### PR TITLE
fix(perf): repair the GUI benchmark instrument and make the 5k verdict launch-bound

### DIFF
--- a/packages/gui/scripts/p3-wall-clock-measure-lib.mjs
+++ b/packages/gui/scripts/p3-wall-clock-measure-lib.mjs
@@ -322,7 +322,7 @@ export async function measureCase(size, outputsPerExecution) {
   } finally {
     if (electronApp) await closeElectronApp(electronApp);
     await sleep(6_000);
-    rmSync(ledgerRoot, { recursive: true, force: true });
+    rmSync(ledgerRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   }
   return result;
 }
@@ -402,5 +402,4 @@ export function runProjectionLayer(size, outputs) {
     },
   };
 }
-
 

--- a/packages/gui/scripts/p3-wall-clock-measure-lib.mjs
+++ b/packages/gui/scripts/p3-wall-clock-measure-lib.mjs
@@ -149,6 +149,13 @@ export async function waitFirstUsable(page, view, timeoutMs) {
   }
 }
 
+export function evaluateFiveKFirstScreenMet({
+  size,
+  overviewLaunchToUsableMs,
+}) {
+  if (size < 5_000) return null;
+  return overviewLaunchToUsableMs < COLD_TARGET_MS;
+}
 
 export async function measureCase(size, outputsPerExecution) {
   const label = `${size}x${outputsPerExecution}`;
@@ -296,11 +303,11 @@ export async function measureCase(size, outputsPerExecution) {
     result.consoleErrors = consoleErrors.slice(0, 20);
     // Primary targets from task_plan Verification (Execution Evidence oriented).
     // 1k: cold first-usable < 10s, warm re-entry < 3s.
-    // 5k: operable first screen within 10s (Overview launch or EE first-nav).
-    const fiveKFirstScreenMet =
-      size < 5_000
-        ? null
-        : overviewLaunchToUsableMs < COLD_TARGET_MS || eeColdFirstNavMs < COLD_TARGET_MS;
+    // 5k: operable first screen within 10s of process launch.
+    const fiveKFirstScreenMet = evaluateFiveKFirstScreenMet({
+      size,
+      overviewLaunchToUsableMs,
+    });
     result.goals = {
       coldTargetMs: COLD_TARGET_MS,
       warmTargetMs: WARM_TARGET_MS,

--- a/packages/gui/scripts/p3-wall-clock-measure-lib.test.mjs
+++ b/packages/gui/scripts/p3-wall-clock-measure-lib.test.mjs
@@ -1,3 +1,4 @@
+// harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
 import { evaluateFiveKFirstScreenMet } from "./p3-wall-clock-measure-lib.mjs";

--- a/packages/gui/scripts/p3-wall-clock-measure-lib.test.mjs
+++ b/packages/gui/scripts/p3-wall-clock-measure-lib.test.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { evaluateFiveKFirstScreenMet } from "./p3-wall-clock-measure-lib.mjs";
+
+test("5k first-screen fails when launch is over budget even if in-app navigation is fast", () => {
+  assert.equal(evaluateFiveKFirstScreenMet({
+    size: 5_000,
+    overviewLaunchToUsableMs: 15_662,
+    executionsFirstNavMs: 3_436,
+  }), false);
+});

--- a/tools/perf/gui-projection-benchmark.mjs
+++ b/tools/perf/gui-projection-benchmark.mjs
@@ -22,7 +22,8 @@ import {
 import { captureProjectionSourceFingerprint } from "../../packages/kernel/src/projection/projection-source-snapshot.ts";
 import { readDeclaredSourceManifestRows } from "../../packages/kernel/src/projection/sqlite-declared-source-manifest.ts";
 import { updateTaskProjectionIncrementally } from "../../packages/kernel/src/projection/sqlite-task-incremental-projection.ts";
-import { createDaemonRuntime } from "../../packages/adapters/local/src/index.ts";
+import { makeLocalProjectionSourceFenceReader } from "../../packages/adapters/local/src/index.ts";
+import { createDaemonRuntime } from "../../packages/daemon/src/index.ts";
 
 const size = positiveInteger("--size", 1_000);
 const outputsPerExecution = positiveInteger("--outputs", 5);
@@ -59,7 +60,11 @@ try {
   const readyGeneration = ensureExecutionEvidenceGenerationReady({ rootDir }).ready;
   const readyEvidencePageSamples = sample(20, () => queryExecutionEvidencePageFromReadyGeneration(readyGeneration, { limit: 25 }));
   const readyEvidencePageP95 = percentile(readyEvidencePageSamples.samples, 0.95);
-  const daemonRuntime = createDaemonRuntime({ rootDir, materializerPollMs: false });
+  const daemonRuntime = createDaemonRuntime({
+    rootDir,
+    materializerPollMs: false,
+    projectionSourceFenceFactory: makeLocalProjectionSourceFenceReader
+  });
   await daemonRuntime.start();
   const daemonGenerationStarted = performance.now();
   const daemonFirstEvidencePage = await daemonRuntime.queryExecutionEvidencePage({ limit: 25 });


### PR DESCRIPTION
# English

## Summary

The PLT-Performance line's own acceptance instrument was broken, and the part of it that still ran was reporting a target as met when it was not.

`tools/perf/gui-projection-benchmark.mjs` threw a `SyntaxError` on load, so the line's hard numbers — how long a write takes, how long a read takes, whether anything blocks — could not be measured at all. Separately, the 5,000-execution first-screen verdict was computed as `overviewLaunchToUsableMs < 10s || eeColdFirstNavMs < 10s`. The right operand measures an in-app navigation performed *after* the app is already running, which cannot establish "an operable first screen within 10 seconds of launch". With a measured launch-to-usable of 15,662 ms and an in-app navigation of 3,436 ms, that verdict reported **met**.

This PR repairs the instrument and makes the verdict answerable only by a quantity that can establish the claim.

## What Changed

- `tools/perf/gui-projection-benchmark.mjs`: import the daemon's `createDaemonRuntime` (the previous specifier no longer exported it), preserving the production assembly's local source-freshness fence.
- `packages/gui/scripts/p3-wall-clock-measure-lib.mjs`: the 5k first-screen verdict is now determined solely by Overview launch→usable. Fixtures, phases, timings and thresholds are unchanged. Also fixes an `ENOTEMPTY` race when cleaning the measurement temp directory.
- `packages/gui/scripts/p3-wall-clock-measure-lib.test.mjs`: new positive control for the verdict, registered in the fast tier.

## Task And Scope

- Harness task: `task_01KYC7KY0NSYYBCW56AH7ZZQ5X`
- Branch: `fix/perf-bench-instrument`
- Public scope: perf benchmark runtime repair and one acceptance-verdict correction
- Private planning/evidence updated: yes
- Out of scope: the measured 5,000-execution launch→usable gap itself; four further non-firing verdicts found while auditing this one (both listed under Residual Risk)

## Version Impact

- Version: no version change because this touches benchmark tooling and one measurement script only
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task `task_01KYC7KY0NSYYBCW56AH7ZZQ5X`; the verdict correction is required by `dec_01KYCA4Q2MZNHX4N8T3K06JG02` (an acceptance verdict whose green is indistinguishable from not looking cannot serve as evidence) and `dec_01KYC6RAWG57W4JHPA78NJ9SRM` criterion 3.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: to be created for the launch→usable gap and the four remaining verdicts

## Verification

- Base `origin/main` SHA: `b9c625370d64802324902825494a26f87b51ae5c`
- Branch merge-base with `origin/main`: `b9c625370d64802324902825494a26f87b51ae5c`
- Last `git fetch origin` time: 2026-07-25, rebased onto the current main before verification
- Sync method: rebase
- Public diff command: `git diff b9c625370d64802324902825494a26f87b51ae5c..HEAD`
- Private evidence commit/path: `harness/tasks/task_01KYC7KY0NSYYBCW56AH7ZZQ5X-.../artifacts/`
- Reviewer evidence path: `artifacts/worker-report.md`, `artifacts/judgment-fix-addendum.md`, `artifacts/p3-wall-clock-matrix.md`
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `git diff --check`
- [x] `npm run check:local` — `Local check passed in 72.7s`, 35 complete manifest gates green
- [x] Targeted tests for the change surface, named with their counts:
  - `packages/gui/scripts/p3-wall-clock-measure-lib.test.mjs` verdict control — 1 pass
  - `tools/` fast tier (contains the integration-shard declaration check affected by the new test file) — 185 tests, 185 pass, 0 fail
  - syntax check, changed-surface ESLint, `npm run typecheck` — all exit 0
- [x] Red/green control for the verdict change:
  - old logic with `launch=15662, nav=3436` → `true`; the control asserts this is wrong and fails against the old implementation
  - new logic on the same inputs → `false`
  - real 5k integration re-run after the change: `launch→Overview = 16147ms`, `Evidence first-nav = 3867ms`, `fiveKFirstScreenMet = false`
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: `npm run check:ci` not run locally — per the repo's local-load policy the full matrix is GitHub CI's job; the 19 broader/environment-only gates it omits are listed by `check:local` itself and run on this PR.

## Review Evidence

- Self-review: CEO independently confirmed via `git log -L` that the `||` verdict was introduced by `2a53de0b` on 2026-07-19 — by the P3 line itself, not by this change — and read the new verdict logic and its control.
- Reviewer subagent: the implementation worker surfaced the faulty verdict rather than benefiting from it: its first pass reported honestly that the strict interpretation of the 5k target was **not met** even though the runner's own flag said met.
- Human review: pending
- Blocking findings: none outstanding on this diff

## Residual Risk

- **The 5,000-execution target is not met.** With a truthful verdict, `launch→Overview usable` measures 16,147 ms against a 10 s target, and against a 13.92 s pre-optimization baseline — this dimension is worse than before the optimization, even though DOM dropped from 170,154 to 626 and the longest long task from 1,590 ms to 0 ms. Cost moved rather than disappeared. This PR makes that visible; it does not fix it.
- **Four further verdicts that cannot fail** were found while auditing this one and are deliberately **not** changed here (one class per change, so each remains verifiable):
  - `executionsColdFirstNavMet` still judges "cold" using an in-app navigation.
  - The top-level wall-clock summary does not aggregate `fiveKFirstScreenMet`; the strict verdict is false while the summary's other fields are all true.
  - The W4 benchmark uses `writers !== 8 || p95 < 2000`, so any non-8-writer scenario reports `absoluteP95Pass: true` unconditionally.
  - Paired qualification infers that all committed tasks are visible from a `list` call returning an array.
  - The attribution-union gates store thresholds only: they compute no verdict and never exit non-zero.
- 1,000-execution results do meet their targets on the in-app navigation metrics the P3 contract specifies (cold first-nav 1.34 s p95 against < 10 s; warm re-entry 0.05 s against < 3 s; DOM 1,010 against ≤ 10,000).

## References

- Task: `task_01KYC7KY0NSYYBCW56AH7ZZQ5X`
- Evidence: `harness/tasks/task_01KYC7KY0NSYYBCW56AH7ZZQ5X-.../artifacts/judgment-fix-addendum.md`
- Review: `dec_01KYCA4Q2MZNHX4N8T3K06JG02`

---

# 中文

## 概要

PLT-Performance 线自己的验收仪器是坏的，而它还能跑的那部分，正在把一项没达标的指标报成达标。

`tools/perf/gui-projection-benchmark.mjs` 加载即抛 `SyntaxError`，因此这条线的硬指标——写多少秒、读多少秒、会不会阻塞——**根本无法测量**。另外，5,000 execution 的首屏判定写作 `overviewLaunchToUsableMs < 10s || eeColdFirstNavMs < 10s`，右操作数测的是**应用已经起来之后**的一次站内导航，它无法证明「启动后 10 秒内出现可操作首屏」。实测 launch→usable 为 15,662 ms、站内导航 3,436 ms 时，该判定报**达标**。

本 PR 修好仪器，并让这条判定只能由**能够证明该命题的量**来决定。

## 改动内容

- `tools/perf/gui-projection-benchmark.mjs`：改用 daemon 的 `createDaemonRuntime`（旧 specifier 已不再导出它），并保留生产装配中的 local source-freshness fence。
- `packages/gui/scripts/p3-wall-clock-measure-lib.mjs`：5k 首屏判定改为**仅**由 Overview launch→usable 决定。夹具、阶段、计时与阈值均未改动。同时修复测量完成后清理临时目录的 `ENOTEMPTY` 竞态。
- `packages/gui/scripts/p3-wall-clock-measure-lib.test.mjs`：新增该判定的阳性对照，已注册进 fast 层。

## 任务与范围

- Harness 任务：`task_01KYC7KY0NSYYBCW56AH7ZZQ5X`
- 分支：`fix/perf-bench-instrument`
- 公开范围：perf benchmark 运行时修复 + 一处验收判定更正
- 私有规划/证据已更新：是
- 范围外：实测出的 5,000 execution launch→usable 缺口本身；审计这一处时发现的另外四处不会红的判定（两者见残余风险）

## 版本影响

- 版本：不变更，只触碰 benchmark 工具与一个测量脚本
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 依据：任务 `task_01KYC7KY0NSYYBCW56AH7ZZQ5X`；判定更正由 `dec_01KYCA4Q2MZNHX4N8T3K06JG02`（一个「绿」与「没在看」不可区分的验收判定不能作为证据）与 `dec_01KYC6RAWG57W4JHPA78NJ9SRM` 判据 3 要求。
- 机器检查边界：本 PR 只断言声明存在；声明是否为真且充分由评审者判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：将为 launch→usable 缺口与剩余四处判定另立

## 验证

- 基线 `origin/main` SHA：`b9c625370d64802324902825494a26f87b51ae5c`
- 分支与 `origin/main` 的 merge-base：`b9c625370d64802324902825494a26f87b51ae5c`
- 最近一次 `git fetch origin`：2026-07-25，验证前已 rebase 到当前 main
- 同步方式：rebase
- 公开 diff 命令：`git diff b9c625370d64802324902825494a26f87b51ae5c..HEAD`
- 私有证据 commit/路径：`harness/tasks/task_01KYC7KY0NSYYBCW56AH7ZZQ5X-.../artifacts/`
- 评审者证据路径：`artifacts/worker-report.md`、`artifacts/judgment-fix-addendum.md`、`artifacts/p3-wall-clock-matrix.md`
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑
- [x] `git diff --check`
- [x] `npm run check:local` —— `Local check passed in 72.7s`，35 道完整 manifest 门全绿
- [x] 改动面定向测试及其计数：
  - `packages/gui/scripts/p3-wall-clock-measure-lib.test.mjs` 判定对照 —— 1 pass
  - `tools/` fast 层（含受新测试文件影响的 integration-shard 声明检查）—— 185 tests，185 pass，0 fail
  - syntax 检查、变更面 ESLint、`npm run typecheck` —— 均 exit 0
- [x] 判定改动的红/绿对照：
  - 旧逻辑在 `launch=15662, nav=3436` 下产出 `true`；对照断言这是错的，并对旧实现失败
  - 新逻辑在同一输入下产出 `false`
  - 改后真实 5k 集成复跑：`launch→Overview = 16147ms`、`Evidence first-nav = 3867ms`、`fiveKFirstScreenMet = false`
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威的完整门）
- 未跑及原因：`npm run check:ci` 未在本机跑——按本仓本机负载治理，完整门矩阵是 GitHub CI 的活；它省略的 19 道更宽/仅环境门由 `check:local` 自己列出，并在本 PR 上运行。

## 审查证据

- 自审：CEO 用 `git log -L` 独立确认那个 `||` 判定是 2026-07-19 的 `2a53de0b` 引入的——由 P3 线自己引入，不是本次改动带来的；并通读了新判定逻辑与其对照。
- 复核 subagent：实现 worker **主动暴露**了这个有缺陷的判定而不是从中获益——它第一轮就如实报告，按严格解释 5k 目标**未达标**，尽管 runner 自己的 flag 说达标。
- 人工复核：待
- 阻塞性发现：本 diff 上无未决项

## 残余风险

- **5,000 execution 这一项没达标。** 判定诚实之后，`launch→Overview usable` 实测 16,147 ms，目标 10 s，而优化前基线是 13.92 s——**这一维度比优化前更差**，尽管 DOM 从 170,154 降到 626、最长 long task 从 1,590 ms 降到 0 ms。成本被搬了位置，没有消失。本 PR 让它变得可见，不修它。
- **审计这一处时发现的另外四处不会红的判定**，本 PR **刻意不改**（一次改一类，每一类才各自可验）：
  - `executionsColdFirstNavMet` 仍用站内导航判定「cold」。
  - 顶层 wall-clock summary 不聚合 `fiveKFirstScreenMet`；严格判定为 false 时，summary 其余字段仍全为 true。
  - W4 benchmark 用 `writers !== 8 || p95 < 2000`，任何非 8-writer 场景无条件报 `absoluteP95Pass: true`。
  - paired qualification 凭一次 `list` 调用返回数组，就推定所有 committed task 已可见。
  - attribution-union 的 gates 只存阈值：不计算 verdict，也不以超阈值非零退出。
- 1,000 execution 在 P3 契约指定的站内导航指标上确实达标（冷首次导航 1.34 s p95，目标 < 10 s；热回访 0.05 s，目标 < 3 s；DOM 1,010，目标 ≤ 10,000）。

## 关联材料

- 任务：`task_01KYC7KY0NSYYBCW56AH7ZZQ5X`
- 证据：`harness/tasks/task_01KYC7KY0NSYYBCW56AH7ZZQ5X-.../artifacts/judgment-fix-addendum.md`
- 复核：`dec_01KYCA4Q2MZNHX4N8T3K06JG02`
