### PR TITLE
fix: make daemon lock ownership honest (publish-window classification, owner provenance, serial topology preflight, repo-level status)

### DIFF
--- a/docs-release/operations-server-daemon.md
+++ b/docs-release/operations-server-daemon.md
@@ -128,6 +128,34 @@ ha --repo A task list
 The running daemon reconciles the registry every second. A newly registered
 repository can attach without restarting the daemon.
 
+## Daemon Repository Ownership Invariants
+
+Treat repository ownership as a set-level invariant, not as a property of the
+socket selected by one command:
+
+- One canonical repository root can belong to only one live daemon at a time.
+- An explicit authority manifest is the complete repository set for that
+  daemon. Every repository in that manifest is projected as enabled; it is not
+  intersected with an existing registry selection.
+- Repository sets served by different live daemons must be disjoint. Starting
+  the same manifest under two user roots is a topology conflict, not an
+  isolation mechanism.
+- `--user-root` isolates the registry, socket, and daemon generation records.
+  It does not isolate the repository-local `.harness/locks/global.lock`.
+- `--repo <id>` selects the default/request routing repository. It does not
+  limit which manifest repositories receive persistent writer children.
+
+Lock conflicts from current daemons include the owning PID, host, repository,
+user root, and endpoint when the lock was written by a provenance-aware
+version. Legacy lock records remain readable but may identify only PID and
+host. `ha daemon status --json` reports `repositoryService.state` directly as
+`served-by-connected-daemon`, `served-by-other-daemon`,
+`served-by-unknown-daemon`, `not-served`, or `lock-record-unavailable`.
+
+When a topology conflict is reported, change the manifest or stop/drain the
+other owner through its own user root. Do not delete a live lock and do not use
+direct mode as a lock-conflict workaround.
+
 ## Submitting hand-edited task prose
 
 Machine-read fields and typed records continue to use their dedicated CLI/RPC

--- a/packages/cli/src/commands/daemon/command.ts
+++ b/packages/cli/src/commands/daemon/command.ts
@@ -36,7 +36,19 @@ function emitDaemonStatusResult(result: Record<string, unknown>, json: boolean):
     if (result[key] !== undefined) parts.push(`${key}=${JSON.stringify(result[key])}`);
   }
   if (typeof result.lockPath === "string") parts.push(`lock=${result.lockPath}`);
+  if (isDaemonCommandRecord(result.repositoryService)) {
+    parts.push(`repoService=${JSON.stringify(result.repositoryService.state)}`);
+    const owner = isDaemonCommandRecord(result.repositoryService.daemon) ? result.repositoryService.daemon : undefined;
+    if (owner?.pid !== undefined && owner.pid !== null) parts.push(`servingPid=${JSON.stringify(owner.pid)}`);
+    if (owner?.hostname !== undefined && owner.hostname !== null) parts.push(`servingHost=${JSON.stringify(owner.hostname)}`);
+    if (owner?.userRoot !== undefined && owner.userRoot !== null) parts.push(`servingUserRoot=${JSON.stringify(owner.userRoot)}`);
+    if (owner?.endpoint !== undefined && owner.endpoint !== null) parts.push(`servingEndpoint=${JSON.stringify(owner.endpoint)}`);
+  }
   console.log(parts.join(" "));
