### PR TITLE
feat(daemon): RD-C assemble remote broker runtime (RemoteBrokerRuntime + synchronize resync consumption)

### DIFF
--- a/packages/daemon/src/broker/broker-errors.ts
+++ b/packages/daemon/src/broker/broker-errors.ts
@@ -1,0 +1,18 @@
+export class BrokerSubmitPreflightError extends Error {
+  readonly path: string;
+  readonly status: string;
+
+  constructor(pathName: string, status: string, message: string) {
+    super(`${message}: ${pathName} (${status})`);
+    this.name = "BrokerSubmitPreflightError";
+    this.path = pathName;
+    this.status = status;
+  }
+}
+
+export class BrokerReplicaIntegrityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BrokerReplicaIntegrityError";
+  }
+}

--- a/packages/daemon/src/broker/broker-operation-latch.ts
+++ b/packages/daemon/src/broker/broker-operation-latch.ts
@@ -1,0 +1,22 @@
+export class BrokerOperationLatch {
+  private tail: Promise<void> = Promise.resolve();
+  private pendingCount = 0;
+
+  run<Value>(operation: () => Promise<Value>): Promise<Value> {
+    this.pendingCount += 1;
+    const result = this.tail.then(operation);
+    this.tail = result.then(
+      () => {
+        this.pendingCount -= 1;
+      },
+      () => {
+        this.pendingCount -= 1;
+      }
+    );
+    return result;
+  }
+
+  get pending(): boolean {
+    return this.pendingCount > 0;
+  }
+}

