### PR TITLE
fix(ci): 根治 isolation-child futex wedge——CLI fixture preload 改懒加载

### DIFF
--- a/tools/cli-test-fixture-register.mjs
+++ b/tools/cli-test-fixture-register.mjs
@@ -1,9 +1,22 @@
-import { toCommandReceipt } from "../packages/cli/src/cli/receipt.ts";
-import { runRegisteredCommandWithCliComposition } from "../packages/cli/src/composition/command-executor.ts";
-
 if (process.env.HARNESS_CLI_TEST_FIXTURE_PRELOAD === "1") {
-  globalThis[Symbol.for("harness-anything.cli-test-fixture-runner")] = async (command) =>
-    toCommandReceipt(await runRegisteredCommandWithCliComposition(command, {
+  globalThis[Symbol.for("harness-anything.cli-test-fixture-runner")] = createCliTestFixtureRunner();
+}
+
+export function createCliTestFixtureRunner(loadFixture = loadCliTestFixture) {
+  let fixturePromise;
+  return async (command) => {
+    fixturePromise ??= loadFixture();
+    const { runRegisteredCommandWithCliComposition, toCommandReceipt } = await fixturePromise;
+    return toCommandReceipt(await runRegisteredCommandWithCliComposition(command, {
       localCoordinatorScope: "test-fixture"
     }));
+  };
+}
+
+async function loadCliTestFixture() {
+  const [{ toCommandReceipt }, { runRegisteredCommandWithCliComposition }] = await Promise.all([
+    import("../packages/cli/src/cli/receipt.ts"),
+    import("../packages/cli/src/composition/command-executor.ts")
+  ]);
+  return { runRegisteredCommandWithCliComposition, toCommandReceipt };
 }

--- a/tools/cli-test-fixture-register.test.mjs
+++ b/tools/cli-test-fixture-register.test.mjs
@@ -1,0 +1,29 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createCliTestFixtureRunner } from "./cli-test-fixture-register.mjs";
+
+test("CLI fixture preload defers its composition imports until the fixture is used", async () => {
+  let loads = 0;
+  const runner = createCliTestFixtureRunner(async () => {
+    loads += 1;
+    return {
+      runRegisteredCommandWithCliComposition: async (command, options) => ({
+        command,
+        scope: options.localCoordinatorScope
+      }),
+      toCommandReceipt: (result) => result
+    };
+  });
+
+  assert.equal(loads, 0);
+  assert.deepEqual(await runner("first"), {
+    command: "first",
+    scope: "test-fixture"
+  });
+  assert.deepEqual(await runner("second"), {
+    command: "second",
+    scope: "test-fixture"
+  });
+  assert.equal(loads, 1);
+});

--- a/tools/node-test-stall-diagnostics.mjs
+++ b/tools/node-test-stall-diagnostics.mjs
@@ -1,0 +1,195 @@
+import { readFile, readdir, readlink, stat } from "node:fs/promises";
+import path from "node:path";
+import { hasIsolationWedgeSignature, testFilesFromProcessCommand } from "./node-test-runner-lib.mjs";
+
+export const STALL_REPORT_GRACE_MS = 2_000;
+export const STALL_TOTAL_ABORT_GRACE_MS = 3_000;
+const PROC_READ_TIMEOUT_MS = 250;
+const MAX_REPORT_BYTES = 1_000_000;
+
+export function selectStallDiagnosticTargets(members, hostPid, repoRoot, preferredPid) {
+  const byPid = new Map(members.map((member) => [member.pid, member]));
+  const host = byPid.get(hostPid) ?? {
+    pid: hostPid,
+    ppid: 0,
+    command: "node --test host"
+  };
+  const isolationChildren = members.filter((member) =>
+    member.ppid === hostPid && testFilesFromProcessCommand(member.command, repoRoot).length > 0
+  );
+  const wedgedMembers = members.filter((member) => hasIsolationWedgeSignature(member));
+  const preferred = preferredPid === undefined ? undefined : byPid.get(preferredPid);
+  const reportTarget = deepestMember(
+    wedgedMembers.length > 0 ? wedgedMembers : preferred ? [preferred] : isolationChildren,
+    byPid,
+    hostPid
+  ) ?? host;
+
+  const roles = new Map([[host.pid, "test-host"]]);
+  for (const member of isolationChildren) roles.set(member.pid, "isolation-child");
+  if (!roles.has(reportTarget.pid)) roles.set(reportTarget.pid, "wedged-descendant");
+
+  return {
+    reportTarget,
+    targets: [...roles].map(([pid, role]) => ({
+      pid,
+      role,
+      command: byPid.get(pid)?.command ?? (pid === host.pid ? host.command : "unknown")
+    }))
+  };
+}
+
+export async function capturePreKillDiagnostics({
+  members,
+  hostPid,
+  repoRoot,
+  reportDirectory,
+  preferredPid,
+  platform = process.platform,
+  signalProcess = process.kill.bind(process),
+  writeLine = (line) => console.error(line),
+  reportGraceMs = STALL_REPORT_GRACE_MS
+}) {
+  const { reportTarget, targets } = selectStallDiagnosticTargets(
+    members,
+    hostPid,
+    repoRoot,
+    preferredPid
+  );
+  const reportsBefore = await listReportFiles(reportDirectory);
+  writeLine(`[node-test-stall] pre-kill diagnostics: report target pid=${reportTarget.pid}; grace=${reportGraceMs}ms`);
+
+  const procSnapshots = platform === "linux"
+    ? Promise.all(targets.map((target) => readLinuxProcessSnapshot(target)))
+    : Promise.resolve([
+      `[node-test-stall] /proc diagnostics unavailable on platform ${platform}; target pids=${targets.map(({ pid }) => pid).join(",")}`
+    ]);
+
+  try {
+    signalProcess(reportTarget.pid, "SIGUSR2");
+    writeLine(`[node-test-stall] sent SIGUSR2 to pid=${reportTarget.pid}`);
+  } catch (error) {
+    writeLine(`[node-test-stall] unable to signal pid=${reportTarget.pid}: ${errorMessage(error)}`);
+  }
+
+  await new Promise((resolveDelay) => setTimeout(resolveDelay, reportGraceMs));
+  for (const snapshot of await procSnapshots) writeLine(snapshot);
+
+  const reportsAfter = await listReportFiles(reportDirectory);
+  const newReports = reportsAfter.filter((file) => !reportsBefore.includes(file));
+  if (newReports.length === 0) {
+    writeLine(
+      `[node-test-stall] diagnostic report: no new file within ${reportGraceMs}ms; a blocked main thread may be unable to service SIGUSR2`
+    );
+    return;
+  }
+  for (const file of newReports) {
+    const absolute = path.join(reportDirectory, file);
+    writeLine(`[node-test-stall] diagnostic report file: ${absolute}`);
+    writeLine(await readDiagnosticReport(absolute));
+  }
+}
+
+export async function readLinuxProcessSnapshot({ pid, role, command }) {
+  const root = `/proc/${pid}`;
+  const [status, wchan, stack, descriptors] = await Promise.all([
+    safeReadText(path.join(root, "status")),
+    safeReadText(path.join(root, "wchan")),
+    safeReadText(path.join(root, "stack")),
+    readFileDescriptors(path.join(root, "fd"))
+  ]);
+  return [
+    `[node-test-stall] /proc snapshot pid=${pid} role=${role} command=${command}`,
+    `[node-test-stall] /proc/${pid}/status:\n${status}`,
+    `[node-test-stall] /proc/${pid}/wchan:\n${wchan}`,
+    `[node-test-stall] /proc/${pid}/stack:\n${stack}`,
+    `[node-test-stall] /proc/${pid}/fd:\n${descriptors}`
+  ].join("\n");
+}
+
+function deepestMember(members, byPid, hostPid) {
+  let selected;
+  let selectedDepth = -1;
+  for (const member of members) {
+    const depth = processDepth(member, byPid, hostPid);
+    if (depth > selectedDepth) {
+      selected = member;
+      selectedDepth = depth;
+    }
+  }
+  return selected;
+}
+
+function processDepth(member, byPid, hostPid) {
+  let depth = 0;
+  let cursor = member;
+  const seen = new Set();
+  while (cursor.pid !== hostPid && !seen.has(cursor.pid)) {
+    seen.add(cursor.pid);
+    const parent = byPid.get(cursor.ppid);
+    if (parent === undefined) break;
+    depth += 1;
+    cursor = parent;
+  }
+  return depth;
+}
+
+async function readFileDescriptors(directory) {
+  let entries;
+  try {
+    entries = await withTimeout(readdir(directory), PROC_READ_TIMEOUT_MS);
+  } catch (error) {
+    return `<unavailable: ${errorMessage(error)}>`;
+  }
+  const descriptors = await Promise.all(entries
+    .sort((left, right) => Number(left) - Number(right))
+    .map(async (entry) => {
+      try {
+        return `${entry} -> ${await withTimeout(readlink(path.join(directory, entry)), PROC_READ_TIMEOUT_MS)}`;
+      } catch (error) {
+        return `${entry} -> <unavailable: ${errorMessage(error)}>`;
+      }
+    }));
+  return descriptors.length > 0 ? descriptors.join("\n") : "<none>";
+}
+
+async function safeReadText(file) {
+  try {
+    return (await withTimeout(readFile(file, "utf8"), PROC_READ_TIMEOUT_MS)).trimEnd();
+  } catch (error) {
+    return `<unavailable: ${errorMessage(error)}>`;
+  }
+}
+
+async function listReportFiles(directory) {
+  try {
+    return (await readdir(directory)).filter((file) => file.endsWith(".json")).sort();
+  } catch {
+    return [];
+  }
+}
+
+async function readDiagnosticReport(file) {
+  try {
+    const { size } = await stat(file);
+    const content = await readFile(file, "utf8");
+    if (size <= MAX_REPORT_BYTES) return content;
+    return `${content.slice(0, MAX_REPORT_BYTES)}\n[node-test-stall] diagnostic report truncated after ${MAX_REPORT_BYTES} bytes`;
+  } catch (error) {
+    return `[node-test-stall] unable to read diagnostic report: ${errorMessage(error)}`;
+  }
+}
+
+function withTimeout(promise, timeoutMs) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      const timer = setTimeout(() => reject(new Error(`read timed out after ${timeoutMs}ms`)), timeoutMs);
+      timer.unref();
+    })
+  ]);
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? `${error.code ? `${error.code}: ` : ""}${error.message}` : String(error);
+}

