### PR TITLE
perf(kernel): generation-trusted source fingerprint + scoped-index commit (write-cost round 4)

### DIFF
--- a/packages/kernel/src/persistence/git/local-version-control-system.ts
+++ b/packages/kernel/src/persistence/git/local-version-control-system.ts
@@ -1,10 +1,12 @@
 import { execFileSync } from "node:child_process";
 import type { ExecFileSyncOptionsWithStringEncoding } from "node:child_process";
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync, lstatSync, mkdtempSync, readFileSync, readlinkSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import type { VcsCommitAuthor, VersionControlSystem } from "../../ports/version-control-system.ts";
 import { VcsCommandError } from "../../ports/version-control-system.ts";
 import { resolveGitMaxBufferBytes } from "../../runtime/operational-limits.ts";
+import { commitWithScopedIndex, nullDelimitedGitPaths } from "./scoped-index-commit.ts";
 
 const gitMaxBuffer = resolveGitMaxBufferBytes();
 
@@ -26,9 +28,20 @@ export function makeLocalVersionControlSystem(): VersionControlSystem {
     },
     workingTreeFiles: (repoRoot, paths) => runGit(repoRoot, "status", "--porcelain", "-uall", "--", ...paths),
     stagedFiles: (repoRoot, paths) => runGit(repoRoot, "diff", "--cached", "--name-only", "--", ...paths),
-    commit: (repoRoot, message, author) => {
-      runGitAs(repoRoot, author, "commit", "-m", message);
-    },
+    commit: (repoRoot, message, author) => commitWithScopedIndex(repoRoot, message, author, {
+      runGitBytes,
+      runGitWithInput,
+      runGitWithEnvironment,
+      runGitWithInputEnvironment,
+      fileSystem: {
+        exists: existsSync,
+        lstat: lstatSync,
+        readFile: readFileSync,
+        readLink: readlinkSync,
+        makeTemporaryDirectory: (prefix) => mkdtempSync(path.join(tmpdir(), prefix)),
+        removeTemporaryDirectory: (inputPath) => rmSync(inputPath, { recursive: true, force: true })
+      }
+    }),
     currentHead: (repoRoot) => {
       try {
         return runGit(repoRoot, "rev-parse", "HEAD").trim();
@@ -265,20 +278,6 @@ function runGitBytes(repoRoot: string, ...args: ReadonlyArray<string>): Uint8Arr
   }
 }
 
-function nullDelimitedGitPaths(input: Uint8Array): ReadonlyArray<Uint8Array> {
-  const paths: Uint8Array[] = [];
-  let start = 0;
-  for (let index = 0; index < input.length; index += 1) {
-    if (input[index] !== 0) continue;
-    paths.push(input.subarray(start, index));
-    start = index + 1;
-  }
-  if (start !== input.length) {
-    throw new Error("GIT_PATH_LIST_NUL_TERMINATOR_MISSING");
-  }
-  return paths;
-}
-
 function gitPathBytesKey(input: Uint8Array): string {
   return Buffer.from(input).toString("base64");
 }
@@ -324,9 +323,44 @@ function runGitWithInput(repoRoot: string, input: string | Uint8Array, ...args: 
   }
 }
 