--- a/packages/daemon/src/broker/index.ts
+++ b/packages/daemon/src/broker/index.ts
@@ -1,5 +1,9 @@
 export { BrokerCasStore } from "./cas-store.ts";
 export {
+  BrokerReplicaIntegrityError,
+  BrokerSubmitPreflightError
+} from "./broker-errors.ts";
+export {
   LocalConflictStore,
   type ConflictReason,
   type LocalConflictEvent,
@@ -19,10 +23,11 @@ export {
   tombstoneFingerprint
 } from "./fingerprint.ts";
 export { CrashSafeNativeApplier, type NativeApplyResult } from "./native-applier.ts";
-export { BrokerSubmitPreflightError, ReplicaBroker } from "./replica-broker.ts";
+export { ReplicaBroker } from "./replica-broker.ts";
 export { RemoteCanonicalSnapshotSource } from "./remote-canonical-snapshot-source.ts";
 export {
   RemoteBrokerRuntime,
+  type RemoteBrokerRuntimeHealth,
   type RemoteBrokerRuntimeOptions
 } from "./remote-broker-runtime.ts";
 export {

--- a/packages/daemon/src/broker/index.ts
+++ b/packages/daemon/src/broker/index.ts
@@ -22,6 +22,10 @@ export { CrashSafeNativeApplier, type NativeApplyResult } from "./native-applier
 export { BrokerSubmitPreflightError, ReplicaBroker } from "./replica-broker.ts";
 export { RemoteCanonicalSnapshotSource } from "./remote-canonical-snapshot-source.ts";
 export {
+  RemoteBrokerRuntime,
+  type RemoteBrokerRuntimeOptions
+} from "./remote-broker-runtime.ts";
+export {
   RemoteReadDownSession,
   RemoteReplicaResyncRequiredError,
   type RemoteReadDownBackoff,
@@ -40,6 +44,7 @@ export type {
   BrokerOptions,
   BrokerPathState,
   BrokerPathStatus,
+  BrokerResyncTarget,
   BrokerVersion,
   CanonicalSnapshot,
   CanonicalSnapshotEntry,

--- a/packages/daemon/src/broker/remote-blob-reader.ts
+++ b/packages/daemon/src/broker/remote-blob-reader.ts
@@ -2,6 +2,11 @@ import type { AuthoritySnapshotManifestEntry, AuthoritySnapshotReservation } fro
 import type { PersistentSshAuthorityClient } from "../transport/persistent-ssh-authority-client.ts";
 import type { BrokerCasStore } from "./cas-store.ts";
 import { isMissing } from "./errno.ts";
+import {
+  asRemoteReadDownError,
+  classifyRemoteReadDownFailure,
+  RemoteReadDownIntegrityError
+} from "./remote-read-down-failure.ts";
 
 export class RemoteBlobReader {
   private readonly flights = new Map<string, Promise<Buffer>>();
@@ -45,13 +50,23 @@ export class RemoteBlobReader {
     try {
       return await this.cas.get(digest);
     } catch (error) {
-      if (!isMissing(error)) throw error;
+      if (!isMissing(error)) {
+        throw new RemoteReadDownIntegrityError(asRemoteReadDownError(error).message);
+      }
     }
     this.assertOpen();
-    const bytes = await this.client.getBlob(reservation.stream.streamToken, digest);
+    let bytes: Uint8Array;
+    try {
+      bytes = await this.client.getBlob(reservation.stream.streamToken, digest);
+    } catch (error) {
+      if (classifyRemoteReadDownFailure(error) !== "TERMINAL") throw error;
+      throw new RemoteReadDownIntegrityError(asRemoteReadDownError(error).message);
+    }
     this.assertOpen();
     const actual = await this.cas.put(bytes);
-    if (actual !== digest) throw new Error(`BLOB_DIGEST_MISMATCH:${digest}:${actual}`);
+    if (actual !== digest) {
+      throw new RemoteReadDownIntegrityError(`BLOB_DIGEST_MISMATCH:${digest}:${actual}`);
+    }
     return Buffer.from(bytes);
   }
 

--- a/packages/daemon/src/broker/remote-broker-runtime-health.ts
+++ b/packages/daemon/src/broker/remote-broker-runtime-health.ts
@@ -1,0 +1,31 @@
+import type { RemoteReadDownSessionHealth } from "./remote-read-down-contract.ts";
+import type { BrokerDurableState } from "./types.ts";
+
+export type RemoteBrokerRuntimeLifecycle = "IDLE" | "STARTING" | "ACTIVE" | "STOPPED";
+
+export type RemoteBrokerRuntimeHealth =
+  | { readonly status: "IDLE" | "STARTING" | "RECOVERING" | "RUNNING" | "STOPPED" }
+  | { readonly status: "TERMINAL"; readonly failure: Error };
+
+export function deriveRemoteBrokerRuntimeHealth(input: {
+  readonly lifecycle: RemoteBrokerRuntimeLifecycle;
+  readonly durable: BrokerDurableState | undefined;
+  readonly session: RemoteReadDownSessionHealth | undefined;
+  readonly hasPendingWork: boolean;
+  readonly failure: Error | undefined;
+}): RemoteBrokerRuntimeHealth {
+  if (input.failure) return { status: "TERMINAL", failure: input.failure };
+  if (input.session?.status === "TERMINAL") {
+    return { status: "TERMINAL", failure: input.session.failure };
+  }
+  if (input.lifecycle === "STOPPED") return { status: "STOPPED" };
+  if (input.lifecycle === "IDLE") return { status: "IDLE" };
+  if (input.lifecycle === "STARTING") return { status: "STARTING" };
+  if (!input.durable
+    || input.durable.mode !== "READY"
+    || input.session?.status !== "READY"
+    || input.hasPendingWork) {
+    return { status: "RECOVERING" };
+  }
+  return { status: "RUNNING" };
+}

--- a/packages/daemon/src/broker/remote-broker-runtime.ts
+++ b/packages/daemon/src/broker/remote-broker-runtime.ts
@@ -1,64 +1,126 @@
-import type { ReplicaChangeRecord } from "@harness-anything/application";
+import type {
+  ReplicaChangeLog,
+  ReplicaChangeRecord
+} from "@harness-anything/application";
+import { AuthorityTransportDisconnectedError } from "../transport/persistent-ssh-authority-client.ts";
 import { RemoteCanonicalSnapshotSource } from "./remote-canonical-snapshot-source.ts";
 import {
   RemoteReadDownSession,
+  RemoteReplicaResyncRequiredError,
   type RemoteReadDownSessionOptions
 } from "./remote-read-down-session.ts";
 import { RemoteReplicaChangeLog } from "./remote-replica-change-log.ts";
 import { ReplicaBroker } from "./replica-broker.ts";
-import type { BrokerDurableState, BrokerOptions } from "./types.ts";
+import type {
+  BrokerDurableState,
+  BrokerOptions,
+  CanonicalSnapshotSource
+} from "./types.ts";
 
 export interface RemoteBrokerRuntimeOptions
-  extends Omit<BrokerOptions, "replicaChangeLog" | "snapshotSource"> {
-  readonly session: Omit<RemoteReadDownSessionOptions, "workspaceId" | "stateRoot">;
+  extends Omit<BrokerOptions, "replicaChangeLog" | "snapshotSource" | "replicaGapPolicy"> {
+  readonly session: Omit<
+    RemoteReadDownSessionOptions,
+    "workspaceId" | "stateRoot" | "expectedResume"
+  >;
 }
 
+export type RemoteBrokerRuntimeHealth =
+  | { readonly status: "IDLE" | "STARTING" | "RUNNING" | "STOPPED" }
+  | { readonly status: "TERMINAL"; readonly failure: Error };
+
 export class RemoteBrokerRuntime {
-  readonly session: RemoteReadDownSession;
-  readonly replicaChangeLog: RemoteReplicaChangeLog;
-  readonly snapshotSource: RemoteCanonicalSnapshotSource;
   readonly broker: ReplicaBroker;
-  private readonly onDiagnostic: ((text: string) => void) | undefined;
+  private readonly options: RemoteBrokerRuntimeOptions;
+  private activeSession: RemoteReadDownSession | undefined;
+  private activeReplicaChangeLog: RemoteReplicaChangeLog | undefined;
+  private activeSnapshotSource: RemoteCanonicalSnapshotSource | undefined;
   private unsubscribe: (() => void) | undefined;
-  private synchronizationTail: Promise<void> = Promise.resolve();
+  private pendingNotification: ReplicaChangeRecord | undefined;
+  private notificationTask: Promise<void> | undefined;
   private startTask: Promise<BrokerDurableState> | undefined;
   private stopTask: Promise<void> | undefined;
+  private phase: "IDLE" | "STARTING" | "RUNNING" | "TERMINAL" | "STOPPED" = "IDLE";
+  private terminalFailure: Error | undefined;
   private stopped = false;
 
   constructor(options: RemoteBrokerRuntimeOptions) {
-    const { session, ...brokerOptions } = options;
-    this.onDiagnostic = session.onDiagnostic;
-    this.session = new RemoteReadDownSession({
-      ...session,
-      workspaceId: options.workspaceId,
-      stateRoot: options.stateRoot
-    });
-    this.replicaChangeLog = new RemoteReplicaChangeLog(this.session);
-    this.snapshotSource = new RemoteCanonicalSnapshotSource(this.session);
+    this.options = options;
+    const { session: _session, ...brokerOptions } = options;
+    const replicaChangeLog: ReplicaChangeLog = {
+      append: (record) => this.replicaChangeLog.append(record),
+      latest: (workspaceId) => this.replicaChangeLog.latest(workspaceId),
+      getByOperation: (workspaceId, opId) => this.replicaChangeLog.getByOperation(workspaceId, opId),
+      changesAfter: (workspaceId, revision) => this.replicaChangeLog.changesAfter(workspaceId, revision),
+      subscribe: (workspaceId, listener) => this.replicaChangeLog.subscribe(workspaceId, listener)
+    };
+    const snapshotSource: CanonicalSnapshotSource = {
+      snapshotAt: (change) => this.snapshotSource.snapshotAt(change)
+    };
     this.broker = new ReplicaBroker({
       ...brokerOptions,
-      replicaChangeLog: this.replicaChangeLog,
-      snapshotSource: this.snapshotSource
+      replicaChangeLog,
+      snapshotSource,
+      replicaGapPolicy: "TERMINAL"
     });
+  }
+
+  get session(): RemoteReadDownSession {
+    if (!this.activeSession) throw new Error("remote broker runtime is not started");
+    return this.activeSession;
+  }
+
+  get replicaChangeLog(): RemoteReplicaChangeLog {
+    if (!this.activeReplicaChangeLog) throw new Error("remote broker runtime is not started");
+    return this.activeReplicaChangeLog;
+  }
+
+  get snapshotSource(): RemoteCanonicalSnapshotSource {
+    if (!this.activeSnapshotSource) throw new Error("remote broker runtime is not started");
+    return this.activeSnapshotSource;
+  }
+
+  health(): RemoteBrokerRuntimeHealth {
+    if (this.terminalFailure) return { status: "TERMINAL", failure: this.terminalFailure };
+    if (this.phase === "TERMINAL") {
+      throw new Error("remote broker runtime terminal state is missing its failure");
+    }
+    return { status: this.phase };
   }
 
   start(): Promise<BrokerDurableState> {
     if (this.stopped) return Promise.reject(new Error("remote broker runtime is stopped"));
-    if (!this.startTask) this.startTask = this.startRuntime();
-    return this.startTask;
+    if (this.terminalFailure) return Promise.reject(this.terminalFailure);
+    if (this.phase === "RUNNING") return Promise.resolve(this.broker.snapshotState());
+    if (this.startTask) return this.startTask;
+    this.phase = "STARTING";
+    const task = this.startRuntime();
+    this.startTask = task;
+    void task.then(
+      () => {
+        if (this.startTask === task) this.startTask = undefined;
+        if (!this.stopped && !this.terminalFailure) this.phase = "RUNNING";
+      },
+      () => {
+        if (this.startTask === task) this.startTask = undefined;
+      }
+    );
+    return task;
   }
 
   stop(): Promise<void> {
     if (this.stopTask) return this.stopTask;
     this.stopped = true;
-    this.unsubscribe?.();
-    this.unsubscribe = undefined;
-    const closeTask = this.session.close();
+    if (!this.terminalFailure) this.phase = "STOPPED";
+    this.unsubscribeNow();
+    this.pendingNotification = undefined;
+    const closeTask = this.activeSession?.close() ?? Promise.resolve();
     this.stopTask = Promise.allSettled([
       closeTask,
       this.startTask ?? Promise.resolve(),
-      this.synchronizationTail
+      this.notificationTask ?? Promise.resolve()
     ]).then((results) => {
+      if (this.terminalFailure) throw this.terminalFailure;
       const closeResult = results[0]!;
       if (closeResult.status === "rejected") throw closeResult.reason;
     });
@@ -70,34 +132,115 @@ export class RemoteBrokerRuntime {
   }
 
   private async startRuntime(): Promise<BrokerDurableState> {
-    await this.broker.initialize();
+    const durable = await this.broker.initialize();
     if (this.stopped) throw new Error("remote broker runtime is stopped");
+    this.bindRemoteComponents(durable);
     this.unsubscribe = this.replicaChangeLog.subscribe(
       this.session.workspaceId,
       (change) => this.handleNotification(change)
     );
-    return this.queueSynchronization();
+    try {
+      return await this.broker.synchronize();
+    } catch (error) {
+      const failure = remoteBrokerError(error);
+      await this.rollbackStart();
+      if (!this.stopped && !isRetryableRuntimeError(failure)) {
+        this.terminalFailure = failure;
+        this.phase = "TERMINAL";
+      } else if (!this.stopped) {
+        this.phase = "IDLE";
+      }
+      throw failure;
+    }
+  }
+
+  private bindRemoteComponents(durable: BrokerDurableState): void {
+    const session = new RemoteReadDownSession({
+      ...this.options.session,
+      workspaceId: this.options.workspaceId,
+      stateRoot: this.options.stateRoot,
+      expectedResume: {
+        epoch: durable.epoch,
+        deliveredRevision: durable.receivedCursor
+      }
+    });
+    this.activeSession = session;
+    this.activeReplicaChangeLog = new RemoteReplicaChangeLog(session);
+    this.activeSnapshotSource = new RemoteCanonicalSnapshotSource(session);
+  }
+
+  private async rollbackStart(): Promise<void> {
+    this.unsubscribeNow();
+    this.pendingNotification = undefined;
+    const session = this.activeSession;
+    if (session) await session.close();
+    if (this.notificationTask) await Promise.allSettled([this.notificationTask]);
+    this.activeSession = undefined;
+    this.activeReplicaChangeLog = undefined;
+    this.activeSnapshotSource = undefined;
   }
 
   private handleNotification(change: ReplicaChangeRecord): void {
-    void this.queueSynchronization(change).catch((error) => {
-      if (!this.stopped) {
-        this.onDiagnostic?.(`remote broker notification synchronization failed: ${remoteBrokerError(error).message}`);
+    if (this.stopped || this.terminalFailure) return;
+    this.pendingNotification = change;
+    if (this.notificationTask) return;
+    const task = this.pumpNotifications();
+    this.notificationTask = task;
+    void task.then(
+      () => {
+        if (this.notificationTask === task) this.notificationTask = undefined;
+        if (this.pendingNotification && !this.stopped && !this.terminalFailure) {
+          this.handleNotification(this.pendingNotification);
+        }
+      },
+      () => {
+        if (this.notificationTask === task) this.notificationTask = undefined;
       }
-    });
+    );
   }
 
-  private queueSynchronization(change?: ReplicaChangeRecord): Promise<BrokerDurableState> {
-    const synchronization = this.synchronizationTail.then(() => {
-      if (this.stopped) throw new Error("remote broker runtime is stopped");
-      return change ? this.broker.onNotification(change) : this.broker.synchronize();
-    });
-    this.synchronizationTail = synchronization.then(
-      () => undefined,
-      () => undefined
-    );
-    return synchronization;
+  private async pumpNotifications(): Promise<void> {
+    while (this.pendingNotification && !this.stopped && !this.terminalFailure) {
+      const change = this.pendingNotification;
+      this.pendingNotification = undefined;
+      try {
+        await this.broker.onNotification(change);
+      } catch (error) {
+        const failure = remoteBrokerError(error);
+        if (this.stopped || this.phase === "STARTING") return;
+        if (isRetryableRuntimeError(failure)) {
+          this.options.session.onDiagnostic?.(
+            `remote broker notification synchronization deferred: ${failure.message}`
+          );
+          return;
+        }
+        await this.enterTerminal(failure);
+        return;
+      }
+    }
   }
+
+  private async enterTerminal(failure: Error): Promise<void> {
+    if (this.terminalFailure) return;
+    this.terminalFailure = failure;
+    this.phase = "TERMINAL";
+    this.unsubscribeNow();
+    this.pendingNotification = undefined;
+    this.options.session.onDiagnostic?.(
+      `remote broker notification synchronization failed terminally: ${failure.message}`
+    );
+    await this.activeSession?.close();
+  }
+
+  private unsubscribeNow(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = undefined;
+  }
+}
+
+function isRetryableRuntimeError(error: Error): boolean {
+  return error instanceof RemoteReplicaResyncRequiredError
+    || error instanceof AuthorityTransportDisconnectedError;
 }
 
 function remoteBrokerError(value: unknown): Error {

--- a/packages/daemon/src/broker/remote-broker-runtime.ts
+++ b/packages/daemon/src/broker/remote-broker-runtime.ts
@@ -2,13 +2,20 @@ import type {
   ReplicaChangeLog,
   ReplicaChangeRecord
 } from "@harness-anything/application";
-import { AuthorityTransportDisconnectedError } from "../transport/persistent-ssh-authority-client.ts";
 import { RemoteCanonicalSnapshotSource } from "./remote-canonical-snapshot-source.ts";
 import {
+  deriveRemoteBrokerRuntimeHealth,
+  type RemoteBrokerRuntimeHealth,
+  type RemoteBrokerRuntimeLifecycle
+} from "./remote-broker-runtime-health.ts";
+import {
   RemoteReadDownSession,
-  RemoteReplicaResyncRequiredError,
   type RemoteReadDownSessionOptions
 } from "./remote-read-down-session.ts";
+import {
+  asRemoteReadDownError,
+  classifyRemoteReadDownFailure
+} from "./remote-read-down-failure.ts";
 import { RemoteReplicaChangeLog } from "./remote-replica-change-log.ts";
 import { ReplicaBroker } from "./replica-broker.ts";
 import type {
@@ -21,13 +28,11 @@ export interface RemoteBrokerRuntimeOptions
   extends Omit<BrokerOptions, "replicaChangeLog" | "snapshotSource" | "replicaGapPolicy"> {
   readonly session: Omit<
     RemoteReadDownSessionOptions,
-    "workspaceId" | "stateRoot" | "expectedResume"
+    "workspaceId" | "stateRoot" | "expectedResume" | "onTerminal"
   >;
 }
 
-export type RemoteBrokerRuntimeHealth =
-  | { readonly status: "IDLE" | "STARTING" | "RUNNING" | "STOPPED" }
-  | { readonly status: "TERMINAL"; readonly failure: Error };
+export { type RemoteBrokerRuntimeHealth } from "./remote-broker-runtime-health.ts";
 
 export class RemoteBrokerRuntime {
   readonly broker: ReplicaBroker;
@@ -38,14 +43,22 @@ export class RemoteBrokerRuntime {
   private unsubscribe: (() => void) | undefined;
   private pendingNotification: ReplicaChangeRecord | undefined;
   private notificationTask: Promise<void> | undefined;
+  private retryTask: Promise<void> | undefined;
+  private terminalTask: Promise<void> | undefined;
   private startTask: Promise<BrokerDurableState> | undefined;
   private stopTask: Promise<void> | undefined;
-  private phase: "IDLE" | "STARTING" | "RUNNING" | "TERMINAL" | "STOPPED" = "IDLE";
+  private lifecycle: RemoteBrokerRuntimeLifecycle = "IDLE";
   private terminalFailure: Error | undefined;
+  private initialized = false;
   private stopped = false;
+  private readonly stoppedSignal: Promise<void>;
+  private resolveStopped!: () => void;
 
   constructor(options: RemoteBrokerRuntimeOptions) {
     this.options = options;
+    this.stoppedSignal = new Promise((resolve) => {
+      this.resolveStopped = resolve;
+    });
     const { session: _session, ...brokerOptions } = options;
     const replicaChangeLog: ReplicaChangeLog = {
       append: (record) => this.replicaChangeLog.append(record),
@@ -81,25 +94,27 @@ export class RemoteBrokerRuntime {
   }
 
   health(): RemoteBrokerRuntimeHealth {
-    if (this.terminalFailure) return { status: "TERMINAL", failure: this.terminalFailure };
-    if (this.phase === "TERMINAL") {
-      throw new Error("remote broker runtime terminal state is missing its failure");
-    }
-    return { status: this.phase };
+    return deriveRemoteBrokerRuntimeHealth({
+      lifecycle: this.lifecycle,
+      durable: this.initialized ? this.broker.snapshotState() : undefined,
+      session: this.activeSession?.health(),
+      hasPendingWork: Boolean(this.notificationTask || this.retryTask),
+      failure: this.terminalFailure
+    });
   }
 
   start(): Promise<BrokerDurableState> {
     if (this.stopped) return Promise.reject(new Error("remote broker runtime is stopped"));
-    if (this.terminalFailure) return Promise.reject(this.terminalFailure);
-    if (this.phase === "RUNNING") return Promise.resolve(this.broker.snapshotState());
+    const health = this.health();
+    if (health.status === "TERMINAL") return Promise.reject(health.failure);
+    if (this.lifecycle === "ACTIVE") return Promise.resolve(this.broker.snapshotState());
     if (this.startTask) return this.startTask;
-    this.phase = "STARTING";
+    this.lifecycle = "STARTING";
     const task = this.startRuntime();
     this.startTask = task;
     void task.then(
       () => {
         if (this.startTask === task) this.startTask = undefined;
-        if (!this.stopped && !this.terminalFailure) this.phase = "RUNNING";
       },
       () => {
         if (this.startTask === task) this.startTask = undefined;
@@ -111,14 +126,17 @@ export class RemoteBrokerRuntime {
   stop(): Promise<void> {
     if (this.stopTask) return this.stopTask;
     this.stopped = true;
-    if (!this.terminalFailure) this.phase = "STOPPED";
+    this.lifecycle = "STOPPED";
+    this.resolveStopped();
     this.unsubscribeNow();
     this.pendingNotification = undefined;
     const closeTask = this.activeSession?.close() ?? Promise.resolve();
     this.stopTask = Promise.allSettled([
       closeTask,
       this.startTask ?? Promise.resolve(),
-      this.notificationTask ?? Promise.resolve()
+      this.notificationTask ?? Promise.resolve(),
+      this.retryTask ?? Promise.resolve(),
+      this.terminalTask ?? Promise.resolve()
     ]).then((results) => {
       if (this.terminalFailure) throw this.terminalFailure;
       const closeResult = results[0]!;
@@ -132,23 +150,26 @@ export class RemoteBrokerRuntime {
   }
 
   private async startRuntime(): Promise<BrokerDurableState> {
-    const durable = await this.broker.initialize();
-    if (this.stopped) throw new Error("remote broker runtime is stopped");
-    this.bindRemoteComponents(durable);
-    this.unsubscribe = this.replicaChangeLog.subscribe(
-      this.session.workspaceId,
-      (change) => this.handleNotification(change)
-    );
     try {
-      return await this.broker.synchronize();
+      const durable = await this.broker.initialize();
+      this.initialized = true;
+      if (this.stopped) throw new Error("remote broker runtime is stopped");
+      this.bindRemoteComponents(durable);
+      this.unsubscribe = this.replicaChangeLog.subscribe(
+        this.session.workspaceId,
+        (change) => this.handleNotification(change)
+      );
+      const state = await this.broker.synchronize();
+      this.lifecycle = "ACTIVE";
+      if (this.pendingNotification) this.handleNotification(this.pendingNotification);
+      return state;
     } catch (error) {
-      const failure = remoteBrokerError(error);
+      const failure = this.terminalFailure ?? asRemoteReadDownError(error);
       await this.rollbackStart();
-      if (!this.stopped && !isRetryableRuntimeError(failure)) {
-        this.terminalFailure = failure;
-        this.phase = "TERMINAL";
+      if (!this.stopped && classifyRemoteReadDownFailure(failure) !== "TERMINAL") {
+        this.lifecycle = "IDLE";
       } else if (!this.stopped) {
-        this.phase = "IDLE";
+        this.latchTerminal(failure);
       }
       throw failure;
     }
@@ -162,7 +183,8 @@ export class RemoteBrokerRuntime {
       expectedResume: {
         epoch: durable.epoch,
         deliveredRevision: durable.receivedCursor
-      }
+      },
+      onTerminal: (failure) => this.latchTerminal(failure)
     });
     this.activeSession = session;
     this.activeReplicaChangeLog = new RemoteReplicaChangeLog(session);
@@ -173,8 +195,12 @@ export class RemoteBrokerRuntime {
     this.unsubscribeNow();
     this.pendingNotification = undefined;
     const session = this.activeSession;
-    if (session) await session.close();
-    if (this.notificationTask) await Promise.allSettled([this.notificationTask]);
+    const pending = [
+      ...(session ? [session.close()] : []),
+      ...(this.notificationTask ? [this.notificationTask] : []),
+      ...(this.retryTask ? [this.retryTask] : [])
+    ];
+    await Promise.allSettled(pending);
     this.activeSession = undefined;
     this.activeReplicaChangeLog = undefined;
     this.activeSnapshotSource = undefined;
@@ -183,18 +209,14 @@ export class RemoteBrokerRuntime {
   private handleNotification(change: ReplicaChangeRecord): void {
     if (this.stopped || this.terminalFailure) return;
     this.pendingNotification = change;
-    if (this.notificationTask) return;
+    if (this.lifecycle !== "ACTIVE" || this.notificationTask) return;
     const task = this.pumpNotifications();
     this.notificationTask = task;
     void task.then(
-      () => {
-        if (this.notificationTask === task) this.notificationTask = undefined;
-        if (this.pendingNotification && !this.stopped && !this.terminalFailure) {
-          this.handleNotification(this.pendingNotification);
-        }
-      },
-      () => {
-        if (this.notificationTask === task) this.notificationTask = undefined;
+      () => this.finishNotificationTask(task),
+      (error) => {
+        this.finishNotificationTask(task);
+        if (!this.stopped) this.latchTerminal(asRemoteReadDownError(error));
       }
     );
   }
@@ -206,43 +228,95 @@ export class RemoteBrokerRuntime {
       try {
         await this.broker.onNotification(change);
       } catch (error) {
-        const failure = remoteBrokerError(error);
-        if (this.stopped || this.phase === "STARTING") return;
-        if (isRetryableRuntimeError(failure)) {
-          this.options.session.onDiagnostic?.(
-            `remote broker notification synchronization deferred: ${failure.message}`
-          );
+        if (this.stopped) return;
+        const failure = asRemoteReadDownError(error);
+        if (classifyRemoteReadDownFailure(failure) !== "TERMINAL") {
+          this.scheduleRetry();
           return;
         }
-        await this.enterTerminal(failure);
+        this.latchTerminal(failure);
         return;
       }
     }
   }
 
-  private async enterTerminal(failure: Error): Promise<void> {
+  private scheduleRetry(): void {
+    if (this.retryTask || this.stopped || this.terminalFailure) return;
+    const task = this.retrySynchronization();
+    this.retryTask = task;
+    void task.then(
+      () => {
+        if (this.retryTask === task) this.retryTask = undefined;
+      },
+      (error) => {
+        if (this.retryTask === task) this.retryTask = undefined;
+        if (!this.stopped) this.latchTerminal(asRemoteReadDownError(error));
+      }
+    );
+  }
+
+  private async retrySynchronization(): Promise<void> {
+    const backoff = {
+      initialMs: this.options.session.backoff?.initialMs ?? 100,
+      maximumMs: this.options.session.backoff?.maximumMs ?? 5_000,
+      multiplier: this.options.session.backoff?.multiplier ?? 2
+    };
+    let delay = backoff.initialMs;
+    while (!this.stopped && !this.terminalFailure && this.lifecycle === "ACTIVE") {
+      await this.retryWait(delay);
+      if (this.stopped) return;
+      try {
+        await this.session.refresh();
+        const state = await this.broker.synchronize();
+        if (state.mode === "READY") return;
+      } catch (error) {
+        const failure = asRemoteReadDownError(error);
+        if (classifyRemoteReadDownFailure(failure) === "TERMINAL") {
+          this.latchTerminal(failure);
+          return;
+        }
+        this.options.session.onDiagnostic?.(
+          `remote broker synchronization retry deferred: ${failure.message}`
+        );
+      }
+      delay = Math.min(
+        backoff.maximumMs,
+        Math.max(delay + 1, Math.ceil(delay * backoff.multiplier))
+      );
+    }
+  }
+
+  private async retryWait(milliseconds: number): Promise<void> {
+    const sleep = this.options.session.sleep
+      ?? ((delay: number) => new Promise<void>((resolve) => setTimeout(resolve, delay)));
+    await Promise.race([sleep(milliseconds), this.stoppedSignal]);
+  }
+
+  private latchTerminal(failure: Error): void {
     if (this.terminalFailure) return;
     this.terminalFailure = failure;
-    this.phase = "TERMINAL";
     this.unsubscribeNow();
     this.pendingNotification = undefined;
     this.options.session.onDiagnostic?.(
-      `remote broker notification synchronization failed terminally: ${failure.message}`
+      `remote broker synchronization failed terminally: ${failure.message}`
     );
-    await this.activeSession?.close();
+    const task = this.activeSession?.close() ?? Promise.resolve();
+    this.terminalTask = task.catch((error) => {
+      this.options.session.onDiagnostic?.(
+        `remote broker terminal close failed: ${asRemoteReadDownError(error).message}`
+      );
+    });
   }
 
   private unsubscribeNow(): void {
     this.unsubscribe?.();
     this.unsubscribe = undefined;
   }
-}
 
-function isRetryableRuntimeError(error: Error): boolean {
-  return error instanceof RemoteReplicaResyncRequiredError
-    || error instanceof AuthorityTransportDisconnectedError;
-}
-
-function remoteBrokerError(value: unknown): Error {
-  return value instanceof Error ? value : new Error(String(value));
+  private finishNotificationTask(task: Promise<void>): void {
+    if (this.notificationTask === task) this.notificationTask = undefined;
+    if (this.pendingNotification && !this.stopped && !this.terminalFailure) {
+      this.handleNotification(this.pendingNotification);
+    }
+  }
 }

--- a/packages/daemon/src/broker/remote-broker-runtime.ts
+++ b/packages/daemon/src/broker/remote-broker-runtime.ts
@@ -1,0 +1,105 @@
+import type { ReplicaChangeRecord } from "@harness-anything/application";
+import { RemoteCanonicalSnapshotSource } from "./remote-canonical-snapshot-source.ts";
+import {
+  RemoteReadDownSession,
+  type RemoteReadDownSessionOptions
+} from "./remote-read-down-session.ts";
+import { RemoteReplicaChangeLog } from "./remote-replica-change-log.ts";
+import { ReplicaBroker } from "./replica-broker.ts";
+import type { BrokerDurableState, BrokerOptions } from "./types.ts";
+
+export interface RemoteBrokerRuntimeOptions
+  extends Omit<BrokerOptions, "replicaChangeLog" | "snapshotSource"> {
+  readonly session: Omit<RemoteReadDownSessionOptions, "workspaceId" | "stateRoot">;
+}
+
+export class RemoteBrokerRuntime {
+  readonly session: RemoteReadDownSession;
+  readonly replicaChangeLog: RemoteReplicaChangeLog;
+  readonly snapshotSource: RemoteCanonicalSnapshotSource;
+  readonly broker: ReplicaBroker;
+  private readonly onDiagnostic: ((text: string) => void) | undefined;
+  private unsubscribe: (() => void) | undefined;
+  private synchronizationTail: Promise<void> = Promise.resolve();
+  private startTask: Promise<BrokerDurableState> | undefined;
+  private stopTask: Promise<void> | undefined;
+  private stopped = false;
+
+  constructor(options: RemoteBrokerRuntimeOptions) {
+    const { session, ...brokerOptions } = options;
+    this.onDiagnostic = session.onDiagnostic;
+    this.session = new RemoteReadDownSession({
+      ...session,
+      workspaceId: options.workspaceId,
+      stateRoot: options.stateRoot
+    });
+    this.replicaChangeLog = new RemoteReplicaChangeLog(this.session);
+    this.snapshotSource = new RemoteCanonicalSnapshotSource(this.session);
+    this.broker = new ReplicaBroker({
+      ...brokerOptions,
+      replicaChangeLog: this.replicaChangeLog,
+      snapshotSource: this.snapshotSource
+    });
+  }
+
+  start(): Promise<BrokerDurableState> {
+    if (this.stopped) return Promise.reject(new Error("remote broker runtime is stopped"));
+    if (!this.startTask) this.startTask = this.startRuntime();
+    return this.startTask;
+  }
+
+  stop(): Promise<void> {
+    if (this.stopTask) return this.stopTask;
+    this.stopped = true;
+    this.unsubscribe?.();
+    this.unsubscribe = undefined;
+    const closeTask = this.session.close();
+    this.stopTask = Promise.allSettled([
+      closeTask,
+      this.startTask ?? Promise.resolve(),
+      this.synchronizationTail
+    ]).then((results) => {
+      const closeResult = results[0]!;
+      if (closeResult.status === "rejected") throw closeResult.reason;
+    });
+    return this.stopTask;
+  }
+
+  close(): Promise<void> {
+    return this.stop();
+  }
+
+  private async startRuntime(): Promise<BrokerDurableState> {
+    await this.broker.initialize();
+    if (this.stopped) throw new Error("remote broker runtime is stopped");
+    this.unsubscribe = this.replicaChangeLog.subscribe(
+      this.session.workspaceId,
+      (change) => this.handleNotification(change)
+    );
+    return this.queueSynchronization();
+  }
+
+  private handleNotification(change: ReplicaChangeRecord): void {
+    void this.queueSynchronization(change).catch((error) => {
+      if (!this.stopped) {
+        this.onDiagnostic?.(`remote broker notification synchronization failed: ${remoteBrokerError(error).message}`);
+      }
+    });
+  }
+
+  private queueSynchronization(change?: ReplicaChangeRecord): Promise<BrokerDurableState> {
+    const synchronization = this.synchronizationTail.then(() => {
+      if (this.stopped) throw new Error("remote broker runtime is stopped");
+      return change ? this.broker.onNotification(change) : this.broker.synchronize();
+    });
+    this.synchronizationTail = synchronization.then(
+      () => undefined,
+      () => undefined
+    );
+    return synchronization;
+  }
+}
+
+function remoteBrokerError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}

--- a/packages/daemon/src/broker/remote-read-down-content.ts
+++ b/packages/daemon/src/broker/remote-read-down-content.ts
@@ -8,7 +8,12 @@ import type {
 import {
   AuthorityReadDownRequestError
 } from "../transport/persistent-ssh-authority-client.ts";
-import type { ActiveSnapshot, RemoteReadDownChangeCacheLimits } from "./remote-read-down-contract.ts";
+import type {
+  ActiveSnapshot,
+  RemoteReadDownChangeCacheLimits,
+  ResumeCursor
+} from "./remote-read-down-contract.ts";
+import { RemoteReadDownIntegrityError } from "./remote-read-down-failure.ts";
 
 export function assertManifest(
   reservation: AuthoritySnapshotReservation,
@@ -17,11 +22,11 @@ export function assertManifest(
 ): void {
   if (manifest.cut.workspaceId !== workspaceId
     || !sameSnapshotCut(manifest.cut, reservation.cut)) {
-    throw new Error("authority snapshot manifest cut mismatch");
+    throw new RemoteReadDownIntegrityError("authority snapshot manifest cut mismatch");
   }
   const actual = manifestDigest(manifest.cut, manifest.entries);
   if (actual !== reservation.cut.manifestDigest) {
-    throw new Error(`MANIFEST_DIGEST_MISMATCH:${reservation.cut.manifestDigest}:${actual}`);
+    throw new RemoteReadDownIntegrityError(`MANIFEST_DIGEST_MISMATCH:${reservation.cut.manifestDigest}:${actual}`);
   }
 }
 
@@ -30,7 +35,9 @@ export function assertCutChange(
   change: ReplicaChangeRecord | null
 ): void {
   if (reservation.cut.revision === 0) {
-    if (change !== null) throw new Error("authority empty cut unexpectedly has a change");
+    if (change !== null) {
+      throw new RemoteReadDownIntegrityError("authority empty cut unexpectedly has a change");
+    }
     return;
   }
   if (!change
@@ -38,7 +45,7 @@ export function assertCutChange(
     || change.revision !== reservation.cut.revision
     || change.commitSha !== reservation.cut.commitSha
     || change.manifest.digest !== reservation.cut.manifestDigest) {
-    throw new Error("authority cut change does not match snapshot reservation");
+    throw new RemoteReadDownIntegrityError("authority cut change does not match snapshot reservation");
   }
 }
 
@@ -52,6 +59,45 @@ export async function mapInBatches<Value>(
   }
 }
 
+export function createActiveSnapshot(
+  reservation: AuthoritySnapshotReservation,
+  manifest: AuthoritySnapshotManifest,
+  cutChange: ReplicaChangeRecord | null,
+  resume: ResumeCursor | undefined
+): ActiveSnapshot {
+  const baseEntries = new Map(manifest.entries.map((entry) => [entry.path, entry]));
+  if (baseEntries.size !== manifest.entries.length) {
+    throw new RemoteReadDownIntegrityError(
+      "authority snapshot manifest contains duplicate paths"
+    );
+  }
+  const sameEpoch = resume?.epoch === reservation.cut.epoch;
+  const canResume = Boolean(
+    resume && sameEpoch && reservation.cut.revision <= resume.deliveredRevision
+  );
+  const resyncReason = resume && !sameEpoch
+    ? `EPOCH_CHANGED:${resume.epoch}:${reservation.cut.epoch}`
+    : resume && !canResume
+      ? `CURSOR_PRECEDES_RECONNECTED_CUT:${resume.deliveredRevision}:${reservation.cut.revision}`
+      : undefined;
+  return {
+    reservation,
+    cutChange,
+    baseEntries,
+    changes: new Map(),
+    changeSizes: new Map(),
+    lossyHintRevisions: new Set(),
+    changeBytes: 0,
+    highestRevision: reservation.cut.revision,
+    durableCursor: reservation.cut.revision,
+    adopted: canResume || (!resume && reservation.cut.revision === 0),
+    deliveredRevision: canResume ? resume!.deliveredRevision : reservation.cut.revision,
+    ...(resyncReason ? { resyncReason } : {}),
+    resyncSignaled: false,
+    resyncReported: false
+  };
+}
+
 export function validateChanges(
   changes: ReadonlyArray<ReplicaChangeRecord>,
   sinceRevision: number,
@@ -60,7 +106,9 @@ export function validateChanges(
   let expected = sinceRevision + 1;
   for (const change of changes) {
     if (change.workspaceId !== workspaceId || change.revision !== expected) {
-      throw new Error(`remote replica change gap at revision ${change.revision}; expected ${expected}`);
+      throw new RemoteReadDownIntegrityError(
+        `remote replica change gap at revision ${change.revision}; expected ${expected}`
+      );
     }
     expected += 1;
   }
@@ -74,7 +122,9 @@ export function applyChange(
     if (item.tombstone) {
       entries.delete(item.path);
     } else {
-      if (!item.blobDigest || !item.mode) throw new Error(`remote change lacks blob metadata for ${item.path}`);
+      if (!item.blobDigest || !item.mode) {
+        throw new RemoteReadDownIntegrityError(`remote change lacks blob metadata for ${item.path}`);
+      }
       entries.set(item.path, {
         path: item.path,
         blobDigest: item.blobDigest,
@@ -97,7 +147,7 @@ export function assertChangeManifest(
     commitSha: change.commitSha
   }, [...entries.values()]);
   if (actual !== change.manifest.digest || entries.size !== change.manifest.entryCount) {
-    throw new Error(`MANIFEST_DIGEST_MISMATCH:${change.manifest.digest}:${actual}`);
+    throw new RemoteReadDownIntegrityError(`MANIFEST_DIGEST_MISMATCH:${change.manifest.digest}:${actual}`);
   }
 }
 
@@ -126,27 +176,36 @@ export function storeCachedChange(
   const existing = active.changes.get(change.revision);
   if (existing) {
     if (!sameChangeIdentity(existing, change)) {
-      throw new Error(`remote replica change identity conflict at revision ${change.revision}`);
+      throw new RemoteReadDownIntegrityError(
+        `remote replica change identity conflict at revision ${change.revision}`
+      );
     }
+    if (!lossyHint) {
+      active.lossyHintRevisions.delete(change.revision);
+    }
+    active.highestRevision = Math.max(active.highestRevision, change.revision);
     return false;
   }
   const byteSize = Buffer.byteLength(JSON.stringify(change));
   if (byteSize > limits.maxBytes) {
-    throw new Error(`REMOTE_CHANGE_CACHE_LIMIT_EXCEEDED:bytes:${byteSize}:${limits.maxBytes}`);
+    throw new RemoteReadDownIntegrityError(
+      `REMOTE_CHANGE_CACHE_LIMIT_EXCEEDED:bytes:${byteSize}:${limits.maxBytes}`
+    );
   }
   if (lossyHint
     && (active.changes.size >= limits.maxCount
       || active.changeBytes + byteSize > limits.maxBytes)) {
     return false;
   }
-  if (active.changes.size >= limits.maxCount
-    || active.changeBytes + byteSize > limits.maxBytes) {
-    throw new Error(
+  if (!lossyHint) evictLossyHints(active, limits, byteSize);
+  if (active.changes.size >= limits.maxCount || active.changeBytes + byteSize > limits.maxBytes) {
+    throw new RemoteReadDownIntegrityError(
       `REMOTE_CHANGE_CACHE_LIMIT_EXCEEDED:${active.changes.size + 1}:${active.changeBytes + byteSize}`
     );
   }
   active.changes.set(change.revision, change);
   active.changeSizes.set(change.revision, byteSize);
+  if (lossyHint) active.lossyHintRevisions.add(change.revision);
   active.changeBytes += byteSize;
   active.highestRevision = Math.max(active.highestRevision, change.revision);
   return true;
@@ -162,11 +221,6 @@ export function compareManifestPaths(
 export function isResyncError(error: unknown): error is AuthorityReadDownRequestError {
   return error instanceof AuthorityReadDownRequestError
     && (error.code === "RESYNC_REQUIRED" || error.code === "SNAPSHOT_EXPIRED");
-}
-
-export function isIntegrityError(error: unknown): boolean {
-  const message = contentError(error).message;
-  return /(?:BLOB|MANIFEST)_DIGEST_MISMATCH|CAS object corrupted|manifest (?:cut mismatch|contains duplicate)|cut change does not match|blob response (?:metadata mismatch|is not canonical)/iu.test(message);
 }
 
 function sameSnapshotCut(
@@ -185,7 +239,23 @@ function deleteCachedChange(active: ActiveSnapshot, revision: number): void {
   const byteSize = active.changeSizes.get(revision) ?? 0;
   active.changes.delete(revision);
   active.changeSizes.delete(revision);
+  active.lossyHintRevisions.delete(revision);
   active.changeBytes -= byteSize;
+}
+
+function evictLossyHints(
+  active: ActiveSnapshot,
+  limits: RemoteReadDownChangeCacheLimits,
+  incomingBytes: number
+): void {
+  const revisions = [...active.lossyHintRevisions].sort((left, right) => right - left);
+  for (const revision of revisions) {
+    if (active.changes.size < limits.maxCount
+      && active.changeBytes + incomingBytes <= limits.maxBytes) {
+      return;
+    }
+    deleteCachedChange(active, revision);
+  }
 }
 
 function recomputeHighestRevision(active: ActiveSnapshot): void {
@@ -194,8 +264,4 @@ function recomputeHighestRevision(active: ActiveSnapshot): void {
     if (revision > highest) highest = revision;
   }
   active.highestRevision = highest;
-}
-
-function contentError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error));
 }

--- a/packages/daemon/src/broker/remote-read-down-contract.ts
+++ b/packages/daemon/src/broker/remote-read-down-contract.ts
@@ -25,6 +25,7 @@ export interface RemoteReadDownSessionOptions {
   readonly sleep?: (milliseconds: number) => Promise<void>;
   readonly schedule?: (milliseconds: number, callback: () => void) => { readonly dispose: () => void };
   readonly changeCache?: Partial<RemoteReadDownChangeCacheLimits>;
+  readonly expectedResume?: ResumeCursor;
   readonly onDiagnostic?: (text: string) => void;
 }
 

--- a/packages/daemon/src/broker/remote-read-down-contract.ts
+++ b/packages/daemon/src/broker/remote-read-down-contract.ts
@@ -27,6 +27,7 @@ export interface RemoteReadDownSessionOptions {
   readonly changeCache?: Partial<RemoteReadDownChangeCacheLimits>;
   readonly expectedResume?: ResumeCursor;
   readonly onDiagnostic?: (text: string) => void;
+  readonly onTerminal?: (failure: Error) => void;
 }
 
 /**
@@ -59,6 +60,7 @@ export interface ActiveSnapshot {
   readonly baseEntries: ReadonlyMap<string, AuthoritySnapshotManifestEntry>;
   readonly changes: Map<number, ReplicaChangeRecord>;
   readonly changeSizes: Map<number, number>;
+  readonly lossyHintRevisions: Set<number>;
   changeBytes: number;
   highestRevision: number;
   durableCursor: number;
@@ -73,6 +75,10 @@ export interface ResumeCursor {
   readonly epoch: string;
   readonly deliveredRevision: number;
 }
+
+export type RemoteReadDownSessionHealth =
+  | { readonly status: "IDLE" | "RECOVERING" | "READY" | "CLOSED" }
+  | { readonly status: "TERMINAL"; readonly failure: Error };
 
 export const defaultBackoff: RemoteReadDownBackoff = {
   initialMs: 100,

--- a/packages/daemon/src/broker/remote-read-down-failure.ts
+++ b/packages/daemon/src/broker/remote-read-down-failure.ts
@@ -1,0 +1,29 @@
+import {
+  AuthorityReadDownRequestError,
+  AuthorityTransportDisconnectedError
+} from "../transport/persistent-ssh-authority-client.ts";
+import { RemoteReplicaResyncRequiredError } from "./remote-read-down-contract.ts";
+
+export type RemoteReadDownFailureKind = "RESYNC" | "TRANSIENT" | "TERMINAL";
+
+export class RemoteReadDownIntegrityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RemoteReadDownIntegrityError";
+  }
+}
+
+export function classifyRemoteReadDownFailure(error: unknown): RemoteReadDownFailureKind {
+  if (error instanceof RemoteReplicaResyncRequiredError) return "RESYNC";
+  if (error instanceof AuthorityTransportDisconnectedError) return "TRANSIENT";
+  if (error instanceof AuthorityReadDownRequestError) {
+    return error.code === "RESYNC_REQUIRED" || error.code === "SNAPSHOT_EXPIRED"
+      ? "RESYNC"
+      : "TERMINAL";
+  }
+  return "TERMINAL";
+}
+
+export function asRemoteReadDownError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/packages/daemon/src/broker/remote-read-down-fetch.ts
+++ b/packages/daemon/src/broker/remote-read-down-fetch.ts
@@ -1,0 +1,63 @@
+import type { ReplicaChangeRecord } from "@harness-anything/application";
+import type { AuthorityChangesAfterResult } from "../authority/protocol.ts";
+import { AuthorityTransportDisconnectedError } from "../transport/persistent-ssh-authority-client.ts";
+import {
+  type ActiveSnapshot,
+  type RemoteReadDownBackoff
+} from "./remote-read-down-contract.ts";
+import { isResyncError, validateChanges } from "./remote-read-down-content.ts";
+import { asRemoteReadDownError } from "./remote-read-down-failure.ts";
+import {
+  advanceRemoteReadDownBackoff,
+  createRemoteResyncError
+} from "./remote-read-down-state.ts";
+
+export async function fetchRemoteChanges(input: {
+  readonly active: ActiveSnapshot;
+  readonly revision: number;
+  readonly workspaceId: string;
+  readonly backoff: RemoteReadDownBackoff;
+  readonly request: (
+    active: ActiveSnapshot,
+    revision: number
+  ) => Promise<AuthorityChangesAfterResult>;
+  readonly assertCurrent: (active: ActiveSnapshot) => void;
+  readonly storeChange: (active: ActiveSnapshot, change: ReplicaChangeRecord) => void;
+  readonly invalidate: (active: ActiveSnapshot) => void;
+  readonly ready: () => Promise<ActiveSnapshot>;
+  readonly sleep: (milliseconds: number) => Promise<void>;
+  readonly stopped: () => boolean;
+}): Promise<ReadonlyArray<ReplicaChangeRecord>> {
+  let current = input.active;
+  let delay = input.backoff.initialMs;
+  for (;;) {
+    try {
+      input.assertCurrent(current);
+      const result = await input.request(current, input.revision);
+      input.assertCurrent(current);
+      validateChanges(result.changes, input.revision, input.workspaceId);
+      for (const change of result.changes) input.storeChange(current, change);
+      return result.changes;
+    } catch (error) {
+      if (input.stopped()) throw asRemoteReadDownError(error);
+      if (isResyncError(error)) {
+        input.invalidate(current);
+        throw createRemoteResyncError(await input.ready(), error.message);
+      }
+      if (!(error instanceof AuthorityTransportDisconnectedError)) throw error;
+      input.invalidate(current);
+      await input.sleep(delay);
+      delay = advanceRemoteReadDownBackoff(delay, input.backoff);
+      current = await input.ready();
+      if (current.resyncReason) {
+        throw createRemoteResyncError(current, current.resyncReason);
+      }
+      if (input.revision < current.reservation.cut.revision) {
+        throw createRemoteResyncError(
+          current,
+          `CURSOR_PRECEDES_RECONNECTED_CUT:${input.revision}:${current.reservation.cut.revision}`
+        );
+      }
+    }
+  }
+}

--- a/packages/daemon/src/broker/remote-read-down-lifecycle.ts
+++ b/packages/daemon/src/broker/remote-read-down-lifecycle.ts
@@ -1,0 +1,108 @@
+import type { ReplicaChangeRecord } from "@harness-anything/application";
+import type { PersistentSshAuthorityClient } from "../transport/persistent-ssh-authority-client.ts";
+import type { RemoteReadDownSessionHealth } from "./remote-read-down-contract.ts";
+import { asRemoteReadDownError } from "./remote-read-down-failure.ts";
+
+export function registerRemoteReadDownListeners(
+  client: PersistentSshAuthorityClient,
+  onNotification: (change: ReplicaChangeRecord) => void,
+  onDisconnect: () => void
+): { readonly removeNotification: () => void; readonly removeDisconnect: () => void } {
+  const removeNotification = client.onNotification(onNotification);
+  try {
+    return { removeNotification, removeDisconnect: client.onDisconnect(onDisconnect) };
+  } catch (error) {
+    removeNotification();
+    throw error;
+  }
+}
+
+export async function closeAndJoinRemoteReadDown(
+  client: PersistentSshAuthorityClient,
+  pending: () => ReadonlyArray<Promise<unknown>>
+): Promise<void> {
+  const closeResult = await Promise.allSettled([
+    Promise.resolve().then(() => client.close())
+  ]);
+  for (;;) {
+    const operations = pending();
+    if (operations.length === 0) break;
+    await Promise.allSettled(operations);
+  }
+  const outcome = closeResult[0]!;
+  if (outcome.status === "rejected") throw outcome.reason;
+}
+
+export function removeRemoteReadDownListeners(
+  removals: ReadonlyArray<() => void>,
+  onDiagnostic: ((text: string) => void) | undefined
+): void {
+  for (const remove of removals) {
+    try {
+      remove();
+    } catch (error) {
+      onDiagnostic?.(
+        `remote read-down listener cleanup failed: ${asRemoteReadDownError(error).message}`
+      );
+    }
+  }
+}
+
+export function deriveRemoteReadDownSessionHealth(input: {
+  readonly terminal: Error | undefined;
+  readonly stopped: boolean;
+  readonly active: boolean;
+  readonly recovering: boolean;
+}): RemoteReadDownSessionHealth {
+  if (input.terminal) return { status: "TERMINAL", failure: input.terminal };
+  if (input.stopped) return { status: "CLOSED" };
+  if (input.active) return { status: "READY" };
+  return { status: input.recovering ? "RECOVERING" : "IDLE" };
+}
+
+export function publishRemoteReadDownTerminal(
+  current: Error | undefined,
+  error: unknown,
+  onTerminal: ((failure: Error) => void) | undefined,
+  onDiagnostic: ((text: string) => void) | undefined
+): Error {
+  if (current) return current;
+  const failure = asRemoteReadDownError(error);
+  try {
+    onTerminal?.(failure);
+  } catch (callbackError) {
+    onDiagnostic?.(
+      `remote read-down terminal observer failed: ${asRemoteReadDownError(callbackError).message}`
+    );
+  }
+  return failure;
+}
+
+export function notifyRemoteReadDownListeners(
+  listeners: ReadonlySet<(change: ReplicaChangeRecord) => void>,
+  change: ReplicaChangeRecord,
+  onDiagnostic: ((text: string) => void) | undefined
+): void {
+  for (const listener of listeners) {
+    try {
+      listener(change);
+    } catch (error) {
+      onDiagnostic?.(
+        `remote read-down notification listener failed: ${asRemoteReadDownError(error).message}`
+      );
+    }
+  }
+}
+
+export function trackRemoteReadDownOperation<Value>(
+  operations: Set<Promise<unknown>>,
+  operation: () => Promise<Value>
+): Promise<Value> {
+  const task = operation();
+  operations.add(task);
+  void task.then(
+    () => operations.delete(task),
+    () => operations.delete(task)
+  );
+  return task;
+}

--- a/packages/daemon/src/broker/remote-read-down-recovery.ts
+++ b/packages/daemon/src/broker/remote-read-down-recovery.ts
@@ -1,0 +1,69 @@
+import {
+  type ActiveSnapshot,
+  type RemoteReadDownBackoff,
+  type ResumeCursor
+} from "./remote-read-down-contract.ts";
+import {
+  asRemoteReadDownError,
+  classifyRemoteReadDownFailure
+} from "./remote-read-down-failure.ts";
+import { advanceRemoteReadDownBackoff } from "./remote-read-down-state.ts";
+
+export async function recoverRemoteSnapshot(input: {
+  readonly resume: ResumeCursor | undefined;
+  readonly backoff: RemoteReadDownBackoff;
+  readonly connect: (replace: boolean) => Promise<void>;
+  readonly openSnapshot: (resume: ResumeCursor | undefined) => Promise<ActiveSnapshot>;
+  readonly assertCurrent: () => void;
+  readonly stopped: () => boolean;
+  readonly sleep: (milliseconds: number) => Promise<void>;
+  readonly terminal: (error: unknown) => Error;
+  readonly diagnostic: ((text: string) => void) | undefined;
+}): Promise<ActiveSnapshot> {
+  let delay = input.backoff.initialMs;
+  let replaceConnection = input.resume !== undefined;
+  for (;;) {
+    try {
+      await input.connect(replaceConnection);
+      input.assertCurrent();
+    } catch (error) {
+      if (input.stopped()) throw asRemoteReadDownError(error);
+      if (classifyRemoteReadDownFailure(error) === "TERMINAL") {
+        throw input.terminal(error);
+      }
+      await retry(input, error, delay);
+      delay = advanceRemoteReadDownBackoff(delay, input.backoff);
+      replaceConnection = true;
+      continue;
+    }
+    try {
+      const active = await input.openSnapshot(input.resume);
+      input.assertCurrent();
+      return active;
+    } catch (error) {
+      if (input.stopped()) throw asRemoteReadDownError(error);
+      if (classifyRemoteReadDownFailure(error) === "TERMINAL") {
+        throw input.terminal(error);
+      }
+      await retry(input, error, delay);
+      delay = advanceRemoteReadDownBackoff(delay, input.backoff);
+      replaceConnection = true;
+    }
+  }
+}
+
+async function retry(
+  input: {
+    readonly diagnostic: ((text: string) => void) | undefined;
+    readonly sleep: (milliseconds: number) => Promise<void>;
+    readonly assertCurrent: () => void;
+  },
+  error: unknown,
+  delay: number
+): Promise<void> {
+  input.diagnostic?.(
+    `remote read-down reconnect failed; retrying in ${delay}ms: ${asRemoteReadDownError(error).message}`
+  );
+  await input.sleep(delay);
+  input.assertCurrent();
+}

--- a/packages/daemon/src/broker/remote-read-down-session.ts
+++ b/packages/daemon/src/broker/remote-read-down-session.ts
@@ -74,6 +74,7 @@ export class RemoteReadDownSession {
     this.blobReader = new RemoteBlobReader(this.cas, options.client, () => this.assertOpen());
     this.backoff = { ...defaultBackoff, ...options.backoff };
     this.changeCache = { ...defaultChangeCache, ...options.changeCache };
+    this.resumeCursor = options.expectedResume ? { ...options.expectedResume } : undefined;
     this.now = options.now ?? Date.now;
     this.sleep = options.sleep ?? ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
     this.stoppedSignal = new Promise((resolve) => {

--- a/packages/daemon/src/broker/remote-read-down-session.ts
+++ b/packages/daemon/src/broker/remote-read-down-session.ts
@@ -12,10 +12,10 @@ import {
   assertChangeCache,
   defaultBackoff,
   defaultChangeCache,
-  RemoteReplicaResyncRequiredError,
   type ActiveSnapshot,
   type RemoteReadDownBackoff,
   type RemoteReadDownChangeCacheLimits,
+  type RemoteReadDownSessionHealth,
   type RemoteReadDownSessionOptions,
   type ResumeCursor
 } from "./remote-read-down-contract.ts";
@@ -25,20 +25,35 @@ import {
   assertCutChange,
   assertManifest,
   compareManifestPaths,
-  isIntegrityError,
-  isResyncError,
+  createActiveSnapshot,
   mapInBatches,
   pruneChanges,
   sameChangeIdentity,
-  storeCachedChange,
-  validateChanges
+  storeCachedChange
 } from "./remote-read-down-content.ts";
+import { fetchRemoteChanges } from "./remote-read-down-fetch.ts";
+import {
+  classifyRemoteReadDownFailure,
+  RemoteReadDownIntegrityError
+} from "./remote-read-down-failure.ts";
+import {
+  closeAndJoinRemoteReadDown,
+  deriveRemoteReadDownSessionHealth,
+  notifyRemoteReadDownListeners,
+  publishRemoteReadDownTerminal,
+  removeRemoteReadDownListeners,
+  registerRemoteReadDownListeners,
+  trackRemoteReadDownOperation
+} from "./remote-read-down-lifecycle.ts";
+import { createRemoteResyncError } from "./remote-read-down-state.ts";
+import { recoverRemoteSnapshot } from "./remote-read-down-recovery.ts";
 import type { CanonicalSnapshot } from "./types.ts";
 
 export {
   RemoteReplicaResyncRequiredError,
   type RemoteReadDownBackoff,
   type RemoteReadDownChangeCacheLimits,
+  type RemoteReadDownSessionHealth,
   type RemoteReadDownSessionOptions
 } from "./remote-read-down-contract.ts";
 
@@ -65,8 +80,8 @@ export class RemoteReadDownSession {
   private readonly changeEpochs = new WeakMap<ReplicaChangeRecord, string>();
   private readonly stoppedSignal: Promise<void>;
   private resolveStopped!: () => void;
-  private readonly removeNotificationListener: () => void;
-  private readonly removeDisconnectListener: () => void;
+  private removeNotificationListener: () => void = () => {};
+  private removeDisconnectListener: () => void = () => {};
 
   constructor(options: RemoteReadDownSessionOptions) {
     this.options = options;
@@ -82,12 +97,32 @@ export class RemoteReadDownSession {
     });
     assertBackoff(this.backoff);
     assertChangeCache(this.changeCache);
-    this.removeNotificationListener = options.client.onNotification((change) => this.receiveNotification(change));
-    this.removeDisconnectListener = options.client.onDisconnect(() => this.handleDisconnect());
+    const listeners = registerRemoteReadDownListeners(
+      options.client,
+      (change) => this.receiveNotification(change),
+      () => this.handleDisconnect()
+    );
+    this.removeNotificationListener = listeners.removeNotification;
+    this.removeDisconnectListener = listeners.removeDisconnect;
   }
 
   get workspaceId(): string {
     return this.options.workspaceId;
+  }
+
+  health(): RemoteReadDownSessionHealth {
+    return deriveRemoteReadDownSessionHealth({
+      terminal: this.terminalError,
+      stopped: this.stopped,
+      active: Boolean(this.active),
+      recovering: Boolean(this.recovery)
+    });
+  }
+
+  async refresh(): Promise<void> {
+    const active = this.active;
+    if (active) this.invalidateActive(active);
+    await this.ready();
   }
 
   subscribe(listener: (change: ReplicaChangeRecord) => void): () => void {
@@ -130,12 +165,12 @@ export class RemoteReadDownSession {
     if (active.resyncReason) {
       if (!active.resyncReported || revision < cutRevision) {
         active.resyncReported = true;
-        throw resyncError(active, active.resyncReason);
+        throw createRemoteResyncError(active, active.resyncReason);
       }
       active.resyncReason = undefined;
     }
     if (revision < cutRevision) {
-      throw resyncError(
+      throw createRemoteResyncError(
         active,
         `CURSOR_PRECEDES_PINNED_CUT:${revision}:${cutRevision}`,
       );
@@ -156,11 +191,14 @@ export class RemoteReadDownSession {
   private async readSnapshotAt(change: ReplicaChangeRecord): Promise<CanonicalSnapshot> {
     const active = await this.ready();
     if (change.workspaceId !== this.options.workspaceId) {
-      throw new Error("remote snapshot change belongs to another workspace");
+      throw new RemoteReadDownIntegrityError("remote snapshot change belongs to another workspace");
     }
     const observedEpoch = this.changeEpochs.get(change);
     if (observedEpoch && observedEpoch !== active.reservation.cut.epoch) {
-      throw resyncError(active, `CHANGE_EPOCH_MISMATCH:${observedEpoch}:${active.reservation.cut.epoch}`);
+      throw createRemoteResyncError(
+        active,
+        `CHANGE_EPOCH_MISMATCH:${observedEpoch}:${active.reservation.cut.epoch}`
+      );
     }
     const entries = await this.entriesAt(active, change);
     const orderedEntries = [...entries.values()].sort(compareManifestPaths);
@@ -189,25 +227,18 @@ export class RemoteReadDownSession {
     this.resolveStopped();
     this.renewalTask?.dispose();
     this.renewalTask = undefined;
-    this.removeNotificationListener();
-    this.removeDisconnectListener();
-    this.closeTask = this.finishClose();
+    removeRemoteReadDownListeners(
+      [this.removeNotificationListener, this.removeDisconnectListener],
+      this.options.onDiagnostic
+    );
+    this.closeTask = closeAndJoinRemoteReadDown(this.options.client, () => [
+      ...this.operations,
+      ...(this.recovery ? [this.recovery.promise] : []),
+      ...(this.notificationPump ? [this.notificationPump] : []),
+      ...(this.renewalOperation ? [this.renewalOperation] : []),
+      ...this.blobReader.pending()
+    ]);
     return this.closeTask;
-  }
-
-  private async finishClose(): Promise<void> {
-    await this.options.client.close();
-    for (;;) {
-      const pending = [
-        ...this.operations,
-        ...(this.recovery ? [this.recovery.promise] : []),
-        ...(this.notificationPump ? [this.notificationPump] : []),
-        ...(this.renewalOperation ? [this.renewalOperation] : []),
-        ...this.blobReader.pending()
-      ];
-      if (pending.length === 0) return;
-      await Promise.allSettled(pending);
-    }
   }
 
   private async ready(): Promise<ActiveSnapshot> {
@@ -231,39 +262,24 @@ export class RemoteReadDownSession {
   }
 
   private async recover(generation: number): Promise<ActiveSnapshot> {
-    let delay = this.backoff.initialMs;
-    let replaceConnection = this.resumeCursor !== undefined;
-    for (;;) {
-      try {
-        if (replaceConnection) {
-          await this.options.client.reconnect();
-        } else {
-          await this.options.client.connect();
-        }
-        this.assertRecoveryCurrent(generation);
-        const active = await this.openSnapshot(this.resumeCursor);
-        this.assertRecoveryCurrent(generation);
-        if (this.active) return this.active;
-        this.active = active;
-        this.scheduleRenewal(active);
-        this.queueNotificationPump();
-        return active;
-      } catch (error) {
-        if (this.stopped) throw readDownError(error);
-        if (generation !== this.lifecycleGeneration) {
-          throw new AuthorityTransportDisconnectedError("remote read-down recovery generation changed");
-        }
-        if (isIntegrityError(error)) {
-          this.terminalError = readDownError(error);
-          throw this.terminalError;
-        }
-        this.options.onDiagnostic?.(`remote read-down reconnect failed; retrying in ${delay}ms: ${readDownError(error).message}`);
-        await this.interruptibleSleep(delay);
-        this.assertRecoveryCurrent(generation);
-        delay = Math.min(this.backoff.maximumMs, Math.max(delay + 1, Math.ceil(delay * this.backoff.multiplier)));
-        replaceConnection = true;
-      }
-    }
+    const active = await recoverRemoteSnapshot({
+      resume: this.resumeCursor,
+      backoff: this.backoff,
+      connect: (replace) => replace
+        ? this.options.client.reconnect()
+        : this.options.client.connect(),
+      openSnapshot: (resume) => this.openSnapshot(resume),
+      assertCurrent: () => this.assertRecoveryCurrent(generation),
+      stopped: () => this.stopped,
+      sleep: (milliseconds) => this.interruptibleSleep(milliseconds),
+      terminal: (error) => this.setTerminal(error),
+      diagnostic: this.options.onDiagnostic
+    });
+    if (this.active) return this.active;
+    this.active = active;
+    this.scheduleRenewal(active);
+    this.queueNotificationPump();
+    return active;
   }
 
   private async openSnapshot(resume: ResumeCursor | undefined): Promise<ActiveSnapshot> {
@@ -279,8 +295,6 @@ export class RemoteReadDownSession {
     this.assertOpen();
     assertCutChange(reservation, cutChange);
     if (cutChange) this.changeEpochs.set(cutChange, reservation.cut.epoch);
-    const baseEntries = new Map(manifest.entries.map((entry) => [entry.path, entry]));
-    if (baseEntries.size !== manifest.entries.length) throw new Error("authority snapshot manifest contains duplicate paths");
     const uniqueDigests = [...new Set(manifest.entries.map((entry) => entry.blobDigest))];
     await mapInBatches(
       uniqueDigests,
@@ -288,59 +302,28 @@ export class RemoteReadDownSession {
       (blobDigest) => this.readBlobFromReservation(reservation, blobDigest)
     );
     this.assertOpen();
-    const sameEpoch = resume?.epoch === reservation.cut.epoch;
-    const canResume = Boolean(resume && sameEpoch && reservation.cut.revision <= resume.deliveredRevision);
-    const resyncReason = resume && !sameEpoch
-      ? `EPOCH_CHANGED:${resume.epoch}:${reservation.cut.epoch}`
-      : resume && !canResume
-        ? `CURSOR_PRECEDES_RECONNECTED_CUT:${resume.deliveredRevision}:${reservation.cut.revision}`
-        : undefined;
-    return {
-      reservation,
-      cutChange,
-      baseEntries,
-      changes: new Map(),
-      changeSizes: new Map(),
-      changeBytes: 0,
-      highestRevision: reservation.cut.revision,
-      durableCursor: reservation.cut.revision,
-      adopted: canResume || (!resume && reservation.cut.revision === 0),
-      deliveredRevision: canResume ? resume!.deliveredRevision : reservation.cut.revision,
-      ...(resyncReason ? { resyncReason } : {}),
-      resyncSignaled: false,
-      resyncReported: false
-    };
+    return createActiveSnapshot(reservation, manifest, cutChange, resume);
   }
 
   private async fetchAfter(active: ActiveSnapshot, revision: number): Promise<ReadonlyArray<ReplicaChangeRecord>> {
-    try {
-      this.assertCurrent(active);
-      const result = await this.options.client.changesAfter(active.reservation.stream.streamToken, revision);
-      this.assertCurrent(active);
-      validateChanges(result.changes, revision, this.options.workspaceId);
-      for (const change of result.changes) this.storeChange(active, change, false);
-      return result.changes;
-    } catch (error) {
-      if (this.stopped) throw readDownError(error);
-      if (isResyncError(error)) {
-        this.invalidateActive(active);
-        const next = await this.ready();
-        throw resyncError(next, error.message);
-      }
-      if (error instanceof AuthorityTransportDisconnectedError) {
-        this.invalidateActive(active);
-        const next = await this.ready();
-        if (next.resyncReason) throw resyncError(next, next.resyncReason);
-        if (revision < next.reservation.cut.revision) {
-          throw resyncError(
-            next,
-            `CURSOR_PRECEDES_RECONNECTED_CUT:${revision}:${next.reservation.cut.revision}`,
-          );
-        }
-        return this.fetchAfter(next, revision);
-      }
-      throw error;
-    }
+    return fetchRemoteChanges({
+      active,
+      revision,
+      workspaceId: this.options.workspaceId,
+      backoff: this.backoff,
+      request: (current, cursor) => this.options.client.changesAfter(
+        current.reservation.stream.streamToken,
+        cursor
+      ),
+      assertCurrent: (current) => this.assertCurrent(current),
+      storeChange: (current, change) => this.storeChange(current, change, false),
+      invalidate: (current) => {
+        this.invalidateActive(current);
+      },
+      ready: () => this.ready(),
+      sleep: (milliseconds) => this.interruptibleSleep(milliseconds),
+      stopped: () => this.stopped
+    });
   }
 
   private async entriesAt(
@@ -349,7 +332,7 @@ export class RemoteReadDownSession {
   ): Promise<ReadonlyMap<string, AuthoritySnapshotManifestEntry>> {
     const cut = active.reservation.cut;
     if (change.revision < cut.revision) {
-      throw resyncError(
+      throw createRemoteResyncError(
         active,
         `SNAPSHOT_PRECEDES_PINNED_CUT:${change.revision}:${cut.revision}`,
       );
@@ -359,18 +342,24 @@ export class RemoteReadDownSession {
       ? active.cutChange
       : active.changes.get(change.revision);
     if (!canonical || !sameChangeIdentity(canonical, change)) {
-      throw resyncError(active, `CHANGE_IDENTITY_MISMATCH:${change.revision}`);
+      throw createRemoteResyncError(active, `CHANGE_IDENTITY_MISMATCH:${change.revision}`);
     }
     const entries = new Map(active.baseEntries);
     for (let revision = cut.revision + 1; revision <= change.revision; revision += 1) {
       const next = active.changes.get(revision);
-      if (!next) throw new Error(`remote snapshot change gap at revision ${revision}`);
+      if (!next) {
+        throw new RemoteReadDownIntegrityError(`remote snapshot change gap at revision ${revision}`);
+      }
       applyChange(entries, next);
       assertChangeManifest(cut.epoch, next, entries);
     }
     if (change.revision === cut.revision) {
       const actual = manifestDigest(cut, [...entries.values()]);
-      if (actual !== change.manifest.digest) throw new Error(`MANIFEST_DIGEST_MISMATCH:${change.manifest.digest}:${actual}`);
+      if (actual !== change.manifest.digest) {
+        throw new RemoteReadDownIntegrityError(
+          `MANIFEST_DIGEST_MISMATCH:${change.manifest.digest}:${actual}`
+        );
+      }
     }
     return entries;
   }
@@ -394,9 +383,11 @@ export class RemoteReadDownSession {
     try {
       this.storeChange(active, change, true);
     } catch (error) {
-      this.terminalError = readDownError(error);
+      this.setTerminal(error);
       this.invalidateActive(active);
-      this.options.onDiagnostic?.(`remote read-down notification rejected: ${this.terminalError.message}`);
+      this.options.onDiagnostic?.(
+        `remote read-down notification rejected: ${this.terminalError!.message}`
+      );
       return;
     }
     this.queueNotificationPump();
@@ -406,6 +397,7 @@ export class RemoteReadDownSession {
     if (this.stopped) return;
     void this.pumpNotifications().catch((error) => {
       if (this.stopped) return;
+      if (classifyRemoteReadDownFailure(error) === "TERMINAL") this.setTerminal(error);
       this.options.onDiagnostic?.(`remote read-down notification pump stopped: ${readDownError(error).message}`);
     });
   }
@@ -478,7 +470,7 @@ export class RemoteReadDownSession {
     if (this.active !== active || this.stopped) return;
     try {
       if (this.now() >= Date.parse(active.reservation.lease.renewableUntil)) {
-        throw resyncError(
+        throw createRemoteResyncError(
           active,
           "LEASE_RENEWAL_LIMIT_REACHED",
         );
@@ -522,13 +514,7 @@ export class RemoteReadDownSession {
   private notifyListeners(change: ReplicaChangeRecord): void {
     const active = this.active;
     if (active) this.changeEpochs.set(change, active.reservation.cut.epoch);
-    for (const listener of this.listeners) {
-      try {
-        listener(change);
-      } catch (error) {
-        this.options.onDiagnostic?.(`remote read-down notification listener failed: ${readDownError(error).message}`);
-      }
-    }
+    notifyRemoteReadDownListeners(this.listeners, change, this.options.onDiagnostic);
   }
 
   private queueRecovery(description: string): void {
@@ -543,15 +529,19 @@ export class RemoteReadDownSession {
     });
   }
 
+  private setTerminal(error: unknown): Error {
+    this.terminalError = publishRemoteReadDownTerminal(
+      this.terminalError,
+      error,
+      this.options.onTerminal,
+      this.options.onDiagnostic
+    );
+    return this.terminalError;
+  }
+
   private runOperation<Value>(operation: () => Promise<Value>): Promise<Value> {
     if (this.stopped) return Promise.reject(new Error("remote read-down session is closed"));
-    const task = operation();
-    this.operations.add(task);
-    void task.then(
-      () => this.operations.delete(task),
-      () => this.operations.delete(task)
-    );
-    return task;
+    return trackRemoteReadDownOperation(this.operations, operation);
   }
 
   private async interruptibleSleep(milliseconds: number): Promise<void> {
@@ -582,10 +572,6 @@ export class RemoteReadDownSession {
 
 function highestKnownRevision(active: ActiveSnapshot): number {
   return active.highestRevision;
-}
-
-function resyncError(active: ActiveSnapshot, message: string): RemoteReplicaResyncRequiredError {
-  return new RemoteReplicaResyncRequiredError(message, active.reservation.cut, active.cutChange);
 }
 
 function readDownError(error: unknown): Error {

--- a/packages/daemon/src/broker/remote-read-down-state.ts
+++ b/packages/daemon/src/broker/remote-read-down-state.ts
@@ -1,0 +1,26 @@
+import {
+  RemoteReplicaResyncRequiredError,
+  type ActiveSnapshot,
+  type RemoteReadDownBackoff
+} from "./remote-read-down-contract.ts";
+
+export function createRemoteResyncError(
+  active: ActiveSnapshot,
+  message: string
+): RemoteReplicaResyncRequiredError {
+  return new RemoteReplicaResyncRequiredError(
+    message,
+    active.reservation.cut,
+    active.cutChange
+  );
+}
+
+export function advanceRemoteReadDownBackoff(
+  delay: number,
+  backoff: RemoteReadDownBackoff
+): number {
+  return Math.min(
+    backoff.maximumMs,
+    Math.max(delay + 1, Math.ceil(delay * backoff.multiplier))
+  );
+}

--- a/packages/daemon/src/broker/replica-broker-barrier.ts
+++ b/packages/daemon/src/broker/replica-broker-barrier.ts
@@ -1,0 +1,80 @@
+import { normalizeRelativeDocumentPath } from "@harness-anything/kernel";
+import {
+  fingerprintDigest,
+  fingerprintPath,
+  sameFingerprint
+} from "./fingerprint.ts";
+import type {
+  BrokerBarrierRequest,
+  BrokerBarrierResult,
+  BrokerDurableState,
+  ManagedFingerprint,
+  MaterializationWitness,
+  WatcherFence,
+  WriterExclusion
+} from "./types.ts";
+
+export async function runBrokerBarrier(
+  request: BrokerBarrierRequest,
+  ports: {
+    readonly current: () => BrokerDurableState;
+    readonly persist: (state: BrokerDurableState) => Promise<void>;
+    readonly visiblePath: (pathName: string) => string;
+    readonly writerExclusion: WriterExclusion | undefined;
+    readonly watcherFence: WatcherFence | undefined;
+  }
+): Promise<BrokerBarrierResult> {
+  const current = ports.current();
+  if (current.mode === "RESYNC_REQUIRED") return { tag: "RESYNC_REQUIRED" };
+  if (request.targetRevision !== undefined && current.resolvedCursor < request.targetRevision) {
+    return { tag: "TIMEOUT", resolvedCursor: current.resolvedCursor };
+  }
+  const selected = request.paths
+    ? request.paths.map((item) => normalizeRelativeDocumentPath(item)).sort()
+    : Object.keys(current.paths).sort();
+  const statuses = selected.map((item) => [item, current.paths[item]?.status] as const);
+  const conflicts = statuses.filter(([, status]) => status === "CONFLICT").map(([item]) => item);
+  if (conflicts.length) return { tag: "LOCAL_CONFLICT", paths: conflicts };
+  const blocked = statuses.filter(([, status]) => status === "APPLY_BLOCKED").map(([item]) => item);
+  if (blocked.length) return { tag: "APPLY_BLOCKED", paths: blocked };
+  const dirty = statuses.filter(([, status]) => status !== "CLEAN").map(([item]) => item);
+  if (dirty.length) return { tag: "DIRTY", paths: dirty };
+  if (!ports.writerExclusion || !ports.watcherFence) return { tag: "NONQUIESCENT" };
+  const lease = await ports.writerExclusion.acquire(selected);
+  if (!lease) return { tag: "NONQUIESCENT" };
+  try {
+    const fingerprints: Record<string, ManagedFingerprint> = {};
+    for (const pathName of selected) {
+      const observed = await fingerprintPath(ports.visiblePath(pathName));
+      const expected = ports.current().paths[pathName]?.canonicalHidden.fingerprint;
+      if (!expected || !sameFingerprint(observed, expected)) {
+        return { tag: "DIRTY", paths: [pathName] };
+      }
+      fingerprints[pathName] = observed;
+    }
+    const watcherFenceVector = await ports.watcherFence.fence(selected);
+    if (JSON.stringify(Object.keys(watcherFenceVector).sort()) !== JSON.stringify(selected)) {
+      throw new Error("BROKER_WATCHER_FENCE_SET_MISMATCH");
+    }
+    const state = ports.current();
+    const cutId = `cut-${state.epoch}-${state.resolvedCursor}-${state.nextJournalLSN}`;
+    const witness: MaterializationWitness = {
+      cutId,
+      selectedDigest: fingerprintDigest(selected),
+      cutKind: "HISTORICAL_EXCLUDED_SET",
+      epoch: state.epoch,
+      revision: state.resolvedCursor,
+      fingerprints,
+      watcherFenceVector,
+      journalLSN: state.nextJournalLSN
+    };
+    await ports.persist({
+      ...state,
+      nextJournalLSN: state.nextJournalLSN + 1,
+      witnesses: { ...state.witnesses, [cutId]: witness }
+    });
+    return { tag: "SATISFIED_EXACT_AT_CUT", witness };
+  } finally {
+    await lease.release();
+  }
+}

--- a/packages/daemon/src/broker/replica-broker-state.ts
+++ b/packages/daemon/src/broker/replica-broker-state.ts
@@ -4,9 +4,22 @@ import type { ConflictReason } from "./conflict-store.ts";
 import { sameFingerprint, tombstoneFingerprint } from "./fingerprint.ts";
 import type {
   BrokerPathState,
+  BrokerResyncTarget,
   BrokerVersion,
   ManagedFingerprint
 } from "./types.ts";
+
+export const maxRemoteResyncTransitionsPerSynchronization = 3;
+
+export function sameResyncTarget(
+  left: BrokerResyncTarget | undefined,
+  right: BrokerResyncTarget
+): boolean {
+  return left?.epoch === right.epoch
+    && left.revision === right.revision
+    && left.commitSha === right.commitSha
+    && JSON.stringify(left.cutChange) === JSON.stringify(right.cutChange);
+}
 
 export function versionFor(
   change: ReplicaChangeRecord | null,

--- a/packages/daemon/src/broker/replica-broker-state.ts
+++ b/packages/daemon/src/broker/replica-broker-state.ts
@@ -3,11 +3,13 @@ import { replicaChangeOperationIdsForPath } from "../authority/replica-change-op
 import type { ConflictReason } from "./conflict-store.ts";
 import { sameFingerprint, tombstoneFingerprint } from "./fingerprint.ts";
 import type {
+  BrokerDurableState,
   BrokerPathState,
   BrokerResyncTarget,
   BrokerVersion,
   ManagedFingerprint
 } from "./types.ts";
+import { BrokerReplicaIntegrityError } from "./broker-errors.ts";
 
 export const maxRemoteResyncTransitionsPerSynchronization = 3;
 
@@ -19,6 +21,16 @@ export function sameResyncTarget(
     && left.revision === right.revision
     && left.commitSha === right.commitSha
     && JSON.stringify(left.cutChange) === JSON.stringify(right.cutChange);
+}
+
+export function requireResyncTarget(
+  state: BrokerDurableState,
+  remoteTerminal: boolean
+): BrokerResyncTarget | undefined {
+  if (state.resyncTarget || !remoteTerminal) return state.resyncTarget;
+  throw new BrokerReplicaIntegrityError(
+    "remote broker has a durable targetless RESYNC state"
+  );
 }
 
 export function versionFor(

--- a/packages/daemon/src/broker/replica-broker-state.ts
+++ b/packages/daemon/src/broker/replica-broker-state.ts
@@ -1,0 +1,69 @@
+import type { ReplicaChangeRecord } from "@harness-anything/application";
+import { replicaChangeOperationIdsForPath } from "../authority/replica-change-operation-paths.ts";
+import type { ConflictReason } from "./conflict-store.ts";
+import { sameFingerprint, tombstoneFingerprint } from "./fingerprint.ts";
+import type {
+  BrokerPathState,
+  BrokerVersion,
+  ManagedFingerprint
+} from "./types.ts";
+
+export function versionFor(
+  change: ReplicaChangeRecord | null,
+  pathName: string,
+  fingerprint: ManagedFingerprint,
+  epoch: string,
+  revision: number,
+  commitSha: string
+): BrokerVersion {
+  const operationIds = change ? replicaChangeOperationIdsForPath(change, pathName) : [];
+  return {
+    epoch,
+    revision,
+    lastChangeOpIds: operationIds,
+    lastChangeOpId: operationIds[0] ?? null,
+    commitSha,
+    fingerprint
+  };
+}
+
+export function localTombstone(epoch: string): BrokerVersion {
+  return {
+    epoch,
+    revision: 0,
+    lastChangeOpIds: [],
+    lastChangeOpId: null,
+    commitSha: null,
+    fingerprint: tombstoneFingerprint()
+  };
+}
+
+export function sameVersion(left: BrokerVersion, right: BrokerVersion): boolean {
+  return left.epoch === right.epoch
+    && left.revision === right.revision
+    && JSON.stringify(versionOperationIds(left)) === JSON.stringify(versionOperationIds(right))
+    && left.commitSha === right.commitSha
+    && sameFingerprint(left.fingerprint, right.fingerprint);
+}
+
+export function versionOperationIds(version: BrokerVersion): ReadonlyArray<string> {
+  return version.lastChangeOpIds
+    ?? (version.lastChangeOpId === null ? [] : [version.lastChangeOpId]);
+}
+
+export function mapConflictReason(reason: string): ConflictReason {
+  return reason === "RECOVERY_GENERATION_AMBIGUOUS"
+    ? "RECOVERY_GENERATION_AMBIGUOUS"
+    : "PRECHECK_FINGERPRINT_MISMATCH";
+}
+
+export function isSubmittableDraft(pathState: BrokerPathState): boolean {
+  return hasPathStatus(pathState, "DIRTY") || hasPathStatus(pathState, "LOCAL_ONLY");
+}
+
+export function hasPathStatus(
+  pathState: BrokerPathState,
+  expected: BrokerPathState["status"]
+): boolean {
+  return pathState.status === expected;
+}

--- a/packages/daemon/src/broker/replica-broker.ts
+++ b/packages/daemon/src/broker/replica-broker.ts
@@ -6,6 +6,10 @@ import {
   normalizeRelativeDocumentPath
 } from "@harness-anything/kernel";
 import { BrokerCasStore } from "./cas-store.ts";
+import {
+  BrokerReplicaIntegrityError,
+  BrokerSubmitPreflightError
+} from "./broker-errors.ts";
 import { LocalConflictStore, type ConflictReason } from "./conflict-store.ts";
 import { BrokerDurableStateStore } from "./durable-state-store.ts";
 import {
@@ -22,6 +26,8 @@ import {
   isSubmittableDraft,
   localTombstone,
   mapConflictReason,
+  maxRemoteResyncTransitionsPerSynchronization,
+  sameResyncTarget,
   sameVersion,
   versionFor,
   versionOperationIds
@@ -47,6 +53,7 @@ export class ReplicaBroker {
   private readonly cas: BrokerCasStore;
   private readonly applier: CrashSafeNativeApplier;
   private state: BrokerDurableState | undefined;
+  private synchronizationTask: Promise<BrokerDurableState> | undefined;
 
   constructor(options: BrokerOptions) {
     this.options = options;
@@ -67,8 +74,23 @@ export class ReplicaBroker {
     return this.snapshotState();
   }
 
-  async synchronize(): Promise<BrokerDurableState> {
+  synchronize(): Promise<BrokerDurableState> {
+    if (this.synchronizationTask) return this.synchronizationTask;
+    const task = this.synchronizeExclusive();
+    this.synchronizationTask = task;
+    void task.then(
+      () => {
+        if (this.synchronizationTask === task) this.synchronizationTask = undefined;
+      },
+      () => {
+        if (this.synchronizationTask === task) this.synchronizationTask = undefined;
+      }
+    );
+    return task;
+  }
+  private async synchronizeExclusive(): Promise<BrokerDurableState> {
     await this.ensureInitialized();
+    let remoteResyncTransitions = 0;
     for (;;) {
       try {
         if (this.current().mode === "RESYNC_REQUIRED") {
@@ -89,7 +111,11 @@ export class ReplicaBroker {
         return this.snapshotState();
       } catch (error) {
         if (!(error instanceof RemoteReplicaResyncRequiredError)) throw error;
-        await this.enterRemoteResync(error);
+        remoteResyncTransitions += 1;
+        const advanced = await this.enterRemoteResync(error);
+        if (!advanced || remoteResyncTransitions >= maxRemoteResyncTransitionsPerSynchronization) {
+          throw error;
+        }
       }
     }
   }
@@ -294,6 +320,11 @@ export class ReplicaBroker {
     if (change.workspaceId !== this.options.workspaceId
       || change.revision !== current.receivedCursor + 1
       || change.previousCommit !== current.receivedCommit) {
+      if (this.options.replicaGapPolicy === "TERMINAL") {
+        throw new BrokerReplicaIntegrityError(
+          `replica change gap or parent mismatch at revision ${change.revision}`
+        );
+      }
       await this.enterResync();
       throw new Error(`replica change gap or parent mismatch at revision ${change.revision}`);
     }
@@ -483,7 +514,7 @@ export class ReplicaBroker {
     await this.persist({ ...this.current(), mode: "RESYNC_REQUIRED" });
   }
 
-  private async enterRemoteResync(error: RemoteReplicaResyncRequiredError): Promise<void> {
+  private async enterRemoteResync(error: RemoteReplicaResyncRequiredError): Promise<boolean> {
     const { cut, cutChange } = error;
     if (cut.workspaceId !== this.options.workspaceId
       || (cutChange !== null && (cutChange.workspaceId !== this.options.workspaceId
@@ -499,12 +530,14 @@ export class ReplicaBroker {
       cutChange
     };
     const current = this.current();
+    if (sameResyncTarget(current.resyncTarget, resyncTarget)) return false;
     await this.persist({
       ...current,
       mode: "RESYNC_REQUIRED",
       resyncTarget,
       nextJournalLSN: current.nextJournalLSN + 1
     });
+    return true;
   }
 
   private async bootstrapResync(): Promise<void> {
@@ -562,17 +595,5 @@ export class ReplicaBroker {
 
   private visiblePath(pathName: string): string {
     return path.join(this.options.viewRoot, ...pathName.split("/"));
-  }
-}
-
-export class BrokerSubmitPreflightError extends Error {
-  readonly path: string;
-  readonly status: string;
-
-  constructor(pathName: string, status: string, message: string) {
-    super(`${message}: ${pathName} (${status})`);
-    this.name = "BrokerSubmitPreflightError";
-    this.path = pathName;
-    this.status = status;
   }
 }

--- a/packages/daemon/src/broker/replica-broker.ts
+++ b/packages/daemon/src/broker/replica-broker.ts
@@ -10,16 +10,17 @@ import {
   BrokerReplicaIntegrityError,
   BrokerSubmitPreflightError
 } from "./broker-errors.ts";
+import { BrokerOperationLatch } from "./broker-operation-latch.ts";
 import { LocalConflictStore, type ConflictReason } from "./conflict-store.ts";
 import { BrokerDurableStateStore } from "./durable-state-store.ts";
 import {
   fingerprintBytes,
-  fingerprintDigest,
   fingerprintPath,
   sameFingerprint,
   tombstoneFingerprint
 } from "./fingerprint.ts";
 import { CrashSafeNativeApplier } from "./native-applier.ts";
+import { runBrokerBarrier } from "./replica-broker-barrier.ts";
 import { RemoteReplicaResyncRequiredError } from "./remote-read-down-session.ts";
 import {
   hasPathStatus,
@@ -27,6 +28,7 @@ import {
   localTombstone,
   mapConflictReason,
   maxRemoteResyncTransitionsPerSynchronization,
+  requireResyncTarget,
   sameResyncTarget,
   sameVersion,
   versionFor,
@@ -42,7 +44,6 @@ import type {
   BrokerVersion,
   CanonicalSnapshot,
   ManagedFingerprint,
-  MaterializationWitness,
   PendingMaterialization
 } from "./types.ts";
 
@@ -52,8 +53,8 @@ export class ReplicaBroker {
   private readonly store: BrokerDurableStateStore;
   private readonly cas: BrokerCasStore;
   private readonly applier: CrashSafeNativeApplier;
+  private readonly operations = new BrokerOperationLatch();
   private state: BrokerDurableState | undefined;
-  private synchronizationTask: Promise<BrokerDurableState> | undefined;
 
   constructor(options: BrokerOptions) {
     this.options = options;
@@ -68,25 +69,19 @@ export class ReplicaBroker {
     });
   }
 
-  async initialize(): Promise<BrokerDurableState> {
+  initialize(): Promise<BrokerDurableState> {
+    return this.operations.run(() => this.initializeExclusive());
+  }
+
+  private async initializeExclusive(): Promise<BrokerDurableState> {
+    if (this.state) return this.snapshotState();
     this.state = await this.store.initialize(this.options.workspaceId);
     await this.materializePending();
     return this.snapshotState();
   }
 
   synchronize(): Promise<BrokerDurableState> {
-    if (this.synchronizationTask) return this.synchronizationTask;
-    const task = this.synchronizeExclusive();
-    this.synchronizationTask = task;
-    void task.then(
-      () => {
-        if (this.synchronizationTask === task) this.synchronizationTask = undefined;
-      },
-      () => {
-        if (this.synchronizationTask === task) this.synchronizationTask = undefined;
-      }
-    );
-    return task;
+    return this.operations.run(() => this.synchronizeExclusive());
   }
   private async synchronizeExclusive(): Promise<BrokerDurableState> {
     await this.ensureInitialized();
@@ -94,7 +89,10 @@ export class ReplicaBroker {
     for (;;) {
       try {
         if (this.current().mode === "RESYNC_REQUIRED") {
-          if (!this.current().resyncTarget) return this.snapshotState();
+          if (!requireResyncTarget(
+            this.current(),
+            this.options.replicaGapPolicy === "TERMINAL"
+          )) return this.snapshotState();
           await this.bootstrapResync();
         }
         while (this.current().resolvedCursor < this.current().receivedCursor) {
@@ -120,15 +118,25 @@ export class ReplicaBroker {
     }
   }
 
-  async onNotification(change: ReplicaChangeRecord): Promise<BrokerDurableState> {
+  onNotification(change: ReplicaChangeRecord): Promise<BrokerDurableState> {
+    return this.operations.run(() => this.onNotificationExclusive(change));
+  }
+
+  private async onNotificationExclusive(
+    change: ReplicaChangeRecord
+  ): Promise<BrokerDurableState> {
     await this.ensureInitialized();
     if (change.workspaceId !== this.options.workspaceId) throw new Error("replica notification belongs to another workspace");
     // Notifications are lossy hints. The durable ReplicaChangeLog query in
     // synchronize(), not the notification body, is the authoritative stream.
-    return this.synchronize();
+    return this.synchronizeExclusive();
   }
 
-  async recordLocalChange(pathName: string): Promise<BrokerPathState> {
+  recordLocalChange(pathName: string): Promise<BrokerPathState> {
+    return this.operations.run(() => this.recordLocalChangeExclusive(pathName));
+  }
+
+  private async recordLocalChangeExclusive(pathName: string): Promise<BrokerPathState> {
     await this.ensureInitialized();
     const safePath = normalizeRelativeDocumentPath(pathName);
     const current = this.current();
@@ -154,7 +162,16 @@ export class ReplicaBroker {
     return structuredClone(nextPath);
   }
 
-  async prepareSubmission(pathName: string, opId: string): Promise<{
+  prepareSubmission(pathName: string, opId: string): Promise<{
+    readonly path: string;
+    readonly content: Buffer;
+    readonly contentFingerprint: ManagedFingerprint;
+    readonly overlayBase: BrokerVersion | null;
+  }> {
+    return this.operations.run(() => this.prepareSubmissionExclusive(pathName, opId));
+  }
+
+  private async prepareSubmissionExclusive(pathName: string, opId: string): Promise<{
     readonly path: string;
     readonly content: Buffer;
     readonly contentFingerprint: ManagedFingerprint;
@@ -187,11 +204,20 @@ export class ReplicaBroker {
     return { path: safePath, content, contentFingerprint: observed, overlayBase: pathState.overlayBase ?? pathState.visibleBase };
   }
 
-  async markSubmissionUnknown(pathName: string, opId: string): Promise<void> {
-    await this.updatePendingStatus(pathName, opId, "PENDING_UNKNOWN");
+  markSubmissionUnknown(pathName: string, opId: string): Promise<void> {
+    return this.operations.run(
+      () => this.updatePendingStatus(pathName, opId, "PENDING_UNKNOWN")
+    );
   }
 
-  async markSubmissionRetryable(pathName: string, opId: string): Promise<void> {
+  markSubmissionRetryable(pathName: string, opId: string): Promise<void> {
+    return this.operations.run(() => this.markSubmissionRetryableExclusive(pathName, opId));
+  }
+
+  private async markSubmissionRetryableExclusive(
+    pathName: string,
+    opId: string
+  ): Promise<void> {
     await this.ensureInitialized();
     const safePath = normalizeRelativeDocumentPath(pathName);
     const current = this.current();
@@ -204,7 +230,21 @@ export class ReplicaBroker {
     });
   }
 
-  async returnRejectedSubmission(pathName: string, opId: string, authorityReason: string): Promise<string> {
+  returnRejectedSubmission(
+    pathName: string,
+    opId: string,
+    authorityReason: string
+  ): Promise<string> {
+    return this.operations.run(
+      () => this.returnRejectedSubmissionExclusive(pathName, opId, authorityReason)
+    );
+  }
+
+  private async returnRejectedSubmissionExclusive(
+    pathName: string,
+    opId: string,
+    authorityReason: string
+  ): Promise<string> {
     await this.ensureInitialized();
     const safePath = normalizeRelativeDocumentPath(pathName);
     const current = this.current();
@@ -259,60 +299,21 @@ export class ReplicaBroker {
     return structuredClone(this.current());
   }
 
-  async barrier(request: BrokerBarrierRequest = {}): Promise<BrokerBarrierResult> {
+  barrier(request: BrokerBarrierRequest = {}): Promise<BrokerBarrierResult> {
+    return this.operations.run(() => this.barrierExclusive(request));
+  }
+
+  private async barrierExclusive(
+    request: BrokerBarrierRequest
+  ): Promise<BrokerBarrierResult> {
     await this.ensureInitialized();
-    const current = this.current();
-    if (current.mode === "RESYNC_REQUIRED") return { tag: "RESYNC_REQUIRED" };
-    if (request.targetRevision !== undefined && current.resolvedCursor < request.targetRevision) {
-      return { tag: "TIMEOUT", resolvedCursor: current.resolvedCursor };
-    }
-    const selected = request.paths
-      ? request.paths.map((item) => normalizeRelativeDocumentPath(item)).sort()
-      : Object.keys(current.paths).sort();
-    const statuses = selected.map((item) => [item, current.paths[item]?.status] as const);
-    const conflicts = statuses.filter(([, status]) => status === "CONFLICT").map(([item]) => item);
-    if (conflicts.length) return { tag: "LOCAL_CONFLICT", paths: conflicts };
-    const blocked = statuses.filter(([, status]) => status === "APPLY_BLOCKED").map(([item]) => item);
-    if (blocked.length) return { tag: "APPLY_BLOCKED", paths: blocked };
-    const dirty = statuses.filter(([, status]) => status !== "CLEAN").map(([item]) => item);
-    if (dirty.length) return { tag: "DIRTY", paths: dirty };
-    if (!this.options.writerExclusion || !this.options.watcherFence) return { tag: "NONQUIESCENT" };
-    const lease = await this.options.writerExclusion.acquire(selected);
-    if (!lease) return { tag: "NONQUIESCENT" };
-    try {
-      const fingerprints: Record<string, ManagedFingerprint> = {};
-      for (const pathName of selected) {
-        const observed = await fingerprintPath(this.visiblePath(pathName));
-        const expected = this.current().paths[pathName]?.canonicalHidden.fingerprint;
-        if (!expected || !sameFingerprint(observed, expected)) return { tag: "DIRTY", paths: [pathName] };
-        fingerprints[pathName] = observed;
-      }
-      const watcherFenceVector = await this.options.watcherFence.fence(selected);
-      const fencedPaths = Object.keys(watcherFenceVector).sort();
-      if (JSON.stringify(fencedPaths) !== JSON.stringify(selected)) {
-        throw new Error("BROKER_WATCHER_FENCE_SET_MISMATCH");
-      }
-      const state = this.current();
-      const cutId = `cut-${state.epoch}-${state.resolvedCursor}-${state.nextJournalLSN}`;
-      const witness: MaterializationWitness = {
-        cutId,
-        selectedDigest: fingerprintDigest(selected),
-        cutKind: "HISTORICAL_EXCLUDED_SET",
-        epoch: state.epoch,
-        revision: state.resolvedCursor,
-        fingerprints,
-        watcherFenceVector,
-        journalLSN: state.nextJournalLSN
-      };
-      await this.persist({
-        ...state,
-        nextJournalLSN: state.nextJournalLSN + 1,
-        witnesses: { ...state.witnesses, [cutId]: witness }
-      });
-      return { tag: "SATISFIED_EXACT_AT_CUT", witness };
-    } finally {
-      await lease.release();
-    }
+    return runBrokerBarrier(request, {
+      current: () => this.current(),
+      persist: (state) => this.persist(state),
+      visiblePath: (pathName) => this.visiblePath(pathName),
+      writerExclusion: this.options.writerExclusion,
+      watcherFence: this.options.watcherFence
+    });
   }
 
   private async receiveChange(change: ReplicaChangeRecord): Promise<void> {
@@ -590,9 +591,8 @@ export class ReplicaBroker {
   }
 
   private async ensureInitialized(): Promise<void> {
-    if (!this.state) await this.initialize();
+    if (!this.state) await this.initializeExclusive();
   }
-
   private visiblePath(pathName: string): string {
     return path.join(this.options.viewRoot, ...pathName.split("/"));
   }

--- a/packages/daemon/src/broker/replica-broker.ts
+++ b/packages/daemon/src/broker/replica-broker.ts
@@ -15,14 +15,24 @@ import {
   sameFingerprint,
   tombstoneFingerprint
 } from "./fingerprint.ts";
-import { replicaChangeOperationIdsForPath } from "../authority/replica-change-operation-paths.ts";
 import { CrashSafeNativeApplier } from "./native-applier.ts";
+import { RemoteReplicaResyncRequiredError } from "./remote-read-down-session.ts";
+import {
+  hasPathStatus,
+  isSubmittableDraft,
+  localTombstone,
+  mapConflictReason,
+  sameVersion,
+  versionFor,
+  versionOperationIds
+} from "./replica-broker-state.ts";
 import type {
   BrokerBarrierRequest,
   BrokerBarrierResult,
   BrokerDurableState,
   BrokerOptions,
   BrokerPathState,
+  BrokerResyncTarget,
   BrokerVersion,
   CanonicalSnapshot,
   ManagedFingerprint,
@@ -59,19 +69,29 @@ export class ReplicaBroker {
 
   async synchronize(): Promise<BrokerDurableState> {
     await this.ensureInitialized();
-    if (this.current().mode === "RESYNC_REQUIRED") return this.snapshotState();
-    while (this.current().resolvedCursor < this.current().receivedCursor) {
-      await this.resolveChange(await this.store.readInbox(this.current().resolvedCursor + 1));
+    for (;;) {
+      try {
+        if (this.current().mode === "RESYNC_REQUIRED") {
+          if (!this.current().resyncTarget) return this.snapshotState();
+          await this.bootstrapResync();
+        }
+        while (this.current().resolvedCursor < this.current().receivedCursor) {
+          await this.resolveChange(await this.store.readInbox(this.current().resolvedCursor + 1));
+        }
+        const changes = await this.options.replicaChangeLog.changesAfter(
+          this.options.workspaceId,
+          this.current().receivedCursor
+        );
+        for (const change of changes) {
+          await this.receiveChange(change);
+          await this.resolveChange(change);
+        }
+        return this.snapshotState();
+      } catch (error) {
+        if (!(error instanceof RemoteReplicaResyncRequiredError)) throw error;
+        await this.enterRemoteResync(error);
+      }
     }
-    const changes = await this.options.replicaChangeLog.changesAfter(
-      this.options.workspaceId,
-      this.current().receivedCursor
-    );
-    for (const change of changes) {
-      await this.receiveChange(change);
-      await this.resolveChange(change);
-    }
-    return this.snapshotState();
   }
 
   async onNotification(change: ReplicaChangeRecord): Promise<BrokerDurableState> {
@@ -289,6 +309,15 @@ export class ReplicaBroker {
   private async resolveChange(change: ReplicaChangeRecord): Promise<void> {
     const snapshot = await this.options.snapshotSource.snapshotAt(change);
     this.validateSnapshot(snapshot, change.revision, change.commitSha);
+    await this.resolveSnapshot(snapshot, change, this.current().epoch, false);
+  }
+
+  private async resolveSnapshot(
+    snapshot: CanonicalSnapshot,
+    change: ReplicaChangeRecord | null,
+    epoch: string,
+    resync: boolean
+  ): Promise<void> {
     const entries = new Map<string, { readonly fingerprint: ManagedFingerprint; readonly bytes: Uint8Array }>();
     const normalizedPaths: string[] = [];
     for (const entry of snapshot.entries) {
@@ -307,8 +336,12 @@ export class ReplicaBroker {
     for (const pathName of [...allPaths].sort()) {
       const old = current.paths[pathName];
       const targetFingerprint = entries.get(pathName)?.fingerprint ?? tombstoneFingerprint();
-      const changed = !old || !sameFingerprint(old.canonicalHidden.fingerprint, targetFingerprint);
-      const target = changed ? versionFor(change, pathName, targetFingerprint) : old.canonicalHidden;
+      const changed = !old
+        || old.canonicalHidden.epoch !== epoch
+        || !sameFingerprint(old.canonicalHidden.fingerprint, targetFingerprint);
+      const target = changed
+        ? versionFor(change, pathName, targetFingerprint, epoch, snapshot.revision, snapshot.commitSha)
+        : old.canonicalHidden;
       if (!old) {
         paths[pathName] = {
           canonicalHidden: target,
@@ -324,8 +357,11 @@ export class ReplicaBroker {
     }
     await this.persist({
       ...current,
-      resolvedCursor: change.revision,
-      resolvedCommit: change.commitSha,
+      epoch,
+      receivedCursor: resync ? snapshot.revision : current.receivedCursor,
+      receivedCommit: resync ? snapshot.commitSha : current.receivedCommit,
+      resolvedCursor: snapshot.revision,
+      resolvedCommit: snapshot.commitSha,
       nextJournalLSN: current.nextJournalLSN + 1,
       paths,
       pendingMaterializations: [...current.pendingMaterializations, ...pending]
@@ -447,6 +483,52 @@ export class ReplicaBroker {
     await this.persist({ ...this.current(), mode: "RESYNC_REQUIRED" });
   }
 
+  private async enterRemoteResync(error: RemoteReplicaResyncRequiredError): Promise<void> {
+    const { cut, cutChange } = error;
+    if (cut.workspaceId !== this.options.workspaceId
+      || (cutChange !== null && (cutChange.workspaceId !== this.options.workspaceId
+        || cutChange.revision !== cut.revision
+        || cutChange.commitSha !== cut.commitSha))
+      || (cut.revision > 0 && !cutChange)) {
+      throw new Error("remote resync cut identity does not match broker workspace");
+    }
+    const resyncTarget: BrokerResyncTarget = {
+      epoch: cut.epoch,
+      revision: cut.revision,
+      commitSha: cut.commitSha,
+      cutChange
+    };
+    const current = this.current();
+    await this.persist({
+      ...current,
+      mode: "RESYNC_REQUIRED",
+      resyncTarget,
+      nextJournalLSN: current.nextJournalLSN + 1
+    });
+  }
+
+  private async bootstrapResync(): Promise<void> {
+    const target = this.current().resyncTarget;
+    if (!target) return;
+    const snapshot: CanonicalSnapshot = target.cutChange
+      ? await this.options.snapshotSource.snapshotAt(target.cutChange)
+      : {
+          workspaceId: this.options.workspaceId,
+          revision: target.revision,
+          commitSha: target.commitSha,
+          entries: []
+        };
+    this.validateSnapshot(snapshot, target.revision, target.commitSha);
+    await this.resolveSnapshot(snapshot, target.cutChange, target.epoch, true);
+    const current = this.current();
+    await this.persist({
+      ...current,
+      mode: "READY",
+      resyncTarget: undefined,
+      nextJournalLSN: current.nextJournalLSN + 1
+    });
+  }
+
   private async updatePendingStatus(
     pathName: string,
     opId: string,
@@ -493,58 +575,4 @@ export class BrokerSubmitPreflightError extends Error {
     this.path = pathName;
     this.status = status;
   }
-}
-
-function versionFor(
-  change: ReplicaChangeRecord,
-  pathName: string,
-  fingerprint: ManagedFingerprint
-): BrokerVersion {
-  const operationIds = replicaChangeOperationIdsForPath(change, pathName);
-  return {
-    epoch: "epoch-1",
-    revision: change.revision,
-    lastChangeOpIds: operationIds,
-    lastChangeOpId: operationIds[0] ?? null,
-    commitSha: change.commitSha,
-    fingerprint
-  };
-}
-
-function localTombstone(epoch: string): BrokerVersion {
-  return {
-    epoch,
-    revision: 0,
-    lastChangeOpIds: [],
-    lastChangeOpId: null,
-    commitSha: null,
-    fingerprint: tombstoneFingerprint()
-  };
-}
-
-function sameVersion(left: BrokerVersion, right: BrokerVersion): boolean {
-  return left.epoch === right.epoch
-    && left.revision === right.revision
-    && JSON.stringify(versionOperationIds(left)) === JSON.stringify(versionOperationIds(right))
-    && left.commitSha === right.commitSha
-    && sameFingerprint(left.fingerprint, right.fingerprint);
-}
-
-function versionOperationIds(version: BrokerVersion): ReadonlyArray<string> {
-  return version.lastChangeOpIds
-    ?? (version.lastChangeOpId === null ? [] : [version.lastChangeOpId]);
-}
-
-function mapConflictReason(reason: string): ConflictReason {
-  return reason === "RECOVERY_GENERATION_AMBIGUOUS"
-    ? "RECOVERY_GENERATION_AMBIGUOUS"
-    : "PRECHECK_FINGERPRINT_MISMATCH";
-}
-
-function isSubmittableDraft(pathState: BrokerPathState): boolean {
-  return hasPathStatus(pathState, "DIRTY") || hasPathStatus(pathState, "LOCAL_ONLY");
-}
-
-function hasPathStatus(pathState: BrokerPathState, expected: BrokerPathState["status"]): boolean {
-  return pathState.status === expected;
 }

--- a/packages/daemon/src/broker/types.ts
+++ b/packages/daemon/src/broker/types.ts
@@ -72,9 +72,17 @@ export interface BrokerDurableState {
   readonly resolvedCommit: string | null;
   readonly nextJournalLSN: number;
   readonly mode: "READY" | "RESYNC_REQUIRED";
+  readonly resyncTarget?: BrokerResyncTarget;
   readonly paths: Readonly<Record<string, BrokerPathState>>;
   readonly pendingMaterializations: ReadonlyArray<PendingMaterialization>;
   readonly witnesses: Readonly<Record<string, MaterializationWitness>>;
+}
+
+export interface BrokerResyncTarget {
+  readonly epoch: string;
+  readonly revision: number;
+  readonly commitSha: string;
+  readonly cutChange: ReplicaChangeRecord | null;
 }
 
 export interface CanonicalSnapshotEntry {

--- a/packages/daemon/src/broker/types.ts
+++ b/packages/daemon/src/broker/types.ts
@@ -141,6 +141,7 @@ export interface BrokerOptions {
   readonly stateRoot: string;
   readonly replicaChangeLog: ReplicaChangeLog;
   readonly snapshotSource: CanonicalSnapshotSource;
+  readonly replicaGapPolicy?: "RESYNC_REQUIRED" | "TERMINAL";
   readonly writerExclusion?: WriterExclusion;
   readonly watcherFence?: WatcherFence;
   readonly crashInjector?: BrokerCrashInjector;

--- a/packages/daemon/src/lifecycle/compound-receipt-composition.ts
+++ b/packages/daemon/src/lifecycle/compound-receipt-composition.ts
@@ -16,7 +16,9 @@ import {
 } from "@harness-anything/application";
 import {
   createBrokerCompoundReceiptCoordinatorV2,
-  ReplicaBroker
+  RemoteBrokerRuntime,
+  ReplicaBroker,
+  type RemoteReadDownSessionOptions
 } from "@harness-anything/daemon";
 import { createDurableCompoundReceiptStoreV2 } from "./durable-compound-receipt-store.ts";
 
@@ -26,6 +28,8 @@ import { createDurableCompoundReceiptStoreV2 } from "./durable-compound-receipt-
  * process-local cache.
  */
 export interface ProductionCompoundReceiptComposition {
+  readonly start: () => Promise<void>;
+  readonly stop: () => Promise<void>;
   readonly openWaiter: (input: { readonly requestId: string; readonly opId: string }) => Promise<WaiterOpenedFrameV1>;
   readonly recordAuthority: (identity: ReceiptIdentityV2, receipt: AuthorityOperationReceipt) => Promise<ResultPreparedFrameV1 | CompoundOperationReceiptV2>;
   readonly acknowledge: (input: Omit<Parameters<ProductionCompoundReceiptComposition["recover"]>[0], "requestId"> & {
@@ -60,7 +64,8 @@ export function createProductionCompoundReceiptComposition(input: {
   readonly viewId: string;
   readonly canonicalRoot: string;
   readonly stateDirectory: string;
-  readonly replicaChangeLog: ReplicaChangeLog;
+  readonly replicaChangeLog?: ReplicaChangeLog;
+  readonly remoteReadDown?: Omit<RemoteReadDownSessionOptions, "workspaceId" | "stateRoot">;
   readonly generationFence?: {
     readonly runExclusive: <Result>(
       input: { readonly workspaceId: string; readonly opId: string },
@@ -82,20 +87,42 @@ export function createProductionCompoundReceiptComposition(input: {
       ...(input.generationFence ? { generationFence: input.generationFence } : {})
     })
   });
-  const coordinator = createBrokerCompoundReceiptCoordinatorV2({
-    receipts,
-    broker: new ReplicaBroker({
+  const brokerStateRoot = path.join(input.stateDirectory, "broker");
+  const remoteRuntime = input.remoteReadDown
+    ? new RemoteBrokerRuntime({
+        workspaceId: input.workspaceId,
+        viewId: input.viewId,
+        viewRoot: input.canonicalRoot,
+        stateRoot: brokerStateRoot,
+        session: input.remoteReadDown,
+        writerExclusion: processWriterExclusion(),
+        watcherFence: processWatcherFence()
+      })
+    : undefined;
+  if (!remoteRuntime && !input.replicaChangeLog) {
+    throw new Error("local compound receipt composition requires a replica change log");
+  }
+  const broker = remoteRuntime?.broker ?? new ReplicaBroker({
       workspaceId: input.workspaceId,
       viewId: input.viewId,
       viewRoot: input.canonicalRoot,
-      stateRoot: path.join(input.stateDirectory, "broker"),
-      replicaChangeLog: input.replicaChangeLog,
+      stateRoot: brokerStateRoot,
+      replicaChangeLog: input.replicaChangeLog!,
       snapshotSource: { snapshotAt: (change) => gitSnapshot(input.canonicalRoot, change.workspaceId, change.revision, change.commitSha) },
       writerExclusion: processWriterExclusion(),
       watcherFence: processWatcherFence()
-    })
+    });
+  const coordinator = createBrokerCompoundReceiptCoordinatorV2({
+    receipts,
+    broker
   });
   return {
+    start: async () => {
+      if (remoteRuntime) await remoteRuntime.start();
+    },
+    stop: async () => {
+      await remoteRuntime?.stop();
+    },
     openWaiter: async ({ requestId, opId }) => {
       const frame = await coordinator.wire.handle({
         type: "harness-compound-receipt-wire/v1",

--- a/packages/daemon/test/remote-broker-runtime-failure-support.ts
+++ b/packages/daemon/test/remote-broker-runtime-failure-support.ts
@@ -1,0 +1,264 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type {
+  ReplicaChangeLog,
+  ReplicaChangeRecord
+} from "../../application/src/index.ts";
+import {
+  AuthorityTransportDisconnectedError,
+  RemoteBrokerRuntime,
+  RemoteReplicaResyncRequiredError,
+  type PersistentSshAuthorityClient
+} from "../src/index.ts";
+import { manifestDigest } from "../src/authority/replication-content-store.ts";
+import type {
+  AuthorityChangesAfterResult,
+  AuthoritySnapshotLease,
+  AuthoritySnapshotManifest,
+  AuthoritySnapshotReservation,
+  Sha256Digest
+} from "../src/authority/protocol.ts";
+import type { Deferred } from "./remote-read-down-test-support.ts";
+
+export const workspaceId = "workspace-remote-runtime-failures";
+
+export class ReadDownClient {
+  readonly notificationListeners = new Set<(change: ReplicaChangeRecord) => void>();
+  readonly disconnectListeners = new Set<() => void>();
+  readonly changeRequests: number[] = [];
+  private readonly fixture: SnapshotFixture;
+  authoritativeChanges: ReplicaChangeRecord[] = [];
+  invalidEmptyCutChange = false;
+  reconnectRequests = 0;
+  fetchFailuresRemaining = 0;
+  closeFailuresRemaining = 0;
+  disconnectRegistrationFailure: Error | undefined;
+  fetchGate: Deferred<void> | undefined;
+  closeRequests = 0;
+
+  constructor(fixture: SnapshotFixture) {
+    this.fixture = fixture;
+  }
+
+  async connect(): Promise<void> {}
+
+  async reconnect(): Promise<void> {
+    this.reconnectRequests += 1;
+  }
+
+  async beginSnapshotAndSubscribe(): Promise<AuthoritySnapshotReservation> {
+    return structuredClone(this.fixture.reservation);
+  }
+
+  async getSnapshotManifest(): Promise<AuthoritySnapshotManifest> {
+    return structuredClone(this.fixture.manifest);
+  }
+
+  async getCutChange(): Promise<ReplicaChangeRecord | null> {
+    if (this.invalidEmptyCutChange) return record(1, "commit-1", null);
+    return structuredClone(this.fixture.cutChange);
+  }
+
+  async getBlob(): Promise<never> {
+    throw new Error("test snapshot has no blobs");
+  }
+
+  async changesAfter(_streamToken: string, sinceRevision: number): Promise<AuthorityChangesAfterResult> {
+    this.changeRequests.push(sinceRevision);
+    if (this.fetchGate) await this.fetchGate.promise;
+    if (this.fetchFailuresRemaining > 0) {
+      this.fetchFailuresRemaining -= 1;
+      throw new AuthorityTransportDisconnectedError("scripted fetch disconnect");
+    }
+    const changes = this.authoritativeChanges.filter(
+      (change) => change.revision > sinceRevision
+    );
+    return {
+      schema: "authority-changes-after/v1",
+      sinceRevision,
+      throughRevision: changes.at(-1)?.revision ?? sinceRevision,
+      changes
+    };
+  }
+
+  async renewLease(): Promise<AuthoritySnapshotLease> {
+    return structuredClone(this.fixture.reservation.lease);
+  }
+
+  onNotification(listener: (change: ReplicaChangeRecord) => void): () => void {
+    this.notificationListeners.add(listener);
+    return () => this.notificationListeners.delete(listener);
+  }
+
+  onDisconnect(listener: () => void): () => void {
+    if (this.disconnectRegistrationFailure) throw this.disconnectRegistrationFailure;
+    this.disconnectListeners.add(listener);
+    return () => this.disconnectListeners.delete(listener);
+  }
+
+  async close(): Promise<void> {
+    this.closeRequests += 1;
+    if (this.closeFailuresRemaining > 0) {
+      this.closeFailuresRemaining -= 1;
+      throw new Error("scripted close failure");
+    }
+  }
+
+  emit(change: ReplicaChangeRecord): void {
+    for (const listener of this.notificationListeners) listener(change);
+  }
+}
+
+interface SnapshotFixture {
+  readonly reservation: AuthoritySnapshotReservation;
+  readonly manifest: AuthoritySnapshotManifest;
+  readonly cutChange: ReplicaChangeRecord | null;
+}
+
+export function snapshotFixture(revision: number, epoch: string): SnapshotFixture {
+  const commitSha = revision === 0 ? "0".repeat(40) : `commit-${revision}`;
+  const cutBase = { workspaceId, epoch, revision, commitSha };
+  const cut = {
+    ...cutBase,
+    manifestDigest: manifestDigest(cutBase, []),
+    provenanceDigest: sha256(`provenance-${epoch}-${revision}`)
+  };
+  const now = Date.now();
+  return {
+    reservation: {
+      schema: "authority-snapshot-reservation/v1",
+      cut,
+      lease: {
+        leaseId: `lease-${epoch}-${revision}`,
+        expiresAt: new Date(now + 60_000).toISOString(),
+        renewableUntil: new Date(now + 3_600_000).toISOString(),
+        minRetainedRevision: revision + 1,
+        pinnedBlobSetDigest: sha256(`set-${epoch}-${revision}`)
+      },
+      stream: { streamToken: `stream-${epoch}-${revision}`, fromRevision: revision + 1 }
+    },
+    manifest: { schema: "authority-snapshot-manifest/v1", cut, entries: [] },
+    cutChange: revision === 0
+      ? null
+      : {
+          ...record(revision, commitSha, revision === 1 ? null : `commit-${revision - 1}`),
+          manifest: { digest: cut.manifestDigest, entryCount: 0 }
+        }
+  };
+}
+
+export function makeRuntime(
+  client: ReadDownClient,
+  viewRoot: string,
+  stateRoot: string,
+  session: {
+    readonly sleep?: (milliseconds: number) => Promise<void>;
+    readonly backoff?: {
+      readonly initialMs: number;
+      readonly maximumMs: number;
+      readonly multiplier: number;
+    };
+  } = {}
+): RemoteBrokerRuntime {
+  return new RemoteBrokerRuntime({
+    workspaceId,
+    viewId: "view-remote",
+    viewRoot,
+    stateRoot,
+    session: {
+      client: client as unknown as PersistentSshAuthorityClient,
+      backoff: session.backoff ?? { initialMs: 0, maximumMs: 0, multiplier: 1 },
+      ...(session.sleep ? { sleep: session.sleep } : {})
+    }
+  });
+}
+
+export function notifyRuntime(runtime: RemoteBrokerRuntime, change: ReplicaChangeRecord): void {
+  const target = runtime as unknown as {
+    readonly handleNotification: (value: ReplicaChangeRecord) => void;
+  };
+  target.handleNotification(change);
+}
+
+export function changeLog(
+  changesAfter: (revision: number) => Promise<ReadonlyArray<ReplicaChangeRecord>>
+): ReplicaChangeLog {
+  return {
+    append: async () => {},
+    latest: async () => undefined,
+    getByOperation: async () => undefined,
+    changesAfter: async (_workspace, revision) => changesAfter(revision),
+    subscribe: () => () => {}
+  };
+}
+
+export function record(
+  revision: number,
+  commitSha: string,
+  previousCommit: string | null
+): ReplicaChangeRecord {
+  return {
+    schema: "replica-change/v2",
+    workspaceId,
+    revision,
+    opId: `op-${revision}`,
+    semanticDigest: `semantic-${revision}`,
+    operations: [{ opId: `op-${revision}`, semanticDigest: `semantic-${revision}` }],
+    commitSha,
+    previousCommit,
+    changedAt: "2026-07-23T14:00:00.000Z",
+    manifest: { digest: sha256(`manifest-${revision}`), entryCount: 0 },
+    paths: []
+  };
+}
+
+export function remoteResync(
+  cutChange: ReplicaChangeRecord,
+  epoch: string
+): RemoteReplicaResyncRequiredError {
+  return new RemoteReplicaResyncRequiredError("test resync", {
+    workspaceId,
+    epoch,
+    revision: cutChange.revision,
+    commitSha: cutChange.commitSha,
+    manifestDigest: cutChange.manifest.digest,
+    provenanceDigest: sha256(`provenance-${epoch}-${cutChange.revision}`)
+  }, cutChange);
+}
+
+export function emptyRemoteResync(): RemoteReplicaResyncRequiredError {
+  const fixture = snapshotFixture(0, "epoch-1");
+  return new RemoteReplicaResyncRequiredError(
+    "retryable start",
+    fixture.reservation.cut,
+    null
+  );
+}
+
+function sha256(text: string): Sha256Digest {
+  return `sha256:${createHash("sha256").update(text).digest("hex")}`;
+}
+
+export async function withRoots(
+  body: (roots: { readonly viewRoot: string; readonly stateRoot: string }) => Promise<void>
+): Promise<void> {
+  const root = await mkdtemp(path.join(tmpdir(), "ha-remote-runtime-failure-"));
+  try {
+    await body({
+      viewRoot: path.join(root, "view"),
+      stateRoot: path.join(root, "state")
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+export async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("timed out waiting for remote broker condition");
+}

--- a/packages/daemon/test/remote-broker-runtime-failures.test.ts
+++ b/packages/daemon/test/remote-broker-runtime-failures.test.ts
@@ -1,33 +1,31 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { createHash } from "node:crypto";
-import { mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
-import type {
-  ReplicaChangeLog,
-  ReplicaChangeRecord
-} from "../../application/src/index.ts";
 import {
   BrokerDurableStateStore,
   BrokerReplicaIntegrityError,
-  RemoteBrokerRuntime,
+  RemoteReadDownSession,
   RemoteReplicaResyncRequiredError,
   ReplicaBroker,
+  type BrokerDurableState,
   type PersistentSshAuthorityClient
 } from "../src/index.ts";
-import { manifestDigest } from "../src/authority/replication-content-store.ts";
-import type {
-  AuthorityChangesAfterResult,
-  AuthoritySnapshotLease,
-  AuthoritySnapshotManifest,
-  AuthoritySnapshotReservation,
-  Sha256Digest
-} from "../src/authority/protocol.ts";
+import {
+  ReadDownClient,
+  changeLog,
+  emptyRemoteResync,
+  makeRuntime,
+  notifyRuntime,
+  record,
+  remoteResync,
+  snapshotFixture,
+  waitFor,
+  withRoots,
+  workspaceId
+} from "./remote-broker-runtime-failure-support.ts";
 import { deferred } from "./remote-read-down-test-support.ts";
-
-const workspaceId = "workspace-remote-runtime-failures";
 
 test("cold restart seeds the durable epoch and bootstraps when the first remote cut changed epoch", async () => {
   await withRoots(async ({ viewRoot, stateRoot }) => {
@@ -82,7 +80,7 @@ test("remote parent mismatch is terminal and never creates targetless RESYNC", a
   });
 });
 
-test("all broker synchronization entrypoints share one in-flight synchronization", async () => {
+test("all broker synchronization entrypoints run serially without merging fresh intents", async () => {
   await withRoots(async ({ viewRoot, stateRoot }) => {
     const release = deferred<void>();
     let calls = 0;
@@ -112,11 +110,13 @@ test("all broker synchronization entrypoints share one in-flight synchronization
     const first = broker.synchronize();
     const second = broker.synchronize();
     const notified = broker.onNotification(hint);
+    assert.notEqual(first, second);
+    assert.notEqual(second, notified);
     await waitFor(() => calls === 1);
     assert.equal(maximumActive, 1);
     release.resolve();
     await Promise.all([first, second, notified]);
-    assert.equal(calls, 1);
+    assert.equal(calls, 3);
     assert.equal(maximumActive, 1);
   });
 });
@@ -228,205 +228,356 @@ test("retryable initial synchronization failure rolls back and a later start cre
   });
 });
 
-class ReadDownClient {
-  readonly notificationListeners = new Set<(change: ReplicaChangeRecord) => void>();
-  readonly disconnectListeners = new Set<() => void>();
-  readonly changeRequests: number[] = [];
-  private readonly fixture: SnapshotFixture;
-  closeRequests = 0;
+test("historical targetless RESYNC is terminal instead of a successful remote startup", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const store = new BrokerDurableStateStore(stateRoot);
+    const initial = await store.initialize(workspaceId);
+    await store.save({ ...initial, mode: "RESYNC_REQUIRED" });
+    const client = new ReadDownClient(snapshotFixture(0, "epoch-1"));
+    const runtime = makeRuntime(client, viewRoot, stateRoot);
 
-  constructor(fixture: SnapshotFixture) {
-    this.fixture = fixture;
-  }
-
-  async connect(): Promise<void> {}
-
-  async reconnect(): Promise<void> {}
-
-  async beginSnapshotAndSubscribe(): Promise<AuthoritySnapshotReservation> {
-    return structuredClone(this.fixture.reservation);
-  }
-
-  async getSnapshotManifest(): Promise<AuthoritySnapshotManifest> {
-    return structuredClone(this.fixture.manifest);
-  }
-
-  async getCutChange(): Promise<ReplicaChangeRecord | null> {
-    return structuredClone(this.fixture.cutChange);
-  }
-
-  async getBlob(): Promise<never> {
-    throw new Error("test snapshot has no blobs");
-  }
-
-  async changesAfter(_streamToken: string, sinceRevision: number): Promise<AuthorityChangesAfterResult> {
-    this.changeRequests.push(sinceRevision);
-    return {
-      schema: "authority-changes-after/v1",
-      sinceRevision,
-      throughRevision: sinceRevision,
-      changes: []
-    };
-  }
-
-  async renewLease(): Promise<AuthoritySnapshotLease> {
-    return structuredClone(this.fixture.reservation.lease);
-  }
-
-  onNotification(listener: (change: ReplicaChangeRecord) => void): () => void {
-    this.notificationListeners.add(listener);
-    return () => this.notificationListeners.delete(listener);
-  }
-
-  onDisconnect(listener: () => void): () => void {
-    this.disconnectListeners.add(listener);
-    return () => this.disconnectListeners.delete(listener);
-  }
-
-  async close(): Promise<void> {
-    this.closeRequests += 1;
-  }
-}
-
-interface SnapshotFixture {
-  readonly reservation: AuthoritySnapshotReservation;
-  readonly manifest: AuthoritySnapshotManifest;
-  readonly cutChange: ReplicaChangeRecord | null;
-}
-
-function snapshotFixture(revision: number, epoch: string): SnapshotFixture {
-  const commitSha = revision === 0 ? "0".repeat(40) : `commit-${revision}`;
-  const cutBase = { workspaceId, epoch, revision, commitSha };
-  const cut = {
-    ...cutBase,
-    manifestDigest: manifestDigest(cutBase, []),
-    provenanceDigest: sha256(`provenance-${epoch}-${revision}`)
-  };
-  const now = Date.now();
-  return {
-    reservation: {
-      schema: "authority-snapshot-reservation/v1",
-      cut,
-      lease: {
-        leaseId: `lease-${epoch}-${revision}`,
-        expiresAt: new Date(now + 60_000).toISOString(),
-        renewableUntil: new Date(now + 3_600_000).toISOString(),
-        minRetainedRevision: revision + 1,
-        pinnedBlobSetDigest: sha256(`set-${epoch}-${revision}`)
-      },
-      stream: { streamToken: `stream-${epoch}-${revision}`, fromRevision: revision + 1 }
-    },
-    manifest: { schema: "authority-snapshot-manifest/v1", cut, entries: [] },
-    cutChange: revision === 0
-      ? null
-      : {
-          ...record(revision, commitSha, revision === 1 ? null : `commit-${revision - 1}`),
-          manifest: { digest: cut.manifestDigest, entryCount: 0 }
-        }
-  };
-}
-
-function makeRuntime(
-  client: ReadDownClient,
-  viewRoot: string,
-  stateRoot: string
-): RemoteBrokerRuntime {
-  return new RemoteBrokerRuntime({
-    workspaceId,
-    viewId: "view-remote",
-    viewRoot,
-    stateRoot,
-    session: {
-      client: client as unknown as PersistentSshAuthorityClient,
-      backoff: { initialMs: 0, maximumMs: 0, multiplier: 1 }
-    }
+    await assert.rejects(runtime.start(), BrokerReplicaIntegrityError);
+    assert.equal(runtime.health().status, "TERMINAL");
+    assert.deepEqual(client.changeRequests, []);
+    await assert.rejects(runtime.stop(), BrokerReplicaIntegrityError);
   });
-}
+});
 
-function notifyRuntime(runtime: RemoteBrokerRuntime, change: ReplicaChangeRecord): void {
-  const target = runtime as unknown as {
-    readonly handleNotification: (value: ReplicaChangeRecord) => void;
-  };
-  target.handleNotification(change);
-}
-
-function changeLog(
-  changesAfter: (revision: number) => Promise<ReadonlyArray<ReplicaChangeRecord>>
-): ReplicaChangeLog {
-  return {
-    append: async () => {},
-    latest: async () => undefined,
-    getByOperation: async () => undefined,
-    changesAfter: async (_workspace, revision) => changesAfter(revision),
-    subscribe: () => () => {}
-  };
-}
-
-function record(
-  revision: number,
-  commitSha: string,
-  previousCommit: string | null
-): ReplicaChangeRecord {
-  return {
-    schema: "replica-change/v2",
-    workspaceId,
-    revision,
-    opId: `op-${revision}`,
-    semanticDigest: `semantic-${revision}`,
-    operations: [{ opId: `op-${revision}`, semanticDigest: `semantic-${revision}` }],
-    commitSha,
-    previousCommit,
-    changedAt: "2026-07-23T14:00:00.000Z",
-    manifest: { digest: sha256(`manifest-${revision}`), entryCount: 0 },
-    paths: []
-  };
-}
-
-function remoteResync(
-  cutChange: ReplicaChangeRecord,
-  epoch: string
-): RemoteReplicaResyncRequiredError {
-  return new RemoteReplicaResyncRequiredError("test resync", {
-    workspaceId,
-    epoch,
-    revision: cutChange.revision,
-    commitSha: cutChange.commitSha,
-    manifestDigest: cutChange.manifest.digest,
-    provenanceDigest: sha256(`provenance-${epoch}-${cutChange.revision}`)
-  }, cutChange);
-}
-
-function emptyRemoteResync(): RemoteReplicaResyncRequiredError {
-  const fixture = snapshotFixture(0, "epoch-1");
-  return new RemoteReplicaResyncRequiredError(
-    "retryable start",
-    fixture.reservation.cut,
-    null
-  );
-}
-
-function sha256(text: string): Sha256Digest {
-  return `sha256:${createHash("sha256").update(text).digest("hex")}`;
-}
-
-async function withRoots(
-  body: (roots: { readonly viewRoot: string; readonly stateRoot: string }) => Promise<void>
-): Promise<void> {
-  const root = await mkdtemp(path.join(tmpdir(), "ha-remote-runtime-failure-"));
-  try {
-    await body({
-      viewRoot: path.join(root, "view"),
-      stateRoot: path.join(root, "state")
+test("submission preflight and synchronization cannot interleave a stale durable snapshot", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const pathName = "tasks/a.md";
+    await mkdir(path.join(viewRoot, "tasks"), { recursive: true });
+    await writeFile(path.join(viewRoot, pathName), "draft\n");
+    let queries = 0;
+    const broker = new ReplicaBroker({
+      workspaceId,
+      viewId: "view-remote",
+      viewRoot,
+      stateRoot,
+      replicaChangeLog: changeLog(async () => {
+        queries += 1;
+        return [record(1, "commit-1", null)];
+      }),
+      snapshotSource: {
+        snapshotAt: async () => ({
+          workspaceId,
+          revision: 1,
+          commitSha: "commit-1",
+          entries: []
+        })
+      }
     });
-  } finally {
-    await rm(root, { recursive: true, force: true });
-  }
-}
+    await broker.recordLocalChange(pathName);
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const internals = broker as unknown as {
+      readonly cas: { put: (bytes: Uint8Array) => Promise<string> };
+    };
+    const put = internals.cas.put.bind(internals.cas);
+    internals.cas.put = async (bytes) => {
+      entered.resolve();
+      await release.promise;
+      return put(bytes);
+    };
 
-async function waitFor(predicate: () => boolean): Promise<void> {
-  for (let attempt = 0; attempt < 200; attempt += 1) {
-    if (predicate()) return;
-    await new Promise((resolve) => setTimeout(resolve, 5));
-  }
-  throw new Error("timed out waiting for remote broker condition");
-}
+    const submission = broker.prepareSubmission(pathName, "op-submit");
+    await entered.promise;
+    const synchronization = broker.synchronize();
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(queries, 0);
+    release.resolve();
+    await submission;
+    await synchronization;
+
+    assert.equal(broker.snapshotState().receivedCursor, 1);
+    assert.equal(broker.snapshotState().resolvedCursor, 1);
+  });
+});
+
+test("a fresh synchronize intent queued during materialization re-queries authority", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const firstSnapshot = deferred<void>();
+    const available = [record(1, "commit-1", null)];
+    let queries = 0;
+    let snapshots = 0;
+    const broker = new ReplicaBroker({
+      workspaceId,
+      viewId: "view-remote",
+      viewRoot,
+      stateRoot,
+      replicaChangeLog: changeLog(async (revision) => {
+        queries += 1;
+        return available.filter((change) => change.revision > revision);
+      }),
+      snapshotSource: {
+        snapshotAt: async (change) => {
+          snapshots += 1;
+          if (snapshots === 1) await firstSnapshot.promise;
+          return {
+            workspaceId,
+            revision: change.revision,
+            commitSha: change.commitSha,
+            entries: []
+          };
+        }
+      }
+    });
+
+    const first = broker.synchronize();
+    await waitFor(() => snapshots === 1);
+    available.push(record(2, "commit-2", "commit-1"));
+    const second = broker.synchronize();
+    assert.notEqual(first, second);
+    firstSnapshot.resolve();
+
+    assert.equal((await first).resolvedCursor, 1);
+    assert.equal((await second).resolvedCursor, 2);
+    assert.equal(queries, 2);
+  });
+});
+
+test("concurrent synchronize and notification share one initialization transition", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const broker = new ReplicaBroker({
+      workspaceId,
+      viewId: "view-remote",
+      viewRoot,
+      stateRoot,
+      replicaChangeLog: changeLog(async () => []),
+      snapshotSource: {
+        snapshotAt: async () => {
+          throw new Error("unexpected snapshot");
+        }
+      }
+    });
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const internals = broker as unknown as {
+      readonly store: {
+        initialize: (id: string) => Promise<BrokerDurableState>;
+      };
+    };
+    const initialize = internals.store.initialize.bind(internals.store);
+    let initializations = 0;
+    internals.store.initialize = async (id) => {
+      initializations += 1;
+      entered.resolve();
+      await release.promise;
+      return initialize(id);
+    };
+
+    const synchronized = broker.synchronize();
+    await entered.promise;
+    const notified = broker.onNotification(record(1, "commit-1", null));
+    release.resolve();
+    await Promise.all([synchronized, notified]);
+    assert.equal(initializations, 1);
+  });
+});
+
+test("background resync keeps health RECOVERING and owns a retry until READY", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const client = new ReadDownClient(snapshotFixture(0, "epoch-1"));
+    const retrySleep = deferred<void>();
+    const runtime = makeRuntime(client, viewRoot, stateRoot, {
+      sleep: async () => retrySleep.promise,
+      backoff: { initialMs: 1, maximumMs: 1, multiplier: 1 }
+    });
+    await runtime.start();
+    const cut = record(1, "commit-1", null);
+    const resync = remoteResync(cut, "epoch-resync");
+    const internals = runtime.broker as unknown as { state: BrokerDurableState };
+    runtime.broker.onNotification = async () => {
+      internals.state = {
+        ...internals.state,
+        mode: "RESYNC_REQUIRED",
+        resyncTarget: {
+          epoch: resync.cut.epoch,
+          revision: resync.cut.revision,
+          commitSha: resync.cut.commitSha,
+          cutChange: resync.cutChange
+        }
+      };
+      throw resync;
+    };
+    let retries = 0;
+    runtime.broker.synchronize = async () => {
+      retries += 1;
+      internals.state = {
+        ...internals.state,
+        mode: "READY",
+        resyncTarget: undefined
+      };
+      return structuredClone(internals.state);
+    };
+
+    notifyRuntime(runtime, cut);
+    await waitFor(() => runtime.health().status === "RECOVERING");
+    assert.equal(runtime.broker.snapshotState().mode, "RESYNC_REQUIRED");
+    assert.equal(retries, 0);
+    retrySleep.resolve();
+    await waitFor(() => runtime.health().status === "RUNNING");
+    assert.equal(retries, 1);
+    await runtime.stop();
+  });
+});
+
+test("a malformed empty cut is classified terminal without reconnect", async () => {
+  await withRoots(async ({ stateRoot }) => {
+    const client = new ReadDownClient(snapshotFixture(0, "epoch-1"));
+    client.invalidEmptyCutChange = true;
+    const sleeps: number[] = [];
+    let terminal: Error | undefined;
+    const session = new RemoteReadDownSession({
+      client: client as unknown as PersistentSshAuthorityClient,
+      workspaceId,
+      stateRoot,
+      sleep: async (milliseconds) => {
+        sleeps.push(milliseconds);
+      },
+      onTerminal: (failure) => {
+        terminal = failure;
+      }
+    });
+
+    await assert.rejects(session.latest(), /empty cut unexpectedly has a change/u);
+    assert.equal(session.health().status, "TERMINAL");
+    assert.match(terminal?.message ?? "", /empty cut unexpectedly has a change/u);
+    assert.equal(client.reconnectRequests, 0);
+    assert.deepEqual(sleeps, []);
+    await session.close();
+  });
+});
+
+test("session notification identity conflict immediately surfaces terminal runtime health", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const client = new ReadDownClient(snapshotFixture(0, "epoch-1"));
+    const runtime = makeRuntime(client, viewRoot, stateRoot);
+    await runtime.start();
+    const first = record(2, "commit-2", "commit-1");
+    client.emit(first);
+    client.emit({ ...first, commitSha: "different-commit" });
+
+    await waitFor(() => runtime.health().status === "TERMINAL");
+    assert.match(
+      runtime.health().status === "TERMINAL" ? runtime.health().failure.message : "",
+      /identity conflict/u
+    );
+    assert.equal(client.notificationListeners.size, 0);
+    await assert.rejects(runtime.stop(), /identity conflict/u);
+  });
+});
+
+test("startup failures leave an explicit terminal or clean retryable boundary", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const initializeClient = new ReadDownClient(snapshotFixture(0, "epoch-1"));
+    const initializeRuntime = makeRuntime(initializeClient, viewRoot, stateRoot);
+    initializeRuntime.broker.initialize = async () => {
+      throw new Error("durable initialize failed");
+    };
+    await assert.rejects(initializeRuntime.start(), /durable initialize failed/u);
+    assert.equal(initializeRuntime.health().status, "TERMINAL");
+
+    const listenerClient = new ReadDownClient(snapshotFixture(0, "epoch-1"));
+    listenerClient.disconnectRegistrationFailure = new Error("listener registration failed");
+    const listenerRuntime = makeRuntime(
+      listenerClient,
+      `${viewRoot}-listener`,
+      `${stateRoot}-listener`
+    );
+    await assert.rejects(listenerRuntime.start(), /listener registration failed/u);
+    assert.equal(listenerClient.notificationListeners.size, 0);
+    assert.equal(listenerRuntime.health().status, "TERMINAL");
+
+    const retryClient = new ReadDownClient(snapshotFixture(0, "epoch-1"));
+    retryClient.closeFailuresRemaining = 1;
+    const retryRuntime = makeRuntime(
+      retryClient,
+      `${viewRoot}-retry`,
+      `${stateRoot}-retry`
+    );
+    const synchronize = retryRuntime.broker.synchronize.bind(retryRuntime.broker);
+    let attempts = 0;
+    retryRuntime.broker.synchronize = () => {
+      attempts += 1;
+      return attempts === 1 ? Promise.reject(emptyRemoteResync()) : synchronize();
+    };
+    await assert.rejects(retryRuntime.start(), RemoteReplicaResyncRequiredError);
+    assert.deepEqual(retryRuntime.health(), { status: "IDLE" });
+    assert.throws(() => retryRuntime.session, /not started/u);
+    assert.equal(retryClient.notificationListeners.size, 0);
+    await retryRuntime.start();
+    await retryRuntime.stop();
+  });
+});
+
+test("authoritative low revisions evict lossy high hints from the bounded cache", async () => {
+  await withRoots(async ({ stateRoot }) => {
+    const client = new ReadDownClient(snapshotFixture(0, "epoch-1"));
+    const session = new RemoteReadDownSession({
+      client: client as unknown as PersistentSshAuthorityClient,
+      workspaceId,
+      stateRoot,
+      changeCache: { maxCount: 3, maxBytes: 64 * 1024 }
+    });
+    await session.changesAfter(0);
+    for (let revision = 100; revision <= 102; revision += 1) {
+      client.emit(record(revision, `commit-${revision}`, `commit-${revision - 1}`));
+    }
+    assert.equal((await session.latest())?.revision, 102);
+    client.authoritativeChanges = [record(1, "commit-1", null)];
+
+    const changes = await session.changesAfter(0);
+    assert.deepEqual(changes.map((change) => change.revision), [1]);
+    assert.notEqual(session.health().status, "TERMINAL");
+    await session.close();
+  });
+});
+
+test("repeated fetch disconnects sleep with bounded backoff before retrying", async () => {
+  await withRoots(async ({ stateRoot }) => {
+    const client = new ReadDownClient(snapshotFixture(0, "epoch-1"));
+    client.fetchFailuresRemaining = 3;
+    const sleeps: number[] = [];
+    const session = new RemoteReadDownSession({
+      client: client as unknown as PersistentSshAuthorityClient,
+      workspaceId,
+      stateRoot,
+      backoff: { initialMs: 2, maximumMs: 5, multiplier: 2 },
+      sleep: async (milliseconds) => {
+        sleeps.push(milliseconds);
+      }
+    });
+
+    await session.changesAfter(0);
+    assert.deepEqual(sleeps, [2, 4, 5]);
+    assert.equal(client.changeRequests.length, 4);
+    assert.equal(client.reconnectRequests, 3);
+    await session.close();
+  });
+});
+
+test("client close rejection is reported only after pending session work joins", async () => {
+  await withRoots(async ({ stateRoot }) => {
+    const client = new ReadDownClient(snapshotFixture(0, "epoch-1"));
+    const fetchGate = deferred<void>();
+    client.fetchGate = fetchGate;
+    client.closeFailuresRemaining = 1;
+    const session = new RemoteReadDownSession({
+      client: client as unknown as PersistentSshAuthorityClient,
+      workspaceId,
+      stateRoot
+    });
+    const reading = session.changesAfter(0);
+    await waitFor(() => client.changeRequests.length === 1);
+    let settled = false;
+    const closing = session.close().finally(() => {
+      settled = true;
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(settled, false);
+    fetchGate.resolve();
+    await assert.rejects(closing, /scripted close failure/u);
+    await assert.rejects(reading, /session is closed/u);
+  });
+});

--- a/packages/daemon/test/remote-broker-runtime-failures.test.ts
+++ b/packages/daemon/test/remote-broker-runtime-failures.test.ts
@@ -1,0 +1,432 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import type {
+  ReplicaChangeLog,
+  ReplicaChangeRecord
+} from "../../application/src/index.ts";
+import {
+  BrokerDurableStateStore,
+  BrokerReplicaIntegrityError,
+  RemoteBrokerRuntime,
+  RemoteReplicaResyncRequiredError,
+  ReplicaBroker,
+  type PersistentSshAuthorityClient
+} from "../src/index.ts";
+import { manifestDigest } from "../src/authority/replication-content-store.ts";
+import type {
+  AuthorityChangesAfterResult,
+  AuthoritySnapshotLease,
+  AuthoritySnapshotManifest,
+  AuthoritySnapshotReservation,
+  Sha256Digest
+} from "../src/authority/protocol.ts";
+import { deferred } from "./remote-read-down-test-support.ts";
+
+const workspaceId = "workspace-remote-runtime-failures";
+
+test("cold restart seeds the durable epoch and bootstraps when the first remote cut changed epoch", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const fixture = snapshotFixture(1, "epoch-2");
+    const store = new BrokerDurableStateStore(stateRoot);
+    const initial = await store.initialize(workspaceId);
+    await store.save({
+      ...initial,
+      epoch: "epoch-1",
+      receivedCursor: 1,
+      resolvedCursor: 1,
+      receivedCommit: fixture.reservation.cut.commitSha,
+      resolvedCommit: fixture.reservation.cut.commitSha
+    });
+    const client = new ReadDownClient(fixture);
+    const runtime = makeRuntime(client, viewRoot, stateRoot);
+
+    const state = await runtime.start();
+
+    assert.equal(state.mode, "READY");
+    assert.equal(state.epoch, "epoch-2");
+    assert.equal(state.resolvedCursor, 1);
+    assert.ok(client.changeRequests.length > 0);
+    assert.ok(client.changeRequests.every((revision) => revision === 1));
+    await runtime.stop();
+  });
+});
+
+test("remote parent mismatch is terminal and never creates targetless RESYNC", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const wrongParent = record(1, "commit-1", "wrong-parent");
+    const broker = new ReplicaBroker({
+      workspaceId,
+      viewId: "view-remote",
+      viewRoot,
+      stateRoot,
+      replicaGapPolicy: "TERMINAL",
+      replicaChangeLog: changeLog(async () => [wrongParent]),
+      snapshotSource: {
+        snapshotAt: async () => ({
+          workspaceId,
+          revision: 1,
+          commitSha: "commit-1",
+          entries: []
+        })
+      }
+    });
+
+    await assert.rejects(broker.synchronize(), BrokerReplicaIntegrityError);
+    assert.equal(broker.snapshotState().mode, "READY");
+    assert.equal(broker.snapshotState().resyncTarget, undefined);
+  });
+});
+
+test("all broker synchronization entrypoints share one in-flight synchronization", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const release = deferred<void>();
+    let calls = 0;
+    let active = 0;
+    let maximumActive = 0;
+    const broker = new ReplicaBroker({
+      workspaceId,
+      viewId: "view-remote",
+      viewRoot,
+      stateRoot,
+      replicaChangeLog: changeLog(async () => {
+        calls += 1;
+        active += 1;
+        maximumActive = Math.max(maximumActive, active);
+        await release.promise;
+        active -= 1;
+        return [];
+      }),
+      snapshotSource: {
+        snapshotAt: async () => {
+          throw new Error("unexpected snapshot");
+        }
+      }
+    });
+    const hint = record(1, "commit-1", null);
+
+    const first = broker.synchronize();
+    const second = broker.synchronize();
+    const notified = broker.onNotification(hint);
+    await waitFor(() => calls === 1);
+    assert.equal(maximumActive, 1);
+    release.resolve();
+    await Promise.all([first, second, notified]);
+    assert.equal(calls, 1);
+    assert.equal(maximumActive, 1);
+  });
+});
+
+test("repeated resync cut exits without rewriting the durable target indefinitely", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const cutChange = record(1, "commit-1", null);
+    const resync = remoteResync(cutChange, "epoch-resync");
+    let snapshotCalls = 0;
+    const broker = new ReplicaBroker({
+      workspaceId,
+      viewId: "view-remote",
+      viewRoot,
+      stateRoot,
+      replicaChangeLog: changeLog(async () => {
+        throw resync;
+      }),
+      snapshotSource: {
+        snapshotAt: async () => {
+          snapshotCalls += 1;
+          throw remoteResync(cutChange, "epoch-resync");
+        }
+      }
+    });
+
+    await assert.rejects(broker.synchronize(), RemoteReplicaResyncRequiredError);
+
+    const state = broker.snapshotState();
+    assert.equal(state.mode, "RESYNC_REQUIRED");
+    assert.equal(state.resyncTarget?.revision, 1);
+    assert.equal(state.nextJournalLSN, 2);
+    assert.equal(snapshotCalls, 1);
+  });
+});
+
+test("background deterministic failure becomes terminal, unsubscribes, and is observable through stop", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const client = new ReadDownClient(snapshotFixture(0, "epoch-1"));
+    const runtime = makeRuntime(client, viewRoot, stateRoot);
+    await runtime.start();
+    const failure = new BrokerReplicaIntegrityError("deterministic snapshot failure");
+    runtime.broker.onNotification = async () => {
+      throw failure;
+    };
+
+    notifyRuntime(runtime, record(1, "commit-1", null));
+    await waitFor(() => runtime.health().status === "TERMINAL");
+
+    const health = runtime.health();
+    assert.equal(health.status, "TERMINAL");
+    if (health.status === "TERMINAL") assert.equal(health.failure, failure);
+    assert.equal(client.notificationListeners.size, 0);
+    assert.equal(client.disconnectListeners.size, 0);
+    await assert.rejects(runtime.stop(), failure);
+  });
+});
+
+test("notification hints coalesce to one running synchronization and one latest rerun", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const client = new ReadDownClient(snapshotFixture(0, "epoch-1"));
+    const runtime = makeRuntime(client, viewRoot, stateRoot);
+    await runtime.start();
+    const release = deferred<void>();
+    const revisions: number[] = [];
+    runtime.broker.onNotification = async (change) => {
+      revisions.push(change.revision);
+      if (revisions.length === 1) await release.promise;
+      return runtime.broker.snapshotState();
+    };
+
+    notifyRuntime(runtime, record(1, "commit-1", null));
+    await waitFor(() => revisions.length === 1);
+    for (let revision = 2; revision <= 100; revision += 1) {
+      notifyRuntime(runtime, record(revision, `commit-${revision}`, `commit-${revision - 1}`));
+    }
+    assert.deepEqual(revisions, [1]);
+    release.resolve();
+    await waitFor(() => revisions.length === 2);
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.deepEqual(revisions, [1, 100]);
+    await runtime.stop();
+  });
+});
+
+test("retryable initial synchronization failure rolls back and a later start creates a fresh session", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const client = new ReadDownClient(snapshotFixture(0, "epoch-1"));
+    const runtime = makeRuntime(client, viewRoot, stateRoot);
+    const synchronize = runtime.broker.synchronize.bind(runtime.broker);
+    let attempts = 0;
+    runtime.broker.synchronize = () => {
+      attempts += 1;
+      return attempts === 1
+        ? Promise.reject(emptyRemoteResync())
+        : synchronize();
+    };
+
+    await assert.rejects(runtime.start(), RemoteReplicaResyncRequiredError);
+    assert.deepEqual(runtime.health(), { status: "IDLE" });
+    assert.equal(client.notificationListeners.size, 0);
+    assert.equal(client.disconnectListeners.size, 0);
+    assert.equal(client.closeRequests, 1);
+
+    const state = await runtime.start();
+    assert.equal(state.mode, "READY");
+    assert.deepEqual(runtime.health(), { status: "RUNNING" });
+    await runtime.stop();
+    assert.equal(client.closeRequests, 2);
+  });
+});
+
+class ReadDownClient {
+  readonly notificationListeners = new Set<(change: ReplicaChangeRecord) => void>();
+  readonly disconnectListeners = new Set<() => void>();
+  readonly changeRequests: number[] = [];
+  private readonly fixture: SnapshotFixture;
+  closeRequests = 0;
+
+  constructor(fixture: SnapshotFixture) {
+    this.fixture = fixture;
+  }
+
+  async connect(): Promise<void> {}
+
+  async reconnect(): Promise<void> {}
+
+  async beginSnapshotAndSubscribe(): Promise<AuthoritySnapshotReservation> {
+    return structuredClone(this.fixture.reservation);
+  }
+
+  async getSnapshotManifest(): Promise<AuthoritySnapshotManifest> {
+    return structuredClone(this.fixture.manifest);
+  }
+
+  async getCutChange(): Promise<ReplicaChangeRecord | null> {
+    return structuredClone(this.fixture.cutChange);
+  }
+
+  async getBlob(): Promise<never> {
+    throw new Error("test snapshot has no blobs");
+  }
+
+  async changesAfter(_streamToken: string, sinceRevision: number): Promise<AuthorityChangesAfterResult> {
+    this.changeRequests.push(sinceRevision);
+    return {
+      schema: "authority-changes-after/v1",
+      sinceRevision,
+      throughRevision: sinceRevision,
+      changes: []
+    };
+  }
+
+  async renewLease(): Promise<AuthoritySnapshotLease> {
+    return structuredClone(this.fixture.reservation.lease);
+  }
+
+  onNotification(listener: (change: ReplicaChangeRecord) => void): () => void {
+    this.notificationListeners.add(listener);
+    return () => this.notificationListeners.delete(listener);
+  }
+
+  onDisconnect(listener: () => void): () => void {
+    this.disconnectListeners.add(listener);
+    return () => this.disconnectListeners.delete(listener);
+  }
+
+  async close(): Promise<void> {
+    this.closeRequests += 1;
+  }
+}
+
+interface SnapshotFixture {
+  readonly reservation: AuthoritySnapshotReservation;
+  readonly manifest: AuthoritySnapshotManifest;
+  readonly cutChange: ReplicaChangeRecord | null;
+}
+
+function snapshotFixture(revision: number, epoch: string): SnapshotFixture {
+  const commitSha = revision === 0 ? "0".repeat(40) : `commit-${revision}`;
+  const cutBase = { workspaceId, epoch, revision, commitSha };
+  const cut = {
+    ...cutBase,
+    manifestDigest: manifestDigest(cutBase, []),
+    provenanceDigest: sha256(`provenance-${epoch}-${revision}`)
+  };
+  const now = Date.now();
+  return {
+    reservation: {
+      schema: "authority-snapshot-reservation/v1",
+      cut,
+      lease: {
+        leaseId: `lease-${epoch}-${revision}`,
+        expiresAt: new Date(now + 60_000).toISOString(),
+        renewableUntil: new Date(now + 3_600_000).toISOString(),
+        minRetainedRevision: revision + 1,
+        pinnedBlobSetDigest: sha256(`set-${epoch}-${revision}`)
+      },
+      stream: { streamToken: `stream-${epoch}-${revision}`, fromRevision: revision + 1 }
+    },
+    manifest: { schema: "authority-snapshot-manifest/v1", cut, entries: [] },
+    cutChange: revision === 0
+      ? null
+      : {
+          ...record(revision, commitSha, revision === 1 ? null : `commit-${revision - 1}`),
+          manifest: { digest: cut.manifestDigest, entryCount: 0 }
+        }
+  };
+}
+
+function makeRuntime(
+  client: ReadDownClient,
+  viewRoot: string,
+  stateRoot: string
+): RemoteBrokerRuntime {
+  return new RemoteBrokerRuntime({
+    workspaceId,
+    viewId: "view-remote",
+    viewRoot,
+    stateRoot,
+    session: {
+      client: client as unknown as PersistentSshAuthorityClient,
+      backoff: { initialMs: 0, maximumMs: 0, multiplier: 1 }
+    }
+  });
+}
+
+function notifyRuntime(runtime: RemoteBrokerRuntime, change: ReplicaChangeRecord): void {
+  const target = runtime as unknown as {
+    readonly handleNotification: (value: ReplicaChangeRecord) => void;
+  };
+  target.handleNotification(change);
+}
+
+function changeLog(
+  changesAfter: (revision: number) => Promise<ReadonlyArray<ReplicaChangeRecord>>
+): ReplicaChangeLog {
+  return {
+    append: async () => {},
+    latest: async () => undefined,
+    getByOperation: async () => undefined,
+    changesAfter: async (_workspace, revision) => changesAfter(revision),
+    subscribe: () => () => {}
+  };
+}
+
+function record(
+  revision: number,
+  commitSha: string,
+  previousCommit: string | null
+): ReplicaChangeRecord {
+  return {
+    schema: "replica-change/v2",
+    workspaceId,
+    revision,
+    opId: `op-${revision}`,
+    semanticDigest: `semantic-${revision}`,
+    operations: [{ opId: `op-${revision}`, semanticDigest: `semantic-${revision}` }],
+    commitSha,
+    previousCommit,
+    changedAt: "2026-07-23T14:00:00.000Z",
+    manifest: { digest: sha256(`manifest-${revision}`), entryCount: 0 },
+    paths: []
+  };
+}
+
+function remoteResync(
+  cutChange: ReplicaChangeRecord,
+  epoch: string
+): RemoteReplicaResyncRequiredError {
+  return new RemoteReplicaResyncRequiredError("test resync", {
+    workspaceId,
+    epoch,
+    revision: cutChange.revision,
+    commitSha: cutChange.commitSha,
+    manifestDigest: cutChange.manifest.digest,
+    provenanceDigest: sha256(`provenance-${epoch}-${cutChange.revision}`)
+  }, cutChange);
+}
+
+function emptyRemoteResync(): RemoteReplicaResyncRequiredError {
+  const fixture = snapshotFixture(0, "epoch-1");
+  return new RemoteReplicaResyncRequiredError(
+    "retryable start",
+    fixture.reservation.cut,
+    null
+  );
+}
+
+function sha256(text: string): Sha256Digest {
+  return `sha256:${createHash("sha256").update(text).digest("hex")}`;
+}
+
+async function withRoots(
+  body: (roots: { readonly viewRoot: string; readonly stateRoot: string }) => Promise<void>
+): Promise<void> {
+  const root = await mkdtemp(path.join(tmpdir(), "ha-remote-runtime-failure-"));
+  try {
+    await body({
+      viewRoot: path.join(root, "view"),
+      stateRoot: path.join(root, "state")
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("timed out waiting for remote broker condition");
+}

--- a/packages/daemon/test/remote-broker-runtime.test.ts
+++ b/packages/daemon/test/remote-broker-runtime.test.ts
@@ -1,0 +1,418 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import type { ReplicaChangeLog, ReplicaChangeRecord } from "../../application/src/index.ts";
+import {
+  BrokerDurableStateStore,
+  RemoteBrokerRuntime,
+  RemoteReplicaResyncRequiredError,
+  ReplicaBroker,
+  createProductionCompoundReceiptComposition,
+  type BrokerDurableState,
+  type CanonicalSnapshot,
+  type PersistentSshAuthorityClient
+} from "../src/index.ts";
+import { manifestDigest } from "../src/authority/replication-content-store.ts";
+import type {
+  AuthorityChangesAfterResult,
+  AuthoritySnapshotLease,
+  AuthoritySnapshotManifest,
+  AuthoritySnapshotReservation,
+  Sha256Digest
+} from "../src/authority/protocol.ts";
+
+const workspaceId = "workspace-remote-runtime";
+
+test("synchronize persists a remote resync cut, bootstraps it, then resumes forward changes", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const cutChange = change(3, "commit-3", "commit-2");
+    const forward = change(4, "commit-4", "commit-3");
+    const snapshots = new Map<string, CanonicalSnapshot>([
+      ["commit-3", snapshot(cutChange, { "notes.md": "cut\n" })],
+      ["commit-4", snapshot(forward, { "notes.md": "forward\n" })]
+    ]);
+    const requested: number[] = [];
+    let observedDurableResync: BrokerDurableState | undefined;
+    const broker = new ReplicaBroker({
+      workspaceId,
+      viewId: "view-remote",
+      viewRoot,
+      stateRoot,
+      replicaChangeLog: logWithChanges(async (revision) => {
+        requested.push(revision);
+        if (revision === 0) throw remoteResync(cutChange, "epoch-remote");
+        return revision === 3 ? [forward] : [];
+      }),
+      snapshotSource: {
+        snapshotAt: async (record) => {
+          if (record.revision === 3) {
+            observedDurableResync = await new BrokerDurableStateStore(stateRoot).load();
+          }
+          return structuredClone(snapshots.get(record.commitSha)!);
+        }
+      }
+    });
+
+    const state = await broker.synchronize();
+
+    assert.equal(observedDurableResync?.mode, "RESYNC_REQUIRED");
+    assert.equal(observedDurableResync?.resyncTarget?.revision, 3);
+    assert.equal(state.mode, "READY");
+    assert.equal(state.resyncTarget, undefined);
+    assert.equal(state.epoch, "epoch-remote");
+    assert.equal(state.receivedCursor, 4);
+    assert.equal(state.resolvedCursor, 4);
+    assert.deepEqual(requested, [0, 3]);
+    assert.equal(await readFile(path.join(viewRoot, "notes.md"), "utf8"), "forward\n");
+  });
+});
+
+test("onNotification consumes a resync raised by snapshotAt without an unhandled rejection", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const first = change(1, "commit-1", null);
+    const cutChange = change(3, "commit-3", "commit-2");
+    let snapshotRequests = 0;
+    const broker = new ReplicaBroker({
+      workspaceId,
+      viewId: "view-remote",
+      viewRoot,
+      stateRoot,
+      replicaChangeLog: logWithChanges(async (revision) => revision === 0 ? [first] : []),
+      snapshotSource: {
+        snapshotAt: async (record) => {
+          snapshotRequests += 1;
+          if (record.revision === 1) throw remoteResync(cutChange, "epoch-replaced");
+          return snapshot(cutChange, { "notes.md": "replacement\n" });
+        }
+      }
+    });
+
+    const state = await broker.onNotification(first);
+
+    assert.equal(state.mode, "READY");
+    assert.equal(state.resolvedCursor, 3);
+    assert.equal(snapshotRequests, 2);
+    assert.equal(await readFile(path.join(viewRoot, "notes.md"), "utf8"), "replacement\n");
+  });
+});
+
+test("restart resumes a durable resync target without querying below the cut", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const cutChange = change(5, "commit-5", "commit-4");
+    const first = new ReplicaBroker({
+      workspaceId,
+      viewId: "view-remote",
+      viewRoot,
+      stateRoot,
+      replicaChangeLog: logWithChanges(async () => {
+        throw remoteResync(cutChange, "epoch-restart");
+      }),
+      snapshotSource: {
+        snapshotAt: async () => {
+          throw new Error("CRASH_DURING_RESYNC_BOOTSTRAP");
+        }
+      }
+    });
+    await assert.rejects(first.synchronize(), /CRASH_DURING_RESYNC_BOOTSTRAP/u);
+    assert.equal(first.snapshotState().mode, "RESYNC_REQUIRED");
+
+    const requested: number[] = [];
+    const restarted = new ReplicaBroker({
+      workspaceId,
+      viewId: "view-remote",
+      viewRoot,
+      stateRoot,
+      replicaChangeLog: logWithChanges(async (revision) => {
+        requested.push(revision);
+        assert.equal(revision, 5, "restart must not request the below-cut durable cursor");
+        return [];
+      }),
+      snapshotSource: {
+        snapshotAt: async () => snapshot(cutChange, { "notes.md": "recovered\n" })
+      }
+    });
+
+    const recovered = await restarted.synchronize();
+
+    assert.equal(recovered.mode, "READY");
+    assert.equal(recovered.resolvedCursor, 5);
+    assert.deepEqual(requested, [5]);
+    assert.equal(await readFile(path.join(viewRoot, "notes.md"), "utf8"), "recovered\n");
+  });
+});
+
+test("an empty revision-zero cut is a valid bootstrap target", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const existing = change(1, "commit-1", null);
+    let resyncPending = true;
+    const broker = new ReplicaBroker({
+      workspaceId,
+      viewId: "view-remote",
+      viewRoot,
+      stateRoot,
+      replicaChangeLog: logWithChanges(async (revision) => {
+        if (revision === 0 && !resyncPending) return [];
+        if (revision === 0) return [existing];
+        resyncPending = false;
+        throw emptyRemoteResync();
+      }),
+      snapshotSource: {
+        snapshotAt: async () => snapshot(existing, { "notes.md": "old\n" })
+      }
+    });
+
+    await broker.synchronize();
+    const state = await broker.synchronize();
+
+    assert.equal(state.mode, "READY");
+    assert.equal(state.epoch, "epoch-empty-replacement");
+    assert.equal(state.resolvedCursor, 0);
+    await assert.rejects(readFile(path.join(viewRoot, "notes.md")), /ENOENT/u);
+  });
+});
+
+test("remote runtime and optional production composition start and stop their persistent session cleanly", async () => {
+  await withRoots(async ({ root, viewRoot, stateRoot }) => {
+    const directClient = new EmptyReadDownClient();
+    const runtime = new RemoteBrokerRuntime({
+      workspaceId,
+      viewId: "view-remote",
+      viewRoot,
+      stateRoot,
+      session: {
+        client: directClient as unknown as PersistentSshAuthorityClient,
+        backoff: { initialMs: 0, maximumMs: 0, multiplier: 1 }
+      }
+    });
+    const started = await runtime.start();
+    assert.equal(started.mode, "READY");
+    assert.equal(directClient.connectRequests, 1);
+    assert.equal(directClient.notificationListeners.size, 1);
+    await runtime.stop();
+    await runtime.stop();
+    assert.equal(directClient.closeRequests, 1);
+    assert.equal(directClient.notificationListeners.size, 0);
+    assert.equal(directClient.disconnectListeners.size, 0);
+
+    const composedClient = new EmptyReadDownClient();
+    const composition = createProductionCompoundReceiptComposition({
+      workspaceId,
+      viewId: "view-composed",
+      canonicalRoot: path.join(root, "composed-view"),
+      stateDirectory: path.join(root, "composed-state"),
+      remoteReadDown: {
+        client: composedClient as unknown as PersistentSshAuthorityClient,
+        backoff: { initialMs: 0, maximumMs: 0, multiplier: 1 }
+      }
+    });
+    await composition.start();
+    await composition.stop();
+    assert.equal(composedClient.closeRequests, 1);
+  });
+});
+
+test("non-resync failures still fail closed and do not manufacture a resync transition", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const broker = new ReplicaBroker({
+      workspaceId,
+      viewId: "view-remote",
+      viewRoot,
+      stateRoot,
+      replicaChangeLog: logWithChanges(async () => {
+        throw new Error("REMOTE_READ_FAILED");
+      }),
+      snapshotSource: { snapshotAt: async (record) => snapshot(record, {}) }
+    });
+    await assert.rejects(broker.synchronize(), /REMOTE_READ_FAILED/u);
+    assert.equal(broker.snapshotState().mode, "READY");
+  });
+});
+
+class EmptyReadDownClient {
+  readonly notificationListeners = new Set<(change: ReplicaChangeRecord) => void>();
+  readonly disconnectListeners = new Set<() => void>();
+  readonly fixture = emptySnapshotFixture();
+  connectRequests = 0;
+  closeRequests = 0;
+
+  async connect(): Promise<void> {
+    this.connectRequests += 1;
+  }
+
+  async reconnect(): Promise<void> {
+    this.connectRequests += 1;
+  }
+
+  async beginSnapshotAndSubscribe(): Promise<AuthoritySnapshotReservation> {
+    return structuredClone(this.fixture.reservation);
+  }
+
+  async getSnapshotManifest(): Promise<AuthoritySnapshotManifest> {
+    return structuredClone(this.fixture.manifest);
+  }
+
+  async getCutChange(): Promise<null> {
+    return null;
+  }
+
+  async getBlob(): Promise<never> {
+    throw new Error("empty snapshot has no blobs");
+  }
+
+  async changesAfter(_streamToken: string, sinceRevision: number): Promise<AuthorityChangesAfterResult> {
+    return {
+      schema: "authority-changes-after/v1",
+      sinceRevision,
+      throughRevision: sinceRevision,
+      changes: []
+    };
+  }
+
+  async renewLease(): Promise<AuthoritySnapshotLease> {
+    return structuredClone(this.fixture.reservation.lease);
+  }
+
+  onNotification(listener: (change: ReplicaChangeRecord) => void): () => void {
+    this.notificationListeners.add(listener);
+    return () => this.notificationListeners.delete(listener);
+  }
+
+  onDisconnect(listener: () => void): () => void {
+    this.disconnectListeners.add(listener);
+    return () => this.disconnectListeners.delete(listener);
+  }
+
+  async close(): Promise<void> {
+    this.closeRequests += 1;
+  }
+}
+
+function logWithChanges(
+  changesAfter: (revision: number) => Promise<ReadonlyArray<ReplicaChangeRecord>>
+): ReplicaChangeLog {
+  return {
+    append: async () => {},
+    latest: async () => undefined,
+    getByOperation: async () => undefined,
+    changesAfter: async (_workspace, revision) => changesAfter(revision),
+    subscribe: () => () => {}
+  };
+}
+
+function change(revision: number, commitSha: string, previousCommit: string | null): ReplicaChangeRecord {
+  return {
+    schema: "replica-change/v2",
+    workspaceId,
+    revision,
+    opId: `op-${revision}`,
+    semanticDigest: `semantic-${revision}`,
+    operations: [{ opId: `op-${revision}`, semanticDigest: `semantic-${revision}` }],
+    commitSha,
+    previousCommit,
+    changedAt: "2026-07-23T08:00:00.000Z",
+    manifest: { digest: sha256(`manifest-${revision}`), entryCount: 1 },
+    paths: []
+  };
+}
+
+function snapshot(
+  record: ReplicaChangeRecord,
+  files: Readonly<Record<string, string>>
+): CanonicalSnapshot {
+  return {
+    workspaceId,
+    revision: record.revision,
+    commitSha: record.commitSha,
+    entries: Object.entries(files).map(([pathName, content]) => ({
+      path: pathName,
+      content: Buffer.from(content),
+      logicalMode: 0o644
+    }))
+  };
+}
+
+function remoteResync(
+  cutChange: ReplicaChangeRecord,
+  epoch: string
+): RemoteReplicaResyncRequiredError {
+  return new RemoteReplicaResyncRequiredError("test cut", {
+    workspaceId,
+    epoch,
+    revision: cutChange.revision,
+    commitSha: cutChange.commitSha,
+    manifestDigest: cutChange.manifest.digest,
+    provenanceDigest: sha256(`provenance-${cutChange.revision}`)
+  }, cutChange);
+}
+
+function emptyRemoteResync(): RemoteReplicaResyncRequiredError {
+  return new RemoteReplicaResyncRequiredError("empty test cut", {
+    workspaceId,
+    epoch: "epoch-empty-replacement",
+    revision: 0,
+    commitSha: "0".repeat(40),
+    manifestDigest: sha256("empty-manifest"),
+    provenanceDigest: sha256("empty-provenance")
+  }, null);
+}
+
+function emptySnapshotFixture(): {
+  readonly reservation: AuthoritySnapshotReservation;
+  readonly manifest: AuthoritySnapshotManifest;
+} {
+  const now = Date.now();
+  const cutBase = {
+    workspaceId,
+    epoch: "epoch-empty",
+    revision: 0,
+    commitSha: "0".repeat(40)
+  };
+  const cut = {
+    ...cutBase,
+    manifestDigest: manifestDigest(cutBase, []),
+    provenanceDigest: sha256("empty-provenance")
+  };
+  const reservation: AuthoritySnapshotReservation = {
+    schema: "authority-snapshot-reservation/v1",
+    cut,
+    lease: {
+      leaseId: "lease-empty",
+      expiresAt: new Date(now + 60_000).toISOString(),
+      renewableUntil: new Date(now + 3_600_000).toISOString(),
+      minRetainedRevision: 0,
+      pinnedBlobSetDigest: sha256("empty-set")
+    },
+    stream: { streamToken: "stream-empty", fromRevision: 1 }
+  };
+  return {
+    reservation,
+    manifest: { schema: "authority-snapshot-manifest/v1", cut, entries: [] }
+  };
+}
+
+function sha256(text: string): Sha256Digest {
+  return `sha256:${createHash("sha256").update(text).digest("hex")}`;
+}
+
+async function withRoots(
+  body: (roots: {
+    readonly root: string;
+    readonly viewRoot: string;
+    readonly stateRoot: string;
+  }) => Promise<void>
+): Promise<void> {
+  const root = await mkdtemp(path.join(tmpdir(), "ha-remote-broker-runtime-"));
+  try {
+    await body({
+      root,
+      viewRoot: path.join(root, "view"),
+      stateRoot: path.join(root, "state")
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/packages/daemon/test/remote-read-down-adapters.test.ts
+++ b/packages/daemon/test/remote-read-down-adapters.test.ts
@@ -468,7 +468,7 @@ class FakeReadDownClient {
     this.connectRequests += 1;
     if (this.connectFailures > 0) {
       this.connectFailures -= 1;
-      throw new Error("scripted connect failure");
+      throw new AuthorityTransportDisconnectedError("scripted connect failure");
     }
   }
 
@@ -476,7 +476,7 @@ class FakeReadDownClient {
     this.reconnectRequests += 1;
     if (this.connectFailures > 0) {
       this.connectFailures -= 1;
-      throw new Error("scripted reconnect failure");
+      throw new AuthorityTransportDisconnectedError("scripted reconnect failure");
     }
     if (this.advanceOnReconnect && this.snapshotIndex < this.snapshots.length - 1) this.snapshotIndex += 1;
   }


### PR DESCRIPTION
# English

## Summary

Assembles RD-B's remote read-down components into a runnable broker: composes `RemoteReplicaChangeLog` + `RemoteCanonicalSnapshotSource` + `RemoteReadDownSession` with `ReplicaBroker` into a `RemoteBrokerRuntime` (start/stop with clean background join, serialized synchronization), and teaches `ReplicaBroker.synchronize` to consume the remote `RemoteReplicaResyncRequiredError` — persisting a durable `RESYNC_REQUIRED` target and bootstrapping from the cut snapshot, so a restart recovers from the durable cut rather than backfilling a below-cut log. This is the transparent-workspace read-down path made runnable. No CLI dual-root (RD-D), no two-host E2E (RD-E); the default local composition path is unchanged.

## What Changed

- **`RemoteBrokerRuntime`** (`broker/remote-broker-runtime.ts`, new): composes the three RD-B components + `ReplicaBroker`; `start()`/`stop()`/`close()` are idempotent; `stop()` unsubscribes and awaits `[session.close(), startTask, synchronizationTail]` (clean background join, inheriting RD-B's `close()` quiescence); synchronizations are serialized through a `synchronizationTail` chain so concurrent notifications never race.
- **`ReplicaBroker.synchronize`** (`broker/replica-broker.ts`): a retry loop catches `RemoteReplicaResyncRequiredError` (from both `changesAfter` and `snapshotAt` throw points) → `enterRemoteResync` validates the cut identity (workspace/revision/commitSha; non-zero revision requires a cutChange) and persists `mode=RESYNC_REQUIRED` + a durable `resyncTarget` → `bootstrapResync` materializes `snapshotAt(cutChange)`, validates snapshot identity, and persists `READY`. Non-resync errors re-throw (fail closed). A durable `RESYNC_REQUIRED` with a target re-bootstraps on the first `synchronize` after restart — no below-cut cursor query.
- **`BrokerDurableState.resyncTarget`** (`broker/types.ts`): new durable field carrying `{epoch, revision, commitSha, cutChange}`.
- **`replica-broker-state.ts`** (new): pure helper extraction (version/tombstone/conflict-reason) to keep `replica-broker.ts` under the file-complexity gate.
- **`compound-receipt-composition.ts`**: an **optional** `remoteReadDown` assembly path + start/stop lifecycle hooks; when absent the local path is unchanged (and still requires a local `replicaChangeLog`).

## Task And Scope

- Task: `task_01KY7JNMMMQVM8TVF7YDJWC2Q6` (RD-C), parent `task_01KXBGXDWQ0AW1CBAEHA8D3PNP` (transparent-workspace implementation root, ADR-0029), depends-on RD-B `task_01KY6YPRFAWPRPJD943N13NHZK` (done).
- File surface: `packages/daemon/src/broker/**` + `packages/daemon/src/lifecycle/**` (composition assembly only) + tests. RD-B's adapters, the wire contract, the authority server, and CLI root selection (RD-D) are untouched.

## Version Impact

Additive. `resyncTarget` is a new optional durable field; the remote assembly path is opt-in. No existing wire frame, type, or default behavior changed.

## Governance Declaration

- Direction accepted by `dec_01KXB6ZB1EAPEZN04T3KR6T2YQ` (transparent workspace) + read-down subdecision `dec_01KXB6ZS4EBW8EPWR7132CTBJY`. No new decision required — implements the accepted design's next layer (broker runtime assembly).
- Read-down only; resync is persisted durably (state-based, not below-cut log backfill); the default local composition is unchanged.

## Verification

- `npm run check:local` green (34 manifest gates); `npm run test:integration` exit 0 (1230 tests, 1226 pass, 0 fail, 4 skipped). The worker also resolved file-complexity and duplicate-helper-name gate findings during verification.
- New `remote-broker-runtime.test.ts` covers the failure paths: resync-cut persist → bootstrap → resume forward; `onNotification` consuming a `snapshotAt`-raised resync with no unhandled rejection; restart resuming a durable resync target without querying below the cut; empty revision-zero cut bootstrap; clean runtime + composition start/stop; non-resync failures staying fail-closed without manufacturing a resync transition.
- `check-cli-daemon-parity` is CI-only/hermetic; verified in this PR's CI, not locally.

## Review Evidence

- CEO semantic + architecture verification (non-delegable), with explicit focus on failure paths (per the RD-B lesson that happy-path CI + architecture reads miss concurrency/lifecycle races): file surface is within the authorized broker/lifecycle scope; RD-B adapters, wire, authority server, and CLI are untouched. Verified in code: `synchronize` consumes the remote resync from both throw points and does not leak an unhandled rejection; `enterRemoteResync` validates the cut identity at the broker boundary; the durable `resyncTarget` drives restart recovery without a below-cut query; `bootstrapResync` validates snapshot identity before materializing; non-resync errors fail closed; `RemoteBrokerRuntime` serializes synchronizations and joins all background work on stop; the composition default stays local.
- Black-box adversarial review (failure-path focus) routed at open; findings ground-truthed before merge.

## Residual Risk

- The remote assembly path is constructible and tested but selection of the remote root is RD-D (CLI dual-root); this PR does not flip the default.
- Two-host E2E (RD-E) is out of scope and will exercise the full path on real hardware.

## References

- Decisions: `dec_01KXB6ZB1EAPEZN04T3KR6T2YQ`, `dec_01KXB6ZS4EBW8EPWR7132CTBJY`
- ADR-0029 transparent workspace; RD-A/RD-A.1/RD-B (done); parent `task_01KXBGXDWQ0AW1CBAEHA8D3PNP`; unblocks RD-D

---

# 中文

## 概要

把 RD-B 的远程 read-down 组件装配成可运行的 broker:用 `RemoteReplicaChangeLog` + `RemoteCanonicalSnapshotSource` + `RemoteReadDownSession` 组合 `ReplicaBroker` 成 `RemoteBrokerRuntime`(start/stop 干净后台 join、synchronization 串行化),并让 `ReplicaBroker.synchronize` 消费远程 `RemoteReplicaResyncRequiredError`——持久 `RESYNC_REQUIRED` target 并从 cut snapshot bootstrap,使重启从 durable cut 恢复而非补拉 below-cut log。这是透明工作区 read-down 路径的可运行化。不做 CLI 双根(RD-D)、不做两机 E2E(RD-E);默认本地装配路径不变。

## 改动内容

- **`RemoteBrokerRuntime`**(`broker/remote-broker-runtime.ts`,新):组合三个 RD-B 组件 + `ReplicaBroker`;`start()`/`stop()`/`close()` 幂等;`stop()` 取消订阅并 await `[session.close(), startTask, synchronizationTail]`(干净后台 join,承 RD-B `close()` 静默语义);synchronization 经 `synchronizationTail` 链串行,并发通知不竞争。
- **`ReplicaBroker.synchronize`**(`broker/replica-broker.ts`):retry loop catch `RemoteReplicaResyncRequiredError`(`changesAfter` 与 `snapshotAt` 两个抛出点)→ `enterRemoteResync` 校验 cut identity(workspace/revision/commitSha;非零 revision 必带 cutChange)并持久 `mode=RESYNC_REQUIRED` + durable `resyncTarget` → `bootstrapResync` 物化 `snapshotAt(cutChange)`、校验 snapshot identity、持久 `READY`。非 resync 错误 re-throw(fail closed)。durable `RESYNC_REQUIRED` 带 target 时,重启后首次 `synchronize` 重新 bootstrap——不查 below-cut cursor。
- **`BrokerDurableState.resyncTarget`**(`broker/types.ts`):新 durable 字段,携带 `{epoch, revision, commitSha, cutChange}`。
- **`replica-broker-state.ts`**(新):纯 helper 抽取(version/tombstone/conflict-reason),使 `replica-broker.ts` 保持在 file-complexity 门下。
- **`compound-receipt-composition.ts`**:**可选** `remoteReadDown` 装配路径 + start/stop 生命周期钩子;缺省时本地路径不变(且仍要求本地 `replicaChangeLog`)。

## 任务与范围

- 任务:`task_01KY7JNMMMQVM8TVF7YDJWC2Q6`(RD-C),父 `task_01KXBGXDWQ0AW1CBAEHA8D3PNP`(透明工作区实现 root,ADR-0029),depends-on RD-B `task_01KY6YPRFAWPRPJD943N13NHZK`(done)。
- 文件面:仅 `packages/daemon/src/broker/**` + `packages/daemon/src/lifecycle/**`(装配)+ 测试。RD-B adapter、wire 契约、authority 服务端、CLI 根选择(RD-D)零改动。

## 版本影响

加性。`resyncTarget` 是新可选 durable 字段;远程装配路径 opt-in。未改任何既有 wire 帧、类型或默认行为。

## 治理声明

- 方向由 `dec_01KXB6ZB1EAPEZN04T3KR6T2YQ`(透明工作区)+ read-down 子决策 `dec_01KXB6ZS4EBW8EPWR7132CTBJY` 接受。**无需新裁决**——实现已接受设计的下一层(broker runtime 装配)。
- read-down only;resync 持久落 durable(状态式,非 below-cut log 补拉);默认本地装配不变。

## 验证

- `npm run check:local` 绿(34 manifest gates);`npm run test:integration` exit 0(1230 测试,1226 pass,0 fail,4 skipped)。worker 验证中另修了 file-complexity 与 duplicate-helper-name 门。
- 新增 `remote-broker-runtime.test.ts` 覆盖失败路径:resync-cut 持久 → bootstrap → resume;`onNotification` 消费 `snapshotAt` 抛的 resync 无未处理 rejection;重启从 durable target 恢复不查 below-cut;revision-0 空 cut bootstrap;runtime + composition 干净启停;非 resync fail-closed 不伪造 resync 转移。
- `check-cli-daemon-parity` CI-only/hermetic,本 PR 的 CI 验,非本地。

## 审查证据

- CEO 语义+架构验收(不可下放),显式聚焦失败路径(承 RD-B 教训:happy-path CI + 架构读会漏并发/生命周期竞争):文件面在授权 broker/lifecycle 内;RD-B adapter、wire、authority 服务端、CLI 零改动。代码里已验:`synchronize` 从两个抛出点消费远程 resync 且不逃逸未处理 rejection;`enterRemoteResync` 在 broker 边界校验 cut identity;durable `resyncTarget` 驱动重启恢复不查 below-cut;`bootstrapResync` 物化前校验 snapshot identity;非 resync 错误 fail closed;`RemoteBrokerRuntime` 串行化 synchronization 并在 stop 时 join 全后台;composition 默认仍本地。
- 黑盒对抗复核(失败路径聚焦)在开 PR 后路由;findings 合并前 ground-truth。

## 残余风险

- 远程装配路径可构造且有测,但选择远程根是 RD-D(CLI 双根);本 PR 不翻默认。
- 两机 E2E(RD-E)不在范围,将在真实硬件上跑全路径。

## 关联材料

- 决策:`dec_01KXB6ZB1EAPEZN04T3KR6T2YQ`、`dec_01KXB6ZS4EBW8EPWR7132CTBJY`
- ADR-0029 透明工作区;RD-A/RD-A.1/RD-B(done);父 `task_01KXBGXDWQ0AW1CBAEHA8D3PNP`;解除 RD-D
