### PR TITLE
fix: derive write receipts from committed outcomes

### DIFF
--- a/packages/application/src/coordinated-execution-authored-store.ts
+++ b/packages/application/src/coordinated-execution-authored-store.ts
@@ -23,6 +23,12 @@ export function makeCoordinatedExecutionAuthoredStore(input: {
   readonly coordinator: WriteCoordinator;
   readonly artifactStore: Pick<ArtifactStore, "readTaskPackage">;
 }): ExecutionAuthoredStore {
+  const submissionAttempts = new Map<string, {
+    readonly beforeExecutionBody: string;
+    readonly beforeIndexBody: string;
+    readonly afterExecutionBody: string;
+    readonly afterIndexBody: string;
+  }>();
   return {
     listExecutions: async (request) => {
       const task = await Effect.runPromise(input.artifactStore.readTaskPackage(request.taskId));
@@ -147,15 +153,113 @@ export function makeCoordinatedExecutionAuthoredStore(input: {
         evidence: allEvidence
       });
       const submitted = submittedExecution(current, finalizedBindings, request.submittedAt, request.submission);
+      const currentIndex = task.documents.find((candidate) => candidate.path === "INDEX.md")?.body;
+      if (!currentIndex) throw new Error(`task INDEX.md missing: ${request.taskId}`);
+      const submittedIndex = taskIndex(task.documents, request.taskId, ["active", "in_review"], "in_review");
+      const attemptKey = submissionAttemptKey(request);
+      submissionAttempts.set(attemptKey, {
+        beforeExecutionBody: document.body,
+        beforeIndexBody: currentIndex,
+        afterExecutionBody: executionDeclaration.documentCodec.encode(submitted),
+        afterIndexBody: submittedIndex
+      });
       await writeExecutionTransaction(
         input,
         request.taskId,
         submitted,
-        taskIndex(task.documents, request.taskId, ["active", "in_review"], "in_review"),
-        { stageTaskTree: true }
+        submittedIndex,
+        {
+          stageTaskTree: true,
+          preconditions: [
+            {
+              taskId: request.taskId,
+              path: executionPath(request.executionId),
+              bodySha256: sha256Text(document.body)
+            },
+            {
+              taskId: request.taskId,
+              path: "INDEX.md",
+              bodySha256: sha256Text(currentIndex)
+            }
+          ]
+        }
       );
+      submissionAttempts.delete(attemptKey);
+    },
+    submitPublicationState: async (request) => {
+      const attemptKey = submissionAttemptKey(request);
+      const attempt = submissionAttempts.get(attemptKey);
+      submissionAttempts.delete(attemptKey);
+      const task = await Effect.runPromise(input.artifactStore.readTaskPackage(request.taskId));
+      const executionBody = task.documents.find((candidate) =>
+        candidate.path === executionPath(request.executionId))?.body;
+      const indexBody = task.documents.find((candidate) => candidate.path === "INDEX.md")?.body;
+      if (!attempt) {
+        const current = executionBody
+          ? Schema.decodeUnknownSync(executionDeclaration.schema)(
+            executionDeclaration.documentCodec.decode(executionBody)
+          ) as ExecutionRecord
+          : null;
+        if (current?.state === "active") return "absent";
+        if (current && submissionPayloadMatches(current, request)) {
+          try {
+            const expectedIndex = taskIndex(task.documents, request.taskId, ["in_review"], "in_review");
+            if (indexBody === expectedIndex) return "committed";
+          } catch {
+            // A missing or non-review INDEX is a partial publication even when
+            // the Execution payload itself is exact.
+          }
+        }
+        return "partial";
+      }
+      if (executionBody === attempt.afterExecutionBody && indexBody === attempt.afterIndexBody) {
+        return "committed";
+      }
+      if (executionBody === attempt.beforeExecutionBody && indexBody === attempt.beforeIndexBody) {
+        return "absent";
+      }
+      return "partial";
     }
   };
+}
+
+function submissionPayloadMatches(
+  execution: ExecutionRecord,
+  request: {
+    readonly submittedAt: string;
+    readonly submission: ExecutionSubmission;
+  }
+): boolean {
+  const expectedSubmission = {
+    completion_claim: request.submission.completionClaim,
+    deliverables: request.submission.deliverables,
+    evidence_refs: request.submission.evidence.map((evidence) => evidence.evidence_id),
+    verification_notes: request.submission.verificationNotes,
+    known_gaps: request.submission.knownGaps,
+    residual_risks: request.submission.residualRisks
+  };
+  const evidenceCount = request.submission.evidence.length;
+  return execution.state === "submitted"
+    && execution.submitted_at === request.submittedAt
+    && isDeepStrictEqual(execution.submission, expectedSubmission)
+    && (evidenceCount === 0 || isDeepStrictEqual(
+      execution.outputs.slice(-evidenceCount),
+      request.submission.evidence
+    ));
+}
+
+function submissionAttemptKey(request: {
+  readonly taskId: string;
+  readonly executionId: string;
+  readonly submittedAt: string;
+  readonly submission: ExecutionSubmission;
+}): string {
+  return stablePayloadHash({
+    taskId: request.taskId,
+    executionId: request.executionId,
+    submittedAt: request.submittedAt,
+    submission: request.submission
+  });
 }
 
 function writeExecutionOnlyTransaction(

--- a/packages/application/src/execution-saga-service.ts
+++ b/packages/application/src/execution-saga-service.ts
@@ -72,6 +72,14 @@ export interface ExecutionClaimResult extends ExecutionLeaseContext {
   readonly leaseAcquiredAt: string;
 }
 
+export interface ExecutionSubmitResult {
+  /**
+   * Authored submission success is authoritative. Lease release is a
+   * post-commit cleanup result and cannot reverse that committed outcome.
+   */
+  readonly leaseReleased: boolean;
+}
+
 export interface ExecutionSagaService {
   readonly reconcileTask: (taskId: string) => Promise<void>;
   readonly claim: (input: {
@@ -98,7 +106,7 @@ export interface ExecutionSagaService {
     readonly leaseToken?: string;
     readonly principal: TaskHolderPrincipal;
     readonly submission: ExecutionSubmission;
-  }) => Promise<void>;
+  }) => Promise<ExecutionSubmitResult>;
 }
 
 export interface ExecutionSagaServiceOptions {
@@ -280,7 +288,22 @@ export function makeExecutionSagaService(options: ExecutionSagaServiceOptions): 
         submittedAt: now(),
         submission: input.submission
       });
-      await options.taskHolderService.releaseExecution(input);
+      let leaseReleased = true;
+      try {
+        await options.taskHolderService.releaseExecution(input);
+      } catch {
+        // Publication is already committed. Reconcile cleanup from authored
+        // state, but never translate a cleanup race into a failed write.
+        try {
+          await reconcileTask(options, input.taskId);
+          leaseReleased = (await options.taskHolderService.holder({
+            taskId: input.taskId
+          })).effectiveHolder === null;
+        } catch {
+          leaseReleased = false;
+        }
+      }
+      return { leaseReleased };
     },
     reconcileTask: (taskId) => reconcileTask(options, taskId)
   };

--- a/packages/application/src/execution-saga-service.ts
+++ b/packages/application/src/execution-saga-service.ts
@@ -64,6 +64,12 @@ export interface ExecutionAuthoredStore {
     readonly submittedAt: string;
     readonly submission: ExecutionSubmission;
   }) => Promise<void>;
