### PR TITLE
fix(test): flush completion proof before exit (fast-contract false-red shape)

### DIFF
--- a/tools/node-test-completion-ledger.test.mjs
+++ b/tools/node-test-completion-ledger.test.mjs
@@ -1,5 +1,7 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
 import test from "node:test";
 import {
   canIgnoreReapedFileFailures,
@@ -9,6 +11,7 @@ import {
 
 const repoRoot = "/repo";
 const file = "packages/cli/test/daemon-control-replacement-safety.test.ts";
+const workspaceRoot = path.resolve(import.meta.dirname, "..");
 
 test("file summary marks an isolation child complete only after a terminated reporter record", () => {
   const ledger = parseCompletionLedger(`${JSON.stringify({
@@ -73,6 +76,29 @@ test("result override requires every selected file and only synthetic reaped SIG
     selectedFiles: [file, other, "packages/missing.test.ts"],
     reapedFiles: new Set([file])
   }), false);
+});
+
+test("completion reporter flushes every proof record before its consumer can exit", () => {
+  const result = spawnSync(process.execPath, [
+    "tools/test-fixtures/.runner-stall/completion-reporter-flush.mjs"
+  ], {
+    cwd: workspaceRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "ignore", "pipe", "pipe"],
+    maxBuffer: 32 * 1024 * 1024,
+    timeout: 15_000
+  });
+  const ledger = parseCompletionLedger(result.output[3] ?? "", repoRoot);
+
+  assert.equal(result.error, undefined, result.output[2] ?? "");
+  assert.equal(result.status, 0, result.output[2] ?? "");
+  assert.equal(ledger.valid, true, ledger.error);
+  assert.equal(ledger.incompleteTrailingRecord, false);
+  assert.equal(ledger.fileSummaries.size, 20_000);
+  assert.deepEqual(ledger.runSummary, {
+    success: true,
+    counts: counts({ tests: 20_000, passed: 20_000 })
+  });
 });
 
 function fileSummary(relativeFile) {

--- a/tools/node-test-completion-reporter.mjs
+++ b/tools/node-test-completion-reporter.mjs
@@ -1,5 +1,6 @@
 import { createWriteStream } from "node:fs";
 import { Readable } from "node:stream";
+import { finished } from "node:stream/promises";
 import { spec } from "node:test/reporters";
 
 /**
@@ -15,6 +16,7 @@ export default async function* completionReporter(source) {
     for await (const chunk of formatted) yield chunk;
   } finally {
     completionStream.end();
+    await finished(completionStream, { cleanup: true });
   }
 }
 

--- a/tools/test-fixtures/.runner-stall/completion-reporter-flush.mjs
+++ b/tools/test-fixtures/.runner-stall/completion-reporter-flush.mjs
@@ -1,0 +1,40 @@
+import completionReporter from "../../node-test-completion-reporter.mjs";
+
+const recordCount = 20_000;
+const counts = {
+  tests: 1,
+  failed: 0,
+  passed: 1,
+  cancelled: 0,
+  skipped: 0,
+  todo: 0
+};
+
+async function* summaries() {
+  for (let index = 0; index < recordCount; index += 1) {
+    yield {
+      type: "test:summary",
+      data: {
+        file: `/repo/tools/flush-${index}.test.mjs`,
+        success: true,
+        counts
+      }
+    };
+  }
+  yield {
+    type: "test:summary",
+    data: {
+      success: true,
+      counts: {
+        ...counts,
+        tests: recordCount,
+        passed: recordCount
+      }
+    }
+  };
+}
+
+for await (const _chunk of completionReporter(summaries())) {
+  // Drain the spec output; this fixture only asserts the fd 3 proof stream.
+}
+process.exit(0);


### PR DESCRIPTION
# English

## Summary

Structural fix for the fast-contract CI red that hit twice today (runs 30596185343 / 30600063921, unrelated PRs): `daemon-snapshot-upgrade.test.ts` was not deadlocking on its own — a Node isolation child stalled in native exit (`futex_do_wait`), the runner safely reaped it with a complete file summary, but the completion reporter only called `end()` on the fd3 proof stream without awaiting flush, so `--test-force-exit` truncated the proof and the strict synthetic-failure judgment correctly failed closed. Deterministic reproduction: 1/20000 proof lines delivered before the fix, 20000/20000 after.

## What Changed

- `tools/node-test-completion-reporter.mjs`: await `finished(completionStream)` after `end()` — the reporter now owns proof-flush responsibility before exit. If the stream ever wedges, the existing stall-reaper still bounds the child (no new hang class; fail-closed judgment unchanged).
- `tools/node-test-completion-ledger.test.mjs`: deterministic 20,000-line proof regression.
- `tools/test-fixtures/.runner-stall/completion-reporter-flush.mjs`: hidden fixture driving the regression.

## Task And Scope

- Harness task: task_01KYV1M2Z4262W0F6CG6KCRFY0
- Branch: codex/ci-flake
- Public scope: test-runner tooling + regression fixture
- Private planning/evidence updated: yes (both CI stall logs archived in task artifacts)
- Out of scope: CI workflows, gate manifest, product code

## Version Impact

- Version: no version change because test tooling only
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no (reporter is runner instrumentation; fail-closed judgment untouched)
- Protected surface scope: n/a
- Authority: task task_01KYV1M2Z4262W0F6CG6KCRFY0 (flake-shape task; same-family standing flow-defect authorization)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: n/a
- Break-glass scope: n/a
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: f4b999ca
- Branch merge-base with `origin/main`: f4b999ca
- Last `git fetch origin` time: 2026-07-31
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/ci-flake`
- Private evidence commit/path: harness/tasks/task_01KYV1M2Z4262W0F6CG6KCRFY0-ci-flake-daemon-snapshot-upgrade-test-ts-fast-futex/artifacts/ (implementation report + both CI logs)
- Reviewer evidence path: CEO acceptance (one-line mechanism fix; hang-risk reasoning in PR body)
- GitHub Actions `rewrite-ci` run URL: (filled after CI)
- [x] `git diff --check`
- [x] `npm run check:stop-point` — check:local green (27 gates, 54.4s), affected fast 195/195, contract 239/239
- [x] Targeted: pre-fix deterministic repro 1/20000 → post-fix 20000/20000 incl. final run summary; merged suite 53/53; CLI fast shape 391/391; Linux Node 24 @ 4 CPU 13/13
- [ ] GitHub Actions `rewrite-ci` passed (authoritative full gate)
- Not run, and why: full CI runs on this PR.

## Review Evidence

- Self-review: CEO verified the fix is flush-ownership only — judgment semantics untouched; wedge risk bounded by existing stall-reaper (no worse than status quo).
- Reviewer subagent: not required (test-instrumentation class, deterministic red/green evidence).
- Human review: not required.
- Blocking findings: none.

## Residual Risk

- The upstream Node futex race in child native exit still exists; only the "safe reap + truncated proof → false red" shape is eliminated. If the upstream race produces a different failure shape, that is a new signal, not this fix regressing.

## References

- Task: task_01KYV1M2Z4262W0F6CG6KCRFY0
- Evidence: harness/tasks/task_01KYV1M2Z4262W0F6CG6KCRFY0-ci-flake-daemon-snapshot-upgrade-test-ts-fast-futex/artifacts/implementation-report.md
- Review: CEO acceptance in task ledger

---

# 中文

## 概要

今日两次(run 30596185343/30600063921,PR 互不相关)fast-contract CI 误红的结构性修复:`daemon-snapshot-upgrade.test.ts` 本身没死锁——Node isolation child 在原生退出阶段停在 `futex_do_wait`,runner 已凭完整 file summary 安全收割,但 completion reporter 只对 fd3 proof 流调了 `end()` 没等 flush,`--test-force-exit` 把 proof 截断,严格的 synthetic-failure 判定正确地 fail closed 成红。确定性复现:修前 1/20000 条 proof,修后 20000/20000。

## 改动内容

- `tools/node-test-completion-reporter.mjs`:`end()` 后 `await finished(completionStream)`——reporter 显式承担退出前 proof flush 责任;若流卡死,现有 stall-reaper 仍兜底(无新挂死类;fail-closed 判定不动)。
- `tools/node-test-completion-ledger.test.mjs`:2 万条 proof 确定性回归。
- `tools/test-fixtures/.runner-stall/completion-reporter-flush.mjs`:回归用隐藏 fixture。

## 任务与范围

- Harness 任务:task_01KYV1M2Z4262W0F6CG6KCRFY0
- 分支:codex/ci-flake
- 公开范围:测试 runner 工具 + 回归 fixture
- 私有规划/证据已更新:是(两份 CI 挂死日志已归档任务包)
- 范围外:CI workflow、gate manifest、产品代码

## 版本影响

- 版本:不改版本,原因是仅测试工具
- 发布影响:不发布

## 治理声明

- 触及 protected surface:否(reporter 是 runner 仪表;fail-closed 判定未动)
- 范围:不适用
- 授权:任务 task_01KYV1M2Z4262W0F6CG6KCRFY0(flake 形状任务;流转缺陷常设授权同族)
- 机检边界:本 PR 只断言声明存在;是否真实充分由评审判断。
- Break-glass:否
- 原因/范围:不适用
- 后续治理任务:无

## 验证

- Base `origin/main` SHA:f4b999ca
- merge-base:f4b999ca
- 最近 `git fetch origin`:2026-07-31
- 同步方式:无需
- 公开 diff 命令:`git diff origin/main...codex/ci-flake`
- 私有证据:任务 artifacts(实现报告+两份 CI 日志)
- 评审证据:CEO 验收(一行机理修复,挂死风险论证见正文)
- `rewrite-ci` run URL:(CI 后回填)
- [x] `git diff --check`
- [x] `npm run check:stop-point`——check:local 全绿(27 门,54.4s),affected fast 195/195、contract 239/239
- [x] 定向:修前确定性复现 1/20000 → 修后 20000/20000 含最终 summary;合并套件 53/53;CLI fast 形状 391/391;Linux Node24@4CPU 13/13
- [ ] GitHub Actions `rewrite-ci` 绿(权威完整门)
- 未运行及原因:完整 CI 在本 PR 上跑。

## 评审证据

- 自评:CEO 核实改动只承担 flush 责任——判定语义未动;卡流风险由既有 stall-reaper 兜底不劣化。
- 评审 subagent:不需要(测试仪表类,红/绿证据确定性)。
- 人工评审:不需要。
- 阻塞 findings:无。

## 残留风险

- 上游 Node futex race 仍在;本修只消灭「安全收割后 proof 截断误红」这一形状。若上游 race 以别的形状出现,那是新信号不是本修回归。

## 参考

- 任务:task_01KYV1M2Z4262W0F6CG6KCRFY0
- 证据:harness/tasks/task_01KYV1M2Z4262W0F6CG6KCRFY0-ci-flake-daemon-snapshot-upgrade-test-ts-fast-futex/artifacts/implementation-report.md
- 评审:CEO 验收见任务台账