-function runGitAs(repoRoot: string, author: VcsCommitAuthor | undefined, ...args: ReadonlyArray<string>): string {
+function runGitWithInputEnvironment(
+  repoRoot: string,
+  author: VcsCommitAuthor | undefined,
+  environment: Readonly<Record<string, string>>,
+  input: string | Uint8Array,
+  ...args: ReadonlyArray<string>
+): string {
   try {
-    return execFileSync("git", ["-C", repoRoot, ...args], localGitProcessOptions(author));
+    const options = localGitProcessOptions(author);
+    return execFileSync("git", ["-C", repoRoot, ...args], {
+      ...options,
+      input,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+      env: { ...(options.env ?? {}), ...environment }
+    });
+  } catch (error) {
+    throw vcsCommandError(repoRoot, args, error);
+  }
+}
+
+function runGitAs(repoRoot: string, author: VcsCommitAuthor | undefined, ...args: ReadonlyArray<string>): string {
+  return runGitWithEnvironment(repoRoot, author, {}, ...args);
+}
+
+function runGitWithEnvironment(
+  repoRoot: string,
+  author: VcsCommitAuthor | undefined,
+  environment: Readonly<Record<string, string>>,
+  ...args: ReadonlyArray<string>
+): string {
+  try {
+    const options = localGitProcessOptions(author);
+    return execFileSync("git", ["-C", repoRoot, ...args], {
+      ...options,
+      env: { ...(options.env ?? {}), ...environment },
+      windowsHide: true
+    });
   } catch (error) {
     throw vcsCommandError(repoRoot, args, error);
   }

--- a/packages/kernel/src/persistence/git/scoped-index-commit.ts
+++ b/packages/kernel/src/persistence/git/scoped-index-commit.ts
@@ -1,0 +1,222 @@
+import path from "node:path";
+import type { VcsCommitAuthor } from "../../ports/version-control-system.ts";
+
+interface StagedIndexEntry {
+  readonly mode: string;
+  readonly object: string;
+}
+
+export interface ScopedIndexGitOperations {
+  readonly runGitBytes: (repoRoot: string, ...args: ReadonlyArray<string>) => Uint8Array;
+  readonly runGitWithInput: (repoRoot: string, input: string | Uint8Array, ...args: ReadonlyArray<string>) => string;
+  readonly runGitWithEnvironment: (
+    repoRoot: string,
+    author: VcsCommitAuthor | undefined,
+    environment: Readonly<Record<string, string>>,
+    ...args: ReadonlyArray<string>
+  ) => string;
+  readonly runGitWithInputEnvironment: (
+    repoRoot: string,
+    author: VcsCommitAuthor | undefined,
+    environment: Readonly<Record<string, string>>,
+    input: string | Uint8Array,
+    ...args: ReadonlyArray<string>
+  ) => string;
+  readonly fileSystem: ScopedIndexFileSystem;
+}
+
+interface ScopedIndexFileStats {
+  readonly mode: number;
+  readonly isSymbolicLink: () => boolean;
+}
+
+interface ScopedIndexFileSystem {
+  readonly exists: (inputPath: string) => boolean;
+  readonly lstat: (inputPath: string) => ScopedIndexFileStats;
+  readonly readFile: (inputPath: string) => Uint8Array;
+  readonly readLink: (inputPath: string) => string | Uint8Array;
+  readonly makeTemporaryDirectory: (prefix: string) => string;
+  readonly removeTemporaryDirectory: (inputPath: string) => void;
+}
+
+/**
+ * Commit the already-staged work through a small alternate index. Git's
+ * ordinary commit refreshes every stat-invalid entry before invoking hooks;
+ * this is particularly expensive after copy-on-write restores. The alternate
+ * index starts at HEAD and receives only the staged entries, while the normal
+ * commit command (and therefore all configured hooks) remains in use.
+ *
+ * If the worktree differs from the staged content, or the index contains an
+ * unsupported/unmerged shape, fall back to Git's native commit so staged-versus-
+ * unstaged semantics remain exact.
+ */
+export function commitWithScopedIndex(
+  repoRoot: string,
+  message: string,
+  author: VcsCommitAuthor | undefined,
+  git: ScopedIndexGitOperations
+): void {
+  let stagedPaths: ReadonlyArray<string>;
+  try {
+    stagedPaths = stagedGitPaths(repoRoot, git);
+  } catch {
+    git.runGitWithEnvironment(repoRoot, author, {}, "commit", "-m", message);
+    return;
+  }
+  if (stagedPaths.length === 0) {
+    git.runGitWithEnvironment(repoRoot, author, {}, "commit", "-m", message);
+    return;
+  }
+
+  let stagedEntries: Map<string, StagedIndexEntry | undefined> | null;
+  try {
+    stagedEntries = readStagedIndexEntries(repoRoot, stagedPaths, git);
+  } catch {
+    git.runGitWithEnvironment(repoRoot, author, {}, "commit", "-m", message);
+    return;
+  }
+  if (!stagedEntries || !worktreeMatchesStagedEntries(repoRoot, stagedEntries, git)) {
+    git.runGitWithEnvironment(repoRoot, author, {}, "commit", "-m", message);
+    return;
+  }
+
+  const temporaryIndexDirectory = git.fileSystem.makeTemporaryDirectory("ha-git-commit-index-");
+  const temporaryIndex = path.join(temporaryIndexDirectory, "index");
+  try {
+    const environment = { GIT_INDEX_FILE: temporaryIndex };
+    try {
+      git.runGitWithEnvironment(repoRoot, undefined, environment, "read-tree", "HEAD");
+    } catch {
+      git.runGitWithEnvironment(repoRoot, undefined, environment, "read-tree", "--empty");
+    }
+    // The alternate index is a complete HEAD tree, but its stat tuples are
+    // intentionally not copied from the possibly cold original index. Mark
+    // every HEAD entry index-only so commit's refresh cannot stat the entire
+    // authored tree; staged entries are cleared below before commit.
+    const headPaths = git.runGitWithEnvironment(repoRoot, undefined, environment, "ls-files", "-z");
+    if (headPaths.length > 0) {
+      git.runGitWithInputEnvironment(
+        repoRoot,
+        undefined,
+        environment,
+        Buffer.from(headPaths, "utf8"),
+        "update-index",
+        "--skip-worktree",
+        "-z",
+        "--stdin"
+      );
+    }
+    for (const relativePath of stagedPaths) {
+      const entry = stagedEntries.get(relativePath);
+      if (entry) {
+        git.runGitWithEnvironment(
+          repoRoot,
+          undefined,
+          environment,
+          "update-index",
+          "--add",
+          "--cacheinfo",
+          entry.mode,
+          entry.object,
+          relativePath
+        );
+        git.runGitWithEnvironment(repoRoot, undefined, environment, "update-index", "--no-skip-worktree", "--", relativePath);
+      } else {
+        git.runGitWithEnvironment(repoRoot, undefined, environment, "update-index", "--force-remove", "--", relativePath);
+      }
+    }
+
+    git.runGitWithEnvironment(repoRoot, author, environment, "commit", "-m", message);
+
+    // stagedGitPaths enumerates the complete pre-hook staged set, so the
+    // alternate index contains every change the normal commit would have
+    // consumed. Re-read HEAD into the original index without touching the
+    // worktree; this keeps the next publication from paying a second refresh.
+    git.runGitWithEnvironment(repoRoot, undefined, {}, "read-tree", "HEAD");
+  } finally {
+    git.fileSystem.removeTemporaryDirectory(temporaryIndexDirectory);
+  }
+}
+
+function stagedGitPaths(repoRoot: string, git: ScopedIndexGitOperations): ReadonlyArray<string> {
+  return nullDelimitedGitPaths(git.runGitBytes(repoRoot, "diff", "--cached", "--no-renames", "--name-only", "-z", "--"))
+    .map((input) => Buffer.from(input).toString("utf8"));
+}
+
+function readStagedIndexEntries(
+  repoRoot: string,
+  stagedPaths: ReadonlyArray<string>,
+  git: ScopedIndexGitOperations
+): Map<string, StagedIndexEntry | undefined> | null {
+  const entriesByPath = new Map<string, StagedIndexEntry[]>();
+  const listing = git.runGitBytes(repoRoot, "ls-files", "--stage", "-z", "--", ...stagedPaths);
+  for (const record of nullDelimitedGitPaths(listing)) {
+    const separator = record.indexOf(9);
+    if (separator < 0) return null;
+    const metadata = Buffer.from(record.subarray(0, separator)).toString("ascii").split(" ");
+    const relativePath = Buffer.from(record.subarray(separator + 1)).toString("utf8");
+    if (metadata.length !== 3 || !metadata[0] || !metadata[1] || !metadata[2]) return null;
+    const entries = entriesByPath.get(relativePath) ?? [];
+    entries.push({ mode: metadata[0], object: metadata[1] });
+    entriesByPath.set(relativePath, entries);
+  }
+
+  const result = new Map<string, StagedIndexEntry | undefined>();
+  for (const relativePath of stagedPaths) {
+    const entries = entriesByPath.get(relativePath) ?? [];
+    if (entries.length > 1) return null;
+    result.set(relativePath, entries[0]);
+  }
+  return result;
+}
+
+function worktreeMatchesStagedEntries(
+  repoRoot: string,
+  stagedEntries: ReadonlyMap<string, StagedIndexEntry | undefined>,
+  git: ScopedIndexGitOperations
+): boolean {
+  for (const [relativePath, entry] of stagedEntries) {
+    const worktreePath = path.join(repoRoot, ...relativePath.split("/"));
+    if (!entry) {
+      if (git.fileSystem.exists(worktreePath)) return false;
+      continue;
+    }
+    let stats: ScopedIndexFileStats;
+    let body: Uint8Array;
+    try {
+      stats = git.fileSystem.lstat(worktreePath);
+      body = stats.isSymbolicLink()
+        ? Buffer.from(git.fileSystem.readLink(worktreePath))
+        : git.fileSystem.readFile(worktreePath);
+    } catch {
+      return false;
+    }
+    if (gitWorktreeMode(stats) !== entry.mode) return false;
+    try {
+      const object = git.runGitWithInput(repoRoot, body, "hash-object", `--path=${relativePath}`, "--stdin").trim();
+      if (object !== entry.object) return false;
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+function gitWorktreeMode(stats: ScopedIndexFileStats): string {
+  if (stats.isSymbolicLink()) return "120000";
+  return stats.mode & 0o111 ? "100755" : "100644";
+}
+
+export function nullDelimitedGitPaths(input: Uint8Array): ReadonlyArray<Uint8Array> {
+  const paths: Uint8Array[] = [];
+  let start = 0;
+  for (let index = 0; index < input.length; index += 1) {
+    if (input[index] !== 0) continue;
+    paths.push(input.subarray(start, index));
+    start = index + 1;
+  }
+  if (start !== input.length) {
+    throw new Error("GIT_PATH_LIST_NUL_TERMINATOR_MISSING");
+  }
+  return paths;
+}

--- a/packages/kernel/src/projection/projection-source-baseline.ts
+++ b/packages/kernel/src/projection/projection-source-baseline.ts
@@ -1,7 +1,17 @@
+import path from "node:path";
 import type { HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
+import type { VersionControlSystem } from "../ports/version-control-system.ts";
 import { readDeclaredSourceManifestRows } from "./sqlite-declared-source-manifest.ts";
 import { captureProjectionSourceFingerprint } from "./projection-source-snapshot.ts";
+
+interface TrustedProjectionFingerprint {
+  readonly head: string;
+  readonly fingerprint: string;
+  readonly worktreeVerified: boolean;
+}
+
+const trustedProjectionFingerprints = new Map<string, TrustedProjectionFingerprint>();
 
 export function captureAuthoredProjectionFingerprint(rootInput: HarnessLayoutInput): string {
   const projectionPath = resolveHarnessLayout(rootInput).projectionPath;
@@ -12,4 +22,85 @@ export function captureAuthoredProjectionFingerprint(rootInput: HarnessLayoutInp
     // A missing or invalid generated manifest is not authoritative; source capture still proceeds.
   }
   return captureProjectionSourceFingerprint(rootInput, hints).fingerprint;
+}
+
+/**
+ * Reuse the source hash for a clean, unchanged authored generation. A write
+ * coordinator and the ledger materializer share this cache, so one generation
+ * pays for a full source capture once and later publications advance it from
+ * their touched paths. A cold cache gets a Git HEAD plus scoped worktree fence;
+ * a successful projection update promotes the same generation to a verified
+ * cache entry, so later calls do not refresh the whole index. The incremental
+ * updater still verifies the touched generation and falls back to a full
+ * rebuild on any mismatch.
+ */
+export function captureTrustedAuthoredProjectionFingerprint(
+  rootInput: HarnessLayoutInput,
+  vcs: VersionControlSystem,
+  repoRoot?: string
+): string {
+  const layout = resolveHarnessLayout(rootInput);
+  const resolvedRepoRoot = repoRoot ?? vcs.topLevel(layout.authoredRoot) ?? vcs.topLevel(layout.rootDir);
+  if (!resolvedRepoRoot) return captureAuthoredProjectionFingerprint(rootInput);
+
+  const key = trustedProjectionFingerprintKey(resolvedRepoRoot, layout.authoredRoot, layout.projectionPath);
+  const head = vcs.currentHead(resolvedRepoRoot);
+  const cached = trustedProjectionFingerprints.get(key);
+  if (cached && cached.head === head) {
+    if (cached.worktreeVerified || authoredWorktreeIsClean(vcs, resolvedRepoRoot, layout.authoredRoot)) {
+      return cached.fingerprint;
+    }
+  }
+
+  const fingerprint = captureAuthoredProjectionFingerprint(rootInput);
+  const capturedHead = vcs.currentHead(resolvedRepoRoot);
+  if (capturedHead === head) {
+    trustedProjectionFingerprints.set(key, { head: capturedHead, fingerprint, worktreeVerified: false });
+  } else {
+    trustedProjectionFingerprints.delete(key);
+  }
+  return fingerprint;
+}
+
+export function rememberTrustedAuthoredProjectionFingerprint(
+  rootInput: HarnessLayoutInput,
+  fingerprint: string,
+  vcs: VersionControlSystem,
+  repoRoot?: string
+): void {
+  const layout = resolveHarnessLayout(rootInput);
+  const resolvedRepoRoot = repoRoot ?? vcs.topLevel(layout.authoredRoot) ?? vcs.topLevel(layout.rootDir);
+  if (!resolvedRepoRoot) return;
+  const key = trustedProjectionFingerprintKey(resolvedRepoRoot, layout.authoredRoot, layout.projectionPath);
+  trustedProjectionFingerprints.set(key, {
+    head: vcs.currentHead(resolvedRepoRoot),
+    fingerprint,
+    worktreeVerified: true
+  });
+}
+
+export function invalidateTrustedAuthoredProjectionFingerprint(
+  rootInput: HarnessLayoutInput,
+  vcs: VersionControlSystem,
+  repoRoot?: string
+): void {
+  const layout = resolveHarnessLayout(rootInput);
+  const resolvedRepoRoot = repoRoot ?? vcs.topLevel(layout.authoredRoot) ?? vcs.topLevel(layout.rootDir);
+  if (!resolvedRepoRoot) return;
+  trustedProjectionFingerprints.delete(
+    trustedProjectionFingerprintKey(resolvedRepoRoot, layout.authoredRoot, layout.projectionPath)
+  );
+}
+
+function trustedProjectionFingerprintKey(repoRoot: string, authoredRoot: string, projectionPath: string): string {
+  return [path.resolve(repoRoot), path.resolve(authoredRoot), path.resolve(projectionPath)].join("\0");
+}
+
+function authoredWorktreeIsClean(vcs: VersionControlSystem, repoRoot: string, authoredRoot: string): boolean {
+  const relativeRoot = path.relative(vcs.normalizePath(repoRoot), vcs.normalizePath(authoredRoot)).split(path.sep).join("/");
+  try {
+    return vcs.workingTreeFiles(repoRoot, relativeRoot.length === 0 ? [] : [relativeRoot]).length === 0;
+  } catch {
+    return false;
+  }
 }

--- a/packages/kernel/src/write-coordination/journal/coordinator.ts
+++ b/packages/kernel/src/write-coordination/journal/coordinator.ts
@@ -20,7 +20,7 @@ import {
   resolveHarnessLayout,
 } from "../../layout/index.ts";
 import type { ProjectionChangeEvent } from "../../projection/projection-change-event.ts";
-import { captureAuthoredProjectionFingerprint } from "../../projection/projection-source-baseline.ts";
+import { captureTrustedAuthoredProjectionFingerprint } from "../../projection/projection-source-baseline.ts";
 import { appendJsonLineDurably, readDurableState, readPayloadRef, writeWatermarkDurably } from "./durable.ts";
 import { finalizeRecoverableDocumentTransaction } from "./operations/recoverable-document-transaction.ts";
 import { assertCommitPlanAddable, commitTouchedPaths } from "./publication/git.ts";
@@ -354,7 +354,7 @@ function flushRecords(
 
   assertCommitPlanAddable(rootDir, plannedRecords.flatMap((record) => record.touchedPaths), rootInput, { versionControlSystem: publicationVcs });
   const previousProjectionSourceFingerprint = records.length > 0
-    ? captureAuthoredProjectionFingerprint(rootInput)
+    ? captureTrustedAuthoredProjectionFingerprint(rootInput, publicationVcs)
     : undefined;
 
   for (const { record, touchedPaths: recordTouchedPaths } of plannedRecords) {
@@ -417,7 +417,7 @@ function flushRecords(
     throw new Error("attribution event durability confirmation failed");
   }
   const projectionUpdate = committedOpIds.length > 0
-    ? rebuildProjectionHash(rootDir, rootInput, touchedPaths, previousProjectionSourceFingerprint, plannedRecords.map(({ record }) => record.entityId))
+    ? rebuildProjectionHash(rootDir, rootInput, touchedPaths, previousProjectionSourceFingerprint, plannedRecords.map(({ record }) => record.entityId), publicationVcs)
     : undefined;
   const projectionHash = projectionUpdate?.hash ?? previousWatermark?.projectionHash ?? "no-projection-change";
   const allCommitted = [...(previousWatermark?.lastCommittedOpIds ?? []), ...committedOpIds];

--- a/packages/kernel/src/write-coordination/journal/publication/projection.ts
+++ b/packages/kernel/src/write-coordination/journal/publication/projection.ts
@@ -1,16 +1,23 @@
 import type { HarnessLayoutInput } from "../../../layout/index.ts";
+import type { VersionControlSystem } from "../../../ports/version-control-system.ts";
 import type { ProjectionChangeEvent } from "../../../projection/projection-change-event.ts";
-import { captureAuthoredProjectionFingerprint } from "../../../projection/projection-source-baseline.ts";
+import {
+  captureTrustedAuthoredProjectionFingerprint,
+  rememberTrustedAuthoredProjectionFingerprint
+} from "../../../projection/projection-source-baseline.ts";
 import { updateTaskProjectionIncrementally } from "../../../projection/sqlite-task-incremental-projection.ts";
 import { hashTaskProjectionRows } from "../../../projection/sqlite-task-projection.ts";
+import { makeLocalVersionControlSystem } from "../../../persistence/git/local-version-control-system.ts";
 
 export function rebuildProjectionHash(
   rootDir: string,
   rootInput: HarnessLayoutInput,
   touchedPaths: ReadonlyArray<string>,
   previousSourceFingerprint: string | undefined,
-  entityIds: ReadonlyArray<string>
+  entityIds: ReadonlyArray<string>,
+  versionControlSystem?: VersionControlSystem
 ): { readonly hash: string; readonly event: ProjectionChangeEvent } {
+  const vcs = versionControlSystem ?? makeLocalVersionControlSystem();
   const layoutOverrides = typeof rootInput === "string" ? undefined : rootInput.layoutOverrides;
   const result = updateTaskProjectionIncrementally({
     rootDir,
@@ -18,11 +25,13 @@ export function rebuildProjectionHash(
     touchedPaths,
     previousSourceFingerprint
   });
+  const sourceHash = result.change?.sourceHash ?? captureTrustedAuthoredProjectionFingerprint(rootInput, vcs);
+  rememberTrustedAuthoredProjectionFingerprint(rootInput, sourceHash, vcs);
   return {
     hash: hashTaskProjectionRows(result.rows),
     event: result.change ?? {
       schema: "projection-change/v1",
-      sourceHash: captureAuthoredProjectionFingerprint(rootInput),
+      sourceHash,
       entities: entityIds.map((entityId) => {
         const separator = entityId.indexOf("/");
         return separator < 0

--- a/packages/kernel/src/write-coordination/materialization/ledger-materializer.ts
+++ b/packages/kernel/src/write-coordination/materialization/ledger-materializer.ts
@@ -6,7 +6,11 @@ import type { VersionControlSystem } from "../../ports/version-control-system.ts
 import { updateTaskProjectionIncrementally } from "../../projection/sqlite-task-incremental-projection.ts";
 import { countAttributionProjectionRows } from "../../projection/sqlite-attribution-projection.ts";
 import { rebuildTaskProjection } from "../../projection/sqlite-task-projection.ts";
-import { captureAuthoredProjectionFingerprint } from "../../projection/projection-source-baseline.ts";
+import {
+  captureTrustedAuthoredProjectionFingerprint,
+  invalidateTrustedAuthoredProjectionFingerprint,
+  rememberTrustedAuthoredProjectionFingerprint
+} from "../../projection/projection-source-baseline.ts";
 import { makeLocalVersionControlSystem } from "../../persistence/git/local-version-control-system.ts";
 import {
   materializerCommitter,
@@ -121,7 +125,7 @@ function materializeBranches(
       continue;
     }
 
-    projectionSourceFingerprintBeforeMerge ??= captureAuthoredProjectionFingerprint(rootInput);
+    projectionSourceFingerprintBeforeMerge ??= captureTrustedAuthoredProjectionFingerprint(rootInput, vcs, repoRoot);
 
     const mergeMessage = semanticMergeMessage(commits, repoRoot, branch, vcs)
       ?? `materializer: merge session ${branch.slice("sessions/".length)}`;
@@ -186,12 +190,17 @@ function materializeBranches(
 
   if (merged > 0) {
     const layout = resolveHarnessLayout(rootInput);
-    updateTaskProjectionIncrementally({
+    const projectionUpdate = updateTaskProjectionIncrementally({
       rootDir: layout.rootDir,
       ...(typeof rootInput === "object" && rootInput.layoutOverrides ? { layoutOverrides: rootInput.layoutOverrides } : {}),
       touchedPaths: [...touchedPaths],
       ...(projectionSourceFingerprintBeforeMerge ? { previousSourceFingerprint: projectionSourceFingerprintBeforeMerge } : {})
     });
+    if (projectionUpdate.sourceHash) {
+      rememberTrustedAuthoredProjectionFingerprint(rootInput, projectionUpdate.sourceHash, vcs, repoRoot);
+    } else {
+      invalidateTrustedAuthoredProjectionFingerprint(rootInput, vcs, repoRoot);
+    }
   }
 
   const layout = resolveHarnessLayout(rootInput);

--- a/packages/kernel/test/store/ledger-materializer.test.ts
+++ b/packages/kernel/test/store/ledger-materializer.test.ts
@@ -3,12 +3,19 @@ import { testWriteAttribution } from "../test-attribution.ts";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { Effect } from "effect";
 import { makeJournaledWriteCoordinator, runLedgerMaterializer } from "../../src/index.ts";
 import { authorityBatchTrailerName, buildAuthorityBatchIntegrity } from "../../src/integrity/authority-batch-integrity.ts";
+import { localProjectionSourceFileSystem } from "../../src/local/local-layout-file-system.ts";
+import { makeLocalVersionControlSystem } from "../../src/persistence/git/local-version-control-system.ts";
+import {
+  captureTrustedAuthoredProjectionFingerprint,
+  invalidateTrustedAuthoredProjectionFingerprint,
+  rememberTrustedAuthoredProjectionFingerprint
+} from "../../src/projection/projection-source-baseline.ts";
 import { readAttributionProjection } from "../../src/projection/sqlite-attribution-projection.ts";
 import { docWrite, withTempStore } from "./helpers.ts";
 
@@ -62,6 +69,79 @@ test("ledger materializer dry-runs and merges pending session branches", () => {
       git(rootDir, "show", "-s", "--format=%an <%ae>", "HEAD"),
       "Harness Anything Materializer <materializer@harness-anything.local>"
     );
+  });
+});
+
+test("trusted generation fingerprint reuses clean state and fails closed on dirty authored state", () => {
+  withTempStore((rootDir) => {
+    initAuthoredGit(rootDir);
+    const taskRoot = path.join(rootDir, "harness/tasks/task-baseline");
+    mkdirSync(taskRoot, { recursive: true });
+    writeFileSync(path.join(taskRoot, "INDEX.md"), [
+      "---",
+      "schema: task-package/v2",
+      "task_id: task-baseline",
+      "title: Baseline",
+      "lifecycle:",
+      "  bindingSchema: lifecycle-binding/v1",
+      "  engine: local",
+      "  status: active",
+      "  ref: ",
+      "  titleSnapshot: Baseline",
+      "  url: ",
+      "  bindingCreatedAt: 2026-07-07T00:00:00.000Z",
+      "  bindingFingerprint: sha256:fixture",
+      "packageDisposition: active",
+      "---",
+      ""
+    ].join("\n"), "utf8");
+    git(rootDir, "add", "--", "tasks/task-baseline/INDEX.md");
+    git(rootDir, "commit", "-m", "seed fingerprint baseline");
+
+    const vcs = makeLocalVersionControlSystem();
+    const first = captureTrustedAuthoredProjectionFingerprint(rootDir, vcs);
+    assert.equal(git(rootDir, "status", "--porcelain"), "");
+    assert.equal(vcs.workingTreeFiles(vcs.topLevel(path.join(rootDir, "harness"))!, []), "");
+    const originalStatSignature = localProjectionSourceFileSystem.statSignature;
+    let cleanReuseStats = 0;
+    localProjectionSourceFileSystem.statSignature = (inputPath) => {
+      cleanReuseStats += 1;
+      return originalStatSignature(inputPath);
+    };
+    try {
+      assert.equal(captureTrustedAuthoredProjectionFingerprint(rootDir, vcs), first);
+    } finally {
+      localProjectionSourceFileSystem.statSignature = originalStatSignature;
+    }
+    assert.equal(cleanReuseStats, 0);
+
+    let generationStatusCalls = 0;
+    const generationVcs = {
+      ...vcs,
+      workingTreeFiles: (repo: string, paths: ReadonlyArray<string>) => {
+        generationStatusCalls += 1;
+        return vcs.workingTreeFiles(repo, paths);
+      }
+    };
+    rememberTrustedAuthoredProjectionFingerprint(rootDir, first, generationVcs);
+    assert.equal(captureTrustedAuthoredProjectionFingerprint(rootDir, generationVcs), first);
+    assert.equal(generationStatusCalls, 0);
+    invalidateTrustedAuthoredProjectionFingerprint(rootDir, vcs);
+
+    writeFileSync(path.join(taskRoot, "INDEX.md"), readFileSync(path.join(taskRoot, "INDEX.md"), "utf8").replace("title: Baseline", "title: Dirty baseline"), "utf8");
+    let dirtyFallbackStats = 0;
+    localProjectionSourceFileSystem.statSignature = (inputPath) => {
+      dirtyFallbackStats += 1;
+      return originalStatSignature(inputPath);
+    };
+    let dirty: string;
+    try {
+      dirty = captureTrustedAuthoredProjectionFingerprint(rootDir, vcs);
+    } finally {
+      localProjectionSourceFileSystem.statSignature = originalStatSignature;
+    }
+    assert.notEqual(dirty, first);
+    assert.ok(dirtyFallbackStats > 0);
   });
 });
 

--- a/packages/kernel/test/store/local-version-control-system.test.ts
+++ b/packages/kernel/test/store/local-version-control-system.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -88,6 +88,52 @@ test("local Git execution preserves captured output and typed command errors", (
   } finally {
     rmSync(repoRoot, { recursive: true, force: true });
     rmSync(nonRepoRoot, { recursive: true, force: true });
+  }
+});
+
+test("scoped commits preserve staged blobs, unstaged work, deletions, and hooks", (t) => {
+  if (process.platform === "win32") {
+    t.skip("shell hook fixture is POSIX-only");
+    return;
+  }
+  const repoRoot = mkdtempSync(path.join(tmpdir(), "ha-scoped-git-commit-"));
+  try {
+    fixtureGit(repoRoot, "init", "-b", "scoped-commit-test");
+    fixtureGit(repoRoot, "config", "user.name", "Harness Test");
+    fixtureGit(repoRoot, "config", "user.email", "harness@example.test");
+    const bodyPath = "body.md";
+    writeFileSync(path.join(repoRoot, bodyPath), "base\n");
+    fixtureGit(repoRoot, "add", "--", bodyPath);
+    fixtureGit(repoRoot, "commit", "-m", "seed");
+
+    const hookMarker = path.join(repoRoot, ".git", "scoped-commit-hook-marker");
+    const hookPath = path.join(repoRoot, ".git", "hooks", "pre-commit");
+    mkdirSync(path.dirname(hookPath), { recursive: true });
+    writeFileSync(hookPath, `#!/bin/sh\nprintf 'hook-ran\\n' >> '${hookMarker}'\n`);
+    chmodSync(hookPath, 0o755);
+
+    writeFileSync(path.join(repoRoot, bodyPath), "staged\n");
+    const vcs = makeLocalVersionControlSystem();
+    vcs.add(repoRoot, { paths: [bodyPath] });
+    writeFileSync(path.join(repoRoot, bodyPath), "unstaged\n");
+    vcs.commit(repoRoot, "commit staged body", { name: "Harness Test", email: "harness@example.test" });
+
+    assert.equal(fixtureGit(repoRoot, "show", `HEAD:${bodyPath}`), "staged\n");
+    assert.equal(readFileSync(path.join(repoRoot, bodyPath), "utf8"), "unstaged\n");
+    assert.equal(fixtureGit(repoRoot, "status", "--porcelain", "--", bodyPath).trim(), "M body.md");
+    assert.equal(readFileSync(hookMarker, "utf8"), "hook-ran\n");
+
+    const deletedPath = "deleted.md";
+    writeFileSync(path.join(repoRoot, deletedPath), "delete me\n");
+    fixtureGit(repoRoot, "add", "--", deletedPath);
+    fixtureGit(repoRoot, "commit", "-m", "add deletion fixture");
+    rmSync(path.join(repoRoot, deletedPath));
+    vcs.add(repoRoot, { paths: [deletedPath] });
+    vcs.commit(repoRoot, "commit deletion", { name: "Harness Test", email: "harness@example.test" });
+    assert.throws(() => fixtureGit(repoRoot, "show", `HEAD:${deletedPath}`));
+    assert.equal(fixtureGit(repoRoot, "status", "--porcelain", "--", deletedPath), "");
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
# English

## Summary

Round 4 — the final two members of the per-write O(cumulative state) family, both located by round 3's production decomposition inside the kernel write-coordination surface:

- **Per-write full authored-source fingerprint** (production request `552:7`: `captureAuthoredProjectionFingerprint` at 4,356.76 ms per governed write): coordinator/materializer now share a repository/layout/generation-scoped trusted fingerprint. Cold start performs one complete baseline behind HEAD/worktree fences; a successful touched-path incremental projection advances the trusted hash; any incremental verification mismatch fails closed into a full rebuild. New tests assert zero `statSignature` calls on clean reuse and hash change + full recapture on explicit dirt; the existing invariant that incremental projection must equal a fresh full result exactly is untouched.
- **Double cold-index Git refresh on session/evidence publication** (production-shaped probe ~3.7–5.0 s; 26.7k-path index refresh dominated): new scoped-index commit builds a temporary alternate index (HEAD tree with entries marked index-only, then only the staged entries), and still runs a plain `git commit` — existing hooks, merge proof, and authority/publication/evidence durability semantics unchanged. Every uncertain shape (staged-path enumeration failure, unmerged entries, worktree/staged mismatch, unsupported modes) falls back to the native commit; the temporary index is cleaned in `finally` and the original index is realigned via `read-tree HEAD`.

Production-scale fixture (26,612 files / 150.6 MiB / 3,179 shards / 24,000 commits / invalidated index stats): five-phase decomposition sum **8,304.54 ms → 3,000.86 ms**; evidence commit after HEAD advance + invalid index **3,701.88 ms → 443.79 ms (8.34×)**. These are synthetic phase sums, not a production wall-clock claim — production re-measurement happens after deployment using the round-3 parent telemetry spans.

Not changed: the 30,000 ms deadline, lock ordering, authority/publication/merge-proof/evidence durability, orphan `PROCEEDING`. The concurrency failure-path seven-questions audit is in the task report.

## What Changed

- `packages/kernel/src/projection/projection-source-baseline.ts` (new): generation-scoped trusted fingerprint cache with HEAD/worktree fences and fail-closed rebuild.
- `packages/kernel/src/persistence/git/scoped-index-commit.ts` (new) + `local-version-control-system.ts`: alternate-index commit with native fallback on any uncertainty.
- `packages/kernel/src/write-coordination/{journal/coordinator.ts,journal/publication/projection.ts,materialization/ledger-materializer.ts}`: consume the shared baseline; capture previous fingerprint before apply/commit; remember only after successful projection update.
- Tests: trusted-fingerprint lifecycle (cold → reuse → dirty), scoped-index hooks/staged/deletion semantics, existing exact-equality incremental assertions retained.

## Task And Scope

- Harness task: `task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- Branch: `codex/write-cost-round4`
- Public scope: `packages/kernel/src/{projection,persistence/git,write-coordination}/**` and tests
- Private planning/evidence updated: yes (task package `artifacts/residual-round-4.md`)
- Out of scope: CLI core / daemon authority production surfaces (untouched); production deployment (follows merge); index-mutating custom hooks (flagged as needing separate qualification; this repository's hooks are post-commit build hooks).

## Version Impact

- Version: no version change because this is an unreleased surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `bd70a5212137ce9acb4fce735ac74603c307dada`
- Branch merge-base with `origin/main`: `bd70a5212137ce9acb4fce735ac74603c307dada`
- Last `git fetch origin` time: immediately before opening this PR
- Sync method: rebase onto `origin/main` (clean), `check:local` rerun green after rebase
- Public diff command: `git diff origin/main...codex/write-cost-round4`
- Private evidence commit/path: task package `artifacts/residual-round-4.md` (decomposition, positive controls, seven-questions audit)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending, linked once the run completes
- [x] `git diff --check`
- [x] `npm run check:local` — green post-rebase (27 manifest gates; pre-rebase: kernel affected fast 76/76, affected contract 93/93)
- [x] Targeted tests for the change surface, named with their counts: kernel targeted set 18/18; full `--tier integration` (pre-rebase base): 1,463 tests, 1,459 pass, 0 fail, 4 platform skips; in-suite latency control localP95 478.08 ms / writeP95 1,357.49 ms
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending
- Not run, and why: full integration tier not rerun post-rebase (clean rebase; authoritative in CI). An architecture-check advisory probe returned `script_result_failed` with no receipt and is recorded as unverified, not used as evidence.

## Review Evidence

- Self-review: CEO verified the scoped-index commit's fallback ladder (four checkpoints, each anomaly → native commit; worktree-match precondition; `finally` cleanup; original index realigned) and that trusted-fingerprint promotion happens only after successful projection update.
- Reviewer subagent: implementation by Codex worker (gpt-5.6-luna, max effort, model verified via session jsonl); report answers the concurrency seven questions and refuses to claim production acceptance before deployment telemetry.
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The trusted generation is an in-process cache guarded by governed-write locks and downstream exact verification; external authored edits outside the coordinator re-establish the baseline via invalidation/restart — the cache is not a source of truth.
- Custom hooks that mutate the index during commit and expect extra staged entries to survive are not qualified for the scoped-index path (native fallback covers unsupported shapes; this repo has no such hooks).
- Production reduction of the 4.36 s fingerprint and 3.7–5 s Git tail is projected, not yet measured live; post-deploy read-only verification with `repo-write-dispatch`/`repo-write-child`/`repo-write-recovery` spans is the next step and gates the family's closeout.

## References

- Task: `task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- Evidence: task package `artifacts/residual-round-4.md`
- Review: same task package

---

# 中文

## 概要

第四轮——「每写 O(累积状态)」缺陷族的最后两个成员，均由 round-3 的生产分解定位在 kernel write-coordination 面内：

- **每写全量 authored source fingerprint**（生产请求 `552:7`：`captureAuthoredProjectionFingerprint` 每条治理写 4,356.76 ms）：coordinator/materializer 现共享 repository/layout/generation 级可信 fingerprint。冷启动在 HEAD/worktree fence 保护下做一次完整 baseline；touched-path 增量 projection 成功后推进可信 hash；增量校验不一致一律 fail-closed 回退全量 rebuild。新测试断言 clean 复用时 `statSignature` 零调用、显式弄脏后 hash 变化并重新全量捕获；「增量 projection 必须与全量结果精确相等」的既有不变量原样保留。
- **session/evidence 发布的双重冷 index 刷新**（生产形态探针 ~3.7–5.0s；26.7k 路径 index refresh 主导）：新增 scoped-index commit——用临时 alternate index（HEAD 树条目标记 index-only，仅放入 staged 条目），仍执行普通 `git commit`——既有 hooks、merge proof、authority/publication/evidence durability 语义不变。任何不确定形态（staged 枚举失败、unmerged、worktree/staged 不一致、不支持的 mode）回退原生 commit；临时 index 在 `finally` 清理，原 index 用 `read-tree HEAD` 对齐。

生产规模 fixture（26,612 文件 / 150.6 MiB / 3,179 shards / 24,000 commits / 故意失效 index stats）：五阶段分解和 **8,304.54 ms → 3,000.86 ms**；HEAD 前进+失效 index 后的 evidence commit **3,701.88 ms → 443.79 ms（8.34×）**。这些是合成阶段和，不是生产 wall 宣称——生产复测在部署后用 round-3 的父侧遥测段进行。

未动的：30,000 ms deadline、锁顺序、authority/publication/merge proof/evidence durability、孤儿 `PROCEEDING`。并发失败路径七问审计在任务报告内。

## 改动内容

- `packages/kernel/src/projection/projection-source-baseline.ts`（新增）：generation 级可信 fingerprint cache，带 HEAD/worktree fence 与 fail-closed rebuild。
- `packages/kernel/src/persistence/git/scoped-index-commit.ts`（新增）+ `local-version-control-system.ts`：alternate-index commit，任何不确定即原生回退。
- `packages/kernel/src/write-coordination/{journal/coordinator.ts,journal/publication/projection.ts,materialization/ledger-materializer.ts}`：消费共享 baseline；apply/commit 前捕获前值；仅在 projection 更新成功后 remember。
- 测试：可信 fingerprint 生命周期（冷→复用→弄脏）、scoped-index 的 hooks/staged/删除语义、既有增量精确相等断言保留。

## 任务与范围

- Harness 任务：`task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- 分支：`codex/write-cost-round4`
- 公开范围：`packages/kernel/src/{projection,persistence/git,write-coordination}/**` 及测试
- 私有计划 / 证据是否已更新：yes（任务包 `artifacts/residual-round-4.md`）
- 范围外：CLI core / daemon authority production 面（零触碰）；生产部署（合并后进行）；会改 index 的定制 hook（标注需单独 qualification；本仓 hooks 为 post-commit build 类）。

## 版本影响

- 版本：不改版本，原因是这是未发布面
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`bd70a5212137ce9acb4fce735ac74603c307dada`
- 当前分支与 `origin/main` 的 merge-base：`bd70a5212137ce9acb4fce735ac74603c307dada`
- 最近一次 `git fetch origin` 时间：开 PR 前即时执行
- 同步方式：rebase 到 `origin/main`（干净），rebase 后 `check:local` 复跑绿
- 公开 diff 命令：`git diff origin/main...codex/write-cost-round4`
- 私有证据 commit/path：任务包 `artifacts/residual-round-4.md`（分解表、阳性对照、七问审计）
- Reviewer 证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：待 run 完成后补链接
- [x] `git diff --check`
- [x] `npm run check:local` —— rebase 后全绿（27 门；rebase 前：kernel 受影响 fast 76/76、contract 93/93）
- [x] 改动面的定向测试，写明测试名与通过数：kernel 定向集 18/18；完整 `--tier integration`（rebase 前基线）：1,463 tests、1,459 过、0 败、4 平台跳过；套内延迟对照 localP95 478.08ms / writeP95 1,357.49ms
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）—— 待跑
- 未跑项及原因：rebase 后未重跑完整 integration tier（rebase 干净；CI 权威执行）。一次 architecture-check advisory 探针返回 `script_result_failed` 且无 receipt，按未验证记录、不作证据。

## 审查证据

- 自查：CEO 核验 scoped-index commit 的回退阶梯（四个检查点任一异常→原生 commit；worktree 匹配前置；`finally` 清理；原 index 对齐）与「可信 fingerprint 仅在 projection 更新成功后提升」。
- Reviewer subagent：Codex worker（gpt-5.6-luna，max effort，session jsonl 核实）；报告答齐并发七问，并拒绝在部署遥测前宣称生产验收。
- 人工审查：待办
- 阻塞发现：无 open

## 残余风险

- 可信 generation 是进程内 cache，由治理写锁与下游精确校验护卫；coordinator 之外的外部 authored 编辑经 invalidation/restart 重建 baseline——cache 不是 SoT。
- commit 期间改 index 并期望额外 staged 条目保留的定制 hook 未 qualification（原生回退覆盖不支持形态；本仓无此类 hook）。
- 4.36s fingerprint 与 3.7–5s Git 尾巴的生产下降是推算、未线上实测；部署后用 `repo-write-dispatch`/`repo-write-child`/`repo-write-recovery` 段只读复测是下一步，也是本族收口的门。

## 关联材料

- 任务：`task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- 证据：任务包 `artifacts/residual-round-4.md`
- 审查：同一任务包
