### PR TITLE
feat(gui): remote mode over the resident-daemon relay with authenticated canonical root

### DIFF
--- a/docs-release/operations-server-daemon.md
+++ b/docs-release/operations-server-daemon.md
@@ -156,23 +156,39 @@ Remote mode is a client of a persistent remote daemon. Declare the repository
 mode in `harness/harness.yaml`, then provide the connection coordinates. It
 opens an SSH stdio session, which the server's forced command relays to the daemon:
 
-```bash
-HARNESS_DAEMON_SSH_HOST=team-host \
-HARNESS_DAEMON_REMOTE_ROOT=/srv/harness/team \
-HARNESS_DAEMON_REMOTE_HA=ha \
-ha task list
+```yaml
+schema: harness-anything/v1
+settings:
+  identity:
+    mode: remote
+  daemon:
+    remote:
+      host: team-host
+      root: /srv/harness/team
+      repoId: canonical
+      haPath: ha
 ```
 
-`settings.identity.mode: remote`, `HARNESS_DAEMON_SSH_HOST`, and
-`HARNESS_DAEMON_REMOTE_ROOT` are required. `HARNESS_DAEMON_REMOTE_HA` defaults
-to `ha`; set it when the remote binary path is different. Set
-`HARNESS_DAEMON_REPO_ID` when the remote side should serve a registered repo id
-other than `canonical`.
+CLI and source GUI use this same configuration and transport. From the client
+directory containing that file, `ha task list` and `ha gui` both read the
+remote canonical; the directory does not need a local copy of its task,
+decision, or fact data. Environment variables override the file when needed:
+`HARNESS_DAEMON_MODE`, `HARNESS_DAEMON_SSH_HOST`,
+`HARNESS_DAEMON_REMOTE_ROOT`, `HARNESS_DAEMON_REPO_ID`, and
+`HARNESS_DAEMON_REMOTE_HA`. The remote binary defaults to `ha`, and the repo id
+defaults to `canonical`.
 
 The client invokes `ssh <host> <remote-ha> daemon connect --stdio`. The server
 must already be running `ha daemon start --service` for the canonical root. The
 remote root is sent with each request and must match the root pinned by the
 member's forced command.
+
+If the persistent daemon is absent or the forced-command root does not match,
+the GUI reports the remote error and does not start or fall back to a local
+daemon. Task and decision reads remain live daemon requests; renderer caches
+are display-only. Decision mutations use the authenticated remote principal.
+Task status and progress mutations remain unavailable until their GUI routes
+use the attributed daemon write coordinator.
 
 ## Team onboarding with SSH forced commands
 

--- a/docs-release/operations-server-daemon.zh-CN.md
+++ b/docs-release/operations-server-daemon.zh-CN.md
@@ -137,21 +137,34 @@ Markdown fail closed，不会因为扩展名像 prose 就擅自放行。
 Remote 模式连接持久远程 daemon。先在 repo config 声明 `settings.identity.mode: remote`，
 再提供连接坐标。客户端会打开 SSH stdio 会话，服务器的 forced command 把它 relay 到 daemon：
 
-```bash
-HARNESS_DAEMON_SSH_HOST=team-host \
-HARNESS_DAEMON_REMOTE_ROOT=/srv/harness/team \
-HARNESS_DAEMON_REMOTE_HA=ha \
-ha task list
+```yaml
+schema: harness-anything/v1
+settings:
+  identity:
+    mode: remote
+  daemon:
+    remote:
+      host: team-host
+      root: /srv/harness/team
+      repoId: canonical
+      haPath: ha
 ```
 
-repo 的 `settings.identity.mode: remote`、`HARNESS_DAEMON_SSH_HOST` 和
-`HARNESS_DAEMON_REMOTE_ROOT` 是必需项。`HARNESS_DAEMON_REMOTE_HA` 默认是
-`ha`；远端二进制路径不是 `ha` 时再设置。远端需要服务非 `canonical` 的已注册仓库
-id 时，设置 `HARNESS_DAEMON_REPO_ID`。
+CLI 与源码 GUI 复用这份配置和同一传输。从包含该文件的客户端目录运行
+`ha task list` 或 `ha gui`，都会读取远端 canonical；本地目录不需要保存 task、decision
+或 fact 数据副本。需要覆盖文件配置时，可使用 `HARNESS_DAEMON_MODE`、
+`HARNESS_DAEMON_SSH_HOST`、`HARNESS_DAEMON_REMOTE_ROOT`、
+`HARNESS_DAEMON_REPO_ID` 与 `HARNESS_DAEMON_REMOTE_HA`。远端二进制默认是
+`ha`，repo id 默认是 `canonical`。
 
 客户端实际执行的是 `ssh <host> <remote-ha> daemon connect --stdio`。服务器必须已经为
 canonical root 启动 `ha daemon start --service`。每个请求都会携带 remote root，并且它必须
 匹配成员 forced command 固定的 root。
+
+持久 daemon 缺失或 forced-command root 不匹配时，GUI 会显示远端错误，不会启动或回退到
+本地 daemon。task 与 decision 读取始终实时请求 daemon；renderer cache 只用于显示。decision
+mutation 使用远端已认证 principal。task status 与 progress mutation 在其 GUI route 接入带归因的
+daemon write coordinator 前仍不可用。
 
 ## 使用 SSH forced command 接入团队
 

