### PR TITLE
fix(daemon): bound task completion publication proof to four history scans

### DIFF
--- a/packages/daemon/src/authority/production/production-authority-task-completion-intent.ts
+++ b/packages/daemon/src/authority/production/production-authority-task-completion-intent.ts
@@ -77,8 +77,8 @@ export async function taskCompletionIntent(
   };
   reportCurrentRepoWriteTelemetry("compile-task-witness");
   const witnesses = existing
-    ? verifyTaskCompleteWitnessRefs({ ...witnessInput, refs: existing.externalCheckpointRefs, snapshotMode: "committed" })
-    : resolveVerifiedTaskCompleteWitnesses(witnessInput);
+    ? await verifyTaskCompleteWitnessRefs({ ...witnessInput, refs: existing.externalCheckpointRefs, snapshotMode: "committed" })
+    : await resolveVerifiedTaskCompleteWitnesses(witnessInput);
   assertLifecycleCompletionPrerequisites(documents, command, completionGates);
   const selectedReplayApproval = !existing && currentRound.kind === "accepted-replay"
     ? acceptedReplayApproval(documents, taskId, currentRound.execution)

--- a/packages/daemon/src/authority/production/task-complete-prepublish-publication.ts
+++ b/packages/daemon/src/authority/production/task-complete-prepublish-publication.ts
@@ -1,21 +1,41 @@
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { stableStringify } from "@harness-anything/kernel";
+import { reportCurrentRepoWriteTelemetry } from "../../runtime/repo-write-telemetry-context.ts";
 
