### PR TITLE
fix(daemon): close build-identity admission — required reader + registry-declared exemptions (PLT-Steady-Transport anchor 2)

### DIFF
--- a/packages/daemon/src/lifecycle/run-daemon-serve.ts
+++ b/packages/daemon/src/lifecycle/run-daemon-serve.ts
@@ -88,7 +88,6 @@ export async function runDaemonServe<
 ): Promise<void> {
   const { rootDir, layoutOverrides, userRoot, endpoint } = input;
   const { serveRepos, authorityManifest, defaultRepoId, lifecycleRepo } = resolveDaemonServeConfiguration(input);
-  const loadedBuild = calculateDaemonArtifactIdentity(input.entrypoint);
   const startedAt = new Date().toISOString();
   const runtimePolicy = input.runtimePolicy ?? resolveDaemonRuntimePolicy();
   const productionChildCutover = authorityManifest !== undefined
@@ -119,6 +118,10 @@ export async function runDaemonServe<
     let terminalMessage: string | undefined;
     let failure: unknown;
     try {
+      // Endpoint ownership is already published, while connections remain
+      // deferred. Replacement control can therefore observe a live owner
+      // during this potentially expensive non-RPC startup scan.
+      const loadedBuild = calculateDaemonArtifactIdentity(input.entrypoint);
       const connections = { active: 0, total: 0 };
       const authorityLifecycle = hooks.authorityLifecycle ?? (
         authorityManifest && !productionChildCutover

--- a/packages/daemon/src/protocol/build-identity-admission.ts
+++ b/packages/daemon/src/protocol/build-identity-admission.ts
@@ -1,27 +1,17 @@
 import type { JsonRpcMethodContract } from "./method-registry.ts";
 import { failureReceipt } from "./receipt-envelope.ts";
 
-const exemptAdminMethods: ReadonlySet<string> = new Set([
-  "admin.daemon.launch-spec",
-  "admin.daemon.restart",
-  "admin.daemon.refresh",
-  "admin.people.list",
-  "admin.rbac.roles.list"
-]);
-
 export function buildIdentityAdmissionFailure(
   contract: JsonRpcMethodContract,
-  readBuildIdentity: (() => {
+  readBuildIdentity: () => {
     readonly loadedIdentity: string;
     readonly installedIdentity: string;
-  }) | undefined
+  }
 ): ReturnType<typeof failureReceipt> | undefined {
-  if (!readBuildIdentity
-    || contract.commandClass === "repo-read"
-    || exemptAdminMethods.has(contract.method)) {
+  if (contract.buildIdentityAdmission === "exempt") {
     return undefined;
   }
-  let build: ReturnType<NonNullable<typeof readBuildIdentity>>;
+  let build: ReturnType<typeof readBuildIdentity>;
   try {
     build = readBuildIdentity();
   } catch (error) {

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -15,7 +15,7 @@ import {
 } from "@harness-anything/application";
 import type { RuntimeEventAppendInput } from "@harness-anything/application/runtime-event-ledger-service";
 import type { TerminalSessionService } from "@harness-anything/application/terminal-session-contract";
-import { commandClassForJsonRpcRequest, currentDaemonProtocolVersion, jsonRpcMethodContract, jsonRpcMethodContracts, type JsonRpcMethodContract } from "./method-registry.ts";
+import { buildIdentityAdmissionForCommandClass, commandClassForJsonRpcRequest, currentDaemonProtocolVersion, jsonRpcMethodContract, jsonRpcMethodContracts, type JsonRpcMethodContract } from "./method-registry.ts";
 import { toJsonValue } from "./json-value.ts";
 import { failureReceipt, serviceResultReceipt, successReceipt } from "./receipt-envelope.ts";
 import { isJsonObject, type JsonObject, type JsonRpcId, type JsonRpcRequest, type JsonRpcResponse } from "./json-rpc-types.ts";
@@ -115,7 +115,7 @@ export interface JsonRpcServerOptions extends ProjectionNotificationOptions {
   readonly daemonId: string;
   readonly repos: ReadonlyArray<DaemonRepoNamespace>;
   readonly services: DaemonServiceHost;
-  readonly readBuildIdentity?: () => {
+  readonly readBuildIdentity: () => {
     readonly loadedIdentity: string;
     readonly installedIdentity: string;
   };
@@ -451,9 +451,13 @@ async function callTaskHolderMethod(
 }
 
 function withEffectiveCommandClass(contract: JsonRpcMethodContract, params: JsonObject): JsonRpcMethodContract {
+  if (contract.commandClassDerivation !== "repo-command-run-action") return contract;
   const commandClass = commandClassForJsonRpcRequest(contract, params);
-  if (commandClass === contract.commandClass) return contract;
-  return commandClass ? { ...contract, commandClass } : { ...contract };
+  return {
+    ...contract,
+    buildIdentityAdmission: buildIdentityAdmissionForCommandClass(commandClass),
+    ...(commandClass ? { commandClass } : {})
+  };
 }
 
 async function handleAdminMethod(

--- a/packages/daemon/src/protocol/method-registry.ts
+++ b/packages/daemon/src/protocol/method-registry.ts
@@ -6,6 +6,7 @@ export const currentDaemonProtocolVersion = 1 as const;
 
 export type JsonRpcMethodMode = "active" | "notification" | "reserved";
 export type { DaemonCommandClass };
+export type BuildIdentityAdmission = "required" | "exempt";
 
 export interface JsonRpcMethodContract {
   readonly method: string;
@@ -19,6 +20,7 @@ export interface JsonRpcMethodContract {
   readonly routeId?: ApiRouteContract["id"];
   readonly auth: ApiRouteContract["auth"];
   readonly requiresRepo: boolean;
+  readonly buildIdentityAdmission: BuildIdentityAdmission;
   readonly commandClass?: DaemonCommandClass;
   readonly commandClassDerivation?: "repo-command-run-action";
   readonly leaseRequired?: boolean;
@@ -33,7 +35,8 @@ const protocolMethodContracts = [
     outputSchemaId: "daemon.hello-result/v1",
     errorSchemaId: "daemon.protocol-error/v1",
     auth: "none",
-    requiresRepo: false
+    requiresRepo: false,
+    buildIdentityAdmission: "exempt"
   }
 ] as const satisfies ReadonlyArray<JsonRpcMethodContract>;
 
@@ -47,6 +50,7 @@ const cliCommandContracts = [
     errorSchemaId: "daemon.protocol-error/v1",
     auth: "local-session-token",
     requiresRepo: true,
+    buildIdentityAdmission: "required",
     commandClassDerivation: "repo-command-run-action"
   }
 ] as const satisfies ReadonlyArray<JsonRpcMethodContract>;
@@ -61,6 +65,7 @@ const docSyncContracts = [
     errorSchemaId: "daemon.protocol-error/v1",
     auth: "local-session-token",
     requiresRepo: true,
+    buildIdentityAdmission: "required",
     commandClass: "repo-write"
   }
 ] as const satisfies ReadonlyArray<JsonRpcMethodContract>;
@@ -75,6 +80,7 @@ const taskHolderContracts = [
     errorSchemaId: "daemon.protocol-error/v1",
     auth: "local-session-token",
     requiresRepo: true,
+    buildIdentityAdmission: "required",
     commandClass: "repo-write"
   },
   {
@@ -86,6 +92,7 @@ const taskHolderContracts = [
     errorSchemaId: "daemon.protocol-error/v1",
     auth: "local-session-token",
     requiresRepo: true,
+    buildIdentityAdmission: "exempt",
     commandClass: "repo-read"
   },
   {
@@ -97,6 +104,7 @@ const taskHolderContracts = [
     errorSchemaId: "daemon.protocol-error/v1",
     auth: "local-session-token",
     requiresRepo: true,
+    buildIdentityAdmission: "required",
     commandClass: "repo-write"
   }
 ] as const satisfies ReadonlyArray<JsonRpcMethodContract>;
@@ -111,6 +119,7 @@ const notificationContracts = [
     errorSchemaId: "daemon.protocol-error/v1",
     auth: "local-session-token",
     requiresRepo: true,
+    buildIdentityAdmission: "exempt",
     commandClass: "repo-read"
   },
   {
@@ -122,6 +131,7 @@ const notificationContracts = [
     errorSchemaId: "daemon.protocol-error/v1",
     auth: "local-session-token",
     requiresRepo: true,
+    buildIdentityAdmission: "exempt",
     commandClass: "repo-read"
   }
 ] as const satisfies ReadonlyArray<JsonRpcMethodContract>;
@@ -136,6 +146,7 @@ const adminReservedContracts = [
     errorSchemaId: "daemon.protocol-error/v1",
     auth: "local-session-token",
     requiresRepo: false,
+    buildIdentityAdmission: "exempt",
     commandClass: "admin"
   },
   {
@@ -147,6 +158,7 @@ const adminReservedContracts = [
     errorSchemaId: "daemon.control-error/v1",
     auth: "local-session-token",
     requiresRepo: false,
+    buildIdentityAdmission: "exempt",
     commandClass: "admin"
   },
   {
@@ -158,6 +170,7 @@ const adminReservedContracts = [
     errorSchemaId: "daemon.control-error/v1",
     auth: "local-session-token",
     requiresRepo: false,
+    buildIdentityAdmission: "exempt",
     commandClass: "admin"
   },
   {
@@ -169,6 +182,7 @@ const adminReservedContracts = [
     errorSchemaId: "daemon.protocol-error/v1",
     auth: "local-session-token",
     requiresRepo: false,
+    buildIdentityAdmission: "exempt",
     commandClass: "admin"
   },
   {
@@ -180,6 +194,7 @@ const adminReservedContracts = [
     errorSchemaId: "daemon.protocol-error/v1",
     auth: "local-session-token",
     requiresRepo: false,
+    buildIdentityAdmission: "exempt",
     commandClass: "admin"
   }
 ] as const satisfies ReadonlyArray<JsonRpcMethodContract>;
@@ -205,6 +220,7 @@ export function deriveJsonRpcServiceMethodContracts(
       routeId: contract.id,
       auth: contract.auth,
       requiresRepo: true,
+      buildIdentityAdmission: buildIdentityAdmissionForCommandClass(commandClassForApiRoute(contract)),
       commandClass: commandClassForApiRoute(contract),
       ...(contract.leaseRequired === true ? { leaseRequired: true } : {})
     };
@@ -216,6 +232,12 @@ export function commandClassForApiRoute(contract: ApiRouteContract): DaemonComma
   if (contract.commandClass) return contract.commandClass;
   if (contract.method === "GET" || contract.method === "WS") return "repo-read";
   return "repo-write";
+}
+
+export function buildIdentityAdmissionForCommandClass(
+  commandClass: DaemonCommandClass | undefined
+): BuildIdentityAdmission {
+  return commandClass === "repo-read" ? "exempt" : "required";
 }
 
 const repoReadCliActionKinds = new Set<string>([

--- a/packages/daemon/test/accepted-connection-evidence.test.ts
+++ b/packages/daemon/test/accepted-connection-evidence.test.ts
@@ -20,6 +20,7 @@ import {
   type DaemonTransportConnection,
   type JsonObject
 } from "../src/index.ts";
+import { matchingBuildIdentity } from "./json-rpc-protocol-fixtures.ts";
 
 test("connection-getpeereid-valid observes the same accepted Darwin socket", {
   skip: process.platform !== "darwin" ? "Darwin getpeereid fixture" : false
@@ -542,6 +543,7 @@ function authorityProtocolServer(
   return createJsonRpcProtocolServer({
     daemonId: "authority-context-test",
     repos: [{ repoId: "canonical", canonicalRoot: "/tmp/canonical" }],
+    readBuildIdentity: matchingBuildIdentity,
     acceptedConnection,
     authorityPeerPolicy: ({ actor, peerCredential }) =>
       actor.personId === "person_local"

--- a/packages/daemon/test/daemon-build-drift-admission.test.ts
+++ b/packages/daemon/test/daemon-build-drift-admission.test.ts
@@ -10,7 +10,11 @@ import {
   rosterIdentityOptions,
   sampleRoster
 } from "./json-rpc-protocol-fixtures.ts";
-import type { JsonRpcResponse } from "../src/index.ts";
+import {
+  jsonRpcMethodContracts,
+  jsonRpcServiceMethodContracts,
+  type JsonRpcResponse
+} from "../src/index.ts";
 
 interface DriftReceipt {
   readonly ok: boolean;
@@ -24,6 +28,31 @@ function driftReceipt(response: JsonRpcResponse | ReadonlyArray<JsonRpcResponse>
   assert.ok(response && !Array.isArray(response) && "result" in response);
   return response.result as unknown as DriftReceipt;
 }
+
+test("build-identity admission is declared by the method registry", () => {
+  const adminMethods = jsonRpcMethodContracts
+    .filter((contract) => contract.namespace === "admin")
+    .map((contract) => contract.method);
+  assert.deepEqual(adminMethods, [
+    "admin.daemon.launch-spec",
+    "admin.daemon.restart",
+    "admin.daemon.refresh",
+    "admin.people.list",
+    "admin.rbac.roles.list"
+  ]);
+  for (const contract of jsonRpcMethodContracts) {
+    assert.equal(contract.buildIdentityAdmission === "exempt" || contract.buildIdentityAdmission === "required", true, contract.method);
+    if (contract.commandClass === "repo-read") {
+      assert.equal(contract.buildIdentityAdmission, "exempt", contract.method);
+    }
+    if (contract.commandClass === "repo-write" || contract.commandClass === "arbiter") {
+      assert.equal(contract.buildIdentityAdmission, "required", contract.method);
+    }
+  }
+  for (const contract of jsonRpcServiceMethodContracts) {
+    assert.equal(contract.buildIdentityAdmission, contract.commandClass === "repo-read" ? "exempt" : "required", contract.method);
+  }
+});
 
 test("artifact drift rejects writes before mixed-version service dispatch and keeps reads available", async () => {
   const loadedIdentity = `sha256:${"a".repeat(64)}`;
@@ -194,6 +223,9 @@ test("explicit read and lifecycle admin methods remain available during artifact
     services: {
       LocalControllerService: emptyLocalController(),
       TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" }),
+      DaemonLaunchSpecService: {
+        getLaunchSpec: () => ({ schema: "daemon-launch-spec/v3" })
+      },
       DaemonControlService: {
         requestControl: (kind) => ({
           ok: true,
@@ -218,6 +250,14 @@ test("explicit read and lifecycle admin methods remain available during artifact
   });
   await server.handle(readFixture("hello-compatible.json"));
 
+  const launchSpec = driftReceipt(await server.handle({
+    jsonrpc: "2.0",
+    id: "launch-spec-during-drift",
+    method: "admin.daemon.launch-spec",
+    params: {}
+  }));
+  assert.equal(launchSpec.ok, true);
+
   const response = await server.handle({
     jsonrpc: "2.0",
     id: "admin-during-drift",
@@ -235,5 +275,21 @@ test("explicit read and lifecycle admin methods remain available during artifact
     params: { payload: { reason: "artifact drift", drainTimeoutMs: 5_000 } }
   }));
   assert.equal(restart.ok, true);
+
+  const refresh = driftReceipt(await server.handle({
+    jsonrpc: "2.0",
+    id: "refresh-during-drift",
+    method: "admin.daemon.refresh",
+    params: { payload: { reason: "artifact drift", drainTimeoutMs: 5_000, trigger: "explicit" } }
+  }));
+  assert.equal(refresh.ok, true);
+
+  const roles = driftReceipt(await server.handle({
+    jsonrpc: "2.0",
+    id: "roles-during-drift",
+    method: "admin.rbac.roles.list",
+    params: {}
+  }));
+  assert.equal(roles.ok, true);
   assert.equal(identityReads, 0);
 });

--- a/packages/daemon/test/doc-sync-protocol.test.ts
+++ b/packages/daemon/test/doc-sync-protocol.test.ts
@@ -11,6 +11,7 @@ import {
   type IdentityProvider,
   type JsonRpcResponse
 } from "../src/index.ts";
+import { matchingBuildIdentity } from "./json-rpc-protocol-fixtures.ts";
 
 test("daemon method registry exposes repo.doc.sync.submit as an active repo write", () => {
   const contract = jsonRpcMethodContracts.find((entry) => entry.method === "repo.doc.sync.submit");
@@ -38,6 +39,7 @@ test("repo.doc.sync.submit appends the authenticated principal and executor axes
   const server = createJsonRpcProtocolServer({
     daemonId: "daemon-test",
     repos: [{ repoId: "canonical", canonicalRoot: "/tmp/canonical" }],
+    readBuildIdentity: matchingBuildIdentity,
     authContext: { transportKind: "unix-socket" },
     identityProvider,
     personRegistry: personRegistryFromDocument([

--- a/packages/daemon/test/identity-provider-contract.test.ts
+++ b/packages/daemon/test/identity-provider-contract.test.ts
@@ -22,6 +22,7 @@ import {
   type IdentityProvider,
   type JsonRpcResponse
 } from "../src/index.ts";
+import { matchingBuildIdentity } from "./json-rpc-protocol-fixtures.ts";
 
 test("daemon core asks identity providers only who the credential belongs to and whether the person may act", async () => {
   const calls: string[] = [];
@@ -474,6 +475,7 @@ function makeServer(overrides: Partial<Parameters<typeof createJsonRpcProtocolSe
   return createJsonRpcProtocolServer({
     daemonId: "identity-contract-test",
     repos: [{ repoId: "canonical", canonicalRoot: "/tmp/canonical" }],
+    readBuildIdentity: matchingBuildIdentity,
     services: {
       LocalControllerService: emptyLocalController(),
       TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" })

--- a/packages/daemon/test/json-rpc-protocol-fixtures.ts
+++ b/packages/daemon/test/json-rpc-protocol-fixtures.ts
@@ -22,12 +22,21 @@ export function makeServer(overrides: Partial<Parameters<typeof createJsonRpcPro
   return createJsonRpcProtocolServer({
     daemonId: "daemon-test",
     repos: [{ repoId: "canonical", canonicalRoot: "/tmp/canonical" }],
+    readBuildIdentity: matchingBuildIdentity,
     services: {
       LocalControllerService: emptyLocalController(),
       TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" })
     },
     ...overrides
   });
+}
+
+export function matchingBuildIdentity(): {
+  readonly loadedIdentity: string;
+  readonly installedIdentity: string;
+} {
+  const identity = `sha256:${"0".repeat(64)}`;
+  return { loadedIdentity: identity, installedIdentity: identity };
 }
 
 export function emptyLocalController(): LocalControllerService {

--- a/packages/daemon/test/request-performance-telemetry.test.ts
+++ b/packages/daemon/test/request-performance-telemetry.test.ts
@@ -27,6 +27,7 @@ import { serveJsonRpcStream } from "../src/transport/json-rpc-stream.ts";
 import { createJsonRpcProtocolServer } from "../src/protocol/json-rpc-server.ts";
 import { currentDaemonProtocolVersion } from "../src/protocol/method-registry.ts";
 import type { JsonRpcRequest, JsonRpcResponse } from "../src/protocol/json-rpc-types.ts";
+import { matchingBuildIdentity } from "./json-rpc-protocol-fixtures.ts";
 
 test("request performance trace is deterministic, bounded, and terminal exactly once", async () => {
   let now = 102;
@@ -434,6 +435,7 @@ test("production protocol sink stores one redacted bounded performance entry aft
     createProtocolServer: () => createJsonRpcProtocolServer({
       daemonId: "daemon-performance-test",
       repos: [repo],
+      readBuildIdentity: matchingBuildIdentity,
       services: {
         LocalControllerService: {} as never,
         TerminalSessionService: {} as never,

--- a/packages/daemon/test/task-holder-rpc.test.ts
+++ b/packages/daemon/test/task-holder-rpc.test.ts
@@ -17,6 +17,7 @@ import {
   type JsonRpcResponse,
   type PeopleRoster
 } from "../src/index.ts";
+import { matchingBuildIdentity } from "./json-rpc-protocol-fixtures.ts";
 import { leaseEnforcementEnabled } from "../../cli/src/commands/settings.ts";
 
 test("task holder RPC claims, reports collisions with holder and expiry, and releases", async () => {
@@ -345,6 +346,7 @@ function createActorServer(
   return createJsonRpcProtocolServer({
     daemonId: "daemon-task-holder-test",
     repos: [{ repoId: "canonical", canonicalRoot: rootDir }],
+    readBuildIdentity: matchingBuildIdentity,
     personRegistry,
     identityAdminSnapshot: makePeopleRosterIdentityAdminSnapshot(roster, personRegistry),
     identityProvider: makeTransportDerivedIdentityProvider(roster, { sshExecIssuer: "host:team-host" }),

--- a/packages/daemon/test/task-return-to-planned-rpc.integration.test.ts
+++ b/packages/daemon/test/task-return-to-planned-rpc.integration.test.ts
@@ -25,6 +25,7 @@ import {
   type JsonRpcRequest,
   type JsonRpcResponse
 } from "../src/index.ts";
+import { matchingBuildIdentity } from "./json-rpc-protocol-fixtures.ts";
 
 const taskId = "task_01KX19GEKWMEJNGSMRT6JJH6HY";
 const executionId = "exe_01KX7H00000000000000000001";
@@ -80,6 +81,7 @@ test("daemon status RPC rejects residual return to planned, guards blocked owner
     const server = createJsonRpcProtocolServer({
       daemonId: "daemon-return-planned-test",
       repos: [{ repoId: "canonical", canonicalRoot: rootDir }],
+      readBuildIdentity: matchingBuildIdentity,
       personRegistry,
       identityAdminSnapshot: makePeopleRosterIdentityAdminSnapshot(roster, personRegistry),
       identityProvider: makeTransportDerivedIdentityProvider(roster, { sshExecIssuer: "host:team-host" }),

--- a/packages/daemon/test/transport-integration.test.ts
+++ b/packages/daemon/test/transport-integration.test.ts
@@ -38,6 +38,7 @@ import {
   type JsonRpcResponse,
   type PeopleRoster
 } from "../src/index.ts";
+import { matchingBuildIdentity } from "./json-rpc-protocol-fixtures.ts";
 
 test("unix socket transport uses single-user path and permissions on POSIX", async (t) => {
   if (process.platform === "win32") return;
@@ -554,6 +555,7 @@ function makeProtocolServerFactory(calls: string[] = []): (authContext: DaemonAu
   return (authContext) => createJsonRpcProtocolServer({
     daemonId: "daemon-test",
     repos: [{ repoId: "canonical", canonicalRoot: "/tmp/canonical" }],
+    readBuildIdentity: matchingBuildIdentity,
     authContext,
     personRegistry,
     identityProvider: makeTransportDerivedIdentityProvider(roster, { sshExecIssuer: "host:team-host" }),


### PR DESCRIPTION
# English

## Summary

PLT-Steady-Transport structural anchor #2. The daemon's build-drift guard — the thing that refuses writes when the running daemon code no longer matches the on-disk dist — was **fail-open by default**:

```ts
export function buildIdentityAdmissionFailure(contract, readBuildIdentity) {
  if (!readBuildIdentity                       // ← capability absent = silently allow
    || contract.commandClass === "repo-read"
    || exemptAdminMethods.has(contract.method)) {
    return undefined;
  }
```

Two structural problems, and this PR removes both — which is what the line's accounting policy (`dec_01KYYX1AXK7JMWFGCKX059W6PV`) demands of every ticket on this line:

- **An illegal state was expressible.** Whether the protection ran at all depended on whether a caller remembered to pass `readBuildIdentity`, and when it didn't, nothing said so. Note the author clearly knew this should fail closed: when the reader *throws*, the guard returns `daemon_build_identity_unavailable` and blocks the write. Only "never installed" was treated as "not needed".
- **A parallel authority existed.** `exemptAdminMethods` was a hand-maintained `Set` living apart from the method registry, so adding or renaming an admin method required someone to remember to sync a second source of truth.

## What Changed

- `JsonRpcServerOptions.readBuildIdentity` and `buildIdentityAdmissionFailure` now **require** the reader. The missing-capability state no longer typechecks.
- `JsonRpcMethodContract.buildIdentityAdmission` is now a **required field on every registry declaration**: static repo-read plus the five admin methods declare `exempt`; write/arbiter methods declare `required`. Derived service methods and the dynamic `repo.command.run` effective contract derive the same field inside the registry/server contract path.
- `build-identity-admission.ts` now consults only that contract field. Both the `!readBuildIdentity` branch and the `exemptAdminMethods` set are gone.
- Direct protocol-server test constructors now pass an explicit test witness, so the former missing-capability state fails the daemon typecheck rather than silently disabling the guard.

A new method declaration that omits its admission policy now fails typecheck instead of inheriting a default.

## Task And Scope

- Task `task_01KZ62MN2X9V9DP3KD235TTMGB` (line `task_01KZ1FMPC53362VFN0175WN0XY`, milestone root `task_01KZ1EVR7Y6PGTK6YQ0QAQ0DB8`). 11 files on base `ae2fc102`.
- Deliberately **not** in scope: anchor #1 (`RepoWriteCommandDto`, already partly eliminated — it is now a discriminated union and legacy names for `task-complete`/`task-submit` throw) and anchor #3 (parent/child dual phase state machines). Those are later slices on this line and would collide on file surface.
- Unchanged: `daemon_build_stale` / `daemon_build_identity_unavailable` error codes and their receipt shape — the post-merge deploy flow depends on them (rebuild dist → un-restarted daemon refuses writes → `ha daemon restart --authority-manifest`).

## Version Impact

- No public CLI surface change; no persisted-schema change. The daemon-internal method contract gains a required field.

## Governance Declaration

- Protected surface touched: no. Not a governance task; no break-glass.

## Verification

- **Honest scope of the defect**: the sole production protocol-server construction (`service-host.ts:236-240`) *already* supplied the witness, so no production path was actually unprotected. What existed was an **expressible** missing-protection state at the shared API — any direct `createJsonRpcProtocolServer` caller could omit the optional field. That expressible state is what this PR deletes; this is not a claim that production was exposed.
- `npm run typecheck`: clean.
- `node --test packages/daemon/test/daemon-build-drift-admission.test.ts packages/daemon/test/json-rpc-protocol.test.ts`: 29 tests, 29 pass, 0 fail.
- `node tools/run-node-tests.mjs --prefix packages/daemon/test/`: 599 tests, 594 pass, 0 fail, 5 skipped.
- `npm run check:local`: green — 27 manifest gates, affected fast 208/208, affected contract 156 pass / 1 skip.
- Behavior regression coverage: build matches → allow; mismatch → `daemon_build_stale`; reader throws → `daemon_build_identity_unavailable`; the five admin methods and all `repo-read` still exempt.

### Second commit — a regression this PR caused, found by CI and fixed

The first push turned `integration-shard (1)` red on `restart waits for a live endpoint owner that becomes ready after the normal startup budget` (98s, then `ENOENT` on the evidence JSON). Negative control: the same shard was green on PR #1221's CI and on the post-merge main gate, and this branch is based on that commit — so it was this change, not a flake, and it was not re-run away.

Root cause: making the build-identity reader required moved `calculateDaemonArtifactIdentity` onto the replacement daemon's startup path **before** endpoint ownership was published. That scan is expensive; under CI shard load the owner record was written too late, so the waiting side never saw a live owner and the evidence file never appeared.

Fix (`run-daemon-serve.ts`, 4 lines): the scan now runs *after* `withDaemonSocketOwnership` publishes ownership and *before* `createDaemonLocalTransport` activates connections. Ownership becomes observable early; no request can be served before the identity check completes, so the admission guarantee this PR establishes is unaffected.

- Post-fix: `npm run check:local` green after rebase onto `baa71414` (72.1s, 27 gates); `node tools/run-node-tests.mjs --tier integration` 1,472 pass / 0 fail / 4 skipped; target test 8/8.

## Review Evidence

- CEO semantic review: the fix satisfies both halves of this line's accounting policy in one slice — an illegal state deleted (protection-not-installed is now a compile error) and a parallel authority deleted (exemptions returned to the single method-contract declaration). It is not a mitigation dressed as a root fix, and it is not "add a test/gate/preflight", which this line's plan explicitly forbids as a primary approach.
- The worker also self-reported an intermediate stop-point failure (its added registry assertion pushed `json-rpc-protocol.test.ts` to 713 lines and tripped the file-complexity gate); the assertion was moved to the build-drift contract test, bringing the file to 687 lines. Reported rather than worked around.

## Residual Risk

- The required contract field means any future method declaration must state an admission policy. That is the intended cost; the failure mode is a compile error, not a silent wrong default.
- Anchors #1 (remaining legacy variant) and #3 (dual phase state machines) are still present on this line — this PR does not close the Transport line.

## References

- Line plan `task_01KZ1FMPC53362VFN0175WN0XY` (its Verification section holds the anchor table); accounting policy `dec_01KYYX1AXK7JMWFGCKX059W6PV`; milestone charter `dec_01KZ1EQY5PATT8GGV35CFE9FHG`.

---

# 中文

## 概要

PLT-Steady-Transport 线的结构锚点 2。daemon 的 build-drift guard——即「daemon 跑的代码与磁盘 dist 不一致时拒绝写」的那道保护——**缺省是 fail-open 的**：

```ts
export function buildIdentityAdmissionFailure(contract, readBuildIdentity) {
  if (!readBuildIdentity                       // ← 能力缺失 = 静默放行
    || contract.commandClass === "repo-read"
    || exemptAdminMethods.has(contract.method)) {
    return undefined;
  }
```

两个结构问题，本 PR 一并删除——这正是本线记账政策（`dec_01KYYX1AXK7JMWFGCKX059W6PV`）对每张票的要求：

- **一个非法状态是可表达的。** 保护到底跑不跑，取决于调用方记不记得传 `readBuildIdentity`；不传时没有任何信号。注意作者显然知道这里该 fail-closed：reader **抛错**时 guard 返回 `daemon_build_identity_unavailable` 并禁写。唯独「压根没装」被当成了「不需要」。
- **存在一个平行 authority。** `exemptAdminMethods` 是与 method registry 分离的手写 `Set`，新增或改名一个 admin method 时必须有人记得同步这第二份事实。

## 改动内容

- `JsonRpcServerOptions.readBuildIdentity` 与 `buildIdentityAdmissionFailure` 现在**必需** reader。能力缺失这个状态不再能通过类型检查。
- `JsonRpcMethodContract.buildIdentityAdmission` 成为**每个 registry 声明的必需字段**：静态 repo-read 与五个 admin 方法声明 `exempt`，write/arbiter 方法声明 `required`。派生 service 方法与动态 `repo.command.run` 的 effective contract 在 registry/server contract 路径内派生同一字段。
- `build-identity-admission.ts` 现在只查该 contract 字段。`!readBuildIdentity` 分支与 `exemptAdminMethods` 集合双双消失。
- 直接构造 protocol server 的测试改为显式传入 test witness，于是原先的「能力缺失」状态会让 daemon typecheck 失败，而不是静默关掉这道保护。

新增 method 声明若省略准入策略，现在会 typecheck 失败，而不是继承一个缺省值。

## 任务与范围

- 任务 `task_01KZ62MN2X9V9DP3KD235TTMGB`（所属线 `task_01KZ1FMPC53362VFN0175WN0XY`，里程碑 root `task_01KZ1EVR7Y6PGTK6YQ0QAQ0DB8`）。基于 `ae2fc102`，11 文件。
- **刻意不在范围内**：锚点 1（`RepoWriteCommandDto`，已部分消灭——现为判别联合，`task-complete`/`task-submit` 走 legacy 名会抛错）与锚点 3（parent/child 双 phase 状态机）。它们是本线后续切片，文件面会撞。
- 未改动：`daemon_build_stale` / `daemon_build_identity_unavailable` 两个错误码与其 receipt 形状——合并后的部署流程依赖它们（重建 dist → 未重启的 daemon 拒写 → `ha daemon restart --authority-manifest`）。

## 版本影响

- 无公开 CLI 面变更；无持久化 schema 变更。daemon 内部 method contract 新增一个必需字段。

## 治理声明

- 未触碰 protected surface。非治理任务；无 break-glass。

## 验证

- **缺陷范围的诚实陈述**：生产上唯一的 protocol server 构造点（`service-host.ts:236-240`）**本来就传了** witness，因此没有任何生产路径实际处于无保护状态。真正存在的是共享 API 上一个**可表达的**缺失状态——任何直接调用 `createJsonRpcProtocolServer` 的地方都可以省略那个可选字段。本 PR 删除的是这个可表达状态；这不是在声称生产曾经暴露。
- `npm run typecheck`：干净。
- `node --test packages/daemon/test/daemon-build-drift-admission.test.ts packages/daemon/test/json-rpc-protocol.test.ts`：29 tests，29 pass，0 fail。
- `node tools/run-node-tests.mjs --prefix packages/daemon/test/`：599 tests，594 pass，0 fail，5 skipped。
- `npm run check:local`：全绿——27 个 manifest 门、affected fast 208/208、affected contract 156 pass / 1 skip。
- 行为回归覆盖：build 一致 → 放行；不一致 → `daemon_build_stale`；reader 抛错 → `daemon_build_identity_unavailable`；五个 admin 方法与全部 `repo-read` 仍豁免。

### 第二个 commit —— 本 PR 引入的一次回归，由 CI 发现并已修

首次 push 后 `integration-shard (1)` 红在 `restart waits for a live endpoint owner that becomes ready after the normal startup budget`（98 秒后 evidence JSON `ENOENT`）。阴性对照：同一 shard 在 PR #1221 的 CI 与合并后 main 的全量门上都是绿的，而本分支正基于那个 commit——所以这是本次改动引入的，不是 flake，也没有靠重跑绕过去。

真因：把 build-identity reader 改为必需，使 `calculateDaemonArtifactIdentity` 落在了替身 daemon 启动路径上、且在 endpoint ownership 发布**之前**。该扫描开销大，CI shard 负载下 owner 记录写得太晚，等待方始终看不到活的 owner，evidence 文件也就从未出现。

修法（`run-daemon-serve.ts`，4 行）：扫描改到 `withDaemonSocketOwnership` 发布所有权**之后**、`createDaemonLocalTransport` 激活连接**之前**。所有权提早可见；同时任何请求都不可能在 identity 检查完成前被服务，因此本 PR 建立的准入保证不受影响。

- 修后：rebase 到 `baa71414` 后 `npm run check:local` 全绿（72.1s，27 gates）；`node tools/run-node-tests.mjs --tier integration` 1,472 pass / 0 fail / 4 skipped；目标测试 8/8。

## 审查证据

- CEO 语义验收：本切片一刀同时满足本线记账政策的两半——删掉一个非法状态（保护未安装现在是编译错误）与一个平行 authority（豁免回归 method contract 单一声明）。它不是伪装成根治的 mitigation，也不是本线 plan 明令禁止作为主方案的「加测试 / 加门 / 加 preflight」。
- worker 还主动报告了一次中途的停止点失败（它新增的 registry 断言把 `json-rpc-protocol.test.ts` 顶到 713 行，撞了 file-complexity 门）；断言被移到 build-drift 契约测试后降到 687 行。是上报而不是绕过。

## 残余风险

- 必需的 contract 字段意味着今后任何 method 声明都必须表态准入策略。这是刻意付出的代价；失败形态是编译错误，而不是一个静默的错误缺省。
- 锚点 1（剩余 legacy variant）与锚点 3（双 phase 状态机）仍在——本 PR 不关闭 Transport 线。

## 关联材料

- 线级 plan `task_01KZ1FMPC53362VFN0175WN0XY`（其 Verification 节是锚点表）；记账政策 `dec_01KYYX1AXK7JMWFGCKX059W6PV`；里程碑 charter `dec_01KZ1EQY5PATT8GGV35CFE9FHG`。

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body complete / 双语正文完整
- [x] Non-governance task did not modify CI/gate authority surfaces / 非治理任务未修改 CI/gate 权威面
- [x] Verification is real command output, not assertion / 验证为真实命令输出而非断言
- [x] Residual risk honestly stated / 残余风险如实陈述
