### PR TITLE
fix: amortize repo write conflict preflight to one scan per writer generation

### DIFF
--- a/packages/application/src/authority/daemon-host-contract.ts
+++ b/packages/application/src/authority/daemon-host-contract.ts
@@ -12,6 +12,7 @@ import type {
   ReviewVerdict,
   SemanticDiffDocumentPolicy,
   OperationalActor,
+  ProjectionWarning,
   TaskWorkKind,
   TaskHolderExecutor,
   TaskHolderPersonPrincipal,
@@ -298,7 +299,13 @@ export interface DaemonHostCommandExecutionOptions {
   readonly makeOperationalWriteCoordinator: (
     actor: OperationalActor
   ) => WriteCoordinator;
+  readonly onTelemetry?: (phase: DaemonHostCommandExecutionTelemetryPhase) => void;
+  readonly conflictMarkerPreflight?: () => ProjectionWarning | undefined;
 }
+
+export type DaemonHostCommandExecutionTelemetryPhase =
+  | "command-conflict-preflight"
+  | "command-conflict-recheck";
 
 export type DaemonCommandHostError =
   | { readonly code: "invalid_session"; readonly context: { readonly cause: string } }

--- a/packages/application/src/authority/service-options.ts
+++ b/packages/application/src/authority/service-options.ts
@@ -38,7 +38,19 @@ export interface AuthoritySubmissionServiceOptions {
   readonly now?: () => string;
   readonly v2?: AuthoritySubmissionV2Options;
   readonly admissionBudget?: DaemonAdmissionBudget;
+  readonly onTelemetry?: (phase: AuthoritySubmissionTelemetryPhase) => void;
 }
+
+export type AuthoritySubmissionTelemetryPhase =
+  | "authority-admission"
+  | "authority-binding-verified"
+  | "authority-batch-start"
+  | "authority-generation-acquire"
+  | "authority-generation-held"
+  | "authority-coordinator-enqueue"
+  | "authority-coordinator-enqueued"
+  | "authority-prepared-persisted"
+  | "authority-flush-start";
 
 export interface AuthoritySubmissionV2Options {
   readonly schemaTuple: ProtocolSchemaTupleV2;

--- a/packages/application/src/authority/service.ts
+++ b/packages/application/src/authority/service.ts
@@ -121,11 +121,13 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
     // The presentation token is authenticated before the semantic payload is
     // decoded. A reconnect may present a newer token for the same protected
     // binding; the envelope's original admissionTokenRef is checked separately.
+    options.onTelemetry?.("authority-admission");
     const verified = await validateActorAxesBindingPresentationV2(attempt.presentationToken, v2.bindingRuntime, {
       workspaceId: options.workspaceId,
       channelNonceDigest: v2.channelNonceDigest,
       schemaTuple: v2.schemaTuple
     });
+    options.onTelemetry?.("authority-binding-verified");
     const envelope = decodeSemanticMutationEnvelopeV2(attempt.envelope);
     const opId = operationIdDiagnosticV2(envelope.operationId);
     return runWithAuthorityAdmission({
@@ -208,6 +210,7 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
   }
 
   async function publishBatch(admissions: ReadonlyArray<AuthorityAdmission>): Promise<ReadonlyArray<AuthorityOperationReceipt>> {
+    options.onTelemetry?.("authority-batch-start");
     const receipts = new Map<PreparedAuthoritySubmission, AuthorityOperationReceipt>();
     const prepared = admissions.filter((admission): admission is PreparedAuthoritySubmission => admission.kind === "prepared");
     if (prepared.length === 0) return admissions.map((admission) => (admission as TerminalAuthoritySubmission).receipt);
@@ -249,7 +252,9 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
         try {
           await options.generationFenceWitness?.assertHeld("before-prepare", entry);
           await entry.publicationRevalidation?.();
+          options.onTelemetry?.("authority-coordinator-enqueue");
           const acknowledgement = await Effect.runPromise(entry.coordinator.enqueue(entry.operation));
+          options.onTelemetry?.("authority-coordinator-enqueued");
           if (acknowledgement.journalWitness) {
             journalWitnesses.set(entry, acknowledgement.journalWitness);
           }
@@ -286,6 +291,7 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
             entry.recoveryPublicationPolicy,
             entry.fixedOperationBinding
           );
+          options.onTelemetry?.("authority-prepared-persisted");
           candidates.push(entry);
         } catch (error) {
           if (isDaemonGenerationFenced(error)) throw error;
@@ -316,6 +322,7 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
         && candidates.every((candidate) => candidate.coordinator === batchCoordinator)
         && exactBatchWitnesses.length === candidates.length
         && batchCoordinator.flushExactJournalRecords;
+      options.onTelemetry?.("authority-flush-start");
       const flush = recoveryCandidate
         ? await Effect.runPromise(recoveryCandidate.coordinator.flushExactJournalRecord!(
           "recovery",
@@ -488,13 +495,20 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
     return batchReceipts(admissions, receipts);
     };
     try {
+      options.onTelemetry?.("authority-generation-acquire");
       return options.generationFenceWitness
         ? await options.generationFenceWitness.runExclusive(
           "before-canonical-publish",
           prepared[0],
-          publishWhileGenerationCurrent
+          () => {
+            options.onTelemetry?.("authority-generation-held");
+            return publishWhileGenerationCurrent();
+          }
         )
-        : await publishWhileGenerationCurrent();
+        : await (() => {
+          options.onTelemetry?.("authority-generation-held");
+          return publishWhileGenerationCurrent();
+        })();
     } catch (error) {
       if (!isDaemonGenerationFenced(error)) throw error;
       for (const entry of prepared) {

--- a/packages/cli/src/cli/conflict-preflight.ts
+++ b/packages/cli/src/cli/conflict-preflight.ts
@@ -1,9 +1,44 @@
 import type { HarnessLayoutInput, ProjectionWarning } from "@harness-anything/kernel";
 import { findConflictMarkerWarnings } from "@harness-anything/kernel";
 import { cliError, CliErrorCode } from "./error-codes.ts";
-import type { CliResult } from "./types.ts";
+import { requiresConflictMarkerPreflight } from "./command-event-policy.ts";
+import { receiptCommandKind } from "./receipt-command-kind.ts";
+import type { CliResult, ParsedCommand } from "./types.ts";
 
-export function readConflictMarkerPreflight(command: string, layoutInput: HarnessLayoutInput): {
+export interface ConflictMarkerExecutionBoundary {
+  readonly authorityCommandSubmission: boolean;
+  readonly outerProceedingRecovery: boolean;
+  readonly onTelemetry?: (phase: "command-conflict-preflight" | "command-conflict-recheck") => void;
+  readonly conflictMarkerPreflight?: () => ProjectionWarning | undefined;
+}
+
+export function readCommandConflictMarkerFailure(
+  command: ParsedCommand,
+  layoutInput: HarnessLayoutInput,
+  execution: ConflictMarkerExecutionBoundary
+): CliResult | undefined {
+  if (!requiresConflictMarkerPreflight(command.action)) return undefined;
+  const result = readConflictMarkerPreflight(
+    receiptCommandKind(command.action),
+    layoutInput,
+    execution.conflictMarkerPreflight
+  );
+  execution.onTelemetry?.("command-conflict-preflight");
+  if (!result.ok) return result.result;
+  if (!result.warning) return undefined;
+  return {
+    ok: false,
+    command: receiptCommandKind(command.action),
+    warnings: [result.warning],
+    error: cliError(CliErrorCode.ConflictMarkerPresent, result.warning.message)
+  } satisfies CliResult;
+}
+
+export function readConflictMarkerPreflight(
+  command: string,
+  layoutInput: HarnessLayoutInput,
+  readWarning: (() => ProjectionWarning | undefined) | undefined = undefined
+): {
   readonly ok: true;
   readonly warning?: ProjectionWarning;
 } | {
@@ -11,7 +46,10 @@ export function readConflictMarkerPreflight(command: string, layoutInput: Harnes
   readonly result: CliResult;
 } {
   try {
-    return { ok: true, warning: findConflictMarkerWarnings(layoutInput)[0] };
+    return {
+      ok: true,
+      warning: readWarning ? readWarning() : findConflictMarkerWarnings(layoutInput)[0]
+    };
   } catch (error) {
     return {
       ok: false,

--- a/packages/cli/src/cli/runner-registry.ts
+++ b/packages/cli/src/cli/runner-registry.ts
@@ -11,7 +11,10 @@ import { commandSpecMap, commandSpecs, type CommandKind } from "./command-spec/i
 import type { CommandSpecDefinition } from "./command-spec/types.ts";
 import { commandDescriptors, commandRegistry } from "./command-registry.ts";
 import type { CommandDescriptor } from "./command-registry.ts";
-import { readConflictMarkerPreflight } from "./conflict-preflight.ts";
+import {
+  readCommandConflictMarkerFailure,
+  type ConflictMarkerExecutionBoundary
+} from "./conflict-preflight.ts";
 import { cliError, CliErrorCode } from "./error-codes.ts";
 import { toCliError } from "./error-mapper.ts";
 import { actionTaskId } from "./parse-args.ts";
@@ -129,24 +132,15 @@ export function runRegisteredCommand(
   makeTaskHolderService: () => TaskHolderService,
   makeRuntimeEventLedgerService: () => RuntimeEventLedgerService,
   runLedgerMaterializer: (rootInput: HarnessLayoutInput, options: { readonly dryRun?: boolean }) => MaterializerCommandReport,
-  execution: {
-    readonly authorityCommandSubmission: boolean;
-    readonly outerProceedingRecovery: boolean;
-  } = { authorityCommandSubmission: false, outerProceedingRecovery: false }
+  execution: ConflictMarkerExecutionBoundary = {
+    authorityCommandSubmission: false,
+    outerProceedingRecovery: false
+  }
 ): CommandRunnerEffect {
   const runner = runnerRegistry[command.action.kind];
   const layoutInput = createHarnessRuntimeContext(command.rootDir, command.layoutOverrides);
-  const conflictMarkerResult = requiresConflictMarkerPreflight(command.action) ? readConflictMarkerPreflight(receiptCommandKind(command.action), layoutInput) : undefined;
-  if (conflictMarkerResult?.ok === false) return Effect.succeed(conflictMarkerResult.result);
-  const conflictMarkerWarning = conflictMarkerResult?.warning;
-  if (conflictMarkerWarning) {
-    return Effect.succeed({
-      ok: false,
-      command: receiptCommandKind(command.action),
-      warnings: [conflictMarkerWarning],
-      error: cliError(CliErrorCode.ConflictMarkerPresent, conflictMarkerWarning.message)
-    } satisfies CliResult);
-  }
+  const conflictMarkerFailure = readCommandConflictMarkerFailure(command, layoutInput, execution);
+  if (conflictMarkerFailure) return Effect.succeed(conflictMarkerFailure);
   let engine: CommandRunnerEngine | undefined;
   let artifactStore: Pick<ArtifactStore, "readTaskPackage" | "readAuthoredDocument"> | undefined;
   let currentSessionProbe: CurrentSessionProbePort | undefined;

--- a/packages/cli/src/composition/command-executor.ts
+++ b/packages/cli/src/composition/command-executor.ts
@@ -11,6 +11,7 @@ import {
   makeRuntimeEventAppendPromise,
   makeTaskHolderService,
   taskStatusLeaseRequired,
+  type DaemonHostCommandExecutionOptions,
   type ProvenanceSessionExporterRejected,
   type ProvenanceSessionExportResult,
   type TaskHolderPrincipal
@@ -52,6 +53,8 @@ export interface ParsedCommandExecutionOptions {
   readonly syncExportedSession?: (result: ProvenanceSessionExportResult) => Effect.Effect<void, ProvenanceSessionExporterRejected>;
   /** Explicit local composition scopes outside the daemon-owned product route. */
   readonly localCoordinatorScope?: LocalCoordinatorScope;
+  readonly onTelemetry?: DaemonHostCommandExecutionOptions["onTelemetry"];
+  readonly conflictMarkerPreflight?: DaemonHostCommandExecutionOptions["conflictMarkerPreflight"];
 }
 
 export async function runRegisteredCommandWithCliComposition(
@@ -144,7 +147,12 @@ export async function runRegisteredCommandWithCliComposition(
       sessionId: getSessionBranchId()
     }), getActorAttribution, options.missingActorAttributionMessage, actor)) : missingInjectedWriteCoordinator);
   const makeWriteCoordinator = requiresConflictMarkerPreflight(command.action)
-    ? (actor: OperationalActor) => withConflictMarkerFlushRecheck(rawMakeWriteCoordinator(actor), layoutInput)
+    ? (actor: OperationalActor) => withConflictMarkerFlushRecheck(
+        rawMakeWriteCoordinator(actor),
+        layoutInput,
+        options.onTelemetry,
+        options.conflictMarkerPreflight
+      )
     : rawMakeWriteCoordinator;
   const rawMakeMigrationWriteCoordinator = options.makeMigrationWriteCoordinator ?? (allowLocalCoordinator ? ((actor: OperationalActor, evidenceRef: string) =>
     makeAttributedWriteCoordinator(() => {
@@ -160,7 +168,9 @@ export async function runRegisteredCommandWithCliComposition(
   const makeMigrationWriteCoordinator = requiresConflictMarkerPreflight(command.action)
     ? (actor: OperationalActor, evidenceRef: string) => withConflictMarkerFlushRecheck(
       rawMakeMigrationWriteCoordinator(actor, evidenceRef),
-      layoutInput
+      layoutInput,
+      options.onTelemetry,
+      options.conflictMarkerPreflight
     )
     : rawMakeMigrationWriteCoordinator;
   const rawMakeSessionWriteCoordinator = options.makeWriteCoordinator ?? (allowLocalCoordinator ? ((actor: OperationalActor) =>
@@ -171,7 +181,12 @@ export async function runRegisteredCommandWithCliComposition(
       commitAuthor: getActorAttribution().commitAuthor
     }), getActorAttribution, options.missingActorAttributionMessage, actor)) : missingInjectedWriteCoordinator);
   const makeSessionWriteCoordinator = requiresConflictMarkerPreflight(command.action)
-    ? (actor: OperationalActor) => withConflictMarkerFlushRecheck(rawMakeSessionWriteCoordinator(actor), layoutInput)
+    ? (actor: OperationalActor) => withConflictMarkerFlushRecheck(
+        rawMakeSessionWriteCoordinator(actor),
+        layoutInput,
+        options.onTelemetry,
+        options.conflictMarkerPreflight
+      )
     : rawMakeSessionWriteCoordinator;
 
   const makeArtifactStore = () => provider.createArtifactStore({
@@ -243,7 +258,9 @@ export async function runRegisteredCommandWithCliComposition(
     })
   }), enforceTaskLease(), makeTaskHolder, getTaskHolderPrincipal, options.taskLeaseGuardMode), makeTaskHolder, getRuntimeEventLedgerService, provider.runLedgerMaterializer, {
     authorityCommandSubmission: options.inlineCreateProvenanceOnly === true,
-    outerProceedingRecovery: options.outerProceedingRecovery === true
+    outerProceedingRecovery: options.outerProceedingRecovery === true,
+    onTelemetry: options.onTelemetry,
+    conflictMarkerPreflight: options.conflictMarkerPreflight
   }).pipe(
     Effect.match({
       onFailure: (error): CliResult => ({
@@ -402,13 +419,21 @@ function taskLeaseWriteError(error: unknown): WriteError {
 
 function withConflictMarkerFlushRecheck(
   coordinator: WriteCoordinator,
-  rootInput: ReturnType<typeof createHarnessRuntimeContext>
+  rootInput: ReturnType<typeof createHarnessRuntimeContext>,
+  onTelemetry: DaemonHostCommandExecutionOptions["onTelemetry"],
+  conflictMarkerPreflight: DaemonHostCommandExecutionOptions["conflictMarkerPreflight"]
 ): WriteCoordinator {
   return {
     enqueue: coordinator.enqueue,
     recover: coordinator.recover,
     flush: (reason) => Effect.try({
-      try: () => findConflictMarkerWarnings(rootInput)[0],
+      try: () => {
+        const warning = conflictMarkerPreflight
+          ? conflictMarkerPreflight()
+          : findConflictMarkerWarnings(rootInput)[0];
+        onTelemetry?.("command-conflict-recheck");
+        return warning;
+      },
       catch: (cause) => ({ _tag: "JournalUnavailable" as const, cause })
     }).pipe(
       Effect.flatMap((warning) => warning

--- a/packages/cli/src/composition/incremental-conflict-marker-preflight.ts
+++ b/packages/cli/src/composition/incremental-conflict-marker-preflight.ts
@@ -1,0 +1,107 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import {
+  findConflictMarkerWarnings,
+  resolveHarnessLayout,
+  type HarnessLayoutInput,
+  type ProjectionWarning
+} from "@harness-anything/kernel";
+
+export interface IncrementalConflictMarkerPreflight {
+  readonly read: () => ProjectionWarning | undefined;
+}
+
+export interface IncrementalConflictMarkerPreflightScan {
+  readonly mode: "full" | "incremental";
+  readonly candidateCount?: number;
+}
+
+/**
+ * Keeps the authored-tree conflict baseline for one long-lived writer generation.
+ * The first read covers every governed text file; later reads cover only paths whose
+ * Git state differs from the last clean authored HEAD plus the two root policy files.
+ */
+export function makeIncrementalConflictMarkerPreflight(
+  rootInput: HarnessLayoutInput,
+  options: {
+    readonly onScan?: (scan: IncrementalConflictMarkerPreflightScan) => void;
+  } = {}
+): IncrementalConflictMarkerPreflight {
+  const layout = resolveHarnessLayout(rootInput);
+  let cleanAuthoredHead: string | undefined;
+
+  return {
+    read: () => {
+      const currentHead = readGitHead(layout.authoredRoot);
+      const changedAuthoredPaths = cleanAuthoredHead && currentHead
+        ? readChangedGitPaths(layout.authoredRoot, cleanAuthoredHead)
+        : null;
+      if (changedAuthoredPaths === null) {
+        options.onScan?.({ mode: "full" });
+        const warning = findConflictMarkerWarnings(rootInput)[0];
+        if (!warning && currentHead) cleanAuthoredHead = currentHead;
+        return warning;
+      }
+
+      const candidates = [...new Set([
+        path.join(layout.rootDir, "AGENTS.md"),
+        path.join(layout.rootDir, "CLAUDE.md"),
+        ...changedAuthoredPaths.map((entry) => path.join(layout.authoredRoot, entry))
+      ].filter((entry) => isTextLikePath(entry)))];
+      options.onScan?.({ mode: "incremental", candidateCount: candidates.length });
+      const warning = findConflictMarkerWarnings(rootInput, candidates)[0];
+      if (!warning && currentHead) cleanAuthoredHead = currentHead;
+      return warning;
+    }
+  };
+}
+
+function readGitHead(repoRoot: string): string | null {
+  try {
+    return readGit(repoRoot, ["rev-parse", "--verify", "HEAD"]).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function readChangedGitPaths(
+  repoRoot: string,
+  cleanHead: string
+): ReadonlyArray<string> | null {
+  try {
+    const outputs = [
+      readGit(repoRoot, ["diff", "--name-only", "-z", cleanHead, "--"]),
+      readGit(repoRoot, ["ls-files", "--others", "-z"])
+    ];
+    return [...new Set(outputs.flatMap(nullSeparatedPaths))]
+      .filter((entry) => safeRepoRelativePath(entry))
+      .filter((entry) => !entry.split(/[\\/]/u).some((part) =>
+        part === ".git" || part === "node_modules"
+      ));
+  } catch {
+    return null;
+  }
+}
+
+function nullSeparatedPaths(output: string): ReadonlyArray<string> {
+  return output.split("\0").filter(Boolean);
+}
+
+function safeRepoRelativePath(relativePath: string): boolean {
+  return relativePath.length > 0
+    && !path.isAbsolute(relativePath)
+    && !relativePath.split(/[\\/]/u).includes("..");
+}
+
+function isTextLikePath(filePath: string): boolean {
+  return /\.(md|markdown|txt|ya?ml|json)$/iu.test(filePath);
+}
+
+function readGit(repoRoot: string, args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", repoRoot, ...args], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "ignore"],
+    windowsHide: true
+  });
+}

--- a/packages/cli/src/composition/repo-write-child-entrypoint.ts
+++ b/packages/cli/src/composition/repo-write-child-entrypoint.ts
@@ -26,6 +26,7 @@ import { defaultCliAdapterProvider } from "./adapter-registry.ts";
 import { cliDaemonCommandHostServices } from "./daemon-command-host-services.ts";
 import { cliDaemonServiceHostServices } from "./daemon-service-host-services.ts";
 import { daemonActorAttribution } from "./actor-attribution.ts";
+import { makeIncrementalConflictMarkerPreflight } from "./incremental-conflict-marker-preflight.ts";
 import {
   createCliProductionAuthorityLifecycle
 } from "./production-authority-lifecycle.ts";
@@ -52,6 +53,13 @@ export async function runRepoWriteChildEntrypoint(
   const layoutOverrides = config.authoredRoot
     ? { authoredRoot: config.authoredRoot }
     : undefined;
+  const conflictMarkerPreflight = makeIncrementalConflictMarkerPreflight({
+    rootDir: config.canonicalRoot,
+    ...(layoutOverrides ? { layoutOverrides } : {})
+  });
+  // Establish the generation baseline before the child advertises readiness so
+  // no request pays for a full authored-tree conflict-marker scan.
+  conflictMarkerPreflight.read();
   const witness = createDaemonGenerationWitness({
     userRoot: config.userRoot,
     endpointIdentity: config.endpointIdentity,
@@ -197,6 +205,7 @@ export async function runRepoWriteChildEntrypoint(
     outcomeStore: outcomes,
     resolveHistoricalPublication,
     recoverHistoricalCommittedReceipt: historicalRecovery.recover,
+    conflictMarkerPreflight: conflictMarkerPreflight.read,
     executeDocSyncSubmit: async ({ command, decoded }) => {
       const wireCommand = command.payload.command as {
         readonly request?: DocSyncSubmitRequestV1;

--- a/packages/cli/test/incremental-conflict-marker-preflight.test.ts
+++ b/packages/cli/test/incremental-conflict-marker-preflight.test.ts
@@ -1,0 +1,101 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  makeIncrementalConflictMarkerPreflight,
+  type IncrementalConflictMarkerPreflightScan
+} from "../src/composition/incremental-conflict-marker-preflight.ts";
+
+test("generation conflict preflight scans cumulative authored state once and later scans only deltas", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-conflict-marker-generation-"));
+  const authoredRoot = path.join(rootDir, "harness");
+  const scans: IncrementalConflictMarkerPreflightScan[] = [];
+  try {
+    mkdirSync(path.join(authoredRoot, "scale"), { recursive: true });
+    writeFileSync(path.join(authoredRoot, "harness.yaml"), "schema: harness-anything/v1\n");
+    writeFileSync(path.join(authoredRoot, ".gitignore"), "late.md\n");
+    for (let index = 0; index < 2_000; index += 1) {
+      writeFileSync(path.join(authoredRoot, "scale", `${index}.txt`), "clean\n");
+    }
+    git(authoredRoot, "init", "-b", "main");
+    git(authoredRoot, "config", "user.name", "Harness Test");
+    git(authoredRoot, "config", "user.email", "harness@example.test");
+    git(authoredRoot, "add", ".");
+    git(authoredRoot, "commit", "-m", "seed cumulative authored state");
+
+    const preflight = makeIncrementalConflictMarkerPreflight(
+      { rootDir },
+      { onScan: (scan) => scans.push(scan) }
+    );
+
+    assert.equal(preflight.read(), undefined);
+    assert.equal(preflight.read(), undefined);
+    assert.deepEqual(scans.map((scan) => scan.mode), ["full", "incremental"]);
+    assert.equal(scans[0]!.candidateCount, undefined);
+    assert.equal(scans[1]!.candidateCount, 2);
+
+    mkdirSync(path.join(authoredRoot, "node_modules", "ignored-package"), { recursive: true });
+    writeFileSync(
+      path.join(authoredRoot, "node_modules", "ignored-package", "README.md"),
+      conflictMarker()
+    );
+    assert.equal(preflight.read(), undefined);
+    assert.equal(scans.at(-1)?.candidateCount, 2);
+
+    writeFileSync(path.join(authoredRoot, "late.md"), conflictMarker());
+    const lateWarning = preflight.read();
+    assert.equal(lateWarning?.code, "conflict_marker_present");
+    assert.match(lateWarning?.message ?? "", /harness\/late\.md/u);
+    assert.equal(scans.at(-1)?.mode, "incremental");
+    assert.equal(scans.at(-1)?.candidateCount, 3);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("generation conflict preflight observes committed deltas and root policy files", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-conflict-marker-delta-"));
+  const authoredRoot = path.join(rootDir, "harness");
+  try {
+    mkdirSync(authoredRoot, { recursive: true });
+    writeFileSync(path.join(authoredRoot, "tracked.md"), "clean\n");
+    git(authoredRoot, "init", "-b", "main");
+    git(authoredRoot, "config", "user.name", "Harness Test");
+    git(authoredRoot, "config", "user.email", "harness@example.test");
+    git(authoredRoot, "add", ".");
+    git(authoredRoot, "commit", "-m", "seed");
+
+    const preflight = makeIncrementalConflictMarkerPreflight({ rootDir });
+    assert.equal(preflight.read(), undefined);
+
+    writeFileSync(path.join(authoredRoot, "tracked.md"), conflictMarker());
+    git(authoredRoot, "add", "tracked.md");
+    git(authoredRoot, "commit", "-m", "introduce marker");
+    assert.equal(preflight.read()?.code, "conflict_marker_present");
+
+    writeFileSync(path.join(authoredRoot, "tracked.md"), "clean again\n");
+    git(authoredRoot, "add", "tracked.md");
+    git(authoredRoot, "commit", "-m", "resolve marker");
+    assert.equal(preflight.read(), undefined);
+
+    writeFileSync(path.join(rootDir, "AGENTS.md"), conflictMarker());
+    assert.equal(preflight.read()?.code, "conflict_marker_present");
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+function conflictMarker(): string {
+  return "<<<<<<< HEAD\nleft\n=======\nright\n>>>>>>> branch\n";
+}
+
+function git(repoRoot: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", repoRoot, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"]
+  }).trim();
+}

--- a/packages/daemon/src/authority/production/production-authority-lifecycle.ts
+++ b/packages/daemon/src/authority/production/production-authority-lifecycle.ts
@@ -178,6 +178,7 @@ export function createProductionAuthorityLifecycle(input: {
       const basePublisher = createDurableAuthorityCommittedEventPublisherV2({
         eventLog,
         commitEvidence: async (canonicalCommitSha) => {
+          reportCurrentRepoWriteTelemetry("authority-evidence-commit");
           reportCurrentRepoWriteTelemetry("fsync");
           await evidenceCommitter.commitPending(canonicalCommitSha);
         },
@@ -186,6 +187,7 @@ export function createProductionAuthorityLifecycle(input: {
             reportCurrentRepoWriteTelemetry("git");
             const inspect = publicationObservers.get(repo.repoId);
             if (!inspect) throw new Error("AUTHORITY_PRODUCTION_PUBLICATION_OBSERVER_UNAVAILABLE");
+            reportCurrentRepoWriteTelemetry("authority-replica-change-read");
             const changes = await replicaChangeLog.changesAfter(request.workspaceId, 0);
             const expectedOpIds = changes
               .filter((change) => change.commitSha === request.commitSha)
@@ -194,10 +196,12 @@ export function createProductionAuthorityLifecycle(input: {
             if (!expectedOpIds.includes(request.opId)) {
               throw new Error(`AUTHORITY_PRODUCTION_PUBLICATION_OPERATION_MISSING:opId=${request.opId};commitSha=${request.commitSha}`);
             }
+            reportCurrentRepoWriteTelemetry("authority-publication-proof");
             const evidence = await inspect(request.previousCommit, expectedOpIds, request.commitSha);
             if (evidence.commitSha !== request.commitSha || evidence.previousCommit !== request.previousCommit) {
               throw new Error("AUTHORITY_PRODUCTION_PUBLICATION_OBSERVATION_MISMATCH");
             }
+            reportCurrentRepoWriteTelemetry("authority-operation-integrity");
             const mutationSets = await Promise.all(expectedOpIds.map(async (opId) => {
               const record = await state.operationRegistry.get(request.workspaceId, opId);
               if (!record?.authorityIntegrity) {
@@ -521,6 +525,7 @@ function createConnectionAuthorityService(
     fenceWitness: input.fenceWitness,
     ...(generationFence ? { generationFenceWitness: generationFence } : {}),
     admissionBudget: input.admissionBudget,
+    onTelemetry: reportCurrentRepoWriteTelemetry,
     v2: {
       schemaTuple: material.config.schemaTuple,
       channelNonceDigest: context.channelBinding.digest,

--- a/packages/daemon/src/authority/production/publication-evidence.ts
+++ b/packages/daemon/src/authority/production/publication-evidence.ts
@@ -27,6 +27,7 @@ import {
 } from "./authority-evidence-tree.ts";
 import { historicalPublicationEvidence } from "./historical-publication-evidence.ts";
 import { createUniquePublicationOperationLookup } from "./publication-operation-lookup.ts";
+import { reportCurrentRepoWriteTelemetry } from "../../runtime/repo-write-telemetry-context.ts";
 
 const materializerCommitter = {
   name: "Harness Anything Materializer",
@@ -119,6 +120,7 @@ export function createGitAuthorityAttributionEvidenceCommitterV2(
         throw new Error(`AUTHORITY_EVENT_V2_EVIDENCE_CANONICAL_COMMIT_MISSING:${canonicalCommitSha}`);
       }
       const head = vcs.currentHead(repoRoot);
+      reportCurrentRepoWriteTelemetry("authority-evidence-worktree");
       const { relativeRoot, pendingPaths } = readAuthorityEvidencePendingPathsAtCommit(
         layout.authorityAttributionEventsV2Root,
         repoRoot,
@@ -131,6 +133,7 @@ export function createGitAuthorityAttributionEvidenceCommitterV2(
       );
       if (verifiedHead !== head) {
         // Establish a trustworthy baseline after startup or any unexpected HEAD change.
+        reportCurrentRepoWriteTelemetry("authority-evidence-history-verify");
         log.verifyIntegrity();
         // A dirty historical tree may still be in crash recovery. Do not cache
         // that transient worktree as the verified baseline.
@@ -141,10 +144,12 @@ export function createGitAuthorityAttributionEvidenceCommitterV2(
         if (worktree.historicalShardChanged) {
           throw new Error("AUTHORITY_EVENT_V2_EVIDENCE_VERIFIED_HISTORY_CHANGED");
         }
+        reportCurrentRepoWriteTelemetry("authority-evidence-pending-verify");
         log.verifyShards(pendingPaths.map((relativePath) => path.basename(relativePath)));
       }
       if (pendingPaths.length === 0) return;
 
+      reportCurrentRepoWriteTelemetry("authority-evidence-git-commit");
       const pending = new Set(pendingPaths);
       assertEvidenceOnlyStaged(vcs.stagedFiles(repoRoot, ["."]), pending);
       vcs.add(repoRoot, { paths: pendingPaths });

--- a/packages/daemon/src/authority/replication-content-store.ts
+++ b/packages/daemon/src/authority/replication-content-store.ts
@@ -14,6 +14,7 @@ import {
   readAuthorityGitBytes
 } from "./production/publication-evidence.ts";
 import { validateReadDownManagedPath } from "./read-down-managed-path.ts";
+import { reportCurrentRepoWriteTelemetry } from "../runtime/repo-write-telemetry-context.ts";
 
 type ReplicaChangeDraft = Parameters<ReplicaChangeLog["append"]>[0];
 type ReplicaFileMode = NonNullable<ReplicaChangeRecord["paths"][number]["mode"]>;
@@ -118,7 +119,12 @@ export function createContentEnrichedReplicaChangeLog(
     ? undefined
     : hydrateRecord(record, content);
   return {
-    append: (draft) => base.append(content.describeChange(draft)),
+    append: (draft) => {
+      reportCurrentRepoWriteTelemetry("authority-replication-snapshot");
+      const change = content.describeChange(draft);
+      reportCurrentRepoWriteTelemetry("authority-replica-change-append");
+      return base.append(change);
+    },
     latest: async (workspaceId) => hydrate(await base.latest(workspaceId)),
     getByOperation: async (workspaceId, opId) => hydrate(await base.getByOperation(workspaceId, opId)),
     changesAfter: async (workspaceId, revision) =>

--- a/packages/daemon/src/lifecycle/run-daemon-serve.ts
+++ b/packages/daemon/src/lifecycle/run-daemon-serve.ts
@@ -274,6 +274,22 @@ export async function runDaemonServe<
                 HARNESS_DAEMON_SERVER_HOST: "1"
               }
             }),
+            onTelemetry: (frame) => {
+              void daemonLogService.append({
+                level: "debug",
+                source: "daemon",
+                component: "repo-write-child",
+                event: "repo-write.request.telemetry",
+                message: JSON.stringify({
+                  schema: "repo-write-request-telemetry/v1",
+                  requestId: frame.requestId,
+                  ...(frame.opId ? { opId: frame.opId } : {}),
+                  phase: frame.phase,
+                  elapsedMs: frame.elapsedMs
+                }),
+                requestId: frame.requestId
+              }, { repo }).catch(() => undefined);
+            },
             onDiagnostic: (frame) => {
               const rejected = frame.kind === "recovery-rejected";
               void daemonLogService.append({

--- a/packages/daemon/src/runtime/production-progress-append-operation.ts
+++ b/packages/daemon/src/runtime/production-progress-append-operation.ts
@@ -69,6 +69,7 @@ export class ProductionRepoWriteOperationHost<
       readonly command: RepoWriteCommandDto;
       readonly decoded: ReturnType<typeof decodeRepoWriteCommand>;
     }) => Promise<CommandReceiptEnvelope | undefined>;
+    readonly conflictMarkerPreflight?: () => import("@harness-anything/kernel").ProjectionWarning | undefined;
     readonly now: () => Date;
     readonly newOuterOpId: () => string;
   };
@@ -89,6 +90,7 @@ export class ProductionRepoWriteOperationHost<
       readonly command: RepoWriteCommandDto;
       readonly decoded: ReturnType<typeof decodeRepoWriteCommand>;
     }) => Promise<CommandReceiptEnvelope | undefined>;
+    readonly conflictMarkerPreflight?: () => import("@harness-anything/kernel").ProjectionWarning | undefined;
     readonly now?: () => Date;
     readonly newOuterOpId?: () => string;
   }) {
@@ -180,7 +182,12 @@ export class ProductionRepoWriteOperationHost<
     const commandService = createDaemonCommandService(
       this.options.runtime,
       this.options.hostServices,
-      { resolveAuthoritySubmissionV2: () => binding }
+      {
+        resolveAuthoritySubmissionV2: () => binding,
+        ...(this.options.conflictMarkerPreflight ? {
+          conflictMarkerPreflight: this.options.conflictMarkerPreflight
+        } : {})
+      }
     );
     return commandReceiptJsonObject(await commandService.runCommand(
       input.command.payload as unknown as JsonObject,
@@ -347,7 +354,10 @@ export class ProductionRepoWriteOperationHost<
       {
         taskLeaseGuardMode: "read-only",
         ...(recovery ? { outerProceedingRecovery: true as const } : {}),
-        resolveAuthoritySubmissionV2: () => capturingSubmission
+        resolveAuthoritySubmissionV2: () => capturingSubmission,
+        ...(this.options.conflictMarkerPreflight ? {
+          conflictMarkerPreflight: this.options.conflictMarkerPreflight
+        } : {})
       }
     );
     const receipt = exactReceipt(await commandService.runCommand(

--- a/packages/daemon/src/runtime/repo-write-diagnostic-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-diagnostic-protocol.ts
@@ -4,22 +4,21 @@ interface RepoWriteDiagnosticFrameBase {
   readonly generation: number;
 }
 
-export type RepoWriteTelemetryPhase =
-  | "queue"
-  | "compile"
-  | "compile-command-normalize"
-  | "compile-authority-plan"
-  | "compile-task-load"
-  | "compile-task-holder"
-  | "compile-task-witness"
-  | "compile-task-plan"
-  | "compile-outcome"
-  | "journal"
-  | "git"
-  | "fsync"
-  | "materializer"
-  | "projection"
-  | "total";
+export const repoWriteTelemetryPhases = [
+  "queue", "compile", "compile-command-normalize", "compile-authority-plan",
+  "compile-task-load", "compile-task-holder", "compile-task-witness",
+  "compile-task-plan", "compile-outcome", "journal", "command-conflict-preflight",
+  "command-conflict-recheck", "git", "authority-replica-change-read",
+  "authority-publication-proof", "authority-operation-integrity", "authority-admission",
+  "authority-binding-verified", "authority-batch-start", "authority-generation-acquire",
+  "authority-generation-held", "authority-coordinator-enqueue", "authority-coordinator-enqueued",
+  "authority-prepared-persisted", "authority-flush-start", "authority-replication-snapshot",
+  "authority-replica-change-append", "authority-evidence-commit", "authority-evidence-worktree",
+  "authority-evidence-history-verify", "authority-evidence-pending-verify",
+  "authority-evidence-git-commit", "fsync", "materializer", "projection", "total"
+] as const;
+
+export type RepoWriteTelemetryPhase = typeof repoWriteTelemetryPhases[number];
 
 export interface RepoWriteTelemetryFrame extends RepoWriteDiagnosticFrameBase {
   readonly kind: "telemetry";

--- a/packages/daemon/src/runtime/repo-write-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-protocol.ts
@@ -2,7 +2,7 @@
 import { repoWriteCommandDtoFromDecodedFields, type RepoWriteCommandDto } from "./repo-write-command-dto.ts";
 export * from "./repo-write-command-dto.ts";
 import { repoWriteTerminalReceiptMatches } from "./repo-write-terminal-receipt.ts";
-import type { RepoWriteRecoveryDeferredFrame, RepoWriteRecoveryDiagnosticFrame, RepoWriteRecoveryRejectedFrame, RepoWriteTelemetryFrame, RepoWriteTelemetryPhase } from "./repo-write-diagnostic-protocol.ts";
+import { repoWriteTelemetryPhases, type RepoWriteRecoveryDeferredFrame, type RepoWriteRecoveryDiagnosticFrame, type RepoWriteRecoveryRejectedFrame, type RepoWriteTelemetryFrame, type RepoWriteTelemetryPhase } from "./repo-write-diagnostic-protocol.ts";
 export type { RepoWriteRecoveryDeferredFrame, RepoWriteRecoveryDiagnosticFrame, RepoWriteRecoveryRejectedFrame, RepoWriteTelemetryFrame, RepoWriteTelemetryPhase } from "./repo-write-diagnostic-protocol.ts";
 export { boundedRepoWriteDiagnostic } from "./repo-write-protocol-diagnostic.ts";
 import {
@@ -413,13 +413,7 @@ function assertTerminalReceipt(
 }
 function decodeTelemetry(frame: FrameRecord, limits: RepoWriteProtocolLimits): RepoWriteTelemetryFrame {
   assertExactKeys(frame, baseKeys(["requestId", "phase", "elapsedMs"]), ["opId"], "$");
-  const phases: ReadonlyArray<RepoWriteTelemetryPhase> = [
-    "queue", "compile", "compile-command-normalize", "compile-authority-plan",
-    "compile-task-load", "compile-task-holder", "compile-task-witness",
-    "compile-task-plan", "compile-outcome", "journal", "git", "fsync",
-    "materializer", "projection", "total"
-  ];
-  if (!phases.includes(frame.phase as RepoWriteTelemetryPhase)) invalid("$.phase", "telemetry phase");
+  if (!repoWriteTelemetryPhases.includes(frame.phase as RepoWriteTelemetryPhase)) invalid("$.phase", "telemetry phase");
   if (typeof frame.elapsedMs !== "number" || !Number.isFinite(frame.elapsedMs) || frame.elapsedMs < 0) {
     invalid("$.elapsedMs", "non-negative finite duration");
   }

--- a/packages/daemon/src/runtime/repo-write-stall-diagnostic.ts
+++ b/packages/daemon/src/runtime/repo-write-stall-diagnostic.ts
@@ -30,8 +30,41 @@ export function repoWriteWaitingStage(
       return "durable-outcome-preparation";
     case "journal":
       return "durable-operation-journal";
+    case "command-conflict-preflight":
+    case "command-conflict-recheck":
+      return phase;
     case "git":
       return "canonical-git-publication";
+    case "authority-replica-change-read":
+      return "authority-replica-change-read";
+    case "authority-publication-proof":
+      return "authority-publication-proof";
+    case "authority-operation-integrity":
+      return "authority-operation-integrity";
+    case "authority-admission":
+    case "authority-binding-verified":
+    case "authority-batch-start":
+    case "authority-generation-acquire":
+    case "authority-generation-held":
+    case "authority-coordinator-enqueue":
+    case "authority-coordinator-enqueued":
+    case "authority-prepared-persisted":
+    case "authority-flush-start":
+      return phase;
+    case "authority-replication-snapshot":
+      return "authority-replication-snapshot";
+    case "authority-replica-change-append":
+      return "authority-replica-change-append";
+    case "authority-evidence-commit":
+      return "authority-evidence-commit";
+    case "authority-evidence-worktree":
+      return "authority-evidence-worktree";
+    case "authority-evidence-history-verify":
+      return "authority-evidence-history-verify";
+    case "authority-evidence-pending-verify":
+      return "authority-evidence-pending-verify";
+    case "authority-evidence-git-commit":
+      return "authority-evidence-git-commit";
     case "fsync":
       return "durable-attribution-evidence";
     case "materializer":

--- a/packages/daemon/src/service/command-service.ts
+++ b/packages/daemon/src/service/command-service.ts
@@ -40,6 +40,7 @@ import {
   RepoWriteNotStartedError,
   RepoWriteOutcomeUnknownError
 } from "../runtime/repo-write-client.ts";
+import { reportCurrentRepoWriteTelemetry } from "../runtime/repo-write-telemetry-context.ts";
 
 export interface DaemonCommandService {
   readonly runCommand: (payload?: JsonObject, context?: {
@@ -54,6 +55,7 @@ export interface DaemonCommandServiceOptions {
   readonly onCommandSettled?: () => void;
   readonly taskLeaseGuardMode?: "read-only";
   readonly outerProceedingRecovery?: true;
+  readonly conflictMarkerPreflight?: () => import("@harness-anything/kernel").ProjectionWarning | undefined;
   readonly repoWriteDispatch?: {
     readonly repoId: string;
     readonly submit: (
@@ -227,7 +229,11 @@ export function createDaemonCommandService<
                 runtime,
                 `${parsedCommand.action.kind}:${actor.kind}:${actor.id}:operational`,
                 actor
-              )
+              ),
+            onTelemetry: reportCurrentRepoWriteTelemetry,
+            ...(options.conflictMarkerPreflight ? {
+              conflictMarkerPreflight: options.conflictMarkerPreflight
+            } : {})
           })
         );
         return hostServices.toReceipt(

--- a/packages/daemon/test/repo-write-client-diagnostic.test.ts
+++ b/packages/daemon/test/repo-write-client-diagnostic.test.ts
@@ -31,6 +31,13 @@ test("compile diagnostics distinguish task completion witness work", () => {
   );
 });
 
+test("authority diagnostics distinguish the cumulative replica-change read", () => {
+  assert.equal(
+    repoWriteWaitingStage("authority-replica-change-read"),
+    "authority-replica-change-read"
+  );
+});
+
 test("timeout diagnostics name the child wait for every authority submission ingress", async () => {
   const cases = [
     { ingress: "generic", commandName: "task-create" },

--- a/packages/daemon/test/repo-write-protocol.test.ts
+++ b/packages/daemon/test/repo-write-protocol.test.ts
@@ -363,7 +363,7 @@ test("ready, terminal, status, telemetry, shutdown, and drained frames have exac
     ...base("telemetry"),
     requestId: "request-terminal",
     opId: "op-terminal",
-    phase: "compile-task-witness",
+    phase: "authority-replica-change-read",
     elapsedMs: 12.5
   });
   const shutdown = decodeRepoWriteParentMessage({
@@ -384,7 +384,7 @@ test("ready, terminal, status, telemetry, shutdown, and drained frames have exac
     committedReceipt
   );
   assert.equal(telemetry.kind === "telemetry" ? telemetry.elapsedMs : undefined, 12.5);
-  assert.equal(telemetry.kind === "telemetry" ? telemetry.phase : undefined, "compile-task-witness");
+  assert.equal(telemetry.kind === "telemetry" ? telemetry.phase : undefined, "authority-replica-change-read");
   assert.equal(shutdown.kind, "shutdown");
   assert.equal(drained.kind, "drained");
   assert.throws(() => decodeRepoWriteChildMessage({ ...ready, requestId: "not-allowed" }), protocolInvalid);

--- a/packages/kernel/src/projection/post-merge-checks.ts
+++ b/packages/kernel/src/projection/post-merge-checks.ts
@@ -9,7 +9,7 @@ import { readFrontmatter, readScalar } from "../markdown/frontmatter.ts";
 import { buildRelationGraphProjection, detectRelationGraphCycles, validateRelationGraphRecords } from "./relation-graph-projection.ts";
 import type { ProjectionCheckAxisReport, ProjectionCheckReport, ProjectionWarning, ProjectionWarningCode, ProjectionWarningSource } from "./types.ts";
 import { readMarkdownSource, sourcePath, type TaskSourceEntry } from "./sqlite-task-source.ts";
-import { readDirIfPresent, readTextFileIfPresent, statPathIfPresent } from "./toctou-safe-fs.ts";
+import { lstatPathIfPresent, readDirIfPresent, readTextFileIfPresent, statPathIfPresent } from "./toctou-safe-fs.ts";
 
 export function runPostMergeChecks(rootInput: HarnessLayoutInput): ReadonlyArray<ProjectionWarning> {
   const rootDir = resolveHarnessLayout(rootInput).rootDir;
@@ -134,11 +134,35 @@ function findTamperedBindings(entries: ReadonlyArray<TaskSourceEntry>): Readonly
   return warnings;
 }
 
-export function findConflictMarkerWarnings(rootInput: HarnessLayoutInput): ReadonlyArray<ProjectionWarning> {
+export function findConflictMarkerWarnings(
+  rootInput: HarnessLayoutInput,
+  candidates?: ReadonlyArray<string>
+): ReadonlyArray<ProjectionWarning> {
   const layout = resolveHarnessLayout(rootInput);
-  const rootDir = layout.rootDir;
-  const roots = [layout.authoredRoot, path.join(layout.rootDir, "AGENTS.md"), path.join(layout.rootDir, "CLAUDE.md")];
-  for (const candidate of roots.flatMap((entry) => listTextFiles(entry))) {
+  return findConflictMarkersInFiles(
+    layout.rootDir,
+    candidates
+      ? candidates.filter((candidate) => {
+          const stat = lstatPathIfPresent(candidate);
+          return stat?.isFile() === true && !stat.isSymbolicLink();
+        })
+      : conflictMarkerRoots(layout).flatMap((entry) => listTextFiles(entry))
+  );
+}
+
+function conflictMarkerRoots(layout: ReturnType<typeof resolveHarnessLayout>): ReadonlyArray<string> {
+  return [
+    layout.authoredRoot,
+    path.join(layout.rootDir, "AGENTS.md"),
+    path.join(layout.rootDir, "CLAUDE.md")
+  ];
+}
+
+function findConflictMarkersInFiles(
+  rootDir: string,
+  candidates: ReadonlyArray<string>
+): ReadonlyArray<ProjectionWarning> {
+  for (const candidate of candidates) {
     const body = readTextFileIfPresent(candidate);
     if (body === null) continue;
     if (/^<<<<<<<[^\n]*\n[\s\S]*?^=======$[\s\S]*?^>>>>>>>[^\n]*$/mu.test(body)) {
@@ -152,7 +176,6 @@ export function findConflictMarkerWarnings(rootInput: HarnessLayoutInput): Reado
   }
   return [];
 }
-
 function findDecisionWatermarkIssues(rootInput: HarnessLayoutInput): ReadonlyArray<ProjectionWarning> {
   const layout = resolveHarnessLayout(rootInput);
   const seen = new Map<string, string>();

--- a/packages/kernel/src/projection/toctou-safe-fs.ts
+++ b/packages/kernel/src/projection/toctou-safe-fs.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import type { Dirent, Stats } from "node:fs";
 import path from "node:path";
 
@@ -14,6 +14,15 @@ export function readTextFileIfPresent(filePath: string): string | null {
 export function statPathIfPresent(inputPath: string): Stats | null {
   try {
     return statSync(inputPath);
+  } catch (error) {
+    if (isVanishedPathError(error)) return null;
+    throw error;
+  }
+}
+
+export function lstatPathIfPresent(inputPath: string): Stats | null {
+  try {
+    return lstatSync(inputPath);
   } catch (error) {
     if (isVanishedPathError(error)) return null;
     throw error;


### PR DESCRIPTION
# English

## Summary

Third confirmed member of the "O(cumulative state) work on every write" defect family (after #1086's per-write redundant persist and #1202's witness full-history scan): the persistent repo-writer child ran **two recursive conflict-marker scans over the complete cumulative authored tree on every governed command** — one early preflight and one flush-time TOCTOU recheck. At production scale (26,612 authored files) the two scans cost 4,461–4,845 ms per request before any authority work, dominating the residual 9–12 s ordinary-write cost that survived #1202.

The fix amortizes the scan to once per writer generation: the child performs one complete baseline scan before advertising `READY`, then each later check scans only Git deltas from the last clean authored `HEAD`, all untracked paths (including ignored governed files), and the root `AGENTS.md`/`CLAUDE.md` policy files. The baseline advances only after a warning-free scan; any Git query failure falls back to the complete scan (fail-closed). Both the early rejection and the flush-time recheck still run, now against the same generation-scoped scanner. Standalone/direct composition keeps the old complete scan.

Production-scale synthetic results (1,011 terminal outcome pairs + 26,612 authored files): ordinary progress writes 8,774/7,912 ms → **4,533/5,305 ms**; valid `doc sync submit` → **2,054 ms**; `task complete` → **5,077 ms** (vs the production acceptance reading of 30,789.74 ms — about 24.9 s of deadline margin instead of finishing past the 30 s observation point). Successful child requests now emit their phase-boundary telemetry as debug `repo-write.request.telemetry` log entries instead of being observable only in stall diagnostics.

Not changed: the 30,000 ms request deadline, child recovery ordering, authority semantics, publication rules, outcome terminalization, and orphan `PROCEEDING` semantics.

## What Changed

- `packages/cli/src/composition/incremental-conflict-marker-preflight.ts` (new): generation-scoped incremental conflict-marker preflight with full-scan fallback.
- `packages/cli/src/composition/command-executor.ts`, `repo-write-child-entrypoint.ts`, `packages/cli/src/cli/conflict-preflight.ts`, `runner-registry.ts`: wire the writer child's early preflight and flush-time recheck to the shared generation-scoped scanner; first full scan runs before `READY`.
- `packages/daemon/src/runtime/repo-write-{protocol,diagnostic-protocol,stall-diagnostic}.ts`, `service/command-service.ts`, `lifecycle/run-daemon-serve.ts`: success-path phase telemetry (`repo-write.request.telemetry`, debug level) with protocol validation and request/op correlation.
- `packages/application/src/authority/*`, `packages/daemon/src/authority/**`: thread the scan hook/options through host contract and production lifecycle; replication snapshot boundary instrumentation.
- Tests: new integration scale test pins the algorithmic shape without wall-clock assertions — 2,000 seeded files: first scan complete, next scan exactly two root-policy candidates, `node_modules` marker adds no candidate, ignored-but-governed `late.md` marker is detected, committed delta + root `AGENTS.md` edit both detected. Existing early-preflight and flush-recheck integration tests unchanged and green.

## Task And Scope

- Harness task: `task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- Branch: `codex/write-cost-residual`
- Public scope: `packages/cli/**`, `packages/daemon/**`, `packages/application/**` and tests
- Private planning/evidence updated: yes (task package `artifacts/residual-fixed-cost.md`)
- Out of scope: the code-doc non-linear publication proof failure and orphan `PROCEEDING` terminal semantics (both recorded as separate defects; the latter needs an authority decision first).

## Version Impact

- Version: no version change because this is an unreleased surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `ee7bf77ba9043f892c1d30f1ec13f5b379d93242`
- Branch merge-base with `origin/main`: `ee7bf77ba9043f892c1d30f1ec13f5b379d93242`
- Last `git fetch origin` time: immediately before opening this PR
- Sync method: rebase onto `origin/main` (twice: after #1203 and after #1204), `check:local` rerun green after the final rebase
- Public diff command: `git diff origin/main...codex/write-cost-residual`
- Private evidence commit/path: task package `artifacts/residual-fixed-cost.md` (measurement decomposition, before/after positive control, production read-only evidence)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending, linked once the run completes
- [x] `git diff --check`
- [x] `npm run check:local` — green after final rebase (27 manifest gates; fast 709/709, contract 555 pass / 0 fail / 1 platform skip on the worker's full run)
- [x] Targeted tests for the change surface, named with their counts: `incremental-conflict-marker-preflight.test.ts` (new, passed inside the full tier); full `--tier integration` on the pre-rebase base: 1,456 tests, 1,452 pass, 0 fail, 4 platform skips
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending
- Not run, and why: full integration tier was not rerun after the two rebases (both rebases were conflict-free; `check:local` covers the affected fast/contract surface and `test-integration` runs authoritatively in CI).

## Review Evidence

- Self-review: CEO verified the fail-closed properties in the diff — Git failure → full scan, baseline advances only after a warning-free scan, untracked (including ignored) and root policy files always candidates, both checks still executed; and that no deadline/bypass/authority change is present.
- Reviewer subagent: implementation by Codex worker under a measurement-first contract (phase decomposition table required to sum to the observed gap before any code change was allowed).
- Human review: pending
- Blocking findings: none open

## Residual Risk

- A replacement child still pays ~5.0 s outcome-history enumeration plus one generation-baseline full scan before readiness — startup/replacement latency, not per-write scaling; the request deadline starts only after the child is ready.
- An unhealthy Git layer causes fallback to the complete scan: slow request rather than bypassed validation (safe direction).
- Success-path debug telemetry adds log volume under the existing daemon log store retention; production should confirm the volume is acceptable.
- Production acceptance still requires deployment + re-measurement (three ordinary writes, doc-sync submissions, and an eligible completion with correlated telemetry).

## References

- Task: `task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- Evidence: task package `artifacts/residual-fixed-cost.md`
- Review: same task package

---

# 中文

## 概要

「每写 O(累积状态)」缺陷族第三个确认成员（前两个：#1086 每写冗余持久写、#1202 witness 全历史扫描）：常驻 repo-writer child **每条治理命令对完整累积 authored 树做两遍递归 conflict-marker 全扫**——一遍早期 preflight、一遍 flush 时 TOCTOU 复查。生产规模（26,612 个 authored 文件）下两遍合计每请求 4,461–4,845 ms，发生在任何 authority 工作之前，是 #1202 之后残余 9–12s 普通写成本的主导项。

修法是把全扫摊销到每个 writer generation 一次：child 在宣告 `READY` 前做一次完整基线扫描，之后每次检查只扫「相对最近一次干净 authored `HEAD` 的 Git 增量 + 全部 untracked 路径（含 ignored 的受治理文件）+ 根 `AGENTS.md`/`CLAUDE.md` 策略文件」。基线只在无警告扫描后推进；Git 查询失败一律回退完整全扫（fail-closed）。早期拒绝与 flush 复查两道检查都保留，共用同一个 generation 级扫描器。standalone/direct 组合保持旧全扫。

生产规模合成结果（1,011 terminal outcome pair + 26,612 authored 文件）：普通 progress 写 8,774/7,912 ms → **4,533/5,305 ms**；有效 `doc sync submit` → **2,054 ms**；`task complete` → **5,077 ms**（对照生产验收实测 30,789.74 ms——从踩过 30s 观察点变成约 24.9s 余量）。成功请求的 child 分阶段遥测现以 debug 级 `repo-write.request.telemetry` 落日志，不再只在 stall 诊断里可见。

未动的：30,000 ms 请求 deadline、child 恢复顺序、authority 语义、publication 规则、outcome 终态化、孤儿 `PROCEEDING` 语义。

## 改动内容

- `packages/cli/src/composition/incremental-conflict-marker-preflight.ts`（新增）：generation 级增量 conflict-marker preflight，带全扫回退。
- `packages/cli/src/composition/command-executor.ts`、`repo-write-child-entrypoint.ts`、`packages/cli/src/cli/conflict-preflight.ts`、`runner-registry.ts`：writer child 的早期 preflight 与 flush 复查接到共享的 generation 级扫描器；首次全扫在 `READY` 前完成。
- `packages/daemon/src/runtime/repo-write-{protocol,diagnostic-protocol,stall-diagnostic}.ts`、`service/command-service.ts`、`lifecycle/run-daemon-serve.ts`：成功路径分阶段遥测（debug 级 `repo-write.request.telemetry`），协议校验并保留 request/op 关联。
- `packages/application/src/authority/*`、`packages/daemon/src/authority/**`：扫描 hook/options 穿过 host contract 与生产 lifecycle；replication snapshot 边界埋点。
- 测试：新增 integration 规模测试钉死算法形状（不依赖机器时钟）——播种 2,000 文件：首扫必须全量、次扫候选恰为两个根策略文件、`node_modules` 下加 marker 不增候选、ignored 但受治理的 `late.md` marker 必须被抓到、committed 增量与根 `AGENTS.md` 修改都必须被抓到。既有早期 preflight 与 flush 复查 integration 测试不变且绿。

## 任务与范围

- Harness 任务：`task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- 分支：`codex/write-cost-residual`
- 公开范围：`packages/cli/**`、`packages/daemon/**`、`packages/application/**` 及测试
- 私有计划 / 证据是否已更新：yes（任务包 `artifacts/residual-fixed-cost.md`）
- 范围外：code-doc non-linear publication proof 失败与孤儿 `PROCEEDING` 终态语义（均已记为独立缺陷；后者须先有 authority decision）。

## 版本影响

- 版本：不改版本，原因是这是未发布面
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`ee7bf77ba9043f892c1d30f1ec13f5b379d93242`
- 当前分支与 `origin/main` 的 merge-base：`ee7bf77ba9043f892c1d30f1ec13f5b379d93242`
- 最近一次 `git fetch origin` 时间：开 PR 前即时执行
- 同步方式：rebase 到 `origin/main`（两次：#1203 与 #1204 合入后），末次 rebase 后 `check:local` 复跑绿
- 公开 diff 命令：`git diff origin/main...codex/write-cost-residual`
- 私有证据 commit/path：任务包 `artifacts/residual-fixed-cost.md`（测量分解、修复前后阳性对照、生产只读证据）
- Reviewer 证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：待 run 完成后补链接
- [x] `git diff --check`
- [x] `npm run check:local` —— 末次 rebase 后全绿（27 个 manifest 门；worker 全量跑 fast 709/709、contract 555 过 / 0 败 / 1 平台跳过）
- [x] 改动面的定向测试，写明测试名与通过数：`incremental-conflict-marker-preflight.test.ts`（新增，在完整 tier 内通过）；rebase 前基线的完整 `--tier integration`：1,456 tests，1,452 过、0 败、4 平台跳过
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）—— 待跑
- 未跑项及原因：两次 rebase 后未重跑完整 integration tier（两次 rebase 均无冲突；`check:local` 覆盖受影响 fast/contract 面，`test-integration` 在 CI 权威执行）。

## 审查证据

- 自查：CEO 在 diff 中逐项核验 fail-closed 性质——Git 失败→全扫、基线仅在无警告扫描后推进、untracked（含 ignored）与根策略文件恒为候选、两道检查都仍执行；且无 deadline/旁路/authority 改动。
- Reviewer subagent：Codex worker 在「先测量后动手」契约下实现（分阶段耗时表必须加总到观测缺口才允许改代码）。
- 人工审查：待办
- 阻塞发现：无 open

## 残余风险

- replacement child 就绪前仍要付 ~5.0s outcome 历史枚举 + 一次 generation 基线全扫——启动/替换延迟，非每写扩张；请求 deadline 在 child 就绪后才起算。
- Git 层不健康时回退完整全扫：变慢而不是绕过校验（安全方向）。
- 成功路径 debug 遥测增加日志量，由既有 daemon log store 留存策略管辖；生产需确认量级可接受。
- 生产验收仍需部署后复测（三次普通写、doc sync、一次 eligible complete，配套关联遥测）。

## 关联材料

- 任务：`task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- 证据：任务包 `artifacts/residual-fixed-cost.md`
- 审查：同一任务包
