### PR TITLE
test: prototype Harness-owned test file workers (PLT-Steady C1)

### DIFF
--- a/tools/prototypes/file-worker-scheduler-prototype.mjs
+++ b/tools/prototypes/file-worker-scheduler-prototype.mjs
@@ -1,0 +1,435 @@
+import { spawn } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { pathToFileURL } from "node:url";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+const completionReporterUrl = pathToFileURL(
+  path.join(repoRoot, "tools/node-test-completion-reporter.mjs")
+).href;
+const DEFAULT_TERMINATION_GRACE_MS = 150;
+const FINAL_CLOSE_BUDGET_MS = 5_000;
+
+/**
+ * Prototype only: run one directly owned Node process per selected test file.
+ * File identity is assigned before spawn and never discovered from an OS table.
+ */
+export async function runFileWorkerSchedule({
+  files,
+  concurrency,
+  env,
+  testTimeoutMs = 180_000,
+  workerDeadlineMs = 180_000,
+  proofExitGraceMs = 1_000,
+  terminationGraceMs = DEFAULT_TERMINATION_GRACE_MS,
+  junitRoot,
+  abortSignal,
+  onEvent = () => {}
+}) {
+  if (!Array.isArray(files) || files.length === 0) {
+    throw new Error("file-worker prototype requires at least one test file");
+  }
+  if (!Number.isSafeInteger(concurrency) || concurrency <= 0) {
+    throw new Error("file-worker prototype concurrency must be a positive integer");
+  }
+  if (junitRoot !== undefined) mkdirSync(junitRoot, { recursive: true });
+
+  const startedAt = performance.now();
+  const results = new Array(files.length);
+  let cursor = 0;
+  const runLane = async () => {
+    while (cursor < files.length) {
+      if (abortSignal?.aborted) return;
+      const index = cursor;
+      cursor += 1;
+      const worker = {
+        id: `file-worker-${String(index + 1).padStart(3, "0")}`,
+        file: files[index]
+      };
+      results[index] = await runOwnedFileWorker({
+        worker,
+        env,
+        testTimeoutMs,
+        workerDeadlineMs,
+        proofExitGraceMs,
+        terminationGraceMs,
+        junitPath: junitRoot === undefined
+          ? undefined
+          : path.join(junitRoot, `${worker.id}.xml`),
+        abortSignal,
+        runStartedAt: startedAt,
+        onEvent
+      });
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, files.length) }, () => runLane())
+  );
+
+  if (abortSignal?.aborted && results.some((result) => result === undefined)) {
+    for (let index = 0; index < results.length; index += 1) {
+      if (results[index] !== undefined) continue;
+      results[index] = unstartedSignalResult(files[index], index, abortSignal.reason);
+    }
+  }
+  const durationMs = performance.now() - startedAt;
+  const passed = results.every((result) => result.outcome === "passed"
+    || result.outcome === "passed-after-reap");
+  return {
+    schema: "harness-file-worker-schedule-prototype/v1",
+    verdict: passed ? "pass" : "fail",
+    exitCode: passed ? 0 : 1,
+    durationMs,
+    concurrency,
+    workers: results
+  };
+}
+
+async function runOwnedFileWorker({
+  worker,
+  env,
+  testTimeoutMs,
+  workerDeadlineMs,
+  proofExitGraceMs,
+  terminationGraceMs,
+  junitPath,
+  abortSignal,
+  runStartedAt,
+  onEvent
+}) {
+  const trace = [];
+  const failures = [];
+  let output = "";
+  let errorOutput = "";
+  let proof;
+  let proofError;
+  let terminationReason;
+  let terminationEffect;
+  let deadline;
+
+  const args = workerInvocation(worker.file, { testTimeoutMs, junitPath });
+  const child = spawn(process.execPath, args, {
+    cwd: repoRoot,
+    env,
+    detached: process.platform !== "win32",
+    stdio: ["ignore", "pipe", "pipe", "pipe"]
+  });
+  recordEvent("spawn", { pid: child.pid, command: process.execPath, args });
+
+  const closed = new Promise((resolveClose) => {
+    child.once("error", (error) => resolveClose({ code: null, signal: null, error }));
+    child.once("close", (code, signal) => resolveClose({ code, signal, error: null }));
+  });
+
+  child.stdout.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+  child.stderr.on("data", (chunk) => {
+    errorOutput += chunk.toString();
+  });
+  consumeProofRecords(child.stdio[3], {
+    onRecord(record) {
+      if (record.type === "test-failure" && proofFile(record.file) === worker.file) {
+        failures.push({ name: record.name, file: worker.file });
+        return;
+      }
+      const isOwnedFileSummary = record.type === "test-file-summary"
+        && proofFile(record.file) === worker.file;
+      // Under `--test-isolation=none`, Node emits the one-process run summary
+      // rather than an outer isolation-file summary. The worker is already
+      // bound to exactly one file at spawn, so that summary is its direct proof.
+      const isOwnedRunSummary = record.type === "test-run-summary";
+      if (!isOwnedFileSummary && !isOwnedRunSummary) return;
+      if (typeof record.success !== "boolean" || !validProofCounts(record.counts)) {
+        proofError = "completion reporter emitted an invalid matching summary";
+        requestTermination("invalid-proof");
+        return;
+      }
+      if (proof !== undefined) {
+        proofError = "completion reporter emitted more than one matching file summary";
+        requestTermination("invalid-proof");
+        return;
+      }
+      proof = {
+        success: record.success,
+        counts: record.counts
+      };
+      recordEvent("proof-flushed", { success: proof.success, counts: proof.counts });
+      clearTimeout(deadline);
+      deadline = setTimeout(
+        () => requestTermination("post-proof-exit-wedge"),
+        proofExitGraceMs
+      );
+    },
+    onProtocolError(error) {
+      proofError = error.message;
+      requestTermination("invalid-proof");
+    }
+  });
+
+  const onAbort = () => requestTermination(parentSignalReason(abortSignal.reason));
+  abortSignal?.addEventListener("abort", onAbort, { once: true });
+  if (abortSignal?.aborted) onAbort();
+  deadline = setTimeout(() => requestTermination("deadline-before-proof"), workerDeadlineMs);
+
+  let close = await closed;
+  clearTimeout(deadline);
+  if (terminationEffect !== undefined) await terminationEffect;
+  if (close.error === null && close.code === null && close.signal === null) {
+    close = await closeWithinBudget(closed, FINAL_CLOSE_BUDGET_MS);
+  }
+  abortSignal?.removeEventListener("abort", onAbort);
+  recordEvent("close/reap", {
+    kind: terminationReason === undefined ? "close" : "reap",
+    reason: terminationReason ?? "natural-close",
+    code: close.code,
+    signal: close.signal,
+    error: close.error?.message ?? null
+  });
+
+  const result = settleWorker({
+    worker,
+    proof,
+    proofError,
+    failures,
+    terminationReason,
+    close,
+    trace,
+    output,
+    errorOutput
+  });
+  recordEvent("settled", { outcome: result.outcome, failure: result.failure });
+  result.trace = trace;
+  result.durationMs = performance.now() - (runStartedAt + trace[0].atMs);
+  return result;
+
+  function requestTermination(reason) {
+    if (terminationEffect !== undefined) return;
+    terminationReason = reason;
+    terminationEffect = terminateOwnedTree(child, terminationGraceMs);
+  }
+
+  function recordEvent(phase, detail) {
+    const event = {
+      phase,
+      atMs: performance.now() - runStartedAt,
+      detail
+    };
+    trace.push(event);
+    onEvent({ workerId: worker.id, file: worker.file, ...event });
+  }
+}
+
+function workerInvocation(file, { testTimeoutMs, junitPath }) {
+  const args = [
+    "--test",
+    "--test-isolation=none",
+    `--test-timeout=${testTimeoutMs}`,
+    `--test-reporter=${completionReporterUrl}`,
+    "--test-reporter-destination=stdout"
+  ];
+  if (junitPath !== undefined) {
+    args.push("--test-reporter=junit", `--test-reporter-destination=${junitPath}`);
+  }
+  args.push("--test-force-exit", file);
+  return args;
+}
+
+function consumeProofRecords(stream, { onRecord, onProtocolError }) {
+  let buffer = "";
+  stream.on("data", (chunk) => {
+    buffer += chunk.toString();
+    while (true) {
+      const newline = buffer.indexOf("\n");
+      if (newline === -1) return;
+      const line = buffer.slice(0, newline);
+      buffer = buffer.slice(newline + 1);
+      if (line.trim() === "") continue;
+      try {
+        onRecord(JSON.parse(line));
+      } catch (error) {
+        onProtocolError(new Error(
+          `completion proof is not valid JSON: ${error instanceof Error ? error.message : String(error)}`
+        ));
+      }
+    }
+  });
+  stream.once("end", () => {
+    if (buffer.trim() !== "") {
+      onProtocolError(new Error("completion proof ended with a partial JSON record"));
+    }
+  });
+  stream.once("error", (error) => onProtocolError(error));
+}
+
+function proofFile(file) {
+  if (typeof file !== "string" || !path.isAbsolute(file)) return null;
+  const relative = path.relative(repoRoot, file).split(path.sep).join("/");
+  if (relative === "" || relative === ".." || relative.startsWith("../")) return null;
+  return relative;
+}
+
+function validProofCounts(counts) {
+  return counts !== null
+    && typeof counts === "object"
+    && [
+      counts.tests,
+      counts.failed,
+      counts.passed,
+      counts.cancelled,
+      counts.skipped,
+      counts.todo
+    ].every((value) => Number.isSafeInteger(value) && value >= 0);
+}
+
+function settleWorker({
+  worker,
+  proof,
+  proofError,
+  failures,
+  terminationReason,
+  close,
+  trace,
+  output,
+  errorOutput
+}) {
+  const base = {
+    id: worker.id,
+    file: worker.file,
+    proof: proof ?? null,
+    failures,
+    close: {
+      code: close.code,
+      signal: close.signal,
+      error: close.error?.message ?? null
+    },
+    output,
+    errorOutput,
+    trace
+  };
+  if (terminationReason?.startsWith("parent-signal:")) {
+    return {
+      ...base,
+      outcome: "failed",
+      failure: { name: worker.file, kind: terminationReason }
+    };
+  }
+  if (proofError !== undefined) {
+    return {
+      ...base,
+      outcome: "failed",
+      failure: { name: worker.file, kind: "invalid-structured-proof", detail: proofError }
+    };
+  }
+  if (proof === undefined) {
+    return {
+      ...base,
+      outcome: "failed",
+      failure: {
+        name: worker.file,
+        kind: terminationReason ?? "closed-before-proof"
+      }
+    };
+  }
+  if (!proof.success) {
+    return {
+      ...base,
+      outcome: terminationReason === "post-proof-exit-wedge" ? "failed-after-reap" : "failed",
+      failure: {
+        name: failures[0]?.name ?? worker.file,
+        kind: "test-failure"
+      }
+    };
+  }
+  if (terminationReason === "post-proof-exit-wedge") {
+    return { ...base, outcome: "passed-after-reap", failure: null };
+  }
+  if (terminationReason === undefined && close.error === null && close.code === 0 && close.signal === null) {
+    return { ...base, outcome: "passed", failure: null };
+  }
+  return {
+    ...base,
+    outcome: "failed",
+    failure: { name: worker.file, kind: terminationReason ?? "unexpected-close-after-proof" }
+  };
+}
+
+async function terminateOwnedTree(child, graceMs) {
+  if (child.pid === undefined) return;
+  if (process.platform === "win32") {
+    await runTaskkill(child.pid, graceMs);
+    return;
+  }
+  signalOwnedGroup(child.pid, "SIGTERM");
+  await delay(graceMs);
+  signalOwnedGroup(child.pid, "SIGKILL");
+}
+
+function signalOwnedGroup(pid, signal) {
+  try {
+    process.kill(-pid, signal);
+  } catch (error) {
+    if (error?.code !== "ESRCH") throw error;
+  }
+}
+
+function runTaskkill(pid, graceMs) {
+  return new Promise((resolveKill) => {
+    const killer = spawn("taskkill", ["/pid", String(pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true
+    });
+    const deadline = setTimeout(() => {
+      killer.kill("SIGKILL");
+      resolveKill();
+    }, Math.max(graceMs, 1_000));
+    killer.once("error", () => {
+      clearTimeout(deadline);
+      resolveKill();
+    });
+    killer.once("close", () => {
+      clearTimeout(deadline);
+      resolveKill();
+    });
+  });
+}
+
+function parentSignalReason(reason) {
+  const signal = reason?.signal;
+  return `parent-signal:${typeof signal === "string" ? signal : "unknown"}`;
+}
+
+function unstartedSignalResult(file, index, reason) {
+  return {
+    id: `file-worker-${String(index + 1).padStart(3, "0")}`,
+    file,
+    outcome: "failed",
+    failure: { name: file, kind: parentSignalReason(reason) },
+    proof: null,
+    failures: [],
+    close: { code: null, signal: null, error: null },
+    trace: [],
+    durationMs: 0,
+    output: "",
+    errorOutput: ""
+  };
+}
+
+function closeWithinBudget(closed, timeoutMs) {
+  return Promise.race([
+    closed,
+    new Promise((resolveClose) => setTimeout(
+      () => resolveClose({
+        code: null,
+        signal: null,
+        error: new Error(`owned worker did not close within ${timeoutMs}ms after termination`)
+      }),
+      timeoutMs
+    ))
+  ]);
+}
+
+function delay(milliseconds) {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+}

--- a/tools/prototypes/run-file-worker-prototype.mjs
+++ b/tools/prototypes/run-file-worker-prototype.mjs
@@ -1,0 +1,538 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync
+} from "node:fs";
+import { arch, cpus, platform, release, tmpdir } from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { pathToFileURL } from "node:url";
+import { runFileWorkerSchedule } from "./file-worker-scheduler-prototype.mjs";
+import { createHermeticTestEnvironment } from "../test-process-environment.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+const scriptPath = path.join(import.meta.dirname, "run-file-worker-prototype.mjs");
+const completionReporterUrl = pathToFileURL(
+  path.join(repoRoot, "tools/node-test-completion-reporter.mjs")
+).href;
+const fixturePreload = `--import=${pathToFileURL(
+  path.join(repoRoot, "tools/cli-test-fixture-register.mjs")
+).href}`;
+const concurrency = 2;
+const afterCompletionWedge = "tools/test-fixtures/.runner-stall/post-complete-wedge.test.mjs";
+const beforeCompletionWedge = "tools/test-fixtures/.runner-stall/wedged-module.test.mjs";
+const failureExitWedge = "tools/test-fixtures/.file-worker-prototype/failure-post-complete-wedge.test.mjs";
+const parentSignalFiles = [
+  "tools/test-fixtures/.file-worker-prototype/parent-signal-a.test.mjs",
+  "tools/test-fixtures/.file-worker-prototype/parent-signal-b.test.mjs"
+];
+const coldStartFixture = "tools/test-fixtures/.runner-stall/chatter.test.mjs";
+const representativeFiles = Object.freeze({
+  fast: [
+    "packages/adapters/github-issues/test/github-ref-mapper.test.ts",
+    "packages/application/test/actor-axes-binding-v2.test.ts",
+    "packages/cli/test/cas-parse-args.test.ts",
+    "packages/daemon/test/authority-key-store.test.ts",
+    "packages/gui/test/favorites-storage.test.ts"
+  ],
+  integration: [
+    "packages/adapters/multica/test/multica-readonly-adopt.test.ts",
+    "packages/application/test/execution-saga.test.ts",
+    "packages/cli/test/progress-evidence-cli.test.ts",
+    "packages/daemon/test/transport-integration.test.ts",
+    "packages/kernel/test/store/payload-hash.test.ts"
+  ]
+});
+
+const [mode = "all", ...args] = process.argv.slice(2);
+if (mode === "schedule-parent-signal") {
+  await runParentSignalChild();
+} else {
+  const samples = sampleCount(args);
+  const output = {
+    schema: "harness-file-worker-prototype-findings/v1",
+    generatedAt: new Date().toISOString(),
+    environment: runtimeEnvironment(),
+    correctness: mode === "benchmark" ? undefined : await runCorrectnessControls(),
+    performance: mode === "correctness" ? undefined : await runPerformanceComparison(samples)
+  };
+  console.log(JSON.stringify(output, null, 2));
+}
+
+async function runCorrectnessControls() {
+  const controls = [];
+  controls.push(await runDirectControl({
+    name: "completion-after-exit-wedge",
+    file: afterCompletionWedge,
+    fixture: "post-complete-wedge",
+    expectedOutcome: "passed-after-reap",
+    expectedFailure: null,
+    expectedProof: true
+  }));
+  controls.push(await runDirectControl({
+    name: "wedge-before-completion",
+    file: beforeCompletionWedge,
+    fixture: "wedge",
+    expectedOutcome: "failed",
+    expectedFailure: {
+      name: beforeCompletionWedge,
+      kind: "deadline-before-proof"
+    },
+    expectedProof: false
+  }));
+  controls.push(await runDirectControl({
+    name: "real-failure-plus-exit-wedge",
+    file: failureExitWedge,
+    fixture: "failure-post-complete-wedge",
+    expectedOutcome: "failed-after-reap",
+    expectedFailure: {
+      name: "prototype preserves the real failure before an exit wedge",
+      kind: "test-failure"
+    },
+    expectedProof: true,
+    expectedProofSuccess: false
+  }));
+  controls.push(await runParentSignalControl());
+  return {
+    verdictInputs: [
+      "spawn-time worker id plus direct ChildProcess handle",
+      "structured JSONL proof on fd 3",
+      "direct worker close event",
+      "owned process-group termination effect"
+    ],
+    forbiddenVerdictInputs: ["ps", "wchan", "registry", "stdout regex"],
+    controls
+  };
+}
+
+async function runDirectControl({
+  name,
+  file,
+  fixture,
+  expectedOutcome,
+  expectedFailure,
+  expectedProof,
+  expectedProofSuccess = true
+}) {
+  return withPrototypeEnvironment({
+    HARNESS_FILE_WORKER_FIXTURE: fixture,
+    HARNESS_RUNNER_STALL_FIXTURE: fixture
+  }, async (env) => {
+    const result = await runFileWorkerSchedule({
+      files: [file],
+      concurrency: 1,
+      env,
+      testTimeoutMs: 5_000,
+      workerDeadlineMs: 500,
+      proofExitGraceMs: 250,
+      terminationGraceMs: 100
+    });
+    const worker = result.workers[0];
+    assert.equal(worker.outcome, expectedOutcome, JSON.stringify(result, null, 2));
+    assert.deepEqual(worker.failure, expectedFailure, JSON.stringify(result, null, 2));
+    assert.equal(worker.proof !== null, expectedProof, JSON.stringify(result, null, 2));
+    if (expectedProof) {
+      assert.equal(worker.proof.success, expectedProofSuccess, JSON.stringify(result, null, 2));
+    }
+    assertTrace(worker.trace, expectedProof);
+    return {
+      name,
+      assertion: "pass",
+      scheduleExitCode: result.exitCode,
+      worker: publicWorkerResult(worker)
+    };
+  });
+}
+
+async function runParentSignalControl() {
+  const pidRoot = mkdtempSync(path.join(tmpdir(), "ha-file-worker-parent-signal-"));
+  try {
+    return await withPrototypeEnvironment({
+      HARNESS_FILE_WORKER_FIXTURE: "parent-signal",
+      HARNESS_FILE_WORKER_PID_ROOT: pidRoot
+    }, async (env) => {
+      const child = spawn(process.execPath, [scriptPath, "schedule-parent-signal"], {
+        cwd: repoRoot,
+        env,
+        stdio: ["ignore", "pipe", "pipe"]
+      });
+      const output = collectChild(child, 15_000);
+      await waitFor(() => parentSignalRecords(pidRoot).length === parentSignalFiles.length, 5_000);
+      const records = parentSignalRecords(pidRoot);
+      child.kill("SIGTERM");
+      const closed = await output;
+      assert.equal(closed.error, null, closed.stderr);
+      assert.equal(closed.signal, null, closed.stderr);
+      assert.equal(closed.code, 1, closed.stderr);
+      const schedule = JSON.parse(closed.stdout.trim());
+      assert.equal(schedule.verdict, "fail", closed.stdout);
+      assert.equal(schedule.workers.length, parentSignalFiles.length, closed.stdout);
+      assert.equal(schedule.workers.every((worker) =>
+        worker.failure?.kind === "parent-signal:SIGTERM"), true, closed.stdout);
+      await waitFor(() => records.every(({ workerPid, descendantPid }) =>
+        !processIsAlive(workerPid) && !processIsAlive(descendantPid)), 5_000);
+      for (const worker of schedule.workers) assertTrace(worker.trace, false);
+      return {
+        name: "parent-signal-reaps-all-direct-worker-trees",
+        assertion: "pass",
+        schedulerClose: { code: closed.code, signal: closed.signal },
+        observedPids: records,
+        allObservedPidsReaped: records.every(({ workerPid, descendantPid }) =>
+          !processIsAlive(workerPid) && !processIsAlive(descendantPid)),
+        workers: schedule.workers.map(publicWorkerResult)
+      };
+    });
+  } finally {
+    rmSync(pidRoot, { recursive: true, force: true });
+  }
+}
+
+async function runParentSignalChild() {
+  const abortController = new AbortController();
+  let parentSignal = null;
+  const onSigterm = () => {
+    parentSignal = "SIGTERM";
+    abortController.abort({ signal: parentSignal });
+  };
+  const onSigint = () => {
+    parentSignal = "SIGINT";
+    abortController.abort({ signal: parentSignal });
+  };
+  process.once("SIGTERM", onSigterm);
+  process.once("SIGINT", onSigint);
+  const result = await runFileWorkerSchedule({
+    files: parentSignalFiles,
+    concurrency: parentSignalFiles.length,
+    env: process.env,
+    workerDeadlineMs: 30_000,
+    proofExitGraceMs: 1_000,
+    terminationGraceMs: 150,
+    abortSignal: abortController.signal
+  });
+  process.removeListener("SIGTERM", onSigterm);
+  process.removeListener("SIGINT", onSigint);
+  console.log(JSON.stringify(result));
+  process.exitCode = parentSignal === null ? result.exitCode : 1;
+}
+
+async function runPerformanceComparison(samples) {
+  const tiers = {};
+  for (const [tier, files] of Object.entries(representativeFiles)) {
+    tiers[tier] = await benchmarkTier(tier, files, samples);
+  }
+  const aggregateBaseline = tiers.fast.samplesMs.map(
+    (duration, index) => duration + tiers.integration.samplesMs[index]
+  );
+  const aggregateCandidate = tiers.fast.candidateSamplesMs.map(
+    (duration, index) => duration + tiers.integration.candidateSamplesMs[index]
+  );
+  const aggregate = comparisonSummary(aggregateBaseline, aggregateCandidate);
+  const coldStart = await benchmarkColdStart(Math.max(samples, 30));
+  const thresholdExceeded = [tiers.fast, tiers.integration, aggregate]
+    .some((comparison) => comparison.p95RegressionPercent > 15);
+  return {
+    concurrency,
+    measuredSamplesPerArchitecturePerTier: samples,
+    warmupsPerArchitecturePerTier: 1,
+    representativeFiles,
+    baselineShape: "one top-level node --test host, default process isolation, five files",
+    candidateShape: "scheduler with one top-level node --test --test-isolation=none worker per file",
+    tiers,
+    aggregate,
+    coldStart,
+    acceptanceThreshold: "candidate p95 regression must be <= 15%",
+    thresholdExceeded
+  };
+}
+
+async function benchmarkTier(tier, files, samples) {
+  return withPrototypeEnvironment({}, async (baseEnv) => {
+    const env = tier === "integration" ? integrationEnvironment(baseEnv) : baseEnv;
+    await runBaseline(files, env);
+    await runCandidate(files, env);
+    const baselineSamples = [];
+    const candidateSamples = [];
+    const candidateWorkerSamples = [];
+    for (let index = 0; index < samples; index += 1) {
+      if (index % 2 === 0) {
+        baselineSamples.push((await runBaseline(files, env)).durationMs);
+        const candidate = await runCandidate(files, env);
+        candidateSamples.push(candidate.durationMs);
+        candidateWorkerSamples.push(...candidate.workers.map((worker) => worker.durationMs));
+      } else {
+        const candidate = await runCandidate(files, env);
+        candidateSamples.push(candidate.durationMs);
+        candidateWorkerSamples.push(...candidate.workers.map((worker) => worker.durationMs));
+        baselineSamples.push((await runBaseline(files, env)).durationMs);
+      }
+    }
+    return {
+      ...comparisonSummary(baselineSamples, candidateSamples),
+      samplesMs: baselineSamples.map(roundMilliseconds),
+      candidateSamplesMs: candidateSamples.map(roundMilliseconds),
+      candidateWorkerDuration: distribution(candidateWorkerSamples)
+    };
+  });
+}
+
+async function benchmarkColdStart(samples) {
+  return withPrototypeEnvironment({}, async (env) => {
+    const rawNodeSamples = [];
+    const fileWorkerSamples = [];
+    await spawnMeasured(["--eval", ""]);
+    await runCandidate([coldStartFixture], env);
+    for (let index = 0; index < samples; index += 1) {
+      rawNodeSamples.push((await spawnMeasured(["--eval", ""])).durationMs);
+      fileWorkerSamples.push((await runCandidate([coldStartFixture], env)).durationMs);
+    }
+    const rawNode = distribution(rawNodeSamples);
+    const directFileWorker = distribution(fileWorkerSamples);
+    return {
+      samples,
+      fixture: coldStartFixture,
+      rawTopLevelNodeProcess: rawNode,
+      directFileWorkerWithTestRunnerAndStructuredProof: directFileWorker,
+      p95TestWorkerEnvelopeAboveRawNodeMs: roundMilliseconds(
+        directFileWorker.p95Ms - rawNode.p95Ms
+      )
+    };
+  });
+}
+
+async function runBaseline(files, env) {
+  const timingRoot = mkdtempSync(path.join(tmpdir(), "ha-file-worker-baseline-"));
+  try {
+    return await spawnMeasured([
+      "--test",
+      `--test-concurrency=${concurrency}`,
+      "--test-timeout=180000",
+      `--test-reporter=${completionReporterUrl}`,
+      "--test-reporter-destination=stdout",
+      "--test-reporter=junit",
+      `--test-reporter-destination=${path.join(timingRoot, "results.xml")}`,
+      "--test-force-exit",
+      ...files
+    ], { env, fd3: true });
+  } finally {
+    rmSync(timingRoot, { recursive: true, force: true });
+  }
+}
+
+async function runCandidate(files, env) {
+  const junitRoot = mkdtempSync(path.join(tmpdir(), "ha-file-worker-candidate-"));
+  try {
+    const result = await runFileWorkerSchedule({
+      files,
+      concurrency,
+      env,
+      junitRoot,
+      testTimeoutMs: 180_000,
+      workerDeadlineMs: 180_000,
+      proofExitGraceMs: 2_000
+    });
+    assert.equal(result.exitCode, 0, JSON.stringify(result, null, 2));
+    return result;
+  } finally {
+    rmSync(junitRoot, { recursive: true, force: true });
+  }
+}
+
+function spawnMeasured(args, { env = process.env, fd3 = false } = {}) {
+  const startedAt = performance.now();
+  const child = spawn(process.execPath, args, {
+    cwd: repoRoot,
+    env,
+    stdio: fd3
+      ? ["ignore", "pipe", "pipe", "pipe"]
+      : ["ignore", "pipe", "pipe"]
+  });
+  return new Promise((resolveRun, rejectRun) => {
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    if (fd3) child.stdio[3].resume();
+    child.once("error", rejectRun);
+    child.once("close", (code, signal) => {
+      const durationMs = performance.now() - startedAt;
+      if (code !== 0 || signal !== null) {
+        rejectRun(new Error(
+          `measured child failed code=${code} signal=${signal}\n${stdout}\n${stderr}`
+        ));
+        return;
+      }
+      resolveRun({ durationMs, code, signal });
+    });
+  });
+}
+
+function withPrototypeEnvironment(additions, run) {
+  const baseEnv = {
+    ...process.env,
+    NODE_COMPILE_CACHE: process.env.NODE_COMPILE_CACHE
+      ?? path.join(repoRoot, "node_modules/.cache/harness-node-compile"),
+    HARNESS_ACTOR: process.env.HARNESS_ACTOR ?? "agent:harness-test",
+    HARNESS_GIT_AUTHOR_NAME: process.env.HARNESS_GIT_AUTHOR_NAME ?? "Harness Test",
+    HARNESS_GIT_AUTHOR_EMAIL: process.env.HARNESS_GIT_AUTHOR_EMAIL ?? "harness@example.test",
+    ...additions
+  };
+  delete baseEnv.NODE_TEST_CONTEXT;
+  const testEnvironment = createHermeticTestEnvironment(baseEnv);
+  return Promise.resolve(run(testEnvironment.env)).finally(() => testEnvironment.cleanup());
+}
+
+function integrationEnvironment(baseEnv) {
+  return {
+    ...baseEnv,
+    HARNESS_CLI_TEST_FIXTURE_PRELOAD: "1",
+    NODE_OPTIONS: [baseEnv.NODE_OPTIONS, fixturePreload].filter(Boolean).join(" ")
+  };
+}
+
+function comparisonSummary(baselineSamples, candidateSamples) {
+  const baseline = distribution(baselineSamples);
+  const candidate = distribution(candidateSamples);
+  return {
+    baseline,
+    candidate,
+    p95RegressionPercent: roundPercent(
+      ((candidate.p95Ms / baseline.p95Ms) - 1) * 100
+    )
+  };
+}
+
+function distribution(values) {
+  const sorted = [...values].sort((left, right) => left - right);
+  return {
+    minMs: roundMilliseconds(sorted[0]),
+    p50Ms: roundMilliseconds(percentile(sorted, 0.5)),
+    p95Ms: roundMilliseconds(percentile(sorted, 0.95)),
+    maxMs: roundMilliseconds(sorted.at(-1)),
+    meanMs: roundMilliseconds(values.reduce((sum, value) => sum + value, 0) / values.length)
+  };
+}
+
+function percentile(sorted, quantile) {
+  return sorted[Math.max(0, Math.ceil(sorted.length * quantile) - 1)];
+}
+
+function publicWorkerResult(worker) {
+  return {
+    id: worker.id,
+    file: worker.file,
+    outcome: worker.outcome,
+    failure: worker.failure,
+    proof: worker.proof,
+    failures: worker.failures,
+    close: worker.close,
+    trace: worker.trace.map((event) => ({
+      ...event,
+      atMs: roundMilliseconds(event.atMs)
+    })),
+    stdout: worker.output.trim(),
+    stderr: worker.errorOutput.trim()
+  };
+}
+
+function assertTrace(trace, expectProof) {
+  const phases = trace.map((event) => event.phase);
+  assert.equal(phases[0], "spawn", JSON.stringify(trace));
+  assert.equal(phases.at(-2), "close/reap", JSON.stringify(trace));
+  assert.equal(phases.at(-1), "settled", JSON.stringify(trace));
+  assert.equal(phases.includes("proof-flushed"), expectProof, JSON.stringify(trace));
+  if (expectProof) {
+    assert.equal(
+      phases.indexOf("proof-flushed") < phases.indexOf("close/reap"),
+      true,
+      JSON.stringify(trace)
+    );
+  }
+}
+
+function parentSignalRecords(pidRoot) {
+  return ["a", "b"]
+    .map((label) => path.join(pidRoot, `${label}.json`))
+    .filter(existsSync)
+    .map((file) => JSON.parse(readFileSync(file, "utf8")));
+}
+
+function collectChild(child, timeoutMs) {
+  return new Promise((resolveChild) => {
+    let stdout = "";
+    let stderr = "";
+    let error = null;
+    const deadline = setTimeout(() => child.kill("SIGKILL"), timeoutMs);
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.once("error", (caught) => {
+      error = caught;
+    });
+    child.once("close", (code, signal) => {
+      clearTimeout(deadline);
+      resolveChild({ code, signal, error, stdout, stderr });
+    });
+  });
+}
+
+async function waitFor(predicate, timeoutMs) {
+  const deadline = performance.now() + timeoutMs;
+  while (!predicate()) {
+    if (performance.now() >= deadline) {
+      throw new Error(`prototype condition was not met within ${timeoutMs}ms`);
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+  }
+}
+
+function processIsAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    if (error?.code === "EPERM") return true;
+    throw error;
+  }
+}
+
+function sampleCount(args) {
+  const raw = args.find((argument) => argument.startsWith("--samples="));
+  if (raw === undefined) return 20;
+  const value = Number(raw.slice("--samples=".length));
+  if (!Number.isSafeInteger(value) || value < 2) {
+    throw new Error("--samples must be an integer of at least 2");
+  }
+  return value;
+}
+
+function runtimeEnvironment() {
+  return {
+    node: process.version,
+    executable: process.execPath,
+    platform: platform(),
+    release: release(),
+    architecture: arch(),
+    logicalCpuCount: cpus().length
+  };
+}
+
+function roundMilliseconds(value) {
+  return Number(value.toFixed(3));
+}
+
+function roundPercent(value) {
+  return Number(value.toFixed(2));
+}

