### PR TITLE
fix(daemon): give autostart a startup budget that cold readiness can meet

### DIFF
--- a/packages/cli/test/daemon-control-dispatcher.test.ts
+++ b/packages/cli/test/daemon-control-dispatcher.test.ts
@@ -1,6 +1,7 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
+import { defaultDaemonAutostartTimeoutMs } from "@harness-anything/daemon";
 import { renderDaemonHelp } from "../src/commands/daemon/help.ts";
 import {
   runDaemonProductCommand,
@@ -107,7 +108,7 @@ test("daemon dispatcher routes restart and every refresh trigger through canonic
       assert.equal(exitCode, 0);
       assert.equal(requests.length, 1);
       assert.equal(replacementStarts, 1);
-      assert.equal(replacementTimeoutMs, 6_000);
+      assert.equal(replacementTimeoutMs, defaultDaemonAutostartTimeoutMs);
       assert.equal(requests[0]?.method, scenario.method);
       const payload = requests[0]?.params.payload as Record<string, unknown>;
       assert.equal(payload.drainTimeoutMs, 30_000);

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -47,7 +47,8 @@ export {
   type ParsedDaemonLaunchArgv
 } from "./daemon-launch-spec-store.ts";
 
-export const defaultDaemonAutostartTimeoutMs = 6_000;
+// Cold authority readiness measured ~7.2s, so a 6s budget could never confirm it.
+export const defaultDaemonAutostartTimeoutMs = 30_000;
 export const defaultDaemonIdleExitMs = 750;
 const minimumReadyProbeResponseTimeoutMs = 500;
 

--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -10,7 +10,10 @@ import type { ApiRouteContract } from "../api/api-contract-registry.ts";
 import type { GuiServiceBridge } from "../api/service-bridge.ts";
 import type { DaemonTransport } from "../daemon/remote-tunnel.ts";
 
-const defaultDaemonAutostartTimeoutMs = 6_000;
+// Keep in step with defaultDaemonAutostartTimeoutMs in
+// packages/daemon/src/client/local-json-rpc-client.ts; gui depends on
+// daemon-client rather than daemon, so the value cannot be imported here.
+const defaultDaemonAutostartTimeoutMs = 30_000;
 const defaultDaemonIdleExitMs = 5 * 60_000;
 
 type JsonObject = { readonly [key: string]: JsonValue };


### PR DESCRIPTION
# English

## Summary

Cold authority readiness takes longer than the autostart budget allowed, so the CLI gave up before a freshly spawned daemon could ever answer, and the write path stayed wedged until someone restarted the daemon by hand. Raise the default autostart budget from 6s to 30s.

## What Changed

- `defaultDaemonAutostartTimeoutMs`: `6_000` -> `30_000` in `packages/daemon/src/client/local-json-rpc-client.ts`.
- The gui main process keeps its own copy of the constant (gui depends on `daemon-client`, not `daemon`, so the value cannot be imported); both are now 30s and carry a pointer to each other.
- Idle exit is deliberately untouched: it is a consequence of the client giving up, not the cause.

Measured from a real failure on a self-hosting repo: daemon `ha-20404` recorded `startedAt 11:36:24.636Z` and reached the running phase at `11:36:31.885Z` (~7.2s), past the 6s budget. The client timed out, and the unattended daemon then hit its 750ms idle exit at `11:36:35.611Z`. Every retry repeated the cycle: another short-lived daemon, another timeout, no recovery.

The value was already an ordinary tunable (`HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS` overrides it), so this changes how long the client is willing to wait, not what it accepts as ready.

## Task And Scope

- Harness task: `task_01KZ8VYVMDDRP2XXH211FFVA0T`
- Branch: `codex/autostart-budget`
- Public scope: the autostart default timeout constant in `packages/daemon` and its hand-copied twin in `packages/gui` main.
- Private planning/evidence updated: yes
- Out of scope: idle-exit policy, the `failed to stop repo writer children` shutdown error, and the behavioural regression gate — all tracked in the task above.

## Version Impact

- Version: no version change because this adjusts a client-side default timeout with no published surface change.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KZ8VYVMDDRP2XXH211FFVA0T`; the simplest-fix-first policy behind this change is `dec_01KZ8X5B9F7WWFC834S98YDBX7`.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- [x] `npm run check:local` — green in 250.5s, 28 complete manifest gates.
- [x] `node tools/run-manifest-gates.mjs --workflow-job fast-contract` after the test fix — `pass 1047 / fail 0` and `pass 916 / fail 0`.
- Not run: `npm test` / `npm run check` (full matrix is GitHub CI's job per repo testing policy); behavioural recovery-after-crash is not yet covered by a regression test.

## Review Evidence

- Self-review: traced the tunable end to end — `packages/cli/src/daemon/client.ts:128` reads the env override and falls back to this default, `client-timing.ts:14` passes it as `timeoutMs`, and `local-json-rpc-client.ts:361-362` turns it into the autostart deadline.
- **Correction**: this section first claimed no test asserted the literal 6000. That was wrong — I had grepped only two test files instead of the whole tree, and CI caught `packages/cli/test/daemon-control-dispatcher.test.ts:110`. Fixed in `d378ab7c` by asserting against the exported constant, since what that test is about is that the dispatcher passes the *default* budget. A full-tree grep found two other `6_000` literals: the gui main copy (same quantity, raised with it) and `projection-notifications.ts` (connection timeout for an already-running daemon — different quantity, left alone).
- Additional review: none. This is a one-constant change whose justification is a timestamp subtraction; a review round would cost more than it could find.
- Blocking findings: none.

## Residual Risk

- A genuinely hung daemon now takes 30s to surface instead of 6s. Accepted: the previous behaviour did not surface it either, it just failed faster and left the write path wedged.
- Behavioural regression coverage (inject a slow start, assert the old budget wedges and the new one recovers) is owed and tracked in `task_01KZ8VYVMDDRP2XXH211FFVA0T`, together with the `failed to stop repo writer children` shutdown error seen in the same incident.

## References

- Task: `task_01KZ8VYVMDDRP2XXH211FFVA0T`
- Evidence: `~/.harness-production/logs/harness-anything/2026-08-05.ndjson` lifecycle records for `ha-90266` and `ha-20404`.

---

# 中文

## 概要

daemon 冷启动的权威就绪耗时超过了 autostart 预算，CLI 在新拉起的 daemon 能够应答之前就放弃了，写路因此卡死，只有人工重启 daemon 才能恢复。本 PR 把 autostart 默认预算从 6 秒提到 30 秒。

## 改动内容

- `packages/daemon/src/client/local-json-rpc-client.ts` 的 `defaultDaemonAutostartTimeoutMs`：`6_000` -> `30_000`。
- GUI 主进程手抄了一份同名常量（GUI 依赖 `daemon-client` 而非 `daemon`，无法 import），一并改为 30 秒，并给两处互相加了指针。
- **不动 idle 退出**：它是客户端放弃之后的后果，不是原因。

真实故障实测：daemon `ha-20404` 的 `startedAt` 是 `11:36:24.636Z`，到达 running 阶段是 `11:36:31.885Z`，约 7.2 秒，超过 6 秒预算。客户端超时后，无人连接的 daemon 又在 `11:36:35.611Z` 按 750ms idle 退出。每次重试重复这个循环：再造一个短命 daemon、再超时一次、始终不恢复。

该值本来就是普通可调参数（`HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS` 可覆盖），所以改的是客户端愿意等多久，不是它接受什么算就绪。

## 任务与范围

- Harness 任务：`task_01KZ8VYVMDDRP2XXH211FFVA0T`
- 分支：`codex/autostart-budget`
- 公开范围：`packages/daemon` 的 autostart 默认超时常量，以及 `packages/gui` 主进程里手抄的那一份。
- 私有计划 / 证据是否已更新：yes
- 范围外：idle 退出策略、`failed to stop repo writer children` 停止路径错误、行为回归门——三项均记在上述任务。

## 版本影响

- 版本：不改版本，原因是本次只调整客户端默认超时，无已发布接口变更。

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`task_01KZ8VYVMDDRP2XXH211FFVA0T`；本次改动背后的「最简解优先」政策为 `dec_01KZ8X5B9F7WWFC834S98YDBX7`。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- [x] `npm run check:local` —— 250.5 秒全绿，28 道完整 manifest 门。
- [x] 测试修复后复跑 `node tools/run-manifest-gates.mjs --workflow-job fast-contract` —— `pass 1047 / fail 0` 与 `pass 916 / fail 0`。
- 未运行：`npm test` / `npm run check`（按本仓测试政策，完整门矩阵是 GitHub CI 的活）；崩溃后自愈的行为回归门尚未覆盖。

## 审查证据

- 自查：把这个可调值端到端走了一遍——`packages/cli/src/daemon/client.ts:128` 读 env 覆盖并回退到该默认值，`client-timing.ts:14` 作为 `timeoutMs` 传下去，`local-json-rpc-client.ts:361-362` 转成 autostart deadline。
- **更正**：本节最初写的是「没有任何测试断言字面量 6000」，这句是错的——我只 grep 了两个测试文件而非全仓，CI 抓到了 `packages/cli/test/daemon-control-dispatcher.test.ts:110`。已在 `d378ab7c` 改为断言导出的常量，因为该测试要验的本来就是 dispatcher 传的是**默认**预算。全仓 grep 另找到两处 `6_000`：GUI 主进程那份（同一个量，已随默认值一起提高）与 `projection-notifications.ts`（连接已在跑的 daemon 的超时，不同的量，不动）。
- 额外审查：无。这是一个单常量改动，其依据是两个时间戳相减；开一轮评审的成本高于它可能发现的东西。
- 阻塞发现：无。

## 残余风险

- 真正挂死的 daemon 现在要 30 秒才暴露，而不是 6 秒。接受：旧行为同样没有暴露它，只是失败得更快，并且把写路留在卡死状态。
- 行为侧回归覆盖（注入慢启动，断言旧预算复现卡死、新预算自愈）是欠账，连同同一次事故中出现的 `failed to stop repo writer children` 停止路径错误，一并记在 `task_01KZ8VYVMDDRP2XXH211FFVA0T`。

## 关联材料

- 任务：`task_01KZ8VYVMDDRP2XXH211FFVA0T`
- 证据：`~/.harness-production/logs/harness-anything/2026-08-05.ndjson` 中 `ha-90266` 与 `ha-20404` 的 lifecycle 记录。
