### PR TITLE
feat(gui): triadic navigation links + decision propose body field

### DIFF
--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -298,15 +298,20 @@ function AppShell() {
     navigate({ focusedEntityRef: `task/${id}`, entityFacet: null, previewId: null, selectedId: id });
   };
 
-  // W2B 活链接:跨实体跳转(task→详情, decision→决策池, fact→事实分诊)
+  // W2B 活链接:跨实体跳转(task→详情, decision→决策池, fact→事实分诊)。
+  // 决策预览抽屉是「精修」不推栈;进入 task/fact 真视图时先关掉抽屉,避免遮挡
+  // 目标面 + 保证 Cmd+[ 回到的是上一个实体视图而非被抽屉盖住的旧位置。
   const navigateToEntity = (ref: string) => {
     if (ref.startsWith("task/")) {
       const id = ref.slice(5).split("/")[0];
+      setDecisionPreviewId(null);
       openTaskDetail(id);
     } else if (ref.startsWith("decision/")) {
       const decisionId = ref.split("/")[1];
+      // 同抽屉内换 peer decision = 仍是预览,不推栈;title 列表由 drawer 解析。
       setDecisionPreviewId(decisionId ?? null);
     } else if (ref.startsWith("fact/")) {
+      setDecisionPreviewId(null);
       navigate({
         focusedEntityRef: ref,
         view: "factTriage",
@@ -558,11 +563,17 @@ function AppShell() {
       />
       <DecisionDetailDrawer
         decision={previewDecision}
+        decisions={decisions}
         tasks={projectTasks}
         facts={facts}
         relations={relations}
         onClose={() => setDecisionPreviewId(null)}
-        onOpenTask={(id) => { setDecisionPreviewId(null); openTaskPreview(id); }}
+        onOpenTask={(id) => {
+          setDecisionPreviewId(null);
+          openTaskDetail(id);
+        }}
+        onOpenDecision={(id) => setDecisionPreviewId(id)}
+        onOpenFact={(ref) => navigateToEntity(ref.startsWith("fact/") ? ref : `fact/${ref}`)}
       />
       <CommandPalette
         open={paletteOpen}

--- a/packages/gui/src/renderer/components/DecisionDetailDrawer.tsx
+++ b/packages/gui/src/renderer/components/DecisionDetailDrawer.tsx
@@ -1,16 +1,48 @@
+import { useEffect } from "react";
 import type { DecisionRow, FactRef, RelationEdge, TaskRow } from "../model/types.ts";
 import { formatActorAxes } from "../views/decision-pool-helpers.ts";
+import { t } from "../i18n/index.tsx";
 
 interface DecisionDetailDrawerProps {
   decision: DecisionRow | null;
+  /** Full decision pool — used to resolve peer decision titles for one-hop links. */
+  decisions?: readonly DecisionRow[];
   tasks: readonly TaskRow[];
   facts: readonly FactRef[];
   relations: readonly RelationEdge[];
   onClose: () => void;
   onOpenTask: (id: string) => void;
+  /** One-hop jump to a related decision (nav ref without drawer re-entry). */
+  onOpenDecision?: (decisionId: string) => void;
+  /** One-hop jump to a related fact (fact triage / inspector path). */
+  onOpenFact?: (factRef: string) => void;
 }
 
-export function DecisionDetailDrawer({ decision, tasks, facts, relations, onClose, onOpenTask }: DecisionDetailDrawerProps) {
+export function DecisionDetailDrawer({
+  decision,
+  decisions = [],
+  tasks,
+  facts,
+  relations,
+  onClose,
+  onOpenTask,
+  onOpenDecision,
+  onOpenFact,
+}: DecisionDetailDrawerProps) {
+  // Esc closes the drawer so keyboard-only users can dismiss without hunting
+  // for the Close button (TaskPreviewDrawer already has this; keep parity).
+  useEffect(() => {
+    if (!decision) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [decision, onClose]);
+
   if (!decision) return null;
   const decisionRef = `decision/${decision.decisionId}`;
   const linkedRefs = new Set<string>();
@@ -19,7 +51,11 @@ export function DecisionDetailDrawer({ decision, tasks, facts, relations, onClos
     if (entityRef(relation.to) === decisionRef) linkedRefs.add(entityRef(relation.from));
   }
   const linkedTasks = tasks.filter((task) => linkedRefs.has(`task/${task.taskId}`));
-  const linkedFacts = facts.filter((fact) => linkedRefs.has(entityRef(fact.anchor.startsWith("fact/") ? fact.anchor : `fact/${fact.anchor}`)));
+  const linkedFacts = facts.filter((fact) =>
+    linkedRefs.has(entityRef(fact.anchor.startsWith("fact/") ? fact.anchor : `fact/${fact.anchor}`)),
+  );
+  // Peer decisions (refines/narrows/supersedes/relates) — exclude self.
+  const linkedDecisions = decisionsFromRefs(linkedRefs, decisions, decision.decisionId);
   const actor = decision.attribution.latestActor ?? decision.attribution.originator;
 
   return (
@@ -27,7 +63,9 @@ export function DecisionDetailDrawer({ decision, tasks, facts, relations, onClos
       data-testid="decision-drawer-overlay"
       className="fixed inset-0 z-[100] isolate flex justify-end bg-bg/80"
       role="presentation"
-      onMouseDown={(event) => { if (event.target === event.currentTarget) onClose(); }}
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
     >
       <aside
         data-testid="decision-drawer-panel"
@@ -38,28 +76,199 @@ export function DecisionDetailDrawer({ decision, tasks, facts, relations, onClos
         aria-labelledby="decision-drawer-title"
       >
         <header className="sticky top-0 z-10 flex items-start justify-between border-b border-border bg-surface px-6 py-5">
-          <div className="min-w-0 pr-6"><p className="font-mono text-xs text-text-faint">{decision.decisionId}</p><h2 id="decision-drawer-title" className="mt-1 text-xl font-semibold text-text">{decision.title}</h2></div>
-          <button type="button" className="rounded border border-border px-3 py-1.5 text-sm text-text-muted hover:border-border-strong hover:bg-surface-raised hover:text-text" onClick={onClose}>Close</button>
+          <div className="min-w-0 pr-6">
+            <p className="font-mono text-xs text-text-faint">{decision.decisionId}</p>
+            <h2 id="decision-drawer-title" className="mt-1 text-xl font-semibold text-text">
+              {decision.title}
+            </h2>
+          </div>
+          <button
+            type="button"
+            className="rounded border border-border px-3 py-1.5 text-sm text-text-muted hover:border-border-strong hover:bg-surface-raised hover:text-text"
+            onClick={onClose}
+            aria-label={t("components.decisionDetailDrawer.close")}
+          >
+            {t("components.decisionDetailDrawer.close")}
+          </button>
         </header>
         <div className="space-y-8 px-6 py-6">
-          <DecisionTextSection label="Question" text={decision.question} />
-          <DecisionClaims label="Chosen" claims={decision.chosen} />
-          <DecisionClaims label="Rejected" claims={decision.rejected} rejected />
-          <section><h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-text-faint">Accepted by</h3><div className="rounded-md border border-border bg-surface-raised p-4 text-sm"><div>{formatActorAxes(actor)}</div><time className="mt-1 block font-mono text-xs text-text-faint">{decision.decidedAt ?? "Not accepted"}</time></div></section>
-          <section><h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-text-faint">Related tasks · {linkedTasks.length}</h3><div className="divide-y divide-border border-y border-border">{linkedTasks.map((task) => <button key={task.taskId} type="button" className="flex w-full justify-between gap-4 py-3 text-left text-sm hover:text-accent" onClick={() => onOpenTask(task.taskId)}><span>{task.title}</span><span className="font-mono text-xs text-text-faint">{task.taskId}</span></button>)}</div></section>
-          <section><h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-text-faint">Related facts · {linkedFacts.length}</h3><div className="space-y-2">{linkedFacts.map((fact) => <div key={fact.anchor} className="rounded-md border border-border bg-surface-raised p-3"><p className="text-sm leading-6">{fact.text}</p><p className="mt-2 font-mono text-xs text-text-faint">{fact.anchor}</p></div>)}</div></section>
+          <DecisionTextSection label={t("components.decisionDetailDrawer.question")} text={decision.question} />
+          <DecisionClaims label={t("components.decisionDetailDrawer.chosen")} claims={decision.chosen} />
+          <DecisionClaims
+            label={t("components.decisionDetailDrawer.rejected")}
+            claims={decision.rejected}
+            rejected
+          />
+          <section>
+            <h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-text-faint">
+              {t("components.decisionDetailDrawer.acceptedBy")}
+            </h3>
+            <div className="rounded-md border border-border bg-surface-raised p-4 text-sm">
+              <div>{formatActorAxes(actor)}</div>
+              <time className="mt-1 block font-mono text-xs text-text-faint">
+                {decision.decidedAt ?? t("components.decisionDetailDrawer.notAccepted")}
+              </time>
+            </div>
+          </section>
+          <section>
+            <h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-text-faint">
+              {t("components.decisionDetailDrawer.relatedTasks", { count: linkedTasks.length })}
+            </h3>
+            <div className="divide-y divide-border border-y border-border">
+              {linkedTasks.map((task) => (
+                <button
+                  key={task.taskId}
+                  type="button"
+                  className="flex w-full justify-between gap-4 py-3 text-left text-sm hover:text-accent"
+                  onClick={() => onOpenTask(task.taskId)}
+                  title={t("components.decisionDetailDrawer.jumpTask")}
+                >
+                  <span>{task.title}</span>
+                  <span className="font-mono text-xs text-text-faint">{task.taskId}</span>
+                </button>
+              ))}
+              {linkedTasks.length === 0 && (
+                <p className="py-3 text-sm text-text-faint">
+                  {t("components.decisionDetailDrawer.noRelatedTasks")}
+                </p>
+              )}
+            </div>
+          </section>
+          <section>
+            <h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-text-faint">
+              {t("components.decisionDetailDrawer.relatedFacts", { count: linkedFacts.length })}
+            </h3>
+            <div className="space-y-2">
+              {linkedFacts.map((fact) => {
+                const factRef = fact.anchor.startsWith("fact/") ? fact.anchor : `fact/${fact.anchor}`;
+                const clickable = Boolean(onOpenFact);
+                const content = (
+                  <>
+                    <p className="text-sm leading-6">{fact.text}</p>
+                    <p className="mt-2 font-mono text-xs text-text-faint">{fact.anchor}</p>
+                  </>
+                );
+                return clickable ? (
+                  <button
+                    key={fact.anchor}
+                    type="button"
+                    data-testid={`decision-drawer-fact-${fact.anchor}`}
+                    className="block w-full rounded-md border border-border bg-surface-raised p-3 text-left hover:border-accent/40 hover:text-accent"
+                    onClick={() => onOpenFact?.(factRef)}
+                    title={t("components.decisionDetailDrawer.jumpFact")}
+                  >
+                    {content}
+                  </button>
+                ) : (
+                  <div key={fact.anchor} className="rounded-md border border-border bg-surface-raised p-3">
+                    {content}
+                  </div>
+                );
+              })}
+              {linkedFacts.length === 0 && (
+                <p className="text-sm text-text-faint">
+                  {t("components.decisionDetailDrawer.noRelatedFacts")}
+                </p>
+              )}
+            </div>
+          </section>
+          <section>
+            <h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-text-faint">
+              {t("components.decisionDetailDrawer.relatedDecisions", { count: linkedDecisions.length })}
+            </h3>
+            <div className="divide-y divide-border border-y border-border">
+              {linkedDecisions.map((peer) => {
+                const clickable = Boolean(onOpenDecision);
+                return clickable ? (
+                  <button
+                    key={peer.decisionId}
+                    type="button"
+                    data-testid={`decision-drawer-decision-${peer.decisionId}`}
+                    className="flex w-full justify-between gap-4 py-3 text-left text-sm hover:text-accent"
+                    onClick={() => onOpenDecision?.(peer.decisionId)}
+                    title={t("components.decisionDetailDrawer.jumpDecision")}
+                  >
+                    <span>{peer.title}</span>
+                    <span className="font-mono text-xs text-text-faint">{peer.decisionId}</span>
+                  </button>
+                ) : (
+                  <div
+                    key={peer.decisionId}
+                    className="flex w-full justify-between gap-4 py-3 text-sm text-text-muted"
+                  >
+                    <span>{peer.title}</span>
+                    <span className="font-mono text-xs text-text-faint">{peer.decisionId}</span>
+                  </div>
+                );
+              })}
+              {linkedDecisions.length === 0 && (
+                <p className="py-3 text-sm text-text-faint">
+                  {t("components.decisionDetailDrawer.noRelatedDecisions")}
+                </p>
+              )}
+            </div>
+          </section>
         </div>
       </aside>
     </div>
   );
 }
 
-function DecisionTextSection({ label, text }: { label: string; text: string }) {
-  return <section><h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-text-faint">{label}</h3><p className="whitespace-pre-wrap text-sm leading-7 text-text">{text}</p></section>;
+function decisionsFromRefs(
+  linkedRefs: ReadonlySet<string>,
+  decisions: readonly DecisionRow[],
+  selfId: string,
+): DecisionRow[] {
+  const byId = new Map(decisions.map((d) => [d.decisionId, d]));
+  const out: DecisionRow[] = [];
+  for (const ref of linkedRefs) {
+    if (!ref.startsWith("decision/")) continue;
+    const id = ref.slice("decision/".length).split("/")[0];
+    if (!id || id === selfId) continue;
+    const peer = byId.get(id);
+    if (peer) out.push(peer);
+  }
+  return out;
 }
 
-function DecisionClaims({ label, claims, rejected = false }: { label: string; claims: DecisionRow["chosen"]; rejected?: boolean }) {
-  return <section><h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-text-faint">{label}</h3><div className="space-y-3">{claims.map((claim) => <div key={claim.id} className={`rounded-md border p-4 ${rejected ? "border-danger/30 bg-danger/10" : "border-border bg-surface-raised"}`}><p className="whitespace-pre-wrap text-sm leading-6 text-text">{claim.text}</p>{claim.whyNot && <p className="mt-2 whitespace-pre-wrap text-sm text-text-muted">{claim.whyNot}</p>}</div>)}</div></section>;
+function DecisionTextSection({ label, text }: { label: string; text: string }) {
+  return (
+    <section>
+      <h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-text-faint">{label}</h3>
+      <p className="whitespace-pre-wrap text-sm leading-7 text-text">{text}</p>
+    </section>
+  );
+}
+
+function DecisionClaims({
+  label,
+  claims,
+  rejected = false,
+}: {
+  label: string;
+  claims: DecisionRow["chosen"];
+  rejected?: boolean;
+}) {
+  return (
+    <section>
+      <h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-text-faint">{label}</h3>
+      <div className="space-y-3">
+        {claims.map((claim) => (
+          <div
+            key={claim.id}
+            className={`rounded-md border p-4 ${
+              rejected ? "border-danger/30 bg-danger/10" : "border-border bg-surface-raised"
+            }`}
+          >
+            <p className="whitespace-pre-wrap text-sm leading-6 text-text">{claim.text}</p>
+            {claim.whyNot && (
+              <p className="mt-2 whitespace-pre-wrap text-sm text-text-muted">{claim.whyNot}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
 }
 
 function entityRef(ref: string): string {

--- a/packages/gui/src/renderer/components/FactInspector.tsx
+++ b/packages/gui/src/renderer/components/FactInspector.tsx
@@ -192,26 +192,61 @@ export function FactInspector({
             <p className="mt-1 text-[12px] text-text-faint">{t("components.factInspector.currentProjectionHasNoIncomingEdgesPointing")}</p>
           ) : (
             <div className="mt-1 space-y-1.5">
-              {inbound.map((relation, index) => (
-                <div key={`${relation.from}-${relation.kind}-${index}`} className="rounded border border-border bg-surface px-2 py-1.5">
-                  <div className="flex items-center gap-1.5 font-mono text-[11px]">
-                    <span className="text-text-faint">{shortEndpoint(relation.from)}</span>
-                    <ArrowSquareOut weight="bold" className="text-[10px] text-text-faint" />
-                    <span className={
-                      relation.kind === "invalidated-by" || relation.kind === "supersedes-fact"
-                        ? "text-stale"
-                        : "text-accent"
-                    }>
-                      {relation.kind}
-                    </span>
-                  </div>
-                  {relation.rationale && (
-                    <div className="mt-1 text-[11px] leading-snug text-text-muted">
-                      {relation.rationale}
+              {inbound.map((relation, index) => {
+                const fromRef = relation.from;
+                const short = shortEndpoint(fromRef);
+                const canJumpDecision =
+                  Boolean(onNavigateDecision) && fromRef.startsWith("decision/");
+                const canJumpTask =
+                  Boolean(onNavigateTask)
+                  && (fromRef.startsWith("task/")
+                    || (!fromRef.startsWith("decision/") && !fromRef.startsWith("fact/")));
+                const canJump = canJumpDecision || canJumpTask;
+                return (
+                  <div key={`${relation.from}-${relation.kind}-${index}`} className="rounded border border-border bg-surface px-2 py-1.5">
+                    <div className="flex items-center gap-1.5 font-mono text-[11px]">
+                      {canJump ? (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            if (canJumpDecision) {
+                              onNavigateDecision?.(normalizeDecisionId(fromRef));
+                            } else if (canJumpTask) {
+                              const taskId = fromRef.startsWith("task/")
+                                ? fromRef.slice("task/".length).split("/")[0]
+                                : fromRef.split("/")[0];
+                              if (taskId) onNavigateTask?.(taskId);
+                            }
+                          }}
+                          className="text-accent hover:underline"
+                          title={
+                            canJumpDecision
+                              ? t("components.factInspector.jumpDecision")
+                              : t("components.factInspector.jumpSourceTask")
+                          }
+                        >
+                          {short}
+                        </button>
+                      ) : (
+                        <span className="text-text-faint">{short}</span>
+                      )}
+                      <ArrowSquareOut weight="bold" className="text-[10px] text-text-faint" />
+                      <span className={
+                        relation.kind === "invalidated-by" || relation.kind === "supersedes-fact"
+                          ? "text-stale"
+                          : "text-accent"
+                      }>
+                        {relation.kind}
+                      </span>
                     </div>
-                  )}
-                </div>
-              ))}
+                    {relation.rationale && (
+                      <div className="mt-1 text-[11px] leading-snug text-text-muted">
+                        {relation.rationale}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           )}
         </div>

--- a/packages/gui/src/renderer/components/TaskPreviewDrawer.tsx
+++ b/packages/gui/src/renderer/components/TaskPreviewDrawer.tsx
@@ -8,6 +8,7 @@ import {
 } from "@phosphor-icons/react";
 import type { EventEntry, RelationEdge, TaskRow } from "../model/types";
 import { isExternal } from "../model/types";
+import { normalizeTaskId } from "../model/triadic.ts";
 import {
   CloseoutBadge,
   EngineBadge,
@@ -63,10 +64,18 @@ export function TaskPreviewDrawer({
 
   if (!task) return null;
 
+  // Relation endpoints are entity refs (task/{id}, decision/{id}, fact/...).
+  // Normalize before comparing against the bare task.taskId so edges actually
+  // resolve — the old raw comparison silently dropped every prefixed edge.
   const related = relations
-    .filter((edge) => edge.from === task.taskId || edge.to === task.taskId)
+    .filter(
+      (edge) =>
+        normalizeTaskId(edge.from) === task.taskId ||
+        normalizeTaskId(edge.to) === task.taskId,
+    )
     .map((edge) => {
-      const otherId = edge.from === task.taskId ? edge.to : edge.from;
+      const fromIsSelf = normalizeTaskId(edge.from) === task.taskId;
+      const otherId = normalizeTaskId(fromIsSelf ? edge.to : edge.from);
       return { edge, task: tasks.find((candidate) => candidate.taskId === otherId) };
     })
     .filter((item) => item.task);

--- a/packages/gui/src/renderer/i18n/locales/en-US/components.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/components.json
@@ -286,5 +286,20 @@
   "components.verticalAndTemplateCards.loadBearing2": "·Load-bearing",
   "components.verticalAndTemplateCards.notDirectlySelectedByCurrentlyParsedPreset": "Not directly selected by the currently parsed preset",
   "components.verticalAndTemplateCards.usedBy": "usedBy",
-  "components.verticalAndTemplateCards.verticalDoesNotDefineStatusMappingAddingVertical": "Vertical does not define statusMapping; adding vertical must not change the kernel entity"
+  "components.verticalAndTemplateCards.verticalDoesNotDefineStatusMappingAddingVertical": "Vertical does not define statusMapping; adding vertical must not change the kernel entity",
+  "components.decisionDetailDrawer.acceptedBy": "Accepted by",
+  "components.decisionDetailDrawer.chosen": "Chosen",
+  "components.decisionDetailDrawer.close": "Close",
+  "components.decisionDetailDrawer.jumpDecision": "Open decision",
+  "components.decisionDetailDrawer.jumpFact": "Open fact",
+  "components.decisionDetailDrawer.jumpTask": "Open task",
+  "components.decisionDetailDrawer.noRelatedDecisions": "No related decisions",
+  "components.decisionDetailDrawer.noRelatedFacts": "No related facts",
+  "components.decisionDetailDrawer.noRelatedTasks": "No related tasks",
+  "components.decisionDetailDrawer.notAccepted": "Not accepted",
+  "components.decisionDetailDrawer.question": "Question",
+  "components.decisionDetailDrawer.relatedDecisions": "Related decisions · {count}",
+  "components.decisionDetailDrawer.relatedFacts": "Related facts · {count}",
+  "components.decisionDetailDrawer.relatedTasks": "Related tasks · {count}",
+  "components.decisionDetailDrawer.rejected": "Rejected"
 }

--- a/packages/gui/src/renderer/i18n/locales/en-US/views.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/views.json
@@ -575,5 +575,9 @@
   "views.timelinePlot.focus": "focus",
   "views.timelinePlot.noTime": "no time",
   "views.timelinePlot.noTime2": "no time",
-  "views.ledger.noPlt": "No PLT"
+  "views.ledger.noPlt": "No PLT",
+  "views.decisionPoolView.jumpDecision": "Open decision",
+  "views.decisionPoolView.jumpTask": "Open task",
+  "views.decisionPropose.bodyLabel": "Body",
+  "views.decisionPropose.bodyPlaceholder": "Long-form context or rationale (optional)"
 }

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/components.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/components.json
@@ -286,5 +286,20 @@
   "components.verticalAndTemplateCards.loadBearing2": "·承重",
   "components.verticalAndTemplateCards.notDirectlySelectedByCurrentlyParsedPreset": "未被当前解析后的 preset 直接选用",
   "components.verticalAndTemplateCards.usedBy": "使用方",
-  "components.verticalAndTemplateCards.verticalDoesNotDefineStatusMappingAddingVertical": "Vertical 不定义 statusMapping；新增 vertical 不得改 kernel entity"
+  "components.verticalAndTemplateCards.verticalDoesNotDefineStatusMappingAddingVertical": "Vertical 不定义 statusMapping；新增 vertical 不得改 kernel entity",
+  "components.decisionDetailDrawer.acceptedBy": "采纳方",
+  "components.decisionDetailDrawer.chosen": "已采纳",
+  "components.decisionDetailDrawer.close": "关闭",
+  "components.decisionDetailDrawer.jumpDecision": "打开决策",
+  "components.decisionDetailDrawer.jumpFact": "打开事实",
+  "components.decisionDetailDrawer.jumpTask": "打开任务",
+  "components.decisionDetailDrawer.noRelatedDecisions": "无关联决策",
+  "components.decisionDetailDrawer.noRelatedFacts": "无关联事实",
+  "components.decisionDetailDrawer.noRelatedTasks": "无关联任务",
+  "components.decisionDetailDrawer.notAccepted": "未采纳",
+  "components.decisionDetailDrawer.question": "问题",
+  "components.decisionDetailDrawer.relatedDecisions": "关联决策 · {count}",
+  "components.decisionDetailDrawer.relatedFacts": "关联事实 · {count}",
+  "components.decisionDetailDrawer.relatedTasks": "关联任务 · {count}",
+  "components.decisionDetailDrawer.rejected": "已驳回"
 }

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/views.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/views.json
@@ -575,5 +575,9 @@
   "views.timelinePlot.focus": "焦点",
   "views.timelinePlot.noTime": "无时间",
   "views.timelinePlot.noTime2": "无时间",
-  "views.ledger.noPlt": "无 PLT"
+  "views.ledger.noPlt": "无 PLT",
+  "views.decisionPoolView.jumpDecision": "打开决策",
+  "views.decisionPoolView.jumpTask": "打开任务",
+  "views.decisionPropose.bodyLabel": "正文",
+  "views.decisionPropose.bodyPlaceholder": "长文本背景或理由（可选）"
 }

--- a/packages/gui/src/renderer/views/DecisionPoolView.tsx
+++ b/packages/gui/src/renderer/views/DecisionPoolView.tsx
@@ -75,10 +75,12 @@ function RelationSummaryView({
   decision,
   relations,
   tasks,
+  onNavigateEntity,
 }: {
   decision: DecisionRow;
   relations: RelationEdge[];
   tasks: TaskRow[];
+  onNavigateEntity?: (ref: string) => void;
 }) {
   const lines = relationSummary(decision, relations, tasks);
   if (lines.length === 0) {
@@ -90,7 +92,21 @@ function RelationSummaryView({
         <div key={line.kind} className="flex flex-wrap items-center gap-1.5">
           <GitBranch weight="bold" className="text-text-faint" />
           <span className="font-mono text-text-faint">{line.label}</span>
-          <span className="font-mono text-text-muted">{line.targets.join(", ")}</span>
+          {line.targets.map((target, i) => {
+            const isTask = line.kind === "derives";
+            return (
+              <span key={`${line.kind}-${target}`} className="inline-flex items-center gap-1">
+                {i > 0 && <span className="text-text-faint">,</span>}
+                {onNavigateEntity ? (
+                  <button type="button" onClick={() => onNavigateEntity(isTask ? `task/${target}` : `decision/${target}`)} className="font-mono text-accent hover:underline" title={t(isTask ? "views.decisionPoolView.jumpTask" : "views.decisionPoolView.jumpDecision")}>
+                    {target}
+                  </button>
+                ) : (
+                  <span className="font-mono text-text-muted">{target}</span>
+                )}
+              </span>
+            );
+          })}
         </div>
       ))}
     </div>
@@ -515,7 +531,12 @@ export function DecisionPoolView({
                           </div>
                         </div>
                         <div className="mt-2 rounded-md border border-border bg-surface-raised/50 px-2.5 py-2">
-                          <RelationSummaryView decision={decision} relations={relations} tasks={tasks} />
+                          <RelationSummaryView
+                            decision={decision}
+                            relations={relations}
+                            tasks={tasks}
+                            onNavigateEntity={onNavigateEntity}
+                          />
                         </div>
                         {expanded && (
                           <div className="mt-2 rounded-md border border-border bg-surface-raised/30 px-2.5 py-2" data-testid={`decision-card-expanded-${decision.decisionId}`}>

--- a/packages/gui/src/renderer/views/DecisionProposeForm.tsx
+++ b/packages/gui/src/renderer/views/DecisionProposeForm.tsx
@@ -57,6 +57,8 @@ export interface DecisionProposeFormProps {
 interface FormState {
   title: string;
   question: string;
+  /** Optional long-form body — daemon `body` field (context / rationale prose). */
+  body: string;
   riskTier: RiskTier;
   urgency: Urgency;
   chosen: DecisionProposeChosenInput[];
@@ -67,6 +69,7 @@ interface FormState {
 const EMPTY_FORM: FormState = {
   title: "",
   question: "",
+  body: "",
   riskTier: "medium",
   urgency: "medium",
   chosen: [{ text: "" }],
@@ -151,6 +154,7 @@ export function DecisionProposeForm({ open, onClose, onSubmit, modules }: Decisi
     setSubmitError(null);
     setSubmitting(true);
     try {
+      const body = state.body.trim();
       const payload = buildDecisionProposePayload({
         title: state.title.trim(),
         question: state.question.trim(),
@@ -161,6 +165,7 @@ export function DecisionProposeForm({ open, onClose, onSubmit, modules }: Decisi
           .filter((entry) => entry.text.trim().length > 0)
           .map((entry) => ({ text: entry.text.trim(), whyNot: entry.whyNot.trim() })),
         claims: state.claims.filter((entry) => entry.text.trim().length > 0),
+        ...(body.length > 0 ? { body } : {}),
         ...(modules && modules.length > 0 ? { modules } : {})
       });
       const result = await onSubmit(payload);
@@ -234,6 +239,18 @@ export function DecisionProposeForm({ open, onClose, onSubmit, modules }: Decisi
             className={`${TEXT_INPUT_CLASS} resize-y`}
             rows={2}
             placeholder={t("views.decisionPropose.questionPlaceholder")}
+            disabled={submitting}
+          />
+        </Field>
+
+        <Field label={t("views.decisionPropose.bodyLabel")}>
+          <textarea
+            value={state.body}
+            data-testid="decision-propose-body"
+            onChange={(event) => patch({ body: event.target.value })}
+            className={`${TEXT_INPUT_CLASS} resize-y`}
+            rows={4}
+            placeholder={t("views.decisionPropose.bodyPlaceholder")}
             disabled={submitting}
           />
         </Field>

--- a/packages/gui/test/decision-approval.vitest.ts
+++ b/packages/gui/test/decision-approval.vitest.ts
@@ -612,6 +612,7 @@ describe("dec_01KXARBFDR · DecisionProposeForm SSR smoke", () => {
     expect(html).toContain('data-testid="decision-propose-rejected-0"');
     expect(html).toContain('data-testid="decision-propose-rejected-0-why-not"');
     expect(html).toContain('data-testid="decision-propose-claim-0"');
+    expect(html).toContain('data-testid="decision-propose-body"');
     expect(html).toContain('data-testid="decision-propose-submit"');
   });
 

--- a/packages/gui/test/navigation-links.vitest.tsx
+++ b/packages/gui/test/navigation-links.vitest.tsx
@@ -1,0 +1,236 @@
+/**
+ * Navigation link tests for the GUI triadic IA (task_01KYTXY0216PJ44VT4Q57KBCBQ).
+ *
+ * Covers the one-hop jumps added in this task:
+ *  - DecisionDetailDrawer: related decisions / facts / tasks are clickable.
+ *  - TaskPreviewDrawer: relation edges with entity-ref endpoints (task/{id})
+ *    are resolved after the normalizeTaskId fix (previously dropped silently).
+ *
+ * SSR smoke only — click handlers are verified by asserting the rendered
+ * button testids / titles; interactive behaviour is left to e2e.
+ */
+import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type {
+  DecisionRow,
+  EventEntry,
+  FactRef,
+  RelationEdge,
+  TaskRow,
+} from "../src/renderer/model/types.ts";
+import { DecisionDetailDrawer } from "../src/renderer/components/DecisionDetailDrawer.tsx";
+import { TaskPreviewDrawer } from "../src/renderer/components/TaskPreviewDrawer.tsx";
+
+const emptyAttribution = {
+  originator: null,
+  latestActor: null,
+  trailCount: 0,
+  completeness: "unresolved" as const,
+};
+
+function decision(overrides: Partial<DecisionRow> = {}): DecisionRow {
+  return {
+    decisionId: "dec_a",
+    title: "Anchor decision",
+    state: "proposed",
+    riskTier: "medium",
+    urgency: "medium",
+    vertical: "software/coding",
+    preset: "coding",
+    attribution: emptyAttribution,
+    proposedAt: "2026-07-01T10:00:00.000Z",
+    question: "Which layout?",
+    chosen: [{ id: "CH1", text: "three-lane", evidence: [] }],
+    rejected: [{ id: "RJ1", text: "flat", evidence: [], whyNot: "loses hierarchy" }],
+    claims: [
+      { id: "CH1", text: "three-lane" },
+      { id: "RJ1", text: "flat" },
+    ],
+    ...overrides,
+  };
+}
+
+function task(overrides: Partial<TaskRow> = {}): TaskRow {
+  return {
+    taskId: "task_leaf",
+    title: "Leaf work",
+    projectId: "proj",
+    coordinationStatus: "active",
+    rawStatus: "active",
+    freshness: "fresh",
+    packageDisposition: "active",
+    closeoutReadiness: "not_required",
+    engine: "local",
+    source: "local-document",
+    module: "software/coding",
+    lastKnownAt: "2026-07-01T00:00:00.000Z",
+    gates: [],
+    docs: [],
+    rootTaskId: "task_root",
+    rootTitle: "Milestone Root",
+    attribution: emptyAttribution,
+    ...overrides,
+  };
+}
+
+function fact(overrides: Partial<FactRef> = {}): FactRef {
+  return {
+    anchor: "task_leaf/F-1",
+    taskId: "task_leaf",
+    category: "finding",
+    text: "layout observation",
+    at: "2026-07-01T00:00:00.000Z",
+    confidence: "high",
+    ...overrides,
+  };
+}
+
+describe("DecisionDetailDrawer · one-hop navigation links", () => {
+  const decA = decision({ decisionId: "dec_a", title: "Anchor decision" });
+  const decB = decision({ decisionId: "dec_b", title: "Refined by decision" });
+  const taskLeaf = task({ taskId: "task_leaf", title: "Leaf work" });
+  const factObs = fact({ anchor: "task_leaf/F-1", text: "layout observation" });
+
+  const relations: RelationEdge[] = [
+    { from: "decision/dec_a", to: "task/task_leaf", kind: "derives", provenance: "local-document" },
+    { from: "decision/dec_a", to: "fact/task_leaf/F-1", kind: "evidenced-by", provenance: "local-document" },
+    { from: "decision/dec_a", to: "decision/dec_b", kind: "refines", provenance: "local-document" },
+  ];
+
+  it("renders related tasks as clickable rows with the task title", () => {
+    const html = renderToStaticMarkup(
+      createElement(DecisionDetailDrawer, {
+        decision: decA,
+        decisions: [decA, decB],
+        tasks: [taskLeaf],
+        facts: [factObs],
+        relations,
+        onClose: () => undefined,
+        onOpenTask: () => undefined,
+        onOpenDecision: () => undefined,
+        onOpenFact: () => undefined,
+      }),
+    );
+    expect(html).toContain("Leaf work");
+    expect(html).toContain("task_leaf");
+  });
+
+  it("renders related facts as clickable buttons keyed by anchor", () => {
+    const html = renderToStaticMarkup(
+      createElement(DecisionDetailDrawer, {
+        decision: decA,
+        decisions: [decA, decB],
+        tasks: [taskLeaf],
+        facts: [factObs],
+        relations,
+        onClose: () => undefined,
+        onOpenTask: () => undefined,
+        onOpenDecision: () => undefined,
+        onOpenFact: () => undefined,
+      }),
+    );
+    expect(html).toContain('data-testid="decision-drawer-fact-task_leaf/F-1"');
+    expect(html).toContain("layout observation");
+  });
+
+  it("renders peer decisions (refines) as clickable buttons, excluding self", () => {
+    const html = renderToStaticMarkup(
+      createElement(DecisionDetailDrawer, {
+        decision: decA,
+        decisions: [decA, decB],
+        tasks: [taskLeaf],
+        facts: [factObs],
+        relations,
+        onClose: () => undefined,
+        onOpenTask: () => undefined,
+        onOpenDecision: () => undefined,
+        onOpenFact: () => undefined,
+      }),
+    );
+    expect(html).toContain('data-testid="decision-drawer-decision-dec_b"');
+    expect(html).toContain("Refined by decision");
+    // Self must not appear as a peer link.
+    expect(html).not.toContain('data-testid="decision-drawer-decision-dec_a"');
+  });
+
+  it("falls back to non-clickable rows when navigation handlers are absent", () => {
+    const html = renderToStaticMarkup(
+      createElement(DecisionDetailDrawer, {
+        decision: decA,
+        decisions: [decA, decB],
+        tasks: [taskLeaf],
+        facts: [factObs],
+        relations,
+        onClose: () => undefined,
+        onOpenTask: () => undefined,
+        // onOpenDecision / onOpenFact deliberately omitted
+      }),
+    );
+    // Facts and decisions still render their text, just without button testids.
+    expect(html).toContain("layout observation");
+    expect(html).toContain("Refined by decision");
+    expect(html).not.toContain('data-testid="decision-drawer-fact-');
+    expect(html).not.toContain('data-testid="decision-drawer-decision-');
+  });
+
+  it("renders nothing when decision is null", () => {
+    const html = renderToStaticMarkup(
+      createElement(DecisionDetailDrawer, {
+        decision: null,
+        decisions: [],
+        tasks: [],
+        facts: [],
+        relations: [],
+        onClose: () => undefined,
+        onOpenTask: () => undefined,
+      }),
+    );
+    expect(html).toBe("");
+  });
+});
+
+describe("TaskPreviewDrawer · relation endpoint normalization", () => {
+  const taskA = task({ taskId: "task_a", title: "Alpha task" });
+  const taskB = task({ taskId: "task_b", title: "Beta task", rootTaskId: "task_root" });
+
+  // Edges use entity-ref endpoints (task/{id}), not bare IDs.
+  const relations: RelationEdge[] = [
+    { from: "task/task_a", to: "task/task_b", kind: "blocks", provenance: "local-document" },
+  ];
+  const events: EventEntry[] = [];
+
+  it("resolves task-to-task edges that use entity-ref endpoints", () => {
+    // Before the normalizeTaskId fix, edge.from === task.taskId never matched
+    // because edge.from is "task/task_a" while task.taskId is "task_a".
+    const html = renderToStaticMarkup(
+      createElement(TaskPreviewDrawer, {
+        task: taskA,
+        tasks: [taskA, taskB],
+        relations,
+        events,
+        onClose: () => undefined,
+        onOpenDetail: () => undefined,
+        onPreviewTask: () => undefined,
+      }),
+    );
+    expect(html).toContain("Beta task");
+    expect(html).toContain("task_b");
+  });
+
+  it("resolves the reverse direction (to === current task)", () => {
+    const html = renderToStaticMarkup(
+      createElement(TaskPreviewDrawer, {
+        task: taskB,
+        tasks: [taskA, taskB],
+        relations,
+        events,
+        onClose: () => undefined,
+        onOpenDetail: () => undefined,
+        onPreviewTask: () => undefined,
+      }),
+    );
+    expect(html).toContain("Alpha task");
+    expect(html).toContain("task_a");
+  });
+});

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -18,6 +18,7 @@ export const guiVitestManifest = [
   "packages/gui/test/entitySearch.vitest.ts",
   "packages/gui/test/commandPalette-render.vitest.ts",
   "packages/gui/test/decision-approval.vitest.ts",
+  "packages/gui/test/navigation-links.vitest.tsx",
   "packages/gui/test/daemon-status.vitest.ts",
   "packages/gui/test/project-repos.vitest.ts",
   "packages/gui/test/daemon-log.vitest.ts",


### PR DESCRIPTION
# English

## Summary

GUI navigation usability + decision-write consumption: complete the triadic (task/decision/fact) cross-entity jump chain — related entities in drawers/inspectors are now clickable buttons, drawers close before navigation, Esc closes drawers, task preview relation lists no longer render empty due to un-normalized entity refs — and the decision propose form gains the body (narrative) field, wired through the already-exposed `proposeDecision` service-bridge route. Zero backend changes.

## What Changed

- `DecisionDetailDrawer`: related decisions/facts clickable (`onOpenDecision`/`onOpenFact`), Esc-to-close, drawer closes before `navigateToEntity`.
- `FactInspector`: inbound edges clickable.
- `TaskPreviewDrawer`: `normalizeTaskId` fixes always-empty related-task list.
- `DecisionPoolView`: relation summaries clickable.
- `DecisionProposeForm`: body field (maps to decision markdown narrative) via existing daemon route — verified full chain renderer → api-client → service-bridge → preload allowlist → daemon; no backend gap.
- i18n keys added for en-US/zh-CN; new `navigation-links.vitest.tsx` suite (registered in tools/gui-test-manifest.mjs).

## Task And Scope

- Harness task: task_01KYTXY0216PJ44VT4Q57KBCBQ
- Branch: codex/gui-nav
- Public scope: packages/gui renderer + tests only
- Private planning/evidence updated: yes
- Out of scope: daemon routes, API shapes, anything outside packages/gui

## Version Impact

- Version: no version change because renderer-only feature increment
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: n/a
- Authority: task task_01KYTXY0216PJ44VT4Q57KBCBQ (GUI line, owner-directed 2026-07-31); direction per accepted GUI IA v2 charter
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: n/a
- Break-glass scope: n/a
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: e2c6a56d
- Branch merge-base with `origin/main`: e2c6a56d
- Last `git fetch origin` time: 2026-07-31
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/gui-nav`
- Private evidence commit/path: harness/tasks/task_01KYTXY0216PJ44VT4Q57KBCBQ-gui/artifacts/implementation-report.md
- Reviewer evidence path: CEO acceptance (frontend line; renderer-only)
- GitHub Actions `rewrite-ci` run URL: (filled after CI)
- [x] `git diff --check`
- [x] `npm run check:stop-point` — check:local green, 34 gates
- [x] Targeted tests: GUI 367/367 (incl. new navigation-links suite), tsc -b 0 errors, vite build OK
- [ ] GitHub Actions `rewrite-ci` passed (authoritative full gate)
- Not run, and why: Electron e2e cold-start walkthrough is the CEO post-merge acceptance step (worktrees cannot run GUI e2e).

## Review Evidence

- Self-review: CEO red-line check — diff confined to packages/gui + test manifest registration; no token/credential strings in renderer; propose route verified pre-existing.
- Reviewer subagent: GLM implemented after Grok outage; GLM reviewed and corrected the predecessor's partial edits (i18n gaps, TaskPreviewDrawer normalization TODO, file-complexity trims).
- Human review: not required.
- Blocking findings: none.

## Residual Risk

- Post-merge CEO e2e walkthrough (real GUI cold start: navigation chain + decision propose) still pending; any friction found becomes follow-up defects.

## References

- Task: task_01KYTXY0216PJ44VT4Q57KBCBQ
- Evidence: harness/tasks/task_01KYTXY0216PJ44VT4Q57KBCBQ-gui/artifacts/implementation-report.md
- Review: task review.md

---

# 中文

## 概要

GUI 导航可用性 + 决策写消费:补全三元语(task/decision/fact)跨实体跳转链——抽屉/检查器里的关联实体全部可点、跳转前先关抽屉、Esc 关闭抽屉、TaskPreview 关联任务列表修复 entity ref 未归一化导致的恒空;决策 propose 表单增加正文(body)字段,走已暴露的 `proposeDecision` service-bridge 路由。零后端改动。

## 改动内容

- `DecisionDetailDrawer`:关联决策/事实可点、Esc 关闭、跳转前关抽屉。
- `FactInspector`:入边可点。
- `TaskPreviewDrawer`:`normalizeTaskId` 修复关联任务恒空。
- `DecisionPoolView`:关联摘要可点。
- `DecisionProposeForm`:正文字段,走既有 daemon 路由——全链核验 renderer → api-client → service-bridge → preload allowlist → daemon,无后端缺口。
- 补 en-US/zh-CN i18n 键;新增 navigation-links 测试套件(已登记 tools/gui-test-manifest.mjs)。

## 任务与范围

- Harness 任务:task_01KYTXY0216PJ44VT4Q57KBCBQ
- 分支:codex/gui-nav
- 公开范围:仅 packages/gui renderer + 测试
- 私有规划/证据已更新:是
- 范围外:daemon 路由、API 形状、packages/gui 以外一切

## 版本影响

- 版本:不改版本,原因是仅 renderer 功能增量
- 发布影响:不发布

## 治理声明

- 触及 protected surface:否
- 范围:不适用
- 授权:任务 task_01KYTXY0216PJ44VT4Q57KBCBQ(GUI 线,泽宇 2026-07-31 指令);方向依 GUI IA v2 既定裁决
- 机检边界:本 PR 只断言声明存在;是否真实充分由评审判断。
- Break-glass:否
- 原因/范围:不适用
- 后续治理任务:无

## 验证

- Base `origin/main` SHA:e2c6a56d
- merge-base:e2c6a56d
- 最近 `git fetch origin`:2026-07-31
- 同步方式:无需
- 公开 diff 命令:`git diff origin/main...codex/gui-nav`
- 私有证据:harness/tasks/task_01KYTXY0216PJ44VT4Q57KBCBQ-gui/artifacts/implementation-report.md
- 评审证据:CEO 验收(前端线,仅 renderer)
- `rewrite-ci` run URL:(CI 后回填)
- [x] `git diff --check`
- [x] `npm run check:stop-point`——check:local 全绿,34 门
- [x] 定向测试:GUI 367/367(含新导航套件)、tsc -b 零错、vite build OK
- [ ] GitHub Actions `rewrite-ci` 绿(权威完整门)
- 未运行及原因:Electron e2e 冷启动走查是 CEO 合并后验收步骤(worktree 跑不了 GUI e2e)。

## 评审证据

- 自评:CEO 红线核查——diff 仅限 packages/gui + 测试清单登记;renderer 无 token/credential;propose 路由为既有。
- 评审 subagent:Grok 断线后 GLM 接管实现,并审阅修正了前任半成品(i18n 缺键、TaskPreviewDrawer 归一化 TODO、文件复杂度收敛)。
- 人工评审:不需要。
- 阻塞 findings:无。

## 残留风险

- 合并后 CEO e2e 走查(真 GUI 冷启动:导航链+decision propose)待做;发现的摩擦点转后续缺陷。

## 参考

- 任务:task_01KYTXY0216PJ44VT4Q57KBCBQ
- 证据:harness/tasks/task_01KYTXY0216PJ44VT4Q57KBCBQ-gui/artifacts/implementation-report.md
- 评审:任务 review.md
