### PR TITLE
fix(daemon): render wide characters in GUI terminal sessions

### DIFF
--- a/packages/daemon/src/terminal/pty-host.ts
+++ b/packages/daemon/src/terminal/pty-host.ts
@@ -126,7 +126,7 @@ export function createPtyTerminalSessionService(options: PtyTerminalSessionServi
       if (useTmux) tmuxNamespaces.set(sessionId, namespace);
       const pty = spawnPty(
         useTmux ? String(tmuxProbe.executable) : shell,
-        useTmux ? ["new-session", "-A", "-s", namespace, "-c", cwd, shell] : [],
+        useTmux ? ["-u", "new-session", "-A", "-s", namespace, "-c", cwd, shell] : [],
         {
         name: "xterm-256color",
         columns: defaultColumns,
@@ -230,7 +230,7 @@ export function createPtyTerminalSessionService(options: PtyTerminalSessionServi
     const output = outputBySession.get(payload.sessionId) ?? createOutputState();
     outputBySession.set(payload.sessionId, output);
     try {
-      const pty = spawnPty(tmuxProbe.executable, ["attach-session", "-t", namespace], {
+      const pty = spawnPty(tmuxProbe.executable, ["-u", "attach-session", "-t", namespace], {
         name: "xterm-256color",
         columns: defaultColumns,
         rows: defaultRows,
@@ -421,12 +421,28 @@ function nodePtySpawner(shell: string, args: ReadonlyArray<string>, options: Pty
 }
 
 function terminalEnvironment(source: NodeJS.ProcessEnv, cwd: string): Record<string, string> {
+  const inherited = Object.fromEntries(
+    Object.entries(source).filter((entry): entry is [string, string] => typeof entry[1] === "string")
+  );
   return {
-    ...Object.fromEntries(Object.entries(source).filter((entry): entry is [string, string] => typeof entry[1] === "string")),
+    ...inherited,
+    ...utf8CtypeOverride(inherited),
     TERM: "xterm-256color",
     COLORTERM: "truecolor",
     PWD: cwd
   };
+}
+
+/**
+ * A launchd-started daemon usually inherits no locale at all, so terminal children run under the
+ * C locale: tmux then renders every wide character as `_` and shells mangle multibyte input.
+ * Fill in a UTF-8 LC_CTYPE only when no inherited variable already selects one.
+ */
+function utf8CtypeOverride(inherited: Record<string, string>): Record<string, string> {
+  const selected = inherited.LC_ALL ?? inherited.LC_CTYPE ?? inherited.LANG ?? "";
+  if (/utf-?8/i.test(selected)) return {};
+  // LC_ALL outranks LC_CTYPE, so a non-UTF-8 LC_ALL has to be replaced rather than supplemented.
+  return inherited.LC_ALL === undefined ? { LC_CTYPE: "C.UTF-8" } : { LC_ALL: "C.UTF-8" };
 }
 
 function canonicalDirectory(value: string): string {

--- a/packages/daemon/test/pty-host.test.ts
+++ b/packages/daemon/test/pty-host.test.ts
@@ -90,7 +90,7 @@ test("daemon registry restores a durable tmux session and reattaches without res
       tmux: controller,
       spawnPty: (command, args) => {
         assert.equal(command, "tmux");
-        assert.deepEqual(args, ["attach-session", "-t", createdNamespace]);
+        assert.deepEqual(args, ["-u", "attach-session", "-t", createdNamespace]);
         return attachedPty.pty;
       }
     });
@@ -105,6 +105,48 @@ test("daemon registry restores a durable tmux session and reattaches without res
       confirmation: "terminate-terminal-session"
     }).ok, true);
     assert.equal(namespaceState.size, 0);
+  } finally {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("terminal children get a UTF-8 ctype and tmux runs in UTF-8 mode", () => {
+  const workspaceRoot = mkdtempSync(path.join(tmpdir(), "ha-pty-utf8-"));
+  const controller = {
+    probe: () => ({ available: true, executable: "tmux", version: "tmux 3.4" }),
+    hasSession: () => true,
+    killSession: () => undefined
+  };
+  try {
+    const spawns: Array<{ readonly args: ReadonlyArray<string>; readonly env: Record<string, string> }> = [];
+    const service = createPtyTerminalSessionService({
+      workspaceRoot,
+      tmux: controller,
+      env: { PATH: process.env.PATH ?? "", LANG: "", LC_CTYPE: "C" },
+      createId: () => "term-utf8",
+      spawnPty: (_command, args, options) => {
+        spawns.push({ args, env: options.env });
+        return fakePty().pty;
+      }
+    });
+    assert.equal(service.createSession({ name: "Locale" }).ok, true);
+    // `tmux -u` renders wide characters even when the daemon inherited no locale at all.
+    assert.equal(spawns[0]?.args[0], "-u");
+    assert.equal(spawns[0]?.env.LC_CTYPE, "C.UTF-8");
+
+    const utf8Inherited = createPtyTerminalSessionService({
+      workspaceRoot,
+      tmux: controller,
+      env: { PATH: process.env.PATH ?? "", LANG: "zh_CN.UTF-8" },
+      createId: () => "term-utf8-inherited",
+      spawnPty: (_command, args, options) => {
+        spawns.push({ args, env: options.env });
+        return fakePty().pty;
+      }
+    });
+    assert.equal(utf8Inherited.createSession({ name: "Locale inherited" }).ok, true);
+    assert.equal(spawns[1]?.env.LC_CTYPE, undefined);
+    assert.equal(spawns[1]?.env.LANG, "zh_CN.UTF-8");
   } finally {
     rmSync(workspaceRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
# English

## Summary

Chinese (and any other wide-character) output was unreadable in the GUI terminal: every CJK character rendered as `_`. The cause is not the font, not xterm.js, and not tmux's storage — it is that the tmux **client** the daemon spawns runs without a UTF-8 locale. A launchd-started daemon typically inherits no locale at all, and `terminalEnvironment()` in `packages/daemon/src/terminal/pty-host.ts` set only `TERM`/`COLORTERM`/`PWD`, leaving locale to inheritance. In non-UTF-8 mode tmux substitutes `_` for every cell of a wide character, which is exactly the observed corruption.

Discriminating experiment against real tmux, holding the server at `LANG=zh_CN.UTF-8` and varying only the client:

| client condition | bytes tmux writes to the pty |
| --- | --- |
| no `LANG`/`LC_*` | `____ABC` |
| `LANG=en_US.UTF-8` | correct UTF-8 for `汉字ABC` |
| no locale, but `tmux -u` | correct UTF-8 for `汉字ABC` |

The client decides, and the client is the pty the daemon spawns. Because tmux stores real UTF-8 in its cells and only mangles at output time, existing sessions are repaired on reattach — including their scrollback — not just newly created ones.

## What Changed

- `pty-host.ts`: spawn tmux with `-u` at both spawn sites (`new-session` on create, `attach-session` on reattach), so the client stays in UTF-8 mode regardless of the inherited locale.
- `pty-host.ts`: `terminalEnvironment()` fills in a UTF-8 `LC_CTYPE` **only when no inherited variable already selects a UTF-8 locale**. A non-UTF-8 `LC_ALL` is rewritten instead, because `LC_ALL` outranks `LC_CTYPE`. This second layer is for the shell inside the pane and its children — with `-u` alone, typing Chinese into the terminal and listing Chinese filenames would still break, and it also covers `direct-pty` sessions, which never involve tmux.
- `pty-host.test.ts`: new test asserting both the `-u` argv and the conditional `LC_CTYPE`, with a negative case proving an inherited `LANG=zh_CN.UTF-8` is left untouched. Existing attach assertion updated for the new argv.

## Task And Scope

- Harness task: none — direct defect fix under the standing fix-on-discovery authorization
- Branch: `fix/terminal-tmux-utf8-locale`
- Public scope: `packages/daemon/src/terminal/pty-host.ts` and its test; 2 files, +62/-4
- Private planning/evidence updated: no
- Out of scope: the per-workspace `tmux` / `direct-pty` **backend toggle** and the orphan-tmux-session cleanup channel. Both are clauses of an already-active decision and are already scoped into the planned task `task_01KXQK02NFG67KFR679EYSAMMJ` (W-C1); they stay there deliberately rather than being carved off here. This PR does not change which backend is chosen — `tmux` remains the default on platforms where it is available.

## Version Impact

- Version: no version change because this is a defect fix inside an existing runtime path with no surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable — the manifest's protected surfaces in this neighbourhood are `packages/daemon-client/src/**` and the `check-cli-daemon-parity` tooling, neither of which is in this diff
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `763f13fa1df75cfed44923657659e8438315eb9b`
- Branch merge-base with `origin/main`: `763f13fa1df75cfed44923657659e8438315eb9b`
- Last `git fetch origin` time: 2026-07-25T09:31:23Z
- Sync method: rebase
- Public diff command: `git diff 763f13fa1df75cfed44923657659e8438315eb9b..HEAD`
- Private evidence commit/path: not applicable — no task package
- Reviewer evidence path: not applicable
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` — 34 complete manifest gates green in 75.8s
- [x] Targeted tests for the change surface, named with their counts:
  - `node tools/run-node-tests.mjs --tier fast --prefix packages/daemon/test` — 157 pass / 0 fail
  - new: `terminal children get a UTF-8 ctype and tmux runs in UTF-8 mode` — 1 pass
  - `pty host spawns at the project root and streams input output resize and exit` — 1 pass
  - `daemon registry restores a durable tmux session and reattaches without respawn-as-resume` (attach argv assertion updated) — 1 pass
  - `npm run typecheck` (`tsc -b`) — exit 0; `eslint` on both changed files — exit 0
- [x] Manual end-to-end confirmation in the running GUI terminal by the repo owner, after rebuilding the CLI distribution and restarting the daemon
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why:
  - Integration tier is not part of the stop-point gate set, so it was not run locally; GitHub CI owns it. The change surface is fast-tier covered.
  - The stop point itself reports 20 broader or environment-only gates it leaves to CI (`check-cli-daemon-parity`, `check-github-required-contexts`, `check-kernel-dead-exports` and others). They were not run locally, by policy.
  - The GUI pane could not be driven by tooling — the renderer's terminal needs the Electron IPC bridge, so loading the dev server in a plain browser would not exercise it. The pixel-level confirmation above is therefore human, and is reported as human rather than claimed as automated.

## Review Evidence

- Self-review: mechanism established by the discriminating tmux experiment above before any code was written, so the fix targets a measured cause rather than a plausible one. Both spawn sites audited; a repository-wide search confirms there is no third tmux spawn site. xterm.js was checked and ruled out: CJK is East-Asian-Wide in the default Unicode 6 tables, so the missing `unicode11` addon is not implicated and no renderer change is needed.
- Reviewer subagent: none
- Human review: repo owner confirmed the rendering fix in the live GUI
- Blocking findings: none

## Residual Risk

- The `C.UTF-8` locale name is not universal. Where it is absent, the C library falls back to `C` — i.e. no worse than the status quo this PR replaces, and tmux rendering is already guaranteed independently by `-u`. The override is monotonic by construction: it only fires when nothing inherited already selects UTF-8.
- Filling in `LC_CTYPE` slightly changes the environment of programs run in the terminal (character classification, and the collation-adjacent behaviour of anything reading `LC_ALL`). This is deliberate — a terminal that cannot render or accept the project's own language is the defect being fixed — and it never overrides an explicit UTF-8 choice.
- Unrelated but noticed while verifying: the `post-commit` hook rebuilds the CLI distribution only for `packages/cli/**` changes, yet the daemon's compiled output ships inside that distribution. Daemon-source fixes therefore leave the distribution stale and appear not to take effect. This PR's distribution was rebuilt by hand; the hook itself is untouched here.

## References

- Task: not applicable
- Evidence: test names and counts recorded in Verification above
- Review: self-review recorded above

---

# 中文

## 概要

GUI 终端里中文（以及任何宽字符）不可读，每个汉字都渲染成 `_`。真凶不是字体、不是 xterm.js、也不是 tmux 的存储，而是 **daemon spawn 出来的那个 tmux 客户端跑在非 UTF-8 locale 下**。launchd 起的 daemon 通常一个 locale 都不继承，而 `packages/daemon/src/terminal/pty-host.ts` 的 `terminalEnvironment()` 只设了 `TERM`/`COLORTERM`/`PWD`，locale 全靠继承。tmux 在非 UTF-8 模式会把宽字符的每一格替换成 `_`，正是观察到的坏法。

对着真 tmux 做的判别实验（server 端固定 `LANG=zh_CN.UTF-8`，只变客户端）：

| 客户端条件 | tmux 写给 pty 的字节 |
| --- | --- |
| 无 `LANG`/`LC_*` | `____ABC` |
| `LANG=en_US.UTF-8` | `汉字ABC` 的正确 UTF-8 |
| 无 locale 但 `tmux -u` | `汉字ABC` 的正确 UTF-8 |

决定权在客户端，而客户端就是 daemon spawn 的那个 pty。又因为 tmux 在 cell 里存的是真 UTF-8、只在输出时才替换，**已存在的会话 reattach 后连历史 scrollback 一起恢复**，不只是新建的会话。

## 改动内容

- `pty-host.ts`：两处 spawn（create 的 `new-session`、reattach 的 `attach-session`）都带 `-u`，让客户端不依赖继承的 locale 也保持 UTF-8 模式。
- `pty-host.ts`：`terminalEnvironment()` **仅在继承变量里没有任何一个指向 UTF-8 时**补一个 UTF-8 `LC_CTYPE`；若 `LC_ALL` 已被设成非 UTF-8 则改写它，因为 `LC_ALL` 压过 `LC_CTYPE`。这第二层是为 pane 里的 shell 及其子进程 —— 光有 `-u` 的话，往终端里**打**中文、`ls` 显示中文文件名照样会坏；它同时覆盖了不经 tmux 的 `direct-pty` 会话。
- `pty-host.test.ts`：新增测试同时断言 `-u` argv 与条件式 `LC_CTYPE`，并带一个反例证明继承来的 `LANG=zh_CN.UTF-8` 不会被覆盖。原有 attach 断言按新 argv 更新。

## 任务与范围

- Harness 任务：无 —— 在「发现即修」常设授权下的直接缺陷修复
- 分支：`fix/terminal-tmux-utf8-locale`
- 公开范围：`packages/daemon/src/terminal/pty-host.ts` 及其测试；2 文件，+62/-4
- 私有计划 / 证据是否已更新：no
- 范围外：per-workspace 的 `tmux` / `direct-pty` **backend 开关**，以及孤儿 tmux 会话清理通道。两者都是一条已 active 裁决的条款，且已纳入 planned 任务 `task_01KXQK02NFG67KFR679EYSAMMJ`（W-C1）的范围，刻意留在那里整体开工而不在此抽切片。本 PR 不改变 backend 选择逻辑 —— tmux 可用平台仍默认 tmux。

## 版本影响

- 版本：不改版本，原因是这是既有运行路径内的缺陷修复，无接口面变化
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用 —— manifest 在这一邻域的 protected surface 是 `packages/daemon-client/src/**` 与 `check-cli-daemon-parity` 工具链，二者均不在本 diff 内
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`763f13fa1df75cfed44923657659e8438315eb9b`
- 当前分支与 `origin/main` 的 merge-base：`763f13fa1df75cfed44923657659e8438315eb9b`
- 最近一次 `git fetch origin` 时间：2026-07-25T09:31:23Z
- 同步方式：rebase
- 公开 diff 命令：`git diff 763f13fa1df75cfed44923657659e8438315eb9b..HEAD`
- 私有证据 commit/path：不适用 —— 无任务包
- Reviewer 证据路径：不适用
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑
- [x] `git diff --check`
- [x] `npm run check:stop-point` —— 34 个完整 manifest 门全绿，75.8s
- [x] 改动面的定向测试，写明测试名与通过数：
  - `node tools/run-node-tests.mjs --tier fast --prefix packages/daemon/test` —— 157 pass / 0 fail
  - 新增：`terminal children get a UTF-8 ctype and tmux runs in UTF-8 mode` —— 1 pass
  - `pty host spawns at the project root and streams input output resize and exit` —— 1 pass
  - `daemon registry restores a durable tmux session and reattaches without respawn-as-resume`（attach argv 断言已更新）—— 1 pass
  - `npm run typecheck`（`tsc -b`）—— exit 0；两个改动文件的 `eslint` —— exit 0
- [x] 仓库所有者在运行中的 GUI 终端里人工端到端确认（先重建 CLI dist 并重启 daemon）
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）
- 未跑项及原因：
  - integration tier 不在停止点门集内，本地未跑，由 GitHub CI 负责；本改动面由 fast tier 覆盖。
  - 停止点自己报还有 20 个更广或仅环境相关的门留给 CI（`check-cli-daemon-parity`、`check-github-required-contexts`、`check-kernel-dead-exports` 等），按策略本地未跑。
  - GUI pane 无法用工具驱动 —— renderer 的终端依赖 Electron IPC bridge，用普通浏览器打开 dev server 驱动不了它。因此上面那条像素级确认是人工的，如实标为人工而不冒充自动化。

## 审查证据

- 自查：先用上面那个判别实验把机制坐实，再动代码，所以修的是**测量出来的**根因而不是看起来像的根因。两处 spawn 点均已审；全仓检索确认不存在第三处 tmux spawn。xterm.js 已查并排除：CJK 在默认 Unicode 6 表里就属 East Asian Wide，缺 `unicode11` addon 与本缺陷无关，renderer 无需改动。
- Reviewer subagent：无
- 人工审查：仓库所有者已在实时 GUI 中确认渲染修复
- 阻塞发现：无

## 残余风险

- `C.UTF-8` 这个 locale 名并非到处都有。缺失时 C 库回落到 `C` —— 即不比本 PR 替换掉的现状更差，而 tmux 的渲染已由 `-u` 独立保证。这个覆盖在构造上是单调的：只在继承变量里没有任何一个已选 UTF-8 时才触发。
- 补 `LC_CTYPE` 会轻微改变终端内程序的环境（字符分类，以及任何读 `LC_ALL` 的程序在 collation 邻域的行为）。这是刻意的 —— 一个渲染不出也输入不了本项目自身语言的终端，正是这里要修的缺陷 —— 且它永远不会覆盖已显式选定的 UTF-8。
- 验证时顺带发现（与本 PR 无关）：`post-commit` 钩子只在 `packages/cli/**` 变动时重建 CLI dist，但 daemon 的编译产物是随该 dist 一起发的。于是改 daemon 源码会让 dist 静默陈旧、表现为「修了没生效」。本 PR 的 dist 是手工重建的；钩子本身此处不动。

## 关联材料

- 任务：不适用
- 证据：测试名与通过数记于上方「验证」段
- 审查：自查记于上方
