### PR TITLE
fix(daemon): terminalize permanent historical recovery failures

### DIFF
--- a/packages/cli/src/composition/repo-write-child-entrypoint.ts
+++ b/packages/cli/src/composition/repo-write-child-entrypoint.ts
@@ -153,7 +153,24 @@ export async function runRepoWriteChildEntrypoint(
   const transport = new RepoWriteChildIpcTransport();
   for (const proceeding of outcomes.listHistoricalProceedings()) {
     try {
-      await recoveryGate.recoverHistoricalProceeding(proceeding);
+      const recovery = await recoveryGate.recoverHistoricalProceeding(proceeding);
+      if (recovery.disposition === "permanently-rejected") {
+        await transport.send({
+          protocol: "harness-repo-write-ipc/v1",
+          repoId: config.repoId,
+          generation: config.generation,
+          kind: "recovery-rejected",
+          outerOpId: proceeding.outerOpId,
+          code: recovery.code,
+          diagnostic:
+            "Historical recovery evidence permanently conflicts with the canonical publication. "
+            + "The outer operation remains outcome-unknown; no authority terminal proof was created.",
+          next:
+            "Run `ha daemon logs --errors --json`, then escalate this outer op for "
+            + "operator-reviewed canonical Git and authority-state repair. "
+            + "Do not delete WAL, outcome, or recovery files."
+        });
+      }
     } catch (error) {
       await transport.send({
         protocol: "harness-repo-write-ipc/v1",

--- a/packages/daemon/src/lifecycle/run-daemon-serve.ts
+++ b/packages/daemon/src/lifecycle/run-daemon-serve.ts
@@ -270,12 +270,17 @@ export async function runDaemonServe<
               }
             }),
             onDiagnostic: (frame) => {
+              const rejected = frame.kind === "recovery-rejected";
               void daemonLogService.append({
                 level: "error",
                 source: "daemon",
                 component: "repo-write-child",
-                event: "repo-write.historical-recovery.deferred",
-                message: `Deferred repo-write historical recovery for outerOpId=${frame.outerOpId}: ${frame.diagnostic}`,
+                event: rejected
+                  ? "repo-write.historical-recovery.rejected"
+                  : "repo-write.historical-recovery.deferred",
+                message: rejected
+                  ? `Permanently rejected repo-write historical recovery for outerOpId=${frame.outerOpId}: ${frame.diagnostic} Next: ${frame.next}`
+                  : `Deferred repo-write historical recovery for outerOpId=${frame.outerOpId}: ${frame.diagnostic}`,
                 errorCode: frame.code,
                 requestId: frame.outerOpId
               }, { repo }).catch(() => undefined);

--- a/packages/daemon/src/runtime/durable-repo-write-outcome-store.ts
+++ b/packages/daemon/src/runtime/durable-repo-write-outcome-store.ts
@@ -1,20 +1,4 @@
-import { randomBytes } from "node:crypto";
-import {
-  chmodSync,
-  closeSync,
-  constants,
-  fchmodSync,
-  fstatSync,
-  fsyncSync,
-  linkSync,
-  lstatSync,
-  mkdirSync,
-  openSync,
-  readdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync
-} from "node:fs";
+import { closeSync, readdirSync } from "node:fs";
 import path from "node:path";
 import type { CommandReceiptEnvelope } from "@harness-anything/application";
 import { sha256Text } from "@harness-anything/kernel";
@@ -26,7 +10,6 @@ import {
   decodeRepoWriteOutcomeV1,
   repoWriteActorStampDigestV1,
   repoWriteReceiptSeedSchema,
-  RepoWriteOutcomeValidationError,
   sameRepoWriteOutcomeImmutableFieldsV1,
   type RepoWriteOutcomeAxesV1,
   type RepoWriteOutcomeV1,
@@ -35,62 +18,43 @@ import {
   type RepoWriteTerminalEvidenceV1,
   type RepoWriteTerminalOutcomeV1
 } from "./repo-write-outcome-schema.ts";
+import {
+  repoWriteOutcomeDurablePathExists,
+  repoWriteOutcomeEnsurePrivateDirectory,
+  repoWriteOutcomeFsyncDirectory,
+  repoWriteOutcomeFsyncOpened,
+  repoWriteOutcomePublishOnce,
+  repoWriteOutcomeReadPrivateText,
+  type RepoWriteOutcomeDurabilityTestHooks
+} from "./repo-write-outcome-durable-file.ts";
+import {
+  repoWriteHistoricalRecoveryRejectionRead,
+  repoWriteHistoricalRecoveryReject,
+  type RepoWriteHistoricalRecoveryRejectionV1,
+  type RepoWriteHistoricalRecoveryRejectInputV1
+} from "./repo-write-historical-recovery-rejection.ts";
+import {
+  RepoWriteOutcomeConflictError,
+  RepoWriteOutcomeCorruptionError,
+  RepoWriteOutcomeGenerationFenceError,
+  RepoWriteOutcomeUnsupportedPlatformError
+} from "./repo-write-outcome-errors.ts";
+
+export {
+  RepoWriteOutcomeConflictError,
+  RepoWriteOutcomeCorruptionError,
+  RepoWriteOutcomeGenerationFenceError,
+  RepoWriteOutcomeUnsupportedPlatformError
+} from "./repo-write-outcome-errors.ts";
+export type { RepoWriteOutcomeDurabilityTestHooks } from "./repo-write-outcome-durable-file.ts";
+export type {
+  RepoWriteHistoricalRecoveryRejectionV1,
+  RepoWriteHistoricalRecoveryRejectInputV1
+} from "./repo-write-historical-recovery-rejection.ts";
 
 const proceedingSuffix = ".proceeding.json";
 const terminalSuffix = ".terminal.json";
-const maximumOutcomeBytes = 2 * 1_024 * 1_024;
-
-export class RepoWriteOutcomeConflictError extends Error {
-  readonly code = "REPO_WRITE_OUTCOME_CONFLICT";
-
-  constructor(message: string) {
-    super(message);
-    this.name = "RepoWriteOutcomeConflictError";
-  }
-}
-
-export class RepoWriteOutcomeCorruptionError extends Error {
-  readonly code = "REPO_WRITE_OUTCOME_CORRUPT";
-
-  constructor(message: string, options: ErrorOptions = {}) {
-    super(message, options);
-    this.name = "RepoWriteOutcomeCorruptionError";
-  }
-}
-
-export class RepoWriteOutcomeUnsupportedPlatformError extends Error {
-  readonly code = "REPO_WRITE_OUTCOME_PLATFORM_UNSUPPORTED";
-
-  constructor() {
-    super("repo-write outcome durability is unsupported on win32");
-    this.name = "RepoWriteOutcomeUnsupportedPlatformError";
-  }
-}
-
-export class RepoWriteOutcomeGenerationFenceError extends Error {
-  readonly code = "REPO_WRITE_OUTCOME_GENERATION_FENCED";
-
-  constructor(message: string) {
-    super(message);
-    this.name = "RepoWriteOutcomeGenerationFenceError";
-  }
-}
-
-type DirectoryFsyncReason = "publish" | "observe-existing" | "eexist-observer";
-type TargetFsyncReason = "observe-existing" | "eexist-observer";
-
-export interface RepoWriteOutcomeDurabilityTestHooks {
-  /** Test-only fault injection; native fsync still runs unless this throws. */
-  readonly beforeDirectoryFsync?: (reason: DirectoryFsyncReason) => void;
-  /** Test-only observation emitted after the native directory fsync succeeds. */
-  readonly afterDirectoryFsync?: (reason: DirectoryFsyncReason) => void;
-  /** Test-only race injection; cannot replace the native link/fsync sequence. */
-  readonly beforePublishLink?: (input: { readonly target: string; readonly text: string }) => void;
-  /** Test-only observation emitted after the native target-inode fsync succeeds. */
-  readonly afterTargetFsync?: (
-    input: { readonly reason: TargetFsyncReason; readonly target: string }
-  ) => void;
-}
+const historicalRecoveryRejectionSuffix = ".recovery-rejected.json";
 
 export interface DurableRepoWriteOutcomeStoreV1Options extends RepoWriteOutcomeAxesV1 {
   readonly directory: string;
@@ -238,10 +202,39 @@ export class DurableRepoWriteOutcomeStoreV1 {
         }
         this.assertIdentity(proceeding, proceeding.outerOpId);
         const current = this.get(proceeding.outerOpId);
-        return current?.phase === "PROCEEDING" && current.generation < this.axes.generation
+        return current?.phase === "PROCEEDING"
+          && current.generation < this.axes.generation
+          && !this.getHistoricalRecoveryRejection(current.outerOpId)
           ? [current]
           : [];
       });
+  }
+
+  getHistoricalRecoveryRejection(
+    outerOpId: string
+  ): RepoWriteHistoricalRecoveryRejectionV1 | undefined {
+    return repoWriteHistoricalRecoveryRejectionRead({
+      directory: this.directory,
+      file: repoWriteOutcomePaths(this.directory, outerOpId).historicalRecoveryRejection,
+      axes: this.axes,
+      current: this.get(outerOpId),
+      ...(this.durabilityHooks ? { hooks: this.durabilityHooks } : {})
+    });
+  }
+
+  rejectHistoricalRecovery(
+    input: RepoWriteHistoricalRecoveryRejectInputV1
+  ): RepoWriteHistoricalRecoveryRejectionV1 {
+    this.assertInputAxes(input);
+    return repoWriteHistoricalRecoveryReject({
+      directory: this.directory,
+      file: repoWriteOutcomePaths(this.directory, input.outerOpId).historicalRecoveryRejection,
+      axes: this.axes,
+      current: this.get(input.outerOpId),
+      requestDigest: input.requestDigest,
+      code: input.code,
+      ...(this.durabilityHooks ? { hooks: this.durabilityHooks } : {})
+    });
   }
 
   begin(input: RepoWriteProceedingInputV1): RepoWriteOutcomeV1 {
@@ -404,9 +397,8 @@ function repoWriteOutcomeReadCanonical(
   hooks?: RepoWriteOutcomeDurabilityTestHooks
 ): RepoWriteOutcomeV1 {
   try {
-    const descriptor = repoWriteOutcomeOpenPrivateRegularFile(file);
+    const { descriptor, text } = repoWriteOutcomeReadPrivateText(file);
     try {
-      const text = readFileSync(descriptor, "utf8");
       const parsed = decodeRepoWriteOutcomeV1(JSON.parse(text) as unknown);
       if (text !== canonicalRepoWriteOutcomeText(parsed)) {
         throw new RepoWriteOutcomeCorruptionError(`repo-write outcome is not canonically encoded: ${path.basename(file)}`);
@@ -425,128 +417,10 @@ function repoWriteOutcomeReadCanonical(
   }
 }
 
-function repoWriteOutcomePublishOnce(
-  directory: string,
-  target: string,
-  text: string,
-  hooks?: RepoWriteOutcomeDurabilityTestHooks
-): boolean {
-  if (Buffer.byteLength(text, "utf8") > maximumOutcomeBytes) {
-    throw new RepoWriteOutcomeValidationError(
-      `repo-write outcome exceeds the ${maximumOutcomeBytes}-byte durable record limit`
-    );
-  }
-  repoWriteOutcomeEnsurePrivateDirectory(directory);
-  const temporary = path.join(
-    directory,
-    `.${path.basename(target)}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`
-  );
-  let descriptor: number | undefined;
-  try {
-    descriptor = openSync(temporary, "wx", 0o600);
-    fchmodSync(descriptor, 0o600);
-    if (process.platform !== "win32" && (fstatSync(descriptor).mode & 0o777) !== 0o600) {
-      throw new RepoWriteOutcomeCorruptionError("repo-write temporary outcome must have mode 0600");
-    }
-    writeFileSync(descriptor, text, "utf8");
-    fsyncSync(descriptor);
-    closeSync(descriptor);
-    descriptor = undefined;
-    hooks?.beforePublishLink?.({ target, text });
-    try {
-      linkSync(temporary, target);
-    } catch (error) {
-      if (repoWriteOutcomeIsAlreadyExists(error)) {
-        repoWriteOutcomeFsyncExisting(target, hooks, "eexist-observer");
-        repoWriteOutcomeFsyncDirectory(directory, hooks, "eexist-observer");
-        return false;
-      }
-      throw error;
-    }
-    repoWriteOutcomeFsyncDirectory(directory, hooks, "publish");
-    return true;
-  } finally {
-    if (descriptor !== undefined) closeSync(descriptor);
-    rmSync(temporary, { force: true });
-  }
-}
-
-function repoWriteOutcomeFsyncExisting(
-  file: string,
-  hooks: RepoWriteOutcomeDurabilityTestHooks | undefined,
-  reason: TargetFsyncReason
-): void {
-  const descriptor = repoWriteOutcomeOpenPrivateRegularFile(file);
-  try {
-    repoWriteOutcomeFsyncOpened(descriptor, file, hooks, reason);
-  } finally {
-    closeSync(descriptor);
-  }
-}
-
-function repoWriteOutcomeFsyncOpened(
-  descriptor: number,
-  file: string,
-  hooks: RepoWriteOutcomeDurabilityTestHooks | undefined,
-  reason: TargetFsyncReason
-): void {
-  fsyncSync(descriptor);
-  hooks?.afterTargetFsync?.({ reason, target: file });
-}
-
-function repoWriteOutcomeEnsurePrivateDirectory(directory: string): void {
-  mkdirSync(directory, { recursive: true, mode: 0o700 });
-  const status = lstatSync(directory);
-  if (!status.isDirectory() || status.isSymbolicLink()) {
-    throw new RepoWriteOutcomeCorruptionError("repo-write outcome root must be a real directory");
-  }
-  if (process.platform !== "win32") {
-    chmodSync(directory, 0o700);
-    if ((lstatSync(directory).mode & 0o777) !== 0o700) {
-      throw new RepoWriteOutcomeCorruptionError("repo-write outcome root must have mode 0700");
-    }
-  }
-}
-
-function repoWriteOutcomeOpenPrivateRegularFile(file: string): number {
-  const descriptor = openSync(file, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
-  const status = fstatSync(descriptor);
-  if (!status.isFile()) {
-    closeSync(descriptor);
-    throw new RepoWriteOutcomeCorruptionError(`repo-write outcome is not a regular file: ${path.basename(file)}`);
-  }
-  if (status.size <= 0 || status.size > maximumOutcomeBytes) {
-    closeSync(descriptor);
-    throw new RepoWriteOutcomeCorruptionError(
-      `repo-write outcome has an invalid byte length: ${path.basename(file)}`
-    );
-  }
-  if (process.platform !== "win32" && (status.mode & 0o777) !== 0o600) {
-    closeSync(descriptor);
-    throw new RepoWriteOutcomeCorruptionError(`repo-write outcome must have mode 0600: ${path.basename(file)}`);
-  }
-  return descriptor;
-}
-
-function repoWriteOutcomeFsyncDirectory(
-  directory: string,
-  hooks: RepoWriteOutcomeDurabilityTestHooks | undefined,
-  reason: DirectoryFsyncReason
-): void {
-  if (process.platform === "win32") throw new RepoWriteOutcomeUnsupportedPlatformError();
-  hooks?.beforeDirectoryFsync?.(reason);
-  const descriptor = openSync(directory, "r");
-  try {
-    fsyncSync(descriptor);
-  } finally {
-    closeSync(descriptor);
-  }
-  hooks?.afterDirectoryFsync?.(reason);
-}
-
 function repoWriteOutcomePaths(directory: string, outerOpId: string): {
   readonly proceeding: string;
   readonly terminal: string;
+  readonly historicalRecoveryRejection: string;
 } {
   const normalized = createRepoWriteProceedingOutcomeV1({
     repoId: "path-check",
@@ -564,22 +438,9 @@ function repoWriteOutcomePaths(directory: string, outerOpId: string): {
   const prefix = path.join(directory, `repo-write-outcome-v1.${key}`);
   return {
     proceeding: `${prefix}${proceedingSuffix}`,
-    terminal: `${prefix}${terminalSuffix}`
+    terminal: `${prefix}${terminalSuffix}`,
+    historicalRecoveryRejection: `${prefix}${historicalRecoveryRejectionSuffix}`
   };
-}
-
-function repoWriteOutcomeIsAlreadyExists(error: unknown): boolean {
-  return error instanceof Error && "code" in error && error.code === "EEXIST";
-}
-
-function repoWriteOutcomeDurablePathExists(file: string): boolean {
-  try {
-    lstatSync(file);
-    return true;
-  } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
-    throw error;
-  }
 }
 
 function repoWriteOutcomeSafeIdentity(value: string): string {

--- a/packages/daemon/src/runtime/durable-repo-write-outcome-store.ts
+++ b/packages/daemon/src/runtime/durable-repo-write-outcome-store.ts
@@ -204,7 +204,7 @@ export class DurableRepoWriteOutcomeStoreV1 {
         const current = this.get(proceeding.outerOpId);
         return current?.phase === "PROCEEDING"
           && current.generation < this.axes.generation
-          && !this.getHistoricalRecoveryRejection(current.outerOpId)
+          && !this.usableHistoricalRecoveryRejection(current)
           ? [current]
           : [];
       });
@@ -321,6 +321,26 @@ export class DurableRepoWriteOutcomeStoreV1 {
       throw new RepoWriteOutcomeConflictError(
         "repo-write outcome input does not match the store repo/workspace/generation axes"
       );
+    }
+  }
+
+  private usableHistoricalRecoveryRejection(
+    current: RepoWriteOutcomeV1
+  ): RepoWriteHistoricalRecoveryRejectionV1 | undefined {
+    try {
+      return repoWriteHistoricalRecoveryRejectionRead({
+        directory: this.directory,
+        file: repoWriteOutcomePaths(
+          this.directory,
+          current.outerOpId
+        ).historicalRecoveryRejection,
+        axes: this.axes,
+        current,
+        ...(this.durabilityHooks ? { hooks: this.durabilityHooks } : {})
+      });
+    } catch (error) {
+      if (error instanceof RepoWriteOutcomeCorruptionError) return undefined;
+      throw error;
     }
   }
 

--- a/packages/daemon/src/runtime/repo-write-authority-recovery-gate.ts
+++ b/packages/daemon/src/runtime/repo-write-authority-recovery-gate.ts
@@ -126,15 +126,27 @@ export class RepoWriteAuthorityRecoveryGate {
         `historical authority recovery cannot admit outer PROCEEDING: ${outcome.outerOpId}`
       );
     }
-    const publication = await this.resolveHistoricalPublication(outcome);
-    if (publication.semanticDigest !== outcome.authoritySemanticDigest) {
-      throw new RepoWriteOutcomeGenerationFenceError(
-        `historical publication semantic digest does not match outer PROCEEDING: ${outcome.outerOpId}`
-      );
+    try {
+      const publication = await this.resolveHistoricalPublication(outcome);
+      if (publication.semanticDigest !== outcome.authoritySemanticDigest) {
+        throw new RepoWriteOutcomeGenerationFenceError(
+          `historical publication semantic digest does not match outer PROCEEDING: ${outcome.outerOpId}`
+        );
+      }
+      await this.assertCurrentWriterFence();
+      const committed = await this.recoverHistorical(outcome, publication);
+      this.terminalizeHistorical(outcome, publication, committed);
+    } catch (error) {
+      const permanentCode = permanentHistoricalRecoveryRejectionCode(error);
+      if (!permanentCode) throw error;
+      await this.assertCurrentWriterFence();
+      this.store.rejectHistoricalRecovery({
+        ...this.axes,
+        outerOpId: outcome.outerOpId,
+        requestDigest: outcome.requestDigest,
+        code: permanentCode
+      });
     }
-    await this.assertCurrentWriterFence();
-    const committed = await this.recoverHistorical(outcome, publication);
-    this.terminalizeHistorical(outcome, publication, committed);
   }
 
   private async recoverHistorical(
@@ -222,6 +234,17 @@ export class RepoWriteAuthorityRecoveryGate {
     await this.assertCurrentWriterFence();
     return useDurableProceeding(outcome);
   }
+}
+
+const permanentHistoricalRecoveryRejectionCodes = new Set([
+  "AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR",
+  "AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH"
+]);
+
+function permanentHistoricalRecoveryRejectionCode(error: unknown): string | undefined {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = /^([A-Z][A-Z0-9_]*)(?=[:;]|$)/u.exec(message)?.[1];
+  return code && permanentHistoricalRecoveryRejectionCodes.has(code) ? code : undefined;
 }
 
 function historicalRecoveryReceipt(

--- a/packages/daemon/src/runtime/repo-write-authority-recovery-gate.ts
+++ b/packages/daemon/src/runtime/repo-write-authority-recovery-gate.ts
@@ -41,6 +41,13 @@ export interface RepoWriteAuthorityRecoveryAttemptWitness {
   };
 }
 
+export type RepoWriteHistoricalProceedingRecoveryResult =
+  | { readonly disposition: "committed" }
+  | {
+      readonly disposition: "permanently-rejected";
+      readonly code: string;
+    };
+
 /**
  * Binds both recovery admission stages to the same child-owned, fsynced outer
  * PROCEEDING row. Temporal or revocation drift is deliberately absent here;
@@ -117,7 +124,7 @@ export class RepoWriteAuthorityRecoveryGate {
 
   async recoverHistoricalProceeding(
     outcome: RepoWriteProceedingOutcomeV1
-  ): Promise<void> {
+  ): Promise<RepoWriteHistoricalProceedingRecoveryResult> {
     if (outcome.generation >= this.axes.generation
       || outcome.repoId !== this.axes.repoId
       || outcome.workspaceId !== this.axes.workspaceId
@@ -136,6 +143,7 @@ export class RepoWriteAuthorityRecoveryGate {
       await this.assertCurrentWriterFence();
       const committed = await this.recoverHistorical(outcome, publication);
       this.terminalizeHistorical(outcome, publication, committed);
+      return { disposition: "committed" };
     } catch (error) {
       const permanentCode = permanentHistoricalRecoveryRejectionCode(error);
       if (!permanentCode) throw error;
@@ -146,6 +154,10 @@ export class RepoWriteAuthorityRecoveryGate {
         requestDigest: outcome.requestDigest,
         code: permanentCode
       });
+      return {
+        disposition: "permanently-rejected",
+        code: permanentCode
+      };
     }
   }
 

--- a/packages/daemon/src/runtime/repo-write-client-contract.ts
+++ b/packages/daemon/src/runtime/repo-write-client-contract.ts
@@ -1,7 +1,7 @@
 import type {
   RepoWriteChildMessage,
   RepoWriteParentMessage,
-  RepoWriteRecoveryDeferredFrame,
+  RepoWriteRecoveryDiagnosticFrame,
   RepoWriteTelemetryFrame
 } from "./repo-write-protocol.ts";
 import type {
@@ -59,7 +59,7 @@ export interface RepoWriteClientOptions {
   readonly expectedArtifactIdentity?: string;
   readonly limits?: Partial<RepoWriteClientLimits>;
   readonly onTelemetry: (frame: RepoWriteTelemetryFrame) => void;
-  readonly onDiagnostic?: (frame: RepoWriteRecoveryDeferredFrame) => void;
+  readonly onDiagnostic?: (frame: RepoWriteRecoveryDiagnosticFrame) => void;
   readonly onRequestTimeout?: (
     diagnostic: RepoWriteRequestTimeoutDiagnostic
   ) => void;

--- a/packages/daemon/src/runtime/repo-write-client-observers.ts
+++ b/packages/daemon/src/runtime/repo-write-client-observers.ts
@@ -1,5 +1,5 @@
 import type {
-  RepoWriteRecoveryDeferredFrame,
+  RepoWriteRecoveryDiagnosticFrame,
   RepoWriteTelemetryFrame
 } from "./repo-write-protocol.ts";
 import { repoWriteProtocolType } from "./repo-write-protocol.ts";
@@ -21,8 +21,8 @@ export function observeRepoWriteTelemetry(
 }
 
 export function observeRepoWriteRecoveryDiagnostic(
-  observer: ((frame: RepoWriteRecoveryDeferredFrame) => void) | undefined,
-  frame: RepoWriteRecoveryDeferredFrame
+  observer: ((frame: RepoWriteRecoveryDiagnosticFrame) => void) | undefined,
+  frame: RepoWriteRecoveryDiagnosticFrame
 ): void {
   try {
     observer?.(frame);

--- a/packages/daemon/src/runtime/repo-write-client.ts
+++ b/packages/daemon/src/runtime/repo-write-client.ts
@@ -351,7 +351,7 @@ export class RepoWriteClient {
       );
       return;
     }
-    if (message.kind === "recovery-deferred") {
+    if (message.kind === "recovery-deferred" || message.kind === "recovery-rejected") {
       observeRepoWriteRecoveryDiagnostic(this.options.onDiagnostic, message);
       return;
     }

--- a/packages/daemon/src/runtime/repo-write-diagnostic-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-diagnostic-protocol.ts
@@ -1,0 +1,34 @@
+interface RepoWriteDiagnosticFrameBase {
+  readonly protocol: "harness-repo-write-ipc/v1";
+  readonly repoId: string;
+  readonly generation: number;
+}
+
+export type RepoWriteTelemetryPhase =
+  "queue" | "compile" | "journal" | "git" | "fsync" | "materializer" | "projection" | "total";
+
+export interface RepoWriteTelemetryFrame extends RepoWriteDiagnosticFrameBase {
+  readonly kind: "telemetry";
+  readonly requestId: string;
+  readonly opId?: string;
+  readonly phase: RepoWriteTelemetryPhase;
+  readonly elapsedMs: number;
+}
+
+export interface RepoWriteRecoveryDeferredFrame extends RepoWriteDiagnosticFrameBase {
+  readonly kind: "recovery-deferred";
+  readonly outerOpId: string;
+  readonly code: string;
+  readonly diagnostic: string;
+}
+
+export interface RepoWriteRecoveryRejectedFrame extends RepoWriteDiagnosticFrameBase {
+  readonly kind: "recovery-rejected";
+  readonly outerOpId: string;
+  readonly code: string;
+  readonly diagnostic: string;
+  readonly next: string;
+}
+
+export type RepoWriteRecoveryDiagnosticFrame =
+  RepoWriteRecoveryDeferredFrame | RepoWriteRecoveryRejectedFrame;

--- a/packages/daemon/src/runtime/repo-write-historical-recovery-rejection.ts
+++ b/packages/daemon/src/runtime/repo-write-historical-recovery-rejection.ts
@@ -47,6 +47,7 @@ interface HistoricalRecoveryRejectionStoreInput {
   readonly axes: RepoWriteOutcomeAxesV1;
   readonly current: RepoWriteOutcomeV1 | undefined;
   readonly hooks?: RepoWriteOutcomeDurabilityTestHooks;
+  readonly allowNewerRejectingGeneration?: boolean;
 }
 
 export function repoWriteHistoricalRecoveryRejectionRead(
@@ -58,7 +59,13 @@ export function repoWriteHistoricalRecoveryRejectionRead(
       "historical recovery rejection has no unsettled PROCEEDING"
     );
   }
-  return readCanonical(input.file, input.current, input.axes, input.hooks);
+  return readCanonical(
+    input.file,
+    input.current,
+    input.axes,
+    input.hooks,
+    input.allowNewerRejectingGeneration === true
+  );
 }
 
 export function repoWriteHistoricalRecoveryReject(
@@ -84,7 +91,11 @@ export function repoWriteHistoricalRecoveryReject(
     );
   }
   const candidate = createRejection(current, input.axes.generation, input.code);
-  const existing = repoWriteHistoricalRecoveryRejectionRead(input);
+  const raceTolerantInput = {
+    ...input,
+    allowNewerRejectingGeneration: true
+  };
+  const existing = repoWriteHistoricalRecoveryRejectionRead(raceTolerantInput);
   if (existing) return idempotent(existing, candidate);
   const published = repoWriteOutcomePublishOnce(
     input.directory,
@@ -92,7 +103,7 @@ export function repoWriteHistoricalRecoveryReject(
     canonicalText(candidate),
     input.hooks
   );
-  const durable = repoWriteHistoricalRecoveryRejectionRead(input);
+  const durable = repoWriteHistoricalRecoveryRejectionRead(raceTolerantInput);
   if (!durable) {
     throw new RepoWriteOutcomeCorruptionError(
       "historical recovery rejection publication disappeared"
@@ -130,7 +141,8 @@ function readCanonical(
   file: string,
   proceeding: RepoWriteProceedingOutcomeV1,
   axes: RepoWriteOutcomeAxesV1,
-  hooks?: RepoWriteOutcomeDurabilityTestHooks
+  hooks?: RepoWriteOutcomeDurabilityTestHooks,
+  allowNewerRejectingGeneration = false
 ): RepoWriteHistoricalRecoveryRejectionV1 {
   try {
     const { descriptor, text } = repoWriteOutcomeReadPrivateText(file);
@@ -138,7 +150,8 @@ function readCanonical(
       const record = parseRecord(text);
       if (!Number.isSafeInteger(record.rejectedByGeneration)
         || (record.rejectedByGeneration as number) <= proceeding.generation
-        || (record.rejectedByGeneration as number) > axes.generation) {
+        || (!allowNewerRejectingGeneration
+          && (record.rejectedByGeneration as number) > axes.generation)) {
         throw new RepoWriteOutcomeValidationError(
           "historical recovery rejection has invalid generation fencing"
         );
@@ -200,7 +213,10 @@ function idempotent(
   current: RepoWriteHistoricalRecoveryRejectionV1,
   candidate: RepoWriteHistoricalRecoveryRejectionV1
 ): RepoWriteHistoricalRecoveryRejectionV1 {
-  if (canonicalText(current) !== canonicalText(candidate)) {
+  const currentRecord = current as unknown as Record<string, unknown>;
+  const candidateRecord = candidate as unknown as Record<string, unknown>;
+  if (Object.entries(candidateRecord).some(([key, value]) =>
+    key !== "rejectedByGeneration" && currentRecord[key] !== value)) {
     throw new RepoWriteOutcomeConflictError("historical recovery rejection is immutable");
   }
   return current;

--- a/packages/daemon/src/runtime/repo-write-historical-recovery-rejection.ts
+++ b/packages/daemon/src/runtime/repo-write-historical-recovery-rejection.ts
@@ -1,0 +1,207 @@
+import { closeSync } from "node:fs";
+import path from "node:path";
+import { stableStringify } from "@harness-anything/kernel";
+import {
+  repoWriteOutcomeDurablePathExists,
+  repoWriteOutcomeFsyncOpened,
+  repoWriteOutcomePublishOnce,
+  repoWriteOutcomeReadPrivateText,
+  type RepoWriteOutcomeDurabilityTestHooks
+} from "./repo-write-outcome-durable-file.ts";
+import {
+  RepoWriteOutcomeConflictError,
+  RepoWriteOutcomeCorruptionError,
+  RepoWriteOutcomeValidationError
+} from "./repo-write-outcome-errors.ts";
+import type {
+  RepoWriteOutcomeAxesV1,
+  RepoWriteOutcomeV1,
+  RepoWriteProceedingOutcomeV1
+} from "./repo-write-outcome-schema.ts";
+
+const schema = "repo-write-historical-recovery-rejection/v1" as const;
+
+export interface RepoWriteHistoricalRecoveryRejectionV1 {
+  readonly schema: typeof schema;
+  readonly disposition: "permanently-rejected";
+  readonly repoId: string;
+  readonly workspaceId: string;
+  readonly proceedingGeneration: number;
+  readonly rejectedByGeneration: number;
+  readonly outerOpId: string;
+  readonly requestDigest: string;
+  readonly innerOpId: string;
+  readonly authoritySemanticDigest: string;
+  readonly code: string;
+}
+
+export interface RepoWriteHistoricalRecoveryRejectInputV1 extends RepoWriteOutcomeAxesV1 {
+  readonly outerOpId: string;
+  readonly requestDigest: string;
+  readonly code: string;
+}
+
+interface HistoricalRecoveryRejectionStoreInput {
+  readonly directory: string;
+  readonly file: string;
+  readonly axes: RepoWriteOutcomeAxesV1;
+  readonly current: RepoWriteOutcomeV1 | undefined;
+  readonly hooks?: RepoWriteOutcomeDurabilityTestHooks;
+}
+
+export function repoWriteHistoricalRecoveryRejectionRead(
+  input: HistoricalRecoveryRejectionStoreInput
+): RepoWriteHistoricalRecoveryRejectionV1 | undefined {
+  if (!repoWriteOutcomeDurablePathExists(input.file)) return undefined;
+  if (!input.current || input.current.phase !== "PROCEEDING") {
+    throw new RepoWriteOutcomeCorruptionError(
+      "historical recovery rejection has no unsettled PROCEEDING"
+    );
+  }
+  return readCanonical(input.file, input.current, input.axes, input.hooks);
+}
+
+export function repoWriteHistoricalRecoveryReject(
+  input: HistoricalRecoveryRejectionStoreInput & {
+    readonly requestDigest: string;
+    readonly code: string;
+  }
+): RepoWriteHistoricalRecoveryRejectionV1 {
+  const current = input.current;
+  if (!current || current.phase !== "PROCEEDING") {
+    throw new RepoWriteOutcomeConflictError(
+      "historical recovery rejection requires unsettled PROCEEDING"
+    );
+  }
+  if (current.generation >= input.axes.generation) {
+    throw new RepoWriteOutcomeConflictError(
+      "historical recovery rejection requires an older writer generation"
+    );
+  }
+  if (current.requestDigest !== input.requestDigest) {
+    throw new RepoWriteOutcomeConflictError(
+      "outer opId is already bound to a different request digest"
+    );
+  }
+  const candidate = createRejection(current, input.axes.generation, input.code);
+  const existing = repoWriteHistoricalRecoveryRejectionRead(input);
+  if (existing) return idempotent(existing, candidate);
+  const published = repoWriteOutcomePublishOnce(
+    input.directory,
+    input.file,
+    canonicalText(candidate),
+    input.hooks
+  );
+  const durable = repoWriteHistoricalRecoveryRejectionRead(input);
+  if (!durable) {
+    throw new RepoWriteOutcomeCorruptionError(
+      "historical recovery rejection publication disappeared"
+    );
+  }
+  return published ? durable : idempotent(durable, candidate);
+}
+
+function createRejection(
+  proceeding: RepoWriteProceedingOutcomeV1,
+  rejectedByGeneration: number,
+  code: string
+): RepoWriteHistoricalRecoveryRejectionV1 {
+  if (!/^[A-Z][A-Z0-9_]{0,255}$/u.test(code)) {
+    throw new RepoWriteOutcomeValidationError(
+      "historical recovery rejection code must be a bounded uppercase identifier"
+    );
+  }
+  return {
+    schema,
+    disposition: "permanently-rejected",
+    repoId: proceeding.repoId,
+    workspaceId: proceeding.workspaceId,
+    proceedingGeneration: proceeding.generation,
+    rejectedByGeneration,
+    outerOpId: proceeding.outerOpId,
+    requestDigest: proceeding.requestDigest,
+    innerOpId: proceeding.innerOpId,
+    authoritySemanticDigest: proceeding.authoritySemanticDigest,
+    code
+  };
+}
+
+function readCanonical(
+  file: string,
+  proceeding: RepoWriteProceedingOutcomeV1,
+  axes: RepoWriteOutcomeAxesV1,
+  hooks?: RepoWriteOutcomeDurabilityTestHooks
+): RepoWriteHistoricalRecoveryRejectionV1 {
+  try {
+    const { descriptor, text } = repoWriteOutcomeReadPrivateText(file);
+    try {
+      const record = parseRecord(text);
+      if (!Number.isSafeInteger(record.rejectedByGeneration)
+        || (record.rejectedByGeneration as number) <= proceeding.generation
+        || (record.rejectedByGeneration as number) > axes.generation) {
+        throw new RepoWriteOutcomeValidationError(
+          "historical recovery rejection has invalid generation fencing"
+        );
+      }
+      const decoded = createRejection(
+        proceeding,
+        record.rejectedByGeneration as number,
+        typeof record.code === "string" ? record.code : ""
+      );
+      if (!matches(record, decoded) || text !== canonicalText(decoded)) {
+        throw new RepoWriteOutcomeValidationError(
+          "historical recovery rejection does not bind its PROCEEDING"
+        );
+      }
+      repoWriteOutcomeFsyncOpened(descriptor, file, hooks, "observe-existing");
+      return decoded;
+    } finally {
+      closeSync(descriptor);
+    }
+  } catch (error) {
+    if (error instanceof RepoWriteOutcomeCorruptionError) throw error;
+    throw new RepoWriteOutcomeCorruptionError(
+      `cannot read durable historical recovery rejection: ${path.basename(file)}`,
+      { cause: error }
+    );
+  }
+}
+
+function parseRecord(text: string): Record<string, unknown> {
+  const value = JSON.parse(text) as unknown;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new RepoWriteOutcomeValidationError("historical recovery rejection must be an object");
+  }
+  const record = value as Record<string, unknown>;
+  const expectedKeys = [
+    "schema", "disposition", "repoId", "workspaceId", "proceedingGeneration",
+    "rejectedByGeneration", "outerOpId", "requestDigest", "innerOpId",
+    "authoritySemanticDigest", "code"
+  ];
+  if (Object.keys(record).length !== expectedKeys.length
+    || expectedKeys.some((key) => !Object.hasOwn(record, key))) {
+    throw new RepoWriteOutcomeValidationError("historical recovery rejection has invalid fields");
+  }
+  return record;
+}
+
+function matches(
+  record: Record<string, unknown>,
+  expected: RepoWriteHistoricalRecoveryRejectionV1
+): boolean {
+  return Object.entries(expected).every(([key, value]) => record[key] === value);
+}
+
+function canonicalText(rejection: RepoWriteHistoricalRecoveryRejectionV1): string {
+  return `${stableStringify(rejection)}\n`;
+}
+
+function idempotent(
+  current: RepoWriteHistoricalRecoveryRejectionV1,
+  candidate: RepoWriteHistoricalRecoveryRejectionV1
+): RepoWriteHistoricalRecoveryRejectionV1 {
+  if (canonicalText(current) !== canonicalText(candidate)) {
+    throw new RepoWriteOutcomeConflictError("historical recovery rejection is immutable");
+  }
+  return current;
+}

--- a/packages/daemon/src/runtime/repo-write-outcome-durable-file.ts
+++ b/packages/daemon/src/runtime/repo-write-outcome-durable-file.ts
@@ -1,0 +1,187 @@
+import { randomBytes } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
+import path from "node:path";
+import {
+  RepoWriteOutcomeCorruptionError,
+  RepoWriteOutcomeUnsupportedPlatformError,
+  RepoWriteOutcomeValidationError
+} from "./repo-write-outcome-errors.ts";
+
+const maximumOutcomeBytes = 2 * 1_024 * 1_024;
+export type RepoWriteOutcomeDirectoryFsyncReason =
+  "publish" | "observe-existing" | "eexist-observer";
+export type RepoWriteOutcomeTargetFsyncReason = "observe-existing" | "eexist-observer";
+
+export interface RepoWriteOutcomeDurabilityTestHooks {
+  readonly beforeDirectoryFsync?: (reason: RepoWriteOutcomeDirectoryFsyncReason) => void;
+  readonly afterDirectoryFsync?: (reason: RepoWriteOutcomeDirectoryFsyncReason) => void;
+  readonly beforePublishLink?: (input: { readonly target: string; readonly text: string }) => void;
+  readonly afterTargetFsync?: (input: {
+    readonly reason: RepoWriteOutcomeTargetFsyncReason;
+    readonly target: string;
+  }) => void;
+}
+
+export function repoWriteOutcomePublishOnce(
+  directory: string,
+  target: string,
+  text: string,
+  hooks?: RepoWriteOutcomeDurabilityTestHooks
+): boolean {
+  if (Buffer.byteLength(text, "utf8") > maximumOutcomeBytes) {
+    throw new RepoWriteOutcomeValidationError(
+      `repo-write outcome exceeds the ${maximumOutcomeBytes}-byte durable record limit`
+    );
+  }
+  repoWriteOutcomeEnsurePrivateDirectory(directory);
+  const temporary = path.join(
+    directory,
+    `.${path.basename(target)}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`
+  );
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(temporary, "wx", 0o600);
+    fchmodSync(descriptor, 0o600);
+    if (process.platform !== "win32" && (fstatSync(descriptor).mode & 0o777) !== 0o600) {
+      throw new RepoWriteOutcomeCorruptionError("repo-write temporary outcome must have mode 0600");
+    }
+    writeFileSync(descriptor, text, "utf8");
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = undefined;
+    hooks?.beforePublishLink?.({ target, text });
+    try {
+      linkSync(temporary, target);
+    } catch (error) {
+      if (repoWriteOutcomeIsAlreadyExists(error)) {
+        repoWriteOutcomeFsyncExisting(target, hooks, "eexist-observer");
+        repoWriteOutcomeFsyncDirectory(directory, hooks, "eexist-observer");
+        return false;
+      }
+      throw error;
+    }
+    repoWriteOutcomeFsyncDirectory(directory, hooks, "publish");
+    return true;
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+    rmSync(temporary, { force: true });
+  }
+}
+
+export function repoWriteOutcomeReadPrivateText(file: string): {
+  readonly descriptor: number;
+  readonly text: string;
+} {
+  const descriptor = repoWriteOutcomeOpenPrivateRegularFile(file);
+  try {
+    return { descriptor, text: readFileSync(descriptor, "utf8") };
+  } catch (error) {
+    closeSync(descriptor);
+    throw error;
+  }
+}
+
+export function repoWriteOutcomeFsyncOpened(
+  descriptor: number,
+  file: string,
+  hooks: RepoWriteOutcomeDurabilityTestHooks | undefined,
+  reason: RepoWriteOutcomeTargetFsyncReason
+): void {
+  fsyncSync(descriptor);
+  hooks?.afterTargetFsync?.({ reason, target: file });
+}
+
+export function repoWriteOutcomeEnsurePrivateDirectory(directory: string): void {
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const status = lstatSync(directory);
+  if (!status.isDirectory() || status.isSymbolicLink()) {
+    throw new RepoWriteOutcomeCorruptionError("repo-write outcome root must be a real directory");
+  }
+  if (process.platform !== "win32") {
+    chmodSync(directory, 0o700);
+    if ((lstatSync(directory).mode & 0o777) !== 0o700) {
+      throw new RepoWriteOutcomeCorruptionError("repo-write outcome root must have mode 0700");
+    }
+  }
+}
+
+export function repoWriteOutcomeFsyncDirectory(
+  directory: string,
+  hooks: RepoWriteOutcomeDurabilityTestHooks | undefined,
+  reason: RepoWriteOutcomeDirectoryFsyncReason
+): void {
+  if (process.platform === "win32") throw new RepoWriteOutcomeUnsupportedPlatformError();
+  hooks?.beforeDirectoryFsync?.(reason);
+  const descriptor = openSync(directory, "r");
+  try {
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+  hooks?.afterDirectoryFsync?.(reason);
+}
+
+export function repoWriteOutcomeDurablePathExists(file: string): boolean {
+  try {
+    lstatSync(file);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function repoWriteOutcomeFsyncExisting(
+  file: string,
+  hooks: RepoWriteOutcomeDurabilityTestHooks | undefined,
+  reason: RepoWriteOutcomeTargetFsyncReason
+): void {
+  const descriptor = repoWriteOutcomeOpenPrivateRegularFile(file);
+  try {
+    repoWriteOutcomeFsyncOpened(descriptor, file, hooks, reason);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function repoWriteOutcomeOpenPrivateRegularFile(file: string): number {
+  const descriptor = openSync(file, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+  const status = fstatSync(descriptor);
+  if (!status.isFile()) {
+    closeSync(descriptor);
+    throw new RepoWriteOutcomeCorruptionError(
+      `repo-write outcome is not a regular file: ${path.basename(file)}`
+    );
+  }
+  if (status.size <= 0 || status.size > maximumOutcomeBytes) {
+    closeSync(descriptor);
+    throw new RepoWriteOutcomeCorruptionError(
+      `repo-write outcome has an invalid byte length: ${path.basename(file)}`
+    );
+  }
+  if (process.platform !== "win32" && (status.mode & 0o777) !== 0o600) {
+    closeSync(descriptor);
+    throw new RepoWriteOutcomeCorruptionError(
+      `repo-write outcome must have mode 0600: ${path.basename(file)}`
+    );
+  }
+  return descriptor;
+}
+
+function repoWriteOutcomeIsAlreadyExists(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "EEXIST";
+}

--- a/packages/daemon/src/runtime/repo-write-outcome-errors.ts
+++ b/packages/daemon/src/runtime/repo-write-outcome-errors.ts
@@ -6,3 +6,39 @@ export class RepoWriteOutcomeValidationError extends Error {
     this.name = "RepoWriteOutcomeValidationError";
   }
 }
+
+export class RepoWriteOutcomeConflictError extends Error {
+  readonly code = "REPO_WRITE_OUTCOME_CONFLICT";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "RepoWriteOutcomeConflictError";
+  }
+}
+
+export class RepoWriteOutcomeCorruptionError extends Error {
+  readonly code = "REPO_WRITE_OUTCOME_CORRUPT";
+
+  constructor(message: string, options: ErrorOptions = {}) {
+    super(message, options);
+    this.name = "RepoWriteOutcomeCorruptionError";
+  }
+}
+
+export class RepoWriteOutcomeUnsupportedPlatformError extends Error {
+  readonly code = "REPO_WRITE_OUTCOME_PLATFORM_UNSUPPORTED";
+
+  constructor() {
+    super("repo-write outcome durability is unsupported on win32");
+    this.name = "RepoWriteOutcomeUnsupportedPlatformError";
+  }
+}
+
+export class RepoWriteOutcomeGenerationFenceError extends Error {
+  readonly code = "REPO_WRITE_OUTCOME_GENERATION_FENCED";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "RepoWriteOutcomeGenerationFenceError";
+  }
+}

--- a/packages/daemon/src/runtime/repo-write-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-protocol.ts
@@ -1,5 +1,7 @@
 // @slice-activation P5-W2 repo-writer foundation; public recovery routing remains activation work owned by task_01KY6QFFC306JRW8JW4Y2ND2TM.
 import { repoWriteTerminalReceiptMatches } from "./repo-write-terminal-receipt.ts";
+import type { RepoWriteRecoveryDeferredFrame, RepoWriteRecoveryDiagnosticFrame, RepoWriteRecoveryRejectedFrame, RepoWriteTelemetryFrame, RepoWriteTelemetryPhase } from "./repo-write-diagnostic-protocol.ts";
+export type { RepoWriteRecoveryDeferredFrame, RepoWriteRecoveryDiagnosticFrame, RepoWriteRecoveryRejectedFrame, RepoWriteTelemetryFrame, RepoWriteTelemetryPhase } from "./repo-write-diagnostic-protocol.ts";
 export { boundedRepoWriteDiagnostic } from "./repo-write-protocol-diagnostic.ts";
 import {
   decodeRepoWriteBigInt,
@@ -133,25 +135,11 @@ export type RepoWriteOperationLookupResult =
     };
 
 export type RepoWriteStatusFrame = RepoWriteOperationFrame<"status"> & RepoWriteOperationLookupResult;
-export type RepoWriteTelemetryPhase =
-  "queue" | "compile" | "journal" | "git" | "fsync" | "materializer" | "projection" | "total";
-
-export interface RepoWriteTelemetryFrame extends RepoWriteRequestFrame<"telemetry"> {
-  readonly opId?: string;
-  readonly phase: RepoWriteTelemetryPhase;
-  readonly elapsedMs: number;
-}
-export interface RepoWriteRecoveryDeferredFrame extends RepoWriteFrameBase {
-  readonly kind: "recovery-deferred";
-  readonly outerOpId: string;
-  readonly code: string;
-  readonly diagnostic: string;
-}
 
 export type RepoWriteChildMessage =
   RepoWriteReadyFrame | RepoWritePreparedFrame | RepoWriteTerminalFrame | RepoWriteFailureFrame
   | RepoWriteDirectResultFrame | RepoWriteDirectFailureFrame
-  | RepoWriteStatusFrame | RepoWriteTelemetryFrame | RepoWriteRecoveryDeferredFrame
+  | RepoWriteStatusFrame | RepoWriteTelemetryFrame | RepoWriteRecoveryDiagnosticFrame
   | RepoWriteDrainedFrame;
 
 export type RepoWriteMessage = RepoWriteParentMessage | RepoWriteChildMessage;
@@ -203,6 +191,7 @@ export function decodeRepoWriteChildMessage(
   if (frame.kind === "status") return decodeStatus(frame, limits, budget);
   if (frame.kind === "telemetry") return decodeTelemetry(frame, limits);
   if (frame.kind === "recovery-deferred") return decodeRecoveryDeferred(frame, limits);
+  if (frame.kind === "recovery-rejected") return decodeRecoveryRejected(frame, limits);
   if (frame.kind === "drained") return decodeRequestFrame(frame, limits, "drained");
   invalid("$.kind", "child message kind");
 }
@@ -451,6 +440,20 @@ function decodeRecoveryDeferred(
     outerOpId: identifier(frame.outerOpId, "$.outerOpId", limits),
     code: identifier(frame.code, "$.code", limits),
     diagnostic: stringAt(frame.diagnostic, "$.diagnostic", limits.maxDiagnosticBytes)
+  };
+}
+function decodeRecoveryRejected(
+  frame: FrameRecord,
+  limits: RepoWriteProtocolLimits
+): RepoWriteRecoveryRejectedFrame {
+  assertExactKeys(frame, baseKeys(["outerOpId", "code", "diagnostic", "next"]), [], "$");
+  return {
+    ...baseFields(frame),
+    kind: "recovery-rejected",
+    outerOpId: identifier(frame.outerOpId, "$.outerOpId", limits),
+    code: identifier(frame.code, "$.code", limits),
+    diagnostic: stringAt(frame.diagnostic, "$.diagnostic", limits.maxDiagnosticBytes),
+    next: stringAt(frame.next, "$.next", limits.maxDiagnosticBytes)
   };
 }
 function frameBase(value: unknown, limits: RepoWriteProtocolLimits, budget: { nodes: number }): FrameRecord {

--- a/packages/daemon/test/repo-write-authority-recovery-gate.test.ts
+++ b/packages/daemon/test/repo-write-authority-recovery-gate.test.ts
@@ -137,6 +137,70 @@ recoveryTest("historical recovery terminalizes only from matching canonical publ
   );
 });
 
+recoveryTest("immutable historical recovery mismatch is durably rejected and not replayed after restart", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "ha-repo-write-historical-rejected-"));
+  try {
+    const historical = { ...proceedingInput(), generation: 403 };
+    const previous = new DurableRepoWriteOutcomeStoreV1({
+      directory,
+      repoId: historical.repoId,
+      workspaceId: historical.workspaceId,
+      generation: historical.generation
+    }).begin(historical);
+    const current = new DurableRepoWriteOutcomeStoreV1({
+      directory,
+      repoId: historical.repoId,
+      workspaceId: historical.workspaceId,
+      generation: 409
+    });
+    const gate = new RepoWriteAuthorityRecoveryGate({
+      repoId: historical.repoId,
+      workspaceId: historical.workspaceId,
+      generation: 409,
+      store: current,
+      assertCurrentWriterFence: () => undefined,
+      resolveHistoricalPublication: async () => ({
+        commitSha: "a".repeat(40),
+        semanticDigest: historical.authoritySemanticDigest
+      }),
+      recoverHistoricalCommittedReceipt: async () => {
+        throw new Error("AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH");
+      }
+    });
+
+    await gate.recoverHistoricalProceeding(current.listHistoricalProceedings()[0]!);
+
+    assert.equal(current.lookup(previous.outerOpId).state, "outcome-unknown");
+    assert.deepEqual(current.getHistoricalRecoveryRejection(previous.outerOpId), {
+      schema: "repo-write-historical-recovery-rejection/v1",
+      disposition: "permanently-rejected",
+      repoId: historical.repoId,
+      workspaceId: historical.workspaceId,
+      proceedingGeneration: historical.generation,
+      rejectedByGeneration: 409,
+      outerOpId: historical.outerOpId,
+      requestDigest: previous.requestDigest,
+      innerOpId: historical.innerOpId,
+      authoritySemanticDigest: historical.authoritySemanticDigest,
+      code: "AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH"
+    });
+    assert.equal(
+      readdirSync(directory).filter((name) => name.endsWith(".terminal.json")).length,
+      0
+    );
+
+    const restarted = new DurableRepoWriteOutcomeStoreV1({
+      directory,
+      repoId: historical.repoId,
+      workspaceId: historical.workspaceId,
+      generation: 410
+    });
+    assert.deepEqual(restarted.listHistoricalProceedings(), []);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 recoveryTest("historical recovery stays outcome-unknown when publication is absent", async () => {
   const directory = mkdtempSync(path.join(os.tmpdir(), "ha-repo-write-historical-absent-"));
   try {

--- a/packages/daemon/test/repo-write-authority-recovery-gate.test.ts
+++ b/packages/daemon/test/repo-write-authority-recovery-gate.test.ts
@@ -168,7 +168,13 @@ recoveryTest("immutable historical recovery mismatch is durably rejected and not
       }
     });
 
-    await gate.recoverHistoricalProceeding(current.listHistoricalProceedings()[0]!);
+    assert.deepEqual(
+      await gate.recoverHistoricalProceeding(current.listHistoricalProceedings()[0]!),
+      {
+        disposition: "permanently-rejected",
+        code: "AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH"
+      }
+    );
 
     assert.equal(current.lookup(previous.outerOpId).state, "outcome-unknown");
     assert.deepEqual(current.getHistoricalRecoveryRejection(previous.outerOpId), {
@@ -196,6 +202,52 @@ recoveryTest("immutable historical recovery mismatch is durably rejected and not
       generation: 410
     });
     assert.deepEqual(restarted.listHistoricalProceedings(), []);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+recoveryTest("NON_LINEAR semicolon diagnostic is durably rejected once", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "ha-repo-write-historical-nonlinear-"));
+  try {
+    const historical = { ...proceedingInput(), generation: 403 };
+    const previous = new DurableRepoWriteOutcomeStoreV1({
+      directory,
+      repoId: historical.repoId,
+      workspaceId: historical.workspaceId,
+      generation: historical.generation
+    }).begin(historical);
+    const current = new DurableRepoWriteOutcomeStoreV1({
+      directory,
+      repoId: historical.repoId,
+      workspaceId: historical.workspaceId,
+      generation: 409
+    });
+    const gate = new RepoWriteAuthorityRecoveryGate({
+      repoId: historical.repoId,
+      workspaceId: historical.workspaceId,
+      generation: 409,
+      store: current,
+      assertCurrentWriterFence: () => undefined,
+      resolveHistoricalPublication: async () => {
+        throw new Error(
+          "AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR;expectedPreviousHead=abc"
+        );
+      }
+    });
+
+    assert.deepEqual(
+      await gate.recoverHistoricalProceeding(current.listHistoricalProceedings()[0]!),
+      {
+        disposition: "permanently-rejected",
+        code: "AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR"
+      }
+    );
+    assert.equal(
+      current.getHistoricalRecoveryRejection(previous.outerOpId)?.code,
+      "AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR"
+    );
+    assert.deepEqual(current.listHistoricalProceedings(), []);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }

--- a/packages/daemon/test/repo-write-client.test.ts
+++ b/packages/daemon/test/repo-write-client.test.ts
@@ -191,6 +191,21 @@ test("reports historical recovery diagnostics before READY without failing the w
     code: "GIT_PATH_NOT_SAFE",
     diagnostic: "historical recovery remains fail-closed"
   });
+
+  transport.emit({
+    ...childFrame("recovery-rejected"),
+    outerOpId: "repo-write:historical-rejected",
+    code: "AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH",
+    diagnostic: "Historical recovery evidence conflicts with the canonical publication.",
+    next: "Run `ha daemon logs --errors --json`, then escalate for operator-reviewed repair."
+  });
+  assert.deepEqual(diagnostics[1], {
+    ...childFrame("recovery-rejected"),
+    outerOpId: "repo-write:historical-rejected",
+    code: "AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH",
+    diagnostic: "Historical recovery evidence conflicts with the canonical publication.",
+    next: "Run `ha daemon logs --errors --json`, then escalate for operator-reviewed repair."
+  });
 });
 
 test("resolves an exact rejected terminal receipt instead of converting it to transport failure", async () => {

--- a/packages/daemon/test/repo-write-historical-recovery-rejection.test.ts
+++ b/packages/daemon/test/repo-write-historical-recovery-rejection.test.ts
@@ -1,0 +1,149 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  DurableRepoWriteOutcomeStoreV1,
+  repoWriteActorStampDigestV1,
+  type RepoWriteProceedingInputV1
+} from "../src/index.ts";
+
+const rejectionTest = process.platform === "win32" ? test.skip : test;
+
+rejectionTest("corrupt optional recovery sidecar degrades to replay without hiding other proceedings", () => {
+  withDirectory((directory) => {
+    const historicalAxes = { ...axes(), generation: 8 };
+    const currentAxes = { ...axes(), generation: 9 };
+    const previous = new DurableRepoWriteOutcomeStoreV1({ directory, ...historicalAxes });
+    const corruptInput = proceedingInput("outer-corrupt-sidecar", 8);
+    const otherInput = proceedingInput("outer-unrelated-proceeding", 8);
+    const corruptProceeding = previous.begin(corruptInput);
+    previous.begin(otherInput);
+    const current = new DurableRepoWriteOutcomeStoreV1({ directory, ...currentAxes });
+    current.rejectHistoricalRecovery({
+      ...currentAxes,
+      outerOpId: corruptInput.outerOpId,
+      requestDigest: corruptProceeding.requestDigest,
+      code: "AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH"
+    });
+    const sidecar = readdirSync(directory).find((name) =>
+      name.endsWith(".recovery-rejected.json"));
+    assert.ok(sidecar);
+    writeFileSync(path.join(directory, sidecar), "{broken-json\n");
+
+    assert.deepEqual(
+      current.listHistoricalProceedings().map((outcome) => outcome.outerOpId).sort(),
+      [corruptInput.outerOpId, otherInput.outerOpId].sort()
+    );
+  });
+});
+
+rejectionTest("historical recovery rejection is idempotent across legal writer generations", () => {
+  withDirectory((directory) => {
+    const previous = new DurableRepoWriteOutcomeStoreV1({
+      directory,
+      ...axes(),
+      generation: 8
+    });
+    const input = proceedingInput("outer-cross-generation-rejection", 8);
+    const proceeding = previous.begin(input);
+    const generationNine = writer(directory, 9);
+    const first = reject(generationNine, input, proceeding.requestDigest, 9);
+    assert.deepEqual(reject(generationNine, input, proceeding.requestDigest, 9), first);
+
+    const generationTen = writer(directory, 10);
+    assert.deepEqual(reject(generationTen, input, proceeding.requestDigest, 10), first);
+
+    const reverseInput = proceedingInput("outer-newer-generation-wins", 8);
+    const reverseProceeding = previous.begin(reverseInput);
+    const newerWinner = reject(generationTen, reverseInput, reverseProceeding.requestDigest, 10);
+    assert.deepEqual(
+      reject(generationNine, reverseInput, reverseProceeding.requestDigest, 9),
+      newerWinner
+    );
+  });
+});
+
+function writer(directory: string, generation: number): DurableRepoWriteOutcomeStoreV1 {
+  return new DurableRepoWriteOutcomeStoreV1({ directory, ...axes(), generation });
+}
+
+function reject(
+  store: DurableRepoWriteOutcomeStoreV1,
+  input: RepoWriteProceedingInputV1,
+  requestDigest: string,
+  generation: number
+) {
+  return store.rejectHistoricalRecovery({
+    ...axes(),
+    generation,
+    outerOpId: input.outerOpId,
+    requestDigest,
+    code: "AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH"
+  });
+}
+
+function proceedingInput(outerOpId: string, generation: number): RepoWriteProceedingInputV1 {
+  const actor = actorStamp();
+  return {
+    ...axes(),
+    generation,
+    outerOpId,
+    innerOpId: `inner-${outerOpId}`,
+    authoritySemanticDigest: "1".repeat(64),
+    canonicalCommand: {
+      commandName: "task.create",
+      actor,
+      context: { requestId: "request-1", presentation: "json" },
+      payload: { parent: null, title: "性能优化" }
+    },
+    authenticatedContext: {
+      actor,
+      presentation: { json: true }
+    },
+    receiptSeed: {
+      schema: "repo-write-receipt-seed/v1",
+      renderer: "cli-command-receipt/v2@1",
+      generatedAt: "2026-07-23T12:00:00.000Z",
+      command: "task create",
+      action: "create",
+      actorStampDigest: repoWriteActorStampDigestV1(actor)
+    },
+    recoveryContext: {
+      authorityEnvelopeDigest: "1".repeat(64),
+      bindingTokenDigest: "2".repeat(64)
+    }
+  };
+}
+
+function axes() {
+  return {
+    repoId: "repo-canonical",
+    workspaceId: "workspace-canonical"
+  } as const;
+}
+
+function actorStamp() {
+  return {
+    personId: "person_zeyu",
+    displayName: "Zeyu Li",
+    providerId: "local-socket",
+    credential: {
+      kind: "unix-socket-owner-boundary",
+      issuer: "local-daemon",
+      subject: "person_zeyu"
+    }
+  } as const;
+}
+
+function withDirectory(run: (directory: string) => void): void {
+  const root = mkdtempSync(path.join(os.tmpdir(), "ha-recovery-rejection-"));
+  const directory = path.join(root, "outcomes");
+  try {
+    run(directory);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}

--- a/packages/daemon/test/repo-write-protocol.test.ts
+++ b/packages/daemon/test/repo-write-protocol.test.ts
@@ -76,6 +76,22 @@ test("historical recovery diagnostics carry a bounded startup failure without re
     parseRepoWriteChildMessage(stringifyRepoWriteChildMessage(diagnostic)),
     diagnostic
   );
+
+  const rejected: RepoWriteChildMessage = {
+    ...base("recovery-rejected"),
+    outerOpId: "repo-write:historical-rejected",
+    code: "AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH",
+    diagnostic: "Historical recovery evidence conflicts with the canonical publication.",
+    next: "Run `ha daemon logs --errors --json`, then escalate for operator-reviewed repair."
+  };
+  assert.deepEqual(
+    parseRepoWriteChildMessage(stringifyRepoWriteChildMessage(rejected)),
+    rejected
+  );
+  assert.throws(() => decodeRepoWriteChildMessage({
+    ...rejected,
+    authorityTerminalProof: { disposition: "rejected" }
+  }), protocolInvalid);
 });
 
 test("volatile direct execution carries an exact receipt without durable recovery fields", () => {


### PR DESCRIPTION
# English

## Summary

Production writes degraded to "receipt always times out, write eventually lands" after a daemon restart. Root cause is **not** a regression from #1156: writer children enumerate historical PROCEEDINGs before READY, and while a successful recovery writes a terminal outcome, a **failed** one only emitted a diagnostic and persisted nothing. The same permanently-failing operations therefore replayed on every writer-child activation — measured at ~4.2s per startup for 18 immutable failures (61 `AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH` + 12 `AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR` events across 15 + 3 unique outer ops, all created before the #1156 deployment). Stacked on request execution, that crossed the 30s direct watchdog; the 35s JSON-RPC timeout is downstream, not causal.

Measurements deliberately ruled out the alternatives before changing anything: a full commit/merge/branch-delete cycle on the production inner ledger takes 0.34–0.58s, so raw Git is not the 25s component and **the deadline was not raised**. The old #1086 empty-blob bug is not recurring (`known !== undefined` still in place).

The fix gives an immutable historical recovery failure exactly one durable disposition, so it settles once instead of replaying forever.

## What Changed

- New immutable `.recovery-rejected.json` sidecar (`repo-write-historical-recovery-rejection/v1`): fsync, link-once publication, 0600/0700, canonical encoding, fail-closed validation, bound to repo/workspace/generation/outerOpId/requestDigest/innerOpId/semanticDigest.
- Only two error codes may settle: `AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH`, `AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR`. `NOT_FOUND`, `NOT_UNIQUE`, fence/digest mismatches, I/O and unknown codes stay deferred — absence of a publication can become false later, so terminalizing it would weaken proof.
- The outer operation still reports `outcome-unknown`; no fabricated `REJECTED`/`COMMITTED` authority proof.
- A corrupt, unverifiable or mis-bound sidecar is treated as **absent** (the proceeding replays as before) — an optional optimization must never be worse broken than missing. Required proceeding/terminal files remain fail-closed.
- New `recovery-rejected` diagnostic frame carrying the reason and the manual-repair next step, so a settled failure is observable rather than silent. The protocol forbids it from carrying authority terminal proof.
- Idempotent re-publication compares binding fields and ignores `rejectedByGeneration` (still range-validated), so a cross-generation race no longer produces a bogus conflict.
- Store internals split into focused modules to stay under the 600-line complexity gate.

## Task And Scope

- Harness task: task_01KYVK7KFF81NAFSNCZH7Z6FBV
- Branch: codex/wal-recovery
- Public scope: daemon writer-child historical recovery disposition + diagnostics
- Private planning/evidence updated: yes
- Out of scope: the 30s deadline constant, WAL/watermark contents, proof semantics, CI/gate surface

## Version Impact

- Version: no version change because internal daemon correctness fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — daemon write-path recovery disposition (production write path)
- Protected surface scope: new durable rejection sidecar + startup scan filter + diagnostic frame; no proof relaxation, no deadline change, no gate change
- Authority: standing flow-defect priority (production write path degraded); task task_01KYVK7KFF81NAFSNCZH7Z6FBV
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: n/a
- Break-glass scope: n/a
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: 3b339bd2
- Branch merge-base with `origin/main`: 3b339bd2
- Last `git fetch origin` time: 2026-07-31
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/wal-recovery`
- Private evidence commit/path: harness/tasks/task_01KYVK7KFF81NAFSNCZH7Z6FBV-.../artifacts/implementation-report.md and artifacts/daemon-evidence-2026-07-31.log
- Reviewer evidence path: blind-review findings + R2 disposition in the same report
- GitHub Actions `rewrite-ci` run URL: (filled after CI)
- [x] `git diff --check`
- [x] `npm run check:stop-point` — check:local green, 27/27 gates; affected fast 586/586, contract 238/238 (1 expected Windows skip)
- [x] Directed regression 64/64; red-before/green-after for the replay storm, the corrupt-sidecar path, the cross-generation race, and NON_LINEAR message parsing
- [ ] GitHub Actions `rewrite-ci` passed (authoritative full gate)
- Not run, and why: full CI runs on this PR; production verification happens after deploy per the runbook.

## Review Evidence

- Self-review: CEO verified the root-cause chain (three candidates measured, #1156 diff shown not to touch the recovery path, Git timing measured), the narrow terminalization whitelist, and that the corrupt-sidecar path degrades to replay rather than to a crash.
- Reviewer subagent: one blind adversarial round (production write path). P1 (corrupt sidecar crashed the writer child on startup, wedging every write) and both P2s confirmed and fixed in R2 with red/green regressions; P3 test-coverage gaps closed.
- Human review: not required.
- Blocking findings: none remaining.

## Residual Risk

- The two historical `NOT_FOUND` outcomes remain honest unknowns and can still be retried.
- `task complete` stays on the volatile direct lane. This removes the measured pre-READY replay tax; if production still approaches 30s afterwards, the next step is to measure the authority-state path or move the operation to the durable lane — not to raise the deadline.
- The first upgraded child startup performs one fsynced sidecar publication per immutable historical failure (bounded, not repeated).

## References

- Task: task_01KYVK7KFF81NAFSNCZH7Z6FBV
- Evidence: artifacts/implementation-report.md, artifacts/daemon-evidence-2026-07-31.log
- Context: #1156 (exposed this debt via restart, not its cause)

---

# 中文

## 概要

daemon 重启后生产写退化为「回执必超时、写最终会落」。根因**不是** #1156 回归:writer child 在 READY 前枚举历史 PROCEEDING,成功恢复会写终态,**失败只发诊断、不落任何处置**,于是同一批永久失败在每次 child 启动重放——实测 18 条不可变失败每轮约 4.2 秒(61 次 `AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH` + 12 次 `AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR`,分属 15 + 3 个 outer op,全部创建于 #1156 部署之前)。叠加请求执行时间即撞 30 秒 direct watchdog;35 秒 JSON-RPC 超时是下游结果,不是原因。

动手前先测量排除了其它候选:生产内层 ledger 跑完整 commit/merge/删分支循环只要 0.34–0.58 秒,原始 Git 不是那 25 秒的构成,**因此没有调大 deadline**;#1086 空 blob 旧因也已证伪(`known !== undefined` 仍在)。

修复让不可变的历史恢复失败恰好落一次持久处置,不再永远重放。

## 改动内容

- 新增不可变 `.recovery-rejected.json` sidecar(`repo-write-historical-recovery-rejection/v1`):fsync、link-once 发布、0600/0700、canonical 编码、读时 fail-closed 校验,绑定 repo/workspace/generation/outerOpId/requestDigest/innerOpId/semanticDigest。
- 仅两个错误码可终态化:`AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH`、`AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR`。`NOT_FOUND`、`NOT_UNIQUE`、fence/digest 失配、IO 与未知码继续 deferred——publication 缺席可能事后变假,终态化会削弱 proof。
- 外层 op 仍报 `outcome-unknown`,不伪造 `REJECTED`/`COMMITTED` 的 authority proof。
- 损坏、不可校验或绑定不匹配的 sidecar 一律**按不存在处理**(该 proceeding 照旧重放)——可选优化坏掉绝不能比它不存在更糟;必需的 proceeding/terminal 文件仍 fail-closed。
- 新增 `recovery-rejected` 诊断帧,带原因与人工修复下一步,让已终态化的失败可观测而非静默;协议禁止它携带 authority 终态 proof。
- 幂等重发布比较 binding 字段并忽略 `rejectedByGeneration`(区间仍校验),跨代竞争不再产生虚假冲突。
- store 内部拆分模块以过 600 行复杂度门。

## 任务与范围

- Harness 任务:task_01KYVK7KFF81NAFSNCZH7Z6FBV
- 分支:codex/wal-recovery
- 公开范围:daemon writer-child 历史恢复处置 + 诊断
- 私有规划/证据已更新:是
- 范围外:30s deadline 常量、WAL/watermark 内容、proof 语义、CI/gate 面

## 版本影响

- 版本:不改版本,原因是 daemon 内部正确性修复
- 发布影响:不发布

## 治理声明

- 触及 protected surface:是——daemon 写路恢复处置(生产写路)
- 范围:新增持久拒绝 sidecar + 启动扫描过滤 + 诊断帧;proof 零放宽、deadline 零改动、门零改动
- 授权:流转缺陷最高优先常设授权(生产写路退化);任务 task_01KYVK7KFF81NAFSNCZH7Z6FBV
- 机检边界:本 PR 只断言声明存在;是否真实充分由评审判断。
- Break-glass:否
- 原因/范围:不适用
- 后续治理任务:无

## 验证

- Base `origin/main` SHA:3b339bd2
- merge-base:3b339bd2
- 最近 `git fetch origin`:2026-07-31
- 同步方式:无需
- 公开 diff 命令:`git diff origin/main...codex/wal-recovery`
- 私有证据:任务 artifacts/implementation-report.md 与 artifacts/daemon-evidence-2026-07-31.log
- 评审证据:盲评 findings + R2 处置(同报告)
- `rewrite-ci` run URL:(CI 后回填)
- [x] `git diff --check`
- [x] `npm run check:stop-point`——check:local 全绿 27/27;affected fast 586/586、contract 238/238(1 个预期 Windows skip)
- [x] 定向回归 64/64;重放风暴、损坏 sidecar、跨代竞争、NON_LINEAR message 解析四项均有修前红/修后绿
- [ ] GitHub Actions `rewrite-ci` 绿(权威完整门)
- 未运行及原因:完整 CI 在本 PR 上跑;生产验证按 runbook 在部署后执行。

## 评审证据

- 自评:CEO 核根因链(三候选全测量、#1156 diff 证明未触恢复路径、Git 耗时实测)、终态化白名单之窄、以及损坏 sidecar 路径降级为重放而非崩溃。
- 评审 subagent:一轮对抗盲评(生产写路)。P1(损坏 sidecar 令 writer child 启动崩溃,楔死全部写)与两条 P2 确认并在 R2 修复,红绿齐全;P3 测试缺口补齐。
- 人工评审:不需要。
- 阻塞 findings:无剩余。

## 残留风险

- 两条历史 `NOT_FOUND` 仍是诚实的未知,可继续重试。
- `task complete` 仍在易失的 direct lane。本修复去掉了实测的 READY 前重放税;若生产验证后仍逼近 30 秒,下一步是测量 authority-state 路径或改走 durable lane,**不是**调大 deadline。
- 升级后首次 child 启动会为每条不可变历史失败做一次 fsync sidecar 发布(有界,不重复)。

## 参考

- 任务:task_01KYVK7KFF81NAFSNCZH7Z6FBV
- 证据:artifacts/implementation-report.md、artifacts/daemon-evidence-2026-07-31.log
- 上下文:#1156(重启显形了这笔债,不是成因)
