### PR TITLE
fix(daemon): read historical paths with a safety-only policy

### DIFF
--- a/packages/cli/src/composition/repo-write-child-entrypoint.ts
+++ b/packages/cli/src/composition/repo-write-child-entrypoint.ts
@@ -143,13 +143,20 @@ export async function runRepoWriteChildEntrypoint(
     }
     return started.component.recoverCommittedReceipt(outcome.innerOpId);
   };
+  const transport = new RepoWriteChildIpcTransport();
   for (const proceeding of outcomes.listHistoricalProceedings()) {
     try {
       await recoveryGate.recoverHistoricalProceeding(proceeding);
     } catch (error) {
-      process.stderr.write(
-        `repo-write historical recovery deferred outerOpId=${proceeding.outerOpId}: ${recoveryErrorMessage(error)}\n`
-      );
+      await transport.send({
+        protocol: "harness-repo-write-ipc/v1",
+        repoId: config.repoId,
+        generation: config.generation,
+        kind: "recovery-deferred",
+        outerOpId: proceeding.outerOpId,
+        code: recoveryErrorCode(error),
+        diagnostic: boundedRecoveryError(error)
+      });
     }
   }
   const operation = new ProductionRepoWriteOperationHost({
@@ -163,7 +170,6 @@ export async function runRepoWriteChildEntrypoint(
     resolveHistoricalPublication,
     recoverHistoricalCommittedReceipt: historicalRecovery.recover
   });
-  const transport = new RepoWriteChildIpcTransport();
   let cleanupPromise: Promise<void> | undefined;
   const cleanup = () => {
     cleanupPromise ??= (async () => {
@@ -205,4 +211,23 @@ export async function runRepoWriteChildEntrypoint(
 
 function recoveryErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function recoveryErrorCode(error: unknown): string {
+  if (error instanceof Error && "code" in error
+    && typeof error.code === "string" && error.code.trim()) {
+    return error.code;
+  }
+  const message = recoveryErrorMessage(error);
+  const match = /^([A-Z][A-Z0-9_]+)(?::|$)/u.exec(message);
+  return match?.[1] ?? "HISTORICAL_RECOVERY_DEFERRED";
+}
+
+function boundedRecoveryError(error: unknown): string {
+  const value = `${error instanceof Error ? `${error.name}: ` : ""}${recoveryErrorMessage(error)}`
+    .replace(/[\u0000-\u001f\u007f]+/gu, " ")
+    .trim();
+  const bytes = Buffer.from(value || "Historical recovery deferred.", "utf8");
+  if (bytes.length <= 2_048) return bytes.toString("utf8");
+  return bytes.subarray(0, 2_048).toString("utf8").replace(/\uFFFD$/u, "");
 }

--- a/packages/daemon/src/authority/read-down-managed-path.ts
+++ b/packages/daemon/src/authority/read-down-managed-path.ts
@@ -1,0 +1,46 @@
+const reservedFoldedSegments = new Set([
+  ".git", ".gitmodules", ".hg", ".svn", ".ha", ".ha-state",
+  ".harness-state", ".staging", ".quarantine", ".tombstones",
+  ".conflicts", ".ds_store", "desktop.ini", "thumbs.db"
+]);
+
+/**
+ * Validates an immutable Git fact before read-down materialization. Unlike
+ * authoring admission, historical paths may contain non-ASCII UTF-8; disk
+ * escape, reserved metadata names, and filesystem-unsafe structure remain
+ * fail-closed.
+ */
+export function validateReadDownManagedPath(managedPath: string): void {
+  if (managedPath.length === 0
+    || managedPath.startsWith("/")
+    || /^[A-Za-z]:/u.test(managedPath)
+    || managedPath.startsWith("\\")) {
+    unsafe(managedPath);
+  }
+  if (managedPath.includes("\\")
+    || managedPath.includes(":")
+    || /[\u0000-\u001f\u007f]/u.test(managedPath)) {
+    unsafe(managedPath);
+  }
+  const segments = managedPath.split("/");
+  for (const segment of segments) {
+    if (!segment
+      || segment === "."
+      || segment === "..") {
+      unsafe(managedPath);
+    }
+    const folded = foldAscii(segment);
+    if (reservedFoldedSegments.has(folded)
+      || folded.startsWith(".ha-")) {
+      unsafe(managedPath);
+    }
+  }
+}
+
+function foldAscii(value: string): string {
+  return value.replace(/[A-Z]/gu, (character) => character.toLowerCase());
+}
+
+function unsafe(managedPath: string): never {
+  throw new Error(`RESYNC_REQUIRED:GIT_PATH_NOT_SAFE:${managedPath}`);
+}

--- a/packages/daemon/src/authority/replication-content-store.ts
+++ b/packages/daemon/src/authority/replication-content-store.ts
@@ -4,8 +4,7 @@ import type {
   ReplicaChangeRecord
 } from "@harness-anything/application";
 import {
-  foldPortableComponent,
-  validatePortableManagedPath
+  foldPortableComponent
 } from "@harness-anything/application";
 import type { AuthoritySnapshotManifestEntry } from "./protocol.ts";
 import type { DurableAuthorityStateTable } from "./production/service-state.ts";
@@ -13,6 +12,7 @@ import {
   readAuthorityGitBatchBytes,
   readAuthorityGitBytes
 } from "./production/publication-evidence.ts";
+import { validateReadDownManagedPath } from "./read-down-managed-path.ts";
 
 type ReplicaChangeDraft = Parameters<ReplicaChangeLog["append"]>[0];
 type ReplicaFileMode = NonNullable<ReplicaChangeRecord["paths"][number]["mode"]>;
@@ -264,11 +264,7 @@ function decodePortableGitPath(pathBytes: Uint8Array): string {
   if (!Buffer.from(pathName, "utf8").equals(Buffer.from(pathBytes))) {
     throw new Error(`RESYNC_REQUIRED:GIT_PATH_NOT_UTF8_ROUND_TRIP:${Buffer.from(pathBytes).toString("hex").slice(0, 80)}`);
   }
-  try {
-    validatePortableManagedPath(pathName);
-  } catch {
-    throw new Error(`RESYNC_REQUIRED:GIT_PATH_NOT_PORTABLE:${pathName}`);
-  }
+  validateReadDownManagedPath(pathName);
   return pathName;
 }
 

--- a/packages/daemon/src/lifecycle/run-daemon-serve.ts
+++ b/packages/daemon/src/lifecycle/run-daemon-serve.ts
@@ -264,7 +264,18 @@ export async function runDaemonServe<
                 ...process.env,
                 HARNESS_DAEMON_SERVER_HOST: "1"
               }
-            })
+            }),
+            onDiagnostic: (frame) => {
+              void daemonLogService.append({
+                level: "error",
+                source: "daemon",
+                component: "repo-write-child",
+                event: "repo-write.historical-recovery.deferred",
+                message: `Deferred repo-write historical recovery for outerOpId=${frame.outerOpId}: ${frame.diagnostic}`,
+                errorCode: frame.code,
+                requestId: frame.outerOpId
+              }, { repo }).catch(() => undefined);
+            }
           });
           repoWriteSupervisors.set(repo.repoId, supervisor);
         }

