### PR TITLE
fix(cli): close cold-start lifecycle gaps

### DIFF
--- a/packages/cli/src/cli/command-spec/command-event-policies.ts
+++ b/packages/cli/src/cli/command-spec/command-event-policies.ts
@@ -1,0 +1,11 @@
+import type { CommandEventPolicySpec } from "./types.ts";
+
+export const writeCommandEventPolicy = {
+  conflictMarkerPreflight: true,
+  runtimeEvent: "auto"
+} as const satisfies CommandEventPolicySpec;
+
+export const readCommandEventPolicy = {
+  conflictMarkerPreflight: false,
+  runtimeEvent: "none"
+} as const satisfies CommandEventPolicySpec;

--- a/packages/cli/src/cli/command-spec/command-groups.ts
+++ b/packages/cli/src/cli/command-spec/command-groups.ts
@@ -139,6 +139,7 @@ export const commandGroups = [
     "ha task create --title \"<title>\"",
     "ha task start <task-id>",
     "ha task progress append <task-id> --text \"<update>\"",
+    "ha fact record --task <task-id> --statement \"<verified fact>\"",
     "ha task submit <task-id> --from-file submission.json",
     "ha task complete <task-id> --approve --from-file approval.json"
   ]),

--- a/packages/cli/src/cli/command-spec/command-spec-core.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-core.ts
@@ -1,4 +1,5 @@
 import { defineCommandSpecs } from "./types.ts";
+import { readCommandEventPolicy, writeCommandEventPolicy } from "./command-event-policies.ts";
 import { parseCapabilitiesArgs } from "../parsers/capabilities.ts";
 import { parseCoreTaskArgs } from "../parsers/core-task.ts";
 import { parseHelpArgs, parseVersionArgs } from "../parsers/meta.ts";
@@ -536,12 +537,13 @@ export const coreCommandSpecs = defineCommandSpecs([
         "completionEvidence": "Only emitted when completion accepts an immutable commit-anchor judgment record.",
         "reviewContract": "Compatibility-only legacy review.md gate evidence; it never authorizes completion."
       },
-      "paths": []
+      "paths": [],
+      "dryRun": {
+        "data": ["taskId", "report"],
+        "paths": []
+      }
     },
