### PR TITLE
refactor(daemon): derive parent and child write phases from one transition table (PLT-Steady-Transport anchor 3)

### DIFF
--- a/packages/daemon/src/runtime/repo-write-child-host-response.ts
+++ b/packages/daemon/src/runtime/repo-write-child-host-response.ts
@@ -1,0 +1,73 @@
+import type { RepoWriteChildResponseWriter } from "./repo-write-child-response-writer.ts";
+import type { RepoWriteHostedOperationSnapshot } from "./repo-write-child-lookup.ts";
+
+export interface RepoWriteChildOperationResponseState {
+  readonly requestId: string;
+  readonly opId?: string;
+  readonly state: RepoWriteHostedOperationSnapshot;
+}
+
+export async function sendRepoWriteDuplicateSubmit(
+  responses: RepoWriteChildResponseWriter,
+  operation: RepoWriteChildOperationResponseState
+): Promise<void> {
+  if (operation.opId && ["proceeding", "terminal", "unknown"].includes(operation.state.phase)) {
+    await responses.unknown(
+      operation.requestId,
+      operation.opId,
+      "DUPLICATE_REQUEST",
+      "request already crossed the proceed boundary"
+    );
+    return;
+  }
+  await responses.notStarted(
+    operation.requestId,
+    "DUPLICATE_REQUEST",
+    "requestId is already admitted",
+    operation.opId
+  );
+}
+
+export async function sendRepoWriteRejectedProceed(
+  responses: RepoWriteChildResponseWriter,
+  operation: RepoWriteChildOperationResponseState | undefined,
+  requestId: string,
+  code: string,
+  diagnostic: string
+): Promise<void> {
+  if (operation?.opId && ["proceeding", "terminal", "unknown"].includes(operation.state.phase)) {
+    await responses.unknown(requestId, operation.opId, code, diagnostic);
+    return;
+  }
+  await responses.notStarted(requestId, code, diagnostic, operation?.opId);
+}
+
+export async function sendRepoWriteRepeatedProceed(
+  responses: RepoWriteChildResponseWriter,
+  operation: RepoWriteChildOperationResponseState
+): Promise<void> {
+  if (operation.state.phase === "terminal") {
+    await responses.terminal(
+      operation.requestId,
+      operation.opId!,
+      operation.state.outcome,
+      operation.state.receipt
+    );
+    return;
+  }
+  if (operation.state.phase === "proceeding" || operation.state.phase === "unknown") {
+    await responses.unknown(
+      operation.requestId,
+      operation.opId!,
+      "DUPLICATE_PROCEED",
+      "operation already crossed the proceed boundary"
+    );
+    return;
+  }
+  await responses.notStarted(
+    operation.requestId,
+    operation.state.phase === "preparing" ? "NOT_PREPARED" : "OPERATION_NOT_PROCEEDABLE",
+    "operation is not in prepared state",
+    operation.opId
+  );
+}