--- a/packages/daemon/src/runtime/repo-write-client-contract.ts
+++ b/packages/daemon/src/runtime/repo-write-client-contract.ts
@@ -1,6 +1,7 @@
 import type {
   RepoWriteChildMessage,
   RepoWriteParentMessage,
+  RepoWriteRecoveryDeferredFrame,
   RepoWriteTelemetryFrame
 } from "./repo-write-protocol.ts";
 import type {
@@ -35,6 +36,7 @@ export interface RepoWriteClientOptions {
   readonly expectedArtifactIdentity?: string;
   readonly limits?: Partial<RepoWriteClientLimits>;
   readonly onTelemetry: (frame: RepoWriteTelemetryFrame) => void;
+  readonly onDiagnostic?: (frame: RepoWriteRecoveryDeferredFrame) => void;
   readonly onProtocolViolation?: (
     error: RepoWriteProtocolViolationError
   ) => void;

--- a/packages/daemon/src/runtime/repo-write-client-observers.ts
+++ b/packages/daemon/src/runtime/repo-write-client-observers.ts
@@ -1,0 +1,32 @@
+import type {
+  RepoWriteRecoveryDeferredFrame,
+  RepoWriteTelemetryFrame
+} from "./repo-write-protocol.ts";
+import { repoWriteProtocolType } from "./repo-write-protocol.ts";
+
+export function repoWriteClientFrameBase(repoId: string, generation: number) {
+  return { protocol: repoWriteProtocolType, repoId, generation } as const;
+}
+
+export function observeRepoWriteTelemetry(
+  observer: (frame: RepoWriteTelemetryFrame) => void,
+  frame: RepoWriteTelemetryFrame,
+  failProtocol: () => void
+): void {
+  try {
+    observer(frame);
+  } catch {
+    failProtocol();
+  }
+}
+
+export function observeRepoWriteRecoveryDiagnostic(
+  observer: ((frame: RepoWriteRecoveryDeferredFrame) => void) | undefined,
+  frame: RepoWriteRecoveryDeferredFrame
+): void {
+  try {
+    observer?.(frame);
+  } catch {
+    // Operational logging cannot change writer protocol or recovery state.
+  }
+}

--- a/packages/daemon/src/runtime/repo-write-client.ts
+++ b/packages/daemon/src/runtime/repo-write-client.ts
@@ -1,6 +1,5 @@
 // @slice-activation P5-W2 repo-writer foundation; production dispatch and durable receipt lookup remain activation work owned by task_01KY6QFFC306JRW8JW4Y2ND2TM.
 import {
-  repoWriteProtocolType,
   type RepoWriteChildMessage,
   type RepoWriteCommandDto,
   type RepoWriteJsonObject,
@@ -17,6 +16,11 @@ import type {
 } from "./repo-write-client-pending.ts";
 import { defaultRepoWriteRequestTimeoutMs } from "./repo-write-client-contract.ts";
 import type { RepoWriteClientLimits, RepoWriteClientOptions } from "./repo-write-client-contract.ts";
+import {
+  observeRepoWriteRecoveryDiagnostic,
+  observeRepoWriteTelemetry,
+  repoWriteClientFrameBase
+} from "./repo-write-client-observers.ts";
 export type { RepoWriteClientLimits, RepoWriteClientOptions, RepoWriteClientTransport } from "./repo-write-client-contract.ts";
 import {
   RepoWriteClientCapacityError,
@@ -223,7 +227,7 @@ export class RepoWriteClient {
     pending.phase = "submitted";
     try {
       const sent = this.options.transport.send({
-        ...this.frameBase(),
+        ...repoWriteClientFrameBase(this.options.repoId, this.options.generation),
         kind: "submit",
         requestId,
         command: pending.command
@@ -320,11 +324,15 @@ export class RepoWriteClient {
         this.failProtocol("Repo writer telemetry does not match a pending request.");
         return;
       }
-      try {
-        this.options.onTelemetry(message);
-      } catch {
-        this.failProtocol("Repo writer telemetry observer failed.");
-      }
+      observeRepoWriteTelemetry(
+        this.options.onTelemetry,
+        message,
+        () => this.failProtocol("Repo writer telemetry observer failed.")
+      );
+      return;
+    }
+    if (message.kind === "recovery-deferred") {
+      observeRepoWriteRecoveryDiagnostic(this.options.onDiagnostic, message);
       return;
     }
     if (message.kind === "failure") {
@@ -462,7 +470,7 @@ export class RepoWriteClient {
     pending.phase = "sent";
     try {
       const sent = this.options.transport.send({
-        ...this.frameBase(),
+        ...repoWriteClientFrameBase(this.options.repoId, this.options.generation),
         kind: "status",
         requestId,
         opId: pending.opId
@@ -509,7 +517,7 @@ export class RepoWriteClient {
     shutdown.sent = true;
     try {
       const sent = this.options.transport.send({
-        ...this.frameBase(),
+        ...repoWriteClientFrameBase(this.options.repoId, this.options.generation),
         kind: "shutdown",
         requestId: shutdown.requestId
       });
@@ -552,7 +560,7 @@ export class RepoWriteClient {
   private dispatchProceed(pending: PendingSubmit): void {
     try {
       const sent = this.options.transport.send({
-        ...this.frameBase(),
+        ...repoWriteClientFrameBase(this.options.repoId, this.options.generation),
         kind: "proceed",
         requestId: pending.requestId,
         opId: pending.opId!
@@ -582,14 +590,6 @@ export class RepoWriteClient {
 
   private pendingRequestCount(): number {
     return this.pending.size + this.directLane.size + this.pendingLookups.size;
-  }
-
-  private frameBase() {
-    return {
-      protocol: repoWriteProtocolType,
-      repoId: this.options.repoId,
-      generation: this.options.generation
-    } as const;
   }
 
   private nextRequestId(): string {

--- a/packages/daemon/src/runtime/repo-write-process-supervisor.ts
+++ b/packages/daemon/src/runtime/repo-write-process-supervisor.ts
@@ -21,6 +21,7 @@ export interface RepoWriteProcessSupervisorOptions {
   readonly spawn: () => RepoWriteParentProcessTransport;
   readonly limits?: ConstructorParameters<typeof RepoWriteClient>[0]["limits"];
   readonly onTelemetry?: ConstructorParameters<typeof RepoWriteClient>[0]["onTelemetry"];
+  readonly onDiagnostic?: ConstructorParameters<typeof RepoWriteClient>[0]["onDiagnostic"];
 }
 
 interface ActiveWriter {
@@ -199,7 +200,8 @@ export class RepoWriteProcessSupervisor {
           expectedArtifactIdentity: this.options.expectedArtifactIdentity
         }),
         ...(this.options.limits ? { limits: this.options.limits } : {}),
-        onTelemetry: this.options.onTelemetry ?? (() => undefined)
+        onTelemetry: this.options.onTelemetry ?? (() => undefined),
+        onDiagnostic: this.options.onDiagnostic
       });
       const writer = { transport, client };
       this.active = writer;

--- a/packages/daemon/src/runtime/repo-write-protocol-diagnostic.ts
+++ b/packages/daemon/src/runtime/repo-write-protocol-diagnostic.ts
@@ -1,0 +1,30 @@
+const defaultMaxDiagnosticBytes = 2 * 1024;
+
+export function boundedRepoWriteDiagnostic(
+  error: unknown,
+  maxBytes = defaultMaxDiagnosticBytes
+): string {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
+    throw new Error("maxBytes must be a positive safe integer");
+  }
+  const source = error instanceof Error
+    ? `${error.name || "Error"}: ${error.message || "writer failure"}`
+    : "Unknown writer failure";
+  const sanitized = source
+    .slice(0, maxBytes * 4 + 1)
+    .replace(/[\u0000-\u001f\u007f]+/gu, " ")
+    .trim();
+  return truncateUtf8(sanitized || "writer failure", maxBytes);
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  let result = "";
+  let bytes = 0;
+  for (const character of value) {
+    const width = Buffer.byteLength(character, "utf8");
+    if (bytes + width > maxBytes) break;
+    result += character;
+    bytes += width;
+  }
+  return result;
+}

--- a/packages/daemon/src/runtime/repo-write-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-protocol.ts
@@ -1,5 +1,6 @@
 // @slice-activation P5-W2 repo-writer foundation; public recovery routing remains activation work owned by task_01KY6QFFC306JRW8JW4Y2ND2TM.
 import { repoWriteTerminalReceiptMatches } from "./repo-write-terminal-receipt.ts";
+export { boundedRepoWriteDiagnostic } from "./repo-write-protocol-diagnostic.ts";
 import {
   decodeRepoWriteBigInt,
   decodeRepoWriteBytes,
@@ -140,11 +141,18 @@ export interface RepoWriteTelemetryFrame extends RepoWriteRequestFrame<"telemetr
   readonly phase: RepoWriteTelemetryPhase;
   readonly elapsedMs: number;
 }
+export interface RepoWriteRecoveryDeferredFrame extends RepoWriteFrameBase {
+  readonly kind: "recovery-deferred";
+  readonly outerOpId: string;
+  readonly code: string;
+  readonly diagnostic: string;
+}
 
 export type RepoWriteChildMessage =
   RepoWriteReadyFrame | RepoWritePreparedFrame | RepoWriteTerminalFrame | RepoWriteFailureFrame
   | RepoWriteDirectResultFrame | RepoWriteDirectFailureFrame
-  | RepoWriteStatusFrame | RepoWriteTelemetryFrame | RepoWriteDrainedFrame;
+  | RepoWriteStatusFrame | RepoWriteTelemetryFrame | RepoWriteRecoveryDeferredFrame
+  | RepoWriteDrainedFrame;
 
 export type RepoWriteMessage = RepoWriteParentMessage | RepoWriteChildMessage;
 export function parseRepoWriteParentMessage(
@@ -194,24 +202,9 @@ export function decodeRepoWriteChildMessage(
   if (frame.kind === "failure") return decodeFailure(frame, limits);
   if (frame.kind === "status") return decodeStatus(frame, limits, budget);
   if (frame.kind === "telemetry") return decodeTelemetry(frame, limits);
+  if (frame.kind === "recovery-deferred") return decodeRecoveryDeferred(frame, limits);
   if (frame.kind === "drained") return decodeRequestFrame(frame, limits, "drained");
   invalid("$.kind", "child message kind");
-}
-
-export function boundedRepoWriteDiagnostic(
-  error: unknown, maxBytes = defaultRepoWriteProtocolLimits.maxDiagnosticBytes
-): string {
-  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
-    throw new Error("maxBytes must be a positive safe integer");
-  }
-  const source = error instanceof Error
-    ? `${error.name || "Error"}: ${error.message || "writer failure"}`
-    : "Unknown writer failure";
-  const sanitized = source
-    .slice(0, maxBytes * 4 + 1)
-    .replace(/[\u0000-\u001f\u007f]+/gu, " ")
-    .trim();
-  return truncateUtf8(sanitized || "writer failure", maxBytes);
 }
 
 type FrameRecord = Record<string, unknown> & {
@@ -447,6 +440,19 @@ function decodeTelemetry(frame: FrameRecord, limits: RepoWriteProtocolLimits): R
     elapsedMs: frame.elapsedMs
   };
 }
+function decodeRecoveryDeferred(
+  frame: FrameRecord,
+  limits: RepoWriteProtocolLimits
+): RepoWriteRecoveryDeferredFrame {
+  assertExactKeys(frame, baseKeys(["outerOpId", "code", "diagnostic"]), [], "$");
+  return {
+    ...baseFields(frame),
+    kind: "recovery-deferred",
+    outerOpId: identifier(frame.outerOpId, "$.outerOpId", limits),
+    code: identifier(frame.code, "$.code", limits),
+    diagnostic: stringAt(frame.diagnostic, "$.diagnostic", limits.maxDiagnosticBytes)
+  };
+}
 function frameBase(value: unknown, limits: RepoWriteProtocolLimits, budget: { nodes: number }): FrameRecord {
   const frame = recordAt(value, "$");
   budget.nodes += 1;
@@ -567,17 +573,6 @@ function stringAt(value: unknown, path: string, maxBytes: number): string {
 }
 function utf8Bytes(value: string): number {
   return Buffer.byteLength(value, "utf8");
-}
-function truncateUtf8(value: string, maxBytes: number): string {
-  let result = "";
-  let bytes = 0;
-  for (const character of value) {
-    const width = utf8Bytes(character);
-    if (bytes + width > maxBytes) break;
-    result += character;
-    bytes += width;
-  }
-  return result;
 }
 function boundedPathSegment(value: string): string {
   return value.length <= 48 ? value : `${value.slice(0, 45)}...`;

--- a/packages/daemon/test/namespace-portability.test.ts
+++ b/packages/daemon/test/namespace-portability.test.ts
@@ -9,7 +9,13 @@ import {
 } from "../../application/src/index.ts";
 
 test("portable-ascii-v2 rejects reserved, non-ASCII, overlong, and Windows-budget paths", () => {
-  for (const candidate of ["tasks/CON.md", "tasks/naïve.md", `tasks/${"a".repeat(113)}.md`, `${"a".repeat(181)}`]) {
+  for (const candidate of [
+    "tasks/CON.md",
+    "tasks/naïve.md",
+    "历史/设计.txt",
+    `tasks/${"a".repeat(113)}.md`,
+    `${"a".repeat(181)}`
+  ]) {
     assert.throws(() => validatePortableManagedPath(candidate), NamespaceAdmissionError, candidate);
   }
   assert.throws(

--- a/packages/daemon/test/replication-content-history-path.test.ts
+++ b/packages/daemon/test/replication-content-history-path.test.ts
@@ -1,0 +1,108 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import type { ReplicaChangeLog, ReplicaChangeRecord } from "../../application/src/index.ts";
+import { validateReadDownManagedPath } from "../src/authority/read-down-managed-path.ts";
+import {
+  createAuthorityReplicationContentStore,
+  createContentEnrichedReplicaChangeLog
+} from "../src/authority/replication-content-store.ts";
+
+test("read-down accepts immutable UTF-8 and legacy long paths but rejects disk escape", () => {
+  const fixture = createFixture();
+  try {
+    mkdirSync(path.join(fixture.gitRoot, "历史"));
+    writeFileSync(path.join(fixture.gitRoot, "历史", "设计.txt"), "immutable history\n");
+    writeFileSync(path.join(fixture.gitRoot, "历史", `${"long-".repeat(38)}fact.txt`), "legacy long path\n");
+    git(fixture.gitRoot, "add", ".");
+    git(fixture.gitRoot, "commit", "-m", "historical paths");
+
+    const snapshot = fixture.content.snapshot(git(fixture.gitRoot, "rev-parse", "HEAD"), 0);
+    assert.deepEqual(snapshot.entries.map((entry) => entry.path), [
+      "历史/设计.txt",
+      `历史/${"long-".repeat(38)}fact.txt`
+    ]);
+  } finally {
+    fixture.cleanup();
+  }
+
+  for (const unsafe of [
+    "../escape", "/absolute", "C:/drive", "\\\\server\\share", "safe/\0escape", ".git/config"
+  ]) {
+    assert.throws(
+      () => validateReadDownManagedPath(unsafe),
+      /RESYNC_REQUIRED:GIT_PATH_NOT_SAFE/u,
+      unsafe
+    );
+  }
+});
+
+test("historical operation lookup hydrates an incomplete replica change containing a CJK path", async () => {
+  const fixture = createFixture();
+  try {
+    writeFileSync(path.join(fixture.gitRoot, "seed.md"), "seed\n");
+    git(fixture.gitRoot, "add", ".");
+    git(fixture.gitRoot, "commit", "-m", "seed");
+    const previousCommit = git(fixture.gitRoot, "rev-parse", "HEAD");
+    mkdirSync(path.join(fixture.gitRoot, "历史"));
+    writeFileSync(path.join(fixture.gitRoot, "历史", "设计.txt"), "immutable history\n");
+    git(fixture.gitRoot, "add", ".");
+    git(fixture.gitRoot, "commit", "-m", "historical operation");
+    const historical = {
+      schema: "replica-change/v1",
+      workspaceId: "workspace-read-down",
+      revision: 1,
+      opId: "op-historical-cjk",
+      semanticDigest: "semantic-historical-cjk",
+      commitSha: git(fixture.gitRoot, "rev-parse", "HEAD"),
+      previousCommit,
+      changedAt: "2026-07-23T04:00:01.000Z"
+    } as unknown as ReplicaChangeRecord;
+    const incompleteLog: ReplicaChangeLog = {
+      append: async () => historical,
+      latest: async () => historical,
+      getByOperation: async (_workspaceId, opId) =>
+        opId === historical.opId ? historical : undefined,
+      changesAfter: async () => [historical],
+      subscribe: () => () => undefined
+    };
+
+    const recovered = await createContentEnrichedReplicaChangeLog(incompleteLog, fixture.content)
+      .getByOperation("workspace-read-down", "op-historical-cjk");
+    assert.ok(recovered);
+    assert.equal(recovered.manifest.entryCount, 2);
+    assert.ok(recovered.paths.some((entry) => entry.path === "历史/设计.txt"));
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+function createFixture() {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-read-down-history-"));
+  const gitRoot = path.join(root, "canonical");
+  mkdirSync(gitRoot);
+  git(gitRoot, "init", "-q");
+  git(gitRoot, "config", "user.name", "Authority Test");
+  git(gitRoot, "config", "user.email", "authority@example.test");
+  const values = new Map<string, unknown>();
+  const state = {
+    get: <Value>(key: string) => values.get(key) as Value | undefined,
+    put: (key: string, value: unknown) => values.set(key, structuredClone(value)),
+    entries: <Value>() => [...values.entries()] as ReadonlyArray<readonly [string, Value]>
+  };
+  return {
+    gitRoot,
+    content: createAuthorityReplicationContentStore({
+      gitRoot, state, workspaceId: "workspace-read-down", epoch: "7"
+    }),
+    cleanup: () => rmSync(root, { recursive: true, force: true })
+  };
+}
+
+function git(root: string, ...args: string[]): string {
+  return execFileSync("git", ["-C", root, ...args], { encoding: "utf8" }).trim();
+}

--- a/packages/daemon/test/replication-content-history-path.test.ts
+++ b/packages/daemon/test/replication-content-history-path.test.ts
@@ -9,23 +9,34 @@ import type { ReplicaChangeLog, ReplicaChangeRecord } from "../../application/sr
 import { validateReadDownManagedPath } from "../src/authority/read-down-managed-path.ts";
 import {
   createAuthorityReplicationContentStore,
-  createContentEnrichedReplicaChangeLog
+  createContentEnrichedReplicaChangeLog,
+  manifestDigest
 } from "../src/authority/replication-content-store.ts";
 
 test("read-down accepts immutable UTF-8 and legacy long paths but rejects disk escape", () => {
   const fixture = createFixture();
   try {
+    const longPath = `历史/${"long-".repeat(38)}fact.txt`;
     mkdirSync(path.join(fixture.gitRoot, "历史"));
     writeFileSync(path.join(fixture.gitRoot, "历史", "设计.txt"), "immutable history\n");
-    writeFileSync(path.join(fixture.gitRoot, "历史", `${"long-".repeat(38)}fact.txt`), "legacy long path\n");
+    writeFileSync(path.join(fixture.gitRoot, longPath), "legacy long path\n");
     git(fixture.gitRoot, "add", ".");
     git(fixture.gitRoot, "commit", "-m", "historical paths");
 
-    const snapshot = fixture.content.snapshot(git(fixture.gitRoot, "rev-parse", "HEAD"), 0);
+    const commitSha = git(fixture.gitRoot, "rev-parse", "HEAD");
+    const snapshot = fixture.content.snapshot(commitSha, 0);
+    // Read-down exposes canonical UTF-8 byte order; callers must not inherit
+    // filesystem locale or directory enumeration order.
     assert.deepEqual(snapshot.entries.map((entry) => entry.path), [
-      "历史/设计.txt",
-      `历史/${"long-".repeat(38)}fact.txt`
+      longPath,
+      "历史/设计.txt"
     ]);
+    assert.equal(manifestDigest({
+      workspaceId: "workspace-read-down",
+      epoch: "7",
+      revision: 0,
+      commitSha
+    }, [...snapshot.entries].reverse()), snapshot.manifestDigest);
   } finally {
     fixture.cleanup();
   }
@@ -50,6 +61,7 @@ test("historical operation lookup hydrates an incomplete replica change containi
     const previousCommit = git(fixture.gitRoot, "rev-parse", "HEAD");
     mkdirSync(path.join(fixture.gitRoot, "历史"));
     writeFileSync(path.join(fixture.gitRoot, "历史", "设计.txt"), "immutable history\n");
+    writeFileSync(path.join(fixture.gitRoot, "历史", "long-fact.txt"), "legacy path\n");
     git(fixture.gitRoot, "add", ".");
     git(fixture.gitRoot, "commit", "-m", "historical operation");
     const historical = {
@@ -74,8 +86,11 @@ test("historical operation lookup hydrates an incomplete replica change containi
     const recovered = await createContentEnrichedReplicaChangeLog(incompleteLog, fixture.content)
       .getByOperation("workspace-read-down", "op-historical-cjk");
     assert.ok(recovered);
-    assert.equal(recovered.manifest.entryCount, 2);
-    assert.ok(recovered.paths.some((entry) => entry.path === "历史/设计.txt"));
+    assert.equal(recovered.manifest.entryCount, 3);
+    assert.deepEqual(recovered.paths.map((entry) => entry.path), [
+      "历史/long-fact.txt",
+      "历史/设计.txt"
+    ]);
   } finally {
     fixture.cleanup();
   }

--- a/packages/daemon/test/repo-write-client.test.ts
+++ b/packages/daemon/test/repo-write-client.test.ts
@@ -60,6 +60,34 @@ test("waits for ready, records prepared opId, proceeds, and resolves only at ter
   assert.deepEqual(await result, receipt);
 });
 
+test("reports historical recovery diagnostics before READY without failing the writer", async () => {
+  const transport = new FakeRepoWriteTransport();
+  const diagnostics: unknown[] = [];
+  const client = new RepoWriteClient({
+    repoId: "repo-canonical",
+    generation: 7,
+    transport,
+    onTelemetry: () => undefined,
+    onDiagnostic: (frame) => diagnostics.push(frame)
+  });
+  transport.emit({
+    ...childFrame("recovery-deferred"),
+    outerOpId: "repo-write:historical",
+    code: "GIT_PATH_NOT_SAFE",
+    diagnostic: "historical recovery remains fail-closed"
+  });
+  transport.emit(readyFrame());
+
+  await client.waitUntilReady();
+  assert.equal(diagnostics.length, 1);
+  assert.deepEqual(diagnostics[0], {
+    ...childFrame("recovery-deferred"),
+    outerOpId: "repo-write:historical",
+    code: "GIT_PATH_NOT_SAFE",
+    diagnostic: "historical recovery remains fail-closed"
+  });
+});
+
 test("resolves an exact rejected terminal receipt instead of converting it to transport failure", async () => {
   const transport = new FakeRepoWriteTransport();
   const client = readyClient(transport);

--- a/packages/daemon/test/repo-write-process-supervisor.test.ts
+++ b/packages/daemon/test/repo-write-process-supervisor.test.ts
@@ -51,6 +51,31 @@ test("supervisor submits through one child and drains it without inline fallback
   assert.equal(supervisor.status().connected, false);
 });
 
+test("supervisor forwards startup recovery diagnostics before READY", async (context) => {
+  const diagnostics: unknown[] = [];
+  const supervisor = new RepoWriteProcessSupervisor({
+    repoId: "repo-transport",
+    generation: 1,
+    spawn: () => forkRepoWriteProcess({
+      modulePath: fixturePath,
+      args: ["recovery-deferred"]
+    }),
+    onDiagnostic: (frame) => diagnostics.push(frame)
+  });
+  context.after(() => supervisor.stop().catch(() => undefined));
+
+  await supervisor.start();
+  assert.deepEqual(diagnostics, [{
+    protocol: "harness-repo-write-ipc/v1",
+    repoId: "repo-transport",
+    generation: 1,
+    kind: "recovery-deferred",
+    outerOpId: "repo-write:historical",
+    code: "GIT_PATH_NOT_SAFE",
+    diagnostic: "historical recovery remains fail-closed"
+  }]);
+});
+
 test("post-proceed child crash performs one exact op lookup in a replacement capsule", async (context) => {
   let forks = 0;
   const supervisor = new RepoWriteProcessSupervisor({

--- a/packages/daemon/test/repo-write-protocol.test.ts
+++ b/packages/daemon/test/repo-write-protocol.test.ts
@@ -64,6 +64,20 @@ test("prepared and proceed form an exact opId handshake before canonical mutatio
   assert.deepEqual(parseRepoWriteParentMessage(stringifyRepoWriteParentMessage(proceed)), proceed);
 });
 
+test("historical recovery diagnostics carry a bounded startup failure without request correlation", () => {
+  const diagnostic: RepoWriteChildMessage = {
+    ...base("recovery-deferred"),
+    outerOpId: "repo-write:historical",
+    code: "GIT_PATH_NOT_SAFE",
+    diagnostic: "historical recovery remains fail-closed"
+  };
+
+  assert.deepEqual(
+    parseRepoWriteChildMessage(stringifyRepoWriteChildMessage(diagnostic)),
+    diagnostic
+  );
+});
+
 test("volatile direct execution carries an exact receipt without durable recovery fields", () => {
   const request: RepoWriteParentMessage = {
     ...base("direct"),

--- a/packages/daemon/test/support/repo-write-ipc-child.ts
+++ b/packages/daemon/test/support/repo-write-ipc-child.ts
@@ -111,6 +111,17 @@ if (mode === "exit") {
   } else if (mode === "malformed-child") {
     process.send?.({ protocol: "wrong", kind: "ready" });
   } else {
+    if (mode === "recovery-deferred") {
+      await transport.send({
+        protocol: repoWriteProtocolType,
+        repoId: "repo-transport",
+        generation: 1,
+        kind: "recovery-deferred",
+        outerOpId: "repo-write:historical",
+        code: "GIT_PATH_NOT_SAFE",
+        diagnostic: "historical recovery remains fail-closed"
+      });
+    }
     await transport.send({
       protocol: repoWriteProtocolType,
       repoId: "repo-transport",


### PR DESCRIPTION
# English

## Summary

Replaying immutable Git history through the authoring admission policy made
`ha decision propose` fail with `RESYNC_REQUIRED:GIT_PATH_NOT_PORTABLE` on a CJK
filename committed months ago, and it was also the real reason the stranded
generation-403 outcome row never converged. Read-down now validates historical
paths with a safety-only check while authoring admission is untouched. The
deferred-recovery reason, previously written to a stderr that is `/dev/null` in
the real deployment, now reaches the daemon log.

## What Changed

- `read-down-managed-path.ts` (new) validates an immutable Git fact before
  materialization. It keeps every escape and injection guard — empty path,
  absolute path, drive letter, backslash, colon, control characters including NUL
  and newline, empty segments, `.` and `..` segments, and reserved metadata names
  (`.git`, `.ha-state`, `.ds_store`, the `.ha-` prefix) — and relaxes only
  cross-platform portability: ASCII-only, the byte and depth budgets, Windows
  device names, and the portable segment grammar.
- `replication-content-store.ts` calls it in place of
  `validatePortableManagedPath`. The fatal UTF-8 decode and the byte round-trip
  check are unchanged and still run first.
- `packages/application/src/namespace/policy.ts` is not modified. Authoring still
  rejects a non-ASCII path; a test asserts this explicitly.
- Historical recovery failures travel over a new length-bounded
  `recovery-deferred` IPC frame, through the client and supervisor, into
  `DaemonLogService`. The previous `process.stderr.write` was invisible because the
  child's fd 2 is `/dev/null` under the real launcher.

## Task And Scope

- Harness task: not applicable; continued incident remediation of the #1075 P5-W2
  CH4 child-writer cutover (follows #1077, #1078, #1079, #1080)
- Branch: `codex/read-down-history-path-policy`
- Public scope: `packages/daemon` replica content store, read-down path validation,
  repo-write IPC protocol and observers, daemon serve logging; `packages/cli`
  repo-write child entrypoint
- Private planning/evidence updated: yes
- Out of scope: whether authoring should accept non-ASCII paths at all; that would
  amend decision `dec_01KXB70Z5MMKSYD7QGHGY9NJFW` and is a separate adjudication

## Version Impact

- Version: no version change because no durable schema or receipt schema changed;
  the added IPC frame is internal to the parent-child repo-write channel and both
  ends ship together
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable; `tools/check-pr-governance.mjs` reports
  no manifest-derived protected surface touched
- Authority: decision `dec_01KXB70Z5MMKSYD7QGHGY9NJFW` establishes the
  `portable-ascii-v2` path policy, whose stated purpose is cross-platform
  unambiguity — preventing `A/x.md` and `a/y.md` from merging on Windows and macOS
  while splitting on Linux. This PR reads that decision as governing admission of
  newly authored paths, not replay of paths already committed to immutable history,
  and leaves the authoring policy byte-identical. Zeyu adjudicated the read-down
  exemption in the operating session on 2026-07-24, with the explicit constraint
  that it must not affect anything else; the implementation therefore relaxes only
  portability and retains every safety guard.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers
  decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: two remain. The cross-generation terminalization
  adjudication from #1080 still needs recording via `ha decision propose`, which is
  the very command this PR unblocks. Separately, whether authoring should accept
  non-ASCII paths is open and would amend `dec_01KXB70Z5MMKSYD7QGHGY9NJFW`; three
  concrete sub-problems are known — Unicode NFC normalization is absent at this
  layer, case folding covers only A-Z, and the length budget counts bytes with
  ASCII encoding so it undercounts multi-byte characters.

## Verification

- Base `origin/main` SHA: `63c7dda937dd75a9e2c78a58d002e37b63ba3f56`
- Branch merge-base with `origin/main`: `63c7dda937dd75a9e2c78a58d002e37b63ba3f56`
- Last `git fetch origin` time: 2026-07-24, immediately before opening this PR
- Sync method: rebase onto current main (after #1080)
- Public diff command: `git diff 63c7dda937dd75a9e2c78a58d002e37b63ba3f56...HEAD`
- Private evidence commit/path: session incident findings (Round 4)
- Reviewer evidence path: CEO semantic acceptance in the merge session
- GitHub Actions `rewrite-ci` run URL: pending; linked once the run starts
- [x] `git diff --check`
- [x] `npm run check:stop-point` — 34 complete manifest gates green (after rebase)
- [x] Targeted tests for the change surface, named with their counts:
  `replication-content-history-path.test.ts` proves a CJK path and an
  over-budget historical path materialize, while `../`, an absolute path, a drive
  letter, a backslash, NUL, and `.git` stay rejected, and that authoring still
  rejects CJK; `repo-write-protocol.test.ts`, `repo-write-client.test.ts` and
  `repo-write-process-supervisor.test.ts` cover strict diagnostic frame codec,
  pre-READY delivery, and supervisor forwarding. `npm run check:local` green with
  affected fast 507/507 and contract 223/223 with one platform skip.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: `npm run check:ci` not run locally (retired local full
  preflight; GitHub Actions is authoritative). No production daemon was started or
  written to; the stranded proceeding row still carries SHA-256
  `c53c2d99f4ad4c1cdfeadb49d6bfb0a3d275f42244bb728eb37e4df2c57c73bb`. End-to-end
  confirmation is a real `ha decision propose` completing after merge, dist rebuild,
  and a deliberate daemon restart.

## Review Evidence

- Self-review: CEO read the new validator line by line against the adjudicated
  constraint and confirmed that every escape-class guard is retained and only
  portability is relaxed, and ran a negative control showing
  `packages/application/src/namespace/policy.ts` has zero changed lines. CEO also
  independently traced the origin of the policy to `472daabd` and decision
  `dec_01KXB70Z5MMKSYD7QGHGY9NJFW`, whose recorded rationale is cross-platform
  unambiguity rather than a preference against non-English names.
- Reviewer subagent: Codex authored the implementation and refuted the CEO's
  hypothesis that the stranded generation-403 row deferred on the writer fence; a
  read-only snapshot probe of the real anchor read 20,675 entries and showed the
  block occurred earlier, during historical content rebuild, at the same CJK path
  rejection. One root cause explains both symptoms.
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Relaxed portability means a historical path can now carry a Windows device name,
  a trailing dot, or an over-budget length. Materializing such a path on Windows
  may fail at write time rather than being refused at read time. This machine is
  macOS; a Windows replica has not been exercised.
- Case folding still covers only A-Z, so two historical paths differing only in
  non-ASCII case could collide on a case-insensitive filesystem. This is unchanged
  from the existing collision semantics, not introduced here.
- Recovery still defers, by design, for paths that are genuinely unsafe; the reason
  is now observable rather than silent.

## References

- Task: not applicable
- Evidence: session incident findings (Round 4)
- Review: CEO semantic acceptance in the merge session

---

# 中文

## 概要

把不可变的 git 历史拿去过 authoring 准入策略，导致 `ha decision propose` 撞
`RESYNC_REQUIRED:GIT_PATH_NOT_PORTABLE`——卡在一个几个月前就提交进历史的中文文件名上；
这同时也是 gen-403 那条搁浅 outcome 行始终不收敛的真实原因。现在 read-down 用一个**只管安全**
的校验器校验历史路径，authoring 准入**原封不动**。此前推迟恢复的原因被写进 stderr，而真实部署
里子进程 fd 2 是 `/dev/null`，那行字没人看得见；现在它进 daemon 日志。

## 改动内容

- `read-down-managed-path.ts`（新增）在物化前校验一条不可变 git 事实。**逃逸与注入类防护一条
  不掉**——空路径、绝对路径、盘符、反斜杠、冒号、控制字符（含 NUL 与换行）、空段、`.` 与 `..`
  段、保留元数据名（`.git`、`.ha-state`、`.ds_store`、`.ha-` 前缀）；**只放开跨平台可移植性**：
  纯 ASCII、字节与深度预算、Windows 设备名、可移植段文法。
- `replication-content-store.ts` 改调它，替代 `validatePortableManagedPath`。fatal UTF-8 解码
  与字节往返校验未动，且仍先执行。
- `packages/application/src/namespace/policy.ts` **未修改**。authoring 仍然拒绝非 ASCII 路径，
  并有测试显式断言这一点。
- 历史恢复失败改走一个**严格限长**的 `recovery-deferred` IPC 帧，经 client 与 supervisor 进
  `DaemonLogService`。此前的 `process.stderr.write` 在真实启动方式下不可见。

## 任务与范围

- Harness 任务：不适用；#1075 P5-W2 CH4 子写进程 cutover 事故的持续补救（承接 #1077、#1078、
  #1079、#1080）
- 分支：`codex/read-down-history-path-policy`
- 公开范围：`packages/daemon` 的 replica 内容存储、read-down 路径校验、repo-write IPC 协议与
  observer、daemon serve 日志；`packages/cli` 的 repo-write 子进程入口
- 私有计划 / 证据是否已更新：yes
- 范围外：authoring 到底该不该接受非 ASCII 路径——那要修订决策
  `dec_01KXB70Z5MMKSYD7QGHGY9NJFW`，是另一次裁决

## 版本影响

- 版本：不改版本，原因是未改动任何持久 schema 或 receipt schema；新增 IPC 帧是父子 repo-write
  通道内部的，两端同版本一起发布
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用；`tools/check-pr-governance.mjs` 报告未触碰任何 manifest 派生
  保护面
- 依据：决策 `dec_01KXB70Z5MMKSYD7QGHGY9NJFW` 确立了 `portable-ascii-v2` 路径策略，其自述目的
  是**跨平台无歧义**——防止 `A/x.md` 与 `a/y.md` 在 Windows/macOS 合一而在 Linux 分二。本 PR
  把该决策理解为**管辖新写入路径的准入**，而非**已提交进不可变历史的路径的回放**，并且让
  authoring 策略保持逐字节不变。泽宇于 2026-07-24 的运营 session 裁决了这条 read-down 豁免，
  并明确限定「不许影响别的」；因此实现只放开可移植性，安全防护全部保留。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：两条。#1080 的跨代终态化裁决仍需经 `ha decision propose` 补记，而那正是本 PR
  解锁的命令。另一条独立：authoring 是否接受非 ASCII 路径尚未裁决，要动就要修订
  `dec_01KXB70Z5MMKSYD7QGHGY9NJFW`；三个具体子问题已定位——该层缺 Unicode NFC 归一化、大小写
  折叠只覆盖 A-Z、长度预算按 ascii 编码计数因而对多字节字符**少算**。

## 验证

- `origin/main` 基准 SHA：`63c7dda937dd75a9e2c78a58d002e37b63ba3f56`
- 当前分支与 `origin/main` 的 merge-base：`63c7dda937dd75a9e2c78a58d002e37b63ba3f56`
- 最近一次 `git fetch origin` 时间：2026-07-24，开 PR 前刚执行
- 同步方式：rebase 到当前 main（#1080 之后）
- 公开 diff 命令：`git diff 63c7dda937dd75a9e2c78a58d002e37b63ba3f56...HEAD`
- 私有证据 commit/path：本 session 事故 findings（Round 4）
- Reviewer 证据路径：合并 session 的 CEO 语义验收
- GitHub Actions `rewrite-ci` run URL：待补，run 起来后回填
- [x] `git diff --check`
- [x] `npm run check:stop-point`——rebase 后 34 个完整 manifest 门全绿
- [x] 改动面的定向测试，写明测试名与通过数：`replication-content-history-path.test.ts` 证明中文
  路径与超预算历史路径可物化，而 `../`、绝对路径、盘符、反斜杠、NUL、`.git` 仍被拒，且
  authoring 仍拒中文；`repo-write-protocol.test.ts`、`repo-write-client.test.ts`、
  `repo-write-process-supervisor.test.ts` 覆盖诊断帧严格编解码、READY 前投递与 supervisor 转发。
  `npm run check:local` 全绿，affected fast 507/507、contract 223/223（一个平台 skip）。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）
- 未跑项及原因：本地未跑 `npm run check:ci`（本地全量预检器已退役，GitHub Actions 是权威）。
  开发全程未启动生产 daemon、未对其写入；那条搁浅 proceeding 行的 SHA-256 仍是
  `c53c2d99f4ad4c1cdfeadb49d6bfb0a3d275f42244bb728eb37e4df2c57c73bb`。端到端确认是合并、dist
  重建、主动重启 daemon 之后，一次真实 `ha decision propose` 跑通。

## 审查证据

- 自查：CEO 逐行对照裁决限定读了新校验器，确认逃逸类防护全部保留、只放开可移植性，并跑了阴性
  对照——`packages/application/src/namespace/policy.ts` 改动行数为 0。CEO 另独立追溯该策略源头至
  `472daabd` 与决策 `dec_01KXB70Z5MMKSYD7QGHGY9NJFW`，其记录在案的理由是跨平台无歧义，**不是**
  对非英文名称的偏好。
- Reviewer subagent：Codex 完成实现，并**推翻了 CEO 关于 gen-403 行卡在 writer fence 的假设**；
  对真实 anchor 的只读 snapshot 探针读出 20,675 个条目，证明阻塞发生在更早的历史内容重建阶段、
  就是同一个中文路径拒绝。一个根因解释两个现象。
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 放开可移植性意味着历史路径现在可能带 Windows 设备名、结尾句点或超预算长度。在 Windows 上物化
  这类路径可能在写入时失败，而不是在读取时被拒。本机是 macOS，未演练 Windows replica。
- 大小写折叠仍只覆盖 A-Z，因此两条仅非 ASCII 大小写不同的历史路径可能在大小写不敏感文件系统上
  相撞。这沿用既有 collision 语义，非本 PR 引入。
- 真正不安全的路径仍按设计推迟恢复；区别是原因现在可观测，不再静默。

## 关联材料

- 任务：不适用
- 证据：本 session 事故 findings（Round 4）
- 审查：合并 session 的 CEO 语义验收