--- a/docs-release/release-posture.md
+++ b/docs-release/release-posture.md
@@ -26,8 +26,8 @@ docs should link here instead of restating status tables.
 | Source CLI write path                             | Shipped      | Initialized repositories default to the local daemon single-writer queue. Local single-user identity can derive from `settings.identity` plus the OS-owned local transport; team/remote identity still requires roster credentials. Explicit direct mode is limited to bootstrap/test recovery. Registered human-read task prose submits through `ha doc sync --submit --path ...`; typed state uses dedicated RPC commands. Top-level ADR/standard/template prose remains outside doc-sync until its write-road rows are governed. Evidence: `packages/cli/src/daemon/client.ts`, `packages/cli/src/commands/daemon/productization.ts`, and `packages/daemon/src/service/doc-sync-service.ts`. |
 | Task hierarchy and relation semantics             | Shipped      | `ha task create --parent <id>`, `ha task show <id> --view tree [--json]`, and `ha task relate <src> depends-on <tgt> --rationale <t>` exist, with depends-on cycle detection. Completing a parent does not require completing children; it emits the `open_child_tasks` warning. The `parent` field is immutable after creation. Evidence: canon 1.4.                                                                                              |
 | Local daemon, including single-machine multi-repo | Shipped      | `ha daemon start`, auto-start, `ha daemon repo register`, hot registration reconciliation, and repo-scoped CLI routing use a daemon-held per-repo global lock. Initialized local repositories default to this path; `HARNESS_DAEMON_MODE=direct` is explicit bootstrap/test recovery only. Evidence: canon 1.3 plus the daemon single-writer cutover.                                                                                                  |
-| Desktop GUI source surface                        | Foundation   | The GUI can be built and run from source and can read real ledger data for several views, but status changes, review, progress append, archive, decision adjudication, terminal, presets, adapters, and parts of relations are either state-only, read-only, deferred, or mock-backed. The repository declares this as `source-checkout-and-package-smoke-only`. Evidence: canon 1.2.                                                             |
-| Remote SSH daemon mode                            | Experimental | Remote mode opens `ssh <host> ha daemon connect --stdio` to an existing daemon. Team principals require per-key `authorized_keys` forced commands and roster credentials; the relay verifies the sshd process context, exact original command, and pinned root. It is not GUI-to-remote-daemon, a tunnel product, TCP, HTTP, or WebSocket. Evidence: `packages/cli/src/commands/daemon/connect.ts`.                                               |
+| Desktop GUI source surface                        | Foundation   | The GUI can be built and run from source, reads real ledger data in supported views, and persists decision mutations through the daemon. Attributed task status/progress writes, archive, terminal, presets, adapters, and parts of relations remain read-only, deferred, or mock-backed. The repository declares this as `source-checkout-and-package-smoke-only`. Evidence: canon 1.2 and the GUI service bridge.                                                    |
+| Remote SSH daemon mode                            | Experimental | Remote mode opens `ssh <host> ha daemon connect --stdio` to an existing daemon. CLI and source GUI share this relay and the daemon method registry. Team principals require per-key `authorized_keys` forced commands and roster credentials; the relay verifies the sshd process context, exact original command, and pinned root. It is not a tunnel product, TCP, HTTP, or WebSocket. Evidence: `packages/cli/src/commands/daemon/connect.ts` and `packages/gui/src/main/local-composition-root.ts`. |
 | Runtime/release readiness                         | Foundation   | Source checkout, Node 24-only CI, package smoke, and GUI build checks are executable gates. Release artifacts remain unshipped. Evidence: `packages/gui/src/distribution/runtime-release-readiness.ts:50-60` and canon 1.2.                                                                                                                                                                                                                       |
 | Supply-chain/license gate                         | Foundation   | SBOM validation, OSV evidence path checks, license policy, Dependabot coverage, and AGPL network-service release-note checklist are gates or packet-checkable policy. Live npm audit runs in the scheduled advisory lane rather than the required merge gate, because its verdict follows upstream advisory data rather than this repository. Release artifacts remain unshipped. Evidence: `package.json:71` and `tools/check-supply-chain.mjs:51-74`.                                                                                                                                                        |
 | M3-M7 backlog                                     | Planned      | External adapter implementations, full GUI product behavior, and release hardening are not shipped. Placeholder adapter packages, page-only GUI code, unsigned artifacts, and release-policy prose must not be inherited as shipped product state.                                                                                                                                                                                                |
@@ -57,6 +57,8 @@ The GUI/daemon track has real foundation slices:
 - local daemon reads and writes through the method registry;
 - local daemon repo registration and multi-repo routing;
 - GUI source checkout that reads real ledger data in the supported read paths;
+- configured GUI remote reads, decision mutations, and projection notifications
+  over the persistent daemon SSH relay;
 - graph topology backed by real relation projection in graph-oriented views;
 - build, runtime, and distribution policy checks for source checkout and package
   smoke.
@@ -65,12 +67,9 @@ The same track also has explicit non-capabilities:
 
 - no signed installers, notarization, published release artifacts, or
   auto-update;
