### PR TITLE
fix(cli): regenerate dependency declarations before the cli build

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,6 +20,7 @@
     "node": ">=24"
   },
   "scripts": {
+    "prebuild": "tsc -b",
     "build": "tsc -p tsconfig.build.json && node scripts/copy-assets.mjs",
     "postbuild": "node dist/cli/src/build/write-build-provenance.js",
     "prepack": "npm run build"


### PR DESCRIPTION
# English

## Summary

Fixes #1031: `npm -w @harness-anything/cli run build` fails with `TS2339` after a plain `git pull`, on source that is correct at that commit.

The cli build type-checks bare workspace imports (`@harness-anything/kernel`) through each package's `exports["."].types` condition, which points at the built `dist/index.d.ts` rather than at source. After a pull that changes a dependency's types, those declarations are stale, so `tsc -p tsconfig.build.json` compiles cli source against the previous commit's types. Only `tsc -b` regenerates them, and the build never ran it — the root `typecheck` script was the accidental prerequisite.

This adds `tsc -b` as a `prebuild` step, so the referenced projects' declarations are current before the emit pass.

## What Changed

- `packages/cli/package.json`: added `"prebuild": "tsc -b"` ahead of the existing `build`. `packages/cli/tsconfig.json` already declares the full reference graph (kernel, application, daemon, gui, adapters), so `tsc -b` rebuilds exactly the declarations the build consumes. It is incremental: an up-to-date graph costs ~0.3s.

## Task And Scope

- Harness task: `task_01KYCNPPZF3J4EE4A8QTB76B78`
- Branch: `fix/cli-build-stale-declarations`
- Public scope: one npm script in `packages/cli/package.json`.
- Private planning/evidence updated: yes (task package created in the ledger)
- Out of scope: the `exports` `types` condition itself (pointing types at source would be a larger, separate change), other workspaces' build scripts, and the deploy runbook wording.

## Version Impact

- Version: no version change — build ordering only, no source or public API change.
- Publish impact: no publish. One disclosed side effect: `tsc -b` emits cli declaration files into `packages/cli/dist`, which `files: ["dist"]` packs. This is not a new artifact class — the root `typecheck` script already emits exactly the same 293 declaration files into that directory in any checkout that has run it; the change is that a packed tarball now contains them deterministically instead of depending on whether `typecheck` happened to have run first. `smoke-cli-package` passes on this branch.

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `packages/cli/package.json`, which matches the manifest-derived `packages/*/package.json` protected surface. The change is confined to one added npm script; no dependency, `files`, `bin`, `exports`, or version field is touched.
- Authority: `task_01KYCNPPZF3J4EE4A8QTB76B78`, created from issue #1031 through the `github-issue-repair` preset.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none required.

## Verification

- Base `origin/main` SHA: `cff8b08554d32a23f949e30134138e1b8509e4cf`
- Branch merge-base with `origin/main`: `cff8b08554d32a23f949e30134138e1b8509e4cf`
- Last `git fetch origin` time: 2026-07-25T12:59:17Z
- Sync method: rebase onto `cff8b085`
- Public diff command: `git diff cff8b08554d32a23f949e30134138e1b8509e4cf..fix/cli-build-stale-declarations --`
- Private evidence commit/path: harness task package `task_01KYCNPPZF3J4EE4A8QTB76B78`
- Reviewer evidence path: this PR body
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions?query=branch%3Afix%2Fcli-build-stale-declarations
- [x] `git diff --check` — clean
- [x] `npm run check:stop-point` — passed, 34 complete manifest gates green in 32.8s; change-aware lint and fast/contract tests also ran (83 pass / 0 fail on the affected contract set).
- [x] Targeted tests for the change surface, named with their counts: `node tools/smoke-cli-package.mjs` — passed (packs the cli workspace and runs the packed binary), 1 gate / 0 failures.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending; this PR does not merge until it is green.
- Negative control (the reported bug, reproduced): added a field `staleProbe` to `TaskProjectionRow` in `packages/kernel/src/projection/types.ts` and consumed it from `packages/cli/src/commands/core/task-query-reports.ts` without regenerating declarations. On the unfixed script the build fails with exactly the reported shape: `error TS2339: Property 'staleProbe' does not exist on type 'TaskProjectionRow'`.
- Positive control: with `prebuild` in place and no other change, the same probe builds clean (17.0s cold, 7.0s warm). The probe was then reverted; `git status` shows only `packages/cli/package.json` modified.
- Not run, and why: the full `npm run check:ci` set was not run locally. The change surface is one npm script, the two controls above exercise the exact failure the issue reports, the packaging gate that could plausibly regress was run directly, and `rewrite-ci` is the authoritative full gate for this PR.

## Review Evidence

- Self-review: yes — confirmed `packages/cli/tsconfig.json` references cover every workspace whose declarations the build reads, and that `prebuild` runs before `build` under npm's lifecycle (and therefore also under `prepack`).
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none

## Residual Risk

- `tsc -b` writes `packages/cli/tsconfig.tsbuildinfo` and declaration output into `dist`; a corrupted `tsbuildinfo` would now surface at build time rather than at `typecheck` time. Deleting the file recovers.
- A cold graph adds ~17s to a fresh build; an up-to-date graph adds ~0.3s.
- This repairs the ordering for the cli build only. Any other workspace whose build reads a dependency's `dist/*.d.ts` has the same latent shape and is not addressed here.

## References

- Task: `task_01KYCNPPZF3J4EE4A8QTB76B78`
- Evidence: this PR body; issue #1031 for the original reproduction
- Review: pending

---

# 中文

## 概要

修 #1031：`git pull` 之后直接 `npm -w @harness-anything/cli run build` 会以 `TS2339` 失败，而该 commit 上的源码本身是对的。

cli build 对 `@harness-anything/kernel` 这类裸 specifier 的类型解析走各包 `exports["."].types` 条件，而该条件指向**已构建的** `dist/index.d.ts`、不是源码。一旦 pull 带来依赖包类型变更，这些声明就是陈旧的，`tsc -p tsconfig.build.json` 于是拿上一个 commit 的类型去编译 cli 源码。只有 `tsc -b` 会重新生成它们，而 build 从来不跑 `tsc -b`——根目录的 `typecheck` 一直在充当这个不成文的前置条件。

本 PR 把 `tsc -b` 加为 `prebuild`，让被引用项目的声明在 emit 之前保持最新。

## 改动内容

- `packages/cli/package.json`：在既有 `build` 之前加 `"prebuild": "tsc -b"`。`packages/cli/tsconfig.json` 已经声明了完整的 references 图（kernel、application、daemon、gui、adapters），因此 `tsc -b` 重建的正好是 build 要消费的那批声明。增量执行：图已最新时约 0.3s。

## 任务与范围

- Harness 任务：`task_01KYCNPPZF3J4EE4A8QTB76B78`
- 分支：`fix/cli-build-stale-declarations`
- 公开范围：`packages/cli/package.json` 里的一条 npm script。
- 私有计划/证据已更新：是（台账中已建任务包）
- 不在范围内：`exports` 的 `types` 条件本身（把类型指向源码是另一个更大的改动）、其他 workspace 的 build 脚本、部署 runbook 文案。

## 版本影响

- 版本：无变更——仅构建顺序，无源码或公开 API 变更。
- 发布影响：不发布。一个需要如实披露的副作用：`tsc -b` 会把 cli 的声明文件 emit 到 `packages/cli/dist`，而 `files: ["dist"]` 会把它们打进包。这不是新增的产物类别——根 `typecheck` 在任何跑过它的 checkout 里已经把同样这 293 个声明文件写进该目录；变化只是打包产物现在**确定性地**包含它们，而不再取决于是否先跑过 `typecheck`。本分支 `smoke-cli-package` 通过。

## 治理声明

- 触及受保护面：是
- 受保护面范围：`packages/cli/package.json`，命中 manifest 派生的 `packages/*/package.json` 受保护面。改动仅限新增一条 npm script，未触及依赖、`files`、`bin`、`exports` 或版本字段。
- 授权：`task_01KYCNPPZF3J4EE4A8QTB76B78`，由 issue #1031 经 `github-issue-repair` preset 建立。
- 机器检查边界：本 PR 只断言声明存在；声明是否为真、是否充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：无需。

## 验证

- 基线 `origin/main` SHA：`cff8b08554d32a23f949e30134138e1b8509e4cf`
- 分支与 `origin/main` 的 merge-base：`cff8b08554d32a23f949e30134138e1b8509e4cf`
- 最后一次 `git fetch origin` 时间：2026-07-25T12:59:17Z
- 同步方式：rebase 到 `cff8b085`
- 公开 diff 命令：`git diff cff8b08554d32a23f949e30134138e1b8509e4cf..fix/cli-build-stale-declarations --`
- 私有证据 commit/路径：台账任务包 `task_01KYCNPPZF3J4EE4A8QTB76B78`
- 评审证据路径：本 PR 正文
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions?query=branch%3Afix%2Fcli-build-stale-declarations
- [x] `git diff --check` —— 干净
- [x] `npm run check:stop-point` —— 通过，34 个完整 manifest 门全绿，32.8s；change-aware lint 与 fast/contract 测试同时跑过（受影响 contract 集 83 通过 / 0 失败）。
- [x] 针对改动面的定向测试及计数：`node tools/smoke-cli-package.mjs` —— 通过（打包 cli workspace 并运行打包后的二进制），1 门 / 0 失败。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）—— 待跑；未绿不合。
- 反向对照（复现所报缺陷）：在 `packages/kernel/src/projection/types.ts` 的 `TaskProjectionRow` 上加字段 `staleProbe`，并在 `packages/cli/src/commands/core/task-query-reports.ts` 消费它，不重新生成声明。未修复的脚本下 build 以完全相同的形状失败：`error TS2339: Property 'staleProbe' does not exist on type 'TaskProjectionRow'`。
- 正向对照：加上 `prebuild`、其他一律不动，同一探针可以编译通过（冷 17.0s，热 7.0s）。随后探针已回滚，`git status` 只显示 `packages/cli/package.json` 被修改。
- 未跑及原因：本地未跑完整 `npm run check:ci`。改动面是一条 npm script，上面两个对照恰好打的就是 issue 所报的失败，最可能被波及的打包门已单独跑过，`rewrite-ci` 是本 PR 的权威全量门。

## 审查证据

- 自评：已做——确认 `packages/cli/tsconfig.json` 的 references 覆盖了 build 读取声明的全部 workspace，且 `prebuild` 在 npm 生命周期中先于 `build` 执行（因而 `prepack` 路径同样受益）。
- 子代理评审：无
- 人工评审：待办
- 阻断性发现：无

## 残余风险

- `tsc -b` 会写 `packages/cli/tsconfig.tsbuildinfo` 与 dist 下的声明产物；若该 tsbuildinfo 损坏，报错时机会从 `typecheck` 前移到 build。删掉该文件即可恢复。
- 冷图会给一次全新构建增加约 17s；图已最新时约 0.3s。
- 本 PR 只修了 cli build 的顺序问题。任何同样从依赖包 `dist/*.d.ts` 读类型的 workspace 都有同型隐患，不在本次范围内。

## 关联材料

- 任务：`task_01KYCNPPZF3J4EE4A8QTB76B78`
- 证据：本 PR 正文；原始复现见 issue #1031
- 评审：待办