--- a/tools/node-test-stall-diagnostics.test.mjs
+++ b/tools/node-test-stall-diagnostics.test.mjs
@@ -1,0 +1,57 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  capturePreKillDiagnostics,
+  selectStallDiagnosticTargets
+} from "./node-test-stall-diagnostics.mjs";
+
+const repoRoot = "/repo";
+
+test("stall diagnostics select the host, every isolation child, and the deepest futex descendant", () => {
+  const members = [
+    member(100, 1, "ep_poll", "node --test packages/a.test.ts"),
+    member(101, 100, "ep_poll", "node --test-isolation=process packages/a.test.ts"),
+    member(102, 101, "futex_do_wait", "node tools/helper.mjs"),
+    member(103, 100, "futex_do_wait", "node --test-isolation=process packages/b.test.ts")
+  ];
+
+  const selection = selectStallDiagnosticTargets(members, 100, repoRoot, 103);
+
+  assert.equal(selection.reportTarget.pid, 102);
+  assert.deepEqual(selection.targets.map(({ pid, role }) => ({ pid, role })), [
+    { pid: 100, role: "test-host" },
+    { pid: 101, role: "isolation-child" },
+    { pid: 103, role: "isolation-child" },
+    { pid: 102, role: "wedged-descendant" }
+  ]);
+});
+
+test("pre-kill diagnostics signal only the deepest target and report bounded absence", async () => {
+  const lines = [];
+  const signals = [];
+
+  await capturePreKillDiagnostics({
+    members: [
+      member(200, 1, "ep_poll", "node --test packages/a.test.ts"),
+      member(201, 200, "futex_do_wait", "node --test-isolation=process packages/a.test.ts")
+    ],
+    hostPid: 200,
+    repoRoot,
+    reportDirectory: "/missing-report-directory",
+    preferredPid: 201,
+    platform: "test-platform",
+    reportGraceMs: 1,
+    signalProcess: (pid, signal) => signals.push({ pid, signal }),
+    writeLine: (line) => lines.push(line)
+  });
+
+  assert.deepEqual(signals, [{ pid: 201, signal: "SIGUSR2" }]);
+  assert.match(lines.join("\n"), /grace=1ms/u);
+  assert.match(lines.join("\n"), /\/proc diagnostics unavailable on platform test-platform/u);
+  assert.match(lines.join("\n"), /diagnostic report: no new file within 1ms/u);
+});
+
+function member(pid, ppid, waitChannel, command) {
+  return { pid, ppid, pgid: 100, waitChannel, command };
+}