+}
+
+function isDaemonCommandRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function emitDaemonStatusError(message: string, json: boolean): void {

--- a/packages/cli/src/commands/daemon/help.ts
+++ b/packages/cli/src/commands/daemon/help.ts
@@ -64,8 +64,12 @@ export function renderDaemonHelp(): string {
     "Common commands:",
     "  start --service              Start a detached local daemon service (default).",
     "  start --foreground           Run the daemon service in the foreground.",
+    "    --user-root PATH           Isolate registry/socket/generation only; repository locks remain shared.",
     "    --authority-manifest PATH Enable fail-closed V2 authority composition from an explicit manifest.",
+    "                               The manifest is this daemon's complete enabled repo set.",
+    "    --repo ID                  Select the default route; does not limit manifest writer children.",
     "  status [--check]             Show status; --check fails on deployment or supervisor drift.",
+    "                               Reports whether this repository is served and by which daemon.",
     "  logs [options]               Read bounded operational daemon logs.",
     "    --limit <1-200>            Set page size (default: 100).",
     "    --since <timestamp>        Include entries at or after an ISO-8601 timestamp.",
@@ -92,7 +96,12 @@ export function renderDaemonHelp(): string {
     "    --ref <git-ref>            Build a specific Git ref (default: current checkout).",
     "    --version <version>        Override the snapshot directory version.",
     "  bootstrap-server             Initialize a canonical team server repository.",
-    "  install-templates --out DIR  Copy systemd, launchd, and Windows Service templates."
+    "  install-templates --out DIR  Copy systemd, launchd, and Windows Service templates.",
+    "",
+    "Repository ownership invariant:",
+    "  One canonicalRoot belongs to at most one live daemon. Explicit manifest repo sets",
+    "  are complete and must be disjoint across daemons, even when --user-root differs.",
+    "  See docs-release/operations-server-daemon.md#daemon-repository-ownership-invariants."
   ].join("\n");
 }
 

--- a/packages/cli/src/commands/daemon/repository-service-status.ts
+++ b/packages/cli/src/commands/daemon/repository-service-status.ts
@@ -1,0 +1,183 @@
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import path from "node:path";
+
+export interface DaemonRepositoryServiceStatus {
+  readonly state:
+    | "served-by-connected-daemon"
+    | "served-by-other-daemon"
+    | "served-by-unknown-daemon"
+    | "not-served"
+    | "lock-record-unavailable";
+  readonly repoId: string;
+  readonly canonicalRoot: string;
+  readonly daemon: {
+    readonly pid: number | null;
+    readonly hostname: string | null;
+    readonly userRoot: string | null;
+    readonly endpoint: string | null;
+    readonly connected: boolean;
+  } | null;
+  readonly reason: string;
+}
+
+export function readDaemonRepositoryLock(lockPath: string): Record<string, unknown> {
+  if (!existsSync(lockPath)) return { started: false, lockPath, lockRecordState: "absent" };
+  try {
+    const lock = JSON.parse(readFileSync(lockPath, "utf8")) as Record<string, unknown>;
+    if (!validLockRecord(lock)) {
+      return { started: false, lockPath, lockRecordState: "publishing-or-invalid" };
+    }
+    return {
+      started: lock.ownerKind === "daemon",
+      lockPath,
+      lockRecordState: "complete",
+      pid: lock.pid,
+      hostname: lock.hostname,
+      heartbeatAt: lock.heartbeatAt,
+      ownerKind: lock.ownerKind,
+      ownerToken: lock.ownerToken,
+      repoId: lock.repoId,
+      canonicalRoot: lock.canonicalRoot,
+      userRoot: lock.userRoot,
+      endpoint: lock.endpoint
+    };
+  } catch {
+    return { started: false, lockPath, lockRecordState: "publishing-or-invalid" };
+  }
+}
+
+export function projectDaemonRepositoryService(input: {
+  readonly requestedRepoId: string;
+  readonly canonicalRoot: string;
+  readonly connectedUserRoot: string;
+  readonly connectedEndpoint: string;
+  readonly reachableStatus?: Record<string, unknown>;
+  readonly lockStatus: Record<string, unknown>;
+}): DaemonRepositoryServiceStatus {
+  const lockIsDaemon = input.lockStatus.ownerKind === "daemon";
+  const lockRecordState = stringField(input.lockStatus, "lockRecordState");
+  const lockRepoId = stringField(input.lockStatus, "repoId");
+  const lockRoot = stringField(input.lockStatus, "canonicalRoot");
+  const lockUserRoot = stringField(input.lockStatus, "userRoot");
+  const lockEndpoint = stringField(input.lockStatus, "endpoint");
+  const connectedRepo = reachableRepo(input.reachableStatus, input.canonicalRoot, input.requestedRepoId);
+  const connectedService = recordField(input.reachableStatus, "service");
+  const reachable = input.reachableStatus !== undefined;
+  const provenanceNamesOther = lockIsDaemon && (
+    lockEndpoint !== undefined && !sameResolvedPath(lockEndpoint, input.connectedEndpoint)
+      || lockUserRoot !== undefined && !sameResolvedPath(lockUserRoot, input.connectedUserRoot)
+  );
+  const provenanceMatchesConnected = lockIsDaemon && reachable && !provenanceNamesOther && (
+    connectedRepo !== undefined
+      || lockEndpoint !== undefined && sameResolvedPath(lockEndpoint, input.connectedEndpoint)
+      || lockUserRoot !== undefined && sameResolvedPath(lockUserRoot, input.connectedUserRoot)
+  );
+  const repoId = lockRepoId ?? (connectedRepo ? stringField(connectedRepo, "repoId") : undefined) ?? input.requestedRepoId;
+
+  if (lockRecordState === "publishing-or-invalid") {
+    return {
+      state: "lock-record-unavailable",
+      repoId,
+      canonicalRoot: input.canonicalRoot,
+      daemon: null,
+      reason: "The repository lock record is currently publishing or invalid, so daemon ownership cannot yet be proven."
+    };
+  }
+  if (lockIsDaemon) {
+    const state = provenanceNamesOther
+      ? "served-by-other-daemon"
+      : provenanceMatchesConnected
+        ? "served-by-connected-daemon"
+        : "served-by-unknown-daemon";
+    return {
+      state,
+      repoId,
+      canonicalRoot: lockRoot ?? input.canonicalRoot,
+      daemon: {
+        pid: numberField(input.lockStatus, "pid") ?? numberField(connectedService, "pid") ?? null,
+        hostname: stringField(input.lockStatus, "hostname") ?? null,
+        userRoot: lockUserRoot ?? stringField(connectedService, "userRoot") ?? null,
+        endpoint: lockEndpoint ?? stringField(connectedService, "endpoint") ?? null,
+        connected: provenanceMatchesConnected
+      },
+      reason: state === "served-by-connected-daemon"
+        ? "This repository is attached to the reachable daemon."
+        : state === "served-by-other-daemon"
+          ? "This repository lock is owned by a daemon outside the selected userRoot/endpoint."
+          : "A daemon owns this repository, but the legacy lock record does not identify its userRoot or endpoint."
+    };
+  }
+  if (connectedRepo && stringField(connectedRepo, "state") === "attached") {
+    return {
+      state: "served-by-connected-daemon",
+      repoId,
+      canonicalRoot: input.canonicalRoot,
+      daemon: {
+        pid: numberField(connectedService, "pid") ?? null,
+        hostname: null,
+        userRoot: stringField(connectedService, "userRoot") ?? input.connectedUserRoot,
+        endpoint: stringField(connectedService, "endpoint") ?? input.connectedEndpoint,
+        connected: true
+      },
+      reason: "The reachable daemon reports this repository as attached; its lock record is not daemon-shaped."
+    };
+  }
+  return {
+    state: "not-served",
+    repoId,
+    canonicalRoot: input.canonicalRoot,
+    daemon: null,
+    reason: reachable
+      ? "A daemon is reachable at the selected endpoint, but it does not serve this repository."
+      : "No daemon lock or reachable daemon proves service for this repository."
+  };
+}
+
+function reachableRepo(
+  status: Record<string, unknown> | undefined,
+  canonicalRoot: string,
+  repoId: string
+): Record<string, unknown> | undefined {
+  if (!status || !Array.isArray(status.repos)) return undefined;
+  return status.repos
+    .filter(isRepositoryStatusRecord)
+    .find((repo) => stringField(repo, "repoId") === repoId
+      || sameResolvedPath(stringField(repo, "canonicalRoot"), canonicalRoot));
+}
+
+function sameResolvedPath(left: string | undefined, right: string): boolean {
+  if (left === undefined) return false;
+  return canonicalExistingPath(left) === canonicalExistingPath(right);
+}
+
+function canonicalExistingPath(value: string): string {
+  const resolved = path.resolve(value);
+  return existsSync(resolved) ? realpathSync.native(resolved) : resolved;
+}
+
+function validLockRecord(lock: Record<string, unknown>): boolean {
+  return typeof lock.pid === "number"
+    && typeof lock.hostname === "string"
+    && typeof lock.acquiredAt === "string"
+    && typeof lock.heartbeatAt === "string"
+    && typeof lock.ownerToken === "string";
+}
+
+function recordField(value: Record<string, unknown> | undefined, key: string): Record<string, unknown> | undefined {
+  const field = value?.[key];
+  return isRepositoryStatusRecord(field) ? field : undefined;
+}
+
+function stringField(value: Record<string, unknown> | undefined, key: string): string | undefined {
+  const field = value?.[key];
+  return typeof field === "string" && field.length > 0 ? field : undefined;
+}
+
+function numberField(value: Record<string, unknown> | undefined, key: string): number | undefined {
+  const field = value?.[key];
+  return typeof field === "number" && Number.isSafeInteger(field) ? field : undefined;
+}
+
+function isRepositoryStatusRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/cli/src/commands/daemon/status-command.ts
+++ b/packages/cli/src/commands/daemon/status-command.ts
@@ -1,9 +1,9 @@
-import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { makeDaemonLogService } from "@harness-anything/application";
 import { createHarnessRuntimeContext, resolveHarnessLayout } from "@harness-anything/kernel";
 import {
   currentDaemonProtocolVersion,
+  DaemonRepoRootResolutionError,
   makeDaemonLogFileStore,
   observeDaemonLifecycle
 } from "@harness-anything/daemon";
@@ -17,6 +17,10 @@ import {
 import type { DaemonCommandInput } from "./command-types.ts";
 import { evaluateDaemonDeploymentCheck } from "./deployment-check.ts";
 import { readDaemonStatusWithGenerationFallback } from "./status-compatibility.ts";
+import {
+  projectDaemonRepositoryService,
+  readDaemonRepositoryLock
+} from "./repository-service-status.ts";
 
 export interface DaemonStatusCommandResult {
   readonly exitCode: number;
@@ -24,15 +28,11 @@ export interface DaemonStatusCommandResult {
 }
 
 export async function runDaemonDeploymentStatusCommand(input: DaemonCommandInput): Promise<DaemonStatusCommandResult> {
-  const target = resolveLocalDaemonTarget({
-    rootDir: input.rootDir,
-    repoIdOverride: deploymentDaemonRepoIdOverride(input.args),
-    userRoot: readDeploymentDaemonUserRootOption(input.args),
-    layoutOverrides: input.layoutOverrides,
-    autoRegisterSingleRepo: false
-  });
+  const repoIdOverride = deploymentDaemonRepoIdOverride(input.args);
+  const userRoot = readDeploymentDaemonUserRootOption(input.args);
+  const target = resolveDaemonStatusTarget(input, repoIdOverride, userRoot);
   const layout = resolveHarnessLayout(createHarnessRuntimeContext(target.canonicalRoot, input.layoutOverrides));
-  const lockStatus = readDaemonDeploymentLock(path.join(layout.locksRoot, "global.lock"));
+  const lockStatus = readDaemonRepositoryLock(path.join(layout.locksRoot, "global.lock"));
   const rpcStatus = await readReachableDaemonDeploymentStatus(target, true, true);
   const cliRpcStatus = rpcStatus ? deploymentStatusForCli(rpcStatus) : undefined;
   const lifecycle = await observeDaemonLifecycle({
@@ -51,8 +51,16 @@ export async function runDaemonDeploymentStatusCommand(input: DaemonCommandInput
       queue: { interactive: 0, normal: 0, background: 0, maintenance: 0, running: false },
       connections: { active: 0, total: 0 }
     }),
-    started: cliRpcStatus?.started === true,
+    started: Boolean(rpcStatus),
     reachable: Boolean(rpcStatus),
+    repositoryService: projectDaemonRepositoryService({
+      requestedRepoId: target.repoId,
+      canonicalRoot: target.canonicalRoot,
+      connectedUserRoot: target.userRoot,
+      connectedEndpoint: target.socketPath,
+      ...(rpcStatus ? { reachableStatus: rpcStatus } : {}),
+      lockStatus
+    }),
     lifecycle,
     ...(deploymentCheck ? { deploymentCheck } : {})
   };
@@ -62,24 +70,29 @@ export async function runDaemonDeploymentStatusCommand(input: DaemonCommandInput
   };
 }
 
-function readDaemonDeploymentLock(lockPath: string): Record<string, unknown> {
-  if (!existsSync(lockPath)) return { started: false, lockPath };
-  const lock = JSON.parse(readFileSync(lockPath, "utf8")) as {
-    readonly pid?: unknown;
-    readonly hostname?: unknown;
-    readonly heartbeatAt?: unknown;
-    readonly ownerKind?: unknown;
-    readonly ownerToken?: unknown;
-  };
-  return {
-    started: lock.ownerKind === "daemon",
-    lockPath,
-    pid: lock.pid,
-    hostname: lock.hostname,
-    heartbeatAt: lock.heartbeatAt,
-    ownerKind: lock.ownerKind,
-    ownerToken: lock.ownerToken
-  };
+function resolveDaemonStatusTarget(
+  input: DaemonCommandInput,
+  repoIdOverride: string | undefined,
+  userRoot: string | undefined
+): LocalDaemonTarget {
+  try {
+    return resolveLocalDaemonTarget({
+      rootDir: input.rootDir,
+      repoIdOverride,
+      userRoot,
+      layoutOverrides: input.layoutOverrides,
+      autoRegisterSingleRepo: false
+    });
+  } catch (error) {
+    if (!(error instanceof DaemonRepoRootResolutionError)) throw error;
+    return resolveLocalDaemonTarget({
+      rootDir: input.rootDir,
+      repoIdOverride: repoIdOverride ?? "canonical",
+      userRoot,
+      layoutOverrides: input.layoutOverrides,
+      autoRegisterSingleRepo: false
+    });
+  }
 }
 
 async function readReachableDaemonDeploymentStatus(

--- a/packages/cli/src/composition/repo-write-child-entrypoint.ts
+++ b/packages/cli/src/composition/repo-write-child-entrypoint.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import path from "node:path";
 import {
   createDaemonGenerationWitness,
@@ -46,7 +47,7 @@ export async function runRepoWriteChildEntrypoint(
   const manifest = loadAuthorityProductionManifest(config.authorityManifest);
   const authorityRepo = manifest.repos.find((repo) =>
     repo.repoId === config.repoId
-      && path.resolve(repo.canonicalRoot) === path.resolve(config.canonicalRoot)
+      && canonicalExistingRoot(repo.canonicalRoot) === canonicalExistingRoot(config.canonicalRoot)
   );
   if (!authorityRepo) throw new Error("REPO_WRITE_CHILD_REPO_NOT_CONFIGURED");
 
@@ -71,6 +72,12 @@ export async function runRepoWriteChildEntrypoint(
     rootDir: config.canonicalRoot,
     ...(layoutOverrides ? { layoutOverrides } : {}),
     writeOwnership: "writer",
+    lockProvenance: {
+      repoId: config.repoId,
+      canonicalRoot: config.canonicalRoot,
+      userRoot: config.userRoot,
+      endpoint: config.endpointIdentity
+    },
     lockTtlMs: config.runtimePolicy.write.lockTtlMs,
     interactiveMicroBatchMs:
       config.runtimePolicy.write.interactiveMicroBatchMs,
@@ -303,6 +310,10 @@ export async function runRepoWriteChildEntrypoint(
       reject(error);
     });
   });
+}
+
+function canonicalExistingRoot(rootDir: string): string {
+  return realpathSync.native(path.resolve(rootDir));
 }
 
 function recoveryErrorMessage(error: unknown): string {

--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -59,6 +59,30 @@ test("daemon client routes writes for two registered repos through one user-leve
       assert.equal(betaStatus.started, true);
       assert.equal(alphaStatus.pid, betaStatus.pid);
       assert.deepEqual((alphaStatus.repos as Array<{ repoId: string }>).map((repo) => repo.repoId), ["alpha", "beta"]);
+      assert.equal((alphaStatus.repositoryService as Record<string, unknown>).state, "served-by-connected-daemon");
+      assert.equal((betaStatus.repositoryService as Record<string, unknown>).state, "served-by-connected-daemon");
+      assert.equal((alphaStatus.repositoryService as { daemon: { userRoot: string } }).daemon.userRoot, userRoot);
+
+      const otherUserRoot = path.join(workspaceRoot, "other-user-daemon");
+      const servedElsewhere = runDaemonCommand(alphaRoot, ["daemon", "status", "--user-root", otherUserRoot, "--json"], {
+        HARNESS_DAEMON_USER_ROOT: otherUserRoot
+      });
+      assert.equal(servedElsewhere.started, false);
+      assert.equal(servedElsewhere.reachable, false);
+      assert.equal((servedElsewhere.repositoryService as Record<string, unknown>).state, "served-by-other-daemon");
+      assert.equal((servedElsewhere.repositoryService as { daemon: { pid: number } }).daemon.pid, alphaStatus.pid);
+      assert.equal((servedElsewhere.repositoryService as { daemon: { userRoot: string } }).daemon.userRoot, userRoot);
+
+      const unservedRoot = path.join(workspaceRoot, "unserved");
+      mkdirSync(unservedRoot, { recursive: true });
+      ensureTestHarnessIdentity(unservedRoot);
+      runRawJson(unservedRoot, ["init"], { HARNESS_DAEMON_MODE: "fixture", HARNESS_DAEMON_USER_ROOT: userRoot });
+      const unserved = runDaemonCommand(unservedRoot, ["daemon", "status", "--user-root", userRoot, "--json"], {
+        HARNESS_DAEMON_USER_ROOT: userRoot
+      });
+      assert.equal(unserved.started, true);
+      assert.equal(unserved.reachable, true);
+      assert.equal((unserved.repositoryService as Record<string, unknown>).state, "not-served");
     } finally {
       await stopDaemon(betaRoot, userRoot);
     }

--- a/packages/cli/test/helpers/production-authority-lifecycle-fixture.ts
+++ b/packages/cli/test/helpers/production-authority-lifecycle-fixture.ts
@@ -24,18 +24,145 @@ export interface ProductionAuthorityLifecycleFixture {
   readonly serviceRoot: string;
   readonly manifestPath: string;
   readonly registryPath: string;
+  readonly repos: ReadonlyArray<ProductionAuthorityLifecycleRepoFixture>;
 }
 
-export function createProductionAuthorityLifecycleFixture(): ProductionAuthorityLifecycleFixture {
+export interface ProductionAuthorityLifecycleRepoFixture {
+  readonly repoId: string;
+  readonly repoRoot: string;
+  readonly authoredRoot: string;
+  readonly registryPath: string;
+  readonly keyStateDirectory: string;
+}
+
+export function createProductionAuthorityLifecycleFixture(
+  options: { readonly repoIds?: ReadonlyArray<string> } = {}
+): ProductionAuthorityLifecycleFixture {
   const root = mkdtempSync(path.join(tmpdir(), "ha-production-authority-"));
-  const repoRoot = path.join(root, "repo");
-  const authoredRoot = path.join(repoRoot, "harness");
   const serviceRoot = path.join(root, "service-state");
-  const keyStateDirectory = path.join(serviceRoot, "keys/canonical");
-  mkdirSync(path.join(authoredRoot, "tasks/task_A"), { recursive: true });
   mkdirSync(serviceRoot, { recursive: true, mode: 0o700 });
-  writeFileSync(path.join(authoredRoot, "tasks/task_A/INDEX.md"), "---\ntask_id: task_A\nstatus: active\n---\n");
-  writeFileSync(path.join(authoredRoot, "people.yaml"), [
+  const repoIds = options.repoIds ?? ["canonical"];
+  if (repoIds.length === 0 || new Set(repoIds).size !== repoIds.length) {
+    throw new Error("production authority fixture requires unique repo ids");
+  }
+  const now = Date.now();
+  const repos = repoIds.map((repoId, index): ProductionAuthorityLifecycleRepoFixture & { readonly manifest: Record<string, unknown> } => {
+    const legacyCanonical = repoIds.length === 1 && repoId === "canonical";
+    const fixtureSuffix = legacyCanonical ? "production" : repoId;
+    const repoRoot = path.join(root, repoIds.length === 1 ? "repo" : `repo-${repoId}`);
+    const authoredRoot = path.join(repoRoot, "harness");
+    const keyStateDirectory = path.join(serviceRoot, `keys/${repoId}`);
+    mkdirSync(path.join(authoredRoot, "tasks/task_A"), { recursive: true });
+    writeFileSync(path.join(authoredRoot, "harness.yaml"), [
+      "schema: harness-anything/v1",
+      "layout:",
+      "  authoredRoot: harness",
+      "  localRoot: .harness",
+      "settings:",
+      "  identity:",
+      "    personId: person_alice",
+      "    displayName: Alice",
+      ""
+    ].join("\n"));
+    writeFileSync(path.join(authoredRoot, "tasks/task_A/INDEX.md"), "---\ntask_id: task_A\nstatus: active\n---\n");
+    writeFileSync(path.join(authoredRoot, "people.yaml"), fixturePeopleRoster());
+    const keyStore = openLocalAuthorityKeyStore({
+      serviceStateRoot: serviceRoot,
+      stateDirectory: keyStateDirectory,
+      workspaceRoot: repoRoot,
+      authorityId: "authority.production",
+      issuer: "authority.production"
+    });
+    const prepublished = keyStore.createPrepublishedKey({ generation: 1, nowMs: now - 1_000 - index });
+    const prepublishedRegistry = createAuthorityKeyRegistryV1({
+      authorityId: "authority.production",
+      generation: 1,
+      globalRevocationEpoch: 1,
+      revision: 1,
+      entries: [prepublished]
+    });
+    const registry = firstPinAuthorityKeyV1({
+      registry: prepublishedRegistry,
+      keyId: prepublished.keyId,
+      expectedPinnedKeyId: prepublished.keyId,
+      pinEvidence: legacyCanonical ? "fixture-out-of-band-pin" : `fixture-out-of-band-pin-${repoId}`,
+      verifierAcknowledgement: legacyCanonical ? "fixture-verifier-ack" : `fixture-verifier-ack-${repoId}`,
+      activatedAtMs: now - 999 - index
+    });
+    const registryPath = path.join(authoredRoot, "authority-key-registry.json");
+    writeFileSync(registryPath, `${JSON.stringify(registry, null, 2)}\n`);
+    const unsignedNamespace = {
+      schema: "operation-namespace/v1" as const,
+      workspaceId: `workspace-${fixtureSuffix}`,
+      deviceId: `device-${fixtureSuffix}`,
+      authorityGeneration: 1n,
+      namespaceId: `namespace-${fixtureSuffix}`,
+      expiresAt: BigInt(now + 60 * 60_000),
+      issuer: "authority.production",
+      keyId: prepublished.keyId
+    };
+    const proof = sign(
+      null,
+      authorityNamespaceProofBytes(unsignedNamespace),
+      keyStore.signingProfile(registry, now).privateKey
+    );
+    fixtureGit(authoredRoot, "init", "-q");
+    fixtureGit(authoredRoot, "add", ".");
+    fixtureGit(authoredRoot, "commit", "-q", "-m", "seed authority fixture");
+    return {
+      repoId,
+      repoRoot,
+      authoredRoot,
+      registryPath,
+      keyStateDirectory,
+      manifest: {
+        repoId,
+        canonicalRoot: repoRoot,
+        workspaceId: unsignedNamespace.workspaceId,
+        deviceId: unsignedNamespace.deviceId,
+        viewId: `view-${fixtureSuffix}`,
+        sessionId: `session-${fixtureSuffix}`,
+        authorityId: "authority.production",
+        issuer: "authority.production",
+        keyRegistryPath: registryPath,
+        keyStateDirectory,
+        schemaTuple: productionTuple(),
+        authorityGeneration: 1,
+        revocationEpochs: {
+          global: "1", workspace: "1", device: "1", view: "1", principal: "1", executor: "1"
+        },
+        admissionTokenRef: `admission-${fixtureSuffix}`,
+        allowedExecutorAgentIds: ["codex"],
+        operationNamespace: {
+          ...unsignedNamespace,
+          authorityGeneration: unsignedNamespace.authorityGeneration.toString(),
+          expiresAt: unsignedNamespace.expiresAt.toString(),
+          proof: proof.toString("base64url")
+        }
+      }
+    };
+  });
+  const manifestPath = path.join(serviceRoot, "authority-production.json");
+  writeFileSync(manifestPath, `${JSON.stringify({
+    schema: "authority-production-composition/v1",
+    serviceStateRoot: serviceRoot,
+    repos: repos.map((repo) => repo.manifest)
+  }, null, 2)}\n`);
+  const [primary] = repos;
+  if (!primary) throw new Error("production authority fixture requires a primary repo");
+  return {
+    root,
+    repoRoot: primary.repoRoot,
+    authoredRoot: primary.authoredRoot,
+    serviceRoot,
+    manifestPath,
+    registryPath: primary.registryPath,
+    repos: repos.map(({ manifest: _manifest, ...repo }) => repo)
+  };
+}
+
+function fixturePeopleRoster(): string {
+  return [
     "schema: harness-people/v1",
     "people:",
     "  - personId: person_alice",
@@ -50,82 +177,7 @@ export function createProductionAuthorityLifecycleFixture(): ProductionAuthority
     "  - roleId: owner",
     "    commandClasses: [admin, repo-write, repo-read, arbiter]",
     ""
-  ].join("\n"));
-  const keyStore = openLocalAuthorityKeyStore({
-    serviceStateRoot: serviceRoot,
-    stateDirectory: keyStateDirectory,
-    workspaceRoot: repoRoot,
-    authorityId: "authority.production",
-    issuer: "authority.production"
-  });
-  const now = Date.now();
-  const prepublished = keyStore.createPrepublishedKey({ generation: 1, nowMs: now - 1_000 });
-  const prepublishedRegistry = createAuthorityKeyRegistryV1({
-    authorityId: "authority.production",
-    generation: 1,
-    globalRevocationEpoch: 1,
-    revision: 1,
-    entries: [prepublished]
-  });
-  const registry = firstPinAuthorityKeyV1({
-    registry: prepublishedRegistry,
-    keyId: prepublished.keyId,
-    expectedPinnedKeyId: prepublished.keyId,
-    pinEvidence: "fixture-out-of-band-pin",
-    verifierAcknowledgement: "fixture-verifier-ack",
-    activatedAtMs: now - 999
-  });
-  const registryPath = path.join(authoredRoot, "authority-key-registry.json");
-  writeFileSync(registryPath, `${JSON.stringify(registry, null, 2)}\n`);
-  const unsignedNamespace = {
-    schema: "operation-namespace/v1" as const,
-    workspaceId: "workspace-production",
-    deviceId: "device-production",
-    authorityGeneration: 1n,
-    namespaceId: "namespace-production",
-    expiresAt: BigInt(now + 60 * 60_000),
-    issuer: "authority.production",
-    keyId: prepublished.keyId
-  };
-  const proof = sign(
-    null,
-    authorityNamespaceProofBytes(unsignedNamespace),
-    keyStore.signingProfile(registry, now).privateKey
-  );
-  const manifestPath = path.join(serviceRoot, "authority-production.json");
-  writeFileSync(manifestPath, `${JSON.stringify({
-    schema: "authority-production-composition/v1",
-    serviceStateRoot: serviceRoot,
-    repos: [{
-      repoId: "canonical",
-      canonicalRoot: repoRoot,
-      workspaceId: "workspace-production",
-      deviceId: "device-production",
-      viewId: "view-production",
-      sessionId: "session-production",
-      authorityId: "authority.production",
-      issuer: "authority.production",
-      keyRegistryPath: registryPath,
-      keyStateDirectory,
-      schemaTuple: productionTuple(),
-      authorityGeneration: 1,
-      revocationEpochs: {
-        global: "1", workspace: "1", device: "1", view: "1", principal: "1", executor: "1"
-      },
-      admissionTokenRef: "admission-production",
-      allowedExecutorAgentIds: ["codex"],
-      operationNamespace: {
-        ...unsignedNamespace,
-        authorityGeneration: unsignedNamespace.authorityGeneration.toString(),
-        expiresAt: unsignedNamespace.expiresAt.toString(),
-        proof: proof.toString("base64url")
-      }
-    }]
-  }, null, 2)}\n`);
-  fixtureGit(authoredRoot, "init", "-q");
-  fixtureGit(authoredRoot, "add", ".");
-  fixtureGit(authoredRoot, "commit", "-q", "-m", "seed authority fixture");
-  return { root, repoRoot, authoredRoot, serviceRoot, manifestPath, registryPath };
+  ].join("\n");
 }
 
 export function productionTuple() {

--- a/packages/cli/test/repo-write-child-production-cutover.test.ts
+++ b/packages/cli/test/repo-write-child-production-cutover.test.ts
@@ -1,12 +1,15 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
+  realpathSync,
   readFileSync,
   rmSync,
   writeFileSync
 } from "node:fs";
+import { hostname } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
@@ -19,7 +22,9 @@ import {
   encodeRepoWriteChildLaunchConfig,
   encodeRepoWriteProgressCommand,
   forkRepoWriteProcess,
+  localUserDaemonEndpoint,
   publishNextDaemonGeneration,
+  requestLocalDaemonJsonRpc,
   readOrCreateDaemonMachineId,
   repoWriteChildLaunchConfigSchema,
   RepoWriteProcessSupervisor,
@@ -41,12 +46,109 @@ import {
   createProductionAuthorityLifecycleFixture,
   fixtureGit
 } from "./helpers/production-authority-lifecycle-fixture.ts";
+import {
+  pollUntil,
+  runRawJsonAsync,
+  runRawJsonMaybeFail,
+  stopDaemon
+} from "./helpers/daemon-cli.ts";
 
 const cutoverTest = process.platform === "win32" ? test.skip : test;
 const taskId = "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4";
 const entrypoint = fileURLToPath(new URL("../src/index.ts", import.meta.url));
 const entrypointArtifactIdentity =
   calculateDaemonArtifactIdentity(entrypoint).identity;
+
+cutoverTest("two signed production repos own distinct child locks and route through one daemon", { timeout: 60_000 }, async (t) => {
+  const fixture = createProductionAuthorityLifecycleFixture({ repoIds: ["alpha", "beta"] });
+  const userRoot = path.join(fixture.root, "daemon-user");
+  const endpoint = localUserDaemonEndpoint(userRoot);
+  const [alpha, beta] = fixture.repos;
+  assert.ok(alpha && beta);
+  const foreground = startProductionForegroundDaemon(fixture, alpha.repoRoot, "alpha", userRoot);
+  try {
+    await waitForProductionLocks(fixture, foreground, userRoot);
+
+    const owners = fixture.repos.map((repo) => {
+      const lockPath = path.join(repo.repoRoot, ".harness/locks/global.lock");
+      assert.equal(existsSync(lockPath), true, lockPath);
+      const lock = JSON.parse(readFileSync(lockPath, "utf8")) as Record<string, unknown>;
+      assert.equal(lock.ownerKind, "daemon");
+      assert.equal(lock.repoId, repo.repoId);
+      assert.equal(lock.canonicalRoot, realpathSync(repo.repoRoot));
+      assert.equal(lock.userRoot, userRoot);
+      assert.equal(lock.endpoint, endpoint);
+      assert.equal(typeof lock.pid, "number");
+      assert.equal(processCwd(lock.pid as number), realpathSync(repo.repoRoot));
+      return lock;
+    });
+    assert.notEqual(owners[0]?.pid, owners[1]?.pid);
+
+    const [alphaStatus, betaStatus] = await Promise.all([
+      requestRepoStatus(alpha.repoRoot, userRoot, "alpha"),
+      requestRepoStatus(beta.repoRoot, userRoot, "beta")
+    ]);
+    assert.equal(alphaStatus.requestedRepo && (alphaStatus.requestedRepo as Record<string, unknown>).state, "attached");
+    assert.equal(betaStatus.requestedRepo && (betaStatus.requestedRepo as Record<string, unknown>).state, "attached");
+    assert.deepEqual(
+      (alphaStatus.repos as Array<Record<string, unknown>>).map((repo) => repo.repoId),
+      ["alpha", "beta"]
+    );
+    t.diagnostic(JSON.stringify({
+      repoCount: owners.length,
+      owners: owners.map((owner) => ({ repoId: owner.repoId, pid: owner.pid, canonicalRoot: owner.canonicalRoot })),
+      routes: [
+        (alphaStatus.requestedRepo as Record<string, unknown>).repoId,
+        (betaStatus.requestedRepo as Record<string, unknown>).repoId
+      ]
+    }));
+  } finally {
+    await stopDaemon(alpha.repoRoot, userRoot).catch(() => undefined);
+    await foreground.result;
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+cutoverTest("stale multi-repo locks recover serially and a second userRoot reports the complete conflict set without leaked children", { timeout: 60_000 }, async (t) => {
+  const fixture = createProductionAuthorityLifecycleFixture({ repoIds: ["alpha", "beta"] });
+  const firstUserRoot = path.join(fixture.root, "daemon-first");
+  const secondUserRoot = path.join(fixture.root, "daemon-second");
+  const [alpha] = fixture.repos;
+  assert.ok(alpha);
+  let foreground: ReturnType<typeof startProductionForegroundDaemon> | undefined;
+  try {
+    for (const repo of fixture.repos) writeStaleDaemonLock(repo.repoRoot, repo.repoId, firstUserRoot);
+    foreground = startProductionForegroundDaemon(fixture, alpha.repoRoot, "alpha", firstUserRoot);
+    await waitForProductionLocks(fixture, foreground, firstUserRoot);
+    const firstOwners = fixture.repos.map((repo) =>
+      JSON.parse(readFileSync(path.join(repo.repoRoot, ".harness/locks/global.lock"), "utf8")) as Record<string, unknown>);
+    assert.equal(firstOwners.every((owner) => owner.userRoot === firstUserRoot), true);
+
+    const second = runRawJsonMaybeFail(alpha.repoRoot, [
+      "--repo", "alpha", "daemon", "start", "--foreground", "--user-root", secondUserRoot,
+      "--authority-manifest", fixture.manifestPath
+    ], productionDaemonEnv(secondUserRoot));
+    assert.notEqual(second.status, 0);
+    const diagnostic = JSON.stringify(second.receipt);
+    assert.match(diagnostic, /DAEMON_REPO_LOCK_SET_CONFLICT/u);
+    assert.match(diagnostic, /alpha@/u);
+    assert.match(diagnostic, /beta@/u);
+    assert.match(diagnostic, /daemon-repository-ownership-invariants/u);
+    assert.doesNotMatch(diagnostic, /takeover.in.progress/iu);
+    for (const [index, repo] of fixture.repos.entries()) {
+      const owner = JSON.parse(readFileSync(path.join(repo.repoRoot, ".harness/locks/global.lock"), "utf8")) as Record<string, unknown>;
+      assert.equal(owner.pid, firstOwners[index]?.pid);
+      assert.equal(owner.userRoot, firstUserRoot);
+    }
+    assert.equal(existsSync(localUserDaemonEndpoint(secondUserRoot)), false);
+    t.diagnostic(diagnostic);
+  } finally {
+    await stopDaemon(alpha.repoRoot, firstUserRoot).catch(() => undefined);
+    await stopDaemon(alpha.repoRoot, secondUserRoot).catch(() => undefined);
+    await foreground?.result;
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
 
 cutoverTest("production child owns the only writer lock and restart lookup returns the exact receipt", async () => {
   const fixture = createProductionAuthorityLifecycleFixture();
@@ -355,4 +457,105 @@ function installProgressTask(authoredRoot: string): void {
     "# Production child",
     ""
   ].join("\n"));
+}
+
+function productionDaemonEnv(userRoot: string): Record<string, string> {
+  return {
+    HARNESS_ACTOR: "agent:codex",
+    HARNESS_DAEMON_MODE: "local",
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_IDLE_MS: "60000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
+    HARNESS_DAEMON_REQUEST_TIMEOUT_MS: "35000",
+    CODEX_THREAD_ID: "production-multi-repo-test"
+  };
+}
+
+function startProductionForegroundDaemon(
+  fixture: ReturnType<typeof createProductionAuthorityLifecycleFixture>,
+  repoRoot: string,
+  repoId: string,
+  userRoot: string
+): { readonly result: Promise<void>; readonly failure: () => unknown } {
+  let failure: unknown;
+  const result = runRawJsonAsync(repoRoot, [
+    "--repo", repoId, "daemon", "start", "--foreground", "--user-root", userRoot,
+    "--authority-manifest", fixture.manifestPath
+  ], productionDaemonEnv(userRoot)).then(
+    (receipt) => {
+      if (receipt.ok !== true) failure = new Error(JSON.stringify(receipt));
+    },
+    (error: unknown) => {
+      failure = error;
+    }
+  );
+  return { result, failure: () => failure };
+}
+
+async function waitForProductionLocks(
+  fixture: ReturnType<typeof createProductionAuthorityLifecycleFixture>,
+  foreground: ReturnType<typeof startProductionForegroundDaemon>,
+  userRoot: string
+): Promise<void> {
+  const state = await pollUntil(
+    async () => {
+      let status: Record<string, unknown> | undefined;
+      try {
+        status = await requestRepoStatus(fixture.repos[0]!.repoRoot, userRoot, fixture.repos[0]!.repoId);
+      } catch {
+        // The foreground daemon may not have activated its socket yet.
+      }
+      return { failure: foreground.failure(), status };
+    },
+    (candidate) => candidate.failure !== undefined
+      || Array.isArray(candidate.status?.repos)
+        && (candidate.status.repos as Array<Record<string, unknown>>).length === fixture.repos.length
+        && (candidate.status.repos as Array<Record<string, unknown>>).every((repo) => repo.state === "attached"),
+    (state, error) => JSON.stringify({ state, error: String(error ?? "") }),
+    { timeoutMs: 20_000 }
+  );
+  if (state.failure) throw state.failure;
+}
+
+async function requestRepoStatus(
+  repoRoot: string,
+  userRoot: string,
+  repoId: string
+): Promise<Record<string, unknown>> {
+  const receipt = await requestLocalDaemonJsonRpc(
+    repoRoot,
+    "repo.daemon.status",
+    { repo: { repoId } },
+    1_000,
+    { userRoot, allowLegacySocket: false }
+  );
+  assert.equal(receipt.ok, true, JSON.stringify(receipt));
+  return ((receipt.details as Record<string, unknown>).data ?? {}) as Record<string, unknown>;
+}
+
+function writeStaleDaemonLock(repoRoot: string, repoId: string, userRoot: string): void {
+  const lockPath = path.join(repoRoot, ".harness/locks/global.lock");
+  mkdirSync(path.dirname(lockPath), { recursive: true });
+  writeFileSync(lockPath, JSON.stringify({
+    pid: 999_999_999,
+    hostname: hostname(),
+    acquiredAt: "2000-01-01T00:00:00.000Z",
+    heartbeatAt: "2000-01-01T00:00:00.000Z",
+    ownerToken: `stale-${repoId}`,
+    ownerKind: "daemon",
+    repoId,
+    canonicalRoot: repoRoot,
+    userRoot,
+    endpoint: path.join(userRoot, "daemon.sock")
+  }), "utf8");
+}
+
+function processCwd(pid: number): string {
+  if (process.platform === "linux") return realpathSync(`/proc/${pid}/cwd`);
+  if (process.platform === "darwin") {
+    const output = execFileSync("/usr/sbin/lsof", ["-a", "-p", String(pid), "-d", "cwd", "-Fn"], { encoding: "utf8" });
+    const cwd = output.split("\n").find((line) => line.startsWith("n"))?.slice(1);
+    if (cwd) return realpathSync(cwd);
+  }
+  throw new Error(`process cwd inspection is unsupported on ${process.platform}`);
 }

--- a/packages/daemon/src/authority/authority-lifecycle.ts
+++ b/packages/daemon/src/authority/authority-lifecycle.ts
@@ -1,3 +1,5 @@
+import { existsSync, realpathSync } from "node:fs";
+import path from "node:path";
 import type {
   ActorAxesBindingRuntimeV2,
   AttributedCoordinatorFactory,
@@ -280,7 +282,7 @@ export function createAuthorityRepoLifecycleController(input: {
 
   function startRepo(repo: DaemonRepoNamespace, runtime: AuthorityLifecycleRuntime): Promise<AuthorityRepoStartResult> {
     const existing = started.get(repo.repoId);
-    if (existing) return Promise.resolve(existing.repo.canonicalRoot === repo.canonicalRoot
+    if (existing) return Promise.resolve(authorityRootsEqual(existing.repo.canonicalRoot, repo.canonicalRoot)
       ? { ok: true, component: existing.component }
       : { ok: false, error: "AUTHORITY_REPO_ATTACHMENT_MISMATCH" });
     const pending = starting.get(repo.repoId);
@@ -436,7 +438,7 @@ function validateServerData(
   data: AuthorityRepoCompositionData,
   allowInMemoryFixture: boolean
 ): void {
-  if (data.repoId !== repo.repoId || data.canonicalRoot !== repo.canonicalRoot) {
+  if (data.repoId !== repo.repoId || !authorityRootsEqual(data.canonicalRoot, repo.canonicalRoot)) {
     throw new Error("AUTHORITY_SERVER_REPO_BINDING_MISMATCH");
   }
   for (const [name, value] of Object.entries({
@@ -460,6 +462,14 @@ function validateServerData(
       }
     }
   }
+}
+
+function authorityRootsEqual(left: string, right: string): boolean {
+  const resolvedLeft = path.resolve(left);
+  const resolvedRight = path.resolve(right);
+  const canonicalLeft = existsSync(resolvedLeft) ? realpathSync.native(resolvedLeft) : resolvedLeft;
+  const canonicalRight = existsSync(resolvedRight) ? realpathSync.native(resolvedRight) : resolvedRight;
+  return canonicalLeft === canonicalRight;
 }
 
 function authorityLifecycleErrorMessage(error: unknown): string {

--- a/packages/daemon/src/lifecycle/run-daemon-serve.ts
+++ b/packages/daemon/src/lifecycle/run-daemon-serve.ts
@@ -39,6 +39,10 @@ import {
   RepoWriteProcessSupervisor
 } from "../runtime/repo-write-process-supervisor.ts";
 import {
+  prepareProductionRepoLocks,
+  startProductionRepoWriteSupervisors
+} from "../runtime/production-repo-lock-topology.ts";
+import {
   encodeRepoWriteChildLaunchConfig,
   repoWriteChildLaunchConfigSchema
 } from "../runtime/repo-write-child-launch-config.ts";
@@ -190,6 +194,15 @@ export async function runDaemonServe<
           daemonGeneration: generation.daemonGeneration
         } : {})
       });
+      if (productionChildCutover) {
+        prepareProductionRepoLocks({
+          repos: activeServeRepos,
+          userRoot,
+          endpoint,
+          lockTtlMs: runtimePolicy.write.lockTtlMs,
+          ...(layoutOverrides ? { layoutOverrides } : {})
+        });
+      }
       runtime = createMultiRepoDaemonRuntime({
         ...(productionChildCutover ? { writeOwnership: "reader" as const } : {}),
         projectionSourceFenceFactory: makeLocalProjectionSourceFenceReader,
@@ -220,6 +233,12 @@ export async function runDaemonServe<
           repoId: repo.repoId,
           rootDir: repo.canonicalRoot,
           displayName: repo.displayName,
+          lockProvenance: {
+            repoId: repo.repoId,
+            canonicalRoot: repo.canonicalRoot,
+            userRoot,
+            endpoint
+          },
           ...(layoutOverrides ? { layoutOverrides } : {})
         }))
       });
@@ -331,10 +350,13 @@ export async function runDaemonServe<
           });
           repoWriteSupervisors.set(repo.repoId, supervisor);
         }
-        await Promise.all(
-          [...repoWriteSupervisors.values()].map((supervisor) =>
-            supervisor.start())
-        );
+        await startProductionRepoWriteSupervisors({
+          supervisors: repoWriteSupervisors,
+          repos: activeServeRepos,
+          userRoot,
+          endpoint,
+          ...(layoutOverrides ? { layoutOverrides } : {})
+        });
       }
       serviceHost = await createDaemonServiceHost(
         runtime,

--- a/packages/daemon/src/runtime/production-repo-lock-topology.ts
+++ b/packages/daemon/src/runtime/production-repo-lock-topology.ts
@@ -1,0 +1,180 @@
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import path from "node:path";
+import {
+  createHarnessRuntimeContext,
+  resolveHarnessLayout,
+  type HarnessLayoutOverrides
+} from "@harness-anything/kernel";
+import { acquireDaemonGlobalLock } from "@harness-anything/kernel/daemon-runtime-support";
+import type { RepoWriteProcessSupervisor } from "./repo-write-process-supervisor.ts";
+
+export interface ProductionRepoLockTarget {
+  readonly repoId: string;
+  readonly canonicalRoot: string;
+}
+
+export function prepareProductionRepoLocks(input: {
+  readonly repos: ReadonlyArray<ProductionRepoLockTarget>;
+  readonly userRoot: string;
+  readonly endpoint: string;
+  readonly lockTtlMs: number;
+  readonly layoutOverrides?: HarnessLayoutOverrides;
+}): void {
+  const failures: Array<{ readonly repo: ProductionRepoLockTarget; readonly error: unknown }> = [];
+  for (const repo of [...input.repos].sort((left, right) => left.repoId.localeCompare(right.repoId))) {
+    const runtimeContext = createHarnessRuntimeContext(repo.canonicalRoot, input.layoutOverrides);
+    const layout = resolveHarnessLayout(runtimeContext);
+    try {
+      acquireProductionPreflightLock({
+        repo,
+        runtimeContext,
+        journalPath: layout.journalPath,
+        lockTtlMs: input.lockTtlMs,
+        userRoot: input.userRoot,
+        endpoint: input.endpoint
+      });
+    } catch (error) {
+      failures.push({ repo, error });
+    }
+  }
+  if (failures.length > 0) throw daemonRepoLockSetConflict(input.repos, failures);
+}
+
+export async function startProductionRepoWriteSupervisors(input: {
+  readonly supervisors: ReadonlyMap<string, RepoWriteProcessSupervisor>;
+  readonly repos: ReadonlyArray<ProductionRepoLockTarget>;
+  readonly userRoot: string;
+  readonly endpoint: string;
+  readonly layoutOverrides?: HarnessLayoutOverrides;
+}): Promise<void> {
+  const orderedEntries = [...input.supervisors.entries()]
+    .sort(([left], [right]) => left.localeCompare(right));
+  const [sentinelEntry, ...remainingEntries] = orderedEntries;
+  // The first repo is a deterministic topology sentinel. Identical manifests
+  // contend here before either daemon can fan out children for other repos.
+  if (sentinelEntry) {
+    const [repoId, sentinel] = sentinelEntry;
+    try {
+      await sentinel.start();
+    } catch (error) {
+      const repo = input.repos.find((candidate) => candidate.repoId === repoId);
+      if (!repo || !repoLockOwnedByOtherDaemon(repo, input)) throw error;
+      throw daemonRepoLockSetConflict(input.repos, [{ repo, error }]);
+    }
+  }
+
+  const results = await Promise.allSettled(
+    remainingEntries.map(([, supervisor]) => supervisor.start())
+  );
+  const failures = results.flatMap((result, index) => {
+    if (result.status === "fulfilled") return [];
+    const repoId = remainingEntries[index]?.[0];
+    const repo = input.repos.find((candidate) => candidate.repoId === repoId);
+    return repo ? [{ repo, error: result.reason }] : [];
+  });
+  if (failures.length === 0) return;
+
+  const classified = failures.map((failure) => ({
+    ...failure,
+    otherDaemonOwnsLock: repoLockOwnedByOtherDaemon(failure.repo, input)
+  }));
+  const lockFailures = classified
+    .filter(({ otherDaemonOwnsLock }) => otherDaemonOwnsLock)
+    .map(({ repo, error }) => ({ repo, error }));
+  if (lockFailures.length === failures.length) {
+    throw daemonRepoLockSetConflict(input.repos, lockFailures);
+  }
+  const nonLockFailures = classified
+    .filter(({ otherDaemonOwnsLock }) => !otherDaemonOwnsLock)
+    .map(({ error }) => error);
+  if (nonLockFailures.length === 1) throw nonLockFailures[0];
+  throw new AggregateError(
+    nonLockFailures,
+    "one or more repo-write children failed to start for reasons other than lock ownership"
+  );
+}
+
+function acquireProductionPreflightLock(input: {
+  readonly repo: ProductionRepoLockTarget;
+  readonly runtimeContext: ReturnType<typeof createHarnessRuntimeContext>;
+  readonly journalPath: string;
+  readonly lockTtlMs: number;
+  readonly userRoot: string;
+  readonly endpoint: string;
+}): void {
+  const deadline = Date.now() + 250;
+  while (true) {
+    try {
+      const lock = acquireDaemonGlobalLock(
+        input.repo.canonicalRoot,
+        input.runtimeContext,
+        input.journalPath,
+        { scope: "operational", kind: "system", id: "daemon-startup-lock-preflight" },
+        input.lockTtlMs,
+        {
+          repoId: input.repo.repoId,
+          canonicalRoot: input.repo.canonicalRoot,
+          userRoot: input.userRoot,
+          endpoint: input.endpoint
+        }
+      );
+      lock.release();
+      return;
+    } catch (error) {
+      if (!transientPreflightConflict(error) || Date.now() >= deadline) throw error;
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+    }
+  }
+}
+
+function transientPreflightConflict(error: unknown): boolean {
+  if (!error || typeof error !== "object" || !("reason" in error)) return false;
+  return error.reason === "takeover-in-progress" || error.reason === "lock-record-publishing";
+}
+
+function daemonRepoLockSetConflict(
+  repos: ReadonlyArray<ProductionRepoLockTarget>,
+  failures: ReadonlyArray<{ readonly repo: ProductionRepoLockTarget; readonly error: unknown }>
+): Error {
+  const repoSet = repos
+    .map((repo) => `${repo.repoId}@${repo.canonicalRoot}`)
+    .sort()
+    .join(", ");
+  const conflicts = failures
+    .map(({ repo, error }) => `${repo.repoId}@${repo.canonicalRoot}: ${error instanceof Error ? error.message : String(error)}`)
+    .join("; ");
+  return new Error(
+    `DAEMON_REPO_LOCK_SET_CONFLICT: manifest repo set=[${repoSet}]; conflicts=[${conflicts}]. `
+    + "One canonicalRoot may belong to only one live daemon; each explicit manifest is the daemon's complete enabled repo set; daemon repo sets must not overlap. "
+    + "See docs-release/operations-server-daemon.md#daemon-repository-ownership-invariants."
+  );
+}
+
+function repoLockOwnedByOtherDaemon(
+  repo: ProductionRepoLockTarget,
+  input: {
+    readonly userRoot: string;
+    readonly endpoint: string;
+    readonly layoutOverrides?: HarnessLayoutOverrides;
+  }
+): boolean {
+  const layout = resolveHarnessLayout(createHarnessRuntimeContext(repo.canonicalRoot, input.layoutOverrides));
+  const lockPath = path.join(layout.locksRoot, "global.lock");
+  if (!existsSync(lockPath)) return false;
+  try {
+    const record = JSON.parse(readFileSync(lockPath, "utf8")) as Record<string, unknown>;
+    if (record.ownerKind !== "daemon") return false;
+    const differentUserRoot = typeof record.userRoot === "string"
+      && canonicalExistingPath(record.userRoot) !== canonicalExistingPath(input.userRoot);
+    const differentEndpoint = typeof record.endpoint === "string"
+      && record.endpoint !== input.endpoint;
+    return differentUserRoot || differentEndpoint;
+  } catch {
+    return false;
+  }
+}
+
+function canonicalExistingPath(value: string): string {
+  const resolved = path.resolve(value);
+  return existsSync(resolved) ? realpathSync.native(resolved) : resolved;
+}

--- a/packages/daemon/src/runtime/production-repo-lock-topology.ts
+++ b/packages/daemon/src/runtime/production-repo-lock-topology.ts
@@ -5,7 +5,7 @@ import {
   resolveHarnessLayout,
   type HarnessLayoutOverrides
 } from "@harness-anything/kernel";
-import { acquireDaemonGlobalLock } from "@harness-anything/kernel/daemon-runtime-support";
+import { acquireDaemonGlobalLock } from "./repo-runtime-lock.ts";
 import type { RepoWriteProcessSupervisor } from "./repo-write-process-supervisor.ts";
 
 export interface ProductionRepoLockTarget {

--- a/packages/daemon/src/runtime/repo-runtime-lock.ts
+++ b/packages/daemon/src/runtime/repo-runtime-lock.ts
@@ -1,0 +1,33 @@
+import {
+  createHarnessRuntimeContext,
+  type OperationalActor
+} from "@harness-anything/kernel";
+import {
+  acquireDaemonGlobalLock,
+  type DaemonGlobalLock
+} from "@harness-anything/kernel/daemon-runtime-support";
+import type { DaemonRuntimeOptions } from "./repo-runtime-options.ts";
+
+export function acquireRepoRuntimeGlobalLock(input: {
+  readonly rootDir: string;
+  readonly runtimeContext: ReturnType<typeof createHarnessRuntimeContext>;
+  readonly journalPath: string;
+  readonly operationalActor: OperationalActor;
+  readonly lockTtlMs: number;
+  readonly repoId: string;
+  readonly lockProvenance?: DaemonRuntimeOptions["lockProvenance"];
+}): DaemonGlobalLock {
+  return acquireDaemonGlobalLock(
+    input.rootDir,
+    input.runtimeContext,
+    input.journalPath,
+    input.operationalActor,
+    input.lockTtlMs,
+    {
+      repoId: input.lockProvenance?.repoId ?? input.repoId,
+      canonicalRoot: input.lockProvenance?.canonicalRoot ?? input.rootDir,
+      ...(input.lockProvenance?.userRoot ? { userRoot: input.lockProvenance.userRoot } : {}),
+      ...(input.lockProvenance?.endpoint ? { endpoint: input.lockProvenance.endpoint } : {})
+    }
+  );
+}

--- a/packages/daemon/src/runtime/repo-runtime-lock.ts
+++ b/packages/daemon/src/runtime/repo-runtime-lock.ts
@@ -8,6 +8,8 @@ import {
 } from "@harness-anything/kernel/daemon-runtime-support";
 import type { DaemonRuntimeOptions } from "./repo-runtime-options.ts";
 
+export { acquireDaemonGlobalLock, type DaemonGlobalLock };
+
 export function acquireRepoRuntimeGlobalLock(input: {
   readonly rootDir: string;
   readonly runtimeContext: ReturnType<typeof createHarnessRuntimeContext>;

--- a/packages/daemon/src/runtime/repo-runtime-options-merge.ts
+++ b/packages/daemon/src/runtime/repo-runtime-options-merge.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type {
   DaemonRepoRuntimeOptions,
   MultiRepoDaemonRuntimeOptions
@@ -11,6 +12,7 @@ export function mergeRepoRuntimeDefaults(
     ...repo,
     ...(repo.writeOwnership ? {} : options.writeOwnership ? { writeOwnership: options.writeOwnership } : {}),
     ...(repo.operationalActor ? {} : options.operationalActor ? { operationalActor: options.operationalActor } : {}),
+    ...(repo.lockProvenance ? {} : options.lockProvenance ? { lockProvenance: options.lockProvenance } : {}),
     ...(repo.lockTtlMs !== undefined ? {} : options.lockTtlMs !== undefined ? { lockTtlMs: options.lockTtlMs } : {}),
     ...(repo.interactiveMicroBatchMs !== undefined ? {} : options.interactiveMicroBatchMs !== undefined ? { interactiveMicroBatchMs: options.interactiveMicroBatchMs } : {}),
     ...(repo.maxInteractiveOpsPerCommit !== undefined ? {} : options.maxInteractiveOpsPerCommit !== undefined ? { maxInteractiveOpsPerCommit: options.maxInteractiveOpsPerCommit } : {}),
@@ -26,4 +28,12 @@ export function mergeRepoRuntimeDefaults(
     ...(repo.generationWitness ? {} : options.generationWitness ? { generationWitness: options.generationWitness } : {}),
     ...(repo.generationCapability ? {} : options.generationCapability ? { generationCapability: options.generationCapability } : {})
   };
+}
+
+export function sortedRepoOptions(
+  repos: ReadonlyArray<DaemonRepoRuntimeOptions>
+): ReadonlyArray<DaemonRepoRuntimeOptions> {
+  return [...repos].sort((left, right) =>
+    left.repoId.localeCompare(right.repoId)
+      || path.resolve(left.rootDir).localeCompare(path.resolve(right.rootDir)));
 }

--- a/packages/daemon/src/runtime/repo-runtime-options.ts
+++ b/packages/daemon/src/runtime/repo-runtime-options.ts
@@ -44,6 +44,13 @@ export interface DaemonRuntimeOptions {
   readonly writeOwnership?: "writer" | "reader";
   readonly layoutOverrides?: HarnessLayoutOverrides;
   readonly operationalActor?: OperationalActor;
+  /** Provenance written only to daemon-owned global lock records. */
+  readonly lockProvenance?: {
+    readonly repoId?: string;
+    readonly canonicalRoot?: string;
+    readonly userRoot?: string;
+    readonly endpoint?: string;
+  };
   readonly lockTtlMs?: number;
   readonly interactiveMicroBatchMs?: number;
   readonly maxInteractiveOpsPerCommit?: number;

--- a/packages/daemon/src/runtime/repo-runtime.ts
+++ b/packages/daemon/src/runtime/repo-runtime.ts
@@ -16,7 +16,6 @@ import {
   resolveHarnessLayout
 } from "@harness-anything/kernel";
 import {
-  acquireDaemonGlobalLock,
   assertDaemonGlobalLockHeld,
   createProjectionChangePublisher,
   createRuntimeAdmissionBudget,
@@ -76,8 +75,9 @@ import {
 import { toDaemonRuntimeStatus } from "./repo-runtime-status.ts";
 import { defaultDaemonRuntimePolicy } from "./runtime-policy.ts";
 import { ReservationReconcilerRunner } from "./reservation-reconciler-runner.ts";
-import { mergeRepoRuntimeDefaults } from "./repo-runtime-options-merge.ts";
+import { mergeRepoRuntimeDefaults, sortedRepoOptions } from "./repo-runtime-options-merge.ts";
 import { describeRepoRuntimeError } from "./repo-runtime-error.ts";
+import { acquireRepoRuntimeGlobalLock } from "./repo-runtime-lock.ts";
 
 const defaultDaemonOperationalActor: OperationalActor = { scope: "operational", kind: "system", id: "daemon-runtime" };
 
@@ -279,7 +279,15 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
         return this.status();
       }
       this.assertBuildCurrent();
-      this.lock = acquireDaemonGlobalLock(this.rootDir, this.runtimeContext, this.layout.journalPath, this.operationalActor, this.lockTtlMs);
+      this.lock = acquireRepoRuntimeGlobalLock({
+        rootDir: this.rootDir,
+        runtimeContext: this.runtimeContext,
+        journalPath: this.layout.journalPath,
+        operationalActor: this.operationalActor,
+        lockTtlMs: this.lockTtlMs,
+        repoId: this.repoId,
+        lockProvenance: this.options.lockProvenance
+      });
       this.assertBuildCurrent();
       this.lastRecovery = Effect.runSync(recoverJournaledWrites({
         rootDir: this.rootDir,
@@ -576,10 +584,6 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
     if (!this.projectionGenerationClosed) this.projectionGenerationClosed = true;
     return this.projectionGeneration.close();
   }
-}
-
-function sortedRepoOptions(repos: ReadonlyArray<DaemonRepoRuntimeOptions>): ReadonlyArray<DaemonRepoRuntimeOptions> {
-  return [...repos].sort((left, right) => left.repoId.localeCompare(right.repoId) || path.resolve(left.rootDir).localeCompare(path.resolve(right.rootDir)));
 }
 
 function sortedContexts(contexts: Map<string, DaemonRepoRuntimeContext>): ReadonlyArray<DaemonRepoRuntimeContext> {

--- a/packages/daemon/src/runtime/write-queue.ts
+++ b/packages/daemon/src/runtime/write-queue.ts
@@ -60,7 +60,7 @@ export interface DaemonQueueSnapshot {
   readonly admission: DaemonAdmissionBudgetSnapshot;
 }
 
-export type { DaemonQueueDrainTarget } from "@harness-anything/kernel/daemon-runtime-support";
+export type { DaemonQueueDrainTarget };
 
 type InteractiveQueueItem = InteractiveWriteAttribution & {
   readonly kind: "interactive";

--- a/packages/daemon/test/runtime/repo-runtime-lock-provenance.test.ts
+++ b/packages/daemon/test/runtime/repo-runtime-lock-provenance.test.ts
@@ -1,0 +1,90 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { hostname } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createDaemonRuntime } from "../../src/runtime/repo-runtime.ts";
+import { withTempStoreAsync } from "./helpers/store.ts";
+
+test("a publishing daemon lock never impersonates takeover and resolves to its owner", async (t) => {
+  await withTempStoreAsync(async (rootDir) => {
+    const lockPath = path.join(rootDir, ".harness/locks/global.lock");
+    mkdirSync(path.dirname(lockPath), { recursive: true });
+    writeFileSync(lockPath, "", "utf8");
+
+    const publishingRuntime = createDaemonRuntime({ rootDir, materializerPollMs: false });
+    const publishing = await rejectedError(publishingRuntime.start());
+    assert.equal(errorReason(publishing), "lock-record-publishing");
+    assert.doesNotMatch(publishing.message, /takeover/iu);
+
+    writeFileSync(lockPath, JSON.stringify({
+      pid: process.pid,
+      hostname: hostname(),
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      ownerToken: "published-owner",
+      ownerKind: "daemon",
+      repoId: "alpha",
+      canonicalRoot: rootDir,
+      userRoot: path.join(rootDir, ".daemon-user"),
+      endpoint: path.join(rootDir, ".daemon-user/daemon.sock")
+    }), "utf8");
+    const heldRuntime = createDaemonRuntime({ rootDir, materializerPollMs: false });
+    const held = await rejectedError(heldRuntime.start());
+    assert.equal(errorReason(held), "held");
+    assert.match(held.message, /repo alpha/u);
+    assert.match(held.message, /userRoot/u);
+    assert.match(held.message, /endpoint/u);
+    assert.match(held.message, /daemon-repository-ownership-invariants/u);
+    t.diagnostic(JSON.stringify({
+      publishing: { reason: errorReason(publishing), message: publishing.message },
+      completed: { reason: errorReason(held), message: held.message }
+    }));
+  });
+});
+
+test("daemon runtime writes optional lock provenance and accepts legacy lock records", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    const userRoot = path.join(rootDir, ".daemon-user");
+    const endpoint = path.join(userRoot, "daemon.sock");
+    const runtime = createDaemonRuntime({
+      rootDir,
+      materializerPollMs: false,
+      lockProvenance: { repoId: "alpha", canonicalRoot: rootDir, userRoot, endpoint }
+    });
+    await runtime.start();
+    const lockPath = path.join(rootDir, ".harness/locks/global.lock");
+    const record = JSON.parse(readFileSync(lockPath, "utf8")) as Record<string, unknown>;
+    assert.equal(record.repoId, "alpha");
+    assert.equal(record.canonicalRoot, rootDir);
+    assert.equal(record.userRoot, userRoot);
+    assert.equal(record.endpoint, endpoint);
+    await runtime.stop();
+
+    writeFileSync(lockPath, JSON.stringify({
+      pid: process.pid,
+      hostname: hostname(),
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      ownerToken: "legacy-owner",
+      ownerKind: "daemon"
+    }), "utf8");
+    const legacyRuntime = createDaemonRuntime({ rootDir, materializerPollMs: false });
+    assert.match((await rejectedError(legacyRuntime.start())).message, /held by daemon pid/u);
+  });
+});
+
+async function rejectedError(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise;
+  } catch (error) {
+    assert.ok(error instanceof Error);
+    return error;
+  }
+  throw new Error("expected promise to reject");
+}
+
+function errorReason(error: Error): unknown {
+  return "reason" in error ? error.reason : undefined;
+}

--- a/packages/kernel/src/write-coordination/journal/locks.ts
+++ b/packages/kernel/src/write-coordination/journal/locks.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, readdirSync, renameSync, rmSync, unlinkSync, writeSync } from "node:fs";
+import { closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, readdirSync, renameSync, rmSync, statSync, unlinkSync, writeSync } from "node:fs";
 import { hostname } from "node:os";
 import path from "node:path";
 import type { EntityId, TaskId } from "../../domain/index.ts";
@@ -19,12 +19,23 @@ export interface RepoLockOptions {
   readonly heldGlobalLock?: OwnedLock;
 }
 
+export interface DaemonLockProvenance {
+  readonly repoId?: string;
+  readonly canonicalRoot?: string;
+  readonly userRoot?: string;
+  readonly endpoint?: string;
+}
+
+const lockRecordPublishReadBudgetMs = 20;
+const lockRecordPublishReadDelayMs = 2;
+const lockRecordPublishFreshnessMs = 100;
+
 export class WriteLockHeldError extends Error {
   readonly _tag = "WriteLockHeldError";
   readonly owner: string;
   readonly entityId?: EntityId;
   readonly taskId?: TaskId;
-  readonly reason: "held" | "changed-during-takeover" | "takeover-in-progress";
+  readonly reason: "held" | "lock-record-publishing" | "lock-record-invalid" | "changed-during-takeover" | "takeover-in-progress";
 
   constructor(input: {
     readonly owner: string;
@@ -34,7 +45,11 @@ export class WriteLockHeldError extends Error {
     const reason = input.reason ?? "held";
     const message = reason === "held"
       ? `lock already held: ${input.owner}`
-      : `lock already held: ${input.owner} ${reason.replaceAll("-", " ")}`;
+      : reason === "lock-record-publishing"
+        ? `lock record is still publishing: ${input.owner}`
+        : reason === "lock-record-invalid"
+          ? `lock record is invalid: ${input.owner}`
+          : `lock already held: ${input.owner} ${reason.replaceAll("-", " ")}`;
     super(message);
     this.name = "WriteLockHeldError";
     this.owner = input.owner;
@@ -79,10 +94,14 @@ export function acquireDaemonGlobalLock(
   layoutInput: HarnessLayoutInput,
   journalPath: string,
   actor: OperationalActor,
-  lockTtlMs: number
+  lockTtlMs: number,
+  provenance: DaemonLockProvenance = {}
 ): DaemonGlobalLock {
   const lockRoot = path.relative(rootDir, resolveHarnessLayout(layoutInput).locksRoot).split(path.sep).join("/");
-  const lock = acquireLock(rootDir, journalPath, actor, `${lockRoot}/global.lock`, lockTtlMs, undefined, "daemon");
+  const lock = acquireLock(rootDir, journalPath, actor, `${lockRoot}/global.lock`, lockTtlMs, undefined, "daemon", {
+    ...provenance,
+    canonicalRoot: provenance.canonicalRoot ?? path.resolve(rootDir)
+  });
   const refreshHeartbeat = () => refreshLockHeartbeat(lock);
   const interval = setInterval(refreshHeartbeat, Math.max(1_000, Math.floor(lockTtlMs / 3)));
   interval.unref();
@@ -127,7 +146,8 @@ function acquireLock(
   relativeLockPath: string,
   lockTtlMs: number,
   entityId?: EntityId,
-  ownerKind?: LockRecord["ownerKind"]
+  ownerKind?: LockRecord["ownerKind"],
+  provenance: DaemonLockProvenance = {}
 ): OwnedLock {
   const lockPath = path.join(rootDir, relativeLockPath);
   const claimPath = `${lockPath}.takeover`;
@@ -147,7 +167,7 @@ function acquireLock(
         throw lockHeld(lockOwnerMessage(relativeLockPath, existing), entityId);
       }
 
-      acquireTakeoverClaim(claimPath, ownerToken, entityId);
+      acquireTakeoverClaim(claimPath, ownerToken, entityId, provenance);
       ownsTakeoverClaim = true;
       const current = readLockRecordOrConflict(lockPath, relativeLockPath, entityId);
       if (current.ownerToken !== existing.ownerToken) {
@@ -184,7 +204,8 @@ function acquireLock(
         acquiredAt: new Date().toISOString(),
         heartbeatAt: new Date().toISOString(),
         ownerToken,
-        ...(ownerKind ? { ownerKind } : {})
+        ...(ownerKind ? { ownerKind } : {}),
+        ...definedLockProvenance(provenance)
       } satisfies LockRecord));
       fsyncSync(fd);
     } finally {
@@ -244,13 +265,23 @@ function refreshLockHeartbeat(lock: OwnedLock): void {
   fsyncDirectory(path.dirname(lock.path));
 }
 
-function acquireTakeoverClaim(claimPath: string, ownerToken: string, entityId?: EntityId): void {
+function acquireTakeoverClaim(
+  claimPath: string,
+  ownerToken: string,
+  entityId?: EntityId,
+  provenance: DaemonLockProvenance = {}
+): void {
   let fd: number;
   try {
     fd = openSync(claimPath, "wx");
   } catch (error) {
     if (isAlreadyExistsError(error)) {
-      throw lockHeld(path.basename(claimPath, ".takeover"), entityId, "takeover-in-progress");
+      const existing = readClaimRecord(claimPath);
+      throw lockHeld(
+        existing ? lockOwnerMessage(path.basename(claimPath, ".takeover"), existing) : path.basename(claimPath, ".takeover"),
+        entityId,
+        "takeover-in-progress"
+      );
     }
     throw error;
   }
@@ -260,8 +291,9 @@ function acquireTakeoverClaim(claimPath: string, ownerToken: string, entityId?: 
       hostname: hostname(),
       ownerToken,
       acquiredAt: new Date().toISOString(),
-      heartbeatAt: new Date().toISOString()
-    }));
+      heartbeatAt: new Date().toISOString(),
+      ...definedLockProvenance(provenance)
+    } satisfies LockRecord));
     fsyncSync(fd);
   } finally {
     closeSync(fd);
@@ -283,7 +315,7 @@ function clearStaleTakeoverClaim(claimPath: string, lockTtlMs: number, entityId?
     throw lockHeld(path.basename(claimPath, ".takeover"), entityId, "takeover-in-progress");
   }
   if (!isStaleLock(record, lockTtlMs)) {
-    throw lockHeld(path.basename(claimPath, ".takeover"), entityId, "takeover-in-progress");
+    throw lockHeld(lockOwnerMessage(path.basename(claimPath, ".takeover"), record), entityId, "takeover-in-progress");
   }
   rmSync(claimPath, { force: true });
 }
@@ -322,6 +354,25 @@ function isAlreadyExistsError(error: unknown): boolean {
 }
 
 function readLockRecordOrConflict(lockPath: string, relativeLockPath: string, entityId?: EntityId): LockRecord {
+  const deadline = Date.now() + lockRecordPublishReadBudgetMs;
+  do {
+    const record = readValidLockRecord(lockPath);
+    if (record) return record;
+    if (Date.now() >= deadline) break;
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, lockRecordPublishReadDelayMs);
+  } while (existsSync(lockPath));
+
+  // open("wx") publishes the directory entry before the owner can write and
+  // fsync the JSON body. A fresh incomplete record is a publication window,
+  // never evidence of a takeover claim. Persistently malformed records fail
+  // closed under their own classification instead of retrying forever.
+  const reason = lockRecordIsFresh(lockPath)
+    ? "lock-record-publishing"
+    : "lock-record-invalid";
+  throw lockHeld(relativeLockPath, entityId, reason);
+}
+
+function readValidLockRecord(lockPath: string): LockRecord | null {
   try {
     const record = JSON.parse(readFileSync(lockPath, "utf8")) as Partial<LockRecord>;
     if (
@@ -330,16 +381,36 @@ function readLockRecordOrConflict(lockPath: string, relativeLockPath: string, en
       || typeof record.acquiredAt !== "string"
       || typeof record.heartbeatAt !== "string"
       || typeof record.ownerToken !== "string"
-    ) {
-      throw new Error("incomplete lock record");
-    }
+      || !validOptionalLockString(record.repoId)
+      || !validOptionalLockString(record.canonicalRoot)
+      || !validOptionalLockString(record.userRoot)
+      || !validOptionalLockString(record.endpoint)
+    ) return null;
     return record as LockRecord;
   } catch {
-    // open("wx") publishes the directory entry before the owner can write and
-    // fsync the JSON body. Treat that short visibility window as contention so
-    // bounded lock retry absorbs it instead of leaking JournalUnavailable.
-    throw lockHeld(relativeLockPath, entityId, "takeover-in-progress");
+    return null;
   }
+}
+
+function lockRecordIsFresh(lockPath: string): boolean {
+  try {
+    return Date.now() - statSync(lockPath).mtimeMs <= lockRecordPublishFreshnessMs;
+  } catch {
+    return true;
+  }
+}
+
+function validOptionalLockString(value: unknown): boolean {
+  return value === undefined || (typeof value === "string" && value.length > 0);
+}
+
+function definedLockProvenance(provenance: DaemonLockProvenance): Partial<LockRecord> {
+  return {
+    ...(provenance.repoId ? { repoId: provenance.repoId } : {}),
+    ...(provenance.canonicalRoot ? { canonicalRoot: path.resolve(provenance.canonicalRoot) } : {}),
+    ...(provenance.userRoot ? { userRoot: path.resolve(provenance.userRoot) } : {}),
+    ...(provenance.endpoint ? { endpoint: provenance.endpoint } : {})
+  };
 }
 
 function lockHeld(
@@ -353,5 +424,11 @@ function lockHeld(
 function lockOwnerMessage(relativeLockPath: string, record: LockRecord): string {
   const holder = `pid ${record.pid} on ${record.hostname}`;
   if (record.ownerKind !== "daemon") return `${relativeLockPath} (held by ${holder})`;
-  return `${relativeLockPath} (held by daemon ${holder}; write through daemon via the daemon-backed ha client/API instead of direct WriteCoordinator writes)`;
+  const repo = record.repoId
+    ? `repo ${record.repoId}${record.canonicalRoot ? ` at ${record.canonicalRoot}` : ""}`
+    : record.canonicalRoot ? `repo at ${record.canonicalRoot}` : undefined;
+  const topology = [record.userRoot ? `userRoot ${record.userRoot}` : undefined, record.endpoint ? `endpoint ${record.endpoint}` : undefined]
+    .filter((part): part is string => part !== undefined)
+    .join("; ");
+  return `${relativeLockPath} (${repo ? `${repo}; ` : ""}held by daemon ${holder}${topology ? `; ${topology}` : ""}; write through daemon via the daemon-backed ha client/API instead of direct WriteCoordinator writes; one canonicalRoot may belong to only one live daemon and daemon manifest repo sets must not overlap: docs-release/operations-server-daemon.md#daemon-repository-ownership-invariants)`;
 }

--- a/packages/kernel/src/write-coordination/journal/types.ts
+++ b/packages/kernel/src/write-coordination/journal/types.ts
@@ -115,6 +115,11 @@ export interface LockRecord {
   readonly heartbeatAt: string;
   readonly ownerToken: string;
   readonly ownerKind?: "daemon";
+  /** Optional daemon topology provenance; absent on legacy and non-daemon locks. */
+  readonly repoId?: string;
+  readonly canonicalRoot?: string;
+  readonly userRoot?: string;
+  readonly endpoint?: string;
 }
 
 export interface OwnedLock {

--- a/packages/kernel/test/store/global-committer-lock.test.ts
+++ b/packages/kernel/test/store/global-committer-lock.test.ts
@@ -356,7 +356,7 @@ test("entity takeover claim conflicts preserve the scoped task id", () => {
 
     assert.equal(failure._tag, "WriteConflict");
     assert.equal(failure.taskId, "task-1");
-    assert.equal(failure.owner, taskLockName);
+    assert.match(failure.owner ?? "", new RegExp(`^${taskLockName} \\(held by pid ${process.pid} on `, "u"));
   });
 });
 
@@ -422,7 +422,7 @@ test("takeover claim prevents silent acquire while stale lock is quarantined", (
     const failure = runWriteFailure(coordinator.flush("explicit"));
 
     assert.equal(failure._tag, "GlobalWriteConflict");
-    assert.equal(failure.owner, "global.lock");
+    assert.match(failure.owner ?? "", new RegExp(`^global\\.lock \\(held by pid ${process.pid} on `, "u"));
     assert.throws(
       () => readFileSync(path.join(rootDir, ".harness/locks/global.lock"), "utf8"),
       /ENOENT/


### PR DESCRIPTION
# English

## Summary

From the kty-web pilot friction report (items #10–#13b and Appendix A): the daemon's lock and multi-daemon topology surfaces lied to operators in four ways, and the pilot agent reported a wrong root cause to the user because of them. The publish window of a freshly created lock (directory entry visible, JSON not yet flushed) was classified as `takeover-in-progress` even though no takeover claim existed; lock conflicts printed only a repo-relative path that looks identical in every repository; `daemon status` could report the self-contradictory `started=false reachable=true`; and the load-bearing ownership invariant (one canonicalRoot per live daemon, disjoint manifest repo sets, userRoot does not isolate in-repo locks) was written nowhere.

This PR makes those surfaces honest:

- **Lock read classification** (`packages/kernel/.../locks.ts`): results are now `held` / `lock-record-publishing` / `lock-record-invalid` / `changed-during-takeover` / `takeover-in-progress`. A fresh incomplete record gets a bounded 20 ms reread (2 ms interval) and converts to owner-`held` once published; past the 100 ms freshness window it becomes `lock-record-invalid` and fails closed — no owner guessing. The word "takeover" is reserved for real claim paths. Mutual exclusion, stale criteria, and exclusive-create semantics are unchanged.
- **Owner provenance**: lock records gain optional `repoId` / `canonicalRoot` / `userRoot` / `endpoint`; conflict messages now name the repo, pid, host, userRoot, and endpoint, and link the ownership invariant anchor. Legacy records without the fields still parse and produce a plain owner-`held`.
- **Serial startup topology** (`packages/daemon/.../production-repo-lock-topology.ts`): before spawning children, the daemon preflights/recovers stale locks for its complete manifest repo set in stable order — eliminating N children racing takeover claims into mutual `takeover-in-progress`. A conflict stops already-started supervisors and reports the complete repo set with all conflicts, not just the default `--repo`.
- **Repo-level status honesty** (`packages/cli/.../repository-service-status.ts`): `daemon status` now answers directly — `served-by-connected-daemon` / `served-by-other-daemon` / `served-by-unknown-daemon` / `not-served` / `lock-record-unavailable` — with owner provenance; `started` and `reachable` derive from the same connection fact, killing the contradictory combination.
- **Ownership invariant documented** in `docs-release/operations-server-daemon.md`, daemon help, and the conflict error text itself (all three share one anchor).
- **Test-coverage gap from Appendix A closed**: the production fixture is now N signed repos; new integration tests cover two real children with independent locks/cwd and dual routing, same-manifest dual-userRoot structured conflict with no leaked children, publish-window → owner-held, and `/var`↔`/private/var` realpath normalization.

## What Changed

- `packages/kernel/src/write-coordination/journal/{locks,types}.ts`: five-way lock read classification, bounded publishing reread, optional flat provenance fields (no minimum-schema raise).
- `packages/daemon/src/runtime/production-repo-lock-topology.ts` (new) + `lifecycle/run-daemon-serve.ts` + `authority/authority-lifecycle.ts`: serial preflight/recovery over the full manifest set; provenance threaded into per-repo runtimes.
- `packages/cli/src/commands/daemon/{repository-service-status.ts (new),status-command.ts,command.ts,help.ts}`: repo-level service status; help documents the invariant.
- `packages/cli/src/composition/repo-write-child-entrypoint.ts`: canonical-root realpath normalization (fixes the `/var` vs `/private/var` false `REPO_NOT_CONFIGURED`, friction #17b adjacent).
- `docs-release/operations-server-daemon.md`: ownership-invariants section (anchor shared with errors/help).
- Tests: `repo-runtime-lock-provenance.test.ts` (new), `repo-write-child-production-cutover.test.ts` (major extension), multi-repo lifecycle status semantics, kernel lock classification regressions; production fixture extended to N signed repos.

## Task And Scope

- Harness task: `task_01KZ3XNKCBMT6RK6DT636K35WW` (parent intake: `task_01KZ3XES4V69C4WXBR7JPVNSG9`)
- Branch: `codex/lock-honesty`
- Public scope: `packages/kernel/src/write-coordination/**`, `packages/daemon/**`, `packages/cli/src/commands/daemon/**`, `docs-release/**` and tests
- Private planning/evidence updated: yes (task package `artifacts/implementation-report.md` with before/after positive controls and the concurrency seven-questions audit)
- Out of scope: `packages/cli/src/commands/core/**` and `packages/daemon/src/authority/production/**` (parallel wave-1 surface); CI/gate authority (test-weight drift warnings left untouched for a governance task); production daemon rollout (deploy is a separate authorized step).

## Version Impact

- Version: no version change because this is an unreleased surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KZ3XNKCBMT6RK6DT636K35WW`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `e8ed31594286f53d06fe77ede4f49e413880d044`
- Branch merge-base with `origin/main`: `e8ed31594286f53d06fe77ede4f49e413880d044`
- Last `git fetch origin` time: immediately before opening this PR
- Sync method: rebase onto `origin/main` (clean auto-merge over #1206's telemetry changes), `check:local` rerun green after rebase
- Public diff command: `git diff origin/main...codex/lock-honesty`
- Private evidence commit/path: task package `artifacts/implementation-report.md`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending, linked once the run completes
- [x] `git diff --check`
- [x] `npm run check:local` — green post-rebase (27 manifest gates, 109.7 s; pre-rebase full run: affected contract 337/338 pass, 1 platform skip)
- [x] Targeted tests for the change surface, named with their counts: full `--tier integration` on pre-rebase base: 1,460 tests, 1,456 pass, 0 fail, 4 platform skips (exclusive rerun after evicting a concurrent runner); post-rebase targeted `--prefix packages/daemon/test/runtime` integration rerun: exit 0
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending
- Not run, and why: full integration tier not rerun post-rebase (clean auto-merge; overlap surface re-verified via the daemon/runtime prefix; `test-integration` runs authoritatively in CI).

## Review Evidence

- Self-review: CEO verified the classification enum and its fail-closed branches in `locks.ts` (publishing → bounded reread; invalid → fail closed; takeover reserved for claim paths), provenance fields optional with legacy compat, and that no wave-1 surface or CI/gate file is touched.
- Reviewer subagent: implementation by Codex worker; the report answers the concurrency failure-path seven questions and documents split-brain behavior honestly (partial-overlap simultaneous starts may both fail and retry; no stable split brain).
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Legacy locks without provenance report owner as unknown until a new daemon naturally rewrites them; rolling-upgrade production display is unverified until deployment (read-only observation planned post-deploy).
- Multi-repo startup is not an atomic multi-lock transaction: pathological simultaneous partial-overlap starts can make both sides fail-and-retry; the guarantee is cleanup-on-failure and no stable split brain, not single-winner.
- A status probe hitting an unfinished/corrupt lock record may briefly return `lock-record-unavailable` rather than fabricating an owner.

## References

- Task: `task_01KZ3XNKCBMT6RK6DT636K35WW`
- Evidence: task package `artifacts/implementation-report.md`
- Review: same task package

---

# 中文

## 概要

来自 kty-web 试点摩擦报告（#10–#13b 与附录 A）：daemon 的锁与多 daemon 拓扑面在四个地方对操作者撒谎，试点 agent 因此向用户报过一版错误根因。新建锁的发布窗口（目录项已可见、JSON 未落盘）被归类为 `takeover-in-progress`，而全程不存在任何 takeover claim；锁冲突只打印在每个仓里长得一样的相对路径；`daemon status` 能输出自相矛盾的 `started=false reachable=true`；承重的所有权不变量（一个 canonicalRoot 只属于一个活 daemon、manifest repo 集互不相交、userRoot 不隔离仓内锁）没写在任何地方。

本 PR 让这些面说真话：

- **锁读取分类**（`packages/kernel/.../locks.ts`）：结果分为 `held` / `lock-record-publishing` / `lock-record-invalid` / `changed-during-takeover` / `takeover-in-progress` 五类。新鲜未完成记录做 20ms（2ms 间隔）有界重读，对方写完即转带 owner 的 `held`；超过 100ms 新鲜窗口转 `lock-record-invalid` 并 fail-closed——不猜 owner。"takeover" 一词只保留给真实 claim 路径。互斥、stale 判据与 exclusive-create 语义不变。
- **owner 溯源**：lock record 新增可选 `repoId` / `canonicalRoot` / `userRoot` / `endpoint`；冲突信息直接指出仓、pid、host、userRoot、endpoint，并附不变量文档锚点。无字段的 legacy 记录照常解析、产生普通 owner-`held`。
- **串行启动拓扑**（`production-repo-lock-topology.ts`）：daemon 起 child 前按稳定顺序对完整 manifest repo 集串行预检/回收陈旧锁——消灭 N 个 child 并发抢 takeover 互撞的形状。冲突时停掉已启动 supervisor，报告完整 repo 集与全部冲突，不再只提默认 `--repo`。
- **仓级 status 诚实**（`repository-service-status.ts`）：`daemon status` 直接回答 `served-by-connected-daemon` / `served-by-other-daemon` / `served-by-unknown-daemon` / `not-served` / `lock-record-unavailable`，带 owner 溯源；`started` 与 `reachable` 同源于一次连接事实，矛盾组合消灭。
- **所有权不变量**写进 `docs-release/operations-server-daemon.md`、daemon help 与冲突报错正文（三处共享同一锚点）。
- **附录 A 点名的测试缺口回补**：production fixture 扩为 N 个签名 repo；新增两仓真实 child 独立 lock/cwd 双路由、同 manifest 双 userRoot 结构化冲突且无泄漏 child、发布窗口→owner-held、`/var`↔`/private/var` realpath 归一化用例。

## 改动内容

- `packages/kernel/src/write-coordination/journal/{locks,types}.ts`：五类锁读取分类、发布窗口有界重读、可选 flat 溯源字段（不抬高最低 schema 要求）。
- `packages/daemon/src/runtime/production-repo-lock-topology.ts`（新增）+ `lifecycle/run-daemon-serve.ts` + `authority/authority-lifecycle.ts`：完整 manifest 集串行预检/回收；溯源传入各 repo runtime。
- `packages/cli/src/commands/daemon/{repository-service-status.ts(新增),status-command.ts,command.ts,help.ts}`：仓级服务状态；help 写明不变量。
- `packages/cli/src/composition/repo-write-child-entrypoint.ts`：canonical-root realpath 归一化（修 `/var` vs `/private/var` 误报 `REPO_NOT_CONFIGURED`，即摩擦 #17b 相邻项）。
- `docs-release/operations-server-daemon.md`：所有权不变量节（与报错/help 共锚）。
- 测试：`repo-runtime-lock-provenance.test.ts`（新增）、`repo-write-child-production-cutover.test.ts`（大幅扩展）、多 repo lifecycle 三种 status 语义、kernel 锁分类回归；production fixture 扩为 N 签名 repo。

## 任务与范围

- Harness 任务：`task_01KZ3XNKCBMT6RK6DT636K35WW`（intake 父任务：`task_01KZ3XES4V69C4WXBR7JPVNSG9`）
- 分支：`codex/lock-honesty`
- 公开范围：`packages/kernel/src/write-coordination/**`、`packages/daemon/**`、`packages/cli/src/commands/daemon/**`、`docs-release/**` 及测试
- 私有计划 / 证据是否已更新：yes（任务包 `artifacts/implementation-report.md`，含修复前后阳性对照与并发七问审计）
- 范围外：`packages/cli/src/commands/core/**` 与 `packages/daemon/src/authority/production/**`（并行 wave-1 面）；CI/gate 权威面（test-weight drift 提示留给治理任务）；生产 daemon 切换（部署是单独授权步骤）。

## 版本影响

- 版本：不改版本，原因是这是未发布面
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`task_01KZ3XNKCBMT6RK6DT636K35WW`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`e8ed31594286f53d06fe77ede4f49e413880d044`
- 当前分支与 `origin/main` 的 merge-base：`e8ed31594286f53d06fe77ede4f49e413880d044`
- 最近一次 `git fetch origin` 时间：开 PR 前即时执行
- 同步方式：rebase 到 `origin/main`（与 #1206 遥测改动干净自动合并），rebase 后 `check:local` 复跑绿
- 公开 diff 命令：`git diff origin/main...codex/lock-honesty`
- 私有证据 commit/path：任务包 `artifacts/implementation-report.md`
- Reviewer 证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：待 run 完成后补链接
- [x] `git diff --check`
- [x] `npm run check:local` —— rebase 后全绿（27 门，109.7s；rebase 前全量：受影响 contract 337/338 过、1 平台跳过）
- [x] 改动面的定向测试，写明测试名与通过数：rebase 前基线完整 `--tier integration`：1,460 tests、1,456 过、0 败、4 平台跳过（驱逐并发 runner 后独占重跑）；rebase 后交叠面定向 `--prefix packages/daemon/test/runtime` integration 重跑退出码 0
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）—— 待跑
- 未跑项及原因：rebase 后未重跑完整 integration tier（自动合并干净；交叠面已用 daemon/runtime prefix 复验；`test-integration` 在 CI 权威执行）。

## 审查证据

- 自查：CEO 核验 `locks.ts` 分类枚举与 fail-closed 分支（publishing→有界重读；invalid→fail-closed；takeover 只留给 claim 路径）、溯源字段可选且 legacy 兼容、未触碰 wave-1 面与 CI/gate 文件。
- Reviewer subagent：Codex worker 实现；报告逐条回答并发失败路径七问，并诚实记录 split-brain 行为（部分重叠同时启动可能双败重试；无稳定 split brain）。
- 人工审查：待办
- 阻塞发现：无 open

## 残余风险

- 无溯源字段的 legacy 锁在新 daemon 自然重写前 owner 显示 unknown；滚动升级的生产现场展示待部署后只读观察。
- 多仓启动非原子 multi-lock 事务：极端的部分重叠同时启动可能双方都失败后重试；保证是失败即清理、无稳定 split brain，不保证单一赢家。
- status 恰撞未完成/损坏 lock record 时可能短暂返回 `lock-record-unavailable`，不伪造 owner。

## 关联材料

- 任务：`task_01KZ3XNKCBMT6RK6DT636K35WW`
- 证据：任务包 `artifacts/implementation-report.md`
- 审查：同一任务包
