### PR TITLE
fix: friction wave-3 — .DS_Store no longer kills the write path, honest receipts, diagnosable path mismatches

### DIFF
--- a/packages/application/src/execution-saga-service.ts
+++ b/packages/application/src/execution-saga-service.ts
@@ -342,7 +342,12 @@ export function makeExecutionSagaService(options: ExecutionSagaServiceOptions): 
           })).effectiveHolder === null;
           cleanup = {
             status: released ? "released" : "retained",
-            diagnostics
+            // A lease-required/release-not-holder error is an expected
+            // post-publication race when reconciliation proves that the
+            // holder is already gone. Keeping its actionable pre-write hint
+            // on a successful receipt makes agents retry a write that already
+            // committed.
+            diagnostics: released && isLeaseCleanupRace(releaseError) ? [] : diagnostics
           };
         } catch (verificationError) {
           cleanup = {
@@ -367,6 +372,12 @@ function cleanupErrorMessage(error: unknown): string {
   return error instanceof Error
     ? `${error.name}: ${error.message}`
     : String(error);
+}
+
+function isLeaseCleanupRace(error: unknown): boolean {
+  if (!error || typeof error !== "object" || !("code" in error)) return false;
+  const code = (error as { readonly code?: unknown }).code;
+  return code === "task_lease_required" || code === "task_release_not_holder";
 }
 
 function selectReusableExecution(

--- a/packages/application/test/execution-submit-receipt-honesty.test.ts
+++ b/packages/application/test/execution-submit-receipt-honesty.test.ts
@@ -60,8 +60,7 @@ test("submit reports the committed authored outcome when its lease expires durin
 
     assert.equal(result.leaseReleased, true);
     assert.equal(result.cleanup.status, "released");
-    assert.equal(result.cleanup.diagnostics.length, 1);
-    assert.match(result.cleanup.diagnostics[0]?.message ?? "", /requires an active lease/u);
+    assert.deepEqual(result.cleanup.diagnostics, []);
     assert.equal(authored.executions.get(executionId)?.state, "submitted");
     assert.equal(authored.taskStatus, "in_review");
     assert.equal((await holder.holder({ taskId })).effectiveHolder, null);

--- a/packages/cli/src/cli/command-spec/command-groups.ts
+++ b/packages/cli/src/cli/command-spec/command-groups.ts
@@ -143,7 +143,7 @@ export const commandGroups = [
     "ha task progress append <task-id> --text \"<update>\"",
     "ha fact record --task <task-id> --statement \"<verified fact>\"",
     "ha task submit <task-id> --from-file submission.json",
-    "ha task code-doc reconcile <task-id> --commit <full-sha> [--path <repo-path>]...",
+    "ha task code-doc reconcile <task-id> --commit <full-sha> [--path <repo-file-path>]...",
     "ha task complete <task-id> --approve --from-file approval.json"
   ]),
   group("template", "List and render templates.", [

--- a/packages/cli/src/cli/command-spec/command-spec-core.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-core.ts
@@ -419,8 +419,8 @@ export const coreCommandSpecs = defineCommandSpecs([
   },
   {
     "kind": "task-code-doc-reconcile",
-    "usage": "task code-doc reconcile <id> --commit <full-sha> [--path <repo-path>]... [--pr <url>] [--force]",
-    "options": [{"flag":"--commit","description":"Set the required full commit SHA used by every generated ledger record."},{"flag":"--path","description":"Add a repository-relative path anchor; repeat for multiple paths."},{"flag":"--pr","description":"Add an optional PR reference anchored to the same commit."},{"flag":"--force","description":"Replace an existing code-doc-anchors.json instead of refusing to overwrite it."}],
+    "usage": "task code-doc reconcile <id> --commit <full-sha> [--path <repo-file-path>]... [--pr <url>] [--force]",
+    "options": [{"flag":"--commit","description":"Set the required full commit SHA used by every generated ledger record."},{"flag":"--path","description":"Add a repository-relative file path anchor; directory paths and trailing slashes are invalid; repeat for multiple files."},{"flag":"--pr","description":"Add an optional PR reference anchored to the same commit."},{"flag":"--force","description":"Replace an existing code-doc-anchors.json instead of refusing to overwrite it."}],
     "summary": "Generate and validate code-doc-anchors.json from task ledgers without hand-authoring JSON.",
     "examples": ["harness-anything task code-doc reconcile task_01ABC --commit 0123456789abcdef0123456789abcdef01234567 --path packages/cli/src/index.ts"],
     "parse": parseCoreTaskArgs,

--- a/packages/cli/src/cli/command-spec/command-spec-runtime-docs.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-runtime-docs.ts
@@ -164,8 +164,8 @@ export const runtimeDocsCommandSpecs = defineCommandSpecs([
   },
   {
     "kind": "doc-sync",
-    "usage": "doc sync (--dry-run|--submit [--path <authored-relative-path>]...) [--json]",
-    "options": [{"flag":"--dry-run","description":"Preview the operation without writing changes."},{"flag":"--submit","description":"Submit eligible authored prose through the daemon doc-sync validator and committer."},{"flag":"--path","description":"Submit only this authored-root-relative dirty path; repeat to select multiple owned files."},{"flag":"--json","description":"Emit command-receipt/v2 JSON."}],
+    "usage": "doc sync (--dry-run|--submit [--path <authored-relative-file-path>]...) [--json]",
+    "options": [{"flag":"--dry-run","description":"Preview the operation without writing changes."},{"flag":"--submit","description":"Submit eligible authored prose through the daemon doc-sync validator and committer."},{"flag":"--path","description":"Submit only this authored-root-relative dirty file; directories and trailing slashes are invalid; repeat to select multiple files. Unrelated dirty paths are excluded from this request."},{"flag":"--json","description":"Emit command-receipt/v2 JSON."}],
     "summary": "Preview or submit authored prose through the governed doc-sync path.",
     "examples": ["harness-anything doc sync --dry-run --json", "harness-anything doc sync --submit --path tasks/task_01ABC/task_plan.md --json"],
     "parse": parseDocArgs,

--- a/packages/cli/src/cli/task-packet-help.ts
+++ b/packages/cli/src/cli/task-packet-help.ts
@@ -58,7 +58,7 @@ function renderLifecycleSequence(commandKind: string): ReadonlyArray<string> {
       "  1. git rev-parse HEAD",
       "     Put this full 40-character public workspace SHA in approval.commit.",
       "  2. ha task code-doc reconcile <task-id> --commit <approval.commit> --path <each-approval.paths-entry> [--pr <approval.prRef>]",
-      "     Run before complete. Repeat --path in the same values as approval.paths; include --pr only when approval.prRef exists.",
+      "     Each --path is one repository-relative file (not a directory or trailing-slash path). Repeat it in the same values as approval.paths; include --pr only when approval.prRef exists.",
       "  3. ha task complete <task-id> --approve --from-file approval.json",
       "     The task must be unheld; complete reads and verifies the pre-existing reconciliation.",
       "",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -297,6 +297,10 @@ function ensureInnerGitRepository(
   }
 
   try {
+    // Finder metadata is intentionally ignored by the inner ledger repository.
+    // Authority read-down still applies the same structural safety validator to
+    // already-tracked metadata, so this only prevents new accidental tracking.
+    ensureGitignoreEntry(path.join(authoredRoot, ".gitignore"), ".DS_Store");
     try {
       runInitGit(authoredRoot, ["init", "--initial-branch=master"], commitAuthor, gitRuntime);
     } catch (error) {

--- a/packages/cli/test/doc-sync-selection-contract.test.ts
+++ b/packages/cli/test/doc-sync-selection-contract.test.ts
@@ -1,0 +1,139 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { buildDocSyncSubmitRequest } from "@harness-anything/daemon";
+import { cliDaemonServiceHostServices } from "../src/composition/daemon-service-host-services.ts";
+
+const repoRoot = path.resolve(fileURLToPath(new URL("../../..", import.meta.url)));
+const registryBody = readFileSync(path.join(repoRoot, "tools/write-road-registry.json"), "utf8");
+
+test("doc sync selection diagnostics name only selected blockers and ignore unrelated machine products", () => {
+  withFixture(({ rootDir, harnessRoot, taskId }) => {
+    const selectedPath = `tasks/${taskId}/INDEX.md`;
+    writeFileSync(path.join(harnessRoot, selectedPath), taskIndex("high"), "utf8");
+    writeFileSync(path.join(harnessRoot, "unrelated-machine-output.log"), "machine output\n", "utf8");
+
+    assert.throws(
+      () => buildSelectedRequest(rootDir, [selectedPath]),
+      (error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        assert.match(message, /selected path/i);
+        assert.match(message, /INDEX\.md/u);
+        assert.doesNotMatch(message, /unrelated-machine-output\.log/u);
+        return true;
+      }
+    );
+  });
+});
+
+test("doc sync submits a large selected file batch without importing unrelated machine products", () => {
+  withFixture(({ rootDir, harnessRoot, taskId }) => {
+    const selectedPaths = Array.from({ length: 12 }, (_, index) =>
+      `tasks/${taskId}/artifacts/agent-note-${String(index + 1).padStart(2, "0")}.md`
+    );
+    for (const selectedPath of selectedPaths) {
+      const absolutePath = path.join(harnessRoot, selectedPath);
+      mkdirSync(path.dirname(absolutePath), { recursive: true });
+      writeFileSync(absolutePath, `# Selected ${selectedPath}\n`, "utf8");
+    }
+    const unrelatedPaths = [
+      ...Array.from({ length: 13 }, (_, index) => `governance/walls/reports/machine-${index + 1}.md`),
+      ...Array.from({ length: 13 }, (_, index) => `context/benchmark/run-${index + 1}/launchd/stderr.log`)
+    ];
+    for (const unrelatedPath of unrelatedPaths) {
+      const absolutePath = path.join(harnessRoot, unrelatedPath);
+      mkdirSync(path.dirname(absolutePath), { recursive: true });
+      writeFileSync(absolutePath, "third-party machine product\n", "utf8");
+    }
+
+    const request = buildSelectedRequest(rootDir, selectedPaths);
+    assert.equal(request.payload.changes.length, 12);
+    assert.deepEqual(request.payload.changes.map((change) => change.path).sort(), selectedPaths);
+  });
+});
+
+function buildSelectedRequest(rootDir: string, selectedPaths: ReadonlyArray<string>) {
+  return buildDocSyncSubmitRequest(
+    rootDir,
+    "canonical",
+    selectedPaths,
+    { kind: "agent", id: "codex-test" },
+    cliDaemonServiceHostServices.docSync,
+    { sessionId: "session-doc-sync-selection", runtime: "codex" }
+  );
+}
+
+function withFixture(fn: (fixture: { readonly rootDir: string; readonly harnessRoot: string; readonly taskId: string }) => void): void {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-sync-selection-"));
+  const harnessRoot = path.join(rootDir, "harness");
+  const taskId = "task_01KX3W4V1EDPHPTGWYYBQQ2J75";
+  const taskRoot = path.join(harnessRoot, "tasks", taskId);
+  try {
+    mkdirSync(path.join(rootDir, "tools"), { recursive: true });
+    writeFileSync(path.join(rootDir, "tools", "write-road-registry.json"), registryBody, "utf8");
+    mkdirSync(taskRoot, { recursive: true });
+    writeFileSync(path.join(taskRoot, "INDEX.md"), taskIndex("medium"), "utf8");
+    writeFileSync(path.join(taskRoot, "task_plan.md"), "# Plan\n\n## Goal\nOriginal prose.\n", "utf8");
+    initHarnessGit(harnessRoot);
+    fn({ rootDir, harnessRoot, taskId });
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function taskIndex(urgency: string): string {
+  return [
+    "---",
+    "schema: task-package/v2",
+    "task_id: task_01KX3W4V1EDPHPTGWYYBQQ2J75",
+    "status: active",
+    `urgency: ${urgency}`,
+    "vertical: software/coding",
+    "preset: standard-task",
+    "---",
+    "# Task",
+    ""
+  ].join("\n");
+}
+
+function initHarnessGit(harnessRoot: string): void {
+  git(harnessRoot, "init");
+  git(harnessRoot, "config", "user.name", "Harness Test");
+  git(harnessRoot, "config", "user.email", "harness@example.test");
+  git(harnessRoot, "add", ".");
+  execFileSync("git", ["-C", harnessRoot, "commit", "-m", "seed"], {
+    stdio: "ignore",
+    env: gitEnvironment(harnessRoot, {
+      GIT_AUTHOR_NAME: "Harness Test",
+      GIT_AUTHOR_EMAIL: "harness@example.test",
+      GIT_COMMITTER_NAME: "Harness Test",
+      GIT_COMMITTER_EMAIL: "harness@example.test"
+    })
+  });
+}
+
+function git(harnessRoot: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", harnessRoot, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: gitEnvironment(harnessRoot)
+  }).trimEnd();
+}
+
+function gitEnvironment(harnessRoot: string, overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const emptyHome = path.join(harnessRoot, ".empty-home");
+  mkdirSync(emptyHome, { recursive: true });
+  const configPath = path.join(emptyHome, "empty.gitconfig");
+  writeFileSync(configPath, "", "utf8");
+  return {
+    ...process.env,
+    HOME: emptyHome,
+    GIT_CONFIG_GLOBAL: configPath,
+    ...overrides
+  };
+}

--- a/packages/cli/test/help-layering.test.ts
+++ b/packages/cli/test/help-layering.test.ts
@@ -30,7 +30,7 @@ test("task primary workflow exposes the complete seven-step lifecycle", () => {
     "ha task progress append <task-id> --text \"<update>\"",
     "ha fact record --task <task-id> --statement \"<verified fact>\"",
     "ha task submit <task-id> --from-file submission.json",
-    "ha task code-doc reconcile <task-id> --commit <full-sha> [--path <repo-path>]...",
+    "ha task code-doc reconcile <task-id> --commit <full-sha> [--path <repo-file-path>]...",
     "ha task complete <task-id> --approve --from-file approval.json"
   ]);
 });

--- a/packages/cli/test/init-cli.test.ts
+++ b/packages/cli/test/init-cli.test.ts
@@ -27,6 +27,7 @@ test("CLI init defaults harness project name from the target root basename", () 
     assert.equal(result.report.isolation.innerRepository.gitDirExists, true);
     assert.equal(result.report.isolation.innerRepository.branch, "master");
     assert.equal(result.report.isolation.innerRepository.commitCount, 1);
+    assert.match(readFileSync(path.join(rootDir, "harness/.gitignore"), "utf8"), /^\.DS_Store$/m);
     assert.equal(result.report.isolation.outerGit.action, "initialized");
     assert.equal(result.report.isolation.outerGit.initialCommitCreated, true);
     assert.equal(result.report.isolation.outerGit.commitCount, 1);

--- a/packages/daemon/src/authority/production/task-complete-prepublish-witness.ts
+++ b/packages/daemon/src/authority/production/task-complete-prepublish-witness.ts
@@ -139,7 +139,10 @@ export function produceCodeDocWitness(input: {
   });
   if (expected.recordIds.length === 0 || expected.body !== codeDoc.body) {
     throw new Error(
-      "AUTHORITY_TASK_COMPLETE_CODE_DOC_NOT_RECONCILED_TO_INTENT: run `ha task code-doc reconcile <task-id> --commit <full-sha> [--path <repo-relative-path>]...` after task submit and before task complete."
+      "AUTHORITY_TASK_COMPLETE_CODE_DOC_NOT_RECONCILED_TO_INTENT: "
+      + `approval intent expects ${describeCodeDocAnchors(expected.body)}; `
+      + `current code-doc ${CODE_DOC_RECONCILIATION_DOCUMENT} has ${describeCodeDocAnchors(codeDoc.body)}; `
+      + "run `ha task code-doc reconcile <task-id> --commit <full-sha> [--path <repo-relative-path>]...` after task submit and before task complete."
     );
   }
   const [repositoryPath] = taskRepositoryPaths(input, [CODE_DOC_RECONCILIATION_DOCUMENT]);
@@ -155,6 +158,36 @@ export function produceCodeDocWitness(input: {
     codeDocBodyDigest: `sha256:${sha256Text(codeDoc.body)}`
   };
   return { ...witnessWithoutRef, ref: encodePrepublishWitnessRef(witnessWithoutRef) };
+}
+
+function describeCodeDocAnchors(body: string): string {
+  try {
+    const parsed = JSON.parse(body) as { readonly records?: unknown };
+    if (!Array.isArray(parsed.records)) return "invalid records";
+    const anchors = parsed.records.flatMap((record) => {
+      if (!record || typeof record !== "object" || !("anchors" in record)) return [];
+      const value = (record as { readonly anchors?: unknown }).anchors;
+      return Array.isArray(value) ? value : [];
+    });
+    const commits = anchors.flatMap((anchor) => {
+      if (!anchor || typeof anchor !== "object") return [];
+      const value = (anchor as { readonly kind?: unknown; readonly sha?: unknown });
+      return value.kind === "commit" && typeof value.sha === "string" ? [value.sha] : [];
+    });
+    const paths = anchors.flatMap((anchor) => {
+      if (!anchor || typeof anchor !== "object") return [];
+      const value = (anchor as { readonly kind?: unknown; readonly path?: unknown });
+      return value.kind === "path" && typeof value.path === "string" ? [value.path] : [];
+    });
+    const prs = anchors.flatMap((anchor) => {
+      if (!anchor || typeof anchor !== "object") return [];
+      const value = (anchor as { readonly kind?: unknown; readonly ref?: unknown });
+      return value.kind === "pr" && typeof value.ref === "string" ? [value.ref] : [];
+    });
+    return `records=${parsed.records.length}; commits=[${commits.join(",")}]; paths=[${paths.join(",")}]; prs=[${prs.join(",")}]`;
+  } catch {
+    return "invalid JSON";
+  }
 }
 
 export function decodePrepublishWitnessRef(ref: string): VerifiedTaskCompleteExternalWitness {
@@ -289,7 +322,9 @@ function findMaterializedPublication(
   const expectedBlobs = bodies.map((body) => witnessGitText(rootDir, ["hash-object", "--stdin"], body));
   const currentBlobs = witnessGitBlobIds(rootDir, "HEAD", repositoryPaths);
   if (currentBlobs.some((actual, index) => actual !== expectedBlobs[index])) {
-    throw new Error(`AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:${repositoryPaths.join(",")}`);
+    throw new Error(
+      `AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:${describeMaterializationMismatches(repositoryPaths, currentBlobs, expectedBlobs)}`
+    );
   }
   for (const entry of firstParentHistory(rootDir, repositoryPaths)) {
     if (entry.parents.length !== 2) continue;
@@ -299,7 +334,23 @@ function findMaterializedPublication(
     const matches = actualBlobs.every((actual, index) => actual === expectedBlobs[index]);
     if (matches) return { commit: entry.commit, operationIds };
   }
-  throw new Error(`AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:${repositoryPaths.join(",")}`);
+  throw new Error(
+    `AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:no matching first-parent publication found for declared paths: ${repositoryPaths.join(",")}`
+  );
+}
+
+function describeMaterializationMismatches(
+  repositoryPaths: ReadonlyArray<string>,
+  actualBlobs: ReadonlyArray<string | null>,
+  expectedBlobs: ReadonlyArray<string>
+): string {
+  return repositoryPaths.flatMap((repositoryPath, index) => {
+    const actual = actualBlobs[index];
+    if (actual === expectedBlobs[index]) return [];
+    return [actual === null
+      ? `${repositoryPath} (missing from HEAD)`
+      : `${repositoryPath} (content differs from expected)`];
+  }).join(", ");
 }
 
 function assertMaterializedPublication(

--- a/packages/daemon/src/authority/read-down-managed-path.ts
+++ b/packages/daemon/src/authority/read-down-managed-path.ts
@@ -4,13 +4,21 @@ const reservedFoldedSegments = new Set([
   ".conflicts", ".ds_store", "desktop.ini", "thumbs.db"
 ]);
 
+export interface ReadDownManagedPathValidationOptions {
+  /** Only the exact final .DS_Store leaf may use this internal exception. */
+  readonly allowPlatformMetadataLeaf?: boolean;
+}
+
 /**
  * Validates an immutable Git fact before read-down materialization. Unlike
  * authoring admission, historical paths may contain non-ASCII UTF-8; disk
  * escape, reserved metadata names, and filesystem-unsafe structure remain
  * fail-closed.
  */
-export function validateReadDownManagedPath(managedPath: string): void {
+export function validateReadDownManagedPath(
+  managedPath: string,
+  options: ReadDownManagedPathValidationOptions = {}
+): void {
   if (managedPath.length === 0
     || managedPath.startsWith("/")
     || /^[A-Za-z]:/u.test(managedPath)
@@ -23,14 +31,17 @@ export function validateReadDownManagedPath(managedPath: string): void {
     unsafe(managedPath);
   }
   const segments = managedPath.split("/");
-  for (const segment of segments) {
+  for (const [index, segment] of segments.entries()) {
     if (!segment
       || segment === "."
       || segment === "..") {
       unsafe(managedPath);
     }
     const folded = foldAscii(segment);
-    if (reservedFoldedSegments.has(folded)
+    const allowedPlatformMetadataLeaf = options.allowPlatformMetadataLeaf === true
+      && index === segments.length - 1
+      && segment === ".DS_Store";
+    if ((reservedFoldedSegments.has(folded) && !allowedPlatformMetadataLeaf)
       || folded.startsWith(".ha-")) {
       unsafe(managedPath);
     }

--- a/packages/daemon/src/authority/replication-content-store.ts
+++ b/packages/daemon/src/authority/replication-content-store.ts
@@ -232,17 +232,18 @@ function readGitEntries(
   persistBlob: (bytes: Uint8Array) => Sha256Digest
 ): ReadonlyArray<AuthoritySnapshotManifestEntry> {
   const listing = readAuthorityGitBytes(root, "ls-tree", "-r", "-z", "--full-tree", commitSha);
-  const rows = splitNul(listing).map((row) => {
+  const rows = splitNul(listing).flatMap((row) => {
     const separator = row.indexOf(0x09);
     const metadata = separator >= 0 ? row.subarray(0, separator).toString("ascii") : "";
     const match = /^(100644|100755|120000) blob ([0-9a-f]+)$/u.exec(metadata);
     if (!match || separator < 0) throw new Error(`RESYNC_REQUIRED:UNSUPPORTED_GIT_TREE_ENTRY:${metadata.slice(0, 80)}`);
     const pathBytes = row.subarray(separator + 1);
-    return {
-      path: decodePortableGitPath(pathBytes),
+    const pathName = decodePortableGitPath(pathBytes);
+    return pathName === undefined ? [] : [{
+      path: pathName,
       objectId: match[2]!,
       mode: match[1] as ReplicaFileMode
-    };
+    }];
   });
   const blobs = readGitBlobBatch(root, rows.map((row) => row.objectId));
   const entries = rows.map((row) => {
@@ -289,6 +290,7 @@ function readGitEntriesIncrementally(
     const match = /^:(\d{6}) (\d{6}) ([0-9a-f]+) ([0-9a-f]+) ([ADMT])$/u.exec(metadata);
     if (!match) throw new Error(`RESYNC_REQUIRED:GIT_DIFF_RAW_ENTRY:${metadata.slice(0, 80)}`);
     const pathName = decodePortableGitPath(rows[index + 1]!);
+    if (pathName === undefined) continue;
     if (match[5] === "D") {
       changed.push({ path: pathName });
       continue;
@@ -392,7 +394,7 @@ function splitNul(value: Uint8Array): ReadonlyArray<Buffer> {
   return rows;
 }
 
-function decodePortableGitPath(pathBytes: Uint8Array): string {
+function decodePortableGitPath(pathBytes: Uint8Array): string | undefined {
   let pathName: string;
   try {
     pathName = new TextDecoder("utf-8", { fatal: true }).decode(pathBytes);
@@ -402,8 +404,9 @@ function decodePortableGitPath(pathBytes: Uint8Array): string {
   if (!Buffer.from(pathName, "utf8").equals(Buffer.from(pathBytes))) {
     throw new Error(`RESYNC_REQUIRED:GIT_PATH_NOT_UTF8_ROUND_TRIP:${Buffer.from(pathBytes).toString("hex").slice(0, 80)}`);
   }
-  validateReadDownManagedPath(pathName);
-  return pathName;
+  const isPlatformMetadata = pathName.slice(pathName.lastIndexOf("/") + 1) === ".DS_Store";
+  validateReadDownManagedPath(pathName, { allowPlatformMetadataLeaf: isPlatformMetadata });
+  return isPlatformMetadata ? undefined : pathName;
 }
 
 function diffSnapshots(

--- a/packages/daemon/src/service/doc-sync-service.ts
+++ b/packages/daemon/src/service/doc-sync-service.ts
@@ -116,10 +116,11 @@ export function buildDocSyncSubmitRequest(
   const unresolvedTouches = report.unresolvedTouches.filter((entry) => filePaths.has(entry.path));
   const deletions = report.deletions.filter((entry) => filePaths.has(entry.path));
   if (forbiddenTouches.length > 0 || unresolvedTouches.length > 0 || deletions.length > 0) {
-    throw new Error(
-      `Doc sync preview is not ready: ${forbiddenTouches.length} forbidden touch(es), ` +
-      `${unresolvedTouches.length} unresolved touch(es), ${deletions.length} deletion(s). Run 'ha doc status'.`
-    );
+    const scope = selected.size > 0 ? ` for selected path(s): ${[...selected].sort().join(", ")}` : "";
+    const blockers = [...forbiddenTouches.map((touch) => `forbidden:${touch.path}`), ...unresolvedTouches.map((touch) => `unresolved:${touch.path}`), ...deletions.map((entry) => `deletion:${entry.path}`)];
+    throw new Error(selected.size === 0
+      ? `Doc sync preview is not ready: ${forbiddenTouches.length} forbidden touch(es), ${unresolvedTouches.length} unresolved touch(es), ${deletions.length} deletion(s). Run 'ha doc status'.`
+      : `Doc sync preview is not ready${scope}: ${blockers.join(", ")}. Only paths in this request are blockers; unrelated dirty paths are excluded. Run 'ha doc status'.`);
   }
   if (!report.baseLedgerSha) throw new Error("Doc sync submit requires an initialized authored Git repository.");
   const layout = resolveHarnessLayout(rootInput);

--- a/packages/daemon/test/replication-content-history-path.test.ts
+++ b/packages/daemon/test/replication-content-history-path.test.ts
@@ -42,13 +42,35 @@ test("read-down accepts immutable UTF-8 and legacy long paths but rejects disk e
   }
 
   for (const unsafe of [
-    "../escape", "/absolute", "C:/drive", "\\\\server\\share", "safe/\0escape", ".git/config"
+    "../escape", "/absolute", "C:/drive", "\\\\server\\share", "safe/\0escape", ".git/config", ".DS_Store"
   ]) {
     assert.throws(
       () => validateReadDownManagedPath(unsafe),
       /RESYNC_REQUIRED:GIT_PATH_NOT_SAFE/u,
       unsafe
     );
+  }
+});
+
+test("read-down excludes tracked Finder metadata without weakening path safety", () => {
+  const fixture = createFixture();
+  try {
+    mkdirSync(path.join(fixture.gitRoot, "nested"));
+    writeFileSync(path.join(fixture.gitRoot, "README.md"), "kept\n");
+    writeFileSync(path.join(fixture.gitRoot, ".DS_Store"), "finder metadata\n");
+    writeFileSync(path.join(fixture.gitRoot, "nested", ".DS_Store"), "finder metadata\n");
+    git(fixture.gitRoot, "add", ".");
+    git(fixture.gitRoot, "commit", "-m", "tracked platform metadata");
+
+    const commitSha = git(fixture.gitRoot, "rev-parse", "HEAD");
+    const snapshot = fixture.content.snapshot(commitSha, 0);
+    assert.deepEqual(snapshot.entries.map((entry) => entry.path), ["README.md"]);
+    assert.throws(
+      () => validateReadDownManagedPath("nested/.DS_Store/escape"),
+      /RESYNC_REQUIRED:GIT_PATH_NOT_SAFE/u
+    );
+  } finally {
+    fixture.cleanup();
   }
 });
 

--- a/packages/daemon/test/task-complete-prepublish-witness.test.ts
+++ b/packages/daemon/test/task-complete-prepublish-witness.test.ts
@@ -82,6 +82,53 @@ test("unpublished document rejection stays bounded with 1011 unrelated first-par
   }
 });
 
+test("unpublished document rejection names only the path whose body is not materialized", () => {
+  const fixture = witnessRepository();
+  try {
+    const documents = fixture.documents.map((document) => document.path === "closeout.md"
+      ? { ...document, body: `${document.body}\nUnpublished mutation.\n` }
+      : document);
+    assert.throws(
+      () => produceDocumentPublicationWitness({ ...fixture, documents }),
+      (error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        assert.match(message, /closeout\.md/u);
+        assert.doesNotMatch(message, /code-doc-anchors\.json/u);
+        assert.match(message, /content differs from expected/u);
+        return true;
+      }
+    );
+  } finally {
+    rmSync(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("code-doc reconciliation rejection names the approval intent and current anchors", () => {
+  const fixture = witnessRepository();
+  try {
+    const command = {
+      ...fixture.command,
+      approval: {
+        ...fixture.command.approval!,
+        paths: ["src/other.ts"]
+      }
+    };
+    assert.throws(
+      () => produceCodeDocWitness({ ...fixture, command }),
+      (error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        assert.match(message, /approval intent/u);
+        assert.match(message, /src\/other\.ts/u);
+        assert.match(message, /current code-doc/u);
+        assert.match(message, /README\.md/u);
+        return true;
+      }
+    );
+  } finally {
+    rmSync(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+});
+
 function witnessRepository() {
   const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-prepublish-witness-"));
   const rootDir = path.join(fixtureRoot, "workspace");


### PR DESCRIPTION
# English

## Summary

Wave 3 of the kty-web pilot friction report. The nine remaining items were originally filed by the reporter as P2 "design smells" and P3 "daily noise"; CEO review overruled that grading — three of them had caused hard failures in real use (`.DS_Store` killing the entire authority write path; `restart` with no rollback stopping a daemon the user was actively using; approval/reconcile path coupling that cost the CEO several debugging steps during a real closeout).

Delivered here: **#6, #15, #16, #20, #23, #24**, plus one new same-family instance the CEO hit while closing out wave-1/wave-2. **#17 and #18 are explicitly NOT delivered** — see Residual Risk. **#19 and #21/#22** were verified to already hold and were deliberately not re-patched.

## What Changed

- **#6 — `.DS_Store` no longer kills the authority write path.** A Finder metadata file made every authority write fail with `AUTHORITY_INDETERMINATE:INDEX_RECOVERY_REQUIRED:GIT_PATH_NOT_SAFE`. The fix does **not** remove `.DS_Store` from the reserved-name set. Instead `validateReadDownManagedPath` gains an opt-in `allowPlatformMetadataLeaf` option that is off by default and only matches an exact-case `.DS_Store` in the **final** path segment; the single caller then excludes that entry from the replication content set entirely. Disk escape, `..`, `.ha-` prefixes, and every other reserved name (`.conflicts`, `desktop.ini`, `thumbs.db`, and even lowercase `.ds_store`) remain fail-closed. `ha init` additionally writes `.DS_Store` into the inner ledger `.gitignore` so new repositories stop accidentally tracking it.
- **#15 / #16 — path semantics and diagnosable mismatch.** `--path` file/directory/trailing-slash semantics are documented where the user looks; an approval-packet vs reconcile mismatch now names which side differs and what was expected instead of a bare `AUTHORITY_TASK_COMPLETE_CODE_DOC_NOT_RECONCILED_TO_INTENT`.
- **#20** — `daemon start --help` now lists `--user-root`, which was always accepted but undocumented.
- **#23 — receipts stop carrying fake failure warnings.** `ha task submit` / `ha task transition` returned `ok status=in_review` *and* a `TaskLeaseRequiredError` telling you to run `ha task start` first — on calls that had actually succeeded (disk execution state was already `submitted`). A success path no longer carries a "you must first do X" warning.
- **#24 — `PREPUBLISH_NOT_MATERIALIZED` lists only what actually mismatched.** It used to join the *entire* task-package path set into the error, so a single untracked artifact read as "nothing in this package is materialized".
- **New same-family instance** — `doc sync --submit` with 12 `--path` arguments reported `Doc sync preview is not ready: 0 forbidden, 26 unresolved`, where all 26 unresolved paths were unrelated third-party machine artifacts. The diagnostic is now selective about the request at hand.

## Task And Scope

- Task `task_01KZ5V3GJQZHGD7H83R651E5SZ` (parent intake `task_01KZ3XES4V69C4WXBR7JPVNSG9`), report in the task package. 15 files on base `ae2fc102`.
- **#19 (restart rollback) and #21/#22 (output-stream separation) were verified, not re-implemented** — the correct behavior already exists. CEO independently confirmed #21/#22 by experiment: with stderr discarded, stdout carries no `[ha]` progress lines, and `ha doc status --json 2>/dev/null` parses as pure JSON.

## Version Impact

- No persisted-schema change. Help text and error text change; `ha init` writes one additional `.gitignore` line in new repositories.

## Governance Declaration

- Protected surface touched: no. Not a governance task; no break-glass. Two items were **abandoned specifically to avoid touching a gate** — see Residual Risk.

## Verification

- `npm run check:local`: green, 27 manifest gates.
- `node tools/run-node-tests.mjs --tier integration`: 1,478 tests, 1,474 pass, 0 fail, 4 skipped.
- Every delivered item carries a red-side (original behavior) and green-side (current command output) transcript in the report.
- CEO independent verification: #21/#22 by direct experiment (above); #6 by reading the exception's single call site and confirming the opt-in cannot widen beyond an exact-case leaf.

## Review Evidence

- CEO semantic review focused on the one way #6 could have been wrong — weakening the path safety validator to make the symptom go away. It was not: the reserved-name set is unchanged, the exception is off by default, it matches only an exact-case final segment, and its sole caller uses it to *exclude* the entry rather than to admit it. Everything ambiguous still fails closed.
- The worker also correctly stopped rather than working around a gate (below), and reported two items as undelivered instead of claiming partial credit.

## Residual Risk

- **#17 (`daemon start --service` discards child stderr) and #18 (6s startup budget misreads slow starts as failure) are NOT fixed.** Both require editing `packages/cli/src/commands/daemon/productization.ts`, which is pinned by `packages/cli/test/production-authority-host-services/golden.test.ts` **by source blob hash** (`expected 565a8eb9… / actual 55db3755…`). Editing the file turns that gate red, and updating the golden is a governance-surface action. The worker withdrew the implementation and recorded the blocker rather than touching the gate — the correct call under the CI/Gate Authority Stop Condition. **A follow-up governance task is needed to decide whether a source file should be blob-pinned like this at all**, since it currently makes every ordinary fix to that file require gate approval. #17 in particular is a diagnosability defect: service-mode startup failures currently leave no evidence at all.
- `.DS_Store` entries are now skipped from replication **silently** — no log line or counter. This is acceptable for a known platform artifact, but it is a silent exclusion, and silent exclusions have bitten this codebase before.
- #19's rollback behavior was verified through existing synthetic tests, not re-derived; the failure path (replacement fails to start) was not exercised against production this round.

## References

- Parent intake `task_01KZ3XES4V69C4WXBR7JPVNSG9` (its closeout carries the full 26-row disposition table); sibling waves PR #1207 / #1208.

---

# 中文

## 概要

kty-web 试点摩擦报告 wave-3。剩余九条最初被报告人归为 P2「设计上说不通的」与 P3「日常噪音」；CEO 复核推翻了这个分级——其中三条在真实使用中造成过硬故障（`.DS_Store` 打死整条 authority 写路径；`restart` 无回滚停掉了用户正在用的 daemon；审批包与 reconcile 的路径耦合让 CEO 在一次真实收口中多花了数步排障）。

本 PR 交付：**#6、#15、#16、#20、#23、#24**，外加 CEO 在做 wave-1/wave-2 销账时踩到的一条同族新实例。**#17 与 #18 明确未交付**——见残余风险。**#19 与 #21/#22** 经核实已经成立，刻意不重复打补丁。

## 改动内容

- **#6 —— `.DS_Store` 不再打死 authority 写路径。** 一个 Finder 元数据文件曾让所有 authority 写以 `AUTHORITY_INDETERMINATE:INDEX_RECOVERY_REQUIRED:GIT_PATH_NOT_SAFE` 失败。修法**没有**把 `.DS_Store` 从保留名集合里删掉，而是给 `validateReadDownManagedPath` 加了一个默认关闭的 opt-in 选项 `allowPlatformMetadataLeaf`，且只匹配**最后一段**、大小写精确的 `.DS_Store`；唯一的调用方随后把该条目整个排除出 replication 内容集。disk escape、`..`、`.ha-` 前缀以及其余全部保留名（`.conflicts`、`desktop.ini`、`thumbs.db`，乃至小写 `.ds_store`）仍然 fail-closed。`ha init` 另外把 `.DS_Store` 写进内层 ledger 的 `.gitignore`，让新仓不再意外跟踪它。
- **#15 / #16 —— path 语义与可诊断的不一致。** `--path` 的文件/目录/尾斜杠语义写在用户会看的地方；审批包与 reconcile 不一致时，报错点名是哪一侧不同、期望是什么，而不是光抛一个 `AUTHORITY_TASK_COMPLETE_CODE_DOC_NOT_RECONCILED_TO_INTENT`。
- **#20** —— `daemon start --help` 现在列出 `--user-root`，它一直可用但从未被文档化。
- **#23 —— 回执不再携带假的失败警告。** `ha task submit` / `ha task transition` 曾在**实际成功**的调用上同时返回 `ok status=in_review` 与 `TaskLeaseRequiredError`（叫你先去跑 `ha task start`）——而磁盘上的 execution 状态早已是 `submitted`。成功路径不再携带「你必须先做 X」这类警告。
- **#24 —— `PREPUBLISH_NOT_MATERIALIZED` 只列真正失配的路径。** 它此前把**整个**任务包路径集合拼进错误消息，于是一个未入库的 artifact 读起来像是「这个包里什么都没 materialize」。
- **同族新实例** —— `doc sync --submit` 带 12 个 `--path` 时报 `Doc sync preview is not ready: 0 forbidden, 26 unresolved`，而那 26 个 unresolved 全是与本次请求无关的第三方机器产物。诊断现在只谈与当次请求相关的内容。

## 任务与范围

- 任务 `task_01KZ5V3GJQZHGD7H83R651E5SZ`（父 intake `task_01KZ3XES4V69C4WXBR7JPVNSG9`），报告在任务包内。基于 `ae2fc102`，15 文件。
- **#19（restart 回滚）与 #21/#22（输出流分离）是经核实已成立，不是重新实现**——正确行为已经存在。CEO 独立做实验确认了 #21/#22：丢弃 stderr 后 stdout 不含任何 `[ha]` 进度行，且 `ha doc status --json 2>/dev/null` 可作为纯 JSON 解析。

## 版本影响

- 无持久化 schema 变更。help 文本与错误文本有变化；`ha init` 在新仓的 `.gitignore` 里多写一行。

## 治理声明

- 未触碰 protected surface。非治理任务；无 break-glass。有两条**正是为了不碰 gate 而放弃交付**——见残余风险。

## 验证

- `npm run check:local`：全绿，27 个 manifest 门。
- `node tools/run-node-tests.mjs --tier integration`：1,478 tests，1,474 pass，0 fail，4 skipped。
- 每条已交付项在报告中都有红侧（原始行为）与绿侧（当前命令输出）的真实记录。
- CEO 独立验证：#21/#22 用直接实验（见上）；#6 通过读该例外的唯一调用点，确认这个 opt-in 无法扩大到「大小写精确的叶子」之外。

## 审查证据

- CEO 语义验收专查 #6 唯一可能出错的方式——为了让症状消失而削弱 path 安全校验器。结论是没有：保留名集合未变，例外默认关闭，只匹配大小写精确的最后一段，且其唯一调用方是用它来**排除**该条目而不是接纳它。一切歧义仍然 fail-closed。
- worker 在撞到 gate 时选择停手而非绕过（见下），并把两条如实报为未交付，而不是含混地邀功。

## 残余风险

- **#17（`daemon start --service` 丢弃 child stderr）与 #18（6 秒启动预算把慢启动误判为失败）未修复。** 两者都必须改 `packages/cli/src/commands/daemon/productization.ts`，而该文件被 `packages/cli/test/production-authority-host-services/golden.test.ts` **按 source blob hash 钉死**（`expected 565a8eb9… / actual 55db3755…`）。改这个文件就让那道门变红，而更新 golden 属于治理面动作。worker 撤回实现、记录 blocker，没有碰 gate——这是 CI/Gate Authority Stop Condition 下的正确选择。**需要一个后续治理任务来裁决：一个源文件到底该不该被这样按 blob 钉死**，因为它目前让对该文件的任何普通修复都需要门禁审批。#17 尤其是诊断能力缺陷：service 模式的启动失败目前不留下任何证据。
- `.DS_Store` 条目现在被**静默**排除出 replication——没有日志行也没有计数。对一个已知的平台产物这是可接受的，但它终究是静默排除，而静默排除在本代码库咬过人。
- #19 的回滚行为是通过既有合成测试核实的，不是重新推导；其失败路径（替身起不来）本轮没有对生产演练。

## 关联材料

- 父 intake `task_01KZ3XES4V69C4WXBR7JPVNSG9`（其 closeout 载完整 26 行去向表）；兄弟 wave PR #1207 / #1208。

## PR Gate Checklist / PR 门禁清单

- [x] Bilingual body complete / 双语正文完整
- [x] Non-governance task did not modify CI/gate authority surfaces / 非治理任务未修改 CI/gate 权威面
- [x] Verification is real command output, not assertion / 验证为真实命令输出而非断言
- [x] Residual risk honestly stated / 残余风险如实陈述