-    "eventPolicy": {
-      "conflictMarkerPreflight": true,
-      "runtimeEvent": "auto"
-    }
+    "eventPolicy": writeCommandEventPolicy
   },
   {
     "kind": "task-show",
@@ -557,10 +559,7 @@ export const coreCommandSpecs = defineCommandSpecs([
       "data": ["taskId", "report"],
       "paths": ["primary"]
     },
-    "eventPolicy": {
-      "conflictMarkerPreflight": false,
-      "runtimeEvent": "none"
-    }
+    "eventPolicy": readCommandEventPolicy
   },
   {
     "kind": "relation-list",

--- a/packages/cli/src/cli/task-packet-templates.ts
+++ b/packages/cli/src/cli/task-packet-templates.ts
@@ -1,0 +1,36 @@
+export interface TaskPacketTemplate {
+  readonly fileName: "submission.json" | "approval.json";
+  readonly value: Readonly<Record<string, unknown>>;
+}
+
+const taskPacketTemplates: Readonly<Record<string, TaskPacketTemplate>> = {
+  "task-submit": {
+    fileName: "submission.json",
+    value: {
+      completionClaim: "<what is complete>",
+      deliverables: ["<deliverable>"],
+      outputs: ["<output evidence>"],
+      verificationNotes: ["<verification command and result>"],
+      knownGaps: [],
+      residualRisks: []
+    }
+  },
+  "task-complete": {
+    fileName: "approval.json",
+    value: {
+      findings: "<review findings>",
+      rationale: "<why the evidence supports approval>",
+      evidenceChecked: [],
+      archiveWarningsAcknowledged: false,
+      consentAssertedRationale: "<how owner approval was obtained>",
+      consentActions: ["approve_execution", "complete_task"],
+      ci: "passed",
+      paths: [],
+      reviewerId: "local-reviewer"
+    }
+  }
+};
+
+export function taskPacketTemplateFor(commandKind: string): TaskPacketTemplate | undefined {
+  return taskPacketTemplates[commandKind];
+}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -77,6 +77,9 @@ interface HarnessIsolationReport {
   readonly innerGitDir: string;
   readonly outerGit: {
     readonly insideWorkTree: boolean;
+    readonly action: "initialized" | "skipped-existing" | "failed";
+    readonly initialCommitCreated: boolean;
+    readonly commitCount: number | null;
   };
   readonly innerRepository: {
     readonly gitDirExists: boolean;
@@ -98,11 +101,15 @@ function ensureHarnessRepositoryIsolation(rootDir: string, authoredRoot: string,
   const warnings: unknown[] = [];
   const authoredRootRelative = initRelativeLayoutPath(rootDir, authoredRoot);
   const innerGitDir = path.join(authoredRoot, ".git");
+  const outerRepository = ensureOuterGitRepository(rootDir, commitAuthor);
+  warnings.push(...outerRepository.warnings);
   const outerGit = isInsideInitGitWorkTree(rootDir);
   const gitignore = ensureOuterGitignoreIsolation(rootDir, outerGit, authoredRootRelative);
   warnings.push(...gitignore.warnings);
   const innerRepository = ensureInnerGitRepository(authoredRoot, innerGitDir, commitAuthor);
   warnings.push(...innerRepository.warnings);
+  const completedOuterRepository = completeOuterGitRepository(rootDir, outerRepository.report, commitAuthor);
+  warnings.push(...completedOuterRepository.warnings);
 
   return {
     warnings,
@@ -111,7 +118,8 @@ function ensureHarnessRepositoryIsolation(rootDir: string, authoredRoot: string,
       authoredRoot: authoredRootRelative,
       innerGitDir: `${authoredRootRelative}/.git`,
       outerGit: {
-        insideWorkTree: outerGit
+        insideWorkTree: outerGit,
+        ...completedOuterRepository.report
       },
       innerRepository: innerRepository.report,
       outerGitignore: gitignore.report,
@@ -120,11 +128,83 @@ function ensureHarnessRepositoryIsolation(rootDir: string, authoredRoot: string,
         "ha daemon repo register --root .",
         "ha daemon start --service",
         "ha doctor --json",
+        "git status",
         `git -C ${authoredRootRelative} status`,
         `git -C ${authoredRootRelative} add . && git -C ${authoredRootRelative} commit`
       ]
     }
   };
+}
+
+function ensureOuterGitRepository(rootDir: string, commitAuthor?: VcsCommitAuthor): {
+  readonly report: Omit<HarnessIsolationReport["outerGit"], "insideWorkTree">;
+  readonly warnings: ReadonlyArray<unknown>;
+} {
+  if (isInsideInitGitWorkTree(rootDir)) {
+    return {
+      warnings: [],
+      report: {
+        action: "skipped-existing",
+        initialCommitCreated: false,
+        commitCount: readCommitCount(rootDir)
+      }
+    };
+  }
+  try {
+    try {
+      runInitGit(rootDir, ["init", "--initial-branch=main"], commitAuthor);
+    } catch {
+      runInitGit(rootDir, ["init"], commitAuthor);
+    }
+    return {
+      warnings: [],
+      report: {
+        action: "initialized",
+        initialCommitCreated: false,
+        commitCount: null
+      }
+    };
+  } catch (error) {
+    return {
+      warnings: [isolationWarning("outer_git_init_failed", error)],
+      report: {
+        action: "failed",
+        initialCommitCreated: false,
+        commitCount: null
+      }
+    };
+  }
+}
+
+function completeOuterGitRepository(
+  rootDir: string,
+  report: Omit<HarnessIsolationReport["outerGit"], "insideWorkTree">,
+  commitAuthor?: VcsCommitAuthor
+): {
+  readonly report: Omit<HarnessIsolationReport["outerGit"], "insideWorkTree">;
+  readonly warnings: ReadonlyArray<unknown>;
+} {
+  if (report.action !== "initialized") return { report, warnings: [] };
+  try {
+    runInitGit(rootDir, ["commit", "--allow-empty", "-m", "chore: initialize harness workspace"], commitAuthor);
+    return {
+      warnings: [],
+      report: {
+        action: "initialized",
+        initialCommitCreated: true,
+        commitCount: readCommitCount(rootDir)
+      }
+    };
+  } catch (error) {
+    return {
+      warnings: [isolationWarning("outer_git_initial_commit_failed", error)],
+      report: {
+        action: "failed",
+        initialCommitCreated: false,
+        commitCount: readCommitCount(rootDir)
+      }
+    };
+  }
 }
 
 function ensureOuterGitignoreIsolation(rootDir: string, outerGit: boolean, authoredRootRelative: string): {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -9,7 +9,22 @@ import type { CliResult } from "../cli/types.ts";
 import { resolveActiveVertical } from "./extensions/active-vertical.ts";
 import { materializeRepositoryScaffold } from "./extensions/repository-scaffold.ts";
 
-export function initializeHarness(rootInput: HarnessLayoutInput, addNpmScripts = false, projectName?: string, commitAuthor?: VcsCommitAuthor): CliResult {
+const DEFAULT_INIT_GIT_TIMEOUT_MS = 10_000;
+
+export interface InitGitRuntime {
+  readonly executable?: string;
+  readonly prefixArgs?: ReadonlyArray<string>;
+  readonly timeoutMs?: number;
+  readonly killSignal?: NodeJS.Signals;
+}
+
+export function initializeHarness(
+  rootInput: HarnessLayoutInput,
+  addNpmScripts = false,
+  projectName?: string,
+  commitAuthor?: VcsCommitAuthor,
+  gitRuntime: InitGitRuntime = {}
+): CliResult {
   const layout = resolveHarnessLayout(rootInput);
   const rootDir = layout.rootDir;
   const warnings: unknown[] = [];
@@ -35,7 +50,7 @@ export function initializeHarness(rootInput: HarnessLayoutInput, addNpmScripts =
   const harnessConfigPath = layout.configPath ?? path.join(layout.authoredRoot, "harness.yaml");
   writeHarnessYaml(harnessConfigPath, resolvedProjectName, projectName !== undefined);
   materializeRepositoryScaffold(rootInput, vertical);
-  const isolation = ensureHarnessRepositoryIsolation(rootDir, layout.authoredRoot, commitAuthor);
+  const isolation = ensureHarnessRepositoryIsolation(rootDir, layout.authoredRoot, commitAuthor, gitRuntime);
   warnings.push(...isolation.warnings);
   const packagePath = path.join(layout.rootDir, "package.json");
   if (addNpmScripts) {
@@ -97,18 +112,23 @@ interface HarnessIsolationReport {
   readonly nextSteps: readonly string[];
 }
 
-function ensureHarnessRepositoryIsolation(rootDir: string, authoredRoot: string, commitAuthor?: VcsCommitAuthor): HarnessIsolationResult {
+function ensureHarnessRepositoryIsolation(
+  rootDir: string,
+  authoredRoot: string,
+  commitAuthor: VcsCommitAuthor | undefined,
+  gitRuntime: InitGitRuntime
+): HarnessIsolationResult {
   const warnings: unknown[] = [];
   const authoredRootRelative = initRelativeLayoutPath(rootDir, authoredRoot);
   const innerGitDir = path.join(authoredRoot, ".git");
-  const outerRepository = ensureOuterGitRepository(rootDir, commitAuthor);
+  const outerRepository = ensureOuterGitRepository(rootDir, commitAuthor, gitRuntime);
   warnings.push(...outerRepository.warnings);
-  const outerGit = isInsideInitGitWorkTree(rootDir);
+  const outerGit = isInsideInitGitWorkTree(rootDir, gitRuntime);
   const gitignore = ensureOuterGitignoreIsolation(rootDir, outerGit, authoredRootRelative);
   warnings.push(...gitignore.warnings);
-  const innerRepository = ensureInnerGitRepository(authoredRoot, innerGitDir, commitAuthor);
+  const innerRepository = ensureInnerGitRepository(authoredRoot, innerGitDir, commitAuthor, gitRuntime);
   warnings.push(...innerRepository.warnings);
-  const completedOuterRepository = completeOuterGitRepository(rootDir, outerRepository.report, commitAuthor);
+  const completedOuterRepository = completeOuterGitRepository(rootDir, outerRepository.report, commitAuthor, gitRuntime);
   warnings.push(...completedOuterRepository.warnings);
 
   return {
@@ -136,25 +156,30 @@ function ensureHarnessRepositoryIsolation(rootDir: string, authoredRoot: string,
   };
 }
 
-function ensureOuterGitRepository(rootDir: string, commitAuthor?: VcsCommitAuthor): {
+function ensureOuterGitRepository(
+  rootDir: string,
+  commitAuthor: VcsCommitAuthor | undefined,
+  gitRuntime: InitGitRuntime
+): {
   readonly report: Omit<HarnessIsolationReport["outerGit"], "insideWorkTree">;
   readonly warnings: ReadonlyArray<unknown>;
 } {
-  if (isInsideInitGitWorkTree(rootDir)) {
+  if (isInsideInitGitWorkTree(rootDir, gitRuntime)) {
     return {
       warnings: [],
       report: {
         action: "skipped-existing",
         initialCommitCreated: false,
-        commitCount: readCommitCount(rootDir)
+        commitCount: readCommitCount(rootDir, gitRuntime)
       }
     };
   }
   try {
     try {
-      runInitGit(rootDir, ["init", "--initial-branch=main"], commitAuthor);
-    } catch {
-      runInitGit(rootDir, ["init"], commitAuthor);
+      runInitGit(rootDir, ["init", "--initial-branch=main"], commitAuthor, gitRuntime);
+    } catch (error) {
+      if (isGitTimeoutError(error)) throw error;
+      runInitGit(rootDir, ["init"], commitAuthor, gitRuntime);
     }
     return {
       warnings: [],
@@ -179,20 +204,21 @@ function ensureOuterGitRepository(rootDir: string, commitAuthor?: VcsCommitAutho
 function completeOuterGitRepository(
   rootDir: string,
   report: Omit<HarnessIsolationReport["outerGit"], "insideWorkTree">,
-  commitAuthor?: VcsCommitAuthor
+  commitAuthor: VcsCommitAuthor | undefined,
+  gitRuntime: InitGitRuntime
 ): {
   readonly report: Omit<HarnessIsolationReport["outerGit"], "insideWorkTree">;
   readonly warnings: ReadonlyArray<unknown>;
 } {
   if (report.action !== "initialized") return { report, warnings: [] };
   try {
-    runInitGit(rootDir, ["commit", "--allow-empty", "-m", "chore: initialize harness workspace"], commitAuthor);
+    runInitGit(rootDir, ["commit", "--no-gpg-sign", "--allow-empty", "-m", "chore: initialize harness workspace"], commitAuthor, gitRuntime);
     return {
       warnings: [],
       report: {
         action: "initialized",
         initialCommitCreated: true,
-        commitCount: readCommitCount(rootDir)
+        commitCount: readCommitCount(rootDir, gitRuntime)
       }
     };
   } catch (error) {
@@ -201,7 +227,7 @@ function completeOuterGitRepository(
       report: {
         action: "failed",
         initialCommitCreated: false,
-        commitCount: readCommitCount(rootDir)
+        commitCount: readCommitCount(rootDir, gitRuntime)
       }
     };
   }
@@ -248,7 +274,12 @@ function ensureOuterGitignoreIsolation(rootDir: string, outerGit: boolean, autho
   }
 }
 
-function ensureInnerGitRepository(authoredRoot: string, innerGitDir: string, commitAuthor?: VcsCommitAuthor): {
+function ensureInnerGitRepository(
+  authoredRoot: string,
+  innerGitDir: string,
+  commitAuthor: VcsCommitAuthor | undefined,
+  gitRuntime: InitGitRuntime
+): {
   readonly report: HarnessIsolationReport["innerRepository"];
   readonly warnings: ReadonlyArray<unknown>;
 } {
@@ -258,30 +289,31 @@ function ensureInnerGitRepository(authoredRoot: string, innerGitDir: string, com
       report: {
         gitDirExists: true,
         action: "skipped-existing",
-        branch: readGitText(authoredRoot, ["branch", "--show-current"]) || null,
+        branch: readGitText(authoredRoot, ["branch", "--show-current"], gitRuntime) || null,
         initialCommitCreated: false,
-        commitCount: readCommitCount(authoredRoot)
+        commitCount: readCommitCount(authoredRoot, gitRuntime)
       }
     };
   }
 
   try {
     try {
-      runInitGit(authoredRoot, ["init", "--initial-branch=master"], commitAuthor);
-    } catch {
-      runInitGit(authoredRoot, ["init"], commitAuthor);
-      runInitGit(authoredRoot, ["symbolic-ref", "HEAD", "refs/heads/master"], commitAuthor);
+      runInitGit(authoredRoot, ["init", "--initial-branch=master"], commitAuthor, gitRuntime);
+    } catch (error) {
+      if (isGitTimeoutError(error)) throw error;
+      runInitGit(authoredRoot, ["init"], commitAuthor, gitRuntime);
+      runInitGit(authoredRoot, ["symbolic-ref", "HEAD", "refs/heads/master"], commitAuthor, gitRuntime);
     }
-    runInitGit(authoredRoot, ["add", "."], commitAuthor);
-    runInitGit(authoredRoot, ["commit", "-m", "chore: initialize harness ledger"], commitAuthor);
+    runInitGit(authoredRoot, ["add", "."], commitAuthor, gitRuntime);
+    runInitGit(authoredRoot, ["commit", "--no-gpg-sign", "-m", "chore: initialize harness ledger"], commitAuthor, gitRuntime);
     return {
       warnings: [],
       report: {
         gitDirExists: existsSync(innerGitDir),
         action: "initialized",
-        branch: readGitText(authoredRoot, ["branch", "--show-current"]) || "master",
+        branch: readGitText(authoredRoot, ["branch", "--show-current"], gitRuntime) || "master",
         initialCommitCreated: true,
-        commitCount: readCommitCount(authoredRoot)
+        commitCount: readCommitCount(authoredRoot, gitRuntime)
       }
     };
   } catch (error) {
@@ -290,42 +322,52 @@ function ensureInnerGitRepository(authoredRoot: string, innerGitDir: string, com
       report: {
         gitDirExists: existsSync(innerGitDir),
         action: "failed",
-        branch: readGitText(authoredRoot, ["branch", "--show-current"]) || null,
+        branch: readGitText(authoredRoot, ["branch", "--show-current"], gitRuntime) || null,
         initialCommitCreated: false,
-        commitCount: readCommitCount(authoredRoot)
+        commitCount: readCommitCount(authoredRoot, gitRuntime)
       }
     };
   }
 }
 
-function isInsideInitGitWorkTree(rootDir: string): boolean {
-  return readGitText(rootDir, ["rev-parse", "--is-inside-work-tree"]) === "true";
+function isInsideInitGitWorkTree(rootDir: string, gitRuntime: InitGitRuntime): boolean {
+  return readGitText(rootDir, ["rev-parse", "--is-inside-work-tree"], gitRuntime) === "true";
 }
 
-function readCommitCount(rootDir: string): number | null {
-  const output = readGitText(rootDir, ["rev-list", "--count", "HEAD"]);
+function readCommitCount(rootDir: string, gitRuntime: InitGitRuntime): number | null {
+  const output = readGitText(rootDir, ["rev-list", "--count", "HEAD"], gitRuntime);
   return output ? Number.parseInt(output, 10) : null;
 }
 
-function readGitText(rootDir: string, args: ReadonlyArray<string>): string | undefined {
+function readGitText(rootDir: string, args: ReadonlyArray<string>, gitRuntime: InitGitRuntime): string | undefined {
   try {
-    return execFileSync("git", ["-C", rootDir, ...args], {
+    return execFileSync(gitRuntime.executable ?? "git", [...(gitRuntime.prefixArgs ?? []), "-C", rootDir, ...args], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
-      windowsHide: true
+      windowsHide: true,
+      timeout: gitRuntime.timeoutMs ?? DEFAULT_INIT_GIT_TIMEOUT_MS,
+      killSignal: gitRuntime.killSignal ?? "SIGKILL"
     }).trim();
   } catch {
     return undefined;
   }
 }
 
-function runInitGit(rootDir: string, args: ReadonlyArray<string>, author?: VcsCommitAuthor): void {
-  execFileSync("git", ["-C", rootDir, ...args], {
+function runInitGit(
+  rootDir: string,
+  args: ReadonlyArray<string>,
+  author: VcsCommitAuthor | undefined,
+  gitRuntime: InitGitRuntime
+): void {
+  execFileSync(gitRuntime.executable ?? "git", [...(gitRuntime.prefixArgs ?? []), "-C", rootDir, ...args], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
     windowsHide: true,
+    timeout: gitRuntime.timeoutMs ?? DEFAULT_INIT_GIT_TIMEOUT_MS,
+    killSignal: gitRuntime.killSignal ?? "SIGKILL",
     env: {
       ...process.env,
+      GIT_TERMINAL_PROMPT: "0",
       ...(author ? {
         GIT_AUTHOR_NAME: author.name,
         GIT_AUTHOR_EMAIL: author.email,
@@ -334,6 +376,10 @@ function runInitGit(rootDir: string, args: ReadonlyArray<string>, author?: VcsCo
       } : {})
     }
   });
+}
+
+function isGitTimeoutError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ETIMEDOUT";
 }
 
 function isolationWarning(code: string, error: unknown): Record<string, string> {

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -15,6 +15,7 @@ import { runCompoundReceiptExitCommand } from "./receipt/compound-exit-command.t
 import { receiptDetailsData, renderReceiptText, toCommandReceipt, type CommandFailureReceipt, type CommandReceipt } from "./cli/receipt.ts";
 import type { CommandRegistryEntry } from "./cli/types.ts";
 import { commandGroups, globalCommandOptions } from "./cli/command-spec/command-groups.ts";
+import { taskPacketTemplateFor } from "./cli/task-packet-templates.ts";
 import { parsePositiveIntegerOr } from "./cli/value-utils.ts";
 import {
   runDaemonCommand,
@@ -333,6 +334,7 @@ function renderCommandHelp(command: CommandRegistryEntry): string {
   const aliases = command.aliases.length > 0 ? ["", "Aliases:", ...command.aliases.map((alias) => `  ${alias}`)] : [];
   const options = command.options.length > 0 ? ["", "Options:", ...command.options.map((option) => `  ${option.flag.padEnd(18)} ${option.description}`)] : [];
   const additional = command.kind === "new-task" ? taskCreatePresetHelp() : [];
+  const packetTemplate = renderTaskPacketTemplate(command.kind);
   const workflow = taskWorkflowNextHelp(command.kind);
   const examples = command.examples.length > 0 ? ["", command.examples.length === 1 ? "Example:" : "Examples:", ...command.examples.map((example) => `  ${example}`)] : [];
   return [
@@ -343,9 +345,20 @@ function renderCommandHelp(command: CommandRegistryEntry): string {
     ...aliases,
     ...options,
     ...additional,
+    ...packetTemplate,
     ...workflow,
     ...examples
   ].join("\n");
+}
+
+function renderTaskPacketTemplate(commandKind: string): ReadonlyArray<string> {
+  const template = taskPacketTemplateFor(commandKind);
+  if (!template) return [];
+  return [
+    "",
+    `Packet template (copy as ${template.fileName}):`,
+    ...JSON.stringify(template.value, null, 2).split("\n").map((line) => `  ${line}`)
+  ];
 }
 
 function renderHelpCommandSummary(entry: CommandRegistryEntry): string {
@@ -367,7 +380,8 @@ function taskWorkflowNextHelp(kind: string): ReadonlyArray<string> {
   const nextByKind: Readonly<Record<string, string>> = {
     "new-task": "ha task start <task-id>",
     "task-start": "ha task progress append <task-id> --text \"<update>\"",
-    "progress-append": "ha task submit <task-id> --from-file submission.json",
+    "progress-append": "ha fact record --task <task-id> --statement \"<verified fact>\"",
+    "record-fact": "ha task submit <task-id> --from-file submission.json",
     "task-submit": "ha task complete <task-id> --approve --from-file approval.json",
     "task-complete": "ha task show <task-id> --view trace"
   };

--- a/packages/cli/test/coldstart-p1-cli.test.ts
+++ b/packages/cli/test/coldstart-p1-cli.test.ts
@@ -1,0 +1,127 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { unwrapCommandReceipt } from "./helpers/receipt.ts";
+import { writeSubstantiveTaskPlan } from "./helpers/task-plan-fixture.ts";
+
+const cliEntry = path.resolve("packages/cli/src/index.ts");
+const cleanGitEnv = {
+  PATH: process.env.PATH,
+  HOME: path.join(tmpdir(), "ha-coldstart-empty-home"),
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+  HARNESS_ACTOR: "agent:coldstart-test",
+  HARNESS_GIT_AUTHOR_NAME: "Harness Coldstart Test",
+  HARNESS_GIT_AUTHOR_EMAIL: "coldstart@example.invalid",
+  HARNESS_DAEMON_MODE: "fixture",
+  HARNESS_CLI_TEST_FIXTURE_PRELOAD: process.env.HARNESS_CLI_TEST_FIXTURE_PRELOAD,
+  NODE_OPTIONS: process.env.NODE_OPTIONS
+} satisfies NodeJS.ProcessEnv;
+
+test("fresh init creates a workspace HEAD without ambient git identity", () => {
+  withTempRoot((rootDir) => {
+    const initialized = runJson(rootDir, ["init"], {
+      HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user")
+    });
+
+    assert.equal(initialized.ok, true);
+    assert.equal(runGit(rootDir, "rev-parse", "--is-inside-work-tree"), "true");
+    assert.match(runGit(rootDir, "rev-parse", "--verify", "HEAD^{commit}"), /^[0-9a-f]{40}$/u);
+    assert.equal(runGit(rootDir, "rev-list", "--count", "HEAD"), "1");
+    assert.equal(initialized.report.isolation.outerGit.action, "initialized");
+    assert.equal(initialized.report.isolation.outerGit.initialCommitCreated, true);
+  });
+});
+
+test("task packet help templates pass submission and approval dry-runs", () => {
+  withTempRoot((rootDir) => {
+    const repoEnv = { HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user") };
+    runJson(rootDir, ["init"], repoEnv);
+    const created = runJson(rootDir, [
+      "task", "create", "--title", "Coldstart packet templates",
+      "--vertical", "software/coding", "--preset", "standard-task"
+    ], repoEnv);
+    writeSubstantiveTaskPlan(rootDir, created.packagePath);
+    const sessionId = "coldstart-template-session";
+    const homeDir = path.join(rootDir, "home");
+    mkdirSync(path.join(homeDir, ".codex/sessions"), { recursive: true });
+    writeFileSync(path.join(homeDir, ".codex/sessions", `${sessionId}.jsonl`), [
+      JSON.stringify({ timestamp: "2026-07-31T00:00:00.000Z", type: "event_msg", payload: { type: "user_message", message: "verify packet templates" } }),
+      JSON.stringify({ timestamp: "2026-07-31T00:00:01.000Z", type: "response_item", payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "verified" }] } })
+    ].join("\n"), "utf8");
+    const sessionEnv = { ...repoEnv, HOME: homeDir, CODEX_THREAD_ID: sessionId, CODEX_SESSION_ID: sessionId };
+    runJson(rootDir, ["task", "start", created.taskId], sessionEnv);
+
+    const submission = packetTemplate(rootDir, ["task", "submit", "--help"]);
+    const submissionPath = path.join(rootDir, "submission.json");
+    writeFileSync(submissionPath, `${JSON.stringify(submission, null, 2)}\n`, "utf8");
+    const submissionDryRun = runJson(rootDir, [
+      "task", "submit", created.taskId, "--from-file", submissionPath, "--dry-run"
+    ], sessionEnv);
+    assert.equal(submissionDryRun.ok, true);
+    runJson(rootDir, ["task", "submit", created.taskId, "--from-file", submissionPath], sessionEnv);
+
+    writeFileSync(path.join(rootDir, created.packagePath, "closeout.md"), [
+      "# Closeout",
+      "",
+      "## Summary",
+      "",
+      "Verified the copy-ready packet templates.",
+      "",
+      "## Verification",
+      "",
+      "Both packets passed their CLI dry-runs.",
+      "",
+      "## Residual Risk",
+      "",
+      "No residual risk observed.",
+      ""
+    ].join("\n"), "utf8");
+    const approval = packetTemplate(rootDir, ["task", "complete", "--help"]);
+    const approvalPath = path.join(rootDir, "approval.json");
+    writeFileSync(approvalPath, `${JSON.stringify(approval, null, 2)}\n`, "utf8");
+    const approvalDryRun = runJson(rootDir, [
+      "--actor", "human:person_test", "task", "complete", created.taskId,
+      "--approve", "--from-file", approvalPath, "--dry-run"
+    ], sessionEnv);
+    assert.equal(approvalDryRun.ok, true);
+  });
+});
+
+function packetTemplate(rootDir: string, args: ReadonlyArray<string>): Record<string, unknown> {
+  const help = execFileSync(process.execPath, [cliEntry, "--root", rootDir, ...args], {
+    encoding: "utf8",
+    env: cleanGitEnv
+  });
+  const match = help.match(/Packet template \(copy as [^)]+\):\n([\s\S]+?)(?:\n\n|$)/u);
+  assert.notEqual(match, null, help);
+  return JSON.parse(match![1]!.split("\n").map((line) => line.replace(/^  /u, "")).join("\n")) as Record<string, unknown>;
+}
+
+function runJson(rootDir: string, args: ReadonlyArray<string>, env: NodeJS.ProcessEnv = {}): Record<string, any> {
+  const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
+    encoding: "utf8",
+    env: { ...cleanGitEnv, ...env }
+  });
+  return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
+}
+
+function runGit(rootDir: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", rootDir, ...args], {
+    encoding: "utf8",
+    env: cleanGitEnv
+  }).trim();
+}
+
+function withTempRoot<T>(fn: (rootDir: string) => T): T {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-coldstart-p1-"));
+  try {
+    return fn(rootDir);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}

--- a/packages/cli/test/coldstart-p1-cli.test.ts
+++ b/packages/cli/test/coldstart-p1-cli.test.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { devNull, tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
@@ -12,8 +12,8 @@ const cliEntry = path.resolve("packages/cli/src/index.ts");
 const cleanGitEnv = {
   PATH: process.env.PATH,
   HOME: path.join(tmpdir(), "ha-coldstart-empty-home"),
-  GIT_CONFIG_GLOBAL: "/dev/null",
-  GIT_CONFIG_SYSTEM: "/dev/null",
+  GIT_CONFIG_GLOBAL: devNull,
+  GIT_CONFIG_SYSTEM: devNull,
   HARNESS_ACTOR: "agent:coldstart-test",
   HARNESS_GIT_AUTHOR_NAME: "Harness Coldstart Test",
   HARNESS_GIT_AUTHOR_EMAIL: "coldstart@example.invalid",

--- a/packages/cli/test/doc-sync-service.test.ts
+++ b/packages/cli/test/doc-sync-service.test.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { devNull, tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -639,7 +639,7 @@ function gitCommit(harnessRoot: string, message: string): void {
     env: {
       ...process.env,
       HOME: path.join(harnessRoot, ".empty-home"),
-      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_GLOBAL: devNull,
       GIT_AUTHOR_NAME: "Harness Test",
       GIT_AUTHOR_EMAIL: "harness@example.test",
       GIT_COMMITTER_NAME: "Harness Test",
@@ -655,7 +655,7 @@ function git(harnessRoot: string, ...args: ReadonlyArray<string>): string {
     env: {
       ...process.env,
       HOME: path.join(harnessRoot, ".empty-home"),
-      GIT_CONFIG_GLOBAL: "/dev/null"
+      GIT_CONFIG_GLOBAL: devNull
     }
   }).trimEnd();
 }

--- a/packages/cli/test/doc-sync-service.test.ts
+++ b/packages/cli/test/doc-sync-service.test.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
-import { devNull, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -639,13 +639,21 @@ function gitCommit(harnessRoot: string, message: string): void {
     env: {
       ...process.env,
       HOME: path.join(harnessRoot, ".empty-home"),
-      GIT_CONFIG_GLOBAL: devNull,
+      GIT_CONFIG_GLOBAL: emptyGitConfigPath(harnessRoot),
       GIT_AUTHOR_NAME: "Harness Test",
       GIT_AUTHOR_EMAIL: "harness@example.test",
       GIT_COMMITTER_NAME: "Harness Test",
       GIT_COMMITTER_EMAIL: "harness@example.test"
     }
   });
+}
+
+function emptyGitConfigPath(harnessRoot: string): string {
+  const emptyHome = path.join(harnessRoot, ".empty-home");
+  mkdirSync(emptyHome, { recursive: true });
+  const configPath = path.join(emptyHome, "empty.gitconfig");
+  writeFileSync(configPath, "", "utf8");
+  return configPath;
 }
 
 function git(harnessRoot: string, ...args: ReadonlyArray<string>): string {
@@ -655,7 +663,7 @@ function git(harnessRoot: string, ...args: ReadonlyArray<string>): string {
     env: {
       ...process.env,
       HOME: path.join(harnessRoot, ".empty-home"),
-      GIT_CONFIG_GLOBAL: devNull
+      GIT_CONFIG_GLOBAL: emptyGitConfigPath(harnessRoot)
     }
   }).trimEnd();
 }

--- a/packages/cli/test/doctor-cli.test.ts
+++ b/packages/cli/test/doctor-cli.test.ts
@@ -160,7 +160,7 @@ test("CLI task help lists every task leaf and declares --json only as a global o
       .map((entry) => `  ${entry.primary.replace(/ \[--json\]/gu, "").replace(/ --json$/u, "")} - ${entry.summary}`);
 
     assert.deepEqual(renderedTaskLeaves, [...expectedDefaultTaskLeaves, ...expectedAdvancedTaskLeaves]);
-    assert.match(stdout, /Primary workflow:[\s\S]+1\. ha task create[\s\S]+2\. ha task start[\s\S]+3\. ha task progress append[\s\S]+4\. ha task submit[\s\S]+5\. ha task complete/u);
+    assert.match(stdout, /Primary workflow:[\s\S]+1\. ha task create[\s\S]+2\. ha task start[\s\S]+3\. ha task progress append[\s\S]+4\. ha fact record[\s\S]+5\. ha task submit[\s\S]+6\. ha task complete/u);
     assert.match(stdout, /Advanced commands:[\s\S]+task claim[\s\S]+Deprecated compatibility spelling/u);
     assert.equal(stdout.match(/--json(?!-input)/gu)?.length, 1);
   });
@@ -176,7 +176,7 @@ test("CLI noun help exposes a bounded primary workflow and common/advanced tiers
       const group = commandGroups.find((candidate) => candidate.name === noun);
       assert.notEqual(group, undefined, noun);
       assert.equal((group?.primaryWorkflow?.length ?? 0) >= 1, true, noun);
-      assert.equal((group?.primaryWorkflow?.length ?? 0) <= 5, true, noun);
+      assert.equal((group?.primaryWorkflow?.length ?? 0) <= 6, true, noun);
 
       const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, noun, "--help"], {
         encoding: "utf8"
@@ -204,10 +204,12 @@ test("CLI primary task leaf help links the workflow and explains structured pack
 
     assert.match(create, /Next:\s+ha task start <task-id>/u);
     assert.match(start, /Next:\s+ha task progress append <task-id>/u);
-    assert.match(progress, /Next:\s+ha task submit <task-id> --from-file submission\.json/u);
+    assert.match(progress, /Next:\s+ha fact record --task <task-id> --statement "<verified fact>"/u);
     assert.match(submit, /completionClaim, deliverables, outputs, verificationNotes, knownGaps, and residualRisks/u);
+    assert.match(submit, /Packet template \(copy as submission\.json\):[\s\S]+"completionClaim"[\s\S]+"residualRisks"/u);
     assert.match(submit, /Next:\s+ha task complete <task-id> --approve --from-file approval\.json/u);
     assert.match(complete, /findings, rationale, and exactly one consent source/u);
+    assert.match(complete, /Packet template \(copy as approval\.json\):[\s\S]+"findings"[\s\S]+"consentActions"/u);
     assert.match(complete, /Next:\s+ha task show <task-id> --view trace/u);
   });
 });

--- a/packages/cli/test/help-layering.test.ts
+++ b/packages/cli/test/help-layering.test.ts
@@ -21,6 +21,19 @@ test("every primary-workflow line names a registered command path", () => {
   }
 });
 
+test("task primary workflow exposes the complete six-step lifecycle", () => {
+  const taskWorkflow = commandGroups.find((group) => group.name === "task")?.primaryWorkflow;
+
+  assert.deepEqual(taskWorkflow, [
+    "ha task create --title \"<title>\"",
+    "ha task start <task-id>",
+    "ha task progress append <task-id> --text \"<update>\"",
+    "ha fact record --task <task-id> --statement \"<verified fact>\"",
+    "ha task submit <task-id> --from-file submission.json",
+    "ha task complete <task-id> --approve --from-file approval.json"
+  ]);
+});
+
 test("every registered leaf remains directly reachable through help", () => {
   for (const entry of commandRegistry) {
     const parsed = parseArgs([...entry.commandPath, "--help"]);

--- a/packages/cli/test/init-cli.test.ts
+++ b/packages/cli/test/init-cli.test.ts
@@ -27,7 +27,10 @@ test("CLI init defaults harness project name from the target root basename", () 
     assert.equal(result.report.isolation.innerRepository.gitDirExists, true);
     assert.equal(result.report.isolation.innerRepository.branch, "master");
     assert.equal(result.report.isolation.innerRepository.commitCount, 1);
-    assert.equal(result.report.isolation.outerGitignore.action, "skipped-not-git");
+    assert.equal(result.report.isolation.outerGit.action, "initialized");
+    assert.equal(result.report.isolation.outerGit.initialCommitCreated, true);
+    assert.equal(result.report.isolation.outerGit.commitCount, 1);
+    assert.equal(result.report.isolation.outerGitignore.action, "updated");
     assert.equal(resolveHarnessLayout(path.join(rootDir, "harness")).rootDir, rootDir);
     assert.match(result.receiptSummary, /Code PRs must not include harness\/ changes/u);
     assert.match(config, new RegExp(`^name: ${path.basename(rootDir)}$`, "m"));
@@ -112,6 +115,8 @@ test("CLI init isolates harness in an outer git repository", () => {
     assert.match(gitignore, /^\.harness\/$/m);
     assert.match(gitignore, /^harness\/$/m);
     assert.equal(result.report.isolation.outerGit.insideWorkTree, true);
+    assert.equal(result.report.isolation.outerGit.action, "skipped-existing");
+    assert.equal(result.report.isolation.outerGit.initialCommitCreated, false);
     assert.equal(result.report.isolation.outerGitignore.action, "updated");
     assert.equal(result.report.isolation.innerRepository.action, "initialized");
   });
@@ -132,15 +137,18 @@ test("CLI init skips existing inner harness git repository and keeps gitignore i
   });
 });
 
-test("CLI init creates an inner harness repo without an outer git repository", () => {
+test("CLI init creates both workspace and inner harness repositories", () => {
   withTempRoot((rootDir) => {
     const result = runJson(rootDir, ["init"]);
 
     assert.equal(result.ok, true);
     assert.equal(existsSync(path.join(rootDir, "harness/.git")), true);
-    assert.equal(existsSync(path.join(rootDir, ".gitignore")), false);
-    assert.equal(result.report.isolation.outerGit.insideWorkTree, false);
-    assert.equal(result.report.isolation.outerGitignore.action, "skipped-not-git");
+    assert.equal(existsSync(path.join(rootDir, ".git")), true);
+    assert.equal(existsSync(path.join(rootDir, ".gitignore")), true);
+    assert.equal(result.report.isolation.outerGit.insideWorkTree, true);
+    assert.equal(result.report.isolation.outerGit.action, "initialized");
+    assert.equal(result.report.isolation.outerGit.initialCommitCreated, true);
+    assert.equal(result.report.isolation.outerGitignore.action, "updated");
   });
 });
 

--- a/packages/cli/test/init-git-timeout.test.ts
+++ b/packages/cli/test/init-git-timeout.test.ts
@@ -1,0 +1,45 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import test from "node:test";
+import { initializeHarness } from "../src/commands/init.ts";
+
+test("init bounds an unresponsive outer Git process and reports fail-safe degradation", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-init-git-timeout-"));
+  const fakeGit = path.join(rootDir, "fake-git.mjs");
+  writeFileSync(fakeGit, [
+    "const args = process.argv.slice(2);",
+    "if (args.includes('rev-parse')) process.exit(1);",
+    "if (args.includes('--initial-branch=main')) setInterval(() => undefined, 1_000);",
+    "process.exit(1);"
+  ].join("\n"), "utf8");
+
+  try {
+    const startedAt = performance.now();
+    const result = initializeHarness(
+      { rootDir },
+      false,
+      "Git Timeout",
+      { name: "Harness Test", email: "harness@example.test" },
+      {
+        executable: process.execPath,
+        prefixArgs: [fakeGit],
+        timeoutMs: 100,
+        killSignal: "SIGKILL"
+      }
+    );
+
+    assert.equal(performance.now() - startedAt < 2_000, true);
+    assert.equal(result.report.isolation.outerGit.action, "failed");
+    assert.equal(result.report.isolation.outerGit.initialCommitCreated, false);
+    assert.equal(
+      result.warnings.some((warning: Record<string, unknown>) => warning.code === "outer_git_init_failed"),
+      true
+    );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/test/local-lifecycle-cli.test.ts
+++ b/packages/cli/test/local-lifecycle-cli.test.ts
@@ -25,7 +25,7 @@ const executionTaskId = "task_01KX7H00000000000000000000";
 const executionId = "exe_01KX7H00000000000000000001";
 const executionActorEnv = { HARNESS_ACTOR: "agent:test" } as const;
 
-test("CLI init creates authored harness and skips outer gitignore outside git repos", () => {
+test("CLI init creates authored harness and a root commit anchor", () => {
   withTempRoot((rootDir) => {
     const result = runJson(rootDir, ["init"]);
 
@@ -38,8 +38,10 @@ test("CLI init creates authored harness and skips outer gitignore outside git re
     assert.match(config, /defaultProfile: baseline/);
     assert.match(config, /locale: zh-CN/);
     assert.match(readFileSync(path.join(rootDir, "AGENTS.md"), "utf8"), /harness\/harness.yaml/);
-    assert.equal(existsSync(path.join(rootDir, ".gitignore")), false);
-    assert.equal(result.report.isolation.outerGitignore.action, "skipped-not-git");
+    assert.equal(existsSync(path.join(rootDir, ".gitignore")), true);
+    assert.equal(result.report.isolation.outerGit.action, "initialized");
+    assert.equal(result.report.isolation.outerGit.initialCommitCreated, true);
+    assert.equal(result.report.isolation.outerGitignore.action, "updated");
     assert.equal(existsSync(path.join(rootDir, "harness/legacy")), false);
   }, { identity: false });
 });

--- a/packages/cli/test/production-authority-event-recovery.test.ts
+++ b/packages/cli/test/production-authority-event-recovery.test.ts
@@ -28,7 +28,7 @@ test("SIGKILL wait observes an exit emitted synchronously by kill", async () => 
     return true;
   }) as ChildProcess["kill"];
 
-  await killAndWaitForSigkill(child);
+  await killAndWaitForAbruptExit(child);
 });
 
 test("publication proof accepts only the declared hosted path inside a slugged task package", () => {
@@ -490,7 +490,7 @@ test("SIGKILL during a scan resumes from the last fully checkpointed commit", as
     const deadline = Date.now() + 10_000;
     while (!existsSync(readyPath) && Date.now() < deadline) await delay(10);
     assert.equal(existsSync(readyPath), true, "fixture did not persist its incremental checkpoint");
-    await killAndWaitForSigkill(child);
+    await killAndWaitForAbruptExit(child);
     const partial = JSON.parse(readFileSync(watermarkPath, "utf8")) as Record<string, unknown>;
     assert.equal(partial.schema, "authority-recovery-watermark/v2");
     assert.equal(partial.phase, "partial");
@@ -519,20 +519,31 @@ test("SIGKILL during a scan resumes from the last fully checkpointed commit", as
     assert.deepEqual(scanInputs, ["a".repeat(40)]);
     assert.equal(JSON.parse(readFileSync(watermarkPath, "utf8")).commitSha, "b".repeat(40));
   } finally {
-    if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+    if (child.exitCode === null && child.signalCode === null) {
+      try {
+        terminateRecoveryFixture(child);
+      } catch {
+        // The bounded wait above retains the primary failure when cleanup races process exit.
+      }
+    }
     rmSync(root, { recursive: true, force: true });
   }
 });
 
-function killAndWaitForSigkill(child: ChildProcess): Promise<void> {
+function killAndWaitForAbruptExit(child: ChildProcess): Promise<void> {
   return new Promise<void>((resolve, reject) => {
+    const exitTimeout = setTimeout(() => {
+      cleanup();
+      reject(new Error("recovery fixture did not exit within 5 seconds after forced termination"));
+    }, 5_000);
     const cleanup = () => {
+      clearTimeout(exitTimeout);
       child.off("exit", onExit);
       child.off("error", onError);
     };
-    const onExit = (_code: number | null, signal: NodeJS.Signals | null) => {
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
       cleanup();
-      if (signal === "SIGKILL") resolve();
+      if (signal === "SIGKILL" || (process.platform === "win32" && (code !== null || signal !== null))) resolve();
       else reject(new Error(`expected SIGKILL, received ${signal ?? "clean exit"}`));
     };
     const onError = (error: Error) => {
@@ -542,12 +553,26 @@ function killAndWaitForSigkill(child: ChildProcess): Promise<void> {
     child.once("exit", onExit);
     child.once("error", onError);
     try {
-      assert.equal(child.kill("SIGKILL"), true);
+      terminateRecoveryFixture(child);
     } catch (error) {
       cleanup();
       reject(error);
     }
   });
+}
+
+function terminateRecoveryFixture(child: ChildProcess): void {
+  if (process.platform === "win32") {
+    assert.notEqual(child.pid, undefined);
+    execFileSync("taskkill.exe", ["/pid", String(child.pid), "/t", "/f"], {
+      stdio: "ignore",
+      timeout: 5_000,
+      killSignal: "SIGKILL",
+      windowsHide: true
+    });
+    return;
+  }
+  assert.equal(child.kill("SIGKILL"), true);
 }
 
 test("recovery watermark remains partial while an indexed operation is unresolved", async () => {

--- a/packages/cli/test/production-authority-event-recovery.test.ts
+++ b/packages/cli/test/production-authority-event-recovery.test.ts
@@ -21,14 +21,24 @@ import {
   recoverPendingProductionEvents
 } from "@harness-anything/daemon";
 
-test("SIGKILL wait observes an exit emitted synchronously by kill", async () => {
-  const child = new EventEmitter() as ChildProcess;
-  child.kill = (() => {
-    child.emit("exit", null, "SIGKILL");
-    return true;
-  }) as ChildProcess["kill"];
+test("abrupt-exit wait observes an exit emitted synchronously by termination", async () => {
+  const exitShapes: ReadonlyArray<{
+    readonly code: number | null;
+    readonly signal: NodeJS.Signals | null;
+  }> = [
+    { code: 1, signal: null },
+    { code: null, signal: "SIGKILL" }
+  ];
 
-  await killAndWaitForAbruptExit(child);
+  for (const { code, signal } of exitShapes) {
+    const child = new EventEmitter() as ChildProcess;
+    let terminationCalled = false;
+    await killAndWaitForAbruptExit(child, (target) => {
+      terminationCalled = true;
+      target.emit("exit", code, signal);
+    });
+    assert.equal(terminationCalled, true);
+  }
 });
 
 test("publication proof accepts only the declared hosted path inside a slugged task package", () => {
@@ -480,17 +490,19 @@ test("recovery watermark falls back on missing or corrupt state and then scans o
   }
 });
 
-test("SIGKILL during a scan resumes from the last fully checkpointed commit", async () => {
+test("forced termination during a scan resumes from the last fully checkpointed commit", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-authority-recovery-kill-resume-"));
   const watermarkPath = path.join(root, "recovery-watermark.json");
   const readyPath = path.join(root, "checkpoint-ready");
   const fixturePath = path.resolve("packages/daemon/test/fixtures/recovery-watermark-kill-target.ts");
   const child = spawn(process.execPath, [fixturePath, watermarkPath, readyPath], { stdio: "inherit" });
+  let exitObserved = false;
   try {
     const deadline = Date.now() + 10_000;
     while (!existsSync(readyPath) && Date.now() < deadline) await delay(10);
     assert.equal(existsSync(readyPath), true, "fixture did not persist its incremental checkpoint");
     await killAndWaitForAbruptExit(child);
+    exitObserved = true;
     const partial = JSON.parse(readFileSync(watermarkPath, "utf8")) as Record<string, unknown>;
     assert.equal(partial.schema, "authority-recovery-watermark/v2");
     assert.equal(partial.phase, "partial");
@@ -519,7 +531,7 @@ test("SIGKILL during a scan resumes from the last fully checkpointed commit", as
     assert.deepEqual(scanInputs, ["a".repeat(40)]);
     assert.equal(JSON.parse(readFileSync(watermarkPath, "utf8")).commitSha, "b".repeat(40));
   } finally {
-    if (child.exitCode === null && child.signalCode === null) {
+    if (!exitObserved && child.exitCode === null && child.signalCode === null) {
       try {
         terminateRecoveryFixture(child);
       } catch {
@@ -530,7 +542,10 @@ test("SIGKILL during a scan resumes from the last fully checkpointed commit", as
   }
 });
 
-function killAndWaitForAbruptExit(child: ChildProcess): Promise<void> {
+function killAndWaitForAbruptExit(
+  child: ChildProcess,
+  terminate: (target: ChildProcess) => void = terminateRecoveryFixture
+): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const exitTimeout = setTimeout(() => {
       cleanup();
@@ -541,10 +556,9 @@ function killAndWaitForAbruptExit(child: ChildProcess): Promise<void> {
       child.off("exit", onExit);
       child.off("error", onError);
     };
-    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+    const onExit = () => {
       cleanup();
-      if (signal === "SIGKILL" || (process.platform === "win32" && (code !== null || signal !== null))) resolve();
-      else reject(new Error(`expected SIGKILL, received ${signal ?? "clean exit"}`));
+      resolve();
     };
     const onError = (error: Error) => {
       cleanup();
@@ -553,7 +567,7 @@ function killAndWaitForAbruptExit(child: ChildProcess): Promise<void> {
     child.once("exit", onExit);
     child.once("error", onError);
     try {
-      terminateRecoveryFixture(child);
+      terminate(child);
     } catch (error) {
       cleanup();
       reject(error);

--- a/tools/test-process-environment.mjs
+++ b/tools/test-process-environment.mjs
@@ -1,5 +1,5 @@
 import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { devNull, tmpdir } from "node:os";
 import path from "node:path";
 
 const gitIdentityFailurePattern = /Author identity unknown|unable to auto-detect email address|no email was given and auto-detection is disabled|Please tell me who you are/iu;
@@ -32,8 +32,8 @@ export function createHermeticTestEnvironment(baseEnv = process.env) {
   const env = {
     ...baseEnv,
     HOME: home,
-    GIT_CONFIG_GLOBAL: "/dev/null",
-    GIT_CONFIG_SYSTEM: "/dev/null",
+    GIT_CONFIG_GLOBAL: devNull,
+    GIT_CONFIG_SYSTEM: devNull,
     // macOS Git can synthesize "user@host" even with both config files
     // disabled. CI cannot, so require an explicitly configured fixture
     // identity on every platform.

--- a/tools/test-process-environment.mjs
+++ b/tools/test-process-environment.mjs
@@ -1,5 +1,5 @@
-import { mkdtempSync, rmSync } from "node:fs";
-import { devNull, tmpdir } from "node:os";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 
 const gitIdentityFailurePattern = /Author identity unknown|unable to auto-detect email address|no email was given and auto-detection is disabled|Please tell me who you are/iu;
@@ -29,11 +29,17 @@ export function createHermeticTestEnvironment(baseEnv = process.env) {
     ?? baseEnv.NPM_CONFIG_CACHE
     ?? (baseEnv.HOME ? path.join(baseEnv.HOME, ".npm") : path.join(tmpdir(), "ha-npm-cache"));
 
+  // Git for Windows rejects the platform null device as a config path
+  // ("unable to access '//./nul'"), so point both config files at an empty
+  // regular file inside the hermetic home instead.
+  const emptyGitConfig = path.join(home, "empty.gitconfig");
+  writeFileSync(emptyGitConfig, "", "utf8");
+
   const env = {
     ...baseEnv,
     HOME: home,
-    GIT_CONFIG_GLOBAL: devNull,
-    GIT_CONFIG_SYSTEM: devNull,
+    GIT_CONFIG_GLOBAL: emptyGitConfig,
+    GIT_CONFIG_SYSTEM: emptyGitConfig,
     // macOS Git can synthesize "user@host" even with both config files
     // disabled. CI cannot, so require an explicitly configured fixture
     // identity on every platform.

--- a/tools/test-process-environment.test.mjs
+++ b/tools/test-process-environment.test.mjs
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { devNull, tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { createHermeticTestEnvironment, gitFixtureIdentityGuidance } from "./test-process-environment.mjs";
@@ -23,8 +23,8 @@ test("hermetic test environment rejects ambient Git identity and preserves the n
     assert.equal(implicitCommit.status, 128);
     assert.match(implicitCommit.stderr, /identity|email/iu);
     assert.equal(environment.env.HOME, environment.home);
-    assert.equal(environment.env.GIT_CONFIG_GLOBAL, "/dev/null");
-    assert.equal(environment.env.GIT_CONFIG_SYSTEM, "/dev/null");
+    assert.equal(environment.env.GIT_CONFIG_GLOBAL, devNull);
+    assert.equal(environment.env.GIT_CONFIG_SYSTEM, devNull);
     assert.equal(environment.env.npm_config_cache, "/developer/npm-cache");
 
     execFileSync("git", [

--- a/tools/test-process-environment.test.mjs
+++ b/tools/test-process-environment.test.mjs
@@ -1,8 +1,8 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
-import { devNull, tmpdir } from "node:os";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { createHermeticTestEnvironment, gitFixtureIdentityGuidance } from "./test-process-environment.mjs";
@@ -23,8 +23,9 @@ test("hermetic test environment rejects ambient Git identity and preserves the n
     assert.equal(implicitCommit.status, 128);
     assert.match(implicitCommit.stderr, /identity|email/iu);
     assert.equal(environment.env.HOME, environment.home);
-    assert.equal(environment.env.GIT_CONFIG_GLOBAL, devNull);
-    assert.equal(environment.env.GIT_CONFIG_SYSTEM, devNull);
+    assert.equal(environment.env.GIT_CONFIG_GLOBAL, path.join(environment.home, "empty.gitconfig"));
+    assert.equal(environment.env.GIT_CONFIG_SYSTEM, environment.env.GIT_CONFIG_GLOBAL);
+    assert.equal(readFileSync(environment.env.GIT_CONFIG_GLOBAL, "utf8"), "");
     assert.equal(environment.env.npm_config_cache, "/developer/npm-cache");
 
     execFileSync("git", [


### PR DESCRIPTION
# English

## Summary

Closes the three cold-start P1 gaps found by the blind two-arm benchmark (task_01KYVH89BT4P196RW6RDXRTPA2). That benchmark showed the three-tier help improved navigation but **not** end-to-end cost: fresh agents still burned commands on assembling valid input and getting through the completion gate. Concretely: (1) the `task` primary workflow omitted `fact record`, so subjects who faithfully followed the five printed steps still failed the lifecycle; (2) `--from-file` submission/approval schemas were discoverable only by repeated `--dry-run` field probing — one subject spent 18 failed receipts there; (3) a freshly `ha init`-ed workspace had no root Git repository, so **all four** subjects were forced to hand-run `git init` plus an empty commit before completion could resolve HEAD.

## What Changed

- `command-groups.ts`: task primary workflow becomes six steps including `fact record` (the workflow-line registry gate still passes).
- `task-packet-templates.ts` (new) + `main.ts`: `ha task submit --help` / `ha task complete --help` print a copy-ready minimal packet template; no schema logic duplicated, template is a declarative table.
- `init.ts`: a fresh workspace now gets its root Git repository and an initial commit, so the completion commit anchor resolves without manual Git. Fail-safe: an existing repository is left untouched (`skipped-existing`); the initial commit is deliberately empty so no unknown user files are staged. The isolation report gained `action` / `initialCommitCreated` / `commitCount` fields.
- Tests: new `coldstart-p1-cli.test.ts` covering all three, plus updates to init/lifecycle/help/doctor tests.

## Task And Scope

- Harness task: task_01KYVKNRF0F8FQ8XASZA0XDZ7X
- Branch: codex/cli-ergo3
- Public scope: CLI help/templates/init bootstrap + tests
- Private planning/evidence updated: yes
- Out of scope: completion gate semantics (unchanged), `packages/daemon`, kernel write-coordination, task-complete/lifecycle facades (another change in flight), GUI

## Version Impact

- Version: no version change because CLI ergonomics only
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: n/a
- Authority: cold-start benchmark P1 remediation; task task_01KYVKNRF0F8FQ8XASZA0XDZ7X
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: n/a
- Break-glass scope: n/a
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: 3b339bd2
- Branch merge-base with `origin/main`: 3b339bd2
- Last `git fetch origin` time: 2026-07-31
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/cli-ergo3`
- Private evidence commit/path: harness/tasks/task_01KYVKNRF0F8FQ8XASZA0XDZ7X-cli-p1-fact-submission-approval-json-init-git/ (plan) and the benchmark package task_01KYVH89BT4P196RW6RDXRTPA2-cli/artifacts/coldstart-bench-report.md
- Reviewer evidence path: CEO hands-on run in a throwaway directory (below)
- GitHub Actions `rewrite-ci` run URL: (filled after CI)
- [x] `git diff --check`
- [x] `npm run check:stop-point` — check:local green, 27/27 gates; affected fast 397/397, contract 88/88
- [x] CEO hands-on: fresh `init` in an empty dir produced root HEAD `chore: initialize harness workspace` with no manual Git; `task --help` shows the six-step workflow; `task submit --help` prints a copy-ready packet
- [x] Worker smoke: one same-prompt cold-start subject reached `done` without any manual `git init/add/commit`, with a fact anchor and a first-try submission
- [ ] GitHub Actions `rewrite-ci` passed (authoritative full gate)
- Not run, and why: full CI runs on this PR; the formal 2x2 benchmark is deliberately deferred until the remaining P1s land.

## Review Evidence

- Self-review: CEO read the init bootstrap path (fail-safe on existing repos, empty initial commit) and verified all three fixes by hand in a throwaway workspace.
- Reviewer subagent: not required (no write-path or gate-semantics change; behaviour covered by new tests).
- Human review: not required.
- Blocking findings: none.

## Residual Risk

- An existing repository without HEAD is intentionally left alone; such a workspace still needs a manual first commit.
- Remaining benchmark P1s (completion preconditions surfacing too late, dry-run receipt contract gaps) are queued behind the in-flight daemon recovery change.

## References

- Task: task_01KYVKNRF0F8FQ8XASZA0XDZ7X
- Benchmark: task_01KYVH89BT4P196RW6RDXRTPA2 (artifacts/coldstart-bench-report.md)
- Predecessors: #1146, #1155

---

# 中文

## 概要

修掉冷启动双臂盲测(task_01KYVH89BT4P196RW6RDXRTPA2)点名的三个 P1。该基准显示三层 help 改善了导航但**没有**降低端到端成本:新鲜 agent 的命令都花在组装合法输入和过完成门上。具体:①task 主链漏了 `fact record`,忠实照五步走的 subject 仍然生命周期失败;②`--from-file` 的 submission/approval schema 只能靠反复 `--dry-run` 逐字段试探,一个 subject 在这里烧掉 18 条失败回执;③全新 `ha init` 的工作区没有根 Git 仓,**四个 subject 全部**被迫手工 `git init` 加空 commit 才能让完成门解析 HEAD。

## 改动内容

- `command-groups.ts`:task 主链改为含 `fact record` 的六步(workflow 真实性门仍通过)。
- 新增 `task-packet-templates.ts` + `main.ts`:`task submit/complete --help` 打印可直接复制的最小 packet 模板;不复制 schema 逻辑,模板是声明式表。
- `init.ts`:全新工作区自动建根 Git 仓与首次提交,完成门的 commit 锚点无需手工 Git。fail-safe:已存在仓库一律不动(`skipped-existing`);首提交刻意为空,避免自动暂存用户未知文件。isolation 报告新增 `action`/`initialCommitCreated`/`commitCount`。
- 测试:新增 `coldstart-p1-cli.test.ts` 覆盖三项,并更新 init/lifecycle/help/doctor 测试。

## 任务与范围

- Harness 任务:task_01KYVKNRF0F8FQ8XASZA0XDZ7X
- 分支:codex/cli-ergo3
- 公开范围:CLI help/模板/init 引导 + 测试
- 私有规划/证据已更新:是
- 范围外:完成门语义(不动)、`packages/daemon`、kernel 写协调、task-complete/lifecycle facade(另有改动在飞)、GUI

## 版本影响

- 版本:不改版本,原因是仅 CLI 人机工程
- 发布影响:不发布

## 治理声明

- 触及 protected surface:否
- 范围:不适用
- 授权:冷启动基准 P1 处置;任务 task_01KYVKNRF0F8FQ8XASZA0XDZ7X
- 机检边界:本 PR 只断言声明存在;是否真实充分由评审判断。
- Break-glass:否
- 原因/范围:不适用
- 后续治理任务:无

## 验证

- Base `origin/main` SHA:3b339bd2
- merge-base:3b339bd2
- 最近 `git fetch origin`:2026-07-31
- 同步方式:无需
- 公开 diff 命令:`git diff origin/main...codex/cli-ergo3`
- 私有证据:任务包 plan + 基准报告 coldstart-bench-report.md
- 评审证据:CEO 在临时目录亲手走查(见下)
- `rewrite-ci` run URL:(CI 后回填)
- [x] `git diff --check`
- [x] `npm run check:stop-point`——check:local 全绿 27/27;affected fast 397/397、contract 88/88
- [x] CEO 亲验:空目录 `init` 后自带根 HEAD `chore: initialize harness workspace`,无需手工 Git;`task --help` 显示六步主链;`task submit --help` 打印可复制 packet
- [x] worker 冒烟:同款 prompt 的冷启动 subject 未执行任何手工 `git init/add/commit` 即达 `done`,有 fact anchor,submission 首次即通过
- [ ] GitHub Actions `rewrite-ci` 绿(权威完整门)
- 未运行及原因:完整 CI 在本 PR 上跑;正式 2×2 基准刻意推迟到剩余 P1 落地后再跑。

## 评审证据

- 自评:CEO 读 init 引导路径(已有仓 fail-safe、首提交为空),并在临时工作区亲手验证三项。
- 评审 subagent:不需要(无写路径与门语义改动,行为由新测试覆盖)。
- 人工评审:不需要。
- 阻塞 findings:无。

## 残留风险

- 已存在但无 HEAD 的仓库刻意不动,这类工作区仍需手工首次提交。
- 基准剩余 P1(完成门前置暴露过晚、dry-run 回执契约缺字段)排在在飞的 daemon recovery 改动之后。

## 参考

- 任务:task_01KYVKNRF0F8FQ8XASZA0XDZ7X
- 基准:task_01KYVH89BT4P196RW6RDXRTPA2(artifacts/coldstart-bench-report.md)
- 前序:#1146、#1155
