### PR TITLE
fix(authority): classify committed skipped publications honestly

### DIFF
--- a/packages/cli/test/authority-publication-materialization.test.ts
+++ b/packages/cli/test/authority-publication-materialization.test.ts
@@ -1,0 +1,152 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Effect } from "effect";
+import {
+  makeHeldLockAttributedCoordinatorFactory,
+  type AuthorityLifecycleRuntime
+} from "@harness-anything/daemon";
+
+test("committed authority publication accepts an already-materialized skipped session", async () => {
+  const coordinator = authorityCoordinator(runtimeFixture(async (input) => ({
+    flush: await input.publish(),
+    materialization: {
+      branches: [{
+        branch: `sessions/${input.sessionId}`,
+        commitCount: 0,
+        status: "skipped"
+      }]
+    }
+  })), "session-already-materialized");
+  await enqueueAuthorityTestOperation(coordinator, "op-already-materialized");
+
+  const report = await runEffect(coordinator.flush("explicit"));
+
+  assert.equal(report.committed, true);
+  assert.equal(report.opCount, 1);
+});
+
+test("uncommitted authority publication remains uncommitted", async () => {
+  const coordinator = authorityCoordinator(runtimeFixture(async (input) => {
+    await input.publish();
+    return {
+      flush: { reason: "explicit", opCount: 1, committed: false },
+      materialization: {
+        branches: [{
+          branch: `sessions/${input.sessionId}`,
+          commitCount: 0,
+          status: "skipped"
+        }]
+      }
+    };
+  }), "session-uncommitted");
+  await enqueueAuthorityTestOperation(coordinator, "op-uncommitted");
+
+  const report = await runEffect(coordinator.flush("explicit"));
+
+  assert.equal(report.committed, false);
+  assert.equal(report.opCount, 1);
+});
+
+test("committed publication without materialization proof remains indeterminate", async (context) => {
+  const cases = [
+    {
+      name: "missing result",
+      materialization: undefined
+    },
+    {
+      name: "conflicted result",
+      materialization: {
+        branches: [{
+          branch: "sessions/session-unproven",
+          commitCount: 1,
+          status: "conflict" as const
+        }]
+      }
+    }
+  ];
+  for (const fixture of cases) {
+    await context.test(fixture.name, async () => {
+      const coordinator = authorityCoordinator(runtimeFixture(async (input) => ({
+        flush: await input.publish(),
+        ...(fixture.materialization
+          ? { materialization: fixture.materialization }
+          : {})
+      })), "session-unproven");
+      await enqueueAuthorityTestOperation(coordinator, `op-${fixture.name.replaceAll(" ", "-")}`);
+
+      const outcome = await runEffect(Effect.either(coordinator.flush("explicit")));
+
+      assert.equal(outcome._tag, "Left");
+      if (outcome._tag === "Right") return;
+      assert.equal(outcome.left._tag, "JournalUnavailable");
+      assert.match(JSON.stringify(outcome.left.cause), /AUTHORITY_SESSION_MATERIALIZATION_FAILED/u);
+    });
+  }
+});
+
+type AuthorityPublication = Parameters<AuthorityLifecycleRuntime["enqueueAuthorityPublication"]>[0];
+type AuthorityPublicationReport = Awaited<ReturnType<AuthorityLifecycleRuntime["enqueueAuthorityPublication"]>>;
+
+function runtimeFixture(
+  publish: (input: AuthorityPublication) => Promise<AuthorityPublicationReport>
+): AuthorityLifecycleRuntime {
+  let pending = 0;
+  return {
+    createAttributedCoordinator: () => ({
+      enqueue: (op) => Effect.sync(() => {
+        pending += 1;
+        return { opId: op.opId, entityId: op.entityId, accepted: true as const };
+      }),
+      flush: (reason) => Effect.sync(() => ({
+        reason,
+        opCount: pending,
+        committed: true
+      })),
+      recover: Effect.succeed({ replayedOps: 0 })
+    }),
+    enqueueMaterializerBatch: async () => ({ branches: [] }),
+    enqueueAuthorityPublication: publish,
+    assertWriteFenceHeld: async () => undefined
+  };
+}
+
+function authorityCoordinator(runtime: AuthorityLifecycleRuntime, sessionId: string) {
+  return makeHeldLockAttributedCoordinatorFactory(runtime).create({
+    attribution: {
+      actor: {
+        principal: { kind: "person", personId: "person_test" },
+        executor: null
+      },
+      principalSource: {
+        kind: "daemon-authenticated",
+        providerId: "test",
+        credentialFingerprint: "sha256:test"
+      },
+      executorSource: "none"
+    },
+    sessionId
+  });
+}
+
+function enqueueAuthorityTestOperation(
+  coordinator: ReturnType<typeof authorityCoordinator>,
+  opId: string
+) {
+  return runEffect(coordinator.enqueue({
+    opId,
+    entityId: "task/task_test",
+    actor: { kind: "human", id: "person_test" },
+    payload: { type: "status-set", status: "active" }
+  }));
+}
+
+function runEffect<A, E>(effect: Effect.Effect<A, E>): Promise<A> {
+  return new Promise((resolve, reject) => {
+    Effect.runCallback(effect, {
+      onExit: (exit) => exit._tag === "Success"
+        ? resolve(exit.value)
+        : reject(new Error(String(exit.cause)))
+    });
+  });
+}

