### PR TITLE
feat(transport): type the task-complete wire command (PLT-Steady T2)

### DIFF
--- a/packages/application/src/authority/daemon-host-contract.ts
+++ b/packages/application/src/authority/daemon-host-contract.ts
@@ -24,6 +24,48 @@ import type { ProvenanceSessionExporterRejected, ProvenanceSessionExportResult }
 import type { LocalControllerServiceOptions } from "../local-controller-runtime-options.ts";
 import type { DaemonLogService } from "../daemon-log-contract.ts";
 import type { DaemonStatusResultV2 } from "../daemon-status-contract.ts";
+export {
+  decodeTaskCompleteTransitionCommand,
+  TaskCompleteTransitionCommandDecodeError
+} from "./task-complete-transition-command.ts";
+
+export type TaskCompleteConsentSource =
+  | { readonly kind: "recorded-consent"; readonly consentId: string }
+  | { readonly kind: "utterance"; readonly utterance: string }
+  | { readonly kind: "standing-policy"; readonly decisionId: string }
+  | { readonly kind: "asserted-rationale"; readonly rationale: string };
+
+export type TaskCompleteExternalCheckpointRef =
+  | { readonly kind: "document-publication"; readonly ref: string }
+  | { readonly kind: "code-doc-reconciliation"; readonly ref: string };
+
+export interface TaskCompleteApproval {
+  readonly executionId: string | null;
+  readonly findings: string;
+  readonly evidenceChecked: ReadonlyArray<string>;
+  readonly rationale: string;
+  readonly archiveWarningsAcknowledged: boolean;
+  readonly consentSource: TaskCompleteConsentSource;
+  readonly consentActions: ReadonlyArray<ConsentAction> | null;
+  readonly paths: ReadonlyArray<string>;
+  readonly prRef: string | null;
+}
+
+/** Complete caller-owned intent; null and [] express non-applicability without decoder defaults. */
+export interface TaskCompleteTransitionCommand {
+  readonly kind: "task-complete";
+  readonly taskId: string;
+  readonly executionId: string | null;
+  readonly ciGate: "passed" | "failed" | "not-applicable" | null;
+  readonly reviewerId: string;
+  readonly evidenceMode: "execution-review" | "commit-anchor";
+  readonly commitRef: string | null;
+  readonly judgment: string | null;
+  readonly approval: TaskCompleteApproval | null;
+  readonly externalCheckpointRefs: ReadonlyArray<TaskCompleteExternalCheckpointRef>;
+  readonly callerIdempotencyKey: string;
+  readonly dryRun: boolean;
+}
 
 export interface AuthorityHostEvidenceInput {
   readonly type: string;
@@ -121,15 +163,8 @@ export type AuthorityHostCommandAction =
   | { readonly kind: "task-code-doc-reconcile"; readonly taskId: string; readonly sha: string; readonly paths: ReadonlyArray<string>; readonly prRef?: string; readonly force: boolean }
   | { readonly kind: "task-consent-record"; readonly taskId: string; readonly executionId: string; readonly utterance?: string; readonly standingPolicyDecisionId?: string; readonly assertedRationale?: string; readonly consentActions: ReadonlyArray<ConsentAction> }
   | { readonly kind: "task-review-execution"; readonly taskId: string; readonly executionId?: string; readonly verdict: ReviewVerdict; readonly findings: string; readonly evidenceChecked: ReadonlyArray<string>; readonly rationale: string; readonly archiveWarningsAcknowledged: boolean; readonly consentId?: string; readonly generatedConsentId?: string; readonly consentUtterance?: string; readonly consentStandingPolicyDecisionId?: string; readonly consentAssertedRationale?: string; readonly consentActions?: ReadonlyArray<ConsentAction> }
-  | {
-      readonly kind: "task-complete";
-      readonly taskId: string;
-      readonly executionId?: string;
+  | TaskCompleteTransitionCommand & {
       readonly completionContractBodySha256?: string | null;
-      readonly evidenceMode?: "execution-review" | "commit-anchor";
-      readonly commitRef?: string;
-      readonly judgment?: string;
-      readonly ciGate?: "passed" | "failed" | "not-applicable";
       readonly completionApplicableGates?: ReadonlyArray<string>;
     }
   | { readonly kind: "task-relate"; readonly sourceTaskId: string; readonly relationType: "depends-on"; readonly targetTaskId: string; readonly rationale: string }
@@ -244,7 +279,7 @@ export interface DaemonCommandHostServices<
   Result extends DaemonHostCommandResult,
   Actor = unknown
 > {
-  readonly parseCommandPayload: (payload: Readonly<Record<string, unknown>> | undefined) => Command;
+  readonly parseCommandPayload: (payload: unknown) => Command;
   readonly normalizeCommand: (command: Command, currentSession: CurrentSessionRef) => Promise<Command>;
   readonly authorityCommand: (command: Command) => AuthorityHostCommand | undefined;
   readonly authorityIngressFor: (kind: string) => AuthorityIngressAdapter | undefined;

--- a/packages/application/src/authority/task-complete-transition-command.ts
+++ b/packages/application/src/authority/task-complete-transition-command.ts
@@ -1,0 +1,205 @@
+import {
+  consentActions as supportedConsentActions,
+  type ConsentAction
+} from "@harness-anything/kernel";
+import type {
+  TaskCompleteApproval,
+  TaskCompleteConsentSource,
+  TaskCompleteExternalCheckpointRef,
+  TaskCompleteTransitionCommand
+} from "./daemon-host-contract.ts";
+
+export class TaskCompleteTransitionCommandDecodeError extends Error {
+  constructor(path: string, expected: string) {
+    super(`TASK_COMPLETE_TRANSITION_COMMAND_INVALID:${path}:${expected}`);
+    this.name = "TaskCompleteTransitionCommandDecodeError";
+  }
+}
+
+export function decodeTaskCompleteTransitionCommand(
+  value: unknown,
+  path = "$.action"
+): TaskCompleteTransitionCommand {
+  const action = taskCompleteRecord(value, path);
+  taskCompleteExactKeys(action, [
+    "kind", "taskId", "executionId", "ciGate", "reviewerId", "evidenceMode",
+    "commitRef", "judgment", "approval", "externalCheckpointRefs",
+    "callerIdempotencyKey", "dryRun"
+  ], path);
+  if (action.kind !== "task-complete") taskCompleteInvalid(`${path}.kind`, "task-complete");
+  const executionId = taskCompleteNullableText(action.executionId, `${path}.executionId`);
+  const ciGate = nullableCiGate(action.ciGate, `${path}.ciGate`);
+  const evidenceMode = completionEvidenceMode(action.evidenceMode, `${path}.evidenceMode`);
+  const commitRef = taskCompleteNullableText(action.commitRef, `${path}.commitRef`);
+  const judgment = taskCompleteNullableText(action.judgment, `${path}.judgment`);
+  const approval = action.approval === null
+    ? null
+    : decodeApproval(action.approval, `${path}.approval`);
+  if (evidenceMode === "commit-anchor") {
+    if (commitRef === null) taskCompleteInvalid(`${path}.commitRef`, "non-empty commit ref for commit-anchor evidence");
+    if (judgment === null) taskCompleteInvalid(`${path}.judgment`, "non-empty judgment for commit-anchor evidence");
+    if (approval !== null) taskCompleteInvalid(`${path}.approval`, "null for commit-anchor evidence");
+  } else if (judgment !== null) {
+    taskCompleteInvalid(`${path}.judgment`, "null for execution-review evidence");
+  }
+  if (approval !== null && approval.executionId !== executionId) {
+    taskCompleteInvalid(`${path}.approval.executionId`, "the same execution id as $.action.executionId");
+  }
+  if (typeof action.dryRun !== "boolean") taskCompleteInvalid(`${path}.dryRun`, "boolean");
+  return {
+    kind: "task-complete",
+    taskId: taskCompleteText(action.taskId, `${path}.taskId`),
+    executionId,
+    ciGate,
+    reviewerId: taskCompleteText(action.reviewerId, `${path}.reviewerId`),
+    evidenceMode,
+    commitRef,
+    judgment,
+    approval,
+    externalCheckpointRefs: checkpointRefs(
+      action.externalCheckpointRefs,
+      `${path}.externalCheckpointRefs`
+    ),
+    callerIdempotencyKey: taskCompleteText(
+      action.callerIdempotencyKey,
+      `${path}.callerIdempotencyKey`
+    ),
+    dryRun: action.dryRun
+  };
+}
+
+function decodeApproval(value: unknown, path: string): TaskCompleteApproval {
+  const approval = taskCompleteRecord(value, path);
+  taskCompleteExactKeys(approval, [
+    "executionId", "findings", "evidenceChecked", "rationale",
+    "archiveWarningsAcknowledged", "consentSource", "consentActions", "paths", "prRef"
+  ], path);
+  if (typeof approval.archiveWarningsAcknowledged !== "boolean") {
+    taskCompleteInvalid(`${path}.archiveWarningsAcknowledged`, "boolean");
+  }
+  const consentSource = decodeConsentSource(approval.consentSource, `${path}.consentSource`);
+  const consentActions = approval.consentActions === null
+    ? null
+    : consentActionList(approval.consentActions, `${path}.consentActions`);
+  if (consentSource.kind === "recorded-consent" && consentActions !== null) {
+    taskCompleteInvalid(`${path}.consentActions`, "null when reusing recorded consent");
+  }
+  if (consentActions !== null && (!consentActions.includes("approve_execution")
+    || !consentActions.includes("complete_task")
+    || new Set(consentActions).size !== consentActions.length)) {
+    taskCompleteInvalid(`${path}.consentActions`, "unique actions including approve_execution and complete_task");
+  }
+  return {
+    executionId: taskCompleteNullableText(approval.executionId, `${path}.executionId`),
+    findings: taskCompleteText(approval.findings, `${path}.findings`),
+    evidenceChecked: stringList(approval.evidenceChecked, `${path}.evidenceChecked`),
+    rationale: taskCompleteText(approval.rationale, `${path}.rationale`),
+    archiveWarningsAcknowledged: approval.archiveWarningsAcknowledged,
+    consentSource,
+    consentActions,
+    paths: stringList(approval.paths, `${path}.paths`),
+    prRef: taskCompleteNullableText(approval.prRef, `${path}.prRef`)
+  };
+}
+
+function decodeConsentSource(value: unknown, path: string): TaskCompleteConsentSource {
+  const source = taskCompleteRecord(value, path);
+  if (source.kind === "recorded-consent") {
+    taskCompleteExactKeys(source, ["kind", "consentId"], path);
+    return { kind: "recorded-consent", consentId: taskCompleteText(source.consentId, `${path}.consentId`) };
+  }
+  if (source.kind === "utterance") {
+    taskCompleteExactKeys(source, ["kind", "utterance"], path);
+    return { kind: "utterance", utterance: taskCompleteText(source.utterance, `${path}.utterance`) };
+  }
+  if (source.kind === "standing-policy") {
+    taskCompleteExactKeys(source, ["kind", "decisionId"], path);
+    return { kind: "standing-policy", decisionId: taskCompleteText(source.decisionId, `${path}.decisionId`) };
+  }
+  if (source.kind === "asserted-rationale") {
+    taskCompleteExactKeys(source, ["kind", "rationale"], path);
+    return { kind: "asserted-rationale", rationale: taskCompleteText(source.rationale, `${path}.rationale`) };
+  }
+  taskCompleteInvalid(`${path}.kind`, "known consent source kind");
+}
+
+function checkpointRefs(value: unknown, path: string): ReadonlyArray<TaskCompleteExternalCheckpointRef> {
+  if (!Array.isArray(value)) taskCompleteInvalid(path, "array");
+  return value.map((entry, index) => {
+    const entryPath = `${path}[${index}]`;
+    const checkpoint = taskCompleteRecord(entry, entryPath);
+    taskCompleteExactKeys(checkpoint, ["kind", "ref"], entryPath);
+    if (checkpoint.kind !== "document-publication"
+      && checkpoint.kind !== "code-doc-reconciliation") {
+      taskCompleteInvalid(`${entryPath}.kind`, "known external checkpoint kind");
+    }
+    return {
+      kind: checkpoint.kind,
+      ref: taskCompleteText(checkpoint.ref, `${entryPath}.ref`)
+    };
+  });
+}
+
+function consentActionList(value: unknown, path: string): ReadonlyArray<ConsentAction> {
+  const actions = stringList(value, path);
+  if (actions.some((action) => !(supportedConsentActions as ReadonlyArray<string>).includes(action))) {
+    taskCompleteInvalid(path, `only ${supportedConsentActions.join(", ")}`);
+  }
+  return actions as ReadonlyArray<ConsentAction>;
+}
+
+function stringList(value: unknown, path: string): ReadonlyArray<string> {
+  if (!Array.isArray(value)) taskCompleteInvalid(path, "array of non-empty strings");
+  return value.map((entry, index) => taskCompleteText(entry, `${path}[${index}]`));
+}
+
+function nullableCiGate(
+  value: unknown,
+  path: string
+): TaskCompleteTransitionCommand["ciGate"] {
+  if (value === null) return null;
+  if (value !== "passed" && value !== "failed" && value !== "not-applicable") {
+    taskCompleteInvalid(path, "passed, failed, not-applicable, or null");
+  }
+  return value;
+}
+
+function completionEvidenceMode(
+  value: unknown,
+  path: string
+): TaskCompleteTransitionCommand["evidenceMode"] {
+  if (value !== "execution-review" && value !== "commit-anchor") {
+    taskCompleteInvalid(path, "execution-review or commit-anchor");
+  }
+  return value;
+}
+
+function taskCompleteNullableText(value: unknown, path: string): string | null {
+  return value === null ? null : taskCompleteText(value, path);
+}
+
+function taskCompleteText(value: unknown, path: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) taskCompleteInvalid(path, "non-empty string");
+  return value;
+}
+
+function taskCompleteRecord(value: unknown, path: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    taskCompleteInvalid(path, "plain object");
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) taskCompleteInvalid(path, "plain object");
+  return value as Record<string, unknown>;
+}
+
+function taskCompleteExactKeys(recordValue: Record<string, unknown>, required: ReadonlyArray<string>, path: string): void {
+  const actual = Object.keys(recordValue);
+  const unknown = actual.find((key) => !required.includes(key));
+  if (unknown) taskCompleteInvalid(`${path}.${unknown}`, "no unknown fields");
+  const missing = required.find((key) => !Object.hasOwn(recordValue, key));
+  if (missing) taskCompleteInvalid(`${path}.${missing}`, "required field");
+}
+
+function taskCompleteInvalid(path: string, expected: string): never {
+  throw new TaskCompleteTransitionCommandDecodeError(path, expected);
+}

--- a/packages/cli/src/cli/command-input-descriptors.ts
+++ b/packages/cli/src/cli/command-input-descriptors.ts
@@ -167,6 +167,14 @@ const explicitInputDescriptors = {
       commit: { type: "string", description: "Workspace Git ref; defaults to HEAD." },
       paths: { type: "array", description: "Optional repository-relative code-doc anchors.", items: { type: "string" } },
       prRef: { type: "string", description: "Optional pull request reference." },
+      externalCheckpointRefs: {
+        type: "array",
+        description: "Optional immutable document-publication or code-doc checkpoint references.",
+        items: { type: "object", properties: {
+          kind: { type: "string" },
+          ref: { type: "string" }
+        } }
+      },
       reviewerId: { type: "string", description: "Completion reviewer id." }
     },
     shortcuts: [

--- a/packages/cli/src/cli/parsers/core-task-complete.ts
+++ b/packages/cli/src/cli/parsers/core-task-complete.ts
@@ -1,8 +1,12 @@
-import { consentActions as validConsentActions, type ConsentAction } from "@harness-anything/kernel";
+import type { TaskCompleteExternalCheckpointRef } from "@harness-anything/application";
+import {
+  consentActions as validConsentActions,
+  type ConsentAction
+} from "@harness-anything/kernel";
 import { cliError, CliErrorCode } from "../error-codes.ts";
 import type { CommandJsonInput } from "../json-input.ts";
 import { readOption } from "../parse-options.ts";
-import type { CliResult, ParsedCommand } from "../types.ts";
+import type { CliResult, CliTaskCompleteAction, ParsedCommand } from "../types.ts";
 import { jsonPayloadFor } from "./json-values.ts";
 
 type ParseResult = { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] };
@@ -47,6 +51,8 @@ export function parseTaskComplete(
   const executionId = readOption(args, "--execution-id") ?? taskCompleteOptionalText(payload.executionId);
   const commitRef = readOption(args, "--commit") ?? taskCompleteOptionalText(payload.commit) ?? "HEAD";
   const reviewerId = readOption(args, "--reviewer") ?? taskCompleteOptionalText(payload.reviewerId) ?? "local-reviewer";
+  const externalCheckpointRefs = parseExternalCheckpointRefs(payload.externalCheckpointRefs);
+  if (!externalCheckpointRefs.ok) return externalCheckpointRefs;
   return {
     ok: true,
     value: {
@@ -69,6 +75,9 @@ export function parseTaskComplete(
           paths: taskCompleteStringList(payload.paths),
           ...(typeof payload.prRef === "string" ? { prRef: payload.prRef } : {})
         },
+        ...(externalCheckpointRefs.value.length > 0
+          ? { externalCheckpointRefs: externalCheckpointRefs.value }
+          : {}),
         dryRun: args.includes("--dry-run")
       }
     }
@@ -138,7 +147,7 @@ function parseCommitAnchorApproval(
 }
 
 function parseTaskCompleteConsent(payload: Readonly<Record<string, unknown>>):
-  | { readonly ok: true; readonly value: Pick<NonNullable<Extract<ParsedCommand["action"], { readonly kind: "task-complete" }>["approval"]>, "consentId" | "consentUtterance" | "consentStandingPolicyDecisionId" | "consentAssertedRationale" | "consentActions"> }
+  | { readonly ok: true; readonly value: Pick<NonNullable<CliTaskCompleteAction["approval"]>, "consentId" | "consentUtterance" | "consentStandingPolicyDecisionId" | "consentAssertedRationale" | "consentActions"> }
   | { readonly ok: false; readonly error: CliResult["error"] } {
   const consentId = taskCompleteOptionalText(payload.consentId);
   const consentUtterance = taskCompleteOptionalText(payload.consentUtterance);
@@ -166,6 +175,31 @@ function parseTaskCompleteConsent(payload: Readonly<Record<string, unknown>>):
     ...(consentAssertedRationale ? { consentAssertedRationale } : {}),
     ...(consentActions ? { consentActions } : {})
   } };
+}
+
+function parseExternalCheckpointRefs(value: unknown):
+  | { readonly ok: true; readonly value: ReadonlyArray<TaskCompleteExternalCheckpointRef> }
+  | { readonly ok: false; readonly error: CliResult["error"] } {
+  if (value === undefined) return { ok: true, value: [] };
+  if (!Array.isArray(value)) return taskCompleteFailure("Approval field externalCheckpointRefs must be an array.");
+  const refs: TaskCompleteExternalCheckpointRef[] = [];
+  for (const [index, entry] of value.entries()) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return taskCompleteFailure(`Approval field externalCheckpointRefs[${index}] must be an object.`);
+    }
+    const record = entry as Record<string, unknown>;
+    const keys = Object.keys(record);
+    if (keys.length !== 2 || !keys.includes("kind") || !keys.includes("ref")) {
+      return taskCompleteFailure(`Approval field externalCheckpointRefs[${index}] must contain exactly kind and ref.`);
+    }
+    if (record.kind !== "document-publication" && record.kind !== "code-doc-reconciliation") {
+      return taskCompleteFailure(`Approval field externalCheckpointRefs[${index}].kind is not supported.`);
+    }
+    const ref = taskCompleteOptionalText(record.ref);
+    if (!ref) return taskCompleteFailure(`Approval field externalCheckpointRefs[${index}].ref must be a non-empty string.`);
+    refs.push({ kind: record.kind, ref });
+  }
+  return { ok: true, value: refs };
 }
 
 function requiredText(value: unknown, label: string): { readonly ok: true; readonly value: string } | { readonly ok: false; readonly error: CliResult["error"] } {

--- a/packages/cli/src/cli/task-complete-transition-command.ts
+++ b/packages/cli/src/cli/task-complete-transition-command.ts
@@ -1,0 +1,123 @@
+import { createHash } from "node:crypto";
+import {
+  decodeTaskCompleteTransitionCommand,
+  type TaskCompleteApproval,
+  type TaskCompleteConsentSource,
+  type TaskCompleteTransitionCommand
+} from "@harness-anything/application";
+import { stableStringify } from "@harness-anything/kernel";
+import type { CliTaskCompleteAction } from "./types.ts";
+
+export function makeTaskCompleteTransitionCommand(
+  command: Omit<TaskCompleteTransitionCommand, "callerIdempotencyKey">,
+  providedKey?: string
+): TaskCompleteTransitionCommand {
+  return decodeTaskCompleteTransitionCommand({
+    ...command,
+    callerIdempotencyKey: providedKey ?? `task-complete-${createHash("sha256")
+      .update(stableStringify(command))
+      .digest("hex")}`
+  });
+}
+
+/** Project the CLI grammar shape into the exact daemon-host command contract. */
+export function taskCompleteTransitionCommandFromCliAction(
+  value: unknown
+): TaskCompleteTransitionCommand {
+  const action = cliTaskCompleteRecord(value, "$.action");
+  if (isTypedTransitionShape(action)) return decodeTaskCompleteTransitionCommand(action);
+  cliTaskCompleteExactKeys(action, [
+    "kind", "taskId", "reviewerId", "evidenceMode"
+  ], [
+    "executionId", "ciGate", "commitRef", "judgment", "approval",
+    "externalCheckpointRefs", "dryRun"
+  ], "$.action");
+  if (action.kind !== "task-complete") cliTaskCompleteInvalid("$.action.kind", "task-complete");
+  const cliAction = action as unknown as CliTaskCompleteAction;
+  const executionId = cliAction.approval?.executionId ?? cliAction.executionId ?? null;
+  return makeTaskCompleteTransitionCommand({
+    kind: "task-complete",
+    taskId: cliAction.taskId,
+    executionId,
+    ciGate: cliAction.ciGate ?? null,
+    reviewerId: cliAction.reviewerId,
+    evidenceMode: cliAction.evidenceMode,
+    commitRef: cliAction.commitRef ?? null,
+    judgment: cliAction.judgment ?? null,
+    approval: cliAction.approval
+      ? approvalFromCli(cliAction.approval, executionId)
+      : null,
+    externalCheckpointRefs: cliAction.externalCheckpointRefs ?? [],
+    dryRun: cliAction.dryRun === true
+  });
+}
+
+function approvalFromCli(
+  value: NonNullable<CliTaskCompleteAction["approval"]>,
+  executionId: string | null
+): TaskCompleteApproval {
+  const approval = cliTaskCompleteRecord(value, "$.action.approval");
+  cliTaskCompleteExactKeys(approval, [
+    "findings", "evidenceChecked", "rationale", "archiveWarningsAcknowledged", "paths"
+  ], [
+    "executionId", "consentId", "consentUtterance", "consentStandingPolicyDecisionId",
+    "consentAssertedRationale", "consentActions", "prRef"
+  ], "$.action.approval");
+  return {
+    executionId,
+    findings: value.findings,
+    evidenceChecked: value.evidenceChecked,
+    rationale: value.rationale,
+    archiveWarningsAcknowledged: value.archiveWarningsAcknowledged,
+    consentSource: consentSourceFromCli(value),
+    consentActions: value.consentActions ?? null,
+    paths: value.paths,
+    prRef: value.prRef ?? null
+  };
+}
+
+function consentSourceFromCli(
+  approval: NonNullable<CliTaskCompleteAction["approval"]>
+): TaskCompleteConsentSource {
+  const sources = [
+    approval.consentId,
+    approval.consentUtterance,
+    approval.consentStandingPolicyDecisionId,
+    approval.consentAssertedRationale
+  ].filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0);
+  if (sources.length !== 1) cliTaskCompleteInvalid("$.action.approval", "exactly one consent source");
+  if (approval.consentId) return { kind: "recorded-consent", consentId: approval.consentId };
+  if (approval.consentUtterance) return { kind: "utterance", utterance: approval.consentUtterance };
+  if (approval.consentStandingPolicyDecisionId) {
+    return { kind: "standing-policy", decisionId: approval.consentStandingPolicyDecisionId };
+  }
+  return { kind: "asserted-rationale", rationale: approval.consentAssertedRationale! };
+}
+
+function isTypedTransitionShape(action: Record<string, unknown>): boolean {
+  return action.approval === null
+    || (typeof action.approval === "object" && action.approval !== null
+      && Object.hasOwn(action.approval, "consentSource"));
+}
+
+function cliTaskCompleteRecord(value: unknown, path: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) cliTaskCompleteInvalid(path, "plain object");
+  return value as Record<string, unknown>;
+}
+
+function cliTaskCompleteExactKeys(
+  value: Record<string, unknown>,
+  required: ReadonlyArray<string>,
+  optional: ReadonlyArray<string>,
+  path: string
+): void {
+  const allowed = new Set([...required, ...optional]);
+  const unknown = Object.keys(value).find((key) => !allowed.has(key));
+  if (unknown) cliTaskCompleteInvalid(`${path}.${unknown}`, "no unknown fields");
+  const missing = required.find((key) => !Object.hasOwn(value, key));
+  if (missing) cliTaskCompleteInvalid(`${path}.${missing}`, "required field");
+}
+
+function cliTaskCompleteInvalid(path: string, expected: string): never {
+  throw new Error(`TASK_COMPLETE_TRANSITION_COMMAND_INVALID:${path}:${expected}`);
+}

