### PR TITLE
fix(daemon): bound task completion witness history

### DIFF
--- a/packages/daemon/src/authority/production/production-authority-task-completion-intent.ts
+++ b/packages/daemon/src/authority/production/production-authority-task-completion-intent.ts
@@ -40,6 +40,9 @@ import {
   resolveVerifiedTaskCompleteWitnesses,
   verifyTaskCompleteWitnessRefs
 } from "./task-complete-prepublish-witness.ts";
+import {
+  reportCurrentRepoWriteTelemetry
+} from "../../runtime/repo-write-telemetry-context.ts";
 
 export async function taskCompletionIntent(
   authoredRoot: string,
@@ -53,6 +56,7 @@ export async function taskCompletionIntent(
 ): Promise<CanonicalAttemptIntent> {
   const taskId = action.taskId;
   const taskRoot = resolvedTaskRoot(authoredRoot, taskId);
+  reportCurrentRepoWriteTelemetry("compile-task-load");
   const documents = readTaskDocuments(taskRoot);
   const taskPath = taskLifecyclePath(authoredRoot, taskId, "INDEX.md");
   const taskSnapshot = requiredLifecycleSnapshot(authoredRoot, taskPath.logical, taskPath.physical);
@@ -62,6 +66,7 @@ export async function taskCompletionIntent(
   const contractBodySha256 = contractSnapshot ? sha256Text(contractSnapshot.body) : null;
   const completionGates = resolveLifecycleCompletionGates(contractSnapshot?.body);
   const command = action as TaskCompleteTransitionCommand;
+  reportCurrentRepoWriteTelemetry("compile-task-holder");
   const holder = await makeTaskHolderService({ rootInput: { rootDir, layoutOverrides } }).holder({ taskId });
   const currentRound = resolveTaskCurrentRound({ taskId, executionId: command.executionId, documents });
   const transitionId = taskLifecycleTransitionId(command.callerIdempotencyKey);
@@ -70,6 +75,7 @@ export async function taskCompletionIntent(
     rootDir, authoredRoot, taskId, documents, command,
     requireCodeDoc: completionGates.includes("code-doc-reconciliation")
   };
+  reportCurrentRepoWriteTelemetry("compile-task-witness");
   const witnesses = existing
     ? verifyTaskCompleteWitnessRefs({ ...witnessInput, refs: existing.externalCheckpointRefs, snapshotMode: "committed" })
     : resolveVerifiedTaskCompleteWitnesses(witnessInput);
@@ -91,6 +97,7 @@ export async function taskCompletionIntent(
         resolvedCommit: resolveLifecycleCommit(rootDir, command.commitRef ?? "HEAD")
       })
     : undefined;
+  reportCurrentRepoWriteTelemetry("compile-task-plan");
   const plan = TaskLifecycleTransitionService.plan({
     taskId,
     taskStatus: status,

--- a/packages/daemon/src/authority/production/task-complete-prepublish-witness.ts
+++ b/packages/daemon/src/authority/production/task-complete-prepublish-witness.ts
@@ -281,12 +281,15 @@ function findMaterializedPublication(
   bodies: ReadonlyArray<string>
 ): { readonly commit: string; readonly operationIds: ReadonlyArray<string> } {
   const expectedBlobs = bodies.map((body) => witnessGitText(rootDir, ["hash-object", "--stdin"], body));
-  for (const entry of firstParentHistory(rootDir)) {
+  const currentBlobs = witnessGitBlobIds(rootDir, "HEAD", repositoryPaths);
+  if (currentBlobs.some((actual, index) => actual !== expectedBlobs[index])) {
+    throw new Error(`AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:${repositoryPaths.join(",")}`);
+  }
+  for (const entry of firstParentHistory(rootDir, repositoryPaths)) {
     if (entry.parents.length !== 2) continue;
     const operationIds = canonicalPublicationOperationIds(rootDir, entry);
     if (operationIds.length === 0) continue;
-    const actualBlobs = repositoryPaths.map((repositoryPath) =>
-      gitTextOrNull(rootDir, ["rev-parse", `${entry.commit}:${repositoryPath}`]));
+    const actualBlobs = witnessGitBlobIds(rootDir, entry.commit, repositoryPaths);
     const matches = actualBlobs.every((actual, index) => actual === expectedBlobs[index]);
     if (matches) return { commit: entry.commit, operationIds };
   }
@@ -300,7 +303,8 @@ function assertMaterializedPublication(
   bodies: ReadonlyArray<string>,
   expectedOperationIds: ReadonlyArray<string>
 ): void {
-  const entry = firstParentHistory(rootDir).find((candidate) => candidate.commit === repositoryCommit);
+  const entry = firstParentHistory(rootDir, repositoryPaths)
+    .find((candidate) => candidate.commit === repositoryCommit);
   if (!entry || entry.parents.length !== 2) {
     throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_COMMIT_NOT_MATERIALIZED_FIRST_PARENT");
   }
@@ -309,9 +313,8 @@ function assertMaterializedPublication(
     throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_OPERATION_MISMATCH");
   }
   const expectedBlobs = bodies.map((body) => witnessGitText(rootDir, ["hash-object", "--stdin"], body));
-  const matches = repositoryPaths.every((repositoryPath, index) =>
-    gitTextOrNull(rootDir, ["rev-parse", `${repositoryCommit}:${repositoryPath}`]) === expectedBlobs[index]
-  );
+  const actualBlobs = witnessGitBlobIds(rootDir, repositoryCommit, repositoryPaths);
+  const matches = actualBlobs.every((actual, index) => actual === expectedBlobs[index]);
   if (!matches) throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_BLOB_MISMATCH");
 }
 
@@ -325,12 +328,20 @@ function canonicalPublicationOperationIds(
     : publicationOperationIds(witnessGitText(rootDir, ["show", "-s", "--format=%s", entry.parents[1]!]));
 }
 
-function firstParentHistory(rootDir: string): ReadonlyArray<{
+function firstParentHistory(rootDir: string, repositoryPaths: ReadonlyArray<string>): ReadonlyArray<{
   readonly commit: string;
   readonly parents: ReadonlyArray<string>;
   readonly subject: string;
 }> {
-  const fields = witnessGitText(rootDir, ["log", "--first-parent", "--format=%H%x00%P%x00%s%x00", "HEAD"]).split("\0");
+  const fields = witnessGitText(rootDir, [
+    "log",
+    "--first-parent",
+    "--full-history",
+    "--format=%H%x00%P%x00%s%x00",
+    "HEAD",
+    "--",
+    ...repositoryPaths.map((repositoryPath) => `:(literal)${repositoryPath}`)
+  ]).split("\0");
   const rows: Array<{ commit: string; parents: ReadonlyArray<string>; subject: string }> = [];
   for (let index = 0; index + 2 < fields.length; index += 3) {
     const commit = fields[index]!.trim();
@@ -414,6 +425,37 @@ function witnessGitBlobText(rootDir: string, commitRef: string, repositoryPath: 
   } catch {
     throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_BLOB_MISSING");
   }
+}
+
+function witnessGitBlobIds(
+  rootDir: string,
+  commitRef: string,
+  repositoryPaths: ReadonlyArray<string>
+): ReadonlyArray<string | null> {
+  const output = execFileSync("git", [
+    "-C",
+    rootDir,
+    "ls-tree",
+    "-z",
+    "--full-tree",
+    commitRef,
+    "--",
+    ...repositoryPaths.map((repositoryPath) => `:(literal)${repositoryPath}`)
+  ], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    maxBuffer: 64 * 1024 * 1024,
+    windowsHide: true
+  });
+  const byPath = new Map<string, string>();
+  for (const row of output.split("\0")) {
+    if (!row) continue;
+    const separator = row.indexOf("\t");
+    if (separator < 0) continue;
+    const [mode, type, objectId] = row.slice(0, separator).split(" ");
+    if (mode && type === "blob" && objectId) byPath.set(row.slice(separator + 1), objectId);
+  }
+  return repositoryPaths.map((repositoryPath) => byPath.get(repositoryPath) ?? null);
 }
 
 function gitTextOrNull(rootDir: string, args: ReadonlyArray<string>): string | null {

--- a/packages/daemon/src/runtime/production-progress-append-operation.ts
+++ b/packages/daemon/src/runtime/production-progress-append-operation.ts
@@ -47,6 +47,9 @@ import type {
 import {
   guardProgressAppendRecoveryEffect
 } from "./repo-write-progress-recovery-guard.ts";
+import {
+  reportCurrentRepoWriteTelemetry
+} from "./repo-write-telemetry-context.ts";
 
 export class ProductionRepoWriteOperationHost<
   Command extends DaemonHostCommand,
@@ -145,6 +148,7 @@ export class ProductionRepoWriteOperationHost<
       },
       recoveryContext: prepared.plan as unknown as import("./repo-write-protocol.ts").RepoWriteJsonObject
     };
+    reportCurrentRepoWriteTelemetry("compile-outcome");
     return this.operations.prepare({
       proceeding,
       executeFresh: (durable) => this.executePrepared(
@@ -165,6 +169,7 @@ export class ProductionRepoWriteOperationHost<
       ? await this.options.executeDocSyncSubmit?.({ command: input.command, decoded })
       : undefined;
     if (directReceipt) return commandReceiptJsonObject(directReceipt);
+    reportCurrentRepoWriteTelemetry("compile-command-normalize");
     const command = await this.options.hostServices.normalizeCommand(
       this.options.hostServices.parseCommandPayload(input.command.payload),
       decoded.currentSession
@@ -212,6 +217,7 @@ export class ProductionRepoWriteOperationHost<
     if (!binding.planCommand || !binding.plannedCommandSubmission) {
       throw new Error("AUTHORITY_COMMAND_PLANNING_UNAVAILABLE");
     }
+    reportCurrentRepoWriteTelemetry("compile-command-normalize");
     const command = await this.options.hostServices.normalizeCommand(
       this.options.hostServices.parseCommandPayload(dto.payload),
       decoded.currentSession
@@ -237,11 +243,13 @@ export class ProductionRepoWriteOperationHost<
         authorityCommand.action.kind
       )
     };
+    reportCurrentRepoWriteTelemetry("compile-authority-plan");
+    const plan = await binding.planCommand(expected);
     return {
       binding,
       expected,
       receiptSeed: this.options.hostServices.receiptSeed(command),
-      plan: await binding.planCommand(expected)
+      plan
     };
   }
 
@@ -268,6 +276,7 @@ export class ProductionRepoWriteOperationHost<
     if (!binding.plannedCommandSubmission) {
       throw new Error("AUTHORITY_COMMAND_PLANNING_UNAVAILABLE");
     }
+    reportCurrentRepoWriteTelemetry("compile-command-normalize");
     const command = await this.options.hostServices.normalizeCommand(
       this.options.hostServices.parseCommandPayload(dto.payload),
       decoded.currentSession

--- a/packages/daemon/src/runtime/repo-write-diagnostic-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-diagnostic-protocol.ts
@@ -5,7 +5,21 @@ interface RepoWriteDiagnosticFrameBase {
 }
 
 export type RepoWriteTelemetryPhase =
-  "queue" | "compile" | "journal" | "git" | "fsync" | "materializer" | "projection" | "total";
+  | "queue"
+  | "compile"
+  | "compile-command-normalize"
+  | "compile-authority-plan"
+  | "compile-task-load"
+  | "compile-task-holder"
+  | "compile-task-witness"
+  | "compile-task-plan"
+  | "compile-outcome"
+  | "journal"
+  | "git"
+  | "fsync"
+  | "materializer"
+  | "projection"
+  | "total";
 
 export interface RepoWriteTelemetryFrame extends RepoWriteDiagnosticFrameBase {
   readonly kind: "telemetry";

--- a/packages/daemon/src/runtime/repo-write-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-protocol.ts
@@ -414,7 +414,10 @@ function assertTerminalReceipt(
 function decodeTelemetry(frame: FrameRecord, limits: RepoWriteProtocolLimits): RepoWriteTelemetryFrame {
   assertExactKeys(frame, baseKeys(["requestId", "phase", "elapsedMs"]), ["opId"], "$");
   const phases: ReadonlyArray<RepoWriteTelemetryPhase> = [
-    "queue", "compile", "journal", "git", "fsync", "materializer", "projection", "total"
+    "queue", "compile", "compile-command-normalize", "compile-authority-plan",
+    "compile-task-load", "compile-task-holder", "compile-task-witness",
+    "compile-task-plan", "compile-outcome", "journal", "git", "fsync",
+    "materializer", "projection", "total"
   ];
   if (!phases.includes(frame.phase as RepoWriteTelemetryPhase)) invalid("$.phase", "telemetry phase");
   if (typeof frame.elapsedMs !== "number" || !Number.isFinite(frame.elapsedMs) || frame.elapsedMs < 0) {

--- a/packages/daemon/src/runtime/repo-write-stall-diagnostic.ts
+++ b/packages/daemon/src/runtime/repo-write-stall-diagnostic.ts
@@ -14,6 +14,20 @@ export function repoWriteWaitingStage(
       return "child-command-admission";
     case "compile":
       return "command-or-authority-attempt-compilation";
+    case "compile-command-normalize":
+      return "child-command-normalization";
+    case "compile-authority-plan":
+      return "authority-attempt-planning";
+    case "compile-task-load":
+      return "task-completion-document-loading";
+    case "compile-task-holder":
+      return "task-completion-holder-resolution";
+    case "compile-task-witness":
+      return "task-completion-prepublish-witness";
+    case "compile-task-plan":
+      return "task-completion-transition-planning";
+    case "compile-outcome":
+      return "durable-outcome-preparation";
     case "journal":
       return "durable-operation-journal";
     case "git":

--- a/packages/daemon/test/repo-write-client-diagnostic.test.ts
+++ b/packages/daemon/test/repo-write-client-diagnostic.test.ts
@@ -12,7 +12,8 @@ import type {
 } from "../src/runtime/repo-write-client-contract.ts";
 import {
   formatRepoWriteFailureDiagnostic,
-  formatRepoWriteTimeoutDiagnostic
+  formatRepoWriteTimeoutDiagnostic,
+  repoWriteWaitingStage
 } from "../src/runtime/repo-write-stall-diagnostic.ts";
 import {
   FakeRepoWriteTransport,
@@ -22,6 +23,13 @@ import {
   requestId
 } from "./support/repo-write-client-fixture.ts";
 import { committedCommandReceipt } from "./support/repo-write-terminal-fixture.ts";
+
+test("compile diagnostics distinguish task completion witness work", () => {
+  assert.equal(
+    repoWriteWaitingStage("compile-task-witness"),
+    "task-completion-prepublish-witness"
+  );
+});
 
 test("timeout diagnostics name the child wait for every authority submission ingress", async () => {
   const cases = [

--- a/packages/daemon/test/repo-write-protocol.test.ts
+++ b/packages/daemon/test/repo-write-protocol.test.ts
@@ -363,7 +363,7 @@ test("ready, terminal, status, telemetry, shutdown, and drained frames have exac
     ...base("telemetry"),
     requestId: "request-terminal",
     opId: "op-terminal",
-    phase: "fsync",
+    phase: "compile-task-witness",
     elapsedMs: 12.5
   });
   const shutdown = decodeRepoWriteParentMessage({
@@ -384,6 +384,7 @@ test("ready, terminal, status, telemetry, shutdown, and drained frames have exac
     committedReceipt
   );
   assert.equal(telemetry.kind === "telemetry" ? telemetry.elapsedMs : undefined, 12.5);
+  assert.equal(telemetry.kind === "telemetry" ? telemetry.phase : undefined, "compile-task-witness");
   assert.equal(shutdown.kind, "shutdown");
   assert.equal(drained.kind, "drained");
   assert.throws(() => decodeRepoWriteChildMessage({ ...ready, requestId: "not-allowed" }), protocolInvalid);

--- a/packages/daemon/test/task-complete-prepublish-witness.test.ts
+++ b/packages/daemon/test/task-complete-prepublish-witness.test.ts
@@ -4,6 +4,7 @@ import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import test from "node:test";
 import {
   CODE_DOC_RECONCILIATION_DOCUMENT,
@@ -61,6 +62,21 @@ test("daemon-produced prepublish witnesses bind immutable publication history, c
         { kind: "code-doc-reconciliation", ref: codeDoc.ref }
       ]
     }), /WITNESS_SNAPSHOT_MISMATCH:document-publication/u);
+  } finally {
+    rmSync(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("unpublished document rejection stays bounded with 1011 unrelated first-parent materializations", () => {
+  const fixture = unpublishedScaleWitnessRepository(1_011, 11);
+  try {
+    const startedAt = performance.now();
+    assert.throws(
+      () => produceDocumentPublicationWitness(fixture),
+      /AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED/u
+    );
+    const elapsedMs = performance.now() - startedAt;
+    assert.ok(elapsedMs < 5_000, `unpublished witness rejection took ${elapsedMs.toFixed(1)}ms`);
   } finally {
     rmSync(fixture.fixtureRoot, { recursive: true, force: true });
   }
@@ -129,6 +145,77 @@ function witnessRepository() {
     publicCommit,
     authoredInitialCommit
   };
+}
+
+function unpublishedScaleWitnessRepository(mergeCount: number, documentCount: number) {
+  const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-prepublish-witness-scale-"));
+  const rootDir = path.join(fixtureRoot, "workspace");
+  const authoredRoot = path.join(rootDir, "harness");
+  const taskRoot = path.join(authoredRoot, "tasks", `${taskId}-scale`);
+  mkdirSync(taskRoot, { recursive: true });
+  gitInit(authoredRoot);
+
+  const documents = Array.from({ length: documentCount }, (_, index) => ({
+    path: index === 0 ? "task_plan.md" : `artifacts/evidence-${String(index).padStart(2, "0")}.md`,
+    body: `# Scale fixture document ${index}\n\nPublished body ${index}.\n`
+  }));
+  for (const document of documents) {
+    const absolutePath = path.join(taskRoot, document.path);
+    mkdirSync(path.dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, document.body);
+  }
+  git(authoredRoot, "add", ".");
+  git(authoredRoot, "commit", "-q", "-m", "test: seed scale witness");
+  appendNoopFirstParentMerges(authoredRoot, git(authoredRoot, "rev-parse", "HEAD"), mergeCount);
+
+  const mutatedDocuments = documents.map((document, index) => index === 0
+    ? { ...document, body: `${document.body}\nUnpublished mutation.\n` }
+    : document);
+  writeFileSync(path.join(taskRoot, mutatedDocuments[0]!.path), mutatedDocuments[0]!.body);
+  return { fixtureRoot, rootDir, authoredRoot, taskId, documents: mutatedDocuments };
+}
+
+function appendNoopFirstParentMerges(rootDir: string, initialCommit: string, mergeCount: number): void {
+  const commands = ["feature done\n"];
+  let firstParent = initialCommit;
+  for (let index = 0; index < mergeCount; index += 1) {
+    const sideMark = index * 2 + 1;
+    const mergeMark = sideMark + 1;
+    commands.push(fastImportCommit("refs/heads/fixture-side", sideMark, `fixture side ${index}`, firstParent));
+    commands.push(fastImportCommit(
+      "refs/heads/main",
+      mergeMark,
+      `fixture materialization ${index} [op_fixture_${index}]`,
+      firstParent,
+      `:${sideMark}`
+    ));
+    firstParent = `:${mergeMark}`;
+  }
+  commands.push("done\n");
+  execFileSync("git", ["-C", rootDir, "fast-import", "--quiet"], {
+    input: commands.join(""),
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"]
+  });
+}
+
+function fastImportCommit(
+  ref: string,
+  mark: number,
+  message: string,
+  from: string,
+  merge?: string
+): string {
+  return [
+    `commit ${ref}\n`,
+    `mark :${mark}\n`,
+    "committer Harness Test <harness@example.test> 1750000000 +0000\n",
+    `data ${Buffer.byteLength(message)}\n`,
+    `${message}\n`,
+    `from ${from}\n`,
+    ...(merge ? [`merge ${merge}\n`] : []),
+    "\n"
+  ].join("");
 }
 
 function completeCommand(commitRef: string): TaskCompleteTransitionCommand {


### PR DESCRIPTION
# English

## Summary

On the production-scale repository, every `task complete` deterministically times out against the repo writer's 30,000ms deadline (`watchdog=deadline; lastPhase=compile`), which structurally strands tasks in `in_review`: a task with a submitted Execution can no longer obtain a lease, so even its blocker cannot be recorded. Three consecutive timeouts were captured live today, including one immediately after a fresh daemon restart.

Instrumented measurement — not code reading — located the cost. The completion prepublish witness (`findMaterializedPublication` and `assertMaterializedPublication`) walked the **entire** first-parent history of the authored ledger and ran one `git rev-parse` subprocess per merge per document, and the completion path does this twice (document-publication witness and code-doc witness). At production scale that is ~8,328 merges × 11 documents; a read-only probe on the production ledger exceeded **116 seconds** before being cut off. A synthetic fixture with 1,011 materialization merges and 11 documents reproduced the shape: **more than 35,008ms, killed by the deadline**. Candidates that looked equally guilty by code reading were killed by measurement: the outcomes-store historical scan costs ~5.0s once per child generation (a replacement cold-start amplifier, not the per-write cause), and outcome `begin`/`terminalize` are 12.8ms/24.3ms.

The fix bounds the work instead of raising the deadline:

1. **Fast fail-closed precheck**: the current documents' blob ids are compared against `HEAD` in one batch; any unpublished mutation fails immediately with `AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED`. This also closes a semantic loophole — a working copy dirty-reverted to an old version can no longer borrow an old commit to pass the witness.
2. **Path-scoped history**: candidate publication merges come from `git log --first-parent --full-history -- <task document paths>` instead of the full ledger history. Publication merges touch those paths by construction, so the candidate set is complete.
3. **Batched blob lookup**: one `git ls-tree` per commit replaces per-document `rev-parse` subprocesses.
4. **Telemetry**: the child's `compile` phase now reports sub-phases, so a future stall names its segment instead of `phase=compile at 0ms`.

Positive control, both directions, on the 1,011-merge / 11-document fixture: before — red, >35,008ms, deadline-killed; after — **190.5ms** (independently regenerated fixture: 127.5ms). The 30,000ms deadline, recovery deadlines, authority semantics, and CI/gates are untouched.

## What Changed

- `packages/daemon/src/authority/production/task-complete-prepublish-witness.ts`: HEAD batch precheck, path-scoped first-parent history, batched `ls-tree` blob resolution.
- `packages/daemon/src/authority/production/production-authority-task-completion-intent.ts`, `production-progress-append-operation.ts`, `repo-write-{protocol,diagnostic-protocol,stall-diagnostic}.ts`: compile sub-phase telemetry so the watchdog names the stalled segment.
- Tests: scale regression pinning witness cost against cumulative-history growth (red before the fix at fixture scale), plus diagnostic-protocol coverage.

## Task And Scope

- Harness task: `task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- Branch: `codex/write-cost-scaling`
- Public scope: `packages/daemon/src/**` and tests
- Private planning/evidence updated: yes (root-cause report with full measurement tables in the task package)
- Out of scope: the ~10 orphaned `PROCEEDING` outcomes retried on every write (measured contribution: ~67ms total — real but negligible). Their terminal disposition needs an authority-semantics decision and is recorded as an open item, not invented here.

## Version Impact

- Version: no version change because this is a defect fix on an unreleased surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: orphaned-PROCEEDING terminal disposition (decision required before any implementation)

## Verification

- Base `origin/main` SHA: `86d68d7923b727136f858a8001322686ffa787b6`
- Branch merge-base with `origin/main`: `86d68d7923b727136f858a8001322686ffa787b6`
- Last `git fetch origin` time: immediately before opening this PR
- Sync method: none needed (main has not moved since branch creation)
- Public diff command: `git diff origin/main...codex/write-cost-scaling`
- Private evidence commit/path: task package `artifacts/root-cause-and-fix.md` (measurement decomposition, positive controls)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending, linked once the run completes
- [x] `git diff --check`
- [x] `npm run check:local` — green (this repository's declared local stop point; `check:stop-point` is the same gate set)
- [x] Targeted tests for the change surface, named with their counts: witness scale regression and prepublish witness tests in `packages/daemon/test/task-complete-prepublish-witness.test.ts`; diagnostic protocol tests. Full integration tier: **1454 tests / 1450 pass / 0 fail / 4 skipped.**
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending
- Not run, and why: production acceptance (three consecutive completes on the production ledger, ordinary writes back to seconds, unblocking the stranded task) requires this merge to be deployed; it is scheduled as the post-merge step and explicitly not claimed here.

## Review Evidence

- Self-review: CEO verified the witness diff is equal-or-stricter (the HEAD precheck rejects states the old code could accept via an old commit match; path-scoping cannot drop legitimate publication merges since they touch the scoped paths), and that no deadline or gate changed.
- Reviewer subagent: implementation by Codex worker under a measurement-first contract: instrument → reproduce at synthetic production scale → checkpoint report with the decomposition table → fix. The checkpoint killed two plausible-but-wrong candidates before any code changed.
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Production acceptance is still pending: the fixture reproduces the shape at 1,011 merges, but the production ledger has ~8× more history. The fix's cost is bounded by path-scoped history (~11 relevant commits measured at 1.297s read-only on production), so margin is expected to be large, but it is verified only after deployment.
- The HEAD precheck makes "documents modified but not yet doc-synced" fail fast with a precise error. Flows that previously (accidentally) relied on completing with drifted working copies will now be told to sync first — that is the intended hardening, but it changes the error such flows see.

## References

- Task: `task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- Evidence: task package `artifacts/root-cause-and-fix.md`
- Review: same task package

---

# 中文

## 概要

在生产规模仓库上，每次 `task complete` 都确定性撞穿 repo writer 的 30,000ms deadline（`watchdog=deadline; lastPhase=compile`），并结构性地把任务卡死在 `in_review`：有 submitted Execution 的任务拿不到 lease，连 blocker 都写不进自己的 progress。今天现场捕获三次连续超时，其中一次发生在全新 daemon 重启后立即执行。

定位靠仪器化测量而不是读代码。completion 的 prepublish witness（`findMaterializedPublication` 与 `assertMaterializedPublication`）遍历 authored 账本的**全部** first-parent 历史，并对每个 merge、每份文档各起一个 `git rev-parse` 子进程；completion 路径要做两次（document-publication 与 code-doc 两个 witness）。生产规模约 8,328 merges × 11 documents；对生产账本的只读探针超过 **116 秒**后被主动截断。1,011 个 materialization merge / 11 份文档的合成 fixture 复现同一形状：**超过 35,008ms，被 deadline 杀死**。读代码时同样像真凶的候选被测量逐一排除：outcomes store 历史扫描每个 child generation 只花约 5.0s（是 replacement 冷启动放大器，不是 per-write 主因），outcome `begin`/`terminalize` 各 12.8ms/24.3ms。

修法是给工作量设界，而不是调大 deadline：

1. **快速 fail-closed 预检**：当前文档的 blob id 与 `HEAD` 一次批量比对；任何未发布的改动立即以 `AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED` 失败。这同时堵住一个语义漏洞——working copy 被 dirty-revert 回旧版本后，不能再借旧 commit 通过 witness。
2. **path-scoped 历史**：候选发布 merge 改由 `git log --first-parent --full-history -- <task 文档路径>` 得出，不再扫全账本历史。发布 merge 按构造必然触碰这些路径，候选集完备。
3. **批量 blob 查询**：每个 commit 一次 `git ls-tree`，替代逐文档 `rev-parse` 子进程。
4. **遥测**：child 的 `compile` 阶段上报子阶段，未来卡死会点名具体段，而不是 `phase=compile at 0ms`。

1,011-merge / 11-document fixture 上的双向阳性对照：改动前——红，>35,008ms 被 deadline 杀死；改动后——**190.5ms**（独立重生成的 fixture：127.5ms）。30,000ms deadline、恢复 deadline、authority 语义与 CI/gate 均未触碰。

## 改动内容

- `packages/daemon/src/authority/production/task-complete-prepublish-witness.ts`：HEAD 批量预检、path-scoped first-parent 历史、批量 `ls-tree` blob 解析。
- `packages/daemon/src/authority/production/production-authority-task-completion-intent.ts`、`production-progress-append-operation.ts`、`repo-write-{protocol,diagnostic-protocol,stall-diagnostic}.ts`：compile 子阶段遥测，watchdog 能点名卡住的段。
- 测试：规模回归钉住 witness 成本与累积历史规模解耦（fixture 规模下修复前为红），以及 diagnostic protocol 覆盖。

## 任务与范围

- Harness 任务：`task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- 分支：`codex/write-cost-scaling`
- 公开范围：`packages/daemon/src/**` 及测试
- 私有计划 / 证据是否已更新：yes（任务包 `artifacts/root-cause-and-fix.md` 含完整测量表）
- 范围外：每写被重试的 ~10 个孤儿 `PROCEEDING`（实测贡献合计约 67ms——真实但可忽略）。其终态处置需要 authority 语义决策，已记为 open item，本 PR 不代为发明。

## 版本影响

- 版本：不改版本，原因是这是未发布面上的缺陷修复
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：孤儿 PROCEEDING 终态处置（先 decision 后实现）

## 验证

- `origin/main` 基准 SHA：`86d68d7923b727136f858a8001322686ffa787b6`
- 当前分支与 `origin/main` 的 merge-base：`86d68d7923b727136f858a8001322686ffa787b6`
- 最近一次 `git fetch origin` 时间：开 PR 前即时执行
- 同步方式：不需要（分支创建后 main 未前进）
- 公开 diff 命令：`git diff origin/main...codex/write-cost-scaling`
- 私有证据 commit/path：任务包 `artifacts/root-cause-and-fix.md`（测量分解、阳性对照）
- Reviewer 证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：待 run 完成后补链接
- [x] `git diff --check`
- [x] `npm run check:local` —— 全绿（本仓声明的本地停止点；`check:stop-point` 即同一门集）
- [x] 改动面的定向测试，写明测试名与通过数：`packages/daemon/test/task-complete-prepublish-witness.test.ts` 的 witness 规模回归与 prepublish witness 测试；diagnostic protocol 测试。完整 integration tier：**1454 tests / 1450 pass / 0 fail / 4 skipped。**
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）—— 待跑
- 未跑项及原因：生产验收（生产账本上连续三次 complete、普通写回秒级、解卡被困任务）需要本 PR 合并部署后才能执行；已排为合并后步骤，此处明确不预先宣称。

## 审查证据

- 自查：CEO 核验 witness diff 为等价或更严（HEAD 预检会拒绝旧代码可能借旧 commit 通过的状态；path-scoping 不会漏掉合法发布 merge——它们按构造触碰这些路径），且 deadline 与 gate 零改动。
- Reviewer subagent：Codex worker 在「测量优先」契约下实现：仪器化 → 合成生产规模复现 → 带分解表的 checkpoint 汇报 → 修复。checkpoint 阶段用测量杀掉了两个貌似有理的假真凶，之后才动代码。
- 人工审查：待办
- 阻塞发现：无 open

## 残余风险

- 生产验收未完成：fixture 在 1,011 merges 规模复现形状，生产账本历史约为其 8 倍。修复后的成本被 path-scoped 历史限定（生产只读实测相关 commit 约 11 个、1.297s），预期余量很大，但只有部署后才算数。
- HEAD 预检让「文档已改但未 doc sync」快速失败并给出精确错误。以前（意外地）靠漂移 working copy 完成收口的流程现在会被要求先 sync——这正是预期的加固，但这类流程看到的报错变了。

## 关联材料

- 任务：`task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- 证据：任务包 `artifacts/root-cause-and-fix.md`
- 审查：同一任务包
