### PR TITLE
fix: preserve code-doc recovery replay

### DIFF
--- a/packages/application/src/authority/daemon-host-contract.ts
+++ b/packages/application/src/authority/daemon-host-contract.ts
@@ -205,6 +205,8 @@ export interface DaemonHostCommandExecutionOptions {
   readonly requireProvidedActorAttribution: true;
   /** Child-writer pilot admission must not renew/write a v1 holder lease. */
   readonly taskLeaseGuardMode?: "read-only";
+  /** The child is resuming an already-durable outer proceeding with its fixed operation. */
+  readonly outerProceedingRecovery?: true;
   readonly actorAttribution?: AuthorityHostAttribution;
   readonly currentSession?: CurrentSessionRef;
   readonly inlineCreateProvenanceOnly?: true;

--- a/packages/cli/src/cli/runner-registry.ts
+++ b/packages/cli/src/cli/runner-registry.ts
@@ -40,6 +40,7 @@ export interface CommandRunnerContext {
   readonly decisionWriteService: DecisionWriteService;
   readonly factWriteService: FactWriteService;
   readonly taskHolderService: TaskHolderService;
+  readonly outerProceedingRecovery: boolean;
   readonly runLedgerMaterializer: (options: { readonly dryRun?: boolean }) => MaterializerCommandReport;
 }
 
@@ -124,7 +125,8 @@ export function runRegisteredCommand(
   makeFactWriteService: () => FactWriteService,
   makeTaskHolderService: () => TaskHolderService,
   makeRuntimeEventLedgerService: () => RuntimeEventLedgerService,
-  runLedgerMaterializer: (rootInput: HarnessLayoutInput, options: { readonly dryRun?: boolean }) => MaterializerCommandReport
+  runLedgerMaterializer: (rootInput: HarnessLayoutInput, options: { readonly dryRun?: boolean }) => MaterializerCommandReport,
+  execution: { readonly outerProceedingRecovery: boolean } = { outerProceedingRecovery: false }
 ): CommandRunnerEffect {
   const runner = runnerRegistry[command.action.kind];
   const layoutInput = createHarnessRuntimeContext(command.rootDir, command.layoutOverrides);
@@ -188,6 +190,7 @@ export function runRegisteredCommand(
       taskHolderService ??= makeTaskHolderService();
       return taskHolderService;
     },
+    outerProceedingRecovery: execution.outerProceedingRecovery,
     get runtimeEventLedgerService() {
       runtimeEventLedgerService ??= makeRuntimeEventLedgerService();
       return runtimeEventLedgerService;

--- a/packages/cli/src/commands/core/task-gates.ts
+++ b/packages/cli/src/commands/core/task-gates.ts
@@ -64,7 +64,7 @@ function runTaskCodeDocReconcile(
   return Effect.gen(function* () {
     const taskPackage = yield* context.artifactStore.readTaskPackage(action.taskId);
     const existing = taskPackage.documents.find((document) => document.path === CODE_DOC_RECONCILIATION_DOCUMENT);
-    if (existing && !action.force) {
+    if (existing && !action.force && !context.outerProceedingRecovery) {
       return {
         ok: false,
         command: action.kind,

--- a/packages/cli/src/composition/command-executor.ts
+++ b/packages/cli/src/composition/command-executor.ts
@@ -41,6 +41,8 @@ export interface ParsedCommandExecutionOptions {
   readonly requireProvidedActorAttribution?: boolean;
   /** Production child-writer pilot admission must be side-effect free. */
   readonly taskLeaseGuardMode?: "read-only";
+  /** Resume the fixed operation instead of treating its already-applied state as a new request. */
+  readonly outerProceedingRecovery?: true;
   readonly currentSession?: CurrentSessionRef;
   /** Typed authority intents already carry the current-session provenance inline. */
   readonly inlineCreateProvenanceOnly?: boolean;
@@ -236,7 +238,9 @@ export async function runRegisteredCommandWithCliComposition(
       provenanceSessionExporter: makeSessionExporter(),
       syncExportedSession
     })
-  }), enforceTaskLease(), makeTaskHolder, getTaskHolderPrincipal, options.taskLeaseGuardMode), makeTaskHolder, getRuntimeEventLedgerService, provider.runLedgerMaterializer).pipe(
+  }), enforceTaskLease(), makeTaskHolder, getTaskHolderPrincipal, options.taskLeaseGuardMode), makeTaskHolder, getRuntimeEventLedgerService, provider.runLedgerMaterializer, {
+    outerProceedingRecovery: options.outerProceedingRecovery === true
+  }).pipe(
     Effect.match({
       onFailure: (error): CliResult => ({
         ok: false,

--- a/packages/cli/test/completion-facade-cli.test.ts
+++ b/packages/cli/test/completion-facade-cli.test.ts
@@ -52,6 +52,12 @@ test("task submit facade sends the exact six-field packet through execution subm
     assert.equal(submitted.report.steps[1].details.data.executionId, claimed.executionId);
     assert.equal(submitted.report.steps[1].details.data.status, "in_review");
     assert.equal(existsSync(path.join(rootDir, created.packagePath, "code-doc-anchors.json")), true);
+    const duplicateCodeDoc = runJson(rootDir, [
+      "task", "code-doc", "reconcile", created.taskId,
+      "--commit", evidenceSha, "--path", "evidence/facade.txt"
+    ], false, env);
+    assert.equal(duplicateCodeDoc.error.code, "code_doc_reconciliation_failed");
+    assert.match(duplicateCodeDoc.error.hint, /code-doc-anchors\.json already exists/u);
     const execution = JSON.parse(readFileSync(path.join(rootDir, created.packagePath, "executions", `${claimed.executionId}.md`), "utf8"));
     assert.deepEqual(execution.submission, {
       completion_claim: "The structured facade preserves execution submission semantics.",

--- a/packages/daemon/src/runtime/production-progress-append-operation.ts
+++ b/packages/daemon/src/runtime/production-progress-append-operation.ts
@@ -337,6 +337,7 @@ export class ProductionRepoWriteOperationHost<
       this.options.hostServices,
       {
         taskLeaseGuardMode: "read-only",
+        ...(recovery ? { outerProceedingRecovery: true as const } : {}),
         resolveAuthoritySubmissionV2: () => capturingSubmission
       }
     );

--- a/packages/daemon/src/service/command-service.ts
+++ b/packages/daemon/src/service/command-service.ts
@@ -53,6 +53,7 @@ export interface DaemonCommandServiceOptions {
   readonly onCommandStart?: () => void;
   readonly onCommandSettled?: () => void;
   readonly taskLeaseGuardMode?: "read-only";
+  readonly outerProceedingRecovery?: true;
   readonly repoWriteDispatch?: {
     readonly repoId: string;
     readonly submit: (
@@ -176,6 +177,9 @@ export function createDaemonCommandService<
             requireProvidedActorAttribution: true,
             ...(options.taskLeaseGuardMode ? {
               taskLeaseGuardMode: options.taskLeaseGuardMode
+            } : {}),
+            ...(options.outerProceedingRecovery ? {
+              outerProceedingRecovery: true as const
             } : {}),
             ...(attribution ? { actorAttribution: attribution } : {}),
             ...(currentSession ? { currentSession } : {}),


### PR DESCRIPTION
# English

## Summary

A durable repo-write operation can be recovered and replayed while its outer proceeding has
not yet been finalized. When that happened to a code-doc operation whose write had already
committed, the replay was treated as a brand-new request and rejected with
`code-doc-anchors.json already exists`.

Nothing dispatched the facade twice. The duplicate was a **legitimate recovery replay of a
fixed operation**, and the write path was simply not idempotent under it.

`--force` was deliberately not used. That flag exists precisely so that "already exists" can
stay a refusal, and reaching for it here would have permanently legalised duplicate writes
and let a second call silently overwrite the first call's anchors.

## What Changed

- Threaded an `outerProceedingRecovery` execution option from the daemon's durable recovery
  path down to the code-doc reconcile gate, so a replay of an already-applied fixed
  operation resumes instead of being rejected as new.
- Added a positive control asserting that an ordinary second `task code-doc reconcile` —
  outside recovery — still fails with `code-doc-anchors.json already exists`.

The option is internal to command execution and is **not** a CLI flag, so a caller cannot
set it. It is only ever true on the daemon's own recovery path.

## Task And Scope

- Harness task: `task_01KYCZ1HX5ZR942PD7QDX2TVHB`
- Branch: `fix/code-doc-anchors-duplicate`
- Public scope: the recovery-context option across the application/daemon/CLI execution
  contract, the code-doc reconcile gate, and the facade test.
- Private planning/evidence updated: yes
- Out of scope: the next defect on the same nightly, a durable serialization failure at
  `$.receipt.details.data.report.prRef`, is tracked separately as
  `task_01KYD26JE5QPY2X29RSJB7JVVZ` and is not touched here. The intermittent lease failure
  at `wave2-parity.ts:150` is likewise untouched.

## Version Impact

- Version: no version change because this is an internal execution-path fix with no packaged
  surface change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task `task_01KYCZ1HX5ZR942PD7QDX2TVHB`.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide
  whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none required by this change.

## Verification

- Base `origin/main` SHA: `242ada349dff7fc0f78cc6469a1855cf708114b8`
- Branch merge-base with `origin/main`: `242ada349dff7fc0f78cc6469a1855cf708114b8`
- Last `git fetch origin` time: 2026-07-26, immediately before the worktree was branched.
- Sync method: none needed
- Public diff command: `git diff 242ada34..HEAD`
- Private evidence commit/path:
  `harness/tasks/task_01KYCZ1HX5ZR942PD7QDX2TVHB-canonical-ingress-nightly-code-doc-anchors-json-already-exists/artifacts/`
- Reviewer evidence path: same directory.
- GitHub Actions `rewrite-ci` run URL: pending on this PR.
- [x] `git diff --check`
- [x] `npm run check:stop-point` — 34 complete manifest gates green in 69.7s; affected fast
  551/551; affected contract 424 pass, 0 fail, 1 pre-existing win32 skip.
- [x] Targeted tests for the change surface, named with their counts:
  - durable recovery: 3 tests, 3 pass, 0 fail.
  - completion facade: 6 tests, 6 pass, 0 fail, including the new positive control that a
    genuinely duplicate request still reports `already exists`.
  - nightly before the change: the original duplicate error reproduces.
  - nightly after the change: that error is gone.
  - the intermittent `wave2-parity.ts:150` noise was hit 0 times across two rounds.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending.
- Not run, and why: the production canonical-ingress nightly is **not** green end to end. It
  now stops on the separate `prRef` durable-serialization defect. The evidence here is "the
  duplicate defect is gone", not "the nightly passes" — different claims, and only the first
  is supported. The 22 broader or environment-only gates that `check:local` defers to CI were
  not run locally; they run on this PR.

## Review Evidence

- Self-review: CEO reviewed the diff directly. Confirmed the relaxation is gated on a
  daemon-internal recovery signal rather than anything a caller supplies, and that the
  ordinary duplicate path is still refused.
- Reviewer subagent: not used for this change.
- Human review: pending.
- Blocking findings: none outstanding.

## Residual Risk

- During recovery the existence check is **skipped**, not satisfied by comparing content. A
  replayed fixed operation should produce identical content, but that equality is not
  asserted anywhere. If replayed content could ever differ, this would overwrite silently.
- The nightly remains red on the separate `prRef` defect, so this production write path still
  has no green end-to-end gate. It is not in `check:local` (which excludes the integration
  tier) and is not a required PR context.

## References

- Task: `task_01KYCZ1HX5ZR942PD7QDX2TVHB`
- Evidence: `.../artifacts/post-fix-checkpoint-new-downstream-red.md`
- Review: task closeout in the same package.

---

# 中文

## 概要

一个 durable repo-write operation 可能在其 outer proceeding **尚未终结**期间被恢复并重放。
当这件事发生在一个**写已经提交成功**的 code-doc operation 上时，
该重放被当成全新请求，于是报 `code-doc-anchors.json already exists`。

**没有任何地方把 facade 派发了两次。** 这个"重复"是一次**对固定 operation 的合法恢复重放**，
而当前写路径对这种重放不幂等。

**刻意没有使用 `--force`。** 那个 flag 的存在恰恰说明「已存在就拒绝」是设计行为；
在这里伸手去用它，等于把重复写永久合法化，并让第二次调用静默覆盖第一次的锚。

## 改动内容

- 把 `outerProceedingRecovery` 这个执行选项从 daemon 的 durable recovery 路径
  贯穿到 code-doc reconcile 门，使**已应用的固定 operation 的重放得以续跑**，
  而不是被当作新请求拒绝。
- 补上阳性对照：**recovery 之外**的普通第二次 `task code-doc reconcile`
  **仍然**以 `code-doc-anchors.json already exists` 失败。

该选项是命令执行的**内部选项，不是 CLI flag**，调用方无法设置；
它只在 daemon 自己的恢复路径上为真。

## 任务与范围

- Harness 任务：`task_01KYCZ1HX5ZR942PD7QDX2TVHB`
- 分支：`fix/code-doc-anchors-duplicate`
- 公开范围：贯穿 application/daemon/CLI 执行契约的 recovery context 选项、
  code-doc reconcile 门，以及 facade 测试。
- 私有计划 / 证据是否已更新：yes
- 范围外：同一 nightly 上的下一条缺陷——
  `$.receipt.details.data.report.prRef` 的 durable 序列化失败——
  已另立 `task_01KYD26JE5QPY2X29RSJB7JVVZ`，本 PR 不碰。
  `wave2-parity.ts:150` 的间歇性 lease 缺陷同样未动。

## 版本影响

- 版本：不改版本，原因是这是内部执行路径修复，不改变任何打包面。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：任务 `task_01KYCZ1HX5ZR942PD7QDX2TVHB`。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：本改动不需要。

## 验证

- `origin/main` 基准 SHA：`242ada349dff7fc0f78cc6469a1855cf708114b8`
- 当前分支与 `origin/main` 的 merge-base：`242ada349dff7fc0f78cc6469a1855cf708114b8`
- 最近一次 `git fetch origin` 时间：2026-07-26，就在建该 worktree 之前。
- 同步方式：不需要
- 公开 diff 命令：`git diff 242ada34..HEAD`
- 私有证据 commit/path：
  `harness/tasks/task_01KYCZ1HX5ZR942PD7QDX2TVHB-canonical-ingress-nightly-code-doc-anchors-json-already-exists/artifacts/`
- Reviewer 证据路径：同一目录。
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑。
- [x] `git diff --check`
- [x] `npm run check:stop-point`——34 个 complete manifest gate 全绿，用时 69.7 秒；
  受影响 fast 551/551；受影响 contract 424 通过、0 失败、1 个既有 win32 skip。
- [x] 改动面的定向测试，写明测试名与通过数：
  - durable recovery：3 tests，3 pass，0 fail。
  - completion facade：6 tests，6 pass，0 fail，**含新增阳性对照**——
    真正重复的请求仍报 `already exists`。
  - 改动前 nightly：原始 duplicate 错误可复现。
  - 改动后 nightly：该错误消失。
  - 两轮运行中 `wave2-parity.ts:150` 的间歇噪声命中 **0 次**。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）——待跑。
- 未跑项及原因：生产 canonical-ingress nightly **端到端并未绿**，
  它现在停在独立的 `prRef` durable 序列化缺陷上。
  本 PR 的证据是「**duplicate 缺陷消失**」，不是「**该 nightly 通过**」——
  这是两个不同的断言，只有前者被支持。
  另外 `check:local` 交给 CI 的那 22 个更广或仅环境相关的门本地未跑，它们会在本 PR 上跑。

## 审查证据

- 自查：CEO 直接复核 diff。确认放行是由 **daemon 内部的 recovery 信号**把关，
  而不是调用方能提供的任何东西；且普通的重复路径仍被拒绝。
- Reviewer subagent：本次未使用。
- 人工审查：待进行。
- 阻塞发现：无遗留。

## 残余风险

- recovery 期间是**跳过**存在性检查，而不是比对内容后放行。
  重放的固定 operation 理应产出一致内容，但**代码里没有任何地方断言这一致性**。
  若将来重放内容可能不同，这里会静默覆盖。
- 该 nightly 仍因独立的 `prRef` 缺陷而红，因此这条生产写路**仍然没有端到端的绿门**。
  它不在 `check:local`（不含 integration tier），也不是 PR 必需门。

## 关联材料

- 任务：`task_01KYCZ1HX5ZR942PD7QDX2TVHB`
- 证据：`.../artifacts/post-fix-checkpoint-new-downstream-red.md`
- 审查：同一任务包内的 closeout。
