### PR TITLE
fix(cli): retire golden source-blob anchor, give service startup failures on-disk evidence and a real budget

### DIFF
--- a/packages/cli/src/commands/daemon/productization.ts
+++ b/packages/cli/src/commands/daemon/productization.ts
@@ -20,7 +20,16 @@ import { initializeHarness } from "../init.ts";
 import { resolveCliVersion } from "../core/version.ts";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
 import { readOption } from "../../cli/parse-options.ts";
-import { resolveLocalDaemonTarget, requestLocalDaemonJsonRpc, type LocalDaemonTarget } from "../../daemon/client.ts";
+import { resolveLocalDaemonTarget } from "../../daemon/client.ts";
+import {
+  daemonServiceStartupTimeoutMs,
+  diagnoseDaemonServiceLaunchFailure,
+  observeDaemonServiceLaunch,
+  readReachableDaemonStatus,
+  DaemonServiceStartupError,
+  waitForEndpointStopped,
+  waitForReachableStatus
+} from "../../daemon/daemon-service-startup.ts";
 import { renderDaemonHelp } from "./help.ts";
 import { loadDaemonIdentityWithEmail } from "./identity.ts";
 import { runDaemonLogsCommand } from "./logs.ts";
@@ -36,7 +45,6 @@ import type { DaemonCommandInput } from "./command-types.ts";
 import { requireDaemonProductOutputPath } from "./output-path.ts";
 import { daemonSafeId, requiredDaemonOption } from "./productization-options.ts";
 import { installSnapshotCommand, upgradeDaemonSnapshot } from "./snapshot-command.ts";
-import { readDaemonStatusWithGenerationFallback } from "./status-compatibility.ts";
 
 export type { DaemonControlLifecycle } from "./control.ts";
 export type { DaemonCommandInput, DaemonServeHooks } from "./command-types.ts";
@@ -100,7 +108,11 @@ export async function runDaemonProductCommand(input: DaemonCommandInput): Promis
     );
     return 2;
   } catch (error) {
-    emitDaemonError(CliErrorCode.JournalUnavailable, error instanceof Error ? error.message : String(error), input.json);
+    const message = error instanceof Error ? error.message : String(error);
+    const context = error instanceof DaemonServiceStartupError
+      ? error.diagnostic
+      : undefined;
+    emitDaemonError(CliErrorCode.JournalUnavailable, message, input.json, context);
     return 1;
   }
 }
@@ -150,20 +162,24 @@ async function startDaemon(input: DaemonCommandInput): Promise<number> {
       ...launchConfiguration.execArgv,
       launchConfiguration.entrypoint,
       ...launchConfiguration.args
-    ], {
-      detached: true,
-      stdio: "ignore",
-      windowsHide: true,
-      env: daemonServerHostEnvironment(process.env, target)
-    });
-    child.unref();
+    ], { detached: true, stdio: ["ignore", "ignore", "pipe"], windowsHide: true, env: daemonServerHostEnvironment(process.env, target) });
     const launchTarget = {
       ...target,
       socketPath: readOption(launchConfiguration.args, "--socket") ?? target.socketPath
     };
-    const status = daemonStatusForCli(await waitForReachableStatus(launchTarget, 6_000));
-    emitDaemonResult("daemon-start", { ...status, mode: "service", socketPath: launchTarget.socketPath }, input.json);
-    return 0;
+    const launch = observeDaemonServiceLaunch(child, launchTarget.userRoot);
+    try {
+      const status = daemonStatusForCli(await waitForReachableStatus(
+        launchTarget,
+        daemonServiceStartupTimeoutMs(),
+        launch
+      ));
+      launch.stderr.discard();
+      emitDaemonResult("daemon-start", { ...status, mode: "service", socketPath: launchTarget.socketPath }, input.json);
+      return 0;
+    } catch (error) {
+      throw await diagnoseDaemonServiceLaunchFailure(launchTarget, launch, error);
+    }
   }
   return 0;
 }
@@ -421,12 +437,16 @@ async function startBootstrapDaemon(
     ...launchConfiguration.args
   ], {
     detached: true,
-    stdio: "ignore",
+    stdio: ["ignore", "ignore", "pipe"],
     windowsHide: true,
     env: daemonServerHostEnvironment(process.env, target)
   });
