### PR TITLE
fix: omit absent prRef from durable code-doc reports

### DIFF
--- a/packages/cli/src/commands/core/task-gates.ts
+++ b/packages/cli/src/commands/core/task-gates.ts
@@ -125,7 +125,7 @@ function runTaskCodeDocReconcile(
         recordIds: draft.recordIds,
         commit: action.sha,
         paths: action.paths,
-        prRef: action.prRef
+        ...(typeof action.prRef === "string" ? { prRef: action.prRef } : {})
       }
     } satisfies CliResult;
   });

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -254,6 +254,8 @@ test("production service route preserves progress dry-run and publishes canonica
       readonly report?: { readonly steps?: ReadonlyArray<{ readonly details?: { readonly data?: Record<string, unknown> } }> };
     } | undefined)?.report?.steps ?? [];
     assert.equal(facadeSteps.length, 2, JSON.stringify(transitioned.receipt));
+    const codeDocReport = facadeSteps[0]?.details?.data?.report as Record<string, unknown> | undefined;
+    assert.equal(Object.hasOwn(codeDocReport ?? {}, "prRef"), false, JSON.stringify(transitioned.receipt));
     assert.equal(authorityOperationRecords(fixture.serviceRoot).length, beforeFacadeSubmit + 2,
       "task submit must publish one code-doc operation and one execution-submit operation");
     const facadeSubmitOperation = latestAuthorityOperation(fixture.serviceRoot);


### PR DESCRIPTION
# English

## Summary

A **successful** code-doc reconcile receipt was rejected by durable serialization:

```text
Invalid durable repo-write JSON at $.receipt.details.data.report.prRef: expected plain object
```

`prRef` is optional. When `--pr` was not supplied, the report still carried the key with an
`undefined` value instead of omitting it, and the durable JSON walker rejects a node that is
neither a plain object nor a supported primitive.

So the defect fires when `--pr` is **omitted**, not when it is supplied — the opposite of the
intuitive reading. The nightly fixture that exposed it submits `codeDoc: { commit, paths }`
with no PR reference.

## What Changed

- `task-gates.ts` now spreads `prRef` conditionally in the durable code-doc report, matching
  the idiom already used in `parsers/task-submit.ts` and `parsers/task-lifecycle-facade.ts`.
- Added nightly assertions covering the reconciled report shape.

The durable validator was **not** touched. Relaxing it to accept `undefined` would blind
every durable JSON integrity check to "key present, no value".

Only the durable report site was changed. The `renderCodeDocReconciliationDraft` argument
keeps passing `action.prRef` directly, because that value never reaches durable JSON.

## Task And Scope

- Harness task: `task_01KYD26JE5QPY2X29RSJB7JVVZ`
- Branch: `fix/durable-receipt-prref`
- Public scope: the durable code-doc report construction and the nightly assertions.
- Private planning/evidence updated: yes
- Out of scope: the next failure on the same nightly, an execution-submit parity deep
  comparison at `canonical-ingress.test.ts:262`, is untouched and pending adjudication.

## Version Impact

- Version: no version change because this is an internal report-shape fix with no packaged
  surface change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task `task_01KYD26JE5QPY2X29RSJB7JVVZ`.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide
  whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none required by this change.

## Verification

- Base `origin/main` SHA: `fca2221dd3c6ac73896e73a774d5187e0e3ca145`
- Branch merge-base with `origin/main`: `fca2221dd3c6ac73896e73a774d5187e0e3ca145`
- Last `git fetch origin` time: 2026-07-26, immediately before the worktree was branched.
- Sync method: none needed
- Public diff command: `git diff fca2221d..HEAD`
- Private evidence commit/path:
  `harness/tasks/task_01KYD26JE5QPY2X29RSJB7JVVZ-durable-receipt-report-prref-canonical-ingress/artifacts/`
  (`pre-fix-prref-hypothesis.md`, `post-fix-verification.md`)
- Reviewer evidence path: same directory.
- GitHub Actions `rewrite-ci` run URL: pending on this PR.
- [x] `git diff --check`
- [x] `npm run check:stop-point` — 34 complete manifest gates green; affected fast 361/361;
  affected contract 83/83.
- [x] Targeted tests for the change surface, named with their counts:
  - nightly before the change: 2 tests, 1 pass, 1 fail, 0 skipped, reproducing the exact
    `$.receipt.details.data.report.prRef` rejection.
  - nightly after the change: that rejection and the new assertions are passed.
  - **positive control**: a report carrying `prRef: undefined` is still rejected by the
    durable reader, so the validator was not blinded.
  - **compatibility control**: previously persisted receipts in both shapes — `prRef`
    omitted, and `prRef` as a string — still read successfully.
  - **same-class sweep**: `prRef` is the only optional field in that report; no other field
    is written unconditionally as `undefined`.
  - the intermittent wave2 lease noise required 2 reruns.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending.
- Not run, and why: the production canonical-ingress nightly is **not** green end to end. It
  now stops at an execution-submit parity deep comparison, a further separate defect that is
  not fixed here. The evidence is "the prRef rejection is gone", not "the nightly passes".
  The 22 broader or environment-only gates that `check:local` defers to CI were not run
  locally; they run on this PR.

## Review Evidence

- Self-review: CEO reviewed the diff directly. The fix uses the idiom already present in the
  repo's parsers, changes only the site that reaches durable JSON, and leaves the validator
  untouched.
