### PR TITLE
fix(daemon): restore governed write path wedged after P5-W2 child-writer cutover

### DIFF
--- a/packages/daemon/src/authority/authority-command-submission.ts
+++ b/packages/daemon/src/authority/authority-command-submission.ts
@@ -191,6 +191,16 @@ export function gateAuthoritySubmissionForRecovery(
           reason
         };
       }
+    } : {}),
+    ...(service.resumeV2 ? {
+      resumeV2: async (recovery) => {
+        const reason = await unavailableReason();
+        if (!reason) return service.resumeV2!(recovery);
+        // Unlike a fresh admission, a recovery candidate may already have
+        // canonical side effects. Preserve the outer PROCEEDING instead of
+        // manufacturing a not-committed receipt while recovery is unresolved.
+        throw new Error(reason);
+      }
     } : {})
   };
 }

--- a/packages/daemon/src/authority/production/production-recovery-admission.ts
+++ b/packages/daemon/src/authority/production/production-recovery-admission.ts
@@ -4,7 +4,9 @@ interface ProductionRecoveryAdmissionState {
   readonly promise: Promise<void>;
 }
 
-export const defaultProductionRecoveryAdmissionTimeoutMs = 30_000;
+// Return a fail-closed recovery receipt before the repo-write transport's 30s
+// request deadline so the supervisor leaves the recovering child alive.
+export const defaultProductionRecoveryAdmissionTimeoutMs = 25_000;
 
 export async function waitForProductionRecovery(
   material: {

--- a/packages/daemon/src/authority/production/publication-evidence.ts
+++ b/packages/daemon/src/authority/production/publication-evidence.ts
@@ -274,13 +274,19 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
       .filter(Boolean)
       .map(canonicalGitPath)
       .sort((left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right)));
-    const physicalChanges = changedPaths.map((changedPath) => ({
-      path: changedPath,
-      beforeDigest: expectedPreviousHead ? blobDigest(rootDir, expectedPreviousHead, changedPath) : null,
-      afterDigest: blobDigest(rootDir, head, changedPath)
-    })).sort((left, right) => Buffer.compare(
-      Buffer.from(encodeCanonicalCbor(left)),
-      Buffer.from(encodeCanonicalCbor(right))
+    const physicalChanges: PhysicalChangeV2[] = [];
+    for (const changedPath of changedPaths) {
+      physicalChanges.push({
+        path: changedPath,
+        beforeDigest: expectedPreviousHead
+          ? await blobDigestAsync(rootDir, expectedPreviousHead, changedPath)
+          : null,
+        afterDigest: await blobDigestAsync(rootDir, head, changedPath)
+      });
+    }
+    physicalChanges.sort((left, right) => Buffer.compare(
+      Buffer.from(encodeCanonicalCbor({ ...left })),
+      Buffer.from(encodeCanonicalCbor({ ...right }))
     ));
     const pipelineGeneratedPaths = expectedOpIds.map((opId) => `attribution-events/${sha256Text(opId)}.jsonl`);
     const observedPipelinePaths = changedPaths.filter((changedPath) => changedPath.startsWith("attribution-events/"));
@@ -463,9 +469,14 @@ function publicationTreeMismatchError(
   ].join(";"));
 }
 
-function blobDigest(rootDir: string, revision: string, changedPath: string): string | null {
+async function blobDigestAsync(
+  rootDir: string,
+  revision: string,
+  changedPath: string
+): Promise<string | null> {
   try {
-    return createHash("sha256").update(readAuthorityGitBytes(rootDir, "show", `${revision}:${changedPath}`)).digest("hex");
+    const bytes = await publicationGitBytesAsync(rootDir, "show", `${revision}:${changedPath}`);
+    return createHash("sha256").update(bytes).digest("hex");
   } catch {
     return null;
   }
@@ -492,6 +503,15 @@ function publicationGitText(rootDir: string, ...args: ReadonlyArray<string>): st
 }
 
 const execFileAsync = promisify(execFile);
+
+async function publicationGitBytesAsync(rootDir: string, ...args: ReadonlyArray<string>): Promise<Buffer> {
+  const { stdout } = await execFileAsync("git", ["-C", rootDir, ...args], {
+    encoding: "buffer",
+    windowsHide: true,
+    maxBuffer: 64 * 1024 * 1024
+  });
+  return stdout;
+}
 
 async function publicationGitTextAsync(rootDir: string, ...args: ReadonlyArray<string>): Promise<string> {
   const { stdout } = await execFileAsync("git", ["-C", rootDir, ...args], {

--- a/packages/daemon/src/runtime/repo-write-client-contract.ts
+++ b/packages/daemon/src/runtime/repo-write-client-contract.ts
@@ -7,6 +7,8 @@ import type {
   RepoWriteProtocolViolationError
 } from "./repo-write-client-errors.ts";
 
+export const defaultRepoWriteRequestTimeoutMs = 30_000;
+
 export interface RepoWriteClientTransport {
   /**
    * A synchronous throw means the frame was definitely not sent. Asynchronous

--- a/packages/daemon/src/runtime/repo-write-client.ts
+++ b/packages/daemon/src/runtime/repo-write-client.ts
@@ -15,6 +15,7 @@ import type {
   PendingShutdown,
   PendingSubmit
 } from "./repo-write-client-pending.ts";
+import { defaultRepoWriteRequestTimeoutMs } from "./repo-write-client-contract.ts";
 import type { RepoWriteClientLimits, RepoWriteClientOptions } from "./repo-write-client-contract.ts";
 export type { RepoWriteClientLimits, RepoWriteClientOptions, RepoWriteClientTransport } from "./repo-write-client-contract.ts";
 import {
@@ -68,7 +69,7 @@ export class RepoWriteClient {
     this.limits = {
       maxPendingRequests: options.limits?.maxPendingRequests ?? 1_024,
       readyTimeoutMs: options.limits?.readyTimeoutMs ?? 30_000,
-      requestTimeoutMs: options.limits?.requestTimeoutMs ?? 30_000
+      requestTimeoutMs: options.limits?.requestTimeoutMs ?? defaultRepoWriteRequestTimeoutMs
     };
     for (const [name, value] of Object.entries(this.limits)) {
       if (!Number.isSafeInteger(value) || value <= 0) {

--- a/packages/daemon/test/authority-submission-error.test.ts
+++ b/packages/daemon/test/authority-submission-error.test.ts
@@ -6,10 +6,16 @@ import {
   gateAuthoritySubmissionForRecovery
 } from "../src/index.ts";
 import { receiptToFlushReport } from "../src/authority/authority-command-submission.ts";
-import { waitForProductionRecovery } from "../src/authority/production/production-recovery-admission.ts";
+import {
+  defaultProductionRecoveryAdmissionTimeoutMs,
+  waitForProductionRecovery
+} from "../src/authority/production/production-recovery-admission.ts";
+import { defaultRepoWriteRequestTimeoutMs } from "../src/runtime/repo-write-client-contract.ts";
 import {
   encodeSemanticMutationEnvelopeV2,
   operationIdDiagnosticV2,
+  semanticRequestDigestV2,
+  type AuthorityRecoveryAttemptV2,
   type ProtocolSchemaTupleV2
 } from "@harness-anything/application";
 import { v2Claims, v2Envelope } from "./authority-v2-fixtures.ts";
@@ -29,7 +35,7 @@ test("authority JournalUnavailable errors serialize diagnostic fields without st
   assert.doesNotMatch(JSON.stringify(writeError), /stack/u);
 });
 
-test("recovery gate waits before admitting both legacy and V2 authority ingress", async () => {
+test("recovery gate waits before admitting legacy, V2, and V2 recovery ingress", async () => {
   let submissions = 0;
   let releaseRecovery!: () => void;
   let recovering = true;
@@ -63,6 +69,17 @@ test("recovery gate waits before admitting both legacy and V2 authority ingress"
         receiptId: Buffer.from(attempt.requestId).toString("hex")
       };
     },
+    resumeV2: async (recoveryAttempt) => {
+      submissions += 1;
+      return {
+        tag: "COMMITTED",
+        workspaceId: recoveryAttempt.witness.workspaceId,
+        opId: recoveryAttempt.witness.opId,
+        semanticDigest: recoveryAttempt.witness.semanticDigest,
+        commitSha: "f".repeat(40),
+        receiptId: recoveryAttempt.attempt.requestId
+      };
+    },
     getOperation: async () => undefined
   }, async () => {
     if (!recovering) return undefined;
@@ -81,16 +98,49 @@ test("recovery gate waits before admitting both legacy and V2 authority ingress"
   });
   const fixture = authorityCommandAttemptFixture();
   const v2Promise = service.submitV2!(fixture.attempt);
+  const recoveryAttempt = authorityRecoveryAttemptFixture(fixture);
+  const recoveryV2Promise = service.resumeV2!(recoveryAttempt);
 
   await new Promise((resolve) => setImmediate(resolve));
   assert.equal(submissions, 0);
   releaseRecovery();
-  const [legacy, v2] = await Promise.all([legacyPromise, v2Promise]);
+  const [legacy, v2, recoveryV2] = await Promise.all([
+    legacyPromise,
+    v2Promise,
+    recoveryV2Promise
+  ]);
 
   assert.equal(legacy.tag, "COMMITTED");
   assert.equal(v2.tag, "COMMITTED");
   assert.equal(v2.opId, fixture.expectedOpId);
-  assert.equal(submissions, 2);
+  assert.equal(recoveryV2.tag, "COMMITTED");
+  assert.equal(recoveryV2.opId, fixture.expectedOpId);
+  assert.equal(submissions, 3);
+});
+
+test("production recovery admission expires before the repo-write transport deadline", () => {
+  assert.ok(defaultProductionRecoveryAdmissionTimeoutMs < defaultRepoWriteRequestTimeoutMs);
+});
+
+test("recovery gate preserves unresolved outer recovery instead of returning a terminal receipt", async () => {
+  let recoverySubmissions = 0;
+  const fixture = authorityCommandAttemptFixture();
+  const service = gateAuthoritySubmissionForRecovery({
+    submit: async () => {
+      throw new Error("legacy admission not used");
+    },
+    resumeV2: async () => {
+      recoverySubmissions += 1;
+      throw new Error("unresolved recovery must remain gated");
+    },
+    getOperation: async () => undefined
+  }, () => "AUTHORITY_RECOVERY_IN_PROGRESS:repoId=canonical");
+
+  await assert.rejects(
+    service.resumeV2!(authorityRecoveryAttemptFixture(fixture)),
+    /AUTHORITY_RECOVERY_IN_PROGRESS:repoId=canonical/u
+  );
+  assert.equal(recoverySubmissions, 0);
 });
 
 test("production recovery admission times out with a reachable service-daemon next step", async () => {
@@ -214,5 +264,38 @@ function authorityCommandAttemptFixture() {
       envelope: encodeSemanticMutationEnvelopeV2(envelope)
     },
     expectedOpId: operationIdDiagnosticV2(envelope.operationId)
+  };
+}
+
+function authorityRecoveryAttemptFixture(
+  fixture: ReturnType<typeof authorityCommandAttemptFixture>
+): AuthorityRecoveryAttemptV2 {
+  return {
+    schema: "authority-recovery-attempt/v1",
+    attempt: fixture.attempt,
+    witness: {
+      repoId: "canonical",
+      outerOpId: "repo-write:outer",
+      outerRequestDigest: "a".repeat(64),
+      outerGeneration: 404,
+      authorityGeneration: 3,
+      requestId: fixture.attempt.requestId,
+      workspaceId: fixture.envelope.workspaceId,
+      opId: fixture.expectedOpId,
+      semanticDigest: Buffer.from(semanticRequestDigestV2(fixture.envelope)).toString("hex"),
+      admittedAtMs: "1",
+      canonicalRequestEnvelope: Buffer.from(fixture.attempt.envelope).toString("base64url"),
+      attribution: {
+        actor: {
+          principal: { kind: "person", personId: "person_zeyu" },
+          executor: null
+        },
+        principalSource: {
+          kind: "daemon-authenticated",
+          providerId: "local-socket"
+        },
+        executorSource: "absent"
+      }
+    }
   };
 }

--- a/packages/daemon/test/publication-evidence-responsiveness.test.ts
+++ b/packages/daemon/test/publication-evidence-responsiveness.test.ts
@@ -1,0 +1,59 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { sha256Text } from "@harness-anything/kernel";
+import {
+  createGitCanonicalPublicationInspector
+} from "../src/authority/production/publication-evidence.ts";
+
+test("publication evidence yields between blob reads so recovery admission timers remain live", async (context) => {
+  const root = mkdtempSync(path.join(tmpdir(), "publication-evidence-responsive-"));
+  context.after(() => rmSync(root, { recursive: true, force: true }));
+  git(root, "init", "-q");
+  git(root, "config", "user.name", "Harness Test");
+  git(root, "config", "user.email", "harness@example.test");
+  writeFileSync(path.join(root, "seed.txt"), "seed\n");
+  git(root, "add", ".");
+  git(root, "commit", "-q", "-m", "seed");
+  const previousCommit = git(root, "rev-parse", "HEAD");
+
+  git(root, "checkout", "-q", "-b", "session");
+  const opId = "namespace:test-responsive-recovery";
+  mkdirSync(path.join(root, "attribution-events"));
+  writeFileSync(
+    path.join(root, "attribution-events", `${sha256Text(opId)}.jsonl`),
+    "{}\n"
+  );
+  mkdirSync(path.join(root, "objects"));
+  for (let index = 0; index < 16; index += 1) {
+    writeFileSync(path.join(root, "objects", `${index}.txt`), `${index}\n`);
+  }
+  git(root, "add", ".");
+  git(root, "commit", "-q", "-m", `test: publication [${opId}]`);
+  git(root, "checkout", "-q", "-");
+  git(root, "merge", "-q", "--no-ff", "session", "-m", "materializer: merge session responsive");
+  const mergeCommit = git(root, "rev-parse", "HEAD");
+
+  let timerFired = false;
+  setTimeout(() => {
+    timerFired = true;
+  }, 0);
+  await createGitCanonicalPublicationInspector(root).inspectPublication(
+    previousCommit,
+    [opId],
+    mergeCommit
+  );
+
+  assert.equal(timerFired, true);
+});
+
+function git(root: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", root, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}


### PR DESCRIPTION
# English

## Summary

After the P5-W2 CH4 cutover (#1075) moved the governed write path into a per-repo
child process, every governed write timed out at 30s while reads stayed healthy.
The child was healthy but never serviced a request in time. This restores the
write path by breaking a recovery/deadline feedback loop and repairing a dropped
recovery method. No durable format changes.

## What Changed

- Publication evidence computes per-blob before/after digests with sequential
  awaited Git subprocesses instead of a synchronous `map` of `execFileSync`. The
  synchronous version blocked the child event loop for the whole inspection, so
  IPC and the child's own recovery-admission timer could not run. Order and
  evidence bytes are unchanged.
- The production recovery-admission deadline is 25s, strictly below the
  repo-write transport's 30s request deadline. Previously both were 30s, so the
  parent transport hit its deadline first, the supervisor replaced the child as
  "outcome unknown," and the replacement restarted recovery — every write killed
  the only process making recovery progress. The child now returns a fail-closed
  retryable recovery receipt before the transport deadline and stays alive.
- `gateAuthoritySubmissionForRecovery()` preserves `resumeV2` through the
  recovery wrapper. It was dropped, so exact same-generation outer recovery threw
  `AUTHORITY_RECOVERY_AUTHORIZATION_UNAVAILABLE`. When recovery is unresolved the
  wrapper throws that reason and leaves the outer operation PROCEEDING; it does
  not manufacture a not-committed terminal receipt for work that may already have
  canonical side effects.
- The 30s repo-write request default is centralized into one exported constant so
  the 25s-under-30s timing invariant has a single source and a regression test.

## Task And Scope

- Harness task: not applicable; incident remediation of the #1075 child-writer
  cutover
- Branch: `codex/repo-write-child-wedge`
- Public scope: `packages/daemon` authority publication evidence, recovery
  admission, authority command submission recovery wrapper, and repo-write client
  request-timeout default
- Private planning/evidence updated: yes
- Out of scope: making recovery asymptotically bounded (batch first-parent
  metadata and blob reads); a governed generation-migration policy for
  old-generation stranded outer PROCEEDING rows

## Version Impact

- Version: no version change because this is a behaviour/perf defect fix with no
  wire, schema, or receipt change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable; `tools/check-pr-governance.mjs`
  reports no manifest-derived protected surface touched (117 rules)
- Authority: origin defect is the #1075 P5-W2 CH4 child-writer cutover; this
  restores its intended write path
- Machine-check boundary: this PR only asserts the declaration exists; reviewers
  decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none required; no durable outcome schema, authority
  wire format, receipt schema, or generation fence changed

## Verification

- Base `origin/main` SHA: `691fb2fe2df746f9ccc00605f83e39fa878f2b74`
- Branch merge-base with `origin/main`: `691fb2fe2df746f9ccc00605f83e39fa878f2b74`
- Last `git fetch origin` time: 2026-07-24, immediately before opening this PR
- Sync method: rebase onto current main (after #1077)
- Public diff command: `git diff 691fb2fe2df746f9ccc00605f83e39fa878f2b74...HEAD`
- Private evidence commit/path: incident findings in the session scratchpad
- Reviewer evidence path: CEO semantic acceptance recorded in the merge session
- GitHub Actions `rewrite-ci` run URL: pending; linked once the run starts
- [x] `git diff --check`
- [x] `npm run check:stop-point` — 34 complete manifest gates green (after rebase)
- [x] Targeted tests for the change surface, named with their counts: new
  `packages/daemon/test/publication-evidence-responsiveness.test.ts` proves a
  zero-delay timer fires before publication inspection completes (fails on the
  synchronous implementation, passes on the awaited one);
  `authority-submission-error.test.ts` extended to prove the recovery wrapper
  preserves and gates V2 recovery ingress. Focused recovery/responsiveness: 8
  passed; repo-write client/supervisor: 29 passed; change-aware fast 142 /
  contract 134 passed with one platform skip.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: `npm run check:ci` not run locally (retired local full
  preflight; GitHub Actions is authoritative). No production governed write was
  submitted to prove the fix end-to-end because production is the single live
  writer; end-to-end confirmation happens after merge, dist rebuild, and a
  deliberate daemon restart.

## Review Evidence

- Self-review: CEO read the full diff against the four mechanisms and confirmed
  order/evidence-byte preservation, the 25s-under-30s invariant, resumeV2
  preservation without a manufactured terminal receipt, and that the only schema
  token in the diff is a test referencing the existing
  `authority-recovery-attempt/v1`.
- Reviewer subagent: Codex authored the root cause and fix; CEO performed
  semantic acceptance.
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Recovery discovery is still proportional to the unscanned first-parent history
  and publication evidence is still proportional to changed paths. This patch
  makes it interruptible and lets the partial watermark and fail-closed admission
  work; it does not make recovery asymptotically bounded. A later performance
  slice should batch first-parent metadata and blob reads without changing
  evidence semantics.
- The partial watermark checkpoints the history scan, not progress through
  individual retained publication anchors, so a crash during anchor inspection
  may repeat completed inspections. Survivable for admission, still avoidable CPU.
- Old-generation stranded outer PROCEEDING rows intentionally remain
  outcome-unknown; completing or migrating them needs an explicit governed
  generation-migration design, out of scope here.
- The 5s deadline margin is a tested ordering invariant but a policy constant,
  not an adaptive budget; transport telemetry should track recovery-wait receipt
  latency.

## References

- Task: not applicable
- Evidence: session incident findings
- Review: CEO semantic acceptance in the merge session

---

# 中文

## 概要

P5-W2 CH4 cutover（#1075）把治理写路径搬进按仓子进程后，所有治理写都在 30s 超时
而读路径健康。子进程健康却从不及时服务请求。本 PR 通过打破一个恢复/超时反馈环、
修复一个被丢弃的恢复方法来恢复写路径。无持久格式变更。

## 改动内容

- 发布证据用**顺序 await** 的 Git 子进程计算每个 blob 的前后摘要，替换掉对
  `execFileSync` 的**同步 `map`**。同步版会在整个检查期间阻塞子进程事件循环，
  IPC 和子进程自己的恢复准入定时器都跑不了。顺序与证据字节不变。
- 生产恢复准入 deadline 改为 25s，严格小于 repo-write 传输层的 30s 请求 deadline。
  此前两者都是 30s，父传输先到 deadline，supervisor 把子进程当作"outcome unknown"
  替换掉，替身重启恢复——每次写都杀掉那个唯一在推进恢复的进程。现在子进程在传输
  deadline 之前返回一个 fail-closed 可重试的恢复回执，并保持存活。
- `gateAuthoritySubmissionForRecovery()` 在恢复包装层保全 `resumeV2`。它此前被
  丢弃，导致同代精确 outer recovery 抛 `AUTHORITY_RECOVERY_AUTHORIZATION_UNAVAILABLE`。
  恢复未决时包装层抛出该原因、保持 outer 操作 PROCEEDING；不为可能已有 canonical
  副作用的工作伪造 not-committed 终态回执。
- 30s repo-write 请求默认值收敛为一个导出常量，让"25s 小于 30s"这个时序不变量有
  单一来源与一个回归测试。

## 任务与范围

- Harness 任务：不适用；#1075 子写进程 cutover 的事故补救
- 分支：`codex/repo-write-child-wedge`
- 公开范围：`packages/daemon` 的 authority 发布证据、恢复准入、authority 命令提交
  的恢复包装层，以及 repo-write client 请求超时默认值
- 私有计划 / 证据是否已更新：yes
- 范围外：让恢复渐进有界（批量取 first-parent 元数据与 blob）；旧代搁浅 outer
  PROCEEDING 行的治理化 generation-migration 策略

## 版本影响

- 版本：不改版本，原因是这是行为 / 性能缺陷修复，无 wire / schema / receipt 变更
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用；`tools/check-pr-governance.mjs` 报告未触碰任何
  manifest 派生保护面（117 条规则）
- 依据：源缺陷是 #1075 的 P5-W2 CH4 子写进程 cutover；本 PR 恢复其预期写路径
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无需；未改动任何持久 outcome schema、authority wire 格式、receipt
  schema 或 generation fence

## 验证

- `origin/main` 基准 SHA：`691fb2fe2df746f9ccc00605f83e39fa878f2b74`
- 当前分支与 `origin/main` 的 merge-base：
  `691fb2fe2df746f9ccc00605f83e39fa878f2b74`
- 最近一次 `git fetch origin` 时间：2026-07-24，开 PR 前刚执行
- 同步方式：rebase 到当前 main（#1077 之后）
- 公开 diff 命令：`git diff 691fb2fe2df746f9ccc00605f83e39fa878f2b74...HEAD`
- 私有证据 commit/path：本 session 的事故 findings
- Reviewer 证据路径：合并 session 中的 CEO 语义验收
- GitHub Actions `rewrite-ci` run URL：待补，run 起来后回填
- [x] `git diff --check`
- [x] `npm run check:stop-point`——rebase 后 34 个完整 manifest 门全绿
- [x] 改动面的定向测试，写明测试名与通过数：新增
  `packages/daemon/test/publication-evidence-responsiveness.test.ts` 证明一个
  零延迟定时器在发布检查完成前触发（同步实现下失败、await 实现下通过）；
  `authority-submission-error.test.ts` 扩展证明恢复包装层保全并 gate 了 V2 恢复
  ingress。定向恢复 / 响应性：8 通过；repo-write client / supervisor：29 通过；
  change-aware fast 142 / contract 134 通过（一个平台 skip）。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）
- 未跑项及原因：本地未跑 `npm run check:ci`（本地全量预检器已退役，GitHub Actions
  是权威）。未向生产提交治理写来端到端证明修复，因为生产是唯一在役写进程；端到端
  确认在合并、dist 重建、主动重启 daemon 之后进行。

## 审查证据

- 自查：CEO 对着四条机制通读完整 diff，确认顺序 / 证据字节保持、25s 小于 30s 不
  变量、resumeV2 保全且不伪造终态回执，以及 diff 里唯一的 schema token 是测试对
  既有 `authority-recovery-attempt/v1` 的引用。
- Reviewer subagent：Codex 撰写根因与修复；CEO 做语义验收。
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 恢复发现仍与未扫描的 first-parent 历史成正比、发布证据仍与改动路径数成正比。本
  补丁让它可中断、让部分 watermark 与 fail-closed 准入生效；没让恢复渐进有界。后续
  性能切片应批量取 first-parent 元数据与 blob，不改证据语义。
- 部分 watermark 检查点记的是历史扫描进度、不是逐个保留发布锚的进度，锚检查中崩溃
  可能重复已完成的检查。对准入是可幸存的，仍是可避免的 CPU。
- 旧代搁浅 outer PROCEEDING 行有意保持 outcome-unknown；完成或迁移它们需要一个显式
  的治理化 generation-migration 设计，不在本 PR 范围。
- 5s deadline 余量是被测的时序不变量、但是一个策略常量而非自适应预算；传输遥测应
  跟踪 recovery-wait 回执延迟。

## 关联材料

- 任务：不适用
- 证据：本 session 事故 findings
- 审查：合并 session 的 CEO 语义验收
