### PR TITLE
fix(daemon): arm repo-write request deadline at dispatch, bound queued requests

### DIFF
--- a/packages/daemon/src/runtime/repo-write-client-contract.ts
+++ b/packages/daemon/src/runtime/repo-write-client-contract.ts
@@ -28,7 +28,7 @@ export interface RepoWriteClientLimits {
   readonly readyTimeoutMs: number;
   readonly requestTimeoutMs: number;
   /**
-   * Total wall time from submit until a proceeded operation is escalated.
+   * Total wall time from request dispatch until a proceeded operation is escalated.
    * The default is two request windows: 30s observes, 60s replaces and looks up.
    */
   readonly proceededStallTimeoutMs: number;

--- a/packages/daemon/src/runtime/repo-write-client-direct.ts
+++ b/packages/daemon/src/runtime/repo-write-client-direct.ts
@@ -169,6 +169,15 @@ export class RepoWriteDirectClientLane {
     }
   }
 
+  rejectQueued(error: Error & { readonly code: string }): void {
+    for (const [requestId, pending] of this.pending) {
+      if (pending.phase !== "queued") continue;
+      clearTimeout(pending.timer);
+      this.pending.delete(requestId);
+      pending.reject(new RepoWriteNotStartedError(error.code, error.message));
+    }
+  }
+
   telemetryMatches(message: RepoWriteTelemetryFrame): boolean {
     const pending = this.pending.get(message.requestId);
     return pending?.phase === "sent" && message.opId === undefined;

--- a/packages/daemon/src/runtime/repo-write-client-pending-lifecycle.ts
+++ b/packages/daemon/src/runtime/repo-write-client-pending-lifecycle.ts
@@ -1,0 +1,65 @@
+import type { RepoWriteRequestTimeoutDiagnostic } from "./repo-write-client-contract.ts";
+import type { RepoWriteDirectClientLane } from "./repo-write-client-direct.ts";
+import {
+  RepoWriteLookupError,
+  RepoWriteProtocolViolationError
+} from "./repo-write-client-errors.ts";
+import type {
+  PendingLookup,
+  PendingSubmit
+} from "./repo-write-client-pending.ts";
+import { expireRepoWriteSubmit } from "./repo-write-client-timeout.ts";
+import { armRepoWriteSubmitEscalation } from "./repo-write-client-watchdog.ts";
+
+export function rejectRepoWriteQueuedRequests(
+  submits: Map<string, PendingSubmit>,
+  direct: RepoWriteDirectClientLane,
+  lookups: Map<string, PendingLookup>,
+  error: Error & { readonly code: string }
+): void {
+  for (const [requestId, pending] of submits) {
+    if (pending.phase !== "queued") continue;
+    clearTimeout(pending.timer);
+    submits.delete(requestId);
+    pending.reject(error);
+  }
+  direct.rejectQueued(error);
+  for (const [requestId, pending] of lookups) {
+    if (pending.phase !== "queued") continue;
+    clearTimeout(pending.timer);
+    lookups.delete(requestId);
+    pending.reject(new RepoWriteLookupError(error.code, error.message, pending.opId));
+  }
+}
+
+export function expireRepoWritePendingSubmit(
+  requestId: string,
+  pendingRequests: Map<string, PendingSubmit>,
+  limits: {
+    readonly requestTimeoutMs: number;
+    readonly proceededStallTimeoutMs: number;
+  },
+  onTimeout: ((diagnostic: RepoWriteRequestTimeoutDiagnostic) => void) | undefined
+): void {
+  const pending = pendingRequests.get(requestId);
+  if (!pending) return;
+  const outcome = expireRepoWriteSubmit(pending, limits.requestTimeoutMs, onTimeout);
+  if (outcome === "queued") {
+    clearTimeout(pending.timer);
+    pendingRequests.delete(requestId);
+    pending.reject(new RepoWriteProtocolViolationError(
+      "Repo writer request deadline fired before dispatch."
+    ));
+    return;
+  }
+  if (outcome === "expired") pendingRequests.delete(requestId);
+  if (outcome === "observed") {
+    armRepoWriteSubmitEscalation({
+      pending,
+      pendingRequests,
+      delayMs: limits.proceededStallTimeoutMs - limits.requestTimeoutMs,
+      totalTimeoutMs: limits.proceededStallTimeoutMs,
+      onTimeout
+    });
+  }
+}

--- a/packages/daemon/src/runtime/repo-write-client-pending.ts
+++ b/packages/daemon/src/runtime/repo-write-client-pending.ts
@@ -10,7 +10,7 @@ export interface PendingSubmit {
   readonly command: RepoWriteCommandDto;
   readonly resolve: (receipt: RepoWriteJsonObject) => void;
   readonly reject: (error: Error) => void;
-  timer: NodeJS.Timeout;
+  timer: NodeJS.Timeout | undefined;
   phase: "queued" | "submitted" | "prepared" | "proceeded";
   opId?: string;
   lastTelemetry?: RepoWriteTelemetryFrame;

--- a/packages/daemon/src/runtime/repo-write-client-timeout.ts
+++ b/packages/daemon/src/runtime/repo-write-client-timeout.ts
@@ -27,7 +27,8 @@ export function expireRepoWriteSubmit(
   pending: PendingSubmit,
   timeoutMs: number,
   observer: TimeoutObserver | undefined
-): "observed" | "expired" {
+): "queued" | "observed" | "expired" {
+  if (pending.phase === "queued") return "queued";
   const diagnostic =
     `Repo writer request exceeded its ${timeoutMs}ms deadline.`
     + repoWriteTelemetryTimeoutSuffix(pending.lastTelemetry);

--- a/packages/daemon/src/runtime/repo-write-client.ts
+++ b/packages/daemon/src/runtime/repo-write-client.ts
@@ -135,17 +135,12 @@ export class RepoWriteClient {
     }
     const requestId = this.nextRequestId();
     const result = new Promise<RepoWriteJsonObject>((resolve, reject) => {
-      const timer = setTimeout(
-        () => this.expireSubmit(requestId),
-        this.limits.requestTimeoutMs
-      );
-      timer.unref();
       this.pending.set(requestId, {
         requestId,
         command,
         resolve,
         reject,
-        timer,
+        timer: undefined,
         phase: "queued"
       });
     });
@@ -228,6 +223,11 @@ export class RepoWriteClient {
     const pending = this.pending.get(requestId);
     if (!pending || pending.phase !== "queued") return;
     pending.phase = "submitted";
+    pending.timer = setTimeout(
+      () => this.expireSubmit(requestId),
+      this.limits.requestTimeoutMs
+    );
+    pending.timer.unref();
     try {
       const sent = this.options.transport.send({
         ...repoWriteClientFrameBase(this.options.repoId, this.options.generation),

--- a/packages/daemon/src/runtime/repo-write-client.ts
+++ b/packages/daemon/src/runtime/repo-write-client.ts
@@ -16,8 +16,11 @@ import type {
 import type { RepoWriteClientLimits, RepoWriteClientOptions } from "./repo-write-client-contract.ts";
 import { resolveRepoWriteClientLimits } from "./repo-write-client-limits.ts";
 import {
+  expireRepoWritePendingSubmit,
+  rejectRepoWriteQueuedRequests
+} from "./repo-write-client-pending-lifecycle.ts";
+import {
   expireRepoWriteLookup,
-  expireRepoWriteSubmit,
   failRepoWriteLookup,
   failRepoWriteSubmit
 } from "./repo-write-client-timeout.ts";
@@ -30,7 +33,6 @@ import {
   observeRepoWriteTelemetry,
   repoWriteClientFrameBase
 } from "./repo-write-client-observers.ts";
-import { armRepoWriteSubmitEscalation } from "./repo-write-client-watchdog.ts";
 export type { RepoWriteClientLimits, RepoWriteClientOptions, RepoWriteClientTransport } from "./repo-write-client-contract.ts";
 import {
   RepoWriteClientCapacityError,
@@ -115,6 +117,7 @@ export class RepoWriteClient {
       this.readyPending = undefined;
       const error = new RepoWriteReadyTimeoutError(this.limits.readyTimeoutMs);
       this.terminalError = error;
+      rejectRepoWriteQueuedRequests(this.pending, this.directLane, this.pendingLookups, error);
       pending.reject(error);
     }, this.limits.readyTimeoutMs);
     timer.unref();
@@ -193,9 +196,11 @@ export class RepoWriteClient {
       return Promise.reject(new Error("timeoutMs must be a positive safe integer"));
     }
     this.closing = true;
+    const closed = new RepoWriteClientClosedError();
     if (this.readyPending) clearTimeout(this.readyPending.timer);
-    this.readyPending?.reject(new RepoWriteClientClosedError());
+    this.readyPending?.reject(closed);
     this.readyPending = undefined;
+    rejectRepoWriteQueuedRequests(this.pending, this.directLane, this.pendingLookups, closed);
     const requestId = this.nextRequestId();
     let resolveShutdown: (() => void) | undefined;
     let rejectShutdown: ((error: Error) => void) | undefined;
@@ -495,23 +500,12 @@ export class RepoWriteClient {
   }
 
   private expireSubmit(requestId: string): void {
-    const pending = this.pending.get(requestId);
-    if (!pending) return;
-    const outcome = expireRepoWriteSubmit(
-      pending,
-      this.limits.requestTimeoutMs,
+    expireRepoWritePendingSubmit(
+      requestId,
+      this.pending,
+      this.limits,
       this.options.onRequestTimeout
     );
-    if (outcome === "expired") this.pending.delete(requestId);
-    if (outcome === "observed") {
-      armRepoWriteSubmitEscalation({
-        pending,
-        pendingRequests: this.pending,
-        delayMs: this.limits.proceededStallTimeoutMs - this.limits.requestTimeoutMs,
-        totalTimeoutMs: this.limits.proceededStallTimeoutMs,
-        onTimeout: this.options.onRequestTimeout
-      });
-    }
   }
 
   private expireLookup(requestId: string): void {

--- a/packages/daemon/test/repo-write-client.test.ts
+++ b/packages/daemon/test/repo-write-client.test.ts
@@ -60,6 +60,47 @@ test("waits for ready, records prepared opId, proceeds, and resolves only at ter
   assert.deepEqual(await result, receipt);
 });
 
+test("starts the durable request deadline only after READY dispatches the request", async () => {
+  const transport = new FakeRepoWriteTransport();
+  const timeoutDiagnostics: unknown[] = [];
+  const client = new RepoWriteClient({
+    repoId: "repo-canonical",
+    generation: 7,
+    transport,
+    limits: { requestTimeoutMs: 10 },
+    onTelemetry: () => undefined,
+    onRequestTimeout: (diagnostic) => timeoutDiagnostics.push(diagnostic)
+  });
+  const result = client.submit(command("task.create"));
+  const outcome = result.then(
+    (receipt) => ({ kind: "resolved" as const, receipt }),
+    (error: unknown) => ({ kind: "rejected" as const, error })
+  );
+
+  await new Promise<void>((resolve) => setTimeout(resolve, 50));
+  assert.deepEqual(transport.sent, []);
+  assert.deepEqual(timeoutDiagnostics, []);
+
+  transport.emit(readyFrame());
+  const submit = transport.sent.at(-1);
+  const receipt = committedCommandReceipt();
+  assert.equal(submit?.kind, "submit");
+  transport.emit({
+    ...childFrame("prepared"),
+    requestId: requestId(submit),
+    opId: "op-after-ready"
+  });
+  transport.emit({
+    ...childFrame("terminal"),
+    requestId: requestId(submit),
+    opId: "op-after-ready",
+    outcome: "committed",
+    receipt
+  });
+
+  assert.deepEqual(await outcome, { kind: "resolved", receipt });
+});
+
 test("reports historical recovery diagnostics before READY without failing the writer", async () => {
   const transport = new FakeRepoWriteTransport();
   const diagnostics: unknown[] = [];

--- a/packages/daemon/test/repo-write-client.test.ts
+++ b/packages/daemon/test/repo-write-client.test.ts
@@ -9,6 +9,7 @@ import {
   RepoWriteNotStartedError,
   RepoWriteOutcomeUnknownError,
   RepoWriteProtocolViolationError,
+  RepoWriteReadyTimeoutError,
   RepoWriteShutdownTimeoutError
 } from "../src/runtime/repo-write-client.ts";
 import {
@@ -99,6 +100,69 @@ test("starts the durable request deadline only after READY dispatches the reques
   });
 
   assert.deepEqual(await outcome, { kind: "resolved", receipt });
+});
+
+test("rejects a queued durable request when the writer misses its READY deadline", async () => {
+  const transport = new FakeRepoWriteTransport();
+  const client = new RepoWriteClient({
+    repoId: "repo-canonical",
+    generation: 7,
+    transport,
+    limits: { readyTimeoutMs: 10, requestTimeoutMs: 50 },
+    onTelemetry: () => undefined
+  });
+  const ready = client.waitUntilReady().then(
+    () => ({ kind: "resolved" as const }),
+    (error: unknown) => ({ kind: "rejected" as const, error })
+  );
+  const submission = client.submit(command("task.create")).then(
+    () => ({ kind: "resolved" as const }),
+    (error: unknown) => ({ kind: "rejected" as const, error })
+  );
+
+  const outcome = await Promise.race([
+    submission,
+    new Promise<{ readonly kind: "still-pending" }>((resolve) => {
+      setTimeout(() => resolve({ kind: "still-pending" }), 100);
+    })
+  ]);
+
+  assert.equal(outcome.kind, "rejected");
+  assert.ok(outcome.kind === "rejected" && outcome.error instanceof RepoWriteReadyTimeoutError);
+  const readyOutcome = await ready;
+  assert.ok(readyOutcome.kind === "rejected" && readyOutcome.error instanceof RepoWriteReadyTimeoutError);
+  assert.deepEqual(transport.sent, []);
+});
+
+test("shutdown rejects a queued durable request before READY", async () => {
+  const transport = new FakeRepoWriteTransport();
+  const client = fixtureClient(transport);
+  const submission = client.submit(command("task.create")).then(
+    () => ({ kind: "resolved" as const }),
+    (error: unknown) => ({ kind: "rejected" as const, error })
+  );
+  const shutdown = client.shutdown({ timeoutMs: 1_000 }).then(
+    () => ({ kind: "resolved" as const }),
+    (error: unknown) => ({ kind: "rejected" as const, error })
+  );
+
+  const outcome = await Promise.race([
+    submission,
+    new Promise<{ readonly kind: "still-pending" }>((resolve) => {
+      setTimeout(() => resolve({ kind: "still-pending" }), 50);
+    })
+  ]);
+
+  assert.equal(outcome.kind, "rejected");
+  assert.ok(outcome.kind === "rejected" && outcome.error instanceof RepoWriteClientClosedError);
+  transport.emit(readyFrame());
+  const shutdownFrame = transport.sent.at(-1);
+  assert.equal(shutdownFrame?.kind, "shutdown");
+  transport.emit({
+    ...childFrame("drained"),
+    requestId: requestId(shutdownFrame)
+  });
+  assert.deepEqual(await shutdown, { kind: "resolved" });
 });
 
 test("reports historical recovery diagnostics before READY without failing the writer", async () => {

--- a/packages/daemon/test/repo-write-durable-deadline-honesty.test.ts
+++ b/packages/daemon/test/repo-write-durable-deadline-honesty.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 import { forkRepoWriteProcess } from "../src/runtime/repo-write-child-process-transport.ts";
+import type { RepoWriteRequestTimeoutDiagnostic } from "../src/runtime/repo-write-client-contract.ts";
 import { RepoWriteProcessSupervisor } from "../src/runtime/repo-write-process-supervisor.ts";
 
 const fixturePath = fileURLToPath(
@@ -11,6 +12,7 @@ const fixturePath = fileURLToPath(
 
 test("durable deadline observes a slow canonical publication without replacing its writer", async (context) => {
   let forks = 0;
+  const timeoutDiagnostics: RepoWriteRequestTimeoutDiagnostic[] = [];
   const supervisor = new RepoWriteProcessSupervisor({
     repoId: "repo-transport",
     generation: 1,
@@ -23,7 +25,8 @@ test("durable deadline observes a slow canonical publication without replacing i
         modulePath: fixturePath,
         args: ["slow-terminal"]
       });
-    }
+    },
+    onRequestTimeout: (diagnostic) => timeoutDiagnostics.push(diagnostic)
   });
   context.after(() => supervisor.stop().catch(() => undefined));
 
@@ -36,6 +39,10 @@ test("durable deadline observes a slow canonical publication without replacing i
 
   assert.equal(receipt.ok, true);
   assert.equal(receipt.summary, "slow canonical publication");
+  assert.ok(timeoutDiagnostics.some((diagnostic) =>
+    diagnostic.watchdogStage === "observation"
+    && diagnostic.deadlineMs === 40
+    && diagnostic.lane === "durable"));
   assert.equal(forks, 1, "PROCEED transfers terminal ownership to the current writer");
   assert.equal(supervisor.status().connected, true);
 });

--- a/packages/daemon/test/repo-write-durable-deadline-honesty.test.ts
+++ b/packages/daemon/test/repo-write-durable-deadline-honesty.test.ts
@@ -14,7 +14,9 @@ test("durable deadline observes a slow canonical publication without replacing i
   const supervisor = new RepoWriteProcessSupervisor({
     repoId: "repo-transport",
     generation: 1,
-    limits: { requestTimeoutMs: 40 },
+    // Keep the 40ms observation deadline below the fixture's 60ms terminal,
+    // while leaving an order-of-magnitude margin before stall escalation.
+    limits: { requestTimeoutMs: 40, proceededStallTimeoutMs: 1_000 },
     spawn: () => {
       forks += 1;
       return forkRepoWriteProcess({


### PR DESCRIPTION
# English

## Summary

Shape-level fix for the repo-write request deadline: `requestTimeoutMs` now measures what it claims — time after the request is actually dispatched to the child — instead of starting at enqueue and silently counting child fork/cold-start time. This was the root cause of the "durable deadline observes a slow canonical publication" test going red intermittently three times (twice on PR CI, once on main run 30569595459): on a loaded machine the 40ms deadline fired before the child was even READY.

## What Changed

- The per-request deadline timer is armed in `dispatchSubmit` (when the frame is actually sent after READY), not in `submit()` enqueue. `proceededStallTimeoutMs` documentation updated to match the new anchor; the escalation window arithmetic is unchanged and `proceededStallTimeoutMs > requestTimeoutMs` is still enforced.
- Bounded failure for queued requests is preserved on every exit path (blind-review findings, all fixed): READY timeout now rejects all queued submits/direct/lookups when it sets the terminal error; `shutdown()` before READY rejects queued requests instead of leaving them hanging; a deadline that somehow fires while still queued rejects explicitly instead of silently leaking.
- Tests: a negative-control regression (red before the fix, green after) for the cold-start scenario; two new bounded-failure regressions (never-READY, shutdown-before-READY); the honesty test now also asserts the observation diagnostic actually fires via `onRequestTimeout` instead of passing vacuously.

## Task And Scope

- Harness task: task_01KYT49ZRRVTDEGRP0J0R3Y0W0
- Branch: codex/durable-deadline
- Public scope: packages/daemon/src/runtime (repo-write client timing semantics), packages/daemon/test
- Private planning/evidence updated: yes
- Out of scope: contraction batches B-2/B-3 (parallel lines), any protocol frame or PROCEED ownership semantics (unchanged).

## Version Impact

- Version: no version change because this repository versions releases through dedicated release tasks
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: daemon production write path (repo-write client/supervisor timing)
- Authority: related to dec_01KYS8HGNH1S445TXG53SJESKA lineage (flake exposed three times during contraction-batch CI); task ledger records the shape-level adjudication; parent/child recovery deadline strict ordering (25s < 30s) verified unchanged
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none required

## Verification

- Base `origin/main` SHA: 47306a71
- Branch merge-base with `origin/main`: 47306a71
- Last `git fetch origin` time: 2026-07-31, before dispatching the worker
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/durable-deadline`
- Private evidence commit/path: harness task artifacts implementation-report.md (root cause, invariant placement, before/after timing, runner output)
- Reviewer evidence path: GLM blind-review findings and their dispositions in the same report
- GitHub Actions `rewrite-ci` run URL: pending (attached by CI on this PR)
- [x] `git diff --check`
- [x] `npm run check:stop-point`
- [x] Targeted tests for the change surface, named with their counts: negative control red-before/green-after for the cold-start scenario; daemon fast 183/183; daemon integration 208 pass / 4 platform-skip / 0 fail; key regression set 31/31; `npm run check:local` exit 0 (37 gates green)
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: full CI matrix runs on GitHub Actions per the local stop-point policy.

## Review Evidence

- Self-review: worker report with negative-control evidence (pre-fix red reproduction, post-fix green)
- Reviewer subagent: GLM adversarial blind review of the production diff — 2 P1 (queued requests could hang unboundedly when the child never becomes READY, and on shutdown-before-READY) + 3 P2 (silent-leak guard, missing regression coverage, vacuous observation assertion); all five implemented and re-verified
- Human review: CEO traced supervisor call chain (submit only after waitUntilReady) and failProtocol/pending flush paths before and after the fix
- Blocking findings: none outstanding

## Residual Risk

- Direct users of the exported `RepoWriteClient` that enqueue before READY now get explicit bounded rejections (ready-timeout / closed) instead of a mislabeled request timeout; supervisors and production paths are unaffected.
- The honesty test still uses real timers for the slow-publication fixture, but the deadline anchor no longer races the fork, and the observation assertion pins the mechanism.

## References

- Task: task_01KYT49ZRRVTDEGRP0J0R3Y0W0
- Evidence: task artifacts implementation-report.md
- Review: GLM findings + dispositions recorded in the same report

---

# 中文

## 概要

repo-write 请求 deadline 的形状级修复:`requestTimeoutMs` 现在度量它声称度量的东西——请求真正下发给 child 之后的时间——而不是从排队起算、把 child fork 冷启动时间静默计入。这是 "durable deadline observes a slow canonical publication" 测试三次间歇红(PR CI 两次、main run 30569595459 一次)的根因:慢机上 40ms deadline 在 child READY 之前就触发。

## 改动内容

- 每请求 deadline 计时器改在 `dispatchSubmit`(READY 后帧实际发送时)arm,不在 `submit()` 排队时。`proceededStallTimeoutMs` 注释同步更新;升级窗口算术不变,`proceededStallTimeoutMs > requestTimeoutMs` 约束仍强制。
- 每条出口路径上 queued 请求的有界失败均保留(盲验 findings,全部修复):READY 超时置 terminal error 时同步拒绝全部 queued submits/direct/lookups;READY 前 `shutdown()` 拒绝 queued 请求而非悬挂;deadline 若在 queued 态触发,显式拒绝而非静默泄漏。
- 测试:冷启动场景的阴性对照回归(修前红/修后绿);两条有界失败回归(永不 READY、READY 前 shutdown);honesty 测试新增 `onRequestTimeout` 断言 observation diagnostic 确实触发,不再空转通过。

## 任务与范围

- Harness 任务:task_01KYT49ZRRVTDEGRP0J0R3Y0W0
- 分支:codex/durable-deadline
- 公开范围:packages/daemon/src/runtime(repo-write 客户端时序语义)、packages/daemon/test
- 私有计划 / 证据是否已更新:yes
- 范围外:收缩批次 B-2/B-3(并行线)、协议帧与 PROCEED 所有权语义(未动)。

## 版本影响

- 版本:不改版本,原因是本仓通过独立 release task 管理版本发布
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:yes
- protected surface 范围:daemon 生产写路径(repo-write client/supervisor 时序)
- 依据:dec_01KYS8HGNH1S445TXG53SJESKA 谱系(收缩批次 CI 三次暴露该 flake);任务台账记录形状级裁决;父子恢复 deadline 严格序(25s < 30s)验证未变
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无需

## 验证

- `origin/main` 基准 SHA:47306a71
- 当前分支与 `origin/main` 的 merge-base:47306a71
- 最近一次 `git fetch origin` 时间:2026-07-31,派 worker 前
- 同步方式:自 origin/main 开分支
- 公开 diff 命令:`git diff origin/main...codex/durable-deadline`
- 私有证据 commit/path:任务 artifacts implementation-report.md(根因、不变量落点、修前后时序、runner 输出)
- Reviewer 证据路径:GLM 盲验 findings 与处置在同一报告
- GitHub Actions `rewrite-ci` run URL:pending(由本 PR 的 CI 附上)
- [x] `git diff --check`
- [x] `npm run check:stop-point`
- [x] 改动面的定向测试,写明测试名与通过数:冷启动场景阴性对照(修前红/修后绿);daemon fast 183/183;daemon integration 208 过/4 平台 skip/0 败;关键回归集 31/31;`npm run check:local` exit 0(37 门全绿)
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- 未跑项及原因:完整 CI 矩阵按本地停止点政策由 GitHub Actions 执行。

## 审查证据

- 自查:worker 报告含阴性对照证据(修前红复现、修后绿)
- Reviewer subagent:GLM 对生产 diff 对抗盲验——2 P1(child 永不 READY 时 queued 请求无界悬挂;READY 前 shutdown 同样悬挂)+ 3 P2(静默泄漏防护、回归覆盖缺失、observation 断言空转);五条全部落实并复验
- 人工审查:CEO 修前修后追 supervisor 调用链(submit 仅在 waitUntilReady 后)与 failProtocol/pending flush 路径
- 阻塞发现:无

## 残余风险

- 直接使用导出 `RepoWriteClient` 且 READY 前排队的调用方,现在得到显式有界拒绝(ready-timeout / closed)而非语义错标的请求超时;supervisor 与生产路径不受影响。
- honesty 测试的慢发布 fixture 仍用真实计时器,但 deadline 锚点不再与 fork 竞速,且 observation 断言钉死了机制本身。

## 关联材料

- 任务:task_01KYT49ZRRVTDEGRP0J0R3Y0W0
- 证据:任务 artifacts implementation-report.md
- 审查:GLM findings 与处置记录在同一报告

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
