### PR TITLE
fix(authority): detect Unicode read-down path collisions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13210,6 +13210,7 @@
         "@effect/platform": "0.96.2",
         "@effect/sql": "0.51.1",
         "@effect/sql-sqlite-node": "0.52.0",
+        "@unicode/unicode-17.0.0": "1.6.17",
         "dependency-cruiser": "17.4.3",
         "effect": "3.21.4"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3231,6 +3231,12 @@
       "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
       "license": "ISC"
     },
+    "node_modules/@unicode/unicode-17.0.0": {
+      "version": "1.6.17",
+      "resolved": "https://registry.npmjs.org/@unicode/unicode-17.0.0/-/unicode-17.0.0-1.6.17.tgz",
+      "integrity": "sha512-TcBN39y5g7rmQbjnIDsW+4XlEXk6BnJMlhGyUHqUljp00affwlSLv5v7nB37pbdD/ks1BpptvILVQRMp34wPPw==",
+      "license": "MIT"
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
@@ -13191,7 +13197,8 @@
       "version": "0.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@harness-anything/kernel": "0.1.0"
+        "@harness-anything/kernel": "0.1.0",
+        "@unicode/unicode-17.0.0": "1.6.17"
       }
     },
     "packages/cli": {

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -17,6 +17,7 @@
     "./terminal-session-contract": "./src/terminal-session-contract.ts"
   },
   "dependencies": {
-    "@harness-anything/kernel": "0.1.0"
+    "@harness-anything/kernel": "0.1.0",
+    "@unicode/unicode-17.0.0": "1.6.17"
   }
 }

--- a/packages/application/src/namespace/policy.ts
+++ b/packages/application/src/namespace/policy.ts
@@ -1,3 +1,8 @@
+// The Unicode version is part of this collision-key contract. Keep both the
+// versioned package name and exact package version pinned; upgrades require an
+// explicit collision audit instead of inheriting Node/ICU data changes.
+import commonCaseFolding from "@unicode/unicode-17.0.0/Case_Folding/C/code-points.js";
+import fullCaseFolding from "@unicode/unicode-17.0.0/Case_Folding/F/code-points.js";
 import { NamespaceAdmissionError, portableAsciiV2, type PortablePathDescriptor, type PortablePathOptions } from "./types.ts";
 
 const portableSegment = /^(?:[A-Za-z0-9_][A-Za-z0-9._-]*|\.[A-Za-z0-9_][A-Za-z0-9._-]*)$/u;
@@ -44,9 +49,15 @@ export function validatePortableManagedPath(
 
 export function foldPortableComponent(segment: string): string {
   let folded = "";
-  for (let index = 0; index < segment.length; index += 1) {
-    const code = segment.charCodeAt(index);
-    folded += code >= 65 && code <= 90 ? String.fromCharCode(code + 32) : segment[index];
+  for (const character of segment) {
+    const codePoint = character.codePointAt(0)!;
+    const fullMapping = fullCaseFolding.get(codePoint);
+    if (fullMapping) {
+      folded += String.fromCodePoint(...fullMapping);
+      continue;
+    }
+    const commonMapping = commonCaseFolding.get(codePoint);
+    folded += commonMapping === undefined ? character : String.fromCodePoint(commonMapping);
   }
   return folded;
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,6 +47,7 @@
     "@effect/platform": "0.96.2",
     "@effect/sql": "0.51.1",
     "@effect/sql-sqlite-node": "0.52.0",
+    "@unicode/unicode-17.0.0": "1.6.17",
     "dependency-cruiser": "17.4.3",
     "effect": "3.21.4"
   },

--- a/packages/daemon/src/authority/replication-content-store.ts
+++ b/packages/daemon/src/authority/replication-content-store.ts
@@ -4,7 +4,8 @@ import type {
   ReplicaChangeRecord
 } from "@harness-anything/application";
 import {
-  foldPortableComponent
+  FoldedComponentTrie,
+  NamespaceAdmissionError
 } from "@harness-anything/application";
 import type { AuthoritySnapshotManifestEntry } from "./protocol.ts";
 import type { DurableAuthorityStateTable } from "./production/service-state.ts";
@@ -193,11 +194,14 @@ function readGitEntries(
       tombstone: false as const
     };
   }).sort(compareEntries);
