### PR TITLE
fix(authority): settle deterministic code-doc reconcile no-op as explicit rejection + retire known unpublished corpses from daily recovery sweep

### DIFF
--- a/packages/application/src/authority/code-doc-reconcile-rejection.ts
+++ b/packages/application/src/authority/code-doc-reconcile-rejection.ts
@@ -1,0 +1,25 @@
+export function codeDocReconcileNoopReason(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const candidate = error as {
+    readonly _tag?: unknown;
+    readonly code?: unknown;
+    readonly message?: unknown;
+    readonly reason?: unknown;
+    readonly cause?: unknown;
+  };
+  if ((candidate._tag === "WriteRejected" || candidate._tag === "WriteRejectedError")
+    && candidate.code === "code_doc_reconcile_noop"
+    && typeof candidate.reason === "string") {
+    return candidate.reason;
+  }
+  if (typeof candidate.message === "string") {
+    try {
+      const parsed = JSON.parse(candidate.message) as unknown;
+      const nested = codeDocReconcileNoopReason(parsed);
+      if (nested) return nested;
+    } catch {
+      // Non-JSON error messages are not typed write rejections.
+    }
+  }
+  return codeDocReconcileNoopReason(candidate.cause);
+}

--- a/packages/application/src/authority/service.ts
+++ b/packages/application/src/authority/service.ts
@@ -52,6 +52,7 @@ import type { AuthoritySubmissionServiceOptions } from "./service-options.ts";
 import { createAuthorityRecoverySubmitterV2 } from "./authority-recovery-submission-v2.ts";
 import { authorityOperationPublicView } from "./operation-record-public-view.ts";
 import { prepareAuthorityV2 } from "./authority-v2-preparation.ts";
+import { codeDocReconcileNoopReason } from "./code-doc-reconcile-rejection.ts";
 export type { AuthoritySubmissionServiceOptions, AuthoritySubmissionV2Options } from "./service-options.ts";
 export function createAuthoritySubmissionService(options: AuthoritySubmissionServiceOptions): AuthoritySubmissionService {
   const writableEntityRegistry = options.v2
@@ -344,6 +345,12 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
       canonicalFlushCommitted = true;
     } catch (error) {
       if (isDaemonGenerationFenced(error)) throw error;
+      const deterministicRejection = codeDocReconcileNoopReason(error);
+      if (deterministicRejection) {
+        await settlePrepared(candidates, receipts, "REJECTED", (entry) =>
+          rejected(entry, entry.semanticDigest, deterministicRejection));
+        return batchReceipts(admissions, receipts);
+      }
       await settlePrepared(candidates, receipts, "INDETERMINATE", (entry) =>
         indeterminate(entry, entry.semanticDigest, `PUBLICATION_OUTCOME_UNKNOWN:${describe(error)}`));
       return batchReceipts(admissions, receipts);

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -61,6 +61,7 @@ import {
   verifyExplicitTaskSubmitIngress,
   verifyInferredTaskSubmitIngress
 } from "./task-submit-ingress.ts";
+import { exerciseIdenticalCodeDocForce } from "./code-doc-force-replay.ts";
 
 test("production service route preserves progress dry-run and publishes canonical task writes", { timeout: 240_000 }, async () => {
   const fixture = createFixture();
@@ -237,6 +238,12 @@ test("production service route preserves progress dry-run and publishes canonica
       `tasks/${sluggedLifecycleTaskId}-production-route/code-doc-anchors.json`
     )), true, "owner-stage reconciliation must publish code-doc anchors before completion");
 
+    const sluggedTaskRoot = await exerciseIdenticalCodeDocForce(
+      fixture,
+      sluggedLifecycleTaskId,
+      sluggedLifecycleEnv
+    );
+
     const completionPacketPath = path.join(fixture.root, "slugged-completion.json");
     writeFileSync(completionPacketPath, JSON.stringify({
       findings: "Slugged production evidence is complete.",
@@ -249,6 +256,7 @@ test("production service route preserves progress dry-run and publishes canonica
       executionId: sluggedExecutionId,
       commit: fixture.publicHead,
       paths: ["README.md"],
+      prRef: "https://github.com/example/repo/pull/999",
       reviewerId: "person_alice"
     }));
     const completed = runRawJsonMaybeFail(fixture.repoRoot, [
@@ -256,7 +264,6 @@ test("production service route preserves progress dry-run and publishes canonica
     ], sluggedLifecycleEnv);
     assert.equal(completed.status, 0, JSON.stringify(completed.receipt));
     assert.equal(completed.receipt.ok, true, JSON.stringify(completed.receipt));
-    const sluggedTaskRoot = path.join(fixture.authoredRoot, `tasks/${sluggedLifecycleTaskId}-production-route`);
     assert.match(readFileSync(path.join(sluggedTaskRoot, "INDEX.md"), "utf8"), /^  status: done$/mu);
     const consentFiles = execFileSync("find", [path.join(sluggedTaskRoot, "consents"), "-type", "f"], { encoding: "utf8" })
       .trim().split("\n").filter(Boolean);
@@ -345,9 +352,13 @@ test("production service route preserves progress dry-run and publishes canonica
     ], { ...env, CODEX_THREAD_ID: concurrentSessionId })));
     assert.equal(interleaved.every((receipt) => receipt.ok === true), true, JSON.stringify(interleaved));
     const settledOperations = authorityOperationRecords(fixture.serviceRoot);
