### PR TITLE
fix(cli): contain user-supplied output paths behind one gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "harness:check-write-coordinator-boundary": "node tools/check-write-coordinator-boundary.mjs",
     "harness:check-write-road-registry": "node tools/check-write-road-registry.mjs",
     "harness:check-cli-direct-writer": "node tools/check-cli-direct-writer.mjs",
+    "harness:check-cli-output-path-containment": "node tools/check-cli-output-path-containment.mjs && node --test tools/check-cli-output-path-containment.test.mjs",
     "harness:check-cli-daemon-parity": "node tools/check-cli-daemon-parity.mjs",
     "harness:check-kernel-dead-exports": "node tools/check-kernel-dead-exports.mjs",
     "harness:check-relation-cycle-substrate": "node tools/check-relation-cycle-substrate.mjs",

--- a/packages/cli/src/cli/output-path.ts
+++ b/packages/cli/src/cli/output-path.ts
@@ -1,0 +1,43 @@
+import { existsSync, lstatSync } from "node:fs";
+import path from "node:path";
+import { isPathInside } from "./path.ts";
+
+export type ContainedOutputPathResult =
+  | { readonly ok: true; readonly path: string }
+  | { readonly ok: false; readonly reason: "absolute-path" | "outside-container" | "canonical-target" | "symlink" };
+
+export interface ContainedOutputPathOptions {
+  readonly requestedPath: string;
+  readonly containerRoots: ReadonlyArray<string>;
+  readonly relativeTo: string;
+  readonly canonicalRoots?: ReadonlyArray<string>;
+  readonly allowAbsolute?: boolean;
+}
+
+export function resolveContainedOutputPath(options: ContainedOutputPathOptions): ContainedOutputPathResult {
+  if (path.isAbsolute(options.requestedPath) && options.allowAbsolute === false) {
+    return { ok: false, reason: "absolute-path" };
+  }
+  const targetPath = path.resolve(options.relativeTo, options.requestedPath);
+  const containerRoot = options.containerRoots.find((root) => isPathInside(root, targetPath));
+  if (!containerRoot) return { ok: false, reason: "outside-container" };
+  if ((options.canonicalRoots ?? []).some((root) => isPathInside(root, targetPath))) {
+    return { ok: false, reason: "canonical-target" };
+  }
+  if (hasSymlinkInExistingPath(containerRoot, targetPath)) {
+    return { ok: false, reason: "symlink" };
+  }
+  return { ok: true, path: targetPath };
+}
+
+function hasSymlinkInExistingPath(rootPath: string, targetPath: string): boolean {
+  let current = path.resolve(rootPath);
+  if (existsSync(current) && lstatSync(current).isSymbolicLink()) return true;
+  const relative = path.relative(current, path.resolve(targetPath));
+  for (const segment of relative.split(path.sep)) {
+    if (!segment) continue;
+    current = path.join(current, segment);
+    if (existsSync(current) && lstatSync(current).isSymbolicLink()) return true;
+  }
+  return false;
+}

--- a/packages/cli/src/commands/daemon/output-path.ts
+++ b/packages/cli/src/commands/daemon/output-path.ts
@@ -1,0 +1,22 @@
+import { resolveHarnessLayout } from "@harness-anything/kernel";
+import { resolveContainedOutputPath } from "../../cli/output-path.ts";
+
+export function requireDaemonProductOutputPath(options: {
+  readonly requestedPath: string;
+  readonly rootDir: string;
+  readonly canonicalRoot?: string;
+  readonly label: string;
+}): string {
+  const canonicalRoot = options.canonicalRoot ?? options.rootDir;
+  const layout = resolveHarnessLayout({ rootDir: canonicalRoot });
+  const resolved = resolveContainedOutputPath({
+    requestedPath: options.requestedPath,
+    containerRoots: [...new Set([options.rootDir, canonicalRoot])],
+    canonicalRoots: [layout.authoredRoot],
+    relativeTo: options.rootDir
+  });
+  if (!resolved.ok) {
+    throw new Error(`${options.label} rejected (${resolved.reason}): output must remain in an allowed repository, outside canonical authored paths, without symlinks.`);
+  }
+  return resolved.path;
+}

--- a/packages/cli/src/commands/daemon/productization-options.ts
+++ b/packages/cli/src/commands/daemon/productization-options.ts
@@ -1,0 +1,11 @@
+import { readOption } from "../../cli/parse-options.ts";
+
+export function requiredDaemonOption(args: ReadonlyArray<string>, name: string): string {
+  const value = readOption(args, name);
+  if (!value || value.startsWith("--")) throw new Error(`Use ${name} <value>.`);
+  return value;
+}
+
+export function daemonSafeId(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/gu, "_").replace(/^_+|_+$/gu, "") || "user";
+}

--- a/packages/cli/src/commands/daemon/productization.ts
+++ b/packages/cli/src/commands/daemon/productization.ts
@@ -33,6 +33,8 @@ import { makeDaemonLogService } from "@harness-anything/application";
 import { prepareDaemonServiceLaunch } from "../../daemon/daemon-service-launch.ts";
 import { parseDaemonLaunchArgv } from "../../daemon/daemon-launch-spec.ts";
 import type { DaemonCommandInput } from "./command-types.ts";
+import { requireDaemonProductOutputPath } from "./output-path.ts";
+import { daemonSafeId, requiredDaemonOption } from "./productization-options.ts";
 import { installSnapshotCommand, upgradeDaemonSnapshot } from "./snapshot-command.ts";
 import { readDaemonStatusWithGenerationFallback } from "./status-compatibility.ts";
 
