### PR TITLE
fix(cli): make terminal pty optional so toolchain-free machines can install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9335,7 +9335,8 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-api-version": {
       "version": "0.2.1",
@@ -9446,6 +9447,7 @@
       "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "node-addon-api": "^7.1.0"
       }
@@ -13238,7 +13240,9 @@
         "@harness-anything/adapter-local": "0.1.0",
         "@harness-anything/api-contracts": "0.1.0",
         "@harness-anything/application": "0.1.0",
-        "@harness-anything/kernel": "0.1.0",
+        "@harness-anything/kernel": "0.1.0"
+      },
+      "optionalDependencies": {
         "node-pty": "^1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "harness:check-catalog-schema": "node tools/check-catalog-schema.mjs",
     "harness:check-runtime-release-readiness": "node tools/check-runtime-release-readiness.mjs",
     "harness:check-package-policy": "node tools/check-package-policy.mjs",
+    "harness:check-cli-installability": "node tools/check-cli-installability.mjs",
     "harness:check-implementation-contracts": "node tools/check-implementation-contracts.mjs",
     "harness:check-service-mappability": "node tools/check-service-mappability.mjs",
     "harness:check-api-contract-registry": "node tools/check-api-contract-registry.mjs",

--- a/packages/cli/src/commands/daemon/snapshot.ts
+++ b/packages/cli/src/commands/daemon/snapshot.ts
@@ -213,7 +213,7 @@ function removeRepositoryBuildWorktree(repositoryRoot: string, buildRoot: string
 
 function copyRuntimeDependencyClosure(dependencyRoot: string, staging: string): ReadonlyArray<string> {
   const packageNames = new Set<string>();
-  const pending = externalWorkspaceDependencies(dependencyRoot).map((name) => ({ name, optional: false }));
+  const pending = externalWorkspaceDependencies(dependencyRoot);
   while (pending.length > 0) {
     const { name: packageName, optional } = pending.pop()!;
     if (packageNames.has(packageName) || packageName.startsWith("@harness-anything/")) continue;
@@ -243,8 +243,8 @@ function copyRuntimeDependencyClosure(dependencyRoot: string, staging: string): 
   return [...packageNames].sort();
 }
 
-function externalWorkspaceDependencies(repositoryRoot: string): string[] {
-  const dependencies = new Set<string>();
+function externalWorkspaceDependencies(repositoryRoot: string): Array<{ readonly name: string; readonly optional: boolean }> {
+  const dependencies = new Map<string, boolean>();
   const installedPackagePath = path.join(repositoryRoot, "package.json");
   if (existsSync(installedPackagePath) && !existsSync(path.join(repositoryRoot, "packages"))) {
     addPackageDependencies(installedPackagePath, dependencies);
@@ -254,17 +254,22 @@ function externalWorkspaceDependencies(repositoryRoot: string): string[] {
     if (!existsSync(packagePath)) continue;
     addPackageDependencies(packagePath, dependencies);
   }
-  dependencies.add("node-pty");
-  return [...dependencies];
+  return [...dependencies]
+    .map(([name, optional]) => ({ name, optional }))
+    .sort((left, right) => left.name.localeCompare(right.name));
 }
 
-function addPackageDependencies(packagePath: string, dependencies: Set<string>): void {
+function addPackageDependencies(packagePath: string, dependencies: Map<string, boolean>): void {
   const packageJson = JSON.parse(readFileSync(packagePath, "utf8")) as {
     readonly dependencies?: Record<string, string>;
     readonly optionalDependencies?: Record<string, string>;
   };
-  for (const name of [...Object.keys(packageJson.dependencies ?? {}), ...Object.keys(packageJson.optionalDependencies ?? {})]) {
-    if (!name.startsWith("@harness-anything/")) dependencies.add(name);
+  const optionalNames = new Set(Object.keys(packageJson.optionalDependencies ?? {}));
+  const names = new Set([...Object.keys(packageJson.dependencies ?? {}), ...optionalNames]);
+  for (const name of names) {
+    if (name.startsWith("@harness-anything/")) continue;
+    const optional = optionalNames.has(name);
+    dependencies.set(name, (dependencies.get(name) ?? true) && optional);
   }
 }
 

--- a/packages/cli/test/daemon-snapshot.test.ts
+++ b/packages/cli/test/daemon-snapshot.test.ts
@@ -13,7 +13,11 @@ test("daemon snapshot installation is idempotent and remains independent from mu
   const sourceEntrypoint = path.join(packageRoot, "dist", "cli", "src", "index.js");
   const userRoot = path.join(root, "user");
   mkdirSync(path.dirname(sourceEntrypoint), { recursive: true });
-  writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({ name: "harness-anything", dependencies: {} }));
+  writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({
+    name: "harness-anything",
+    dependencies: {},
+    optionalDependencies: { "node-pty": "1.0.0" }
+  }));
   writeFileSync(sourceEntrypoint, "export const daemonVersion = 'snapshot-v1';\n");
   const nodePtyRoot = path.join(packageRoot, "node_modules", "node-pty");
   mkdirSync(nodePtyRoot, { recursive: true });
@@ -38,6 +42,7 @@ test("daemon snapshot installation is idempotent and remains independent from mu
     assert.equal(second.snapshotDir, first.snapshotDir);
     assert.deepEqual(second.manifest, first.manifest);
     assert.equal(first.manifest.builtAt, "2026-07-22T01:02:03.000Z");
+    assert.equal(first.manifest.runtimePackages.includes("node-pty"), true);
     assert.equal(calculateDaemonArtifactIdentity(first.entrypoint).identity, first.manifest.contentFingerprint);
 
     writeFileSync(sourceEntrypoint, "export const daemonVersion = 'mutable-dist-v2';\n");
@@ -49,6 +54,32 @@ test("daemon snapshot installation is idempotent and remains independent from mu
       () => installDaemonSnapshot({ sourceEntrypoint, userRoot, version: "release-1" }),
       /snapshot version already belongs to different source bytes/u
     );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("daemon snapshot installation skips an unavailable optional runtime dependency", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-daemon-snapshot-optional-test-"));
+  const packageRoot = path.join(root, "package");
+  const sourceEntrypoint = path.join(packageRoot, "dist", "cli", "src", "index.js");
+  const userRoot = path.join(root, "user");
+  mkdirSync(path.dirname(sourceEntrypoint), { recursive: true });
+  writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({
+    name: "harness-anything",
+    dependencies: {},
+    optionalDependencies: { "node-pty": "1.0.0" }
+  }));
+  writeFileSync(sourceEntrypoint, "export const daemonVersion = 'snapshot-without-pty';\n");
+
+  try {
+    const installed = installDaemonSnapshot({
+      sourceEntrypoint,
+      userRoot,
+      version: "release-without-pty"
+    });
+    assert.equal(installed.installed, true);
+    assert.equal(installed.manifest.runtimePackages.includes("node-pty"), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -13,7 +13,9 @@
     "@harness-anything/adapter-local": "0.1.0",
     "@harness-anything/api-contracts": "0.1.0",
     "@harness-anything/application": "0.1.0",
-    "@harness-anything/kernel": "0.1.0",
+    "@harness-anything/kernel": "0.1.0"
+  },
+  "optionalDependencies": {
     "node-pty": "^1.1.0"
   }
 }

--- a/packages/daemon/src/terminal/pty-host.ts
+++ b/packages/daemon/src/terminal/pty-host.ts
@@ -31,6 +31,7 @@ export interface PtySpawnOptions {
 }
 
 export type PtySpawner = (shell: string, args: ReadonlyArray<string>, options: PtySpawnOptions) => IPty;
+export type NodePtyLoader = () => Pick<typeof import("node-pty"), "spawn">;
 
 export interface TmuxController {
   readonly probe: () => { readonly available: boolean; readonly executable?: string; readonly version?: string; readonly reason?: string };
@@ -41,6 +42,7 @@ export interface TmuxController {
 export interface PtyTerminalSessionServiceOptions {
   readonly workspaceRoot: string;
   readonly spawnPty?: PtySpawner;
+  readonly loadNodePty?: NodePtyLoader;
   readonly now?: () => string;
   readonly createId?: () => string;
   readonly env?: NodeJS.ProcessEnv;
@@ -70,7 +72,7 @@ export function createPtyTerminalSessionService(options: PtyTerminalSessionServi
   const env = options.env ?? process.env;
   const outputMaxBytes = Math.max(1, options.outputMaxBytes ?? defaultOutputMaxBytes);
   const defaultReadTimeoutMs = options.defaultReadTimeoutMs ?? 250;
-  const spawnPty = options.spawnPty ?? nodePtySpawner;
+  const spawnPty = options.spawnPty ?? createNodePtySpawner(options.loadNodePty ?? loadNodePty, platform);
   const tmux = options.tmux ?? (options.spawnPty ? unavailableTmuxController : systemTmuxController);
   const tmuxProbe = tmux.probe();
   const tmuxAvailable = tmuxProbe.available && Boolean(tmuxProbe.executable);
@@ -101,8 +103,6 @@ export function createPtyTerminalSessionService(options: PtyTerminalSessionServi
       outputBySession.set(session.sessionId, createOutputState());
     }
   }
-
-  if (!options.spawnPty) ensureNodePtySpawnHelperExecutable(platform);
 
   function createSession(payload: CreateTerminalSessionPayload): TerminalSessionDetailResult {
     let cwd: string;
@@ -140,6 +140,9 @@ export function createPtyTerminalSessionService(options: PtyTerminalSessionServi
     } catch (error) {
       outputBySession.delete(sessionId);
       registry.markSessionExited({ sessionId, exitCode: 1 });
+      if (error instanceof NodePtyUnavailableError) {
+        return terminalFailure("terminal_pty_unavailable", error.message);
+      }
       return terminalFailure("terminal_spawn_failed", `Unable to spawn terminal shell: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
@@ -408,18 +411,45 @@ export function resolveTerminalShell(
   throw new Error("No executable terminal shell was found.");
 }
 
-function nodePtySpawner(shell: string, args: ReadonlyArray<string>, options: PtySpawnOptions): IPty {
-  // Lazy-load node-pty so merely importing this module (e.g. the packaged CLI's
-  // `gui` command) does not require the native dependency; it is only needed
-  // when a terminal is actually spawned (daemon runtime).
-  const { spawn: spawnNodePty } = createRequire(import.meta.url)("node-pty") as typeof import("node-pty");
-  return spawnNodePty(shell, [...args], {
-    name: options.name,
-    cols: options.columns,
-    rows: options.rows,
-    cwd: options.cwd,
-    env: options.env
-  });
+class NodePtyUnavailableError extends Error {
+  constructor(cause: unknown) {
+    super(
+      "Embedded terminal unavailable: node-pty is not installed or could not load its native binary. " +
+      "All non-terminal CLI and daemon features remain available. To enable the embedded terminal, " +
+      "install Python 3, make, and a C++ compiler, then reinstall @harness-anything/cli with optional dependencies enabled.",
+      { cause }
+    );
+    this.name = "NodePtyUnavailableError";
+  }
+}
+
+function loadNodePty(): Pick<typeof import("node-pty"), "spawn"> {
+  try {
+    return createRequire(import.meta.url)("node-pty") as Pick<typeof import("node-pty"), "spawn">;
+  } catch (error) {
+    throw new NodePtyUnavailableError(error);
+  }
+}
+
+function createNodePtySpawner(load: NodePtyLoader, platform: NodeJS.Platform): PtySpawner {
+  let loaded: ReturnType<NodePtyLoader> | undefined;
+  return (shell, args, options) => {
+    try {
+      loaded ??= load();
+      ensureNodePtySpawnHelperExecutable(platform);
+      return loaded.spawn(shell, [...args], {
+        name: options.name,
+        cols: options.columns,
+        rows: options.rows,
+        cwd: options.cwd,
+        env: options.env
+      });
+    } catch (error) {
+      if (error instanceof NodePtyUnavailableError) throw error;
+      if (loaded === undefined) throw new NodePtyUnavailableError(error);
+      throw error;
+    }
+  };
 }
 
 function terminalEnvironment(source: NodeJS.ProcessEnv, cwd: string): Record<string, string> {

--- a/packages/daemon/test/pty-host.test.ts
+++ b/packages/daemon/test/pty-host.test.ts
@@ -55,6 +55,39 @@ test("pty host spawns at the project root and streams input output resize and ex
   }
 });
 
+test("missing optional node-pty leaves daemon usable and returns an actionable terminal failure", () => {
+  const workspaceRoot = mkdtempSync(path.join(tmpdir(), "ha-pty-optional-"));
+  let loadCalls = 0;
+  try {
+    const service = createPtyTerminalSessionService({
+      workspaceRoot,
+      createId: () => "term-unavailable",
+      loadNodePty: () => {
+        loadCalls += 1;
+        throw Object.assign(new Error("Cannot find module 'node-pty'"), { code: "MODULE_NOT_FOUND" });
+      }
+    });
+
+    assert.equal(loadCalls, 0);
+    assert.deepEqual(service.listSessions(), { ok: true, sessions: [] });
+
+    const created = service.createSession({
+      name: "Unavailable terminal",
+      backend: "direct-pty",
+      shell: process.execPath
+    });
+    assert.equal(loadCalls, 1);
+    assert.equal(created.ok, false);
+    if (created.ok) return;
+    assert.equal(created.error.code, "terminal_pty_unavailable");
+    assert.match(created.error.hint, /node-pty is not installed or could not load its native binary/u);
+    assert.match(created.error.hint, /All non-terminal CLI and daemon features remain available/u);
+    assert.match(created.error.hint, /Python 3, make, and a C\+\+ compiler/u);
+  } finally {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
 test("daemon registry restores a durable tmux session and reattaches without respawn-as-resume", () => {
   const workspaceRoot = mkdtempSync(path.join(tmpdir(), "ha-tmux-host-"));
   const namespaceState = new Set<string>();

--- a/tools/check-cli-installability.mjs
+++ b/tools/check-cli-installability.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const cliBuildConfigPath = "packages/cli/tsconfig.build.json";
+const bundledPrebuildPlatforms = ["linux-x64", "linux-arm64"];
+const fetchedPrebuildInstallers = [
+  /\bprebuild-install\b/u,
+  /\bnode-pre-gyp\b/u,
+  /\bnode-gyp-build(?:-optional-packages)?\b/u
+];
+
+export function checkCliInstallability(root = process.cwd()) {
+  const violations = [];
+  const checked = new Set();
+  const prebuildBackedNativePackages = new Set();
+  const pending = runtimeWorkspaceRoots(root).flatMap((workspaceRoot) =>
+    requiredDependencyEntries(readJson(path.join(root, workspaceRoot, "package.json")))
+      .filter(([name]) => !name.startsWith("@harness-anything/"))
+      .map(([name]) => ({ name, dependencyRoot: path.join(root, workspaceRoot), chain: [workspaceRoot, name] }))
+  );
+
+  while (pending.length > 0) {
+    const request = pending.pop();
+    const packageRoot = resolveDependencyPackage(request.dependencyRoot, request.name);
+    if (!packageRoot) {
+      violations.push(`${request.chain.join(" -> ")}: required runtime dependency is not installed`);
+      continue;
+    }
+    const canonicalRoot = realpathSync(packageRoot);
+    if (checked.has(canonicalRoot)) continue;
+    checked.add(canonicalRoot);
+
+    const manifest = readJson(path.join(canonicalRoot, "package.json"));
+    const nativeRisk = nativeInstallRisk(canonicalRoot, manifest);
+    if (nativeRisk.kind === "compile-required") {
+      violations.push(`${request.chain.join(" -> ")}: ${nativeRisk.reason}; move the capability behind optionalDependencies`);
+    } else if (nativeRisk.kind === "prebuild-backed") {
+      prebuildBackedNativePackages.add(`${manifest.name}@${manifest.version}`);
+    }
+
+    for (const [name] of requiredDependencyEntries(manifest)) {
+      pending.push({ name, dependencyRoot: canonicalRoot, chain: [...request.chain, name] });
+    }
+  }
+
+  return {
+    ok: violations.length === 0,
+    violations,
+    checkedPackageCount: checked.size,
+    prebuildBackedNativePackages: [...prebuildBackedNativePackages].sort()
+  };
+}
+
+function runtimeWorkspaceRoots(root) {
+  const config = readJson(path.join(root, cliBuildConfigPath));
+  const roots = new Set(["packages/cli"]);
+  for (const include of config.include ?? []) {
+    const match = /^\.\.\/([^/]+)(?:\/([^/]+))?\/src\/\*\*\/\*\.ts$/u.exec(include);
+    if (!match) continue;
+    roots.add(match[2] ? `packages/${match[1]}/${match[2]}` : `packages/${match[1]}`);
+  }
+  return [...roots].sort();
+}
+
+function requiredDependencyEntries(manifest) {
+  const optional = new Set(Object.keys(manifest.optionalDependencies ?? {}));
+  return Object.entries(manifest.dependencies ?? {}).filter(([name]) => !optional.has(name));
+}
+
+function resolveDependencyPackage(start, packageName) {
+  let current = start;
+  while (true) {
+    const candidate = path.join(current, "node_modules", ...packageName.split("/"));
+    if (existsSync(path.join(candidate, "package.json"))) return candidate;
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function nativeInstallRisk(packageRoot, manifest) {
+  const install = String(manifest.scripts?.install ?? "");
+  const hasBindingGyp = existsSync(path.join(packageRoot, "binding.gyp")) || manifest.gypfile === true;
+  const invokesLocalCompiler = /\bnode-gyp\b/u.test(install) || (hasBindingGyp && install === "" && manifest.gypfile !== false);
+  if (!hasBindingGyp && !invokesLocalCompiler) return { kind: "not-native" };
+
+  if (fetchedPrebuildInstallers.some((pattern) => pattern.test(install))) {
+    return { kind: "prebuild-backed" };
+  }
+
+  if (/\bprebuilds?\b/u.test(install)) {
+    const missing = bundledPrebuildPlatforms.filter((platform) =>
+      !existsSync(path.join(packageRoot, "prebuilds", platform))
+    );
+    if (missing.length === 0) return { kind: "prebuild-backed" };
+    return {
+      kind: "compile-required",
+      reason: `${manifest.name}@${manifest.version} has a native install script but no bundled prebuild for ${missing.join(", ")}`
+    };
+  }
+
+  return {
+    kind: "compile-required",
+    reason: `${manifest.name}@${manifest.version} requires local native compilation during install`
+  };
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, "utf8"));
+}
+
+function main() {
+  const result = checkCliInstallability();
+  if (!result.ok) {
+    console.error("CLI installability check failed:");
+    for (const violation of result.violations) console.error(`- ${violation}`);
+    process.exitCode = 1;
+    return;
+  }
+  const prebuildSummary = result.prebuildBackedNativePackages.length > 0
+    ? `; prebuild-backed native packages: ${result.prebuildBackedNativePackages.join(", ")}`
+    : "";
+  console.log(`CLI installability check passed (${result.checkedPackageCount} required runtime package(s)${prebuildSummary}).`);
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/tools/check-cli-installability.test.mjs
+++ b/tools/check-cli-installability.test.mjs
@@ -1,0 +1,83 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { checkCliInstallability } from "./check-cli-installability.mjs";
+
+test("CLI installability accepts a native terminal dependency only when it is optional", () => {
+  const root = installabilityFixture({ nodePtyOptional: true });
+  try {
+    const result = checkCliInstallability(root);
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.violations, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("CLI installability rejects node-pty when it becomes a required daemon dependency", () => {
+  const root = installabilityFixture({ nodePtyOptional: false });
+  try {
+    const result = checkCliInstallability(root);
+    assert.equal(result.ok, false);
+    assert.deepEqual(result.violations, [
+      "packages/daemon -> node-pty: node-pty@1.1.0 has a native install script but no bundled prebuild for linux-x64, linux-arm64; move the capability behind optionalDependencies"
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("CLI installability records prebuild-backed native packages without requiring a compiler", () => {
+  const root = installabilityFixture({ nodePtyOptional: true, includePrebuildBacked: true });
+  try {
+    const result = checkCliInstallability(root);
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.prebuildBackedNativePackages, ["better-sqlite3@12.11.1"]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function installabilityFixture(options) {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-cli-installability-"));
+  writeJson(root, "packages/cli/tsconfig.build.json", {
+    include: ["src/**/*.ts", "../daemon/src/**/*.ts"]
+  });
+  writeJson(root, "packages/cli/package.json", {
+    name: "@harness-anything/cli",
+    dependencies: options.includePrebuildBacked ? { "better-sqlite3": "12.11.1" } : {}
+  });
+  writeJson(root, "packages/daemon/package.json", {
+    name: "@harness-anything/daemon",
+    dependencies: options.nodePtyOptional ? {} : { "node-pty": "1.1.0" },
+    optionalDependencies: options.nodePtyOptional ? { "node-pty": "1.1.0" } : {}
+  });
+  writeJson(root, "node_modules/node-pty/package.json", {
+    name: "node-pty",
+    version: "1.1.0",
+    scripts: { install: "node scripts/prebuild.js || node-gyp rebuild" }
+  });
+  writeFile(root, "node_modules/node-pty/binding.gyp", "{}\n");
+  if (options.includePrebuildBacked) {
+    writeJson(root, "node_modules/better-sqlite3/package.json", {
+      name: "better-sqlite3",
+      version: "12.11.1",
+      scripts: { install: "prebuild-install || node-gyp rebuild --release" }
+    });
+    writeFile(root, "node_modules/better-sqlite3/binding.gyp", "{}\n");
+  }
+  return root;
+}
+
+function writeJson(root, relativePath, value) {
+  writeFile(root, relativePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeFile(root, relativePath, body) {
+  const file = path.join(root, relativePath);
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, body);
+}

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -107,6 +107,7 @@
         "check-catalog-schema",
         "check-runtime-release-readiness",
         "check-package-policy",
+        "check-cli-installability",
         "check-implementation-contracts",
         "check-service-mappability",
         "check-api-contract-registry",
@@ -157,6 +158,7 @@
         "check-catalog-schema",
         "check-runtime-release-readiness",
         "check-package-policy",
+        "check-cli-installability",
         "check-implementation-contracts",
         "check-service-mappability",
         "check-api-contract-registry",
@@ -211,6 +213,7 @@
         "check-catalog-schema",
         "check-runtime-release-readiness",
         "check-package-policy",
+        "check-cli-installability",
         "check-implementation-contracts",
         "check-service-mappability",
         "check-api-contract-registry",
@@ -220,7 +223,7 @@
         "check-stage0-manifest",
         "check-supply-chain"
       ],
-      "harnessLeafGateCount": 48
+      "harnessLeafGateCount": 49
     },
     "rewriteCi": {
       "pullRequestGateJobs": [
@@ -4134,6 +4137,84 @@
         "status": "documented-gap",
         "evidence": [
           "No dedicated positive-control fixture is registered for check-package-policy."
+        ]
+      }
+    },
+    {
+      "id": "check-cli-installability",
+      "command": "npm run harness:check-cli-installability",
+      "category": "boundary",
+      "tier": "pr-required",
+      "tierReason": null,
+      "authoritySource": [
+        "docs-release/constitution/stage0.md#8",
+        "harness/governance/standards/ci-cd-standard.md#local-distribution-and-release",
+        "packages/cli/tsconfig.build.json",
+        "packages/*/package.json",
+        "package-lock.json"
+      ],
+      "consumerScope": [
+        "@harness-anything/cli bundled runtime dependency closure and zero-toolchain installability"
+      ],
+      "githubContext": {
+        "requiredContexts": [
+          "package-policy"
+        ],
+        "workflowJobs": [
+          "package-policy"
+        ],
+        "nodeVersions": [
+          24
+        ]
+      },
+      "allowlistPolicy": {
+        "allowed": false,
+        "location": null,
+        "adrOrDecisionRequired": false,
+        "notes": "Required native dependencies without Linux x64 and arm64 prebuild delivery fail closed; capability-specific native modules must be optional."
+      },
+      "changeControl": {
+        "ordinaryImplementationMayModify": false,
+        "requiresGovernanceEvidence": true,
+        "protectedSurfaces": [
+          "tools/check-cli-installability.mjs",
+          "tools/check-cli-installability.test.mjs",
+          "package.json:scripts.harness:check-cli-installability",
+          "packages/cli/tsconfig.build.json",
+          "packages/*/package.json",
+          "package-lock.json",
+          "tools/gate-manifest.json"
+        ]
+      },
+      "bypassFixtureRequired": true,
+      "executionSurfaces": {
+        "packageJson": {
+          "check": true,
+          "checkPr": true,
+          "script": "harness:check-cli-installability"
+        },
+        "rewriteCi": {
+          "pullRequestJobs": [
+            "package-policy"
+          ],
+          "nonPullRequestJobs": []
+        },
+        "branchProtection": {
+          "required": true,
+          "contexts": [
+            "package-policy"
+          ]
+        },
+        "classes": [
+          "local",
+          "pr"
+        ]
+      },
+      "deterministic": true,
+      "positiveControl": {
+        "status": "covered",
+        "evidence": [
+          "tools/check-cli-installability.test.mjs"
         ]
       }
     },


### PR DESCRIPTION
# English

## Summary

The first wall a stranger hits is not a gate — it is `npm install`. `node-pty` sat in `dependencies` and requires a native `node-gyp` build, so on any machine without a C++ toolchain the CLI could not be installed at all. This PR moves the terminal capability behind `optionalDependencies`, makes it load lazily with an actionable degradation message, and adds a mechanical gate so the class cannot silently regress.

## What Changed

- `node-pty` moved from `dependencies` to `optionalDependencies`; `package-lock.json` node marked optional accordingly.
- `pty-host` loads `node-pty` lazily and caches the handle; the spawn-helper `chmod` probe moved from service construction into the spawn path, so constructing the terminal service no longer requires the native module to exist.
- Missing/broken native module now returns a dedicated `terminal_pty_unavailable` code with a message that states plainly that all non-terminal CLI and daemon features remain available, plus what to install to enable the embedded terminal.
- Daemon snapshot preserves optional-dependency semantics instead of copying `node-pty` as a required dependency.
- New gate `check-cli-installability` derives the CLI's required runtime closure from the actual bundled workspace and rejects any required native module without Linux x64/arm64 prebuilds. Registered in `tools/gate-manifest.json`, the package-policy PR job, and the local stop point.
- Cold-start image now packs on the host and copies only the tarball plus public docs, instead of copying the source tree into the container to run `npm pack` there.

## Task And Scope

- Harness task: `task_01KYEMKNJKH6Y2B7FQY3PCKJ2W`
- Branch: `codex/wall0-installability`
- Public scope: terminal pty loading, daemon snapshot, CLI installability gate, cold-start image build script
- Private planning/evidence updated: yes
- Out of scope: `better-sqlite3` and the rest of the native-dependency family (recorded below as residual risk, routed to a separate decision)

## Version Impact

- Version: no version change because this is a dependency-classification and gate change with no published surface change
- Publish impact: publish readiness only — it makes installation possible on toolchain-free machines

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gate-manifest.json` (registers one new gate, `check-cli-installability`)
- Authority: M7 metabolism milestone, task `task_01KYEMKNJKH6Y2B7FQY3PCKJ2W`. The gate itself is listed as an open adjudication item (A2) for the project owner; the repair is independent of it.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: owner adjudication on whether "peripheral capability must not become a core hard dependency" becomes a standing gate

## Verification

- Base `origin/main` SHA: `51107ac8`
- Branch merge-base with `origin/main`: `51107ac8`
- Last `git fetch origin` time: 2026-07-27, immediately before opening this PR
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: cold-start run archive `2026-07-26-wall0-r6` and the wall0 installability report, both under the private ledger
- Reviewer evidence path: same run archive
- GitHub Actions `rewrite-ci` run URL: pending — this PR has just been opened
- [x] `git diff --check`
- [x] `npm run check:stop-point` — passed in 363.4s, 37 complete manifest gates green
- [x] Targeted tests for the change surface, named with their counts: `packages/daemon/test/pty-host.test.ts` + `packages/cli/test/daemon-snapshot.test.ts` 12/12 pass; `tools/check-cli-installability.test.mjs` 3/3 pass
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: `rewrite-ci` has not run yet because the PR is being opened by this change; merge waits on it. Four cold-start scenarios were executed and all four are recorded as FAIL against their oracle — the installability wall is gone, but later walls remain and were deliberately not repaired in this PR.

## Review Evidence

- Self-review: CEO re-ran the image purity check independently rather than trusting the report — inside the built image, `ha --version` works, `require("node-pty")` returns `MODULE_NOT_FOUND`, and `g++`/`c++`/`make`/`gcc` are all absent. That combination is the actual claim: the CLI installs and runs with no C++ toolchain present.
- Reviewer subagent: gate positive control verified by reading the test — the gate is asserted red (with its exact violation message) when `node-pty` is moved back into `dependencies`, not merely green on the passing path.
- Human review: pending
- Blocking findings: none

## Residual Risk

- `better-sqlite3` remains a required dependency whose install script falls back to `node-gyp`. This was empirically hit during this work: a single TLS drop while fetching its prebuilt binary caused a fallback to local compilation, which then failed because the image deliberately has no `make`. Prebuild-backed is therefore not a zero-toolchain guarantee — it is a dependency on a third-party CDN staying reachable.
- The new gate reasons statically over package manifests, install scripts, and the installed dependency tree. It can stop an explicit required-native-compile regression; it cannot prove a third-party prebuild CDN stays online, nor validate remote assets across every Node ABI.
- npm allows core installation to continue when an optional dependency fails, possibly with a warning; what was verified here is that non-terminal CLI/daemon paths work when `node-pty` is absent.

## References

- Task: `task_01KYEMKNJKH6Y2B7FQY3PCKJ2W`
- Evidence: cold-start run archive `2026-07-26-wall0-r6` (four scenarios, image build log, leak check)
- Review: CEO acceptance recorded in the M7 pending-adjudication ledger

---

# 中文

## 概要

陌生人撞上的第一堵墙不是某道门，而是 `npm install`。`node-pty` 挂在 `dependencies` 里且需要 `node-gyp` 原生编译，因此**任何没有 C++ 工具链的机器根本装不上这个 CLI**。本 PR 把终端能力挪到 `optionalDependencies`，改为惰性加载并给出可操作的降级说明，同时加一道机械门，防止这一类缺陷再静默复发。

## 改动内容

- `node-pty` 从 `dependencies` 移入 `optionalDependencies`，`package-lock.json` 对应节点标记为 optional。
- `pty-host` 改为惰性加载 `node-pty` 并缓存句柄；spawn helper 的 `chmod` 探测从服务构造期移到 spawn 路径——构造终端服务不再要求原生模块存在。
- 原生模块缺失或损坏时返回专用错误码 `terminal_pty_unavailable`，消息明确说明「所有非终端的 CLI 与 daemon 功能仍然可用」，以及要装什么才能启用内嵌终端。
- daemon snapshot 保留 optional 依赖语义，不再把 `node-pty` 当必需依赖复制。
- 新增门 `check-cli-installability`：从 CLI build 的实际 bundled workspace 反推必需运行时闭包，拒绝任何没有 Linux x64/arm64 预构建的必需原生模块。已注册进 `tools/gate-manifest.json`、package-policy PR job 与本地停止点。
- 冷启动镜像改为宿主机 pack、容器只拷 tarball 与公开文档，不再把源码树拷进容器里执行 `npm pack`。

## 任务与范围

- Harness 任务：`task_01KYEMKNJKH6Y2B7FQY3PCKJ2W`
- 分支：`codex/wall0-installability`
- 公开范围：终端 pty 加载、daemon snapshot、CLI 可安装性门、冷启动镜像构建脚本
- 私有计划 / 证据是否已更新：yes
- 范围外：`better-sqlite3` 及其余原生依赖family（列入下方残余风险，另走决策）

## 版本影响

- 版本：不改版本，原因是这是依赖分类与门的改动，没有改变已发布接口
- 发布影响：只做发布准备——它让「无工具链机器装得上」成为可能

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`tools/gate-manifest.json`（新增一道门 `check-cli-installability`）
- 依据：M7 代谢里程碑，任务 `task_01KYEMKNJKH6Y2B7FQY3PCKJ2W`。这道门本身已列为待项目 owner 裁决项（A2）；修复部分不依赖该裁决。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：由 owner 裁决「外围能力不得成为核心硬依赖」是否立为常设门

## 验证

- `origin/main` 基准 SHA：`51107ac8`
- 当前分支与 `origin/main` 的 merge-base：`51107ac8`
- 最近一次 `git fetch origin` 时间：2026-07-27，开 PR 前即时执行
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...HEAD`
- 私有证据 commit/path：冷启动轮次归档 `2026-07-26-wall0-r6` 与 wall0 可安装性报告，均在私有台账内
- Reviewer 证据路径：同一轮次归档
- GitHub Actions `rewrite-ci` run URL：待生成——本 PR 刚开
- [x] `git diff --check`
- [x] `npm run check:stop-point`——363.4 秒通过，37 个完整 manifest 门全绿
- [x] 改动面的定向测试，写明测试名与通过数：`packages/daemon/test/pty-host.test.ts` + `packages/cli/test/daemon-snapshot.test.ts` 12/12 通过；`tools/check-cli-installability.test.mjs` 3/3 通过
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）
- 未跑项及原因：`rewrite-ci` 尚未跑，因为它由本 PR 的创建触发，合并等它。四个冷启动场景已真实执行，四个全部按 oracle 判为 FAIL——可安装性这堵墙已经拆掉，但后面的墙仍在，本 PR 刻意不修它们。

## 审查证据

- 自查：CEO 没有采信报告，而是自己在构建出的镜像里复跑了纯净性检查——`ha --version` 正常，`require("node-pty")` 返回 `MODULE_NOT_FOUND`，`g++`/`c++`/`make`/`gcc` 全部不存在。这三者同时成立才是真正的断言：**没有任何 C++ 工具链的机器上，CLI 装得上并且能跑**。
- Reviewer subagent：门的阳性对照经读测试确认——把 `node-pty` 挪回 `dependencies` 时断言门变红并给出精确 violation 消息，不是只测通过路径的假绿。
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- `better-sqlite3` 仍是必需依赖，其安装脚本会回退 `node-gyp`。本次工作中已实证撞到：抓取预编译二进制时一次 TLS 断连就导致回退本地编译，随后因镜像刻意没有 `make` 而失败。所以「有预编译」不等于「零工具链保证」，它等于「依赖第三方 CDN 持续可达」。
- 新门是基于包 manifest、安装脚本与已安装依赖树做静态判断。它能拦住明确的「必需原生编译」回归，但不能证明第三方预编译 CDN 永久在线，也无法验证所有 Node ABI 的远端资产完整性。
- npm 在 optional 依赖安装失败时允许核心安装继续（可能带 warning）；本次验证的是 `node-pty` 缺失时非终端的 CLI/daemon 路径仍然可用。

## 关联材料

- 任务：`task_01KYEMKNJKH6Y2B7FQY3PCKJ2W`
- 证据：冷启动轮次归档 `2026-07-26-wall0-r6`（四场景、镜像构建日志、泄漏检查）
- 审查：CEO 验收结论记录在 M7 待裁决台账
