### PR TITLE
refactor(daemon): collapse governed submission into one discriminated ingress

### DIFF
--- a/packages/cli/test/authority-amendment3-seam.test.ts
+++ b/packages/cli/test/authority-amendment3-seam.test.ts
@@ -14,13 +14,16 @@ test("cold task create submits provenance session and task as two ordered canoni
   const taskId = "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG9";
   const submittedEntityIds: string[] = [];
   const coordinator = makeDaemonAuthorityWriteCoordinator({
-    submitProvenanceSession: async (input) => {
-      submittedEntityIds.push(input.operation.entityId);
-      return committedReceipt("fixture-session-op", 1);
-    },
     submit: async (input) => {
-      submittedEntityIds.push(input.canonicalEntityId);
-      return committedReceipt("fixture-task-op", 2);
+      if (input.ingress === "provenance-session") {
+        submittedEntityIds.push(input.operation.entityId);
+        return committedReceipt("fixture-session-op", 1);
+      }
+      if (input.ingress === "generic") {
+        submittedEntityIds.push(input.canonicalEntityId);
+        return committedReceipt("fixture-task-op", 2);
+      }
+      throw new Error(`unexpected ingress: ${input.ingress}`);
     }
   }, {
     command: {
@@ -83,8 +86,10 @@ test("task claim submits the observed execution write through its narrow typed i
   const executionId = "exe_01KXSVW65Q5QK3M8382FK4C0DR";
   let submittedOperation: unknown;
   const coordinator = makeDaemonAuthorityWriteCoordinator({
-    submit: async () => { throw new Error("generic authority submission must not compile task claim"); },
-    submitTaskClaim: async (input) => {
+    submit: async (input) => {
+      if (input.ingress !== "task-claim") {
+        throw new Error("task claim must use its typed ingress");
+      }
       submittedOperation = input.operation;
       return committedReceipt("fixture-task-claim-op", 1);
     }

--- a/packages/cli/test/helpers/authority-command-adapter-v2.ts
+++ b/packages/cli/test/helpers/authority-command-adapter-v2.ts
@@ -172,6 +172,7 @@ export async function submitThroughActualAuthorityServiceV2(): Promise<Authority
       }
     }
   }).submit({
+    ingress: "generic",
     command: {
       rootDir: "/repo",
       json: true,

--- a/packages/cli/test/production-authority-attempt-plan.test.ts
+++ b/packages/cli/test/production-authority-attempt-plan.test.ts
@@ -208,10 +208,16 @@ test("fixed-attempt planning is pure and activation validates exact durable reco
       expected: compileInput,
       plan
     });
-    assert.equal((await plannedSubmission.submit(compileInput)).tag, "REJECTED");
+    assert.equal((await plannedSubmission.submit({
+      ...compileInput,
+      ingress: "generic"
+    })).tag, "REJECTED");
     assert.equal(freshSubmissions, 1);
     await assert.rejects(
-      plannedSubmission.submit(compileInput),
+      plannedSubmission.submit({
+        ...compileInput,
+        ingress: "generic"
+      }),
       /PLANNED_SUBMISSION_REUSED/u
     );
     const mismatchedSubmission = createProductionProgressAppendSubmission({
@@ -228,6 +234,7 @@ test("fixed-attempt planning is pure and activation validates exact durable reco
     });
     await assert.rejects(mismatchedSubmission.submit({
       ...compileInput,
+      ingress: "generic",
       canonicalEntityId: taskEntityId("task_other")
     }), /PLANNED_INPUT_MISMATCH/u);
     compiler.activatePlannedProgressAppend(plan);
@@ -307,7 +314,10 @@ test("fixed-attempt planning is pure and activation validates exact durable reco
       plan,
       recovery: outerWitness
     });
-    assert.equal((await recoverySubmission.submit(compileInput)).tag, "REJECTED");
+    assert.equal((await recoverySubmission.submit({
+      ...compileInput,
+      ingress: "generic"
+    })).tag, "REJECTED");
     assert.equal(recoveredWitness?.repoId, config.repoId);
     assert.equal(recoveredWitness?.outerOpId, proceeding.outerOpId);
     assert.equal(recoveredWitness?.outerRequestDigest, proceeding.requestDigest);
@@ -499,6 +509,15 @@ test("fixed-attempt planning is pure and activation validates exact durable reco
     assert.equal(productionAuthorityCommandHasPurePlan({
       rootDir: fixture.repoRoot,
       action: {
+        kind: "new-task",
+        title: "Multi-operation task",
+        titleProvided: true,
+        taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG9"
+      }
+    }), false);
+    assert.equal(productionAuthorityCommandHasPurePlan({
+      rootDir: fixture.repoRoot,
+      action: {
         kind: "task-complete",
         taskId: "task_A"
       }
@@ -610,6 +629,7 @@ test("fixed-attempt planning is pure and activation validates exact durable reco
     await assert.rejects(
       recoveredDecisionSubmission.submit({
         ...decisionInput,
+        ingress: "generic",
         canonicalEntityId: taskEntityId("task_other")
       }),
       /AUTHORITY_PLANNED_INPUT_MISMATCH/u
@@ -617,6 +637,7 @@ test("fixed-attempt planning is pure and activation validates exact durable reco
     assert.equal(
       (await recoveredDecisionSubmission.submit({
         ...decisionInput,
+        ingress: "generic",
         canonicalEntityId: decisionPlan.targetEntityId
       })).tag,
       "REJECTED"

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -12,7 +12,6 @@ import {
 import {
   decisionEntityId,
   createTaskPackagePath,
-  moduleEntityId,
   sha256Text,
   taskEntityId
 } from "../../../kernel/src/index.ts";
@@ -55,6 +54,7 @@ import { verifyProductionCommandParity } from "./production-parity.ts";
 import { verifyTypedMinimalParameterMatrix } from "./minimal-parameter-matrix.ts";
 import { verifyProductionPresetIngress } from "./preset-ingress.ts";
 import { verifyOmittedIngressRegressions } from "./omitted-ingress-regressions.ts";
+import { verifyGenericIngressRejections } from "./generic-ingress-rejections.ts";
 import { verifySluggedTaskRelatePathCas } from "./slugged-path-cas.ts";
 import { assertProductionConsentIngress, productionConsentIngressCase } from "./consent-ingress.ts";
 
@@ -561,6 +561,7 @@ test("production generic canonical ingress accepts and journals one write for ev
     for (const [index, fixtureCase] of cases.entries()) {
       const sessionId = `real-cli-session-${index + 1}`;
       const receipt = await submission.submit({
+        ingress: "generic",
         command: { rootDir: fixture.repoRoot, json: true, action: fixtureCase.action },
         attribution: daemonActorAttribution(actor, index === 0 ? null : { kind: "agent", id: "codex" }),
         currentSession: { runtime: "codex", sessionId, source: "runtime", detectedAt: "2026-07-17T00:00:00.000Z" },
@@ -662,34 +663,10 @@ test("production generic canonical ingress accepts and journals one write for ev
         assert.equal(existsSync(path.join(taskRoot, "task-contract.json")), true);
       }
     }
-    await assert.rejects(submission.submit({
-      command: {
-        rootDir: fixture.repoRoot,
-        action: { kind: "task-claim", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0" }
-      },
-      attribution: daemonActorAttribution(actor, { kind: "agent", id: "codex" }),
-      currentSession: { runtime: "codex", sessionId: "session-production", source: "manual", detectedAt: "2026-07-17T00:00:00.000Z" },
-      canonicalEntityId: taskEntityId("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0")
-    }), (error: unknown) => {
-      const rejected = error as { readonly _tag?: unknown; readonly code?: unknown; readonly reason?: unknown };
-      return rejected?._tag === "WriteRejected"
-        && rejected.code === "authority_ingress_rejected"
-        && rejected.reason === "AUTHORITY_TYPED_COMMAND_UNSUPPORTED:task-claim";
-    });
-    await assert.rejects(submission.submit({
-      command: {
-        rootDir: fixture.repoRoot,
-        json: true,
-        action: { kind: "progress-append", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0", text: "entity mismatch evidence", dryRun: false }
-      },
-      attribution: daemonActorAttribution(actor, { kind: "agent", id: "codex" }),
-      currentSession: { runtime: "codex", sessionId: "session-mismatch", source: "manual", detectedAt: "2026-07-17T00:00:00.000Z" },
-      canonicalEntityId: moduleEntityId("wrong-entity")
-    }), (error: unknown) => {
-      const rejected = error as { readonly _tag?: unknown; readonly code?: unknown; readonly reason?: unknown };
-      return rejected?._tag === "WriteRejected"
-        && rejected.code === "authority_ingress_rejected"
-        && rejected.reason === "AUTHORITY_CANONICAL_ENTITY_MISMATCH:submittedEntityId=module/wrong-entity;intentEntityId=task/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0";
+    await verifyGenericIngressRejections({
+      submission,
+      repoRoot: fixture.repoRoot,
+      actor
     });
     await lifecycle.stopAll("daemon-shutdown");
   } finally {

--- a/packages/cli/test/production-authority-canonical-ingress/generic-ingress-rejections.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/generic-ingress-rejections.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import {
+  moduleEntityId,
+  taskEntityId
+} from "../../../kernel/src/index.ts";
+import type { DaemonAuthorityCommandSubmissionV2 } from "../../../daemon/src/index.ts";
+import { daemonActorAttribution } from "../../src/composition/actor-attribution.ts";
+
+export async function verifyGenericIngressRejections(input: {
+  readonly submission: DaemonAuthorityCommandSubmissionV2;
+  readonly repoRoot: string;
+  readonly actor: Parameters<typeof daemonActorAttribution>[0];
+}): Promise<void> {
+  await assert.rejects(input.submission.submit({
+    ingress: "generic",
+    command: {
+      rootDir: input.repoRoot,
+      action: { kind: "task-claim", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0" }
+    },
+    attribution: daemonActorAttribution(input.actor, { kind: "agent", id: "codex" }),
+    currentSession: { runtime: "codex", sessionId: "session-production", source: "manual", detectedAt: "2026-07-17T00:00:00.000Z" },
+    canonicalEntityId: taskEntityId("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0")
+  }), (error: unknown) => {
+    const rejected = error as { readonly _tag?: unknown; readonly code?: unknown; readonly reason?: unknown };
+    return rejected?._tag === "WriteRejected"
+      && rejected.code === "authority_ingress_rejected"
+      && rejected.reason === "AUTHORITY_TYPED_COMMAND_UNSUPPORTED:task-claim";
+  });
+  await assert.rejects(input.submission.submit({
+    ingress: "generic",
+    command: {
+      rootDir: input.repoRoot,
+      json: true,
+      action: { kind: "progress-append", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0", text: "entity mismatch evidence", dryRun: false }
+    },
+    attribution: daemonActorAttribution(input.actor, { kind: "agent", id: "codex" }),
+    currentSession: { runtime: "codex", sessionId: "session-mismatch", source: "manual", detectedAt: "2026-07-17T00:00:00.000Z" },
+    canonicalEntityId: moduleEntityId("wrong-entity")
+  }), (error: unknown) => {
+    const rejected = error as { readonly _tag?: unknown; readonly code?: unknown; readonly reason?: unknown };
+    return rejected?._tag === "WriteRejected"
+      && rejected.code === "authority_ingress_rejected"
+      && rejected.reason === "AUTHORITY_CANONICAL_ENTITY_MISMATCH:submittedEntityId=module/wrong-entity;intentEntityId=task/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0";
+  });
+}

--- a/packages/cli/test/production-authority-evidence-commit.test.ts
+++ b/packages/cli/test/production-authority-evidence-commit.test.ts
@@ -32,6 +32,7 @@ test("the next publication commits a V2 event left durable before its evidence c
     const actor = productionAuthorityActor();
     const submission = started.component.bindConnection(productionAuthorityConnection(actor));
     const submit = (text: string) => submission.submit({
+      ingress: "generic",
       command: {
         rootDir: fixture.repoRoot,
         json: true,

--- a/packages/cli/test/production-authority-lifecycle.test.ts
+++ b/packages/cli/test/production-authority-lifecycle.test.ts
@@ -53,6 +53,7 @@ test("production lifecycle uses external Ed25519 material, durable state, live c
     const actor = productionAuthorityActor();
     const submission = started.component.bindConnection(productionAuthorityConnection(actor));
     const receipt = await submission.submit({
+      ingress: "generic",
       command: {
         rootDir: fixture.repoRoot,
         json: true,
@@ -107,6 +108,7 @@ test("authority publication records an out-of-band first-parent gap and commits 
     if (!started.ok) return;
     const submission = started.component.bindConnection(productionAuthorityConnection(actor));
     const first = await submission.submit({
+      ingress: "generic",
       command: {
         rootDir: fixture.repoRoot,
         json: true,
@@ -131,6 +133,7 @@ test("authority publication records an out-of-band first-parent gap and commits 
     const outOfBandCommit = git(fixture.authoredRoot, "rev-parse", "HEAD");
 
     const acrossGap = await submission.submit({
+      ingress: "generic",
       command: {
         rootDir: fixture.repoRoot,
         json: true,
@@ -174,6 +177,7 @@ test("restart reconciles a durable published operation whose replica-change row 
     assert.equal(started.ok, true, started.ok ? "" : started.error);
     if (!started.ok) return;
     const committed = await started.component.bindConnection(productionAuthorityConnection(actor)).submit({
+      ingress: "generic",
       command: {
         rootDir: fixture.repoRoot,
         json: true,
@@ -251,6 +255,7 @@ test("frozen production restart reuses an indexed append event below a direct do
     const actor = productionAuthorityActor();
     const submission = started.component.bindConnection(productionAuthorityConnection(actor));
     const receipt = await submission.submit({
+      ingress: "generic",
       command: {
         rootDir: fixture.repoRoot,
         json: true,

--- a/packages/daemon/src/authority/authority-command-submission.ts
+++ b/packages/daemon/src/authority/authority-command-submission.ts
@@ -23,86 +23,44 @@ import type {
 import { taskEntityId } from "@harness-anything/kernel";
 import { measureCurrentDaemonRequestPerformancePhase } from "../observability/request-performance.ts";
 
+interface DaemonAuthoritySubmissionInputBaseV2 {
+  readonly command: AuthorityHostCommand;
+  readonly attribution: AuthorityHostAttribution;
+  readonly currentSession: CurrentSessionRef;
+  readonly ingressAdapter?: AuthorityIngressAdapter;
+}
+
+export type DaemonAuthorityCommandSubmissionInputV2 =
+  | (DaemonAuthoritySubmissionInputBaseV2 & {
+      readonly ingress: "generic";
+      readonly canonicalEntityId: WriteOp["entityId"];
+    })
+  | (DaemonAuthoritySubmissionInputBaseV2 & {
+      readonly ingress:
+        | "provenance-session"
+        | "decision-transition"
+        | "task-claim"
+        | "observed-write"
+        | "script-ingest";
+      readonly operation: WriteOp;
+    });
+
 export interface DaemonAuthorityAttemptCompilerV2 {
   /**
-   * Compiles a server-observed parsed command into canonical typed semantic
-   * intent. Raw WriteOps are deliberately absent from this boundary.
+   * Add a governed ingress by extending the discriminated union above and the
+   * exhaustive production compiler switch. Do not add another submission
+   * method: wrappers forward this one capability and semantic differences live
+   * in the ingress payload and compiler handler.
    */
-  readonly compile: (input: {
-    readonly command: AuthorityHostCommand;
-    readonly attribution: AuthorityHostAttribution;
-    readonly currentSession: CurrentSessionRef;
-    readonly canonicalEntityId: WriteOp["entityId"];
-  }) => Promise<AuthorizedOperationAttemptV2>;
-  readonly compileProvenanceSession?: (input: {
-    readonly command: AuthorityHostCommand;
-    readonly attribution: AuthorityHostAttribution;
-    readonly currentSession: CurrentSessionRef;
-    readonly operation: WriteOp;
-  }) => Promise<AuthorizedOperationAttemptV2>;
-  readonly compileDecisionTransition?: (input: {
-    readonly command: AuthorityHostCommand;
-    readonly attribution: AuthorityHostAttribution;
-    readonly currentSession: CurrentSessionRef;
-    readonly operation: WriteOp;
-  }) => Promise<AuthorizedOperationAttemptV2>;
-  readonly compileTaskClaim?: (input: {
-    readonly command: AuthorityHostCommand;
-    readonly attribution: AuthorityHostAttribution;
-    readonly currentSession: CurrentSessionRef;
-    readonly operation: WriteOp;
-  }) => Promise<AuthorizedOperationAttemptV2>;
-  readonly compileObservedWrite?: (input: {
-    readonly command: AuthorityHostCommand;
-    readonly attribution: AuthorityHostAttribution;
-    readonly currentSession: CurrentSessionRef;
-    readonly operation: WriteOp;
-  }) => Promise<AuthorizedOperationAttemptV2>;
-  readonly compileScriptIngest?: (input: {
-    readonly command: AuthorityHostCommand;
-    readonly attribution: AuthorityHostAttribution;
-    readonly currentSession: CurrentSessionRef;
-    readonly operation: WriteOp;
-  }) => Promise<AuthorizedOperationAttemptV2>;
+  readonly compile: (
+    input: DaemonAuthorityCommandSubmissionInputV2
+  ) => Promise<AuthorizedOperationAttemptV2>;
 }
 
 export interface DaemonAuthorityCommandSubmissionV2 {
-  readonly submit: (input: {
-    readonly command: AuthorityHostCommand;
-    readonly attribution: AuthorityHostAttribution;
-    readonly currentSession: CurrentSessionRef;
-    readonly canonicalEntityId: WriteOp["entityId"];
-  }) => Promise<AuthorityOperationReceipt>;
-  readonly submitProvenanceSession?: (input: {
-    readonly command: AuthorityHostCommand;
-    readonly attribution: AuthorityHostAttribution;
-    readonly currentSession: CurrentSessionRef;
-    readonly operation: WriteOp;
-  }) => Promise<AuthorityOperationReceipt>;
-  readonly submitDecisionTransition?: (input: {
-    readonly command: AuthorityHostCommand;
-    readonly attribution: AuthorityHostAttribution;
-    readonly currentSession: CurrentSessionRef;
-    readonly operation: WriteOp;
-  }) => Promise<AuthorityOperationReceipt>;
-  readonly submitTaskClaim?: (input: {
-    readonly command: AuthorityHostCommand;
-    readonly attribution: AuthorityHostAttribution;
-    readonly currentSession: CurrentSessionRef;
-    readonly operation: WriteOp;
-  }) => Promise<AuthorityOperationReceipt>;
-  readonly submitObservedWrite?: (input: {
-    readonly command: AuthorityHostCommand;
-    readonly attribution: AuthorityHostAttribution;
-    readonly currentSession: CurrentSessionRef;
-    readonly operation: WriteOp;
-  }) => Promise<AuthorityOperationReceipt>;
-  readonly submitScriptIngest?: (input: {
-    readonly command: AuthorityHostCommand;
-    readonly attribution: AuthorityHostAttribution;
-    readonly currentSession: CurrentSessionRef;
-    readonly operation: WriteOp;
-  }) => Promise<AuthorityOperationReceipt>;
+  readonly submit: (
+    input: DaemonAuthorityCommandSubmissionInputV2
+  ) => Promise<AuthorityOperationReceipt>;
 }
 
 export function createDaemonAuthorityCommandSubmissionV2(options: {
@@ -136,27 +94,7 @@ export function createDaemonAuthorityCommandSubmissionV2(options: {
     async () => submitAttempt(await compileAttempt(compile))
   );
   return {
-    submit: (input) => compileAndSubmit(() => options.attemptCompiler.compile(input)),
-    ...(options.attemptCompiler.compileProvenanceSession ? {
-      submitProvenanceSession: async (input: Parameters<NonNullable<DaemonAuthorityAttemptCompilerV2["compileProvenanceSession"]>>[0]) =>
-        compileAndSubmit(() => options.attemptCompiler.compileProvenanceSession!(input))
-    } : {}),
-    ...(options.attemptCompiler.compileDecisionTransition ? {
-      submitDecisionTransition: async (input: Parameters<NonNullable<DaemonAuthorityAttemptCompilerV2["compileDecisionTransition"]>>[0]) =>
-        compileAndSubmit(() => options.attemptCompiler.compileDecisionTransition!(input))
-    } : {}),
-    ...(options.attemptCompiler.compileTaskClaim ? {
-      submitTaskClaim: async (input: Parameters<NonNullable<DaemonAuthorityAttemptCompilerV2["compileTaskClaim"]>>[0]) =>
-        compileAndSubmit(() => options.attemptCompiler.compileTaskClaim!(input))
-    } : {}),
-    ...(options.attemptCompiler.compileObservedWrite ? {
-      submitObservedWrite: async (input: Parameters<NonNullable<DaemonAuthorityAttemptCompilerV2["compileObservedWrite"]>>[0]) =>
-        compileAndSubmit(() => options.attemptCompiler.compileObservedWrite!(input))
-    } : {}),
-    ...(options.attemptCompiler.compileScriptIngest ? {
-      submitScriptIngest: async (input: Parameters<NonNullable<DaemonAuthorityAttemptCompilerV2["compileScriptIngest"]>>[0]) =>
-        compileAndSubmit(() => options.attemptCompiler.compileScriptIngest!(input))
-    } : {})
+    submit: (input) => compileAndSubmit(() => options.attemptCompiler.compile(input))
   };
 }
 
@@ -245,38 +183,24 @@ export function makeDaemonAuthorityWriteCoordinator(
         if (provenanceSession && provenanceCommitted) {
           throw authorityWriteRejected("AUTHORITY_COMMAND_REQUIRES_SINGLE_PROVENANCE_SESSION");
         }
-        if (provenanceSession && !submission.submitProvenanceSession) {
-          throw authorityWriteRejected("AUTHORITY_PROVENANCE_SESSION_SUBMISSION_UNAVAILABLE");
-        }
         const ingressAdapter = input.ingressAdapter;
         const decisionTransition = ingressAdapter === "decision-transition";
-        if (decisionTransition && !submission.submitDecisionTransition) {
-          throw authorityWriteRejected("AUTHORITY_DECISION_TRANSITION_SUBMISSION_UNAVAILABLE");
-        }
         const taskClaim = ingressAdapter === "task-claim";
-        if (taskClaim && !submission.submitTaskClaim) {
-          throw authorityWriteRejected("AUTHORITY_TASK_CLAIM_SUBMISSION_UNAVAILABLE");
-        }
         const observedWrite = ingressAdapter === "observed-write";
-        if (observedWrite && !submission.submitObservedWrite) {
-          throw authorityWriteRejected("AUTHORITY_OBSERVED_WRITE_SUBMISSION_UNAVAILABLE");
-        }
         const scriptIngest = pending.kind === "script_ingest";
-        if (scriptIngest && !submission.submitScriptIngest) {
-          throw authorityWriteRejected("AUTHORITY_SCRIPT_SCOPE_SUBMISSION_UNAVAILABLE");
-        }
-        settled ??= scriptIngest
-          ? submission.submitScriptIngest!({ ...input, operation: pending })
+        settled ??= submission.submit(scriptIngest
+          ? { ...input, ingress: "script-ingest", operation: pending }
           : provenanceSession
-          ? submission.submitProvenanceSession!({ ...input, operation: pending })
+          ? { ...input, ingress: "provenance-session", operation: pending }
           : decisionTransition
-            ? submission.submitDecisionTransition!({ ...input, operation: pending })
+            ? { ...input, ingress: "decision-transition", operation: pending }
           : taskClaim
-            ? submission.submitTaskClaim!({ ...input, operation: pending })
+            ? { ...input, ingress: "task-claim", operation: pending }
           : observedWrite
-            ? submission.submitObservedWrite!({ ...input, operation: pending })
-          : submission.submit({
+            ? { ...input, ingress: "observed-write", operation: pending }
+          : {
             ...input,
+            ingress: "generic",
             command: commandWithCompletionContractFence(input.command, pending),
             canonicalEntityId: commandMainEntityId(input.command) ?? pending.entityId
           });

--- a/packages/daemon/src/authority/authority-submission-dispatch.ts
+++ b/packages/daemon/src/authority/authority-submission-dispatch.ts
@@ -15,37 +15,7 @@ export function bindAuthoritySubmissionForDispatch(
     submit: async (submission) => {
       dispatch.assertActive();
       return bound.submit(submission);
-    },
-    ...(bound.submitProvenanceSession ? {
-      submitProvenanceSession: async (submission: Parameters<NonNullable<typeof bound.submitProvenanceSession>>[0]) => {
-        dispatch.assertActive();
-        return bound.submitProvenanceSession!(submission);
-      }
-    } : {}),
-    ...(bound.submitDecisionTransition ? {
-      submitDecisionTransition: async (submission: Parameters<NonNullable<typeof bound.submitDecisionTransition>>[0]) => {
-        dispatch.assertActive();
-        return bound.submitDecisionTransition!(submission);
-      }
-    } : {}),
-    ...(bound.submitTaskClaim ? {
-      submitTaskClaim: async (submission: Parameters<NonNullable<typeof bound.submitTaskClaim>>[0]) => {
-        dispatch.assertActive();
-        return bound.submitTaskClaim!(submission);
-      }
-    } : {}),
-    ...(bound.submitObservedWrite ? {
-      submitObservedWrite: async (submission: Parameters<NonNullable<typeof bound.submitObservedWrite>>[0]) => {
-        dispatch.assertActive();
-        return bound.submitObservedWrite!(submission);
-      }
-    } : {}),
-    ...(bound.submitScriptIngest ? {
-      submitScriptIngest: async (submission: Parameters<NonNullable<typeof bound.submitScriptIngest>>[0]) => {
-        dispatch.assertActive();
-        return bound.submitScriptIngest!(submission);
-      }
-    } : {})
+    }
   };
 }
 

--- a/packages/daemon/src/authority/production/production-authority-attempt-compiler.ts
+++ b/packages/daemon/src/authority/production/production-authority-attempt-compiler.ts
@@ -16,7 +16,6 @@ import {
 import {
   decisionEntityId,
   decisionSemanticMutationActions,
-  moduleEntityId,
   parseDecisionDocument,
   sha256Text,
   taskEntityId,
@@ -26,8 +25,17 @@ import {
   type WriteOp
 } from "@harness-anything/kernel";
 import type { AuthorityConnectionContext } from "../../protocol/connection-context.ts";
-import type { DaemonAuthorityAttemptCompilerV2 } from "../authority-command-submission.ts";
+import type {
+  DaemonAuthorityAttemptCompilerV2,
+  DaemonAuthorityCommandSubmissionInputV2
+} from "../authority-command-submission.ts";
 import { hostedSnapshot } from "./semantic-state.ts";
+import {
+  canonicalIntent,
+  decisionTransitionAttemptIntent,
+  moduleCanonicalIntent,
+  registryRef as ref
+} from "./production-authority-canonical-intents.ts";
 import {
   openAuthorityProductionKeyMaterial,
   type AuthorityProductionRepoConfigV1,
@@ -81,7 +89,10 @@ export interface CanonicalAttemptIntent {
 }
 
 type CanonicalCompileInput =
-  Parameters<DaemonAuthorityAttemptCompilerV2["compile"]>[0];
+  Omit<
+    Extract<DaemonAuthorityCommandSubmissionInputV2, { readonly ingress: "generic" }>,
+    "ingress"
+  >;
 
 export type ProductionProgressAppendCompileInput = CanonicalCompileInput & {
   readonly ingressAdapter?: AuthorityIngressAdapter;
@@ -89,8 +100,6 @@ export type ProductionProgressAppendCompileInput = CanonicalCompileInput & {
 
 export type ProductionAuthorityCommandPlanInput =
   Omit<CanonicalCompileInput, "canonicalEntityId">;
-
-export type ProductionAuthorityCommandSubmissionInput = CanonicalCompileInput;
 
 export interface ProductionCanonicalAttemptCompilerV2
   extends DaemonAuthorityAttemptCompilerV2 {
@@ -206,38 +215,95 @@ export function createProductionCanonicalAttemptCompiler(input: {
       }
       return attemptPlanner.activateRecoveryPlan(plan, witness);
     },
-    compile: async ({ command, attribution, currentSession, canonicalEntityId }) => {
-      const disposition = input.hostServices.productionAuthorityIngressFor(command.action.kind);
-      const intent = disposition?.status === "typed-v2" && disposition.adapter === "generic"
-        ? await canonicalAttemptIntent(command, currentSession, canonicalEntityId, input.authoredRoot, attribution.writeAttribution.actor, input.hostServices)
-        : null;
-      return compileIntent(command, attribution, currentSession, canonicalEntityId, intent);
-    },
-    compileProvenanceSession: async ({ command, attribution, currentSession, operation }) => {
-      assertTypedIngressAdapter(command.action.kind, "generic", input.hostServices);
-      return compileIntent(command, attribution, currentSession, operation.entityId,
-        provenanceSessionAttemptIntent(command, currentSession, operation));
-    },
-    compileDecisionTransition: async ({ command, attribution, currentSession, operation }) => {
-      assertTypedIngressAdapter(command.action.kind, "decision-transition", input.hostServices);
-      return compileIntent(command, attribution, currentSession, operation.entityId,
-        decisionTransitionAttemptIntent(command, operation, input.authoredRoot));
-    },
-    compileTaskClaim: async ({ command, attribution, currentSession, operation }) => {
-      assertTypedIngressAdapter(command.action.kind, "task-claim", input.hostServices);
-      return compileIntent(command, attribution, currentSession, operation.entityId,
-        taskClaimAttemptIntent(command, attribution, currentSession, operation));
-    },
-    compileObservedWrite: async ({ command, attribution, currentSession, operation }) => {
-      assertTypedIngressAdapter(command.action.kind, "observed-write", input.hostServices);
-      return compileIntent(command, attribution, currentSession, operation.entityId,
-        productionObservedWriteAttemptIntent(command, operation, input.authoredRoot));
-    },
-    compileScriptIngest: async ({ command, attribution, currentSession, operation }) => {
-      return compileIntent(command, attribution, currentSession, operation.entityId,
-        productionScriptIngestAttemptIntent(command, operation, input.authoredRoot));
+    compile: async (submission) => {
+      switch (submission.ingress) {
+        case "generic": {
+          const {
+            command,
+            attribution,
+            currentSession,
+            canonicalEntityId
+          } = submission;
+          const disposition = input.hostServices.productionAuthorityIngressFor(command.action.kind);
+          const intent = disposition?.status === "typed-v2" && disposition.adapter === "generic"
+            ? await canonicalAttemptIntent(command, currentSession, canonicalEntityId, input.authoredRoot, attribution.writeAttribution.actor, input.hostServices)
+            : null;
+          return compileIntent(command, attribution, currentSession, canonicalEntityId, intent);
+        }
+        case "provenance-session":
+          assertTypedIngressAdapter(submission.command.action.kind, "generic", input.hostServices);
+          return compileIntent(
+            submission.command,
+            submission.attribution,
+            submission.currentSession,
+            submission.operation.entityId,
+            provenanceSessionAttemptIntent(
+              submission.command,
+              submission.currentSession,
+              submission.operation
+            )
+          );
+        case "decision-transition":
+          assertTypedIngressAdapter(submission.command.action.kind, "decision-transition", input.hostServices);
+          return compileIntent(
+            submission.command,
+            submission.attribution,
+            submission.currentSession,
+            submission.operation.entityId,
+            decisionTransitionAttemptIntent(
+              submission.command,
+              submission.operation,
+              input.authoredRoot
+            )
+          );
+        case "task-claim":
+          assertTypedIngressAdapter(submission.command.action.kind, "task-claim", input.hostServices);
+          return compileIntent(
+            submission.command,
+            submission.attribution,
+            submission.currentSession,
+            submission.operation.entityId,
+            taskClaimAttemptIntent(
+              submission.command,
+              submission.attribution,
+              submission.currentSession,
+              submission.operation
+            )
+          );
+        case "observed-write":
+          assertTypedIngressAdapter(submission.command.action.kind, "observed-write", input.hostServices);
+          return compileIntent(
+            submission.command,
+            submission.attribution,
+            submission.currentSession,
+            submission.operation.entityId,
+            productionObservedWriteAttemptIntent(
+              submission.command,
+              submission.operation,
+              input.authoredRoot
+            )
+          );
+        case "script-ingest":
+          return compileIntent(
+            submission.command,
+            submission.attribution,
+            submission.currentSession,
+            submission.operation.entityId,
+            productionScriptIngestAttemptIntent(
+              submission.command,
+              submission.operation,
+              input.authoredRoot
+            )
+          );
+        default:
+          return assertNeverSubmissionIngress(submission);
+      }
     }
   };
+}
+
+function assertNeverSubmissionIngress(input: never): never {
+  throw new Error(`AUTHORITY_SUBMISSION_INGRESS_UNHANDLED:${String(input)}`);
 }
 
 function assertTypedIngressAdapter(
@@ -249,52 +315,6 @@ function assertTypedIngressAdapter(
   if (disposition?.status !== "typed-v2" || disposition.adapter !== expected) {
     throw new Error(`AUTHORITY_TYPED_INGRESS_REGISTRY_MISMATCH:${kind}:${expected}`);
   }
-}
-
-function decisionTransitionAttemptIntent(
-  command: ProductionAuthorityCommand,
-  operation: WriteOp,
-  authoredRoot: string
-): CanonicalAttemptIntent {
-  const action = command.action;
-  if (action.kind !== "decision-transition") throw new Error("AUTHORITY_DECISION_TRANSITION_COMMAND_REQUIRED");
-  const expectedKind = `decision_${action.transition}`;
-  if (operation.entityId !== decisionEntityId(action.decisionId) || operation.kind !== expectedKind) {
-    throw new Error("AUTHORITY_DECISION_TRANSITION_OPERATION_MISMATCH");
-  }
-  const raw = operation.payload;
-  if (!raw || typeof raw !== "object" || !("decision" in raw)) {
-    throw new Error("AUTHORITY_DECISION_TRANSITION_PAYLOAD_INVALID");
-  }
-  const decision = (raw as { readonly decision?: DecisionPackage }).decision;
-  if (!decision || decision.decision_id !== action.decisionId) {
-    throw new Error("AUTHORITY_DECISION_TRANSITION_ENTITY_MISMATCH");
-  }
-  const body = (raw as { readonly body?: unknown }).body;
-  if (body !== undefined && typeof body !== "string") {
-    throw new Error("AUTHORITY_DECISION_TRANSITION_BODY_INVALID");
-  }
-  const documentPath = `decisions/decision-${action.decisionId}/decision.md`;
-  const snapshot = hostedSnapshot(authoredRoot, documentPath);
-  if (!snapshot) throw new Error("AUTHORITY_CANONICAL_HOST_DOCUMENT_REQUIRED: decision transition requires the current Decision document");
-  const entity = ref("decision", `decision/${action.decisionId}`);
-  const payload: TaskDecisionModuleCommandPayloadV2 = {
-    schema: "decision.state/v1",
-    transition: action.transition,
-    decision,
-    ...(body === undefined ? {} : { body })
-  };
-  return {
-    ...canonicalIntent(
-      "decision.state",
-      encodeTaskDecisionModuleCommandPayloadV2(payload),
-      [{ entity, action: decisionSemanticMutationActions.state }],
-      [entity],
-      [documentPath],
-      decisionEntityId(action.decisionId)
-    ),
-    declaredPathCas: [{ path: documentPath, ...snapshot.cas }]
-  };
 }
 
 async function canonicalAttemptIntent(
@@ -537,25 +557,4 @@ async function canonicalAttemptIntent(
     };
   }
   return productionLifecycleAttemptIntent({ command, currentSession, canonicalEntityId, authoredRoot, actor: executionActor }, hostServices);
-}
-
-function canonicalIntent(
-  commandName: string,
-  payload: Uint8Array,
-  mutations: CanonicalAttemptIntent["mutations"],
-  baseRefs: ReadonlyArray<RegistryEntityRefV2>,
-  portablePaths: ReadonlyArray<string>,
-  physicalEntityId: string
-): CanonicalAttemptIntent {
-  return { commandName, payload, mutations, baseRefs, portablePaths, declaredPathCas: [], physicalEntityId };
-}
-
-function moduleCanonicalIntent(commandName: string, payload: Uint8Array, entity: RegistryEntityRefV2, action: string, moduleKey: string, authoredRoot: string): CanonicalAttemptIntent {
-  const intent = canonicalIntent(commandName, payload, [{ entity, action }], [entity], ["modules.json"], moduleEntityId(moduleKey));
-  const snapshot = hostedSnapshot(authoredRoot, "modules.json");
-  return { ...intent, declaredPathCas: snapshot ? [{ path: "modules.json", ...snapshot.cas }] : [] };
-}
-
-function ref(entityKind: string, canonicalRef: string): RegistryEntityRefV2 {
-  return { registryVersion: 1, entityKind, canonicalRef };
 }

--- a/packages/daemon/src/authority/production/production-authority-canonical-intents.ts
+++ b/packages/daemon/src/authority/production/production-authority-canonical-intents.ts
@@ -1,0 +1,99 @@
+import {
+  encodeTaskDecisionModuleCommandPayloadV2,
+  type ProductionAuthorityCommand,
+  type TaskDecisionModuleCommandPayloadV2
+} from "@harness-anything/application";
+import {
+  decisionEntityId,
+  decisionSemanticMutationActions,
+  moduleEntityId,
+  type DecisionPackage,
+  type RegistryEntityRefV2,
+  type WriteOp
+} from "@harness-anything/kernel";
+import type { CanonicalAttemptIntent } from "./production-authority-attempt-compiler.ts";
+import { hostedSnapshot } from "./semantic-state.ts";
+
+export function canonicalIntent(
+  commandName: string,
+  payload: Uint8Array,
+  mutations: CanonicalAttemptIntent["mutations"],
+  baseRefs: ReadonlyArray<RegistryEntityRefV2>,
+  portablePaths: ReadonlyArray<string>,
+  physicalEntityId: string
+): CanonicalAttemptIntent {
+  return { commandName, payload, mutations, baseRefs, portablePaths, declaredPathCas: [], physicalEntityId };
+}
+
+export function moduleCanonicalIntent(
+  commandName: string,
+  payload: Uint8Array,
+  entity: RegistryEntityRefV2,
+  action: string,
+  moduleKey: string,
+  authoredRoot: string
+): CanonicalAttemptIntent {
+  const intent = canonicalIntent(
+    commandName,
+    payload,
+    [{ entity, action }],
+    [entity],
+    ["modules.json"],
+    moduleEntityId(moduleKey)
+  );
+  const snapshot = hostedSnapshot(authoredRoot, "modules.json");
+  return { ...intent, declaredPathCas: snapshot ? [{ path: "modules.json", ...snapshot.cas }] : [] };
+}
+
+export function registryRef(
+  entityKind: string,
+  canonicalRef: string
+): RegistryEntityRefV2 {
+  return { registryVersion: 1, entityKind, canonicalRef };
+}
+
+export function decisionTransitionAttemptIntent(
+  command: ProductionAuthorityCommand,
+  operation: WriteOp,
+  authoredRoot: string
+): CanonicalAttemptIntent {
+  const action = command.action;
+  if (action.kind !== "decision-transition") throw new Error("AUTHORITY_DECISION_TRANSITION_COMMAND_REQUIRED");
+  const expectedKind = `decision_${action.transition}`;
+  if (operation.entityId !== decisionEntityId(action.decisionId) || operation.kind !== expectedKind) {
+    throw new Error("AUTHORITY_DECISION_TRANSITION_OPERATION_MISMATCH");
+  }
+  const raw = operation.payload;
+  if (!raw || typeof raw !== "object" || !("decision" in raw)) {
+    throw new Error("AUTHORITY_DECISION_TRANSITION_PAYLOAD_INVALID");
+  }
+  const decision = (raw as { readonly decision?: DecisionPackage }).decision;
+  if (!decision || decision.decision_id !== action.decisionId) {
+    throw new Error("AUTHORITY_DECISION_TRANSITION_ENTITY_MISMATCH");
+  }
+  const body = (raw as { readonly body?: unknown }).body;
+  if (body !== undefined && typeof body !== "string") {
+    throw new Error("AUTHORITY_DECISION_TRANSITION_BODY_INVALID");
+  }
+  const documentPath = `decisions/decision-${action.decisionId}/decision.md`;
+  const snapshot = hostedSnapshot(authoredRoot, documentPath);
+  if (!snapshot) throw new Error("AUTHORITY_CANONICAL_HOST_DOCUMENT_REQUIRED: decision transition requires the current Decision document");
+  const entity = registryRef("decision", `decision/${action.decisionId}`);
+  const payload: TaskDecisionModuleCommandPayloadV2 = {
+    schema: "decision.state/v1",
+    transition: action.transition,
+    decision,
+    ...(body === undefined ? {} : { body })
+  };
+  return {
+    ...canonicalIntent(
+      "decision.state",
+      encodeTaskDecisionModuleCommandPayloadV2(payload),
+      [{ entity, action: decisionSemanticMutationActions.state }],
+      [entity],
+      [documentPath],
+      decisionEntityId(action.decisionId)
+    ),
+    declaredPathCas: [{ path: documentPath, ...snapshot.cas }]
+  };
+}

--- a/packages/daemon/src/authority/production/production-authority-lifecycle.ts
+++ b/packages/daemon/src/authority/production/production-authority-lifecycle.ts
@@ -441,22 +441,7 @@ function createRepoComponent(
         attemptCompiler: progressCompiler
       });
       const binding: AuthorityRepoConnectionBinding = {
-        submit: commandSubmission.submit,
-        ...(commandSubmission.submitProvenanceSession ? {
-          submitProvenanceSession: commandSubmission.submitProvenanceSession
-        } : {}),
-        ...(commandSubmission.submitDecisionTransition ? {
-          submitDecisionTransition: commandSubmission.submitDecisionTransition
-        } : {}),
-        ...(commandSubmission.submitTaskClaim ? {
-          submitTaskClaim: commandSubmission.submitTaskClaim
-        } : {}),
-        ...(commandSubmission.submitObservedWrite ? {
-          submitObservedWrite: commandSubmission.submitObservedWrite
-        } : {}),
-        ...(commandSubmission.submitScriptIngest ? {
-          submitScriptIngest: commandSubmission.submitScriptIngest
-        } : {}),
+        ...commandSubmission,
         ...progressBinding,
         serveForcedCommand: ({ input: readable, output }) => {
           const session = serveAuthorityForcedCommand({

--- a/packages/daemon/src/authority/production/production-authority-pure-command-plan.ts
+++ b/packages/daemon/src/authority/production/production-authority-pure-command-plan.ts
@@ -51,5 +51,8 @@ export function productionAuthorityCommandHasPurePlan(
   command: ProductionAuthorityCommand
 ): boolean {
   return directTypedCommandEntityId(command) !== undefined
-    && !(command.action.kind === "new-task" && command.action.registerModule);
+    // Task creation may first publish a provenance-session operation. A single
+    // fixed durable plan cannot represent both canonical operations, so keep
+    // the whole command on the direct child lane.
+    && command.action.kind !== "new-task";
 }

--- a/packages/daemon/src/authority/production/production-progress-append-submission.ts
+++ b/packages/daemon/src/authority/production/production-progress-append-submission.ts
@@ -13,7 +13,6 @@ import {
 } from "../authority-command-submission.ts";
 import type {
   ProductionAuthorityCommandPlanInput,
-  ProductionAuthorityCommandSubmissionInput,
   ProductionCanonicalAttemptCompilerV2,
   ProductionProgressAppendCompileInput
 } from "./production-authority-attempt-compiler.ts";
@@ -30,11 +29,8 @@ import type {
 } from "./authority-production-state.ts";
 import type { openAuthorityProductionKeyMaterial } from "./authority-production-state.ts";
 
-export interface ProductionPlannedCommandSubmission {
-  readonly submit: (
-    input: ProductionAuthorityCommandSubmissionInput
-  ) => Promise<AuthorityOperationReceipt>;
-}
+export type ProductionPlannedCommandSubmission =
+  DaemonAuthorityCommandSubmissionV2;
 
 export function createProductionProgressAppendConnectionBinding(input: {
   readonly material: {
@@ -149,33 +145,40 @@ export function createProductionPlannedCommandSubmission(input: {
   readonly recovery?: ProductionAuthorityOuterRecoveryWitnessV1;
 }): ProductionPlannedCommandSubmission {
   let submitted = false;
-  return {
-    submit: async (actual) => {
-      if (submitted) {
-        throw new Error("AUTHORITY_PLANNED_SUBMISSION_REUSED");
-      }
-      const {
-        canonicalEntityId,
-        ...actualPlanInput
-      } = actual;
-      if (canonicalEntityId !== input.plan.targetEntityId
-        || stableStringify(actualPlanInput) !== stableStringify(input.expected)) {
-        throw new Error("AUTHORITY_PLANNED_INPUT_MISMATCH");
-      }
-      submitted = true;
-      const attempt = input.recovery
-        ? await input.compiler.activateRecoveryCommand(input.plan, input.recovery)
-        : input.compiler.activatePlannedCommand(input.plan);
-      const envelope = decodeSemanticMutationEnvelopeV2(attempt.envelope);
-      const expectedOpId = operationIdDiagnosticV2(envelope.operationId);
-      const receipt = input.recovery
-        ? await resumePlannedCommand({ ...input, recovery: input.recovery }, attempt)
-        : await submitPlannedCommand(input.authorityService, attempt);
-      assertCompleteAuthorityReceiptV2(receipt);
-      assertAuthorityReceiptOperation(receipt, expectedOpId);
-      return receipt;
+  const submit = async (
+    actual: Parameters<DaemonAuthorityCommandSubmissionV2["submit"]>[0]
+  ): Promise<AuthorityOperationReceipt> => {
+    if (submitted) {
+      throw new Error("AUTHORITY_PLANNED_SUBMISSION_REUSED");
     }
+    if (actual.ingress !== "generic") {
+      throw new Error("AUTHORITY_PLANNED_INPUT_MISMATCH");
+    }
+    const canonicalEntityId = actual.canonicalEntityId;
+    const actualPlanInput: ProductionAuthorityCommandPlanInput = {
+      command: actual.command,
+      attribution: actual.attribution,
+      currentSession: actual.currentSession,
+      ...(actual.ingressAdapter ? { ingressAdapter: actual.ingressAdapter } : {})
+    };
+    if (canonicalEntityId !== input.plan.targetEntityId
+      || stableStringify(actualPlanInput) !== stableStringify(input.expected)) {
+      throw new Error("AUTHORITY_PLANNED_INPUT_MISMATCH");
+    }
+    submitted = true;
+    const attempt = input.recovery
+      ? await input.compiler.activateRecoveryCommand(input.plan, input.recovery)
+      : input.compiler.activatePlannedCommand(input.plan);
+    const envelope = decodeSemanticMutationEnvelopeV2(attempt.envelope);
+    const expectedOpId = operationIdDiagnosticV2(envelope.operationId);
+    const receipt = input.recovery
+      ? await resumePlannedCommand({ ...input, recovery: input.recovery }, attempt)
+      : await submitPlannedCommand(input.authorityService, attempt);
+    assertCompleteAuthorityReceiptV2(receipt);
+    assertAuthorityReceiptOperation(receipt, expectedOpId);
+    return receipt;
   };
+  return { submit };
 }
 
 async function submitPlannedCommand(

--- a/packages/daemon/test/authority-submission-error.test.ts
+++ b/packages/daemon/test/authority-submission-error.test.ts
@@ -1,9 +1,12 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
+import { Effect } from "effect";
 import {
+  createDaemonAuthorityCommandSubmissionV2,
   authoritySubmissionWriteError,
-  gateAuthoritySubmissionForRecovery
+  gateAuthoritySubmissionForRecovery,
+  makeDaemonAuthorityWriteCoordinator
 } from "../src/index.ts";
 import { receiptToFlushReport } from "../src/authority/authority-command-submission.ts";
 import { gateCutoverAdmission } from "../src/authority/production/cutover-admission.ts";
@@ -11,12 +14,26 @@ import {
   defaultProductionRecoveryAdmissionTimeoutMs,
   waitForProductionRecovery
 } from "../src/authority/production/production-recovery-admission.ts";
+import {
+  createProductionPlannedCommandSubmission
+} from "../src/authority/production/production-progress-append-submission.ts";
+import {
+  productionAuthorityCommandHasPurePlan
+} from "../src/authority/production/production-authority-pure-command-plan.ts";
+import type {
+  ProductionAuthorityCommandPlanInput,
+  ProductionCanonicalAttemptCompilerV2
+} from "../src/authority/production/production-authority-attempt-compiler.ts";
+import type {
+  ProductionAuthorityAttemptPlanV1
+} from "../src/authority/production/production-authority-attempt-plan.ts";
 import { defaultRepoWriteRequestTimeoutMs } from "../src/runtime/repo-write-client-contract.ts";
 import {
   encodeSemanticMutationEnvelopeV2,
   operationIdDiagnosticV2,
   semanticRequestDigestV2,
   type AuthorityRecoveryAttemptV2,
+  type AuthoritySubmissionService,
   type ProtocolSchemaTupleV2
 } from "@harness-anything/application";
 import { v2Claims, v2Envelope } from "./authority-v2-fixtures.ts";
@@ -147,6 +164,139 @@ test("cutover admission preserves V2 recovery admission", async () => {
   assert.equal(admitted, 1);
   assert.equal(resumed, 1);
 });
+
+test("planned durable submission exposes one forwarding method and rejects specialized ingress", async () => {
+  const submission = createProductionPlannedCommandSubmission({
+    repoId: "canonical",
+    authorityGeneration: 7,
+    authorityService: {} as AuthoritySubmissionService,
+    compiler: {} as ProductionCanonicalAttemptCompilerV2,
+    expected: {} as ProductionAuthorityCommandPlanInput,
+    plan: {} as ProductionAuthorityAttemptPlanV1
+  });
+
+  assert.deepEqual(Object.keys(submission), ["submit"]);
+  await assert.rejects(submission.submit({
+    ingress: "task-claim",
+    command: {} as never,
+    attribution: {} as never,
+    currentSession: {} as never,
+    operation: {
+      opId: "op-specialized",
+      entityId: "task/task_SPECIALIZED",
+      kind: "doc_write"
+    }
+  }), /AUTHORITY_PLANNED_INPUT_MISMATCH/u);
+});
+
+test("multi-operation task creation stays on the direct child lane", () => {
+  assert.equal(productionAuthorityCommandHasPurePlan({
+    rootDir: "/repo",
+    action: {
+      kind: "new-task",
+      title: "Task with provenance",
+      titleProvided: true,
+      taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG9"
+    }
+  }), false);
+});
+
+test("one submission method carries every governed ingress discriminator", async () => {
+  const fixture = authorityCommandAttemptFixture();
+  const compiled: string[] = [];
+  const submission = createDaemonAuthorityCommandSubmissionV2({
+    authorityService: {
+      submit: async () => { throw new Error("unused"); },
+      submitV2: async () => { throw new Error("stop after compile"); },
+      getOperation: async () => undefined
+    },
+    attemptCompiler: {
+      compile: async (input) => {
+        compiled.push(input.ingress);
+        return fixture.attempt;
+      }
+    }
+  });
+  const common = {
+    command: {} as never,
+    attribution: {} as never,
+    currentSession: {} as never
+  };
+  const operation = {
+    opId: "op-ingress",
+    entityId: "task/task_INGRESS",
+    kind: "progress_append" as const
+  };
+  const inputs = [
+    { ...common, ingress: "generic" as const, canonicalEntityId: operation.entityId },
+    { ...common, ingress: "provenance-session" as const, operation },
+    { ...common, ingress: "decision-transition" as const, operation },
+    { ...common, ingress: "task-claim" as const, operation },
+    { ...common, ingress: "observed-write" as const, operation },
+    { ...common, ingress: "script-ingest" as const, operation }
+  ];
+  for (const input of inputs) {
+    await assert.rejects(submission.submit(input), /stop after compile/u);
+  }
+  assert.deepEqual(compiled, inputs.map((input) => input.ingress));
+});
+
+test("write coordinator routes specialized semantics through the single submission entry", async () => {
+  const cases = [
+    { ingressAdapter: "decision-transition", ingress: "decision-transition", actionKind: "decision-transition", operationKind: "doc_write" },
+    { ingressAdapter: "task-claim", ingress: "task-claim", actionKind: "task-claim", operationKind: "doc_write" },
+    { ingressAdapter: "observed-write", ingress: "observed-write", actionKind: "task-amend", operationKind: "doc_write" },
+    { ingressAdapter: undefined, ingress: "script-ingest", actionKind: "script-run", operationKind: "script_ingest" }
+  ] as const;
+  for (const fixture of cases) {
+    let observedIngress = "";
+    const coordinator = makeDaemonAuthorityWriteCoordinator({
+      submit: async (submission) => {
+        observedIngress = submission.ingress;
+        return {
+          tag: "COMMITTED",
+          workspaceId: "workspace-ingress",
+          opId: `op-${fixture.ingress}`,
+          semanticDigest: "a".repeat(64),
+          revision: 1,
+          commitSha: "b".repeat(40),
+          previousCommit: null
+        };
+      }
+    }, {
+      command: {
+        rootDir: "/fixture",
+        json: true,
+        action: { kind: fixture.actionKind }
+      } as never,
+      attribution: {} as never,
+      currentSession: {
+        runtime: "codex",
+        sessionId: "session-ingress",
+        source: "runtime",
+        detectedAt: "2026-07-24T00:00:00.000Z"
+      },
+      ...(fixture.ingressAdapter ? { ingressAdapter: fixture.ingressAdapter } : {})
+    });
+    await runEffect(coordinator.enqueue({
+      opId: `op-${fixture.ingress}`,
+      entityId: "task/task_INGRESS",
+      kind: fixture.operationKind
+    } as never));
+    await runEffect(coordinator.flush("explicit"));
+    assert.equal(observedIngress, fixture.ingress);
+  }
+});
+
+function runEffect<A, E>(effect: Effect.Effect<A, E>): Promise<A> {
+  return new Promise((resolve, reject) => {
+    Effect.runCallback(effect, {
+      onExit: (exit) => exit._tag === "Success"
+        ? resolve(exit.value)
+        : reject(new Error(String(exit.cause)))
+    });
+  });
+}
 
 test("production recovery admission expires before the repo-write transport deadline", () => {
   assert.ok(defaultProductionRecoveryAdmissionTimeoutMs < defaultRepoWriteRequestTimeoutMs);

--- a/packages/daemon/test/production-progress-append-operation.test.ts
+++ b/packages/daemon/test/production-progress-append-operation.test.ts
@@ -304,6 +304,7 @@ function authorityComponent(
       submit: async (actual) => {
         assert.deepEqual(actual, {
           ...expected,
+          ingress: "generic",
           canonicalEntityId: fixed.targetEntityId
         });
         assert.equal(fixed.innerOpId, "inner-progress-operation");
@@ -326,7 +327,10 @@ function authorityComponent(
     },
     plannedProgressAppendSubmission: ({ expected, plan: fixed, recovery }) => ({
       submit: async (actual) => {
-        assert.deepEqual(actual, expected);
+        assert.deepEqual(actual, {
+          ...expected,
+          ingress: "generic"
+        });
         assert.equal(fixed.innerOpId, "inner-progress-operation");
         if (expectedRecovery) {
           assert.deepEqual(recovery, {


### PR DESCRIPTION
# English

## Summary

Five governed ingress classes were rejected in production with
`AUTHORITY_*_SUBMISSION_UNAVAILABLE`, blocking `task create`, `decision transition`,
`task claim`, observed write, and script ingest. The cause was structural, not a
single missing wire: submission was six optional method slots that every wrapper
layer had to forward by hand, and dropping one was legal at compile time. This
collapses them into one discriminated entry point, so there is a single capability
to forward and a missed ingress cannot compile.

## What Changed

- `DaemonAuthorityCommandSubmissionV2` exposes one submission capability taking a
  discriminated `DaemonAuthorityCommandSubmissionInputV2` (`generic` |
  `provenance-session` | `decision-transition` | `task-claim` | `observed-write` |
  `script-ingest`) instead of `submit` plus five optional `submitXxx` methods.
- The production compiler switches exhaustively over that discriminator and ends in
  `assertNeverSubmissionIngress(input: never)`, which also throws
  `AUTHORITY_SUBMISSION_INGRESS_UNHANDLED` at runtime. Adding an ingress without
  handling it fails `tsc` with `TS2345 … not assignable to parameter of type 'never'`.
- Per-method forwarding is deleted at every layer. In
  `production-authority-lifecycle.ts` sixteen lines of conditional spreads become
  `...commandSubmission`.
- The five `AUTHORITY_*_SUBMISSION_UNAVAILABLE` guards are removed because the state
  they guarded — an optional method being absent — is no longer representable. The
  single-canonical-operation and single-provenance-session guards are untouched.
- `productionAuthorityCommandHasPurePlan` now excludes every `new-task`, not only
  `new-task` with `registerModule`. Task creation may first publish a
  provenance-session operation and one fixed durable plan cannot represent both
  canonical operations, so the command stays on the direct child lane. This narrows
  an optimization; it does not widen any admission.
- A comment at the union declares the pattern for future work: extend the union and
  the exhaustive switch, and do not add another submission method.

## Task And Scope

- Harness task: not applicable; continued incident remediation of the #1075 P5-W2
  CH4 child-writer cutover (follows #1077, #1078, #1079, #1080, #1081)
- Branch: `codex/complete-submission-wrappers`
- Public scope: `packages/daemon` authority command submission, submission dispatch,
  production attempt compiler and canonical intents, production authority lifecycle,
  pure command plan, progress-append submission
- Private planning/evidence updated: yes
- Out of scope: the ledger-side bookkeeping this unblocks

## Version Impact

- Version: no version change because no wire format, durable schema, or receipt
  schema changed; the collapsed interface is internal to the daemon
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable; `tools/check-pr-governance.mjs` reports
  no manifest-derived protected surface touched
- Authority: this changes the shape of the daemon's governed submission surface,
  which is an architecture-level decision. Zeyu directed it in the operating session
  on 2026-07-24 after the same defect class recurred a third time, with the explicit
  requirement that the result be the pattern future work copies rather than another
  per-instance patch.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers
  decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: two decisions remain to be recorded once the governed
  write path is confirmed — the cross-generation terminalization adjudication
  promised in #1080, and this submission-surface collapse. Neither could be recorded
  first because `ha decision transition` is one of the ingress classes this PR
  restores.

## Verification

- Base `origin/main` SHA: `209af4672f3161fd20bc8570295c73f354729952`
- Branch merge-base with `origin/main`: `209af4672f3161fd20bc8570295c73f354729952`
- Last `git fetch origin` time: 2026-07-25, immediately before opening this PR
- Sync method: rebase onto current main (after #1081)
- Public diff command: `git diff 209af4672f3161fd20bc8570295c73f354729952...HEAD`
- Private evidence commit/path: session incident findings (Round 6)
- Reviewer evidence path: CEO semantic acceptance in the merge session
- GitHub Actions `rewrite-ci` run URL: pending; linked once the run starts
- [x] `git diff --check`
- [x] `npm run check:stop-point` — 34 complete manifest gates green (after rebase)
- [x] Targeted tests for the change surface, named with their counts:
  `authority-submission-error.test.ts` and `generic-ingress-rejections.ts` cover each
  discriminator and its rejection path; focused seams 21/21; full fast 794/794;
  contract 841 passed with 1 skipped; `check:local` affected fast 511/511 and
  contract 223 passed with one platform skip.
- [x] Adversarial check of the anti-recurrence gate, run by the CEO with both
  controls: `npm run typecheck` exits 0 on the branch as authored; injecting an
  unhandled `ceo-adversarial-probe` member into the ingress union makes it exit 2
  with `TS2345 … not assignable to parameter of type 'never'`; the probe was then
  reverted and the worktree confirmed clean.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: `npm run check:ci` not run locally (retired local full preflight;
  GitHub Actions is authoritative). No production daemon was started or written to.
  End-to-end confirmation is every governed ingress class exercised against the live
  writer after merge, dist rebuild, and a deliberate daemon restart.

## Review Evidence

- Self-review: CEO read the full diff and verified four things independently: the
  runtime `never` branch still throws, so fail-closed survives a caller that evades
  the type system; the single-canonical-operation and single-provenance-session
  guards are unchanged at two occurrences each; the removed
  `SUBMISSION_UNAVAILABLE` guards protected a state the collapsed interface makes
  unrepresentable, so removing them is stronger rather than weaker; and the
  `new-task` pure-plan change narrows eligibility rather than widening admission.
- Reviewer subagent: Codex authored the collapse. The CEO's first two briefs for
  this work carried a wrong premise — that two `AuthoritySubmissionService` wrappers
  were dropping the methods — which was retracted after tracing the real declaring
  type; the third brief carried the correct trace and the mandate to make the class
  structurally impossible.
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Production verification is still outstanding; the previous end-to-end claim in
  this incident used a single command that happened to need none of the specialized
  ingress classes, so acceptance here must exercise every discriminator rather than
  a representative one.
- The runtime `never` throw is reachable only by a caller that bypasses the type
  system; it is a backstop, not the primary gate.
- Nightly canonical-ingress runner was not executed; it asserts against an existing
  daemon-generation environment and would fail for unrelated reasons.

## References

- Task: not applicable
- Evidence: session incident findings (Round 6)
- Review: CEO semantic acceptance in the merge session

---

# 中文

## 概要

五类治理 ingress 在生产上被 `AUTHORITY_*_SUBMISSION_UNAVAILABLE` 拒绝，堵死了
`task create`、`decision transition`、`task claim`、observed write 与 script ingest。
病因是**结构性的**，不是漏接了某一根线：提交能力被摊成**六个可选方法槽**，每一层包装都要
手工逐个转发，**漏掉任何一个在编译期完全合法**。本 PR 把它们收敛为**单一判别式入口**——
需要转发的能力只剩一个，漏掉一类 ingress 编译不过。

## 改动内容

- `DaemonAuthorityCommandSubmissionV2` 只暴露**一个**提交能力，入参是判别式联合
  `DaemonAuthorityCommandSubmissionInputV2`（`generic` / `provenance-session` /
  `decision-transition` / `task-claim` / `observed-write` / `script-ingest`），
  取代原来的 `submit` + 五个可选 `submitXxx`。
- 生产 compiler 对该判别式做**穷尽 switch**，收尾是
  `assertNeverSubmissionIngress(input: never)`，它在**运行时也会抛**
  `AUTHORITY_SUBMISSION_INGRESS_UNHANDLED`。新增 ingress 却不处理，`tsc` 直接报
  `TS2345 … not assignable to parameter of type 'never'`。
- 各层的逐方法转发全部删除。`production-authority-lifecycle.ts` 里 **16 行条件展开变成
  `...commandSubmission` 一行**。
- 五个 `AUTHORITY_*_SUBMISSION_UNAVAILABLE` 守卫被移除，因为它们守的状态——「某个可选方法
  不存在」——在收敛后**已不可表示**。单 canonical 操作与单 provenance session 两个守卫
  **未动**。
- `productionAuthorityCommandHasPurePlan` 现在排除**全部** `new-task`，而非仅
  `new-task` + `registerModule`：task 创建可能先发布一个 provenance-session 操作，
  单个固定持久计划表达不了两个 canonical 操作，因此整条命令留在 direct child lane。
  这是**收窄优化适用面**，不是放宽任何准入。
- 联合类型处写了范式说明：新增 ingress 请扩展联合与穷尽 switch，**不要再加提交方法**。

## 任务与范围

- Harness 任务：不适用；#1075 P5-W2 CH4 子写进程 cutover 事故的持续补救（承接 #1077、
  #1078、#1079、#1080、#1081）
- 分支：`codex/complete-submission-wrappers`
- 公开范围：`packages/daemon` 的 authority 命令提交、提交分发、生产 attempt compiler 与
  canonical intents、生产 authority lifecycle、pure command plan、progress-append 提交
- 私有计划 / 证据是否已更新：yes
- 范围外：本 PR 解锁之后的台账销账工作

## 版本影响

- 版本：不改版本，原因是未改动任何 wire 格式、持久 schema 或 receipt schema；收敛后的接口
  是 daemon 内部的
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用；`tools/check-pr-governance.mjs` 报告未触碰任何 manifest
  派生保护面
- 依据：本 PR 改变了 daemon 治理提交面的**形状**，属架构级决策。泽宇于 2026-07-24 的运营
  session 在同一缺陷族第三次复发后直接裁定要做，并明确要求**结果必须成为此后照抄的范式**，
  而不是又一次逐实例打补丁。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：两条决策待补记（写路径确认后立即办）——#1080 承诺的跨代终态化裁决，以及
  本次提交面收敛。两条都无法先落库，因为 `ha decision transition` 正是本 PR 要恢复的 ingress
  之一。

## 验证

- `origin/main` 基准 SHA：`209af4672f3161fd20bc8570295c73f354729952`
- 当前分支与 `origin/main` 的 merge-base：`209af4672f3161fd20bc8570295c73f354729952`
- 最近一次 `git fetch origin` 时间：2026-07-25，开 PR 前刚执行
- 同步方式：rebase 到当前 main（#1081 之后）
- 公开 diff 命令：`git diff 209af4672f3161fd20bc8570295c73f354729952...HEAD`
- 私有证据 commit/path：本 session 事故 findings（Round 6）
- Reviewer 证据路径：合并 session 的 CEO 语义验收
- GitHub Actions `rewrite-ci` run URL：待补，run 起来后回填
- [x] `git diff --check`
- [x] `npm run check:stop-point`——rebase 后 34 个完整 manifest 门全绿
- [x] 改动面的定向测试，写明测试名与通过数：`authority-submission-error.test.ts` 与
  `generic-ingress-rejections.ts` 覆盖每个判别式分支及其拒绝路径；focused seams 21/21；
  全量 fast 794/794；contract 841 通过、1 skip；`check:local` 的 affected fast 511/511、
  contract 223 通过（一个平台 skip）。
- [x] **防复发门的对抗式检查，由 CEO 亲跑且做了双侧对照**：分支原样 `npm run typecheck`
  退出 0；向 ingress 联合注入一个未处理的 `ceo-adversarial-probe` 成员后退出 2，报
  `TS2345 … not assignable to parameter of type 'never'`；随后还原探针并确认工作树干净。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）
- 未跑项及原因：本地未跑 `npm run check:ci`（本地全量预检器已退役，GitHub Actions 是权威）。
  开发全程未启动生产 daemon、未对其写入。端到端确认是合并、dist 重建、主动重启 daemon 之后，
  **对在役写进程逐一跑通每一类治理 ingress**。

## 审查证据

- 自查：CEO 通读完整 diff 并独立核实四点：运行时 `never` 分支仍会抛，因此绕过类型系统的
  调用方仍 fail-closed；单 canonical 操作与单 provenance session 两个守卫各 2 处、未变；
  被移除的 `SUBMISSION_UNAVAILABLE` 守卫所守的状态在收敛后不可表示，移除是**更强**而非更弱；
  `new-task` 的 pure-plan 改动是**收窄适用面**而非放宽准入。
- Reviewer subagent：Codex 完成收敛。CEO 前两版 brief 带着**错误前提**——以为是两个
  `AuthoritySubmissionService` wrapper 丢了方法——追到真正的声明类型后撤回；第三版才带上
  正确取证与「让这一族结构性不可能」的授权。
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 生产验证尚未进行。本次事故中上一次的端到端结论用的是**单条恰好不需要任何专用 ingress 的
  命令**，因此这次验收必须**逐个判别式跑**，不能用代表性命令背书。
- 运行时 `never` 抛只对绕过类型系统的调用方可达，它是兜底不是主门。
- 未执行 nightly canonical-ingress runner；它对既有 daemon-generation 环境做断言，裸跑会因
  无关原因失败。

## 关联材料

- 任务：不适用
- 证据：本 session 事故 findings（Round 6）
- 审查：合并 session 的 CEO 语义验收
