### PR TITLE
feat(daemon): instrument residual repo-write cost windows (round 6: materializer/evidence/child-shutdown telemetry spans)

### DIFF
--- a/packages/application/src/authority/service-options.ts
+++ b/packages/application/src/authority/service-options.ts
@@ -50,7 +50,10 @@ export type AuthoritySubmissionTelemetryPhase =
   | "authority-coordinator-enqueue"
   | "authority-coordinator-enqueued"
   | "authority-prepared-persisted"
-  | "authority-flush-start";
+  | "authority-flush-start"
+  | "authority-event-published"
+  | "authority-terminal-record-start"
+  | "authority-terminal-record-persisted";
 
 export interface AuthoritySubmissionV2Options {
   readonly schemaTuple: ProtocolSchemaTupleV2;

--- a/packages/application/src/authority/service.ts
+++ b/packages/application/src/authority/service.ts
@@ -466,8 +466,10 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
               actorAxesBinding: entry.actorAxesBinding!,
               occurredAt: change.changedAt
             });
+            options.onTelemetry?.("authority-event-published");
           }
           await options.generationFenceWitness?.assertHeld("before-terminal-visibility", entry);
+          options.onTelemetry?.("authority-terminal-record-start");
           await put(
             entry,
             entry.semanticDigest,
@@ -480,6 +482,7 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
             entry.recoveryPublicationPolicy,
             entry.fixedOperationBinding
           );
+          options.onTelemetry?.("authority-terminal-record-persisted");
           return receipt;
         };
         receipt = options.generationFenceWitness

--- a/packages/daemon/src/authority/production/production-authority-lifecycle.ts
+++ b/packages/daemon/src/authority/production/production-authority-lifecycle.ts
@@ -174,13 +174,15 @@ export function createProductionAuthorityLifecycle(input: {
         rootDir: repo.canonicalRoot,
         ...(input.layoutOverrides ? { layoutOverrides: input.layoutOverrides } : {})
       });