@@ -231,8 +233,11 @@ async function stopDaemon(input: DaemonCommandInput): Promise<number> {
 }
 
 function installTemplates(input: DaemonCommandInput): number {
-  const outDir = readOption(input.args, "--out");
-  if (!outDir) throw new Error("Use ha daemon install-templates --out <directory>.");
+  const requestedOutDir = readOption(input.args, "--out");
+  if (!requestedOutDir) throw new Error("Use ha daemon install-templates --out <directory>.");
+  const outDir = requireDaemonProductOutputPath({
+    requestedPath: requestedOutDir, rootDir: input.rootDir, label: "Daemon template output path"
+  });
   mkdirSync(outDir, { recursive: true });
   cpSync(daemonAssetPath("systemd/harness-anything-daemon.service"), path.join(outDir, "harness-anything-daemon.service"));
   cpSync(daemonAssetPath("launchd/com.harness-anything.daemon.plist"), path.join(outDir, "com.harness-anything.daemon.plist"));
@@ -249,18 +254,21 @@ function installTemplates(input: DaemonCommandInput): number {
 }
 
 async function bootstrapServer(input: DaemonCommandInput): Promise<number> {
-  const canonicalRoot = path.resolve(requiredOption(input.args, "--canonical-root"));
-  const sshHost = requiredOption(input.args, "--ssh-host");
+  const canonicalRoot = path.resolve(requiredDaemonOption(input.args, "--canonical-root"));
+  const sshHost = requiredDaemonOption(input.args, "--ssh-host");
   const sshUser = readOption(input.args, "--ssh-user") ?? os.userInfo().username;
-  const personId = readOption(input.args, "--person-id") ?? `person_${safeId(sshUser)}`;
+  const personId = readOption(input.args, "--person-id") ?? `person_${daemonSafeId(sshUser)}`;
   const displayName = readOption(input.args, "--display-name") ?? sshUser;
   const primaryEmail = readOption(input.args, "--email");
   const role = readOption(input.args, "--role") ?? "owner";
   const readonlyMirror = readOption(input.args, "--readonly-mirror");
-  const reportPath = readOption(input.args, "--report") ?? path.join(canonicalRoot, ".harness", "generated", "daemon-bootstrap-report.json");
+  const requestedReportPath = readOption(input.args, "--report") ?? path.join(canonicalRoot, ".harness", "generated", "daemon-bootstrap-report.json");
   const skipSshCheck = input.args.includes("--skip-ssh-check");
   const noStart = input.args.includes("--no-start");
   const registryRepoId = readOption(input.args, "--repo-id") ?? "canonical";
+  const reportPath = requireDaemonProductOutputPath({
+    requestedPath: requestedReportPath, rootDir: input.rootDir, canonicalRoot, label: "Daemon bootstrap report path"
+  });
 
   ensureCanonicalRepo(canonicalRoot);
   initializeHarness({ rootDir: canonicalRoot }, false, path.basename(canonicalRoot));
@@ -549,12 +557,6 @@ function readDaemonUserRootOption(args: ReadonlyArray<string>): string | undefin
   return readOption(args, "--user-root") ?? process.env.HARNESS_DAEMON_USER_ROOT;
 }
 
-function requiredOption(args: ReadonlyArray<string>, name: string): string {
-  const value = readOption(args, name);
-  if (!value || value.startsWith("--")) throw new Error(`Use ${name} <value>.`);
-  return value;
-}
-
 function runDaemonGit(cwd: string, args: ReadonlyArray<string>): void {
   try {
     execFileSync("git", [...args], { cwd, stdio: "ignore", windowsHide: true });
@@ -580,10 +582,6 @@ function daemonAssetPath(relativePath: string): string {
   const found = candidates.find((candidate) => existsSync(candidate));
   if (!found) throw new Error(`daemon asset not found: ${relativePath}`);
   return found;
-}
-
-function safeId(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9]+/gu, "_").replace(/^_+|_+$/gu, "") || "user";
 }
 
 function waitDaemonPollInterval(ms: number): Promise<void> {

--- a/packages/cli/src/commands/graph-panorama.ts
+++ b/packages/cli/src/commands/graph-panorama.ts
@@ -1,8 +1,8 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import path from "node:path";
-import { readEntityCascadeImpact } from "@harness-anything/kernel";
-import { readRelationGraphProjection } from "@harness-anything/kernel";
+import { readEntityCascadeImpact, readRelationGraphProjection, resolveHarnessLayout } from "@harness-anything/kernel";
+import { resolveContainedOutputPath } from "../cli/output-path.ts";
 
 const defaultProjectionPath = ".harness/cache/projections.sqlite";
 const defaultOutputPath = ".harness/generated/graph-panorama/index.html";
@@ -32,7 +32,17 @@ interface ProjectedEntity {
 export function generateGraphPanorama(input: GenerateGraphPanoramaInput = {}): Record<string, any> {
   const rootDir = path.resolve(input.rootDir ?? process.cwd());
   const projectionPath = path.resolve(rootDir, input.projectionPath ?? defaultProjectionPath);
-  const outputPath = path.resolve(rootDir, input.outputPath ?? defaultOutputPath);
+  const layout = resolveHarnessLayout({ rootDir });
+  const resolvedOutput = resolveContainedOutputPath({
+    requestedPath: input.outputPath ?? defaultOutputPath,
+    containerRoots: [rootDir],
+    canonicalRoots: [layout.authoredRoot],
+    relativeTo: rootDir
+  });
+  if (!resolvedOutput.ok) {
+    throw new Error(`Graph output path rejected (${resolvedOutput.reason}): output must remain in the repository, outside canonical authored paths, without symlinks.`);
+  }
+  const outputPath = resolvedOutput.path;
   if (!existsSync(projectionPath)) {
     throw new Error(`Projection database not found: ${projectionPath}`);
   }

--- a/packages/cli/src/commands/migration.ts
+++ b/packages/cli/src/commands/migration.ts
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Effect, Schema } from "effect";
 import { moduleEntityId, stablePayloadHash, type WriteCoordinator, type WriteError } from "@harness-anything/kernel";
@@ -6,6 +6,7 @@ import type { HarnessLayoutInput } from "@harness-anything/kernel";
 import { resolveHarnessLayout } from "@harness-anything/kernel";
 import { LegacyIndexSchema, type LegacyIndex, type LegacyIndexEntry } from "@harness-anything/kernel";
 import { cliError, CliErrorCode } from "../cli/error-codes.ts";
+import { resolveContainedOutputPath } from "../cli/output-path.ts";
 import { isGeneratedOrVendorPath, isPathInside, normalizeSlashes } from "../cli/path.ts";
 import type { CliResult } from "../cli/types.ts";
 import { applyCollisionReport, buildLegacyCopyPlan, readCollisionReport, writeCollisionReport } from "./migration-collision.ts";
@@ -113,7 +114,16 @@ function migrateRunSessionResult(rootDir: string, report: LegacyScanReport, acti
     indexDigest: digestJson(toLegacyIndex(rootDir, report)),
     entries: report.entries
   };
-  const sessionPath = writeSession(rootDir, action.outDir, session);
+  const written = writeSession(rootDir, action.outDir, session);
+  if (!written.ok) {
+    return {
+      ok: false,
+      command: "migrate-run",
+      report: session,
+      error: cliError(CliErrorCode.ArtifactWriteRejected, `Migration session output path rejected (${written.reason}): output must remain in the repository, outside canonical authored paths, without symlinks.`)
+    };
+  }
+  const sessionPath = written.path;
   return {
     ok: true,
     command: "migrate-run",
@@ -196,22 +206,13 @@ export function runLegacyIntakePlan(rootInput: HarnessLayoutInput, action: Legac
 
 function resolveLegacyIntakeArtifactPath(rootDir: string, requestedPath: string): { readonly ok: true; readonly path: string } | { readonly ok: false } {
   const artifactRoot = path.join(rootDir, ".harness", "migration-artifacts");
-  if (path.isAbsolute(requestedPath)) return { ok: false };
-  const outputPath = path.resolve(artifactRoot, requestedPath);
-  if (!isPathInside(artifactRoot, outputPath) || hasSymlinkInExistingPath(artifactRoot, outputPath)) return { ok: false };
-  return { ok: true, path: outputPath };
-}
-
-function hasSymlinkInExistingPath(rootPath: string, targetPath: string): boolean {
-  let current = rootPath;
-  if (existsSync(current) && lstatSync(current).isSymbolicLink()) return true;
-  const relative = path.relative(rootPath, targetPath);
-  for (const segment of relative.split(path.sep)) {
-    if (!segment) continue;
-    current = path.join(current, segment);
-    if (existsSync(current) && lstatSync(current).isSymbolicLink()) return true;
-  }
-  return false;
+  const resolved = resolveContainedOutputPath({
+    requestedPath,
+    containerRoots: [artifactRoot],
+    relativeTo: artifactRoot,
+    allowAbsolute: false
+  });
+  return resolved.ok ? resolved : { ok: false };
 }
 
 export function runLegacyCopySafeDocs(rootInput: HarnessLayoutInput, action: LegacyCopySafeDocsAction): CliResult {
@@ -521,12 +522,26 @@ function digestJson(value: unknown): `sha256:${string}` {
   return `sha256:${stablePayloadHash(value)}`;
 }
 
-function writeSession(rootDir: string, outDir: string, session: LegacyIntakeSession): string {
-  const directory = path.resolve(rootDir, outDir);
+function writeSession(
+  rootDir: string,
+  outDir: string,
+  session: LegacyIntakeSession
+): { readonly ok: true; readonly path: string } | { readonly ok: false; readonly reason: string } {
+  const layout = resolveHarnessLayout({ rootDir });
+  const resolved = resolveContainedOutputPath({
+    requestedPath: outDir,
+    containerRoots: [rootDir],
+    canonicalRoots: [layout.authoredRoot],
+    relativeTo: rootDir
+  });
+  if (!resolved.ok) {
+    return resolved;
+  }
+  const directory = resolved.path;
   mkdirSync(directory, { recursive: true });
   const sessionPath = path.join(directory, "session.json");
   writeFileSync(sessionPath, `${JSON.stringify(session, null, 2)}\n`, "utf8");
-  return sessionPath;
+  return { ok: true, path: sessionPath };
 }
 
 function relative(rootDir: string, targetPath: string): string {

--- a/packages/cli/test/daemon-output-path-containment.test.ts
+++ b/packages/cli/test/daemon-output-path-containment.test.ts
@@ -1,0 +1,41 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { runRawJsonMaybeFail, withTempRoot } from "./helpers/daemon-cli.ts";
+
+test("daemon install-templates rejects canonical authored output directories", () => {
+  withTempRoot((rootDir) => {
+    const outDir = path.join(rootDir, "harness/decisions/template-output");
+    const result = runRawJsonMaybeFail(rootDir, ["daemon", "install-templates", "--out", outDir], {
+      HARNESS_DAEMON_MODE: "fixture"
+    });
+    assert.notEqual(result.status, 0);
+    assert.equal(result.receipt.ok, false);
+    assert.equal(existsSync(path.join(outDir, "harness-anything-daemon.service")), false);
+  });
+});
+
+test("daemon bootstrap-server rejects a report path beneath canonical authored paths", () => {
+  withTempRoot((rootDir) => {
+    const canonicalRoot = path.join(rootDir, "canonical");
+    const reportPath = path.join(canonicalRoot, "harness/decisions/bootstrap-report.json");
+    const result = runRawJsonMaybeFail(rootDir, [
+      "daemon",
+      "bootstrap-server",
+      "--canonical-root",
+      canonicalRoot,
+      "--ssh-host",
+      "team-host",
+      "--report",
+      reportPath,
+      "--skip-ssh-check",
+      "--no-start"
+    ], { HARNESS_DAEMON_MODE: "fixture" });
+
+    assert.notEqual(result.status, 0);
+    assert.equal(result.receipt.ok, false);
+    assert.equal(existsSync(reportPath), false);
+  });
+});

--- a/packages/cli/test/graph-cli.test.ts
+++ b/packages/cli/test/graph-cli.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -72,6 +72,42 @@ test("CLI graph hides archived task refs by default and can include them explici
     assert.equal(withArchived.report.summary.islands, 2);
     assert.match(withArchivedHtml, /task\/task-archived/u);
     assert.match(withArchivedHtml, /task\/task-archived-island/u);
+  });
+});
+
+test("CLI graph confines user output paths outside canonical authored paths and symlinks", () => {
+  withTempRoot((rootDir) => {
+    writeTask(rootDir, "task-one", "Task One");
+    runJson(rootDir, ["task", "list"]);
+    const canonicalPath = path.join(rootDir, "harness/tasks/task-one-fixture/INDEX.md");
+    const canonicalBefore = readFileSync(canonicalPath, "utf8");
+    const parentEscape = path.resolve(rootDir, "../graph-parent-escape.html");
+
+    const canonical = runJsonFailure(rootDir, ["graph", "--out", canonicalPath]);
+    const parent = runJsonFailure(rootDir, ["graph", "--out", "../graph-parent-escape.html"]);
+
+    assert.equal(canonical.ok, false);
+    assert.equal(canonical.error.code, "projection_check_failed");
+    assert.equal(readFileSync(canonicalPath, "utf8"), canonicalBefore);
+    assert.equal(parent.ok, false);
+    assert.equal(existsSync(parentEscape), false);
+
+    const externalRoot = mkdtempSync(path.join(tmpdir(), "ha-graph-output-symlink-"));
+    try {
+      const generatedRoot = path.join(rootDir, ".harness/generated");
+      mkdirSync(generatedRoot, { recursive: true });
+      symlinkSync(externalRoot, path.join(generatedRoot, "escape"));
+      const symlink = runJsonFailure(rootDir, ["graph", "--out", ".harness/generated/escape/graph.html"]);
+      assert.equal(symlink.ok, false);
+      assert.equal(existsSync(path.join(externalRoot, "graph.html")), false);
+    } finally {
+      rmSync(externalRoot, { recursive: true, force: true });
+    }
+
+    const legalPath = path.join(rootDir, ".harness/generated/graph-panorama/legal.html");
+    const legal = runJson(rootDir, ["graph", "--out", legalPath]);
+    assert.equal(legal.ok, true);
+    assert.equal(existsSync(legalPath), true);
   });
 });
 
@@ -158,6 +194,16 @@ function runJson(rootDir: string, args: ReadonlyArray<string>): Record<string, a
     env: cliTestEnv()
   });
   return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
+}
+
+function runJsonFailure(rootDir: string, args: ReadonlyArray<string>): Record<string, any> {
+  try {
+    runJson(rootDir, args);
+    assert.fail(`Expected command to fail: ${args.join(" ")}`);
+  } catch (error) {
+    const stdout = error && typeof error === "object" && "stdout" in error ? String(error.stdout) : "";
+    return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
+  }
 }
 
 function withTempRoot<T>(fn: (rootDir: string) => T): T {

--- a/packages/cli/test/migration-adopt-cli.test.ts
+++ b/packages/cli/test/migration-adopt-cli.test.ts
@@ -113,6 +113,21 @@ test("CLI legacy intake-plan confines --out to migration artifacts and rejects e
   });
 });
 
