### PR TITLE
fix(ci): scope main-red advisory issues per watched workflow

### DIFF
--- a/.github/workflows/main-red-notify.yml
+++ b/.github/workflows/main-red-notify.yml
@@ -20,21 +20,46 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Every watched workflow owns a separate advisory issue. Sharing one issue across
+      # workflows meant a green rewrite-ci run closed the red opened by nightly-integration,
+      # under a title naming rewrite-ci — so a tier that was red for two weeks was reported
+      # daily under the wrong name and silenced within the hour. See
+      # dec_01KZ20MPDZH490AXKQX3VC1NEG. This script is kept in parity with
+      # tools/main-red-notify.mjs by tools/main-red-notify.test.mjs; the workflow cannot import
+      # that module because it deliberately never checks out the repository.
       - name: Open, update, or resolve the main-red advisory issue
         uses: actions/github-script@v7
         with:
           script: |
             const label = 'main-red';
-            const title = '[CI] rewrite-ci is red on main';
             const run = context.payload.workflow_run;
             const { owner, repo } = context.repo;
             const clean = (value) => String(value).replace(/[\r\n]+/g, ' ').trim();
+            const workflowName = clean(run.name || run.workflow_id || 'unknown workflow');
+            // Identity is the numeric workflow_id, not the display name: a name is editable
+            // (renaming would strand an open issue forever) and lossy to slugify (two names
+            // differing only in punctuation would collide). Sanitised defensively because it
+            // is embedded in an HTML comment marker. The name is display only.
+            const workflowIdentity = clean(run.workflow_id).replace(/[^A-Za-z0-9._-]+/g, '-') || 'unknown-workflow';
+            const title = `[CI] ${workflowName} is red on main`;
+            const workflowMarker = `<!-- main-red-workflow:${workflowIdentity} -->`;
             const shaMarker = `<!-- main-red-sha:${clean(run.head_sha)} -->`;
             const runMarker = `<!-- main-red-run:${clean(run.id)} -->`;
+            // null means the issue declares no owner. Issues opened before per-workflow
+            // identity are the only such issues, and they are deliberately not attributed by
+            // guesswork: the shared issue carried a rewrite-ci title no matter which workflow
+            // had failed, so assuming rewrite-ci owns it would reproduce the wrong-workflow
+            // closure this change exists to remove. They are left for a human.
+            const issueWorkflowIdentity = (issue) => {
+              const match = (issue.body || '').match(/<!-- main-red-workflow:([A-Za-z0-9._-]+) -->/);
+              return match ? match[1] : null;
+            };
             const recordedRunId = (issue) => {
               const match = (issue.body || '').match(/<!-- main-red-run:(\d+) -->/);
               return match ? Number(match[1]) : null;
             };
+            // Strictly greater-than: a re-run keeps the same run id, so treating an equal id as
+            // stale would leave the issue open forever after "run N failed, run N re-run passed".
             const isStale = (issue) => {
               const recorded = recordedRunId(issue);
               return recorded !== null && recorded > Number(run.id);
@@ -46,16 +71,18 @@ jobs:
               labels: label,
               per_page: 100
             });
-            const openIssues = listed.filter((issue) => !issue.pull_request);
+            const openIssues = listed
+              .filter((issue) => !issue.pull_request)
+              .filter((issue) => issueWorkflowIdentity(issue) === workflowIdentity);
 
             if (run.conclusion === 'success') {
-              const comment = `rewrite-ci is green again on main for \`${clean(run.head_sha)}\`: ${clean(run.html_url)}. Closing this advisory issue.`;
+              const comment = `${workflowName} is green again on main for \`${clean(run.head_sha)}\`: ${clean(run.html_url)}. Closing this advisory issue.`;
               const eligibleIssues = openIssues.filter((issue) => !isStale(issue));
               for (const issue of eligibleIssues) {
                 await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body: comment });
                 await github.rest.issues.update({ owner, repo, issue_number: issue.number, state: 'closed', state_reason: 'completed' });
               }
-              core.info(`Resolved ${eligibleIssues.length} open ${label} issue(s); ignored ${openIssues.length - eligibleIssues.length} newer failure(s).`);
+              core.info(`Resolved ${eligibleIssues.length} open ${label} issue(s) for ${workflowName}; ignored ${openIssues.length - eligibleIssues.length} newer failure(s).`);
               return;
             }
 
@@ -72,16 +99,19 @@ jobs:
               : ['- Unable to identify a failed job from the run API.'];
             const body = [
               '<!-- main-red-notification -->',
+              workflowMarker,
               runMarker,
               shaMarker,
-              '## rewrite-ci is red on main',
+              `## ${workflowName} is red on main`,
               '',
+              `- Workflow: ${workflowName}`,
               `- Run: ${clean(run.html_url)}`,
               `- Head SHA: \`${clean(run.head_sha)}\``,
               '- Failed jobs:',
               ...jobLines,
               '',
-              'This issue is advisory only. It does not change required checks, branch protection, or merge enforcement.'
+              'This issue is advisory only. It does not change required checks, branch protection, or merge enforcement.',
+              `Only a later green ${workflowName} run closes it; other watched workflows keep their own advisory issues.`
             ].join('\n');
             const current = openIssues[0];
 
@@ -90,15 +120,15 @@ jobs:
                 await github.rest.issues.getLabel({ owner, repo, name: label });
               } catch (error) {
                 if (error.status !== 404) throw error;
-                await github.rest.issues.createLabel({ owner, repo, name: label, color: 'b60205', description: 'rewrite-ci is red on main' });
+                await github.rest.issues.createLabel({ owner, repo, name: label, color: 'b60205', description: 'A watched workflow is red on main' });
               }
               const created = await github.rest.issues.create({ owner, repo, title, body, labels: [label] });
-              core.info(`Opened ${created.data.html_url}.`);
+              core.info(`Opened ${created.data.html_url} for ${workflowName}.`);
               return;
             }
 
             if (isStale(current)) {
-              core.info(`Issue #${current.number} records a newer workflow run; stale failure ${run.id} ignored.`);
+              core.info(`Issue #${current.number} records a newer ${workflowName} run; stale failure ${run.id} ignored.`);
               return;
             }
 
