### PR TITLE
fix(authority): make each completion prerequisite declare its enforcement surface, and run the ones completion owns

### DIFF
--- a/packages/application/src/authority/production-authority-host-contract.ts
+++ b/packages/application/src/authority/production-authority-host-contract.ts
@@ -15,6 +15,7 @@ import type {
 import type { TaskWipSnapshotV1 } from "./task-wip-policy.ts";
 import type { TaskReturnToIdeaSnapshotV1 } from "./task-return-to-idea-policy.ts";
 import type { TaskPlanAdmissionSnapshotV1 } from "./task-execution-admission-policy.ts";
+import type { TaskCompletionPrerequisiteSnapshot } from "../task-completion-prerequisite-catalog.ts";
 
 export type ProductionAuthorityCommand = AuthorityHostCommand;
 export type ProductionAuthorityCommandAction = AuthorityHostCommandAction;
@@ -70,6 +71,7 @@ export interface ProductionAuthorityCompilerHostServices {
     rootInput: HarnessLayoutInput,
     taskId: string
   ) => Promise<TaskReturnToIdeaSnapshotV1>;
+  readonly readTaskCompletionPrerequisiteSnapshot: () => TaskCompletionPrerequisiteSnapshot;
 }
 
 export interface ProductionAuthorityIdentityHostService<Identity> {

--- a/packages/application/src/public-exports.ts
+++ b/packages/application/src/public-exports.ts
@@ -475,6 +475,20 @@ export type {
   TaskLifecycleWriter
 } from "./task-lifecycle-orchestrator.ts";
 export {
+  completionPrerequisiteCatalog,
+  taskAuthorityCompletionPrerequisites
+} from "./task-completion-prerequisite-catalog.ts";
+export type {
+  CompletionPrerequisiteCatalogEntry,
+  CompletionPrerequisiteDecisionRef,
+  CompletionPrerequisiteEnforcementSurface,
+  TaskAuthorityCompletionPrerequisiteEntry,
+  TaskAuthorityCompletionPrerequisiteId,
+  TaskCompletionPrerequisiteInput,
+  TaskCompletionPrerequisiteResult,
+  TaskCompletionPrerequisiteSnapshot
+} from "./task-completion-prerequisite-catalog.ts";
+export {
   TaskLifecycleTransitionPlanningError,
   TaskLifecycleTransitionService,
   decodeCanonicalTaskMutationPlan,

--- a/packages/application/src/task-completion-prerequisite-catalog.ts
+++ b/packages/application/src/task-completion-prerequisite-catalog.ts
@@ -1,0 +1,170 @@
+import { isCloseoutPlaceholderMarkdown, type TaskDocumentPlaceholderPolicy } from "./task-lifecycle-gates.ts";
+
+export type CompletionPrerequisiteDecisionRef = `dec_${string}/${string}`;
+
+export type CompletionPrerequisiteEnforcementSurface =
+  | { readonly kind: "task-authority"; readonly stage: "complete" }
+  | {
+      readonly kind: "ci-only";
+      readonly gateId: string;
+      readonly reason: string;
+      readonly decisionRef: CompletionPrerequisiteDecisionRef;
+    }
+  | {
+      readonly kind: "audit-only";
+      readonly profile: string;
+      readonly reason: string;
+      readonly decisionRef: CompletionPrerequisiteDecisionRef;
+    };
+
+export interface TaskCompletionPrerequisiteSnapshot {
+  readonly documentPlaceholderPolicy: TaskDocumentPlaceholderPolicy;
+}
+
+export interface TaskCompletionPrerequisiteInput {
+  readonly taskId: string;
+  readonly documents: ReadonlyArray<{ readonly path: string; readonly body: string }>;
+  readonly completionGates: ReadonlyArray<string>;
+  readonly ciGate: "passed" | "failed" | "not-applicable" | null;
+  readonly snapshot: TaskCompletionPrerequisiteSnapshot;
+}
+
+export type TaskCompletionPrerequisiteResult<Id extends string = string> =
+  | {
+      readonly id: Id;
+      readonly ok: true;
+      readonly disposition: "passed" | "not-applicable";
+    }
+  | {
+      readonly id: Id;
+      readonly ok: false;
+      readonly errorCode: string;
+    };
+
+interface TaskAuthorityCompletionPrerequisite<Id extends string> {
+  readonly id: Id;
+  readonly surface: { readonly kind: "task-authority"; readonly stage: "complete" };
+  readonly evaluate: (input: TaskCompletionPrerequisiteInput) => TaskCompletionPrerequisiteResult<Id>;
+}
+
+interface ExternallyEnforcedCompletionPrerequisite<Id extends string> {
+  readonly id: Id;
+  readonly surface: Extract<CompletionPrerequisiteEnforcementSurface, { readonly kind: "ci-only" | "audit-only" }>;
+  readonly evaluatorRef: string;
+}
+
+type AnyCompletionPrerequisiteCatalogEntry<Id extends string = string> =
+  | TaskAuthorityCompletionPrerequisite<Id>
+  | ExternallyEnforcedCompletionPrerequisite<Id>;
+
+function defineCompletionPrerequisiteCatalog<
+  const Catalog extends ReadonlyArray<AnyCompletionPrerequisiteCatalogEntry>
+>(catalog: Catalog): Catalog {
+  return catalog;
+}
+
+export const completionPrerequisiteCatalog = defineCompletionPrerequisiteCatalog([{
+  id: "closeout-substantive",
+  surface: { kind: "task-authority", stage: "complete" },
+  evaluate: evaluateCloseoutSubstantive
+}, {
+  id: "ci-passed",
+  surface: { kind: "task-authority", stage: "complete" },
+  evaluate: evaluateCiPassed
+}, {
+  id: "milestone-dossier",
+  surface: {
+    kind: "ci-only",
+    gateId: "ha-check/milestone-dossier",
+    reason: "Milestone dossier validity is a repository-wide merge prerequisite, not a task lifecycle transition prerequisite.",
+    decisionRef: "dec_mr5ukw8f/CH1"
+  },
+  evaluatorRef: "packages/cli/src/commands/check.ts#checkMilestoneDossier"
+}, {
+  id: "task-contract-marker",
+  surface: {
+    kind: "audit-only",
+    profile: "strict",
+    reason: "The marker is strict-profile hardening and is not declared as a universal task completion prerequisite.",
+    decisionRef: "dec_01KZ9C6R2SQ1E46D1TVRK2AHE2/CH1"
+  },
+  evaluatorRef: "packages/cli/src/commands/check.ts#task_contract_marker_missing"
+}, {
+  id: "visual-phase-table",
+  surface: {
+    kind: "audit-only",
+    profile: "strict",
+    reason: "The visual phase table is strict-profile hardening for tasks that carry a visual map.",
+    decisionRef: "dec_01KZ9C6R2SQ1E46D1TVRK2AHE2/CH1"
+  },
+  evaluatorRef: "packages/cli/src/commands/check.ts#visual_phase_table_missing"
+}, {
+  id: "worker-authorization-resolved",
+  surface: {
+    kind: "audit-only",
+    profile: "strict",
+    reason: "Worker authorization prose is a strict-profile audit until a decision promotes it to lifecycle authority.",
+    decisionRef: "dec_01KZ9C6R2SQ1E46D1TVRK2AHE2/CH1"
+  },
+  evaluatorRef: "packages/cli/src/commands/check.ts#worker_authorization_pending"
+}, {
+  id: "lesson-candidates-substantive",
+  surface: {
+    kind: "audit-only",
+    profile: "strict",
+    reason: "Lesson routing remains optional strict-profile hardening and does not determine task completion eligibility.",
+    decisionRef: "dec_01KZ9C6R2SQ1E46D1TVRK2AHE2/CH1"
+  },
+  evaluatorRef: "packages/cli/src/commands/check.ts#lesson_placeholder"
+}] as const);
+
+export type CompletionPrerequisiteCatalogEntry = typeof completionPrerequisiteCatalog[number];
+export type TaskAuthorityCompletionPrerequisiteEntry = Extract<
+  CompletionPrerequisiteCatalogEntry,
+  { readonly surface: { readonly kind: "task-authority" } }
+>;
+export type TaskAuthorityCompletionPrerequisiteId = TaskAuthorityCompletionPrerequisiteEntry["id"];
+
+export const taskAuthorityCompletionPrerequisites: ReadonlyArray<TaskAuthorityCompletionPrerequisiteEntry> =
+  completionPrerequisiteCatalog.filter(
+    (entry): entry is TaskAuthorityCompletionPrerequisiteEntry => entry.surface.kind === "task-authority"
+  );
+
+function evaluateCloseoutSubstantive(
+  input: TaskCompletionPrerequisiteInput
+): TaskCompletionPrerequisiteResult<"closeout-substantive"> {
+  const closeout = input.documents.find((document) => document.path === "closeout.md")?.body;
+  if (!closeout?.trim()) {
+    return {
+      id: "closeout-substantive",
+      ok: false,
+      errorCode: "AUTHORITY_TASK_COMPLETE_CLOSEOUT_REQUIRED"
+    };
+  }
+  if (!isCloseoutPlaceholderMarkdown(
+    closeout,
+    input.snapshot.documentPlaceholderPolicy.closeoutPlaceholderFingerprints
+  )) {
+    return { id: "closeout-substantive", ok: true, disposition: "passed" };
+  }
+  return {
+    id: "closeout-substantive",
+    ok: false,
+    errorCode: "AUTHORITY_TASK_COMPLETE_CLOSEOUT_PLACEHOLDER"
+  };
+}
+
+function evaluateCiPassed(
+  input: TaskCompletionPrerequisiteInput
+): TaskCompletionPrerequisiteResult<"ci-passed"> {
+  if (!input.completionGates.includes("ci")) {
+    return { id: "ci-passed", ok: true, disposition: "not-applicable" };
+  }
+  return input.ciGate === "passed"
+    ? { id: "ci-passed", ok: true, disposition: "passed" }
+    : {
+        id: "ci-passed",
+        ok: false,
+        errorCode: `AUTHORITY_TASK_COMPLETE_CI_GATE_REQUIRED:${input.ciGate ?? "missing"}`
+      };
+}

--- a/packages/application/test/task-lifecycle-gates.test.ts
+++ b/packages/application/test/task-lifecycle-gates.test.ts
@@ -10,6 +10,11 @@ import {
   parseReviewMarkdown,
   validatePhaseRows
 } from "../src/task-lifecycle-gates.ts";
+import {
+  completionPrerequisiteCatalog,
+  taskAuthorityCompletionPrerequisites,
+  type TaskCompletionPrerequisiteInput
+} from "../src/task-completion-prerequisite-catalog.ts";
 
 test("review gate blocks open release-blocking P0-P3 findings", () => {
   const result = evaluateReviewGate({
@@ -123,6 +128,84 @@ test("task document placeholder detection distinguishes scaffold text from real 
     ""
   ].join("\n")), false);
 });
+
+test("completion prerequisite catalog keeps authority enumerable and permissive surfaces justified", () => {
+  assert.deepEqual(
+    taskAuthorityCompletionPrerequisites.map((entry) => entry.id),
+    ["closeout-substantive", "ci-passed"]
+  );
+  for (const entry of completionPrerequisiteCatalog) {
+    if (entry.surface.kind === "task-authority") {
+      assert.equal(typeof entry.evaluate, "function");
+      continue;
+    }
+    assert.match(entry.surface.reason, /\S/u);
+    assert.match(entry.surface.decisionRef, /^dec_[^/]+\/[^/]+$/u);
+    assert.match(entry.evaluatorRef, /\S/u);
+  }
+});
+
+test("substantive closeout prerequisite rejects placeholders without a continuing historical exemption", () => {
+  const closeout = taskAuthorityCompletionPrerequisites.find((entry) => entry.id === "closeout-substantive");
+  assert.ok(closeout);
+  const base = completionPrerequisiteInput({
+    taskId: "task_NEW",
+    closeout: "# Closeout\n\n## Summary\n\nReplace me.\n"
+  });
+  assert.deepEqual(closeout.evaluate(base), {
+    id: "closeout-substantive",
+    ok: false,
+    errorCode: "AUTHORITY_TASK_COMPLETE_CLOSEOUT_PLACEHOLDER"
+  });
+  assert.deepEqual(closeout.evaluate({
+    ...base,
+    documents: [{ path: "closeout.md", body: "# Closeout\n\nSubstantive.\n" }]
+  }), {
+    id: "closeout-substantive",
+    ok: true,
+    disposition: "passed"
+  });
+});
+
+test("CI prerequisite is explicit for both applicable and non-applicable contracts", () => {
+  const ci = taskAuthorityCompletionPrerequisites.find((entry) => entry.id === "ci-passed");
+  assert.ok(ci);
+  const base = completionPrerequisiteInput({
+    taskId: "task_CI",
+    closeout: "# Closeout\n\nSubstantive.\n"
+  });
+  assert.deepEqual(ci.evaluate(base), {
+    id: "ci-passed",
+    ok: true,
+    disposition: "not-applicable"
+  });
+  assert.equal(ci.evaluate({ ...base, completionGates: ["ci"], ciGate: "passed" }).ok, true);
+  assert.deepEqual(ci.evaluate({ ...base, completionGates: ["ci"], ciGate: "failed" }), {
+    id: "ci-passed",
+    ok: false,
+    errorCode: "AUTHORITY_TASK_COMPLETE_CI_GATE_REQUIRED:failed"
+  });
+});
+
+function completionPrerequisiteInput(input: {
+  readonly taskId: string;
+  readonly closeout: string;
+}): TaskCompletionPrerequisiteInput {
+  return {
+    taskId: input.taskId,
+    documents: [{ path: "closeout.md", body: input.closeout }],
+    completionGates: [],
+    ciGate: "not-applicable",
+    snapshot: {
+      documentPlaceholderPolicy: {
+        closeoutPlaceholderFingerprints: ["Replace me."],
+        taskPlanPlaceholderFingerprintSets: [],
+        visualMapPlaceholderFingerprintSets: [],
+        lessonCandidatesPlaceholderFingerprintSets: []
+      }
+    }
+  };
+}
 
 test("phase validation rejects agent-owned human gate and missing exit commands", () => {
   const result = validatePhaseRows([{

--- a/packages/cli/src/commands/task-completion-prerequisite-snapshot.ts
+++ b/packages/cli/src/commands/task-completion-prerequisite-snapshot.ts
@@ -1,0 +1,8 @@
+import type { TaskCompletionPrerequisiteSnapshot } from "@harness-anything/application";
+import { bundledTaskDocumentPlaceholderPolicy } from "./core/task-document-placeholders.ts";
+
+export function readTaskCompletionPrerequisiteSnapshot(): TaskCompletionPrerequisiteSnapshot {
+  return {
+    documentPlaceholderPolicy: bundledTaskDocumentPlaceholderPolicy()
+  };
+}

--- a/packages/cli/src/composition/production-authority-host-services.ts
+++ b/packages/cli/src/composition/production-authority-host-services.ts
@@ -27,6 +27,7 @@ import {
 import { readTaskWipSnapshot } from "../commands/task-wip-settings.ts";
 import { readTaskPlanAdmissionSnapshot } from "../commands/task-plan-admission-snapshot.ts";
 import { readTaskReturnToIdeaSnapshot } from "../commands/task-return-to-idea-snapshot.ts";
+import { readTaskCompletionPrerequisiteSnapshot } from "../commands/task-completion-prerequisite-snapshot.ts";
 import { defaultCliAdapterProvider } from "./adapter-registry.ts";
 
 type CliNewTaskAction = Extract<ParsedCommand["action"], { readonly kind: "new-task" }>;
@@ -105,5 +106,6 @@ export const productionAuthorityHostServices = {
   readTaskWipSnapshot,
   readTaskPlanAdmissionSnapshot,
   readTaskReturnToIdeaSnapshot,
+  readTaskCompletionPrerequisiteSnapshot,
   loadDaemonIdentity
 } satisfies ProductionAuthorityHostServices<LoadedDaemonIdentity>;

--- a/packages/cli/test/complete-final-step-deadzone.test.ts
+++ b/packages/cli/test/complete-final-step-deadzone.test.ts
@@ -1,6 +1,5 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
 import { copyFileSync, lstatSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
@@ -11,12 +10,15 @@ import {
   runRawJsonMaybeFail,
   stopDaemon
 } from "./helpers/daemon-cli.ts";
+import { assertHelpOrder, cliHelp, packetTemplate } from "./helpers/cli-help-fixture.ts";
 import {
   createFixture,
   git,
   writeColdCodexSessionLog
 } from "./production-authority-canonical-ingress/fixture.ts";
 import {
+  placeholderCloseout,
+  productionCloseout,
   productionPlan,
   publishSeededTaskFixture
 } from "./helpers/canonical-task-publication-fixture.ts";
@@ -149,9 +151,30 @@ test("published completion dry-runs report checked gates without mutating holder
 
 test("task closeout publishes approval and completion through the production daemon", { timeout: 60_000 }, async () => {
   await withReviewedCompletionFixture("complete-final-step-deadzone", {}, ({
-    fixture, taskId, executionId, taskRoot, closeoutPacketPath, env
+    fixture, taskId, executionId, taskRoot, approvalPath, closeoutPacketPath, env
   }) => {
+    writeFileSync(path.join(taskRoot, "closeout.md"), placeholderCloseout());
     publishCloseout(fixture.repoRoot, taskId, env);
+    const blockedPlaceholderCloseout = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "complete", taskId, "--approve", "--from-file", approvalPath
+    ], env);
+    assert.equal(blockedPlaceholderCloseout.status, 1, JSON.stringify(blockedPlaceholderCloseout.receipt));
+    assert.match(JSON.stringify(blockedPlaceholderCloseout.receipt), /AUTHORITY_TASK_COMPLETE_CLOSEOUT_PLACEHOLDER/u);
+    assert.match(readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"), /^  status: in_review$/mu);
+
+    const holder = runRawJsonMaybeFail(fixture.repoRoot, ["task", "holder", taskId], env);
+    assert.equal(holder.status, 0, JSON.stringify(holder.receipt));
+    assert.equal((holder.receipt.details as {
+      readonly data?: { readonly effectiveHolder?: unknown };
+    } | undefined)?.data?.effectiveHolder, null, JSON.stringify(holder.receipt));
+
+    writeFileSync(path.join(taskRoot, "closeout.md"), productionCloseout("Corrected after the placeholder rejection."));
+    publishCloseout(fixture.repoRoot, taskId, env);
+    const correctedReady = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "complete", taskId, "--approve", "--from-file", approvalPath, "--dry-run"
+    ], env);
+    assert.equal(correctedReady.status, 0, JSON.stringify(correctedReady.receipt));
+
     const closeoutCommand = ["task", "closeout", taskId, "--from-file", closeoutPacketPath] as const;
     const original = runRawJsonMaybeFail(fixture.repoRoot, closeoutCommand, env);
     const completed = original.status === 0
@@ -557,24 +580,3 @@ test("task complete closes one legacy submitted current round with no live holde
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });
-
-function cliHelp(rootDir: string, args: ReadonlyArray<string>): string {
-  return execFileSync(process.execPath, [path.resolve("packages/cli/src/index.ts"), "--root", rootDir, ...args], {
-    encoding: "utf8"
-  });
-}
-
-function packetTemplate(help: string): Readonly<Record<string, unknown>> {
-  const match = help.match(/Packet template \(copy as [^)]+\):\n([\s\S]+?)(?:\n\n|$)/u);
-  assert.ok(match, help);
-  return JSON.parse(match[1]!.split("\n").map((line) => line.replace(/^  /u, "")).join("\n")) as Record<string, unknown>;
-}
-
-function assertHelpOrder(help: string, fragments: ReadonlyArray<string>): void {
-  let previous = -1;
-  for (const fragment of fragments) {
-    const index = help.indexOf(fragment, previous + 1);
-    assert.ok(index > previous, `Expected help fragment after offset ${previous}: ${fragment}\n${help}`);
-    previous = index;
-  }
-}

--- a/packages/cli/test/complete-final-step-deadzone.test.ts
+++ b/packages/cli/test/complete-final-step-deadzone.test.ts
@@ -151,30 +151,9 @@ test("published completion dry-runs report checked gates without mutating holder
 
 test("task closeout publishes approval and completion through the production daemon", { timeout: 60_000 }, async () => {
   await withReviewedCompletionFixture("complete-final-step-deadzone", {}, ({
-    fixture, taskId, executionId, taskRoot, approvalPath, closeoutPacketPath, env
+    fixture, taskId, executionId, taskRoot, closeoutPacketPath, env
   }) => {
-    writeFileSync(path.join(taskRoot, "closeout.md"), placeholderCloseout());
     publishCloseout(fixture.repoRoot, taskId, env);
-    const blockedPlaceholderCloseout = runRawJsonMaybeFail(fixture.repoRoot, [
-      "task", "complete", taskId, "--approve", "--from-file", approvalPath
-    ], env);
-    assert.equal(blockedPlaceholderCloseout.status, 1, JSON.stringify(blockedPlaceholderCloseout.receipt));
-    assert.match(JSON.stringify(blockedPlaceholderCloseout.receipt), /AUTHORITY_TASK_COMPLETE_CLOSEOUT_PLACEHOLDER/u);
-    assert.match(readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"), /^  status: in_review$/mu);
-
-    const holder = runRawJsonMaybeFail(fixture.repoRoot, ["task", "holder", taskId], env);
-    assert.equal(holder.status, 0, JSON.stringify(holder.receipt));
-    assert.equal((holder.receipt.details as {
-      readonly data?: { readonly effectiveHolder?: unknown };
-    } | undefined)?.data?.effectiveHolder, null, JSON.stringify(holder.receipt));
-
-    writeFileSync(path.join(taskRoot, "closeout.md"), productionCloseout("Corrected after the placeholder rejection."));
-    publishCloseout(fixture.repoRoot, taskId, env);
-    const correctedReady = runRawJsonMaybeFail(fixture.repoRoot, [
-      "task", "complete", taskId, "--approve", "--from-file", approvalPath, "--dry-run"
-    ], env);
-    assert.equal(correctedReady.status, 0, JSON.stringify(correctedReady.receipt));
-
     const closeoutCommand = ["task", "closeout", taskId, "--from-file", closeoutPacketPath] as const;
     const original = runRawJsonMaybeFail(fixture.repoRoot, closeoutCommand, env);
     const completed = original.status === 0
@@ -213,6 +192,35 @@ test("task closeout publishes approval and completion through the production dae
       } | undefined)?.data?.report?.completionPlan)?.transitionId;
       assert.equal(replayTransition, transitionId, JSON.stringify({ attempt, replayed: replayed.receipt }));
     }
+  });
+});
+
+test("placeholder closeout rejection leaves production authority usable for corrected completion", { timeout: 60_000 }, async () => {
+  await withReviewedCompletionFixture("completion-placeholder-authority", {}, ({
+    fixture, taskId, taskRoot, approvalPath, env
+  }) => {
+    writeFileSync(path.join(taskRoot, "closeout.md"), placeholderCloseout());
+    publishCloseout(fixture.repoRoot, taskId, env);
+    const blocked = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "complete", taskId, "--approve", "--from-file", approvalPath
+    ], env);
+    assert.equal(blocked.status, 1, JSON.stringify(blocked.receipt));
+    assert.match(JSON.stringify(blocked.receipt), /AUTHORITY_TASK_COMPLETE_CLOSEOUT_PLACEHOLDER/u);
+    assert.match(readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"), /^  status: in_review$/mu);
+
+    const holder = runRawJsonMaybeFail(fixture.repoRoot, ["task", "holder", taskId], env);
+    assert.equal(holder.status, 0, JSON.stringify(holder.receipt));
+    assert.equal((holder.receipt.details as {
+      readonly data?: { readonly effectiveHolder?: unknown };
+    } | undefined)?.data?.effectiveHolder, null, JSON.stringify(holder.receipt));
+
+    writeFileSync(path.join(taskRoot, "closeout.md"), productionCloseout("Corrected after the placeholder rejection."));
+    publishCloseout(fixture.repoRoot, taskId, env);
+    const completed = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "complete", taskId, "--approve", "--from-file", approvalPath
+    ], env);
+    assert.equal(completed.status, 0, JSON.stringify(completed.receipt));
+    assert.match(readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"), /^  status: done$/mu);
   });
 });
 

--- a/packages/cli/test/helpers/canonical-task-publication-fixture.ts
+++ b/packages/cli/test/helpers/canonical-task-publication-fixture.ts
@@ -76,6 +76,21 @@ export function productionCloseout(summary: string): string {
   ].join("\n");
 }
 
+export function placeholderCloseout(): string {
+  return [
+    "# Closeout", "",
+    "Replace this file's placeholder content before closeout; `ha task complete` rejects placeholder text. Closeout summarizes the verdict, but it does not replace the fact ledger or decision/relation records.", "",
+    "## Summary", "", "Summarize the completed behavior change.", "",
+    "## Verification", "",
+    "List passing applicable checks, the Review result, and any explicitly promoted",
+    "`F-...` Facts. CI belongs here only when the resolved completion contract",
+    "declares it; Facts remain optional `0..N` promotions (dec_mrg3z1we/CH4;",
+    "ADR-0027 D7).", "",
+    "## Residual Risk", "",
+    "Record accepted non-blocking risks; if a risk affects later choices, create or relate a decision.", ""
+  ].join("\n");
+}
+
 function snapshotTextTree(rootDir: string): ReadonlyArray<readonly [string, string]> {
   const rows: Array<readonly [string, string]> = [];
   const visit = (current: string): void => {

--- a/packages/cli/test/helpers/cli-help-fixture.ts
+++ b/packages/cli/test/helpers/cli-help-fixture.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+export function cliHelp(rootDir: string, args: ReadonlyArray<string>): string {
+  return execFileSync(process.execPath, [path.resolve("packages/cli/src/index.ts"), "--root", rootDir, ...args], {
+    encoding: "utf8"
+  });
+}
+
+export function packetTemplate(help: string): Readonly<Record<string, unknown>> {
+  const match = help.match(/Packet template \(copy as [^)]+\):\n([\s\S]+?)(?:\n\n|$)/u);
+  assert.ok(match, help);
+  return JSON.parse(match[1]!.split("\n").map((line) => line.replace(/^  /u, "")).join("\n")) as Record<string, unknown>;
+}
+
+export function assertHelpOrder(help: string, fragments: ReadonlyArray<string>): void {
+  let previous = -1;
+  for (const fragment of fragments) {
+    const index = help.indexOf(fragment, previous + 1);
+    assert.ok(index > previous, `Expected help fragment after offset ${previous}: ${fragment}\n${help}`);
+    previous = index;
+  }
+}

--- a/packages/daemon/src/authority/production/production-authority-lifecycle-intents.ts
+++ b/packages/daemon/src/authority/production/production-authority-lifecycle-intents.ts
@@ -129,7 +129,8 @@ export async function productionLifecycleAttemptIntent(input: {
       input.currentSession.sessionId,
       action,
       input.canonicalEntityId,
-      input.actor
+      input.actor,
+      hostServices
     );
   }
   return null;

--- a/packages/daemon/src/authority/production/production-authority-task-completion-intent.ts
+++ b/packages/daemon/src/authority/production/production-authority-task-completion-intent.ts
@@ -11,6 +11,7 @@ import {
   type CanonicalTaskMutationPlan,
   type ExistingTaskLifecycleTransition,
   type ProductionAuthorityCommand,
+  type ProductionAuthorityCompilerHostServices,
   type TaskCompleteTransitionCommand
 } from "@harness-anything/application";
 import {
@@ -43,6 +44,7 @@ import {
 import {
   reportCurrentRepoWriteTelemetry
 } from "../../runtime/repo-write-telemetry-context.ts";
+import { assertProductionTaskCompletionPrerequisites } from "./production-authority-task-completion-prerequisites.ts";
 
 export async function taskCompletionIntent(
   authoredRoot: string,
@@ -52,7 +54,8 @@ export async function taskCompletionIntent(
   sessionId: string,
   action: Extract<ProductionAuthorityCommand["action"], { readonly kind: "task-complete" }>,
   canonicalEntityId: string,
-  actor: ExecutionRecord["primary_actor"]
+  actor: ExecutionRecord["primary_actor"],
+  hostServices: ProductionAuthorityCompilerHostServices
 ): Promise<CanonicalAttemptIntent> {
   const taskId = action.taskId;
   const taskRoot = resolvedTaskRoot(authoredRoot, taskId);
@@ -79,7 +82,13 @@ export async function taskCompletionIntent(
   const witnesses = existing
     ? await verifyTaskCompleteWitnessRefs({ ...witnessInput, refs: existing.externalCheckpointRefs, snapshotMode: "committed" })
     : await resolveVerifiedTaskCompleteWitnesses(witnessInput);
-  assertLifecycleCompletionPrerequisites(documents, command, completionGates);
+  assertProductionTaskCompletionPrerequisites({
+    taskId,
+    documents,
+    completionGates,
+    ciGate: command.ciGate,
+    snapshot: hostServices.readTaskCompletionPrerequisiteSnapshot()
+  });
   const selectedReplayApproval = !existing && currentRound.kind === "accepted-replay"
     ? acceptedReplayApproval(documents, taskId, currentRound.execution)
     : undefined;
@@ -149,18 +158,6 @@ function existingLifecycleTransition(
     throw new Error("AUTHORITY_TASK_COMPLETE_TRANSITION_IDEMPOTENCY_CONFLICT");
   }
   return decoded;
-}
-
-function assertLifecycleCompletionPrerequisites(
-  documents: ReadonlyArray<{ readonly path: string; readonly body: string }>,
-  command: TaskCompleteTransitionCommand,
-  completionGates: ReadonlyArray<string>
-): void {
-  const closeout = documents.find((document) => document.path === "closeout.md");
-  if (!closeout || !closeout.body.trim()) throw new Error("AUTHORITY_TASK_COMPLETE_CLOSEOUT_REQUIRED");
-  if (completionGates.includes("ci") && command.ciGate !== "passed") {
-    throw new Error(`AUTHORITY_TASK_COMPLETE_CI_GATE_REQUIRED:${command.ciGate ?? "missing"}`);
-  }
 }
 
 function commitCompletionEvidence(input: {

--- a/packages/daemon/src/authority/production/production-authority-task-completion-prerequisites.ts
+++ b/packages/daemon/src/authority/production/production-authority-task-completion-prerequisites.ts
@@ -1,0 +1,18 @@
+import {
+  taskAuthorityCompletionPrerequisites,
+  type TaskAuthorityCompletionPrerequisiteId,
+  type TaskCompletionPrerequisiteInput,
+  type TaskCompletionPrerequisiteResult
+} from "@harness-anything/application";
+
+export const productionTaskCompletionPrerequisiteIds: ReadonlyArray<TaskAuthorityCompletionPrerequisiteId> =
+  taskAuthorityCompletionPrerequisites.map((entry) => entry.id);
+
+export function assertProductionTaskCompletionPrerequisites(
+  input: TaskCompletionPrerequisiteInput
+): ReadonlyArray<TaskCompletionPrerequisiteResult<TaskAuthorityCompletionPrerequisiteId>> {
+  const results = taskAuthorityCompletionPrerequisites.map((entry) => entry.evaluate(input));
+  const failure = results.find((result) => !result.ok);
+  if (failure && !failure.ok) throw new Error(failure.errorCode);
+  return results;
+}

--- a/packages/daemon/test/production-authority-completion-contract-fence.test.ts
+++ b/packages/daemon/test/production-authority-completion-contract-fence.test.ts
@@ -7,6 +7,7 @@ import {
   encodeTaskLifecycleTransitionCommandPayloadV2,
   makeTaskLifecycleTransitionSemanticCompilerV2,
   semanticMutationEnvelopeV2Schema,
+  taskAuthorityCompletionPrerequisites,
   TaskLifecycleTransitionService,
   type CanonicalTaskMutationPlan,
   type HostedDocumentSnapshotV2,
@@ -18,6 +19,7 @@ import {
 } from "@harness-anything/application";
 import { sha256Text } from "@harness-anything/kernel";
 import { makeDaemonAuthorityWriteCoordinator } from "../src/authority/authority-command-submission.ts";
+import { productionTaskCompletionPrerequisiteIds } from "../src/authority/production/production-authority-task-completion-prerequisites.ts";
 
 const taskId = "task_01KXD8H2QFMMA4T203PJZ77AQ5";
 const executionId = "exe_01KXD8H2QFMMA4T203PJZ77AQ6";
@@ -35,6 +37,13 @@ const witness: VerifiedTaskCompleteDocumentPublicationWitness = {
   coveredTaskRelativePaths: ["closeout.md"],
   coveredPathSetDigest: `sha256:${"c".repeat(64)}`
 };
+
+test("production completion authority consumes the catalog-derived task-authority set", () => {
+  assert.deepEqual(
+    productionTaskCompletionPrerequisiteIds,
+    taskAuthorityCompletionPrerequisites.map((entry) => entry.id)
+  );
+});
 
 test("canonical lifecycle plan fences the daemon-evaluated task-contract snapshot against TOCTOU", async () => {
   const evaluatedContract = "{\"schema\":\"task-contract-snapshot/v1\",\"completionGates\":[]}\n";


### PR DESCRIPTION
# English

## Summary

A completion prerequisite existed, resolved, and matched — and never ran. The placeholder-closeout detector was reachable, its policy resolved, and its fingerprints matched the documents; the production authority completion path simply never called it. `ha check` called it, so the check looked alive. The result: 31 tasks reached `done` with a `closeout.md` still holding the scaffold prompt text.

This is the B half of `dec_01KZ9C6R2SQ1E46D1TVRK2AHE2` — the independent bleed-stop. A typed prerequisite catalog now declares, per prerequisite, **which surface enforces it**. Entries whose surface is `task-authority` carry an `evaluate` function and are consumed in full by the production completion path. Entries whose surface is `ci-only` or `audit-only` carry no evaluator at all — only a reference, a reason, and the decision that put them there — so completion cannot run them even by accident. The "no chokepoint" failure and the "audit gate silently folded into completion" failure are both made unrepresentable rather than merely avoided.

Resolver three-state (the A half) is **not** in this PR. It stops at the plan's checkpoint.

## What Changed

- `packages/application/src/task-completion-prerequisite-catalog.ts` (new): the typed catalog and its enforcement-surface union. `task-authority` entries have `evaluate`; `ci-only`/`audit-only` entries have `evaluatorRef` + `reason` + `decisionRef` and no evaluator.
- `packages/daemon/src/authority/production/production-authority-task-completion-prerequisites.ts` (new) and `production-authority-task-completion-intent.ts`: the production completion intent now derives its prerequisite set from the catalog and consumes every `task-authority` entry. A placeholder closeout returns `AUTHORITY_TASK_COMPLETE_CLOSEOUT_PLACEHOLDER` and the task stays `in_review`.
- `packages/cli/src/commands/task-completion-prerequisite-snapshot.ts` (new): supplies the resolved placeholder policy to the authority path.
- `packages/application/src/authority/production-authority-host-contract.ts`, `public-exports.ts`, `packages/cli/src/composition/production-authority-host-services.ts`: wiring.
- Tests: `task-lifecycle-gates.test.ts` (+83), a contract fence test, shared `cli-help-fixture.ts` helpers, and a **new independent placeholder-rejection test** in `complete-final-step-deadzone.test.ts`.

## Task And Scope

- Harness task: `task_01KZ9JFC3HAMEBQWAPYX17B5F4`
- Branch: `codex/prereq-catalog`
- Public scope: the typed catalog and its wiring across application/cli/daemon-authority, plus tests.
- Private planning/evidence updated: yes
- Out of scope: resolver three-state (the A half); the 31 historical placeholder closeouts, which are governed by a separate ruling and are not reopened here.

## Version Impact

- Version: no version change because this restores an already-declared prerequisite to its intended enforcement surface; no package version bump is in scope.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none. No CI/gate authority surface was modified — not `tools/gate-manifest.json`, workflows, timeouts, stall policy, shard weights, or the test-tier manifest.
- Authority: `dec_01KZ9C6R2SQ1E46D1TVRK2AHE2` (active) authorizes the typed enforcement surface and the resolver three-state; this PR delivers only the former. `dec_01KZ9MC8PQHX9V96JAWEF1Y66E` (active) rules that the 31 historical placeholder closeouts keep `done`, are not reopened, rewritten, or retroactively gated, and that the ruling covers **only that closed list** — it is not a standing exemption and must not be cited as precedent for a 32nd.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `d0180ca996def2dff5b1c30680b62ec3c6a7876c`
- Branch merge-base with `origin/main`: `d0180ca996def2dff5b1c30680b62ec3c6a7876c`
- Last `git fetch origin` time: 2026-08-05T21:20Z
- Sync method: rebase
- Public diff command: `git diff --stat origin/main...codex/prereq-catalog`
- Private evidence commit/path: `harness/tasks/task_01KZ9JFC3HAMEBQWAPYX17B5F4-dec-01kz9c6r2sq1e46d1tvrk2ahe2-typed-resolver/`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` — `check:local` green in 83.3s; 27 stop-point gates; fast 735/735; contract 483 pass, 1 skip
- [x] Targeted tests for the change surface, named with their counts: application + daemon contract 16/16; `packages/cli/test/complete-final-step-deadzone.test.ts` 8/8, **cancelled 0**
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending
- Not run, and why: `npm run check:ci` was not run; its omitted gates are CI's authority and run on this PR.

**Mutation-proven discrimination is the load-bearing evidence.** With the authority prerequisite consumption disconnected, the new test goes red in 24.455s and the failure receipt shows a placeholder closeout wrongly reaching `done` (`0 !== 1`). Reconnected, the same test is green in 28.153s. The test can tell the defect from its absence — and the mutation was re-run **after** the assertion moved to its own test, because discrimination does not follow an assertion around by itself.

**The proof runs on the production route, not a fixture shortcut**: the test writes a placeholder `closeout.md`, submits it through `doc sync --submit`, publishes it through `materializer run`, and only then calls `task complete` — asserting the rejection, that `INDEX.md` still reads `status: in_review`, that the holder is released, and finally that the same task reaches `done` after the closeout is corrected. No hand-written intermediate state substitutes for the real path.

**Test headroom is stated explicitly, because this PR sits on top of the fix for a stall-abort.** `4f54ae67` (#1242) split the completion test after it spent three merges at 97% of the 60-second isolation abort window. An earlier revision of this branch put its new assertions into that PR's fourth scenario, pushing it to 34.3s local (~44.8s CI at the measured ×1.29 — back to 75% of the window). That was rejected and the scenario was split again:

| test | local | CI est. (×1.29) | headroom to 60s |
|---|---:|---:|---:|
| original fourth scenario, boundary restored | 25.841s | ~33.3s | ~26.7s |
| new independent placeholder scenario | 28.069s | ~36.2s | ~23.8s |

## Review Evidence

- Self-review: implementer stopped at the plan's checkpoint with the A half untouched, and stated explicitly which surfaces it did not modify.
- Reviewer subagent: none.
- Human review: the maintainer verified three claims by reading the tree rather than accepting the report. (a) The catalog's `ci-only`/`audit-only` entries genuinely have no `evaluate` member, so the plan's prohibition on folding audit-only work into completion is enforced by the type, not by convention. (b) The rewritten integration test is additive — helpers moved to a shared fixture, assertions added, nothing relaxed. (c) An earlier iteration placed a 31-id grandfather list under `governance/migrations/` and read it at runtime; the maintainer flagged that as a retroactive-exemption surface, and it has since been removed from the runtime path entirely — the tree contains no code reference to it, and the list survives only as a record inside the task package. The maintainer additionally rejected the first rebase for spending half the headroom `4f54ae67` had just bought, and required the scenario be split with the mutation proof re-run afterwards.
- Blocking findings: none.

## Residual Risk

- **Only the placeholder-closeout prerequisite is restored.** The catalog now makes every prerequisite's enforcement surface explicit, but this PR wires exactly the entries it declares as `task-authority`. Any prerequisite not yet in the catalog is still enforced wherever it was before, including nowhere.
- **The A half is not done.** Resolver three-state — distinguishing "declared and resolved", "declared and unresolvable", and "not declared" — is still outstanding, so a prerequisite whose policy fails to resolve is still not separable from one that was never declared.
- **31 historical tasks keep `done`** with placeholder closeouts. That is an accepted, registered debt, not an oversight; nothing here reopens or rewrites them, and no runtime exemption encodes them.
- The catalog is a compile-time structure; adding an entry with the wrong surface is still a review question, not a mechanical one.
- **Total shard time grows again.** The independent placeholder scenario rebuilds its own fixture. That is the same trade #1242 made deliberately: total runtime for per-test headroom.

## References

- Task: `task_01KZ9JFC3HAMEBQWAPYX17B5F4`
- Evidence: shape audits and the remediation proposal in `task_01KZ9796059QPK79Q86PHB053F` artifacts; the historical debt inventory in the same package.
- Review: recorded in the task package

---

# 中文

## 概要

一条完成前置条件一直存在、能解析出来、指纹也对得上——但它从来没被执行过。占位 closeout 检测器可达，策略解析得出，指纹与文档匹配；生产 authority 的完成路径就是没调用它。而 `ha check` 调用了它，所以这个检查看上去是活的。后果是 31 个任务带着仍写着脚手架提示语的 `closeout.md` 走到了 `done`。

本 PR 是 `dec_01KZ9C6R2SQ1E46D1TVRK2AHE2` 的 B 半段——可独立交付的止血。新的**类型化前置条件 catalog** 让每一条前置条件自己声明**由哪个面执法**。surface 为 `task-authority` 的条目带 `evaluate` 函数，被生产完成路径全量消费；surface 为 `ci-only` / `audit-only` 的条目**根本没有 evaluator**，只有一个引用、一条理由和把它放在那里的决策——所以完成路径想跑也跑不了。「缺 chokepoint」和「审计门被悄悄折进完成门」这两种失败，都变成了写不出来，而不只是被避开。

resolver 三态（A 半段）**不在**本 PR 内，按计划的 checkpoint 停住。

## 改动内容

- `packages/application/src/task-completion-prerequisite-catalog.ts`（新增）：类型化 catalog 及其执法面联合类型。`task-authority` 条目有 `evaluate`；`ci-only` / `audit-only` 条目只有 `evaluatorRef` + `reason` + `decisionRef`，没有 evaluator。
- `packages/daemon/src/authority/production/production-authority-task-completion-prerequisites.ts`（新增）与 `production-authority-task-completion-intent.ts`：生产完成意图现在从 catalog 派生前置集合并全量消费其中的 `task-authority` 条目。占位 closeout 返回 `AUTHORITY_TASK_COMPLETE_CLOSEOUT_PLACEHOLDER`，任务保持 `in_review`。
- `packages/cli/src/commands/task-completion-prerequisite-snapshot.ts`（新增）：把解析好的占位策略供给 authority 路径。
- `production-authority-host-contract.ts`、`public-exports.ts`、`production-authority-host-services.ts`：接线。
- 测试：`task-lifecycle-gates.test.ts`（+83）、一个契约 fence 测试、共享 `cli-help-fixture.ts`，以及 `complete-final-step-deadzone.test.ts` 里**一条新增的独立占位拒绝测试**。

## 任务与范围

- Harness 任务：`task_01KZ9JFC3HAMEBQWAPYX17B5F4`
- 分支：`codex/prereq-catalog`
- 公开范围：类型化 catalog 及其在 application / cli / daemon-authority 的接线，加测试。
- 私有计划 / 证据是否已更新：yes
- 范围外：resolver 三态（A 半段）；31 条历史占位 closeout——它们由另一条裁决管辖，本 PR 不 reopen。

## 版本影响

- 版本：不改版本，原因是本次是把一条**已声明**的前置条件恢复到它本该在的执法面，范围内不含包版本号变更。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：无。未修改任何 CI/gate 权威面——不含 `tools/gate-manifest.json`、workflow、超时、stall 策略、分片权重与 test-tier manifest。
- 依据：`dec_01KZ9C6R2SQ1E46D1TVRK2AHE2`（active）授权类型化执法面与 resolver 三态，本 PR 只交付前者。`dec_01KZ9MC8PQHX9V96JAWEF1Y66E`（active）裁定 31 条历史占位 closeout 保持 `done`，不 reopen、不手改、不追溯适用新门，且该裁定**只**覆盖那份封闭清单——它不是常设豁免，不得被引为第 32 条的先例。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`d0180ca996def2dff5b1c30680b62ec3c6a7876c`
- 当前分支与 `origin/main` 的 merge-base：`d0180ca996def2dff5b1c30680b62ec3c6a7876c`
- 最近一次 `git fetch origin` 时间：2026-08-05T21:20Z
- 同步方式：rebase
- 公开 diff 命令：`git diff --stat origin/main...codex/prereq-catalog`
- 私有证据 commit/path：`harness/tasks/task_01KZ9JFC3HAMEBQWAPYX17B5F4-dec-01kz9c6r2sq1e46d1tvrk2ahe2-typed-resolver/`
- Reviewer 证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：待本 PR 跑出
- [x] `git diff --check`
- [x] `npm run check:stop-point`——`check:local` 83.3s 绿；27 道 stop-point gate；fast 735/735；contract 483 通过、1 skip
- [x] 改动面的定向测试，写明测试名与通过数：application + daemon 契约 16/16；`packages/cli/test/complete-final-step-deadzone.test.ts` 8/8，**cancelled 0**
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）——待跑
- 未跑项及原因：未跑 `npm run check:ci`；它省略的门是 CI 的权威面，会在本 PR 上跑。

**由 mutation 证明的分辨力是承重证据。** 断开 authority 侧的前置消费后，新测试在 24.455s 变红，失败回执显示占位 closeout 错误地走到 `done`（断言 `0 !== 1`）；恢复接线后同一测试 28.153s 转绿。这个测试能区分「缺陷在」和「缺陷不在」——而且 mutation 是在断言搬进独立测试**之后重跑**的，因为分辨力不会自己跟着断言搬家。

**取证跑在生产路上，不是夹具捷径**：测试先写占位 `closeout.md`，经 `doc sync --submit` 提交、`materializer run` 发布，然后才调 `task complete`——断言拒绝、断言 `INDEX.md` 仍是 `status: in_review`、断言 holder 已释放，最后断言同一任务在 closeout 修正后真实到达 `done`。全程没有手写中间状态替代真实路径。

**测试余量在此显式声明，因为本 PR 就叠在一次 stall 中止的修复之上。** `4f54ae67`（#1242）拆开那条在 60 秒 isolation 中止窗口 97% 处待了三次合并的测试。本分支早先一版把新断言塞进了那个 PR 的第四场景，把它推到本地 34.3s（按实测 ×1.29 折算约 44.8s CI——回到窗口的 75%）。该版被驳回，场景被再拆一刀：

| 测试 | 本地 | CI 预估（×1.29） | 距 60s 余量 |
|---|---:|---:|---:|
| 原第四场景，边界已恢复 | 25.841s | 约 33.3s | 约 26.7s |
| 新独立占位场景 | 28.069s | 约 36.2s | 约 23.8s |

## 审查证据

- 自查：实现者在计划的 checkpoint 停住，A 半段未动，并显式列出自己没有改的面。
- Reviewer subagent：未派。
- 人工审查：维护者读树复核了三条断言，而不是采信报告。(a) catalog 的 `ci-only` / `audit-only` 条目确实没有 `evaluate` 成员——所以计划里「禁止把 audit-only 折进 completion」这条是由**类型**执行的，不靠自觉。(b) 被改写的集成测试是**增量**的：helper 移进共享 fixture，另加断言，没有任何放松。(c) 早先一版曾把 31 个 id 的 grandfather 清单放在 `governance/migrations/` 下并在运行时读取，维护者把它标为「追溯性豁免面」；该清单此后已从运行时路径彻底移除——树里再无任何代码引用它，清单只作为记录留在任务包内。维护者另外驳回了第一次 rebase，理由是它把 `4f54ae67` 刚买下的余量吃掉一半，要求把场景拆开并在拆完后**重跑** mutation 证明。
- 阻塞发现：无。

## 残余风险

- **只恢复了占位 closeout 这一条前置。** catalog 现在让每条前置的执法面变得显式，但本 PR 只接了它声明为 `task-authority` 的那些条目。任何尚未进 catalog 的前置，仍然停在它原来被执行的地方——包括「没有任何地方」。
- **A 半段未做。** resolver 三态（区分「已声明且解析成功」「已声明但无法解析」「从未声明」）仍欠着，所以策略解析失败的前置目前仍无法与从未声明的前置区分开。
- **31 个历史任务保持 `done`**，closeout 仍是占位。那是一笔已接受、已登记的债，不是疏漏；本 PR 不 reopen、不重写它们，也没有任何运行时豁免编码它们。
- catalog 是编译期结构；给某条目填错 surface 仍然是一个复核问题，不是机械问题。
- **分片总时长再次上升。** 独立的占位场景各自重建夹具。这与 #1242 有意做的是同一笔交换：用总运行时间换每条测试的余量。

## 关联材料

- 任务：`task_01KZ9JFC3HAMEBQWAPYX17B5F4`
- 证据：`task_01KZ9796059QPK79Q86PHB053F` 任务包内的形状审计与形状级修法提案；同包内的历史债清单。
- 审查：记录在任务包内

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚：squash 合并，合并后删远端分支并清理本地 worktree。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
