### PR TITLE
fix(cli): fail closed when --evidence PATH swallows a URL scheme, and name the doc-sync path base

### DIFF
--- a/packages/cli/src/cli/command-spec/command-spec-core.ts
+++ b/packages/cli/src/cli/command-spec/command-spec-core.ts
@@ -323,7 +323,7 @@ export const coreCommandSpecs = defineCommandSpecs([
   {
     "kind": "progress-append",
     "usage": "task progress append <id> --text <text> [--evidence type:PATH:summary]... [--dry-run]",
-    "options": [{"flag":"--text","description":"Progress text appended as-is (no Markdown formatting or normalization)."},{"flag":"--evidence","description":"Attach evidence in type:path:summary format; repeat for multiple entries."},{"flag":"--dry-run","description":"Preview the append without entering canonical authority ingress or writing files."}],
+    "options": [{"flag":"--text","description":"Progress text appended as-is (no Markdown formatting or normalization)."},{"flag":"--evidence","description":"Attach evidence in type:PATH:summary format; PATH must not contain ':' (use the summary slot, which allows ':') and is resolved against the working directory, repository root, then authored root. Repeat for multiple entries."},{"flag":"--dry-run","description":"Preview the append without entering canonical authority ingress or writing files."}],
     "summary": "Append the provided text as-is to a task package, with optional repeatable evidence; no Markdown formatting or normalization is applied.",
     "examples": ["harness-anything task progress append task_01ABC --text \"Implemented parser guard\" --evidence log:artifacts/check.log:passed"],
     "parse": parseCoreTaskArgs,

--- a/packages/cli/src/cli/parsers/core-task.ts
+++ b/packages/cli/src/cli/parsers/core-task.ts
@@ -2,6 +2,7 @@ import { domainStatuses, isDomainStatus, slugifyTaskTitle } from "@harness-anyth
 import { cliError, CliErrorCode } from "../error-codes.ts";
 import { readOption, readRepeatedRawOption, readRequiredValueOption } from "../parse-options.ts";
 import type { CliResult, ParsedCommand } from "../types.ts";
+import { parseEvidence } from "./evidence-parser.ts";
 import { parseTaskArchive } from "./core-task-archive.ts";
 import { parseArtifactAdd } from "./core-task-artifact.ts";
 import { parseTaskCodeDocReconcile } from "./core-task-code-doc.ts";
@@ -208,22 +209,6 @@ function parseTaskRelate(args: ReadonlyArray<string>, rootDir: string, json: boo
     rationale,
     dryRun: args.includes("--dry-run")
   });
-}
-
-function parseEvidence(values: ReadonlyArray<string | undefined>):
-  | { readonly ok: true; readonly value?: ReadonlyArray<{ readonly type: string; readonly path: string; readonly summary: string }> }
-  | { readonly ok: false; readonly error: NonNullable<CliResult["error"]> } {
-  if (values.length === 0) return { ok: true };
-  const evidence: Array<{ readonly type: string; readonly path: string; readonly summary: string }> = [];
-  for (const value of values) {
-    if (!value) return { ok: false, error: cliError(CliErrorCode.InvalidEvidence, "Use --evidence type:PATH:summary.") };
-    const [type, evidencePath, ...summaryParts] = value.split(":");
-    if (!type || !evidencePath || summaryParts.length === 0) {
-      return { ok: false, error: cliError(CliErrorCode.InvalidEvidence, "Use --evidence type:PATH:summary.") };
-    }
-    evidence.push({ type, path: evidencePath, summary: summaryParts.join(":") });
-  }
-  return { ok: true, value: evidence };
 }
 
 function ok(rootDir: string, json: boolean, action: ParsedCommand["action"]): ParseResult {

--- a/packages/cli/src/cli/parsers/evidence-parser.ts
+++ b/packages/cli/src/cli/parsers/evidence-parser.ts
@@ -1,0 +1,63 @@
+import { cliError, CliErrorCode } from "../error-codes.ts";
+import type { CliResult } from "../types.ts";
+
+// The 'type:PATH:summary' format is the historical evidence shape used by
+// `ha task progress append --evidence`. PATH and summary are separated by the
+// second ':' in the value; summaries may contain ':' (they are rejoined after
+// the split), but PATH must not. This file owns the parser and the rejection
+// hint so the parser-file line budget in core-task.ts stays inside the CLI
+// structure gate.
+
+export type ParsedEvidence = { readonly type: string; readonly path: string; readonly summary: string };
+
+export function parseEvidence(values: ReadonlyArray<string | undefined>):
+  | { readonly ok: true; readonly value?: ReadonlyArray<ParsedEvidence> }
+  | { readonly ok: false; readonly error: NonNullable<CliResult["error"]> } {
+  if (values.length === 0) return { ok: true };
+  const evidence: Array<ParsedEvidence> = [];
+  for (const value of values) {
+    if (!value) return { ok: false, error: cliError(CliErrorCode.InvalidEvidence, "Use --evidence type:PATH:summary.") };
+    const [type, evidencePath, ...summaryParts] = value.split(":");
+    if (!type || !evidencePath || summaryParts.length === 0) {
+      return { ok: false, error: cliError(CliErrorCode.InvalidEvidence, "Use --evidence type:PATH:summary.") };
+    }
+    // The format has no way to encode ':' inside PATH. When the user passes a
+    // URL (`url:https://...`) or a Windows-drive absolute path (`file:C:/...`),
+    // the naive split above silently puts the scheme or drive letter in PATH
+    // and the rest in summary — and the existing non-empty guard passes because
+    // all three slots are filled, just with the wrong content. Detect that
+    // signature and reject loudly with a copyable correct form, instead of
+    // persisting a miscategorized evidence pointer to progress.md.
+    const ambiguity = describeEvidencePathAmbiguity(value, type, evidencePath, summaryParts);
+    if (ambiguity) {
+      return { ok: false, error: cliError(CliErrorCode.InvalidEvidence, ambiguity) };
+    }
+    evidence.push({ type, path: evidencePath, summary: summaryParts.join(":") });
+  }
+  return { ok: true, value: evidence };
+}
+
+// Returns a hint string when the parsed PATH is almost certainly a URL scheme
+// fragment or Windows drive letter (the rest of the URL/path leaked into
+// summary), or undefined when the parse looks legitimate.
+function describeEvidencePathAmbiguity(
+  value: string,
+  type: string,
+  evidencePath: string,
+  summaryParts: ReadonlyArray<string>
+): string | undefined {
+  // After the split, evidencePath is a bare identifier (no path separators)
+  // matching a URL scheme (`https`, `ftp`) or a single Windows drive letter
+  // (`C`, `D`). The next segment continues an absolute path/URL.
+  if (!/^[a-z][a-z0-9+.-]*$/iu.test(evidencePath)) return undefined;
+  const first = summaryParts[0] ?? "";
+  if (!first.startsWith("/") && !first.startsWith("\\")) return undefined;
+  const parsedSummary = summaryParts.join(":");
+  if (evidencePath.length > 1) {
+    // URL scheme case: the user meant `<type>:<full URL>[:summary]`.
+    const host = first.replace(/^[/\\]+/u, "");
+    return `Evidence PATH cannot contain ':' in '${value}' — the 'type:PATH:summary' format has no delimiter after PATH, so the URL scheme '${evidencePath}' became PATH and the URL leaked into summary (parsed as type='${type}', path='${evidencePath}', summary='${parsedSummary}'). For URL evidence, keep PATH free of ':' and put the full URL in summary, which allows ':' — e.g. --evidence ${type}:<short-label>:${evidencePath}://${host}.`;
+  }
+  // Single-letter drive case: the user meant a Windows absolute path.
+  return `Evidence PATH cannot contain ':' in '${value}' — the 'type:PATH:summary' format has no delimiter after PATH, so the Windows drive letter '${evidencePath}:' became PATH and the rest leaked into summary (parsed as type='${type}', path='${evidencePath}', summary='${parsedSummary}'). Use a POSIX-style path relative to the repository root.`;
+}

--- a/packages/cli/test/doc-sync-cli.test.ts
+++ b/packages/cli/test/doc-sync-cli.test.ts
@@ -243,7 +243,38 @@ test("progress evidence ingests an untracked artifact before recording its gover
 
 test("progress evidence preserves a URL-shaped free pointer when it is not a local artifact", async () => {
   await withTempRoot(async (rootDir) => {
-    await assertPointerOnlyEvidence(rootDir, "pr:https://github.com/FairladyZ625/harness-anything/pull/1104:merged");
+    // The URL must live in the summary slot, not PATH: `type:PATH:summary` cannot encode ':' in PATH
+    // (the parser rejects `pr:https://...:merged` because the URL scheme 'https' would silently become
+    // PATH and the rest would leak into summary — see task_01KZ92RAJ1HXRSYDY4JP6APRCN). Use a short
+    // label in PATH and the full URL in summary, which allows ':'.
+    await assertPointerOnlyEvidence(rootDir, "pr:1104:https://github.com/FairladyZ625/harness-anything/pull/1104:merged");
+  });
+});
+
+test("progress evidence rejects a URL-in-PATH shape that the parser cannot disambiguate, with a copyable correct form", async () => {
+  await withTempRoot(async (rootDir) => {
+    const harnessRoot = path.join(rootDir, "harness");
+    const taskId = "task_01KX3W4V1EDPHPTGWYYBQQ2J75";
+    const taskRoot = path.join(harnessRoot, "tasks", taskId);
+    mkdirSync(taskRoot, { recursive: true });
+    seedDocSyncWriteRoadRegistry(rootDir);
+    writeFileSync(path.join(taskRoot, "INDEX.md"), taskIndex());
+    writeFileSync(path.join(taskRoot, "progress.md"), "# Progress\n\n## Entries\n\n");
+    initHarnessGit(harnessRoot);
+
+    const rejected = runJson(rootDir, [
+      "task", "progress", "append", taskId,
+      "--text", "must not be appended",
+      "--evidence", "pr:https://github.com/FairladyZ625/harness-anything/pull/1104:merged"
+    ], false);
+
+    assert.equal(rejected.ok, false);
+    assert.equal(rejected.error.code, "invalid_evidence");
+    assert.match(rejected.error.hint, /PATH cannot contain ':'/u);
+    assert.match(rejected.error.hint, /URL scheme 'https' became PATH/u);
+    assert.match(rejected.error.hint, /--evidence pr:<short-label>:https:/u);
+    // progress.md was not changed — no miscategorized pointer persisted.
+    assert.equal(readFileSync(path.join(taskRoot, "progress.md"), "utf8"), "# Progress\n\n## Entries\n\n");
   });
 });
 

--- a/packages/cli/test/doc-sync-selection-contract.test.ts
+++ b/packages/cli/test/doc-sync-selection-contract.test.ts
@@ -57,6 +57,36 @@ test("doc sync submits a large selected file batch without importing unrelated m
   });
 });
 
