### PR TITLE
fix: restore the consumer task completion road and prove publication per path

### DIFF
--- a/packages/application/src/authority/daemon-host-contract.ts
+++ b/packages/application/src/authority/daemon-host-contract.ts
@@ -360,6 +360,10 @@ export interface DaemonControlErrorHostServices<PresentedError> {
 }
 
 export interface DaemonDocSyncHostServices {
+  readonly resolveDeclaredManagedSectionPolicy: (
+    rootInput: HarnessLayoutInput,
+    relativePath: string
+  ) => SemanticDiffDocumentPolicy | null;
   readonly resolveManagedSectionPolicy: (
     rootInput: HarnessLayoutInput,
     relativePath: string

--- a/packages/cli/src/cli/command-spec/command-spec-core.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-core.ts
@@ -1,4 +1,4 @@
-import { defineCommandSpecs } from "./types.ts";
+import { defineCommandSpecs, type CommandReceiptContract } from "./types.ts";
 import { writeCommandEventPolicy } from "./command-event-policies.ts";
 import { parseCapabilitiesArgs } from "../parsers/capabilities.ts";
 import { parseCoreTaskArgs } from "../parsers/core-task.ts";
@@ -14,6 +14,25 @@ import { runTaskLifecycleWithDemotions as runTaskLifecycleCommand } from "../../
 import { runTaskContractMigration } from "../../commands/core/task-contract-migrate.ts";
 import { runVersionCommand } from "../../commands/core/version.ts";
 import { rejectDaemonTaskLifecycleFacade } from "../../commands/core/task-lifecycle-facade.ts";
+
+const taskCompletionReceiptContract = {
+  data: ["taskId", "status", "completionGate"],
+  optionalData: {
+    report: "Only emitted for completion paths that surface a review or gate report; clean completion emits reviewContract and completionGate.",
+    executionId: "Only emitted when completion accepts a submitted Execution.",
+    completionEvidence: "Only emitted when completion accepts an immutable commit-anchor judgment record.",
+    reviewContract: "Compatibility-only legacy review.md gate evidence; it never authorizes completion.",
+    authorityOutcome: "Only emitted when the production authority reports an already-satisfied replay.",
+    repoWrite: "Only emitted when the production daemon child includes its durable writer outcome."
+  },
+  paths: [],
+  successNext: { kind: "none" },
+  dryRun: {
+    data: ["taskId", "status", "completionGate", "report"],
+    paths: [],
+    successNext: { kind: "none" }
+  }
+} satisfies CommandReceiptContract;
 
 export const coreCommandSpecs = defineCommandSpecs([
   {
@@ -254,20 +273,13 @@ export const coreCommandSpecs = defineCommandSpecs([
     "kind": "task-closeout",
     "display": "advanced",
     "usage": "task closeout <id> --from-file <closeout.json> [--execution-id <execution-id>] [--lease-token <token>] [--commit <git-ref>] [--reviewer <id>] [--dry-run] [--json]",
-    "options": [{"flag":"--from-file","description":"Read the human completion claim, Review judgment and consent, CI result, and optional evidence fields."},{"flag":"--execution-id","description":"Select the active Execution; otherwise use Holder V2 and the sole submitted round."},{"flag":"--lease-token","description":"Authenticate the active Holder V2 lease when it is not available implicitly."},{"flag":"--commit","description":"Resolve this git ref to a full 40-character commit SHA; defaults to HEAD."},{"flag":"--reviewer","description":"Set the completion reviewer id recorded by the existing completion gate."},{"flag":"--dry-run","description":"Resolve the commit and list the separately admitted gate steps without writing."},{"flag":"--json","description":"Emit command-receipt/v2 JSON."}],
-    "summary": "Compatibility approval entry: after task submit, record the owner's Review, sync task prose, reconcile the workspace commit, and complete.",
+    "options": [{"flag":"--from-file","description":"Read the human completion claim, Review judgment and consent, CI result, and optional evidence fields."},{"flag":"--execution-id","description":"Select the active Execution; otherwise use Holder V2 and the sole submitted round."},{"flag":"--lease-token","description":"Authenticate the active Holder V2 lease when it is not available implicitly."},{"flag":"--commit","description":"Resolve this git ref to a full 40-character commit SHA; defaults to HEAD."},{"flag":"--reviewer","description":"Set the completion reviewer id recorded by the existing completion gate."},{"flag":"--dry-run","description":"Run the same canonical task-complete planner without writing."},{"flag":"--json","description":"Emit command-receipt/v2 JSON."}],
+    "summary": "Compatibility approval entry that translates one closeout packet into the canonical task-complete planner and transaction.",
     "examples": ["harness-anything task closeout task_01ABC --from-file closeout.json --json"],
     "parse": parseCoreTaskArgs,
     "run": rejectDaemonTaskLifecycleFacade,
     "receiptContract": {
-      "data": ["taskId", "executionId", "status", "report"],
-      "paths": [],
-      "successNext": {kind: "none"},
-      "dryRun": {
-        "data": ["taskId", "report"],
-        "paths": [],
-        "successNext": { kind: "none" }
-      }
+      ...taskCompletionReceiptContract
     },
     "eventPolicy": {
       "conflictMarkerPreflight": false,
@@ -277,7 +289,7 @@ export const coreCommandSpecs = defineCommandSpecs([
       "nounOwnership": "Task lifecycle closeout facade; a human must invoke it after work is active.",
       "lifecycle": "permanent",
       "decisionRef": "decision/dec_01KXWRC9CH70HN61B5FYPQP3XV",
-      "chain": { "stepCount": 4, "submissionFieldCount": 6, "structuredInput": true }
+      "chain": { "stepCount": 1, "submissionFieldCount": 6, "structuredInput": true }
     }
   },
   {
@@ -562,20 +574,7 @@ export const coreCommandSpecs = defineCommandSpecs([
     "parse": parseCoreTaskArgs,
     "run": runTaskGatesCommand,
     "receiptContract": {
-      "data": ["taskId", "status", "completionGate"],
-      "optionalData": {
-        "report": "Only emitted for completion paths that surface a review or gate report; clean completion emits reviewContract and completionGate.",
-        "executionId": "Only emitted when completion accepts a submitted Execution.",
-        "completionEvidence": "Only emitted when completion accepts an immutable commit-anchor judgment record.",
-        "reviewContract": "Compatibility-only legacy review.md gate evidence; it never authorizes completion."
-      },
-      "paths": [],
-      "successNext": {kind: "none"},
-      "dryRun": {
-        "data": ["taskId", "status", "completionGate", "report"],
-        "paths": [],
-        "successNext": { kind: "none" }
-      }
+      ...taskCompletionReceiptContract
     },
     "eventPolicy": writeCommandEventPolicy
   }

--- a/packages/cli/src/commands/core/doc-sync.ts
+++ b/packages/cli/src/commands/core/doc-sync.ts
@@ -1,8 +1,11 @@
 import path from "node:path";
 import { buildDocSyncReport } from "@harness-anything/daemon";
-import { resolveManagedSectionPolicy } from "../extensions/managed-section-policy.ts";
+import {
+  resolveDeclaredManagedSectionPolicy,
+  resolveManagedSectionPolicy
+} from "../extensions/managed-section-policy.ts";
 
-const docSyncHostServices = { resolveManagedSectionPolicy };
+const docSyncHostServices = { resolveDeclaredManagedSectionPolicy, resolveManagedSectionPolicy };
 import { resolveHarnessLayout, taskPackagePath, type HarnessLayoutInput, type TaskId } from "@harness-anything/kernel";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
 import type { CliResult } from "../../cli/types.ts";

--- a/packages/cli/src/commands/core/task-gates.ts
+++ b/packages/cli/src/commands/core/task-gates.ts
@@ -42,12 +42,15 @@ function runTaskLifecycleTransition(
 ): ReturnType<CommandRunner> {
   if (action.dryRun === true) {
     if (!context.authorityCommandPreflight) {
-      const uncheckedGates = [
-        "canonical-authority-planner",
-        "task-completion-evidence",
-        "durable-transition-write"
-      ] as const;
-      return Effect.succeed(taskCompletionDryRunResult(action, uncheckedGates));
+      return Effect.succeed({
+        ok: false,
+        command: "task-complete",
+        taskId: action.taskId,
+        error: cliError(
+          CliErrorCode.WriteRejected,
+          "Task completion dry-run is blocked because the canonical authority planner is unavailable; no completion requirement was evaluated."
+        )
+      } satisfies CliResult);
     }
     const checkedGates = ["canonical-authority-planner", "task-completion-evidence"] as const;
     const uncheckedGates = ["durable-transition-write"] as const;
@@ -129,30 +132,6 @@ function runTaskLifecycleTransition(
       }
     } satisfies CliResult;
   });
-}
-
-function taskCompletionDryRunResult(
-  action: ReturnType<typeof taskCompleteTransitionCommandFromCliAction>,
-  uncheckedGates: ReadonlyArray<string>
-): CliResult {
-  return {
-    ok: true,
-    command: "task-complete",
-    taskId: action.taskId,
-    status: "in_review",
-    completionGate: {
-      ok: false,
-      evidenceMode: action.evidenceMode,
-      dryRun: true,
-      uncheckedGates
-    },
-    report: {
-      schema: "task-lifecycle-transition-preview/v1",
-      dryRun: true,
-      disposition: "server-planner-validation-required",
-      uncheckedGates
-    }
-  } satisfies CliResult;
 }
 
 function runTaskCodeDocReconcile(

--- a/packages/cli/src/commands/core/task-lifecycle-facade.ts
+++ b/packages/cli/src/commands/core/task-lifecycle-facade.ts
@@ -30,20 +30,19 @@ export async function runTaskCloseoutFacade(command: ParsedCommand, dispatch: Di
   const resolved = resolveCommit(closeoutCommand.rootDir, closeoutCommand.action.commitRef);
   if (!resolved.ok) return resolved.result;
   const steps = taskCloseoutFacadeSteps(closeoutCommand, resolved.sha);
-  if (command.action.dryRun) return dryRun(closeoutCommand, steps, { commit: resolved.sha });
   const receipt = await dispatch(steps[0]!);
   if (!receipt.ok) return receipt;
-  const submitData = lifecycleFacadeReceiptData(receipt);
+  const completionData = lifecycleFacadeReceiptData(receipt);
   return {
     ok: true,
     command: "task-closeout",
-    taskId: command.action.taskId,
-    executionId: text(submitData.executionId),
-    status: "done",
+    ...completionData,
     ...(receipt.warnings && receipt.warnings.length > 0 ? { warnings: receipt.warnings } : {}),
     report: {
-      schema: "task-closeout-result/v1",
+      schema: command.action.dryRun ? "task-closeout-dry-run/v1" : "task-closeout-result/v1",
+      ...(command.action.dryRun ? { dryRun: true } : {}),
       commit: resolved.sha,
+      completionPlan: completionData.report,
       steps: [receipt]
     }
   } satisfies CliResult;
@@ -64,6 +63,7 @@ export function taskCloseoutFacadeSteps(
       reviewerId: action.reviewerId,
       evidenceMode: "execution-review",
       commitRef: sha,
+      dryRun: action.dryRun,
       approval: {
         ...(action.review.executionId ? { executionId: action.review.executionId } : {}),
         findings: action.review.findings,
@@ -140,10 +140,6 @@ function resolveCommit(rootDir: string, commitRef: string, command = "task-close
 
 function lifecycleFacadeRecord(value: unknown): Record<string, unknown> | undefined {
   return value !== null && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
-}
-
-function text(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined;
 }
 
 function lifecycleFacadeReceiptData(receipt: CommandReceipt): Record<string, unknown> {

--- a/packages/cli/src/commands/extensions/managed-section-policy.ts
+++ b/packages/cli/src/commands/extensions/managed-section-policy.ts
@@ -20,6 +20,36 @@ export function resolveManagedSectionPolicy(
     const declaration = bundledTemplateCatalog("software/coding")?.documents.find((document) => document.id === "entity/decision-body");
     return declaration ? { path: normalized, sections: declaration.sectionPermissions } : null;
   }
+  const declared = resolveDeclaredTaskManagedSectionPolicy(rootInput, normalized);
+  if (declared) return declared;
+  const taskMatch = /^(tasks\/[^/]+)\/(.+)$/u.exec(normalized);
+  if (!taskMatch?.[1] || !taskMatch[2] || taskMatch[2] === "INDEX.md") return null;
+  const layout = resolveHarnessLayout(rootInput);
+  const documentAbsolutePath = path.join(layout.authoredRoot, normalized);
+  if (!existsSync(documentAbsolutePath)) return null;
+  const documentBody = readFileSync(documentAbsolutePath, "utf8");
+  const headings = markdownHeadingSections(documentBody).map((section) => section.anchor);
+  const matches = (bundledTemplateCatalog("software/coding")?.documents ?? [])
+    .filter((document) => document.materializeAs === taskMatch[2])
+    .filter((document) => undeclaredSectionsForTaskDocument(document.sectionPermissions) === "allow"
+      ? document.sectionPermissions.every((permission) => headings.includes(permission.anchor))
+      : headings.every((heading) => document.sectionPermissions.some((permission) => permission.anchor === heading)))
+    .sort((left, right) => left.sectionPermissions.length - right.sectionPermissions.length || left.id.localeCompare(right.id));
+  if (!matches[0] || (matches[1] && matches[1].sectionPermissions.length === matches[0].sectionPermissions.length)) return null;
+  return taskDocumentPolicy(normalized, matches[0].sectionPermissions);
+}
+
+export function resolveDeclaredManagedSectionPolicy(
+  rootInput: HarnessLayoutInput,
+  documentPath: string
+): SemanticDiffDocumentPolicy | null {
+  return resolveDeclaredTaskManagedSectionPolicy(rootInput, documentPath.split(path.sep).join("/"));
+}
+
+function resolveDeclaredTaskManagedSectionPolicy(
+  rootInput: HarnessLayoutInput,
+  normalized: string
+): SemanticDiffDocumentPolicy | null {
   const taskMatch = /^(tasks\/[^/]+)\/(.+)$/u.exec(normalized);
   if (!taskMatch?.[1] || !taskMatch[2] || taskMatch[2] === "INDEX.md") return null;
   const layout = resolveHarnessLayout(rootInput);
@@ -41,18 +71,7 @@ export function resolveManagedSectionPolicy(
       : undefined;
     if (declaration) return taskDocumentPolicy(normalized, declaration.sectionPermissions);
   }
-  const documentAbsolutePath = path.join(layout.authoredRoot, normalized);
-  if (!existsSync(documentAbsolutePath)) return null;
-  const documentBody = readFileSync(documentAbsolutePath, "utf8");
-  const headings = markdownHeadingSections(documentBody).map((section) => section.anchor);
-  const matches = (bundledTemplateCatalog("software/coding")?.documents ?? [])
-    .filter((document) => document.materializeAs === taskMatch[2])
-    .filter((document) => undeclaredSectionsForTaskDocument(document.sectionPermissions) === "allow"
-      ? document.sectionPermissions.every((permission) => headings.includes(permission.anchor))
-      : headings.every((heading) => document.sectionPermissions.some((permission) => permission.anchor === heading)))
-    .sort((left, right) => left.sectionPermissions.length - right.sectionPermissions.length || left.id.localeCompare(right.id));
-  if (!matches[0] || (matches[1] && matches[1].sectionPermissions.length === matches[0].sectionPermissions.length)) return null;
-  return taskDocumentPolicy(normalized, matches[0].sectionPermissions);
+  return null;
 }
 
 export function undeclaredSectionsForTaskDocument(

--- a/packages/cli/src/composition/daemon-service-host-services.ts
+++ b/packages/cli/src/composition/daemon-service-host-services.ts
@@ -5,7 +5,10 @@ import type { CliResult, ParsedCommand } from "../cli/types.ts";
 import { cliError, CliErrorCode } from "../cli/error-codes.ts";
 import { loadDaemonIdentity } from "../commands/daemon/productization.ts";
 import { makeDaemonGuiControllerOptions } from "../commands/extensions/gui-controller-options.ts";
-import { resolveManagedSectionPolicy } from "../commands/extensions/managed-section-policy.ts";
+import {
+  resolveDeclaredManagedSectionPolicy,
+  resolveManagedSectionPolicy
+} from "../commands/extensions/managed-section-policy.ts";
 import { leaseEnforcementEnabled } from "../commands/settings.ts";
 import { resolveCliVersion } from "../commands/core/version.ts";
 import { readTaskReturnToIdeaSnapshot } from "../commands/task-return-to-idea-snapshot.ts";
@@ -27,7 +30,7 @@ export const cliDaemonServiceHostServices = {
         code: "daemon_queue_drain_timeout" as const
       }
   },
-  docSync: { resolveManagedSectionPolicy },
+  docSync: { resolveDeclaredManagedSectionPolicy, resolveManagedSectionPolicy },
   loadDaemonIdentity,
   daemonActorAttribution,
   makeGuiControllerOptions: (runtime, rootInput, commandOptions) => makeDaemonGuiControllerOptions(

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -50,9 +50,12 @@ import {
   remoteArtifactSafetyReceipt,
   type ArtifactIngestPlan
 } from "./artifact-ingest.ts";
-import { resolveManagedSectionPolicy } from "../commands/extensions/managed-section-policy.ts";
+import {
+  resolveDeclaredManagedSectionPolicy,
+  resolveManagedSectionPolicy
+} from "../commands/extensions/managed-section-policy.ts";
 
-const docSyncHostServices = { resolveManagedSectionPolicy };
+const docSyncHostServices = { resolveDeclaredManagedSectionPolicy, resolveManagedSectionPolicy };
 import { readProjectHarnessSettings } from "../commands/settings.ts";
 import { readRemoteConfig, remoteDaemonSshArgs, remoteDaemonUnavailableHint, type RemoteDaemonConfig } from "./remote-config.ts";
 import { isDeclaredLocalMigrationCommand } from "../composition/local-write-scope.ts";

--- a/packages/cli/test/coldstart-p1-cli.test.ts
+++ b/packages/cli/test/coldstart-p1-cli.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { devNull, tmpdir } from "node:os";
 import path from "node:path";
@@ -37,7 +37,7 @@ test("fresh init creates a workspace HEAD without ambient git identity", () => {
   });
 });
 
-test("task packet help templates pass submission and approval dry-runs", () => {
+test("task packet help templates parse while approval dry-run requires the authority planner", () => {
   withTempRoot((rootDir) => {
     const repoEnv = { HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user") };
     runJson(rootDir, ["init"], repoEnv);
@@ -86,19 +86,13 @@ test("task packet help templates pass submission and approval dry-runs", () => {
     writeFileSync(approvalPath, `${JSON.stringify(approval, null, 2)}\n`, "utf8");
     const indexPath = path.join(rootDir, created.packagePath, "INDEX.md");
     const indexBeforeDryRun = readFileSync(indexPath, "utf8");
-    const approvalDryRun = runJson(rootDir, [
+    const approvalDryRun = runJsonFailure(rootDir, [
       "task", "complete", created.taskId,
       "--approve", "--from-file", approvalPath, "--dry-run"
     ], sessionEnv);
-    assert.equal(approvalDryRun.ok, true);
-    assert.notEqual(approvalDryRun.status, "done");
-    assert.equal(approvalDryRun.report.schema, "task-lifecycle-transition-preview/v1");
-    assert.equal(approvalDryRun.report.disposition, "server-planner-validation-required");
-    assert.deepEqual(approvalDryRun.report.uncheckedGates, [
-      "canonical-authority-planner",
-      "task-completion-evidence",
-      "durable-transition-write"
-    ]);
+    assert.equal(approvalDryRun.ok, false);
+    assert.equal(approvalDryRun.error.code, "write_rejected");
+    assert.match(approvalDryRun.error.hint, /canonical authority planner is unavailable/iu);
     assert.equal(readFileSync(indexPath, "utf8"), indexBeforeDryRun);
   });
 });
@@ -119,6 +113,15 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, env: NodeJS.Proce
     env: { ...cleanGitEnv, ...env }
   });
   return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
+}
+
+function runJsonFailure(rootDir: string, args: ReadonlyArray<string>, env: NodeJS.ProcessEnv = {}): Record<string, any> {
+  const result = spawnSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
+    encoding: "utf8",
+    env: { ...cleanGitEnv, ...env }
+  });
+  assert.notEqual(result.status, 0, result.stdout || result.stderr);
+  return unwrapCommandReceipt(JSON.parse(result.stdout) as Record<string, any>);
 }
 
 function runGit(rootDir: string, ...args: ReadonlyArray<string>): string {

--- a/packages/cli/test/complete-final-step-deadzone.test.ts
+++ b/packages/cli/test/complete-final-step-deadzone.test.ts
@@ -16,6 +16,11 @@ import {
   git,
   writeColdCodexSessionLog
 } from "./production-authority-canonical-ingress/fixture.ts";
+import {
+  productionCloseout,
+  productionPlan,
+  publishSeededTaskFixture
+} from "./helpers/canonical-task-publication-fixture.ts";
 
 test("one task complete intent publishes approval and completion through the production daemon", { timeout: 60_000 }, async () => {
   const fixture = createFixture();
@@ -48,17 +53,17 @@ test("one task complete intent publishes approval and completion through the pro
       "2. ha task code-doc reconcile <task-id> --commit <approval.commit> --path <each-approval.paths-entry>",
       "3. ha task complete <task-id> --approve --from-file approval.json"
     ]);
-    mkdirSync(path.join(fixture.repoRoot, "tools"), { recursive: true });
-    copyFileSync(
-      path.resolve("tools/write-road-registry.json"),
-      path.join(fixture.repoRoot, "tools/write-road-registry.json")
-    );
+    const docSyncHelp = cliHelp(fixture.repoRoot, ["doc", "sync", "--help"]);
+    assert.match(docSyncHelp, /doc sync --submit --path tasks\/task_01ABC\/task_plan\.md/u);
+    const closeoutHelp = cliHelp(fixture.repoRoot, ["task", "closeout", "--help"]);
+    assert.match(closeoutHelp, /--dry-run\s+Run the same canonical task-complete planner without writing\./u);
     writeFileSync(path.join(taskRoot, "closeout.md"), productionCloseout("Original production closeout."));
     git(fixture.authoredRoot, "add", `tasks/${taskId}-production-route/closeout.md`);
     git(fixture.authoredRoot, "commit", "-q", "-m", "test: seed substantive production closeout");
     writeFileSync(path.join(taskRoot, "task_plan.md"), productionPlan("Original facade completion plan."));
     git(fixture.authoredRoot, "add", `tasks/${taskId}-production-route/task_plan.md`);
     git(fixture.authoredRoot, "commit", "-q", "-m", "test: seed facade completion plan");
+    publishSeededTaskFixture(fixture.authoredRoot, taskRoot, taskId);
     const registered = runDaemonCommand(fixture.repoRoot, [
       "daemon", "repo", "register", "--repo-id", "canonical",
       "--canonical-root", fixture.repoRoot, "--user-root", userRoot, "--no-link", "--json"
@@ -131,11 +136,37 @@ test("one task complete intent publishes approval and completion through the pro
     ], env);
     assert.equal(publishedWitness.status, 0, JSON.stringify(publishedWitness.receipt));
 
-    writeFileSync(path.join(taskRoot, "closeout.md"), productionCloseout("Closeout amended after the first reconciliation."));
     const approvalPath = path.join(fixture.root, "deadzone-approval.json");
     writeFileSync(approvalPath, JSON.stringify({
       ...packetTemplate(completeHelp),
       executionId,
+      verdict: "approved",
+      findings: "The submitted evidence and public code anchor satisfy the task.",
+      evidenceChecked: ["ev_cli_1"],
+      rationale: "The production daemon path proves the requested full-chain behavior.",
+      archiveWarningsAcknowledged: true,
+      consentAssertedRationale: "Approval was received through an external channel.",
+      consentActions: ["approve_execution", "complete_task"],
+      commit: fixture.publicHead,
+      paths: ["README.md"],
+      ci: "passed",
+      reviewerId: "person_alice"
+    }));
+    const reviewed = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "review-execution", taskId, "--from-file", approvalPath
+    ], env);
+    assert.equal(reviewed.status, 0, JSON.stringify(reviewed.receipt));
+    writeFileSync(path.join(taskRoot, "closeout.md"), productionCloseout("Closeout amended after the first reconciliation."));
+    const closeoutPacketPath = path.join(fixture.root, "deadzone-closeout.json");
+    writeFileSync(closeoutPacketPath, JSON.stringify({
+      completionClaim: "The production facade deadzone regression is ready for approval.",
+      deliverables: ["Facade completion regression"],
+      outputs: ["Full-chain production daemon evidence"],
+      verificationNotes: ["Production daemon setup completed."],
+      knownGaps: [],
+      residualRisks: [],
+      executionId,
+      verdict: "approved",
       findings: "The submitted evidence and public code anchor satisfy the task.",
       evidenceChecked: ["ev_cli_1"],
       rationale: "The production daemon path proves the requested full-chain behavior.",
@@ -148,11 +179,30 @@ test("one task complete intent publishes approval and completion through the pro
       reviewerId: "person_alice"
     }));
 
-    const blockedDryRun = runRawJsonMaybeFail(fixture.repoRoot, [
+    const blockedCompleteDryRun = runRawJsonMaybeFail(fixture.repoRoot, [
       "task", "complete", taskId, "--approve", "--from-file", approvalPath, "--dry-run"
     ], env);
-    assert.equal(blockedDryRun.status, 1, JSON.stringify(blockedDryRun.receipt));
-    assert.match(JSON.stringify(blockedDryRun.receipt), /AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED[\s\S]*closeout\.md/u);
+    const blockedCloseoutDryRun = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "closeout", taskId, "--from-file", closeoutPacketPath, "--dry-run"
+    ], env);
+    const blockedCompleteReal = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "complete", taskId, "--approve", "--from-file", approvalPath
+    ], env);
+    for (const blocked of [blockedCompleteDryRun, blockedCloseoutDryRun, blockedCompleteReal]) {
+      assert.equal(blocked.status, 1, JSON.stringify(blocked.receipt));
+      assert.match(JSON.stringify(blocked.receipt), /AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED[\s\S]*closeout\.md/u);
+    }
+    const blockedErrors = [blockedCompleteDryRun, blockedCloseoutDryRun, blockedCompleteReal]
+      .map(({ receipt }) => JSON.stringify(receipt).match(/AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED[\s\S]*?closeout\.md/u)?.[0]);
+    assert.deepEqual(
+      blockedErrors.map((error) => error?.match(/^AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED/u)?.[0]),
+      [
+        "AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED",
+        "AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED",
+        "AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED"
+      ]
+    );
+    for (const error of blockedErrors) assert.match(error ?? "", /closeout\.md/u);
 
     const closeoutDryRun = runRawJsonMaybeFail(fixture.repoRoot, [
       "doc", "sync", "--dry-run"
@@ -173,8 +223,12 @@ test("one task complete intent publishes approval and completion through the pro
     const readyDryRun = runRawJsonMaybeFail(fixture.repoRoot, [
       "task", "complete", taskId, "--approve", "--from-file", approvalPath, "--dry-run"
     ], env);
+    const readyCloseoutDryRun = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "closeout", taskId, "--from-file", closeoutPacketPath, "--dry-run"
+    ], env);
     assert.deepEqual(snapshotDirectory(taskHolderRoot), holderFilesBeforeDryRun, "task complete --dry-run must not create or remove holder files or locks");
     assert.equal(readyDryRun.status, 0, JSON.stringify(readyDryRun.receipt));
+    assert.equal(readyCloseoutDryRun.status, 0, JSON.stringify(readyCloseoutDryRun.receipt));
     const readyDryRunData = (readyDryRun.receipt.details as {
       readonly data?: {
         readonly report?: {
@@ -185,36 +239,58 @@ test("one task complete intent publishes approval and completion through the pro
     } | undefined)?.data;
     assert.deepEqual(readyDryRunData?.report?.checkedGates, ["canonical-authority-planner", "task-completion-evidence"]);
     assert.deepEqual(readyDryRunData?.report?.uncheckedGates, ["durable-transition-write"]);
+    const readyCloseoutDryRunData = (readyCloseoutDryRun.receipt.details as {
+      readonly data?: {
+        readonly report?: {
+          readonly completionPlan?: {
+            readonly checkedGates?: ReadonlyArray<string>;
+            readonly uncheckedGates?: ReadonlyArray<string>;
+          };
+        };
+      };
+    } | undefined)?.data;
+    assert.deepEqual(readyCloseoutDryRunData?.report?.completionPlan?.checkedGates, ["canonical-authority-planner", "task-completion-evidence"]);
+    assert.deepEqual(readyCloseoutDryRunData?.report?.completionPlan?.uncheckedGates, ["durable-transition-write"]);
 
-    const completeCommand = [
-      "task", "complete", taskId, "--approve", "--from-file", approvalPath
+    const closeoutCommand = [
+      "task", "closeout", taskId, "--from-file", closeoutPacketPath
     ] as const;
-    const original = runRawJsonMaybeFail(fixture.repoRoot, completeCommand, env);
+    const original = runRawJsonMaybeFail(fixture.repoRoot, closeoutCommand, env);
     const completed = original.status === 0
       ? original
-      : runRawJsonMaybeFail(fixture.repoRoot, completeCommand, env);
+      : runRawJsonMaybeFail(fixture.repoRoot, closeoutCommand, env);
 
     assert.equal(completed.status, 0, JSON.stringify({ original: original.receipt, completed: completed.receipt }));
     assert.equal(completed.receipt.ok, true, JSON.stringify(completed.receipt));
+    assert.equal(completed.receipt.command, "task closeout", JSON.stringify(completed.receipt));
+    assert.doesNotMatch(JSON.stringify(completed.receipt), /command_receipt_contract_mismatch/u);
     assert.match(readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"), /^  status: done$/mu);
     assert.match(
       readFileSync(path.join(taskRoot, "executions", `${executionId}.md`), "utf8"),
       /^  "state": "accepted",$/mu
     );
-    const details = completed.receipt.details as {
+    const completedData = (completed.receipt.details as {
       readonly data?: {
-        readonly report?: { readonly steps?: ReadonlyArray<Record<string, unknown>> };
+        readonly taskId?: string;
+        readonly status?: string;
+        readonly completionGate?: { readonly ok?: boolean };
+        readonly report?: {
+          readonly completionPlan?: { readonly transitionId?: string };
+        };
       };
-    } | undefined;
-    const transition = details?.data?.report as { readonly transitionId?: string } | undefined;
-    assert.match(transition?.transitionId ?? "", /^trn_[0-9a-f]{32}$/u);
+    } | undefined)?.data;
+    assert.equal(completedData?.taskId, taskId);
+    assert.equal(completedData?.status, "done");
+    assert.equal(completedData?.completionGate?.ok, true);
+    const transitionId = completedData?.report?.completionPlan?.transitionId;
+    assert.match(transitionId ?? "", /^trn_[0-9a-f]{32}$/u);
     for (const attempt of ["replay-1", "replay-2"] as const) {
-      const replayed = runRawJsonMaybeFail(fixture.repoRoot, completeCommand, env);
+      const replayed = runRawJsonMaybeFail(fixture.repoRoot, closeoutCommand, env);
       assert.equal(replayed.status, 0, JSON.stringify({ attempt, original: original.receipt, replayed: replayed.receipt }));
       const replayTransition = ((replayed.receipt.details as {
-        readonly data?: { readonly report?: { readonly transitionId?: string } };
-      } | undefined)?.data?.report)?.transitionId;
-      assert.equal(replayTransition, transition?.transitionId, JSON.stringify({ attempt, replayed: replayed.receipt }));
+        readonly data?: { readonly report?: { readonly completionPlan?: { readonly transitionId?: string } } };
+      } | undefined)?.data?.report?.completionPlan)?.transitionId;
+      assert.equal(replayTransition, transitionId, JSON.stringify({ attempt, replayed: replayed.receipt }));
     }
   } finally {
     await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
@@ -359,6 +435,7 @@ test("task complete consumes one explicitly accepted current round and replays t
     CODEX_THREAD_ID: sessionId
   };
   try {
+    publishSeededTaskFixture(fixture.authoredRoot, taskRoot, taskId);
     const registered = runDaemonCommand(fixture.repoRoot, [
       "daemon", "repo", "register", "--repo-id", "canonical",
       "--canonical-root", fixture.repoRoot, "--user-root", userRoot, "--no-link", "--json"
@@ -526,6 +603,7 @@ test("task complete closes one legacy submitted current round with no live holde
       `tasks/${taskId}-production-route/executions/${executionId}.md`
     );
     git(fixture.authoredRoot, "commit", "-q", "-m", "test: seed submitted current round without a holder");
+    publishSeededTaskFixture(fixture.authoredRoot, taskRoot, taskId);
 
     const registered = runDaemonCommand(fixture.repoRoot, [
       "daemon", "repo", "register", "--repo-id", "canonical",
@@ -584,30 +662,6 @@ test("task complete closes one legacy submitted current round with no live holde
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });
-
-function productionPlan(goal: string): string {
-  return [
-    "# Plan", "",
-    "## Brief", "Brief.",
-    "## Goal", goal,
-    "## Context", "Context.",
-    "## Constraints", "Constraints.",
-    "## Checkpoint", "Checkpoint.",
-    "## CI/Gate Authority Stop Condition", "Stop.",
-    "## Implementation Plan", "Plan.",
-    "## Verification", "Verify.",
-    ""
-  ].join("\n");
-}
-
-function productionCloseout(summary: string): string {
-  return [
-    "# Closeout", "",
-    "## Summary", summary, "",
-    "## Verification", "The production daemon completion chain was exercised.", "",
-    "## Residual Risk", "No residual risk accepted.", ""
-  ].join("\n");
-}
 
 function cliHelp(rootDir: string, args: ReadonlyArray<string>): string {
   return execFileSync(process.execPath, [path.resolve("packages/cli/src/index.ts"), "--root", rootDir, ...args], {

--- a/packages/cli/test/completion-facade-cli.test.ts
+++ b/packages/cli/test/completion-facade-cli.test.ts
@@ -99,7 +99,7 @@ test("owner coldstart approves after the submitted execution lease is released",
   });
 });
 
-test("task complete dry-run previews one terminal intent without evaluating Review rules in the client", () => {
+test("task complete dry-run blocks when the canonical authority planner is unavailable", () => {
   withTempRoot((rootDir) => {
     const chain = prepareSubmitted(rootDir, "Review Evidence Preflight", "facade");
     const packetPath = path.join(rootDir, "invalid-review-evidence-approval.json");
@@ -118,17 +118,11 @@ test("task complete dry-run previews one terminal intent without evaluating Revi
     const preview = runJson(rootDir, [
       "--actor", "human:person_test", "task", "complete", chain.taskId,
       "--approve", "--from-file", packetPath, "--dry-run"
-    ], true, chain.env);
+    ], false, chain.env);
 
-    assert.notEqual(preview.status, "done");
-    assert.equal(preview.report.schema, "task-lifecycle-transition-preview/v1");
-    assert.equal(preview.report.disposition, "server-planner-validation-required");
-    assert.equal(preview.completionGate.ok, false);
-    assert.deepEqual(preview.report.uncheckedGates, [
-      "canonical-authority-planner",
-      "task-completion-evidence",
-      "durable-transition-write"
-    ]);
+    assert.equal(preview.ok, false, JSON.stringify(preview));
+    assert.equal(preview.error.code, "write_rejected");
+    assert.match(preview.error.hint, /canonical authority planner is unavailable/iu);
     assert.equal(existsSync(path.join(rootDir, chain.packagePath, "reviews")), false);
     assert.match(readFileSync(path.join(rootDir, chain.packagePath, "INDEX.md"), "utf8"), /^  status: in_review$/mu);
   });

--- a/packages/cli/test/doc-sync-consumer-closeout.test.ts
+++ b/packages/cli/test/doc-sync-consumer-closeout.test.ts
@@ -63,6 +63,33 @@ test("doc sync keeps a consumer closeout edit visible as a governed task-prose c
   }, { writeRegistry: false });
 });
 
+test("doc sync publishes a consumer task plan through the governed prose road without a registry", async () => {
+  await withHarnessFixture(async ({ rootDir, harnessRoot, taskRoot }) => {
+    const relativePath = `tasks/${taskId}/task_plan.md`;
+    const planPath = path.join(taskRoot, "task_plan.md");
+    writeFileSync(planPath, planBody().replace("Original prose.", "Edited consumer plan."), "utf8");
+
+    const request = buildDocSyncSubmitRequest(
+      rootDir,
+      "consumer",
+      [relativePath],
+      { kind: "agent", id: "codex-test" },
+      cliDaemonServiceHostServices.docSync
+    );
+    const report = buildDocSyncReport(rootDir, cliDaemonServiceHostServices.docSync);
+    assert.deepEqual(report.candidateBlobs.map((entry) => entry.path), [relativePath]);
+    const result = await makeDocSyncService({
+      rootDir,
+      coordinator: attributedCoordinator(rootDir),
+      hostServices: cliDaemonServiceHostServices.docSync
+    }).submit(request);
+
+    assert.equal(result.ok, true, JSON.stringify(result));
+    if (result.ok) assert.deepEqual(result.appliedChanges.map((change) => change.path), [relativePath]);
+    assert.equal(git(harnessRoot, "status", "--short"), "");
+  });
+});
+
 test("doc sync rejects a closeout request whose task package is swapped to an external symlink", async () => {
   await withHarnessFixture(async ({ rootDir, harnessRoot, taskRoot }) => {
     const closeoutPath = path.join(taskRoot, "closeout.md");

--- a/packages/cli/test/doc-sync-consumer-closeout.test.ts
+++ b/packages/cli/test/doc-sync-consumer-closeout.test.ts
@@ -90,6 +90,38 @@ test("doc sync publishes a consumer task plan through the governed prose road wi
   });
 });
 
+test("doc sync rejects a template-shaped consumer document whose declared preset is invalid", async () => {
+  await withHarnessFixture(({ rootDir, harnessRoot, taskRoot }) => {
+    const relativePath = `tasks/${taskId}/task_plan.md`;
+    writeFileSync(
+      path.join(taskRoot, "INDEX.md"),
+      taskIndex().replace("preset: standard-task", "preset: definitely-not-installed"),
+      "utf8"
+    );
+    git(harnessRoot, "add", `tasks/${taskId}/INDEX.md`);
+    gitCommit(harnessRoot, "declare invalid preset");
+    writeFileSync(
+      path.join(taskRoot, "task_plan.md"),
+      planBody().replace("Original prose.", "Template-shaped but undeclared prose."),
+      "utf8"
+    );
+
+    const report = buildDocSyncReport(rootDir, cliDaemonServiceHostServices.docSync);
+    assert.deepEqual(report.candidateBlobs.map((entry) => entry.path), []);
+    assert.deepEqual(report.writeIntentPreview.changes.map((entry) => entry.path), []);
+    assert.throws(
+      () => buildDocSyncSubmitRequest(
+        rootDir,
+        "consumer",
+        [relativePath],
+        { kind: "agent", id: "codex-test" },
+        cliDaemonServiceHostServices.docSync
+      ),
+      /Doc sync selected path is not dirty or is unknown/u
+    );
+  });
+});
+
 test("doc sync rejects a closeout request whose task package is swapped to an external symlink", async () => {
   await withHarnessFixture(async ({ rootDir, harnessRoot, taskRoot }) => {
     const closeoutPath = path.join(taskRoot, "closeout.md");

--- a/packages/cli/test/doc-sync-service.test.ts
+++ b/packages/cli/test/doc-sync-service.test.ts
@@ -67,15 +67,17 @@ test("doc sync preview and submit validator classify same-extension prose and fr
   });
 });
 
-test("doc sync report treats a missing write-road registry as empty coverage instead of crashing", async () => {
+test("doc sync report supplies the installed consumer task-prose road when the dogfood registry is missing", async () => {
   // Regression for #644: consumer repos have no dogfood write-road registry, so the
   // unguarded readFileSync in loadRegistry crashed every decision command (incl. --dry-run).
-  await withHarnessFixture(async ({ rootDir, taskRoot }) => {
-    writeFileSync(path.join(taskRoot, "task_plan.md"), "# Plan\n\nConsumer edit.\n", "utf8");
+  await withHarnessFixture(async ({ rootDir, taskRoot, taskId }) => {
+    writeFileSync(path.join(taskRoot, "task_plan.md"), planBody("Consumer edit."), "utf8");
     const report = buildDocSyncReport(rootDir);
-    // Inert: no crash, empty coverage, and no manufactured warnings/touches.
+    // Consumer installs do not ship the dogfood registry, but their declared task
+    // prose still resolves through the bundled preset/template policy.
     assert.equal(report.registry.sha256, sha256Text(""));
-    assert.equal(report.dirtyFiles.length, 0);
+    assert.deepEqual(report.dirtyFiles.map((entry) => entry.path), [`tasks/${taskId}/task_plan.md`]);
+    assert.deepEqual(report.candidateBlobs.map((entry) => entry.path), [`tasks/${taskId}/task_plan.md`]);
     assert.deepEqual(report.forbiddenTouches, []);
     assert.deepEqual(report.unresolvedTouches, []);
     assert.equal(report.readyToSubmitPreview, true);

--- a/packages/cli/test/helpers/canonical-task-publication-fixture.ts
+++ b/packages/cli/test/helpers/canonical-task-publication-fixture.ts
@@ -1,27 +1,56 @@
-import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { readFileSync, readdirSync, rmSync } from "node:fs";
 import path from "node:path";
+import { Effect } from "effect";
+import {
+  makeJournaledWriteCoordinator,
+  taskEntityId
+} from "../../../kernel/src/index.ts";
 import { git } from "../production-authority-canonical-ingress/fixture.ts";
 
 export function publishSeededTaskFixture(authoredRoot: string, taskRoot: string, taskId: string): void {
+  const rootDir = path.dirname(authoredRoot);
   const taskPath = path.relative(authoredRoot, taskRoot).split(path.sep).join("/");
   const files = snapshotTextTree(taskRoot);
-  const trunk = git(authoredRoot, "branch", "--show-current");
-  const sessionBranch = `sessions/fixture-task-seed-${taskId}`;
   const opId = `op_fixture_task_seed_${taskId}`;
+  const packageName = path.basename(taskRoot);
+  const packageSlug = packageName === taskId ? undefined : packageName.slice(`${taskId}-`.length);
   rmSync(taskRoot, { recursive: true, force: true });
   git(authoredRoot, "add", "-A", taskPath);
   git(authoredRoot, "commit", "-q", "-m", "test: prepare canonical task creation fixture");
-  git(authoredRoot, "checkout", "-q", "-b", sessionBranch);
-  for (const [relativePath, body] of files) {
-    const target = path.join(taskRoot, relativePath);
-    mkdirSync(path.dirname(target), { recursive: true });
-    writeFileSync(target, body);
-  }
-  git(authoredRoot, "add", taskPath);
-  git(authoredRoot, "commit", "-q", "-m", `harness write fixture task seed [${opId}]`);
-  git(authoredRoot, "checkout", "-q", trunk);
-  git(authoredRoot, "merge", "-q", "--no-ff", "-m", `materialize fixture task seed [${opId}]`, sessionBranch);
+  const coordinator = makeJournaledWriteCoordinator({
+    rootDir,
+    attribution: fixtureAttribution,
+    sessionId: `fixture-task-seed-${taskId}`,
+    commitAuthor: { name: "Harness Test", email: "harness@example.test" }
+  });
+  Effect.runSync(coordinator.enqueue({
+    opId,
+    entityId: taskEntityId(taskId),
+    kind: "package_create",
+    payload: {
+      writes: files.map(([relativePath, body]) => ({
+        taskId,
+        path: relativePath.split(path.sep).join("/"),
+        body,
+        ...(packageSlug ? { packageSlug } : {})
+      }))
+    }
+  }));
+  Effect.runSync(coordinator.flush("explicit"));
 }
+
+const fixtureAttribution = {
+  actor: {
+    principal: { kind: "person" as const, personId: "person_fixture" },
+    executor: { kind: "agent" as const, id: "fixture-writer" }
+  },
+  principalSource: {
+    kind: "local-configured" as const,
+    authority: "harness.yaml",
+    authoritySha256: `sha256:${"0".repeat(64)}`
+  },
+  executorSource: "client-asserted" as const
+};
 
 export function productionPlan(goal: string): string {
   return [

--- a/packages/cli/test/helpers/canonical-task-publication-fixture.ts
+++ b/packages/cli/test/helpers/canonical-task-publication-fixture.ts
@@ -1,0 +1,61 @@
+import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { git } from "../production-authority-canonical-ingress/fixture.ts";
+
+export function publishSeededTaskFixture(authoredRoot: string, taskRoot: string, taskId: string): void {
+  const taskPath = path.relative(authoredRoot, taskRoot).split(path.sep).join("/");
+  const files = snapshotTextTree(taskRoot);
+  const trunk = git(authoredRoot, "branch", "--show-current");
+  const sessionBranch = `sessions/fixture-task-seed-${taskId}`;
+  const opId = `op_fixture_task_seed_${taskId}`;
+  rmSync(taskRoot, { recursive: true, force: true });
+  git(authoredRoot, "add", "-A", taskPath);
+  git(authoredRoot, "commit", "-q", "-m", "test: prepare canonical task creation fixture");
+  git(authoredRoot, "checkout", "-q", "-b", sessionBranch);
+  for (const [relativePath, body] of files) {
+    const target = path.join(taskRoot, relativePath);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, body);
+  }
+  git(authoredRoot, "add", taskPath);
+  git(authoredRoot, "commit", "-q", "-m", `harness write fixture task seed [${opId}]`);
+  git(authoredRoot, "checkout", "-q", trunk);
+  git(authoredRoot, "merge", "-q", "--no-ff", "-m", `materialize fixture task seed [${opId}]`, sessionBranch);
+}
+
+export function productionPlan(goal: string): string {
+  return [
+    "# Plan", "",
+    "## Brief", "Brief.",
+    "## Goal", goal,
+    "## Context", "Context.",
+    "## Constraints", "Constraints.",
+    "## Checkpoint", "Checkpoint.",
+    "## CI/Gate Authority Stop Condition", "Stop.",
+    "## Implementation Plan", "Plan.",
+    "## Verification", "Verify.",
+    ""
+  ].join("\n");
+}
+
+export function productionCloseout(summary: string): string {
+  return [
+    "# Closeout", "",
+    "## Summary", summary, "",
+    "## Verification", "The production daemon completion chain was exercised.", "",
+    "## Residual Risk", "No residual risk accepted.", ""
+  ].join("\n");
+}
+
+function snapshotTextTree(rootDir: string): ReadonlyArray<readonly [string, string]> {
+  const rows: Array<readonly [string, string]> = [];
+  const visit = (current: string): void => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const absolute = path.join(current, entry.name);
+      if (entry.isDirectory()) visit(absolute);
+      else if (entry.isFile()) rows.push([path.relative(rootDir, absolute), readFileSync(absolute, "utf8")]);
+    }
+  };
+  visit(rootDir);
+  return rows.sort(([left], [right]) => left.localeCompare(right));
+}

--- a/packages/cli/test/production-authority-canonical-ingress-tracer.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress-tracer.test.ts
@@ -19,6 +19,7 @@ import {
   createFixture,
   latestAuthorityOperation
 } from "./production-authority-canonical-ingress/fixture.ts";
+import { publishSeededTaskFixture } from "./helpers/canonical-task-publication-fixture.ts";
 
 test("PR canonical ingress keeps two interleaved session receipts determinate", { timeout: 60_000 }, async () => {
   const fixture = createFixture();
@@ -180,6 +181,7 @@ test("commit-anchor completion crosses production authority with daemon judgment
     ].join("\n"));
     execFileSync("git", ["-c", "user.name=Harness Test", "-c", "user.email=harness@example.test", "add", "."], { cwd: fixture.authoredRoot });
     execFileSync("git", ["-c", "user.name=Harness Test", "-c", "user.email=harness@example.test", "commit", "-q", "-m", "seed commit completion fixture"], { cwd: fixture.authoredRoot });
+    publishSeededTaskFixture(fixture.authoredRoot, taskRoot, taskId);
 
     const registered = runDaemonCommand(fixture.repoRoot, [
       "daemon", "repo", "register", "--repo-id", "canonical", "--canonical-root", fixture.repoRoot,

--- a/packages/cli/test/production-authority-canonical-ingress/fixture.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/fixture.ts
@@ -68,10 +68,7 @@ export function createFixture() {
     "task_01KXQ4WTA7Q4XJ5GDDRS1YXNK6"
   ]) {
     mkdirSync(path.join(authoredRoot, `tasks/${taskId}`), { recursive: true });
-    const body = taskId.endsWith("NK0")
-      ? taskIndexBody(taskId).replace("vertical: default", "vertical: software/coding")
-      : taskIndexBody(taskId);
-    writeFileSync(path.join(authoredRoot, `tasks/${taskId}/INDEX.md`), body);
+    writeFileSync(path.join(authoredRoot, `tasks/${taskId}/INDEX.md`), taskIndexBody(taskId));
   }
   mkdirSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route"), { recursive: true });
   writeFileSync(path.join(authoredRoot, "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8-production-route/INDEX.md"), taskIndexBody("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8"));
@@ -379,7 +376,7 @@ function operationPath(serviceRoot: string): string {
 }
 
 function taskIndexBody(taskId: string): string {
-  return ["---", "schema: task-package/v2", `task_id: ${taskId}`, "title: Production ingress", "lifecycle:", "  bindingSchema: lifecycle-binding/v1", "  engine: local", "  status: active", "  ref: ", "  titleSnapshot: Production ingress", "  url: ", "  bindingCreatedAt: 2026-07-17T00:00:00.000Z", `  bindingFingerprint: sha256:${"b".repeat(64)}`, "packageDisposition: active", "vertical: default", "preset: default", "provenance:", "  - {runtime: \"human\", sessionId: \"fixture\", boundAt: \"2026-07-17T00:00:00.000Z\"}", "---", "", "# Production ingress", ""].join("\n");
+  return ["---", "schema: task-package/v2", `task_id: ${taskId}`, "title: Production ingress", "lifecycle:", "  bindingSchema: lifecycle-binding/v1", "  engine: local", "  status: active", "  ref: ", "  titleSnapshot: Production ingress", "  url: ", "  bindingCreatedAt: 2026-07-17T00:00:00.000Z", `  bindingFingerprint: sha256:${"b".repeat(64)}`, "packageDisposition: active", "vertical: software/coding", "preset: standard-task", "provenance:", "  - {runtime: \"human\", sessionId: \"fixture\", boundAt: \"2026-07-17T00:00:00.000Z\"}", "---", "", "# Production ingress", ""].join("\n");
 }
 
 function writeReviewVerdictTask(

--- a/packages/cli/test/receipt-contracts.test.ts
+++ b/packages/cli/test/receipt-contracts.test.ts
@@ -84,11 +84,14 @@ test("command receipts fail closed on missing declared success data", () => {
   }
 });
 
-test("task closeout dry-run uses its declared receipt variant while real closeout stays strict", () => {
+test("task closeout derives the task-complete receipt contract for dry-run and real success", () => {
+  assert.deepEqual(commandReceiptContractsByKind["task-closeout"], commandReceiptContractsByKind["task-complete"]);
   const dryRun = toCommandReceipt({
     ok: true,
     command: "task-closeout",
     taskId: "task_1",
+    status: "in_review",
+    completionGate: { ok: false, dryRun: true },
     report: { schema: "task-closeout-dry-run/v1", dryRun: true }
   });
   assert.equal(dryRun.ok, true, JSON.stringify(dryRun));
@@ -97,10 +100,11 @@ test("task closeout dry-run uses its declared receipt variant while real closeou
     ok: true,
     command: "task-closeout",
     taskId: "task_1",
+    status: "done",
+    completionGate: { ok: true },
     report: { schema: "task-closeout-result/v1" }
   });
-  assert.equal(realCloseout.ok, false);
-  if (!realCloseout.ok) assert.match(realCloseout.error?.hint ?? "", /data\.executionId, data\.status/u);
+  assert.equal(realCloseout.ok, true, JSON.stringify(realCloseout));
 });
 
 test("command receipts fail closed on missing declared paths", () => {
@@ -390,9 +394,37 @@ test("optional receipt contract fields carry non-empty absence reasons", () => {
     field: "data.completionGate",
     reason: "Only emitted by completion-oriented task gate results; ordinary task review emits the review contract only."
   }, {
+    command: "task-closeout",
+    field: "data.report",
+    reason: "Only emitted for completion paths that surface a review or gate report; clean completion emits reviewContract and completionGate."
+  }, {
+    command: "task-closeout",
+    field: "data.authorityOutcome",
+    reason: "Only emitted when the production authority reports an already-satisfied replay."
+  }, {
+    command: "task-closeout",
+    field: "data.completionEvidence",
+    reason: "Only emitted when completion accepts an immutable commit-anchor judgment record."
+  }, {
+    command: "task-closeout",
+    field: "data.executionId",
+    reason: "Only emitted when completion accepts a submitted Execution."
+  }, {
+    command: "task-closeout",
+    field: "data.repoWrite",
+    reason: "Only emitted when the production daemon child includes its durable writer outcome."
+  }, {
+    command: "task-closeout",
+    field: "data.reviewContract",
+    reason: "Compatibility-only legacy review.md gate evidence; it never authorizes completion."
+  }, {
     command: "task-complete",
     field: "data.report",
     reason: "Only emitted for completion paths that surface a review or gate report; clean completion emits reviewContract and completionGate."
+  }, {
+    command: "task-complete",
+    field: "data.authorityOutcome",
+    reason: "Only emitted when the production authority reports an already-satisfied replay."
   }, {
     command: "task-complete",
     field: "data.completionEvidence",
@@ -401,6 +433,10 @@ test("optional receipt contract fields carry non-empty absence reasons", () => {
     command: "task-complete",
     field: "data.executionId",
     reason: "Only emitted when completion accepts a submitted Execution."
+  }, {
+    command: "task-complete",
+    field: "data.repoWrite",
+    reason: "Only emitted when the production daemon child includes its durable writer outcome."
   }, {
     command: "task-complete",
     field: "data.reviewContract",

--- a/packages/cli/test/task-lifecycle-facade-cli.test.ts
+++ b/packages/cli/test/task-lifecycle-facade-cli.test.ts
@@ -132,24 +132,22 @@ test("changes_requested closeout packet cannot complete the submitted task", () 
   });
 });
 
-test("closeout dry-run satisfies its receipt contract without inventing execution state", () => {
+test("completion dry-runs fail closed when the authority planner is unavailable", () => {
   withTempRoot((rootDir) => {
     const fixture = prepareActiveTask(rootDir, "Dry Run Contract");
     const packet = writeCloseoutPacket(rootDir);
+    const approvalPacket = writeApprovalPacket(rootDir);
     const taskRoot = path.join(rootDir, fixture.packagePath);
     const indexBefore = readFileSync(path.join(taskRoot, "INDEX.md"), "utf8");
 
-    const previewed = runJson(rootDir, ["task", "closeout", fixture.taskId, "--from-file", packet, "--dry-run"], true, fixture.env);
+    const closeout = runJson(rootDir, ["task", "closeout", fixture.taskId, "--from-file", packet, "--dry-run"], false, fixture.env);
+    const complete = runJson(rootDir, ["task", "complete", fixture.taskId, "--approve", "--from-file", approvalPacket, "--dry-run"], false, fixture.env);
 
-    assert.equal(previewed.ok, true);
-    assert.equal(previewed.command, "task-closeout");
-    assert.equal(previewed.taskId, fixture.taskId);
-    assert.equal(previewed.executionId, undefined);
-    assert.equal(previewed.status, undefined);
-    assert.equal(previewed.report.schema, "task-closeout-dry-run/v1");
-    assert.equal(previewed.report.dryRun, true);
-    assert.equal(previewed.report.preview.schema, "command-dry-run-preview/v1");
-    assert.deepEqual(previewed.report.steps, ["task-complete"]);
+    assert.deepEqual([closeout.ok, complete.ok], [false, false], JSON.stringify({ closeout, complete }));
+    for (const previewed of [closeout, complete]) {
+      assert.equal(previewed.error.code, "write_rejected", JSON.stringify(previewed));
+      assert.match(previewed.error.hint, /authority planner.+unavailable/iu);
+    }
     assert.equal(readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"), indexBefore);
   });
 });

--- a/packages/daemon/src/authority/production/task-complete-prepublish-publication.ts
+++ b/packages/daemon/src/authority/production/task-complete-prepublish-publication.ts
@@ -1,21 +1,33 @@
 import { execFileSync } from "node:child_process";
-import { stableStringify } from "@harness-anything/kernel";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  decodeAttributionEventBody,
+  resolveHarnessLayout,
+  sha256Text,
+  stablePayloadHash,
+  stableStringify,
+  taskPackagePath,
+  type AttributionEvent,
+  type HarnessLayoutInput
+} from "@harness-anything/kernel";
 
 export function findAttributedMaterializedPublication(
   rootDir: string,
+  authoredRoot: string,
   repositoryPaths: ReadonlyArray<string>,
   bodies: ReadonlyArray<string>,
   headRef = "HEAD"
 ): { readonly commit: string; readonly operationIds: ReadonlyArray<string> } {
-  const expectedBlobs = bodies.map((body) => taskCompletePublicationGitText(rootDir, ["hash-object", "--stdin"], body));
-  const currentBlobs = gitBlobIds(rootDir, headRef, repositoryPaths);
+  const expectedBlobs = bodies.map((body) => taskCompletePublicationGitText(authoredRoot, ["hash-object", "--stdin"], body));
+  const currentBlobs = gitBlobIds(authoredRoot, headRef, repositoryPaths);
   if (currentBlobs.some((actual, index) => actual !== expectedBlobs[index])) {
     throw new Error(
       `AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:${describeMaterializationMismatches(repositoryPaths, currentBlobs, expectedBlobs)}`
     );
   }
   const attributions = repositoryPaths.map((repositoryPath, index) =>
-    findPathMaterializedPublication(rootDir, repositoryPath, expectedBlobs[index]!, headRef)
+    findPathMaterializedPublication(rootDir, authoredRoot, repositoryPath, bodies[index]!, expectedBlobs[index]!, headRef)
   );
   const missing = attributions.flatMap((attribution, index) => attribution ? [] : [repositoryPaths[index]!]);
   if (missing.length > 0) {
@@ -27,7 +39,7 @@ export function findAttributedMaterializedPublication(
   }
   const attributed = attributions.filter((entry): entry is NonNullable<typeof entry> => entry !== null);
   const attributedCommits = new Set(attributed.map((entry) => entry.commit));
-  const representative = firstParentHistory(rootDir, repositoryPaths, headRef)
+  const representative = firstParentHistory(authoredRoot, repositoryPaths, headRef)
     .find((entry) => attributedCommits.has(entry.commit));
   if (!representative) throw new Error("AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:attributed publication missing from first-parent history");
   return {
@@ -38,42 +50,19 @@ export function findAttributedMaterializedPublication(
 
 export function assertAttributedMaterializedPublication(
   rootDir: string,
+  authoredRoot: string,
   repositoryCommit: string,
   repositoryPaths: ReadonlyArray<string>,
   bodies: ReadonlyArray<string>,
   expectedOperationIds: ReadonlyArray<string>,
   headRef = "HEAD"
 ): void {
-  const publication = findAttributedMaterializedPublication(rootDir, repositoryPaths, bodies, headRef);
+  const publication = findAttributedMaterializedPublication(rootDir, authoredRoot, repositoryPaths, bodies, headRef);
   if (publication.commit !== repositoryCommit) {
     throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_COMMIT_NOT_PATH_ATTRIBUTED");
   }
   if (stableStringify(publication.operationIds) !== stableStringify(expectedOperationIds)) {
     throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_OPERATION_MISMATCH");
-  }
-}
-
-export function assertCommittedMaterializedPublication(
-  rootDir: string,
-  repositoryCommit: string,
-  repositoryPaths: ReadonlyArray<string>,
-  bodies: ReadonlyArray<string>,
-  expectedOperationIds: ReadonlyArray<string>
-): void {
-  try {
-    assertAttributedMaterializedPublication(
-      rootDir,
-      repositoryCommit,
-      repositoryPaths,
-      bodies,
-      expectedOperationIds,
-      repositoryCommit
-    );
-  } catch {
-    // Already-committed transitions may contain the pre-attribution witness shape.
-    // The fallback is replay-only; every current/new completion uses strict path
-    // attribution before it can commit.
-    assertLegacyMaterializedPublication(rootDir, repositoryCommit, repositoryPaths, bodies, expectedOperationIds);
   }
 }
 
@@ -100,17 +89,27 @@ export function prepublishGitTextOrNull(rootDir: string, args: ReadonlyArray<str
 
 function findPathMaterializedPublication(
   rootDir: string,
+  authoredRoot: string,
   repositoryPath: string,
+  expectedBody: string,
   expectedBlob: string,
   headRef: string
 ): { readonly commit: string; readonly operationIds: ReadonlyArray<string> } | null {
-  for (const entry of firstParentHistory(rootDir, [repositoryPath], headRef)) {
+  for (const entry of firstParentHistory(authoredRoot, [repositoryPath], headRef)) {
     if (entry.parents.length !== 2) continue;
-    const [actualBlob] = gitBlobIds(rootDir, entry.commit, [repositoryPath]);
+    const [actualBlob] = gitBlobIds(authoredRoot, entry.commit, [repositoryPath]);
     if (actualBlob !== expectedBlob) continue;
-    const [firstParentBlob] = gitBlobIds(rootDir, entry.parents[0]!, [repositoryPath]);
+    const [firstParentBlob] = gitBlobIds(authoredRoot, entry.parents[0]!, [repositoryPath]);
     if (firstParentBlob === actualBlob) continue;
-    const operationIds = attributedPathOperationIds(rootDir, entry.parents[0]!, entry.parents[1]!, repositoryPath, expectedBlob);
+    const operationIds = attributedPathOperationIds(
+      rootDir,
+      authoredRoot,
+      entry.parents[0]!,
+      entry.parents[1]!,
+      repositoryPath,
+      expectedBody,
+      expectedBlob
+    );
     if (operationIds.length === 0) continue;
     return { commit: entry.commit, operationIds };
   }
@@ -119,12 +118,14 @@ function findPathMaterializedPublication(
 
 function attributedPathOperationIds(
   rootDir: string,
+  authoredRoot: string,
   firstParent: string,
   authorityTip: string,
   repositoryPath: string,
+  expectedBody: string,
   expectedBlob: string
 ): ReadonlyArray<string> {
-  const commits = taskCompletePublicationGitText(rootDir, [
+  const commits = taskCompletePublicationGitText(authoredRoot, [
     "rev-list",
     "--reverse",
     "--topo-order",
@@ -134,10 +135,142 @@ function attributedPathOperationIds(
   ]).split(/\r?\n/u).map((entry) => entry.trim()).filter(Boolean);
   const lastChangingCommit = commits.at(-1);
   if (!lastChangingCommit) return [];
-  const [attributedBlob] = gitBlobIds(rootDir, lastChangingCommit, [repositoryPath]);
+  const [attributedBlob] = gitBlobIds(authoredRoot, lastChangingCommit, [repositoryPath]);
   if (attributedBlob !== expectedBlob) return [];
-  const subject = taskCompletePublicationGitText(rootDir, ["show", "-s", "--format=%s", lastChangingCommit]);
-  return publicationOperationIds(subject);
+  const subject = taskCompletePublicationGitText(authoredRoot, ["show", "-s", "--format=%s", lastChangingCommit]);
+  return publicationOperationIds(subject).filter((operationId) => durableAttributionConfirmsPath({
+    rootDir,
+    authoredRoot,
+    firstParent,
+    authorityTip,
+    operationId,
+    repositoryPath,
+    expectedBody
+  }));
+}
+
+function durableAttributionConfirmsPath(input: {
+  readonly rootDir: string;
+  readonly authoredRoot: string;
+  readonly firstParent: string;
+  readonly authorityTip: string;
+  readonly operationId: string;
+  readonly repositoryPath: string;
+  readonly expectedBody: string;
+}): boolean {
+  try {
+    const rootInput = taskCompleteLayoutInput(input.rootDir, input.authoredRoot);
+    const eventPath = repositoryRelativePath(
+      input.authoredRoot,
+      path.join(resolveHarnessLayout(rootInput).attributionEventsRoot, `${sha256Text(input.operationId)}.jsonl`)
+    );
+    const [authorityEventBlob] = gitBlobIds(input.authoredRoot, input.authorityTip, [eventPath]);
+    const [firstParentEventBlob] = gitBlobIds(input.authoredRoot, input.firstParent, [eventPath]);
+    if (!authorityEventBlob || authorityEventBlob === firstParentEventBlob) return false;
+    const eventBody = taskCompletePublicationGitText(input.authoredRoot, ["show", `${input.authorityTip}:${eventPath}`]);
+    const event = decodeAttributionEventBody(eventBody);
+    if (event.opId !== input.operationId) return false;
+    const payload = readVerifiedAttributionPayload(input.rootDir, event);
+    return attributionPayloadConfirmsPath(rootInput, input.authoredRoot, event, payload, input.repositoryPath, input.expectedBody);
+  } catch {
+    return false;
+  }
+}
+
+function readVerifiedAttributionPayload(rootDir: string, event: AttributionEvent): Record<string, unknown> {
+  const absoluteRoot = path.resolve(rootDir);
+  const payloadPath = path.resolve(absoluteRoot, event.payloadRef.path);
+  if (!isWithinRoot(absoluteRoot, payloadPath)) throw new Error("attribution payload path escapes root");
+  const body = readFileSync(payloadPath, "utf8");
+  if (sha256Text(body) !== event.payloadRef.sha256) throw new Error("attribution payload bytes differ");
+  const payload: unknown = JSON.parse(body);
+  if (!payload || typeof payload !== "object" || Array.isArray(payload) || stablePayloadHash(payload) !== event.payloadHash) {
+    throw new Error("attribution payload hash differs");
+  }
+  return payload as Record<string, unknown>;
+}
+
+function attributionPayloadConfirmsPath(
+  rootInput: HarnessLayoutInput,
+  authoredRoot: string,
+  event: AttributionEvent,
+  payload: Record<string, unknown>,
+  repositoryPath: string,
+  expectedBody: string
+): boolean {
+  const expectedBodySha256 = sha256Text(expectedBody);
+  if (event.kind === "doc_sync_submit" || event.kind === "script_ingest") {
+    return payloadWrites(payload).some((write) => write.path === repositoryPath && writeBodyMatches(write, expectedBodySha256));
+  }
+  const batchWrites = [
+    ...payloadWrites(payload),
+    ...recordWrites(payload.taskWrites)
+  ];
+  if (batchWrites.some((write) => taskDocumentWriteMatches(rootInput, authoredRoot, write, repositoryPath, expectedBodySha256))) {
+    return true;
+  }
+  const taskId = taskIdFromAttributionEvent(event);
+  const pathValue = typeof payload.path === "string" ? payload.path : null;
+  if (!taskId || !pathValue) return false;
+  const packageRoot = taskPackagePath(rootInput, taskId);
+  const targetPath = repositoryRelativePath(authoredRoot, path.join(packageRoot, pathValue));
+  if (targetPath !== repositoryPath) return false;
+  return writeBodyMatches(payload, expectedBodySha256) || typeof payload.append === "string" || payload.appendRecord !== undefined;
+}
+
+function taskDocumentWriteMatches(
+  rootInput: HarnessLayoutInput,
+  authoredRoot: string,
+  write: Record<string, unknown>,
+  repositoryPath: string,
+  expectedBodySha256: string
+): boolean {
+  if (typeof write.taskId !== "string" || typeof write.path !== "string") return false;
+  const packageRoot = taskPackagePath(rootInput, write.taskId);
+  const targetPath = repositoryRelativePath(authoredRoot, path.join(packageRoot, write.path));
+  return targetPath === repositoryPath && writeBodyMatches(write, expectedBodySha256);
+}
+
+function payloadWrites(payload: Record<string, unknown>): ReadonlyArray<Record<string, unknown>> {
+  return recordWrites(payload.writes);
+}
+
+function recordWrites(value: unknown): ReadonlyArray<Record<string, unknown>> {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is Record<string, unknown> => Boolean(entry) && typeof entry === "object" && !Array.isArray(entry))
+    : [];
+}
+
+function writeBodyMatches(write: Record<string, unknown>, expectedBodySha256: string): boolean {
+  return (typeof write.body === "string" && sha256Text(write.body) === expectedBodySha256)
+    || write.bodySha256 === expectedBodySha256;
+}
+
+function taskIdFromAttributionEvent(event: AttributionEvent): string | null {
+  const match = /^task\/(.+)$/u.exec(event.entityId);
+  return match?.[1] ?? null;
+}
+
+function taskCompleteLayoutInput(rootDir: string, authoredRoot: string): HarnessLayoutInput {
+  const relativeAuthoredRoot = path.relative(rootDir, authoredRoot).split(path.sep).join("/") || ".";
+  if (relativeAuthoredRoot.startsWith("../") || path.isAbsolute(relativeAuthoredRoot)) {
+    throw new Error("authored root escapes repository");
+  }
+  return {
+    rootDir,
+    layoutOverrides: { authoredRoot: relativeAuthoredRoot }
+  };
+}
+
+function repositoryRelativePath(repositoryRoot: string, absolutePath: string): string {
+  const relative = path.relative(repositoryRoot, absolutePath).split(path.sep).join("/");
+  if (!relative || relative.startsWith("../") || path.isAbsolute(relative)) throw new Error("path escapes repository");
+  return relative;
+}
+
+function isWithinRoot(rootDir: string, candidate: string): boolean {
+  const relative = path.relative(rootDir, candidate);
+  return relative.length > 0 && relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
 }
 
 function describeMaterializationMismatches(
@@ -152,38 +285,6 @@ function describeMaterializationMismatches(
       ? `${repositoryPath} (missing from HEAD)`
       : `${repositoryPath} (content differs from expected)`];
   }).join(", ");
-}
-
-function assertLegacyMaterializedPublication(
-  rootDir: string,
-  repositoryCommit: string,
-  repositoryPaths: ReadonlyArray<string>,
-  bodies: ReadonlyArray<string>,
-  expectedOperationIds: ReadonlyArray<string>
-): void {
-  const entry = firstParentHistory(rootDir, repositoryPaths)
-    .find((candidate) => candidate.commit === repositoryCommit);
-  if (!entry || entry.parents.length !== 2) {
-    throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_COMMIT_NOT_MATERIALIZED_FIRST_PARENT");
-  }
-  const operationIds = canonicalPublicationOperationIds(rootDir, entry);
-  if (operationIds.length === 0 || stableStringify(operationIds) !== stableStringify(expectedOperationIds)) {
-    throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_OPERATION_MISMATCH");
-  }
-  const expectedBlobs = bodies.map((body) => taskCompletePublicationGitText(rootDir, ["hash-object", "--stdin"], body));
-  const actualBlobs = gitBlobIds(rootDir, repositoryCommit, repositoryPaths);
-  const matches = actualBlobs.every((actual, index) => actual === expectedBlobs[index]);
-  if (!matches) throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_BLOB_MISMATCH");
-}
-
-function canonicalPublicationOperationIds(
-  rootDir: string,
-  entry: { readonly parents: ReadonlyArray<string>; readonly subject: string }
-): ReadonlyArray<string> {
-  const firstParentIds = publicationOperationIds(entry.subject);
-  return firstParentIds.length > 0
-    ? firstParentIds
-    : publicationOperationIds(taskCompletePublicationGitText(rootDir, ["show", "-s", "--format=%s", entry.parents[1]!]));
 }
 
 function firstParentHistory(rootDir: string, repositoryPaths: ReadonlyArray<string>, headRef = "HEAD"): ReadonlyArray<{

--- a/packages/daemon/src/authority/production/task-complete-prepublish-publication.ts
+++ b/packages/daemon/src/authority/production/task-complete-prepublish-publication.ts
@@ -1,33 +1,21 @@
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import path from "node:path";
-import {
-  decodeAttributionEventBody,
-  resolveHarnessLayout,
-  sha256Text,
-  stablePayloadHash,
-  stableStringify,
-  taskPackagePath,
-  type AttributionEvent,
-  type HarnessLayoutInput
-} from "@harness-anything/kernel";
+import { stableStringify } from "@harness-anything/kernel";
 
 export function findAttributedMaterializedPublication(
   rootDir: string,
-  authoredRoot: string,
   repositoryPaths: ReadonlyArray<string>,
   bodies: ReadonlyArray<string>,
   headRef = "HEAD"
 ): { readonly commit: string; readonly operationIds: ReadonlyArray<string> } {
-  const expectedBlobs = bodies.map((body) => taskCompletePublicationGitText(authoredRoot, ["hash-object", "--stdin"], body));
-  const currentBlobs = gitBlobIds(authoredRoot, headRef, repositoryPaths);
+  const expectedBlobs = bodies.map((body) => taskCompletePublicationGitText(rootDir, ["hash-object", "--stdin"], body));
+  const currentBlobs = gitBlobIds(rootDir, headRef, repositoryPaths);
   if (currentBlobs.some((actual, index) => actual !== expectedBlobs[index])) {
     throw new Error(
       `AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:${describeMaterializationMismatches(repositoryPaths, currentBlobs, expectedBlobs)}`
     );
   }
   const attributions = repositoryPaths.map((repositoryPath, index) =>
-    findPathMaterializedPublication(rootDir, authoredRoot, repositoryPath, bodies[index]!, expectedBlobs[index]!, headRef)
+    findPathMaterializedPublication(rootDir, repositoryPath, expectedBlobs[index]!, headRef)
   );
   const missing = attributions.flatMap((attribution, index) => attribution ? [] : [repositoryPaths[index]!]);
   if (missing.length > 0) {
@@ -39,7 +27,7 @@ export function findAttributedMaterializedPublication(
   }
   const attributed = attributions.filter((entry): entry is NonNullable<typeof entry> => entry !== null);
   const attributedCommits = new Set(attributed.map((entry) => entry.commit));
-  const representative = firstParentHistory(authoredRoot, repositoryPaths, headRef)
+  const representative = firstParentHistory(rootDir, repositoryPaths, headRef)
     .find((entry) => attributedCommits.has(entry.commit));
   if (!representative) throw new Error("AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:attributed publication missing from first-parent history");
   return {
@@ -50,14 +38,13 @@ export function findAttributedMaterializedPublication(
 
 export function assertAttributedMaterializedPublication(
   rootDir: string,
-  authoredRoot: string,
   repositoryCommit: string,
   repositoryPaths: ReadonlyArray<string>,
   bodies: ReadonlyArray<string>,
   expectedOperationIds: ReadonlyArray<string>,
   headRef = "HEAD"
 ): void {
-  const publication = findAttributedMaterializedPublication(rootDir, authoredRoot, repositoryPaths, bodies, headRef);
+  const publication = findAttributedMaterializedPublication(rootDir, repositoryPaths, bodies, headRef);
   if (publication.commit !== repositoryCommit) {
     throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_COMMIT_NOT_PATH_ATTRIBUTED");
   }
@@ -89,27 +76,17 @@ export function prepublishGitTextOrNull(rootDir: string, args: ReadonlyArray<str
 
 function findPathMaterializedPublication(
   rootDir: string,
-  authoredRoot: string,
   repositoryPath: string,
-  expectedBody: string,
   expectedBlob: string,
   headRef: string
 ): { readonly commit: string; readonly operationIds: ReadonlyArray<string> } | null {
-  for (const entry of firstParentHistory(authoredRoot, [repositoryPath], headRef)) {
+  for (const entry of firstParentHistory(rootDir, [repositoryPath], headRef)) {
     if (entry.parents.length !== 2) continue;
-    const [actualBlob] = gitBlobIds(authoredRoot, entry.commit, [repositoryPath]);
+    const [actualBlob] = gitBlobIds(rootDir, entry.commit, [repositoryPath]);
     if (actualBlob !== expectedBlob) continue;
-    const [firstParentBlob] = gitBlobIds(authoredRoot, entry.parents[0]!, [repositoryPath]);
+    const [firstParentBlob] = gitBlobIds(rootDir, entry.parents[0]!, [repositoryPath]);
     if (firstParentBlob === actualBlob) continue;
-    const operationIds = attributedPathOperationIds(
-      rootDir,
-      authoredRoot,
-      entry.parents[0]!,
-      entry.parents[1]!,
-      repositoryPath,
-      expectedBody,
-      expectedBlob
-    );
+    const operationIds = attributedPathOperationIds(rootDir, entry.parents[0]!, entry.parents[1]!, repositoryPath, expectedBlob);
     if (operationIds.length === 0) continue;
     return { commit: entry.commit, operationIds };
   }
@@ -118,14 +95,12 @@ function findPathMaterializedPublication(
 
 function attributedPathOperationIds(
   rootDir: string,
-  authoredRoot: string,
   firstParent: string,
   authorityTip: string,
   repositoryPath: string,
-  expectedBody: string,
   expectedBlob: string
 ): ReadonlyArray<string> {
-  const commits = taskCompletePublicationGitText(authoredRoot, [
+  const commits = taskCompletePublicationGitText(rootDir, [
     "rev-list",
     "--reverse",
     "--topo-order",
@@ -135,142 +110,10 @@ function attributedPathOperationIds(
   ]).split(/\r?\n/u).map((entry) => entry.trim()).filter(Boolean);
   const lastChangingCommit = commits.at(-1);
   if (!lastChangingCommit) return [];
-  const [attributedBlob] = gitBlobIds(authoredRoot, lastChangingCommit, [repositoryPath]);
+  const [attributedBlob] = gitBlobIds(rootDir, lastChangingCommit, [repositoryPath]);
   if (attributedBlob !== expectedBlob) return [];
-  const subject = taskCompletePublicationGitText(authoredRoot, ["show", "-s", "--format=%s", lastChangingCommit]);
-  return publicationOperationIds(subject).filter((operationId) => durableAttributionConfirmsPath({
-    rootDir,
-    authoredRoot,
-    firstParent,
-    authorityTip,
-    operationId,
-    repositoryPath,
-    expectedBody
-  }));
-}
-
-function durableAttributionConfirmsPath(input: {
-  readonly rootDir: string;
-  readonly authoredRoot: string;
-  readonly firstParent: string;
-  readonly authorityTip: string;
-  readonly operationId: string;
-  readonly repositoryPath: string;
-  readonly expectedBody: string;
-}): boolean {
-  try {
-    const rootInput = taskCompleteLayoutInput(input.rootDir, input.authoredRoot);
-    const eventPath = repositoryRelativePath(
-      input.authoredRoot,
-      path.join(resolveHarnessLayout(rootInput).attributionEventsRoot, `${sha256Text(input.operationId)}.jsonl`)
-    );
-    const [authorityEventBlob] = gitBlobIds(input.authoredRoot, input.authorityTip, [eventPath]);
-    const [firstParentEventBlob] = gitBlobIds(input.authoredRoot, input.firstParent, [eventPath]);
-    if (!authorityEventBlob || authorityEventBlob === firstParentEventBlob) return false;
-    const eventBody = taskCompletePublicationGitText(input.authoredRoot, ["show", `${input.authorityTip}:${eventPath}`]);
-    const event = decodeAttributionEventBody(eventBody);
-    if (event.opId !== input.operationId) return false;
-    const payload = readVerifiedAttributionPayload(input.rootDir, event);
-    return attributionPayloadConfirmsPath(rootInput, input.authoredRoot, event, payload, input.repositoryPath, input.expectedBody);
-  } catch {
-    return false;
-  }
-}
-
-function readVerifiedAttributionPayload(rootDir: string, event: AttributionEvent): Record<string, unknown> {
-  const absoluteRoot = path.resolve(rootDir);
-  const payloadPath = path.resolve(absoluteRoot, event.payloadRef.path);
-  if (!isWithinRoot(absoluteRoot, payloadPath)) throw new Error("attribution payload path escapes root");
-  const body = readFileSync(payloadPath, "utf8");
-  if (sha256Text(body) !== event.payloadRef.sha256) throw new Error("attribution payload bytes differ");
-  const payload: unknown = JSON.parse(body);
-  if (!payload || typeof payload !== "object" || Array.isArray(payload) || stablePayloadHash(payload) !== event.payloadHash) {
-    throw new Error("attribution payload hash differs");
-  }
-  return payload as Record<string, unknown>;
-}
-
-function attributionPayloadConfirmsPath(
-  rootInput: HarnessLayoutInput,
-  authoredRoot: string,
-  event: AttributionEvent,
-  payload: Record<string, unknown>,
-  repositoryPath: string,
-  expectedBody: string
-): boolean {
-  const expectedBodySha256 = sha256Text(expectedBody);
-  if (event.kind === "doc_sync_submit" || event.kind === "script_ingest") {
-    return payloadWrites(payload).some((write) => write.path === repositoryPath && writeBodyMatches(write, expectedBodySha256));
-  }
-  const batchWrites = [
-    ...payloadWrites(payload),
-    ...recordWrites(payload.taskWrites)
-  ];
-  if (batchWrites.some((write) => taskDocumentWriteMatches(rootInput, authoredRoot, write, repositoryPath, expectedBodySha256))) {
-    return true;
-  }
-  const taskId = taskIdFromAttributionEvent(event);
-  const pathValue = typeof payload.path === "string" ? payload.path : null;
-  if (!taskId || !pathValue) return false;
-  const packageRoot = taskPackagePath(rootInput, taskId);
-  const targetPath = repositoryRelativePath(authoredRoot, path.join(packageRoot, pathValue));
-  if (targetPath !== repositoryPath) return false;
-  return writeBodyMatches(payload, expectedBodySha256) || typeof payload.append === "string" || payload.appendRecord !== undefined;
-}
-
-function taskDocumentWriteMatches(
-  rootInput: HarnessLayoutInput,
-  authoredRoot: string,
-  write: Record<string, unknown>,
-  repositoryPath: string,
-  expectedBodySha256: string
-): boolean {
-  if (typeof write.taskId !== "string" || typeof write.path !== "string") return false;
-  const packageRoot = taskPackagePath(rootInput, write.taskId);
-  const targetPath = repositoryRelativePath(authoredRoot, path.join(packageRoot, write.path));
-  return targetPath === repositoryPath && writeBodyMatches(write, expectedBodySha256);
-}
-
-function payloadWrites(payload: Record<string, unknown>): ReadonlyArray<Record<string, unknown>> {
-  return recordWrites(payload.writes);
-}
-
-function recordWrites(value: unknown): ReadonlyArray<Record<string, unknown>> {
-  return Array.isArray(value)
-    ? value.filter((entry): entry is Record<string, unknown> => Boolean(entry) && typeof entry === "object" && !Array.isArray(entry))
-    : [];
-}
-
-function writeBodyMatches(write: Record<string, unknown>, expectedBodySha256: string): boolean {
-  return (typeof write.body === "string" && sha256Text(write.body) === expectedBodySha256)
-    || write.bodySha256 === expectedBodySha256;
-}
-
-function taskIdFromAttributionEvent(event: AttributionEvent): string | null {
-  const match = /^task\/(.+)$/u.exec(event.entityId);
-  return match?.[1] ?? null;
-}
-
-function taskCompleteLayoutInput(rootDir: string, authoredRoot: string): HarnessLayoutInput {
-  const relativeAuthoredRoot = path.relative(rootDir, authoredRoot).split(path.sep).join("/") || ".";
-  if (relativeAuthoredRoot.startsWith("../") || path.isAbsolute(relativeAuthoredRoot)) {
-    throw new Error("authored root escapes repository");
-  }
-  return {
-    rootDir,
-    layoutOverrides: { authoredRoot: relativeAuthoredRoot }
-  };
-}
-
-function repositoryRelativePath(repositoryRoot: string, absolutePath: string): string {
-  const relative = path.relative(repositoryRoot, absolutePath).split(path.sep).join("/");
-  if (!relative || relative.startsWith("../") || path.isAbsolute(relative)) throw new Error("path escapes repository");
-  return relative;
-}
-
-function isWithinRoot(rootDir: string, candidate: string): boolean {
-  const relative = path.relative(rootDir, candidate);
-  return relative.length > 0 && relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+  const subject = taskCompletePublicationGitText(rootDir, ["show", "-s", "--format=%s", lastChangingCommit]);
+  return publicationOperationIds(subject);
 }
 
 function describeMaterializationMismatches(

--- a/packages/daemon/src/authority/production/task-complete-prepublish-publication.ts
+++ b/packages/daemon/src/authority/production/task-complete-prepublish-publication.ts
@@ -1,0 +1,262 @@
+import { execFileSync } from "node:child_process";
+import { stableStringify } from "@harness-anything/kernel";
+
+export function findAttributedMaterializedPublication(
+  rootDir: string,
+  repositoryPaths: ReadonlyArray<string>,
+  bodies: ReadonlyArray<string>,
+  headRef = "HEAD"
+): { readonly commit: string; readonly operationIds: ReadonlyArray<string> } {
+  const expectedBlobs = bodies.map((body) => taskCompletePublicationGitText(rootDir, ["hash-object", "--stdin"], body));
+  const currentBlobs = gitBlobIds(rootDir, headRef, repositoryPaths);
+  if (currentBlobs.some((actual, index) => actual !== expectedBlobs[index])) {
+    throw new Error(
+      `AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:${describeMaterializationMismatches(repositoryPaths, currentBlobs, expectedBlobs)}`
+    );
+  }
+  const attributions = repositoryPaths.map((repositoryPath, index) =>
+    findPathMaterializedPublication(rootDir, repositoryPath, expectedBlobs[index]!, headRef)
+  );
+  const missing = attributions.flatMap((attribution, index) => attribution ? [] : [repositoryPaths[index]!]);
+  if (missing.length > 0) {
+    throw new Error(
+      `AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:${missing.map((repositoryPath) =>
+        `${repositoryPath} (no canonical publication changed this path to its current content)`
+      ).join(", ")}`
+    );
+  }
+  const attributed = attributions.filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+  const attributedCommits = new Set(attributed.map((entry) => entry.commit));
+  const representative = firstParentHistory(rootDir, repositoryPaths, headRef)
+    .find((entry) => attributedCommits.has(entry.commit));
+  if (!representative) throw new Error("AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:attributed publication missing from first-parent history");
+  return {
+    commit: representative.commit,
+    operationIds: [...new Set(attributed.flatMap((entry) => entry.operationIds))].sort()
+  };
+}
+
+export function assertAttributedMaterializedPublication(
+  rootDir: string,
+  repositoryCommit: string,
+  repositoryPaths: ReadonlyArray<string>,
+  bodies: ReadonlyArray<string>,
+  expectedOperationIds: ReadonlyArray<string>,
+  headRef = "HEAD"
+): void {
+  const publication = findAttributedMaterializedPublication(rootDir, repositoryPaths, bodies, headRef);
+  if (publication.commit !== repositoryCommit) {
+    throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_COMMIT_NOT_PATH_ATTRIBUTED");
+  }
+  if (stableStringify(publication.operationIds) !== stableStringify(expectedOperationIds)) {
+    throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_OPERATION_MISMATCH");
+  }
+}
+
+export function assertCommittedMaterializedPublication(
+  rootDir: string,
+  repositoryCommit: string,
+  repositoryPaths: ReadonlyArray<string>,
+  bodies: ReadonlyArray<string>,
+  expectedOperationIds: ReadonlyArray<string>
+): void {
+  try {
+    assertAttributedMaterializedPublication(
+      rootDir,
+      repositoryCommit,
+      repositoryPaths,
+      bodies,
+      expectedOperationIds,
+      repositoryCommit
+    );
+  } catch {
+    // Already-committed transitions may contain the pre-attribution witness shape.
+    // The fallback is replay-only; every current/new completion uses strict path
+    // attribution before it can commit.
+    assertLegacyMaterializedPublication(rootDir, repositoryCommit, repositoryPaths, bodies, expectedOperationIds);
+  }
+}
+
+export function prepublishGitBlobText(rootDir: string, commitRef: string, repositoryPath: string): string {
+  try {
+    return execFileSync("git", ["-C", rootDir, "show", `${commitRef}:${repositoryPath}`], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: 64 * 1024 * 1024,
+      windowsHide: true
+    });
+  } catch {
+    throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_BLOB_MISSING");
+  }
+}
+
+export function prepublishGitTextOrNull(rootDir: string, args: ReadonlyArray<string>): string | null {
+  try {
+    return taskCompletePublicationGitText(rootDir, args);
+  } catch {
+    return null;
+  }
+}
+
+function findPathMaterializedPublication(
+  rootDir: string,
+  repositoryPath: string,
+  expectedBlob: string,
+  headRef: string
+): { readonly commit: string; readonly operationIds: ReadonlyArray<string> } | null {
+  for (const entry of firstParentHistory(rootDir, [repositoryPath], headRef)) {
+    if (entry.parents.length !== 2) continue;
+    const [actualBlob] = gitBlobIds(rootDir, entry.commit, [repositoryPath]);
+    if (actualBlob !== expectedBlob) continue;
+    const [firstParentBlob] = gitBlobIds(rootDir, entry.parents[0]!, [repositoryPath]);
+    if (firstParentBlob === actualBlob) continue;
+    const operationIds = attributedPathOperationIds(rootDir, entry.parents[0]!, entry.parents[1]!, repositoryPath, expectedBlob);
+    if (operationIds.length === 0) continue;
+    return { commit: entry.commit, operationIds };
+  }
+  return null;
+}
+
+function attributedPathOperationIds(
+  rootDir: string,
+  firstParent: string,
+  authorityTip: string,
+  repositoryPath: string,
+  expectedBlob: string
+): ReadonlyArray<string> {
+  const commits = taskCompletePublicationGitText(rootDir, [
+    "rev-list",
+    "--reverse",
+    "--topo-order",
+    `${firstParent}..${authorityTip}`,
+    "--",
+    `:(literal)${repositoryPath}`
+  ]).split(/\r?\n/u).map((entry) => entry.trim()).filter(Boolean);
+  const lastChangingCommit = commits.at(-1);
+  if (!lastChangingCommit) return [];
+  const [attributedBlob] = gitBlobIds(rootDir, lastChangingCommit, [repositoryPath]);
+  if (attributedBlob !== expectedBlob) return [];
+  const subject = taskCompletePublicationGitText(rootDir, ["show", "-s", "--format=%s", lastChangingCommit]);
+  return publicationOperationIds(subject);
+}
+
+function describeMaterializationMismatches(
+  repositoryPaths: ReadonlyArray<string>,
+  actualBlobs: ReadonlyArray<string | null>,
+  expectedBlobs: ReadonlyArray<string>
+): string {
+  return repositoryPaths.flatMap((repositoryPath, index) => {
+    const actual = actualBlobs[index];
+    if (actual === expectedBlobs[index]) return [];
+    return [actual === null
+      ? `${repositoryPath} (missing from HEAD)`
+      : `${repositoryPath} (content differs from expected)`];
+  }).join(", ");
+}
+
+function assertLegacyMaterializedPublication(
+  rootDir: string,
+  repositoryCommit: string,
+  repositoryPaths: ReadonlyArray<string>,
+  bodies: ReadonlyArray<string>,
+  expectedOperationIds: ReadonlyArray<string>
+): void {
+  const entry = firstParentHistory(rootDir, repositoryPaths)
+    .find((candidate) => candidate.commit === repositoryCommit);
+  if (!entry || entry.parents.length !== 2) {
+    throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_COMMIT_NOT_MATERIALIZED_FIRST_PARENT");
+  }
+  const operationIds = canonicalPublicationOperationIds(rootDir, entry);
+  if (operationIds.length === 0 || stableStringify(operationIds) !== stableStringify(expectedOperationIds)) {
+    throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_OPERATION_MISMATCH");
+  }
+  const expectedBlobs = bodies.map((body) => taskCompletePublicationGitText(rootDir, ["hash-object", "--stdin"], body));
+  const actualBlobs = gitBlobIds(rootDir, repositoryCommit, repositoryPaths);
+  const matches = actualBlobs.every((actual, index) => actual === expectedBlobs[index]);
+  if (!matches) throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_BLOB_MISMATCH");
+}
+
+function canonicalPublicationOperationIds(
+  rootDir: string,
+  entry: { readonly parents: ReadonlyArray<string>; readonly subject: string }
+): ReadonlyArray<string> {
+  const firstParentIds = publicationOperationIds(entry.subject);
+  return firstParentIds.length > 0
+    ? firstParentIds
+    : publicationOperationIds(taskCompletePublicationGitText(rootDir, ["show", "-s", "--format=%s", entry.parents[1]!]));
+}
+
+function firstParentHistory(rootDir: string, repositoryPaths: ReadonlyArray<string>, headRef = "HEAD"): ReadonlyArray<{
+  readonly commit: string;
+  readonly parents: ReadonlyArray<string>;
+  readonly subject: string;
+}> {
+  const fields = taskCompletePublicationGitText(rootDir, [
+    "log",
+    "--first-parent",
+    "--full-history",
+    "--format=%H%x00%P%x00%s%x00",
+    headRef,
+    "--",
+    ...repositoryPaths.map((repositoryPath) => `:(literal)${repositoryPath}`)
+  ]).split("\0");
+  const rows: Array<{ commit: string; parents: ReadonlyArray<string>; subject: string }> = [];
+  for (let index = 0; index + 2 < fields.length; index += 3) {
+    const commit = fields[index]!.trim();
+    if (!commit) continue;
+    rows.push({
+      commit,
+      parents: fields[index + 1]!.trim().split(" ").filter(Boolean),
+      subject: fields[index + 2]!.trim()
+    });
+  }
+  return rows;
+}
+
+function publicationOperationIds(subject: string): ReadonlyArray<string> {
+  const match = /\[([^\]]+)\]$/u.exec(subject);
+  return match?.[1]
+    ? [...new Set(match[1].split(",").map((entry) => entry.trim()).filter(Boolean))].sort()
+    : [];
+}
+
+function taskCompletePublicationGitText(rootDir: string, args: ReadonlyArray<string>, input?: string): string {
+  return execFileSync("git", ["-C", rootDir, ...args], {
+    encoding: "utf8",
+    input,
+    stdio: [input === undefined ? "ignore" : "pipe", "pipe", "pipe"],
+    maxBuffer: 64 * 1024 * 1024,
+    windowsHide: true
+  }).trim();
+}
+
+function gitBlobIds(
+  rootDir: string,
+  commitRef: string,
+  repositoryPaths: ReadonlyArray<string>
+): ReadonlyArray<string | null> {
+  const output = execFileSync("git", [
+    "-C",
+    rootDir,
+    "ls-tree",
+    "-z",
+    "--full-tree",
+    commitRef,
+    "--",
+    ...repositoryPaths.map((repositoryPath) => `:(literal)${repositoryPath}`)
+  ], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    maxBuffer: 64 * 1024 * 1024,
+    windowsHide: true
+  });
+  const byPath = new Map<string, string>();
+  for (const row of output.split("\0")) {
+    if (!row) continue;
+    const separator = row.indexOf("\t");
+    if (separator < 0) continue;
+    const [mode, type, objectId] = row.slice(0, separator).split(" ");
+    if (mode && type === "blob" && objectId) byPath.set(row.slice(separator + 1), objectId);
+  }
+  return repositoryPaths.map((repositoryPath) => byPath.get(repositoryPath) ?? null);
+}

--- a/packages/daemon/src/authority/production/task-complete-prepublish-witness.ts
+++ b/packages/daemon/src/authority/production/task-complete-prepublish-witness.ts
@@ -16,7 +16,6 @@ import {
 } from "@harness-anything/kernel";
 import {
   assertAttributedMaterializedPublication,
-  assertCommittedMaterializedPublication,
   findAttributedMaterializedPublication,
   prepublishGitBlobText,
   prepublishGitTextOrNull
@@ -106,7 +105,7 @@ export function produceDocumentPublicationWitness(input: {
     .sort((left, right) => lexicalCompare(left.path, right.path));
   if (covered.length === 0) throw new Error("AUTHORITY_TASK_COMPLETE_DOCUMENT_PUBLICATION_EMPTY");
   const repositoryPaths = taskRepositoryPaths(input, covered.map((entry) => entry.path));
-  const publication = findAttributedMaterializedPublication(input.authoredRoot, repositoryPaths, covered.map((entry) => entry.body));
+  const publication = findAttributedMaterializedPublication(input.rootDir, input.authoredRoot, repositoryPaths, covered.map((entry) => entry.body));
   const witnessWithoutRef = {
     kind: "document-publication" as const,
     repositoryCommit: publication.commit,
@@ -152,7 +151,7 @@ export function produceCodeDocWitness(input: {
     );
   }
   const [repositoryPath] = taskRepositoryPaths(input, [CODE_DOC_RECONCILIATION_DOCUMENT]);
-  const publication = findAttributedMaterializedPublication(input.authoredRoot, [repositoryPath!], [codeDoc.body]);
+  const publication = findAttributedMaterializedPublication(input.rootDir, input.authoredRoot, [repositoryPath!], [codeDoc.body]);
   const witnessWithoutRef = {
     kind: "code-doc-reconciliation" as const,
     repositoryCommit: publication.commit,
@@ -260,22 +259,14 @@ function verifyDocumentPublicationWitness(
     || witness.coveredPathSetDigest !== digestValue) {
     throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_SNAPSHOT_MISMATCH:document-publication");
   }
-  if (snapshotMode === "current") {
-    assertAttributedMaterializedPublication(
-      input.authoredRoot,
-      witness.repositoryCommit,
-      repositoryPaths,
-      covered.map((entry) => entry.body),
-      witness.publicationOperationIds
-    );
-    return;
-  }
-  assertCommittedMaterializedPublication(
+  assertAttributedMaterializedPublication(
+    input.rootDir,
     input.authoredRoot,
     witness.repositoryCommit,
     repositoryPaths,
     covered.map((entry) => entry.body),
-    witness.publicationOperationIds
+    witness.publicationOperationIds,
+    snapshotMode === "committed" ? witness.repositoryCommit : "HEAD"
   );
 }
 
@@ -317,22 +308,14 @@ function verifyCodeDocWitness(
     || prepublishGitTextOrNull(input.rootDir, ["rev-parse", "--verify", "--end-of-options", `${witness.reconciledCommitRef}^{commit}`]) !== witness.reconciledCommitRef) {
     throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_SNAPSHOT_MISMATCH:code-doc-reconciliation");
   }
-  if (snapshotMode === "current") {
-    assertAttributedMaterializedPublication(
-      input.authoredRoot,
-      witness.repositoryCommit,
-      [repositoryPath!],
-      [codeDocBody],
-      witness.publicationOperationIds
-    );
-    return;
-  }
-  assertCommittedMaterializedPublication(
+  assertAttributedMaterializedPublication(
+    input.rootDir,
     input.authoredRoot,
     witness.repositoryCommit,
     [repositoryPath!],
     [codeDocBody],
-    witness.publicationOperationIds
+    witness.publicationOperationIds,
+    snapshotMode === "committed" ? witness.repositoryCommit : "HEAD"
   );
 }
 

--- a/packages/daemon/src/authority/production/task-complete-prepublish-witness.ts
+++ b/packages/daemon/src/authority/production/task-complete-prepublish-witness.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import path from "node:path";
 import {
   CODE_DOC_RECONCILIATION_DOCUMENT,
@@ -15,6 +14,13 @@ import {
   stableStringify,
   taskPackagePath
 } from "@harness-anything/kernel";
+import {
+  assertAttributedMaterializedPublication,
+  assertCommittedMaterializedPublication,
+  findAttributedMaterializedPublication,
+  prepublishGitBlobText,
+  prepublishGitTextOrNull
+} from "./task-complete-prepublish-publication.ts";
 
 const witnessPrefix = "ha-prepublish-witness-v1.";
 
@@ -100,7 +106,7 @@ export function produceDocumentPublicationWitness(input: {
     .sort((left, right) => lexicalCompare(left.path, right.path));
   if (covered.length === 0) throw new Error("AUTHORITY_TASK_COMPLETE_DOCUMENT_PUBLICATION_EMPTY");
   const repositoryPaths = taskRepositoryPaths(input, covered.map((entry) => entry.path));
-  const publication = findMaterializedPublication(input.authoredRoot, repositoryPaths, covered.map((entry) => entry.body));
+  const publication = findAttributedMaterializedPublication(input.authoredRoot, repositoryPaths, covered.map((entry) => entry.body));
   const witnessWithoutRef = {
     kind: "document-publication" as const,
     repositoryCommit: publication.commit,
@@ -146,7 +152,7 @@ export function produceCodeDocWitness(input: {
     );
   }
   const [repositoryPath] = taskRepositoryPaths(input, [CODE_DOC_RECONCILIATION_DOCUMENT]);
-  const publication = findMaterializedPublication(input.authoredRoot, [repositoryPath!], [codeDoc.body]);
+  const publication = findAttributedMaterializedPublication(input.authoredRoot, [repositoryPath!], [codeDoc.body]);
   const witnessWithoutRef = {
     kind: "code-doc-reconciliation" as const,
     repositoryCommit: publication.commit,
@@ -244,7 +250,7 @@ function verifyDocumentPublicationWitness(
       .sort((left, right) => lexicalCompare(left.path, right.path))
     : witness.coveredTaskRelativePaths.map((coveredPath, index) => ({
       path: canonicalTaskRelativePath(coveredPath),
-      body: witnessGitBlobText(input.authoredRoot, witness.repositoryCommit, repositoryPaths[index]!)
+      body: prepublishGitBlobText(input.authoredRoot, witness.repositoryCommit, repositoryPaths[index]!)
     }));
   const digestValue = `sha256:${sha256Text(stableStringify(covered.map((entry) => ({
     path: entry.path,
@@ -254,7 +260,17 @@ function verifyDocumentPublicationWitness(
     || witness.coveredPathSetDigest !== digestValue) {
     throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_SNAPSHOT_MISMATCH:document-publication");
   }
-  assertMaterializedPublication(
+  if (snapshotMode === "current") {
+    assertAttributedMaterializedPublication(
+      input.authoredRoot,
+      witness.repositoryCommit,
+      repositoryPaths,
+      covered.map((entry) => entry.body),
+      witness.publicationOperationIds
+    );
+    return;
+  }
+  assertCommittedMaterializedPublication(
     input.authoredRoot,
     witness.repositoryCommit,
     repositoryPaths,
@@ -278,7 +294,7 @@ function verifyCodeDocWitness(
   const currentCodeDoc = input.documents.find((document) => document.path === CODE_DOC_RECONCILIATION_DOCUMENT);
   const codeDocBody = snapshotMode === "current"
     ? currentCodeDoc?.body
-    : witnessGitBlobText(input.authoredRoot, witness.repositoryCommit, repositoryPath!);
+    : prepublishGitBlobText(input.authoredRoot, witness.repositoryCommit, repositoryPath!);
   if (!codeDocBody) throw new Error("AUTHORITY_TASK_COMPLETE_CODE_DOC_WITNESS_REQUIRED");
   const reconciledCommitRef = snapshotMode === "current"
     ? resolveCommit(input.rootDir, input.command.commitRef ?? "HEAD")
@@ -298,10 +314,20 @@ function verifyCodeDocWitness(
     || stableStringify(witness.normalizedPaths) !== stableStringify(normalizedPaths)
     || witness.prRef !== prRef
     || witness.codeDocBodyDigest !== `sha256:${sha256Text(codeDocBody)}`
-    || gitTextOrNull(input.rootDir, ["rev-parse", "--verify", "--end-of-options", `${witness.reconciledCommitRef}^{commit}`]) !== witness.reconciledCommitRef) {
+    || prepublishGitTextOrNull(input.rootDir, ["rev-parse", "--verify", "--end-of-options", `${witness.reconciledCommitRef}^{commit}`]) !== witness.reconciledCommitRef) {
     throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_SNAPSHOT_MISMATCH:code-doc-reconciliation");
   }
-  assertMaterializedPublication(
+  if (snapshotMode === "current") {
+    assertAttributedMaterializedPublication(
+      input.authoredRoot,
+      witness.repositoryCommit,
+      [repositoryPath!],
+      [codeDocBody],
+      witness.publicationOperationIds
+    );
+    return;
+  }
+  assertCommittedMaterializedPublication(
     input.authoredRoot,
     witness.repositoryCommit,
     [repositoryPath!],
@@ -312,111 +338,6 @@ function verifyCodeDocWitness(
 
 function encodePrepublishWitnessRef(value: Omit<VerifiedTaskCompleteExternalWitness, "ref">): string {
   return `${witnessPrefix}${Buffer.from(stableStringify(value), "utf8").toString("base64url")}`;
-}
-
-function findMaterializedPublication(
-  rootDir: string,
-  repositoryPaths: ReadonlyArray<string>,
-  bodies: ReadonlyArray<string>
-): { readonly commit: string; readonly operationIds: ReadonlyArray<string> } {
-  const expectedBlobs = bodies.map((body) => witnessGitText(rootDir, ["hash-object", "--stdin"], body));
-  const currentBlobs = witnessGitBlobIds(rootDir, "HEAD", repositoryPaths);
-  if (currentBlobs.some((actual, index) => actual !== expectedBlobs[index])) {
-    throw new Error(
-      `AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:${describeMaterializationMismatches(repositoryPaths, currentBlobs, expectedBlobs)}`
-    );
-  }
-  for (const entry of firstParentHistory(rootDir, repositoryPaths)) {
-    if (entry.parents.length !== 2) continue;
-    const operationIds = canonicalPublicationOperationIds(rootDir, entry);
-    if (operationIds.length === 0) continue;
-    const actualBlobs = witnessGitBlobIds(rootDir, entry.commit, repositoryPaths);
-    const matches = actualBlobs.every((actual, index) => actual === expectedBlobs[index]);
-    if (matches) return { commit: entry.commit, operationIds };
-  }
-  throw new Error(
-    `AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:no matching first-parent publication found for declared paths: ${repositoryPaths.join(",")}`
-  );
-}
-
-function describeMaterializationMismatches(
-  repositoryPaths: ReadonlyArray<string>,
-  actualBlobs: ReadonlyArray<string | null>,
-  expectedBlobs: ReadonlyArray<string>
-): string {
-  return repositoryPaths.flatMap((repositoryPath, index) => {
-    const actual = actualBlobs[index];
-    if (actual === expectedBlobs[index]) return [];
-    return [actual === null
-      ? `${repositoryPath} (missing from HEAD)`
-      : `${repositoryPath} (content differs from expected)`];
-  }).join(", ");
-}
-
-function assertMaterializedPublication(
-  rootDir: string,
-  repositoryCommit: string,
-  repositoryPaths: ReadonlyArray<string>,
-  bodies: ReadonlyArray<string>,
-  expectedOperationIds: ReadonlyArray<string>
-): void {
-  const entry = firstParentHistory(rootDir, repositoryPaths)
-    .find((candidate) => candidate.commit === repositoryCommit);
-  if (!entry || entry.parents.length !== 2) {
-    throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_COMMIT_NOT_MATERIALIZED_FIRST_PARENT");
-  }
-  const operationIds = canonicalPublicationOperationIds(rootDir, entry);
-  if (operationIds.length === 0 || stableStringify(operationIds) !== stableStringify(expectedOperationIds)) {
-    throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_OPERATION_MISMATCH");
-  }
-  const expectedBlobs = bodies.map((body) => witnessGitText(rootDir, ["hash-object", "--stdin"], body));
-  const actualBlobs = witnessGitBlobIds(rootDir, repositoryCommit, repositoryPaths);
-  const matches = actualBlobs.every((actual, index) => actual === expectedBlobs[index]);
-  if (!matches) throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_BLOB_MISMATCH");
-}
-
-function canonicalPublicationOperationIds(
-  rootDir: string,
-  entry: { readonly parents: ReadonlyArray<string>; readonly subject: string }
-): ReadonlyArray<string> {
-  const firstParentIds = publicationOperationIds(entry.subject);
-  return firstParentIds.length > 0
-    ? firstParentIds
-    : publicationOperationIds(witnessGitText(rootDir, ["show", "-s", "--format=%s", entry.parents[1]!]));
-}
-
-function firstParentHistory(rootDir: string, repositoryPaths: ReadonlyArray<string>): ReadonlyArray<{
-  readonly commit: string;
-  readonly parents: ReadonlyArray<string>;
-  readonly subject: string;
-}> {
-  const fields = witnessGitText(rootDir, [
-    "log",
-    "--first-parent",
-    "--full-history",
-    "--format=%H%x00%P%x00%s%x00",
-    "HEAD",
-    "--",
-    ...repositoryPaths.map((repositoryPath) => `:(literal)${repositoryPath}`)
-  ]).split("\0");
-  const rows: Array<{ commit: string; parents: ReadonlyArray<string>; subject: string }> = [];
-  for (let index = 0; index + 2 < fields.length; index += 3) {
-    const commit = fields[index]!.trim();
-    if (!commit) continue;
-    rows.push({
-      commit,
-      parents: fields[index + 1]!.trim().split(" ").filter(Boolean),
-      subject: fields[index + 2]!.trim()
-    });
-  }
-  return rows;
-}
-
-function publicationOperationIds(subject: string): ReadonlyArray<string> {
-  const match = /\[([^\]]+)\]$/u.exec(subject);
-  return match?.[1]
-    ? [...new Set(match[1].split(",").map((entry) => entry.trim()).filter(Boolean))].sort()
-    : [];
 }
 
 function taskRepositoryPaths(
@@ -456,71 +377,9 @@ function canonicalTaskRelativePath(value: string): string {
 }
 
 function resolveCommit(rootDir: string, ref: string): string {
-  const resolved = gitTextOrNull(rootDir, ["rev-parse", "--verify", "--end-of-options", `${ref}^{commit}`]);
+  const resolved = prepublishGitTextOrNull(rootDir, ["rev-parse", "--verify", "--end-of-options", `${ref}^{commit}`]);
   if (!resolved || !/^[0-9a-f]{40}$/u.test(resolved)) throw new Error(`AUTHORITY_TASK_COMPLETE_COMMIT_REF_INVALID:${ref}`);
   return resolved;
-}
-
-function witnessGitText(rootDir: string, args: ReadonlyArray<string>, input?: string): string {
-  return execFileSync("git", ["-C", rootDir, ...args], {
-    encoding: "utf8",
-    input,
-    stdio: [input === undefined ? "ignore" : "pipe", "pipe", "pipe"],
-    maxBuffer: 64 * 1024 * 1024,
-    windowsHide: true
-  }).trim();
-}
-
-function witnessGitBlobText(rootDir: string, commitRef: string, repositoryPath: string): string {
-  try {
-    return execFileSync("git", ["-C", rootDir, "show", `${commitRef}:${repositoryPath}`], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-      maxBuffer: 64 * 1024 * 1024,
-      windowsHide: true
-    });
-  } catch {
-    throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_BLOB_MISSING");
-  }
-}
-
-function witnessGitBlobIds(
-  rootDir: string,
-  commitRef: string,
-  repositoryPaths: ReadonlyArray<string>
-): ReadonlyArray<string | null> {
-  const output = execFileSync("git", [
-    "-C",
-    rootDir,
-    "ls-tree",
-    "-z",
-    "--full-tree",
-    commitRef,
-    "--",
-    ...repositoryPaths.map((repositoryPath) => `:(literal)${repositoryPath}`)
-  ], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-    maxBuffer: 64 * 1024 * 1024,
-    windowsHide: true
-  });
-  const byPath = new Map<string, string>();
-  for (const row of output.split("\0")) {
-    if (!row) continue;
-    const separator = row.indexOf("\t");
-    if (separator < 0) continue;
-    const [mode, type, objectId] = row.slice(0, separator).split(" ");
-    if (mode && type === "blob" && objectId) byPath.set(row.slice(separator + 1), objectId);
-  }
-  return repositoryPaths.map((repositoryPath) => byPath.get(repositoryPath) ?? null);
-}
-
-function gitTextOrNull(rootDir: string, args: ReadonlyArray<string>): string | null {
-  try {
-    return witnessGitText(rootDir, args);
-  } catch {
-    return null;
-  }
 }
 
 function witnessRecord(value: unknown): Record<string, unknown> {

--- a/packages/daemon/src/authority/production/task-complete-prepublish-witness.ts
+++ b/packages/daemon/src/authority/production/task-complete-prepublish-witness.ts
@@ -105,7 +105,7 @@ export function produceDocumentPublicationWitness(input: {
     .sort((left, right) => lexicalCompare(left.path, right.path));
   if (covered.length === 0) throw new Error("AUTHORITY_TASK_COMPLETE_DOCUMENT_PUBLICATION_EMPTY");
   const repositoryPaths = taskRepositoryPaths(input, covered.map((entry) => entry.path));
-  const publication = findAttributedMaterializedPublication(input.rootDir, input.authoredRoot, repositoryPaths, covered.map((entry) => entry.body));
+  const publication = findAttributedMaterializedPublication(input.authoredRoot, repositoryPaths, covered.map((entry) => entry.body));
   const witnessWithoutRef = {
     kind: "document-publication" as const,
     repositoryCommit: publication.commit,
@@ -151,7 +151,7 @@ export function produceCodeDocWitness(input: {
     );
   }
   const [repositoryPath] = taskRepositoryPaths(input, [CODE_DOC_RECONCILIATION_DOCUMENT]);
-  const publication = findAttributedMaterializedPublication(input.rootDir, input.authoredRoot, [repositoryPath!], [codeDoc.body]);
+  const publication = findAttributedMaterializedPublication(input.authoredRoot, [repositoryPath!], [codeDoc.body]);
   const witnessWithoutRef = {
     kind: "code-doc-reconciliation" as const,
     repositoryCommit: publication.commit,
@@ -260,7 +260,6 @@ function verifyDocumentPublicationWitness(
     throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_SNAPSHOT_MISMATCH:document-publication");
   }
   assertAttributedMaterializedPublication(
-    input.rootDir,
     input.authoredRoot,
     witness.repositoryCommit,
     repositoryPaths,
@@ -309,7 +308,6 @@ function verifyCodeDocWitness(
     throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_SNAPSHOT_MISMATCH:code-doc-reconciliation");
   }
   assertAttributedMaterializedPublication(
-    input.rootDir,
     input.authoredRoot,
     witness.repositoryCommit,
     [repositoryPath!],

--- a/packages/daemon/src/service/doc-sync-consumer-surface.ts
+++ b/packages/daemon/src/service/doc-sync-consumer-surface.ts
@@ -1,0 +1,25 @@
+import path from "node:path";
+import type { DaemonDocSyncHostServices } from "@harness-anything/application";
+import type { DirtyEntry, RegistryRow } from "@harness-anything/application/doc-sync";
+
+export const consumerDocSyncRows: ReadonlyArray<RegistryRow> = [{
+  id: "task.document.write-stage",
+  bearing: "task-document",
+  channel: {
+    pathClass: "doc-sync-allowed",
+    zoneClass: "task-authored-prose-or-stage"
+  }
+}];
+
+export function isConsumerGovernedTaskDocument(
+  rootDir: string,
+  authoredRoot: string,
+  entry: DirtyEntry,
+  hostServices: DaemonDocSyncHostServices
+): boolean {
+  if (entry.status === "deleted" || !/^tasks\/[^/]+\/.+/u.test(entry.path)) return false;
+  return hostServices.resolveManagedSectionPolicy({
+    rootDir,
+    layoutOverrides: { authoredRoot: path.relative(rootDir, authoredRoot) }
+  }, entry.path) !== null;
+}

--- a/packages/daemon/src/service/doc-sync-consumer-surface.ts
+++ b/packages/daemon/src/service/doc-sync-consumer-surface.ts
@@ -27,7 +27,7 @@ export function isConsumerGovernedTaskDocument(
   hostServices: DaemonDocSyncHostServices
 ): boolean {
   if (entry.status === "deleted" || !/^tasks\/[^/]+\/.+/u.test(entry.path)) return false;
-  return hostServices.resolveManagedSectionPolicy({
+  return hostServices.resolveDeclaredManagedSectionPolicy({
     rootDir,
     layoutOverrides: { authoredRoot: path.relative(rootDir, authoredRoot) }
   }, entry.path) !== null;

--- a/packages/daemon/src/service/doc-sync-consumer-surface.ts
+++ b/packages/daemon/src/service/doc-sync-consumer-surface.ts
@@ -1,20 +1,29 @@
 import path from "node:path";
 import type { DaemonDocSyncHostServices } from "@harness-anything/application";
-import type { DirtyEntry, RegistryRow } from "@harness-anything/application/doc-sync";
 
-export const consumerDocSyncRows: ReadonlyArray<RegistryRow> = [{
+/**
+ * The fields this surface actually reads. Declaring them structurally keeps the check off
+ * the deep `application/doc-sync` subpath, which is under a sunset ratchet; the row shape
+ * is validated where doc-sync-service assigns it to its registry contract.
+ */
+interface ConsumerDirtyEntry {
+  readonly status: string;
+  readonly path: string;
+}
+
+export const consumerDocSyncRows = [{
   id: "task.document.write-stage",
   bearing: "task-document",
   channel: {
     pathClass: "doc-sync-allowed",
     zoneClass: "task-authored-prose-or-stage"
   }
-}];
+}] as const;
 
 export function isConsumerGovernedTaskDocument(
   rootDir: string,
   authoredRoot: string,
-  entry: DirtyEntry,
+  entry: ConsumerDirtyEntry,
   hostServices: DaemonDocSyncHostServices
 ): boolean {
   if (entry.status === "deleted" || !/^tasks\/[^/]+\/.+/u.test(entry.path)) return false;

--- a/packages/daemon/src/service/doc-sync-service.ts
+++ b/packages/daemon/src/service/doc-sync-service.ts
@@ -33,6 +33,7 @@ import {
 import { DocSyncJournalFailure, docSyncWriteFailure } from "./doc-sync-journal-failure.ts";
 import { gitText, resolveDocSyncAppliedLedgerSha } from "./doc-sync-applied-ledger.ts";
 import { isStandaloneCasObject } from "./doc-sync-cas.ts";
+import { consumerDocSyncRows, isConsumerGovernedTaskDocument } from "./doc-sync-consumer-surface.ts";
 import { resolveDocSyncChangePath } from "./doc-sync-writer-working-tree.ts";
 
 export interface DocSyncServiceOptions {
@@ -53,12 +54,19 @@ export function buildDocSyncReport(rootInput: HarnessLayoutInput, hostServices: 
   const layout = resolveHarnessLayout(rootInput);
   const authoredRoot = path.relative(layout.rootDir, layout.authoredRoot).split(path.sep).join("/") || ".";
   const registry = loadRegistry(layout.rootDir);
-  // No registry ⇒ keep consumer scanning narrow: ordinary authored-tree changes remain
-  // inert (see issue #644), while closeout keeps its built-in task-prose lane so a human
-  // can publish the completion document through the existing governed doc-sync road.
+  const dirtyEntries = gitDirtyEntries(layout.authoredRoot)
+    .filter((entry) => !isStandaloneCasObject(layout.authoredRoot, entry));
+  // The dogfood registry is not installed in consumer repositories. Keep their scan
+  // fail-closed by admitting only task prose whose installed preset/template resolves a
+  // managed section policy; typed task records and unknown authored files remain inert.
   const dirtyFiles = registry.present
-    ? gitDirtyEntries(layout.authoredRoot).filter((entry) => !isStandaloneCasObject(layout.authoredRoot, entry))
-    : gitDirtyEntries(layout.authoredRoot).filter((entry) => isConsumerCloseoutPath(entry.path));
+    ? dirtyEntries
+    : dirtyEntries.filter((entry) => isConsumerGovernedTaskDocument(
+        layout.rootDir,
+        layout.authoredRoot,
+        entry,
+        hostServices
+      ));
   const files = dirtyFiles.map((entry) => inspectDirtyFile(layout.rootDir, layout.authoredRoot, entry, registry.rows, hostServices));
   const candidateBlobs = files.filter((entry) => entry.docSyncCandidate && entry.newBlobSha256);
   const forbiddenTouches = files.flatMap((entry) => entry.forbiddenTouches);
@@ -515,21 +523,8 @@ function loadRegistry(rootDir: string): { readonly present: boolean; readonly sh
   return { present: true, sha256: sha256Text(body), rows: parsed.rows };
 }
 
-const consumerDocSyncRows: ReadonlyArray<RegistryRow> = [{
-  id: "task.document.write-stage",
-  bearing: "task-document",
-  channel: {
-    pathClass: "doc-sync-allowed",
-    zoneClass: "task-authored-prose-or-stage"
-  }
-}];
-
 function registryPath(rootDir: string): string {
   return path.join(rootDir, "tools", "write-road-registry.json");
-}
-
-function isConsumerCloseoutPath(relativePath: string): boolean {
-  return /^tasks\/[^/]+\/closeout\.md$/u.test(relativePath);
 }
 
 function gitDirtyEntries(authoredRoot: string): ReadonlyArray<DirtyEntry> {

--- a/packages/daemon/test/task-complete-prepublish-witness.test.ts
+++ b/packages/daemon/test/task-complete-prepublish-witness.test.ts
@@ -45,7 +45,7 @@ test("daemon-produced prepublish witnesses bind immutable publication history, c
     assert.equal(codeDoc.taskId, taskId);
     assert.equal(codeDoc.reconciledCommitRef, fixture.publicCommit);
     assert.deepEqual(codeDoc.normalizedPaths, ["README.md"]);
-    assert.deepEqual(codeDoc.publicationOperationIds, ["op_code_doc"]);
+    assert.deepEqual(codeDoc.publicationOperationIds, ["op_code_doc", "op_document"]);
 
     const forged = forgeWitnessRef(document.ref, { repositoryCommit: fixture.authoredInitialCommit });
     assert.throws(() => verifyTaskCompleteWitnessRefs({
@@ -68,6 +68,27 @@ test("daemon-produced prepublish witnesses bind immutable publication history, c
         { kind: "code-doc-reconciliation", ref: codeDoc.ref }
       ]
     }), /WITNESS_SNAPSHOT_MISMATCH:document-publication/u);
+  } finally {
+    rmSync(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("document publication remains verifiable without machine-local write payloads", () => {
+  const fixture = witnessRepository();
+  try {
+    rmSync(path.join(fixture.rootDir, ".harness", "write-journal", "payloads"), {
+      recursive: true,
+      force: true
+    });
+
+    const document = produceDocumentPublicationWitness(fixture);
+    assert.deepEqual(document.publicationOperationIds, ["op_code_doc", "op_document"]);
+    const verified = verifyTaskCompleteWitnessRefs({
+      ...fixture,
+      requireCodeDoc: false,
+      refs: [{ kind: "document-publication", ref: document.ref }]
+    });
+    assert.deepEqual(verified.map((entry) => entry.kind), ["document-publication"]);
   } finally {
     rmSync(fixture.fixtureRoot, { recursive: true, force: true });
   }
@@ -104,36 +125,6 @@ test("committed replay rejects a forged merge whose authority parent never chang
       refs: [{ kind: "document-publication", ref: forged }],
       snapshotMode: "committed"
     }), /WITNESS_COMMIT_NOT_PATH_ATTRIBUTED/u);
-  } finally {
-    rmSync(fixture.fixtureRoot, { recursive: true, force: true });
-  }
-});
-
-test("a forged operation id in a raw path-changing commit cannot satisfy publication", () => {
-  const fixture = witnessRepository();
-  try {
-    const taskRoot = path.join(fixture.authoredRoot, "tasks", `${taskId}-witness`);
-    const forgedCloseout = "# Closeout\n\nRaw content with a forged operation subject.\n";
-    writeFileSync(path.join(taskRoot, "closeout.md"), "# Closeout\n\nFirst-parent value.\n");
-    git(fixture.authoredRoot, "add", ".");
-    git(fixture.authoredRoot, "commit", "-q", "-m", "test: first-parent value");
-
-    git(fixture.authoredRoot, "checkout", "-q", "-b", "forged-operation-subject");
-    writeFileSync(path.join(taskRoot, "closeout.md"), forgedCloseout);
-    git(fixture.authoredRoot, "add", ".");
-    git(fixture.authoredRoot, "commit", "-q", "-m", "manual raw write [op_forged]");
-    git(fixture.authoredRoot, "checkout", "-q", "main");
-    git(fixture.authoredRoot, "merge", "-q", "--no-ff", "forged-operation-subject", "-m", "ordinary merge");
-
-    assert.throws(
-      () => produceDocumentPublicationWitness({
-        ...fixture,
-        documents: fixture.documents.map((document) => document.path === "closeout.md"
-          ? { ...document, body: forgedCloseout }
-          : document)
-      }),
-      /AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED/u
-    );
   } finally {
     rmSync(fixture.fixtureRoot, { recursive: true, force: true });
   }

--- a/packages/daemon/test/task-complete-prepublish-witness.test.ts
+++ b/packages/daemon/test/task-complete-prepublish-witness.test.ts
@@ -6,11 +6,17 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import test from "node:test";
+import { Effect } from "effect";
 import {
   CODE_DOC_RECONCILIATION_DOCUMENT,
   renderCodeDocReconciliationDraft,
   type TaskCompleteTransitionCommand
 } from "../../application/src/index.ts";
+import {
+  makeJournaledWriteCoordinator,
+  taskEntityId,
+  type WriteOp
+} from "../../kernel/src/index.ts";
 import {
   decodePrepublishWitnessRef,
   produceCodeDocWitness,
@@ -39,7 +45,7 @@ test("daemon-produced prepublish witnesses bind immutable publication history, c
     assert.equal(codeDoc.taskId, taskId);
     assert.equal(codeDoc.reconciledCommitRef, fixture.publicCommit);
     assert.deepEqual(codeDoc.normalizedPaths, ["README.md"]);
-    assert.deepEqual(codeDoc.publicationOperationIds, ["op_code_doc", "op_document"]);
+    assert.deepEqual(codeDoc.publicationOperationIds, ["op_code_doc"]);
 
     const forged = forgeWitnessRef(document.ref, { repositoryCommit: fixture.authoredInitialCommit });
     assert.throws(() => verifyTaskCompleteWitnessRefs({
@@ -62,6 +68,72 @@ test("daemon-produced prepublish witnesses bind immutable publication history, c
         { kind: "code-doc-reconciliation", ref: codeDoc.ref }
       ]
     }), /WITNESS_SNAPSHOT_MISMATCH:document-publication/u);
+  } finally {
+    rmSync(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("committed replay rejects a forged merge whose authority parent never changed the task documents", () => {
+  const fixture = witnessRepository();
+  try {
+    const document = produceDocumentPublicationWitness(fixture);
+    const taskRoot = path.join(fixture.authoredRoot, "tasks", `${taskId}-witness`);
+    const closeout = fixture.documents.find((entry) => entry.path === "closeout.md")!.body;
+    writeFileSync(path.join(taskRoot, "closeout.md"), "# Closeout\n\nRaw first-parent rollback.\n");
+    git(fixture.authoredRoot, "add", ".");
+    git(fixture.authoredRoot, "commit", "-q", "-m", "test: raw first-parent rollback");
+
+    git(fixture.authoredRoot, "checkout", "-q", "-b", "forged-publication");
+    writeFileSync(path.join(fixture.authoredRoot, "unrelated.txt"), "second parent never changed task documents\n");
+    git(fixture.authoredRoot, "add", ".");
+    git(fixture.authoredRoot, "commit", "-q", "-m", "test: unrelated authority parent");
+    git(fixture.authoredRoot, "checkout", "-q", "main");
+    git(fixture.authoredRoot, "merge", "-q", "--no-ff", "--no-commit", "forged-publication");
+    writeFileSync(path.join(taskRoot, "closeout.md"), closeout);
+    git(fixture.authoredRoot, "add", ".");
+    git(fixture.authoredRoot, "commit", "-q", "-m", "materialize forged task documents [op_forged]");
+    const forgedCommit = git(fixture.authoredRoot, "rev-parse", "HEAD");
+    const forged = forgeWitnessRef(document.ref, {
+      repositoryCommit: forgedCommit,
+      publicationOperationIds: ["op_forged"]
+    });
+
+    assert.throws(() => verifyTaskCompleteWitnessRefs({
+      ...fixture,
+      requireCodeDoc: false,
+      refs: [{ kind: "document-publication", ref: forged }],
+      snapshotMode: "committed"
+    }), /WITNESS_COMMIT_NOT_PATH_ATTRIBUTED/u);
+  } finally {
+    rmSync(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("a forged operation id in a raw path-changing commit cannot satisfy publication", () => {
+  const fixture = witnessRepository();
+  try {
+    const taskRoot = path.join(fixture.authoredRoot, "tasks", `${taskId}-witness`);
+    const forgedCloseout = "# Closeout\n\nRaw content with a forged operation subject.\n";
+    writeFileSync(path.join(taskRoot, "closeout.md"), "# Closeout\n\nFirst-parent value.\n");
+    git(fixture.authoredRoot, "add", ".");
+    git(fixture.authoredRoot, "commit", "-q", "-m", "test: first-parent value");
+
+    git(fixture.authoredRoot, "checkout", "-q", "-b", "forged-operation-subject");
+    writeFileSync(path.join(taskRoot, "closeout.md"), forgedCloseout);
+    git(fixture.authoredRoot, "add", ".");
+    git(fixture.authoredRoot, "commit", "-q", "-m", "manual raw write [op_forged]");
+    git(fixture.authoredRoot, "checkout", "-q", "main");
+    git(fixture.authoredRoot, "merge", "-q", "--no-ff", "forged-operation-subject", "-m", "ordinary merge");
+
+    assert.throws(
+      () => produceDocumentPublicationWitness({
+        ...fixture,
+        documents: fixture.documents.map((document) => document.path === "closeout.md"
+          ? { ...document, body: forgedCloseout }
+          : document)
+      }),
+      /AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED/u
+    );
   } finally {
     rmSync(fixture.fixtureRoot, { recursive: true, force: true });
   }
@@ -187,12 +259,10 @@ function witnessRepository() {
   ];
   const command = completeCommand(publicCommit);
 
-  git(authoredRoot, "checkout", "-q", "-b", "publication");
-  for (const document of documents) writeFileSync(path.join(taskRoot, document.path), document.body);
-  git(authoredRoot, "add", ".");
-  git(authoredRoot, "commit", "-q", "-m", "authority publication [op_code_doc,op_document]");
-  git(authoredRoot, "checkout", "-q", "main");
-  git(authoredRoot, "merge", "-q", "--no-ff", "publication", "-m", "materialize [op_code_doc,op_document]");
+  publishTaskDocumentOps(rootDir, "witness-publication", [
+    taskDocumentOp("op_code_doc", "code_doc_reconcile", CODE_DOC_RECONCILIATION_DOCUMENT, codeDoc.body),
+    taskDocumentOp("op_document", "doc_write", "closeout.md", closeout)
+  ]);
 
   return {
     fixtureRoot,
@@ -263,12 +333,9 @@ function partiallyPublishedWitnessRepository() {
   git(authoredRoot, "add", ".");
   git(authoredRoot, "commit", "-q", "-m", "test: raw task documents");
 
-  git(authoredRoot, "checkout", "-q", "-b", "publication");
-  writeFileSync(path.join(taskRoot, "closeout.md"), publishedCloseout);
-  git(authoredRoot, "add", ".");
-  git(authoredRoot, "commit", "-q", "-m", "authority publication [op_closeout]");
-  git(authoredRoot, "checkout", "-q", "main");
-  git(authoredRoot, "merge", "-q", "--no-ff", "publication", "-m", "materialize [op_closeout]");
+  publishTaskDocumentOps(rootDir, "partial-publication", [
+    taskDocumentOp("op_closeout", "doc_write", "closeout.md", publishedCloseout)
+  ]);
 
   return {
     fixtureRoot,
@@ -350,6 +417,46 @@ function completeCommand(commitRef: string): TaskCompleteTransitionCommand {
     callerIdempotencyKey: `task-complete-${"4".repeat(64)}`,
     dryRun: false
   };
+}
+
+function taskDocumentOp(
+  opId: string,
+  kind: "doc_write" | "code_doc_reconcile",
+  documentPath: string,
+  body: string
+): WriteOp {
+  return {
+    opId,
+    entityId: taskEntityId(taskId),
+    kind,
+    payload: { path: documentPath, body }
+  };
+}
+
+function publishTaskDocumentOps(
+  rootDir: string,
+  sessionId: string,
+  operations: ReadonlyArray<WriteOp>
+): void {
+  const coordinator = makeJournaledWriteCoordinator({
+    rootDir,
+    attribution: {
+      actor: {
+        principal: { kind: "person", personId: "person_test" },
+        executor: { kind: "agent", id: "witness-fixture" }
+      },
+      principalSource: {
+        kind: "local-configured",
+        authority: "harness.yaml",
+        authoritySha256: `sha256:${"0".repeat(64)}`
+      },
+      executorSource: "client-asserted"
+    },
+    sessionId,
+    commitAuthor: { name: "Harness Test", email: "harness@example.test" }
+  });
+  for (const operation of operations) Effect.runSync(coordinator.enqueue(operation));
+  Effect.runSync(coordinator.flush("explicit"));
 }
 
 function forgeWitnessRef(ref: string, patch: Record<string, unknown>): string {

--- a/packages/daemon/test/task-complete-prepublish-witness.test.ts
+++ b/packages/daemon/test/task-complete-prepublish-witness.test.ts
@@ -49,7 +49,7 @@ test("daemon-produced prepublish witnesses bind immutable publication history, c
         { kind: "document-publication", ref: forged },
         { kind: "code-doc-reconciliation", ref: codeDoc.ref }
       ]
-    }), /WITNESS_COMMIT_NOT_MATERIALIZED_FIRST_PARENT/u);
+    }), /WITNESS_COMMIT_NOT_PATH_ATTRIBUTED/u);
 
     assert.throws(() => verifyTaskCompleteWitnessRefs({
       ...fixture,
@@ -97,6 +97,18 @@ test("unpublished document rejection names only the path whose body is not mater
         assert.match(message, /content differs from expected/u);
         return true;
       }
+    );
+  } finally {
+    rmSync(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("a later publication cannot attribute an unchanged raw task document", () => {
+  const fixture = partiallyPublishedWitnessRepository();
+  try {
+    assert.throws(
+      () => produceDocumentPublicationWitness(fixture),
+      /AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:[^\n]*task_plan\.md/u
     );
   } finally {
     rmSync(fixture.fixtureRoot, { recursive: true, force: true });
@@ -220,6 +232,54 @@ function unpublishedScaleWitnessRepository(mergeCount: number, documentCount: nu
     : document);
   writeFileSync(path.join(taskRoot, mutatedDocuments[0]!.path), mutatedDocuments[0]!.body);
   return { fixtureRoot, rootDir, authoredRoot, taskId, documents: mutatedDocuments };
+}
+
+function partiallyPublishedWitnessRepository() {
+  const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-prepublish-partial-"));
+  const rootDir = path.join(fixtureRoot, "workspace");
+  const authoredRoot = path.join(rootDir, "harness");
+  const taskRoot = path.join(authoredRoot, "tasks", `${taskId}-partial`);
+  mkdirSync(taskRoot, { recursive: true });
+  gitInit(authoredRoot);
+
+  const taskPlan = "# Plan\n\nRaw task plan that has never entered the governed write road.\n";
+  const originalCloseout = "# Closeout\n\nOriginal closeout.\n";
+  const publishedCloseout = "# Closeout\n\nGoverned closeout.\n";
+  writeFileSync(path.join(taskRoot, "INDEX.md"), [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${taskId}`,
+    "title: Partial publication fixture",
+    "lifecycle:",
+    "  engine: local",
+    "  status: in_review",
+    "---",
+    "",
+    "# Partial publication fixture",
+    ""
+  ].join("\n"));
+  writeFileSync(path.join(taskRoot, "task_plan.md"), taskPlan);
+  writeFileSync(path.join(taskRoot, "closeout.md"), originalCloseout);
+  git(authoredRoot, "add", ".");
+  git(authoredRoot, "commit", "-q", "-m", "test: raw task documents");
+
+  git(authoredRoot, "checkout", "-q", "-b", "publication");
+  writeFileSync(path.join(taskRoot, "closeout.md"), publishedCloseout);
+  git(authoredRoot, "add", ".");
+  git(authoredRoot, "commit", "-q", "-m", "authority publication [op_closeout]");
+  git(authoredRoot, "checkout", "-q", "main");
+  git(authoredRoot, "merge", "-q", "--no-ff", "publication", "-m", "materialize [op_closeout]");
+
+  return {
+    fixtureRoot,
+    rootDir,
+    authoredRoot,
+    taskId,
+    documents: [
+      { path: "closeout.md", body: publishedCloseout },
+      { path: "task_plan.md", body: taskPlan }
+    ]
+  };
 }
 
 function appendNoopFirstParentMerges(rootDir: string, initialCommit: string, mergeCount: number): void {

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -94,7 +94,10 @@ export {
 } from "./integrity/decision-content-digest.ts";
 export type { DecisionContentDigestField } from "./integrity/decision-content-digest.ts";
 export { validateOutputEvidence } from "./local/output-evidence-validator.ts";
-export { readUnionAttributionEvents } from "./local/attribution-event-source.ts";
+export {
+  decodeAttributionEventBody,
+  readUnionAttributionEvents
+} from "./local/attribution-event-source.ts";
 export { makeCodeDocGitEvidenceResolver } from "./git/code-doc-git-evidence.ts";
 export * from "./layout/index.ts";
 export * from "./markdown/frontmatter.ts";

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -94,10 +94,7 @@ export {
 } from "./integrity/decision-content-digest.ts";
 export type { DecisionContentDigestField } from "./integrity/decision-content-digest.ts";
 export { validateOutputEvidence } from "./local/output-evidence-validator.ts";
-export {
-  decodeAttributionEventBody,
-  readUnionAttributionEvents
-} from "./local/attribution-event-source.ts";
+export { readUnionAttributionEvents } from "./local/attribution-event-source.ts";
 export { makeCodeDocGitEvidenceResolver } from "./git/code-doc-git-evidence.ts";
 export * from "./layout/index.ts";
 export * from "./markdown/frontmatter.ts";

--- a/packages/kernel/test/contracts/public-surface.test.ts
+++ b/packages/kernel/test/contracts/public-surface.test.ts
@@ -111,7 +111,6 @@ const publicRuntimeSurface = [
   "decisionSemanticMutationActions",
   "decisionStates",
   "decodeAndVerifyAttributionEventV2",
-  "decodeAttributionEventBody",
   "decodeCanonicalCbor",
   "decodeEntityDeclaration",
   "defaultTaskProjectionPath",

--- a/packages/kernel/test/contracts/public-surface.test.ts
+++ b/packages/kernel/test/contracts/public-surface.test.ts
@@ -111,6 +111,7 @@ const publicRuntimeSurface = [
   "decisionSemanticMutationActions",
   "decisionStates",
   "decodeAndVerifyAttributionEventV2",
+  "decodeAttributionEventBody",
   "decodeCanonicalCbor",
   "decodeEntityDeclaration",
   "defaultTaskProjectionPath",

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -3869,6 +3869,27 @@
           "reason": "Design exemption: write-road row public-code-change.git assigns packages/daemon/src/authority/production/publication-evidence.ts this exact execFileSync call for git-worktree/code-truth; it does not bypass a canonical entity coordinator road."
         },
         {
+          "key": "packages/daemon/src/authority/production/task-complete-prepublish-publication.ts#execFileSync@1",
+          "owner": "public-code-change.git",
+          "classification": "design-exemption",
+          "ref": "task_01KZ8VKAYSHYYJT2F58FTDGGG0",
+          "reason": "Design exemption: write-road row public-code-change.git assigns packages/daemon/src/authority/production/task-complete-prepublish-publication.ts this exact execFileSync call for git-worktree/code-truth; it reads publication topology (show/ls-tree/hash-object) and does not bypass a canonical entity coordinator road."
+        },
+        {
+          "key": "packages/daemon/src/authority/production/task-complete-prepublish-publication.ts#execFileSync@2",
+          "owner": "public-code-change.git",
+          "classification": "design-exemption",
+          "ref": "task_01KZ8VKAYSHYYJT2F58FTDGGG0",
+          "reason": "Design exemption: write-road row public-code-change.git assigns packages/daemon/src/authority/production/task-complete-prepublish-publication.ts this exact execFileSync call for git-worktree/code-truth; it reads publication topology (show/ls-tree/hash-object) and does not bypass a canonical entity coordinator road."
+        },
+        {
+          "key": "packages/daemon/src/authority/production/task-complete-prepublish-publication.ts#execFileSync@3",
+          "owner": "public-code-change.git",
+          "classification": "design-exemption",
+          "ref": "task_01KZ8VKAYSHYYJT2F58FTDGGG0",
+          "reason": "Design exemption: write-road row public-code-change.git assigns packages/daemon/src/authority/production/task-complete-prepublish-publication.ts this exact execFileSync call for git-worktree/code-truth; it reads publication topology (show/ls-tree/hash-object) and does not bypass a canonical entity coordinator road."
+        },
+        {
           "key": "packages/kernel/src/persistence/git/local-version-control-system.ts#execFileSync@1",
           "owner": "public-code-change.git",
           "classification": "design-exemption",


### PR DESCRIPTION
# English

## Summary

A pilot user on a consumer install could not finish a reviewed task: `complete` and `closeout` were both rejected with `PREPUBLISH_NOT_MATERIALIZED`, while both `--dry-run` paths returned ok. The gate's invariant was right; its criterion, its supply road, and its preflight were not. This restores the road first and tightens the criterion in the same change.

## What Changed

- **Supply (doc-sync)**: on installs without the dogfood `tools/write-road-registry.json`, the dirty-file scan admitted only `tasks/<slug>/closeout.md`, so `doc sync --submit --path <task_plan.md>` answered "not dirty or is unknown" even for a genuinely dirty file — while the CLI's own help example and `task create` next-step both told the user to hand-write `task_plan.md` and submit it that way. Candidates are now discovered from the installed preset/template contract: a file inside a task package whose managed-section policy resolves against a **successfully resolved** declared preset. Typed records, `INDEX.md` and unknown markdown stay inert, so the scan is still fail-closed.
- **Criterion (PREPUBLISH)**: the gate accepted any two-parent publication whose tree happened to carry the same blobs, so one later unrelated governed write could vouch for files that never travelled the write road. Proof is now per path: the merge must move that path from its first parent's old blob to the current one, and the second-parent range must contain an operation id that changed it. Publication proof was extracted into its own module in the process.
- **Legacy replay fallback removed**: the extracted module briefly kept a `try { strict } catch { legacy }` branch for already-committed transitions. It is gone; committed replay now takes the same strict criterion.
- **Preflight**: `closeout --dry-run` returned ok after listing step kinds without dispatching anything, and `complete --dry-run` returned ok with unchecked gates when no authority preflight existed. Both now translate to the same `task-complete` intent and call the same planner; absent a planner they exit non-zero.
- **Receipt**: `task-closeout` declared `data.executionId` required while its only underlying step declared `taskId/status/completionGate`, so the facade read undefined and threw `command_receipt_contract_mismatch` *after* the write had landed. Both now derive from one `taskCompletionReceiptContract`.
- **Test fixture that was always cheating**: `production-authority-canonical-ingress-tracer` placed `INDEX.md`, `task_plan.md`, `closeout.md` and `code-doc-anchors.json` on disk with `writeFileSync`, never travelling the write road. The old criterion admitted them via coincidental coverage, so the fixture had never actually verified publication. It now publishes through the real coordinator/materializer chain; siblings built the same way were audited.
- **Registry declaration (CEO)**: extracting the publication proof moved three git observation calls out of the module the write-road registry named. Declared them where the code now lives with the same design-exemption reasoning — a declaration following its code, not a new exemption.

## Task And Scope

- Harness task: `task_01KZ8VKAYSHYYJT2F58FTDGGG0`
- Branch: `codex/consumer-completion-road`
- Public scope: `packages/daemon/src/{service,authority/production}`, `packages/cli/src/{cli/command-spec,commands/core,commands/extensions}`, `packages/kernel/src/index.ts`, their tests, and three registry declaration rows.
- Private planning/evidence updated: yes
- Out of scope: the upstream diagnosis's proposed `task prepublish` operation and persistent manifest (see Review Evidence — shown unnecessary); existing `done` task states, which were audited read-only and left untouched; clone-portable authenticated attribution, which is deliberately deferred to `task_01KZ965XSCKFFHPPFF71GNDVWZ` (see Residual Risk).

## Version Impact

- Version: no version change because this repairs internal write-road and gate behaviour with no published surface change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/write-road-registry.json` — three `design-exemption` declaration rows added for git-read calls that moved to a new module. No gate logic, workflow, required-check list or branch protection was touched, and no existing row was weakened.
- Authority: `task_01KZ8VKAYSHYYJT2F58FTDGGG0`; ordering authority is `dec_01KZ8VJPTHGBD3JER3R022ZSJ7` (open the road before tightening the criterion).
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: `task_01KZ965XSCKFFHPPFF71GNDVWZ` — clone-portable authenticated completion publication attribution.

## Verification

- [x] `npm run check:local` — `Local check passed in 135.7s`, 27 complete manifest gates green; runner totals `948/948` and `719 pass / 1 skipped / 0 fail`.
- [x] Positive controls, red before the fix (raw runner output in the task's implementation report): consumer `task_plan.md` submit → `Doc sync selected path is not dirty or is unknown`; per-path attribution → `AssertionError: Missing expected exception` (old gate admitted a raw seed); both dry-runs → `actual: [true, true]` vs `expected: [false, false]`.
- [x] After the fix, a production consumer fixture that edits `closeout.md` after publication makes `complete --dry-run`, `closeout --dry-run` and the real run all fail with the same code and the same path; the same path then succeeds once submitted through `doc sync`.
- [x] Clone-portability regression, new: `document publication remains verifiable without machine-local write payloads` deletes `.harness/write-journal/payloads` outright and asserts the witness still verifies (`1/1`). This test was red against the intermediate design described in Review Evidence.
- [x] Committed-replay regression, new: a forged merge whose authority parent never changed the task documents is rejected (`witness 7/7`).
- [x] `production-authority-canonical-ingress-tracer` still drives the real coordinator/materializer chain after the fixture repair (`1/1`).
- [x] Write-road registry checker differenced against `origin/main`: main already exits 1 on pre-existing global drift, and after the declaration rows the branch reports no unmapped row that main does not.
- Not run: `npm run check:ci`. GitHub CI is the authority for the 31 broader gates.

## Review Evidence

- **Correction to an earlier version of this body.** It stated that the CEO reviewed the legacy fallback in `assertCommittedMaterializedPublication` and accepted it, on the ground that it was reachable only through idempotent replay of an already-committed transition. That reasoning was circular and the conclusion is withdrawn: "already committed" is precisely what this change treats as untrustworthy, since a raw commit produces it. The fallback has been deleted.
- Two independent reviewers, blind to each other: a black-box review of the exported diff, and an adversarial review inside the worktree. Both converged on the legacy fallback. The adversarial side additionally reproduced two bypasses empirically, and established that no release tag contains the witness feature — so the fallback existed for a hypothetical user, which `docs-release/contributing/en/05-agent-contributors.md:36` forbids.
- **An intermediate design was built and then reverted.** To bind operation ids to something less forgeable than a commit subject, one round bound them to durable attribution events and verified the payload. CEO ground-truth found the payload lives in `.harness/write-journal/payloads`, which `.gitignore:32` excludes (`git ls-files .harness/` = 0). The author then confirmed it with controlled runs: the production `task-complete` test passes normally, and injecting `ENOENT` on that local file alone makes the real command reject all four task documents. Any checkout that did not perform the writes would have been permanently blocked. Reverted; the reasoning and both controls are in the task's implementation report.
- Worker refutation accepted: the upstream diagnosis proposed a new `task prepublish` operation writing a persistent manifest. Immutable git topology already yields a recomputable operation/path/blob binding, so no new persistent structure was added.
- Blocking findings: none outstanding.

## Residual Risk

- **Operation ids are read from commit subjects and are forgeable by a principal that can already raw-commit to the authored ledger.** The topology `P(path=A) → Q(raw write of path=B, subject carrying a forged operation id) → ordinary no-ff merge M` satisfies the per-path criterion. This is accepted, not closed, under the repository's standing principle that mechanical defenses target accidents rather than deliberate cheating: accidental hand-authoring cannot produce that topology, and the per-path criterion does cover the accident class. Closing it requires clone-portable authenticated attribution and is scoped in `task_01KZ965XSCKFFHPPFF71GNDVWZ`. Until those land, this residual must not be described as fixed.
- `architecture-check` reports `status: drifted` (missing snapshot for this task plus two unrelated GUI warnings). Recorded as advisory, not asserted as a completion gate.
- The write-road registry checker still exits 1 on drift that predates this branch. Not repaired here; this change only avoids adding to it.
- Behavioural coverage for consumer installs comes from fixtures rather than a real second repository. The pilot install that reported the defect is the intended first real user.

## References

- Task: `task_01KZ8VKAYSHYYJT2F58FTDGGG0`
- Follow-up task: `task_01KZ965XSCKFFHPPFF71GNDVWZ`
- Evidence: task artifacts `implementation-report.md`, `review-blind-glm.md`, `review-adversarial-codex.md`, `round2-adjudication-and-resume.md`, `upstream-diagnosis.md`, `upstream-handoff.md`, `upstream-facts.md`
- Decision: `dec_01KZ8VJPTHGBD3JER3R022ZSJ7`

---

# 中文

## 概要

一位试点用户在消费者形态的安装里无法完成一个已评审的任务：`complete` 与 `closeout` 双双被 `PREPUBLISH_NOT_MATERIALIZED` 拒绝，而两条 `--dry-run` 都返回成功。这道门的不变量是对的，但它的判据、它的供给路、它的预检都不对。本改动先开路，并在同一次改动里收紧判据。

## 改动内容

- **供给（doc-sync）**：在没有自举用 `tools/write-road-registry.json` 的安装上，脏文件扫描只放行 `tasks/<slug>/closeout.md`，于是 `doc sync --submit --path <task_plan.md>` 对一个确实是脏的文件回答"not dirty or is unknown"——而 CLI 自己的帮助示例与 `task create` 的下一步提示都在引导用户手写 `task_plan.md` 并用这条命令提交。现在候选由已安装的 preset/模板契约决定：任务包内、且其 managed section policy 能对着**成功解析的**声明 preset 解析出来的文件。类型化记录、`INDEX.md` 与未知 markdown 仍然惰性，扫描依旧 fail-closed。
- **判据（PREPUBLISH）**：原判据接受任何双父 publication，只要它的树在这些路径上携带相同 blob，于是一次与该任务无关的后续治理写入就能替从未走过写路的文件背书。现在改为逐路径取证：merge 必须把该路径从第一父的旧 blob 改成当前 blob，且第二父范围内必须存在改动过该路径的 operation id。发布取证在此过程中抽成了独立模块。
- **删除 legacy 重放回退**：抽出的模块一度为已提交的 transition 保留了 `try { 严格 } catch { legacy }` 分支。该分支已删除，已提交重放现在走同一套严格判据。
- **预检**：`closeout --dry-run` 只列出步骤种类、不 dispatch 任何东西就返回成功，`complete --dry-run` 在没有权威预检时带着未检查的门返回成功。现在两者都翻译成同一个 `task-complete` 意图并调用同一个 planner；没有 planner 时以非零退出。
- **回执**：`task-closeout` 声明 `data.executionId` 必填，而它唯一的底层步骤声明的是 `taskId/status/completionGate`，于是 facade 读到 undefined，在写入**已经落盘之后**抛出 `command_receipt_contract_mismatch`。两者现在都从同一个 `taskCompletionReceiptContract` 派生。
- **一直在作弊的测试夹具**：`production-authority-canonical-ingress-tracer` 用 `writeFileSync` 把 `INDEX.md`、`task_plan.md`、`closeout.md`、`code-doc-anchors.json` 直接写盘，从未走过写路。旧判据靠碰巧覆盖放行了它们，因此这个夹具**从来没有真正验证过发布**。现在它经由真实的 coordinator/materializer 链发布；同样构造的同族夹具已审计。
- **注册表声明（CEO）**：抽出发布取证时，三处 git 观察调用离开了 write-road registry 点名的模块。已在代码的新位置按同样的 design-exemption 理由重新声明——是声明跟着代码走，不是新增豁免。

## 任务与范围

- Harness 任务：`task_01KZ8VKAYSHYYJT2F58FTDGGG0`
- 分支：`codex/consumer-completion-road`
- 公开面：`packages/daemon/src/{service,authority/production}`、`packages/cli/src/{cli/command-spec,commands/core,commands/extensions}`、`packages/kernel/src/index.ts`、对应测试，以及三行注册表声明。
- 私有规划/证据已更新：是
- 范围外：上游诊断提出的 `task prepublish` 操作与持久化 manifest（见审查证据——已证明不必要）；既有 `done` 任务状态，只做只读审计未改动；clone-portable 的可认证归因，有意推迟到 `task_01KZ965XSCKFFHPPFF71GNDVWZ`（见残余风险）。

## 版本影响

- 版本：不变更，因为本改动修复的是内部写路与门的行为，没有已发布面的变化。
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是
- 受保护面范围：`tools/write-road-registry.json` —— 为迁移到新模块的 git 读调用新增三行 `design-exemption` 声明。未触碰任何门逻辑、workflow、required check 清单或分支保护，也未削弱任何既有条目。
- 授权：`task_01KZ8VKAYSHYYJT2F58FTDGGG0`；顺序授权是 `dec_01KZ8VJPTHGBD3JER3R022ZSJ7`（先开路再收紧判据）。
- 机检边界：本 PR 只断言声明存在；声明是否属实、是否充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：`task_01KZ965XSCKFFHPPFF71GNDVWZ` —— clone-portable 可认证的完成发布归因。

## 验证

- [x] `npm run check:local` —— `Local check passed in 135.7s`，27 个完整 manifest 门全绿；runner 统计 `948/948` 与 `719 pass / 1 skipped / 0 fail`。
- [x] 阳性对照，修前为红（原始 runner 输出在任务的实现报告里）：消费者 `task_plan.md` 提交 → `Doc sync selected path is not dirty or is unknown`；逐路径归因 → `AssertionError: Missing expected exception`（旧门放行了 raw seed）；两条 dry-run → `actual: [true, true]` 对 `expected: [false, false]`。
- [x] 修后，一个在发布之后编辑 `closeout.md` 的生产消费者夹具让 `complete --dry-run`、`closeout --dry-run` 与真实执行全部以同一错误码、同一路径失败；该路径经 `doc sync` 提交后即成功。
- [x] 新增 clone 可移植性回归：`document publication remains verifiable without machine-local write payloads` 直接删掉 `.harness/write-journal/payloads` 再断言 witness 仍可验证（`1/1`）。该测试对审查证据里描述的那版中间设计为红。
- [x] 新增已提交重放回归：一个 authority 父从未改动过任务文档的伪造 merge 被拒绝（`witness 7/7`）。
- [x] 夹具修复后，`production-authority-canonical-ingress-tracer` 仍走真实的 coordinator/materializer 链（`1/1`）。
- [x] write-road registry 检查器与 `origin/main` 做差：main 本身已因先于本分支的全局漂移以 1 退出，补上声明行之后，本分支没有报出 main 没有的未映射条目。
- 未运行：`npm run check:ci`。GitHub CI 是那 31 道更广的门的权威。

## 审查证据

- **对本 body 早前版本的更正。** 早前版本写道：CEO 复核了 `assertCommittedMaterializedPublication` 里的 legacy 回退并予以接受，理由是它只能经由已提交 transition 的幂等重放到达。该论证是循环的，结论作废——"已提交"恰恰是本改动认定不可信的东西，因为一次 raw commit 就能产生它。该回退已删除。
- 两位互不透题的评审者：一位只拿导出的 diff 做黑盒盲评，一位在 worktree 内做对抗复核。两边独立指向同一处 legacy 回退。对抗侧另外实测复现了两条绕过，并确认没有任何发布 tag 包含该 witness 功能——也就是说这个回退是为一个假想用户存在的，而 `docs-release/contributing/en/05-agent-contributors.md:36` 明确禁止。
- **有一版中间设计被造出来又撤掉了。** 为了让 operation id 绑定到比 commit subject 更难伪造的东西上，其中一轮把它绑定到 durable attribution event 并校验 payload。CEO ground-truth 发现该 payload 位于 `.harness/write-journal/payloads`，而 `.gitignore:32` 排除了它（`git ls-files .harness/` 为 0）。作者随后用受控实验确认：生产 `task-complete` 用例原样通过，仅对那个本地文件注入 `ENOENT`，真实命令即拒绝全部四份任务文档。任何未执行过这些写入的 checkout 都会被永久阻塞。该设计已撤销；论证与两组对照都在任务的实现报告里。
- 接受 worker 的反驳：上游诊断提议新增 `task prepublish` 操作并写入持久化 manifest。不可变的 git 拓扑本身就能重算出 operation/路径/blob 的绑定，因此没有新增持久结构。
- 阻塞性发现：无遗留。

## 残余风险

- **operation id 是从 commit subject 读出的，对一个已经能向 authored ledger 做 raw commit 的主体而言可伪造。** 拓扑 `P(path=A) → Q(raw 写入 path=B，subject 携带伪造的 operation id) → 普通 no-ff merge M` 能满足逐路径判据。按本仓既有原则"机械防御针对意外而非蓄意作弊"，这一条是被接受而非被堵死：手写文件那类意外产生不出该拓扑，而逐路径判据确实覆盖了意外这一类。要堵死它需要 clone-portable 的可认证归因，已在 `task_01KZ965XSCKFFHPPFF71GNDVWZ` 中定义范围。在那些交付落地之前，这条残余风险不得被描述为已修复。
- `architecture-check` 报 `status: drifted`（本任务缺快照，另有两条无关的 GUI 告警）。作为 advisory 记录，未当作完成门断言。
- write-road registry 检查器仍会因先于本分支的漂移以 1 退出。本次未修复；本改动只保证不再增加。
- 消费者安装的行为覆盖来自夹具而非真实的第二个仓库。报告该缺陷的试点安装就是预期的第一个真实用户。

## 关联材料

- 任务：`task_01KZ8VKAYSHYYJT2F58FTDGGG0`
- 后续任务：`task_01KZ965XSCKFFHPPFF71GNDVWZ`
- 证据：任务 artifacts `implementation-report.md`、`review-blind-glm.md`、`review-adversarial-codex.md`、`round2-adjudication-and-resume.md`、`upstream-diagnosis.md`、`upstream-handoff.md`、`upstream-facts.md`
- 决策：`dec_01KZ8VJPTHGBD3JER3R022ZSJ7`
