### PR TITLE
fix(daemon): break the reservation reconciler's self-deadlock on the write queue

### DIFF
--- a/packages/daemon/src/authority/authority-command-submission.ts
+++ b/packages/daemon/src/authority/authority-command-submission.ts
@@ -22,6 +22,7 @@ import type {
 } from "@harness-anything/kernel";
 import { taskEntityId } from "@harness-anything/kernel";
 import { measureCurrentDaemonRequestPerformancePhase } from "../observability/request-performance.ts";
+import { reportCurrentRepoWriteTelemetry } from "../runtime/repo-write-telemetry-context.ts";
 
 interface DaemonAuthoritySubmissionInputBaseV2 {
   readonly command: AuthorityHostCommand;
@@ -71,6 +72,7 @@ export function createDaemonAuthorityCommandSubmissionV2(options: {
   const submitAttempt = async (attempt: AuthorizedOperationAttemptV2): Promise<AuthorityOperationReceipt> => {
     const envelope = decodeSemanticMutationEnvelopeV2(attempt.envelope);
     const expectedOpId = operationIdDiagnosticV2(envelope.operationId);
+    reportCurrentRepoWriteTelemetry("git");
     const receipt = await options.authorityService.submitV2!(attempt);
     assertCompleteAuthorityReceiptV2(receipt);
     assertAuthorityReceiptOperation(receipt, expectedOpId);
@@ -78,6 +80,7 @@ export function createDaemonAuthorityCommandSubmissionV2(options: {
   };
   const compileAttempt = async (compile: () => Promise<AuthorizedOperationAttemptV2>) => {
     try {
+      reportCurrentRepoWriteTelemetry("compile");
       return await compile();
     } catch (cause) {
       throw authorityWriteRejected(

--- a/packages/daemon/src/authority/production/production-authority-lifecycle.ts
+++ b/packages/daemon/src/authority/production/production-authority-lifecycle.ts
@@ -68,6 +68,7 @@ import {
   type AuthorityProductionRepoConfigV1,
   type DurableAuthorityBindingRuntimeV2
 } from "./authority-production-state.ts";
+import { reportCurrentRepoWriteTelemetry } from "../../runtime/repo-write-telemetry-context.ts";
 import { withProductionRecoveryV2 } from "./authority-attribution-event-v2-production-recovery.ts";
 import { createProductionProgressAppendConnectionBinding } from "./production-progress-append-submission.ts";
 import { createProductionAuthoritySemanticCompiler } from "./production-authority-semantic-compiler.ts";
@@ -176,9 +177,13 @@ export function createProductionAuthorityLifecycle(input: {
       });
       const basePublisher = createDurableAuthorityCommittedEventPublisherV2({
         eventLog,
-        commitEvidence: evidenceCommitter.commitPending,
+        commitEvidence: async (canonicalCommitSha) => {
+          reportCurrentRepoWriteTelemetry("fsync");
+          await evidenceCommitter.commitPending(canonicalCommitSha);
+        },
         observation: {
           observe: async (request) => {
+            reportCurrentRepoWriteTelemetry("git");
             const inspect = publicationObservers.get(repo.repoId);
             if (!inspect) throw new Error("AUTHORITY_PRODUCTION_PUBLICATION_OBSERVER_UNAVAILABLE");
             const changes = await replicaChangeLog.changesAfter(request.workspaceId, 0);

--- a/packages/daemon/src/lifecycle/run-daemon-serve.ts
+++ b/packages/daemon/src/lifecycle/run-daemon-serve.ts
@@ -32,6 +32,10 @@ import {
   forkRepoWriteProcess
 } from "../runtime/repo-write-child-process-transport.ts";
 import {
+  formatRepoWriteFailureDiagnostic,
+  formatRepoWriteTimeoutDiagnostic
+} from "../runtime/repo-write-stall-diagnostic.ts";
+import {
   RepoWriteProcessSupervisor
 } from "../runtime/repo-write-process-supervisor.ts";
 import {
@@ -274,6 +278,28 @@ export async function runDaemonServe<
                 message: `Deferred repo-write historical recovery for outerOpId=${frame.outerOpId}: ${frame.diagnostic}`,
                 errorCode: frame.code,
                 requestId: frame.outerOpId
+              }, { repo }).catch(() => undefined);
+            },
+            onRequestTimeout: (diagnostic) => {
+              void daemonLogService.append({
+                level: "error",
+                source: "daemon",
+                component: "repo-write-child",
+                event: "repo-write.request.timeout",
+                message: formatRepoWriteTimeoutDiagnostic(diagnostic),
+                errorCode: "REPO_WRITE_REQUEST_TIMEOUT",
+                requestId: diagnostic.requestId
+              }, { repo }).catch(() => undefined);
+            },
+            onRequestFailure: (diagnostic) => {
+              void daemonLogService.append({
+                level: "error",
+                source: "daemon",
+                component: "repo-write-child",
+                event: "repo-write.request.failure",
+                message: formatRepoWriteFailureDiagnostic(diagnostic),
+                errorCode: diagnostic.code,
+                requestId: diagnostic.requestId
               }, { repo }).catch(() => undefined);
             }
           });

--- a/packages/daemon/src/runtime/authority-publication.ts
+++ b/packages/daemon/src/runtime/authority-publication.ts
@@ -1,6 +1,10 @@
 import type { FlushReport, LedgerMaterializerReport } from "@harness-anything/kernel";
 import type { DaemonWriteQueue } from "./write-queue.ts";
 import { measureCurrentDaemonRequestPerformancePhase } from "../observability/request-performance.ts";
+import {
+  bindCurrentRepoWriteTelemetry,
+  reportCurrentRepoWriteTelemetry
+} from "./repo-write-telemetry-context.ts";
 
 export interface DaemonAuthorityPublicationOptions {
   readonly sessionId: string;
@@ -17,22 +21,28 @@ export function enqueueDaemonAuthorityPublication(
   options: DaemonAuthorityPublicationOptions,
   materialize: (sessionId: string) => LedgerMaterializerReport
 ): Promise<DaemonAuthorityPublicationReport> {
+  reportCurrentRepoWriteTelemetry("projection");
   return queue.enqueueBackground({
     source: "authority-publication",
     priority: "normal",
-    run: async () => {
+    run: bindCurrentRepoWriteTelemetry(async () => {
+      reportCurrentRepoWriteTelemetry("materializer");
       const flush = await measureCurrentDaemonRequestPerformancePhase(
         "durable-flush",
         options.publish
       );
+      reportCurrentRepoWriteTelemetry("git");
       if (!flush.committed || flush.opCount === 0) return { flush };
-      return {
+      reportCurrentRepoWriteTelemetry("fsync");
+      const result = {
         flush,
         materialization: measureCurrentDaemonRequestPerformancePhase(
           "materializer",
           () => materialize(options.sessionId)
         )
       };
-    }
+      reportCurrentRepoWriteTelemetry("total");
+      return result;
+    })
   });
 }

--- a/packages/daemon/src/runtime/repo-runtime.ts
+++ b/packages/daemon/src/runtime/repo-runtime.ts
@@ -75,6 +75,7 @@ import {
 } from "./projection-generation-manager.ts";
 import { toDaemonRuntimeStatus } from "./repo-runtime-status.ts";
 import { defaultDaemonRuntimePolicy } from "./runtime-policy.ts";
+import { ReservationReconcilerRunner } from "./reservation-reconciler-runner.ts";
 
 const defaultDaemonOperationalActor: OperationalActor = { scope: "operational", kind: "system", id: "daemon-runtime" };
 
@@ -207,6 +208,7 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
   private lastError: string | undefined;
   private lastMaterializerError: string | undefined;
   private materializerTimer: ReturnType<typeof setInterval> | undefined;
+  private readonly reservationReconciler: ReservationReconcilerRunner;
   private runtimeRegistrationId: string | undefined;
 
   constructor(options: DaemonRepoRuntimeOptions) {
@@ -227,6 +229,15 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
       this.admissionBudget
     );
     this.projectionGeneration = this.createProjectionGenerationManager();
+    this.reservationReconciler = new ReservationReconcilerRunner(
+      options.reservationReconciler,
+      {
+        rootDir: this.rootDir,
+        ...(options.layoutOverrides ? {
+          layoutOverrides: options.layoutOverrides
+        } : {})
+      }
+    );
   }
 
   start(): Promise<DaemonRuntimeStatus> {
@@ -262,7 +273,7 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
       this.lastError = undefined;
       this.lastMaterializerError = undefined;
       this.state = "attached";
-      await this.enqueueReservationReconciler();
+      await this.reservationReconciler.run();
       if (this.options.generationAxes) this.runtimeRegistrationId = randomUUID();
       this.startMaterializerTimer();
       return this.status();
@@ -472,7 +483,7 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
       return;
     }
     this.materializerTimer = setInterval(() => {
-      void this.enqueueReservationReconciler().catch(() => undefined);
+      void this.reservationReconciler.run().catch(() => undefined);
       void this.enqueueMaterializerBatch().catch(() => undefined);
     }, this.options.materializerPollMs);
     this.materializerTimer.unref();
@@ -494,18 +505,6 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
       this.lastMaterializerError = undefined;
     }
     return report;
-  }
-
-  private enqueueReservationReconciler(): Promise<void> {
-    if (!this.options.reservationReconciler) return Promise.resolve();
-    return this.enqueueBackgroundBatch({
-      source: "execution-reservation-reconciler",
-      priority: "background",
-      run: () => this.options.reservationReconciler!({
-        rootDir: this.rootDir,
-        ...(this.options.layoutOverrides ? { layoutOverrides: this.options.layoutOverrides } : {})
-      })
-    });
   }
 
   private stopMaterializerTimer(): void {

--- a/packages/daemon/src/runtime/repo-write-child-direct.ts
+++ b/packages/daemon/src/runtime/repo-write-child-direct.ts
@@ -4,6 +4,11 @@ import type {
 } from "./repo-write-protocol.ts";
 import type { RepoWriteChildResponseWriter } from "./repo-write-child-response-writer.ts";
 import type { RepoWriteExecutionSequencer } from "./repo-write-execution-sequencer.ts";
+import {
+  createRepoWriteTelemetryDelivery,
+  reportCurrentRepoWriteTelemetry,
+  runWithRepoWriteTelemetry
+} from "./repo-write-telemetry-context.ts";
 
 export interface RepoWriteDirectInput {
   readonly repoId: string;
@@ -82,15 +87,25 @@ export async function executeRepoWriteChildDirect(
   options.requestIds.add(message.requestId);
   options.admit();
   try {
-    const receipt = await options.sequencer.run(() =>
-      options.execute({
-        repoId: options.repoId,
-        workspaceId: options.workspaceId,
-        generation: options.generation,
-        requestId: message.requestId,
-        command: message.command
+    await options.responses.telemetry(message.requestId, "queue", 0);
+    const telemetry = createRepoWriteTelemetryDelivery(
+      (phase, elapsedMs) =>
+        options.responses.telemetry(message.requestId, phase, elapsedMs)
+    );
+    const receipt = await runWithRepoWriteTelemetry(
+      telemetry.report,
+      () => options.sequencer.run(() => {
+        reportCurrentRepoWriteTelemetry("compile");
+        return options.execute({
+          repoId: options.repoId,
+          workspaceId: options.workspaceId,
+          generation: options.generation,
+          requestId: message.requestId,
+          command: message.command
+        });
       })
     );
+    await telemetry.flush();
     await options.responses.directResult(message.requestId, receipt);
   } catch (error) {
     await options.responses.directUnknown(

--- a/packages/daemon/src/runtime/repo-write-child-host.ts
+++ b/packages/daemon/src/runtime/repo-write-child-host.ts
@@ -19,6 +19,12 @@ import { RepoWriteExecutionSequencer } from "./repo-write-execution-sequencer.ts
 import {
   executeRepoWriteChildDirect
 } from "./repo-write-child-direct.ts";
+import {
+  createRepoWriteTelemetryDelivery,
+  reportCurrentRepoWriteTelemetry,
+  runWithRepoWriteTelemetry,
+  type RepoWriteTelemetryDelivery
+} from "./repo-write-telemetry-context.ts";
 import type {
   RepoWriteChildHostLimits,
   RepoWriteChildHostOptions,
@@ -43,6 +49,7 @@ interface HostedOperation {
   opId?: string;
   execute?: RepoWritePreparedOperation["execute"];
   receipt?: RepoWriteJsonObject;
+  telemetry?: RepoWriteTelemetryDelivery;
   admitted: boolean;
   cancelledBeforeProceed?: boolean;
 }
@@ -198,12 +205,22 @@ export class RepoWriteChildHost {
     this.operationsByRequest.set(message.requestId, operation);
     this.activeAdmissions += 1;
     try {
-      const prepared = await this.options.hooks.prepare({
-        repoId: this.options.repoId,
-        generation: this.options.generation,
-        requestId: message.requestId,
-        command: message.command
+      await this.responses.telemetry(message.requestId, "queue", 0);
+      const telemetry = createRepoWriteTelemetryDelivery(
+        (phase, elapsedMs) =>
+          this.responses.telemetry(message.requestId, phase, elapsedMs)
+      );
+      operation.telemetry = telemetry;
+      const prepared = await runWithRepoWriteTelemetry(telemetry.report, () => {
+        reportCurrentRepoWriteTelemetry("compile");
+        return this.options.hooks.prepare({
+          repoId: this.options.repoId,
+          generation: this.options.generation,
+          requestId: message.requestId,
+          command: message.command
+        });
       });
+      await telemetry.flush();
       if (!prepared.opId.trim()) throw new Error("prepare returned an empty opId");
       operation.opId = prepared.opId;
       if (this.operationsById.has(prepared.opId)) {
@@ -229,7 +246,10 @@ export class RepoWriteChildHost {
         );
         return;
       }
-      operation.execute = prepared.execute;
+      operation.execute = () => runWithRepoWriteTelemetry(telemetry.report, () => {
+        reportCurrentRepoWriteTelemetry("journal");
+        return prepared.execute();
+      });
       operation.phase = "prepared";
       await this.responses.prepared(message.requestId, prepared.opId);
     } catch (error) {
@@ -290,6 +310,7 @@ export class RepoWriteChildHost {
         const durableOutcome = decodeRepoWriteOutcomeV1(
           await this.executionSequencer.run(operation.execute!)
         );
+        await operation.telemetry?.flush();
         if (durableOutcome.phase !== "TERMINAL" || durableOutcome.outerOpId !== operation.opId) {
           throw new Error("execution did not return the matching durable TERMINAL outer outcome");
         }
@@ -297,6 +318,7 @@ export class RepoWriteChildHost {
         receipt = durableOutcome.receipt as unknown as RepoWriteJsonObject;
         operation.phase = durableOutcome.terminalKind;
       } catch (error) {
+        await operation.telemetry?.flush();
         operation.phase = "unknown";
         this.release(operation);
         await this.responses.unknown(

--- a/packages/daemon/src/runtime/repo-write-child-response-writer.ts
+++ b/packages/daemon/src/runtime/repo-write-child-response-writer.ts
@@ -5,6 +5,7 @@ import {
   type RepoWriteChildMessage,
   type RepoWriteJsonObject,
   type RepoWriteOperationLookupResult,
+  type RepoWriteTelemetryPhase,
   type RepoWriteTerminalOutcome
 } from "./repo-write-protocol.ts";
 
@@ -81,6 +82,20 @@ export class RepoWriteChildResponseWriter {
       kind: "direct-result",
       requestId,
       receipt: receipt as RepoWriteJsonObject
+    });
+  }
+
+  telemetry(
+    requestId: string,
+    phase: RepoWriteTelemetryPhase,
+    elapsedMs: number
+  ): Promise<void> {
+    return this.send({
+      ...this.frameBase(),
+      kind: "telemetry",
+      requestId,
+      phase,
+      elapsedMs
     });
   }
 

--- a/packages/daemon/src/runtime/repo-write-client-contract.ts
+++ b/packages/daemon/src/runtime/repo-write-client-contract.ts
@@ -29,6 +29,23 @@ export interface RepoWriteClientLimits {
   readonly requestTimeoutMs: number;
 }
 
+export interface RepoWriteRequestDiagnostic {
+  readonly requestId: string;
+  readonly commandName: string;
+  readonly lane: "durable" | "direct" | "lookup";
+  readonly opId?: string;
+  readonly lastTelemetry?: RepoWriteTelemetryFrame;
+}
+
+export interface RepoWriteRequestTimeoutDiagnostic extends RepoWriteRequestDiagnostic {
+  readonly deadlineMs: number;
+}
+
+export interface RepoWriteRequestFailureDiagnostic extends RepoWriteRequestDiagnostic {
+  readonly code: string;
+  readonly diagnostic: string;
+}
+
 export interface RepoWriteClientOptions {
   readonly repoId: string;
   readonly generation: number;
@@ -37,6 +54,12 @@ export interface RepoWriteClientOptions {
   readonly limits?: Partial<RepoWriteClientLimits>;
   readonly onTelemetry: (frame: RepoWriteTelemetryFrame) => void;
   readonly onDiagnostic?: (frame: RepoWriteRecoveryDeferredFrame) => void;
+  readonly onRequestTimeout?: (
+    diagnostic: RepoWriteRequestTimeoutDiagnostic
+  ) => void;
+  readonly onRequestFailure?: (
+    diagnostic: RepoWriteRequestFailureDiagnostic
+  ) => void;
   readonly onProtocolViolation?: (
     error: RepoWriteProtocolViolationError
   ) => void;

--- a/packages/daemon/src/runtime/repo-write-client-direct.ts
+++ b/packages/daemon/src/runtime/repo-write-client-direct.ts
@@ -9,6 +9,15 @@ import {
   type RepoWriteTelemetryFrame
 } from "./repo-write-protocol.ts";
 import type { RepoWriteClientTransport } from "./repo-write-client-contract.ts";
+import type {
+  RepoWriteRequestFailureDiagnostic,
+  RepoWriteRequestTimeoutDiagnostic
+} from "./repo-write-client-contract.ts";
+import {
+  observeRepoWriteRequestFailure,
+  observeRepoWriteRequestTimeout,
+  repoWriteTelemetryTimeoutSuffix
+} from "./repo-write-client-timeout.ts";
 import {
   RepoWriteDirectOutcomeUnknownError,
   RepoWriteNotStartedError,
@@ -22,6 +31,7 @@ interface PendingDirect {
   readonly reject: (error: Error) => void;
   readonly timer: NodeJS.Timeout;
   phase: "queued" | "sent";
+  lastTelemetry?: RepoWriteTelemetryFrame;
 }
 
 export interface RepoWriteDirectClientLaneOptions {
@@ -30,6 +40,10 @@ export interface RepoWriteDirectClientLaneOptions {
   readonly requestTimeoutMs: number;
   readonly transport: RepoWriteClientTransport;
   readonly failProtocol: (message: string) => void;
+  readonly onRequestTimeout?: (diagnostic: RepoWriteRequestTimeoutDiagnostic) => void;
+  readonly onRequestFailure?: (
+    diagnostic: RepoWriteRequestFailureDiagnostic
+  ) => void;
 }
 
 export class RepoWriteDirectClientLane {
@@ -96,6 +110,14 @@ export class RepoWriteDirectClientLane {
     }
     clearTimeout(pending.timer);
     this.pending.delete(message.requestId);
+    observeRepoWriteRequestFailure(this.options.onRequestFailure, {
+      requestId: message.requestId,
+      commandName: pending.command.commandName,
+      lane: "direct",
+      code: message.code,
+      diagnostic: message.diagnostic,
+      ...(pending.lastTelemetry ? { lastTelemetry: pending.lastTelemetry } : {})
+    });
     pending.reject(new RepoWriteDirectOutcomeUnknownError(message.code, message.diagnostic));
   }
 
@@ -109,6 +131,14 @@ export class RepoWriteDirectClientLane {
     }
     clearTimeout(pending.timer);
     this.pending.delete(message.requestId);
+    observeRepoWriteRequestFailure(this.options.onRequestFailure, {
+      requestId: message.requestId,
+      commandName: pending.command.commandName,
+      lane: "direct",
+      code: message.code,
+      diagnostic: message.diagnostic,
+      ...(pending.lastTelemetry ? { lastTelemetry: pending.lastTelemetry } : {})
+    });
     pending.reject(new RepoWriteNotStartedError(message.code, message.diagnostic));
     return true;
   }
@@ -144,6 +174,11 @@ export class RepoWriteDirectClientLane {
     return pending?.phase === "sent" && message.opId === undefined;
   }
 
+  recordTelemetry(message: RepoWriteTelemetryFrame): void {
+    const pending = this.pending.get(message.requestId);
+    if (pending?.phase === "sent") pending.lastTelemetry = message;
+  }
+
   private dispatch(requestId: string): void {
     const pending = this.pending.get(requestId);
     if (!pending || pending.phase !== "queued") return;
@@ -170,7 +205,15 @@ export class RepoWriteDirectClientLane {
     if (!pending) return;
     this.pending.delete(requestId);
     const diagnostic =
-      `Repo writer direct request exceeded its ${this.options.requestTimeoutMs}ms deadline.`;
+      `Repo writer direct request exceeded its ${this.options.requestTimeoutMs}ms deadline.`
+      + repoWriteTelemetryTimeoutSuffix(pending.lastTelemetry);
+    observeRepoWriteRequestTimeout(this.options.onRequestTimeout, {
+      requestId,
+      commandName: pending.command.commandName,
+      lane: "direct",
+      deadlineMs: this.options.requestTimeoutMs,
+      ...(pending.lastTelemetry ? { lastTelemetry: pending.lastTelemetry } : {})
+    });
     pending.reject(pending.phase === "sent"
       ? new RepoWriteDirectOutcomeUnknownError("REPO_WRITE_DIRECT_TIMEOUT", diagnostic)
       : new RepoWriteNotStartedError("REPO_WRITE_DIRECT_TIMEOUT", diagnostic));

--- a/packages/daemon/src/runtime/repo-write-client-pending.ts
+++ b/packages/daemon/src/runtime/repo-write-client-pending.ts
@@ -1,7 +1,8 @@
 import type {
   RepoWriteCommandDto,
   RepoWriteJsonObject,
-  RepoWriteOperationLookupResult
+  RepoWriteOperationLookupResult,
+  RepoWriteTelemetryFrame
 } from "./repo-write-protocol.ts";
 
 export interface PendingSubmit {
@@ -12,6 +13,7 @@ export interface PendingSubmit {
   readonly timer: NodeJS.Timeout;
   phase: "queued" | "submitted" | "prepared" | "proceeded";
   opId?: string;
+  lastTelemetry?: RepoWriteTelemetryFrame;
 }
 
 export interface PendingLookup {
@@ -21,6 +23,7 @@ export interface PendingLookup {
   readonly reject: (error: Error) => void;
   readonly timer: NodeJS.Timeout;
   phase: "queued" | "sent";
+  lastTelemetry?: RepoWriteTelemetryFrame;
 }
 
 export interface PendingShutdown {

--- a/packages/daemon/src/runtime/repo-write-client-telemetry.ts
+++ b/packages/daemon/src/runtime/repo-write-client-telemetry.ts
@@ -1,0 +1,46 @@
+import type { RepoWriteDirectClientLane } from "./repo-write-client-direct.ts";
+import type {
+  PendingLookup,
+  PendingShutdown,
+  PendingSubmit
+} from "./repo-write-client-pending.ts";
+import type { RepoWriteTelemetryFrame } from "./repo-write-protocol.ts";
+
+export function repoWriteTelemetryMatchesPendingRequest(
+  message: RepoWriteTelemetryFrame,
+  submits: ReadonlyMap<string, PendingSubmit>,
+  lookups: ReadonlyMap<string, PendingLookup>,
+  direct: RepoWriteDirectClientLane,
+  shutdown: PendingShutdown | undefined
+): boolean {
+  const submit = submits.get(message.requestId);
+  if (submit) return message.opId === undefined || submit.opId === message.opId;
+  const lookup = lookups.get(message.requestId);
+  if (lookup) {
+    return lookup.phase === "sent"
+      && (message.opId === undefined || lookup.opId === message.opId);
+  }
+  if (direct.telemetryMatches(message)) return true;
+  return shutdown?.sent === true
+    && shutdown.requestId === message.requestId
+    && message.opId === undefined;
+}
+
+export function recordRepoWriteClientTelemetry(
+  message: RepoWriteTelemetryFrame,
+  submits: Map<string, PendingSubmit>,
+  lookups: Map<string, PendingLookup>,
+  direct: RepoWriteDirectClientLane
+): void {
+  const submit = submits.get(message.requestId);
+  if (submit) {
+    submit.lastTelemetry = message;
+    return;
+  }
+  const lookup = lookups.get(message.requestId);
+  if (lookup) {
+    lookup.lastTelemetry = message;
+    return;
+  }
+  direct.recordTelemetry(message);
+}

--- a/packages/daemon/src/runtime/repo-write-client-timeout.ts
+++ b/packages/daemon/src/runtime/repo-write-client-timeout.ts
@@ -1,0 +1,143 @@
+import type {
+  PendingLookup,
+  PendingSubmit
+} from "./repo-write-client-pending.ts";
+import type {
+  RepoWriteRequestFailureDiagnostic,
+  RepoWriteRequestTimeoutDiagnostic
+} from "./repo-write-client-contract.ts";
+import {
+  RepoWriteLookupError,
+  RepoWriteNotStartedError,
+  RepoWriteOutcomeUnknownError
+} from "./repo-write-client-errors.ts";
+import type {
+  RepoWriteFailureFrame,
+  RepoWriteTelemetryFrame
+} from "./repo-write-protocol.ts";
+
+type TimeoutObserver = (
+  diagnostic: RepoWriteRequestTimeoutDiagnostic
+) => void;
+type FailureObserver = (
+  diagnostic: RepoWriteRequestFailureDiagnostic
+) => void;
+
+export function expireRepoWriteSubmit(
+  pending: PendingSubmit,
+  timeoutMs: number,
+  observer: TimeoutObserver | undefined
+): void {
+  const diagnostic =
+    `Repo writer request exceeded its ${timeoutMs}ms deadline.`
+    + repoWriteTelemetryTimeoutSuffix(pending.lastTelemetry);
+  observeRepoWriteRequestTimeout(observer, {
+    requestId: pending.requestId,
+    commandName: pending.command.commandName,
+    lane: "durable",
+    deadlineMs: timeoutMs,
+    ...(pending.opId ? { opId: pending.opId } : {}),
+    ...(pending.lastTelemetry ? { lastTelemetry: pending.lastTelemetry } : {})
+  });
+  pending.reject(pending.phase === "proceeded" && pending.opId
+    ? new RepoWriteOutcomeUnknownError(
+        "REPO_WRITE_REQUEST_TIMEOUT",
+        diagnostic,
+        pending.opId
+      )
+    : new RepoWriteNotStartedError(
+        "REPO_WRITE_REQUEST_TIMEOUT",
+        diagnostic,
+        pending.opId
+      ));
+}
+
+export function expireRepoWriteLookup(
+  pending: PendingLookup,
+  timeoutMs: number,
+  observer: TimeoutObserver | undefined
+): void {
+  observeRepoWriteRequestTimeout(observer, {
+    requestId: pending.requestId,
+    commandName: "repo-write.lookup",
+    lane: "lookup",
+    deadlineMs: timeoutMs,
+    opId: pending.opId,
+    ...(pending.lastTelemetry ? { lastTelemetry: pending.lastTelemetry } : {})
+  });
+  pending.reject(new RepoWriteLookupError(
+    "REPO_WRITE_LOOKUP_TIMEOUT",
+    `Repo writer lookup exceeded its ${timeoutMs}ms deadline.`,
+    pending.opId
+  ));
+}
+
+export function failRepoWriteLookup(
+  pending: PendingLookup,
+  message: RepoWriteFailureFrame,
+  observer: FailureObserver | undefined
+): void {
+  observeRepoWriteRequestFailure(observer, {
+    requestId: message.requestId,
+    commandName: "repo-write.lookup",
+    lane: "lookup",
+    code: message.code,
+    diagnostic: message.diagnostic,
+    opId: pending.opId,
+    ...(pending.lastTelemetry ? { lastTelemetry: pending.lastTelemetry } : {})
+  });
+  pending.reject(new RepoWriteLookupError(
+    message.code,
+    message.diagnostic,
+    pending.opId
+  ));
+}
+
+export function failRepoWriteSubmit(
+  pending: PendingSubmit,
+  message: RepoWriteFailureFrame,
+  observer: FailureObserver | undefined
+): void {
+  observeRepoWriteRequestFailure(observer, {
+    requestId: message.requestId,
+    commandName: pending.command.commandName,
+    lane: "durable",
+    code: message.code,
+    diagnostic: message.diagnostic,
+    ...(message.opId ? { opId: message.opId } : {}),
+    ...(pending.lastTelemetry ? { lastTelemetry: pending.lastTelemetry } : {})
+  });
+  pending.reject(message.outcome === "not-started"
+    ? new RepoWriteNotStartedError(message.code, message.diagnostic, message.opId)
+    : new RepoWriteOutcomeUnknownError(message.code, message.diagnostic, message.opId));
+}
+
+export function observeRepoWriteRequestTimeout(
+  observer: TimeoutObserver | undefined,
+  diagnostic: RepoWriteRequestTimeoutDiagnostic
+): void {
+  try {
+    observer?.(diagnostic);
+  } catch {
+    // Operational logging cannot change the fail-closed timeout outcome.
+  }
+}
+
+export function observeRepoWriteRequestFailure(
+  observer: FailureObserver | undefined,
+  diagnostic: RepoWriteRequestFailureDiagnostic
+): void {
+  try {
+    observer?.(diagnostic);
+  } catch {
+    // Operational logging cannot change the fail-closed failure outcome.
+  }
+}
+
+export function repoWriteTelemetryTimeoutSuffix(
+  telemetry: RepoWriteTelemetryFrame | undefined
+): string {
+  return telemetry
+    ? ` Child last reported phase=${telemetry.phase} at elapsedMs=${Math.round(telemetry.elapsedMs)}.`
+    : " Child reported no execution phase.";
+}

--- a/packages/daemon/src/runtime/repo-write-client.ts
+++ b/packages/daemon/src/runtime/repo-write-client.ts
@@ -3,8 +3,7 @@ import {
   type RepoWriteChildMessage,
   type RepoWriteCommandDto,
   type RepoWriteJsonObject,
-  type RepoWriteOperationLookupResult,
-  type RepoWriteTelemetryFrame
+  type RepoWriteOperationLookupResult
 } from "./repo-write-protocol.ts";
 import { repoWriteTerminalReceiptMatches } from "./repo-write-terminal-receipt.ts";
 import { RepoWriteDirectClientLane } from "./repo-write-client-direct.ts";
@@ -16,6 +15,16 @@ import type {
 } from "./repo-write-client-pending.ts";
 import { defaultRepoWriteRequestTimeoutMs } from "./repo-write-client-contract.ts";
 import type { RepoWriteClientLimits, RepoWriteClientOptions } from "./repo-write-client-contract.ts";
+import {
+  expireRepoWriteLookup,
+  expireRepoWriteSubmit,
+  failRepoWriteLookup,
+  failRepoWriteSubmit
+} from "./repo-write-client-timeout.ts";
+import {
+  recordRepoWriteClientTelemetry,
+  repoWriteTelemetryMatchesPendingRequest
+} from "./repo-write-client-telemetry.ts";
 import {
   observeRepoWriteRecoveryDiagnostic,
   observeRepoWriteTelemetry,
@@ -85,7 +94,9 @@ export class RepoWriteClient {
       generation: options.generation,
       requestTimeoutMs: this.limits.requestTimeoutMs,
       transport: options.transport,
-      failProtocol: (message) => this.failProtocol(message)
+      failProtocol: (message) => this.failProtocol(message),
+      onRequestTimeout: options.onRequestTimeout,
+      onRequestFailure: options.onRequestFailure
     });
     options.transport.onMessage((message) => this.handleMessage(message));
     options.transport.onDisconnect((error) => this.handleDisconnect(error));
@@ -320,10 +331,22 @@ export class RepoWriteClient {
       return;
     }
     if (message.kind === "telemetry") {
-      if (!this.telemetryMatchesPendingRequest(message)) {
+      if (!repoWriteTelemetryMatchesPendingRequest(
+        message,
+        this.pending,
+        this.pendingLookups,
+        this.directLane,
+        this.shutdownPending
+      )) {
         this.failProtocol("Repo writer telemetry does not match a pending request.");
         return;
       }
+      recordRepoWriteClientTelemetry(
+        message,
+        this.pending,
+        this.pendingLookups,
+        this.directLane
+      );
       observeRepoWriteTelemetry(
         this.options.onTelemetry,
         message,
@@ -354,7 +377,7 @@ export class RepoWriteClient {
         }
         clearTimeout(lookup.timer);
         this.pendingLookups.delete(message.requestId);
-        lookup.reject(new RepoWriteLookupError(message.code, message.diagnostic, lookup.opId));
+        failRepoWriteLookup(lookup, message, this.options.onRequestFailure);
         return;
       }
       if (this.directLane.handleNotStarted(message)) return;
@@ -365,9 +388,7 @@ export class RepoWriteClient {
       }
       clearTimeout(pending.timer);
       this.pending.delete(message.requestId);
-      pending.reject(message.outcome === "not-started"
-        ? new RepoWriteNotStartedError(message.code, message.diagnostic, message.opId)
-        : new RepoWriteOutcomeUnknownError(message.code, message.diagnostic, message.opId));
+      failRepoWriteSubmit(pending, message, this.options.onRequestFailure);
       return;
     }
     if (message.kind === "drained") {
@@ -485,30 +506,22 @@ export class RepoWriteClient {
     const pending = this.pending.get(requestId);
     if (!pending) return;
     this.pending.delete(requestId);
-    const diagnostic =
-      `Repo writer request exceeded its ${this.limits.requestTimeoutMs}ms deadline.`;
-    pending.reject(pending.phase === "proceeded" && pending.opId
-      ? new RepoWriteOutcomeUnknownError(
-          "REPO_WRITE_REQUEST_TIMEOUT",
-          diagnostic,
-          pending.opId
-        )
-      : new RepoWriteNotStartedError(
-          "REPO_WRITE_REQUEST_TIMEOUT",
-          diagnostic,
-          pending.opId
-        ));
+    expireRepoWriteSubmit(
+      pending,
+      this.limits.requestTimeoutMs,
+      this.options.onRequestTimeout
+    );
   }
 
   private expireLookup(requestId: string): void {
     const pending = this.pendingLookups.get(requestId);
     if (!pending) return;
     this.pendingLookups.delete(requestId);
-    pending.reject(new RepoWriteLookupError(
-      "REPO_WRITE_LOOKUP_TIMEOUT",
-      `Repo writer lookup exceeded its ${this.limits.requestTimeoutMs}ms deadline.`,
-      pending.opId
-    ));
+    expireRepoWriteLookup(
+      pending,
+      this.limits.requestTimeoutMs,
+      this.options.onRequestTimeout
+    );
   }
 
   private dispatchShutdown(): void {
@@ -570,22 +583,6 @@ export class RepoWriteClient {
     } catch (error) {
       this.rejectSendFailure(pending.requestId, error, true);
     }
-  }
-
-  private telemetryMatchesPendingRequest(message: RepoWriteTelemetryFrame): boolean {
-    const submit = this.pending.get(message.requestId);
-    if (submit) {
-      return message.opId === undefined || submit.opId === message.opId;
-    }
-    const lookup = this.pendingLookups.get(message.requestId);
-    if (lookup) {
-      return lookup.phase === "sent" && (message.opId === undefined || lookup.opId === message.opId);
-    }
-    if (this.directLane.telemetryMatches(message)) return true;
-    const shutdown = this.shutdownPending;
-    return shutdown?.sent === true
-      && shutdown.requestId === message.requestId
-      && message.opId === undefined;
   }
 
   private pendingRequestCount(): number {

--- a/packages/daemon/src/runtime/repo-write-process-supervisor.ts
+++ b/packages/daemon/src/runtime/repo-write-process-supervisor.ts
@@ -22,6 +22,8 @@ export interface RepoWriteProcessSupervisorOptions {
   readonly limits?: ConstructorParameters<typeof RepoWriteClient>[0]["limits"];
   readonly onTelemetry?: ConstructorParameters<typeof RepoWriteClient>[0]["onTelemetry"];
   readonly onDiagnostic?: ConstructorParameters<typeof RepoWriteClient>[0]["onDiagnostic"];
+  readonly onRequestTimeout?: ConstructorParameters<typeof RepoWriteClient>[0]["onRequestTimeout"];
+  readonly onRequestFailure?: ConstructorParameters<typeof RepoWriteClient>[0]["onRequestFailure"];
 }
 
 interface ActiveWriter {
@@ -201,7 +203,9 @@ export class RepoWriteProcessSupervisor {
         }),
         ...(this.options.limits ? { limits: this.options.limits } : {}),
         onTelemetry: this.options.onTelemetry ?? (() => undefined),
-        onDiagnostic: this.options.onDiagnostic
+        onDiagnostic: this.options.onDiagnostic,
+        onRequestTimeout: this.options.onRequestTimeout,
+        onRequestFailure: this.options.onRequestFailure
       });
       const writer = { transport, client };
       this.active = writer;

--- a/packages/daemon/src/runtime/repo-write-stall-diagnostic.ts
+++ b/packages/daemon/src/runtime/repo-write-stall-diagnostic.ts
@@ -1,0 +1,64 @@
+import type {
+  RepoWriteTelemetryPhase
+} from "./repo-write-protocol.ts";
+import type {
+  RepoWriteRequestFailureDiagnostic,
+  RepoWriteRequestTimeoutDiagnostic
+} from "./repo-write-client-contract.ts";
+
+export function repoWriteWaitingStage(
+  phase: RepoWriteTelemetryPhase | undefined
+): string {
+  switch (phase) {
+    case "queue":
+      return "child-command-admission";
+    case "compile":
+      return "command-or-authority-attempt-compilation";
+    case "journal":
+      return "durable-operation-journal";
+    case "git":
+      return "canonical-git-publication";
+    case "fsync":
+      return "durable-attribution-evidence";
+    case "materializer":
+      return "authority-publication-flush";
+    case "projection":
+      return "daemon-write-queue:authority-publication";
+    case "total":
+      return "terminal-receipt-delivery";
+    case undefined:
+      return "child-execution-phase-unreported";
+  }
+}
+
+export function formatRepoWriteFailureDiagnostic(
+  diagnostic: RepoWriteRequestFailureDiagnostic
+): string {
+  return [
+    "Repo-write child request failed",
+    `command=${diagnostic.commandName}`,
+    `lane=${diagnostic.lane}`,
+    `waiting=${repoWriteWaitingStage(diagnostic.lastTelemetry?.phase)}`,
+    `lastPhase=${diagnostic.lastTelemetry?.phase ?? "none"}`,
+    `childElapsedMs=${diagnostic.lastTelemetry
+      ? Math.round(diagnostic.lastTelemetry.elapsedMs)
+      : "unknown"}`,
+    `code=${diagnostic.code}`,
+    ...(diagnostic.opId ? [`opId=${diagnostic.opId}`] : [])
+  ].join(";");
+}
+
+export function formatRepoWriteTimeoutDiagnostic(
+  diagnostic: RepoWriteRequestTimeoutDiagnostic
+): string {
+  const telemetry = diagnostic.lastTelemetry;
+  return [
+    `Repo-write child request timed out after ${diagnostic.deadlineMs}ms`,
+    `command=${diagnostic.commandName}`,
+    `lane=${diagnostic.lane}`,
+    `waiting=${repoWriteWaitingStage(telemetry?.phase)}`,
+    `lastPhase=${telemetry?.phase ?? "none"}`,
+    `childElapsedMs=${telemetry ? Math.round(telemetry.elapsedMs) : "unknown"}`,
+    ...(diagnostic.opId ? [`opId=${diagnostic.opId}`] : [])
+  ].join(";");
+}

--- a/packages/daemon/src/runtime/repo-write-telemetry-context.ts
+++ b/packages/daemon/src/runtime/repo-write-telemetry-context.ts
@@ -1,0 +1,59 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { performance } from "node:perf_hooks";
+import type { RepoWriteTelemetryPhase } from "./repo-write-protocol.ts";
+
+type RepoWriteTelemetryReporter = (
+  phase: RepoWriteTelemetryPhase,
+  elapsedMs: number
+) => void;
+
+export interface RepoWriteTelemetryDelivery {
+  readonly report: RepoWriteTelemetryReporter;
+  readonly flush: () => Promise<void>;
+}
+
+const storage = new AsyncLocalStorage<{
+  readonly startedAt: number;
+  readonly report: RepoWriteTelemetryReporter;
+}>();
+
+export function runWithRepoWriteTelemetry<Result>(
+  report: RepoWriteTelemetryReporter,
+  operation: () => Result
+): Result {
+  return storage.run({ startedAt: performance.now(), report }, operation);
+}
+
+export function reportCurrentRepoWriteTelemetry(
+  phase: RepoWriteTelemetryPhase
+): void {
+  const current = storage.getStore();
+  if (!current) return;
+  current.report(phase, Math.max(0, performance.now() - current.startedAt));
+}
+
+export function bindCurrentRepoWriteTelemetry<Result>(
+  operation: () => Result
+): () => Result {
+  const current = storage.getStore();
+  return current
+    ? () => storage.run(current, operation)
+    : operation;
+}
+
+export function createRepoWriteTelemetryDelivery(
+  deliver: (
+    phase: RepoWriteTelemetryPhase,
+    elapsedMs: number
+  ) => Promise<void>
+): RepoWriteTelemetryDelivery {
+  let pending = Promise.resolve();
+  return {
+    report: (phase, elapsedMs) => {
+      pending = pending
+        .then(() => deliver(phase, elapsedMs))
+        .catch(() => undefined);
+    },
+    flush: () => pending
+  };
+}

--- a/packages/daemon/src/runtime/reservation-reconciler-runner.ts
+++ b/packages/daemon/src/runtime/reservation-reconciler-runner.ts
@@ -1,0 +1,32 @@
+import type { DaemonRepoRuntimeOptions } from "./repo-runtime-options.ts";
+
+export class ReservationReconcilerRunner {
+  private readonly reconcile: DaemonRepoRuntimeOptions["reservationReconciler"];
+  private readonly input: Parameters<
+    NonNullable<DaemonRepoRuntimeOptions["reservationReconciler"]>
+  >[0];
+  private active: Promise<void> | undefined;
+
+  constructor(
+    reconcile: DaemonRepoRuntimeOptions["reservationReconciler"],
+    input: Parameters<
+      NonNullable<DaemonRepoRuntimeOptions["reservationReconciler"]>
+    >[0]
+  ) {
+    this.reconcile = reconcile;
+    this.input = input;
+  }
+
+  run(): Promise<void> {
+    if (!this.reconcile) return Promise.resolve();
+    // The reconciler orchestrates writes that are themselves serialized by
+    // the daemon queue. Single-flight excludes poll overlap without making
+    // the orchestrator a queue item that can wait for a write behind itself.
+    if (this.active) return this.active;
+    const run = this.reconcile(this.input).finally(() => {
+      if (this.active === run) this.active = undefined;
+    });
+    this.active = run;
+    return run;
+  }
+}

--- a/packages/daemon/test/authority-submission-error.test.ts
+++ b/packages/daemon/test/authority-submission-error.test.ts
@@ -28,6 +28,7 @@ import type {
   ProductionAuthorityAttemptPlanV1
 } from "../src/authority/production/production-authority-attempt-plan.ts";
 import { defaultRepoWriteRequestTimeoutMs } from "../src/runtime/repo-write-client-contract.ts";
+import { runWithRepoWriteTelemetry } from "../src/runtime/repo-write-telemetry-context.ts";
 import {
   encodeSemanticMutationEnvelopeV2,
   operationIdDiagnosticV2,
@@ -235,10 +236,24 @@ test("one submission method carries every governed ingress discriminator", async
     { ...common, ingress: "observed-write" as const, operation },
     { ...common, ingress: "script-ingest" as const, operation }
   ];
+  const telemetry: Array<{ ingress: string; phase: string }> = [];
   for (const input of inputs) {
-    await assert.rejects(submission.submit(input), /stop after compile/u);
+    await assert.rejects(
+      runWithRepoWriteTelemetry(
+        (phase) => telemetry.push({ ingress: input.ingress, phase }),
+        () => submission.submit(input)
+      ),
+      /stop after compile/u
+    );
   }
   assert.deepEqual(compiled, inputs.map((input) => input.ingress));
+  assert.deepEqual(
+    telemetry,
+    inputs.flatMap((input) => [
+      { ingress: input.ingress, phase: "compile" },
+      { ingress: input.ingress, phase: "git" }
+    ])
+  );
 });
 
 test("write coordinator routes specialized semantics through the single submission entry", async () => {

--- a/packages/daemon/test/repo-write-child-host-terminal.test.ts
+++ b/packages/daemon/test/repo-write-child-host-terminal.test.ts
@@ -96,7 +96,18 @@ test("volatile direct returns an exact receipt without durable frames or lookup"
 
   assert.equal(preparations, 0);
   assert.equal(lookups, 0);
-  assert.deepEqual(messages.map((message) => message.kind), ["ready", "direct-result"]);
+  assert.deepEqual(messages.map((message) => message.kind), [
+    "ready",
+    "telemetry",
+    "telemetry",
+    "direct-result"
+  ]);
+  assert.deepEqual(
+    messages
+      .filter((message) => message.kind === "telemetry")
+      .map((message) => message.phase),
+    ["queue", "compile"]
+  );
   assert.deepEqual(messages.at(-1), {
     ...childBase("direct-result"),
     requestId: "direct-receipt",

--- a/packages/daemon/test/repo-write-child-host.test.ts
+++ b/packages/daemon/test/repo-write-child-host.test.ts
@@ -30,7 +30,18 @@ test("host announces ready and executes only after the exact prepared handshake"
 
   await host.start();
   await host.receive(submit("request-1"));
-  assert.deepEqual(fixture.messages.map((message) => message.kind), ["ready", "prepared"]);
+  assert.deepEqual(fixture.messages.map((message) => message.kind), [
+    "ready",
+    "telemetry",
+    "telemetry",
+    "prepared"
+  ]);
+  assert.deepEqual(
+    fixture.messages
+      .filter((message) => message.kind === "telemetry")
+      .map((message) => message.phase),
+    ["queue", "compile"]
+  );
   assert.equal(executions, 0);
 
   await host.receive(proceed("request-1", "op-request-1"));
@@ -59,7 +70,12 @@ test("host accepts an immediate submit as soon as ready becomes observable", asy
   readyDelivery.resolve();
   await Promise.all([starting, submitted]);
 
-  assert.deepEqual(fixture.messages.map((message) => message.kind), ["ready", "prepared"]);
+  assert.deepEqual(fixture.messages.map((message) => message.kind), [
+    "ready",
+    "telemetry",
+    "telemetry",
+    "prepared"
+  ]);
 });
 
 test("prepare failures and bounded admission are definitely not started", async () => {
@@ -78,7 +94,7 @@ test("prepare failures and bounded admission are definitely not started", async 
   const first = host.receive(submit("request-1"));
   await Promise.resolve();
   await host.receive(submit("request-2"));
-  assertFailure(fixture.messages.at(-1), {
+  assertFailure(findMessage(fixture.messages, "failure", "request-2"), {
     requestId: "request-2",
     phase: "before-proceed",
     outcome: "not-started",
@@ -97,7 +113,7 @@ test("prepare failures and bounded admission are definitely not started", async 
     throw new Error("compile rejected");
   };
   await host.receive(submit("request-3"));
-  assertFailure(fixture.messages.at(-1), {
+  assertFailure(findMessage(fixture.messages, "failure", "request-3"), {
     requestId: "request-3",
     phase: "before-proceed",
     outcome: "not-started",

--- a/packages/daemon/test/repo-write-client-diagnostic.test.ts
+++ b/packages/daemon/test/repo-write-client-diagnostic.test.ts
@@ -1,0 +1,178 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  RepoWriteClient,
+  RepoWriteDirectOutcomeUnknownError,
+  RepoWriteNotStartedError,
+  RepoWriteOutcomeUnknownError
+} from "../src/runtime/repo-write-client.ts";
+import type {
+  RepoWriteRequestFailureDiagnostic,
+  RepoWriteRequestTimeoutDiagnostic
+} from "../src/runtime/repo-write-client-contract.ts";
+import {
+  formatRepoWriteFailureDiagnostic,
+  formatRepoWriteTimeoutDiagnostic
+} from "../src/runtime/repo-write-stall-diagnostic.ts";
+import {
+  FakeRepoWriteTransport,
+  childFrame,
+  command,
+  readyFrame,
+  requestId
+} from "./support/repo-write-client-fixture.ts";
+
+test("timeout diagnostics name the child wait for every authority submission ingress", async () => {
+  const cases = [
+    { ingress: "generic", commandName: "task-create" },
+    { ingress: "provenance-session", commandName: "session-start" },
+    { ingress: "decision-transition", commandName: "decision-transition" },
+    { ingress: "task-claim", commandName: "task-claim" },
+    { ingress: "observed-write", commandName: "task-amend" },
+    { ingress: "script-ingest", commandName: "script-run" }
+  ] as const;
+
+  for (const fixture of cases) {
+    const transport = new FakeRepoWriteTransport();
+    let observed: RepoWriteRequestTimeoutDiagnostic | undefined;
+    const client = new RepoWriteClient({
+      repoId: "repo-canonical",
+      generation: 7,
+      transport,
+      limits: { requestTimeoutMs: 10 },
+      onTelemetry: () => undefined,
+      onRequestTimeout: (diagnostic) => {
+        observed = diagnostic;
+      }
+    });
+    transport.emit(readyFrame());
+
+    const result = client.direct(command(fixture.commandName));
+    const request = transport.sent.at(-1);
+    transport.emit({
+      ...childFrame("telemetry"),
+      requestId: requestId(request),
+      phase: "projection",
+      elapsedMs: 3
+    });
+
+    await assert.rejects(result, RepoWriteDirectOutcomeUnknownError);
+    assert.ok(observed, `missing timeout diagnostic for ${fixture.ingress}`);
+    assert.equal(observed.commandName, fixture.commandName);
+    assert.match(
+      formatRepoWriteTimeoutDiagnostic(observed),
+      /waiting=daemon-write-queue:authority-publication;lastPhase=projection/u
+    );
+  }
+});
+
+test("durable timeout diagnostics retain the last child phase and recovery handle", async () => {
+  const transport = new FakeRepoWriteTransport();
+  let observed: RepoWriteRequestTimeoutDiagnostic | undefined;
+  const client = new RepoWriteClient({
+    repoId: "repo-canonical",
+    generation: 7,
+    transport,
+    limits: { requestTimeoutMs: 10 },
+    onTelemetry: () => undefined,
+    onRequestTimeout: (diagnostic) => {
+      observed = diagnostic;
+    }
+  });
+  transport.emit(readyFrame());
+
+  const result = client.submit(command("task-create"));
+  const submit = transport.sent.at(-1);
+  transport.emit({
+    ...childFrame("prepared"),
+    requestId: requestId(submit),
+    opId: "op-timeout-diagnostic"
+  });
+  transport.emit({
+    ...childFrame("telemetry"),
+    requestId: requestId(submit),
+    opId: "op-timeout-diagnostic",
+    phase: "git",
+    elapsedMs: 4
+  });
+
+  await assert.rejects(result, RepoWriteOutcomeUnknownError);
+  assert.ok(observed);
+  assert.equal(observed.lane, "durable");
+  assert.equal(observed.opId, "op-timeout-diagnostic");
+  assert.match(
+    formatRepoWriteTimeoutDiagnostic(observed),
+    /waiting=canonical-git-publication;lastPhase=git/u
+  );
+});
+
+test("explicit direct and durable failures report their last named child wait", async () => {
+  const transport = new FakeRepoWriteTransport();
+  const failures: RepoWriteRequestFailureDiagnostic[] = [];
+  const client = new RepoWriteClient({
+    repoId: "repo-canonical",
+    generation: 7,
+    transport,
+    onTelemetry: () => undefined,
+    onRequestFailure: (diagnostic) => failures.push(diagnostic)
+  });
+  transport.emit(readyFrame());
+
+  const direct = client.direct(command("task-claim"));
+  const directRequest = transport.sent.at(-1);
+  transport.emit({
+    ...childFrame("telemetry"),
+    requestId: requestId(directRequest),
+    phase: "compile",
+    elapsedMs: 2
+  });
+  transport.emit({
+    ...childFrame("direct-failure"),
+    requestId: requestId(directRequest),
+    outcome: "unknown",
+    replay: "forbidden",
+    code: "DIRECT_FAILED",
+    diagnostic: "direct fixture failed"
+  });
+  await assert.rejects(direct, RepoWriteDirectOutcomeUnknownError);
+
+  const durable = client.submit(command("task-create"));
+  const durableRequest = transport.sent.at(-1);
+  transport.emit({
+    ...childFrame("telemetry"),
+    requestId: requestId(durableRequest),
+    phase: "git",
+    elapsedMs: 4
+  });
+  transport.emit({
+    ...childFrame("failure"),
+    requestId: requestId(durableRequest),
+    phase: "before-proceed",
+    outcome: "not-started",
+    replay: "caller-may-retry",
+    code: "DURABLE_FAILED",
+    diagnostic: "durable fixture failed"
+  });
+  await assert.rejects(durable, RepoWriteNotStartedError);
+
+  assert.deepEqual(
+    failures.map((failure) => ({
+      commandName: failure.commandName,
+      lane: failure.lane,
+      code: failure.code
+    })),
+    [
+      { commandName: "task-claim", lane: "direct", code: "DIRECT_FAILED" },
+      { commandName: "task-create", lane: "durable", code: "DURABLE_FAILED" }
+    ]
+  );
+  assert.match(
+    formatRepoWriteFailureDiagnostic(failures[0]!),
+    /waiting=command-or-authority-attempt-compilation;lastPhase=compile/u
+  );
+  assert.match(
+    formatRepoWriteFailureDiagnostic(failures[1]!),
+    /waiting=canonical-git-publication;lastPhase=git/u
+  );
+});

--- a/packages/daemon/test/repo-write-process-supervisor.test.ts
+++ b/packages/daemon/test/repo-write-process-supervisor.test.ts
@@ -20,6 +20,8 @@ import {
 import {
   calculateDaemonArtifactIdentity
 } from "../src/protocol/daemon-artifact-identity.ts";
+import type { RepoWriteRequestTimeoutDiagnostic } from "../src/runtime/repo-write-client-contract.ts";
+import { formatRepoWriteTimeoutDiagnostic } from "../src/runtime/repo-write-stall-diagnostic.ts";
 
 const fixturePath = fileURLToPath(
   new URL("./support/repo-write-ipc-child.ts", import.meta.url)
@@ -151,6 +153,7 @@ test("non-durable task-claim timeout replaces the child without replay or lookup
   const root = mkdtempSync(path.join(os.tmpdir(), "ha-repo-write-direct-"));
   const tracePath = path.join(root, "trace.log");
   let forks = 0;
+  let timeoutDiagnostic: RepoWriteRequestTimeoutDiagnostic | undefined;
   const supervisor = new RepoWriteProcessSupervisor({
     repoId: "repo-transport",
     generation: 1,
@@ -161,6 +164,9 @@ test("non-durable task-claim timeout replaces the child without replay or lookup
         modulePath: fixturePath,
         args: [forks === 1 ? "swallow-direct" : "roundtrip", tracePath]
       });
+    },
+    onRequestTimeout: (diagnostic) => {
+      timeoutDiagnostic = diagnostic;
     }
   });
   context.after(async () => {
@@ -173,6 +179,11 @@ test("non-durable task-claim timeout replaces the child without replay or lookup
     (error) => error instanceof RepoWriteDirectOutcomeUnknownError
   );
   assert.equal(forks, 2);
+  assert.ok(timeoutDiagnostic);
+  assert.match(
+    formatRepoWriteTimeoutDiagnostic(timeoutDiagnostic),
+    /command=task-claim;lane=direct;waiting=daemon-write-queue:authority-publication;lastPhase=projection/u
+  );
   assert.deepEqual(
     readFileSync(tracePath, "utf8").trim().split("\n"),
     ["direct:task-claim"]

--- a/packages/daemon/test/repo-write-telemetry-context.test.ts
+++ b/packages/daemon/test/repo-write-telemetry-context.test.ts
@@ -1,0 +1,22 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  bindCurrentRepoWriteTelemetry,
+  reportCurrentRepoWriteTelemetry,
+  runWithRepoWriteTelemetry
+} from "../src/runtime/repo-write-telemetry-context.ts";
+
+test("a queued callback retains the request telemetry context that admitted it", () => {
+  const phases: string[] = [];
+  const queued = runWithRepoWriteTelemetry(
+    (phase) => phases.push(phase),
+    () => bindCurrentRepoWriteTelemetry(() => {
+      reportCurrentRepoWriteTelemetry("materializer");
+    })
+  );
+
+  queued();
+
+  assert.deepEqual(phases, ["materializer"]);
+});

--- a/packages/daemon/test/reservation-reconciler-queue.test.ts
+++ b/packages/daemon/test/reservation-reconciler-queue.test.ts
@@ -1,0 +1,44 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { createDaemonRuntime } from "../src/runtime/repo-runtime.ts";
+import { daemonAttribution } from "./runtime/helpers/daemon-runtime.ts";
+import { docWrite, withTempStoreAsync } from "./runtime/helpers/store.ts";
+
+test("reservation reconciliation may await a write on the daemon queue without self-deadlocking", { timeout: 5_000 }, async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    let reconciliations = 0;
+    const runtime = createDaemonRuntime({
+      rootDir,
+      materializerPollMs: false,
+      interactiveMicroBatchMs: 0,
+      reservationReconciler: async () => {
+        reconciliations += 1;
+        await runtime.enqueueInteractiveWrite({
+          commandId: "runtime-event-lease-reconcile",
+          attribution: daemonAttribution("person_test", "test", "credential-test"),
+          ops: [docWrite(
+            "op-reservation-reconcile",
+            "task-reservation-reconcile",
+            "reconciled.md",
+            "reconciled\n"
+          )]
+        });
+      }
+    });
+
+    await runtime.start();
+
+    assert.equal(reconciliations, 1);
+    assert.equal(
+      readFileSync(path.join(
+        rootDir,
+        "harness/tasks/task-reservation-reconcile/reconciled.md"
+      ), "utf8"),
+      "reconciled\n"
+    );
+    await runtime.stop();
+  });
+});

--- a/packages/daemon/test/support/repo-write-ipc-child.ts
+++ b/packages/daemon/test/support/repo-write-ipc-child.ts
@@ -19,7 +19,18 @@ if (mode === "exit") {
   transport.onMessage((message) => {
     if (message.kind === "direct") {
       trace(`direct:${message.command.commandName}`);
-      if (mode === "swallow-direct") return;
+      if (mode === "swallow-direct") {
+        void transport.send({
+          protocol: repoWriteProtocolType,
+          repoId: message.repoId,
+          generation: message.generation,
+          kind: "telemetry",
+          requestId: message.requestId,
+          phase: "projection",
+          elapsedMs: 2.5
+        });
+        return;
+      }
       void transport.send({
         protocol: repoWriteProtocolType,
         repoId: message.repoId,


### PR DESCRIPTION
# English

## Summary

Governed writes on a production-sized ledger were taking roughly 27–32 seconds against a 30 second parent transport deadline, so they succeeded or failed depending on which side of that line they landed. `ha task claim` sat slightly over and never landed; lighter commands intermittently slipped under. The root cause is a self-deadlock: the reservation reconciler was enqueued onto `DaemonWriteQueue` as a background batch, but its own lease-event append enqueues `runtime-event-lease-reconcile` onto that same queue and awaits it. The reconciler occupied the only slot while waiting for work queued behind itself, and its `coordinator.flush("explicit")` promise was never fulfilled.

A second, equally serious defect: a write that exhausted its deadline produced **no diagnostic at all**, because the child's stderr is discarded. Diagnosing this took over an hour purely because the instrument did not exist.

## What Changed

- The reservation reconciler now runs outside `DaemonWriteQueue` with single-flight protection. Poll overlap is still excluded, and its writes remain serialized — the lease-event path through the queue, the authored-store path by `withRepoLocks` — but the orchestrator is no longer a queue item that can wait on itself.
- Both the direct and durable lanes now report the last executed phase across all six ingress kinds.
- The parent emits `repo-write.request.timeout` and `repo-write.request.failure` carrying command, lane, `lastPhase`, `waiting`, `childElapsedMs`, and `opId`/`code` where available. At the root-cause site this records `waiting=daemon-write-queue:authority-publication;lastPhase=projection`.

## Task And Scope

- Harness task: `task_01KYAEWX4H8JB9JJTNHSF4W9YZ`
- Branch: `codex/claim-subprocess-hang`
- Public scope: `packages/daemon/src/runtime/*`, `packages/daemon/src/authority/*`, `packages/daemon/src/lifecycle/run-daemon-serve.ts`, plus tests
- Private planning/evidence updated: yes — findings under the task package `artifacts/`
- Out of scope: the reconciler's authored-store path never passes `heldGlobalLock`, before or after this change. Its lock posture is unchanged here and is filed as a separate follow-up rather than altered under a deadlock fix.

## Version Impact

- Version: no version change because no published surface signature changed.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none — the governance checker reports no protected surfaces touched across 117 manifest-derived rules.
- Authority: `task_01KYAEWX4H8JB9JJTNHSF4W9YZ`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `11b6e1b5408c592810d181c001b19ff012d777d0`
- Branch merge-base with `origin/main`: `11b6e1b5408c592810d181c001b19ff012d777d0`
- Last `git fetch origin` time: 2026-07-24T17:40Z
- Sync method: rebase
- Public diff command: `git diff 11b6e1b5408c592810d181c001b19ff012d777d0..045c1635`
- Private evidence commit/path: task package `artifacts/claim-subprocess-hang-findings.md`
- Reviewer evidence path: same task package `artifacts/`
- GitHub Actions `rewrite-ci` run URL: see the checks on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` — EXIT=0 on the rebased commit, 34 manifest gates green
- [x] Targeted tests for the change surface, named with their counts: root-cause test red/green — old behaviour times out at 5,004ms, fixed behaviour passes at 141ms. CLI integration tier, `--prefix packages/cli/test/`, 108 files: EXIT=0 with zero failures on this branch, and EXIT=0 on `main` as a baseline.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending on this PR.
- Not run, and why: the production-latency claim is **not yet verified against the live daemon**. It cannot be, before merge — the production daemon runs from the main checkout. Verifying that a governed write returns to seconds in production is the acceptance step after merge, and it is the only evidence that would actually close the original symptom.

## Review Evidence

- Self-review: the comment justifying the fix asserts that the reconciler's writes stay serialized by the queue. That claim was checked rather than taken on trust, and it is only half true by itself — the lease-event path goes through the queue, but `authoredStoreForLease` uses a direct `makeJournaledWriteCoordinator`. It is nonetheless safe, because that coordinator acquires its own locks through `withRepoLocks`. Whether moving the reconciler out of the queue changed its lock posture was also checked: it never passed `heldGlobalLock`, before or after, so nothing regressed.
- Reviewer subagent: not used.
- Human review: pending.
- Blocking findings: none surviving. The worker reported one integration test failing on a principal assertion (`person_test` versus an expected `person_execution`) and judged it unrelated. That judgement was not taken on trust — the CEO ran the full CLI integration tier on both sides. It passes on `main` **and** on this branch, and the specific test passes at 8,675ms. The reported failure came from invoking the test bare, without this repository's hermetic environment and fixture preload, which is a known false-red source for identity assertions. The worker's conclusion was correct; the interim CEO suspicion that a regression had been dismissed was not.

## Residual Risk

- The measured production symptom was a ~27–32s write against a 30s deadline. The isolated fixture reproduced a deadlock, but a deadlock alone does not explain why *successful* writes clustered at 26–29 seconds rather than completing quickly. Whether this fix removes that entire latency or only the claim-path deadlock is unproven until measured on the live daemon after merge.
- The reconciler's authored-store path does not pass `heldGlobalLock` and does not set `lockConflictRetry`. Now that it runs concurrently with queue writes rather than inside a queue slot, it can contend for repo locks in timing windows it previously could not reach. No test exercises the reconciler actually authoring lease state while the daemon is live.
- The new diagnostics are additive; if the last-phase reporting is itself wrong, it will mislead the next diagnosis in the same way the absent instrument misled this one.

## References

- Task: `task_01KYAEWX4H8JB9JJTNHSF4W9YZ`
- Evidence: task package `artifacts/claim-subprocess-hang-findings.md`; production `request.performance` frames showing `totalMs` 31,204 with `eventLoopActiveMs` 245, establishing the parent was waiting rather than computing.
- Review: supersedes the CEO's earlier hypothesis that #1082 unmasked this defect. That hypothesis is refuted — claim completes in ~1.9s on both `d9a7c7e6^` and `d9a7c7e6` in an isolated fixture, so the defect predates and is independent of that PR.

---

# 中文

## 概要

在生产规模台账上，一条治理写要 **27–32 秒**，而父传输 deadline 是 **30 秒**，因此写入成败取决于落在这条线的哪一侧。`ha task claim` 稍微偏在线外，从不落盘；较轻的命令则时而擦线通过。根因是**自锁**：reservation reconciler 被作为 background batch 塞进 `DaemonWriteQueue`，而它自己的 lease-event 追加又把 `runtime-event-lease-reconcile` 塞进**同一个队列并等待它**。于是 reconciler 占着唯一的槽位，等待排在自己后面的工作，其 `coordinator.flush("explicit")` 的 promise 永远不会兑现。

第二个同样严重的缺陷：一条写耗尽 deadline 之后**不产生任何诊断**，因为子进程的 stderr 被丢弃。这次排查花掉一个多小时，**纯粹是因为仪器不存在**。

## 改动内容

- reservation reconciler 改为在 `DaemonWriteQueue` **之外**运行，并加 single-flight 保护。轮询重叠仍被排除，它的写仍然是串行的——lease-event 走队列，authored-store 走 `withRepoLocks`——但**编排者本身不再是一个会等待自己的队列项**。
- direct 与 durable 两条 lane 现在都会上报最后执行到的阶段，覆盖全部六类 ingress。
- 父进程新增 `repo-write.request.timeout` 与 `repo-write.request.failure`，携带 command、lane、`lastPhase`、`waiting`、`childElapsedMs`，以及可用时的 `opId`/`code`。在根因现场会明确记录 `waiting=daemon-write-queue:authority-publication;lastPhase=projection`。

## 任务与范围

- Harness 任务：`task_01KYAEWX4H8JB9JJTNHSF4W9YZ`
- 分支：`codex/claim-subprocess-hang`
- 公开范围：`packages/daemon/src/runtime/*`、`packages/daemon/src/authority/*`、`packages/daemon/src/lifecycle/run-daemon-serve.ts` 及测试
- 私有计划／证据已更新：是——findings 落在任务包 `artifacts/`
- 不在范围：reconciler 的 authored-store 路径**在本改动前后都没有**传 `heldGlobalLock`。其锁姿态未被本 PR 改变，作为独立后续项单列，而不是塞进一个死锁修复里顺手改掉。

## 版本影响

- 版本：不升版，未改变任何已发布面的签名。
- 发布影响：不发布

## 治理声明

- 触碰 protected surface：否
- Protected surface 范围：无——治理检查器在 117 条 manifest 派生规则下报告未触碰任何 protected surface。
- 授权：`task_01KYAEWX4H8JB9JJTNHSF4W9YZ`
- 机器检查边界：本 PR 只断言声明存在；声明是否属实、是否充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`11b6e1b5408c592810d181c001b19ff012d777d0`
- 分支与 `origin/main` 的 merge-base：`11b6e1b5408c592810d181c001b19ff012d777d0`
- 最近一次 `git fetch origin` 时间：2026-07-24T17:40Z
- 同步方式：rebase
- 公开 diff 命令：`git diff 11b6e1b5408c592810d181c001b19ff012d777d0..045c1635`
- 私有证据提交／路径：任务包 `artifacts/claim-subprocess-hang-findings.md`
- 评审证据路径：同一任务包 `artifacts/`
- GitHub Actions `rewrite-ci` 运行 URL：见本 PR 的 checks
- [x] `git diff --check`
- [x] `npm run check:stop-point`——rebase 后的提交上 EXIT=0，34 个 manifest 门全绿
- [x] 针对改动面的定向测试及其条数：根因测试 red/green——旧行为在 5,004ms 超时，修复后 141ms 通过。CLI integration 档，`--prefix packages/cli/test/`，108 个文件：本分支 EXIT=0 零失败，`main` 作为基线同样 EXIT=0。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威的完整门）——本 PR 上待跑。
- 未跑及原因：**生产延迟这一断言尚未在在役 daemon 上验证**。合并前也无法验证——生产 daemon 跑的是 main 检出。「一条治理写是否回到秒级」是**合并后的验收步骤**，而且它是唯一能真正关闭原始症状的证据。

## 审查证据

- 自审：解释该修复的注释断言「reconciler 的写仍由队列串行化」。这条断言**被核查而非采信**，且单独看只对了一半——lease-event 路径确实走队列，但 `authoredStoreForLease` 用的是**直接的** `makeJournaledWriteCoordinator`。尽管如此它仍是安全的，因为该 coordinator 通过 `withRepoLocks` **自行加锁**。另外也核查了「把 reconciler 移出队列是否改变了它的锁姿态」：**前后都没传** `heldGlobalLock`，因此没有回归。
- 评审子代理：未使用。
- 人工评审：待泽宇。
- 阻塞性发现：无幸存项。worker 报告有一条 integration 测试在 principal 断言上失败（实际 `person_test`，期待 `person_execution`），并判定与本修复无关。**这个判定没有被采信**——CEO 在两侧各跑了完整 CLI integration 档：`main` 上通过，本分支上**也**通过，且该测试本身以 8,675ms 通过。worker 看到的失败来自**裸调用**测试，缺少本仓的 hermetic 环境与 fixture preload，而这正是身份类断言的已知假红来源。**worker 的结论是对的；CEO 中途「有回归被掩盖」的怀疑是错的。**

## 残余风险

- 实测到的生产症状是「27–32 秒的写撞 30 秒 deadline」。隔离夹具复现出的是死锁，但**死锁本身并不能解释为什么*成功*的写会聚集在 26–29 秒**而不是很快完成。本修复究竟消除了整段延迟，还是只消除了 claim 路径上的死锁，**在合并后到在役 daemon 上实测之前都未被证明**。
- reconciler 的 authored-store 路径不传 `heldGlobalLock`，也未设 `lockConflictRetry`。既然它现在与队列写**并发**运行而不再占着队列槽，它就可能在以前到达不了的时间窗里与队列写争抢仓库锁。**没有任何测试覆盖「daemon 在役时 reconciler 真的去 author 一次 lease 状态」。**
- 新增诊断是纯增量的；但如果 last-phase 上报本身是错的，它会以「仪器缺失误导了这次排查」同样的方式误导下一次排查。

## 关联材料

- 任务：`task_01KYAEWX4H8JB9JJTNHSF4W9YZ`
- 证据：任务包 `artifacts/claim-subprocess-hang-findings.md`；生产 `request.performance` 帧显示 `totalMs` 31,204 而 `eventLoopActiveMs` 仅 245，证明父进程是在**等**而不是在**算**。
- 评审：本 PR **推翻**了 CEO 早先「#1082 揭开了这个缺陷」的假设。该假设已被证伪——在隔离夹具中，`d9a7c7e6^` 与 `d9a7c7e6` 上 claim 都在约 1.9 秒完成，故该缺陷早于且独立于那个 PR。
