### PR TITLE
fix(daemon): recover anchored historical outcomes

### DIFF
--- a/packages/cli/src/composition/repo-write-child-entrypoint.ts
+++ b/packages/cli/src/composition/repo-write-child-entrypoint.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import {
   createDaemonGenerationWitness,
   calculateDaemonArtifactIdentity,
+  createGitCanonicalPublicationInspector,
   createRepoWriteChildHost,
   decodeRepoWriteChildLaunchConfig,
   DurableRepoWriteOutcomeStoreV1,
@@ -11,6 +12,7 @@ import {
   RepoWriteChildIpcTransport,
   type HarnessDaemonRuntime
 } from "@harness-anything/daemon";
+import { resolveHarnessLayout } from "@harness-anything/kernel";
 import { defaultCliAdapterProvider } from "./adapter-registry.ts";
 import { cliDaemonCommandHostServices } from "./daemon-command-host-services.ts";
 import {
@@ -88,12 +90,31 @@ export async function runRepoWriteChildEntrypoint(
     workspaceId: authorityRepo.workspaceId,
     generation: config.generation
   });
+  const publicationInspector = createGitCanonicalPublicationInspector(
+    resolveHarnessLayout({
+      rootDir: config.canonicalRoot,
+      ...(layoutOverrides ? { layoutOverrides } : {})
+    }).authoredRoot
+  );
+  const resolveHistoricalPublication = (
+    outcome: import("@harness-anything/daemon").RepoWriteProceedingOutcomeV1
+  ) => publicationInspector.findHistoricalPublicationForOperation(outcome.innerOpId);
+  const historicalRecovery: {
+    recover?: import("@harness-anything/daemon").RepoWriteAuthorityRecoveryGateOptions["recoverHistoricalCommittedReceipt"];
+  } = {};
   const recoveryGate = new RepoWriteAuthorityRecoveryGate({
     repoId: config.repoId,
     workspaceId: authorityRepo.workspaceId,
     generation: config.generation,
     store: outcomes,
-    assertCurrentWriterFence: runtime.assertWriteFenceHeld
+    assertCurrentWriterFence: runtime.assertWriteFenceHeld,
+    resolveHistoricalPublication,
+    recoverHistoricalCommittedReceipt: (outcome) => {
+      if (!historicalRecovery.recover) {
+        throw new Error("AUTHORITY_COMMITTED_RECEIPT_RECOVERY_UNAVAILABLE");
+      }
+      return historicalRecovery.recover(outcome);
+    }
   });
   const lifecycleRuntime = {
     ...runtime,
@@ -116,6 +137,21 @@ export async function runRepoWriteChildEntrypoint(
     await runtime.stop();
     throw new Error(started.error);
   }
+  historicalRecovery.recover = (outcome) => {
+    if (!started.component.recoverCommittedReceipt) {
+      throw new Error("AUTHORITY_COMMITTED_RECEIPT_RECOVERY_UNAVAILABLE");
+    }
+    return started.component.recoverCommittedReceipt(outcome.innerOpId);
+  };
+  for (const proceeding of outcomes.listHistoricalProceedings()) {
+    try {
+      await recoveryGate.recoverHistoricalProceeding(proceeding);
+    } catch (error) {
+      process.stderr.write(
+        `repo-write historical recovery deferred outerOpId=${proceeding.outerOpId}: ${recoveryErrorMessage(error)}\n`
+      );
+    }
+  }
   const operation = new ProductionRepoWriteOperationHost({
     repoId: config.repoId,
     workspaceId: authorityRepo.workspaceId,
@@ -123,7 +159,9 @@ export async function runRepoWriteChildEntrypoint(
     runtime,
     authorityComponent: started.component,
     hostServices: cliDaemonCommandHostServices,
-    outcomeStore: outcomes
+    outcomeStore: outcomes,
+    resolveHistoricalPublication,
+    recoverHistoricalCommittedReceipt: historicalRecovery.recover
   });
   const transport = new RepoWriteChildIpcTransport();
   let cleanupPromise: Promise<void> | undefined;
@@ -163,4 +201,8 @@ export async function runRepoWriteChildEntrypoint(
       reject(error);
     });
   });
+}
+
+function recoveryErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/daemon/src/authority/authority-lifecycle.ts
+++ b/packages/daemon/src/authority/authority-lifecycle.ts
@@ -71,6 +71,10 @@ export interface AuthorityRepoComponent {
   readonly cutoverControl: AuthorityCutoverControlService;
   /** Present for production components; in-memory lifecycle fixtures omit it. */
   readonly compoundReceipt?: ProductionCompoundReceiptComposition;
+  /** Production-only recovery from the durable inner operation record. */
+  readonly recoverCommittedReceipt?: (
+    opId: string
+  ) => Promise<import("@harness-anything/application").AuthorityCommittedReceipt>;
   readonly bindConnection: (context: AuthorityConnectionContext) => AuthorityRepoConnectionBinding;
   readonly stop: (reason: AuthorityRepoStopReason) => Promise<void>;
 }

--- a/packages/daemon/src/authority/production/cutover-admission.ts
+++ b/packages/daemon/src/authority/production/cutover-admission.ts
@@ -14,6 +14,10 @@ export function gateCutoverAdmission(
       submitV2: (attempt: Parameters<NonNullable<AuthoritySubmissionService["submitV2"]>>[0]) =>
         control.runDuringOpenAdmission(() => service.submitV2!(attempt))
     } : {}),
+    ...(service.resumeV2 ? {
+      resumeV2: (recovery: Parameters<NonNullable<AuthoritySubmissionService["resumeV2"]>>[0]) =>
+        control.runDuringOpenAdmission(() => service.resumeV2!(recovery))
+    } : {}),
     getOperation: service.getOperation
   };
 }

--- a/packages/daemon/src/authority/production/historical-publication-evidence.ts
+++ b/packages/daemon/src/authority/production/historical-publication-evidence.ts
@@ -1,0 +1,43 @@
+import { sha256Text } from "@harness-anything/kernel";
+
+export async function historicalPublicationEvidence(input: {
+  readonly opId: string;
+  readonly publication: {
+    readonly commitSha: string;
+    readonly pipelineGeneratedPaths: ReadonlyArray<string>;
+  };
+  readonly readAtCommit: (commitSha: string, path: string) => Promise<Buffer>;
+}): Promise<{ readonly commitSha: string; readonly semanticDigest: string }> {
+  const eventPath = `attribution-events/${sha256Text(input.opId)}.jsonl`;
+  if (!input.publication.pipelineGeneratedPaths.includes(eventPath)) {
+    throw new Error(`AUTHORITY_HISTORICAL_PUBLICATION_EVENT_MISSING:${input.opId}`);
+  }
+  const eventBytes = await input.readAtCommit(input.publication.commitSha, eventPath);
+  return {
+    commitSha: input.publication.commitSha,
+    semanticDigest: historicalPublicationSemanticDigest(eventBytes, input.opId)
+  };
+}
+
+function historicalPublicationSemanticDigest(bytes: Buffer, opId: string): string {
+  const lines = bytes.toString("utf8").trim().split("\n").filter(Boolean);
+  if (lines.length !== 1) throw new Error(`AUTHORITY_HISTORICAL_PUBLICATION_EVENT_INVALID:${opId}`);
+  const event = JSON.parse(lines[0]!) as unknown;
+  if (!event || typeof event !== "object" || Array.isArray(event)) {
+    throw new Error(`AUTHORITY_HISTORICAL_PUBLICATION_EVENT_INVALID:${opId}`);
+  }
+  const record = event as Record<string, unknown>;
+  const integrity = record.authorityIntegrity;
+  if (record.schema !== "attribution-event/v1"
+    || record.opId !== opId
+    || !integrity
+    || typeof integrity !== "object"
+    || Array.isArray(integrity)) {
+    throw new Error(`AUTHORITY_HISTORICAL_PUBLICATION_EVENT_INVALID:${opId}`);
+  }
+  const semanticDigest = (integrity as Record<string, unknown>).semanticRequestDigest;
+  if (typeof semanticDigest !== "string" || !/^[a-f0-9]{64}$/u.test(semanticDigest)) {
+    throw new Error(`AUTHORITY_HISTORICAL_PUBLICATION_SEMANTIC_DIGEST_INVALID:${opId}`);
+  }
+  return semanticDigest;
+}

