### PR TITLE
perf(kernel): publish projection fingerprint after mismatch rebuild + self-attesting generation telemetry (round 10, final)

### DIFF
--- a/packages/daemon/src/lifecycle/run-daemon-serve.ts
+++ b/packages/daemon/src/lifecycle/run-daemon-serve.ts
@@ -305,7 +305,8 @@ export async function runDaemonServe<
                   requestId: frame.requestId,
                   ...(frame.opId ? { opId: frame.opId } : {}),
                   phase: frame.phase,
-                  elapsedMs: frame.elapsedMs
+                  elapsedMs: frame.elapsedMs,
+                  ...(frame.details ? { details: frame.details } : {})
                 }),
                 requestId: frame.requestId
               }, { repo }).catch(() => undefined);

--- a/packages/daemon/src/runtime/repo-runtime.ts
+++ b/packages/daemon/src/runtime/repo-runtime.ts
@@ -78,7 +78,7 @@ import { mergeRepoRuntimeDefaults, sortedRepoOptions } from "./repo-runtime-opti
 import { describeRepoRuntimeError } from "./repo-runtime-error.ts";
 import { acquireRepoRuntimeGlobalLock } from "./repo-runtime-lock.ts";
 import { bindCurrentRepoWriteTelemetry } from "./repo-write-telemetry-context.ts";
