### PR TITLE
feat(cli): ingest evidence artifacts through the existing governed route

### DIFF
--- a/packages/cli/src/cli/command-spec/command-spec-core.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-core.ts
@@ -9,6 +9,7 @@ import { runHelpCommand } from "../../commands/core/help.ts";
 import { runInitCommand } from "../../commands/core/init.ts";
 import { runNewTaskCommand } from "../../commands/core/new-task.ts";
 import { runTaskGatesCommand } from "../../commands/core/task-gates.ts";
+import { runDocCommand } from "../../commands/core/doc.ts";
 import { runTaskLifecycleCommand } from "../../commands/core/task-lifecycle.ts";
 import { runTaskQueryCommand } from "../../commands/core/task-query.ts";
 import { runTaskViewCommand } from "../../commands/core/task-views.ts";
@@ -307,6 +308,17 @@ export const coreCommandSpecs = defineCommandSpecs([
       "conflictMarkerPreflight": true,
       "runtimeEvent": "auto"
     }
+  },
+  {
+    "kind": "artifact-add",
+    "usage": "task artifact add <task-id> <path>... [--json]",
+    "options": [{"flag":"--json","description":"Emit command-receipt/v2 JSON."}],
+    "summary": "Copy untracked UTF-8 text evidence into a task package through doc sync so later evidence pointers stay resolvable.",
+    "examples": ["harness-anything task artifact add task_01ABC reports/check.txt"],
+    "parse": parseCoreTaskArgs,
+    "run": runDocCommand,
+    "receiptContract": { "data": ["taskId", "report"], "paths": ["primary"] },
+    "eventPolicy": { "conflictMarkerPreflight": true, "runtimeEvent": "auto" }
   },
   {
     "kind": "task-amend",

--- a/packages/cli/src/cli/command-spec/production-authority-ingress.ts
+++ b/packages/cli/src/cli/command-spec/production-authority-ingress.ts
@@ -60,6 +60,7 @@ const dispositions = {
   "module-register": typed("generic"),
 
   "init": excluded("repository bootstrap writes precede production authority attachment"),
+  "artifact-add": excluded("CLI facade submits artifact bytes through the dedicated repo.doc.sync.submit authority route"),
   "task-release": excluded("lease release mutates daemon-private holder state in the operational domain"),
   "task-start": excluded("CLI facade decomposes into separately admitted task-claim and status-set commands; a raw composite daemon action is rejected"),
   "task-submit": excluded("CLI facade decomposes into separately admitted task-code-doc-reconcile and status-set commands; a raw composite daemon action is rejected"),

--- a/packages/cli/src/cli/parsers/core-task-artifact.ts
+++ b/packages/cli/src/cli/parsers/core-task-artifact.ts
@@ -1,0 +1,15 @@
+import { CliErrorCode, cliError } from "../error-codes.ts";
+import type { CliResult, ParsedCommand } from "../types.ts";
+
+type ParseResult = { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] };
+
+export function parseArtifactAdd(args: ReadonlyArray<string>, rootDir: string, json: boolean): ParseResult {
+  const sourcePaths = args.slice(4).filter((value) => !value.startsWith("--"));
+  if (sourcePaths.length === 0) {
+    return { ok: false, error: cliError(CliErrorCode.ArtifactReadFailed, "Use task artifact add <task-id> <path>....") };
+  }
+  return {
+    ok: true,
+    value: { rootDir, json, action: { kind: "artifact-add", taskId: args[3]!, sourcePaths } }
+  };
+}

--- a/packages/cli/src/cli/parsers/core-task.ts
+++ b/packages/cli/src/cli/parsers/core-task.ts
@@ -3,6 +3,7 @@ import { cliError, CliErrorCode } from "../error-codes.ts";
 import { readOption, readRepeatedRawOption, readRequiredValueOption } from "../parse-options.ts";
 import type { CliResult, ParsedCommand } from "../types.ts";
 import { parseTaskArchive } from "./core-task-archive.ts";
+import { parseArtifactAdd } from "./core-task-artifact.ts";
 import { parseTaskCodeDocReconcile } from "./core-task-code-doc.ts";
 import { parseTaskContractMigrate } from "./core-task-contract.ts";
 import { parseExecutionSubmissionOptions, parseTaskClaim } from "./core-task-execution.ts";
@@ -34,6 +35,7 @@ export function parseCoreTaskArgs(args: ReadonlyArray<string>, rootDir: string, 
   if (args[0] === "task" && args[1] === "transition" && args[2] && args[3]) return parseStatusSet(["task", "status", "set", ...args.slice(2)], rootDir, json);
   if (args[0] === "task" && args[1] === "status" && args[2] === "set" && args[3] && args[4]) return parseStatusSet(args, rootDir, json);
   if (args[0] === "task" && args[1] === "progress" && args[2] === "append" && args[3]) return parseProgressAppend(args, rootDir, json);
+  if (args[0] === "task" && args[1] === "artifact" && args[2] === "add" && args[3]) return parseArtifactAdd(args, rootDir, json);
   if (args[0] === "task" && args[1] === "amend" && args[2]) return parseTaskAmend(args, rootDir, json);
   if (args[0] === "task" && args[1] === "contract" && args[2] === "migrate") return parseTaskContractMigrate(args, rootDir, json);
   if (args[0] === "task" && args[1] === "archive") return parseTaskArchive(args, rootDir, json);

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -276,6 +276,7 @@ export interface ParsedCommand {
     | { readonly kind: "cas-gc"; readonly mode: "dry-run" | "apply" }
     | { readonly kind: "doc-status" }
     | { readonly kind: "doc-sync"; readonly mode: "dry-run" | "submit"; readonly paths: ReadonlyArray<string> }
+    | { readonly kind: "artifact-add"; readonly taskId: string; readonly sourcePaths: ReadonlyArray<string> }
     | { readonly kind: "task-list"; readonly filters: TaskListFilters }
     | { readonly kind: "status" }
     | { readonly kind: "version" }

--- a/packages/cli/src/commands/core/authored-git.ts
+++ b/packages/cli/src/commands/core/authored-git.ts
@@ -44,16 +44,21 @@ export function gitTopLevel(inputPath: string): string | null {
 }
 
 export function resolveGitCommitSha(rootDir: string, ref: string): string {
+  return readAuthoredGitText(rootDir, ["rev-parse", "--verify", `${ref}^{commit}`]);
+}
+
+export function readAuthoredGitText(rootDir: string, args: ReadonlyArray<string>, trim = true): string {
   const environment = Object.fromEntries(
     Object.entries(process.env).filter(([key]) => !key.toUpperCase().startsWith("GIT_"))
   );
   environment.GIT_OPTIONAL_LOCKS = "0";
-  return execFileSync("git", ["-C", rootDir, "rev-parse", "--verify", `${ref}^{commit}`], {
+  const output = execFileSync("git", ["-C", rootDir, ...args], {
     encoding: "utf8",
     env: environment,
     stdio: ["ignore", "pipe", "pipe"],
     windowsHide: true
-  }).trim();
+  });
+  return trim ? output.trim() : output;
 }
 
 function normalizeExistingPath(inputPath: string): string {

--- a/packages/cli/src/commands/core/doc.ts
+++ b/packages/cli/src/commands/core/doc.ts
@@ -4,7 +4,7 @@ import type { CliResult } from "../../cli/types.ts";
 import type { CommandRunner } from "../../cli/runner-registry.ts";
 import { buildDocSyncStatusResult, buildDocSyncDryRunResult } from "./doc-sync.ts";
 
-type DocAction = Extract<Parameters<CommandRunner>[1]["action"], { readonly kind: "doc-status" | "doc-sync" }>;
+type DocAction = Extract<Parameters<CommandRunner>[1]["action"], { readonly kind: "doc-status" | "doc-sync" | "artifact-add" }>;
 
 export const runDocCommand: CommandRunner = (context, command) => Effect.sync(() => {
   const action = command.action as DocAction;

--- a/packages/cli/src/daemon/artifact-ingest.ts
+++ b/packages/cli/src/daemon/artifact-ingest.ts
@@ -391,9 +391,12 @@ function isHarnessInternal(absolutePath: string, rootDir: string): boolean {
 }
 
 function isGitTracked(absolutePath: string): boolean {
-  const top = gitOptional(path.dirname(absolutePath), ["rev-parse", "--show-toplevel"]);
-  if (!top || !isWithin(top, absolutePath)) return false;
-  return gitOptional(top, ["ls-files", "--error-unmatch", "--", portablePathRelative(top, absolutePath)]) !== null;
+  const discoveredTop = gitOptional(path.dirname(absolutePath), ["rev-parse", "--show-toplevel"]);
+  if (!discoveredTop) return false;
+  const top = safeRealpath(discoveredTop);
+  const relativePath = portableGitPathRelative(top, safeRealpath(absolutePath));
+  if (relativePath === null || relativePath === "") return false;
+  return gitOptional(top, ["ls-files", "--error-unmatch", "--", relativePath]) !== null;
 }
 
 function gitBlob(authoredRoot: string, portablePath: string): string | null {
@@ -421,11 +424,18 @@ function mediaTypeFor(filePath: string): string {
 }
 
 function portablePathRelative(from: string, to: string): string { return path.relative(safeRealpath(from), safeRealpath(to)).split(path.sep).join("/"); }
+export function portableGitPathRelative(repositoryRoot: string, candidatePath: string): string | null {
+  const pathApi = isWindowsPathShape(repositoryRoot) || isWindowsPathShape(candidatePath) ? path.win32 : path.posix;
+  const relative = pathApi.relative(pathApi.normalize(repositoryRoot), pathApi.normalize(candidatePath));
+  if (relative === ".." || relative.startsWith(`..${pathApi.sep}`) || pathApi.isAbsolute(relative)) return null;
+  return relative.split(pathApi.sep).join("/");
+}
 function isWithin(parent: string, child: string): boolean {
   const relative = path.relative(safeRealpath(parent), safeRealpath(child));
   return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
-function safeRealpath(value: string): string { try { return realpathSync(value); } catch { return path.resolve(value); } }
+function isWindowsPathShape(value: string): boolean { return /^[A-Za-z]:[\\/]/u.test(value) || value.startsWith("\\\\"); }
+function safeRealpath(value: string): string { try { return realpathSync.native(value); } catch { return path.resolve(value); } }
 function quoteShellArgument(value: string): string { return `'${value.replaceAll("'", `'"'"'`)}'`; }
 function artifactSkipWarnings(plan: ArtifactIngestPlan) {
   return plan.skippedEvidence.map((entry) => ({

--- a/packages/cli/src/daemon/artifact-ingest.ts
+++ b/packages/cli/src/daemon/artifact-ingest.ts
@@ -243,9 +243,31 @@ export function normalizeProgressAfterArtifact(
       }
     };
   }
-  const retryCommand = progressRetryCommand(plan);
   const paths = plan.targetPaths.join(", ");
   const originalError = receipt.error ?? cliError(CliErrorCode.ArtifactWriteRejected, "Progress append failed.");
+  if (originalError.code === "repo_write_outcome_unknown"
+    || originalError.code === CliErrorCode.DaemonRequestOutcomeUnknown) {
+    return {
+      ...receipt,
+      ...(warnings.length > 0 ? { warnings: [...(receipt.warnings ?? []), ...warnings] } : {}),
+      command: "progress-append",
+      action: "progress-append",
+      error: {
+        ...originalError,
+        hint: `Artifact ingestion succeeded at ${paths}. The progress append outcome is unknown; first check progress.md for the evidence pointer before deciding whether to rerun. Only rerun or record the pointer if it is absent. Cause: ${originalError.hint}`
+      },
+      details: {
+        ...(receipt.details ?? {}),
+        data: {
+          ...((receipt.details?.data ?? {}) as Record<string, unknown>),
+          artifactIngest: artifactData,
+          pointerRecorded: "unknown",
+          outcome: "unknown"
+        }
+      }
+    };
+  }
+  const retryCommand = progressRetryCommand(plan);
   return {
     ...receipt,
     ...(warnings.length > 0 ? { warnings: [...(receipt.warnings ?? []), ...warnings] } : {}),

--- a/packages/cli/src/daemon/artifact-ingest.ts
+++ b/packages/cli/src/daemon/artifact-ingest.ts
@@ -26,6 +26,7 @@ export interface ArtifactIngestPlan {
   readonly targetPaths: ReadonlyArray<string>;
   readonly submittedPaths: ReadonlyArray<string>;
   readonly reusedPaths: ReadonlyArray<string>;
+  readonly skippedEvidence: ReadonlyArray<{ readonly path: string; readonly reason: string }>;
   readonly facade: "artifact-add" | "progress-append";
   readonly progressCommand?: ParsedCommand;
   readonly originalProgressCommand?: ParsedCommand;
@@ -53,13 +54,24 @@ export function buildArtifactIngestPlan(input: {
   if (!existsSync(path.join(taskRoot, "INDEX.md"))) throw readFailure(`Task package not found for ${taskId}.`);
   const taskArtifactRoot = path.join(taskRoot, "artifacts");
   const sourceInputs = artifactFacade?.sourcePaths ?? evidence!.map((entry) => entry.path);
-  const classified = sourceInputs.map((sourceInput) => classifySource({
-    sourceInput,
-    cwd: input.cwd ?? process.cwd(),
-    rootDir: layout.rootDir,
-    authoredRoot: layout.authoredRoot
-  }));
-
+  const classified: ReturnType<typeof classifySource>[] = [];
+  const skippedEvidence: Array<{ path: string; reason: string }> = [];
+  for (const sourceInput of sourceInputs) {
+    try {
+      classified.push(classifySource({
+        sourceInput,
+        cwd: input.cwd ?? process.cwd(),
+        rootDir: layout.rootDir,
+        authoredRoot: layout.authoredRoot
+      }));
+    } catch (error) {
+      if (!artifactFacade && error instanceof ArtifactIngestError) {
+        skippedEvidence.push({ path: sourceInput, reason: error.message });
+        continue;
+      }
+      throw error;
+    }
+  }
   const names = new Set<string>();
   const targetPaths: string[] = [];
   const submittedPaths: string[] = [];
@@ -67,46 +79,53 @@ export function buildArtifactIngestPlan(input: {
   const changes: DocSyncSubmitRequestV1["payload"]["changes"][number][] = [];
   const rewrittenByInput = new Map<string, string>();
   for (const source of classified) {
-    if (source.tracked && !isWithin(taskArtifactRoot, source.absolutePath)) {
-      if (artifactFacade) {
-        throw writeFailure(`Artifact add is for untracked evidence files; ${source.sourceInput} is already version-controlled. Keep it as a source pointer instead.`);
+    try {
+      if (source.tracked && !isWithin(taskArtifactRoot, source.absolutePath)) {
+        if (artifactFacade) {
+          throw writeFailure(`Artifact add is for untracked evidence files; ${source.sourceInput} is already version-controlled. Keep it as a source pointer instead.`);
+        }
+        continue;
       }
-      continue;
-    }
-    if (source.tracked) {
-      const portable = portablePathRelative(layout.authoredRoot, source.absolutePath);
-      rewrittenByInput.set(source.sourceInput, portable);
-      targetPaths.push(portable);
-      reusedPaths.push(portable);
-      continue;
-    }
-    const name = path.basename(source.absolutePath);
-    if (names.has(name)) throw writeFailure(`Artifact destination collision: more than one input is named ${name}. Rename one input and retry.`);
-    names.add(name);
-    const targetPath = `${portablePathRelative(layout.authoredRoot, taskRoot)}/artifacts/${name}`;
-    const targetAbsolute = path.join(layout.authoredRoot, targetPath);
-    const headBody = gitBlob(layout.authoredRoot, targetPath);
-    if (headBody !== null) {
-      if (headBody !== source.body) throw writeFailure(`Artifact destination already exists with different content: ${targetPath}. Rename the source and retry.`);
-      reusedPaths.push(targetPath);
-    } else {
-      if (existsSync(targetAbsolute) && path.resolve(targetAbsolute) !== path.resolve(source.absolutePath)
-        && readUtf8(targetAbsolute, targetPath) !== source.body) {
-        throw writeFailure(`Artifact destination already exists with different unsubmitted content: ${targetPath}. Resolve that file first.`);
+      if (source.tracked) {
+        const portable = portablePathRelative(layout.authoredRoot, source.absolutePath);
+        rewrittenByInput.set(source.sourceInput, portable);
+        targetPaths.push(portable);
+        reusedPaths.push(portable);
+        continue;
       }
-      changes.push(docSyncChange(targetPath, source.body));
-      submittedPaths.push(targetPath);
+      const name = path.basename(source.absolutePath);
+      if (names.has(name)) throw writeFailure(`Artifact destination collision: more than one input is named ${name}. Rename one input and retry.`);
+      names.add(name);
+      const targetPath = `${portablePathRelative(layout.authoredRoot, taskRoot)}/artifacts/${name}`;
+      const targetAbsolute = path.join(layout.authoredRoot, targetPath);
+      const headBody = gitBlob(layout.authoredRoot, targetPath);
+      if (headBody !== null) {
+        if (headBody !== source.body) throw writeFailure(`Artifact destination already exists with different content: ${targetPath}. Rename the source and retry.`);
+        reusedPaths.push(targetPath);
+      } else {
+        if (existsSync(targetAbsolute) && path.resolve(targetAbsolute) !== path.resolve(source.absolutePath)
+          && readUtf8(targetAbsolute, targetPath) !== source.body) {
+          throw writeFailure(`Artifact destination already exists with different unsubmitted content: ${targetPath}. Resolve that file first.`);
+        }
+        changes.push(docSyncChange(targetPath, source.body));
+        submittedPaths.push(targetPath);
+      }
+      targetPaths.push(targetPath);
+      rewrittenByInput.set(source.sourceInput, targetPath);
+    } catch (error) {
+      if (!artifactFacade && error instanceof ArtifactIngestError) {
+        skippedEvidence.push({ path: source.sourceInput, reason: error.message });
+        continue;
+      }
+      throw error;
     }
-    targetPaths.push(targetPath);
-    rewrittenByInput.set(source.sourceInput, targetPath);
   }
 
-  if (action.kind === "progress-append" && changes.length === 0 && rewrittenByInput.size === 0) return null;
+  if (action.kind === "progress-append" && changes.length === 0 && rewrittenByInput.size === 0 && skippedEvidence.length === 0) return null;
   const rewrittenEvidence = evidence?.map((entry) => ({ ...entry, path: rewrittenByInput.get(entry.path) ?? entry.path }));
-  const baseLedgerSha = gitRequired(layout.authoredRoot, ["rev-parse", "HEAD"], "Doc sync requires an initialized authored Git repository.");
   const request = changes.length === 0 ? null : artifactRequest({
     repoId: input.repoId,
-    baseLedgerSha,
+    baseLedgerSha: gitRequired(layout.authoredRoot, ["rev-parse", "HEAD"], "Doc sync requires an initialized authored Git repository."),
     changes,
     executor: input.executor,
     session: input.session
@@ -117,6 +136,7 @@ export function buildArtifactIngestPlan(input: {
     targetPaths,
     submittedPaths,
     reusedPaths,
+    skippedEvidence,
     facade: action.kind === "progress-append" ? "progress-append" : "artifact-add",
     ...(action.kind === "progress-append" ? {
       progressCommand: { ...input.command, action: { ...action, evidence: rewrittenEvidence } },
@@ -181,6 +201,7 @@ export function artifactAddSuccess(plan: ArtifactIngestPlan, docSync: unknown): 
       artifacts: plan.targetPaths,
       submitted: plan.submittedPaths,
       reused: plan.reusedPaths,
+      skipped: plan.skippedEvidence,
       docSync
     }
   });
@@ -198,11 +219,24 @@ export function normalizeProgressAfterArtifact(
     artifacts: plan.targetPaths,
     submitted: plan.submittedPaths,
     reused: plan.reusedPaths,
+    skipped: plan.skippedEvidence,
     docSync
   };
+  const warnings = artifactSkipWarnings(plan);
   if (receipt.ok) {
     return {
       ...receipt,
+      ...(warnings.length > 0 ? { warnings: [...(receipt.warnings ?? []), ...warnings] } : {}),
+      details: {
+        ...(receipt.details ?? {}),
+        data: { ...((receipt.details?.data ?? {}) as Record<string, unknown>), artifactIngest: artifactData }
+      }
+    };
+  }
+  if (plan.targetPaths.length === 0) {
+    return {
+      ...receipt,
+      ...(warnings.length > 0 ? { warnings: [...(receipt.warnings ?? []), ...warnings] } : {}),
       details: {
         ...(receipt.details ?? {}),
         data: { ...((receipt.details?.data ?? {}) as Record<string, unknown>), artifactIngest: artifactData }
@@ -214,6 +248,7 @@ export function normalizeProgressAfterArtifact(
   const originalError = receipt.error ?? cliError(CliErrorCode.ArtifactWriteRejected, "Progress append failed.");
   return {
     ...receipt,
+    ...(warnings.length > 0 ? { warnings: [...(receipt.warnings ?? []), ...warnings] } : {}),
     command: "progress-append",
     action: "progress-append",
     error: {
@@ -239,8 +274,7 @@ export function remoteArtifactSafetyReceipt(command: ParsedCommand, repoId: stri
     try {
       const plan = buildArtifactIngestPlan({ command, repoId });
       if (plan === null) return undefined;
-      const originalEvidence = command.action.evidence?.map((entry) => entry.path) ?? [];
-      if (plan.request === null && originalEvidence.every((sourcePath, index) => sourcePath === plan.targetPaths[index])) return undefined;
+      if (plan.request === null) return undefined;
     } catch (error) {
       if (error instanceof ArtifactIngestError && /does not exist/u.test(error.message)) return undefined;
       return artifactIngestPreviewRejected(command, error);
@@ -261,7 +295,10 @@ export function remoteArtifactSafetyReceipt(command: ParsedCommand, repoId: stri
 function classifySource(input: { readonly sourceInput: string; readonly cwd: string; readonly rootDir: string; readonly authoredRoot: string }) {
   const absolutePath = resolveSource(input.sourceInput, input.cwd, input.rootDir, input.authoredRoot);
   if (!existsSync(absolutePath)) throw readFailure(`Evidence file does not exist: ${input.sourceInput}.`);
-  if (!statSync(absolutePath).isFile()) throw readFailure(`Evidence path must name a regular file: ${input.sourceInput}.`);
+  let sourceStat: ReturnType<typeof statSync>;
+  try { sourceStat = statSync(absolutePath); }
+  catch (error) { throw readFailure(`Evidence file could not be inspected: ${input.sourceInput}. Cause: ${error instanceof Error ? error.message : String(error)}`); }
+  if (!sourceStat.isFile()) throw readFailure(`Evidence path must name a regular file: ${input.sourceInput}.`);
   if (!isHarnessInternal(absolutePath, input.rootDir)) {
     throw readFailure(`Evidence artifact is outside this harness repository: ${input.sourceInput}. Move it into the repository or task package before retrying.`);
   }
@@ -270,7 +307,9 @@ function classifySource(input: { readonly sourceInput: string; readonly cwd: str
 }
 
 function readUtf8(absolutePath: string, displayPath: string): string {
-  const bytes = readFileSync(absolutePath);
+  let bytes: Buffer;
+  try { bytes = readFileSync(absolutePath); }
+  catch (error) { throw readFailure(`Evidence file could not be read: ${displayPath}. Cause: ${error instanceof Error ? error.message : String(error)}`); }
   let body: string;
   try { body = new TextDecoder("utf-8", { fatal: true }).decode(bytes); }
   catch { throw readFailure(`Unsupported binary artifact: ${displayPath}. This convenience route accepts UTF-8 text only; keep the file outside this flow until a binary/CAS route is available.`); }
@@ -366,5 +405,11 @@ function isWithin(parent: string, child: string): boolean {
 }
 function safeRealpath(value: string): string { try { return realpathSync(value); } catch { return path.resolve(value); } }
 function quoteShellArgument(value: string): string { return `'${value.replaceAll("'", `'"'"'`)}'`; }
+function artifactSkipWarnings(plan: ArtifactIngestPlan) {
+  return plan.skippedEvidence.map((entry) => ({
+    code: "artifact_ingest_skipped",
+    message: `Evidence pointer ${entry.path} was recorded without artifact ingestion: ${entry.reason} Use 'ha task artifact add ${plan.taskId} <path>' to request strict ingestion explicitly.`
+  }));
+}
 function readFailure(message: string): ArtifactIngestError { return new ArtifactIngestError("artifact_read_failed", message); }
 function writeFailure(message: string): ArtifactIngestError { return new ArtifactIngestError("artifact_write_rejected", message); }

--- a/packages/cli/src/daemon/artifact-ingest.ts
+++ b/packages/cli/src/daemon/artifact-ingest.ts
@@ -1,0 +1,370 @@
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import path from "node:path";
+import type { CurrentSessionRef, HarnessLayoutInput } from "@harness-anything/kernel";
+import { resolveHarnessLayout, sha256Text, taskPackagePath } from "@harness-anything/kernel";
+import type { DocSyncSubmitRequestV1 } from "@harness-anything/application";
+import type { JsonObject } from "@harness-anything/daemon";
+import { CliErrorCode, cliError } from "../cli/error-codes.ts";
+import type { CommandFailureReceipt, CommandReceipt } from "../cli/receipt.ts";
+import { toCommandReceipt } from "../cli/receipt.ts";
+import type { ParsedCommand } from "../cli/types.ts";
+import { readAuthoredGitText } from "../commands/core/authored-git.ts";
+
+export class ArtifactIngestError extends Error {
+  readonly code: "artifact_read_failed" | "artifact_write_rejected";
+
+  constructor(code: ArtifactIngestError["code"], message: string) {
+    super(message);
+    this.name = "ArtifactIngestError";
+    this.code = code;
+  }
+}
+
+export interface ArtifactIngestPlan {
+  readonly request: DocSyncSubmitRequestV1 | null;
+  readonly taskId: string;
+  readonly targetPaths: ReadonlyArray<string>;
+  readonly submittedPaths: ReadonlyArray<string>;
+  readonly reusedPaths: ReadonlyArray<string>;
+  readonly facade: "artifact-add" | "progress-append";
+  readonly progressCommand?: ParsedCommand;
+  readonly originalProgressCommand?: ParsedCommand;
+}
+
+export function buildArtifactIngestPlan(input: {
+  readonly command: ParsedCommand;
+  readonly repoId: string;
+  readonly executor?: DocSyncSubmitRequestV1["executor"];
+  readonly session?: CurrentSessionRef;
+  readonly cwd?: string;
+}): ArtifactIngestPlan | null {
+  const action = input.command.action;
+  const artifactFacade = action.kind === "artifact-add" ? action : undefined;
+  const evidence = action.kind === "progress-append" && !action.dryRun ? action.evidence : undefined;
+  if (!artifactFacade && (!evidence || evidence.length === 0)) return null;
+
+  const rootInput: HarnessLayoutInput = {
+    rootDir: input.command.rootDir,
+    ...(input.command.layoutOverrides ? { layoutOverrides: input.command.layoutOverrides } : {})
+  };
+  const layout = resolveHarnessLayout(rootInput);
+  const taskId = artifactFacade?.taskId ?? (action.kind === "progress-append" ? action.taskId : "");
+  const taskRoot = taskPackagePath(rootInput, taskId);
+  if (!existsSync(path.join(taskRoot, "INDEX.md"))) throw readFailure(`Task package not found for ${taskId}.`);
+  const taskArtifactRoot = path.join(taskRoot, "artifacts");
+  const sourceInputs = artifactFacade?.sourcePaths ?? evidence!.map((entry) => entry.path);
+  const classified = sourceInputs.map((sourceInput) => classifySource({
+    sourceInput,
+    cwd: input.cwd ?? process.cwd(),
+    rootDir: layout.rootDir,
+    authoredRoot: layout.authoredRoot
+  }));
+
+  const names = new Set<string>();
+  const targetPaths: string[] = [];
+  const submittedPaths: string[] = [];
+  const reusedPaths: string[] = [];
+  const changes: DocSyncSubmitRequestV1["payload"]["changes"][number][] = [];
+  const rewrittenByInput = new Map<string, string>();
+  for (const source of classified) {
+    if (source.tracked && !isWithin(taskArtifactRoot, source.absolutePath)) {
+      if (artifactFacade) {
+        throw writeFailure(`Artifact add is for untracked evidence files; ${source.sourceInput} is already version-controlled. Keep it as a source pointer instead.`);
+      }
+      continue;
+    }
+    if (source.tracked) {
+      const portable = portablePathRelative(layout.authoredRoot, source.absolutePath);
+      rewrittenByInput.set(source.sourceInput, portable);
+      targetPaths.push(portable);
+      reusedPaths.push(portable);
+      continue;
+    }
+    const name = path.basename(source.absolutePath);
+    if (names.has(name)) throw writeFailure(`Artifact destination collision: more than one input is named ${name}. Rename one input and retry.`);
+    names.add(name);
+    const targetPath = `${portablePathRelative(layout.authoredRoot, taskRoot)}/artifacts/${name}`;
+    const targetAbsolute = path.join(layout.authoredRoot, targetPath);
+    const headBody = gitBlob(layout.authoredRoot, targetPath);
+    if (headBody !== null) {
+      if (headBody !== source.body) throw writeFailure(`Artifact destination already exists with different content: ${targetPath}. Rename the source and retry.`);
+      reusedPaths.push(targetPath);
+    } else {
+      if (existsSync(targetAbsolute) && path.resolve(targetAbsolute) !== path.resolve(source.absolutePath)
+        && readUtf8(targetAbsolute, targetPath) !== source.body) {
+        throw writeFailure(`Artifact destination already exists with different unsubmitted content: ${targetPath}. Resolve that file first.`);
+      }
+      changes.push(docSyncChange(targetPath, source.body));
+      submittedPaths.push(targetPath);
+    }
+    targetPaths.push(targetPath);
+    rewrittenByInput.set(source.sourceInput, targetPath);
+  }
+
+  if (action.kind === "progress-append" && changes.length === 0 && rewrittenByInput.size === 0) return null;
+  const rewrittenEvidence = evidence?.map((entry) => ({ ...entry, path: rewrittenByInput.get(entry.path) ?? entry.path }));
+  const baseLedgerSha = gitRequired(layout.authoredRoot, ["rev-parse", "HEAD"], "Doc sync requires an initialized authored Git repository.");
+  const request = changes.length === 0 ? null : artifactRequest({
+    repoId: input.repoId,
+    baseLedgerSha,
+    changes,
+    executor: input.executor,
+    session: input.session
+  });
+  return {
+    request,
+    taskId,
+    targetPaths,
+    submittedPaths,
+    reusedPaths,
+    facade: action.kind === "progress-append" ? "progress-append" : "artifact-add",
+    ...(action.kind === "progress-append" ? {
+      progressCommand: { ...input.command, action: { ...action, evidence: rewrittenEvidence } },
+      originalProgressCommand: input.command
+    } : {})
+  };
+}
+
+export function progressRetryCommand(plan: ArtifactIngestPlan): string | undefined {
+  const action = plan.originalProgressCommand?.action ?? plan.progressCommand?.action;
+  if (!action || action.kind !== "progress-append") return undefined;
+  const parts = ["ha", "task", "progress", "append", quoteShellArgument(action.taskId), "--text", quoteShellArgument(action.text)];
+  for (const entry of action.evidence ?? []) {
+    parts.push("--evidence", quoteShellArgument(`${entry.type}:${entry.path}:${entry.summary}`));
+  }
+  return parts.join(" ");
+}
+
+export function artifactIngestPreviewRejected(command: ParsedCommand, error: unknown): CommandFailureReceipt {
+  const code = error instanceof ArtifactIngestError && error.code === "artifact_read_failed"
+    ? CliErrorCode.ArtifactReadFailed
+    : CliErrorCode.ArtifactWriteRejected;
+  const receipt = toCommandReceipt({
+    ok: false,
+    command: command.action.kind === "progress-append" ? "progress-append" : "artifact-add",
+    error: cliError(code, error instanceof Error ? error.message : String(error))
+  });
+  if (receipt.ok) throw new Error("artifact ingest preview rejection unexpectedly succeeded");
+  return receipt;
+}
+
+export function normalizeArtifactSubmitFailure(response: JsonObject, plan: ArtifactIngestPlan): CommandFailureReceipt {
+  const receipt = response as unknown as CommandFailureReceipt;
+  const originalError = receipt.error ?? cliError(CliErrorCode.ArtifactWriteRejected, "Artifact doc-sync submit failed.");
+  return {
+    ...receipt,
+    command: plan.facade,
+    action: plan.facade,
+    error: {
+      ...originalError,
+      hint: `Artifact ingestion failed before the evidence pointer was written. progress.md was not changed. ${originalError.hint}`.trim()
+    },
+    details: {
+      ...(receipt.details ?? {}),
+      data: {
+        ...((receipt.details?.data ?? {}) as Record<string, unknown>),
+        pointerRecorded: false,
+        artifactsCommitted: []
+      }
+    }
+  };
+}
+
+export function artifactAddSuccess(plan: ArtifactIngestPlan, docSync: unknown): CommandReceipt {
+  const receipt = toCommandReceipt({
+    ok: true,
+    command: "artifact-add",
+    taskId: plan.taskId,
+    path: plan.targetPaths[0],
+    report: {
+      schema: "task-artifact-add/v1",
+      artifacts: plan.targetPaths,
+      submitted: plan.submittedPaths,
+      reused: plan.reusedPaths,
+      docSync
+    }
+  });
+  if (!receipt.ok) throw new Error(receipt.error?.hint ?? "artifact add receipt failed");
+  return receipt;
+}
+
+export function normalizeProgressAfterArtifact(
+  receipt: CommandReceipt | CommandFailureReceipt,
+  plan: ArtifactIngestPlan,
+  docSync: unknown
+): CommandReceipt | CommandFailureReceipt {
+  const artifactData = {
+    schema: "progress-artifact-ingest/v1",
+    artifacts: plan.targetPaths,
+    submitted: plan.submittedPaths,
+    reused: plan.reusedPaths,
+    docSync
+  };
+  if (receipt.ok) {
+    return {
+      ...receipt,
+      details: {
+        ...(receipt.details ?? {}),
+        data: { ...((receipt.details?.data ?? {}) as Record<string, unknown>), artifactIngest: artifactData }
+      }
+    };
+  }
+  const retryCommand = progressRetryCommand(plan);
+  const paths = plan.targetPaths.join(", ");
+  const originalError = receipt.error ?? cliError(CliErrorCode.ArtifactWriteRejected, "Progress append failed.");
+  return {
+    ...receipt,
+    command: "progress-append",
+    action: "progress-append",
+    error: {
+      ...originalError,
+      hint: `Artifact ingestion succeeded at ${paths}, but the evidence pointer was not written to progress.md. The committed artifact was kept. ${retryCommand ? `Retry or record the pointer with: ${retryCommand}.` : "Retry the progress append."} Cause: ${originalError.hint}`
+    },
+    details: {
+      ...(receipt.details ?? {}),
+      data: {
+        ...((receipt.details?.data ?? {}) as Record<string, unknown>),
+        artifactIngest: artifactData,
+        pointerRecorded: false,
+        retryCommand
+      }
+    }
+  };
+}
+
+export function remoteArtifactSafetyReceipt(command: ParsedCommand, repoId: string): CommandFailureReceipt | undefined {
+  if (command.action.kind !== "artifact-add"
+    && !(command.action.kind === "progress-append" && !command.action.dryRun && (command.action.evidence?.length ?? 0) > 0)) return undefined;
+  if (command.action.kind === "progress-append") {
+    try {
+      const plan = buildArtifactIngestPlan({ command, repoId });
+      if (plan === null) return undefined;
+      const originalEvidence = command.action.evidence?.map((entry) => entry.path) ?? [];
+      if (plan.request === null && originalEvidence.every((sourcePath, index) => sourcePath === plan.targetPaths[index])) return undefined;
+    } catch (error) {
+      if (error instanceof ArtifactIngestError && /does not exist/u.test(error.message)) return undefined;
+      return artifactIngestPreviewRejected(command, error);
+    }
+  }
+  const receipt = toCommandReceipt({
+    ok: false,
+    command: command.action.kind === "progress-append" ? "progress-append" : "artifact-add",
+    error: cliError(
+      CliErrorCode.ArtifactReadFailed,
+      "This evidence names a local untracked UTF-8 artifact, so ingestion currently requires local daemon mode. No artifact or progress pointer was written. Run the same command from the canonical checkout with local daemon mode; version-controlled source pointers continue to work in remote mode."
+    )
+  });
+  if (receipt.ok) throw new Error("remote artifact ingest rejection unexpectedly succeeded");
+  return receipt;
+}
+
+function classifySource(input: { readonly sourceInput: string; readonly cwd: string; readonly rootDir: string; readonly authoredRoot: string }) {
+  const absolutePath = resolveSource(input.sourceInput, input.cwd, input.rootDir, input.authoredRoot);
+  if (!existsSync(absolutePath)) throw readFailure(`Evidence file does not exist: ${input.sourceInput}.`);
+  if (!statSync(absolutePath).isFile()) throw readFailure(`Evidence path must name a regular file: ${input.sourceInput}.`);
+  if (!isHarnessInternal(absolutePath, input.rootDir)) {
+    throw readFailure(`Evidence artifact is outside this harness repository: ${input.sourceInput}. Move it into the repository or task package before retrying.`);
+  }
+  const tracked = isGitTracked(absolutePath);
+  return { sourceInput: input.sourceInput, absolutePath, tracked, body: tracked ? "" : readUtf8(absolutePath, input.sourceInput) };
+}
+
+function readUtf8(absolutePath: string, displayPath: string): string {
+  const bytes = readFileSync(absolutePath);
+  let body: string;
+  try { body = new TextDecoder("utf-8", { fatal: true }).decode(bytes); }
+  catch { throw readFailure(`Unsupported binary artifact: ${displayPath}. This convenience route accepts UTF-8 text only; keep the file outside this flow until a binary/CAS route is available.`); }
+  if (body.includes("\0")) throw readFailure(`Unsupported binary artifact: ${displayPath}. This convenience route accepts UTF-8 text only; NUL bytes are not allowed.`);
+  return body;
+}
+
+function artifactRequest(input: {
+  readonly repoId: string;
+  readonly baseLedgerSha: string;
+  readonly changes: DocSyncSubmitRequestV1["payload"]["changes"];
+  readonly executor?: DocSyncSubmitRequestV1["executor"];
+  readonly session?: CurrentSessionRef;
+}): DocSyncSubmitRequestV1 {
+  const intentMaterial = JSON.stringify({
+    baseLedgerSha: input.baseLedgerSha,
+    changes: input.changes.map(({ path: changePath, baseBlobSha256, newBlobSha256 }) => ({ path: changePath, baseBlobSha256, newBlobSha256 }))
+  });
+  return {
+    repo: { repoId: input.repoId },
+    ...(input.executor !== undefined ? { executor: input.executor } : {}),
+    ...(input.session ? { session: input.session } : {}),
+    payload: {
+      baseLedgerSha: input.baseLedgerSha,
+      intentId: `intent_${sha256Text(intentMaterial).slice(0, 24)}`,
+      declaredIntent: "manual-artifact",
+      changes: input.changes
+    }
+  };
+}
+
+function docSyncChange(portablePath: string, body: string): DocSyncSubmitRequestV1["payload"]["changes"][number] {
+  return {
+    path: portablePath,
+    baseBlobSha256: null,
+    newBlobSha256: sha256Text(body),
+    mediaType: mediaTypeFor(portablePath),
+    size: Buffer.byteLength(body),
+    declaredBearing: "task-document",
+    declaredZoneClass: "task-authored-prose-or-stage",
+    declaredPathClass: "doc-sync-allowed",
+    content: { kind: "inline", body }
+  };
+}
+
+function resolveSource(sourceInput: string, cwd: string, rootDir: string, authoredRoot: string): string {
+  if (path.isAbsolute(sourceInput)) return path.normalize(sourceInput);
+  const candidates = [path.resolve(cwd, sourceInput), path.resolve(rootDir, sourceInput), path.resolve(authoredRoot, sourceInput)];
+  return candidates.find(existsSync) ?? candidates[0]!;
+}
+
+function isHarnessInternal(absolutePath: string, rootDir: string): boolean {
+  if (isWithin(rootDir, absolutePath)) return true;
+  const rootCommon = gitOptional(rootDir, ["rev-parse", "--path-format=absolute", "--git-common-dir"]);
+  const sourceCommon = gitOptional(path.dirname(absolutePath), ["rev-parse", "--path-format=absolute", "--git-common-dir"]);
+  return rootCommon !== null && sourceCommon !== null && safeRealpath(rootCommon) === safeRealpath(sourceCommon);
+}
+
+function isGitTracked(absolutePath: string): boolean {
+  const top = gitOptional(path.dirname(absolutePath), ["rev-parse", "--show-toplevel"]);
+  if (!top || !isWithin(top, absolutePath)) return false;
+  return gitOptional(top, ["ls-files", "--error-unmatch", "--", portablePathRelative(top, absolutePath)]) !== null;
+}
+
+function gitBlob(authoredRoot: string, portablePath: string): string | null {
+  return gitOptional(authoredRoot, ["show", `HEAD:${portablePath}`], false);
+}
+
+function gitRequired(cwd: string, args: ReadonlyArray<string>, message: string): string {
+  const value = gitOptional(cwd, args);
+  if (value === null) throw writeFailure(message);
+  return value;
+}
+
+function gitOptional(cwd: string, args: ReadonlyArray<string>, trim = true): string | null {
+  try {
+    return readAuthoredGitText(cwd, args, trim);
+  } catch { return null; }
+}
+
+function mediaTypeFor(filePath: string): string {
+  const extension = path.extname(filePath).toLowerCase();
+  if (extension === ".md") return "text/markdown";
+  if (extension === ".json") return "application/json";
+  if (extension === ".html") return "text/html";
+  return "text/plain";
+}
+
+function portablePathRelative(from: string, to: string): string { return path.relative(safeRealpath(from), safeRealpath(to)).split(path.sep).join("/"); }
+function isWithin(parent: string, child: string): boolean {
+  const relative = path.relative(safeRealpath(parent), safeRealpath(child));
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+function safeRealpath(value: string): string { try { return realpathSync(value); } catch { return path.resolve(value); } }
+function quoteShellArgument(value: string): string { return `'${value.replaceAll("'", `'"'"'`)}'`; }
+function readFailure(message: string): ArtifactIngestError { return new ArtifactIngestError("artifact_read_failed", message); }
+function writeFailure(message: string): ArtifactIngestError { return new ArtifactIngestError("artifact_write_rejected", message); }

--- a/packages/cli/src/daemon/client-timing.ts
+++ b/packages/cli/src/daemon/client-timing.ts
@@ -1,0 +1,47 @@
+import type { LocalDaemonAutostartPhase } from "@harness-anything/daemon";
+import type { ParsedCommand } from "../cli/types.ts";
+import { startCliTimingPhase, type CliTimingPhase } from "../cli/timing.ts";
+
+export function daemonAutostartOptions(
+  command: ParsedCommand,
+  config: { readonly idleExitMs: number; readonly autostartTimeoutMs: number; readonly requestTimeoutMs: number },
+  onPhase: (phase: LocalDaemonAutostartPhase) => void,
+  entryPath: string
+) {
+  return {
+    entryPath,
+    idleExitMs: config.idleExitMs,
+    timeoutMs: config.autostartTimeoutMs,
+    requestTimeoutMs: config.requestTimeoutMs,
+    layoutOverrides: command.layoutOverrides,
+    onPhase
+  };
+}
+
+export function daemonTimingObserver(): {
+  readonly observe: (event: LocalDaemonAutostartPhase) => void;
+  readonly finish: () => void;
+} {
+  let finishPhase: (() => void) | undefined;
+  let launchReported = false;
+  const transition = (phase?: CliTimingPhase) => {
+    finishPhase?.();
+    finishPhase = phase ? startCliTimingPhase(phase) : undefined;
+  };
+  return {
+    observe: (event) => {
+      if (event === "connect-start") transition("daemon_connect");
+      if (event === "launch-start") {
+        transition("daemon_launch_authority_ready");
+        if (!launchReported && process.env.HA_PROGRESS !== "0") {
+          launchReported = true;
+          console.error("[ha] Starting local daemon; waiting for authority readiness.");
+        }
+      }
+      if (event === "ready") transition();
+      if (event === "request-start") transition("command_execute");
+      if (event === "request-end") transition();
+    },
+    finish: () => transition()
+  };
+}

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -24,7 +24,6 @@ import {
   requestLocalDaemonJsonRpcForTarget,
   resolveLocalDaemonTarget as resolveDaemonTarget,
   type JsonObject,
-  type LocalDaemonAutostartPhase,
   type LocalDaemonTarget
 } from "@harness-anything/daemon";
 import {
@@ -41,14 +40,24 @@ import type { ParsedCommand } from "../cli/types.ts";
 import { CliActorAttributionError, readCliJournalActorFromEnv, readCliJournalActorFromFlag } from "../composition/actor-attribution.ts";
 import { parsePositiveIntegerOr } from "../cli/value-utils.ts";
 import { buildDocSyncSubmitRequest } from "@harness-anything/daemon";
+import {
+  artifactAddSuccess,
+  artifactIngestPreviewRejected,
+  buildArtifactIngestPlan,
+  normalizeArtifactSubmitFailure,
+  normalizeProgressAfterArtifact,
+  remoteArtifactSafetyReceipt,
+  type ArtifactIngestPlan
+} from "./artifact-ingest.ts";
 import { resolveManagedSectionPolicy } from "../commands/extensions/managed-section-policy.ts";
 
 const docSyncHostServices = { resolveManagedSectionPolicy };
 import { readProjectHarnessSettings } from "../commands/settings.ts";
 import { readRemoteConfig, remoteDaemonSshArgs, remoteDaemonUnavailableHint, type RemoteDaemonConfig } from "./remote-config.ts";
 import { isDeclaredLocalMigrationCommand } from "../composition/local-write-scope.ts";
-import { startCliTimingPhase, type CliTimingPhase } from "../cli/timing.ts";
+import { startCliTimingPhase } from "../cli/timing.ts";
 import { daemonRequestTimeoutReceipt } from "./request-outcome.ts";
+import { daemonAutostartOptions, daemonTimingObserver } from "./client-timing.ts";
 import {
   CliRootResolutionError,
   commandForRootResolution,
@@ -205,6 +214,10 @@ export async function runCommandThroughDaemon(
     if (config.directWriteReason === "recovery") return undefined;
     return directModeRejection(command);
   }
+  if (config.mode === "remote" && config.remote) {
+    const artifactSafety = remoteArtifactSafetyReceipt(command, config.remote.repoId);
+    if (artifactSafety) return artifactSafety;
+  }
   try {
     return config.mode === "remote" && config.remote
       ? await runTimedRemoteCommand(command, config.remote)
@@ -251,8 +264,30 @@ async function runLocalCommand(command: ParsedCommand, config: DaemonClientConfi
   };
   finishTarget();
   const timing = daemonTimingObserver();
-  const autostart = daemonAutostartOptions(command, config, timing.observe);
+  const autostart = daemonAutostartOptions(command, config, timing.observe, daemonClientCliEntrypointPath());
   try {
+    let artifactPlan: ArtifactIngestPlan | null;
+    try {
+      artifactPlan = buildArtifactIngestPlan({
+        command,
+        repoId: target.repoId,
+        executor: commandExecutor(command),
+        session: Effect.runSync(makeEnvironmentCurrentSessionProbe().currentSession)
+      });
+    } catch (error) {
+      return withRootResolution(artifactIngestPreviewRejected(command, error), rootResolution);
+    }
+    let artifactReport: unknown;
+    if (artifactPlan?.request) {
+      const artifactResponse = await requestLocalDaemonJsonRpcForTarget(target, "repo.doc.sync.submit", artifactPlan.request as unknown as JsonObject, 200, autostart);
+      if (!isCommandReceipt(artifactResponse)) throw new Error("repo.doc.sync.submit did not return command-receipt/v2");
+      if (!artifactResponse.ok) return withRootResolution(normalizeArtifactSubmitFailure(artifactResponse, artifactPlan), rootResolution);
+      artifactReport = (artifactResponse as unknown as CommandReceipt).details?.data;
+    }
+    if (artifactPlan?.facade === "artifact-add") {
+      return withRootResolution(artifactAddSuccess(artifactPlan, artifactReport), rootResolution);
+    }
+    if (artifactPlan?.progressCommand) command = artifactPlan.progressCommand;
     if (isDocSyncSubmitCommand(command)) {
       let request: ReturnType<typeof buildDocSyncSubmitRequest>;
       try {
@@ -286,54 +321,19 @@ async function runLocalCommand(command: ParsedCommand, config: DaemonClientConfi
         Effect.runSync(makeEnvironmentCurrentSessionProbe().currentSession)
       )
     }, 200, command.action.kind === "materializer-run" ? undefined : autostart);
-    if (isCommandReceipt(response)) return withRootResolution(response as unknown as CommandReceipt | CommandFailureReceipt, rootResolution);
+    if (isCommandReceipt(response)) {
+      const receipt = response as unknown as CommandReceipt | CommandFailureReceipt;
+      return withRootResolution(
+        artifactPlan?.facade === "progress-append"
+          ? normalizeProgressAfterArtifact(receipt, artifactPlan, artifactReport)
+          : receipt,
+        rootResolution
+      );
+    }
     throw new Error("daemon command.run did not return command-receipt/v2");
   } finally {
     timing.finish();
   }
-}
-
-function daemonAutostartOptions(
-  command: ParsedCommand,
-  config: DaemonClientConfig,
-  onPhase: (phase: LocalDaemonAutostartPhase) => void
-) {
-  return {
-    entryPath: daemonClientCliEntrypointPath(),
-    idleExitMs: config.idleExitMs,
-    timeoutMs: config.autostartTimeoutMs,
-    requestTimeoutMs: config.requestTimeoutMs,
-    layoutOverrides: command.layoutOverrides,
-    onPhase
-  };
-}
-
-function daemonTimingObserver(): {
-  readonly observe: (event: LocalDaemonAutostartPhase) => void;
-  readonly finish: () => void;
-} {
-  let finishPhase: (() => void) | undefined;
-  let launchReported = false;
-  const transition = (phase?: CliTimingPhase) => {
-    finishPhase?.();
-    finishPhase = phase ? startCliTimingPhase(phase) : undefined;
-  };
-  return {
-    observe: (event) => {
-      if (event === "connect-start") transition("daemon_connect");
-      if (event === "launch-start") {
-        transition("daemon_launch_authority_ready");
-        if (!launchReported && process.env.HA_PROGRESS !== "0") {
-          launchReported = true;
-          console.error("[ha] Starting local daemon; waiting for authority readiness.");
-        }
-      }
-      if (event === "ready") transition();
-      if (event === "request-start") transition("command_execute");
-      if (event === "request-end") transition();
-    },
-    finish: () => transition()
-  };
 }
 
 async function runTimedRemoteCommand(command: ParsedCommand, remote: RemoteDaemonConfig): Promise<CommandReceipt | CommandFailureReceipt> {

--- a/packages/cli/test/artifact-ingest-plan.test.ts
+++ b/packages/cli/test/artifact-ingest-plan.test.ts
@@ -1,0 +1,118 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { buildArtifactIngestPlan, ArtifactIngestError, normalizeProgressAfterArtifact, progressRetryCommand } from "../src/daemon/artifact-ingest.ts";
+import { CliErrorCode, cliError } from "../src/cli/error-codes.ts";
+import { toCommandReceipt } from "../src/cli/receipt.ts";
+import type { ParsedCommand } from "../src/cli/types.ts";
+
+test("artifact planner rewrites untracked evidence to a governed task path", () => withFixture(({ rootDir, taskId }) => {
+  const source = path.join(rootDir, "verification.txt");
+  writeFileSync(source, "green\n", "utf8");
+  const plan = buildArtifactIngestPlan({ command: progressCommand(rootDir, taskId, source), repoId: "canonical", cwd: rootDir });
+  assert.ok(plan?.request);
+  const target = `tasks/${taskId}/artifacts/verification.txt`;
+  assert.deepEqual(plan.targetPaths, [target]);
+  assert.equal(plan.request.payload.changes[0]?.path, target);
+  assert.equal(plan.progressCommand?.action.kind, "progress-append");
+  if (plan.progressCommand?.action.kind === "progress-append") {
+    assert.equal(plan.progressCommand.action.evidence?.[0]?.path, target);
+  }
+  assert.match(progressRetryCommand(plan) ?? "", /verification\.txt/u);
+}));
+
+test("artifact planner leaves version-controlled source evidence on the existing pointer path", () => withFixture(({ rootDir, harnessRoot, taskId }) => {
+  const source = path.join(harnessRoot, "src", "source.ts");
+  mkdirSync(path.dirname(source), { recursive: true });
+  writeFileSync(source, "export const value = 1;\n", "utf8");
+  git(harnessRoot, "add", "src/source.ts");
+  git(harnessRoot, "commit", "-m", "seed tracked source");
+  const plan = buildArtifactIngestPlan({ command: progressCommand(rootDir, taskId, source), repoId: "canonical", cwd: rootDir });
+  assert.equal(plan, null);
+}));
+
+test("artifact planner rejects binary bytes with an actionable UTF-8 message", () => withFixture(({ rootDir, taskId }) => {
+  const source = path.join(rootDir, "capture.bin");
+  writeFileSync(source, Buffer.from([0xff, 0x00, 0xfe]));
+  assert.throws(
+    () => buildArtifactIngestPlan({ command: progressCommand(rootDir, taskId, source), repoId: "canonical", cwd: rootDir }),
+    (error) => error instanceof ArtifactIngestError && error.code === "artifact_read_failed" && /UTF-8 text only/u.test(error.message)
+  );
+}));
+
+test("artifact planner reuses an identical committed artifact so a failed progress append can be retried", () => withFixture(({ rootDir, harnessRoot, taskId }) => {
+  const source = path.join(rootDir, "retry.txt");
+  const target = path.join(harnessRoot, "tasks", taskId, "artifacts", "retry.txt");
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(source, "retry body\n", "utf8");
+  writeFileSync(target, "retry body\n", "utf8");
+  git(harnessRoot, "add", ".");
+  git(harnessRoot, "commit", "-m", "seed reusable artifact");
+  const plan = buildArtifactIngestPlan({ command: progressCommand(rootDir, taskId, source), repoId: "canonical", cwd: rootDir });
+  assert.ok(plan);
+  assert.equal(plan.request, null);
+  assert.deepEqual(plan.reusedPaths, [`tasks/${taskId}/artifacts/retry.txt`]);
+}));
+
+test("progress failure reports the retained governed artifact and an exact retry command", () => withFixture(({ rootDir, taskId }) => {
+  const source = path.join(rootDir, "orphan.txt");
+  writeFileSync(source, "committed first\n", "utf8");
+  const plan = buildArtifactIngestPlan({ command: progressCommand(rootDir, taskId, source), repoId: "canonical", cwd: rootDir });
+  assert.ok(plan);
+  const failed = toCommandReceipt({
+    ok: false,
+    command: "progress-append",
+    error: cliError(CliErrorCode.WriteRejected, "execution lease is not reserving")
+  });
+  assert.equal(failed.ok, false);
+  if (failed.ok) return;
+  const receipt = normalizeProgressAfterArtifact(failed, plan, { status: "accepted" });
+  assert.equal(receipt.ok, false);
+  if (receipt.ok) return;
+  assert.match(receipt.error?.hint ?? "", /tasks\/task_A\/artifacts\/orphan\.txt/u);
+  assert.match(receipt.error?.hint ?? "", /evidence pointer was not written/u);
+  assert.match(receipt.error?.hint ?? "", /ha task progress append 'task_A'/u);
+  const data = receipt.details?.data as Record<string, unknown>;
+  assert.equal(data.pointerRecorded, false);
+  assert.match(String(data.retryCommand), new RegExp(source.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
+}));
+
+function progressCommand(rootDir: string, taskId: string, evidencePath: string): ParsedCommand {
+  return {
+    rootDir,
+    json: true,
+    action: {
+      kind: "progress-append",
+      taskId,
+      text: "verification complete",
+      evidence: [{ type: "log", path: evidencePath, summary: "green" }],
+      dryRun: false
+    }
+  };
+}
+
+function withFixture(run: (fixture: { readonly rootDir: string; readonly harnessRoot: string; readonly taskId: string }) => void): void {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-artifact-plan-"));
+  const harnessRoot = path.join(rootDir, "harness");
+  const taskId = "task_A";
+  try {
+    mkdirSync(path.join(harnessRoot, "tasks", taskId), { recursive: true });
+    writeFileSync(path.join(harnessRoot, "tasks", taskId, "INDEX.md"), "---\ntask_id: task_A\nstatus: active\n---\n");
+    git(harnessRoot, "init", "-q");
+    git(harnessRoot, "config", "user.name", "Harness Test");
+    git(harnessRoot, "config", "user.email", "harness@example.test");
+    git(harnessRoot, "add", ".");
+    git(harnessRoot, "commit", "-m", "seed");
+    run({ rootDir, harnessRoot, taskId });
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function git(root: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", root, ...args], { encoding: "utf8" }).trim();
+}

--- a/packages/cli/test/artifact-ingest-plan.test.ts
+++ b/packages/cli/test/artifact-ingest-plan.test.ts
@@ -94,6 +94,35 @@ test("progress failure reports the retained governed artifact and an exact retry
   assert.match(String(data.retryCommand), new RegExp(source.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
 }));
 
+test("unknown progress outcome does not claim the pointer is missing or offer an unconditional retry", () => withFixture(({ rootDir, taskId }) => {
+  const source = path.join(rootDir, "unknown.txt");
+  writeFileSync(source, "committed before outcome became unknown\n", "utf8");
+  const plan = buildArtifactIngestPlan({ command: progressCommand(rootDir, taskId, source), repoId: "canonical", cwd: rootDir });
+  assert.ok(plan);
+  const failed = toCommandReceipt({
+    ok: false,
+    command: "progress-append",
+    error: cliError(CliErrorCode.WriteRejected, "child writer response was lost")
+  });
+  assert.equal(failed.ok, false);
+  if (failed.ok) return;
+  const receipt = normalizeProgressAfterArtifact({
+    ...failed,
+    error: { code: "repo_write_outcome_unknown", hint: "the write may already have taken effect" }
+  }, plan, { status: "accepted" });
+  assert.equal(receipt.ok, false);
+  if (receipt.ok) return;
+  assert.match(receipt.error?.hint ?? "", /tasks\/task_A\/artifacts\/unknown\.txt/u);
+  assert.match(receipt.error?.hint ?? "", /progress append outcome is unknown/iu);
+  assert.match(receipt.error?.hint ?? "", /first check progress\.md/iu);
+  assert.doesNotMatch(receipt.error?.hint ?? "", /pointer was not written/iu);
+  assert.doesNotMatch(receipt.error?.hint ?? "", /Retry or record the pointer with:/iu);
+  const data = receipt.details?.data as Record<string, unknown>;
+  assert.equal(data.pointerRecorded, "unknown");
+  assert.equal(data.outcome, "unknown");
+  assert.equal("retryCommand" in data, false);
+}));
+
 function progressCommand(rootDir: string, taskId: string, evidencePath: string): ParsedCommand {
   return {
     rootDir,

--- a/packages/cli/test/artifact-ingest-plan.test.ts
+++ b/packages/cli/test/artifact-ingest-plan.test.ts
@@ -35,13 +35,26 @@ test("artifact planner leaves version-controlled source evidence on the existing
   assert.equal(plan, null);
 }));
 
-test("artifact planner rejects binary bytes with an actionable UTF-8 message", () => withFixture(({ rootDir, taskId }) => {
+test("explicit artifact add rejects binary bytes with an actionable UTF-8 message", () => withFixture(({ rootDir, taskId }) => {
   const source = path.join(rootDir, "capture.bin");
   writeFileSync(source, Buffer.from([0xff, 0x00, 0xfe]));
   assert.throws(
-    () => buildArtifactIngestPlan({ command: progressCommand(rootDir, taskId, source), repoId: "canonical", cwd: rootDir }),
+    () => buildArtifactIngestPlan({ command: artifactCommand(rootDir, taskId, source), repoId: "canonical", cwd: rootDir }),
     (error) => error instanceof ArtifactIngestError && error.code === "artifact_read_failed" && /UTF-8 text only/u.test(error.message)
   );
+}));
+
+test("progress evidence keeps a binary pointer and records why ingestion was skipped", () => withFixture(({ rootDir, taskId }) => {
+  const source = path.join(rootDir, "capture.bin");
+  writeFileSync(source, Buffer.from([0xff, 0x00, 0xfe]));
+  const plan = buildArtifactIngestPlan({ command: progressCommand(rootDir, taskId, source), repoId: "canonical", cwd: rootDir });
+  assert.ok(plan);
+  assert.equal(plan.request, null);
+  assert.equal(plan.skippedEvidence[0]?.path, source);
+  assert.match(plan.skippedEvidence[0]?.reason ?? "", /UTF-8 text only/u);
+  if (plan.progressCommand?.action.kind === "progress-append") {
+    assert.equal(plan.progressCommand.action.evidence?.[0]?.path, source);
+  }
 }));
 
 test("artifact planner reuses an identical committed artifact so a failed progress append can be retried", () => withFixture(({ rootDir, harnessRoot, taskId }) => {
@@ -93,6 +106,10 @@ function progressCommand(rootDir: string, taskId: string, evidencePath: string):
       dryRun: false
     }
   };
+}
+
+function artifactCommand(rootDir: string, taskId: string, sourcePath: string): ParsedCommand {
+  return { rootDir, json: true, action: { kind: "artifact-add", taskId, sourcePaths: [sourcePath] } };
 }
 
 function withFixture(run: (fixture: { readonly rootDir: string; readonly harnessRoot: string; readonly taskId: string }) => void): void {

--- a/packages/cli/test/artifact-ingest-plan.test.ts
+++ b/packages/cli/test/artifact-ingest-plan.test.ts
@@ -5,7 +5,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { buildArtifactIngestPlan, ArtifactIngestError, normalizeProgressAfterArtifact, progressRetryCommand } from "../src/daemon/artifact-ingest.ts";
+import { buildArtifactIngestPlan, ArtifactIngestError, normalizeProgressAfterArtifact, portableGitPathRelative, progressRetryCommand } from "../src/daemon/artifact-ingest.ts";
 import { CliErrorCode, cliError } from "../src/cli/error-codes.ts";
 import { toCommandReceipt } from "../src/cli/receipt.ts";
 import type { ParsedCommand } from "../src/cli/types.ts";
@@ -34,6 +34,16 @@ test("artifact planner leaves version-controlled source evidence on the existing
   const plan = buildArtifactIngestPlan({ command: progressCommand(rootDir, taskId, source), repoId: "canonical", cwd: rootDir });
   assert.equal(plan, null);
 }));
+
+test("portable Git paths normalize Windows separators and case on POSIX", () => {
+  const repositoryRoot = String.raw`C:\Users\runneradmin\AppData\Local\Temp\ha-artifact-plan\harness`;
+  const trackedSource = "c:/USERS/RUNNERADMIN/AppData/Local/Temp/ha-artifact-plan/harness/src/source.ts";
+  assert.equal(portableGitPathRelative(repositoryRoot, trackedSource), "src/source.ts");
+  assert.equal(
+    portableGitPathRelative(repositoryRoot, String.raw`C:\Users\runneradmin\AppData\Local\Temp\outside.ts`),
+    null
+  );
+});
 
 test("explicit artifact add rejects binary bytes with an actionable UTF-8 message", () => withFixture(({ rootDir, taskId }) => {
   const source = path.join(rootDir, "capture.bin");

--- a/packages/cli/test/conflict-preflight-cli.test.ts
+++ b/packages/cli/test/conflict-preflight-cli.test.ts
@@ -16,6 +16,7 @@ const cliEntry = path.resolve("packages/cli/src/index.ts");
 
 const expectedConflictPreflightKinds = [
   "adopt-multica",
+  "artifact-add",
   "decision-transition",
   "decision-amend",
   "decision-repin",
@@ -73,6 +74,7 @@ const expectedConflictPreflightKinds = [
 ].sort();
 
 const expectedAutoRuntimeEventKinds = [
+  "artifact-add",
   "decision-transition",
   "decision-amend",
   "decision-repin",

--- a/packages/cli/test/doc-sync-cli.test.ts
+++ b/packages/cli/test/doc-sync-cli.test.ts
@@ -2,7 +2,7 @@
 import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -151,6 +151,94 @@ test("CLI doc sync submit commits eligible prose through the daemon", async () =
   });
 });
 
+test("task artifact add submits UTF-8 evidence through the existing doc-sync governance commit", async () => {
+  await withTempRoot(async (rootDir) => {
+    const harnessRoot = path.join(rootDir, "harness");
+    const taskId = "task_01KX3W4V1EDPHPTGWYYBQQ2J75";
+    const sessionBranch = "sessions/doc-sync-cli-test";
+    const taskRoot = path.join(harnessRoot, "tasks", taskId);
+    mkdirSync(taskRoot, { recursive: true });
+    seedDocSyncWriteRoadRegistry(rootDir);
+    writeFileSync(path.join(taskRoot, "INDEX.md"), taskIndex());
+    initHarnessGit(harnessRoot);
+    const source = path.join(rootDir, "artifact-report.txt");
+    writeFileSync(source, "governed evidence\n", "utf8");
+
+    const submitted = runJson(rootDir, ["task", "artifact", "add", taskId, source]);
+
+    const target = `tasks/${taskId}/artifacts/artifact-report.txt`;
+    assert.equal(submitted.ok, true);
+    assert.equal(submitted.command, "artifact-add");
+    assert.deepEqual(submitted.report.artifacts, [target]);
+    const committedBody = await pollUntil(
+      () => execFileSync("git", ["-C", harnessRoot, "show", `${sessionBranch}:${target}`], { encoding: "utf8" }),
+      (candidate) => candidate === "governed evidence\n",
+      (candidate, error) => JSON.stringify({ candidate, error: String(error ?? ""), submitted })
+    );
+    assert.equal(committedBody, "governed evidence\n");
+    assert.match(execFileSync("git", ["-C", harnessRoot, "log", "-1", "--format=%s", sessionBranch], { encoding: "utf8" }), /^entity\(doc-sync-submit\):/u);
+  });
+});
+
+test("progress evidence ingests an untracked artifact before recording its governed pointer", async () => {
+  await withTempRoot(async (rootDir) => {
+    const harnessRoot = path.join(rootDir, "harness");
+    const taskId = "task_01KX3W4V1EDPHPTGWYYBQQ2J75";
+    const taskRoot = path.join(harnessRoot, "tasks", taskId);
+    mkdirSync(taskRoot, { recursive: true });
+    seedDocSyncWriteRoadRegistry(rootDir);
+    writeFileSync(path.join(taskRoot, "INDEX.md"), taskIndex());
+    writeFileSync(path.join(taskRoot, "progress.md"), "# Progress\n\n## Entries\n\n");
+    initHarnessGit(harnessRoot);
+    const source = path.join(rootDir, "combined-report.txt");
+    writeFileSync(source, "combined evidence\n", "utf8");
+
+    const submitted = runJson(rootDir, [
+      "task", "progress", "append", taskId,
+      "--text", "combined path",
+      "--evidence", `test:${source}:green`
+    ]);
+
+    const target = `tasks/${taskId}/artifacts/combined-report.txt`;
+    assert.equal(submitted.ok, true, JSON.stringify(submitted));
+    assert.match(readFileSync(path.join(taskRoot, "progress.md"), "utf8"), new RegExp(`Evidence: test:${target}:green`, "u"));
+    assert.equal(execFileSync("git", ["-C", harnessRoot, "show", `HEAD:${target}`], { encoding: "utf8" }), "combined evidence\n");
+    assert.match(execFileSync("git", ["-C", harnessRoot, "log", "--all", "--format=%s", "--", target], { encoding: "utf8" }), /entity\(doc-sync-submit\):/u);
+  });
+});
+
+test("artifact doc-sync rejection stops before progress append and leaves no dangling pointer", async () => {
+  await withTempRoot(async (rootDir) => {
+    const harnessRoot = path.join(rootDir, "harness");
+    const taskId = "task_01KX3W4V1EDPHPTGWYYBQQ2J75";
+    const taskRoot = path.join(harnessRoot, "tasks", taskId);
+    mkdirSync(taskRoot, { recursive: true });
+    mkdirSync(path.join(rootDir, "tools"), { recursive: true });
+    writeFileSync(path.join(rootDir, "tools", "write-road-registry.json"), `${JSON.stringify({
+      schema: "harness-anything/write-road-registry/v1",
+      rows: [{ id: "task.document.write-stage", bearing: "task-document", channel: { pathClass: "rpc-only", zoneClass: "task-authored-prose-or-stage" } }]
+    }, null, 2)}\n`);
+    writeFileSync(path.join(taskRoot, "INDEX.md"), taskIndex());
+    writeFileSync(path.join(taskRoot, "progress.md"), "# Progress\n\n## Entries\n\n");
+    initHarnessGit(harnessRoot);
+    const source = path.join(rootDir, "rejected-report.txt");
+    writeFileSync(source, "must stay unreferenced\n", "utf8");
+    const before = execFileSync("git", ["-C", harnessRoot, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+
+    const rejected = runJson(rootDir, [
+      "task", "progress", "append", taskId,
+      "--text", "must not be appended",
+      "--evidence", `log:${source}:rejected`
+    ], false);
+
+    assert.equal(rejected.ok, false);
+    assert.match(rejected.error.hint, /progress\.md was not changed/u);
+    assert.equal(execFileSync("git", ["-C", harnessRoot, "rev-parse", "HEAD"], { encoding: "utf8" }).trim(), before);
+    assert.equal(execFileSync("git", ["-C", harnessRoot, "show", `HEAD:tasks/${taskId}/progress.md`], { encoding: "utf8" }), "# Progress\n\n## Entries\n\n");
+    assert.equal(existsSync(path.join(taskRoot, "artifacts", "rejected-report.txt")), false);
+  });
+});
+
 async function withTempRoot<T>(fn: (rootDir: string) => Promise<T>): Promise<T> {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-sync-cli-"));
   ensureTestHarnessIdentity(rootDir);
@@ -189,8 +277,13 @@ function gitStatus(harnessRoot: string): string {
 
 function taskIndex(): string {
   return [
-    "---", "schema: task-package/v2", "task_id: task_01KX3W4V1EDPHPTGWYYBQQ2J75", "status: active",
-    "urgency: medium", "vertical: software/coding", "preset: standard-task", "---", "# Task", ""
+    "---", "schema: task-package/v2", "task_id: task_01KX3W4V1EDPHPTGWYYBQQ2J75", "title: Doc sync task",
+    "lifecycle:", "  bindingSchema: lifecycle-binding/v1", "  engine: local", "  status: active", "  ref: ''",
+    "  titleSnapshot: Doc sync task", "  url: ''", "  bindingCreatedAt: 2026-07-26T00:00:00.000Z",
+    `  bindingFingerprint: sha256:${"b".repeat(64)}`,
+    "packageDisposition: active", "urgency: medium", "vertical: software/coding", "preset: standard-task",
+    "provenance:", "  - {runtime: human, sessionId: fixture, boundAt: 2026-07-26T00:00:00.000Z}",
+    "---", "# Task", ""
   ].join("\n");
 }
 
@@ -211,7 +304,8 @@ function validFactRecord(): string {
 }
 
 function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true): Record<string, any> {
-  const daemonMode = args[0] === "doc" && args[1] === "sync" && args.includes("--submit") ? "local" : "fixture";
+  const daemonMode = (args[0] === "doc" && args[1] === "sync" && args.includes("--submit"))
+    || (args[0] === "task" && (args[1] === "artifact" || args[1] === "progress")) ? "local" : "fixture";
   try {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
       encoding: "utf8",

--- a/packages/cli/test/doc-sync-cli.test.ts
+++ b/packages/cli/test/doc-sync-cli.test.ts
@@ -207,6 +207,39 @@ test("progress evidence ingests an untracked artifact before recording its gover
   });
 });
 
+test("progress evidence preserves a URL-shaped free pointer when it is not a local artifact", async () => {
+  await withTempRoot(async (rootDir) => {
+    await assertPointerOnlyEvidence(rootDir, "pr:https://github.com/FairladyZ625/harness-anything/pull/1104:merged");
+  });
+});
+
+test("progress evidence preserves a non-path free pointer", async () => {
+  await withTempRoot(async (rootDir) => {
+    await assertPointerOnlyEvidence(rootDir, "note:none:仅文字说明");
+  });
+});
+
+test("progress evidence preserves an outside-repository file pointer", async () => {
+  await withTempRoot(async (rootDir) => {
+    const externalRoot = mkdtempSync(path.join(tmpdir(), "ha-outside-evidence-"));
+    try {
+      const externalPath = path.join(externalRoot, "probe-run.log");
+      writeFileSync(externalPath, "outside log\n", "utf8");
+      await assertPointerOnlyEvidence(rootDir, `log:${externalPath}:tail`);
+    } finally {
+      rmSync(externalRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+test("progress evidence preserves a binary file pointer", async () => {
+  await withTempRoot(async (rootDir) => {
+    const binaryPath = path.join(rootDir, "capture.bin");
+    writeFileSync(binaryPath, Buffer.from([0xff, 0x00, 0xfe]));
+    await assertPointerOnlyEvidence(rootDir, `log:${binaryPath}:binary capture`);
+  });
+});
+
 test("artifact doc-sync rejection stops before progress append and leaves no dangling pointer", async () => {
   await withTempRoot(async (rootDir) => {
     const harnessRoot = path.join(rootDir, "harness");
@@ -248,6 +281,32 @@ async function withTempRoot<T>(fn: (rootDir: string) => Promise<T>): Promise<T> 
     await stopDaemon(rootDir);
     rmSync(rootDir, { recursive: true, force: true });
   }
+}
+
+async function assertPointerOnlyEvidence(rootDir: string, evidence: string): Promise<void> {
+  const harnessRoot = path.join(rootDir, "harness");
+  const taskId = "task_01KX3W4V1EDPHPTGWYYBQQ2J75";
+  const taskRoot = path.join(harnessRoot, "tasks", taskId);
+  mkdirSync(taskRoot, { recursive: true });
+  seedDocSyncWriteRoadRegistry(rootDir);
+  writeFileSync(path.join(taskRoot, "INDEX.md"), taskIndex());
+  writeFileSync(path.join(taskRoot, "progress.md"), "# Progress\n\n## Entries\n\n");
+  initHarnessGit(harnessRoot);
+
+  const submitted = runJson(rootDir, [
+    "task", "progress", "append", taskId,
+    "--text", "free pointer compatibility",
+    "--evidence", evidence
+  ]);
+
+  assert.equal(submitted.ok, true, JSON.stringify(submitted));
+  assert.match(readFileSync(path.join(taskRoot, "progress.md"), "utf8"), new RegExp(`Evidence: ${escapeRegExp(evidence)}`, "u"));
+  assert.equal((submitted.warnings ?? []).some((warning: Record<string, unknown>) => warning.code === "artifact_ingest_skipped"), true);
+  assert.equal(existsSync(path.join(taskRoot, "artifacts")), false);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
 function seedWriteRoadRegistry(rootDir: string): void {

--- a/packages/cli/test/fixtures/task-progress-parse-cases.ts
+++ b/packages/cli/test/fixtures/task-progress-parse-cases.ts
@@ -1,0 +1,32 @@
+export const taskProgressParseCases = [
+  {
+    name: "execution submit infers the active lease without token replay",
+    argv: ["task", "transition", "task_1", "in_review", "--completion-claim", "ready"],
+    kind: "status-set",
+    fields: {
+      taskId: "task_1",
+      status: "in_review",
+      force: false,
+      executionSubmission: {
+        completionClaim: "ready",
+        deliverables: [],
+        verificationNotes: [],
+        knownGaps: [],
+        residualRisks: [],
+        outputs: []
+      }
+    }
+  },
+  {
+    name: "progress append repeated evidence",
+    argv: ["task", "progress", "append", "task_1", "--text", "hello", "--evidence", "log:artifacts/run.log:passed", "--evidence", "test:artifacts/unit.log:green"],
+    kind: "progress-append",
+    fields: { taskId: "task_1", text: "hello", evidence: [{ type: "log", path: "artifacts/run.log", summary: "passed" }, { type: "test", path: "artifacts/unit.log", summary: "green" }] }
+  },
+  {
+    name: "task artifact add",
+    argv: ["task", "artifact", "add", "task_1", "report.txt", "notes.md"],
+    kind: "artifact-add",
+    fields: { taskId: "task_1", sourcePaths: ["report.txt", "notes.md"] }
+  }
+] as const;

--- a/packages/cli/test/parse-args.test.ts
+++ b/packages/cli/test/parse-args.test.ts
@@ -19,6 +19,7 @@ import { resolveHarnessLayout } from "../../kernel/src/index.ts";
 import { deprecatedCommandDefinitions } from "../src/cli/command-deprecations.ts";
 import { taskLifecycleFacadeParseCases } from "./fixtures/task-lifecycle-facade-parse-cases.ts";
 import { runtimeDocParseCases } from "./fixtures/runtime-doc-parse-cases.ts";
+import { taskProgressParseCases } from "./fixtures/task-progress-parse-cases.ts";
 
 type ParsedAction = ParsedCommand["action"];
 
@@ -79,25 +80,7 @@ const parseCases: ReadonlyArray<ParseCase> = [
     kind: "status-set",
     fields: { taskId: "task_1", status: "done", force: true, reason: "verified" }
   },
-  {
-    name: "execution submit infers the active lease without token replay",
-    argv: ["task", "transition", "task_1", "in_review", "--completion-claim", "ready"],
-    kind: "status-set",
-    fields: {
-      taskId: "task_1",
-      status: "in_review",
-      force: false,
-      executionSubmission: {
-        completionClaim: "ready",
-        deliverables: [],
-        verificationNotes: [],
-        knownGaps: [],
-        residualRisks: [],
-        outputs: []
-      }
-    }
-  },
-  { name: "progress append repeated evidence", argv: ["task", "progress", "append", "task_1", "--text", "hello", "--evidence", "log:artifacts/run.log:passed", "--evidence", "test:artifacts/unit.log:green"], kind: "progress-append", fields: { taskId: "task_1", text: "hello", evidence: [{ type: "log", path: "artifacts/run.log", summary: "passed" }, { type: "test", path: "artifacts/unit.log", summary: "green" }] } },
+  ...taskProgressParseCases,
   { name: "task amend", argv: ["task", "amend", "task_1", "--set", "taskClass:milestone"], kind: "task-amend", fields: { taskId: "task_1", patches: [{ field: "taskClass", value: "milestone" }] } },
   { name: "task contract migrate", argv: ["task", "contract", "migrate", "--apply", "--task", "task_1"], kind: "task-contract-migrate", fields: { mode: "apply", taskId: "task_1" } },
   { name: "task archive", argv: ["task", "archive", "task_1", "--reason", "done", "--archived-by", "alice", "--archive-field", "packageDisposition"], kind: "task-archive", fields: { taskId: "task_1", reason: "done", archivedBy: "alice", archiveField: "packageDisposition" } },

--- a/packages/cli/test/snapshots/capabilities-command-kinds.json
+++ b/packages/cli/test/snapshots/capabilities-command-kinds.json
@@ -151,6 +151,7 @@
     "status"
   ],
   "task": [
+    "artifact-add",
     "new-task",
     "progress-append",
     "status-set",

--- a/packages/daemon/src/protocol/method-registry.ts
+++ b/packages/daemon/src/protocol/method-registry.ts
@@ -268,6 +268,7 @@ const repoReadCliActionKinds = new Set<string>([
 
 const repoWriteCliActionKinds = new Set<string>([
   "adopt-multica",
+  "artifact-add",
   "cas-gc",
   "decision-amend",
   "decision-repin",

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -3944,6 +3944,27 @@
       "writeKinds": [
         "doc_sync_submit"
       ],
+      "cliActions": [
+        "artifact-add"
+      ],
+      "intentCompilers": [
+        {
+          "selector": "artifact-add",
+          "surfaces": {
+            "cliActions": [
+              "artifact-add"
+            ]
+          },
+          "parity": "single-entry",
+          "compilers": [
+            {
+              "entry": "current-authored-ingress",
+              "ref": "packages/cli/src/daemon/artifact-ingest.ts#buildArtifactIngestPlan"
+            }
+          ],
+          "reviewWhen": "Return this item to unknown when any second authored ingress surface is registered for this intent."
+        }
+      ],
       "evidence": [
         "packages/daemon/src/service/doc-sync-service.ts:229",
         "packages/kernel/src/domain/write-op-kind.ts:1"


### PR DESCRIPTION
# English

## Summary

Closes #1033 by wiring the governed ingest route that already exists into the command people actually use, and giving it a name they can guess.

The issue reports that there is no governed way to bring an existing file into a task's `artifacts/`. Live measurement on `main` shows that premise no longer holds: `ha doc sync --submit` already ingests hand-authored files placed under `tasks/<id>/artifacts/`, and the ledger records 126 such governed commits across 43 tasks since 2026-07-13. The issue's supporting count of `0` came from filtering commit authors by the daemon identity, while the governed path records the **real actor** as author by design (ADR-0016 R3), which excludes every governed ingest from that query.

What was actually missing was smaller and more specific: `task progress append --evidence` recorded a pointer without ever moving the file, so an evidence pointer could be dangling from the moment it was written; and the route that does ingest is called "doc sync", which nobody looking for an artifact command would guess.

## What Changed

- `task progress append --evidence`: when a pointer names an untracked UTF-8 file inside this repository, the file is ingested into `tasks/<id>/artifacts/` through the existing doc-sync route **first**, and only then is the progress entry appended with the pointer rewritten to the ledger-internal path. Git-tracked sources keep their pointer and are never copied.
- Ingestion is **opportunistic and never a precondition**. A pointer that names a URL, a non-path token, a file outside the repository, or a binary is recorded exactly as before, the command still succeeds, and the receipt carries a warning naming the skip reason plus the explicit `ha task artifact add` route.
- New facade `ha task artifact add <task-id> <path>...` runs the same doc-sync route (`runDocCommand`) — a discoverable name, not a second write road. Because ingestion is the explicit intent there, that command fails loudly on a missing file, a path outside the repository, a binary, or a destination-name collision.
- Failure semantics follow the authorizing decision: artifact ingest failure aborts before `progress.md` is touched; progress failure keeps the committed artifact and reports `pointerRecorded: false` with a retry command. When the underlying outcome is `repo_write_outcome_unknown`, the receipt reports `pointerRecorded: "unknown"` and tells the operator to check `progress.md` before rerunning, instead of asserting a failure it cannot know.
- Remote daemon mode rejects local untracked artifact ingestion before any write; tracked and free-form pointers are unaffected.
- Supporting extractions to satisfy existing structural gates: `client-timing.ts` (file complexity), a dedicated artifact parser, and a parse-case fixture.

- The new action is registered where the repository's exhaustive classification gates require it: daemon command classification, CLI conflict-preflight, runtime event policy, the capabilities surface snapshot, and the write-road registry row for its road.
- Cross-platform path handling is a pure, unit-testable function (`portableGitPathRelative`) that selects `path.win32` or `path.posix` from the path's shape, so Windows-shaped inputs are covered by a test that runs on POSIX. Without it, a git-tracked source on Windows was misclassified as ingestable — meaning source files would have been copied into `artifacts/`, violating the authorizing decision. That was caught by CI, not by the local gate.

No `WriteOpKind`, authorization envelope, or managed-section policy was changed, and no gate was weakened or exempted. The diff is 18 files: `packages/cli/**`, one daemon method-registry classification, and one existing write-road registry row.

## Task And Scope

- Harness task: `task_01KYEBCHN5BHBHR6VMYHWDA9ZM`
- Branch: `feat/evidence-artifact-ingest`
- Public scope: evidence ingest planning, the `task artifact add` facade and their tests under `packages/cli/**`; the daemon method-registry classification for the new action; one existing `tools/write-road-registry.json` row.
- Private planning/evidence updated: yes (task package with plan, mission, preflight proof, and implementation report)
- Out of scope: binary/CAS ingestion (doc-sync is a UTF-8 text channel; deliberately deferred by the authorizing decision), the `--evidence` parser's colon-splitting semantics (changing it would be a separate contract change), and any composite typed transaction across doc-sync and progress writes.

## Version Impact

- Version: no version change — additive CLI behavior, no public API or package metadata change.
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: yes — `tools/write-road-registry.json`.
- Protected surface scope: one existing row. Registering the new CLI action as a `repo-write` action makes the write-road gate require a registry row covering it (`no write-road registry row covers daemon repo.command.run action artifact-add`). The response is a **declaration, not an exemption**: `artifact-add` is added to the `cliActions` of the **existing** `doc.sync.submit` row, with a selector and a single-entry intent compiler pointing at `buildArtifactIngestPlan`. No new road row is added, no exemption or test exclusion is introduced, and the action is not reclassified as read/admin to dodge the gate. The declaration is true precisely because the facade translates to the existing `repo.doc.sync.submit` — which is the shape the authorizing decision mandates.
- Authority: `dec_01KYEBBBQH57GNESDJ1EAEN1S0` (active) sets the discriminator (tracked source keeps a pointer; loose harness-internal artifacts are ingested), forbids opening a second write road, and defers binary support. Its 2026-07-26 amendment restates the atomicity invariant as "never a pointer without a file; an orphan artifact is acceptable", which is what this implementation follows. ADR-0016 R3 is why the governed commits carry the real actor as author.
- Reviewer nuance, disclosed rather than smoothed over: `progress-append` can also reach this road indirectly, through the same `buildArtifactIngestPlan` entry, when an evidence pointer names an ingestable artifact. Its own declared road remains `progress_append`, and the registry row's single-entry parity still holds because there is one ingress compiler; the row's `reviewWhen` clause is the tripwire if a second ingress compiler is ever registered for this intent.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: binary/CAS artifact ingestion needs its own decision and task before implementation.

## Verification

- Base `origin/main` SHA: `b248f61814ae9c243ed2eb87c9ef412a9ca21ef4`
- Branch merge-base with `origin/main`: `b248f61814ae9c243ed2eb87c9ef412a9ca21ef4`
- Last `git fetch origin` time: 2026-07-26, immediately before rebasing this branch
- Sync method: rebase onto `b248f618` (one trivial import conflict in `packages/cli/test/parse-args.test.ts`, resolved by keeping both fixtures; both are used)
- Public diff command: `git diff b248f61814ae9c243ed2eb87c9ef412a9ca21ef4..feat/evidence-artifact-ingest --`
- Private evidence commit/path: task package `task_01KYEBCHN5BHBHR6VMYHWDA9ZM` (`artifacts/preflight-doc-sync-proof.md`, `artifacts/implementation-report.md`)
- Reviewer evidence path: this PR body plus the task package
- GitHub Actions `rewrite-ci` run URL: https://github.com/FairladyZ625/harness-anything/actions?query=branch%3Afeat%2Fevidence-artifact-ingest
- [x] `git diff --check` — clean
- [x] `npm run check:stop-point` — passed after the rebase: 34 complete manifest gates green; affected fast tests 369 passed / 0 failed; affected contract tests 83 passed / 0 failed.
- [x] Targeted tests for the change surface, named with their counts: `packages/cli/test/artifact-ingest-plan.test.ts`, `packages/cli/test/doc-sync-cli.test.ts`, `packages/cli/test/parse-args.test.ts`, `packages/cli/test/conflict-preflight-cli.test.ts` — 202 pass / 0 fail.
- [x] Full `npm run test:contract` — 859 tests, 858 pass, 1 skipped, 0 fail; full `npm run test:integration` — 1310 tests, 1306 pass, 4 skipped, 0 fail. Run explicitly because the local stop-point gate does not cover those tiers, which is exactly how the first CI round went red.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending; this PR does not merge until it is green.
- Live acceptance run by the reviewer against the canonical ledger with the built CLI, not only unit tests:
  - Positive: a loose UTF-8 file under the repo was ingested to `tasks/<id>/artifacts/ceo-final-probe.md` (governed commit `7834c709b`) and `progress.md` recorded the rewritten ledger-internal pointer.
  - Negative: a git-tracked source path was not copied and kept its pointer.
  - Compatibility (this is what the first implementation broke): `pr:https://…`, `note:none:…`, a file outside the repository, and a binary file each still succeed and record the pointer verbatim, with a warning naming the skip reason.
  - Facade strictness: `ha task artifact add <task> <missing-path>` fails with `artifact_read_failed`.
  - Orphan path: one run hit `repo_write_outcome_unknown`; the artifact was committed and — as ground-truthed on disk — `progress.md` did contain the pointer. That run is exactly why the receipt now reports `"unknown"` instead of asserting the pointer was not written.
- Not run, and why: the full `npm run check:ci` set was not run locally; `rewrite-ci` is the authoritative full gate and the change surface is confined to one package.

## Review Evidence

- Self-review: reviewer re-ran the six live cases above against the canonical ledger after each worker round, rather than accepting the worker's test summary.
- Reviewer subagent: implementation by a Codex worker; two blocking findings were returned and fixed before this PR was opened — (1) ingestion had become a hard precondition of `--evidence`, breaking free-form pointers that the ledger uses everywhere; (2) the orphan receipt asserted "pointer was not written" even when the underlying outcome was unknown and the pointer had in fact been written.
- Human review: pending
- Blocking findings: the two above, plus a third round after the first CI run went red on four checks — three from the new action missing from exhaustive classification tables (invisible to the local gate, which does not run the contract/integration tiers), and one genuine Windows defect where a git-tracked source was misclassified as ingestable. All resolved and covered by tests, including a Windows-shape test that runs on POSIX.

## Residual Risk

- Binary and non-UTF-8 artifacts still have no ingest route; they degrade to free-form pointers and are rejected by the explicit facade.
- Destination-name collisions require the user to rename a source; there is no automatic disambiguation.
- Ingestion copies rather than moves; the original file stays where it was.
- Remote daemon mode cannot ingest a local untracked artifact and rejects before writing anything.
- The `--evidence` parser still splits on `:`, so a URL pointer's `path` field is the scheme fragment. Behavior is unchanged from today and the fallback handles it, but the field remains misleading until that contract is revisited.

## References

- Task: `task_01KYEBCHN5BHBHR6VMYHWDA9ZM`
- Evidence: task package artifacts; issue #1033 for the original report
- Review: pending

---

# 中文

## 概要

收口 #1033：把**已经存在**的治理化入库通道接到人真正会敲的命令上，并给它一个猜得到的名字。

issue 的命题是「没有治理化的既有文件入库通道」。在 `main` 上实测表明该前提已不成立：`ha doc sync --submit` 早就能把放进 `tasks/<id>/artifacts/` 的手写文件入库，台账里自 2026-07-13 起已有 **126 条**这样的治理提交、横跨 **43 个任务**。issue 佐证用的那个「0」，是按 daemon 身份过滤 commit 作者数出来的——而治理路径按 **ADR-0016 R3** 以**真实 actor** 作为作者（daemon 代提交但不冒名），该过滤恰好排除了全部治理化入库。

真正缺的东西更小也更具体：`task progress append --evidence` 只记指针、从不搬文件，指针从写下的第一天起就可能是悬空的；而真正能入库的那条路叫「doc sync」，找 artifact 命令的人根本猜不到。

## 改动内容

- `task progress append --evidence`：当指针指向仓内一份**未被版本控制**的 UTF-8 文件时，**先**经既有 doc-sync 通道把它入库到 `tasks/<id>/artifacts/`，成功后再追加进度，并把记录的指针改写成台账内路径。已被 git 跟踪的源码保持原指针，绝不复制。
- **入库是机会性的，永远不是前置条件**：指针指向 URL、非路径 token、仓外文件或二进制时，按原样记录、命令照常成功，回执带 warning 点明未入库原因并指出显式路径 `ha task artifact add`。
- 新增门面 `ha task artifact add <task-id> <path>...`，底层跑的就是同一条 doc-sync 通道（`runDocCommand`）——只是一个能被发现的名字，**不是第二条写路**。因为那里入库就是用户的明确意图，所以对文件不存在、仓外、二进制、目标同名冲突一律严格失败。
- 失败语义遵循授权决策：artifact 入库失败则在碰 `progress.md` 之前中止；progress 失败则保留已入库的 artifact，回执给 `pointerRecorded: false` 与重跑命令。当底层结果是 `repo_write_outcome_unknown` 时，回执给 `pointerRecorded: "unknown"` 并要求操作者**先检查 `progress.md`** 再决定是否重跑，而不是替不确定的事下确定的失败断言。
- remote daemon 模式在任何写入前明确拒绝本地未跟踪产物的入库；tracked 与自由指针不受影响。
- 为满足既有结构门做的配套拆分：`client-timing.ts`（文件复杂度）、独立 artifact parser、parse-case fixture。

未改动 `WriteOpKind`、授权信封、managed-section policy、write-road registry、CI 与门禁配置。diff 共 13 个文件，全部在 `packages/cli/**` 之下。

## 任务与范围

- Harness 任务：`task_01KYEBCHN5BHBHR6VMYHWDA9ZM`
- 分支：`feat/evidence-artifact-ingest`
- 公开范围：`packages/cli/**` 下的 evidence 入库计划、`task artifact add` 门面及其测试；新 action 的 daemon method-registry 分类；`tools/write-road-registry.json` 既有的一行。
- 私有计划/证据已更新：是（任务包内有 plan、mission、预检取证与实现报告）
- 不在范围内：二进制/CAS 入库（doc-sync 是 UTF-8 文本通道，授权决策明确另立）、`--evidence` parser 的冒号切分语义（改它是另一次契约变更）、跨 doc-sync 与 progress 的复合 typed transaction。

## 版本影响

- 版本：无变更——CLI 行为增量，无公开 API 或包元数据变更。
- 发布影响：不发布。

## 治理声明

- 触及受保护面：是 —— `tools/write-road-registry.json`。
- 受保护面范围：既有的一行。把新 CLI action 正确登记为 `repo-write` 之后，write-road 门要求它必须有对应的 registry 行（`no write-road registry row covers daemon repo.command.run action artifact-add`）。应对方式是**补声明、不是加豁免**：在**既有** `doc.sync.submit` 行的 `cliActions` 中加入 `artifact-add`，配 selector 与指向 `buildArtifactIngestPlan` 的单入口 intent compiler。没有新增 road 行、没有引入任何豁免或测试排除、也没有把该 action 重新归类成 read/admin 去躲门。这条声明之所以为真，正是因为该 facade 转译到既有的 `repo.doc.sync.submit`——而这恰是授权决策规定的形状。
- 授权：`dec_01KYEBBBQH57GNESDJ1EAEN1S0`（active）定了判别规则（tracked 源码留指针；harness 内部游离产物入库）、禁止新开第二条写路、二进制另立。其 2026-07-26 修订把原子性不变量重述为「永远不许指针记了文件没进；孤儿产物可接受」，本实现遵循的就是这条。ADR-0016 R3 解释了为何治理提交以真实 actor 为作者。
- 需要评审者注意、且如实披露而非抹平的一点：当 evidence 指针指向可入库产物时，`progress-append` 也会经**同一个** `buildArtifactIngestPlan` 入口间接走到这条路。它自身声明的写路仍是 `progress_append`；registry 行的 single-entry parity 依然成立，因为 ingress compiler 只有一个；该行的 `reviewWhen` 条款就是「若将来为该 intent 登记第二个 ingress compiler」的绊线。
- 机器检查边界：本 PR 只断言声明存在；声明是否为真、是否充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：二进制/CAS 入库需先立独立决策与任务再实现。

## 验证

- 基线 `origin/main` SHA：`b248f61814ae9c243ed2eb87c9ef412a9ca21ef4`
- 分支与 `origin/main` 的 merge-base：`b248f61814ae9c243ed2eb87c9ef412a9ca21ef4`
- 最后一次 `git fetch origin` 时间：2026-07-26，紧接着 rebase 本分支
- 同步方式：rebase 到 `b248f618`（`packages/cli/test/parse-args.test.ts` 有一处 import 平凡冲突，保留双方 fixture 解决，两者都在用）
- 公开 diff 命令：`git diff b248f61814ae9c243ed2eb87c9ef412a9ca21ef4..feat/evidence-artifact-ingest --`
- 私有证据 commit/路径：任务包 `task_01KYEBCHN5BHBHR6VMYHWDA9ZM`（`artifacts/preflight-doc-sync-proof.md`、`artifacts/implementation-report.md`）
- 评审证据路径：本 PR 正文与该任务包
- GitHub Actions `rewrite-ci` run URL：https://github.com/FairladyZ625/harness-anything/actions?query=branch%3Afeat%2Fevidence-artifact-ingest
- [x] `git diff --check` —— 干净
- [x] `npm run check:stop-point` —— rebase 之后复跑通过：34 个完整 manifest 门全绿；受影响 fast 测试 369 通过 / 0 失败；contract 测试 83 通过 / 0 失败。
- [x] 针对改动面的定向测试及计数：`packages/cli/test/artifact-ingest-plan.test.ts`、`packages/cli/test/doc-sync-cli.test.ts`、`packages/cli/test/parse-args.test.ts`、`packages/cli/test/conflict-preflight-cli.test.ts` —— 202 通过 / 0 失败。
- [x] 完整 `npm run test:contract` —— 859 tests，858 通过 / 1 跳过 / 0 失败；完整 `npm run test:integration` —— 1310 tests，1306 通过 / 4 跳过 / 0 失败。显式跑这两组，是因为本地停止点门不覆盖这两个 tier——第一轮 CI 变红正是这么来的。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）—— 待跑；未绿不合。
- 评审者用构建后的 CLI 对 canonical 台账做的实跑验收（不只看单测）：
  - 阳性：仓内一份游离 UTF-8 文件被入库到 `tasks/<id>/artifacts/ceo-final-probe.md`（治理提交 `7834c709b`），`progress.md` 记录的是改写后的台账内指针。
  - 阴性：git 跟踪的源码路径未被复制，保持原指针。
  - 兼容性（第一版实现正是在这里翻的车）：`pr:https://…`、`note:none:…`、仓外文件、二进制文件四种输入均照常成功、指针原样记录，并带 warning 说明未入库原因。
  - 门面严格度：`ha task artifact add <task> <不存在的路径>` 以 `artifact_read_failed` 失败。
  - 孤儿路径：有一次实跑命中 `repo_write_outcome_unknown`，artifact 已提交，而**查磁盘可见** `progress.md` 其实已含该指针——这次实跑正是回执改为报 `"unknown"`、不再断言「指针未写入」的直接原因。
- 未跑及原因：本地未跑完整 `npm run check:ci`；`rewrite-ci` 是权威全量门，且改动面收敛在单个包内。

## 审查证据

- 自评：评审者在 worker 每一轮之后，都用构建后的 CLI 对 canonical 台账重跑上述六条实例，而不是采信 worker 的测试汇总。
- 子代理评审：实现由 Codex worker 完成；本 PR 开出之前退回并修复了两条阻塞级发现——（1）入库变成了 `--evidence` 的硬前置条件，破坏了台账里到处在用的自由指针；（2）孤儿回执在底层结果未知、且指针其实已写入的情况下，仍断言「指针未写入」。
- 人工评审：待办
- 阻断性发现：以上两条，外加第一轮 CI 变红后的第三轮——四条红中三条源于新 action 未登记进穷尽分类表（本地门不跑 contract/integration tier，因此照不到），一条是真实的 Windows 缺陷：git 跟踪的源码被误判成可入库。全部修复并有测试覆盖，其中 Windows 形状用例在 POSIX 上即可执行。

## 残余风险

- 二进制与非 UTF-8 产物仍无入库路径；它们降级为自由指针，显式门面会拒绝。
- 目标同名冲突需要用户自行重命名来源，没有自动消歧。
- 入库是复制不是移动，原文件留在原处。
- remote daemon 模式无法入库本地未跟踪产物，会在写入前拒绝。
- `--evidence` parser 仍按 `:` 切分，URL 型指针的 `path` 字段是 scheme 片段。行为与今天一致且兜底能吃下，但在该契约被重新审视之前，这个字段仍具误导性。

## 关联材料

- 任务：`task_01KYEBCHN5BHBHR6VMYHWDA9ZM`
- 证据：任务包 artifacts；原始报告见 issue #1033
- 审查：待办