-- no GUI task management write path;
-- no GUI decision adjudication;
-- no GUI connection to a daemon on another machine;
-- no working remote tunnel, attach-token transport, TCP listener, HTTP API,
-  WebSocket server, live notification subscription, or enforced RBAC when no
-  `harness/people.yaml` roster exists.
+- no attributed GUI task status or progress write path;
+- no working attach-token transport, TCP listener, HTTP API, WebSocket server,
+  or enforced RBAC when no `harness/people.yaml` roster exists.
 
 These boundaries are why the GUI is foundation state, not a full desktop
 product.
@@ -81,7 +80,7 @@ product.
 | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | Shipped and mechanism-complete CLI surfaces | Workflow proof and complete public documentation.                                                                                  | Old docs that call shipped hierarchy work planned, or docs that hide attribution requirements for write commands.             |
 | Adapter integrations                        | Real GitHub Issues or Linear implementations and proof.                                                                            | Placeholder packages as shipped integrations.                                                                                 |
-| Full GUI product                            | Persisted GUI writes, decision actions, real relations everywhere, non-mock terminal/adapters/presets, and supported distribution. | Page-only GUI assumptions, duplicate CLI/daemon business logic, or state-only drag/drop behavior as lifecycle truth.          |
+| Full GUI product                            | Attributed task writes, real relations everywhere, non-mock terminal/adapters/presets, and supported distribution.                | Page-only GUI assumptions, duplicate CLI/daemon business logic, or state-only drag/drop behavior as lifecycle truth.          |
 | Release hardening                           | Signed artifacts, notarization, update feeds, release artifact SBOMs, and publication evidence.                                    | Unsigned production, unreviewed license/SBOM gaps, or auto-update without signing, update-feed, rollback, and security tests. |
 
 ## Runtime and release readiness

--- a/docs-release/release-posture.zh-CN.md
+++ b/docs-release/release-posture.zh-CN.md
@@ -17,8 +17,8 @@
 | 源码 CLI 写路径           | Shipped      | 已初始化仓库默认进入本地 daemon 单写队列。本地单人身份可由 `settings.identity` 与 OS 所有的本地 transport 推导；团队/远程身份仍要求 roster credential。显式 direct 只用于 bootstrap/测试恢复。已登记的人读 task prose 用 `ha doc sync --submit --path ...`；typed state 使用专用 RPC。顶层 ADR/standard/template prose 在 write-road 完成治理前仍不属于 doc-sync。证据：`packages/cli/src/daemon/client.ts`、`packages/cli/src/commands/daemon/productization.ts`、`packages/daemon/src/service/doc-sync-service.ts`。 |
 | 任务层级与关系语义        | Shipped      | `ha task create --parent <id>`、`ha task show <id> --view tree [--json]`、`ha task relate <src> depends-on <tgt> --rationale <t>` 已存在，并且 depends-on 有环检测。父任务完成不要求子任务完成；只会发出 `open_child_tasks` 软告警。`parent` 字段创建后不可变。证据：canon 1.4。                                                                                                    |
 | 本地 daemon，包括单机多仓 | Shipped      | `ha daemon start`、自动启动、`ha daemon repo register`、热注册 reconcile、按 repo 路由的 CLI 都使用 daemon 持有的 per-repo global lock。已初始化本地仓库默认走此路径；`HARNESS_DAEMON_MODE=direct` 只用于显式 bootstrap/测试恢复。证据：canon 1.3 与 daemon 单写入口收口。                                                                                                                     |
-| 桌面 GUI 源码界面         | Foundation   | GUI 可以从源码构建和运行，并且若干视图能读取真实 ledger 数据，但状态变更、review、追加进度、archive、决策裁决、terminal、presets、adapters，以及部分 relations，仍是仅 state、只读、deferred 或 mock-backed。仓库自我声明状态为 `source-checkout-and-package-smoke-only`。证据：canon 1.2。                                                                                        |
-| Remote SSH daemon 模式    | Experimental | remote 模式会打开 `ssh <host> ha daemon connect --stdio`，连接到已有 daemon。团队 principal 需要逐 key 配置 `authorized_keys` forced command 与 roster credential；relay 会验证 sshd 进程上下文、精确 original command 与固定 root。它不是“GUI 连接远端 daemon”、tunnel 产品、TCP、HTTP 或 WebSocket。证据：`packages/cli/src/commands/daemon/connect.ts`。                        |
+| 桌面 GUI 源码界面         | Foundation   | GUI 可以从源码构建和运行，受支持的视图读取真实 ledger 数据，decision mutation 也会经 daemon 持久化。带归因的 task status/progress 写入、archive、terminal、presets、adapters 与部分 relations 仍是只读、deferred 或 mock-backed。仓库自我声明状态为 `source-checkout-and-package-smoke-only`。证据：canon 1.2 与 GUI service bridge。                                                       |
+| Remote SSH daemon 模式    | Experimental | remote 模式会打开 `ssh <host> ha daemon connect --stdio`，连接到已有 daemon。CLI 与源码 GUI 复用该 relay 和 daemon method registry。团队 principal 需要逐 key 配置 `authorized_keys` forced command 与 roster credential；relay 会验证 sshd 进程上下文、精确 original command 与固定 root。它不是 tunnel 产品、TCP、HTTP 或 WebSocket。证据：`packages/cli/src/commands/daemon/connect.ts` 与 `packages/gui/src/main/local-composition-root.ts`。 |
 | 运行时与发布就绪          | Foundation   | 源码 checkout、Node 24 CI、package smoke、GUI build 都有可执行 gate。发布产物仍未 ship。证据：`packages/gui/src/distribution/runtime-release-readiness.ts:50-60` 与 canon 1.2。                                                                                                                                                                                                     |
 | 供应链与许可证 gate       | Foundation   | npm audit、SBOM 校验、OSV 证据路径检查、许可证策略、Dependabot 覆盖、AGPL 网络服务发布说明 checklist，都是 gate 或任务包可检查的策略。发布产物仍未 ship。证据：`package.json:71` 与 `tools/check-supply-chain.mjs:51-74`。                                                                                                                                                         |
 | M3-M7 backlog             | Planned      | 外部 adapter 实现、完整 GUI 产品行为与发布硬化都尚未 ship。占位 adapter package、仅页面级 GUI 代码、未签名产物、纯发布策略 prose，都不能被继承为已 ship 产品状态。                                                                                                                                                                                                                 |
