### PR TITLE
fix(daemon): wire response deadline through daemon control client

### DIFF
--- a/packages/cli/src/commands/daemon/control.ts
+++ b/packages/cli/src/commands/daemon/control.ts
@@ -1,5 +1,6 @@
 import {
   calculateDaemonArtifactIdentity,
+  defaultDaemonJsonRpcRequestTimeoutMs,
   requestLocalDaemonJsonRpcForTarget,
   type JsonObject,
   type LocalDaemonTarget
@@ -8,6 +9,7 @@ import { makeLocalVersionControlSystem, readDaemonRegistry } from "@harness-anyt
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { readOption } from "../../cli/parse-options.ts";
+import { parsePositiveIntegerOr } from "../../cli/value-utils.ts";
 import { requestLocalDaemonJsonRpc, resolveLocalDaemonTarget } from "../../daemon/client.ts";
 import type { DaemonLaunchConfiguration } from "../../daemon/daemon-launch-spec.ts";
 import {
@@ -68,17 +70,24 @@ export async function runDaemonControl(
     ? "admin.daemon.restart"
     : "admin.daemon.refresh";
   const lifecycle = input.daemonControlLifecycle ?? defaultDaemonControlLifecycle(input);
-  const request = input.requestDaemonControl ?? ((control: DaemonControlRequest) => requestLocalDaemonJsonRpc(
-    input.rootDir,
-    control.method,
-    control.params,
-    5_000,
-    {
-      userRoot: lifecycle.target.userRoot,
-      socketPath: readOption(input.args, "--socket"),
-      allowLegacySocket: false
-    }
-  ));
+  const request = input.requestDaemonControl ?? ((control: DaemonControlRequest) => {
+    const requestTimeoutMs = parsePositiveIntegerOr(
+      process.env.HARNESS_DAEMON_REQUEST_TIMEOUT_MS,
+      defaultDaemonJsonRpcRequestTimeoutMs
+    );
+    return requestLocalDaemonJsonRpc(
+      input.rootDir,
+      control.method,
+      control.params,
+      5_000,
+      {
+        userRoot: lifecycle.target.userRoot,
+        socketPath: readOption(input.args, "--socket"),
+        allowLegacySocket: false,
+        requestTimeoutMs
+      }
+    );
+  });
   const probedGeneration = lifecycle.probeGenerationStatus
     ? generationExpectationFromCapabilityStatus(
       await lifecycle.probeGenerationStatus(lifecycle.target),

--- a/packages/cli/test/daemon-refresh-preflight.test.ts
+++ b/packages/cli/test/daemon-refresh-preflight.test.ts
@@ -1,8 +1,10 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
+import { spawn, type ChildProcess } from "node:child_process";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import net from "node:net";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import test from "node:test";
 import { pathToFileURL } from "node:url";
 import { localUserDaemonEndpoint, requestLocalDaemonJsonRpc } from "../../daemon/src/index.ts";
@@ -17,38 +19,45 @@ import { createFixture } from "./production-authority-canonical-ingress/fixture.
 import { initializeHarness } from "../src/commands/init.ts";
 
 const DAEMON_REFRESH_TEST_TIMEOUT_MS = positiveIntegerEnv("HARNESS_TEST_DAEMON_REFRESH_TIMEOUT_MS", 180_000);
+const DAEMON_REFRESH_AUTOSTART_TIMEOUT_MS = positiveIntegerEnv("HARNESS_TEST_DAEMON_REFRESH_AUTOSTART_TIMEOUT_MS", 20_000);
+const DAEMON_REFRESH_CONTROL_TIMEOUT_MS = positiveIntegerEnv("HARNESS_TEST_DAEMON_REFRESH_CONTROL_TIMEOUT_MS", 10_000);
 const DAEMON_REFRESH_REQUEST_TIMEOUT_MS = positiveIntegerEnv("HARNESS_TEST_DAEMON_REFRESH_REQUEST_TIMEOUT_MS", 90_000);
 
-test("refresh preflight reports the real manifest failure and leaves the running daemon unchanged", { timeout: DAEMON_REFRESH_TEST_TIMEOUT_MS }, async () => {
+test("refresh derives and preflight failure scenarios share one isolated service fixture", { timeout: DAEMON_REFRESH_TEST_TIMEOUT_MS }, async (t) => {
+  const fixtureTiming = new RefreshTestTiming("shared-fixture");
   const fixture = createFixture();
   const userRoot = defaultDaemonUserRoot(fixture.root);
+  const classicRoot = path.join(fixture.root, "classic-repo");
+  const preflightDelayMarker = path.join(fixture.root, "refresh-preflight-delay.marker");
+  const preflightDelayMs = positiveIntegerEnv("HARNESS_TEST_DAEMON_REFRESH_PREFLIGHT_DELAY_MS", 0);
   const env = {
     HARNESS_DAEMON_MODE: "local",
     HARNESS_DAEMON_USER_ROOT: userRoot,
     HARNESS_DAEMON_IDLE_MS: "60000",
-    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
-    HARNESS_DAEMON_REQUEST_TIMEOUT_MS: String(DAEMON_REFRESH_REQUEST_TIMEOUT_MS)
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: String(DAEMON_REFRESH_AUTOSTART_TIMEOUT_MS),
+    HARNESS_DAEMON_REQUEST_TIMEOUT_MS: String(DAEMON_REFRESH_REQUEST_TIMEOUT_MS),
+    ...(preflightDelayMs > 0 ? {
+      HARNESS_TEST_DAEMON_REFRESH_PREFLIGHT_DELAY_MS: String(preflightDelayMs),
+      HARNESS_TEST_DAEMON_REFRESH_PREFLIGHT_DELAY_MARKER: preflightDelayMarker
+    } : {})
   };
   const validManifest = readFileSync(fixture.manifestPath, "utf8");
   try {
-    const registered = runDaemonCommand(fixture.repoRoot, [
+    const registered = fixtureTiming.measure("register", () => runDaemonCommand(fixture.repoRoot, [
       "daemon", "repo", "register",
       "--repo-id", "canonical",
       "--canonical-root", fixture.repoRoot,
       "--user-root", userRoot,
       "--no-link",
       "--json"
-    ], env);
+    ], env));
     assert.equal(registered.ok, true, JSON.stringify(registered));
-    const started = runDaemonCommand(fixture.repoRoot, [
+    const started = fixtureTiming.measure("daemon-start", () => runDaemonCommand(fixture.repoRoot, [
       "daemon", "start", "--service",
       "--authority-manifest", fixture.manifestPath,
       "--json"
-    ], env);
+    ], env));
     assert.equal(started.started, true, JSON.stringify(started));
-    const before = runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env);
-    assert.equal(before.reachable, true, JSON.stringify(before));
-    assert.equal(typeof before.pid, "number");
     const launchReceipt = await requestLocalDaemonJsonRpc(
       fixture.repoRoot,
       "admin.daemon.launch-spec",
@@ -62,84 +71,87 @@ test("refresh preflight reports the real manifest failure and leaves the running
     assert.notEqual(manifestIndex, -1, JSON.stringify(launchSpec));
     assert.equal(launchSpec.args?.[manifestIndex + 1], fixture.manifestPath);
 
-    writeFileSync(fixture.manifestPath, "{}\n", "utf8");
-    const refresh = runRawJsonMaybeFail(fixture.repoRoot, [
-      "daemon", "refresh",
-      "--trigger", "post-merge",
-      "--timeout-ms", "10000",
-      "--user-root", userRoot
-    ], env);
-    assert.notEqual(refresh.status, 0, JSON.stringify(refresh.receipt));
-    assert.match(JSON.stringify(refresh.receipt), /AUTHORITY_PRODUCTION_MANIFEST_SCHEMA_INVALID/u);
-    assert.doesNotMatch(JSON.stringify(refresh.receipt), /did not become reachable/u);
+    await t.test("refresh preflight reports the real manifest failure and leaves the running daemon unchanged", async () => {
+      const timing = new RefreshTestTiming("preflight-failure");
+      const before = runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env);
+      assert.equal(before.reachable, true, JSON.stringify(before));
+      assert.equal(typeof before.pid, "number");
+      try {
+        writeFileSync(fixture.manifestPath, "{}\n", "utf8");
+        const refresh = timing.measure("preflight", () => runRawJsonMaybeFail(fixture.repoRoot, [
+          "daemon", "refresh",
+          "--trigger", "post-merge",
+          "--timeout-ms", String(DAEMON_REFRESH_CONTROL_TIMEOUT_MS),
+          "--user-root", userRoot
+        ], env));
+        assert.notEqual(refresh.status, 0, JSON.stringify(refresh.receipt));
+        assert.match(JSON.stringify(refresh.receipt), /AUTHORITY_PRODUCTION_MANIFEST_SCHEMA_INVALID/u);
+        assert.doesNotMatch(JSON.stringify(refresh.receipt), /did not become reachable/u);
 
-    const after = runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env);
-    assert.equal(after.reachable, true, JSON.stringify(after));
-    assert.equal(after.pid, before.pid);
-    process.kill(before.pid as number, 0);
-    console.log(JSON.stringify({ scenario: "preflight-failure", beforePid: before.pid, afterPid: after.pid, reachable: after.reachable, refresh: refresh.receipt }));
+        const after = runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env);
+        assert.equal(after.reachable, true, JSON.stringify(after));
+        assert.equal(after.pid, before.pid);
+        process.kill(before.pid as number, 0);
+        console.log(JSON.stringify({ scenario: "preflight-failure", beforePid: before.pid, afterPid: after.pid, reachable: after.reachable, refresh: refresh.receipt }));
+      } finally {
+        writeFileSync(fixture.manifestPath, validManifest, "utf8");
+        timing.report();
+      }
+    });
+
+    await t.test("refresh derives the explicit manifest across a mixed registry and converges on a ready replacement", async () => {
+      const timing = new RefreshTestTiming("derived-manifest-refresh");
+      const before = runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env);
+      assert.equal(typeof before.pid, "number");
+
+      mkdirSync(classicRoot, { recursive: true });
+      initializeHarness({ rootDir: classicRoot }, false, "Classic");
+      runDaemonCommand(fixture.repoRoot, [
+        "daemon", "repo", "register", "--repo-id", "classic",
+        "--canonical-root", classicRoot, "--user-root", userRoot, "--no-link", "--json"
+      ], env);
+      const registry = readDaemonRegistry({ userRoot });
+      assert.equal(registry.repos.find((repo) => repo.repoId === "canonical")?.authorityManifestPath, fixture.manifestPath);
+      assert.equal(registry.repos.find((repo) => repo.repoId === "classic")?.authorityManifestPath, undefined);
+
+      if (preflightDelayMs > 0) writeFileSync(preflightDelayMarker, "ready\n", "utf8");
+      const stopPressure = startRefreshCpuPressure();
+      const refreshStartedAt = Date.now();
+      let refresh: ReturnType<typeof runRawJsonMaybeFail>;
+      try {
+        refresh = timing.measure("refresh-total", () => runRawJsonMaybeFail(fixture.repoRoot, [
+          "daemon", "refresh", "--trigger", "post-merge", "--timeout-ms", String(DAEMON_REFRESH_CONTROL_TIMEOUT_MS), "--user-root", userRoot
+        ], env));
+      } finally {
+        stopPressure();
+        rmSync(preflightDelayMarker, { force: true });
+      }
+      const refreshFinishedAt = Date.now();
+      assert.equal(refresh.status, 0, JSON.stringify(refresh.receipt));
+      assert.equal(refresh.receipt.ok, true, JSON.stringify(refresh.receipt));
+      timing.recordRefreshReceipt(refresh.receipt, refreshStartedAt, refreshFinishedAt);
+      const convergence = assertRefreshConvergence(refresh.receipt, before.pid as number);
+      const after = runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env);
+      assert.equal(after.reachable, true, JSON.stringify({ refresh, after }));
+      assert.equal(after.pid, convergence.replacementPid);
+      const beforeService = before.service as { readonly build: { readonly loadedIdentity: string } };
+      const afterService = after.service as {
+        readonly build: { readonly loadedIdentity: string; readonly installedIdentity: string };
+        readonly activeControl: unknown;
+      };
+      assert.equal(afterService.build.loadedIdentity, afterService.build.installedIdentity);
+      assert.equal(afterService.build.loadedIdentity, beforeService.build.loadedIdentity);
+      assert.equal(afterService.activeControl, null);
+      process.kill(after.pid as number, 0);
+      console.log(JSON.stringify({ scenario: "derived-manifest-refresh", events: convergence.events, beforePid: before.pid, afterPid: after.pid, reachable: after.reachable }));
+      timing.report();
+    });
   } finally {
     writeFileSync(fixture.manifestPath, validManifest, "utf8");
-    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    rmSync(preflightDelayMarker, { force: true });
+    await fixtureTiming.measureAsync("daemon-stop", () => stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined));
     rmSync(fixture.root, { recursive: true, force: true });
-  }
-});
-
-test("refresh derives the explicit manifest across a mixed registry and converges on a ready replacement", { timeout: DAEMON_REFRESH_TEST_TIMEOUT_MS }, async () => {
-  const fixture = createFixture();
-  const userRoot = defaultDaemonUserRoot(fixture.root);
-  const classicRoot = path.join(fixture.root, "classic-repo");
-  const env = {
-    HARNESS_DAEMON_MODE: "local",
-    HARNESS_DAEMON_USER_ROOT: userRoot,
-    HARNESS_DAEMON_IDLE_MS: "60000",
-    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
-    HARNESS_DAEMON_REQUEST_TIMEOUT_MS: String(DAEMON_REFRESH_REQUEST_TIMEOUT_MS)
-  };
-  try {
-    runDaemonCommand(fixture.repoRoot, [
-      "daemon", "repo", "register", "--repo-id", "canonical",
-      "--canonical-root", fixture.repoRoot, "--user-root", userRoot, "--no-link", "--json"
-    ], env);
-    const started = runDaemonCommand(fixture.repoRoot, [
-      "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
-    ], env);
-    assert.equal(started.started, true, JSON.stringify(started));
-    const before = runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env);
-    assert.equal(typeof before.pid, "number");
-
-    mkdirSync(classicRoot, { recursive: true });
-    initializeHarness({ rootDir: classicRoot }, false, "Classic");
-    runDaemonCommand(fixture.repoRoot, [
-      "daemon", "repo", "register", "--repo-id", "classic",
-      "--canonical-root", classicRoot, "--user-root", userRoot, "--no-link", "--json"
-    ], env);
-    const registry = readDaemonRegistry({ userRoot });
-    assert.equal(registry.repos.find((repo) => repo.repoId === "canonical")?.authorityManifestPath, fixture.manifestPath);
-    assert.equal(registry.repos.find((repo) => repo.repoId === "classic")?.authorityManifestPath, undefined);
-
-    const refresh = runRawJsonMaybeFail(fixture.repoRoot, [
-      "daemon", "refresh", "--trigger", "post-merge", "--timeout-ms", "10000", "--user-root", userRoot
-    ], env);
-    assert.equal(refresh.status, 0, JSON.stringify(refresh.receipt));
-    assert.equal(refresh.receipt.ok, true, JSON.stringify(refresh.receipt));
-    const convergence = assertRefreshConvergence(refresh.receipt, before.pid as number);
-    const after = runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env);
-    assert.equal(after.reachable, true, JSON.stringify({ refresh, after }));
-    assert.equal(after.pid, convergence.replacementPid);
-    const beforeService = before.service as { readonly build: { readonly loadedIdentity: string } };
-    const afterService = after.service as {
-      readonly build: { readonly loadedIdentity: string; readonly installedIdentity: string };
-      readonly activeControl: unknown;
-    };
-    assert.equal(afterService.build.loadedIdentity, afterService.build.installedIdentity);
-    assert.equal(afterService.build.loadedIdentity, beforeService.build.loadedIdentity);
-    assert.equal(afterService.activeControl, null);
-    process.kill(after.pid as number, 0);
-    console.log(JSON.stringify({ scenario: "derived-manifest-refresh", events: convergence.events, beforePid: before.pid, afterPid: after.pid, reachable: after.reachable }));
-  } finally {
-    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
-    rmSync(fixture.root, { recursive: true, force: true });
+    fixtureTiming.report();
   }
 });
 
