### PR TITLE
fix(daemon): fail-closed writes on build drift (mixed-version write-path family)

### DIFF
--- a/packages/application/src/command-receipt.ts
+++ b/packages/application/src/command-receipt.ts
@@ -61,6 +61,12 @@ export function failureReceiptNextActions(
       description: "Start the task and acquire its lease, then retry the original command."
     }] : undefined;
   }
+  if (code === "daemon_build_stale" || code === "daemon_build_identity_unavailable") {
+    return [{
+      command: "ha daemon start --service",
+      description: "Restart the daemon on the current dist build, then retry the original write."
+    }];
+  }
   if (code !== "repo_unavailable" && code !== "repo_lock_held") return undefined;
 
   const repo = receiptRecord(details.repo) ?? receiptRecord(data?.repo);

--- a/packages/application/test/command-receipt-recovery.test.ts
+++ b/packages/application/test/command-receipt-recovery.test.ts
@@ -13,6 +13,15 @@ test("task lease recovery uses only the structured task id", () => {
   assert.equal(failureReceiptNextActions("task_lease_required", {}), undefined);
 });
 
+test("daemon build drift points to a service restart", () => {
+  for (const code of ["daemon_build_stale", "daemon_build_identity_unavailable"]) {
+    assert.deepEqual(failureReceiptNextActions(code), [{
+      command: "ha daemon start --service",
+      description: "Restart the daemon on the current dist build, then retry the original write."
+    }]);
+  }
+});
+
 test("repo recovery commands use structured repo identity and remain shell-copyable", () => {
   assert.deepEqual(failureReceiptNextActions("repo_unavailable", {
     repo: {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "node": ">=24"
   },
   "scripts": {
-    "prebuild": "tsc -b",
+    "prebuild": "node scripts/clear-build-provenance.mjs && tsc -b",
     "build": "tsc -p tsconfig.build.json && node scripts/copy-assets.mjs",
     "postbuild": "node dist/cli/src/build/write-build-provenance.js",
     "prepack": "npm run build"

--- a/packages/cli/scripts/clear-build-provenance.mjs
+++ b/packages/cli/scripts/clear-build-provenance.mjs
@@ -1,0 +1,4 @@
+import { rmSync } from "node:fs";
+import path from "node:path";
+
+rmSync(path.resolve(import.meta.dirname, "../dist/daemon-build-provenance.json"), { force: true });

--- a/packages/cli/test/daemon-build-drift-registry.test.ts
+++ b/packages/cli/test/daemon-build-drift-registry.test.ts
@@ -1,0 +1,181 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { registerDaemonRepo } from "../../kernel/src/index.ts";
+import {
+  calculateDaemonArtifactIdentity,
+  createDaemonServiceHost,
+  daemonBuildProvenanceFilename
+} from "@harness-anything/daemon";
+import { cliDaemonServiceHostServices } from "../src/composition/daemon-service-host-services.ts";
+
+test("artifact drift blocks registry attach recovery and logs the diagnosis only once", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-build-drift-registry-"));
+  const serviceRoot = path.join(root, "service");
+  const alphaRoot = path.join(root, "alpha");
+  const betaRoot = path.join(root, "beta");
+  const artifactRoot = path.join(root, "artifact", "dist");
+  const entrypoint = path.join(artifactRoot, "index.js");
+  for (const directory of [serviceRoot, alphaRoot, betaRoot, artifactRoot]) {
+    mkdirSync(directory, { recursive: true });
+  }
+  initializeHarness(betaRoot);
+  writeFileSync(entrypoint, "export const version = 'loaded';\n", "utf8");
+  const loadedIdentity = calculateDaemonArtifactIdentity(entrypoint).identity;
+  writeProvenance(artifactRoot, loadedIdentity);
+  let assertBuildCurrent = () => undefined;
+  let recoveryRuns = 0;
+  const repo = { repoId: "alpha", canonicalRoot: alphaRoot };
+  const repoRuntime = runtimeFixture(repo);
+  const runtime = {
+    start: async () => managerStatus(repo),
+    stop: async () => undefined,
+    status: () => managerStatus(repo),
+    installWriteGuard: (guard: () => void) => {
+      assertBuildCurrent = guard;
+    },
+    attachRepo: async () => {
+      assertBuildCurrent();
+      recoveryRuns += 1;
+      throw new Error("recovery must not run during artifact drift");
+    },
+    detachRepo: async () => { throw new Error("detach not used"); },
+    retryUnavailableRepos: async () => [],
+    getRepoRuntime: (repoId: string) => repoId === repo.repoId ? repoRuntime : undefined,
+    enqueueInteractiveWrite: async () => { throw new Error("manager write not used"); },
+    enqueueBackgroundBatch: async () => { throw new Error("manager background not used"); },
+    enqueueMaterializerBatch: async () => { throw new Error("manager materializer not used"); }
+  };
+  const logMessages: string[] = [];
+  const daemonLogService = {
+    append: async (input: { readonly message: string }) => {
+      logMessages.push(input.message);
+      return {} as never;
+    },
+    list: async () => ({}) as never
+  };
+
+  try {
+    const host = await createDaemonServiceHost(
+      runtime as Parameters<typeof createDaemonServiceHost>[0],
+      [repo],
+      repo.repoId,
+      undefined,
+      0,
+      path.join(serviceRoot, "daemon.sock"),
+      { active: 0, total: 0 },
+      serviceRoot,
+      {
+        entrypoint,
+        loadedIdentity,
+        startedAt: "2026-07-31T00:00:00.000Z",
+        launchConfiguration: {
+          execPath: process.execPath,
+          execArgv: [],
+          entrypoint,
+          args: ["--root", alphaRoot, "daemon", "serve"]
+        },
+        preflightReplacement: async () => undefined
+      },
+      cliDaemonServiceHostServices,
+      undefined,
+      daemonLogService as Parameters<typeof createDaemonServiceHost>[11]
+    );
+    registerDaemonRepo({
+      userRoot: serviceRoot,
+      repoId: "beta",
+      canonicalRoot: betaRoot,
+      createConvenienceLinks: false
+    });
+    writeFileSync(entrypoint, "export const version = 'rebuilt';\n", "utf8");
+    writeProvenance(artifactRoot, calculateDaemonArtifactIdentity(entrypoint).identity);
+
+    await host.reconcileNow(serviceRoot);
+    await host.reconcileNow(serviceRoot);
+
+    assert.equal(recoveryRuns, 0);
+    assert.match(host.status().service.lastReconcileError?.message ?? "", /DAEMON_BUILD_STALE/u);
+    assert.equal(logMessages.length, 1);
+    assert.match(logMessages[0] ?? "", /ha daemon start --service/u);
+    await host.stop();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function initializeHarness(rootDir: string): void {
+  mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+  writeFileSync(
+    path.join(rootDir, "harness", "harness.yaml"),
+    "schema: harness-anything/v1\nlayout:\n  authoredRoot: harness\n",
+    "utf8"
+  );
+}
+
+function writeProvenance(artifactRoot: string, contentFingerprint: string): void {
+  writeFileSync(
+    path.join(artifactRoot, daemonBuildProvenanceFilename),
+    `${JSON.stringify({ schema: "daemon-build-provenance/v1", contentFingerprint })}\n`,
+    "utf8"
+  );
+}
+
+function managerStatus(repo: { readonly repoId: string; readonly canonicalRoot: string }) {
+  return {
+    started: true,
+    repoCount: 1,
+    attachedCount: 1,
+    unavailableCount: 0,
+    repos: [runtimeFixture(repo).status()]
+  };
+}
+
+function runtimeFixture(repo: { readonly repoId: string; readonly canonicalRoot: string }) {
+  return {
+    start: async () => ({}),
+    stop: async () => undefined,
+    status: () => ({
+      started: true,
+      repoId: repo.repoId,
+      rootDir: repo.canonicalRoot,
+      canonicalRoot: repo.canonicalRoot,
+      state: "attached" as const,
+      queue: {
+        depth: 0,
+        active: false,
+        interactiveDepth: 0,
+        backgroundDepth: 0,
+        activePriority: null,
+        maxInteractiveOpsPerCommit: 32
+      },
+      projectionGeneration: {
+        state: "unknown" as const,
+        validationRuns: 0,
+        invalidations: 0,
+        hintedInvalidations: 0,
+        fenceRuns: 0,
+        reconciliationRuns: 0,
+        activeCanonicalWrites: 0,
+        pendingTouchedPaths: 0
+      }
+    }),
+    enqueueInteractiveWrite: async () => { throw new Error("repo write not used"); },
+    enqueueBackgroundBatch: async () => { throw new Error("repo background not used"); },
+    enqueueMaterializerBatch: async () => { throw new Error("repo materializer not used"); },
+    queryExecutionEvidencePage: async () => ({ groups: [], nextCursor: null }),
+    createAttributedCoordinator: () => { throw new Error("coordinator not used"); },
+    assertWriteFenceHeld: async () => undefined,
+    admissionBudget: {
+      limits: {
+        maxOperations: 1,
+        maxBytes: 1,
+        reservedOperationsPerPlane: 0,
+        reservedBytesPerPlane: 0
+      }
+    },
+    subscribeProjectionChanges: () => () => undefined
+  };
+}

--- a/packages/daemon/src/authority/authority-wire-service.ts
+++ b/packages/daemon/src/authority/authority-wire-service.ts
@@ -17,8 +17,10 @@ export interface AuthorityWireRepoBinding {
 export function createAuthorityWireIngressHandler(input: {
   readonly authorityLifecycle?: AuthorityRepoLifecycleController;
   readonly repoBindings: () => Iterable<AuthorityWireRepoBinding>;
+  readonly assertBuildCurrent?: () => void;
 }): AuthorityWireIngressHandler {
   return async (request) => {
+    input.assertBuildCurrent?.();
     if (!input.authorityLifecycle) throw new Error("AUTHORITY_PRODUCTION_LIFECYCLE_DISABLED");
     const repoBinding = [...input.repoBindings()].find((binding) =>
       canonicalRootIdentity(binding.repo.canonicalRoot) === canonicalRootIdentity(request.bootstrap.canonicalRoot)

--- a/packages/daemon/src/protocol/build-identity-admission.ts
+++ b/packages/daemon/src/protocol/build-identity-admission.ts
@@ -1,0 +1,49 @@
+import type { JsonRpcMethodContract } from "./method-registry.ts";
+import { failureReceipt } from "./receipt-envelope.ts";
+
+const exemptAdminMethods: ReadonlySet<string> = new Set([
+  "admin.daemon.launch-spec",
+  "admin.daemon.restart",
+  "admin.daemon.refresh",
+  "admin.people.list",
+  "admin.rbac.roles.list"
+]);
+
+export function buildIdentityAdmissionFailure(
+  contract: JsonRpcMethodContract,
+  readBuildIdentity: (() => {
+    readonly loadedIdentity: string;
+    readonly installedIdentity: string;
+  }) | undefined
+): ReturnType<typeof failureReceipt> | undefined {
+  if (!readBuildIdentity
+    || contract.commandClass === "repo-read"
+    || exemptAdminMethods.has(contract.method)) {
+    return undefined;
+  }
+  let build: ReturnType<NonNullable<typeof readBuildIdentity>>;
+  try {
+    build = readBuildIdentity();
+  } catch (error) {
+    const cause = error instanceof Error ? error.message : String(error);
+    return failureReceipt(
+      contract.method,
+      "daemon_build_identity_unavailable",
+      `Daemon cannot verify that its running code matches the current dist build (${cause}); mixed-version writes are disabled. Run \`ha daemon start --service\`.`,
+      { data: { nextCommand: "ha daemon start --service" } }
+    );
+  }
+  if (build.loadedIdentity === build.installedIdentity) return undefined;
+  return failureReceipt(
+    contract.method,
+    "daemon_build_stale",
+    `Daemon code version ${build.loadedIdentity} does not match current dist version ${build.installedIdentity}; mixed-version writes are disabled. Run \`ha daemon start --service\`.`,
+    {
+      data: {
+        loadedIdentity: build.loadedIdentity,
+        installedIdentity: build.installedIdentity,
+        nextCommand: "ha daemon start --service"
+      }
+    }
+  );
+}

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -114,6 +114,10 @@ export interface JsonRpcServerOptions extends ProjectionNotificationOptions {
   readonly daemonId: string;
   readonly repos: ReadonlyArray<DaemonRepoNamespace>;
   readonly services: DaemonServiceHost;
+  readonly readBuildIdentity?: () => {
+    readonly loadedIdentity: string;
+    readonly installedIdentity: string;
+  };
   readonly resolveRepoServices?: (repo: DaemonRepoNamespace) => DaemonServiceHost | undefined;
   readonly resolveRepoAvailability?: (repo: DaemonRepoNamespace) => DaemonRepoAvailabilityFailure | undefined;
   /** Workspace policy resolver supplied by the CLI composition root. */
@@ -207,6 +211,8 @@ async function handleRequest(
   const effectiveContract = withEffectiveCommandClass(contract, params);
   const forcedRootFailure = validateForcedCommandRoot(effectiveContract, params, repo, options.authContext);
   if (forcedRootFailure) return response(forcedRootFailure);
+  const buildDrift = buildDriftFailure(effectiveContract, options);
+  if (buildDrift) return response(buildDrift);
   const repoRuntimeFailure = validateRepoRuntime(effectiveContract, repo, options);
   if (repoRuntimeFailure) return response(repoRuntimeFailure);
 
@@ -447,6 +453,46 @@ function withEffectiveCommandClass(contract: JsonRpcMethodContract, params: Json
   const commandClass = commandClassForJsonRpcRequest(contract, params);
   if (commandClass === contract.commandClass) return contract;
   return commandClass ? { ...contract, commandClass } : { ...contract };
+}
+
+function buildDriftFailure(
+  contract: JsonRpcMethodContract,
+  options: JsonRpcServerOptions
+): ReturnType<typeof failureReceipt> | undefined {
+  if (!options.readBuildIdentity
+    || contract.commandClass === "repo-read"
+    || contract.namespace === "admin") {
+    return undefined;
+  }
+  let build: ReturnType<NonNullable<JsonRpcServerOptions["readBuildIdentity"]>>;
+  try {
+    build = options.readBuildIdentity();
+  } catch (error) {
+    const cause = error instanceof Error ? error.message : String(error);
+    return failureReceipt(
+      contract.method,
+      "daemon_build_identity_unavailable",
+      `Daemon cannot verify that its running code matches the current dist build (${cause}); mixed-version writes are disabled. Run \`ha daemon start --service\`.`,
+      {
+        data: {
+          nextCommand: "ha daemon start --service"
+        }
+      }
+    );
+  }
+  if (build.loadedIdentity === build.installedIdentity) return undefined;
+  return failureReceipt(
+    contract.method,
+    "daemon_build_stale",
+    `Daemon code version ${build.loadedIdentity} does not match current dist version ${build.installedIdentity}; mixed-version writes are disabled. Run \`ha daemon start --service\`.`,
+    {
+      data: {
+        loadedIdentity: build.loadedIdentity,
+        installedIdentity: build.installedIdentity,
+        nextCommand: "ha daemon start --service"
+      }
+    }
+  );
 }
 
 async function handleAdminMethod(

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -42,6 +42,7 @@ import {
   authorizeIdentityActorForMethod,
   resolveIdentityActorForMethod
 } from "./identity-dispatch.ts";
+import { buildIdentityAdmissionFailure } from "./build-identity-admission.ts";
 import {
   resolveAuthorityConnectionForRequest,
   type AcceptedConnectionBinding,
@@ -211,7 +212,7 @@ async function handleRequest(
   const effectiveContract = withEffectiveCommandClass(contract, params);
   const forcedRootFailure = validateForcedCommandRoot(effectiveContract, params, repo, options.authContext);
   if (forcedRootFailure) return response(forcedRootFailure);
-  const buildDrift = buildDriftFailure(effectiveContract, options);
+  const buildDrift = buildIdentityAdmissionFailure(effectiveContract, options.readBuildIdentity);
   if (buildDrift) return response(buildDrift);
   const repoRuntimeFailure = validateRepoRuntime(effectiveContract, repo, options);
   if (repoRuntimeFailure) return response(repoRuntimeFailure);
@@ -453,46 +454,6 @@ function withEffectiveCommandClass(contract: JsonRpcMethodContract, params: Json
   const commandClass = commandClassForJsonRpcRequest(contract, params);
   if (commandClass === contract.commandClass) return contract;
   return commandClass ? { ...contract, commandClass } : { ...contract };
-}
-
-function buildDriftFailure(
-  contract: JsonRpcMethodContract,
-  options: JsonRpcServerOptions
-): ReturnType<typeof failureReceipt> | undefined {
-  if (!options.readBuildIdentity
-    || contract.commandClass === "repo-read"
-    || contract.namespace === "admin") {
-    return undefined;
-  }
-  let build: ReturnType<NonNullable<JsonRpcServerOptions["readBuildIdentity"]>>;
-  try {
-    build = options.readBuildIdentity();
-  } catch (error) {
-    const cause = error instanceof Error ? error.message : String(error);
-    return failureReceipt(
-      contract.method,
-      "daemon_build_identity_unavailable",
-      `Daemon cannot verify that its running code matches the current dist build (${cause}); mixed-version writes are disabled. Run \`ha daemon start --service\`.`,
-      {
-        data: {
-          nextCommand: "ha daemon start --service"
-        }
-      }
-    );
-  }
-  if (build.loadedIdentity === build.installedIdentity) return undefined;
-  return failureReceipt(
-    contract.method,
-    "daemon_build_stale",
-    `Daemon code version ${build.loadedIdentity} does not match current dist version ${build.installedIdentity}; mixed-version writes are disabled. Run \`ha daemon start --service\`.`,
-    {
-      data: {
-        loadedIdentity: build.loadedIdentity,
-        installedIdentity: build.installedIdentity,
-        nextCommand: "ha daemon start --service"
-      }
-    }
-  );
 }
 
 async function handleAdminMethod(

--- a/packages/daemon/src/runtime/repo-runtime-error.ts
+++ b/packages/daemon/src/runtime/repo-runtime-error.ts
@@ -1,0 +1,7 @@
+export function describeRepoRuntimeError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "object" && error !== null && "cause" in error) {
+    return describeRepoRuntimeError((error as { readonly cause?: unknown }).cause);
+  }
+  return String(error);
+}

--- a/packages/daemon/src/runtime/repo-runtime-options-merge.ts
+++ b/packages/daemon/src/runtime/repo-runtime-options-merge.ts
@@ -1,0 +1,29 @@
+import type {
+  DaemonRepoRuntimeOptions,
+  MultiRepoDaemonRuntimeOptions
+} from "./repo-runtime-options.ts";
+
+export function mergeRepoRuntimeDefaults(
+  repo: DaemonRepoRuntimeOptions,
+  options: MultiRepoDaemonRuntimeOptions
+): DaemonRepoRuntimeOptions {
+  return {
+    ...repo,
+    ...(repo.writeOwnership ? {} : options.writeOwnership ? { writeOwnership: options.writeOwnership } : {}),
+    ...(repo.operationalActor ? {} : options.operationalActor ? { operationalActor: options.operationalActor } : {}),
+    ...(repo.lockTtlMs !== undefined ? {} : options.lockTtlMs !== undefined ? { lockTtlMs: options.lockTtlMs } : {}),
+    ...(repo.interactiveMicroBatchMs !== undefined ? {} : options.interactiveMicroBatchMs !== undefined ? { interactiveMicroBatchMs: options.interactiveMicroBatchMs } : {}),
+    ...(repo.maxInteractiveOpsPerCommit !== undefined ? {} : options.maxInteractiveOpsPerCommit !== undefined ? { maxInteractiveOpsPerCommit: options.maxInteractiveOpsPerCommit } : {}),
+    ...(repo.materializerPollMs !== undefined ? {} : options.materializerPollMs !== undefined ? { materializerPollMs: options.materializerPollMs } : {}),
+    ...(repo.materializerMaxBranchesPerBatch !== undefined ? {} : options.materializerMaxBranchesPerBatch !== undefined ? { materializerMaxBranchesPerBatch: options.materializerMaxBranchesPerBatch } : {}),
+    ...(repo.projectionReconcileIntervalMs !== undefined ? {} : options.projectionReconcileIntervalMs !== undefined ? { projectionReconcileIntervalMs: options.projectionReconcileIntervalMs } : {}),
+    ...(repo.admissionMaxOperations !== undefined ? {} : options.admissionMaxOperations !== undefined ? { admissionMaxOperations: options.admissionMaxOperations } : {}),
+    ...(repo.admissionMaxBytes !== undefined ? {} : options.admissionMaxBytes !== undefined ? { admissionMaxBytes: options.admissionMaxBytes } : {}),
+    ...(repo.admissionReservedOperationsPerPlane !== undefined ? {} : options.admissionReservedOperationsPerPlane !== undefined ? { admissionReservedOperationsPerPlane: options.admissionReservedOperationsPerPlane } : {}),
+    ...(repo.admissionReservedBytesPerPlane !== undefined ? {} : options.admissionReservedBytesPerPlane !== undefined ? { admissionReservedBytesPerPlane: options.admissionReservedBytesPerPlane } : {}),
+    ...(repo.projectionSourceFenceFactory ? {} : options.projectionSourceFenceFactory ? { projectionSourceFenceFactory: options.projectionSourceFenceFactory } : {}),
+    ...(repo.generationAxes ? {} : options.generationAxes ? { generationAxes: options.generationAxes } : {}),
+    ...(repo.generationWitness ? {} : options.generationWitness ? { generationWitness: options.generationWitness } : {}),
+    ...(repo.generationCapability ? {} : options.generationCapability ? { generationCapability: options.generationCapability } : {})
+  };
+}

--- a/packages/daemon/src/runtime/repo-runtime-options.ts
+++ b/packages/daemon/src/runtime/repo-runtime-options.ts
@@ -59,6 +59,8 @@ export interface DaemonRuntimeOptions {
     readonly rootDir: string;
     readonly layoutOverrides?: HarnessLayoutOverrides;
   }) => Promise<void>;
+  /** Fail-closed build witness shared by every persistent writer in this daemon. */
+  readonly assertBuildCurrent?: () => void;
   /** Present only when this runtime is owned by a durable daemon generation. */
   readonly generationAxes?: {
     readonly machineId: string;
@@ -152,6 +154,7 @@ export interface MultiRepoHarnessDaemonRuntime {
   readonly attachRepo: (repo: DaemonRepoRuntimeOptions) => Promise<DaemonRepoRuntimeStatus>;
   readonly detachRepo: (repoId: string) => Promise<DaemonRepoRuntimeStatus>;
   readonly retryUnavailableRepos: () => Promise<ReadonlyArray<DaemonRepoRuntimeStatus>>;
+  readonly installWriteGuard?: (assertBuildCurrent: () => void) => void;
   readonly getRepoRuntime: (repoId: string) => HarnessDaemonRuntime | undefined;
   readonly enqueueInteractiveWrite: (repoId: string, request: InteractiveWriteRequest) => Promise<InteractiveWriteReceipt>;
   readonly enqueueBackgroundBatch: <Result>(repoId: string, request: BackgroundBatchRequest<Result>) => Promise<Result>;

--- a/packages/daemon/src/runtime/repo-runtime.ts
+++ b/packages/daemon/src/runtime/repo-runtime.ts
@@ -76,6 +76,8 @@ import {
 import { toDaemonRuntimeStatus } from "./repo-runtime-status.ts";
 import { defaultDaemonRuntimePolicy } from "./runtime-policy.ts";
 import { ReservationReconcilerRunner } from "./reservation-reconciler-runner.ts";
+import { mergeRepoRuntimeDefaults } from "./repo-runtime-options-merge.ts";
+import { describeRepoRuntimeError } from "./repo-runtime-error.ts";
 
 const defaultDaemonOperationalActor: OperationalActor = { scope: "operational", kind: "system", id: "daemon-runtime" };
 
@@ -109,9 +111,10 @@ export function createDaemonRuntime(options: DaemonRuntimeOptions): HarnessDaemo
 export function createMultiRepoDaemonRuntime(options: MultiRepoDaemonRuntimeOptions): MultiRepoHarnessDaemonRuntime {
   const contexts = new Map<string, DaemonRepoRuntimeContext>();
   let started = false;
+  let assertBuildCurrent = options.assertBuildCurrent;
 
   for (const repo of sortedRepoOptions(options.repos)) {
-    addContext(mergeRepoDefaults(repo, options));
+    addContext(mergeRepoRuntimeDefaults(repo, options));
   }
 
   const runtime: MultiRepoHarnessDaemonRuntime = {
@@ -138,7 +141,7 @@ export function createMultiRepoDaemonRuntime(options: MultiRepoDaemonRuntimeOpti
     },
     status,
     attachRepo: async (repo) => {
-      const context = contexts.get(repo.repoId) ?? addContext(mergeRepoDefaults(repo, options));
+      const context = contexts.get(repo.repoId) ?? addContext(mergeRepoRuntimeDefaults(repo, options));
       started = true;
       return context.attach({ failOnError: false });
     },
@@ -154,6 +157,10 @@ export function createMultiRepoDaemonRuntime(options: MultiRepoDaemonRuntimeOpti
         retried.push(await context.attach({ failOnError: false }));
       }
       return retried;
+    },
+    installWriteGuard: (guard) => {
+      assertBuildCurrent = guard;
+      for (const context of contexts.values()) context.installWriteGuard(guard);
     },
     getRepoRuntime: (repoId) => contexts.get(repoId),
     enqueueInteractiveWrite: (repoId, request) => requireContext(contexts, repoId).enqueueInteractiveWrite(request),
@@ -179,7 +186,11 @@ export function createMultiRepoDaemonRuntime(options: MultiRepoDaemonRuntimeOpti
     for (const existing of contexts.values()) {
       if (existing.rootDir === rootDir) throw new Error(`duplicate daemon repo root: ${rootDir}`);
     }
-    const context = new DaemonRepoRuntimeContext({ ...repo, rootDir });
+    const context = new DaemonRepoRuntimeContext({
+      ...repo,
+      rootDir,
+      ...(assertBuildCurrent ? { assertBuildCurrent } : {})
+    });
     contexts.set(repo.repoId, context);
     return context;
   }
@@ -209,6 +220,7 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
   private lastMaterializerError: string | undefined;
   private materializerTimer: ReturnType<typeof setInterval> | undefined;
   private readonly reservationReconciler: ReservationReconcilerRunner;
+  private assertBuildCurrent: () => void;
   private runtimeRegistrationId: string | undefined;
 
   constructor(options: DaemonRepoRuntimeOptions) {
@@ -238,6 +250,11 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
         } : {})
       }
     );
+    this.assertBuildCurrent = options.assertBuildCurrent ?? (() => undefined);
+  }
+
+  installWriteGuard(assertBuildCurrent: () => void): void {
+    this.assertBuildCurrent = assertBuildCurrent;
   }
 
   start(): Promise<DaemonRuntimeStatus> {
@@ -261,7 +278,9 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
         this.state = "attached";
         return this.status();
       }
+      this.assertBuildCurrent();
       this.lock = acquireDaemonGlobalLock(this.rootDir, this.runtimeContext, this.layout.journalPath, this.operationalActor, this.lockTtlMs);
+      this.assertBuildCurrent();
       this.lastRecovery = Effect.runSync(recoverJournaledWrites({
         rootDir: this.rootDir,
         layoutOverrides: this.options.layoutOverrides,
@@ -273,6 +292,7 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
       this.lastError = undefined;
       this.lastMaterializerError = undefined;
       this.state = "attached";
+      this.assertBuildCurrent();
       await this.reservationReconciler.run();
       if (this.options.generationAxes) this.runtimeRegistrationId = randomUUID();
       this.startMaterializerTimer();
@@ -454,6 +474,7 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
         cause: new Error(`daemon repo "${this.repoId}" write ownership belongs to its child capsule`)
       } satisfies WriteError;
     }
+    this.assertBuildCurrent();
     return { lock: this.lock };
   }
 
@@ -483,10 +504,19 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
       return;
     }
     this.materializerTimer = setInterval(() => {
-      void this.reservationReconciler.run().catch(() => undefined);
-      void this.enqueueMaterializerBatch().catch(() => undefined);
+      void this.runMaterializerTimerCycle();
     }, this.options.materializerPollMs);
     this.materializerTimer.unref();
+  }
+
+  private async runMaterializerTimerCycle(): Promise<void> {
+    try {
+      this.requireWriterAttached();
+      await this.reservationReconciler.run();
+      await this.enqueueMaterializerBatch();
+    } catch (error) {
+      this.lastMaterializerError = describeRepoRuntimeError(error);
+    }
   }
 
   private runMaterializerBatch(batchOptions: DaemonMaterializerBatchOptions): LedgerMaterializerReport {
@@ -548,28 +578,6 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
   }
 }
 
-function mergeRepoDefaults(repo: DaemonRepoRuntimeOptions, options: MultiRepoDaemonRuntimeOptions): DaemonRepoRuntimeOptions {
-  return {
-    ...repo,
-    ...(repo.writeOwnership ? {} : options.writeOwnership ? { writeOwnership: options.writeOwnership } : {}),
-    ...(repo.operationalActor ? {} : options.operationalActor ? { operationalActor: options.operationalActor } : {}),
-    ...(repo.lockTtlMs !== undefined ? {} : options.lockTtlMs !== undefined ? { lockTtlMs: options.lockTtlMs } : {}),
-    ...(repo.interactiveMicroBatchMs !== undefined ? {} : options.interactiveMicroBatchMs !== undefined ? { interactiveMicroBatchMs: options.interactiveMicroBatchMs } : {}),
-    ...(repo.maxInteractiveOpsPerCommit !== undefined ? {} : options.maxInteractiveOpsPerCommit !== undefined ? { maxInteractiveOpsPerCommit: options.maxInteractiveOpsPerCommit } : {}),
-    ...(repo.materializerPollMs !== undefined ? {} : options.materializerPollMs !== undefined ? { materializerPollMs: options.materializerPollMs } : {}),
-    ...(repo.materializerMaxBranchesPerBatch !== undefined ? {} : options.materializerMaxBranchesPerBatch !== undefined ? { materializerMaxBranchesPerBatch: options.materializerMaxBranchesPerBatch } : {}),
-    ...(repo.projectionReconcileIntervalMs !== undefined ? {} : options.projectionReconcileIntervalMs !== undefined ? { projectionReconcileIntervalMs: options.projectionReconcileIntervalMs } : {}),
-    ...(repo.admissionMaxOperations !== undefined ? {} : options.admissionMaxOperations !== undefined ? { admissionMaxOperations: options.admissionMaxOperations } : {}),
-    ...(repo.admissionMaxBytes !== undefined ? {} : options.admissionMaxBytes !== undefined ? { admissionMaxBytes: options.admissionMaxBytes } : {}),
-    ...(repo.admissionReservedOperationsPerPlane !== undefined ? {} : options.admissionReservedOperationsPerPlane !== undefined ? { admissionReservedOperationsPerPlane: options.admissionReservedOperationsPerPlane } : {}),
-    ...(repo.admissionReservedBytesPerPlane !== undefined ? {} : options.admissionReservedBytesPerPlane !== undefined ? { admissionReservedBytesPerPlane: options.admissionReservedBytesPerPlane } : {}),
-    ...(repo.projectionSourceFenceFactory ? {} : options.projectionSourceFenceFactory ? { projectionSourceFenceFactory: options.projectionSourceFenceFactory } : {}),
-    ...(repo.generationAxes ? {} : options.generationAxes ? { generationAxes: options.generationAxes } : {}),
-    ...(repo.generationWitness ? {} : options.generationWitness ? { generationWitness: options.generationWitness } : {}),
-    ...(repo.generationCapability ? {} : options.generationCapability ? { generationCapability: options.generationCapability } : {})
-  };
-}
-
 function sortedRepoOptions(repos: ReadonlyArray<DaemonRepoRuntimeOptions>): ReadonlyArray<DaemonRepoRuntimeOptions> {
   return [...repos].sort((left, right) => left.repoId.localeCompare(right.repoId) || path.resolve(left.rootDir).localeCompare(path.resolve(right.rootDir)));
 }
@@ -582,12 +590,4 @@ function requireContext(contexts: Map<string, DaemonRepoRuntimeContext>, repoId:
   const context = contexts.get(repoId);
   if (!context) throw { _tag: "JournalUnavailable", cause: new Error(`unknown daemon repo "${repoId}"`) } satisfies WriteError;
   return context;
-}
-
-function describeRepoRuntimeError(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  if (typeof error === "object" && error !== null && "cause" in error) {
-    return describeRepoRuntimeError((error as { readonly cause?: unknown }).cause);
-  }
-  return String(error);
 }

--- a/packages/daemon/src/service/build-identity-write-guard.ts
+++ b/packages/daemon/src/service/build-identity-write-guard.ts
@@ -1,0 +1,48 @@
+import type { DaemonLogService } from "@harness-anything/application";
+import type { DaemonRepoNamespace } from "../protocol/json-rpc-server.ts";
+import type { MultiRepoHarnessDaemonRuntime } from "../runtime/repo-runtime.ts";
+import {
+  createDaemonBuildIdentityWitness,
+  type DaemonBuildIdentityWitness,
+  type DaemonDeploymentStatusBuild
+} from "./deployment-status-options.ts";
+
+export function installDaemonBuildWriteGuard(input: {
+  readonly runtime: MultiRepoHarnessDaemonRuntime;
+  readonly repos: ReadonlyArray<DaemonRepoNamespace>;
+  readonly defaultRepoId: string;
+  readonly build: DaemonDeploymentStatusBuild;
+  readonly daemonLogService: DaemonLogService;
+}): DaemonBuildIdentityWitness {
+  const witness = createDaemonBuildIdentityWitness(input.build, {
+    onBlocked: (diagnostic) => {
+      const repo = input.repos.find((candidate) => candidate.repoId === input.defaultRepoId)
+        ?? input.repos[0];
+      if (!repo) return;
+      void input.daemonLogService.append({
+        level: "error",
+        source: "daemon",
+        component: "build-identity",
+        event: "mixed-version-writes-blocked",
+        message: diagnostic.message,
+        errorCode: diagnostic.code,
+        hint: "Run `ha daemon start --service`."
+      }, { repo }).catch(() => undefined);
+    }
+  });
+  input.runtime.installWriteGuard?.(witness.assertCurrent);
+  return witness;
+}
+
+export function runWhenBuildCurrent(
+  witness: DaemonBuildIdentityWitness,
+  action: () => void
+): boolean {
+  try {
+    witness.assertCurrent();
+  } catch {
+    return false;
+  }
+  action();
+  return true;
+}

--- a/packages/daemon/src/service/deployment-status-options.ts
+++ b/packages/daemon/src/service/deployment-status-options.ts
@@ -1,5 +1,11 @@
 import type { DaemonDeploymentStatus } from "@harness-anything/application";
-import { calculateDaemonArtifactIdentity } from "../protocol/daemon-artifact-identity.ts";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import {
+  calculateDaemonArtifactIdentity,
+  daemonBuildProvenanceFilename,
+  resolveDaemonArtifactRoot
+} from "../protocol/daemon-artifact-identity.ts";
 import { captureDaemonDeploymentStatus } from "../protocol/daemon-deployment-identity.ts";
 
 const emptyArtifactIdentity = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
@@ -9,14 +15,34 @@ export interface DaemonDeploymentStatusBuild {
   readonly loadedIdentity: string;
 }
 
-export function createDaemonBuildIdentityWitness(build: DaemonDeploymentStatusBuild): {
+export interface DaemonBuildIdentityWitness {
   readonly read: () => { readonly loadedIdentity: string; readonly installedIdentity: string };
   readonly assertCurrent: () => void;
-} {
-  const deploymentStatus = daemonDeploymentStatusOptions(build);
+}
+
+export class DaemonBuildIdentityError extends Error {
+  readonly code: "DAEMON_BUILD_STALE" | "DAEMON_BUILD_IDENTITY_UNAVAILABLE";
+
+  constructor(code: DaemonBuildIdentityError["code"], message: string) {
+    super(message);
+    this.name = "DaemonBuildIdentityError";
+    this.code = code;
+  }
+}
+
+export function createDaemonBuildIdentityWitness(
+  build: DaemonDeploymentStatusBuild,
+  options: {
+    readonly onBlocked?: (diagnostic: DaemonBuildIdentityError) => void;
+    readonly readInstalledIdentity?: () => string;
+  } = {}
+): DaemonBuildIdentityWitness {
+  const deploymentStatus = daemonDeploymentStatusOptions(build, { requireBuildProvenance: true });
+  const readInstalledIdentity = options.readInstalledIdentity ?? deploymentStatus.readInstalledIdentity;
+  let blocked = false;
   const read = () => ({
     loadedIdentity: build.loadedIdentity,
-    installedIdentity: deploymentStatus.readInstalledIdentity()
+    installedIdentity: readInstalledIdentity()
   });
   return {
     read,
@@ -25,28 +51,45 @@ export function createDaemonBuildIdentityWitness(build: DaemonDeploymentStatusBu
       try {
         identity = read();
       } catch (error) {
-        throw new Error(
+        return block(new DaemonBuildIdentityError(
+          "DAEMON_BUILD_IDENTITY_UNAVAILABLE",
           `DAEMON_BUILD_IDENTITY_UNAVAILABLE: Daemon cannot verify that its running code matches the current dist build (${error instanceof Error ? error.message : String(error)}); mixed-version writes are disabled. Run \`ha daemon start --service\`.`
-        );
+        ));
       }
       if (identity.loadedIdentity !== identity.installedIdentity) {
-        throw new Error(
+        return block(new DaemonBuildIdentityError(
+          "DAEMON_BUILD_STALE",
           `DAEMON_BUILD_STALE: Daemon code version ${identity.loadedIdentity} does not match current dist version ${identity.installedIdentity}; mixed-version writes are disabled. Run \`ha daemon start --service\`.`
-        );
+        ));
       }
+      blocked = false;
     }
   };
+
+  function block(diagnostic: DaemonBuildIdentityError): never {
+    if (!blocked) {
+      blocked = true;
+      options.onBlocked?.(diagnostic);
+    }
+    throw diagnostic;
+  }
 }
 
-export function daemonDeploymentStatusOptions(build?: DaemonDeploymentStatusBuild): {
+export function daemonDeploymentStatusOptions(
+  build?: DaemonDeploymentStatusBuild,
+  options: { readonly requireBuildProvenance?: boolean } = {}
+): {
   readonly readInstalledIdentity: () => string;
   readonly readDeploymentStatus?: (installedIdentity: string) => DaemonDeploymentStatus;
 } {
   if (!build) {
     return { readInstalledIdentity: () => emptyArtifactIdentity };
   }
+  const readInstalledIdentity = options.requireBuildProvenance === true
+    ? createCachedInstalledIdentityReader(build.entrypoint)
+    : () => calculateDaemonArtifactIdentity(build.entrypoint).identity;
   return {
-    readInstalledIdentity: () => calculateDaemonArtifactIdentity(build.entrypoint).identity,
+    readInstalledIdentity,
     readDeploymentStatus: (installedIdentity) => captureDaemonDeploymentStatus({
       entrypoint: build.entrypoint,
       loadedIdentity: build.loadedIdentity,
@@ -54,4 +97,46 @@ export function daemonDeploymentStatusOptions(build?: DaemonDeploymentStatusBuil
       supervisor: process.env.HARNESS_DAEMON_SUPERVISOR
     })
   };
+}
+
+function createCachedInstalledIdentityReader(entrypoint: string): () => string {
+  const artifactRoot = resolveDaemonArtifactRoot(entrypoint);
+  const provenancePath = path.join(artifactRoot, daemonBuildProvenanceFilename);
+  let cached: { readonly signature: string; readonly identity: string } | undefined;
+  return () => {
+    if (!existsSync(provenancePath)) {
+      cached = undefined;
+      if (path.basename(artifactRoot) === "dist") {
+        throw new Error(`daemon build identity file is unavailable: ${provenancePath}`);
+      }
+      return calculateDaemonArtifactIdentity(entrypoint).identity;
+    }
+    const provenanceStat = statSync(provenancePath, { bigint: true });
+    const signature = [
+      provenanceStat.dev,
+      provenanceStat.ino,
+      provenanceStat.size,
+      provenanceStat.mtimeNs
+    ].join(":");
+    if (cached?.signature === signature) return cached.identity;
+    const document = JSON.parse(readFileSync(provenancePath, "utf8")) as unknown;
+    if (!isBuildProvenance(document)) {
+      cached = undefined;
+      throw new Error(`invalid daemon build identity file: ${provenancePath}`);
+    }
+    cached = { signature, identity: document.contentFingerprint };
+    return cached.identity;
+  };
+}
+
+function isBuildProvenance(value: unknown): value is {
+  readonly schema: "daemon-build-provenance/v1";
+  readonly contentFingerprint: string;
+} {
+  return typeof value === "object"
+    && value !== null
+    && !Array.isArray(value)
+    && (value as Record<string, unknown>).schema === "daemon-build-provenance/v1"
+    && typeof (value as Record<string, unknown>).contentFingerprint === "string"
+    && /^sha256:[0-9a-f]{64}$/u.test((value as Record<string, unknown>).contentFingerprint as string);
 }

--- a/packages/daemon/src/service/deployment-status-options.ts
+++ b/packages/daemon/src/service/deployment-status-options.ts
@@ -9,6 +9,35 @@ export interface DaemonDeploymentStatusBuild {
   readonly loadedIdentity: string;
 }
 
+export function createDaemonBuildIdentityWitness(build: DaemonDeploymentStatusBuild): {
+  readonly read: () => { readonly loadedIdentity: string; readonly installedIdentity: string };
+  readonly assertCurrent: () => void;
+} {
+  const deploymentStatus = daemonDeploymentStatusOptions(build);
+  const read = () => ({
+    loadedIdentity: build.loadedIdentity,
+    installedIdentity: deploymentStatus.readInstalledIdentity()
+  });
+  return {
+    read,
+    assertCurrent: () => {
+      let identity: ReturnType<typeof read>;
+      try {
+        identity = read();
+      } catch (error) {
+        throw new Error(
+          `DAEMON_BUILD_IDENTITY_UNAVAILABLE: Daemon cannot verify that its running code matches the current dist build (${error instanceof Error ? error.message : String(error)}); mixed-version writes are disabled. Run \`ha daemon start --service\`.`
+        );
+      }
+      if (identity.loadedIdentity !== identity.installedIdentity) {
+        throw new Error(
+          `DAEMON_BUILD_STALE: Daemon code version ${identity.loadedIdentity} does not match current dist version ${identity.installedIdentity}; mixed-version writes are disabled. Run \`ha daemon start --service\`.`
+        );
+      }
+    }
+  };
+}
+
 export function daemonDeploymentStatusOptions(build?: DaemonDeploymentStatusBuild): {
   readonly readInstalledIdentity: () => string;
   readonly readDeploymentStatus?: (installedIdentity: string) => DaemonDeploymentStatus;

--- a/packages/daemon/src/service/repo-availability.ts
+++ b/packages/daemon/src/service/repo-availability.ts
@@ -1,0 +1,39 @@
+import type {
+  DaemonRepoAvailabilityFailure,
+  DaemonRepoNamespace
+} from "../protocol/json-rpc-server.ts";
+import type { MultiRepoHarnessDaemonRuntime } from "../runtime/repo-runtime.ts";
+
+export function repoAvailabilityFailure(
+  runtime: MultiRepoHarnessDaemonRuntime,
+  repo: DaemonRepoNamespace,
+  authorityUnavailable?: string
+): DaemonRepoAvailabilityFailure | undefined {
+  const status = runtime.status().repos.find((candidate) => candidate.repoId === repo.repoId);
+  if (!status) {
+    return {
+      code: "repo_unavailable",
+      repo: {
+        repoId: repo.repoId,
+        canonicalRoot: repo.canonicalRoot,
+        state: "unavailable",
+        lockPath: null,
+        lockOwnerToken: null,
+        lastError: "runtime context not found"
+      }
+    };
+  }
+  if (status.state === "attached" && !authorityUnavailable) return undefined;
+  const lockHeld = typeof status.lastError === "string" && /lock already held|global\.lock/u.test(status.lastError);
+  return {
+    code: lockHeld ? "repo_lock_held" : "repo_unavailable",
+    repo: {
+      repoId: repo.repoId,
+      canonicalRoot: repo.canonicalRoot,
+      state: status.state,
+      lockPath: status.lockPath ?? null,
+      lockOwnerToken: status.lockOwnerToken ?? null,
+      lastError: authorityUnavailable ?? status.lastError ?? null
+    }
+  };
+}

--- a/packages/daemon/src/service/service-host.ts
+++ b/packages/daemon/src/service/service-host.ts
@@ -11,7 +11,7 @@ import type { AcceptedConnectionBinding } from "../protocol/connection-context.t
 import type { AuthorityWireIngressHandler } from "../transport/authority-wire-ingress.ts";
 import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
 import type { JsonObject, JsonRpcNotification } from "../protocol/json-rpc-types.ts";
-import type { DaemonRepoAvailabilityFailure, DaemonRepoNamespace } from "../protocol/json-rpc-server.ts";
+import type { DaemonRepoNamespace } from "../protocol/json-rpc-server.ts";
 import { noRepoBindingsError } from "../authority/authority-lifecycle.ts";
 import type { AuthorityRepoComponent, AuthorityRepoLifecycleController } from "../authority/authority-lifecycle.ts";
 import type { AuthenticatedActor, IdentityAdminSnapshot, IdentityProvider, PersonRegistry } from "../identity/types.ts";
@@ -39,10 +39,9 @@ import { requireAuthoritySubmissionForDispatch } from "../authority/authority-su
 import { daemonStatusPayload, type DaemonConnectionStats } from "./status-payload.ts";
 import { projectDaemonLaunchConfiguration } from "../client/local-json-rpc-client.ts";
 import { createDaemonIdleExitScheduler } from "./idle-exit-scheduler.ts";
-import {
-  createDaemonBuildIdentityWitness,
-  daemonDeploymentStatusOptions
-} from "./deployment-status-options.ts";
+import { daemonDeploymentStatusOptions } from "./deployment-status-options.ts";
+import { installDaemonBuildWriteGuard, runWhenBuildCurrent } from "./build-identity-write-guard.ts";
+import { repoAvailabilityFailure } from "./repo-availability.ts";
 import type {
   RepoWriteProcessSupervisor
 } from "../runtime/repo-write-process-supervisor.ts";
@@ -133,10 +132,12 @@ export async function createDaemonServiceHost<
   const daemonId = `ha-${process.pid}`;
   const daemonLogService = providedDaemonLogService
     ?? makeDaemonLogService({ store: makeDaemonLogFileStore({ userRoot }) });
-  const buildIdentity = createDaemonBuildIdentityWitness(build);
   const stopHandlers: Array<() => Promise<void>> = [];
   registerRepoWriteSupervisorStops(stopHandlers, repoWriteSupervisors);
   const reposById = new Map(repos.map((repo) => [repo.repoId, repo]));
+  const buildIdentity = installDaemonBuildWriteGuard({
+    runtime, repos, defaultRepoId, build, daemonLogService
+  });
   let requestStop: ((request: DaemonServiceStopRequest) => void) | undefined;
   const stopRequested = new Promise<DaemonServiceStopRequest>((resolve) => {
     requestStop = resolve;
@@ -320,7 +321,10 @@ export async function createDaemonServiceHost<
 
   async function reconcileDaemonRepos(userRoot: string): Promise<void> {
     await reconcileDaemonRepoRegistry({
-      loadDesiredRepos: () => readDaemonRegistry({ userRoot }).repos.filter((repo) => repo.state === "enabled"),
+      loadDesiredRepos: () => {
+        buildIdentity.assertCurrent();
+        return readDaemonRegistry({ userRoot }).repos.filter((repo) => repo.state === "enabled");
+      },
       knownRepoIds: () => [...reposById.keys()],
       repoStatus: (repoId) => runtime.status().repos.find((candidate) => candidate.repoId === repoId),
       attachRepo: async (repo) => {
@@ -342,6 +346,7 @@ export async function createDaemonServiceHost<
         if (!repoRuntime) throw new Error(`daemon runtime missing repo context: ${repo.repoId}`);
         let authorityComponent: AuthorityRepoComponent | undefined;
         if (authorityLifecycle) {
+          buildIdentity.assertCurrent();
           const startedAuthority = await authorityLifecycle.startRepo(namespace, repoRuntime);
           if (!startedAuthority.ok) throw new Error(startedAuthority.error);
           authorityComponent = startedAuthority.component;
@@ -370,7 +375,8 @@ export async function createDaemonServiceHost<
         reposById.delete(repoId);
       }
     }, reconcileState);
-    publishRuntimeRegistrationSnapshot({ userRoot, ...build, runtimeStatus: runtime.status() });
+    runWhenBuildCurrent(buildIdentity, () =>
+      publishRuntimeRegistrationSnapshot({ userRoot, ...build, runtimeStatus: runtime.status() }));
   }
 
   function serviceStatus(repoId: string, includeGenerationAxes = false): DaemonStatusResultV2 {
@@ -561,38 +567,4 @@ function loadRepoIdentity<
       loadError: error instanceof Error ? error.message : String(error)
     };
   }
-}
-
-function repoAvailabilityFailure(
-  runtime: MultiRepoHarnessDaemonRuntime,
-  repo: DaemonRepoNamespace,
-  authorityUnavailable?: string
-): DaemonRepoAvailabilityFailure | undefined {
-  const status = runtime.status().repos.find((candidate) => candidate.repoId === repo.repoId);
-  if (!status) {
-    return {
-      code: "repo_unavailable",
-      repo: {
-        repoId: repo.repoId,
-        canonicalRoot: repo.canonicalRoot,
-        state: "unavailable",
-        lockPath: null,
-        lockOwnerToken: null,
-        lastError: "runtime context not found"
-      }
-    };
-  }
-  if (status.state === "attached" && !authorityUnavailable) return undefined;
-  const lockHeld = typeof status.lastError === "string" && /lock already held|global\.lock/u.test(status.lastError);
-  return {
-    code: lockHeld ? "repo_lock_held" : "repo_unavailable",
-    repo: {
-      repoId: repo.repoId,
-      canonicalRoot: repo.canonicalRoot,
-      state: status.state,
-      lockPath: status.lockPath ?? null,
-      lockOwnerToken: status.lockOwnerToken ?? null,
-      lastError: authorityUnavailable ?? status.lastError ?? null
-    }
-  };
 }

--- a/packages/daemon/src/service/service-host.ts
+++ b/packages/daemon/src/service/service-host.ts
@@ -39,7 +39,10 @@ import { requireAuthoritySubmissionForDispatch } from "../authority/authority-su
 import { daemonStatusPayload, type DaemonConnectionStats } from "./status-payload.ts";
 import { projectDaemonLaunchConfiguration } from "../client/local-json-rpc-client.ts";
 import { createDaemonIdleExitScheduler } from "./idle-exit-scheduler.ts";
-import { daemonDeploymentStatusOptions } from "./deployment-status-options.ts";
+import {
+  createDaemonBuildIdentityWitness,
+  daemonDeploymentStatusOptions
+} from "./deployment-status-options.ts";
 import type {
   RepoWriteProcessSupervisor
 } from "../runtime/repo-write-process-supervisor.ts";
@@ -130,6 +133,7 @@ export async function createDaemonServiceHost<
   const daemonId = `ha-${process.pid}`;
   const daemonLogService = providedDaemonLogService
     ?? makeDaemonLogService({ store: makeDaemonLogFileStore({ userRoot }) });
+  const buildIdentity = createDaemonBuildIdentityWitness(build);
   const stopHandlers: Array<() => Promise<void>> = [];
   registerRepoWriteSupervisorStops(stopHandlers, repoWriteSupervisors);
   const reposById = new Map(repos.map((repo) => [repo.repoId, repo]));
@@ -232,6 +236,7 @@ export async function createDaemonServiceHost<
       daemonId,
       repos: protocolRepos(),
       services: defaultRepoBinding().services,
+      readBuildIdentity: buildIdentity.read,
       resolveRepoServices: (repo) => protocolRepoBinding(repo)?.services,
       resolveRepoIdentity: (repo) => protocolRepoBinding(repo)?.identity,
       resolveRepoAvailability: (repo) => repoAvailabilityFailure(
@@ -263,7 +268,8 @@ export async function createDaemonServiceHost<
     ),
     authorityWireIngress: createAuthorityWireIngressHandler({
       authorityLifecycle,
-      repoBindings: () => repoBindings.values()
+      repoBindings: () => repoBindings.values(),
+      assertBuildCurrent: buildIdentity.assertCurrent
     }),
     status: () => serviceStatus(defaultRepoBinding().repo.repoId),
     requestControl: controlService.requestControl,

--- a/packages/daemon/test/authority-wire-binding.test.ts
+++ b/packages/daemon/test/authority-wire-binding.test.ts
@@ -12,6 +12,28 @@ import {
 } from "../src/index.ts";
 import { createAuthorityWireIngressHandler } from "../src/index.ts";
 
+test("authority-wire ingress rejects artifact drift before binding a mixed-version writer", async () => {
+  let repoBindingReads = 0;
+  const handler = createAuthorityWireIngressHandler({
+    authorityLifecycle: {} as AuthorityRepoLifecycleController,
+    repoBindings: () => {
+      repoBindingReads += 1;
+      return [];
+    },
+    assertBuildCurrent: () => {
+      throw new Error(
+        `DAEMON_BUILD_STALE: Daemon code version sha256:${"a".repeat(64)} does not match current dist version sha256:${"b".repeat(64)}; mixed-version writes are disabled. Run \`ha daemon start --service\`.`
+      );
+    }
+  });
+
+  await assert.rejects(
+    handler({} as never),
+    /DAEMON_BUILD_STALE:[\s\S]*sha256:a{64}[\s\S]*sha256:b{64}[\s\S]*ha daemon start --service/u
+  );
+  assert.equal(repoBindingReads, 0);
+});
+
 test("authority-wire service binds the authenticated principal to the exact accepted connection", async () => {
   const repo: DaemonRepoNamespace = { repoId: "canonical", canonicalRoot: process.cwd() };
   const generation = connectionGeneration("wire-generation");

--- a/packages/daemon/test/daemon-build-drift-admission.test.ts
+++ b/packages/daemon/test/daemon-build-drift-admission.test.ts
@@ -1,0 +1,72 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createInMemoryTerminalSessionService } from "../src/terminal/session-registry.ts";
+import {
+  commandRunRequest,
+  emptyLocalController,
+  makeServer,
+  readFixture,
+  resultReceipt,
+  rosterIdentityOptions,
+  sampleRoster
+} from "./json-rpc-protocol-fixtures.ts";
+
+test("artifact drift rejects writes before mixed-version service dispatch and keeps reads available", async () => {
+  const loadedIdentity = `sha256:${"a".repeat(64)}`;
+  const installedIdentity = `sha256:${"b".repeat(64)}`;
+  const dispatched: string[] = [];
+  const roster = sampleRoster();
+  const server = makeServer({
+    ...rosterIdentityOptions(roster),
+    authContext: {
+      transportKind: "ssh-exec",
+      sshExecUser: { username: "alice", host: "team-host", source: "ssh-authenticated-exec" }
+    },
+    readBuildIdentity: () => ({ loadedIdentity, installedIdentity }),
+    services: {
+      LocalControllerService: emptyLocalController(),
+      TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" }),
+      CliCommandService: {
+        runCommand: async (payload) => {
+          const command = payload?.command as { readonly action?: { readonly kind?: string } } | undefined;
+          dispatched.push(command?.action?.kind ?? "unknown");
+          return {
+            ok: true,
+            schema: "command-receipt/v2",
+            command: command?.action?.kind ?? "unknown",
+            action: "run",
+            summary: "dispatched",
+            details: {},
+            meta: {
+              generatedAt: "2026-07-31T00:00:00.000Z",
+              compatibility: {}
+            }
+          };
+        }
+      }
+    }
+  });
+  await server.handle(readFixture("hello-compatible.json"));
+
+  const write = resultReceipt(await server.handle(commandRunRequest("task-complete", "write-stale")));
+  assert.equal(write.ok, false);
+  assert.equal(write.error?.code, "daemon_build_stale");
+  assert.match(write.error?.hint ?? "", new RegExp(loadedIdentity, "u"));
+  assert.match(write.error?.hint ?? "", new RegExp(installedIdentity, "u"));
+  assert.match(write.error?.hint ?? "", /ha daemon start --service/u);
+  assert.deepEqual(write.details.data, {
+    loadedIdentity,
+    installedIdentity,
+    nextCommand: "ha daemon start --service"
+  });
+  assert.deepEqual(write.next, [{
+    command: "ha daemon start --service",
+    description: "Restart the daemon on the current dist build, then retry the original write."
+  }]);
+  assert.deepEqual(dispatched, []);
+
+  const read = resultReceipt(await server.handle(commandRunRequest("task-show", "read-stale")));
+  assert.equal(read.ok, true);
+  assert.deepEqual(dispatched, ["task-show"]);
+});

--- a/packages/daemon/test/daemon-build-drift-admission.test.ts
+++ b/packages/daemon/test/daemon-build-drift-admission.test.ts
@@ -7,10 +7,23 @@ import {
   emptyLocalController,
   makeServer,
   readFixture,
-  resultReceipt,
   rosterIdentityOptions,
   sampleRoster
 } from "./json-rpc-protocol-fixtures.ts";
+import type { JsonRpcResponse } from "../src/index.ts";
+
+interface DriftReceipt {
+  readonly ok: boolean;
+  readonly error?: { readonly code?: string; readonly hint?: string };
+  readonly next?: ReadonlyArray<{ readonly command: string; readonly description?: string }>;
+  readonly items?: ReadonlyArray<unknown>;
+  readonly details: Record<string, unknown>;
+}
+
+function driftReceipt(response: JsonRpcResponse | ReadonlyArray<JsonRpcResponse> | undefined): DriftReceipt {
+  assert.ok(response && !Array.isArray(response) && "result" in response);
+  return response.result as unknown as DriftReceipt;
+}
 
 test("artifact drift rejects writes before mixed-version service dispatch and keeps reads available", async () => {
   const loadedIdentity = `sha256:${"a".repeat(64)}`;
@@ -49,7 +62,7 @@ test("artifact drift rejects writes before mixed-version service dispatch and ke
   });
   await server.handle(readFixture("hello-compatible.json"));
 
-  const write = resultReceipt(await server.handle(commandRunRequest("task-complete", "write-stale")));
+  const write = driftReceipt(await server.handle(commandRunRequest("task-complete", "write-stale")));
   assert.equal(write.ok, false);
   assert.equal(write.error?.code, "daemon_build_stale");
   assert.match(write.error?.hint ?? "", new RegExp(loadedIdentity, "u"));
@@ -66,7 +79,161 @@ test("artifact drift rejects writes before mixed-version service dispatch and ke
   }]);
   assert.deepEqual(dispatched, []);
 
-  const read = resultReceipt(await server.handle(commandRunRequest("task-show", "read-stale")));
+  const read = driftReceipt(await server.handle(commandRunRequest("task-show", "read-stale")));
   assert.equal(read.ok, true);
   assert.deepEqual(dispatched, ["task-show"]);
+});
+
+test("matching artifact identities allow writes", async () => {
+  const identity = `sha256:${"c".repeat(64)}`;
+  const dispatched: string[] = [];
+  const roster = sampleRoster();
+  const server = makeServer({
+    ...rosterIdentityOptions(roster),
+    authContext: {
+      transportKind: "ssh-exec",
+      sshExecUser: { username: "alice", host: "team-host", source: "ssh-authenticated-exec" }
+    },
+    readBuildIdentity: () => ({ loadedIdentity: identity, installedIdentity: identity }),
+    services: {
+      LocalControllerService: emptyLocalController(),
+      TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" }),
+      CliCommandService: {
+        runCommand: async (payload) => {
+          const command = payload?.command as { readonly action?: { readonly kind?: string } } | undefined;
+          dispatched.push(command?.action?.kind ?? "unknown");
+          return {
+            ok: true,
+            schema: "command-receipt/v2",
+            command: command?.action?.kind ?? "unknown",
+            action: "run",
+            summary: "dispatched",
+            details: {},
+            meta: { generatedAt: "2026-07-31T00:00:00.000Z", compatibility: {} }
+          };
+        }
+      }
+    }
+  });
+  await server.handle(readFixture("hello-compatible.json"));
+
+  const write = driftReceipt(await server.handle(commandRunRequest("task-complete", "write-current")));
+  assert.equal(write.ok, true);
+  assert.deepEqual(dispatched, ["task-complete"]);
+});
+
+test("temporarily unavailable artifact identity fails closed and automatically recovers", async () => {
+  const identity = `sha256:${"d".repeat(64)}`;
+  let available = false;
+  const dispatched: string[] = [];
+  const roster = sampleRoster();
+  const server = makeServer({
+    ...rosterIdentityOptions(roster),
+    authContext: {
+      transportKind: "ssh-exec",
+      sshExecUser: { username: "alice", host: "team-host", source: "ssh-authenticated-exec" }
+    },
+    readBuildIdentity: () => {
+      if (!available) throw new Error("identity file is being replaced");
+      return { loadedIdentity: identity, installedIdentity: identity };
+    },
+    services: {
+      LocalControllerService: emptyLocalController(),
+      TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" }),
+      CliCommandService: {
+        runCommand: async (payload) => {
+          const command = payload?.command as { readonly action?: { readonly kind?: string } } | undefined;
+          dispatched.push(command?.action?.kind ?? "unknown");
+          return {
+            ok: true,
+            schema: "command-receipt/v2",
+            command: command?.action?.kind ?? "unknown",
+            action: "run",
+            summary: "dispatched",
+            details: {},
+            meta: { generatedAt: "2026-07-31T00:00:00.000Z", compatibility: {} }
+          };
+        }
+      }
+    }
+  });
+  await server.handle(readFixture("hello-compatible.json"));
+
+  const unavailable = driftReceipt(await server.handle(commandRunRequest("task-complete", "write-unavailable")));
+  assert.equal(unavailable.ok, false);
+  assert.equal(unavailable.error?.code, "daemon_build_identity_unavailable");
+  assert.match(unavailable.error?.hint ?? "", /ha daemon start --service/u);
+  assert.deepEqual(dispatched, []);
+
+  const read = driftReceipt(await server.handle(commandRunRequest("task-show", "read-unavailable")));
+  assert.equal(read.ok, true);
+  assert.deepEqual(dispatched, ["task-show"]);
+
+  available = true;
+  const recovered = driftReceipt(await server.handle(commandRunRequest("task-complete", "write-recovered")));
+  assert.equal(recovered.ok, true);
+  assert.deepEqual(dispatched, ["task-show", "task-complete"]);
+});
+
+test("explicit read and lifecycle admin methods remain available during artifact drift", async () => {
+  const roster = sampleRoster();
+  let identityReads = 0;
+  const server = makeServer({
+    ...rosterIdentityOptions(roster),
+    authContext: {
+      transportKind: "ssh-exec",
+      sshExecUser: { username: "alice", host: "team-host", source: "ssh-authenticated-exec" }
+    },
+    readBuildIdentity: () => {
+      identityReads += 1;
+      return {
+        loadedIdentity: `sha256:${"e".repeat(64)}`,
+        installedIdentity: `sha256:${"f".repeat(64)}`
+      };
+    },
+    services: {
+      LocalControllerService: emptyLocalController(),
+      TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" }),
+      DaemonControlService: {
+        requestControl: (kind) => ({
+          ok: true,
+          accepted: {
+            schema: "daemon-control-accepted/v1",
+            accepted: true,
+            operationId: "control-during-drift",
+            kind,
+            scope: "service",
+            requestedAt: "2026-07-31T00:00:00.000Z",
+            before: {
+              pid: 41001,
+              loadedIdentity: `sha256:${"e".repeat(64)}`,
+              repoCount: 1,
+              queueDepth: 0
+            }
+          },
+          afterResponse: () => undefined
+        })
+      }
+    }
+  });
+  await server.handle(readFixture("hello-compatible.json"));
+
+  const response = await server.handle({
+    jsonrpc: "2.0",
+    id: "admin-during-drift",
+    method: "admin.people.list",
+    params: {}
+  });
+  const receipt = driftReceipt(response);
+  assert.equal(receipt.ok, true);
+  assert.equal(receipt.items?.length, 4);
+
+  const restart = driftReceipt(await server.handle({
+    jsonrpc: "2.0",
+    id: "restart-during-drift",
+    method: "admin.daemon.restart",
+    params: { payload: { reason: "artifact drift", drainTimeoutMs: 5_000 } }
+  }));
+  assert.equal(restart.ok, true);
+  assert.equal(identityReads, 0);
 });

--- a/packages/daemon/test/daemon-deployment-identity.test.ts
+++ b/packages/daemon/test/daemon-deployment-identity.test.ts
@@ -10,6 +10,7 @@ import {
   daemonBuildProvenanceFilename,
   inspectDaemonSupervision
 } from "../src/index.ts";
+import { daemonDeploymentStatusOptions } from "../src/service/deployment-status-options.ts";
 
 test("deployment identity binds commit, source bytes, loaded artifact bytes, and manager PID", () => {
   const fixture = deploymentFixture();
@@ -89,6 +90,37 @@ test("dead or mismatched manager unit cannot validate a manually started daemon"
   assert.equal(status.matchesPid, false);
   assert.equal(status.managerState, "inactive");
   assert.equal(status.observedPid, null);
+});
+
+test("installed build identity cache fails closed while provenance is unavailable and recovers on replacement", () => {
+  const fixture = deploymentFixture();
+  const provenancePath = path.join(
+    calculateDaemonArtifactIdentity(fixture.entrypoint).artifactRoot,
+    daemonBuildProvenanceFilename
+  );
+  try {
+    const status = daemonDeploymentStatusOptions({
+      entrypoint: fixture.entrypoint,
+      loadedIdentity: fixture.artifactIdentity
+    }, { requireBuildProvenance: true });
+    assert.equal(status.readInstalledIdentity(), fixture.artifactIdentity);
+    assert.equal(status.readInstalledIdentity(), fixture.artifactIdentity);
+
+    rmSync(provenancePath);
+    assert.throws(
+      () => status.readInstalledIdentity(),
+      /daemon build identity file is unavailable/u
+    );
+
+    const replacementIdentity = `sha256:${"b".repeat(64)}`;
+    writeFileSync(provenancePath, `${JSON.stringify({
+      schema: "daemon-build-provenance/v1",
+      contentFingerprint: replacementIdentity
+    })}\n`, "utf8");
+    assert.equal(status.readInstalledIdentity(), replacementIdentity);
+  } finally {
+    fixture.cleanup();
+  }
 });
 
 function deploymentFixture(): {

--- a/packages/daemon/test/json-rpc-protocol-fixtures.ts
+++ b/packages/daemon/test/json-rpc-protocol-fixtures.ts
@@ -87,7 +87,8 @@ export function resultReceipt(response: JsonRpcResponse | ReadonlyArray<JsonRpcR
   readonly schema: string;
   readonly command: string;
   readonly action?: string;
-  readonly error?: { readonly code?: string };
+  readonly error?: { readonly code?: string; readonly hint?: string };
+  readonly next?: ReadonlyArray<{ readonly command: string; readonly description?: string }>;
   readonly items?: ReadonlyArray<unknown>;
   readonly details: Record<string, any>;
 } {
@@ -98,7 +99,8 @@ export function resultReceipt(response: JsonRpcResponse | ReadonlyArray<JsonRpcR
     readonly schema: string;
     readonly command: string;
     readonly action?: string;
-    readonly error?: { readonly code?: string };
+    readonly error?: { readonly code?: string; readonly hint?: string };
+    readonly next?: ReadonlyArray<{ readonly command: string; readonly description?: string }>;
     readonly items?: ReadonlyArray<unknown>;
     readonly details: Record<string, any>;
   };

--- a/packages/daemon/test/json-rpc-protocol-fixtures.ts
+++ b/packages/daemon/test/json-rpc-protocol-fixtures.ts
@@ -87,8 +87,7 @@ export function resultReceipt(response: JsonRpcResponse | ReadonlyArray<JsonRpcR
   readonly schema: string;
   readonly command: string;
   readonly action?: string;
-  readonly error?: { readonly code?: string; readonly hint?: string };
-  readonly next?: ReadonlyArray<{ readonly command: string; readonly description?: string }>;
+  readonly error?: { readonly code?: string };
   readonly items?: ReadonlyArray<unknown>;
   readonly details: Record<string, any>;
 } {
@@ -99,8 +98,7 @@ export function resultReceipt(response: JsonRpcResponse | ReadonlyArray<JsonRpcR
     readonly schema: string;
     readonly command: string;
     readonly action?: string;
-    readonly error?: { readonly code?: string; readonly hint?: string };
-    readonly next?: ReadonlyArray<{ readonly command: string; readonly description?: string }>;
+    readonly error?: { readonly code?: string };
     readonly items?: ReadonlyArray<unknown>;
     readonly details: Record<string, any>;
   };

--- a/packages/daemon/test/runtime/repo-runtime.test.ts
+++ b/packages/daemon/test/runtime/repo-runtime.test.ts
@@ -439,6 +439,30 @@ test("daemon runtime runs the reservation reconciler at attach and on the existi
   });
 });
 
+test("artifact drift stops the materializer timer before any persistent reconciliation", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    let reconciliations = 0;
+    let stale = false;
+    const runtime = createDaemonRuntime({
+      rootDir,
+      materializerPollMs: 10,
+      assertBuildCurrent: () => {
+        if (stale) throw new Error("DAEMON_BUILD_STALE: restart required");
+      },
+      reservationReconciler: async () => {
+        reconciliations += 1;
+      }
+    });
+
+    await runtime.start();
+    assert.equal(reconciliations, 1);
+    stale = true;
+    await new Promise<void>((resolve) => setTimeout(resolve, 75));
+    assert.equal(reconciliations, 1);
+    await runtime.stop();
+  });
+});
+
 test("daemon restart after SIGKILL takes over stale lock and recovers durable journal", async () => {
   await withTempStoreAsync(async (rootDir) => {
     await spawnJournalOnlyDaemon(rootDir);


### PR DESCRIPTION
# English

## Summary

Structural fix for the mixed-version write-path incident family: when the resident daemon's loaded code no longer matches the current dist build (post-merge rebuilds while the daemon keeps running), every persistent write — request-driven and self-driven — now fails closed with an explicit "restart the daemon" diagnostic instead of producing misleading `AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR` / `CAPSULE_DISCONNECTED` errors. Root cause was established experimentally in production: a stuck `task complete` failed identically across four retries under a stale daemon and succeeded on first retry after `ha daemon start --service`.

## What Changed

- `packages/daemon/src/service/deployment-status-options.ts`: build-identity witness — compares loaded identity vs installed dist identity (provenance anchor), metadata-cached; prebuild removes the anchor and postbuild rewrites it, so the rebuild window is fail-closed and recovery is automatic once the anchor returns.
- `packages/daemon/src/protocol/json-rpc-server.ts`: write methods rejected on drift with `daemon_build_stale` (loaded/installed identities + `ha daemon start --service` next step); identity-unavailable also fails closed. repo-read exempt; admin exemption narrowed to five explicit read/lifecycle methods (future admin methods are gated by default).
- `packages/daemon/src/service/build-identity-write-guard.ts` (new): single enforcement point installed into the runtime; materializer timer, registry reconcile → repo attach/recovery, and runtime projection writes all consult the same witness; on drift they stop with a one-shot diagnostic (no 5s log spam).
- `packages/application/src/command-receipt.ts`: structured restart guidance surfaces through the CLI error mapper.
- Tests: drift-rejected / current-allowed / unavailable-fail-closed / admin-exemption quadrants plus regressions proving the materializer and recovery do not run under drift; recovery-after-anchor-restored covered.

## Task And Scope

- Harness task: task_01KYV26EJH8VJFGSMH6FTR4RZB
- Branch: codex/replay-fix
- Public scope: daemon runtime/service/protocol + application receipt + tests
- Private planning/evidence updated: yes (two production incident timelines + decisive restart experiment in task package)
- Out of scope: NON_LINEAR publication-proof semantics (unchanged), kernel

## Version Impact

- Version: no version change because daemon runtime guard only
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: n/a
- Authority: task task_01KYV26EJH8VJFGSMH6FTR4RZB (flow-defect standing authorization; second occurrence of the family)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: n/a
- Break-glass scope: n/a
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: 9ed118e7
- Branch merge-base with `origin/main`: 9ed118e7
- Last `git fetch origin` time: 2026-07-31
- Sync method: none needed (no conflicting files landed since)
- Public diff command: `git diff origin/main...codex/replay-fix`
- Private evidence commit/path: harness/tasks/task_01KYV26EJH8VJFGSMH6FTR4RZB-authority-attribution-evidence-op-base-publication-non-linear/artifacts/implementation-report.md
- Reviewer evidence path: GLM blind review R2 findings (2 P1 background-bypass paths) fixed in R3; dispositions in task ledger
- GitHub Actions `rewrite-ci` run URL: (filled after CI)
- [x] `git diff --check`
- [x] `npm run check:stop-point` — check:local green, affected fast 595/595
- [x] Targeted: committed-state regressions 31/31, extended 78/78; red/green for drift-blocked writes
- [ ] GitHub Actions `rewrite-ci` passed (authoritative full gate)
- Not run, and why: production acceptance (deploy + retry a real write under a deliberately stale daemon) is the CEO post-merge step.

## Review Evidence

- Self-review: CEO verified the unified witness covers request writes, authority-wire, materializer timer, registry attach/recovery, and runtime projection; admin whitelist is exactly five read/lifecycle methods.
- Reviewer subagent: GLM blind adversarial review — confirmed core gate correct/fail-closed, found 2 P1 background bypasses (materializer timer, reconcile→recovery), both fixed in R3; P2s (identity read cost → metadata cache; rebuild-window availability → automatic recovery test; test quadrants; admin scope) all addressed; P3 fixture creep reverted.
- Human review: not required (flow-defect standing authorization).
- Blocking findings: none outstanding.

## Residual Risk

- Reads remain exempt by design so a stale daemon can still be diagnosed and stopped; stale reads are bounded by the restart guidance appearing on the first blocked write.

## References

- Task: task_01KYV26EJH8VJFGSMH6FTR4RZB
- Evidence: harness/tasks/task_01KYV26EJH8VJFGSMH6FTR4RZB-authority-attribution-evidence-op-base-publication-non-linear/artifacts/implementation-report.md
- Review: GLM R2 findings dispositioned in task ledger

---

# 中文

## 概要

混版本写路事故族的结构性修复:daemon 常驻代码与当前 dist 构建不一致时(post-merge 重建而 daemon 未重启),一切持久写——请求驱动与自驱动——一律 fail-closed 并给出明确「重启 daemon」诊断,不再产出误导性的 `AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR` / `CAPSULE_DISCONNECTED`。根因由生产实验定案:卡死的 `task complete` 在陈旧 daemon 下四连同形失败,`ha daemon start --service` 后首次重试即成功。

## 改动内容

- `deployment-status-options.ts`:build-identity witness——loaded 与 installed dist identity(provenance 锚)对比,metadata 缓存;prebuild 删锚、postbuild 重建,重建窗口 fail-closed,锚恢复后自动放行。
- `json-rpc-server.ts`:漂移时写方法拒绝报 `daemon_build_stale`(两侧 identity+下一步命令);identity 不可用同样 fail-closed。repo-read 豁免;admin 豁免收窄为 5 个明确只读/生命周期方法(未来 admin 方法默认被闸)。
- `build-identity-write-guard.ts`(新):单一执法点注入 runtime;materializer 定时器、registry reconcile→attach/recovery、runtime projection 写全部消费同一 witness;漂移即停并一次性诊断(不每 5s 刷屏)。
- `command-receipt.ts`:结构化重启指引经 CLI error mapper 呈现。
- 测试:漂移拒写/一致放行/unavailable fail-closed/admin 豁免四象限 + 漂移下 materializer 不写、recovery 不跑 + 锚恢复自动放行。

## 任务与范围

- Harness 任务:task_01KYV26EJH8VJFGSMH6FTR4RZB
- 分支:codex/replay-fix
- 公开范围:daemon runtime/service/protocol + application receipt + 测试
- 私有规划/证据已更新:是(两次生产时间线+决定性重启实验)
- 范围外:NON_LINEAR publication proof 语义(未动)、kernel

## 版本影响

- 版本:不改版本,原因是仅 daemon 运行时守卫
- 发布影响:不发布

## 治理声明

- 触及 protected surface:否
- 范围:不适用
- 授权:任务 task_01KYV26EJH8VJFGSMH6FTR4RZB(流转缺陷常设授权;同族第二次)
- 机检边界:本 PR 只断言声明存在;是否真实充分由评审判断。
- Break-glass:否
- 原因/范围:不适用
- 后续治理任务:无

## 验证

- Base `origin/main` SHA:9ed118e7
- merge-base:9ed118e7
- 最近 `git fetch origin`:2026-07-31
- 同步方式:无需(其后合入无冲突文件)
- 公开 diff 命令:`git diff origin/main...codex/replay-fix`
- 私有证据:任务 artifacts/implementation-report.md
- 评审证据:GLM 盲评 R2 findings(2 P1 后台绕过)R3 修复,处置见任务台账
- `rewrite-ci` run URL:(CI 后回填)
- [x] `git diff --check`
- [x] `npm run check:stop-point`——check:local 全绿,affected fast 595/595
- [x] 定向:提交态回归 31/31、扩展 78/78;漂移拒写红/绿
- [ ] GitHub Actions `rewrite-ci` 绿(权威完整门)
- 未运行及原因:生产验收(部署后在故意陈旧的 daemon 下重试真实写)为 CEO 合并后步骤。

## 评审证据

- 自评:CEO 核实统一 witness 覆盖请求写/authority-wire/materializer 定时器/registry attach-recovery/runtime projection;admin 白名单恰为 5 个只读/生命周期方法。
- 评审 subagent:GLM 对抗盲评——核心闸门正确且 fail-closed,抓到 2 条 P1 后台绕过(materializer 定时器、reconcile→recovery),R3 全修;P2(identity 读成本→metadata 缓存、重建窗口→自动恢复测试、测试四象限、admin 面)全处置;P3 fixture 扩面撤回。
- 人工评审:不需要(流转缺陷常设授权)。
- 阻塞 findings:无未决。

## 残留风险

- 读路径按设计保持豁免,陈旧 daemon 仍可诊断与停止;陈旧读的暴露窗口由首次被拒写的重启指引收敛。

## 参考

- 任务:task_01KYV26EJH8VJFGSMH6FTR4RZB
- 证据:任务 artifacts/implementation-report.md
- 评审:GLM R2 findings 处置见任务台账