--- a/tools/test-fixtures/.file-worker-prototype/failure-post-complete-wedge.test.mjs
+++ b/tools/test-fixtures/.file-worker-prototype/failure-post-complete-wedge.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+if (process.env.HARNESS_FILE_WORKER_FIXTURE === "failure-post-complete-wedge") {
+  process.on("exit", () => {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+  });
+}
+
+test("prototype preserves the real failure before an exit wedge", () => {
+  if (process.env.HARNESS_FILE_WORKER_FIXTURE === "failure-post-complete-wedge") {
+    assert.fail("intentional prototype failure before exit wedge");
+  }
+});

--- a/tools/test-fixtures/.file-worker-prototype/parent-signal-a.test.mjs
+++ b/tools/test-fixtures/.file-worker-prototype/parent-signal-a.test.mjs
@@ -1,0 +1,3 @@
+import { registerParentSignalFixture } from "./parent-signal-fixture.mjs";
+
+registerParentSignalFixture("a");

--- a/tools/test-fixtures/.file-worker-prototype/parent-signal-b.test.mjs
+++ b/tools/test-fixtures/.file-worker-prototype/parent-signal-b.test.mjs
@@ -1,0 +1,3 @@
+import { registerParentSignalFixture } from "./parent-signal-fixture.mjs";
+
+registerParentSignalFixture("b");