@@ -46,16 +46,15 @@ GUI/daemon 方向有真实的 foundation 切片：
 - 本地 daemon 通过 method registry 读写；
 - 本地 daemon 仓库注册与多仓路由；
 - GUI 源码 checkout 中，受支持的读取路径会读取真实 ledger 数据；
+- 配置后的 GUI 可通过持久 daemon SSH relay 进行远程读取、decision mutation 与投影通知；
 - 面向 graph 的视图使用真实关系投影；
 - 源码 checkout 与 package smoke 有构建、运行时、分发策略检查。
 
 同一方向也有明确的非能力：
 
 - 没有签名 installer、notarization、已发布产物或 auto-update；
-- 没有 GUI task 管理写路径；
-- 没有 GUI 决策裁决；
-- 没有 GUI 连接另一台机器上的 daemon；
-- 没有可工作的 remote tunnel、attach-token transport、TCP listener、HTTP API、WebSocket server、实时通知订阅，也没有在缺少 `harness/people.yaml` roster 时强制 RBAC。
+- 没有带归因的 GUI task status 或 progress 写路径；
+- 没有可工作的 attach-token transport、TCP listener、HTTP API、WebSocket server，也没有在缺少 `harness/people.yaml` roster 时强制 RBAC。
 
 这些边界就是 GUI 仍是 foundation 状态，而不是完整桌面产品的原因。
 
@@ -65,7 +64,7 @@ GUI/daemon 方向有真实的 foundation 切片：
 | ----------------------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | 已 ship 与 mechanism-complete 的 CLI 界面 | 工作流证明与完整公开文档。                                                                         | 把已 ship 的层级能力继续写成 planned 的旧文档，或隐藏写命令归属与 `--actor human:<id>` 要求的文档。       |
 | Adapter 集成                              | 真实 GitHub Issues 或 Linear 实现与证明。                                                          | 把占位 package 当成已 ship 集成。                                                                         |
-| 完整 GUI 产品                             | 持久化 GUI 写入、决策动作、全局真实 relations、非 mock terminal/adapters/presets，以及受支持分发。 | 把页面级 GUI 假设、重复 CLI/daemon 业务逻辑，或仅 state 的拖拽行为当成生命周期真相。                      |
+| 完整 GUI 产品                             | 带归因的 task 写入、全局真实 relations、非 mock terminal/adapters/presets，以及受支持分发。        | 把页面级 GUI 假设、重复 CLI/daemon 业务逻辑，或仅 state 的拖拽行为当成生命周期真相。                      |
 | 发布硬化                                  | 签名产物、notarization、update feeds、发布产物 SBOM、发布证据。                                    | 未签名生产产物、未经审查的 license/SBOM 缺口，或没有签名、update-feed、rollback、安全测试的 auto-update。 |
 
 ## 运行时与发布就绪

