### PR TITLE
feat(daemon): RD-B remote read-down broker adapters (RemoteReplicaChangeLog + RemoteCanonicalSnapshotSource)

### DIFF
--- a/packages/daemon/src/broker/index.ts
+++ b/packages/daemon/src/broker/index.ts
@@ -20,6 +20,14 @@ export {
 } from "./fingerprint.ts";
 export { CrashSafeNativeApplier, type NativeApplyResult } from "./native-applier.ts";
 export { BrokerSubmitPreflightError, ReplicaBroker } from "./replica-broker.ts";
+export { RemoteCanonicalSnapshotSource } from "./remote-canonical-snapshot-source.ts";
+export {
+  RemoteReadDownSession,
+  RemoteReplicaResyncRequiredError,
+  type RemoteReadDownBackoff,
+  type RemoteReadDownSessionOptions
+} from "./remote-read-down-session.ts";
+export { RemoteReplicaChangeLog } from "./remote-replica-change-log.ts";
 export { BrokerSubmissionCoordinator, type AuthoredSubmissionResult } from "./submission-coordinator.ts";
 export type {
   AuthoritySubmissionClient,

--- a/packages/daemon/src/broker/index.ts
+++ b/packages/daemon/src/broker/index.ts
@@ -25,6 +25,7 @@ export {
   RemoteReadDownSession,
   RemoteReplicaResyncRequiredError,
   type RemoteReadDownBackoff,
+  type RemoteReadDownChangeCacheLimits,
   type RemoteReadDownSessionOptions
 } from "./remote-read-down-session.ts";
 export { RemoteReplicaChangeLog } from "./remote-replica-change-log.ts";

--- a/packages/daemon/src/broker/remote-blob-reader.ts
+++ b/packages/daemon/src/broker/remote-blob-reader.ts
@@ -1,0 +1,61 @@
+import type { AuthoritySnapshotManifestEntry, AuthoritySnapshotReservation } from "../authority/protocol.ts";
+import type { PersistentSshAuthorityClient } from "../transport/persistent-ssh-authority-client.ts";
+import type { BrokerCasStore } from "./cas-store.ts";
+import { isMissing } from "./errno.ts";
+
+export class RemoteBlobReader {
+  private readonly flights = new Map<string, Promise<Buffer>>();
+  private readonly cas: BrokerCasStore;
+  private readonly client: PersistentSshAuthorityClient;
+  private readonly assertOpen: () => void;
+
+  constructor(
+    cas: BrokerCasStore,
+    client: PersistentSshAuthorityClient,
+    assertOpen: () => void
+  ) {
+    this.cas = cas;
+    this.client = client;
+    this.assertOpen = assertOpen;
+  }
+
+  read(
+    reservation: AuthoritySnapshotReservation,
+    digest: AuthoritySnapshotManifestEntry["blobDigest"]
+  ): Promise<Buffer> {
+    const existing = this.flights.get(digest);
+    if (existing) return existing;
+    const flight = this.load(reservation, digest);
+    this.flights.set(digest, flight);
+    void flight.then(
+      () => this.deleteFlight(digest, flight),
+      () => this.deleteFlight(digest, flight)
+    );
+    return flight;
+  }
+
+  pending(): ReadonlyArray<Promise<Buffer>> {
+    return [...this.flights.values()];
+  }
+
+  private async load(
+    reservation: AuthoritySnapshotReservation,
+    digest: AuthoritySnapshotManifestEntry["blobDigest"]
+  ): Promise<Buffer> {
+    try {
+      return await this.cas.get(digest);
+    } catch (error) {
+      if (!isMissing(error)) throw error;
+    }
+    this.assertOpen();
+    const bytes = await this.client.getBlob(reservation.stream.streamToken, digest);
+    this.assertOpen();
+    const actual = await this.cas.put(bytes);
+    if (actual !== digest) throw new Error(`BLOB_DIGEST_MISMATCH:${digest}:${actual}`);
+    return Buffer.from(bytes);
+  }
+
+  private deleteFlight(digest: string, flight: Promise<Buffer>): void {
+    if (this.flights.get(digest) === flight) this.flights.delete(digest);
+  }
+}

--- a/packages/daemon/src/broker/remote-canonical-snapshot-source.ts
+++ b/packages/daemon/src/broker/remote-canonical-snapshot-source.ts
@@ -1,0 +1,15 @@
+import type { ReplicaChangeRecord } from "@harness-anything/application";
+import { RemoteReadDownSession } from "./remote-read-down-session.ts";
+import type { CanonicalSnapshot, CanonicalSnapshotSource } from "./types.ts";
+
+export class RemoteCanonicalSnapshotSource implements CanonicalSnapshotSource {
+  private readonly session: RemoteReadDownSession;
+
+  constructor(session: RemoteReadDownSession) {
+    this.session = session;
+  }
+
+  snapshotAt(change: ReplicaChangeRecord): Promise<CanonicalSnapshot> {
+    return this.session.snapshotAt(change);
+  }
+}

--- a/packages/daemon/src/broker/remote-read-down-content.ts
+++ b/packages/daemon/src/broker/remote-read-down-content.ts
@@ -1,0 +1,201 @@
+import type { ReplicaChangeRecord } from "@harness-anything/application";
+import { manifestDigest } from "../authority/replication-content-store.ts";
+import type {
+  AuthoritySnapshotManifest,
+  AuthoritySnapshotManifestEntry,
+  AuthoritySnapshotReservation
+} from "../authority/protocol.ts";
+import {
+  AuthorityReadDownRequestError
+} from "../transport/persistent-ssh-authority-client.ts";
+import type { ActiveSnapshot, RemoteReadDownChangeCacheLimits } from "./remote-read-down-contract.ts";
+
+export function assertManifest(
+  reservation: AuthoritySnapshotReservation,
+  manifest: AuthoritySnapshotManifest,
+  workspaceId: string
+): void {
+  if (manifest.cut.workspaceId !== workspaceId
+    || !sameSnapshotCut(manifest.cut, reservation.cut)) {
+    throw new Error("authority snapshot manifest cut mismatch");
+  }
+  const actual = manifestDigest(manifest.cut, manifest.entries);
+  if (actual !== reservation.cut.manifestDigest) {
+    throw new Error(`MANIFEST_DIGEST_MISMATCH:${reservation.cut.manifestDigest}:${actual}`);
+  }
+}
+
+export function assertCutChange(
+  reservation: AuthoritySnapshotReservation,
+  change: ReplicaChangeRecord | null
+): void {
+  if (reservation.cut.revision === 0) {
+    if (change !== null) throw new Error("authority empty cut unexpectedly has a change");
+    return;
+  }
+  if (!change
+    || change.workspaceId !== reservation.cut.workspaceId
+    || change.revision !== reservation.cut.revision
+    || change.commitSha !== reservation.cut.commitSha
+    || change.manifest.digest !== reservation.cut.manifestDigest) {
+    throw new Error("authority cut change does not match snapshot reservation");
+  }
+}
+
+export async function mapInBatches<Value>(
+  values: ReadonlyArray<Value>,
+  batchSize: number,
+  operation: (value: Value) => Promise<unknown>
+): Promise<void> {
+  for (let offset = 0; offset < values.length; offset += batchSize) {
+    await Promise.all(values.slice(offset, offset + batchSize).map(operation));
+  }
+}
+
+export function validateChanges(
+  changes: ReadonlyArray<ReplicaChangeRecord>,
+  sinceRevision: number,
+  workspaceId: string
+): void {
+  let expected = sinceRevision + 1;
+  for (const change of changes) {
+    if (change.workspaceId !== workspaceId || change.revision !== expected) {
+      throw new Error(`remote replica change gap at revision ${change.revision}; expected ${expected}`);
+    }
+    expected += 1;
+  }
+}
+
+export function applyChange(
+  entries: Map<string, AuthoritySnapshotManifestEntry>,
+  change: ReplicaChangeRecord
+): void {
+  for (const item of change.paths) {
+    if (item.tombstone) {
+      entries.delete(item.path);
+    } else {
+      if (!item.blobDigest || !item.mode) throw new Error(`remote change lacks blob metadata for ${item.path}`);
+      entries.set(item.path, {
+        path: item.path,
+        blobDigest: item.blobDigest,
+        mode: item.mode,
+        tombstone: false
+      });
+    }
+  }
+}
+
+export function assertChangeManifest(
+  epoch: string,
+  change: ReplicaChangeRecord,
+  entries: ReadonlyMap<string, AuthoritySnapshotManifestEntry>
+): void {
+  const actual = manifestDigest({
+    workspaceId: change.workspaceId,
+    epoch,
+    revision: change.revision,
+    commitSha: change.commitSha
+  }, [...entries.values()]);
+  if (actual !== change.manifest.digest || entries.size !== change.manifest.entryCount) {
+    throw new Error(`MANIFEST_DIGEST_MISMATCH:${change.manifest.digest}:${actual}`);
+  }
+}
+
+export function pruneChanges(active: ActiveSnapshot, throughRevision: number): void {
+  for (const revision of active.changes.keys()) {
+    if (revision <= throughRevision) deleteCachedChange(active, revision);
+  }
+  recomputeHighestRevision(active);
+}
+
+export function sameChangeIdentity(left: ReplicaChangeRecord, right: ReplicaChangeRecord): boolean {
+  return left.workspaceId === right.workspaceId
+    && left.revision === right.revision
+    && left.commitSha === right.commitSha
+    && left.previousCommit === right.previousCommit
+    && left.manifest.digest === right.manifest.digest
+    && left.manifest.entryCount === right.manifest.entryCount;
+}
+
+export function storeCachedChange(
+  active: ActiveSnapshot,
+  change: ReplicaChangeRecord,
+  limits: RemoteReadDownChangeCacheLimits,
+  lossyHint: boolean
+): boolean {
+  const existing = active.changes.get(change.revision);
+  if (existing) {
+    if (!sameChangeIdentity(existing, change)) {
+      throw new Error(`remote replica change identity conflict at revision ${change.revision}`);
+    }
+    return false;
+  }
+  const byteSize = Buffer.byteLength(JSON.stringify(change));
+  if (byteSize > limits.maxBytes) {
+    throw new Error(`REMOTE_CHANGE_CACHE_LIMIT_EXCEEDED:bytes:${byteSize}:${limits.maxBytes}`);
+  }
+  if (lossyHint
+    && (active.changes.size >= limits.maxCount
+      || active.changeBytes + byteSize > limits.maxBytes)) {
+    return false;
+  }
+  if (active.changes.size >= limits.maxCount
+    || active.changeBytes + byteSize > limits.maxBytes) {
+    throw new Error(
+      `REMOTE_CHANGE_CACHE_LIMIT_EXCEEDED:${active.changes.size + 1}:${active.changeBytes + byteSize}`
+    );
+  }
+  active.changes.set(change.revision, change);
+  active.changeSizes.set(change.revision, byteSize);
+  active.changeBytes += byteSize;
+  active.highestRevision = Math.max(active.highestRevision, change.revision);
+  return true;
+}
+
+export function compareManifestPaths(
+  left: AuthoritySnapshotManifestEntry,
+  right: AuthoritySnapshotManifestEntry
+): number {
+  return left.path.localeCompare(right.path, "en");
+}
+
+export function isResyncError(error: unknown): error is AuthorityReadDownRequestError {
+  return error instanceof AuthorityReadDownRequestError
+    && (error.code === "RESYNC_REQUIRED" || error.code === "SNAPSHOT_EXPIRED");
+}
+
+export function isIntegrityError(error: unknown): boolean {
+  const message = contentError(error).message;
+  return /(?:BLOB|MANIFEST)_DIGEST_MISMATCH|CAS object corrupted|manifest (?:cut mismatch|contains duplicate)|cut change does not match|blob response (?:metadata mismatch|is not canonical)/iu.test(message);
+}
+
+function sameSnapshotCut(
+  left: AuthoritySnapshotReservation["cut"],
+  right: AuthoritySnapshotReservation["cut"]
+): boolean {
+  return left.workspaceId === right.workspaceId
+    && left.epoch === right.epoch
+    && left.revision === right.revision
+    && left.commitSha === right.commitSha
+    && left.manifestDigest === right.manifestDigest
+    && left.provenanceDigest === right.provenanceDigest;
+}
+
+function deleteCachedChange(active: ActiveSnapshot, revision: number): void {
+  const byteSize = active.changeSizes.get(revision) ?? 0;
+  active.changes.delete(revision);
+  active.changeSizes.delete(revision);
+  active.changeBytes -= byteSize;
+}
+
+function recomputeHighestRevision(active: ActiveSnapshot): void {
+  let highest = active.reservation.cut.revision;
+  for (const revision of active.changes.keys()) {
+    if (revision > highest) highest = revision;
+  }
+  active.highestRevision = highest;
+}
+
+function contentError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/packages/daemon/src/broker/remote-read-down-contract.ts
+++ b/packages/daemon/src/broker/remote-read-down-contract.ts
@@ -1,0 +1,105 @@
+import type { ReplicaChangeRecord } from "@harness-anything/application";
+import type {
+  AuthoritySnapshotManifestEntry,
+  AuthoritySnapshotReservation
+} from "../authority/protocol.ts";
+import type { PersistentSshAuthorityClient } from "../transport/persistent-ssh-authority-client.ts";
+
+export interface RemoteReadDownBackoff {
+  readonly initialMs: number;
+  readonly maximumMs: number;
+  readonly multiplier: number;
+}
+
+export interface RemoteReadDownChangeCacheLimits {
+  readonly maxCount: number;
+  readonly maxBytes: number;
+}
+
+export interface RemoteReadDownSessionOptions {
+  readonly client: PersistentSshAuthorityClient;
+  readonly workspaceId: string;
+  readonly stateRoot: string;
+  readonly backoff?: Partial<RemoteReadDownBackoff>;
+  readonly now?: () => number;
+  readonly sleep?: (milliseconds: number) => Promise<void>;
+  readonly schedule?: (milliseconds: number, callback: () => void) => { readonly dispose: () => void };
+  readonly changeCache?: Partial<RemoteReadDownChangeCacheLimits>;
+  readonly onDiagnostic?: (text: string) => void;
+}
+
+/**
+ * Consumers must catch this error, persist a durable RESYNC transition, and
+ * bootstrap from `cut`/`cutChange`, then acknowledge that bootstrap by retrying
+ * `changesAfter(cut.revision)` before resuming incremental reads.
+ * ReplicaChangeLog cannot mutate broker durable state on the consumer's behalf.
+ */
+export class RemoteReplicaResyncRequiredError extends Error {
+  readonly cutChange: ReplicaChangeRecord | null;
+  readonly cut: AuthoritySnapshotReservation["cut"];
+  readonly cutRevision: number;
+
+  constructor(
+    message: string,
+    cut: AuthoritySnapshotReservation["cut"],
+    cutChange: ReplicaChangeRecord | null
+  ) {
+    super(`RESYNC_REQUIRED:${message}`);
+    this.name = "RemoteReplicaResyncRequiredError";
+    this.cut = cut;
+    this.cutRevision = cut.revision;
+    this.cutChange = cutChange;
+  }
+}
+
+export interface ActiveSnapshot {
+  readonly reservation: AuthoritySnapshotReservation;
+  readonly cutChange: ReplicaChangeRecord | null;
+  readonly baseEntries: ReadonlyMap<string, AuthoritySnapshotManifestEntry>;
+  readonly changes: Map<number, ReplicaChangeRecord>;
+  readonly changeSizes: Map<number, number>;
+  changeBytes: number;
+  highestRevision: number;
+  durableCursor: number;
+  adopted: boolean;
+  deliveredRevision: number;
+  resyncReason?: string;
+  resyncSignaled: boolean;
+  resyncReported: boolean;
+}
+
+export interface ResumeCursor {
+  readonly epoch: string;
+  readonly deliveredRevision: number;
+}
+
+export const defaultBackoff: RemoteReadDownBackoff = {
+  initialMs: 100,
+  maximumMs: 5_000,
+  multiplier: 2
+};
+
+export const defaultChangeCache: RemoteReadDownChangeCacheLimits = {
+  maxCount: 4_096,
+  maxBytes: 8 * 1024 * 1024
+};
+
+export function assertBackoff(backoff: RemoteReadDownBackoff): void {
+  if (!Number.isFinite(backoff.initialMs)
+    || !Number.isFinite(backoff.maximumMs)
+    || !Number.isFinite(backoff.multiplier)
+    || backoff.initialMs < 0
+    || backoff.maximumMs < backoff.initialMs
+    || backoff.multiplier < 1) {
+    throw new Error("remote read-down backoff must be finite, non-negative, and bounded");
+  }
+}
+
+export function assertChangeCache(cache: RemoteReadDownChangeCacheLimits): void {
+  if (!Number.isSafeInteger(cache.maxCount)
+    || !Number.isSafeInteger(cache.maxBytes)
+    || cache.maxCount < 1
+    || cache.maxBytes < 1) {
+    throw new Error("remote read-down change cache limits must be positive safe integers");
+  }
+}

--- a/packages/daemon/src/broker/remote-read-down-session.ts
+++ b/packages/daemon/src/broker/remote-read-down-session.ts
@@ -1,85 +1,86 @@
 import type { ReplicaChangeRecord } from "@harness-anything/application";
 import { manifestDigest } from "../authority/replication-content-store.ts";
 import type {
-  AuthoritySnapshotManifest,
   AuthoritySnapshotManifestEntry,
   AuthoritySnapshotReservation
 } from "../authority/protocol.ts";
-import {
-  AuthorityReadDownRequestError,
-  AuthorityTransportDisconnectedError,
-  type PersistentSshAuthorityClient
-} from "../transport/persistent-ssh-authority-client.ts";
+import { AuthorityTransportDisconnectedError } from "../transport/persistent-ssh-authority-client.ts";
+import { RemoteBlobReader } from "./remote-blob-reader.ts";
 import { BrokerCasStore } from "./cas-store.ts";
-import { isMissing } from "./errno.ts";
+import {
+  assertBackoff,
+  assertChangeCache,
+  defaultBackoff,
+  defaultChangeCache,
+  RemoteReplicaResyncRequiredError,
+  type ActiveSnapshot,
+  type RemoteReadDownBackoff,
+  type RemoteReadDownChangeCacheLimits,
+  type RemoteReadDownSessionOptions,
+  type ResumeCursor
+} from "./remote-read-down-contract.ts";
+import {
+  applyChange,
+  assertChangeManifest,
+  assertCutChange,
+  assertManifest,
+  compareManifestPaths,
+  isIntegrityError,
+  isResyncError,
+  mapInBatches,
+  pruneChanges,
+  sameChangeIdentity,
+  storeCachedChange,
+  validateChanges
+} from "./remote-read-down-content.ts";
 import type { CanonicalSnapshot } from "./types.ts";
 
-export interface RemoteReadDownBackoff {
-  readonly initialMs: number;
-  readonly maximumMs: number;
-  readonly multiplier: number;
-}
-
-export interface RemoteReadDownSessionOptions {
-  readonly client: PersistentSshAuthorityClient;
-  readonly workspaceId: string;
-  readonly stateRoot: string;
-  readonly backoff?: Partial<RemoteReadDownBackoff>;
-  readonly now?: () => number;
-  readonly sleep?: (milliseconds: number) => Promise<void>;
-  readonly schedule?: (milliseconds: number, callback: () => void) => { readonly dispose: () => void };
-  readonly onDiagnostic?: (text: string) => void;
-}
-
-export class RemoteReplicaResyncRequiredError extends Error {
-  readonly cutChange: ReplicaChangeRecord | null;
-  readonly cutRevision: number;
-
-  constructor(message: string, cutRevision: number, cutChange: ReplicaChangeRecord | null) {
-    super(`RESYNC_REQUIRED:${message}`);
-    this.name = "RemoteReplicaResyncRequiredError";
-    this.cutRevision = cutRevision;
-    this.cutChange = cutChange;
-  }
-}
-
-interface ActiveSnapshot {
-  readonly reservation: AuthoritySnapshotReservation;
-  readonly cutChange: ReplicaChangeRecord | null;
-  readonly baseEntries: ReadonlyMap<string, AuthoritySnapshotManifestEntry>;
-  readonly changes: Map<number, ReplicaChangeRecord>;
-  adopted: boolean;
-  deliveredRevision: number;
-}
-
-const defaultBackoff: RemoteReadDownBackoff = {
-  initialMs: 100,
-  maximumMs: 5_000,
-  multiplier: 2
-};
+export {
+  RemoteReplicaResyncRequiredError,
+  type RemoteReadDownBackoff,
+  type RemoteReadDownChangeCacheLimits,
+  type RemoteReadDownSessionOptions
+} from "./remote-read-down-contract.ts";
 
 export class RemoteReadDownSession {
   private readonly options: RemoteReadDownSessionOptions;
   private readonly cas: BrokerCasStore;
+  private readonly blobReader: RemoteBlobReader;
   private readonly backoff: RemoteReadDownBackoff;
+  private readonly changeCache: RemoteReadDownChangeCacheLimits;
   private readonly now: () => number;
   private readonly sleep: (milliseconds: number) => Promise<void>;
   private readonly listeners = new Set<(change: ReplicaChangeRecord) => void>();
   private active: ActiveSnapshot | undefined;
-  private recovery: Promise<ActiveSnapshot> | undefined;
+  private recovery: { readonly generation: number; readonly promise: Promise<ActiveSnapshot> } | undefined;
   private renewalTask: { readonly dispose: () => void } | undefined;
+  private renewalOperation: Promise<void> | undefined;
   private stopped = false;
+  private closeTask: Promise<void> | undefined;
+  private lifecycleGeneration = 0;
+  private resumeCursor: ResumeCursor | undefined;
+  private terminalError: Error | undefined;
   private notificationPump: Promise<void> | undefined;
+  private readonly operations = new Set<Promise<unknown>>();
+  private readonly changeEpochs = new WeakMap<ReplicaChangeRecord, string>();
+  private readonly stoppedSignal: Promise<void>;
+  private resolveStopped!: () => void;
   private readonly removeNotificationListener: () => void;
   private readonly removeDisconnectListener: () => void;
 
   constructor(options: RemoteReadDownSessionOptions) {
     this.options = options;
     this.cas = new BrokerCasStore(options.stateRoot);
+    this.blobReader = new RemoteBlobReader(this.cas, options.client, () => this.assertOpen());
     this.backoff = { ...defaultBackoff, ...options.backoff };
+    this.changeCache = { ...defaultChangeCache, ...options.changeCache };
     this.now = options.now ?? Date.now;
     this.sleep = options.sleep ?? ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+    this.stoppedSignal = new Promise((resolve) => {
+      this.resolveStopped = resolve;
+    });
     assertBackoff(this.backoff);
+    assertChangeCache(this.changeCache);
     this.removeNotificationListener = options.client.onNotification((change) => this.receiveNotification(change));
     this.removeDisconnectListener = options.client.onDisconnect(() => this.handleDisconnect());
   }
@@ -90,52 +91,88 @@ export class RemoteReadDownSession {
 
   subscribe(listener: (change: ReplicaChangeRecord) => void): () => void {
     this.listeners.add(listener);
-    void this.ready().catch((error) => this.options.onDiagnostic?.(`remote read-down start failed: ${readDownError(error).message}`));
+    this.queueRecovery("remote read-down start failed");
     return () => this.listeners.delete(listener);
   }
 
-  async latest(): Promise<ReplicaChangeRecord | undefined> {
-    const active = await this.ready();
-    await this.fetchAfter(active, highestKnownRevision(active));
-    return [...active.changes.values()].sort(compareChanges).at(-1) ?? active.cutChange ?? undefined;
+  latest(): Promise<ReplicaChangeRecord | undefined> {
+    return this.runOperation(() => this.readLatest());
   }
 
-  async getByOperation(opId: string): Promise<ReplicaChangeRecord | undefined> {
+  private async readLatest(): Promise<ReplicaChangeRecord | undefined> {
     const active = await this.ready();
     await this.fetchAfter(active, highestKnownRevision(active));
-    return [active.cutChange, ...active.changes.values()]
-      .filter((change): change is ReplicaChangeRecord => change !== null)
-      .find((change) => change.operations.some((operation) => operation.opId === opId));
+    return active.changes.get(active.highestRevision) ?? active.cutChange ?? undefined;
   }
 
-  async changesAfter(revision: number): Promise<ReadonlyArray<ReplicaChangeRecord>> {
+  getByOperation(opId: string): Promise<ReplicaChangeRecord | undefined> {
+    return this.runOperation(() => this.readByOperation(opId));
+  }
+
+  private async readByOperation(opId: string): Promise<ReplicaChangeRecord | undefined> {
+    const active = await this.ready();
+    await this.fetchAfter(active, highestKnownRevision(active));
+    if (active.cutChange?.operations.some((operation) => operation.opId === opId)) return active.cutChange;
+    for (const change of active.changes.values()) {
+      if (change.operations.some((operation) => operation.opId === opId)) return change;
+    }
+    return undefined;
+  }
+
+  changesAfter(revision: number): Promise<ReadonlyArray<ReplicaChangeRecord>> {
+    return this.runOperation(() => this.readChangesAfter(revision));
+  }
+
+  private async readChangesAfter(revision: number): Promise<ReadonlyArray<ReplicaChangeRecord>> {
     const active = await this.ready();
     const cutRevision = active.reservation.cut.revision;
+    if (active.resyncReason) {
+      if (!active.resyncReported || revision < cutRevision) {
+        active.resyncReported = true;
+        throw resyncError(active, active.resyncReason);
+      }
+      active.resyncReason = undefined;
+    }
     if (revision < cutRevision) {
-      throw new RemoteReplicaResyncRequiredError(
+      throw resyncError(
+        active,
         `CURSOR_PRECEDES_PINNED_CUT:${revision}:${cutRevision}`,
-        cutRevision,
-        active.cutChange
       );
     }
     active.adopted = true;
     active.deliveredRevision = Math.max(active.deliveredRevision, revision);
+    active.durableCursor = Math.max(active.durableCursor, revision);
+    pruneChanges(active, active.durableCursor);
     const changes = await this.fetchAfter(active, revision);
     this.queueNotificationPump();
     return changes;
   }
 
-  async snapshotAt(change: ReplicaChangeRecord): Promise<CanonicalSnapshot> {
+  snapshotAt(change: ReplicaChangeRecord): Promise<CanonicalSnapshot> {
+    return this.runOperation(() => this.readSnapshotAt(change));
+  }
+
+  private async readSnapshotAt(change: ReplicaChangeRecord): Promise<CanonicalSnapshot> {
     const active = await this.ready();
     if (change.workspaceId !== this.options.workspaceId) {
       throw new Error("remote snapshot change belongs to another workspace");
     }
+    const observedEpoch = this.changeEpochs.get(change);
+    if (observedEpoch && observedEpoch !== active.reservation.cut.epoch) {
+      throw resyncError(active, `CHANGE_EPOCH_MISMATCH:${observedEpoch}:${active.reservation.cut.epoch}`);
+    }
     const entries = await this.entriesAt(active, change);
-    const snapshotEntries = await Promise.all([...entries.values()].sort(compareManifestPaths).map(async (entry) => ({
+    const orderedEntries = [...entries.values()].sort(compareManifestPaths);
+    const uniqueDigests = [...new Set(orderedEntries.map((entry) => entry.blobDigest))];
+    const blobs = new Map<string, Buffer>();
+    await mapInBatches(uniqueDigests, 8, async (blobDigest) => {
+      blobs.set(blobDigest, await this.readBlob(active, blobDigest));
+    });
+    const snapshotEntries = orderedEntries.map((entry) => ({
       path: entry.path,
-      content: await this.readBlob(active, entry.blobDigest),
+      content: blobs.get(entry.blobDigest)!,
       logicalMode: Number.parseInt(entry.mode, 8)
-    })));
+    }));
     return {
       workspaceId: change.workspaceId,
       revision: change.revision,
@@ -144,69 +181,133 @@ export class RemoteReadDownSession {
     };
   }
 
-  async close(): Promise<void> {
+  close(): Promise<void> {
+    if (this.closeTask) return this.closeTask;
     this.stopped = true;
+    this.lifecycleGeneration += 1;
+    this.resolveStopped();
     this.renewalTask?.dispose();
+    this.renewalTask = undefined;
     this.removeNotificationListener();
     this.removeDisconnectListener();
+    this.closeTask = this.finishClose();
+    return this.closeTask;
+  }
+
+  private async finishClose(): Promise<void> {
     await this.options.client.close();
+    for (;;) {
+      const pending = [
+        ...this.operations,
+        ...(this.recovery ? [this.recovery.promise] : []),
+        ...(this.notificationPump ? [this.notificationPump] : []),
+        ...(this.renewalOperation ? [this.renewalOperation] : []),
+        ...this.blobReader.pending()
+      ];
+      if (pending.length === 0) return;
+      await Promise.allSettled(pending);
+    }
   }
 
   private async ready(): Promise<ActiveSnapshot> {
     if (this.stopped) throw new Error("remote read-down session is closed");
+    if (this.terminalError) throw this.terminalError;
     if (this.active) return this.active;
-    if (!this.recovery) {
-      this.recovery = this.recover().finally(() => {
-        this.recovery = undefined;
-      });
-    }
-    return this.recovery;
+    if (this.recovery) return this.recovery.promise;
+    const generation = this.lifecycleGeneration;
+    const promise = this.recover(generation);
+    const recovery = { generation, promise };
+    this.recovery = recovery;
+    void promise.then(
+      () => {
+        if (this.recovery === recovery) this.recovery = undefined;
+      },
+      () => {
+        if (this.recovery === recovery) this.recovery = undefined;
+      }
+    );
+    return promise;
   }
 
-  private async recover(): Promise<ActiveSnapshot> {
+  private async recover(generation: number): Promise<ActiveSnapshot> {
     let delay = this.backoff.initialMs;
+    let replaceConnection = this.resumeCursor !== undefined;
     for (;;) {
       try {
-        await this.options.client.connect();
-        const active = await this.openSnapshot();
+        if (replaceConnection) {
+          await this.options.client.reconnect();
+        } else {
+          await this.options.client.connect();
+        }
+        this.assertRecoveryCurrent(generation);
+        const active = await this.openSnapshot(this.resumeCursor);
+        this.assertRecoveryCurrent(generation);
+        if (this.active) return this.active;
         this.active = active;
         this.scheduleRenewal(active);
         this.queueNotificationPump();
         return active;
       } catch (error) {
         if (this.stopped) throw readDownError(error);
-        if (isIntegrityError(error)) throw readDownError(error);
+        if (generation !== this.lifecycleGeneration) {
+          throw new AuthorityTransportDisconnectedError("remote read-down recovery generation changed");
+        }
+        if (isIntegrityError(error)) {
+          this.terminalError = readDownError(error);
+          throw this.terminalError;
+        }
         this.options.onDiagnostic?.(`remote read-down reconnect failed; retrying in ${delay}ms: ${readDownError(error).message}`);
-        await this.sleep(delay);
+        await this.interruptibleSleep(delay);
+        this.assertRecoveryCurrent(generation);
         delay = Math.min(this.backoff.maximumMs, Math.max(delay + 1, Math.ceil(delay * this.backoff.multiplier)));
-        await this.options.client.reconnect().catch(() => undefined);
+        replaceConnection = true;
       }
     }
   }
 
-  private async openSnapshot(): Promise<ActiveSnapshot> {
+  private async openSnapshot(resume: ResumeCursor | undefined): Promise<ActiveSnapshot> {
     const reservation = await this.options.client.beginSnapshotAndSubscribe();
+    this.assertOpen();
     const manifest = await this.options.client.getSnapshotManifest(
       reservation.stream.streamToken,
       reservation.cut.manifestDigest
     );
+    this.assertOpen();
     assertManifest(reservation, manifest, this.options.workspaceId);
     const cutChange = await this.options.client.getCutChange(reservation.stream.streamToken);
+    this.assertOpen();
     assertCutChange(reservation, cutChange);
+    if (cutChange) this.changeEpochs.set(cutChange, reservation.cut.epoch);
     const baseEntries = new Map(manifest.entries.map((entry) => [entry.path, entry]));
     if (baseEntries.size !== manifest.entries.length) throw new Error("authority snapshot manifest contains duplicate paths");
+    const uniqueDigests = [...new Set(manifest.entries.map((entry) => entry.blobDigest))];
     await mapInBatches(
-      manifest.entries,
+      uniqueDigests,
       8,
-      (entry) => this.readBlobFromReservation(reservation, entry.blobDigest)
+      (blobDigest) => this.readBlobFromReservation(reservation, blobDigest)
     );
+    this.assertOpen();
+    const sameEpoch = resume?.epoch === reservation.cut.epoch;
+    const canResume = Boolean(resume && sameEpoch && reservation.cut.revision <= resume.deliveredRevision);
+    const resyncReason = resume && !sameEpoch
+      ? `EPOCH_CHANGED:${resume.epoch}:${reservation.cut.epoch}`
+      : resume && !canResume
+        ? `CURSOR_PRECEDES_RECONNECTED_CUT:${resume.deliveredRevision}:${reservation.cut.revision}`
+        : undefined;
     return {
       reservation,
       cutChange,
       baseEntries,
       changes: new Map(),
-      adopted: reservation.cut.revision === 0,
-      deliveredRevision: reservation.cut.revision
+      changeSizes: new Map(),
+      changeBytes: 0,
+      highestRevision: reservation.cut.revision,
+      durableCursor: reservation.cut.revision,
+      adopted: canResume || (!resume && reservation.cut.revision === 0),
+      deliveredRevision: canResume ? resume!.deliveredRevision : reservation.cut.revision,
+      ...(resyncReason ? { resyncReason } : {}),
+      resyncSignaled: false,
+      resyncReported: false
     };
   }
 
@@ -214,27 +315,25 @@ export class RemoteReadDownSession {
     try {
       this.assertCurrent(active);
       const result = await this.options.client.changesAfter(active.reservation.stream.streamToken, revision);
+      this.assertCurrent(active);
       validateChanges(result.changes, revision, this.options.workspaceId);
-      for (const change of result.changes) active.changes.set(change.revision, change);
+      for (const change of result.changes) this.storeChange(active, change, false);
       return result.changes;
     } catch (error) {
+      if (this.stopped) throw readDownError(error);
       if (isResyncError(error)) {
-        this.active = undefined;
+        this.invalidateActive(active);
         const next = await this.ready();
-        throw new RemoteReplicaResyncRequiredError(
-          error.message,
-          next.reservation.cut.revision,
-          next.cutChange
-        );
+        throw resyncError(next, error.message);
       }
       if (error instanceof AuthorityTransportDisconnectedError) {
-        this.active = undefined;
+        this.invalidateActive(active);
         const next = await this.ready();
+        if (next.resyncReason) throw resyncError(next, next.resyncReason);
         if (revision < next.reservation.cut.revision) {
-          throw new RemoteReplicaResyncRequiredError(
+          throw resyncError(
+            next,
             `CURSOR_PRECEDES_RECONNECTED_CUT:${revision}:${next.reservation.cut.revision}`,
-            next.reservation.cut.revision,
-            next.cutChange
           );
         }
         return this.fetchAfter(next, revision);
@@ -249,13 +348,18 @@ export class RemoteReadDownSession {
   ): Promise<ReadonlyMap<string, AuthoritySnapshotManifestEntry>> {
     const cut = active.reservation.cut;
     if (change.revision < cut.revision) {
-      throw new RemoteReplicaResyncRequiredError(
+      throw resyncError(
+        active,
         `SNAPSHOT_PRECEDES_PINNED_CUT:${change.revision}:${cut.revision}`,
-        cut.revision,
-        active.cutChange
       );
     }
     if (change.revision > cut.revision) await this.fetchAfter(active, cut.revision);
+    const canonical = change.revision === cut.revision
+      ? active.cutChange
+      : active.changes.get(change.revision);
+    if (!canonical || !sameChangeIdentity(canonical, change)) {
+      throw resyncError(active, `CHANGE_IDENTITY_MISMATCH:${change.revision}`);
+    }
     const entries = new Map(active.baseEntries);
     for (let revision = cut.revision + 1; revision <= change.revision; revision += 1) {
       const next = active.changes.get(revision);
@@ -279,27 +383,28 @@ export class RemoteReadDownSession {
     reservation: AuthoritySnapshotReservation,
     digest: AuthoritySnapshotManifestEntry["blobDigest"]
   ): Promise<Buffer> {
-    try {
-      return await this.cas.get(digest);
-    } catch (error) {
-      if (!isMissing(error)) throw error;
-    }
-    const bytes = await this.options.client.getBlob(reservation.stream.streamToken, digest);
-    const actual = await this.cas.put(bytes);
-    if (actual !== digest) throw new Error(`BLOB_DIGEST_MISMATCH:${digest}:${actual}`);
-    return Buffer.from(bytes);
+    return this.blobReader.read(reservation, digest);
   }
 
   private receiveNotification(change: ReplicaChangeRecord): void {
     const active = this.active;
     if (!active || change.workspaceId !== this.options.workspaceId) return;
     if (change.revision <= active.reservation.cut.revision) return;
-    active.changes.set(change.revision, change);
+    try {
+      this.storeChange(active, change, true);
+    } catch (error) {
+      this.terminalError = readDownError(error);
+      this.invalidateActive(active);
+      this.options.onDiagnostic?.(`remote read-down notification rejected: ${this.terminalError.message}`);
+      return;
+    }
     this.queueNotificationPump();
   }
 
   private queueNotificationPump(): void {
+    if (this.stopped) return;
     void this.pumpNotifications().catch((error) => {
+      if (this.stopped) return;
       this.options.onDiagnostic?.(`remote read-down notification pump stopped: ${readDownError(error).message}`);
     });
   }
@@ -314,8 +419,17 @@ export class RemoteReadDownSession {
 
   private async flushNotifications(): Promise<void> {
     const active = this.active;
-    if (!active?.adopted || this.listeners.size === 0) return;
+    if (!active || this.listeners.size === 0) return;
+    if (active.resyncReason) {
+      if (!active.resyncSignaled && active.cutChange) {
+        active.resyncSignaled = true;
+        this.notifyListeners(active.cutChange);
+      }
+      return;
+    }
+    if (!active.adopted) return;
     for (;;) {
+      if (this.stopped || this.active !== active) return;
       const expected = active.deliveredRevision + 1;
       let change = active.changes.get(expected);
       if (!change) {
@@ -324,21 +438,17 @@ export class RemoteReadDownSession {
       }
       if (!change || change.revision !== expected) return;
       active.deliveredRevision = change.revision;
-      for (const listener of this.listeners) {
-        try {
-          listener(change);
-        } catch (error) {
-          this.options.onDiagnostic?.(`remote read-down notification listener failed: ${readDownError(error).message}`);
-        }
-      }
+      this.resumeCursor = { epoch: active.reservation.cut.epoch, deliveredRevision: active.deliveredRevision };
+      this.notifyListeners(change);
+      pruneChanges(active, active.deliveredRevision);
     }
   }
 
   private handleDisconnect(): void {
     if (this.stopped) return;
-    this.active = undefined;
-    this.renewalTask?.dispose();
-    void this.ready().catch((error) => this.options.onDiagnostic?.(`remote read-down recovery stopped: ${readDownError(error).message}`));
+    const active = this.active;
+    if (active) this.invalidateActive(active);
+    this.queueRecovery("remote read-down recovery stopped");
   }
 
   private scheduleRenewal(active: ActiveSnapshot): void {
@@ -348,20 +458,32 @@ export class RemoteReadDownSession {
     const remaining = expiresAt - this.now();
     const delay = Math.max(0, Math.min(remaining / 2, renewableUntil - this.now()));
     const schedule = this.options.schedule ?? defaultSchedule;
-    this.renewalTask = schedule(delay, () => void this.renew(active));
+    this.renewalTask = schedule(delay, () => {
+      if (this.stopped) return;
+      const operation = this.renew(active);
+      this.renewalOperation = operation;
+      void operation.then(
+        () => {
+          if (this.renewalOperation === operation) this.renewalOperation = undefined;
+        },
+        () => {
+          if (this.renewalOperation === operation) this.renewalOperation = undefined;
+        }
+      );
+    });
   }
 
   private async renew(active: ActiveSnapshot): Promise<void> {
     if (this.active !== active || this.stopped) return;
     try {
       if (this.now() >= Date.parse(active.reservation.lease.renewableUntil)) {
-        throw new RemoteReplicaResyncRequiredError(
+        throw resyncError(
+          active,
           "LEASE_RENEWAL_LIMIT_REACHED",
-          active.reservation.cut.revision,
-          active.cutChange
         );
       }
       const lease = await this.options.client.renewLease(active.reservation.stream.streamToken);
+      if (this.stopped || this.active !== active) return;
       const renewed: ActiveSnapshot = {
         ...active,
         reservation: { ...active.reservation, lease }
@@ -369,157 +491,100 @@ export class RemoteReadDownSession {
       this.active = renewed;
       this.scheduleRenewal(renewed);
     } catch (error) {
+      if (this.stopped || this.active !== active) return;
       this.options.onDiagnostic?.(`remote read-down lease requires resnapshot: ${readDownError(error).message}`);
-      this.active = undefined;
-      await this.options.client.reconnect().catch(() => undefined);
-      void this.ready().catch((recoveryError) => {
-        this.options.onDiagnostic?.(`remote read-down lease recovery failed: ${readDownError(recoveryError).message}`);
-      });
+      this.invalidateActive(active);
+      this.queueRecovery("remote read-down lease recovery failed");
+    }
+  }
+
+  private storeChange(active: ActiveSnapshot, change: ReplicaChangeRecord, lossyHint: boolean): void {
+    if (storeCachedChange(active, change, this.changeCache, lossyHint)) {
+      this.changeEpochs.set(change, active.reservation.cut.epoch);
+    }
+  }
+
+  private invalidateActive(active: ActiveSnapshot): boolean {
+    if (this.active !== active) return false;
+    this.resumeCursor = {
+      epoch: active.reservation.cut.epoch,
+      deliveredRevision: active.deliveredRevision
+    };
+    this.active = undefined;
+    this.lifecycleGeneration += 1;
+    this.recovery = undefined;
+    this.renewalTask?.dispose();
+    this.renewalTask = undefined;
+    return true;
+  }
+
+  private notifyListeners(change: ReplicaChangeRecord): void {
+    const active = this.active;
+    if (active) this.changeEpochs.set(change, active.reservation.cut.epoch);
+    for (const listener of this.listeners) {
+      try {
+        listener(change);
+      } catch (error) {
+        this.options.onDiagnostic?.(`remote read-down notification listener failed: ${readDownError(error).message}`);
+      }
+    }
+  }
+
+  private queueRecovery(description: string): void {
+    if (this.stopped || this.terminalError) return;
+    void this.ready().catch((error) => {
+      if (this.stopped) return;
+      if (error instanceof AuthorityTransportDisconnectedError && !this.active) {
+        queueMicrotask(() => this.queueRecovery(description));
+        return;
+      }
+      this.options.onDiagnostic?.(`${description}: ${readDownError(error).message}`);
+    });
+  }
+
+  private runOperation<Value>(operation: () => Promise<Value>): Promise<Value> {
+    if (this.stopped) return Promise.reject(new Error("remote read-down session is closed"));
+    const task = operation();
+    this.operations.add(task);
+    void task.then(
+      () => this.operations.delete(task),
+      () => this.operations.delete(task)
+    );
+    return task;
+  }
+
+  private async interruptibleSleep(milliseconds: number): Promise<void> {
+    await Promise.race([
+      this.sleep(milliseconds),
+      this.stoppedSignal.then(() => {
+        throw new Error("remote read-down session is closed");
+      })
+    ]);
+  }
+
+  private assertOpen(): void {
+    if (this.stopped) throw new Error("remote read-down session is closed");
+  }
+
+  private assertRecoveryCurrent(generation: number): void {
+    this.assertOpen();
+    if (generation !== this.lifecycleGeneration) {
+      throw new AuthorityTransportDisconnectedError("remote read-down recovery generation changed");
     }
   }
 
   private assertCurrent(active: ActiveSnapshot): void {
+    this.assertOpen();
     if (this.active !== active) throw new AuthorityTransportDisconnectedError("remote read-down snapshot generation changed");
   }
 }
 
-function assertManifest(
-  reservation: AuthoritySnapshotReservation,
-  manifest: AuthoritySnapshotManifest,
-  workspaceId: string
-): void {
-  if (manifest.cut.workspaceId !== workspaceId
-    || !sameSnapshotCut(manifest.cut, reservation.cut)) {
-    throw new Error("authority snapshot manifest cut mismatch");
-  }
-  const actual = manifestDigest(manifest.cut, manifest.entries);
-  if (actual !== reservation.cut.manifestDigest) {
-    throw new Error(`MANIFEST_DIGEST_MISMATCH:${reservation.cut.manifestDigest}:${actual}`);
-  }
-}
-
-function sameSnapshotCut(
-  left: AuthoritySnapshotReservation["cut"],
-  right: AuthoritySnapshotReservation["cut"]
-): boolean {
-  return left.workspaceId === right.workspaceId
-    && left.epoch === right.epoch
-    && left.revision === right.revision
-    && left.commitSha === right.commitSha
-    && left.manifestDigest === right.manifestDigest
-    && left.provenanceDigest === right.provenanceDigest;
-}
-
-function assertCutChange(
-  reservation: AuthoritySnapshotReservation,
-  change: ReplicaChangeRecord | null
-): void {
-  if (reservation.cut.revision === 0) {
-    if (change !== null) throw new Error("authority empty cut unexpectedly has a change");
-    return;
-  }
-  if (!change
-    || change.workspaceId !== reservation.cut.workspaceId
-    || change.revision !== reservation.cut.revision
-    || change.commitSha !== reservation.cut.commitSha
-    || change.manifest.digest !== reservation.cut.manifestDigest) {
-    throw new Error("authority cut change does not match snapshot reservation");
-  }
-}
-
-async function mapInBatches<Value>(
-  values: ReadonlyArray<Value>,
-  batchSize: number,
-  operation: (value: Value) => Promise<unknown>
-): Promise<void> {
-  for (let offset = 0; offset < values.length; offset += batchSize) {
-    await Promise.all(values.slice(offset, offset + batchSize).map(operation));
-  }
-}
-
-function validateChanges(
-  changes: ReadonlyArray<ReplicaChangeRecord>,
-  sinceRevision: number,
-  workspaceId: string
-): void {
-  let expected = sinceRevision + 1;
-  for (const change of changes) {
-    if (change.workspaceId !== workspaceId || change.revision !== expected) {
-      throw new Error(`remote replica change gap at revision ${change.revision}; expected ${expected}`);
-    }
-    expected += 1;
-  }
-}
-
-function applyChange(
-  entries: Map<string, AuthoritySnapshotManifestEntry>,
-  change: ReplicaChangeRecord
-): void {
-  for (const item of change.paths) {
-    if (item.tombstone) {
-      entries.delete(item.path);
-    } else {
-      if (!item.blobDigest || !item.mode) throw new Error(`remote change lacks blob metadata for ${item.path}`);
-      entries.set(item.path, {
-        path: item.path,
-        blobDigest: item.blobDigest,
-        mode: item.mode,
-        tombstone: false
-      });
-    }
-  }
-}
-
-function assertChangeManifest(
-  epoch: string,
-  change: ReplicaChangeRecord,
-  entries: ReadonlyMap<string, AuthoritySnapshotManifestEntry>
-): void {
-  const actual = manifestDigest({
-    workspaceId: change.workspaceId,
-    epoch,
-    revision: change.revision,
-    commitSha: change.commitSha
-  }, [...entries.values()]);
-  if (actual !== change.manifest.digest || entries.size !== change.manifest.entryCount) {
-    throw new Error(`MANIFEST_DIGEST_MISMATCH:${change.manifest.digest}:${actual}`);
-  }
-}
-
 function highestKnownRevision(active: ActiveSnapshot): number {
-  return Math.max(active.reservation.cut.revision, ...active.changes.keys());
+  return active.highestRevision;
 }
 
-function compareChanges(left: ReplicaChangeRecord, right: ReplicaChangeRecord): number {
-  return left.revision - right.revision;
-}
-
-function compareManifestPaths(
-  left: AuthoritySnapshotManifestEntry,
-  right: AuthoritySnapshotManifestEntry
-): number {
-  return left.path.localeCompare(right.path, "en");
-}
-
-function assertBackoff(backoff: RemoteReadDownBackoff): void {
-  if (!Number.isFinite(backoff.initialMs)
-    || !Number.isFinite(backoff.maximumMs)
-    || !Number.isFinite(backoff.multiplier)
-    || backoff.initialMs < 0
-    || backoff.maximumMs < backoff.initialMs
-    || backoff.multiplier < 1) {
-    throw new Error("remote read-down backoff must be finite, non-negative, and bounded");
-  }
-}
-
-function isResyncError(error: unknown): error is AuthorityReadDownRequestError {
-  return error instanceof AuthorityReadDownRequestError
-    && (error.code === "RESYNC_REQUIRED" || error.code === "SNAPSHOT_EXPIRED");
-}
-
-function isIntegrityError(error: unknown): boolean {
-  const message = readDownError(error).message;
-  return /(?:BLOB|MANIFEST)_DIGEST_MISMATCH|manifest (?:cut mismatch|contains duplicate)|cut change does not match|blob response (?:metadata mismatch|is not canonical)/iu.test(message);
+function resyncError(active: ActiveSnapshot, message: string): RemoteReplicaResyncRequiredError {
+  return new RemoteReplicaResyncRequiredError(message, active.reservation.cut, active.cutChange);
 }
 
 function readDownError(error: unknown): Error {

--- a/packages/daemon/src/broker/remote-read-down-session.ts
+++ b/packages/daemon/src/broker/remote-read-down-session.ts
@@ -1,0 +1,533 @@
+import type { ReplicaChangeRecord } from "@harness-anything/application";
+import { manifestDigest } from "../authority/replication-content-store.ts";
+import type {
+  AuthoritySnapshotManifest,
+  AuthoritySnapshotManifestEntry,
+  AuthoritySnapshotReservation
+} from "../authority/protocol.ts";
+import {
+  AuthorityReadDownRequestError,
+  AuthorityTransportDisconnectedError,
+  type PersistentSshAuthorityClient
+} from "../transport/persistent-ssh-authority-client.ts";
+import { BrokerCasStore } from "./cas-store.ts";
+import { isMissing } from "./errno.ts";
+import type { CanonicalSnapshot } from "./types.ts";
+
+export interface RemoteReadDownBackoff {
+  readonly initialMs: number;
+  readonly maximumMs: number;
+  readonly multiplier: number;
+}
+
+export interface RemoteReadDownSessionOptions {
+  readonly client: PersistentSshAuthorityClient;
+  readonly workspaceId: string;
+  readonly stateRoot: string;
+  readonly backoff?: Partial<RemoteReadDownBackoff>;
+  readonly now?: () => number;
+  readonly sleep?: (milliseconds: number) => Promise<void>;
+  readonly schedule?: (milliseconds: number, callback: () => void) => { readonly dispose: () => void };
+  readonly onDiagnostic?: (text: string) => void;
+}
+
+export class RemoteReplicaResyncRequiredError extends Error {
+  readonly cutChange: ReplicaChangeRecord | null;
+  readonly cutRevision: number;
+
+  constructor(message: string, cutRevision: number, cutChange: ReplicaChangeRecord | null) {
+    super(`RESYNC_REQUIRED:${message}`);
+    this.name = "RemoteReplicaResyncRequiredError";
+    this.cutRevision = cutRevision;
+    this.cutChange = cutChange;
+  }
+}
+
+interface ActiveSnapshot {
+  readonly reservation: AuthoritySnapshotReservation;
+  readonly cutChange: ReplicaChangeRecord | null;
+  readonly baseEntries: ReadonlyMap<string, AuthoritySnapshotManifestEntry>;
+  readonly changes: Map<number, ReplicaChangeRecord>;
+  adopted: boolean;
+  deliveredRevision: number;
+}
+
+const defaultBackoff: RemoteReadDownBackoff = {
+  initialMs: 100,
+  maximumMs: 5_000,
+  multiplier: 2
+};
+
+export class RemoteReadDownSession {
+  private readonly options: RemoteReadDownSessionOptions;
+  private readonly cas: BrokerCasStore;
+  private readonly backoff: RemoteReadDownBackoff;
+  private readonly now: () => number;
+  private readonly sleep: (milliseconds: number) => Promise<void>;
+  private readonly listeners = new Set<(change: ReplicaChangeRecord) => void>();
+  private active: ActiveSnapshot | undefined;
+  private recovery: Promise<ActiveSnapshot> | undefined;
+  private renewalTask: { readonly dispose: () => void } | undefined;
+  private stopped = false;
+  private notificationPump: Promise<void> | undefined;
+  private readonly removeNotificationListener: () => void;
+  private readonly removeDisconnectListener: () => void;
+
+  constructor(options: RemoteReadDownSessionOptions) {
+    this.options = options;
+    this.cas = new BrokerCasStore(options.stateRoot);
+    this.backoff = { ...defaultBackoff, ...options.backoff };
+    this.now = options.now ?? Date.now;
+    this.sleep = options.sleep ?? ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+    assertBackoff(this.backoff);
+    this.removeNotificationListener = options.client.onNotification((change) => this.receiveNotification(change));
+    this.removeDisconnectListener = options.client.onDisconnect(() => this.handleDisconnect());
+  }
+
+  get workspaceId(): string {
+    return this.options.workspaceId;
+  }
+
+  subscribe(listener: (change: ReplicaChangeRecord) => void): () => void {
+    this.listeners.add(listener);
+    void this.ready().catch((error) => this.options.onDiagnostic?.(`remote read-down start failed: ${readDownError(error).message}`));
+    return () => this.listeners.delete(listener);
+  }
+
+  async latest(): Promise<ReplicaChangeRecord | undefined> {
+    const active = await this.ready();
+    await this.fetchAfter(active, highestKnownRevision(active));
+    return [...active.changes.values()].sort(compareChanges).at(-1) ?? active.cutChange ?? undefined;
+  }
+
+  async getByOperation(opId: string): Promise<ReplicaChangeRecord | undefined> {
+    const active = await this.ready();
+    await this.fetchAfter(active, highestKnownRevision(active));
+    return [active.cutChange, ...active.changes.values()]
+      .filter((change): change is ReplicaChangeRecord => change !== null)
+      .find((change) => change.operations.some((operation) => operation.opId === opId));
+  }
+
+  async changesAfter(revision: number): Promise<ReadonlyArray<ReplicaChangeRecord>> {
+    const active = await this.ready();
+    const cutRevision = active.reservation.cut.revision;
+    if (revision < cutRevision) {
+      throw new RemoteReplicaResyncRequiredError(
+        `CURSOR_PRECEDES_PINNED_CUT:${revision}:${cutRevision}`,
+        cutRevision,
+        active.cutChange
+      );
+    }
+    active.adopted = true;
+    active.deliveredRevision = Math.max(active.deliveredRevision, revision);
+    const changes = await this.fetchAfter(active, revision);
+    this.queueNotificationPump();
+    return changes;
+  }
+
+  async snapshotAt(change: ReplicaChangeRecord): Promise<CanonicalSnapshot> {
+    const active = await this.ready();
+    if (change.workspaceId !== this.options.workspaceId) {
+      throw new Error("remote snapshot change belongs to another workspace");
+    }
+    const entries = await this.entriesAt(active, change);
+    const snapshotEntries = await Promise.all([...entries.values()].sort(compareManifestPaths).map(async (entry) => ({
+      path: entry.path,
+      content: await this.readBlob(active, entry.blobDigest),
+      logicalMode: Number.parseInt(entry.mode, 8)
+    })));
+    return {
+      workspaceId: change.workspaceId,
+      revision: change.revision,
+      commitSha: change.commitSha,
+      entries: snapshotEntries
+    };
+  }
+
+  async close(): Promise<void> {
+    this.stopped = true;
+    this.renewalTask?.dispose();
+    this.removeNotificationListener();
+    this.removeDisconnectListener();
+    await this.options.client.close();
+  }
+
+  private async ready(): Promise<ActiveSnapshot> {
+    if (this.stopped) throw new Error("remote read-down session is closed");
+    if (this.active) return this.active;
+    if (!this.recovery) {
+      this.recovery = this.recover().finally(() => {
+        this.recovery = undefined;
+      });
+    }
+    return this.recovery;
+  }
+
+  private async recover(): Promise<ActiveSnapshot> {
+    let delay = this.backoff.initialMs;
+    for (;;) {
+      try {
+        await this.options.client.connect();
+        const active = await this.openSnapshot();
+        this.active = active;
+        this.scheduleRenewal(active);
+        this.queueNotificationPump();
+        return active;
+      } catch (error) {
+        if (this.stopped) throw readDownError(error);
+        if (isIntegrityError(error)) throw readDownError(error);
+        this.options.onDiagnostic?.(`remote read-down reconnect failed; retrying in ${delay}ms: ${readDownError(error).message}`);
+        await this.sleep(delay);
+        delay = Math.min(this.backoff.maximumMs, Math.max(delay + 1, Math.ceil(delay * this.backoff.multiplier)));
+        await this.options.client.reconnect().catch(() => undefined);
+      }
+    }
+  }
+
+  private async openSnapshot(): Promise<ActiveSnapshot> {
+    const reservation = await this.options.client.beginSnapshotAndSubscribe();
+    const manifest = await this.options.client.getSnapshotManifest(
+      reservation.stream.streamToken,
+      reservation.cut.manifestDigest
+    );
+    assertManifest(reservation, manifest, this.options.workspaceId);
+    const cutChange = await this.options.client.getCutChange(reservation.stream.streamToken);
+    assertCutChange(reservation, cutChange);
+    const baseEntries = new Map(manifest.entries.map((entry) => [entry.path, entry]));
+    if (baseEntries.size !== manifest.entries.length) throw new Error("authority snapshot manifest contains duplicate paths");
+    await mapInBatches(
+      manifest.entries,
+      8,
+      (entry) => this.readBlobFromReservation(reservation, entry.blobDigest)
+    );
+    return {
+      reservation,
+      cutChange,
+      baseEntries,
+      changes: new Map(),
+      adopted: reservation.cut.revision === 0,
+      deliveredRevision: reservation.cut.revision
+    };
+  }
+
+  private async fetchAfter(active: ActiveSnapshot, revision: number): Promise<ReadonlyArray<ReplicaChangeRecord>> {
+    try {
+      this.assertCurrent(active);
+      const result = await this.options.client.changesAfter(active.reservation.stream.streamToken, revision);
+      validateChanges(result.changes, revision, this.options.workspaceId);
+      for (const change of result.changes) active.changes.set(change.revision, change);
+      return result.changes;
+    } catch (error) {
+      if (isResyncError(error)) {
+        this.active = undefined;
+        const next = await this.ready();
+        throw new RemoteReplicaResyncRequiredError(
+          error.message,
+          next.reservation.cut.revision,
+          next.cutChange
+        );
+      }
+      if (error instanceof AuthorityTransportDisconnectedError) {
+        this.active = undefined;
+        const next = await this.ready();
+        if (revision < next.reservation.cut.revision) {
+          throw new RemoteReplicaResyncRequiredError(
+            `CURSOR_PRECEDES_RECONNECTED_CUT:${revision}:${next.reservation.cut.revision}`,
+            next.reservation.cut.revision,
+            next.cutChange
+          );
+        }
+        return this.fetchAfter(next, revision);
+      }
+      throw error;
+    }
+  }
+
+  private async entriesAt(
+    active: ActiveSnapshot,
+    change: ReplicaChangeRecord
+  ): Promise<ReadonlyMap<string, AuthoritySnapshotManifestEntry>> {
+    const cut = active.reservation.cut;
+    if (change.revision < cut.revision) {
+      throw new RemoteReplicaResyncRequiredError(
+        `SNAPSHOT_PRECEDES_PINNED_CUT:${change.revision}:${cut.revision}`,
+        cut.revision,
+        active.cutChange
+      );
+    }
+    if (change.revision > cut.revision) await this.fetchAfter(active, cut.revision);
+    const entries = new Map(active.baseEntries);
+    for (let revision = cut.revision + 1; revision <= change.revision; revision += 1) {
+      const next = active.changes.get(revision);
+      if (!next) throw new Error(`remote snapshot change gap at revision ${revision}`);
+      applyChange(entries, next);
+      assertChangeManifest(cut.epoch, next, entries);
+    }
+    if (change.revision === cut.revision) {
+      const actual = manifestDigest(cut, [...entries.values()]);
+      if (actual !== change.manifest.digest) throw new Error(`MANIFEST_DIGEST_MISMATCH:${change.manifest.digest}:${actual}`);
+    }
+    return entries;
+  }
+
+  private async readBlob(active: ActiveSnapshot, digest: AuthoritySnapshotManifestEntry["blobDigest"]): Promise<Buffer> {
+    this.assertCurrent(active);
+    return this.readBlobFromReservation(active.reservation, digest);
+  }
+
+  private async readBlobFromReservation(
+    reservation: AuthoritySnapshotReservation,
+    digest: AuthoritySnapshotManifestEntry["blobDigest"]
+  ): Promise<Buffer> {
+    try {
+      return await this.cas.get(digest);
+    } catch (error) {
+      if (!isMissing(error)) throw error;
+    }
+    const bytes = await this.options.client.getBlob(reservation.stream.streamToken, digest);
+    const actual = await this.cas.put(bytes);
+    if (actual !== digest) throw new Error(`BLOB_DIGEST_MISMATCH:${digest}:${actual}`);
+    return Buffer.from(bytes);
+  }
+
+  private receiveNotification(change: ReplicaChangeRecord): void {
+    const active = this.active;
+    if (!active || change.workspaceId !== this.options.workspaceId) return;
+    if (change.revision <= active.reservation.cut.revision) return;
+    active.changes.set(change.revision, change);
+    this.queueNotificationPump();
+  }
+
+  private queueNotificationPump(): void {
+    void this.pumpNotifications().catch((error) => {
+      this.options.onDiagnostic?.(`remote read-down notification pump stopped: ${readDownError(error).message}`);
+    });
+  }
+
+  private async pumpNotifications(): Promise<void> {
+    if (this.notificationPump) return this.notificationPump;
+    this.notificationPump = this.flushNotifications().finally(() => {
+      this.notificationPump = undefined;
+    });
+    return this.notificationPump;
+  }
+
+  private async flushNotifications(): Promise<void> {
+    const active = this.active;
+    if (!active?.adopted || this.listeners.size === 0) return;
+    for (;;) {
+      const expected = active.deliveredRevision + 1;
+      let change = active.changes.get(expected);
+      if (!change) {
+        const fetched = await this.fetchAfter(active, active.deliveredRevision);
+        change = fetched[0];
+      }
+      if (!change || change.revision !== expected) return;
+      active.deliveredRevision = change.revision;
+      for (const listener of this.listeners) {
+        try {
+          listener(change);
+        } catch (error) {
+          this.options.onDiagnostic?.(`remote read-down notification listener failed: ${readDownError(error).message}`);
+        }
+      }
+    }
+  }
+
+  private handleDisconnect(): void {
+    if (this.stopped) return;
+    this.active = undefined;
+    this.renewalTask?.dispose();
+    void this.ready().catch((error) => this.options.onDiagnostic?.(`remote read-down recovery stopped: ${readDownError(error).message}`));
+  }
+
+  private scheduleRenewal(active: ActiveSnapshot): void {
+    this.renewalTask?.dispose();
+    const expiresAt = Date.parse(active.reservation.lease.expiresAt);
+    const renewableUntil = Date.parse(active.reservation.lease.renewableUntil);
+    const remaining = expiresAt - this.now();
+    const delay = Math.max(0, Math.min(remaining / 2, renewableUntil - this.now()));
+    const schedule = this.options.schedule ?? defaultSchedule;
+    this.renewalTask = schedule(delay, () => void this.renew(active));
+  }
+
+  private async renew(active: ActiveSnapshot): Promise<void> {
+    if (this.active !== active || this.stopped) return;
+    try {
+      if (this.now() >= Date.parse(active.reservation.lease.renewableUntil)) {
+        throw new RemoteReplicaResyncRequiredError(
+          "LEASE_RENEWAL_LIMIT_REACHED",
+          active.reservation.cut.revision,
+          active.cutChange
+        );
+      }
+      const lease = await this.options.client.renewLease(active.reservation.stream.streamToken);
+      const renewed: ActiveSnapshot = {
+        ...active,
+        reservation: { ...active.reservation, lease }
+      };
+      this.active = renewed;
+      this.scheduleRenewal(renewed);
+    } catch (error) {
+      this.options.onDiagnostic?.(`remote read-down lease requires resnapshot: ${readDownError(error).message}`);
+      this.active = undefined;
+      await this.options.client.reconnect().catch(() => undefined);
+      void this.ready().catch((recoveryError) => {
+        this.options.onDiagnostic?.(`remote read-down lease recovery failed: ${readDownError(recoveryError).message}`);
+      });
+    }
+  }
+
+  private assertCurrent(active: ActiveSnapshot): void {
+    if (this.active !== active) throw new AuthorityTransportDisconnectedError("remote read-down snapshot generation changed");
+  }
+}
+
+function assertManifest(
+  reservation: AuthoritySnapshotReservation,
+  manifest: AuthoritySnapshotManifest,
+  workspaceId: string
+): void {
+  if (manifest.cut.workspaceId !== workspaceId
+    || !sameSnapshotCut(manifest.cut, reservation.cut)) {
+    throw new Error("authority snapshot manifest cut mismatch");
+  }
+  const actual = manifestDigest(manifest.cut, manifest.entries);
+  if (actual !== reservation.cut.manifestDigest) {
+    throw new Error(`MANIFEST_DIGEST_MISMATCH:${reservation.cut.manifestDigest}:${actual}`);
+  }
+}
+
+function sameSnapshotCut(
+  left: AuthoritySnapshotReservation["cut"],
+  right: AuthoritySnapshotReservation["cut"]
+): boolean {
+  return left.workspaceId === right.workspaceId
+    && left.epoch === right.epoch
+    && left.revision === right.revision
+    && left.commitSha === right.commitSha
+    && left.manifestDigest === right.manifestDigest
+    && left.provenanceDigest === right.provenanceDigest;
+}
+
+function assertCutChange(
+  reservation: AuthoritySnapshotReservation,
+  change: ReplicaChangeRecord | null
+): void {
+  if (reservation.cut.revision === 0) {
+    if (change !== null) throw new Error("authority empty cut unexpectedly has a change");
+    return;
+  }
+  if (!change
+    || change.workspaceId !== reservation.cut.workspaceId
+    || change.revision !== reservation.cut.revision
+    || change.commitSha !== reservation.cut.commitSha
+    || change.manifest.digest !== reservation.cut.manifestDigest) {
+    throw new Error("authority cut change does not match snapshot reservation");
+  }
+}
+
+async function mapInBatches<Value>(
+  values: ReadonlyArray<Value>,
+  batchSize: number,
+  operation: (value: Value) => Promise<unknown>
+): Promise<void> {
+  for (let offset = 0; offset < values.length; offset += batchSize) {
+    await Promise.all(values.slice(offset, offset + batchSize).map(operation));
+  }
+}
+
+function validateChanges(
+  changes: ReadonlyArray<ReplicaChangeRecord>,
+  sinceRevision: number,
+  workspaceId: string
+): void {
+  let expected = sinceRevision + 1;
+  for (const change of changes) {
+    if (change.workspaceId !== workspaceId || change.revision !== expected) {
+      throw new Error(`remote replica change gap at revision ${change.revision}; expected ${expected}`);
+    }
+    expected += 1;
+  }
+}
+
+function applyChange(
+  entries: Map<string, AuthoritySnapshotManifestEntry>,
+  change: ReplicaChangeRecord
+): void {
+  for (const item of change.paths) {
+    if (item.tombstone) {
+      entries.delete(item.path);
+    } else {
+      if (!item.blobDigest || !item.mode) throw new Error(`remote change lacks blob metadata for ${item.path}`);
+      entries.set(item.path, {
+        path: item.path,
+        blobDigest: item.blobDigest,
+        mode: item.mode,
+        tombstone: false
+      });
+    }
+  }
+}
+
+function assertChangeManifest(
+  epoch: string,
+  change: ReplicaChangeRecord,
+  entries: ReadonlyMap<string, AuthoritySnapshotManifestEntry>
+): void {
+  const actual = manifestDigest({
+    workspaceId: change.workspaceId,
+    epoch,
+    revision: change.revision,
+    commitSha: change.commitSha
+  }, [...entries.values()]);
+  if (actual !== change.manifest.digest || entries.size !== change.manifest.entryCount) {
+    throw new Error(`MANIFEST_DIGEST_MISMATCH:${change.manifest.digest}:${actual}`);
+  }
+}
+
+function highestKnownRevision(active: ActiveSnapshot): number {
+  return Math.max(active.reservation.cut.revision, ...active.changes.keys());
+}
+
+function compareChanges(left: ReplicaChangeRecord, right: ReplicaChangeRecord): number {
+  return left.revision - right.revision;
+}
+
+function compareManifestPaths(
+  left: AuthoritySnapshotManifestEntry,
+  right: AuthoritySnapshotManifestEntry
+): number {
+  return left.path.localeCompare(right.path, "en");
+}
+
+function assertBackoff(backoff: RemoteReadDownBackoff): void {
+  if (!Number.isFinite(backoff.initialMs)
+    || !Number.isFinite(backoff.maximumMs)
+    || !Number.isFinite(backoff.multiplier)
+    || backoff.initialMs < 0
+    || backoff.maximumMs < backoff.initialMs
+    || backoff.multiplier < 1) {
+    throw new Error("remote read-down backoff must be finite, non-negative, and bounded");
+  }
+}
+
+function isResyncError(error: unknown): error is AuthorityReadDownRequestError {
+  return error instanceof AuthorityReadDownRequestError
+    && (error.code === "RESYNC_REQUIRED" || error.code === "SNAPSHOT_EXPIRED");
+}
+
+function isIntegrityError(error: unknown): boolean {
+  const message = readDownError(error).message;
+  return /(?:BLOB|MANIFEST)_DIGEST_MISMATCH|manifest (?:cut mismatch|contains duplicate)|cut change does not match|blob response (?:metadata mismatch|is not canonical)/iu.test(message);
+}
+
+function readDownError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function defaultSchedule(milliseconds: number, callback: () => void): { readonly dispose: () => void } {
+  const timer = setTimeout(callback, milliseconds);
+  timer.unref?.();
+  return { dispose: () => clearTimeout(timer) };
+}

--- a/packages/daemon/src/broker/remote-replica-change-log.ts
+++ b/packages/daemon/src/broker/remote-replica-change-log.ts
@@ -1,0 +1,47 @@
+import type {
+  ReplicaChangeLog,
+  ReplicaChangeRecord
+} from "@harness-anything/application";
+import { RemoteReadDownSession, type RemoteReadDownSessionOptions } from "./remote-read-down-session.ts";
+
+export class RemoteReplicaChangeLog implements ReplicaChangeLog {
+  readonly session: RemoteReadDownSession;
+  private readonly workspaceId: string;
+
+  constructor(options: RemoteReadDownSessionOptions | RemoteReadDownSession) {
+    this.session = options instanceof RemoteReadDownSession ? options : new RemoteReadDownSession(options);
+    this.workspaceId = options instanceof RemoteReadDownSession ? options.workspaceId : options.workspaceId;
+  }
+
+  async append(_record: Parameters<ReplicaChangeLog["append"]>[0]): Promise<void> {
+    throw new Error("REMOTE_REPLICA_CHANGE_LOG_READ_DOWN_ONLY");
+  }
+
+  latest(workspaceId: string): Promise<ReplicaChangeRecord | undefined> {
+    this.assertWorkspace(workspaceId);
+    return this.session.latest();
+  }
+
+  getByOperation(workspaceId: string, opId: string): Promise<ReplicaChangeRecord | undefined> {
+    this.assertWorkspace(workspaceId);
+    return this.session.getByOperation(opId);
+  }
+
+  changesAfter(workspaceId: string, revision: number): Promise<ReadonlyArray<ReplicaChangeRecord>> {
+    this.assertWorkspace(workspaceId);
+    return this.session.changesAfter(revision);
+  }
+
+  subscribe(workspaceId: string, listener: (change: ReplicaChangeRecord) => void): () => void {
+    this.assertWorkspace(workspaceId);
+    return this.session.subscribe(listener);
+  }
+
+  close(): Promise<void> {
+    return this.session.close();
+  }
+
+  private assertWorkspace(workspaceId: string): void {
+    if (workspaceId !== this.workspaceId) throw new Error("remote replica log belongs to another workspace");
+  }
+}

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -297,6 +297,7 @@ export {
 } from "./transport/length-frame-codec.ts";
 export {
   AuthorityTransportDisconnectedError,
+  AuthorityReadDownRequestError,
   PersistentSshAuthorityClient,
   buildAuthoritySshArgs,
   type AuthoritySshTarget,

--- a/packages/daemon/src/transport/persistent-ssh-authority-client.ts
+++ b/packages/daemon/src/transport/persistent-ssh-authority-client.ts
@@ -88,6 +88,7 @@ export class PersistentSshAuthorityClient {
   private sequence = 0;
   private ready = false;
   private closing = false;
+  private connectionTask: Promise<void> | undefined;
   private readonly notificationListeners = new Set<(change: ReplicaChangeRecord) => void>();
   private readonly disconnectListeners = new Set<(error: AuthorityTransportDisconnectedError) => void>();
   private pending = new Map<string, {
@@ -109,9 +110,23 @@ export class PersistentSshAuthorityClient {
     return this.generation;
   }
 
-  async connect(): Promise<void> {
-    if (this.child && this.ready) return;
+  connect(): Promise<void> {
+    if (this.child && this.ready) return Promise.resolve();
+    if (this.connectionTask) return this.connectionTask;
     this.closing = false;
+    return this.runConnectionTask(() => this.openConnection());
+  }
+
+  reconnect(): Promise<void> {
+    if (this.connectionTask) return this.connectionTask;
+    this.closing = false;
+    return this.runConnectionTask(async () => {
+      await this.closeChild(new AuthorityTransportDisconnectedError("authority SSH connection replaced"));
+      await this.openConnection();
+    });
+  }
+
+  private async openConnection(): Promise<void> {
     this.generation += 1;
     const generation = this.generation;
     const childFactory = this.options.childFactory ?? nodeSshAuthorityChildFactory;
@@ -133,22 +148,27 @@ export class PersistentSshAuthorityClient {
     child.on("error", (error) => this.disconnect(asError(error), generation));
     child.on("exit", () => this.disconnect(new AuthorityTransportDisconnectedError("authority SSH connection exited"), generation));
 
-    const response = await this.request({
-      type: authorityWireFrameType,
-      kind: "hello",
-      requestId: this.nextRequestId(),
-      connectionGeneration: generation,
-      workspaceId: this.options.workspaceId,
-      channelNonceDigest: this.options.channelNonceDigest(),
-      protocol: this.options.protocol
-    });
-    if (!response.ok) throw new Error(response.error?.message ?? "authority protocol negotiation failed");
-    this.ready = true;
-  }
-
-  async reconnect(): Promise<void> {
-    await this.closeChild();
-    await this.connect();
+    try {
+      const response = await this.request({
+        type: authorityWireFrameType,
+        kind: "hello",
+        requestId: this.nextRequestId(),
+        connectionGeneration: generation,
+        workspaceId: this.options.workspaceId,
+        channelNonceDigest: this.options.channelNonceDigest(),
+        protocol: this.options.protocol
+      });
+      if (!response.ok) throw new Error(response.error?.message ?? "authority protocol negotiation failed");
+      if (this.closing || this.generation !== generation || this.child !== child) {
+        throw new AuthorityTransportDisconnectedError("authority SSH connection changed during negotiation");
+      }
+      this.ready = true;
+    } catch (error) {
+      if (this.generation === generation && this.child === child) {
+        await this.closeChild(new AuthorityTransportDisconnectedError(asError(error).message));
+      }
+      throw error;
+    }
   }
 
   async submit(envelope: AuthorityOperationEnvelope): Promise<AuthorityOperationReceipt> {
@@ -293,7 +313,9 @@ export class PersistentSshAuthorityClient {
 
   async close(): Promise<void> {
     this.closing = true;
-    await this.closeChild();
+    const connectionTask = this.connectionTask;
+    await this.closeChild(new AuthorityTransportDisconnectedError("authority SSH connection closed"));
+    await connectionTask?.catch(() => undefined);
   }
 
   private request(frame: AuthorityRequestFrame, opId?: string): Promise<AuthorityResponseFrame> {
@@ -365,14 +387,39 @@ export class PersistentSshAuthorityClient {
     }
   }
 
-  private async closeChild(): Promise<void> {
+  private async closeChild(error: AuthorityTransportDisconnectedError): Promise<void> {
     const child = this.child;
+    const generation = this.generation;
     this.ready = false;
     this.child = undefined;
-    if (!child) return;
-    child.stdin.end();
-    child.kill("SIGTERM");
+    this.rejectPendingGeneration(generation, error);
+    if (child) {
+      child.stdin.end();
+      child.kill("SIGTERM");
+    }
     await Promise.resolve();
+  }
+
+  private rejectPendingGeneration(generation: number, error: AuthorityTransportDisconnectedError): void {
+    for (const [requestId, pending] of this.pending) {
+      if (pending.generation !== generation) continue;
+      this.pending.delete(requestId);
+      pending.reject(new AuthorityTransportDisconnectedError(error.message, pending.opId));
+    }
+  }
+
+  private runConnectionTask(operation: () => Promise<void>): Promise<void> {
+    const task = operation();
+    this.connectionTask = task;
+    void task.then(
+      () => {
+        if (this.connectionTask === task) this.connectionTask = undefined;
+      },
+      () => {
+        if (this.connectionTask === task) this.connectionTask = undefined;
+      }
+    );
+    return task;
   }
 
   private nextRequestId(): string {

--- a/packages/daemon/src/transport/persistent-ssh-authority-client.ts
+++ b/packages/daemon/src/transport/persistent-ssh-authority-client.ts
@@ -11,10 +11,15 @@ import type {
 import {
   authorityWireFrameType,
   isAuthorityServerFrame,
+  type AuthorityBlobResult,
+  type AuthorityChangesAfterResult,
   type AuthorityNegotiatedProtocol,
   type AuthorityRequestFrame,
   type AuthorityResponseFrame,
-  type AuthoritySnapshotLease
+  type AuthoritySnapshotLease,
+  type AuthoritySnapshotManifest,
+  type AuthoritySnapshotReservation,
+  type Sha256Digest
 } from "../authority/protocol.ts";
 import {
   createLengthPrefixedFrameReader,
@@ -65,6 +70,16 @@ export class AuthorityTransportDisconnectedError extends Error {
   }
 }
 
+export class AuthorityReadDownRequestError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(`${code}: ${message}`);
+    this.name = "AuthorityReadDownRequestError";
+    this.code = code;
+  }
+}
+
 export class PersistentSshAuthorityClient {
   private readonly options: PersistentSshAuthorityClientOptions;
   private readonly limits: TransportFlowLimits;
@@ -73,6 +88,8 @@ export class PersistentSshAuthorityClient {
   private sequence = 0;
   private ready = false;
   private closing = false;
+  private readonly notificationListeners = new Set<(change: ReplicaChangeRecord) => void>();
+  private readonly disconnectListeners = new Set<(error: AuthorityTransportDisconnectedError) => void>();
   private pending = new Map<string, {
     readonly generation: number;
     readonly opId?: string;
@@ -175,6 +192,69 @@ export class PersistentSshAuthorityClient {
     return (response.result ?? undefined) as AuthorityOperationRecord | undefined;
   }
 
+  async beginSnapshotAndSubscribe(): Promise<AuthoritySnapshotReservation> {
+    this.assertReady();
+    const response = await this.request({
+      type: authorityWireFrameType,
+      kind: "begin_snapshot_and_subscribe",
+      requestId: this.nextRequestId(),
+      connectionGeneration: this.generation,
+      workspaceId: this.options.workspaceId
+    });
+    return this.readDownResult(response, "authority snapshot reservation") as AuthoritySnapshotReservation;
+  }
+
+  async getSnapshotManifest(
+    streamToken: string,
+    manifestDigest: Sha256Digest
+  ): Promise<AuthoritySnapshotManifest> {
+    this.assertReady();
+    const response = await this.request({
+      type: authorityWireFrameType,
+      kind: "get_snapshot_manifest",
+      requestId: this.nextRequestId(),
+      connectionGeneration: this.generation,
+      streamToken,
+      manifestDigest
+    });
+    return this.readDownResult(response, "authority snapshot manifest") as AuthoritySnapshotManifest;
+  }
+
+  async getBlob(streamToken: string, digest: Sha256Digest): Promise<Uint8Array> {
+    this.assertReady();
+    const response = await this.request({
+      type: authorityWireFrameType,
+      kind: "get_blob",
+      requestId: this.nextRequestId(),
+      connectionGeneration: this.generation,
+      streamToken,
+      digest
+    });
+    const result = this.readDownResult(response, "authority blob") as AuthorityBlobResult;
+    if (result.encoding !== "base64" || result.digest !== digest) {
+      throw new Error(`authority blob response metadata mismatch for ${digest}`);
+    }
+    const bytes = Buffer.from(result.bytes, "base64");
+    if (bytes.toString("base64") !== result.bytes) {
+      throw new Error(`authority blob response is not canonical base64 for ${digest}`);
+    }
+    return bytes;
+  }
+
+  async changesAfter(streamToken: string, sinceRevision: number): Promise<AuthorityChangesAfterResult> {
+    this.assertReady();
+    const response = await this.request({
+      type: authorityWireFrameType,
+      kind: "changes_after",
+      requestId: this.nextRequestId(),
+      connectionGeneration: this.generation,
+      workspaceId: this.options.workspaceId,
+      streamToken,
+      sinceRevision
+    });
+    return this.readDownResult(response, "authority changes") as AuthorityChangesAfterResult;
+  }
+
   async renewLease(streamToken: string): Promise<AuthoritySnapshotLease> {
     this.assertReady();
     const response = await this.request({
@@ -185,10 +265,7 @@ export class PersistentSshAuthorityClient {
       workspaceId: this.options.workspaceId,
       streamToken
     });
-    if (!response.ok || !response.result) {
-      throw new Error(response.error?.message ?? "authority lease renewal failed without a lease");
-    }
-    return response.result as AuthoritySnapshotLease;
+    return this.readDownResult(response, "authority lease renewal") as AuthoritySnapshotLease;
   }
 
   async getCutChange(streamToken: string): Promise<ReplicaChangeRecord | null> {
@@ -200,8 +277,18 @@ export class PersistentSshAuthorityClient {
       connectionGeneration: this.generation,
       streamToken
     });
-    if (!response.ok) throw new Error(response.error?.message ?? "authority cut change read failed");
+    if (!response.ok) throw this.readDownError(response, "authority cut change read");
     return (response.result ?? null) as ReplicaChangeRecord | null;
+  }
+
+  onNotification(listener: (change: ReplicaChangeRecord) => void): () => void {
+    this.notificationListeners.add(listener);
+    return () => this.notificationListeners.delete(listener);
+  }
+
+  onDisconnect(listener: (error: AuthorityTransportDisconnectedError) => void): () => void {
+    this.disconnectListeners.add(listener);
+    return () => this.disconnectListeners.delete(listener);
   }
 
   async close(): Promise<void> {
@@ -228,7 +315,18 @@ export class PersistentSshAuthorityClient {
     if (sourceGeneration !== this.generation || !isAuthorityServerFrame(value)) return;
     if (value.connectionGeneration !== this.generation) return;
     if (value.kind === "replica_change") {
-      this.options.onNotification?.(value.change);
+      try {
+        this.options.onNotification?.(value.change);
+      } catch (error) {
+        this.options.onDiagnostic?.(`authority notification listener failed: ${asError(error).message}`);
+      }
+      for (const listener of this.notificationListeners) {
+        try {
+          listener(value.change);
+        } catch (error) {
+          this.options.onDiagnostic?.(`authority notification listener failed: ${asError(error).message}`);
+        }
+      }
       return;
     }
     if (value.kind === "stream_closed") {
@@ -245,6 +343,9 @@ export class PersistentSshAuthorityClient {
     if (sourceGeneration !== this.generation) return;
     this.ready = false;
     this.child = undefined;
+    const disconnected = error instanceof AuthorityTransportDisconnectedError
+      ? error
+      : new AuthorityTransportDisconnectedError(error.message);
     for (const [requestId, pending] of this.pending) {
       if (pending.generation !== sourceGeneration) continue;
       this.pending.delete(requestId);
@@ -253,6 +354,15 @@ export class PersistentSshAuthorityClient {
         : new AuthorityTransportDisconnectedError(error.message, pending.opId));
     }
     if (!this.closing) this.options.onDiagnostic?.(`authority transport disconnected: ${error.message}`);
+    if (!this.closing) {
+      for (const listener of this.disconnectListeners) {
+        try {
+          listener(disconnected);
+        } catch (listenerError) {
+          this.options.onDiagnostic?.(`authority disconnect listener failed: ${asError(listenerError).message}`);
+        }
+      }
+    }
   }
 
   private async closeChild(): Promise<void> {
@@ -272,6 +382,19 @@ export class PersistentSshAuthorityClient {
 
   private assertReady(): void {
     if (!this.child || !this.ready) throw new AuthorityTransportDisconnectedError("authority SSH connection is not ready");
+  }
+
+  private readDownResult(response: AuthorityResponseFrame, description: string): NonNullable<AuthorityResponseFrame["result"]> {
+    if (!response.ok || response.result === undefined || response.result === null) {
+      throw this.readDownError(response, `${description} failed without a result`);
+    }
+    return response.result;
+  }
+
+  private readDownError(response: AuthorityResponseFrame, fallback: string): Error {
+    return response.error
+      ? new AuthorityReadDownRequestError(response.error.code, response.error.message)
+      : new Error(fallback);
   }
 }
 

--- a/packages/daemon/test/persistent-ssh-read-down-client.test.ts
+++ b/packages/daemon/test/persistent-ssh-read-down-client.test.ts
@@ -1,0 +1,187 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import test from "node:test";
+import { authorityProtocolTuple, type ReplicaChangeRecord } from "../../application/src/index.ts";
+import {
+  authorityWireFrameType,
+  type AuthoritySnapshotLease,
+  type AuthoritySnapshotManifest,
+  type AuthoritySnapshotReservation
+} from "../src/authority/protocol.ts";
+import {
+  PersistentSshAuthorityClient,
+  type SshAuthorityChild,
+  type SshAuthorityChildFactory
+} from "../src/transport/persistent-ssh-authority-client.ts";
+import {
+  createLengthPrefixedFrameReader,
+  encodeLengthPrefixedFrame
+} from "../src/transport/length-frame-codec.ts";
+
+const workspaceId = "workspace-read-down-client";
+const digest = `sha256:${"1".repeat(64)}` as const;
+
+test("persistent SSH client consumes all six frozen read-down request frames", async () => {
+  const requested: Array<Record<string, unknown>> = [];
+  const lease: AuthoritySnapshotLease = {
+    leaseId: "lease-read-down",
+    expiresAt: "2026-07-23T04:09:00.000Z",
+    renewableUntil: "2026-07-23T05:00:00.000Z",
+    minRetainedRevision: 2,
+    pinnedBlobSetDigest: digest
+  };
+  const cutChange = change();
+  const reservation: AuthoritySnapshotReservation = {
+    schema: "authority-snapshot-reservation/v1",
+    cut: {
+      workspaceId,
+      epoch: "7",
+      revision: 1,
+      commitSha: cutChange.commitSha,
+      manifestDigest: digest,
+      provenanceDigest: digest
+    },
+    lease,
+    stream: { streamToken: "stream-token", fromRevision: 2 }
+  };
+  const manifest: AuthoritySnapshotManifest = {
+    schema: "authority-snapshot-manifest/v1",
+    cut: reservation.cut,
+    entries: []
+  };
+  const changes = {
+    schema: "authority-changes-after/v1" as const,
+    sinceRevision: 1,
+    throughRevision: 1,
+    changes: []
+  };
+  const client = new PersistentSshAuthorityClient({
+    target: { destination: "authority.internal", fixedCommand: "ha-authority-connect" },
+    workspaceId,
+    channelNonceDigest: () => "sha256:channel-generation",
+    protocol: authorityProtocolTuple,
+    childFactory: scriptedChildFactory(
+      { lease, cutChange, reservation, manifest, changes, blob: Buffer.from("blob") },
+      requested
+    )
+  });
+
+  await client.connect();
+  assert.deepEqual(await client.beginSnapshotAndSubscribe(), reservation);
+  assert.deepEqual(await client.getSnapshotManifest("stream-token", digest), manifest);
+  assert.deepEqual(await client.getBlob("stream-token", digest), Buffer.from("blob"));
+  assert.deepEqual(await client.changesAfter("stream-token", 1), changes);
+  assert.deepEqual(await client.renewLease("stream-token"), lease);
+  assert.deepEqual(await client.getCutChange("stream-token"), cutChange);
+  assert.deepEqual(requested, [
+    { kind: "begin_snapshot_and_subscribe", workspaceId },
+    { kind: "get_snapshot_manifest", streamToken: "stream-token", manifestDigest: digest },
+    { kind: "get_blob", streamToken: "stream-token", digest },
+    { kind: "changes_after", workspaceId, streamToken: "stream-token", sinceRevision: 1 },
+    { kind: "renew_lease", workspaceId, streamToken: "stream-token" },
+    { kind: "get_cut_change", streamToken: "stream-token" }
+  ]);
+  await client.close();
+});
+
+function scriptedChildFactory(
+  results: {
+    readonly lease: AuthoritySnapshotLease;
+    readonly cutChange: ReplicaChangeRecord;
+    readonly reservation: AuthoritySnapshotReservation;
+    readonly manifest: AuthoritySnapshotManifest;
+    readonly changes: {
+      readonly schema: "authority-changes-after/v1";
+      readonly sinceRevision: number;
+      readonly throughRevision: number;
+      readonly changes: readonly [];
+    };
+    readonly blob: Buffer;
+  },
+  requested: Array<Record<string, unknown>>
+): SshAuthorityChildFactory {
+  return {
+    spawn: () => {
+      const stdin = new PassThrough();
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const events = new EventEmitter();
+      const reader = createLengthPrefixedFrameReader();
+      stdin.on("data", (chunk: Buffer) => {
+        const batch = reader.push(chunk);
+        assert.equal(batch.error, undefined);
+        for (const value of batch.frames) {
+          const frame = value as Record<string, unknown> & {
+            readonly kind: string;
+            readonly requestId: string;
+            readonly connectionGeneration: number;
+          };
+          if (frame.kind !== "hello") requested.push(selectRequestFields(frame));
+          stdout.write(encodeLengthPrefixedFrame({
+            type: authorityWireFrameType,
+            kind: "response",
+            requestId: frame.requestId,
+            connectionGeneration: frame.connectionGeneration,
+            ok: true,
+            result: resultFor(frame.kind, frame, results)
+          }));
+        }
+      });
+      return {
+        stdin,
+        stdout,
+        stderr,
+        on: (event, listener) => events.on(event, listener),
+        kill: () => {
+          queueMicrotask(() => events.emit("exit", 0, null));
+          return true;
+        }
+      } satisfies SshAuthorityChild;
+    }
+  };
+}
+
+function resultFor(
+  kind: string,
+  frame: Readonly<Record<string, unknown>>,
+  results: Parameters<typeof scriptedChildFactory>[0]
+): unknown {
+  if (kind === "hello") return { accepted: true, protocol: authorityProtocolTuple, capabilities: [] };
+  if (kind === "begin_snapshot_and_subscribe") return results.reservation;
+  if (kind === "get_snapshot_manifest") return results.manifest;
+  if (kind === "get_blob") {
+    return {
+      schema: "authority-blob/v1",
+      digest: frame.digest,
+      encoding: "base64",
+      bytes: results.blob.toString("base64")
+    };
+  }
+  if (kind === "changes_after") return results.changes;
+  if (kind === "get_cut_change") return results.cutChange;
+  return results.lease;
+}
+
+function selectRequestFields(frame: Readonly<Record<string, unknown>>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(frame).filter(([key]) => [
+    "kind", "workspaceId", "streamToken", "manifestDigest", "digest", "sinceRevision"
+  ].includes(key)));
+}
+
+function change(): ReplicaChangeRecord {
+  return {
+    schema: "replica-change/v2",
+    workspaceId,
+    revision: 1,
+    opId: "op-cut",
+    semanticDigest: "cut",
+    operations: [{ opId: "op-cut", semanticDigest: "cut" }],
+    commitSha: "1".repeat(40),
+    previousCommit: null,
+    changedAt: "2026-07-23T04:00:00.000Z",
+    manifest: { digest, entryCount: 0 },
+    paths: []
+  };
+}

--- a/packages/daemon/test/persistent-ssh-read-down-client.test.ts
+++ b/packages/daemon/test/persistent-ssh-read-down-client.test.ts
@@ -86,6 +86,53 @@ test("persistent SSH client consumes all six frozen read-down request frames", a
   await client.close();
 });
 
+test("concurrent reconnects share one connection transition and reject the replaced generation", async () => {
+  let spawnCount = 0;
+  const client = new PersistentSshAuthorityClient({
+    target: { destination: "authority.internal", fixedCommand: "ha-authority-connect" },
+    workspaceId,
+    channelNonceDigest: () => "sha256:channel-generation",
+    protocol: authorityProtocolTuple,
+    childFactory: frameHandlingChildFactory((frame, respond) => {
+      if (frame.kind === "hello") respond({
+        accepted: true,
+        protocol: authorityProtocolTuple,
+        capabilities: []
+      });
+    }, () => {
+      spawnCount += 1;
+    })
+  });
+
+  await client.connect();
+  const pending = client.changesAfter("stream-token", 1);
+  const firstReconnect = client.reconnect();
+  const secondReconnect = client.reconnect();
+
+  await assert.rejects(pending, /connection replaced/u);
+  await Promise.all([firstReconnect, secondReconnect]);
+  assert.equal(spawnCount, 2, "concurrent recovery creates exactly one replacement child");
+  await client.close();
+});
+
+test("closing a negotiating child rejects its pending hello instead of leaving connect hung", async () => {
+  let sawHello = false;
+  const client = new PersistentSshAuthorityClient({
+    target: { destination: "authority.internal", fixedCommand: "ha-authority-connect" },
+    workspaceId,
+    channelNonceDigest: () => "sha256:channel-generation",
+    protocol: authorityProtocolTuple,
+    childFactory: frameHandlingChildFactory((frame) => {
+      if (frame.kind === "hello") sawHello = true;
+    })
+  });
+
+  const connecting = client.connect();
+  await waitFor(() => sawHello);
+  await client.close();
+  await assert.rejects(connecting, /connection closed/u);
+});
+
 function scriptedChildFactory(
   results: {
     readonly lease: AuthoritySnapshotLease;
@@ -143,6 +190,58 @@ function scriptedChildFactory(
   };
 }
 
+function frameHandlingChildFactory(
+  handle: (
+    frame: Record<string, unknown> & {
+      readonly kind: string;
+      readonly requestId: string;
+      readonly connectionGeneration: number;
+    },
+    respond: (result: unknown) => void
+  ) => void,
+  onSpawn: () => void = () => undefined
+): SshAuthorityChildFactory {
+  return {
+    spawn: () => {
+      onSpawn();
+      const stdin = new PassThrough();
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const events = new EventEmitter();
+      const reader = createLengthPrefixedFrameReader();
+      stdin.on("data", (chunk: Buffer) => {
+        const batch = reader.push(chunk);
+        assert.equal(batch.error, undefined);
+        for (const value of batch.frames) {
+          const frame = value as Record<string, unknown> & {
+            readonly kind: string;
+            readonly requestId: string;
+            readonly connectionGeneration: number;
+          };
+          handle(frame, (result) => stdout.write(encodeLengthPrefixedFrame({
+            type: authorityWireFrameType,
+            kind: "response",
+            requestId: frame.requestId,
+            connectionGeneration: frame.connectionGeneration,
+            ok: true,
+            result
+          })));
+        }
+      });
+      return {
+        stdin,
+        stdout,
+        stderr,
+        on: (event, listener) => events.on(event, listener),
+        kill: () => {
+          queueMicrotask(() => events.emit("exit", 0, null));
+          return true;
+        }
+      };
+    }
+  };
+}
+
 function resultFor(
   kind: string,
   frame: Readonly<Record<string, unknown>>,
@@ -184,4 +283,12 @@ function change(): ReplicaChangeRecord {
     manifest: { digest, entryCount: 0 },
     paths: []
   };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  throw new Error("timed out waiting for transport condition");
 }

--- a/packages/daemon/test/remote-read-down-adapters.test.ts
+++ b/packages/daemon/test/remote-read-down-adapters.test.ts
@@ -1,13 +1,14 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import type { ReplicaChangeRecord } from "../../application/src/index.ts";
 import {
   AuthorityReadDownRequestError,
+  AuthorityTransportDisconnectedError,
   RemoteCanonicalSnapshotSource,
   RemoteReadDownSession,
   RemoteReplicaChangeLog,
@@ -24,6 +25,7 @@ import type {
   AuthoritySnapshotReservation,
   Sha256Digest
 } from "../src/authority/protocol.ts";
+import { deferred, type Deferred } from "./remote-read-down-test-support.ts";
 
 const workspaceId = "workspace-remote-adapter";
 
@@ -199,6 +201,235 @@ test("lease renewal failure reconnects and begins a new snapshot instead of exte
   });
 });
 
+test("late renewal and stale fetch continuations cannot overwrite or clear a replacement generation", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const now = Date.parse("2026-07-23T04:00:00.000Z");
+    const first = makeSnapshot(1, { "one.md": Buffer.from("one\n") }, now + 1_000, now + 5_000);
+    const second = makeSnapshot(2, { "two.md": Buffer.from("two\n") }, now + 2_000, now + 10_000);
+    const client = new FakeReadDownClient([first, second]);
+    const renewal = deferred<AuthoritySnapshotLease>();
+    const fetch = deferred<AuthorityChangesAfterResult>();
+    const scheduled: Array<() => void> = [];
+    const session = new RemoteReadDownSession({
+      client: client as unknown as PersistentSshAuthorityClient,
+      workspaceId,
+      stateRoot,
+      now: () => now,
+      schedule: (_milliseconds, callback) => {
+        scheduled.push(callback);
+        return { dispose: () => undefined };
+      },
+      backoff: { initialMs: 0, maximumMs: 0, multiplier: 1 }
+    });
+
+    assert.equal((await session.latest())?.revision, 1);
+    client.renewalGate = renewal;
+    client.changesGate = fetch;
+    const staleFetch = session.changesAfter(1);
+    await waitFor(() => client.changesRequests === 2);
+    scheduled.shift()!();
+    await waitFor(() => client.renewRequests === 1);
+    client.disconnect();
+    await waitFor(() => client.beginRequests === 2);
+
+    renewal.resolve({
+      ...first.reservation.lease,
+      expiresAt: new Date(now + 3_000).toISOString()
+    });
+    fetch.reject(new AuthorityTransportDisconnectedError("stale fetch disconnected"));
+    client.changesGate = undefined;
+    await assert.rejects(
+      staleFetch,
+      (error: unknown) => error instanceof RemoteReplicaResyncRequiredError && error.cutRevision === 2
+    );
+    assert.equal((await session.latest())?.revision, 2, "late continuations leave the replacement cut installed");
+    assert.equal(client.beginRequests, 2, "stale catch does not clear and reopen the replacement generation");
+    await session.close();
+  });
+});
+
+test("same-epoch reconnect inherits the delivered cursor and keeps an existing subscription live", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const base = makeSnapshot(0, {});
+    const firstChange = makeChange(base, 1, { "one.md": Buffer.from("one\n") });
+    base.forwardChanges.push(firstChange.change);
+    const next = firstChange.snapshot;
+    const secondChange = makeChange(next, 2, { "two.md": Buffer.from("two\n") });
+    next.forwardChanges.push(secondChange.change);
+    const client = new FakeReadDownClient([base, next]);
+    const session = makeSession(client, stateRoot);
+    const received: number[] = [];
+    session.subscribe((change) => received.push(change.revision));
+
+    await session.changesAfter(0);
+    await waitFor(() => received.includes(1));
+    client.disconnect();
+    await waitFor(() => client.beginRequests === 2);
+    client.notify(secondChange.change);
+    await waitFor(() => received.includes(2));
+
+    assert.deepEqual(received, [1, 2]);
+    await session.close();
+  });
+});
+
+test("epoch replacement and same-revision identity drift require explicit resync with a bootstrap cut", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const before = makeSnapshot(1, { "value.md": Buffer.from("old\n") }, undefined, undefined, "7");
+    const after = makeSnapshot(1, { "value.md": Buffer.from("new\n") }, undefined, undefined, "8");
+    const client = new FakeReadDownClient([before, after]);
+    const session = makeSession(client, stateRoot);
+
+    const oldChange = await session.latest();
+    await session.changesAfter(1);
+    client.disconnect();
+    await waitFor(() => client.beginRequests === 2);
+    await assert.rejects(
+      session.changesAfter(1),
+      (error: unknown) => error instanceof RemoteReplicaResyncRequiredError
+        && error.cut.epoch === "8"
+        && error.cut.manifestDigest === after.reservation.cut.manifestDigest
+        && error.cutChange?.revision === 1
+    );
+    await assert.rejects(
+      session.snapshotAt(oldChange!),
+      /CHANGE_EPOCH_MISMATCH/u
+    );
+    const replacement = await session.snapshotAt(after.cutChange!);
+    assert.equal(Buffer.from(replacement.entries[0]!.content).toString("utf8"), "new\n");
+    assert.deepEqual(await session.changesAfter(1), [], "retry at the bootstrap cut explicitly acknowledges resync");
+    await session.close();
+  });
+});
+
+test("close cancels recovery sleep and joins in-flight blob work before resolving", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const snapshot = makeSnapshot(1, { "value.md": Buffer.from("value\n") });
+    const sleeping = deferred<void>();
+    const client = new FakeReadDownClient([snapshot]);
+    client.connectFailures = 1;
+    const session = new RemoteReadDownSession({
+      client: client as unknown as PersistentSshAuthorityClient,
+      workspaceId,
+      stateRoot,
+      sleep: () => sleeping.promise,
+      backoff: { initialMs: 1, maximumMs: 1, multiplier: 1 }
+    });
+    const pending = session.latest();
+    await waitFor(() => client.connectRequests === 1);
+    await session.close();
+    await assert.rejects(pending, /closed|connect failure/u);
+    sleeping.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    assert.equal(client.reconnectRequests, 0, "recovery does not reconnect after close");
+  });
+
+  await withStateRoot(async (stateRoot) => {
+    const snapshot = makeSnapshot(1, { "value.md": Buffer.from("value\n") });
+    const blob = deferred<void>();
+    const client = new FakeReadDownClient([snapshot]);
+    client.blobGate = blob;
+    const session = makeSession(client, stateRoot);
+    const pending = session.latest();
+    await waitFor(() => client.activeBlobRequests === 1);
+    let closed = false;
+    const closing = session.close().then(() => {
+      closed = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    assert.equal(closed, false, "close waits for an in-flight blob operation");
+    blob.resolve();
+    await closing;
+    await assert.rejects(pending, /closed/u);
+    assert.equal(client.activeBlobRequests, 0);
+  });
+});
+
+test("a corrupted durable CAS object is a terminal integrity failure without reconnect", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const bytes = Buffer.from("trusted\n");
+    const snapshot = makeSnapshot(1, { "value.md": bytes });
+    const firstClient = new FakeReadDownClient([snapshot]);
+    const firstSession = makeSession(firstClient, stateRoot);
+    await firstSession.latest();
+    await firstSession.close();
+
+    const objectDigest = digest(bytes).slice("sha256:".length);
+    await writeFile(path.join(stateRoot, "cas", objectDigest.slice(0, 2), objectDigest.slice(2)), "corrupt");
+    const client = new FakeReadDownClient([snapshot]);
+    const session = makeSession(client, stateRoot);
+    await assert.rejects(session.latest(), /CAS object corrupted/u);
+    assert.equal(client.beginRequests, 1);
+    assert.equal(client.reconnectRequests, 0, "deterministic local corruption is not retried as transport failure");
+    await assert.rejects(session.latest(), /CAS object corrupted/u);
+    assert.equal(client.beginRequests, 1, "terminal integrity failure is sticky for the session");
+    await session.close();
+  });
+});
+
+test("notification cache remains count and byte bounded under a large hint burst", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const base = makeSnapshot(0, {});
+    const client = new FakeReadDownClient([base]);
+    const session = new RemoteReadDownSession({
+      client: client as unknown as PersistentSshAuthorityClient,
+      workspaceId,
+      stateRoot,
+      changeCache: { maxCount: 32, maxBytes: 32 * 1024 },
+      backoff: { initialMs: 0, maximumMs: 0, multiplier: 1 }
+    });
+    await session.latest();
+    for (let revision = 1; revision <= 50_000; revision += 1) {
+      client.notify(recordFor(
+        revision,
+        revision.toString(16).padStart(40, "0"),
+        digest(Buffer.from(`manifest-${revision}`)),
+        0,
+        []
+      ));
+    }
+    const active = (session as unknown as {
+      readonly active: { readonly changes: ReadonlyMap<number, ReplicaChangeRecord>; readonly changeBytes: number };
+    }).active;
+    assert.ok(active.changes.size <= 32);
+    assert.ok(active.changeBytes <= 32 * 1024);
+    assert.equal((await session.latest())?.revision, 32, "highest revision lookup does not spread the large input set");
+    await session.close();
+  });
+});
+
+test("blob warming deduplicates digest requests and all blob IO stays batch bounded", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const shared = Buffer.from("shared\n");
+    const duplicateFiles = Object.fromEntries(
+      Array.from({ length: 100 }, (_, index) => [`shared-${index}.md`, shared])
+    );
+    const duplicateSnapshot = makeSnapshot(1, duplicateFiles);
+    const duplicateClient = new FakeReadDownClient([duplicateSnapshot]);
+    const duplicateSession = makeSession(duplicateClient, stateRoot);
+    await duplicateSession.latest();
+    assert.equal(duplicateClient.blobRequests.length, 1, "manifest warming pulls each digest once");
+    await duplicateSession.close();
+  });
+
+  await withStateRoot(async (stateRoot) => {
+    const files = Object.fromEntries(
+      Array.from({ length: 25 }, (_, index) => [`file-${index}.md`, Buffer.from(`value-${index}\n`)])
+    );
+    const snapshot = makeSnapshot(1, files);
+    const client = new FakeReadDownClient([snapshot]);
+    client.delayBlobs = true;
+    const session = makeSession(client, stateRoot);
+    await session.latest();
+    assert.ok(client.maximumBlobConcurrency <= 8, "manifest warming observes the batch limit");
+    await rm(path.join(stateRoot, "cas"), { recursive: true, force: true });
+    client.maximumBlobConcurrency = 0;
+    await session.snapshotAt(snapshot.cutChange!);
+    assert.ok(client.maximumBlobConcurrency <= 8, "snapshot materialization observes the batch limit");
+    await session.close();
+  });
+});
+
 interface SnapshotFixture {
   readonly reservation: AuthoritySnapshotReservation;
   readonly manifest: AuthoritySnapshotManifest;
@@ -211,12 +442,20 @@ class FakeReadDownClient {
   readonly snapshots: ReadonlyArray<SnapshotFixture>;
   readonly blobRequests: Array<{ readonly snapshot: number; readonly digest: Sha256Digest }> = [];
   beginRequests = 0;
+  connectRequests = 0;
+  changesRequests = 0;
   renewRequests = 0;
   reconnectRequests = 0;
+  activeBlobRequests = 0;
+  maximumBlobConcurrency = 0;
   connectFailures = 0;
   advanceOnReconnect = true;
   failRenewal = false;
   corruptBlob = false;
+  delayBlobs = false;
+  renewalGate: Deferred<AuthoritySnapshotLease> | undefined;
+  changesGate: Deferred<AuthorityChangesAfterResult> | undefined;
+  blobGate: Deferred<void> | undefined;
   private snapshotIndex = 0;
   private readonly notificationListeners = new Set<(change: ReplicaChangeRecord) => void>();
   private readonly disconnectListeners = new Set<() => void>();
@@ -226,6 +465,7 @@ class FakeReadDownClient {
   }
 
   async connect(): Promise<void> {
+    this.connectRequests += 1;
     if (this.connectFailures > 0) {
       this.connectFailures -= 1;
       throw new Error("scripted connect failure");
@@ -234,6 +474,10 @@ class FakeReadDownClient {
 
   async reconnect(): Promise<void> {
     this.reconnectRequests += 1;
+    if (this.connectFailures > 0) {
+      this.connectFailures -= 1;
+      throw new Error("scripted reconnect failure");
+    }
     if (this.advanceOnReconnect && this.snapshotIndex < this.snapshots.length - 1) this.snapshotIndex += 1;
   }
 
@@ -252,12 +496,22 @@ class FakeReadDownClient {
 
   async getBlob(_streamToken: string, requested: Sha256Digest): Promise<Uint8Array> {
     this.blobRequests.push({ snapshot: this.snapshotIndex, digest: requested });
-    const bytes = this.current().blobs.get(requested);
-    if (!bytes) throw new Error(`missing scripted blob ${requested}`);
-    return this.corruptBlob ? Buffer.from("changed") : Buffer.from(bytes);
+    this.activeBlobRequests += 1;
+    this.maximumBlobConcurrency = Math.max(this.maximumBlobConcurrency, this.activeBlobRequests);
+    try {
+      if (this.blobGate) await this.blobGate.promise;
+      if (this.delayBlobs) await new Promise((resolve) => setTimeout(resolve, 1));
+      const bytes = this.current().blobs.get(requested);
+      if (!bytes) throw new Error(`missing scripted blob ${requested}`);
+      return this.corruptBlob ? Buffer.from("changed") : Buffer.from(bytes);
+    } finally {
+      this.activeBlobRequests -= 1;
+    }
   }
 
   async changesAfter(_streamToken: string, sinceRevision: number): Promise<AuthorityChangesAfterResult> {
+    this.changesRequests += 1;
+    if (this.changesGate) return this.changesGate.promise;
     const current = this.current();
     if (sinceRevision < current.reservation.cut.revision) {
       throw new AuthorityReadDownRequestError("RESYNC_REQUIRED", "CURSOR_PRECEDES_PINNED_CUT");
@@ -273,6 +527,7 @@ class FakeReadDownClient {
 
   async renewLease(): Promise<AuthoritySnapshotLease> {
     this.renewRequests += 1;
+    if (this.renewalGate) return this.renewalGate.promise;
     if (this.failRenewal) throw new AuthorityReadDownRequestError("SNAPSHOT_EXPIRED", "scripted renewal failure");
     const current = this.current().reservation.lease;
     return {
@@ -320,7 +575,8 @@ function makeSnapshot(
   revision: number,
   files: Readonly<Record<string, Buffer>>,
   expiresAt = Date.now() + 60_000,
-  renewableUntil = Date.now() + 3_600_000
+  renewableUntil = Date.now() + 3_600_000,
+  epoch = "7"
 ): SnapshotFixture {
   const entries = Object.entries(files).map(([pathName, bytes]) => ({
     path: pathName,
@@ -329,7 +585,7 @@ function makeSnapshot(
     tombstone: false as const
   })).sort((left, right) => left.path.localeCompare(right.path, "en"));
   const commitSha = revision.toString(16).padStart(40, "0");
-  const cutBase = { workspaceId, epoch: "7", revision, commitSha };
+  const cutBase = { workspaceId, epoch, revision, commitSha };
   const cut = {
     ...cutBase,
     manifestDigest: manifestDigest(cutBase, entries),

--- a/packages/daemon/test/remote-read-down-adapters.test.ts
+++ b/packages/daemon/test/remote-read-down-adapters.test.ts
@@ -1,0 +1,433 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import type { ReplicaChangeRecord } from "../../application/src/index.ts";
+import {
+  AuthorityReadDownRequestError,
+  RemoteCanonicalSnapshotSource,
+  RemoteReadDownSession,
+  RemoteReplicaChangeLog,
+  RemoteReplicaResyncRequiredError,
+  type PersistentSshAuthorityClient
+} from "../src/index.ts";
+import {
+  manifestDigest
+} from "../src/authority/replication-content-store.ts";
+import type {
+  AuthorityChangesAfterResult,
+  AuthoritySnapshotLease,
+  AuthoritySnapshotManifest,
+  AuthoritySnapshotReservation,
+  Sha256Digest
+} from "../src/authority/protocol.ts";
+
+const workspaceId = "workspace-remote-adapter";
+
+test("remote adapters are read-down only and materialize verified manifest blobs through durable CAS", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const first = Buffer.from("first\n");
+    const snapshot = makeSnapshot(1, { "notes.md": first });
+    const client = new FakeReadDownClient([snapshot]);
+    const session = makeSession(client, stateRoot);
+    const log = new RemoteReplicaChangeLog(session);
+    const source = new RemoteCanonicalSnapshotSource(session);
+
+    await assert.rejects(
+      log.append(snapshot.cutChange!),
+      /REMOTE_REPLICA_CHANGE_LOG_READ_DOWN_ONLY/u
+    );
+    assert.deepEqual(await log.latest(workspaceId), snapshot.cutChange);
+    const materialized = await source.snapshotAt(snapshot.cutChange!);
+    assert.equal(Buffer.from(materialized.entries[0]!.content).toString("utf8"), "first\n");
+    assert.equal(client.blobRequests.length, 1);
+
+    await source.snapshotAt(snapshot.cutChange!);
+    assert.equal(client.blobRequests.length, 1, "second snapshot read is served by durable CAS");
+    await log.close();
+
+    const reopenedClient = new FakeReadDownClient([snapshot]);
+    const reopened = makeSession(reopenedClient, stateRoot);
+    await reopened.latest();
+    assert.equal(reopenedClient.blobRequests.length, 0, "reconnect manifest diff reuses CAS across process sessions");
+    await reopened.close();
+  });
+});
+
+test("blob digest mismatch fails closed instead of entering reconnect retry", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const snapshot = makeSnapshot(1, { "notes.md": Buffer.from("trusted\n") });
+    const client = new FakeReadDownClient([snapshot]);
+    client.corruptBlob = true;
+    const session = makeSession(client, stateRoot);
+
+    await assert.rejects(session.latest(), /BLOB_DIGEST_MISMATCH/u);
+    assert.equal(client.beginRequests, 1, "integrity failure is terminal for this read, not an infinite reconnect");
+    await session.close();
+  });
+});
+
+test("stateful reconnect opens a new cut, CAS-deduplicates its manifest, and requires explicit cursor resync", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const shared = Buffer.from("shared\n");
+    const before = makeSnapshot(1, { "shared.md": shared });
+    const after = makeSnapshot(3, {
+      "shared.md": shared,
+      "new.md": Buffer.from("new\n")
+    });
+    const client = new FakeReadDownClient([before, after]);
+    const session = makeSession(client, stateRoot);
+
+    assert.deepEqual(await session.changesAfter(1), []);
+    assert.equal(client.blobRequests.length, 1);
+    client.disconnect();
+    await waitFor(() => client.beginRequests === 2);
+
+    await assert.rejects(
+      session.changesAfter(1),
+      (error: unknown) => error instanceof RemoteReplicaResyncRequiredError
+        && error.cutRevision === 3
+        && error.cutChange?.revision === 3
+    );
+    assert.deepEqual(
+      client.blobRequests.map((request) => request.digest).sort(),
+      [digest(Buffer.from("new\n")), digest(shared)].sort(),
+      "new cut pulls only the blob absent from local CAS"
+    );
+    assert.deepEqual(await session.changesAfter(3), []);
+    await session.close();
+  });
+});
+
+test("notifications carry metadata only, fill forward gaps, and deliver revisions once in order", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const base = makeSnapshot(0, {});
+    const change1 = makeChange(base, 1, { "one.md": Buffer.from("one\n") });
+    const change2 = makeChange(change1.snapshot, 2, { "two.md": Buffer.from("two\n") });
+    for (const [digestKey, bytes] of change2.snapshot.blobs) {
+      (base.blobs as Map<Sha256Digest, Buffer>).set(digestKey, bytes);
+    }
+    base.forwardChanges.push(change1.change, change2.change);
+    const client = new FakeReadDownClient([base]);
+    const session = makeSession(client, stateRoot);
+    const received: number[] = [];
+    const unsubscribe = session.subscribe((change) => received.push(change.revision));
+
+    await session.changesAfter(0);
+    client.notify(change2.change);
+    await waitFor(() => received.length === 2);
+
+    assert.deepEqual(received, [1, 2]);
+    assert.equal(client.blobRequests.length, 0, "notification and log catch-up do not pull file bodies");
+    const snapshot = await session.snapshotAt(change2.change);
+    assert.deepEqual(snapshot.entries.map((entry) => entry.path), ["one.md", "two.md"]);
+    assert.equal(client.blobRequests.length, 2, "content is fetched only through CAS snapshot reads");
+    unsubscribe();
+    await session.close();
+  });
+});
+
+test("reconnect backoff is capped and lease renewal or absolute lifetime transitions are stateful", async () => {
+  await withStateRoot(async (stateRoot) => {
+    let now = Date.parse("2026-07-23T04:00:00.000Z");
+    const first = makeSnapshot(0, {}, now + 1_000, now + 5_000);
+    const second = makeSnapshot(0, {}, now + 2_000, now + 10_000);
+    const client = new FakeReadDownClient([first, second]);
+    client.advanceOnReconnect = false;
+    client.connectFailures = 3;
+    const sleeps: number[] = [];
+    const scheduled: Array<() => void> = [];
+    const session = new RemoteReadDownSession({
+      client: client as unknown as PersistentSshAuthorityClient,
+      workspaceId,
+      stateRoot,
+      now: () => now,
+      sleep: async (milliseconds) => {
+        sleeps.push(milliseconds);
+      },
+      schedule: (_milliseconds, callback) => {
+        scheduled.push(callback);
+        return { dispose: () => undefined };
+      },
+      backoff: { initialMs: 2, maximumMs: 5, multiplier: 2 }
+    });
+
+    await session.latest();
+    assert.deepEqual(sleeps, [2, 4, 5]);
+    client.advanceOnReconnect = true;
+    scheduled.shift()!();
+    await waitFor(() => client.renewRequests === 1);
+    assert.ok(scheduled.length > 0, "successful renewal schedules the next keepalive");
+
+    now = Date.parse(first.reservation.lease.renewableUntil);
+    scheduled.at(-1)!();
+    await waitFor(() => client.beginRequests === 2);
+    assert.equal(client.reconnectRequests > 0, true, "absolute lease lifetime creates a new connection and snapshot");
+    await session.close();
+  });
+});
+
+test("lease renewal failure reconnects and begins a new snapshot instead of extending stale state", async () => {
+  await withStateRoot(async (stateRoot) => {
+    const now = Date.parse("2026-07-23T04:00:00.000Z");
+    const first = makeSnapshot(1, { "one.md": Buffer.from("one\n") }, now + 1_000, now + 5_000);
+    const second = makeSnapshot(2, { "two.md": Buffer.from("two\n") }, now + 2_000, now + 10_000);
+    const client = new FakeReadDownClient([first, second]);
+    client.failRenewal = true;
+    const scheduled: Array<() => void> = [];
+    const session = new RemoteReadDownSession({
+      client: client as unknown as PersistentSshAuthorityClient,
+      workspaceId,
+      stateRoot,
+      now: () => now,
+      schedule: (_milliseconds, callback) => {
+        scheduled.push(callback);
+        return { dispose: () => undefined };
+      },
+      backoff: { initialMs: 0, maximumMs: 0, multiplier: 1 }
+    });
+
+    await session.latest();
+    scheduled.shift()!();
+    await waitFor(() => client.beginRequests === 2);
+    assert.equal(client.renewRequests, 1);
+    assert.equal(client.reconnectRequests, 1);
+    await session.close();
+  });
+});
+
+interface SnapshotFixture {
+  readonly reservation: AuthoritySnapshotReservation;
+  readonly manifest: AuthoritySnapshotManifest;
+  readonly cutChange: ReplicaChangeRecord | null;
+  readonly blobs: ReadonlyMap<Sha256Digest, Buffer>;
+  readonly forwardChanges: ReplicaChangeRecord[];
+}
+
+class FakeReadDownClient {
+  readonly snapshots: ReadonlyArray<SnapshotFixture>;
+  readonly blobRequests: Array<{ readonly snapshot: number; readonly digest: Sha256Digest }> = [];
+  beginRequests = 0;
+  renewRequests = 0;
+  reconnectRequests = 0;
+  connectFailures = 0;
+  advanceOnReconnect = true;
+  failRenewal = false;
+  corruptBlob = false;
+  private snapshotIndex = 0;
+  private readonly notificationListeners = new Set<(change: ReplicaChangeRecord) => void>();
+  private readonly disconnectListeners = new Set<() => void>();
+
+  constructor(snapshots: ReadonlyArray<SnapshotFixture>) {
+    this.snapshots = snapshots;
+  }
+
+  async connect(): Promise<void> {
+    if (this.connectFailures > 0) {
+      this.connectFailures -= 1;
+      throw new Error("scripted connect failure");
+    }
+  }
+
+  async reconnect(): Promise<void> {
+    this.reconnectRequests += 1;
+    if (this.advanceOnReconnect && this.snapshotIndex < this.snapshots.length - 1) this.snapshotIndex += 1;
+  }
+
+  async beginSnapshotAndSubscribe(): Promise<AuthoritySnapshotReservation> {
+    this.beginRequests += 1;
+    return structuredClone(this.current().reservation);
+  }
+
+  async getSnapshotManifest(): Promise<AuthoritySnapshotManifest> {
+    return structuredClone(this.current().manifest);
+  }
+
+  async getCutChange(): Promise<ReplicaChangeRecord | null> {
+    return structuredClone(this.current().cutChange);
+  }
+
+  async getBlob(_streamToken: string, requested: Sha256Digest): Promise<Uint8Array> {
+    this.blobRequests.push({ snapshot: this.snapshotIndex, digest: requested });
+    const bytes = this.current().blobs.get(requested);
+    if (!bytes) throw new Error(`missing scripted blob ${requested}`);
+    return this.corruptBlob ? Buffer.from("changed") : Buffer.from(bytes);
+  }
+
+  async changesAfter(_streamToken: string, sinceRevision: number): Promise<AuthorityChangesAfterResult> {
+    const current = this.current();
+    if (sinceRevision < current.reservation.cut.revision) {
+      throw new AuthorityReadDownRequestError("RESYNC_REQUIRED", "CURSOR_PRECEDES_PINNED_CUT");
+    }
+    const changes = current.forwardChanges.filter((change) => change.revision > sinceRevision);
+    return {
+      schema: "authority-changes-after/v1",
+      sinceRevision,
+      throughRevision: changes.at(-1)?.revision ?? sinceRevision,
+      changes: structuredClone(changes)
+    };
+  }
+
+  async renewLease(): Promise<AuthoritySnapshotLease> {
+    this.renewRequests += 1;
+    if (this.failRenewal) throw new AuthorityReadDownRequestError("SNAPSHOT_EXPIRED", "scripted renewal failure");
+    const current = this.current().reservation.lease;
+    return {
+      ...current,
+      expiresAt: new Date(Date.parse(current.expiresAt) + 1_000).toISOString()
+    };
+  }
+
+  onNotification(listener: (change: ReplicaChangeRecord) => void): () => void {
+    this.notificationListeners.add(listener);
+    return () => this.notificationListeners.delete(listener);
+  }
+
+  onDisconnect(listener: () => void): () => void {
+    this.disconnectListeners.add(listener);
+    return () => this.disconnectListeners.delete(listener);
+  }
+
+  async close(): Promise<void> {}
+
+  notify(change: ReplicaChangeRecord): void {
+    for (const listener of this.notificationListeners) listener(change);
+  }
+
+  disconnect(): void {
+    if (this.snapshotIndex < this.snapshots.length - 1) this.snapshotIndex += 1;
+    for (const listener of this.disconnectListeners) listener();
+  }
+
+  private current(): SnapshotFixture {
+    return this.snapshots[this.snapshotIndex]!;
+  }
+}
+
+function makeSession(client: FakeReadDownClient, stateRoot: string): RemoteReadDownSession {
+  return new RemoteReadDownSession({
+    client: client as unknown as PersistentSshAuthorityClient,
+    workspaceId,
+    stateRoot,
+    backoff: { initialMs: 0, maximumMs: 0, multiplier: 1 }
+  });
+}
+
+function makeSnapshot(
+  revision: number,
+  files: Readonly<Record<string, Buffer>>,
+  expiresAt = Date.now() + 60_000,
+  renewableUntil = Date.now() + 3_600_000
+): SnapshotFixture {
+  const entries = Object.entries(files).map(([pathName, bytes]) => ({
+    path: pathName,
+    blobDigest: digest(bytes),
+    mode: "100644" as const,
+    tombstone: false as const
+  })).sort((left, right) => left.path.localeCompare(right.path, "en"));
+  const commitSha = revision.toString(16).padStart(40, "0");
+  const cutBase = { workspaceId, epoch: "7", revision, commitSha };
+  const cut = {
+    ...cutBase,
+    manifestDigest: manifestDigest(cutBase, entries),
+    provenanceDigest: digest(Buffer.from(`provenance-${revision}`))
+  };
+  const reservation: AuthoritySnapshotReservation = {
+    schema: "authority-snapshot-reservation/v1",
+    cut,
+    lease: {
+      leaseId: `lease-${revision}`,
+      expiresAt: new Date(expiresAt).toISOString(),
+      renewableUntil: new Date(renewableUntil).toISOString(),
+      minRetainedRevision: revision + 1,
+      pinnedBlobSetDigest: digest(Buffer.from(`set-${revision}`))
+    },
+    stream: { streamToken: `stream-${revision}`, fromRevision: revision + 1 }
+  };
+  const manifest: AuthoritySnapshotManifest = {
+    schema: "authority-snapshot-manifest/v1",
+    cut,
+    entries
+  };
+  const cutChange = revision === 0 ? null : recordFor(revision, commitSha, cut.manifestDigest, entries.length, []);
+  return {
+    reservation,
+    manifest,
+    cutChange,
+    blobs: new Map(Object.values(files).map((bytes) => [digest(bytes), bytes])),
+    forwardChanges: []
+  };
+}
+
+function makeChange(
+  previous: SnapshotFixture,
+  revision: number,
+  additions: Readonly<Record<string, Buffer>>
+): { readonly snapshot: SnapshotFixture; readonly change: ReplicaChangeRecord } {
+  const files = Object.fromEntries(previous.manifest.entries.map((entry) => [
+    entry.path,
+    previous.blobs.get(entry.blobDigest)!
+  ]));
+  const snapshot = makeSnapshot(revision, { ...files, ...additions });
+  const paths = Object.entries(additions).map(([pathName, bytes]) => ({
+    path: pathName,
+    blobDigest: digest(bytes),
+    mode: "100644" as const,
+    tombstone: false as const
+  }));
+  const change = recordFor(
+    revision,
+    snapshot.reservation.cut.commitSha,
+    snapshot.reservation.cut.manifestDigest,
+    snapshot.manifest.entries.length,
+    paths
+  );
+  for (const [key, value] of snapshot.blobs) (previous.blobs as Map<Sha256Digest, Buffer>).set(key, value);
+  return { snapshot, change };
+}
+
+function recordFor(
+  revision: number,
+  commitSha: string,
+  manifest: Sha256Digest,
+  entryCount: number,
+  paths: ReplicaChangeRecord["paths"]
+): ReplicaChangeRecord {
+  return {
+    schema: "replica-change/v2",
+    workspaceId,
+    revision,
+    opId: `op-${revision}`,
+    semanticDigest: `semantic-${revision}`,
+    operations: [{ opId: `op-${revision}`, semanticDigest: `semantic-${revision}` }],
+    commitSha,
+    previousCommit: revision > 1 ? (revision - 1).toString(16).padStart(40, "0") : null,
+    changedAt: "2026-07-23T04:00:00.000Z",
+    manifest: { digest: manifest, entryCount },
+    paths
+  };
+}
+
+function digest(bytes: Uint8Array): Sha256Digest {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+async function withStateRoot(body: (stateRoot: string) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(path.join(tmpdir(), "ha-remote-read-down-"));
+  try {
+    await body(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("timed out waiting for remote read-down condition");
+}

--- a/packages/daemon/test/remote-read-down-test-support.ts
+++ b/packages/daemon/test/remote-read-down-test-support.ts
@@ -1,0 +1,15 @@
+export interface Deferred<Value> {
+  readonly promise: Promise<Value>;
+  readonly resolve: (value: Value) => void;
+  readonly reject: (error: Error) => void;
+}
+
+export function deferred<Value>(): Deferred<Value> {
+  let resolve!: (value: Value) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<Value>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}


### PR DESCRIPTION
# English

## Summary

Consumes the RD-A/RD-A.1 frozen server-side read-down data plane into the broker's two port implementations, so a per-machine broker can materialize the central ledger as local files (read-down). Adds `RemoteReplicaChangeLog` (implements `ReplicaChangeLog`, `append` fail-closed), `RemoteCanonicalSnapshotSource` (implements `CanonicalSnapshotSource`, manifest+blob CAS with digest verification), and a `RemoteReadDownSession` that runs on `PersistentSshAuthorityClient` with production-grade **state-based** reconnect, bounded backoff, and lease renewal. No broker runtime assembly (RD-C), no CLI dual-root (RD-D).

## What Changed

- **Transport (`PersistentSshAuthorityClient`)**: adds the six frozen read-down request methods — `beginSnapshotAndSubscribe` / `getSnapshotManifest` / `getBlob` / `changesAfter` + RD-A.1's `renewLease` / `getCutChange` — plus `onDisconnect` and an `AuthorityReadDownRequestError` (typed `code`). Reuses the existing request/generation/pending machinery.
- **`RemoteReplicaChangeLog`**: `latest` / `getByOperation` / `changesAfter` / `subscribe` delegate to the session; `append` fail-closes with `REMOTE_REPLICA_CHANGE_LOG_READ_DOWN_ONLY` (read-down clients never write).
- **`RemoteCanonicalSnapshotSource`**: `snapshotAt(change)` assembles a `CanonicalSnapshot` from the manifest + per-entry blob CAS fetch, with sha256 digest verification.
- **`RemoteReadDownSession` (the core)**: persistent connection manager. **State-based reconnect** — on disconnect it re-`begin_snapshot_and_subscribe` to a new cut S′, fetches the real cut record via `get_cut_change`, diffs the manifest against locally-materialized state, and CAS-deduplicates unchanged blobs; below-cut cursors fail closed (`CURSOR_PRECEDES_PINNED_CUT` / `CURSOR_PRECEDES_RECONNECTED_CUT`) rather than backfilling from a log. Lease keepalive via `renewLease` (half-TTL schedule, bounded by the absolute `renewableUntil`; reaching the limit → RESYNC). Forward stream delivered strictly in-order (`deliveredRevision + 1`), notifications carry metadata only (content pulled through CAS). Integrity errors (digest/manifest mismatch) fail closed instead of being masked by reconnect retries.

## Task And Scope

- Task: `task_01KY6YPRFAWPRPJD943N13NHZK` (RD-B), parent `task_01KXBGXDWQ0AW1CBAEHA8D3PNP` (transparent-workspace implementation root, ADR-0029).
- File surface: `packages/daemon/src/transport/**`, `packages/daemon/src/broker/**` (two new adapters + one session manager + barrel exports) and their tests only. No wire-contract change, no CLI, no authority server, no lifecycle/runtime assembly (that is RD-C).

## Version Impact

Additive. New broker exports and transport methods; no existing wire frame, type, or public API changed. Consumes the already-shipped `replica-change/v2` + read-down frames (incl. RD-A.1's `renew_lease` / `get_cut_change`) without modifying them.

## Governance Declaration

- Direction accepted by `dec_01KXB6ZB1EAPEZN04T3KR6T2YQ` (transparent workspace) + read-down subdecision `dec_01KXB6ZS4EBW8EPWR7132CTBJY`. No new architecture decision required — this implements an accepted design.
- Scope guardrails `dec_01KY6FT6YM5RM2A083Y45TH6ND` honored: read-down only (`append` fail-closed); notifications carry no payload (content via CAS); no rsync/scp/git-fetch substitution for snapshot+cursor+CAS; not writable; not GA.

## Verification

- `npm run check:local` green (34 manifest gates); `npm run test:integration` exit 0 (1224 tests, 1220 pass, 0 fail, 4 skipped) — re-run after the adversarial fix round.
- Negative/architectural tests: read-down-only + CAS-verified materialization; blob-digest-mismatch fails closed (no reconnect retry); state-based reconnect opens a new cut + CAS-dedups + inherits cursor / requires explicit resync; notifications metadata-only + forward-gap fill + in-order-once; backoff capped + stateful lease-renewal/absolute-lifetime; lease-renewal failure reconnects to a new snapshot; plus the fix round's concurrency-race, terminal-corrupt-CAS, bounded-cache (50k), and blob-dedup/concurrency tests, and a transport test asserting all six frozen read-down frames are consumed.
- `check-cli-daemon-parity` is CI-only/hermetic; verified in this PR's CI, not locally. `fast-contract` (advisory) went red on the pre-fix commit for the F6 close-race and is green post-fix.
- Rebased onto latest `main` (`c20120a2`); `tsc -b` clean post-rebase.

## Review Evidence

- CEO semantic + architecture verification (non-delegable): the diff touches only the authorized daemon transport/broker surface; the wire contract, CLI, authority server, and `replica-broker.ts` (RD-C wiring) are untouched. Every RD architecture invariant was ground-truthed in code: state-based reconnect (not below-cut backfill), manifest-diff + CAS dedup, blob-digest verification fail-closed, `renewLease` keepalive bounded by the absolute lifetime, metadata-only notifications, in-order forward delivery, bounded backoff, and `append` fail-closed.
- **Black-box adversarial review (Codex) found 9 production-reachable defects (7 P1 + 2 P2), all CEO-ground-truthed as real and fixed in one bounded round** (fix commit `8307c8b4`): (F1) two disconnect paths racing the transport generation could permanently wedge recovery → serialized single-flight recovery keyed by lifecycle generation; (F2) post-await state writes overwriting a newer snapshot → compare-and-set generation checks + compare-and-clear invalidation; (F3) reconnect resetting `adopted` silently stalled push subscriptions → reconnect inherits the delivered cursor or signals explicit resync; (F5) cross-epoch same-revision content mislabeled → full identity/epoch verification, epoch change forces resync; (F6) `close()` not joining background work caused post-close CAS writes (the `fast-contract`/ENOTEMPTY red) → `close()` cancels via interruptible sleep and awaits full quiescence; (F7) local CAS corruption treated as transient → terminal sticky integrity failure; (F8) unbounded change cache + `Math.max(...spread)` → cursor-pruned bounded cache, tracked-max; (F9) duplicate blob fetch/fsync + unbounded fan-out → digest single-flight + bounded batches. F4 (broker persisting the RESYNC signal) was correctly scoped to RD-C — the adapter now carries the full cut/cutChange in its resync exception and documents the consumer contract, without touching `replica-broker.ts`. The lifecycle was decomposed into `remote-blob-reader.ts` / `remote-read-down-content.ts` / `remote-read-down-contract.ts`.

## Residual Risk

- A single cut `ReplicaChangeRecord` larger than one 1 MiB frame is not chunked (a pre-existing limitation shared with the manifest/cut frames); deferred, same as RD-A.1.
- Broker runtime composition/lifecycle assembly (RD-C) and CLI dual-root (RD-D) are out of scope here; the adapters are exported but not yet wired into a running broker.

## References

- Decisions: `dec_01KXB6ZB1EAPEZN04T3KR6T2YQ`, `dec_01KXB6ZS4EBW8EPWR7132CTBJY`, `dec_01KY6FT6YM5RM2A083Y45TH6ND`
- ADR-0029 transparent workspace; RD-A `task_01KY6GFT78G6DYYYD2K73PK8P5` (done), RD-A.1 `task_01KY6ZP85EF1R901SGJDPQAGGW` (done, PR #1060)
- Parent `task_01KXBGXDWQ0AW1CBAEHA8D3PNP`; unblocks RD-C

---

# 中文

## 概要

把 RD-A/RD-A.1 冻结的服务端 read-down 数据面消费成 broker 的两个 port 实现,使每机 broker 能把中心账本物化成本地文件(read-down)。新增 `RemoteReplicaChangeLog`(implements `ReplicaChangeLog`,`append` fail-closed)、`RemoteCanonicalSnapshotSource`(implements `CanonicalSnapshotSource`,manifest+blob CAS+digest 校验),以及跑在 `PersistentSshAuthorityClient` 之上、具备生产级**状态式** reconnect / 有界 backoff / 续租保活的 `RemoteReadDownSession`。不做 broker runtime 装配(RD-C)、不做 CLI 双根(RD-D)。

## 改动内容

- **transport(`PersistentSshAuthorityClient`)**:补齐 6 个冻结的 read-down 请求方法——`beginSnapshotAndSubscribe`/`getSnapshotManifest`/`getBlob`/`changesAfter` + RD-A.1 的 `renewLease`/`getCutChange`——加 `onDisconnect` 与带 typed `code` 的 `AuthorityReadDownRequestError`。复用既有 request/generation/pending 机制。
- **`RemoteReplicaChangeLog`**:`latest`/`getByOperation`/`changesAfter`/`subscribe` 委托 session;`append` 以 `REMOTE_REPLICA_CHANGE_LOG_READ_DOWN_ONLY` fail-close(read-down 客户端永不写)。
- **`RemoteCanonicalSnapshotSource`**:`snapshotAt(change)` 以 manifest + 逐 entry blob CAS 拉取组装 `CanonicalSnapshot`,带 sha256 digest 校验。
- **`RemoteReadDownSession`(核心)**:持久连接管理器。**状态式 reconnect**——断连后重新 `begin_snapshot_and_subscribe` 到新 cut S′,经 `get_cut_change` 取真实 cut record,对本地已物化态做 manifest diff,CAS 去重未变 blob;below-cut 游标一律 fail-close(`CURSOR_PRECEDES_PINNED_CUT`/`CURSOR_PRECEDES_RECONNECTED_CUT`),不从 log 补拉。`renewLease` 保活(半 TTL 调度,受绝对 `renewableUntil` 上界;到限即 RESYNC)。前向流严格有序交付(`deliveredRevision + 1`),通知只带元数据(内容经 CAS 拉)。integrity 错误(digest/manifest 不符)fail-close,不被 reconnect 重试掩盖。

## 任务与范围

- 任务:`task_01KY6YPRFAWPRPJD943N13NHZK`(RD-B),父 `task_01KXBGXDWQ0AW1CBAEHA8D3PNP`(透明工作区实现 root,ADR-0029)。
- 文件面:仅 `packages/daemon/src/transport/**`、`packages/daemon/src/broker/**`(两个新 adapter + 一个 session 管理器 + barrel export)及其测试。不改 wire 契约、不碰 CLI、不碰 authority 服务端、不做 lifecycle/runtime 装配(那是 RD-C)。

## 版本影响

加性。新增 broker export 与 transport 方法;未改任何既有 wire 帧、类型或公开 API。消费已发布的 `replica-change/v2` + read-down 帧(含 RD-A.1 的 `renew_lease`/`get_cut_change`),只消费不改。

## 治理声明

- 方向由 `dec_01KXB6ZB1EAPEZN04T3KR6T2YQ`(透明工作区)+ read-down 子决策 `dec_01KXB6ZS4EBW8EPWR7132CTBJY` 接受。**无需新架构裁决**——本 PR 实现已接受设计。
- 遵守 scope 护栏 `dec_01KY6FT6YM5RM2A083Y45TH6ND`:read-down only(`append` fail-closed);通知不带正文(内容经 CAS);不以 rsync/scp/git-fetch 替代 snapshot+cursor+CAS;不 writable;不 GA。

## 验证

- `npm run check:local` 绿(34 manifest gates);`npm run test:integration` exit 0(1224 测试,1220 pass,0 fail,4 skipped)——对抗修复轮后复跑。
- 负向/架构测试:read-down-only + CAS 校验物化;blob-digest 不符 fail-close(不进 reconnect 重试);状态式 reconnect 开新 cut + CAS 去重 + 继承游标/强制 resync;通知仅元数据 + 前向补 gap + 有序一次;backoff 有上限 + 状态式续租/绝对寿命;续租失败 reconnect 到新 snapshot;另加修复轮的并发竞争、坏 CAS terminal、有界缓存(50k)、blob 去重/并发测试,以及 transport 断言 6 个冻结 read-down 帧全消费。
- `check-cli-daemon-parity` CI-only/hermetic,本 PR 的 CI 验,非本地。`fast-contract`(咨询门)在修复前 commit 因 F6 close 竞争红,修复后绿。
- 已 rebase 到最新 `main`(`c20120a2`);rebase 后 `tsc -b` 干净。

## 审查证据

- CEO 语义+架构验收(不可下放):diff 只碰授权的 daemon transport/broker 面;wire 契约、CLI、authority 服务端、`replica-broker.ts`(RD-C 装配)零改动。每条 RD 架构不变量都在代码里 ground-truth:状态式 reconnect(非 below-cut 补拉)、manifest-diff + CAS 去重、blob-digest 校验 fail-close、`renewLease` 保活受绝对寿命上界、通知仅元数据、前向有序交付、有界 backoff、`append` fail-close。
- **黑盒对抗复核(Codex)抓到 9 条生产可达缺陷(7 P1 + 2 P2),CEO 全部 ground-truth 属实并一轮有界修掉**(fix commit `8307c8b4`):(F1)两条断连路竞争 transport generation 可永久挂死恢复 → 按 lifecycle generation 串行 single-flight 恢复;(F2)await 后写覆盖更新 snapshot → compare-and-set 代际校验 + compare-and-clear 失效;(F3)reconnect 重置 `adopted` 静默停摆 push 订阅 → 重连继承 delivered cursor 或显式 resync;(F5)跨 epoch 同 revision 内容误标 → 完整 identity/epoch 校验、epoch 变必 resync;(F6)`close()` 不 join 后台致 close 后 CAS 写(`fast-contract`/ENOTEMPTY 红)→ close 用可取消 sleep + 等全静默;(F7)本地 CAS 损坏被当瞬态 → terminal sticky integrity failure;(F8)无界缓存 + `Math.max(...spread)` → 按游标 prune 有界缓存 + tracked-max;(F9)重复 blob 拉取/fsync + 无界 fan-out → digest single-flight + 有界批。F4(broker 持久化 RESYNC 信号)正确划归 RD-C——adapter 现让 resync 异常携带完整 cut/cutChange 并写清消费方契约,不碰 `replica-broker.ts`。生命周期已分解为 `remote-blob-reader.ts`/`remote-read-down-content.ts`/`remote-read-down-contract.ts`。

## 残余风险

- 单条 >1 MiB 帧的 cut `ReplicaChangeRecord` 未分块(与 manifest/cut 帧共有的既存限制),DEFER,同 RD-A.1。
- broker runtime 装配(RD-C)与 CLI 双根(RD-D)不在本 PR 范围;adapter 已导出但尚未接入运行中的 broker。

## 关联材料

- 决策:`dec_01KXB6ZB1EAPEZN04T3KR6T2YQ`、`dec_01KXB6ZS4EBW8EPWR7132CTBJY`、`dec_01KY6FT6YM5RM2A083Y45TH6ND`
- ADR-0029 透明工作区;RD-A `task_01KY6GFT78G6DYYYD2K73PK8P5`(done)、RD-A.1 `task_01KY6ZP85EF1R901SGJDPQAGGW`(done,PR #1060)
- 父 `task_01KXBGXDWQ0AW1CBAEHA8D3PNP`;解除 RD-C
