### PR TITLE
fix(daemon): keep large doc sync payloads off IPC and fail closed on references

### DIFF
--- a/packages/application/src/doc-sync.ts
+++ b/packages/application/src/doc-sync.ts
@@ -130,6 +130,17 @@ export type DocSyncSubmitResultV1 =
     readonly forbiddenTouches?: ReadonlyArray<DocSyncForbiddenTouchV1>;
     readonly unresolvedTouches?: ReadonlyArray<{ readonly path: string; readonly reason: string; readonly bearing?: string; readonly zoneClass?: string }>;
     readonly postApplyViolations?: ReadonlyArray<DocSyncForbiddenTouchV1>;
+    readonly ipcError?: {
+      readonly name: "RepoWriteIpcPayloadTooLargeError";
+      readonly code: "REPO_WRITE_IPC_PAYLOAD_TOO_LARGE";
+      readonly delivery: "definitely-not-sent";
+      readonly sender: "parent" | "child";
+      readonly path: string;
+      readonly boundary: string;
+      readonly actualBytes: number;
+      readonly maximumBytes: number;
+      readonly excessBytes: number;
+    };
   };
 
 export interface DocSyncValidationResult {

--- a/packages/cli/src/composition/repo-write-child-entrypoint.ts
+++ b/packages/cli/src/composition/repo-write-child-entrypoint.ts
@@ -13,10 +13,14 @@ import {
   failureReceipt,
   makeDaemonQueuedWriteCoordinator,
   makeDocSyncService,
+  materializeDocSyncWriterWorkingTree,
   successReceipt,
   type HarnessDaemonRuntime
 } from "@harness-anything/daemon";
-import type { DocSyncSubmitRequestV1 } from "@harness-anything/application";
+import type {
+  DocSyncSubmitRequestV1,
+  DocSyncSubmitResultV1
+} from "@harness-anything/application";
 import { resolveHarnessLayout } from "@harness-anything/kernel";
 import { defaultCliAdapterProvider } from "./adapter-registry.ts";
 import { cliDaemonCommandHostServices } from "./daemon-command-host-services.ts";
@@ -204,6 +208,31 @@ export async function runRepoWriteChildEntrypoint(
           "The writer child received no doc-sync request."
         );
       }
+      const materialized = materializeDocSyncWriterWorkingTree(
+        {
+          rootDir: config.canonicalRoot,
+          ...(layoutOverrides ? { layoutOverrides } : {})
+        },
+        wireCommand.request
+      );
+      if (!materialized.ok) {
+        const result: DocSyncSubmitResultV1 = {
+          ok: false,
+          _tag: "WriteRejected",
+          schema: "daemon.doc-sync-submit-result/v1",
+          status: "rejected",
+          intentId: wireCommand.request.payload.intentId,
+          code: "doc_sync_invalid_payload",
+          reason: `The writer child rejected a working-tree reference: ${materialized.reason}`,
+          retryable: false
+        };
+        return failureReceipt(
+          "repo.doc.sync.submit",
+          result.code,
+          result.reason,
+          { data: result as unknown as import("@harness-anything/daemon").JsonObject }
+        );
+      }
       const attribution = daemonActorAttribution(decoded.actor, decoded.executor);
       const result = await makeDocSyncService({
         rootDir: config.canonicalRoot,
@@ -220,7 +249,7 @@ export async function runRepoWriteChildEntrypoint(
               : {})
           }
         )