--- a/tools/test-fixtures/.file-worker-prototype/parent-signal-fixture.mjs
+++ b/tools/test-fixtures/.file-worker-prototype/parent-signal-fixture.mjs
@@ -1,0 +1,26 @@
+import { spawn } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+export function registerParentSignalFixture(label) {
+  test(`prototype parent signal owns worker tree ${label}`, async () => {
+    const pidRoot = process.env.HARNESS_FILE_WORKER_PID_ROOT;
+    if (process.env.HARNESS_FILE_WORKER_FIXTURE !== "parent-signal" || pidRoot === undefined) return;
+
+    const descendant = spawn(process.execPath, [
+      "--input-type=module",
+      "--eval",
+      "process.on('SIGTERM', () => {}); setInterval(() => {}, 60_000)"
+    ], {
+      stdio: "ignore"
+    });
+    mkdirSync(pidRoot, { recursive: true });
+    writeFileSync(path.join(pidRoot, `${label}.json`), `${JSON.stringify({
+      label,
+      workerPid: process.pid,
+      descendantPid: descendant.pid
+    })}\n`);
+    await new Promise(() => {});
+  });
+}


### PR DESCRIPTION
# English

## Summary

Adds a bounded, throwaway prototype that proves Harness can own test file worker creation directly, instead of letting Node create hidden per-file isolation children whose verdict must then be reconstructed from five channels with no shared transaction boundary.