-export function findAttributedMaterializedPublication(
+const execFileAsync = promisify(execFile);
+
+export async function findAttributedMaterializedPublication(
   rootDir: string,
   repositoryPaths: ReadonlyArray<string>,
   bodies: ReadonlyArray<string>,
   headRef = "HEAD"
-): { readonly commit: string; readonly operationIds: ReadonlyArray<string> } {
-  const expectedBlobs = bodies.map((body) => taskCompletePublicationGitText(rootDir, ["hash-object", "--stdin"], body));
-  const currentBlobs = gitBlobIds(rootDir, headRef, repositoryPaths);
+): Promise<{ readonly commit: string; readonly operationIds: ReadonlyArray<string> }> {
+  reportCurrentRepoWriteTelemetry("authority-publication-proof", { stage: "blob-hash" });
+  const expectedBlobs: string[] = [];
+  for (const body of bodies) expectedBlobs.push(await gitHashObject(rootDir, body));
+  const currentBlobs = await gitBlobIds(rootDir, headRef, repositoryPaths);
   if (currentBlobs.some((actual, index) => actual !== expectedBlobs[index])) {
     throw new Error(
       `AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:${describeMaterializationMismatches(repositoryPaths, currentBlobs, expectedBlobs)}`
     );
   }
-  const attributions = repositoryPaths.map((repositoryPath, index) =>
-    findPathMaterializedPublication(rootDir, repositoryPath, expectedBlobs[index]!, headRef)
+  const historyPromise = firstParentHistory(rootDir, repositoryPaths, headRef);
+  reportCurrentRepoWriteTelemetry("authority-publication-proof", {
+    stage: "history-start",
+    pathCount: repositoryPaths.length
+  });
+  const history = await historyPromise;
+  reportCurrentRepoWriteTelemetry("authority-publication-proof", {
+    stage: "history-done",
+    pathCount: repositoryPaths.length,
+    historyEntryCount: history.length
+  });
+  const attributions = await findPathMaterializedPublications(
+    rootDir,
+    repositoryPaths,
+    expectedBlobs,
+    history
   );
   const missing = attributions.flatMap((attribution, index) => attribution ? [] : [repositoryPaths[index]!]);
   if (missing.length > 0) {
@@ -27,8 +47,7 @@ export function findAttributedMaterializedPublication(
   }
   const attributed = attributions.filter((entry): entry is NonNullable<typeof entry> => entry !== null);
   const attributedCommits = new Set(attributed.map((entry) => entry.commit));
-  const representative = firstParentHistory(rootDir, repositoryPaths, headRef)
-    .find((entry) => attributedCommits.has(entry.commit));
+  const representative = history.find((entry) => attributedCommits.has(entry.commit));
   if (!representative) throw new Error("AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:attributed publication missing from first-parent history");
   return {
     commit: representative.commit,
@@ -36,15 +55,15 @@ export function findAttributedMaterializedPublication(
   };
 }
 
-export function assertAttributedMaterializedPublication(
+export async function assertAttributedMaterializedPublication(
   rootDir: string,
   repositoryCommit: string,
   repositoryPaths: ReadonlyArray<string>,
   bodies: ReadonlyArray<string>,
   expectedOperationIds: ReadonlyArray<string>,
   headRef = "HEAD"
-): void {
-  const publication = findAttributedMaterializedPublication(rootDir, repositoryPaths, bodies, headRef);
+): Promise<void> {
+  const publication = await findAttributedMaterializedPublication(rootDir, repositoryPaths, bodies, headRef);
   if (publication.commit !== repositoryCommit) {
     throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_COMMIT_NOT_PATH_ATTRIBUTED");
   }
@@ -53,66 +72,87 @@ export function assertAttributedMaterializedPublication(
   }
 }
 
-export function prepublishGitBlobText(rootDir: string, commitRef: string, repositoryPath: string): string {
+export async function prepublishGitBlobText(rootDir: string, commitRef: string, repositoryPath: string): Promise<string> {
   try {
-    return execFileSync("git", ["-C", rootDir, "show", `${commitRef}:${repositoryPath}`], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-      maxBuffer: 64 * 1024 * 1024,
-      windowsHide: true
-    });
+    return await taskCompletePublicationGitTextRaw(rootDir, ["show", `${commitRef}:${repositoryPath}`]);
   } catch {
     throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_BLOB_MISSING");
   }
 }
 
-export function prepublishGitTextOrNull(rootDir: string, args: ReadonlyArray<string>): string | null {
+export async function prepublishGitTextOrNull(rootDir: string, args: ReadonlyArray<string>): Promise<string | null> {
   try {
-    return taskCompletePublicationGitText(rootDir, args);
+    return await taskCompletePublicationGitText(rootDir, args);
   } catch {
     return null;
   }
 }
 
-function findPathMaterializedPublication(
+async function findPathMaterializedPublications(
   rootDir: string,
-  repositoryPath: string,
-  expectedBlob: string,
-  headRef: string
-): { readonly commit: string; readonly operationIds: ReadonlyArray<string> } | null {
-  for (const entry of firstParentHistory(rootDir, [repositoryPath], headRef)) {
+  repositoryPaths: ReadonlyArray<string>,
+  expectedBlobs: ReadonlyArray<string>,
+  history: ReadonlyArray<{
+    readonly commit: string;
+    readonly parents: ReadonlyArray<string>;
+    readonly subject: string;
+  }>
+): Promise<ReadonlyArray<{ readonly commit: string; readonly operationIds: ReadonlyArray<string> } | null>> {
+  const attributions: Array<{ readonly commit: string; readonly operationIds: ReadonlyArray<string> } | null> =
+    repositoryPaths.map(() => null);
+  let remaining = repositoryPaths.length;
+  for (const entry of history) {
     if (entry.parents.length !== 2) continue;
-    const [actualBlob] = gitBlobIds(rootDir, entry.commit, [repositoryPath]);
-    if (actualBlob !== expectedBlob) continue;
-    const [firstParentBlob] = gitBlobIds(rootDir, entry.parents[0]!, [repositoryPath]);
-    if (firstParentBlob === actualBlob) continue;
-    const operationIds = attributedPathOperationIds(rootDir, entry.parents[0]!, entry.parents[1]!, repositoryPath, expectedBlob);
-    if (operationIds.length === 0) continue;
-    return { commit: entry.commit, operationIds };
+    const actualBlobs = await gitBlobIds(rootDir, entry.commit, repositoryPaths);
+    const candidates = repositoryPaths.flatMap((_repositoryPath, index) =>
+      attributions[index] === null && actualBlobs[index] === expectedBlobs[index] ? [index] : []
+    );
+    if (candidates.length === 0) continue;
+    const firstParentBlobs = await gitBlobIds(rootDir, entry.parents[0]!, repositoryPaths);
+    for (const index of candidates) {
+      if (firstParentBlobs[index] === actualBlobs[index]) continue;
+      const operationIds = await attributedPathOperationIds(
+        rootDir,
+        entry.parents[0]!,
+        entry.parents[1]!,
+        repositoryPaths[index]!,
+        expectedBlobs[index]!
+      );
+      if (operationIds.length === 0) continue;
+      attributions[index] = { commit: entry.commit, operationIds };
+      remaining -= 1;
+      reportCurrentRepoWriteTelemetry("authority-publication-proof", {
+        stage: "path-attribution",
+        pathCount: repositoryPaths.length,
+        completedPathCount: repositoryPaths.length - remaining
+      });
+    }
+    if (remaining === 0) break;
   }
-  return null;
+  return attributions;
 }
 
-function attributedPathOperationIds(
+async function attributedPathOperationIds(
   rootDir: string,
   firstParent: string,
   authorityTip: string,
   repositoryPath: string,
   expectedBlob: string
-): ReadonlyArray<string> {
-  const commits = taskCompletePublicationGitText(rootDir, [
+): Promise<ReadonlyArray<string>> {
+  const output = await taskCompletePublicationGitText(rootDir, [
     "rev-list",
     "--reverse",
     "--topo-order",
     `${firstParent}..${authorityTip}`,
     "--",
     `:(literal)${repositoryPath}`
-  ]).split(/\r?\n/u).map((entry) => entry.trim()).filter(Boolean);
+  ]);
+  const commits = output.split(/\r?\n/u).map((entry) => entry.trim()).filter(Boolean);
   const lastChangingCommit = commits.at(-1);
   if (!lastChangingCommit) return [];
-  const [attributedBlob] = gitBlobIds(rootDir, lastChangingCommit, [repositoryPath]);
+  const [attributedBlob] = await gitBlobIds(rootDir, lastChangingCommit, [repositoryPath]);
   if (attributedBlob !== expectedBlob) return [];
-  const subject = taskCompletePublicationGitText(rootDir, ["show", "-s", "--format=%s", lastChangingCommit]);
+  const subject = await taskCompletePublicationGitText(rootDir, ["show", "-s", "--format=%s", lastChangingCommit]);
   return publicationOperationIds(subject);
 }
 
@@ -130,12 +170,12 @@ function describeMaterializationMismatches(
   }).join(", ");
 }
 
-function firstParentHistory(rootDir: string, repositoryPaths: ReadonlyArray<string>, headRef = "HEAD"): ReadonlyArray<{
+async function firstParentHistory(rootDir: string, repositoryPaths: ReadonlyArray<string>, headRef = "HEAD"): Promise<ReadonlyArray<{
   readonly commit: string;
   readonly parents: ReadonlyArray<string>;
   readonly subject: string;
-}> {
-  const fields = taskCompletePublicationGitText(rootDir, [
+}>> {
+  const output = await taskCompletePublicationGitText(rootDir, [
     "log",
     "--first-parent",
     "--full-history",
@@ -143,7 +183,8 @@ function firstParentHistory(rootDir: string, repositoryPaths: ReadonlyArray<stri
     headRef,
     "--",
     ...repositoryPaths.map((repositoryPath) => `:(literal)${repositoryPath}`)
-  ]).split("\0");
+  ]);
+  const fields = output.split("\0");
   const rows: Array<{ commit: string; parents: ReadonlyArray<string>; subject: string }> = [];
   for (let index = 0; index + 2 < fields.length; index += 3) {
     const commit = fields[index]!.trim();
@@ -164,36 +205,55 @@ function publicationOperationIds(subject: string): ReadonlyArray<string> {
     : [];
 }
 
-function taskCompletePublicationGitText(rootDir: string, args: ReadonlyArray<string>, input?: string): string {
-  return execFileSync("git", ["-C", rootDir, ...args], {
-    encoding: "utf8",
-    input,
-    stdio: [input === undefined ? "ignore" : "pipe", "pipe", "pipe"],
-    maxBuffer: 64 * 1024 * 1024,
-    windowsHide: true
-  }).trim();
+async function taskCompletePublicationGitText(rootDir: string, args: ReadonlyArray<string>): Promise<string> {
+  return (await taskCompletePublicationGitTextRaw(rootDir, args)).trim();
 }
 
-function gitBlobIds(
+async function taskCompletePublicationGitTextRaw(rootDir: string, args: ReadonlyArray<string>): Promise<string> {
+  const { stdout } = await execFileAsync("git", ["-C", rootDir, ...args], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    windowsHide: true,
+    timeout: 25_000
+  });
+  return stdout;
+}
+
+async function gitHashObject(rootDir: string, body: string): Promise<string> {
+  const child = execFile("git", ["-C", rootDir, "hash-object", "--stdin"], {
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: 25_000
+  });
+  child.stdin?.write(body);
+  child.stdin?.end();
+  const { stdout } = await new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk: string) => { stdout += chunk; });
+    child.stderr?.on("data", (chunk: string) => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) reject(new Error(`git hash-object failed (exit ${code}): ${stderr.trim()}`));
+      else resolve({ stdout, stderr });
+    });
+  });
+  return stdout.trim();
+}
+
+async function gitBlobIds(
   rootDir: string,
   commitRef: string,
   repositoryPaths: ReadonlyArray<string>
-): ReadonlyArray<string | null> {
-  const output = execFileSync("git", [
-    "-C",
-    rootDir,
+): Promise<ReadonlyArray<string | null>> {
+  const output = await taskCompletePublicationGitText(rootDir, [
     "ls-tree",
     "-z",
     "--full-tree",
     commitRef,
     "--",
     ...repositoryPaths.map((repositoryPath) => `:(literal)${repositoryPath}`)
-  ], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-    maxBuffer: 64 * 1024 * 1024,
-    windowsHide: true
-  });
+  ]);
   const byPath = new Map<string, string>();
   for (const row of output.split("\0")) {
     if (!row) continue;

--- a/packages/daemon/src/authority/production/task-complete-prepublish-witness.ts
+++ b/packages/daemon/src/authority/production/task-complete-prepublish-witness.ts
@@ -20,17 +20,18 @@ import {
   prepublishGitBlobText,
   prepublishGitTextOrNull
 } from "./task-complete-prepublish-publication.ts";
+import { reportCurrentRepoWriteTelemetry } from "../../runtime/repo-write-telemetry-context.ts";
 
 const witnessPrefix = "ha-prepublish-witness-v1.";
 
-export function resolveVerifiedTaskCompleteWitnesses(input: {
+export async function resolveVerifiedTaskCompleteWitnesses(input: {
   readonly rootDir: string;
   readonly authoredRoot: string;
   readonly taskId: string;
   readonly documents: ReadonlyArray<{ readonly path: string; readonly body: string }>;
   readonly command: TaskCompleteTransitionCommand;
   readonly requireCodeDoc: boolean;
-}): ReadonlyArray<VerifiedTaskCompleteExternalWitness> {
+}): Promise<ReadonlyArray<VerifiedTaskCompleteExternalWitness>> {
   const suppliedByKind = new Map<string, TaskCompleteExternalCheckpointRef>();
   for (const witness of input.command.externalCheckpointRefs) {
     if (suppliedByKind.has(witness.kind)) {
@@ -46,15 +47,15 @@ export function resolveVerifiedTaskCompleteWitnesses(input: {
   if (unknown) throw new Error(`AUTHORITY_TASK_COMPLETE_WITNESS_NOT_APPLICABLE:${unknown}`);
   const refs = [
     suppliedByKind.get("document-publication")
-      ?? produceDocumentPublicationWitness(input),
+      ?? (await produceDocumentPublicationWitness(input)),
     ...(input.requireCodeDoc
-      ? [suppliedByKind.get("code-doc-reconciliation") ?? produceCodeDocWitness(input)]
+      ? [suppliedByKind.get("code-doc-reconciliation") ?? (await produceCodeDocWitness(input))]
       : [])
   ];
-  return verifyTaskCompleteWitnessRefs({ ...input, refs });
+  return await verifyTaskCompleteWitnessRefs({ ...input, refs });
 }
 
-export function verifyTaskCompleteWitnessRefs(input: {
+export async function verifyTaskCompleteWitnessRefs(input: {
   readonly rootDir: string;
   readonly authoredRoot: string;
   readonly taskId: string;
@@ -63,7 +64,7 @@ export function verifyTaskCompleteWitnessRefs(input: {
   readonly requireCodeDoc: boolean;
   readonly refs: ReadonlyArray<TaskCompleteExternalCheckpointRef>;
   readonly snapshotMode?: "current" | "committed";
-}): ReadonlyArray<VerifiedTaskCompleteExternalWitness> {
+}): Promise<ReadonlyArray<VerifiedTaskCompleteExternalWitness>> {
   const decodedByKind = new Map<string, VerifiedTaskCompleteExternalWitness>();
   for (const supplied of input.refs) {
     if (decodedByKind.has(supplied.kind)) throw new Error(`AUTHORITY_TASK_COMPLETE_WITNESS_DUPLICATE:${supplied.kind}`);
@@ -75,13 +76,13 @@ export function verifyTaskCompleteWitnessRefs(input: {
   if (!document || document.kind !== "document-publication") {
     throw new Error("AUTHORITY_TASK_COMPLETE_DOCUMENT_PUBLICATION_WITNESS_REQUIRED");
   }
-  verifyDocumentPublicationWitness(input, document, input.snapshotMode ?? "current");
+  await verifyDocumentPublicationWitness(input, document, input.snapshotMode ?? "current");
   const codeDoc = decodedByKind.get("code-doc-reconciliation");
   if (input.requireCodeDoc) {
     if (!codeDoc || codeDoc.kind !== "code-doc-reconciliation") {
       throw new Error("AUTHORITY_TASK_COMPLETE_CODE_DOC_WITNESS_REQUIRED");
     }
-    verifyCodeDocWitness(input, codeDoc, input.snapshotMode ?? "current");
+    await verifyCodeDocWitness(input, codeDoc, input.snapshotMode ?? "current");
   } else if (codeDoc) {
     throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_NOT_APPLICABLE:code-doc-reconciliation");
   }
@@ -94,18 +95,22 @@ export function verifyTaskCompleteWitnessRefs(input: {
   return [document, ...(codeDoc ? [codeDoc] : [])];
 }
 
-export function produceDocumentPublicationWitness(input: {
+export async function produceDocumentPublicationWitness(input: {
   readonly rootDir: string;
   readonly authoredRoot: string;
   readonly taskId: string;
   readonly documents: ReadonlyArray<{ readonly path: string; readonly body: string }>;
-}): VerifiedTaskCompleteDocumentPublicationWitness {
+}): Promise<VerifiedTaskCompleteDocumentPublicationWitness> {
+  reportCurrentRepoWriteTelemetry("compile-task-witness", {
+    stage: "document-produce",
+    state: "start"
+  });
   const covered = [...input.documents]
     .map((document) => ({ path: canonicalTaskRelativePath(document.path), body: document.body }))
     .sort((left, right) => lexicalCompare(left.path, right.path));
   if (covered.length === 0) throw new Error("AUTHORITY_TASK_COMPLETE_DOCUMENT_PUBLICATION_EMPTY");
   const repositoryPaths = taskRepositoryPaths(input, covered.map((entry) => entry.path));
-  const publication = findAttributedMaterializedPublication(input.authoredRoot, repositoryPaths, covered.map((entry) => entry.body));
+  const publication = await findAttributedMaterializedPublication(input.authoredRoot, repositoryPaths, covered.map((entry) => entry.body));
   const witnessWithoutRef = {
     kind: "document-publication" as const,
     repositoryCommit: publication.commit,
@@ -116,23 +121,32 @@ export function produceDocumentPublicationWitness(input: {
       bodySha256: sha256Text(entry.body)
     }))))}`
   };
-  return { ...witnessWithoutRef, ref: encodePrepublishWitnessRef(witnessWithoutRef) };
+  const witness = { ...witnessWithoutRef, ref: encodePrepublishWitnessRef(witnessWithoutRef) };
+  reportCurrentRepoWriteTelemetry("compile-task-witness", {
+    stage: "document-produce",
+    state: "done"
+  });
+  return witness;
 }
 
-export function produceCodeDocWitness(input: {
+export async function produceCodeDocWitness(input: {
   readonly rootDir: string;
   readonly authoredRoot: string;
   readonly taskId: string;
   readonly documents: ReadonlyArray<{ readonly path: string; readonly body: string }>;
   readonly command: TaskCompleteTransitionCommand;
-}): VerifiedTaskCompleteCodeDocWitness {
+}): Promise<VerifiedTaskCompleteCodeDocWitness> {
+  reportCurrentRepoWriteTelemetry("compile-task-witness", {
+    stage: "code-doc-produce",
+    state: "start"
+  });
   const codeDoc = input.documents.find((document) => document.path === CODE_DOC_RECONCILIATION_DOCUMENT);
   if (!codeDoc) {
     throw new Error(
       "AUTHORITY_TASK_COMPLETE_CODE_DOC_WITNESS_REQUIRED: run `ha task submit <task-id> --from-file submission.json`, then `ha task code-doc reconcile <task-id> --commit <full-sha> [--path <repo-relative-path>]...`, before `ha task complete`."
     );
   }
-  const reconciled = resolveCommit(input.rootDir, input.command.commitRef ?? "HEAD");
+  const reconciled = await resolveCommit(input.rootDir, input.command.commitRef ?? "HEAD");
   const normalizedPaths = normalizeCommandPaths(input.rootDir, input.command.approval?.paths ?? []);
   const prRef = input.command.approval?.prRef ?? null;
   const expected = renderCodeDocReconciliationDraft({
@@ -151,7 +165,7 @@ export function produceCodeDocWitness(input: {
     );
   }
   const [repositoryPath] = taskRepositoryPaths(input, [CODE_DOC_RECONCILIATION_DOCUMENT]);
-  const publication = findAttributedMaterializedPublication(input.authoredRoot, [repositoryPath!], [codeDoc.body]);
+  const publication = await findAttributedMaterializedPublication(input.authoredRoot, [repositoryPath!], [codeDoc.body]);
   const witnessWithoutRef = {
     kind: "code-doc-reconciliation" as const,
     repositoryCommit: publication.commit,
@@ -162,7 +176,12 @@ export function produceCodeDocWitness(input: {
     prRef,
     codeDocBodyDigest: `sha256:${sha256Text(codeDoc.body)}`
   };
-  return { ...witnessWithoutRef, ref: encodePrepublishWitnessRef(witnessWithoutRef) };
+  const witness = { ...witnessWithoutRef, ref: encodePrepublishWitnessRef(witnessWithoutRef) };
+  reportCurrentRepoWriteTelemetry("compile-task-witness", {
+    stage: "code-doc-produce",
+    state: "done"
+  });
+  return witness;
 }
 
 function describeCodeDocAnchors(body: string): string {
@@ -232,7 +251,7 @@ export function decodePrepublishWitnessRef(ref: string): VerifiedTaskCompleteExt
   throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_KIND_INVALID");
 }
 
-function verifyDocumentPublicationWitness(
+async function verifyDocumentPublicationWitness(
   input: {
     readonly rootDir: string;
     readonly authoredRoot: string;
@@ -241,16 +260,26 @@ function verifyDocumentPublicationWitness(
   },
   witness: VerifiedTaskCompleteDocumentPublicationWitness,
   snapshotMode: "current" | "committed"
-): void {
+): Promise<void> {
+  reportCurrentRepoWriteTelemetry("compile-task-witness", {
+    stage: "document-verify",
+    state: "start"
+  });
   const repositoryPaths = taskRepositoryPaths(input, witness.coveredTaskRelativePaths);
-  const covered = snapshotMode === "current"
-    ? [...input.documents]
+  let covered: ReadonlyArray<{ readonly path: string; readonly body: string }>;
+  if (snapshotMode === "current") {
+    covered = [...input.documents]
       .map((document) => ({ path: canonicalTaskRelativePath(document.path), body: document.body }))
-      .sort((left, right) => lexicalCompare(left.path, right.path))
-    : witness.coveredTaskRelativePaths.map((coveredPath, index) => ({
-      path: canonicalTaskRelativePath(coveredPath),
-      body: prepublishGitBlobText(input.authoredRoot, witness.repositoryCommit, repositoryPaths[index]!)
-    }));
+      .sort((left, right) => lexicalCompare(left.path, right.path));
+  } else {
+    covered = [];
+    for (const [index, coveredPath] of witness.coveredTaskRelativePaths.entries()) {
+      covered = [...covered, {
+        path: canonicalTaskRelativePath(coveredPath),
+        body: await prepublishGitBlobText(input.authoredRoot, witness.repositoryCommit, repositoryPaths[index]!)
+      }];
+    }
+  }
   const digestValue = `sha256:${sha256Text(stableStringify(covered.map((entry) => ({
     path: entry.path,
     bodySha256: sha256Text(entry.body)
@@ -259,7 +288,7 @@ function verifyDocumentPublicationWitness(
     || witness.coveredPathSetDigest !== digestValue) {
     throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_SNAPSHOT_MISMATCH:document-publication");
   }
-  assertAttributedMaterializedPublication(
+  await assertAttributedMaterializedPublication(
     input.authoredRoot,
     witness.repositoryCommit,
     repositoryPaths,
@@ -267,9 +296,13 @@ function verifyDocumentPublicationWitness(
     witness.publicationOperationIds,
     snapshotMode === "committed" ? witness.repositoryCommit : "HEAD"
   );
+  reportCurrentRepoWriteTelemetry("compile-task-witness", {
+    stage: "document-verify",
+    state: "done"
+  });
 }
 
-function verifyCodeDocWitness(
+async function verifyCodeDocWitness(
   input: {
     readonly rootDir: string;
     readonly authoredRoot: string;
@@ -279,15 +312,19 @@ function verifyCodeDocWitness(
   },
   witness: VerifiedTaskCompleteCodeDocWitness,
   snapshotMode: "current" | "committed"
-): void {
+): Promise<void> {
+  reportCurrentRepoWriteTelemetry("compile-task-witness", {
+    stage: "code-doc-verify",
+    state: "start"
+  });
   const [repositoryPath] = taskRepositoryPaths(input, [CODE_DOC_RECONCILIATION_DOCUMENT]);
   const currentCodeDoc = input.documents.find((document) => document.path === CODE_DOC_RECONCILIATION_DOCUMENT);
   const codeDocBody = snapshotMode === "current"
     ? currentCodeDoc?.body
-    : prepublishGitBlobText(input.authoredRoot, witness.repositoryCommit, repositoryPath!);
+    : await prepublishGitBlobText(input.authoredRoot, witness.repositoryCommit, repositoryPath!);
   if (!codeDocBody) throw new Error("AUTHORITY_TASK_COMPLETE_CODE_DOC_WITNESS_REQUIRED");
   const reconciledCommitRef = snapshotMode === "current"
-    ? resolveCommit(input.rootDir, input.command.commitRef ?? "HEAD")
+    ? await resolveCommit(input.rootDir, input.command.commitRef ?? "HEAD")
     : witness.reconciledCommitRef;
   const normalizedPaths = normalizeCommandPaths(input.rootDir, input.command.approval?.paths ?? []);
   const prRef = input.command.approval?.prRef ?? null;
@@ -298,16 +335,17 @@ function verifyCodeDocWitness(
     paths: normalizedPaths,
     ...(prRef ? { prRef } : {})
   }) : null;
+  const revParseResult = await prepublishGitTextOrNull(input.rootDir, ["rev-parse", "--verify", "--end-of-options", `${witness.reconciledCommitRef}^{commit}`]);
   if ((expected && (expected.recordIds.length === 0 || expected.body !== codeDocBody))
     || witness.taskId !== input.taskId
     || witness.reconciledCommitRef !== reconciledCommitRef
     || stableStringify(witness.normalizedPaths) !== stableStringify(normalizedPaths)
     || witness.prRef !== prRef
     || witness.codeDocBodyDigest !== `sha256:${sha256Text(codeDocBody)}`
-    || prepublishGitTextOrNull(input.rootDir, ["rev-parse", "--verify", "--end-of-options", `${witness.reconciledCommitRef}^{commit}`]) !== witness.reconciledCommitRef) {
+    || revParseResult !== witness.reconciledCommitRef) {
     throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_SNAPSHOT_MISMATCH:code-doc-reconciliation");
   }
-  assertAttributedMaterializedPublication(
+  await assertAttributedMaterializedPublication(
     input.authoredRoot,
     witness.repositoryCommit,
     [repositoryPath!],
@@ -315,6 +353,10 @@ function verifyCodeDocWitness(
     witness.publicationOperationIds,
     snapshotMode === "committed" ? witness.repositoryCommit : "HEAD"
   );
+  reportCurrentRepoWriteTelemetry("compile-task-witness", {
+    stage: "code-doc-verify",
+    state: "done"
+  });
 }
 
 function encodePrepublishWitnessRef(value: Omit<VerifiedTaskCompleteExternalWitness, "ref">): string {
@@ -357,8 +399,8 @@ function canonicalTaskRelativePath(value: string): string {
   return normalized;
 }
 
-function resolveCommit(rootDir: string, ref: string): string {
-  const resolved = prepublishGitTextOrNull(rootDir, ["rev-parse", "--verify", "--end-of-options", `${ref}^{commit}`]);
+async function resolveCommit(rootDir: string, ref: string): Promise<string> {
+  const resolved = await prepublishGitTextOrNull(rootDir, ["rev-parse", "--verify", "--end-of-options", `${ref}^{commit}`]);
   if (!resolved || !/^[0-9a-f]{40}$/u.test(resolved)) throw new Error(`AUTHORITY_TASK_COMPLETE_COMMIT_REF_INVALID:${ref}`);
   return resolved;
 }

--- a/packages/daemon/test/task-complete-prepublish-witness.test.ts
+++ b/packages/daemon/test/task-complete-prepublish-witness.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
@@ -23,15 +23,19 @@ import {
   produceDocumentPublicationWitness,
   verifyTaskCompleteWitnessRefs
 } from "../src/authority/production/task-complete-prepublish-witness.ts";
+import {
+  createRepoWriteTelemetryDelivery,
+  runWithRepoWriteTelemetry
+} from "../src/runtime/repo-write-telemetry-context.ts";
 
 const taskId = "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8";
 
-test("daemon-produced prepublish witnesses bind immutable publication history, covered blobs, and code intent", () => {
+test("daemon-produced prepublish witnesses bind immutable publication history, covered blobs, and code intent", async () => {
   const fixture = witnessRepository();
   try {
-    const document = produceDocumentPublicationWitness(fixture);
-    const codeDoc = produceCodeDocWitness(fixture);
-    const verified = verifyTaskCompleteWitnessRefs({
+    const document = await produceDocumentPublicationWitness(fixture);
+    const codeDoc = await produceCodeDocWitness(fixture);
+    const verified = await verifyTaskCompleteWitnessRefs({
       ...fixture,
       requireCodeDoc: true,
       refs: [
@@ -48,7 +52,7 @@ test("daemon-produced prepublish witnesses bind immutable publication history, c
     assert.deepEqual(codeDoc.publicationOperationIds, ["op_code_doc", "op_document"]);
 
     const forged = forgeWitnessRef(document.ref, { repositoryCommit: fixture.authoredInitialCommit });
-    assert.throws(() => verifyTaskCompleteWitnessRefs({
+    await assert.rejects(() => verifyTaskCompleteWitnessRefs({
       ...fixture,
       requireCodeDoc: true,
       refs: [
@@ -57,7 +61,7 @@ test("daemon-produced prepublish witnesses bind immutable publication history, c
       ]
     }), /WITNESS_COMMIT_NOT_PATH_ATTRIBUTED/u);
 
-    assert.throws(() => verifyTaskCompleteWitnessRefs({
+    await assert.rejects(() => verifyTaskCompleteWitnessRefs({
       ...fixture,
       documents: fixture.documents.map((entry) => entry.path === "closeout.md"
         ? { ...entry, body: `${entry.body}\npost-publication mutation\n` }
@@ -73,7 +77,64 @@ test("daemon-produced prepublish witnesses bind immutable publication history, c
   }
 });
 
-test("document publication remains verifiable without machine-local write payloads", () => {
+test("one multi-path publication proof scans first-parent history once", async () => {
+  const fixture = witnessRepository();
+  try {
+    const traced = await withTracedGit(fixture.fixtureRoot, 0, () =>
+      Promise.resolve(produceDocumentPublicationWitness(fixture))
+    );
+    const historyCalls = traced.events.filter((event) =>
+      event.event === "start"
+      && event.args.includes("log")
+      && event.args.includes("--first-parent")
+    );
+    const treeCalls = traced.events.filter((event) =>
+      event.event === "start" && event.args.includes("ls-tree")
+    );
+    assert.equal(historyCalls.length, 1, JSON.stringify(historyCalls));
+    assert.equal(treeCalls.length, 5, JSON.stringify(treeCalls));
+  } finally {
+    rmSync(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("history telemetry is delivered before a delayed Git history call completes", async () => {
+  const fixture = witnessRepository();
+  try {
+    let proofSettled = false;
+    let observeHistoryStart!: () => void;
+    const historyStart = new Promise<void>((resolve) => { observeHistoryStart = resolve; });
+    const delivery = createRepoWriteTelemetryDelivery(async (_phase, _elapsedMs, details) => {
+      if (details?.stage === "history-start") observeHistoryStart();
+    });
+    const traced = withTracedGit(fixture.fixtureRoot, 300, async (tracePath) => {
+      const proof = Promise.resolve(runWithRepoWriteTelemetry(delivery.report, () =>
+        produceDocumentPublicationWitness(fixture)
+      )).finally(() => { proofSettled = true; });
+      try {
+        await withTimeout(
+          historyStart,
+          1_000,
+          "history-start telemetry was not delivered while Git was running"
+        );
+        await waitForTraceEvent(tracePath, (event) => event.event === "start" && event.delayed);
+        const duringGit = readTraceEvents(tracePath);
+        const delayedEnds = duringGit.filter((event) => event.event === "done" && event.delayed);
+        assert.equal(proofSettled, false);
+        assert.equal(delayedEnds.length, 0);
+      } finally {
+        await proof;
+      }
+    });
+    await traced;
+    await delivery.flush();
+    delivery.close();
+  } finally {
+    rmSync(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("document publication remains verifiable without machine-local write payloads", async () => {
   const fixture = witnessRepository();
   try {
     rmSync(path.join(fixture.rootDir, ".harness", "write-journal", "payloads"), {
@@ -81,9 +142,9 @@ test("document publication remains verifiable without machine-local write payloa
       force: true
     });
 
-    const document = produceDocumentPublicationWitness(fixture);
+    const document = await produceDocumentPublicationWitness(fixture);
     assert.deepEqual(document.publicationOperationIds, ["op_code_doc", "op_document"]);
-    const verified = verifyTaskCompleteWitnessRefs({
+    const verified = await verifyTaskCompleteWitnessRefs({
       ...fixture,
       requireCodeDoc: false,
       refs: [{ kind: "document-publication", ref: document.ref }]
@@ -94,10 +155,10 @@ test("document publication remains verifiable without machine-local write payloa
   }
 });
 
-test("committed replay rejects a forged merge whose authority parent never changed the task documents", () => {
+test("committed replay rejects a forged merge whose authority parent never changed the task documents", async () => {
   const fixture = witnessRepository();
   try {
-    const document = produceDocumentPublicationWitness(fixture);
+    const document = await produceDocumentPublicationWitness(fixture);
     const taskRoot = path.join(fixture.authoredRoot, "tasks", `${taskId}-witness`);
     const closeout = fixture.documents.find((entry) => entry.path === "closeout.md")!.body;
     writeFileSync(path.join(taskRoot, "closeout.md"), "# Closeout\n\nRaw first-parent rollback.\n");
@@ -119,7 +180,7 @@ test("committed replay rejects a forged merge whose authority parent never chang
       publicationOperationIds: ["op_forged"]
     });
 
-    assert.throws(() => verifyTaskCompleteWitnessRefs({
+    await assert.rejects(() => verifyTaskCompleteWitnessRefs({
       ...fixture,
       requireCodeDoc: false,
       refs: [{ kind: "document-publication", ref: forged }],
@@ -130,11 +191,11 @@ test("committed replay rejects a forged merge whose authority parent never chang
   }
 });
 
-test("unpublished document rejection stays bounded with 1011 unrelated first-parent materializations", () => {
+test("unpublished document rejection stays bounded with 1011 unrelated first-parent materializations", async () => {
   const fixture = unpublishedScaleWitnessRepository(1_011, 11);
   try {
     const startedAt = performance.now();
-    assert.throws(
+    await assert.rejects(
       () => produceDocumentPublicationWitness(fixture),
       /AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED/u
     );
@@ -145,13 +206,13 @@ test("unpublished document rejection stays bounded with 1011 unrelated first-par
   }
 });
 
-test("unpublished document rejection names only the path whose body is not materialized", () => {
+test("unpublished document rejection names only the path whose body is not materialized", async () => {
   const fixture = witnessRepository();
   try {
     const documents = fixture.documents.map((document) => document.path === "closeout.md"
       ? { ...document, body: `${document.body}\nUnpublished mutation.\n` }
       : document);
-    assert.throws(
+    await assert.rejects(
       () => produceDocumentPublicationWitness({ ...fixture, documents }),
       (error: unknown) => {
         const message = error instanceof Error ? error.message : String(error);
@@ -166,10 +227,10 @@ test("unpublished document rejection names only the path whose body is not mater
   }
 });
 
-test("a later publication cannot attribute an unchanged raw task document", () => {
+test("a later publication cannot attribute an unchanged raw task document", async () => {
   const fixture = partiallyPublishedWitnessRepository();
   try {
-    assert.throws(
+    await assert.rejects(
       () => produceDocumentPublicationWitness(fixture),
       /AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:[^\n]*task_plan\.md/u
     );
@@ -178,7 +239,7 @@ test("a later publication cannot attribute an unchanged raw task document", () =
   }
 });
 
-test("code-doc reconciliation rejection names the approval intent and current anchors", () => {
+test("code-doc reconciliation rejection names the approval intent and current anchors", async () => {
   const fixture = witnessRepository();
   try {
     const command = {
@@ -188,7 +249,7 @@ test("code-doc reconciliation rejection names the approval intent and current an
         paths: ["src/other.ts"]
       }
     };
-    assert.throws(
+    await assert.rejects(
       () => produceCodeDocWitness({ ...fixture, command }),
       (error: unknown) => {
         const message = error instanceof Error ? error.message : String(error);
@@ -469,4 +530,98 @@ function git(rootDir: string, ...args: ReadonlyArray<string>): string {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"]
   }).trim();
+}
+
+interface GitTraceEvent {
+  readonly event: "start" | "done";
+  readonly args: ReadonlyArray<string>;
+  readonly delayed: boolean;
+}
+
+async function withTracedGit<Result>(
+  fixtureRoot: string,
+  historyDelayMs: number,
+  operation: (tracePath: string) => Promise<Result>
+): Promise<{ readonly result: Result; readonly events: ReadonlyArray<GitTraceEvent> }> {
+  const wrapperRoot = path.join(fixtureRoot, "git-wrapper");
+  const wrapperPath = path.join(wrapperRoot, "git");
+  const tracePath = path.join(fixtureRoot, "git-trace.jsonl");
+  mkdirSync(wrapperRoot, { recursive: true });
+  writeFileSync(wrapperPath, `#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+const args = process.argv.slice(2);
+const delayed = args.includes("log") && args.includes("--first-parent");
+appendFileSync(process.env.HA_TEST_GIT_TRACE, JSON.stringify({ event: "start", args, delayed }) + "\\n");
+if (delayed && Number(process.env.HA_TEST_GIT_HISTORY_DELAY_MS) > 0) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Number(process.env.HA_TEST_GIT_HISTORY_DELAY_MS));
+}
+const result = spawnSync(process.env.HA_TEST_REAL_GIT, args, { stdio: "inherit" });
+appendFileSync(process.env.HA_TEST_GIT_TRACE, JSON.stringify({ event: "done", args, delayed }) + "\\n");
+process.exit(result.status ?? 1);
+`);
+  chmodSync(wrapperPath, 0o755);
+  const previous = {
+    path: process.env.PATH,
+    trace: process.env.HA_TEST_GIT_TRACE,
+    realGit: process.env.HA_TEST_REAL_GIT,
+    delay: process.env.HA_TEST_GIT_HISTORY_DELAY_MS
+  };
+  const realGit = execFileSync("/usr/bin/which", ["git"], { encoding: "utf8" }).trim();
+  process.env.PATH = `${wrapperRoot}${path.delimiter}${previous.path ?? ""}`;
+  process.env.HA_TEST_GIT_TRACE = tracePath;
+  process.env.HA_TEST_REAL_GIT = realGit;
+  process.env.HA_TEST_GIT_HISTORY_DELAY_MS = String(historyDelayMs);
+  try {
+    const result = await operation(tracePath);
+    return { result, events: readTraceEvents(tracePath) };
+  } finally {
+    restoreEnvironment("PATH", previous.path);
+    restoreEnvironment("HA_TEST_GIT_TRACE", previous.trace);
+    restoreEnvironment("HA_TEST_REAL_GIT", previous.realGit);
+    restoreEnvironment("HA_TEST_GIT_HISTORY_DELAY_MS", previous.delay);
+  }
+}
+
+function readTraceEvents(tracePath: string): ReadonlyArray<GitTraceEvent> {
+  try {
+    return readFileSync(tracePath, "utf8")
+      .split(/\r?\n/u)
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as GitTraceEvent);
+  } catch {
+    return [];
+  }
+}
+
+function restoreEnvironment(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+async function waitForTraceEvent(
+  tracePath: string,
+  predicate: (event: GitTraceEvent) => boolean
+): Promise<void> {
+  await withTimeout(new Promise<void>((resolve) => {
+    const poll = () => {
+      if (readTraceEvents(tracePath).some(predicate)) resolve();
+      else setTimeout(poll, 5);
+    };
+    poll();
+  }), 1_000, "delayed Git history call did not start");
+}
+
+async function withTimeout<Result>(promise: Promise<Result>, timeoutMs: number, message: string): Promise<Result> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+      })
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -3869,25 +3869,11 @@
           "reason": "Design exemption: write-road row public-code-change.git assigns packages/daemon/src/authority/production/publication-evidence.ts this exact execFileSync call for git-worktree/code-truth; it does not bypass a canonical entity coordinator road."
         },
         {
-          "key": "packages/daemon/src/authority/production/task-complete-prepublish-publication.ts#execFileSync@1",
+          "key": "packages/daemon/src/authority/production/task-complete-prepublish-publication.ts#execFile@1",
           "owner": "public-code-change.git",
           "classification": "design-exemption",
-          "ref": "task_01KZ8VKAYSHYYJT2F58FTDGGG0",
-          "reason": "Design exemption: write-road row public-code-change.git assigns packages/daemon/src/authority/production/task-complete-prepublish-publication.ts this exact execFileSync call for git-worktree/code-truth; it reads publication topology (show/ls-tree/hash-object) and does not bypass a canonical entity coordinator road."
-        },
-        {
-          "key": "packages/daemon/src/authority/production/task-complete-prepublish-publication.ts#execFileSync@2",
-          "owner": "public-code-change.git",
-          "classification": "design-exemption",
-          "ref": "task_01KZ8VKAYSHYYJT2F58FTDGGG0",
-          "reason": "Design exemption: write-road row public-code-change.git assigns packages/daemon/src/authority/production/task-complete-prepublish-publication.ts this exact execFileSync call for git-worktree/code-truth; it reads publication topology (show/ls-tree/hash-object) and does not bypass a canonical entity coordinator road."
-        },
-        {
-          "key": "packages/daemon/src/authority/production/task-complete-prepublish-publication.ts#execFileSync@3",
-          "owner": "public-code-change.git",
-          "classification": "design-exemption",
-          "ref": "task_01KZ8VKAYSHYYJT2F58FTDGGG0",
-          "reason": "Design exemption: write-road row public-code-change.git assigns packages/daemon/src/authority/production/task-complete-prepublish-publication.ts this exact execFileSync call for git-worktree/code-truth; it reads publication topology (show/ls-tree/hash-object) and does not bypass a canonical entity coordinator road."
+          "ref": "task_01KZ9CYGP6R850Q069DM07HVSQ",
+          "reason": "Design exemption: write-road row public-code-change.git assigns packages/daemon/src/authority/production/task-complete-prepublish-publication.ts this exact asynchronous execFile call for git-worktree/code-truth; it reads publication topology (show/ls-tree/hash-object) and does not bypass a canonical entity coordinator road."
         },
         {
           "key": "packages/kernel/src/persistence/git/local-version-control-system.ts#execFileSync@1",


### PR DESCRIPTION
# English

## Summary

PR #1237 made completion publication proof per-path. It also made it run one full first-parent history scan **per path per phase**, so on the canonical ledger the proof took 37.4s and blew through the repo writer's 30s deadline. Every `ha task complete` — including its read-only `--dry-run` preflight — became unreachable on that ledger. This bounds the scan count without touching the criterion.

## What Changed

- **One union history per phase.** The 44 expensive first-parent scans were: documents 19 × produce/verify, code-doc 1 × produce/verify, plus two representative unions. They are now exactly 4 — one 19-path union for document produce, one for verify, and one single-path scan for each code-doc phase. Produce and verify still re-derive independently; nothing is cached across them.
- **The five per-path attribution conditions are unchanged.** Each path is still checked for: current blob matches, publication commit blob matches, first-parent blob differs from current, the authority-branch last change produced that blob, and the commit subject carries a valid operation id. Short-range authority-side `rev-list` calls are retained.
- **Prepublish telemetry now reports while it works.** The scans were synchronous `execFileSync` with no emission points inside, so the writer child reported `phase=compile at elapsedMs=0` and then nothing for 30s — the operator saw a wedge with no signal. Long history calls now await, and each phase emits `history-start`/`history-done` with bounded details (document/code-doc, produce/verify, path count, completed count). No raw paths are emitted.

## Task And Scope

- Harness task: `task_01KZ9CYGP6R850Q069DM07HVSQ`
- Branch: `codex/p0-prepublish-history`
- Public scope: `packages/daemon/src/authority/production/task-complete-prepublish-{publication,witness}.ts`, their tests, and write-road registry declaration rows following the moved git reads.
- Private planning/evidence updated: yes
- Out of scope: capacity work for larger ledgers (see Residual Risk).

## Version Impact

- Version: no version change because this repairs internal proof cost with no published surface change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/write-road-registry.json` — declaration rows updated to follow git observation calls that moved within the publication module. No gate logic, workflow, required-check list or branch protection was touched, and no existing row was weakened.
- Authority: `task_01KZ9CYGP6R850Q069DM07HVSQ`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- [x] **Causal A/B on the canonical ledger, same clone, same task, same packet**: parent `999ae84b` completed the same request in 8.37s (exit 0); `e9b9394a` hit the writer's 30s deadline. This identifies #1237 as the regression rather than ledger growth.
- [x] **Cost arithmetic before the fix**: 42 single-path history scans 29.2169s + 2 union scans 4.4780s = 33.6949s in history alone; total proof 37.3815s.
- [x] **After the fix, three consecutive real `--dry-run` runs against the canonical ledger** (not fixtures): cold CLI wall 20.34s / writer child 17.003s; warm RPC 10.750s and 10.434s / writer child 9.784s and 9.420s. Receipt `ok: true`; the target task stayed `in_review` (no state was mutated).
- [x] Telemetry shows exactly 4 `history-start` frames (19/1/19/1 paths), down from 44. First frame at 0.819s, first `history-start` at 1.005s — the 30-second blind spot is gone.
- [x] Targeted tests `24 pass / 0 fail / 12875ms`, covering scan count, telemetry arriving before the git call finishes, produce/verify independence, writer FIFO, and the forged authority-parent negative case.
- [x] **Negative-case discrimination proven by mutation**: temporarily removing the parent-change constraint turns that test red with `Missing expected rejection`; restoring it turns it green. The test is not a rubber stamp.
- [x] `npm run check:local` — `Local check passed in 87.8s`, 27 complete manifest gates green; fast `500 pass / 0 fail`, contract `398 pass / 0 fail / 1 skip`.
- Not run: `npm run check:ci`. GitHub CI is the authority for the broader gates.

## Review Evidence

- CEO rejected the first root-cause report. It attributed the wedge to per-path full scans but the arithmetic did not close against the CEO's own measurement (one full scan measured 0.65s; 4 documents ≈ 3.2s, an order of magnitude short of 30s). The author was sent back to close the arithmetic before any fix was authorized. The missing factor was the path count: the proof runs over 19 paths, not 4, across produce and verify — 42 single-path scans, which does close.
- The CEO's own earlier inference was also wrong and is corrected here: entry counts returned by `rev-list --first-parent -- <path>` (4/2/2/1 for this task) do not bound the scan cost, and the writer child's 1.1 GB RSS was cold-start allocation recycled to ~702 MB, not the mechanism — the proof itself adds roughly 15 MB.
- Concurrency was challenged explicitly, since making long git calls await introduces yield points on a single-writer path. Answer accepted: the whole direct/dry-run promise stays inside `RepoWriteExecutionSequencer.run`, so `await` yields the event loop without releasing the FIFO tail; durable prepare may overlap message handling but performs no write, and the real mutation runs in `proceed` on the same FIFO, where witness-covered paths are re-read and become write preconditions.
- Blocking findings: none outstanding.

## Residual Risk

- **Capacity, measured rather than assumed.** With 19 paths fixed, cost grows roughly linearly with commit count: 25k→50k commits is projected at 16–18s, and the 30s wall returns near 100k–120k commits. If both double (≈50k commits × 38 paths) the union worst case is roughly 4× and approaches 30s again. A capacity task should land before the ledger nears 75k–100k commits or task packages routinely exceed ~40 files; indexed or precomputed provenance is the likely shape. Not attempted here.
- The routing choice is recorded as proposed decision `dec_01KZ9GWSNNQPGNERQWRVJKXBHM`, pending adjudication.
- Fixture-scale tests could not reproduce this defect — that is why #1237 shipped with it. The canonical-ledger runs above are the only evidence at real scale, and they are manual rather than gated.

## References

- Task: `task_01KZ9CYGP6R850Q069DM07HVSQ`
- Regressed by: #1237 (main `e9b9394a`)
- Fact: `F-QVHD9KJC`
- Decision (proposed): `dec_01KZ9GWSNNQPGNERQWRVJKXBHM`

---

# 中文

## 概要

PR #1237 把完成发布取证改成了逐路径，同时也让它**每条路径、每个阶段各跑一次完整的 first-parent 历史扫描**：在 canonical 台账上取证耗时 37.4 秒，撞穿 repo writer 的 30 秒 deadline。于是该台账上每一次 `ha task complete`——连同它的只读 `--dry-run` 预检——都变得不可达。本改动在不动判据的前提下把扫描次数收敛掉。

## 改动内容

- **每阶段只做一次 union 历史扫描。** 修前那 44 次昂贵的 first-parent 扫描是：文档 19 × produce/verify、code-doc 1 × produce/verify，外加两次 representative union。现在正好 4 次——文档 produce 与 verify 各一次 19 路径 union，code-doc 两个阶段各一次单路径扫描。produce 与 verify 仍各自独立重新推导，两者之间不做任何缓存。
- **逐路径归因的五个条件一条未改。** 每条路径仍然要满足：当前 blob 相符、publication commit 的 blob 相符、第一父的 blob 与当前不同、authority 分支最后一次改动确实产生该 blob、commit subject 携带合法 operation id。短范围的 authority-side `rev-list` 调用保留。
- **prepublish telemetry 现在边干边报。** 那些扫描原本是同步 `execFileSync` 且内部没有发射点，于是 writer child 报完 `phase=compile at elapsedMs=0` 之后 30 秒零帧——操作者看到的是一个没有任何信号的卡死。长历史调用现在是 await 的，每个阶段发 `history-start`/`history-done`，details 有界（document/code-doc、produce/verify、路径总数、完成数），不发送原始路径。

## 任务与范围

- Harness 任务：`task_01KZ9CYGP6R850Q069DM07HVSQ`
- 分支：`codex/p0-prepublish-history`
- 公开面：`packages/daemon/src/authority/production/task-complete-prepublish-{publication,witness}.ts`、对应测试，以及跟随 git 读调用迁移的 write-road registry 声明行。
- 私有规划/证据已更新：是
- 范围外：更大台账的容量工程（见残余风险）。

## 版本影响

- 版本：不变更，本改动修复的是内部取证成本，没有已发布面的变化。
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是
- 受保护面范围：`tools/write-road-registry.json` —— 声明行跟随发布模块内迁移的 git 观察调用做了更新。未触碰任何门逻辑、workflow、required check 清单或分支保护，也未削弱任何既有条目。
- 授权：`task_01KZ9CYGP6R850Q069DM07HVSQ`
- 机检边界：本 PR 只断言声明存在；声明是否属实、是否充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- [x] **canonical 台账上的因果 A/B**，同一克隆、同一 task、同一 packet：父提交 `999ae84b` 处理同一请求 8.37 秒 exit 0；`e9b9394a` 撞 writer 的 30 秒 deadline。这把回归定位到 #1237，而不是台账自然长大。
- [x] **修前的成本算术**：42 次单路径历史扫描 29.2169s + 2 次 union 扫描 4.4780s = 光 history 就 33.6949s；总 proof 37.3815s。
- [x] **修后在 canonical 台账上连续跑了三次真实 `--dry-run`**（不是夹具）：冷启动 CLI wall 20.34s / writer child 17.003s；热态 RPC 10.750s 与 10.434s / writer child 9.784s 与 9.420s。回执 `ok: true`，目标任务保持 `in_review`（未改动任何状态）。
- [x] telemetry 精确出现 4 个 `history-start` 帧（19/1/19/1 路径），从 44 次降下来。首帧 0.819s，首个 `history-start` 1.005s——30 秒盲区消失。
- [x] 定向测试 `24 pass / 0 fail / 12875ms`，覆盖扫描次数、telemetry 在 git 调用完成前抵达、produce/verify 独立重验、writer FIFO，以及伪造 authority 父的负例。
- [x] **负例的分辨力由 mutation 证明**：临时移除父变更约束时该测试确实红为 `Missing expected rejection`，恢复后转绿。它不是橡皮图章。
- [x] `npm run check:local` —— `Local check passed in 87.8s`，27 个完整 manifest 门全绿；fast `500 pass / 0 fail`，contract `398 pass / 0 fail / 1 skip`。
- 未运行：`npm run check:ci`。GitHub CI 是更广那批门的权威。

## 审查证据

- CEO 驳回了第一版根因报告。它把卡死归因于逐路径全量扫描，但账和 CEO 自己的实测对不上（单次全量扫描实测 0.65 秒，四份文档约 3.2 秒，离 30 秒差一个数量级）。作者被退回去先把算术做平，修法才获授权。缺的因子是路径数：取证跑的是 19 条路径而非 4 条，横跨 produce 与 verify 共 42 次单路径扫描——这样账才平。
- CEO 自己先前的推断同样是错的，在此更正：`rev-list --first-parent -- <path>` 返回的条目数（本任务为 4/2/2/1）并不约束扫描成本；writer child 的 1.1 GB RSS 是冷启动分配后回收到约 702 MB，不是机制本身——取证过程只增加约 15 MB。
- 并发被显式质疑，因为把长 git 调用改成 await 等于在单写路径上引入让出点。答复被接受：direct/dry-run 的整个 Promise 仍包在 `RepoWriteExecutionSequencer.run` 内，`await` 只让出事件循环、不释放 FIFO tail；durable prepare 可以与消息处理重叠但它本身不写，真正的 mutation 在同一 FIFO 的 proceed 内执行，届时会重新读取 witness 覆盖的路径并把它们变成写前 precondition。
- 阻塞性发现：无遗留。

## 残余风险

- **容量是量出来的，不是假设的。** 固定 19 条路径时成本随提交数近似线性：25k→50k commits 预计 16–18 秒，30 秒墙在约 100k–120k commits 处回来。若提交数与路径数同时翻倍（约 50k commits × 38 路径），union 部分最坏接近 4 倍，会再次逼近 30 秒。容量任务应在台账接近 75k–100k commits、或任务包常态超过约 40 个文件之前落地，形态大概率是索引化或预计算 provenance。本次未做。
- 选路记录为 proposed decision `dec_01KZ9GWSNNQPGNERQWRVJKXBHM`，待裁决。
- 夹具规模复现不了这条缺陷——这正是 #1237 带着它合入的原因。上面的 canonical 台账实测是唯一的真实规模证据，而它是手工的、没有进门。

## 关联材料

- 任务：`task_01KZ9CYGP6R850Q069DM07HVSQ`
- 被其回归：#1237（main `e9b9394a`）
- Fact：`F-QVHD9KJC`
- 决策（proposed）：`dec_01KZ9GWSNNQPGNERQWRVJKXBHM`