+  readonly submitPublicationState: (input: {
+    readonly taskId: string;
+    readonly executionId: string;
+    readonly submittedAt: string;
+    readonly submission: ExecutionSubmission;
+  }) => Promise<"committed" | "absent" | "partial">;
 }
 
 export interface ExecutionClaimResult extends ExecutionLeaseContext {
@@ -78,6 +84,13 @@ export interface ExecutionSubmitResult {
    * post-commit cleanup result and cannot reverse that committed outcome.
    */
   readonly leaseReleased: boolean;
+  readonly cleanup: {
+    readonly status: "released" | "retained" | "unknown";
+    readonly diagnostics: ReadonlyArray<{
+      readonly phase: "release" | "verification";
+      readonly message: string;
+    }>;
+  };
 }
 
 export interface ExecutionSagaService {
@@ -282,31 +295,78 @@ export function makeExecutionSagaService(options: ExecutionSagaServiceOptions): 
       const execution = await options.authoredStore.readExecution({ taskId: input.taskId, executionId: input.executionId });
       const primarySession = execution ? boundPrimarySession(execution.session_bindings) : null;
       if (primarySession && options.finalizeSession) await options.finalizeSession(primarySession);
-      await options.authoredStore.submitForReview({
+      const submissionAttempt = {
         taskId: input.taskId,
         executionId: input.executionId,
         submittedAt: now(),
         submission: input.submission
-      });
-      let leaseReleased = true;
+      };
+      try {
+        await options.authoredStore.submitForReview(submissionAttempt);
+      } catch (error) {
+        let publication: "committed" | "absent" | "partial";
+        try {
+          publication = await options.authoredStore.submitPublicationState(submissionAttempt);
+        } catch (queryError) {
+          throw new Error(
+            `execution submit publication is indeterminate because its exact authored state could not be read: ${input.executionId}`,
+            { cause: new AggregateError([error, queryError]) }
+          );
+        }
+        if (publication === "absent") throw error;
+        if (publication === "partial") {
+          throw new Error(
+            `execution submit publication is indeterminate because only part of the exact submission is observable: ${input.executionId}`,
+            { cause: error }
+          );
+        }
+        // Exact authored execution and INDEX bytes are authoritative even if
+        // the coordinator failed after their canonical publication.
+      }
+      let cleanup: ExecutionSubmitResult["cleanup"] = {
+        status: "released",
+        diagnostics: []
+      };
       try {
         await options.taskHolderService.releaseExecution(input);
-      } catch {
+      } catch (releaseError) {
         // Publication is already committed. Reconcile cleanup from authored
         // state, but never translate a cleanup race into a failed write.
+        const diagnostics: Array<ExecutionSubmitResult["cleanup"]["diagnostics"][number]> = [
+          { phase: "release", message: cleanupErrorMessage(releaseError) }
+        ];
         try {
           await reconcileTask(options, input.taskId);
-          leaseReleased = (await options.taskHolderService.holder({
+          const released = (await options.taskHolderService.holder({
             taskId: input.taskId
           })).effectiveHolder === null;
-        } catch {
-          leaseReleased = false;
+          cleanup = {
+            status: released ? "released" : "retained",
+            diagnostics
+          };
+        } catch (verificationError) {
+          cleanup = {
+            status: "unknown",
+            diagnostics: [
+              ...diagnostics,
+              { phase: "verification", message: cleanupErrorMessage(verificationError) }
+            ]
+          };
         }
       }
-      return { leaseReleased };
+      return {
+        leaseReleased: cleanup.status === "released",
+        cleanup
+      };
     },
     reconcileTask: (taskId) => reconcileTask(options, taskId)
   };
+}
+
+function cleanupErrorMessage(error: unknown): string {
+  return error instanceof Error
+    ? `${error.name}: ${error.message}`
+    : String(error);
 }
 
 function selectReusableExecution(

--- a/packages/application/test/execution-saga-fixtures.ts
+++ b/packages/application/test/execution-saga-fixtures.ts
@@ -52,6 +52,27 @@ export function memoryAuthoredStore(options: { readonly failOpen?: boolean } = {
         }
       });
       store.taskStatus = "in_review";
+    },
+    submitPublicationState: async (input) => {
+      const current = executions.get(input.executionId);
+      if (!current) return "absent";
+      const expectedSubmission = {
+        completion_claim: input.submission.completionClaim,
+        deliverables: input.submission.deliverables,
+        evidence_refs: input.submission.evidence.map((evidence) => evidence.evidence_id),
+        verification_notes: input.submission.verificationNotes,
+        known_gaps: input.submission.knownGaps,
+        residual_risks: input.submission.residualRisks
+      };
+      if (current.state === "submitted"
+          && current.submitted_at === input.submittedAt
+          && JSON.stringify(current.submission) === JSON.stringify(expectedSubmission)
+          && store.taskStatus === "in_review") {
+        return "committed";
+      }
+      return current.state === "active" && store.taskStatus === "active"
+        ? "absent"
+        : "partial";
     }
   };
   return store;

--- a/packages/application/test/execution-submit-concurrency.test.ts
+++ b/packages/application/test/execution-submit-concurrency.test.ts
@@ -1,0 +1,189 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { Effect } from "effect";
+import {
+  makeCoordinatedExecutionAuthoredStore,
+  makeExecutionSagaService,
+  makeJournaledWriteCoordinator,
+  makeMarkdownArtifactStore,
+  makeTaskHolderService,
+  taskHolderActor,
+  type ExecutionRecord
+} from "../src/index.ts";
+import {
+  writeContentAddressedBlobWithDisposition,
+  writeSessionEntity,
+  type WriteCoordinator
+} from "../../kernel/src/index.ts";
+import { taskIndex } from "./execution-saga-fixtures.ts";
+import { writeAttribution } from "./test-attribution.ts";
+
+const taskId = "task_01KX19GEKWMEJNGSMRT6JJH6HY";
+const executionId = "exe_01KX7H00000000000000000001";
+const primarySessionId = "codex-submit-race-primary";
+const principal = taskHolderActor(
+  { personId: "alice", displayName: "Alice" },
+  { kind: "agent", id: "codex" }
+);
+
+test("concurrent submitters from one active snapshot admit one distinct submission without lost update", async () => {
+  const { results, submissions, stored, indexBody, restartedPublication } = await runConcurrentSubmissions("alpha", "beta");
+
+  assert.equal(results.filter((result) => result.status === "fulfilled").length, 1, JSON.stringify(results));
+  assert.equal(results.filter((result) => result.status === "rejected").length, 1, JSON.stringify(results));
+  const winner = results.findIndex((result) => result.status === "fulfilled");
+  assert.equal(stored.submission?.completion_claim, submissions[winner]!.completionClaim);
+  assert.match(indexBody, /^  status: in_review$/mu);
+  assert.equal(restartedPublication, "committed");
+});
+
+test("concurrent byte-identical submissions are idempotent after the winning CAS publication", async () => {
+  const { results, submissions, stored, restartedPublication } = await runConcurrentSubmissions("same", "same");
+
+  assert.equal(results.filter((result) => result.status === "fulfilled").length, 2, JSON.stringify(results));
+  assert.equal(stored.submission?.completion_claim, submissions[0]!.completionClaim);
+  assert.equal(restartedPublication, "committed");
+});
+
+async function runConcurrentSubmissions(left: string, right: string) {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-submit-race-"));
+  try {
+    const taskRoot = path.join(rootDir, "harness/tasks", `${taskId}-submit-race`);
+    mkdirSync(taskRoot, { recursive: true });
+    writeFileSync(path.join(taskRoot, "INDEX.md"), taskIndex(taskId, "active"), "utf8");
+    const holder = makeTaskHolderService({ rootInput: rootDir });
+    const initialCoordinator = makeJournaledWriteCoordinator({
+      rootDir,
+      attribution: writeAttribution("alice", "initial")
+    });
+    const initialSaga = makeExecutionSagaService({
+      taskHolderService: holder,
+      authoredStore: makeCoordinatedExecutionAuthoredStore({
+        rootInput: rootDir,
+        coordinator: initialCoordinator,
+        artifactStore: makeMarkdownArtifactStore({ rootDir })
+      }),
+      generateExecutionId: () => executionId,
+      now: () => "2026-07-30T00:00:00.000Z"
+    });
+    await initialSaga.claim({
+      taskId,
+      principal,
+      primarySession: {
+        runtime: "codex",
+        sessionId: primarySessionId,
+        source: "runtime",
+        detectedAt: "2026-07-30T00:00:00.000Z"
+      }
+    });
+    writeFinalizedSession(rootDir, initialCoordinator);
+
+    const bothReadyToPublish = barrier(2);
+    const saga = (executor: string) => {
+      const journaled = makeJournaledWriteCoordinator({
+        rootDir,
+        attribution: writeAttribution("alice", executor)
+      });
+      const coordinator: WriteCoordinator = {
+        ...journaled,
+        enqueue: (op) => op.kind === "doc_write"
+          ? Effect.promise(() => bothReadyToPublish()).pipe(Effect.flatMap(() => journaled.enqueue(op)))
+          : journaled.enqueue(op)
+      };
+      return makeExecutionSagaService({
+        taskHolderService: makeTaskHolderService({ rootInput: rootDir }),
+        authoredStore: makeCoordinatedExecutionAuthoredStore({
+          rootInput: rootDir,
+          coordinator,
+          artifactStore: makeMarkdownArtifactStore({ rootDir })
+        }),
+        now: () => "2026-07-30T00:01:00.000Z"
+      });
+    };
+    const submissions = [submission(left), submission(right)];
+    const results = await Promise.allSettled([
+      saga("submit-alpha").submitForReview({ taskId, executionId, principal, submission: submissions[0]! }),
+      saga("submit-beta").submitForReview({ taskId, executionId, principal, submission: submissions[1]! })
+    ]);
+
+    const stored = JSON.parse(readFileSync(
+      path.join(taskRoot, "executions", `${executionId}.md`),
+      "utf8"
+    )) as ExecutionRecord;
+    const winner = results.findIndex((result) => result.status === "fulfilled");
+    const restartedStore = makeCoordinatedExecutionAuthoredStore({
+      rootInput: rootDir,
+      coordinator: makeJournaledWriteCoordinator({
+        rootDir,
+        attribution: writeAttribution("alice", "restart-query")
+      }),
+      artifactStore: makeMarkdownArtifactStore({ rootDir })
+    });
+    const restartedPublication = await restartedStore.submitPublicationState({
+      taskId,
+      executionId,
+      submittedAt: "2026-07-30T00:01:00.000Z",
+      submission: submissions[winner]!
+    });
+    return {
+      results,
+      submissions,
+      stored,
+      indexBody: readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"),
+      restartedPublication
+    };
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function submission(label: string) {
+  return {
+    completionClaim: `submission ${label}`,
+    deliverables: [label],
+    verificationNotes: [],
+    knownGaps: [],
+    residualRisks: [],
+    evidence: []
+  };
+}
+
+function writeFinalizedSession(rootDir: string, coordinator: WriteCoordinator): void {
+  const bodyRef = writeContentAddressedBlobWithDisposition(
+    rootDir,
+    "# finalized concurrent submit session\n",
+    "text/markdown; charset=utf-8"
+  );
+  Effect.runSync(writeSessionEntity(coordinator, rootDir, {
+    schema: "session-entity/v1",
+    sessionId: primarySessionId,
+    lifecycle: "sealed",
+    archiveStatus: "complete",
+    runtime: "codex",
+    source: "runtime",
+    detectedAt: "2026-07-30T00:00:00.000Z",
+    exportedAt: "2026-07-30T00:00:01.000Z",
+    bodyRef: { store: "authored-cas/v1", ...bodyRef },
+    snapshot: {
+      capturedAt: "2026-07-30T00:00:01.000Z",
+      completeness: "complete",
+      captureRange: { messageCount: 1 },
+      privacyScan: { scannerVersion: "test", passed: true, findings: [] }
+    }
+  }));
+}
+
+function barrier(count: number): () => Promise<void> {
+  let waiting = 0;
+  let release!: () => void;
+  const ready = new Promise<void>((resolve) => { release = resolve; });
+  return async () => {
+    waiting += 1;
+    if (waiting === count) release();
+    await ready;
+  };
+}

--- a/packages/application/test/execution-submit-receipt-honesty.test.ts
+++ b/packages/application/test/execution-submit-receipt-honesty.test.ts
@@ -58,10 +58,114 @@ test("submit reports the committed authored outcome when its lease expires durin
       }
     });
 
