### PR TITLE
fix(authority): accept planned specialized ingress

### DIFF
--- a/packages/cli/test/production-authority-attempt-plan.test.ts
+++ b/packages/cli/test/production-authority-attempt-plan.test.ts
@@ -654,7 +654,8 @@ test("fixed-attempt planning is pure and activation validates exact durable reco
         ingress: "generic",
         canonicalEntityId: taskEntityId("task_other")
       }),
-      /AUTHORITY_PLANNED_INPUT_MISMATCH/u
+      (error: unknown) => error instanceof Error
+        && error.message === "AUTHORITY_PLANNED_INPUT_MISMATCH"
     );
     assert.equal(
       (await recoveredDecisionSubmission.submit({

--- a/packages/daemon/src/authority/production/production-progress-append-submission.ts
+++ b/packages/daemon/src/authority/production/production-progress-append-submission.ts
@@ -152,7 +152,7 @@ export function createProductionPlannedCommandSubmission(input: {
       throw new Error("AUTHORITY_PLANNED_SUBMISSION_REUSED");
     }
     if (actual.ingress !== "generic") {
-      throw new Error("AUTHORITY_PLANNED_INPUT_MISMATCH");
+      throw new Error("AUTHORITY_PLANNED_INGRESS_MISMATCH");
     }
     const canonicalEntityId = actual.canonicalEntityId;
     const actualPlanInput: ProductionAuthorityCommandPlanInput = {

--- a/packages/daemon/src/authority/production/production-progress-append-submission.ts
+++ b/packages/daemon/src/authority/production/production-progress-append-submission.ts
@@ -151,10 +151,9 @@ export function createProductionPlannedCommandSubmission(input: {
     if (submitted) {
       throw new Error("AUTHORITY_PLANNED_SUBMISSION_REUSED");
     }
-    if (actual.ingress !== "generic") {
-      throw new Error("AUTHORITY_PLANNED_INGRESS_MISMATCH");
-    }
-    const canonicalEntityId = actual.canonicalEntityId;
+    const canonicalEntityId = actual.ingress === "generic"
+      ? actual.canonicalEntityId
+      : actual.operation.entityId;
     const actualPlanInput: ProductionAuthorityCommandPlanInput = {
       command: actual.command,
       attribution: actual.attribution,

--- a/packages/daemon/test/authority-submission-error.test.ts
+++ b/packages/daemon/test/authority-submission-error.test.ts
@@ -166,7 +166,7 @@ test("cutover admission preserves V2 recovery admission", async () => {
   assert.equal(resumed, 1);
 });
 
-test("planned durable submission reports every specialized coordinator ingress as a channel mismatch", async (t) => {
+test("planned durable submission accepts every specialized coordinator ingress with exact planned content", async (t) => {
   const cases = [
     {
       ingress: "provenance-session",
@@ -200,23 +200,37 @@ test("planned durable submission reports every specialized coordinator ingress a
 
   for (const fixture of cases) {
     await t.test(fixture.ingress, async () => {
+      const attempt = authorityCommandAttemptFixture();
+      const currentSession = {
+        runtime: "codex" as const,
+        sessionId: "session-ingress",
+        source: "runtime" as const,
+        detectedAt: "2026-07-24T00:00:00.000Z"
+      };
+      const expected = {
+        command: fixture.command,
+        attribution: {},
+        currentSession,
+        ...(fixture.ingressAdapter ? { ingressAdapter: fixture.ingressAdapter } : {})
+      } as unknown as ProductionAuthorityCommandPlanInput;
       const submission = createProductionPlannedCommandSubmission({
         repoId: "canonical",
         authorityGeneration: 7,
-        authorityService: {} as AuthoritySubmissionService,
-        compiler: {} as ProductionCanonicalAttemptCompilerV2,
-        expected: {} as ProductionAuthorityCommandPlanInput,
-        plan: {} as ProductionAuthorityAttemptPlanV1
+        authorityService: {
+          submitV2: async () => committedAttemptReceipt(attempt)
+        } as AuthoritySubmissionService,
+        compiler: {
+          activatePlannedCommand: () => attempt.attempt
+        } as unknown as ProductionCanonicalAttemptCompilerV2,
+        expected,
+        plan: {
+          targetEntityId: fixture.operation.entityId
+        } as ProductionAuthorityAttemptPlanV1
       });
       const coordinator = makeDaemonAuthorityWriteCoordinator(submission, {
         command: fixture.command as never,
         attribution: {} as never,
-        currentSession: {
-          runtime: "codex",
-          sessionId: "session-ingress",
-          source: "runtime",
-          detectedAt: "2026-07-24T00:00:00.000Z"
-        },
+        currentSession,
         ...(fixture.ingressAdapter ? { ingressAdapter: fixture.ingressAdapter } : {})
       });
 
@@ -225,12 +239,63 @@ test("planned durable submission reports every specialized coordinator ingress a
         opId: `op-${fixture.ingress}`,
         ...fixture.operation
       } as never));
-      await assert.rejects(
-        runEffect(coordinator.flush("explicit")),
-        /AUTHORITY_PLANNED_INGRESS_MISMATCH/u
-      );
+      const report = await runEffect(coordinator.flush("explicit"));
+      assert.equal(report.committed, true);
+      assert.equal(report.watermark, attempt.expectedOpId);
     });
   }
+});
+
+test("planned durable submission still rejects specialized finalize content that differs from its plan", async () => {
+  const attempt = authorityCommandAttemptFixture();
+  const currentSession = {
+    runtime: "codex" as const,
+    sessionId: "session-ingress",
+    source: "runtime" as const,
+    detectedAt: "2026-07-24T00:00:00.000Z"
+  };
+  const plannedCommand = {
+    rootDir: "/fixture",
+    action: { kind: "task-claim", taskId: "task_PLANNED" }
+  };
+  const submission = createProductionPlannedCommandSubmission({
+    repoId: "canonical",
+    authorityGeneration: 7,
+    authorityService: {
+      submitV2: async () => committedAttemptReceipt(attempt)
+    } as AuthoritySubmissionService,
+    compiler: {
+      activatePlannedCommand: () => attempt.attempt
+    } as unknown as ProductionCanonicalAttemptCompilerV2,
+    expected: {
+      command: plannedCommand,
+      attribution: {},
+      currentSession,
+      ingressAdapter: "task-claim"
+    } as unknown as ProductionAuthorityCommandPlanInput,
+    plan: {
+      targetEntityId: "task/task_PLANNED"
+    } as ProductionAuthorityAttemptPlanV1
+  });
+  const coordinator = makeDaemonAuthorityWriteCoordinator(submission, {
+    command: {
+      ...plannedCommand,
+      action: { ...plannedCommand.action, taskId: "task_DIFFERENT" }
+    } as never,
+    attribution: {} as never,
+    currentSession,
+    ingressAdapter: "task-claim"
+  });
+
+  await runEffect(coordinator.enqueue({
+    opId: "op-task-claim-different",
+    entityId: "task/task_PLANNED",
+    kind: "doc_write"
+  }));
+  await assert.rejects(
+    runEffect(coordinator.flush("explicit")),
+    /AUTHORITY_PLANNED_INPUT_MISMATCH/u
+  );
 });
 
 test("multi-operation task creation stays on the direct child lane", () => {
@@ -502,6 +567,40 @@ function authorityCommandAttemptFixture() {
       envelope: encodeSemanticMutationEnvelopeV2(envelope)
     },
     expectedOpId: operationIdDiagnosticV2(envelope.operationId)
+  };
+}
+
+function committedAttemptReceipt(
+  fixture: ReturnType<typeof authorityCommandAttemptFixture>
+) {
+  const semanticDigest =
+    Buffer.from(semanticRequestDigestV2(fixture.envelope)).toString("hex");
+  return {
+    tag: "COMMITTED" as const,
+    workspaceId: fixture.envelope.workspaceId,
+    opId: fixture.expectedOpId,
+    semanticDigest,
+    revision: 1,
+    commitSha: "a".repeat(40),
+    previousCommit: null,
+    authorityIntegrity: {
+      schema: "authority-operation-integrity/v2" as const,
+      semanticRequestDigest: semanticDigest,
+      semanticMutationSetDigest: "b".repeat(64),
+      mutationRegistryVersion: 1,
+      actorAxesBindingDigest: "c".repeat(64),
+      canonicalMutationSet: {
+        registryVersion: 1,
+        mutations: []
+      }
+    },
+    integrityTuple: {
+      schema: "authority-integrity-tuple/v2" as const,
+      canonicalEventDigest: "d".repeat(64),
+      changeSetDigest: "e".repeat(64),
+      semanticMutationSetDigest: "b".repeat(64),
+      actorAxesBindingDigest: "c".repeat(64)
+    }
   };
 }
 

--- a/packages/daemon/test/authority-submission-error.test.ts
+++ b/packages/daemon/test/authority-submission-error.test.ts
@@ -166,28 +166,71 @@ test("cutover admission preserves V2 recovery admission", async () => {
   assert.equal(resumed, 1);
 });
 
-test("planned durable submission exposes one forwarding method and rejects specialized ingress", async () => {
-  const submission = createProductionPlannedCommandSubmission({
-    repoId: "canonical",
-    authorityGeneration: 7,
-    authorityService: {} as AuthoritySubmissionService,
-    compiler: {} as ProductionCanonicalAttemptCompilerV2,
-    expected: {} as ProductionAuthorityCommandPlanInput,
-    plan: {} as ProductionAuthorityAttemptPlanV1
-  });
-
-  assert.deepEqual(Object.keys(submission), ["submit"]);
-  await assert.rejects(submission.submit({
-    ingress: "task-claim",
-    command: {} as never,
-    attribution: {} as never,
-    currentSession: {} as never,
-    operation: {
-      opId: "op-specialized",
-      entityId: "task/task_SPECIALIZED",
-      kind: "doc_write"
+test("planned durable submission reports every specialized coordinator ingress as a channel mismatch", async (t) => {
+  const cases = [
+    {
+      ingress: "provenance-session",
+      command: { rootDir: "/fixture", action: { kind: "session-export", sessionId: "session-ingress" } },
+      operation: { entityId: "entity/session/session-ingress", kind: "doc_write" }
+    },
+    {
+      ingress: "decision-transition",
+      ingressAdapter: "decision-transition",
+      command: { rootDir: "/fixture", action: { kind: "decision-transition" } },
+      operation: { entityId: "decision/dec_INGRESS", kind: "doc_write" }
+    },
+    {
+      ingress: "task-claim",
+      ingressAdapter: "task-claim",
+      command: { rootDir: "/fixture", action: { kind: "task-claim" } },
+      operation: { entityId: "task/task_INGRESS", kind: "doc_write" }
+    },
+    {
+      ingress: "observed-write",
+      ingressAdapter: "observed-write",
+      command: { rootDir: "/fixture", action: { kind: "task-amend" } },
+      operation: { entityId: "task/task_INGRESS", kind: "doc_write" }
+    },
+    {
+      ingress: "script-ingest",
+      command: { rootDir: "/fixture", action: { kind: "script-run" } },
+      operation: { entityId: "task/task_INGRESS", kind: "script_ingest" }
     }
-  }), /AUTHORITY_PLANNED_INPUT_MISMATCH/u);
+  ] as const;
+
+  for (const fixture of cases) {
+    await t.test(fixture.ingress, async () => {
+      const submission = createProductionPlannedCommandSubmission({
+        repoId: "canonical",
+        authorityGeneration: 7,
+        authorityService: {} as AuthoritySubmissionService,
+        compiler: {} as ProductionCanonicalAttemptCompilerV2,
+        expected: {} as ProductionAuthorityCommandPlanInput,
+        plan: {} as ProductionAuthorityAttemptPlanV1
+      });
+      const coordinator = makeDaemonAuthorityWriteCoordinator(submission, {
+        command: fixture.command as never,
+        attribution: {} as never,
+        currentSession: {
+          runtime: "codex",
+          sessionId: "session-ingress",
+          source: "runtime",
+          detectedAt: "2026-07-24T00:00:00.000Z"
+        },
+        ...(fixture.ingressAdapter ? { ingressAdapter: fixture.ingressAdapter } : {})
+      });
+
+      assert.deepEqual(Object.keys(submission), ["submit"]);
+      await runEffect(coordinator.enqueue({
+        opId: `op-${fixture.ingress}`,
+        ...fixture.operation
+      } as never));
+      await assert.rejects(
+        runEffect(coordinator.flush("explicit")),
+        /AUTHORITY_PLANNED_INGRESS_MISMATCH/u
+      );
+    });
+  }
 });
 
 test("multi-operation task creation stays on the direct child lane", () => {


### PR DESCRIPTION
# English

## Summary

`session export` failed through the production canonical ingress with
`AUTHORITY_PLANNED_INPUT_MISMATCH`. The plan-time and finalize-time inputs were in fact
**identical** — `stableStringify` matched byte for byte and both sides agreed on the entity ID.
The rejection came from an earlier guard that required the finalize envelope's ingress
discriminator to be `generic`, while the coordinator legitimately dispatches specialized ingress
based on the operation.

The equality guard is untouched. Only the channel gate is removed, because the channel was never
part of the submission's identity.

## What Changed

- `production-progress-append-submission.ts`: removed the blanket `actual.ingress !== "generic"`
  rejection and derived `canonicalEntityId` from `actual.operation.entityId` for specialized
  ingress. Entity identity and full content equality are still enforced exactly as before.
- This also resolves an ambiguity that actively misled diagnosis: `AUTHORITY_PLANNED_INPUT_MISMATCH`
  was thrown from two distinct sites for two unrelated causes (channel vs content). With the channel
  site gone, the name now denotes exactly one cause.

## Task And Scope

- Harness task: `task_01KYCB1QQAJ6GQKPNYFG5DMA67`
- Branch: `fix/session-export-plan-input`
- Public scope: `packages/daemon/src/authority/production/**`, `packages/daemon/test/**`
- Private planning/evidence updated: yes
- Out of scope: the lease receipt defect and the `canonical-ingress.test.ts:201` snapshot failure,
  both recorded below and routed to separate tasks

## Version Impact

- Version: no version change because this is a behavioural fix inside the daemon authority path
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `dec_01KYCF5V2FRM90QV68BC45JMJX` (planned finalize accepts specialized ingress).
  The scope expansion from one command to the dispatch family was reported by the worker at the
  task contract's Checkpoint and adjudicated by the CEO before implementation.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it
  is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `132aa88748f9b4f917f01c0a529d1aa3017fa12e`
- Branch merge-base with `origin/main`: `132aa88748f9b4f917f01c0a529d1aa3017fa12e`
- Last `git fetch origin` time: 2026-07-25, immediately before opening this PR
- Sync method: rebase
- Public diff command: `git diff 132aa88748f9b4f917f01c0a529d1aa3017fa12e..HEAD`
- Private evidence commit/path: `harness/tasks/task_01KYCB1QQAJ6GQKPNYFG5DMA67-*/artifacts/`
- Reviewer evidence path: `harness/tasks/task_01KYCB1QQAJ6GQKPNYFG5DMA67-*/closeout.md`
- GitHub Actions `rewrite-ci` run URL: pending, added after the run starts
- [x] `git diff --check`
- [x] `npm run check:stop-point` (the gate set is derived from `tools/gate-manifest.json`; do not
      enumerate gates by hand) — 34 gates green; fast 533/533; contract 224 pass / 1 skip
- [x] Targeted tests for the change surface, named with their counts: 18/18 targeted;
      generic-input control 1/1. All five specialized ingress are executed for real
      (`provenance-session`, `decision-transition`, `task-claim`, `observed-write`,
      `script-ingest`), each asserting `report.committed === true` and a matching watermark.
      **Guard control**: "planned durable submission still rejects specialized finalize content
      that differs from its plan" — without this, "fixed the guard" and "blinded the guard" would
      be indistinguishable.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: the production canonical-ingress nightly is still red, at a **different**
  location than the one this PR fixes — `canonical-ingress.test.ts:201`, a missing
  `service-initial-task-leases` snapshot. This is out of this task's contract and is routed to a
  separate task; see Residual Risk. It is not claimed to be unrelated to the change surface, only
  that it is a distinct failure that this change first made reachable.

## Review Evidence

- Self-review: CEO read the three-line production hunk and both test controls. The swap protection
  the guard exists for is preserved: substituting a different entity fails the entity comparison,
  and substituting different content fails the `stableStringify` comparison. Only the channel, which
  was never part of identity, stopped being checked.
- Reviewer subagent: implementing worker, whose negative control falsified the CEO's original
  premise — the task plan told it to "diff which field differs", and it correctly reported that no
  field differs at all.
- Human review: CEO semantic acceptance, 2026-07-25.
- Blocking findings: none.

## Residual Risk

- **`canonical-ingress.test.ts:201`** fails on a missing `service-initial-task-leases` snapshot.
  This is the third instance in this chain of one defect masking the next (C1 masked session export,
  session export masked this). Routed to a separate task; deliberately not investigated here rather
  than expanding scope mid-task.
- **Lease receipt defect, now classified.** During closeout the CEO reproduced by hand the
  `write_rejected / current holder none / lease status none` symptom that this worker could not
  reproduce, and captured the paired disk state: the task was already `in_review` with
  `closeoutReadiness: ready`. **The write succeeded and the receipt reported rejection.** The
  worker's earlier "undeterminable" classification was correct given its evidence; this sample
  resolves it. Evidence:
  `harness/tasks/task_01KYCB1QQAJ6GQKPNYFG5DMA67-*/artifacts/lease-failure-h2-confirmed.md`.
  Separate task.

## References

- Task: `harness/tasks/task_01KYCB1QQAJ6GQKPNYFG5DMA67-*/task_plan.md`
- Evidence: `harness/tasks/task_01KYCB1QQAJ6GQKPNYFG5DMA67-*/artifacts/`
- Review: `harness/tasks/task_01KYCB1QQAJ6GQKPNYFG5DMA67-*/closeout.md`

---

# 中文

## 概要

`session export` 经生产 canonical ingress 提交时以 `AUTHORITY_PLANNED_INPUT_MISMATCH` 失败。
实际上 plan 期与 finalize 期的输入**完全相同**——`stableStringify` 逐字节一致，
两侧实体 ID 也相同。真正的拒绝来自更早的一道守卫：它要求 finalize envelope 的 ingress
判别式必须是 `generic`，而 coordinator 本来就会按 operation 合法地分派 specialized ingress。

等值守卫一行未动。**只去掉了通道门**，因为通道从来就不是这次提交的身份的一部分。

## 改动内容

- `production-progress-append-submission.ts`：去掉 `actual.ingress !== "generic"` 的一刀切拒绝，
  specialized ingress 的 `canonicalEntityId` 改由 `actual.operation.entityId` 取得。
  实体身份与完整内容等值检查与此前完全一致。
- 顺带消除了一处**实际误导过诊断**的歧义：`AUTHORITY_PLANNED_INPUT_MISMATCH` 原本由两个
  互不相关的原因（通道 vs 内容）从两处抛出。通道那处去掉后，这个名字只对应一个原因。

## 任务与范围

- Harness 任务：`task_01KYCB1QQAJ6GQKPNYFG5DMA67`
- 分支：`fix/session-export-plan-input`
- 公开范围：`packages/daemon/src/authority/production/**`、`packages/daemon/test/**`
- 私有规划/证据已更新：是
- 不在范围内：lease 回执缺陷，以及 `canonical-ingress.test.ts:201` snapshot 失败，
  两条均记录在下方并另立任务

## 版本影响

- 版本：无变更，这是 daemon authority 写路内部的行为修复
- 发布影响：不发布

## 治理声明

- 触及 protected surface：否
- Protected surface 范围：不适用
- 权威依据：`dec_01KYCF5V2FRM90QV68BC45JMJX`（planned finalize 接受 specialized ingress）。
  从「修一条命令」扩到「一族分派」的范围变更，由 worker 在任务契约的 Checkpoint 处上报，
  CEO 裁决后才开始实现。
- 机器检查边界：本 PR 只断言声明存在；声明是否为真、是否充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`132aa88748f9b4f917f01c0a529d1aa3017fa12e`
- 分支与 `origin/main` 的 merge-base：`132aa88748f9b4f917f01c0a529d1aa3017fa12e`
- 最近一次 `git fetch origin` 时间：2026-07-25，开 PR 前
- 同步方式：rebase
- 公开 diff 命令：`git diff 132aa88748f9b4f917f01c0a529d1aa3017fa12e..HEAD`
- 私有证据 commit/路径：`harness/tasks/task_01KYCB1QQAJ6GQKPNYFG5DMA67-*/artifacts/`
- 评审证据路径：`harness/tasks/task_01KYCB1QQAJ6GQKPNYFG5DMA67-*/closeout.md`
- GitHub Actions `rewrite-ci` run URL：待补，run 起来后回填
- [x] `git diff --check`
- [x] `npm run check:stop-point`（门集从 `tools/gate-manifest.json` 派生，不手工枚举）——
      34 道门全绿；fast 533/533；contract 224 通过 / 1 跳过
- [x] 变更面定向测试及计数：定向 18/18；generic input 对照 1/1。
      五类 specialized ingress **真实执行**（`provenance-session`、`decision-transition`、
      `task-claim`、`observed-write`、`script-ingest`），每类都断言
      `report.committed === true` 且 watermark 匹配。
      **守卫对照**：「planned durable submission still rejects specialized finalize content
      that differs from its plan」——缺这条，「修好了守卫」与「把守卫弄瞎了」不可区分。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）
- 未跑及原因：生产 canonical-ingress nightly 仍红，但红在**另一个位置**，不是本 PR 修的那处——
  `canonical-ingress.test.ts:201`，`service-initial-task-leases` snapshot 缺失。
  该条超出本任务契约，已另立任务，见残余风险。**不声称它与本改动无关**，
  只声称它是一条被本改动首次变得可达的、不同的失败。

## 审查证据

- 自审：CEO 读了那三行生产 hunk 与两条测试对照。守卫存在的意义——防掉包——完整保留：
  换实体过不了实体比较，换内容过不了 `stableStringify` 比较；
  只有从来不属于身份的通道不再被检查。
- 评审 subagent：实现 worker。它的阴性对照**证伪了 CEO 的原始前提**——
  任务 plan 让它「先 diff 出哪个字段不等」，它如实报告：根本没有字段不等。
- 人工评审：CEO 语义验收，2026-07-25。
- 阻塞性发现：无。

## 残余风险

- **`canonical-ingress.test.ts:201`** 因 `service-initial-task-leases` snapshot 缺失而红。
  这是本链条上第三次「上一个缺陷把下一个挡住」（C1 挡住 session export，
  session export 挡住它）。已另立任务；**有意不在本任务内追**，避免中途扩大范围。
- **lease 回执缺陷，已定性。** 收口过程中 CEO 手工复现了本 worker 未能复现的
  `write_rejected / current holder none / lease status none`，并抓到了配对的磁盘状态：
  任务当时**已经是** `in_review`、`closeoutReadiness: ready`。
  **写入成功了，回执报了拒绝。** worker 此前基于其证据判「不可判定」是正确的；
  这份样本把它定死了。证据见
  `harness/tasks/task_01KYCB1QQAJ6GQKPNYFG5DMA67-*/artifacts/lease-failure-h2-confirmed.md`。
  另立任务。

## 关联材料

- 任务：`harness/tasks/task_01KYCB1QQAJ6GQKPNYFG5DMA67-*/task_plan.md`
- 证据：`harness/tasks/task_01KYCB1QQAJ6GQKPNYFG5DMA67-*/artifacts/`
- 评审：`harness/tasks/task_01KYCB1QQAJ6GQKPNYFG5DMA67-*/closeout.md`