+test("doc sync --path rejection suggests the authored-root-relative form when the caller passed a repo-root-relative path", () => {
+  // `--evidence file:<path>` accepts repo-root-relative paths (it tries cwd → rootDir → authoredRoot);
+  // `doc sync --submit --path` is authored-root-relative only. Agents that use both commands
+  // routinely type `harness/tasks/<id>/...` here and get this rejection. The error must name the
+  // authored-root prefix to drop and the exact rewritten path to retry. See task_01KZ92RAJ1HXRSYDY4JP6APRCN.
+  withFixture(({ rootDir, harnessRoot, taskId }) => {
+    const authoredRelative = `tasks/${taskId}/task_plan.md`;
+    // Keep the required ## Goal heading so the rewritten path is a valid doc-sync candidate.
+    writeFileSync(path.join(harnessRoot, authoredRelative), "# Plan\n\n## Goal\nUpdated prose.\n", "utf8");
+    const repoRootRelative = `harness/${authoredRelative}`;
+
+    assert.throws(
+      () => buildSelectedRequest(rootDir, [repoRootRelative]),
+      (error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        assert.match(message, /Doc sync selected path is not dirty or is unknown/u);
+        assert.match(message, new RegExp(repoRootRelative.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
+        assert.match(message, /relative to the authored root/u);
+        assert.match(message, /drop that prefix/u);
+        assert.match(message, new RegExp(`'${authoredRelative}'`.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
+        return true;
+      }
+    );
+
+    // Round-trip: the suggested authored-relative form is accepted and produces a single change.
+    const request = buildSelectedRequest(rootDir, [authoredRelative]);
+    assert.deepEqual(request.payload.changes.map((change) => change.path), [authoredRelative]);
+  });
+});
+
 function buildSelectedRequest(rootDir: string, selectedPaths: ReadonlyArray<string>) {
   return buildDocSyncSubmitRequest(
     rootDir,

--- a/packages/cli/test/evidence-parse.test.ts
+++ b/packages/cli/test/evidence-parse.test.ts
@@ -1,0 +1,63 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseArgs } from "../src/cli/parse-args.ts";
+
+// These cases pin the behavior of the --evidence parser when PATH cannot be
+// encoded in the `type:PATH:summary` format. They were split out of
+// parse-args.test.ts so that file stays under the 700-line test-file budget
+// while keeping a focused home for evidence-specific regressions. See
+// task_01KZ92RAJ1HXRSYDY4JP6APRCN.
+
+test("parseArgs rejects --evidence values where PATH silently chopped a colon (URL scheme / drive letter)", () => {
+  // The 'type:PATH:summary' format has no way to encode ':' inside PATH.
+  // Without a guard, `url:https://x.com:summary` parses as type=url, path=https,
+  // summary=//x.com:summary and is persisted to progress.md as a miscategorized pointer.
+  // The same signature catches Windows drive letters (file:C:/... → path=C).
+  const urlCases = [
+    "url:https://github.com/o/r/pull/1:summary text",
+    "url:https://x.com:摘要",
+    "url:https://example.com"
+  ];
+  for (const evidence of urlCases) {
+    const parsed = parseArgs(["task", "progress", "append", "task_1", "--text", "x", "--evidence", evidence]);
+    assert.equal(parsed.ok, false, `expected rejection for ${evidence}`);
+    if (parsed.ok) continue;
+    assert.equal(parsed.error.code, "invalid_evidence", `code for ${evidence}`);
+    assert.match(parsed.error.hint, /PATH cannot contain ':'/u, `hint names the colon-in-PATH cause for ${evidence}`);
+    assert.match(parsed.error.hint, /URL scheme/u, `hint names URL scheme cause for ${evidence}`);
+    assert.match(parsed.error.hint, /--evidence url:<short-label>:https:/u, `hint offers a copyable URL form for ${evidence}`);
+  }
+  const driveCases = [
+    "file:C:/Users/me/report.md:summary",
+    "file:D:\\path:summary"
+  ];
+  for (const evidence of driveCases) {
+    const parsed = parseArgs(["task", "progress", "append", "task_1", "--text", "x", "--evidence", evidence]);
+    assert.equal(parsed.ok, false, `expected rejection for ${evidence}`);
+    if (parsed.ok) continue;
+    assert.equal(parsed.error.code, "invalid_evidence", `code for ${evidence}`);
+    assert.match(parsed.error.hint, /Windows drive letter/u, `hint names Windows drive cause for ${evidence}`);
+    assert.match(parsed.error.hint, /POSIX-style path/u, `hint suggests POSIX path for ${evidence}`);
+  }
+});
+
+test("parseArgs still accepts --evidence values whose PATH has no colon and keeps colon-in-summary semantics", () => {
+  // Regression: summaries may freely contain colons; PATH looks like a normal relative path.
+  const accepted = [
+    { value: "log:artifacts/run.log:passed", expectPath: "artifacts/run.log", expectSummary: "passed" },
+    { value: "file:path/to/a.md:some:colon:summary", expectPath: "path/to/a.md", expectSummary: "some:colon:summary" },
+    { value: "url:github.com/o/r/pull/1:PR review", expectPath: "github.com/o/r/pull/1", expectSummary: "PR review" },
+    { value: "test:artifacts/unit.log:green", expectPath: "artifacts/unit.log", expectSummary: "green" }
+  ];
+  for (const { value, expectPath, expectSummary } of accepted) {
+    const parsed = parseArgs(["task", "progress", "append", "task_1", "--text", "x", "--evidence", value]);
+    assert.equal(parsed.ok, true, `expected accept for ${value}`);
+    if (!parsed.ok) continue;
+    assert.equal(parsed.value.action.kind, "progress-append");
+    if (parsed.value.action.kind !== "progress-append") continue;
+    const evidence = parsed.value.action.evidence?.[0];
+    assert.equal(evidence?.path, expectPath, `path for ${value}`);
+    assert.equal(evidence?.summary, expectSummary, `summary for ${value}`);
+  }
+});

--- a/packages/daemon/src/service/doc-sync-selection-hint.ts
+++ b/packages/daemon/src/service/doc-sync-selection-hint.ts
@@ -1,0 +1,24 @@
+// `doc sync --submit --path` matches dirty paths reported by `git status` run
+// inside the authored root, so the value must be authored-root-relative. The
+// `--evidence file:<path>` consumer accepts repo-root-relative paths too, so an
+// agent that uses both commands routinely types `harness/tasks/...` here and is
+// rejected with a generic "not dirty" error. This module renders the actionable
+// suffix that tells them exactly which prefix to drop. See
+// task_01KZ92RAJ1HXRSYDY4JP6APRCN for the basis mismatch.
+
+export function renderDocSyncSelectionHint(
+  authoredRoot: string,
+  missingSelections: ReadonlyArray<string>
+): string {
+  // `buildDocSyncReport` emits the authored root relative to the repository
+  // root (or "." when they coincide); there is nothing to strip in the
+  // collapsed case.
+  const prefix = authoredRoot && authoredRoot !== "." ? `${authoredRoot}/` : null;
+  if (!prefix) return "";
+  const rewrites = missingSelections
+    .filter((path) => path.startsWith(prefix))
+    .map((path) => path.slice(prefix.length));
+  if (rewrites.length === 0) return "";
+  const quoted = rewrites.map((path) => `'${path}'`).join(", ");
+  return ` Paths are relative to the authored root ('${authoredRoot}/'); drop that prefix and retry with ${quoted}.`;
+}

--- a/packages/daemon/src/service/doc-sync-service.ts
+++ b/packages/daemon/src/service/doc-sync-service.ts
@@ -35,6 +35,7 @@ import { gitText, resolveDocSyncAppliedLedgerSha } from "./doc-sync-applied-ledg
 import { isStandaloneCasObject } from "./doc-sync-cas.ts";
 import { consumerDocSyncRows, isConsumerGovernedTaskDocument } from "./doc-sync-consumer-surface.ts";
 import { resolveDocSyncChangePath } from "./doc-sync-writer-working-tree.ts";
+import { renderDocSyncSelectionHint } from "./doc-sync-selection-hint.ts";
 
 export interface DocSyncServiceOptions {
   readonly rootDir: string;
@@ -117,7 +118,12 @@ export function buildDocSyncSubmitRequest(
     : report.dirtyFiles;
   const missingSelections = [...selected].filter((selectedPath) => !files.some((entry) => entry.path === selectedPath));
   if (missingSelections.length > 0) {
-    throw new Error(`Doc sync selected path is not dirty or is unknown: ${missingSelections.join(", ")}. Run 'ha doc status'.`);
+    // `doc sync --path` is authored-root-relative; `--evidence file:<path>`
+    // accepts repo-root-relative paths too. When the caller used the repo-root
+    // form here, append the actionable prefix-strip hint. See
+    // task_01KZ92RAJ1HXRSYDY4JP6APRCN for the basis mismatch.
+    const hint = renderDocSyncSelectionHint(report.authoredRoot, missingSelections);
+    throw new Error(`Doc sync selected path is not dirty or is unknown: ${missingSelections.join(", ")}.${hint} Run 'ha doc status'.`);
   }
   const filePaths = new Set(files.map((entry) => entry.path));
   const forbiddenTouches = report.forbiddenTouches.filter((entry) => filePaths.has(entry.path));


### PR DESCRIPTION
## Summary

`--evidence type:PATH:summary` silently mis-parsed any value whose PATH contained `:`. `url:https://x.com:note` split into `path="https"`, `summary="//x.com:note"`, and the existing three-slot non-empty guard passed — because all three slots *were* filled, just with the wrong content. The miscategorized pointer was then written to `progress.md` with no error and no warning. This PR makes that shape fail closed with a copyable correct form.

Separately, `--evidence file:<path>` resolves against three bases in turn (cwd → repository root → authored root) while `ha doc sync --submit --path` accepts only authored-relative paths. In a repo where `authoredRoot != rootDir` — which is exactly the self-hosted layout — the same document reached by the same operator needs two different path spellings. The bases are left unchanged (unifying them would break callers currently recording repo-root-relative evidence); the rejection now names the authored root and prints the rewritten path to retry with.

## What Changed

- `packages/cli/src/cli/parsers/evidence-parser.ts` (new): `parseEvidence` extracted from `core-task.ts`, plus `describeEvidencePathAmbiguity`, which detects a PATH that is really a URL scheme or a Windows drive letter and rejects with `invalid_evidence`. The hint echoes the wrong parse the value *would* have produced, then gives the correct form (`type:<short-label>:<full-url>` — summary may contain `:`).
- `packages/cli/src/cli/parsers/core-task.ts`: imports the extracted parser (277 → 225 lines, inside the CLI parser file gate).
- `packages/daemon/src/service/doc-sync-selection-hint.ts` (new, pure function) + `doc-sync-service.ts`: a rejected selection whose path starts with the authored-root prefix now returns "drop that prefix and retry with `<path>`" (608 → 598 lines).
- `packages/cli/src/cli/command-spec/command-spec-core.ts`: `--evidence` help states that PATH must not contain `:` and names the three resolution bases.
- Tests: new `packages/cli/test/evidence-parse.test.ts`; new selection-hint contract test; **one existing integration test was rewritten** — see Review Evidence.

## Version Impact

- Version: no version change because this is a defect fix inside existing CLI surfaces with no package version bump in scope.

## Verification

- [x] `npm run check:local` — run twice independently (implementer, then maintainer): `Local check passed in 156.9s. Local stop point passed: 27 complete manifest gate(s) are green.`
- [x] Targeted tests: `parse-args.test.ts` + `evidence-parse.test.ts` 193 pass / 0 fail; `doc-sync-selection-contract.test.ts` 3 pass / 0 fail; `doc-sync-cli.test.ts` (integration) 12 pass / 0 fail; `doc-sync-consumer-closeout.test.ts` + `artifact-ingest-plan.test.ts` 12 pass / 0 fail; `doc-sync-protocol.test.ts` + `doc-sync-writer-dispatch.test.ts` 9 pass / 0 fail.
- [x] `npm run typecheck`, `npm run lint`, `run-node-tests --tier fast` for `packages/cli/test/` (426 pass) and `packages/daemon/test/` (284 pass).
- [x] Maintainer hands-on acceptance (the task plan requires this and forbids the implementer self-certifying it): six inputs through the built parser — three ambiguous shapes rejected with the wrong-parse echo and a copyable fix, three legitimate shapes (normal path, summary containing `:`, `url:pr-1104:https://…`) accepted unchanged.
- Not run: `npm run check:ci` — the omitted 31 gates are CI's authority and run on this PR.
- Pre-existing unrelated failure: `packages/cli/test/diagnostics-cli.test.ts` fails identically on clean `origin/main` (`journal_unavailable`, needs a registered daemon repo root). Negative control performed via `git stash`; not caused by this change.

## Review Evidence

- Self-review: implementer produced before/after raw output for both defects, and flagged its own out-of-plan surfaces rather than burying them.
- Additional review: maintainer re-ran the stop-point gate independently and performed the hands-on acceptance above. Two implementer claims were checked rather than accepted: (a) that `check:local` was green — confirmed by an independent run; (b) that the rewritten test had been pinning buggy behavior — confirmed by reading the diff.
- **The one change that deserves a reviewer's eye**: `packages/cli/test/doc-sync-cli.test.ts:244` previously fed `pr:https://…/pull/1104:merged` and passed. Under the buggy parse its fields happened to re-concatenate into the original string, so the test was green either way — it had **zero** discrimination on this defect. It is now fed the unambiguous form, and a second test pins the rejection of the old shape *and* asserts `progress.md` is left byte-identical (negative control against a silent write). This is a deliberate re-interpretation of an existing contract, not a test loosened to go green.
- Blocking findings: none.

## Residual Risk

- **The "natural" URL evidence form is now rejected.** `pr:https://…:merged` used to round-trip by accident and will now error. The equivalent is `pr:<label>:<full-url>`. No script or CI job in this repository was found generating the old form, and historical `progress.md` entries are never re-parsed, so there is no data migration — but any external caller emitting the old shape will start failing after upgrade.
- **The format ambiguity is bounded, not eliminated.** `type:PATH:summary` cannot encode `:` inside PATH at all. In-format disambiguation was considered and rejected: URLs with a port (`https://x.com:8080`) and URLs with no summary defeat any last-colon heuristic. Fail-closed rejection is the bounded fix; a format change is out of scope.
- **Windows absolute paths still have no working spelling** in evidence. The hint steers to POSIX repo-relative paths; a genuine `C:\…` file must be moved into the repository. Inherent to the current format.
- **Path bases were not unified**, only documented and hinted. Unifying them is separate surgery with its own blast radius.
- Drive-letter detection was exercised on POSIX only; real Windows shell argv assembly is unverified.

## References

- Task: `task_01KZ92RAJ1HXRSYDY4JP6APRCN`
- Standing family line for CLI diagnosability (findings to be fed back): `task_01KXV0HEYVWW6X237K43Q3R2AC`
- Evidence: implementer report with raw before/after output and an explicit `unverified` list, in the task package `artifacts/worker-report.md`

---

## 摘要

`--evidence type:PATH:summary` 对任何 PATH 含 `:` 的值都会静默记错。`url:https://x.com:摘要` 会被切成 `path="https"`、`summary="//x.com:摘要"`，而原有那道「三段非空」的守卫照样放行——因为三段确实都非空，只是内容全错。随后这条被误分类的指针就无声无息写进 `progress.md`。本 PR 让这一族 fail-closed，并在拒绝时给出可照抄的正确写法。

另一条：`--evidence file:<path>` 会依次用三个基准解析（工作目录 → 仓库根 → authored 根），而 `ha doc sync --submit --path` 只吃 authored 相对路径。在 `authoredRoot != rootDir` 的仓里（自托管布局正是如此），同一份文档、同一个操作者，两条命令要写两种路径。本次**没有统一基准**（统一会让当前以仓库根相对形式记 evidence 的调用方突然失败），改为在拒绝时点名 authored 根并直接打印可重试的改写路径。

## 改动内容

- `packages/cli/src/cli/parsers/evidence-parser.ts`（新增）：从 `core-task.ts` 抽出 `parseEvidence`，并新增 `describeEvidencePathAmbiguity` —— 识别出「PATH 其实是被切碎的 URL scheme 或 Windows 盘符」并以 `invalid_evidence` 拒绝。拒绝文案会**回显它本会记成的错误解析**，再给出正确形式（`type:<短标签>:<完整 URL>`，summary 允许含 `:`）。
- `packages/cli/src/cli/parsers/core-task.ts`：改为引用抽出的 parser（277 → 225 行，落回 CLI parser 文件门内）。
- `packages/daemon/src/service/doc-sync-selection-hint.ts`（新增纯函数）+ `doc-sync-service.ts`：被拒路径若以 authored 根前缀开头，提示「去掉该前缀、改用 `<路径>` 重试」（608 → 598 行）。
- `packages/cli/src/cli/command-spec/command-spec-core.ts`：`--evidence` 的 help 写明 PATH 不得含 `:`，并列出三级解析基准。
- 测试：新增 `packages/cli/test/evidence-parse.test.ts`、新增 selection-hint 契约测试；**改写了一个既有集成测试** —— 见审查证据。

## 版本影响

- 不改版本，原因是本次是既有 CLI 面内的缺陷修复，范围内不含包版本号变更。

## 验证

- [x] `npm run check:local` —— 由实现者与维护者各自独立跑过一次：`Local check passed in 156.9s. Local stop point passed: 27 complete manifest gate(s) are green.`
- [x] 定向测试：`parse-args.test.ts` + `evidence-parse.test.ts` 193 pass / 0 fail；`doc-sync-selection-contract.test.ts` 3 pass / 0 fail；`doc-sync-cli.test.ts`（integration）12 pass / 0 fail；`doc-sync-consumer-closeout.test.ts` + `artifact-ingest-plan.test.ts` 12 pass / 0 fail；`doc-sync-protocol.test.ts` + `doc-sync-writer-dispatch.test.ts` 9 pass / 0 fail。
- [x] `npm run typecheck`、`npm run lint`、`run-node-tests --tier fast`（`packages/cli/test/` 426 pass、`packages/daemon/test/` 284 pass）。
- [x] 维护者亲手验收（任务计划明确要求这一条且禁止由实现者自证）：六条输入过一遍构建后的 parser —— 三条歧义形式被拒且带错误解析回显与可照抄的修法，三条正当形式（普通路径、摘要含 `:`、`url:pr-1104:https://…`）照常接受。
- 未运行：`npm run check:ci` —— 被省略的 31 个门是 CI 的权威面，会在本 PR 上跑。
- 预存的无关失败：`packages/cli/test/diagnostics-cli.test.ts` 在干净的 `origin/main` 上以同样的 `journal_unavailable` 失败（它要求一个已注册的 daemon 仓根）。已用 `git stash` 做阴性对照，与本次改动无关。

## 审查证据

- 自查：实现者给出了两个缺陷的改前/改后原始输出，并主动上报了自己越出计划预期的改动面，而不是把它埋掉。
- 额外审查：维护者独立重跑停止点门，并完成上述亲手验收。实现者的两条断言是被核过而不是被采信的——（a）`check:local` 全绿，由一次独立运行确认；（b）被改写的那个测试原本在钉 buggy 行为，由读 diff 确认。
- **最该被复核者盯一眼的那处改动**：`packages/cli/test/doc-sync-cli.test.ts:244` 原本喂 `pr:https://…/pull/1104:merged` 且通过。在 buggy 解析下它的各字段恰好能重新拼回原串，所以这个测试**无论有没有这个缺陷都是绿的**——它对本缺陷的分辨力是零。现在输入换成无歧义形式，并新增第二个测试钉住旧形式被拒、**同时断言 `progress.md` 逐字节未变**（针对静默写入的阴性对照）。这是对既有契约的有意重释，不是把测试放松到跑绿。
- 阻塞发现：无。

## 残余风险

- **URL evidence 的「自然写法」现在会被拒。** `pr:https://…:merged` 过去靠巧合能原样还原，今后会报错。等价写法是 `pr:<标签>:<完整 URL>`。仓内没有搜到生成旧形式的脚本或 CI 任务，历史 `progress.md` 条目也不会被重新解析，所以没有数据迁移——但任何仍在产出旧形式的外部调用方升级后会开始失败。
- **format 的歧义是被围住了，不是被消除了。** `type:PATH:summary` 根本无法在 PATH 里编码 `:`。format 内消歧的路子考虑过并否决：带端口的 URL（`https://x.com:8080`）和没有 summary 的 URL 会打穿任何「按最后一个冒号切」的启发式。fail-closed 拒绝是有界的修法；改 format 不在本次范围。
- **Windows 绝对路径在 evidence 里仍然没有可用写法。** 提示语引导用 POSIX 仓库相对路径；真正位于 `C:\…` 的文件只能先移进仓。这是现有 format 的固有限制。
- **路径基准未统一**，只做了文档化与提示增强。统一是另一台手术，有它自己的波及面。
- 盘符检测只在 POSIX 上跑过测试，真实 Windows shell 的 argv 拼接未验证。

## 关联材料

- 任务：`task_01KZ92RAJ1HXRSYDY4JP6APRCN`
- CLI 可诊断性常设族线（结论待回灌）：`task_01KXV0HEYVWW6X237K43Q3R2AC`
- 证据：实现者报告（含改前/改后原始输出与显式的 `unverified` 清单），在任务包 `artifacts/worker-report.md`
