### PR TITLE
fix(daemon): settle live replacements before rollback

### DIFF
--- a/packages/cli/src/commands/daemon/control-replacement.ts
+++ b/packages/cli/src/commands/daemon/control-replacement.ts
@@ -16,9 +16,16 @@ export interface DaemonControlLifecycle {
   readonly probeGenerationStatus?: (target: LocalDaemonTarget) => Promise<Record<string, unknown> | undefined>;
   readonly probeStatus: (
     target: LocalDaemonTarget,
-    capability?: { readonly includeGenerationAxes: true }
+    capability?: { readonly includeGenerationAxes: true },
+    requestTimeoutMs?: number
   ) => Promise<Record<string, unknown> | undefined>;
+  readonly probeEndpointOwner?: (
+    target: LocalDaemonTarget
+  ) => { readonly pid: number; readonly alive: boolean } | undefined;
   readonly ownerIsAlive: (pid: number) => boolean;
+  readonly isReadinessTimeout?: (error: unknown) => boolean;
+  readonly readinessTimeoutPid?: (error: unknown) => number | undefined;
+  readonly reportProgress?: (message: string) => void;
   readonly prepareReplacement?: (target: LocalDaemonTarget) => Promise<DaemonLaunchConfiguration>;
   readonly startReplacement: (
     target: LocalDaemonTarget,
@@ -52,6 +59,7 @@ interface CompleteDaemonReplacementInput {
   readonly operationId: unknown;
   readonly handoffTimeoutMs: number;
   readonly replacementTimeoutMs: number;
+  readonly replacementSettlingTimeoutMs: number;
   readonly kind: "restart" | "refresh" | "upgrade";
   readonly method: "admin.daemon.restart" | "admin.daemon.refresh";
   readonly launchConfiguration: DaemonLaunchConfiguration;
@@ -126,7 +134,14 @@ async function attemptDaemonReplacement(
       input.expectedGeneration ? { includeGenerationAxes: true } : undefined
     );
   } catch (error) {
-    return await failOrRollback(input, error, beforePid, operationId, "replacement-start");
+    if (!input.lifecycle.isReadinessTimeout?.(error)) {
+      return await failOrRollback(input, error, beforePid, operationId, "replacement-start");
+    }
+    try {
+      replacement = await waitForTimedOutReplacement(input, error, beforePid);
+    } catch (settlingError) {
+      return await failOrRollback(input, settlingError, beforePid, operationId, "replacement-start");
+    }
   }
   try {
     const replacementLifecycle = normalizeDaemonLifecycleStatus(replacement);
@@ -140,6 +155,84 @@ async function attemptDaemonReplacement(
   } catch (error) {
     return await failOrRollback(input, error, beforePid, operationId, "replacement-validation");
   }
+}
+
+async function waitForTimedOutReplacement(
+  input: CompleteDaemonReplacementInput,
+  readinessTimeout: unknown,
+  beforePid: number
+): Promise<Record<string, unknown>> {
+  const initialOwner = input.lifecycle.probeEndpointOwner?.(input.lifecycle.target);
+  const spawnedPid = input.lifecycle.readinessTimeoutPid?.(readinessTimeout);
+  const replacementPid = spawnedPid
+    ?? (initialOwner?.alive === true && initialOwner.pid !== beforePid ? initialOwner.pid : undefined);
+  if (replacementPid === undefined || !input.lifecycle.ownerIsAlive(replacementPid)) {
+    throw readinessTimeout;
+  }
+  if (initialOwner && initialOwner.pid !== replacementPid) {
+    throw new Error(
+      `replacement readiness deadline elapsed, but endpoint owner pid ${initialOwner.pid} did not match launched pid ${replacementPid}`
+    );
+  }
+
+  input.lifecycle.reportProgress?.(
+    `Replacement readiness deadline elapsed after ${input.replacementTimeoutMs}ms; pid ${replacementPid} is alive`
+    + `${initialOwner?.pid === replacementPid ? " and owns the endpoint" : ""}, and is still starting. `
+    + `Continuing bounded observation for up to ${input.replacementSettlingTimeoutMs}ms.`
+  );
+
+  const deadline = Date.now() + input.replacementSettlingTimeoutMs;
+  while (Date.now() < deadline) {
+    const remainingMs = Math.max(1, deadline - Date.now());
+    const status = await input.lifecycle.probeStatus(
+      input.lifecycle.target,
+      input.expectedGeneration ? { includeGenerationAxes: true } : undefined,
+      Math.min(1_000, remainingMs)
+    );
+    const observedLifecycle = status ? normalizeDaemonLifecycleStatus(status) : undefined;
+    if (status && observedLifecycle) {
+      if (observedLifecycle.pid !== replacementPid) {
+        throw new Error(
+          `replacement readiness observation reached pid ${observedLifecycle.pid}, expected launched pid ${replacementPid}`
+        );
+      }
+      return status;
+    }
+    if (!input.lifecycle.ownerIsAlive(replacementPid)) throw readinessTimeout;
+    const owner = input.lifecycle.probeEndpointOwner?.(input.lifecycle.target);
+    if (owner && owner.pid !== replacementPid) {
+      throw new Error(
+        `replacement readiness observation found endpoint owner pid ${owner.pid}, expected launched pid ${replacementPid}`
+      );
+    }
+    const waitMs = Math.min(100, Math.max(0, deadline - Date.now()));
+    if (waitMs > 0) await input.lifecycle.wait(waitMs);
+  }
+
+  if (!input.lifecycle.ownerIsAlive(replacementPid)) throw readinessTimeout;
+  if (!input.lifecycle.stopReplacement) {
+    throw new Error(
+      `replacement pid ${replacementPid} remained alive but unreachable after the additional `
+      + `${input.replacementSettlingTimeoutMs}ms settling limit; cleanup unavailable, so it may still be starting`
+    );
+  }
+  try {
+    await input.lifecycle.stopReplacement(
+      input.lifecycle.target,
+      replacementPid,
+      input.replacementTimeoutMs
+    );
+  } catch (error) {
+    throw new Error(
+      `replacement pid ${replacementPid} remained alive but unreachable after the additional `
+      + `${input.replacementSettlingTimeoutMs}ms settling limit; cleanup failed and it may still be starting: `
+      + daemonReplacementErrorMessage(error)
+    );
+  }
+  throw new DaemonReplacementEndpointUnownedError(
+    `replacement pid ${replacementPid} exceeded the additional ${input.replacementSettlingTimeoutMs}ms settling limit; `
+    + "the timed-out replacement was stopped and the endpoint remained unowned"
+  );
 }
 
 async function waitForStartedReplacement(

--- a/packages/cli/src/commands/daemon/control.ts
+++ b/packages/cli/src/commands/daemon/control.ts
@@ -1,7 +1,9 @@
 import {
   calculateDaemonArtifactIdentity,
+  DaemonAutostartTimeoutError,
   defaultDaemonAutostartTimeoutMs,
   defaultDaemonJsonRpcRequestTimeoutMs,
+  readDaemonSocketOwner,
   requestLocalDaemonJsonRpcForTarget,
   type JsonObject,
   type LocalDaemonTarget
@@ -67,6 +69,7 @@ export async function runDaemonControl(
   if (kind === "refresh") assertCanonicalRefreshCheckout(input.rootDir);
   const drainTimeoutMs = daemonControlTimeoutMs(input.args);
   const replacementTimeoutMs = daemonReplacementTimeoutMs(input.args);
+  const replacementSettlingTimeoutMs = daemonReplacementSettlingTimeoutMs(input.args);
   const trigger = kind === "restart" ? undefined : daemonRefreshTrigger(input.args);
   const method: DaemonControlRequest["method"] = kind === "restart"
     ? "admin.daemon.restart"
@@ -132,6 +135,7 @@ export async function runDaemonControl(
     operationId: receipt.operationId,
     handoffTimeoutMs: drainTimeoutMs,
     replacementTimeoutMs,
+    replacementSettlingTimeoutMs,
     kind,
     method,
     launchConfiguration,
@@ -213,7 +217,11 @@ function defaultDaemonControlLifecycle(input: DaemonControlCommandInput): Daemon
     target,
     probeGenerationStatus: (candidate) => probeExactDaemonStatus(candidate, { includeGenerationAxes: true }),
     probeStatus: probeExactDaemonStatus,
+    probeEndpointOwner: (candidate) => readDaemonSocketOwner(candidate.socketPath, input.platform ?? process.platform),
     ownerIsAlive: daemonProcessIsAlive,
+    isReadinessTimeout: (error) => error instanceof DaemonAutostartTimeoutError,
+    readinessTimeoutPid: (error) => error instanceof DaemonAutostartTimeoutError ? error.spawnedPid : undefined,
+    reportProgress: (message) => console.error(`[ha] ${message}`),
     prepareReplacement: async (candidate) => {
       let receipt: Record<string, unknown>;
       try {
@@ -263,7 +271,8 @@ function daemonLaunchSpecUpgradeError(target: LocalDaemonTarget): Error {
 
 async function probeExactDaemonStatus(
   target: LocalDaemonTarget,
-  capability?: { readonly includeGenerationAxes: true }
+  capability?: { readonly includeGenerationAxes: true },
+  requestTimeoutMs = defaultDaemonJsonRpcRequestTimeoutMs
 ): Promise<Record<string, unknown> | undefined> {
   try {
     const receipt = await requestLocalDaemonJsonRpc(target.canonicalRoot, "repo.daemon.status", {
@@ -273,7 +282,8 @@ async function probeExactDaemonStatus(
       userRoot: target.userRoot,
       daemonId: target.daemonId,
       socketPath: target.socketPath,
-      allowLegacySocket: false
+      allowLegacySocket: false,
+      requestTimeoutMs
     });
     return statusFromReceipt(receipt) ?? { rpcError: receipt };
   } catch {
@@ -327,8 +337,9 @@ function daemonControlRecoveryGuidance(
 
 function defaultDaemonReplacementStopRuntime(): DaemonReplacementStopRuntime {
   return {
-    probeStatus: probeExactDaemonStatus,
+    probeStatus: (target) => probeExactDaemonStatus(target, undefined, 500),
     statusPid: (status) => normalizeDaemonLifecycleStatus(status)?.pid,
+    endpointOwnerPid: (target) => readDaemonSocketOwner(target.socketPath)?.pid,
     processIsAlive: daemonProcessIsAlive,
     signal: (pid, signal) => process.kill(pid, signal),
     wait: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
@@ -372,9 +383,17 @@ function daemonReplacementTimeoutMs(args: ReadonlyArray<string>): number {
   return daemonTimeoutOption(args, "--replacement-timeout-ms", fallback);
 }
 
+function daemonReplacementSettlingTimeoutMs(args: ReadonlyArray<string>): number {
+  return daemonTimeoutOption(
+    args,
+    "--replacement-settle-timeout-ms",
+    defaultDaemonJsonRpcRequestTimeoutMs
+  );
+}
+
 function daemonTimeoutOption(
   args: ReadonlyArray<string>,
-  option: "--timeout-ms" | "--replacement-timeout-ms",
+  option: "--timeout-ms" | "--replacement-timeout-ms" | "--replacement-settle-timeout-ms",
   fallback: number
 ): number {
   const raw = readOption(args, option) ?? String(fallback);

--- a/packages/cli/src/commands/daemon/help.ts
+++ b/packages/cli/src/commands/daemon/help.ts
@@ -84,6 +84,8 @@ export function renderDaemonHelp(): string {
     "    --timeout-ms <ms>          Set the aggregate queue drain timeout (100-120000).",
     "    --replacement-timeout-ms <ms>",
     "                               Set replacement startup timeout (default: daemon autostart timeout).",
+    "    --replacement-settle-timeout-ms <ms>",
+    "                               Keep observing a live starting replacement after the normal startup timeout (default: 35000).",
     "    --reason <text>            Record the operator or automation reason.",
     "  upgrade [options]            Install a snapshot, drain, switch, start, and verify authority convergence.",
     "  snapshot install [options]   Install an immutable daemon artifact snapshot without switching.",

--- a/packages/cli/src/commands/daemon/replacement-cleanup.ts
+++ b/packages/cli/src/commands/daemon/replacement-cleanup.ts
@@ -3,6 +3,7 @@ import type { LocalDaemonTarget } from "@harness-anything/daemon";
 export interface DaemonReplacementStopRuntime {
   readonly probeStatus: (target: LocalDaemonTarget) => Promise<Record<string, unknown> | undefined>;
   readonly statusPid: (status: Record<string, unknown>) => number | undefined;
+  readonly endpointOwnerPid?: (target: LocalDaemonTarget) => number | undefined;
   readonly processIsAlive: (pid: number) => boolean;
   readonly signal: (pid: number, signal: NodeJS.Signals) => void;
   readonly wait: (ms: number) => Promise<void>;
@@ -60,9 +61,14 @@ async function targetEndpointIsOwnedBy(
   const status = await runtime.probeStatus(target);
   const observedPid = status ? runtime.statusPid(status) : undefined;
   if (observedPid === pid) return true;
+  const endpointOwnerPid = runtime.endpointOwnerPid?.(target);
+  if (endpointOwnerPid === pid) return true;
   if (!runtime.processIsAlive(pid)) return false;
   if (observedPid !== undefined) {
     throw new Error(`target endpoint reports pid ${observedPid}; refusing to signal pid ${pid}`);
+  }
+  if (endpointOwnerPid !== undefined) {
+    throw new Error(`target endpoint owner record reports pid ${endpointOwnerPid}; refusing to signal pid ${pid}`);
   }
   throw new Error(`target endpoint does not prove ownership by pid ${pid}; refusing to signal it`);
 }
@@ -96,6 +102,10 @@ async function verifyEndpointRemainsUnowned(
           ? "target endpoint remained reachable with an unrecognized daemon status"
           : `target endpoint became reachable again with pid ${observedPid}`
       );
+    }
+    const endpointOwnerPid = runtime.endpointOwnerPid?.(target);
+    if (endpointOwnerPid !== undefined && runtime.processIsAlive(endpointOwnerPid)) {
+      throw new Error(`target endpoint remained owned by live pid ${endpointOwnerPid}`);
     }
     if (attempt + 1 < attempts) await runtime.wait(pollIntervalMs);
   }

--- a/packages/cli/test/daemon-control-dispatcher.test.ts
+++ b/packages/cli/test/daemon-control-dispatcher.test.ts
@@ -615,6 +615,7 @@ test("daemon help exposes logs, restart, refresh, and refresh trigger selection"
   assert.match(help, /restart/u);
   assert.match(help, /refresh/u);
   assert.match(help, /--replacement-timeout-ms <ms>/u);
+  assert.match(help, /--replacement-settle-timeout-ms <ms>/u);
   assert.match(help, /explicit\|post-merge\|dist-watcher/u);
   assert.match(help, /snapshot install/u);
   assert.match(help, /upgrade/u);

--- a/packages/cli/test/daemon-control-recovery.test.ts
+++ b/packages/cli/test/daemon-control-recovery.test.ts
@@ -1,6 +1,7 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
+import { DaemonAutostartTimeoutError } from "@harness-anything/daemon";
 import {
   runDaemonControl,
   type DaemonControlLifecycle
@@ -64,6 +65,80 @@ test("restart restores service when the released endpoint replacement fails to s
     assert.match(error.message, /service restored and reachable/u);
     return true;
   });
+  assert.equal(replacementStarts, 2);
+});
+
+test("restart adopts a live replacement that becomes ready after the normal startup budget", async () => {
+  const progress: string[] = [];
+  let probes = 0;
+  let replacementStarts = 0;
+  const lifecycle: DaemonControlLifecycle = {
+    target,
+    probeStatus: async () => {
+      probes += 1;
+      return probes === 1 ? undefined : daemonStatus(84);
+    },
+    probeEndpointOwner: () => ({ pid: 84, alive: true }),
+    ownerIsAlive: (pid) => pid === 84,
+    isReadinessTimeout: (error) => error instanceof DaemonAutostartTimeoutError,
+    readinessTimeoutPid: (error) => error instanceof DaemonAutostartTimeoutError ? error.spawnedPid : undefined,
+    reportProgress: (message) => progress.push(message),
+    startReplacement: async () => {
+      replacementStarts += 1;
+      throw new DaemonAutostartTimeoutError(100, new Error("not ready"), 84);
+    },
+    wait: async () => undefined
+  };
+
+  const result = await runRestart(lifecycle, [
+    "--replacement-timeout-ms", "100",
+    "--replacement-settle-timeout-ms", "100"
+  ]);
+
+  const replacement = result.replacement as { readonly service?: { readonly pid?: unknown } };
+  assert.equal(replacement.service?.pid, 84);
+  assert.equal(replacementStarts, 1);
+  assert.equal(progress.length, 1);
+  assert.match(progress[0]!, /pid 84.*owns the endpoint.*still starting/iu);
+});
+
+test("restart stops a live unreachable replacement at the settling cap before restoring service", async () => {
+  let replacementAlive = true;
+  let replacementStarts = 0;
+  const stoppedPids: number[] = [];
+  const lifecycle: DaemonControlLifecycle = {
+    target,
+    probeStatus: async () => undefined,
+    probeEndpointOwner: () => replacementAlive ? { pid: 84, alive: true } : undefined,
+    ownerIsAlive: (pid) => pid === 84 && replacementAlive,
+    isReadinessTimeout: (error) => error instanceof DaemonAutostartTimeoutError,
+    readinessTimeoutPid: (error) => error instanceof DaemonAutostartTimeoutError ? error.spawnedPid : undefined,
+    startReplacement: async () => {
+      replacementStarts += 1;
+      if (replacementStarts === 1) {
+        throw new DaemonAutostartTimeoutError(100, new Error("not ready"), 84);
+      }
+      return daemonStatus(85);
+    },
+    stopReplacement: async (_target, pid) => {
+      stoppedPids.push(pid);
+      replacementAlive = false;
+    },
+    wait: async () => undefined
+  };
+
+  await assert.rejects(
+    runRestart(lifecycle, [
+      "--replacement-timeout-ms", "100",
+      "--replacement-settle-timeout-ms", "100"
+    ]),
+    (error: Error) => {
+      assert.match(error.message, /exceeded the additional 100ms settling limit/u);
+      assert.match(error.message, /service restored and reachable/u);
+      return true;
+    }
+  );
+  assert.deepEqual(stoppedPids, [84]);
   assert.equal(replacementStarts, 2);
 });
 

--- a/packages/cli/test/daemon-control-replacement-safety.test.ts
+++ b/packages/cli/test/daemon-control-replacement-safety.test.ts
@@ -152,6 +152,24 @@ test("replacement cleanup validates target ownership, escalates to SIGKILL, and 
   assert.deepEqual(signals, ["SIGTERM", "SIGKILL"]);
 });
 
+test("replacement cleanup accepts the live owner record while startup RPC is not ready", async () => {
+  const signals: NodeJS.Signals[] = [];
+  let alive = true;
+  const runtime = stopRuntime({
+    probeStatus: async () => undefined,
+    endpointOwnerPid: () => alive ? 84 : undefined,
+    processIsAlive: () => alive,
+    signal: (_pid, signal) => {
+      signals.push(signal);
+      alive = false;
+    }
+  });
+
+  await stopDaemonReplacement(controlTarget, 84, 100, runtime);
+
+  assert.deepEqual(signals, ["SIGTERM"]);
+});
+
 test("replacement cleanup refuses to signal a PID not owned by the target endpoint", async () => {
   const signals: NodeJS.Signals[] = [];
   const runtime = stopRuntime({
@@ -212,7 +230,7 @@ test("replacement cleanup detects supervisor resurrection during the endpoint st
 
 function stopRuntime(
   overrides: Pick<DaemonReplacementStopRuntime, "probeStatus" | "processIsAlive" | "signal">
-    & Partial<Pick<DaemonReplacementStopRuntime, "endpointStabilityMs">>
+    & Partial<Pick<DaemonReplacementStopRuntime, "endpointOwnerPid" | "endpointStabilityMs">>
 ): DaemonReplacementStopRuntime {
   return {
     ...overrides,

--- a/packages/cli/test/daemon-refresh-preflight.test.ts
+++ b/packages/cli/test/daemon-refresh-preflight.test.ts
@@ -228,6 +228,81 @@ test("restart replacement launch failure restores a reachable daemon", { timeout
   }
 });
 
+test("restart waits for a live endpoint owner that becomes ready after the normal startup budget", { timeout: DAEMON_REFRESH_TEST_TIMEOUT_MS }, async (t) => {
+  if (process.platform === "win32") return t.skip("controlled SIGSTOP/SIGCONT startup delay requires POSIX signals");
+  const fixture = createFixture();
+  const userRoot = defaultDaemonUserRoot(fixture.root);
+  const delayMarker = path.join(fixture.root, "slow-owned-replacement.marker");
+  const delayEvidence = path.join(fixture.root, "slow-owned-replacement.json");
+  const preloadPath = path.resolve("packages/cli/test/fixtures/daemon-slow-owned-replacement-preload.mjs");
+  const replacementTimeoutMs = 4_000;
+  const ownedDelayMs = 4_500;
+  const env = {
+    HARNESS_DAEMON_MODE: "local",
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_IDLE_MS: "60000",
+    HARNESS_DAEMON_REQUEST_TIMEOUT_MS: String(DAEMON_REFRESH_REQUEST_TIMEOUT_MS),
+    HARNESS_TEST_DAEMON_SLOW_REPLACEMENT_MARKER: delayMarker,
+    HARNESS_TEST_DAEMON_SLOW_REPLACEMENT_EVIDENCE: delayEvidence,
+    HARNESS_TEST_DAEMON_SLOW_REPLACEMENT_MS: String(ownedDelayMs),
+    NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --import=${pathToFileURL(preloadPath).href}`.trim()
+  };
+  let delayedPid: number | undefined;
+  try {
+    runDaemonCommand(fixture.repoRoot, [
+      "daemon", "repo", "register", "--repo-id", "canonical",
+      "--canonical-root", fixture.repoRoot, "--user-root", userRoot, "--no-link", "--json"
+    ], env);
+    const started = runDaemonCommand(fixture.repoRoot, [
+      "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
+    ], env);
+    const beforePid = started.pid as number;
+    assert.equal(typeof beforePid, "number", JSON.stringify(started));
+
+    writeFileSync(delayMarker, "pause replacement after endpoint ownership\n", "utf8");
+    const restartStartedAt = performance.now();
+    const restart = runRawJsonMaybeFail(fixture.repoRoot, [
+      "daemon", "restart", "--timeout-ms", "3000",
+      "--replacement-timeout-ms", String(replacementTimeoutMs),
+      "--user-root", userRoot
+    ], env);
+    const restartElapsedMs = performance.now() - restartStartedAt;
+    const evidence = JSON.parse(readFileSync(delayEvidence, "utf8")) as {
+      readonly pid: number;
+      readonly ownerPath: string;
+      readonly pausedAt: string;
+      readonly delayMs: number;
+    };
+    delayedPid = evidence.pid;
+
+    assert.equal(restart.status, 0, JSON.stringify({ restart, evidence, restartElapsedMs }));
+    assert.equal(restart.receipt.ok, true, JSON.stringify(restart.receipt));
+    assert.match(restart.stderr, /replacement readiness deadline elapsed.*still starting/iu);
+    assert.ok(restartElapsedMs > replacementTimeoutMs, JSON.stringify({ restartElapsedMs, replacementTimeoutMs }));
+    const replacement = restart.receipt.replacement as Record<string, unknown>;
+    assert.equal(replacement.pid, delayedPid, JSON.stringify(restart.receipt));
+
+    const after = runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env);
+    assert.equal(after.reachable, true, JSON.stringify(after));
+    assert.equal(after.pid, delayedPid, JSON.stringify({ restart: restart.receipt, after }));
+    assert.notEqual(after.pid, beforePid);
+    console.log(JSON.stringify({
+      scenario: "slow-owned-replacement",
+      replacementTimeoutMs,
+      ownedDelayMs,
+      restartElapsedMs,
+      beforePid,
+      replacementPid: delayedPid,
+      reachable: after.reachable
+    }));
+  } finally {
+    rmSync(delayMarker, { force: true });
+    if (delayedPid !== undefined && processIsAlive(delayedPid)) process.kill(delayedPid, "SIGCONT");
+    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("refresh explicitly exits the old owner after safe shutdown even with an active resource", { timeout: DAEMON_REFRESH_TEST_TIMEOUT_MS }, async () => {
   const fixture = createFixture();
   const userRoot = defaultDaemonUserRoot(fixture.root);

--- a/packages/cli/test/fixtures/daemon-slow-owned-replacement-preload.mjs
+++ b/packages/cli/test/fixtures/daemon-slow-owned-replacement-preload.mjs
@@ -1,0 +1,44 @@
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+
+const markerPath = process.env.HARNESS_TEST_DAEMON_SLOW_REPLACEMENT_MARKER;
+const evidencePath = process.env.HARNESS_TEST_DAEMON_SLOW_REPLACEMENT_EVIDENCE;
+const delayMs = Number(process.env.HARNESS_TEST_DAEMON_SLOW_REPLACEMENT_MS);
+const socketIndex = process.argv.indexOf("--socket");
+const socketPath = socketIndex >= 0 ? process.argv[socketIndex + 1] : undefined;
+const isReplacementServe = process.argv.includes("daemon")
+  && process.argv.includes("serve")
+  && !process.argv.includes("--check");
+
+if (process.platform !== "win32"
+  && markerPath
+  && evidencePath
+  && socketPath
+  && Number.isSafeInteger(delayMs)
+  && delayMs > 0
+  && isReplacementServe
+  && existsSync(markerPath)) {
+  rmSync(markerPath, { force: true });
+  const ownerPath = `${socketPath}.owner`;
+  const ownerPoll = setInterval(() => {
+    try {
+      const owner = JSON.parse(readFileSync(ownerPath, "utf8"));
+      if (owner?.schema !== "daemon-socket-owner/v1" || owner.pid !== process.pid) return;
+      clearInterval(ownerPoll);
+      writeFileSync(evidencePath, JSON.stringify({
+        pid: process.pid,
+        ownerPath,
+        pausedAt: new Date().toISOString(),
+        delayMs
+      }), "utf8");
+      const resumer = spawn(process.execPath, [
+        "-e",
+        `setTimeout(() => process.kill(${process.pid}, "SIGCONT"), ${delayMs})`
+      ], { detached: true, stdio: "ignore" });
+      resumer.unref();
+      process.kill(process.pid, "SIGSTOP");
+    } catch {
+      // Ownership is published atomically; keep polling until this process owns it.
+    }
+  }, 10);
+}

--- a/packages/cli/test/helpers/daemon-cli.ts
+++ b/packages/cli/test/helpers/daemon-cli.ts
@@ -45,7 +45,7 @@ export function runRawJsonMaybeFail(
   rootDir: string,
   args: ReadonlyArray<string>,
   env: Readonly<Record<string, string>> = {}
-): { readonly status: number | null; readonly receipt: Record<string, unknown> } {
+): { readonly status: number | null; readonly receipt: Record<string, unknown>; readonly stderr: string } {
   const result = spawnSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
     encoding: "utf8",
     env: daemonTestEnv(rootDir, env)
@@ -53,7 +53,8 @@ export function runRawJsonMaybeFail(
   assert.equal(stderrWithoutDeprecationWarnings(result.stderr), "");
   return {
     status: result.status,
-    receipt: JSON.parse(result.stdout) as Record<string, unknown>
+    receipt: JSON.parse(result.stdout) as Record<string, unknown>,
+    stderr: result.stderr
   };
 }
 

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -51,6 +51,22 @@ export const defaultDaemonAutostartTimeoutMs = 6_000;
 export const defaultDaemonIdleExitMs = 750;
 const minimumReadyProbeResponseTimeoutMs = 500;
 
+export class DaemonAutostartTimeoutError extends Error {
+  readonly timeoutMs: number;
+  readonly spawnedPid?: number;
+
+  constructor(timeoutMs: number, lastError: unknown, spawnedPid?: number) {
+    const cause = lastError instanceof Error ? lastError.message : String(lastError ?? "no ready probe completed");
+    super(
+      `DAEMON_AUTOSTART_TIMEOUT: readiness was not confirmed within the normal ${timeoutMs}ms startup budget; `
+      + `the launched process${spawnedPid === undefined ? "" : ` pid ${spawnedPid}`} may still be starting. Last probe: ${cause}`
+    );
+    this.name = "DaemonAutostartTimeoutError";
+    this.timeoutMs = timeoutMs;
+    this.spawnedPid = spawnedPid;
+  }
+}
+
 export {
   DaemonJsonRpcRequestTimeoutError,
   DaemonJsonRpcResponseError,
@@ -104,12 +120,13 @@ export interface LocalDaemonJsonRpcOptions {
   readonly env?: NodeJS.ProcessEnv;
 }
 
-type SpawnLocalDaemon = (target: LocalDaemonTarget, options: LocalDaemonAutostartOptions) => void;
+type SpawnLocalDaemon = (target: LocalDaemonTarget, options: LocalDaemonAutostartOptions) => number | void;
 
 interface DaemonStartupFlight {
   readonly startedAt: number;
   deadline: number;
   lastError: unknown;
+  spawnedPid?: number;
   promise: Promise<void>;
 }
 
@@ -283,8 +300,9 @@ export async function requestLocalDaemonJsonRpcForTarget(
   return requestLocalDaemonJsonRpcWithAutostart(target, method, params, timeoutMs, autostart);
 }
 
-export function spawnLocalDaemon(target: LocalDaemonTarget, options: LocalDaemonAutostartOptions): void {
-  spawnLocalDaemonImplementation(target, options);
+export function spawnLocalDaemon(target: LocalDaemonTarget, options: LocalDaemonAutostartOptions): number | undefined {
+  const pid = spawnLocalDaemonImplementation(target, options);
+  return typeof pid === "number" ? pid : undefined;
 }
 
 export function daemonServerHostEnvironment(
@@ -310,7 +328,7 @@ export function replaceSpawnLocalDaemonForTest(replacement: SpawnLocalDaemon): (
   };
 }
 
-function spawnLocalDaemonProcess(target: LocalDaemonTarget, options: LocalDaemonAutostartOptions): void {
+function spawnLocalDaemonProcess(target: LocalDaemonTarget, options: LocalDaemonAutostartOptions): number | undefined {
   const launchConfiguration = options.launchConfiguration ?? createDaemonLaunchConfiguration({
     target,
     entrypoint: options.entryPath,
@@ -330,6 +348,7 @@ function spawnLocalDaemonProcess(target: LocalDaemonTarget, options: LocalDaemon
     env: daemonServerHostEnvironment(options.env ?? process.env, target)
   });
   child.unref();
+  return child.pid;
 }
 
 async function requestLocalDaemonJsonRpcWithAutostart(
@@ -410,7 +429,7 @@ async function spawnAndWaitForLocalDaemon(
   flight: DaemonStartupFlight
 ): Promise<void> {
   autostart.onPhase?.("launch-start");
-  spawnLocalDaemon(target, autostart);
+  flight.spawnedPid = spawnLocalDaemon(target, autostart);
   while (Date.now() <= flight.deadline) {
     try {
       await probeLocalDaemonReady(
@@ -426,7 +445,7 @@ async function spawnAndWaitForLocalDaemon(
       if (retryDelayMs > 0) await delay(retryDelayMs);
     }
   }
-  throw daemonAutostartTimeoutError(flight.deadline - flight.startedAt, flight.lastError);
+  throw daemonAutostartTimeoutError(flight.deadline - flight.startedAt, flight.lastError, flight.spawnedPid);
 }
 
 async function waitForDaemonStartupFlight(
@@ -438,12 +457,12 @@ async function waitForDaemonStartupFlight(
   const remainingMs = deadline - Date.now();
   if (remainingMs <= 0) {
     if (deadline >= flight.deadline) clearDaemonStartupFlight(socketPath, flight);
-    throw daemonAutostartTimeoutError(autostartTimeoutMs, flight.lastError);
+    throw daemonAutostartTimeoutError(autostartTimeoutMs, flight.lastError, flight.spawnedPid);
   }
   return new Promise<void>((resolve, reject) => {
     const timer = setTimeout(() => {
       if (deadline >= flight.deadline) clearDaemonStartupFlight(socketPath, flight);
-      reject(daemonAutostartTimeoutError(autostartTimeoutMs, flight.lastError));
+      reject(daemonAutostartTimeoutError(autostartTimeoutMs, flight.lastError, flight.spawnedPid));
     }, remainingMs);
     flight.promise.then(
       () => {
@@ -572,7 +591,6 @@ function readyProbeResponseTimeout(deadline: number): number {
   );
 }
 
-function daemonAutostartTimeoutError(timeoutMs: number, lastError: unknown): Error {
-  const cause = lastError instanceof Error ? lastError.message : String(lastError ?? "no ready probe completed");
-  return new Error(`DAEMON_AUTOSTART_TIMEOUT: autostart exhausted its ${timeoutMs}ms total budget. Last probe: ${cause}`);
+function daemonAutostartTimeoutError(timeoutMs: number, lastError: unknown, spawnedPid?: number): Error {
+  return new DaemonAutostartTimeoutError(timeoutMs, lastError, spawnedPid);
 }

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -28,6 +28,7 @@ export {
   daemonServerHostEnvironment,
   daemonUserRoot,
   daemonUserRootForRepo,
+  DaemonAutostartTimeoutError,
   DaemonJsonRpcRequestTimeoutError,
   DaemonJsonRpcResponseError,
   defaultDaemonAutostartTimeoutMs,

--- a/packages/daemon/src/transport/local-service-transport.ts
+++ b/packages/daemon/src/transport/local-service-transport.ts
@@ -26,6 +26,11 @@ interface DaemonSocketOwnerRecord {
   readonly ownerToken: string;
 }
 
+export interface DaemonSocketOwnerSnapshot {
+  readonly pid: number;
+  readonly alive: boolean;
+}
+
 export interface DaemonSocketOwnership {
   readonly release: () => void;
 }
@@ -97,6 +102,14 @@ function daemonSocketOwnerLockPath(endpoint: string, platform: NodeJS.Platform):
   if (platform !== "win32") return `${endpoint}.owner`;
   const endpointDigest = createHash("sha256").update(endpoint).digest("hex").slice(0, 32);
   return path.join(os.tmpdir(), `harness-anything-daemon-${endpointDigest}.owner`);
+}
+
+export function readDaemonSocketOwner(
+  endpoint: string,
+  platform: NodeJS.Platform = process.platform
+): DaemonSocketOwnerSnapshot | undefined {
+  const owner = readOwnerLock(daemonSocketOwnerLockPath(endpoint, platform));
+  return owner ? { pid: owner.pid, alive: processIsAlive(owner.pid) } : undefined;
 }
 
 export async function withDaemonSocketOwnership<Result>(

--- a/packages/daemon/test/local-json-rpc-client.test.ts
+++ b/packages/daemon/test/local-json-rpc-client.test.ts
@@ -9,6 +9,7 @@ import test from "node:test";
 import {
   createDaemonLaunchConfiguration,
   daemonLaunchOptionsResolvedFlag,
+  DaemonAutostartTimeoutError,
   DaemonJsonRpcRequestTimeoutError,
   DaemonJsonRpcResponseError,
   JsonRpcLineClient,
@@ -432,6 +433,7 @@ test("autostart bounds a never-responding ready probe by the total startup budge
   const target = makeTarget(socketPath);
   let helloCalls = 0;
   let server: net.Server | undefined;
+  const spawnedPid = 24_680;
   const restoreSpawn = replaceSpawnLocalDaemonForTest(() => {
     setTimeout(() => {
       void startJsonRpcServer(socketPath, {
@@ -443,6 +445,7 @@ test("autostart bounds a never-responding ready probe by the total startup budge
         server = started;
       });
     }, 10);
+    return spawnedPid;
   });
   t.after(async () => {
     restoreSpawn();
@@ -458,8 +461,10 @@ test("autostart bounds a never-responding ready probe by the total startup budge
       200,
       { entryPath: "/unused", timeoutMs: 1_200 }
     ),
-    (error: unknown) => !(error instanceof DaemonJsonRpcRequestTimeoutError)
-      && /autostart.*1200ms/u.test(error instanceof Error ? error.message : "")
+    (error: unknown) => error instanceof DaemonAutostartTimeoutError
+      && error.timeoutMs === 1_200
+      && error.spawnedPid === spawnedPid
+      && /readiness.*1200ms.*may still be starting/u.test(error.message)
   );
   assert.ok(helloCalls >= 2, `expected multiple bounded ready probes; saw ${helloCalls}`);
 });


### PR DESCRIPTION
# English

## Summary

On a production-scale repository, `ha daemon restart` reports `FAILED_AFTER_HANDOFF` while the service is in fact reachable a second or two later. The report is wrong, not the service.

The chain is deterministic and was reproduced twice on the live production ledger:

1. Startup on that repository takes **7.58s** (`startedAt 03:44:22.709` → `lifecycle.started 03:44:30.289`), because 1011 task packages / 927MB require repo-write historical recovery before the daemon answers.
2. The replacement readiness budget is 6000ms, so the deadline elapses first and the replacement is declared failed.
3. The replacement is nevertheless alive and already owns the endpoint, so rollback refuses to run: *"service restoration was not started because the endpoint is still owned"*.

Those last two judgements contradict each other. **The endpoint being owned is evidence that the replacement is alive — which means it is still starting, not that it failed.** The control path treated "not ready within the budget" and "failed" as the same thing, and the operator was left with a failure receipt for a working service.

This change makes readiness-timeout a distinct outcome from failure. When the deadline elapses, the launched process is alive, and it owns the endpoint, the control path continues bounded observation instead of rolling back. It also splits one timeout number that was carrying two unrelated meanings.

## What Changed

- `packages/cli/src/commands/daemon/control-replacement.ts`: on readiness timeout, if the launched pid is alive and owns the endpoint, keep observing for up to a settling limit and adopt the replacement when it answers. If the endpoint owner ever differs from the launched pid, or the pid dies, fail as before. If the settling limit elapses with the pid still alive but unreachable, stop the replacement and surface the endpoint-unowned error rather than leaving an orphan.
- `packages/cli/src/commands/daemon/control.ts`: `--timeout-ms` (drain/handoff budget) and the replacement start budget were the same number serving two purposes. The replacement budget is now `--replacement-timeout-ms` (default from `HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS`, 6000), plus a separate `--replacement-settling-timeout-ms`. Rollback now uses the prepared running launch configuration when one exists.
- `packages/daemon/src/client/local-json-rpc-client.ts` and `local-service-transport.ts`: readiness timeouts are now identifiable as such and carry the spawned pid, so the control path can tell "not ready yet" from "failed to start". `probeStatus` accepts a per-probe request timeout.
- `replacement-cleanup.ts`: cleanup path for a live-but-unreachable replacement.

## Task And Scope

- Harness task: `task_01KZ2FDG2PHWKKM5SK3YG9S75V`
- Branch: `codex/daemon-restart-slow`
- Public scope: `packages/cli/src/commands/daemon/**`, `packages/daemon/src/client/local-json-rpc-client.ts`, `packages/daemon/src/transport/local-service-transport.ts`, `packages/daemon/src/index.ts`, and their tests
- Private planning/evidence updated: yes
- Out of scope: reducing the 7.58s startup itself. This PR makes a slow start reportable rather than mis-reported; making startup fast is a separate concern.

## Version Impact

- Version: no version change because this is a defect fix on an unreleased surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KZ2FDG2PHWKKM5SK3YG9S75V`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `00921aaefa164585c15d9a82de426205bef5c97c`
- Branch merge-base with `origin/main`: `00921aaefa164585c15d9a82de426205bef5c97c`
- Last `git fetch origin` time: immediately before the rebase for this PR
- Sync method: rebase
- Public diff command: `git diff origin/main...codex/daemon-restart-slow`
- Private evidence commit/path: recorded in the harness task package for `task_01KZ2FDG2PHWKKM5SK3YG9S75V`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending, linked once the run completes
- [x] `git diff --check`
- [x] `npm run check:local` — passed in 96.7s, 27 complete manifest gates green (this repository's declared local stop point; `check:stop-point` is the same gate set)
- [x] Targeted tests for the change surface, named with their counts: see below
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending
- Not run, and why: nothing was skipped. `rewrite-ci` is pending rather than skipped.

**Positive control, both directions.** The injection is a `--import` preload that acts on the replacement process itself: once that process owns the socket it `SIGSTOP`s itself and schedules a detached `SIGCONT` after a delay, so it is genuinely alive-and-owning-but-not-yet-answering. This is the production shape, not a synthesized error code at the call site.

- Before this change: ✖ fails with `endpoint is still owned` — the same wording seen on the production ledger.
- After this change: ✔ restart succeeds in 13.9s.

Named tests:

- `restart adopts a live replacement that becomes ready after the normal startup budget` (new)
- `restart stops a live unreachable replacement at the settling cap before restoring service` (new)
- `restart restores service when the old owner exits just after the handoff deadline`
- `restart restores service when the released endpoint replacement fails to start`
- Full integration tier: **1453 tests / 1447 pass / 2 fail / 4 skipped.** Both failures are `DAEMON_AUTOSTART_TIMEOUT` in `doc-sync-cli.test.ts` — the test's temporary-repo daemon did not confirm readiness within the 6000ms budget. They occurred at a moment when the machine's load average exceeded 150 (an unrelated VM), while dozens of tests in the same run that also autostart a daemon passed. A local re-run has no discriminating power at that load, so no "unrelated to this change" claim is made: if `rewrite-ci` fails these on a clean machine, treat it as a real regression in the autostart path this PR touches, not as noise.

## Review Evidence

- Self-review: the two contradictory judgements were located by reading the control path against two live production reproductions, not from the failure text alone. The first reproduction is what showed that the receipt disagreed with the reachable service.
- Reviewer subagent: implementation by Codex worker; acceptance and the bidirectional positive control run by the orchestrator.
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The settling limit is a bound, not a guarantee. A repository slower than the settling limit still ends in a failure receipt — correctly this time, since the replacement is then stopped and the endpoint left unowned, but the operator still has to restart manually.
- Startup cost itself is untouched. A 7.58s start remains 7.58s; this PR only stops it from being misreported.
- The earlier measurement that said cold start was ~1.36s was taken on a temporary fixture repository with no accumulated history, where the expensive startup path does not exist at all. Any future timing work on this surface has to be done at production scale or it will reach the opposite conclusion again.

## References

- Task: `task_01KZ2FDG2PHWKKM5SK3YG9S75V`
- Evidence: harness task package progress and artifacts
- Review: same task package

---

# 中文

## 概要

在生产规模的仓库上，`ha daemon restart` 会报 `FAILED_AFTER_HANDOFF`，而服务其实一两秒后就可达。错的是回执，不是服务。

这条链是确定性的，已在生产账本上复演两次：

1. 该仓库启动耗时 **7.58 秒**（`startedAt 03:44:22.709` → `lifecycle.started 03:44:30.289`）——1011 个任务包 / 927MB 使得 daemon 应答前必须先做 repo-write historical recovery。
2. 替身就绪预算是 6000ms，于是先撞 deadline，替身被判失败。
3. 但替身活着并且已经持有 endpoint，于是回滚拒绝执行：*"service restoration was not started because the endpoint is still owned"*。

后两个判断自相矛盾。**endpoint 被占着恰恰证明替身活着——那意味着它还在启动，而不是它失败了。** 控制路径把「预算内没就绪」和「失败」当成同一件事，操作者拿到的是一个正在正常工作的服务的失败回执。

本改动把「就绪超时」与「失败」分成两个不同的结局：deadline 到点时，若启动的进程活着且持有 endpoint，控制路径继续有界观察而不是回滚。同时拆开了一个身兼两职的超时数字。

## 改动内容

- `packages/cli/src/commands/daemon/control-replacement.ts`：就绪超时时，若启动的 pid 活着且持有 endpoint，则继续观察至 settling 上限，待它应答即采纳。若 endpoint 持有者与启动的 pid 不一致，或 pid 已死，仍按原路失败。若 settling 上限耗尽而 pid 仍活着且不可达，则停掉替身并抛出 endpoint-unowned 错误，而不是留下孤儿进程。
- `packages/cli/src/commands/daemon/control.ts`：`--timeout-ms`（排空 / 交接预算）与替身启动预算原本是同一个数字承担两个语义。替身预算改为 `--replacement-timeout-ms`（默认取 `HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS`，6000），另加 `--replacement-settling-timeout-ms`。回滚在存在 prepared running launch configuration 时改用它。
- `packages/daemon/src/client/local-json-rpc-client.ts` 与 `local-service-transport.ts`：就绪超时现在可被识别为就绪超时并携带 spawn 出的 pid，控制路径因此能分辨「还没就绪」与「起不来」。`probeStatus` 支持单次探测的请求超时。
- `replacement-cleanup.ts`：为「活着但不可达」的替身补上清理路径。

## 任务与范围

- Harness 任务：`task_01KZ2FDG2PHWKKM5SK3YG9S75V`
- 分支：`codex/daemon-restart-slow`
- 公开范围：`packages/cli/src/commands/daemon/**`、`packages/daemon/src/client/local-json-rpc-client.ts`、`packages/daemon/src/transport/local-service-transport.ts`、`packages/daemon/src/index.ts` 及其测试
- 私有计划 / 证据是否已更新：yes
- 范围外：把 7.58 秒的启动本身变快。本 PR 让「慢启动」可以被如实汇报，而不是被误报；让启动变快是另一件事。

## 版本影响

- 版本：不改版本，原因是这是未发布面上的缺陷修复
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`task_01KZ2FDG2PHWKKM5SK3YG9S75V`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`00921aaefa164585c15d9a82de426205bef5c97c`
- 当前分支与 `origin/main` 的 merge-base：`00921aaefa164585c15d9a82de426205bef5c97c`
- 最近一次 `git fetch origin` 时间：本 PR rebase 前即时执行
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main...codex/daemon-restart-slow`
- 私有证据 commit/path：记录在 `task_01KZ2FDG2PHWKKM5SK3YG9S75V` 的任务包中
- Reviewer 证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：待 run 完成后补链接
- [x] `git diff --check`
- [x] `npm run check:local` —— 96.7 秒通过，27 个 manifest gate 全绿（本仓声明的本地停止点；`check:stop-point` 是同一套门集）
- [x] 改动面的定向测试，写明测试名与通过数：见下
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）—— 待跑
- 未跑项及原因：没有跳过项。`rewrite-ci` 是待跑，不是跳过。

**双向阳性对照。** 注入手段是一个 `--import` preload，作用在替身进程自身：该进程一旦持有 socket 就对自己 `SIGSTOP`，并调度一个 detached 的延时 `SIGCONT`，因此它是真正的「活着、占着 endpoint、但还答不上话」。这是生产的形状，不是在调用侧造一个错误码。

- 改动前：✖ 报 `endpoint is still owned` —— 与生产账本上看到的措辞逐字同形。
- 改动后：✔ restart 在 13.9 秒内成功。

测试名：

- `restart adopts a live replacement that becomes ready after the normal startup budget`（新增）
- `restart stops a live unreachable replacement at the settling cap before restoring service`（新增）
- `restart restores service when the old owner exits just after the handoff deadline`
- `restart restores service when the released endpoint replacement fails to start`
- 完整 integration tier：**1453 tests / 1447 pass / 2 fail / 4 skipped。** 两条失败都是 `doc-sync-cli.test.ts` 里的 `DAEMON_AUTOSTART_TIMEOUT`——测试临时仓的 daemon 未在 6000ms 预算内确认就绪。失败发生时本机 load average 超过 150（一个无关的 VM 在跑），而同一次 run 里几十条同样要自启动 daemon 的测试全部通过。该负载下本地重跑没有分辨力，因此**不做「与本改动无关」的宣称**：若 `rewrite-ci` 在干净机器上跑红这两条，按本 PR 触碰的 autostart 路径的真实回归处理，不当噪声。

## 审查证据

- 自查：两个自相矛盾的判断是把控制路径对着两次生产复演读出来的，不是只看失败文案。第一次复演才暴露出回执与可达的服务互相打架。
- Reviewer subagent：实现由 Codex worker 完成；验收与双向阳性对照由编排者亲跑。
- 人工审查：待办
- 阻塞发现：无 open

## 残余风险

- settling 上限是个界限，不是保证。比该上限还慢的仓库仍会落到失败回执——这次是正确的失败（替身被停掉、endpoint 保持无主），但操作者仍需手工重启。
- 启动开销本身未动。7.58 秒还是 7.58 秒；本 PR 只是让它不再被误报。
- 早先那次「冷启动约 1.36 秒」的测量是在临时 fixture 仓上取的，那种仓没有历史积累，最耗时的那段启动路径压根不存在。今后在这个面上做任何计时工作都必须在生产规模上做，否则会再次得出相反的结论。

## 关联材料

- 任务：`task_01KZ2FDG2PHWKKM5SK3YG9S75V`
- 证据：harness 任务包的 progress 与 artifacts
- 审查：同一任务包