The prototype is **not wired into** `tools/run-node-tests.mjs`, any gate, or any `.github/` workflow. It exists to answer one question before the production migration starts: does the route work, and what does it cost?

**Answer: it works, and p95 did not regress.**

## What Changed

- `tools/prototypes/file-worker-scheduler-prototype.mjs` — concurrency-limited scheduler plus a direct file-worker lifecycle reducer.
- `tools/prototypes/run-file-worker-prototype.mjs` — the four correctness controls, representative-file A/B benchmark, and cold-start measurement.
- `tools/test-fixtures/.file-worker-prototype/` — a real-failure-then-exit-wedge fixture and two parent-signal worker-tree fixtures (hidden directory, does not enter production tiers).

Every candidate worker is invoked as `node --test --test-isolation=none --test-reporter=<completion-reporter> --test-force-exit <one-file>`. Structured completion proof still arrives on fd 3. Because the scheduler binds the process to its unique file at spawn time, identity never has to be recovered from file summaries, PIDs, or argv.

## Task And Scope

- Task: `task_01KZ1GG35F0HH4XZK5P0W4Y8NS` (PLT-Steady CI slice C1)
- Parent line: `task_01KZ1FKCKNJ8DYD5VV7HG9E94S`
- Scope: anchor registration (read-only) plus a bounded prototype with real performance data. Production migration is explicitly out of scope for this slice.

