### PR TITLE
fix: isolate authority publications from orphan ops

### DIFF
--- a/packages/application/src/authority/service.ts
+++ b/packages/application/src/authority/service.ts
@@ -250,6 +250,9 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
           await options.generationFenceWitness?.assertHeld("before-prepare", entry);
           await entry.publicationRevalidation?.();
           const acknowledgement = await Effect.runPromise(entry.coordinator.enqueue(entry.operation));
+          if (acknowledgement.journalWitness) {
+            journalWitnesses.set(entry, acknowledgement.journalWitness);
+          }
           if (entry.recoveryMode) {
             if (!acknowledgement.journalWitness || !entry.coordinator.flushExactJournalRecord) {
               receipts.set(entry, await persistTerminal(
@@ -269,7 +272,6 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
               ));
               continue;
             }
-            journalWitnesses.set(entry, acknowledgement.journalWitness);
           }
           await options.generationFenceWitness?.assertHeld("before-prepare", entry);
           await put(
@@ -305,12 +307,26 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
       try {
       await options.generationFenceWitness?.assertHeld("before-canonical-publish", candidates[0]);
       const recoveryCandidate = candidates[0]!.recoveryMode ? candidates[0] : undefined;
+      const batchCoordinator = candidates[0]!.coordinator;
+      const exactBatchWitnesses = candidates.flatMap((candidate) => {
+        const witness = journalWitnesses.get(candidate);
+        return witness ? [witness] : [];
+      });
+      const canFlushExactBatch = !recoveryCandidate
+        && candidates.every((candidate) => candidate.coordinator === batchCoordinator)
+        && exactBatchWitnesses.length === candidates.length
+        && batchCoordinator.flushExactJournalRecords;
       const flush = recoveryCandidate
         ? await Effect.runPromise(recoveryCandidate.coordinator.flushExactJournalRecord!(
           "recovery",
           journalWitnesses.get(recoveryCandidate)!
         ))
-        : await Effect.runPromise(candidates[0]!.coordinator.flush("explicit"));
+        : canFlushExactBatch
+          ? await Effect.runPromise(batchCoordinator.flushExactJournalRecords!(
+            "explicit",
+            exactBatchWitnesses
+          ))
+          : await Effect.runPromise(batchCoordinator.flush("explicit"));
       if (!flush.committed || flush.opCount !== candidates.length) {
         // Keep the v1 wire reason stable; the invariant now means exactly the
         // operation set owned by this publication batch, still never a subset.

--- a/packages/cli/src/commands/core/task-complete-facade-steps.ts
+++ b/packages/cli/src/commands/core/task-complete-facade-steps.ts
@@ -1,0 +1,99 @@
+import { Effect } from "effect";
+import {
+  CODE_DOC_RECONCILIATION_DOCUMENT,
+  renderCodeDocReconciliationDraft
+} from "@harness-anything/application";
+import { makeMarkdownArtifactStore } from "@harness-anything/kernel";
+import type { ParsedCommand } from "../../cli/types.ts";
+
+export type TaskCompleteCommand = ParsedCommand & {
+  readonly action: Extract<
+    ParsedCommand["action"],
+    { readonly kind: "task-complete" }
+  >;
+};
+
+export async function taskCompleteCodeDocAlreadyCurrent(
+  command: TaskCompleteCommand,
+  sha: string
+): Promise<boolean> {
+  const taskPackage = await Effect.runPromise(makeMarkdownArtifactStore({
+    rootDir: command.rootDir,
+    ...(command.layoutOverrides ? { layoutOverrides: command.layoutOverrides } : {})
+  }).readTaskPackage(command.action.taskId));
+  return isCodeDocReconciliationCurrent({
+    taskId: command.action.taskId,
+    documents: taskPackage.documents,
+    sha,
+    paths: command.action.approval?.paths ?? [],
+    ...(command.action.approval?.prRef ? { prRef: command.action.approval.prRef } : {})
+  });
+}
+
+export function taskCompleteFacadeSteps(
+  command: TaskCompleteCommand,
+  sha: string,
+  docSyncPaths: ReadonlyArray<string> = [],
+  options: { readonly codeDocAlreadyCurrent?: boolean } = {}
+): ReadonlyArray<ParsedCommand> {
+  const action = command.action;
+  const approval = action.approval;
+  return [
+    ...(docSyncPaths.length > 0 ? [completeChild(command, {
+      kind: "doc-sync",
+      mode: "submit",
+      paths: docSyncPaths
+    }), completeChild(command, { kind: "materializer-run", dryRun: false, currentSessionOnly: true })] : []),
+    ...(approval ? [completeChild(command, {
+      kind: "task-review-execution",
+      taskId: action.taskId,
+      ...(approval.executionId ? { executionId: approval.executionId } : {}),
+      verdict: "approved",
+      findings: approval.findings,
+      evidenceChecked: approval.evidenceChecked,
+      rationale: approval.rationale,
+      archiveWarningsAcknowledged: approval.archiveWarningsAcknowledged,
+      ...(approval.consentId ? { consentId: approval.consentId } : {}),
+      ...(approval.consentUtterance ? { consentUtterance: approval.consentUtterance } : {}),
+      ...(approval.consentStandingPolicyDecisionId ? { consentStandingPolicyDecisionId: approval.consentStandingPolicyDecisionId } : {}),
+      ...(approval.consentAssertedRationale ? { consentAssertedRationale: approval.consentAssertedRationale } : {}),
+      ...(approval.consentActions ? { consentActions: approval.consentActions } : {})
+    })] : []),
+    ...(!options.codeDocAlreadyCurrent ? [completeChild(command, {
+      kind: "task-code-doc-reconcile",
+      taskId: action.taskId,
+      sha,
+      paths: approval?.paths ?? [],
+      ...(approval?.prRef ? { prRef: approval.prRef } : {}),
+      force: true
+    })] : []),
+    completeChild(command, {
+      kind: "task-complete",
+      taskId: action.taskId,
+      ...(approval?.executionId ? { executionId: approval.executionId } : {}),
+      ciGate: action.ciGate,
+      reviewerId: action.reviewerId,
+      evidenceMode: action.evidenceMode,
+      ...(action.evidenceMode === "commit-anchor" ? { commitRef: sha, judgment: action.judgment } : {})
+    })
+  ];
+}
+
+export function isCodeDocReconciliationCurrent(input: {
+  readonly taskId: string;
+  readonly documents: ReadonlyArray<{ readonly path: string; readonly body: string }>;
+  readonly sha: string;
+  readonly paths?: ReadonlyArray<string>;
+  readonly prRef?: string;
+}): boolean {
+  const existing = input.documents.find(
+    (document) => document.path === CODE_DOC_RECONCILIATION_DOCUMENT
+  );
+  if (!existing) return false;
+  const draft = renderCodeDocReconciliationDraft(input);
+  return draft.recordIds.length > 0 && existing.body === draft.body;
+}
+
+function completeChild(command: ParsedCommand, action: ParsedCommand["action"]): ParsedCommand {
+  return { ...command, action };
+}

--- a/packages/cli/src/commands/core/task-complete-facade-steps.ts
+++ b/packages/cli/src/commands/core/task-complete-facade-steps.ts
@@ -38,6 +38,8 @@ export function taskCompleteFacadeSteps(
 ): ReadonlyArray<ParsedCommand> {
   const action = command.action;
   const approval = action.approval;
+  const codeDocCanSkip = options.codeDocAlreadyCurrent === true
+    && docSyncPaths.length === 0;
   return [
     ...(docSyncPaths.length > 0 ? [completeChild(command, {
       kind: "doc-sync",
@@ -59,7 +61,7 @@ export function taskCompleteFacadeSteps(
       ...(approval.consentAssertedRationale ? { consentAssertedRationale: approval.consentAssertedRationale } : {}),
       ...(approval.consentActions ? { consentActions: approval.consentActions } : {})
     })] : []),
-    ...(!options.codeDocAlreadyCurrent ? [completeChild(command, {
+    ...(!codeDocCanSkip ? [completeChild(command, {
       kind: "task-code-doc-reconcile",
       taskId: action.taskId,
       sha,

--- a/packages/cli/src/commands/core/task-lifecycle-facade.ts
+++ b/packages/cli/src/commands/core/task-lifecycle-facade.ts
@@ -6,12 +6,20 @@ import type { CommandRunner } from "../../cli/runner-registry.ts";
 import type { CliResult, ParsedCommand } from "../../cli/types.ts";
 import { inspectGitCommitRef } from "./authored-git.ts";
 import { resolveTaskDocSyncPaths } from "./doc-sync.ts";
+import {
+  taskCompleteCodeDocAlreadyCurrent,
+  taskCompleteFacadeSteps,
+  type TaskCompleteCommand
+} from "./task-complete-facade-steps.ts";
 import { dispatchLifecycleFacadeSteps, shellLifecycleToken } from "./task-lifecycle-facade-guidance.ts";
+export {
+  isCodeDocReconciliationCurrent,
+  taskCompleteFacadeSteps
+} from "./task-complete-facade-steps.ts";
 
 type Dispatch = (step: ParsedCommand) => Promise<CommandReceipt | CommandFailureReceipt>;
 type TaskStartCommand = ParsedCommand & { readonly action: Extract<ParsedCommand["action"], { readonly kind: "task-start" }> };
 type TaskCloseoutCommand = ParsedCommand & { readonly action: Extract<ParsedCommand["action"], { readonly kind: "task-closeout" }> };
-type TaskCompleteCommand = ParsedCommand & { readonly action: Extract<ParsedCommand["action"], { readonly kind: "task-complete" }> };
 
 export async function runTaskStartFacade(command: ParsedCommand, dispatch: Dispatch): Promise<CommandReceipt | CommandFailureReceipt | CliResult> {
   if (command.action.kind !== "task-start") throw new Error("task start facade received a non-start command");
@@ -58,8 +66,20 @@ export async function runTaskCompleteFacade(command: ParsedCommand, dispatch: Di
   const layoutInput = { rootDir: command.rootDir, layoutOverrides: command.layoutOverrides };
   const docPaths = resolveTaskDocSyncPaths(layoutInput, command.action.taskId, "task-complete");
   if (!docPaths.ok) return docPaths.result;
-  const steps = taskCompleteFacadeSteps(completeCommand, resolved.sha, docPaths.paths);
-  if (command.action.dryRun) return dryRun(completeCommand, steps, { commit: resolved.sha });
+  const codeDocAlreadyCurrent = await taskCompleteCodeDocAlreadyCurrent(
+    completeCommand,
+    resolved.sha
+  );
+  const steps = taskCompleteFacadeSteps(
+    completeCommand,
+    resolved.sha,
+    docPaths.paths,
+    { codeDocAlreadyCurrent }
+  );
+  if (command.action.dryRun) return dryRun(completeCommand, steps, {
+    commit: resolved.sha,
+    codeDocReconciliation: codeDocAlreadyCurrent ? "already-current" : "reconcile-required"
+  });
   const dispatched = await dispatchLifecycleFacadeSteps(steps, dispatch, "task-complete");
   if (!dispatched.ok) return dispatched.receipt;
   const { receipts, warnings } = dispatched;
@@ -76,6 +96,9 @@ export async function runTaskCompleteFacade(command: ParsedCommand, dispatch: Di
         report: {
           schema: "task-complete-result/v1",
           commit: resolved.sha,
+          codeDocReconciliation: codeDocAlreadyCurrent
+            ? { status: "already-current", skippedWrite: true }
+            : { status: "reconciled", skippedWrite: false },
           steps: receipts
         }
       }
@@ -127,54 +150,6 @@ export function taskCloseoutFacadeSteps(
       }
     }
   }, sha, docSyncPaths);
-}
-
-export function taskCompleteFacadeSteps(
-  command: TaskCompleteCommand,
-  sha: string,
-  docSyncPaths: ReadonlyArray<string> = []
-): ReadonlyArray<ParsedCommand> {
-  const action = command.action;
-  const approval = action.approval;
-  return [
-    ...(docSyncPaths.length > 0 ? [child(command, {
-      kind: "doc-sync",
-      mode: "submit",
-      paths: docSyncPaths
-    }), child(command, { kind: "materializer-run", dryRun: false, currentSessionOnly: true })] : []),
-    ...(approval ? [child(command, {
-      kind: "task-review-execution",
-      taskId: action.taskId,
-      ...(approval.executionId ? { executionId: approval.executionId } : {}),
-      verdict: "approved",
-      findings: approval.findings,
-      evidenceChecked: approval.evidenceChecked,
-      rationale: approval.rationale,
-      archiveWarningsAcknowledged: approval.archiveWarningsAcknowledged,
-      ...(approval.consentId ? { consentId: approval.consentId } : {}),
-      ...(approval.consentUtterance ? { consentUtterance: approval.consentUtterance } : {}),
-      ...(approval.consentStandingPolicyDecisionId ? { consentStandingPolicyDecisionId: approval.consentStandingPolicyDecisionId } : {}),
-      ...(approval.consentAssertedRationale ? { consentAssertedRationale: approval.consentAssertedRationale } : {}),
-      ...(approval.consentActions ? { consentActions: approval.consentActions } : {})
-    })] : []),
-    child(command, {
-      kind: "task-code-doc-reconcile",
-      taskId: action.taskId,
-      sha,
-      paths: approval?.paths ?? [],
-      ...(approval?.prRef ? { prRef: approval.prRef } : {}),
-      force: true
-    }),
-    child(command, {
-      kind: "task-complete",
-      taskId: action.taskId,
-      ...(approval?.executionId ? { executionId: approval.executionId } : {}),
-      ciGate: action.ciGate,
-      reviewerId: action.reviewerId,
-      evidenceMode: action.evidenceMode,
-      ...(action.evidenceMode === "commit-anchor" ? { commitRef: sha, judgment: action.judgment } : {})
-    })
-  ];
 }
 
 export const rejectDaemonTaskLifecycleFacade: CommandRunner = (_context, command) => Effect.succeed({

--- a/packages/cli/src/commands/core/task-lifecycle-facade.ts
+++ b/packages/cli/src/commands/core/task-lifecycle-facade.ts
@@ -66,10 +66,9 @@ export async function runTaskCompleteFacade(command: ParsedCommand, dispatch: Di
   const layoutInput = { rootDir: command.rootDir, layoutOverrides: command.layoutOverrides };
   const docPaths = resolveTaskDocSyncPaths(layoutInput, command.action.taskId, "task-complete");
   if (!docPaths.ok) return docPaths.result;
-  const codeDocAlreadyCurrent = await taskCompleteCodeDocAlreadyCurrent(
-    completeCommand,
-    resolved.sha
-  );
+  const codeDocAlreadyCurrent = docPaths.paths.length === 0
+    ? await taskCompleteCodeDocAlreadyCurrent(completeCommand, resolved.sha)
+    : false;
   const steps = taskCompleteFacadeSteps(
     completeCommand,
     resolved.sha,

--- a/packages/cli/test/task-lifecycle-facade.test.ts
+++ b/packages/cli/test/task-lifecycle-facade.test.ts
@@ -13,7 +13,13 @@ import type { CommandRunnerContext } from "../src/cli/runner-registry.ts";
 import type { CliResult, ParsedCommand } from "../src/cli/types.ts";
 import { canonicalTaskStartResult } from "../src/commands/core/task-holder-support.ts";
 import { runTaskLifecycleWithDemotions } from "../src/commands/core/task-lifecycle-demotions.ts";
-import { runTaskStartFacade, taskCloseoutFacadeSteps, taskCompleteFacadeSteps, taskStartFacadeSteps } from "../src/commands/core/task-lifecycle-facade.ts";
+import {
+  isCodeDocReconciliationCurrent,
+  runTaskStartFacade,
+  taskCloseoutFacadeSteps,
+  taskCompleteFacadeSteps,
+  taskStartFacadeSteps
+} from "../src/commands/core/task-lifecycle-facade.ts";
 import { dispatchLifecycleFacadeSteps } from "../src/commands/core/task-lifecycle-facade-guidance.ts";
 
 test("non-local terminal status success preserves the owner-visible demotion warning", () => {
@@ -176,6 +182,53 @@ test("task complete owner approval materializes accepted prose before Review, re
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("task complete explicitly deduplicates an already-current code-doc reconciliation", () => {
+  const sha = "a".repeat(40);
+  const documents = [
+    { path: "closeout.md", body: "# Closeout\n" },
+    {
+      path: "code-doc-anchors.json",
+      body: `${JSON.stringify({
+        schema: "code-doc-reconciliation/v1",
+        taskId: "task_BOUNDARY",
+        records: [{
+          id: "closeout",
+          ledgerPath: "closeout.md",
+          kind: "closeout",
+          anchors: [
+            { kind: "commit", sha },
+            { kind: "path", sha, path: "packages/kernel/src/index.ts" }
+          ]
+        }]
+      }, null, 2)}\n`
+    }
+  ];
+
+  assert.equal(isCodeDocReconciliationCurrent({
+    taskId: "task_BOUNDARY",
+    documents,
+    sha,
+    paths: ["packages/kernel/src/index.ts"]
+  }), true);
+  const command = {
+    rootDir: "/fixture",
+    json: true,
+    action: {
+      kind: "task-complete",
+      taskId: "task_BOUNDARY",
+      reviewerId: "person_reviewer",
+      evidenceMode: "execution-review"
+    }
+  } as ParsedCommand & {
+    readonly action: Extract<ParsedCommand["action"], { readonly kind: "task-complete" }>;
+  };
+  assert.deepEqual(
+    taskCompleteFacadeSteps(command, sha, [], { codeDocAlreadyCurrent: true })
+      .map((step) => step.action.kind),
+    ["task-complete"]
+  );
 });
 
 test("direct-mode doc sync unavailability becomes a completion warning", async () => {

--- a/packages/cli/test/task-lifecycle-facade.test.ts
+++ b/packages/cli/test/task-lifecycle-facade.test.ts
@@ -231,6 +231,37 @@ test("task complete explicitly deduplicates an already-current code-doc reconcil
   );
 });
 
+test("task complete reconciles after doc sync can add a new ledger document", () => {
+  const sha = "a".repeat(40);
+  const command = {
+    rootDir: "/fixture",
+    json: true,
+    action: {
+      kind: "task-complete",
+      taskId: "task_BOUNDARY",
+      reviewerId: "person_reviewer",
+      evidenceMode: "execution-review"
+    }
+  } as ParsedCommand & {
+    readonly action: Extract<ParsedCommand["action"], { readonly kind: "task-complete" }>;
+  };
+
+  assert.deepEqual(
+    taskCompleteFacadeSteps(
+      command,
+      sha,
+      ["tasks/task_BOUNDARY/closeout.md"],
+      { codeDocAlreadyCurrent: true }
+    ).map((step) => step.action.kind),
+    [
+      "doc-sync",
+      "materializer-run",
+      "task-code-doc-reconcile",
+      "task-complete"
+    ]
+  );
+});
+
 test("direct-mode doc sync unavailability becomes a completion warning", async () => {
   const steps: ReadonlyArray<ParsedCommand> = [
     { rootDir: "/tmp", json: true, action: { kind: "doc-sync", mode: "submit", paths: ["tasks/task_BOUNDARY/closeout.md"] } },

--- a/packages/daemon/src/runtime/authority-write-coordinator.ts
+++ b/packages/daemon/src/runtime/authority-write-coordinator.ts
@@ -1,5 +1,9 @@
 import { Effect } from "effect";
-import type { WriteCoordinator, WriteOp } from "@harness-anything/kernel";
+import type {
+  WriteCoordinator,
+  WriteError,
+  WriteOp
+} from "@harness-anything/kernel";
 
 interface ProjectionWriteHandle {
   readonly settle: () => void;
@@ -26,9 +30,26 @@ export function makeDeferredAuthorityCoordinator(input: {
           const witnesses = acknowledgements.flatMap((acknowledgement) =>
             acknowledgement.journalWitness ? [acknowledgement.journalWitness] : []
           );
-          return coordinator.flushExactJournalRecords && witnesses.length === ops.length
-            ? coordinator.flushExactJournalRecords(reason, witnesses)
-            : coordinator.flush(reason);
+          if (!coordinator.flushExactJournalRecords || witnesses.length !== ops.length) {
+            const witnessedOpIds = new Set(witnesses.map((witness) => witness.opId));
+            const missingOpIds = ops
+              .map((op) => op.opId)
+              .filter((opId) => !witnessedOpIds.has(opId));
+            const error: WriteError = {
+              _tag: "WriteRejected" as const,
+              code: "authority_exact_journal_witness_required",
+              reason: "Authority publication requires one exact durable journal witness for every enqueued operation; broad journal flush is forbidden.",
+              retryable: false,
+              context: { missingOpIds }
+            };
+            return Effect.fail(error);
+          }
+          return coordinator.flushExactJournalRecords(reason, witnesses).pipe(
+            Effect.map((report) => ({
+              ...report,
+              publicationMode: "exact-batch" as const
+            }))
+          );
         }),
         Effect.ensuring(Effect.sync(() => {
           for (const projectionWrite of projectionWrites.splice(0, projectionWrites.length)) {

--- a/packages/daemon/src/runtime/authority-write-coordinator.ts
+++ b/packages/daemon/src/runtime/authority-write-coordinator.ts
@@ -21,8 +21,15 @@ export function makeDeferredAuthorityCoordinator(input: {
       if (pending.length === 0) return Effect.succeed({ reason, opCount: 0, committed: false });
       const ops = pending.splice(0, pending.length);
       const coordinator = input.makeDurableCoordinator();
-      return Effect.forEach(ops, (op) => coordinator.enqueue(op), { discard: true }).pipe(
-        Effect.flatMap(() => coordinator.flush(reason)),
+      return Effect.forEach(ops, (op) => coordinator.enqueue(op)).pipe(
+        Effect.flatMap((acknowledgements) => {
+          const witnesses = acknowledgements.flatMap((acknowledgement) =>
+            acknowledgement.journalWitness ? [acknowledgement.journalWitness] : []
+          );
+          return coordinator.flushExactJournalRecords && witnesses.length === ops.length
+            ? coordinator.flushExactJournalRecords(reason, witnesses)
+            : coordinator.flush(reason);
+        }),
         Effect.ensuring(Effect.sync(() => {
           for (const projectionWrite of projectionWrites.splice(0, projectionWrites.length)) {
             projectionWrite.settle();

--- a/packages/daemon/test/runtime/authority-write-coordinator.test.ts
+++ b/packages/daemon/test/runtime/authority-write-coordinator.test.ts
@@ -1,0 +1,57 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Effect } from "effect";
+import type {
+  JournalRecordWitnessV1,
+  WriteCoordinator,
+  WriteOp
+} from "@harness-anything/kernel";
+import { makeDeferredAuthorityCoordinator } from "../../src/runtime/authority-write-coordinator.ts";
+
+test("deferred authority flush publishes only records enqueued by that authority batch", () => {
+  const witnesses: JournalRecordWitnessV1[] = [];
+  let broadFlushes = 0;
+  let exactFlushes = 0;
+  const durable: WriteCoordinator = {
+    enqueue: (op) => Effect.sync(() => {
+      const journalWitness = {
+        schema: "write-journal-record-witness/v1" as const,
+        opId: op.opId,
+        recordDigest: `digest:${op.opId}`
+      };
+      witnesses.push(journalWitness);
+      return { opId: op.opId, entityId: op.entityId, accepted: true as const, journalWitness };
+    }),
+    flush: (reason) => Effect.sync(() => {
+      broadFlushes += 1;
+      return { reason, opCount: 2, committed: true };
+    }),
+    flushExactJournalRecords: (reason, selected) => Effect.sync(() => {
+      exactFlushes += 1;
+      assert.deepEqual(selected, witnesses);
+      return { reason, opCount: selected.length, committed: true };
+    }),
+    recover: Effect.succeed({ replayedOps: 0 })
+  };
+  const deferred = makeDeferredAuthorityCoordinator({
+    beginProjectionWrite: () => ({ settle: () => undefined }),
+    makeDurableCoordinator: () => durable
+  });
+
+  Effect.runSync(deferred.enqueue(authorityWrite("op-current")));
+  const report = Effect.runSync(deferred.flush("explicit"));
+
+  assert.equal(report.opCount, 1);
+  assert.equal(exactFlushes, 1);
+  assert.equal(broadFlushes, 0);
+});
+
+function authorityWrite(opId: string): WriteOp {
+  return {
+    opId,
+    entityId: "task:task-current",
+    kind: "doc_write",
+    payload: { path: "progress.md", body: "current" }
+  };
+}

--- a/packages/daemon/test/runtime/authority-write-coordinator.test.ts
+++ b/packages/daemon/test/runtime/authority-write-coordinator.test.ts
@@ -43,7 +43,47 @@ test("deferred authority flush publishes only records enqueued by that authority
   const report = Effect.runSync(deferred.flush("explicit"));
 
   assert.equal(report.opCount, 1);
+  assert.equal(report.publicationMode, "exact-batch");
   assert.equal(exactFlushes, 1);
+  assert.equal(broadFlushes, 0);
+});
+
+test("deferred authority flush fails closed when an accepted op has no exact journal witness", () => {
+  let broadFlushes = 0;
+  let exactFlushes = 0;
+  const durable: WriteCoordinator = {
+    enqueue: (op) => Effect.succeed({
+      opId: op.opId,
+      entityId: op.entityId,
+      accepted: true as const
+    }),
+    flush: (reason) => Effect.sync(() => {
+      broadFlushes += 1;
+      return { reason, opCount: 1, committed: true };
+    }),
+    flushExactJournalRecords: (reason, selected) => Effect.sync(() => {
+      exactFlushes += 1;
+      return { reason, opCount: selected.length, committed: true };
+    }),
+    recover: Effect.succeed({ replayedOps: 0 })
+  };
+  const deferred = makeDeferredAuthorityCoordinator({
+    beginProjectionWrite: () => ({ settle: () => undefined }),
+    makeDurableCoordinator: () => durable
+  });
+
+  Effect.runSync(deferred.enqueue(authorityWrite("op-already-watermarked")));
+  const result = Effect.runSync(Effect.either(deferred.flush("explicit")));
+
+  assert.equal(result._tag, "Left");
+  if (result._tag === "Left") {
+    assert.equal(result.left._tag, "WriteRejected");
+    assert.equal(
+      result.left._tag === "WriteRejected" ? result.left.code : undefined,
+      "authority_exact_journal_witness_required"
+    );
+  }
+  assert.equal(exactFlushes, 0);
   assert.equal(broadFlushes, 0);
 });
 

--- a/packages/kernel/src/ports/write-coordinator.ts
+++ b/packages/kernel/src/ports/write-coordinator.ts
@@ -118,6 +118,7 @@ export interface FlushReport {
   readonly opCount: number;
   readonly committed: boolean;
   readonly watermark?: string;
+  readonly publicationMode?: "exact-batch" | "integrity-domain";
 }
 
 export interface RecoveryReport {

--- a/packages/kernel/src/ports/write-coordinator.ts
+++ b/packages/kernel/src/ports/write-coordinator.ts
@@ -130,6 +130,14 @@ export interface WriteCoordinator {
   readonly enqueue: (op: WriteOp) => Effect.Effect<WriteAck, WriteError>;
   readonly flush: (reason: FlushReason) => Effect.Effect<FlushReport, WriteError>;
   /**
+   * Publishes only the durable journal records named by witnesses returned
+   * from this coordinator's validated enqueue calls.
+   */
+  readonly flushExactJournalRecords?: (
+    reason: FlushReason,
+    witnesses: ReadonlyArray<JournalRecordWitnessV1>
+  ) => Effect.Effect<FlushReport, WriteError>;
+  /**
    * Recovery-only boundary. It may publish only the journal record named by
    * the exact witness returned from this coordinator's validated enqueue.
    */

--- a/packages/kernel/src/write-coordination/journal/coordinator.ts
+++ b/packages/kernel/src/write-coordination/journal/coordinator.ts
@@ -449,7 +449,8 @@ function flushRecords(
     reason,
     opCount: records.length,
     committed: true,
-    watermark
+    watermark,
+    publicationMode: "integrity-domain"
   };
 }
 

--- a/packages/kernel/src/write-coordination/journal/coordinator.ts
+++ b/packages/kernel/src/write-coordination/journal/coordinator.ts
@@ -1,4 +1,3 @@
-import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
 import type {
@@ -22,7 +21,7 @@ import {
 } from "../../layout/index.ts";
 import type { ProjectionChangeEvent } from "../../projection/projection-change-event.ts";
 import { captureAuthoredProjectionFingerprint } from "../../projection/projection-source-baseline.ts";
-import { appendJsonLineDurably, readDurableState, readPayloadRef, writeWatermarkDurably, writeFileDurably } from "./durable.ts";
+import { appendJsonLineDurably, readDurableState, readPayloadRef, writeWatermarkDurably } from "./durable.ts";
 import { finalizeRecoverableDocumentTransaction } from "./operations/recoverable-document-transaction.ts";
 import { assertCommitPlanAddable, commitTouchedPaths } from "./publication/git.ts";
 import { makeLocalVersionControlSystem } from "../../persistence/git/local-version-control-system.ts";
@@ -55,11 +54,14 @@ import { memoizePublicationVcs } from "./publication/memoized-vcs.ts";
 import {
   authorizeExactJournalRecord,
   createExactJournalRecordFlusher,
+  createExactJournalRecordsFlusher,
+  flushExactAuthorizedJournalRecords,
   flushExactAuthorizedJournalRecord
 } from "./exact-journal-flush.ts";
 import { maybeAutoMaterialize } from "./publication/materialization.ts";
 import { rebuildProjectionHash } from "./publication/projection.ts";
-import type { ApplyMarkerRecord, DeleteAuditRecord, JournaledWriteCoordinatorOptions, JournalRecoveryOptions, LockConflictRetryOptions, LockTakeoverRecord, OperationalActor, OperationalJournaledWriteCoordinatorOptions, ReadableJournalRecord, WriteWatermark } from "./types.ts";
+import { compactJournalAndCanTrimWatermark } from "./journal-compaction.ts";
+import type { JournaledWriteCoordinatorOptions, JournalRecoveryOptions, LockConflictRetryOptions, OperationalActor, OperationalJournaledWriteCoordinatorOptions, ReadableJournalRecord, WriteWatermark } from "./types.ts";
 export type {
   JournalActor,
   JournalRecordV1,
@@ -166,6 +168,22 @@ function makeJournaledWriteCoordinatorInternal(
       effect, runtimeContext, sessionId, autoMaterialize, versionControlSystem
     )
   });
+  const flushExactJournalRecords = createExactJournalRecordsFlusher({
+    run: (reason, witnesses) => flushExactAuthorizedJournalRecords({
+      rootDir, rootInput: runtimeContext, journalPath, watermarkPath,
+      operationalActor, lockTtlMs, ...(heldGlobalLock ? { heldGlobalLock } : {}),
+      witnesses, authorizations: exactJournalAuthorizations, pending,
+      flushRecords: (state, records) => flushRecords(
+        reason, rootDir, runtimeContext, journalPath, watermarkPath,
+        state.watermark, records, state.fileApplied, sessionId, commitAuthor,
+        versionControlSystem, attributionEventStore, options.onProjectionChange
+      )
+    }),
+    mapError: (cause) => toJournalError(cause),
+    finish: (effect) => maybeAutoMaterialize(
+      effect, runtimeContext, sessionId, autoMaterialize, versionControlSystem
+    )
+  });
 
   return {
     enqueue: (op) => Effect.try({
@@ -232,6 +250,7 @@ function makeJournaledWriteCoordinatorInternal(
         }));
       return maybeAutoMaterialize(effect, runtimeContext, sessionId, autoMaterialize, versionControlSystem);
     },
+    flushExactJournalRecords,
     flushExactJournalRecord,
     recover: lockConflictRetry
       ? retryLockConflict(() => recoverOnce, lockConflictRetry, Date.now(), 0)
@@ -411,7 +430,7 @@ function flushRecords(
       updatedAt: new Date().toISOString()
     } satisfies WriteWatermark;
     writeWatermarkDurably(watermarkPath, fullWatermark);
-    if (tryCompactJournal(journalPath, new Set(allCommitted), confirmedAttributionOpIds) && recentCommitted.length < allCommitted.length) {
+    if (compactJournalAndCanTrimWatermark(journalPath, new Set(allCommitted), confirmedAttributionOpIds) && recentCommitted.length < allCommitted.length) {
       writeWatermarkDurably(watermarkPath, {
         ...fullWatermark,
         lastCommittedOpIds: recentCommitted,
@@ -500,34 +519,6 @@ function readVerifiedPayload(rootDir: string, record: ReadableJournalRecord): Re
 
 function recentOpIds(opIds: ReadonlyArray<string>): ReadonlyArray<string> {
   return opIds.slice(-maxWatermarkCommittedOpIds);
-}
-
-function tryCompactJournal(journalPath: string, coveredOpIds: ReadonlySet<string>, confirmedAttributionOpIds: ReadonlySet<string>): boolean {
-  try {
-    compactJournalDurably(journalPath, coveredOpIds, confirmedAttributionOpIds);
-    return true;
-  } catch {
-    // Compaction is an optimization. The watermark is authoritative for replay,
-    // so a failed compaction must not turn a committed flush into a failure.
-    return false;
-  }
-}
-
-function compactJournalDurably(journalPath: string, coveredOpIds: ReadonlySet<string>, confirmedAttributionOpIds: ReadonlySet<string>): void {
-  if (!existsSync(journalPath)) return;
-  const body = readFileSync(journalPath, "utf8");
-  if (body.trim().length === 0) return;
-
-  const retained = body
-    .split("\n")
-    .filter((line) => line.trim().length > 0)
-    .filter((line) => {
-      const parsed = JSON.parse(line) as Partial<ReadableJournalRecord | LockTakeoverRecord | DeleteAuditRecord | ApplyMarkerRecord>;
-      if (parsed.schema !== "write-journal/v1" && parsed.schema !== "write-journal/v2" && parsed.schema !== "apply-marker/v1") return true;
-      if (parsed.schema === "write-journal/v2" && typeof parsed.opId === "string" && !confirmedAttributionOpIds.has(parsed.opId)) return true;
-      return typeof parsed.opId !== "string" || !coveredOpIds.has(parsed.opId);
-    });
-  writeFileDurably(journalPath, retained.length === 0 ? "" : `${retained.join("\n")}\n`);
 }
 
 function validateOp(rootInput: HarnessLayoutInput, op: WriteOp): void {

--- a/packages/kernel/src/write-coordination/journal/durable.ts
+++ b/packages/kernel/src/write-coordination/journal/durable.ts
@@ -196,6 +196,10 @@ export function durableFileExists(filePath: string): boolean {
   return existsSync(filePath);
 }
 
+export function readDurableTextIfExists(filePath: string): string | null {
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : null;
+}
+
 export function readFileBytes(filePath: string): Uint8Array {
   return readFileSync(filePath);
 }

--- a/packages/kernel/src/write-coordination/journal/exact-journal-flush.ts
+++ b/packages/kernel/src/write-coordination/journal/exact-journal-flush.ts
@@ -46,6 +46,32 @@ export function flushExactAuthorizedJournalRecord(input: {
     record: ReadableJournalRecord
   ) => FlushReport;
 }): FlushReport {
+  return flushExactAuthorizedJournalRecords({
+    ...input,
+    witnesses: [input.witness],
+    flushRecords: (state, records) => input.flushRecord(state, records[0]!)
+  });
+}
+
+export function flushExactAuthorizedJournalRecords(input: {
+  readonly rootDir: string;
+  readonly rootInput: HarnessLayoutInput;
+  readonly journalPath: string;
+  readonly watermarkPath: string;
+  readonly operationalActor: OperationalActor;
+  readonly lockTtlMs: number;
+  readonly heldGlobalLock?: OwnedLock;
+  readonly witnesses: ReadonlyArray<JournalRecordWitnessV1>;
+  readonly authorizations: Map<string, JournalRecordWitnessV1>;
+  readonly pending: WriteOp[];
+  readonly flushRecords: (
+    state: {
+      readonly watermark: WriteWatermark | null;
+      readonly fileApplied: ReadonlySet<string>;
+    },
+    records: ReadonlyArray<ReadableJournalRecord>
+  ) => FlushReport;
+}): FlushReport {
   return withRepoLocks(
     input.rootDir,
     input.rootInput,
@@ -54,32 +80,46 @@ export function flushExactAuthorizedJournalRecord(input: {
     input.lockTtlMs,
     [],
     () => {
-      const authorized = input.authorizations.get(input.witness.opId);
-      if (!authorized
-        || authorized.schema !== input.witness.schema
-        || authorized.recordDigest !== input.witness.recordDigest) {
-        rejectWrite(`exact journal witness is not authorized: ${input.witness.opId}`);
+      if (input.witnesses.length === 0) {
+        rejectWrite("exact journal publication requires at least one witness");
+      }
+      const opIds = new Set(input.witnesses.map((witness) => witness.opId));
+      if (opIds.size !== input.witnesses.length) {
+        rejectWrite("exact journal publication witnesses must be unique");
+      }
+      for (const witness of input.witnesses) {
+        const authorized = input.authorizations.get(witness.opId);
+        if (!authorized
+          || authorized.schema !== witness.schema
+          || authorized.recordDigest !== witness.recordDigest) {
+          rejectWrite(`exact journal witness is not authorized: ${witness.opId}`);
+        }
       }
       const state = readDurableState(
         input.journalPath,
         input.watermarkPath,
         input.rootDir
       );
-      const record = state.records.find(
-        (candidate) => candidate.opId === input.witness.opId
-      );
-      if (!record) rejectWrite(`exact journal record is missing: ${input.witness.opId}`);
-      if (journalRecordWitnessV1(record).recordDigest !== input.witness.recordDigest) {
-        rejectWrite(
-          `exact journal witness does not match durable record: ${input.witness.opId}`
+      const records = input.witnesses.map((witness) => {
+        const record = state.records.find(
+          (candidate) => candidate.opId === witness.opId
         );
+        if (!record) rejectWrite(`exact journal record is missing: ${witness.opId}`);
+        if (journalRecordWitnessV1(record).recordDigest !== witness.recordDigest) {
+          rejectWrite(
+            `exact journal witness does not match durable record: ${witness.opId}`
+          );
+        }
+        return record;
+      });
+      const report = input.flushRecords(state, records);
+      for (const witness of input.witnesses) {
+        const pendingIndex = input.pending.findIndex(
+          (operation) => operation.opId === witness.opId
+        );
+        if (pendingIndex >= 0) input.pending.splice(pendingIndex, 1);
+        input.authorizations.delete(witness.opId);
       }
-      const report = input.flushRecord(state, record);
-      const pendingIndex = input.pending.findIndex(
-        (operation) => operation.opId === input.witness.opId
-      );
-      if (pendingIndex >= 0) input.pending.splice(pendingIndex, 1);
-      input.authorizations.delete(input.witness.opId);
       return report;
     },
     { heldGlobalLock: input.heldGlobalLock }
@@ -100,6 +140,24 @@ export function createExactJournalRecordFlusher(input: {
 ]> {
   return (reason, witness) => input.finish(Effect.try({
     try: () => input.run(reason, witness),
+    catch: input.mapError
+  }));
+}
+
+export function createExactJournalRecordsFlusher(input: {
+  readonly run: (
+    reason: import("../../ports/write-coordinator.ts").FlushReason,
+    witnesses: ReadonlyArray<JournalRecordWitnessV1>
+  ) => FlushReport;
+  readonly mapError: (cause: unknown) => WriteError;
+  readonly finish: (
+    effect: Effect.Effect<FlushReport, WriteError>
+  ) => Effect.Effect<FlushReport, WriteError>;
+}): NonNullable<import("../../ports/write-coordinator.ts").WriteCoordinator[
+  "flushExactJournalRecords"
+]> {
+  return (reason, witnesses) => input.finish(Effect.try({
+    try: () => input.run(reason, witnesses),
     catch: input.mapError
   }));
 }

--- a/packages/kernel/src/write-coordination/journal/exact-journal-flush.ts
+++ b/packages/kernel/src/write-coordination/journal/exact-journal-flush.ts
@@ -120,7 +120,7 @@ export function flushExactAuthorizedJournalRecords(input: {
         if (pendingIndex >= 0) input.pending.splice(pendingIndex, 1);
         input.authorizations.delete(witness.opId);
       }
-      return report;
+      return { ...report, publicationMode: "exact-batch" };
     },
     { heldGlobalLock: input.heldGlobalLock }
   );

--- a/packages/kernel/src/write-coordination/journal/journal-compaction.ts
+++ b/packages/kernel/src/write-coordination/journal/journal-compaction.ts
@@ -1,0 +1,60 @@
+import { readDurableTextIfExists, writeFileDurably } from "./durable.ts";
+import type {
+  ApplyMarkerRecord,
+  DeleteAuditRecord,
+  LockTakeoverRecord,
+  ReadableJournalRecord
+} from "./types.ts";
+
+export function compactJournalAndCanTrimWatermark(
+  journalPath: string,
+  coveredOpIds: ReadonlySet<string>,
+  confirmedAttributionOpIds: ReadonlySet<string>
+): boolean {
+  try {
+    return compactJournalDurably(
+      journalPath,
+      coveredOpIds,
+      confirmedAttributionOpIds
+    );
+  } catch {
+    // Compaction is an optimization. The watermark is authoritative for replay,
+    // so a failed compaction must not turn a committed flush into a failure.
+    return false;
+  }
+}
+
+function compactJournalDurably(
+  journalPath: string,
+  coveredOpIds: ReadonlySet<string>,
+  confirmedAttributionOpIds: ReadonlySet<string>
+): boolean {
+  const body = readDurableTextIfExists(journalPath);
+  if (body === null) return true;
+  if (body.trim().length === 0) return true;
+
+  let retainedCoveredWrite = false;
+  const retained = body
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .filter((line) => {
+      const parsed = JSON.parse(line) as Partial<
+        ReadableJournalRecord | LockTakeoverRecord | DeleteAuditRecord | ApplyMarkerRecord
+      >;
+      if (parsed.schema !== "write-journal/v1"
+        && parsed.schema !== "write-journal/v2"
+        && parsed.schema !== "apply-marker/v1") return true;
+      if (parsed.schema === "write-journal/v2"
+        && typeof parsed.opId === "string"
+        && !confirmedAttributionOpIds.has(parsed.opId)) {
+        if (coveredOpIds.has(parsed.opId)) retainedCoveredWrite = true;
+        return true;
+      }
+      return typeof parsed.opId !== "string" || !coveredOpIds.has(parsed.opId);
+    });
+  writeFileDurably(
+    journalPath,
+    retained.length === 0 ? "" : `${retained.join("\n")}\n`
+  );
+  return !retainedCoveredWrite;
+}

--- a/packages/kernel/src/write-coordination/journal/receipt.ts
+++ b/packages/kernel/src/write-coordination/journal/receipt.ts
@@ -26,7 +26,8 @@ export function reconcileDurableFlush(
     reason,
     opCount: ownedOpIds.length,
     committed: true,
-    watermark: ownedOpIds.at(-1)
+    watermark: ownedOpIds.at(-1),
+    publicationMode: "integrity-domain"
   };
 }
 

--- a/packages/kernel/test/store/crash-before-watermark.test.ts
+++ b/packages/kernel/test/store/crash-before-watermark.test.ts
@@ -94,6 +94,7 @@ test("exact journal publication commits only the witnessed batch and leaves an o
 
     assert.equal(report.committed, true);
     assert.equal(report.opCount, 2);
+    assert.equal(report.publicationMode, "exact-batch");
     assert.equal(
       readFileSync(path.join(rootDir, "harness/tasks/task-first/progress.md"), "utf8"),
       "first"

--- a/packages/kernel/test/store/crash-before-watermark.test.ts
+++ b/packages/kernel/test/store/crash-before-watermark.test.ts
@@ -69,6 +69,46 @@ test("exact journal recovery publishes only the witnessed operation", () => {
   });
 });
 
+test("exact journal publication commits only the witnessed batch and leaves an orphan queued", () => {
+  withTempStore((rootDir) => {
+    const attribution = testWriteAttribution();
+    const orphan = makeJournaledWriteCoordinator({ attribution, rootDir });
+    const publication = makeJournaledWriteCoordinator({ attribution, rootDir });
+    Effect.runSync(orphan.enqueue(
+      docWrite("op-orphan", "task-orphan", "progress.md", "orphan")
+    ));
+    const firstAck = Effect.runSync(publication.enqueue(
+      docWrite("op-first", "task-first", "progress.md", "first")
+    ));
+    const secondAck = Effect.runSync(publication.enqueue(
+      docWrite("op-second", "task-second", "progress.md", "second")
+    ));
+
+    assert.ok(firstAck.journalWitness);
+    assert.ok(secondAck.journalWitness);
+    assert.ok(publication.flushExactJournalRecords);
+    const report = Effect.runSync(publication.flushExactJournalRecords(
+      "explicit",
+      [firstAck.journalWitness, secondAck.journalWitness]
+    ));
+
+    assert.equal(report.committed, true);
+    assert.equal(report.opCount, 2);
+    assert.equal(
+      readFileSync(path.join(rootDir, "harness/tasks/task-first/progress.md"), "utf8"),
+      "first"
+    );
+    assert.equal(
+      readFileSync(path.join(rootDir, "harness/tasks/task-second/progress.md"), "utf8"),
+      "second"
+    );
+    assert.equal(
+      existsSync(path.join(rootDir, "harness/tasks/task-orphan/progress.md")),
+      false
+    );
+  });
+});
+
 test("exact journal recovery rejects a witness not authorized by validated enqueue", () => {
   withTempStore((rootDir) => {
     const first = makeJournaledWriteCoordinator({

--- a/packages/kernel/test/store/same-task-fifo.test.ts
+++ b/packages/kernel/test/store/same-task-fifo.test.ts
@@ -474,7 +474,8 @@ test("retained no-op journal record stays watermarked after the recent-id window
 
     const coordinator = makeJournaledWriteCoordinator({
       attribution: testWriteAttribution(),
-      rootDir
+      rootDir,
+      commitAuthor: testCommitAuthor
     });
     Effect.runSync(coordinator.enqueue(
       docWrite("op-retained-noop", "task-1", "notes.md", "already committed")

--- a/packages/kernel/test/store/same-task-fifo.test.ts
+++ b/packages/kernel/test/store/same-task-fifo.test.ts
@@ -462,6 +462,57 @@ test("WriteCoordinator records nested harness HEAD when self-host flush has no s
   });
 });
 
+test("retained no-op journal record stays watermarked after the recent-id window fills", () => {
+  withTempStore((rootDir) => {
+    initializeGitRepo(rootDir);
+    const harnessRoot = initializeNestedHarnessRepo(rootDir);
+    mkdirSync(path.join(harnessRoot, "tasks/task-1"), { recursive: true });
+    writeFileSync(path.join(harnessRoot, "tasks/task-1/notes.md"), "already committed", "utf8");
+    runGit(harnessRoot, "add", ".");
+    runGit(harnessRoot, "commit", "-m", "seed no-op target");
+
+    const coordinator = makeJournaledWriteCoordinator({
+      attribution: testWriteAttribution(),
+      rootDir
+    });
+    Effect.runSync(coordinator.enqueue(
+      docWrite("op-retained-noop", "task-1", "notes.md", "already committed")
+    ));
+    Effect.runSync(coordinator.flush("explicit"));
+
+    const watermarkPath = path.join(rootDir, ".harness/write-journal/watermark.json");
+    const firstWatermark = JSON.parse(readFileSync(watermarkPath, "utf8")) as {
+      readonly schema: "write-watermark/v1";
+      readonly lastCommittedOpIds: ReadonlyArray<string>;
+      readonly lastCommitSha: string;
+      readonly projectionHash: string;
+      readonly updatedAt: string;
+    };
+    writeFileSync(watermarkPath, `${JSON.stringify({
+      ...firstWatermark,
+      lastCommittedOpIds: [
+        "op-retained-noop",
+        ...Array.from({ length: 127 }, (_, index) => `op-historical-${index}`)
+      ]
+    })}\n`, "utf8");
+
+    Effect.runSync(coordinator.enqueue(
+      docWrite("op-new-commit", "task-1", "new.md", "new commit")
+    ));
+    Effect.runSync(coordinator.flush("explicit"));
+
+    const finalWatermark = JSON.parse(readFileSync(watermarkPath, "utf8")) as {
+      readonly lastCommittedOpIds: ReadonlyArray<string>;
+    };
+    const journalBody = readFileSync(
+      path.join(rootDir, ".harness/write-journal/writes.jsonl"),
+      "utf8"
+    );
+    assert.match(journalBody, /"opId":"op-retained-noop"/u);
+    assert.equal(finalWatermark.lastCommittedOpIds.includes("op-retained-noop"), true);
+  });
+});
+
 test("WriteCoordinator fails closed when authored root is not an independent nested Git repo", () => {
   withTempStore((rootDir) => {
     initializeGitRepo(rootDir);

--- a/packages/kernel/test/store/same-task-fifo.test.ts
+++ b/packages/kernel/test/store/same-task-fifo.test.ts
@@ -21,6 +21,7 @@ test("WriteCoordinator flushes same-task writes in FIFO order", () => {
 
     const report = Effect.runSync(coordinator.flush("explicit"));
     assert.equal(report.watermark, "op-2");
+    assert.equal(report.publicationMode, "integrity-domain");
     assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-1/notes.md"), "utf8"), "second");
   });
 });


### PR DESCRIPTION
# English

## Summary

Terminal-state fix for the orphan-operation family in the authority write path. The production symptom was deterministic: a failed `task complete` left an orphan op in the durable WAL; the next publication's broad `flush()` bundled every un-watermarked record in the integrity domain, producing a two-op commit that the exactly-one-operation proof correctly rejected — wedging the task until a daemon restart. Root cause is a commit-boundary/WAL-lifecycle mismatch, not an over-strict proof; the proof is untouched.

Three structural changes: (1) authority publications now commit **only the journal records they own** via a new witness-verified exact-batch flush; broad journal flush is forbidden on the authority path and fails closed with `authority_exact_journal_witness_required` when any witness is missing; (2) journal compaction now reports whether every covered write record was truly removed, and the watermark is only trimmed to its bounded window when that holds — retained no-op v2 records can no longer resurrect as pending after trimming; (3) `task complete` performs an explicit byte-equality idempotence check for `code-doc-anchors.json` (reported as `already-current`, never a silent drop), and the dedup is disabled whenever a doc-sync will run in the same command, so newly synced ledger documents always reach reconciliation.

One blind-review round (production write path) returned two P2s — the broad-flush fallback re-exposing the orphan bundling, and the dedup reading a pre-doc-sync snapshot — both fixed with red/green regressions; `FlushReport.publicationMode` added for observability.

## What Changed

- `packages/kernel`: `flushExactAuthorizedJournalRecords` (multi-witness generalization of the existing recovery-only single-witness flush; authorization map + digest checks, unique opIds, fail-closed), compaction can-trim reporting, `publicationMode` on `FlushReport`.
- `packages/application/src/authority/service.ts`: exact-batch flush when every candidate in the batch has a validated witness from the same coordinator; wire reason for the exactly-one proof unchanged.
- `packages/daemon/src/runtime/authority-write-coordinator.ts`: deferred authority publication collects witnesses after durable enqueue and uses exact-batch flush; missing witnesses fail closed (no broad-flush fallback).
- `packages/cli`: complete-facade idempotence step (`already-current` / `reconcile-required`), disabled when doc-sync paths are pending; facade steps split into a dedicated module for the complexity gate.
- Tests: kernel crash-before-watermark + FIFO regressions, daemon coordinator opCount and fail-closed regressions, CLI facade idempotence incl. the doc-sync-after-dedup scenario. All went red before the fix, green after.

## Task And Scope

- Harness task: task_01KYV8XBG165YPT5CY0265M6G1
- Branch: codex/orphan-op
- Public scope: kernel write-coordination + application/daemon authority publication + CLI complete facade
- Private planning/evidence updated: yes
- Out of scope: proof semantics, WAL/watermark manual surgery, GUI

## Version Impact

- Version: no version change because internal write-path correctness fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — write-coordination journal internals (production write path)
- Protected surface scope: exact-batch publication + compaction/watermark lifecycle; no proof relaxation, no gate changes
- Authority: standing flow-defect priority (production write-path deadlock); task task_01KYV8XBG165YPT5CY0265M6G1 with full evidence chain
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: n/a
- Break-glass scope: n/a
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: 186a5a8d
- Branch merge-base with `origin/main`: 186a5a8d
- Last `git fetch origin` time: 2026-07-31
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/orphan-op`
- Private evidence commit/path: harness/tasks/task_01KYV8XBG165YPT5CY0265M6G1-op-complete-op-exactly-one-operation/artifacts/implementation-report.md (mechanism, dual-op evidence, red/green, production-drain runbook)
- Reviewer evidence path: GLM blind-review findings + R2 disposition in the same report
- GitHub Actions `rewrite-ci` run URL: (filled after CI)
- [x] `git diff --check`
- [x] `npm run check:stop-point` — check:local green (R2: 94.3s, 27/27 gates, contract 550 passed / 1 skipped / 0 failed)
- [x] Targeted: 46/46 (kernel store, daemon coordinator, application authority, CLI facade)
- [ ] GitHub Actions `rewrite-ci` passed (authoritative full gate)
- Not run, and why: full CI runs on this PR.

## Review Evidence

- Self-review: CEO verified fail-closed direction on every new branch (exact-batch condition falls back to rejection, not broad flush; compaction failure cannot fail a committed flush; dedup uncertainty falls to the write path).
- Reviewer subagent: one GLM adversarial blind round (production write path). P1: none. P2-1 (dedup pre-doc-sync snapshot) and P2-2 (broad-flush fallback) both confirmed and fixed in R2 with red/green regressions. P3-2 addressed (`publicationMode`); P3-1 recorded as residual.
- Human review: not required.
- Blocking findings: none remaining.

## Residual Risk

- Watermark growth is unbounded while covered v2 records lack confirmed attribution events (correctness-first trade-off; recorded in the task ledger with a monitoring suggestion).
- Production drain of the previously wedged task follows the dry-run-first runbook in the implementation report after deploy.

## References

- Task: task_01KYV8XBG165YPT5CY0265M6G1
- Evidence: harness/tasks/task_01KYV8XBG165YPT5CY0265M6G1-op-complete-op-exactly-one-operation/artifacts/implementation-report.md
- Review: GLM findings + R2 disposition in the task ledger

---

# 中文

## 概要

authority 写路孤儿 op 族的终局修复。生产症状是确定性的:一次失败的 `task complete` 在 durable WAL 留下孤儿 op,下一次 publication 的宽 `flush()` 把 integrity domain 内所有未 watermark 的 record 全部打包,产生双 op commit,被「恰好一个操作」proof 正确拒绝——任务卡死直到 daemon 重启。根因是提交边界与 WAL 生命周期不一致,不是 proof 过严;proof 零改动。

三处结构性修复:①authority publication 只提交**自己拥有的** journal record(新的 witness 校验精确批次 flush);authority 路径禁止宽 flush,缺任一 witness 即 fail-closed(`authority_exact_journal_witness_required`);②compaction 汇报 covered record 是否全部真正移除,只有全移除才把 watermark 裁到有界窗口——retained no-op v2 record 不再因裁剪复活为 pending;③`task complete` 对 `code-doc-anchors.json` 做显式字节相等幂等判定(报告 `already-current`,绝不静默丢弃),且同命令内有 doc-sync 时禁用该判定,保证新同步的 ledger 文档必进 reconcile。

一轮盲评(生产写路)出两条 P2——宽 flush 回退重新暴露孤儿打包、幂等判定读 pre-doc-sync 快照——均已修复并有修前红/修后绿回归;新增 `FlushReport.publicationMode` 可观测字段。

## 改动内容

- kernel:`flushExactAuthorizedJournalRecords`(既有 recovery 单 witness flush 的多 witness 推广;授权表+digest 校验、opId 唯一、fail-closed)、compaction can-trim 汇报、`publicationMode`。
- application authority service:整批 candidate 都有同 coordinator 已验证 witness 时走精确批次;proof wire reason 不变。
- daemon deferred coordinator:durable enqueue 后收集 witness 走精确批次;缺 witness 即 fail-closed,无宽 flush 回退。
- CLI:complete facade 幂等步骤(`already-current`/`reconcile-required`),doc-sync 待执行时禁用;facade steps 拆独立模块过复杂度门。
- 测试:kernel crash-before-watermark + FIFO、daemon opCount 与 fail-closed、CLI 幂等含 doc-sync-after-dedup 场景;全部修前红、修后绿。

## 任务与范围

- Harness 任务:task_01KYV8XBG165YPT5CY0265M6G1
- 分支:codex/orphan-op
- 公开范围:kernel 写协调 + application/daemon authority publication + CLI complete facade
- 私有规划/证据已更新:是
- 范围外:proof 语义、WAL/watermark 手工修改、GUI

## 版本影响

- 版本:不改版本,原因是内部写路正确性修复
- 发布影响:不发布

## 治理声明

- 触及 protected surface:是——写协调 journal 内部(生产写路)
- 范围:精确批次发布 + compaction/watermark 生命周期;proof 零放宽、门零改动
- 授权:流转缺陷最高优先常设授权(生产写路卡死);任务 task_01KYV8XBG165YPT5CY0265M6G1 全证据链
- 机检边界:本 PR 只断言声明存在;是否真实充分由评审判断。
- Break-glass:否
- 原因/范围:不适用
- 后续治理任务:无

## 验证

- Base `origin/main` SHA:186a5a8d
- merge-base:186a5a8d
- 最近 `git fetch origin`:2026-07-31
- 同步方式:无需
- 公开 diff 命令:`git diff origin/main...codex/orphan-op`
- 私有证据:任务 artifacts/implementation-report.md(机理、双 op 证据、红绿、生产排干 runbook)
- 评审证据:GLM 盲评 findings + R2 处置(同报告)
- `rewrite-ci` run URL:(CI 后回填)
- [x] `git diff --check`
- [x] `npm run check:stop-point`——check:local 全绿(R2:94.3s,27/27 门,contract 550 过/1 跳/0 败)
- [x] 定向:46/46(kernel store、daemon coordinator、application authority、CLI facade)
- [ ] GitHub Actions `rewrite-ci` 绿(权威完整门)
- 未运行及原因:完整 CI 在本 PR 上跑。

## 评审证据

- 自评:CEO 逐分支核 fail-closed 方向(精确批次条件不满足落到拒绝而非宽 flush;compaction 失败不能反转已提交 flush;幂等不确定落到写路径)。
- 评审 subagent:一轮 GLM 对抗盲评(生产写路)。P1 无;P2-1(pre-doc-sync 快照)与 P2-2(宽 flush 回退)确认并在 R2 修复,红绿回归齐全;P3-2 已做(`publicationMode`),P3-1 记残留。
- 人工评审:不需要。
- 阻塞 findings:无剩余。

## 残留风险

- covered v2 record 缺 confirmed attribution event 期间 watermark 无界增长(正确性优先的取舍,已记台账并附监控建议)。
- 部署后按实现报告的 dry-run 先行 runbook 排干此前卡死的任务。

## 参考

- 任务:task_01KYV8XBG165YPT5CY0265M6G1
- 证据:任务 artifacts/implementation-report.md
- 评审:GLM findings + R2 处置见任务台账
