### PR TITLE
fix: honest receipts and write-path recovery (friction wave-1: identity slot, dry-run, child poisoning, queryable unknowns, WIP backfill exemption)

### DIFF
--- a/packages/application/src/authority/daemon-host-contract.ts
+++ b/packages/application/src/authority/daemon-host-contract.ts
@@ -406,6 +406,7 @@ export interface DaemonServeHostServices<LaunchConfiguration, AuthorityLifecycle
     readonly manifestPath: string;
     readonly daemonLogService: DaemonLogService;
     readonly backgroundRecovery: true;
+    readonly userRoot: string;
     readonly layoutOverrides?: HarnessLayoutOverrides;
   }) => AuthorityLifecycle;
   readonly projectStartedStatus: (status: DaemonStatusResultV2) => Record<string, unknown>;

--- a/packages/application/src/authority/task-wip-policy.ts
+++ b/packages/application/src/authority/task-wip-policy.ts
@@ -7,6 +7,8 @@ export interface TaskWipSnapshotEntryV1 {
   readonly status: DomainStatus;
   readonly packageDisposition: "active" | "archived" | "tombstoned";
   readonly isContainer: boolean;
+  /** Existing delivery evidence makes a planned task a closeout backfill. */
+  readonly hasCloseoutEvidence?: boolean;
 }
 
 export interface TaskWipSnapshotV1 {
@@ -26,7 +28,8 @@ export function taskWipPublicationRevalidation(
     if (!Number.isSafeInteger(snapshot.limit) || snapshot.limit < 1) {
       throw admission("TASK_WIP_POLICY_INVALID: settings.tasks.wipLimit must be a positive integer.");
     }
-    if (snapshot.tasks.some((task) => task.taskId === activatingTaskId && task.isContainer)) return;
+    if (snapshot.tasks.some((task) => task.taskId === activatingTaskId
+      && (task.isContainer || task.hasCloseoutEvidence === true))) return;
     const occupying = snapshot.tasks
       .filter((task) => !task.isContainer && isExecutionWipTask(task.status, task.packageDisposition))
       .sort(compareTaskWipSuggestions);

--- a/packages/application/test/task-wip-policy.test.ts
+++ b/packages/application/test/task-wip-policy.test.ts
@@ -71,6 +71,30 @@ test("container tasks with children do not occupy execution workstations", async
   await assert.doesNotReject(revalidate);
 });
 
+test("closeout backfill with delivery evidence does not consume a WIP slot", async () => {
+  const revalidate = taskWipPublicationRevalidation(async () => ({
+    limit: 1,
+    tasks: [
+      task("task_ACTIVE", "Active task", "active", "active"),
+      { ...task("task_BACKFILL", "Delivered backfill", "planned", "active"), hasCloseoutEvidence: true }
+    ]
+  }), "task_BACKFILL");
+
+  await assert.doesNotReject(revalidate);
+});
+
+test("planned work without delivery evidence still consumes a WIP slot", async () => {
+  const revalidate = taskWipPublicationRevalidation(async () => ({
+    limit: 1,
+    tasks: [
+      task("task_ACTIVE", "Active task", "active", "active"),
+      task("task_NEW", "New work", "planned", "active")
+    ]
+  }), "task_NEW");
+
+  await assert.rejects(revalidate, /TASK_WIP_LIMIT_REACHED/u);
+});
+
 test("activating a container is admitted even when every leaf workstation is occupied", async () => {
   const revalidate = taskWipPublicationRevalidation(async () => ({
     limit: 1,

--- a/packages/cli/src/cli/command-spec/command-groups.ts
+++ b/packages/cli/src/cli/command-spec/command-groups.ts
@@ -141,6 +141,7 @@ export const commandGroups = [
     "ha task progress append <task-id> --text \"<update>\"",
     "ha fact record --task <task-id> --statement \"<verified fact>\"",
     "ha task submit <task-id> --from-file submission.json",
+    "ha task code-doc reconcile <task-id> --commit <full-sha> [--path <repo-path>]...",
     "ha task complete <task-id> --approve --from-file approval.json"
   ]),
   group("template", "List and render templates.", [

--- a/packages/cli/src/commands/core/task-gates.ts
+++ b/packages/cli/src/commands/core/task-gates.ts
@@ -41,16 +41,27 @@ function runTaskLifecycleTransition(
   action: ReturnType<typeof taskCompleteTransitionCommandFromCliAction>
 ): ReturnType<CommandRunner> {
   if (action.dryRun === true) {
+    const uncheckedGates = [
+      "canonical-authority-planner",
+      "task-completion-evidence",
+      "durable-transition-write"
+    ] as const;
     return Effect.succeed({
       ok: true,
       command: "task-complete",
       taskId: action.taskId,
-      status: "done",
-      completionGate: { ok: true, evidenceMode: action.evidenceMode, dryRun: true },
+      status: "in_review",
+      completionGate: {
+        ok: false,
+        evidenceMode: action.evidenceMode,
+        dryRun: true,
+        uncheckedGates
+      },
       report: {
         schema: "task-lifecycle-transition-preview/v1",
         dryRun: true,
-        disposition: "server-planner-validation-required"
+        disposition: "server-planner-validation-required",
+        uncheckedGates
       }
     } satisfies CliResult);
   }

--- a/packages/cli/src/commands/task-wip-settings.ts
+++ b/packages/cli/src/commands/task-wip-settings.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
+import { isCloseoutPlaceholderMarkdown } from "@harness-anything/application";
 import {
   isDomainStatus,
   isPackageDisposition,
@@ -10,6 +11,7 @@ import {
 } from "@harness-anything/kernel";
 import { cliError, CliErrorCode } from "../cli/error-codes.ts";
 import type { CliResult } from "../cli/types.ts";
+import { bundledTaskDocumentPlaceholderPolicy } from "./core/task-document-placeholders.ts";
 import { parseSettingsDocument } from "./settings-document.ts";
 
 export const DEFAULT_TASK_WIP_LIMIT = 30;
@@ -71,13 +73,34 @@ export function readTaskWipSnapshot(rootInput: HarnessLayoutInput) {
       if (!isDomainStatus(status) || !isPackageDisposition(packageDisposition)) {
         throw new Error(`Invalid task WIP axes: ${indexPath}`);
       }
-      return [{ taskId, title, parent, status, packageDisposition }];
+      const hasCloseoutEvidence = taskHasCloseoutEvidence(path.dirname(indexPath));
+      return [{
+        taskId,
+        title,
+        parent,
+        status,
+        packageDisposition,
+        ...(hasCloseoutEvidence ? { hasCloseoutEvidence: true } : {})
+      }];
     });
   const parentTaskIds = new Set(taskRows.map((task) => task.parent).filter((parent) => parent.length > 0));
   const tasks = taskRows
     .map(({ parent: _parent, ...task }) => ({ ...task, isContainer: parentTaskIds.has(task.taskId) }))
     .sort((left, right) => left.taskId.localeCompare(right.taskId));
   return { limit: resolved.limit, tasks };
+}
+
+function taskHasCloseoutEvidence(taskRoot: string): boolean {
+  const closeoutPath = path.join(taskRoot, "closeout.md");
+  if (existsSync(closeoutPath)) {
+    const closeout = readFileSync(closeoutPath, "utf8");
+    const policy = bundledTaskDocumentPlaceholderPolicy();
+    if (closeout.trim() && !isCloseoutPlaceholderMarkdown(closeout, policy.closeoutPlaceholderFingerprints)) return true;
+  }
+  return ["review.md", "code-doc-anchors.json"].some((document) => {
+    const documentPath = path.join(taskRoot, document);
+    return existsSync(documentPath) && readFileSync(documentPath, "utf8").trim().length > 0;
+  });
 }
 
 function invalidWipLimit(command: string): Extract<TaskWipLimitResult, { readonly ok: false }> {

--- a/packages/cli/src/composition/actor-attribution.ts
+++ b/packages/cli/src/composition/actor-attribution.ts
@@ -120,16 +120,19 @@ export function readCliJournalActorFromEnv(env: NodeJS.ProcessEnv): CliJournalAc
   return actor;
 }
 
-export function readCliJournalActorFromFlag(raw: string): CliJournalActor {
-  const actor = parseActorToken(raw, "--actor");
+export function readCliJournalActorFromFlag(raw: string, configuredPersonId?: string): CliJournalActor {
+  const actor = parseActorToken(raw, "--actor", configuredPersonId);
   assertEntityActor(actor, "--actor");
   return actor;
 }
 
-function parseActorToken(raw: string, channel: "HARNESS_ACTOR" | "--actor"): CliJournalActor {
+function parseActorToken(raw: string, channel: "HARNESS_ACTOR" | "--actor", configuredPersonId?: string): CliJournalActor {
   const separator = raw.indexOf(":");
   if (separator <= 0 || separator === raw.length - 1) {
-    throw new CliActorAttributionError(`${channel} must use kind:id form, for example ${channel === "HARNESS_ACTOR" ? "agent:codex" : "human:lizeyu"}.`);
+    const example = channel === "HARNESS_ACTOR"
+      ? "agent:codex"
+      : `human:${configuredPersonId?.trim() || "lizeyu"}`;
+    throw new CliActorAttributionError(`${channel} must use kind:id form, for example ${example}.`);
   }
   const kind = raw.slice(0, separator);
   const id = raw.slice(separator + 1);

--- a/packages/cli/src/composition/local-principal.ts
+++ b/packages/cli/src/composition/local-principal.ts
@@ -52,7 +52,10 @@ export function resolveLocalCliActorAttribution(
   actorFlag?: string,
   personRegistry?: PersonRegistry
 ): CliActorAttribution {
-  const flagActor = actorFlag ? readCliJournalActorFromFlag(actorFlag) : undefined;
+  const configuredPersonId = actorFlag
+    ? configuredLocalPrincipalIdForActorHint(rootInput, env, personRegistry)
+    : undefined;
+  const flagActor = actorFlag ? readCliJournalActorFromFlag(actorFlag, configuredPersonId) : undefined;
   const assertedActor = flagActor ?? readCliJournalActorFromEnv(env);
   const name = readNonBlankEnv(env, "HARNESS_GIT_AUTHOR_NAME") ?? readNonBlankEnv(env, "GIT_AUTHOR_NAME");
   const email = readNonBlankEnv(env, "HARNESS_GIT_AUTHOR_EMAIL") ?? readNonBlankEnv(env, "GIT_AUTHOR_EMAIL");
@@ -91,6 +94,20 @@ export function resolveLocalCliActorAttribution(
     taskHolderPrincipal: configured.principal,
     executor
   };
+}
+
+export function configuredLocalPrincipalIdForActorHint(
+  rootInput: HarnessLayoutInput,
+  env: NodeJS.ProcessEnv = process.env,
+  personRegistry?: PersonRegistry
+): string | undefined {
+  const settings = readProjectHarnessSettings(rootInput, "identity");
+  if (settings.ok && settings.settings.identity?.personId) return settings.settings.identity.personId;
+  try {
+    return readConfiguredLocalPrincipalWithSource(rootInput, personRegistry, env).principal.personId;
+  } catch {
+    return undefined;
+  }
 }
 
 export function readConfiguredLocalPrincipal(rootInput: HarnessLayoutInput, env: NodeJS.ProcessEnv = process.env): TaskHolderPersonPrincipal {

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -38,6 +38,7 @@ import { toCommandReceipt } from "../cli/receipt.ts";
 import { receiptCommandKind } from "../cli/receipt-command-kind.ts";
 import type { ParsedCommand } from "../cli/types.ts";
 import { CliActorAttributionError, readCliJournalActorFromEnv, readCliJournalActorFromFlag } from "../composition/actor-attribution.ts";
+import { configuredLocalPrincipalIdForActorHint } from "../composition/local-principal.ts";
 import { parsePositiveIntegerOr } from "../cli/value-utils.ts";
 import { buildDocSyncSubmitRequest } from "@harness-anything/daemon";
 import {
@@ -546,7 +547,10 @@ function taskHolderExecutorPayload(command: ParsedCommand): JsonObject | null | 
 
 function commandExecutor(command: ParsedCommand): TaskHolderExecutor | null | undefined {
   const actor = command.actor
-    ? readCliJournalActorFromFlag(command.actor)
+    ? readCliJournalActorFromFlag(command.actor, configuredLocalPrincipalIdForActorHint({
+      rootDir: command.rootDir,
+      layoutOverrides: command.layoutOverrides
+    }, process.env))
     : readCliJournalActorFromEnv(process.env);
   if (!actor) return undefined;
   return taskHolderExecutorFromJournalActor(actor);

--- a/packages/cli/src/daemon/request-outcome.ts
+++ b/packages/cli/src/daemon/request-outcome.ts
@@ -9,14 +9,34 @@ export function daemonRequestTimeoutReceipt(
   command: ParsedCommand,
   error: DaemonJsonRpcRequestTimeoutError
 ): CommandFailureReceipt {
+  const taskId = "taskId" in command.action && typeof command.action.taskId === "string"
+    && command.action.taskId.trim().length > 0
+    ? command.action.taskId
+    : undefined;
+  const query = {
+    schema: "command-outcome-query/v1" as const,
+    method: taskId ? "task.show" as const : "task.list" as const,
+    parameters: taskId ? { taskId } : {},
+    retry: "forbidden-until-queried" as const
+  };
   const receipt = toCommandReceipt({
     ok: false,
     command: receiptCommandKind(command.action),
     error: cliError(
       CliErrorCode.DaemonRequestOutcomeUnknown,
-      `Daemon request timed out, so the outcome is unknown: the write may already have taken effect even though no response arrived. Do not rerun this write blindly. First verify whether the target entity already exists or reflects the requested change (for task creation, run 'ha task list' and inspect the task title or ID; for a known task ID, run 'ha task show <task-id>'). Only decide whether to retry after that check. Cause: ${error.message}`
+      `Daemon request timed out, so the outcome is unknown: the write may already have taken effect even though no response arrived. Do not rerun this write blindly. First verify the target with the machine-readable query in details.data.query. Cause: ${error.message}`
     )
   });
   if (receipt.ok) throw new Error("daemon request timeout receipt unexpectedly succeeded");
-  return receipt;
+  return {
+    ...receipt,
+    details: {
+      ...(receipt.details ?? {}),
+      data: {
+        ...((receipt.details?.data ?? {}) as Record<string, unknown>),
+        outcome: "unknown",
+        query
+      }
+    }
+  };
 }

--- a/packages/cli/test/actor-attribution-malformed.test.ts
+++ b/packages/cli/test/actor-attribution-malformed.test.ts
@@ -1,0 +1,22 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveLocalCliActorAttribution } from "../src/composition/local-principal.ts";
+import { withTestHarnessRoot } from "./helpers/git-fixtures.ts";
+
+test("malformed actor flag names the configured principal in its repair example", () => {
+  withTestHarnessRoot((rootDir) => {
+    assert.throws(
+      () => resolveLocalCliActorAttribution(
+        { rootDir },
+        {
+          HARNESS_ACTOR: "",
+          HARNESS_GIT_AUTHOR_NAME: "Harness Writer",
+          HARNESS_GIT_AUTHOR_EMAIL: "writer@example.test"
+        },
+        "person_zeyu"
+      ),
+      /--actor must use kind:id form, for example human:person_test/u
+    );
+  });
+});

--- a/packages/cli/test/coldstart-p1-cli.test.ts
+++ b/packages/cli/test/coldstart-p1-cli.test.ts
@@ -91,9 +91,14 @@ test("task packet help templates pass submission and approval dry-runs", () => {
       "--approve", "--from-file", approvalPath, "--dry-run"
     ], sessionEnv);
     assert.equal(approvalDryRun.ok, true);
-    assert.equal(approvalDryRun.status, "done");
+    assert.notEqual(approvalDryRun.status, "done");
     assert.equal(approvalDryRun.report.schema, "task-lifecycle-transition-preview/v1");
     assert.equal(approvalDryRun.report.disposition, "server-planner-validation-required");
+    assert.deepEqual(approvalDryRun.report.uncheckedGates, [
+      "canonical-authority-planner",
+      "task-completion-evidence",
+      "durable-transition-write"
+    ]);
     assert.equal(readFileSync(indexPath, "utf8"), indexBeforeDryRun);
   });
 });

--- a/packages/cli/test/completion-facade-cli.test.ts
+++ b/packages/cli/test/completion-facade-cli.test.ts
@@ -120,9 +120,15 @@ test("task complete dry-run previews one terminal intent without evaluating Revi
       "--approve", "--from-file", packetPath, "--dry-run"
     ], true, chain.env);
 
-    assert.equal(preview.status, "done");
+    assert.notEqual(preview.status, "done");
     assert.equal(preview.report.schema, "task-lifecycle-transition-preview/v1");
     assert.equal(preview.report.disposition, "server-planner-validation-required");
+    assert.equal(preview.completionGate.ok, false);
+    assert.deepEqual(preview.report.uncheckedGates, [
+      "canonical-authority-planner",
+      "task-completion-evidence",
+      "durable-transition-write"
+    ]);
     assert.equal(existsSync(path.join(rootDir, chain.packagePath, "reviews")), false);
     assert.match(readFileSync(path.join(rootDir, chain.packagePath, "INDEX.md"), "utf8"), /^  status: in_review$/mu);
   });

--- a/packages/cli/test/daemon-command-outcomes.test.ts
+++ b/packages/cli/test/daemon-command-outcomes.test.ts
@@ -35,7 +35,11 @@ test("a timed-out write reports an unknown outcome after the daemon accepted the
       assert.match(result.error.hint, /outcome is unknown/iu);
       assert.match(result.error.hint, /write may already have taken effect/iu);
       assert.match(result.error.hint, /Do not rerun this write blindly/iu);
-      assert.match(result.error.hint, /ha task list/iu);
+      assert.match(result.error.hint, /details\.data\.query/iu);
+      const data = (result as { readonly details?: { readonly data?: Record<string, unknown> } }).details?.data;
+      assert.equal(data?.outcome, "unknown");
+      assert.equal((data?.query as { readonly schema?: string } | undefined)?.schema, "command-outcome-query/v1");
+      assert.equal((data?.query as { readonly method?: string } | undefined)?.method, "task.show");
       assert.doesNotMatch(result.error.hint, /Daemon unavailable/iu);
       assert.doesNotMatch(result.error.hint, /HARNESS_DAEMON_MODE=direct/iu);
     } finally {

--- a/packages/cli/test/daemon-connect.test.ts
+++ b/packages/cli/test/daemon-connect.test.ts
@@ -30,6 +30,7 @@ import {
   type RemoteDaemonConfig
 } from "../src/daemon/client.ts";
 import { parseArgs } from "../src/cli/parse-args.ts";
+import { withTestHarnessRoot } from "./helpers/git-fixtures.ts";
 
 test("daemon client resolves its CLI entrypoint across native path separators", () => {
   const clientPath = fileURLToPath(new URL("../src/daemon/client.ts", import.meta.url));
@@ -161,6 +162,18 @@ test("remote command payloads do not attach the caller's local runtime session",
     sessionId: "local-codex-session",
     source: "runtime",
     detectedAt: "2026-07-14T00:00:00.000Z"
+  });
+});
+
+test("malformed daemon command actor hints use the configured principal", () => {
+  withTestHarnessRoot((rootDir) => {
+    const parsed = parseArgs(["--root", rootDir, "--actor", "person_zeyu", "task", "claim", "task_remote", "--execution"]);
+    assert.equal(parsed.ok, true);
+    if (!parsed.ok) return;
+    assert.throws(
+      () => commandRunPayload(parsed.value),
+      /--actor must use kind:id form, for example human:person_test/u
+    );
   });
 });
 

--- a/packages/cli/test/doctor-cli.test.ts
+++ b/packages/cli/test/doctor-cli.test.ts
@@ -160,7 +160,7 @@ test("CLI task help lists every task leaf and declares --json only as a global o
       .map((entry) => `  ${entry.primary.replace(/ \[--json\]/gu, "").replace(/ --json$/u, "")} - ${entry.summary}`);
 
     assert.deepEqual(renderedTaskLeaves, [...expectedDefaultTaskLeaves, ...expectedAdvancedTaskLeaves]);
-    assert.match(stdout, /Primary workflow:[\s\S]+1\. ha task create[\s\S]+2\. ha task start[\s\S]+3\. ha task progress append[\s\S]+4\. ha fact record[\s\S]+5\. ha task submit[\s\S]+6\. ha task complete/u);
+    assert.match(stdout, /Primary workflow:[\s\S]+1\. ha task create[\s\S]+2\. ha task start[\s\S]+3\. ha task progress append[\s\S]+4\. ha fact record[\s\S]+5\. ha task submit[\s\S]+6\. ha task code-doc reconcile[\s\S]+7\. ha task complete/u);
     assert.match(stdout, /Advanced commands:[\s\S]+task claim[\s\S]+Deprecated compatibility spelling/u);
     assert.equal(stdout.match(/--json(?!-input)/gu)?.length, 1);
   });
@@ -176,7 +176,7 @@ test("CLI noun help exposes a bounded primary workflow and common/advanced tiers
       const group = commandGroups.find((candidate) => candidate.name === noun);
       assert.notEqual(group, undefined, noun);
       assert.equal((group?.primaryWorkflow?.length ?? 0) >= 1, true, noun);
-      assert.equal((group?.primaryWorkflow?.length ?? 0) <= 6, true, noun);
+      assert.equal((group?.primaryWorkflow?.length ?? 0) <= 7, true, noun);
 
       const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, noun, "--help"], {
         encoding: "utf8"

--- a/packages/cli/test/help-layering.test.ts
+++ b/packages/cli/test/help-layering.test.ts
@@ -21,7 +21,7 @@ test("every primary-workflow line names a registered command path", () => {
   }
 });
 
-test("task primary workflow exposes the complete six-step lifecycle", () => {
+test("task primary workflow exposes the complete seven-step lifecycle", () => {
   const taskWorkflow = commandGroups.find((group) => group.name === "task")?.primaryWorkflow;
 
   assert.deepEqual(taskWorkflow, [
@@ -30,6 +30,7 @@ test("task primary workflow exposes the complete six-step lifecycle", () => {
     "ha task progress append <task-id> --text \"<update>\"",
     "ha fact record --task <task-id> --statement \"<verified fact>\"",
     "ha task submit <task-id> --from-file submission.json",
+    "ha task code-doc reconcile <task-id> --commit <full-sha> [--path <repo-path>]...",
     "ha task complete <task-id> --approve --from-file approval.json"
   ]);
 });

--- a/packages/cli/test/production-authority-lifecycle.test.ts
+++ b/packages/cli/test/production-authority-lifecycle.test.ts
@@ -32,6 +32,7 @@ import {
   loadAuthorityProductionManifest,
   openAuthorityProductionKeyMaterial
 } from "@harness-anything/daemon";
+
 import {
   createCliProductionAuthorityLifecycle as createProductionAuthorityLifecycle
 } from "../src/composition/production-authority-lifecycle.ts";

--- a/packages/cli/test/production-authority-user-root.test.ts
+++ b/packages/cli/test/production-authority-user-root.test.ts
@@ -1,0 +1,46 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import {
+  createProductionAuthorityLifecycleFixture as createFixture,
+  productionWriterRuntime as writerRuntime
+} from "./helpers/production-authority-lifecycle-fixture.ts";
+import {
+  createCliProductionAuthorityLifecycle as createProductionAuthorityLifecycle
+} from "../src/composition/production-authority-lifecycle.ts";
+
+test("production lifecycle passes the daemon user root to machine-only identity loading", async () => {
+  const fixture = createFixture();
+  const userRoot = path.join(fixture.root, "machine-user-root");
+  try {
+    rmSync(path.join(fixture.authoredRoot, "people.yaml"));
+    mkdirSync(userRoot, { recursive: true });
+    writeFileSync(path.join(userRoot, "people.yaml"), [
+      "schema: harness-people/v1",
+      "people:",
+      "  - personId: person_machine",
+      "    displayName: Machine",
+      "    roles: [owner]",
+      "    credentials: []",
+      "roles:",
+      "  - roleId: owner",
+      "    commandClasses: [admin, repo-write, repo-read, arbiter]",
+      ""
+    ].join("\n"));
+
+    const lifecycle = createProductionAuthorityLifecycle({
+      manifestPath: fixture.manifestPath,
+      userRoot
+    });
+    const started = await lifecycle.startRepo(
+      { repoId: "canonical", canonicalRoot: fixture.repoRoot },
+      writerRuntime(fixture.authoredRoot)
+    );
+    assert.equal(started.ok, true, started.ok ? "" : started.error);
+    await lifecycle.stopAll("daemon-shutdown");
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/test/project-policy-settings.test.ts
+++ b/packages/cli/test/project-policy-settings.test.ts
@@ -63,6 +63,11 @@ test("task WIP snapshot reads the configured limit and authored task axes", () =
     writeTaskIndex(rootDir, "task_ACTIVE", "Active", "active", "active");
     writeTaskIndex(rootDir, "task_CHILD", "Child", "planned", "active", "task_ACTIVE");
     writeTaskIndex(rootDir, "task_ARCHIVED", "Archived", "blocked", "archived");
+    writeFileSync(
+      path.join(rootDir, "harness/tasks/task_IDEA-fixture/closeout.md"),
+      "# Summary\n\nDelivered before the lifecycle backfill.\n\n# Verification\n\nVerified.\n\n# Residual Risk\n\nNone known.\n",
+      "utf8"
+    );
 
     assert.deepEqual(readTaskWipSnapshot(rootDir), {
       limit: 4,
@@ -70,7 +75,7 @@ test("task WIP snapshot reads the configured limit and authored task axes", () =
         { taskId: "task_ACTIVE", title: "Active", status: "active", packageDisposition: "active", isContainer: true },
         { taskId: "task_ARCHIVED", title: "Archived", status: "blocked", packageDisposition: "archived", isContainer: false },
         { taskId: "task_CHILD", title: "Child", status: "planned", packageDisposition: "active", isContainer: false },
-        { taskId: "task_IDEA", title: "Idea", status: "planned", packageDisposition: "active", isContainer: false }
+        { taskId: "task_IDEA", title: "Idea", status: "planned", packageDisposition: "active", isContainer: false, hasCloseoutEvidence: true }
       ]
     });
   });

--- a/packages/daemon/src/authority/production/production-authority-lifecycle.ts
+++ b/packages/daemon/src/authority/production/production-authority-lifecycle.ts
@@ -107,6 +107,7 @@ interface ProductionAuthorityIdentity {
 
 export function createProductionAuthorityLifecycle(input: {
   readonly manifestPath: string;
+  readonly userRoot?: string;
   readonly layoutOverrides?: { readonly authoredRoot?: string };
   readonly daemonLogService?: DaemonLogService;
   readonly backgroundRecovery?: true;
@@ -128,7 +129,7 @@ export function createProductionAuthorityLifecycle(input: {
         repo.canonicalRoot,
         input.layoutOverrides,
         undefined,
-        manifest.serviceStateRoot
+        input.userRoot
       );
       if (!identity.personRegistry) throw new Error("AUTHORITY_PRODUCTION_PERSON_REGISTRY_REQUIRED");
       const keyMaterial = openAuthorityProductionKeyMaterial({ config, serviceStateRoot: manifest.serviceStateRoot });

--- a/packages/daemon/src/authority/production/task-complete-prepublish-witness.ts
+++ b/packages/daemon/src/authority/production/task-complete-prepublish-witness.ts
@@ -122,7 +122,11 @@ export function produceCodeDocWitness(input: {
   readonly command: TaskCompleteTransitionCommand;
 }): VerifiedTaskCompleteCodeDocWitness {
   const codeDoc = input.documents.find((document) => document.path === CODE_DOC_RECONCILIATION_DOCUMENT);
-  if (!codeDoc) throw new Error("AUTHORITY_TASK_COMPLETE_CODE_DOC_WITNESS_REQUIRED");
+  if (!codeDoc) {
+    throw new Error(
+      "AUTHORITY_TASK_COMPLETE_CODE_DOC_WITNESS_REQUIRED: run `ha task submit <task-id> --from-file submission.json`, then `ha task code-doc reconcile <task-id> --commit <full-sha> [--path <repo-relative-path>]...`, before `ha task complete`."
+    );
+  }
   const reconciled = resolveCommit(input.rootDir, input.command.commitRef ?? "HEAD");
   const normalizedPaths = normalizeCommandPaths(input.rootDir, input.command.approval?.paths ?? []);
   const prRef = input.command.approval?.prRef ?? null;
@@ -134,7 +138,9 @@ export function produceCodeDocWitness(input: {
     ...(prRef ? { prRef } : {})
   });
   if (expected.recordIds.length === 0 || expected.body !== codeDoc.body) {
-    throw new Error("AUTHORITY_TASK_COMPLETE_CODE_DOC_NOT_RECONCILED_TO_INTENT");
+    throw new Error(
+      "AUTHORITY_TASK_COMPLETE_CODE_DOC_NOT_RECONCILED_TO_INTENT: run `ha task code-doc reconcile <task-id> --commit <full-sha> [--path <repo-relative-path>]...` after task submit and before task complete."
+    );
   }
   const [repositoryPath] = taskRepositoryPaths(input, [CODE_DOC_RECONCILIATION_DOCUMENT]);
   const publication = findMaterializedPublication(input.authoredRoot, [repositoryPath!], [codeDoc.body]);

--- a/packages/daemon/src/lifecycle/run-daemon-serve.ts
+++ b/packages/daemon/src/lifecycle/run-daemon-serve.ts
@@ -126,6 +126,7 @@ export async function runDaemonServe<
           manifestPath: authorityManifest,
           daemonLogService,
           backgroundRecovery: true,
+          userRoot,
           ...(layoutOverrides ? { layoutOverrides } : {})
         })
         : undefined);

--- a/packages/daemon/src/runtime/repo-write-child-direct.ts
+++ b/packages/daemon/src/runtime/repo-write-child-direct.ts
@@ -86,9 +86,10 @@ export async function executeRepoWriteChildDirect(
 
   options.requestIds.add(message.requestId);
   options.admit();
+  let telemetry: ReturnType<typeof createRepoWriteTelemetryDelivery> | undefined;
   try {
     await options.responses.telemetry(message.requestId, "queue", 0);
-    const telemetry = createRepoWriteTelemetryDelivery(
+    telemetry = createRepoWriteTelemetryDelivery(
       (phase, elapsedMs) =>
         options.responses.telemetry(message.requestId, phase, elapsedMs)
     );
@@ -106,8 +107,11 @@ export async function executeRepoWriteChildDirect(
       })
     );
     await telemetry.flush();
+    telemetry.close();
     await options.responses.directResult(message.requestId, receipt);
   } catch (error) {
+    await telemetry?.flush();
+    telemetry?.close();
     await options.responses.directUnknown(
       message.requestId,
       "DIRECT_EXECUTION_OUTCOME_UNKNOWN",

--- a/packages/daemon/src/runtime/repo-write-child-host.ts
+++ b/packages/daemon/src/runtime/repo-write-child-host.ts
@@ -212,6 +212,7 @@ export class RepoWriteChildHost {
       operation.opId = prepared.opId;
       if (this.operationsById.has(prepared.opId)) {
         operation.phase = "failed";
+        await this.closeTelemetry(operation);
         this.release(operation);
         await this.responses.notStarted(
           message.requestId,
@@ -224,6 +225,7 @@ export class RepoWriteChildHost {
       this.operationsById.set(prepared.opId, operation);
       if (!this.admissionOpen) {
         operation.phase = "failed";
+        await this.closeTelemetry(operation);
         this.release(operation);
         await this.responses.notStarted(
           message.requestId,
@@ -242,6 +244,7 @@ export class RepoWriteChildHost {
     } catch (error) {
       if (operation.phase === "preparing") {
         operation.phase = "failed";
+        await this.closeTelemetry(operation);
         this.release(operation);
         const rejection = classifyRepoWriteNotStartedFailure(error);
         await this.responses.notStarted(
@@ -252,6 +255,7 @@ export class RepoWriteChildHost {
         );
       } else if (operation.phase === "prepared") {
         operation.phase = "failed";
+        await this.closeTelemetry(operation);
         this.release(operation);
         throw error;
       } else {
@@ -281,6 +285,7 @@ export class RepoWriteChildHost {
       if (operation.phase === "prepared") {
         operation.phase = "failed";
         operation.cancelledBeforeProceed = true;
+        await this.closeTelemetry(operation);
         this.release(operation);
       }
       await this.responses.notStarted(
@@ -311,7 +316,7 @@ export class RepoWriteChildHost {
         receipt = durableOutcome.receipt as unknown as RepoWriteJsonObject;
         operation.phase = durableOutcome.terminalKind;
       } catch (error) {
-        await operation.telemetry?.flush();
+        await this.closeTelemetry(operation);
         operation.phase = "unknown";
         this.release(operation);
         await this.responses.unknown(
@@ -323,6 +328,7 @@ export class RepoWriteChildHost {
         return;
       }
       operation.receipt = receipt;
+      await this.closeTelemetry(operation);
       this.release(operation);
       await this.responses.terminal(
         operation.requestId,
@@ -431,6 +437,7 @@ export class RepoWriteChildHost {
       if (operation.phase !== "prepared") continue;
       operation.phase = "failed";
       operation.cancelledBeforeProceed = true;
+      await this.closeTelemetry(operation);
       this.release(operation);
       cancelled.push(operation);
     }
@@ -443,6 +450,11 @@ export class RepoWriteChildHost {
       );
     }
     await this.maybeCompleteShutdown();
+  }
+
+  private async closeTelemetry(operation: HostedOperation): Promise<void> {
+    await operation.telemetry?.flush();
+    operation.telemetry?.close();
   }
 
   private async sendDuplicateSubmit(operation: HostedOperation): Promise<void> {

--- a/packages/daemon/src/runtime/repo-write-process-supervisor.ts
+++ b/packages/daemon/src/runtime/repo-write-process-supervisor.ts
@@ -153,9 +153,7 @@ export class RepoWriteProcessSupervisor {
     } catch (error) {
       throw new RepoWriteOutcomeUnknownError(
         "REPO_WRITE_LOOKUP_FAILED",
-        `Exact repo-write outcome lookup failed for ${opId}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        `${mostActionableRepoWriteErrorMessage(error)}. Exact repo-write outcome lookup failed for ${opId}; query the stable outer opId ${opId}.`,
         opId
       );
     }
@@ -261,4 +259,56 @@ function decodeReceipt(
   value: Parameters<typeof decodeRepoWriteCommandReceiptV2>[0]
 ): CommandReceiptEnvelope {
   return decodeRepoWriteCommandReceiptV2(value, "$.repoWriteReceipt");
+}
+
+export function mostActionableRepoWriteErrorMessage(error: unknown): string {
+  const candidates: string[] = [];
+  collectErrorMessages(error, candidates, new Set<unknown>());
+  return candidates[0] ?? (error instanceof Error ? error.message : String(error));
+}
+
+function collectErrorMessages(value: unknown, candidates: string[], seen: Set<unknown>): void {
+  if (value === null || value === undefined) return;
+  if (typeof value === "string") {
+    const text = value.trim();
+    if (!text) return;
+    const embedded = parseEmbeddedJson(text);
+    if (embedded !== undefined) collectErrorMessages(embedded, candidates, seen);
+    else candidates.push(text.replace(/^Error:\s*/u, ""));
+    return;
+  }
+  if (typeof value !== "object") {
+    candidates.push(String(value));
+    return;
+  }
+  if (seen.has(value)) return;
+  seen.add(value);
+  if (value instanceof Error) {
+    collectErrorMessages(value.cause, candidates, seen);
+    collectErrorMessages(value.message, candidates, seen);
+    return;
+  }
+  const record = value as Record<string, unknown>;
+  for (const key of ["cause", "reason", "message", "hint", "error"]) {
+    if (key in record) collectErrorMessages(record[key], candidates, seen);
+  }
+}
+
+function parseEmbeddedJson(value: string): unknown | undefined {
+  const whole = tryParseJson(value);
+  if (whole !== undefined) return whole;
+  for (let index = 0; index < value.length; index += 1) {
+    if (value[index] !== "{" && value[index] !== "[") continue;
+    const embedded = tryParseJson(value.slice(index));
+    if (embedded !== undefined) return embedded;
+  }
+  return undefined;
+}
+
+function tryParseJson(value: string): unknown | undefined {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/daemon/src/runtime/repo-write-telemetry-context.ts
+++ b/packages/daemon/src/runtime/repo-write-telemetry-context.ts
@@ -10,6 +10,7 @@ type RepoWriteTelemetryReporter = (
 export interface RepoWriteTelemetryDelivery {
   readonly report: RepoWriteTelemetryReporter;
   readonly flush: () => Promise<void>;
+  readonly close: () => void;
 }
 
 const storage = new AsyncLocalStorage<{
@@ -48,12 +49,17 @@ export function createRepoWriteTelemetryDelivery(
   ) => Promise<void>
 ): RepoWriteTelemetryDelivery {
   let pending = Promise.resolve();
+  let closed = false;
   return {
     report: (phase, elapsedMs) => {
+      if (closed) return;
       pending = pending
         .then(() => deliver(phase, elapsedMs))
         .catch(() => undefined);
     },
-    flush: () => pending
+    flush: () => pending,
+    close: () => {
+      closed = true;
+    }
   };
 }

--- a/packages/daemon/src/service/command-service.ts
+++ b/packages/daemon/src/service/command-service.ts
@@ -133,16 +133,18 @@ export function createDaemonCommandService<
             const outerOpId = error instanceof RepoWriteOutcomeUnknownError
               ? error.opId
               : undefined;
+            const outcomeUnknown = error instanceof RepoWriteOutcomeUnknownError
+              || error instanceof RepoWriteDirectOutcomeUnknownError;
             return childRouteFailure(
               parsedCommand.action.kind,
-              error instanceof RepoWriteOutcomeUnknownError
-                || error instanceof RepoWriteDirectOutcomeUnknownError
+              outcomeUnknown
                 ? "repo_write_outcome_unknown"
                 : error instanceof RepoWriteNotStartedError
                   ? error.code
                 : "repo_write_child_unavailable",
               error instanceof Error ? error.message : String(error),
-              outerOpId
+              outerOpId,
+              outcomeUnknown ? repoWriteOutcomeQuery(parsedCommand.action, outerOpId) : undefined
             );
           }
         }
@@ -270,7 +272,8 @@ function childRouteFailure(
   command: string,
   code: string,
   hint: string,
-  outerOpId?: string
+  outerOpId?: string,
+  query?: JsonObject
 ): CommandReceiptEnvelope {
   return {
     ok: false,
@@ -288,8 +291,33 @@ function childRouteFailure(
       ...(outerOpId ? { context: { outerOpId } } : {})
     },
     ...(outerOpId ? {
-      details: { data: { outerOpId, recovery: "lookup-only" } }
+      details: { data: { outcome: "unknown", outerOpId, recovery: "lookup-only", ...(query ? { query } : {}) } }
+    } : query ? {
+      details: { data: { outcome: "unknown", query } }
     } : {})
+  };
+}
+
+function repoWriteOutcomeQuery(
+  action: { readonly kind?: unknown; readonly taskId?: unknown },
+  outerOpId?: string
+): JsonObject {
+  if (outerOpId) {
+    return {
+      schema: "command-outcome-query/v1",
+      method: "repo-write.lookup",
+      parameters: { opId: outerOpId },
+      retry: "forbidden-until-queried"
+    };
+  }
+  const taskId = typeof action.taskId === "string" && action.taskId.trim().length > 0
+    ? action.taskId
+    : undefined;
+  return {
+    schema: "command-outcome-query/v1",
+    method: taskId ? "task.show" : "task.list",
+    parameters: taskId ? { taskId } : {},
+    retry: "forbidden-until-queried"
   };
 }
 

--- a/packages/daemon/test/repo-write-child-host-telemetry.test.ts
+++ b/packages/daemon/test/repo-write-child-host-telemetry.test.ts
@@ -1,0 +1,85 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createRepoWriteChildHost } from "../src/runtime/repo-write-child-host.ts";
+import {
+  RepoWriteClient,
+  RepoWriteDirectOutcomeUnknownError
+} from "../src/runtime/repo-write-client.ts";
+import { reportCurrentRepoWriteTelemetry } from "../src/runtime/repo-write-telemetry-context.ts";
+import {
+  type RepoWriteChildMessage,
+  type RepoWriteCommandDto
+} from "../src/runtime/repo-write-protocol.ts";
+import {
+  committedCommandReceipt,
+  committedTerminalOutcome
+} from "./support/repo-write-terminal-fixture.ts";
+
+test("direct failure telemetry cannot poison the parent client for the next command", async () => {
+  const messages: RepoWriteChildMessage[] = [];
+  let directAttempts = 0;
+  let childMessageListener: ((message: RepoWriteChildMessage) => void) | undefined;
+  const direct = async () => {
+    directAttempts += 1;
+    if (directAttempts === 1) {
+      setImmediate(() => reportCurrentRepoWriteTelemetry("projection"));
+      throw new Error("direct fixture failure");
+    }
+    return committedCommandReceipt("direct recovered");
+  };
+  const client = new RepoWriteClient({
+    repoId: "repo-canonical",
+    generation: 3,
+    transport: {
+      send: (message) => host.receive(message),
+      onMessage: (listener) => {
+        childMessageListener = listener;
+        return () => {
+          if (childMessageListener === listener) childMessageListener = undefined;
+        };
+      },
+      onDisconnect: () => () => undefined
+    },
+    onTelemetry: () => undefined
+  });
+  const host = createRepoWriteChildHost({
+    repoId: "repo-canonical",
+    workspaceId: "workspace-canonical",
+    generation: 3,
+    artifactIdentity: `sha256:${"a".repeat(64)}`,
+    transport: {
+      send: (message) => {
+        messages.push(message);
+        queueMicrotask(() => childMessageListener?.(message));
+      }
+    },
+    hooks: {
+      prepare: async ({ requestId }) => ({
+        opId: `op-${requestId}`,
+        execute: async () => committedTerminalOutcome(`op-${requestId}`)
+      }),
+      direct,
+      lookup: async () => ({ state: "not-found" }),
+      shutdown: async () => undefined
+    }
+  });
+
+  await host.start();
+  await client.waitUntilReady();
+  await assert.rejects(client.direct(command()), RepoWriteDirectOutcomeUnknownError);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const recovered = await client.direct(command());
+  assert.deepEqual(recovered, committedCommandReceipt("direct recovered"));
+  assert.equal(directAttempts, 2);
+  assert.equal(messages.some((message) => message.kind === "telemetry" && message.phase === "projection"), false);
+});
+
+function command(): RepoWriteCommandDto {
+  return {
+    commandName: "task.create",
+    actor: { personId: "person_zeyu" },
+    context: {},
+    payload: { title: "writer isolate" }
+  };
+}

--- a/packages/daemon/test/repo-write-command-cutover.test.ts
+++ b/packages/daemon/test/repo-write-command-cutover.test.ts
@@ -11,7 +11,11 @@ import type { HarnessDaemonRuntime } from "../src/runtime/repo-runtime.ts";
 import {
   decodeRepoWriteCommand
 } from "../src/runtime/repo-write-progress-command.ts";
-import { RepoWriteNotStartedError } from "../src/runtime/repo-write-client.ts";
+import {
+  RepoWriteDirectOutcomeUnknownError,
+  RepoWriteNotStartedError,
+  RepoWriteOutcomeUnknownError
+} from "../src/runtime/repo-write-client.ts";
 import { createDaemonCommandService } from "../src/service/command-service.ts";
 import {
   productionAuthorityActor,
@@ -190,6 +194,57 @@ test("parent command service preserves a structured child rejection before proce
   assert.equal(receipt.ok, false);
   assert.equal(receipt.error?.code, "authority_ingress_rejected", JSON.stringify(receipt));
   assert.match(receipt.error?.hint ?? "", /AUTHORITY_MANUAL_ENTITY_ID_FORBIDDEN/u);
+});
+
+test("unknown child receipts expose a machine-readable final-state query", async () => {
+  const actor = productionAuthorityActor();
+  for (const [kind, failure] of [
+    ["durable", new RepoWriteOutcomeUnknownError("EXECUTION_OUTCOME_UNKNOWN", "write may have committed", "outer-op")],
+    ["direct", new RepoWriteDirectOutcomeUnknownError("DIRECT_EXECUTION_OUTCOME_UNKNOWN", "write may have committed")]
+  ] as const) {
+    const service = createDaemonCommandService(
+      unusedRuntime(),
+      hostServices(() => undefined),
+      {
+        repoWriteDispatch: {
+          repoId: "canonical",
+          submit: async () => {
+            if (kind !== "durable") throw new Error("unexpected durable route");
+            throw failure;
+          },
+          direct: async () => {
+            if (kind !== "direct") throw new Error("unexpected direct route");
+            throw failure;
+          }
+        }
+      }
+    );
+    const receipt = await service.runCommand({
+      command: {
+        rootDir: "/repo",
+        action: kind === "durable"
+          ? { kind: "progress-append", taskId: "task-queryable", text: "unknown", dryRun: false }
+          : { kind: "task-claim", taskId: "task-queryable", dryRun: false }
+      },
+      session: session()
+    }, {
+      actor,
+      executor: { kind: "agent", id: "codex" },
+      authorityConnection: {
+        available: true,
+        context: productionAuthorityConnection(actor),
+        assertActive: () => undefined
+      }
+    });
+
+    assert.equal(receipt.ok, false, JSON.stringify(receipt));
+    assert.equal(receipt.error?.code, "repo_write_outcome_unknown");
+    const data = receipt.details?.data as Record<string, unknown>;
+    const query = data.query as Record<string, unknown>;
+    assert.equal(data.outcome, "unknown");
+    assert.equal(query.schema, "command-outcome-query/v1");
+    assert.equal(query.method, kind === "durable" ? "repo-write.lookup" : "task.show");
+  }
 });
 
 function hostServices(onExecute: () => void): DaemonCommandHostServices<

--- a/packages/daemon/test/repo-write-process-supervisor.test.ts
+++ b/packages/daemon/test/repo-write-process-supervisor.test.ts
@@ -10,7 +10,8 @@ import {
   forkRepoWriteProcess
 } from "../src/runtime/repo-write-child-process-transport.ts";
 import {
-  RepoWriteProcessSupervisor
+  RepoWriteProcessSupervisor,
+  mostActionableRepoWriteErrorMessage
 } from "../src/runtime/repo-write-process-supervisor.ts";
 import {
   RepoWriteDirectOutcomeUnknownError,
@@ -31,6 +32,28 @@ import {
 const fixturePath = fileURLToPath(
   new URL("./support/repo-write-ipc-child.ts", import.meta.url)
 );
+
+test("nested authority failures lead with the innermost actionable reason", () => {
+  const nested = new Error([
+    "Error: AUTHORITY_INDETERMINATE:PUBLICATION_OUTCOME_UNKNOWN:",
+    JSON.stringify({
+      _tag: "JournalUnavailable",
+      cause: {
+        name: "(FiberFailure) Error",
+        message: JSON.stringify({
+          _tag: "WriteRejected",
+          taskId: "task_nested",
+          reason: "invalid document path segment: ops/qa/"
+        })
+      }
+    })
+  ].join(" "));
+
+  assert.equal(
+    mostActionableRepoWriteErrorMessage(nested),
+    "invalid document path segment: ops/qa/"
+  );
+});
 
 test("supervisor submits through one child and drains it without inline fallback", async (context) => {
   let forks = 0;


### PR DESCRIPTION
# English

## Summary

Wave 1 of the kty-web pilot friction report (items #1, #2, #4, #5, #7, #9, #14, #8): the receipt-honesty and write-path-recovery fixes on the CLI/daemon surface. Every item ships with a two-sided positive control (old behavior reproduced red, new behavior green). Three of them close P0/P1 defects that structurally broke a real user session:

- **#1 identity argument slot (P0)**: `production-authority-lifecycle.ts` called the 4-param `loadDaemonIdentity` with `manifest.serviceStateRoot` in the `endpoint` slot and no `userRoot` at all, so the machine-level `~/.harness/people.yaml` roster was permanently invisible on the authority path — any repo without a project-level roster hard-failed with `AUTHORITY_PRODUCTION_PERSON_REGISTRY_REQUIRED`. The daemon's canonical `userRoot` is now threaded through `runDaemonServe` → host contract → lifecycle and passed in the correct position. New integration test boots a machine-roster-only repo successfully.
- **#2 dry-run fake green (P0)**: `task complete --dry-run` returned `ok:true, status:"done"` unconditionally before any gate check — seven approval packets went dry-run-green then real-run-red in the field. Dry-run now returns `status: in_review`, `completionGate.ok: false`, and names the three unexecuted gates (`canonical-authority-planner`, `task-completion-evidence`, `durable-transition-write`); it never claims terminal success.
- **#4 child poisoning (P1)**: after any failed command, every subsequent command returned `repo_write_child_unavailable` ("telemetry does not match a pending request") until the daemon was restarted. Root cause: late telemetry emitted after a terminal unknown/success frame entered the same host/client stream and was treated as a protocol violation. Terminal paths now flush then close telemetry delivery; all child-host exits share `closeTelemetry`. Fixture: direct failure + scheduled late telemetry → parent gets the unknown error, then a second direct write succeeds with no poisoning.
- **#5 queryable unknown outcomes**: unknown receipts gain additive machine-readable `outcome: "unknown"` + a `query` descriptor (`task.show`/`task.list` at the daemon layer, stable `repo-write.lookup(opId)` at the child layer, `retry: forbidden-until-queried`). Error codes, hints, and the wire envelope are unchanged.
- **#7 innermost error first**: exact-lookup failure messages now lead with the deepest actionable cause (e.g. `invalid document path segment: ops/qa/`) instead of burying it under three wrapper layers; the outer opId query hint is preserved after it.
- **#9 workflow declares reconcile**: the primary task workflow is now seven steps with `task code-doc reconcile` between submit and complete; both completion-witness failure branches hint the correct chain.
- **#14 actor hint uses the real principal**: the malformed `--actor` error now derives its example from project settings `identity.personId` or the configured local principal instead of a hardcoded wrong `human:lizeyu`.
- **#8 WIP exemption for closeout backfill** (`dec_01KZ3YKMT8V9XVNYYVEAY2R3E9`): a planned task counts against the WIP limit unless it already carries delivery evidence (substantive `closeout.md` per the existing placeholder policy, non-empty `review.md`, or non-empty `code-doc-anchors.json`). No new flag, protocol field, or bypass — evidence-derived from existing documents, satisfying the decision's "must be simple" condition. Negative control: planned work without evidence still consumes a slot.

## What Changed

- `packages/daemon/src/lifecycle/run-daemon-serve.ts`, `packages/application/src/authority/daemon-host-contract.ts`, `packages/daemon/src/authority/production/production-authority-lifecycle.ts`: `userRoot` threaded and passed in the correct parameter position (#1).
- `packages/cli/src/commands/core/task-gates.ts`: honest dry-run preview (#2).
- `packages/daemon/src/runtime/repo-write-child-direct.ts` + child-host exits: telemetry flush/close on terminal paths (#4).
- `packages/cli/src/daemon/{client,request-outcome}.ts`: additive `outcome`/`query` fields on unknown receipts (#5, #7 innermost-cause extraction).
- `packages/cli/src/cli/command-spec/command-groups.ts` + witness hints (#9); `packages/cli/src/composition/{actor-attribution,local-principal}.ts` (#14).
- `packages/application/src/authority/task-wip-policy.ts`, `packages/cli/src/commands/task-wip-settings.ts`: evidence-derived WIP exemption (#8).
- Tests: new `production-authority-user-root.test.ts`, `actor-attribution-malformed.test.ts`, WIP policy positive/negative controls, child-poisoning fixture, unknown-outcome query assertions, help/doctor workflow assertions.

## Task And Scope

- Harness task: `task_01KZ3XG00DKXP686TR6ZDQWYZJ` (parent intake: `task_01KZ3XES4V69C4WXBR7JPVNSG9`; WIP decision: `dec_01KZ3YKMT8V9XVNYYVEAY2R3E9`)
- Branch: `codex/receipt-honesty`
- Public scope: `packages/cli/src/**`, `packages/daemon/src/**`, `packages/application/src/authority/**` and tests
- Private planning/evidence updated: yes (task package `artifacts/implementation-report.md`, eight items each with two-sided controls)
- Out of scope: `packages/cli/src/commands/daemon/**` and `packages/kernel/**` (owned by #1207, merged before this PR's rebase; no diff under either), authority-enrollment tooling (separate task `task_01KZ3Z2KR8KY996WXKFVRD885G`).

## Version Impact

- Version: no version change because this is an unreleased surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KZ3XG00DKXP686TR6ZDQWYZJ`; WIP semantics change authorized by `dec_01KZ3YKMT8V9XVNYYVEAY2R3E9`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `e0511c5dcdc3c65569accdbcc1440fd48a10febf`
- Branch merge-base with `origin/main`: `e0511c5dcdc3c65569accdbcc1440fd48a10febf`
- Last `git fetch origin` time: immediately before opening this PR
- Sync method: rebase onto `origin/main` (clean over #1207), `check:local` rerun green after rebase
- Public diff command: `git diff origin/main...codex/receipt-honesty`
- Private evidence commit/path: task package `artifacts/implementation-report.md`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending, linked once the run completes
- [x] `git diff --check`
- [x] `npm run check:local` — green post-rebase (27 manifest gates; pre-rebase full run: affected fast 639/639, affected contract 467 pass / 1 skip)
- [x] Targeted tests for the change surface, named with their counts: WIP/supervisor 18/18, child-host/cutover 19/19, daemon-connect 18/18, help/policy 11/11; full `--tier integration` (pre-rebase base): 1,461 tests, 1,457 pass, 0 fail, 4 platform skips
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending
- Not run, and why: full integration tier not rerun post-rebase (clean rebase; `test-integration` runs authoritatively in CI). Two earlier `daemon-thin-client-cli` autostart timeouts occurred while another worktree ran a concurrent full tier; both passed in the final exclusive rerun and the contended run is not used as evidence.

## Review Evidence

- Self-review: CEO ground-truthed the #1 fix against the 4-param host-contract wrapper (endpoint explicitly `undefined`, `userRoot` in the correct final position, wrapper derives `primaryEmail` internally) and the #8 exemption (reuses the existing placeholder policy; no new bypass surface).
- Reviewer subagent: implementation by Codex worker (gpt-5.6-luna, max effort, model verified via session jsonl) from a plan carrying per-item acceptance criteria; all eight report two-sided positive controls.
- Human review: pending
- Blocking findings: none open

## Residual Risk

- #4 intentionally drops telemetry produced after a terminal frame — the trade for stream integrity; unknown receipts remain queryable (#5).
- #8 treats substantive review/code-doc evidence as closeout evidence for backfill; that is the decision's intended scope (historical backlog recovery), not a general WIP bypass.
- #14 falls back to the legacy example only when no configuration is readable at all.
- Legacy tests may still construct the lifecycle without `userRoot`; the production serve path always provides it.

## References

- Task: `task_01KZ3XG00DKXP686TR6ZDQWYZJ`
- Evidence: task package `artifacts/implementation-report.md`
- Review: same task package

---

# 中文

## 概要

kty-web 试点摩擦报告 wave-1（#1、#2、#4、#5、#7、#9、#14、#8）：CLI/daemon 面的回执诚实与写路恢复修复。每条都带双侧阳性对照（旧行为复现红、新行为绿）。其中三条是结构性打断过真实用户会话的 P0/P1：

- **#1 identity 参数位（P0）**：`production-authority-lifecycle.ts` 调四参 `loadDaemonIdentity` 时把 `manifest.serviceStateRoot` 塞进 `endpoint` 位、`userRoot` 完全没传——机器级 `~/.harness/people.yaml` 名册在 authority 路径上永不可见，无仓级名册的仓一挂 authority 就硬报 `AUTHORITY_PRODUCTION_PERSON_REGISTRY_REQUIRED`。现在 daemon 的 canonical `userRoot` 经 `runDaemonServe` → host contract → lifecycle 全程贯通并落在正确参数位。新 integration 测试用仅机器级名册的仓成功启动。
- **#2 dry-run 假绿（P0）**：`task complete --dry-run` 在任何门检查前无条件返回 `ok:true, status:"done"`——实测七个审批包 dry-run 全绿、真跑全红。现在 dry-run 返回 `status: in_review`、`completionGate.ok: false`，并点名三个未执行的门（`canonical-authority-planner`、`task-completion-evidence`、`durable-transition-write`），绝不宣称终态成功。
- **#4 child 毒化（P1）**：任一命令失败后，后续所有命令报 `repo_write_child_unavailable`，只能重启 daemon。根因：terminal unknown/success 帧发出后迟到的 telemetry 进入同一 host/client 流被判协议违规。现在 terminal 路径先 flush 再关闭 telemetry 投递，child-host 全部出口统一走 `closeTelemetry`。fixture：direct 失败 + 安排迟到 telemetry → 父侧拿到 unknown 错误后，第二次 direct 写正常成功、零毒化。
- **#5 unknown 可查证**：unknown 回执新增 additive 机读字段 `outcome:"unknown"` + `query` 描述（daemon 层 `task.show`/`task.list`，child 层稳定 `repo-write.lookup(opId)`，`retry: forbidden-until-queried`）。error code、hint 与 wire envelope 不变。
- **#7 根因前置**：exact-lookup 失败信息现在以最内层可行动原因开头（如 `invalid document path segment: ops/qa/`），不再埋三层包装之下；外层 opId 查询提示保留在后段。
- **#9 workflow 补 reconcile**：primary workflow 变七步，`task code-doc reconcile` 在 submit 与 complete 之间；completion witness 两个失败分支都提示正确链条。
- **#14 actor 提示用真 principal**：`--actor` 格式错误的报错例子改为从项目 settings `identity.personId` 或 configured local principal 派生，不再硬编码错误的 `human:lizeyu`。
- **#8 收尾链 WIP 豁免**（`dec_01KZ3YKMT8V9XVNYYVEAY2R3E9`）：planned 任务只有携带交付证据（`closeout.md` 有实质内容——按既有 placeholder policy 判定、`review.md` 非空、或 `code-doc-anchors.json` 非空）才不占 WIP 名额。零新 flag、零协议字段、零旁路——从既有文档派生证据，满足裁决的「必须简单」硬条件。阴性对照：无证据的 planned 工作照旧占名额。

## 改动内容

- `packages/daemon/src/lifecycle/run-daemon-serve.ts`、`packages/application/src/authority/daemon-host-contract.ts`、`packages/daemon/src/authority/production/production-authority-lifecycle.ts`：`userRoot` 贯通并落正确参数位（#1）。
- `packages/cli/src/commands/core/task-gates.ts`：诚实 dry-run 预览（#2）。
- `packages/daemon/src/runtime/repo-write-child-direct.ts` 与 child-host 出口：terminal 路径 telemetry flush/close（#4）。
- `packages/cli/src/daemon/{client,request-outcome}.ts`：unknown 回执 additive `outcome`/`query` 字段（#5）、最内层原因提取（#7）。
- `packages/cli/src/cli/command-spec/command-groups.ts` 与 witness 提示（#9）；`packages/cli/src/composition/{actor-attribution,local-principal}.ts`（#14）。
- `packages/application/src/authority/task-wip-policy.ts`、`packages/cli/src/commands/task-wip-settings.ts`：证据派生 WIP 豁免（#8）。
- 测试：新增 `production-authority-user-root.test.ts`、`actor-attribution-malformed.test.ts`、WIP 正/反对照、child 毒化 fixture、unknown 查询断言、help/doctor workflow 断言。

## 任务与范围

- Harness 任务：`task_01KZ3XG00DKXP686TR6ZDQWYZJ`（intake 父任务：`task_01KZ3XES4V69C4WXBR7JPVNSG9`；WIP 裁决：`dec_01KZ3YKMT8V9XVNYYVEAY2R3E9`）
- 分支：`codex/receipt-honesty`
- 公开范围：`packages/cli/src/**`、`packages/daemon/src/**`、`packages/application/src/authority/**` 及测试
- 私有计划 / 证据是否已更新：yes（任务包 `artifacts/implementation-report.md`，八条各带双侧对照）
- 范围外：`packages/cli/src/commands/daemon/**` 与 `packages/kernel/**`（#1207 的面，本 PR rebase 前已合入，两处零 diff）；authority 签发工具（独立任务 `task_01KZ3Z2KR8KY996WXKFVRD885G`）。

## 版本影响

- 版本：不改版本，原因是这是未发布面
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`task_01KZ3XG00DKXP686TR6ZDQWYZJ`；WIP 语义变更由 `dec_01KZ3YKMT8V9XVNYYVEAY2R3E9` 授权
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`e0511c5dcdc3c65569accdbcc1440fd48a10febf`
- 当前分支与 `origin/main` 的 merge-base：`e0511c5dcdc3c65569accdbcc1440fd48a10febf`
- 最近一次 `git fetch origin` 时间：开 PR 前即时执行
- 同步方式：rebase 到 `origin/main`（越过 #1207 干净合并），rebase 后 `check:local` 复跑绿
- 公开 diff 命令：`git diff origin/main...codex/receipt-honesty`
- 私有证据 commit/path：任务包 `artifacts/implementation-report.md`
- Reviewer 证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：待 run 完成后补链接
- [x] `git diff --check`
- [x] `npm run check:local` —— rebase 后全绿（27 门；rebase 前全量：受影响 fast 639/639、contract 467 过 / 1 跳过）
- [x] 改动面的定向测试，写明测试名与通过数：WIP/supervisor 18/18、child-host/cutover 19/19、daemon-connect 18/18、help/policy 11/11；完整 `--tier integration`（rebase 前基线）：1,461 tests、1,457 过、0 败、4 平台跳过
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）—— 待跑
- 未跑项及原因：rebase 后未重跑完整 integration tier（rebase 干净；`test-integration` 在 CI 权威执行）。早前两次 `daemon-thin-client-cli` autostart 超时发生在另一 worktree 并发全量 tier 期间；最终独占重跑均通过，竞争轮不作证据。

## 审查证据

- 自查：CEO 对 #1 按四参 host-contract 包装逐位核验（endpoint 显式 `undefined`、`userRoot` 落在正确末位、包装内部推导 `primaryEmail`）；对 #8 核验复用既有 placeholder policy、零新旁路面。
- Reviewer subagent：Codex worker（gpt-5.6-luna，max effort，session jsonl 核实生效模型）依逐条判据的 plan 实现；八条全带双侧阳性对照。
- 人工审查：待办
- 阻塞发现：无 open

## 残余风险

- #4 有意丢弃 terminal 帧之后产生的 telemetry——换取流完整性；unknown 回执保持可查证（#5）。
- #8 把实质 review/code-doc 证据也视为收口证据——这正是裁决的适用域（历史积压补账），不是普适 WIP 旁路。
- #14 仅在配置完全不可读时保留兼容 fallback 例子。
- 旧测试仍可不带 `userRoot` 构造 lifecycle；生产 serve 路径恒提供。

## 关联材料

- 任务：`task_01KZ3XG00DKXP686TR6ZDQWYZJ`
- 证据：任务包 `artifacts/implementation-report.md`
- 审查：同一任务包