+      const commitEvidence = async (canonicalCommitSha: string): Promise<void> => {
+        reportCurrentRepoWriteTelemetry("authority-evidence-commit");
+        reportCurrentRepoWriteTelemetry("fsync");
+        await evidenceCommitter.commitPending(canonicalCommitSha);
+        reportCurrentRepoWriteTelemetry("authority-evidence-publish-returned");
+      };
       const basePublisher = createDurableAuthorityCommittedEventPublisherV2({
         eventLog,
-        commitEvidence: async (canonicalCommitSha) => {
-          reportCurrentRepoWriteTelemetry("authority-evidence-commit");
-          reportCurrentRepoWriteTelemetry("fsync");
-          await evidenceCommitter.commitPending(canonicalCommitSha);
-        },
+        commitEvidence,
         observation: {
           observe: async (request) => {
             reportCurrentRepoWriteTelemetry("git");
@@ -223,7 +225,7 @@ export function createProductionAuthorityLifecycle(input: {
         bindingRuntime,
         eventLog,
         publicationInspector,
-        commitEvidence: evidenceCommitter.commitPending
+        commitEvidence
       });
       const recovery = {} as ProductionRecoveryState;
       const material: RepoProductionMaterial = {

--- a/packages/daemon/src/authority/production/publication-evidence.ts
+++ b/packages/daemon/src/authority/production/publication-evidence.ts
@@ -166,6 +166,7 @@ export function createGitAuthorityAttributionEvidenceCommitterV2(
         materializerCommitter
       );
       verifiedHead = vcs.currentHead(repoRoot);
+      reportCurrentRepoWriteTelemetry("authority-evidence-git-commit-done");
     }
   };
 }

--- a/packages/daemon/src/runtime/repo-runtime.ts
+++ b/packages/daemon/src/runtime/repo-runtime.ts
@@ -5,7 +5,6 @@ import {
   createHarnessRuntimeContext,
   makeJournaledWriteCoordinator,
   makeOperationalJournaledWriteCoordinator,
-  runLedgerMaterializer,
   type DaemonAdmissionBudget,
   type LedgerMaterializerReport,
   type OperationalActor,
@@ -78,6 +77,7 @@ import { ReservationReconcilerRunner } from "./reservation-reconciler-runner.ts"
 import { mergeRepoRuntimeDefaults, sortedRepoOptions } from "./repo-runtime-options-merge.ts";
 import { describeRepoRuntimeError } from "./repo-runtime-error.ts";
 import { acquireRepoRuntimeGlobalLock } from "./repo-runtime-lock.ts";
+import { runMaterializerWithRepoWriteTelemetry } from "./repo-write-materializer-telemetry.ts";
 
 const defaultDaemonOperationalActor: OperationalActor = { scope: "operational", kind: "system", id: "daemon-runtime" };
 
@@ -529,7 +529,7 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
 
   private runMaterializerBatch(batchOptions: DaemonMaterializerBatchOptions): LedgerMaterializerReport {
     const started = this.requireWriterAttached();
-    const report = runLedgerMaterializer(this.runtimeContext, {
+    const report = runMaterializerWithRepoWriteTelemetry(this.runtimeContext, {
       heldGlobalLock: started.lock,
       ...(batchOptions.dryRun ? { dryRun: true } : {}),
       ...(batchOptions.sessionId

--- a/packages/daemon/src/runtime/repo-write-child-host.ts
+++ b/packages/daemon/src/runtime/repo-write-child-host.ts
@@ -28,6 +28,7 @@ import {
 } from "./repo-write-not-started-classification.ts";
 import {
   createRepoWriteTelemetryDelivery,
+  executeRepoWriteChildWithTelemetry,
   reportCurrentRepoWriteTelemetry,
   runWithRepoWriteTelemetry,
   type RepoWriteTelemetryDelivery
@@ -235,10 +236,7 @@ export class RepoWriteChildHost {
         );
         return;
       }
-      operation.execute = () => runWithRepoWriteTelemetry(telemetry.report, () => {
-        reportCurrentRepoWriteTelemetry("journal");
-        return prepared.execute();
-      });
+      operation.execute = () => executeRepoWriteChildWithTelemetry(telemetry, prepared.execute);
       operation.phase = "prepared";
       await this.responses.prepared(message.requestId, prepared.opId);
     } catch (error) {
@@ -309,6 +307,8 @@ export class RepoWriteChildHost {
           await this.executionSequencer.run(operation.execute!)
         );
         await operation.telemetry?.flush();
+        operation.telemetry?.reportCurrent("child-telemetry-flushed");
+        await operation.telemetry?.flush();
         if (durableOutcome.phase !== "TERMINAL" || durableOutcome.outerOpId !== operation.opId) {
           throw new Error("execution did not return the matching durable TERMINAL outer outcome");
         }
@@ -328,6 +328,7 @@ export class RepoWriteChildHost {
         return;
       }
       operation.receipt = receipt;
+      operation.telemetry?.reportCurrent("child-terminal-response");
       await this.closeTelemetry(operation);
       this.release(operation);
       await this.responses.terminal(

--- a/packages/daemon/src/runtime/repo-write-diagnostic-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-diagnostic-protocol.ts
@@ -15,7 +15,16 @@ export const repoWriteTelemetryPhases = [
   "authority-prepared-persisted", "authority-flush-start", "authority-replication-snapshot",
   "authority-replica-change-append", "authority-evidence-commit", "authority-evidence-worktree",
   "authority-evidence-history-verify", "authority-evidence-pending-verify",
-  "authority-evidence-git-commit", "fsync", "materializer", "projection", "total"
+  "authority-evidence-git-commit", "authority-evidence-git-commit-done",
+  "authority-evidence-publish-returned", "authority-event-published",
+  "authority-terminal-record-start", "authority-terminal-record-persisted",
+  "authority-materializer-start", "authority-materializer-baseline-start",
+  "authority-materializer-baseline-done", "authority-materializer-merge-start",
+  "authority-materializer-merge-done", "authority-materializer-projection-start",
+  "authority-materializer-projection-done", "authority-materializer-attribution-start",
+  "authority-materializer-attribution-done", "authority-materializer-end",
+  "child-execution-returned", "child-telemetry-flushed", "child-terminal-response",
+  "fsync", "materializer", "projection", "total"
 ] as const;
 
 export type RepoWriteTelemetryPhase = typeof repoWriteTelemetryPhases[number];

--- a/packages/daemon/src/runtime/repo-write-materializer-telemetry.ts
+++ b/packages/daemon/src/runtime/repo-write-materializer-telemetry.ts
@@ -1,0 +1,39 @@
+import {
+  runLedgerMaterializer,
+  type LedgerMaterializerProgressStep
+} from "@harness-anything/kernel";
+import { reportCurrentRepoWriteTelemetry } from "./repo-write-telemetry-context.ts";
+import type { RepoWriteTelemetryPhase } from "./repo-write-protocol.ts";
+
+const materializerProgressPhases: Record<LedgerMaterializerProgressStep, RepoWriteTelemetryPhase> = {
+  "baseline-start": "authority-materializer-baseline-start",
+  "baseline-done": "authority-materializer-baseline-done",
+  "merge-start": "authority-materializer-merge-start",
+  "merge-done": "authority-materializer-merge-done",
+  "projection-start": "authority-materializer-projection-start",
+  "projection-done": "authority-materializer-projection-done",
+  "attribution-start": "authority-materializer-attribution-start",
+  "attribution-done": "authority-materializer-attribution-done"
+};
+
+export function materializerProgressPhase(step: LedgerMaterializerProgressStep): RepoWriteTelemetryPhase {
+  return materializerProgressPhases[step];
+}
+
+export function runMaterializerWithRepoWriteTelemetry(
+  rootInput: Parameters<typeof runLedgerMaterializer>[0],
+  options: NonNullable<Parameters<typeof runLedgerMaterializer>[1]> = {}
+): ReturnType<typeof runLedgerMaterializer> {
+  reportCurrentRepoWriteTelemetry("authority-materializer-start");
+  try {
+    return runLedgerMaterializer(rootInput, {
+      ...options,
+      onProgress: (step) => {
+        reportCurrentRepoWriteTelemetry(materializerProgressPhase(step));
+        options.onProgress?.(step);
+      }
+    });
+  } finally {
+    reportCurrentRepoWriteTelemetry("authority-materializer-end");
+  }
+}

--- a/packages/daemon/src/runtime/repo-write-stall-diagnostic.ts
+++ b/packages/daemon/src/runtime/repo-write-stall-diagnostic.ts
@@ -65,6 +65,42 @@ export function repoWriteWaitingStage(
       return "authority-evidence-pending-verify";
     case "authority-evidence-git-commit":
       return "authority-evidence-git-commit";
+    case "authority-evidence-git-commit-done":
+      return "authority-evidence-git-commit-done";
+    case "authority-evidence-publish-returned":
+      return "authority-evidence-publish-returned";
+    case "authority-event-published":
+      return "authority-event-published";
+    case "authority-terminal-record-start":
+      return "authority-terminal-record-start";
+    case "authority-terminal-record-persisted":
+      return "authority-terminal-record-persisted";
+    case "authority-materializer-start":
+      return "authority-materializer-start";
+    case "authority-materializer-baseline-start":
+      return "authority-materializer-baseline";
+    case "authority-materializer-baseline-done":
+      return "authority-materializer-baseline-done";
+    case "authority-materializer-merge-start":
+      return "authority-materializer-merge";
+    case "authority-materializer-merge-done":
+      return "authority-materializer-merge-done";
+    case "authority-materializer-projection-start":
+      return "authority-materializer-projection";
+    case "authority-materializer-projection-done":
+      return "authority-materializer-projection-done";
+    case "authority-materializer-attribution-start":
+      return "authority-materializer-attribution";
+    case "authority-materializer-attribution-done":
+      return "authority-materializer-attribution-done";
+    case "authority-materializer-end":
+      return "authority-materializer-end";
+    case "child-execution-returned":
+      return "child-execution-returned";
+    case "child-telemetry-flushed":
+      return "child-telemetry-flushed";
+    case "child-terminal-response":
+      return "child-terminal-response";
     case "fsync":
       return "durable-attribution-evidence";
     case "materializer":

--- a/packages/daemon/src/runtime/repo-write-telemetry-context.ts
+++ b/packages/daemon/src/runtime/repo-write-telemetry-context.ts
@@ -9,6 +9,7 @@ type RepoWriteTelemetryReporter = (
 
 export interface RepoWriteTelemetryDelivery {
   readonly report: RepoWriteTelemetryReporter;
+  readonly reportCurrent: (phase: RepoWriteTelemetryPhase) => void;
   readonly flush: () => Promise<void>;
   readonly close: () => void;
 }
@@ -33,6 +34,18 @@ export function reportCurrentRepoWriteTelemetry(
   current.report(phase, Math.max(0, performance.now() - current.startedAt));
 }
 
+export async function executeRepoWriteChildWithTelemetry<Result>(
+  delivery: RepoWriteTelemetryDelivery,
+  execute: () => Result | Promise<Result>
+): Promise<Result> {
+  return runWithRepoWriteTelemetry(delivery.report, async () => {
+    reportCurrentRepoWriteTelemetry("journal");
+    const outcome = await execute();
+    reportCurrentRepoWriteTelemetry("child-execution-returned");
+    return outcome;
+  });
+}
+
 export function bindCurrentRepoWriteTelemetry<Result>(
   operation: () => Result
 ): () => Result {
@@ -50,11 +63,18 @@ export function createRepoWriteTelemetryDelivery(
 ): RepoWriteTelemetryDelivery {
   let pending = Promise.resolve();
   let closed = false;
+  const startedAt = performance.now();
   return {
     report: (phase, elapsedMs) => {
       if (closed) return;
       pending = pending
         .then(() => deliver(phase, elapsedMs))
+        .catch(() => undefined);
+    },
+    reportCurrent: (phase) => {
+      if (closed) return;
+      pending = pending
+        .then(() => deliver(phase, Math.max(0, performance.now() - startedAt)))
         .catch(() => undefined);
     },
     flush: () => pending,

--- a/packages/daemon/test/publication-evidence-committer.test.ts
+++ b/packages/daemon/test/publication-evidence-committer.test.ts
@@ -82,6 +82,7 @@ test("canonical HEAD advancement outside the evidence tree preserves the verifie
   );
 
   assert.ok(phases.includes("authority-evidence-pending-verify"), phases.join(","));
+  assert.ok(phases.includes("authority-evidence-git-commit-done"), phases.join(","));
   assert.equal(phases.includes("authority-evidence-history-verify"), false, phases.join(","));
 });
 

--- a/packages/daemon/test/repo-write-child-host.test.ts
+++ b/packages/daemon/test/repo-write-child-host.test.ts
@@ -46,6 +46,12 @@ test("host announces ready and executes only after the exact prepared handshake"
 
   await host.receive(proceed("request-1", "op-request-1"));
   assert.equal(executions, 1);
+  assert.deepEqual(
+    fixture.messages
+      .filter((message) => message.kind === "telemetry")
+      .map((message) => message.phase),
+    ["queue", "compile", "journal", "child-execution-returned", "child-telemetry-flushed", "child-terminal-response"]
+  );
   assert.deepEqual(fixture.messages.at(-1), {
     ...childBase("terminal"),
     requestId: "request-1",

--- a/packages/daemon/test/runtime/materializer-runtime.test.ts
+++ b/packages/daemon/test/runtime/materializer-runtime.test.ts
@@ -12,6 +12,7 @@ import {
   type ProjectionSourceFenceFactory
 } from "@harness-anything/kernel";
 import { createDaemonRuntime, createMultiRepoDaemonRuntime } from "../../src/runtime/repo-runtime.ts";
+import { runWithRepoWriteTelemetry } from "../../src/runtime/repo-write-telemetry-context.ts";
 import { docWrite, withTempStoreAsync } from "./helpers/store.ts";
 import {
   commitAuthoredFixture,
@@ -69,26 +70,33 @@ test("authority publication materializes its session before a queued timer batch
     });
     let competingMaterializer: ReturnType<typeof runtime.enqueueMaterializerBatch> | undefined;
 
-    const publication = await runtime.enqueueAuthorityPublication({
-      sessionId: "authority-atomic-materialization",
-      publish: async () => {
-        Effect.runSync(coordinator.enqueue(docWrite(
-          "op-authority-atomic",
-          "task-authority-atomic",
-          "note.md",
-          "authority\n"
-        )));
-        const flush = Effect.runSync(coordinator.flush("explicit"));
-        competingMaterializer = runtime.enqueueMaterializerBatch();
-        return flush;
-      }
-    });
+    const phases: string[] = [];
+    const publication = await runWithRepoWriteTelemetry(
+      (phase) => phases.push(phase),
+      () => runtime.enqueueAuthorityPublication({
+        sessionId: "authority-atomic-materialization",
+        publish: async () => {
+          Effect.runSync(coordinator.enqueue(docWrite(
+            "op-authority-atomic",
+            "task-authority-atomic",
+            "note.md",
+            "authority\n"
+          )));
+          const flush = Effect.runSync(coordinator.flush("explicit"));
+          competingMaterializer = runtime.enqueueMaterializerBatch();
+          return flush;
+        }
+      })
+    );
     const competing = await competingMaterializer!;
 
     assert.equal(publication.materialization?.branches[0]?.status, "merged");
     assert.equal(publication.materialization?.branches[0]?.commitCount, 1);
     assert.equal(competing.merged, 0);
     assert.equal(readGitFile(rootDir, "tasks/task-authority-atomic/note.md"), "authority\n");
+    assert.ok(phases.includes("authority-materializer-baseline-start"), phases.join(","));
+    assert.ok(phases.includes("authority-materializer-projection-done"), phases.join(","));
+    assert.ok(phases.includes("authority-materializer-end"), phases.join(","));
     await runtime.stop();
   });
 });

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -183,6 +183,7 @@ export { daemonAdmissionBytes } from "./daemon/admission-budget.ts";
 export type { DaemonAdmissionBudget } from "./daemon/admission-budget.ts";
 export {
   runLedgerMaterializer,
+  type LedgerMaterializerProgressStep,
   type LedgerMaterializerReport
 } from "./write-coordination/materialization/ledger-materializer.ts";
 export { writeCoordinatedPayload, writeCoordinatedTaskDocuments } from "./write-coordination/submit.ts";

--- a/packages/kernel/src/write-coordination/materialization/ledger-materializer.ts
+++ b/packages/kernel/src/write-coordination/materialization/ledger-materializer.ts
@@ -49,7 +49,18 @@ export interface LedgerMaterializerOptions {
   readonly sessionId?: string;
   readonly heldGlobalLock?: OwnedLock;
   readonly versionControlSystem?: VersionControlSystem;
+  readonly onProgress?: (step: LedgerMaterializerProgressStep) => void;
 }
+
+export type LedgerMaterializerProgressStep =
+  | "baseline-start"
+  | "baseline-done"
+  | "merge-start"
+  | "merge-done"
+  | "projection-start"
+  | "projection-done"
+  | "attribution-start"
+  | "attribution-done";
 
 const defaultVersionControlSystem = makeLocalVersionControlSystem();
 
@@ -70,7 +81,15 @@ export function runLedgerMaterializer(rootInput: HarnessLayoutInput, options: Le
   }
 
   return withRepoLocks(layout.rootDir, rootInput, layout.journalPath, { scope: "operational", kind: "system", id: "ledger-materializer" }, 60_000, [], () => {
-    return materializeBranches(repoRoot, rootInput, options.dryRun === true, options.maxBranches, options.sessionId, versionControlSystem);
+    return materializeBranches(
+      repoRoot,
+      rootInput,
+      options.dryRun === true,
+      options.maxBranches,
+      options.sessionId,
+      versionControlSystem,
+      options.onProgress
+    );
   }, { heldGlobalLock: options.heldGlobalLock });
 }
 
@@ -80,7 +99,8 @@ function materializeBranches(
   dryRun: boolean,
   maxBranches: number | undefined,
   sessionId: string | undefined,
-  vcs: VersionControlSystem
+  vcs: VersionControlSystem,
+  onProgress: ((step: LedgerMaterializerProgressStep) => void) | undefined
 ): LedgerMaterializerReport {
   const reports: LedgerMaterializerBranchReport[] = [];
   const warnings: string[] = [];
@@ -125,7 +145,11 @@ function materializeBranches(
       continue;
     }
 
-    projectionSourceFingerprintBeforeMerge ??= captureTrustedAuthoredProjectionFingerprint(rootInput, vcs, repoRoot);
+    if (projectionSourceFingerprintBeforeMerge === undefined) {
+      onProgress?.("baseline-start");
+      projectionSourceFingerprintBeforeMerge = captureTrustedAuthoredProjectionFingerprint(rootInput, vcs, repoRoot);
+      onProgress?.("baseline-done");
+    }
 
     const mergeMessage = semanticMergeMessage(commits, repoRoot, branch, vcs)
       ?? `materializer: merge session ${branch.slice("sessions/".length)}`;
@@ -133,7 +157,9 @@ function materializeBranches(
     const beforeMergeHead = vcs.currentHead(repoRoot);
     let preservedArtifacts: ReadonlyArray<PreservedMachineArtifact> = [];
     try {
+      onProgress?.("merge-start");
       vcs.mergeNoFf(repoRoot, branch, mergeMessage, materializerCommitter);
+      onProgress?.("merge-done");
     } catch (error) {
       let conflictPaths: ReadonlyArray<string>;
       let recoveryError: unknown;
@@ -190,6 +216,7 @@ function materializeBranches(
 
   if (merged > 0) {
     const layout = resolveHarnessLayout(rootInput);
+    onProgress?.("projection-start");
     const projectionUpdate = updateTaskProjectionIncrementally({
       rootDir: layout.rootDir,
       ...(typeof rootInput === "object" && rootInput.layoutOverrides ? { layoutOverrides: rootInput.layoutOverrides } : {}),
@@ -201,6 +228,7 @@ function materializeBranches(
     } else {
       invalidateTrustedAuthoredProjectionFingerprint(rootInput, vcs, repoRoot);
     }
+    onProgress?.("projection-done");
   }
 
   const layout = resolveHarnessLayout(rootInput);
@@ -208,13 +236,17 @@ function materializeBranches(
   let projectionRebuilt = merged > 0;
   if (!dryRun) {
     if (!durableFileExists(layout.projectionPath)) {
+      onProgress?.("projection-start");
       rebuildTaskProjection({
         rootDir: layout.rootDir,
         ...(typeof rootInput === "object" && rootInput.layoutOverrides ? { layoutOverrides: rootInput.layoutOverrides } : {})
       });
       projectionRebuilt = true;
+      onProgress?.("projection-done");
     }
+    onProgress?.("attribution-start");
     attributionEventsProjected = countAttributionProjectionRows(layout.projectionPath);
+    onProgress?.("attribution-done");
   }
 
   return {

--- a/packages/kernel/test/store/ledger-materializer.test.ts
+++ b/packages/kernel/test/store/ledger-materializer.test.ts
@@ -59,7 +59,10 @@ test("ledger materializer dry-runs and merges pending session branches", () => {
     assert.equal(dryRun.branches.find((branch) => branch.branch === "sessions/codex-session-2")?.status, "would_merge");
     assert.equal(existsSync(path.join(rootDir, "harness/tasks/task-2/note.md")), false);
 
-    const merged = runLedgerMaterializer(rootDir);
+    const progress: string[] = [];
+    const merged = runLedgerMaterializer(rootDir, {
+      onProgress: (step) => progress.push(step)
+    });
     assert.equal(merged.merged, 1);
     assert.equal(merged.projectionRebuilt, true);
     assert.equal(git(rootDir, "branch", "--list", "sessions/codex-session-2"), "");
@@ -67,6 +70,16 @@ test("ledger materializer dry-runs and merges pending session branches", () => {
     assert.equal(readGitFile(rootDir, "tasks/task-2/note.md"), "materialized write\n");
     assert.equal(merged.attributionEventsProjected, 1);
     assert.equal(readAttributionProjection(rootDir)[0]?.opId, "op-materialize");
+    assert.deepEqual(progress, [
+      "baseline-start",
+      "baseline-done",
+      "merge-start",
+      "merge-done",
+      "projection-start",
+      "projection-done",
+      "attribution-start",
+      "attribution-done"
+    ]);
     assert.equal(
       git(rootDir, "show", "-s", "--format=%an <%ae>", "HEAD"),
       "Harness Anything Materializer <materializer@harness-anything.local>"

--- a/tools/perf/residual-write-cost-fixture.mjs
+++ b/tools/perf/residual-write-cost-fixture.mjs
@@ -15,7 +15,8 @@ import {
   canonicalAttributionEventDigestV2,
   makeLocalAuthorityAttributionEventV2Log,
   physicalChangeSetDigestV2,
-  semanticMutationSetDigestV2
+  semanticMutationSetDigestV2,
+  runLedgerMaterializer
 } from "@harness-anything/kernel";
 import {
   captureAuthoredProjectionFingerprint,
@@ -25,6 +26,10 @@ import { makeLocalVersionControlSystem } from "../../packages/kernel/src/persist
 import { rebuildTaskProjection } from "../../packages/kernel/src/projection/sqlite-task-projection.ts";
 import { createAuthorityReplicationContentStore } from "../../packages/daemon/src/authority/replication-content-store.ts";
 import { createGitAuthorityAttributionEvidenceCommitterV2 } from "../../packages/daemon/src/authority/production/publication-evidence.ts";
+import {
+  reportCurrentRepoWriteTelemetry,
+  runWithRepoWriteTelemetry
+} from "../../packages/daemon/src/runtime/repo-write-telemetry-context.ts";
 
 const authoredFileCount = 26_612;
 const authoredFileBytes = 5_933;
@@ -62,48 +67,95 @@ try {
   const trustedFingerprintColdMs = measure(() => captureTrustedAuthoredProjectionFingerprint(root, trustedVcs));
   const trustedFingerprintWrites = [];
   for (let writeIndex = 1; writeIndex <= 2; writeIndex += 1) {
-    const taskIndexPath = path.join(authoredRoot, authoredPaths[0]);
-    writeFileSync(
-      taskIndexPath,
-      readFileSync(taskIndexPath, "utf8").replace(/^title:.*$/mu, `title: Synthetic governance write ${writeIndex}`),
-      "utf8"
-    );
-    git("add", authoredPaths[0]);
-    const canonicalCommitStartedAt = performance.now();
-    git("commit", "-q", "-m", `synthetic governance write ${writeIndex}`);
-    const canonicalCommitMs = performance.now() - canonicalCommitStartedAt;
-    const canonicalCommit = git("rev-parse", "HEAD");
-    const canonicalTrustedStartedAt = performance.now();
-    const canonicalTrustedFingerprint = captureTrustedAuthoredProjectionFingerprint(root, trustedVcs);
-    const canonicalTrustedMs = performance.now() - canonicalTrustedStartedAt;
-    const canonicalFullStartedAt = performance.now();
-    const canonicalFullFingerprint = captureAuthoredProjectionFingerprint(root);
-    const canonicalFullMs = performance.now() - canonicalFullStartedAt;
-    if (canonicalTrustedFingerprint !== canonicalFullFingerprint) {
-      throw new Error(`trusted fingerprint mismatch after canonical write ${writeIndex}`);
-    }
+    const writeStartedAt = performance.now();
+    const telemetryFrames = [];
+    await runWithRepoWriteTelemetry((phase, elapsedMs) => {
+      telemetryFrames.push({ phase, elapsedMs });
+    }, async () => {
+      const report = (phase) => reportCurrentRepoWriteTelemetry(phase);
+      report("queue");
+      report("compile");
+      report("journal");
+      const sessionId = `round6-write-${writeIndex}`;
+      const sessionBranch = `sessions/${sessionId}`;
+      const taskIndexPath = path.join(authoredRoot, authoredPaths[0]);
+      git("branch", sessionBranch);
+      git("checkout", sessionBranch);
+      writeFileSync(
+        taskIndexPath,
+        readFileSync(taskIndexPath, "utf8").replace(/^title:.*$/mu, `title: Synthetic governance write ${writeIndex}`),
+        "utf8"
+      );
+      git("add", authoredPaths[0]);
+      const sessionCommitStartedAt = performance.now();
+      git("commit", "-q", "-m", `synthetic governance write ${writeIndex}`);
+      const sessionCommitMs = performance.now() - sessionCommitStartedAt;
+      const sessionCommit = git("rev-parse", "HEAD");
+      git("checkout", "master");
 
-    evidenceLog.ensure(v2Event(`op-round5-${String(writeIndex).padStart(2, "0")}`, evidenceShardCount + writeIndex));
-    const evidenceCommitStartedAt = performance.now();
-    await evidenceCommitter.commitPending(canonicalCommit);
-    const evidenceCommitMs = performance.now() - evidenceCommitStartedAt;
-    const evidenceTrustedStartedAt = performance.now();
-    const evidenceTrustedFingerprint = captureTrustedAuthoredProjectionFingerprint(root, trustedVcs);
-    const evidenceTrustedMs = performance.now() - evidenceTrustedStartedAt;
-    const evidenceFullStartedAt = performance.now();
-    const evidenceFullFingerprint = captureAuthoredProjectionFingerprint(root);
-    const evidenceFullMs = performance.now() - evidenceFullStartedAt;
-    if (evidenceTrustedFingerprint !== evidenceFullFingerprint) {
-      throw new Error(`trusted fingerprint mismatch after evidence write ${writeIndex}`);
-    }
-    trustedFingerprintWrites.push({
-      writeIndex,
-      canonicalCommitMs,
-      canonicalTrustedMs,
-      canonicalFullMs,
-      evidenceCommitMs,
-      evidenceTrustedMs,
-      evidenceFullMs
+      report("authority-flush-start");
+      report("git");
+      report("fsync");
+      report("authority-materializer-start");
+      const materializerStartedAt = performance.now();
+      const materializer = runLedgerMaterializer(root, {
+        sessionId,
+        versionControlSystem: trustedVcs,
+        onProgress: (step) => report(materializerTelemetryPhase(step))
+      });
+      const materializerMs = performance.now() - materializerStartedAt;
+      report("authority-materializer-end");
+      report("total");
+      if (materializer.merged !== 1 || materializer.warnings.length > 0) {
+        throw new Error(`fixture materializer did not merge ${sessionBranch}: ${JSON.stringify(materializer)}`);
+      }
+      const canonicalCommit = git("rev-parse", "HEAD");
+
+      const canonicalTrustedStartedAt = performance.now();
+      const canonicalTrustedFingerprint = captureTrustedAuthoredProjectionFingerprint(root, trustedVcs);
+      const canonicalTrustedMs = performance.now() - canonicalTrustedStartedAt;
+      const canonicalFullStartedAt = performance.now();
+      const canonicalFullFingerprint = captureAuthoredProjectionFingerprint(root);
+      const canonicalFullMs = performance.now() - canonicalFullStartedAt;
+      if (canonicalTrustedFingerprint !== canonicalFullFingerprint) {
+        throw new Error(`trusted fingerprint mismatch after canonical write ${writeIndex}`);
+      }
+
+      report("authority-evidence-commit");
+      report("fsync");
+      evidenceLog.ensure(v2Event(`op-round6-${String(writeIndex).padStart(2, "0")}`, evidenceShardCount + writeIndex));
+      const evidenceCommitStartedAt = performance.now();
+      await evidenceCommitter.commitPending(canonicalCommit);
+      const evidenceCommitMs = performance.now() - evidenceCommitStartedAt;
+      report("authority-evidence-publish-returned");
+      report("authority-event-published");
+      const evidenceTrustedStartedAt = performance.now();
+      const evidenceTrustedFingerprint = captureTrustedAuthoredProjectionFingerprint(root, trustedVcs);
+      const evidenceTrustedMs = performance.now() - evidenceTrustedStartedAt;
+      const evidenceFullStartedAt = performance.now();
+      const evidenceFullFingerprint = captureAuthoredProjectionFingerprint(root);
+      const evidenceFullMs = performance.now() - evidenceFullStartedAt;
+      if (evidenceTrustedFingerprint !== evidenceFullFingerprint) {
+        throw new Error(`trusted fingerprint mismatch after evidence write ${writeIndex}`);
+      }
+      report("authority-terminal-record-start");
+      report("authority-terminal-record-persisted");
+      report("child-execution-returned");
+      report("child-telemetry-flushed");
+      report("child-terminal-response");
+      trustedFingerprintWrites.push({
+        writeIndex,
+        sessionCommit,
+        sessionCommitMs,
+        canonicalCommit,
+        materializerMs,
+        canonicalTrustedMs,
+        canonicalFullMs,
+        evidenceCommitMs,
+        evidenceTrustedMs,
+        evidenceFullMs,
+        telemetry: summarizeTelemetry(telemetryFrames, performance.now() - writeStartedAt)
+      });
     });
   }
   const values = new Map();
@@ -246,6 +298,77 @@ function measure(operation) {
   const startedAt = performance.now();
   operation();
   return performance.now() - startedAt;
+}
+
+function materializerTelemetryPhase(step) {
+  const phases = {
+    "baseline-start": "authority-materializer-baseline-start",
+    "baseline-done": "authority-materializer-baseline-done",
+    "merge-start": "authority-materializer-merge-start",
+    "merge-done": "authority-materializer-merge-done",
+    "projection-start": "authority-materializer-projection-start",
+    "projection-done": "authority-materializer-projection-done",
+    "attribution-start": "authority-materializer-attribution-start",
+    "attribution-done": "authority-materializer-attribution-done"
+  };
+  const phase = phases[step];
+  if (!phase) throw new Error(`unknown materializer telemetry step: ${step}`);
+  return phase;
+}
+
+function summarizeTelemetry(frames, wallMs) {
+  const ordered = frames.map((frame, index) => ({ ...frame, index }));
+  const firstTotalIndex = ordered.findIndex((frame) => frame.phase === "total");
+  const firstFsyncBeforeTotalIndex = ordered.findLastIndex(
+    (frame, index) => index < firstTotalIndex && frame.phase === "fsync"
+  );
+  const evidenceDoneIndex = ordered.findLastIndex((frame) => frame.phase === "authority-evidence-git-commit-done");
+  const childTerminalIndex = ordered.findLastIndex((frame) => frame.phase === "child-terminal-response");
+  const materializerWindow = summarizeWindow(ordered, firstFsyncBeforeTotalIndex, firstTotalIndex);
+  const evidenceTail = summarizeWindow(ordered, evidenceDoneIndex, childTerminalIndex);
+  const firstElapsedMs = ordered[0]?.elapsedMs ?? 0;
+  const lastElapsedMs = ordered.at(-1)?.elapsedMs ?? 0;
+  const beforeFirstFrameMs = Math.max(0, firstElapsedMs);
+  const framedSpanMs = Math.max(0, lastElapsedMs - firstElapsedMs);
+  const afterLastFrameMs = Math.max(0, wallMs - lastElapsedMs);
+  return {
+    frameCount: frames.length,
+    frames,
+    wallMs,
+    materializerWindow,
+    evidenceToChildTail: evidenceTail,
+    accounting: {
+      beforeFirstFrameMs,
+      framedSpanMs,
+      afterLastFrameMs,
+      accountedWallMs: beforeFirstFrameMs + framedSpanMs + afterLastFrameMs,
+      wallResidualMs: wallMs - (beforeFirstFrameMs + framedSpanMs + afterLastFrameMs)
+    }
+  };
+}
+
+function summarizeWindow(frames, startIndex, endIndex) {
+  if (startIndex < 0 || endIndex < 0 || endIndex < startIndex) {
+    return { found: false, durationMs: 0, subspansMs: [] };
+  }
+  const start = frames[startIndex];
+  const end = frames[endIndex];
+  const subspansMs = [];
+  for (let index = startIndex + 1; index <= endIndex; index += 1) {
+    subspansMs.push({
+      from: frames[index - 1].phase,
+      to: frames[index].phase,
+      milliseconds: frames[index].elapsedMs - frames[index - 1].elapsedMs
+    });
+  }
+  return {
+    found: true,
+    from: start.phase,
+    to: end.phase,
+    durationMs: end.elapsedMs - start.elapsedMs,
+    subspansMs,
+    subspansTotalMs: subspansMs.reduce((total, span) => total + span.milliseconds, 0)
+  };
 }
 
 function git(...args) {


### PR DESCRIPTION
# English

## Summary

Round 6 of the residual governance-write cost work. Production verification after round 5 (PR #1211) showed warm writes still at 15.8–16.3s with two windows that have no telemetry coverage at all: a 4,320ms gap between the flush `fsync` and `total` frames, and a ~4,950ms tail between the last evidence frame and child total. Attribution of those windows to the fingerprint path has so far been shape-inference only — production logs contain no fingerprint/baseline frames. This PR therefore adds instrumentation only and deliberately makes no performance change.

Key falsification result from the upgraded fixture: with two consecutive writes where the materializer itself advances HEAD, the trusted fingerprint still takes the ancestor/incremental path (18/24ms vs 214/288ms full, exactly equal outputs). "HEAD moved, therefore full rescan" is no longer a valid sole attribution for the production gap. The fixture also **fails to reproduce** the production 4,320ms gap (663/1,034ms only) — evidence that production holds a state variable the fixture lacks, so an algorithmic "fix" now would be unfounded.

## What Changed

- **Materializer spans** (`authority-materializer-start/end` plus `baseline`/`merge`/`projection`/`attribution` sub-steps): the kernel `ledger-materializer` gains an optional `onProgress` callback (no-op by default); the daemon wraps `runLedgerMaterializer` (`repo-write-materializer-telemetry.ts`) and maps steps onto `repo-write-request-telemetry/v1` phases.
- **Evidence/terminal spans**: `authority-evidence-git-commit-done` (after the real `vcs.commit()` returns), `authority-evidence-publish-returned`, `authority-event-published`, `authority-terminal-record-start/persisted` — these split the post-evidence tail into publisher, event, and durable registry segments.
- **Child shutdown spans**: `child-execution-returned`, `child-telemetry-flushed`, `child-terminal-response` in the repo-write child host.
- **Fixture upgrade**: `tools/perf/residual-write-cost-fixture.mjs` now runs two consecutive HEAD-advancing writes through the real materializer/evidence chain and does full wall accounting (residual ≈ 0ms).

All new frames reuse the existing AsyncLocalStorage gating and async best-effort delivery; without telemetry they are no-ops. No change to flush ordering, authority/publication semantics, locks, or durability.

## Task And Scope

- Task: `task_01KZ3DCGW7K0XEY69Z47J1AEA8` (residual write-cost line), round-6 report at `artifacts/residual-round-6.md`.
- Scope: observation layer only — daemon telemetry plumbing, one optional kernel callback, fixture/test updates. 17 files, +372/−74.
- Out of scope (deliberately): any change to fingerprint cache, scoped-index commit, replica algorithms, or write-coordination semantics.

## Version Impact

- No public CLI surface change; no schema change to persisted state. `repo-write-request-telemetry/v1` phase enum grows (additive). Parent and child must run the same dist (strict phase decoder on old parents would reject new phases); both come from the same CLI dist, so the standard daemon restart covers it.

## Governance Declaration

- No protected surfaces touched (no CI/gate authority files, no lock files, no branch-protection or queue configuration). Not a governance task; no break-glass.

## Verification

- `npm run check:local` green (27 manifest gates; affected fast/contract included, contract 710 pass / 1 skip).
- Full integration tier: `node tools/run-node-tests.mjs --tier integration` — 1,468 tests, 1,464 pass, 0 fail, 4 skipped (exit 0).
- Governance walls: pass 9, red 0, expected 3.
- Fixture wall accounting: both writes account to wall with ≈0ms residual; sub-frame sums exactly match the `fsync→total` window.

## Review Evidence

- CEO semantic review: diff confirmed observation-layer only — kernel change is an optional callback with default-unchanged call paths; no timing state shared across requests; `finally`-guaranteed end frames; evidence `-done` frame only after real commit returns.
- Concurrency failure-path review (seven questions) recorded in the round-6 report: mid-flight death only loses `-done` frames; replay paths keep publisher/pending-verify boundaries; no new locks.

## Residual Risk

- Phase enum growth requires parent/child dist to move together — covered by normal restart, but a mixed-version window would drop/reject frames (telemetry only, writes unaffected).
- Slight always-on log I/O per governance write (best-effort async).
- The production 4.3s window remains unattributed until the next deployment + three-write observation; that observation is the explicit next step and gate for any round-7 fix.

## References

- Task `task_01KZ3DCGW7K0XEY69Z47J1AEA8`, report `artifacts/residual-round-6.md`.
- Prior rounds: PR #1205, #1206, #1209, #1211.

---

# 中文

## 概要

治理写残余成本第 6 轮。round-5（PR #1211）部署后的生产验收显示暖写仍在 15.8–16.3s，且有两个**完全没有遥测覆盖**的窗口：flush `fsync`→`total` 之间 4,320ms 的缺口，以及最后一个 evidence 帧到 child total 之间约 4,950ms 的尾巴。此前把这些窗口归因到 fingerprint 路径只是形状推断——生产日志里根本没有 fingerprint/baseline 帧。因此本 PR **只加仪器，刻意不做任何性能修改**。

升级后 fixture 的关键证伪结论：materializer 自己推进 HEAD 的连续两写下，trusted fingerprint 仍走 ancestor/增量路径（18/24ms，对照全量 214/288ms，结果精确相等）。「HEAD 变了所以必然全量重扫」不再是生产缺口的有效单一归因。fixture 同时**复现不出**生产的 4,320ms 缺口（只有 663/1,034ms）——说明生产持有 fixture 缺失的状态变量，此时做算法「修复」没有依据。

## 改动内容

- **Materializer 分段帧**（`authority-materializer-start/end` 加 `baseline`/`merge`/`projection`/`attribution` 子步骤）：kernel `ledger-materializer` 增加可选 `onProgress` 回调（默认 no-op）；daemon 侧 `repo-write-materializer-telemetry.ts` 包住 `runLedgerMaterializer` 并把步骤映射为 `repo-write-request-telemetry/v1` phase。
- **Evidence/终态帧**：`authority-evidence-git-commit-done`（真实 `vcs.commit()` 返回后）、`authority-evidence-publish-returned`、`authority-event-published`、`authority-terminal-record-start/persisted`——把 evidence 之后的尾巴切成 publisher、事件、durable registry 三段。
- **Child 收尾帧**：repo-write child host 里的 `child-execution-returned`、`child-telemetry-flushed`、`child-terminal-response`。
- **Fixture 升级**：`tools/perf/residual-write-cost-fixture.mjs` 现在跑连续两条推进 HEAD 的写，走真实 materializer/evidence 链并做全 wall 对账（残差 ≈ 0ms）。

所有新帧复用现有 AsyncLocalStorage 门控与异步 best-effort delivery；无遥测时为 no-op。不改 flush 顺序、authority/publication 语义、锁与持久化。

## 任务与范围

- 任务：`task_01KZ3DCGW7K0XEY69Z47J1AEA8`（残余写成本线），round-6 报告在 `artifacts/residual-round-6.md`。
- 范围：纯观测层——daemon 遥测管线、kernel 一个可选回调、fixture/测试更新。17 个文件，+372/−74。
- 明确不在范围内：fingerprint cache、scoped-index commit、replica 算法与 write-coordination 语义的任何改动。

## 版本影响

- 无公开 CLI 面变更；无持久化 schema 变更。`repo-write-request-telemetry/v1` phase 枚举增量扩展。parent 与 child 必须同版本 dist（旧 parent 的严格 phase decoder 会拒绝新 phase）；两者出自同一 CLI dist，常规 daemon 重启即可覆盖。

## 治理声明

- 未触碰 protected surface（无 CI/gate 权威文件、无 lock 文件、无分支保护/队列配置）。非治理任务；无 break-glass。

## 验证

- `npm run check:local` 全绿（27 个 manifest 门；含受影响 fast/contract，contract 710 过 / 1 跳过）。
- 完整 integration tier：1,468 tests，1,464 过，0 失败，4 跳过（exit 0）。
- 治理 walls：pass 9，red 0，expected 3。
- Fixture wall 对账：两条写加总到 wall 残差 ≈ 0ms；子帧和与 `fsync→total` 窗口精确相等。

## 审查证据

- CEO 语义验收：diff 确认纯观测层——kernel 改动是默认路径不变的可选回调；无跨请求共享计时状态；end 帧有 `finally` 保证；evidence `-done` 帧只在真实 commit 返回后发。
- 并发失败路径七问已记录在 round-6 报告：中途死亡只丢 `-done` 帧；replay 路径保留 publisher/pending-verify 边界；不新增锁。

## 残余风险

- phase 枚举扩展要求 parent/child dist 同步升级——常规重启覆盖，但混版本窗口会丢帧/拒帧（仅遥测面，写不受影响）。
- 每条治理写增加少量常开日志 I/O（异步 best-effort）。
- 生产 4.3s 窗口在下一次部署+三写观察前仍未归因；该观察是明确的下一步，也是任何 round-7 修复的门。

## 关联材料

- 任务 `task_01KZ3DCGW7K0XEY69Z47J1AEA8`，报告 `artifacts/residual-round-6.md`。
- 前序轮：PR #1205、#1206、#1209、#1211。

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body complete / 双语正文完整
- [x] Non-governance task did not modify CI/gate authority surfaces / 非治理任务未修改 CI/gate 权威面
- [x] Verification is real command output, not assertion / 验证为真实命令输出而非断言
- [x] Residual risk honestly stated / 残余风险如实陈述