--- a/packages/daemon/src/authority/production/production-authority-lifecycle.ts
+++ b/packages/daemon/src/authority/production/production-authority-lifecycle.ts
@@ -74,6 +74,7 @@ import { createProductionAuthoritySemanticCompiler } from "./production-authorit
 import { connectionBoundRuntime } from "./connection-bound-runtime.ts";
 import { waitForProductionRecovery } from "./production-recovery-admission.ts";
 import { attestSubmissionService } from "./transport-attested-submission-service.ts";
+import { recoverProductionCommittedReceipt } from "./production-committed-receipt-recovery.ts";
 export { recoverPendingProductionEvents } from "./recovery.ts";
 
 interface RepoProductionMaterial {
@@ -399,6 +400,10 @@ function createRepoComponent(
     commandSubmissionV2: unbound,
     cutoverControl,
     compoundReceipt,
+    recoverCommittedReceipt: (opId) => recoverProductionCommittedReceipt({
+      recovery: material.recovery.promise, operationRegistry: input.operationRegistry,
+      publisher: input.committedEventPublisher, workspaceId: material.config.workspaceId, opId
+    }),
     setServing: (value) => {
       if (stopped && value) throw new Error("AUTHORITY_REPO_COMPONENT_STOPPED");
       serving = value;

--- a/packages/daemon/src/authority/production/production-committed-receipt-recovery.ts
+++ b/packages/daemon/src/authority/production/production-committed-receipt-recovery.ts
@@ -1,0 +1,23 @@
+import type {
+  AuthorityCommittedEventPublisherV2,
+  AuthorityCommittedReceipt,
+  AuthoritySubmissionV2Options
+} from "@harness-anything/application";
+import type { DurableAuthorityServiceState } from "./service-state.ts";
+
+export async function recoverProductionCommittedReceipt(input: {
+  readonly recovery: Promise<void>;
+  readonly operationRegistry: DurableAuthorityServiceState["operationRegistry"];
+  readonly publisher: AuthorityCommittedEventPublisherV2;
+  readonly workspaceId: string;
+  readonly opId: string;
+}): Promise<AuthorityCommittedReceipt> {
+  await input.recovery;
+  const record = await input.operationRegistry.get(input.workspaceId, input.opId);
+  if (!record) throw new Error(`AUTHORITY_OPERATION_NOT_FOUND:opId=${input.opId}`);
+  const recover = (input.publisher as typeof input.publisher & {
+    recoverCommittedReceipt?: NonNullable<AuthoritySubmissionV2Options["recoverCommittedReceipt"]>
+  }).recoverCommittedReceipt;
+  if (!recover) throw new Error("AUTHORITY_COMMITTED_RECEIPT_RECOVERY_UNAVAILABLE");
+  return recover(record);
+}

--- a/packages/daemon/src/authority/production/publication-evidence.ts
+++ b/packages/daemon/src/authority/production/publication-evidence.ts
@@ -19,6 +19,8 @@ import {
   publicationSubjectOperationIds,
   scanFirstParentPublicationMetadata
 } from "./publication-history.ts";
+import { historicalPublicationEvidence } from "./historical-publication-evidence.ts";
+import { createUniquePublicationOperationLookup } from "./publication-operation-lookup.ts";
 
 const materializerCommitter = {
   name: "Harness Anything Materializer",
@@ -44,6 +46,10 @@ export interface GitCanonicalPublicationInspector extends CanonicalPublicationIn
   ) => Promise<CanonicalPublicationEvidence>;
   readonly findPublication: (expectedOpIds: ReadonlyArray<string>) => Promise<CanonicalPublicationEvidence>;
   readonly findPublicationForOperation: (opId: string) => Promise<CanonicalPublicationEvidence>;
+  readonly findHistoricalPublicationForOperation: (opId: string) => Promise<{
+    readonly commitSha: string;
+    readonly semanticDigest: string;
+  }>;
   readonly scanFirstParentOperationAnchors: (input: {
     readonly exclusiveCommit?: string;
     readonly interestedOpIds: ReadonlySet<string>;
@@ -359,6 +365,11 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
       contentAddressedPaths
     };
   };
+  const findPublicationForOperation = createUniquePublicationOperationLookup({
+    anchors: async (opId) => (await indexedHistory())?.byOperationId.get(opId) ?? [],
+    inspect: (anchor) => inspectPublication(anchor.previousCommit, anchor.opIds, anchor.commitSha),
+    notFound: (opId) => new AuthorityCanonicalPublicationNotFoundError(opId)
+  });
   return {
     currentHead,
     inspectPublishedHead: async (expectedPreviousHead, expectedOpIds) => {
@@ -388,24 +399,15 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
       }
       return matches[0]!;
     },
-    findPublicationForOperation: async (opId) => {
-      const history = await indexedHistory();
-      if (!history) throw new AuthorityCanonicalPublicationNotFoundError(opId);
-      const matches: CanonicalPublicationEvidence[] = [];
-      for (const anchor of history.byOperationId.get(opId) ?? []) {
-        matches.push(await inspectPublication(
-          anchor.previousCommit,
-          anchor.opIds,
-          anchor.commitSha
-        ));
-      }
-      if (matches.length === 0) throw new AuthorityCanonicalPublicationNotFoundError(opId);
-      if (matches.length !== 1) {
-        throw new Error(
-          `AUTHORITY_CANONICAL_PUBLICATION_NOT_UNIQUE:expectedOpId=${opId};matches=${matches.map((entry) => entry.commitSha).join(",") || "none"}`
-        );
-      }
-      return matches[0]!;
+    findPublicationForOperation,
+    findHistoricalPublicationForOperation: async (opId) => {
+      const publication = await findPublicationForOperation(opId);
+      return historicalPublicationEvidence({
+        opId,
+        publication,
+        readAtCommit: (commitSha, eventPath) =>
+          publicationGitBytesAsync(rootDir, "show", `${commitSha}:${eventPath}`)
+      });
     }
   };
 }

--- a/packages/daemon/src/authority/production/publication-operation-lookup.ts
+++ b/packages/daemon/src/authority/production/publication-operation-lookup.ts
@@ -1,0 +1,27 @@
+export function createUniquePublicationOperationLookup<Anchor, Evidence extends {
+  readonly commitSha: string;
+}>(input: {
+  readonly anchors: (opId: string) => Promise<ReadonlyArray<Anchor>>;
+  readonly inspect: (anchor: Anchor) => Promise<Evidence>;
+  readonly notFound: (opId: string) => Error;
+}): (opId: string) => Promise<Evidence> {
+  return async (opId) => findUniquePublication(opId, await input.anchors(opId), input);
+}
+
+async function findUniquePublication<Anchor, Evidence extends { readonly commitSha: string }>(
+  opId: string,
+  anchors: ReadonlyArray<Anchor>,
+  input: {
+    readonly inspect: (anchor: Anchor) => Promise<Evidence>;
+    readonly notFound: (opId: string) => Error;
+  }
+): Promise<Evidence> {
+  const matches = await Promise.all(anchors.map(input.inspect));
+  if (matches.length === 0) throw input.notFound(opId);
+  if (matches.length !== 1) {
+    throw new Error(
+      `AUTHORITY_CANONICAL_PUBLICATION_NOT_UNIQUE:expectedOpId=${opId};matches=${matches.map((entry) => entry.commitSha).join(",") || "none"}`
+    );
+  }
+  return matches[0]!;
+}

--- a/packages/daemon/src/authority/production/transport-attested-submission-service.ts
+++ b/packages/daemon/src/authority/production/transport-attested-submission-service.ts
@@ -23,6 +23,12 @@ export function attestSubmissionService(
         return service.submitV2!(attempt);
       }
     } : {}),
