### PR TITLE
fix(ci): expose nightly authority failures and repair load-bearing evidence

### DIFF
--- a/.github/workflows/main-red-notify.yml
+++ b/.github/workflows/main-red-notify.yml
@@ -2,7 +2,7 @@ name: main-red-notify
 
 on:
   workflow_run:
-    workflows: ["rewrite-ci"]
+    workflows: ["rewrite-ci", "nightly-integration"]
     branches: [main]
     types: [completed]
 

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   decisionEntityId,
   createTaskPackagePath,
+  moduleEntityId,
   sha256Text,
   taskEntityId
 } from "../../../kernel/src/index.ts";
@@ -95,7 +96,12 @@ test("production service route preserves progress dry-run and publishes canonica
       (status, error) => JSON.stringify({ status, error: error instanceof Error ? error.message : String(error ?? "") }),
       { timeoutMs: 20_000 }
     );
-    assert.equal(status.repoCount, 2, JSON.stringify(status));
+    assert.equal(status.repoCount, 1, JSON.stringify(status));
+    assert.deepEqual(
+      (status.repos as ReadonlyArray<{ readonly repoId?: string }>).map((repo) => repo.repoId),
+      ["canonical"],
+      "the explicit production authority manifest must bound the active service inventory"
+    );
 
     verifyProductionPresetIngress(fixture, env);
 
@@ -410,7 +416,9 @@ test("production generic canonical ingress accepts and journals one write for ev
   const daemon = defaultCliAdapterProvider().createMultiRepoDaemonRuntime({
     repos: [{ repoId: "canonical", rootDir: fixture.repoRoot }],
     materializerPollMs: 5,
-    materializerMaxBranchesPerBatch: 1
+    materializerMaxBranchesPerBatch: 1,
+    generationAxes: fixture.generationAxes,
+    generationWitness: fixture.generationWitness
   });
   try {
     await daemon.start();

--- a/packages/cli/test/production-authority-canonical-ingress/fixture.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/fixture.ts
@@ -9,7 +9,13 @@ import {
   firstPinAuthorityKeyV1,
   type AuthorityStoredOperationRecord
 } from "../../../application/src/index.ts";
-import { openLocalAuthorityKeyStore } from "../../../daemon/src/index.ts";
+import {
+  createDaemonGenerationWitness,
+  localUserDaemonEndpoint,
+  openLocalAuthorityKeyStore,
+  publishNextDaemonGeneration,
+  readOrCreateDaemonMachineId
+} from "../../../daemon/src/index.ts";
 import { executionDeclaration, type ExecutionRecord } from "../../../kernel/src/index.ts";
 import { authorityNamespaceProofBytes } from "@harness-anything/daemon";
 
@@ -22,6 +28,21 @@ export function createFixture() {
   const auxiliaryRoot = path.join(root, "auxiliary");
   const auxiliaryAuthoredRoot = path.join(auxiliaryRoot, "harness");
   const serviceRoot = path.join(root, "service-state");
+  const daemonUserRoot = path.join(root, ".daemon-user");
+  const endpointIdentity = localUserDaemonEndpoint(daemonUserRoot);
+  const machineId = readOrCreateDaemonMachineId(daemonUserRoot);
+  const generation = publishNextDaemonGeneration({
+    userRoot: daemonUserRoot,
+    endpointIdentity,
+    machineId,
+    daemonInstanceId: `production-fixture-${process.pid}`
+  });
+  const generationAxes = { machineId, daemonGeneration: generation.daemonGeneration };
+  const generationWitness = createDaemonGenerationWitness({
+    userRoot: daemonUserRoot,
+    endpointIdentity,
+    ...generationAxes
+  });
   const keyStateDirectory = path.join(serviceRoot, "keys/canonical");
   mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0"), { recursive: true });
   mkdirSync(serviceRoot, { recursive: true, mode: 0o700 });
@@ -145,7 +166,7 @@ export function createFixture() {
       }]
     })
   );