-  child.unref();
-  return waitForReachableStatus(target, 6_000);
+  const launch = observeDaemonServiceLaunch(child, target.userRoot);
+  try {
+    return await waitForReachableStatus(target, daemonServiceStartupTimeoutMs(), launch);
+  } catch (error) {
+    throw await diagnoseDaemonServiceLaunchFailure(target, launch, error);
+  }
 }
 
 async function checkSshReachability(host: string, user: string, canonicalRoot: string): Promise<Record<string, unknown>> {
@@ -461,42 +481,6 @@ function readDaemonLock(lockPath: string): Record<string, unknown> {
     ownerKind: lock.ownerKind,
     ownerToken: lock.ownerToken
   };
-}
-
-async function readReachableDaemonStatus(
-  target: LocalDaemonTarget,
-  includeGenerationAxes = false
-): Promise<Record<string, unknown> | undefined> {
-  return readDaemonStatusWithGenerationFallback(includeGenerationAxes, (includeAxes) =>
-    requestLocalDaemonJsonRpc(target.canonicalRoot, "repo.daemon.status", {
-      repo: { repoId: target.repoId },
-      ...(includeAxes ? { includeGenerationAxes: true } : {})
-    }, 1_000, {
-      userRoot: target.userRoot,
-      daemonId: target.daemonId,
-      socketPath: target.socketPath,
-      allowLegacySocket: true
-    })
-  );
-}
-
-async function waitForReachableStatus(target: LocalDaemonTarget, timeoutMs: number): Promise<Record<string, unknown>> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() <= deadline) {
-    const status = await readReachableDaemonStatus(target);
-    if (status) return status;
-    await waitDaemonPollInterval(100);
-  }
-  throw new Error("daemon service did not become reachable before timeout");
-}
-
-async function waitForEndpointStopped(target: LocalDaemonTarget, timeoutMs: number): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() <= deadline) {
-    if (!await readReachableDaemonStatus(target)) return true;
-    await waitDaemonPollInterval(100);
-  }
-  return !await readReachableDaemonStatus(target);
 }
 
 function daemonStatusForCli(status: Record<string, unknown>): Record<string, unknown> {
@@ -541,9 +525,14 @@ function emitDaemonResult(command: string, result: Record<string, unknown>, json
   console.log(parts.join(" "));
 }
 
-function emitDaemonError(code: CliErrorCode, message: string, json: boolean): void {
+function emitDaemonError(
+  code: CliErrorCode,
+  message: string,
+  json: boolean,
+  context?: Readonly<Record<string, unknown>>
+): void {
   if (json) {
-    console.log(JSON.stringify({ ok: false, schema: "daemon-command/v1", command: "daemon", error: cliError(code, message) }));
+    console.log(JSON.stringify({ ok: false, schema: "daemon-command/v1", command: "daemon", error: cliError(code, message, context) }));
     return;
   }
   console.error(`error code=${code} hint=${message}`);
@@ -582,10 +571,6 @@ function daemonAssetPath(relativePath: string): string {
   const found = candidates.find((candidate) => existsSync(candidate));
   if (!found) throw new Error(`daemon asset not found: ${relativePath}`);
   return found;
-}
-
-function waitDaemonPollInterval(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function isDaemonRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/src/daemon/daemon-service-startup.ts
+++ b/packages/cli/src/daemon/daemon-service-startup.ts
@@ -1,0 +1,274 @@
+import { type ChildProcess } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { readDaemonSocketOwner } from "@harness-anything/daemon";
+import { parsePositiveIntegerOr } from "../cli/value-utils.ts";
+import { readDaemonStatusWithGenerationFallback } from "../commands/daemon/status-compatibility.ts";
+import { requestLocalDaemonJsonRpc, type LocalDaemonTarget } from "./client.ts";
+
+const defaultDaemonServiceStartupTimeoutMs = 20_000;
+const maxDaemonServiceStartupTimeoutMs = 120_000;
+const daemonLaunchLogLimitBytes = 64 * 1024;
+
+interface DaemonChildExit {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly error?: string;
+}
+
+export interface BoundedLaunchStderr {
+  readonly append: (chunk: Buffer | string) => void;
+  readonly flush: (reason: string) => void;
+  readonly discard: () => void;
+}
+
+export interface DaemonServiceLaunch {
+  readonly child: ChildProcess;
+  readonly launchLogPath: string;
+  readonly stderr: BoundedLaunchStderr;
+  readonly exit: Promise<DaemonChildExit>;
+  readonly state: { value?: DaemonChildExit };
+}
+
+export class DaemonServiceStartupError extends Error {
+  readonly diagnostic: {
+    readonly childExitCode: number | null;
+    readonly childSignal: NodeJS.Signals | null;
+    readonly launchLogPath: string;
+  };
+
+  constructor(message: string, diagnostic: DaemonServiceStartupError["diagnostic"]) {
+    super(
+      `${message}; child exit code=${String(diagnostic.childExitCode)}`
+      + `${diagnostic.childSignal ? `; child signal=${diagnostic.childSignal}` : ""}`
+      + `; launch log: ${diagnostic.launchLogPath}`
+    );
+    this.name = "DaemonServiceStartupError";
+    this.diagnostic = diagnostic;
+  }
+}
+
+class DaemonServiceStartupTimeoutError extends Error {
+  constructor() {
+    super("daemon service did not become reachable before timeout");
+    this.name = "DaemonServiceStartupTimeoutError";
+  }
+}
+
+class DaemonServiceChildExitBeforeReadinessError extends Error {
+  constructor() {
+    super("daemon service child exited before becoming reachable");
+    this.name = "DaemonServiceChildExitBeforeReadinessError";
+  }
+}
+
+export async function readReachableDaemonStatus(
+  target: LocalDaemonTarget,
+  includeGenerationAxes = false
+): Promise<Record<string, unknown> | undefined> {
+  return readDaemonStatusWithGenerationFallback(includeGenerationAxes, (includeAxes) =>
+    requestLocalDaemonJsonRpc(target.canonicalRoot, "repo.daemon.status", {
+      repo: { repoId: target.repoId },
+      ...(includeAxes ? { includeGenerationAxes: true } : {})
+    }, 1_000, {
+      userRoot: target.userRoot,
+      daemonId: target.daemonId,
+      socketPath: target.socketPath,
+      allowLegacySocket: true
+    })
+  );
+}
+
+export async function waitForReachableStatus(
+  target: LocalDaemonTarget,
+  timeoutMs: number,
+  launch?: DaemonServiceLaunch
+): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    if (launch?.state.value) throw new DaemonServiceChildExitBeforeReadinessError();
+    const status = await readReachableDaemonStatus(target);
+    if (status) return status;
+    if (launch?.state.value) throw new DaemonServiceChildExitBeforeReadinessError();
+    await waitDaemonPollInterval(100);
+  }
+  throw new DaemonServiceStartupTimeoutError();
+}
+
+export function daemonServiceStartupTimeoutMs(): number {
+  return Math.min(
+    maxDaemonServiceStartupTimeoutMs,
+    parsePositiveIntegerOr(
+      process.env.HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS,
+      defaultDaemonServiceStartupTimeoutMs
+    )
+  );
+}
+
+export function observeDaemonServiceLaunch(child: ChildProcess, userRoot: string): DaemonServiceLaunch {
+  const state: { value?: DaemonChildExit } = {};
+  const launchLogPath = path.join(
+    path.resolve(userRoot),
+    "logs",
+    "daemon-startup",
+    `launch-${Date.now()}-${child.pid ?? "unknown"}-${randomBytes(6).toString("hex")}.stderr.log`
+  );
+  const stderr = boundedLaunchStderr(launchLogPath, child.pid);
+  child.stderr?.on("data", (chunk: Buffer | string) => stderr.append(chunk));
+  const unref = (child.stderr as (NodeJS.ReadableStream & { readonly unref?: () => void }) | null)?.unref;
+  unref?.call(child.stderr);
+  child.unref();
+  let resolveExit!: (exit: DaemonChildExit) => void;
+  let settled = false;
+  const exit = new Promise<DaemonChildExit>((resolve) => {
+    resolveExit = resolve;
+  });
+  const settle = (value: DaemonChildExit): void => {
+    if (settled) return;
+    settled = true;
+    state.value = value;
+    resolveExit(value);
+  };
+  child.once("error", (error) => settle({ code: null, signal: null, error: error.message }));
+  child.once("close", (code, signal) => settle({ code, signal }));
+  return { child, launchLogPath, stderr, exit, state };
+}
+
+function boundedLaunchStderr(launchLogPath: string, pid: number | undefined): BoundedLaunchStderr {
+  const chunks: Buffer[] = [];
+  let byteLength = 0;
+  let truncated = false;
+  let accepting = true;
+  return {
+    append: (chunk) => {
+      if (!accepting) return;
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      if (byteLength >= daemonLaunchLogLimitBytes) {
+        truncated = true;
+        return;
+      }
+      const remaining = daemonLaunchLogLimitBytes - byteLength;
+      const bounded = bytes.byteLength <= remaining ? bytes : bytes.subarray(0, remaining);
+      chunks.push(bounded);
+      byteLength += bounded.byteLength;
+      if (bounded.byteLength !== bytes.byteLength) truncated = true;
+    },
+    flush: (reason) => {
+      accepting = false;
+      mkdirSync(path.dirname(launchLogPath), { recursive: true, mode: 0o700 });
+      const header = Buffer.from([
+        "schema=daemon-launch-stderr/v1",
+        `pid=${pid === undefined ? "unknown" : String(pid)}`,
+        `reason=${reason}`,
+        "",
+        ""
+      ].join("\n"), "utf8");
+      const suffix = truncated
+        ? Buffer.from("\n[stderr truncated at 65536 bytes]\n", "utf8")
+        : Buffer.alloc(0);
+      writeFileSync(launchLogPath, Buffer.concat([header, ...chunks, suffix]), { mode: 0o600 });
+    },
+    discard: () => {
+      accepting = false;
+      chunks.length = 0;
+    }
+  };
+}
+
+export async function diagnoseDaemonServiceLaunchFailure(
+  target: LocalDaemonTarget,
+  launch: DaemonServiceLaunch,
+  error: unknown
+): Promise<DaemonServiceStartupError> {
+  const message = error instanceof Error ? error.message : String(error);
+  const timedOut = error instanceof DaemonServiceStartupTimeoutError;
+  if (!launch.state.value) await stopDaemonServiceLaunch(launch);
+  const exit = launch.state.value ?? await waitForDaemonChildExit(launch, 1_000);
+  let cleanupFailure: string | undefined;
+  try {
+    await waitForLaunchedEndpointStopped(target, launch.child.pid);
+  } catch (cleanupError) {
+    cleanupFailure = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+  }
+  launch.stderr.flush(timedOut ? "startup timeout" : "child exited before readiness");
+  const childError = exit?.error ? `; child error=${exit.error}` : "";
+  const cleanupDiagnostic = cleanupFailure ? `; cleanup=${cleanupFailure}` : "";
+  const diagnostic = {
+    childExitCode: exit?.code ?? null,
+    childSignal: exit?.signal ?? null,
+    launchLogPath: launch.launchLogPath
+  } as const;
+  return new DaemonServiceStartupError(`${message}${childError}${cleanupDiagnostic}`, diagnostic);
+}
+
+async function stopDaemonServiceLaunch(launch: DaemonServiceLaunch): Promise<void> {
+  if (launch.state.value || launch.child.pid === undefined) return;
+  signalDaemonServiceProcess(launch, "SIGTERM");
+  if (await waitForDaemonChildExit(launch, 5_000)) return;
+  signalDaemonServiceProcess(launch, "SIGKILL");
+  await waitForDaemonChildExit(launch, 2_000);
+}
+
+async function waitForLaunchedEndpointStopped(
+  target: LocalDaemonTarget,
+  launchedPid: number | undefined
+): Promise<void> {
+  if (launchedPid === undefined) return;
+  const owner = readDaemonSocketOwner(target.socketPath);
+  if (owner?.pid !== launchedPid) return;
+  if (!await waitForEndpointStopped(target, 5_000)) {
+    throw new Error(`daemon service child pid ${launchedPid} exited but its endpoint remained reachable`);
+  }
+}
+
+async function waitForDaemonChildExit(
+  launch: DaemonServiceLaunch,
+  timeoutMs: number
+): Promise<DaemonChildExit | undefined> {
+  if (launch.state.value) return launch.state.value;
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(undefined), timeoutMs);
+    launch.exit.then((exit) => {
+      clearTimeout(timer);
+      resolve(exit);
+    });
+  });
+}
+
+function signalDaemonServiceProcess(launch: DaemonServiceLaunch, signal: NodeJS.Signals): void {
+  const pid = launch.child.pid;
+  if (pid === undefined) return;
+  if (process.platform !== "win32") {
+    try {
+      process.kill(-pid, signal);
+      return;
+    } catch (error) {
+      if (processErrorCode(error) === "ESRCH") return;
+    }
+  }
+  try {
+    launch.child.kill(signal);
+  } catch (error) {
+    if (processErrorCode(error) !== "ESRCH") throw error;
+  }
+}
+
+export async function waitForEndpointStopped(target: LocalDaemonTarget, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    if (!await readReachableDaemonStatus(target)) return true;
+    await waitDaemonPollInterval(100);
+  }
+  return !await readReachableDaemonStatus(target);
+}
+
+function waitDaemonPollInterval(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function processErrorCode(error: unknown): unknown {
+  return error && typeof error === "object" && "code" in error
+    ? (error as { readonly code?: unknown }).code
+    : undefined;
+}

--- a/packages/cli/test/daemon-service-startup-diagnostics.test.ts
+++ b/packages/cli/test/daemon-service-startup-diagnostics.test.ts
@@ -1,0 +1,116 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { createFixture } from "./production-authority-canonical-ingress/fixture.ts";
+import {
+  delay,
+  pollUntil,
+  runRawJsonAsync,
+  runRawJsonMaybeFail,
+  stopDaemon
+} from "./helpers/daemon-cli.ts";
+
+test("service startup persists child stderr and reports the exit code and log path", { timeout: 45_000 }, async () => {
+  const fixture = createFixture();
+  const firstUserRoot = path.join(fixture.root, "first-user");
+  const blockedUserRoot = path.join(fixture.root, "blocked-user");
+  const lockPath = path.join(fixture.repoRoot, ".harness/locks/global.lock");
+  const first = runRawJsonAsync(
+    fixture.repoRoot,
+    ["daemon", "start", "--foreground", "--user-root", firstUserRoot, "--authority-manifest", fixture.manifestPath],
+    daemonEnv(firstUserRoot)
+  );
+  try {
+    await pollUntil(
+      () => existsSync(lockPath),
+      (exists) => exists,
+      (exists, error) => JSON.stringify({ lockPath, exists, error: String(error ?? "") }),
+      { timeoutMs: 20_000 }
+    );
+    const failed = runRawJsonMaybeFail(
+      fixture.repoRoot,
+      ["daemon", "start", "--service", "--user-root", blockedUserRoot, "--authority-manifest", fixture.manifestPath],
+      daemonEnv(blockedUserRoot)
+    );
+    assert.notEqual(failed.status, 0, JSON.stringify(failed.receipt));
+    const error = failed.receipt.error as { readonly context?: Record<string, unknown>; readonly hint?: string };
+    assert.equal(error.context?.childExitCode, 1, JSON.stringify(failed.receipt));
+    const logPath = requireLaunchLogPath(error.context?.launchLogPath, blockedUserRoot);
+    assert.match(error.hint ?? "", /child exit code=1/u);
+    assert.match(error.hint ?? "", new RegExp(`launch log: ${escapeRegExp(logPath)}$`, "u"));
+    assert.match(readFileSync(logPath, "utf8"), /DAEMON_REPO_LOCK_SET_CONFLICT/u);
+  } finally {
+    await stopDaemon(fixture.repoRoot, firstUserRoot).catch(() => undefined);
+    await first.catch(() => undefined);
+  }
+});
+
+test("service startup timeout stops a delayed child before it can publish a lock", { timeout: 45_000 }, async () => {
+  const fixture = createFixture();
+  const userRoot = path.join(fixture.root, "slow-user");
+  const lockPath = path.join(fixture.repoRoot, ".harness/locks/global.lock");
+  const preloadPath = path.join(fixture.root, "slow-start-preload.mjs");
+  writeFileSync(preloadPath, [
+    'if (process.env.HARNESS_DAEMON_SERVER_HOST === "1") {',
+    '  const delayMs = Number.parseInt(process.env.HARNESS_DIAGNOSTIC_START_DELAY_MS ?? "0", 10);',
+    '  if (Number.isSafeInteger(delayMs) && delayMs > 0) {',
+    '    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);',
+    "  }",
+    "}",
+    ""
+  ].join("\n"), "utf8");
+  try {
+    const failed = runRawJsonMaybeFail(
+      fixture.repoRoot,
+      ["daemon", "start", "--service", "--user-root", userRoot, "--authority-manifest", fixture.manifestPath],
+      daemonEnv(userRoot, {
+        HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "1000",
+        HARNESS_DIAGNOSTIC_START_DELAY_MS: "8000",
+        NODE_OPTIONS: `--import=${preloadPath}`
+      })
+    );
+    assert.notEqual(failed.status, 0, JSON.stringify(failed.receipt));
+    const error = failed.receipt.error as { readonly context?: Record<string, unknown>; readonly hint?: string };
+    assert.equal(error.context?.childExitCode, null, JSON.stringify(failed.receipt));
+    const logPath = requireLaunchLogPath(error.context?.launchLogPath, userRoot);
+    assert.match(error.hint ?? "", /child exit code=null/u);
+    assert.match(error.hint ?? "", new RegExp(`launch log: ${escapeRegExp(logPath)}$`, "u"));
+    await delay(2_500);
+    const status = runRawJsonMaybeFail(
+      fixture.repoRoot,
+      ["daemon", "status", "--user-root", userRoot],
+      daemonEnv(userRoot)
+    );
+    assert.equal(status.receipt.reachable, false, JSON.stringify(status.receipt));
+    assert.equal(existsSync(lockPath), false, `startup timeout left lock: ${lockPath}`);
+    assert.equal(readFileSync(logPath, "utf8").includes("startup timeout"), true);
+  } finally {
+    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+  }
+});
+
+function daemonEnv(userRoot: string, overrides: Readonly<Record<string, string>> = {}): Record<string, string> {
+  return {
+    HARNESS_DAEMON_MODE: "local",
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_IDLE_MS: "60000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
+    HARNESS_DAEMON_REQUEST_TIMEOUT_MS: "35000",
+    ...overrides
+  };
+}
+
+function requireLaunchLogPath(value: unknown, userRoot: string): string {
+  assert.equal(typeof value, "string", JSON.stringify({ value, userRoot }));
+  const logPath = value as string;
+  const relative = path.relative(path.resolve(userRoot), path.resolve(logPath));
+  assert.equal(relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative)), true, logPath);
+  assert.equal(existsSync(logPath), true, logPath);
+  return logPath;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}

