### PR TITLE
fix: finalize session before execution submit

### DIFF
--- a/packages/daemon/src/authority/production/production-authority-pure-command-plan.ts
+++ b/packages/daemon/src/authority/production/production-authority-pure-command-plan.ts
@@ -51,8 +51,9 @@ export function productionAuthorityCommandHasPurePlan(
   command: ProductionAuthorityCommand
 ): boolean {
   return directTypedCommandEntityId(command) !== undefined
-    // Task creation may first publish a provenance-session operation. A single
-    // fixed durable plan cannot represent both canonical operations, so keep
-    // the whole command on the direct child lane.
-    && command.action.kind !== "new-task";
+    // Task creation and execution submit may first publish a provenance-session
+    // operation. A single fixed durable plan cannot represent both canonical
+    // operations, so keep the whole command on the direct child lane.
+    && command.action.kind !== "new-task"
+    && !(command.action.kind === "status-set" && Boolean(command.action.executionSubmission));
 }

--- a/packages/daemon/test/authority-submission-error.test.ts
+++ b/packages/daemon/test/authority-submission-error.test.ts
@@ -310,6 +310,39 @@ test("multi-operation task creation stays on the direct child lane", () => {
   }), false);
 });
 
+test("multi-operation execution submit stays on the direct child lane", () => {
+  assert.equal(productionAuthorityCommandHasPurePlan({
+    rootDir: "/repo",
+    action: {
+      kind: "status-set",
+      taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG6",
+      status: "in_review",
+      force: false,
+      executionSubmission: {
+        executionId: "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG5",
+        completionClaim: "ready",
+        deliverables: [],
+        verificationNotes: [],
+        knownGaps: [],
+        residualRisks: [],
+        outputs: []
+      }
+    }
+  }), false);
+});
+
+test("ordinary status transition stays on the durable child lane", () => {
+  assert.equal(productionAuthorityCommandHasPurePlan({
+    rootDir: "/repo",
+    action: {
+      kind: "status-set",
+      taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG6",
+      status: "active",
+      force: false
+    }
+  }), true);
+});
+
 test("one submission method carries every governed ingress discriminator", async () => {
   const fixture = authorityCommandAttemptFixture();
   const compiled: string[] = [];


### PR DESCRIPTION
# English

## Summary

A production execution submit publishes two canonical operations: it first finalizes and
exports its provenance Session, then submits the Execution. But the command was routed to
the durable child lane, where a single fixed durable plan is built up front — so
`planCommand()` read the Session manifest *before* `submitForReview()` had run
`finalizeSession()`, and rejected the submit because the snapshot was not yet there.

The observable symptom was a Session snapshot that never appeared: the transcript CAS body
was written as an untracked file, `harness/sessions/<id>.md` never existed, `git log --all`
showed no commit for it, and the authority records contained no `session.export` operation
at all. The rejection itself was correct — the compiler was right to refuse a missing
snapshot. What was wrong is that the write upstream never got the chance to happen.

This is the same invariant the code already documented for task creation, applied to the
case that was missed. The existing comment reads: task creation may first publish a
provenance-session operation, and a single fixed durable plan cannot represent both
canonical operations, so the whole command stays on the direct child lane. Execution submit
has exactly that property.

## What Changed

- `productionAuthorityCommandHasPurePlan` now also keeps a `status-set` command that carries
  an `executionSubmission` on the direct child lane, so `session.export` commits before the
  execution is submitted.
- Added the matching lane test, plus a reverse control asserting that a plain `status-set`
  with a valid ULID and **no** `executionSubmission` still takes the durable lane.

The guard is deliberately narrow — `status-set` **and** carrying `executionSubmission`. It
does not move the whole `status-set` command class.

## Task And Scope

- Harness task: `task_01KYCQQ2MQ0ED5M40N8VA7ZVKY`
- Branch: `fix/canonical-ingress-lease-snapshot`
- Public scope: the pure-command-plan lane predicate and its daemon tests.
- Private planning/evidence updated: yes
- Out of scope: two further defects on the same nightly are deliberately untouched and
  tracked separately — an intermittent lease failure at `wave2-parity.ts:150`
  (`task_01KYCXHCCV2TSK21GV024X2P0S`) and a `code-doc-anchors.json already exists` failure at
  `canonical-ingress.test.ts:251` (`task_01KYCZ1HX5ZR942PD7QDX2TVHB`). No fixture was
  modified and no retry was added to work around either.

## Version Impact

- Version: no version change because this is an internal routing fix with no packaged
  surface change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task `task_01KYCQQ2MQ0ED5M40N8VA7ZVKY`; CEO adjudication recorded at
  `harness/tasks/task_01KYCQQ2MQ0ED5M40N8VA7ZVKY-canonical-ingress-nightly-canonical-ingress-test-ts-201-service-initial/artifacts/ceo-adjudication-150-vs-201.md`.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide
  whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none required by this change.

## Verification

- Base `origin/main` SHA: `d4806ad80141a62f43d5585f63dc26d50320a697`
- Branch merge-base with `origin/main`: `d4806ad80141a62f43d5585f63dc26d50320a697`
- Last `git fetch origin` time: 2026-07-25, immediately before the rebase below.
- Sync method: rebase
- Public diff command: `git diff d4806ad8..HEAD`
- Private evidence commit/path:
  `harness/tasks/task_01KYCQQ2MQ0ED5M40N8VA7ZVKY-canonical-ingress-nightly-canonical-ingress-test-ts-201-service-initial/artifacts/`
  (`checkpoint-stop-session-finalization.md` for the root cause,
  `post-fix-checkpoint-new-downstream-red.md` for the post-fix state)
- Reviewer evidence path: same directory.
- GitHub Actions `rewrite-ci` run URL: pending on this PR.
- [x] `git diff --check`
- [x] `npm run check:stop-point` — re-run after the rebase onto `d4806ad8`; 34 complete
  manifest gates green.
- [x] Targeted tests for the change surface, named with their counts:
  - lane-routing red/green: 18 pass / 1 fail before the change, 19 pass / 0 fail / 0 skipped
    after; focused suite 20/20 after the reverse control was added.
  - fail-closed controls: 13 pass / 0 fail / 0 skipped — a genuinely missing or
    undecidable Session still reports `snapshot is not finalized`, and a failed provenance
    finalization still aborts the submit without mutating authored state or releasing the
    lease.
  - nightly: `canonical-ingress.test.ts:201` now passes. The run does not reach green
    overall — see below.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending.
- Not run, and why: the production canonical-ingress nightly is **not** green end to end. It
  now stops later, at `canonical-ingress.test.ts:251`, on a separate defect that is tracked
  under its own task and deliberately not fixed here. The evidence for this PR is therefore
  "201 passes", not "the nightly passes" — those are different claims and only the first is
  supported. The 22 broader or environment-only gates that `check:local` defers to CI were
  not run locally; they run on this PR.

## Review Evidence

- Self-review: CEO reviewed the diff directly. The fix extends an invariant the code already
  stated for `new-task` rather than introducing a new mechanism, and the guard is scoped to
  `status-set` carrying `executionSubmission`.
- Reviewer subagent: not used for this change.
- Human review: pending.
- Blocking findings: one, now resolved. The first round pinned only the positive case, so
  broadening the guard to the entire `status-set` class would have kept every test green —
  "fixed the ordering" and "moved a whole command class" were indistinguishable. A reverse
  control asserting the durable lane for a plain `status-set` was added.

## Residual Risk

- The nightly remains red at `canonical-ingress.test.ts:251`, so this production write path
  still has no green end-to-end gate. It is not in `check:local` (which excludes the
  integration tier) and is not a required PR context.
- An intermittent lease failure at `wave2-parity.ts:150` was hit 4 times during this work
  (3 before the change, 1 after) and is unaffected by this fix — neither repaired nor masked.

## References

- Task: `task_01KYCQQ2MQ0ED5M40N8VA7ZVKY`
- Evidence: `.../artifacts/checkpoint-stop-session-finalization.md`
- Review: `.../artifacts/ceo-adjudication-150-vs-201.md`

---

# 中文

## 概要

一次生产 execution submit 会发布**两个** canonical operation：先 finalize 并导出它的
provenance Session，再提交 Execution。但该命令被路由到了 durable child lane——
那条 lane 会预先构建一个固定的 durable plan，于是 `planCommand()` 在
`submitForReview()` 执行 `finalizeSession()` **之前**就去读 Session manifest，
并因快照尚不存在而拒绝提交。

表现出来的症状是一个**永远不出现**的 Session 快照：transcript CAS body 已作为
untracked 文件落盘，`harness/sessions/<id>.md` 从不存在，`git log --all` 对它零 commit，
authority 记录里**根本没有** `session.export` 操作。
**拒绝本身是对的**——编译器拒绝一个缺失的快照没有错；错的是上游那次写从来没机会发生。

这与代码里**早已为 task creation 写明的不变量是同一条**，只是漏掉了这个场景。
原注释写的是：task creation 可能先发布一个 provenance-session operation，
而单个固定 durable plan 表达不了两个 canonical operation，所以整条命令留在 direct child lane。
execution submit 具有完全相同的性质。

## 改动内容

- `productionAuthorityCommandHasPurePlan` 现在也把**携带 `executionSubmission` 的
  `status-set`** 留在 direct child lane，使 `session.export` 先于 execution 提交。
- 补上对应的 lane 测试，以及一条**反向对照**：合法 ULID、**不带** `executionSubmission`
  的普通 `status-set` **仍然**走 durable lane。

守卫是**刻意窄**的——必须同时满足 `status-set` **且**携带 `executionSubmission`，
不会把整个 `status-set` 命令类挪走。

## 任务与范围

- Harness 任务：`task_01KYCQQ2MQ0ED5M40N8VA7ZVKY`
- 分支：`fix/canonical-ingress-lease-snapshot`
- 公开范围：pure-command-plan 的 lane 判据及其 daemon 测试。
- 私有计划 / 证据是否已更新：yes
- 范围外：同一 nightly 上另外两个缺陷**有意未动**，各自单独立案——
  `wave2-parity.ts:150` 的间歇性 lease 失败（`task_01KYCXHCCV2TSK21GV024X2P0S`）
  与 `canonical-ingress.test.ts:251` 的 `code-doc-anchors.json already exists`
  （`task_01KYCZ1HX5ZR942PD7QDX2TVHB`）。
  **未修改任何 fixture，也未为绕过它们添加重试。**

## 版本影响

- 版本：不改版本，原因是这是内部路由修复，不改变任何打包面。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：任务 `task_01KYCQQ2MQ0ED5M40N8VA7ZVKY`；CEO 裁决记录于
  `harness/tasks/task_01KYCQQ2MQ0ED5M40N8VA7ZVKY-canonical-ingress-nightly-canonical-ingress-test-ts-201-service-initial/artifacts/ceo-adjudication-150-vs-201.md`。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：本改动不需要。

## 验证

- `origin/main` 基准 SHA：`d4806ad80141a62f43d5585f63dc26d50320a697`
- 当前分支与 `origin/main` 的 merge-base：`d4806ad80141a62f43d5585f63dc26d50320a697`
- 最近一次 `git fetch origin` 时间：2026-07-25，就在下面这次 rebase 之前。
- 同步方式：rebase
- 公开 diff 命令：`git diff d4806ad8..HEAD`
- 私有证据 commit/path：
  `harness/tasks/task_01KYCQQ2MQ0ED5M40N8VA7ZVKY-canonical-ingress-nightly-canonical-ingress-test-ts-201-service-initial/artifacts/`
  （根因见 `checkpoint-stop-session-finalization.md`，修后状态见
  `post-fix-checkpoint-new-downstream-red.md`）
- Reviewer 证据路径：同一目录。
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑。
- [x] `git diff --check`
- [x] `npm run check:stop-point`——已在 rebase 到 `d4806ad8` **之后重跑**；
  34 个 complete manifest gate 全绿。
- [x] 改动面的定向测试，写明测试名与通过数：
  - lane 路由红/绿：改前 18 pass / 1 fail，改后 19 pass / 0 fail / 0 skipped；
    补上反向对照后 focused suite 20/20。
  - fail-closed 对照：13 pass / 0 fail / 0 skipped——真正缺失或不可判定的 Session
    仍报 `snapshot is not finalized`；provenance finalization 失败仍会中止 submit，
    不修改 authored state、不释放 Lease。
  - nightly：`canonical-ingress.test.ts:201` 现已通过。整轮**并未全绿**，见下。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）——待跑。
- 未跑项及原因：生产 canonical-ingress nightly **端到端并未绿**。
  它现在停得更靠后，落在 `canonical-ingress.test.ts:251` 的另一条缺陷上，
  该缺陷已单独立案且**有意不在本 PR 修**。
  因此本 PR 的证据是「**201 通过**」，不是「**该 nightly 通过**」——
  这是两个不同的断言，只有前者被支持。
  另外 `check:local` 交给 CI 的那 22 个更广或仅环境相关的门本地未跑，它们会在本 PR 上跑。

## 审查证据

- 自查：CEO 直接复核 diff。该修复是把代码**早已为 `new-task` 写明**的不变量
  应用到漏掉的场景，不是引入新机制；守卫范围限定在携带 `executionSubmission` 的 `status-set`。
- Reviewer subagent：本次未使用。
- 人工审查：待进行。
- 阻塞发现：一条，已解决。第一轮只钉住了阳性case，于是**把守卫放宽成整个
  `status-set` 命令类也不会让任何测试变红**——「修好了顺序」与「顺手把整类命令挪了 lane」
  不可区分。已补上断言普通 `status-set` 仍走 durable lane 的反向对照。

## 残余风险

- 该 nightly 仍在 `canonical-ingress.test.ts:251` 红，因此这条生产写路**仍然没有
  端到端的绿门**。它不在 `check:local`（不含 integration tier），也不是 PR 必需门。
- `wave2-parity.ts:150` 的间歇性 lease 失败在本轮工作中撞到 4 次
  （改前 3 次、改后 1 次），与本修复无关——**既未修复也未掩盖**。

## 关联材料

- 任务：`task_01KYCQQ2MQ0ED5M40N8VA7ZVKY`
- 证据：`.../artifacts/checkpoint-stop-session-finalization.md`
- 审查：`.../artifacts/ceo-adjudication-150-vs-201.md`