-      }).submit(wireCommand.request);
+      }).submit(materialized.request);
       return result.ok
         ? successReceipt("repo.doc.sync.submit", "completed repo.doc.sync.submit", result as unknown as import("@harness-anything/daemon").JsonObject)
         : failureReceipt("repo.doc.sync.submit", result.code, result.reason, {

--- a/packages/cli/test/repo-write-child-production-cutover.test.ts
+++ b/packages/cli/test/repo-write-child-production-cutover.test.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 import {
+  buildDocSyncSubmitRequest,
   createDaemonGenerationWitness,
   calculateDaemonArtifactIdentity,
   decodeRepoWriteCommandReceiptV2,
@@ -30,6 +31,8 @@ import {
 } from "@harness-anything/kernel";
 import { daemonActorAttribution } from "../src/composition/actor-attribution.ts";
 import { defaultCliAdapterProvider } from "../src/composition/adapter-registry.ts";
+import { cliDaemonServiceHostServices } from "../src/composition/daemon-service-host-services.ts";
+import { dispatchDocSyncSubmitToWriter } from "../../daemon/src/service/doc-sync-writer-dispatch.ts";
 import {
   productionAuthorityActor,
   productionAuthorityConnection
@@ -219,6 +222,100 @@ cutoverTest("production child owns the only writer lock and restart lookup retur
     await first?.stop().catch(() => undefined);
     await restarted?.stop().catch(() => undefined);
     await parentReader?.stop().catch(() => undefined);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+cutoverTest("doc-sync submits a working-tree file larger than the repo-writer IPC frame", async () => {
+  const fixture = createProductionAuthorityLifecycleFixture();
+  const userRoot = path.join(fixture.root, "daemon-user");
+  const endpoint = path.join(userRoot, "daemon.sock");
+  let supervisor: RepoWriteProcessSupervisor | undefined;
+  try {
+    mkdirSync(path.join(fixture.repoRoot, "tools"), { recursive: true });
+    writeFileSync(
+      path.join(fixture.repoRoot, "tools/write-road-registry.json"),
+      readFileSync(fileURLToPath(new URL("../../../tools/write-road-registry.json", import.meta.url)))
+    );
+    const largeRelativePath = "tasks/task_A/artifacts/subject-logs/large.raw.jsonl";
+    const largeAbsolutePath = path.join(fixture.authoredRoot, largeRelativePath);
+    mkdirSync(path.dirname(largeAbsolutePath), { recursive: true });
+    writeFileSync(largeAbsolutePath, `${"x".repeat(1_100_000)}\n`, "utf8");
+
+    const actor = productionAuthorityActor();
+    const request = buildDocSyncSubmitRequest(
+      fixture.repoRoot,
+      "canonical",
+      [largeRelativePath],
+      { kind: "agent", id: "codex" },
+      cliDaemonServiceHostServices.docSync,
+      {
+        runtime: "codex",
+        sessionId: "session-large-doc-sync",
+        source: "manual",
+        detectedAt: "2026-07-31T00:00:00.000Z"
+      }
+    );
+    assert.ok(Buffer.byteLength(JSON.stringify(request)) > 1024 * 1024);
+
+    const machineId = readOrCreateDaemonMachineId(userRoot);
+    const generationRecord = publishNextDaemonGeneration({
+      userRoot,
+      endpointIdentity: endpoint,
+      machineId,
+      daemonInstanceId: "production-child-large-doc-sync-test"
+    });
+    supervisor = new RepoWriteProcessSupervisor({
+      repoId: "canonical",
+      generation: generationRecord.daemonGeneration,
+      expectedArtifactIdentity: entrypointArtifactIdentity,
+      spawn: () => forkRepoWriteProcess({
+        modulePath: entrypoint,
+        args: [
+          "__repo-write-child",
+          encodeRepoWriteChildLaunchConfig({
+            schema: repoWriteChildLaunchConfigSchema,
+            repoId: "canonical",
+            canonicalRoot: fixture.repoRoot,
+            authoredRoot: "harness",
+            authorityManifest: fixture.manifestPath,
+            userRoot,
+            endpointIdentity: endpoint,
+            machineId,
+            generation: generationRecord.daemonGeneration,
+            entrypointArtifactIdentity,
+            runtimePolicy: defaultDaemonRuntimePolicy
+          })
+        ],
+        cwd: fixture.repoRoot,
+        env: { ...process.env, HARNESS_DAEMON_SERVER_HOST: "1" }
+      })
+    });
+    await supervisor.start();
+
+    const result = await dispatchDocSyncSubmitToWriter({
+      rootDir: fixture.repoRoot,
+      request,
+      actor,
+      executor: { kind: "agent", id: "codex" },
+      authority: {
+        available: true,
+        context: productionAuthorityConnection(actor),
+        assertActive: () => undefined
+      },
+      supervisor
+    });
+
+    assert.equal(result.ok, true, JSON.stringify(result));
+    assert.equal(fixtureGit(fixture.authoredRoot, "status", "--short"), "");
+    assert.equal(fixtureGit(
+      fixture.authoredRoot,
+      "cat-file",
+      "-s",
+      `sessions/session-large-doc-sync:${largeRelativePath}`
+    ), "1100001");
+  } finally {
+    await supervisor?.stop().catch(() => undefined);
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -100,6 +100,7 @@ export * from "./lifecycle/reservation-reconciler.ts";
 export * from "./lifecycle/run-daemon-serve.ts";
 export * from "./service/command-service.ts";
 export * from "./service/doc-sync-service.ts";
+export * from "./service/doc-sync-writer-working-tree.ts";
 export * from "./service/service-host.ts";
 export * from "./service/status-payload.ts";
 export * from "./protocol/receipt-envelope.ts";

--- a/packages/daemon/src/runtime/repo-write-client-direct.ts
+++ b/packages/daemon/src/runtime/repo-write-client-direct.ts
@@ -20,6 +20,7 @@ import {
 } from "./repo-write-client-timeout.ts";
 import {
   RepoWriteDirectOutcomeUnknownError,
+  RepoWriteIpcPayloadTooLargeError,
   RepoWriteNotStartedError,
   RepoWriteSendDeliveryError
 } from "./repo-write-client-errors.ts";
@@ -234,6 +235,10 @@ export class RepoWriteDirectClientLane {
     if (!pending) return;
     clearTimeout(pending.timer);
     this.pending.delete(requestId);
+    if (error instanceof RepoWriteIpcPayloadTooLargeError) {
+      pending.reject(error);
+      return;
+    }
     const message = error instanceof Error ? error.message : String(error);
     const definitelyNotSent = synchronous
       || (error instanceof RepoWriteSendDeliveryError

--- a/packages/daemon/src/runtime/repo-write-client-errors.ts
+++ b/packages/daemon/src/runtime/repo-write-client-errors.ts
@@ -18,6 +18,41 @@ export class RepoWriteSendDeliveryError extends Error {
   }
 }
 
+export class RepoWriteIpcPayloadTooLargeError extends RepoWriteSendDeliveryError {
+  readonly code = "REPO_WRITE_IPC_PAYLOAD_TOO_LARGE" as const;
+  readonly sender: "parent" | "child";
+  readonly path: string;
+  readonly boundary: string;
+  readonly actualBytes: number;
+  readonly maximumBytes: number;
+  readonly excessBytes: number;
+
+  constructor(
+    sender: "parent" | "child",
+    path: string,
+    boundary: string,
+    actualBytes: number,
+    maximumBytes: number,
+    options: { readonly cause?: unknown } = {}
+  ) {
+    const excessBytes = actualBytes - maximumBytes;
+    super(
+      "definitely-not-sent",
+      `Repo writer ${sender} IPC payload is too large at ${path}: ${boundary} is `
+        + `${actualBytes} bytes, limit ${maximumBytes} bytes, over by ${excessBytes} bytes. `
+        + "Next: split the request or send large content by working-tree path or attachment reference.",
+      options
+    );
+    this.name = "RepoWriteIpcPayloadTooLargeError";
+    this.sender = sender;
+    this.path = path;
+    this.boundary = boundary;
+    this.actualBytes = actualBytes;
+    this.maximumBytes = maximumBytes;
+    this.excessBytes = excessBytes;
+  }
+}
+
 export class RepoWriteClientCapacityError extends Error {
   readonly code = "REPO_WRITE_PENDING_LIMIT" as const;
 

--- a/packages/daemon/src/runtime/repo-write-client-errors.ts
+++ b/packages/daemon/src/runtime/repo-write-client-errors.ts
@@ -38,7 +38,7 @@ export class RepoWriteIpcPayloadTooLargeError extends RepoWriteSendDeliveryError
     const excessBytes = actualBytes - maximumBytes;
     super(
       "definitely-not-sent",
-      `Repo writer ${sender} IPC payload is too large at ${path}: ${boundary} is `
+      `Repo writer ${sender} IPC payload cannot be sent because it is too large at ${path}: ${boundary} is `
         + `${actualBytes} bytes, limit ${maximumBytes} bytes, over by ${excessBytes} bytes. `
         + "Next: split the request or send large content by working-tree path or attachment reference.",
       options

--- a/packages/daemon/src/runtime/repo-write-client.ts
+++ b/packages/daemon/src/runtime/repo-write-client.ts
@@ -38,6 +38,7 @@ import {
   RepoWriteClientCapacityError,
   RepoWriteClientClosedError,
   RepoWriteDrainError,
+  RepoWriteIpcPayloadTooLargeError,
   RepoWriteLookupError,
   RepoWriteNotStartedError,
   RepoWriteOutcomeUnknownError,
@@ -50,6 +51,7 @@ export {
   RepoWriteClientCapacityError,
   RepoWriteClientClosedError,
   RepoWriteDrainError,
+  RepoWriteIpcPayloadTooLargeError,
   RepoWriteLookupError,
   RepoWriteNotStartedError,
   RepoWriteOutcomeUnknownError,
@@ -540,6 +542,10 @@ export class RepoWriteClient {
     if (!pending) return;
     clearTimeout(pending.timer);
     this.pending.delete(requestId);
+    if (error instanceof RepoWriteIpcPayloadTooLargeError) {
+      pending.reject(error);
+      return;
+    }
     const message = error instanceof Error ? error.message : String(error);
     const definitelyNotSent = synchronous
       || (error instanceof RepoWriteSendDeliveryError && error.delivery === "definitely-not-sent");

--- a/packages/daemon/src/runtime/repo-write-ipc-shared.ts
+++ b/packages/daemon/src/runtime/repo-write-ipc-shared.ts
@@ -1,5 +1,9 @@
 // @slice-activation P5-W2 repo-writer IPC primitives shared by parent and child transports.
-import { RepoWriteSendDeliveryError } from "./repo-write-client.ts";
+import {
+  RepoWriteIpcPayloadTooLargeError,
+  RepoWriteSendDeliveryError
+} from "./repo-write-client.ts";
+import { RepoWriteProtocolDecodeError } from "./repo-write-protocol-scalars.ts";
 
 export function repoWriteIpcJsonText(value: unknown): string {
   let text: string | undefined;
@@ -20,6 +24,16 @@ export function serializeRepoWriteIpcFrame<T>(
   try {
     return JSON.parse(stringify(message)) as object;
   } catch (error) {
+    if (error instanceof RepoWriteProtocolDecodeError && error.limit) {
+      throw new RepoWriteIpcPayloadTooLargeError(
+        sender,
+        error.limit.path,
+        error.limit.boundary,
+        error.limit.actual,
+        error.limit.maximum,
+        { cause: error }
+      );
+    }
     throw new RepoWriteSendDeliveryError(
       "definitely-not-sent",
       `Repo writer ${sender} frame could not be serialized for IPC.`,

--- a/packages/daemon/src/runtime/repo-write-protocol-errors.ts
+++ b/packages/daemon/src/runtime/repo-write-protocol-errors.ts
@@ -1,0 +1,27 @@
+import { RepoWriteProtocolDecodeError } from "./repo-write-protocol-scalars.ts";
+
+export function invalidRepoWriteProtocol(path: string, expected: string): never {
+  throw new RepoWriteProtocolDecodeError(
+    "REPO_WRITE_PROTOCOL_INVALID",
+    `Invalid repo writer IPC at ${boundedProtocolPath(path)}: expected ${expected}.`
+  );
+}
+
+export function limitRepoWriteProtocol(
+  path: string,
+  boundary: string,
+  actual?: number,
+  maximum?: number
+): never {
+  throw new RepoWriteProtocolDecodeError(
+    "REPO_WRITE_PROTOCOL_LIMIT",
+    `Repo writer IPC limit exceeded at ${boundedProtocolPath(path)}: ${boundary}.`,
+    actual === undefined || maximum === undefined
+      ? undefined
+      : { path: boundedProtocolPath(path), boundary, actual, maximum }
+  );
+}
+
+function boundedProtocolPath(path: string): string {
+  return path.length <= 160 ? path : `${path.slice(0, 157)}...`;
+}

--- a/packages/daemon/src/runtime/repo-write-protocol-scalars.ts
+++ b/packages/daemon/src/runtime/repo-write-protocol-scalars.ts
@@ -12,11 +12,22 @@ export interface RepoWriteEncodedBytes {
 
 export class RepoWriteProtocolDecodeError extends Error {
   readonly code: "REPO_WRITE_PROTOCOL_INVALID" | "REPO_WRITE_PROTOCOL_LIMIT";
+  readonly limit?: {
+    readonly path: string;
+    readonly boundary: string;
+    readonly actual: number;
+    readonly maximum: number;
+  };
 
-  constructor(code: RepoWriteProtocolDecodeError["code"], message: string) {
+  constructor(
+    code: RepoWriteProtocolDecodeError["code"],
+    message: string,
+    limit?: RepoWriteProtocolDecodeError["limit"]
+  ) {
     super(message);
     this.name = "RepoWriteProtocolDecodeError";
     this.code = code;
+    this.limit = limit;
   }
 }
 

--- a/packages/daemon/src/runtime/repo-write-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-protocol.ts
@@ -5,9 +5,12 @@ export type { RepoWriteRecoveryDeferredFrame, RepoWriteRecoveryDiagnosticFrame, 
 export { boundedRepoWriteDiagnostic } from "./repo-write-protocol-diagnostic.ts";
 import {
   decodeRepoWriteBigInt,
-  decodeRepoWriteBytes,
-  RepoWriteProtocolDecodeError
+  decodeRepoWriteBytes
 } from "./repo-write-protocol-scalars.ts";
+import {
+  invalidRepoWriteProtocol as invalid,
+  limitRepoWriteProtocol as limit
+} from "./repo-write-protocol-errors.ts";
 export {
   decodeRepoWriteBigInt,
   decodeRepoWriteBytes,
@@ -530,7 +533,10 @@ function jsonValue(
 }
 function parseFrame(text: string, limits: RepoWriteProtocolLimits): unknown {
   if (typeof text !== "string") invalid("$", "JSON text");
-  if (utf8Bytes(text) > limits.maxFrameBytes) limit("$", "frame byte length");
+  const bytes = utf8Bytes(text);
+  if (bytes > limits.maxFrameBytes) {
+    limit("$", "frame byte length", bytes, limits.maxFrameBytes);
+  }
   try {
     return JSON.parse(text) as unknown;
   } catch {
@@ -539,7 +545,10 @@ function parseFrame(text: string, limits: RepoWriteProtocolLimits): unknown {
 }
 function stringifyFrame(message: RepoWriteMessage, limits: RepoWriteProtocolLimits): string {
   const text = JSON.stringify(message);
-  if (utf8Bytes(text) > limits.maxFrameBytes) limit("$", "frame byte length");
+  const bytes = utf8Bytes(text);
+  if (bytes > limits.maxFrameBytes) {
+    limit("$", "frame byte length", bytes, limits.maxFrameBytes);
+  }
   return text;
 }
 function resolveLimits(overrides: Partial<RepoWriteProtocolLimits>): RepoWriteProtocolLimits {
@@ -571,7 +580,8 @@ function identifier(value: unknown, path: string, limits: RepoWriteProtocolLimit
 }
 function stringAt(value: unknown, path: string, maxBytes: number): string {
   if (typeof value !== "string") invalid(path, "string");
-  if (utf8Bytes(value) > maxBytes) limit(path, "string byte length");
+  const bytes = utf8Bytes(value);
+  if (bytes > maxBytes) limit(path, "string byte length", bytes, maxBytes);
   return value;
 }
 function utf8Bytes(value: string): number {
@@ -579,19 +589,4 @@ function utf8Bytes(value: string): number {
 }
 function boundedPathSegment(value: string): string {
   return value.length <= 48 ? value : `${value.slice(0, 45)}...`;
-}
-function invalid(path: string, expected: string): never {
-  throw new RepoWriteProtocolDecodeError(
-    "REPO_WRITE_PROTOCOL_INVALID",
-    `Invalid repo writer IPC at ${boundedProtocolPath(path)}: expected ${expected}.`
-  );
-}
-function limit(path: string, boundary: string): never {
-  throw new RepoWriteProtocolDecodeError(
-    "REPO_WRITE_PROTOCOL_LIMIT",
-    `Repo writer IPC limit exceeded at ${boundedProtocolPath(path)}: ${boundary}.`
-  );
-}
-function boundedProtocolPath(path: string): string {
-  return path.length <= 160 ? path : `${path.slice(0, 157)}...`;
 }

--- a/packages/daemon/src/service/doc-sync-service.ts
+++ b/packages/daemon/src/service/doc-sync-service.ts
@@ -32,6 +32,7 @@ import {
 } from "@harness-anything/application/doc-sync";
 import { DocSyncJournalFailure, docSyncWriteFailure } from "./doc-sync-journal-failure.ts";
 import { isStandaloneCasObject } from "./doc-sync-cas.ts";
+import { resolveDocSyncChangePath } from "./doc-sync-writer-working-tree.ts";
 
 export interface DocSyncServiceOptions {
   readonly rootDir: string;
@@ -162,7 +163,7 @@ export function validateDocSyncSubmitRequest(input: { readonly rootInput: Harnes
   const unresolvedTouches: Array<{ readonly path: string; readonly reason: string; readonly bearing?: string; readonly zoneClass?: string }> = [];
 
   for (const change of input.request.payload.changes) {
-    const target = resolveChangePath(layout.authoredRoot, change.path);
+    const target = resolveDocSyncChangePath(layout.authoredRoot, change.path);
     if (!target.ok) {
       unresolvedTouches.push({ path: change.path, reason: target.reason });
       continue;
@@ -289,7 +290,9 @@ async function submitDocSyncRequest(options: DocSyncServiceOptions, request: Doc
           semanticMutationPlan: validation.semanticMutationPlan,
           writes: validation.acceptedChanges.map((change) => ({
             path: change.path,
-            body: change.body,
+            ...(currentBlobSha(change.absolutePath) === change.newBlobSha256
+              ? { bodySha256: change.newBlobSha256 }
+              : { body: change.body }),
             baseBlobSha256: change.baseBlobSha256
           }))
         }
@@ -561,18 +564,6 @@ function reject(request: DocSyncSubmitRequestV1, code: Extract<DocSyncSubmitResu
     retryable,
     ...extra
   };
-}
-
-function resolveChangePath(authoredRoot: string, pathInput: string): { readonly ok: true; readonly path: string } | { readonly ok: false; readonly reason: string } {
-  if (path.isAbsolute(pathInput)) return { ok: false, reason: "doc sync path must be authored-root relative" };
-  const normalized = pathInput.split(/[\\/]+/u).filter(Boolean).join("/");
-  if (normalized.includes("..")) return { ok: false, reason: "doc sync path traversal is forbidden" };
-  const absolute = path.resolve(authoredRoot, normalized);
-  const relative = path.relative(authoredRoot, absolute);
-  if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
-    return { ok: false, reason: "doc sync path is outside authored root" };
-  }
-  return { ok: true, path: absolute };
 }
 
 function gitText(cwd: string, args: ReadonlyArray<string>): string | null {

--- a/packages/daemon/src/service/doc-sync-submit-handler.ts
+++ b/packages/daemon/src/service/doc-sync-submit-handler.ts
@@ -36,6 +36,7 @@ export function makeDocSyncSubmitHandler(options: {
     if (options.supervisor) {
       return dispatchDocSyncSubmitToWriter({
         rootDir: options.rootDir,
+        ...(options.layoutOverrides ? { layoutOverrides: options.layoutOverrides } : {}),
         request,
         actor,
         executor: context?.executor,

--- a/packages/daemon/src/service/doc-sync-writer-dispatch.ts
+++ b/packages/daemon/src/service/doc-sync-writer-dispatch.ts
@@ -9,6 +9,7 @@ import type { AuthorityConnectionDispatch } from "../protocol/connection-context
 import { encodeRepoWriteCommand } from "../runtime/repo-write-progress-command.ts";
 import type { RepoWriteProcessSupervisor } from "../runtime/repo-write-process-supervisor.ts";
 import { docSyncJournalUnavailable } from "./doc-sync-journal-failure.ts";
+import { referenceDocSyncWriterWorkingTree } from "./doc-sync-writer-working-tree.ts";
 
 export async function dispatchDocSyncSubmitToWriter(input: {
   readonly rootDir: string;
@@ -31,7 +32,7 @@ export async function dispatchDocSyncSubmitToWriter(input: {
       command: {
         rootDir: input.rootDir,
         action: { kind: "doc-sync-submit" },
-        request: input.request
+        request: referenceDocSyncWriterWorkingTree(input.rootDir, input.request)
       },
       context: {
         actor: input.actor,

--- a/packages/daemon/src/service/doc-sync-writer-dispatch.ts
+++ b/packages/daemon/src/service/doc-sync-writer-dispatch.ts
@@ -4,15 +4,21 @@ import type {
   TaskHolderExecutor
 } from "@harness-anything/application";
 import type { CurrentSessionRef } from "@harness-anything/kernel";
+import type { HarnessLayoutOverrides } from "@harness-anything/kernel";
 import type { AuthenticatedActor } from "../identity/types.ts";
 import type { AuthorityConnectionDispatch } from "../protocol/connection-context.ts";
 import { encodeRepoWriteCommand } from "../runtime/repo-write-progress-command.ts";
 import type { RepoWriteProcessSupervisor } from "../runtime/repo-write-process-supervisor.ts";
+import { RepoWriteIpcPayloadTooLargeError } from "../runtime/repo-write-client-errors.ts";
 import { docSyncJournalUnavailable } from "./doc-sync-journal-failure.ts";
-import { referenceDocSyncWriterWorkingTree } from "./doc-sync-writer-working-tree.ts";
+import {
+  ExternalDocSyncWorkingTreeReferenceError,
+  referenceDocSyncWriterWorkingTree
+} from "./doc-sync-writer-working-tree.ts";
 
 export async function dispatchDocSyncSubmitToWriter(input: {
   readonly rootDir: string;
+  readonly layoutOverrides?: HarnessLayoutOverrides;
   readonly request: DocSyncSubmitRequestV1;
   readonly actor?: AuthenticatedActor;
   readonly executor?: TaskHolderExecutor | null;
@@ -32,7 +38,12 @@ export async function dispatchDocSyncSubmitToWriter(input: {
       command: {
         rootDir: input.rootDir,
         action: { kind: "doc-sync-submit" },
-        request: referenceDocSyncWriterWorkingTree(input.rootDir, input.request)
+        request: referenceDocSyncWriterWorkingTree(
+          input.layoutOverrides
+            ? { rootDir: input.rootDir, layoutOverrides: input.layoutOverrides }
+            : input.rootDir,
+          input.request
+        )
       },
       context: {
         actor: input.actor,
@@ -46,11 +57,60 @@ export async function dispatchDocSyncSubmitToWriter(input: {
       ? report
       : docSyncJournalUnavailable(input.request, "The doc-sync writer child returned no typed report.");
   } catch (error) {
+    if (error instanceof RepoWriteIpcPayloadTooLargeError) {
+      return writerRejection(
+        input.request,
+        "doc_sync_invalid_payload",
+        `Repo writer ${error.sender} IPC payload cannot be sent because it is too large at ${error.path}: ${error.boundary} is `
+          + `${error.actualBytes} bytes, limit ${error.maximumBytes} bytes, over by ${error.excessBytes} bytes. `
+          + "Next: split the request or send large content by working-tree path or attachment reference.",
+        {
+          ipcError: {
+            name: "RepoWriteIpcPayloadTooLargeError",
+            code: error.code,
+            delivery: "definitely-not-sent",
+            sender: error.sender,
+            path: error.path,
+            boundary: error.boundary,
+            actualBytes: error.actualBytes,
+            maximumBytes: error.maximumBytes,
+            excessBytes: error.excessBytes
+          }
+        }
+      );
+    }
+    if (error instanceof ExternalDocSyncWorkingTreeReferenceError) {
+      return writerRejection(
+        input.request,
+        "doc_sync_invalid_payload",
+        "The internal writer-working-tree content kind cannot be supplied at the doc-sync wire boundary. "
+          + "Run 'ha doc status --json', rebuild the request with inline content, then retry 'ha doc sync --submit'."
+      );
+    }
     return docSyncJournalUnavailable(
       input.request,
       error instanceof Error ? error.stack ?? error.message : String(error)
     );
   }
+}
+
+function writerRejection(
+  request: DocSyncSubmitRequestV1,
+  code: Extract<DocSyncSubmitResultV1, { readonly ok: false }>["code"],
+  reason: string,
+  extra: Partial<Extract<DocSyncSubmitResultV1, { readonly ok: false }>> = {}
+): DocSyncSubmitResultV1 {
+  return {
+    ok: false,
+    _tag: "WriteRejected",
+    schema: "daemon.doc-sync-submit-result/v1",
+    status: "rejected",
+    intentId: request.payload.intentId,
+    code,
+    reason,
+    retryable: false,
+    ...extra
+  };
 }
 
 function docSyncCurrentSession(request: DocSyncSubmitRequestV1): CurrentSessionRef | undefined {

--- a/packages/daemon/src/service/doc-sync-writer-working-tree.ts
+++ b/packages/daemon/src/service/doc-sync-writer-working-tree.ts
@@ -2,11 +2,22 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import type { DocSyncSubmitRequestV1 } from "@harness-anything/application";
 import {
+  normalizeRelativeDocumentPath,
   resolveHarnessLayout,
   type HarnessLayoutInput
 } from "@harness-anything/kernel";
 
 const docSyncWriterWorkingTreeContentKind = "writer-working-tree/v1";
+
+export class ExternalDocSyncWorkingTreeReferenceError extends Error {
+  constructor() {
+    super(
+      "The internal writer-working-tree content kind cannot be supplied at the doc-sync wire boundary. "
+      + "Run 'ha doc status --json', rebuild the request with inline content, then retry 'ha doc sync --submit'."
+    );
+    this.name = "ExternalDocSyncWorkingTreeReferenceError";
+  }
+}
 
 export function referenceDocSyncWriterWorkingTree(
   rootInput: HarnessLayoutInput,
@@ -18,6 +29,9 @@ export function referenceDocSyncWriterWorkingTree(
     payload: {
       ...request.payload,
       changes: request.payload.changes.map((change) => {
+        if (change.content.kind === docSyncWriterWorkingTreeContentKind) {
+          throw new ExternalDocSyncWorkingTreeReferenceError();
+        }
         if (change.content.kind !== "inline"
           || !("body" in change.content)
           || typeof change.content.body !== "string") return change;
@@ -76,9 +90,11 @@ export function resolveDocSyncChangePath(
   if (path.isAbsolute(pathInput)) {
     return { ok: false, reason: "doc sync path must be authored-root relative" };
   }
-  const normalized = pathInput.split(/[\\/]+/u).filter(Boolean).join("/");
-  if (normalized.includes("..")) {
-    return { ok: false, reason: "doc sync path traversal is forbidden" };
+  let normalized: string;
+  try {
+    normalized = normalizeRelativeDocumentPath(pathInput);
+  } catch (error) {
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) };
   }
   const absolute = path.resolve(authoredRoot, normalized);
   const relative = path.relative(authoredRoot, absolute);

--- a/packages/daemon/src/service/doc-sync-writer-working-tree.ts
+++ b/packages/daemon/src/service/doc-sync-writer-working-tree.ts
@@ -1,0 +1,89 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import type { DocSyncSubmitRequestV1 } from "@harness-anything/application";
+import {
+  resolveHarnessLayout,
+  type HarnessLayoutInput
+} from "@harness-anything/kernel";
+
+const docSyncWriterWorkingTreeContentKind = "writer-working-tree/v1";
+
+export function referenceDocSyncWriterWorkingTree(
+  rootInput: HarnessLayoutInput,
+  request: DocSyncSubmitRequestV1
+): DocSyncSubmitRequestV1 {
+  const layout = resolveHarnessLayout(rootInput);
+  return {
+    ...request,
+    payload: {
+      ...request.payload,
+      changes: request.payload.changes.map((change) => {
+        if (change.content.kind !== "inline"
+          || !("body" in change.content)
+          || typeof change.content.body !== "string") return change;
+        const target = resolveDocSyncChangePath(layout.authoredRoot, change.path);
+        if (!target.ok || !existsSync(target.path)) return change;
+        const workingTreeBody = readFileSync(target.path, "utf8");
+        if (workingTreeBody !== change.content.body) return change;
+        return {
+          ...change,
+          content: { kind: docSyncWriterWorkingTreeContentKind }
+        };
+      })
+    }
+  };
+}
+
+export function materializeDocSyncWriterWorkingTree(
+  rootInput: HarnessLayoutInput,
+  request: DocSyncSubmitRequestV1
+): { readonly ok: true; readonly request: DocSyncSubmitRequestV1 }
+  | { readonly ok: false; readonly reason: string } {
+  const layout = resolveHarnessLayout(rootInput);
+  const changes = [];
+  for (const change of request.payload.changes) {
+    if (change.content.kind !== docSyncWriterWorkingTreeContentKind) {
+      changes.push(change);
+      continue;
+    }
+    const target = resolveDocSyncChangePath(layout.authoredRoot, change.path);
+    if (!target.ok) return { ok: false, reason: `${change.path}: ${target.reason}` };
+    try {
+      changes.push({
+        ...change,
+        content: { kind: "inline" as const, body: readFileSync(target.path, "utf8") }
+      });
+    } catch (error) {
+      return {
+        ok: false,
+        reason: `${change.path}: writer child could not read the canonical working-tree file: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      };
+    }
+  }
+  return {
+    ok: true,
+    request: { ...request, payload: { ...request.payload, changes } }
+  };
+}
+
+export function resolveDocSyncChangePath(
+  authoredRoot: string,
+  pathInput: string
+): { readonly ok: true; readonly path: string }
+  | { readonly ok: false; readonly reason: string } {
+  if (path.isAbsolute(pathInput)) {
+    return { ok: false, reason: "doc sync path must be authored-root relative" };
+  }
+  const normalized = pathInput.split(/[\\/]+/u).filter(Boolean).join("/");
+  if (normalized.includes("..")) {
+    return { ok: false, reason: "doc sync path traversal is forbidden" };
+  }
+  const absolute = path.resolve(authoredRoot, normalized);
+  const relative = path.relative(authoredRoot, absolute);
+  if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    return { ok: false, reason: "doc sync path is outside authored root" };
+  }
+  return { ok: true, path: absolute };
+}

--- a/packages/daemon/test/doc-sync-writer-dispatch.test.ts
+++ b/packages/daemon/test/doc-sync-writer-dispatch.test.ts
@@ -104,7 +104,7 @@ test("writer working-tree paths use the canonical portable path normalizer", () 
   assert.equal(nfc.ok, true);
   if (!backslash.ok) assert.match(backslash.reason, /POSIX separators/u);
   if (!nul.ok) assert.match(nul.reason, /NUL/u);
-  if (nfc.ok) assert.equal(nfc.path, "/tmp/authored/notes/café.md");
+  if (nfc.ok) assert.equal(nfc.path, path.resolve("/tmp/authored", "notes/café.md"));
 });
 
 function request(

--- a/packages/daemon/test/doc-sync-writer-dispatch.test.ts
+++ b/packages/daemon/test/doc-sync-writer-dispatch.test.ts
@@ -1,0 +1,208 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import type { DocSyncSubmitRequestV1 } from "@harness-anything/application";
+import type { AuthenticatedActor } from "../src/identity/types.ts";
+import type { AuthorityConnectionDispatch } from "../src/protocol/connection-context.ts";
+import { RepoWriteIpcPayloadTooLargeError } from "../src/runtime/repo-write-client-errors.ts";
+import type { RepoWriteCommandDto } from "../src/runtime/repo-write-protocol.ts";
+import type { RepoWriteProcessSupervisor } from "../src/runtime/repo-write-process-supervisor.ts";
+import { dispatchDocSyncSubmitToWriter } from "../src/service/doc-sync-writer-dispatch.ts";
+import { resolveDocSyncChangePath } from "../src/service/doc-sync-writer-working-tree.ts";
+
+test("doc-sync dispatch preserves a non-retryable structured IPC payload-size error", async () => {
+  const error = new RepoWriteIpcPayloadTooLargeError(
+    "parent",
+    "$.command.payload.body",
+    "string byte length",
+    262_145,
+    262_144
+  );
+
+  const result = await dispatchDocSyncSubmitToWriter(dispatchInput(request(), async () => {
+    throw error;
+  }));
+
+  assert.deepEqual(result, {
+    ok: false,
+    _tag: "WriteRejected",
+    schema: "daemon.doc-sync-submit-result/v1",
+    status: "rejected",
+    intentId: "intent-dispatch",
+    code: "doc_sync_invalid_payload",
+    reason: error.message,
+    retryable: false,
+    ipcError: {
+      name: error.name,
+      code: error.code,
+      delivery: error.delivery,
+      sender: error.sender,
+      path: error.path,
+      boundary: error.boundary,
+      actualBytes: error.actualBytes,
+      maximumBytes: error.maximumBytes,
+      excessBytes: error.excessBytes
+    }
+  });
+});
+
+test("doc-sync dispatch rejects an externally supplied writer-working-tree content kind", async () => {
+  let directCalls = 0;
+  const externalReference = request({ kind: "writer-working-tree/v1" });
+
+  const result = await dispatchDocSyncSubmitToWriter(dispatchInput(externalReference, async () => {
+    directCalls += 1;
+    return acceptedReceipt();
+  }));
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.code, "doc_sync_invalid_payload");
+    assert.equal(result.retryable, false);
+    assert.match(result.reason, /internal writer-working-tree content kind/u);
+  }
+  assert.equal(directCalls, 0);
+});
+
+test("doc-sync dispatch applies authored-root layout overrides before framing", async () => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "ha-doc-sync-dispatch-"));
+  const body = "large custom-root evidence\n";
+  const relativePath = "tasks/task_A/artifacts/large.raw.jsonl";
+  const targetPath = path.join(rootDir, ".custom-harness", relativePath);
+  let framedCommand: RepoWriteCommandDto | undefined;
+  try {
+    mkdirSync(path.dirname(targetPath), { recursive: true });
+    writeFileSync(targetPath, body, "utf8");
+    const result = await dispatchDocSyncSubmitToWriter({
+      ...dispatchInput(request({ kind: "inline", body }), async (command) => {
+        framedCommand = command;
+        return acceptedReceipt();
+      }),
+      rootDir,
+      layoutOverrides: { authoredRoot: ".custom-harness" }
+    });
+
+    assert.equal(result.ok, true);
+    const wireRequest = ((framedCommand?.payload as {
+      readonly command?: { readonly request?: DocSyncSubmitRequestV1 };
+    }).command?.request);
+    assert.equal(wireRequest?.payload.changes[0]?.content.kind, "writer-working-tree/v1");
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("writer working-tree paths use the canonical portable path normalizer", () => {
+  const backslash = resolveDocSyncChangePath("/tmp/authored", "tasks\\task_A\\note.md");
+  const nul = resolveDocSyncChangePath("/tmp/authored", "tasks/task_A/note\0.md");
+  const nfc = resolveDocSyncChangePath("/tmp/authored", "notes/cafe\u0301.md");
+  assert.equal(backslash.ok, false);
+  assert.equal(nul.ok, false);
+  assert.equal(nfc.ok, true);
+  if (!backslash.ok) assert.match(backslash.reason, /POSIX separators/u);
+  if (!nul.ok) assert.match(nul.reason, /NUL/u);
+  if (nfc.ok) assert.equal(nfc.path, "/tmp/authored/notes/café.md");
+});
+
+function request(
+  content: DocSyncSubmitRequestV1["payload"]["changes"][number]["content"] = {
+    kind: "inline",
+    body: "inline evidence\n"
+  }
+): DocSyncSubmitRequestV1 {
+  return {
+    repo: { repoId: "canonical" },
+    session: {
+      sessionId: "session-dispatch",
+      runtime: "codex",
+      source: "runtime",
+      detectedAt: "2026-07-31T00:00:00.000Z"
+    },
+    payload: {
+      baseLedgerSha: "base",
+      intentId: "intent-dispatch",
+      declaredIntent: "session-export",
+      changes: [{
+        path: "tasks/task_A/artifacts/large.raw.jsonl",
+        baseBlobSha256: null,
+        newBlobSha256: "a".repeat(64),
+        mediaType: "application/jsonl",
+        size: "body" in content && typeof content.body === "string" ? Buffer.byteLength(content.body) : 0,
+        content
+      }]
+    }
+  };
+}
+
+function dispatchInput(
+  docSyncRequest: DocSyncSubmitRequestV1,
+  direct: (command: RepoWriteCommandDto) => Promise<ReturnType<typeof acceptedReceipt>>
+) {
+  const actor: AuthenticatedActor = {
+    personId: "person_local",
+    displayName: "Local Person",
+    providerId: "local-socket",
+    resolvedCredential: {
+      kind: "unix-socket-owner-boundary",
+      issuer: "fixture",
+      subject: "501"
+    }
+  };
+  const authority: AuthorityConnectionDispatch = {
+    available: true,
+    assertActive: () => undefined,
+    context: {
+      schema: "authority-connection-context/v1",
+      connectionId: "connection-dispatch",
+      connectionGeneration: "generation-dispatch" as never,
+      actor,
+      repoId: "canonical",
+      channelBinding: {
+        digest: Buffer.alloc(32, 0x61) as never,
+        source: "transport-observed"
+      },
+      peerCredential: {
+        schema: "os-observed-peer-credential/v1",
+        platform: "darwin",
+        source: "getpeereid",
+        uid: 501,
+        gid: 20
+      }
+    }
+  };
+  return {
+    rootDir: "/tmp/doc-sync-dispatch",
+    request: docSyncRequest,
+    actor,
+    authority,
+    supervisor: { direct } as unknown as RepoWriteProcessSupervisor
+  };
+}
+
+function acceptedReceipt() {
+  return {
+    ok: true as const,
+    schema: "command-receipt/v2" as const,
+    command: "repo.doc.sync.submit",
+    action: "submit",
+    summary: "accepted",
+    details: {
+      data: {
+        ok: true,
+        schema: "daemon.doc-sync-submit-result/v1",
+        status: "accepted",
+        intentId: "intent-dispatch",
+        baseLedgerSha: "base",
+        appliedLedgerSha: "head",
+        appliedChanges: []
+      }
+    },
+    meta: {
+      generatedAt: "2026-07-31T00:00:00.000Z",
+      compatibility: {}
+    }
+  };
+}

--- a/packages/daemon/test/repo-write-child-process-transport.test.ts
+++ b/packages/daemon/test/repo-write-child-process-transport.test.ts
@@ -12,7 +12,10 @@ import {
   RepoWriteParentProcessTransport,
   RepoWriteProcessDisconnectError,
 } from "../src/runtime/repo-write-child-process-transport.ts";
-import { RepoWriteSendDeliveryError } from "../src/runtime/repo-write-client.ts";
+import {
+  RepoWriteIpcPayloadTooLargeError,
+  RepoWriteSendDeliveryError
+} from "../src/runtime/repo-write-client.ts";
 import {
   repoWriteProtocolType,
   type RepoWriteChildMessage
@@ -240,6 +243,33 @@ test("marks synchronous IPC rejection as definitely not sent before disconnect n
 
   const disconnect = await disconnected;
   assertDisconnect(disconnect, "send");
+});
+
+test("reports the exact oversized IPC field, byte overage, and next action", () => {
+  const transport = new RepoWriteParentProcessTransport(stalledChild());
+
+  assert.throws(() => transport.send({
+    protocol: repoWriteProtocolType,
+    repoId: "repo-transport",
+    generation: 1,
+    kind: "direct",
+    requestId: "oversized-direct",
+    command: {
+      commandName: "doc-sync-submit",
+      actor: {},
+      context: {},
+      payload: { body: "x".repeat(256 * 1024 + 1) }
+    }
+  }), (error) => {
+    assert.ok(error instanceof RepoWriteIpcPayloadTooLargeError);
+    assert.equal(error.code, "REPO_WRITE_IPC_PAYLOAD_TOO_LARGE");
+    assert.equal(error.path, "$.command.payload.body");
+    assert.equal(error.actualBytes, 256 * 1024 + 1);
+    assert.equal(error.maximumBytes, 256 * 1024);
+    assert.equal(error.excessBytes, 1);
+    assert.match(error.message, /Next: split the request or send large content by working-tree path or attachment reference/u);
+    return true;
+  });
 });
 
 test("marks callback send failure as possibly sent", async () => {

--- a/packages/daemon/test/repo-write-client.test.ts
+++ b/packages/daemon/test/repo-write-client.test.ts
@@ -6,6 +6,7 @@ import {
   RepoWriteClientClosedError,
   RepoWriteDirectOutcomeUnknownError,
   RepoWriteDrainError,
+  RepoWriteIpcPayloadTooLargeError,
   RepoWriteNotStartedError,
   RepoWriteOutcomeUnknownError,
   RepoWriteProtocolViolationError,
@@ -251,6 +252,29 @@ test("volatile direct execution resolves the exact existing receipt without PREP
 
   assert.deepEqual(await result, receipt);
   assert.deepEqual(transport.sent.map((message) => message.kind), ["direct"]);
+});
+
+test("volatile direct preserves an IPC payload-size diagnosis instead of reporting not-started", async () => {
+  const failure = new RepoWriteIpcPayloadTooLargeError(
+    "parent",
+    "$.command.payload.body",
+    "string byte length",
+    262_145,
+    262_144
+  );
+  class OversizedTransport extends FakeRepoWriteTransport {
+    override send(): never {
+      throw failure;
+    }
+  }
+  const transport = new OversizedTransport();
+  const client = readyClient(transport);
+
+  await assert.rejects(client.direct(command("doc-sync-submit")), (error) => {
+    assert.equal(error, failure);
+    assert.equal(error instanceof RepoWriteNotStartedError, false);
+    return true;
+  });
 });
 
 test("volatile direct timeout releases capacity without retry or durable lookup", async () => {

--- a/packages/kernel/src/write-coordination/journal/coordinator.ts
+++ b/packages/kernel/src/write-coordination/journal/coordinator.ts
@@ -44,6 +44,7 @@ import {
   documentWritesForWriteValidation,
   readHardDeletePayload,
   validateWriteTransaction,
+  verifyAlreadyAppliedWriteOp,
   writeOpTouchedPaths
 } from "./operations/transaction-plan.ts";
 import { reconcileDurableFlush, shouldWaitForForeignCommitter } from "./receipt.ts";
@@ -362,6 +363,7 @@ function flushRecords(
     if (!fileApplied.has(record.opId)) {
       applyRecord(rootDir, rootInput, journalPath, record);
     } else {
+      verifyAlreadyAppliedWriteOp(rootInput, recordToOp(rootDir, record));
       finalizeRecoverableDocumentTransaction(rootInput, record.opId);
     }
     touchedPaths.push(...recordTouchedPaths);

--- a/packages/kernel/src/write-coordination/journal/durable.ts
+++ b/packages/kernel/src/write-coordination/journal/durable.ts
@@ -1,4 +1,4 @@
-import { closeSync, existsSync, fsyncSync, ftruncateSync, linkSync, mkdirSync, openSync, readFileSync, renameSync, rmSync, writeSync } from "node:fs";
+import { closeSync, existsSync, fsyncSync, ftruncateSync, linkSync, lstatSync, mkdirSync, openSync, readFileSync, renameSync, rmSync, writeSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { Schema } from "effect";
@@ -194,6 +194,15 @@ export function writeWatermarkDurably(filePath: string, watermark: WriteWatermar
 
 export function durableFileExists(filePath: string): boolean {
   return existsSync(filePath);
+}
+
+export function durableFileIsRegularNoFollow(filePath: string): boolean {
+  try {
+    const stat = lstatSync(filePath);
+    return stat.isFile() && !stat.isSymbolicLink();
+  } catch {
+    return false;
+  }
 }
 
 export function readDurableTextIfExists(filePath: string): string | null {

--- a/packages/kernel/src/write-coordination/journal/operations/canonical-authored-batch.ts
+++ b/packages/kernel/src/write-coordination/journal/operations/canonical-authored-batch.ts
@@ -8,7 +8,8 @@ import { rejectWrite } from "../rejection.ts";
 
 export interface CanonicalAuthoredWrite {
   readonly path: string;
-  readonly body: string;
+  readonly body?: string;
+  readonly bodySha256?: string;
   readonly baseBlobSha256: string | null;
 }
 
@@ -22,9 +23,15 @@ export function canonicalAuthoredBatchWrites(op: WriteOp): ReadonlyArray<Canonic
   return writes.map((write) => {
     if (!write || typeof write !== "object") malformed(op);
     const candidate = write as Partial<CanonicalAuthoredWrite>;
-    if (typeof candidate.path !== "string" || typeof candidate.body !== "string" ||
+    const hasBody = typeof candidate.body === "string";
+    const hasWorkingTreeBody = typeof candidate.bodySha256 === "string"
+      && /^[a-f0-9]{64}$/u.test(candidate.bodySha256);
+    if (typeof candidate.path !== "string" || hasBody === hasWorkingTreeBody ||
       (candidate.baseBlobSha256 !== null && typeof candidate.baseBlobSha256 !== "string")) {
       malformed(op);
+    }
+    if (hasWorkingTreeBody && op.kind !== "doc_sync_submit") {
+      rejectWrite(`${op.kind} cannot use a working-tree body reference`, op.entityId);
     }
     const normalized = normalizeBatchPath(candidate.path, op.entityId);
     if (isTaskTypedAuthorityPath(normalized)) {
@@ -32,7 +39,11 @@ export function canonicalAuthoredBatchWrites(op: WriteOp): ReadonlyArray<Canonic
     }
     if (paths.has(normalized)) rejectWrite(`duplicate canonical authored batch path: ${normalized}`, op.entityId);
     paths.add(normalized);
-    return { path: normalized, body: candidate.body, baseBlobSha256: candidate.baseBlobSha256 };
+    return {
+      path: normalized,
+      ...(hasBody ? { body: candidate.body } : { bodySha256: candidate.bodySha256 }),
+      baseBlobSha256: candidate.baseBlobSha256
+    };
   });
 }
 
@@ -52,7 +63,7 @@ export function validateCanonicalAuthoredBatch(rootInput: HarnessLayoutInput, op
   for (const write of canonicalAuthoredBatchWrites(op)) {
     const targetPath = path.join(authoredRoot, write.path);
     const currentHash = durableFileExists(targetPath) ? sha256Text(readText(targetPath)) : null;
-    const submittedHash = sha256Text(write.body);
+    const submittedHash = write.bodySha256 ?? sha256Text(write.body!);
     const acceptsPreAppliedDocSync = op.kind === "doc_sync_submit" && currentHash === submittedHash;
     if (currentHash !== write.baseBlobSha256 && !acceptsPreAppliedDocSync) {
       rejectWrite(`canonical authored base changed before ${op.kind}: ${write.path}`, op.entityId);
@@ -66,13 +77,14 @@ export function applyCanonicalAuthoredBatch(rootInput: HarnessLayoutInput, op: W
     ...write,
     targetPath: path.join(authoredRoot, write.path)
   }));
+  const changedWrites = writes.filter((write) => write.body !== undefined);
   const backups = writes.map((write) => ({
     targetPath: write.targetPath,
     existed: durableFileExists(write.targetPath),
     body: durableFileExists(write.targetPath) ? readFileBytes(write.targetPath) : null
   }));
   try {
-    for (const write of writes) writeFileDurably(write.targetPath, write.body);
+    for (const write of changedWrites) writeFileDurably(write.targetPath, write.body!);
   } catch (error) {
     for (const backup of backups.reverse()) {
       if (backup.existed && backup.body !== null) {
@@ -103,5 +115,5 @@ function normalizeBatchPath(input: string, entityId: EntityId): string {
 }
 
 function malformed(op: WriteOp): never {
-  rejectWrite(`${op.kind} requires writes with path, body, and baseBlobSha256`, op.entityId);
+  rejectWrite(`${op.kind} requires writes with path, exactly one of body/bodySha256, and baseBlobSha256`, op.entityId);
 }

--- a/packages/kernel/src/write-coordination/journal/operations/canonical-authored-batch.ts
+++ b/packages/kernel/src/write-coordination/journal/operations/canonical-authored-batch.ts
@@ -3,7 +3,7 @@ import type { EntityId } from "../../../domain/index.ts";
 import { sha256Text } from "../../../integrity/stable-hash.ts";
 import { normalizeRelativeDocumentPath, resolveHarnessLayout, type HarnessLayoutInput } from "../../../layout/index.ts";
 import type { WriteOp } from "../../../ports/write-coordinator.ts";
-import { durableFileExists, readFileBytes, removeFileDurably, writeFileDurably } from "../durable.ts";
+import { durableFileExists, durableFileIsRegularNoFollow, readFileBytes, removeFileDurably, writeFileDurably } from "../durable.ts";
 import { rejectWrite } from "../rejection.ts";
 
 export interface CanonicalAuthoredWrite {
@@ -77,16 +77,21 @@ export function applyCanonicalAuthoredBatch(rootInput: HarnessLayoutInput, op: W
     ...write,
     targetPath: path.join(authoredRoot, write.path)
   }));
+  verifyCanonicalAuthoredWorkingTreeReferences(op, writes);
   const changedWrites = writes.filter((write) => write.body !== undefined);
-  const backups = writes.map((write) => ({
+  const backups = changedWrites.map((write) => ({
     targetPath: write.targetPath,
     existed: durableFileExists(write.targetPath),
     body: durableFileExists(write.targetPath) ? readFileBytes(write.targetPath) : null
   }));
+  const writtenBackups: typeof backups[number][] = [];
   try {
-    for (const write of changedWrites) writeFileDurably(write.targetPath, write.body!);
+    for (const [index, write] of changedWrites.entries()) {
+      writeFileDurably(write.targetPath, write.body!);
+      writtenBackups.push(backups[index]!);
+    }
   } catch (error) {
-    for (const backup of backups.reverse()) {
+    for (const backup of writtenBackups.reverse()) {
       if (backup.existed && backup.body !== null) {
         writeFileDurably(backup.targetPath, backup.body);
       } else {
@@ -95,6 +100,52 @@ export function applyCanonicalAuthoredBatch(rootInput: HarnessLayoutInput, op: W
     }
     throw error;
   }
+}
+
+export function verifyAppliedCanonicalAuthoredBatch(rootInput: HarnessLayoutInput, op: WriteOp): void {
+  const authoredRoot = resolveHarnessLayout(rootInput).authoredRoot;
+  const writes = canonicalAuthoredBatchWrites(op).map((write) => ({
+    ...write,
+    targetPath: path.join(authoredRoot, write.path)
+  }));
+  verifyCanonicalAuthoredWorkingTreeReferences(op, writes);
+}
+
+function verifyCanonicalAuthoredWorkingTreeReferences(
+  op: WriteOp,
+  writes: ReadonlyArray<CanonicalAuthoredWrite & { readonly targetPath: string }>
+): void {
+  for (const write of writes) {
+    if (write.bodySha256 === undefined) continue;
+    assertRegularWorkingTreeReference(op, write);
+    let actualHash: string;
+    try {
+      actualHash = sha256Text(readText(write.targetPath));
+    } catch {
+      rejectWrite(
+        `canonical authored working-tree body reference could not be read before ${op.kind}: ${write.path}`,
+        op.entityId
+      );
+    }
+    assertRegularWorkingTreeReference(op, write);
+    if (actualHash !== write.bodySha256) {
+      rejectWrite(
+        `canonical authored working-tree body reference changed before ${op.kind}: ${write.path}; expected ${write.bodySha256}, current ${actualHash}`,
+        op.entityId
+      );
+    }
+  }
+}
+
+function assertRegularWorkingTreeReference(
+  op: WriteOp,
+  write: CanonicalAuthoredWrite & { readonly targetPath: string }
+): void {
+  if (durableFileIsRegularNoFollow(write.targetPath)) return;
+  rejectWrite(
+    `canonical authored working-tree body reference must remain a regular file before ${op.kind}: ${write.path}`,
+    op.entityId
+  );
 }
 
 function readText(filePath: string): string {

--- a/packages/kernel/src/write-coordination/journal/operations/transaction-plan.ts
+++ b/packages/kernel/src/write-coordination/journal/operations/transaction-plan.ts
@@ -21,7 +21,8 @@ import {
 import {
   applyCanonicalAuthoredBatch,
   canonicalAuthoredBatchPaths,
-  validateCanonicalAuthoredBatch
+  validateCanonicalAuthoredBatch,
+  verifyAppliedCanonicalAuthoredBatch
 } from "./canonical-authored-batch.ts";
 import { applyWithCompensatedCasBody } from "./composite-cas-compensation.ts";
 import {
@@ -396,6 +397,10 @@ export function validateWriteTransaction(rootInput: HarnessLayoutInput, op: Writ
 
 export function applyWriteOp(rootInput: HarnessLayoutInput, op: WriteOp): DocumentWrite | null {
   return writeTransactionPlan(op).apply(rootInput, op);
+}
+
+export function verifyAlreadyAppliedWriteOp(rootInput: HarnessLayoutInput, op: WriteOp): void {
+  if (op.kind === "doc_sync_submit") verifyAppliedCanonicalAuthoredBatch(rootInput, op);
 }
 
 export function writeOpTouchedPaths(rootInput: HarnessLayoutInput, op: WriteOp): ReadonlyArray<string> {

--- a/packages/kernel/test/store/canonical-authored-batch.test.ts
+++ b/packages/kernel/test/store/canonical-authored-batch.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -37,7 +37,7 @@ test("script_ingest retains its declared Task artifact surface", () => {
   }]);
 });
 
-test("doc_sync_submit references an exact pre-applied working-tree body and rejects drift", () => {
+test("doc_sync_submit apply rejects a deleted working-tree body reference", () => {
   const rootDir = mkdtempSync(path.join(os.tmpdir(), "ha-doc-sync-working-tree-"));
   const relativePath = "tasks/task_A/artifacts/large.raw.jsonl";
   const absolutePath = path.join(rootDir, "harness", relativePath);
@@ -45,28 +45,118 @@ test("doc_sync_submit references an exact pre-applied working-tree body and reje
   try {
     mkdirSync(path.dirname(absolutePath), { recursive: true });
     writeFileSync(absolutePath, body, "utf8");
+    const op = workingTreeBatch(relativePath, body, null);
+
+    rmSync(absolutePath);
+    assert.doesNotThrow(() => validateCanonicalAuthoredBatch(rootDir, op));
+    assert.throws(() => applyCanonicalAuthoredBatch(rootDir, op), /working-tree body reference/u);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("doc_sync_submit apply rejects a working-tree body rolled back to its base", () => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "ha-doc-sync-working-tree-"));
+  const relativePath = "tasks/task_A/artifacts/large.raw.jsonl";
+  const absolutePath = path.join(rootDir, "harness", relativePath);
+  const baseBody = "base evidence\n";
+  const submittedBody = "submitted evidence\n";
+  try {
+    mkdirSync(path.dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, submittedBody, "utf8");
+    const op = workingTreeBatch(relativePath, submittedBody, sha256Text(baseBody));
+
+    writeFileSync(absolutePath, baseBody, "utf8");
+    assert.doesNotThrow(() => validateCanonicalAuthoredBatch(rootDir, op));
+    assert.throws(() => applyCanonicalAuthoredBatch(rootDir, op), /working-tree body reference/u);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("doc_sync_submit apply rejects working-tree drift after validation", () => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "ha-doc-sync-working-tree-"));
+  const relativePath = "tasks/task_A/artifacts/large.raw.jsonl";
+  const absolutePath = path.join(rootDir, "harness", relativePath);
+  const body = "large evidence\n";
+  try {
+    mkdirSync(path.dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, body, "utf8");
+    const op = workingTreeBatch(relativePath, body, null);
+
+    assert.doesNotThrow(() => validateCanonicalAuthoredBatch(rootDir, op));
+    writeFileSync(absolutePath, "changed after validation\n", "utf8");
+    assert.throws(() => applyCanonicalAuthoredBatch(rootDir, op), /working-tree body reference/u);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("doc_sync_submit apply rejects a symlink working-tree body reference", () => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "ha-doc-sync-working-tree-"));
+  const relativePath = "tasks/task_A/artifacts/large.raw.jsonl";
+  const absolutePath = path.join(rootDir, "harness", relativePath);
+  const symlinkTarget = path.join(rootDir, "outside.raw.jsonl");
+  const body = "large evidence\n";
+  try {
+    mkdirSync(path.dirname(absolutePath), { recursive: true });
+    writeFileSync(symlinkTarget, body, "utf8");
+    symlinkSync(symlinkTarget, absolutePath);
+    const op = workingTreeBatch(relativePath, body, null);
+
+    assert.doesNotThrow(() => validateCanonicalAuthoredBatch(rootDir, op));
+    assert.throws(() => applyCanonicalAuthoredBatch(rootDir, op), /regular file/u);
+    assert.equal(lstatSync(absolutePath).isSymbolicLink(), true);
+    assert.equal(readFileSync(symlinkTarget, "utf8"), body);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("mixed batch rollback restores only inline paths that apply could write", () => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "ha-doc-sync-working-tree-"));
+  const authoredRoot = path.join(rootDir, "harness");
+  const referencedPath = path.join(authoredRoot, "artifacts/referenced.jsonl");
+  const changedPath = path.join(authoredRoot, "notes/changed.md");
+  const blockingParent = path.join(authoredRoot, "blocked");
+  const referencedBody = "referenced evidence\n";
+  const originalChangedBody = "original note\n";
+  try {
+    mkdirSync(path.dirname(referencedPath), { recursive: true });
+    mkdirSync(path.dirname(changedPath), { recursive: true });
+    writeFileSync(referencedPath, referencedBody, "utf8");
+    writeFileSync(changedPath, originalChangedBody, "utf8");
+    writeFileSync(blockingParent, "not a directory\n", "utf8");
+    const referencedInode = statSync(referencedPath).ino;
     const op: WriteOp = {
-      opId: "op-doc-sync-working-tree",
-      entityId: "entity/test/doc-sync-working-tree",
+      opId: "op-doc-sync-mixed-rollback",
+      entityId: "entity/test/doc-sync-mixed-rollback",
       kind: "doc_sync_submit",
       payload: {
-        writes: [{
-          path: relativePath,
-          bodySha256: sha256Text(body),
-          baseBlobSha256: null
-        }]
+        writes: [
+          {
+            path: "artifacts/referenced.jsonl",
+            bodySha256: sha256Text(referencedBody),
+            baseBlobSha256: null
+          },
+          {
+            path: "notes/changed.md",
+            body: "changed note\n",
+            baseBlobSha256: sha256Text(originalChangedBody)
+          },
+          {
+            path: "blocked/failure.md",
+            body: "cannot land\n",
+            baseBlobSha256: null
+          }
+        ]
       }
     };
 
-    assert.doesNotThrow(() => validateCanonicalAuthoredBatch(rootDir, op));
-    applyCanonicalAuthoredBatch(rootDir, op);
-    assert.equal(readFileSync(absolutePath, "utf8"), body);
-
-    writeFileSync(absolutePath, "changed after validation\n", "utf8");
-    assert.throws(
-      () => validateCanonicalAuthoredBatch(rootDir, op),
-      /canonical authored base changed before doc_sync_submit/u
-    );
+    assert.throws(() => applyCanonicalAuthoredBatch(rootDir, op));
+    assert.equal(readFileSync(referencedPath, "utf8"), referencedBody);
+    assert.equal(statSync(referencedPath).ino, referencedInode);
+    assert.equal(readFileSync(changedPath, "utf8"), originalChangedBody);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }
@@ -93,5 +183,24 @@ function batch(kind: "doc_sync_submit" | "script_ingest", path: string): WriteOp
     entityId: "entity/test/canonical-batch",
     kind,
     payload: { writes: [{ path, body: "{}\n", baseBlobSha256: null }] }
+  };
+}
+
+function workingTreeBatch(
+  relativePath: string,
+  body: string,
+  baseBlobSha256: string | null
+): WriteOp {
+  return {
+    opId: "op-doc-sync-working-tree",
+    entityId: "entity/test/doc-sync-working-tree",
+    kind: "doc_sync_submit",
+    payload: {
+      writes: [{
+        path: relativePath,
+        bodySha256: sha256Text(body),
+        baseBlobSha256
+      }]
+    }
   };
 }

--- a/packages/kernel/test/store/canonical-authored-batch.test.ts
+++ b/packages/kernel/test/store/canonical-authored-batch.test.ts
@@ -1,8 +1,15 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
-import type { WriteOp } from "../../src/index.ts";
-import { canonicalAuthoredBatchWrites } from "../../src/write-coordination/journal/operations/canonical-authored-batch.ts";
+import { sha256Text, type WriteOp } from "../../src/index.ts";
+import {
+  applyCanonicalAuthoredBatch,
+  canonicalAuthoredBatchWrites,
+  validateCanonicalAuthoredBatch
+} from "../../src/write-coordination/journal/operations/canonical-authored-batch.ts";
 
 const reservedPaths = [
   "tasks/task_01KX3W4V1EDPHPTGWYYBQQ2J75/INDEX.md",
@@ -28,6 +35,56 @@ test("script_ingest retains its declared Task artifact surface", () => {
     body: "{}\n",
     baseBlobSha256: null
   }]);
+});
+
+test("doc_sync_submit references an exact pre-applied working-tree body and rejects drift", () => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "ha-doc-sync-working-tree-"));
+  const relativePath = "tasks/task_A/artifacts/large.raw.jsonl";
+  const absolutePath = path.join(rootDir, "harness", relativePath);
+  const body = "large evidence\n";
+  try {
+    mkdirSync(path.dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, body, "utf8");
+    const op: WriteOp = {
+      opId: "op-doc-sync-working-tree",
+      entityId: "entity/test/doc-sync-working-tree",
+      kind: "doc_sync_submit",
+      payload: {
+        writes: [{
+          path: relativePath,
+          bodySha256: sha256Text(body),
+          baseBlobSha256: null
+        }]
+      }
+    };
+
+    assert.doesNotThrow(() => validateCanonicalAuthoredBatch(rootDir, op));
+    applyCanonicalAuthoredBatch(rootDir, op);
+    assert.equal(readFileSync(absolutePath, "utf8"), body);
+
+    writeFileSync(absolutePath, "changed after validation\n", "utf8");
+    assert.throws(
+      () => validateCanonicalAuthoredBatch(rootDir, op),
+      /canonical authored base changed before doc_sync_submit/u
+    );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("canonical authored working-tree references require a sha256 digest", () => {
+  assert.throws(() => canonicalAuthoredBatchWrites({
+    opId: "op-invalid-working-tree-digest",
+    entityId: "entity/test/invalid-working-tree-digest",
+    kind: "doc_sync_submit",
+    payload: {
+      writes: [{
+        path: "tasks/task_A/artifacts/large.raw.jsonl",
+        bodySha256: "not-a-sha256",
+        baseBlobSha256: null
+      }]
+    }
+  }), /exactly one of body\/bodySha256/u);
 });
 
 function batch(kind: "doc_sync_submit" | "script_ingest", path: string): WriteOp {

--- a/packages/kernel/test/store/crash-before-watermark.test.ts
+++ b/packages/kernel/test/store/crash-before-watermark.test.ts
@@ -2,10 +2,10 @@
 import { testWriteAttribution } from "../test-attribution.ts";
 import assert from "node:assert/strict";
 import test from "node:test";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Effect } from "effect";
-import { checkTaskProjection, moduleEntityId } from "../../src/index.ts";
+import { checkTaskProjection, moduleEntityId, sha256Text } from "../../src/index.ts";
 import { decisionEntityId, type DecisionPackage } from "../../src/domain/index.ts";
 import { serializeDecisionDocument } from "../../src/domain/decision-document.ts";
 import { makeJournaledWriteCoordinator } from "../../src/index.ts";
@@ -24,6 +24,44 @@ test("WriteCoordinator recovers queued journal entries after crash before waterm
     assert.equal(report.replayedOps, 1);
     assert.equal(report.recoveredWatermark, "op-1");
     assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-1/progress.md"), "utf8"), "replayed");
+  });
+});
+
+test("apply-marker recovery rechecks a doc-sync working-tree body reference", () => {
+  withTempStore((rootDir) => {
+    const opId = "op-doc-sync-applied-recovery";
+    const relativePath = "tasks/task_A/artifacts/large.raw.jsonl";
+    const targetPath = path.join(rootDir, "harness", relativePath);
+    const submittedBody = "submitted evidence\n";
+    mkdirSync(path.dirname(targetPath), { recursive: true });
+    writeFileSync(targetPath, submittedBody, "utf8");
+    const crashed = makeJournaledWriteCoordinator({ attribution: testWriteAttribution(), rootDir });
+    Effect.runSync(crashed.enqueue({
+      opId,
+      entityId: "entity/doc-sync/recovery",
+      kind: "doc_sync_submit",
+      payload: {
+        writes: [{
+          path: relativePath,
+          bodySha256: sha256Text(submittedBody),
+          baseBlobSha256: null
+        }]
+      }
+    }));
+    appendFileSync(
+      path.join(rootDir, ".harness/write-journal/writes.jsonl"),
+      `${JSON.stringify({ schema: "apply-marker/v1", opId, entityId: "entity/doc-sync/recovery", at: "2026-07-31T00:00:00.000Z" })}\n`,
+      "utf8"
+    );
+    writeFileSync(targetPath, "drift after apply marker\n", "utf8");
+
+    const recovered = makeJournaledWriteCoordinator({ attribution: testWriteAttribution(), rootDir });
+    const report = Effect.runSync(recovered.recover);
+
+    assert.equal(report.replayedOps, 0);
+    assert.equal(report.deferredOps, 1);
+    assert.equal(report.recoveredWatermark, undefined);
+    assert.equal(readFileSync(targetPath, "utf8"), "drift after apply marker\n");
   });
 });
 


### PR DESCRIPTION
# English

## Summary

`ha doc sync --submit` (and any `task complete` embedding it) failed deterministically once a task package carried large evidence: the parent process inlined every file body into a single direct IPC frame, and the repo's own frame limits (256 KiB per string, 1 MiB per frame) fired long before Node's IPC. The real-world trigger was a benchmark task archiving 16.4 MiB of subject logs (largest file 8.86 MiB — measured request JSON 19.4 MiB). Worse, the size error was double-wrapped into `RepoWriteNotStartedError(CAPSULE_SEND_FAILED)`, telling the operator "the writer did not start" instead of "the payload is too large" — a lying diagnostic.

Fix: when an inline body is byte-identical to the canonical working-tree file, the parent replaces it with an internal `writer-working-tree/v1` reference; the child re-resolves the authored-root-constrained path, re-reads, and re-verifies `sha256(body) === newBlobSha256`. The real fixture's frame drops from 19.4 MiB to 10.9 KiB. No frame-format change, no protocol version bump, no limit raise.

One adversarial blind-review round found the load-bearing gap (6 P2s, 4 sharing one root cause): the `bodySha256`-only branch validated once at lock-free enqueue and never again. R2 closes the family with a single shared gate: **at apply time — and on the apply-marker recovery path — every `bodySha256`-only write is re-read under the repo lock and must match its declared hash (lstat no-follow, so symlinks cannot ride through); any mismatch rejects the write.** Deletion, rollback-to-base, window tampering, recovery-time drift and symlink smuggling all fail closed, each with a red/green regression.

## What Changed

- `packages/daemon`: parent-side working-tree referencing (`doc-sync-writer-working-tree.ts`), child-side materialization + hash re-verification, `layoutOverrides` passthrough, unified path normalization via `normalizeRelativeDocumentPath`.
- `packages/kernel` (`canonical-authored-batch.ts`, `coordinator.ts`, `durable.ts`): shared publish gate `verifyCanonicalAuthoredWorkingTreeReferences` at apply and recovery; rollback restores only paths actually written; no-follow regular-file assertion.
- `RepoWriteIpcPayloadTooLargeError`: structured size diagnostics (sender, JSON path, boundary, actual/maximum/excess bytes, next step); dispatch layer passes it through as non-retryable instead of downgrading to a retryable `journal_unavailable`.
- Wire boundary rejects externally-constructed `writer-working-tree/v1` content kinds.
- Tests: dispatch-layer suite (208 lines), kernel batch drift/deletion/rollback/symlink/recovery regressions, production cutover large-file path.

## Task And Scope

- Harness task: task_01KYVRBQHQVTGB6JPK164WJ998
- Branch: codex/ipc-frame
- Public scope: daemon doc-sync transport + kernel authored-batch publish gate + diagnostics
- Private planning/evidence updated: yes
- Out of scope: IPC frame format/limits, protocol version, proof semantics, GUI

## Version Impact

- Version: no version change because internal write-path correctness fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — kernel write-coordination authored-batch apply path (production write path)
- Protected surface scope: working-tree reference materialization + publish-time hash gate; no proof relaxation, no limit/protocol change
- Authority: standing flow-defect priority (task-package closeout deterministically blocked); task task_01KYVRBQHQVTGB6JPK164WJ998
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: n/a
- Break-glass scope: n/a
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: 3a1148fa
- Branch merge-base with `origin/main`: 3a1148fa
- Last `git fetch origin` time: 2026-07-31
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/ipc-frame`
- Private evidence commit/path: harness/tasks/task_01KYVRBQHQVTGB6JPK164WJ998-.../task_plan.md (thresholds measured: 262,144/262,145 string boundary, 1,048,576/1,048,577 frame boundary)
- Reviewer evidence path: blind-review findings + R2 disposition (task ledger)
- GitHub Actions `rewrite-ci` run URL: (filled after CI)
- [x] `git diff --check`
- [x] `npm run check:stop-point` — check:local green, 27/27 gates (both rounds)
- [x] Directed regression: R1 71/71, R2 89/89; real 25-file/17.2 MiB fixture submits through a production child (red before, green after)
- [ ] GitHub Actions `rewrite-ci` passed (authoritative full gate)
- Not run, and why: full CI runs on this PR; production drain of the blocked benchmark task happens after deploy.

## Review Evidence

- Self-review: CEO verified the reference path is opt-in only on byte-equality, the publish gate covers both apply and recovery, and the four drift scenarios share one enforcement point rather than four patches.
- Reviewer subagent: one GLM adversarial blind round (production write path). P1: none. P2 x6 confirmed — four (deletion / rollback / tamper-window / recovery) closed by the shared publish gate, symlink sanitization restored via no-follow assertion, size-error downgrade fixed at dispatch. P3: rollback scope and wire-boundary rejection fixed; streaming hash deferred with rationale.
- Human review: not required.
- Blocking findings: none remaining.

## Residual Risk

- Large files are still read fully in memory in parent and child (linear, bounded by file size); streaming hash deferred.
- Files must stay byte-stable between CLI read and daemon parent read to take the reference path; drift falls back to inline (and the frame limit) by design.

## References

- Task: task_01KYVRBQHQVTGB6JPK164WJ998
- Trigger: benchmark task task_01KYVH89BT4P196RW6RDXRTPA2 (16.4 MiB subject logs, kept as repro fixture)
- Review: GLM findings + R2 disposition in the task ledger

---

# 中文

## 概要

任务包一旦带上大证据,`ha doc sync --submit`(以及内嵌它的 `task complete`)就确定性失败:parent 把每个文件的完整正文内嵌进单条 direct IPC 帧,仓库自定义帧限制(单字符串 256 KiB、整帧 1 MiB)先于 Node IPC 触发。真实触发场景是基准任务归档 16.4 MiB subject 日志(最大单文件 8.86 MiB,实测请求 JSON 19.4 MiB)。更糟的是尺寸错误被双层包装成 `RepoWriteNotStartedError(CAPSULE_SEND_FAILED)`——把「payload 太大」说成「writer 没启动」,诊断撒谎。

修法:inline body 与 canonical working-tree 文件逐字节相同时,parent 换成内部 `writer-working-tree/v1` 引用;child 在 authored-root 约束下重解析路径、重读、复核 `sha256(body) === newBlobSha256`。真实夹具帧从 19.4 MiB 降到 10.9 KiB。不改帧格式、不升协议、不提上限。

一轮对抗盲评抓到承重缺口(6 条 P2,其中 4 条同根):`bodySha256` 分支只在无锁 enqueue 时校验一次,后段零复核。R2 用**一道共享门**封死这一族:apply 阶段(以及 apply-marker recovery 路径)持锁重读每个 `bodySha256`-only write 并核对声明 hash(lstat no-follow,symlink 无法搭车);不符即拒。删除、回滚、窗口篡改、recovery 漂移、symlink 走私全部 fail-closed,各有红绿回归。

## 改动内容

- daemon:parent 侧 working-tree 引用化、child 侧物化+hash 复核、`layoutOverrides` 透传、路径规范化统一到 `normalizeRelativeDocumentPath`。
- kernel:apply 与 recovery 共用发布门 `verifyCanonicalAuthoredWorkingTreeReferences`;rollback 只还原真正写过的路径;no-follow 常规文件断言。
- `RepoWriteIpcPayloadTooLargeError`:结构化尺寸诊断(边界、实际/上限/超出字节、下一步);dispatch 层按类型透传为 non-retryable,不再降级成可重试的 `journal_unavailable`。
- wire 边界拒绝外部构造的 `writer-working-tree/v1`。
- 测试:dispatch 层套件、kernel 漂移/删除/rollback/symlink/recovery 回归、production cutover 大文件路径。

## 任务与范围

- Harness 任务:task_01KYVRBQHQVTGB6JPK164WJ998
- 分支:codex/ipc-frame
- 公开范围:daemon doc-sync 传输 + kernel authored-batch 发布门 + 诊断
- 私有规划/证据已更新:是
- 范围外:IPC 帧格式/上限、协议版本、proof 语义、GUI

## 版本影响

- 版本:不改版本,原因是内部写路正确性修复
- 发布影响:不发布

## 治理声明

- 触及 protected surface:是——kernel 写协调 authored-batch apply 路径(生产写路)
- 范围:working-tree 引用物化 + 发布时 hash 门;proof 零放宽、上限/协议零改动
- 授权:流转缺陷最高优先常设授权(任务包销账被确定性阻塞);任务 task_01KYVRBQHQVTGB6JPK164WJ998
- 机检边界:本 PR 只断言声明存在;是否真实充分由评审判断。
- Break-glass:否
- 原因/范围:不适用
- 后续治理任务:无

## 验证

- Base `origin/main` SHA:3a1148fa
- merge-base:3a1148fa
- 最近 `git fetch origin`:2026-07-31
- 同步方式:无需
- 公开 diff 命令:`git diff origin/main...codex/ipc-frame`
- 私有证据:任务 task_plan.md(阈值实测:字符串 262,144/262,145、帧 1,048,576/1,048,577)
- 评审证据:盲评 findings + R2 处置(任务台账)
- `rewrite-ci` run URL:(CI 后回填)
- [x] `git diff --check`
- [x] `npm run check:stop-point`——两轮 check:local 全绿 27/27
- [x] 定向回归:R1 71/71、R2 89/89;真实 25 文件/17.2 MiB 夹具经 production child 提交成功(修前红、修后绿)
- [ ] GitHub Actions `rewrite-ci` 绿(权威完整门)
- 未运行及原因:完整 CI 在本 PR 上跑;被阻塞的基准任务在部署后排干。

## 评审证据

- 自评:CEO 核引用路径仅在字节相等时启用、发布门同时覆盖 apply 与 recovery、四类漂移共用一个执法点而非四个补丁。
- 评审 subagent:一轮 GLM 对抗盲评(生产写路)。P1 无;P2×6 确认——4 条同根由共享发布门封死,symlink 消毒经 no-follow 断言恢复,尺寸错误降级在 dispatch 修正;P3 rollback 范围与 wire 边界已修,流式 hash 暂缓并写明理由。
- 人工评审:不需要。
- 阻塞 findings:无剩余。

## 残留风险

- 大文件在 parent/child 仍整读进内存(线性、有界);流式 hash 暂缓。
- 引用路径要求文件在 CLI 读与 daemon parent 读之间字节稳定;漂移按设计回退 inline(并受帧限制)。

## 参考

- 任务:task_01KYVRBQHQVTGB6JPK164WJ998
- 触发:基准任务 task_01KYVH89BT4P196RW6RDXRTPA2(16.4 MiB 日志,留作复现夹具)
- 评审:GLM findings + R2 处置见任务台账
