### PR TITLE
fix(daemon): bound authority recovery git work to unwedge governed writes

### DIFF
--- a/packages/daemon/src/authority/production/publication-evidence.ts
+++ b/packages/daemon/src/authority/production/publication-evidence.ts
@@ -15,6 +15,10 @@ import {
   type PhysicalChangeV2,
   type SemanticMutationSetV2
 } from "@harness-anything/kernel";
+import {
+  publicationSubjectOperationIds,
+  scanFirstParentPublicationMetadata
+} from "./publication-history.ts";
 
 const materializerCommitter = {
   name: "Harness Anything Materializer",
@@ -161,7 +165,48 @@ function repoRelativePath(repoRoot: string, filePath: string): string {
 
 export function createGitCanonicalPublicationInspector(canonicalRoot: string): GitCanonicalPublicationInspector {
   const rootDir = path.resolve(canonicalRoot);
-  const currentHead = async (): Promise<string | null> => gitOptional(rootDir, "rev-parse", "--verify", "HEAD");
+  const currentHead = async (): Promise<string | null> =>
+    gitOptionalAsync(rootDir, "rev-parse", "--verify", "HEAD");
+  let indexedHistoryCache: {
+    readonly headCommit: string;
+    readonly value: Promise<{
+      readonly commits: Awaited<ReturnType<typeof scanFirstParentPublicationMetadata>>;
+      readonly byOperationId: ReadonlyMap<string, ReadonlyArray<{
+        readonly commitSha: string;
+        readonly previousCommit: string;
+        readonly opIds: ReadonlyArray<string>;
+      }>>;
+    }>;
+  } | undefined;
+  const indexedHistory = async () => {
+    const headCommit = await currentHead();
+    if (!headCommit) return null;
+    if (indexedHistoryCache?.headCommit === headCommit) return indexedHistoryCache.value;
+    const value = scanFirstParentPublicationMetadata({ rootDir, headCommit }).then((commits) => {
+      const byOperationId = new Map<string, Array<{
+        readonly commitSha: string;
+        readonly previousCommit: string;
+        readonly opIds: ReadonlyArray<string>;
+      }>>();
+      for (const commit of commits) {
+        if (commit.parents.length !== 2) continue;
+        const opIds = publicationSubjectOperationIds(commit.sessionSubject ?? "");
+        const anchor = {
+          commitSha: commit.commitSha,
+          previousCommit: commit.parents[0]!,
+          opIds
+        };
+        for (const opId of opIds) {
+          const known = byOperationId.get(opId) ?? [];
+          known.push(anchor);
+          byOperationId.set(opId, known);
+        }
+      }
+      return { commits, byOperationId };
+    });
+    indexedHistoryCache = { headCommit, value };
+    return value;
+  };
   const scanFirstParentOperationAnchors = async (input: {
     readonly exclusiveCommit?: string;
     readonly interestedOpIds: ReadonlySet<string>;
@@ -170,16 +215,15 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
   }): Promise<FirstParentOperationAnchorScan> => {
     const headCommit = await currentHead();
     if (!headCommit) return { headCommit: null, scannedCommitCount: 0, anchors: [] };
-    let commits: string[];
+    let commits: Awaited<ReturnType<typeof scanFirstParentPublicationMetadata>>;
     try {
       commits = input.exclusiveCommit === headCommit
         ? []
-        : (await publicationGitTextAsync(
+        : await scanFirstParentPublicationMetadata({
           rootDir,
-          "rev-list",
-          "--first-parent",
-          input.exclusiveCommit ? `${input.exclusiveCommit}..${headCommit}` : headCommit
-        )).split("\n").filter(Boolean);
+          headCommit,
+          ...(input.exclusiveCommit ? { exclusiveCommit: input.exclusiveCommit } : {})
+        });
     } catch (error) {
       if (input.exclusiveCommit) throw new AuthorityRecoveryWatermarkInvalidError(input.exclusiveCommit);
       throw error;
@@ -187,16 +231,7 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
     const recoveryWatermark = input.exclusiveCommit;
     if (recoveryWatermark && headCommit !== recoveryWatermark) {
       const oldest = commits.at(-1);
-      const oldestParents = await (async () => {
-        try {
-          return oldest
-            ? (await publicationGitTextAsync(rootDir, "rev-list", "--parents", "-n", "1", oldest)).split(" ").slice(1)
-            : [];
-        } catch {
-          throw new AuthorityRecoveryWatermarkInvalidError(recoveryWatermark);
-        }
-      })();
-      if (!oldest || oldestParents[0] !== recoveryWatermark) {
+      if (!oldest || oldest.parents[0] !== recoveryWatermark) {
         throw new AuthorityRecoveryWatermarkInvalidError(recoveryWatermark);
       }
     }
@@ -209,21 +244,31 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
     let scannedCommitCount = 0;
     // A watermark may advance only from the old boundary toward HEAD. Scanning
     // oldest-to-newest makes every reported commit a complete prefix.
-    for (const commitSha of [...commits].reverse()) {
-      const parents = (await publicationGitTextAsync(rootDir, "rev-list", "--parents", "-n", "1", commitSha)).split(" ").slice(1);
-      if (parents.length === 2) {
-        const sessionSubject = await publicationGitTextAsync(rootDir, "show", "-s", "--format=%s", parents[1]!);
-        const opIds = commitSubjectOpIds(sessionSubject);
+    for (const commit of [...commits].reverse()) {
+      if (commit.parents.length === 2) {
+        const sessionSubject = commit.sessionSubject ?? "";
+        const opIds = publicationSubjectOperationIds(sessionSubject);
         if (opIds.some((opId) => input.interestedOpIds.has(opId))) {
-          const anchor = { commitSha, previousCommit: parents[0]!, opIds };
+          const anchor = {
+            commitSha: commit.commitSha,
+            previousCommit: commit.parents[0]!,
+            opIds
+          };
           anchors.push(anchor);
           batchAnchors.push(anchor);
         }
       }
       scannedCommitCount += 1;
-      if (input.onProgress && (scannedCommitCount % progressBatchSize === 0 || scannedCommitCount === commits.length)) {
-        await input.onProgress({ commitSha, scannedCommitCount, anchors: batchAnchors });
-        batchAnchors = [];
+      if (scannedCommitCount % progressBatchSize === 0 || scannedCommitCount === commits.length) {
+        if (input.onProgress) {
+          await input.onProgress({
+            commitSha: commit.commitSha,
+            scannedCommitCount,
+            anchors: batchAnchors
+          });
+          batchAnchors = [];
+        }
+        await yieldToEventLoop();
       }
     }
     return { headCommit, scannedCommitCount, anchors };
@@ -324,16 +369,17 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
     scanFirstParentOperationAnchors,
     findPublication: async (expectedOpIds) => {
       const expectedSessionSubjectSuffix = `[${expectedOpIds.join(",")}]`;
-      const firstParentCommits = publicationGitText(rootDir, "rev-list", "--first-parent", "HEAD")
-        .split("\n")
-        .filter(Boolean);
+      const history = await indexedHistory();
+      if (!history) throw new Error("AUTHORITY_CANONICAL_PUBLICATION_MISSING");
       const matches: CanonicalPublicationEvidence[] = [];
-      for (const commitSha of firstParentCommits) {
-        const parents = publicationGitText(rootDir, "rev-list", "--parents", "-n", "1", commitSha).split(" ").slice(1);
-        if (parents.length !== 2) continue;
-        const sessionSubject = publicationGitText(rootDir, "show", "-s", "--format=%s", parents[1]!);
-        if (!sessionSubject.endsWith(expectedSessionSubjectSuffix)) continue;
-        matches.push(await inspectPublication(parents[0]!, expectedOpIds, commitSha));
+      for (const commit of history.commits) {
+        if (commit.parents.length !== 2
+          || !commit.sessionSubject?.endsWith(expectedSessionSubjectSuffix)) continue;
+        matches.push(await inspectPublication(
+          commit.parents[0]!,
+          expectedOpIds,
+          commit.commitSha
+        ));
       }
       if (matches.length !== 1) {
         throw new Error(
@@ -343,17 +389,15 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
       return matches[0]!;
     },
     findPublicationForOperation: async (opId) => {
-      const firstParentCommits = publicationGitText(rootDir, "rev-list", "--first-parent", "HEAD")
-        .split("\n")
-        .filter(Boolean);
+      const history = await indexedHistory();
+      if (!history) throw new AuthorityCanonicalPublicationNotFoundError(opId);
       const matches: CanonicalPublicationEvidence[] = [];
-      for (const commitSha of firstParentCommits) {
-        const parents = publicationGitText(rootDir, "rev-list", "--parents", "-n", "1", commitSha).split(" ").slice(1);
-        if (parents.length !== 2) continue;
-        const sessionSubject = publicationGitText(rootDir, "show", "-s", "--format=%s", parents[1]!);
-        const opIds = commitSubjectOpIds(sessionSubject);
-        if (!opIds.includes(opId)) continue;
-        matches.push(await inspectPublication(parents[0]!, opIds, commitSha));
+      for (const anchor of history.byOperationId.get(opId) ?? []) {
+        matches.push(await inspectPublication(
+          anchor.previousCommit,
+          anchor.opIds,
+          anchor.commitSha
+        ));
       }
       if (matches.length === 0) throw new AuthorityCanonicalPublicationNotFoundError(opId);
       if (matches.length !== 1) {
@@ -366,10 +410,8 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
   };
 }
 
-function commitSubjectOpIds(subject: string): ReadonlyArray<string> {
-  const match = /\[([^\]]+)\]$/u.exec(subject);
-  if (!match?.[1]) return [];
-  return match[1].split(",").filter(Boolean);
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
 }
 
 function publicationTopologyError(input: {
@@ -490,9 +532,9 @@ function canonicalGitPath(value: string): string {
   return normalized;
 }
 
-function gitOptional(rootDir: string, ...args: ReadonlyArray<string>): string | null {
+async function gitOptionalAsync(rootDir: string, ...args: ReadonlyArray<string>): Promise<string | null> {
   try {
-    return publicationGitText(rootDir, ...args);
+    return await publicationGitTextAsync(rootDir, ...args);
   } catch {
     return null;
   }
@@ -538,10 +580,15 @@ function gitExitCode(rootDir: string, ...args: ReadonlyArray<string>): number {
 
 /** Read-only Git observation shared by authority publication and cutover scanners. */
 export function readAuthorityGitBytes(rootDir: string, ...args: ReadonlyArray<string>): Buffer {
+  return readAuthorityGitBatchBytes(rootDir, args, Buffer.alloc(0));
+}
+
+export function readAuthorityGitBatchBytes(
+  rootDir: string,
+  args: ReadonlyArray<string>,
+  input: Buffer
+): Buffer {
   return execFileSync("git", ["-C", rootDir, ...args], {
-    encoding: "buffer",
-    stdio: ["ignore", "pipe", "pipe"],
-    windowsHide: true,
-    maxBuffer: 64 * 1024 * 1024
+    encoding: "buffer", input, stdio: ["pipe", "pipe", "pipe"], windowsHide: true, maxBuffer: 64 * 1024 * 1024
   });
 }

--- a/packages/daemon/src/authority/production/publication-history.ts
+++ b/packages/daemon/src/authority/production/publication-history.ts
@@ -1,0 +1,76 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const subjectBatchSize = 256;
+
+export interface FirstParentPublicationMetadata {
+  readonly commitSha: string;
+  readonly parents: ReadonlyArray<string>;
+  readonly sessionSubject?: string;
+}
+
+export function publicationSubjectOperationIds(subject: string): ReadonlyArray<string> {
+  const match = /\[([^\]]+)\]$/u.exec(subject);
+  return match?.[1] ? match[1].split(",").filter(Boolean) : [];
+}
+
+export async function scanFirstParentPublicationMetadata(input: {
+  readonly rootDir: string;
+  readonly headCommit: string;
+  readonly exclusiveCommit?: string;
+}): Promise<ReadonlyArray<FirstParentPublicationMetadata>> {
+  const revision = input.exclusiveCommit
+    ? `${input.exclusiveCommit}..${input.headCommit}`
+    : input.headCommit;
+  const history = parsePairs(await publicationHistoryGitText(
+    input.rootDir,
+    "log",
+    "--first-parent",
+    "--format=%H%x00%P%x00",
+    revision
+  )).map(([commitSha, parents]) => ({
+    commitSha,
+    parents: parents.split(" ").filter(Boolean)
+  }));
+  const sessionCommits = [...new Set(history
+    .filter((row) => row.parents.length === 2)
+    .map((row) => row.parents[1]!))];
+  const subjects = new Map<string, string>();
+  for (let start = 0; start < sessionCommits.length; start += subjectBatchSize) {
+    const batch = sessionCommits.slice(start, start + subjectBatchSize);
+    for (const [commitSha, subject] of parsePairs(await publicationHistoryGitText(
+      input.rootDir,
+      "log",
+      "--no-walk=unsorted",
+      "--format=%H%x00%s%x00",
+      ...batch
+    ))) {
+      subjects.set(commitSha, subject);
+    }
+  }
+  return history.map((row) => ({
+    ...row,
+    ...(row.parents[1] ? { sessionSubject: subjects.get(row.parents[1]) ?? "" } : {})
+  }));
+}
+
+async function publicationHistoryGitText(rootDir: string, ...args: ReadonlyArray<string>): Promise<string> {
+  const { stdout } = await execFileAsync("git", ["-C", rootDir, ...args], {
+    encoding: "utf8",
+    windowsHide: true,
+    maxBuffer: 64 * 1024 * 1024
+  });
+  return stdout;
+}
+
+function parsePairs(value: string): ReadonlyArray<readonly [string, string]> {
+  const fields = value.split("\0");
+  const pairs: Array<readonly [string, string]> = [];
+  for (let index = 0; index + 1 < fields.length; index += 2) {
+    const first = fields[index]!.trim();
+    const second = fields[index + 1]!.trim();
+    if (first) pairs.push([first, second]);
+  }
+  return pairs;
+}

--- a/packages/daemon/src/authority/replication-content-store.ts
+++ b/packages/daemon/src/authority/replication-content-store.ts
@@ -9,7 +9,10 @@ import {
 } from "@harness-anything/application";
 import type { AuthoritySnapshotManifestEntry } from "./protocol.ts";
 import type { DurableAuthorityStateTable } from "./production/service-state.ts";
-import { readAuthorityGitBytes } from "./production/publication-evidence.ts";
+import {
+  readAuthorityGitBatchBytes,
+  readAuthorityGitBytes
+} from "./production/publication-evidence.ts";
 
 type ReplicaChangeDraft = Parameters<ReplicaChangeLog["append"]>[0];
 type ReplicaFileMode = NonNullable<ReplicaChangeRecord["paths"][number]["mode"]>;
@@ -167,18 +170,26 @@ function readGitEntries(
   persistBlob: (bytes: Uint8Array) => Sha256Digest
 ): ReadonlyArray<AuthoritySnapshotManifestEntry> {
   const listing = readAuthorityGitBytes(root, "ls-tree", "-r", "-z", "--full-tree", commitSha);
-  const entries = splitNul(listing).map((row) => {
+  const rows = splitNul(listing).map((row) => {
     const separator = row.indexOf(0x09);
     const metadata = separator >= 0 ? row.subarray(0, separator).toString("ascii") : "";
     const match = /^(100644|100755|120000) blob ([0-9a-f]+)$/u.exec(metadata);
     if (!match || separator < 0) throw new Error(`RESYNC_REQUIRED:UNSUPPORTED_GIT_TREE_ENTRY:${metadata.slice(0, 80)}`);
     const pathBytes = row.subarray(separator + 1);
-    const pathName = decodePortableGitPath(pathBytes);
-    const bytes = readAuthorityGitBytes(root, "cat-file", "blob", match[2]!);
     return {
-      path: pathName,
+      path: decodePortableGitPath(pathBytes),
+      objectId: match[2]!,
+      mode: match[1] as ReplicaFileMode
+    };
+  });
+  const blobs = readGitBlobBatch(root, rows.map((row) => row.objectId));
+  const entries = rows.map((row) => {
+    const bytes = blobs.get(row.objectId);
+    if (!bytes) throw new Error(`RESYNC_REQUIRED:GIT_BLOB_MISSING:${row.objectId}`);
+    return {
+      path: row.path,
       blobDigest: persistBlob(bytes),
-      mode: match[1] as ReplicaFileMode,
+      mode: row.mode,
       tombstone: false as const
     };
   }).sort(compareEntries);
@@ -189,6 +200,45 @@ function readGitEntries(
     portableKeys.add(portableKey);
   }
   return entries;
+}
+
+function readGitBlobBatch(
+  root: string,
+  objectIds: ReadonlyArray<string>
+): ReadonlyMap<string, Buffer> {
+  const blobs = new Map<string, Buffer>();
+  const unique = [...new Set(objectIds)];
+  for (let start = 0; start < unique.length; start += 512) {
+    const batch = unique.slice(start, start + 512);
+    const output = readAuthorityGitBatchBytes(
+      root,
+      ["cat-file", "--batch"],
+      Buffer.from(`${batch.join("\n")}\n`, "ascii")
+    );
+    let offset = 0;
+    for (const objectId of batch) {
+      const headerEnd = output.indexOf(0x0a, offset);
+      if (headerEnd < 0) throw new Error("RESYNC_REQUIRED:GIT_BLOB_BATCH_HEADER");
+      const header = output.subarray(offset, headerEnd).toString("ascii");
+      const match = /^([0-9a-f]+) blob ([0-9]+)$/u.exec(header);
+      if (!match || match[1] !== objectId) {
+        throw new Error(`RESYNC_REQUIRED:GIT_BLOB_BATCH_ID:${objectId}`);
+      }
+      const byteLength = Number(match[2]);
+      const contentStart = headerEnd + 1;
+      const contentEnd = contentStart + byteLength;
+      if (!Number.isSafeInteger(byteLength)
+        || byteLength < 0
+        || contentEnd >= output.length
+        || output[contentEnd] !== 0x0a) {
+        throw new Error(`RESYNC_REQUIRED:GIT_BLOB_BATCH_LENGTH:${objectId}`);
+      }
+      blobs.set(objectId, Buffer.from(output.subarray(contentStart, contentEnd)));
+      offset = contentEnd + 1;
+    }
+    if (offset !== output.length) throw new Error("RESYNC_REQUIRED:GIT_BLOB_BATCH_TRAILING");
+  }
+  return blobs;
 }
 
 function splitNul(value: Uint8Array): ReadonlyArray<Buffer> {

--- a/packages/daemon/test/publication-evidence-responsiveness.test.ts
+++ b/packages/daemon/test/publication-evidence-responsiveness.test.ts
@@ -1,12 +1,13 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { sha256Text } from "@harness-anything/kernel";
 import {
+  AuthorityCanonicalPublicationNotFoundError,
   createGitCanonicalPublicationInspector
 } from "../src/authority/production/publication-evidence.ts";
 
@@ -49,6 +50,53 @@ test("publication evidence yields between blob reads so recovery admission timer
   );
 
   assert.equal(timerFired, true);
+});
+
+test("missing-operation recovery search yields and reuses one bounded history scan", async (context) => {
+  const root = mkdtempSync(path.join(tmpdir(), "publication-evidence-history-"));
+  context.after(() => rmSync(root, { recursive: true, force: true }));
+  git(root, "init", "-q");
+  git(root, "config", "user.name", "Harness Test");
+  git(root, "config", "user.email", "harness@example.test");
+  writeFileSync(path.join(root, "seed.txt"), "seed\n");
+  git(root, "add", ".");
+  git(root, "commit", "-q", "-m", "seed");
+  const tree = git(root, "rev-parse", "HEAD^{tree}");
+  let parent = git(root, "rev-parse", "HEAD");
+  for (let index = 0; index < 2_048; index += 1) {
+    parent = git(root, "commit-tree", tree, "-p", parent, "-m", `history ${index}`);
+  }
+  git(root, "update-ref", "HEAD", parent);
+
+  let timerFired = false;
+  const tracePath = path.join(root, "git-trace.jsonl");
+  const previousTrace = process.env.GIT_TRACE2_EVENT;
+  process.env.GIT_TRACE2_EVENT = tracePath;
+  setTimeout(() => {
+    timerFired = true;
+  }, 0);
+  try {
+    const inspector = createGitCanonicalPublicationInspector(root);
+    await assert.rejects(
+      inspector.findPublicationForOperation("namespace:missing-publication"),
+      AuthorityCanonicalPublicationNotFoundError
+    );
+    await assert.rejects(
+      inspector.findPublicationForOperation("namespace:still-missing"),
+      AuthorityCanonicalPublicationNotFoundError
+    );
+  } finally {
+    if (previousTrace === undefined) delete process.env.GIT_TRACE2_EVENT;
+    else process.env.GIT_TRACE2_EVENT = previousTrace;
+  }
+
+  assert.equal(timerFired, true);
+  const starts = readFileSync(tracePath, "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as { readonly event: string })
+    .filter((event) => event.event === "start");
+  assert.ok(starts.length <= 3, `expected one history scan plus HEAD checks, observed ${starts.length} Git processes`);
 });
 
 function git(root: string, ...args: ReadonlyArray<string>): string {

--- a/packages/daemon/test/replication-content-store-batch.test.ts
+++ b/packages/daemon/test/replication-content-store-batch.test.ts
@@ -1,0 +1,65 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  createAuthorityReplicationContentStore
+} from "../src/authority/replication-content-store.ts";
+
+test("replication snapshot reads a large Git tree with bounded subprocess work", (context) => {
+  const root = mkdtempSync(path.join(tmpdir(), "replication-content-batch-"));
+  context.after(() => rmSync(root, { recursive: true, force: true }));
+  git(root, "init", "-q");
+  git(root, "config", "user.name", "Harness Test");
+  git(root, "config", "user.email", "harness@example.test");
+  mkdirSync(path.join(root, "files"));
+  for (let index = 0; index < 256; index += 1) {
+    writeFileSync(path.join(root, "files", `${index}.txt`), `${index}\n`);
+  }
+  git(root, "add", ".");
+  git(root, "commit", "-q", "-m", "tree");
+  const commitSha = git(root, "rev-parse", "HEAD");
+  const values = new Map<string, unknown>();
+  const tracePath = path.join(root, "git-trace.jsonl");
+  const previousTrace = process.env.GIT_TRACE2_EVENT;
+  process.env.GIT_TRACE2_EVENT = tracePath;
+  try {
+    const snapshot = createAuthorityReplicationContentStore({
+      gitRoot: root,
+      workspaceId: "workspace-batch",
+      epoch: "1",
+      state: {
+        get: <Value>(key: string) => values.get(key) as Value | undefined,
+        put: (key, value) => { values.set(key, structuredClone(value)); },
+        entries: <Value>() => [...values.entries()] as ReadonlyArray<readonly [string, Value]>
+      }
+    }).snapshot(commitSha, 1);
+    assert.equal(snapshot.entries.length, 256);
+  } finally {
+    if (previousTrace === undefined) delete process.env.GIT_TRACE2_EVENT;
+    else process.env.GIT_TRACE2_EVENT = previousTrace;
+  }
+
+  const starts = readFileSync(tracePath, "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as { readonly event: string })
+    .filter((event) => event.event === "start");
+  assert.ok(starts.length <= 2, `expected at most two Git subprocesses, observed ${starts.length}`);
+});
+
+function git(root: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", root, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}


### PR DESCRIPTION
# English

## Summary

PR #1078 let the repo-write child survive recovery but the governed write path
stayed wedged: every write still hit the 30s deadline. Root cause was
synchronous, unbounded Git subprocess work on the child's single JS thread — not
a livelock. This bounds and batches that Git work so recovery and per-write
publication/replica evidence complete in well under the deadline. No durable
format changes.

## What Changed

- Replica snapshot reconstruction (`replication-content-store.ts`
  `readGitEntries`) replaced one synchronous `git cat-file blob` per tree entry
  with bounded 512-object `git cat-file --batch` chunks over deduplicated object
  ids. The first retained recovery anchor has 15,719 tree entries; this drops
  ~15.7k subprocess spawns to ~31 batched reads. Exact bytes, modes, paths,
  digests, and fail-closed parsing are preserved.
- First-parent publication discovery (`publication-evidence.ts`
  `findPublication` / `findPublicationForOperation`, and the watermark scanner)
  moved to a new `publication-history.ts` that batches topology into one awaited
  `git log --first-parent --format=…` (bounded to the recovery watermark
  interval when present), batches second-parent session subjects with awaited
  `git log --no-walk=unsorted`, yields to the event loop per progress batch, and
  caches the HEAD-keyed history indexed by operation id so every pending record
  and retry shares one scan. The unique/not-found checks and full publication
  inspection for candidate anchors are unchanged.

## Task And Scope

- Harness task: not applicable; continued incident remediation of the #1075
  child-writer cutover (follows #1078)
- Branch: `codex/repo-write-child-wedge-round2`
- Public scope: `packages/daemon` authority publication evidence + history,
  replica content store
- Private planning/evidence updated: yes
- Out of scope: making the replica snapshot API fully async (larger interface
  refactor); a governed generation-migration policy for the old-generation
  stranded outer PROCEEDING

## Version Impact

- Version: no version change because this is a performance/responsiveness defect
  fix with no wire, schema, or receipt change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable; `tools/check-pr-governance.mjs`
  reports no manifest-derived protected surface touched
- Authority: origin defect is the #1075 P5-W2 CH4 child-writer cutover; this
  restores its intended write path (follows #1078)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers
  decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: the old-generation stranded outer PROCEEDING may
  still need a governed generation-migration decision; it does not block this fix
  and is not changed here

## Verification

- Base `origin/main` SHA: `7409a4e64e6179824d93fe7130b6481f10e3ebc9`
- Branch merge-base with `origin/main`: `7409a4e64e6179824d93fe7130b6481f10e3ebc9`
- Last `git fetch origin` time: 2026-07-24, immediately before opening this PR
- Sync method: rebase onto current main (after #1078)
- Public diff command: `git diff 7409a4e64e6179824d93fe7130b6481f10e3ebc9...HEAD`
- Private evidence commit/path: session incident findings (Round 2), live child
  process sample
- Reviewer evidence path: CEO semantic acceptance in the merge session
- GitHub Actions `rewrite-ci` run URL: pending; linked once the run starts
- [x] `git diff --check`
- [x] `npm run check:stop-point` — 34 complete manifest gates green (after rebase)
- [x] Targeted tests for the change surface, named with their counts:
  `publication-evidence-responsiveness.test.ts` proves a zero-delay timer fires
  during a 2,048-commit missing-op discovery (blocks ~32.7s pre-fix);
  `replication-content-store-batch.test.ts` proves a 256-file snapshot uses at
  most two Git processes (257 pre-fix). Focused regression 5 passed; wider
  authority/read-down/wire 22 passed; clean-env Git regression 3 passed;
  change-aware fast 143 / contract 136 passed with one platform skip.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: `npm run check:ci` not run locally (retired local full
  preflight; GitHub Actions is authoritative). End-to-end confirmation against
  the live production writer happens after merge, dist rebuild, and a deliberate
  daemon restart — a real governed write completing under 30s — before this fix
  is treated as resolving the incident.

## Review Evidence

- Self-review: CEO read the full diff, confirmed the batch parser preserves exact
  bytes/modes/paths/digests with fail-closed `RESYNC_REQUIRED:*` errors, the
  history scan preserves the unique/not-found checks and is bounded to the
  watermark interval, and no durable outcome/wire/receipt/watermark/fence schema
  changed.
- Reviewer subagent: Codex authored the root cause and fix; CEO performed
  semantic acceptance and independently ground-truthed the live child stack
  sample (`Builtins_ArrayMap` → `SyncProcessRunner::Spawn`) against the fixed
  sites.
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Replica materialization remains proportional to tree content; it now uses at
  most one synchronous subprocess per 512 unique blobs, not one per file. A fully
  async snapshot API is a larger refactor deferred here.
- With a valid watermark, topology discovery is bounded to the interval. If the
  watermark is absent or invalid, the fail-closed fallback still scans all
  reachable first-parent history once at HEAD; the HEAD-keyed cache prevents
  per-record/retry rescans.
- The old-generation stranded outer PROCEEDING still needs an explicit governed
  decision to terminalize or migrate across generations; this patch does not
  forge, rewrite, delete, or relax it.

## References

- Task: not applicable
- Evidence: session incident findings (Round 2)
- Review: CEO semantic acceptance in the merge session

---

# 中文

## 概要

#1078 让 repo-write 子进程能在恢复中存活，但治理写路径仍卡：每次写仍撞 30s deadline。
根因是子进程单 JS 线程上**同步、无界的 git 子进程工作**——不是 livelock。本 PR 把这些
git 工作**批量化并有界化**，让恢复和每次写的 publication/replica 证据都远快于 deadline。
无持久格式变更。

## 改动内容

- Replica 快照重建（`replication-content-store.ts` 的 `readGitEntries`）把逐个 tree
  entry 的同步 `git cat-file blob` 换成对去重后 object id 的有界 512 对象
  `git cat-file --batch` 批读。首个保留恢复 anchor 有 15,719 个 tree entry；这把
  ~1.57 万次子进程 spawn 降到 ~31 次批读。字节、mode、path、digest 与 fail-closed
  解析全部保持。
- First-parent publication 发现（`publication-evidence.ts` 的 `findPublication` /
  `findPublicationForOperation` 与 watermark 扫描器）迁到新的 `publication-history.ts`：
  用一次 await 的 `git log --first-parent --format=…` 批量取拓扑（有 watermark 时
  **按其区间有界**），用 await 的 `git log --no-walk=unsorted` 批量取 second-parent
  session subject，每个进度批**让出事件循环**，并缓存按 HEAD 键、按 operation id 索引
  的历史，使每条 pending record 和每次重试共享一次扫描。唯一 / 未找到检查与候选 anchor
  的完整 publication inspection 不变。

## 任务与范围

- Harness 任务：不适用；#1075 子写进程 cutover 事故的持续补救（承接 #1078）
- 分支：`codex/repo-write-child-wedge-round2`
- 公开范围：`packages/daemon` 的 authority publication evidence + history、replica
  content store
- 私有计划 / 证据是否已更新：yes
- 范围外：把 replica 快照 API 完全异步化（更大的接口重构）；旧代搁浅 outer
  PROCEEDING 的治理化 generation-migration 策略

## 版本影响

- 版本：不改版本，原因是这是性能 / 响应性缺陷修复，无 wire / schema / receipt 变更
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用；`tools/check-pr-governance.mjs` 报告未触碰任何
  manifest 派生保护面
- 依据：源缺陷是 #1075 的 P5-W2 CH4 子写进程 cutover；本 PR 恢复其预期写路径（承接
  #1078）
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：旧代搁浅 outer PROCEEDING 可能仍需一个治理化 generation-migration
  决策；它不阻塞本修复，本 PR 也不改动它

## 验证

- `origin/main` 基准 SHA：`7409a4e64e6179824d93fe7130b6481f10e3ebc9`
- 当前分支与 `origin/main` 的 merge-base：`7409a4e64e6179824d93fe7130b6481f10e3ebc9`
- 最近一次 `git fetch origin` 时间：2026-07-24，开 PR 前刚执行
- 同步方式：rebase 到当前 main（#1078 之后）
- 公开 diff 命令：`git diff 7409a4e64e6179824d93fe7130b6481f10e3ebc9...HEAD`
- 私有证据 commit/path：本 session 事故 findings（Round 2）、活子进程栈采样
- Reviewer 证据路径：合并 session 的 CEO 语义验收
- GitHub Actions `rewrite-ci` run URL：待补，run 起来后回填
- [x] `git diff --check`
- [x] `npm run check:stop-point`——rebase 后 34 个完整 manifest 门全绿
- [x] 改动面的定向测试，写明测试名与通过数：
  `publication-evidence-responsiveness.test.ts` 证明在 2,048-commit 的缺失 op 发现中
  零延迟定时器会触发（修复前阻塞 ~32.7s）；`replication-content-store-batch.test.ts`
  证明 256-文件快照最多用 2 个 git 进程（修复前 257 个）。定向回归 5 通过；更宽的
  authority/read-down/wire 22 通过；干净环境 git 回归 3 通过；change-aware fast 143 /
  contract 136 通过（一个平台 skip）。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）
- 未跑项及原因：本地未跑 `npm run check:ci`（本地全量预检器已退役，GitHub Actions
  是权威）。对生产在役写进程的端到端确认在合并、dist 重建、主动重启 daemon 之后
  进行——一次真实治理写在 30s 内完成——在此之前不把本修复视为已解决事故。

## 审查证据

- 自查：CEO 通读完整 diff，确认批量解析器以 fail-closed `RESYNC_REQUIRED:*` 错误保持
  精确字节 / mode / path / digest，历史扫描保持唯一 / 未找到检查且按 watermark 区间
  有界，且未改动任何持久 outcome/wire/receipt/watermark/fence schema。
- Reviewer subagent：Codex 撰写根因与修复；CEO 做语义验收，并独立 ground-truth 了活
  子进程栈采样（`Builtins_ArrayMap` → `SyncProcessRunner::Spawn`）对应修复点。
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- Replica 物化仍与树内容成正比；现在最多每 512 个唯一 blob 一个同步子进程，而非每
  文件一个。完全异步的快照 API 是更大的重构，本 PR 暂缓。
- 有有效 watermark 时，拓扑发现按其区间有界。watermark 缺失或无效时，fail-closed 回退
  仍在 HEAD 处扫一次全部可达 first-parent 历史；按 HEAD 键的缓存避免逐 record/重试重扫。
- 旧代搁浅 outer PROCEEDING 仍需一个显式治理决策来跨代 terminalize 或迁移；本补丁不
  伪造、不改写、不删除、不放松它。

## 关联材料

- 任务：不适用
- 证据：本 session 事故 findings（Round 2）
- 审查：合并 session 的 CEO 语义验收
