### PR TITLE
test(cli): cover task-submit canonical ingress parity (nightly perf-matrix red)

### DIFF
--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -237,8 +237,22 @@ test("production service route preserves progress dry-run and publishes canonica
       `tasks/${sluggedLifecycleTaskId}-production-route/code-doc-anchors.json`
     )), true, "owner-stage reconciliation must publish code-doc anchors before completion");
 
+    const completionPacketPath = path.join(fixture.root, "slugged-completion.json");
+    writeFileSync(completionPacketPath, JSON.stringify({
+      findings: "Slugged production evidence is complete.",
+      evidenceChecked: ["ev_cli_1"],
+      rationale: "The submitted execution and reconciled code-doc evidence support completion.",
+      archiveWarningsAcknowledged: true,
+      consentAssertedRationale: "Approval was received through an external channel.",
+      consentActions: ["approve_execution", "complete_task"],
+      ci: "passed",
+      executionId: sluggedExecutionId,
+      commit: fixture.publicHead,
+      paths: ["README.md"],
+      reviewerId: "person_alice"
+    }));
     const completed = runRawJsonMaybeFail(fixture.repoRoot, [
-      "task", "complete", sluggedLifecycleTaskId, "--ci", "passed", "--reviewer", "person_alice"
+      "task", "complete", sluggedLifecycleTaskId, "--approve", "--from-file", completionPacketPath
     ], sluggedLifecycleEnv);
     assert.equal(completed.status, 0, JSON.stringify(completed.receipt));
     assert.equal(completed.receipt.ok, true, JSON.stringify(completed.receipt));
@@ -378,6 +392,9 @@ test("production generic canonical ingress accepts and journals one write for ev
         gid: process.getgid?.() ?? 0
       }
     });
