### PR TITLE
fix(test): reap wedged node-test isolation children platform-neutrally

### DIFF
--- a/packages/cli/test/compound-receipt-durability.test.ts
+++ b/packages/cli/test/compound-receipt-durability.test.ts
@@ -14,6 +14,7 @@ import {
   type ReceiptIdentity
 } from "../../application/src/index.ts";
 import { createDurableCompoundReceiptStore, renderCompoundCliExit } from "../src/receipt/index.ts";
+import { forceTerminateChildAndWait } from "../../../tools/test-child-process-lifecycle.mjs";
 
 const workerFlag = "--compound-receipt-crash-worker";
 const identity: ReceiptIdentity = {
@@ -88,8 +89,7 @@ async function runUntilDurableThenKill(directory: string, phase: CompoundReceipt
     child.once("error", reject);
     child.once("exit", (code) => reject(new Error(`crash worker exited before kill (${code}): ${stderr}`)));
   });
-  assert.equal(child.kill("SIGKILL"), true);
-  await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+  await forceTerminateChildAndWait(child, { label: "compound receipt crash worker" });
 }
 
 async function advanceTo(directory: string, phase: CompoundReceiptPhase): Promise<void> {

--- a/packages/cli/test/daemon-generation-disease-integration.test.ts
+++ b/packages/cli/test/daemon-generation-disease-integration.test.ts
@@ -19,6 +19,7 @@ import {
   stopDaemon
 } from "./helpers/daemon-cli.ts";
 import { createFixture } from "./production-authority-canonical-ingress/fixture.ts";
+import { forceTerminateChildAndWait } from "../../../tools/test-child-process-lifecycle.mjs";
 
 test("kill -9 replacement fences stale terminal residue across launch status control and receipt", {
   skip: process.platform === "win32" ? "SIGKILL and durable generation publication are unavailable on Windows" : false,
@@ -175,9 +176,8 @@ test("kill -9 replacement fences stale terminal residue across launch status con
     assert.equal((rejected.context as Record<string, unknown>).schema, "daemon-generation-write-rejection/v1");
     assert.equal(readFileSync(statePath).equals(currentBytes), true, "stale terminal attempt changed replacement receipt bytes");
   } finally {
-    for (const child of children) {
-      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
-    }
+    await Promise.all(children.map((child) =>
+      forceTerminateChildAndWait(child, { label: "generation disease racer" })));
     await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
     rmSync(fixture.root, { recursive: true, force: true });
   }

--- a/packages/cli/test/daemon-thin-client-cli.test.ts
+++ b/packages/cli/test/daemon-thin-client-cli.test.ts
@@ -5,6 +5,7 @@ import { existsSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import net from "node:net";
 import path from "node:path";
 import test from "node:test";
+import { forceTerminateChildAndWait } from "../../../tools/test-child-process-lifecycle.mjs";
 import { JsonRpcLineClient } from "../../daemon/src/index.ts";
 import { readDaemonClientConfig } from "../src/daemon/client.ts";
 import {
@@ -169,9 +170,7 @@ test("persistent daemon connection prevents idle exit after a command settles", 
   });
 });
 
-test("SIGKILL of a GUI notification holder closes its socket and restores daemon idle exit", {
-  skip: process.platform === "win32" ? "SIGKILL is unavailable on Windows" : false
-}, async () => {
+test("abrupt exit of a GUI notification holder closes its socket and restores daemon idle exit", async () => {
   await withTempRootAsync(async (rootDir) => {
     const userRoot = defaultDaemonUserRoot(rootDir);
     runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "fixture", HARNESS_DAEMON_USER_ROOT: userRoot });
@@ -207,8 +206,7 @@ test("SIGKILL of a GUI notification holder closes its socket and restores daemon
       await waitForChildOutput(holder, "GUI_NOTIFICATION_SOCKET_READY");
       await pollDaemonConnectionCount(readDaemonStatus, 2);
 
-      assert.equal(holder.kill("SIGKILL"), true);
-      await new Promise<void>((resolve) => holder.once("exit", () => resolve()));
+      await forceTerminateChildAndWait(holder, { label: "GUI notification holder" });
       // This status probe is the only remaining connection. Once it closes,
       // the daemon's active count returns to zero and its idle timer starts.
       await pollDaemonConnectionCount(readDaemonStatus, 1);
@@ -223,7 +221,9 @@ test("SIGKILL of a GUI notification holder closes its socket and restores daemon
       );
       assert.equal(daemon.exitCode, 0);
     } finally {
-      if (holder.exitCode === null && holder.signalCode === null) holder.kill("SIGKILL");
+      if (holder.exitCode === null && holder.signalCode === null) {
+        await forceTerminateChildAndWait(holder, { label: "GUI notification holder cleanup" }).catch(() => undefined);
+      }
       if (!statusSocket.destroyed) {
         statusClient.close();
         statusSocket.destroy();

--- a/packages/daemon/test/compound-terminal-sequence-fence.test.ts
+++ b/packages/daemon/test/compound-terminal-sequence-fence.test.ts
@@ -8,6 +8,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { createCompoundReceiptServiceV2 } from "@harness-anything/application";
 import { createDurableCompoundReceiptStoreV2 } from "../src/index.ts";
+import { forceTerminateChildAndWait } from "../../../tools/test-child-process-lifecycle.mjs";
 
 test("two processes publishing the same terminal sequence cannot overwrite each other", async () => {
   const root = mkdtempSync(path.join(os.tmpdir(), "ha-terminal-sequence-race-"));
@@ -53,7 +54,8 @@ test("two processes publishing the same terminal sequence cannot overwrite each 
     assert.equal(recovered?.terminalLSN, 1);
     assert.equal(recovered?.sequence, initial.sequence + 1);
   } finally {
-    for (const child of children) child.kill("SIGKILL");
+    await Promise.all(children.map((child) =>
+      forceTerminateChildAndWait(child, { label: "terminal sequence racer" })));
     rmSync(root, { recursive: true, force: true });
   }
 });

--- a/packages/daemon/test/daemon-generation-write-fence.test.ts
+++ b/packages/daemon/test/daemon-generation-write-fence.test.ts
@@ -28,6 +28,7 @@ import {
   publishNextDaemonGeneration,
   readOrCreateDaemonMachineId
 } from "../src/index.ts";
+import { forceTerminateChildAndWait } from "../../../tools/test-child-process-lifecycle.mjs";
 
 const posixOnly = process.platform === "win32"
   ? "durable generation publication is unsupported on Windows"
@@ -202,7 +203,8 @@ test("disease B: stale daemon cannot win compound terminal CAS after replacement
     assert.equal((staleResult.context as { schema?: string }).schema, "daemon-generation-write-rejection/v1");
     assert.equal(readFileSync(statePath).equals(afterCurrent), true, "stale child overwrote current terminal bytes");
   } finally {
-    for (const child of children) child.kill("SIGKILL");
+    await Promise.all(children.map((child) =>
+      forceTerminateChildAndWait(child, { label: "daemon generation racer" })));
     rmSync(root, { recursive: true, force: true });
   }
 });
@@ -253,7 +255,8 @@ test("two abandoned-lock contenders cannot quarantine the newly acquired winner"
     contenderB.send("release");
     assert.deepEqual(await nextChildMessage(contenderB), { type: "done", contenderId: "b" });
   } finally {
-    for (const child of children) child.kill("SIGKILL");
+    await Promise.all(children.map((child) =>
+      forceTerminateChildAndWait(child, { label: "daemon generation lock contender" })));
     rmSync(root, { recursive: true, force: true });
   }
 });

--- a/packages/daemon/test/daemon-writer-reader-cutover.test.ts
+++ b/packages/daemon/test/daemon-writer-reader-cutover.test.ts
@@ -25,6 +25,10 @@ import { createFixture } from "../../cli/test/production-authority-canonical-ing
 import { cliTestEnv } from "../../cli/test/helpers/cli-test-env.ts";
 import { parseNewTaskArgs } from "../../cli/src/cli/parsers/new-task.ts";
 import { createTaskPackagePath } from "@harness-anything/kernel";
+import {
+  forceTerminateChildAndWait,
+  terminateChildAndWait
+} from "../../../tools/test-child-process-lifecycle.mjs";
 
 const integrationTest = process.platform === "win32" ? test.skip : test;
 const amplifierDelayMs = 5_250;
@@ -376,14 +380,13 @@ async function connectWhenReady(
 
 async function stopDaemon(daemon: ChildProcessWithoutNullStreams): Promise<void> {
   if (daemon.exitCode !== null || daemon.signalCode !== null) return;
-  daemon.kill("SIGTERM");
-  const exited = await Promise.race([
-    new Promise<true>((resolve) => daemon.once("exit", () => resolve(true))),
-    delay(1_000).then(() => false)
-  ]);
-  if (exited) return;
-  daemon.kill("SIGKILL");
-  await new Promise<void>((resolve) => daemon.once("exit", () => resolve()));
+  try {
+    await terminateChildAndWait(daemon, (target) => {
+      if (!target.kill("SIGTERM")) throw new Error("daemon rejected SIGTERM");
+    }, { timeoutMs: 1_000, label: "writer-reader daemon" });
+  } catch {
+    await forceTerminateChildAndWait(daemon, { label: "writer-reader daemon" });
+  }
 }
 
 async function waitFor(

--- a/packages/daemon/test/fence-durability.test.ts
+++ b/packages/daemon/test/fence-durability.test.ts
@@ -13,6 +13,7 @@ import {
   readSingleAuthorityDurabilityLedger,
   runSingleAuthorityBoundedRpoCommit
 } from "../src/index.ts";
+import { forceTerminateChildAndWait } from "../../../tools/test-child-process-lifecycle.mjs";
 
 test("bounded-RPO commit audits every fsync boundary and withholds COMMITTED when backup is unsatisfied", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "ha-durability-order-"));
@@ -236,7 +237,9 @@ test("kill -9 and restart preserves every fsynced durability audit record", asyn
       "commit-after-restart"
     );
   } finally {
-    if (activeChild?.exitCode === null && activeChild.signalCode === null) activeChild.kill("SIGKILL");
+    if (activeChild?.exitCode === null && activeChild.signalCode === null) {
+      await forceTerminateChildAndWait(activeChild, { label: "durability audit child cleanup" }).catch(() => undefined);
+    }
     await rm(root, { recursive: true, force: true });
   }
 });

--- a/packages/daemon/test/repo-write-child-process-transport.test.ts
+++ b/packages/daemon/test/repo-write-child-process-transport.test.ts
@@ -4,7 +4,7 @@ import {
   fork,
   type ChildProcess
 } from "node:child_process";
-import { EventEmitter, once } from "node:events";
+import { EventEmitter } from "node:events";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 import {
@@ -21,6 +21,10 @@ import {
   type RepoWriteChildMessage
 } from "../src/runtime/repo-write-protocol.ts";
 import { committedCommandReceipt } from "./support/repo-write-terminal-fixture.ts";
+import {
+  forceTerminateChildAndWait,
+  waitForChildExit
+} from "../../../tools/test-child-process-lifecycle.mjs";
 
 const fixturePath = fileURLToPath(new URL("./support/repo-write-ipc-child.ts", import.meta.url));
 
@@ -314,13 +318,12 @@ function assertDisconnect(error: Error, reason: RepoWriteProcessDisconnectError[
 }
 
 async function waitForExit(child: ChildProcess): Promise<void> {
-  if (child.exitCode !== null || child.signalCode !== null) return;
-  await once(child, "exit");
+  await waitForChildExit(child, { label: "repo-write child process" });
 }
 
-function stop(transport: RepoWriteParentProcessTransport): void {
+async function stop(transport: RepoWriteParentProcessTransport): Promise<void> {
   if (transport.child.exitCode === null && transport.child.signalCode === null) {
-    transport.terminate("SIGKILL");
+    await forceTerminateChildAndWait(transport.child, { label: "repo-write child cleanup" });
   }
 }
 

--- a/tools/node-test-completion-ledger.mjs
+++ b/tools/node-test-completion-ledger.mjs
@@ -39,7 +39,8 @@ export function parseCompletionLedger(source, repoRoot) {
       failures.push({
         file,
         name: record.name,
-        signal: typeof record.signal === "string" ? record.signal : null
+        signal: typeof record.signal === "string" ? record.signal : null,
+        exitCode: Number.isInteger(record.exitCode) ? record.exitCode : null
       });
       continue;
     }
@@ -90,13 +91,18 @@ export function canIgnoreReapedFileFailures({
     || ledger.failures.some((failure) =>
       !reapedFiles.has(failure.file)
       || failure.name !== failure.file
-      || failure.signal !== "SIGKILL"
+      || !isForcedTermination(failure)
     )
   ) {
     return false;
   }
   return ledger.runSummary.success === false
     && ledger.runSummary.counts.failed === reapedFiles.size;
+}
+
+function isForcedTermination(failure) {
+  return failure.signal === "SIGKILL"
+    || (failure.signal === null && Number.isInteger(failure.exitCode) && failure.exitCode !== 0);
 }
 
 function repositoryRelativeFile(file, repoRoot) {

--- a/tools/node-test-completion-ledger.mjs
+++ b/tools/node-test-completion-ledger.mjs
@@ -90,7 +90,7 @@ export function canIgnoreReapedFileFailures({
     ledger.failures.length !== reapedFiles.size
     || ledger.failures.some((failure) =>
       !reapedFiles.has(failure.file)
-      || failure.name !== failure.file
+      || !reportedFileNameMatches(failure.name, failure.file)
       || !isForcedTermination(failure)
     )
   ) {
@@ -103,6 +103,10 @@ export function canIgnoreReapedFileFailures({
 function isForcedTermination(failure) {
   return failure.signal === "SIGKILL"
     || (failure.signal === null && Number.isInteger(failure.exitCode) && failure.exitCode !== 0);
+}
+
+function reportedFileNameMatches(name, repositoryFile) {
+  return name.replaceAll("\\", "/") === repositoryFile;
 }
 
 function repositoryRelativeFile(file, repoRoot) {

--- a/tools/node-test-completion-ledger.test.mjs
+++ b/tools/node-test-completion-ledger.test.mjs
@@ -89,6 +89,45 @@ test("result override requires every selected file and only synthetic forced-ter
   }), false);
 });
 
+test("result override recognizes a Windows file-level failure name", () => {
+  const records = [
+    fileSummary(file),
+    {
+      type: "test-failure",
+      file: `${repoRoot}/${file}`,
+      name: file.replaceAll("/", "\\"),
+      signal: null,
+      exitCode: 1
+    },
+    {
+      type: "test-run-summary",
+      success: false,
+      counts: counts({ tests: 2, passed: 1, failed: 1 })
+    }
+  ];
+  const ledger = parseCompletionLedger(
+    `${records.map((record) => JSON.stringify(record)).join("\n")}\n`,
+    repoRoot
+  );
+
+  assert.equal(canIgnoreReapedFileFailures({
+    ledger,
+    selectedFiles: [file],
+    reapedFiles: new Set([file])
+  }), true);
+  const realFailureLedger = parseCompletionLedger(
+    `${records.map((record) => JSON.stringify(record.type === "test-failure"
+      ? { ...record, name: "real test failure" }
+      : record)).join("\n")}\n`,
+    repoRoot
+  );
+  assert.equal(canIgnoreReapedFileFailures({
+    ledger: realFailureLedger,
+    selectedFiles: [file],
+    reapedFiles: new Set([file])
+  }), false);
+});
+
 test("completion reporter flushes every proof record before its consumer can exit", () => {
   const result = spawnSync(process.execPath, [
     "tools/test-fixtures/.runner-stall/completion-reporter-flush.mjs"

--- a/tools/node-test-completion-ledger.test.mjs
+++ b/tools/node-test-completion-ledger.test.mjs
@@ -44,7 +44,7 @@ test("missing or incomplete reporter records fail closed", () => {
   assert.equal(completedIsolationFile(parseCompletionLedger("", repoRoot), [file, "packages/other.test.ts"]), null);
 });
 
-test("result override requires every selected file and only synthetic reaped SIGKILL failures", () => {
+test("result override requires every selected file and only synthetic forced-termination failures", () => {
   const other = "packages/kernel/test/healthy.test.ts";
   const records = [
     fileSummary(file),
@@ -68,6 +68,17 @@ test("result override requires every selected file and only synthetic reaped SIG
 
   assert.equal(canIgnoreReapedFileFailures({
     ledger,
+    selectedFiles: [file, other],
+    reapedFiles: new Set([file])
+  }), true);
+  const signalLessLedger = parseCompletionLedger(
+    `${records.map((record) => JSON.stringify(record.type === "test-failure"
+      ? { ...record, signal: null, exitCode: 1 }
+      : record)).join("\n")}\n`,
+    repoRoot
+  );
+  assert.equal(canIgnoreReapedFileFailures({
+    ledger: signalLessLedger,
     selectedFiles: [file, other],
     reapedFiles: new Set([file])
   }), true);

--- a/tools/node-test-completion-reporter.mjs
+++ b/tools/node-test-completion-reporter.mjs
@@ -34,7 +34,8 @@ async function* recordCompletionEvents(source, completionStream) {
         type: "test-failure",
         file: event.data.file,
         name: event.data.name,
-        signal: event.data.details?.error?.signal ?? null
+        signal: event.data.details?.error?.signal ?? null,
+        exitCode: event.data.details?.error?.exitCode ?? null
       });
     } else if (event.type === "test:summary" && event.data?.file === undefined) {
       record(completionStream, {

--- a/tools/node-test-isolation-register.mjs
+++ b/tools/node-test-isolation-register.mjs
@@ -1,3 +1,7 @@
 import { registerCurrentTestIsolation } from "./node-test-isolation-registry.mjs";
 
-registerCurrentTestIsolation();
+try {
+  await registerCurrentTestIsolation();
+} catch {
+  // Stall diagnostics are best-effort and never own test module loading.
+}

--- a/tools/node-test-isolation-register.mjs
+++ b/tools/node-test-isolation-register.mjs
@@ -1,0 +1,3 @@
+import { registerCurrentTestIsolation } from "./node-test-isolation-registry.mjs";
+
+registerCurrentTestIsolation();

--- a/tools/node-test-isolation-registry.mjs
+++ b/tools/node-test-isolation-registry.mjs
@@ -1,0 +1,91 @@
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+export const NODE_TEST_ISOLATION_REGISTRY_ENV = "HARNESS_NODE_TEST_ISOLATION_REGISTRY";
+
+export function registerCurrentTestIsolation({
+  env = process.env,
+  pid = process.pid,
+  ppid = process.ppid,
+  argv = process.argv
+} = {}) {
+  const registryRoot = env[NODE_TEST_ISOLATION_REGISTRY_ENV];
+  if (registryRoot === undefined || env.NODE_TEST_CONTEXT !== "child-v8") return null;
+  const files = argv.slice(1).filter((argument) => /\.(?:test|spec)\.(?:mjs|js|ts)$/u.test(argument));
+  if (files.length !== 1) return null;
+
+  const record = {
+    schema: "node-test-isolation/v1",
+    pid,
+    ppid,
+    files
+  };
+  const recordPath = path.join(registryRoot, `${pid}.json`);
+  writeFileSync(recordPath, `${JSON.stringify(record)}\n`, { encoding: "utf8", flag: "wx" });
+  return recordPath;
+}
+
+export function readRegisteredTestIsolations({
+  registryRoot,
+  repoRoot,
+  hostPid,
+  selectedFiles,
+  isProcessAlive = defaultProcessIsAlive
+}) {
+  if (!Number.isSafeInteger(hostPid) || hostPid <= 0) return [];
+  const selected = new Set(selectedFiles);
+  let entries;
+  try {
+    entries = readdirSync(registryRoot, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === "ENOENT") return [];
+    throw error;
+  }
+
+  const candidates = [];
+  const seenPids = new Set();
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (!entry.isFile() || !/^\d+\.json$/u.test(entry.name)) continue;
+    let record;
+    try {
+      record = JSON.parse(readFileSync(path.join(registryRoot, entry.name), "utf8"));
+    } catch {
+      continue;
+    }
+    if (
+      record?.schema !== "node-test-isolation/v1"
+      || !Number.isSafeInteger(record.pid)
+      || record.pid <= 0
+      || record.ppid !== hostPid
+      || !Array.isArray(record.files)
+      || record.files.length !== 1
+      || seenPids.has(record.pid)
+      || !isProcessAlive(record.pid)
+    ) {
+      continue;
+    }
+    const file = repositoryRelativeFile(record.files[0], repoRoot);
+    if (file === null || !selected.has(file)) continue;
+    seenPids.add(record.pid);
+    candidates.push({ pid: record.pid, files: [file] });
+  }
+  return candidates;
+}
+
+function repositoryRelativeFile(file, repoRoot) {
+  if (typeof file !== "string" || !path.isAbsolute(file)) return null;
+  const relative = path.relative(repoRoot, file).split(path.sep).join("/");
+  if (relative === "" || relative === ".." || relative.startsWith("../")) return null;
+  return relative;
+}
+
+function defaultProcessIsAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "EPERM") return true;
+    if (error?.code === "ESRCH") return false;
+    throw error;
+  }
+}

--- a/tools/node-test-isolation-registry.mjs
+++ b/tools/node-test-isolation-registry.mjs
@@ -1,38 +1,173 @@
-import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { readFileSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { createConnection, createServer } from "node:net";
 import path from "node:path";
+import { randomUUID } from "node:crypto";
 
 export const NODE_TEST_ISOLATION_REGISTRY_ENV = "HARNESS_NODE_TEST_ISOLATION_REGISTRY";
+export const NODE_TEST_ISOLATION_BROKER_PORT_ENV = "HARNESS_NODE_TEST_ISOLATION_BROKER_PORT";
+export const NODE_TEST_ISOLATION_BROKER_SECRET_ENV = "HARNESS_NODE_TEST_ISOLATION_BROKER_SECRET";
+const IDENTITY_HANDSHAKE_TIMEOUT_MS = 1_000;
 
-export function registerCurrentTestIsolation({
+export function shouldUseNodeTestIsolationRegistry({
+  platform = process.platform,
+  fixtureMode,
+  fixtureFiles = []
+} = {}) {
+  return platform === "win32"
+    || (typeof fixtureMode === "string" && fixtureMode.length > 0 && fixtureFiles.length > 0);
+}
+
+export async function createNodeTestIsolationIdentityBroker() {
+  const secret = `${randomUUID()}${randomUUID()}`;
+  const identities = new Map();
+  const sockets = new Set();
+  const server = createServer((socket) => {
+    sockets.add(socket);
+    socket.unref();
+    let input = "";
+    const deadline = setTimeout(() => socket.destroy(), IDENTITY_HANDSHAKE_TIMEOUT_MS);
+    deadline.unref?.();
+    const removeSocket = () => {
+      clearTimeout(deadline);
+      sockets.delete(socket);
+      for (const [token, entry] of identities) {
+        if (entry.socket === socket) identities.delete(token);
+      }
+    };
+    socket.once("close", removeSocket);
+    socket.once("error", () => socket.destroy());
+    socket.on("data", (chunk) => {
+      input += chunk.toString();
+      if (input.length > 1_024) {
+        socket.destroy();
+        return;
+      }
+      const newline = input.indexOf("\n");
+      if (newline === -1) return;
+      socket.removeAllListeners("data");
+      let hello;
+      try {
+        hello = JSON.parse(input.slice(0, newline));
+      } catch {
+        socket.destroy();
+        return;
+      }
+      if (!validBrokerHello(hello, secret)) {
+        socket.destroy();
+        return;
+      }
+      const previous = identities.get(hello.token);
+      previous?.socket.destroy();
+      identities.set(hello.token, {
+        pid: hello.pid,
+        ppid: hello.ppid,
+        socket
+      });
+      clearTimeout(deadline);
+      socket.write("ok\n");
+    });
+  });
+  try {
+    await listenOnLoopback(server);
+  } catch (error) {
+    closeServer(server);
+    throw error;
+  }
+  server.unref();
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    closeServer(server);
+    throw new Error("test isolation identity broker did not bind a TCP port");
+  }
+
+  return {
+    environment: {
+      [NODE_TEST_ISOLATION_BROKER_PORT_ENV]: String(address.port),
+      [NODE_TEST_ISOLATION_BROKER_SECRET_ENV]: secret
+    },
+    matches(candidate) {
+      const entry = identities.get(candidate?.identity?.token);
+      return entry !== undefined
+        && entry.pid === candidate.pid
+        && entry.ppid === candidate.ppid
+        && !entry.socket.destroyed;
+    },
+    dispose() {
+      for (const socket of sockets) socket.destroy();
+      identities.clear();
+      closeServer(server);
+    }
+  };
+}
+
+export async function registerCurrentTestIsolation({
   env = process.env,
   pid = process.pid,
   ppid = process.ppid,
   argv = process.argv
 } = {}) {
   const registryRoot = env[NODE_TEST_ISOLATION_REGISTRY_ENV];
-  if (registryRoot === undefined || env.NODE_TEST_CONTEXT !== "child-v8") return null;
+  const brokerPort = parsePort(env[NODE_TEST_ISOLATION_BROKER_PORT_ENV]);
+  const brokerSecret = env[NODE_TEST_ISOLATION_BROKER_SECRET_ENV];
+  if (
+    registryRoot === undefined
+    || brokerPort === null
+    || typeof brokerSecret !== "string"
+    || brokerSecret.length === 0
+    || env.NODE_TEST_CONTEXT !== "child-v8"
+  ) {
+    return null;
+  }
   const files = argv.slice(1).filter((argument) => /\.(?:test|spec)\.(?:mjs|js|ts)$/u.test(argument));
   if (files.length !== 1) return null;
 
-  const record = {
-    schema: "node-test-isolation/v1",
-    pid,
-    ppid,
-    files
-  };
-  const recordPath = path.join(registryRoot, `${pid}.json`);
-  writeFileSync(recordPath, `${JSON.stringify(record)}\n`, { encoding: "utf8", flag: "wx" });
-  return recordPath;
+  const identity = { token: randomUUID() };
+  let identityConnection;
+  let record;
+  let recordPath;
+  try {
+    identityConnection = await connectToIdentityBroker({
+      port: brokerPort,
+      secret: brokerSecret,
+      token: identity.token,
+      pid,
+      ppid
+    });
+    record = {
+      schema: "node-test-isolation/v1",
+      pid,
+      ppid,
+      files,
+      identity
+    };
+    recordPath = path.join(registryRoot, `${pid}.json`);
+    writeFileSync(recordPath, `${JSON.stringify(record)}\n`, { encoding: "utf8", flag: "w" });
+    let disposed = false;
+    const dispose = () => {
+      if (disposed) return;
+      disposed = true;
+      removeOwnedRecord(recordPath, record.identity.token);
+      identityConnection.close();
+    };
+    return { recordPath, record, dispose };
+  } catch {
+    if (recordPath !== undefined && record !== undefined) {
+      removeOwnedRecord(recordPath, record.identity.token);
+    }
+    identityConnection?.close();
+    return null;
+  }
 }
 
-export function readRegisteredTestIsolations({
+export async function readRegisteredTestIsolations({
   registryRoot,
   repoRoot,
   hostPid,
   selectedFiles,
-  isProcessAlive = defaultProcessIsAlive
+  isProcessAlive = defaultProcessIsAlive,
+  probeIdentity
 }) {
-  if (!Number.isSafeInteger(hostPid) || hostPid <= 0) return [];
+  if (!Number.isSafeInteger(hostPid) || hostPid <= 0 || typeof probeIdentity !== "function") return [];
   const selected = new Set(selectedFiles);
   let entries;
   try {
@@ -59,6 +194,7 @@ export function readRegisteredTestIsolations({
       || record.ppid !== hostPid
       || !Array.isArray(record.files)
       || record.files.length !== 1
+      || !validIdentity(record.identity)
       || seenPids.has(record.pid)
       || !isProcessAlive(record.pid)
     ) {
@@ -66,10 +202,112 @@ export function readRegisteredTestIsolations({
     }
     const file = repositoryRelativeFile(record.files[0], repoRoot);
     if (file === null || !selected.has(file)) continue;
+    const candidate = {
+      pid: record.pid,
+      ppid: record.ppid,
+      files: [file],
+      identity: record.identity
+    };
+    if (!await registeredTestIsolationIdentityMatches(candidate, { probeIdentity })) continue;
     seenPids.add(record.pid);
-    candidates.push({ pid: record.pid, files: [file] });
+    candidates.push(candidate);
   }
   return candidates;
+}
+
+export async function registeredTestIsolationIdentityMatches(candidate, { probeIdentity } = {}) {
+  if (!validIdentity(candidate?.identity) || typeof probeIdentity !== "function") return false;
+  try {
+    return await probeIdentity(candidate);
+  } catch {
+    return false;
+  }
+}
+
+function connectToIdentityBroker({ port, secret, token, pid, ppid }) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let response = "";
+    const socket = createConnection({ host: "127.0.0.1", port });
+    const finish = (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(deadline);
+      socket.removeAllListeners("data");
+      socket.removeAllListeners("error");
+      if (error !== undefined) {
+        socket.destroy();
+        reject(error);
+        return;
+      }
+      socket.on("error", () => socket.destroy());
+      socket.unref();
+      resolve({ close: () => socket.destroy() });
+    };
+    const deadline = setTimeout(() => {
+      finish(new Error("test isolation identity broker handshake timed out"));
+    }, IDENTITY_HANDSHAKE_TIMEOUT_MS);
+    deadline.unref?.();
+    socket.once("connect", () => {
+      socket.write(`${JSON.stringify({ secret, token, pid, ppid })}\n`);
+    });
+    socket.once("error", (error) => finish(error));
+    socket.on("data", (chunk) => {
+      response += chunk.toString();
+      if (response === "ok\n") finish();
+      else if (response.length >= 3) finish(new Error("test isolation identity broker rejected registration"));
+    });
+  });
+}
+
+function listenOnLoopback(server) {
+  return new Promise((resolve, reject) => {
+    const onError = (error) => reject(error);
+    server.once("error", onError);
+    server.listen({ host: "127.0.0.1", port: 0 }, () => {
+      server.off("error", onError);
+      server.on("error", () => undefined);
+      resolve();
+    });
+  });
+}
+
+function validBrokerHello(hello, secret) {
+  return hello?.secret === secret
+    && validIdentity({ token: hello.token })
+    && Number.isSafeInteger(hello.pid)
+    && hello.pid > 0
+    && Number.isSafeInteger(hello.ppid)
+    && hello.ppid > 0;
+}
+
+function removeOwnedRecord(recordPath, identityToken) {
+  try {
+    const record = JSON.parse(readFileSync(recordPath, "utf8"));
+    if (record?.identity?.token === identityToken) unlinkSync(recordPath);
+  } catch {
+    // Registration is diagnostic evidence and never owns test correctness.
+  }
+}
+
+function closeServer(server) {
+  try {
+    server.close();
+  } catch {
+    // Identity evidence is best-effort and must not affect the test process.
+  }
+}
+
+function validIdentity(identity) {
+  return identity !== null
+    && typeof identity === "object"
+    && typeof identity.token === "string"
+    && /^[0-9a-f-]{36}$/u.test(identity.token);
+}
+
+function parsePort(value) {
+  const port = Number(value);
+  return Number.isSafeInteger(port) && port > 0 && port <= 65_535 ? port : null;
 }
 
 function repositoryRelativeFile(file, repoRoot) {

--- a/tools/node-test-isolation-registry.test.mjs
+++ b/tools/node-test-isolation-registry.test.mjs
@@ -1,0 +1,180 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  createNodeTestIsolationIdentityBroker,
+  NODE_TEST_ISOLATION_REGISTRY_ENV,
+  readRegisteredTestIsolations,
+  registerCurrentTestIsolation,
+  shouldUseNodeTestIsolationRegistry
+} from "./node-test-isolation-registry.mjs";
+import { reapPostCompletionChild } from "./node-test-process-tree.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const selectedFile = "tools/node-test-stall-policy.test.mjs";
+const absoluteFile = path.join(repoRoot, selectedFile);
+
+test("test isolation registration binds one selected file to its owning host", async () => {
+  const registryRoot = mkdtempSync(path.join(tmpdir(), "ha-test-isolation-registry-"));
+  const broker = await createNodeTestIsolationIdentityBroker();
+  let registration;
+  try {
+    registration = await registerCurrentTestIsolation({
+      env: {
+        NODE_TEST_CONTEXT: "child-v8",
+        [NODE_TEST_ISOLATION_REGISTRY_ENV]: registryRoot,
+        ...broker.environment
+      },
+      pid: 48001,
+      ppid: 47001,
+      argv: [process.execPath, absoluteFile]
+    });
+
+    assert.equal(registration.recordPath, path.join(registryRoot, "48001.json"));
+    assert.deepEqual(JSON.parse(readFileSync(registration.recordPath, "utf8")), registration.record);
+    assert.deepEqual(await readRegisteredTestIsolations({
+      registryRoot,
+      repoRoot,
+      hostPid: 47001,
+      selectedFiles: [selectedFile],
+      isProcessAlive: (pid) => pid === 48001,
+      probeIdentity: broker.matches
+    }), [{
+      pid: 48001,
+      ppid: 47001,
+      files: [selectedFile],
+      identity: registration.record.identity
+    }]);
+    assert.deepEqual(await readRegisteredTestIsolations({
+      registryRoot,
+      repoRoot,
+      hostPid: 47002,
+      selectedFiles: [selectedFile],
+      isProcessAlive: () => true,
+      probeIdentity: broker.matches
+    }), []);
+    const staleRecord = registration.record;
+    registration.dispose();
+    await new Promise((resolveClose) => setTimeout(resolveClose, 25));
+    writeFileSync(registration.recordPath, `${JSON.stringify(staleRecord)}\n`);
+    assert.deepEqual(await readRegisteredTestIsolations({
+      registryRoot,
+      repoRoot,
+      hostPid: 47001,
+      selectedFiles: [selectedFile],
+      isProcessAlive: () => true,
+      probeIdentity: broker.matches
+    }), []);
+  } finally {
+    registration?.dispose();
+    broker.dispose();
+    rmSync(registryRoot, { recursive: true, force: true });
+  }
+});
+
+test("test isolation registry rejects a recycled PID with a different live identity", async () => {
+  const registryRoot = mkdtempSync(path.join(tmpdir(), "ha-test-isolation-recycle-"));
+  const record = {
+    schema: "node-test-isolation/v1",
+    pid: 48003,
+    ppid: 47001,
+    files: [absoluteFile],
+    identity: { token: "11111111-1111-4111-8111-111111111111" }
+  };
+  try {
+    writeFileSync(path.join(registryRoot, "48003.json"), `${JSON.stringify(record)}\n`);
+    const read = (probeIdentity) => readRegisteredTestIsolations({
+      registryRoot,
+      repoRoot,
+      hostPid: 47001,
+      selectedFiles: [selectedFile],
+      isProcessAlive: () => true,
+      probeIdentity
+    });
+
+    assert.deepEqual(await read(async () => false), []);
+    assert.deepEqual(await read(async (candidate) => candidate.identity.token === record.identity.token), [{
+      pid: 48003,
+      ppid: 47001,
+      files: [selectedFile],
+      identity: record.identity
+    }]);
+  } finally {
+    rmSync(registryRoot, { recursive: true, force: true });
+  }
+});
+
+test("test isolation registration collisions and storage failures never fail test preload", async () => {
+  const registryRoot = mkdtempSync(path.join(tmpdir(), "ha-test-isolation-collision-"));
+  const broker = await createNodeTestIsolationIdentityBroker();
+  const registrationInput = {
+    env: {
+      NODE_TEST_CONTEXT: "child-v8",
+      [NODE_TEST_ISOLATION_REGISTRY_ENV]: registryRoot,
+      ...broker.environment
+    },
+    pid: 48004,
+    ppid: 47001,
+    argv: [process.execPath, absoluteFile]
+  };
+  try {
+    writeFileSync(path.join(registryRoot, "48004.json"), "stale record\n");
+    let registration;
+    await assert.doesNotReject(async () => {
+      registration = await registerCurrentTestIsolation(registrationInput);
+    });
+    assert.deepEqual(JSON.parse(readFileSync(registration.recordPath, "utf8")), registration.record);
+    registration.dispose();
+
+    await assert.doesNotReject(async () => {
+      const unavailable = await registerCurrentTestIsolation({
+        ...registrationInput,
+        pid: 48005,
+        env: {
+          ...registrationInput.env,
+          [NODE_TEST_ISOLATION_REGISTRY_ENV]: path.join(registryRoot, "missing")
+        }
+      });
+      assert.equal(unavailable, null);
+    });
+  } finally {
+    broker.dispose();
+    rmSync(registryRoot, { recursive: true, force: true });
+  }
+});
+
+test("test isolation registry leaves ordinary POSIX runner behavior unchanged", () => {
+  assert.equal(shouldUseNodeTestIsolationRegistry({ platform: "win32" }), true);
+  assert.equal(shouldUseNodeTestIsolationRegistry({ platform: "linux" }), false);
+  assert.equal(shouldUseNodeTestIsolationRegistry({
+    platform: "darwin",
+    fixtureMode: "post-complete-wedge",
+    fixtureFiles: ["tools/test-fixtures/.runner-stall/post-complete-wedge.test.mjs"]
+  }), true);
+});
+
+test("post-completion reap revalidates process identity after diagnostics", async () => {
+  let diagnosticsCaptured = false;
+  let terminationCalled = false;
+  const reaped = await reapPostCompletionChild({
+    hostPid: 47001,
+    isolationChildPid: 48006,
+    file: selectedFile,
+    identity: { token: "22222222-2222-4222-8222-222222222222" },
+    probeIdentity: async () => false,
+    captureDiagnostics: async () => {
+      diagnosticsCaptured = true;
+    },
+    terminateProcessTree: async () => {
+      terminationCalled = true;
+      return true;
+    }
+  });
+
+  assert.equal(diagnosticsCaptured, true);
+  assert.equal(terminationCalled, false);
+  assert.equal(reaped, false);
+});

--- a/tools/node-test-process-tree.mjs
+++ b/tools/node-test-process-tree.mjs
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { registeredTestIsolationIdentityMatches } from "./node-test-isolation-registry.mjs";
 
 const PROCESS_TREE_KILL_GRACE_MS = 2_000;
 
@@ -33,6 +34,44 @@ export function forceTerminateProcessTree(pid) {
     killer.once("error", () => finish(signalProcess(pid, "SIGKILL")));
     killer.once("close", (code) => finish(code === 0 || !processIsAlive(pid)));
   });
+}
+
+export async function reapPostCompletionChild({
+  hostPid,
+  isolationChildPid,
+  file,
+  identity,
+  probeIdentity,
+  captureDiagnostics,
+  terminateProcessTree = forceTerminateProcessTree
+}) {
+  console.error(
+    `\n[node-test-stall] isolation child pid=${isolationChildPid} completed reporter summary for ${file}; collecting diagnostics before post-completion reap`
+  );
+  await captureDiagnostics();
+  if (
+    identity !== undefined
+    && !await registeredTestIsolationIdentityMatches(
+      { pid: isolationChildPid, ppid: hostPid, identity },
+      { probeIdentity }
+    )
+  ) {
+    console.error(
+      `[node-test-stall] post-completion child pid=${isolationChildPid} no longer matches its registered process identity; skipping termination`
+    );
+    return false;
+  }
+  const reaped = await terminateProcessTree(isolationChildPid);
+  if (reaped) {
+    console.error(
+      `[node-test-stall] reaped post-completion child pid=${isolationChildPid} file=${file} termination=${process.platform === "win32" ? "taskkill" : "SIGKILL"}`
+    );
+  } else {
+    console.error(
+      `[node-test-stall] post-completion child pid=${isolationChildPid} exited before forced termination; no result override recorded`
+    );
+  }
+  return reaped;
 }
 
 export async function terminateLingeringPosixProcessGroup(pid) {

--- a/tools/node-test-process-tree.mjs
+++ b/tools/node-test-process-tree.mjs
@@ -1,0 +1,75 @@
+import { spawn } from "node:child_process";
+
+const PROCESS_TREE_KILL_GRACE_MS = 2_000;
+
+export function terminateWindowsProcessTree(child) {
+  if (child.pid === undefined) return;
+  const killer = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+    stdio: "ignore",
+    windowsHide: true
+  });
+  killer.once("error", () => child.kill("SIGKILL"));
+}
+
+export function forceTerminateProcessTree(pid) {
+  if (process.platform !== "win32") return Promise.resolve(signalProcess(pid, "SIGKILL"));
+  return new Promise((resolveTermination) => {
+    let settled = false;
+    let deadline;
+    const finish = (terminated) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(deadline);
+      resolveTermination(terminated);
+    };
+    const killer = spawn("taskkill", ["/pid", String(pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true
+    });
+    deadline = setTimeout(() => {
+      killer.kill("SIGKILL");
+      finish(signalProcess(pid, "SIGKILL"));
+    }, PROCESS_TREE_KILL_GRACE_MS);
+    killer.once("error", () => finish(signalProcess(pid, "SIGKILL")));
+    killer.once("close", (code) => finish(code === 0 || !processIsAlive(pid)));
+  });
+}
+
+export async function terminateLingeringPosixProcessGroup(pid) {
+  if (process.platform === "win32" || pid === undefined || !signalProcessGroup(pid, "SIGTERM")) return false;
+  console.error("node --test completed with lingering descendants; terminating its process tree");
+  await new Promise((resolveDelay) => setTimeout(resolveDelay, PROCESS_TREE_KILL_GRACE_MS));
+  signalProcessGroup(pid, "SIGKILL");
+  return true;
+}
+
+export function signalProcessGroup(pid, signal) {
+  try {
+    process.kill(-pid, signal);
+    return true;
+  } catch (error) {
+    if (error?.code !== "ESRCH") throw error;
+    return false;
+  }
+}
+
+function signalProcess(pid, signal) {
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch (error) {
+    if (error?.code !== "ESRCH") throw error;
+    return false;
+  }
+}
+
+function processIsAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "EPERM") return true;
+    if (error?.code === "ESRCH") return false;
+    throw error;
+  }
+}

--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -37,11 +37,13 @@ import {
   parseCompletionLedger
 } from "./node-test-completion-ledger.mjs";
 import {
+  createNodeTestIsolationIdentityBroker,
   NODE_TEST_ISOLATION_REGISTRY_ENV,
-  readRegisteredTestIsolations
+  readRegisteredTestIsolations,
+  shouldUseNodeTestIsolationRegistry
 } from "./node-test-isolation-registry.mjs";
 import {
-  forceTerminateProcessTree,
+  reapPostCompletionChild,
   signalProcessGroup,
   terminateLingeringPosixProcessGroup,
   terminateWindowsProcessTree
@@ -137,7 +139,11 @@ const timingRoot = mkdtempSync(path.join(tmpdir(), "ha-test-timings-"));
 const timingPath = path.join(timingRoot, "results.xml");
 const stallReportRoot = mkdtempSync(path.join(timingRoot, "stall-reports-"));
 const isolationRegistryRoot = path.join(timingRoot, "isolation-registry");
-mkdirSync(isolationRegistryRoot);
+const useIsolationRegistry = shouldUseNodeTestIsolationRegistry({
+  fixtureMode: process.env.HARNESS_RUNNER_STALL_FIXTURE,
+  fixtureFiles: options.fixtures
+});
+if (useIsolationRegistry) mkdirSync(isolationRegistryRoot);
 const stallDiagnosticMs = positiveIntegerOrDefault(
   process.env.HARNESS_TEST_STALL_DIAGNOSTIC_MS,
   DEFAULT_NODE_TEST_STALL_DIAGNOSTIC_MS
@@ -148,9 +154,17 @@ const stallAbortWindows = positiveIntegerOrDefault(
 );
 
 process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}` }, async (lease) => {
+  const identityBroker = useIsolationRegistry
+    ? await createNodeTestIsolationIdentityBroker().catch((error) => {
+        console.warn(`[node-test-stall] isolation identity broker unavailable; using aggregate stall protection: ${error instanceof Error ? error.message : String(error)}`);
+        return null;
+      })
+    : null;
   const qosPrefix = lease.inherited ? [] : discoverQosPrefix();
   const invocation = prefixCommand(qosPrefix, process.execPath, [
-    `--import=${pathToFileURL(resolve(repoRoot, "tools/node-test-isolation-register.mjs")).href}`,
+    ...(identityBroker !== null
+      ? [`--import=${pathToFileURL(resolve(repoRoot, "tools/node-test-isolation-register.mjs")).href}`]
+      : []),
     "--test",
     `--test-reporter=${pathToFileURL(resolve(repoRoot, "tools/node-test-completion-reporter.mjs")).href}`,
     "--test-reporter-destination=stdout",
@@ -166,7 +180,10 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
     ...selection.files
   ]);
   const testEnvironment = createHermeticTestEnvironment(lease.childEnv);
-  testEnvironment.env[NODE_TEST_ISOLATION_REGISTRY_ENV] = isolationRegistryRoot;
+  if (identityBroker !== null) {
+    testEnvironment.env[NODE_TEST_ISOLATION_REGISTRY_ENV] = isolationRegistryRoot;
+    Object.assign(testEnvironment.env, identityBroker.environment);
+  }
   const child = spawn(invocation.command, invocation.args, {
     cwd: repoRoot,
     stdio: ["inherit", "pipe", "pipe", "pipe"],
@@ -196,14 +213,20 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
     stallAbortStarted = true;
     void abortStalledRun({ child, ...input });
   };
-  const startPostCompleteReap = ({ isolationChildPid, file, processGroupMembers }) => {
+  const startPostCompleteReap = ({ isolationChildPid, file, identity, processGroupMembers }) => {
     if (reapingPids.has(isolationChildPid)) return;
     reapingPids.add(isolationChildPid);
     const reap = reapPostCompletionChild({
       hostPid: child.pid,
       isolationChildPid,
       file,
-      processGroupMembers
+      identity,
+      probeIdentity: identityBroker?.matches,
+      captureDiagnostics: () => captureBoundedPreKillDiagnostics(
+        child.pid,
+        processGroupMembers,
+        isolationChildPid
+      )
     }).then(async (reaped) => {
       if (process.env.HARNESS_RUNNER_STALL_FIXTURE === "post-complete-close-before-reap") {
         await new Promise((resolveDelay) => setTimeout(resolveDelay, 500));
@@ -232,12 +255,15 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
         child.pid
       );
       const completionLedger = readCompletionLedger();
-      const registeredCompletionCandidates = readRegisteredTestIsolations({
-        registryRoot: isolationRegistryRoot,
-        repoRoot,
-        hostPid: child.pid,
-        selectedFiles: selection.files
-      }).filter((candidate) => completedIsolationFile(completionLedger, candidate.files) !== null);
+      const registeredCompletionCandidates = identityBroker !== null
+        ? (await readRegisteredTestIsolations({
+            registryRoot: isolationRegistryRoot,
+            repoRoot,
+            hostPid: child.pid,
+            selectedFiles: selection.files,
+            probeIdentity: identityBroker.matches
+          })).filter((candidate) => completedIsolationFile(completionLedger, candidate.files) !== null)
+        : [];
       const isolationCandidates = mergeIsolationCandidates(
         registeredCompletionCandidates,
         processGroupCandidates
@@ -265,6 +291,7 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
           startPostCompleteReap({
             isolationChildPid: decision.abort.isolationChildPid,
             file: completion.file,
+            identity: candidate.identity,
             processGroupMembers
           });
           return;
@@ -321,6 +348,7 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
       clearInterval(stallDiagnosticTimer);
       removeParentSignalForwarding();
       console.error(error.message);
+      identityBroker?.dispose();
       testEnvironment.cleanup();
       rmSync(timingRoot, { recursive: true, force: true });
       resolveExitCode(1);
@@ -329,6 +357,7 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
       clearInterval(stallDiagnosticTimer);
       removeParentSignalForwarding();
       await Promise.allSettled(inFlightReaps);
+      identityBroker?.dispose();
       const leakedDescendants = await terminateLingeringPosixProcessGroup(child.pid);
       testEnvironment.cleanup();
       const completionLedger = readCompletionLedger();
@@ -467,29 +496,6 @@ async function diagnoseThenTerminateStalledTree(hostPid, processGroupMembers, is
   );
 }
 
-async function reapPostCompletionChild({
-  hostPid,
-  isolationChildPid,
-  file,
-  processGroupMembers
-}) {
-  console.error(
-    `\n[node-test-stall] isolation child pid=${isolationChildPid} completed reporter summary for ${file}; collecting diagnostics before post-completion reap`
-  );
-  await captureBoundedPreKillDiagnostics(hostPid, processGroupMembers, isolationChildPid);
-  const reaped = await forceTerminateProcessTree(isolationChildPid);
-  if (reaped) {
-    console.error(
-      `[node-test-stall] reaped post-completion child pid=${isolationChildPid} file=${file} termination=${process.platform === "win32" ? "taskkill" : "SIGKILL"}`
-    );
-  } else {
-    console.error(
-      `[node-test-stall] post-completion child pid=${isolationChildPid} exited before forced termination; no result override recorded`
-    );
-  }
-  return reaped;
-}
-
 async function captureBoundedPreKillDiagnostics(hostPid, processGroupMembers, preferredPid) {
   let diagnosticDeadlineTimer;
   await Promise.race([
@@ -537,7 +543,9 @@ function mergeIsolationCandidates(...groups) {
     const previous = candidates.get(candidate.pid);
     candidates.set(candidate.pid, {
       pid: candidate.pid,
-      files: [...new Set([...(previous?.files ?? []), ...candidate.files])].sort()
+      ppid: previous?.ppid ?? candidate.ppid,
+      files: [...new Set([...(previous?.files ?? []), ...candidate.files])].sort(),
+      identity: previous?.identity ?? candidate.identity
     });
   }
   return [...candidates.values()];

--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path, { resolve } from "node:path";
 import { performance } from "node:perf_hooks";
@@ -36,11 +36,20 @@ import {
   completedIsolationFile,
   parseCompletionLedger
 } from "./node-test-completion-ledger.mjs";
+import {
+  NODE_TEST_ISOLATION_REGISTRY_ENV,
+  readRegisteredTestIsolations
+} from "./node-test-isolation-registry.mjs";
+import {
+  forceTerminateProcessTree,
+  signalProcessGroup,
+  terminateLingeringPosixProcessGroup,
+  terminateWindowsProcessTree
+} from "./node-test-process-tree.mjs";
 import { defaultTestTierNames, discoverTestTierManifest, testTierNames } from "./test-tier-manifest.mjs";
 import { createHermeticTestEnvironment, gitFixtureIdentityGuidance } from "./test-process-environment.mjs";
 
 const repoRoot = resolve(import.meta.dirname, "..");
-const PROCESS_TREE_KILL_GRACE_MS = 2_000;
 // `--test-timeout` bounds any single test, so silence lasting several windows
 // means the wedge is outside a test body — module load, a blocked thread, a
 // child that never exits — where the per-test timeout can never fire. Reporting
@@ -127,6 +136,8 @@ const timeoutArgs = [`--test-timeout=${options.testTimeoutMs}`];
 const timingRoot = mkdtempSync(path.join(tmpdir(), "ha-test-timings-"));
 const timingPath = path.join(timingRoot, "results.xml");
 const stallReportRoot = mkdtempSync(path.join(timingRoot, "stall-reports-"));
+const isolationRegistryRoot = path.join(timingRoot, "isolation-registry");
+mkdirSync(isolationRegistryRoot);
 const stallDiagnosticMs = positiveIntegerOrDefault(
   process.env.HARNESS_TEST_STALL_DIAGNOSTIC_MS,
   DEFAULT_NODE_TEST_STALL_DIAGNOSTIC_MS
@@ -139,6 +150,7 @@ const stallAbortWindows = positiveIntegerOrDefault(
 process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}` }, async (lease) => {
   const qosPrefix = lease.inherited ? [] : discoverQosPrefix();
   const invocation = prefixCommand(qosPrefix, process.execPath, [
+    `--import=${pathToFileURL(resolve(repoRoot, "tools/node-test-isolation-register.mjs")).href}`,
     "--test",
     `--test-reporter=${pathToFileURL(resolve(repoRoot, "tools/node-test-completion-reporter.mjs")).href}`,
     "--test-reporter-destination=stdout",
@@ -154,6 +166,7 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
     ...selection.files
   ]);
   const testEnvironment = createHermeticTestEnvironment(lease.childEnv);
+  testEnvironment.env[NODE_TEST_ISOLATION_REGISTRY_ENV] = isolationRegistryRoot;
   const child = spawn(invocation.command, invocation.args, {
     cwd: repoRoot,
     stdio: ["inherit", "pipe", "pipe", "pipe"],
@@ -214,9 +227,20 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
       const processGroupMembers = processGroupLines
         .map((line) => parsePosixProcessGroupLine(line))
         .filter((member) => member !== null);
-      const isolationCandidates = isolationCandidatesFromProcessGroup(
+      const processGroupCandidates = isolationCandidatesFromProcessGroup(
         processGroupMembers,
         child.pid
+      );
+      const completionLedger = readCompletionLedger();
+      const registeredCompletionCandidates = readRegisteredTestIsolations({
+        registryRoot: isolationRegistryRoot,
+        repoRoot,
+        hostPid: child.pid,
+        selectedFiles: selection.files
+      }).filter((candidate) => completedIsolationFile(completionLedger, candidate.files) !== null);
+      const isolationCandidates = mergeIsolationCandidates(
+        registeredCompletionCandidates,
+        processGroupCandidates
       );
       const decision = stallPolicy.tick({
         at: performance.now(),
@@ -236,7 +260,7 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
         );
         const completion = candidate === undefined
           ? null
-          : completedIsolationFile(readCompletionLedger(), candidate.files);
+          : completedIsolationFile(completionLedger, candidate.files);
         if (completion !== null) {
           startPostCompleteReap({
             isolationChildPid: decision.abort.isolationChildPid,
@@ -337,7 +361,7 @@ process.exitCode = await withLocalHeavySlot({ label: `node-tests:${options.tier}
         });
       if (ignoredSyntheticFailures) {
         console.error(
-          `[node-test-stall] accepted ${reapedFiles.size} completed file result(s); ignoring only the host-generated SIGKILL file failure(s)`
+          `[node-test-stall] accepted ${reapedFiles.size} completed file result(s); ignoring only the host-generated forced-termination file failure(s)`
         );
       }
       resolveExitCode(signal === null && !leakedDescendants
@@ -453,14 +477,14 @@ async function reapPostCompletionChild({
     `\n[node-test-stall] isolation child pid=${isolationChildPid} completed reporter summary for ${file}; collecting diagnostics before post-completion reap`
   );
   await captureBoundedPreKillDiagnostics(hostPid, processGroupMembers, isolationChildPid);
-  const reaped = signalProcess(isolationChildPid, "SIGKILL");
+  const reaped = await forceTerminateProcessTree(isolationChildPid);
   if (reaped) {
     console.error(
-      `[node-test-stall] reaped post-completion child pid=${isolationChildPid} file=${file} signal=SIGKILL`
+      `[node-test-stall] reaped post-completion child pid=${isolationChildPid} file=${file} termination=${process.platform === "win32" ? "taskkill" : "SIGKILL"}`
     );
   } else {
     console.error(
-      `[node-test-stall] post-completion child pid=${isolationChildPid} exited before SIGKILL; no result override recorded`
+      `[node-test-stall] post-completion child pid=${isolationChildPid} exited before forced termination; no result override recorded`
     );
   }
   return reaped;
@@ -505,6 +529,18 @@ function isolationCandidatesFromProcessGroup(members, processGroupId) {
       files: testFilesFromProcessCommand(member.command, repoRoot)
     }))
     .filter((candidate) => candidate.files.length > 0);
+}
+
+function mergeIsolationCandidates(...groups) {
+  const candidates = new Map();
+  for (const candidate of groups.flat()) {
+    const previous = candidates.get(candidate.pid);
+    candidates.set(candidate.pid, {
+      pid: candidate.pid,
+      files: [...new Set([...(previous?.files ?? []), ...candidate.files])].sort()
+    });
+  }
+  return [...candidates.values()];
 }
 
 /**
@@ -599,38 +635,4 @@ function installTestTreeSignalForwarding(child) {
     process.prependOnceListener(signal, handler);
   }
   return remove;
-}
-
-function terminateWindowsProcessTree(child) {
-  if (child.pid === undefined) return;
-  const killer = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
-  killer.once("error", () => child.kill("SIGKILL"));
-}
-
-async function terminateLingeringPosixProcessGroup(pid) {
-  if (process.platform === "win32" || pid === undefined || !signalProcessGroup(pid, "SIGTERM")) return false;
-  console.error("node --test completed with lingering descendants; terminating its process tree");
-  await new Promise((resolveDelay) => setTimeout(resolveDelay, PROCESS_TREE_KILL_GRACE_MS));
-  signalProcessGroup(pid, "SIGKILL");
-  return true;
-}
-
-function signalProcessGroup(pid, signal) {
-  try {
-    process.kill(-pid, signal);
-    return true;
-  } catch (error) {
-    if (error?.code !== "ESRCH") throw error;
-    return false;
-  }
-}
-
-function signalProcess(pid, signal) {
-  try {
-    process.kill(pid, signal);
-    return true;
-  } catch (error) {
-    if (error?.code !== "ESRCH") throw error;
-    return false;
-  }
 }

--- a/tools/run-node-tests.test.mjs
+++ b/tools/run-node-tests.test.mjs
@@ -1,16 +1,9 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { pathToFileURL } from "node:url";
-import {
-  NODE_TEST_ISOLATION_REGISTRY_ENV,
-  readRegisteredTestIsolations,
-  registerCurrentTestIsolation
-} from "./node-test-isolation-registry.mjs";
 import { collectSlowTests, DEFAULT_TEST_TIMEOUT_MS, filterTestFilesByPrefixes, formatSlowTestSummary, hasIsolationWedgeSignature, parseCompletedTestLine, parsePosixProcessGroupLine, parseRunnerArgs, resolveTestConcurrency, selectTestFiles, testFilesFromProcessCommand, validateManifest } from "./node-test-runner-lib.mjs";
 import { defaultTestTierNames, deriveTestTierManifest, discoverTestTierManifest, parseTestTierMarker, testTierNames } from "./test-tier-manifest.mjs";
 
@@ -65,48 +58,6 @@ test("test timeout defaults to three minutes and cannot be disabled", () => {
   assert.equal(parseRunnerArgs(["--test-timeout=360000"], testTierNames).testTimeoutMs, 360_000);
   assert.throws(() => parseRunnerArgs(["--test-timeout", "0"], testTierNames), /positive integer/u);
   assert.throws(() => parseRunnerArgs(["--test-timeout=x"], testTierNames), /--test-timeout/u);
-});
-
-test("test isolation registration binds one selected file to its owning host", () => {
-  const registryRoot = mkdtempSync(path.join(tmpdir(), "ha-test-isolation-registry-"));
-  const file = path.join(repoRoot, "tools/node-test-stall-policy.test.mjs");
-  try {
-    const recordPath = registerCurrentTestIsolation({
-      env: {
-        NODE_TEST_CONTEXT: "child-v8",
-        [NODE_TEST_ISOLATION_REGISTRY_ENV]: registryRoot
-      },
-      pid: 48001,
-      ppid: 47001,
-      argv: [process.execPath, file]
-    });
-
-    assert.deepEqual(JSON.parse(readFileSync(recordPath, "utf8")), {
-      schema: "node-test-isolation/v1",
-      pid: 48001,
-      ppid: 47001,
-      files: [file]
-    });
-    assert.deepEqual(readRegisteredTestIsolations({
-      registryRoot,
-      repoRoot,
-      hostPid: 47001,
-      selectedFiles: ["tools/node-test-stall-policy.test.mjs"],
-      isProcessAlive: (pid) => pid === 48001
-    }), [{
-      pid: 48001,
-      files: ["tools/node-test-stall-policy.test.mjs"]
-    }]);
-    assert.deepEqual(readRegisteredTestIsolations({
-      registryRoot,
-      repoRoot,
-      hostPid: 47002,
-      selectedFiles: ["tools/node-test-stall-policy.test.mjs"],
-      isProcessAlive: () => true
-    }), []);
-  } finally {
-    rmSync(registryRoot, { recursive: true, force: true });
-  }
 });
 
 test("runner bounds a non-terminating test and prints timeout next steps", () => {

--- a/tools/run-node-tests.test.mjs
+++ b/tools/run-node-tests.test.mjs
@@ -1,9 +1,16 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { pathToFileURL } from "node:url";
+import {
+  NODE_TEST_ISOLATION_REGISTRY_ENV,
+  readRegisteredTestIsolations,
+  registerCurrentTestIsolation
+} from "./node-test-isolation-registry.mjs";
 import { collectSlowTests, DEFAULT_TEST_TIMEOUT_MS, filterTestFilesByPrefixes, formatSlowTestSummary, hasIsolationWedgeSignature, parseCompletedTestLine, parsePosixProcessGroupLine, parseRunnerArgs, resolveTestConcurrency, selectTestFiles, testFilesFromProcessCommand, validateManifest } from "./node-test-runner-lib.mjs";
 import { defaultTestTierNames, deriveTestTierManifest, discoverTestTierManifest, parseTestTierMarker, testTierNames } from "./test-tier-manifest.mjs";
 
@@ -58,6 +65,48 @@ test("test timeout defaults to three minutes and cannot be disabled", () => {
   assert.equal(parseRunnerArgs(["--test-timeout=360000"], testTierNames).testTimeoutMs, 360_000);
   assert.throws(() => parseRunnerArgs(["--test-timeout", "0"], testTierNames), /positive integer/u);
   assert.throws(() => parseRunnerArgs(["--test-timeout=x"], testTierNames), /--test-timeout/u);
+});
+
+test("test isolation registration binds one selected file to its owning host", () => {
+  const registryRoot = mkdtempSync(path.join(tmpdir(), "ha-test-isolation-registry-"));
+  const file = path.join(repoRoot, "tools/node-test-stall-policy.test.mjs");
+  try {
+    const recordPath = registerCurrentTestIsolation({
+      env: {
+        NODE_TEST_CONTEXT: "child-v8",
+        [NODE_TEST_ISOLATION_REGISTRY_ENV]: registryRoot
+      },
+      pid: 48001,
+      ppid: 47001,
+      argv: [process.execPath, file]
+    });
+
+    assert.deepEqual(JSON.parse(readFileSync(recordPath, "utf8")), {
+      schema: "node-test-isolation/v1",
+      pid: 48001,
+      ppid: 47001,
+      files: [file]
+    });
+    assert.deepEqual(readRegisteredTestIsolations({
+      registryRoot,
+      repoRoot,
+      hostPid: 47001,
+      selectedFiles: ["tools/node-test-stall-policy.test.mjs"],
+      isProcessAlive: (pid) => pid === 48001
+    }), [{
+      pid: 48001,
+      files: ["tools/node-test-stall-policy.test.mjs"]
+    }]);
+    assert.deepEqual(readRegisteredTestIsolations({
+      registryRoot,
+      repoRoot,
+      hostPid: 47002,
+      selectedFiles: ["tools/node-test-stall-policy.test.mjs"],
+      isProcessAlive: () => true
+    }), []);
+  } finally {
+    rmSync(registryRoot, { recursive: true, force: true });
+  }
 });
 
 test("runner bounds a non-terminating test and prints timeout next steps", () => {
@@ -240,11 +289,7 @@ test("runner treats a real failure hidden by a shutdown wedge as a named wedge f
   );
 });
 
-test("runner reaps a child only after its file summary is complete", {
-  skip: process.platform === "win32"
-    ? "post-completion reaping uses POSIX isolation process evidence"
-    : false
-}, () => {
+test("runner reaps a completed isolation child without POSIX process inspection", () => {
   const childEnv = {
     ...process.env,
     HARNESS_RUNNER_STALL_FIXTURE: "post-complete-wedge",
@@ -252,6 +297,7 @@ test("runner reaps a child only after its file summary is complete", {
     HARNESS_TEST_STALL_DIAGNOSTIC_MS: "250",
     HARNESS_TEST_STALL_ABORT_WINDOWS: "2"
   };
+  if (process.platform !== "win32") childEnv.PATH = path.dirname(process.execPath);
   delete childEnv.NODE_TEST_CONTEXT;
   const result = spawnSync(process.execPath, [
     "tools/run-node-tests.mjs",
@@ -268,15 +314,11 @@ test("runner reaps a child only after its file summary is complete", {
   assert.equal(result.error, undefined, output);
   assert.equal(result.status, 0, output);
   assert.match(output, /✔ post-complete wedge fixture passes before native-style exit deadlock/u);
-  assert.match(output, /\[node-test-stall\] reaped post-completion child pid=\d+ file=tools\/test-fixtures\/\.runner-stall\/post-complete-wedge\.test\.mjs signal=SIGKILL/u);
-  assert.match(output, /accepted 1 completed file result\(s\); ignoring only the host-generated SIGKILL file failure/u);
+  assert.match(output, /\[node-test-stall\] reaped post-completion child pid=\d+ file=tools\/test-fixtures\/\.runner-stall\/post-complete-wedge\.test\.mjs termination=(?:SIGKILL|taskkill)/u);
+  assert.match(output, /accepted 1 completed file result\(s\); ignoring only the host-generated forced-termination file failure/u);
 });
 
-test("runner waits for an in-flight reap record before accepting the host result", {
-  skip: process.platform === "win32"
-    ? "post-completion reaping uses POSIX isolation process evidence"
-    : false
-}, () => {
+test("runner waits for an in-flight reap record before accepting the host result", () => {
   const childEnv = {
     ...process.env,
     HARNESS_RUNNER_STALL_FIXTURE: "post-complete-close-before-reap",
@@ -284,6 +326,7 @@ test("runner waits for an in-flight reap record before accepting the host result
     HARNESS_TEST_STALL_DIAGNOSTIC_MS: "250",
     HARNESS_TEST_STALL_ABORT_WINDOWS: "2"
   };
+  if (process.platform !== "win32") childEnv.PATH = path.dirname(process.execPath);
   delete childEnv.NODE_TEST_CONTEXT;
   const result = spawnSync(process.execPath, [
     "tools/run-node-tests.mjs",
@@ -299,8 +342,8 @@ test("runner waits for an in-flight reap record before accepting the host result
 
   assert.equal(result.error, undefined, output);
   assert.equal(result.status, 0, output);
-  assert.match(output, /\[node-test-stall\] reaped post-completion child pid=\d+ file=tools\/test-fixtures\/\.runner-stall\/post-complete-wedge\.test\.mjs signal=SIGKILL/u);
-  assert.match(output, /accepted 1 completed file result\(s\); ignoring only the host-generated SIGKILL file failure/u);
+  assert.match(output, /\[node-test-stall\] reaped post-completion child pid=\d+ file=tools\/test-fixtures\/\.runner-stall\/post-complete-wedge\.test\.mjs termination=(?:SIGKILL|taskkill)/u);
+  assert.match(output, /accepted 1 completed file result\(s\); ignoring only the host-generated forced-termination file failure/u);
 });
 
 test("parseRunnerArgs accepts safe repository-relative test prefixes", () => {

--- a/tools/test-child-process-lifecycle.mjs
+++ b/tools/test-child-process-lifecycle.mjs
@@ -1,0 +1,84 @@
+import { execFileSync } from "node:child_process";
+
+const DEFAULT_CHILD_EXIT_TIMEOUT_MS = 5_000;
+
+export function waitForChildExit(child, options = {}) {
+  return observeChildExit(child, undefined, options);
+}
+
+export function terminateChildAndWait(child, terminate, options = {}) {
+  if (typeof terminate !== "function") throw new Error("terminateChildAndWait requires a termination function");
+  return observeChildExit(child, terminate, options);
+}
+
+export function forceTerminateChildAndWait(child, options = {}) {
+  const timeoutMs = positiveTimeout(options.timeoutMs);
+  return terminateChildAndWait(child, (target) => {
+    if (process.platform === "win32") {
+      if (!Number.isSafeInteger(target.pid) || target.pid <= 0) {
+        throw new Error(`${options.label ?? "child process"} has no process id`);
+      }
+      try {
+        execFileSync("taskkill.exe", ["/pid", String(target.pid), "/t", "/f"], {
+          stdio: "ignore",
+          timeout: timeoutMs,
+          killSignal: "SIGKILL",
+          windowsHide: true
+        });
+      } catch {
+        // The child may have exited after the pre-termination state check.
+        // The already-installed observer below decides that race or times out.
+      }
+      return;
+    }
+    target.kill("SIGKILL");
+  }, { ...options, timeoutMs });
+}
+
+function observeChildExit(child, terminate, options) {
+  const timeoutMs = positiveTimeout(options.timeoutMs);
+  const label = options.label ?? `child process ${child.pid ?? "unknown"}`;
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (error, result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.off("exit", onExit);
+      child.off("error", onError);
+      if (error) reject(error);
+      else resolve(result);
+    };
+    const onExit = (code, signal) => finish(undefined, { code, signal });
+    const onError = (error) => finish(error);
+    const timer = setTimeout(() => {
+      finish(new Error(`${label} did not exit within ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.once("exit", onExit);
+    child.once("error", onError);
+
+    if (child.exitCode !== null || child.signalCode !== null) {
+      finish(undefined, { code: child.exitCode, signal: child.signalCode });
+      return;
+    }
+    if (terminate !== undefined) {
+      try {
+        terminate(child);
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error(String(error)));
+      }
+    }
+  });
+}
+
+function positiveTimeout(value) {
+  const timeoutMs = value ?? DEFAULT_CHILD_EXIT_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new Error("child exit timeout must be a positive integer");
+  }
+  return timeoutMs;
+}

--- a/tools/test-child-process-lifecycle.test.mjs
+++ b/tools/test-child-process-lifecycle.test.mjs
@@ -1,0 +1,39 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+import {
+  terminateChildAndWait,
+  waitForChildExit
+} from "./test-child-process-lifecycle.mjs";
+
+test("child termination observes a synchronous exit emitted by the native action", async () => {
+  const child = fakeChild();
+  const exit = await terminateChildAndWait(child, (target) => {
+    target.exitCode = 1;
+    target.emit("exit", 1, null);
+  }, { timeoutMs: 100, label: "synchronous child" });
+
+  assert.deepEqual(exit, { code: 1, signal: null });
+  assert.equal(child.listenerCount("exit"), 0);
+  assert.equal(child.listenerCount("error"), 0);
+});
+
+test("child exit waiting is bounded and removes its observers", async () => {
+  const child = fakeChild();
+  await assert.rejects(
+    waitForChildExit(child, { timeoutMs: 10, label: "stalled child" }),
+    /stalled child did not exit within 10ms/u
+  );
+  assert.equal(child.listenerCount("exit"), 0);
+  assert.equal(child.listenerCount("error"), 0);
+});
+
+function fakeChild() {
+  return Object.assign(new EventEmitter(), {
+    pid: 48002,
+    exitCode: null,
+    signalCode: null,
+    kill: () => true
+  });
+}


### PR DESCRIPTION
# English

## Summary

Fix the intermittent `windows-local-check` stall that hit three unrelated PRs in one day (#1161, #1162, #1164 — each needed a manual rerun): a `node --test` isolation child sometimes fails to exit after reporting its file's completion. The POSIX runner reaps such wedged children via `ps` process-group inspection; on Windows that candidate set is unconditionally empty, so the runner could only wait ~215–225s for the aggregate-silence fuse and fail the whole tier. The fix gives the runner a platform-neutral, verified way to identify and reap only provably-completed isolation children — no skips, no widened stall/test timeout windows.

## What Changed

- New test-isolation registry (`tools/node-test-isolation-register.mjs` preload + `tools/node-test-isolation-registry.mjs`): each isolation child records a host-bound identity (PID, direct parent PID, unique absolute test file). Consumers accept a record only if it is same-host, same-selection, canonical in-repo path, and the PID is alive; malformed/stale/cross-host records fail closed.
- `tools/run-node-tests.mjs` + `tools/node-test-process-tree.mjs`: registry candidates merge with the existing POSIX `ps` candidates; a child is reaped only when the completion ledger already holds a successful summary for its file. Windows uses bounded `taskkill /T /F`; POSIX keeps process-group SIGKILL semantics. The result override still requires every selected file to have a successful summary and the failure set to equal exactly the runner's own force-terminated completed files — a wedged-but-incomplete file still fails the run.
- Completion ledger records both `signal` and `exitCode` so Windows' signal-less nonzero forced-termination exits are classified correctly.
- Family cleanup: remaining `spawn → kill → wait` test helpers with POSIX-signal assumptions (kill-before-listener, kill-without-wait) converted to listener-first, bounded-wait, platform-native termination — same family as the #1157 fixes.
- Blind-review round: F1 (MEDIUM, stale registry record + PID recycle could misreap a new child on Windows where no `ps` cross-check exists) fixed by binding records to process instances via a loopback broker identity check — identity change after the diagnostic window never calls termination; F2 (registration `EEXIST` crash on PID collision) fixed with collision-overwrite and fully non-throwing registration; F3 addressed; F4/F5 informational notes recorded. If the broker cannot be established the runner degrades loudly to the existing aggregate stall protection — never a wrong reap.

## Task And Scope

- Harness task: task_01KYW7PCR11XQ66TG7CPPKHHY1
- Branch: codex/win-stall
- Public scope: tools/ test runner infrastructure (runner, process tree, completion ledger/reporter, new registry modules + tests); test-helper family cleanup
- Private planning/evidence updated: yes (implementation report with attempt-1 log forensics and mechanical completed-set diffs for both failures)
- Out of scope: gate semantics, stall/test timeout values, any product package code

## Version Impact

- Version: no version change because this is pre-release trunk development
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no (test runner internals; no CI workflow, required-check, or gate-manifest change)
- Protected surface scope: not applicable
- Authority: task_01KYW7PCR11XQ66TG7CPPKHHY1 (flake-shape line, standing flow-defect authorization)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 86f2e84c4805a046ea247a30806bd67ce4d12f91
- Branch merge-base with `origin/main`: 86f2e84c4805a046ea247a30806bd67ce4d12f91
- Last `git fetch origin` time: 2026-08-01 01:55 CST (rebased onto 86f2e84c, gates re-run)
- Sync method: rebase
- Public diff command: `git diff 86f2e84c..codex/win-stall`
- Private evidence commit/path: harness task package task_01KYW7PCR11XQ66TG7CPPKHHY1 `artifacts/implementation-report.md`
- Reviewer evidence path: GLM blind review findings (summarized below)
- GitHub Actions `rewrite-ci` run URL: pending (attached by CI on this PR)
- [x] `git diff --check`
- [x] `npm run check:local` (27 manifest gates green; fast 800/800, contract 477 + 1 pre-existing skip; re-run green after rebase)
- [x] Targeted tests: deterministic red/green for the Windows blind spot (PATH-restricted `ps` disable), F1 (stale-record identity), F2 (EEXIST collision); registry unit tests; runner/ledger/lifecycle 37/37; tools fast 198/198
- [ ] GitHub Actions `rewrite-ci` passed (authoritative; pending on this PR — its own `windows-local-check` run is the first real-Windows validation)
- Not run, and why: real Windows execution not possible on this macOS host — attribution rests on attempt-1 CI log forensics, platform-neutral invariants, and injected simulations; full local `check:ci` not run per repo policy

## Review Evidence

- Self-review: attempt-1 log discipline (a bare `--job --log` fetches the green rerun and hides the failure); mechanical completed-set diff for both incidents localized the wedge to the outer isolation child, exonerating the last-printed tests; red/green via deterministic `ps` disable.
- Reviewer subagent: GLM blind adversarial review focused on false-green (this changes the instrument that declares CI green). Verdict: the result-override invariant (all selected files successful ∧ failure set ≡ runner-reaped completed files) is strong enough that forgery/stale-record scenarios cannot flip a red to green. Findings: F1 (misreap under PID recycle, a false-red not false-green) and F2 (EEXIST preload crash) fixed with deterministic red/green; F3 addressed; F4/F5 informational.
- Human review: CEO semantic acceptance (no skip, no window inflation, degrade-to-existing-fuse on any uncertainty).
- Blocking findings: none outstanding

## Residual Risk

- Real-Windows behavior validated only via CI logs and simulation until this PR's own Windows job runs; if the loopback broker cannot establish, the runner logs it and falls back to the pre-existing aggregate stall protection (the status quo), never a wrong reap.

## References

- Task: task_01KYW7PCR11XQ66TG7CPPKHHY1
- Evidence: task package `artifacts/implementation-report.md`
- Review: GLM blind review findings (F1–F5 dispositions above)

---

# 中文

## 概要

修复一天内命中三条互不相关 PR(#1161、#1162、#1164,各需人工重跑)的 `windows-local-check` 间歇挂死:`node --test` isolation child 偶发在上报文件完成后不退出。POSIX runner 靠 `ps` 进程组检查收尸;Windows 上该候选集恒为空,只能等 ~215–225s 的 aggregate-silence 熔断然后整 tier 失败。本修给 runner 一条平台中立、可验证的路径,只收割**可证明已完成**的 isolation child——零 skip、零窗口放宽。

## 改动内容

- 新增 test-isolation 注册(preload + registry 模块):每个 isolation child 记录 host-bound 身份(PID、直接父 PID、唯一绝对测试文件);消费端仅接受同 host、同选择集、仓内规范路径且 PID 存活的记录,畸形/陈旧/跨 host 全部 fail closed。
- runner:注册候选与既有 POSIX `ps` 候选合并;仅当 completion ledger 已有该文件成功 summary 才收尸;Windows 有界 `taskkill /T /F`,POSIX 保持进程组 SIGKILL。result override 仍要求全部选择文件有成功 summary 且失败集恰等于 runner 自己强杀的已完成文件——卡死且未完成的文件仍判失败。
- completion ledger 同时记 `signal` 与 `exitCode`,正确归类 Windows 无信号非零强杀退出。
- 族清理:残余的 `spawn → kill → wait` 测试辅助(先 kill 后挂 listener、只 kill 不等待)统一改为 listener-first、有界等待、平台原生终止——与 #1157 同族修净。
- 盲评轮:F1(MEDIUM,陈旧记录+PID 复用在无 `ps` 交叉验证的 Windows 上可误杀新 child)以 loopback broker 进程实例身份绑定修复——诊断窗口后身份变化绝不触发 termination;F2(PID 碰撞 `EEXIST` 崩 preload)改为碰撞覆盖、注册全程不抛;F3 处置;F4/F5 注记。broker 建不起来则响亮降级回既有熔断,绝不误杀。

## 任务与范围

- Harness 任务:task_01KYW7PCR11XQ66TG7CPPKHHY1
- 分支:codex/win-stall
- 公开范围:tools/ 测试 runner 基础设施(runner、process tree、completion ledger/reporter、新注册模块+测试);测试辅助族清理
- 私有计划 / 证据是否已更新:yes(实现报告含 attempt-1 日志取证与两次事故的机械完成集差分)
- 范围外:门语义、stall/test timeout 数值、任何产品包代码

## 版本影响

- 版本:不改版本,原因是 pre-release 主干开发
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no(runner 内部;不改 CI workflow、required check、gate-manifest)
- protected surface 范围:不适用
- 依据:task_01KYW7PCR11XQ66TG7CPPKHHY1(flake 形状线,流转缺陷常设授权)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no

## 验证

- `origin/main` 基准 SHA:86f2e84c4805a046ea247a30806bd67ce4d12f91
- 当前分支与 `origin/main` 的 merge-base:86f2e84c4805a046ea247a30806bd67ce4d12f91
- 最近一次 `git fetch origin` 时间:2026-08-01 01:55 CST(rebase 后复跑门)
- 同步方式:rebase
- 公开 diff 命令:`git diff 86f2e84c..codex/win-stall`
- 私有证据 commit/path:任务包 task_01KYW7PCR11XQ66TG7CPPKHHY1 `artifacts/implementation-report.md`
- Reviewer 证据路径:GLM 盲评 findings(要点见下)
- GitHub Actions `rewrite-ci` run URL:待本 PR CI 生成
- [x] `git diff --check`
- [x] `npm run check:local`(27 门全绿;fast 800/800,contract 477+1 既有 skip;rebase 后复跑绿)
- [x] 定向测试:Windows 盲区确定性红/绿(PATH 禁 `ps`)、F1 陈旧记录身份、F2 EEXIST 碰撞;registry 单测;runner/ledger/lifecycle 37/37;tools fast 198/198
- [ ] GitHub Actions `rewrite-ci` 通过(权威;本 PR 自己的 windows-local-check 就是首次真实 Windows 验证)
- 未跑项及原因:本机 macOS 无法跑真实 Windows——归因基于 attempt-1 CI 日志取证、平台中立不变量与注入模拟;未跑本地 `check:ci` 全量等价

## 审查证据

- 自查:attempt-1 日志纪律(裸 `--job --log` 会拿到重跑绿日志掩盖现场);两次事故机械完成集差分把楔死定位到外层 isolation child,为末尾打印的测试洗清嫌疑;`ps` 禁用构造确定性红/绿。
- 额外审查:GLM 对抗盲评,主打 false-green(改的是判绿仪器)。结论:result-override 不变量(全部选择文件成功 ∧ 失败集≡runner 自杀的已完成文件)足以让伪造/陈旧记录场景无法把红洗绿。F1(PID 复用误杀,假红非假绿)与 F2(EEXIST 崩)确定性红/绿修复;F3 处置;F4/F5 注记。
- 人工审查:CEO 语义验收(零 skip、零窗口放宽、任何不确定即降级回既有熔断)。
- 阻塞发现:无未决

## 残余风险

- 真实 Windows 行为在本 PR 自己的 Windows job 跑过之前仅由 CI 日志与模拟验证;broker 建不起来时响亮降级为既有 aggregate 熔断(现状),绝不误杀。

## 关联材料

- 任务:task_01KYW7PCR11XQ66TG7CPPKHHY1
- 证据:任务包 `artifacts/implementation-report.md`
- 审查:GLM 盲评 findings(F1–F5 处置见上)
