### PR TITLE
fix(daemon): route doc sync submit to the writer child

### DIFF
--- a/packages/application/src/doc-sync.ts
+++ b/packages/application/src/doc-sync.ts
@@ -28,7 +28,13 @@ export interface DocSyncChangeV1 {
 
 export interface DocSyncSubmitRequestV1 {
   readonly repo: { readonly repoId: string };
-  readonly session?: { readonly sessionId?: string; readonly runtime?: "human" | "claude-code" | "codex" | "zcode" | "antigravity" | "unknown" };
+  readonly session?: {
+    readonly sessionId?: string;
+    readonly runtime?: "human" | "claude-code" | "codex" | "zcode" | "antigravity" | "unknown";
+    readonly source?: "runtime" | "manual";
+    readonly detectedAt?: string;
+    readonly user?: string;
+  };
   readonly executor?: { readonly kind: "agent"; readonly id: string } | null;
   readonly payload: {
     readonly baseLedgerSha: string;
@@ -111,11 +117,11 @@ export type DocSyncSubmitResultV1 =
   }
   | {
     readonly ok: false;
-    readonly _tag?: "WriteRejected";
+    readonly _tag?: "WriteRejected" | "JournalUnavailable";
     readonly schema: "daemon.doc-sync-submit-result/v1";
     readonly status: "rejected";
     readonly intentId: string;
-    readonly code: "doc_sync_forbidden_touch" | "cas_watermark_mismatch" | "doc_sync_conflict" | "doc_sync_post_apply_bearing_changed" | "doc_sync_invalid_payload";
+    readonly code: "doc_sync_forbidden_touch" | "cas_watermark_mismatch" | "doc_sync_conflict" | "doc_sync_post_apply_bearing_changed" | "doc_sync_invalid_payload" | "journal_unavailable";
     readonly reason: string;
     readonly retryable: boolean;
     readonly currentWatermark?: string | null;

--- a/packages/cli/src/composition/repo-write-child-entrypoint.ts
+++ b/packages/cli/src/composition/repo-write-child-entrypoint.ts
@@ -10,11 +10,18 @@ import {
   ProductionRepoWriteOperationHost,
   RepoWriteAuthorityRecoveryGate,
   RepoWriteChildIpcTransport,
+  failureReceipt,
+  makeDaemonQueuedWriteCoordinator,
+  makeDocSyncService,
+  successReceipt,
   type HarnessDaemonRuntime
 } from "@harness-anything/daemon";
+import type { DocSyncSubmitRequestV1 } from "@harness-anything/application";
 import { resolveHarnessLayout } from "@harness-anything/kernel";
 import { defaultCliAdapterProvider } from "./adapter-registry.ts";
 import { cliDaemonCommandHostServices } from "./daemon-command-host-services.ts";
+import { cliDaemonServiceHostServices } from "./daemon-service-host-services.ts";
+import { daemonActorAttribution } from "./actor-attribution.ts";
 import {
   createCliProductionAuthorityLifecycle
 } from "./production-authority-lifecycle.ts";
@@ -168,7 +175,38 @@ export async function runRepoWriteChildEntrypoint(
     hostServices: cliDaemonCommandHostServices,
     outcomeStore: outcomes,
     resolveHistoricalPublication,
-    recoverHistoricalCommittedReceipt: historicalRecovery.recover
+    recoverHistoricalCommittedReceipt: historicalRecovery.recover,
+    executeDocSyncSubmit: async ({ command, decoded }) => {
+      const wireCommand = command.payload.command as {
+        readonly request?: DocSyncSubmitRequestV1;
+      };
+      if (!wireCommand.request) {
+        return failureReceipt(
+          "repo.doc.sync.submit",
+          "doc_sync_invalid_payload",
+          "The writer child received no doc-sync request."
+        );
+      }
+      const attribution = daemonActorAttribution(decoded.actor, decoded.executor);
+      const result = await makeDocSyncService({
+        rootDir: config.canonicalRoot,
+        ...(layoutOverrides ? { layoutOverrides } : {}),
+        hostServices: cliDaemonServiceHostServices.docSync,
+        coordinator: makeDaemonQueuedWriteCoordinator(
+          runtime,
+          `doc-sync-submit:${wireCommand.request.payload.intentId}`,
+          {
+            attribution: attribution.writeAttribution,
+            commitAuthor: attribution.commitAuthor
+          }
+        )
+      }).submit(wireCommand.request);
+      return result.ok
+        ? successReceipt("repo.doc.sync.submit", "completed repo.doc.sync.submit", result as unknown as import("@harness-anything/daemon").JsonObject)
+        : failureReceipt("repo.doc.sync.submit", result.code, result.reason, {
+          data: result as unknown as import("@harness-anything/daemon").JsonObject
+        });
+    }
   });
   let cleanupPromise: Promise<void> | undefined;
   const cleanup = () => {

--- a/packages/cli/src/composition/repo-write-child-entrypoint.ts
+++ b/packages/cli/src/composition/repo-write-child-entrypoint.ts
@@ -197,7 +197,10 @@ export async function runRepoWriteChildEntrypoint(
           `doc-sync-submit:${wireCommand.request.payload.intentId}`,
           {
             attribution: attribution.writeAttribution,
-            commitAuthor: attribution.commitAuthor
+            commitAuthor: attribution.commitAuthor,
+            ...(wireCommand.request.session?.sessionId
+              ? { sessionId: wireCommand.request.session.sessionId }
+              : {})
           }
         )
       }).submit(wireCommand.request);

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -261,7 +261,8 @@ async function runLocalCommand(command: ParsedCommand, config: DaemonClientConfi
           target.repoId,
           docSyncSubmitPaths(command),
           commandExecutor(command),
-          docSyncHostServices
+          docSyncHostServices,
+          Effect.runSync(makeEnvironmentCurrentSessionProbe().currentSession)
         );
       } catch (error) {
         return withRootResolution(docSyncSubmitPreviewRejected(error), rootResolution);
@@ -370,7 +371,8 @@ async function runWithLineClient(
           repoId,
           docSyncSubmitPaths(command),
           commandExecutor(command),
-          docSyncHostServices
+          docSyncHostServices,
+          Effect.runSync(makeEnvironmentCurrentSessionProbe().currentSession)
         );
       } catch (error) {
         return docSyncSubmitPreviewRejected(error);

--- a/packages/cli/test/doc-sync-cli.test.ts
+++ b/packages/cli/test/doc-sync-cli.test.ts
@@ -110,6 +110,7 @@ test("CLI doc sync submit commits eligible prose through the daemon", async () =
   await withTempRoot(async (rootDir) => {
     const harnessRoot = path.join(rootDir, "harness");
     const taskRoot = path.join(harnessRoot, "tasks", "task_01KX3W4V1EDPHPTGWYYBQQ2J75");
+    const sessionBranch = "sessions/doc-sync-cli-test";
     mkdirSync(taskRoot, { recursive: true });
     seedDocSyncWriteRoadRegistry(rootDir);
     writeFileSync(path.join(harnessRoot, "harness.yaml"), [
@@ -138,11 +139,15 @@ test("CLI doc sync submit commits eligible prose through the daemon", async () =
     assert.equal(submitted.report.appliedChanges[0].path, "tasks/task_01KX3W4V1EDPHPTGWYYBQQ2J75/task_plan.md");
     assert.match(gitStatus(harnessRoot), /facts\.md/u);
     const author = await pollUntil(
-      () => execFileSync("git", ["-C", harnessRoot, "log", "-1", "--format=%an <%ae>"], { encoding: "utf8" }).trim(),
+      () => execFileSync("git", ["-C", harnessRoot, "log", "-1", "--format=%an <%ae>", sessionBranch], { encoding: "utf8" }).trim(),
       (candidate) => candidate === "Doc Sync User <harness@example.test>",
       (candidate, error) => JSON.stringify({ candidate, error: String(error ?? ""), submitted })
     );
     assert.equal(author, "Doc Sync User <harness@example.test>");
+    assert.match(
+      execFileSync("git", ["-C", harnessRoot, "show", `${sessionBranch}:tasks/task_01KX3W4V1EDPHPTGWYYBQQ2J75/task_plan.md`], { encoding: "utf8" }),
+      /Updated through daemon/u
+    );
   });
 });
 
@@ -210,7 +215,7 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",
-      env: cliTestEnv({ HARNESS_ACTOR: "agent:doc-sync-cli-test", HARNESS_GIT_AUTHOR_NAME: "Harness Test", HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test", HARNESS_DAEMON_MODE: daemonMode, HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user"), HARNESS_DAEMON_IDLE_MS: "250", GIT_CONFIG_GLOBAL: "/dev/null" })
+      env: cliTestEnv({ CODEX_THREAD_ID: "doc-sync-cli-test", HARNESS_ACTOR: "agent:doc-sync-cli-test", HARNESS_GIT_AUTHOR_NAME: "Harness Test", HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test", HARNESS_DAEMON_MODE: daemonMode, HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user"), HARNESS_DAEMON_IDLE_MS: "250", GIT_CONFIG_GLOBAL: "/dev/null" })
     });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {

--- a/packages/cli/test/production-authority-canonical-ingress-tracer.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress-tracer.test.ts
@@ -82,6 +82,7 @@ test("doc sync submit dispatches prose to the production writer child", { timeou
   const userRoot = defaultDaemonUserRoot(fixture.root);
   const taskId = "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0";
   const planPath = path.join(fixture.authoredRoot, `tasks/${taskId}/task_plan.md`);
+  const sessionBranch = "sessions/doc-sync-production-writer-child";
   const env = {
     HARNESS_ACTOR: "agent:codex",
     HARNESS_DAEMON_MODE: "local",
@@ -107,6 +108,10 @@ test("doc sync submit dispatches prose to the production writer child", { timeou
       "-c", "user.email=harness@example.test",
       "commit", "-q", "-m", "seed doc sync fixture"
     ], { cwd: fixture.authoredRoot });
+    const trunkHead = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: fixture.authoredRoot,
+      encoding: "utf8"
+    }).trim();
 
     const registered = runDaemonCommand(fixture.repoRoot, [
       "daemon", "repo", "register", "--repo-id", "canonical",
@@ -147,7 +152,21 @@ test("doc sync submit dispatches prose to the production writer child", { timeou
       `tasks/${taskId}/task_plan.md`,
       JSON.stringify(submitted.receipt)
     );
-    assert.match(readFileSync(planPath, "utf8"), /Updated through the writer child/u);
+    assert.equal(
+      execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: fixture.authoredRoot,
+        encoding: "utf8"
+      }).trim(),
+      trunkHead
+    );
+    assert.match(readFileSync(planPath, "utf8"), /Original governed prose/u);
+    assert.match(
+      execFileSync("git", ["show", `${sessionBranch}:tasks/${taskId}/task_plan.md`], {
+        cwd: fixture.authoredRoot,
+        encoding: "utf8"
+      }),
+      /Updated through the writer child/u
+    );
     assert.equal(
       execFileSync("git", ["status", "--short", "--", `tasks/${taskId}/task_plan.md`], {
         cwd: fixture.authoredRoot,
@@ -156,7 +175,7 @@ test("doc sync submit dispatches prose to the production writer child", { timeou
       ""
     );
     assert.match(
-      execFileSync("git", ["log", "-1", "--format=%s"], {
+      execFileSync("git", ["log", "-1", "--format=%s", sessionBranch], {
         cwd: fixture.authoredRoot,
         encoding: "utf8"
       }).trim(),

--- a/packages/cli/test/production-authority-canonical-ingress-tracer.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress-tracer.test.ts
@@ -1,6 +1,7 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { readFileSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { copyFileSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { createGitCanonicalPublicationInspector } from "@harness-anything/daemon";
@@ -75,3 +76,109 @@ test("PR canonical ingress tracer starts the real daemon and publishes one full-
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });
+
+test("doc sync submit dispatches prose to the production writer child", { timeout: 60_000 }, async () => {
+  const fixture = createFixture();
+  const userRoot = defaultDaemonUserRoot(fixture.root);
+  const taskId = "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0";
+  const planPath = path.join(fixture.authoredRoot, `tasks/${taskId}/task_plan.md`);
+  const env = {
+    HARNESS_ACTOR: "agent:codex",
+    HARNESS_DAEMON_MODE: "local",
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_IDLE_MS: "60000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
+    CODEX_THREAD_ID: "doc-sync-production-writer-child"
+  };
+  try {
+    mkdirSync(path.join(fixture.repoRoot, "tools"), { recursive: true });
+    copyFileSync(
+      path.resolve("tools/write-road-registry.json"),
+      path.join(fixture.repoRoot, "tools/write-road-registry.json")
+    );
+    writeFileSync(planPath, productionPlan("Original governed prose."));
+    execFileSync("git", [
+      "-c", "user.name=Harness Test",
+      "-c", "user.email=harness@example.test",
+      "add", `tasks/${taskId}/task_plan.md`
+    ], { cwd: fixture.authoredRoot });
+    execFileSync("git", [
+      "-c", "user.name=Harness Test",
+      "-c", "user.email=harness@example.test",
+      "commit", "-q", "-m", "seed doc sync fixture"
+    ], { cwd: fixture.authoredRoot });
+
+    const registered = runDaemonCommand(fixture.repoRoot, [
+      "daemon", "repo", "register", "--repo-id", "canonical",
+      "--canonical-root", fixture.repoRoot, "--user-root", userRoot,
+      "--no-link", "--json"
+    ], env);
+    assert.equal(registered.ok, true, JSON.stringify(registered));
+    try {
+      runDaemonCommand(fixture.repoRoot, [
+        "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
+      ], env);
+    } catch {
+      // Startup can outlive the command's reachability wait.
+    }
+    await pollUntil(
+      () => runDaemonCommand(fixture.repoRoot, [
+        "daemon", "status", "--user-root", userRoot, "--json"
+      ], env),
+      (value) => value.reachable === true,
+      (value, error) => JSON.stringify({ value, error: String(error ?? "") }),
+      { timeoutMs: 20_000 }
+    );
+    writeFileSync(planPath, productionPlan("Updated through the writer child."));
+
+    const submitted = runRawJsonMaybeFail(fixture.repoRoot, [
+      "doc", "sync", "--submit"
+    ], env);
+    assert.equal(submitted.status, 0, JSON.stringify(submitted.receipt));
+    assert.equal(submitted.receipt.ok, true, JSON.stringify(submitted.receipt));
+    assert.equal(submitted.receipt.details?.data?.report?.status, "accepted");
+    assert.equal(
+      submitted.receipt.details?.data?.report?.appliedChanges?.length,
+      1,
+      JSON.stringify(submitted.receipt)
+    );
+    assert.equal(
+      submitted.receipt.details?.data?.report?.appliedChanges?.[0]?.path,
+      `tasks/${taskId}/task_plan.md`,
+      JSON.stringify(submitted.receipt)
+    );
+    assert.match(readFileSync(planPath, "utf8"), /Updated through the writer child/u);
+    assert.equal(
+      execFileSync("git", ["status", "--short", "--", `tasks/${taskId}/task_plan.md`], {
+        cwd: fixture.authoredRoot,
+        encoding: "utf8"
+      }).trim(),
+      ""
+    );
+    assert.match(
+      execFileSync("git", ["log", "-1", "--format=%s"], {
+        cwd: fixture.authoredRoot,
+        encoding: "utf8"
+      }).trim(),
+      /^entity\(doc-sync-submit\): doc-sync\//u
+    );
+  } finally {
+    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+function productionPlan(goal: string): string {
+  return [
+    "# Plan", "",
+    "## Brief", "Brief.",
+    "## Goal", goal,
+    "## Context", "Context.",
+    "## Constraints", "Constraints.",
+    "## Checkpoint", "Checkpoint.",
+    "## CI/Gate Authority Stop Condition", "Stop.",
+    "## Implementation Plan", "Plan.",
+    "## Verification", "Verify.",
+    ""
+  ].join("\n");
+}

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -93,6 +93,7 @@ export * from "./service/command-service.ts";
 export * from "./service/doc-sync-service.ts";
 export * from "./service/service-host.ts";
 export * from "./service/status-payload.ts";
+export * from "./protocol/receipt-envelope.ts";
 export * from "./transport/local-service-transport.ts";
 export * from "./agent-runtime/holder-projection-host.ts";
 export {

--- a/packages/daemon/src/protocol/doc-sync-service-context.ts
+++ b/packages/daemon/src/protocol/doc-sync-service-context.ts
@@ -1,0 +1,11 @@
+import type { TaskHolderExecutor } from "@harness-anything/application";
+import type { AuthenticatedActor } from "../identity/types.ts";
+import type { AuthorityConnectionDispatch } from "./connection-context.ts";
+import type { DaemonRepoNamespace } from "./json-rpc-server.ts";
+
+export interface DocSyncServiceContext {
+  readonly actor?: AuthenticatedActor;
+  readonly executor?: TaskHolderExecutor | null;
+  readonly repo?: DaemonRepoNamespace;
+  readonly authorityConnection?: AuthorityConnectionDispatch;
+}

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -19,6 +19,7 @@ import { commandClassForJsonRpcRequest, currentDaemonProtocolVersion, jsonRpcMet
 import { failureReceipt, serviceResultReceipt, successReceipt } from "./receipt-envelope.ts";
 import { isJsonObject, type JsonObject, type JsonRpcId, type JsonRpcRequest, type JsonRpcResponse, type JsonValue } from "./json-rpc-types.ts";
 import { readTaskHolderExecutor } from "./task-holder-payload.ts";
+import type { DocSyncServiceContext } from "./doc-sync-service-context.ts";
 import {
   bindDaemonRequestPerformanceForRepo,
   callDaemonLogList,
@@ -84,7 +85,6 @@ export interface DaemonRepoAvailabilityFailure {
 export interface DaemonRepoServiceContext {
   readonly repo: DaemonRepoNamespace;
 }
-
 export interface DaemonServiceHost {
   readonly LocalControllerService: LocalControllerService;
   readonly TerminalSessionService: TerminalSessionService;
@@ -104,7 +104,7 @@ export interface DaemonServiceHost {
     }) => Promise<CommandReceipt | CommandFailureReceipt>;
   };
   readonly DocSyncService?: {
-    readonly submit: (request: DocSyncSubmitRequestV1, context?: { readonly actor?: AuthenticatedActor; readonly executor?: TaskHolderExecutor | null; readonly repo?: DaemonRepoNamespace }) => Promise<DocSyncSubmitResultV1>;
+    readonly submit: (request: DocSyncSubmitRequestV1, context?: DocSyncServiceContext) => Promise<DocSyncSubmitResultV1>;
   };
 }
 
@@ -393,7 +393,8 @@ async function callServiceMethod(
     const result = await services.DocSyncService.submit(params as unknown as DocSyncSubmitRequestV1, {
       actor,
       executor: readTaskHolderExecutor(params as JsonObject),
-      repo
+      repo,
+      ...(authorityConnection ? { authorityConnection } : {})
     });
     return result.ok
       ? successReceipt(contract.method, `completed ${contract.method}`, result as unknown as JsonObject)

--- a/packages/daemon/src/runtime/production-progress-append-operation.ts
+++ b/packages/daemon/src/runtime/production-progress-append-operation.ts
@@ -62,6 +62,10 @@ export class ProductionRepoWriteOperationHost<
     readonly outcomeStore: DurableRepoWriteOutcomeStoreV1;
     readonly resolveHistoricalPublication?: RepoWriteAuthorityRecoveryGateOptions["resolveHistoricalPublication"];
     readonly recoverHistoricalCommittedReceipt?: RepoWriteAuthorityRecoveryGateOptions["recoverHistoricalCommittedReceipt"];
+    readonly executeDocSyncSubmit?: (input: {
+      readonly command: RepoWriteCommandDto;
+      readonly decoded: ReturnType<typeof decodeRepoWriteCommand>;
+    }) => Promise<CommandReceiptEnvelope | undefined>;
     readonly now: () => Date;
     readonly newOuterOpId: () => string;
   };
@@ -78,6 +82,10 @@ export class ProductionRepoWriteOperationHost<
     readonly outcomeStore: DurableRepoWriteOutcomeStoreV1;
     readonly resolveHistoricalPublication?: RepoWriteAuthorityRecoveryGateOptions["resolveHistoricalPublication"];
     readonly recoverHistoricalCommittedReceipt?: RepoWriteAuthorityRecoveryGateOptions["recoverHistoricalCommittedReceipt"];
+    readonly executeDocSyncSubmit?: (input: {
+      readonly command: RepoWriteCommandDto;
+      readonly decoded: ReturnType<typeof decodeRepoWriteCommand>;
+    }) => Promise<CommandReceiptEnvelope | undefined>;
     readonly now?: () => Date;
     readonly newOuterOpId?: () => string;
   }) {
@@ -150,6 +158,13 @@ export class ProductionRepoWriteOperationHost<
 
   async direct(input: RepoWriteDirectInput): Promise<import("./repo-write-protocol.ts").RepoWriteJsonObject> {
     const decoded = decodeRepoWriteCommand(input.command);
+    const binding = this.options.authorityComponent.bindConnection(
+      decoded.authorityConnection
+    );
+    const directReceipt = input.command.commandName === "doc-sync-submit"
+      ? await this.options.executeDocSyncSubmit?.({ command: input.command, decoded })
+      : undefined;
+    if (directReceipt) return commandReceiptJsonObject(directReceipt);
     const command = await this.options.hostServices.normalizeCommand(
       this.options.hostServices.parseCommandPayload(input.command.payload),
       decoded.currentSession
@@ -157,9 +172,6 @@ export class ProductionRepoWriteOperationHost<
     if (this.options.hostServices.repoWriteChildExecutionMode(command) !== "direct") {
       throw new Error(`REPO_WRITE_DIRECT_MODE_REQUIRED:${command.action.kind}`);
     }
-    const binding = this.options.authorityComponent.bindConnection(
-      decoded.authorityConnection
-    );
     const commandService = createDaemonCommandService(
       this.options.runtime,
       this.options.hostServices,

--- a/packages/daemon/src/service/doc-sync-journal-failure.ts
+++ b/packages/daemon/src/service/doc-sync-journal-failure.ts
@@ -1,0 +1,88 @@
+import type {
+  DocSyncSubmitRequestV1,
+  DocSyncSubmitResultV1
+} from "@harness-anything/application";
+import type { WriteError } from "@harness-anything/kernel";
+
+export class DocSyncJournalFailure extends Error {
+  readonly writeError: WriteError;
+
+  constructor(writeError: WriteError) {
+    super(writeErrorReason(writeError));
+    this.name = "DocSyncJournalFailure";
+    this.writeError = writeError;
+  }
+}
+
+export function docSyncWriteFailure(
+  request: DocSyncSubmitRequestV1,
+  error: unknown
+): DocSyncSubmitResultV1 | undefined {
+  if (!(error instanceof DocSyncJournalFailure)) return undefined;
+  if (error.writeError._tag === "JournalUnavailable") {
+    return docSyncJournalUnavailable(request, error.message);
+  }
+  return rejection(
+    request,
+    "doc_sync_invalid_payload",
+    error.message,
+    error.writeError._tag === "WriteRejected"
+      ? error.writeError.retryable ?? false
+      : false,
+    error.writeError._tag === "WriteRejected" ? "WriteRejected" : undefined
+  );
+}
+
+export function docSyncJournalUnavailable(
+  request: DocSyncSubmitRequestV1,
+  reason: string
+): DocSyncSubmitResultV1 {
+  return rejection(
+    request,
+    "journal_unavailable",
+    `${reason} Run 'ha daemon status --json', then retry 'ha doc sync --submit'.`,
+    true,
+    "JournalUnavailable"
+  );
+}
+
+function rejection(
+  request: DocSyncSubmitRequestV1,
+  code: Extract<DocSyncSubmitResultV1, { readonly ok: false }>["code"],
+  reason: string,
+  retryable: boolean,
+  tag?: "JournalUnavailable" | "WriteRejected"
+): DocSyncSubmitResultV1 {
+  return {
+    ok: false,
+    ...(tag ? { _tag: tag } : {}),
+    schema: "daemon.doc-sync-submit-result/v1",
+    status: "rejected",
+    intentId: request.payload.intentId,
+    code,
+    reason,
+    retryable
+  };
+}
+
+function writeErrorReason(error: WriteError): string {
+  if (error._tag === "WriteRejected") return error.reason;
+  if (error._tag === "WriteConflict") {
+    return `write conflict${error.owner ? ` owned by ${error.owner}` : ""}`;
+  }
+  if (error._tag === "GlobalWriteConflict") {
+    return `global write conflict${error.owner ? ` owned by ${error.owner}` : ""}`;
+  }
+  return `journal unavailable: ${causeReason(error.cause)}`;
+}
+
+function causeReason(cause: unknown): string {
+  if (cause instanceof Error) return cause.stack ?? cause.message;
+  if (typeof cause === "string") return cause;
+  if (cause === undefined) return "no cause was provided";
+  try {
+    return JSON.stringify(cause);
+  } catch {
+    return String(cause);
+  }
+}

--- a/packages/daemon/src/service/doc-sync-service.ts
+++ b/packages/daemon/src/service/doc-sync-service.ts
@@ -10,7 +10,8 @@ import {
   type HarnessLayoutOverrides,
   type SemanticDiffCandidateTree,
   type SemanticDiffDocumentPolicy,
-  type WriteCoordinator
+  type WriteCoordinator,
+  type WriteError
 } from "@harness-anything/kernel";
 import { compileManagedCandidateTreeV2, type DaemonDocSyncHostServices } from "@harness-anything/application";
 import {
@@ -29,6 +30,7 @@ import {
   type RegistryRow,
   type TouchedZone
 } from "@harness-anything/application/doc-sync";
+import { DocSyncJournalFailure, docSyncWriteFailure } from "./doc-sync-journal-failure.ts";
 
 export interface DocSyncServiceOptions {
   readonly rootDir: string;
@@ -91,7 +93,8 @@ export function buildDocSyncSubmitRequest(
   repoId: string,
   selectedPaths: ReadonlyArray<string> = [],
   executor?: { readonly kind: "agent"; readonly id: string } | null,
-  hostServices?: DaemonDocSyncHostServices
+  hostServices?: DaemonDocSyncHostServices,
+  session?: DocSyncSubmitRequestV1["session"]
 ): DocSyncSubmitRequestV1 {
   if (!hostServices) throw new Error("doc-sync host services are required");
   const report = buildDocSyncReport(rootInput, hostServices);
@@ -136,6 +139,7 @@ export function buildDocSyncSubmitRequest(
   return {
     repo: { repoId },
     ...(executor !== undefined ? { executor } : {}),
+    ...(session ? { session } : {}),
     payload: {
       baseLedgerSha: report.baseLedgerSha,
       intentId: `intent_${sha256Text(intentMaterial).slice(0, 24)}`,
@@ -273,7 +277,7 @@ async function submitDocSyncRequest(options: DocSyncServiceOptions, request: Doc
     }
     if (validation.acceptedChanges.length > 0) {
       coordinatorStarted = true;
-      await Effect.runPromise(options.coordinator!.enqueue({
+      await runDocSyncJournalEffect(options.coordinator!.enqueue({
         opId: request.payload.intentId,
         entityId: docSyncEntityId(request.payload.intentId),
         kind: "doc_sync_submit",
@@ -287,7 +291,7 @@ async function submitDocSyncRequest(options: DocSyncServiceOptions, request: Doc
           }))
         }
       }));
-      await Effect.runPromise(options.coordinator!.flush("explicit"));
+      await runDocSyncJournalEffect(options.coordinator!.flush("explicit"));
     }
     const appliedLedgerSha = gitText(layout.authoredRoot, ["rev-parse", "HEAD"]) ?? "no-git-head";
     return {
@@ -307,8 +311,18 @@ async function submitDocSyncRequest(options: DocSyncServiceOptions, request: Doc
     };
   } catch (error) {
     if (!coordinatorStarted && beforeFiles) restoreFiles(layout.authoredRoot, beforeFiles);
+    const writeFailure = docSyncWriteFailure(request, error);
+    if (writeFailure) return writeFailure;
     return reject(request, "doc_sync_invalid_payload", error instanceof Error ? error.message : String(error), false);
   }
+}
+
+async function runDocSyncJournalEffect<A>(
+  effect: Effect.Effect<A, WriteError>
+): Promise<A> {
+  const result = await Effect.runPromise(Effect.either(effect));
+  if (result._tag === "Left") throw new DocSyncJournalFailure(result.left);
+  return result.right;
 }
 
 function compileDocSyncSemanticPlan(

--- a/packages/daemon/src/service/doc-sync-submit-handler.ts
+++ b/packages/daemon/src/service/doc-sync-submit-handler.ts
@@ -53,7 +53,10 @@ export function makeDocSyncSubmitHandler(options: {
           `doc-sync-submit:${request.payload.intentId}`,
           {
             attribution: attribution.writeAttribution,
-            commitAuthor: attribution.commitAuthor
+            commitAuthor: attribution.commitAuthor,
+            ...(request.session?.sessionId
+              ? { sessionId: request.session.sessionId }
+              : {})
           }
         )
       } : {})

--- a/packages/daemon/src/service/doc-sync-submit-handler.ts
+++ b/packages/daemon/src/service/doc-sync-submit-handler.ts
@@ -1,0 +1,62 @@
+import type {
+  AuthorityHostAttribution,
+  DaemonDocSyncHostServices,
+  DocSyncSubmitRequestV1,
+  DocSyncSubmitResultV1,
+  TaskHolderExecutor
+} from "@harness-anything/application";
+import type { HarnessLayoutOverrides } from "@harness-anything/kernel";
+import type { AuthenticatedActor } from "../identity/types.ts";
+import type { DocSyncServiceContext } from "../protocol/doc-sync-service-context.ts";
+import type { HarnessDaemonRuntime } from "../runtime/repo-runtime.ts";
+import type { RepoWriteProcessSupervisor } from "../runtime/repo-write-process-supervisor.ts";
+import { makeDaemonQueuedWriteCoordinator } from "../lifecycle/queued-write-coordinator.ts";
+import { makeDocSyncService } from "./doc-sync-service.ts";
+import { dispatchDocSyncSubmitToWriter } from "./doc-sync-writer-dispatch.ts";
+
+export function makeDocSyncSubmitHandler(options: {
+  readonly rootDir: string;
+  readonly layoutOverrides?: HarnessLayoutOverrides;
+  readonly runtime: HarnessDaemonRuntime;
+  readonly hostServices: DaemonDocSyncHostServices;
+  readonly actorAttribution: (
+    actor: AuthenticatedActor,
+    executor: TaskHolderExecutor | null
+  ) => AuthorityHostAttribution;
+  readonly supervisor?: RepoWriteProcessSupervisor;
+}): (
+  request: DocSyncSubmitRequestV1,
+  context?: DocSyncServiceContext
+) => Promise<DocSyncSubmitResultV1> {
+  return async (request, context) => {
+    const actor = context?.actor;
+    const attribution = actor
+      ? options.actorAttribution(actor, context?.executor ?? null)
+      : undefined;
+    if (options.supervisor) {
+      return dispatchDocSyncSubmitToWriter({
+        rootDir: options.rootDir,
+        request,
+        actor,
+        executor: context?.executor,
+        authority: context?.authorityConnection,
+        supervisor: options.supervisor
+      });
+    }
+    return makeDocSyncService({
+      rootDir: options.rootDir,
+      layoutOverrides: options.layoutOverrides,
+      hostServices: options.hostServices,
+      ...(attribution ? {
+        coordinator: makeDaemonQueuedWriteCoordinator(
+          options.runtime,
+          `doc-sync-submit:${request.payload.intentId}`,
+          {
+            attribution: attribution.writeAttribution,
+            commitAuthor: attribution.commitAuthor
+          }
+        )
+      } : {})
+    }).submit(request);
+  };
+}

--- a/packages/daemon/src/service/doc-sync-writer-dispatch.ts
+++ b/packages/daemon/src/service/doc-sync-writer-dispatch.ts
@@ -1,0 +1,74 @@
+import type {
+  DocSyncSubmitRequestV1,
+  DocSyncSubmitResultV1,
+  TaskHolderExecutor
+} from "@harness-anything/application";
+import type { CurrentSessionRef } from "@harness-anything/kernel";
+import type { AuthenticatedActor } from "../identity/types.ts";
+import type { AuthorityConnectionDispatch } from "../protocol/connection-context.ts";
+import { encodeRepoWriteCommand } from "../runtime/repo-write-progress-command.ts";
+import type { RepoWriteProcessSupervisor } from "../runtime/repo-write-process-supervisor.ts";
+import { docSyncJournalUnavailable } from "./doc-sync-journal-failure.ts";
+
+export async function dispatchDocSyncSubmitToWriter(input: {
+  readonly rootDir: string;
+  readonly request: DocSyncSubmitRequestV1;
+  readonly actor?: AuthenticatedActor;
+  readonly executor?: TaskHolderExecutor | null;
+  readonly authority?: AuthorityConnectionDispatch;
+  readonly supervisor: RepoWriteProcessSupervisor;
+}): Promise<DocSyncSubmitResultV1> {
+  const currentSession = docSyncCurrentSession(input.request);
+  if (!input.actor || !input.authority?.available || !currentSession) {
+    return docSyncJournalUnavailable(
+      input.request,
+      "The doc-sync writer child requires an active authenticated authority connection and current session."
+    );
+  }
+  try {
+    input.authority.assertActive();
+    const receipt = await input.supervisor.direct(encodeRepoWriteCommand({
+      command: {
+        rootDir: input.rootDir,
+        action: { kind: "doc-sync-submit" },
+        request: input.request
+      },
+      context: {
+        actor: input.actor,
+        authorityConnection: input.authority.context,
+        currentSession,
+        executor: input.executor ?? null
+      }
+    }));
+    const report = receipt.details?.data;
+    return isDocSyncSubmitResult(report)
+      ? report
+      : docSyncJournalUnavailable(input.request, "The doc-sync writer child returned no typed report.");
+  } catch (error) {
+    return docSyncJournalUnavailable(
+      input.request,
+      error instanceof Error ? error.stack ?? error.message : String(error)
+    );
+  }
+}
+
+function docSyncCurrentSession(request: DocSyncSubmitRequestV1): CurrentSessionRef | undefined {
+  const session = request.session;
+  if (!session?.sessionId || !session.runtime || session.runtime === "unknown"
+    || !session.source || !session.detectedAt) return undefined;
+  return {
+    runtime: session.runtime,
+    sessionId: session.sessionId,
+    source: session.source,
+    detectedAt: session.detectedAt,
+    ...(session.user ? { user: session.user } : {})
+  };
+}
+
+function isDocSyncSubmitResult(value: unknown): value is DocSyncSubmitResultV1 {
+  return typeof value === "object" && value !== null
+    && "schema" in value
+    && value.schema === "daemon.doc-sync-submit-result/v1"
+    && "ok" in value
+    && typeof value.ok === "boolean";
+}

--- a/packages/daemon/src/service/service-host.ts
+++ b/packages/daemon/src/service/service-host.ts
@@ -23,7 +23,6 @@ import {
 import type { HarnessDaemonRuntime, MultiRepoHarnessDaemonRuntime } from "../runtime/repo-runtime.ts";
 import { makeLocalLifecycleEngine } from "@harness-anything/adapter-local";
 import { createDaemonCommandService, type DaemonCommandServiceOptions } from "./command-service.ts";
-import { makeDocSyncService } from "./doc-sync-service.ts";
 import {
   createDaemonControlService,
   type DaemonLaunchConfiguration
@@ -31,7 +30,6 @@ import {
 import { failClosedReservationReconcilerCoordinator } from "../lifecycle/reservation-reconciler.ts";
 import { makeDaemonLogFileStore } from "../lifecycle/daemon-log-file-store.ts";
 import { drainDaemonRuntime, isDaemonDrainTimeout } from "../lifecycle/daemon-drain.ts";
-import { makeDaemonQueuedWriteCoordinator } from "../lifecycle/queued-write-coordinator.ts";
 import { makeLocalAgentHolderServices } from "../agent-runtime/holder-projection-host.ts";
 import { createJsonRpcProtocolServer } from "../protocol/json-rpc-server.ts";
 import { createDaemonReconcileState, reconcileDaemonRepoRegistry, type DaemonReconcileState } from "../runtime/registry-reconciler.ts";
@@ -56,6 +54,7 @@ import {
   sortedDaemonRepos
 } from "./daemon-host-boundary-policy.ts";
 import { repoWriteCommandDispatch } from "./repo-write-command-dispatch.ts";
+import { makeDocSyncSubmitHandler } from "./doc-sync-submit-handler.ts";
 
 export { localAuthorityPeerPolicy } from "./daemon-host-boundary-policy.ts";
 
@@ -519,23 +518,14 @@ function createRepoServiceBinding<
       } : {}),
       CliCommandService: daemonCommandService,
       DocSyncService: {
-        submit: (request, context) => {
-          const actor = context?.actor;
-          const attribution = actor ? hostServices.daemonActorAttribution(actor, context?.executor ?? null) : undefined;
-          const docSyncService = makeDocSyncService({
-            rootDir,
-            layoutOverrides,
-            hostServices: hostServices.docSync,
-            ...(attribution ? {
-              coordinator: makeDaemonQueuedWriteCoordinator(runtime, `doc-sync-submit:${request.payload.intentId}`, {
-                attribution: attribution.writeAttribution,
-                commitAuthor: attribution.commitAuthor,
-                ...(request.session?.sessionId ? { sessionId: request.session.sessionId } : {})
-              })
-            } : {})
-          });
-          return docSyncService.submit(request);
-        }
+        submit: makeDocSyncSubmitHandler({
+          rootDir,
+          layoutOverrides,
+          runtime,
+          hostServices: hostServices.docSync,
+          actorAttribution: hostServices.daemonActorAttribution,
+          ...(repoWriteSupervisor ? { supervisor: repoWriteSupervisor } : {})
+        })
       }
     },
     appendRuntimeEvent

--- a/packages/daemon/test/doc-sync-journal-failure.test.ts
+++ b/packages/daemon/test/doc-sync-journal-failure.test.ts
@@ -1,0 +1,33 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  DocSyncJournalFailure,
+  docSyncWriteFailure,
+} from "../src/service/doc-sync-journal-failure.ts";
+
+const request = {
+  repo: { repoId: "canonical" },
+  payload: {
+    baseLedgerSha: "base",
+    intentId: "intent-journal-unavailable",
+    declaredIntent: "prose-edit" as const,
+    changes: []
+  }
+};
+
+test("doc sync preserves the journal throw site and classifies coordinator failure", () => {
+  const journalCause = new Error("writer capsule rejected parent-owned journal flush");
+  const result = docSyncWriteFailure(request, new DocSyncJournalFailure({
+    _tag: "JournalUnavailable",
+    cause: journalCause
+  }));
+  assert.equal(result?.ok, false);
+  if (!result || result.ok) assert.fail("expected a doc-sync journal rejection");
+  assert.equal(result._tag, "JournalUnavailable");
+  assert.equal(result.code, "journal_unavailable");
+  assert.equal(result.retryable, true);
+  assert.match(result.reason, /writer capsule rejected parent-owned journal flush/u);
+  assert.match(result.reason, /doc-sync-journal-failure\.test\.ts/u);
+  assert.doesNotMatch(result.reason, /"cause":\{\}/u);
+});


### PR DESCRIPTION
# English

## Summary

`ha doc sync --submit` — the only governed path for hand-authored task-package prose (closeout.md, task_plan.md, artifacts/*) to reach the ledger — failed 100% of the time on the production daemon with `doc_sync_invalid_payload` / `{"_tag":"JournalUnavailable","cause":{}}`, while `ha doc sync --dry-run` and `ha doc status` succeeded on the same files. Read path worked, write path was broken. The consequence is that any task with hand-authored prose can never pass `ha task complete`'s `task_tree_dirty` gate; 24 uncommitted entries had accumulated under `harness/tasks/` across many historical task packages.

Root cause: in the production parent/child daemon topology, the parent doc-sync service built a write coordinator on its own **reader** runtime and called `requireWriterAttached()` there. The parent is a reader; only the writer child has the writer attached, so the call failed closed. A single-process fixture (parent is also the writer) never reproduced it, which is why it slipped through. This PR routes the submit to the writer child, where the writer is actually attached.

## What Changed

- New `packages/daemon/src/service/doc-sync-submit-handler.ts` and `doc-sync-writer-dispatch.ts`: when a writer-child supervisor exists (production), the submit is forwarded to the child via `supervisor.direct(encodeRepoWriteCommand({ action: { kind: "doc-sync-submit" }, request }))`, carrying the authenticated actor, authority connection, executor, and current session. When there is no supervisor (single-process), it falls back to the previous in-parent path unchanged.
- `packages/cli/src/composition/repo-write-child-entrypoint.ts`: the writer child gains an `executeDocSyncSubmit` handler that runs the identical `makeDocSyncService(...).submit(request)` against the child's writer-attached runtime, rebuilding attribution from the forwarded actor/executor. All existing validation — forbidden-touch, CAS watermark, post-apply bearing check, semantic diff compilation — runs unchanged; only the execution location moved from parent to child.
- New `packages/daemon/src/service/doc-sync-journal-failure.ts`: introduces a distinct `journal_unavailable` result code (retryable, with a `ha daemon status` next step) instead of mislabeling a journal failure as `doc_sync_invalid_payload`, and preserves the real `WriteError` cause and stack, including the previously blank `cause: {}` case.
- `packages/cli/src/daemon/client.ts`: the CLI now sends the current-session probe with the submit so the writer-child path has the session context it requires.

## Task And Scope

- Harness task: `task_01KYARDY4WPFH2HHHXN3JJNN8X`
- Related prior delivery: `task_01KX8YW0Y3EBX6FFYZME6CDF8D` / PR #641 first shipped `ha doc sync --submit`; this PR fixes a production-topology defect in it, not a missing feature.
- Branch: `fix/doc-sync-submit-journal-unavailable`
- Public scope: daemon doc-sync service and dispatch, writer-child entrypoint, CLI client session plumbing, and their tests.
- Out of scope: the two related lifecycle defects filed separately — `scanIntegrity` O(history) per write (`task_01KYASBZVHX6XBD43C85845G6F`) and lease-TTL-shorter-than-a-write plus the submitted-plus-dirty exit-less state (`task_01KYASCCD07YQ3P79R71WP0BQ0`).

## Version Impact

- Version: no version change; internal daemon write-routing correctness fix.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KYARDY4WPFH2HHHXN3JJNN8X`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `dc7b153d5ce3405080833152a7ed7d0d4d797173`
- Branch merge-base with `origin/main`: `dc7b153d5ce3405080833152a7ed7d0d4d797173`
- Last `git fetch origin` time: 2026-07-24T19:12Z
- Sync method: branched from `origin/main` at `dc7b153d`; no rebase needed.
- Public diff command: `git diff dc7b153d5ce3405080833152a7ed7d0d4d797173..133e8db5`
- Private evidence commit/path: `harness/tasks/task_01KYARDY4WPFH2HHHXN3JJNN8X-*/`
- Reviewer evidence path: not applicable
- GitHub Actions `rewrite-ci` run URL: see the checks on this PR
- [x] `git diff --check`
- [x] `npm run check:local` — passed (worker run: 34 manifest gates, 533 affected fast tests, 423 contract tests + 1 platform skip, changed-file lint)
- [x] `npm run typecheck` — passed
- [x] Targeted tests for the change surface, named with their counts: new integration test `doc sync submit dispatches prose to the production writer child` in `production-authority-canonical-ingress-tracer.test.ts`, plus `doc-sync-journal-failure.test.ts`. **Double-sided control run by the reviewer:** with all source reverted to base and only the test kept, this test fails with the exact production symptom `{"_tag":"JournalUnavailable","cause":{}}` / `doc_sync_invalid_payload`; with the fix restored it passes and a real `entity(doc-sync-submit): doc-sync/…` commit lands.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending on this PR.
- Not run, and why: end-to-end verification against the live production daemon is the post-merge acceptance step, since the production daemon runs from the main checkout. The reproduction is instead pinned by the writer-child integration test above.

## Review Evidence

- CEO semantic acceptance: read the full mechanism, not just the report. Confirmed the writer child runs the identical `makeDocSyncService(...).submit()` with all validation gates intact, that attribution is rebuilt from the forwarded actor, and that no gate was relaxed and no arbitrary working-tree staging was introduced. Confirmed the fallback (no supervisor) preserves single-process behavior, which explains why simple fixtures passed.
- Double-sided control run independently by the reviewer, as recorded under Verification.
- Adversarial review focus (production write path): (1) whether a writer-child IPC loss after commit but before response can now mis-report a landed write, and (2) whether the new hard requirement for a current session on the writer-child path can reject a legitimate production submit. See Residual Risk.
- Adversarial review round found and fixed one blocking defect CI did not catch: the initial commit (cca12e05) silently dropped `request.session.sessionId` from both new write-coordinator constructions, which routed doc-sync commits directly to trunk instead of the session branch (`publication/git.ts` checks out `sessions/<id>` only when sessionId is present). Fixed in `133e8db5` by threading sessionId through both paths, matching base semantics. The integration test now asserts trunk HEAD is unchanged and the write lands on `sessions/<id>`; the reviewer's double-sided control was reproduced independently — reverting the thread-through fails the test because the write hits trunk.
- Blocking findings: none (after the round-2 fix).

## Residual Risk

- The writer-child dispatch uses the existing volatile direct transport lane. The inner journal write is durable and intent-addressed, but an IPC loss after the child commits and before the response reaches the parent can still produce an uncertain outer result — the same receipt-after-commit uncertainty that exists elsewhere on this path, neither introduced nor removed here.
- The writer-child path now requires a resolvable current session; a context where the session probe yields runtime "unknown" would be rejected with `journal_unavailable` rather than served. doc-sync submit is an interactive authoring action, so this is expected, but it is a behavioral tightening relative to the pre-existing optional-session parent path.
- The 24 already-accumulated dirty task-package entries are not committed by this PR; they need a follow-up sweep once this lands, run through the now-working `doc sync --submit`.

## References

- Task: `task_01KYARDY4WPFH2HHHXN3JJNN8X`
- Prior delivery of the command: `task_01KX8YW0Y3EBX6FFYZME6CDF8D` / PR #641 (`27d69375`)
- Related follow-ups: `task_01KYASBZVHX6XBD43C85845G6F`, `task_01KYASCCD07YQ3P79R71WP0BQ0`

---

# 中文

## 概要

`ha doc sync --submit`——**人手写的任务包文稿（closeout.md、task_plan.md、artifacts/*）进台账的唯一治理路径**——在生产 daemon 上 100% 失败，报 `doc_sync_invalid_payload` / `{"_tag":"JournalUnavailable","cause":{}}`，而 `ha doc sync --dry-run` 与 `ha doc status` 对同一批文件都成功。**读路通、写路断。** 后果是任何写过手改文稿的任务都过不了 `ha task complete` 的 `task_tree_dirty` 门；`harness/tasks/` 下已积压 24 条未提交项，跨多个历史任务包。

根因：在生产的父/子 daemon 拓扑里，父 doc-sync 服务在自己的**读端** runtime 上构造写协调器并调用 `requireWriterAttached()`。父进程是 reader，只有 writer 子进程挂着 writer，于是该调用 fail-closed。单进程夹具（父进程同时是 writer）从不复现，因此漏了过去。本 PR 把 submit 路由到真正挂着 writer 的子进程。

## 改动内容

- 新增 `doc-sync-submit-handler.ts` 与 `doc-sync-writer-dispatch.ts`：存在 writer 子进程 supervisor（生产）时，submit 经 `supervisor.direct(encodeRepoWriteCommand({ action: { kind: "doc-sync-submit" }, request }))` 转发给子进程，携带已认证的 actor、authority 连接、executor 与当前 session；无 supervisor（单进程）时回退到原父进程路径，不变。
- `repo-write-child-entrypoint.ts`：writer 子进程新增 `executeDocSyncSubmit`，对子进程挂着 writer 的 runtime 跑**完全相同的** `makeDocSyncService(...).submit(request)`，并从转发来的 actor/executor 重建归属。**所有既有校验——forbidden-touch、CAS watermark、post-apply bearing 检查、语义 diff 编译——原样运行；只是执行位置从父进程挪到了子进程。**
- 新增 `doc-sync-journal-failure.ts`：引入独立的 `journal_unavailable` 结果码（retryable，附 `ha daemon status` 下一步），不再把 journal 失败误标成 `doc_sync_invalid_payload`，并保留真实的 `WriteError` cause 与栈——包括此前空白的 `cause: {}` 情形。
- `client.ts`：CLI 现在随 submit 一起发送当前 session 探针，让 writer 子进程路径拿到它需要的 session 上下文。

## 任务与范围

- Harness 任务：`task_01KYARDY4WPFH2HHHXN3JJNN8X`
- 相关既往交付：`task_01KX8YW0Y3EBX6FFYZME6CDF8D` / PR #641 首次交付 `ha doc sync --submit`；本 PR 修的是其中一个**生产拓扑缺陷**，不是缺功能。
- 分支：`fix/doc-sync-submit-journal-unavailable`
- 公开范围：daemon doc-sync 服务与 dispatch、writer 子进程入口、CLI client session 接线及其测试。
- 不在范围：另立的两条生命周期缺陷——`scanIntegrity` 每写 O(历史)（`task_01KYASBZVHX6XBD43C85845G6F`），以及 lease TTL 短于一次写 + submitted-plus-脏树 无出口状态（`task_01KYASCCD07YQ3P79R71WP0BQ0`）。

## 版本影响

- 版本：不升版；daemon 内部写路由正确性修复。
- 发布影响：不发布

## 治理声明

- 触碰 protected surface：否
- Protected surface 范围：不适用
- 授权：`task_01KYARDY4WPFH2HHHXN3JJNN8X`
- 机器检查边界：本 PR 只断言声明存在；声明是否属实、是否充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`dc7b153d5ce3405080833152a7ed7d0d4d797173`
- 分支与 `origin/main` 的 merge-base：`dc7b153d5ce3405080833152a7ed7d0d4d797173`
- 最近一次 `git fetch origin` 时间：2026-07-24T19:12Z
- 同步方式：从 `origin/main` 的 `dc7b153d` 起分支；无需 rebase。
- 公开 diff 命令：`git diff dc7b153d5ce3405080833152a7ed7d0d4d797173..133e8db5`
- 私有证据提交／路径：`harness/tasks/task_01KYARDY4WPFH2HHHXN3JJNN8X-*/`
- 评审证据路径：不适用
- GitHub Actions `rewrite-ci` 运行 URL：见本 PR 的 checks
- [x] `git diff --check`
- [x] `npm run check:local`——通过（worker 跑：34 manifest 门、533 fast、423 contract + 1 平台 skip、changed-file lint）
- [x] `npm run typecheck`——通过
- [x] 针对改动面的定向测试及其条数：新增集成测试 `doc sync submit dispatches prose to the production writer child`（`production-authority-canonical-ingress-tracer.test.ts`），及 `doc-sync-journal-failure.test.ts`。**评审者亲跑双侧对照**：把全部 src 退回 base、只留测试，该测试以**完全相同的生产症状** `{"_tag":"JournalUnavailable","cause":{}}` / `doc_sync_invalid_payload` 失败；恢复修复后通过，并落下一个真实的 `entity(doc-sync-submit): doc-sync/…` 提交。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威的完整门）——本 PR 上待跑。
- 未跑及原因：对活的生产 daemon 的端到端验证是**合并后的验收步骤**（生产 daemon 跑 main 检出）。复现改由上面的 writer 子进程集成测试钉住。

## 审查证据

- CEO 语义验收：读的是完整机制而非报告。确认 writer 子进程跑的是**完全相同的** `makeDocSyncService(...).submit()`、所有校验门保留、归属从转发的 actor 重建、未削任何门、未引入任意工作区 staging；确认无 supervisor 的回退保留单进程行为——这解释了为何简单夹具能过。
- 双侧对照由评审者独立跑过，见「验证」。
- 对抗复核聚焦（生产写路）：(1) writer 子进程在 commit 之后、response 之前的 IPC 丢失是否会把已落盘的写误报；(2) writer 子进程路径新增的 current-session 硬要求是否会拒绝合法的生产 submit。见「残余风险」。
- 对抗复核轮发现并修掉一个 CI 未捕获的阻塞缺陷：初始提交（cca12e05）在两处新的写协调器构造里静默丢掉了 `request.session.sessionId`，导致 doc-sync 提交直接落在 trunk 而非 session 分支（`publication/git.ts` 仅在 sessionId 存在时 checkout `sessions/<id>`）。已在 `133e8db5` 修复：在两条路径上按 base 语义把 sessionId 接回。集成测试现在断言 trunk HEAD 不变、写落在 `sessions/<id>`；评审者的双侧对照已独立复现——撤掉接线该测试即失败（写落到 trunk）。
- 阻塞性发现：无（round-2 修复后）。

## 残余风险

- writer 子进程 dispatch 走的是既有的 volatile direct 传输通道。内层 journal 写是持久且 intent 寻址的，但子进程 commit 之后、response 到达父进程之前的 IPC 丢失，仍可能产生不确定的外层结果——这是该路径上既有的「回执晚于 commit」不确定性，本 PR 既未引入也未消除。
- writer 子进程路径现在要求可解析的 current session；session 探针得出 runtime "unknown" 的上下文会被以 `journal_unavailable` 拒绝而非受理。doc-sync submit 是交互式创作动作，故属预期，但相对此前父进程「session 可选」是一次行为收紧。
- 已积压的 24 条脏任务包项**不由本 PR 提交**；待本 PR 合入后，用已修好的 `doc sync --submit` 做一次补交扫尾。

## 关联材料

- 任务：`task_01KYARDY4WPFH2HHHXN3JJNN8X`
- 该命令的既往交付：`task_01KX8YW0Y3EBX6FFYZME6CDF8D` / PR #641（`27d69375`）
- 相关后续：`task_01KYASBZVHX6XBD43C85845G6F`、`task_01KYASCCD07YQ3P79R71WP0BQ0`