## Version Impact

No published artifact changes. No package version bump. `tools/prototypes/` is developer tooling that no build or release path consumes.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable — this PR adds new files only under `tools/prototypes/` and a hidden fixture directory; it does not modify `tools/run-node-tests.mjs`, `tools/gate-manifest.json`, `tools/test-tier-manifest.mjs`, or anything under `.github/`
- Authority: `dec_01KZ1EQY5PATT8GGV35CFE9FHG` (PLT-Steady charter), task `task_01KZ1GG35F0HH4XZK5P0W4Y8NS`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: the production migration slice will touch the CI authority surface and carries its own declaration; that authority comes from the CI line's task plan, not from this PR.

## Verification

- Base `origin/main` SHA: `cd25b064cf288948dfac823efd4172d3eba356ba`
- Branch merge-base with `origin/main`: `cd25b064cf288948dfac823efd4172d3eba356ba`
- Last `git fetch origin` time: at branch creation, immediately before this PR
- Sync method: none needed (merge-base equals `origin/main` head)
- Public diff command: `git diff cd25b064cf288948dfac823efd4172d3eba356ba..072ae0331497e88b8154652c02ef09f64b07842a`
- Private evidence commit/path: prototype findings and anchor registry live in the private task package artifacts
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending on this PR

### Four correctness controls (Node 24.18.0 and Node 26.4.0, 4/4 pass on both)

