### PR TITLE
fix: unblock task return to planned (reclaim-direction lease gate + single reclaim guard enforcement)

### DIFF
--- a/packages/application/src/authority/daemon-host-contract.ts
+++ b/packages/application/src/authority/daemon-host-contract.ts
@@ -312,6 +312,10 @@ export interface DaemonServiceHostServices<
     rootInput: Exclude<HarnessLayoutInput, string>,
     commandOptions: { readonly onCommandStart: () => void; readonly onCommandSettled: () => void }
   ) => Pick<LocalControllerServiceOptions, "catalogSnapshotReader" | "decisionMutationPort">;
+  readonly readTaskReturnToIdeaSnapshot: (
+    rootInput: HarnessLayoutInput,
+    taskId: string
+  ) => Promise<import("./task-return-to-idea-policy.ts").TaskReturnToIdeaSnapshotV1>;
   readonly leaseEnforcementEnabled: (rootInput: HarnessLayoutInput) => boolean;
   readonly version: () => string;
 }

--- a/packages/application/src/local-controller-runtime-options.ts
+++ b/packages/application/src/local-controller-runtime-options.ts
@@ -17,6 +17,7 @@ import type {
   TaskDocumentPayload,
   TaskIdPayload
 } from "./index.ts";
+import type { ReadTaskReturnToIdeaSnapshotV1 } from "./authority/task-return-to-idea-policy.ts";
 
 export interface LocalControllerServiceOptions {
   readonly rootDir: string;
@@ -29,6 +30,7 @@ export interface LocalControllerServiceOptions {
   readonly agentRuntimeInventoryReader?: () => Promise<import("./index.ts").AgentRuntimeInventoryResult>;
   readonly agentRuntimeControl?: AgentRuntimeControlService;
   readonly agentHolderProjection?: AgentHolderProjectionService;
+  readonly readTaskReturnToIdeaSnapshot?: ReadTaskReturnToIdeaSnapshotV1;
 }
 export interface LocalControllerProjectionQueries {
   readonly getExecutionEvidencePage: (

--- a/packages/application/src/local-controller-service.ts
+++ b/packages/application/src/local-controller-service.ts
@@ -40,7 +40,8 @@ export function makeLocalControllerService(options: LocalControllerServiceOption
     rootDir,
     layoutOverrides: options.layoutOverrides,
     taskWriter,
-    artifactStore: options.artifactStore
+    artifactStore: options.artifactStore,
+    readTaskReturnToIdeaSnapshot: options.readTaskReturnToIdeaSnapshot
   });
 
   return {

--- a/packages/application/src/public-exports.ts
+++ b/packages/application/src/public-exports.ts
@@ -203,6 +203,7 @@ export {
 export type { ExecutionRetirementResult, ExecutionRetirementService } from "./execution-retirement-service.ts";
 export { makeFactWriteService } from "./fact-write-service.ts";
 export {
+  taskStatusLeaseRequired,
   taskWriteApiRoutePolicies,
   taskWriteCliRoutePolicies,
   taskWriteCliRoutePolicy

--- a/packages/application/src/task-lifecycle-orchestrator.ts
+++ b/packages/application/src/task-lifecycle-orchestrator.ts
@@ -5,7 +5,7 @@ import type { HarnessLayoutOverrides } from "@harness-anything/kernel";
 import { readFrontmatter, readScalar } from "@harness-anything/kernel";
 import { evaluateCodeDocReconciliationGate } from "./code-doc-reconciliation.ts";
 import { parseTaskContractSnapshot, resolveTaskCompletionGates } from "./task-contract-snapshot.ts";
-import { evaluateCompletionGate } from "./task-lifecycle-gates.ts";
+import { evaluateCompletionGate, evaluateTaskReturnToIdeaGate } from "./task-lifecycle-gates.ts";
 import type { CompletionCiGateStatus, TaskDocumentPlaceholderPolicy, VerifierBackedReviewContract } from "./task-lifecycle-gates.ts";
 import type { ExecutionCompletionService } from "./execution-completion-service.ts";
 import { evaluateTaskCompletionAuthority, type CommitCompletionService, type TaskCompletionEvidence, type TaskCompletionEvidenceMode } from "./task-completion-authority.ts";
@@ -19,6 +19,7 @@ import {
 } from "./task-lifecycle-orchestrator-helpers.ts";
 import { collectCompletionRequirementIssues, completionRequirementsFailure, isExecutionCompletionRequirement, validateCompletionDocumentPlaceholders } from "./task-completion-requirements.ts";
 import { validateTaskPlanAdmissionPreflight } from "./task-plan-admission-preflight.ts";
+import type { ReadTaskReturnToIdeaSnapshotV1 } from "./authority/task-return-to-idea-policy.ts";
 
 type CompletionGateResult = ReturnType<typeof evaluateCompletionGate> & {
   readonly evidenceMode?: TaskCompletionEvidenceMode;
@@ -63,6 +64,7 @@ export interface TaskLifecycleOrchestratorOptions {
     readonly preset?: string;
     readonly profile?: string;
   }) => ReadonlyArray<string>;
+  readonly readTaskReturnToIdeaSnapshot?: ReadTaskReturnToIdeaSnapshotV1;
 }
 
 export interface TaskLifecycleError {
@@ -155,6 +157,31 @@ export function makeTaskLifecycleOrchestrator(options: TaskLifecycleOrchestrator
           "invalid_transition",
           "A Task in review can leave that state only through an execution-scoped Review transaction. Use changes_requested to return it to active."
         );
+      }
+      if (payload.status === "planned") {
+        const inspection = yield* Effect.tryPromise({
+          try: () => options.readTaskReturnToIdeaSnapshot
+            ? options.readTaskReturnToIdeaSnapshot(payload.taskId)
+            : Promise.reject(new Error("Return-to-idea snapshot reader is unavailable.")),
+          catch: (error) => error
+        }).pipe(Effect.match({
+          onFailure: (error) => ({
+            ok: false as const,
+            hint: `Return-to-idea safety inspection failed closed: ${error instanceof Error ? error.message : String(error)}`
+          }),
+          onSuccess: (snapshot) => ({ ok: true as const, snapshot })
+        }));
+        if (!inspection.ok) {
+          return taskFailure(payload.taskId, "task_return_to_idea_blocked", inspection.hint);
+        }
+        const gate = evaluateTaskReturnToIdeaGate(inspection.snapshot);
+        if (!gate.ok) {
+          return taskFailure(
+            payload.taskId,
+            "task_return_to_idea_blocked",
+            `Task ${payload.taskId} cannot return to planned. ${gate.issues.map((issue) => issue.message).join(" ")}`
+          );
+        }
       }
       if (payload.status === "active" || payload.status === "blocked") {
         const planPlaceholder = yield* validateTaskPlanAdmissionPreflight({

--- a/packages/application/src/task-write-route-policy.ts
+++ b/packages/application/src/task-write-route-policy.ts
@@ -88,3 +88,7 @@ export const taskWriteCliRoutePolicies = [
 export function taskWriteCliRoutePolicy(actionKind: string): TaskWriteCliRoutePolicy | undefined {
   return taskWriteCliRoutePolicies.find((policy) => policy.actionKind === actionKind);
 }
+
+export function taskStatusLeaseRequired(status: unknown): boolean {
+  return status !== "planned";
+}

--- a/packages/application/test/task-write-route-policy.test.ts
+++ b/packages/application/test/task-write-route-policy.test.ts
@@ -1,0 +1,12 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { taskStatusLeaseRequired } from "../src/task-write-route-policy.ts";
+
+test("task status lease policy exempts only the planned return direction", () => {
+  assert.equal(taskStatusLeaseRequired("planned"), false);
+  assert.equal(taskStatusLeaseRequired("active"), true);
+  assert.equal(taskStatusLeaseRequired("blocked"), true);
+  assert.equal(taskStatusLeaseRequired("in_review"), true);
+  assert.equal(taskStatusLeaseRequired(undefined), true);
+});

--- a/packages/cli/src/composition/command-executor.ts
+++ b/packages/cli/src/composition/command-executor.ts
@@ -10,6 +10,7 @@ import {
   makeRuntimeEventLedgerService,
   makeRuntimeEventAppendPromise,
   makeTaskHolderService,
+  taskStatusLeaseRequired,
   type ProvenanceSessionExporterRejected,
   type ProvenanceSessionExportResult,
   type TaskHolderPrincipal
@@ -331,7 +332,9 @@ function withOptionalLeaseGuard(
   );
   return {
     ...engine,
-    setStatus: (input) => guard(input.taskId).pipe(Effect.flatMap(() => engine.setStatus(input))),
+    setStatus: (input) => taskStatusLeaseRequired(input.status)
+      ? guard(input.taskId).pipe(Effect.flatMap(() => engine.setStatus(input)))
+      : engine.setStatus(input),
     appendProgress: (input) => guard(input.taskId).pipe(Effect.flatMap(() => engine.appendProgress(input))),
     archiveTask: (input) => guard(input.taskId).pipe(Effect.flatMap(() => engine.archiveTask(input))),
     supersedeTask: (input) => guard(input.oldTaskId).pipe(Effect.flatMap(() => engine.supersedeTask(input))),

--- a/packages/cli/src/composition/command-executor.ts
+++ b/packages/cli/src/composition/command-executor.ts
@@ -1,8 +1,8 @@
 import { Effect } from "effect";
 import {
   bindCreateProvenance,
-  evaluateTaskReturnToIdeaGate,
   isTaskHolderError,
+  makeTaskLifecycleOrchestrator,
   makeDecisionWriteService,
   makeEnvironmentCurrentSessionProbe,
   makeFactWriteService,
@@ -207,7 +207,7 @@ export async function runRegisteredCommandWithCliComposition(
     artifactStore: makeArtifactStore()
   });
 
-  return Effect.runPromise(runRegisteredCommand(command, () => withReturnToIdeaGuard(withOptionalLeaseGuard(provider.createLifecycleEngine({
+  return Effect.runPromise(runRegisteredCommand(command, () => withLifecycleOrchestration(withOptionalLeaseGuard(provider.createLifecycleEngine({
     rootDir: command.rootDir,
     layoutOverrides: command.layoutOverrides,
     coordinator: makeWriteCoordinator(operationalActor("task-lifecycle")),
@@ -218,7 +218,7 @@ export async function runRegisteredCommandWithCliComposition(
         syncExportedSession
       })
     }, boundAt)
-  }), enforceTaskLease(), makeTaskHolder, getTaskHolderPrincipal, options.taskLeaseGuardMode), layoutInput), makeArtifactStore, getCurrentSessionProbe, makeSessionExporter, syncExportedSession, makeWriteCoordinator, makeMigrationWriteCoordinator, makeOperationalWriteCoordinator, getActorAttribution, getTaskHolderPrincipal, () => {
+  }), enforceTaskLease(), makeTaskHolder, getTaskHolderPrincipal, options.taskLeaseGuardMode), layoutInput, makeArtifactStore()), makeArtifactStore, getCurrentSessionProbe, makeSessionExporter, syncExportedSession, makeWriteCoordinator, makeMigrationWriteCoordinator, makeOperationalWriteCoordinator, getActorAttribution, getTaskHolderPrincipal, () => {
     const attribution = getActorAttribution().writeAttribution;
     const repin = command.action.kind === "decision-repin" ? command.action : undefined;
     return makeDecisionWriteService({
@@ -281,38 +281,35 @@ function failClosedMissingCoordinator(writer: string): WriteCoordinator {
 }
 
 type LifecycleEngine = ReturnType<CliCompositionAdapterProvider["createLifecycleEngine"]>;
+type CliArtifactStore = ReturnType<CliCompositionAdapterProvider["createArtifactStore"]>;
 type FactWriteService = ReturnType<typeof makeFactWriteService>;
 type TaskHolderServiceFactory = () => ReturnType<typeof makeTaskHolderService>;
 type TaskHolderPrincipalFactory = () => TaskHolderPrincipal;
 
-function withReturnToIdeaGuard(
+function withLifecycleOrchestration(
   engine: LifecycleEngine,
-  rootInput: ReturnType<typeof createHarnessRuntimeContext>
+  rootInput: ReturnType<typeof createHarnessRuntimeContext>,
+  artifactStore: CliArtifactStore
 ): LifecycleEngine {
+  const orchestrator = makeTaskLifecycleOrchestrator({
+    rootDir: rootInput.rootDir,
+    layoutOverrides: rootInput.layoutOverrides,
+    taskWriter: engine,
+    artifactStore,
+    readTaskReturnToIdeaSnapshot: (taskId) => readTaskReturnToIdeaSnapshot(rootInput, taskId)
+  });
   return {
     ...engine,
-    setStatus: (input) => {
-      if (input.status !== "planned") return engine.setStatus(input);
-      return Effect.tryPromise({
-        try: () => readTaskReturnToIdeaSnapshot(rootInput, input.taskId),
-        catch: (error): WriteError => ({
+    setStatus: (input) => input.status === "planned"
+      ? orchestrator.setTaskStatus(input).pipe(Effect.flatMap((result) => result.ok
+        ? Effect.succeed({ taskId: result.taskId, status: result.status!, engine: "local" as const })
+        : Effect.fail({
           _tag: "WriteRejected",
           taskId: input.taskId,
-          code: "task_return_to_idea_blocked",
-          reason: `Return-to-idea safety inspection failed closed: ${error instanceof Error ? error.message : String(error)}`
-        })
-      }).pipe(Effect.flatMap((snapshot) => {
-        const gate = evaluateTaskReturnToIdeaGate(snapshot);
-        return gate.ok
-          ? engine.setStatus(input)
-          : Effect.fail({
-            _tag: "WriteRejected",
-            taskId: input.taskId,
-            code: "task_return_to_idea_blocked",
-            reason: `Task ${input.taskId} cannot return to planned. ${gate.issues.map((issue) => issue.message).join(" ")}`
-          } satisfies WriteError);
-      }));
-    }
+          code: result.error.code,
+          reason: result.error.hint
+        } satisfies WriteError)))
+      : engine.setStatus(input)
   };
 }
 

--- a/packages/cli/src/composition/daemon-service-host-services.ts
+++ b/packages/cli/src/composition/daemon-service-host-services.ts
@@ -8,6 +8,7 @@ import { makeDaemonGuiControllerOptions } from "../commands/extensions/gui-contr
 import { resolveManagedSectionPolicy } from "../commands/extensions/managed-section-policy.ts";
 import { leaseEnforcementEnabled } from "../commands/settings.ts";
 import { resolveCliVersion } from "../commands/core/version.ts";
+import { readTaskReturnToIdeaSnapshot } from "../commands/task-return-to-idea-snapshot.ts";
 import { daemonActorAttribution } from "./actor-attribution.ts";
 import { cliDaemonCommandHostServices } from "./daemon-command-host-services.ts";
 
@@ -35,6 +36,7 @@ export const cliDaemonServiceHostServices = {
     commandOptions,
     cliDaemonCommandHostServices
   ),
+  readTaskReturnToIdeaSnapshot,
   leaseEnforcementEnabled,
   version: resolveCliVersion
 } satisfies DaemonServiceHostServices<

--- a/packages/cli/test/task-lifecycle-facade-cli.test.ts
+++ b/packages/cli/test/task-lifecycle-facade-cli.test.ts
@@ -259,19 +259,20 @@ test("task retire-execution rejects live and submitted rounds, then records an a
 test("return to planned requires explicit lease release and active Execution retirement", () => {
   withTempRoot((rootDir) => {
     const fixture = prepareActiveTask(rootDir, "Return To Idea Guard");
+    const leaseEnv = { ...fixture.env, HARNESS_TASK_LEASE_ENFORCEMENT: "1" };
 
     const leased = runJson(rootDir, [
       "task", "transition", fixture.taskId, "planned"
-    ], false, fixture.env);
+    ], false, leaseEnv);
     assert.equal(leased.error.code, "task_return_to_idea_blocked");
     assert.match(leased.error.hint, new RegExp(`Execution ${fixture.executionId}`, "u"));
     assert.match(leased.error.hint, /person:.+\/agent:facade-worker/u);
     assert.match(leased.error.hint, new RegExp(`ha task release ${fixture.taskId}`, "u"));
 
-    runJson(rootDir, ["task", "release", fixture.taskId], true, fixture.env);
+    runJson(rootDir, ["task", "release", fixture.taskId], true, leaseEnv);
     const executing = runJson(rootDir, [
       "task", "transition", fixture.taskId, "planned"
-    ], false, fixture.env);
+    ], false, leaseEnv);
     assert.equal(executing.error.code, "task_return_to_idea_blocked");
     assert.match(executing.error.hint, new RegExp(
       `ha task retire-execution ${fixture.taskId} --execution-id ${fixture.executionId} --reason`,
@@ -282,11 +283,40 @@ test("return to planned requires explicit lease release and active Execution ret
       "task", "retire-execution", fixture.taskId,
       "--execution-id", fixture.executionId,
       "--reason", "returning task to the idea inbox"
-    ], true, fixture.env);
+    ], true, leaseEnv);
     const planned = runJson(rootDir, [
       "task", "transition", fixture.taskId, "planned"
-    ], true, fixture.env);
+    ], true, leaseEnv);
     assert.equal(planned.status, "planned");
+
+    const reacquireRequired = runJson(rootDir, [
+      "task", "transition", fixture.taskId, "active"
+    ], false, leaseEnv);
+    assert.equal(reacquireRequired.ok, false);
+    assert.match(reacquireRequired.error.hint, /requires an active lease/iu);
+    assert.match(reacquireRequired.error.hint, new RegExp(`ha task start ${fixture.taskId}`, "u"));
+    assert.match(readFileSync(path.join(rootDir, fixture.packagePath, "INDEX.md"), "utf8"), /^  status: planned$/mu);
+  });
+});
+
+test("blocked task returns to planned without reacquiring a lease after cleanup", () => {
+  withTempRoot((rootDir) => {
+    const fixture = prepareActiveTask(rootDir, "Blocked Return To Idea");
+    const leaseEnv = { ...fixture.env, HARNESS_TASK_LEASE_ENFORCEMENT: "1" };
+    runJson(rootDir, ["task", "transition", fixture.taskId, "blocked"], true, leaseEnv);
+    runJson(rootDir, ["task", "release", fixture.taskId], true, leaseEnv);
+    runJson(rootDir, [
+      "task", "retire-execution", fixture.taskId,
+      "--execution-id", fixture.executionId,
+      "--reason", "returning blocked task to the idea inbox"
+    ], true, leaseEnv);
+
+    const planned = runJson(rootDir, [
+      "task", "transition", fixture.taskId, "planned"
+    ], true, leaseEnv);
+
+    assert.equal(planned.status, "planned");
+    assert.match(readFileSync(path.join(rootDir, fixture.packagePath, "INDEX.md"), "utf8"), /^  status: planned$/mu);
   });
 });
 

--- a/packages/cli/test/task-lifecycle-facade-cli.test.ts
+++ b/packages/cli/test/task-lifecycle-facade-cli.test.ts
@@ -270,6 +270,13 @@ test("return to planned requires explicit lease release and active Execution ret
     assert.match(leased.error.hint, new RegExp(`ha task release ${fixture.taskId}`, "u"));
 
     runJson(rootDir, ["task", "release", fixture.taskId], true, leaseEnv);
+    const blockedWithoutLease = runJson(rootDir, [
+      "task", "transition", fixture.taskId, "blocked"
+    ], false, leaseEnv);
+    assert.equal(blockedWithoutLease.error.code, "task_lease_required");
+    assert.match(blockedWithoutLease.error.hint, /requires an active lease/iu);
+    assert.match(readFileSync(path.join(rootDir, fixture.packagePath, "INDEX.md"), "utf8"), /^  status: active$/mu);
+
     const executing = runJson(rootDir, [
       "task", "transition", fixture.taskId, "planned"
     ], false, leaseEnv);

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -16,8 +16,9 @@ import {
 import type { RuntimeEventAppendInput } from "@harness-anything/application/runtime-event-ledger-service";
 import type { TerminalSessionService } from "@harness-anything/application/terminal-session-contract";
 import { commandClassForJsonRpcRequest, currentDaemonProtocolVersion, jsonRpcMethodContract, jsonRpcMethodContracts, type JsonRpcMethodContract } from "./method-registry.ts";
+import { toJsonValue } from "./json-value.ts";
 import { failureReceipt, serviceResultReceipt, successReceipt } from "./receipt-envelope.ts";
-import { isJsonObject, type JsonObject, type JsonRpcId, type JsonRpcRequest, type JsonRpcResponse, type JsonValue } from "./json-rpc-types.ts";
+import { isJsonObject, type JsonObject, type JsonRpcId, type JsonRpcRequest, type JsonRpcResponse } from "./json-rpc-types.ts";
 import { readTaskHolderExecutor } from "./task-holder-payload.ts";
 import type { DocSyncServiceContext } from "./doc-sync-service-context.ts";
 import {
@@ -34,6 +35,7 @@ import {
   handleProjectionNotificationSubscription,
   type ProjectionNotificationOptions
 } from "./projection-notification-subscription.ts";
+import { taskHolderErrorDetails, validateTaskLeaseForServiceWrite } from "./task-holder-write-policy.ts";
 import { commandRootMismatch, validateForcedCommandRoot } from "./forced-command-root.ts";
 import { daemonControlRequest } from "./daemon-control-request.ts";
 import {
@@ -441,51 +443,6 @@ async function callTaskHolderMethod(
   }
 }
 
-function taskHolderErrorDetails(error: {
-  readonly code: string;
-  readonly taskId: string;
-  readonly holder?: unknown;
-  readonly principal?: unknown;
-  readonly leaseExpiresAt?: string | null;
-  readonly orphan?: boolean;
-}): JsonObject {
-  return {
-    taskId: error.taskId,
-    code: error.code,
-    ...(error.holder ? { holder: toJsonValue(error.holder) } : {}),
-    ...(error.principal ? { principal: toJsonValue(error.principal) } : {}),
-    leaseExpiresAt: error.leaseExpiresAt ?? null,
-    ...(typeof error.orphan === "boolean" ? { orphan: error.orphan } : {})
-  };
-}
-
-async function validateTaskLeaseForServiceWrite(
-  contract: JsonRpcMethodContract,
-  payload: JsonObject | undefined,
-  services: DaemonServiceHost,
-  actor: AuthenticatedActor | undefined,
-  repo: DaemonRepoNamespace | undefined,
-  options: JsonRpcServerOptions
-): Promise<ReturnType<typeof failureReceipt> | undefined> {
-  if (!repo || !options.leaseEnforcementEnabled?.(repo) || contract.leaseRequired !== true) return undefined;
-  const taskId = typeof payload?.taskId === "string" ? payload.taskId : undefined;
-  if (!taskId) return failureReceipt(contract.method, "task_id_required", "Task lease enforcement requires payload.taskId.");
-  if (!services.TaskHolderService) {
-    return failureReceipt(contract.method, "task_holder_service_unavailable", "Task holder service is not configured.");
-  }
-  if (!actor) return failureReceipt(contract.method, "actor_required", "Task lease enforcement requires a per-request authenticated actor.");
-  try {
-    const executor = readTaskHolderExecutor(payload);
-    await services.TaskHolderService.assertActiveLease({ taskId, principal: taskHolderPrincipalFromActor(actor, { executor }) });
-    return undefined;
-  } catch (error) {
-    if (isTaskHolderError(error)) {
-      return failureReceipt(contract.method, error.code, error.message, taskHolderErrorDetails(error));
-    }
-    return failureReceipt(contract.method, "task_holder_failed", error instanceof Error ? error.message : String(error));
-  }
-}
-
 function withEffectiveCommandClass(contract: JsonRpcMethodContract, params: JsonObject): JsonRpcMethodContract {
   const commandClass = commandClassForJsonRpcRequest(contract, params);
   if (commandClass === contract.commandClass) return contract;
@@ -589,11 +546,4 @@ function isJsonRpcRequest(value: unknown): value is JsonRpcRequest {
 
 function errorResponse(id: JsonRpcId, code: number, message: string): JsonRpcResponse {
   return { jsonrpc: "2.0", id, error: { code, message } };
-}
-
-function toJsonValue(value: unknown): JsonValue {
-  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
-  if (Array.isArray(value)) return value.map(toJsonValue);
-  if (isJsonObject(value)) return value;
-  return String(value);
 }

--- a/packages/daemon/src/protocol/json-value.ts
+++ b/packages/daemon/src/protocol/json-value.ts
@@ -1,0 +1,8 @@
+import { isJsonObject, type JsonValue } from "./json-rpc-types.ts";
+
+export function toJsonValue(value: unknown): JsonValue {
+  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
+  if (Array.isArray(value)) return value.map(toJsonValue);
+  if (isJsonObject(value)) return value;
+  return String(value);
+}

--- a/packages/daemon/src/protocol/task-holder-write-policy.ts
+++ b/packages/daemon/src/protocol/task-holder-write-policy.ts
@@ -1,0 +1,71 @@
+import {
+  isTaskHolderError,
+  taskStatusLeaseRequired,
+  taskHolderPrincipalFromActor,
+  type TaskHolderService
+} from "@harness-anything/application";
+import type { AuthenticatedActor } from "../identity/types.ts";
+import type { JsonRpcMethodContract } from "./method-registry.ts";
+import { failureReceipt } from "./receipt-envelope.ts";
+import { readTaskHolderExecutor } from "./task-holder-payload.ts";
+import type { JsonObject } from "./json-rpc-types.ts";
+import { toJsonValue } from "./json-value.ts";
+
+interface TaskLeaseRepo {
+  readonly repoId: string;
+  readonly canonicalRoot: string;
+}
+
+interface TaskLeaseServices {
+  readonly TaskHolderService?: TaskHolderService;
+}
+
+interface TaskLeaseOptions {
+  readonly leaseEnforcementEnabled?: (repo: TaskLeaseRepo) => boolean;
+}
+
+export async function validateTaskLeaseForServiceWrite(
+  contract: JsonRpcMethodContract,
+  payload: JsonObject | undefined,
+  services: TaskLeaseServices,
+  actor: AuthenticatedActor | undefined,
+  repo: TaskLeaseRepo | undefined,
+  options: TaskLeaseOptions
+): Promise<ReturnType<typeof failureReceipt> | undefined> {
+  if (!repo || !options.leaseEnforcementEnabled?.(repo) || contract.leaseRequired !== true) return undefined;
+  if (contract.method === "repo.tasks.status.set" && !taskStatusLeaseRequired(payload?.status)) return undefined;
+  const taskId = typeof payload?.taskId === "string" ? payload.taskId : undefined;
+  if (!taskId) return failureReceipt(contract.method, "task_id_required", "Task lease enforcement requires payload.taskId.");
+  if (!services.TaskHolderService) {
+    return failureReceipt(contract.method, "task_holder_service_unavailable", "Task holder service is not configured.");
+  }
+  if (!actor) return failureReceipt(contract.method, "actor_required", "Task lease enforcement requires a per-request authenticated actor.");
+  try {
+    const executor = readTaskHolderExecutor(payload);
+    await services.TaskHolderService.assertActiveLease({ taskId, principal: taskHolderPrincipalFromActor(actor, { executor }) });
+    return undefined;
+  } catch (error) {
+    if (isTaskHolderError(error)) {
+      return failureReceipt(contract.method, error.code, error.message, taskHolderErrorDetails(error));
+    }
+    return failureReceipt(contract.method, "task_holder_failed", error instanceof Error ? error.message : String(error));
+  }
+}
+
+export function taskHolderErrorDetails(error: {
+  readonly code: string;
+  readonly taskId: string;
+  readonly holder?: unknown;
+  readonly principal?: unknown;
+  readonly leaseExpiresAt?: string | null;
+  readonly orphan?: boolean;
+}): JsonObject {
+  return {
+    taskId: error.taskId,
+    code: error.code,
+    ...(error.holder ? { holder: toJsonValue(error.holder) } : {}),
+    ...(error.principal ? { principal: toJsonValue(error.principal) } : {}),
+    leaseExpiresAt: error.leaseExpiresAt ?? null,
+    ...(typeof error.orphan === "boolean" ? { orphan: error.orphan } : {})
+  };
+}

--- a/packages/daemon/src/service/service-host.ts
+++ b/packages/daemon/src/service/service-host.ts
@@ -442,6 +442,10 @@ function createRepoServiceBinding<
     layoutOverrides,
     taskWriter,
     artifactStore: makeMarkdownArtifactStore({ rootDir, layoutOverrides }),
+    readTaskReturnToIdeaSnapshot: (taskId) => hostServices.readTaskReturnToIdeaSnapshot(
+      { rootDir, layoutOverrides },
+      taskId
+    ),
     ...hostServices.makeGuiControllerOptions(runtime, { rootDir, layoutOverrides }, commandOptions),
     projectionQueries: {
       getExecutionEvidencePage: async (payload) => ({

--- a/packages/daemon/test/task-holder-rpc.test.ts
+++ b/packages/daemon/test/task-holder-rpc.test.ts
@@ -136,6 +136,49 @@ test("task lease enforcement guards daemon task progress API writes when enabled
   }
 });
 
+test("daemon status lease enforcement exempts only the planned return direction", async () => {
+  const previous = process.env.HARNESS_TASK_LEASE_ENFORCEMENT;
+  const rootDir = createHarnessRoot(["settings:", "  tasks:", "    leaseEnforcement: true"]);
+  try {
+    delete process.env.HARNESS_TASK_LEASE_ENFORCEMENT;
+    const statusWrites: string[] = [];
+    const { alice } = makeActorServers(rootDir, {
+      ...emptyLocalController(),
+      setTaskStatus: async (payload) => {
+        statusWrites.push(payload.status);
+        return { ok: true };
+      }
+    });
+    await hello(alice);
+
+    const taskId = "task_01KX19GEKWMEJNGSMRT6JJH6HY";
+    const request = (status: "planned" | "active"): JsonRpcRequest => ({
+      jsonrpc: "2.0",
+      id: `status-${status}`,
+      method: "repo.tasks.status.set",
+      params: {
+        repo: { repoId: "canonical" },
+        payload: { taskId, status }
+      }
+    });
+
+    const planned = resultReceipt(await alice.handle(request("planned")));
+    const active = resultReceipt(await alice.handle(request("active")));
+
+    assert.equal(planned.ok, true);
+    assert.equal(active.ok, false);
+    assert.equal(active.error?.code, "task_lease_required");
+    assert.deepEqual(statusWrites, ["planned"]);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.HARNESS_TASK_LEASE_ENFORCEMENT;
+    } else {
+      process.env.HARNESS_TASK_LEASE_ENFORCEMENT = previous;
+    }
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("task progress lease refresh and orphan recovery preserve the requesting executor", async () => {
   const previous = process.env.HARNESS_TASK_LEASE_ENFORCEMENT;
   const rootDir = createHarnessRoot(["settings:", "  tasks:", "    leaseEnforcement: true"]);

--- a/packages/daemon/test/task-return-to-planned-rpc.integration.test.ts
+++ b/packages/daemon/test/task-return-to-planned-rpc.integration.test.ts
@@ -1,0 +1,243 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { makeLocalLifecycleEngine } from "../../adapters/local/src/index.ts";
+import {
+  makeLocalControllerService,
+  makeTaskHolderService,
+  type ExecutionRecord
+} from "../../application/src/index.ts";
+import {
+  makeJournaledWriteCoordinator,
+  makeMarkdownArtifactStore
+} from "../../kernel/src/index.ts";
+import { readTaskReturnToIdeaSnapshot } from "../../cli/src/commands/task-return-to-idea-snapshot.ts";
+import { createInMemoryTerminalSessionService } from "../src/terminal/session-registry.ts";
+import {
+  createJsonRpcProtocolServer,
+  makePeopleRosterIdentityAdminSnapshot,
+  makeTransportDerivedIdentityProvider,
+  peopleRosterFromDocument,
+  personRegistryFromLegacyRoster,
+  type JsonRpcRequest,
+  type JsonRpcResponse
+} from "../src/index.ts";
+
+const taskId = "task_01KX19GEKWMEJNGSMRT6JJH6HY";
+const executionId = "exe_01KX7H00000000000000000001";
+
+test("daemon status RPC rejects residual return to planned, guards blocked ownership, and permits cleaned return", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-daemon-return-planned-"));
+  try {
+    const taskRoot = createActiveTask(rootDir);
+    writeExecution(taskRoot, "active");
+    const taskHolderService = makeTaskHolderService({ rootInput: rootDir });
+    const controller = makeLocalControllerService({
+      rootDir,
+      artifactStore: makeMarkdownArtifactStore({ rootDir }),
+      readTaskReturnToIdeaSnapshot: (requestedTaskId) => readTaskReturnToIdeaSnapshot(
+        rootDir,
+        requestedTaskId
+      ),
+      taskWriter: makeLocalLifecycleEngine({
+        rootDir,
+        coordinator: makeJournaledWriteCoordinator({
+          rootDir,
+          attribution: {
+            actor: {
+              principal: { kind: "person", personId: "person_alice" },
+              executor: { kind: "agent", id: "daemon-integration" }
+            },
+            principalSource: {
+              kind: "local-configured",
+              authority: "harness.yaml",
+              authoritySha256: "sha256:test"
+            },
+            executorSource: "client-asserted"
+          }
+        })
+      })
+    });
+    const roster = peopleRosterFromDocument([
+      "schema: harness-people/v1",
+      "people:",
+      "  - personId: person_alice",
+      "    displayName: Alice",
+      "    roles: [owner]",
+      "    credentials:",
+      "      - kind: ssh-username",
+      "        issuer: host:team-host",
+      "        subject: alice",
+      "roles:",
+      "  - roleId: owner",
+      "    commandClasses: [admin, repo-write, repo-read, arbiter]",
+      ""
+    ].join("\n"));
+    const personRegistry = personRegistryFromLegacyRoster(roster);
+    const server = createJsonRpcProtocolServer({
+      daemonId: "daemon-return-planned-test",
+      repos: [{ repoId: "canonical", canonicalRoot: rootDir }],
+      personRegistry,
+      identityAdminSnapshot: makePeopleRosterIdentityAdminSnapshot(roster, personRegistry),
+      identityProvider: makeTransportDerivedIdentityProvider(roster, { sshExecIssuer: "host:team-host" }),
+      authContext: {
+        transportKind: "ssh-exec",
+        sshExecUser: { username: "alice", host: "team-host", source: "ssh-authenticated-exec" }
+      },
+      services: {
+        LocalControllerService: controller,
+        TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" }),
+        TaskHolderService: taskHolderService
+      },
+      leaseEnforcementEnabled: () => true
+    });
+    await hello(server);
+    assert.equal(receipt(await server.handle(holderRequest("repo.task.claim"))).ok, true);
+
+    const leased = receipt(await server.handle(statusRequest("planned")));
+    assert.equal(leased.ok, false);
+    assert.equal(leased.error?.code, "task_return_to_idea_blocked", JSON.stringify(leased));
+    assert.match(leased.error?.hint ?? "", new RegExp(`ha task release ${taskId}`, "u"));
+    assert.match(leased.error?.hint ?? "", new RegExp(
+      `ha task retire-execution ${taskId} --execution-id ${executionId} --reason`,
+      "u"
+    ));
+    assert.match(readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"), /^  status: active$/mu);
+
+    assert.equal(receipt(await server.handle(holderRequest("repo.task.release"))).ok, true);
+    const executing = receipt(await server.handle(statusRequest("planned")));
+    assert.equal(executing.ok, false);
+    assert.equal(executing.error?.code, "task_return_to_idea_blocked");
+    assert.match(executing.error?.hint ?? "", new RegExp(
+      `ha task retire-execution ${taskId} --execution-id ${executionId} --reason`,
+      "u"
+    ));
+
+    writeExecution(taskRoot, "abandoned");
+    const blocked = receipt(await server.handle(statusRequest("blocked")));
+    assert.equal(blocked.ok, false);
+    assert.equal(blocked.error?.code, "task_lease_required");
+    assert.match(readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"), /^  status: active$/mu);
+
+    const planned = receipt(await server.handle(statusRequest("planned")));
+    assert.equal(planned.ok, true);
+    assert.match(readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"), /^  status: planned$/mu);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+function createActiveTask(rootDir: string): string {
+  const taskRoot = path.join(rootDir, "harness/tasks", `${taskId}-daemon-return-planned`);
+  mkdirSync(path.join(taskRoot, "executions"), { recursive: true });
+  writeFileSync(path.join(rootDir, "harness/harness.yaml"), [
+    "schema: harness-anything/v1",
+    "layout:",
+    "  authoredRoot: harness",
+    "settings:",
+    "  tasks:",
+    "    leaseEnforcement: true",
+    ""
+  ].join("\n"), "utf8");
+  writeFileSync(path.join(taskRoot, "INDEX.md"), [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${taskId}`,
+    "title: Daemon return to planned",
+    "lifecycle:",
+    "  bindingSchema: lifecycle-binding/v1",
+    "  engine: local",
+    "  status: active",
+    "  ref:",
+    "  titleSnapshot: Daemon return to planned",
+    "  url:",
+    "  bindingCreatedAt: 2026-07-31T00:00:00.000Z",
+    "  bindingFingerprint: sha256:fixture",
+    "packageDisposition: active",
+    "vertical: default",
+    "preset: default",
+    "provenance:",
+    "  - {runtime: \"codex\", sessionId: \"daemon-return-planned\", boundAt: \"2026-07-31T00:00:00.000Z\"}",
+    "---",
+    "",
+    "# Daemon return to planned",
+    ""
+  ].join("\n"), "utf8");
+  return taskRoot;
+}
+
+function writeExecution(taskRoot: string, state: "active" | "abandoned"): void {
+  const execution: ExecutionRecord = {
+    schema: "execution/v2",
+    execution_id: executionId,
+    task_ref: `task/${taskId}`,
+    state,
+    primary_actor: {
+      principal: { kind: "person", personId: "person_alice" },
+      executor: { kind: "agent", id: "daemon-integration" },
+      responsibleHuman: "person:person_alice"
+    },
+    claimed_at: "2026-07-31T00:00:00.000Z",
+    submitted_at: state === "abandoned" ? "2026-07-31T00:01:00.000Z" : null,
+    closed_at: state === "abandoned" ? "2026-07-31T00:02:00.000Z" : null,
+    session_bindings: [],
+    outputs: [],
+    submission: state === "abandoned" ? {
+      completion_claim: "retired",
+      deliverables: [],
+      evidence_refs: [],
+      verification_notes: [],
+      known_gaps: [],
+      residual_risks: []
+    } : null
+  };
+  writeFileSync(path.join(taskRoot, "executions", `${executionId}.md`), `${JSON.stringify(execution, null, 2)}\n`, "utf8");
+}
+
+function statusRequest(status: "planned" | "blocked"): JsonRpcRequest {
+  return {
+    jsonrpc: "2.0",
+    id: `status-${status}`,
+    method: "repo.tasks.status.set",
+    params: {
+      repo: { repoId: "canonical" },
+      payload: { taskId, status }
+    }
+  };
+}
+
+function holderRequest(method: "repo.task.claim" | "repo.task.release"): JsonRpcRequest {
+  return {
+    jsonrpc: "2.0",
+    id: method,
+    method,
+    params: {
+      repo: { repoId: "canonical" },
+      payload: { taskId }
+    }
+  };
+}
+
+async function hello(server: ReturnType<typeof createJsonRpcProtocolServer>): Promise<void> {
+  assert.equal(receipt(await server.handle({
+    jsonrpc: "2.0",
+    id: "hello",
+    method: "protocol.hello",
+    params: { protocolVersion: 1 }
+  })).ok, true);
+}
+
+function receipt(response: JsonRpcResponse | ReadonlyArray<JsonRpcResponse> | undefined): {
+  readonly ok: boolean;
+  readonly error?: { readonly code?: string; readonly hint?: string };
+} {
+  assert.ok(response && !Array.isArray(response));
+  assert.equal("result" in response, true);
+  return response.result as {
+    readonly ok: boolean;
+    readonly error?: { readonly code?: string; readonly hint?: string };
+  };
+}


### PR DESCRIPTION
# English

## Summary

Fix the gate-ordering wedge that made the #1120 reclaim transitions (`active→planned` / `blocked→planned`) unusable in production: the generic task-lease pre-gate demanded a caller lease for `transition planned`, while `task start` (the only way to get a lease) created a lease+execution that tripped the reclaim guard `task_return_to_idea_blocked` — a mutual-exclusion loop with no CLI exit. After this fix, reclaim-direction status writes (`planned`) no longer require a caller lease; their admission is the reclaim guard itself. Possession-direction writes (`active`, `in_review`, …, and any unknown value) still require a lease (fail-closed).

## What Changed

- `packages/application/src/task-write-route-policy.ts`: new shared predicate `taskStatusLeaseRequired(status)` — only `"planned"` is exempt; unknown values stay lease-required.
- `packages/cli/src/composition/command-executor.ts`: local lifecycle lease wrapper consults the predicate; the outer return-to-idea guard is untouched.
- `packages/daemon/src/protocol/task-holder-write-policy.ts` (new, split from `json-rpc-server.ts` per file-complexity gate): daemon `repo.tasks.status.set` consumes the same shared predicate — wire parity by construction, daemon does not re-interpret status semantics.
- `packages/daemon/src/protocol/json-value.ts`: extracted existing JSON value helper (single source).
- Tests: full deadlock loop red→green in `task-lifecycle-facade-cli.test.ts` (incl. negative tests both directions), daemon contract `task-holder-rpc.test.ts` (planned without lease ok, active/blocked without lease rejected), shared-policy contract test (planned/active/blocked/in_review/undefined). Registered in `tools/test-tier-manifest.mjs`.
- R2 (after blind-review P1): reclaim guard sunk into the application orchestrator as the single enforcement point — daemon `repo.tasks.status.set` now fails closed with `task_return_to_idea_blocked` when residuals exist (previously guard-less on the direct RPC path); the CLI's duplicate wrapper guard was replaced by an orchestration adapter. New real-chain daemon integration test `task-return-to-planned-rpc.integration.test.ts` (red before / green after).

## Task And Scope

- Harness task: task_01KYTQBPNNB738KM4WH9JG8BC9
- Branch: codex/planned-wire
- Public scope: application/cli/daemon lease-gate direction routing + tests
- Private planning/evidence updated: yes (task_plan, implementation-report in task artifacts)
- Out of scope: reclaim guard semantics, kernel state machine, error codes, CI/gates

## Version Impact

- Version: no version change because behavior fix within existing command surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: n/a
- Authority: task_01KYTQBPNNB738KM4WH9JG8BC9 (flow-defect standing authorization); reclaim transitions introduced by PR #1120
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: n/a
- Break-glass scope: n/a
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: dfab1ed9
- Branch merge-base with `origin/main`: dfab1ed9
- Last `git fetch origin` time: 2026-07-31 (pre-PR)
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/planned-wire`
- Private evidence commit/path: harness/tasks/task_01KYTQBPNNB738KM4WH9JG8BC9-active-planned-lease-wire/artifacts/implementation-report.md
- Reviewer evidence path: GLM blind review (production write path), findings dispositioned in task review.md
- GitHub Actions `rewrite-ci` run URL: (filled after push)
- [x] `git diff --check`
- [x] `npm run check:stop-point` — `check:local` green: 34 complete manifest gates, contract 885 pass/1 skip, GUI 360/360
- [x] Targeted tests: CLI facade 14/14, daemon task-holder RPC 7/7, application policy suite 13/13, identity-hermetic rerun 2/2
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: full CI runs on this PR; production 19-task stowage is the CEO acceptance step executed after merge+deploy.

## Review Evidence

- Self-review: CEO semantic acceptance — predicate fail-closed, only planned exempt; CLI outer reclaim guard untouched; daemon bypass scoped to `repo.tasks.status.set`+planned with authority revalidation downstream intact.
- Reviewer subagent: GLM blind adversarial review, one round. P1 (daemon direct path guard-less for planned) confirmed by CEO ground-truth and fixed in R2; P2 (missing blocked-direction lease negatives) fixed in R2; P3 TOCTOU deferred as residual risk.
- Human review: not required (single-line contraction campaign, standing authorization).
- Blocking findings: P1 dispositioned (fixed, re-verified in code by CEO); none outstanding.

## Residual Risk

- Reclaim-direction writes now reach the reclaim guard without a lease; guard remains fail-closed and its own negative tests are in place.

## References

- Task: task_01KYTQBPNNB738KM4WH9JG8BC9
- Evidence: harness/tasks/task_01KYTQBPNNB738KM4WH9JG8BC9-active-planned-lease-wire/artifacts/implementation-report.md
- Review: GLM findings, dispositioned in task review.md

---

# 中文

## 概要

修复 #1120 回收转换(`active→planned` / `blocked→planned`)在生产上不可用的门序死结:通用 lease 前置门要求 caller 先持有 lease,而拿 lease 的唯一途径 `task start` 又会创建 lease+execution 触发回收守卫 `task_return_to_idea_blocked`——互斥环、无 CLI 出口。修复后,回收方向(`planned`)的状态写不再要求 caller lease,其准入由回收守卫负责;占有方向(`active`、`in_review` 等,含未知值)仍要求 lease(fail-closed)。

## 改动内容

- `packages/application/src/task-write-route-policy.ts`:新增共享谓词 `taskStatusLeaseRequired(status)`——仅 `"planned"` 免 lease,未知值一律要求。
- `packages/cli/src/composition/command-executor.ts`:本地 lifecycle lease wrapper 按谓词分流;外层回收守卫不动。
- `packages/daemon/src/protocol/task-holder-write-policy.ts`(新文件,依文件复杂度门从 `json-rpc-server.ts` 拆出):daemon `repo.tasks.status.set` 消费同一共享谓词——wire parity 由构造保证。
- `packages/daemon/src/protocol/json-value.ts`:抽出既有 JSON value helper(单源)。
- 测试:CLI facade 完整死结环修前红/修后绿(两方向阴性齐备)、daemon contract(planned 免 lease 放行,active/blocked 无 lease 拒绝)、共享策略 contract 全值覆盖;已登记 `tools/test-tier-manifest.mjs`。
- R2(盲评 P1 后):回收守卫下沉 application orchestrator 单一执法点——daemon `repo.tasks.status.set` 带残留时 fail-closed 报 `task_return_to_idea_blocked`(此前直达 RPC 路径无守卫);CLI 重复 wrapper 守卫替换为 orchestration 适配器。新增 daemon 真实链路集成测试 `task-return-to-planned-rpc.integration.test.ts`(修前红/修后绿)。

## 任务与范围

- Harness 任务:task_01KYTQBPNNB738KM4WH9JG8BC9
- 分支:codex/planned-wire
- 公开范围:application/cli/daemon 的 lease 门方向化 + 测试
- 私有规划/证据已更新:是
- 范围外:回收守卫语义、kernel 状态机、错误码、CI/gates

## 版本影响

- 版本:不改版本,原因是既有命令面内的行为修复
- 发布影响:不发布

## 治理声明

- 触及 protected surface:否
- 范围:不适用
- 授权:task_01KYTQBPNNB738KM4WH9JG8BC9(流转缺陷常设授权);回收转换由 PR #1120 引入
- 机检边界:本 PR 只断言声明存在;是否真实充分由评审判断。
- Break-glass:否
- 原因/范围:不适用
- 后续治理任务:无

## 验证

- Base `origin/main` SHA:dfab1ed9
- merge-base:dfab1ed9
- 最近 `git fetch origin`:2026-07-31(发 PR 前)
- 同步方式:无需
- 公开 diff 命令:`git diff origin/main...codex/planned-wire`
- 私有证据:harness/tasks/task_01KYTQBPNNB738KM4WH9JG8BC9-active-planned-lease-wire/artifacts/implementation-report.md
- 评审证据:GLM 盲评(生产写路径),findings 处置记录在任务 review.md
- `rewrite-ci` run URL:(push 后回填)
- [x] `git diff --check`
- [x] `npm run check:stop-point`——`check:local` 全绿:34 个完整门、contract 885 pass/1 skip、GUI 360/360
- [x] 定向测试:CLI facade 14/14、daemon 7/7、application 13/13、身份隔离复跑 2/2
- [ ] GitHub Actions `rewrite-ci` 绿(权威完整门)
- 未运行及原因:完整 CI 在本 PR 上跑;19 笔生产存量收纳是合并部署后的 CEO 验收步骤。

## 评审证据

- 自评:CEO 语义验收——谓词 fail-closed 仅 planned 豁免;CLI 外层回收守卫不动;daemon 绕过仅限 `repo.tasks.status.set`+planned,下游 authority revalidation 完整。
- 评审 subagent:GLM 对抗盲评一轮。P1(daemon 直达路径 planned 无守卫)经 CEO ground-truth 确认并在 R2 修复;P2(blocked 方向 lease 阴性缺失)R2 修复;P3 TOCTOU 延后为残留风险。
- 人工评审:不需要(收缩线常设授权)。
- 阻塞 findings:P1 已处置(fixed,CEO 代码复核);无未决。

## 残留风险

- 回收方向写现在无 lease 直达回收守卫;守卫保持 fail-closed 且自带阴性测试。

## 参考

- 任务:task_01KYTQBPNNB738KM4WH9JG8BC9
- 证据:harness/tasks/task_01KYTQBPNNB738KM4WH9JG8BC9-active-planned-lease-wire/artifacts/implementation-report.md
- 评审:GLM findings,处置见任务 review.md