+test("CLI migrate-run rejects session output beneath canonical authored paths", () => {
+  withTempRoot((rootDir) => {
+    const canonicalDir = path.join(rootDir, "harness/tasks/session-output");
+    const rejected = runJson(rootDir, ["migrate-run", "--plan-only", "--out-dir", canonicalDir], false);
+
+    assert.equal(rejected.ok, false);
+    assert.equal(existsSync(path.join(canonicalDir, "session.json")), false);
+
+    const legalDir = path.join(rootDir, ".harness/generated/migration-sessions/contained");
+    const legal = runJson(rootDir, ["migrate-run", "--plan-only", "--out-dir", legalDir]);
+    assert.equal(legal.ok, true);
+    assert.equal(existsSync(path.join(legalDir, "session.json")), true);
+  });
+});
+
 test("CLI legacy copy preserves legacy evidence and forwards safe authored docs", () => {
   withTempRoot((rootDir) => {
     writeLegacyTask(rootDir, "done-task", "done");

--- a/packages/cli/test/production-authority-host-services/fixtures/batch5a-parent-differential.json
+++ b/packages/cli/test/production-authority-host-services/fixtures/batch5a-parent-differential.json
@@ -8,7 +8,7 @@
     "packages/cli/src/commands/core/decision-relate.ts": "22b3eff78b8115c6c97e870d0218b6f779064dca",
     "packages/cli/src/commands/core/decision-relation-record.ts": "b802dcbb858030d86d40e2b928750afd7150d239",
     "packages/cli/src/commands/core/task-lifecycle.ts": "ca002e96498531aef065647cabe7ed6279caa54e",
-    "packages/cli/src/commands/daemon/productization.ts": "97eba53a9fb0b7b4baac466f0a4b0e27e1fdac8f",
+    "packages/cli/src/commands/daemon/productization.ts": "565a8eb9ebc5ddf5de9c631154088d30c0bc9476",
     "packages/cli/src/commands/preset-task.ts": "34d32398c4fd4ed6e578022ca1140905906cabad",
     "packages/cli/src/commands/settings.ts": "dcc83b0f0775494d4f6d7326aaa7285d5f67b619",
     "packages/cli/src/composition/adapter-registry.ts": "8c0be49785f847e0e26e8f0c1a5e661f5c5d17df"

--- a/tools/check-cli-output-path-containment.mjs
+++ b/tools/check-cli-output-path-containment.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+import { fsWriteApis } from "./fs-write-apis.mjs";
+
+const sourceRoot = "packages/cli/src";
+const ignoredPrefix = "packages/cli/src/commands/extensions/assets/";
+const outputFlags = /^--(?:out(?:put)?(?:-.+)?|report)$/u;
+const containmentResolvers = new Set(["resolveContainedOutputPath", "requireDaemonProductOutputPath"]);
+const destinationArgument = new Map([
+  ["copyFile", 1],
+  ["copyFileSync", 1],
+  ["cp", 1],
+  ["cpSync", 1],
+  ["rename", 1],
+  ["renameSync", 1]
+]);
+
+export function checkCliOutputPathContainment(root = process.cwd()) {
+  const files = walkSourceFiles(root);
+  const parsed = files.map((rel) => ({ rel, sourceFile: parseSource(root, rel) }));
+  const outputProperties = discoverOutputProperties(parsed);
+  const findings = parsed.flatMap(({ rel, sourceFile }) => inspectFile(rel, sourceFile, outputProperties));
+  const unique = new Map(findings.map((finding) => [`${finding.file}:${finding.line}:${finding.column}`, finding]));
+  return { violations: [...unique.values()].sort(compareFindings) };
+}
+
+function discoverOutputProperties(parsed) {
+  const properties = new Set();
+  for (const { sourceFile } of parsed) {
+    visit(sourceFile, (node) => {
+      if (!ts.isPropertyAssignment(node) || !containsOutputOptionRead(node.initializer)) return;
+      const name = propertyName(node.name);
+      if (name) properties.add(name);
+    });
+  }
+  return properties;
+}
+
+function containsOutputOptionRead(node) {
+  let found = false;
+  const inspect = (candidate) => {
+    if (found) return;
+    if (candidate !== node && (ts.isObjectLiteralExpression(candidate) || ts.isPropertyAssignment(candidate))) return;
+    if (ts.isCallExpression(candidate) && calledName(candidate.expression) === "readOption") {
+      const flag = candidate.arguments[1];
+      if (flag && ts.isStringLiteral(flag) && outputFlags.test(flag.text)) {
+        found = true;
+        return;
+      }
+    }
+    ts.forEachChild(candidate, inspect);
+  };
+  inspect(node);
+  return found;
+}
+
+function inspectFile(rel, sourceFile, outputProperties) {
+  const fsImports = fsBindings(sourceFile);
+  const findings = [];
+  const functions = functionsIn(sourceFile);
+  const namedFunctions = new Map(functions.flatMap((fn) => functionName(fn) ? [[functionName(fn), fn]] : []));
+  const taintedParameters = new Map(functions.map((fn) => [fn, new Set()]));
+  let propagated = true;
+  let analyses = new Map();
+  while (propagated) {
+    propagated = false;
+    analyses = new Map(functions.map((fn) => [fn, analyzeFunction(fn, taintedParameters.get(fn), outputProperties)]));
+    for (const fn of functions) {
+      const analysis = analyses.get(fn);
+      visit(fn.body, (node) => {
+        if (!ts.isCallExpression(node) || !ts.isIdentifier(node.expression)) return;
+        const callee = namedFunctions.get(node.expression.text);
+        if (!callee) return;
+        const marked = taintedParameters.get(callee);
+        node.arguments.forEach((argument, index) => {
+          if (isTaintedExpression(argument, analysis.tainted, outputProperties, analysis.sanitized) && !marked.has(index)) {
+            marked.add(index);
+            propagated = true;
+          }
+        });
+      });
+    }
+  }
+  for (const fn of functions) {
+    const { tainted, sanitized } = analyses.get(fn);
+    visit(fn.body, (node) => {
+      if (!ts.isCallExpression(node)) return;
+      const api = calledFsApi(node.expression, fsImports);
+      if (!api) return;
+      const target = node.arguments[destinationArgument.get(api) ?? 0];
+      if (!target || !isTaintedExpression(target, tainted, outputProperties, sanitized)) return;
+      findings.push(finding(rel, node.expression, sourceFile, api));
+    });
+  }
+  return findings;
+}
+
+function analyzeFunction(fn, taintedParameterIndexes, outputProperties) {
+  const tainted = new Set();
+  fn.parameters.forEach((parameter, index) => {
+    if (taintedParameterIndexes.has(index) && ts.isIdentifier(parameter.name)) tainted.add(parameter.name.text);
+  });
+    const sanitized = new Set();
+    let changed = true;
+    while (changed) {
+      changed = false;
+      visit(fn.body, (node) => {
+        if (!ts.isVariableDeclaration(node) || !ts.isIdentifier(node.name) || !node.initializer) return;
+        if (isSanitizedExpression(node.initializer, sanitized)) {
+          if (!sanitized.has(node.name.text)) {
+            sanitized.add(node.name.text);
+            changed = true;
+          }
+          return;
+        }
+        if (isTaintedExpression(node.initializer, tainted, outputProperties, sanitized) && !tainted.has(node.name.text)) {
+          tainted.add(node.name.text);
+          changed = true;
+        }
+      });
+    }
+  return { tainted, sanitized };
+}
+
+function isTaintedExpression(node, tainted, outputProperties, sanitized) {
+  if (isSanitizedExpression(node, sanitized)) return false;
+  if (ts.isIdentifier(node)) return tainted.has(node.text) && !sanitized.has(node.text);
+  if (ts.isPropertyAccessExpression(node) && outputProperties.has(node.name.text)) return true;
+  if (ts.isElementAccessExpression(node) && node.argumentExpression && ts.isStringLiteral(node.argumentExpression)
+    && outputProperties.has(node.argumentExpression.text)) return true;
+  if (ts.isCallExpression(node) && calledName(node.expression) === "readOption") {
+    const flag = node.arguments[1];
+    return Boolean(flag && ts.isStringLiteral(flag) && outputFlags.test(flag.text));
+  }
+  let found = false;
+  ts.forEachChild(node, (child) => {
+    if (!found && isTaintedExpression(child, tainted, outputProperties, sanitized)) found = true;
+  });
+  return found;
+}
+
+function isSanitizedExpression(node, sanitized) {
+  if (ts.isCallExpression(node) && containmentResolvers.has(calledName(node.expression))) return true;
+  return ts.isPropertyAccessExpression(node)
+    && node.name.text === "path"
+    && ts.isIdentifier(node.expression)
+    && sanitized.has(node.expression.text);
+}
+
+function functionsIn(sourceFile) {
+  const functions = [];
+  visit(sourceFile, (node) => {
+    if ((ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node) || ts.isArrowFunction(node) || ts.isMethodDeclaration(node)) && node.body) {
+      functions.push(node);
+    }
+  });
+  return functions;
+}
+
+function functionName(fn) {
+  if ("name" in fn && fn.name && ts.isIdentifier(fn.name)) return fn.name.text;
+  if ((ts.isArrowFunction(fn) || ts.isFunctionExpression(fn)) && ts.isVariableDeclaration(fn.parent) && ts.isIdentifier(fn.parent.name)) {
+    return fn.parent.name.text;
+  }
+  return undefined;
+}
+
+function fsBindings(sourceFile) {
+  const named = new Map();
+  const namespaces = new Set();
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    if (!["node:fs", "node:fs/promises"].includes(statement.moduleSpecifier.text)) continue;
+    const bindings = statement.importClause?.namedBindings;
+    if (bindings && ts.isNamespaceImport(bindings)) namespaces.add(bindings.name.text);
+    if (bindings && ts.isNamedImports(bindings)) {
+      for (const element of bindings.elements) {
+        const imported = (element.propertyName ?? element.name).text;
+        if (fsWriteApis.has(imported)) named.set(element.name.text, imported);
+      }
+    }
+  }
+  return { named, namespaces };
+}
+
+function calledFsApi(expression, bindings) {
+  if (ts.isIdentifier(expression)) return bindings.named.get(expression.text);
+  if (!ts.isPropertyAccessExpression(expression) || !bindings.namespaces.has(expression.expression.getText())) return undefined;
+  return fsWriteApis.has(expression.name.text) ? expression.name.text : undefined;
+}
+
+function calledName(expression) {
+  if (ts.isIdentifier(expression)) return expression.text;
+  if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
+  return undefined;
+}
+
+function walkSourceFiles(root) {
+  const absolute = path.join(root, sourceRoot);
+  if (!existsSync(absolute)) return [];
+  return ts.sys.readDirectory(absolute, [".ts", ".mts", ".cts"], undefined, undefined)
+    .filter((entry) => statSync(entry).isFile() && !entry.endsWith(".d.ts"))
+    .map((entry) => path.relative(root, entry).split(path.sep).join("/"))
+    .filter((entry) => !entry.startsWith(ignoredPrefix))
+    .sort();
+}
+
+function parseSource(root, rel) {
+  const text = readFileSync(path.join(root, rel), "utf8");
+  return ts.createSourceFile(rel, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
+
+function finding(file, node, sourceFile, api) {
+  const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+  return {
+    file,
+    line: line + 1,
+    column: character + 1,
+    message: `${api} receives a user-controlled output path without resolveContainedOutputPath`
+  };
+}
+
+function propertyName(name) {
+  return ts.isIdentifier(name) || ts.isStringLiteral(name) ? name.text : undefined;
+}
+
+function compareFindings(left, right) {
+  return left.file.localeCompare(right.file) || left.line - right.line || left.column - right.column;
+}
+
+function visit(node, fn) {
+  fn(node);
+  ts.forEachChild(node, (child) => visit(child, fn));
+}
+
+function main() {
+  const rootFlag = process.argv.indexOf("--root");
+  const root = rootFlag >= 0 && process.argv[rootFlag + 1] ? path.resolve(process.argv[rootFlag + 1]) : process.cwd();
+  const result = checkCliOutputPathContainment(root);
+  if (result.violations.length > 0) {
+    console.error("CLI output-path containment check failed:");
+    for (const violation of result.violations) {
+      console.error(`- ${violation.file}:${violation.line}:${violation.column} ${violation.message}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+  console.log("CLI output-path containment check passed.");
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/tools/check-cli-output-path-containment.test.mjs
+++ b/tools/check-cli-output-path-containment.test.mjs
@@ -1,0 +1,58 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const checkerPath = path.resolve("tools/check-cli-output-path-containment.mjs");
+
+test("CLI output-path gate rejects a renamed and path-resolved bare user output write", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-cli-output-path-"));
+  try {
+    const sourceDir = path.join(root, "packages/cli/src");
+    mkdirSync(sourceDir, { recursive: true });
+    writeFileSync(path.join(sourceDir, "bare-output.ts"), [
+      'import { writeFileSync } from "node:fs";',
+      'import path from "node:path";',
+      'import { readOption } from "./parse-options.ts";',
+      "export function emit(args: string[], rootDir: string) {",
+      '  const destination = path.resolve(rootDir, readOption(args, "--out") ?? "result.txt");',
+      '  writeFileSync(destination, "uncontained");',
+      "}",
+      ""
+    ].join("\n"), "utf8");
+
+    const result = spawnSync(process.execPath, [checkerPath, "--root", root], { encoding: "utf8" });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /packages\/cli\/src\/bare-output\.ts:6:\d+ writeFileSync receives a user-controlled output path/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("CLI output-path gate accepts writes only after the shared resolver", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-cli-contained-output-"));
+  try {
+    const sourceDir = path.join(root, "packages/cli/src");
+    mkdirSync(sourceDir, { recursive: true });
+    writeFileSync(path.join(sourceDir, "contained-output.ts"), [
+      'import { writeFileSync } from "node:fs";',
+      'import { readOption } from "./parse-options.ts";',
+      "export function emit(args: string[], rootDir: string) {",
+      '  const requested = readOption(args, "--out") ?? "result.txt";',
+      "  const resolved = resolveContainedOutputPath({ requestedPath: requested, containerRoots: [rootDir], relativeTo: rootDir });",
+      '  if (resolved.ok) writeFileSync(resolved.path, "contained");',
+      "}",
+      ""
+    ].join("\n"), "utf8");
+
+    const result = spawnSync(process.execPath, [checkerPath, "--root", root], { encoding: "utf8" });
+
+    assert.equal(result.status, 0, result.stderr);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -133,6 +133,7 @@
         "check-write-coordinator-boundary",
         "check-write-road-registry",
         "check-cli-direct-writer",
+        "check-cli-output-path-containment",
         "check-cli-daemon-parity",
         "check-kernel-dead-exports",
         "check-relation-cycle-substrate",
@@ -184,6 +185,7 @@
         "check-write-coordinator-boundary",
         "check-write-road-registry",
         "check-cli-direct-writer",
+        "check-cli-output-path-containment",
         "check-cli-daemon-parity",
         "check-kernel-dead-exports",
         "check-relation-cycle-substrate",
@@ -213,7 +215,7 @@
         "check-legacy-intake-readiness",
         "check-supply-chain"
       ],
-      "harnessLeafGateCount": 47
+      "harnessLeafGateCount": 48
     },
     "rewriteCi": {
       "pullRequestGateJobs": [
@@ -2174,6 +2176,80 @@
         "status": "covered",
         "evidence": [
           "tools/check-cli-direct-writer.test.mjs"
+        ]
+      }
+    },
+    {
+      "id": "check-cli-output-path-containment",
+      "command": "npm run harness:check-cli-output-path-containment",
+      "category": "boundary",
+      "tier": "pr-required",
+      "tierReason": null,
+      "authoritySource": [
+        "dec_01KYCA4Q2MZNHX4N8T3K06JG02#CH1",
+        "task_01KYCF6WF7MD6VPEBR09XWNZ3S",
+        "tools/check-cli-output-path-containment.mjs"
+      ],
+      "consumerScope": [
+        "AST-derived user-controlled CLI output path flows into Node filesystem write sinks under packages/cli/src",
+        "shared containment resolver use before user-selected output writes"
+      ],
+      "githubContext": {
+        "requiredContexts": [
+          "boundaries"
+        ],
+        "workflowJobs": [
+          "boundaries"
+        ],
+        "nodeVersions": [
+          24
+        ]
+      },
+      "allowlistPolicy": {
+        "allowed": false,
+        "location": null,
+        "adrOrDecisionRequired": false,
+        "notes": "No skip or allowlist is permitted; user-controlled output paths must pass the shared containment resolver before a filesystem write."
+      },
+      "changeControl": {
+        "ordinaryImplementationMayModify": false,
+        "requiresGovernanceEvidence": true,
+        "protectedSurfaces": [
+          "tools/check-cli-output-path-containment.mjs",
+          "tools/check-cli-output-path-containment.test.mjs",
+          "package.json:scripts.harness:check-cli-output-path-containment",
+          "tools/gate-manifest.json"
+        ]
+      },
+      "bypassFixtureRequired": true,
+      "executionSurfaces": {
+        "packageJson": {
+          "check": true,
+          "checkPr": true,
+          "script": "harness:check-cli-output-path-containment"
+        },
+        "rewriteCi": {
+          "pullRequestJobs": [
+            "boundaries"
+          ],
+          "nonPullRequestJobs": []
+        },
+        "branchProtection": {
+          "required": true,
+          "contexts": [
+            "boundaries"
+          ]
+        },
+        "classes": [
+          "local",
+          "pr"
+        ]
+      },
+      "deterministic": true,
+      "positiveControl": {
+        "status": "covered",
+        "evidence": [
+          "tools/check-cli-output-path-containment.test.mjs"
         ]
       }
     },


### PR DESCRIPTION
# English

## Summary

`ha graph --out <path>` accepted any resolved absolute path and wrote to it, which meant it could
overwrite a canonical governance document and still return `ok: true`. The same shape existed on
`migrate-run --out-dir/--session-dir`, `daemon install-templates --out`, and
`daemon bootstrap-server --report`.

The fix is one gate, not four patches. All user-supplied CLI output paths now pass a single
containment resolver before any filesystem write, and a new AST-based mechanical check makes this
class of escape impossible to reintroduce.

## What Changed

- New `packages/cli/src/cli/output-path.ts`: `resolveContainedOutputPath` enforces container
  containment, rejects canonical authored targets, and rejects symlinked path components. The
  canonical root is derived from `resolveHarnessLayout`, not matched as a path literal, so renaming
  a directory moves the protection with it rather than silently disabling it.
- `graph-panorama.ts`, `migration.ts`, and the two `daemon` productization sinks now route through
  that resolver. `migration.ts` reuses the pre-existing legacy primitive rather than adding a
  parallel one.
- New `tools/check-cli-output-path-containment.mjs`: an AST detector that fails on a bare
  filesystem write to a user-supplied path under `packages/cli/src`.
- The detector's npm script runs the detector **and** its positive-control fixture in the same
  command, so a detector that stopped firing would itself go red in CI.

## Task And Scope

- Harness task: `task_01KYCF6WF7MD6VPEBR09XWNZ3S`
- Branch: `fix/c3-cli-output-path-containment`
- Public scope: `packages/cli/**`, `tools/check-cli-output-path-containment*`,
  `tools/gate-manifest.json`, `package.json`
- Private planning/evidence updated: yes
- Out of scope: daemon authority write paths, terminal subsystem (both have concurrent work)

## Version Impact

- Version: no version change because no published package surface changes; the resolver is internal
  to the CLI
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gate-manifest.json` (registers one new gate),
  `package.json` (adds one `harness:*` script)
- Authority: `dec_01KYCA4Q2MZNHX4N8T3K06JG02#CH1` judgment 1 — a criterion only counts as executed
  once it is compiled into something that speaks on every PR, and every detector must carry a
  fixture that makes it go red. A checker that exists but is not registered is precisely the
  no-resident-enforcer failure that decision exists to prevent, so registration executes that
  decision rather than creating new policy. Task trace: `task_01KYCF6WF7MD6VPEBR09XWNZ3S`.
  The registration was authorized by the CEO after the implementing worker stopped at the task
  contract's declared CI/Gate Authority Stop Condition.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it
  is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `65789c9a3b09da7e52254bd8175d6db0d88fdf38`
- Branch merge-base with `origin/main`: `65789c9a3b09da7e52254bd8175d6db0d88fdf38`
- Last `git fetch origin` time: 2026-07-25, immediately before opening this PR
- Sync method: none needed
- Public diff command: `git diff 65789c9a3b09da7e52254bd8175d6db0d88fdf38..HEAD`
- Private evidence commit/path: `harness/tasks/task_01KYCF6WF7MD6VPEBR09XWNZ3S-*/`
- Reviewer evidence path: `harness/tasks/task_01KYCF6WF7MD6VPEBR09XWNZ3S-*/review.md`
- GitHub Actions `rewrite-ci` run URL: pending, added after the run starts
- [x] `git diff --check`
- [x] `npm run check:stop-point` (the gate set is derived from `tools/gate-manifest.json`; do not
      enumerate gates by hand) — 34 local-stop gates green in 63.7s; fast 546/546; contract 315/315
- [x] Targeted tests for the change surface, named with their counts:
      detector positive/safe controls 2/2; `check-gate-manifest-invariants` pass (51/64
      deterministic gates); `check-gate-surface` pass (64 manifest gates, 0 drift findings).
      Bypass coverage is itemized per bypass rather than asserted in aggregate: `../` escape at
      `graph-cli.test.ts:84` with non-existence of the outside file asserted at lines 92-93;
      a real symlink is created at line 99, rejection asserted at 101, and non-creation of the
      symlink's outside target asserted at 102.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: nothing was skipped. The negative control was executed against a temporary copy
  of a canonical document rather than the live ledger — before the fix the copy's SHA moved from
  `643f4b…2658` to `2ae1bc…9bc`; after the fix the same attack is rejected and the SHA is unchanged.

## Review Evidence

- Self-review: CEO read the resolver, the `graph-panorama` call site, and the full
  `tools/gate-manifest.json` hunk line by line, confirming the change is purely additive (two list
  insertions, leaf count 47→48, one new gate object) and that no existing tier, `requiredContexts`,
  or allowlist was modified.
- Reviewer subagent: implementing worker's report, cross-read by CEO. The worker's first-round
  claim that bypasses were covered "3/3" was sent back for per-bypass attribution; the itemization
  above is the answer.
- Human review: CEO semantic acceptance, 2026-07-25.
- Blocking findings: none.

## Residual Risk

- The containment check and the subsequent write are not atomic, so a symlink created between the
  two would not be caught. Accepted for a local CLI: the threat model here is accident, not an
  attacker racing the process, consistent with ADR-0016 D3.
- `containerRoots` is the repository root, so the resolver permits writes anywhere in the repo
  outside the authored root. It bounds the blast radius rather than eliminating it; narrowing the
  container per command would be a separate product-surface decision.
- `tools/gate-manifest.json` may conflict textually with concurrent work on the decision-writing
  length gate. Resolution is the merge side's responsibility.

## References

- Task: `harness/tasks/task_01KYCF6WF7MD6VPEBR09XWNZ3S-*/task_plan.md`
- Evidence: `harness/tasks/task_01KYCF6WF7MD6VPEBR09XWNZ3S-*/artifacts/`
- Review: `harness/tasks/task_01KYCF6WF7MD6VPEBR09XWNZ3S-*/review.md`

---

# 中文

## 概要

`ha graph --out <path>` 会接受任何解析后的绝对路径并直接写入，因此它可以覆盖一份 canonical
治理文档、并且照样返回 `ok: true`。同形状的活口还有 `migrate-run --out-dir/--session-dir`、
`daemon install-templates --out`、`daemon bootstrap-server --report`。

修法是**一道门，不是四个补丁**：CLI 中所有来自用户参数的输出路径，写盘前统一过同一个
containment resolver；另有一条新增的 AST 机械检查，使这一类逃逸不可能再被引入。

## 改动内容

- 新增 `packages/cli/src/cli/output-path.ts`：`resolveContainedOutputPath` 强制容器内包含、
  拒绝 canonical authored 目标、拒绝路径上任何 symlink 组件。**canonical root 由
  `resolveHarnessLayout` 派生，不是按路径字面量匹配**——改目录名时保护会跟着走，
  而不是悄悄失效。
- `graph-panorama.ts`、`migration.ts` 与两处 `daemon` productization sink 全部改走该 resolver。
  `migration.ts` 复用既有的 legacy 原语，没有另造一套。
- 新增 `tools/check-cli-output-path-containment.mjs`：AST detector，对 `packages/cli/src`
  下针对用户给定路径的裸写入报红。
- 该 detector 的 npm script **同时**运行 detector 与它的阳性对照 fixture，
  因此一个「不再报红的 detector」自己会在 CI 上变红。

## 任务与范围

- Harness 任务：`task_01KYCF6WF7MD6VPEBR09XWNZ3S`
- 分支：`fix/c3-cli-output-path-containment`
- 公开范围：`packages/cli/**`、`tools/check-cli-output-path-containment*`、
  `tools/gate-manifest.json`、`package.json`
- 私有规划/证据已更新：是
- 不在范围内：daemon authority 写路、终端子系统（两处均有并行任务在飞）

## 版本影响

- 版本：无变更，因为没有改动任何已发布的包对外面；resolver 是 CLI 内部实现
- 发布影响：不发布

## 治理声明

- 触及 protected surface：是
- Protected surface 范围：`tools/gate-manifest.json`（注册一道新门）、
  `package.json`（新增一个 `harness:*` script）
- 权威依据：`dec_01KYCA4Q2MZNHX4N8T3K06JG02#CH1` 判据 1——「判据只有编译成会在每个 PR 上
  出声的东西，才算被执行」，且「每个 detector 必须自带一个会让它变红的 fixture」。
  一个存在却没注册的 checker，正是该决策要防的「有尺子但没人量」，
  因此注册是执行既有决策，不是新立政策。任务留痕：`task_01KYCF6WF7MD6VPEBR09XWNZ3S`。
  实现 worker 在任务契约声明的 CI/Gate Authority Stop Condition 处停手，
  由 CEO 裁决后授权本次注册。
- 机器检查边界：本 PR 只断言声明存在；声明是否为真、是否充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`65789c9a3b09da7e52254bd8175d6db0d88fdf38`
- 分支与 `origin/main` 的 merge-base：`65789c9a3b09da7e52254bd8175d6db0d88fdf38`
- 最近一次 `git fetch origin` 时间：2026-07-25，开 PR 前
- 同步方式：无需同步
- 公开 diff 命令：`git diff 65789c9a3b09da7e52254bd8175d6db0d88fdf38..HEAD`
- 私有证据 commit/路径：`harness/tasks/task_01KYCF6WF7MD6VPEBR09XWNZ3S-*/`
- 评审证据路径：`harness/tasks/task_01KYCF6WF7MD6VPEBR09XWNZ3S-*/review.md`
- GitHub Actions `rewrite-ci` run URL：待补，run 起来后回填
- [x] `git diff --check`
- [x] `npm run check:stop-point`（门集从 `tools/gate-manifest.json` 派生，不手工枚举）——
      34 道 local-stop 门全绿，63.7 秒；fast 546/546；contract 315/315
- [x] 变更面定向测试及计数：detector 阳性/安全对照 2/2；
      `check-gate-manifest-invariants` 通过（51/64 deterministic gates）；
      `check-gate-surface` 通过（64 manifest gates，0 drift findings）。
      **绕法覆盖是逐种归因的，不是笼统断言**：`../` 逃逸见 `graph-cli.test.ts:84`，
      容器外文件不存在的断言在第 92–93 行；第 99 行真实创建 symlink，
      第 101 行断言被拒，第 102 行断言 symlink 的容器外目标未被生成。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）
- 未跑及原因：无跳过项。阴性对照在 canonical 文档的**临时副本**上执行、没有真的动台账——
  修复前副本 SHA 由 `643f4b…2658` 变为 `2ae1bc…9bc`；修复后同一攻击被拒绝，SHA 保持不变。

## 审查证据

- 自审：CEO 逐行读了 resolver、`graph-panorama` 调用点，以及完整的
  `tools/gate-manifest.json` hunk，确认改动纯粹是增量（两处列表插入、
  leaf count 47→48、一个新 gate 对象），且未修改任何既有条目的 tier、
  `requiredContexts` 或 allowlist。
- 评审 subagent：实现 worker 的报告，由 CEO 交叉复读。worker 首轮把绕法覆盖笼统写成
  「3/3 通过」，被我打回要求逐种归因；上面的逐行归因就是回答。
- 人工评审：CEO 语义验收，2026-07-25。
- 阻塞性发现：无。

## 残余风险

- containment 检查与随后的写入不是原子的，两者之间被创建的 symlink 抓不到。
  本地 CLI 场景下接受：这里的威胁模型是**意外不是对手抢跑**，与 ADR-0016 D3 一致。
- `containerRoots` 取的是仓库根，因此 resolver 允许写到 authored root 之外的仓库任意位置。
  它收窄了爆炸半径而非消除它；按命令进一步收窄容器属于另一个产品面决策。
- `tools/gate-manifest.json` 可能与并行的「决策书写长度门」产生文本冲突，由合并侧处理。

## 关联材料

- 任务：`harness/tasks/task_01KYCF6WF7MD6VPEBR09XWNZ3S-*/task_plan.md`
- 证据：`harness/tasks/task_01KYCF6WF7MD6VPEBR09XWNZ3S-*/artifacts/`
- 评审：`harness/tasks/task_01KYCF6WF7MD6VPEBR09XWNZ3S-*/review.md`