-    assert.deepEqual(result, { leaseReleased: true });
+    assert.equal(result.leaseReleased, true);
+    assert.equal(result.cleanup.status, "released");
+    assert.equal(result.cleanup.diagnostics.length, 1);
+    assert.match(result.cleanup.diagnostics[0]?.message ?? "", /requires an active lease/u);
     assert.equal(authored.executions.get(executionId)?.state, "submitted");
     assert.equal(authored.taskStatus, "in_review");
     assert.equal((await holder.holder({ taskId })).effectiveHolder, null);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("submit adopts the exact authored publication when the store throws after commit", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-submit-commit-after-error-"));
+  try {
+    const holder = makeTaskHolderService({ rootInput: rootDir });
+    const authored = memoryAuthoredStore();
+    const publishedThenRejected = {
+      ...authored,
+      submitForReview: async (input: Parameters<typeof authored.submitForReview>[0]) => {
+        await authored.submitForReview(input);
+        throw new Error("publication transport failed after authored commit");
+      },
+      submitPublicationState: async () => "committed" as const
+    };
+    const saga = makeExecutionSagaService({
+      taskHolderService: holder,
+      authoredStore: publishedThenRejected,
+      generateExecutionId: () => executionId,
+      now: () => new Date("2026-07-30T00:00:00.000Z").toISOString()
+    });
+    await saga.claim({ taskId, principal: actor, ttlMs: 60_000 });
+    authored.taskStatus = "active";
+
+    const result = await saga.submitForReview({
+      taskId,
+      executionId,
+      principal: actor,
+      submission: {
+        completionClaim: "committed before transport error",
+        deliverables: [],
+        verificationNotes: [],
+        knownGaps: [],
+        residualRisks: [],
+        evidence: []
+      }
+    });
+
+    assert.deepEqual(result, {
+      leaseReleased: true,
+      cleanup: { status: "released", diagnostics: [] }
+    });
+    assert.equal(authored.executions.get(executionId)?.state, "submitted");
+    assert.equal(authored.taskStatus, "in_review");
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("submit reports cleanup unknown with both release and verification diagnostics", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-submit-cleanup-double-failure-"));
+  try {
+    const holder = makeTaskHolderService({ rootInput: rootDir });
+    const cleanupFailures = {
+      ...holder,
+      releaseExecution: async () => {
+        throw new Error("release credential rejected");
+      },
+      reconcileExecution: async () => {
+        throw new Error("cleanup journal disk full");
+      }
+    };
+    const authored = memoryAuthoredStore();
+    const saga = makeExecutionSagaService({
+      taskHolderService: cleanupFailures,
+      authoredStore: authored,
+      generateExecutionId: () => executionId,
+      now: () => "2026-07-30T00:00:00.000Z"
+    });
+    await saga.claim({ taskId, principal: actor, ttlMs: 60_000 });
+    authored.taskStatus = "active";
+
+    const result = await saga.submitForReview({
+      taskId,
+      executionId,
+      principal: actor,
+      submission: {
+        completionClaim: "authored commit survives cleanup failures",
+        deliverables: [],
+        verificationNotes: [],
+        knownGaps: [],
+        residualRisks: [],
+        evidence: []
+      }
+    });
+
+    assert.deepEqual(result, {
+      leaseReleased: false,
+      cleanup: {
+        status: "unknown",
+        diagnostics: [
+          { phase: "release", message: "Error: release credential rejected" },
+          { phase: "verification", message: "Error: cleanup journal disk full" }
+        ]
+      }
+    });
+    assert.equal(authored.executions.get(executionId)?.state, "submitted");
+    assert.equal(authored.taskStatus, "in_review");
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }

--- a/packages/application/test/execution-submit-receipt-honesty.test.ts
+++ b/packages/application/test/execution-submit-receipt-honesty.test.ts
@@ -1,0 +1,68 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  makeExecutionSagaService,
+  makeTaskHolderService,
+  taskHolderActor
+} from "../src/index.ts";
+import { memoryAuthoredStore } from "./execution-saga-fixtures.ts";
+
+const taskId = "task_01KX19GEKWMEJNGSMRT6JJH6HY";
+const executionId = "exe_01KX7H00000000000000000001";
+const actor = taskHolderActor(
+  { personId: "alice", displayName: "Alice" },
+  { kind: "agent", id: "codex" }
+);
+
+test("submit reports the committed authored outcome when its lease expires during publication", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-submit-receipt-honesty-"));
+  let nowMs = Date.parse("2026-07-30T00:00:00.000Z");
+  try {
+    const holder = makeTaskHolderService({
+      rootInput: rootDir,
+      now: () => new Date(nowMs)
+    });
+    const authored = memoryAuthoredStore();
+    const publish = authored.submitForReview;
+    const authoredWithSlowPublication = {
+      ...authored,
+      submitForReview: async (input: Parameters<typeof publish>[0]) => {
+        await publish(input);
+        nowMs += 120_000;
+      }
+    };
+    const saga = makeExecutionSagaService({
+      taskHolderService: holder,
+      authoredStore: authoredWithSlowPublication,
+      generateExecutionId: () => executionId,
+      now: () => new Date(nowMs).toISOString()
+    });
+    await saga.claim({ taskId, principal: actor, ttlMs: 60_000 });
+    authored.taskStatus = "active";
+
+    const result = await saga.submitForReview({
+      taskId,
+      executionId,
+      principal: actor,
+      submission: {
+        completionClaim: "publication committed before lease cleanup",
+        deliverables: [],
+        verificationNotes: [],
+        knownGaps: [],
+        residualRisks: [],
+        evidence: []
+      }
+    });
+
+    assert.deepEqual(result, { leaseReleased: true });
+    assert.equal(authored.executions.get(executionId)?.state, "submitted");
+    assert.equal(authored.taskStatus, "in_review");
+    assert.equal((await holder.holder({ taskId })).effectiveHolder, null);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/src/commands/core/task-holder-submit-result.ts
+++ b/packages/cli/src/commands/core/task-holder-submit-result.ts
@@ -1,0 +1,39 @@
+import type { CliResult } from "../../cli/types.ts";
+
+interface ExecutionSubmitCleanup {
+  readonly status: "released" | "retained" | "unknown";
+  readonly diagnostics: ReadonlyArray<{
+    readonly phase: "release" | "verification";
+    readonly message: string;
+  }>;
+}
+
+export function executionSubmitSuccessResult(input: {
+  readonly taskId: string;
+  readonly executionId: string;
+  readonly leaseReleased: boolean;
+  readonly cleanup: ExecutionSubmitCleanup;
+  readonly unavailableBindings: ReadonlyArray<unknown>;
+}): CliResult {
+  return {
+    ok: true,
+    command: "status-set",
+    taskId: input.taskId,
+    executionId: input.executionId,
+    status: "in_review",
+    report: {
+      schema: "execution-submit-result/v1",
+      executionId: input.executionId,
+      leaseReleased: input.leaseReleased,
+      cleanup: input.cleanup,
+      unavailableBindings: input.unavailableBindings
+    },
+    ...(input.cleanup.diagnostics.length === 0 ? {} : {
+      warnings: input.cleanup.diagnostics.map((diagnostic) => ({
+        code: "execution_submit_cleanup_warning",
+        phase: diagnostic.phase,
+        message: diagnostic.message
+      }))
+    })
+  };
+}

--- a/packages/cli/src/commands/core/task-holder.ts
+++ b/packages/cli/src/commands/core/task-holder.ts
@@ -113,7 +113,7 @@ export function runExecutionSubmit(
       catch: (error) => error
     }).pipe(Effect.match({
       onFailure: (error) => ({ ok: false as const, error }),
-      onSuccess: () => ({ ok: true as const })
+      onSuccess: (result) => ({ ok: true as const, result })
     }));
     if (!submitted.ok) {
       return {
@@ -147,7 +147,7 @@ export function runExecutionSubmit(
       report: {
         schema: "execution-submit-result/v1",
         executionId,
-        leaseReleased: true,
+        leaseReleased: submitted.result.leaseReleased,
         unavailableBindings
       }
     } satisfies CliResult;

--- a/packages/cli/src/commands/core/task-holder.ts
+++ b/packages/cli/src/commands/core/task-holder.ts
@@ -9,6 +9,7 @@ import { milestoneDecisionLineageFailure } from "./task-lineage-gate.ts";
 import { preflightActiveStatusSet } from "./task-active-transition.ts";
 import { commandExecutionSaga } from "./task-holder-execution-saga.ts";
 import { canonicalTaskStartResult, resultForTaskHolderFailure, taskHolderCommandFailure, taskHolderPrincipal } from "./task-holder-support.ts";
+import { executionSubmitSuccessResult } from "./task-holder-submit-result.ts";
 type TaskHolderAction = Extract<
   Parameters<CommandRunner>[1]["action"],
   { readonly kind: "task-claim" | "task-holder" | "task-release" }
@@ -138,19 +139,13 @@ export function runExecutionSubmit(
         sessionRef: binding.session_ref,
         archiveStatus: binding.archive_status
       })) ?? [];
-    return {
-      ok: true,
-      command: "status-set",
+    return executionSubmitSuccessResult({
       taskId: action.taskId,
       executionId,
-      status: "in_review",
-      report: {
-        schema: "execution-submit-result/v1",
-        executionId,
-        leaseReleased: submitted.result.leaseReleased,
-        unavailableBindings
-      }
-    } satisfies CliResult;
+      leaseReleased: submitted.result.leaseReleased,
+      cleanup: submitted.result.cleanup,
+      unavailableBindings
+    });
   });
 }
 