--- a/packages/daemon/src/authority/authority-lifecycle.ts
+++ b/packages/daemon/src/authority/authority-lifecycle.ts
@@ -390,7 +390,10 @@ export function makeHeldLockAttributedCoordinatorFactory(
               const { flush: report, materialization: materialized } = publication;
               if (!report.committed || report.opCount === 0) return report;
               const branch = materialized?.branches.find((entry) => entry.branch === `sessions/${sessionId}`);
-              if (!branch || branch.commitCount === 0 || branch.status !== "merged") {
+              const materializationProvesPublication = branch
+                && ((branch.status === "merged" && branch.commitCount > 0)
+                  || (branch.status === "skipped" && branch.commitCount === 0));
+              if (!materializationProvesPublication) {
                 throw new Error(
                   `AUTHORITY_SESSION_MATERIALIZATION_FAILED:sessionId=${sessionId};status=${branch?.status ?? "missing"};commitCount=${branch?.commitCount ?? 0};warning=${branch?.warning ?? "none"}`
                 );


### PR DESCRIPTION
# English

## Summary

Write receipts on the task lifecycle path reported rejection or uncertainty for writes that had
already committed. Nine instances were captured on 2026-07-25, three of them deterministic
reproductions of the same step. The operator-visible consequence is worse than a cosmetic wrong
message: seeing `write_rejected`, an operator retries or reroutes — while the real state has
already moved on.

Root cause is a single chain. An already-committed flush whose session materialization returned
`skipped / commitCount 0` was converted into `JournalUnavailable`. Terminal committed evidence
could then not be formed, which triggered a recovery replay, and the receipt ended up describing
the post-replay world instead of the original successful write.

## What Changed

- `packages/daemon/src/authority/authority-lifecycle.ts`: materialization now proves publication
  for exactly two `(status, commitCount)` pairs — `merged` with a positive count (unchanged), or
  `skipped` with zero (new). Everything else still throws.
- The pre-existing `if (!report.committed || report.opCount === 0) return report;` guard is
  untouched and still runs first, so the new allowance can only apply to a flush that already
  committed with operations.
- New `packages/cli/test/authority-publication-materialization.test.ts` (tier `integration`).

This narrows a false-uncertain classification. It does not widen what counts as success.

## Task And Scope

- Harness task: `task_01KYCQHP8H75TPQ8J0F1H5WWXZ`
- Branch: `fix/write-receipt-terminal-state-honesty`
- Public scope: `packages/daemon/src/authority/authority-lifecycle.ts`, `packages/cli/test/**`
- Private planning/evidence updated: yes
- Out of scope: the missing-Session-snapshot defect (`task_01KYCQQ2MQ0ED5M40N8VA7ZVKY`), lease
  validation itself, and the canonical-ingress fixtures — all owned elsewhere

## Version Impact

- Version: no version change because this is a behavioural fix inside the daemon authority path
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `dec_01KYC6RAWG57W4JHPA78NJ9SRM` — an instrument that cannot distinguish two states is
  a defect, not a tolerance. Classifying "committed, nothing further to materialize" as "outcome
  unknown" is precisely that defect, so this is a defect fix executing an existing decision rather
  than new policy. The red/green control requirement follows
  `dec_01KYCA4Q2MZNHX4N8T3K06JG02#CH1` judgment 3: this sits on the accountability chain, so an
  input that should report not-committed must be shown to report not-committed.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it
  is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `7db7e5671b590e051f6ee16172e29e9c21f0f1e1`
- Branch merge-base with `origin/main`: `7db7e5671b590e051f6ee16172e29e9c21f0f1e1`
- Last `git fetch origin` time: 2026-07-25, immediately before opening this PR
- Sync method: none needed
- Public diff command: `git diff 7db7e5671b590e051f6ee16172e29e9c21f0f1e1..HEAD`
- Private evidence commit/path: `harness/tasks/task_01KYCQHP8H75TPQ8J0F1H5WWXZ-*/`
- Reviewer evidence path: `harness/tasks/task_01KYCQHP8H75TPQ8J0F1H5WWXZ-*/closeout.md`
- GitHub Actions `rewrite-ci` run URL: pending, added after the run starts
- [x] `git diff --check`
- [x] `npm run check:stop-point` (the gate set is derived from `tools/gate-manifest.json`; do not
      enumerate gates by hand)
- [x] Targeted tests for the change surface, named with their counts: TDD red first — 14 tests,
      13 pass, 1 fail emitting the exact
      `AUTHORITY_SESSION_MATERIALIZATION_FAILED:status=skipped;commitCount=0`; green after the fix
      at 18/18. Four controls, the last two of which are the reverse controls that make this
      claim falsifiable:
      committed + `skipped/0` succeeds; **`committed=false` + `skipped/0` stays uncommitted**;
      **missing materialization stays `JournalUnavailable`**; **`conflict` stays
      `JournalUnavailable`** (the latter two as parameterized subtests).
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- **Not run, and why — end-to-end verification is NOT claimed.** `wave2-parity.ts:150` was the
  original reported symptom, but `canonical-ingress.test.ts` is blocked before reaching it by a
  separate, independently diagnosed defect: `submitForReview` never commits the Session manifest or
  a `session.export` operation, so submit correctly rejects on the missing snapshot
  (`task_01KYCQQ2MQ0ED5M40N8VA7ZVKY`, latent since `a87b094f`, not a regression). That file is
  `harness-test-tier: nightly` and is not a PR-required context. The evidence here is seam-level
  red/green plus the four controls — **it is not end-to-end evidence**, and this is deliberately
  not described as "unrelated to the change surface", because no control supports that claim.

## Review Evidence

- Self-review: CEO read the five-line production hunk and confirmed the allowance is an allowlist
  of two exact pairs rather than a relaxation — `conflict`, a missing branch, `merged` with zero
  commits, and `skipped` with a positive count all still throw. Also confirmed the four claimed
  controls actually exist in the test file after the worker's report cited a different filename
  than the diff contained.
- Reviewer subagent: implementing worker. It stopped at the task contract's architecture checkpoint
  rather than changing the publication contract unilaterally, and explicitly refused to patch at
  the CLI receipt layer on the grounds that doing so would destroy both reverse controls.
- Human review: CEO semantic acceptance, 2026-07-25.
- Blocking findings: none.

## Residual Risk

- **End-to-end verification is outstanding**, per the Verification section. Once
  `task_01KYCQQ2MQ0ED5M40N8VA7ZVKY` lands, the nightly can reach `wave2-parity.ts:150` and this
  fix should be re-verified there.
- Recovery replay still exists for legitimate paths (transport timeout after outer PROCEEDING,
  writer restart within a generation, cross-generation historical PROCEEDING). Those bind the
  original outer digest, inner operation, and semantic digest, reuse an existing terminal receipt,
  and stay `unknown` when a canonical publication is missing, non-unique, or digest-mismatched.
  A static audit found no remaining path where a legitimate recovery returns the wrong world;
  the recovery integration tests were not re-run this round because of the nightly blocker above.

## References

- Task: `harness/tasks/task_01KYCQHP8H75TPQ8J0F1H5WWXZ-*/task_plan.md`
- Evidence: `harness/tasks/task_01KYCB1QQAJ6GQKPNYFG5DMA67-*/artifacts/lease-failure-h2-confirmed.md`
- Review: `harness/tasks/task_01KYCQHP8H75TPQ8J0F1H5WWXZ-*/closeout.md`

---

# 中文

## 概要

任务生命周期写路上的回执，对**已经提交成功**的写入报了拒绝或不确定。2026-07-25 一天取到
9 个实例，其中 3 个是同一步骤上的确定性复现。真实伤害比"报错文案不准"严重得多：
操作者看到 `write_rejected` 会重试或改道，**而真实状态早已推进**——重试是在一个已经变了的
世界上操作。

根因是一条链：已提交的 flush，其 session materialization 返回
`skipped / commitCount 0` 时被转成 `JournalUnavailable`；随后拿不到 terminal committed
evidence，触发恢复重放；**回执最终描述的是重放后的世界，不是首次成功的结果。**

## 改动内容

- `packages/daemon/src/authority/authority-lifecycle.ts`：materialization 现在只对**两个精确的**
  `(status, commitCount)` 组合视为已证明发布——`merged` 且计数为正（不变），
  或 `skipped` 且计数为零（新增）。其余一律照旧抛出。
- 原有的 `if (!report.committed || report.opCount === 0) return report;` 守卫**一行未动**
  且仍然先执行，因此新增的放行**只可能作用于已提交且有操作的 flush**。
- 新增 `packages/cli/test/authority-publication-materialization.test.ts`（tier `integration`）。

**这是收窄一条"假不确定"的分类，不是放宽"什么算成功"。**

## 任务与范围

- Harness 任务：`task_01KYCQHP8H75TPQ8J0F1H5WWXZ`
- 分支：`fix/write-receipt-terminal-state-honesty`
- 公开范围：`packages/daemon/src/authority/authority-lifecycle.ts`、`packages/cli/test/**`
- 私有规划/证据已更新：是
- 不在范围内：Session snapshot 未提交缺陷（`task_01KYCQQ2MQ0ED5M40N8VA7ZVKY`）、
  lease 校验本身、canonical-ingress fixture——均归属他处

## 版本影响

- 版本：无变更，这是 daemon authority 写路内部的行为修复
- 发布影响：不发布

## 治理声明

- 触及 protected surface：否
- Protected surface 范围：不适用
- 权威依据：`dec_01KYC6RAWG57W4JHPA78NJ9SRM`——「分不出两种状态的仪器是缺陷，不是容差」。
  把「已提交、且无新增 materialization 可做」判成「结果未知」，正是该决策点名的缺陷，
  因此这是**执行既有决策的缺陷修复，不是新立政策**。红/绿对照的要求来自
  `dec_01KYCA4Q2MZNHX4N8T3K06JG02#CH1` 判据 3：本改动落在问责链路上，
  因此必须构造一个应当报"未提交"的输入并证明它确实报"未提交"。
- 机器检查边界：本 PR 只断言声明存在；声明是否为真、是否充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`7db7e5671b590e051f6ee16172e29e9c21f0f1e1`
- 分支与 `origin/main` 的 merge-base：`7db7e5671b590e051f6ee16172e29e9c21f0f1e1`
- 最近一次 `git fetch origin` 时间：2026-07-25，开 PR 前
- 同步方式：无需同步
- 公开 diff 命令：`git diff 7db7e5671b590e051f6ee16172e29e9c21f0f1e1..HEAD`
- 私有证据 commit/路径：`harness/tasks/task_01KYCQHP8H75TPQ8J0F1H5WWXZ-*/`
- 评审证据路径：`harness/tasks/task_01KYCQHP8H75TPQ8J0F1H5WWXZ-*/closeout.md`
- GitHub Actions `rewrite-ci` run URL：待补，run 起来后回填
- [x] `git diff --check`
- [x] `npm run check:stop-point`（门集从 `tools/gate-manifest.json` 派生，不手工枚举）
- [x] 变更面定向测试及计数：**先红后绿**——红：14 tests、13 通过、1 失败，
      失败输出正是那条 `AUTHORITY_SESSION_MATERIALIZATION_FAILED:status=skipped;commitCount=0`；
      修复后绿：18/18。四条对照，**后两条是让这个主张可证伪的反向对照**：
      committed + `skipped/0` 成功；**`committed=false` + `skipped/0` 仍为未提交**；
      **materialization 缺失仍报 `JournalUnavailable`**；
      **`conflict` 仍报 `JournalUnavailable`**（后两条以参数化子测试覆盖）。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）
- **未跑及原因——本 PR 不声称端到端验证。** `wave2-parity.ts:150` 是最初上报的症状点，
  但 `canonical-ingress.test.ts` 在到达它之前，被另一条**独立定性**的缺陷挡住：
  `submitForReview` 从未提交 Session manifest 或 `session.export` operation，
  于是 submit 因 snapshot 缺失而拒绝——拒绝本身是对的
  （`task_01KYCQQ2MQ0ED5M40N8VA7ZVKY`，自 `a87b094f` 起潜伏，不是回归）。
  该文件是 `harness-test-tier: nightly`，**不在 PR required context 内**。
  本 PR 的证据是 seam 层红/绿加四条对照，**不是端到端证据**；
  且**有意不写成「与本改动无关」**——没有任何对照能支撑那句话。

## 审查证据

- 自审：CEO 通读那五行生产 hunk，确认放行是**两个精确组合的白名单**而非放宽——
  `conflict`、branch 缺失、`merged` 且计数为零、`skipped` 且计数为正，全部仍然抛出。
  另外核实了 worker 声称的四条对照**确实存在**于测试文件中（它的报告写的文件名与 diff 不符，
  故逐条核过）。
- 评审 subagent：实现 worker。它在任务契约的架构 checkpoint 处停手，没有擅自改发布契约；
  并且**主动拒绝**了在 CLI 回执层打补丁的捷径，理由是那会毁掉两条反向对照。
- 人工评审：CEO 语义验收，2026-07-25。
- 阻塞性发现：无。

## 残余风险

- **端到端验证尚未完成**，见验证节。待 `task_01KYCQQ2MQ0ED5M40N8VA7ZVKY` 合入后，
  nightly 才能跑到 `wave2-parity.ts:150`，届时应在那里复验本修复。
- 恢复重放机制在合法场景下仍然存在（outer PROCEEDING 后 transport 超时、
  writer 重启后恢复同 generation、跨 generation 历史 PROCEEDING）。这些路径绑定原 outer
  digest、inner operation 与 semantic digest，已有 terminal receipt 直接复用；
  publication 缺失、不唯一或 digest 不同则继续保持 unknown。
  静态审计未发现仍会让合法 recovery 返回错误世界的路径；
  recovery 相关 integration 测试因上述 nightly blocker 本轮未重跑。

## 关联材料

- 任务：`harness/tasks/task_01KYCQHP8H75TPQ8J0F1H5WWXZ-*/task_plan.md`
- 证据：`harness/tasks/task_01KYCB1QQAJ6GQKPNYFG5DMA67-*/artifacts/lease-failure-h2-confirmed.md`
- 评审：`harness/tasks/task_01KYCQHP8H75TPQ8J0F1H5WWXZ-*/closeout.md`