-    assert.equal(settledOperations.every((record) => record.state === "COMMITTED"), true, JSON.stringify(settledOperations));
+    assert.equal(settledOperations.every((record) =>
+      record.state === "COMMITTED"
+      || (record.state === "REJECTED" && record.receipt?.reason?.includes("produced no authored change"))
+    ), true, JSON.stringify(settledOperations));
     const eventBodies = authorityEventBodies(fixture.authoredRoot);
     for (const record of settledOperations) {
+      if (record.state !== "COMMITTED") continue;
       assert.equal(eventBodies.filter((body) => body.includes(record.opId ?? "missing-op")).length, 1, JSON.stringify(record));
     }
   } finally {

--- a/packages/cli/test/production-authority-canonical-ingress/code-doc-force-replay.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/code-doc-force-replay.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { createGitCanonicalPublicationInspector } from "../../../daemon/src/index.ts";
+import { runRawJsonMaybeFail } from "../helpers/daemon-cli.ts";
+import { git, latestAuthorityOperation } from "./fixture.ts";
+
+interface CanonicalFixtureRoots {
+  readonly authoredRoot: string;
+  readonly publicHead: string;
+  readonly repoRoot: string;
+  readonly serviceRoot: string;
+}
+
+export async function exerciseIdenticalCodeDocForce(
+  fixture: CanonicalFixtureRoots,
+  taskId: string,
+  env: Readonly<Record<string, string>>
+): Promise<string> {
+  const taskRoot = path.join(fixture.authoredRoot, `tasks/${taskId}-production-route`);
+  const closeoutPath = path.join(taskRoot, "closeout.md");
+  writeFileSync(closeoutPath, `${readFileSync(closeoutPath, "utf8")}\nAmended after implementation review.\n`);
+  git(fixture.authoredRoot, "add", `tasks/${taskId}-production-route/closeout.md`);
+  git(fixture.authoredRoot, "commit", "-q", "-m", "amend closeout before force reconciliation");
+
+  const forceArgs = [
+    "task", "code-doc", "reconcile", taskId,
+    "--commit", fixture.publicHead, "--path", "README.md",
+    "--pr", "https://github.com/example/repo/pull/999", "--force"
+  ];
+  const forced = runRawJsonMaybeFail(fixture.repoRoot, forceArgs, env);
+  assert.equal(forced.status, 0, JSON.stringify(forced.receipt));
+  assert.equal(forced.receipt.ok, true, JSON.stringify(forced.receipt));
+  const forcedOperation = latestAuthorityOperation(fixture.serviceRoot);
+  assert.equal(forcedOperation.canonicalOperation?.kind, "code_doc_reconcile", JSON.stringify(forcedOperation));
+  assert.equal(forcedOperation.state, "COMMITTED", JSON.stringify(forcedOperation));
+  assert.equal(forcedOperation.receipt?.tag, "COMMITTED", JSON.stringify(forcedOperation));
+  const forcedPublication = await createGitCanonicalPublicationInspector(fixture.authoredRoot)
+    .findPublicationForOperation(forcedOperation.opId!);
+  assert.equal(forcedPublication.commitSha, forcedOperation.commitSha, "force after closeout change");
+
+  const identicalForce = runRawJsonMaybeFail(fixture.repoRoot, forceArgs, env);
+  assert.notEqual(identicalForce.status, 0, JSON.stringify(identicalForce.receipt));
+  assert.equal(identicalForce.receipt.ok, false, JSON.stringify(identicalForce.receipt));
+  assert.match(JSON.stringify(identicalForce.receipt), /produced no authored change/u);
+  assert.doesNotMatch(
+    JSON.stringify(identicalForce.receipt),
+    /repo_write_outcome_unknown|execution_outcome_unknown|outcome remains unknown/u
+  );
+  return taskRoot;
+}

--- a/packages/daemon/src/runtime/repo-write-authority-recovery-gate.ts
+++ b/packages/daemon/src/runtime/repo-write-authority-recovery-gate.ts
@@ -250,6 +250,7 @@ export class RepoWriteAuthorityRecoveryGate {
 
 const permanentHistoricalRecoveryRejectionCodes = new Set([
   "AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR",
+  "AUTHORITY_CANONICAL_PUBLICATION_NOT_FOUND",
   "AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH"
 ]);
 

--- a/packages/daemon/test/repo-write-authority-recovery-gate.test.ts
+++ b/packages/daemon/test/repo-write-authority-recovery-gate.test.ts
@@ -253,7 +253,7 @@ recoveryTest("NON_LINEAR semicolon diagnostic is durably rejected once", async (
   }
 });
 
-recoveryTest("historical recovery stays outcome-unknown when publication is absent", async () => {
+recoveryTest("historical recovery durably rejects once when publication is absent", async () => {
   const directory = mkdtempSync(path.join(os.tmpdir(), "ha-repo-write-historical-absent-"));
   try {
     const historical = { ...proceedingInput(), generation: 403 };
@@ -279,12 +279,28 @@ recoveryTest("historical recovery stays outcome-unknown when publication is abse
         throw new Error("AUTHORITY_CANONICAL_PUBLICATION_NOT_FOUND");
       }
     });
-    await assert.rejects(
-      gate.recoverHistoricalProceeding(current.listHistoricalProceedings()[0]!),
-      /AUTHORITY_CANONICAL_PUBLICATION_NOT_FOUND/u
+    assert.deepEqual(
+      await gate.recoverHistoricalProceeding(current.listHistoricalProceedings()[0]!),
+      {
+        disposition: "permanently-rejected",
+        code: "AUTHORITY_CANONICAL_PUBLICATION_NOT_FOUND"
+      }
     );
     assert.equal(current.lookup(previous.outerOpId).state, "outcome-unknown");
+    assert.equal(
+      current.getHistoricalRecoveryRejection(previous.outerOpId)?.code,
+      "AUTHORITY_CANONICAL_PUBLICATION_NOT_FOUND"
+    );
     assert.equal(readdirSync(directory).filter((name) => name.endsWith(".terminal.json")).length, 0);
+    assert.deepEqual(current.listHistoricalProceedings(), []);
+
+    const restarted = new DurableRepoWriteOutcomeStoreV1({
+      directory,
+      repoId: historical.repoId,
+      workspaceId: historical.workspaceId,
+      generation: 410
+    });
+    assert.deepEqual(restarted.listHistoricalProceedings(), []);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }

--- a/packages/kernel/src/write-coordination/journal/code-doc-reconcile-noop.ts
+++ b/packages/kernel/src/write-coordination/journal/code-doc-reconcile-noop.ts
@@ -1,0 +1,55 @@
+import type { HarnessLayoutInput } from "../../layout/index.ts";
+import type { VersionControlSystem } from "../../ports/version-control-system.ts";
+import type { ReadableJournalRecord } from "./types.ts";
+import { durableFileExists, readFileBytes } from "./durable.ts";
+import {
+  createAttributionEvent,
+  planAttributionEventCommit,
+  type AttributionEventStore
+} from "../attribution/inline-attribution-event-store.ts";
+import { WriteRejectedError } from "./rejection.ts";
+
+export function assertCodeDocReplacementHasAuthoredChange(input: {
+  readonly rootDir: string;
+  readonly rootInput: HarnessLayoutInput;
+  readonly plannedRecords: ReadonlyArray<{
+    readonly record: ReadableJournalRecord;
+    readonly touchedPaths: ReadonlyArray<string>;
+  }>;
+  readonly publicationVcs: VersionControlSystem;
+  readonly attributionEventStore: AttributionEventStore;
+  readonly readPayload: (record: ReadableJournalRecord) => Record<string, unknown>;
+}): void {
+  for (const entry of input.plannedRecords) {
+    if (entry.record.schema !== "write-journal/v2" || entry.record.kind !== "code_doc_reconcile") continue;
+    const eventPlan = planAttributionEventCommit(
+      input.rootDir,
+      input.rootInput,
+      entry.touchedPaths,
+      input.publicationVcs
+    );
+    const payload = input.readPayload(entry.record);
+    const targetPath = entry.touchedPaths[0];
+    const bodyIsAlreadyApplied = typeof payload.body === "string"
+      && typeof targetPath === "string"
+      && durableFileExists(targetPath)
+      && new TextDecoder().decode(readFileBytes(targetPath)) === payload.body;
+    if (!bodyIsAlreadyApplied) continue;
+    const event = createAttributionEvent(entry.record);
+    const alreadyPublished = input.attributionEventStore.confirms(event, {
+      rootDir: input.rootDir,
+      rootInput: input.rootInput,
+      commitSha: eventPlan.preCommitSha,
+      versionControlSystem: input.publicationVcs
+    });
+    if (alreadyPublished) continue;
+    throw new WriteRejectedError(
+      "code_doc_reconcile produced no authored change; update closeout/review or anchors before retrying --force",
+      entry.record.entityId,
+      {
+        code: "code_doc_reconcile_noop",
+        retryable: false
+      }
+    );
+  }
+}

--- a/packages/kernel/src/write-coordination/journal/coordinator.ts
+++ b/packages/kernel/src/write-coordination/journal/coordinator.ts
@@ -61,6 +61,8 @@ import {
 } from "./exact-journal-flush.ts";
 import { maybeAutoMaterialize } from "./publication/materialization.ts";
 import { finalizeJournalPostCommit } from "./post-commit.ts";
+import { assertCodeDocReplacementHasAuthoredChange } from "./code-doc-reconcile-noop.ts";
+import { isLocalProjectionPath } from "./projection-path.ts";
 import type { JournalPostCommitPhase, JournalProjectionFingerprintPhase, JournaledWriteCoordinatorOptions, JournalRecoveryOptions, LockConflictRetryOptions, OperationalActor, OperationalJournaledWriteCoordinatorOptions, ReadableJournalRecord, WriteWatermark } from "./types.ts";
 export type {
   JournalActor,
@@ -363,6 +365,14 @@ function flushRecords(
   );
 
   assertCommitPlanAddable(rootDir, plannedRecords.flatMap((record) => record.touchedPaths), rootInput, { versionControlSystem: publicationVcs });
+  assertCodeDocReplacementHasAuthoredChange({
+    rootDir,
+    rootInput,
+    plannedRecords,
+    publicationVcs,
+    attributionEventStore,
+    readPayload: (record) => readVerifiedPayload(rootDir, record)
+  });
   onProjectionFingerprintPhase?.("capture-start");
   const previousProjectionSourceFingerprint = records.length > 0 && projectionRelevant
     ? captureTrustedAuthoredProjectionFingerprint(rootInput, publicationVcs, undefined, {
@@ -392,12 +402,12 @@ function flushRecords(
   const mutationWillCommit = eventCommitPlan.willCommit;
   const eventWrites = mutationWillCommit
     ? attributedRecords
-    .map((record) => attributionEventStore.ensure(record, {
-      rootDir,
-      rootInput,
-      commitSha: eventCommitPlan.preCommitSha,
-      versionControlSystem: eventVcs
-    }))
+      .map((record) => attributionEventStore.ensure(record, {
+        rootDir,
+        rootInput,
+        commitSha: eventCommitPlan.preCommitSha,
+        versionControlSystem: eventVcs
+      }))
     : [];
   const eventPaths = eventWrites.flatMap((write) => write.touchedPaths);
   const mutationCommitSha = commitTouchedPaths(
@@ -524,12 +534,6 @@ function readVerifiedPayload(rootDir: string, record: ReadableJournalRecord): Re
     rejectWrite(`payload hash mismatch for op ${record.opId}`, record.entityId);
   }
   return payload;
-}
-
-function isLocalProjectionPath(rootPath: string, filePath: string): boolean {
-  const relativePath = path.relative(rootPath, filePath);
-  return relativePath.length === 0
-    || (relativePath !== ".." && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath));
 }
 
 function validateOp(rootInput: HarnessLayoutInput, op: WriteOp): void {

--- a/packages/kernel/src/write-coordination/journal/projection-path.ts
+++ b/packages/kernel/src/write-coordination/journal/projection-path.ts
@@ -1,0 +1,7 @@
+import path from "node:path";
+
+export function isLocalProjectionPath(rootPath: string, filePath: string): boolean {
+  const relativePath = path.relative(rootPath, filePath);
+  return relativePath.length === 0
+    || (relativePath !== ".." && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath));
+}

--- a/packages/kernel/test/store/code-doc-git-evidence.test.ts
+++ b/packages/kernel/test/store/code-doc-git-evidence.test.ts
@@ -60,6 +60,36 @@ test("code-doc reconciliation is independent of the Execution and Review documen
   });
 });
 
+test("an identical code-doc replacement fails closed before publication", () => {
+  withTempStore((rootDir) => {
+    const fixture = initializeNestedGitFixture(rootDir);
+    const coordinator = makeJournaledWriteCoordinator({
+      attribution: testWriteAttribution(),
+      rootDir,
+      commitAuthor: { name: "Harness Test", email: "harness-test@example.invalid" }
+    });
+    const first = codeDocOp("code-doc-first", [{ kind: "commit", sha: fixture.authoredSha }]);
+    const second = codeDocOp("code-doc-identical-replace", [{ kind: "commit", sha: fixture.authoredSha }]);
+
+    Effect.runSync(coordinator.enqueue(first));
+    const firstReport = Effect.runSync(coordinator.flush("manual"));
+    const firstHead = runHermeticGit(fixture.authoredRoot, "rev-parse", "HEAD");
+
+    Effect.runSync(coordinator.enqueue(second));
+    let secondFailure: unknown;
+    try {
+      Effect.runSync(coordinator.flush("manual"));
+    } catch (error) {
+      secondFailure = error;
+    }
+    const secondHead = runHermeticGit(fixture.authoredRoot, "rev-parse", "HEAD");
+
+    assert.equal(firstReport.committed, true);
+    assert.match(JSON.stringify(secondFailure), /produced no authored change/u);
+    assert.equal(secondHead, firstHead, "a rejected no-op must not advance publication HEAD");
+  });
+});
+
 function codeDocOp(opId: string, anchors: ReadonlyArray<Record<string, string>>) {
   return {
     opId,


### PR DESCRIPTION
# English

## Summary

Two latent production write-path defects, both visible daily since 2026-08-01 and neither a new-deployment regression:

1. **`code-doc reconcile --force` died deterministically with `EXECUTION_OUTCOME_UNKNOWN`.** The root cause is *not* an outer CLI timeout killing the child. The replace shape re-submits an identical rendered code-doc body: the flush plan produces no authored mutation and no attribution event, so the canonical proof correctly sees `HEAD == expectedPreviousHead` with no legitimate mutation publication and reports `AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR`. The authority service then treated that **deterministic no-op** as a generic flush anomaly and settled it `INDETERMINATE`, leaving the child with nothing to return but `EXECUTION_OUTCOME_UNKNOWN`. This blocked closeout for any task needing a code-doc re-anchor (it actually blocked the enrollment task's `complete` in the early hours of 2026-08-04).
2. **Deferred historical recovery failed hundreds of times per day** with `AUTHORITY_CANONICAL_PUBLICATION_NOT_FOUND` (258/66/221 on 08-01/02/03, plus a fresh burst on every daemon restart). These are **decidable already-unpublished corpses**, not a transient the lookup should retry forever — the recovery gate simply never listed this code in its permanent-rejection set.

## What Changed

- **No-op guard before commit** (`journal/code-doc-reconcile-noop.ts`, `journal/coordinator.ts`): if the target `code_doc_reconcile` bytes are already identical and the attribution event is not confirmed-published, throw a stable `code_doc_reconcile_noop` with `retryable:false`. No authored file written, no HEAD advance, no fabricated event-only publication. Exact replays already confirmed by `attributionEventStore.confirms` are still allowed, preserving op-id idempotency without weakening the "a real authored mutation must exist" publication proof.
- **Honest authority result** (`authority/code-doc-reconcile-rejection.ts`, `authority/service.ts`): the service recursively unwraps nested `FiberFailure`/`JournalUnavailable` JSON and settles **only** that stable code as `REJECTED`. Every other flush error still settles `INDETERMINATE` — an unknown failure is never re-labelled a rejection.
- **Permanent rejection for known corpses** (`repo-write-authority-recovery-gate.ts`, one line): `AUTHORITY_CANONICAL_PUBLICATION_NOT_FOUND` joins the existing durable permanent-rejection set, reusing the existing sidecar and history filter. Non-unique publications, semantic digest mismatches, and generation/fence mismatches **still** stay outcome-unknown and still demand adjudication.

**`--force` is not disabled.** With a genuinely changed body (closeout edit + new PR anchor) the first force still commits; only the byte-identical repeat is now explicitly rejected instead of silently unknown.

## Task And Scope

- Task `task_01KZ4ZYAKB8ZM9W6CVMRVQEQRA`, report `artifacts/implementation-report.md`. 10 files, +225/−18 on base `8da9fded` (no rebase needed).
- Untouched: canonical publication proof, authority validation, the 30s deadline, intent prepublish witness, orphan `PROCEEDING` semantics, lock ordering.

## Version Impact

- No public CLI surface change; no persisted-schema change. A previously-unknown outcome now surfaces as an explicit non-retryable rejection with actionable text.

## Governance Declaration

- Protected surface touched: no. Not a governance task; no break-glass.

## Verification

- Three candidate fixes were **falsified before implementing**, which is why the diff is this small:
  - "outer CLI timeout kills the child" — refuted by the parent-side proof showing `head == expectedPreviousHead` with the child exiting after flush/materializer.
  - "relax the publication proof's legal subject shape" — the failing sample carries `mergeTreeMatchesSession=true` but `mergeMessageMatchesSession=false`, `legacySubjectShape=false`, `semanticSubjectShape=false`; a synthetic probe confirmed this path was not viable and it was **not** taken.
  - "append an attribution event only" — rejected by `publication-evidence.ts` with `AUTHORITY_PUBLICATION_DECLARED_PATH_MISSING:tasks/<taskId>`.
- `node --test packages/kernel/test/store/code-doc-git-evidence.test.ts`: 4 passed / 0 failed.
- `node --test packages/daemon/test/repo-write-authority-recovery-gate.test.ts`: 8 passed / 0 failed.
- Production canonical ingress targeted test: 1 passed / 0 failed (197,680ms).
- `npm run check:local`: green — affected fast 719/719, affected contract 560 passed (1 skipped), static gates green.
- `node tools/run-node-tests.mjs --tier integration`: 1,476 tests, 1,472 passed, 0 failed, 4 skipped, exit 0.
- Full production canonical fixture: closeout change + new PR anchor → first force `COMMITTED`; identical second force explicitly rejected with no unknown in the receipt; historical list empty both immediately and after restart.

## Review Evidence

- CEO semantic review focused on the two ways this fix could have been wrong, and neither happened: (a) `--force` was not disabled to make the crash go away — a real body change still commits, only the true no-op is refused; (b) the permanent-rejection set was not widened into a catch-all — exactly one precise code was added, anchored on production evidence that the sampled records are `REJECTED` with `commitSha=null` and no terminal sidecar, while every ambiguous class stays unknown-and-visible.
- Concurrency/failure-path seven questions answered in the report, including the crash window between no-op detection and apply.

## Residual Risk

- **Production effect is unverified at PR time** and the report says so explicitly: the noise counts are *not* claimed cleared. Post-deploy checks are (1) a repeat force returns `REJECTED` rather than child-unknown, and (2) the `NOT_FOUND` repeat count on restart and the next daily sweep drops to zero.
- Re-anchoring the *same* rendered code-doc now requires changing an input (closeout/review/anchor) first. That is a deliberate behavior change: an explicit non-retryable error replaces a silent unknown.
- Legacy `NON_LINEAR`, non-unique publication, and digest mismatch remain conservatively handled; changing their legal publication shape needs its own adjudication and was kept out of scope.

## References

- Task `task_01KZ4ZYAKB8ZM9W6CVMRVQEQRA`; parent intake `task_01KZ3XES4V69C4WXBR7JPVNSG9`; sibling waves PR #1207 / #1208; write-cost line PR #1220.

---

# 中文

## 概要

两条生产写路径的存量潜伏缺陷，自 2026-08-01 起每日可见，均非新部署回归：

1. **`code-doc reconcile --force` 确定性死于 `EXECUTION_OUTCOME_UNKNOWN`。** 根因**不是**外层 CLI 超时杀 child。replace 形状把完全相同的 rendered code-doc body 再提交一次：flush 计划不产生 authored mutation、也不产生 attribution event，因此 canonical proof 正确地看到 `HEAD == expectedPreviousHead` 且没有合法的 mutation publication，报 `AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR`。而 authority service 把这个**确定性 no-op** 当作一般 flush 异常结算成 `INDETERMINATE`，child 于是只能返回 `EXECUTION_OUTCOME_UNKNOWN`。它会阻塞任何需要重锚 code-doc 的任务收口（2026-08-04 凌晨实际阻塞过 enrollment 任务的 complete）。
2. **deferred historical recovery 每日失败成百次**，报 `AUTHORITY_CANONICAL_PUBLICATION_NOT_FOUND`（08-01/02/03 分别 258/66/221 条，且每次 daemon 重启还会集中爆发一轮）。这些是**可判定的历史未发布尸体**，不是查找逻辑该无限重试的暂态——recovery gate 只是从没把这个 code 列进永久拒绝集合。

## 改动内容

- **commit 前的 no-op guard**（`journal/code-doc-reconcile-noop.ts`、`journal/coordinator.ts`）：若 `code_doc_reconcile` 的目标 bytes 已相同且 attribution event 未确认发布，抛稳定的 `code_doc_reconcile_noop`、`retryable:false`。不写 authored 文件、不推进 HEAD、不伪造 event-only publication。已由 `attributionEventStore.confirms` 确认的精确 replay 仍然放行，从而保留 op-id 幂等性，同时不放宽「必须存在真实 authored mutation」的 publication 证明。
- **authority 结果诚实**（`authority/code-doc-reconcile-rejection.ts`、`authority/service.ts`）：service 递归解包嵌套的 `FiberFailure`/`JournalUnavailable` JSON，**只**把上述稳定 code 结算为 `REJECTED`。其余 flush 错误继续结算 `INDETERMINATE`——未知失败绝不会被改标成拒绝。
- **已知尸体永久拒绝**（`repo-write-authority-recovery-gate.ts`，一行）：把 `AUTHORITY_CANONICAL_PUBLICATION_NOT_FOUND` 加入既有的 durable 永久拒绝集合，复用既有 sidecar 与历史过滤。非唯一 publication、语义 digest 不符、generation/fence 不匹配**仍然**保持 outcome-unknown，仍然要求后续裁决。

**`--force` 没有被禁用。** body 真的变化时（改 closeout + 新 PR anchor），首次 force 照常提交；只有字节完全相同的重复才从「静默 unknown」变成「显式拒绝」。

## 任务与范围

- 任务 `task_01KZ4ZYAKB8ZM9W6CVMRVQEQRA`，报告 `artifacts/implementation-report.md`。基于 `8da9fded`，10 文件、+225/−18（无需 rebase）。
- 未触碰：canonical publication proof、authority 校验、30s deadline、intent prepublish witness、孤儿 `PROCEEDING` 语义、锁顺序。

## 版本影响

- 无公开 CLI 面变更；无持久化 schema 变更。原先的 unknown 结果现在以显式、不可重试的拒绝呈现，并带可行动的提示文本。

## 治理声明

- 未触碰 protected surface。非治理任务；无 break-glass。

## 验证

- 三个候选修法在动手前**被逐一证伪**，这也是 diff 这么小的原因：
  - 「外层 CLI 超时杀 child」——被父侧 proof 证伪：`head == expectedPreviousHead`，且 child 是在 flush/materializer 之后退出的。
  - 「放宽 publication proof 的合法 subject 形状」——失败样本 `mergeTreeMatchesSession=true` 而 `mergeMessageMatchesSession=false`、`legacySubjectShape=false`、`semanticSubjectShape=false`；合成探针确认此路不通，本轮**未**采用。
  - 「只追加 attribution event」——被 `publication-evidence.ts` 以 `AUTHORITY_PUBLICATION_DECLARED_PATH_MISSING:tasks/<taskId>` 拒绝。
- `node --test packages/kernel/test/store/code-doc-git-evidence.test.ts`：4 passed / 0 failed。
- `node --test packages/daemon/test/repo-write-authority-recovery-gate.test.ts`：8 passed / 0 failed。
- production canonical ingress 定向测试：1 passed / 0 failed（197,680ms）。
- `npm run check:local`：通过——affected fast 719/719、affected contract 560 passed（1 skipped）、静态 gates 全绿。
- `node tools/run-node-tests.mjs --tier integration`：1,476 tests，1,472 passed，0 failed，4 skipped，exit 0。
- 完整生产 canonical fixture：改 closeout + 新 PR anchor 后首次 force `COMMITTED`；同参数第二次 force 显式拒绝且 receipt 不含 unknown；historical list 在当场与重启后均为空。

## 审查证据

- CEO 语义验收专门针对这个修复可能错的两种方式，两种都没发生：(a) 没有为了让崩溃消失而**禁用 `--force`**——body 真变化仍然提交，只拒绝真正的 no-op；(b) 没有把永久拒绝集合放宽成 catch-all——只加了一个精确 code，且有生产证据支撑（抽样记录均为 `REJECTED`、`commitSha=null`、无 terminal sidecar），一切歧义类别仍然保持 unknown 且可见。
- 并发/失败路径七问已在报告作答，含 no-op 判定与 apply 之间的崩溃窗口。

## 残余风险

- **发 PR 时生产效果尚未验证**，报告对此明确说明：噪声计数**没有**被宣称清零。部署后的检查项是：(1) 重复 force 返回 `REJECTED` 而非 child unknown；(2) 重启与下一次日扫的 `NOT_FOUND` 重复计数降为零。
- 重锚**同一份** rendered code-doc 现在必须先改动输入（closeout/review/anchor）。这是刻意的行为变更：用显式不可重试的错误替换了静默的未知结果。
- 旧的 `NON_LINEAR`、非唯一 publication、digest 不符仍保守处理；若要改变其合法 publication 形状，需另行裁决，本任务刻意不扩大范围。

## 关联材料

- 任务 `task_01KZ4ZYAKB8ZM9W6CVMRVQEQRA`；父 intake `task_01KZ3XES4V69C4WXBR7JPVNSG9`；兄弟 wave PR #1207 / #1208；写路径线 PR #1220。

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body complete / 双语正文完整
- [x] Non-governance task did not modify CI/gate authority surfaces / 非治理任务未修改 CI/gate 权威面
- [x] Verification is real command output, not assertion / 验证为真实命令输出而非断言
- [x] Residual risk honestly stated / 残余风险如实陈述