@@ -153,7 +165,7 @@ test("refresh explicitly exits the old owner after safe shutdown even with an ac
     HARNESS_DAEMON_MODE: "local",
     HARNESS_DAEMON_USER_ROOT: userRoot,
     HARNESS_DAEMON_IDLE_MS: "60000",
-    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: String(DAEMON_REFRESH_AUTOSTART_TIMEOUT_MS),
     HARNESS_DAEMON_REQUEST_TIMEOUT_MS: String(DAEMON_REFRESH_REQUEST_TIMEOUT_MS),
     HARNESS_TEST_DAEMON_OWNER_RESOURCE_MARKER: markerPath,
     HARNESS_TEST_DAEMON_OWNER_RESOURCE_EVIDENCE: evidencePath,
@@ -179,7 +191,7 @@ test("refresh explicitly exits the old owner after safe shutdown even with an ac
     const persistentClientClosed = new Promise<void>((resolve) => persistentClient!.once("close", () => resolve()));
 
     const refresh = runRawJsonMaybeFail(fixture.repoRoot, [
-      "daemon", "refresh", "--trigger", "post-merge", "--timeout-ms", "10000", "--user-root", userRoot
+      "daemon", "refresh", "--trigger", "post-merge", "--timeout-ms", String(DAEMON_REFRESH_CONTROL_TIMEOUT_MS), "--user-root", userRoot
     ], env);
     const evidence = JSON.parse(readFileSync(evidencePath, "utf8")) as {
       readonly pid: number;
@@ -209,7 +221,7 @@ test("refresh reports a stuck drain timeout and leaves the old owner alive", { t
     HARNESS_DAEMON_MODE: "local",
     HARNESS_DAEMON_USER_ROOT: userRoot,
     HARNESS_DAEMON_IDLE_MS: "60000",
-    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: String(DAEMON_REFRESH_AUTOSTART_TIMEOUT_MS),
     HARNESS_DAEMON_REQUEST_TIMEOUT_MS: String(DAEMON_REFRESH_REQUEST_TIMEOUT_MS),
     HARNESS_TEST_DAEMON_STUCK_DRAIN_MARKER: markerPath,
     NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --import=${pathToFileURL(preloadPath).href}`.trim()
@@ -290,4 +302,66 @@ function assertRefreshConvergence(receipt: Record<string, any>, oldPid: number):
 function positiveIntegerEnv(name: string, fallback: number): number {
   const parsed = Number(process.env[name]);
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+class RefreshTestTiming {
+  private readonly startedAt = performance.now();
+  private readonly phasesMs: Record<string, number> = {};
+  private readonly scenario: string;
+
+  constructor(scenario: string) {
+    this.scenario = scenario;
+  }
+
+  measure<T>(phase: string, operation: () => T): T {
+    const startedAt = performance.now();
+    try {
+      return operation();
+    } finally {
+      this.phasesMs[phase] = roundMs(performance.now() - startedAt);
+    }
+  }
+
+  async measureAsync<T>(phase: string, operation: () => Promise<T>): Promise<T> {
+    const startedAt = performance.now();
+    try {
+      return await operation();
+    } finally {
+      this.phasesMs[phase] = roundMs(performance.now() - startedAt);
+    }
+  }
+
+  recordRefreshReceipt(receipt: Record<string, unknown>, refreshStartedAt: number, refreshFinishedAt: number): void {
+    const requestedAt = Date.parse(String(receipt.requestedAt));
+    const replacement = receipt.replacement as { readonly service?: { readonly startedAt?: unknown } } | undefined;
+    const replacementStartedAt = Date.parse(String(replacement?.service?.startedAt));
+    if (!Number.isFinite(requestedAt) || !Number.isFinite(replacementStartedAt)) return;
+    this.phasesMs["prepare-and-preflight"] = roundMs(Math.max(0, requestedAt - refreshStartedAt));
+    this.phasesMs["drain-exit-and-spawn"] = roundMs(Math.max(0, replacementStartedAt - requestedAt));
+    this.phasesMs["replacement-readiness"] = roundMs(Math.max(0, refreshFinishedAt - replacementStartedAt));
+  }
+
+  report(): void {
+    console.log(JSON.stringify({
+      scenario: `${this.scenario}-timing`,
+      phasesMs: this.phasesMs,
+      totalMs: roundMs(performance.now() - this.startedAt)
+    }));
+  }
+}
+
+function roundMs(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function startRefreshCpuPressure(): () => void {
+  const burners = positiveIntegerEnv("HARNESS_TEST_DAEMON_REFRESH_CPU_BURNERS", 0);
+  const children: ChildProcess[] = Array.from({ length: burners }, () => spawn(
+    process.execPath,
+    ["-e", "while (true) {}"],
+    { stdio: "ignore" }
+  ));
+  return () => {
+    for (const child of children) child.kill("SIGTERM");
+  };
 }

--- a/packages/cli/test/fixtures/daemon-refresh-preflight-background.mjs
+++ b/packages/cli/test/fixtures/daemon-refresh-preflight-background.mjs
@@ -1,0 +1,11 @@
+import { existsSync } from "node:fs";
+import os from "node:os";
+
+if (process.argv.includes("--check") && process.env.HARNESS_TEST_DAEMON_REFRESH_PREFLIGHT_BACKGROUND === "1") {
+  if (process.platform !== "win32") os.setPriority(19);
+  const delayMs = Number(process.env.HARNESS_TEST_DAEMON_REFRESH_PREFLIGHT_DELAY_MS);
+  const markerPath = process.env.HARNESS_TEST_DAEMON_REFRESH_PREFLIGHT_DELAY_MARKER;
+  if (Number.isSafeInteger(delayMs) && delayMs > 0 && markerPath && existsSync(markerPath)) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
+  }
+}

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -99,6 +99,7 @@ export interface LocalDaemonJsonRpcOptions {
   readonly repoIdOverride?: string;
   readonly autoRegisterSingleRepo?: boolean;
   readonly allowLegacySocket?: boolean;
+  readonly requestTimeoutMs?: number;
   readonly autostart?: LocalDaemonAutostartOptions;
   readonly env?: NodeJS.ProcessEnv;
 }
@@ -265,7 +266,7 @@ export async function requestLocalDaemonJsonRpc(
   const socketPath = options.socketPath ?? localUserDaemonEndpoint(userRoot, options.daemonId ?? daemonIdFromEnv(options.env));
   const legacySocketPath = process.platform === "win32" ? undefined : localDaemonSocketPath(rootDir);
   const socket = await connectUnixSocketWithLegacyFallback(socketPath, options.allowLegacySocket === false ? undefined : legacySocketPath, timeoutMs);
-  return requestWithSocket(socket, method, params);
+  return requestWithSocket(socket, method, params, options.requestTimeoutMs);
 }
 
 export async function requestLocalDaemonJsonRpcForTarget(

--- a/packages/daemon/test/local-json-rpc-client.test.ts
+++ b/packages/daemon/test/local-json-rpc-client.test.ts
@@ -13,6 +13,7 @@ import {
   DaemonJsonRpcResponseError,
   JsonRpcLineClient,
   replaceSpawnLocalDaemonForTest,
+  requestLocalDaemonJsonRpc,
   requestLocalDaemonJsonRpcForTarget,
   type LocalDaemonTarget
 } from "../src/client/local-json-rpc-client.ts";
@@ -164,6 +165,33 @@ test("JSON-RPC requests reject within their deadline when the peer never respond
     input.destroy();
     output.destroy();
   }
+});
+
+test("non-autostart requests keep connect and response deadlines separate", async (t) => {
+  if (process.platform === "win32") return;
+  const socketPath = uniqueSocketPath("ha-daemon-explicit-request-timeout");
+  const server = await startJsonRpcServer(socketPath, { ignoreMethod: "admin.daemon.refresh" });
+  t.after(async () => {
+    await closeServer(server);
+    rmSync(socketPath, { force: true });
+  });
+
+  await assert.rejects(
+    requestLocalDaemonJsonRpc(
+      "/tmp/canonical",
+      "admin.daemon.refresh",
+      {},
+      200,
+      {
+        socketPath,
+        allowLegacySocket: false,
+        requestTimeoutMs: 40
+      }
+    ),
+    (error: unknown) => error instanceof DaemonJsonRpcRequestTimeoutError
+      && error.method === "admin.daemon.refresh"
+      && error.timeoutMs <= 40
+  );
 });
 
 test("autostart coalesces concurrent requests to one spawn per socket path", async (t) => {

--- a/tools/repro-daemon-refresh-flake.mjs
+++ b/tools/repro-daemon-refresh-flake.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const targetTest = "packages/cli/test/daemon-refresh-preflight.test.ts";
+const burners = positiveIntegerOption("--burners", Math.max(2, os.availableParallelism() * 2));
+const runs = positiveIntegerOption("--runs", 1);
+
+console.error(JSON.stringify({
+  scenario: "daemon-refresh-resource-pressure",
+  burners,
+  runs,
+  availableParallelism: os.availableParallelism(),
+  pressureWindow: "admin.daemon.refresh"
+}));
+
+let exitCode = 0;
+for (let run = 1; run <= runs; run += 1) {
+  console.error(`[repro] run ${run}/${runs}`);
+  const code = await runTargetTest();
+  if (code !== 0) {
+    exitCode = code;
+    break;
+  }
+}
+
+process.exitCode = exitCode;
+
+function runTargetTest() {
+  const nodeArgs = [
+    "--test",
+    "--test-concurrency=1",
+    "--test-timeout=180000",
+    "--test-name-pattern=refresh derives",
+    targetTest
+  ];
+  const preload = `--import=${path.join(repoRoot, "tools/cli-test-fixture-register.mjs")}`;
+  const preflightBackground = `--import=${path.join(repoRoot, "packages/cli/test/fixtures/daemon-refresh-preflight-background.mjs")}`;
+  const child = spawn(process.execPath, nodeArgs, {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      HARNESS_CLI_TEST_FIXTURE_PRELOAD: "1",
+      HARNESS_TEST_DAEMON_REFRESH_CONTROL_TIMEOUT_MS: "60000",
+      HARNESS_TEST_DAEMON_REFRESH_CPU_BURNERS: String(burners),
+      HARNESS_TEST_DAEMON_REFRESH_PREFLIGHT_DELAY_MS: "40000",
+      HARNESS_TEST_DAEMON_REFRESH_PREFLIGHT_BACKGROUND: "1",
+      NODE_DISABLE_COMPILE_CACHE: "1",
+      NODE_OPTIONS: [process.env.NODE_OPTIONS, preload, preflightBackground].filter(Boolean).join(" ")
+    }
+  });
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      if (signal !== null) {
+        reject(new Error(`resource-pressure test terminated by ${signal}`));
+        return;
+      }
+      resolve(code ?? 1);
+    });
+  });
+}
+
+function positiveIntegerOption(name, fallback) {
+  const inline = process.argv.slice(2).find((arg) => arg.startsWith(`${name}=`));
+  const index = process.argv.indexOf(name);
+  const raw = inline?.slice(name.length + 1) ?? (index === -1 ? undefined : process.argv[index + 1]);
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}


### PR DESCRIPTION
# English

## Summary

Fix the daemon-refresh-preflight test flake root cause: the test's declared 90s deadline was never wired through — the daemon control client's timeout parameter only bounded the socket connect, and the response wait silently fell back to the 35s production default. Under CI load, legitimate ~45s refreshes hit the phantom 35s wall.

## What Changed

- `packages/daemon/src/client/local-json-rpc-client.ts`: separate connect timeout from response timeout; new optional `requestTimeoutMs` is threaded to the response wait.
- `packages/cli/src/commands/daemon/control.ts`: daemon control requests pass a response deadline (env-overridable via `HARNESS_DAEMON_REQUEST_TIMEOUT_MS`, defaulting to the existing production default — production timing constants untouched).
- `packages/cli/test/daemon-refresh-preflight.test.ts`: two same-configuration scenarios now share one isolated daemon fixture (comparable total time ~16.2s → ~11.3s); regression added in the existing fast test file (no tier-manifest change needed).
- `tools/repro-daemon-refresh-flake.mjs`: deterministic load-pressure reproducer (`--burners 32 --runs 2`); red before the fix (45.263s failure at `timeout=34913ms`), green after (two passes at 49.0s/49.3s — proof the deadline is now connected, not that things got faster).

## Task And Scope

- Harness task: task_01KYVQA7ARZMBNEWBKVTMNRYBM
- Branch: codex/refresh-flake
- Public scope: packages/daemon client, packages/cli daemon control + one test, tools reproducer
- Private planning/evidence updated: yes (implementation report in task package artifacts)
- Out of scope: production timeout constants, required checks, daemon server-side deadlines (30s < 35s layering preserved)

## Version Impact

- Version: no version change because this is pre-release trunk development
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task_01KYVQA7ARZMBNEWBKVTMNRYBM (flake-shape investigation mandate: measure, forbid timeout inflation)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 2c4ba085345231213ec73657044b0e340d3b3d91
- Branch merge-base with `origin/main`: 2c4ba085345231213ec73657044b0e340d3b3d91
- Last `git fetch origin` time: 2026-07-31 20:09 CST
- Sync method: none needed
- Public diff command: `git diff 2c4ba085..codex/refresh-flake`
- Private evidence commit/path: harness task package task_01KYVQA7ARZMBNEWBKVTMNRYBM `artifacts/implementation-report.md`
- Reviewer evidence path: implementation report timing tables (pre/post reproducer runs)
- GitHub Actions `rewrite-ci` run URL: pending (will be attached by CI on this PR)
- [x] `git diff --check`
- [x] `npm run check:local` (27 manifest gates green; fast 748/748, contract 477 passed + 1 platform skip)
- [x] Targeted tests: JSON-RPC client 16/16; refresh integration 5/5; reproducer red-before/green-after under identical load
- [ ] GitHub Actions `rewrite-ci` passed (authoritative; pending on this PR)
- Not run, and why: full local `check:ci` not run — GitHub CI on this PR is the authority per repo policy; reproducer priority-branch behavior verified on macOS only (Windows path keeps deterministic delay without priority tweaks)

## Review Evidence

- Self-review: worker measured before asserting — reproducer demonstrates the deterministic 35s wall pre-fix and its removal post-fix under the same 32-burner load; fix is deadline wiring, not timeout inflation (test had already declared 90s; production defaults unchanged)
- Reviewer subagent: CEO diff review (small surface; the change threads an existing declared deadline; negative control = pre-fix reproducer failure at `timeout=34913ms` matches the two observed CI hits on this exact file)
- Human review: CEO semantic acceptance against the task contract (root-cause-not-symptom requirement satisfied)
- Blocking findings: none

## Residual Risk

- `HARNESS_DAEMON_REQUEST_TIMEOUT_MS` is a new env knob on the CLI control path; it defaults to the existing production value and is only read at request construction. Fresh GitHub Actions runs on this PR are the first CI-environment validation of the fix.

## References

- Task: task_01KYVQA7ARZMBNEWBKVTMNRYBM
- Evidence: task package `artifacts/implementation-report.md`
- Review: CEO diff review + reproducer red/green evidence

---

# 中文

## 概要

修复 daemon-refresh-preflight 测试 flake 的根因:测试声明的 90s 期限从未接通——daemon control 客户端的超时参数只限制 socket 连接,响应等待静默回落到 35s 生产默认值。CI 负载下,合法的 ~45s refresh 撞上这堵幽灵 35s 墙。

## 改动内容

- `packages/daemon/src/client/local-json-rpc-client.ts`:分离连接超时与响应超时;新增可选 `requestTimeoutMs` 传入响应等待。
- `packages/cli/src/commands/daemon/control.ts`:daemon control 请求传递响应期限(可经 `HARNESS_DAEMON_REQUEST_TIMEOUT_MS` 覆盖,默认沿用既有生产默认——生产时序常量零改动)。
- `packages/cli/test/daemon-refresh-preflight.test.ts`:两个同配置场景共享一个隔离 daemon fixture(可比总耗时 ~16.2s → ~11.3s);回归写入既有 fast 测试文件,无需改 tier manifest。
- `tools/repro-daemon-refresh-flake.mjs`:确定性负载复现器(`--burners 32 --runs 2`);修前红(45.263s 于 `timeout=34913ms` 失败),修后绿(两轮 49.0s/49.3s 通过——证明是期限接通了,不是变快了)。

## 任务与范围

- Harness 任务:task_01KYVQA7ARZMBNEWBKVTMNRYBM
- 分支:codex/refresh-flake
- 公开范围:daemon 客户端、CLI daemon control + 一个测试、tools 复现器
- 私有计划 / 证据是否已更新:yes(任务包 artifacts 实现报告)
- 范围外:生产超时常量、required checks、daemon 服务端期限(30s < 35s 层级保持)

## 版本影响

- 版本:不改版本,原因是 pre-release 主干开发
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:task_01KYVQA7ARZMBNEWBKVTMNRYBM(flake 形状勘测授权:先测量,禁调大超时)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no

## 验证

- `origin/main` 基准 SHA:2c4ba085345231213ec73657044b0e340d3b3d91
- 当前分支与 `origin/main` 的 merge-base:2c4ba085345231213ec73657044b0e340d3b3d91
- 最近一次 `git fetch origin` 时间:2026-07-31 20:09 CST
- 同步方式:不需要
- 公开 diff 命令:`git diff 2c4ba085..codex/refresh-flake`
- 私有证据 commit/path:任务包 task_01KYVQA7ARZMBNEWBKVTMNRYBM `artifacts/implementation-report.md`
- Reviewer 证据路径:实现报告耗时表(修前/修后复现器运行)
- GitHub Actions `rewrite-ci` run URL:待本 PR CI 生成
- [x] `git diff --check`
- [x] `npm run check:local`(27 门全绿;fast 748/748,contract 477 过 + 1 平台跳过)
- [x] 定向测试:JSON-RPC 客户端 16/16;refresh 集成 5/5;复现器同负载修前红/修后绿
- [ ] GitHub Actions `rewrite-ci` 通过(权威;待本 PR)
- 未跑项及原因:未跑本地 `check:ci` 全量等价——以 GitHub CI 为权威;复现器优先级分支仅在 macOS 验证(Windows 路径保留确定性延迟、不调进程优先级)

## 审查证据

- 自查:worker 先测量后断言——复现器在同一 32-burner 负载下演示修前确定性 35s 墙与修后消失;修法是接通期限而非放宽超时(测试早已声明 90s;生产默认未动)
- 额外审查:CEO diff 审(改面小;改动只是把已声明的期限接通;阴性对照 = 修前复现器在 `timeout=34913ms` 失败,与该文件两次 CI 命中完全同形)
- 人工审查:CEO 按任务契约做语义验收(满足"根因非症状"要求)
- 阻塞发现:无

## 残余风险

- `HARNESS_DAEMON_REQUEST_TIMEOUT_MS` 是 CLI control 路径新增 env 旋钮;默认沿用既有生产值,仅在请求构造时读取。本 PR 的全新 GitHub Actions run 是该修复在 CI 环境的首次验证。

## 关联材料

- 任务:task_01KYVQA7ARZMBNEWBKVTMNRYBM
- 证据:任务包 `artifacts/implementation-report.md`
- 审查:CEO diff 审 + 复现器红绿证据