--- a/packages/cli/test/task-lease-cli.test.ts
+++ b/packages/cli/test/task-lease-cli.test.ts
@@ -333,6 +333,7 @@ test("execution claim activates once and the Holder V2 actor can submit without 
 
     assert.equal(submitted.status, "in_review");
     assert.equal(submitted.report.leaseReleased, true);
+    assert.deepEqual(submitted.report.cleanup, { status: "released", diagnostics: [] });
     const holder = runJson(rootDir, ["task", "holder", created.taskId]);
     assert.equal(holder.report.effectiveHolder, null);
   });

--- a/packages/daemon/src/runtime/repo-write-client-contract.ts
+++ b/packages/daemon/src/runtime/repo-write-client-contract.ts
@@ -27,6 +27,11 @@ export interface RepoWriteClientLimits {
   readonly maxPendingRequests: number;
   readonly readyTimeoutMs: number;
   readonly requestTimeoutMs: number;
+  /**
+   * Total wall time from submit until a proceeded operation is escalated.
+   * The default is two request windows: 30s observes, 60s replaces and looks up.
+   */
+  readonly proceededStallTimeoutMs: number;
 }
 
 export interface RepoWriteRequestDiagnostic {
@@ -39,6 +44,7 @@ export interface RepoWriteRequestDiagnostic {
 
 export interface RepoWriteRequestTimeoutDiagnostic extends RepoWriteRequestDiagnostic {
   readonly deadlineMs: number;
+  readonly watchdogStage: "deadline" | "observation" | "escalation";
 }
 
 export interface RepoWriteRequestFailureDiagnostic extends RepoWriteRequestDiagnostic {

--- a/packages/daemon/src/runtime/repo-write-client-direct.ts
+++ b/packages/daemon/src/runtime/repo-write-client-direct.ts
@@ -212,6 +212,7 @@ export class RepoWriteDirectClientLane {
       commandName: pending.command.commandName,
       lane: "direct",
       deadlineMs: this.options.requestTimeoutMs,
+      watchdogStage: "deadline",
       ...(pending.lastTelemetry ? { lastTelemetry: pending.lastTelemetry } : {})
     });
     pending.reject(pending.phase === "sent"

--- a/packages/daemon/src/runtime/repo-write-client-limits.ts
+++ b/packages/daemon/src/runtime/repo-write-client-limits.ts
@@ -1,0 +1,25 @@
+import {
+  defaultRepoWriteRequestTimeoutMs,
+  type RepoWriteClientLimits
+} from "./repo-write-client-contract.ts";
+
+export function resolveRepoWriteClientLimits(
+  configured: Partial<RepoWriteClientLimits> | undefined
+): RepoWriteClientLimits {
+  const requestTimeoutMs = configured?.requestTimeoutMs ?? defaultRepoWriteRequestTimeoutMs;
+  const limits = {
+    maxPendingRequests: configured?.maxPendingRequests ?? 1_024,
+    readyTimeoutMs: configured?.readyTimeoutMs ?? 30_000,
+    requestTimeoutMs,
+    proceededStallTimeoutMs: configured?.proceededStallTimeoutMs ?? requestTimeoutMs * 2
+  };
+  for (const [name, value] of Object.entries(limits)) {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      throw new Error(`${name} must be a positive safe integer`);
+    }
+  }
+  if (limits.proceededStallTimeoutMs <= limits.requestTimeoutMs) {
+    throw new Error("proceededStallTimeoutMs must exceed requestTimeoutMs");
+  }
+  return limits;
+}

--- a/packages/daemon/src/runtime/repo-write-client-pending.ts
+++ b/packages/daemon/src/runtime/repo-write-client-pending.ts
@@ -10,7 +10,7 @@ export interface PendingSubmit {
   readonly command: RepoWriteCommandDto;
   readonly resolve: (receipt: RepoWriteJsonObject) => void;
   readonly reject: (error: Error) => void;
-  readonly timer: NodeJS.Timeout;
+  timer: NodeJS.Timeout;
   phase: "queued" | "submitted" | "prepared" | "proceeded";
   opId?: string;
   lastTelemetry?: RepoWriteTelemetryFrame;

--- a/packages/daemon/src/runtime/repo-write-client-timeout.ts
+++ b/packages/daemon/src/runtime/repo-write-client-timeout.ts
@@ -36,6 +36,9 @@ export function expireRepoWriteSubmit(
     commandName: pending.command.commandName,
     lane: "durable",
     deadlineMs: timeoutMs,
+    watchdogStage: pending.phase === "proceeded" && pending.opId
+      ? "observation"
+      : "deadline",
     ...(pending.opId ? { opId: pending.opId } : {}),
     ...(pending.lastTelemetry ? { lastTelemetry: pending.lastTelemetry } : {})
   });
@@ -51,6 +54,30 @@ export function expireRepoWriteSubmit(
   return "expired";
 }
 
+export function escalateRepoWriteSubmitStall(
+  pending: PendingSubmit,
+  timeoutMs: number,
+  observer: TimeoutObserver | undefined
+): void {
+  const diagnostic =
+    `Repo writer proceeded operation exceeded its bounded ${timeoutMs}ms stall deadline.`
+    + repoWriteTelemetryTimeoutSuffix(pending.lastTelemetry);
+  observeRepoWriteRequestTimeout(observer, {
+    requestId: pending.requestId,
+    commandName: pending.command.commandName,
+    lane: "durable",
+    deadlineMs: timeoutMs,
+    watchdogStage: "escalation",
+    opId: pending.opId!,
+    ...(pending.lastTelemetry ? { lastTelemetry: pending.lastTelemetry } : {})
+  });
+  pending.reject(new RepoWriteOutcomeUnknownError(
+    "REPO_WRITE_STALL_TIMEOUT",
+    diagnostic,
+    pending.opId!
+  ));
+}
+
 export function expireRepoWriteLookup(
   pending: PendingLookup,
   timeoutMs: number,
@@ -61,6 +88,7 @@ export function expireRepoWriteLookup(
     commandName: "repo-write.lookup",
     lane: "lookup",
     deadlineMs: timeoutMs,
+    watchdogStage: "deadline",
     opId: pending.opId,
     ...(pending.lastTelemetry ? { lastTelemetry: pending.lastTelemetry } : {})
   });

--- a/packages/daemon/src/runtime/repo-write-client-timeout.ts
+++ b/packages/daemon/src/runtime/repo-write-client-timeout.ts
@@ -27,7 +27,7 @@ export function expireRepoWriteSubmit(
   pending: PendingSubmit,
   timeoutMs: number,
   observer: TimeoutObserver | undefined
-): void {
+): "observed" | "expired" {
   const diagnostic =
     `Repo writer request exceeded its ${timeoutMs}ms deadline.`
     + repoWriteTelemetryTimeoutSuffix(pending.lastTelemetry);
@@ -39,17 +39,16 @@ export function expireRepoWriteSubmit(
     ...(pending.opId ? { opId: pending.opId } : {}),
     ...(pending.lastTelemetry ? { lastTelemetry: pending.lastTelemetry } : {})
   });
-  pending.reject(pending.phase === "proceeded" && pending.opId
-    ? new RepoWriteOutcomeUnknownError(
-        "REPO_WRITE_REQUEST_TIMEOUT",
-        diagnostic,
-        pending.opId
-      )
-    : new RepoWriteNotStartedError(
-        "REPO_WRITE_REQUEST_TIMEOUT",
-        diagnostic,
-        pending.opId
-      ));
+  // PROCEED transfers terminal ownership to the durable child operation. From
+  // that point onward the deadline is a stall observation, not permission to
+  // manufacture an unknown outcome or replace a writer during publication.
+  if (pending.phase === "proceeded" && pending.opId) return "observed";
+  pending.reject(new RepoWriteNotStartedError(
+    "REPO_WRITE_REQUEST_TIMEOUT",
+    diagnostic,
+    pending.opId
+  ));
+  return "expired";
 }
 
 export function expireRepoWriteLookup(

--- a/packages/daemon/src/runtime/repo-write-client-watchdog.ts
+++ b/packages/daemon/src/runtime/repo-write-client-watchdog.ts
@@ -1,0 +1,17 @@
+import type { RepoWriteRequestTimeoutDiagnostic } from "./repo-write-client-contract.ts";
+import type { PendingSubmit } from "./repo-write-client-pending.ts";
+import { escalateRepoWriteSubmitStall } from "./repo-write-client-timeout.ts";
+
+export function armRepoWriteSubmitEscalation(input: {
+  readonly pending: PendingSubmit;
+  readonly pendingRequests: Map<string, PendingSubmit>;
+  readonly delayMs: number;
+  readonly totalTimeoutMs: number;
+  readonly onTimeout?: (diagnostic: RepoWriteRequestTimeoutDiagnostic) => void;
+}): void {
+  input.pending.timer = setTimeout(() => {
+    if (!input.pendingRequests.delete(input.pending.requestId)) return;
+    escalateRepoWriteSubmitStall(input.pending, input.totalTimeoutMs, input.onTimeout);
+  }, input.delayMs);
+  input.pending.timer.unref();
+}

--- a/packages/daemon/src/runtime/repo-write-client.ts
+++ b/packages/daemon/src/runtime/repo-write-client.ts
@@ -13,8 +13,8 @@ import type {
   PendingShutdown,
   PendingSubmit
 } from "./repo-write-client-pending.ts";
-import { defaultRepoWriteRequestTimeoutMs } from "./repo-write-client-contract.ts";
 import type { RepoWriteClientLimits, RepoWriteClientOptions } from "./repo-write-client-contract.ts";
+import { resolveRepoWriteClientLimits } from "./repo-write-client-limits.ts";
 import {
   expireRepoWriteLookup,
   expireRepoWriteSubmit,
@@ -30,6 +30,7 @@ import {
   observeRepoWriteTelemetry,
   repoWriteClientFrameBase
 } from "./repo-write-client-observers.ts";
+import { armRepoWriteSubmitEscalation } from "./repo-write-client-watchdog.ts";
 export type { RepoWriteClientLimits, RepoWriteClientOptions, RepoWriteClientTransport } from "./repo-write-client-contract.ts";
 import {
   RepoWriteClientCapacityError,
@@ -79,16 +80,7 @@ export class RepoWriteClient {
       throw new Error("generation must be a positive safe integer");
     }
     this.options = options;
-    this.limits = {
-      maxPendingRequests: options.limits?.maxPendingRequests ?? 1_024,
-      readyTimeoutMs: options.limits?.readyTimeoutMs ?? 30_000,
-      requestTimeoutMs: options.limits?.requestTimeoutMs ?? defaultRepoWriteRequestTimeoutMs
-    };
-    for (const [name, value] of Object.entries(this.limits)) {
-      if (!Number.isSafeInteger(value) || value <= 0) {
-        throw new Error(`${name} must be a positive safe integer`);
-      }
-    }
+    this.limits = resolveRepoWriteClientLimits(options.limits);
     this.directLane = new RepoWriteDirectClientLane({
       repoId: options.repoId,
       generation: options.generation,
@@ -511,6 +503,15 @@ export class RepoWriteClient {
       this.options.onRequestTimeout
     );
     if (outcome === "expired") this.pending.delete(requestId);
+    if (outcome === "observed") {
+      armRepoWriteSubmitEscalation({
+        pending,
+        pendingRequests: this.pending,
+        delayMs: this.limits.proceededStallTimeoutMs - this.limits.requestTimeoutMs,
+        totalTimeoutMs: this.limits.proceededStallTimeoutMs,
+        onTimeout: this.options.onRequestTimeout
+      });
+    }
   }
 
   private expireLookup(requestId: string): void {

--- a/packages/daemon/src/runtime/repo-write-client.ts
+++ b/packages/daemon/src/runtime/repo-write-client.ts
@@ -505,12 +505,12 @@ export class RepoWriteClient {
   private expireSubmit(requestId: string): void {
     const pending = this.pending.get(requestId);
     if (!pending) return;
-    this.pending.delete(requestId);
-    expireRepoWriteSubmit(
+    const outcome = expireRepoWriteSubmit(
       pending,
       this.limits.requestTimeoutMs,
       this.options.onRequestTimeout
     );
+    if (outcome === "expired") this.pending.delete(requestId);
   }
 
   private expireLookup(requestId: string): void {

--- a/packages/daemon/src/runtime/repo-write-process-supervisor.ts
+++ b/packages/daemon/src/runtime/repo-write-process-supervisor.ts
@@ -56,7 +56,7 @@ export class RepoWriteProcessSupervisor {
       return decodeReceipt(await writer.client.submit(command));
     } catch (error) {
       if (error instanceof RepoWriteOutcomeUnknownError) {
-        return this.recoverExact(error.opId, error);
+        return this.recoverAfterUnknown(writer, error);
       }
       if (error instanceof RepoWriteNotStartedError
         && error.code === "REPO_WRITE_REQUEST_TIMEOUT") {
@@ -73,7 +73,7 @@ export class RepoWriteProcessSupervisor {
         return decodeReceipt(await writer.client.submit(command));
       } catch (retryError) {
         if (retryError instanceof RepoWriteOutcomeUnknownError) {
-          return this.recoverExact(retryError.opId, retryError);
+          return this.recoverAfterUnknown(writer, retryError);
         }
         throw retryError;
       }
@@ -166,6 +166,26 @@ export class RepoWriteProcessSupervisor {
       `Repo-write outcome remains ${result.state}; query the stable outer opId ${opId}.`,
       opId
     );
+  }
+
+  private async recoverAfterUnknown(
+    writer: ActiveWriter,
+    error: RepoWriteOutcomeUnknownError
+  ): Promise<CommandReceiptEnvelope> {
+    if (error.code === "REPO_WRITE_STALL_TIMEOUT") {
+      try {
+        await this.replace(writer);
+      } catch (replacementError) {
+        throw new RepoWriteOutcomeUnknownError(
+          "REPO_WRITE_LOOKUP_FAILED",
+          `Repo-write stall replacement failed for ${error.opId}: ${
+            replacementError instanceof Error ? replacementError.message : String(replacementError)
+          }`,
+          error.opId
+        );
+      }
+    }
+    return this.recoverExact(error.opId, error);
   }
 
   private current(): Promise<ActiveWriter> {

--- a/packages/daemon/src/runtime/repo-write-process-supervisor.ts
+++ b/packages/daemon/src/runtime/repo-write-process-supervisor.ts
@@ -56,9 +56,6 @@ export class RepoWriteProcessSupervisor {
       return decodeReceipt(await writer.client.submit(command));
     } catch (error) {
       if (error instanceof RepoWriteOutcomeUnknownError) {
-        if (error.code === "REPO_WRITE_REQUEST_TIMEOUT") {
-          await this.replace(writer);
-        }
         return this.recoverExact(error.opId, error);
       }
       if (error instanceof RepoWriteNotStartedError

--- a/packages/daemon/src/runtime/repo-write-stall-diagnostic.ts
+++ b/packages/daemon/src/runtime/repo-write-stall-diagnostic.ts
@@ -54,6 +54,7 @@ export function formatRepoWriteTimeoutDiagnostic(
   const telemetry = diagnostic.lastTelemetry;
   return [
     `Repo-write child request timed out after ${diagnostic.deadlineMs}ms`,
+    `watchdog=${diagnostic.watchdogStage}`,
     `command=${diagnostic.commandName}`,
     `lane=${diagnostic.lane}`,
     `waiting=${repoWriteWaitingStage(telemetry?.phase)}`,

--- a/packages/daemon/test/repo-write-client-diagnostic.test.ts
+++ b/packages/daemon/test/repo-write-client-diagnostic.test.ts
@@ -4,8 +4,7 @@ import test from "node:test";
 import {
   RepoWriteClient,
   RepoWriteDirectOutcomeUnknownError,
-  RepoWriteNotStartedError,
-  RepoWriteOutcomeUnknownError
+  RepoWriteNotStartedError
 } from "../src/runtime/repo-write-client.ts";
 import type {
   RepoWriteRequestFailureDiagnostic,
@@ -22,6 +21,7 @@ import {
   readyFrame,
   requestId
 } from "./support/repo-write-client-fixture.ts";
+import { committedCommandReceipt } from "./support/repo-write-terminal-fixture.ts";
 
 test("timeout diagnostics name the child wait for every authority submission ingress", async () => {
   const cases = [
@@ -97,7 +97,7 @@ test("durable timeout diagnostics retain the last child phase and recovery handl
     elapsedMs: 4
   });
 
-  await assert.rejects(result, RepoWriteOutcomeUnknownError);
+  await new Promise<void>((resolve) => setTimeout(resolve, 20));
   assert.ok(observed);
   assert.equal(observed.lane, "durable");
   assert.equal(observed.opId, "op-timeout-diagnostic");
@@ -105,6 +105,14 @@ test("durable timeout diagnostics retain the last child phase and recovery handl
     formatRepoWriteTimeoutDiagnostic(observed),
     /waiting=canonical-git-publication;lastPhase=git/u
   );
+  transport.emit({
+    ...childFrame("terminal"),
+    requestId: requestId(submit),
+    opId: "op-timeout-diagnostic",
+    outcome: "committed",
+    receipt: committedCommandReceipt("slow publication")
+  });
+  assert.equal((await result).summary, "slow publication");
 });
 
 test("explicit direct and durable failures report their last named child wait", async () => {

--- a/packages/daemon/test/repo-write-durable-deadline-honesty.test.ts
+++ b/packages/daemon/test/repo-write-durable-deadline-honesty.test.ts
@@ -1,0 +1,39 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { forkRepoWriteProcess } from "../src/runtime/repo-write-child-process-transport.ts";
+import { RepoWriteProcessSupervisor } from "../src/runtime/repo-write-process-supervisor.ts";
+
+const fixturePath = fileURLToPath(
+  new URL("./support/repo-write-ipc-child.ts", import.meta.url)
+);
+
+test("durable deadline observes a slow canonical publication without replacing its writer", async (context) => {
+  let forks = 0;
+  const supervisor = new RepoWriteProcessSupervisor({
+    repoId: "repo-transport",
+    generation: 1,
+    limits: { requestTimeoutMs: 40 },
+    spawn: () => {
+      forks += 1;
+      return forkRepoWriteProcess({
+        modulePath: fixturePath,
+        args: ["slow-terminal"]
+      });
+    }
+  });
+  context.after(() => supervisor.stop().catch(() => undefined));
+
+  const receipt = await supervisor.submit({
+    commandName: "record-fact",
+    actor: { personId: "person-test" },
+    context: {},
+    payload: {}
+  });
+
+  assert.equal(receipt.ok, true);
+  assert.equal(receipt.summary, "slow canonical publication");
+  assert.equal(forks, 1, "PROCEED transfers terminal ownership to the current writer");
+  assert.equal(supervisor.status().connected, true);
+});

--- a/packages/daemon/test/repo-write-process-supervisor.test.ts
+++ b/packages/daemon/test/repo-write-process-supervisor.test.ts
@@ -143,15 +143,13 @@ test("child that swallows PROCEED is replaced after the bounded stall window and
   });
   context.after(() => supervisor.stop().catch(() => undefined));
 
-  const outcome = await Promise.race([
-    supervisor.submit(command()).then(
-      () => ({ kind: "committed" as const }),
-      (error: unknown) => ({ kind: "rejected" as const, error })
-    ),
-    new Promise<{ readonly kind: "still-pending" }>((resolve) => {
-      setTimeout(() => resolve({ kind: "still-pending" }), 1_600);
-    })
-  ]);
+  // Boundedness is asserted by awaiting the rejection itself: an unbounded
+  // regression hangs into the runner's per-test timeout instead of racing a
+  // wall-clock budget that slow CI child spawns cannot meet.
+  const outcome = await supervisor.submit(command()).then(
+    () => ({ kind: "committed" as const }),
+    (error: unknown) => ({ kind: "rejected" as const, error })
+  );
 
   assert.equal(outcome.kind, "rejected");
   assert.ok(outcome.kind === "rejected" && outcome.error instanceof RepoWriteOutcomeUnknownError);

--- a/packages/daemon/test/repo-write-process-supervisor.test.ts
+++ b/packages/daemon/test/repo-write-process-supervisor.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../src/runtime/repo-write-process-supervisor.ts";
 import {
   RepoWriteDirectOutcomeUnknownError,
+  RepoWriteOutcomeUnknownError,
   RepoWriteProtocolViolationError,
   RepoWriteReadyTimeoutError
 } from "../src/runtime/repo-write-client.ts";
@@ -122,8 +123,9 @@ test("connected child that never announces READY is terminated at the readiness 
   assert.equal(supervisor.status().connected, false);
 });
 
-test("child that swallows PROCEED remains terminal owner after the observation deadline", async (context) => {
+test("child that swallows PROCEED is replaced after the bounded stall window and recovered by exact lookup", async (context) => {
   let forks = 0;
+  const timeoutDiagnostics: RepoWriteRequestTimeoutDiagnostic[] = [];
   const supervisor = new RepoWriteProcessSupervisor({
     repoId: "repo-transport",
     generation: 1,
@@ -136,20 +138,37 @@ test("child that swallows PROCEED remains terminal owner after the observation d
         modulePath: fixturePath,
         args: ["swallow-proceed"]
       });
-    }
+    },
+    onRequestTimeout: (diagnostic) => timeoutDiagnostics.push(diagnostic)
   });
   context.after(() => supervisor.stop().catch(() => undefined));
 
-  let settled = false;
-  const submission = supervisor.submit(command()).then(
-    () => { settled = true; },
-    () => { settled = true; }
+  const outcome = await Promise.race([
+    supervisor.submit(command()).then(
+      () => ({ kind: "committed" as const }),
+      (error: unknown) => ({ kind: "rejected" as const, error })
+    ),
+    new Promise<{ readonly kind: "still-pending" }>((resolve) => {
+      setTimeout(() => resolve({ kind: "still-pending" }), 1_600);
+    })
+  ]);
+
+  assert.equal(outcome.kind, "rejected");
+  assert.ok(outcome.kind === "rejected" && outcome.error instanceof RepoWriteOutcomeUnknownError);
+  assert.equal(outcome.error.code, "REPO_WRITE_STALL_TIMEOUT");
+  assert.equal(forks, 2);
+  assert.deepEqual(
+    timeoutDiagnostics.map((diagnostic) => [
+      diagnostic.watchdogStage,
+      diagnostic.deadlineMs,
+      diagnostic.opId,
+      diagnostic.lastTelemetry?.phase
+    ]),
+    [
+      ["observation", 40, timeoutDiagnostics[0]?.opId, "git"],
+      ["escalation", 80, timeoutDiagnostics[0]?.opId, "git"]
+    ]
   );
-  await new Promise<void>((resolve) => setTimeout(resolve, 80));
-  assert.equal(settled, false);
-  assert.equal(forks, 1);
-  await supervisor.stop().catch(() => undefined);
-  await submission;
 });
 
 test("non-durable task-claim timeout replaces the child without replay or lookup", async (context) => {

--- a/packages/daemon/test/repo-write-process-supervisor.test.ts
+++ b/packages/daemon/test/repo-write-process-supervisor.test.ts
@@ -13,7 +13,6 @@ import {
 } from "../src/runtime/repo-write-process-supervisor.ts";
 import {
   RepoWriteDirectOutcomeUnknownError,
-  RepoWriteOutcomeUnknownError,
   RepoWriteProtocolViolationError,
   RepoWriteReadyTimeoutError
 } from "../src/runtime/repo-write-client.ts";
@@ -123,7 +122,7 @@ test("connected child that never announces READY is terminated at the readiness 
   assert.equal(supervisor.status().connected, false);
 });
 
-test("child that swallows PROCEED releases the pending request at its deadline", async (context) => {
+test("child that swallows PROCEED remains terminal owner after the observation deadline", async (context) => {
   let forks = 0;
   const supervisor = new RepoWriteProcessSupervisor({
     repoId: "repo-transport",
@@ -141,12 +140,16 @@ test("child that swallows PROCEED releases the pending request at its deadline",
   });
   context.after(() => supervisor.stop().catch(() => undefined));
 
-  await assert.rejects(supervisor.submit(command()), (error) => {
-    assert.ok(error instanceof RepoWriteOutcomeUnknownError);
-    assert.equal(error.code, "REPO_WRITE_REQUEST_TIMEOUT");
-    return true;
-  });
-  assert.equal(forks, 2);
+  let settled = false;
+  const submission = supervisor.submit(command()).then(
+    () => { settled = true; },
+    () => { settled = true; }
+  );
+  await new Promise<void>((resolve) => setTimeout(resolve, 80));
+  assert.equal(settled, false);
+  assert.equal(forks, 1);
+  await supervisor.stop().catch(() => undefined);
+  await submission;
 });
 
 test("non-durable task-claim timeout replaces the child without replay or lookup", async (context) => {

--- a/packages/daemon/test/support/repo-write-ipc-child.ts
+++ b/packages/daemon/test/support/repo-write-ipc-child.ts
@@ -90,7 +90,19 @@ if (mode === "exit") {
       return;
     }
     if (message.kind === "proceed") {
-      if (mode === "swallow-proceed") return;
+      if (mode === "swallow-proceed") {
+        void transport.send({
+          protocol: repoWriteProtocolType,
+          repoId: message.repoId,
+          generation: message.generation,
+          kind: "telemetry",
+          requestId: message.requestId,
+          opId: message.opId,
+          phase: "git",
+          elapsedMs: 2.5
+        });
+        return;
+      }
       if (mode === "crash-after-proceed") {
         process.exit(24);
       }
@@ -116,7 +128,7 @@ if (mode === "exit") {
             outcome: "committed",
             receipt: committedCommandReceipt("slow canonical publication")
           });
-        }, 80);
+        }, 60);
         return;
       }
       void transport.send({

--- a/packages/daemon/test/support/repo-write-ipc-child.ts
+++ b/packages/daemon/test/support/repo-write-ipc-child.ts
@@ -94,6 +94,31 @@ if (mode === "exit") {
       if (mode === "crash-after-proceed") {
         process.exit(24);
       }
+      if (mode === "slow-terminal") {
+        void transport.send({
+          protocol: repoWriteProtocolType,
+          repoId: message.repoId,
+          generation: message.generation,
+          kind: "telemetry",
+          requestId: message.requestId,
+          opId: message.opId,
+          phase: "git",
+          elapsedMs: 2.5
+        });
+        setTimeout(() => {
+          void transport.send({
+            protocol: repoWriteProtocolType,
+            repoId: message.repoId,
+            generation: message.generation,
+            kind: "terminal",
+            requestId: message.requestId,
+            opId: message.opId,
+            outcome: "committed",
+            receipt: committedCommandReceipt("slow canonical publication")
+          });
+        }, 80);
+        return;
+      }
       void transport.send({
         protocol: repoWriteProtocolType,
         repoId: message.repoId,


### PR DESCRIPTION
# English

## Summary

Close the "control-flow receipt diverges from persisted fact" defect family on the write road. Two reproduced production incidents shared one semantic shape — a secondary observation (a deadline, or a post-commit cleanup error) overwrote the real committed outcome in the receipt:

1. The daemon repo-write child was declared `outcome_unknown` and SIGTERM'd by a 30s deadline while its canonical git publication was still completing (and often had already landed), producing a false error receipt plus a respawn crash loop.
2. `task submit` committed the execution atomically, then a post-commit lease release hit an expired lease; the cleanup error was wrapped as a whole-write failure — receipt said rejected, disk said submitted (reproduced twice, deterministic).

After this PR the three facts are decided by three separate instruments: publication state comes from a disk query, concurrency comes from CAS preconditions, and cleanup is an independent diagnostic that can never reverse a committed result.

## What Changed

- Daemon runtime: after PROCEED, the request deadline is a stall observation, not permission to manufacture an unknown outcome. A bounded two-stage watchdog replaces the old behavior: 30s observation, then at 60s total a single writer replacement plus an exact per-opId disk lookup; only when that lookup also cannot prove a terminal does the caller get outcome-unknown. Slow-but-completing writes (30–60s, the shape seen in both incident forensics) now wait for their real terminal. The timeout→replacement/SIGTERM path during publication is gone; child crash/disconnect recovery is unchanged.
- Application saga: authored submission success is authoritative. Post-commit lease-release failure triggers reconcile-from-authored-state and an honest `leaseReleased` value plus a typed `cleanup.status = released | retained | unknown` with diagnostics — never a failed-write receipt. A new `committed | absent | partial` publication-state query (verifying execution, INDEX, submittedAt, full submission payload) covers mid-publication errors after files applied, aligning submit with the claim path's commit-after-error determination.
- Concurrency: the submit transaction now carries execution + INDEX CAS preconditions (same discipline PR #1128 gave the claim path). A losing concurrent submit fails unless the disk submission is byte-identical to its payload (idempotent success only then). The double-fulfilled lost-update reproduction is fixed as a red-first regression test.
- CLI: submit receipts are derived from the saga's actual result (the old code hardcoded `leaseReleased: true`); cleanup diagnostics are projected as warnings instead of being swallowed.

## Task And Scope

- Harness task: task_01KYQ6Q6320E73877FPX3V19XW (30s durable deadline / crash loop) and task_01KYRBERS25X7070045SMX76RK (submit lying receipt)
- Branch: codex/write-road-receipts
- Public scope: packages/daemon runtime (repo-write client/supervisor/timeout/watchdog), packages/application (execution saga, coordinated execution store), packages/cli (submit receipt projection), tests
- Private planning/evidence updated: yes
- Out of scope: the respawn exit-1 chain's own backoff/circuit-breaker hygiene (independent resilience defect, tracked in the task; this PR removes the erroneous SIGTERM entry into that chain), generic WriteCoordinator receipt machinery (reviewed, no defect found).

## Version Impact

- Version: no version change because receipt schemas gain only additive fields (`cleanup` on execution-submit-result/v1) and no public API is removed.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: the two defect tasks above; both filed and root-caused from production incidents (forensics in task artifacts) under the standing find-it-fix-it authorization.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: 64b1b233 (merge of #1128)
- Branch merge-base with `origin/main`: 64b1b233
- Last `git fetch origin` time: 2026-07-30 (worktree created from origin/main the same day)
- Sync method: none needed
- Public diff command: `git diff 64b1b233..ad4e4a7b`
- Private evidence commit/path: both task packages (missions, review findings, fix-evidence artifacts, progress)
- Reviewer evidence path: dual-blind round-1 findings and round-2 per-finding closures recorded in task artifacts/progress
- GitHub Actions `rewrite-ci` run URL: pending first run on this PR
- [x] `git diff --check`
- [x] `npm run check:local` (36 manifest gates green, re-run at final code state)
- [x] Targeted tests for the change surface, named with their counts: application integration 66/66; daemon integration 207/207 (4 platform skips); F1 supervisor/deadline/diagnostic targeted 12/12; CLI integration 694/694; per-finding red-first negative controls (F1 unbounded pending, F2 double-fulfilled lost update, F3 partial-then-committed, F4 swallowed diagnostics) each red before its fix and green after
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: full `check:ci` matrix not run locally; GitHub CI is the authoritative full gate per repo policy and will run on this PR.

## Review Evidence

- Self-review: worker root-cause chains with per-case negative controls
- Reviewer subagent: one dual-blind round on the round-1 diff — codex adversarial (3 P1 + 1 P2, including an executed reproduction of the concurrent double-submit lost update) + GLM black-box (consensus P1 on the unbounded wedged-child hang; independent verdict that the two original defects were correctly closed). All four findings fixed in round 2 with red-first evidence; where the two reviewers disagreed (concurrency), the executed reproduction was taken over the reasoning.
- Human review: CEO personally read both rounds' diffs — the PROCEED terminal-ownership change, the two-stage watchdog escalation (receipt still derived from disk lookup on escalation, replacement failure fails closed), the CAS preconditions, and the tri-state cleanup projection
- Blocking findings: none open

## Residual Risk

- A wedged writer now costs up to ~60s before escalation (was a lying 30s kill); the bound is configurable and validated (`proceededStallTimeoutMs > requestTimeoutMs`).
- The respawn exit-1 chain still lacks backoff/circuit-breaker hygiene; its erroneous trigger from this incident class is removed, and the independent hardening is tracked in the task ledger.
- `leaseReleased` remains a compatibility boolean; consumers wanting exact cleanup semantics should read the new `cleanup.status`.

## References

- Task: task_01KYQ6Q6320E73877FPX3V19XW, task_01KYRBERS25X7070045SMX76RK
- Evidence: incident forensics and fix-evidence artifacts in both task packages; review round-1 findings artifact
- Review: dual-blind round recorded in task artifacts

---

# 中文

## 概要

关闭写路上「控制流回执脱离持久化事实」缺陷族。两起已复现的生产事故共享同一语义形状——次级观察(deadline 或 post-commit 清理错误)在回执里覆盖了真实的已提交结果:

1. daemon repo-write 子进程在 canonical git publication 仍在完成(且常已落盘)时被 30s deadline 判为 `outcome_unknown` 并 SIGTERM,产生假错误回执 + respawn 崩溃循环。
2. `task submit` 已原子落盘,post-commit 的 lease release 撞上过期 lease,清理错误被包装成整个写入失败——回执说拒绝,磁盘说已提交(两次确定性复现)。

本 PR 之后,三种事实由三种独立仪器裁定:publication 状态来自磁盘查询,并发来自 CAS 前置,cleanup 是独立诊断,永远不能反转已提交结果。

## 改动内容

- daemon runtime:PROCEED 之后 deadline 只是 stall 观察,不再有权制造 unknown。有界二阶段看门狗取代旧行为:30s 观察,总计 60s 升级——单次替换 writer + 按 opId 精确磁盘 lookup;只有 lookup 也无法证明终局才返回 outcome-unknown。30–60s 完成的慢写(两起事故取证的真实形状)如实等待真实终局。publication 期间的 timeout→replacement/SIGTERM 路径删除;child 崩溃/断连恢复不变。
- application saga:authored 提交成功即权威。post-commit lease release 失败触发从 authored state 对账,返回诚实的 `leaseReleased` + 类型化 `cleanup.status = released | retained | unknown` 与诊断——绝不返回假失败。新增 `committed | absent | partial` 精确 publication 查询(核验 execution、INDEX、submittedAt、完整 submission 字段),覆盖文件已 apply 后 git/attribution 阶段报错的场景,使 submit 与 claim 路径的 commit-after-error 判定对齐。
- 并发:submit 事务补上 execution + INDEX CAS 前置(与 PR #1128 给 claim 路径的同一纪律)。并发落败方除非磁盘 submission 与其 payload 逐字节一致(幂等成功),否则失败。「双 fulfilled 丢更新」的复现已固化为先红回归测试。
- CLI:submit 回执由 saga 真实结果派生(旧代码硬编码 `leaseReleased: true`);cleanup 诊断以 warning 投影,不再静默吞错。

## 任务与范围

- Harness 任务:task_01KYQ6Q6320E73877FPX3V19XW(30s durable deadline / 崩溃循环)与 task_01KYRBERS25X7070045SMX76RK(submit 回执撒谎)
- 分支:codex/write-road-receipts
- 公开范围:packages/daemon runtime(repo-write client/supervisor/timeout/watchdog)、packages/application(execution saga、coordinated execution store)、packages/cli(submit 回执投影)、测试
- 私有计划 / 证据是否已更新:yes
- 范围外:respawn exit-1 链自身的 backoff/熔断治理(独立韧性缺陷,已记任务台账;本 PR 移除了本事故类进入该链的错误入口)、通用 WriteCoordinator 回执机制(已评审,未发现缺陷)。

## 版本影响

- 版本:不改版本,原因是回执 schema 仅新增字段(execution-submit-result/v1 增加 `cleanup`),无公开 API 移除。
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:上述两个缺陷任务,均由生产事故取证立案(取证在任务 artifacts),在「发现即修」常设授权范围内。
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无

## 验证

- `origin/main` 基准 SHA:64b1b233(#1128 合并点)
- 当前分支与 `origin/main` 的 merge-base:64b1b233
- 最近一次 `git fetch origin` 时间:2026-07-30(worktree 当日从 origin/main 建出)
- 同步方式:不需要
- 公开 diff 命令:`git diff 64b1b233..ad4e4a7b`
- 私有证据 commit/path:两任务包(mission、评审 findings、fix-evidence artifacts、progress)
- Reviewer 证据路径:双盲 round-1 findings 与 round-2 逐条闭合记录于任务 artifacts/progress
- GitHub Actions `rewrite-ci` run URL:等待本 PR 首跑
- [x] `git diff --check`
- [x] `npm run check:local`(36 个 manifest gates 全绿,最终代码态复跑)
- [x] 改动面的定向测试,写明测试名与通过数:application integration 66/66;daemon integration 207/207(4 个平台 skip);F1 supervisor/deadline/diagnostic 定向 12/12;CLI integration 694/694;逐 finding 先红阴性对照(F1 无界 pending、F2 双 fulfilled 丢更新、F3 partial→committed、F4 吞诊断)修复前红、修复后绿
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- 未跑项及原因:完整 `check:ci` 矩阵未在本地跑;按仓库政策 GitHub CI 是权威全量门,将在本 PR 上运行。

## 审查证据

- 自查:worker 根因链 + 逐案阴性对照
- Reviewer subagent:对 round-1 diff 做一轮双盲——codex 对抗(3 P1 + 1 P2,含并发双 submit 丢更新的**实际执行复现**)+ GLM 黑盒(共识 P1=楔死 child 无界挂起;独立判定两个原始缺陷已正确闭合)。四条 findings 全部在 round-2 以先红后绿证据修复;两位评审员分歧处(并发)以执行复现为准。
- 人工审查:CEO 亲读两轮 diff——PROCEED 终态所有权变更、二阶段看门狗升级(升级路径回执仍由磁盘 lookup 派生,replacement 失败 fail closed)、CAS 前置、三态 cleanup 投影
- 阻塞发现:无未关闭项

## 残余风险

- 楔死 writer 现在最多消耗 ~60s 才升级(旧行为是 30s 撒谎击杀);边界可配置且有校验(`proceededStallTimeoutMs > requestTimeoutMs`)。
- respawn exit-1 链仍缺 backoff/熔断治理;本事故类的错误触发入口已移除,独立加固已记任务台账。
- `leaseReleased` 保留为兼容布尔;需要精确 cleanup 语义的消费方应读新的 `cleanup.status`。

## 关联材料

- 任务:task_01KYQ6Q6320E73877FPX3V19XW、task_01KYRBERS25X7070045SMX76RK
- 证据:两任务包内的事故取证与 fix-evidence artifacts;评审 round-1 findings artifact
- 审查:双盲评审轮记录于任务 artifacts

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