@@ -112,8 +142,8 @@ jobs:
                 owner,
                 repo,
                 issue_number: current.number,
-                body: `rewrite-ci failed again on main: ${clean(run.html_url)} (\`${clean(run.head_sha)}\`). Updating the advisory issue.`
+                body: `${workflowName} failed again on main: ${clean(run.html_url)} (\`${clean(run.head_sha)}\`). Updating the advisory issue.`
               });
             }
             await github.rest.issues.update({ owner, repo, issue_number: current.number, title, body });
-            core.info(`Updated issue #${current.number}.`);
+            core.info(`Updated issue #${current.number} for ${workflowName}.`);

--- a/tools/main-red-notify.mjs
+++ b/tools/main-red-notify.mjs
@@ -1,3 +1,18 @@
+// This module is the tested oracle for the inline github-script body in
+// .github/workflows/main-red-notify.yml. The workflow deliberately does not check out the
+// repository (workflow_run runs with issues: write, and a checkout there widens the attack
+// surface), so its logic must stay inline and cannot import this file. main-red-notify.test.mjs
+// keeps the two in parity by executing the extracted inline script against these builders.
+//
+// Per-workflow identity exists because main-red-notify watches more than one workflow. While
+// they shared a single advisory issue, a green rewrite-ci run closed the red that
+// nightly-integration had opened, under a title naming rewrite-ci — so a tier that was red for
+// two weeks was reported daily under the wrong name and silenced within the hour.
+// See dec_01KZ20MPDZH490AXKQX3VC1NEG.
+//
+// Identity is the numeric workflow_id, not the display name: a name is editable (renaming a
+// workflow would strand its open issue forever) and lossy to slugify (two names differing only
+// in punctuation would collide and close each other's issues). The name is display only.
 const notificationMarker = "<!-- main-red-notification -->";
 
 function cleanInline(value) {
@@ -5,7 +20,30 @@ function cleanInline(value) {
 }
 
 export const mainRedLabel = "main-red";
-export const mainRedIssueTitle = "[CI] rewrite-ci is red on main";
+
+// Defensive: the identity is embedded in an HTML comment marker, so it must not be able to
+// terminate one even if the payload is not the expected numeric id.
+export function mainRedWorkflowIdentity(workflowId) {
+  return cleanInline(workflowId).replace(/[^A-Za-z0-9._-]+/gu, "-") || "unknown-workflow";
+}
+
+export function mainRedWorkflowMarker(workflowId) {
+  return `<!-- main-red-workflow:${mainRedWorkflowIdentity(workflowId)} -->`;
+}
+
+// null means "this issue declares no owner". Issues opened before per-workflow identity are the
+// only such issues, and they are NOT attributed by guesswork: the shared issue carried a
+// rewrite-ci title no matter which workflow had failed, so assuming rewrite-ci owns it would
+// reproduce exactly the wrong-workflow closure this change exists to remove. They are left for
+// a human, which is visible, rather than closed by the wrong workflow, which is not.
+export function readMainRedWorkflowIdentity(issue) {
+  const match = typeof issue.body === "string" ? issue.body.match(/<!-- main-red-workflow:([A-Za-z0-9._-]+) -->/u) : null;
+  return match === null ? null : match[1];
+}
+
+export function mainRedIssueTitle(workflowName) {
+  return `[CI] ${cleanInline(workflowName)} is red on main`;
+}
 
 export function mainRedShaMarker(headSha) {
   return `<!-- main-red-sha:${cleanInline(headSha)} -->`;
@@ -20,26 +58,30 @@ export function readMainRedRunId(issue) {
   return match === null ? null : Number(match[1]);
 }
 
-export function buildMainRedIssueBody({ runId, runUrl, headSha, failedJobs }) {
+export function buildMainRedIssueBody({ workflowId, workflowName, runId, runUrl, headSha, failedJobs }) {
+  const workflow = cleanInline(workflowName);
   const jobs = [...new Set(failedJobs.map(cleanInline).filter(Boolean))];
   const jobLines = jobs.length > 0 ? jobs.map((name) => `- ${name}`) : ["- Unable to identify a failed job from the run API."];
   return [
     notificationMarker,
+    mainRedWorkflowMarker(workflowId),
     mainRedRunMarker(runId),
     mainRedShaMarker(headSha),
-    "## rewrite-ci is red on main",
+    `## ${workflow} is red on main`,
     "",
+    `- Workflow: ${workflow}`,
     `- Run: ${cleanInline(runUrl)}`,
     `- Head SHA: \`${cleanInline(headSha)}\``,
     "- Failed jobs:",
     ...jobLines,
     "",
-    "This issue is advisory only. It does not change required checks, branch protection, or merge enforcement."
+    "This issue is advisory only. It does not change required checks, branch protection, or merge enforcement.",
+    `Only a later green ${workflow} run closes it; other watched workflows keep their own advisory issues.`
   ].join("\n");
 }
 
-export function buildMainRedRecoveryComment({ runUrl, headSha }) {
-  return `rewrite-ci is green again on main for \`${cleanInline(headSha)}\`: ${cleanInline(runUrl)}. Closing this advisory issue.`;
+export function buildMainRedRecoveryComment({ workflowName, runUrl, headSha }) {
+  return `${cleanInline(workflowName)} is green again on main for \`${cleanInline(headSha)}\`: ${cleanInline(runUrl)}. Closing this advisory issue.`;
 }
 
 export function selectOpenMainRedIssues(issues) {
@@ -47,10 +89,19 @@ export function selectOpenMainRedIssues(issues) {
     issue.labels.some((label) => (typeof label === "string" ? label : label.name) === mainRedLabel));
 }
 
+// A workflow only ever reads, updates, or closes the advisory issue it owns. Without this
+// filter one watched workflow's green run retires another's red.
+export function selectWorkflowMainRedIssues(issues, workflowId) {
+  const identity = mainRedWorkflowIdentity(workflowId);
+  return selectOpenMainRedIssues(issues).filter((issue) => readMainRedWorkflowIdentity(issue) === identity);
+}
+
 export function isIssueForHeadSha(issue, headSha) {
   return typeof issue.body === "string" && issue.body.includes(mainRedShaMarker(headSha));
 }
 
+// Strictly greater-than. A re-run keeps the same run id, so treating an equal id as stale would
+// leave the advisory issue open forever after "run N failed, run N re-run succeeded".
 export function isStaleMainRedRun(issue, runId) {
   const recordedRunId = readMainRedRunId(issue);
   return recordedRunId !== null && recordedRunId > Number(runId);

--- a/tools/main-red-notify.test.mjs
+++ b/tools/main-red-notify.test.mjs
@@ -9,11 +9,18 @@ import {
   isStaleMainRedRun,
   mainRedIssueTitle,
   mainRedLabel,
+  mainRedWorkflowIdentity,
+  mainRedWorkflowMarker,
   readMainRedRunId,
-  selectOpenMainRedIssues
+  readMainRedWorkflowIdentity,
+  selectOpenMainRedIssues,
+  selectWorkflowMainRedIssues
 } from "./main-red-notify.mjs";
 
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+const REWRITE_CI = { id: 111, name: "rewrite-ci" };
+const NIGHTLY = { id: 222, name: "nightly-integration" };
 
 function extractWorkflowScript() {
   const workflow = readFileSync(new URL("../.github/workflows/main-red-notify.yml", import.meta.url), "utf8");
@@ -23,7 +30,18 @@ function extractWorkflowScript() {
   return lines.slice(marker + 1).filter((line) => line.startsWith("            ")).map((line) => line.slice(12)).join("\n");
 }
 
-function workflowHarness({ conclusion, runId, headSha, workflowName = "rewrite-ci", openIssues = [], jobs = [] }) {
+// Every behavioural case below drives the extracted inline script, not the module. Asserting a
+// property only against the module leaves the deployed copy free to drift: a mutation review
+// found that removing the workflow's slug sanitiser, repointing its legacy fallback, and
+// loosening its staleness comparison all left an earlier version of this suite green.
+function workflowHarness({
+  conclusion,
+  runId,
+  headSha,
+  workflow = REWRITE_CI,
+  openIssues = [],
+  jobs = []
+}) {
   const calls = { comments: [], creates: [], labels: [], updates: [] };
   const listForRepo = () => {};
   const listJobsForWorkflowRun = () => {};
@@ -52,7 +70,8 @@ function workflowHarness({ conclusion, runId, headSha, workflowName = "rewrite-c
         head_sha: headSha,
         html_url: `https://github.com/example/repo/actions/runs/${runId}`,
         id: runId,
-        name: workflowName
+        name: workflow.name,
+        workflow_id: workflow.id
       }
     }
   };
@@ -63,16 +82,27 @@ function workflowHarness({ conclusion, runId, headSha, workflowName = "rewrite-c
   };
 }
 
+function advisoryBody({ workflow, runId, headSha, failedJobs = ["some-job"] }) {
+  return buildMainRedIssueBody({
+    workflowId: workflow.id,
+    workflowName: workflow.name,
+    runId,
+    runUrl: `https://github.com/example/repo/actions/runs/${runId}`,
+    headSha,
+    failedJobs
+  });
+}
+
 test("failure issue content carries the run, failed jobs, SHA, and advisory boundary", () => {
-  const body = buildMainRedIssueBody({
+  const body = advisoryBody({
+    workflow: REWRITE_CI,
     runId: 42,
-    runUrl: "https://github.com/example/repo/actions/runs/42",
     headSha: "abc123",
     failedJobs: ["full-check (24)", "full-check (26)", "full-check (24)"]
   });
 
   assert.equal(mainRedLabel, "main-red");
-  assert.equal(mainRedIssueTitle, "[CI] rewrite-ci is red on main");
+  assert.equal(mainRedIssueTitle("rewrite-ci"), "[CI] rewrite-ci is red on main");
   assert.match(body, /main-red-sha:abc123/u);
   assert.match(body, /main-red-run:42/u);
   assert.match(body, /actions\/runs\/42/u);
@@ -84,6 +114,43 @@ test("failure issue content carries the run, failed jobs, SHA, and advisory boun
   assert.equal(readMainRedRunId({ body }), 42);
   assert.equal(isStaleMainRedRun({ body }, 41), true);
   assert.equal(isStaleMainRedRun({ body }, 43), false);
+  // A re-run keeps the same run id, so the recorded run is not newer than itself.
+  assert.equal(isStaleMainRedRun({ body }, 42), false);
+});
+
+test("issue identity is the workflow id, and the display name is only displayed", () => {
+  const body = advisoryBody({ workflow: NIGHTLY, runId: 44, headSha: "nightly123" });
+
+  assert.equal(readMainRedWorkflowIdentity({ body }), "222");
+  assert.match(body, /## nightly-integration is red on main/u);
+  assert.match(body, /- Workflow: nightly-integration/u);
+  assert.equal(mainRedIssueTitle("nightly-integration"), "[CI] nightly-integration is red on main");
+});
+
+test("an issue that declares no owner is owned by nobody", () => {
+  // Advisory issues opened before per-workflow identity carried a rewrite-ci title regardless
+  // of which workflow had failed, so attributing them to rewrite-ci would reproduce exactly the
+  // wrong-workflow closure this change removes.
+  const legacy = { body: "<!-- main-red-notification -->\n<!-- main-red-run:50 -->", state: "open", labels: [{ name: "main-red" }] };
+
+  assert.equal(readMainRedWorkflowIdentity(legacy), null);
+  assert.deepEqual(selectWorkflowMainRedIssues([legacy], REWRITE_CI.id), []);
+  assert.deepEqual(selectWorkflowMainRedIssues([legacy], NIGHTLY.id), []);
+});
+
+test("identity survives a rename and does not collide across similar names", () => {
+  assert.equal(mainRedWorkflowIdentity(111), mainRedWorkflowIdentity(111));
+  assert.notEqual(mainRedWorkflowIdentity(111), mainRedWorkflowIdentity(222));
+  // Two display names that would slugify to the same string still have distinct identities.
+  const renamed = advisoryBody({ workflow: { id: 111, name: "rewrite ci" }, runId: 42, headSha: "abc123" });
+  const original = advisoryBody({ workflow: REWRITE_CI, runId: 42, headSha: "abc123" });
+  assert.equal(readMainRedWorkflowIdentity({ body: renamed }), readMainRedWorkflowIdentity({ body: original }));
+});
+
+test("a hostile identity cannot terminate the marker it is embedded in", () => {
+  const hostile = mainRedWorkflowMarker("222 --> <!-- main-red-workflow:111");
+  assert.equal(hostile.match(/-->/gu)?.length, 1);
+  assert.notEqual(readMainRedWorkflowIdentity({ body: hostile }), "111");
 });
 
 test("legacy notification issues without a run marker remain eligible for recovery", () => {
@@ -103,10 +170,33 @@ test("open notification selection excludes pull requests, closed issues, and oth
   assert.deepEqual(issues.map((issue) => issue.number), [1]);
 });
 
-test("recovery comment identifies the successful run and head SHA", () => {
+test("workflow selection keeps only the advisory issue that workflow owns", () => {
+  const issues = [
+    { number: 1, state: "open", labels: [{ name: "main-red" }], body: mainRedWorkflowMarker(REWRITE_CI.id) },
+    { number: 2, state: "open", labels: [{ name: "main-red" }], body: mainRedWorkflowMarker(NIGHTLY.id) },
+    { number: 3, state: "open", labels: [{ name: "main-red" }], body: "<!-- main-red-notification -->" }
+  ];
+
+  assert.deepEqual(selectWorkflowMainRedIssues(issues, NIGHTLY.id).map((issue) => issue.number), [2]);
+  assert.deepEqual(selectWorkflowMainRedIssues(issues, REWRITE_CI.id).map((issue) => issue.number), [1]);
+});
+
+test("recovery comment identifies the workflow, successful run, and head SHA", () => {
   assert.equal(
-    buildMainRedRecoveryComment({ runUrl: "https://github.com/example/repo/actions/runs/43", headSha: "def456" }),
+    buildMainRedRecoveryComment({
+      workflowName: "rewrite-ci",
+      runUrl: "https://github.com/example/repo/actions/runs/43",
+      headSha: "def456"
+    }),
     "rewrite-ci is green again on main for `def456`: https://github.com/example/repo/actions/runs/43. Closing this advisory issue."
+  );
+  assert.match(
+    buildMainRedRecoveryComment({
+      workflowName: "nightly-integration",
+      runUrl: "https://github.com/example/repo/actions/runs/45",
+      headSha: "def456"
+    }),
+    /^nightly-integration is green again/u
   );
 });
 
@@ -136,40 +226,115 @@ test("workflow failure path creates the locally tested issue content", async () 
   await harness.run();
 
   assert.equal(harness.calls.creates.length, 1);
-  assert.equal(harness.calls.creates[0].title, mainRedIssueTitle);
+  assert.equal(harness.calls.creates[0].title, mainRedIssueTitle("rewrite-ci"));
   assert.deepEqual(harness.calls.creates[0].labels, [mainRedLabel]);
-  assert.equal(harness.calls.creates[0].body, buildMainRedIssueBody({
+  assert.equal(harness.calls.creates[0].body, advisoryBody({
+    workflow: REWRITE_CI,
     runId: 42,
-    runUrl: "https://github.com/example/repo/actions/runs/42",
     headSha: "abc123",
     failedJobs: ["full-check (24)"]
   }));
 });
 
-test("nightly-integration failure follows the same main-red issue path", async () => {
+test("nightly-integration failure opens an advisory issue under its own name and identity", async () => {
   const harness = workflowHarness({
     conclusion: "failure",
     runId: 44,
     headSha: "nightly123",
-    workflowName: "nightly-integration",
+    workflow: NIGHTLY,
     jobs: [{ name: "production-authority-perf-matrix", conclusion: "failure" }]
   });
   await harness.run();
 
   assert.equal(harness.calls.creates.length, 1);
-  assert.equal(harness.calls.creates[0].title, mainRedIssueTitle);
-  assert.deepEqual(harness.calls.creates[0].labels, [mainRedLabel]);
-  assert.match(harness.calls.creates[0].body, /production-authority-perf-matrix/u);
-  assert.match(harness.calls.creates[0].body, /actions\/runs\/44/u);
+  assert.equal(harness.calls.creates[0].title, mainRedIssueTitle("nightly-integration"));
+  assert.equal(harness.calls.creates[0].body, advisoryBody({
+    workflow: NIGHTLY,
+    runId: 44,
+    headSha: "nightly123",
+    failedJobs: ["production-authority-perf-matrix"]
+  }));
+});
+
+test("the workflow embeds its identity as the workflow id, not the display name", async () => {
+  const harness = workflowHarness({
+    conclusion: "failure",
+    runId: 46,
+    headSha: "abc123",
+    workflow: { id: 333, name: "rewrite ci" },
+    jobs: [{ name: "some-job", conclusion: "failure" }]
+  });
+  await harness.run();
+
+  assert.equal(readMainRedWorkflowIdentity({ body: harness.calls.creates[0].body }), "333");
+});
+
+test("the workflow's own sanitiser keeps a hostile identity inside one marker", async () => {
+  const harness = workflowHarness({
+    conclusion: "failure",
+    runId: 46,
+    headSha: "abc123",
+    workflow: { id: "222 --> <!-- main-red-workflow:111", name: "hostile" },
+    jobs: [{ name: "some-job", conclusion: "failure" }]
+  });
+  await harness.run();
+
+  const identity = readMainRedWorkflowIdentity({ body: harness.calls.creates[0].body });
+  assert.notEqual(identity, "111", "a hostile identity impersonated another workflow");
+  assert.equal(identity, mainRedWorkflowIdentity("222 --> <!-- main-red-workflow:111"));
+});
+
+test("a green run does not retire another workflow's advisory issue", async () => {
+  const harness = workflowHarness({
+    conclusion: "success",
+    runId: 45,
+    headSha: "def456",
+    workflow: REWRITE_CI,
+    openIssues: [{ number: 42, body: advisoryBody({ workflow: NIGHTLY, runId: 44, headSha: "nightly123" }) }]
+  });
+  await harness.run();
+
+  assert.deepEqual(harness.calls.updates, [], "a green rewrite-ci run closed nightly-integration's advisory issue");
+  assert.deepEqual(harness.calls.comments, []);
+});
+
+test("neither workflow retires an advisory issue that declares no owner", async () => {
+  const legacyIssue = { number: 7, body: "<!-- main-red-notification -->\n<!-- main-red-run:50 -->" };
+
+  for (const workflow of [REWRITE_CI, NIGHTLY]) {
+    const harness = workflowHarness({
+      conclusion: "success",
+      runId: 60,
+      headSha: "def456",
+      workflow,
+      openIssues: [legacyIssue]
+    });
+    await harness.run();
+    assert.deepEqual(
+      harness.calls.updates,
+      [],
+      `${workflow.name} retired a pre-identity advisory issue whose owner is unknown`
+    );
+  }
+});
+
+test("a failing run opens its own advisory issue instead of overwriting another workflow's", async () => {
+  const harness = workflowHarness({
+    conclusion: "failure",
+    runId: 44,
+    headSha: "nightly123",
+    workflow: NIGHTLY,
+    openIssues: [{ number: 9, body: advisoryBody({ workflow: REWRITE_CI, runId: 40, headSha: "abc123" }) }],
+    jobs: [{ name: "production-authority-perf-matrix", conclusion: "failure" }]
+  });
+  await harness.run();
+
+  assert.equal(harness.calls.creates.length, 1);
+  assert.deepEqual(harness.calls.updates, [], "nightly-integration overwrote rewrite-ci's advisory issue");
 });
 
 test("workflow does not duplicate the same run and ignores stale completions", async () => {
-  const currentBody = buildMainRedIssueBody({
-    runId: 42,
-    runUrl: "https://github.com/example/repo/actions/runs/42",
-    headSha: "abc123",
-    failedJobs: ["full-check (24)"]
-  });
+  const currentBody = advisoryBody({ workflow: REWRITE_CI, runId: 42, headSha: "abc123", failedJobs: ["full-check (24)"] });
   const duplicate = workflowHarness({
     conclusion: "failure",
     runId: 42,
@@ -192,13 +357,26 @@ test("workflow does not duplicate the same run and ignores stale completions", a
   assert.deepEqual(staleSuccess.calls.updates, []);
 });
 
-test("workflow closes an open advisory issue after a newer green run", async () => {
-  const failureBody = buildMainRedIssueBody({
+test("a re-run of the same failed run closes the advisory issue it opened", async () => {
+  // GitHub keeps the run id across a re-run, so an equal id must not be treated as stale.
+  const failureBody = advisoryBody({ workflow: REWRITE_CI, runId: 42, headSha: "abc123", failedJobs: ["full-check (24)"] });
+  const harness = workflowHarness({
+    conclusion: "success",
     runId: 42,
-    runUrl: "https://github.com/example/repo/actions/runs/42",
     headSha: "abc123",
-    failedJobs: ["full-check (24)"]
+    openIssues: [{ number: 1, body: failureBody }]
   });
+  await harness.run();
+
+  assert.deepEqual(
+    harness.calls.updates.map((update) => update.state),
+    ["closed"],
+    "a re-run's equal run id was treated as stale, so the advisory issue was never retired"
+  );
+});
+
+test("workflow closes an open advisory issue after a newer green run", async () => {
+  const failureBody = advisoryBody({ workflow: REWRITE_CI, runId: 42, headSha: "abc123", failedJobs: ["full-check (24)"] });
   const harness = workflowHarness({
     conclusion: "success",
     runId: 43,
@@ -208,6 +386,7 @@ test("workflow closes an open advisory issue after a newer green run", async () 
   await harness.run();
 
   assert.equal(harness.calls.comments[0].body, buildMainRedRecoveryComment({
+    workflowName: "rewrite-ci",
     runUrl: "https://github.com/example/repo/actions/runs/43",
     headSha: "def456"
   }));
@@ -218,4 +397,19 @@ test("workflow closes an open advisory issue after a newer green run", async () 
     state: "closed",
     state_reason: "completed"
   });
+});
+
+test("each watched workflow recovers only its own advisory issue", async () => {
+  const issues = [
+    { number: 1, body: advisoryBody({ workflow: REWRITE_CI, runId: 40, headSha: "abc123" }) },
+    { number: 2, body: advisoryBody({ workflow: NIGHTLY, runId: 41, headSha: "nightly123" }) }
+  ];
+
+  const rewriteGreen = workflowHarness({ conclusion: "success", runId: 50, headSha: "def456", workflow: REWRITE_CI, openIssues: issues });
+  await rewriteGreen.run();
+  assert.deepEqual(rewriteGreen.calls.updates.map((update) => update.issue_number), [1]);
+
+  const nightlyGreen = workflowHarness({ conclusion: "success", runId: 51, headSha: "def456", workflow: NIGHTLY, openIssues: issues });
+  await nightlyGreen.run();
+  assert.deepEqual(nightlyGreen.calls.updates.map((update) => update.issue_number), [2]);
 });


### PR DESCRIPTION
# English

## Summary

`main-red-notify` watches two workflows but gave them one shared advisory issue, one shared label, and one hardcoded title naming `rewrite-ci`. A green `rewrite-ci` run therefore closed the red that `nightly-integration` had opened.

Issue #1186 is the record: its body carries `main-red-run:30715830796` and `Failed jobs: production-authority-perf-matrix` — both `nightly-integration` — while its title says `rewrite-ci is red on main`, and its closing comment cites a `rewrite-ci` run. Issue #1193, open right now, is the same thing happening again: opened three minutes after the `nightly-integration` run that failed on 2026-08-02, titled for `rewrite-ci`.

Meanwhile `nightly-integration`'s `production-authority-perf-matrix` job has failed on every scheduled run since 2026-07-21. That tier was red for two weeks not because nobody looked, but because the advisory issue named the wrong workflow and was silenced by an unrelated workflow's green within the hour.

Each watched workflow now owns its advisory issue identity and lifecycle.

## What Changed

- `tools/main-red-notify.mjs`: the issue body gains a `<!-- main-red-workflow:<id> -->` identity marker and a `- Workflow:` line; `mainRedIssueTitle` becomes a function of the workflow name; the recovery comment names the workflow; new `selectWorkflowMainRedIssues` restricts a run to the issue it owns.
- `.github/workflows/main-red-notify.yml`: the inline `github-script` body is updated to match, so a success closes only same-workflow issues and a failure never reuses another workflow's issue.
- `tools/main-red-notify.test.mjs`: assertions that pinned the old shared-issue behaviour are replaced, and every behavioural case now drives the extracted inline script rather than the module alone.

**Identity is the numeric `workflow_id`, not the display name.** A name is editable — renaming a workflow would strand its open issue forever, because the renamed workflow's green would no longer match the old marker. A name is also lossy to slugify: `rewrite-ci` and `rewrite ci` would produce the same slug and close each other's issues. The name is used for the title and body text only.

**An issue that declares no owner is owned by nobody.** Advisory issues opened before this change carry no identity marker, and attributing them to `rewrite-ci` would be a guess — the shared issue carried a `rewrite-ci` title regardless of which workflow had actually failed. #1193 is exactly such an issue and it belongs to `nightly-integration`. Guessing `rewrite-ci` would make the very next green `rewrite-ci` run close it: the wrong-workflow closure this change exists to remove, performed one final time. Unowned issues are therefore left for a human, which is visible, rather than closed by the wrong workflow, which is not. The one live instance is handled in the merge steps below.

### Why the logic is duplicated, and why that stays

`tools/main-red-notify.mjs` is not imported by the workflow. The workflow is `workflow_run`-triggered with `issues: write`, and `tools/main-red-notify.test.mjs` asserts it never uses `actions/checkout` — a deliberate boundary, since checking out and executing repository code inside a write-privileged `workflow_run` job widens the attack surface. The logic therefore has to stay inline, and the module exists as a tested oracle that the test suite pins the inline script against.

Removing the duplication would mean deleting that boundary, so this change does not attempt it.

## Task And Scope

- Harness task: `task_01KZ20YRQ6N5KDYPEKKM3G8H5A`
- Branch: `codex/main-red-notify`
- Public scope: `.github/workflows/main-red-notify.yml`, `tools/main-red-notify.mjs`, `tools/main-red-notify.test.mjs`
- Private planning/evidence updated: yes
- Out of scope: `nightly-integration.yml` cron and job layout; required checks; branch protection; the diagnosis of nightly's three failures, which belongs to `task_01KZ2047XDG8REWM61Q3N6T5Y9` and is independent of this change

## Version Impact

- Version: no version change because this only touches a CI advisory workflow, its oracle module, and its tests
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `.github/workflows/main-red-notify.yml`. The two `tools/` files are ordinary source and tests, not a gate authority surface.
- Authority: decision `dec_01KZ20MPDZH490AXKQX3VC1NEG` (accepted), task `task_01KZ20YRQ6N5KDYPEKKM3G8H5A`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

Assertions in `tools/main-red-notify.test.mjs` that pinned the shared-issue behaviour were replaced. They encoded the behaviour `dec_01KZ20MPDZH490AXKQX3VC1NEG` judges to be the defect, so replacing them is the mechanism substitution the decision authorises, not an edit made to turn a red test green. The replacements assert the new contract rather than deleting coverage.

## Verification

- Base `origin/main` SHA: `3797631a2bb66038990ac359a42ebfbb29ab194f`
- Branch merge-base with `origin/main`: `3797631a2bb66038990ac359a42ebfbb29ab194f`
- Last `git fetch origin` time: 2026-08-03, before branching
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/main-red-notify`
- Private evidence commit/path: `harness/tasks/task_01KZ20YRQ6N5KDYPEKKM3G8H5A-plt-steady-ci-c4-main-red-notify-workflow-advisory-issue/task_plan.md`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: see the checks on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` (Local check passed in 58.5s; 27 complete manifest gates green)
- [x] Targeted tests for the change surface, named with their counts: `tools/main-red-notify.test.mjs` — 21 tests, 21 pass, 0 fail
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: real GitHub behaviour cannot be exercised before merge. The observation the decision requires is scheduled in the merge steps below rather than claimed here.

### Mutation controls

A passing suite does not show the suite can fail. An adversarial review found that an earlier version of these tests stayed green while the deployed inline script was broken three different ways, because those properties were only asserted against the module. Each mutation is applied to the inline script alone and re-run:

| Mutation applied to the inline script | Result |
| --- | --- |
| Remove the identity sanitiser | 1 test fails |
| Make an unowned issue fall back to the current workflow | 1 test fails |
| Loosen staleness from `>` to `>=` | 1 test fails |
| Take identity from the mutable display name instead of `workflow_id` | 8 tests fail |
| No mutation | 21 pass, 0 fail |

The staleness case is not academic: GitHub keeps the same run id across a re-run, so `>=` would leave the advisory issue open forever after "run N failed, run N re-run passed".

### Merge steps

1. Merge this PR. This triggers `rewrite-ci` on main.
2. Close #1193 with a comment pointing at this change. It is a pre-identity issue whose real owner is `nightly-integration`, and under this change no workflow will retire it.
3. Manually dispatch `nightly-integration`. It has failed on every scheduled run since 2026-07-21, so it will open a fresh advisory issue — which must be titled `[CI] nightly-integration is red on main` and carry `<!-- main-red-workflow:316532515 -->`.
4. On the next green `rewrite-ci` run on main, that issue must still be open. This is the live observation `dec_01KZ20MPDZH490AXKQX3VC1NEG` requires; the task does not close until it is recorded.

## Review Evidence

- Self-review: yes — including reading the pre-existing test file before changing behaviour, which surfaced the deliberate no-checkout boundary and the oracle/parity structure
- Reviewer subagent: Codex adversarial review. It raised three findings, all of which were confirmed and fixed in this PR: identity must be the stable `workflow_id` rather than the mutable name (P1); unowned legacy issues must not be attributed by guesswork (P1, and #1193 proved it live); and the test suite did not actually deliver the "changing one side fails" property it claimed (P2). The mutation table above is the response to the third.
- Human review: pending
- Blocking findings: none outstanding

## Residual Risk

- The live behaviour is unverified until the merge steps above are carried out. Until then this change is argued from local execution of the same script body, not from GitHub.
- Any advisory issue that predates this change, other than #1193, would be retired by nobody. `main-red` currently has exactly one open issue, so #1193 is the only instance; if another appears between now and merge it needs the same manual handling.
- The inline script and its oracle module remain two copies of the same logic, held together by tests rather than by construction. That is the accepted cost of the no-checkout boundary; if the boundary is ever revisited, the duplication should be revisited with it.
- The suite extracts the inline script by matching `script: |` and a fixed indent. A change to that block's shape breaks extraction — it fails closed with an assertion rather than silently passing, but it does need updating with any such change.
- This change does not make `nightly-integration` green. It makes the tier's redness reportable under its own name; the three failures themselves are diagnosed separately.

## References

- Task: `task_01KZ20YRQ6N5KDYPEKKM3G8H5A`
- Evidence: `task_01KZ2047XDG8REWM61Q3N6T5Y9` (two facts recording the nightly failure history and the notifier defect)
- Review: decision `dec_01KZ20MPDZH490AXKQX3VC1NEG`

---

# 中文

## 概要

`main-red-notify` 监听两个 workflow,却让它们共用同一个 advisory issue、同一个 label、同一个写死的标题(标题里写的是 `rewrite-ci`)。于是一次 `rewrite-ci` 的绿,会关掉 `nightly-integration` 报的红。

issue #1186 是记录:它的 body 里写着 `main-red-run:30715830796` 和 `Failed jobs: production-authority-perf-matrix`,两者都属于 `nightly-integration`;标题却是 `rewrite-ci is red on main`;关闭评论引用的是一次 `rewrite-ci` 的 run。此刻仍然 open 的 issue #1193 是同一件事正在重演:它开于 2026-08-02 那次 `nightly-integration` 失败之后三分钟,标题写的是 `rewrite-ci`。

同期,`nightly-integration` 的 `production-authority-perf-matrix` job 自 2026-07-21 起每一次定时运行都失败。那个 tier 红了两周,不是因为没人看,而是因为 advisory issue 写着别人的名字,并且在一小时内就被一个无关 workflow 的绿灯消音了。

现在每个被监听的 workflow 拥有自己的 advisory issue 身份与生命周期。

## 改动内容

- `tools/main-red-notify.mjs`:issue body 增加 `<!-- main-red-workflow:<id> -->` 身份 marker 与 `- Workflow:` 行;`mainRedIssueTitle` 由常量改为按 workflow 名生成的函数;恢复评论写明 workflow 名;新增 `selectWorkflowMainRedIssues`,把一次运行限制在它自己拥有的 issue 上。
- `.github/workflows/main-red-notify.yml`:内联 `github-script` 同步更新,使一次成功只关闭同 workflow 的 issue,一次失败也不再复用另一个 workflow 的 issue。
- `tools/main-red-notify.test.mjs`:替换锁定旧共用行为的断言,并且每一条行为用例现在都驱动抽取出来的内联脚本,而不只是模块。

**身份用的是数字 `workflow_id`,不是显示名。** 名字可改 —— workflow 一旦改名,它的 open issue 会永久悬置,因为改名后的绿灯不再匹配旧 marker。名字 slug 化也是有损的:`rewrite-ci` 与 `rewrite ci` 会得到同一个 slug,互相关闭对方的 issue。名字只用于标题与正文文本。

**不声明归属的 issue 不属于任何人。** 本次改动之前开出的 advisory issue 不带身份 marker,把它们归给 `rewrite-ci` 是猜 —— 那个共用 issue 无论谁失败,标题写的都是 `rewrite-ci`。#1193 正是这样一个 issue,而它真正属于 `nightly-integration`。猜成 `rewrite-ci`,就会让下一次 `rewrite-ci` 的绿把它关掉:本改动要消灭的那次错误关闭,再执行最后一遍。因此无归属的 issue 留给人处理 —— 这是可见的;而不是被错误的一方关掉 —— 那是不可见的。现存的唯一一例在下面的合并步骤里处理。

### 为什么逻辑是两份,以及为什么保持两份

`tools/main-red-notify.mjs` 并不被 workflow import。该 workflow 由 `workflow_run` 触发且持有 `issues: write`,而 `tools/main-red-notify.test.mjs` 断言它从不使用 `actions/checkout` —— 这是一条有意的边界:在一个有写权限的 `workflow_run` job 里 checkout 并执行仓库代码会扩大攻击面。所以逻辑只能内联,模块的角色是可测的 oracle,由测试把内联脚本钉在它上面。

消除这份重复就意味着拆掉那条边界,因此本次改动不做这件事。

## 任务与范围

- Harness 任务:`task_01KZ20YRQ6N5KDYPEKKM3G8H5A`
- 分支:`codex/main-red-notify`
- 公开范围:`.github/workflows/main-red-notify.yml`、`tools/main-red-notify.mjs`、`tools/main-red-notify.test.mjs`
- 私有计划 / 证据是否已更新:yes
- 范围外:`nightly-integration.yml` 的 cron 与 job 拆分;required checks;分支保护;nightly 三个失败的性质判定(归 `task_01KZ2047XDG8REWM61Q3N6T5Y9`,与本改动相互独立)

## 版本影响

- 版本:不改版本,原因是本次只触碰一个 CI advisory workflow、它的 oracle 模块与测试
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:yes
- protected surface 范围:`.github/workflows/main-red-notify.yml`。两个 `tools/` 文件是普通源码与测试,不属于门禁权威面。
- 依据:decision `dec_01KZ20MPDZH490AXKQX3VC1NEG`(已 accept),task `task_01KZ20YRQ6N5KDYPEKKM3G8H5A`
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

`tools/main-red-notify.test.mjs` 中锁定旧共用行为的断言被替换。它们编码的正是 `dec_01KZ20MPDZH490AXKQX3VC1NEG` 判定为缺陷的行为,所以替换它们是该决策授权的机制替换,不是为了让红测试变绿而改测试。替换后的断言写的是新契约而非删除覆盖。

## 验证

- `origin/main` 基准 SHA:`3797631a2bb66038990ac359a42ebfbb29ab194f`
- 当前分支与 `origin/main` 的 merge-base:`3797631a2bb66038990ac359a42ebfbb29ab194f`
- 最近一次 `git fetch origin` 时间:2026-08-03,建分支前
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...codex/main-red-notify`
- 私有证据 commit/path:`harness/tasks/task_01KZ20YRQ6N5KDYPEKKM3G8H5A-plt-steady-ci-c4-main-red-notify-workflow-advisory-issue/task_plan.md`
- Reviewer 证据路径:同一任务包
- GitHub Actions `rewrite-ci` run URL:见本 PR 的 checks
- [x] `git diff --check`
- [x] `npm run check:stop-point`(Local check passed in 58.5s; 27 complete manifest gates green)
- [x] 改动面的定向测试,写明测试名与通过数:`tools/main-red-notify.test.mjs` —— 21 tests,21 pass,0 fail
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- 未跑项及原因:真实 GitHub 行为在合并前无法验证。决策要求的那次观察排在下面的合并步骤里,不在此处冒充已完成。

### Mutation 对照

测试全绿并不能说明这套测试会红。一次对抗复核发现:这些测试的早期版本在**部署出去的那份内联脚本**被三种方式破坏的情况下依然全绿,因为那些性质只对模块做了断言。下表每一行的 mutation 都**只**施加于内联脚本,然后重跑:

| 施加于内联脚本的 mutation | 结果 |
| --- | --- |
| 移除身份 sanitiser | 1 条测试红 |
| 让无归属 issue 回退给当前 workflow | 1 条测试红 |
| 把 staleness 从 `>` 放宽成 `>=` | 1 条测试红 |
| 用可变的显示名而非 `workflow_id` 作身份 | 8 条测试红 |
| 不施加 mutation | 21 pass,0 fail |

staleness 那条不是学术问题:GitHub 在重跑时保留同一个 run id,所以 `>=` 会让 advisory issue 在「run N 失败、run N 重跑成功」之后永远关不掉。

### 合并步骤

1. 合并本 PR,这会在 main 上触发一次 `rewrite-ci`。
2. 关闭 #1193 并留一条指向本改动的评论。它是身份机制之前的 issue,真正的归属者是 `nightly-integration`,而本改动之后不会有任何 workflow 去关闭它。
3. 手动 dispatch 一次 `nightly-integration`。它自 2026-07-21 起每次定时运行都失败,所以会开出一个新的 advisory issue —— 该 issue 必须以 `[CI] nightly-integration is red on main` 为标题,并带有 `<!-- main-red-workflow:316532515 -->`。
4. 在 main 上的下一次 `rewrite-ci` 变绿之后,那个 issue 必须仍然 open。这就是 `dec_01KZ20MPDZH490AXKQX3VC1NEG` 要求的实地观察;记录到它之前,任务不收口。

## 审查证据

- 自查:yes —— 包括在改行为之前先读完既有测试文件,正是这一步暴露出那条有意的 no-checkout 边界与 oracle/parity 结构
- Reviewer subagent:Codex 对抗复核。提出三条 findings,全部经核实成立并已在本 PR 修复:身份必须用稳定的 `workflow_id` 而非可变的名字(P1);无归属的 legacy issue 不得靠猜来归属(P1,而 #1193 当场证实了这一点);以及这套测试并没有真正兑现它声称的「只改一边就会红」(P2)。上面的 mutation 表就是对第三条的回应。
- 人工审查:待
- 阻塞发现:无未决项

## 残余风险

- 在上述合并步骤执行之前,实地行为未经验证。在那之前,本改动的依据是同一段脚本体的本地执行,不是 GitHub 上的观察。
- 本改动之前开出的 advisory issue,除 #1193 外若还有,将没有任何一方去关闭它。`main-red` 当前恰好只有一个 open issue,所以 #1193 是唯一实例;若在合并前又出现一个,需要同样的人工处理。
- 内联脚本与 oracle 模块仍是同一逻辑的两份拷贝,靠测试而非构造方式绑在一起。这是 no-checkout 边界的既定代价;哪天要重新审视那条边界,这份重复应当一并重新审视。
- 测试通过匹配 `script: |` 与固定缩进来抽取内联脚本。该块形状变化会破坏抽取 —— 它是 fail-closed 的断言失败而非静默通过,但确实需要随之更新。
- 本改动不会让 `nightly-integration` 变绿。它让这个 tier 的红能以自己的名字被报出来;三个失败本身另行诊断。

## 关联材料

- 任务:`task_01KZ20YRQ6N5KDYPEKKM3G8H5A`
- 证据:`task_01KZ2047XDG8REWM61Q3N6T5Y9`(两条 fact 记录 nightly 失败史与通知机制缺陷)
- 审查:decision `dec_01KZ20MPDZH490AXKQX3VC1NEG`

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