--- a/packages/cli/test/production-authority-host-services/fixtures/batch5a-parent-differential.json
+++ b/packages/cli/test/production-authority-host-services/fixtures/batch5a-parent-differential.json
@@ -1,17 +1,5 @@
 {
   "baselineCommit": "b4db87f72675b78e2dc1f25b803d183610942fa9",
-  "baselineImplementationBlobs": {
-    "packages/cli/src/cli/command-semantic-normalizer.ts": "714a6822fa65957f83c5136bcc19e32252b07e46",
-    "packages/cli/src/cli/command-spec/index.ts": "202dea76b5114628fb98767a0da57f333aad1a42",
-    "packages/cli/src/cli/decision-propose-normalizer.ts": "9855cbd743297bf74506b8964f1e84f9e015ff16",
-    "packages/cli/src/commands/core/decision-propose.ts": "8b97336df933154a9b6bc7c85b92728ec33459ae",
-    "packages/cli/src/commands/core/decision-relate.ts": "22b3eff78b8115c6c97e870d0218b6f779064dca",
-    "packages/cli/src/commands/core/decision-relation-record.ts": "b802dcbb858030d86d40e2b928750afd7150d239",
-    "packages/cli/src/commands/daemon/productization.ts": "565a8eb9ebc5ddf5de9c631154088d30c0bc9476",
-    "packages/cli/src/commands/preset-task.ts": "cd7bb2b01ddad1c4ee2d8f3b49bf067e1bf597a8",
-    "packages/cli/src/commands/settings.ts": "dcc83b0f0775494d4f6d7326aaa7285d5f67b619",
-    "packages/cli/src/composition/adapter-registry.ts": "8c0be49785f847e0e26e8f0c1a5e661f5c5d17df"
-  },
   "adapterE2E": {
     "generic": {
       "envelope": {

--- a/packages/cli/test/production-authority-host-services/golden.test.ts
+++ b/packages/cli/test/production-authority-host-services/golden.test.ts
@@ -1,6 +1,5 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
-import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 import { toCliError } from "../../src/cli/error-mapper.ts";
@@ -19,7 +18,6 @@ test("all injected production authority host branches match the parent-commit by
   }
   const fixture = JSON.parse(readFileSync(fixtureUrl, "utf8")) as {
     readonly baselineCommit: string;
-    readonly baselineImplementationBlobs: Readonly<Record<string, string>>;
     readonly hostServices: unknown;
   };
   assert.equal(fixture.baselineCommit, "b4db87f72675b78e2dc1f25b803d183610942fa9");
@@ -28,12 +26,6 @@ test("all injected production authority host branches match the parent-commit by
     JSON.stringify(actual),
     JSON.stringify(captureProductionAuthorityHostEquivalence(directProductionAuthorityHostServices))
   );
-  const repoRoot = new URL("../../../../", import.meta.url);
-  for (const [sourcePath, expectedBlobId] of Object.entries(fixture.baselineImplementationBlobs)) {
-    const bytes = readFileSync(new URL(sourcePath, repoRoot));
-    const header = Buffer.from(`blob ${bytes.byteLength}\0`);
-    assert.equal(createHash("sha1").update(header).update(bytes).digest("hex"), expectedBlobId, sourcePath);
-  }
 });
 
 test("structured daemon unsupported-command data retains the CLI receipt bytes", () => {


### PR DESCRIPTION
# English

## Summary

Retire the production-authority golden's source-blob anchor now that the cutover it evidenced is complete and irreversible, and deliver the two friction items that anchor had been blocking: service-mode startup failures left no evidence on disk (#17), and a hardcoded 6s readiness budget misreported slow-but-healthy startups as failures (#18).

## What Changed

- `production-authority-host-services/golden.test.ts`: removed the `baselineImplementationBlobs` loop that pinned a set of source files by git blob hash. Both behavior-equivalence assertions and the `baselineCommit` assertion are retained unchanged.
- New `packages/cli/src/daemon/daemon-service-startup.ts`: bounded (64 KiB) child-stderr capture for service and bootstrap launches, flushed to a mode-restricted log under `<userRoot>/logs/daemon-startup/` on startup failure and discarded on success. Failure receipts now carry child exit code/signal and the launch-log path in structured context and in the human-readable hint.
- `packages/cli/src/commands/daemon/productization.ts`: the two hardcoded `6_000` readiness waits are replaced by a shared startup budget (default `20_000 ms`, configurable via `HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS`, capped at `120_000 ms`). On timeout the detached child is terminated as a process group (`SIGTERM`, then a bounded `SIGKILL` fallback), endpoint ownership is checked, and readiness/lock cleanup is verified before the failure receipt is returned.

## Task And Scope

Scope is exactly the three items above. No other golden, workflow, gate manifest, or branch-protection surface is touched. Normal daemon stop/control semantics are unchanged. The `daemon_build_stale` and `daemon_build_identity_unavailable` receipt shapes are untouched.

## Version Impact

No published package API change. Behavior change is limited to the daemon service/bootstrap startup path: the default readiness budget rises from 6s to 20s, and startup failures now write a diagnostic log file under the user root.

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `packages/cli/test/production-authority-host-services/golden.test.ts` and its fixture — removal of the `baselineImplementationBlobs` source-blob pin.
- Authority: decision `dec_01KZ682PQRF8E1QE5RP83NZ86Z` (retire the blob anchor together with the cutover it evidenced; retain both behavior-equivalence assertions), implemented by task `task_01KZ6848ZHAXKQVFE167WXVXAW`, which that decision derives.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Positive control for the retained gate (required by the task's checkpoint): the captured host-services object was cloned and its `new-task` ingress result was intentionally corrupted. Both retained assertions failed — the fixture comparison and the direct-equivalence comparison. Behavior drift still turns this gate red without the blob anchor, so the decision's premise holds.
- Red-green evidence was recorded before implementing the two diagnostics tests: the lock-conflict case initially carried no exit-code context; the delayed-start case initially carried no timeout context and left the child and its repo lock alive.
- `node --test packages/cli/test/production-authority-host-services/golden.test.ts packages/cli/test/daemon-service-startup-diagnostics.test.ts`: 5/5 pass.
- `npm run typecheck`: exit 0. `npm run lint`: exit 0.
- `npm run check:local`: exit 0 — 27 manifest gates, changed-file lint, 415 fast tests, 90 contract tests.
- `node tools/run-node-tests.mjs --tier integration`: exit 0 — 1,481 tests, 1,477 passed, 0 failed, 4 skipped. The full integration tier was the stop point for this task because it touches daemon startup timing, where a targeted-tests-only stop point let a regression through on a recent PR.

## Review Evidence

CEO review, performed against the diff rather than the report:

- Confirmed the golden diff removes only the blob loop, its type field, and the now-unused `createHash` import; both behavior-equivalence assertions and `baselineCommit` are byte-identical to before.
- Confirmed no CI, workflow, gate-manifest, or branch-protection path appears in the changed-file set.
- Confirmed the process-group termination cannot reach an unrelated daemon: the negated pid is the task's own `detached` child (hence its own group leader), the call is skipped once the child's exit has been observed, `ESRCH` is swallowed, and `waitForLaunchedEndpointStopped` returns immediately unless the endpoint owner's pid equals the launched child's pid.
- Confirmed the startup log is written with directory mode `0o700` and file mode `0o600`.

## Residual Risk

- `HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS` now has three readers with two different fallbacks: CLI autostart and restart-replacement both fall back to 6s, while the service/bootstrap path introduced here falls back to 20s. Setting the variable unifies all three; leaving it unset does not. Widening this PR to the other two readers was deliberately declined — the restart path's 6s expiry is load-bearing for the settling window added in #1200, so changing it belongs in its own slice with that interaction in scope.
- `#17` bounds the captured stderr at 64 KiB; a failure whose useful output exceeds that is truncated, marked as truncated, but not recoverable from the log alone.
- The 20s default is a budget, not a guarantee. A repository slow enough to exceed it still produces a failure receipt — now a correct one, with the child stopped and its lock released.

## References

- Decision `dec_01KZ682PQRF8E1QE5RP83NZ86Z`
- Task `task_01KZ6848ZHAXKQVFE167WXVXAW`
- Friction items #17 and #18, deferred as blockers by PR #1223

# 中文

## 概要

产线 authority golden 中的 source-blob 锚所证明的那次 cutover 已完成且不可逆，本 PR 将该锚退役，并交付此前被它挡住的两条摩擦项：service 模式启动失败在磁盘上不留任何证据（#17）；硬编码的 6 秒就绪预算把「慢但健康」的启动误报为失败（#18）。

## 改动内容

- `production-authority-host-services/golden.test.ts`：删除按 git blob hash 钉死一组源文件的 `baselineImplementationBlobs` 循环。两条行为等价断言与 `baselineCommit` 断言原样保留。
- 新增 `packages/cli/src/daemon/daemon-service-startup.ts`：service 与 bootstrap 启动的子进程 stderr 有界捕获（64 KiB），启动失败时落到 `<userRoot>/logs/daemon-startup/` 下的受限权限日志，成功则丢弃。失败回执现在在结构化上下文与人读 hint 中同时带上子进程 exit code / signal 与该日志路径。
- `packages/cli/src/commands/daemon/productization.ts`：两处硬编码的 `6_000` 就绪等待改为共享启动预算（默认 `20_000 ms`，可经 `HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS` 配置，上限 `120_000 ms`）。超时后按进程组终止 detached 子进程（`SIGTERM`，再有界 `SIGKILL` 兜底），检查 endpoint 归属，并在返回失败回执前核实就绪状态与锁已清理。

## 任务与范围

范围严格限于上述三项。未触碰其他 golden、workflow、gate manifest 或分支保护面。daemon 常规 stop/control 语义未变。`daemon_build_stale` 与 `daemon_build_identity_unavailable` 的回执形状未动。

## 版本影响

无已发布包 API 变更。行为变更限于 daemon service/bootstrap 启动路径：默认就绪预算由 6 秒提高到 20 秒；启动失败时会在 user root 下写一份诊断日志文件。

## 治理声明

- 触碰 protected surface：是
- Protected surface 范围：`packages/cli/test/production-authority-host-services/golden.test.ts` 及其 fixture —— 删除 `baselineImplementationBlobs` 源文件 blob 锚。
- 依据：裁决 `dec_01KZ682PQRF8E1QE5RP83NZ86Z`（blob 锚随其所证明的 cutover 一并退役，两条行为等价断言保留），由该裁决派生的任务 `task_01KZ6848ZHAXKQVFE167WXVXAW` 实施。
- 机器检查边界：本 PR 仅断言声明存在；声明是否属实与充分由评审者判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 保留门的阳性对照（任务 checkpoint 的硬要求）：克隆捕获到的 host-services 对象并故意改坏其 `new-task` ingress 结果，两条保留断言**双双变红**——fixture 比对与直接等价比对都失败。说明去掉 blob 锚后行为漂移仍会让这道门红，裁决前提成立。
- 两个诊断测试在实现前留有红绿对照证据：锁冲突用例原先不带 exit-code 上下文；延迟启动用例原先不带超时上下文，且会留下活着的子进程与未归还的仓锁。
- `node --test packages/cli/test/production-authority-host-services/golden.test.ts packages/cli/test/daemon-service-startup-diagnostics.test.ts`：5/5 通过。
- `npm run typecheck`：exit 0。`npm run lint`：exit 0。
- `npm run check:local`：exit 0 —— 27 个 manifest gate、改动文件 lint、415 个 fast 测试、90 个 contract 测试。
- `node tools/run-node-tests.mjs --tier integration`：exit 0 —— 1,481 个测试，1,477 通过，0 失败，4 跳过。本任务把完整 integration tier 作为停止点，因为它改的是 daemon 启动时序；近期一个 PR 正是因为只跑定向测试而漏掉了一条该层回归。

## 审查证据

CEO 复核，对着 diff 做而非采信报告：

- 确认 golden 的 diff 只删掉了 blob 循环、其类型字段与因此不再使用的 `createHash` import；两条行为等价断言与 `baselineCommit` 与改动前逐字节相同。
- 确认改动文件集中不出现任何 CI、workflow、gate-manifest 或分支保护路径。
- 确认进程组终止不可能波及无关 daemon：取负的 pid 是本任务自己 `detached` 拉起的子进程（因而它就是自己进程组的组长）；一旦观察到子进程已退出便跳过发信号；`ESRCH` 被吞掉；且 `waitForLaunchedEndpointStopped` 仅在 endpoint 持有者 pid 等于自己拉起的子进程 pid 时才继续，否则立即返回。
- 确认启动日志以目录 `0o700`、文件 `0o600` 权限写入。

## 残余风险

- `HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS` 现在有三个读取点、两套 fallback：CLI autostart 与 restart 替身启动都回落到 6 秒，而本 PR 引入的 service/bootstrap 路径回落到 20 秒。设了该变量则三处统一，不设则不统一。**刻意没有**把本 PR 扩大到另外两个读取点——restart 路径的 6 秒到点是 #1200 所加 settling 观察窗的承重前提，改它应当连同该交互一起单独成片。
- `#17` 的 stderr 捕获上限为 64 KiB；有用输出超过该上限的失败会被截断，截断有标记，但仅凭日志无法还原被截掉的部分。
- 20 秒默认值是预算不是保证。慢到超过它的仓库仍会得到失败回执——但那是一个正确的失败：子进程已停止，锁已归还。

## 关联材料

- 裁决 `dec_01KZ682PQRF8E1QE5RP83NZ86Z`
- 任务 `task_01KZ6848ZHAXKQVFE167WXVXAW`
- 摩擦项 #17 与 #18，由 PR #1223 记为 blocker 延后

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