-  const transcriptPath = path.join(root, "session-transcript.md");
+  const transcriptPath = path.join(root, "session-transcript.jsonl");
   writeFileSync(transcriptPath, `${JSON.stringify({ timestamp: "2026-07-17T00:00:00.000Z", type: "event_msg", payload: { type: "user_message", message: "Production session ingress." } })}\n`);
   writeFileSync(path.join(authoredRoot, "people.yaml"), [
     "schema: harness-people/v1", "people:", "  - personId: person_alice", "    displayName: Alice",
@@ -194,7 +215,19 @@ export function createFixture() {
   mkdirSync(auxiliaryAuthoredRoot, { recursive: true });
   writeFileSync(path.join(auxiliaryAuthoredRoot, "harness.yaml"), "schema: harness-anything/v1\nproject: auxiliary-ingress\n");
   git(auxiliaryAuthoredRoot, "init", "-q"); git(auxiliaryAuthoredRoot, "add", "."); git(auxiliaryAuthoredRoot, "commit", "-q", "-m", "seed auxiliary ingress fixture");
-  return { root, repoRoot, authoredRoot, auxiliaryRoot, serviceRoot, manifestPath, actor, transcriptPath, publicHead };
+  return {
+    root,
+    repoRoot,
+    authoredRoot,
+    auxiliaryRoot,
+    serviceRoot,
+    manifestPath,
+    actor,
+    transcriptPath,
+    publicHead,
+    generationAxes,
+    generationWitness
+  };
 }
 
 export function enablePresetAwareTaskCreate(authoredRoot: string): void {

--- a/packages/cli/test/production-authority-canonical-ingress/minimal-parameter-matrix.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/minimal-parameter-matrix.ts
@@ -29,6 +29,7 @@ export function verifyTypedMinimalParameterMatrix(
     "task-relate": { argv: ["task", "relate", missingTask, "depends-on", "task_01KXT3E1MN1VBS64DCNZ4VX81E", "--rationale", "minimal"], outcome: "guided-error" },
     "task-code-doc-reconcile": { argv: ["task", "code-doc", "reconcile", missingTask, "--commit", fixture.publicHead, "--path", "README.md"], outcome: "guided-error" },
     "task-consent-record": { argv: ["task", "consent-record", missingTask, "--execution-id", missingExecution, "--utterance", "Approved"], outcome: "guided-error" },
+    "task-retire-execution": { argv: ["task", "retire-execution", missingTask, "--execution-id", missingExecution, "--reason", "minimal"], outcome: "guided-error" },
     "task-review-execution": { argv: ["task", "review-execution", missingTask, "--execution-id", missingExecution, "--verdict", "dismissed", "--findings", "none", "--rationale", "minimal"], outcome: "guided-error" },
     "task-complete": { argv: ["task", "complete", missingTask], outcome: "guided-error" },
     "decision-propose": { argv: ["decision", "propose", "--title", "Minimal ingress decision", "--question", "Minimal?", "--chosen", "Yes", "--rejected", "No", "--why-not", "Not selected"], outcome: "success" },

--- a/packages/cli/test/production-authority-host-services/adapter-golden.test.ts
+++ b/packages/cli/test/production-authority-host-services/adapter-golden.test.ts
@@ -32,7 +32,9 @@ test("all four production ingress adapters retain canonical envelope and receipt
   const daemon = defaultCliAdapterProvider().createMultiRepoDaemonRuntime({
     repos: [{ repoId: "canonical", rootDir: fixture.repoRoot }],
     materializerPollMs: 5,
-    materializerMaxBranchesPerBatch: 1
+    materializerMaxBranchesPerBatch: 1,
+    generationAxes: fixture.generationAxes,
+    generationWitness: fixture.generationWitness
   });
   const lifecycle = createCliProductionAuthorityLifecycle({ manifestPath: fixture.manifestPath });
   try {

--- a/packages/cli/test/production-authority-host-services/fixtures/batch5a-parent-differential.json
+++ b/packages/cli/test/production-authority-host-services/fixtures/batch5a-parent-differential.json
@@ -30,8 +30,8 @@
         "sha256": "aaa618d11cd1805e081c0f503c6efe8ff20b2269ca415f9ad0e5180fefa8ea37"
       },
       "receipt": {
-        "byteLength": 1368,
-        "sha256": "4fd7d4dc44cd68d0b08c5458fad2e8859e670b69d3a37ade8979cc4e6f203d42"
+        "byteLength": 1404,
+        "sha256": "802b04ae40daba5b6f7dc10395222861de1ab1eb5b0cb1b93f893fd7255befcd"
       }
     },
     "observedWrite": {

--- a/packages/cli/test/production-authority-startup-performance.test.ts
+++ b/packages/cli/test/production-authority-startup-performance.test.ts
@@ -1,10 +1,21 @@
 // harness-test-tier: nightly
 // harness-test-tier-decision: dec_01KXZ2WZMB8YS18F549K8BMM7H
 import assert from "node:assert/strict";
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
 import path from "node:path";
 import test from "node:test";
-import { openDurableAuthorityServiceState } from "@harness-anything/daemon";
+import {
+  openDurableAuthorityServiceState,
+  requestLocalDaemonJsonRpc
+} from "@harness-anything/daemon";
 import {
   defaultDaemonUserRoot,
   pollUntil,
@@ -28,9 +39,10 @@ test("production service exposes its socket while authority recovery scans histo
   // Windows writable authority remains deferred, and its process startup cost
   // is not comparable to the qualified POSIX service path measured here.
   skip: process.platform === "win32" ? "production writable recovery performance is POSIX-qualified" : false
-}, async () => {
+}, async (t) => {
   const fixture = createFixture();
   const userRoot = defaultDaemonUserRoot(fixture.root);
+  const recoveryBarrier = installRecoveryScanBarrier(fixture.authoredRoot, fixture.root);
   const env = {
     HARNESS_ACTOR: "agent:codex",
     HARNESS_DAEMON_MODE: "local",
@@ -38,7 +50,8 @@ test("production service exposes its socket while authority recovery scans histo
     HARNESS_DAEMON_IDLE_MS: "60000",
     HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
     HARNESS_DAEMON_REQUEST_TIMEOUT_MS: "35000",
-    CODEX_THREAD_ID: "service-recovery-session"
+    CODEX_THREAD_ID: "service-recovery-session",
+    PATH: `${recoveryBarrier.binRoot}:${process.env.PATH ?? ""}`
   };
   const watermarkPath = path.join(
     fixture.serviceRoot,
@@ -62,23 +75,51 @@ test("production service exposes its socket while authority recovery scans histo
     assert.equal(registered.ok, true, JSON.stringify(registered));
 
     const coldStartedAt = Date.now();
-    runDaemonCommand(fixture.repoRoot, [
+    const coldStart = runRawJsonAsync(fixture.repoRoot, [
       "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
     ], env);
+    await pollUntil(
+      () => existsSync(recoveryBarrier.enteredPath),
+      (entered) => entered,
+      (entered, error) => JSON.stringify({ entered, error: String(error ?? "") }),
+      { timeoutMs: 20_000 }
+    );
+    const statusDuringRecovery = await pollUntil(
+      () => readDirectDaemonStatus(fixture.repoRoot, userRoot),
+      (status) => status.schema === "daemon-status/v2",
+      (status, error) => JSON.stringify({ status, error: String(error ?? "") }),
+      { timeoutMs: 20_000 }
+    );
     const coldSocketMs = Date.now() - coldStartedAt;
-    const statusDuringRecovery = runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env);
-    assert.equal(statusDuringRecovery.reachable, true, JSON.stringify(statusDuringRecovery));
-    assert.equal(existsSync(watermarkPath), false, "cold full scan must still be in progress when the socket is first reachable");
+    assert.equal(statusDuringRecovery.schema, "daemon-status/v2", JSON.stringify(statusDuringRecovery));
+    assertRecoveryStillInProgress(
+      readRecoveryWatermark(watermarkPath),
+      "cold full scan must still be in progress when the socket is first reachable"
+    );
+    recoveryBarrier.release();
+    const coldStartReceipt = await coldStart;
+    assert.equal(coldStartReceipt.ok, true, JSON.stringify(coldStartReceipt));
     const admittedPromise = runRawJsonAsync(fixture.repoRoot, [
       "task", "progress", "append", "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4", "--text", "must wait for recovery"
     ], env);
     const [admitted] = await Promise.all([admittedPromise, pollUntil(
-      () => existsSync(watermarkPath) ? JSON.parse(readFileSync(watermarkPath, "utf8")) as { readonly commitSha?: string } : undefined,
-      (watermark) => watermark?.commitSha === coldHead,
+      () => readRecoveryWatermark(watermarkPath),
+      (watermark) => watermark?.schema === "authority-recovery-watermark/v1" && watermark.commitSha === coldHead,
       (watermark, error) => JSON.stringify({ watermark, error: String(error ?? "") }),
       { timeoutMs: 30_000 }
     )]);
     assert.equal(admitted.ok, true, JSON.stringify(admitted));
+    await t.test("positive control: a socket serialized after completed recovery fails the in-progress assertion", async () => {
+      const statusAfterRecovery = await readDirectDaemonStatus(fixture.repoRoot, userRoot);
+      assert.equal(statusAfterRecovery.schema, "daemon-status/v2", JSON.stringify(statusAfterRecovery));
+      assert.throws(
+        () => assertRecoveryStillInProgress(
+          readRecoveryWatermark(watermarkPath),
+          "completed recovery must not satisfy the in-progress signal"
+        ),
+        /completed recovery must not satisfy the in-progress signal/u
+      );
+    });
     const coldRecoveryMs = Date.now() - coldStartedAt;
     assert.equal(authorityOperationRecords(fixture.serviceRoot).find((record) => record.opId === "namespace-production:unpublished-startup")?.state, "REJECTED");
     const committed = runRawJsonMaybeFail(fixture.repoRoot, [
@@ -97,8 +138,8 @@ test("production service exposes its socket while authority recovery scans histo
     ], env);
     const incrementalSocketMs = Date.now() - incrementalStartedAt;
     await pollUntil(
-      () => JSON.parse(readFileSync(watermarkPath, "utf8")) as { readonly commitSha?: string },
-      (watermark) => watermark.commitSha === incrementalHead,
+      () => readRecoveryWatermark(watermarkPath),
+      (watermark) => watermark?.schema === "authority-recovery-watermark/v1" && watermark.commitSha === incrementalHead,
       (watermark, error) => JSON.stringify({ watermark, error: String(error ?? "") }),
       { timeoutMs: 10_000 }
     );
@@ -107,7 +148,93 @@ test("production service exposes its socket while authority recovery scans histo
     assert.ok(incrementalRecoveryMs < coldRecoveryMs, JSON.stringify({ incrementalRecoveryMs, coldRecoveryMs }));
     console.log(JSON.stringify({ coldSocketMs, coldRecoveryMs, incrementalSocketMs, incrementalRecoveryMs }));
   } finally {
+    recoveryBarrier.release();
     await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });
+
+interface RecoveryWatermark {
+  readonly schema?: string;
+  readonly phase?: string;
+  readonly commitSha?: string;
+}
+
+function readRecoveryWatermark(watermarkPath: string): RecoveryWatermark | undefined {
+  return existsSync(watermarkPath)
+    ? JSON.parse(readFileSync(watermarkPath, "utf8")) as RecoveryWatermark
+    : undefined;
+}
+
+function assertRecoveryStillInProgress(
+  watermark: RecoveryWatermark | undefined,
+  message: string
+): void {
+  assert.equal(
+    watermark === undefined
+      || (watermark.schema === "authority-recovery-watermark/v2" && watermark.phase === "partial"),
+    true,
+    message
+  );
+}
+
+async function readDirectDaemonStatus(
+  repoRoot: string,
+  userRoot: string
+): Promise<Record<string, unknown>> {
+  const response = await requestLocalDaemonJsonRpc(
+    repoRoot,
+    "repo.daemon.status",
+    { repo: { repoId: "canonical" } },
+    1_000,
+    { userRoot, allowLegacySocket: false }
+  );
+  assert.equal(response.ok, true, JSON.stringify(response));
+  return (response.details as { readonly data: Record<string, unknown> }).data;
+}
+
+function installRecoveryScanBarrier(
+  authoredRoot: string,
+  fixtureRoot: string
+): {
+  readonly binRoot: string;
+  readonly enteredPath: string;
+  readonly release: () => void;
+} {
+  const binRoot = path.join(fixtureRoot, "recovery-git-wrapper");
+  const enteredPath = path.join(fixtureRoot, "recovery-scan-entered");
+  const releasePath = path.join(fixtureRoot, "recovery-scan-release");
+  const realGit = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
+  mkdirSync(binRoot, { recursive: true });
+  const wrapperPath = path.join(binRoot, "git");
+  writeFileSync(wrapperPath, [
+    "#!/usr/bin/env node",
+    'import { spawnSync } from "node:child_process";',
+    'import { existsSync, writeFileSync } from "node:fs";',
+    'import path from "node:path";',
+    `const realGit = ${JSON.stringify(realGit)};`,
+    `const authoredRoot = ${JSON.stringify(authoredRoot)};`,
+    `const enteredPath = ${JSON.stringify(enteredPath)};`,
+    `const releasePath = ${JSON.stringify(releasePath)};`,
+    "const args = process.argv.slice(2);",
+    'if (args[0] === "-C" && path.resolve(args[1] ?? "") === authoredRoot',
+    '  && args[2] === "log" && args.includes("--first-parent") && !existsSync(releasePath)) {',
+    '  writeFileSync(enteredPath, "entered\\n");',
+    "  while (!existsSync(releasePath)) {",
+    "    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);",
+    "  }",
+    "}",
+    'const result = spawnSync(realGit, args, { stdio: "inherit" });',
+    "if (result.error) throw result.error;",
+    "process.exit(result.status ?? 1);",
+    ""
+  ].join("\n"));
+  chmodSync(wrapperPath, 0o755);
+  return {
+    binRoot,
+    enteredPath,
+    release: () => {
+      if (!existsSync(releasePath)) writeFileSync(releasePath, "released\n");
+    }
+  };
+}

--- a/tools/main-red-notify.test.mjs
+++ b/tools/main-red-notify.test.mjs
@@ -23,7 +23,7 @@ function extractWorkflowScript() {
   return lines.slice(marker + 1).filter((line) => line.startsWith("            ")).map((line) => line.slice(12)).join("\n");
 }
 
-function workflowHarness({ conclusion, runId, headSha, openIssues = [], jobs = [] }) {
+function workflowHarness({ conclusion, runId, headSha, workflowName = "rewrite-ci", openIssues = [], jobs = [] }) {
   const calls = { comments: [], creates: [], labels: [], updates: [] };
   const listForRepo = () => {};
   const listJobsForWorkflowRun = () => {};
@@ -51,7 +51,8 @@ function workflowHarness({ conclusion, runId, headSha, openIssues = [], jobs = [
         conclusion,
         head_sha: headSha,
         html_url: `https://github.com/example/repo/actions/runs/${runId}`,
-        id: runId
+        id: runId,
+        name: workflowName
       }
     }
   };
@@ -113,7 +114,7 @@ test("workflow stays notify-only and uses the declared minimal permissions", () 
   const workflow = readFileSync(new URL("../.github/workflows/main-red-notify.yml", import.meta.url), "utf8");
 
   assert.match(workflow, /workflow_run:/u);
-  assert.match(workflow, /workflows: \["rewrite-ci"\]/u);
+  assert.match(workflow, /workflows: \["rewrite-ci", "nightly-integration"\]/u);
   assert.match(workflow, /branches: \[main\]/u);
   assert.match(workflow, /types: \[completed\]/u);
   assert.match(workflow, /permissions:\n  actions: read\n  issues: write/u);
@@ -143,6 +144,23 @@ test("workflow failure path creates the locally tested issue content", async () 
     headSha: "abc123",
     failedJobs: ["full-check (24)"]
   }));
+});
+
+test("nightly-integration failure follows the same main-red issue path", async () => {
+  const harness = workflowHarness({
+    conclusion: "failure",
+    runId: 44,
+    headSha: "nightly123",
+    workflowName: "nightly-integration",
+    jobs: [{ name: "production-authority-perf-matrix", conclusion: "failure" }]
+  });
+  await harness.run();
+
+  assert.equal(harness.calls.creates.length, 1);
+  assert.equal(harness.calls.creates[0].title, mainRedIssueTitle);
+  assert.deepEqual(harness.calls.creates[0].labels, [mainRedLabel]);
+  assert.match(harness.calls.creates[0].body, /production-authority-perf-matrix/u);
+  assert.match(harness.calls.creates[0].body, /actions\/runs\/44/u);
 });
 
 test("workflow does not duplicate the same run and ignores stale completions", async () => {


### PR DESCRIPTION
# English

## Summary

`nightly-integration` had been failing for five consecutive nights (07-20 through 07-24) and produced **zero** notifications, because `main-red-notify.yml` only listened to `rewrite-ci`. The load-bearing evidence that proves production authority composition works end-to-end had been dead for five days and nobody could have known. This PR makes that failure visible and repairs the tests that can honestly be repaired.

This is the first landing item of `dec_01KYC6RAWG57W4JHPA78NJ9SRM` criterion 2: "load-bearing evidence must run inside a merge-blocking gate and be currently green". Until that holds, no "the gates are green" conclusion in this repo carries weight.

## What Changed

- `main-red-notify` now listens to `nightly-integration` in addition to `rewrite-ci`, so a nightly failure follows the same main-red issue path.
- Three production-authority tests repaired at the fixture level (missing `generationAxes` / `generationWitness`, one missing import, one golden fixture drift).
- `production-authority-startup-performance.test.ts`: the assertion `existsSync(watermarkPath) === false` asserted a **timing race** ("the cold scan must still be running when the socket first becomes reachable"), which only passes on a machine slow enough. It is replaced by a deterministic barrier: a scoped `git` wrapper blocks exactly the recovery scan's `git -C <authoredRoot> log --first-parent` call, so the property under test — socket reachability does not wait on recovery completion — is observed rather than raced. A **positive control** subtest asserts that a socket serialized *after* recovery completes fails the in-progress assertion.
- `tools/main-red-notify.test.mjs` extended to cover the nightly path (9 tests).

## Task And Scope

- Harness task: `task_01KYC6WAAF5ART5J64MJE9Y5Z4`
- Branch: `fix/c1-load-bearing-evidence-visibility`
- Public scope: notification wiring, nightly-tier test repair, one test assertion replacement
- Private planning/evidence updated: yes
- Out of scope: the writer-child error-classification defect (see Residual Risk), the kind gate (claim falsified, see below)

## Version Impact

- Version: no version change because this touches CI wiring and tests only
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `.github/workflows/main-red-notify.yml`
- Authority: `dec_01KYC6RAWG57W4JHPA78NJ9SRM` (PLT-Remote go/no-go criteria, criterion 2), task `task_01KYC6WAAF5ART5J64MJE9Y5Z4`. Authorization is limited to **adding** a nightly listener to `main-red-notify`; it does not extend to adding/removing required checks, branch protection, or Mergify conditions, and none of those are touched.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: `task_01KYC8D0RJSZV1VVG76K6S064A`

## Verification

- Base `origin/main` SHA: `da529e30be0898d26da9a225c4ae757cc8e6fb77`
- Branch merge-base with `origin/main`: `da529e30be0898d26da9a225c4ae757cc8e6fb77`
- Last `git fetch origin` time: 2026-07-25, immediately before opening this PR
- Sync method: none needed
- Public diff command: `git diff da529e30be0898d26da9a225c4ae757cc8e6fb77..HEAD`
- Private evidence commit/path: `harness/tasks/task_01KYC6WAAF5ART5J64MJE9Y5Z4-.../`
- Reviewer evidence path: same
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `git diff --check`
- [x] Targeted tests for the change surface, named with their counts:
  - `production generic canonical ingress accepts and journals one write for every directly compiled kind` — 1 pass
  - `all four production ingress adapters retain canonical envelope and receipt bytes` — 1 pass
  - `production service exposes its socket while authority recovery scans history` + `positive control: a socket serialized after completed recovery fails the in-progress assertion` — 2 pass
  - `tools/main-red-notify.test.mjs` — 9 pass, including `nightly-integration failure follows the same main-red issue path`
  - `npm run typecheck` — exit 0
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why:
  - `npm run check:stop-point` not run: per the repo's local-load policy the worker stop point is targeted tests plus commit; the full matrix is GitHub CI's job.
  - **The real `workflow_run` trigger cannot be proven locally.** YAML validity, listener conditions, permissions and a simulated failure path are verified; end-to-end proof requires one actual nightly completion. Stated here rather than claimed as verified.

## Review Evidence

- Self-review: CEO read the full diff, independently confirmed the barrier is scoped to the fixture root and released in `finally`, and independently confirmed the replaced assertion now fails closed (a v1/complete watermark does not satisfy the in-progress predicate).
- Reviewer subagent: implementation worker reported two checkpoint escalations rather than working around them; both were adjudicated by CEO.
- Human review: pending
- Blocking findings: none outstanding on this diff

## Residual Risk

- **`nightly-integration` will still be red after this merges**, on one test: a semantic rejection (`AUTHORITY_MANUAL_ENTITY_ID_FORBIDDEN`) is laundered into `repo_write_child_unavailable` by a catch-all at `packages/daemon/src/runtime/repo-write-child-direct.ts:110-116`. That is a production defect, out of this task's authorized surface, and is carried by `task_01KYC8D0RJSZV1VVG76K6S064A` (in progress). It was deliberately **not** papered over by changing the assertion. This PR does not leave that red behind — it is what makes it visible.
- Consequence: the new nightly notification will fire until that task lands.
- The kind gate change listed in the task brief was **not made**: the audit's claim that a kind gate accepts 8 names instead of set-equality was falsified. A constructed missing-kind case produces `AUTHORITY_CUTOVER_V2_WRITER_KIND_SET_INCOMPLETE: missing=execution:unexpected=none` and exits 1 — the gate already fails closed on missing, extra and duplicate kinds. Reporting the falsification rather than changing a correct gate to produce a deliverable.

## References

- Task: `task_01KYC6WAAF5ART5J64MJE9Y5Z4`
- Evidence: `harness/tasks/task_01KYC2606AVJP56GTH2BJQCENC-r1-p1/artifacts/r1-verdict.md`
- Review: `dec_01KYC6RAWG57W4JHPA78NJ9SRM`

---

# 中文

## 概要

`nightly-integration` 连红 5 夜（07-20 至 07-24），却产生了**零**通知——因为 `main-red-notify.yml` 只监听 `rewrite-ci`。证明生产 authority composition 端到端成立的那份承重证据死了 5 天，而系统结构性地看不见它。本 PR 让这次失败变得可见，并修好那些能被诚实修好的测试。

这是 `dec_01KYC6RAWG57W4JHPA78NJ9SRM` 判据 2「承重证据必须跑在会阻塞合并的门内且当前绿」的第一个落地项。在它成立之前，本仓任何「门是绿的」结论都不具效力。

## 改动内容

- `main-red-notify` 在 `rewrite-ci` 之外增加监听 `nightly-integration`，使 nightly 失败走与 main 红同一条 issue 路径。
- 三个 production-authority 测试在夹具层面修好（漏传 `generationAxes` / `generationWitness`、一处漏导入、一份 golden 夹具漂移）。
- `production-authority-startup-performance.test.ts`：原断言 `existsSync(watermarkPath) === false` 断的是一个**时序竞态**（「socket 首次可达时冷扫描必须仍在进行中」），只在机器够慢时才绿。改为确定性屏障：一个作用域受限的 `git` wrapper 只拦截恢复扫描那一次 `git -C <authoredRoot> log --first-parent`，使被测的**性质**——socket 可达性不等待恢复完成——被观测而不是被撞运气。并增加**阳性对照**子测试：断言一个在恢复完成之后才可达的 socket 会让 in-progress 断言失败。
- `tools/main-red-notify.test.mjs` 扩展覆盖 nightly 路径（9 个测试）。

## 任务与范围

- Harness 任务：`task_01KYC6WAAF5ART5J64MJE9Y5Z4`
- 分支：`fix/c1-load-bearing-evidence-visibility`
- 公开范围：通知接线、nightly 层测试修复、一处测试断言替换
- 私有规划/证据已更新：是
- 范围外：writer-child 错误分类缺陷（见残余风险）、kind 门（说法已证伪，见下）

## 版本影响

- 版本：不变更，因为只触碰 CI 接线与测试
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是
- 受保护面范围：`.github/workflows/main-red-notify.yml`
- 依据：`dec_01KYC6RAWG57W4JHPA78NJ9SRM`（PLT-Remote 开工判据，判据 2）、任务 `task_01KYC6WAAF5ART5J64MJE9Y5Z4`。授权范围**仅限**为 `main-red-notify` 增加 nightly 监听，**不含**增删 required check、改分支保护、改 Mergify 条件，本 PR 也未触碰这三者。
- 机器检查边界：本 PR 只断言声明存在；声明是否为真且充分由评审者判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：`task_01KYC8D0RJSZV1VVG76K6S064A`

## 验证

- 基线 `origin/main` SHA：`da529e30be0898d26da9a225c4ae757cc8e6fb77`
- 分支与 `origin/main` 的 merge-base：`da529e30be0898d26da9a225c4ae757cc8e6fb77`
- 最近一次 `git fetch origin`：2026-07-25，开 PR 前
- 同步方式：无需同步
- 公开 diff 命令：`git diff da529e30be0898d26da9a225c4ae757cc8e6fb77..HEAD`
- 私有证据 commit/路径：`harness/tasks/task_01KYC6WAAF5ART5J64MJE9Y5Z4-.../`
- 评审者证据路径：同上
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑
- [x] `git diff --check`
- [x] 改动面定向测试及其计数：
  - `production generic canonical ingress accepts and journals one write for every directly compiled kind` — 1 pass
  - `all four production ingress adapters retain canonical envelope and receipt bytes` — 1 pass
  - `production service exposes its socket while authority recovery scans history` + `positive control: a socket serialized after completed recovery fails the in-progress assertion` — 2 pass
  - `tools/main-red-notify.test.mjs` — 9 pass，含 `nightly-integration failure follows the same main-red issue path`
  - `npm run typecheck` — exit 0
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威的完整门）
- 未跑及原因：
  - `npm run check:stop-point` 未跑：按本仓本机负载治理，worker 停止点是定向测试 + commit，完整门矩阵是 GitHub CI 的活。
  - **真实 `workflow_run` 触发无法在本地证明。** 已验证 YAML 合法性、监听条件、权限与模拟 failure 路径；端到端证明需要一次真实 nightly completion。此处如实标注，不当作已验证。

## 审查证据

- 自审：CEO 通读全 diff，独立确认屏障作用域限于夹具根且在 `finally` 释放，独立确认替换后的断言 fail-closed（v1/complete watermark 不满足 in-progress 谓词）。
- 复核 subagent：实现 worker 命中两条 checkpoint 主动停下上报而非绕开，两条均由 CEO 裁决。
- 人工复核：待
- 阻塞性发现：本 diff 上无未决项

## 残余风险

- **合入后 `nightly-integration` 仍会红**，红在一个测试上：一个语义拒绝（`AUTHORITY_MANUAL_ENTITY_ID_FORBIDDEN`）被 `packages/daemon/src/runtime/repo-write-child-direct.ts:110-116` 的 catch-all 洗成 `repo_write_child_unavailable`。那是生产缺陷，超出本任务授权面，由 `task_01KYC8D0RJSZV1VVG76K6S064A` 承载（进行中）。**没有**靠改断言把它糊过去。这条红不是本 PR 留下的，本 PR 正是让它变得可见的东西。
- 后果：新增的 nightly 通知会持续触发，直到该任务合入。
- 任务 brief 里列的 kind 门改动**没有做**：审计所称「某处 kind 门只要求 8 名而非集合相等」已被证伪。构造缺项用例产出 `AUTHORITY_CUTOVER_V2_WRITER_KIND_SET_INCOMPLETE: missing=execution:unexpected=none` 并退出 1——该门对缺项、多项、重复项均已 fail-closed。如实报告证伪结果，不为凑交付物去改一道正确的门。

## 关联材料

- 任务：`task_01KYC6WAAF5ART5J64MJE9Y5Z4`
- 证据：`harness/tasks/task_01KYC2606AVJP56GTH2BJQCENC-r1-p1/artifacts/r1-verdict.md`
- 复核：`dec_01KYC6RAWG57W4JHPA78NJ9SRM`