| Control | Expected | Observed |
| --- | --- | --- |
| Post-completion exit wedge | pass after reap | `passed-after-reap`, proof flushed at 93.7ms, reaped at 445.8ms |
| Pre-completion wedge | exact named fail | `deadline-before-proof`, filename from spawn-time identity, no proof frame |
| Real failure plus exit wedge | fail | `failed-after-reap`, `success:false` proof cannot be reconstructed as pass |
| Parent signal | whole owned tree reaped | 2 workers plus 2 SIGTERM-ignoring descendants, all 4 PIDs returned `ESRCH` |

### Verdict authority audit

The reducer's only inputs are spawn-time worker identity, the fd 3 JSONL summary, the direct child `close` event, and the scheduler's own owned-tree termination. Static negative check:

```
rg -n -- 'spawn\("ps"|wchan|isolation-registry|\.test\(output\)|output\.match|output\.includes' \
   tools/prototypes/file-worker-scheduler-prototype.mjs
(no matches)
```

Worker stdout/stderr is retained for human diagnosis but never read by the reducer.

### Performance (20 samples, alternating baseline-first / candidate-first, identical concurrency of 2)

| Set | Baseline p95 | Candidate p95 | Delta |
| --- | ---: | ---: | ---: |
| fast, 5 files | 1036.073ms | 988.482ms | **-4.59%** |
| integration, 5 files | 4323.115ms | 4127.272ms | **-4.53%** |
| combined | 5347.279ms | 5106.767ms | **-4.50%** |