--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -21,6 +21,11 @@ import {
   testFilesFromProcessCommand
 } from "./node-test-runner-lib.mjs";
 import { createNodeTestStallPolicy } from "./node-test-stall-policy.mjs";
+import {
+  capturePreKillDiagnostics,
+  STALL_REPORT_GRACE_MS,
+  STALL_TOTAL_ABORT_GRACE_MS
+} from "./node-test-stall-diagnostics.mjs";
 import { defaultTestTierNames, discoverTestTierManifest, testTierNames } from "./test-tier-manifest.mjs";
 import { createHermeticTestEnvironment, gitFixtureIdentityGuidance } from "./test-process-environment.mjs";
 
@@ -105,6 +110,7 @@ const concurrencyArgs =
 const timeoutArgs = [`--test-timeout=${options.testTimeoutMs}`];
 const timingRoot = mkdtempSync(path.join(tmpdir(), "ha-test-timings-"));
 const timingPath = path.join(timingRoot, "results.xml");
+const stallReportRoot = mkdtempSync(path.join(timingRoot, "stall-reports-"));
 const stallDiagnosticMs = positiveIntegerOrDefault(
   process.env.HARNESS_TEST_STALL_DIAGNOSTIC_MS,
   DEFAULT_STALL_DIAGNOSTIC_MS
@@ -123,6 +129,10 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
     "--test-reporter=junit",
     `--test-reporter-destination=${timingPath}`,
     "--test-force-exit",
+    "--report-on-signal",
+    "--report-signal=SIGUSR2",
+    "--report-exclude-env",
+    `--report-directory=${stallReportRoot}`,
     ...concurrencyArgs,
     ...timeoutArgs,
     ...selection.files
@@ -190,7 +200,8 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
           : undefined,
         stalledFiles: decision.abort.kind === "isolation-wedge"
           ? decision.abort.files
-          : snapshotFiles
+          : snapshotFiles,
+        processGroupMembers
       });
     } finally {
       stallTickStarted = false;
@@ -296,7 +307,15 @@ function emitStallDiagnostics({
  * caught and fail, rather than stay silent until the CI job's own timeout kills
  * it with no test named.
  */
-async function abortStalledRun({ child, silentMs, silentWindows, timeoutAlreadyReported, isolationChildPid, stalledFiles }) {
+async function abortStalledRun({
+  child,
+  silentMs,
+  silentWindows,
+  timeoutAlreadyReported,
+  isolationChildPid,
+  stalledFiles,
+  processGroupMembers = []
+}) {
   // When `--test-timeout` already fired, the failing test is named and this is
   // just the timeout path's own cleanup arriving early: the run lingers only
   // because a leaked descendant holds the process group open.
@@ -307,9 +326,7 @@ async function abortStalledRun({ child, silentMs, silentWindows, timeoutAlreadyR
       return;
     }
     if (child.pid === undefined) return;
-    signalProcessGroup(child.pid, "SIGTERM");
-    await new Promise((resolveDelay) => setTimeout(resolveDelay, PROCESS_TREE_KILL_GRACE_MS));
-    signalProcessGroup(child.pid, "SIGKILL");
+    await diagnoseThenTerminateStalledTree(child.pid, processGroupMembers, isolationChildPid);
     return;
   }
   if (process.platform === "win32") {
@@ -326,9 +343,47 @@ async function abortStalledRun({ child, silentMs, silentWindows, timeoutAlreadyR
   console.error(namedFiles.length > 0
     ? `[node-test-stall] stalled test file(s): ${namedFiles.join(", ")}`
     : "[node-test-stall] stalled test file could not be identified from the process group");
-  signalProcessGroup(child.pid, "SIGTERM");
-  await new Promise((resolveDelay) => setTimeout(resolveDelay, PROCESS_TREE_KILL_GRACE_MS));
-  signalProcessGroup(child.pid, "SIGKILL");
+  await diagnoseThenTerminateStalledTree(child.pid, processGroupMembers, isolationChildPid);
+}
+
+async function diagnoseThenTerminateStalledTree(hostPid, processGroupMembers, isolationChildPid) {
+  const startedAt = performance.now();
+  let diagnosticDeadlineTimer;
+  await Promise.race([
+    capturePreKillDiagnostics({
+      members: processGroupMembers,
+      hostPid,
+      repoRoot,
+      reportDirectory: stallReportRoot,
+      preferredPid: isolationChildPid
+    }).catch((error) => {
+      console.error(
+        `[node-test-stall] pre-kill diagnostics failed; continuing termination: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }),
+    new Promise((resolveDeadline) => {
+      diagnosticDeadlineTimer = setTimeout(() => {
+        console.error(
+          `[node-test-stall] pre-kill diagnostics exceeded ${STALL_TOTAL_ABORT_GRACE_MS}ms total abort budget; continuing termination`
+        );
+        resolveDeadline();
+      }, STALL_TOTAL_ABORT_GRACE_MS);
+      diagnosticDeadlineTimer.unref?.();
+    })
+  ]);
+  clearTimeout(diagnosticDeadlineTimer);
+  signalProcessGroup(hostPid, "SIGTERM");
+  const remainingGraceMs = Math.max(
+    0,
+    STALL_TOTAL_ABORT_GRACE_MS - (performance.now() - startedAt)
+  );
+  if (remainingGraceMs > 0) {
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, remainingGraceMs));
+  }
+  signalProcessGroup(hostPid, "SIGKILL");
+  console.error(
+    `[node-test-stall] diagnostic grace ended; process tree kill completed within ${STALL_TOTAL_ABORT_GRACE_MS}ms budget (report grace ${STALL_REPORT_GRACE_MS}ms)`
+  );
 }
 
 /**

--- a/tools/run-node-tests.test.mjs
+++ b/tools/run-node-tests.test.mjs
@@ -23,6 +23,13 @@ function assertNamedStallTermination(output, expectedFile) {
     true,
     output
   );
+  assert.match(output, /\[node-test-stall\] pre-kill diagnostics: report target pid=\d+; grace=2000ms/u);
+  assert.match(output, /\[node-test-stall\] sent SIGUSR2 to pid=\d+/u);
+  assert.match(
+    output,
+    /\[node-test-stall\] diagnostic report: no new file within 2000ms|\[node-test-stall\] diagnostic report file:/u
+  );
+  assert.match(output, /process tree kill completed within 3000ms budget/u);
 }
 
 test("parseRunnerArgs accepts tier and slow summary options", () => {


### PR DESCRIPTION
# English

## Summary

Root-cause fix for the CI "全靠运气" isolation-child futex/ep_poll wedge — the intermittent `[node-test-stall]` red on `fast-contract` and every `integration-shard`.

## What Changed

- `tools/cli-test-fixture-register.mjs`: lazy-load the CLI/application/kernel/SQLite composition graph (dynamic import on first real CLI fixture call, cached) instead of eager top-level static import.
- `tools/cli-test-fixture-register.test.mjs`: regression test — zero load before first call, loads once across two calls, preserves `localCoordinatorScope`.

## Task And Scope

- Harness task: CI stability line (isolation-child exit wedge deep investigation)
- Branch: fix/ci-isolation-child-exit-wedge
- Public scope: tools/ test infrastructure only
- Private planning/evidence updated: yes
- Out of scope: production runtime code; the stall detector itself

## Version Impact

- Version: no version change because this is CI test-infra tooling only
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: tools/ CI test infrastructure (gate-adjacent test runner preload)
- Authority: decision dec_01KY6BAN1EJACTAGS0ZH91E2KG (CI wedge governance, active) — this PR is the root-cause remediation of that wedge and respects its "no retry, no Node upgrade" constraints
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: n/a
- Break-glass scope: n/a
- Follow-up governance task: CI wedge-rate validation over multiple runs

## Verification

- Base `origin/main` SHA: branched from 10aa4601
- Sync method: none needed
- Public diff command: `git diff origin/main...fix/ci-isolation-child-exit-wedge`
- [x] `git diff --check`
- [x] `npm run check:stop-point`: all 7 stop-point steps green
- [x] Targeted tests: `cli-test-fixture-register.test.mjs` (lazy-load red/green), `task-list-cli.test.ts` 3/3 (CLI fixture path intact)
- [ ] GitHub Actions `rewrite-ci` passed (pending; wedge-rate needs multiple runs)
- Not run, and why: multi-run CI wedge-rate validation is pending — a single green does not prove an intermittent wedge is cured.

## Review Evidence

- Self-review: CEO semantic acceptance PASS (lazy-load is clean, fixture contract preserved)
- Reviewer subagent: Codex deep-investigation report (real CI-log forensics + Node 24.18 source)
- Human review: pending
- Blocking findings: none

## Residual Risk

- H1's last hop (the futex resides inside the preload graph) is inferred, not proven from a native stack (local zero-repro). If CI still wedges, next step is capturing `/proc/<pid>/{fd,stack}` or a Node diagnostic report before the stall-kill.

## References

- Task: CI stability line
- Evidence: Codex investigation report (private)
- Review: CEO semantic acceptance

---

# 中文

## 概要

CI「全靠运气」隔离子进程 futex/ep_poll 死锁的根因修复——`fast-contract` 与每个 `integration-shard` 上偶发的 `[node-test-stall]` 假红。

## 改动内容

- `tools/cli-test-fixture-register.mjs`：把 CLI/application/kernel/SQLite composition 图改为懒加载（首次真实 CLI fixture 调用时动态 import，缓存），不再顶层静态 eager import。
- `tools/cli-test-fixture-register.test.mjs`：回归测试——首次调用前零加载、两次只加载一次、保留 `localCoordinatorScope`。

## 任务与范围

- Harness 任务：CI 稳定性线（隔离子进程退出死锁深查）
- 分支：fix/ci-isolation-child-exit-wedge
- 公开范围：仅 tools/ 测试基础设施
- 私有计划 / 证据是否已更新：yes
- 范围外：生产运行时代码；stall 检测器本身

## 版本影响

- 版本：不改版本，原因是仅 CI 测试基础设施工具
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：tools/ CI 测试基础设施（gate 相邻的 test runner preload）
- 依据：decision dec_01KY6BAN1EJACTAGS0ZH91E2KG（CI wedge 治理，active）——本 PR 是该 wedge 的根因修复，遵守其"不重试不升级 Node"约束
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：n/a
- Break-glass 范围：n/a
- 后续治理任务：多次运行验证 CI wedge 率

## 验证

- `origin/main` 基准 SHA：从 10aa4601 拉出
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...fix/ci-isolation-child-exit-wedge`
- [x] `git diff --check`
- [x] `npm run check:stop-point`：7 个 stop-point step 全绿
- [x] 定向测试：`cli-test-fixture-register.test.mjs`（懒加载 red/green）、`task-list-cli.test.ts` 3/3（CLI fixture 路径完好）
- [ ] GitHub Actions `rewrite-ci` 通过（待定；wedge 率需多次运行）
- 未跑项及原因：多次运行的 CI wedge 率验证待定——单次绿不能证明偶发 wedge 已治愈。

## 审查证据

- 自查：CEO 语义验收 PASS（懒加载干净，fixture 契约保留）
- Reviewer subagent：Codex 深查报告（CI 真日志取证 + Node 24.18 源码）
- 人工审查：待定
- 阻塞发现：无

## 残余风险

- H1 最后一跳（futex 在 preload 图内）是推断，非 native stack 证明（本地零复现）。若 CI 仍 wedge，下一步在 stall-kill 前采 `/proc/<pid>/{fd,stack}` 或 Node diagnostic report。

## 关联材料

- 任务：CI 稳定性线
- 证据：Codex 调查报告（私有）
- 审查：CEO 语义验收
