### PR TITLE
fix(kernel): advance write-cost caches across governed commits (round 5: ancestor-chain trusted fingerprint + replica ancestor cache)

### DIFF
--- a/packages/daemon/src/authority/replication-content-store.ts
+++ b/packages/daemon/src/authority/replication-content-store.ts
@@ -109,17 +109,45 @@ export function createAuthorityReplicationContentStore(input: {
   ): ReadonlyArray<AuthoritySnapshotManifestEntry> {
     const cached = cache.get(commitSha);
     if (cached) return structuredClone(cached);
-    const entries = previous
+    const cachedAncestor = previous ? undefined : findCachedAncestor(commitSha);
+    const base = previous ?? cachedAncestor;
+    const entries = base
       ? readGitEntriesIncrementally(
           input.gitRoot,
-          previous.commitSha,
+          base.commitSha,
           commitSha,
-          previous.entries,
+          base.entries,
           storeBlob
         )
       : readGitEntries(input.gitRoot, commitSha, storeBlob);
     cache.set(commitSha, entries);
     return structuredClone(entries);
+  }
+
+  function findCachedAncestor(commitSha: string): {
+    readonly commitSha: string;
+    readonly entries: ReadonlyArray<AuthoritySnapshotManifestEntry>;
+  } | undefined {
+    // The latest prewarmed snapshot is normally the nearest useful base. Walk
+    // newest-to-oldest so a restart that prewarmed only the last published
+    // canonical commit does not turn the following evidence descendant into a
+    // full tree read. A non-ancestor is never used: branch forks must retain
+    // the existing fail-closed full snapshot path.
+    for (const [cachedCommit, entries] of [...cache.entries()].reverse()) {
+      if (cachedCommit === commitSha || isCommitAncestor(cachedCommit, commitSha)) {
+        return { commitSha: cachedCommit, entries };
+      }
+    }
+    return undefined;
+  }
+
+  function isCommitAncestor(before: string, after: string): boolean {
+    try {
+      readAuthorityGitBytes(input.gitRoot, "merge-base", "--is-ancestor", before, after);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   function storeBlob(bytes: Uint8Array): Sha256Digest {

--- a/packages/daemon/test/replication-content-history-path.test.ts
+++ b/packages/daemon/test/replication-content-history-path.test.ts
@@ -96,6 +96,46 @@ test("historical operation lookup hydrates an incomplete replica change containi
   }
 });
 
+test("replica content walks a cached ancestor across an evidence descendant", () => {
+  const fixture = createFixture();
+  try {
+    writeFileSync(path.join(fixture.gitRoot, "seed.md"), "seed\n");
+    git(fixture.gitRoot, "add", ".");
+    git(fixture.gitRoot, "commit", "-m", "seed");
+    const cachedCommit = git(fixture.gitRoot, "rev-parse", "HEAD");
+    fixture.content.snapshot(cachedCommit, 0);
+
+    writeFileSync(path.join(fixture.gitRoot, "evidence.json"), "{\"op\":1}\n");
+    git(fixture.gitRoot, "add", ".");
+    git(fixture.gitRoot, "commit", "-m", "evidence descendant");
+    const previousCommit = git(fixture.gitRoot, "rev-parse", "HEAD");
+
+    writeFileSync(path.join(fixture.gitRoot, "current.md"), "current\n");
+    git(fixture.gitRoot, "add", ".");
+    git(fixture.gitRoot, "commit", "-m", "current publication");
+    const commitSha = git(fixture.gitRoot, "rev-parse", "HEAD");
+
+    const change = fixture.content.describeChange({
+      schema: "replica-change/v1",
+      workspaceId: "workspace-read-down",
+      revision: 1,
+      opId: "op-ancestor-chain",
+      semanticDigest: "aa".repeat(32),
+      commitSha,
+      previousCommit,
+      changedAt: "2026-08-04T00:00:00.000Z"
+    });
+    assert.deepEqual(change.paths.map((entry) => entry.path), ["current.md"]);
+    assert.deepEqual(fixture.content.snapshot(commitSha, 1).entries.map((entry) => entry.path), [
+      "current.md",
+      "evidence.json",
+      "seed.md"
+    ]);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
 test("read-down retains ASCII component-collision detection", () => {
   assertPathCollision(["A/x.md", "a/y.md"]);
 });

--- a/packages/kernel/src/projection/projection-source-baseline.ts
+++ b/packages/kernel/src/projection/projection-source-baseline.ts
@@ -3,6 +3,7 @@ import type { HarnessLayoutInput } from "../layout/index.ts";
 import { resolveHarnessLayout } from "../layout/index.ts";
 import type { VersionControlSystem } from "../ports/version-control-system.ts";
 import { readDeclaredSourceManifestRows } from "./sqlite-declared-source-manifest.ts";
+import { updateTaskProjectionIncrementally } from "./sqlite-task-incremental-projection.ts";
 import { captureProjectionSourceFingerprint } from "./projection-source-snapshot.ts";
 
 interface TrustedProjectionFingerprint {
@@ -30,7 +31,9 @@ export function captureAuthoredProjectionFingerprint(rootInput: HarnessLayoutInp
  * pays for a full source capture once and later publications advance it from
  * their touched paths. A cold cache gets a Git HEAD plus scoped worktree fence;
  * a successful projection update promotes the same generation to a verified
- * cache entry, so later calls do not refresh the whole index. The incremental
+ * cache entry, so later calls do not refresh the whole index. If HEAD has
+ * advanced through a known ancestor chain, the persisted projection is
+ * advanced from the changed paths before the cache is reused. The incremental
  * updater still verifies the touched generation and falls back to a full
  * rebuild on any mismatch.
  */
@@ -50,6 +53,17 @@ export function captureTrustedAuthoredProjectionFingerprint(
     if (cached.worktreeVerified || authoredWorktreeIsClean(vcs, resolvedRepoRoot, layout.authoredRoot)) {
       return cached.fingerprint;
     }
+  }
+  if (cached && authoredWorktreeIsClean(vcs, resolvedRepoRoot, layout.authoredRoot)) {
+    const advanced = advanceTrustedProjectionFingerprint(
+      rootInput,
+      layout,
+      vcs,
+      resolvedRepoRoot,
+      cached,
+      head
+    );
+    if (advanced) return advanced;
   }
 
   const fingerprint = captureAuthoredProjectionFingerprint(rootInput);
@@ -103,4 +117,42 @@ function authoredWorktreeIsClean(vcs: VersionControlSystem, repoRoot: string, au
   } catch {
     return false;
   }
+}
+
+function advanceTrustedProjectionFingerprint(
+  rootInput: HarnessLayoutInput,
+  layout: ReturnType<typeof resolveHarnessLayout>,
+  vcs: VersionControlSystem,
+  repoRoot: string,
+  cached: TrustedProjectionFingerprint,
+  head: string
+): string | undefined {
+  if (cached.head === head) return cached.fingerprint;
+  if (!vcs.resolveCommit(repoRoot, cached.head).ok) return undefined;
+
+  let changedPaths: ReadonlyArray<string>;
+  try {
+    changedPaths = vcs.changedFilesBetween(repoRoot, cached.head, head);
+  } catch {
+    return undefined;
+  }
+
+  const result = updateTaskProjectionIncrementally({
+    rootDir: layout.rootDir,
+    ...(typeof rootInput === "object" && rootInput.layoutOverrides
+      ? { layoutOverrides: rootInput.layoutOverrides }
+      : {}),
+    projectionPath: layout.projectionPath,
+    touchedPaths: changedPaths.map((relativePath) => path.resolve(repoRoot, relativePath)),
+    previousSourceFingerprint: cached.fingerprint
+  });
+  if (!result.sourceHash || vcs.currentHead(repoRoot) !== head) return undefined;
+
+  const key = trustedProjectionFingerprintKey(repoRoot, layout.authoredRoot, layout.projectionPath);
+  trustedProjectionFingerprints.set(key, {
+    head,
+    fingerprint: result.sourceHash,
+    worktreeVerified: true
+  });
+  return result.sourceHash;
 }

--- a/packages/kernel/test/store/ledger-materializer.test.ts
+++ b/packages/kernel/test/store/ledger-materializer.test.ts
@@ -12,11 +12,13 @@ import { authorityBatchTrailerName, buildAuthorityBatchIntegrity } from "../../s
 import { localProjectionSourceFileSystem } from "../../src/local/local-layout-file-system.ts";
 import { makeLocalVersionControlSystem } from "../../src/persistence/git/local-version-control-system.ts";
 import {
+  captureAuthoredProjectionFingerprint,
   captureTrustedAuthoredProjectionFingerprint,
   invalidateTrustedAuthoredProjectionFingerprint,
   rememberTrustedAuthoredProjectionFingerprint
 } from "../../src/projection/projection-source-baseline.ts";
 import { readAttributionProjection } from "../../src/projection/sqlite-attribution-projection.ts";
+import { rebuildTaskProjection } from "../../src/projection/sqlite-task-projection.ts";
 import { docWrite, withTempStore } from "./helpers.ts";
 
 test("WriteCoordinator commits session-routed writes to a session branch", () => {
@@ -142,6 +144,50 @@ test("trusted generation fingerprint reuses clean state and fails closed on dirt
     }
     assert.notEqual(dirty, first);
     assert.ok(dirtyFallbackStats > 0);
+  });
+});
+
+test("trusted generation fingerprint advances across a clean descendant HEAD with touched-path parity", () => {
+  withTempStore((rootDir) => {
+    initAuthoredGit(rootDir);
+    const taskRoot = path.join(rootDir, "harness/tasks/task-baseline");
+    mkdirSync(taskRoot, { recursive: true });
+    writeFileSync(path.join(taskRoot, "INDEX.md"), [
+      "---",
+      "schema: task-package/v2",
+      "task_id: task-baseline",
+      "title: Baseline",
+      "status: active",
+      "packageDisposition: active",
+      "---",
+      ""
+    ].join("\n"), "utf8");
+    git(rootDir, "add", "--", "tasks/task-baseline/INDEX.md");
+    git(rootDir, "commit", "-m", "seed descendant fingerprint baseline");
+    rebuildTaskProjection({ rootDir });
+
+    const vcs = makeLocalVersionControlSystem();
+    const first = captureTrustedAuthoredProjectionFingerprint(rootDir, vcs);
+    writeFileSync(
+      path.join(taskRoot, "INDEX.md"),
+      readFileSync(path.join(taskRoot, "INDEX.md"), "utf8").replace("title: Baseline", "title: Descendant"),
+      "utf8"
+    );
+    git(rootDir, "add", "--", "tasks/task-baseline/INDEX.md");
+    git(rootDir, "commit", "-m", "authority evidence descendant");
+    const expected = captureAuthoredProjectionFingerprint(rootDir);
+
+    let changedBetweenCalls = 0;
+    const descendantVcs = {
+      ...vcs,
+      changedFilesBetween: (repo: string, before: string, after: string) => {
+        changedBetweenCalls += 1;
+        return vcs.changedFilesBetween(repo, before, after);
+      }
+    };
+    assert.equal(captureTrustedAuthoredProjectionFingerprint(rootDir, descendantVcs), expected);
+    assert.equal(changedBetweenCalls, 1);
+    assert.notEqual(expected, first);
   });
 });
 

--- a/tools/perf/residual-write-cost-fixture.mjs
+++ b/tools/perf/residual-write-cost-fixture.mjs
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import {
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   utimesSync,
   writeFileSync
@@ -16,7 +17,12 @@ import {
   physicalChangeSetDigestV2,
   semanticMutationSetDigestV2
 } from "@harness-anything/kernel";
-import { captureAuthoredProjectionFingerprint } from "../../packages/kernel/src/projection/projection-source-baseline.ts";
+import {
+  captureAuthoredProjectionFingerprint,
+  captureTrustedAuthoredProjectionFingerprint
+} from "../../packages/kernel/src/projection/projection-source-baseline.ts";
+import { makeLocalVersionControlSystem } from "../../packages/kernel/src/persistence/git/local-version-control-system.ts";
+import { rebuildTaskProjection } from "../../packages/kernel/src/projection/sqlite-task-projection.ts";
 import { createAuthorityReplicationContentStore } from "../../packages/daemon/src/authority/replication-content-store.ts";
 import { createGitAuthorityAttributionEvidenceCommitterV2 } from "../../packages/daemon/src/authority/production/publication-evidence.ts";
 
@@ -51,6 +57,55 @@ try {
   await evidenceCommitter.commitPending(previousCommit);
 
   const fingerprintMs = measure(() => captureAuthoredProjectionFingerprint(root));
+  const projectionRebuildMs = measure(() => rebuildTaskProjection({ rootDir: root }));
+  const trustedVcs = makeLocalVersionControlSystem();
+  const trustedFingerprintColdMs = measure(() => captureTrustedAuthoredProjectionFingerprint(root, trustedVcs));
+  const trustedFingerprintWrites = [];
+  for (let writeIndex = 1; writeIndex <= 2; writeIndex += 1) {
+    const taskIndexPath = path.join(authoredRoot, authoredPaths[0]);
+    writeFileSync(
+      taskIndexPath,
+      readFileSync(taskIndexPath, "utf8").replace(/^title:.*$/mu, `title: Synthetic governance write ${writeIndex}`),
+      "utf8"
+    );
+    git("add", authoredPaths[0]);
+    const canonicalCommitStartedAt = performance.now();
+    git("commit", "-q", "-m", `synthetic governance write ${writeIndex}`);
+    const canonicalCommitMs = performance.now() - canonicalCommitStartedAt;
+    const canonicalCommit = git("rev-parse", "HEAD");
+    const canonicalTrustedStartedAt = performance.now();
+    const canonicalTrustedFingerprint = captureTrustedAuthoredProjectionFingerprint(root, trustedVcs);
+    const canonicalTrustedMs = performance.now() - canonicalTrustedStartedAt;
+    const canonicalFullStartedAt = performance.now();
+    const canonicalFullFingerprint = captureAuthoredProjectionFingerprint(root);
+    const canonicalFullMs = performance.now() - canonicalFullStartedAt;
+    if (canonicalTrustedFingerprint !== canonicalFullFingerprint) {
+      throw new Error(`trusted fingerprint mismatch after canonical write ${writeIndex}`);
+    }
+
+    evidenceLog.ensure(v2Event(`op-round5-${String(writeIndex).padStart(2, "0")}`, evidenceShardCount + writeIndex));
+    const evidenceCommitStartedAt = performance.now();
+    await evidenceCommitter.commitPending(canonicalCommit);
+    const evidenceCommitMs = performance.now() - evidenceCommitStartedAt;
+    const evidenceTrustedStartedAt = performance.now();
+    const evidenceTrustedFingerprint = captureTrustedAuthoredProjectionFingerprint(root, trustedVcs);
+    const evidenceTrustedMs = performance.now() - evidenceTrustedStartedAt;
+    const evidenceFullStartedAt = performance.now();
+    const evidenceFullFingerprint = captureAuthoredProjectionFingerprint(root);
+    const evidenceFullMs = performance.now() - evidenceFullStartedAt;
+    if (evidenceTrustedFingerprint !== evidenceFullFingerprint) {
+      throw new Error(`trusted fingerprint mismatch after evidence write ${writeIndex}`);
+    }
+    trustedFingerprintWrites.push({
+      writeIndex,
+      canonicalCommitMs,
+      canonicalTrustedMs,
+      canonicalFullMs,
+      evidenceCommitMs,
+      evidenceTrustedMs,
+      evidenceFullMs
+    });
+  }
   const values = new Map();
   const state = {
     get: (key) => values.get(key),
@@ -66,6 +121,7 @@ try {
   replication.snapshot(previousCommit, 1);
 
   const changedRelativePath = authoredPaths.at(-1);
+  const replicationPreviousCommit = git("rev-parse", "HEAD");
   writeAuthoredFile(changedRelativePath, authoredFileCount + 1, "# Changed synthetic payload\n");
   git("add", changedRelativePath);
   git("commit", "-q", "-m", "synthetic one-file change");
@@ -77,7 +133,7 @@ try {
     opId: "op-current",
     semanticDigest: "55".repeat(32),
     commitSha: canonicalCommit,
-    previousCommit,
+    previousCommit: replicationPreviousCommit,
     changedAt: "2026-08-03T00:00:00.000Z"
   }));
   const evidenceVerifyMs = measure(() => evidenceLog.verifyIntegrity());
@@ -101,10 +157,13 @@ try {
     },
     phasesMs: {
       projectionFingerprint: fingerprintMs,
+      projectionRebuild: projectionRebuildMs,
+      trustedFingerprintCold: trustedFingerprintColdMs,
       replicationDescribeOneFileChange: replicationMs,
       evidenceHistoryVerify: evidenceVerifyMs,
       evidencePendingShardVerify: pendingVerifyMs,
-      evidenceCommitAfterHeadAdvanceAndInvalidatedIndex: evidenceCommitMs
+      evidenceCommitAfterHeadAdvanceAndInvalidatedIndex: evidenceCommitMs,
+      trustedFingerprintWrites
     }
   }, null, 2));
 } finally {


### PR DESCRIPTION
# English

## Summary

Round 5 of the write-cost line. After deploying #1209, production telemetry showed the fingerprint block unchanged at ~4.37 s per warm write — round 4's trusted generation never hit in production. Root cause, proven by direct measurement: the trusted cache used **HEAD equality** as its fence, but every governed write itself advances HEAD by 2–3 ledger commits (materializer merge, attribution evidence), so the next write always sees a descendant HEAD and falls back to a full source capture. A fixture probe that advances HEAD with a no-content commit reproduced it exactly: same source, 5,078 stat calls on recapture. The single-HEAD fixture shape used in round 4 was structurally unable to detect this; the fixture now performs two consecutive governed writes that each advance HEAD.

Fixes (all fail-closed):

- **Trusted fingerprint across descendant HEADs** (`projection-source-baseline.ts`): if the cached HEAD is an ancestor of the current HEAD, catch up via `changedFilesBetween` → incremental projection update; remember only if the incremental hash equals the full-capture definition and HEAD is unchanged after the update (double fence). Ancestor unprovable, dirty worktree, incremental failure, or mid-flight HEAD movement all fall back to the existing full path. Fixture positive control: two consecutive HEAD-advancing writes, trusted capture 315–339 ms (canonical) with exact hash parity against full reference — no more unconditional 4.36 s recapture.
- **Replica content ancestor cache** (`replication-content-store.ts`): exact-key miss now searches newest-to-oldest for a cached Git ancestor (`merge-base --is-ancestor`) and derives incrementally from it; forked or unprovable ancestry keeps the full snapshot path. Cold describe 1,743.5 ms → 233.9 ms across an evidence-descendant gap, snapshot entries exactly equal to the Git tree.
- **Flush path verified, not re-modified**: `options.publish()` → `commitTouchedPaths` → `commitWithScopedIndex` is already wired (direct scoped commit ~224 ms at 26.7k paths); no semantic surface was touched twice. The remaining production flush wall gets re-attributed after this deploys.

Not changed: 30 s deadline, authority/publication/durability semantics, hooks/merge proof, orphan `PROCEEDING`. Concurrency seven-questions audit in the task report. Production single-digit acceptance is still gated on post-deploy telemetry — this PR does not claim it.

## What Changed

- `packages/kernel/src/projection/projection-source-baseline.ts`: ancestor-chain incremental catch-up with hash-parity and HEAD-stability double fence.
- `packages/daemon/src/authority/replication-content-store.ts`: nearest-ancestor snapshot reuse on exact miss.
- Tests: `ledger-materializer.test.ts` (+ descendant-HEAD/touched-path/full-parity cases, 9/9), `replication-content-history-path.test.ts` (new, 6/6).
- `tools/perf/residual-write-cost-fixture.mjs`: consecutive HEAD-advancing governed writes as the standing positive-control shape.

## Task And Scope

- Harness task: `task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- Branch: `codex/write-cost-round5`
- Public scope: `packages/kernel/src/projection/**`, `packages/daemon/src/authority/replication-content-store.ts`, `tools/perf/**` and tests
- Private planning/evidence updated: yes (task package `artifacts/residual-round-5.md`)
- Out of scope: CLI core / daemon authority production surfaces; production deployment (follows merge); further flush/replica attribution (data-gated on this deploy).

## Version Impact

- Version: no version change because this is an unreleased surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `d07b67aa8a531549fb81f66f071e29f7ac1ab55a`
- Branch merge-base with `origin/main`: `d07b67aa8a531549fb81f66f071e29f7ac1ab55a`
- Last `git fetch origin` time: immediately before opening this PR
- Sync method: none needed (main has not moved since branch creation)
- Public diff command: `git diff origin/main...codex/write-cost-round5`
- Private evidence commit/path: task package `artifacts/residual-round-5.md`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending, linked once the run completes
- [x] `git diff --check`
- [x] `npm run check:local` — green (27 manifest gates, affected fast/contract green)
- [x] Targeted tests for the change surface, named with their counts: `ledger-materializer.test.ts` 9/9, `replication-content-history-path.test.ts` 6/6; full `--tier integration`: 1,468 tests, 1,464 pass, 0 fail, 4 platform skips (runner-exclusivity checked before the run)
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending
- Not run, and why: nothing skipped; the supply-chain timeout in tier output is that test's intentional bounded-timeout fixture, and the tier summary is 0 failures.

## Review Evidence

- Self-review: CEO verified the double fence (remember only on hash parity + stable HEAD), every fallback edge (unprovable ancestor, dirty worktree, incremental failure, mid-flight HEAD change → full path), and that the flush path was verified rather than re-modified.
- Reviewer subagent: implementation by Codex worker (gpt-5.6-luna, max effort, same session across rounds 4–5, model verified via jsonl); the HEAD-fence hypothesis was confirmed by measurement before any code change (checkpoint discipline).
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Trusted catch-up performs a projection update inside capture, guarded by global write coordination; all failure edges fall back to full capture.
- Replica ancestor search adds `merge-base --is-ancestor` checks on cold miss, newest-to-oldest; candidate count vs hit rate should be observed post-deploy.
- Fixture's evidence-descendant trusted path (2.30–2.63 s) suggests touched-path projection catch-up may be the next cost layer after full-capture elimination; production frames after this deploy decide whether another round is warranted.
- Production improvement is projected, not yet measured; post-deploy warm-write telemetry (fingerprint segment, replica append, full-chain wall) is the acceptance gate.

## References

- Task: `task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- Evidence: task package `artifacts/residual-round-5.md`
- Review: same task package

---

# 中文

## 概要

写路径成本线第五轮。#1209 部署后，生产遥测显示 fingerprint 块纹丝不动仍 ~4.37s/暖写——round-4 的可信 generation 在生产从未命中。根因经直接测量钉死：可信 cache 以 **HEAD 相等**为 fence，而每条治理写自身推进 HEAD 2-3 个台账提交（materializer merge、attribution evidence），下一条写必然看到 descendant HEAD、退回全量捕获。fixture 用无内容提交推进 HEAD 精确复现：同一 source，重捕 5,078 次 stat。round-4 的单 HEAD fixture 形态结构性测不出此缺陷；fixture 现改为连续两条各自推进 HEAD 的治理写。

修复（全部 fail-closed）：

- **跨 descendant HEAD 的可信 fingerprint**（`projection-source-baseline.ts`）：cached HEAD 是当前 HEAD 祖先时，经 `changedFilesBetween` → 增量 projection 追赶；仅当增量 hash 与全量定义精确相等**且**更新后 HEAD 未变（双 fence）才 remember。祖先不可证、worktree 脏、增量失败、HEAD 中途变化一律回退既有全量路径。fixture 阳性对照：连续两条推进 HEAD 的写，canonical trusted capture 315-339ms 且与全量参考 hash 精确相等——4.36s 无条件重捕消失。
- **replica content 祖先缓存**（`replication-content-store.ts`）：exact key miss 时 newest-to-oldest 找已缓存的 Git 祖先（`merge-base --is-ancestor`）增量派生；分叉或祖先不可证保持全量快照。跨 evidence descendant 的冷 describe 1,743.5ms → 233.9ms，snapshot entries 与 Git tree 精确一致。
- **flush 路径核实而非重改**：`options.publish()` → `commitTouchedPaths` → `commitWithScopedIndex` 已接通（26.7k 路径下直接 scoped commit ~224ms）；未对语义面二次动刀。生产剩余 flush wall 待本轮部署后重新归因。

未动的：30s deadline、authority/publication/durability 语义、hooks/merge proof、孤儿 `PROCEEDING`。并发七问在任务报告。生产个位数秒验收仍以部署后遥测为门——本 PR 不宣称。

## 改动内容

- `packages/kernel/src/projection/projection-source-baseline.ts`：祖先链增量追赶 + hash 相等/HEAD 稳定双 fence。
- `packages/daemon/src/authority/replication-content-store.ts`：exact miss 时最近祖先快照复用。
- 测试：`ledger-materializer.test.ts`（新增 descendant-HEAD/touched-path/全量相等用例，9/9）、`replication-content-history-path.test.ts`（新增，6/6）。
- `tools/perf/residual-write-cost-fixture.mjs`：连续推进 HEAD 的治理写成为常设阳性对照形态。

## 任务与范围

- Harness 任务：`task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- 分支：`codex/write-cost-round5`
- 公开范围：`packages/kernel/src/projection/**`、`packages/daemon/src/authority/replication-content-store.ts`、`tools/perf/**` 及测试
- 私有计划 / 证据是否已更新：yes（任务包 `artifacts/residual-round-5.md`）
- 范围外：CLI core / daemon authority production 面；生产部署（合并后进行）；进一步 flush/replica 归因（以本轮部署数据为门）。

## 版本影响

- 版本：不改版本，原因是这是未发布面
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`d07b67aa8a531549fb81f66f071e29f7ac1ab55a`
- 当前分支与 `origin/main` 的 merge-base：`d07b67aa8a531549fb81f66f071e29f7ac1ab55a`
- 最近一次 `git fetch origin` 时间：开 PR 前即时执行
- 同步方式：不需要（分支创建后 main 未前进）
- 公开 diff 命令：`git diff origin/main...codex/write-cost-round5`
- 私有证据 commit/path：任务包 `artifacts/residual-round-5.md`
- Reviewer 证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：待 run 完成后补链接
- [x] `git diff --check`
- [x] `npm run check:local` —— 全绿（27 门，受影响 fast/contract 绿）
- [x] 改动面的定向测试，写明测试名与通过数：`ledger-materializer.test.ts` 9/9、`replication-content-history-path.test.ts` 6/6；完整 `--tier integration`：1,468 tests、1,464 过、0 败、4 平台跳过（跑前核查过 runner 独占）
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）—— 待跑
- 未跑项及原因：无跳过项；tier 输出中的 supply-chain timeout 是该测试有意注入的有界超时 fixture，tier 汇总 0 失败。

## 审查证据

- 自查：CEO 核验双 fence（hash 相等+HEAD 稳定才 remember）、全部回退边（祖先不可证/脏树/增量失败/HEAD 中途变→全量）、以及 flush 路径是核实而非二次改动。
- Reviewer subagent：Codex worker（gpt-5.6-luna，max effort，round 4-5 同 session，jsonl 核实）；HEAD-fence 假设在改代码前先由测量证实（Checkpoint 纪律）。
- 人工审查：待办
- 阻塞发现：无 open

## 残余风险

- trusted 追赶在 capture 内做一次 projection 更新，由全局写协调护卫；全部失败边回退全量。
- replica 祖先搜索在冷 miss 增加 `merge-base --is-ancestor` 检查；候选数与命中率部署后观测。
- fixture 的 evidence-descendant trusted 路径（2.30-2.63s）提示全量捕获消灭后 touched-path 追赶可能是下一层成本；是否再来一轮由部署后生产帧决定。
- 生产改善是推算未实测；部署后暖写遥测（fingerprint 段/replica append/全链 wall）是验收门。

## 关联材料

- 任务：`task_01KZ3DCGW7K0XEY69Z47J1AEA8`
- 证据：任务包 `artifacts/residual-round-5.md`
- 审查：同一任务包
