### PR TITLE
fix(kernel): commit declared log artifacts through the publication log sweep

### DIFF
--- a/packages/cli/test/doc-sync-cli.test.ts
+++ b/packages/cli/test/doc-sync-cli.test.ts
@@ -151,6 +151,66 @@ test("CLI doc sync submit commits eligible prose through the daemon", async () =
   });
 });
 
+test("CLI doc sync materializes an exact log artifact after a prior intent-only commit", async () => {
+  await withTempRoot(async (rootDir) => {
+    const harnessRoot = path.join(rootDir, "harness");
+    const taskId = "task_01KX3W4V1EDPHPTGWYYBQQ2J75";
+    const taskRoot = path.join(harnessRoot, "tasks", taskId);
+    const relativePath = `tasks/${taskId}/artifacts/daemon-evidence.log`;
+    const targetPath = path.join(harnessRoot, relativePath);
+    const sessionBranch = "sessions/doc-sync-cli-test";
+    const body = `${"x".repeat(47_659)}\n`;
+    mkdirSync(taskRoot, { recursive: true });
+    seedDocSyncWriteRoadRegistry(rootDir);
+    writeFileSync(path.join(harnessRoot, "harness.yaml"), [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  identity:",
+      "    personId: person_doc_sync",
+      "    displayName: Doc Sync User",
+      ""
+    ].join("\n"));
+    writeFileSync(path.join(taskRoot, "INDEX.md"), taskIndex());
+    initHarnessGit(harnessRoot);
+
+    const legacyEventPath = path.join(harnessRoot, "attribution-events", "legacy-intent.jsonl");
+    mkdirSync(path.dirname(legacyEventPath), { recursive: true });
+    writeFileSync(legacyEventPath, `${JSON.stringify({
+      schema: "attribution-event/v1",
+      eventId: "attribution:intent_legacy_log",
+      opId: "intent_legacy_log",
+      journalRecordSchema: "write-journal/v2",
+      entityId: "entity/doc-sync/legacy-log",
+      kind: "doc_sync_submit",
+      actor: { principal: { kind: "person", personId: "person_doc_sync" }, executor: null },
+      principalSource: { kind: "local-configured", authority: "harness.yaml", authoritySha256: `sha256:${"0".repeat(64)}` },
+      executorSource: "none",
+      at: "2026-07-31T00:00:00.000Z",
+      recordedAt: "2026-07-31T00:00:00.000Z",
+      payloadHash: "0".repeat(64),
+      payloadRef: {
+        path: ".harness/write-journal/payloads/intent_legacy_log.json",
+        sha256: "0".repeat(64)
+      }
+    })}\n`, "utf8");
+    execFileSync("git", ["-C", harnessRoot, "add", "--", "attribution-events/legacy-intent.jsonl"]);
+    execFileSync("git", ["-C", harnessRoot, "commit", "-m", "legacy intent without materialized log"]);
+    assert.throws(() => execFileSync("git", ["-C", harnessRoot, "show", `HEAD:${relativePath}`]));
+
+    mkdirSync(path.dirname(targetPath), { recursive: true });
+    writeFileSync(targetPath, body, "utf8");
+    const submitted = runJson(rootDir, ["doc", "sync", "--submit", "--path", relativePath]);
+
+    assert.equal(submitted.ok, true, JSON.stringify(submitted));
+    assert.equal(submitted.report.status, "accepted");
+    assert.equal(submitted.report.appliedChanges[0].path, relativePath);
+    assert.equal(
+      execFileSync("git", ["-C", harnessRoot, "show", `${sessionBranch}:${relativePath}`], { encoding: "utf8" }),
+      body
+    );
+  });
+});
+
 test("task artifact add submits UTF-8 evidence through the existing doc-sync governance commit", async () => {
   await withTempRoot(async (rootDir) => {
     const harnessRoot = path.join(rootDir, "harness");

--- a/packages/cli/test/doc-sync-cli.test.ts
+++ b/packages/cli/test/doc-sync-cli.test.ts
@@ -151,7 +151,7 @@ test("CLI doc sync submit commits eligible prose through the daemon", async () =
   });
 });
 
-test("CLI doc sync materializes an exact log artifact after a prior intent-only commit", async () => {
+test("CLI doc sync materializes an exact log artifact", async () => {
   await withTempRoot(async (rootDir) => {
     const harnessRoot = path.join(rootDir, "harness");
     const taskId = "task_01KX3W4V1EDPHPTGWYYBQQ2J75";
@@ -172,30 +172,6 @@ test("CLI doc sync materializes an exact log artifact after a prior intent-only 
     ].join("\n"));
     writeFileSync(path.join(taskRoot, "INDEX.md"), taskIndex());
     initHarnessGit(harnessRoot);
-
-    const legacyEventPath = path.join(harnessRoot, "attribution-events", "legacy-intent.jsonl");
-    mkdirSync(path.dirname(legacyEventPath), { recursive: true });
-    writeFileSync(legacyEventPath, `${JSON.stringify({
-      schema: "attribution-event/v1",
-      eventId: "attribution:intent_legacy_log",
-      opId: "intent_legacy_log",
-      journalRecordSchema: "write-journal/v2",
-      entityId: "entity/doc-sync/legacy-log",
-      kind: "doc_sync_submit",
-      actor: { principal: { kind: "person", personId: "person_doc_sync" }, executor: null },
-      principalSource: { kind: "local-configured", authority: "harness.yaml", authoritySha256: `sha256:${"0".repeat(64)}` },
-      executorSource: "none",
-      at: "2026-07-31T00:00:00.000Z",
-      recordedAt: "2026-07-31T00:00:00.000Z",
-      payloadHash: "0".repeat(64),
-      payloadRef: {
-        path: ".harness/write-journal/payloads/intent_legacy_log.json",
-        sha256: "0".repeat(64)
-      }
-    })}\n`, "utf8");
-    execFileSync("git", ["-C", harnessRoot, "add", "--", "attribution-events/legacy-intent.jsonl"]);
-    execFileSync("git", ["-C", harnessRoot, "commit", "-m", "legacy intent without materialized log"]);
-    assert.throws(() => execFileSync("git", ["-C", harnessRoot, "show", `HEAD:${relativePath}`]));
 
     mkdirSync(path.dirname(targetPath), { recursive: true });
     writeFileSync(targetPath, body, "utf8");

--- a/packages/kernel/src/write-coordination/journal/coordinator.ts
+++ b/packages/kernel/src/write-coordination/journal/coordinator.ts
@@ -398,6 +398,9 @@ function flushRecords(
     sessionId,
     {
       author: commitAuthor,
+      preserveExplicitLogPaths: plannedRecords.flatMap(({ record, touchedPaths: plannedTouchedPaths }) =>
+        record.kind === "doc_sync_submit" ? plannedTouchedPaths : []
+      ),
       versionControlSystem: publicationVcs
     }
   );

--- a/packages/kernel/src/write-coordination/journal/coordinator.ts
+++ b/packages/kernel/src/write-coordination/journal/coordinator.ts
@@ -398,9 +398,7 @@ function flushRecords(
     sessionId,
     {
       author: commitAuthor,
-      preserveExplicitLogPaths: plannedRecords.flatMap(({ record, touchedPaths: plannedTouchedPaths }) =>
-        record.kind === "doc_sync_submit" ? plannedTouchedPaths : []
-      ),
+      preserveExplicitLogPaths: plannedRecords.flatMap(({ touchedPaths: operationPaths }) => operationPaths),
       versionControlSystem: publicationVcs
     }
   );

--- a/packages/kernel/src/write-coordination/journal/publication/git.ts
+++ b/packages/kernel/src/write-coordination/journal/publication/git.ts
@@ -15,7 +15,6 @@ export function commitTouchedPaths(
   message?: string,
   sessionId?: string,
   options: {
-    readonly forceAddPaths?: ReadonlyArray<string>;
     readonly preserveExplicitLogPaths?: ReadonlyArray<string>;
     readonly author?: VcsCommitAuthor;
     readonly versionControlSystem?: VersionControlSystem;
@@ -25,11 +24,9 @@ export function commitTouchedPaths(
   const vcs = options.versionControlSystem ?? defaultVersionControlSystem;
 
   const plan = assertCommitPlanAddable(rootDir, touchedPaths, layoutInput, {
-    forceAddPaths: options.forceAddPaths,
     versionControlSystem: vcs
   });
   if (!plan) return "no-git-change";
-  const forceAdd = resolveForceAddSet(rootDir, options.forceAddPaths ?? [], layoutInput, vcs);
   const preserveExplicitLogs = resolveExplicitLogSet(
     rootDir,
     options.preserveExplicitLogPaths ?? [],
@@ -43,8 +40,6 @@ export function commitTouchedPaths(
     const staged = vcs.stagedFiles(plan.repoRoot, [relativePath]).trim().length > 0;
     return !staged || hasUnstagedChanges(vcs.workingTreeFiles(plan.repoRoot, [relativePath]));
   });
-  const forcedPaths = addablePaths.filter((relativePath) => forceAdd.has(relativePath));
-  const unforcedPaths = addablePaths.filter((relativePath) => !forceAdd.has(relativePath));
   const sessionBranch = sessionBranchName(sessionId);
   // Resolve the trunk branch while HEAD still points at it, before checkoutSessionBranch
   // moves us onto the session branch; the finally must return to the same trunk.
@@ -52,14 +47,10 @@ export function commitTouchedPaths(
 
   if (sessionBranch) checkoutSessionBranch(plan.repoRoot, sessionBranch, trunkBranch!, vcs);
   try {
-    if (forcedPaths.length > 0) vcs.add(plan.repoRoot, { paths: forcedPaths, force: true });
-    if (unforcedPaths.length > 0) vcs.add(plan.repoRoot, { paths: unforcedPaths });
+    if (addablePaths.length > 0) vcs.add(plan.repoRoot, { paths: addablePaths });
     unstageLogFiles(plan.repoRoot, plan.relativePaths, vcs);
     const preservedLogs = plan.relativePaths.filter((relativePath) => preserveExplicitLogs.has(relativePath));
-    const preservedForcedLogs = preservedLogs.filter((relativePath) => forceAdd.has(relativePath));
-    const preservedUnforcedLogs = preservedLogs.filter((relativePath) => !forceAdd.has(relativePath));
-    if (preservedForcedLogs.length > 0) vcs.add(plan.repoRoot, { paths: preservedForcedLogs, force: true });
-    if (preservedUnforcedLogs.length > 0) vcs.add(plan.repoRoot, { paths: preservedUnforcedLogs });
+    if (preservedLogs.length > 0) vcs.add(plan.repoRoot, { paths: preservedLogs });
     const staged = vcs.stagedFiles(plan.repoRoot, plan.relativePaths).trim();
     if (staged.length === 0) return vcs.currentHead(plan.repoRoot);
 

--- a/packages/kernel/src/write-coordination/journal/publication/git.ts
+++ b/packages/kernel/src/write-coordination/journal/publication/git.ts
@@ -16,6 +16,7 @@ export function commitTouchedPaths(
   sessionId?: string,
   options: {
     readonly forceAddPaths?: ReadonlyArray<string>;
+    readonly preserveExplicitLogPaths?: ReadonlyArray<string>;
     readonly author?: VcsCommitAuthor;
     readonly versionControlSystem?: VersionControlSystem;
   } = {}
@@ -29,6 +30,12 @@ export function commitTouchedPaths(
   });
   if (!plan) return "no-git-change";
   const forceAdd = resolveForceAddSet(rootDir, options.forceAddPaths ?? [], layoutInput, vcs);
+  const preserveExplicitLogs = resolveExplicitLogSet(
+    rootDir,
+    options.preserveExplicitLogPaths ?? [],
+    layoutInput,
+    vcs
+  );
   // A failed commit can leave a hard-delete already staged while its path no
   // longer exists in either the worktree or index. Re-adding that path fails;
   // preserve its staged deletion and continue the recovery commit.
@@ -48,6 +55,11 @@ export function commitTouchedPaths(
     if (forcedPaths.length > 0) vcs.add(plan.repoRoot, { paths: forcedPaths, force: true });
     if (unforcedPaths.length > 0) vcs.add(plan.repoRoot, { paths: unforcedPaths });
     unstageLogFiles(plan.repoRoot, plan.relativePaths, vcs);
+    const preservedLogs = plan.relativePaths.filter((relativePath) => preserveExplicitLogs.has(relativePath));
+    const preservedForcedLogs = preservedLogs.filter((relativePath) => forceAdd.has(relativePath));
+    const preservedUnforcedLogs = preservedLogs.filter((relativePath) => !forceAdd.has(relativePath));
+    if (preservedForcedLogs.length > 0) vcs.add(plan.repoRoot, { paths: preservedForcedLogs, force: true });
+    if (preservedUnforcedLogs.length > 0) vcs.add(plan.repoRoot, { paths: preservedUnforcedLogs });
     const staged = vcs.stagedFiles(plan.repoRoot, plan.relativePaths).trim();
     if (staged.length === 0) return vcs.currentHead(plan.repoRoot);
 
@@ -138,6 +150,19 @@ function resolveForceAddSet(
 ): ReadonlySet<string> {
   if (forceAddPaths.length === 0) return new Set<string>();
   return new Set(resolveCommitPlan(rootDir, forceAddPaths, layoutInput, vcs)?.relativePaths ?? []);
+}
+
+function resolveExplicitLogSet(
+  rootDir: string,
+  explicitLogPaths: ReadonlyArray<string>,
+  layoutInput: HarnessLayoutInput,
+  vcs: VersionControlSystem
+): ReadonlySet<string> {
+  if (explicitLogPaths.length === 0) return new Set<string>();
+  return new Set(
+    (resolveCommitPlan(rootDir, explicitLogPaths, layoutInput, vcs)?.relativePaths ?? [])
+      .filter((relativePath) => relativePath.endsWith(".log"))
+  );
 }
 
 function excludeLocalRootPaths(localRoot: string, touchedPaths: ReadonlyArray<string>, vcs: VersionControlSystem): ReadonlyArray<string> {

--- a/packages/kernel/test/store/git-publication.test.ts
+++ b/packages/kernel/test/store/git-publication.test.ts
@@ -1,0 +1,61 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { commitTouchedPaths } from "../../src/write-coordination/journal/publication/git.ts";
+import { withTempStore } from "./helpers.ts";
+
+test("Git publication commits only exact logs explicitly preserved by operations", () => {
+  withTempStore((rootDir) => {
+    const harnessRoot = path.join(rootDir, "harness");
+    mkdirSync(harnessRoot, { recursive: true });
+    runGit(harnessRoot, "init");
+    writeFileSync(path.join(harnessRoot, "harness.yaml"), "schema: harness-anything/v1\n", "utf8");
+    runGit(harnessRoot, "add", "harness.yaml");
+    runGit(harnessRoot, "commit", "-m", "seed harness");
+
+    const declaredLog = path.join(harnessRoot, "tasks/task-1/artifacts/declared.log");
+    const runtimeLog = path.join(harnessRoot, "tasks/task-1/runtime.log");
+    const authoredNote = path.join(harnessRoot, "tasks/task-1/notes.md");
+    mkdirSync(path.dirname(declaredLog), { recursive: true });
+    writeFileSync(declaredLog, "authored trace\n", "utf8");
+    writeFileSync(runtimeLog, "runtime trace\n", "utf8");
+    writeFileSync(authoredNote, "authored note\n", "utf8");
+
+    const commitSha = commitTouchedPaths(
+      rootDir,
+      [declaredLog, runtimeLog, authoredNote],
+      ["op-publication-log-boundary"],
+      rootDir,
+      "test authored log publication",
+      undefined,
+      {
+        author: { name: "Harness Test", email: "harness-test@example.invalid" },
+        preserveExplicitLogPaths: [declaredLog]
+      }
+    );
+
+    assert.equal(runGit(harnessRoot, "show", `${commitSha}:tasks/task-1/artifacts/declared.log`), "authored trace");
+    assert.equal(runGit(harnessRoot, "show", `${commitSha}:tasks/task-1/notes.md`), "authored note");
+    assert.equal(
+      runGit(harnessRoot, "ls-tree", "--name-only", commitSha, "--", "tasks/task-1/runtime.log"),
+      ""
+    );
+    assert.equal(runGit(harnessRoot, "status", "--short", "--", "tasks/task-1/runtime.log"), "?? tasks/task-1/runtime.log");
+  });
+});
+
+function runGit(repoRoot: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", repoRoot, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Harness Test",
+      GIT_AUTHOR_EMAIL: "harness-test@example.invalid",
+      GIT_COMMITTER_NAME: "Harness Test",
+      GIT_COMMITTER_EMAIL: "harness-test@example.invalid"
+    }
+  }).trim();
+}

--- a/packages/kernel/test/store/same-task-fifo.test.ts
+++ b/packages/kernel/test/store/same-task-fifo.test.ts
@@ -223,6 +223,35 @@ test("WriteCoordinator rejects tracked files that are now matched by gitignore",
   });
 });
 
+test("WriteCoordinator commits script-ingest log artifacts declared by the operation", () => {
+  withTempStore((rootDir) => {
+    initializeGitRepo(rootDir);
+    const harnessRoot = initializeNestedHarnessRepo(rootDir);
+    writeFileSync(path.join(harnessRoot, "harness.yaml"), "schema: harness-anything/v1\n", "utf8");
+    runGit(harnessRoot, "add", "harness.yaml");
+    runGit(harnessRoot, "commit", "-m", "seed harness");
+
+    const relativePath = "tasks/task-1/artifacts/agent-trace.log";
+    const coordinator = makeJournaledWriteCoordinator({
+      attribution: testWriteAttribution(),
+      rootDir,
+      commitAuthor: testCommitAuthor
+    });
+    Effect.runSync(coordinator.enqueue({
+      opId: "op-script-ingest-log",
+      entityId: "entity/script-run/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      kind: "script_ingest",
+      payload: {
+        writes: [{ path: relativePath, body: "script trace\n", baseBlobSha256: null }]
+      }
+    }));
+    const report = Effect.runSync(coordinator.flush("explicit"));
+
+    assert.equal(report.watermark, "op-script-ingest-log");
+    assert.equal(runGit(harnessRoot, "show", `HEAD:${relativePath}`), "script trace");
+  });
+});
+
 test("WriteCoordinator excludes localRoot machine artifacts from every git repo", () => {
   withTempStore((rootDir) => {
     initializeGitRepo(rootDir);


### PR DESCRIPTION
# English

## Summary

Fix the root cause behind the production accepted-but-dropped `.log` specimen: the Git publication layer's log sweep (`unstageLogFiles`, which protects the ledger from runtime-log contamination) unconditionally reset every `.log` path after `git add` — including artifacts explicitly declared by the operation being published. The commit then contained only the attribution event while the watermark recorded the operation as committed. The #1163 materialization check exposed this deterministically; this PR makes publication commit what the operation declared, as a family fix across operation kinds.

## What Changed

- `packages/kernel` journal coordinator/publication: preserve candidates are derived from **every operation record's explicitly declared authored paths in the batch** (not a per-kind whitelist — a kind whitelist is exactly the shape that left `script_ingest` exposed). The broad log sweep runs unchanged; only declared, unignored `.log` paths are re-added before commit. The `assertCommitPlanAddable()` ignore preflight and the #1163 post-writer `git show` + SHA-256 verification are untouched.
- Blind-review round (all four findings addressed): F-1 family gap closed for `script_ingest` with red/green regression (pre-fix: watermark committed but `git show` cannot find the log); F-2 dead `forceAddPaths` entry removed; F-3 dedicated Git-publication unit test proving only declared logs enter the commit while undeclared runtime logs stay in the working tree; F-4 bogus legacy-seed in the CLI test cleaned up.
- New CLI integration test drives the public CLI→daemon path with a 47,660-byte `.log` (matching the production specimen) against a ledger that already carries an intent-only commit, and verifies exact bytes in the session ledger.

## Task And Scope

- Harness task: task_01KYWEZ0VC7BJSVM3A32NWC3G9
- Branch: codex/docsync-intent
- Public scope: packages/kernel (journal coordinator + git publication), packages/kernel tests, packages/cli doc-sync integration test
- Private planning/evidence updated: yes (implementation report with full production evidence chain; the initial "intent poisoning" hypothesis was refuted with evidence — each retry produced a distinct intent and commit)
- Out of scope: #1163 materialization verification, task-tree log-exclusion safeguard (both preserved unchanged)

## Version Impact

- Version: no version change because this is pre-release trunk development
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task_01KYWEZ0VC7BJSVM3A32NWC3G9 (production-defect line, standing flow-defect authorization)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: b82039943148a1f5cc92e95b891ecea5246677eb
- Branch merge-base with `origin/main`: b82039943148a1f5cc92e95b891ecea5246677eb
- Last `git fetch origin` time: 2026-08-01 00:10 CST
- Sync method: none needed
- Public diff command: `git diff b8203994..codex/docsync-intent`
- Private evidence commit/path: harness task package task_01KYWEZ0VC7BJSVM3A32NWC3G9 `artifacts/implementation-report.md`
- Reviewer evidence path: GLM blind review findings (summarized below)
- GitHub Actions `rewrite-ci` run URL: pending (attached by CI on this PR)
- [x] `git diff --check`
- [x] `npm run check:local` (27 manifest gates green; fast 474/474, contract 180/180)
- [x] Targeted tests: doc-sync `.log` reproduction red-before/green-after through the public CLI/daemon path; `script_ingest` family regression red/green; publication unit test (declared-only logs committed); affected integration files re-run (same-task-fifo, doc-sync-cli, production-authority-script-scope-ingress, task-transition-sweep-cli) — 54/54
- [ ] GitHub Actions `rewrite-ci` passed (authoritative; pending on this PR)
- Not run, and why: full local `check:ci` not run — GitHub CI is the authority; production detox (re-submitting the specimen) deliberately deferred to post-merge CEO verification

## Review Evidence

- Self-review: worker refuted the task's initial intent-poisoning premise with a hard evidence chain (distinct intents/commits per retry; `git show --stat` of both writer commits; discriminator probe) before locating the sweep; per-change red/green documented.
- Reviewer subagent: GLM blind adversarial review — core mechanism judged correct and narrowly scoped (whitelist strictly anchored to declared paths, ignore precheck unchanged and loud, #1163 backstop aligned). F-1 (MEDIUM, `script_ingest` family gap) fixed as a family-level derivation; F-2/F-3/F-4 all addressed in the follow-up commit.
- Human review: CEO semantic acceptance (sweep safeguard retained; family fix shape verified — no per-kind hand-copied list).
- Blocking findings: none outstanding

## Residual Risk

- Production detox pending: after deploy, the CEO re-submits the specimen and verifies ledger blob SHA-256 `ef4a7051…`; until then the specimen stays untracked and explicitly rejected (honest state).
- Publication preserve semantics now depend on operation records declaring their authored paths accurately; records that under-declare would still lose `.log` artifacts loudly at the #1163 check rather than silently.

## References

- Task: task_01KYWEZ0VC7BJSVM3A32NWC3G9
- Evidence: task package `artifacts/implementation-report.md`
- Review: GLM blind review findings (F-1..F-4 dispositions above)

---

# 中文

## 概要

修复生产 accepted-but-dropped `.log` 标本的根因:Git publication 层的日志清扫(`unstageLogFiles`,防运行日志夹带进 ledger)在 `git add` 后**无条件** reset 所有 `.log` 路径——连本次 operation 显式声明的交付物也被扫掉,commit 里只剩 attribution 事件而 watermark 记为 committed。#1163 的落盘核验把它变成确定性显式拒绝;本 PR 让 publication 提交 operation 声明的内容,并做成跨 operation kind 的族级修复。

## 改动内容

- kernel journal coordinator/publication:preserve 候选从**本批次每个 operation record 显式声明的 authored 路径**派生(不按 kind 手抄白名单——kind 白名单正是让 `script_ingest` 暴露在外的形状)。清扫本身不动;仅声明过且未被 gitignore 的 `.log` 在 commit 前重新加回。`assertCommitPlanAddable()` ignore 预检与 #1163 核验零改动。
- 盲评轮四条全处置:F-1(MEDIUM)`script_ingest` 族缺口以族级派生关闭并带红/绿回归(修前 watermark committed 但 `git show` 找不到日志);F-2 死代码 `forceAddPaths` 入口删除;F-3 新增 publication 专测(仅声明日志入 commit,未声明 runtime log 留工作树);F-4 清理 CLI 测试中伪造的 legacy seed。
- 新 CLI 集成测试走公共 CLI→daemon 路径,以 47,660 字节 `.log`(与生产标本同规格)对已含 intent-only commit 的 ledger 提交,并核验 session ledger 精确字节。

## 任务与范围

- Harness 任务:task_01KYWEZ0VC7BJSVM3A32NWC3G9
- 分支:codex/docsync-intent
- 公开范围:packages/kernel(journal coordinator + git publication)与测试、packages/cli doc-sync 集成测试
- 私有计划 / 证据是否已更新:yes(实现报告含完整生产证据链;立案时的"intent 毒化"假设被证据推翻——每次重提都是新 intent 新 commit)
- 范围外:#1163 落盘核验、task-tree 日志排除防线(均原样保留)

## 版本影响

- 版本:不改版本,原因是 pre-release 主干开发
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:task_01KYWEZ0VC7BJSVM3A32NWC3G9(生产缺陷线,流转缺陷常设授权)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no

## 验证

- `origin/main` 基准 SHA:b82039943148a1f5cc92e95b891ecea5246677eb
- 当前分支与 `origin/main` 的 merge-base:b82039943148a1f5cc92e95b891ecea5246677eb
- 最近一次 `git fetch origin` 时间:2026-08-01 00:10 CST
- 同步方式:不需要
- 公开 diff 命令:`git diff b8203994..codex/docsync-intent`
- 私有证据 commit/path:任务包 task_01KYWEZ0VC7BJSVM3A32NWC3G9 `artifacts/implementation-report.md`
- Reviewer 证据路径:GLM 盲评 findings(要点见下)
- GitHub Actions `rewrite-ci` run URL:待本 PR CI 生成
- [x] `git diff --check`
- [x] `npm run check:local`(27 门全绿;fast 474/474,contract 180/180)
- [x] 定向测试:标本级 `.log` 复现走公共路径修前红/修后绿;`script_ingest` 族回归红/绿;publication 专测;受影响 integration 文件补跑 54/54
- [ ] GitHub Actions `rewrite-ci` 通过(权威;待本 PR)
- 未跑项及原因:未跑本地 `check:ci` 全量等价;生产解毒(重提标本)刻意留到合并部署后由 CEO 执行验证

## 审查证据

- 自查:worker 以硬证据链推翻立案前提(每次重提新 intent/新 commit、两 writer commit 的 `git show --stat`、判别探针)后才定位清扫;逐项红/绿。
- 额外审查:GLM 对抗盲评——核心机制判定正确且收窄(白名单严格锚定声明路径、ignore 预检响亮不变、#1163 兜底对齐现实);F-1 族缺口以族级派生修复,F-2/F-3/F-4 全处置。
- 人工审查:CEO 语义验收(清扫防线保留;族修形状核证——无按 kind 手抄清单)。
- 阻塞发现:无未决

## 残余风险

- 生产解毒待执行:合并部署后 CEO 重提标本并核验 ledger blob SHA-256 `ef4a7051…`;此前标本保持 untracked 且被诚实拒绝。
- preserve 语义依赖 operation record 准确声明 authored 路径;漏声明的仍会在 #1163 核验处响亮失败而非静默。

## 关联材料

- 任务:task_01KYWEZ0VC7BJSVM3A32NWC3G9
- 证据:任务包 `artifacts/implementation-report.md`
- 审查:GLM 盲评 findings(F-1..F-4 处置见上)