- Reviewer subagent: not used for this change.
- Human review: pending.
- Blocking findings: none outstanding.

## Residual Risk

- The nightly remains red on a further execution-submit parity defect, so this production
  write path still has no green end-to-end gate. It is not in `check:local` (which excludes
  the integration tier) and is not a required PR context.

## References

- Task: `task_01KYD26JE5QPY2X29RSJB7JVVZ`
- Evidence: `.../artifacts/pre-fix-prref-hypothesis.md`
- Review: `.../artifacts/post-fix-verification.md`

---

# 中文

## 概要

一个**成功**的 code-doc reconcile 回执被 durable 序列化判为非法：

```text
Invalid durable repo-write JSON at $.receipt.details.data.report.prRef: expected plain object
```

`prRef` 是可选字段。**未提供 `--pr` 时，report 仍然带着这个键、值为 `undefined`**，
而不是把键省略掉；durable JSON 遍历器遇到既不是 plain object、也不是受支持基本类型的节点就拒绝。

所以缺陷在**不传 `--pr`** 时触发，而不是传了才触发——与直觉正好相反。
暴露它的那条 nightly fixture 提交的正是 `codeDoc: { commit, paths }`，**不带 PR 引用**。

## 改动内容

- `task-gates.ts` 在构造 durable code-doc report 时改为**条件展开** `prRef`，
  与 `parsers/task-submit.ts`、`parsers/task-lifecycle-facade.ts` 里既有的写法一致。
- 补上覆盖该 report 形状的 nightly 断言。

**未改动 durable 校验器。** 放宽它去接受 `undefined`，会让所有 durable JSON
完整性检查对"键存在但没值"失明。

**只改了会进入 durable JSON 的那一处。** `renderCodeDocReconciliationDraft` 的实参
仍直接传 `action.prRef`，因为那个值不会到达 durable JSON。

## 任务与范围

- Harness 任务：`task_01KYD26JE5QPY2X29RSJB7JVVZ`
- 分支：`fix/durable-receipt-prref`
- 公开范围：durable code-doc report 的构造，以及 nightly 断言。
- 私有计划 / 证据是否已更新：yes
- 范围外：同一 nightly 上的下一个失败——`canonical-ingress.test.ts:262`
  的 execution-submit parity 深比较——**未动**，待裁决。

## 版本影响

- 版本：不改版本，原因是这是内部 report 形状修复，不改变任何打包面。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：任务 `task_01KYD26JE5QPY2X29RSJB7JVVZ`。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：本改动不需要。

## 验证

- `origin/main` 基准 SHA：`fca2221dd3c6ac73896e73a774d5187e0e3ca145`
- 当前分支与 `origin/main` 的 merge-base：`fca2221dd3c6ac73896e73a774d5187e0e3ca145`
- 最近一次 `git fetch origin` 时间：2026-07-26，就在建该 worktree 之前。
- 同步方式：不需要
- 公开 diff 命令：`git diff fca2221d..HEAD`
- 私有证据 commit/path：
  `harness/tasks/task_01KYD26JE5QPY2X29RSJB7JVVZ-durable-receipt-report-prref-canonical-ingress/artifacts/`
  （`pre-fix-prref-hypothesis.md`、`post-fix-verification.md`）
- Reviewer 证据路径：同一目录。
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑。
- [x] `git diff --check`
- [x] `npm run check:stop-point`——34 个 complete manifest gate 全绿；
  受影响 fast 361/361；受影响 contract 83/83。
- [x] 改动面的定向测试，写明测试名与通过数：
  - 改动前 nightly：2 tests，1 pass / 1 fail / 0 skipped，精确复现
    `$.receipt.details.data.report.prRef` 的拒绝。
  - 改动后 nightly：该拒绝与新增断言均已通过。
  - **阳性对照**：带 `prRef: undefined` 的 report **仍被 durable reader 拒绝**，
    证明校验没有被弄瞎。
  - **兼容对照**：已落盘的两种旧形状回执——省略 `prRef` 的、以及 `prRef` 为字符串的——
    均仍可正常读取。
  - **同类排查**：该 report 中 `prRef` 是唯一的可选字段，
    没有其它字段被无条件写成 `undefined`。
  - 间歇性 wave2 lease 噪声导致重跑 2 次。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）——待跑。
- 未跑项及原因：生产 canonical-ingress nightly **端到端并未绿**，
  它现在停在 execution-submit parity 的深比较处，那是又一条独立缺陷，本 PR 不修。
  本 PR 的证据是「**prRef 拒绝消失**」，不是「**该 nightly 通过**」。
  另外 `check:local` 交给 CI 的那 22 个门本地未跑，它们会在本 PR 上跑。

## 审查证据

- 自查：CEO 直接复核 diff。修复采用仓内 parser 已有的写法，
  只改会进入 durable JSON 的那一处，未动校验器。
- Reviewer subagent：本次未使用。
- 人工审查：待进行。
- 阻塞发现：无遗留。

## 残余风险

- 该 nightly 仍因 execution-submit parity 缺陷而红，因此这条生产写路**仍然没有端到端的绿门**。
  它不在 `check:local`（不含 integration tier），也不是 PR 必需门。

## 关联材料

- 任务：`task_01KYD26JE5QPY2X29RSJB7JVVZ`
- 证据：`.../artifacts/pre-fix-prref-hypothesis.md`
- 审查：`.../artifacts/post-fix-verification.md`
