### PR TITLE
chore(deps): clear high and moderate advisories in transitive dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9282,9 +9282,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -10174,9 +10174,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -10194,7 +10194,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -11631,9 +11631,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {


### PR DESCRIPTION
# English

## Summary

`npm audit --audit-level=high` began failing on two newly published advisories in transitive dependencies, turning the `supply-chain` gate red on every open pull request and on `main` itself. This is a lockfile-only patch bump that clears both. It was found while accepting PR #1083, and `main` was verified red on the same check as a negative control, so the failure is not attributable to that PR.

## What Changed

- `postcss` 8.5.16 -> 8.5.23 — GHSA-r28c-9q8g-f849, path traversal in previous-source-map auto-loading via `sourceMappingURL`, leading to arbitrary `.map` file disclosure (high).
- `tar` 7.5.19 -> 7.5.22 — GHSA-r292-9mhp-454m, uncontrolled recursion in `mapHas`/`filesFilter` allowing an uncatchable stack-overflow denial of service via a crafted long-path archive (moderate).
- `nanoid` 3.3.12 -> 3.3.16, pulled in as a transitive requirement of the `postcss` bump.

No `package.json` manifest changed and no major or minor version boundary was crossed.

## Task And Scope

- Harness task: `task_01KYAJR8JPEGHXTYSJF5HY97PC`
- Branch: `fix/supply-chain-audit-advisories`
- Public scope: `package-lock.json`
- Private planning/evidence updated: not applicable
- Out of scope: the two remaining advisories are fully resolved by these bumps; no policy, allowlist, or license tuple was touched, and no audit exception was added.

## Version Impact

- Version: no version change because only transitive lockfile entries moved.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `package-lock.json`
- Authority: `task_01KYAJR8JPEGHXTYSJF5HY97PC`, opened under the standing fix-on-discovery authorization for defects that block the shared pipeline. No gate was weakened, no advisory was suppressed, and no exception entry was added — the advisories are actually resolved.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `d9a7c7e6e86a7b96c61790039bd2ef214e11ade4`
- Branch merge-base with `origin/main`: `d9a7c7e6e86a7b96c61790039bd2ef214e11ade4`
- Last `git fetch origin` time: 2026-07-24T17:10:14Z
- Sync method: none needed
- Public diff command: `git diff d9a7c7e6e86a7b96c61790039bd2ef214e11ade4..bd6b36d8`
- Private evidence commit/path: not applicable
- Reviewer evidence path: not applicable
- GitHub Actions `rewrite-ci` run URL: see the checks on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` — EXIT=0 on this commit
- [x] Targeted tests for the change surface, named with their counts: `npm run harness:check-supply-chain` — failed on `main` with 2 vulnerabilities (1 high, 1 moderate), passes on this branch with the CycloneDX SBOM and release/license gates.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending on this PR.
- Not run, and why: nothing omitted for this change surface. The bumps are patch-level and lockfile-only, so no behavioural test was written; the advisories themselves are the assertion.

## Review Evidence

- Self-review: negative control run first — `harness:check-supply-chain` was executed on `main` at `d9a7c7e6` and reproduced the identical two advisories, establishing that the failure predates and is independent of PR #1083. Without that control, this would have been dismissed as "unrelated to my change" on assumption rather than evidence.
- Reviewer subagent: not used.
- Human review: pending.
- Blocking findings: none.

## Residual Risk

- `npm audit` reads live registry data, so a gate that is green now can go red later with no repository change. This class of failure will recur whenever a new advisory lands against any transitive dependency, and it blocks every open pull request when it does.
- These are patch bumps of widely used packages taken without upstream changelog review; the local gate set passing is the evidence, not an upstream diff read.

## References

- Task: `task_01KYAJR8JPEGHXTYSJF5HY97PC`
- Evidence: GHSA-r28c-9q8g-f849 (postcss), GHSA-r292-9mhp-454m (tar)
- Review: found during CEO acceptance of PR #1083

---

# 中文

## 概要

`npm audit --audit-level=high` 因两条**新发布**的传递依赖安全公告开始失败，使 `supply-chain` 门在所有 open PR 以及 `main` 本身上全部变红。本 PR 是仅改 lockfile 的补丁级升级，清除这两条公告。它是在验收 PR #1083 时发现的；我先做了**阴性对照**——确认 `main` 在同一个门上同样是红的——因此该失败不归因于那个 PR。

## 改动内容

- `postcss` 8.5.16 -> 8.5.23——GHSA-r28c-9q8g-f849，经 `sourceMappingURL` 自动加载 previous source map 时的路径穿越，可导致任意 `.map` 文件泄露（high）。
- `tar` 7.5.19 -> 7.5.22——GHSA-r292-9mhp-454m，`mapHas`/`filesFilter` 中的不受控递归，可被构造的长路径归档触发不可捕获的栈溢出拒绝服务（moderate）。
- `nanoid` 3.3.12 -> 3.3.16，随 `postcss` 升级被一并带上的传递依赖。

**未改动任何 `package.json`**，也未跨越任何 major 或 minor 版本边界。

## 任务与范围

- Harness 任务：`task_01KYAJR8JPEGHXTYSJF5HY97PC`
- 分支：`fix/supply-chain-audit-advisories`
- 公开范围：`package-lock.json`
- 私有计划／证据已更新：不适用
- 不在范围：两条公告已由本次升级**实际解决**；未触碰任何策略、白名单或许可证 tuple，**未新增任何 audit 例外**。

## 版本影响

- 版本：不升版，仅移动传递依赖的 lockfile 条目。
- 发布影响：不发布

## 治理声明

- 触碰 protected surface：是
- Protected surface 范围：`package-lock.json`
- 授权：`task_01KYAJR8JPEGHXTYSJF5HY97PC`，依据对阻塞共享流水线的缺陷的「发现即修」常设授权开立。**未削弱任何门、未抑制任何公告、未添加任何例外条目**——公告是被真正修掉的。
- 机器检查边界：本 PR 只断言声明存在；声明是否属实、是否充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`d9a7c7e6e86a7b96c61790039bd2ef214e11ade4`
- 分支与 `origin/main` 的 merge-base：`d9a7c7e6e86a7b96c61790039bd2ef214e11ade4`
- 最近一次 `git fetch origin` 时间：2026-07-24T17:10:14Z
- 同步方式：无需同步
- 公开 diff 命令：`git diff d9a7c7e6e86a7b96c61790039bd2ef214e11ade4..bd6b36d8`
- 私有证据提交／路径：不适用
- 评审证据路径：不适用
- GitHub Actions `rewrite-ci` 运行 URL：见本 PR 的 checks
- [x] `git diff --check`
- [x] `npm run check:stop-point`——本提交上 EXIT=0
- [x] 针对改动面的定向测试及其条数：`npm run harness:check-supply-chain`——在 `main` 上以 2 条漏洞（1 high、1 moderate）失败，在本分支上连同 CycloneDX SBOM 与 release/license 门一起通过。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威的完整门）——本 PR 上待跑。
- 未跑及原因：针对本改动面没有遗漏项。升级是补丁级且仅动 lockfile，故未写行为测试；**公告本身就是那条断言**。

## 审查证据

- 自审：**先做阴性对照**——在 `main` 的 `d9a7c7e6` 上跑 `harness:check-supply-chain`，复现出完全相同的两条公告，从而证明该失败早于且独立于 PR #1083。**没有这个对照，这件事就会基于假设而不是证据被判成「与我的改动无关」。**
- 评审子代理：未使用。
- 人工评审：待泽宇。
- 阻塞性发现：无。

## 残余风险

- `npm audit` 读取的是**实时**registry 数据，因此现在绿的门可能在仓库毫无改动的情况下之后变红。只要有新公告命中任一传递依赖，这一类失败就会复发，且复发时会**阻塞所有 open PR**。
- 这些是被广泛使用的包的补丁升级，**未逐条阅读上游 changelog**；证据是本地门集通过，不是上游 diff 复核。

## 关联材料

- 任务：`task_01KYAJR8JPEGHXTYSJF5HY97PC`
- 证据：GHSA-r28c-9q8g-f849（postcss）、GHSA-r292-9mhp-454m（tar）
- 评审：在 CEO 验收 PR #1083 期间发现
