### PR TITLE
fix(daemon): migrate legacy authority binding consumption and report empty binding cause

### DIFF
--- a/packages/daemon/src/authority/authority-lifecycle.ts
+++ b/packages/daemon/src/authority/authority-lifecycle.ts
@@ -206,6 +206,27 @@ export type AuthorityRepoStartResult =
   | { readonly ok: true; readonly component: AuthorityRepoComponent }
   | { readonly ok: false; readonly error: string };
 
+/**
+ * Why no repo produced a service binding. A repo is skipped when its runtime is
+ * not attached or when its authority component refused to start; both reasons
+ * are otherwise only visible inside the skip, so the empty binding set alone
+ * cannot explain itself. Carry the aggregate cause into the failure instead.
+ */
+export function noRepoBindingsError(
+  repos: ReadonlyArray<DaemonRepoNamespace>,
+  runtimeRepos: ReadonlyArray<{ readonly repoId: string; readonly state: string }>,
+  lifecycle?: Pick<AuthorityRepoLifecycleController, "unavailableReason">
+): Error {
+  const detail = repos.length === 0 ? "no repos are registered" : repos.map((repo) => {
+    const runtimeState = runtimeRepos
+      .find((candidate) => candidate.repoId === repo.repoId)?.state ?? "missing";
+    const authorityReason = lifecycle?.unavailableReason(repo.repoId);
+    const authority = authorityReason === undefined ? "" : `, authority ${authorityReason}`;
+    return `${repo.repoId} (runtime ${runtimeState}${authority})`;
+  }).join("; ");
+  return new Error(`daemon service host has no repo bindings: ${detail}`);
+}
+
 interface StartedAuthorityRepo {
   readonly repo: DaemonRepoNamespace;
   readonly component: AuthorityRepoComponent;

--- a/packages/daemon/src/authority/production/authority-binding-state.ts
+++ b/packages/daemon/src/authority/production/authority-binding-state.ts
@@ -8,6 +8,15 @@ import type { DurableAuthorityStateTable } from "./service-state.ts";
 
 const bindingStateSchema = "authority-binding-state/v2" as const;
 const legacyBindingStateSchema = "authority-binding-state/v1" as const;
+/**
+ * Reserved witness prefix for consumption a v1 row counted but never named.
+ * v1 stored only a count, so the identity of an already-spent operation cannot
+ * be reconstructed. Recovery mints one reserved witness per counted operation:
+ * the count-derived invariants (exhaustion, remaining capacity) carry over
+ * exactly, and the witness text states on its face that no operation id was
+ * ever observed. Callers may never present a reserved witness as an opId.
+ */
+const legacyUnwitnessedPrefix = "legacy-unwitnessed:" as const;
 
 interface DurableBindingRowV2 {
   readonly schema: typeof bindingStateSchema;
@@ -31,7 +40,7 @@ interface LegacyDurableBindingRowV1 {
 export function recoverAuthorityBindingRows(
   table: DurableAuthorityStateTable
 ): void {
-  const unconsumedLegacyRows: Array<readonly [string, LegacyDurableBindingRowV1]> = [];
+  const legacyRows: Array<readonly [string, LegacyDurableBindingRowV1]> = [];
   for (const [key, value] of table.entries<unknown>()) {
     if (validBindingRow(value)) {
       if (key !== bindingKey(value.tokenId)) {
@@ -42,20 +51,29 @@ export function recoverAuthorityBindingRows(
     if (!validLegacyBindingRow(value) || key !== bindingKey(value.tokenId)) {
       throw new Error("AUTHORITY_BINDING_DURABLE_MISMATCH");
     }
-    if (value.consumedOperations > 0) {
-      throw new Error(
-        `AUTHORITY_BINDING_LEGACY_CONSUMPTION_WITNESS_REQUIRED:${value.tokenId}:${value.consumedOperations}`
-      );
-    }
-    unconsumedLegacyRows.push([key, value]);
+    legacyRows.push([key, value]);
   }
-  for (const [key, row] of unconsumedLegacyRows) {
+  for (const [key, row] of legacyRows) {
     table.put(key, {
       ...row,
       schema: bindingStateSchema,
-      consumedOperationIds: []
+      consumedOperationIds: legacyUnwitnessedOperationIds(row)
     } satisfies DurableBindingRowV2);
   }
+}
+
+/** One reserved witness per operation a v1 row counted but never named. */
+export function legacyUnwitnessedOperationIds(
+  row: Pick<LegacyDurableBindingRowV1, "tokenId" | "consumedOperations">
+): ReadonlyArray<string> {
+  return Array.from(
+    { length: row.consumedOperations },
+    (_unused, index) => `${legacyUnwitnessedPrefix}${row.tokenId}:${index + 1}`
+  );
+}
+
+function isLegacyUnwitnessedOperationId(opId: string): boolean {
+  return opId.startsWith(legacyUnwitnessedPrefix);
 }
 
 export function registerAuthorityBindingRow(
@@ -92,6 +110,7 @@ export function consumeAuthorityBindingOperation(
 ): ActorAxesBindingOperationConsumeResultV2 {
   const { tokenId, maximum, opId } = input;
   if (!isRequiredText(tokenId) || !isRequiredText(opId)
+    || isLegacyUnwitnessedOperationId(opId)
     || !Number.isSafeInteger(maximum) || maximum < 1) return "denied";
   const row = table.get<unknown>(bindingKey(tokenId));
   if (!validBindingRow(row) || maximum !== row.maxOperations

--- a/packages/daemon/src/service/service-host.ts
+++ b/packages/daemon/src/service/service-host.ts
@@ -12,6 +12,7 @@ import type { AuthorityWireIngressHandler } from "../transport/authority-wire-in
 import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
 import type { JsonObject, JsonRpcNotification } from "../protocol/json-rpc-types.ts";
 import type { DaemonRepoAvailabilityFailure, DaemonRepoNamespace } from "../protocol/json-rpc-server.ts";
+import { noRepoBindingsError } from "../authority/authority-lifecycle.ts";
 import type { AuthorityRepoComponent, AuthorityRepoLifecycleController } from "../authority/authority-lifecycle.ts";
 import type { AuthenticatedActor, IdentityAdminSnapshot, IdentityProvider, PersonRegistry } from "../identity/types.ts";
 import type { DaemonActiveControlStatus, DaemonControlService, DaemonStatusResultV2 } from "@harness-anything/application/daemon-status-contract";
@@ -224,7 +225,7 @@ export async function createDaemonServiceHost<
     ));
   }
   const selectedFallbackBinding = repoBindings.get(defaultRepoId) ?? repoBindings.values().next().value;
-  if (!selectedFallbackBinding) throw new Error("daemon service host has no repo bindings");
+  if (!selectedFallbackBinding) throw noRepoBindingsError(repos, runtime.status().repos, authorityLifecycle);
   const serviceFallbackBinding: RepoServiceBinding = selectedFallbackBinding;
   return {
     daemonId,

--- a/packages/daemon/test/authority-production-state.test.ts
+++ b/packages/daemon/test/authority-production-state.test.ts
@@ -175,7 +175,50 @@ test("durable operation state preserves the exact fixed WriteOp across restart",
   }
 });
 
-test("legacy count-only binding rows with consumed slots block startup without an op witness", () => {
+test("startup upgrades legacy count-only consumption into reserved unwitnessed witnesses", async () => {
+  const config = productionConfig(2);
+  const binding = config.bootstrapBindings[0]!;
+  const table = memoryTable([[
+    "token:token-1",
+    {
+      schema: "authority-binding-state/v1",
+      tokenId: binding.tokenId,
+      tokenDigest: Buffer.from(binding.tokenDigest).toString("base64url"),
+      maxOperations: 2,
+      consumedOperations: 1,
+      record: binding.record
+    }
+  ]]);
+  const runtime = createDurableAuthorityBindingRuntimeV2({
+    config: { ...config, bootstrapBindings: [] },
+    table,
+    proofKeys: emptyProofKeys
+  });
+
+  assert.deepEqual(table.get<Record<string, unknown>>("token:token-1"), {
+    schema: "authority-binding-state/v2",
+    tokenId: "token-1",
+    tokenDigest: Buffer.from(binding.tokenDigest).toString("base64url"),
+    maxOperations: 2,
+    consumedOperations: 1,
+    consumedOperationIds: ["legacy-unwitnessed:token-1:1"],
+    record: binding.record
+  });
+  // A reserved witness is never a presentable opId: it may not be replayed into
+  // an idempotent hit, and it may not spend the surviving slot either.
+  assert.equal(await runtime.consumeOperation({
+    tokenId: "token-1",
+    maximum: 2,
+    opId: "legacy-unwitnessed:token-1:1"
+  }), "denied");
+  assert.equal(await runtime.consumeOperation({
+    tokenId: "token-1",
+    maximum: 2,
+    opId: "namespace-1:operation-a"
+  }), "consumed");
+});
+
+test("startup preserves exhaustion for a fully consumed legacy binding row", async () => {
   const config = productionConfig(1);
   const binding = config.bootstrapBindings[0]!;
   const table = memoryTable([[
@@ -185,15 +228,21 @@ test("legacy count-only binding rows with consumed slots block startup without a
       tokenId: binding.tokenId,
       tokenDigest: Buffer.from(binding.tokenDigest).toString("base64url"),
       maxOperations: binding.maxOperations,
-      consumedOperations: 1,
+      consumedOperations: binding.maxOperations,
       record: binding.record
     }
   ]]);
-  assert.throws(() => createDurableAuthorityBindingRuntimeV2({
+  const runtime = createDurableAuthorityBindingRuntimeV2({
     config,
     table,
     proofKeys: emptyProofKeys
-  }), /AUTHORITY_BINDING_LEGACY_CONSUMPTION_WITNESS_REQUIRED:token-1:1/u);
+  });
+
+  assert.equal(await runtime.consumeOperation({
+    tokenId: "token-1",
+    maximum: 1,
+    opId: "namespace-1:operation-a"
+  }), "denied");
 });
 
 test("startup upgrades every unconsumed legacy binding row even when it is not bootstrapped", async () => {


### PR DESCRIPTION
# English

## Summary

Durable authority binding recovery had no path for the one v1 shape it cannot
reconstruct, so any installation holding real v1 state could not start. This PR
gives that shape a migration and makes the resulting startup failure explain
itself.

## What Changed

- `recoverAuthorityBindingRows` upgrades every legacy row, including consumed
  ones. Each counted operation mints one reserved witness,
  `legacy-unwitnessed:<tokenId>:<ordinal>`, so the v2 witness list is satisfied
  by values that name the absence of an observed operation id instead of
  inventing a plausible one.
- `consumeAuthorityBindingOperation` denies any `opId` carrying the reserved
  prefix, so a synthesized witness can neither replay into an idempotent hit nor
  spend a surviving slot.
- The daemon service host now reports each repo's runtime state and recorded
  authority reason when no repo produced a service binding. Fail-closed
  behaviour is unchanged; only the explanation is.

## Task And Scope

- Harness task: not applicable; incident remediation adjudicated by
  `dec_01KY9M3G4A10J8C300B6Y7GD01`
- Branch: `fix/authority-binding-legacy-witness-migration`
- Public scope: `packages/daemon` authority binding state, authority lifecycle,
  and daemon service host
- Private planning/evidence updated: yes
- Out of scope: the separate repo-writer child request-servicing defect observed
  during this incident; it is being investigated on its own line

## Version Impact

- Version: no version change because this is a defect fix inside an existing
  durable schema version, not a new schema version
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: durable authority binding state recovery
  (`packages/daemon/src/authority/production/authority-binding-state.ts`)
- Authority: `dec_01KY9M3G4A10J8C300B6Y7GD01`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers
  decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: the standing constraint recorded in
  `dec_01KY9M3G4A10J8C300B6Y7GD01` — a durable schema change ships its migration
  for the shape production already holds, plus a test over that shape

## Verification

- Base `origin/main` SHA: `447e15b9170db18b99d1b9413ada5e0ae9e5dcca`
- Branch merge-base with `origin/main`: `447e15b9170db18b99d1b9413ada5e0ae9e5dcca`
- Last `git fetch origin` time: 2026-07-24, immediately before opening this PR
- Sync method: none needed
- Public diff command: `git diff 447e15b9170db18b99d1b9413ada5e0ae9e5dcca...HEAD`
- Private evidence commit/path: decision package for
  `dec_01KY9M3G4A10J8C300B6Y7GD01`
- Reviewer evidence path: same decision package
- GitHub Actions `rewrite-ci` run URL: pending; linked once the run starts
- [x] `git diff --check`
- [x] `npm run check:stop-point` — 34 complete manifest gates green
- [x] Targeted tests for the change surface, named with their counts:
  `packages/daemon` suite via `node tools/run-node-tests.mjs --prefix
  packages/daemon/test/` — 477 tests, 472 pass, 0 fail, 5 skipped (Windows-only
  named pipe cases). Includes two new cases: startup upgrades legacy count-only
  consumption into reserved unwitnessed witnesses, and startup preserves
  exhaustion for a fully consumed legacy row.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: `npm run check:ci` was not run locally; the local full
  preflight is retired and GitHub Actions is the authoritative full gate.

## Review Evidence

- Self-review: read the full diff against the v2 row invariants — witness list
  length equals the count, entries unique and non-empty, count and maximum
  unchanged by the migration.
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none open

## Residual Risk

- A reserved witness records that consumption happened without recording what
  consumed it. That is the honest limit of what v1 stored; no migration can
  recover an identity that was never written.
- The migration rewrites rows in place on the next startup. The binding store is
  append-only, so each migrated row appends a v2 envelope beside the v1 envelope
  it replaces and the pre-migration state stays readable in the same file.

## References

- Task: not applicable
- Evidence: decision package for `dec_01KY9M3G4A10J8C300B6Y7GD01`
- Review: decision package for `dec_01KY9M3G4A10J8C300B6Y7GD01`

---

# 中文

## 概要

持久 authority binding 的恢复路径，对唯一一种它无法重建的 v1 形状没有留迁移
路径，于是任何持有真实 v1 存量状态的安装都起不来。本 PR 给这种形状补上迁移，
并让由此产生的启动失败能自己说清原因。

## 改动内容

- `recoverAuthorityBindingRows` 升级每一条 legacy 行，包括已消费的行。每一次
  计数中的消费铸造一条保留见证 `legacy-unwitnessed:<tokenId>:<ordinal>`，v2 的
  见证列表由"指明没有观测到 operation id"的值满足，而不是编造一个看起来合理的
  id。
- `consumeAuthorityBindingOperation` 拒绝任何带该保留前缀的 `opId`，因此合成的
  见证既不能被重放成幂等命中，也不能花掉尚存的额度。
- 当没有任何 repo 产出 service binding 时，daemon service host 现在会报出每个
  repo 的 runtime 状态与已记录的 authority 原因。fail-closed 行为不变，变的只是
  解释。

## 任务与范围

- Harness 任务：不适用；事故补救，依据裁决 `dec_01KY9M3G4A10J8C300B6Y7GD01`
- 分支：`fix/authority-binding-legacy-witness-migration`
- 公开范围：`packages/daemon` 的 authority binding state、authority lifecycle
  与 daemon service host
- 私有计划 / 证据是否已更新：yes
- 范围外：本次事故中同时观察到的 repo writer 子进程不服务请求的缺陷，另起一条
  线排查

## 版本影响

- 版本：不改版本，原因是这是既有持久 schema 版本内部的缺陷修复，不是新增
  schema 版本
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：持久 authority binding 状态恢复
  （`packages/daemon/src/authority/production/authority-binding-state.ts`）
- 依据：`dec_01KY9M3G4A10J8C300B6Y7GD01`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：`dec_01KY9M3G4A10J8C300B6Y7GD01` 中记录的常设约束——持久 schema
  变更必须为生产已持有的形状附带迁移，并有一个跑那种形状的测试

## 验证

- `origin/main` 基准 SHA：`447e15b9170db18b99d1b9413ada5e0ae9e5dcca`
- 当前分支与 `origin/main` 的 merge-base：
  `447e15b9170db18b99d1b9413ada5e0ae9e5dcca`
- 最近一次 `git fetch origin` 时间：2026-07-24，开 PR 前刚执行
- 同步方式：不需要
- 公开 diff 命令：`git diff 447e15b9170db18b99d1b9413ada5e0ae9e5dcca...HEAD`
- 私有证据 commit/path：`dec_01KY9M3G4A10J8C300B6Y7GD01` 的决策包
- Reviewer 证据路径：同上决策包
- GitHub Actions `rewrite-ci` run URL：待补，run 起来后回填
- [x] `git diff --check`
- [x] `npm run check:stop-point`——34 个完整 manifest 门全绿
- [x] 改动面的定向测试，写明测试名与通过数：
  `node tools/run-node-tests.mjs --prefix packages/daemon/test/` 跑
  `packages/daemon` 套件——477 个测试，472 通过，0 失败，5 跳过（仅 Windows 的
  named pipe 用例）。含两个新增用例：启动把 legacy 纯计数消费升级为保留的
  unwitnessed 见证；启动为已完全消费的 legacy 行保持用尽状态。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）
- 未跑项及原因：本地没有跑 `npm run check:ci`；本地全量预检器已退役，GitHub
  Actions 是权威全量门。

## 审查证据

- 自查：对着 v2 行的不变量通读了完整 diff——见证列表长度等于计数、条目唯一且
  非空、迁移不改变计数与上限。
- Reviewer subagent：无
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 保留见证记录的是"发生过消费"，而不是"什么消费了它"。这是 v1 存下来的东西的
  诚实上限；任何迁移都无法恢复一个从未被写下的身份。
- 迁移在下一次启动时就地改写行。binding 存储是 append-only 的，因此每条被迁移的
  行都会在它替换的 v1 信封旁追加一条 v2 信封，迁移前的状态在同一个文件里仍然
  可读。

## 关联材料

- 任务：不适用
- 证据：`dec_01KY9M3G4A10J8C300B6Y7GD01` 的决策包
- 审查：`dec_01KY9M3G4A10J8C300B6Y7GD01` 的决策包