Cold start, 30 sequential runs: bare `node --eval ""` p95 60.662ms → 63.711ms; a full file worker with test runner and fd 3 proof p95 99.676ms. The envelope costs **35.965ms** more per top-level process. That is not free, but the current baseline additionally creates one isolation child per file, and at equal concurrency the top-level cost did not translate into wall-clock regression across the 10 representative files.

The `>15%` p95 stop condition was not hit.

- [x] `git diff --check`
- [x] `npm run check:local` — exit 0 in 52.4s, 27 complete manifest gates green
- [x] Targeted tests for the change surface, named with their counts: change-aware fast `205 pass / 0 fail`, contract `239 pass / 0 fail`, four correctness controls `4/4` on Node 24.18.0 and `4/4` on Node 26.4.0
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)

## Review Evidence

CEO semantic acceptance was performed against the CI line's charter criterion rather than against the PR's own claims. The charter says the line is done when `tools/run-node-tests.mjs` covers `--test-isolation` and the verdict path stops depending on `ps` / wchan / the isolation registry. This PR does not delete those anchors — it is not supposed to. What it had to prove is that deleting them is feasible without paying a performance penalty, and that is what the four controls plus the A/B measurement show.

One measurement was discarded and reported rather than quietly dropped: the worktree's seeded `better-sqlite3.node` was built for Node 26 ABI 147, so the first Node 24 integration run failed on the baseline side. It was excluded, the binary was rebuilt for the measurement and then restored, and the SHA-256 matched before and after (`0000d73c6e2e94318ed2b9339139623d5a0908b195f1e761c16cfd98f9cc6229`). No native rebuild artifact reached the lockfile, sources, or Git state.

## Residual Risk

- The A/B covers 10 representative files at concurrency 2. The advantage is not proven to hold at the concurrency levels production CI actually uses, and per-file top-level process cost scales differently from hidden isolation children. **The production migration slice must re-measure at production concurrency** — over-subscription is a known failure mode for this subsystem.
- Not validated and must not be extrapolated: Linux and Windows termination adapters, full fast/contract/integration parity, JUnit merge semantics, slow-summary aggregation, global setup and coverage, CI soak.
- The prototype is discardable. If the production migration takes a different shape, deleting `tools/prototypes/` costs nothing.

## References

- PLT-Steady charter: `dec_01KZ1EQY5PATT8GGV35CFE9FHG`
- Mitigation accounting policy: `dec_01KYYX1AXK7JMWFGCKX059W6PV`
- CI line: `task_01KZ1FKCKNJ8DYD5VV7HG9E94S`
- This slice: `task_01KZ1GG35F0HH4XZK5P0W4Y8NS`

# 中文

## 概要

新增一个有界的、可丢弃的 prototype,证明 Harness 可以直接拥有测试文件 worker 的创建权,而不是让 Node 为每个文件创建一个我们看不见的 isolation child、再从五条没有共同事务边界的通道反推 verdict。

这个 prototype **没有接入** `tools/run-node-tests.mjs`、任何 gate 或 `.github/` 下的 workflow。它只回答生产迁移开工前必须先回答的一个问题:这条路走不走得通,代价是多少?

**答案:走得通,且 p95 没有退化。**

## 改动内容

- `tools/prototypes/file-worker-scheduler-prototype.mjs` —— 并发受限的 scheduler 与直接 file-worker 生命周期 reducer。
- `tools/prototypes/run-file-worker-prototype.mjs` —— 四个真实性对照、代表文件 A/B、冷启动测量。
- `tools/test-fixtures/.file-worker-prototype/` —— 真实失败后 exit wedge,以及两棵 parent-signal worker tree fixture(隐藏目录,不进入生产 tier)。

每个 candidate worker 的实际 invocation 是 `node --test --test-isolation=none --test-reporter=<completion-reporter> --test-force-exit <单文件>`。结构化 completion proof 仍从 fd 3 写出。因为 scheduler 在 spawn 时就把这个 process 绑定到唯一文件,身份不需要再从 file summary、PID 或 argv 反推。

## 任务与范围

- 任务:`task_01KZ1GG35F0HH4XZK5P0W4Y8NS`(PLT-Steady CI 线切片 C1)
- 父线:`task_01KZ1FKCKNJ8DYD5VV7HG9E94S`
- 范围:结构锚点登记(只读)+ 带真实性能数据的有界 prototype。生产迁移**明确不在本切片范围内**。

