### PR TITLE
fix(cli): require receipt ground-truth anchors

### DIFF
--- a/packages/cli/src/cli/command-spec/command-spec-extensions.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-extensions.ts
@@ -34,7 +34,7 @@ export const extensionsCommandSpecs = defineCommandSpecs([
     "parse": parsePresetArgs,
     "run": runExtensionRunnerCommand,
     "receiptContract": {
-      "data": ["presets", "issues"],
+      "data": ["presets", "issues", "rows"],
       "paths": []
     },
     "eventPolicy": {
@@ -238,7 +238,7 @@ export const extensionsCommandSpecs = defineCommandSpecs([
     "parse": parseModuleArgs,
     "run": runExtensionRunnerCommand,
     "receiptContract": {
-      "data": ["modules"],
+      "data": ["modules", "rows"],
       "paths": []
     },
     "eventPolicy": {

--- a/packages/cli/src/cli/command-spec/command-spec-runtime-docs.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-runtime-docs.ts
@@ -185,7 +185,7 @@ export const runtimeDocsCommandSpecs = defineCommandSpecs([
     "parse": parseTemplateArgs,
     "run": runExtensionRunnerCommand,
     "receiptContract": {
-      "data": ["templates", "issues"],
+      "data": ["templates", "issues", "rows"],
       "paths": []
     },
     "eventPolicy": {
@@ -219,7 +219,7 @@ export const runtimeDocsCommandSpecs = defineCommandSpecs([
     "parse": parseCoreTaskArgs,
     "run": runTaskQueryCommand,
     "receiptContract": {
-      "data": ["tasks"],
+      "data": ["tasks", "rows"],
       "paths": []
     },
     "eventPolicy": {

--- a/packages/cli/src/cli/receipt-contracts.ts
+++ b/packages/cli/src/cli/receipt-contracts.ts
@@ -1,8 +1,33 @@
-import { commandSpecMap, type CommandKind } from "./command-spec/index.ts";
-import type { CommandReceiptContract } from "./command-spec/types.ts";
+import { actionForCommand } from "./command-input-descriptors.ts";
+import { commandSpecMap, commandSpecs, type CommandKind } from "./command-spec/index.ts";
+import type { CommandDescriptorIdentity, CommandReceiptContract } from "./command-spec/types.ts";
 
 export type { CommandReceiptContract } from "./command-spec/types.ts";
 export type { CommandKind } from "./command-spec/index.ts";
+
+type ReceiptAnchorDescriptor = CommandDescriptorIdentity & {
+  readonly receiptContract: CommandReceiptContract;
+};
+
+const pathAnchoredActions = new Set(["create", "propose", "record", "scaffold"]);
+
+export function assertCommandReceiptAnchorContracts(
+  descriptors: ReadonlyArray<ReceiptAnchorDescriptor> = commandSpecs
+): void {
+  const violations = descriptors.flatMap((descriptor) => {
+    const action = actionForCommand(descriptor);
+    if (action === "list" && !descriptor.receiptContract.data.includes("rows")) {
+      return [`${descriptor.kind} (${descriptor.usage}) must declare data.rows`];
+    }
+    if (pathAnchoredActions.has(action) && descriptor.receiptContract.paths.length === 0) {
+      return [`${descriptor.kind} (${descriptor.usage}) must declare a required path`];
+    }
+    return [];
+  });
+  if (violations.length > 0) {
+    throw new Error(`Command receipt anchor contract violations:\n${violations.join("\n")}`);
+  }
+}
 
 const canonicalContracts = commandSpecMap((entry) => entry.receiptContract);
 const decisionTransitionContract = { data: ["decisionId", "decisionState", "report"], paths: ["primary"] } satisfies CommandReceiptContract;

--- a/packages/cli/src/cli/receipt.ts
+++ b/packages/cli/src/cli/receipt.ts
@@ -90,6 +90,10 @@ export function renderReceiptText(receipt: CommandReceiptEnvelope): string {
   if (receipt.command === "completion") return renderCompletionText(receipt);
   if (receipt.command === "capabilities") return renderCapabilitiesText(receipt);
   if (receipt.command === "preset list") return renderPresetListText(receipt);
+  return renderSuccessReceiptText(receipt);
+}
+
+function renderSuccessReceiptText(receipt: CommandReceipt): string {
   const data = receiptDetailsData(receipt);
   const parts = [`ok`, `command=${formatToken(receipt.command)}`];
   const rootResolution = receiptRootResolution(receipt.details?.rootResolution);
@@ -150,7 +154,7 @@ function renderPresetListText(receipt: CommandReceipt): string {
     const description = typeof preset.description === "string" ? preset.description : title;
     return [`${preset.id} — ${title} — ${description}`];
   });
-  return rows.length > 0 ? rows.join("\n") : "No presets installed.";
+  return [rows.length > 0 ? rows.join("\n") : "No presets installed.", renderSuccessReceiptText(receipt)].join("\n");
 }
 
 function receiptWarningCode(value: unknown): string | undefined {

--- a/packages/cli/src/commands/core/task-query.ts
+++ b/packages/cli/src/commands/core/task-query.ts
@@ -32,6 +32,7 @@ export const runTaskQueryCommand: CommandRunner = (context, command) => {
       return {
         ok: true,
         command: "task-list",
+        rows: result.rows.length,
         tasks: result.rows,
         warnings: result.warnings
       } satisfies CliResult;

--- a/packages/cli/src/commands/extensions/module.ts
+++ b/packages/cli/src/commands/extensions/module.ts
@@ -25,10 +25,12 @@ export function runModuleCommand(rootInput: HarnessLayoutInput, action: ModuleAc
   const layout = resolveHarnessLayout(rootInput);
   const rootDir = layout.rootDir;
   if (action.kind === "module-list") {
+    const modules = readModules(rootInput).modules.filter((module) => module.status !== "unregistered");
     return {
       ok: true,
       command: "module-list",
-      modules: readModules(rootInput).modules.filter((module) => module.status !== "unregistered")
+      rows: modules.length,
+      modules
     };
   }
 

--- a/packages/cli/src/commands/extensions/preset-query.ts
+++ b/packages/cli/src/commands/extensions/preset-query.ts
@@ -68,6 +68,7 @@ export function runPresetList(rootInput: HarnessLayoutInput, activeVerticalId: s
   return {
     ok: true,
     command: "preset-list",
+    rows: validations.length,
     presets: validations.map((entry) => entry.summary),
     issues,
     warnings

--- a/packages/cli/src/commands/extensions/template.ts
+++ b/packages/cli/src/commands/extensions/template.ts
@@ -26,16 +26,18 @@ export function runTemplateCommand(rootInput: HarnessLayoutInput, action: Templa
     }
     const catalog = decoded.value;
     const validation = validateTemplateCatalog(catalog, { resolveBody: resolveTemplateCatalogBody(catalog) });
+    const templates = catalog.documents.map((document) => ({
+      templateRef: `template://${document.id}@${document.version}`,
+      documentKind: document.documentKind,
+      slot: document.slot,
+      materializeAs: document.materializeAs,
+      locales: document.locales.map((variant) => variant.locale)
+    }));
     return {
       ok: validation.ok,
       command: "template-list",
-      templates: catalog.documents.map((document) => ({
-        templateRef: `template://${document.id}@${document.version}`,
-        documentKind: document.documentKind,
-        slot: document.slot,
-        materializeAs: document.materializeAs,
-        locales: document.locales.map((variant) => variant.locale)
-      })),
+      rows: templates.length,
+      templates,
       issues: validation.issues,
       error: validation.ok ? undefined : cliError(CliErrorCode.TemplateCatalogInvalid, "Template catalog failed validation.")
     };

--- a/packages/cli/test/extension-cli.test.ts
+++ b/packages/cli/test/extension-cli.test.ts
@@ -18,6 +18,7 @@ test("CLI template list emits stable JSON over the template catalog", () => {
 
   assert.equal(result.ok, true);
   assert.equal(result.command, "template-list");
+  assert.equal(result.rows, result.templates.length);
   assert.deepEqual(result.templates, [{
     templateRef: "template://planning/task-flow@1",
     documentKind: "task-flow",

--- a/packages/cli/test/preset-document-cli.test.ts
+++ b/packages/cli/test/preset-document-cli.test.ts
@@ -32,6 +32,7 @@ test("CLI preset summaries load PRESET.md frontmatter", () => {
     ].join("\n"));
 
     const listed = runJson(rootDir, ["preset", "list"]);
+    assert.equal(listed.rows, listed.presets.length);
     const custom = listed.presets.find((preset: Record<string, unknown>) => preset.id === "custom-task");
     assert.equal(custom.description, "Prepare a custom implementation task.");
     assert.equal(custom.whenToUse, "Use when the standard task shape needs project-specific guidance.");
@@ -48,9 +49,10 @@ test("CLI preset list text prints one semantic row per bundled preset", () => {
     });
     const rows = stdout.trim().split("\n");
     const bundledPresetIndex = JSON.parse(readFileSync(bundledPresetIndexPath, "utf8")) as { readonly presets: ReadonlyArray<string> };
-    assert.equal(rows.length, bundledPresetIndex.presets.length);
-    assert.equal(rows.every((row) => row.split(" — ").length === 3), true);
+    assert.equal(rows.length, bundledPresetIndex.presets.length + 1);
+    assert.equal(rows.slice(0, -1).every((row) => row.split(" — ").length === 3), true);
     assert.equal(rows.some((row) => row.startsWith("standard-task — Standard Task — Create the standard planning")), true);
+    assert.match(rows.at(-1) ?? "", new RegExp(`^ok command="preset list" rows=${bundledPresetIndex.presets.length} summary=`, "u"));
   });
 });
 

--- a/packages/cli/test/preset-module-cli.test.ts
+++ b/packages/cli/test/preset-module-cli.test.ts
@@ -466,6 +466,7 @@ test("CLI module CRUD maintains generated module view and module-step state", ()
 
     const listed = runJson(rootDir, ["module", "list"]);
     assert.equal(listed.ok, true);
+    assert.equal(listed.rows, 1);
     assert.equal(listed.modules.length, 1);
     assert.equal(listed.modules[0].key, "billing");
 

--- a/packages/cli/test/receipt-contracts.test.ts
+++ b/packages/cli/test/receipt-contracts.test.ts
@@ -2,8 +2,27 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { toCliError } from "../src/cli/error-mapper.ts";
-import { commandReceiptContractsByKind } from "../src/cli/receipt-contracts.ts";
+import { commandDescriptors } from "../src/cli/command-registry.ts";
+import {
+  assertCommandReceiptAnchorContracts,
+  commandReceiptContractsByKind
+} from "../src/cli/receipt-contracts.ts";
 import { renderReceiptText, toCommandReceipt } from "../src/cli/receipt.ts";
+
+test("list and creation command families declare ground-truth receipt anchors", () => {
+  assert.doesNotThrow(() => assertCommandReceiptAnchorContracts(commandDescriptors));
+});
+
+test("receipt anchor regression gate rejects a new list command without rows", () => {
+  assert.throws(
+    () => assertCommandReceiptAnchorContracts([{
+      kind: "fixture-list",
+      usage: "fixture list [--json]",
+      receiptContract: { data: ["items"], paths: [] }
+    }]),
+    /fixture-list .* must declare data\.rows/u
+  );
+});
 
 test("command receipts fail closed on undeclared path fields", () => {
   const receipt = toCommandReceipt({
@@ -480,6 +499,7 @@ test("preset list text renders id, title, and description rows", () => {
       title: "Standard Task",
       description: "Handle general implementation and maintenance work."
     }],
+    rows: 1,
     issues: []
   });
 
@@ -487,7 +507,10 @@ test("preset list text renders id, title, and description rows", () => {
   if (!receipt.ok) return;
   assert.equal(
     renderReceiptText(receipt),
-    "standard-task — Standard Task — Handle general implementation and maintenance work."
+    [
+      "standard-task — Standard Task — Handle general implementation and maintenance work.",
+      "ok command=\"preset list\" rows=1 summary=\"completed preset list with 1 row\""
+    ].join("\n")
   );
 });
 

--- a/packages/cli/test/task-list-cli.test.ts
+++ b/packages/cli/test/task-list-cli.test.ts
@@ -62,6 +62,11 @@ test("CLI task list filters projection rows without treating generated cache as 
 
     const defaultList = runJson(rootDir, ["task", "list"]);
     assert.deepEqual(defaultList.tasks.map((row: Record<string, unknown>) => row.taskId), ["task-billing", "task-missing", "task-review"]);
+    assert.equal(defaultList.rows, 3);
+    assert.match(
+      runText(rootDir, ["task", "list"]).trim().split(/\r?\n/u).at(-1) ?? "",
+      /^ok command="task list" rows=3 summary="completed task list with 3 rows"$/u
+    );
 
     const openList = runJson(rootDir, ["task", "list", "--state", "open"]);
     assert.deepEqual(openList.tasks.map((row: Record<string, unknown>) => row.taskId), ["task-billing"]);
@@ -206,6 +211,12 @@ function runJson(rootDir: string, args: ReadonlyArray<string>): Record<string, a
     encoding: "utf8"
   });
   return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
+}
+
+function runText(rootDir: string, args: ReadonlyArray<string>): string {
+  return execFileSync(process.execPath, [cliEntry, "--root", rootDir, ...args], {
+    encoding: "utf8"
+  });
 }
 
 function runJsonFailure(rootDir: string, args: ReadonlyArray<string>): Record<string, any> {


### PR DESCRIPTION
# English

## Summary

A real first-mile incident on the kty-web pilot: an agent judged `ha task list | tail -15` as "0 rows", because `task list`'s text summary was just `"completed task list"` — with no row count, a truncated output cannot distinguish "genuinely empty" from "rows cut off". It then could not cross-check with its create receipt either, because `task create`'s text receipt did not carry the package path (the JSON receipt does). Four wrong hypotheses (TMPDIR split, socket, daemon, root mismatch) followed, none of which a single receipt could falsify on the spot.

The mechanism already existed — `receipt.ts` renders `completed <cmd> with N rows` when a receipt declares `rows`, and `doc status` uses it — but adoption was per-command and voluntary. That is the same declared-surface-vs-implementation drift shape this repository has been converging all along, landing on the first mile of a new user.

This PR makes the anchors mandatory by contract: every `list`-action command must declare `data.rows`; every creation-family command (`create`/`propose`/`record`/`scaffold`) must declare a required path. A contract-tier gate (`assertCommandReceiptAnchorContracts`) runs over the full command registry, so a future command that omits its anchor goes red in tests instead of shipping silently. `task list` now reports real projection row counts; `task create` prints its package path in the text receipt; `preset list`'s bare text output now ends with the standard receipt line.

## What Changed

- `packages/cli/src/cli/receipt-contracts.ts`: `assertCommandReceiptAnchorContracts` — list commands must declare `data.rows`, creation-family commands must declare a required path; violations name the command and its usage line.
- `packages/cli/src/cli/receipt.ts`: success-receipt text rendering extracted; `preset list` appends the standard receipt line after its listing.
- `packages/cli/src/commands/core/task-query.ts`: `task list` result carries `rows`.
- `packages/cli/src/commands/extensions/*`, `command-spec-{extensions,runtime-docs}.ts`: backfilled the commands the new gate flagged.
- Tests: gate green over the real registry; positive control — a fixture list command without `rows` fails with a named violation; `task list` CLI test asserts the rendered summary.

## Task And Scope

- Harness task: `task_01KZ3RJ0ME73PBNCX8GWT78060`
- Branch: `codex/receipt-anchors`
- Public scope: `packages/cli/src/**` and tests
- Private planning/evidence updated: yes
- Out of scope: JSON schema changes (only the additive `rows` field with existing semantics); daemon/kernel surfaces.

## Version Impact

- Version: no version change because this is an unreleased surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KZ3RJ0ME73PBNCX8GWT78060`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `93135e98f817d63f500ec52ec7ff929c3c6fc6a5`
- Branch merge-base with `origin/main`: `93135e98f817d63f500ec52ec7ff929c3c6fc6a5`
- Last `git fetch origin` time: immediately before opening this PR
- Sync method: none needed (main has not moved since branch creation)
- Public diff command: `git diff origin/main...codex/receipt-anchors`
- Private evidence commit/path: task package `artifacts/implementation-report.md`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending, linked once the run completes
- [x] `git diff --check`
- [x] `npm run check:local` — green (this repository's declared local stop point; `check:stop-point` is the same gate set)
- [x] Targeted tests for the change surface, named with their counts: `receipt-contracts.test.ts` (contract tier, includes the red positive control), `task-list-cli.test.ts` summary assertion; contract tests 21/21. Full integration tier: green.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending
- Not run, and why: nothing was skipped; `rewrite-ci` is pending rather than skipped.

Real receipts from the fixture run (usability acceptance):

```text
ok command="task list" rows=1 summary="completed task list with 1 row"
ok command="task create" task=task_01KZ3T8851QYJ51WV21ZZNXR25 status=planned path=harness/tasks/task_01KZ3T8851QYJ51WV21ZZNXR25-receipt-anchor-acceptance ...
```

## Review Evidence

- Self-review: CEO verified the gate covers the full registry (the backfilled extension/preset/template commands are exactly the violations it flagged), the positive control names its violation, and `--json` consumers are unaffected.
- Reviewer subagent: implementation by Codex worker from a task plan carrying the full incident chain; the worker surveyed the command surface and chose contract-gate enforcement over per-command patching.
- Human review: pending
- Blocking findings: none open

## Residual Risk

- `preset list` text output gains a trailing receipt line; no text-parsing consumer was found, but any undiscovered one would see one extra line.
- The gate classifies commands by derived action name; a future list-like command whose action string is not `list` would evade it. The violation message format makes such gaps cheap to extend when noticed.

## References

- Task: `task_01KZ3RJ0ME73PBNCX8GWT78060`
- Evidence: task package `artifacts/implementation-report.md`
- Review: same task package

---

# 中文

## 概要

kty-web 试点的一次真实首公里事故：一个 agent 用 `ha task list | tail -15` 判「0 行」——因为 `task list` 的文本 summary 只有 `"completed task list"`，**不带行数**，截尾后「真空」与「有行被截」不可分辨；它也没法用 create 回执反查，因为 `task create` 的文本回执不带任务包路径（JSON 里有）。随后四个错误假设（TMPDIR 分裂、socket、daemon、root 错位）没有一个能被一条回执当场证伪。

机制其实早就存在——`receipt.ts` 在回执声明 `rows` 时会渲染 `completed <cmd> with N rows`，`doc status` 就在用——但接入是按命令自愿的。这正是本仓一路在收敛的「声明面 ≠ 实现面」漂移形状，砸在了新用户的第一公里上。

本 PR 把锚变成契约强制：所有 `list` 类命令必须声明 `data.rows`；所有创建族命令（`create`/`propose`/`record`/`scaffold`）必须声明必填路径。contract tier 的门（`assertCommandReceiptAnchorContracts`）扫全命令注册表——未来新命令漏声明会在测试期变红，而不是静默上线。`task list` 现在报真实投影行数；`task create` 文本回执带任务包路径；`preset list` 的裸列表输出末尾补上标准回执行。

## 改动内容

- `packages/cli/src/cli/receipt-contracts.ts`：`assertCommandReceiptAnchorContracts`——list 命令必须声明 `data.rows`，创建族必须声明必填路径；违规信息点名命令与其 usage 行。
- `packages/cli/src/cli/receipt.ts`：成功回执文本渲染抽出；`preset list` 列表后追加标准回执行。
- `packages/cli/src/commands/core/task-query.ts`：`task list` 结果携带 `rows`。
- `packages/cli/src/commands/extensions/*`、`command-spec-{extensions,runtime-docs}.ts`：回填新门点名的缺口命令。
- 测试：门对真实注册表全绿；阳性对照——无 `rows` 的假想 list 命令以点名违规失败；`task list` CLI 测试断言渲染后的 summary。

## 任务与范围

- Harness 任务：`task_01KZ3RJ0ME73PBNCX8GWT78060`
- 分支：`codex/receipt-anchors`
- 公开范围：`packages/cli/src/**` 及测试
- 私有计划 / 证据是否已更新：yes
- 范围外：JSON schema 变更（仅新增语义不变的 `rows` 字段）；daemon/kernel 面。

## 版本影响

- 版本：不改版本，原因是这是未发布面
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`task_01KZ3RJ0ME73PBNCX8GWT78060`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`93135e98f817d63f500ec52ec7ff929c3c6fc6a5`
- 当前分支与 `origin/main` 的 merge-base：`93135e98f817d63f500ec52ec7ff929c3c6fc6a5`
- 最近一次 `git fetch origin` 时间：开 PR 前即时执行
- 同步方式：不需要（分支创建后 main 未前进）
- 公开 diff 命令：`git diff origin/main...codex/receipt-anchors`
- 私有证据 commit/path：任务包 `artifacts/implementation-report.md`
- Reviewer 证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：待 run 完成后补链接
- [x] `git diff --check`
- [x] `npm run check:local` —— 全绿（本仓声明的本地停止点；`check:stop-point` 即同一门集）
- [x] 改动面的定向测试，写明测试名与通过数：`receipt-contracts.test.ts`（contract tier，含红色阳性对照）、`task-list-cli.test.ts` summary 断言；contract 21/21。完整 integration tier：全绿。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）—— 待跑
- 未跑项及原因：没有跳过项；`rewrite-ci` 是待跑，不是跳过。

fixture 实跑的真实回执（使用性验收）：

```text
ok command="task list" rows=1 summary="completed task list with 1 row"
ok command="task create" task=task_01KZ3T8851QYJ51WV21ZZNXR25 status=planned path=harness/tasks/task_01KZ3T8851QYJ51WV21ZZNXR25-receipt-anchor-acceptance ...
```

## 审查证据

- 自查：CEO 核验门覆盖全注册表（被回填的 extension/preset/template 命令正是它点名的违规项）、阳性对照点名违规、`--json` 消费者零影响。
- Reviewer subagent：Codex worker 依携带完整事故链的 task plan 实现；worker 盘点命令面后选择契约门强制而非逐命令打补丁。
- 人工审查：待办
- 阻塞发现：无 open

## 残余风险

- `preset list` 文本输出末尾新增一行回执；未发现文本解析消费方，若有未发现的会多看到一行。
- 门按派生的 action 名分类；未来某个 list 形态命令若 action 字符串不是 `list` 会绕过它。违规信息格式让此类缺口被注意到时扩展成本很低。

## 关联材料

- 任务：`task_01KZ3RJ0ME73PBNCX8GWT78060`
- 证据：任务包 `artifacts/implementation-report.md`
- 审查：同一任务包