-  const portableKeys = new Set<string>();
+  const portablePaths = new FoldedComponentTrie();
   for (const entry of entries) {
-    const portableKey = entry.path.split("/").map(foldPortableComponent).join("/");
-    if (portableKeys.has(portableKey)) throw new Error(`RESYNC_REQUIRED:PORTABLE_PATH_COLLISION:${portableKey}`);
-    portableKeys.add(portableKey);
+    try {
+      portablePaths.admit(entry.path.split("/"));
+    } catch (error) {
+      if (!(error instanceof NamespaceAdmissionError)) throw error;
+      throw new Error(`RESYNC_REQUIRED:PORTABLE_PATH_COLLISION:${entry.path}`, { cause: error });
+    }
   }
   return entries;
 }

--- a/packages/daemon/test/replication-content-history-path.test.ts
+++ b/packages/daemon/test/replication-content-history-path.test.ts
@@ -96,6 +96,44 @@ test("historical operation lookup hydrates an incomplete replica change containi
   }
 });
 
+test("read-down retains ASCII component-collision detection", () => {
+  assertPathCollision(["A/x.md", "a/y.md"]);
+});
+
+test("read-down rejects full Unicode case-folded component collisions", () => {
+  for (const paths of [["Ä/x.md", "ä/y.md"], ["Straße/x.md", "STRASSE/y.md"]]) {
+    assertPathCollision(paths);
+  }
+});
+
+test("read-down case folding does not normalize NFC and NFD spellings", () => {
+  const fixture = createFixture();
+  try {
+    const paths = ["café.md", "cafe\u0301.md"];
+    commitTreePaths(fixture.gitRoot, paths);
+    const commitSha = git(fixture.gitRoot, "rev-parse", "HEAD");
+    const snapshot = fixture.content.snapshot(commitSha, 0);
+    assert.deepEqual([...snapshot.entries.map((entry) => entry.path)].sort(), [...paths].sort());
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+function assertPathCollision(paths: ReadonlyArray<string>): void {
+  const fixture = createFixture();
+  try {
+    commitTreePaths(fixture.gitRoot, paths);
+    const commitSha = git(fixture.gitRoot, "rev-parse", "HEAD");
+    assert.throws(
+      () => fixture.content.snapshot(commitSha, 0),
+      /RESYNC_REQUIRED:PORTABLE_PATH_COLLISION/u,
+      paths.join(" vs ")
+    );
+  } finally {
+    fixture.cleanup();
+  }
+}
+
 function createFixture() {
   const root = mkdtempSync(path.join(tmpdir(), "ha-read-down-history-"));
   const gitRoot = path.join(root, "canonical");
@@ -118,6 +156,43 @@ function createFixture() {
   };
 }
 
+type GitTree = Map<string, GitTree | string>;
+
+function commitTreePaths(root: string, paths: ReadonlyArray<string>): void {
+  const blobSha = gitWithInput(root, ["hash-object", "-w", "--stdin"], Buffer.from("content\n"));
+  const tree: GitTree = new Map();
+  for (const managedPath of paths) {
+    const segments = managedPath.split("/");
+    let current = tree;
+    for (const segment of segments.slice(0, -1)) {
+      const existing = current.get(segment);
+      if (typeof existing === "string") throw new Error(`test tree file ancestor: ${managedPath}`);
+      const child = existing ?? new Map<string, GitTree | string>();
+      current.set(segment, child);
+      current = child;
+    }
+    current.set(segments.at(-1)!, blobSha);
+  }
+  const treeSha = writeTree(tree);
+  const commitSha = git(root, "commit-tree", treeSha, "-m", "plumbed paths");
+  git(root, "update-ref", "HEAD", commitSha);
+
+  function writeTree(node: GitTree): string {
+    const rows = [...node.entries()]
+      .sort(([left], [right]) => Buffer.compare(Buffer.from(left), Buffer.from(right)))
+      .map(([name, value]) => {
+        const objectId = typeof value === "string" ? value : writeTree(value);
+        const metadata = typeof value === "string" ? "100644 blob" : "040000 tree";
+        return Buffer.concat([Buffer.from(`${metadata} ${objectId}\t`), Buffer.from(name), Buffer.from([0])]);
+      });
+    return gitWithInput(root, ["mktree", "-z"], Buffer.concat(rows));
+  }
+}
+
 function git(root: string, ...args: string[]): string {
   return execFileSync("git", ["-C", root, ...args], { encoding: "utf8" }).trim();
+}
+
+function gitWithInput(root: string, args: ReadonlyArray<string>, input: Buffer): string {
+  return execFileSync("git", ["-C", root, ...args], { encoding: "utf8", input }).trim();
 }


### PR DESCRIPTION
# English

## Summary

PR #1081 relaxed read-down path validation so immutable Git history containing non-ASCII paths can be materialized. The collision detector guarding that materialization was not widened to match: `replication-content-store.ts` builds each `portableKey` with `foldPortableComponent`, which folded only `A`–`Z`. The result was a guard weaker than the surface it guards — `Ä/x.md` and `ä/y.md` materialize into the same directory on case-insensitive filesystems while the detector reports no collision. That is the exact failure mode `dec_01KXB70Z5MMKSYD7QGHGY9NJFW` was written to prevent; the original decision guarded it on an admission surface that has no production caller, leaving it open on the read-down path that does.

## What Changed

- `foldPortableComponent` now performs full Unicode case folding, applying the `F` (full) mapping when one exists and falling back to the `C` (common) mapping.
- Case-folding data comes from `@unicode/unicode-17.0.0`, so the Unicode version is part of the package name and is pinned by lockfile integrity. Node/ICU tables are deliberately not used, because a runtime upgrade must not be able to silently change collision keys.
- Regression tests cover the new Unicode collision case, an ASCII monotonicity control, and an explicit lock on current NFC/NFD behaviour.
- Second commit: the dependency is mirrored into `packages/cli/package.json`, because the packaged CLI inlines application sources without inheriting that package's dependencies.

## Task And Scope

- Harness task: `task_01KYAEWX4H8JB9JJTNHSF4W9YZ`
- Branch: `codex/unicode-read-down-casefold`
- Public scope: `packages/application/src/namespace/policy.ts`, `packages/daemon/src/authority/replication-content-store.ts`, `packages/daemon/test/replication-content-history-path.test.ts`, `packages/application/package.json`, `packages/cli/package.json`, `package-lock.json`
- Private planning/evidence updated: yes — findings under the task package `artifacts/`
- Out of scope: kernel `normalizeRelativeDocumentPath`, the CLI toolchain path copies, and retiring the unwired admission surface. Those belong to `dec_01KYAEPB4P4R2Q0B7MMH2QEHTR`, which is proposed and not yet adjudicated.

## Version Impact

- Version: no version change because this is a defect fix with no published-surface signature change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `package-lock.json` and `packages/*/package.json` — one third-party runtime dependency added, `@unicode/unicode-17.0.0@1.6.17` (MIT).
- Authority: `task_01KYAEWX4H8JB9JJTNHSF4W9YZ`. `dec_01KYAEPB4P4R2Q0B7MMH2QEHTR` is proposed but **not accepted**, and is deliberately not cited as authorization — this PR is scoped to a defect that stands on its own regardless of how that decision is adjudicated.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: adjudicate `dec_01KYAEPB4P4R2Q0B7MMH2QEHTR`, which covers converging the three fold rules onto one shared implementation.

## Verification

- Base `origin/main` SHA: `a3b9f5443d92fa226b3ed356481ab1003854f9a1`
- Branch merge-base with `origin/main`: `a3b9f5443d92fa226b3ed356481ab1003854f9a1`
- Last `git fetch origin` time: 2026-07-24T17:40Z
- Sync method: rebase onto `main` after #1084 landed the advisory bumps; both branches edit `package-lock.json`, so they were serialized deliberately rather than queued in parallel.
- Public diff command: `git diff a3b9f5443d92fa226b3ed356481ab1003854f9a1..037d43bc`
- Private evidence commit/path: `harness/tasks/task_01KYAEWX4H8JB9JJTNHSF4W9YZ-.../artifacts/unicode-read-down-casefold-findings.md`
- Reviewer evidence path: same task package `artifacts/`
- GitHub Actions `rewrite-ci` run URL: see the checks on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` — run on the final commit
- [x] Targeted tests for the change surface, named with their counts: daemon integration tier, `--prefix packages/daemon/test/`, run **both sides** by the CEO. With the implementation reverted and tests kept: **exactly 1 failure**, `read-down rejects full Unicode case-folded component collisions`, while `read-down retains ASCII component-collision detection` and `read-down case folding does not normalize NFC and NFD spellings` both still passed. With the implementation restored: 0 failures. `main` was run first on the same tier as a baseline and is green.
- [x] `node tools/run-manifest-gates.mjs --workflow-job package-policy` — reproduced the CI `smoke-cli-package` failure locally, then confirmed it passes after the packaging fix.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending on this PR.
- Not run, and why: no native Windows materialization test was run; the fixture builds Git trees with `git mktree -z` so it exercises immutable Git bytes rather than host filesystem behaviour. Cross-platform behaviour rests on the Unicode specification, not on measurement.

## Review Evidence

- Windows resolution: an earlier revision of this branch failed `windows-local-check` on `GUI evidence route reuses one daemon generation across an interaction pause`. That was **not** caused by this change. It was the reservation-reconciler self-deadlock fixed in PR #1085; after rebasing onto `a3b9f544` the job passes with no edit to this branch's diff. The competing hypothesis considered and discarded was that the 33MB `@unicode` package perturbed Windows module-resolution timing — discarded because two control PRs (#1084, #1085) passed the same job while carrying no such dependency, and because the rebase alone flipped it green.

- Self-review: CEO ran the double-sided control described above rather than accepting the worker's local green, because the new tests are integration tier and `check:local` does not run that tier — the worker's green could not have covered them.
- Reviewer subagent: not used; the CEO verified directly.
- Human review: pending.
- Blocking findings: one, found and fixed during acceptance — the first CI run failed `package-policy`. Root cause was that the packaged CLI inlines application sources but does not inherit that package's dependencies, so the published tarball could not resolve the new dependency at runtime. `smoke-cli-package` caught it; the gate worked as designed.

## Residual Risk

- NFC and NFD spellings of the same name are still **not** treated as colliding. This PR locks that as current behaviour with an explicit test rather than changing it.
- Kernel `normalizeRelativeDocumentPath` still uses `toLocaleLowerCase("en-US")`, which is not equivalent to full case folding. Three fold rules therefore still coexist, and which one evaluates a pair decides whether it collides. Converging them is the pending decision, not this PR.
- Mirroring third-party dependencies into `packages/cli/package.json` is a manual step that any future dependency addition to an inlined package must repeat. `smoke-cli-package` catches the omission, but only at CI time and with an error buried in a tarball resolution stack.

## References

- Task: `task_01KYAEWX4H8JB9JJTNHSF4W9YZ`
- Evidence: task package `artifacts/unicode-read-down-casefold-findings.md`; full-history collision scan of both repositories covering 23,354 current and 24,498 historical paths, with zero collision groups and zero non-NFC forms, and no persisted folded key anywhere — so this change needs no migration and invalidates no index.
- Review: `dec_01KXB70Z5MMKSYD7QGHGY9NJFW` (the original policy), `dec_01KYAEPB4P4R2Q0B7MMH2QEHTR` (proposed successor)

---

# 中文

## 概要

PR #1081 放宽了 read-down 的路径校验，使含非 ASCII 路径的不可变 Git 历史可以被物化。但守护物化的撞车检测器没有同步放宽认知：`replication-content-store.ts` 用 `foldPortableComponent` 构造 `portableKey`，而该折叠器**只折叠 `A`–`Z`**。后果是守卫比它守护的面更弱——`Ä/x.md` 与 `ä/y.md` 在大小写不敏感文件系统上会物化到同一目录，而检测器报告无撞车。**这正是 `dec_01KXB70Z5MMKSYD7QGHGY9NJFW` 当初要防的那个失败模式**：原决策把它防在了一个没有生产 caller 的准入面上，却漏在了真正接线的 read-down 路径上。

## 改动内容

- `foldPortableComponent` 改为执行完整 Unicode case folding：优先用 `F`（full）映射，无则回退 `C`（common）映射。
- case-folding 数据取自 `@unicode/unicode-17.0.0`——Unicode 版本写在**包名里**，精确版本由 lockfile integrity 钉死。**刻意不使用 Node/ICU 表**，因为运行时升级绝不能悄悄改变撞车 key。
- 回归测试覆盖新增的 Unicode 撞车用例、一条 ASCII 单调性对照，以及对当前 NFC/NFD 行为的显式锁定。
- 第二个提交：依赖镜像进 `packages/cli/package.json`，因为打包后的 CLI 内联了 application 源码却**不继承**该包的依赖。

## 任务与范围

- Harness 任务：`task_01KYAEWX4H8JB9JJTNHSF4W9YZ`
- 分支：`codex/unicode-read-down-casefold`
- 公开范围：`packages/application/src/namespace/policy.ts`、`packages/daemon/src/authority/replication-content-store.ts`、`packages/daemon/test/replication-content-history-path.test.ts`、`packages/application/package.json`、`packages/cli/package.json`、`package-lock.json`
- 私有计划／证据已更新：是——findings 落在任务包 `artifacts/`
- 不在范围：kernel `normalizeRelativeDocumentPath`、CLI 工具链的路径副本、以及退役那个未接线的准入面。三者属于 `dec_01KYAEPB4P4R2Q0B7MMH2QEHTR`，该决策已提出、尚未裁决。

## 版本影响

- 版本：不升版，因为这是缺陷修复，未改变已发布面的签名。
- 发布影响：不发布

## 治理声明

- 触碰 protected surface：是
- Protected surface 范围：`package-lock.json` 与 `packages/*/package.json`——新增一个第三方运行时依赖 `@unicode/unicode-17.0.0@1.6.17`（MIT）。
- 授权：`task_01KYAEWX4H8JB9JJTNHSF4W9YZ`。`dec_01KYAEPB4P4R2Q0B7MMH2QEHTR` **已提出但未接受**，**刻意不作为授权引用**——本 PR 只针对一个独立成立的缺陷，无论那条决策如何裁决都成立。
- 机器检查边界：本 PR 只断言声明存在；声明是否属实、是否充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：裁决 `dec_01KYAEPB4P4R2Q0B7MMH2QEHTR`，其中包含把三套折叠规则收敛为一份共享实现。

## 验证

- 基线 `origin/main` SHA：`a3b9f5443d92fa226b3ed356481ab1003854f9a1`
- 分支与 `origin/main` 的 merge-base：`a3b9f5443d92fa226b3ed356481ab1003854f9a1`
- 最近一次 `git fetch origin` 时间：2026-07-24T17:40Z
- 同步方式：在 #1084 合入公告升级后 rebase 到 `main`；两个分支都改 `package-lock.json`，故**刻意串行**而非并行入队。
- 公开 diff 命令：`git diff a3b9f5443d92fa226b3ed356481ab1003854f9a1..037d43bc`
- 私有证据提交／路径：`harness/tasks/task_01KYAEWX4H8JB9JJTNHSF4W9YZ-.../artifacts/unicode-read-down-casefold-findings.md`
- 评审证据路径：同一任务包 `artifacts/`
- GitHub Actions `rewrite-ci` 运行 URL：见本 PR 的 checks
- [x] `git diff --check`
- [x] `npm run check:stop-point`——在最终提交上跑过
- [x] 针对改动面的定向测试及其条数：daemon integration 档，`--prefix packages/daemon/test/`，由 CEO **双侧**各跑一次。还原实现、保留测试时：**恰好 1 条失败**——`read-down rejects full Unicode case-folded component collisions`；而 `read-down retains ASCII component-collision detection` 与 `read-down case folding does not normalize NFC and NFD spellings` **仍然通过**。恢复实现后：0 失败。先在同档跑了 `main` 作基线，全绿。
- [x] `node tools/run-manifest-gates.mjs --workflow-job package-policy`——本地复现了 CI 的 `smoke-cli-package` 失败，打包修复后确认通过。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威的完整门）——本 PR 上待跑。
- 未跑及原因：未做原生 Windows 物化测试；夹具用 `git mktree -z` 构造 Git tree，测的是不可变 Git 字节而非宿主文件系统行为。跨平台行为依据的是 Unicode 规范，不是实测。

## 审查证据

- Windows 红的归属：本分支早先版本在 `windows-local-check` 的 `GUI evidence route reuses one daemon generation across an interaction pause` 上失败。**不是本改动造成的**——真凶是 PR #1085 修掉的 reservation reconciler 自死锁；rebase 到 `a3b9f544` 后该 job 直接通过，本分支 diff 一行未改。被考虑并排除的竞争假设是「33MB 的 `@unicode` 包扰动了 Windows 的模块解析时序」——排除依据是两个对照 PR（#1084、#1085）在不带该依赖的情况下同样跑过这个 job，且仅靠 rebase 就翻绿。

- 自审：CEO 亲跑了上述双侧对照，**没有**采信 worker 的本地绿——新测试标在 integration 档，而 `check:local` **不跑该档**，worker 的绿不可能覆盖它们。
- 评审子代理：未使用；由 CEO 直接验证。
- 人工评审：待泽宇。
- 阻塞性发现：一条，在验收过程中发现并已修复——首次 CI 跑挂在 `package-policy`。根因是打包后的 CLI 内联 application 源码却不继承其依赖，导致发布 tarball 运行时解析不到新依赖。`smoke-cli-package` 抓到了它，**门按设计起了作用**。

## 残余风险

- 同一名字的 NFC 与 NFD 拼写仍**不**判为撞车。本 PR 用显式测试**锁定**这一现状，而非改变它。
- kernel 的 `normalizeRelativeDocumentPath` 仍用 `toLocaleLowerCase("en-US")`，与完整 case folding 不等价。因此三套折叠规则**仍然并存**，一对路径撞不撞车取决于由哪一套来判。收敛它们属于待裁决的那条决策，不属于本 PR。
- 把第三方依赖镜像进 `packages/cli/package.json` 是一个**手工步骤**，今后任何往被内联包里加依赖的改动都必须重复它。`smoke-cli-package` 能抓到遗漏，但只在 CI 时刻，且错误埋在 tarball 解析栈里。

## 关联材料

- 任务：`task_01KYAEWX4H8JB9JJTNHSF4W9YZ`
- 证据：任务包 `artifacts/unicode-read-down-casefold-findings.md`；两仓全历史撞车扫描，覆盖当前 23,354 条与历史 24,498 条路径，零撞车组、零非 NFC 形式，且无任何持久化 folded key——故本改动零迁移、零索引失效。
- 评审：`dec_01KXB70Z5MMKSYD7QGHGY9NJFW`（原策略）、`dec_01KYAEPB4P4R2Q0B7MMH2QEHTR`（提出中的后继）