## 版本影响

不改动任何已发布工件,不涉及 package 版本变更。`tools/prototypes/` 是开发工具,没有任何 build 或 release 路径消费它。

## 治理声明

- 是否触碰 protected surface:否
- Protected surface 范围:不适用 —— 本 PR 只在 `tools/prototypes/` 和一个隐藏 fixture 目录下新增文件,不修改 `tools/run-node-tests.mjs`、`tools/gate-manifest.json`、`tools/test-tier-manifest.mjs` 或 `.github/` 下任何内容
- 依据:`dec_01KZ1EQY5PATT8GGV35CFE9FHG`(PLT-Steady charter)、任务 `task_01KZ1GG35F0HH4XZK5P0W4Y8NS`
- 机器检查边界:本 PR 只断言声明存在;是否属实、是否充分由评审者判断。
- Break-glass:否
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:生产迁移切片会触碰 CI 权威面并自带声明;那份授权来自 CI 线的 task plan,不来自本 PR。

## 验证

- 基线 `origin/main` SHA:`cd25b064cf288948dfac823efd4172d3eba356ba`
- 分支与 `origin/main` 的 merge-base:`cd25b064cf288948dfac823efd4172d3eba356ba`
- 最近一次 `git fetch origin` 时间:建分支时,即本 PR 之前
- 同步方式:无需同步(merge-base 等于 `origin/main` head)
- 公开 diff 命令:`git diff cd25b064cf288948dfac823efd4172d3eba356ba..072ae0331497e88b8154652c02ef09f64b07842a`
- 私有证据 commit/路径:prototype findings 与锚点清单在私有任务包 artifacts 内
- 评审证据路径:同一任务包
- GitHub Actions `rewrite-ci` run URL:本 PR 待跑

### 四个真实性对照(Node 24.18.0 与 Node 26.4.0 均 4/4 pass)

| 对照 | 预期 | 实测 |
| --- | --- | --- |
| 完成后 exit wedge | pass-after-reap | `passed-after-reap`,proof 于 93.7ms flushed,445.8ms 被回收 |
| 完成前 wedge | exact named fail | `deadline-before-proof`,文件名来自 spawn-time identity,无 proof 帧 |
| 真实 failure + exit wedge | fail | `failed-after-reap`,`success:false` 的 proof 不可能被构造成 pass |
| Parent signal | 整棵 owned tree 被回收 | 2 个 worker + 2 个忽略 SIGTERM 的 descendant,4 个 PID 全部返回 `ESRCH` |

### Verdict 权威面审计

reducer 的输入只有:spawn 时的 worker identity、fd 3 上的 JSONL summary、direct child 的 `close` 事件、以及 scheduler 自己发起的 owned-tree termination。静态负向检查:

```
rg -n -- 'spawn\("ps"|wchan|isolation-registry|\.test\(output\)|output\.match|output\.includes' \
   tools/prototypes/file-worker-scheduler-prototype.mjs
(无匹配)
```

worker 的 stdout/stderr 保留给人诊断,但 reducer 从不读取。

### 性能(20 样本,交替 baseline-first / candidate-first,并发同为 2)

| 集合 | Baseline p95 | Candidate p95 | 差值 |
| --- | ---: | ---: | ---: |
| fast,5 文件 | 1036.073ms | 988.482ms | **-4.59%** |
| integration,5 文件 | 4323.115ms | 4127.272ms | **-4.53%** |
| 合计 | 5347.279ms | 5106.767ms | **-4.50%** |

冷启动 30 次顺序执行:裸 `node --eval ""` p95 63.711ms;带 test runner 与 fd 3 proof 的完整 file worker p95 99.676ms。每个顶级 process 的 envelope 成本高出 **35.965ms**。这不是免费的,但当前 baseline 本来还会为每个文件再创建一个 isolation child;在相同并发的 10 个代表文件上,这项顶级进程成本没有转化成墙钟退化。

`>15%` 的 p95 停手口未命中。

- [x] `git diff --check`
- [x] `npm run check:local` —— exit 0,52.4s,27 个 complete manifest gates 全绿
- [x] 改动面的定向测试,写明测试名与通过数:change-aware fast `205 pass / 0 fail`、contract `239 pass / 0 fail`、四个真实性对照在 Node 24.18.0 `4/4`、Node 26.4.0 `4/4`
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)

## 审查证据

CEO 语义验收对的是 CI 线 charter 的判据,不是 PR 自己的声明。charter 说本线做完的标志是 `tools/run-node-tests.mjs` 覆盖了 `--test-isolation`、verdict 路径不再依赖 `ps` / wchan / isolation registry。本 PR **没有**删除这些锚点 —— 它本来也不该删。它必须证明的是:删除它们可行,且不付性能代价。四个对照加 A/B 测量正是这件事的证据。

有一次测量被作废并如实报告,而不是悄悄丢掉:worktree 播种的 `better-sqlite3.node` 是按 Node 26 ABI 147 编译的,第一次 Node 24 integration 运行在 baseline 侧失败。那次被排除,二进制为测量重建后又恢复,恢复前后 SHA-256 一致(`0000d73c6e2e94318ed2b9339139623d5a0908b195f1e761c16cfd98f9cc6229`)。没有任何 native rebuild 产物进入 lockfile、源码或 Git 状态。

## 残余风险

- A/B 覆盖的是并发为 2 时的 10 个代表文件。这个优势**未被证明**在生产 CI 实际使用的并发水平上依然成立,而且每文件顶级 process 的成本与隐藏 isolation child 的扩展方式不同。**生产迁移切片必须在生产并发下重测** —— 过度订阅是这个子系统已知的故障模式。
- 未验证、不得外推:Linux / Windows termination adapter、全量 fast/contract/integration parity、JUnit 合并语义、slow-summary 聚合、global setup 与 coverage、CI soak。
- 这个 prototype 是可丢弃的。若生产迁移最终换了形状,删掉 `tools/prototypes/` 零代价。

## 关联材料

- PLT-Steady charter:`dec_01KZ1EQY5PATT8GGV35CFE9FHG`
- 记账政策:`dec_01KYYX1AXK7JMWFGCKX059W6PV`
- CI 线:`task_01KZ1FKCKNJ8DYD5VV7HG9E94S`
- 本切片:`task_01KZ1GG35F0HH4XZK5P0W4Y8NS`

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