-import { reportFlushGitCommitPhase, reportFlushPostCommitPhase, reportFlushProjectionFingerprintPhase, runMaterializerWithRepoWriteTelemetry } from "./repo-write-materializer-telemetry.ts";
+import { reportFlushGitCommitPhase, reportFlushPostCommitPhase, reportFlushProjectionFingerprintDiagnostic, reportFlushProjectionFingerprintPhase, runMaterializerWithRepoWriteTelemetry } from "./repo-write-materializer-telemetry.ts";
 
 const defaultDaemonOperationalActor: OperationalActor = { scope: "operational", kind: "system", id: "daemon-runtime" };
 export type {
@@ -498,7 +498,7 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
       autoMaterialize: false,
       onProjectionChange: this.projectionChanges.publish,
       onCommitPhase: reportFlushGitCommitPhase,
-      onProjectionFingerprintPhase: reportFlushProjectionFingerprintPhase,
+      onProjectionFingerprintPhase: reportFlushProjectionFingerprintPhase, onProjectionFingerprintDiagnostic: reportFlushProjectionFingerprintDiagnostic,
       onPostCommitPhase: reportFlushPostCommitPhase,
       ...(request.sessionId ? { sessionId: request.sessionId } : {}),
       ...(request.commitAuthor ? { commitAuthor: request.commitAuthor } : {})

--- a/packages/daemon/src/runtime/repo-write-child-direct.ts
+++ b/packages/daemon/src/runtime/repo-write-child-direct.ts
@@ -90,8 +90,8 @@ export async function executeRepoWriteChildDirect(
   try {
     await options.responses.telemetry(message.requestId, "queue", 0);
     telemetry = createRepoWriteTelemetryDelivery(
-      (phase, elapsedMs) =>
-        options.responses.telemetry(message.requestId, phase, elapsedMs)
+      (phase, elapsedMs, details) =>
+        options.responses.telemetry(message.requestId, phase, elapsedMs, details)
     );
     const receipt = await runWithRepoWriteTelemetry(
       telemetry.report,

--- a/packages/daemon/src/runtime/repo-write-child-host.ts
+++ b/packages/daemon/src/runtime/repo-write-child-host.ts
@@ -195,8 +195,8 @@ export class RepoWriteChildHost {
     try {
       await this.responses.telemetry(message.requestId, "queue", 0);
       const telemetry = createRepoWriteTelemetryDelivery(
-        (phase, elapsedMs) =>
-          this.responses.telemetry(message.requestId, phase, elapsedMs)
+        (phase, elapsedMs, details) =>
+          this.responses.telemetry(message.requestId, phase, elapsedMs, details)
       );
       operation.telemetry = telemetry;
       const prepared = await runWithRepoWriteTelemetry(telemetry.report, () => {

--- a/packages/daemon/src/runtime/repo-write-child-response-writer.ts
+++ b/packages/daemon/src/runtime/repo-write-child-response-writer.ts
@@ -5,6 +5,7 @@ import {
   type RepoWriteChildMessage,
   type RepoWriteJsonObject,
   type RepoWriteOperationLookupResult,
+  type RepoWriteTelemetryDetails,
   type RepoWriteTelemetryPhase,
   type RepoWriteTerminalOutcome
 } from "./repo-write-protocol.ts";
@@ -88,14 +89,16 @@ export class RepoWriteChildResponseWriter {
   telemetry(
     requestId: string,
     phase: RepoWriteTelemetryPhase,
-    elapsedMs: number
+    elapsedMs: number,
+    details?: RepoWriteTelemetryDetails
   ): Promise<void> {
     return this.send({
       ...this.frameBase(),
       kind: "telemetry",
       requestId,
       phase,
-      elapsedMs
+      elapsedMs,
+      ...(details ? { details } : {})
     });
   }
 

--- a/packages/daemon/src/runtime/repo-write-diagnostic-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-diagnostic-protocol.ts
@@ -35,6 +35,7 @@ export const repoWriteTelemetryPhases = [
   "authority-flush-git-native-commit-done",
   "authority-flush-projection-fingerprint-start",
   "authority-flush-projection-fingerprint-done",
+  "authority-flush-projection-fingerprint-summary",
   "authority-flush-post-commit-attribution-confirm-start",
   "authority-flush-post-commit-attribution-confirm-done",
   "authority-flush-post-commit-projection-hash-start",
@@ -48,12 +49,16 @@ export const repoWriteTelemetryPhases = [
   "runtime-event-append-start", "runtime-event-append-done",
   "authority-materializer-start", "authority-materializer-baseline-start",
   "authority-materializer-baseline-done", "authority-materializer-merge-start",
+  "authority-materializer-baseline-fence", "authority-materializer-baseline-cache",
   "authority-materializer-merge-done", "authority-materializer-projection-start",
   "authority-materializer-projection-load-current", "authority-materializer-projection-capture-source",
   "authority-materializer-projection-derive-affected", "authority-materializer-projection-declared-delta",
   "authority-materializer-projection-hash-next", "authority-materializer-projection-verify-source",
   "authority-materializer-projection-source-cache-refresh",
   "authority-materializer-projection-source-cache-change",
+  "authority-materializer-projection-source-summary",
+  "authority-materializer-projection-metadata-summary",
+  "authority-materializer-projection-trusted-advance",
   "authority-materializer-projection-attribution-delta",
   "authority-materializer-projection-source-delta", "authority-materializer-projection-publish",
   "authority-materializer-projection-database-start",
@@ -104,12 +109,21 @@ export const repoWriteTelemetryPhases = [
 
 export type RepoWriteTelemetryPhase = typeof repoWriteTelemetryPhases[number];
 
+/**
+ * Optional telemetry context is deliberately flat and scalar. Producers use
+ * this for bounded counts, category hashes, and decision labels; authored
+ * content and raw paths never belong in a常开 diagnostic frame.
+ */
+export type RepoWriteTelemetryDetail = string | number | boolean | null;
+export type RepoWriteTelemetryDetails = Readonly<Record<string, RepoWriteTelemetryDetail>>;
+
 export interface RepoWriteTelemetryFrame extends RepoWriteDiagnosticFrameBase {
   readonly kind: "telemetry";
   readonly requestId: string;
   readonly opId?: string;
   readonly phase: RepoWriteTelemetryPhase;
   readonly elapsedMs: number;
+  readonly details?: RepoWriteTelemetryDetails;
 }
 
 export interface RepoWriteRecoveryDeferredFrame extends RepoWriteDiagnosticFrameBase {

--- a/packages/daemon/src/runtime/repo-write-materializer-telemetry.ts
+++ b/packages/daemon/src/runtime/repo-write-materializer-telemetry.ts
@@ -1,6 +1,7 @@
 import {
   runLedgerMaterializer,
   type IncrementalProjectionPhase,
+  type IncrementalProjectionDiagnostic,
   type IncrementalProjectionRebuildReason,
   type IncrementalTaskProjectionMode,
   type AttributionProjectionDecisionReason,
@@ -9,8 +10,13 @@ import {
   type LedgerMaterializerProgressStep,
   type VcsCommitPhase
 } from "@harness-anything/kernel";
+import type {
+  ProjectionSourceSummary,
+  ProjectionSourceWorktreeFenceDiagnostic,
+  TrustedProjectionFingerprintDiagnostic
+} from "@harness-anything/kernel";
 import { reportCurrentRepoWriteTelemetry } from "./repo-write-telemetry-context.ts";
-import type { RepoWriteTelemetryPhase } from "./repo-write-protocol.ts";
+import type { RepoWriteTelemetryDetails, RepoWriteTelemetryPhase } from "./repo-write-protocol.ts";
 
 const materializerProgressPhases: Record<LedgerMaterializerProgressStep, RepoWriteTelemetryPhase> = {
   "baseline-start": "authority-materializer-baseline-start",
@@ -172,6 +178,125 @@ export function reportFlushProjectionFingerprintPhase(phase: JournalProjectionFi
   reportCurrentRepoWriteTelemetry(projectionFingerprintPhases[phase]);
 }
 
+export function reportFlushProjectionFingerprintDiagnostic(
+  diagnostic: TrustedProjectionFingerprintDiagnostic
+): void {
+  reportProjectionDiagnostic(diagnostic, "flush");
+}
+
+type ProjectionDiagnostic = TrustedProjectionFingerprintDiagnostic | IncrementalProjectionDiagnostic;
+
+function reportProjectionDiagnostic(
+  diagnostic: ProjectionDiagnostic,
+  location: "flush" | "materializer"
+): void {
+  if (diagnostic.kind === "cache") {
+    if (diagnostic.fence) {
+      reportCurrentRepoWriteTelemetry(
+        location === "flush"
+          ? "authority-flush-projection-fingerprint-summary"
+          : "authority-materializer-baseline-fence",
+        fenceDetails(diagnostic.fence)
+      );
+    }
+    reportCurrentRepoWriteTelemetry(
+      location === "flush"
+        ? "authority-flush-projection-fingerprint-summary"
+        : "authority-materializer-baseline-cache",
+      {
+        kind: "cache",
+        outcome: diagnostic.outcome,
+        reason: diagnostic.reason,
+        head: diagnostic.head,
+        ...(diagnostic.cachedHead ? { cachedHead: diagnostic.cachedHead } : {}),
+        ...(diagnostic.cachedFingerprint ? { cachedFingerprint: diagnostic.cachedFingerprint } : {}),
+        ...(diagnostic.worktreeVerified !== undefined ? { worktreeVerified: diagnostic.worktreeVerified } : {})
+      }
+    );
+    if (diagnostic.summary) {
+      reportCurrentRepoWriteTelemetry(
+        location === "flush"
+          ? "authority-flush-projection-fingerprint-summary"
+          : "authority-materializer-projection-source-summary",
+        sourceSummaryDetails(diagnostic.summary)
+      );
+    }
+    return;
+  }
+
+  if (diagnostic.kind !== "advance") return;
+
+  reportCurrentRepoWriteTelemetry(
+    location === "flush"
+      ? "authority-flush-projection-fingerprint-summary"
+      : "authority-materializer-baseline-fence",
+    fenceDetails(diagnostic.fence)
+  );
+  reportCurrentRepoWriteTelemetry(
+    location === "flush"
+      ? "authority-flush-projection-fingerprint-summary"
+      : "authority-materializer-projection-trusted-advance",
+    {
+      kind: "advance",
+      outcome: diagnostic.outcome,
+      reason: diagnostic.reason,
+      head: diagnostic.head,
+      cachedHead: diagnostic.cachedHead,
+      cachedFingerprint: diagnostic.cachedFingerprint,
+      ...(diagnostic.fingerprint ? { fingerprint: diagnostic.fingerprint } : {})
+    }
+  );
+}
+
+export function reportMaterializerProjectionDiagnostic(
+  diagnostic: IncrementalProjectionDiagnostic
+): void {
+  reportCurrentRepoWriteTelemetry(
+    "authority-materializer-projection-source-summary",
+    sourceSummaryDetails(diagnostic.summary)
+  );
+  reportCurrentRepoWriteTelemetry(
+    "authority-materializer-projection-metadata-summary",
+    {
+      kind: "metadata",
+      phase: diagnostic.phase,
+      existingSourceHash: diagnostic.existingSourceHash,
+      ...(diagnostic.previousSourceFingerprint
+        ? { previousSourceFingerprint: diagnostic.previousSourceFingerprint }
+        : {}),
+      ...(diagnostic.storedSourceHash ? { storedSourceHash: diagnostic.storedSourceHash } : {})
+    }
+  );
+}
+
+function fenceDetails(fence: ProjectionSourceWorktreeFenceDiagnostic): RepoWriteTelemetryDetails {
+  return {
+    kind: "fence",
+    clean: fence.clean,
+    statusCount: fence.statusCount,
+    sourceDirtyCount: fence.sourceDirtyCount,
+    unparseableStatusCount: fence.unparseableStatusCount,
+    sourceDirtyCategoryHash: fence.sourceDirtyCategoryHash
+  };
+}
+
+function sourceSummaryDetails(summary: ProjectionSourceSummary): RepoWriteTelemetryDetails {
+  return {
+    kind: "source-summary",
+    taskEntryCount: summary.taskEntryCount,
+    taskInputCount: summary.taskInputCount,
+    taskSourceHash: summary.taskSourceHash,
+    declaredSourceCount: summary.declaredSourceCount,
+    declaredInputCount: summary.declaredInputCount,
+    declaredSourceHash: summary.declaredSourceHash,
+    attributionInputCount: summary.attributionInputCount,
+    attributionSourceHash: summary.attributionSourceHash,
+    legacyPersonIdCount: summary.legacyPersonIdCount,
+    legacyPersonIdsHash: summary.legacyPersonIdsHash,
+    fingerprint: summary.fingerprint
+  };
+}
+
 export function runMaterializerWithRepoWriteTelemetry(
   rootInput: Parameters<typeof runLedgerMaterializer>[0],
   options: NonNullable<Parameters<typeof runLedgerMaterializer>[1]> = {}
@@ -192,6 +317,14 @@ export function runMaterializerWithRepoWriteTelemetry(
         reportCurrentRepoWriteTelemetry(materializerProjectionModePhase(mode));
         if (reason) reportCurrentRepoWriteTelemetry(materializerProjectionRebuildReasonPhase(reason));
         options.onProjectionMode?.(mode, reason);
+      },
+      onProjectionDiagnostic: (diagnostic) => {
+        if (diagnostic.kind === "cache" || diagnostic.kind === "advance") {
+          reportProjectionDiagnostic(diagnostic, "materializer");
+        } else {
+          reportMaterializerProjectionDiagnostic(diagnostic);
+        }
+        options.onProjectionDiagnostic?.(diagnostic);
       },
       onProjectionAttributionDecision: (reason) => {
         reportCurrentRepoWriteTelemetry(materializerAttributionDecisionPhase(reason));

--- a/packages/daemon/src/runtime/repo-write-protocol-telemetry.ts
+++ b/packages/daemon/src/runtime/repo-write-protocol-telemetry.ts
@@ -1,0 +1,88 @@
+import {
+  repoWriteTelemetryPhases,
+  type RepoWriteTelemetryDetails,
+  type RepoWriteTelemetryFrame,
+  type RepoWriteTelemetryPhase
+} from "./repo-write-diagnostic-protocol.ts";
+import type { RepoWriteProtocolLimits } from "./repo-write-protocol.ts";
+import {
+  invalidRepoWriteProtocol as invalid,
+  limitRepoWriteProtocol as limit
+} from "./repo-write-protocol-errors.ts";
+
+type TelemetryFrameRecord = Record<string, unknown> & {
+  readonly kind: string;
+};
+
+type TelemetryBaseFields = Pick<RepoWriteTelemetryFrame, "protocol" | "repoId" | "generation">;
+
+export function decodeRepoWriteTelemetry(
+  frame: TelemetryFrameRecord,
+  limits: RepoWriteProtocolLimits,
+  baseFields: TelemetryBaseFields
+): RepoWriteTelemetryFrame {
+  assertExactTelemetryKeys(frame);
+  if (!repoWriteTelemetryPhases.includes(frame.phase as RepoWriteTelemetryPhase)) {
+    invalid("$.phase", "telemetry phase");
+  }
+  if (typeof frame.elapsedMs !== "number" || !Number.isFinite(frame.elapsedMs) || frame.elapsedMs < 0) {
+    invalid("$.elapsedMs", "non-negative finite duration");
+  }
+  return {
+    ...baseFields,
+    kind: "telemetry",
+    requestId: telemetryIdentifier(frame.requestId, "$.requestId", limits),
+    ...(Object.hasOwn(frame, "opId") ? { opId: telemetryIdentifier(frame.opId, "$.opId", limits) } : {}),
+    phase: frame.phase as RepoWriteTelemetryPhase,
+    elapsedMs: frame.elapsedMs,
+    ...(Object.hasOwn(frame, "details") ? { details: decodeTelemetryDetails(frame.details, limits) } : {})
+  };
+}
+
+function decodeTelemetryDetails(value: unknown, limits: RepoWriteProtocolLimits): RepoWriteTelemetryDetails {
+  const record = telemetryRecordAt(value, "$.details");
+  const entries = Object.entries(record);
+  if (entries.length > Math.min(limits.maxObjectKeys, 32)) limit("$.details", "detail key count");
+  const decoded: Record<string, string | number | boolean | null> = {};
+  for (const [key, detail] of entries) {
+    telemetryStringAt(key, "$.details key", Math.min(limits.maxStringBytes, 128));
+    if (key === "__proto__" || key === "prototype" || key === "constructor") invalid("$.details", "safe detail keys");
+    if (detail === null || typeof detail === "boolean") decoded[key] = detail;
+    else if (typeof detail === "string") decoded[key] = telemetryStringAt(detail, `$.details.${telemetryPathSegment(key)}`, 256);
+    else if (typeof detail === "number" && Number.isFinite(detail)) decoded[key] = detail;
+    else invalid(`$.details.${telemetryPathSegment(key)}`, "scalar telemetry detail");
+  }
+  return decoded;
+}
+
+function assertExactTelemetryKeys(frame: Record<string, unknown>): void {
+  const required = ["protocol", "repoId", "generation", "kind", "requestId", "phase", "elapsedMs"];
+  const allowed = new Set([...required, "opId", "details"]);
+  if (required.some((key) => !Object.hasOwn(frame, key)) || Object.keys(frame).some((key) => !allowed.has(key))) {
+    invalid("$", "exact message fields");
+  }
+}
+
+function telemetryRecordAt(value: unknown, path: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) invalid(path, "object");
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) invalid(path, "plain object");
+  return value as Record<string, unknown>;
+}
+
+function telemetryIdentifier(value: unknown, path: string, limits: RepoWriteProtocolLimits): string {
+  const text = telemetryStringAt(value, path, Math.min(limits.maxStringBytes, 4_096));
+  if (!text.trim()) invalid(path, "non-empty identifier");
+  return text;
+}
+
+function telemetryStringAt(value: unknown, path: string, maxBytes: number): string {
+  if (typeof value !== "string") invalid(path, "string");
+  const bytes = Buffer.byteLength(value, "utf8");
+  if (bytes > maxBytes) limit(path, "string byte length", bytes, maxBytes);
+  return value;
+}
+
+function telemetryPathSegment(value: string): string {
+  return value.length <= 48 ? value : `${value.slice(0, 45)}...`;
+}

--- a/packages/daemon/src/runtime/repo-write-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-protocol.ts
@@ -2,8 +2,9 @@
 import { repoWriteCommandDtoFromDecodedFields, type RepoWriteCommandDto } from "./repo-write-command-dto.ts";
 export * from "./repo-write-command-dto.ts";
 import { repoWriteTerminalReceiptMatches } from "./repo-write-terminal-receipt.ts";
-import { repoWriteTelemetryPhases, type RepoWriteRecoveryDeferredFrame, type RepoWriteRecoveryDiagnosticFrame, type RepoWriteRecoveryRejectedFrame, type RepoWriteTelemetryFrame, type RepoWriteTelemetryPhase } from "./repo-write-diagnostic-protocol.ts";
-export type { RepoWriteRecoveryDeferredFrame, RepoWriteRecoveryDiagnosticFrame, RepoWriteRecoveryRejectedFrame, RepoWriteTelemetryFrame, RepoWriteTelemetryPhase } from "./repo-write-diagnostic-protocol.ts";
+import { type RepoWriteRecoveryDeferredFrame, type RepoWriteRecoveryDiagnosticFrame, type RepoWriteRecoveryRejectedFrame, type RepoWriteTelemetryFrame } from "./repo-write-diagnostic-protocol.ts";
+import { decodeRepoWriteTelemetry } from "./repo-write-protocol-telemetry.ts";
+export type { RepoWriteRecoveryDeferredFrame, RepoWriteRecoveryDiagnosticFrame, RepoWriteRecoveryRejectedFrame, RepoWriteTelemetryDetail, RepoWriteTelemetryDetails, RepoWriteTelemetryFrame, RepoWriteTelemetryPhase } from "./repo-write-diagnostic-protocol.ts";
 export { boundedRepoWriteDiagnostic } from "./repo-write-protocol-diagnostic.ts";
 import {
   decodeRepoWriteBigInt,
@@ -188,7 +189,7 @@ export function decodeRepoWriteChildMessage(
   if (frame.kind === "direct-failure") return decodeDirectFailure(frame, limits);
   if (frame.kind === "failure") return decodeFailure(frame, limits);
   if (frame.kind === "status") return decodeStatus(frame, limits, budget);
-  if (frame.kind === "telemetry") return decodeTelemetry(frame, limits);
+  if (frame.kind === "telemetry") return decodeRepoWriteTelemetry(frame, limits, baseFields(frame));
   if (frame.kind === "recovery-deferred") return decodeRecoveryDeferred(frame, limits);
   if (frame.kind === "recovery-rejected") return decodeRecoveryRejected(frame, limits);
   if (frame.kind === "drained") return decodeRequestFrame(frame, limits, "drained");
@@ -410,21 +411,6 @@ function assertTerminalReceipt(
   if (!repoWriteTerminalReceiptMatches(outcome, receipt)) {
     invalid(path, "exact command-receipt/v2");
   }
-}
-function decodeTelemetry(frame: FrameRecord, limits: RepoWriteProtocolLimits): RepoWriteTelemetryFrame {
-  assertExactKeys(frame, baseKeys(["requestId", "phase", "elapsedMs"]), ["opId"], "$");
-  if (!repoWriteTelemetryPhases.includes(frame.phase as RepoWriteTelemetryPhase)) invalid("$.phase", "telemetry phase");
-  if (typeof frame.elapsedMs !== "number" || !Number.isFinite(frame.elapsedMs) || frame.elapsedMs < 0) {
-    invalid("$.elapsedMs", "non-negative finite duration");
-  }
-  return {
-    ...baseFields(frame),
-    kind: "telemetry",
-    requestId: identifier(frame.requestId, "$.requestId", limits),
-    ...("opId" in frame ? { opId: identifier(frame.opId, "$.opId", limits) } : {}),
-    phase: frame.phase as RepoWriteTelemetryPhase,
-    elapsedMs: frame.elapsedMs
-  };
 }
 function decodeRecoveryDeferred(
   frame: FrameRecord,

--- a/packages/daemon/src/runtime/repo-write-stall-diagnostic.ts
+++ b/packages/daemon/src/runtime/repo-write-stall-diagnostic.ts
@@ -105,6 +105,7 @@ export function repoWriteWaitingStage(
     case "authority-flush-git-native-commit-done":
     case "authority-flush-projection-fingerprint-start":
     case "authority-flush-projection-fingerprint-done":
+    case "authority-flush-projection-fingerprint-summary":
     case "authority-flush-post-commit-attribution-confirm-start":
     case "authority-flush-post-commit-attribution-confirm-done":
     case "authority-flush-post-commit-projection-hash-start":
@@ -125,6 +126,8 @@ export function repoWriteWaitingStage(
     case "authority-materializer-baseline-start":
       return "authority-materializer-baseline";
     case "authority-materializer-baseline-done":
+    case "authority-materializer-baseline-fence":
+    case "authority-materializer-baseline-cache":
       return "authority-materializer-baseline-done";
     case "authority-materializer-merge-start":
       return "authority-materializer-merge";
@@ -140,6 +143,9 @@ export function repoWriteWaitingStage(
     case "authority-materializer-projection-verify-source":
     case "authority-materializer-projection-source-cache-refresh":
     case "authority-materializer-projection-source-cache-change":
+    case "authority-materializer-projection-source-summary":
+    case "authority-materializer-projection-metadata-summary":
+    case "authority-materializer-projection-trusted-advance":
     case "authority-materializer-projection-attribution-delta":
     case "authority-materializer-projection-source-delta":
     case "authority-materializer-projection-publish":

--- a/packages/daemon/src/runtime/repo-write-telemetry-context.ts
+++ b/packages/daemon/src/runtime/repo-write-telemetry-context.ts
@@ -1,15 +1,16 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { performance } from "node:perf_hooks";
-import type { RepoWriteTelemetryPhase } from "./repo-write-protocol.ts";
+import type { RepoWriteTelemetryDetails, RepoWriteTelemetryPhase } from "./repo-write-protocol.ts";
 
 type RepoWriteTelemetryReporter = (
   phase: RepoWriteTelemetryPhase,
-  elapsedMs: number
+  elapsedMs: number,
+  details?: RepoWriteTelemetryDetails
 ) => void;
 
 export interface RepoWriteTelemetryDelivery {
   readonly report: RepoWriteTelemetryReporter;
-  readonly reportCurrent: (phase: RepoWriteTelemetryPhase) => void;
+  readonly reportCurrent: (phase: RepoWriteTelemetryPhase, details?: RepoWriteTelemetryDetails) => void;
   readonly flush: () => Promise<void>;
   readonly close: () => void;
 }
@@ -27,11 +28,12 @@ export function runWithRepoWriteTelemetry<Result>(
 }
 
 export function reportCurrentRepoWriteTelemetry(
-  phase: RepoWriteTelemetryPhase
+  phase: RepoWriteTelemetryPhase,
+  details?: RepoWriteTelemetryDetails
 ): void {
   const current = storage.getStore();
   if (!current) return;
-  current.report(phase, Math.max(0, performance.now() - current.startedAt));
+  current.report(phase, Math.max(0, performance.now() - current.startedAt), details);
 }
 
 export async function executeRepoWriteChildWithTelemetry<Result>(
@@ -58,23 +60,24 @@ export function bindCurrentRepoWriteTelemetry<Result>(
 export function createRepoWriteTelemetryDelivery(
   deliver: (
     phase: RepoWriteTelemetryPhase,
-    elapsedMs: number
+    elapsedMs: number,
+    details?: RepoWriteTelemetryDetails
   ) => Promise<void>
 ): RepoWriteTelemetryDelivery {
   let pending = Promise.resolve();
   let closed = false;
   const startedAt = performance.now();
   return {
-    report: (phase, elapsedMs) => {
+    report: (phase, elapsedMs, details) => {
       if (closed) return;
       pending = pending
-        .then(() => deliver(phase, elapsedMs))
+        .then(() => deliver(phase, elapsedMs, details))
         .catch(() => undefined);
     },
-    reportCurrent: (phase) => {
+    reportCurrent: (phase, details) => {
       if (closed) return;
       pending = pending
-        .then(() => deliver(phase, Math.max(0, performance.now() - startedAt)))
+        .then(() => deliver(phase, Math.max(0, performance.now() - startedAt), details))
         .catch(() => undefined);
     },
     flush: () => pending,

--- a/packages/daemon/test/repo-write-protocol.test.ts
+++ b/packages/daemon/test/repo-write-protocol.test.ts
@@ -364,7 +364,14 @@ test("ready, terminal, status, telemetry, shutdown, and drained frames have exac
     requestId: "request-terminal",
     opId: "op-terminal",
     phase: "authority-replica-change-read",
-    elapsedMs: 12.5
+    elapsedMs: 12.5,
+    details: {
+      kind: "source-summary",
+      count: 3,
+      clean: true,
+      hash: "sha256:fixture",
+      absent: null
+    }
   });
   const shutdown = decodeRepoWriteParentMessage({
     ...base("shutdown"),
@@ -385,11 +392,19 @@ test("ready, terminal, status, telemetry, shutdown, and drained frames have exac
   );
   assert.equal(telemetry.kind === "telemetry" ? telemetry.elapsedMs : undefined, 12.5);
   assert.equal(telemetry.kind === "telemetry" ? telemetry.phase : undefined, "authority-replica-change-read");
+  assert.deepEqual(
+    telemetry.kind === "telemetry" ? telemetry.details : undefined,
+    { kind: "source-summary", count: 3, clean: true, hash: "sha256:fixture", absent: null }
+  );
   assert.equal(shutdown.kind, "shutdown");
   assert.equal(drained.kind, "drained");
   assert.throws(() => decodeRepoWriteChildMessage({ ...ready, requestId: "not-allowed" }), protocolInvalid);
   assert.throws(() => decodeRepoWriteParentMessage({ ...shutdown, deadlineMs: 5_000 }), protocolInvalid);
   assert.throws(() => decodeRepoWriteChildMessage({ ...telemetry, payload: "not telemetry" }), protocolInvalid);
+  assert.throws(() => decodeRepoWriteChildMessage({
+    ...telemetry,
+    details: { nested: { not: "scalar" } }
+  }), protocolInvalid);
   assert.throws(() => decodeRepoWriteChildMessage({
     ...base("status"),
     requestId: "status-missing-receipt",

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -187,9 +187,17 @@ export {
   type LedgerMaterializerProgressStep,
   type LedgerMaterializerReport,
   type IncrementalProjectionPhase,
+  type IncrementalProjectionDiagnostic,
   type IncrementalTaskProjectionMode,
   type IncrementalProjectionRebuildReason
 } from "./write-coordination/materialization/ledger-materializer.ts";
+export type {
+  ProjectionSourceSummary
+} from "./projection/projection-source-snapshot.ts";
+export type {
+  ProjectionSourceWorktreeFenceDiagnostic,
+  TrustedProjectionFingerprintDiagnostic
+} from "./projection/projection-source-baseline.ts";
 export type {
   AttributionProjectionDecisionReason
 } from "./projection/sqlite-attribution-incremental.ts";

--- a/packages/kernel/src/projection/projection-change-event.ts
+++ b/packages/kernel/src/projection/projection-change-event.ts
@@ -37,7 +37,7 @@ export type IncrementalProjectionRebuildReason =
 
 export type IncrementalTaskProjectionResult = ProjectionReadResult & (
   | { readonly mode: "incremental" | "unchanged"; readonly sourceHash: string; readonly change: ProjectionChangeEvent }
-  | { readonly mode: "rebuild"; readonly rebuildReason: IncrementalProjectionRebuildReason; readonly sourceHash?: undefined; readonly change?: undefined }
+  | { readonly mode: "rebuild"; readonly rebuildReason: IncrementalProjectionRebuildReason; readonly sourceHash?: string; readonly change?: undefined }
 );
 
 export function projectionChange(

--- a/packages/kernel/src/projection/projection-source-baseline.ts
+++ b/packages/kernel/src/projection/projection-source-baseline.ts
@@ -4,7 +4,47 @@ import { resolveHarnessLayout, type HarnessLayout } from "../layout/index.ts";
 import type { VersionControlSystem } from "../ports/version-control-system.ts";
 import { readDeclaredSourceManifestRows } from "./sqlite-declared-source-manifest.ts";
 import { updateTaskProjectionIncrementally } from "./sqlite-task-incremental-projection.ts";
-import { captureProjectionSourceFingerprint } from "./projection-source-snapshot.ts";
+import { stablePayloadHash } from "../integrity/stable-hash.ts";
+import {
+  captureProjectionSourceFingerprint,
+  summarizeProjectionSourceFingerprint,
+  type ProjectionSourceSummary
+} from "./projection-source-snapshot.ts";
+
+export interface ProjectionSourceWorktreeFenceDiagnostic {
+  readonly clean: boolean;
+  readonly statusCount: number;
+  readonly sourceDirtyCount: number;
+  readonly unparseableStatusCount: number;
+  readonly sourceDirtyCategoryHash: string;
+}
+
+export type TrustedProjectionFingerprintDiagnostic =
+  | {
+      readonly kind: "cache";
+      readonly outcome: "hit" | "full-capture";
+      readonly reason: string;
+      readonly head: string;
+      readonly cachedHead?: string;
+      readonly cachedFingerprint?: string;
+      readonly worktreeVerified?: boolean;
+      readonly fence?: ProjectionSourceWorktreeFenceDiagnostic;
+      readonly summary?: ProjectionSourceSummary;
+    }
+  | {
+      readonly kind: "advance";
+      readonly outcome: "advanced" | "not-advanced";
+      readonly reason: string;
+      readonly head: string;
+      readonly cachedHead: string;
+      readonly cachedFingerprint: string;
+      readonly fingerprint?: string;
+      readonly fence: ProjectionSourceWorktreeFenceDiagnostic;
+    };
+
+export interface TrustedProjectionFingerprintOptions {
+  readonly onDiagnostic?: (diagnostic: TrustedProjectionFingerprintDiagnostic) => void;
+}
 
 interface TrustedProjectionFingerprint {
   readonly head: string;
@@ -15,6 +55,10 @@ interface TrustedProjectionFingerprint {
 const trustedProjectionFingerprints = new Map<string, TrustedProjectionFingerprint>();
 
 export function captureAuthoredProjectionFingerprint(rootInput: HarnessLayoutInput): string {
+  return captureAuthoredProjectionSource(rootInput).fingerprint;
+}
+
+function captureAuthoredProjectionSource(rootInput: HarnessLayoutInput) {
   const projectionPath = resolveHarnessLayout(rootInput).projectionPath;
   let hints: ReturnType<typeof readDeclaredSourceManifestRows> = [];
   try {
@@ -22,7 +66,7 @@ export function captureAuthoredProjectionFingerprint(rootInput: HarnessLayoutInp
   } catch {
     // A missing or invalid generated manifest is not authoritative; source capture still proceeds.
   }
-  return captureProjectionSourceFingerprint(rootInput, hints).fingerprint;
+  return captureProjectionSourceFingerprint(rootInput, hints);
 }
 
 /**
@@ -40,40 +84,259 @@ export function captureAuthoredProjectionFingerprint(rootInput: HarnessLayoutInp
 export function captureTrustedAuthoredProjectionFingerprint(
   rootInput: HarnessLayoutInput,
   vcs: VersionControlSystem,
-  repoRoot?: string
+  repoRoot?: string,
+  options: TrustedProjectionFingerprintOptions = {}
 ): string {
   const layout = resolveHarnessLayout(rootInput);
   const resolvedRepoRoot = repoRoot ?? vcs.topLevel(layout.authoredRoot) ?? vcs.topLevel(layout.rootDir);
-  if (!resolvedRepoRoot) return captureAuthoredProjectionFingerprint(rootInput);
+  if (!resolvedRepoRoot) {
+    const source = captureAuthoredProjectionSource(rootInput);
+    options.onDiagnostic?.({
+      kind: "cache",
+      outcome: "full-capture",
+      reason: "repo-root-unavailable",
+      head: "unresolved",
+      summary: summarizeProjectionSourceFingerprint(source)
+    });
+    return source.fingerprint;
+  }
 
   const key = trustedProjectionFingerprintKey(resolvedRepoRoot, layout.authoredRoot, layout.projectionPath);
   const head = vcs.currentHead(resolvedRepoRoot);
   const cached = trustedProjectionFingerprints.get(key);
   if (cached && cached.head === head) {
-    if (cached.worktreeVerified || projectionSourceWorktreeIsClean(vcs, resolvedRepoRoot, layout)) {
+    if (cached.worktreeVerified) {
+      options.onDiagnostic?.({
+        kind: "cache",
+        outcome: "hit",
+        reason: "same-head-verified",
+        head,
+        cachedHead: cached.head,
+        cachedFingerprint: cached.fingerprint,
+        worktreeVerified: true
+      });
       return cached.fingerprint;
     }
+    const fence = projectionSourceWorktreeIsClean(vcs, resolvedRepoRoot, layout);
+    if (fence.clean) {
+      options.onDiagnostic?.({
+        kind: "cache",
+        outcome: "hit",
+        reason: "same-head-fence-clean",
+        head,
+        cachedHead: cached.head,
+        cachedFingerprint: cached.fingerprint,
+        worktreeVerified: false,
+        fence
+      });
+      return cached.fingerprint;
+    }
+    options.onDiagnostic?.({
+      kind: "cache",
+      outcome: "full-capture",
+      reason: "same-head-fence-dirty",
+      head,
+      cachedHead: cached.head,
+      cachedFingerprint: cached.fingerprint,
+      worktreeVerified: false,
+      fence
+    });
   }
-  if (cached && projectionSourceWorktreeIsClean(vcs, resolvedRepoRoot, layout)) {
-    const advanced = advanceTrustedProjectionFingerprint(
-      rootInput,
-      layout,
-      vcs,
-      resolvedRepoRoot,
-      cached,
-      head
-    );
-    if (advanced) return advanced;
+  if (cached && cached.head !== head) {
+    const fence = projectionSourceWorktreeIsClean(vcs, resolvedRepoRoot, layout);
+    if (fence.clean) {
+      const advanced = advanceTrustedProjectionFingerprint(
+        rootInput,
+        layout,
+        vcs,
+        resolvedRepoRoot,
+        cached,
+        head
+      );
+      if (advanced.fingerprint) {
+        options.onDiagnostic?.({
+          kind: "advance",
+          outcome: "advanced",
+          reason: advanced.reason,
+          head,
+          cachedHead: cached.head,
+          cachedFingerprint: cached.fingerprint,
+          fingerprint: advanced.fingerprint,
+          fence
+        });
+        return advanced.fingerprint;
+      }
+      options.onDiagnostic?.({
+        kind: "advance",
+        outcome: "not-advanced",
+        reason: advanced.reason,
+        head,
+        cachedHead: cached.head,
+        cachedFingerprint: cached.fingerprint,
+        fence
+      });
+    } else {
+      options.onDiagnostic?.({
+        kind: "advance",
+        outcome: "not-advanced",
+        reason: "head-advanced-fence-dirty",
+        head,
+        cachedHead: cached.head,
+        cachedFingerprint: cached.fingerprint,
+        fence
+      });
+    }
   }
 
-  const fingerprint = captureAuthoredProjectionFingerprint(rootInput);
+  const source = captureAuthoredProjectionSource(rootInput);
+  const fingerprint = source.fingerprint;
   const capturedHead = vcs.currentHead(resolvedRepoRoot);
   if (capturedHead === head) {
     trustedProjectionFingerprints.set(key, { head: capturedHead, fingerprint, worktreeVerified: false });
   } else {
     trustedProjectionFingerprints.delete(key);
   }
+  options.onDiagnostic?.({
+    kind: "cache",
+    outcome: "full-capture",
+    reason: cached ? "trusted-cache-not-reusable" : "cache-cold",
+    head,
+    ...(cached ? { cachedHead: cached.head, cachedFingerprint: cached.fingerprint } : {}),
+    summary: summarizeProjectionSourceFingerprint(source)
+  });
   return fingerprint;
+}
+
+function advanceTrustedProjectionFingerprint(
+  rootInput: HarnessLayoutInput,
+  layout: ReturnType<typeof resolveHarnessLayout>,
+  vcs: VersionControlSystem,
+  repoRoot: string,
+  cached: TrustedProjectionFingerprint,
+  head: string
+): { readonly fingerprint?: string; readonly reason: string } {
+  if (cached.head === head) return { fingerprint: cached.fingerprint, reason: "same-head" };
+  if (!vcs.resolveCommit(repoRoot, cached.head).ok) {
+    return { reason: "cached-head-unresolvable" };
+  }
+
+  let changedPaths: ReadonlyArray<string>;
+  try {
+    changedPaths = vcs.changedFilesBetween(repoRoot, cached.head, head);
+  } catch {
+    return { reason: "changed-paths-read-failed" };
+  }
+
+  const result = updateTaskProjectionIncrementally({
+    rootDir: layout.rootDir,
+    ...(typeof rootInput === "object" && rootInput.layoutOverrides
+      ? { layoutOverrides: rootInput.layoutOverrides }
+      : {}),
+    projectionPath: layout.projectionPath,
+    touchedPaths: changedPaths.map((relativePath) => path.resolve(repoRoot, relativePath)),
+    previousSourceFingerprint: cached.fingerprint
+  });
+  if (!result.sourceHash) {
+    return {
+      reason: `projection-advance-${result.mode}-${result.mode === "rebuild" ? result.rebuildReason : "no-source-hash"}`
+    };
+  }
+  if (vcs.currentHead(repoRoot) !== head) return { reason: "head-changed-during-advance" };
+
+  const key = trustedProjectionFingerprintKey(repoRoot, layout.authoredRoot, layout.projectionPath);
+  trustedProjectionFingerprints.set(key, {
+    head,
+    fingerprint: result.sourceHash,
+    worktreeVerified: true
+  });
+  return { fingerprint: result.sourceHash, reason: "known-ancestor-incremental" };
+}
+
+/*
+ * The fence is intentionally scoped to projection-relevant source classes.
+ * Its diagnostic reports only aggregate categories, so a permanently enabled
+ * always-on production frame cannot disclose authored paths.
+ */
+function projectionSourceWorktreeIsClean(
+  vcs: VersionControlSystem,
+  repoRoot: string,
+  layout: HarnessLayout
+): ProjectionSourceWorktreeFenceDiagnostic {
+  const relativeRoot = path.relative(vcs.normalizePath(repoRoot), vcs.normalizePath(layout.authoredRoot)).split(path.sep).join("/");
+  try {
+    const status = vcs.workingTreeFiles(repoRoot, relativeRoot.length === 0 ? [] : [relativeRoot]);
+    const lines = status.split(/\r?\n/u).filter(Boolean);
+    const categories = new Map<string, number>();
+    let unparseableStatusCount = 0;
+    for (const line of lines) {
+      const parsed = parseWorktreeStatusPath(line);
+      const category = parsed === null
+        ? "unparseable-status"
+        : projectionSourcePathCategory(layout, relativeRoot, parsed);
+      if (category) categories.set(category, (categories.get(category) ?? 0) + 1);
+      if (parsed === null) unparseableStatusCount += 1;
+    }
+    const sourceDirtyCount = [...categories.values()].reduce((sum, count) => sum + count, 0);
+    return {
+      clean: sourceDirtyCount === 0,
+      statusCount: lines.length,
+      sourceDirtyCount,
+      unparseableStatusCount,
+      sourceDirtyCategoryHash: stablePayloadHash({
+        schema: "projection-source-worktree-fence/v1",
+        categories: [...categories.entries()].sort(([left], [right]) => left.localeCompare(right))
+      })
+    };
+  } catch {
+    return {
+      clean: false,
+      statusCount: 0,
+      sourceDirtyCount: 0,
+      unparseableStatusCount: 0,
+      sourceDirtyCategoryHash: stablePayloadHash({
+        schema: "projection-source-worktree-fence/v1",
+        categories: [["status-read-failed", 1]]
+      })
+    };
+  }
+}
+
+function parseWorktreeStatusPath(statusLine: string): string | null {
+  if (statusLine.length < 4 || statusLine[2] !== " ") return null;
+  const pathPart = statusLine.slice(3);
+  if (pathPart.includes('"')) return null;
+  const renameSeparator = pathPart.lastIndexOf(" -> ");
+  return (renameSeparator >= 0 ? pathPart.slice(renameSeparator + 4) : pathPart).replaceAll("\\", "/");
+}
+
+function projectionSourcePathCategory(
+  layout: HarnessLayout,
+  relativeRoot: string,
+  statusPath: string
+): string | null {
+  const authoredPrefix = relativeRoot.length === 0 ? "" : `${relativeRoot}/`;
+  if (!statusPath.startsWith(authoredPrefix)) return "outside-authored-root";
+  const relativePath = statusPath.slice(authoredPrefix.length);
+  const tasksRoot = relativePathFromAuthoredRoot(layout, layout.tasksRoot);
+  const decisionsRoot = relativePathFromAuthoredRoot(layout, layout.decisionsRoot);
+  const sessionsRoot = relativePathFromAuthoredRoot(layout, layout.sessionsRoot);
+  const attributionRoot = relativePathFromAuthoredRoot(layout, layout.attributionEventsRoot);
+  const authorityAttributionRoot = relativePathFromAuthoredRoot(layout, layout.authorityAttributionEventsV2Root);
+
+  if (relativePath === "people.yaml") return "people";
+  if (relativePath === attributionRoot || relativePath.startsWith(`${attributionRoot}/`)) return "v1-attribution";
+  if (relativePath === authorityAttributionRoot || relativePath.startsWith(`${authorityAttributionRoot}/`)) return "v2-attribution";
+  if (relativePath.startsWith(`${sessionsRoot}/`)) return /^.+\.md$/u.test(relativePath.slice(sessionsRoot.length + 1)) ? "session" : null;
+  if (relativePath.startsWith(`${decisionsRoot}/`)) return path.basename(relativePath) === "decision.md" ? "decision" : null;
+  if (!relativePath.startsWith(`${tasksRoot}/`)) return null;
+
+  const taskRelativePath = relativePath.slice(tasksRoot.length + 1);
+  if (/^.+\/(?:executions|consents|reviews)\/[^/]+\.md$/u.test(taskRelativePath)) return "declared-entity";
+  return /^.+\/(?:INDEX|facts|module|review|closeout)\.md$/u.test(taskRelativePath) ? "task-source" : null;
+}
+
+function relativePathFromAuthoredRoot(layout: HarnessLayout, inputPath: string): string {
+  return path.relative(layout.authoredRoot, inputPath).split(path.sep).join("/");
 }
 
 export function rememberTrustedAuthoredProjectionFingerprint(
@@ -108,90 +371,4 @@ export function invalidateTrustedAuthoredProjectionFingerprint(
 
 function trustedProjectionFingerprintKey(repoRoot: string, authoredRoot: string, projectionPath: string): string {
   return [path.resolve(repoRoot), path.resolve(authoredRoot), path.resolve(projectionPath)].join("\0");
-}
-
-function projectionSourceWorktreeIsClean(vcs: VersionControlSystem, repoRoot: string, layout: HarnessLayout): boolean {
-  const relativeRoot = path.relative(vcs.normalizePath(repoRoot), vcs.normalizePath(layout.authoredRoot)).split(path.sep).join("/");
-  try {
-    const status = vcs.workingTreeFiles(repoRoot, relativeRoot.length === 0 ? [] : [relativeRoot]);
-    return status
-      .split(/\r?\n/u)
-      .filter(Boolean)
-      .map(parseWorktreeStatusPath)
-      .every((relativePath) => relativePath !== null && !isProjectionSourcePath(layout, relativeRoot, relativePath));
-  } catch {
-    return false;
-  }
-}
-
-function parseWorktreeStatusPath(statusLine: string): string | null {
-  if (statusLine.length < 4 || statusLine[2] !== " ") return null;
-  const pathPart = statusLine.slice(3);
-  if (pathPart.includes('"')) return null;
-  const renameSeparator = pathPart.lastIndexOf(" -> ");
-  return (renameSeparator >= 0 ? pathPart.slice(renameSeparator + 4) : pathPart).replaceAll("\\", "/");
-}
-
-function isProjectionSourcePath(layout: HarnessLayout, relativeRoot: string, statusPath: string): boolean {
-  const authoredPrefix = relativeRoot.length === 0 ? "" : `${relativeRoot}/`;
-  if (!statusPath.startsWith(authoredPrefix)) return true;
-  const relativePath = statusPath.slice(authoredPrefix.length);
-  const tasksRoot = relativePathFromAuthoredRoot(layout, layout.tasksRoot);
-  const decisionsRoot = relativePathFromAuthoredRoot(layout, layout.decisionsRoot);
-  const sessionsRoot = relativePathFromAuthoredRoot(layout, layout.sessionsRoot);
-  const attributionRoot = relativePathFromAuthoredRoot(layout, layout.attributionEventsRoot);
-  const authorityAttributionRoot = relativePathFromAuthoredRoot(layout, layout.authorityAttributionEventsV2Root);
-
-  if (relativePath === "people.yaml") return true;
-  if (relativePath === attributionRoot || relativePath.startsWith(`${attributionRoot}/`)) return true;
-  if (relativePath === authorityAttributionRoot || relativePath.startsWith(`${authorityAttributionRoot}/`)) return true;
-  if (relativePath.startsWith(`${sessionsRoot}/`)) return /^.+\.md$/u.test(relativePath.slice(sessionsRoot.length + 1));
-  if (relativePath.startsWith(`${decisionsRoot}/`)) return path.basename(relativePath) === "decision.md";
-  if (!relativePath.startsWith(`${tasksRoot}/`)) return false;
-
-  const taskRelativePath = relativePath.slice(tasksRoot.length + 1);
-  return /^.+\/(?:INDEX|facts|module|review|closeout)\.md$/u.test(taskRelativePath) ||
-    /^.+\/(?:executions|consents|reviews)\/[^/]+\.md$/u.test(taskRelativePath);
-}
-
-function relativePathFromAuthoredRoot(layout: HarnessLayout, inputPath: string): string {
-  return path.relative(layout.authoredRoot, inputPath).split(path.sep).join("/");
-}
-
-function advanceTrustedProjectionFingerprint(
-  rootInput: HarnessLayoutInput,
-  layout: ReturnType<typeof resolveHarnessLayout>,
-  vcs: VersionControlSystem,
-  repoRoot: string,
-  cached: TrustedProjectionFingerprint,
-  head: string
-): string | undefined {
-  if (cached.head === head) return cached.fingerprint;
-  if (!vcs.resolveCommit(repoRoot, cached.head).ok) return undefined;
-
-  let changedPaths: ReadonlyArray<string>;
-  try {
-    changedPaths = vcs.changedFilesBetween(repoRoot, cached.head, head);
-  } catch {
-    return undefined;
-  }
-
-  const result = updateTaskProjectionIncrementally({
-    rootDir: layout.rootDir,
-    ...(typeof rootInput === "object" && rootInput.layoutOverrides
-      ? { layoutOverrides: rootInput.layoutOverrides }
-      : {}),
-    projectionPath: layout.projectionPath,
-    touchedPaths: changedPaths.map((relativePath) => path.resolve(repoRoot, relativePath)),
-    previousSourceFingerprint: cached.fingerprint
-  });
-  if (!result.sourceHash || vcs.currentHead(repoRoot) !== head) return undefined;
-
-  const key = trustedProjectionFingerprintKey(repoRoot, layout.authoredRoot, layout.projectionPath);
-  trustedProjectionFingerprints.set(key, {
-    head,
-    fingerprint: result.sourceHash,
-    worktreeVerified: true
-  });
-  return result.sourceHash;
 }

--- a/packages/kernel/src/projection/projection-source-snapshot.ts
+++ b/packages/kernel/src/projection/projection-source-snapshot.ts
@@ -53,6 +53,24 @@ export interface ProjectionSourceFingerprint {
   readonly fingerprint: string;
 }
 
+/**
+ * Content-free shape information for production diagnostics. Hashes identify
+ * a source generation without putting authored bodies or paths on the wire.
+ */
+export interface ProjectionSourceSummary {
+  readonly taskEntryCount: number;
+  readonly taskInputCount: number;
+  readonly taskSourceHash: string;
+  readonly declaredSourceCount: number;
+  readonly declaredInputCount: number;
+  readonly declaredSourceHash: string;
+  readonly attributionInputCount: number;
+  readonly attributionSourceHash: string;
+  readonly legacyPersonIdCount: number;
+  readonly legacyPersonIdsHash: string;
+  readonly fingerprint: string;
+}
+
 export interface ProjectionSourceSnapshot extends ProjectionSourceFingerprint {
   readonly decisionRows: ReadonlyArray<DecisionProjectionRow>;
   readonly declaredTables: ReadonlyArray<DeclaredProjectionSnapshot>;
@@ -66,6 +84,34 @@ export interface ProjectionSourceCacheReuse {
   readonly touchedTaskPaths?: ReadonlyArray<string>;
   readonly validateReusedTaskDirectories?: boolean;
   readonly validateReusedDeclaredDirectories?: boolean;
+}
+
+export function summarizeProjectionSourceFingerprint(
+  source: ProjectionSourceFingerprint
+): ProjectionSourceSummary {
+  return {
+    taskEntryCount: source.taskSource.entries.length,
+    taskInputCount: source.taskSource.sourceInputs.length,
+    taskSourceHash: source.taskSource.hash,
+    declaredSourceCount: source.declaredSources.length,
+    declaredInputCount: source.declaredSources.reduce(
+      (count, declared) => count + declared.source.inputs.length,
+      0
+    ),
+    declaredSourceHash: stablePayloadHash({
+      schema: "projection-declared-source-summary/v1",
+      sources: source.declaredSources.map(({ table, source: declared }) => ({
+        table,
+        inputCount: declared.inputs.length,
+        hash: declared.hash
+      }))
+    }),
+    attributionInputCount: source.attributionSource.inputs.length,
+    attributionSourceHash: source.attributionSource.hash,
+    legacyPersonIdCount: source.legacyPersonIds.length,
+    legacyPersonIdsHash: hashProjectionLegacyPersonIds(source.legacyPersonIds),
+    fingerprint: source.fingerprint
+  };
 }
 
 export function captureProjectionSourceFingerprint(

--- a/packages/kernel/src/projection/sqlite-task-incremental-projection-affected.ts
+++ b/packages/kernel/src/projection/sqlite-task-incremental-projection-affected.ts
@@ -1,0 +1,113 @@
+import path from "node:path";
+import { resolveHarnessLayout } from "../layout/index.ts";
+import type { RelationGraphEdgeRow } from "./relation-graph-projection.ts";
+import { isDeclaredEntityFile, isPathWithin } from "./projection-path.ts";
+import { realPathIfExists } from "./toctou-safe-fs.ts";
+import { readMarkdownSource, sourcePath } from "./sqlite-task-source.ts";
+import type { DecisionProjectionRow, TaskProjectionRow } from "./types.ts";
+
+export function affectedProjectionEntities(input: {
+  readonly rootDir: string;
+  readonly rootInput: Parameters<typeof resolveHarnessLayout>[0];
+  readonly touchedPaths: ReadonlyArray<string>;
+  readonly sourceEntries: ReturnType<typeof readMarkdownSource>["entries"];
+  readonly existingRows: ReadonlyArray<TaskProjectionRow>;
+  readonly existingDecisionRows: ReadonlyArray<DecisionProjectionRow>;
+  readonly oldEdges: ReadonlyArray<RelationGraphEdgeRow>;
+  readonly newEdges: ReadonlyArray<RelationGraphEdgeRow>;
+}): {
+  readonly taskIds: ReadonlySet<string>;
+  readonly decisionIds: ReadonlySet<string>;
+  readonly decisionPaths: ReadonlySet<string>;
+} {
+  const layout = resolveHarnessLayout(input.rootInput);
+  const rootDir = realPathIfExists(input.rootDir);
+  const tasksRoot = realPathIfExists(layout.tasksRoot);
+  const decisionsRoot = realPathIfExists(layout.decisionsRoot);
+  const authoredRoot = realPathIfExists(layout.authoredRoot);
+  const taskIds = new Set<string>();
+  const decisionIds = new Set<string>();
+  const decisionPaths = new Set<string>();
+  const touchedRelativePaths = new Set(input.touchedPaths.map((filePath) => sourcePath(rootDir, realPathIfExists(filePath))));
+  const declaredEntityRelativePaths = new Set(input.touchedPaths
+    .map(realPathIfExists)
+    .filter((filePath) => isDeclaredEntityFile(authoredRoot, filePath))
+    .map((filePath) => sourcePath(rootDir, filePath)));
+  const taskTouchedRelativePaths = [...touchedRelativePaths]
+    .filter((relativePath) => !declaredEntityRelativePaths.has(relativePath));
+  const tasksRootRelativePath = sourcePath(rootDir, tasksRoot);
+  const taskPackageTouchedRelativePaths = taskTouchedRelativePaths.filter((relativePath) =>
+    relativePath === tasksRootRelativePath || relativePath.startsWith(`${tasksRootRelativePath}/`));
+
+  for (const filePath of input.touchedPaths) {
+    const resolved = realPathIfExists(filePath);
+    const taskSlug = taskSlugForPath(tasksRoot, resolved);
+    if (taskSlug && !isDeclaredEntityFile(authoredRoot, resolved)) taskIds.add(taskSlug);
+    if (path.basename(resolved) === "decision.md" && isPathWithin(decisionsRoot, resolved)) {
+      decisionPaths.add(path.join(input.rootDir, sourcePath(rootDir, resolved)));
+    }
+  }
+
+  for (const relativePath of taskPackageTouchedRelativePaths) {
+    const entry = input.sourceEntries.find((candidate) => {
+      const entrySourcePath = sourcePath(path.resolve(input.rootDir), path.resolve(candidate.indexPath));
+      return relativePath === entrySourcePath || relativePath.startsWith(`${path.posix.dirname(entrySourcePath)}/`);
+    });
+    if (entry) taskIds.add(entry.taskId);
+
+    const row = input.existingRows.find((candidate) =>
+      relativePath === candidate.sourcePath || relativePath.startsWith(`${path.posix.dirname(candidate.sourcePath)}/`));
+    if (row) taskIds.add(row.taskId);
+  }
+
+  if (taskPackageTouchedRelativePaths.length > 1) {
+    for (const entry of input.sourceEntries) {
+      const entrySourcePath = sourcePath(path.resolve(input.rootDir), path.resolve(entry.indexPath));
+      if (taskPackageTouchedRelativePaths.some((relativePath) => relativePath === entrySourcePath || relativePath.startsWith(`${path.posix.dirname(entrySourcePath)}/`))) {
+        taskIds.add(entry.taskId);
+      }
+    }
+
+    for (const row of input.existingRows) {
+      if (taskPackageTouchedRelativePaths.some((relativePath) => relativePath === row.sourcePath || relativePath.startsWith(`${path.posix.dirname(row.sourcePath)}/`))) {
+        taskIds.add(row.taskId);
+      }
+    }
+  }
+
+  for (const row of input.existingDecisionRows) {
+    if (touchedRelativePaths.has(row.path)) {
+      decisionIds.add(row.decisionId);
+      decisionPaths.add(path.join(input.rootDir, row.path));
+    }
+  }
+
+  for (const edge of [...input.oldEdges, ...input.newEdges]) {
+    if (!touchedRelativePaths.has(edge.sourcePath)) continue;
+    addEntityRef(edge.sourceRef, taskIds, decisionIds);
+    addEntityRef(edge.targetRef, taskIds, decisionIds);
+  }
+
+  for (const row of input.existingDecisionRows) {
+    if (decisionIds.has(row.decisionId)) decisionPaths.add(path.join(input.rootDir, row.path));
+  }
+
+  return { taskIds, decisionIds, decisionPaths };
+}
+
+function taskSlugForPath(tasksRoot: string, filePath: string): string | undefined {
+  if (!isPathWithin(tasksRoot, filePath)) return undefined;
+  const relative = path.relative(tasksRoot, filePath);
+  const [slug] = relative.split(path.sep);
+  return slug && slug.length > 0 ? slug : undefined;
+}
+
+function addEntityRef(ref: string, taskIds: Set<string>, decisionIds: Set<string>): void {
+  const [kind, id] = ref.split("/");
+  if (kind === "task" && id) taskIds.add(id);
+  if (kind === "decision" && id) decisionIds.add(id);
+  if (kind === "fact") {
+    const ownerTaskId = ref.split("/")[1];
+    if (ownerTaskId) taskIds.add(ownerTaskId);
+  }
+}

--- a/packages/kernel/src/projection/sqlite-task-incremental-projection-diagnostics.ts
+++ b/packages/kernel/src/projection/sqlite-task-incremental-projection-diagnostics.ts
@@ -1,0 +1,63 @@
+import type { TaskFieldExtensionProjection } from "./types.ts";
+import type { IncrementalProjectionRebuildReason } from "./projection-change-event.ts";
+import {
+  summarizeProjectionSourceFingerprint,
+  type ProjectionSourceFingerprint,
+  type ProjectionSourceSummary
+} from "./projection-source-snapshot.ts";
+import { tryReadProjectionDatabase } from "./sqlite-projection-store.ts";
+
+export interface IncrementalProjectionDiagnostic {
+  readonly kind: "source-capture" | "metadata";
+  readonly phase: "captured" | "mismatch" | "stored";
+  readonly summary: ProjectionSourceSummary;
+  readonly existingSourceHash: string;
+  readonly previousSourceFingerprint?: string;
+  readonly storedSourceHash?: string;
+}
+
+export function sourceCaptureDiagnostic(
+  source: ProjectionSourceFingerprint,
+  existingSourceHash: string,
+  previousSourceFingerprint?: string
+): IncrementalProjectionDiagnostic {
+  return metadataDiagnostic("captured", source, existingSourceHash, previousSourceFingerprint, "source-capture");
+}
+
+export function projectionMetadataDiagnostic(
+  phase: "mismatch" | "stored",
+  source: ProjectionSourceFingerprint,
+  existingSourceHash: string,
+  previousSourceFingerprint?: string,
+  storedSourceHash?: string
+): IncrementalProjectionDiagnostic {
+  return metadataDiagnostic(phase, source, existingSourceHash, previousSourceFingerprint, "metadata", storedSourceHash);
+}
+
+export function rebuiltProjectionSourceHash(
+  reason: IncrementalProjectionRebuildReason,
+  projectionPath: string,
+  taskFieldExtensions?: ReadonlyArray<TaskFieldExtensionProjection>
+): string | undefined {
+  if (reason !== "source-fingerprint-mismatch") return undefined;
+  const persisted = tryReadProjectionDatabase(projectionPath, taskFieldExtensions);
+  return persisted.ok ? persisted.meta.sourceHash : undefined;
+}
+
+function metadataDiagnostic(
+  phase: "captured" | "mismatch" | "stored",
+  source: ProjectionSourceFingerprint,
+  existingSourceHash: string,
+  previousSourceFingerprint: string | undefined,
+  kind: IncrementalProjectionDiagnostic["kind"],
+  storedSourceHash?: string
+): IncrementalProjectionDiagnostic {
+  return {
+    kind,
+    phase,
+    summary: summarizeProjectionSourceFingerprint(source),
+    existingSourceHash,
+    ...(previousSourceFingerprint ? { previousSourceFingerprint } : {}),
+    ...(storedSourceHash ? { storedSourceHash } : {})
+  };
+}

--- a/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
@@ -42,6 +42,13 @@ import {
   hashProjectionLegacyPersonIds,
   readDeclaredProjectionSnapshots
 } from "./projection-source-snapshot.ts";
+import {
+  projectionMetadataDiagnostic,
+  rebuiltProjectionSourceHash,
+  sourceCaptureDiagnostic,
+  type IncrementalProjectionDiagnostic
+} from "./sqlite-task-incremental-projection-diagnostics.ts";
+import { affectedProjectionEntities } from "./sqlite-task-incremental-projection-affected.ts";
 import type { DecisionProjectionRow, TaskProjectionOptions, TaskProjectionRow } from "./types.ts";
 import {
   declaredProjectionEntityChanges,
@@ -53,6 +60,8 @@ import { isDeclaredEntityFile, isPathWithin } from "./projection-path.ts";
 import { realPathIfExists } from "./toctou-safe-fs.ts";
 import type { AttributionProjectionDecisionReason } from "./sqlite-attribution-incremental.ts";
 import type { IncrementalProjectionRebuildReason } from "./projection-change-event.ts";
+
+export type { IncrementalProjectionDiagnostic } from "./sqlite-task-incremental-projection-diagnostics.ts";
 
 export interface IncrementalProjectionPhase {
   readonly phase:
@@ -67,6 +76,7 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
   readonly previousSourceFingerprint?: string;
   readonly onPhase?: (phase: IncrementalProjectionPhase) => void;
   readonly onAttributionDecision?: (reason: AttributionProjectionDecisionReason) => void;
+  readonly onDiagnostic?: (diagnostic: IncrementalProjectionDiagnostic) => void;
 }): IncrementalTaskProjectionResult {
   let phaseStarted = performance.now();
   const recordPhase = (phase: IncrementalProjectionPhase["phase"]): void => {
@@ -77,11 +87,21 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
   const rootDir = path.resolve(options.rootDir);
   const runtimeContext = createHarnessRuntimeContext(rootDir, options.layoutOverrides);
   const projectionPath = options.projectionPath ? path.resolve(options.projectionPath) : resolveHarnessLayout(runtimeContext).projectionPath;
-  const rebuild = (reason: IncrementalProjectionRebuildReason): IncrementalTaskProjectionResult => ({
-    ...rebuildTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, projectionPath, taskFieldExtensions: options.taskFieldExtensions }),
-    mode: "rebuild",
-    rebuildReason: reason
-  });
+  const rebuild = (reason: IncrementalProjectionRebuildReason): IncrementalTaskProjectionResult => {
+    const rebuilt = rebuildTaskProjection({
+      rootDir,
+      layoutOverrides: options.layoutOverrides,
+      projectionPath,
+      taskFieldExtensions: options.taskFieldExtensions
+    });
+    const sourceHash = rebuiltProjectionSourceHash(reason, projectionPath, options.taskFieldExtensions);
+    return {
+      ...rebuilt,
+      mode: "rebuild",
+      rebuildReason: reason,
+      ...(sourceHash ? { sourceHash } : {})
+    };
+  };
 
   if (!existsSync(projectionPath)) {
     return rebuild("projection-missing");
@@ -157,6 +177,7 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
   recordPhase("capture-source");
   const source = snapshot.taskSource;
   const sourceHash = snapshot.fingerprint;
+  options.onDiagnostic?.(sourceCaptureDiagnostic(snapshot, existing.meta.sourceHash, options.previousSourceFingerprint));
 
   const graphSourceChange = declaredEntityOnly
     ? { changed: false, factProjectionReusable: false }
@@ -212,7 +233,22 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
   }
 
   if (existing.meta.sourceHash !== sourceHash && existing.meta.sourceHash !== options.previousSourceFingerprint) {
-    return rebuild("source-fingerprint-mismatch");
+    options.onDiagnostic?.(projectionMetadataDiagnostic(
+      "mismatch",
+      snapshot,
+      existing.meta.sourceHash,
+      options.previousSourceFingerprint,
+      sourceHash
+    ));
+    const rebuilt = rebuild("source-fingerprint-mismatch");
+    if (rebuilt.sourceHash) options.onDiagnostic?.(projectionMetadataDiagnostic(
+      "stored",
+      snapshot,
+      existing.meta.sourceHash,
+      options.previousSourceFingerprint,
+      rebuilt.sourceHash
+    ));
+    return rebuilt;
   }
 
   const taskChange = incrementalTaskRows(runtimeContext, source.entries, existing.rows, affected.taskIds, options.taskFieldExtensions);
@@ -349,6 +385,13 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
     undefined,
     sourceCache ?? persistedSourceCache
   );
+  options.onDiagnostic?.(projectionMetadataDiagnostic(
+    "stored",
+    snapshot,
+    existing.meta.sourceHash,
+    options.previousSourceFingerprint,
+    sourceHash
+  ));
 
   return {
     rows: taskChange.rows,
@@ -490,110 +533,4 @@ function incrementalDecisionRows(
     currentRows,
     deleteIds
   };
-}
-
-function affectedProjectionEntities(input: {
-  readonly rootDir: string;
-  readonly rootInput: Parameters<typeof resolveHarnessLayout>[0];
-  readonly touchedPaths: ReadonlyArray<string>;
-  readonly sourceEntries: ReturnType<typeof readMarkdownSource>["entries"];
-  readonly existingRows: ReadonlyArray<TaskProjectionRow>;
-  readonly existingDecisionRows: ReadonlyArray<DecisionProjectionRow>;
-  readonly oldEdges: ReadonlyArray<RelationGraphEdgeRow>;
-  readonly newEdges: ReadonlyArray<RelationGraphEdgeRow>;
-}): {
-  readonly taskIds: ReadonlySet<string>;
-  readonly decisionIds: ReadonlySet<string>;
-  readonly decisionPaths: ReadonlySet<string>;
-} {
-  const layout = resolveHarnessLayout(input.rootInput);
-  const rootDir = realPathIfExists(input.rootDir);
-  const tasksRoot = realPathIfExists(layout.tasksRoot);
-  const decisionsRoot = realPathIfExists(layout.decisionsRoot);
-  const authoredRoot = realPathIfExists(layout.authoredRoot);
-  const taskIds = new Set<string>();
-  const decisionIds = new Set<string>();
-  const decisionPaths = new Set<string>();
-  const touchedRelativePaths = new Set(input.touchedPaths.map((filePath) => sourcePath(rootDir, realPathIfExists(filePath))));
-  const declaredEntityRelativePaths = new Set(input.touchedPaths
-    .map(realPathIfExists)
-    .filter((filePath) => isDeclaredEntityFile(authoredRoot, filePath))
-    .map((filePath) => sourcePath(rootDir, filePath)));
-  const taskTouchedRelativePaths = [...touchedRelativePaths]
-    .filter((relativePath) => !declaredEntityRelativePaths.has(relativePath));
-  const tasksRootRelativePath = sourcePath(rootDir, tasksRoot);
-  const taskPackageTouchedRelativePaths = taskTouchedRelativePaths.filter((relativePath) =>
-    relativePath === tasksRootRelativePath || relativePath.startsWith(`${tasksRootRelativePath}/`));
-
-  for (const filePath of input.touchedPaths) {
-    const resolved = realPathIfExists(filePath);
-    const taskSlug = taskSlugForPath(tasksRoot, resolved);
-    if (taskSlug && !isDeclaredEntityFile(authoredRoot, resolved)) taskIds.add(taskSlug);
-    if (path.basename(resolved) === "decision.md" && isPathWithin(decisionsRoot, resolved)) {
-      decisionPaths.add(path.join(input.rootDir, sourcePath(rootDir, resolved)));
-    }
-  }
-
-  for (const relativePath of taskPackageTouchedRelativePaths) {
-    const entry = input.sourceEntries.find((candidate) => {
-      const entrySourcePath = sourcePath(path.resolve(input.rootDir), path.resolve(candidate.indexPath));
-      return relativePath === entrySourcePath || relativePath.startsWith(`${path.posix.dirname(entrySourcePath)}/`);
-    });
-    if (entry) taskIds.add(entry.taskId);
-
-    const row = input.existingRows.find((candidate) =>
-      relativePath === candidate.sourcePath || relativePath.startsWith(`${path.posix.dirname(candidate.sourcePath)}/`));
-    if (row) taskIds.add(row.taskId);
-  }
-
-  if (taskPackageTouchedRelativePaths.length > 1) {
-    for (const entry of input.sourceEntries) {
-      const entrySourcePath = sourcePath(path.resolve(input.rootDir), path.resolve(entry.indexPath));
-      if (taskPackageTouchedRelativePaths.some((relativePath) => relativePath === entrySourcePath || relativePath.startsWith(`${path.posix.dirname(entrySourcePath)}/`))) {
-        taskIds.add(entry.taskId);
-      }
-    }
-
-    for (const row of input.existingRows) {
-      if (taskPackageTouchedRelativePaths.some((relativePath) => relativePath === row.sourcePath || relativePath.startsWith(`${path.posix.dirname(row.sourcePath)}/`))) {
-        taskIds.add(row.taskId);
-      }
-    }
-  }
-
-  for (const row of input.existingDecisionRows) {
-    if (touchedRelativePaths.has(row.path)) {
-      decisionIds.add(row.decisionId);
-      decisionPaths.add(path.join(input.rootDir, row.path));
-    }
-  }
-
-  for (const edge of [...input.oldEdges, ...input.newEdges]) {
-    if (!touchedRelativePaths.has(edge.sourcePath)) continue;
-    addEntityRef(edge.sourceRef, taskIds, decisionIds);
-    addEntityRef(edge.targetRef, taskIds, decisionIds);
-  }
-
-  for (const row of input.existingDecisionRows) {
-    if (decisionIds.has(row.decisionId)) decisionPaths.add(path.join(input.rootDir, row.path));
-  }
-
-  return { taskIds, decisionIds, decisionPaths };
-}
-
-function taskSlugForPath(tasksRoot: string, filePath: string): string | undefined {
-  if (!isPathWithin(tasksRoot, filePath)) return undefined;
-  const relative = path.relative(tasksRoot, filePath);
-  const [slug] = relative.split(path.sep);
-  return slug && slug.length > 0 ? slug : undefined;
-}
-
-function addEntityRef(ref: string, taskIds: Set<string>, decisionIds: Set<string>): void {
-  const [kind, id] = ref.split("/");
-  if (kind === "task" && id) taskIds.add(id);
-  if (kind === "decision" && id) decisionIds.add(id);
-  if (kind === "fact") {
-    const ownerTaskId = ref.split("/")[1];
-    if (ownerTaskId) taskIds.add(ownerTaskId);
-  }
 }

--- a/packages/kernel/src/write-coordination/journal/coordinator.ts
+++ b/packages/kernel/src/write-coordination/journal/coordinator.ts
@@ -122,7 +122,7 @@ function makeJournaledWriteCoordinatorInternal(
         uniquePendingRecords(state.records, state.applied),
         requestedDomain
       );
-      return flushRecords(reason, rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords, state.fileApplied, sessionId, commitAuthor, versionControlSystem, attributionEventStore, options.onProjectionChange, options.onCommitPhase, options.onProjectionFingerprintPhase, options.onPostCommitPhase);
+      return flushRecords(reason, rootDir, runtimeContext, journalPath, watermarkPath, state.watermark, pendingRecords, state.fileApplied, sessionId, commitAuthor, versionControlSystem, attributionEventStore, options.onProjectionChange, options.onCommitPhase, options.onProjectionFingerprintPhase, options.onProjectionFingerprintDiagnostic, options.onPostCommitPhase);
     }, { heldGlobalLock }),
     catch: (cause): WriteError => toJournalError(cause)
   });
@@ -148,6 +148,7 @@ function makeJournaledWriteCoordinatorInternal(
           options.onProjectionChange,
           options.onCommitPhase,
           options.onProjectionFingerprintPhase,
+          options.onProjectionFingerprintDiagnostic,
           options.onPostCommitPhase
         )
       });
@@ -162,7 +163,7 @@ function makeJournaledWriteCoordinatorInternal(
       flushRecord: (state, record) => flushRecords(
         reason, rootDir, runtimeContext, journalPath, watermarkPath,
         state.watermark, [record], state.fileApplied, sessionId, commitAuthor,
-        versionControlSystem, attributionEventStore, options.onProjectionChange, options.onCommitPhase, options.onProjectionFingerprintPhase, options.onPostCommitPhase
+        versionControlSystem, attributionEventStore, options.onProjectionChange, options.onCommitPhase, options.onProjectionFingerprintPhase, options.onProjectionFingerprintDiagnostic, options.onPostCommitPhase
       )
     }),
     mapError: (cause) => toJournalError(cause),
@@ -178,7 +179,7 @@ function makeJournaledWriteCoordinatorInternal(
       flushRecords: (state, records) => flushRecords(
         reason, rootDir, runtimeContext, journalPath, watermarkPath,
         state.watermark, records, state.fileApplied, sessionId, commitAuthor,
-        versionControlSystem, attributionEventStore, options.onProjectionChange, options.onCommitPhase, options.onProjectionFingerprintPhase, options.onPostCommitPhase
+        versionControlSystem, attributionEventStore, options.onProjectionChange, options.onCommitPhase, options.onProjectionFingerprintPhase, options.onProjectionFingerprintDiagnostic, options.onPostCommitPhase
       )
     }),
     mapError: (cause) => toJournalError(cause),
@@ -343,6 +344,7 @@ function flushRecords(
   onProjectionChange?: (event: ProjectionChangeEvent) => void,
   onCommitPhase?: (phase: VcsCommitPhase) => void,
   onProjectionFingerprintPhase?: (phase: JournalProjectionFingerprintPhase) => void,
+  onProjectionFingerprintDiagnostic?: (diagnostic: import("../../projection/projection-source-baseline.ts").TrustedProjectionFingerprintDiagnostic) => void,
   onPostCommitPhase?: (phase: JournalPostCommitPhase) => void
 ): FlushReport {
   const touchedPaths: string[] = [];
@@ -363,7 +365,9 @@ function flushRecords(
   assertCommitPlanAddable(rootDir, plannedRecords.flatMap((record) => record.touchedPaths), rootInput, { versionControlSystem: publicationVcs });
   onProjectionFingerprintPhase?.("capture-start");
   const previousProjectionSourceFingerprint = records.length > 0 && projectionRelevant
-    ? captureTrustedAuthoredProjectionFingerprint(rootInput, publicationVcs)
+    ? captureTrustedAuthoredProjectionFingerprint(rootInput, publicationVcs, undefined, {
+      onDiagnostic: onProjectionFingerprintDiagnostic
+    })
     : undefined;
   onProjectionFingerprintPhase?.("capture-done");
 

--- a/packages/kernel/src/write-coordination/journal/types.ts
+++ b/packages/kernel/src/write-coordination/journal/types.ts
@@ -3,6 +3,7 @@ import type { HarnessLayoutOverrides } from "../../layout/index.ts";
 import type { VcsCommitAuthor, VcsCommitPhase, VersionControlSystem } from "../../ports/version-control-system.ts";
 import type { AttributionEventStore } from "../attribution/inline-attribution-event-store.ts";
 import type { ProjectionChangeEvent } from "../../projection/projection-change-event.ts";
+import type { TrustedProjectionFingerprintDiagnostic } from "../../projection/projection-source-baseline.ts";
 import type { WriteOp } from "../../ports/write-coordinator.ts";
 import type { ActorAxes, AgentRef, OperationalActor, WriteAttribution } from "../../schemas/actor-attribution.ts";
 export type { OperationalActor } from "../../schemas/actor-attribution.ts";
@@ -29,6 +30,7 @@ export interface JournaledWriteCoordinatorOptions {
   readonly onProjectionChange?: (event: ProjectionChangeEvent) => void;
   readonly onCommitPhase?: (phase: VcsCommitPhase) => void;
   readonly onProjectionFingerprintPhase?: (phase: JournalProjectionFingerprintPhase) => void;
+  readonly onProjectionFingerprintDiagnostic?: (diagnostic: TrustedProjectionFingerprintDiagnostic) => void;
   readonly onPostCommitPhase?: (phase: JournalPostCommitPhase) => void;
 }
 

--- a/packages/kernel/src/write-coordination/materialization/ledger-materializer.ts
+++ b/packages/kernel/src/write-coordination/materialization/ledger-materializer.ts
@@ -4,7 +4,7 @@ import type { HarnessLayoutInput } from "../../layout/index.ts";
 import { resolveHarnessLayout } from "../../layout/index.ts";
 import type { VersionControlSystem } from "../../ports/version-control-system.ts";
 import { updateTaskProjectionIncrementally } from "../../projection/sqlite-task-incremental-projection.ts";
-import type { IncrementalProjectionPhase } from "../../projection/sqlite-task-incremental-projection.ts";
+import type { IncrementalProjectionDiagnostic, IncrementalProjectionPhase } from "../../projection/sqlite-task-incremental-projection.ts";
 import { countAttributionProjectionRows } from "../../projection/sqlite-attribution-projection.ts";
 import { rebuildTaskProjection } from "../../projection/sqlite-task-projection.ts";
 import {
@@ -12,6 +12,7 @@ import {
   invalidateTrustedAuthoredProjectionFingerprint,
   rememberTrustedAuthoredProjectionFingerprint
 } from "../../projection/projection-source-baseline.ts";
+import type { TrustedProjectionFingerprintDiagnostic } from "../../projection/projection-source-baseline.ts";
 import { makeLocalVersionControlSystem } from "../../persistence/git/local-version-control-system.ts";
 import {
   materializerCommitter,
@@ -56,9 +57,12 @@ export interface LedgerMaterializerOptions {
   readonly onProjectionPhase?: (phase: IncrementalProjectionPhase) => void;
   readonly onProjectionMode?: (mode: IncrementalTaskProjectionMode, reason?: IncrementalProjectionRebuildReason) => void;
   readonly onProjectionAttributionDecision?: (reason: AttributionProjectionDecisionReason) => void;
+  readonly onProjectionDiagnostic?: (
+    diagnostic: TrustedProjectionFingerprintDiagnostic | IncrementalProjectionDiagnostic
+  ) => void;
 }
 
-export type { IncrementalProjectionPhase };
+export type { IncrementalProjectionDiagnostic, IncrementalProjectionPhase };
 export type { IncrementalProjectionRebuildReason };
 
 export type IncrementalTaskProjectionMode = "incremental" | "rebuild" | "unchanged";
@@ -102,7 +106,8 @@ export function runLedgerMaterializer(rootInput: HarnessLayoutInput, options: Le
       options.onProgress,
       options.onProjectionPhase,
       options.onProjectionMode,
-      options.onProjectionAttributionDecision
+      options.onProjectionAttributionDecision,
+      options.onProjectionDiagnostic
     );
   }, { heldGlobalLock: options.heldGlobalLock });
 }
@@ -117,7 +122,8 @@ function materializeBranches(
   onProgress: ((step: LedgerMaterializerProgressStep) => void) | undefined,
   onProjectionPhase: ((phase: IncrementalProjectionPhase) => void) | undefined,
   onProjectionMode: ((mode: IncrementalTaskProjectionMode, reason?: IncrementalProjectionRebuildReason) => void) | undefined,
-  onProjectionAttributionDecision: ((reason: AttributionProjectionDecisionReason) => void) | undefined
+  onProjectionAttributionDecision: ((reason: AttributionProjectionDecisionReason) => void) | undefined,
+  onProjectionDiagnostic: ((diagnostic: TrustedProjectionFingerprintDiagnostic | IncrementalProjectionDiagnostic) => void) | undefined
 ): LedgerMaterializerReport {
   const reports: LedgerMaterializerBranchReport[] = [];
   const warnings: string[] = [];
@@ -164,7 +170,9 @@ function materializeBranches(
 
     if (projectionSourceFingerprintBeforeMerge === undefined) {
       onProgress?.("baseline-start");
-      projectionSourceFingerprintBeforeMerge = captureTrustedAuthoredProjectionFingerprint(rootInput, vcs, repoRoot);
+      projectionSourceFingerprintBeforeMerge = captureTrustedAuthoredProjectionFingerprint(rootInput, vcs, repoRoot, {
+        onDiagnostic: onProjectionDiagnostic
+      });
       onProgress?.("baseline-done");
     }
 
@@ -240,7 +248,8 @@ function materializeBranches(
       touchedPaths: [...touchedPaths],
       ...(projectionSourceFingerprintBeforeMerge ? { previousSourceFingerprint: projectionSourceFingerprintBeforeMerge } : {}),
       onPhase: onProjectionPhase,
-      onAttributionDecision: onProjectionAttributionDecision
+      onAttributionDecision: onProjectionAttributionDecision,
+      onDiagnostic: onProjectionDiagnostic
     });
     onProjectionMode?.(
       projectionUpdate.mode,

--- a/packages/kernel/test/store/sqlite-projection-integrity.test.ts
+++ b/packages/kernel/test/store/sqlite-projection-integrity.test.ts
@@ -43,6 +43,24 @@ test("incremental task and decision edits preserve authored attribution", () => 
   });
 });
 
+test("a source-fingerprint rebuild publishes its generation for the next trusted advance", () => {
+  withTempStore((rootDir) => {
+    writeIntegrityTask(rootDir, "task-a", "Task A", "active");
+    rebuildTaskProjection({ rootDir });
+
+    writeIntegrityTask(rootDir, "task-a", "Task A generation one", "active");
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    const mismatchedTouchedPath = writeIntegrityTask(rootDir, "task-b", "Task B generation two", "done");
+    const rebuilt = updateTaskProjectionIncrementally({ rootDir, touchedPaths: [mismatchedTouchedPath], previousSourceFingerprint });
+
+    assert.equal(rebuilt.mode, "rebuild");
+    assert.equal(rebuilt.sourceHash, captureProjectionSourceSnapshot(rootDir).fingerprint);
+    const nextTouchedPath = writeIntegrityTask(rootDir, "task-c", "Task C generation three", "done");
+    const next = updateTaskProjectionIncrementally({ rootDir, touchedPaths: [nextTouchedPath], previousSourceFingerprint: rebuilt.sourceHash });
+    assert.equal(next.mode, "incremental");
+  });
+});
+
 test("projection reads reject valid-looking attribution tampering", () => {
   withTempStore((rootDir) => {
     writeIntegrityTask(rootDir, "task-a", "Task A", "active");

--- a/tools/perf/residual-write-cost-fixture.mjs
+++ b/tools/perf/residual-write-cost-fixture.mjs
@@ -94,22 +94,35 @@ try {
 
   const fingerprintMs = measure(() => captureAuthoredProjectionFingerprint(root));
   const projectionRebuildMs = measure(() => rebuildTaskProjection({ rootDir: root }));
+
+  // Production's prior materializer generation is followed by an evidence V2
+  // commit before the next governance write. Keep that HEAD/source generation
+  // gap in the fixture so a rebuild can invalidate the trusted cache just as
+  // the daemon does; no trusted capture is allowed to bridge it here.
+  const preflightEvidenceCommitParent = git("rev-parse", "HEAD");
+  evidenceLog.ensure(v2Event("op-preflight-generation", evidenceShardCount + 1, {
+    taskId: "task_synthetic_00000",
+    action: "append",
+    path: "tasks/task_synthetic_00000/progress.md"
+  }));
+  await evidenceCommitter.commitPending(preflightEvidenceCommitParent);
+
   const trustedVcs = makeLocalVersionControlSystem();
   const trustedFingerprintColdMs = measure(() => captureTrustedAuthoredProjectionFingerprint(root, trustedVcs));
   const trustedFingerprintWrites = [];
   for (let writeIndex = 1; writeIndex <= 2; writeIndex += 1) {
     const writeStartedAt = performance.now();
     const telemetryFrames = [];
-    await runWithRepoWriteTelemetry((phase, elapsedMs) => {
-      telemetryFrames.push({ phase, elapsedMs });
+    await runWithRepoWriteTelemetry((phase, elapsedMs, details) => {
+      telemetryFrames.push({ phase, elapsedMs, ...(details ? { details } : {}) });
     }, async () => {
       const report = (phase) => reportCurrentRepoWriteTelemetry(phase);
       report("queue");
       report("compile");
       report("journal");
-      const sessionId = `round9-write-${writeIndex}`;
+      const sessionId = `round10-write-${writeIndex}`;
       const sessionBranch = `sessions/${sessionId}`;
-      const opId = `op-round9-${String(writeIndex).padStart(2, "0")}`;
+      const opId = `op-round10-${String(writeIndex).padStart(2, "0")}`;
       const taskProgressRelativePath = path.join("tasks", "task_synthetic_00000", "progress.md");
       const taskProgressPath = path.join(authoredRoot, taskProgressRelativePath);
       git("branch", sessionBranch);
@@ -165,19 +178,11 @@ try {
         true
       );
 
-      const canonicalTrustedStartedAt = performance.now();
-      const canonicalTrustedFingerprint = captureTrustedAuthoredProjectionFingerprint(root, trustedVcs);
-      const canonicalTrustedMs = performance.now() - canonicalTrustedStartedAt;
-      const canonicalFullStartedAt = performance.now();
-      const canonicalFullFingerprint = captureAuthoredProjectionFingerprint(root);
-      const canonicalFullMs = performance.now() - canonicalFullStartedAt;
-      if (canonicalTrustedFingerprint !== canonicalFullFingerprint) {
-        throw new Error(`trusted fingerprint mismatch after canonical write ${writeIndex}`);
-      }
+      const canonicalFullMs = measure(() => captureAuthoredProjectionFingerprint(root));
 
       report("authority-evidence-commit");
       report("fsync");
-      evidenceLog.ensure(v2Event(opId, evidenceShardCount + writeIndex, {
+      evidenceLog.ensure(v2Event(opId, evidenceShardCount + 1 + writeIndex, {
         taskId: "task_synthetic_00000",
         action: "append",
         path: taskProgressRelativePath
@@ -187,25 +192,17 @@ try {
       const evidenceCommitMs = performance.now() - evidenceCommitStartedAt;
       report("authority-evidence-publish-returned");
       report("authority-event-published");
-      const evidenceTrustedStartedAt = performance.now();
-      const evidenceTrustedFingerprint = captureTrustedAuthoredProjectionFingerprint(root, trustedVcs);
-      const evidenceTrustedMs = performance.now() - evidenceTrustedStartedAt;
-      const evidenceFullStartedAt = performance.now();
-      const evidenceFullFingerprint = captureAuthoredProjectionFingerprint(root);
-      const evidenceFullMs = performance.now() - evidenceFullStartedAt;
-      if (evidenceTrustedFingerprint !== evidenceFullFingerprint) {
-        throw new Error(`trusted fingerprint mismatch after evidence write ${writeIndex}`);
-      }
+      const evidenceFullMs = measure(() => captureAuthoredProjectionFingerprint(root));
       report("authority-terminal-record-start");
       report("authority-terminal-record-persisted");
       report("runtime-event-append-start");
       const runtimeEventReceipt = await pollingRuntime.enqueueInteractiveWrite({
-        commandId: `runtime-event-round9-${String(writeIndex).padStart(2, "0")}`,
+        commandId: `runtime-event-round10-${String(writeIndex).padStart(2, "0")}`,
         operationalActor: { scope: "operational", kind: "system", id: "runtime-event-cli" },
         ops: [runtimeEventOp(
-          `runtime-event-round9-${String(writeIndex).padStart(2, "0")}`,
+          `runtime-event-round10-${String(writeIndex).padStart(2, "0")}`,
           `${sessionId}.jsonl`,
-          `evt-round9-${String(writeIndex).padStart(2, "0")}`
+          `evt-round10-${String(writeIndex).padStart(2, "0")}`
         )]
       });
       if (!runtimeEventReceipt.flush.committed || runtimeEventReceipt.flush.opCount !== 1) {
@@ -224,10 +221,10 @@ try {
         materializerMs: telemetry.materializerWindow.durationMs,
         preAuthorityBarrierMs,
         postAuthorityBarrierMs,
-        canonicalTrustedMs,
+        canonicalTrustedMs: null,
         canonicalFullMs,
         evidenceCommitMs,
-        evidenceTrustedMs,
+        evidenceTrustedMs: null,
         evidenceFullMs,
         telemetry: compactTelemetry(telemetry)
       });
@@ -283,6 +280,7 @@ try {
       taskPackageCount,
       evidenceShardCount,
       pairedLegacyAttributionShardCount: evidenceShardCount,
+      postProjectionEvidenceGenerationCommit: true,
       historyCommitCount,
       fixtureMaterializerPollMs,
       untrackedProjectionExternalArtifact: true
@@ -527,6 +525,13 @@ function compactTelemetry(telemetry) {
     projectionModeReasons: telemetry.frames
       .filter((frame) => frame.phase.startsWith("authority-materializer-projection-mode-rebuild-reason-"))
       .map((frame) => frame.phase),
+    projectionDiagnostics: telemetry.frames
+      .filter((frame) => frame.phase === "authority-materializer-baseline-fence" ||
+        frame.phase === "authority-materializer-baseline-cache" ||
+        frame.phase === "authority-materializer-projection-source-summary" ||
+        frame.phase === "authority-materializer-projection-metadata-summary" ||
+        frame.phase === "authority-materializer-projection-trusted-advance")
+      .map((frame) => ({ phase: frame.phase, details: frame.details })),
     attributionDecisions: telemetry.frames
       .filter((frame) => frame.phase.startsWith("authority-materializer-projection-attribution-decision-"))
       .map((frame) => frame.phase),


### PR DESCRIPTION
# English

## Summary

Round 10 — and the last performance round on this task — of the residual governance-write cost work. Production warm writes still took a ~1,967ms projection `mode-rebuild` on **every** write with `reason-source-fingerprint-mismatch`, even after round 9 narrowed the dirty fence. This round first falsified the remaining fence hypothesis (production-shaped fixture reports `clean=true`, `sourceDirtyCount=0` on every write), then found the actual generation break: **a successful `source-fingerprint-mismatch` full rebuild persisted a new source fingerprint into the projection DB but did not return it**, so `ledger-materializer` hit its fail-closed `else invalidate` branch and dropped the trusted cache. The next write re-captured from cold, its metadata was one generation behind again, and it rebuilt — forever.

The reason the previous three rounds went "fixture green / production red" is also answered here: the fixture contained a manual `capture trusted fingerprint` step after each evidence commit, which did by hand exactly what the rebuild failed to do. Removing that step made the pre-fix fixture reproduce the production per-write rebuild immediately.

## What Changed

- **Fix** (`sqlite-task-incremental-projection.ts` + `ledger-materializer.ts`): after a successful `source-fingerprint-mismatch` full rebuild, read the already-persisted `sourceHash` from the projection DB and return it on the `ProjectionChangeEvent`. The materializer reuses its existing `if (sourceHash) rememberTrusted… else invalidate…` branch — no new bypass, no second lock. Deletes, non-single upserts, unparsable op-ids, precedence ambiguity, read failures, ordinary rebuilds and recovery rebuilds all still carry no `sourceHash` and continue to full-capture/invalidate.
- **Six always-on self-attesting telemetry phases** so production names its own cause instead of needing another attribution round: `baseline-fence` (clean/status/source-dirty/unparseable counts), `baseline-cache` (cold / same-head / fence / ancestor-incremental and failure reasons), `projection-source-summary` (per-category counts and hashes), `projection-metadata-summary` (existing/previous/current/stored generations), `projection-trusted-advance` (advanced or invalidated, with reason), `flush-projection-fingerprint-summary`. `details` is a bounded scalar map (key count, key length, value length, nesting all capped, fail-closed on violation); no authored paths or blob content.
- **Fixture instrument fixed**: removed the manual trusted-fingerprint capture that masked this defect for three rounds, and added a post-materializer V2 generation commit so consecutive writes genuinely advance HEAD.
- `sqlite-task-incremental-projection.ts` split into `-affected` / `-diagnostics` modules to stay within the file-complexity standard.

## Task And Scope

- Task `task_01KZ3DCGW7K0XEY69Z47J1AEA8`, report `artifacts/residual-round-10.md`. 24 files, +911/−280 on base `8739ec14` (no rebase needed).
- Untouched: authority / publication / durability semantics, lock ordering, the 30s deadline, orphan PROCEEDING recovery, CLI enrollment, CI/gate surfaces.
- **CEO ruling recorded in `artifacts/round-10-closeout-decision.md`: this is the final performance round on this task.** All three original acceptance criteria in the task plan are already met (warm writes 18–25s → single-digit seconds; `task complete` has >13s headroom under the 30s wall instead of deterministically blowing it; the structurally stuck L4 task closed out). Any residual — the replication snapshot at ~525ms — is demoted to a backlog observation rather than another round.

## Version Impact

- No public CLI change; no persisted-schema change. Telemetry phase enum grows (additive) and gains a bounded `details` map on the wire; parent and child deploy together via the standard daemon restart.

## Governance Declaration

- No protected surfaces touched. Not a governance task; no break-glass.
- `architecture-check` advisory returned `script_result_failed` with no detail during this round. It was **not** used to justify any change to authority or gate surfaces, and is not being reported as a code failure — it is the known receipt defect already filed separately.

## Verification

- `npm run check:local`: green — 27 local manifest gates, affected fast 500/500, affected contract 487/487 (1 skipped).
- `node tools/run-node-tests.mjs --tier integration`: exit 0 — 1,475 tests, 1,471 pass, 0 fail, 4 skipped.
- `npm run lint`, kernel/daemon TypeScript build, kernel dead-export gate, `git diff --check`: pass.
- Governance walls: 9 pass, 0 red.
- Fixture (production-shaped: 26,612 authored files, 150.57 MiB, 1,011 task packages, 3,179 paired V1/V2 attribution shards, 24,000 history commits, cold index):

| | write 1 | write 2 |
| --- | ---: | ---: |
| pre-fix | 4,360.7ms · rebuild-mismatch | 4,570.7ms · rebuild-mismatch |
| post-fix | 4,200.0ms · rebuild-mismatch (deliberate generation seed) | 3,966.4ms · **incremental** |

  Phase accounting residual 0.00ms on both writes; the exact-equality assertion between incremental and full projection is retained.

## Review Evidence

- CEO semantic review: the attribution is anchored on a falsification (fence self-reports clean on every write, so the fence was not the cause) rather than on shape inference; the fix reuses the existing fail-closed remember/invalidate branch instead of adding a path around it; and the fixture instrument defect that made three consecutive rounds report false green is itself corrected, which is the durable part of this round.
- Concurrency/failure-path seven questions answered in the report, including the two crash windows (post-rebuild-pre-remember, and post-remember-pre-next-commit).

## Residual Risk

- Production effect is **unverified at time of PR** — the report is explicit about this. Expectation after deployment: the first warm write may still pay one rebuild to seed the current projection generation, with incremental from the second write onward. If mismatch persists, the four new frame families name the generation directly instead of requiring wall-shape guessing.
- Replication snapshot ~525ms remains an open observation, now formally demoted to backlog per the closeout ruling.

## References

- Task `task_01KZ3DCGW7K0XEY69Z47J1AEA8`; reports `artifacts/residual-round-{6,7,8,9,10}.md`; ruling `artifacts/round-10-closeout-decision.md`.
- Prior rounds in this defect family: #1086, #1205, #1206, #1209, #1211, #1212, #1215, #1217, #1219.

---

# 中文

## 概要

治理写残余成本第 10 轮——也是本任务的**最后一轮性能轮**。round-9 收窄 dirty fence 之后，生产暖写**每一条**仍要付约 1,967ms 的 projection `mode-rebuild`，原因编码 `reason-source-fingerprint-mismatch`。本轮先证伪了残留的 fence 假设（生产形状 fixture 每写自报 `clean=true`、`sourceDirtyCount=0`），随后找到真正的代际断点：**`source-fingerprint-mismatch` 的全量 rebuild 成功后把新 source fingerprint 持久化进了 projection DB，却没有把它返回**，于是 `ledger-materializer` 落进 fail-closed 的 `else invalidate` 分支丢掉 trusted cache。下一写只能冷启重新 capture，metadata 又落后一代，于是再次 rebuild——永远循环。

前三轮为什么「fixture 绿 / 生产红」，本轮也一并有了答案：fixture 里有一个每次 evidence commit 后**手工 capture trusted fingerprint** 的步骤，正好替 rebuild 做了它漏做的事。删掉这个步骤后，修前的 fixture 立刻复现了生产的每写 rebuild。

## 改动内容

- **修复**（`sqlite-task-incremental-projection.ts` + `ledger-materializer.ts`）：`source-fingerprint-mismatch` 的全量 rebuild 成功后，从 projection DB 读回已持久化的 `sourceHash`，随 `ProjectionChangeEvent` 返回。materializer 复用既有的 `if (sourceHash) rememberTrusted… else invalidate…` 分支——不新增旁路、不新增第二把锁。delete、非单一 upsert、op-id 不可解析、precedence 歧义、读取异常、普通 rebuild 与 recovery rebuild 一律仍不携带 `sourceHash`，继续走 full capture / invalidate。
- **六类常开自证 telemetry**，让生产自己说出原因，不再需要专门的归因轮：`baseline-fence`（clean/status/source-dirty/unparseable 计数）、`baseline-cache`（cold / same-head / fence / ancestor 增量及失败原因）、`projection-source-summary`（各类目计数与 hash）、`projection-metadata-summary`（existing/previous/current/stored 代际）、`projection-trusted-advance`（推进还是失效，附原因）、`flush-projection-fingerprint-summary`。`details` 是受限 scalar map（键数、键长、值长、嵌套均有上限，越界 fail-closed）；不落 authored 路径与 blob 内容。
- **修好了仪器本身**：删掉掩盖此缺陷三轮的手工 trusted-fingerprint capture，并补上 materializer 之后的 V2 generation commit，确保连续两写真正推进 HEAD。
- `sqlite-task-incremental-projection.ts` 拆出 `-affected` / `-diagnostics` 两个模块以满足 file-complexity 标准。

## 任务与范围

- 任务 `task_01KZ3DCGW7K0XEY69Z47J1AEA8`，报告 `artifacts/residual-round-10.md`。基于 `8739ec14`，24 文件、+911/−280（无需 rebase）。
- 未触碰：authority / publication / durability 语义、锁顺序、30s deadline、孤儿 PROCEEDING 恢复、CLI enrollment、CI/gate 面。
- **CEO 裁决已落 `artifacts/round-10-closeout-decision.md`：本轮是该任务最后一轮性能轮。** task plan 的三条原始判据全部达成（暖写 18–25s → 个位数秒；`task complete` 在 30s 墙下有 13s 以上余量，而非确定性撞穿；结构性卡死的 L4 任务已收口）。残余项（replication snapshot 约 525ms）降级为 backlog 观察，不再开新轮。

## 版本影响

- 无公开 CLI 变更；无持久化 schema 变更。遥测 phase 枚举增量扩展，wire 上新增受限 `details` map；parent 与 child 经常规 daemon 重启同 dist 部署。

## 治理声明

- 未触碰 protected surface。非治理任务；无 break-glass。
- 本轮 `architecture-check` advisory 返回 `script_result_failed` 且无细节。**未**据此改动 authority 或 gate 面，也未把它冒充为本轮代码失败——它是已单独立案的回执缺陷。

## 验证

- `npm run check:local`：全绿——27 个本地 manifest 门、affected fast 500/500、affected contract 487/487（1 skipped）。
- `node tools/run-node-tests.mjs --tier integration`：exit 0——1,475 tests，1,471 pass，0 fail，4 skipped。
- `npm run lint`、kernel/daemon TypeScript build、kernel dead-export 门、`git diff --check`：通过。
- 治理墙：9 pass、0 red。
- fixture（生产形状：26,612 authored files、150.57 MiB、1,011 任务包、3,179 对 V1/V2 配对 attribution shards、24,000 history commits、冷 index）：

| | 写 1 | 写 2 |
| --- | ---: | ---: |
| 修前 | 4,360.7ms · rebuild-mismatch | 4,570.7ms · rebuild-mismatch |
| 修后 | 4,200.0ms · rebuild-mismatch（刻意的代际 seed） | 3,966.4ms · **incremental** |

  两写 phase 对账残差均为 0.00ms；增量与全量投影精确相等的断言保留。

## 审查证据

- CEO 语义验收：归因锚在一次**证伪**上（fence 每写自报 clean，因此 fence 不是病因），而非形状推断；修法复用既有 fail-closed 的 remember/invalidate 分支，没有绕开它另开一条路；并且让连续三轮报假绿的**仪器缺陷本身**被修正——这才是本轮真正沉淀下来的东西。
- 并发/失败路径七问已在报告作答，含两个崩溃窗口（rebuild 后 remember 前、remember 后下一次 commit 前）。

## 残余风险

- **发 PR 时生产效果尚未验证**——报告对此明确披露。部署后预期：第一条暖写可能仍需付一次 rebuild 以 seed 当前 projection generation，从第二条起进入 incremental。若 mismatch 仍在，四类新帧会直接报出代际，不再需要从 wall 形状猜。
- replication snapshot 约 525ms 仍是开放观察项，按收口裁决正式降级为 backlog。

## 关联材料

- 任务 `task_01KZ3DCGW7K0XEY69Z47J1AEA8`；报告 `artifacts/residual-round-{6,7,8,9,10}.md`；裁决 `artifacts/round-10-closeout-decision.md`。
- 本缺陷族前序轮次：#1086、#1205、#1206、#1209、#1211、#1212、#1215、#1217、#1219。

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body complete / 双语正文完整
- [x] Non-governance task did not modify CI/gate authority surfaces / 非治理任务未修改 CI/gate 权威面
- [x] Verification is real command output, not assertion / 验证为真实命令输出而非断言
- [x] Residual risk honestly stated / 残余风险如实陈述