+    ...(service.resumeV2 ? {
+      resumeV2: async (recovery: Parameters<NonNullable<AuthoritySubmissionService["resumeV2"]>>[0]) => {
+        await assertAttested();
+        return service.resumeV2!(recovery);
+      }
+    } : {}),
     getOperation: async (workspaceId, opId) => {
       await assertAttested();
       return service.getOperation(workspaceId, opId);

--- a/packages/daemon/src/runtime/durable-repo-write-outcome-store.ts
+++ b/packages/daemon/src/runtime/durable-repo-write-outcome-store.ts
@@ -10,6 +10,7 @@ import {
   lstatSync,
   mkdirSync,
   openSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync
@@ -101,6 +102,7 @@ export interface RepoWriteTerminalizeInputV1 extends RepoWriteOutcomeAxesV1 {
   readonly requestDigest: string;
   readonly receipt: CommandReceiptEnvelope;
   readonly authorityEvidence: RepoWriteTerminalEvidenceV1;
+  readonly historicalPublicationCommitSha?: string;
 }
 
 export type RepoWriteOutcomeLookupV1 =
@@ -220,6 +222,28 @@ export class DurableRepoWriteOutcomeStoreV1 {
     return terminal;
   }
 
+  listHistoricalProceedings(): ReadonlyArray<RepoWriteProceedingOutcomeV1> {
+    return readdirSync(this.directory)
+      .filter((name) => name.endsWith(proceedingSuffix))
+      .sort()
+      .flatMap((name) => {
+        const proceeding = repoWriteOutcomeReadCanonical(
+          path.join(this.directory, name),
+          this.durabilityHooks
+        );
+        if (proceeding.phase !== "PROCEEDING") {
+          throw new RepoWriteOutcomeCorruptionError(
+            `repo-write proceeding file has phase ${proceeding.phase}: ${name}`
+          );
+        }
+        this.assertIdentity(proceeding, proceeding.outerOpId);
+        const current = this.get(proceeding.outerOpId);
+        return current?.phase === "PROCEEDING" && current.generation < this.axes.generation
+          ? [current]
+          : [];
+      });
+  }
+
   begin(input: RepoWriteProceedingInputV1): RepoWriteOutcomeV1 {
     this.assertInputAxes(input);
     const candidate = createRepoWriteProceedingOutcomeV1(input);
@@ -250,7 +274,11 @@ export class DurableRepoWriteOutcomeStoreV1 {
         `cannot terminalize repo-write outcome before PROCEEDING: ${repoWriteOutcomeSafeIdentity(input.outerOpId)}`
       );
     }
-    if (current.generation !== this.axes.generation) {
+    const historicalPublication = input.historicalPublicationCommitSha;
+    if (current.generation !== this.axes.generation
+      && (current.generation >= this.axes.generation
+        || input.authorityEvidence.tag !== "COMMITTED"
+        || input.authorityEvidence.commitSha !== historicalPublication)) {
       throw new RepoWriteOutcomeConflictError(
         `historical-generation repo-write outcome requires fenced resume: ${repoWriteOutcomeSafeIdentity(input.outerOpId)}`
       );
@@ -269,7 +297,6 @@ export class DurableRepoWriteOutcomeStoreV1 {
       input.authorityEvidence
     );
     if (current.phase === "TERMINAL") return repoWriteOutcomeIdempotentTerminal(current, candidate);
-
     const published = repoWriteOutcomePublishOnce(
       this.directory,
       repoWriteOutcomePaths(this.directory, input.outerOpId).terminal,

--- a/packages/daemon/src/runtime/production-progress-append-operation.ts
+++ b/packages/daemon/src/runtime/production-progress-append-operation.ts
@@ -15,7 +15,8 @@ import type { JsonObject } from "../protocol/json-rpc-types.ts";
 import { createDaemonCommandService } from "../service/command-service.ts";
 import type { HarnessDaemonRuntime } from "./repo-runtime.ts";
 import {
-  RepoWriteAuthorityRecoveryGate
+  RepoWriteAuthorityRecoveryGate,
+  type RepoWriteAuthorityRecoveryGateOptions
 } from "./repo-write-authority-recovery-gate.ts";
 import {
   RepoWriteDurableOperationController,
@@ -59,6 +60,8 @@ export class ProductionRepoWriteOperationHost<
     readonly authorityComponent: AuthorityRepoComponent;
     readonly hostServices: DaemonCommandHostServices<Command, Result, AuthenticatedActor>;
     readonly outcomeStore: DurableRepoWriteOutcomeStoreV1;
+    readonly resolveHistoricalPublication?: RepoWriteAuthorityRecoveryGateOptions["resolveHistoricalPublication"];
+    readonly recoverHistoricalCommittedReceipt?: RepoWriteAuthorityRecoveryGateOptions["recoverHistoricalCommittedReceipt"];
     readonly now: () => Date;
     readonly newOuterOpId: () => string;
   };
@@ -73,6 +76,8 @@ export class ProductionRepoWriteOperationHost<
     readonly authorityComponent: AuthorityRepoComponent;
     readonly hostServices: DaemonCommandHostServices<Command, Result, AuthenticatedActor>;
     readonly outcomeStore: DurableRepoWriteOutcomeStoreV1;
+    readonly resolveHistoricalPublication?: RepoWriteAuthorityRecoveryGateOptions["resolveHistoricalPublication"];
+    readonly recoverHistoricalCommittedReceipt?: RepoWriteAuthorityRecoveryGateOptions["recoverHistoricalCommittedReceipt"];
     readonly now?: () => Date;
     readonly newOuterOpId?: () => string;
   }) {
@@ -86,7 +91,13 @@ export class ProductionRepoWriteOperationHost<
       workspaceId: options.workspaceId,
       generation: options.generation,
       store: options.outcomeStore,
-      assertCurrentWriterFence: options.runtime.assertWriteFenceHeld
+      assertCurrentWriterFence: options.runtime.assertWriteFenceHeld,
+      ...(options.resolveHistoricalPublication ? {
+        resolveHistoricalPublication: options.resolveHistoricalPublication
+      } : {}),
+      ...(options.recoverHistoricalCommittedReceipt ? {
+        recoverHistoricalCommittedReceipt: options.recoverHistoricalCommittedReceipt
+      } : {})
     });
     this.operations = new RepoWriteDurableOperationController({
       repoId: options.repoId,

--- a/packages/daemon/src/runtime/repo-write-authority-recovery-gate.ts
+++ b/packages/daemon/src/runtime/repo-write-authority-recovery-gate.ts
@@ -1,3 +1,8 @@
+import {
+  isCompleteAuthorityCommittedReceiptV2,
+  type AuthorityCommittedReceipt,
+  type CommandReceiptEnvelope
+} from "@harness-anything/application";
 import type { ProductionAuthorityOuterRecoveryWitnessV1 } from "../authority/production/production-authority-attempt-plan.ts";
 import {
   DurableRepoWriteOutcomeStoreV1,
@@ -13,6 +18,15 @@ export interface RepoWriteAuthorityRecoveryGateOptions
   extends RepoWriteOutcomeAxesV1 {
   readonly store: DurableRepoWriteOutcomeStoreV1;
   readonly assertCurrentWriterFence: () => void | Promise<void>;
+  readonly resolveHistoricalPublication?: (
+    outcome: RepoWriteProceedingOutcomeV1
+  ) => Promise<{
+    readonly commitSha: string;
+    readonly semanticDigest: string;
+  }>;
+  readonly recoverHistoricalCommittedReceipt?: (
+    outcome: RepoWriteProceedingOutcomeV1
+  ) => Promise<AuthorityCommittedReceipt>;
 }
 
 export interface RepoWriteAuthorityRecoveryAttemptWitness {
@@ -36,6 +50,10 @@ export class RepoWriteAuthorityRecoveryGate {
   private readonly axes: RepoWriteOutcomeAxesV1;
   private readonly store: DurableRepoWriteOutcomeStoreV1;
   private readonly assertCurrentWriterFence: RepoWriteAuthorityRecoveryGateOptions["assertCurrentWriterFence"];
+  private readonly resolveHistoricalPublication:
+    RepoWriteAuthorityRecoveryGateOptions["resolveHistoricalPublication"];
+  private readonly recoverHistoricalCommittedReceipt:
+    RepoWriteAuthorityRecoveryGateOptions["recoverHistoricalCommittedReceipt"];
 
   constructor(options: RepoWriteAuthorityRecoveryGateOptions) {
     this.axes = {
@@ -45,6 +63,8 @@ export class RepoWriteAuthorityRecoveryGate {
     };
     this.store = options.store;
     this.assertCurrentWriterFence = options.assertCurrentWriterFence;
+    this.resolveHistoricalPublication = options.resolveHistoricalPublication;
+    this.recoverHistoricalCommittedReceipt = options.recoverHistoricalCommittedReceipt;
   }
 
   runPlannedRecovery<Result>(
@@ -65,7 +85,7 @@ export class RepoWriteAuthorityRecoveryGate {
       outerOpId: witness.outerOpId,
       outerRequestDigest: witness.outerRequestDigest,
       outerGeneration: witness.outerGeneration
-    }, async (outcome) => {
+    }, async (outcome, historicalPublication) => {
       if (witness.repoId !== outcome.repoId
         || witness.workspaceId !== outcome.workspaceId
         || witness.opId !== outcome.innerOpId
@@ -74,14 +94,95 @@ export class RepoWriteAuthorityRecoveryGate {
           `authority recovery witness does not bind the durable outer operation: ${witness.outerOpId}`
         );
       }
-      return useDurableProceeding();
+      const result: Result = historicalPublication
+        ? await this.recoverHistorical(outcome, historicalPublication) as Result
+        : await useDurableProceeding();
+      if (historicalPublication) {
+        const committed = result as AuthorityCommittedReceipt;
+        if (!committed || committed.tag !== "COMMITTED"
+          || !isCompleteAuthorityCommittedReceiptV2(committed)
+          || committed.workspaceId !== outcome.workspaceId
+          || committed.opId !== outcome.innerOpId
+          || committed.semanticDigest !== outcome.authoritySemanticDigest
+          || committed.commitSha !== historicalPublication.commitSha) {
+          throw new RepoWriteOutcomeGenerationFenceError(
+            `historical authority recovery did not return exact committed publication evidence: ${witness.outerOpId}`
+          );
+        }
+        this.terminalizeHistorical(outcome, historicalPublication, committed);
+      }
+      return result;
+    });
+  }
+
+  async recoverHistoricalProceeding(
+    outcome: RepoWriteProceedingOutcomeV1
+  ): Promise<void> {
+    if (outcome.generation >= this.axes.generation
+      || outcome.repoId !== this.axes.repoId
+      || outcome.workspaceId !== this.axes.workspaceId
+      || !this.resolveHistoricalPublication) {
+      throw new RepoWriteOutcomeGenerationFenceError(
+        `historical authority recovery cannot admit outer PROCEEDING: ${outcome.outerOpId}`
+      );
+    }
+    const publication = await this.resolveHistoricalPublication(outcome);
+    if (publication.semanticDigest !== outcome.authoritySemanticDigest) {
+      throw new RepoWriteOutcomeGenerationFenceError(
+        `historical publication semantic digest does not match outer PROCEEDING: ${outcome.outerOpId}`
+      );
+    }
+    await this.assertCurrentWriterFence();
+    const committed = await this.recoverHistorical(outcome, publication);
+    this.terminalizeHistorical(outcome, publication, committed);
+  }
+
+  private async recoverHistorical(
+    outcome: RepoWriteProceedingOutcomeV1,
+    publication: { readonly commitSha: string; readonly semanticDigest: string }
+  ): Promise<AuthorityCommittedReceipt> {
+    if (!this.recoverHistoricalCommittedReceipt) {
+      throw new RepoWriteOutcomeGenerationFenceError(
+        `historical authority committed receipt recovery is unavailable: ${outcome.outerOpId}`
+      );
+    }
+    const committed = await this.recoverHistoricalCommittedReceipt(outcome);
+    if (committed.tag !== "COMMITTED"
+      || !isCompleteAuthorityCommittedReceiptV2(committed)
+      || committed.workspaceId !== outcome.workspaceId
+      || committed.opId !== outcome.innerOpId
+      || committed.semanticDigest !== outcome.authoritySemanticDigest
+      || committed.commitSha !== publication.commitSha) {
+      throw new RepoWriteOutcomeGenerationFenceError(
+        `historical authority recovery did not return exact committed publication evidence: ${outcome.outerOpId}`
+      );
+    }
+    return committed;
+  }
+
+  private terminalizeHistorical(
+    outcome: RepoWriteProceedingOutcomeV1,
+    publication: { readonly commitSha: string },
+    committed: AuthorityCommittedReceipt
+  ): void {
+    this.store.terminalize({
+      ...this.axes,
+      outerOpId: outcome.outerOpId,
+      requestDigest: outcome.requestDigest,
+      historicalPublicationCommitSha: publication.commitSha,
+      receipt: historicalRecoveryReceipt(outcome, publication.commitSha),
+      authorityEvidence: committed
     });
   }
 
   private async authorize<Result>(
     witness: ProductionAuthorityOuterRecoveryWitnessV1,
     useDurableProceeding: (
-      outcome: RepoWriteProceedingOutcomeV1
+      outcome: RepoWriteProceedingOutcomeV1,
+      historicalPublication?: {
+        readonly commitSha: string;
+        readonly semanticDigest: string;
+      }
     ) => Result | Promise<Result>
   ): Promise<Result> {
     const current = this.store.lookup(witness.outerOpId);
@@ -91,9 +192,22 @@ export class RepoWriteAuthorityRecoveryGate {
       );
     }
     if (current.state === "outcome-unknown") {
-      throw new RepoWriteOutcomeGenerationFenceError(
-        `authority recovery cannot consume historical outer PROCEEDING: ${witness.outerOpId}`
-      );
+      const outcome = current.outcome;
+      if (witness.outerGeneration !== outcome.generation
+        || witness.outerRequestDigest !== outcome.requestDigest
+        || !this.resolveHistoricalPublication) {
+        throw new RepoWriteOutcomeGenerationFenceError(
+          `authority recovery cannot consume historical outer PROCEEDING: ${witness.outerOpId}`
+        );
+      }
+      const publication = await this.resolveHistoricalPublication(outcome);
+      if (publication.semanticDigest !== outcome.authoritySemanticDigest) {
+        throw new RepoWriteOutcomeGenerationFenceError(
+          `historical publication semantic digest does not match outer PROCEEDING: ${witness.outerOpId}`
+        );
+      }
+      await this.assertCurrentWriterFence();
+      return useDurableProceeding(outcome, publication);
     }
     const outcome = current.outcome;
     if (outcome.repoId !== this.axes.repoId
@@ -108,4 +222,33 @@ export class RepoWriteAuthorityRecoveryGate {
     await this.assertCurrentWriterFence();
     return useDurableProceeding(outcome);
   }
+}
+
+function historicalRecoveryReceipt(
+  outcome: RepoWriteProceedingOutcomeV1,
+  publicationCommitSha: string
+): CommandReceiptEnvelope {
+  return {
+    ok: true,
+    schema: "command-receipt/v2",
+    command: outcome.receiptSeed.command,
+    action: outcome.receiptSeed.action,
+    summary: "Recovered committed outcome from canonical publication.",
+    details: {
+      actor: outcome.canonicalCommand.actor,
+      data: {
+        repoWrite: {
+          schema: "repo-write-recovery/v1",
+          repoId: outcome.repoId,
+          generation: outcome.generation,
+          outerOpId: outcome.outerOpId,
+          recoveryEvidence: `cross-generation-publication:${publicationCommitSha}`
+        }
+      }
+    },
+    meta: {
+      generatedAt: outcome.receiptSeed.generatedAt,
+      compatibility: {}
+    }
+  };
 }

--- a/packages/daemon/test/attestation-transport-observed.test.ts
+++ b/packages/daemon/test/attestation-transport-observed.test.ts
@@ -10,6 +10,7 @@ import {
   verifyAttestationAssertion,
   type AuthorityConnectionContext
 } from "../src/index.ts";
+import { attestSubmissionService } from "../src/authority/production/transport-attested-submission-service.ts";
 
 const context: AuthorityConnectionContext = {
   schema: "authority-connection-context/v1",
@@ -92,4 +93,26 @@ test("client-reported credential and channel data are ignored", async () => {
     canonicalTranscript: "client-reported-transcript",
     proof: "client-reported-proof"
   }), false);
+});
+
+test("transport attestation preserves V2 recovery admission", async () => {
+  let resumed = 0;
+  const service = attestSubmissionService({
+    submit: async () => { throw new Error("unused"); },
+    resumeV2: async () => {
+      resumed += 1;
+      return {
+        tag: "INDETERMINATE",
+        workspaceId: "workspace-attested-recovery",
+        opId: "op-attested-recovery",
+        semanticDigest: "a".repeat(64),
+        reason: "fixture"
+      };
+    },
+    getOperation: async () => undefined
+  }, context);
+
+  assert.equal(typeof service.resumeV2, "function");
+  await service.resumeV2!({} as Parameters<NonNullable<typeof service.resumeV2>>[0]);
+  assert.equal(resumed, 1);
 });

--- a/packages/daemon/test/authority-submission-error.test.ts
+++ b/packages/daemon/test/authority-submission-error.test.ts
@@ -6,6 +6,7 @@ import {
   gateAuthoritySubmissionForRecovery
 } from "../src/index.ts";
 import { receiptToFlushReport } from "../src/authority/authority-command-submission.ts";
+import { gateCutoverAdmission } from "../src/authority/production/cutover-admission.ts";
 import {
   defaultProductionRecoveryAdmissionTimeoutMs,
   waitForProductionRecovery
@@ -116,6 +117,35 @@ test("recovery gate waits before admitting legacy, V2, and V2 recovery ingress",
   assert.equal(recoveryV2.tag, "COMMITTED");
   assert.equal(recoveryV2.opId, fixture.expectedOpId);
   assert.equal(submissions, 3);
+});
+
+test("cutover admission preserves V2 recovery admission", async () => {
+  let admitted = 0;
+  let resumed = 0;
+  const fixture = authorityCommandAttemptFixture();
+  const service = gateCutoverAdmission({
+    submit: async () => { throw new Error("unused"); },
+    resumeV2: async (recovery) => {
+      resumed += 1;
+      return {
+        tag: "INDETERMINATE",
+        workspaceId: recovery.witness.workspaceId,
+        opId: recovery.witness.opId,
+        semanticDigest: recovery.witness.semanticDigest,
+        reason: "fixture"
+      };
+    },
+    getOperation: async () => undefined
+  }, {
+    runDuringOpenAdmission: async (operation) => {
+      admitted += 1;
+      return operation();
+    }
+  } as import("@harness-anything/application").AuthorityCutoverControlService);
+
+  await service.resumeV2!(authorityRecoveryAttemptFixture(fixture));
+  assert.equal(admitted, 1);
+  assert.equal(resumed, 1);
 });
 
 test("production recovery admission expires before the repo-write transport deadline", () => {

--- a/packages/daemon/test/publication-evidence-responsiveness.test.ts
+++ b/packages/daemon/test/publication-evidence-responsiveness.test.ts
@@ -24,10 +24,15 @@ test("publication evidence yields between blob reads so recovery admission timer
 
   git(root, "checkout", "-q", "-b", "session");
   const opId = "namespace:test-responsive-recovery";
+  const semanticDigest = "a".repeat(64);
   mkdirSync(path.join(root, "attribution-events"));
   writeFileSync(
     path.join(root, "attribution-events", `${sha256Text(opId)}.jsonl`),
-    "{}\n"
+    `${JSON.stringify({
+      schema: "attribution-event/v1",
+      opId,
+      authorityIntegrity: { semanticRequestDigest: semanticDigest }
+    })}\n`
   );
   mkdirSync(path.join(root, "objects"));
   for (let index = 0; index < 16; index += 1) {
@@ -43,11 +48,16 @@ test("publication evidence yields between blob reads so recovery admission timer
   setTimeout(() => {
     timerFired = true;
   }, 0);
-  await createGitCanonicalPublicationInspector(root).inspectPublication(
+  const inspector = createGitCanonicalPublicationInspector(root);
+  await inspector.inspectPublication(
     previousCommit,
     [opId],
     mergeCommit
   );
+  assert.deepEqual(await inspector.findHistoricalPublicationForOperation(opId), {
+    commitSha: mergeCommit,
+    semanticDigest
+  });
 
   assert.equal(timerFired, true);
 });

--- a/packages/daemon/test/repo-write-authority-recovery-gate.test.ts
+++ b/packages/daemon/test/repo-write-authority-recovery-gate.test.ts
@@ -1,6 +1,7 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -78,6 +79,177 @@ recoveryTest("request, generation, inner identity, and writer fence mismatches f
   });
 });
 
+recoveryTest("historical recovery terminalizes only from matching canonical publication evidence", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "ha-repo-write-historical-recovery-"));
+  const historical = { ...proceedingInput(), generation: 403 };
+  const previous = new DurableRepoWriteOutcomeStoreV1({
+    directory,
+    repoId: historical.repoId,
+    workspaceId: historical.workspaceId,
+    generation: historical.generation
+  }).begin(historical);
+  const proceedingPath = path.join(
+    directory,
+    readdirSync(directory).find((name) => name.endsWith(".proceeding.json"))!
+  );
+  const proceedingBytes = readFileSync(proceedingPath);
+  const proceedingSha256 = createHash("sha256").update(proceedingBytes).digest("hex");
+  const publicationCommitSha = "a".repeat(40);
+  const evidence = committedEvidence(historical, publicationCommitSha);
+  const current = new DurableRepoWriteOutcomeStoreV1({
+    directory,
+    repoId: historical.repoId,
+    workspaceId: historical.workspaceId,
+    generation: 409
+  });
+  const gate = new RepoWriteAuthorityRecoveryGate({
+    repoId: historical.repoId,
+    workspaceId: historical.workspaceId,
+    generation: 409,
+    store: current,
+    assertCurrentWriterFence: () => undefined,
+    resolveHistoricalPublication: async () => ({
+      commitSha: publicationCommitSha,
+      semanticDigest: historical.authoritySemanticDigest
+    }),
+    recoverHistoricalCommittedReceipt: async () => evidence
+  });
+
+  const pending = current.listHistoricalProceedings();
+  assert.equal(pending.length, 1);
+  await gate.recoverHistoricalProceeding(pending[0]!);
+
+  const terminal = current.lookup(previous.outerOpId);
+  assert.equal(terminal.state, "terminal");
+  assert.equal(terminal.generation, "historical");
+  if (terminal.state !== "terminal") return;
+  assert.equal(terminal.outcome.terminalProof.evidence.commitSha, publicationCommitSha);
+  assert.equal(
+    (terminal.outcome.receipt.details?.data as {
+      readonly repoWrite?: { readonly recoveryEvidence?: string };
+    })?.repoWrite?.recoveryEvidence,
+    `cross-generation-publication:${publicationCommitSha}`
+  );
+  assert.deepEqual(readFileSync(proceedingPath), proceedingBytes);
+  assert.equal(
+    createHash("sha256").update(readFileSync(proceedingPath)).digest("hex"),
+    proceedingSha256
+  );
+});
+
+recoveryTest("historical recovery stays outcome-unknown when publication is absent", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "ha-repo-write-historical-absent-"));
+  try {
+    const historical = { ...proceedingInput(), generation: 403 };
+    const previous = new DurableRepoWriteOutcomeStoreV1({
+      directory,
+      repoId: historical.repoId,
+      workspaceId: historical.workspaceId,
+      generation: historical.generation
+    }).begin(historical);
+    const current = new DurableRepoWriteOutcomeStoreV1({
+      directory,
+      repoId: historical.repoId,
+      workspaceId: historical.workspaceId,
+      generation: 409
+    });
+    const gate = new RepoWriteAuthorityRecoveryGate({
+      repoId: historical.repoId,
+      workspaceId: historical.workspaceId,
+      generation: 409,
+      store: current,
+      assertCurrentWriterFence: () => undefined,
+      resolveHistoricalPublication: async () => {
+        throw new Error("AUTHORITY_CANONICAL_PUBLICATION_NOT_FOUND");
+      }
+    });
+    await assert.rejects(
+      gate.recoverHistoricalProceeding(current.listHistoricalProceedings()[0]!),
+      /AUTHORITY_CANONICAL_PUBLICATION_NOT_FOUND/u
+    );
+    assert.equal(current.lookup(previous.outerOpId).state, "outcome-unknown");
+    assert.equal(readdirSync(directory).filter((name) => name.endsWith(".terminal.json")).length, 0);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+recoveryTest("historical recovery stays outcome-unknown when publication is not unique", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "ha-repo-write-historical-nonunique-"));
+  try {
+    const historical = { ...proceedingInput(), generation: 403 };
+    const previous = new DurableRepoWriteOutcomeStoreV1({
+      directory,
+      repoId: historical.repoId,
+      workspaceId: historical.workspaceId,
+      generation: historical.generation
+    }).begin(historical);
+    const current = new DurableRepoWriteOutcomeStoreV1({
+      directory,
+      repoId: historical.repoId,
+      workspaceId: historical.workspaceId,
+      generation: 409
+    });
+    const gate = new RepoWriteAuthorityRecoveryGate({
+      repoId: historical.repoId,
+      workspaceId: historical.workspaceId,
+      generation: 409,
+      store: current,
+      assertCurrentWriterFence: () => undefined,
+      resolveHistoricalPublication: async () => {
+        throw new Error("AUTHORITY_CANONICAL_PUBLICATION_NOT_UNIQUE");
+      }
+    });
+
+    await assert.rejects(
+      gate.recoverHistoricalProceeding(current.listHistoricalProceedings()[0]!),
+      /AUTHORITY_CANONICAL_PUBLICATION_NOT_UNIQUE/u
+    );
+    assert.equal(current.lookup(previous.outerOpId).state, "outcome-unknown");
+    assert.equal(readdirSync(directory).filter((name) => name.endsWith(".terminal.json")).length, 0);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+recoveryTest("historical recovery stays outcome-unknown when publication semantic digest differs", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "ha-repo-write-historical-digest-"));
+  try {
+    const historical = { ...proceedingInput(), generation: 403 };
+    const previous = new DurableRepoWriteOutcomeStoreV1({
+      directory,
+      repoId: historical.repoId,
+      workspaceId: historical.workspaceId,
+      generation: historical.generation
+    }).begin(historical);
+    const current = new DurableRepoWriteOutcomeStoreV1({
+      directory,
+      repoId: historical.repoId,
+      workspaceId: historical.workspaceId,
+      generation: 409
+    });
+    const gate = new RepoWriteAuthorityRecoveryGate({
+      repoId: historical.repoId,
+      workspaceId: historical.workspaceId,
+      generation: 409,
+      store: current,
+      assertCurrentWriterFence: () => undefined,
+      resolveHistoricalPublication: async () => ({
+        commitSha: "a".repeat(40),
+        semanticDigest: "9".repeat(64)
+      })
+    });
+    await assert.rejects(
+      gate.recoverHistoricalProceeding(current.listHistoricalProceedings()[0]!),
+      /semantic digest does not match/u
+    );
+    assert.equal(current.lookup(previous.outerOpId).state, "outcome-unknown");
+    assert.equal(readdirSync(directory).filter((name) => name.endsWith(".terminal.json")).length, 0);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 async function withGate(
   run: (fixture: {
     readonly directory: string;
@@ -104,6 +276,36 @@ async function withGate(
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
+}
+
+function committedEvidence(
+  proceeding: RepoWriteProceedingInputV1,
+  commitSha: string
+) {
+  return {
+    tag: "COMMITTED" as const,
+    workspaceId: proceeding.workspaceId,
+    opId: proceeding.innerOpId,
+    semanticDigest: proceeding.authoritySemanticDigest,
+    revision: 1,
+    commitSha,
+    previousCommit: "b".repeat(40),
+    authorityIntegrity: {
+      schema: "authority-operation-integrity/v2" as const,
+      semanticRequestDigest: proceeding.authoritySemanticDigest,
+      semanticMutationSetDigest: "2".repeat(64),
+      mutationRegistryVersion: 1,
+      actorAxesBindingDigest: "3".repeat(64),
+      canonicalMutationSet: { registryVersion: 1 as const, mutations: [] }
+    },
+    integrityTuple: {
+      schema: "authority-integrity-tuple/v2" as const,
+      canonicalEventDigest: "4".repeat(64),
+      changeSetDigest: "5".repeat(64),
+      semanticMutationSetDigest: "2".repeat(64),
+      actorAxesBindingDigest: "3".repeat(64)
+    }
+  };
 }
 
 function axes() {


### PR DESCRIPTION
# English

## Summary

A single outer PROCEEDING row left behind by an older daemon generation made the
recovery gate fail closed forever, so every governed write was rejected with
`AUTHORITY_RECOVERY_AUTHORIZATION_UNAVAILABLE`. One stranded row is a total write
outage. This lets such a row converge — but only when the ledger holds authoritative
evidence that the work was in fact canonically published. Rows without that evidence
keep today's behaviour exactly. No durable schema changes; no existing row is ever
rewritten or deleted.

## What Changed

- `repo-write-authority-recovery-gate.ts` admits a historical outer PROCEEDING only
  when all of the following hold: its generation is strictly older than the current
  one; repo and workspace match; its `innerOpId` resolves to exactly one canonical
  publication; that publication's semantic digest equals the row's
  `authoritySemanticDigest`; the current writer fence is held; and the recovered
  receipt is a complete `COMMITTED` receipt whose workspace, opId, semantic digest,
  and commit sha all match. Any miss throws `RepoWriteOutcomeGenerationFenceError`
  and the row stays `outcome-unknown`. The same-generation path is untouched.
- `historical-publication-evidence.ts` (new) derives the semantic digest from the
  published artifact rather than synthesizing it: the publication commit must
  actually contain `attribution-events/<sha256(opId)>.jsonl`, whose bytes are read
  at that commit, validated for `attribution-event/v1` and a matching `opId`, and
  whose own `authorityIntegrity.semanticRequestDigest` becomes the compared digest.
  Two independent records cross-check; nothing is manufactured.
- `publication-operation-lookup.ts` (new) factors out the exactly-one rule: zero
  matches raise not-found, more than one raises
  `AUTHORITY_CANONICAL_PUBLICATION_NOT_UNIQUE`.
- `durable-repo-write-outcome-store.ts` gains `listHistoricalProceedings()` (read
  only) and admits a cross-generation terminalize solely when the caller passes the
  resolved publication sha and the evidence is `COMMITTED` at that exact sha.
  Omitting the new optional field reproduces the previous throw verbatim, so no
  existing caller changes behaviour. Terminalization only appends the terminal
  record; the proceeding file is never written.
- `repo-write-child-entrypoint.ts` sweeps historical proceedings once at child
  start, per row inside `try/catch`: a row that cannot be anchored logs its reason
  to stderr and startup continues.
- `attestSubmissionService` and `gateCutoverAdmission` preserve `resumeV2` through
  their wrappers. #1078 repaired the innermost layer only; these two still stripped
  the method, so the recovery ingress above would be unreachable in production.

## Task And Scope

- Harness task: not applicable; continued incident remediation of the #1075 P5-W2
  CH4 child-writer cutover (follows #1077, #1078, #1079)
- Branch: `codex/repo-write-cross-generation-recovery`
- Public scope: `packages/daemon` repo-write outcome store and recovery gate,
  authority publication evidence, submission wrappers; `packages/cli` repo-write
  child entrypoint
- Private planning/evidence updated: yes
- Out of scope: adjudicating rows that have no canonical publication anchor; those
  remain `outcome-unknown` pending human review

## Version Impact

- Version: no version change because no wire format, durable schema, or receipt
  schema changed; `command-receipt/v2` and `repo-write-recovery/v1` already exist on
  `main`
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable; `tools/check-pr-governance.mjs` reports
  no manifest-derived protected surface touched
- Authority: this changes when a durable outer PROCEEDING may be terminalized, which
  is a governed semantic. It was adjudicated by Zeyu in the operating session on
  2026-07-24: cross-generation terminalization is permitted **only** with an exact
  publication anchor (unique canonical publication for the inner opId **and** an
  exactly matching authority semantic digest); rows without such an anchor may not
  be terminalized. The implementation is strictly narrower than that grant — it adds
  a writer-fence assertion and a complete-committed-receipt check on top.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers
  decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: the adjudication above must be recorded in the ledger
  via `ha decision propose` / `accept`. It could not be recorded first because the
  governed write path is the very thing this PR restores — the decision would have
  had to be written through the path it unblocks. CEO records it retroactively once
  a real governed write completes post-merge, and links it to this PR.

## Verification

- Base `origin/main` SHA: `b27d131b3b78fbfef2b483bad7afb7f98fdb7948`
- Branch merge-base with `origin/main`: `b27d131b3b78fbfef2b483bad7afb7f98fdb7948`
- Last `git fetch origin` time: 2026-07-24, immediately before opening this PR
- Sync method: rebase onto current main (after #1079)
- Public diff command: `git diff b27d131b3b78fbfef2b483bad7afb7f98fdb7948...HEAD`
- Private evidence commit/path: session incident findings (Round 3)
- Reviewer evidence path: CEO semantic acceptance in the merge session
- GitHub Actions `rewrite-ci` run URL: pending; linked once the run starts
- [x] `git diff --check`
- [x] `npm run check:stop-point` — 34 complete manifest gates green (after rebase)
- [x] Targeted tests for the change surface, named with their counts:
  `repo-write-authority-recovery-gate.test.ts` covers the accept path plus three
  reject paths (no anchor, non-unique anchor, digest mismatch) and asserts the
  proceeding file's bytes and SHA-256 are unchanged across recovery;
  `authority-submission-error.test.ts` and `attestation-transport-observed.test.ts`
  cover `resumeV2` preservation through both wrappers. Focused suites 37/37 passed;
  affected fast 501/501; affected contract 223/223 with one platform skip.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: `npm run check:ci` not run locally (retired local full preflight;
  GitHub Actions is authoritative). No production daemon was started or written to
  during development; the live proceeding row still carries its original hash and its
  terminal record still does not exist. End-to-end confirmation against the live
  writer happens after merge, dist rebuild, and a deliberate daemon restart — a real
  governed write completing under 30s — before this is treated as resolving the
  incident.

## Review Evidence

- Self-review: CEO read the full diff against the adjudicated conditions and
  independently ground-truthed the anchor in the ledger repository. The canonical
  anchor is materializer merge commit
  `936ed7f658555e202cff44340ce98e77c52cc747`, whose second parent
  `97ebd188f1332560372512c5519e84b7110b0715` carries
  `[namespace-harness-anything-production:736978ed777a15179942b6f068bc151c]` in its
  subject; a `--grep` over all refs returns exactly that one commit, so the
  uniqueness requirement holds on real data. CEO also verified that no new schema
  token is introduced, that omitting the new optional field reproduces the prior
  throw, and that an unanchorable row logs its reason and does not block child
  startup.
- Reviewer subagent: Codex authored the implementation and corrected the CEO's
  initial anchor attribution (the CEO had named the session commit rather than the
  materializer merge); the correction was independently verified before acceptance.
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The startup sweep performs one publication lookup per older-generation proceeding
  row. Production currently holds exactly one such row, and #1079 bounded the
  underlying Git work, but the sweep is still linear in stranded rows.
- Recovery depends on the attribution event remaining present at the publication
  commit. If a publication commit lacks the expected event path, the row stays
  `outcome-unknown` rather than converging — fail-closed, but it means history
  rewriting upstream would silently move a row back into the pending set.
- Rows with no anchor still require human adjudication; this PR deliberately
  provides no mechanism to resolve them.

## References

- Task: not applicable
- Evidence: session incident findings (Round 3)
- Review: CEO semantic acceptance in the merge session

---

# 中文

## 概要

一条旧代 daemon 遗留的 outer PROCEEDING 行让恢复门永久 fail-closed，导致**每一次**治理写
都被 `AUTHORITY_RECOVERY_AUTHORIZATION_UNAVAILABLE` 拒绝——一行脏数据 = 全局写停摆。本 PR
让这类行能够收敛，但**仅当**账本里存在权威证据证明该工作确实已 canonical 发布。没有该证据
的行，行为与今天逐字相同。无持久 schema 变更；既有行永不改写、永不删除。

## 改动内容

- `repo-write-authority-recovery-gate.ts` 只在下列条件**全部**成立时接纳一条历史 outer
  PROCEEDING：其 generation 严格早于当前代；repo 与 workspace 匹配；其 `innerOpId` 解析到
  **唯一**一个 canonical publication；该 publication 的 semantic digest 与该行的
  `authoritySemanticDigest` 相等；当前 writer fence 持有；恢复出的回执是**完整**的
  `COMMITTED` 回执且 workspace / opId / semantic digest / commit sha 四项全等。任一不中
  即抛 `RepoWriteOutcomeGenerationFenceError`，该行保持 `outcome-unknown`。同代路径未改动。
- `historical-publication-evidence.ts`（新增）从**已发布产物**派生 semantic digest，而不是
  合成它：该 publication commit 必须真的包含 `attribution-events/<sha256(opId)>.jsonl`，
  在该 commit 处读出真实字节、校验 `attribution-event/v1` 与 `opId` 相符，再取该记录自身的
  `authorityIntegrity.semanticRequestDigest` 作为比对用 digest。两份独立记录互证，不制造
  任何东西。
- `publication-operation-lookup.ts`（新增）抽出「恰好一个」规则：零个抛 not-found，多于一个
  抛 `AUTHORITY_CANONICAL_PUBLICATION_NOT_UNIQUE`。
- `durable-repo-write-outcome-store.ts` 新增只读的 `listHistoricalProceedings()`；跨代
  terminalize 仅在调用方传入解析出的 publication sha **且**证据是该 sha 上的 `COMMITTED`
  时才放行。省略这个新的可选字段时，抛错路径与此前逐字相同，因此**没有任何既有调用方的行为
  发生变化**。终态化只 append terminal 记录，proceeding 文件从不被写。
- `repo-write-child-entrypoint.ts` 在子进程启动时扫一次历史 proceeding，**逐行 try/catch**：
  无法锚定的行把原因打到 stderr，启动继续。
- `attestSubmissionService` 与 `gateCutoverAdmission` 在各自 wrapper 里保全 `resumeV2`。
  #1078 只修了最内层，这两层仍会把该方法剥掉，不修的话上面这条恢复入口在生产里根本走不到。

## 任务与范围

- Harness 任务：不适用；#1075 P5-W2 CH4 子写进程 cutover 事故的持续补救（承接 #1077、
  #1078、#1079）
- 分支：`codex/repo-write-cross-generation-recovery`
- 公开范围：`packages/daemon` 的 repo-write outcome store 与恢复门、authority publication
  证据、submission wrapper；`packages/cli` 的 repo-write 子进程入口
- 私有计划 / 证据是否已更新：yes
- 范围外：裁决那些**没有** canonical publication anchor 的行；它们继续保持
  `outcome-unknown`，等人工复核

## 版本影响

- 版本：不改版本，原因是未改动任何 wire 格式、持久 schema 或 receipt schema；
  `command-receipt/v2` 与 `repo-write-recovery/v1` 在 `main` 上均已存在
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用；`tools/check-pr-governance.mjs` 报告未触碰任何 manifest
  派生保护面
- 依据：本 PR 改变了「一条持久 outer PROCEEDING 何时可被终态化」，这是治理语义。泽宇已于
  2026-07-24 的运营 session 中裁决：跨代终态化**仅当**存在精确 publication anchor（inner
  opId 的**唯一** canonical publication **且** authority semantic digest 精确相等）才被允许；
  没有该 anchor 的行不得终态化。实现比该授权**更严格**——额外加了 writer fence 断言与完整
  COMMITTED 回执校验。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：上述裁决必须经 `ha decision propose` / `accept` 落进账本。它无法先落库，
  因为治理写路径正是本 PR 要恢复的东西——该决策本身得穿过它自己解锁的那条路才写得进去。
  合并后一次真实治理写跑通，CEO 立即补记并关联本 PR。

## 验证

- `origin/main` 基准 SHA：`b27d131b3b78fbfef2b483bad7afb7f98fdb7948`
- 当前分支与 `origin/main` 的 merge-base：`b27d131b3b78fbfef2b483bad7afb7f98fdb7948`
- 最近一次 `git fetch origin` 时间：2026-07-24，开 PR 前刚执行
- 同步方式：rebase 到当前 main（#1079 之后）
- 公开 diff 命令：`git diff b27d131b3b78fbfef2b483bad7afb7f98fdb7948...HEAD`
- 私有证据 commit/path：本 session 事故 findings（Round 3）
- Reviewer 证据路径：合并 session 的 CEO 语义验收
- GitHub Actions `rewrite-ci` run URL：待补，run 起来后回填
- [x] `git diff --check`
- [x] `npm run check:stop-point`——rebase 后 34 个完整 manifest 门全绿
- [x] 改动面的定向测试，写明测试名与通过数：
  `repo-write-authority-recovery-gate.test.ts` 覆盖一条接受路径与三条拒绝路径（无 anchor /
  非唯一 anchor / digest 不匹配），并断言 proceeding 文件字节与 SHA-256 在恢复前后不变；
  `authority-submission-error.test.ts` 与 `attestation-transport-observed.test.ts` 覆盖
  `resumeV2` 在两层 wrapper 中的保全。定向套件 37/37 通过；affected fast 501/501；
  affected contract 223/223（一个平台 skip）。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）
- 未跑项及原因：本地未跑 `npm run check:ci`（本地全量预检器已退役，GitHub Actions 是权威）。
  开发全程未启动生产 daemon、未对其写入；线上那条 proceeding 行仍是原 hash、其 terminal
  记录仍不存在。对在役写进程的端到端确认在合并、dist 重建、主动重启 daemon 之后进行——
  一次真实治理写在 30s 内完成——在此之前不把本 PR 视为已解决事故。

## 审查证据

- 自查：CEO 对照裁决条件通读完整 diff，并在账本仓独立 ground-truth 了 anchor。真正的
  canonical anchor 是 materializer merge commit
  `936ed7f658555e202cff44340ce98e77c52cc747`，其 second parent
  `97ebd188f1332560372512c5519e84b7110b0715` 的 subject 里带
  `[namespace-harness-anything-production:736978ed777a15179942b6f068bc151c]`；对全部 ref
  做 `--grep` 恰好只返回这一个 commit，因此唯一性要求在真实数据上成立。CEO 另核实：未引入
  任何新 schema token；省略新可选字段时抛错路径与此前一致；无法锚定的行会打出原因且不阻塞
  子进程启动。
- Reviewer subagent：Codex 完成实现，并纠正了 CEO 最初的 anchor 归属（CEO 报的是 session
  commit 而非 materializer merge）；该纠正在验收前已被独立复核证实。
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 启动扫描对每一条旧代 proceeding 行做一次 publication 查找。生产当前恰好只有一条，且
  #1079 已把底层 git 工作有界化，但该扫描仍与搁浅行数成线性。
- 恢复依赖 attribution event 在 publication commit 处仍然存在。若某 publication commit 缺
  该事件路径，该行保持 `outcome-unknown` 而非收敛——是 fail-closed，但也意味着上游历史重写
  会把一行静默地退回待决集合。
- 没有 anchor 的行仍需人工裁决；本 PR 有意不提供解决它们的机制。

## 关联材料

- 任务：不适用
- 证据：本 session 事故 findings（Round 3）
- 审查：合并 session 的 CEO 语义验收
