### PR TITLE
fix(authority): retain empty replication blobs once

### DIFF
--- a/packages/daemon/src/authority/replication-content-store.ts
+++ b/packages/daemon/src/authority/replication-content-store.ts
@@ -98,7 +98,7 @@ export function createAuthorityReplicationContentStore(input: {
     const digest = digestBlobBytes(bytes);
     const key = blobStateKey(digest);
     const known = input.state.get<string>(key);
-    if (known) {
+    if (known !== undefined) {
       const knownBytes = Buffer.from(known, "base64");
       if (knownBytes.toString("base64") !== known || digestBlobBytes(knownBytes) !== digest) {
         throw new Error(`BLOB_DIGEST_MISMATCH:${digest}`);

--- a/packages/daemon/test/replication-content-store-batch.test.ts
+++ b/packages/daemon/test/replication-content-store-batch.test.ts
@@ -57,6 +57,47 @@ test("replication snapshot reads a large Git tree with bounded subprocess work",
   assert.ok(starts.length <= 2, `expected at most two Git subprocesses, observed ${starts.length}`);
 });
 
+test("replication snapshot retains empty blobs without rewriting them", (context) => {
+  const root = mkdtempSync(path.join(tmpdir(), "replication-content-restart-"));
+  context.after(() => rmSync(root, { recursive: true, force: true }));
+  git(root, "init", "-q");
+  git(root, "config", "user.name", "Harness Test");
+  git(root, "config", "user.email", "harness@example.test");
+  mkdirSync(path.join(root, "files"));
+  for (let index = 0; index < 64; index += 1) {
+    writeFileSync(path.join(root, "files", `${index}.txt`), "");
+  }
+  git(root, "add", ".");
+  git(root, "commit", "-q", "-m", "initial tree");
+
+  const values = new Map<string, unknown>();
+  let putCalls = 0;
+  const state = {
+    get: <Value>(key: string) => values.get(key) as Value | undefined,
+    put: (key: string, value: unknown) => {
+      putCalls += 1;
+      values.set(key, structuredClone(value));
+    },
+    entries: <Value>() => [...values.entries()] as ReadonlyArray<readonly [string, Value]>
+  };
+  createAuthorityReplicationContentStore({
+    gitRoot: root,
+    workspaceId: "workspace-restart",
+    epoch: "1",
+    state
+  }).snapshot(git(root, "rev-parse", "HEAD"), 1);
+
+  const snapshot = createAuthorityReplicationContentStore({
+    gitRoot: root,
+    workspaceId: "workspace-restart",
+    epoch: "1",
+    state
+  }).snapshot(git(root, "rev-parse", "HEAD"), 1);
+
+  assert.equal(snapshot.entries.length, 64);
+  assert.equal(putCalls, 1, "the shared empty blob should be retained exactly once");
+});
+
 function git(root: string, ...args: ReadonlyArray<string>): string {
   return execFileSync("git", ["-C", root, ...args], {
     encoding: "utf8",


### PR DESCRIPTION
# English

## Summary

Every authored governed write against a production-scale ledger carried a fixed ~19.5 second tail, against a 30 second parent transport deadline — so the same command succeeded or failed on a coin flip. The cause is a falsy-empty-string check: `storeBlob()` tested `if (known)`, but a retained empty file is stored as base64 `""`, which is falsy. Every empty path in the tree was therefore treated as unknown on every snapshot and durably re-appended with an fsync. In this ledger 1,315 paths are Git's empty blob, across two inspected trees, which is 2,630 redundant durable puts per write.

Measured on a copied fixture, the uninstrumented call goes from **22,177.7ms to 2,044.8ms**, with redundant durable puts dropping to **0**.

## What Changed

- `packages/daemon/src/authority/replication-content-store.ts` — `if (known)` becomes `if (known !== undefined)`, so a retained empty blob is recognized as present instead of missing. One line.
- `packages/daemon/test/replication-content-store-batch.test.ts` — a regression test that creates 64 empty files, snapshots the same commit twice, and asserts the shared empty blob is stored exactly once.

## Task And Scope

- Harness task: `task_01KYAQ7FED7330AE6VV7S2BFQ0`
- Branch: `fix/authored-write-19s-tail`
- Public scope: `packages/daemon/src/authority/replication-content-store.ts`, `packages/daemon/test/replication-content-store-batch.test.ts`
- Private planning/evidence updated: task plan, mission, and the measured fact are recorded in the task package.
- Out of scope: the snapshot path remains O(tree) at roughly 2 seconds for 20,749 entries, and the discarded `scanIntegrity()` work described under Residual Risk is untouched.

## Version Impact

- Version: no version change; this is an internal daemon correctness fix with no surface change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KYAQ7FED7330AE6VV7S2BFQ0`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `dc7b153d5ce3405080833152a7ed7d0d4d797173`
- Branch merge-base with `origin/main`: `dc7b153d5ce3405080833152a7ed7d0d4d797173`
- Last `git fetch origin` time: 2026-07-24T19:12Z
- Sync method: rebase onto `origin/main` after PR #1083 merged; the two changes touch different regions of the same file and rebased without conflict.
- Public diff command: `git diff dc7b153d5ce3405080833152a7ed7d0d4d797173..18f66b91`
- Private evidence commit/path: `harness/tasks/task_01KYAQ7FED7330AE6VV7S2BFQ0-*/`
- Reviewer evidence path: not applicable
- GitHub Actions `rewrite-ci` run URL: see the checks on this PR
- [x] `git diff --check`
- [x] `npm run check:local` — passed
- [x] `npm run typecheck` — passed
- [x] Targeted tests for the change surface, named with their counts: `node tools/run-node-tests.mjs --tier contract --prefix packages/daemon/test/` green on this commit. Double-sided control run by the reviewer: with the fix reverted to `if (known)`, exactly one test fails — `replication snapshot retains empty blobs without rewriting them` — and restoring the fix returns the tier to green.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending on this PR.
- Not run, and why: **the production latency improvement is not yet verified against the live daemon.** It cannot be before merge, because the production daemon runs from the main checkout. The 22.2s to 2.0s figure is measured on a copied fixture, not in production. Confirming that a governed write returns to seconds in production is the acceptance step after merge.

## Review Evidence

- Investigation discipline: three candidate causes were refuted by direct measurement before this one was found, and each refutation is recorded in the task plan so it is not repeated. `scanIntegrity()` over all 1,554 V2 shards costs 550ms, not 19.5s. `filesExistingAtCommit` issues a single `git ls-tree` at 13ms rather than one spawn per path. Staged/status scanning over the 20,696-file ledger costs 13–174ms. Reading the code suggested all three; measuring killed all three.
- The delivered phase breakdown sums to 16,373ms — Git tree listing 87.0ms, blob reads 1,401.6ms, digest and state lookup 273.9ms, retained-content validation 449.8ms, **2,630 redundant durable puts 14,077.0ms**, unaccounted 83.7ms — which lands inside the 15–22s band measured in production. A timing table that adds up was required as the deliverable precisely so that a plausible story could not substitute for one.
- Red/green proof from the implementer: restoring the bug produced 128 writes instead of 1.
- Reviewer double-sided control: run independently and reproduced, as recorded under Verification.
- Blocking findings: none.

## Residual Risk

- The snapshot path is still O(tree), about 2 seconds for 20,749 entries, so it grows with the ledger.
- `publication-evidence.ts` calls `scanIntegrity()` with no assignment on every write: it decodes and verifies all 1,554 shards, re-encodes and SHA-256s each, builds a log digest and discards it. Only the throw is load-bearing. At today's size that is 550ms, but it is O(total history) per write and is on the same growth curve toward the same 30s deadline. It is tracked separately and deliberately not fixed here.
- The production p50 is unverified until the daemon is restarted onto this commit.

## References

- Task: `task_01KYAQ7FED7330AE6VV7S2BFQ0`
- Evidence: 116 paired samples from the `harness/` ledger history (min 15s, median 19s, tight unimodal 15–22s), plus `request.performance` frames showing `eventLoopActiveMs` of 170–250ms against `totalMs` of 25,000–32,000.
- Related: PR #1085 fixed the reservation-reconciler self-deadlock, which was a different defect on the same path; it made `task claim` land at all but did not remove this tail.

---

# 中文

## 概要

在生产规模台账上，每一条 **authored** 治理写都带着一个固定的 ~19.5 秒尾巴，而父传输 deadline 是 30 秒——于是同一条命令成败靠掷硬币。根因是**空字符串的 falsy 判断**：`storeBlob()` 用 `if (known)` 判存在，而被保留的空文件存成 base64 的 `""`，**它是 falsy 的**。于是树里每一个空文件路径在每次 snapshot 都被当成「不存在」，重新做一次带 fsync 的持久追加。本台账有 **1,315** 个路径指向 Git 的空 blob，跨两棵被检查的树，即**每次写 2,630 次冗余持久写**。

在复制出来的夹具上实测，未插桩的同一调用从 **22,177.7ms 降到 2,044.8ms**，冗余持久写降为 **0**。

## 改动内容

- `packages/daemon/src/authority/replication-content-store.ts`——`if (known)` 改为 `if (known !== undefined)`，让被保留的空 blob 被识别为「已存在」而不是「缺失」。**一行**。
- `packages/daemon/test/replication-content-store-batch.test.ts`——回归测试：建 64 个空文件，对同一个 commit 连做两次 snapshot，断言共享的空 blob **只被写入一次**。

## 任务与范围

- Harness 任务：`task_01KYAQ7FED7330AE6VV7S2BFQ0`
- 分支：`fix/authored-write-19s-tail`
- 公开范围：`packages/daemon/src/authority/replication-content-store.ts`、`packages/daemon/test/replication-content-store-batch.test.ts`
- 私有计划／证据已更新：task plan、mission 与实测 fact 均已落在任务包内。
- 不在范围：snapshot 路径仍是 O(树)，20,749 条约 2 秒；残余风险里写明的 `scanIntegrity()` 空转**本 PR 不动**。

## 版本影响

- 版本：不升版；这是 daemon 内部正确性修复，无对外面变化。
- 发布影响：不发布

## 治理声明

- 触碰 protected surface：否
- Protected surface 范围：不适用
- 授权：`task_01KYAQ7FED7330AE6VV7S2BFQ0`
- 机器检查边界：本 PR 只断言声明存在；声明是否属实、是否充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`dc7b153d5ce3405080833152a7ed7d0d4d797173`
- 分支与 `origin/main` 的 merge-base：`dc7b153d5ce3405080833152a7ed7d0d4d797173`
- 最近一次 `git fetch origin` 时间：2026-07-24T19:12Z
- 同步方式：在 PR #1083 合入后 rebase 到 `origin/main`；两处改动落在同一文件的不同区域，rebase 无冲突。
- 公开 diff 命令：`git diff dc7b153d5ce3405080833152a7ed7d0d4d797173..18f66b91`
- 私有证据提交／路径：`harness/tasks/task_01KYAQ7FED7330AE6VV7S2BFQ0-*/`
- 评审证据路径：不适用
- GitHub Actions `rewrite-ci` 运行 URL：见本 PR 的 checks
- [x] `git diff --check`
- [x] `npm run check:local`——通过
- [x] `npm run typecheck`——通过
- [x] 针对改动面的定向测试及其条数：`node tools/run-node-tests.mjs --tier contract --prefix packages/daemon/test/` 在本提交上全绿。**评审者亲跑双侧对照**：把修复退回 `if (known)` 后，**恰好一条**测试失败——`replication snapshot retains empty blobs without rewriting them`——恢复修复后该 tier 回绿。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威的完整门）——本 PR 上待跑。
- 未跑及原因：**生产延迟改善尚未在活的 daemon 上验证**。合并前无法验证，因为生产 daemon 跑的是 main 检出。22.2s→2.0s 是在复制夹具上测的，不是生产。确认治理写在生产上回到秒级是**合并之后的验收步骤**。

## 审查证据

- 排查纪律：在找到本根因之前，**三个候选原因被直接测量逐一证伪**，且每条证伪都写进 task plan 以免重做。`scanIntegrity()` 扫全部 1,554 个 V2 shard 只要 550ms，不是 19.5s；`filesExistingAtCommit` 只发**一条** `git ls-tree`（13ms）而非逐路径 spawn；在 20,696 文件台账上扫 staged/status 只要 13–174ms。**读代码让这三个都很像真凶，测量把三个都杀了。**
- 交付的分阶段耗时表加总 16,373ms——Git 树列举 87.0ms、blob 读取 1,401.6ms、摘要与状态查找 273.9ms、保留内容校验 449.8ms、**2,630 次冗余持久写 14,077.0ms**、未归类 83.7ms——落在生产实测的 15–22s 带内。**「表必须加得起来」是刻意设的交付标准**，就是为了不让一个说得通的故事冒充定位。
- 实现方的红绿证明：把 bug 放回去，写入次数从 1 变成 128。
- 评审者双侧对照：独立跑过并复现，见「验证」节。
- 阻塞性发现：无。

## 残余风险

- snapshot 路径**仍是 O(树)**，20,749 条约 2 秒，会随台账增长。
- `publication-evidence.ts` 每次写都**无赋值**调用 `scanIntegrity()`：解码校验全部 1,554 个 shard、逐个重编码 SHA-256、算出 log digest 然后**丢弃**，只有抛异常是承重的。今天 550ms，但它是 **O(全部历史)/写**，在撞同一条 30s 线的增长曲线上。**单独跟踪，本 PR 刻意不修。**
- 生产 p50 在 daemon 重启到本提交之前**未经验证**。

## 关联材料

- 任务：`task_01KYAQ7FED7330AE6VV7S2BFQ0`
- 证据：`harness/` 台账历史中 116 个配对样本（min 15s、median 19s、紧致单峰 15–22s），以及 `request.performance` 帧显示 `eventLoopActiveMs` 仅 170–250ms 而 `totalMs` 为 25,000–32,000。
- 相关：PR #1085 修的是 reservation reconciler 自死锁，是同一条路径上的**另一个**缺陷；它让 `task claim` 能落地，但**没有**消除本尾巴。