--- a/packages/daemon-client/src/persistent-daemon-client.ts
+++ b/packages/daemon-client/src/persistent-daemon-client.ts
@@ -32,7 +32,7 @@ export class PersistentDaemonClient {
     & PersistentDaemonClientOptions;
   readonly #listeners = new Set<(event: ProjectionChangeNotification) => void>();
   readonly #stateListeners = new Set<(state: DaemonClientState) => void>();
-  readonly #subscriptions = new Map<string, { refs: number }>();
+  readonly #subscriptions = new Map<string, { refs: number; canonicalRoot?: string }>();
   #connection?: JsonRpcConnection;
   #writer?: JsonRpcWriter;
   #hello?: HelloResult;
@@ -75,16 +75,20 @@ export class PersistentDaemonClient {
     return writer.request(method, params, { signal, timeoutMs: this.#options.requestTimeoutMs }) as Promise<Output<M>>;
   }
 
-  async subscribe(repoId: string): Promise<Subscription> {
+  async subscribe(repoId: string, canonicalRoot?: string): Promise<Subscription> {
     const existing = this.#subscriptions.get(repoId);
     if (existing) {
+      if (canonicalRoot && existing.canonicalRoot && canonicalRoot !== existing.canonicalRoot) {
+        throw new Error(`repo ${repoId} is already subscribed with a different canonical root`);
+      }
+      if (canonicalRoot && !existing.canonicalRoot) existing.canonicalRoot = canonicalRoot;
       existing.refs += 1;
       return this.#subscriptionHandle(repoId);
     }
-    this.#subscriptions.set(repoId, { refs: 1 });
+    this.#subscriptions.set(repoId, { refs: 1, ...(canonicalRoot ? { canonicalRoot } : {}) });
     try {
       await this.connect();
-      await this.#sendSubscription("repo.notifications.subscribe", repoId);
+      await this.#sendSubscription("repo.notifications.subscribe", repoId, canonicalRoot);
       return this.#subscriptionHandle(repoId);
     } catch (error) {
       this.#subscriptions.delete(repoId);
@@ -120,7 +124,11 @@ export class PersistentDaemonClient {
     clearTimeout(this.#reconnectTimer);
     const repos = [...this.#subscriptions.keys()];
     if (this.#writer) {
-      await Promise.allSettled(repos.map((repoId) => this.#sendSubscription("repo.notifications.unsubscribe", repoId)));
+      await Promise.allSettled(repos.map((repoId) => this.#sendSubscription(
+        "repo.notifications.unsubscribe",
+        repoId,
+        this.#subscriptions.get(repoId)?.canonicalRoot
+      )));
     }
     this.#subscriptions.clear();
     this.#writer?.disconnect(new Error("daemon client disposed"));
@@ -201,8 +209,8 @@ export class PersistentDaemonClient {
     const delay = Math.max(0, Math.round(exponential * (0.5 + this.#options.jitter())));
     this.#reconnectTimer = setTimeout(() => {
       void this.connect().then(async () => {
-        for (const repoId of this.#subscriptions.keys()) {
-          await this.#sendSubscription("repo.notifications.subscribe", repoId);
+        for (const [repoId, subscription] of this.#subscriptions) {
+          await this.#sendSubscription("repo.notifications.subscribe", repoId, subscription.canonicalRoot);
         }
       }).catch((error: unknown) => {
         this.#diagnose({
@@ -220,7 +228,7 @@ export class PersistentDaemonClient {
     subscription.refs -= 1;
     if (subscription.refs > 0) return;
     this.#subscriptions.delete(repoId);
-    if (this.#writer) await this.#sendSubscription("repo.notifications.unsubscribe", repoId);
+    if (this.#writer) await this.#sendSubscription("repo.notifications.unsubscribe", repoId, subscription.canonicalRoot);
   }
 
   #subscriptionHandle(repoId: string): Subscription {
@@ -237,11 +245,14 @@ export class PersistentDaemonClient {
 
   async #sendSubscription(
     method: "repo.notifications.subscribe" | "repo.notifications.unsubscribe",
-    repoId: string
+    repoId: string,
+    canonicalRoot?: string
   ): Promise<void> {
     const writer = this.#writer;
     if (!writer) throw new Error("daemon connection is unavailable");
-    const result = await writer.request(method, { repo: { repoId } }, { timeoutMs: this.#options.requestTimeoutMs });
+    const result = await writer.request(method, {
+      repo: { repoId, ...(canonicalRoot ? { canonicalRoot } : {}) }
+    }, { timeoutMs: this.#options.requestTimeoutMs });
     requireSuccessfulReceipt(result, method);
   }
 

--- a/packages/daemon-client/test/persistent-daemon-client.test.ts
+++ b/packages/daemon-client/test/persistent-daemon-client.test.ts
@@ -44,6 +44,24 @@ test("stale connection reconnects and restores repo subscriptions", async () => 
   await client.dispose();
 });
 
+test("projection subscriptions retain the forced-command canonical root across reconnect and release", async () => {
+  const transport = subscribingTransport();
+  const client = fixtureClient(transport, { reconnectBaseMs: 1 });
+  const subscription = await client.subscribe("repo-a", "/srv/canonical");
+  transport.connections[0]!.disconnect();
+  await waitFor(() => transport.connections.length === 2 && subscribeCount(transport) === 2);
+  await subscription.dispose();
+
+  const requests = transport.connections.flatMap((connection) => connection.writes)
+    .filter((frame) => (frame as { method?: string }).method?.startsWith("repo.notifications."));
+  assert.deepEqual(requests.map((frame) => (frame as { params?: unknown }).params), [
+    { repo: { repoId: "repo-a", canonicalRoot: "/srv/canonical" } },
+    { repo: { repoId: "repo-a", canonicalRoot: "/srv/canonical" } },
+    { repo: { repoId: "repo-a", canonicalRoot: "/srv/canonical" } }
+  ]);
+  await client.dispose();
+});
+
 test("unknown and malformed notification frames leave diagnostic evidence", async () => {
   const diagnostics: DaemonClientDiagnostic[] = [];
   const transport = subscribingTransport();

--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -146,7 +146,7 @@ export function createGuiServiceBridge(
       });
       return await remoteClient.request(
         jsonRpcMethodForGuiRoute(route) as never,
-        jsonRpcParamsForGuiRoute(route, transport.repoId, payload) as never
+        jsonRpcParamsForGuiRoute(route, transport.repoId, payload, transport.remoteRoot) as never
       ) as JsonObject;
     } catch (error) {
       return {
@@ -451,7 +451,8 @@ export function jsonRpcMethodForGuiRoute(route: ApiRouteContract): string {
 export function jsonRpcParamsForGuiRoute(
   route: ApiRouteContract,
   fallbackRepoId: string,
-  payload: unknown
+  payload: unknown,
+  canonicalRoot?: string
 ): JsonObject {
   if (route.commandClass === "admin") {
     // admin.daemon.restart takes { payload: DaemonControlRequestV1 } without repo.
@@ -460,7 +461,8 @@ export function jsonRpcParamsForGuiRoute(
   }
   const { repoId, servicePayload } = extractRepoScopedPayload(payload, fallbackRepoId);
   return {
-    repo: { repoId },
+    // The remote forced-command boundary authenticates and pins this root.
+    repo: { repoId, ...(canonicalRoot ? { canonicalRoot } : {}) },
     ...(servicePayload ? { payload: servicePayload } : {})
   };
 }

--- a/packages/gui/src/main/projection-notifications.ts
+++ b/packages/gui/src/main/projection-notifications.ts
@@ -52,6 +52,7 @@ function createProjectionNotifications(
   let clientState: Disposable | undefined;
   let subscription: Subscription | undefined;
   let watchedRepoId: string | undefined;
+  let remoteCanonicalRoot: string | undefined;
   let sink: ((notification: RendererProjectionNotification) => void) | undefined;
 
   const source: HarnessProjectionNotificationSource = {
@@ -67,7 +68,7 @@ function createProjectionNotifications(
         if (!hello.repos.some((repo) => repo.repoId === repoId)) {
           throw new Error(`repo_not_advertised: daemon hello did not advertise ${repoId}`);
         }
-        subscription = await activeClient.subscribe(repoId);
+        subscription = await activeClient.subscribe(repoId, remoteCanonicalRoot);
         return { mode: "push" };
       } catch (error) {
         const diagnostic = `Projection notifications unavailable for ${repoId}: ${error instanceof Error ? error.message : String(error)}`;
@@ -92,6 +93,7 @@ function createProjectionNotifications(
   async function ensureClient(): Promise<PersistentDaemonClient> {
     if (client) return client;
     const selected = forceLocal ? undefined : await resolveGuiDaemonTransport(rootDir, layoutOverrides, options.env);
+    remoteCanonicalRoot = selected?.kind === "ssh-stdio" ? selected.remoteRoot : undefined;
     const target = selected?.kind === "ssh-stdio"
       ? {
           endpoint: `ssh-stdio:${selected.host}`,

--- a/packages/gui/test/service-bridge-remote.test.ts
+++ b/packages/gui/test/service-bridge-remote.test.ts
@@ -8,6 +8,12 @@ import { fileURLToPath } from "node:url";
 import test from "node:test";
 import { SshStdioTransport } from "../../daemon-client/src/ssh-stdio-transport.ts";
 import {
+  FakeTransport,
+  hello,
+  receipt,
+  type RequestFrame
+} from "../../daemon-client/test/fake-transport.ts";
+import {
   createGuiProjectionNotifications,
   createGuiServiceBridge,
   createLocalGuiServiceBridge
@@ -119,3 +125,70 @@ test("GUI remote selection reads tasks and documents from a second repo over dae
     rmSync(remoteRoot, { recursive: true, force: true });
   }
 });
+
+test("GUI remote requests carry the canonical root required by the forced-command boundary", async () => {
+  const nearRoot = mkdtempSync(path.join(tmpdir(), "ha-gui-near-"));
+  const requests: RequestFrame[] = [];
+  const transport = new FakeTransport((request, connection) => {
+    requests.push(request);
+    if (hello(connection, request)) return;
+    connection.respond(request.id, receipt(request.method, { ok: true, tasks: [] }));
+  });
+  const remoteRoot = "/srv/harness/gui-remote";
+  const bridge = createGuiServiceBridge(nearRoot, undefined, {
+    env: remoteDaemonEnv(remoteRoot),
+    createSshTransport: () => transport
+  });
+  try {
+    const tasks = await bridge.invoke("getTasks", null) as { readonly ok: boolean };
+
+    assert.equal(tasks.ok, true, JSON.stringify(tasks));
+    const request = requests.find((candidate) => candidate.method === "repo.tasks.list");
+    assert.deepEqual(request?.params, {
+      repo: { repoId: "canonical", canonicalRoot: remoteRoot }
+    });
+  } finally {
+    await bridge.dispose?.();
+    rmSync(nearRoot, { recursive: true, force: true });
+  }
+});
+
+test("GUI remote mode fails closed when the persistent daemon is unavailable", async () => {
+  const nearRoot = mkdtempSync(path.join(tmpdir(), "ha-gui-near-"));
+  writeTaskIndex(nearRoot, "task-near", "Near-only task", "planned");
+  const bridge = createGuiServiceBridge(nearRoot, undefined, {
+    env: remoteDaemonEnv("/srv/harness/gui-remote"),
+    createSshTransport: () => ({
+      open: async () => {
+        throw new Error("No persistent daemon is listening on the remote host");
+      }
+    })
+  });
+  try {
+    const tasks = await bridge.invoke("getTasks", null) as {
+      readonly ok: boolean;
+      readonly tasks?: ReadonlyArray<unknown>;
+      readonly error?: { readonly code?: string; readonly hint?: string };
+    };
+
+    assert.equal(tasks.ok, false, JSON.stringify(tasks));
+    assert.equal(tasks.error?.code, "daemon_unavailable");
+    assert.match(tasks.error?.hint ?? "", /fixture-remote.*No persistent daemon/iu);
+    assert.equal(tasks.tasks, undefined);
+  } finally {
+    await bridge.dispose?.();
+    rmSync(nearRoot, { recursive: true, force: true });
+  }
+});
+
+function remoteDaemonEnv(remoteRoot: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    HARNESS_DAEMON_MODE: "remote",
+    HARNESS_DAEMON_SSH_HOST: "fixture-remote",
+    HARNESS_DAEMON_REMOTE_HA: "/opt/ha",
+    HARNESS_DAEMON_REMOTE_ROOT: remoteRoot,
+    HARNESS_DAEMON_REPO_ID: "canonical",
+    HARNESS_DAEMON_REQUEST_TIMEOUT_MS: "5000"
+  };
+}


### PR DESCRIPTION
# English

## Summary

Enable GUI remote mode over the resident-daemon relay: the GUI's remote JSON-RPC requests and projection-notification subscriptions previously omitted `repo.canonicalRoot`, so the remote forced-command boundary (A2) rejected them. This change threads the configured remote canonical root through every repo-scoped request and subscription, keeping the server as the sole authority that authenticates and pins the root. Verified end-to-end against a real second machine: the GUI reads the remote ledger's real data, a GUI decision write lands on the remote journal attributed to the remote principal (`ssh-forced-command-person` credential), projection notifications arrive as push, and a stopped remote daemon yields an explicit `daemon_unavailable` error with no silent fallback to local data.

## What Changed

- `packages/daemon-client/src/persistent-daemon-client.ts` — `subscribe()` accepts an optional canonical root, remembers it per repo subscription, and reuses it on reconnect and unsubscribe; conflicting roots for the same repo throw cleanly without touching the existing subscription.
- `packages/gui/src/main/local-composition-root.ts` — the existing GUI route parameter adapter adds `repo.canonicalRoot` for remote transports; no GUI-specific RPC, no daemon method-registry change; remote failures return `daemon_unavailable` and never fall through to the local branch.
- `packages/gui/src/main/projection-notifications.ts` — remote subscriptions carry the same root.
- `docs-release/operations-server-daemon(.zh-CN).md`, `release-posture(.zh-CN).md` — remote-mode configuration documented.
- Tests: new `packages/gui/test/service-bridge-remote.test.ts` (remote params carry the root; daemon-unavailable path leaks no local data) and daemon-client subscription tests.

## Task And Scope

- Harness task: task_01KX3Q9MRWTXG3T8C93B3J4PSH
- Branch: codex/gui-remote
- Public scope: packages/daemon-client, packages/gui main-process bridge, docs-release remote-mode sections
- Private planning/evidence updated: yes (implementation report with dual-machine e2e evidence)
- Out of scope: GUI task status/progress remote writes (delivered read-only per plan; gap recorded), RBAC v2, transparent-workspace GA

## Version Impact

- Version: no version change because this is pre-release trunk development
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task_01KX3Q9MRWTXG3T8C93B3J4PSH (approved by Zeyu 2026-08-01: GUI remote mode go, server access granted); invariants from dec_mrcz1kqh / dec_mrcz2q6k / dec_mrczk07e / dec_mrcd9zfl
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: c7ca0af05f5c8198010407e823e06fa2960eb0b2
- Branch merge-base with `origin/main`: c7ca0af05f5c8198010407e823e06fa2960eb0b2
- Last `git fetch origin` time: 2026-08-01 18:40 CST
- Sync method: rebased onto merged #1180 before implementation
- Public diff command: `git diff c7ca0af0..codex/gui-remote`
- Private evidence commit/path: task package `artifacts/implementation-report.md`
- Reviewer evidence path: task package `artifacts/glm-review-findings.md`
- GitHub Actions `rewrite-ci` run URL: pending (attached by CI on this PR)
- [x] `git diff --check`
- [x] `npm run check:local` (exit 0, 28 manifest gates green, 222.0s)
- [x] Targeted tests: 35 pass / 1 conditional skip; identity-sensitive tests hermetic (stripped global gitconfig) 21 pass / 1 skip; config tests 7 pass
- [x] Real dual-machine e2e (tencent-lighthouse): remote read, attributed remote write, push notifications, fail-closed on stopped daemon
- [ ] GitHub Actions `rewrite-ci` passed (authoritative; pending on this PR)
- Not run, and why: full Electron visual acceptance and Zeyu's hands-on dual-machine use are user-facing acceptance, deferred to post-merge; `check:ci` full equivalence not run locally — GitHub CI is the authority

## Review Evidence

- Self-review: worker reproduced the forced-command rejection before the fix, then verified the full remote loop on a real second machine; CEO read the core diff and checked the invariants (no second write-coordination plane; client root is a routing hint, server authenticates and pins it; fail-closed preserved; adjudicating reads stay on live daemon projections).
- Reviewer subagent: GLM blind adversarial review over the subscription-lifecycle and trust-boundary surfaces. Verdict: no CRITICAL/HIGH/MEDIUM; 3 LOW (root fill-path protocol asymmetry that is unreachable in remote because the server rejects rootless subscribes; connection-pool signature note; test-coverage note) recorded as follow-up candidates, none touching trust or fail-open; 2 INFO pre-existing.
- Human review: CEO semantic acceptance against dec_mrcz1kqh / dec_mrcd9zfl — verified.
- Blocking findings: none

## Residual Risk

- GUI task status/progress remain read-only over remote until the attributed daemon write coordinator lands for those routes; documented as a known gap, no second write plane was added.
- LOW-1 subscription root fill-path asymmetry becomes relevant only if the server later pairs subscribe/unsubscribe strictly by (repoId, canonicalRoot); revisit then.

## References

- Task: task_01KX3Q9MRWTXG3T8C93B3J4PSH
- Evidence: task package `artifacts/implementation-report.md`
- Review: task package `artifacts/glm-review-findings.md`

---

# 中文

## 概要

打通 GUI 远程模式(经常驻 daemon 中继):此前 GUI 的远程 JSON-RPC 请求与投影通知订阅漏传 `repo.canonicalRoot`,被远端 forced-command 边界(A2)拒绝。本改动把配置的远端 canonical root 带进每个 repo-scoped 请求与订阅,服务端仍是认证与锚定 root 的唯一权威。已在真实第二台机器上端到端验证:GUI 读到远端台账真实数据,GUI decision 写入落远端 journal 且归因远端 principal(`ssh-forced-command-person` credential),投影通知为 push,远端 daemon 停止时明确报 `daemon_unavailable`,不静默降级本地数据。

## 改动内容

- `packages/daemon-client/src/persistent-daemon-client.ts`——`subscribe()` 接受可选 canonical root,按 repo 订阅记忆并在重连/退订时复用;同一 repo 冲突 root 干净抛错,不污染既有订阅。
- `packages/gui/src/main/local-composition-root.ts`——复用既有 GUI route 参数适配器,远程传输时补 `repo.canonicalRoot`;无 GUI 专属 RPC,不改 daemon method registry;远端失败统一 `daemon_unavailable`,不落本地分支。
- `packages/gui/src/main/projection-notifications.ts`——远程订阅携带同一 root。
- `docs-release` 四篇——远程模式配置文档。
- 测试:新增 `service-bridge-remote.test.ts`(远程参数带 root;daemon 不可用不泄漏本地数据)与 daemon-client 订阅测试。

## 任务与范围

- Harness 任务:task_01KX3Q9MRWTXG3T8C93B3J4PSH
- 分支:codex/gui-remote
- 公开范围:packages/daemon-client、packages/gui 主进程 bridge、docs-release 远程模式节
- 私有计划 / 证据是否已更新:yes(实现报告含真实双机 e2e 证据)
- 范围外:GUI task status/progress 远程写(按 plan 只读交付,缺口已记录)、RBAC v2、transparent-workspace GA

## 版本影响

- 版本:不改版本,原因是 pre-release 主干开发
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:task_01KX3Q9MRWTXG3T8C93B3J4PSH(泽宇 2026-08-01 批准 GUI 远程模式开工并授权服务器);不变量来自 dec_mrcz1kqh / dec_mrcz2q6k / dec_mrczk07e / dec_mrcd9zfl
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no

## 验证

- `origin/main` 基准 SHA:c7ca0af05f5c8198010407e823e06fa2960eb0b2
- 当前分支与 `origin/main` 的 merge-base:c7ca0af05f5c8198010407e823e06fa2960eb0b2
- 最近一次 `git fetch origin` 时间:2026-08-01 18:40 CST
- 同步方式:实现前已 rebase 到 #1180 合并后 main
- 公开 diff 命令:`git diff c7ca0af0..codex/gui-remote`
- 私有证据 commit/path:任务包 `artifacts/implementation-report.md`
- Reviewer 证据路径:任务包 `artifacts/glm-review-findings.md`
- GitHub Actions `rewrite-ci` run URL:待本 PR CI 生成
- [x] `git diff --check`
- [x] `npm run check:local`(exit 0,28 门绿,222.0s)
- [x] 定向测试 35 pass/1 条件跳过;身份类测试 hermetic 剥净环境 21 pass/1 跳过;配置测试 7 pass
- [x] 真实双机 e2e(tencent-lighthouse):远端读/归因写/push 通知/停 daemon fail-closed
- [ ] GitHub Actions `rewrite-ci` 通过(权威;待本 PR)
- 未跑项及原因:完整 Electron 视觉验收与泽宇亲手双机使用属用户侧验收,留合并后;本地未跑 `check:ci` 全量等价

## 审查证据

- 自查:worker 修前复现 forced-command 拒绝,修后在真实第二台机器验证全远程回路;CEO 亲读核心 diff 核不变量(无第二写协调面;客户端 root 只是路由提示,服务端认证锚定;fail-closed 保持;判定性读走 daemon 实时投影)。
- 额外审查:GLM 对订阅生命周期与信任边界面对抗盲评。结论:无 CRITICAL/HIGH/MEDIUM;3 LOW(root fill 路径协议对称性缺陷——remote 下服务端拒绝无 root 订阅故不可达;connection-pool 签名备注;测试覆盖备注)记为后续候选,均不触信任/fail-open;2 INFO 为存量。
- 人工审查:CEO 按 dec_mrcz1kqh / dec_mrcd9zfl 语义验收——通过。
- 阻塞发现:无

## 残余风险

- GUI task status/progress 在带归因的 daemon 写协调器接入前保持远程只读;已记录为已知缺口,未新增第二写面。
- LOW-1 订阅 root fill 路径对称性问题仅当服务端将来按 (repoId, canonicalRoot) 严格配对 subscribe/unsubscribe 时才承重;届时重审。

## 关联材料

- 任务:task_01KX3Q9MRWTXG3T8C93B3J4PSH
- 证据:任务包 `artifacts/implementation-report.md`
- 审查:任务包 `artifacts/glm-review-findings.md`
