### PR TITLE
feat(authority): first-mile enrollment — ha authority repo enroll/resign with per-repo independent trust domains

### DIFF
--- a/packages/cli/src/cli/command-spec/command-groups.ts
+++ b/packages/cli/src/cli/command-spec/command-groups.ts
@@ -21,6 +21,8 @@ export const commandGroups = [
     "ha audit provenance --task <task-id> --json"
   ]),
   group("authority", "Manage authority cutover controls.", [
+    "ha authority repo enroll --repo-id <id> --repo-root <path> --manifest <path> --service-state-root <path> --json",
+    "ha authority repo resign --repo-id <id> --manifest <path> --json",
     "ha authority cutover status --json",
     "ha authority cutover drain --json",
     "ha authority cutover scan --json",

--- a/packages/cli/src/cli/command-spec/command-spec-authority-cutover.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-authority-cutover.ts
@@ -1,6 +1,8 @@
 import { defineCommandSpecs } from "./types.ts";
 import { parseAuthorityCutoverArgs } from "../parsers/authority-cutover.ts";
+import { parseAuthorityRepoArgs } from "../parsers/authority-repo.ts";
 import { runAuthorityCutoverCommand } from "../../commands/core/authority-cutover.ts";
+import { runAuthorityRepoCommand } from "../../commands/core/authority-repo.ts";
 
 const shared = {
   receiptContract: { data: ["report"], paths: [] },
@@ -14,5 +16,47 @@ export const authorityCutoverCommandSpecs = defineCommandSpecs([
   { kind: "authority-cutover-confirm", usage: "authority cutover confirm --first-scan <id> --second-scan <id> [--json]", options: [{ flag: "--first-scan", description: "Select the first durable scan receipt." }, { flag: "--second-scan", description: "Select a distinct second durable scan receipt." }, { flag: "--json", description: "Emit command-receipt/v2 JSON." }], summary: "Persist exact equality or mismatch for two independent final scans.", examples: ["harness-anything authority cutover confirm --first-scan scan_1 --second-scan scan_2 --json"], parse: parseAuthorityCutoverArgs, run: runAuthorityCutoverCommand, ...shared },
   { kind: "authority-cutover-boundary", usage: "authority cutover boundary --id <id> --equality <receipt-id> --expected-v2-tuple-digest <sha256> [--json]", options: [{ flag: "--id", description: "Name the durable cutover boundary." }, { flag: "--equality", description: "Select a passing double final-scan equality receipt." }, { flag: "--expected-v2-tuple-digest", description: "Pin the exact selected V2 protocol tuple digest." }, { flag: "--json", description: "Emit command-receipt/v2 JSON." }], summary: "Activate the named V2 authority boundary while retaining V1 read-only compatibility.", examples: ["harness-anything authority cutover boundary --id sme-v2 --equality equality_1 --expected-v2-tuple-digest <sha256> --json"], parse: parseAuthorityCutoverArgs, run: runAuthorityCutoverCommand, ...shared },
   { kind: "authority-cutover-freeze", display: "advanced", usage: "authority cutover freeze --reason <text> --boundary-receipt-digest <sha256> [--json]", options: [{ flag: "--reason", description: "Record the containment reason." }, { flag: "--boundary-receipt-digest", description: "Pin the active boundary receipt digest." }, { flag: "--json", description: "Emit command-receipt/v2 JSON." }], summary: "Freeze authority writes without restoring the retired V1 fresh writer.", examples: ["harness-anything authority cutover freeze --reason \"forward fix\" --boundary-receipt-digest <sha256> --json"], parse: parseAuthorityCutoverArgs, run: runAuthorityCutoverCommand, ...shared },
-  { kind: "authority-cutover-re-enable", display: "advanced", usage: "authority cutover re-enable --boundary <id> --freeze-receipt-digest <sha256> --equality <receipt-id> --forward-fix <ref> [--json]", options: [{ flag: "--boundary", description: "Pin the active boundary id." }, { flag: "--freeze-receipt-digest", description: "Pin the containment receipt digest." }, { flag: "--equality", description: "Select a new passing equality receipt recorded after freeze." }, { flag: "--forward-fix", description: "Record the verified forward-fix evidence reference." }, { flag: "--json", description: "Emit command-receipt/v2 JSON." }], summary: "Re-enable V2 admission after frozen-state rescans and a verified forward fix.", examples: ["harness-anything authority cutover re-enable --boundary sme-v2 --freeze-receipt-digest <sha256> --equality equality_2 --forward-fix fix/w6-1 --json"], parse: parseAuthorityCutoverArgs, run: runAuthorityCutoverCommand, ...shared }
+  { kind: "authority-cutover-re-enable", display: "advanced", usage: "authority cutover re-enable --boundary <id> --freeze-receipt-digest <sha256> --equality <receipt-id> --forward-fix <ref> [--json]", options: [{ flag: "--boundary", description: "Pin the active boundary id." }, { flag: "--freeze-receipt-digest", description: "Pin the containment receipt digest." }, { flag: "--equality", description: "Select a new passing equality receipt recorded after freeze." }, { flag: "--forward-fix", description: "Record the verified forward-fix evidence reference." }, { flag: "--json", description: "Emit command-receipt/v2 JSON." }], summary: "Re-enable V2 admission after frozen-state rescans and a verified forward fix.", examples: ["harness-anything authority cutover re-enable --boundary sme-v2 --freeze-receipt-digest <sha256> --equality equality_2 --forward-fix fix/w6-1 --json"], parse: parseAuthorityCutoverArgs, run: runAuthorityCutoverCommand, ...shared },
+  {
+    kind: "authority-repo-enroll",
+    usage: "authority repo enroll --repo-id <id> --repo-root <path> --manifest <path> --service-state-root <path> [--key-registry <path>] [--namespace-ttl-ms <ms>] [--allow-executor <agent-id>]... [--json]",
+    options: [
+      { flag: "--repo-id", description: "Stable repository id to enroll." },
+      { flag: "--repo-root", description: "Canonical repository root; private key material is forbidden below it." },
+      { flag: "--manifest", description: "Authority production manifest to create or extend." },
+      { flag: "--service-state-root", description: "External service-state root for the authority key store." },
+      { flag: "--key-registry", description: "Optional external authority key registry path." },
+      { flag: "--namespace-ttl-ms", description: "Optional positive operation-namespace lifetime in milliseconds." },
+      { flag: "--allow-executor", description: "Executor agent id allowed by the new repository manifest; repeat to add ids." },
+      { flag: "--json", description: "Emit command-receipt/v2 JSON." }
+    ],
+    summary: "Generate and pin an independent authority key, registry, and signed manifest entry for a repository; then start its daemon and make the first governance write.",
+    examples: [
+      "harness-anything authority repo enroll --repo-id billing --repo-root . --manifest /var/lib/ha/authority-production.json --service-state-root /var/lib/ha/service-state --json",
+      "ha --repo billing daemon start --service --authority-manifest /var/lib/ha/authority-production.json --json",
+      "ha --repo billing task create --title \"first governance write\" --json"
+    ],
+    parse: parseAuthorityRepoArgs,
+    run: runAuthorityRepoCommand,
+    receiptContract: { data: ["report"], paths: ["primary"] },
+    eventPolicy: { conflictMarkerPreflight: false, runtimeEvent: "none" }
+  },
+  {
+    kind: "authority-repo-resign",
+    usage: "authority repo resign --repo-id <id> --manifest <path> [--key-registry <path>] [--switch-record <path>] [--namespace-ttl-ms <ms>] [--json]",
+    options: [
+      { flag: "--repo-id", description: "Repository id whose current trust domain will be replaced." },
+      { flag: "--manifest", description: "Existing authority production manifest." },
+      { flag: "--key-registry", description: "Optional external path for the new public key registry." },
+      { flag: "--switch-record", description: "Optional external path for the prepared/applied trust-domain switch record." },
+      { flag: "--namespace-ttl-ms", description: "Optional positive operation-namespace lifetime in milliseconds." },
+      { flag: "--json", description: "Emit command-receipt/v2 JSON." }
+    ],
+    summary: "Resign one repository into a new trust domain and retain verifiable previous-domain evidence.",
+    examples: ["harness-anything authority repo resign --repo-id billing --manifest /var/lib/ha/authority-production.json --json"],
+    parse: parseAuthorityRepoArgs,
+    run: runAuthorityRepoCommand,
+    receiptContract: { data: ["report"], paths: ["primary"] },
+    eventPolicy: { conflictMarkerPreflight: false, runtimeEvent: "none" }
+  }
 ]);

--- a/packages/cli/src/cli/parsers/authority-repo.ts
+++ b/packages/cli/src/cli/parsers/authority-repo.ts
@@ -1,0 +1,87 @@
+import { cliError, CliErrorCode } from "../error-codes.ts";
+import { readOption, readRepeatedRawOption } from "../parse-options.ts";
+import type { CliResult, ParsedCommand } from "../types.ts";
+
+type ParseResult = { readonly ok: true; readonly value: ParsedCommand } | { readonly ok: false; readonly error: CliResult["error"] };
+type AuthorityRepoAction = Extract<ParsedCommand["action"], { readonly kind: `authority-repo-${string}` }>;
+
+export function parseAuthorityRepoArgs(args: ReadonlyArray<string>, rootDir: string, json: boolean): ParseResult | null {
+  if (args[0] !== "authority" || args[1] !== "repo") return null;
+  const subcommand = args[2];
+  if (subcommand === "enroll") return parseEnroll(args, rootDir, json);
+  if (subcommand === "resign") return parseResign(args, rootDir, json);
+  return parseFailure("Use authority repo enroll or authority repo resign.");
+}
+
+function parseEnroll(args: ReadonlyArray<string>, rootDir: string, json: boolean): ParseResult {
+  const repoId = authorityRequiredOption(args, "--repo-id");
+  const repoRoot = authorityRequiredOption(args, "--repo-root");
+  const manifestPath = authorityRequiredOption(args, "--manifest");
+  const serviceStateRoot = authorityRequiredOption(args, "--service-state-root");
+  const keyRegistryPath = authorityOptionalOption(args, "--key-registry");
+  const namespaceTtlMs = authorityPositiveInteger(args, "--namespace-ttl-ms");
+  const allowedExecutorAgentIds = repeated(args, "--allow-executor");
+  if (!repoId || !repoRoot || !manifestPath || !serviceStateRoot || namespaceTtlMs === null) {
+    return parseFailure("authority repo enroll requires --repo-id, --repo-root, --manifest, and --service-state-root; --namespace-ttl-ms must be a positive integer when supplied.");
+  }
+  return parseSuccess(rootDir, json, {
+    kind: "authority-repo-enroll",
+    repoId,
+    repoRoot,
+    manifestPath,
+    serviceStateRoot,
+    ...(keyRegistryPath ? { keyRegistryPath } : {}),
+    ...(namespaceTtlMs !== undefined ? { namespaceTtlMs } : {}),
+    allowedExecutorAgentIds: allowedExecutorAgentIds.length > 0 ? allowedExecutorAgentIds : ["codex"]
+  });
+}
+
+function parseResign(args: ReadonlyArray<string>, rootDir: string, json: boolean): ParseResult {
+  const repoId = authorityRequiredOption(args, "--repo-id");
+  const manifestPath = authorityRequiredOption(args, "--manifest");
+  const keyRegistryPath = authorityOptionalOption(args, "--key-registry");
+  const switchRecordPath = authorityOptionalOption(args, "--switch-record");
+  const namespaceTtlMs = authorityPositiveInteger(args, "--namespace-ttl-ms");
+  if (!repoId || !manifestPath || namespaceTtlMs === null) {
+    return parseFailure("authority repo resign requires --repo-id and --manifest; --namespace-ttl-ms must be a positive integer when supplied.");
+  }
+  return parseSuccess(rootDir, json, {
+    kind: "authority-repo-resign",
+    repoId,
+    manifestPath,
+    ...(keyRegistryPath ? { keyRegistryPath } : {}),
+    ...(switchRecordPath ? { switchRecordPath } : {}),
+    ...(namespaceTtlMs !== undefined ? { namespaceTtlMs } : {})
+  });
+}
+
+function authorityRequiredOption(args: ReadonlyArray<string>, name: string): string | undefined {
+  const value = authorityOptionalOption(args, name);
+  return value;
+}
+
+function authorityOptionalOption(args: ReadonlyArray<string>, name: string): string | undefined {
+  if (!args.includes(name)) return undefined;
+  const value = readOption(args, name);
+  return value && !value.startsWith("--") ? value : undefined;
+}
+
+function repeated(args: ReadonlyArray<string>, name: string): ReadonlyArray<string> {
+  return readRepeatedRawOption(args, name).map((value) => value ?? "").filter((value) => value.length > 0 && !value.startsWith("--"));
+}
+
+function authorityPositiveInteger(args: ReadonlyArray<string>, name: string): number | undefined | null {
+  if (!args.includes(name)) return undefined;
+  const value = authorityOptionalOption(args, name);
+  if (!value || !/^\d+$/u.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parseSuccess(rootDir: string, json: boolean, action: AuthorityRepoAction): ParseResult {
+  return { ok: true, value: { rootDir, json, action } };
+}
+
+function parseFailure(message: string): ParseResult {
+  return { ok: false, error: cliError(CliErrorCode.WriteRejected, message) };
+}

--- a/packages/cli/src/cli/receipt-command-kind.ts
+++ b/packages/cli/src/cli/receipt-command-kind.ts
@@ -14,6 +14,10 @@ export function receiptCommandKind(action: ParsedCommand["action"]): string {
       return `snapshot-${action.provider}`;
     case "external-list":
       return `list-${action.provider}`;
+    case "authority-repo-enroll":
+      return "authority repo enroll";
+    case "authority-repo-resign":
+      return "authority repo resign";
     case "preset-entrypoint":
       return `preset-${action.entrypointType}`;
     default:

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -314,6 +314,8 @@ export interface ParsedCommand {
     | { readonly kind: "authority-cutover-boundary"; readonly boundaryId: string; readonly equalityReceiptId: string; readonly expectedSelectedSchemaTupleDigest: string }
     | { readonly kind: "authority-cutover-freeze"; readonly reason: string; readonly expectedBoundaryReceiptDigest: string }
     | { readonly kind: "authority-cutover-re-enable"; readonly boundaryId: string; readonly expectedFreezeReceiptDigest: string; readonly equalityReceiptId: string; readonly forwardFixRef: string }
+    | { readonly kind: "authority-repo-enroll"; readonly repoId: string; readonly repoRoot: string; readonly manifestPath: string; readonly serviceStateRoot: string; readonly keyRegistryPath?: string; readonly namespaceTtlMs?: number; readonly allowedExecutorAgentIds: ReadonlyArray<string> }
+    | { readonly kind: "authority-repo-resign"; readonly repoId: string; readonly manifestPath: string; readonly keyRegistryPath?: string; readonly switchRecordPath?: string; readonly namespaceTtlMs?: number }
     | { readonly kind: "worktree-create"; readonly taskId: string; readonly agent?: string; readonly branchPrefix?: string; readonly baseRef?: string; readonly worktreePath?: string }
     | { readonly kind: "worktree-status"; readonly taskId: string }
     | { readonly kind: "graph"; readonly outputPath?: string; readonly focus?: string; readonly projectionPath?: string; readonly includeArchived: boolean }

--- a/packages/cli/src/commands/core/authority-repo.ts
+++ b/packages/cli/src/commands/core/authority-repo.ts
@@ -1,0 +1,56 @@
+import { Effect } from "effect";
+import {
+  enrollAuthorityRepo,
+  resignAuthorityRepo
+} from "@harness-anything/daemon";
+import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
+import type { CliResult } from "../../cli/types.ts";
+import type { CommandRunner } from "../../cli/runner-registry.ts";
+
+export const runAuthorityRepoCommand: CommandRunner = (_context, command) => Effect.sync(() => {
+  try {
+    if (command.action.kind === "authority-repo-enroll") {
+      const result = enrollAuthorityRepo({
+        repoId: command.action.repoId,
+        repoRoot: command.action.repoRoot,
+        manifestPath: command.action.manifestPath,
+        serviceStateRoot: command.action.serviceStateRoot,
+        ...(command.action.keyRegistryPath ? { keyRegistryPath: command.action.keyRegistryPath } : {}),
+        ...(command.action.namespaceTtlMs !== undefined ? { namespaceTtlMs: command.action.namespaceTtlMs } : {}),
+        allowedExecutorAgentIds: command.action.allowedExecutorAgentIds
+      });
+      return {
+        ok: true,
+        command: command.action.kind,
+        path: result.manifestPath,
+        report: result.report
+      } satisfies CliResult;
+    }
+    if (command.action.kind === "authority-repo-resign") {
+      const result = resignAuthorityRepo({
+        repoId: command.action.repoId,
+        manifestPath: command.action.manifestPath,
+        ...(command.action.keyRegistryPath ? { keyRegistryPath: command.action.keyRegistryPath } : {}),
+        ...(command.action.switchRecordPath ? { switchRecordPath: command.action.switchRecordPath } : {}),
+        ...(command.action.namespaceTtlMs !== undefined ? { namespaceTtlMs: command.action.namespaceTtlMs } : {})
+      });
+      return {
+        ok: true,
+        command: command.action.kind,
+        path: result.manifestPath,
+        report: result.report
+      } satisfies CliResult;
+    }
+    return {
+      ok: false,
+      command: command.action.kind,
+      error: cliError(CliErrorCode.UnknownCommand, "The authority repo runner received an unsupported action.")
+    } satisfies CliResult;
+  } catch (error) {
+    return {
+      ok: false,
+      command: command.action.kind,
+      error: cliError(CliErrorCode.WriteRejected, error instanceof Error ? error.message : String(error))
+    } satisfies CliResult;
+  }
+});

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -141,7 +141,9 @@ function isDaemonIndependentCommand(command: { readonly action: { readonly kind:
     || command.action.kind === "capabilities"
     || command.action.kind === "completion"
     || command.action.kind === "gui"
-    || command.action.kind === "git-diff";
+    || command.action.kind === "git-diff"
+    || command.action.kind === "authority-repo-enroll"
+    || command.action.kind === "authority-repo-resign";
 }
 
 async function maybeRunAgentRuntimeCommand(argv: ReadonlyArray<string>): Promise<number | undefined> {

--- a/packages/cli/test/authority-repo-enrollment.integration.test.ts
+++ b/packages/cli/test/authority-repo-enrollment.integration.test.ts
@@ -1,0 +1,241 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { createPublicKey, sign, verify } from "node:crypto";
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import type { AuthorityKeyRegistryV1 } from "../../application/src/index.ts";
+import {
+  authorityNamespaceProofBytes,
+  loadAuthorityProductionManifest,
+  openLocalAuthorityKeyStore
+} from "@harness-anything/daemon";
+import {
+  createProductionAuthorityLifecycleFixture as createFixture
+} from "./helpers/production-authority-lifecycle-fixture.ts";
+import {
+  runRawJson,
+  stopDaemon
+} from "./helpers/daemon-cli.ts";
+
+test("authority repo enrollment reaches a production daemon and its first governance write", { timeout: 60_000 }, async () => {
+  const fixture = createFixture();
+  const userRoot = path.join(fixture.root, "enrolled-daemon-user");
+  const serviceRoot = path.join(fixture.root, "enrolled-service-state");
+  const manifestPath = path.join(serviceRoot, "authority-production.json");
+  const env = productionCliEnv(userRoot);
+  try {
+    const enrolled = runRawJson(fixture.repoRoot, [
+      "authority", "repo", "enroll",
+      "--repo-id", "enrolled",
+      "--repo-root", fixture.repoRoot,
+      "--manifest", manifestPath,
+      "--service-state-root", serviceRoot,
+      "--namespace-ttl-ms", "3600000"
+    ], env);
+    assert.equal(enrolled.ok, true, JSON.stringify(enrolled));
+    const enrollmentReport = receiptReport(enrolled);
+    assert.equal(enrollmentReport.trustDomain, "independent-per-repository");
+    assert.equal(enrollmentReport.authorityId, "authority.repo.enrolled");
+    assert.equal(
+      enrollmentReport.nextCommands?.daemonStart,
+      "ha --repo enrolled daemon start --service --authority-manifest " + JSON.stringify(manifestPath)
+    );
+    assert.doesNotMatch(JSON.stringify(enrolled), /BEGIN [A-Z ]*PRIVATE KEY|privateKey|\.pk8/u);
+
+    const started = runRawJson(fixture.repoRoot, [
+      "--repo", "enrolled",
+      "daemon", "start", "--service",
+      "--authority-manifest", manifestPath,
+      "--user-root", userRoot
+    ], env);
+    assert.equal(started.ok, true, JSON.stringify(started));
+    assert.equal(started.command, "daemon-start");
+
+    const firstWrite = runRawJson(fixture.repoRoot, [
+      "--repo", "enrolled",
+      "task", "create",
+      "--title", "first governance write"
+    ], env);
+    assert.equal(firstWrite.ok, true, JSON.stringify(firstWrite));
+    const taskData = receiptData(firstWrite);
+    assert.equal(taskData.status, "planned");
+    assert.equal(typeof taskData.taskId, "string");
+
+    const operation = latestOperation(serviceRoot, "enrolled");
+    assert.equal(operation.state, "COMMITTED", JSON.stringify(operation));
+    assert.equal(operation.receipt?.tag, "COMMITTED", JSON.stringify(operation));
+    assert.equal(typeof operation.commitSha, "string", JSON.stringify(operation));
+    const manifest = loadAuthorityProductionManifest(manifestPath);
+    const config = manifest.repos.find((repo) => repo.repoId === "enrolled");
+    assert.ok(config);
+    assert.equal(config.authorityId, "authority.repo.enrolled");
+    assert.equal(verifyNamespace(config, readRegistry(config.keyRegistryPath)), true);
+  } finally {
+    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("authority repo resign preserves the old public domain, switches the manifest, and records both proofs", () => {
+  const fixture = createFixture({ repoIds: ["repo-a", "repo-b"] });
+  const manifestJson = JSON.parse(readFileSync(fixture.manifestPath, "utf8")) as {
+    readonly schema: string;
+    readonly serviceStateRoot: string;
+    repos: Array<Record<string, unknown>>;
+  };
+  const repoB = manifestJson.repos.find((repo) => repo.repoId === "repo-b");
+  const repoAFixture = fixture.repos.find((repo) => repo.repoId === "repo-a");
+  assert.ok(repoB);
+  assert.ok(repoAFixture);
+  try {
+    const oldRegistry = readRegistry(repoAFixture.registryPath);
+    const oldKeyStore = openLocalAuthorityKeyStore({
+      serviceStateRoot: fixture.serviceRoot,
+      stateDirectory: repoAFixture.keyStateDirectory,
+      workspaceRoot: repoAFixture.repoRoot,
+      authorityId: "authority.production",
+      issuer: "authority.production"
+    });
+    const activeOldKey = oldRegistry.entries.find((entry) => entry.state === "ACTIVE_SIGNING");
+    assert.ok(activeOldKey);
+    const oldNamespace = repoB.operationNamespace as Record<string, string>;
+    const unsignedSharedNamespace = {
+      schema: "operation-namespace/v1" as const,
+      workspaceId: oldNamespace.workspaceId,
+      deviceId: oldNamespace.deviceId,
+      authorityGeneration: BigInt(oldNamespace.authorityGeneration),
+      namespaceId: oldNamespace.namespaceId,
+      expiresAt: BigInt(oldNamespace.expiresAt),
+      issuer: "authority.production",
+      keyId: activeOldKey.keyId
+    };
+    const oldProfile = oldKeyStore.signingProfile(oldRegistry, Date.now());
+    if (oldProfile.algorithm !== "Ed25519") throw new Error("test fixture did not create an Ed25519 key");
+    const oldProof = sign(null, authorityNamespaceProofBytes(unsignedSharedNamespace), oldProfile.privateKey);
+    manifestJson.repos = manifestJson.repos.map((repo) => repo.repoId === "repo-b"
+      ? {
+          ...repo,
+          keyRegistryPath: repoAFixture.registryPath,
+          keyStateDirectory: repoAFixture.keyStateDirectory,
+          operationNamespace: {
+            ...unsignedSharedNamespace,
+            authorityGeneration: unsignedSharedNamespace.authorityGeneration.toString(),
+            expiresAt: unsignedSharedNamespace.expiresAt.toString(),
+            proof: oldProof.toString("base64url")
+          }
+        }
+      : repo);
+    writeFileSync(fixture.manifestPath, JSON.stringify(manifestJson, null, 2) + "\n");
+
+    const beforeManifest = loadAuthorityProductionManifest(fixture.manifestPath);
+    const before = beforeManifest.repos.find((repo) => repo.repoId === "repo-b");
+    assert.ok(before);
+    assert.equal(verifyNamespace(before, oldRegistry), true);
+    const beforeSide = {
+      authorityId: before.authorityId,
+      registryManifestDigest: oldRegistry.manifestDigest,
+      namespaceId: before.operationNamespace.namespaceId
+    };
+
+    const resigned = runRawJson(fixture.repoRoot, [
+      "authority", "repo", "resign",
+      "--repo-id", "repo-b",
+      "--manifest", fixture.manifestPath
+    ], { HARNESS_DAEMON_MODE: "local" });
+    assert.equal(resigned.ok, true, JSON.stringify(resigned));
+    assert.doesNotMatch(JSON.stringify(resigned), /BEGIN [A-Z ]*PRIVATE KEY|privateKey|\.pk8/u);
+    const resignReport = receiptReport(resigned);
+    const switchRecordPath = String(resignReport.switchRecordPath);
+    const switchRecord = JSON.parse(readFileSync(switchRecordPath, "utf8")) as Record<string, any>;
+    assert.equal(switchRecord.state, "applied");
+    assert.equal(switchRecord.sharedAuthorityDetected, true);
+    assert.equal(switchRecord.previous.namespaceProofVerified, true);
+    assert.equal(switchRecord.next.namespaceProofVerified, true);
+    assert.equal(switchRecord.previous.registryManifestDigest, beforeSide.registryManifestDigest);
+    assert.equal(switchRecord.previous.namespace.namespaceId, beforeSide.namespaceId);
+    assert.equal(switchRecord.previous.publicKeyRegistry.manifestDigest, oldRegistry.manifestDigest);
+    assert.doesNotMatch(JSON.stringify(switchRecord), /BEGIN [A-Z ]*PRIVATE KEY|privateKey|\.pk8/u);
+
+    const afterManifest = loadAuthorityProductionManifest(fixture.manifestPath);
+    const after = afterManifest.repos.find((repo) => repo.repoId === "repo-b");
+    const repoAAfter = afterManifest.repos.find((repo) => repo.repoId === "repo-a");
+    assert.ok(after);
+    assert.ok(repoAAfter);
+    const nextRegistry = readRegistry(after.keyRegistryPath);
+    assert.notEqual(after.authorityId, beforeSide.authorityId);
+    assert.notEqual(after.authorityId, repoAAfter.authorityId);
+    assert.equal(verifyNamespace(after, nextRegistry), true);
+    assert.equal(switchRecord.next.authorityId, after.authorityId);
+    assert.equal(switchRecord.next.registryManifestDigest, nextRegistry.manifestDigest);
+    assert.equal(repoAAfter.authorityId, "authority.production");
+    assert.equal(repoAAfter.keyRegistryPath, repoAFixture.registryPath);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+function productionCliEnv(userRoot: string): Readonly<Record<string, string>> {
+  return {
+    HARNESS_ACTOR: "agent:codex",
+    HARNESS_DAEMON_MODE: "local",
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_IDLE_MS: "60000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
+    HARNESS_DAEMON_REQUEST_TIMEOUT_MS: "35000",
+    CODEX_THREAD_ID: "authority-repo-enrollment-integration"
+  };
+}
+
+function receiptData(receipt: Record<string, unknown>): Record<string, any> {
+  const details = receipt.details as Record<string, unknown> | undefined;
+  return (details?.data as Record<string, any> | undefined) ?? {};
+}
+
+function receiptReport(receipt: Record<string, unknown>): Record<string, any> {
+  const report = receiptData(receipt).report;
+  assert.ok(report && typeof report === "object" && !Array.isArray(report), JSON.stringify(receipt));
+  return report as Record<string, any>;
+}
+
+function latestOperation(serviceRoot: string, repoId: string): Record<string, any> {
+  const operationPath = path.join(serviceRoot, "authority", Buffer.from(repoId, "utf8").toString("base64url"), "operations.jsonl");
+  const rows = readFileSync(operationPath, "utf8").split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as { readonly table?: string; readonly value?: Record<string, any> })
+    .filter((row) => row.table === "operation" && row.value);
+  assert.ok(rows.length > 0, operationPath);
+  return rows.at(-1)!.value!;
+}
+
+function readRegistry(registryPath: string): AuthorityKeyRegistryV1 {
+  return JSON.parse(readFileSync(registryPath, "utf8")) as AuthorityKeyRegistryV1;
+}
+
+function verifyNamespace(
+  config: ReturnType<typeof loadAuthorityProductionManifest>["repos"][number],
+  registry: AuthorityKeyRegistryV1
+): boolean {
+  const entry = registry.entries.find((candidate) =>
+    candidate.keyId === config.operationNamespace.keyId
+    && candidate.authorityId === config.authorityId
+    && candidate.issuer === config.issuer
+    && candidate.generation === config.authorityGeneration
+  );
+  assert.ok(entry);
+  const publicKey = createPublicKey({
+    key: Buffer.from(entry.publicKeySpki, "base64url"),
+    format: "der",
+    type: "spki"
+  });
+  return verify(null, authorityNamespaceProofBytes({
+    schema: config.operationNamespace.schema,
+    workspaceId: config.operationNamespace.workspaceId,
+    deviceId: config.operationNamespace.deviceId,
+    authorityGeneration: config.operationNamespace.authorityGeneration,
+    namespaceId: config.operationNamespace.namespaceId,
+    expiresAt: config.operationNamespace.expiresAt,
+    issuer: config.operationNamespace.issuer,
+    keyId: config.operationNamespace.keyId
+  }), publicKey, config.operationNamespace.proof);
+}

--- a/packages/cli/test/parse-args.test.ts
+++ b/packages/cli/test/parse-args.test.ts
@@ -39,6 +39,8 @@ const parseCases: ReadonlyArray<ParseCase> = [
   { name: "init", argv: ["init"], kind: "init", fields: { addNpmScripts: false } },
   { name: "init add npm scripts", argv: ["init", "--add-npm-scripts"], kind: "init", fields: { addNpmScripts: true } },
   { name: "init project name", argv: ["init", "--name", "human-kernel"], kind: "init", fields: { projectName: "human-kernel" } },
+  { name: "authority repo enroll", argv: ["authority", "repo", "enroll", "--repo-id", "billing", "--repo-root", "repo", "--manifest", "manifest.json", "--service-state-root", "state"], kind: "authority-repo-enroll", fields: { repoId: "billing", repoRoot: "repo", manifestPath: "manifest.json", serviceStateRoot: "state", allowedExecutorAgentIds: ["codex"] } },
+  { name: "authority repo resign", argv: ["authority", "repo", "resign", "--repo-id", "billing", "--manifest", "manifest.json"], kind: "authority-repo-resign", fields: { repoId: "billing", manifestPath: "manifest.json" } },
   { name: "authority cutover status", argv: ["authority", "cutover", "status"], kind: "authority-cutover-status" },
   { name: "authority cutover drain classify", argv: ["authority", "cutover", "drain", "--classify", `op-1|retryable-not-committed|${"a".repeat(64)}|rehearsal/op-1`], kind: "authority-cutover-drain", fields: { classifications: [{ opId: "op-1", disposition: "retryable-not-committed", recordedTupleDigest: "a".repeat(64), evidenceRef: "rehearsal/op-1" }] } },
   { name: "authority cutover scan", argv: ["authority", "cutover", "scan"], kind: "authority-cutover-scan", fields: { profileId: "production-final-scan/v1" } },

--- a/packages/cli/test/snapshots/capabilities-command-kinds.json
+++ b/packages/cli/test/snapshots/capabilities-command-kinds.json
@@ -12,7 +12,9 @@
     "authority-cutover-freeze",
     "authority-cutover-re-enable",
     "authority-cutover-scan",
-    "authority-cutover-status"
+    "authority-cutover-status",
+    "authority-repo-enroll",
+    "authority-repo-resign"
   ],
   "cas": [
     "cas-gc"

--- a/packages/daemon/src/authority/production/authority-repo-enrollment-support.ts
+++ b/packages/daemon/src/authority/production/authority-repo-enrollment-support.ts
@@ -1,0 +1,437 @@
+import { createPublicKey, randomUUID, sign, verify } from "node:crypto";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync
+} from "node:fs";
+import {
+  assertAuthorityKeyRegistryV1,
+  type AuthorityKeyRegistryV1,
+  type ProtocolSchemaTupleV2
+} from "@harness-anything/application";
+import path from "node:path";
+import {
+  type LocalAuthorityKeyStore
+} from "../local-key-store.ts";
+import {
+  authorityNamespaceProofBytes,
+  loadAuthorityProductionManifest,
+  type AuthorityProductionRepoConfigV1
+} from "./authority-production-state.ts";
+
+const defaultNamespaceTtlMs = 365 * 24 * 60 * 60 * 1_000;
+const productionManifestSchema = "authority-production-composition/v1" as const;
+const switchRecordSchema = "authority-trust-domain-switch/v1" as const;
+
+interface JsonManifest {
+  readonly schema: typeof productionManifestSchema;
+  readonly serviceStateRoot: string;
+  readonly repos: ReadonlyArray<Record<string, unknown>>;
+}
+
+function createNamespace(input: {
+  readonly repoId: string;
+  readonly authorityId: string;
+  readonly issuer: string;
+  readonly keyId: string;
+  readonly workspaceId: string;
+  readonly deviceId: string;
+  readonly viewId: string;
+  readonly sessionId: string;
+  readonly namespaceId: string;
+  readonly expiresAt: number;
+}): {
+  readonly schema: "operation-namespace/v1";
+  readonly workspaceId: string;
+  readonly deviceId: string;
+  readonly authorityGeneration: bigint;
+  readonly namespaceId: string;
+  readonly expiresAt: bigint;
+  readonly issuer: string;
+  readonly keyId: string;
+} {
+  return {
+    schema: "operation-namespace/v1",
+    workspaceId: authorityRepoRequiredText(input.workspaceId, "workspaceId"),
+    deviceId: authorityRepoRequiredText(input.deviceId, "deviceId"),
+    authorityGeneration: 1n,
+    namespaceId: authorityRepoRequiredText(input.namespaceId, "namespaceId"),
+    expiresAt: BigInt(authorityRepoNonNegativeInteger(input.expiresAt, "expiresAt")),
+    issuer: authorityRepoRequiredText(input.issuer, "issuer"),
+    keyId: authorityRepoRequiredText(input.keyId, "keyId")
+  };
+}
+
+function signedNamespaceJson(
+  namespace: ReturnType<typeof createNamespace>,
+  proof: Uint8Array
+): Record<string, unknown> {
+  return {
+    ...namespace,
+    authorityGeneration: namespace.authorityGeneration.toString(),
+    expiresAt: namespace.expiresAt.toString(),
+    proof: Buffer.from(proof).toString("base64url")
+  };
+}
+
+function manifestRepoJson(input: {
+  readonly repoId: string;
+  readonly canonicalRoot: string;
+  readonly workspaceId: string;
+  readonly deviceId: string;
+  readonly viewId: string;
+  readonly sessionId: string;
+  readonly authorityId: string;
+  readonly issuer: string;
+  readonly keyRegistryPath: string;
+  readonly keyStateDirectory: string;
+  readonly schemaTuple: ProtocolSchemaTupleV2;
+  readonly authorityGeneration: number;
+  readonly revocationEpochs: Record<string, string>;
+  readonly admissionTokenRef: string;
+  readonly allowedExecutorAgentIds: ReadonlyArray<string>;
+  readonly operationNamespace: Record<string, unknown>;
+  readonly bootstrapBindings: ReadonlyArray<unknown>;
+}): Record<string, unknown> {
+  return {
+    repoId: requiredRepoId(input.repoId),
+    canonicalRoot: input.canonicalRoot,
+    workspaceId: authorityRepoRequiredText(input.workspaceId, "workspaceId"),
+    deviceId: authorityRepoRequiredText(input.deviceId, "deviceId"),
+    viewId: authorityRepoRequiredText(input.viewId, "viewId"),
+    sessionId: authorityRepoRequiredText(input.sessionId, "sessionId"),
+    authorityId: authorityRepoRequiredText(input.authorityId, "authorityId"),
+    issuer: authorityRepoRequiredText(input.issuer, "issuer"),
+    keyRegistryPath: input.keyRegistryPath,
+    keyStateDirectory: input.keyStateDirectory,
+    schemaTuple: input.schemaTuple,
+    authorityGeneration: input.authorityGeneration,
+    revocationEpochs: input.revocationEpochs,
+    admissionTokenRef: authorityRepoRequiredText(input.admissionTokenRef, "admissionTokenRef"),
+    allowedExecutorAgentIds: [...input.allowedExecutorAgentIds],
+    operationNamespace: input.operationNamespace,
+    bootstrapBindings: [...input.bootstrapBindings]
+  };
+}
+
+function authorityDomainSnapshot(
+  config: AuthorityProductionRepoConfigV1,
+  registry: AuthorityKeyRegistryV1,
+  namespaceProofVerified: boolean
+): Record<string, unknown> {
+  return {
+    authorityId: config.authorityId,
+    issuer: config.issuer,
+    workspaceId: config.workspaceId,
+    deviceId: config.deviceId,
+    viewId: config.viewId,
+    sessionId: config.sessionId,
+    authorityGeneration: config.authorityGeneration,
+    keyRegistryPath: config.keyRegistryPath,
+    keyStateDirectory: config.keyStateDirectory,
+    keyId: config.operationNamespace.keyId,
+    registryManifestDigest: registry.manifestDigest,
+    publicKeyRegistry: registry,
+    namespaceId: config.operationNamespace.namespaceId,
+    namespaceProofVerified,
+    namespace: signedNamespaceSnapshot(config.operationNamespace)
+  };
+}
+
+function signWithAuthorityKey(message: Uint8Array, profile: ReturnType<LocalAuthorityKeyStore["signingProfile"]>): Buffer {
+  if (profile.algorithm !== "Ed25519") throw new Error("AUTHORITY_REPO_ED25519_SIGNER_REQUIRED");
+  return sign(null, message, profile.privateKey);
+}
+
+function signedNamespaceSnapshot(namespace: AuthorityProductionRepoConfigV1["operationNamespace"]): Record<string, unknown> {
+  return {
+    schema: namespace.schema,
+    workspaceId: namespace.workspaceId,
+    deviceId: namespace.deviceId,
+    authorityGeneration: namespace.authorityGeneration.toString(),
+    namespaceId: namespace.namespaceId,
+    expiresAt: namespace.expiresAt.toString(),
+    issuer: namespace.issuer,
+    keyId: namespace.keyId,
+    proof: Buffer.from(namespace.proof).toString("base64url")
+  };
+}
+
+function switchRecordJson(input: {
+  readonly state: "prepared" | "applied";
+  readonly repoId: string;
+  readonly canonicalRoot: string;
+  readonly recordedAt: string;
+  readonly appliedAt?: string;
+  readonly sharedAuthorityDetected: boolean;
+  readonly previous: Record<string, unknown>;
+  readonly next: Record<string, unknown>;
+  readonly ledgerContinuity: Record<string, unknown>;
+}): Record<string, unknown> {
+  return {
+    schema: switchRecordSchema,
+    state: input.state,
+    repoId: input.repoId,
+    canonicalRoot: input.canonicalRoot,
+    recordedAt: input.recordedAt,
+    ...(input.appliedAt ? { appliedAt: input.appliedAt } : {}),
+    sharedAuthorityDetected: input.sharedAuthorityDetected,
+    previous: input.previous,
+    next: input.next,
+    ledgerContinuity: input.ledgerContinuity
+  };
+}
+
+function verifyNamespaceAgainstRegistry(
+  config: AuthorityProductionRepoConfigV1,
+  registry: AuthorityKeyRegistryV1
+): boolean {
+  const entry = registry.entries.find((candidate) =>
+    candidate.keyId === config.operationNamespace.keyId
+    && candidate.authorityId === config.authorityId
+    && candidate.issuer === config.issuer
+    && candidate.generation === config.authorityGeneration
+  );
+  if (!entry) throw new Error("AUTHORITY_REPO_OLD_NAMESPACE_KEY_NOT_FOUND");
+  const publicKey = createPublicKey({
+    key: Buffer.from(entry.publicKeySpki, "base64url"),
+    format: "der",
+    type: "spki"
+  });
+  const verified = verify(
+    null,
+    authorityNamespaceProofBytes({
+      schema: config.operationNamespace.schema,
+      workspaceId: config.operationNamespace.workspaceId,
+      deviceId: config.operationNamespace.deviceId,
+      authorityGeneration: config.operationNamespace.authorityGeneration,
+      namespaceId: config.operationNamespace.namespaceId,
+      expiresAt: config.operationNamespace.expiresAt,
+      issuer: config.operationNamespace.issuer,
+      keyId: config.operationNamespace.keyId
+    }),
+    publicKey,
+    config.operationNamespace.proof
+  );
+  if (!verified) throw new Error("AUTHORITY_REPO_OLD_NAMESPACE_PROOF_INVALID");
+  return true;
+}
+
+function readRegistry(registryPath: string): AuthorityKeyRegistryV1 {
+  const registry = JSON.parse(readFileSync(registryPath, "utf8")) as AuthorityKeyRegistryV1;
+  assertAuthorityKeyRegistryV1(registry);
+  return registry;
+}
+
+function readManifest(manifestPath: string): JsonManifest {
+  const parsed = readJsonManifest(manifestPath);
+  if (parsed.schema !== productionManifestSchema || !Array.isArray(parsed.repos)) {
+    throw new Error("AUTHORITY_PRODUCTION_MANIFEST_SCHEMA_INVALID");
+  }
+  return parsed;
+}
+
+function readOptionalManifest(manifestPath: string): JsonManifest | undefined {
+  if (!pathEntryExists(manifestPath)) return undefined;
+  return readManifest(manifestPath);
+}
+
+function readJsonManifest(manifestPath: string): JsonManifest {
+  const parsed = JSON.parse(readFileSync(manifestPath, "utf8")) as Record<string, unknown>;
+  if (parsed.schema !== productionManifestSchema || typeof parsed.serviceStateRoot !== "string" || !Array.isArray(parsed.repos)) {
+    throw new Error("AUTHORITY_PRODUCTION_MANIFEST_SCHEMA_INVALID");
+  }
+  return {
+    schema: productionManifestSchema,
+    serviceStateRoot: parsed.serviceStateRoot,
+    repos: parsed.repos.map((repo) => {
+      if (!repo || typeof repo !== "object" || Array.isArray(repo)) throw new Error("AUTHORITY_PRODUCTION_MANIFEST_REPO_INVALID");
+      return repo as Record<string, unknown>;
+    })
+  };
+}
+
+function appendManifestRepo(
+  existing: JsonManifest | undefined,
+  serviceStateRoot: string,
+  repo: Record<string, unknown>
+): Record<string, unknown> {
+  return {
+    schema: productionManifestSchema,
+    serviceStateRoot: existing?.serviceStateRoot ?? serviceStateRoot,
+    repos: [...(existing?.repos ?? []), repo]
+  };
+}
+
+function replaceManifestRepo(
+  existing: JsonManifest,
+  repoId: string,
+  replacement: Record<string, unknown>
+): Record<string, unknown> {
+  return {
+    schema: productionManifestSchema,
+    serviceStateRoot: existing.serviceStateRoot,
+    repos: existing.repos.map((repo) => readManifestRepoId(repo) === repoId ? replacement : repo)
+  };
+}
+
+function writeManifestAtomically(
+  manifestPath: string,
+  manifest: Record<string, unknown>,
+  newUuid: () => string
+): void {
+  ensureParentDirectory(manifestPath);
+  const temporary = `${manifestPath}.${newUuid()}.tmp`;
+  try {
+    writeFileSync(temporary, `${JSON.stringify(manifest, null, 2)}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    loadAuthorityProductionManifest(temporary);
+    rejectExistingSymlink(manifestPath, "manifestPath");
+    renameSync(temporary, manifestPath);
+  } finally {
+    removeCreatedFile(temporary);
+  }
+}
+
+function writeJsonExclusive(filePath: string, value: unknown): void {
+  ensureParentDirectory(filePath);
+  const temporary = `${filePath}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    rejectExistingSymlink(filePath, "outputPath");
+    renameSync(temporary, filePath);
+  } finally {
+    removeCreatedFile(temporary);
+  }
+}
+
+function writeJsonAtomically(filePath: string, value: unknown, newUuid: () => string): void {
+  ensureParentDirectory(filePath);
+  const temporary = `${filePath}.${newUuid()}.tmp`;
+  try {
+    writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    rejectExistingSymlink(filePath, "outputPath");
+    renameSync(temporary, filePath);
+  } finally {
+    removeCreatedFile(temporary);
+  }
+}
+
+function existingRealPath(value: string, label: string): string {
+  const absolute = authorityRepoAbsolutePath(value);
+  if (!existsSync(absolute)) throw new Error(`AUTHORITY_REPO_PATH_NOT_FOUND:${label}:${absolute}`);
+  return realpathSync(absolute);
+}
+
+function resolveManifestPath(value: string, manifestPath: string): string {
+  return authorityRepoRealpathIfPresent(path.resolve(path.dirname(manifestPath), value));
+}
+
+function authorityRepoAbsolutePath(value: string): string {
+  if (typeof value !== "string" || value.trim() === "" || value.includes("\0")) {
+    throw new Error("AUTHORITY_REPO_PATH_INVALID");
+  }
+  return path.resolve(value);
+}
+
+function assertExternalServiceState(serviceStateRoot: string, repoRoot: string): void {
+  if (samePath(serviceStateRoot, repoRoot) || authorityRepoIsDescendant(serviceStateRoot, repoRoot) || authorityRepoIsDescendant(repoRoot, serviceStateRoot)) {
+    throw new Error("AUTHORITY_REPO_SERVICE_STATE_MUST_BE_EXTERNAL");
+  }
+}
+
+function assertNewFile(filePath: string, label: string): void {
+  if (pathEntryExists(filePath)) throw new Error(`AUTHORITY_REPO_OUTPUT_EXISTS:${label}:${filePath}`);
+}
+
+function rejectExistingSymlink(filePath: string, label: string): void {
+  if (!pathEntryExists(filePath)) return;
+  const stat = lstatSync(filePath);
+  if (stat.isSymbolicLink()) throw new Error(`AUTHORITY_REPO_OUTPUT_SYMLINK_UNSAFE:${label}`);
+}
+
+function pathEntryExists(filePath: string): boolean {
+  try {
+    lstatSync(filePath);
+    return true;
+  } catch (error) {
+    if (authorityRepoIsMissing(error)) return false;
+    throw error;
+  }
+}
+
+function shellArgument(value: string): string {
+  return JSON.stringify(value);
+}
+
+function ensureParentDirectory(filePath: string): void {
+  mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+}
+
+function removeCreatedFile(filePath: string): void {
+  try {
+    unlinkSync(filePath);
+  } catch (error) {
+    if (!authorityRepoIsMissing(error)) throw error;
+  }
+}
+
+function readManifestRepoId(repo: Record<string, unknown>): string | undefined {
+  return typeof repo.repoId === "string" ? repo.repoId : undefined;
+}
+
+function oneEpochJson(): Record<string, string> {
+  return { global: "1", workspace: "1", device: "1", view: "1", principal: "1", executor: "1" };
+}
+
+function requiredRepoId(value: string): string {
+  if (typeof value !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/u.test(value)) {
+    throw new Error("AUTHORITY_REPO_ID_INVALID: use letters, digits, dot, underscore, or hyphen");
+  }
+  return value;
+}
+
+function authorityRepoRequiredText(value: string, label: string): string {
+  if (typeof value !== "string" || value.trim() === "" || value.includes("\0")) {
+    throw new Error(`AUTHORITY_REPO_FIELD_INVALID:${label}`);
+  }
+  return value;
+}
+
+function authorityRepoPositiveInteger(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 1) throw new Error(`AUTHORITY_REPO_FIELD_INVALID:${label}`);
+  return value;
+}
+
+function authorityRepoNonNegativeInteger(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error(`AUTHORITY_REPO_FIELD_INVALID:${label}`);
+  return value;
+}
+
+function samePath(left: string, right: string): boolean {
+  return authorityRepoRealpathIfPresent(left) === authorityRepoRealpathIfPresent(right);
+}
+
+function authorityRepoRealpathIfPresent(value: string): string {
+  try {
+    return realpathSync(value);
+  } catch (error) {
+    if (authorityRepoIsMissing(error)) return path.resolve(value);
+    throw error;
+  }
+}
+
+function authorityRepoIsDescendant(candidate: string, root: string): boolean {
+  const relative = path.relative(authorityRepoRealpathIfPresent(root), authorityRepoRealpathIfPresent(candidate));
+  return relative !== "" && relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+}
+
+function authorityRepoIsMissing(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && (error as { readonly code?: unknown }).code === "ENOENT";
+}
+
+export { defaultNamespaceTtlMs, createNamespace, signedNamespaceJson, manifestRepoJson, authorityDomainSnapshot, signWithAuthorityKey, signedNamespaceSnapshot, switchRecordJson, verifyNamespaceAgainstRegistry, readRegistry, readManifest, readOptionalManifest, readJsonManifest, appendManifestRepo, replaceManifestRepo, writeManifestAtomically, writeJsonExclusive, writeJsonAtomically, existingRealPath, resolveManifestPath, authorityRepoAbsolutePath, assertExternalServiceState, assertNewFile, rejectExistingSymlink, pathEntryExists, shellArgument, ensureParentDirectory, removeCreatedFile, readManifestRepoId, oneEpochJson, requiredRepoId, authorityRepoRequiredText, authorityRepoPositiveInteger, authorityRepoNonNegativeInteger, samePath, authorityRepoRealpathIfPresent, authorityRepoIsDescendant, authorityRepoIsMissing };

--- a/packages/daemon/src/authority/production/authority-repo-enrollment.ts
+++ b/packages/daemon/src/authority/production/authority-repo-enrollment.ts
@@ -1,0 +1,389 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import {
+  createAuthorityKeyRegistryV1,
+  firstPinAuthorityKeyV1,
+  type ProtocolSchemaTupleV2
+} from "@harness-anything/application";
+import { openLocalAuthorityKeyStore } from "../local-key-store.ts";
+import {
+  authorityNamespaceProofBytes,
+  loadAuthorityProductionManifest
+} from "./authority-production-state.ts";
+import {
+  appendManifestRepo,
+  assertExternalServiceState,
+  assertNewFile,
+  authorityDomainSnapshot,
+  createNamespace,
+  defaultNamespaceTtlMs,
+  existingRealPath,
+  manifestRepoJson,
+  authorityRepoNonNegativeInteger,
+  oneEpochJson,
+  authorityRepoPositiveInteger,
+  readManifest,
+  readManifestRepoId,
+  readOptionalManifest,
+  readRegistry,
+  resolveManifestPath,
+  removeCreatedFile,
+  replaceManifestRepo,
+  requiredRepoId,
+  samePath,
+  shellArgument,
+  signWithAuthorityKey,
+  signedNamespaceJson,
+  switchRecordJson,
+  verifyNamespaceAgainstRegistry,
+  writeJsonAtomically,
+  writeJsonExclusive,
+  writeManifestAtomically,
+  authorityRepoAbsolutePath
+} from "./authority-repo-enrollment-support.ts";
+
+export const productionAuthoritySchemaTupleV2 = {
+  wire: 2,
+  event: 2,
+  receipt: 2,
+  digest: 2,
+  policy: 2,
+  commandRegistry: 1,
+  entityRegistry: 1,
+  mutationRegistry: 1,
+  localState: 1,
+  applyJournal: 1
+} as const satisfies ProtocolSchemaTupleV2;
+
+export interface AuthorityRepoEnrollmentInput {
+  readonly repoId: string;
+  readonly repoRoot: string;
+  readonly manifestPath: string;
+  readonly serviceStateRoot: string;
+  readonly keyRegistryPath?: string;
+  readonly namespaceTtlMs?: number;
+  readonly allowedExecutorAgentIds?: ReadonlyArray<string>;
+  readonly nowMs?: number;
+  readonly newUuid?: () => string;
+}
+
+export interface AuthorityRepoResignInput {
+  readonly repoId: string;
+  readonly manifestPath: string;
+  readonly keyRegistryPath?: string;
+  readonly switchRecordPath?: string;
+  readonly namespaceTtlMs?: number;
+  readonly nowMs?: number;
+  readonly newUuid?: () => string;
+}
+
+export interface AuthorityRepoEnrollmentResult {
+  readonly manifestPath: string;
+  readonly keyRegistryPath: string;
+  readonly keyStateDirectory: string;
+  readonly serviceStateRoot: string;
+  readonly report: Readonly<Record<string, unknown>>;
+}
+
+export interface AuthorityRepoResignResult {
+  readonly manifestPath: string;
+  readonly keyRegistryPath: string;
+  readonly keyStateDirectory: string;
+  readonly switchRecordPath: string;
+  readonly report: Readonly<Record<string, unknown>>;
+}
+
+export function enrollAuthorityRepo(input: AuthorityRepoEnrollmentInput): AuthorityRepoEnrollmentResult {
+  const nowMs = authorityRepoNonNegativeInteger(input.nowMs ?? Date.now(), "nowMs");
+  const newUuid = input.newUuid ?? randomUUID;
+  const repoId = requiredRepoId(input.repoId);
+  const repoRoot = existingRealPath(input.repoRoot, "repoRoot");
+  const manifestPath = authorityRepoAbsolutePath(input.manifestPath);
+  const serviceStateRoot = authorityRepoAbsolutePath(input.serviceStateRoot);
+  assertExternalServiceState(serviceStateRoot, repoRoot);
+  const namespaceTtlMs = authorityRepoPositiveInteger(input.namespaceTtlMs ?? defaultNamespaceTtlMs, "namespaceTtlMs");
+  const existing = readOptionalManifest(manifestPath);
+  if (existing?.repos.some((repo) => readManifestRepoId(repo) === repoId)) {
+    throw new Error("AUTHORITY_REPO_ALREADY_ENROLLED:" + repoId);
+  }
+  if (existing && resolveManifestPath(existing.serviceStateRoot, manifestPath) !== serviceStateRoot) {
+    throw new Error("AUTHORITY_REPO_SERVICE_STATE_ROOT_MISMATCH");
+  }
+
+  const authorityId = "authority.repo." + repoId;
+  const issuer = authorityId;
+  const authorityDirectory = path.join(serviceStateRoot, "authority", repoId);
+  const keyStateDirectory = path.join(authorityDirectory, "keys");
+  const keyRegistryPath = authorityRepoAbsolutePath(input.keyRegistryPath ?? path.join(authorityDirectory, "authority-key-registry.json"));
+  assertNewFile(keyRegistryPath, "keyRegistryPath");
+  const keyStore = openLocalAuthorityKeyStore({
+    serviceStateRoot,
+    stateDirectory: keyStateDirectory,
+    workspaceRoot: repoRoot,
+    authorityId,
+    issuer,
+    forbiddenRoots: [repoRoot]
+  });
+
+  let generatedKeyId: string | undefined;
+  let registryWritten = false;
+  try {
+    const prepublished = keyStore.createPrepublishedKey({ generation: 1, nowMs: Math.max(0, nowMs - 1) });
+    generatedKeyId = prepublished.keyId;
+    const registry = firstPinAuthorityKeyV1({
+      registry: createAuthorityKeyRegistryV1({
+        authorityId,
+        generation: 1,
+        globalRevocationEpoch: 1,
+        revision: 1,
+        entries: [prepublished]
+      }),
+      keyId: prepublished.keyId,
+      expectedPinnedKeyId: prepublished.keyId,
+      pinEvidence: "ha authority repo enroll:" + repoId,
+      verifierAcknowledgement: "local enrollment generated and pinned this repository authority key",
+      activatedAtMs: nowMs
+    });
+    const workspaceId = "workspace-" + repoId;
+    const deviceId = "device-" + newUuid();
+    const viewId = "view-" + newUuid();
+    const sessionId = "session-" + newUuid();
+    const namespace = createNamespace({
+      repoId,
+      authorityId,
+      issuer,
+      keyId: prepublished.keyId,
+      workspaceId,
+      deviceId,
+      viewId,
+      sessionId,
+      namespaceId: "namespace-" + newUuid(),
+      expiresAt: nowMs + namespaceTtlMs
+    });
+    const proof = signWithAuthorityKey(authorityNamespaceProofBytes(namespace), keyStore.signingProfile(registry, nowMs));
+    const manifestRepo = manifestRepoJson({
+      repoId,
+      canonicalRoot: repoRoot,
+      workspaceId: namespace.workspaceId,
+      deviceId: namespace.deviceId,
+      viewId,
+      sessionId,
+      authorityId,
+      issuer,
+      keyRegistryPath,
+      keyStateDirectory,
+      schemaTuple: productionAuthoritySchemaTupleV2,
+      authorityGeneration: 1,
+      revocationEpochs: oneEpochJson(),
+      admissionTokenRef: "admission-" + newUuid(),
+      allowedExecutorAgentIds: [...(input.allowedExecutorAgentIds ?? ["codex"])],
+      operationNamespace: signedNamespaceJson(namespace, proof),
+      bootstrapBindings: []
+    });
+    writeJsonExclusive(keyRegistryPath, registry);
+    registryWritten = true;
+    writeManifestAtomically(manifestPath, appendManifestRepo(existing, serviceStateRoot, manifestRepo), newUuid);
+    return {
+      manifestPath,
+      keyRegistryPath,
+      keyStateDirectory,
+      serviceStateRoot,
+      report: {
+        schema: "authority-repo-enrollment-report/v1",
+        repoId,
+        canonicalRoot: repoRoot,
+        authorityId,
+        issuer,
+        keyId: prepublished.keyId,
+        manifestPath,
+        keyRegistryPath,
+        keyStateDirectory,
+        namespaceId: namespace.namespaceId,
+        namespaceExpiresAt: namespace.expiresAt.toString(),
+        trustDomain: "independent-per-repository",
+        peopleRoster: {
+          project: "<repo-root>/harness/people.yaml",
+          machine: "<daemon-user-root>/people.yaml",
+          note: "The daemon merges the machine roster first and the repository roster as an overlay."
+        },
+        nextCommands: {
+          daemonStart: "ha --repo " + repoId + " daemon start --service --authority-manifest " + shellArgument(manifestPath),
+          firstGovernanceWrite: "ha --repo " + repoId + " task create --title " + shellArgument("first governance write")
+        }
+      }
+    };
+  } catch (error) {
+    if (registryWritten) removeCreatedFile(keyRegistryPath);
+    if (generatedKeyId) {
+      try {
+        keyStore.destroyPrivateKey(generatedKeyId);
+      } catch {
+        // Preserve the original failure without exposing key material.
+      }
+    }
+    throw error;
+  }
+}
+
+export function resignAuthorityRepo(input: AuthorityRepoResignInput): AuthorityRepoResignResult {
+  const nowMs = authorityRepoNonNegativeInteger(input.nowMs ?? Date.now(), "nowMs");
+  const newUuid = input.newUuid ?? randomUUID;
+  const repoId = requiredRepoId(input.repoId);
+  const manifestPath = existingRealPath(input.manifestPath, "manifestPath");
+  const existing = readManifest(manifestPath);
+  const loaded = loadAuthorityProductionManifest(manifestPath);
+  const oldConfig = loaded.repos.find((repo) => repo.repoId === repoId);
+  if (!oldConfig) throw new Error("AUTHORITY_REPO_NOT_FOUND:" + repoId);
+  const oldRegistry = readRegistry(oldConfig.keyRegistryPath);
+  if (oldRegistry.authorityId !== oldConfig.authorityId || oldRegistry.generation !== oldConfig.authorityGeneration) {
+    throw new Error("AUTHORITY_REPO_OLD_KEY_REGISTRY_SCOPE_MISMATCH");
+  }
+  const oldNamespaceProof = verifyNamespaceAgainstRegistry(oldConfig, oldRegistry);
+  const serviceStateRoot = loaded.serviceStateRoot;
+  const namespaceTtlMs = authorityRepoPositiveInteger(input.namespaceTtlMs ?? defaultNamespaceTtlMs, "namespaceTtlMs");
+  const nextAuthorityId = "authority.repo." + repoId + "." + newUuid();
+  const nextIssuer = nextAuthorityId;
+  const authorityDirectory = path.join(serviceStateRoot, "authority", repoId, nextAuthorityId);
+  const keyStateDirectory = path.join(authorityDirectory, "keys");
+  const keyRegistryPath = authorityRepoAbsolutePath(input.keyRegistryPath ?? path.join(authorityDirectory, "authority-key-registry.json"));
+  assertNewFile(keyRegistryPath, "keyRegistryPath");
+  const switchRecordPath = authorityRepoAbsolutePath(input.switchRecordPath ?? path.join(
+    serviceStateRoot,
+    "authority",
+    repoId,
+    "trust-domain-switches",
+    nowMs + "-" + newUuid() + ".json"
+  ));
+  assertNewFile(switchRecordPath, "switchRecordPath");
+  assertExternalServiceState(serviceStateRoot, oldConfig.canonicalRoot);
+
+  const keyStore = openLocalAuthorityKeyStore({
+    serviceStateRoot,
+    stateDirectory: keyStateDirectory,
+    workspaceRoot: oldConfig.canonicalRoot,
+    authorityId: nextAuthorityId,
+    issuer: nextIssuer,
+    forbiddenRoots: [oldConfig.canonicalRoot]
+  });
+  let generatedKeyId: string | undefined;
+  let registryWritten = false;
+  let manifestReplaced = false;
+  try {
+    const prepublished = keyStore.createPrepublishedKey({ generation: 1, nowMs: Math.max(0, nowMs - 1) });
+    generatedKeyId = prepublished.keyId;
+    const registry = firstPinAuthorityKeyV1({
+      registry: createAuthorityKeyRegistryV1({
+        authorityId: nextAuthorityId,
+        generation: 1,
+        globalRevocationEpoch: 1,
+        revision: 1,
+        entries: [prepublished]
+      }),
+      keyId: prepublished.keyId,
+      expectedPinnedKeyId: prepublished.keyId,
+      pinEvidence: "ha authority repo resign:" + repoId,
+      verifierAcknowledgement: "local enrollment generated a new independent repository trust domain",
+      activatedAtMs: nowMs
+    });
+    const nextNamespace = createNamespace({
+      repoId,
+      authorityId: nextAuthorityId,
+      issuer: nextIssuer,
+      keyId: prepublished.keyId,
+      workspaceId: oldConfig.workspaceId,
+      deviceId: oldConfig.deviceId,
+      viewId: oldConfig.viewId,
+      sessionId: oldConfig.sessionId,
+      namespaceId: "namespace-" + newUuid(),
+      expiresAt: nowMs + namespaceTtlMs
+    });
+    const nextProof = signWithAuthorityKey(authorityNamespaceProofBytes(nextNamespace), keyStore.signingProfile(registry, nowMs));
+    const nextManifestRepo = manifestRepoJson({
+      repoId,
+      canonicalRoot: oldConfig.canonicalRoot,
+      workspaceId: nextNamespace.workspaceId,
+      deviceId: nextNamespace.deviceId,
+      viewId: oldConfig.viewId,
+      sessionId: oldConfig.sessionId,
+      authorityId: nextAuthorityId,
+      issuer: nextIssuer,
+      keyRegistryPath,
+      keyStateDirectory,
+      schemaTuple: oldConfig.schemaTuple,
+      authorityGeneration: 1,
+      revocationEpochs: oneEpochJson(),
+      admissionTokenRef: "admission-" + newUuid(),
+      allowedExecutorAgentIds: [...oldConfig.allowedExecutorAgentIds],
+      operationNamespace: signedNamespaceJson(nextNamespace, nextProof),
+      bootstrapBindings: []
+    });
+    writeJsonExclusive(keyRegistryPath, registry);
+    registryWritten = true;
+    const sharedAuthorityDetected = loaded.repos
+      .filter((repo) => repo.repoId !== repoId)
+      .some((repo) => repo.authorityId === oldConfig.authorityId
+        && samePath(repo.keyRegistryPath, oldConfig.keyRegistryPath)
+        && samePath(repo.keyStateDirectory, oldConfig.keyStateDirectory));
+    const nextConfig = {
+      ...oldConfig,
+      authorityId: nextAuthorityId,
+      issuer: nextIssuer,
+      keyRegistryPath,
+      keyStateDirectory,
+      authorityGeneration: 1,
+      operationNamespace: { ...nextNamespace, proof: nextProof }
+    };
+    const preparedRecord = switchRecordJson({
+      state: "prepared",
+      repoId,
+      canonicalRoot: oldConfig.canonicalRoot,
+      recordedAt: new Date(nowMs).toISOString(),
+      sharedAuthorityDetected,
+      previous: authorityDomainSnapshot(oldConfig, oldRegistry, oldNamespaceProof),
+      next: authorityDomainSnapshot(nextConfig, registry, true),
+      ledgerContinuity: {
+        kind: "historical-ledger-retained-under-previous-trust-domain",
+        previousNamespaceId: oldConfig.operationNamespace.namespaceId,
+        nextNamespaceId: nextNamespace.namespaceId,
+        evidence: "The previous public key registry and namespace are retained in this switch record; new writes use only the next namespace."
+      }
+    });
+    writeJsonExclusive(switchRecordPath, preparedRecord);
+    writeManifestAtomically(manifestPath, replaceManifestRepo(existing, repoId, nextManifestRepo), newUuid);
+    manifestReplaced = true;
+    writeJsonAtomically(switchRecordPath, { ...preparedRecord, state: "applied", appliedAt: new Date().toISOString() }, newUuid);
+    return {
+      manifestPath,
+      keyRegistryPath,
+      keyStateDirectory,
+      switchRecordPath,
+      report: {
+        schema: "authority-repo-resign-report/v1",
+        repoId,
+        manifestPath,
+        switchRecordPath,
+        previous: authorityDomainSnapshot(oldConfig, oldRegistry, oldNamespaceProof),
+        next: authorityDomainSnapshot(nextConfig, registry, true),
+        sharedAuthorityDetected,
+        ledgerContinuity: "See the applied switch record for the previous namespace and public key evidence."
+      }
+    };
+  } catch (error) {
+    if (manifestReplaced) {
+      try {
+        writeManifestAtomically(manifestPath, { ...existing }, newUuid);
+      } catch {
+        // Preserve the original failure; the prepared record remains operator-visible.
+      }
+    }
+    if (registryWritten) removeCreatedFile(keyRegistryPath);
+    if (generatedKeyId) {
+      try {
+        keyStore.destroyPrivateKey(generatedKeyId);
+      } catch {
+        // Preserve the original failure without exposing key material.
+      }
+    }
+    throw error;
+  }
+}

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -9,6 +9,7 @@ export * from "./authority/production/service-state.ts";
 export * from "./authority/production/authority-attribution-event-v2-production-recovery.ts";
 export * from "./authority/production/authority-manifest-registry.ts";
 export * from "./authority/production/authority-production-state.ts";
+export * from "./authority/production/authority-repo-enrollment.ts";
 export * from "./authority/production/production-authority-attempt-compiler.ts";
 export * from "./authority/production/production-authority-lifecycle-intents.ts";
 export * from "./authority/production/production-authority-lifecycle.ts";

--- a/packages/daemon/src/protocol/method-registry.ts
+++ b/packages/daemon/src/protocol/method-registry.ts
@@ -328,7 +328,9 @@ const adminCliActionKinds = new Set<string>([
   "authority-cutover-freeze",
   "authority-cutover-re-enable",
   "authority-cutover-scan",
-  "authority-cutover-status"
+  "authority-cutover-status",
+  "authority-repo-enroll",
+  "authority-repo-resign"
 ]);
 
 export const repoCommandRunClassifiedActionKinds = [


### PR DESCRIPTION
# English

## Summary

First-mile authority enrollment, adjudicated by decision `dec_01KZ3Z0ZBFVCTNS2CG47TTV840` (independent trust domain per repository). Until now the only thing in the repository that could sign a production authority manifest entry was a test fixture — a real user enrolling a new repository had to copy test code into a hand-rolled script and, in practice, reused the canonical private key, silently merging four business repositories into one trust domain (friction report #3 + appendix B). This PR turns issuance into a user-reachable command surface.

## What Changed

- **`ha authority repo enroll`**: generates an independent per-repository authority key (external key store, `keyStateDirectory` layout), writes the public registry, signs the operation-namespace proof, and appends the signed production manifest entry. `--help` carries the full next-step chain (enroll → `daemon start --service --authority-manifest` → first governance write).
- **`ha authority repo resign`**: migrates an existing shared-key repository into a fresh trust domain. The old public registry/namespace evidence is preserved verbatim in an `authority-trust-domain-switch/v1` record (`state=applied`, `sharedAuthorityDetected`), with both old-domain and new-domain proofs verified; history is not re-signed into the new domain.
- **First-mile regression test**: `packages/cli/test/authority-repo-enrollment.integration.test.ts` boots a real production daemon from a synthetic enrollment and completes the first governance write (`task create` → COMMITTED), plus a resign three-way check (before / switch record / after).
- Support surface: enrollment core in `packages/daemon/src/authority/production/authority-repo-enrollment{,-support}.ts`, CLI spec/parser/runner wiring, admin classification of the new action kinds in the method registry.

## Task And Scope

- Task `task_01KZ3Z2KR8KY996WXKFVRD885G`; report at `artifacts/implementation-report.md`. 14 files, +1,275/−4, purely additive (no kernel changes, no authority verification-semantics changes).
- Deliberately out of scope: actually migrating the four production business repositories — that is a separately approved production window using this tooling (dry-run → audit → approve → execute).

## Version Impact

- New CLI subcommands under `ha authority repo`; no changes to existing manifest schema (already-signed manifests continue to load). No persisted-state schema changes.

## Governance Declaration

- No protected surfaces touched; no CI/gate authority files modified. Not a governance task; no break-glass.

## Verification

- `npm run check:local` green after rebase onto latest main (81.3s, 27 manifest gates).
- Full integration tier green at the pre-rebase base (exit 0); the two new integration tests re-verified green on the rebased head (2/2 pass, 8.7s).
- Usability acceptance in the report: help-only enrollment of a fresh synthetic repository reaches a running production daemon and a COMMITTED first governance write, with receipts containing no private-key material.

## Review Evidence

- CEO semantic review against decision `dec_01KZ3Z0ZBF`: per-repo independent trust domain enforced (enrolled repo gets its own authority id/key/namespace, distinct from canonical and from other repos); resign is an explicit tool-level transition record rather than an invented continuity signature — matching the adjudicated boundary.
- Rebase onto main d60d6891 was clean; diff face re-verified additive (+1,275/−4).

## Residual Risk

- Audit/history consumers must learn to interpret `authority-trust-domain-switch/v1` records at domain boundaries.
- Enrollment requires the caller to provide an external `service-state-root`; daemon first start uses `--repo <id>` to avoid mis-registering the new repository as canonical.
- Production migration of the four shared-key repositories (approval, backup window, key rotation) remains a follow-up production-window task.

## References

- Decision `dec_01KZ3Z0ZBFVCTNS2CG47TTV840`; friction report #3 + appendix B (task `task_01KZ3XES4V69C4WXBR7JPVNSG9` artifacts); task `task_01KZ3Z2KR8KY996WXKFVRD885G`.

---

# 中文

## 概要

authority 签发首公里，落实裁决 `dec_01KZ3Z0ZBFVCTNS2CG47TTV840`（每仓独立信任域）。此前全仓唯一会签 production authority manifest 条目的是测试 fixture——真实用户给新仓 enrollment 只能照抄测试代码手搓脚本，并且实际复用了 canonical 私钥，把四个业务仓静默并进了同一个信任域（摩擦报告 #3 + 附录 B）。本 PR 把签发变成用户可达的命令面。

## 改动内容

- **`ha authority repo enroll`**：生成每仓独立 authority key（外置 key store，遵循 `keyStateDirectory` 布局），写 public registry，签 operation-namespace proof，追加已签名的 production manifest 条目。`--help` 自带完整下一步链（enroll → `daemon start --service --authority-manifest` → 首条治理写）。
- **`ha authority repo resign`**：把既有共钥仓迁入新信任域。旧 public registry/namespace 证据原样保存进 `authority-trust-domain-switch/v1` record（`state=applied`、`sharedAuthorityDetected`），新旧两域 proof 都验证通过；不把历史重签进新域。
- **首公里回归测试**：`packages/cli/test/authority-repo-enrollment.integration.test.ts` 从合成 enrollment 拉起真实 production daemon 并完成首条治理写（`task create` → COMMITTED），另含重签三侧对照（before / switch record / after）。
- 支撑面：enrollment 核心在 `packages/daemon/src/authority/production/authority-repo-enrollment{,-support}.ts`，CLI spec/parser/runner 接线，method registry 里新 action kind 的 admin 分类。

## 任务与范围

- 任务 `task_01KZ3Z2KR8KY996WXKFVRD885G`；报告在 `artifacts/implementation-report.md`。14 个文件，+1,275/−4，纯增量（不碰 kernel、不碰 authority 校验语义）。
- 明确不在范围内：实际迁移四个生产业务仓——那是使用本工具的独立生产窗口任务（dry-run → 审计 → 审批 → 执行）。

## 版本影响

- `ha authority repo` 下新增子命令；现有 manifest schema 无变更（已签 manifest 继续可加载）。无持久化 schema 变更。

## 治理声明

- 未触碰 protected surface；未修改 CI/gate 权威文件。非治理任务；无 break-glass。

## 验证

- rebase 到最新 main 后 `npm run check:local` 全绿（81.3s，27 个 manifest 门）。
- 完整 integration tier 在 rebase 前 base 上全绿（exit 0）；两个新增 integration 测试在 rebase 后 head 复验绿（2/2 过，8.7s）。
- 使用性验收见报告：只凭 help 给全新合成仓 enrollment，达到运行中的 production daemon 与 COMMITTED 首条治理写，receipt 不含任何私钥材料。

## 审查证据

- CEO 依裁决 `dec_01KZ3Z0ZBF` 做语义验收：每仓独立信任域成立（enrolled 仓拿到独立 authority id/key/namespace，与 canonical 及其他仓均不同）；resign 是显式工具级 transition record 而非伪造旧域连续签名——与裁决边界一致。
- rebase 到 main d60d6891 干净；diff 面复核为纯增量（+1,275/−4）。

## 残余风险

- 审计/历史消费者需要学会在域边界处解释 `authority-trust-domain-switch/v1` record。
- enrollment 要求调用者提供外置 `service-state-root`；daemon 首启用 `--repo <id>`，避免把新仓误注册为 canonical。
- 四个共钥仓的生产迁移（审批、备份窗口、真实 key rotation）仍是后续生产窗口任务。

## 关联材料

- 裁决 `dec_01KZ3Z0ZBFVCTNS2CG47TTV840`；摩擦报告 #3 + 附录 B（任务 `task_01KZ3XES4V69C4WXBR7JPVNSG9` artifacts）；任务 `task_01KZ3Z2KR8KY996WXKFVRD885G`。

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body complete / 双语正文完整
- [x] Non-governance task did not modify CI/gate authority surfaces / 非治理任务未修改 CI/gate 权威面
- [x] Verification is real command output, not assertion / 验证为真实命令输出而非断言
- [x] Residual risk honestly stated / 残余风险如实陈述
