### PR TITLE
fix(daemon): preserve uncertain terminal outcomes

### DIFF
--- a/packages/daemon/src/terminal/pty-host.ts
+++ b/packages/daemon/src/terminal/pty-host.ts
@@ -203,13 +203,14 @@ export function createPtyTerminalSessionService(options: PtyTerminalSessionServi
   function closeSession(payload: TerminalSessionIdPayload): TerminalSessionDetailResult {
     const current = registry.getSession(payload);
     if (!current.ok || ptySessionHasExited(current.session)) return current;
-    terminateBackend(payload.sessionId);
     const pty = processes.get(payload.sessionId);
     try {
       pty?.kill();
-    } catch {
-      // The process may have exited between the metadata read and kill.
+    } catch (error) {
+      return terminalFailure("terminal_termination_failed", error instanceof Error ? error.message : String(error));
     }
+    const backendFailure = terminateBackend(payload.sessionId);
+    if (backendFailure) return backendFailure;
     return finalizeExit(payload.sessionId, 0);
   }
 
@@ -248,22 +249,23 @@ export function createPtyTerminalSessionService(options: PtyTerminalSessionServi
     if (payload.confirmation !== "terminate-terminal-session") return registry.terminateSession(payload);
     const current = registry.getSession(payload);
     if (!current.ok || ptySessionHasExited(current.session)) return current;
-    terminateBackend(payload.sessionId);
     try {
       processes.get(payload.sessionId)?.kill();
-    } catch {
-      // The terminal client may have exited while the explicit terminate was being handled.
+    } catch (error) {
+      return terminalFailure("terminal_termination_failed", error instanceof Error ? error.message : String(error));
     }
+    const backendFailure = terminateBackend(payload.sessionId);
+    if (backendFailure) return backendFailure;
     return registry.terminateSession(payload);
   }
 
-  function terminateBackend(sessionId: string): void {
+  function terminateBackend(sessionId: string): (TerminalSessionDetailResult & { readonly ok: false }) | undefined {
     const namespace = tmuxNamespaces.get(sessionId);
     if (!namespace || !tmuxProbe.executable) return;
     try {
       tmux.killSession(tmuxProbe.executable, namespace);
-    } catch {
-      // The tmux session may already have exited.
+    } catch (error) {
+      return terminalFailure("terminal_termination_failed", error instanceof Error ? error.message : String(error));
     }
     tmuxNamespaces.delete(sessionId);
   }

--- a/packages/daemon/src/terminal/session-store.ts
+++ b/packages/daemon/src/terminal/session-store.ts
@@ -5,17 +5,21 @@ import type { TerminalSessionInfo } from "@harness-anything/application/terminal
 const schema = "terminal-session-registry/v1" as const;
 
 export function loadTerminalSessionRegistry(filePath: string): ReadonlyArray<TerminalSessionInfo> {
+  let parsed: unknown;
   try {
-    const parsed: unknown = JSON.parse(readFileSync(filePath, "utf8"));
-    if (!isTerminalStoreRecord(parsed) || parsed.schema !== schema || !Array.isArray(parsed.sessions)) return [];
-    return parsed.sessions.flatMap((session) => {
-      const projected = readTerminalSessionInfo(session);
-      return projected ? [projected] : [];
-    });
+    parsed = JSON.parse(readFileSync(filePath, "utf8"));
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
-    return [];
+    throw error;
   }
+  if (!isTerminalStoreRecord(parsed) || parsed.schema !== schema || !Array.isArray(parsed.sessions)) {
+    throw new Error("invalid terminal session registry schema");
+  }
+  const sessions = parsed.sessions.map(readTerminalSessionInfo);
+  if (!sessions.every((session): session is TerminalSessionInfo => session !== undefined)) {
+    throw new Error("invalid terminal session registry record");
+  }
+  return sessions;
 }
 
 export function saveTerminalSessionRegistry(filePath: string, sessions: ReadonlyArray<TerminalSessionInfo>): void {

--- a/packages/daemon/test/pty-host.test.ts
+++ b/packages/daemon/test/pty-host.test.ts
@@ -110,6 +110,136 @@ test("daemon registry restores a durable tmux session and reattaches without res
   }
 });
 
+test("close reports a PTY kill failure without inventing exit zero", () => {
+  const workspaceRoot = mkdtempSync(path.join(tmpdir(), "ha-pty-close-"));
+  const fake = fakePty({ killError: new Error("PTY kill unavailable") });
+  try {
+    const service = createPtyTerminalSessionService({
+      workspaceRoot,
+      createId: () => "term-close-failure",
+      spawnPty: () => fake.pty
+    });
+    assert.equal(service.createSession({ name: "Close failure", backend: "direct-pty" }).ok, true);
+
+    assert.deepEqual(service.closeSession({ sessionId: "term-close-failure" }), {
+      ok: false,
+      error: {
+        code: "terminal_termination_failed",
+        hint: "PTY kill unavailable"
+      }
+    });
+    const retained = service.getSession({ sessionId: "term-close-failure" });
+    assert.equal(retained.ok, true);
+    if (!retained.ok) return;
+    assert.equal(retained.session.status, "active");
+    assert.equal(retained.session.exitCode, undefined);
+  } finally {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("close persists exit zero after the PTY kill succeeds", () => {
+  const workspaceRoot = mkdtempSync(path.join(tmpdir(), "ha-pty-close-"));
+  try {
+    const service = createPtyTerminalSessionService({
+      workspaceRoot,
+      createId: () => "term-close-success",
+      spawnPty: () => fakePty().pty
+    });
+    assert.equal(service.createSession({ name: "Close success", backend: "direct-pty" }).ok, true);
+
+    const closed = service.closeSession({ sessionId: "term-close-success" });
+    assert.equal(closed.ok, true);
+    if (!closed.ok) return;
+    assert.equal(closed.session.status, "exited");
+    assert.equal(closed.session.exitCode, 0);
+  } finally {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("explicit termination reports a PTY kill failure without inventing exit zero", () => {
+  const workspaceRoot = mkdtempSync(path.join(tmpdir(), "ha-pty-terminate-"));
+  const fake = fakePty({ killError: new Error("PTY kill unavailable") });
+  try {
+    const service = createPtyTerminalSessionService({
+      workspaceRoot,
+      createId: () => "term-terminate-failure",
+      spawnPty: () => fake.pty
+    });
+    assert.equal(service.createSession({ name: "Terminate failure", backend: "direct-pty" }).ok, true);
+
+    assert.deepEqual(service.terminateSession({
+      sessionId: "term-terminate-failure",
+      confirmation: "terminate-terminal-session"
+    }), {
+      ok: false,
+      error: {
+        code: "terminal_termination_failed",
+        hint: "PTY kill unavailable"
+      }
+    });
+    const retained = service.getSession({ sessionId: "term-terminate-failure" });
+    assert.equal(retained.ok, true);
+    if (!retained.ok) return;
+    assert.equal(retained.session.status, "active");
+    assert.equal(retained.session.exitCode, undefined);
+  } finally {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("tmux termination failure keeps the namespace available for a retry", () => {
+  const workspaceRoot = mkdtempSync(path.join(tmpdir(), "ha-tmux-close-"));
+  const fake = fakePty();
+  let failKill = true;
+  let killAttempts = 0;
+  const controller = {
+    probe: () => ({ available: true, executable: "tmux", version: "tmux 3.4" }),
+    hasSession: () => true,
+    killSession: () => {
+      killAttempts += 1;
+      if (failKill) throw new Error("tmux kill unavailable");
+    }
+  };
+  try {
+    const service = createPtyTerminalSessionService({
+      workspaceRoot,
+      tmux: controller,
+      createId: () => "term-tmux-close-failure",
+      spawnPty: () => fake.pty
+    });
+    assert.equal(service.createSession({ name: "Tmux close failure" }).ok, true);
+
+    assert.deepEqual(service.terminateSession({
+      sessionId: "term-tmux-close-failure",
+      confirmation: "terminate-terminal-session"
+    }), {
+      ok: false,
+      error: {
+        code: "terminal_termination_failed",
+        hint: "tmux kill unavailable"
+      }
+    });
+    assert.equal(killAttempts, 1);
+    const retained = service.getSession({ sessionId: "term-tmux-close-failure" });
+    assert.equal(retained.ok, true);
+    if (!retained.ok) return;
+    assert.notEqual(retained.session.status, "exited");
+    assert.equal(retained.session.exitCode, undefined);
+
+    failKill = false;
+    const retried = service.terminateSession({
+      sessionId: "term-tmux-close-failure",
+      confirmation: "terminate-terminal-session"
+    });
+    assert.equal(retried.ok, true);
+    assert.equal(killAttempts, 2);
+  } finally {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
 test("terminal children get a UTF-8 ctype and tmux runs in UTF-8 mode", () => {
   const workspaceRoot = mkdtempSync(path.join(tmpdir(), "ha-pty-utf8-"));
   const controller = {
@@ -183,7 +313,7 @@ test("pty host allows project subdirectories and rejects cwd escapes", () => {
   }
 });
 
-function fakePty() {
+function fakePty(options: { readonly killError?: Error } = {}) {
   let dataListener: ((data: string) => void) | undefined;
   let exitListener: ((event: IExitEvent) => void) | undefined;
   const writes: string[] = [];
@@ -198,7 +328,10 @@ function fakePty() {
     clear: () => undefined,
     pause: () => undefined,
     resume: () => undefined,
-    kill: () => exitListener?.({ exitCode: 0, signal: 0 }),
+    kill: () => {
+      if (options.killError) throw options.killError;
+      exitListener?.({ exitCode: 0, signal: 0 });
+    },
     onData: (listener: (data: string) => void) => {
       dataListener = listener;
       return { dispose: () => { dataListener = undefined; } };

--- a/packages/daemon/test/terminal-session-store.test.ts
+++ b/packages/daemon/test/terminal-session-store.test.ts
@@ -1,10 +1,10 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { loadTerminalSessionRegistry } from "../src/terminal/session-store.ts";
+import { loadTerminalSessionRegistry, saveTerminalSessionRegistry } from "../src/terminal/session-store.ts";
 
 test("terminal registry load projects owner-stripped DTOs and drops undeclared secret fields", () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-terminal-store-"));
@@ -23,6 +23,52 @@ test("terminal registry load projects owner-stripped DTOs and drops undeclared s
     assert.equal(sessions.length, 1);
     assert.equal("token" in (sessions[0] as object), false);
     assert.equal("ownerPid" in (sessions[0] as object), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("terminal registry load rejects malformed data before it can be overwritten as empty", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-terminal-store-"));
+  const filePath = path.join(root, "generated", "terminal-sessions.json");
+  try {
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, "{ damaged registry");
+
+    assert.throws(() => loadTerminalSessionRegistry(filePath), SyntaxError);
+    assert.equal(readFileSync(filePath, "utf8"), "{ damaged registry");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("terminal registry load rejects incompatible schemas and invalid session records", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-terminal-store-"));
+  const filePath = path.join(root, "generated", "terminal-sessions.json");
+  try {
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, JSON.stringify({ schema: "terminal-session-registry/v2", sessions: [] }));
+    assert.throws(() => loadTerminalSessionRegistry(filePath), /invalid terminal session registry schema/u);
+
+    writeFileSync(filePath, JSON.stringify({
+      schema: "terminal-session-registry/v1",
+      sessions: [{ sessionId: "incomplete" }]
+    }));
+    assert.throws(() => loadTerminalSessionRegistry(filePath), /invalid terminal session registry record/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("terminal registry load preserves the real zero-session cases", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-terminal-store-"));
+  const missingFilePath = path.join(root, "missing", "terminal-sessions.json");
+  const emptyFilePath = path.join(root, "generated", "terminal-sessions.json");
+  try {
+    assert.deepEqual(loadTerminalSessionRegistry(missingFilePath), []);
+
+    saveTerminalSessionRegistry(emptyFilePath, []);
+    assert.deepEqual(loadTerminalSessionRegistry(emptyFilePath), []);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
# English

## Summary

Two terminal-subsystem paths reported a known-bad outcome as a good one. `pty-host` treated a
failed `kill()` as a clean exit and persisted `exitCode: 0`; `session-store` swallowed every
registry read failure — corrupt JSON, wrong schema, malformed records — and returned an empty
session list indistinguishable from "no sessions exist". Both are instances of the
lying-terminal-state defect family: the caller cannot tell success from failure.

This PR makes both paths report what actually happened. It does not add new capability.

## What Changed

- `packages/daemon/src/terminal/pty-host.ts`: a throwing `pty.kill()` now returns
  `terminal_termination_failed` instead of falling through to `finalizeExit(..., 0)`. The session
  is retained as `active` with `exitCode` unset, so a retry is possible and correct.
- `packages/daemon/src/terminal/pty-host.ts`: `terminateBackend` changed from `void` to returning
  a failure result, so a tmux `kill-session` failure propagates instead of being discarded. The
  tmux namespace is preserved on failure so a retry can still address it.
- `packages/daemon/src/terminal/pty-host.ts`: kill now precedes backend termination, so a kill
  failure short-circuits before the tmux namespace is touched.
- `packages/daemon/src/terminal/session-store.ts`: only `ENOENT` returns `[]` (a genuine
  zero-session registry). Corrupt JSON, schema mismatch, and malformed individual records now
  throw instead of being silently dropped by `flatMap`.

## Task And Scope

- Harness task: `task_01KYCF6G2CYSSSPR7JV59826HV`
- Branch: `fix/c2-terminal-terminal-state-honesty`
- Public scope: `packages/daemon/src/terminal/**`, `packages/daemon/test/**`
- Private planning/evidence updated: yes
- Out of scope: terminal transport, GUI terminal surface, session lifecycle policy

## Version Impact

- Version: no version change because this is a behavioural fix inside the daemon, with no
  package surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `dec_01KYC6RAWG57W4JHPA78NJ9SRM` (property-based criteria: an instrument that cannot
  distinguish two states is a defect, not a tolerance)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it
  is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `65789c9a3b09da7e52254bd8175d6db0d88fdf38`
- Branch merge-base with `origin/main`: `65789c9a3b09da7e52254bd8175d6db0d88fdf38`
- Last `git fetch origin` time: 2026-07-25, immediately before opening this PR
- Sync method: none needed
- Public diff command: `git diff 65789c9a3b09da7e52254bd8175d6db0d88fdf38..HEAD`
- Private evidence commit/path: `harness/tasks/task_01KYCF6G2CYSSSPR7JV59826HV-*/`
- Reviewer evidence path: `harness/tasks/task_01KYCF6G2CYSSSPR7JV59826HV-*/review.md`
- GitHub Actions `rewrite-ci` run URL: pending, added after the run starts
- [x] `git diff --check`
- [x] `npm run check:stop-point` (the gate set is derived from `tools/gate-manifest.json`; do not
      enumerate gates by hand) — 34 gates green
- [x] Targeted tests for the change surface, named with their counts:
      `packages/daemon` affected fast tier 166/166 pass; affected contract tier 141 pass / 1 skip.
      New coverage: PTY kill failure on close, PTY kill failure on explicit terminate, tmux
      termination failure retaining the namespace, and the success path still persisting exit 0
      (the positive control that proves the new failure path did not make success unreachable).
      Registry side: corrupt JSON, schema mismatch, and a single malformed record each now throw,
      with `ENOENT` still returning `[]`.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: failure injection uses test doubles rather than real `node-pty` / `tmux`
  binaries. The classification logic is covered; the real-binary failure modes that reach it are
  not exercised. Recorded below as residual risk.

## Review Evidence

- Self-review: CEO read both hunks in full against the task plan's criteria.
- Reviewer subagent: implementing worker's own report, cross-read by CEO.
- Human review: CEO semantic acceptance, 2026-07-25.
- Blocking findings: none.

## Residual Risk

- `pty.kill()` can throw `ESRCH` in the narrow window where the process exits after the
  `ptySessionHasExited` guard but before the kill. That case is now reported as
  `terminal_termination_failed` for a session that is in fact gone. This is a false alarm rather
  than a false success, and it self-heals: a retry hits the `hasExited` early return and succeeds.
  Accepted deliberately — the previous behaviour got the direction of the error wrong.
- Failure injection is via test doubles, so a real `node-pty` or `tmux` failure whose shape differs
  from the doubles would exercise an unverified path.

## References

- Task: `harness/tasks/task_01KYCF6G2CYSSSPR7JV59826HV-*/task_plan.md`
- Evidence: `harness/tasks/task_01KYCF6G2CYSSSPR7JV59826HV-*/artifacts/`
- Review: `harness/tasks/task_01KYCF6G2CYSSSPR7JV59826HV-*/review.md`

---

# 中文

## 概要

终端子系统有两条路把"已知的坏结果"报成了好结果。`pty-host` 把失败的 `kill()` 当成正常退出，
落盘 `exitCode: 0`；`session-store` 吞掉了注册表读取的所有失败——JSON 损坏、schema 不符、
记录格式非法——统一返回空会话列表，与"确实没有会话"不可区分。两条都属于"终态撒谎"缺陷族：
调用方分不出成功与失败。

本 PR 让这两条路如实上报实际发生的事，不新增能力。

## 改动内容

- `packages/daemon/src/terminal/pty-host.ts`：`pty.kill()` 抛错时返回
  `terminal_termination_failed`，不再落到 `finalizeExit(..., 0)`。会话保留为 `active`、
  `exitCode` 不写，重试是可行且正确的。
- `packages/daemon/src/terminal/pty-host.ts`：`terminateBackend` 由 `void` 改为返回失败结果，
  tmux `kill-session` 失败会向上传播而不是被丢弃；失败时保留 tmux namespace，重试仍能处理它。
- `packages/daemon/src/terminal/pty-host.ts`：kill 移到 backend 终止之前，kill 失败即短路，
  不再动 tmux namespace。
- `packages/daemon/src/terminal/session-store.ts`：只有 `ENOENT` 返回 `[]`（真实的零会话
  注册表）。JSON 损坏、schema 不符、单条记录非法现在都抛出，不再被 `flatMap` 静默丢弃。

## 任务与范围

- Harness 任务：`task_01KYCF6G2CYSSSPR7JV59826HV`
- 分支：`fix/c2-terminal-terminal-state-honesty`
- 公开范围：`packages/daemon/src/terminal/**`、`packages/daemon/test/**`
- 私有规划/证据已更新：是
- 不在范围内：终端传输层、GUI 终端界面、会话生命周期策略

## 版本影响

- 版本：无变更，因为这是 daemon 内部的行为修复，未改动包对外面
- 发布影响：不发布

## 治理声明

- 触及 protected surface：否
- Protected surface 范围：不适用
- 权威依据：`dec_01KYC6RAWG57W4JHPA78NJ9SRM`（属性化判据：分不出两种状态的仪器是缺陷，
  不是容差）
- 机器检查边界：本 PR 只断言声明存在；声明是否为真、是否充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`65789c9a3b09da7e52254bd8175d6db0d88fdf38`
- 分支与 `origin/main` 的 merge-base：`65789c9a3b09da7e52254bd8175d6db0d88fdf38`
- 最近一次 `git fetch origin` 时间：2026-07-25，开 PR 前
- 同步方式：无需同步
- 公开 diff 命令：`git diff 65789c9a3b09da7e52254bd8175d6db0d88fdf38..HEAD`
- 私有证据 commit/路径：`harness/tasks/task_01KYCF6G2CYSSSPR7JV59826HV-*/`
- 评审证据路径：`harness/tasks/task_01KYCF6G2CYSSSPR7JV59826HV-*/review.md`
- GitHub Actions `rewrite-ci` run URL：待补，run 起来后回填
- [x] `git diff --check`
- [x] `npm run check:stop-point`（门集从 `tools/gate-manifest.json` 派生，不手工枚举）——
      34 道门全绿
- [x] 变更面定向测试及计数：`packages/daemon` affected fast tier 166/166 通过；
      affected contract tier 141 通过 / 1 跳过。新增覆盖：close 时 PTY kill 失败、
      显式 terminate 时 PTY kill 失败、tmux 终止失败保留 namespace，以及成功路径仍然落盘
      exit 0（这条是阳性对照，证明新增失败路径没有把成功路径变得不可达）。注册表侧：
      JSON 损坏、schema 不符、单条记录非法各自抛出，`ENOENT` 仍返回 `[]`。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）
- 未跑及原因：失败注入用的是测试 double，不是真实 `node-pty` / `tmux` 二进制。分类逻辑已覆盖，
  但真正会走到它的二进制级失败模式没有被执行。已记入下方残余风险。

## 审查证据

- 自审：CEO 对照 task plan 判据通读两处 hunk。
- 评审 subagent：实现 worker 自身报告，由 CEO 交叉复读。
- 人工评审：CEO 语义验收，2026-07-25。
- 阻塞性发现：无。

## 残余风险

- `pty.kill()` 可能在"进程于 `ptySessionHasExited` 守卫之后、kill 之前退出"的窄窗口里抛
  `ESRCH`。此时一个实际已经死掉的会话会被报成 `terminal_termination_failed`。这是误报，
  不是假成功，而且会自愈：重试会命中 `hasExited` 提前返回并成功。**有意接受**——
  原先的行为把误差方向搞反了。
- 失败注入走测试 double，若真实 `node-pty` 或 `tmux` 的失败形状与 double 不同，
  那条路径未被验证。

## 关联材料

- 任务：`harness/tasks/task_01KYCF6G2CYSSSPR7JV59826HV-*/task_plan.md`
- 证据：`harness/tasks/task_01KYCF6G2CYSSSPR7JV59826HV-*/artifacts/`
- 评审：`harness/tasks/task_01KYCF6G2CYSSSPR7JV59826HV-*/review.md`