+    const paritySubmitTaskId = "task_01KXQ4WTA7Q4XJ5GDDRS1YXNJ0";
+    const paritySubmitExecutionId = "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNJ1";
+    const paritySubmitSessionId = "service-wave2-submit-session";
     const cases: ReadonlyArray<{
       readonly kind: string;
       readonly action: ParsedCommand["action"];
@@ -427,10 +444,31 @@ test("production generic canonical ingress accepts and journals one write for ev
       authoredMarker: /decision\/dec_INGRESS\/C1/u
     }, {
       kind: "session",
-      action: { kind: "session-export", sessionId: "session-ingress", runtime: "codex", source: "manual", detectedAt: "2026-07-17T00:00:00.000Z", transcriptFile: fixture.transcriptPath },
-      canonicalEntityId: "entity/session/session-ingress" as EntityId,
-      authoredPath: "sessions/session-ingress.md",
-      authoredMarker: /session-ingress/u
+      action: { kind: "session-export", sessionId: paritySubmitSessionId, runtime: "codex", source: "manual", detectedAt: "2026-07-17T00:00:00.000Z", transcriptFile: fixture.transcriptPath },
+      canonicalEntityId: `entity/session/${paritySubmitSessionId}` as EntityId,
+      authoredPath: `sessions/${paritySubmitSessionId}.md`,
+      authoredMarker: /service-wave2-submit-session/u
+    }, {
+      kind: "task-submit",
+      action: {
+        kind: "task-submit",
+        taskId: paritySubmitTaskId,
+        executionId: paritySubmitExecutionId,
+        leaseToken: null,
+        submission: {
+          completionClaim: "Generic canonical task-submit ingress qualified.",
+          deliverables: ["execution submission"],
+          verificationNotes: ["generic canonical ingress"],
+          knownGaps: [],
+          residualRisks: [],
+          outputs: ["task-submit output evidence"]
+        },
+        callerIdempotencyKey: "generic-task-submit-ingress",
+        dryRun: false
+      },
+      canonicalEntityId: `execution/${paritySubmitExecutionId}` as EntityId,
+      authoredPath: `tasks/${paritySubmitTaskId}/executions/${paritySubmitExecutionId}.md`,
+      authoredMarker: /"state": "submitted"/u
     }, {
       kind: "review",
       action: {
@@ -491,14 +529,33 @@ test("production generic canonical ingress accepts and journals one write for ev
       kind: "task-complete",
       action: {
         kind: "task-complete", taskId: "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0",
-        reviewerId: "person_alice", evidenceMode: "execution-review"
+        executionId: "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG5",
+        ciGate: "passed",
+        reviewerId: "person_alice",
+        evidenceMode: "execution-review",
+        commitRef: fixture.publicHead,
+        judgment: null,
+        approval: {
+          executionId: "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG5",
+          findings: "All production evidence verified.",
+          evidenceChecked: ["evidence:ingress"],
+          rationale: "Consent-backed evidence satisfies the closeout contract.",
+          archiveWarningsAcknowledged: true,
+          consentSource: { kind: "recorded-consent", consentId: "cns_01KXQ4WTA7Q4XJ5GDDRS1YXNG3" },
+          consentActions: null,
+          paths: ["README.md"],
+          prRef: null
+        },
+        externalCheckpointRefs: [],
+        callerIdempotencyKey: "generic-task-complete-ingress",
+        dryRun: false
       },
       canonicalEntityId: "execution/exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG5" as EntityId,
       authoredPath: "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0/INDEX.md",
       authoredMarker: /status: done/u
     }];
     const coveredKinds = new Set(cases.map((fixtureCase) => fixtureCase.kind));
-    assert.equal(["consent", "decision", "fact", "module", "relation", "review", "session", "task"]
+    assert.equal(["consent", "decision", "fact", "module", "relation", "review", "session", "task", "task-submit"]
       .every((kind) => coveredKinds.has(kind)), true);
     for (const [index, fixtureCase] of cases.entries()) {
       const sessionId = `real-cli-session-${index + 1}`;

--- a/packages/cli/test/production-authority-canonical-ingress/minimal-parameter-matrix.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/minimal-parameter-matrix.ts
@@ -31,6 +31,7 @@ export function verifyTypedMinimalParameterMatrix(
     "task-consent-record": { argv: ["task", "consent-record", missingTask, "--execution-id", missingExecution, "--utterance", "Approved"], outcome: "guided-error" },
     "task-retire-execution": { argv: ["task", "retire-execution", missingTask, "--execution-id", missingExecution, "--reason", "minimal"], outcome: "guided-error" },
     "task-review-execution": { argv: ["task", "review-execution", missingTask, "--execution-id", missingExecution, "--verdict", "dismissed", "--findings", "none", "--rationale", "minimal"], outcome: "guided-error" },
+    "task-submit": { argv: ["task", "submit", missingTask], outcome: "guided-error" },
     "task-complete": { argv: ["task", "complete", missingTask], outcome: "guided-error" },
     "decision-propose": { argv: ["decision", "propose", "--title", "Minimal ingress decision", "--question", "Minimal?", "--chosen", "Yes", "--rejected", "No", "--why-not", "Not selected"], outcome: "success" },
     "decision-transition": { argv: ["decision", "transition", "rejected", missingDecision], outcome: "guided-error" },


### PR DESCRIPTION
# English

## Summary

The nightly-integration `production-authority-perf-matrix` job has been red for two consecutive nights (runs 30764389717, 30849549560) on two canonical-ingress tests. Investigation verdict: **not** a production wiring gap — `task-submit` has been fully registered as a typed generic ingress kind since the steady-lifecycle L3 commit (`3bddce61`), with the CLI command spec, daemon compiler, and provenance/session chain all in place. The red was the ingress **coverage-parity alarm doing its job**: the test's minimal-parameter matrix missed `task-submit` while the expected kind list derives from the command-spec registry, so the parity assertion flagged the drift. A second failure in the service-route test was a stale `task-complete` fixture lagging the current strict typed contract.

## What Changed

Test-only (2 files under `packages/cli/test/production-authority-canonical-ingress/`):

- `minimal-parameter-matrix.ts`: add the `task-submit` minimal guided-error case so registry-derived kind parity is satisfied and future kind additions without coverage keep failing loudly.
- `canonical-ingress.test.ts`: add a real typed `task-submit` generic-ingress case (canonical session export → full typed action → assert watermark, journal attribution, and the execution document reaching `submitted`); align the stale `task-complete` fixture with the strict typed contract, reusing the same public commit/path as code-doc reconcile.

Wire-parity family sweep: L4 (`b4c64bd8`) added no new compiled kind; `task-complete` already covered; no other L4 kind lacks canonical ingress coverage.

## Task And Scope

- Task `task_01KZ55B1EJPCW2GX75E520KQ8M`, report `artifacts/implementation-report.md`. 2 test files, +65/−7. No production code, no schema, no CI/gate authority changes.

## Version Impact

- None (test-only).

## Governance Declaration

- No protected surfaces touched. Not a governance task; no break-glass.

## Verification

- Before (rebased onto main `00d0d86a`): targeted nightly-tier run reproduced both failures (0 pass / 2 fail, including the `- 'task-submit'` parity diff).
- After: same targeted run 2 pass / 0 fail (real durations 163.1s + 94.3s recorded in the report).
- `npm run check:local` green (36.9s, 27 gates; affected fast 413 pass, contract 90 pass). Governance walls: pass 9, red 0, expected 3.

## Review Evidence

- CEO semantic review: verdict "coverage drift, not design exclusion" verified against `production-authority-ingress.ts` (task-submit registered `typed("generic")` pre-existing); diff face confirmed test-only.
- Known follow-up: the repo `architecture-check` script returned a `script_result_failed` receipt with no diagnostics during verification — checker receipt anomaly unrelated to this diff, recorded in the report for separate follow-up.

## Residual Risk

- Nightly synthetic fixtures must keep tracking the strict typed contract; the parity matrix now guards `task-submit` like every other kind.
- Green confirmation of the nightly lane itself lands on the next scheduled run.

## References

- Nightly runs 30764389717 / 30849549560; task `task_01KZ55B1EJPCW2GX75E520KQ8M`; L3 commit `3bddce61`, L4 commit `b4c64bd8`.

---

# 中文

## 概要

nightly-integration 的 `production-authority-perf-matrix` job 连续两晚红（run 30764389717、30849549560），红在两条 canonical-ingress 测试。勘察裁定：**不是**生产接线缺口——`task-submit` 自 steady-lifecycle L3 提交（`3bddce61`）起就已注册为 typed generic ingress kind，CLI command spec、daemon compiler、provenance/session 链全部在位。红点是 ingress **覆盖 parity 告警器在正确工作**：测试的 minimal-parameter 矩阵漏了 `task-submit`，而期望 kind 列表从 command-spec registry 派生，parity 断言把漂移揪了出来。service-route 测试的第二处失败是 `task-complete` fixture 落后于当前 strict typed contract。

## 改动内容

纯测试面（`packages/cli/test/production-authority-canonical-ingress/` 下 2 文件）：

- `minimal-parameter-matrix.ts`：补 `task-submit` 最小 guided-error case，满足 registry 派生的 kind parity——未来再有人加 kind 不加覆盖仍会响亮失败。
- `canonical-ingress.test.ts`：加真实 typed `task-submit` generic-ingress case（canonical session export → 完整 typed action → 断言 watermark、journal attribution、execution 文档进入 `submitted`）；把落后的 `task-complete` fixture 对齐 strict typed contract，复用 code-doc reconcile 同一 public commit/path。

wire-parity 族自查：L4（`b4c64bd8`）未新增 compiled kind；`task-complete` 已覆盖；无其他 L4 kind 缺 canonical ingress 覆盖。

## 任务与范围

- 任务 `task_01KZ55B1EJPCW2GX75E520KQ8M`，报告 `artifacts/implementation-report.md`。2 个测试文件，+65/−7。零生产代码、零 schema、零 CI/gate 权威面改动。

## 版本影响

- 无（纯测试）。

## 治理声明

- 未触碰 protected surface。非治理任务；无 break-glass。

## 验证

- 修前（rebase 到 main `00d0d86a` 后）：定向 nightly tier 复现两条失败（0 过/2 败，含 `- 'task-submit'` parity diff）。
- 修后：同一定向跑 2 过/0 败（真实耗时 163.1s + 94.3s 见报告）。
- `npm run check:local` 全绿（36.9s，27 门；affected fast 413 过、contract 90 过）。治理 walls：pass 9，red 0，expected 3。

## 审查证据

- CEO 语义验收：「覆盖漂移非设计性排除」的裁定已对照 `production-authority-ingress.ts` 核实（task-submit 早已注册 `typed("generic")`）；diff 面确认纯测试。
- 已知跟进项：验证过程中仓内 `architecture-check` 脚本返回无诊断的 `script_result_failed` receipt——检查器 receipt 异常，与本 diff 无关，已记录在报告待单独跟进。

## 残余风险

- nightly 合成 fixture 需持续跟踪 strict typed contract；parity 矩阵现在像守其他 kind 一样守 `task-submit`。
- nightly 轨道本身的转绿在下一次定时 run 确认。

## 关联材料

- nightly run 30764389717 / 30849549560；任务 `task_01KZ55B1EJPCW2GX75E520KQ8M`；L3 提交 `3bddce61`、L4 提交 `b4c64bd8`。

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body complete / 双语正文完整
- [x] Non-governance task did not modify CI/gate authority surfaces / 非治理任务未修改 CI/gate 权威面
- [x] Verification is real command output, not assertion / 验证为真实命令输出而非断言
- [x] Residual risk honestly stated / 残余风险如实陈述