--- a/packages/cli/src/cli/task-packet-templates.ts
+++ b/packages/cli/src/cli/task-packet-templates.ts
@@ -26,6 +26,7 @@ const taskPacketTemplates: Readonly<Record<string, TaskPacketTemplate>> = {
       consentActions: ["approve_execution", "complete_task"],
       ci: "passed",
       paths: [],
+      externalCheckpointRefs: [],
       reviewerId: "local-reviewer"
     }
   }

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -16,6 +16,7 @@ import type {
 import type { DecisionAmendField, DecisionAmendOperation } from "@harness-anything/kernel";
 import type { DecisionClaimFulfillment } from "@harness-anything/kernel";
 import type { HarnessLayoutOverrides } from "@harness-anything/kernel";
+import type { TaskCompleteTransitionCommand } from "@harness-anything/application";
 import type { CliError } from "./error-codes.ts";
 import type { CommandDisplayTier } from "./command-spec/types.ts";
 
@@ -242,7 +243,8 @@ export interface ParsedCommand {
     | { readonly kind: "task-review"; readonly taskId: string; readonly reviewerId: string }
     | { readonly kind: "task-consent-record"; readonly taskId: string; readonly executionId: string; readonly utterance?: string; readonly standingPolicyDecisionId?: string; readonly assertedRationale?: string; readonly consentActions: ReadonlyArray<ConsentAction> }
     | { readonly kind: "task-review-execution"; readonly taskId: string; readonly executionId?: string; readonly executionSelectionError?: string; readonly verdict: ReviewVerdict; readonly findings: string; readonly evidenceChecked: ReadonlyArray<string>; readonly rationale: string; readonly archiveWarningsAcknowledged: boolean; readonly consentId?: string; readonly generatedConsentId?: string; readonly consentUtterance?: string; readonly consentStandingPolicyDecisionId?: string; readonly consentAssertedRationale?: string; readonly consentActions?: ReadonlyArray<ConsentAction> }
-    | { readonly kind: "task-complete"; readonly taskId: string; readonly executionId?: string; readonly ciGate?: "passed" | "failed" | "not-applicable"; readonly reviewerId: string; readonly evidenceMode: "execution-review" | "commit-anchor"; readonly commitRef?: string; readonly judgment?: string; readonly approval?: { readonly executionId?: string; readonly findings: string; readonly evidenceChecked: ReadonlyArray<string>; readonly rationale: string; readonly archiveWarningsAcknowledged: boolean; readonly consentId?: string; readonly consentUtterance?: string; readonly consentStandingPolicyDecisionId?: string; readonly consentAssertedRationale?: string; readonly consentActions?: ReadonlyArray<ConsentAction>; readonly paths: ReadonlyArray<string>; readonly prRef?: string }; readonly dryRun?: boolean }
+    | { readonly kind: "task-complete"; readonly taskId: string; readonly executionId?: string; readonly ciGate?: "passed" | "failed" | "not-applicable"; readonly reviewerId: string; readonly evidenceMode: "execution-review" | "commit-anchor"; readonly commitRef?: string; readonly judgment?: string; readonly approval?: { readonly executionId?: string; readonly findings: string; readonly evidenceChecked: ReadonlyArray<string>; readonly rationale: string; readonly archiveWarningsAcknowledged: boolean; readonly consentId?: string; readonly consentUtterance?: string; readonly consentStandingPolicyDecisionId?: string; readonly consentAssertedRationale?: string; readonly consentActions?: ReadonlyArray<ConsentAction>; readonly paths: ReadonlyArray<string>; readonly prRef?: string }; readonly externalCheckpointRefs?: ReadonlyArray<import("@harness-anything/application").TaskCompleteExternalCheckpointRef>; readonly dryRun?: boolean }
+    | TaskCompleteTransitionCommand
     | { readonly kind: "task-show"; readonly taskId: string; readonly view: "summary" | "trace" | "tree" }
     | { readonly kind: "session-show"; readonly sessionId: string; readonly view: "summary" | "trace" }
     | { readonly kind: "execution-show"; readonly executionId: string }
@@ -340,3 +342,8 @@ export interface ParsedCommand {
     | { readonly kind: "module-step"; readonly moduleKey: string; readonly stepId: string; readonly state: "planned" | "in-progress" | "blocked" | "done" }
     | { readonly kind: "vertical-validate"; readonly definitionPath?: string };
 }
+
+export type CliTaskCompleteAction = Exclude<
+  Extract<ParsedCommand["action"], { readonly kind: "task-complete" }>,
+  TaskCompleteTransitionCommand
+>;

--- a/packages/cli/src/commands/core/task-complete-facade-steps.ts
+++ b/packages/cli/src/commands/core/task-complete-facade-steps.ts
@@ -10,13 +10,10 @@ import {
   type ExecutionRecord
 } from "@harness-anything/kernel";
 import { normalizeReviewExecutionSelection } from "../../cli/review-execution-normalizer.ts";
-import type { ParsedCommand } from "../../cli/types.ts";
+import type { CliTaskCompleteAction, ParsedCommand } from "../../cli/types.ts";
 
 export type TaskCompleteCommand = ParsedCommand & {
-  readonly action: Extract<
-    ParsedCommand["action"],
-    { readonly kind: "task-complete" }
-  >;
+  readonly action: CliTaskCompleteAction;
 };
 
 export async function taskCompleteCodeDocAlreadyCurrent(

--- a/packages/cli/src/commands/core/task-gates.ts
+++ b/packages/cli/src/commands/core/task-gates.ts
@@ -54,13 +54,13 @@ export const runTaskGatesCommand: CommandRunner = (context, command) => {
   }
   const complete = () => context.currentSessionProbe.currentSession.pipe(Effect.flatMap((session) => orchestrator.completeTask({
     taskId: action.taskId,
-    executionId: action.executionId,
+    executionId: action.executionId ?? undefined,
     reviewerId: action.reviewerId,
-    ciGate: action.ciGate,
+    ciGate: action.ciGate ?? undefined,
     actor: context.taskHolderPrincipal(),
     evidenceMode: action.evidenceMode,
-    commitRef: action.commitRef,
-    judgment: action.judgment,
+    commitRef: action.commitRef ?? undefined,
+    judgment: action.judgment ?? undefined,
     sessionRef: `session/${session.sessionId}`,
     preflight: action.dryRun === true
   })),

--- a/packages/cli/src/commands/core/task-lifecycle-facade-guidance.ts
+++ b/packages/cli/src/commands/core/task-lifecycle-facade-guidance.ts
@@ -154,7 +154,7 @@ function renderLifecycleStep(command: ParsedCommand): string {
   if (action.kind === "task-code-doc-reconcile") {
     return joinLifecycleCommand("ha", "task", "code-doc", "reconcile", action.taskId, "--commit", action.sha, ...repeatLifecycleFlag("--path", action.paths), action.prRef && "--pr", action.prRef, action.force && "--force");
   }
-  if (action.kind === "task-complete") return joinLifecycleCommand("ha", "task", "complete", action.taskId, "--ci", action.ciGate, "--reviewer", action.reviewerId);
+  if (action.kind === "task-complete") return joinLifecycleCommand("ha", "task", "complete", action.taskId, "--ci", action.ciGate ?? undefined, "--reviewer", action.reviewerId);
   return `ha ${action.kind}`;
 }
 

--- a/packages/cli/src/composition/daemon-command-host-services.ts
+++ b/packages/cli/src/composition/daemon-command-host-services.ts
@@ -15,6 +15,7 @@ import { productionAuthorityIngressFor } from "../cli/command-spec/index.ts";
 import { displayCommand, toCommandReceipt } from "../cli/receipt.ts";
 import { receiptCommandKind } from "../cli/receipt-command-kind.ts";
 import type { CliResult, ParsedCommand } from "../cli/types.ts";
+import { taskCompleteTransitionCommandFromCliAction } from "../cli/task-complete-transition-command.ts";
 import { isPlainRecord } from "../cli/value-utils.ts";
 import { materializerCommandResult } from "../commands/core/materializer.ts";
 import {
@@ -35,12 +36,17 @@ const cliProductionCommandsSatisfyAuthorityHostContract = true satisfies
 void cliProductionCommandsSatisfyAuthorityHostContract;
 
 export const cliDaemonCommandHostServices = {
-  parseCommandPayload: (payload) => {
-    const command = payload?.command;
+  parseCommandPayload: (payload: unknown) => {
+    const command = isPlainRecord(payload) ? payload.command : undefined;
     if (!isPlainRecord(command) || typeof command.rootDir !== "string" || !isPlainRecord(command.action) || typeof command.action.kind !== "string") {
       throw new Error("command.run requires payload.command parsed by the CLI parser.");
     }
-    return command as unknown as ParsedCommand;
+    return {
+      ...command,
+      action: command.action.kind === "task-complete"
+        ? taskCompleteTransitionCommandFromCliAction(command.action)
+        : command.action
+    } as unknown as ParsedCommand;
   },
   normalizeCommand: (command, currentSession) => normalizeCommandSemantics(
     command,

--- a/packages/cli/src/composition/production-authority-host-services.ts
+++ b/packages/cli/src/composition/production-authority-host-services.ts
@@ -1,6 +1,7 @@
 import type {
   ProductionAuthorityCommandAction,
-  ProductionAuthorityHostServices
+  ProductionAuthorityHostServices,
+  TaskCompleteTransitionCommand
 } from "@harness-anything/application";
 import { normalizeDecisionProposeAction } from "../cli/decision-propose-normalizer.ts";
 import { normalizedFactSource } from "../cli/command-semantic-normalizer.ts";
@@ -34,9 +35,17 @@ type CliProductionAuthorityAction = Extract<
   { readonly kind: ProductionAuthorityCommandAction["kind"] }
 >;
 
+type CliProductionAuthorityActionWithoutComplete = Exclude<
+  CliProductionAuthorityAction,
+  { readonly kind: "task-complete" }
+>;
+
 const cliProductionActionsSatisfyHostContract = true satisfies
-  CliProductionAuthorityAction extends ProductionAuthorityCommandAction ? true : never;
+  CliProductionAuthorityActionWithoutComplete extends ProductionAuthorityCommandAction ? true : never;
 void cliProductionActionsSatisfyHostContract;
+const projectedCompleteActionSatisfiesHostContract = true satisfies
+  TaskCompleteTransitionCommand extends ProductionAuthorityCommandAction ? true : never;
+void projectedCompleteActionSatisfiesHostContract;
 
 export const productionAuthorityHostServices = {
   productionAuthorityIngressFor,

--- a/packages/cli/test/task-complete-transition-command.test.ts
+++ b/packages/cli/test/task-complete-transition-command.test.ts
@@ -1,0 +1,114 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseTaskComplete } from "../src/cli/parsers/core-task-complete.ts";
+import { taskCompleteTransitionCommandFromCliAction } from "../src/cli/task-complete-transition-command.ts";
+import { cliDaemonCommandHostServices } from "../src/composition/daemon-command-host-services.ts";
+
+test("CLI complete intent is field-equal after daemon host strict decoding", () => {
+  const parsed = parseTaskComplete(
+    ["task-complete", "task_TYPED", "--approve", "--ci", "passed"],
+    "/repo",
+    true,
+    {
+      commandKind: "task-complete",
+      payload: {
+        executionId: "exe_TYPED",
+        reviewerId: "reviewer_TYPED",
+        findings: "The execution evidence is complete.",
+        evidenceChecked: ["artifact:report", "test:local-gate"],
+        rationale: "The reviewed execution satisfies the completion contract.",
+        archiveWarningsAcknowledged: true,
+        consentStandingPolicyDecisionId: "dec_TYPED",
+        consentActions: ["approve_execution", "complete_task"],
+        paths: ["packages/application/src/authority/daemon-host-contract.ts"],
+        prRef: "#typed",
+        externalCheckpointRefs: [
+          { kind: "document-publication", ref: "sha256:document-checkpoint" },
+          { kind: "code-doc-reconciliation", ref: "sha256:code-doc-checkpoint" }
+        ]
+      }
+    }
+  );
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+
+  const constructed = taskCompleteTransitionCommandFromCliAction(parsed.value.action);
+  const transported = JSON.parse(JSON.stringify(parsed.value)) as Record<string, unknown>;
+  const decoded = cliDaemonCommandHostServices.parseCommandPayload({ command: transported });
+  assert.deepEqual(decoded.action, constructed);
+  assert.deepEqual(decoded.action, {
+    kind: "task-complete",
+    taskId: "task_TYPED",
+    executionId: "exe_TYPED",
+    ciGate: "passed",
+    reviewerId: "reviewer_TYPED",
+    evidenceMode: "execution-review",
+    commitRef: "HEAD",
+    judgment: null,
+    approval: {
+      executionId: "exe_TYPED",
+      findings: "The execution evidence is complete.",
+      evidenceChecked: ["artifact:report", "test:local-gate"],
+      rationale: "The reviewed execution satisfies the completion contract.",
+      archiveWarningsAcknowledged: true,
+      consentSource: { kind: "standing-policy", decisionId: "dec_TYPED" },
+      consentActions: ["approve_execution", "complete_task"],
+      paths: ["packages/application/src/authority/daemon-host-contract.ts"],
+      prRef: "#typed"
+    },
+    externalCheckpointRefs: [
+      { kind: "document-publication", ref: "sha256:document-checkpoint" },
+      { kind: "code-doc-reconciliation", ref: "sha256:code-doc-checkpoint" }
+    ],
+    callerIdempotencyKey: constructed.callerIdempotencyKey,
+    dryRun: false
+  });
+});
+
+test("daemon host rejects unknown and missing complete-intent fields", () => {
+  const action = completeAction();
+  assert.throws(
+    () => cliDaemonCommandHostServices.parseCommandPayload({
+      command: { rootDir: "/repo", json: true, action: { ...action, silentlyDropped: true } }
+    }),
+    /TASK_COMPLETE_TRANSITION_COMMAND_INVALID:\$\.action\.silentlyDropped:no unknown fields/u
+  );
+  const { callerIdempotencyKey: _missing, ...withoutIdempotencyKey } = action;
+  assert.throws(
+    () => cliDaemonCommandHostServices.parseCommandPayload({
+      command: { rootDir: "/repo", json: true, action: withoutIdempotencyKey }
+    }),
+    /TASK_COMPLETE_TRANSITION_COMMAND_INVALID:\$\.action\.callerIdempotencyKey:required field/u
+  );
+});
+
+test("CLI derives the same load-bearing idempotency key for the same intent", () => {
+  const first = parseTaskComplete(["task-complete", "task_RETRY", "--ci", "passed"], "/repo", true);
+  const replay = parseTaskComplete(["task-complete", "task_RETRY", "--ci", "passed"], "/repo", true);
+  assert.equal(first.ok, true);
+  assert.equal(replay.ok, true);
+  if (!first.ok || !replay.ok || first.value.action.kind !== "task-complete"
+    || replay.value.action.kind !== "task-complete") return;
+  const firstCommand = taskCompleteTransitionCommandFromCliAction(first.value.action);
+  const replayCommand = taskCompleteTransitionCommandFromCliAction(replay.value.action);
+  assert.match(firstCommand.callerIdempotencyKey, /^task-complete-[a-f0-9]{64}$/u);
+  assert.equal(replayCommand.callerIdempotencyKey, firstCommand.callerIdempotencyKey);
+});
+
+function completeAction() {
+  return {
+    kind: "task-complete" as const,
+    taskId: "task_STRICT",
+    executionId: null,
+    ciGate: "passed" as const,
+    reviewerId: "reviewer_STRICT",
+    evidenceMode: "execution-review" as const,
+    commitRef: null,
+    judgment: null,
+    approval: null,
+    externalCheckpointRefs: [],
+    callerIdempotencyKey: "caller-strict-key",
+    dryRun: false
+  };
+}

--- a/packages/daemon/src/authority/production/production-authority-lifecycle-intents.ts
+++ b/packages/daemon/src/authority/production/production-authority-lifecycle-intents.ts
@@ -417,7 +417,7 @@ function taskCompletionIntent(
   const status = /^  status:\s*(\S+)$/mu.exec(taskSnapshot.body)?.[1] ?? "unknown";
   const evaluation = evaluateTaskCompletionAuthority({
     taskId,
-    executionId: action.executionId,
+    executionId: action.executionId ?? undefined,
     mode: action.evidenceMode ?? "execution-review",
     status,
     documents,
@@ -425,9 +425,9 @@ function taskCompletionIntent(
     sessionRef: `session/${sessionId}`,
     judgedAt: completedAt,
     applicableGates: completionApplicableGates(action),
-    ciGate: action.ciGate,
-    commitRef: action.commitRef,
-    judgment: action.judgment,
+    ciGate: action.ciGate ?? undefined,
+    commitRef: action.commitRef ?? undefined,
+    judgment: action.judgment ?? undefined,
     rootDir,
     versionControlSystem: makeLocalVersionControlSystem()
   });

--- a/packages/daemon/src/runtime/durable-repo-write-outcome-store.ts
+++ b/packages/daemon/src/runtime/durable-repo-write-outcome-store.ts
@@ -33,6 +33,7 @@ import {
   type RepoWriteHistoricalRecoveryRejectionV1,
   type RepoWriteHistoricalRecoveryRejectInputV1
 } from "./repo-write-historical-recovery-rejection.ts";
+import { repoWriteLegacyCommandName } from "./repo-write-protocol.ts";
 import {
   RepoWriteOutcomeConflictError,
   RepoWriteOutcomeCorruptionError,
@@ -113,7 +114,7 @@ export class DurableRepoWriteOutcomeStoreV1 {
         outerOpId: "store-axis-check",
         innerOpId: "store-axis-check",
         authoritySemanticDigest: "0".repeat(64),
-        canonicalCommand: { commandName: "store.axis.check", actor: {}, context: {}, payload: {} },
+        canonicalCommand: { commandName: repoWriteLegacyCommandName("store.axis.check"), actor: {}, context: {}, payload: {} },
         authenticatedContext: { actor: {} },
         receiptSeed: repoWriteOutcomePlaceholderReceiptSeed(),
         recoveryContext: {}
@@ -449,7 +450,7 @@ function repoWriteOutcomePaths(directory: string, outerOpId: string): {
     outerOpId,
     innerOpId: "path-check",
     authoritySemanticDigest: "0".repeat(64),
-    canonicalCommand: { commandName: "path.check", actor: {}, context: {}, payload: {} },
+    canonicalCommand: { commandName: repoWriteLegacyCommandName("path.check"), actor: {}, context: {}, payload: {} },
     authenticatedContext: { actor: {} },
     receiptSeed: repoWriteOutcomePlaceholderReceiptSeed(),
     recoveryContext: {}

--- a/packages/daemon/src/runtime/repo-write-command-dto.ts
+++ b/packages/daemon/src/runtime/repo-write-command-dto.ts
@@ -1,0 +1,223 @@
+import {
+  decodeTaskCompleteTransitionCommand,
+  type TaskCompleteTransitionCommand
+} from "@harness-anything/application";
+import type { RepoWriteJsonObject } from "./repo-write-protocol.ts";
+
+declare const repoWriteLegacyCommandNameBrand: unique symbol;
+export type RepoWriteLegacyCommandName = string & {
+  readonly [repoWriteLegacyCommandNameBrand]: "not-task-complete";
+};
+
+export interface RepoWriteLegacyCommandDto {
+  readonly commandName: RepoWriteLegacyCommandName;
+  readonly actor: RepoWriteJsonObject;
+  readonly context: RepoWriteJsonObject;
+  readonly payload: RepoWriteJsonObject;
+}
+
+export interface RepoWriteTaskCompleteWireCommand {
+  readonly rootDir: string;
+  readonly rootResolutionSource?: "explicit-override" | "local-cwd";
+  readonly layoutOverrides?: RepoWriteJsonObject;
+  readonly daemonRepoId?: string;
+  readonly actor?: string;
+  readonly daemonModeOverride?: "direct" | "local" | "remote";
+  readonly daemonProfileOverride?: "default" | "isolated";
+  readonly json: boolean;
+  readonly deprecatedInvocation?: RepoWriteJsonObject;
+  readonly action: TaskCompleteTransitionCommand;
+}
+
+export interface RepoWriteTaskCompleteWireSession {
+  readonly runtime: "human" | "claude-code" | "codex" | "zcode" | "antigravity";
+  readonly sessionId: string;
+  readonly source: "runtime" | "manual";
+  readonly detectedAt: string;
+  readonly user?: string;
+}
+
+export interface RepoWriteTaskCompleteCommandPayload {
+  readonly command: RepoWriteTaskCompleteWireCommand;
+  readonly session: RepoWriteTaskCompleteWireSession;
+}
+
+export interface RepoWriteTaskCompleteCommandDto {
+  readonly commandName: "task-complete";
+  readonly actor: RepoWriteJsonObject;
+  readonly context: RepoWriteJsonObject;
+  readonly payload: RepoWriteTaskCompleteCommandPayload;
+}
+
+export type RepoWriteCommandDto =
+  | RepoWriteLegacyCommandDto
+  | RepoWriteTaskCompleteCommandDto;
+
+type Invalid = (path: string, expected: string) => never;
+
+export function repoWriteLegacyCommandName(value: string): RepoWriteLegacyCommandName {
+  if (value === "task-complete") {
+    throw new Error("REPO_WRITE_TASK_COMPLETE_TYPED_COMMAND_REQUIRED");
+  }
+  return value as RepoWriteLegacyCommandName;
+}
+
+export function repoWriteCommandDtoFromDecodedFields(input: {
+  readonly commandName: string;
+  readonly actor: RepoWriteJsonObject;
+  readonly context: RepoWriteJsonObject;
+  readonly payload: RepoWriteJsonObject;
+}, path = "$.command", invalid: Invalid = commandInvalid): RepoWriteCommandDto {
+  if (input.commandName !== "task-complete") {
+    return { ...input, commandName: repoWriteLegacyCommandName(input.commandName) };
+  }
+  return {
+    ...input,
+    commandName: "task-complete",
+    payload: decodeTaskCompleteCommandPayload(input.payload, `${path}.payload`, invalid)
+  };
+}
+
+function decodeTaskCompleteCommandPayload(
+  payload: RepoWriteJsonObject,
+  path: string,
+  invalid: Invalid
+): RepoWriteTaskCompleteCommandPayload {
+  const payloadKeys = Object.keys(payload);
+  if (payloadKeys.length !== 2 || !payloadKeys.includes("command") || !payloadKeys.includes("session")) {
+    invalid(path, "typed task-complete payload with required command/session and no unknown keys");
+  }
+  const command = taskCompleteWireRecord(payload.command, `${path}.command`, invalid);
+  taskCompleteWireExactKeys(command, ["rootDir", "json", "action"], [
+    "rootResolutionSource", "layoutOverrides", "daemonRepoId", "actor",
+    "daemonModeOverride", "daemonProfileOverride", "deprecatedInvocation"
+  ], `${path}.command`, invalid);
+  const action = decodeTaskCompleteTransitionCommand(
+    command.action,
+    `${path}.command.action`
+  );
+  const session = taskCompleteWireRecord(payload.session, `${path}.session`, invalid);
+  taskCompleteWireExactKeys(
+    session,
+    ["runtime", "sessionId", "source", "detectedAt"],
+    ["user"],
+    `${path}.session`,
+    invalid
+  );
+  if (typeof command.rootDir !== "string" || !command.rootDir.trim()) {
+    invalid(`${path}.command.rootDir`, "non-empty string");
+  }
+  if (typeof command.json !== "boolean") invalid(`${path}.command.json`, "boolean");
+  const rootResolutionSource = optionalEnum(
+    command.rootResolutionSource,
+    ["explicit-override", "local-cwd"],
+    `${path}.command.rootResolutionSource`,
+    invalid
+  );
+  const daemonModeOverride = optionalEnum(
+    command.daemonModeOverride,
+    ["direct", "local", "remote"],
+    `${path}.command.daemonModeOverride`,
+    invalid
+  );
+  const daemonProfileOverride = optionalEnum(
+    command.daemonProfileOverride,
+    ["default", "isolated"],
+    `${path}.command.daemonProfileOverride`,
+    invalid
+  );
+  const runtime = requiredEnum(
+    session.runtime,
+    ["human", "claude-code", "codex", "zcode", "antigravity"],
+    `${path}.session.runtime`,
+    invalid
+  );
+  const source = requiredEnum(
+    session.source,
+    ["runtime", "manual"],
+    `${path}.session.source`,
+    invalid
+  );
+  return {
+    command: {
+      rootDir: command.rootDir,
+      ...(rootResolutionSource ? { rootResolutionSource } : {}),
+      ...(command.layoutOverrides === undefined
+        ? {}
+        : { layoutOverrides: taskCompleteWireRecord(command.layoutOverrides, `${path}.command.layoutOverrides`, invalid) as RepoWriteJsonObject }),
+      ...(command.daemonRepoId === undefined
+        ? {}
+        : { daemonRepoId: nonEmptyString(command.daemonRepoId, `${path}.command.daemonRepoId`, invalid) }),
+      ...(command.actor === undefined
+        ? {}
+        : { actor: nonEmptyString(command.actor, `${path}.command.actor`, invalid) }),
+      ...(daemonModeOverride ? { daemonModeOverride } : {}),
+      ...(daemonProfileOverride ? { daemonProfileOverride } : {}),
+      json: command.json,
+      ...(command.deprecatedInvocation === undefined
+        ? {}
+        : { deprecatedInvocation: taskCompleteWireRecord(command.deprecatedInvocation, `${path}.command.deprecatedInvocation`, invalid) as RepoWriteJsonObject }),
+      action
+    },
+    session: {
+      runtime,
+      sessionId: nonEmptyString(session.sessionId, `${path}.session.sessionId`, invalid),
+      source,
+      detectedAt: nonEmptyString(session.detectedAt, `${path}.session.detectedAt`, invalid),
+      ...(session.user === undefined
+        ? {}
+        : { user: nonEmptyString(session.user, `${path}.session.user`, invalid) })
+    }
+  };
+}
+
+function taskCompleteWireRecord(value: unknown, path: string, invalid: Invalid): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) invalid(path, "plain object");
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) invalid(path, "plain object");
+  return value as Record<string, unknown>;
+}
+
+function taskCompleteWireExactKeys(
+  value: Record<string, unknown>,
+  required: ReadonlyArray<string>,
+  optional: ReadonlyArray<string>,
+  path: string,
+  invalid: Invalid
+): void {
+  const allowed = new Set([...required, ...optional]);
+  if (required.some((key) => !Object.hasOwn(value, key))
+    || Object.keys(value).some((key) => !allowed.has(key))) {
+    invalid(path, "exact message fields");
+  }
+}
+
+function optionalEnum<const T extends string>(
+  value: unknown,
+  allowed: ReadonlyArray<T>,
+  path: string,
+  invalid: Invalid
+): T | undefined {
+  return value === undefined ? undefined : requiredEnum(value, allowed, path, invalid);
+}
+
+function requiredEnum<const T extends string>(
+  value: unknown,
+  allowed: ReadonlyArray<T>,
+  path: string,
+  invalid: Invalid
+): T {
+  if (typeof value !== "string" || !allowed.includes(value as T)) {
+    invalid(path, allowed.join(", "));
+  }
+  return value as T;
+}
+
+function nonEmptyString(value: unknown, path: string, invalid: Invalid): string {
+  if (typeof value !== "string" || !value.trim()) invalid(path, "non-empty string");
+  return value;
+}
+
+function commandInvalid(path: string, expected: string): never {
+  throw new Error(`REPO_WRITE_TASK_COMPLETE_COMMAND_INVALID:${path}:${expected}`);
+}

--- a/packages/daemon/src/runtime/repo-write-outcome-schema.ts
+++ b/packages/daemon/src/runtime/repo-write-outcome-schema.ts
@@ -1,9 +1,14 @@
 import type { CommandReceiptEnvelope } from "@harness-anything/application";
 import { stablePayloadHash, stableStringify } from "@harness-anything/kernel";
-import type {
-  RepoWriteCommandDto,
-  RepoWriteJsonObject
+import {
+  repoWriteCommandDtoFromDecodedFields,
+  type RepoWriteCommandDto,
+  type RepoWriteJsonObject
 } from "./repo-write-protocol.ts";
+/*
+ * Canonical outcomes retain the same command decoder as the live IPC frame;
+ * recovery must not reopen a payload shape rejected on ingress.
+ */
 import { decodeRepoWriteCommandReceiptV2 } from "./repo-write-command-receipt.ts";
 import { RepoWriteOutcomeValidationError } from "./repo-write-outcome-errors.ts";
 import {
@@ -344,12 +349,20 @@ function repoWriteOutcomeCommandAt(
 ): RepoWriteCommandDto {
   const record = repoWriteOutcomeRecordAt(value, path);
   repoWriteOutcomeExactKeys(record, ["commandName", "actor", "context", "payload"], [], path);
-  return {
+  const fields = {
     commandName: repoWriteOutcomeIdentifierAt(record.commandName, `${path}.commandName`),
     actor: jsonObjectAt(record.actor, `${path}.actor`, budget, 1),
     context: jsonObjectAt(record.context, `${path}.context`, budget, 1),
     payload: jsonObjectAt(record.payload, `${path}.payload`, budget, 1)
   };
+  try {
+    return repoWriteCommandDtoFromDecodedFields(fields, path);
+  } catch (error) {
+    repoWriteOutcomeInvalid(
+      `${path}.payload`,
+      error instanceof Error ? error.message : "strict task-complete command payload"
+    );
+  }
 }
 
 function repoWriteOutcomeRecordAt(value: unknown, path: string): Record<string, unknown> {

--- a/packages/daemon/src/runtime/repo-write-progress-command.ts
+++ b/packages/daemon/src/runtime/repo-write-progress-command.ts
@@ -12,6 +12,7 @@ import type { AuthorityConnectionContext } from "../protocol/connection-context.
 import {
   decodeRepoWriteBytes,
   encodeRepoWriteBytes,
+  repoWriteCommandDtoFromDecodedFields,
   type RepoWriteCommandDto,
   type RepoWriteJsonObject
 } from "./repo-write-protocol.ts";
@@ -48,7 +49,7 @@ export function encodeRepoWriteCommand(input: {
   if (authority.actor.personId !== input.context.actor.personId) {
     throw new Error("REPO_WRITE_PROGRESS_ACTOR_CONTEXT_MISMATCH");
   }
-  return {
+  return repoWriteCommandDtoFromDecodedFields({
     commandName,
     actor: actorStampJson(input.context.actor),
     context: progressJsonObject({
@@ -77,7 +78,7 @@ export function encodeRepoWriteCommand(input: {
       command: input.command,
       session: input.context.currentSession
     })
-  };
+  });
 }
 
 export function encodeRepoWriteProgressCommand(input: {

--- a/packages/daemon/src/runtime/repo-write-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-protocol.ts
@@ -1,4 +1,7 @@
 // @slice-activation P5-W2 repo-writer foundation; public recovery routing remains activation work owned by task_01KY6QFFC306JRW8JW4Y2ND2TM.
+import { repoWriteCommandDtoFromDecodedFields, type RepoWriteCommandDto } from "./repo-write-command-dto.ts";
+export { repoWriteCommandDtoFromDecodedFields, repoWriteLegacyCommandName } from "./repo-write-command-dto.ts";
+export type { RepoWriteCommandDto, RepoWriteLegacyCommandDto, RepoWriteLegacyCommandName, RepoWriteTaskCompleteCommandDto, RepoWriteTaskCompleteCommandPayload, RepoWriteTaskCompleteWireCommand, RepoWriteTaskCompleteWireSession } from "./repo-write-command-dto.ts";
 import { repoWriteTerminalReceiptMatches } from "./repo-write-terminal-receipt.ts";
 import type { RepoWriteRecoveryDeferredFrame, RepoWriteRecoveryDiagnosticFrame, RepoWriteRecoveryRejectedFrame, RepoWriteTelemetryFrame, RepoWriteTelemetryPhase } from "./repo-write-diagnostic-protocol.ts";
 export type { RepoWriteRecoveryDeferredFrame, RepoWriteRecoveryDiagnosticFrame, RepoWriteRecoveryRejectedFrame, RepoWriteTelemetryFrame, RepoWriteTelemetryPhase } from "./repo-write-diagnostic-protocol.ts";
@@ -45,12 +48,6 @@ export const defaultRepoWriteProtocolLimits: RepoWriteProtocolLimits = {
 export type RepoWriteJsonPrimitive = string | number | boolean | null;
 export type RepoWriteJsonValue = RepoWriteJsonPrimitive | RepoWriteJsonObject | ReadonlyArray<RepoWriteJsonValue>;
 export interface RepoWriteJsonObject { readonly [key: string]: RepoWriteJsonValue }
-export interface RepoWriteCommandDto {
-  readonly commandName: string;
-  readonly actor: RepoWriteJsonObject;
-  readonly context: RepoWriteJsonObject;
-  readonly payload: RepoWriteJsonObject;
-}
 interface RepoWriteFrameBase {
   readonly protocol: typeof repoWriteProtocolType;
   readonly repoId: string;
@@ -228,17 +225,18 @@ function decodeCommandFrame<K extends "submit" | "direct">(
     ...baseFields(frame),
     kind,
     requestId: identifier(frame.requestId, "$.requestId", limits),
-    command: {
+    command: repoWriteCommandDtoFromDecodedFields({
       commandName: identifier(command.commandName, "$.command.commandName", limits),
       actor: jsonObject(command.actor, "$.command.actor", limits, budget, 1),
       context: jsonObject(command.context, "$.command.context", limits, budget, 1),
       payload: jsonObject(command.payload, "$.command.payload", limits, budget, 1)
-    }
+    }, "$.command", invalid)
   };
   return decoded as unknown as K extends "submit"
     ? RepoWriteSubmitFrame
     : RepoWriteDirectFrame;
 }
+
 function decodeOperationFrame<K extends "proceed" | "status" | "prepared">(
   frame: FrameRecord, limits: RepoWriteProtocolLimits, kind: K
 ): RepoWriteOperationFrame<K> {

--- a/packages/daemon/test/repo-write-protocol.test.ts
+++ b/packages/daemon/test/repo-write-protocol.test.ts
@@ -11,6 +11,7 @@ import {
   encodeRepoWriteBytes,
   parseRepoWriteChildMessage,
   parseRepoWriteParentMessage,
+  repoWriteLegacyCommandName,
   repoWriteProtocolType,
   stringifyRepoWriteChildMessage,
   stringifyRepoWriteParentMessage,
@@ -45,6 +46,92 @@ test("submit codec carries command DTOs as JSON-safe values with explicit scalar
   assert.deepEqual(
     [...decodeRepoWriteBytes(decoded.kind === "submit" ? decoded.command.payload.bytes : undefined)],
     [0, 127, 255]
+  );
+});
+
+test("task-complete is a strict typed wire branch instead of a generic command payload", () => {
+  const action = {
+    kind: "task-complete",
+    taskId: "task_TYPED",
+    executionId: "exe_TYPED",
+    ciGate: "passed",
+    reviewerId: "reviewer_TYPED",
+    evidenceMode: "execution-review",
+    commitRef: "HEAD",
+    judgment: null,
+    approval: {
+      executionId: "exe_TYPED",
+      findings: "Reviewed.",
+      evidenceChecked: ["test:typed-wire"],
+      rationale: "The evidence supports completion.",
+      archiveWarningsAcknowledged: true,
+      consentSource: { kind: "recorded-consent", consentId: "cns_TYPED" },
+      consentActions: null,
+      paths: ["packages/daemon/src/runtime/repo-write-protocol.ts"],
+      prRef: "#typed"
+    },
+    externalCheckpointRefs: [
+      { kind: "document-publication", ref: "checkpoint:document" }
+    ],
+    callerIdempotencyKey: "caller-typed-wire",
+    dryRun: false
+  };
+  const frame = {
+    ...base("submit"),
+    requestId: "request-task-complete",
+    command: {
+      commandName: "task-complete",
+      actor: { personId: "person_zeyu" },
+      context: {},
+      payload: {
+        command: { rootDir: "/repo", json: true, action },
+        session: {
+          runtime: "codex",
+          sessionId: "session_TYPED",
+          source: "runtime",
+          detectedAt: "2026-08-03T00:00:00.000Z"
+        }
+      }
+    }
+  };
+  const decoded = decodeRepoWriteParentMessage(frame);
+  assert.equal(decoded.kind, "submit");
+  assert.equal(decoded.kind === "submit" ? decoded.command.commandName : undefined, "task-complete");
+  assert.deepEqual(
+    decoded.kind === "submit" ? decoded.command.payload.command.action : undefined,
+    action
+  );
+
+  assert.throws(() => decodeRepoWriteParentMessage({
+    ...frame,
+    command: {
+      ...frame.command,
+      payload: {
+        ...frame.command.payload,
+        command: {
+          ...frame.command.payload.command,
+          action: { ...action, silentlyDropped: true }
+        }
+      }
+    }
+  }), /TASK_COMPLETE_TRANSITION_COMMAND_INVALID/u);
+  assert.throws(() => decodeRepoWriteParentMessage({
+    ...frame,
+    command: { ...frame.command, payload: { arbitrary: "generic payload" } }
+  }), /unknown keys|TASK_COMPLETE_TRANSITION_COMMAND_INVALID/u);
+  assert.throws(() => decodeRepoWriteParentMessage({
+    ...frame,
+    command: {
+      ...frame.command,
+      payload: {
+        ...frame.command.payload,
+        command: { ...frame.command.payload.command, transportEscape: true }
+      }
+    }
+  }), /exact message fields/u);
+  assert.throws(
+    () => repoWriteLegacyCommandName("task-complete"),
+    /REPO_WRITE_TASK_COMPLETE_TYPED_COMMAND_REQUIRED/u
   );
 });
 


### PR DESCRIPTION
# English

## Summary

Makes the `task complete` intent expressible in one piece over the wire.

Until now the CLI carried the full intent — reviewer, approval, consent source, evidence, paths, PR ref — while the daemon host contract's `task-complete` action carried none of it (zero grep hits). The two sides were connected by structural assignability, so superset fields were silently dropped. The CLI's only option was to split one user intent into five separately-dispatched sub-intents, with a durable crash cut between every pair.

This PR closes that gap, and closes it **without adding another layer on top of the open string channel**.

## What Changed

`RepoWriteCommandDto` is now a discriminated union: a legacy branch for everything else, and a typed `task-complete` branch. `repoWriteLegacyCommandName()` throws `REPO_WRITE_TASK_COMPLETE_TYPED_COMMAND_REQUIRED` when handed `"task-complete"` — that command **can no longer travel the generic `commandName: string` + arbitrary-`JsonObject` path at all**.

The host contract's `task-complete` action gained `approval`, `externalCheckpointRefs`, `judgment`, `evidenceMode`, `commitRef`, and a **required** `callerIdempotencyKey: string` (not optional — downstream durable checkpointing depends on retries resolving to the same transition id).

Decoding is strict: unknown keys and missing required fields are rejected rather than dropped.

- `packages/daemon/src/runtime/repo-write-command-dto.ts` (new, 223 lines) — the union, the legacy-name guard, and strict decoders.
- `packages/application/src/authority/task-complete-transition-command.ts` (new, 205 lines) — the transition command shape.
- `packages/cli/src/cli/task-complete-transition-command.ts` (new, 123 lines) — CLI-side construction.
- Contract, parser, host-service and outcome-schema wiring across 14 existing files.

## Task And Scope

- Task: `task_01KZ1KDH7KBZM2VKH7SX3NZ1PB` (PLT-Steady transport slice T2)
- Parent line: `task_01KZ1FMPC53362VFN0175WN0XY`
- This slice is **ownership item 1** of the joint-slice adjudication. Items 2 (write-path compiler) and 3 (lifecycle planner) are both blocked on it.
- Explicitly **out of scope**: deleting the CLI facade, implementing the planner, changing the semantic compiler. This slice only guarantees that when the planner arrives, it can receive a complete command.

## Version Impact

No published artifact or package version change. The typed branch is additive at the protocol level; the only removal is the ability to send `task-complete` down the legacy generic path, which no external consumer uses.

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `packages/daemon/src/runtime/` is declared in `tools/write-road-registry.json`; this PR modifies `repo-write-protocol.ts`, `repo-write-outcome-schema.ts`, `repo-write-progress-command.ts`, and `durable-repo-write-outcome-store.ts` (5 lines), and adds `repo-write-command-dto.ts` under that path.
- Authority: `dec_01KZ1EQY5PATT8GGV35CFE9FHG` (PLT-Steady charter) and `dec_01KZ1JJX7K2Q27WBEB46PEH4E9` (joint-slice adjudication, which names this exact deliverable as ownership item 1), task `task_01KZ1KDH7KBZM2VKH7SX3NZ1PB`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: items 2 and 3 of the adjudication will each carry their own declaration.

## Verification

- Base `origin/main` SHA: `8607f1a870693108c78479a48ec957049f6b757a`
- Branch merge-base with `origin/main`: `8607f1a870693108c78479a48ec957049f6b757a`
- Last `git fetch origin` time: at rebase, immediately before this PR
- Sync method: rebase onto current `origin/main`
- Public diff command: `git diff 8607f1a870693108c78479a48ec957049f6b757a..c43171c46a83d9e712c603a4e7ca37d4608209ab`
- Private evidence commit/path: T2 findings live in the private task package artifacts
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending on this PR

Three acceptance criteria were written into the task plan before implementation and each was independently verified by the reviewer, not taken from the report:

| Criterion | Verification |
| --- | --- |
| host contract's `task-complete` carries approval / checkpoint / idempotency (previously 0 grep hits) | `daemon-host-contract.ts:56-68` — `approval`, `externalCheckpointRefs`, `judgment`, and a non-optional `callerIdempotencyKey: string` |
| unknown fields are **rejected**, not silently dropped | `repo-write-protocol.test.ts` — four `assert.throws` sites matching `/unknown keys\|TASK_COMPLETE_TRANSITION_COMMAND_INVALID/u` |
| CLI-constructed command and daemon-decoded structure are **field-level equal** | `task-complete-transition-command.test.ts:39-40` — `assert.deepEqual(decoded.action, constructed)` |

- [x] `git diff --check`
- [x] `npm run check:local` — exit 0, `Local check passed in 110.0s`, 27 complete manifest gates green
- [x] Targeted tests for the change surface, named with their counts: focused suite `33/33`; `npm run test:fast` `921 passed / 0 failed`; `npm run test:integration` `1452 passed / 0 failed` (4 platform skips); affected fast `621/621`; affected contract `464 passed / 0 failed` (1 win32 skip)
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)

## Review Evidence

The task plan named one core tension in advance and required a direct answer: the adjudication describes this slice as "purely additive", but the transport line's own anchor 01 says the underlying DTO is `commandName: string` plus arbitrary `JsonObject`. A typed command that merely rides that open channel would pass every test, go green, and be a **third layer** rather than an unlock — which is precisely the pattern behind this line's 33 historical instances.

The implementation answers it directly rather than working around it. `RepoWriteCommandDto` became a discriminated union and `repoWriteLegacyCommandName()` hard-rejects `"task-complete"`, so the generic path is closed for this command rather than shadowed by a parallel one. Reviewer verified the rejection is an unconditional string comparison plus `throw`, not a heuristic.

Per `dec_01KYYX1AXK7JMWFGCKX059W6PV`, this does not add a parallel authority: it removes one legal state (task-complete travelling untyped) instead of introducing a second entry point alongside an unclosed first.

## Residual Risk

- **The five-step CLI facade still exists.** This slice deliberately does not delete it — that is ownership item 3 (lifecycle planner). Deletion condition: once the planner consumes the typed command end to end, the facade's `task-complete` path has no remaining caller. Owner: item 3.
- **Only `task-complete` is closed.** Every other repo-write command still travels the legacy open-JSON path. Closing them is later transport-line work, not a regression introduced here.
- Planner, semantic compiler, and durable checkpoint consumer are all unimplemented by design — they are ownership items 2, 3, and 4.
- `npm run check:ci` was not run locally; the authoritative full gate is this PR's CI.
- No GUI interaction validation; the production daemon was neither stopped nor refreshed during this work.

## References

- PLT-Steady charter: `dec_01KZ1EQY5PATT8GGV35CFE9FHG`
- Joint-slice adjudication: `dec_01KZ1JJX7K2Q27WBEB46PEH4E9`
- Mitigation accounting policy: `dec_01KYYX1AXK7JMWFGCKX059W6PV`
- Transport line: `task_01KZ1FMPC53362VFN0175WN0XY`
- This slice: `task_01KZ1KDH7KBZM2VKH7SX3NZ1PB`

# 中文

## 概要

让 `task complete` 这个意图能在 wire 上一次说完整。

在此之前,完整意图只存在于 CLI —— reviewer、approval、consent source、evidence、paths、PR ref;而 daemon host contract 的 `task-complete` action 一个都没有(grep 0 命中)。两侧靠结构可赋值连接,超集字段被静默丢弃。CLI 唯一的选择就是把一个用户意图拆成五个分别 dispatch 的子意图,每两步之间是一个可持久化的 crash cut。

本 PR 补上这个缺口,而且**没有在开放 string 通道之上再加一层**。

## 改动内容

`RepoWriteCommandDto` 现在是 discriminated union:一个 legacy 分支承载其余命令,一个 typed 分支承载 `task-complete`。`repoWriteLegacyCommandName()` 收到 `"task-complete"` 时抛 `REPO_WRITE_TASK_COMPLETE_TYPED_COMMAND_REQUIRED` —— 该命令**再也不能走通用 `commandName: string` + 任意 `JsonObject` 那条路**。

host contract 的 `task-complete` action 新增 `approval`、`externalCheckpointRefs`、`judgment`、`evidenceMode`、`commitRef`,以及一个**必选**的 `callerIdempotencyKey: string`(不是 optional —— 下游 durable checkpoint 要靠它让重试收敛到同一个 transition id)。

解码是严格的:未知字段与缺失必填字段都被拒绝,而不是丢弃。

- `packages/daemon/src/runtime/repo-write-command-dto.ts`(新增 223 行)—— union、legacy 名字守卫与严格解码器。
- `packages/application/src/authority/task-complete-transition-command.ts`(新增 205 行)—— transition command 形状。
- `packages/cli/src/cli/task-complete-transition-command.ts`(新增 123 行)—— CLI 侧构造。
- 契约、parser、host service 与 outcome schema 的接线散在 14 个既有文件。

## 任务与范围

- 任务:`task_01KZ1KDH7KBZM2VKH7SX3NZ1PB`(PLT-Steady 传输线切片 T2)
- 父线:`task_01KZ1FMPC53362VFN0175WN0XY`
- 本切片是联合切片裁决的**序号 1**。序号 2(写路径 compiler)与序号 3(生命周期 planner)都卡在它上面。
- **明确不在范围内**:删除 CLI facade、实现 planner、改 semantic compiler。本切片只保证:当 planner 就位时,它能拿到完整 command。

## 版本影响

不改动任何已发布工件,不涉及 package 版本变更。typed 分支在协议层是加法;唯一的移除是「`task-complete` 可以走 legacy 通用路径」这一能力,没有外部消费者依赖它。

## 治理声明

- 是否触碰 protected surface:是
- Protected surface 范围:`packages/daemon/src/runtime/` 已在 `tools/write-road-registry.json` 中声明;本 PR 修改了 `repo-write-protocol.ts`、`repo-write-outcome-schema.ts`、`repo-write-progress-command.ts` 与 `durable-repo-write-outcome-store.ts`(5 行),并在该路径下新增 `repo-write-command-dto.ts`。
- 依据:`dec_01KZ1EQY5PATT8GGV35CFE9FHG`(PLT-Steady charter)与 `dec_01KZ1JJX7K2Q27WBEB46PEH4E9`(联合切片裁决,其中把本交付物点名为 ownership 序号 1)、任务 `task_01KZ1KDH7KBZM2VKH7SX3NZ1PB`
- 机器检查边界:本 PR 只断言声明存在;是否属实、是否充分由评审者判断。
- Break-glass:否
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:裁决的序号 2 与序号 3 各自携带自己的声明。

## 验证

- 基线 `origin/main` SHA:`8607f1a870693108c78479a48ec957049f6b757a`
- 分支与 `origin/main` 的 merge-base:`8607f1a870693108c78479a48ec957049f6b757a`
- 最近一次 `git fetch origin` 时间:rebase 时,即本 PR 之前
- 同步方式:rebase 到当前 `origin/main`
- 公开 diff 命令:`git diff 8607f1a870693108c78479a48ec957049f6b757a..c43171c46a83d9e712c603a4e7ca37d4608209ab`
- 私有证据 commit/路径:T2 findings 在私有任务包 artifacts 内
- 评审证据路径:同一任务包
- GitHub Actions `rewrite-ci` run URL:本 PR 待跑

三条验收判据在实现之前就写进了 task plan,每一条都由评审者独立验证,不取自报告:

| 判据 | 验证 |
| --- | --- |
| host contract 的 `task-complete` 携带 approval / checkpoint / idempotency(此前 grep 0 命中) | `daemon-host-contract.ts:56-68` —— `approval`、`externalCheckpointRefs`、`judgment`,以及非 optional 的 `callerIdempotencyKey: string` |
| 未知字段被**拒绝**而非静默丢弃 | `repo-write-protocol.test.ts` —— 四处 `assert.throws` 匹配 `/unknown keys\|TASK_COMPLETE_TRANSITION_COMMAND_INVALID/u` |
| CLI 构造的 command 与 daemon 解码后的结构**字段级相等** | `task-complete-transition-command.test.ts:39-40` —— `assert.deepEqual(decoded.action, constructed)` |

- [x] `git diff --check`
- [x] `npm run check:local` —— exit 0,`Local check passed in 110.0s`,27 个 complete manifest gates 全绿
- [x] 改动面的定向测试,写明测试名与通过数:聚焦测试 `33/33`;`npm run test:fast` `921 passed / 0 failed`;`npm run test:integration` `1452 passed / 0 failed`(4 个平台 skip);affected fast `621/621`;affected contract `464 passed / 0 failed`(1 个 win32 skip)
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)

## 审查证据

task plan 事先点名了一个核心张力并要求正面回答:裁决把本切片描述为「纯加法」,但传输线自己的锚点 01 说底层 DTO 是 `commandName: string` 加任意 `JsonObject`。一个只是跑在那条开放通道上的 typed command,会通过所有测试、会绿,然后成为**第三层**而不是解锁点 —— 这正是本线 33 个历史实例背后的模式。

实现选择正面回答而不是绕开:`RepoWriteCommandDto` 变成 discriminated union,`repoWriteLegacyCommandName()` 硬拒 `"task-complete"`,于是通用路径对这个命令是**关闭**的,而不是被一条平行路径遮蔽。评审者已核实该拒绝是无条件字符串比对加 `throw`,不是启发式判断。

按 `dec_01KYYX1AXK7JMWFGCKX059W6PV`,这不新增平行 authority:它**删除了一个合法状态**(task-complete 可以不 typed 地传输),而不是在一个未封闭的入口旁边再开第二个。

## 残余风险

- **五步 CLI facade 仍然存在。** 本切片刻意不删它 —— 那是 ownership 序号 3(生命周期 planner)的活。删除条件:planner 端到端消费 typed command 之后,facade 的 `task-complete` 路径就没有剩余 caller。owner:序号 3。
- **只有 `task-complete` 被封闭。** 其余 repo-write 命令仍走 legacy 开放 JSON 路径。封闭它们是传输线后续的活,不是本 PR 引入的回归。
- planner、semantic compiler、durable checkpoint 消费方均按切片边界未实现 —— 它们是 ownership 序号 2、3、4。
- 未在本地运行 `npm run check:ci`;权威全量门是本 PR 的 CI。
- 未做 GUI 交互验证;本次工作期间未启停或 refresh 生产 daemon。

## 关联材料

- PLT-Steady charter:`dec_01KZ1EQY5PATT8GGV35CFE9FHG`
- 联合切片裁决:`dec_01KZ1JJX7K2Q27WBEB46PEH4E9`
- 记账政策:`dec_01KYYX1AXK7JMWFGCKX059W6PV`
- 传输线:`task_01KZ1FMPC53362VFN0175WN0XY`
- 本切片:`task_01KZ1KDH7KBZM2VKH7SX3NZ1PB`

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