--- a/packages/daemon/src/runtime/repo-write-child-host.ts
+++ b/packages/daemon/src/runtime/repo-write-child-host.ts
@@ -10,11 +10,16 @@ import {
 import {
   repoWriteCanonicalLookupResult,
   repoWriteLocalLookupResult,
-  type RepoWriteHostedOperationPhase
+  type RepoWriteHostedOperationSnapshot
 } from "./repo-write-child-lookup.ts";
 import {
   RepoWriteChildResponseWriter
 } from "./repo-write-child-response-writer.ts";
+import {
+  sendRepoWriteDuplicateSubmit,
+  sendRepoWriteRejectedProceed,
+  sendRepoWriteRepeatedProceed
+} from "./repo-write-child-host-response.ts";
 import { RepoWriteExecutionSequencer } from "./repo-write-execution-sequencer.ts";
 import {
   executeRepoWriteChildDirect
@@ -38,6 +43,7 @@ import type {
   RepoWriteChildHostOptions,
   RepoWritePreparedOperation
 } from "./repo-write-child-contract.ts";
+import { advanceRepoWritePhase } from "./repo-write-phase.ts";
 
 export type { RepoWriteChildTransport } from "./repo-write-child-response-writer.ts";
 export type { RepoWriteDirectInput } from "./repo-write-child-direct.ts";
@@ -53,10 +59,9 @@ export type {
 
 interface HostedOperation {
   readonly requestId: string;
-  phase: RepoWriteHostedOperationPhase;
+  state: RepoWriteHostedOperationSnapshot;
   opId?: string;
   execute?: RepoWritePreparedOperation["execute"];
-  receipt?: RepoWriteJsonObject;
   telemetry?: RepoWriteTelemetryDelivery;
   admitted: boolean;
   cancelledBeforeProceed?: boolean;
@@ -165,7 +170,7 @@ export class RepoWriteChildHost {
     }
     const existing = this.operationsByRequest.get(message.requestId);
     if (existing) {
-      await this.sendDuplicateSubmit(existing);
+      await sendRepoWriteDuplicateSubmit(this.responses, existing);
       return;
     }
     if (!this.admissionOpen) {
@@ -187,7 +192,7 @@ export class RepoWriteChildHost {
 
     const operation: HostedOperation = {
       requestId: message.requestId,
-      phase: "preparing",
+      state: { phase: advanceRepoWritePhase("child", "submit", null) },
       admitted: true
     };
     this.operationsByRequest.set(message.requestId, operation);
@@ -212,7 +217,7 @@ export class RepoWriteChildHost {
       if (!prepared.opId.trim()) throw new Error("prepare returned an empty opId");
       operation.opId = prepared.opId;
       if (this.operationsById.has(prepared.opId)) {
-        operation.phase = "failed";
+        operation.state = { phase: advanceRepoWritePhase("child", "not-started", "preparing") };
         await this.closeTelemetry(operation);
         this.release(operation);
         await this.responses.notStarted(
@@ -225,7 +230,7 @@ export class RepoWriteChildHost {
       }
       this.operationsById.set(prepared.opId, operation);
       if (!this.admissionOpen) {
-        operation.phase = "failed";
+        operation.state = { phase: advanceRepoWritePhase("child", "not-started", "preparing") };
         await this.closeTelemetry(operation);
         this.release(operation);
         await this.responses.notStarted(
@@ -237,11 +242,13 @@ export class RepoWriteChildHost {
         return;
       }
       operation.execute = () => executeRepoWriteChildWithTelemetry(telemetry, prepared.execute);
-      operation.phase = "prepared";
+      operation.state = { phase: advanceRepoWritePhase("child", "prepared", "preparing") };
       await this.responses.prepared(message.requestId, prepared.opId);
     } catch (error) {
-      if (operation.phase === "preparing") {
-        operation.phase = "failed";
+      if (operation.state.phase === "preparing") {
+        operation.state = {
+          phase: advanceRepoWritePhase("child", "not-started", operation.state.phase)
+        };
         await this.closeTelemetry(operation);
         this.release(operation);
         const rejection = classifyRepoWriteNotStartedFailure(error);
@@ -251,8 +258,10 @@ export class RepoWriteChildHost {
           rejection?.diagnostic ?? error,
           operation.opId
         );
-      } else if (operation.phase === "prepared") {
-        operation.phase = "failed";
+      } else if (operation.state.phase === "prepared") {
+        operation.state = {
+          phase: advanceRepoWritePhase("child", "not-started", operation.state.phase)
+        };
         await this.closeTelemetry(operation);
         this.release(operation);
         throw error;
@@ -268,7 +277,13 @@ export class RepoWriteChildHost {
     const operation = this.operationsByRequest.get(message.requestId);
     const boundaryError = this.boundaryError(message);
     if (boundaryError) {
-      await this.sendRejectedProceed(operation, message.requestId, boundaryError, "proceed rejected by capsule boundary");
+      await sendRepoWriteRejectedProceed(
+        this.responses,
+        operation,
+        message.requestId,
+        boundaryError,
+        "proceed rejected by capsule boundary"
+      );
       return;
     }
     if (!operation) {
@@ -276,12 +291,20 @@ export class RepoWriteChildHost {
       return;
     }
     if (operation.opId !== message.opId) {
-      await this.sendRejectedProceed(operation, message.requestId, "OP_ID_MISMATCH", "proceed opId does not match prepared opId");
+      await sendRepoWriteRejectedProceed(
+        this.responses,
+        operation,
+        message.requestId,
+        "OP_ID_MISMATCH",
+        "proceed opId does not match prepared opId"
+      );
       return;
     }
-    if (!this.admissionOpen && (operation.phase === "prepared" || operation.cancelledBeforeProceed)) {
-      if (operation.phase === "prepared") {
-        operation.phase = "failed";
+    if (!this.admissionOpen && (operation.state.phase === "prepared" || operation.cancelledBeforeProceed)) {
+      if (operation.state.phase === "prepared") {
+        operation.state = {
+          phase: advanceRepoWritePhase("child", "shutdown-before-proceed", operation.state.phase)
+        };
         operation.cancelledBeforeProceed = true;
         await this.closeTelemetry(operation);
         this.release(operation);
@@ -294,12 +317,12 @@ export class RepoWriteChildHost {
       );
       return;
     }
-    if (operation.phase !== "prepared") {
-      await this.sendRepeatedProceed(operation);
+    if (operation.state.phase !== "prepared") {
+      await sendRepoWriteRepeatedProceed(this.responses, operation);
       return;
     }
 
-    operation.phase = "proceeding";
+    operation.state = { phase: advanceRepoWritePhase("child", "proceed", operation.state.phase) };
     try {
       let receipt: RepoWriteJsonObject;
       try {
@@ -314,10 +337,16 @@ export class RepoWriteChildHost {
         }
         assertRepoWriteOutcomeAxesV1(durableOutcome, this.outcomeAxes());
         receipt = durableOutcome.receipt as unknown as RepoWriteJsonObject;
-        operation.phase = durableOutcome.terminalKind;
+        operation.state = {
+          phase: advanceRepoWritePhase("child", "terminal", "proceeding"),
+          outcome: durableOutcome.terminalKind,
+          receipt
+        };
       } catch (error) {
         await this.closeTelemetry(operation);
-        operation.phase = "unknown";
+        operation.state = {
+          phase: advanceRepoWritePhase("child", "outcome-unknown", "proceeding")
+        };
         this.release(operation);
         await this.responses.unknown(
           operation.requestId,
@@ -327,15 +356,18 @@ export class RepoWriteChildHost {
         );
         return;
       }
-      operation.receipt = receipt;
       operation.telemetry?.reportCurrent("child-terminal-response");
       await this.closeTelemetry(operation);
       this.release(operation);
+      if (operation.state.phase !== "terminal") {
+        throw new Error("terminal repo writer operation did not retain its terminal result");
+      }
+      const terminal = operation.state;
       await this.responses.terminal(
         operation.requestId,
         operation.opId!,
-        operation.phase,
-        operation.receipt
+        terminal.outcome,
+        terminal.receipt
       );
     } finally {
       await this.maybeCompleteShutdown();
@@ -378,7 +410,7 @@ export class RepoWriteChildHost {
       );
       const local = this.operationsById.get(message.opId);
       const result = canonical.state === "not-found" && local
-        ? repoWriteLocalLookupResult(local)
+        ? repoWriteLocalLookupResult(local.state)
         : repoWriteCanonicalLookupResult(canonical, message.opId, this.outcomeAxes());
       await this.responses.status(message.requestId, message.opId, result);
     } catch (error) {
@@ -435,8 +467,10 @@ export class RepoWriteChildHost {
 
     const cancelled: HostedOperation[] = [];
     for (const operation of this.operationsByRequest.values()) {
-      if (operation.phase !== "prepared") continue;
-      operation.phase = "failed";
+      if (operation.state.phase !== "prepared") continue;
+      operation.state = {
+        phase: advanceRepoWritePhase("child", "shutdown-before-proceed", operation.state.phase)
+      };
       operation.cancelledBeforeProceed = true;
       await this.closeTelemetry(operation);
       this.release(operation);
@@ -458,64 +492,6 @@ export class RepoWriteChildHost {
     operation.telemetry?.close();
   }
 
-  private async sendDuplicateSubmit(operation: HostedOperation): Promise<void> {
-    if (operation.opId && ["proceeding", "committed", "rejected", "unknown"].includes(operation.phase)) {
-      await this.responses.unknown(
-        operation.requestId,
-        operation.opId,
-        "DUPLICATE_REQUEST",
-        "request already crossed the proceed boundary"
-      );
-      return;
-    }
-    await this.responses.notStarted(
-      operation.requestId,
-      "DUPLICATE_REQUEST",
-      "requestId is already admitted",
-      operation.opId
-    );
-  }
-
-  private async sendRejectedProceed(
-    operation: HostedOperation | undefined,
-    requestId: string,
-    code: string,
-    diagnostic: string
-  ): Promise<void> {
-    if (operation?.opId && ["proceeding", "committed", "rejected", "unknown"].includes(operation.phase)) {
-      await this.responses.unknown(requestId, operation.opId, code, diagnostic);
-      return;
-    }
-    await this.responses.notStarted(requestId, code, diagnostic, operation?.opId);
-  }
-
-  private async sendRepeatedProceed(operation: HostedOperation): Promise<void> {
-    if ((operation.phase === "committed" || operation.phase === "rejected") && operation.receipt) {
-      await this.responses.terminal(
-        operation.requestId,
-        operation.opId!,
-        operation.phase,
-        operation.receipt
-      );
-      return;
-    }
-    if (operation.phase === "proceeding" || operation.phase === "unknown") {
-      await this.responses.unknown(
-        operation.requestId,
-        operation.opId!,
-        "DUPLICATE_PROCEED",
-        "operation already crossed the proceed boundary"
-      );
-      return;
-    }
-    await this.responses.notStarted(
-      operation.requestId,
-      operation.phase === "preparing" ? "NOT_PREPARED" : "OPERATION_NOT_PROCEEDABLE",
-      "operation is not in prepared state",
-      operation.opId
-    );
-  }
-
   private boundaryError(message: RepoWriteParentMessage): string | undefined {
     if (message.repoId !== this.options.repoId) return "REPO_MISMATCH";
     if (message.generation !== this.options.generation) return "STALE_GENERATION";
@@ -531,7 +507,7 @@ export class RepoWriteChildHost {
   private hasUnsettledOperations(): boolean {
     if (this.activeLookups > 0 || this.activeAdmissions > 0) return true;
     for (const operation of this.operationsByRequest.values()) {
-      if (operation.phase === "preparing" || operation.phase === "prepared" || operation.phase === "proceeding") {
+      if (operation.state.phase === "preparing" || operation.state.phase === "prepared" || operation.state.phase === "proceeding") {
         return true;
       }
     }

--- a/packages/daemon/src/runtime/repo-write-child-lookup.ts
+++ b/packages/daemon/src/runtime/repo-write-child-lookup.ts
@@ -8,9 +8,49 @@ import type {
   RepoWriteOperationLookupResult,
   RepoWriteTerminalOutcome
 } from "./repo-write-protocol.ts";
+import type { RepoWriteChildOperationPhase } from "./repo-write-phase.ts";
 
-export type RepoWriteHostedOperationPhase =
-  "preparing" | "prepared" | "proceeding" | RepoWriteTerminalOutcome | "failed" | "unknown";
+export type RepoWriteHostedOperationPhase = RepoWriteChildOperationPhase;
+export type RepoWriteHostedOperationNonTerminalPhase = Exclude<
+  RepoWriteHostedOperationPhase,
+  "terminal"
+>;
+
+export type RepoWriteHostedOperationSnapshot =
+  | { readonly phase: RepoWriteHostedOperationNonTerminalPhase }
+  | {
+      readonly phase: "terminal";
+      readonly outcome: RepoWriteTerminalOutcome;
+      readonly receipt: RepoWriteJsonObject;
+    };
+
+type RepoWriteAssertTrue<Value extends true> = Value;
+type RepoWriteTerminalSnapshot = Extract<RepoWriteHostedOperationSnapshot, { phase: "terminal" }>;
+type RepoWriteTerminalSnapshotOutcomeIsRequired =
+  object extends Pick<RepoWriteTerminalSnapshot, "outcome"> ? false : true;
+type _RepoWriteTerminalSnapshotMustCarryOutcome =
+  RepoWriteAssertTrue<RepoWriteTerminalSnapshotOutcomeIsRequired>;
+
+export function repoWriteHostedOperationSnapshot(operation: {
+  readonly phase: RepoWriteHostedOperationPhase;
+  readonly outcome?: RepoWriteTerminalOutcome;
+  readonly receipt?: RepoWriteJsonObject;
+}): RepoWriteHostedOperationSnapshot {
+  if (operation.phase === "terminal") {
+    if (operation.outcome === undefined || operation.receipt === undefined) {
+      throw new Error("terminal repo writer operation is missing its outcome or receipt");
+    }
+    return {
+      phase: "terminal",
+      outcome: operation.outcome,
+      receipt: operation.receipt
+    };
+  }
+  if (operation.outcome !== undefined || operation.receipt !== undefined) {
+    throw new Error("non-terminal repo writer operation has terminal result data");
+  }
+  return { phase: operation.phase };
+}
 
 export type RepoWriteCanonicalLookupResult =
   | { readonly state: Exclude<RepoWriteOperationLookupResult["state"], "committed" | "rejected"> }
@@ -55,17 +95,18 @@ export function repoWriteCanonicalLookupResult(
       };
 }
 
-export function repoWriteLocalLookupResult(operation: {
-  readonly phase: RepoWriteHostedOperationPhase;
-  readonly receipt?: RepoWriteJsonObject;
-}): RepoWriteOperationLookupResult {
+export function repoWriteLocalLookupResult(
+  operation: RepoWriteHostedOperationSnapshot
+): RepoWriteOperationLookupResult {
   if (operation.phase === "preparing" || operation.phase === "prepared") return { state: "prepared" };
   if (operation.phase === "proceeding") return { state: "proceeding" };
-  if (operation.phase !== "committed" && operation.phase !== "rejected") {
+  if (operation.phase !== "terminal") {
     return { state: operation.phase };
   }
-  if (!operation.receipt) throw new Error("terminal repo writer operation is missing its receipt");
-  return operation.phase === "committed"
+  if (operation.outcome === undefined || operation.receipt === undefined) {
+    throw new Error("terminal repo writer operation is missing its outcome or receipt");
+  }
+  return operation.outcome === "committed"
     ? { state: "committed", outcome: "committed", receipt: operation.receipt }
     : { state: "rejected", outcome: "rejected", receipt: operation.receipt };
 }

--- a/packages/daemon/src/runtime/repo-write-client-pending-lifecycle.ts
+++ b/packages/daemon/src/runtime/repo-write-client-pending-lifecycle.ts
@@ -8,6 +8,8 @@ import type {
   PendingLookup,
   PendingSubmit
 } from "./repo-write-client-pending.ts";
+import type { RepoWriteFailureFrame } from "./repo-write-protocol.ts";
+import { advanceRepoWritePhase } from "./repo-write-phase.ts";
 import { expireRepoWriteSubmit } from "./repo-write-client-timeout.ts";
 import { armRepoWriteSubmitEscalation } from "./repo-write-client-watchdog.ts";
 import { finishRepoWriteParentPerformanceTiming } from "./repo-write-parent-performance.ts";
@@ -69,4 +71,22 @@ export function expireRepoWritePendingSubmit(
       onTimeout
     });
   }
+}
+
+export function repoWritePendingFailureTransitionError(
+  pending: PendingSubmit,
+  message: Extract<RepoWriteFailureFrame, { readonly kind: "failure" }>
+): string | undefined {
+  if (message.outcome === "not-started") {
+    if (pending.phase !== "submitted" && pending.phase !== "prepared" && pending.phase !== "proceeded") {
+      return "Repo writer not-started failure has an invalid phase transition.";
+    }
+    advanceRepoWritePhase("parent", "not-started", pending.phase);
+    return undefined;
+  }
+  if (pending.phase !== "prepared" && pending.phase !== "proceeded") {
+    return "Repo writer outcome-unknown failure has an invalid phase transition.";
+  }
+  advanceRepoWritePhase("parent", "outcome-unknown", pending.phase);
+  return undefined;
 }

--- a/packages/daemon/src/runtime/repo-write-client-pending.ts
+++ b/packages/daemon/src/runtime/repo-write-client-pending.ts
@@ -8,6 +8,7 @@ import {
   beginRepoWriteParentPerformanceTiming,
   type RepoWriteParentPerformanceTiming
 } from "./repo-write-parent-performance.ts";
+import type { RepoWriteParentPendingPhase } from "./repo-write-phase.ts";
 
 export interface PendingSubmit {
   readonly requestId: string;
@@ -15,7 +16,7 @@ export interface PendingSubmit {
   readonly resolve: (receipt: RepoWriteJsonObject) => void;
   readonly reject: (error: Error) => void;
   timer: NodeJS.Timeout | undefined;
-  phase: "queued" | "submitted" | "prepared" | "proceeded";
+  phase: RepoWriteParentPendingPhase;
   opId?: string;
   lastTelemetry?: RepoWriteTelemetryFrame;
   readonly performanceTiming?: RepoWriteParentPerformanceTiming;

--- a/packages/daemon/src/runtime/repo-write-client.ts
+++ b/packages/daemon/src/runtime/repo-write-client.ts
@@ -20,7 +20,8 @@ import { resolveRepoWriteClientLimits } from "./repo-write-client-limits.ts";
 import { disconnectRepoWritePendingRequests } from "./repo-write-client-disconnect.ts";
 import {
   expireRepoWritePendingSubmit,
-  rejectRepoWriteQueuedRequests
+  rejectRepoWriteQueuedRequests,
+  repoWritePendingFailureTransitionError
 } from "./repo-write-client-pending-lifecycle.ts";
 import {
   expireRepoWriteLookup,
@@ -40,6 +41,7 @@ import {
   finishRepoWriteParentPerformanceTiming,
   markRepoWriteChildStarted
 } from "./repo-write-parent-performance.ts";
+import { advanceRepoWritePhase } from "./repo-write-phase.ts";
 export type { RepoWriteClientLimits, RepoWriteClientOptions, RepoWriteClientTransport } from "./repo-write-client-contract.ts";
 import {
   RepoWriteClientCapacityError,
@@ -233,7 +235,7 @@ export class RepoWriteClient {
   private dispatchSubmit(requestId: string): void {
     const pending = this.pending.get(requestId);
     if (!pending || pending.phase !== "queued") return;
-    pending.phase = "submitted";
+    pending.phase = advanceRepoWritePhase("parent", "submit", pending.phase);
     pending.timer = setTimeout(
       () => this.expireSubmit(requestId),
       this.limits.requestTimeoutMs
@@ -282,7 +284,7 @@ export class RepoWriteClient {
         this.failProtocol("Repo writer sent a duplicate or unknown prepared request.");
         return;
       }
-      pending.phase = "prepared";
+      pending.phase = advanceRepoWritePhase("parent", "prepared", pending.phase);
       pending.opId = message.opId;
       markRepoWriteChildStarted(pending.performanceTiming);
       this.dispatchProceed(pending);
@@ -295,6 +297,7 @@ export class RepoWriteClient {
         this.failProtocol("Repo writer terminal correlation does not match the prepared request.");
         return;
       }
+      advanceRepoWritePhase("parent", "terminal", pending.phase);
       if (!repoWriteTerminalReceiptMatches(message.outcome, message.receipt)) {
         this.failProtocol("Repo writer terminal receipt does not match its durable outcome.");
         return;
@@ -390,6 +393,11 @@ export class RepoWriteClient {
       const pending = this.pending.get(message.requestId);
       if (!pending || (message.opId !== undefined && pending.opId !== message.opId)) {
         this.failProtocol("Repo writer failure correlation does not match the pending request.");
+        return;
+      }
+      const failureTransitionError = repoWritePendingFailureTransitionError(pending, message);
+      if (failureTransitionError !== undefined) {
+        this.failProtocol(failureTransitionError);
         return;
       }
       clearTimeout(pending.timer);
@@ -565,6 +573,8 @@ export class RepoWriteClient {
   }
 
   private dispatchProceed(pending: PendingSubmit): void {
+    if (pending.phase !== "prepared") return;
+    const proceededPhase = advanceRepoWritePhase("parent", "proceed", pending.phase);
     try {
       const sent = this.options.transport.send({
         ...repoWriteClientFrameBase(this.options.repoId, this.options.generation),
@@ -572,13 +582,12 @@ export class RepoWriteClient {
         requestId: pending.requestId,
         opId: pending.opId!
       });
-      if (this.pending.has(pending.requestId)) pending.phase = "proceeded";
+      if (this.pending.has(pending.requestId)) pending.phase = proceededPhase;
       void Promise.resolve(sent).catch((error: unknown) => this.rejectSendFailure(pending.requestId, error));
     } catch (error) {
       this.rejectSendFailure(pending.requestId, error, true);
     }
   }
-
   private pendingRequestCount(): number {
     return this.pending.size + this.directLane.size + this.pendingLookups.size;
   }

--- a/packages/daemon/src/runtime/repo-write-phase.ts
+++ b/packages/daemon/src/runtime/repo-write-phase.ts
@@ -1,0 +1,114 @@
+type RepoWritePhaseTransitionDefinition = {
+  readonly parent: {
+    readonly from: readonly (string | null)[];
+    readonly to: string | null;
+  };
+  readonly child: {
+    readonly from: readonly (string | null)[];
+    readonly to: string | null;
+  };
+};
+
+/**
+ * The durable write protocol's one phase/transition authority.
+ *
+ * The parent and child observe different sides of the same transport event.
+ * Keeping both projections in each row is intentional: it models the legal
+ * window in which the child has prepared locally while the parent still has
+ * only submitted knowledge.
+ */
+export const repoWritePhaseTransitions = {
+  submit: {
+    parent: { from: ["queued"], to: "submitted" },
+    child: { from: [null], to: "preparing" }
+  },
+  prepared: {
+    parent: { from: ["submitted"], to: "prepared" },
+    child: { from: ["preparing"], to: "prepared" }
+  },
+  proceed: {
+    parent: { from: ["prepared"], to: "proceeded" },
+    child: { from: ["prepared"], to: "proceeding" }
+  },
+  terminal: {
+    parent: { from: ["prepared", "proceeded"], to: null },
+    child: { from: ["proceeding"], to: "terminal" }
+  },
+  "not-started": {
+    parent: { from: ["submitted", "prepared", "proceeded"], to: null },
+    child: { from: ["preparing", "prepared"], to: "failed" }
+  },
+  "outcome-unknown": {
+    parent: { from: ["prepared", "proceeded"], to: null },
+    child: { from: ["proceeding"], to: "unknown" }
+  },
+  "shutdown-before-proceed": {
+    parent: { from: ["prepared", "proceeded"], to: null },
+    child: { from: ["prepared"], to: "failed" }
+  }
+} as const satisfies Record<string, RepoWritePhaseTransitionDefinition>;
+
+type RepoWritePhaseTransitionTable = typeof repoWritePhaseTransitions;
+
+export type RepoWritePhaseTransitionName = keyof RepoWritePhaseTransitionTable;
+export type RepoWritePhaseSide = keyof RepoWritePhaseTransitionTable["submit"];
+
+type RepoWritePhaseTransitionSpec<
+  Name extends RepoWritePhaseTransitionName,
+  Side extends RepoWritePhaseSide
+> = RepoWritePhaseTransitionTable[Name][Side];
+
+export type RepoWritePhaseTransitionFrom<
+  Side extends RepoWritePhaseSide,
+  Name extends RepoWritePhaseTransitionName
+> = RepoWritePhaseTransitionSpec<Name, Side>["from"][number];
+
+export type RepoWritePhaseTransitionTo<
+  Side extends RepoWritePhaseSide,
+  Name extends RepoWritePhaseTransitionName
+> = RepoWritePhaseTransitionSpec<Name, Side>["to"];
+
+export type RepoWritePhaseFor<Side extends RepoWritePhaseSide> = Exclude<{
+  [Name in RepoWritePhaseTransitionName]:
+    | RepoWritePhaseTransitionSpec<Name, Side>["from"][number]
+    | RepoWritePhaseTransitionSpec<Name, Side>["to"]
+}[RepoWritePhaseTransitionName], null>;
+
+export type RepoWriteParentPendingPhase = RepoWritePhaseFor<"parent">;
+export type RepoWriteChildOperationPhase = RepoWritePhaseFor<"child">;
+
+export function advanceRepoWritePhase<
+  Side extends RepoWritePhaseSide,
+  Name extends RepoWritePhaseTransitionName,
+  From extends RepoWritePhaseTransitionFrom<Side, Name>
+>(
+  side: Side,
+  transition: Name,
+  from: From
+): RepoWritePhaseTransitionTo<Side, Name>;
+export function advanceRepoWritePhase(
+  side: RepoWritePhaseSide,
+  transition: RepoWritePhaseTransitionName,
+  from: string | null
+): string | null {
+  const spec = repoWritePhaseTransitions[transition][side];
+  if (!spec.from.includes(from as never)) {
+    throw new Error(
+      `Repo write ${side} phase cannot apply ${transition} from ${String(from)}`
+    );
+  }
+  return spec.to;
+}
+
+// These type-only probes are deliberately kept beside the authority. If a
+// transition is widened or a terminal outcome is accidentally reintroduced as
+// a phase, typecheck fails here.
+type RepoWriteAssertFalse<Value extends false> = Value;
+type RepoWriteChildPreparationFromPrepared =
+  "prepared" extends RepoWritePhaseTransitionFrom<"child", "prepared"> ? true : false;
+type RepoWriteChildTerminalOutcomeIsPhase =
+  "committed" extends RepoWriteChildOperationPhase ? true : false;
+type _RepoWriteChildPreparationMustStartLocally =
+  RepoWriteAssertFalse<RepoWriteChildPreparationFromPrepared>;
+type _RepoWriteTerminalOutcomeMustStaySeparate =
+  RepoWriteAssertFalse<RepoWriteChildTerminalOutcomeIsPhase>;

--- a/packages/daemon/test/repo-write-protocol.test.ts
+++ b/packages/daemon/test/repo-write-protocol.test.ts
@@ -22,6 +22,13 @@ import {
   committedCommandReceipt,
   rejectedCommandReceipt
 } from "./support/repo-write-terminal-fixture.ts";
+import {
+  advanceRepoWritePhase
+} from "../src/runtime/repo-write-phase.ts";
+import {
+  repoWriteHostedOperationSnapshot,
+  repoWriteLocalLookupResult
+} from "../src/runtime/repo-write-child-lookup.ts";
 
 test("submit codec carries command DTOs as JSON-safe values with explicit scalar text encodings", () => {
   const message: RepoWriteParentMessage = {
@@ -210,6 +217,30 @@ test("prepared and proceed form an exact opId handshake before canonical mutatio
 
   assert.deepEqual(parseRepoWriteChildMessage(stringifyRepoWriteChildMessage(prepared)), prepared);
   assert.deepEqual(parseRepoWriteParentMessage(stringifyRepoWriteParentMessage(proceed)), proceed);
+});
+
+test("one phase table derives both views without collapsing the legal transport window", () => {
+  assert.equal(advanceRepoWritePhase("parent", "submit", "queued"), "submitted");
+  assert.equal(advanceRepoWritePhase("child", "submit", null), "preparing");
+  assert.equal(advanceRepoWritePhase("child", "prepared", "preparing"), "prepared");
+  assert.equal(advanceRepoWritePhase("parent", "prepared", "submitted"), "prepared");
+  assert.equal(advanceRepoWritePhase("child", "proceed", "prepared"), "proceeding");
+
+  const receipt = committedCommandReceipt();
+  const terminal = repoWriteHostedOperationSnapshot({
+    phase: "terminal",
+    outcome: "committed",
+    receipt
+  });
+  assert.deepEqual(repoWriteLocalLookupResult(terminal), {
+    state: "committed",
+    outcome: "committed",
+    receipt
+  });
+  assert.throws(
+    () => repoWriteHostedOperationSnapshot({ phase: "terminal" }),
+    /missing its outcome or receipt/u
+  );
 });
 
 test("historical recovery diagnostics carry a bounded startup failure without request correlation", () => {


### PR DESCRIPTION
# English

## Summary

Collapse the repo-write protocol's duplicated phase authority into one declaration. Parent and child previously each hand-maintained their own phase union and their own transition checks for the same durable write transaction, so a new phase or transition could be added on one side and still typecheck. This is the third and largest structural anchor of the PLT-Steady-Transport line.

## What Changed

- New `packages/daemon/src/runtime/repo-write-phase.ts`: one transition table whose every row declares both the parent projection and the child projection of the same transport event, pinned by `satisfies Record<string, RepoWritePhaseTransitionDefinition>`. Both phase unions and the single runtime transition guard `advanceRepoWritePhase` are derived from that table.
- `RepoWriteHostedOperationSnapshot` becomes a discriminated union: `phase: "terminal"` must carry both `outcome` and `receipt`. Terminal outcomes are no longer members of the child phase union.
- Parent `PendingSubmit.phase` is now a derived type. `PendingLookup` is deliberately left out of the table and keeps its own `"queued" | "sent"` lifecycle.
- `repo-write-protocol.ts` is untouched — no wire shape change, so no mixed-version migration surface.

## Task And Scope

Scope is anchor 3 only. Anchor 1's remaining legacy-variant typing is explicitly out of scope. No CI, gate, workflow, or branch-protection surface is touched.

## Version Impact

No published package API change and no wire protocol change. The change is internal to daemon runtime phase representation.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: decision `dec_01KZ6GNYWPNGRDFVDMHZVB1A59` (concentrate durable write phase/transition into a single declaration), which derives task `task_01KZ6FPRYQY5CRP4P7WA3D2RDM`; line accounting policy `dec_01KYYX1AXK7JMWFGCKX059W6PV`.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

Both accounting criteria carry before/after evidence rather than a claim:

- **Parallel authority deleted.** Before: parent declared `queued/submitted/prepared/proceeded` inline while child separately declared `preparing/prepared/proceeding/<terminal outcome>/failed/unknown`; adding a literal to one side had no type-level consequence on the other. After: every transition row must supply both projections, so a one-sided change fails typecheck.
- **Illegal state deleted.** Before: `{ phase: "committed" }` without a receipt was constructible and could reach local lookup, because terminal outcomes were phase members and the receipt was a separate optional field. After: terminal is a single phase that structurally requires `outcome` and `receipt` together. Type-only probes fail the build if a terminal outcome is reintroduced into the child phase union.
- **The legal desync window is preserved and covered.** The table does not require the two sides to be equal: child may be `prepared` while the parent is still `submitted`, which is inherent to a one-hop protocol. Regression coverage asserts exactly that sequence.
- `npm run typecheck`, `npm run lint`: passed. `npm run check:local`: passed in 57.5s, 27 manifest gates green, 209 affected fast tests passed.
- `node tools/run-node-tests.mjs --tier integration`: exit 0 — 1,481 tests, 1,477 passed, 0 failed, 4 skipped.

## Review Evidence

CEO review against the diff:

- Confirmed the three phase sets were **not** collapsed indiscriminately: `PendingLookup` remains a separate entity with its own lifecycle. Merging it in was one of the three rejected options in the governing decision, and the diff honours that.
- Confirmed the `prepared` row models the desync window rather than forbidding it (parent `submitted→prepared`, child `preparing→prepared`, independently advanced).
- Confirmed `repo-write-protocol.ts` is absent from the changed-file set, so wire compatibility is untouched.
- Confirmed the canonical worktree was not polluted: only the pre-existing untracked `.codegraph/` remains.

## Residual Risk

- `PendingLookup` staying outside the table is a deliberate semantic boundary, not a third write authority left behind.
- Any new method or transition must now declare both projections. That cost is intentional; the failure mode is a compile error rather than a silent one-sided drift.
- This line is still open: anchor 1's remaining legacy-variant typing is untouched.

## References

- Decision `dec_01KZ6GNYWPNGRDFVDMHZVB1A59`
- Accounting policy `dec_01KYYX1AXK7JMWFGCKX059W6PV`
- Task `task_01KZ6FPRYQY5CRP4P7WA3D2RDM`

# 中文

## 概要

把 repo-write 协议中重复的 phase authority 收敛为单一声明。此前父侧与子侧各自手工维护同一笔 durable write 事务的 phase 取值与转移校验，因此在一侧新增 phase 或转移、另一侧不动仍能通过 typecheck。这是 PLT-Steady-Transport 线的第三个、也是体量最大的结构锚点。

## 改动内容

- 新增 `packages/daemon/src/runtime/repo-write-phase.ts`：一张转移表，每一行同时声明同一个 transport event 的父侧投影与子侧投影，由 `satisfies Record<string, RepoWritePhaseTransitionDefinition>` 钉住。两侧的 phase union 与唯一的运行时转移守卫 `advanceRepoWritePhase` 均从该表派生。
- `RepoWriteHostedOperationSnapshot` 改为判别联合：`phase: "terminal"` 必须同时携带 `outcome` 与 `receipt`。终态结果不再是子侧 phase union 的成员。
- 父侧 `PendingSubmit.phase` 改为派生类型。`PendingLookup` **刻意**未接入该表，保留自己的 `"queued" | "sent"` 生命周期。
- `repo-write-protocol.ts` 未改动——wire 形状不变，因此没有混版迁移面。

## 任务与范围

范围仅限锚点 3。锚点 1 剩余的 legacy variant typed 化明确出界。未触碰任何 CI、gate、workflow 或分支保护面。

## 版本影响

无已发布包 API 变更，无 wire 协议变更。改动限于 daemon 运行时内部的 phase 表示。

## 治理声明

- 触碰 protected surface：否
- Protected surface 范围：不适用
- 依据：裁决 `dec_01KZ6GNYWPNGRDFVDMHZVB1A59`（将 durable write phase/transition 集中到一个声明中），其派生任务 `task_01KZ6FPRYQY5CRP4P7WA3D2RDM`；本线记账政策 `dec_01KYYX1AXK7JMWFGCKX059W6PV`。
- 机器检查边界：本 PR 仅断言声明存在；声明是否属实与充分由评审者判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

两条记账判据均带修前/修后证据，而非声称：

- **删除一份平行 authority。** 修前：父侧在 pending 定义里内联声明 `queued/submitted/prepared/proceeded`，子侧另行声明 `preparing/prepared/proceeding/<终态结果>/failed/unknown`；只在一侧加字面量，对另一侧没有任何类型级约束。修后：每一行转移都必须同时提供两侧投影，单侧改动无法通过 typecheck。
- **删除一个非法状态。** 修前：`{ phase: "committed" }` 这种不带 receipt 的终态可以构造并流入 local lookup，因为终态结果是 phase 成员而 receipt 是可分离的可选字段。修后：终态收敛为单一 phase，结构上要求 `outcome` 与 `receipt` 同时存在；type-only probe 会在有人把终态结果重新放回子侧 phase union 时让构建失败。
- **合法的不同步窗口被保留且有覆盖。** 该表不要求两侧相等：子侧已 `prepared` 而父侧仍 `submitted` 是单跳协议的内在状态。回归测试正是断言这一序列。
- `npm run typecheck`、`npm run lint`：通过。`npm run check:local`：57.5 秒通过，27 个 manifest gate 全绿，209 个受影响 fast 测试通过。
- `node tools/run-node-tests.mjs --tier integration`：exit 0 —— 1,481 个测试，1,477 通过，0 失败，4 跳过。

## 审查证据

CEO 对着 diff 复核：

- 确认三套 phase **没有**被粗暴合并：`PendingLookup` 仍是独立实体、保留自己的生命周期。把它并入正是本裁决三个 rejected 选项之一，diff 遵守了该边界。
- 确认 `prepared` 那一行是在**建模**不同步窗口而非禁止它（父侧 `submitted→prepared`、子侧 `preparing→prepared`，各自独立推进）。
- 确认改动文件集中不含 `repo-write-protocol.ts`，wire 兼容性未被触碰。
- 确认 canonical 工作树未被污染：仅剩既存的未跟踪 `.codegraph/`。

## 残余风险

- `PendingLookup` 留在表外是刻意的语义边界，不是遗留的第三份 write authority。
- 今后任何新 method 或转移都必须声明两侧投影。这是刻意付出的代价；失败形态是编译错误，而不是单侧的静默漂移。
- 本线尚未关闭：锚点 1 剩余的 legacy variant typed 化未动。

## 关联材料

- 裁决 `dec_01KZ6GNYWPNGRDFVDMHZVB1A59`
- 记账政策 `dec_01KYYX1AXK7JMWFGCKX059W6PV`
- 任务 `task_01KZ6FPRYQY5CRP4P7WA3D2RDM`

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
