### PR TITLE
test(cli): split the completion test that was riding the 60s stall-abort window

### DIFF
--- a/packages/cli/test/complete-final-step-deadzone.test.ts
+++ b/packages/cli/test/complete-final-step-deadzone.test.ts
@@ -17,27 +17,16 @@ import {
   writeColdCodexSessionLog
 } from "./production-authority-canonical-ingress/fixture.ts";
 import {
-  productionCloseout,
   productionPlan,
   publishSeededTaskFixture
 } from "./helpers/canonical-task-publication-fixture.ts";
+import {
+  publishCloseout,
+  withReviewedCompletionFixture
+} from "./helpers/production-completion-fixture.ts";
 
-test("one task complete intent publishes approval and completion through the production daemon", { timeout: 60_000 }, async () => {
+test("completion help documents the canonical production sequence", () => {
   const fixture = createFixture();
-  const userRoot = defaultDaemonUserRoot(fixture.root);
-  const taskId = "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8";
-  const executionId = "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG7";
-  const sessionId = "complete-final-step-deadzone";
-  const taskRoot = path.join(fixture.authoredRoot, `tasks/${taskId}-production-route`);
-  const env = {
-    HARNESS_ACTOR: "agent:codex",
-    HARNESS_DAEMON_MODE: "local",
-    HARNESS_DAEMON_USER_ROOT: userRoot,
-    HARNESS_DAEMON_IDLE_MS: "60000",
-    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
-    HARNESS_DAEMON_MATERIALIZER_POLL_MS: "3600000",
-    CODEX_THREAD_ID: sessionId
-  };
   try {
     const submitHelp = cliHelp(fixture.repoRoot, ["task", "submit", "--help"]);
     assertHelpOrder(submitHelp, [
@@ -46,6 +35,14 @@ test("one task complete intent publishes approval and completion through the pro
       "releases it after the submitted round is published",
       "completion requires the task to remain unheld"
     ]);
+    assert.deepEqual(packetTemplate(submitHelp), {
+      completionClaim: "<what is complete>",
+      deliverables: ["<delivered file, behavior, or result>"],
+      outputs: ["<output evidence>"],
+      verificationNotes: ["<verification command and result>"],
+      knownGaps: [],
+      residualRisks: []
+    });
     const completeHelp = cliHelp(fixture.repoRoot, ["task", "complete", "--help"]);
     assertHelpOrder(completeHelp, [
       "Required sequence for --approve --from-file (after task submit released the Holder):",
@@ -53,132 +50,32 @@ test("one task complete intent publishes approval and completion through the pro
       "2. ha task code-doc reconcile <task-id> --commit <approval.commit> --path <each-approval.paths-entry>",
       "3. ha task complete <task-id> --approve --from-file approval.json"
     ]);
+    assert.deepEqual(packetTemplate(completeHelp), {
+      findings: "<review findings>",
+      rationale: "<why the evidence supports approval>",
+      evidenceChecked: ["ev_cli_1"],
+      archiveWarningsAcknowledged: true,
+      consentAssertedRationale: "<how owner approval was obtained outside the bound transcript>",
+      consentActions: ["approve_execution", "complete_task"],
+      ci: "passed",
+      commit: "<full 40-character public workspace commit SHA>",
+      paths: ["<repo-relative delivered path>"],
+      externalCheckpointRefs: []
+    });
     const docSyncHelp = cliHelp(fixture.repoRoot, ["doc", "sync", "--help"]);
     assert.match(docSyncHelp, /doc sync --submit --path tasks\/task_01ABC\/task_plan\.md/u);
     const closeoutHelp = cliHelp(fixture.repoRoot, ["task", "closeout", "--help"]);
     assert.match(closeoutHelp, /--dry-run\s+Run the same canonical task-complete planner without writing\./u);
-    writeFileSync(path.join(taskRoot, "closeout.md"), productionCloseout("Original production closeout."));
-    git(fixture.authoredRoot, "add", `tasks/${taskId}-production-route/closeout.md`);
-    git(fixture.authoredRoot, "commit", "-q", "-m", "test: seed substantive production closeout");
-    writeFileSync(path.join(taskRoot, "task_plan.md"), productionPlan("Original facade completion plan."));
-    git(fixture.authoredRoot, "add", `tasks/${taskId}-production-route/task_plan.md`);
-    git(fixture.authoredRoot, "commit", "-q", "-m", "test: seed facade completion plan");
-    publishSeededTaskFixture(fixture.authoredRoot, taskRoot, taskId);
-    const registered = runDaemonCommand(fixture.repoRoot, [
-      "daemon", "repo", "register", "--repo-id", "canonical",
-      "--canonical-root", fixture.repoRoot, "--user-root", userRoot, "--no-link", "--json"
-    ], env);
-    assert.equal(registered.ok, true, JSON.stringify(registered));
-    try {
-      runDaemonCommand(fixture.repoRoot, [
-        "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
-      ], env);
-    } catch {
-      // Observe the same detached production service if startup outlives the CLI wait.
-    }
-    await pollUntil(
-      () => runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env),
-      (status) => status.reachable === true,
-      (status, error) => JSON.stringify({ status, error: error instanceof Error ? error.message : String(error ?? "") }),
-      { timeoutMs: 20_000 }
-    );
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
 
-    writeColdCodexSessionLog(fixture.repoRoot, sessionId);
-    const exported = runRawJsonMaybeFail(fixture.repoRoot, [
-      "session", "export", "--session", sessionId, "--runtime", "codex", "--source", "runtime",
-      "--detected-at", "2026-07-31T00:00:00.000Z", "--transcript-file", fixture.transcriptPath
-    ], env);
-    assert.equal(exported.status, 0, JSON.stringify(exported.receipt));
-
-    const started = runRawJsonMaybeFail(fixture.repoRoot, [
-      "task", "start", taskId, "--execution-id", executionId
-    ], env);
-    assert.equal(started.status, 0, JSON.stringify(started.receipt));
-
-    const submissionPath = path.join(fixture.root, "deadzone-submission.json");
-    writeFileSync(submissionPath, JSON.stringify({
-      ...packetTemplate(submitHelp),
-      completionClaim: "The production facade deadzone regression is ready for approval.",
-      deliverables: ["Facade completion regression"],
-      outputs: ["Full-chain production daemon evidence"],
-      verificationNotes: ["Production daemon setup completed."],
-      knownGaps: [],
-      residualRisks: []
-    }));
-    const submitted = runRawJsonMaybeFail(fixture.repoRoot, [
-      "task", "submit", taskId, "--execution-id", executionId, "--from-file", submissionPath
-    ], env);
-    assert.equal(submitted.status, 0, JSON.stringify(submitted.receipt));
-    const holder = runRawJsonMaybeFail(fixture.repoRoot, ["task", "holder", taskId], env);
-    assert.equal(holder.status, 0, JSON.stringify(holder.receipt));
-    const holderData = (holder.receipt.details as {
-      readonly data?: { readonly effectiveHolder?: unknown };
-    } | undefined)?.data;
-    assert.equal(holderData?.effectiveHolder, null, JSON.stringify(holder.receipt));
-
-    writeFileSync(path.join(taskRoot, "task_plan.md"), productionPlan("Updated by the final facade chain."));
-
-    const synced = runRawJsonMaybeFail(fixture.repoRoot, [
-      "doc", "sync", "--submit", "--path", `tasks/${taskId}-production-route/task_plan.md`
-    ], env);
-    assert.equal(synced.status, 0, JSON.stringify(synced.receipt));
-    const publishedProse = runRawJsonMaybeFail(fixture.repoRoot, [
-      "materializer", "run", "--current-session-only"
-    ], env);
-    assert.equal(publishedProse.status, 0, JSON.stringify(publishedProse.receipt));
-    const reconciled = runRawJsonMaybeFail(fixture.repoRoot, [
-      "task", "code-doc", "reconcile", taskId,
-      "--commit", fixture.publicHead, "--path", "README.md", "--force"
-    ], env);
-    assert.equal(reconciled.status, 0, JSON.stringify(reconciled.receipt));
-    const publishedWitness = runRawJsonMaybeFail(fixture.repoRoot, [
-      "materializer", "run", "--current-session-only"
-    ], env);
-    assert.equal(publishedWitness.status, 0, JSON.stringify(publishedWitness.receipt));
-
-    const approvalPath = path.join(fixture.root, "deadzone-approval.json");
-    writeFileSync(approvalPath, JSON.stringify({
-      ...packetTemplate(completeHelp),
-      executionId,
-      verdict: "approved",
-      findings: "The submitted evidence and public code anchor satisfy the task.",
-      evidenceChecked: ["ev_cli_1"],
-      rationale: "The production daemon path proves the requested full-chain behavior.",
-      archiveWarningsAcknowledged: true,
-      consentAssertedRationale: "Approval was received through an external channel.",
-      consentActions: ["approve_execution", "complete_task"],
-      commit: fixture.publicHead,
-      paths: ["README.md"],
-      ci: "passed",
-      reviewerId: "person_alice"
-    }));
-    const reviewed = runRawJsonMaybeFail(fixture.repoRoot, [
-      "task", "review-execution", taskId, "--from-file", approvalPath
-    ], env);
-    assert.equal(reviewed.status, 0, JSON.stringify(reviewed.receipt));
-    writeFileSync(path.join(taskRoot, "closeout.md"), productionCloseout("Closeout amended after the first reconciliation."));
-    const closeoutPacketPath = path.join(fixture.root, "deadzone-closeout.json");
-    writeFileSync(closeoutPacketPath, JSON.stringify({
-      completionClaim: "The production facade deadzone regression is ready for approval.",
-      deliverables: ["Facade completion regression"],
-      outputs: ["Full-chain production daemon evidence"],
-      verificationNotes: ["Production daemon setup completed."],
-      knownGaps: [],
-      residualRisks: [],
-      executionId,
-      verdict: "approved",
-      findings: "The submitted evidence and public code anchor satisfy the task.",
-      evidenceChecked: ["ev_cli_1"],
-      rationale: "The production daemon path proves the requested full-chain behavior.",
-      archiveWarningsAcknowledged: true,
-      consentAssertedRationale: "Approval was received through an external channel.",
-      consentActions: ["approve_execution", "complete_task"],
-      commit: fixture.publicHead,
-      paths: ["README.md"],
-      ci: "passed",
-      reviewerId: "person_alice"
-    }));
-
+test("unpublished closeout blocks task complete and task closeout through the production daemon", { timeout: 60_000 }, async () => {
+  await withReviewedCompletionFixture("complete-unpublished-closeout", {
+    exercisePlanPublication: true,
+    assertReleasedHolder: true
+  }, ({ fixture, taskId, approvalPath, closeoutPacketPath, env }) => {
     const blockedCompleteDryRun = runRawJsonMaybeFail(fixture.repoRoot, [
       "task", "complete", taskId, "--approve", "--from-file", approvalPath, "--dry-run"
     ], env);
@@ -203,22 +100,18 @@ test("one task complete intent publishes approval and completion through the pro
       ]
     );
     for (const error of blockedErrors) assert.match(error ?? "", /closeout\.md/u);
+  });
+});
 
-    const closeoutDryRun = runRawJsonMaybeFail(fixture.repoRoot, [
-      "doc", "sync", "--dry-run"
-    ], env);
+test("published completion dry-runs report checked gates without mutating holders", { timeout: 60_000 }, async () => {
+  await withReviewedCompletionFixture("complete-ready-dry-run", {}, ({
+    fixture, taskId, approvalPath, closeoutPacketPath, taskHolderRoot, env
+  }) => {
+    const closeoutDryRun = runRawJsonMaybeFail(fixture.repoRoot, ["doc", "sync", "--dry-run"], env);
     assert.equal(closeoutDryRun.status, 0, JSON.stringify(closeoutDryRun.receipt));
     assert.match(JSON.stringify(closeoutDryRun.receipt), /closeout\.md/u);
-    const syncedCloseout = runRawJsonMaybeFail(fixture.repoRoot, [
-      "doc", "sync", "--submit", "--path", `tasks/${taskId}-production-route/closeout.md`
-    ], env);
-    assert.equal(syncedCloseout.status, 0, JSON.stringify(syncedCloseout.receipt));
-    const publishedCloseout = runRawJsonMaybeFail(fixture.repoRoot, [
-      "materializer", "run", "--current-session-only"
-    ], env);
-    assert.equal(publishedCloseout.status, 0, JSON.stringify(publishedCloseout.receipt));
+    publishCloseout(fixture.repoRoot, taskId, env);
 
-    const taskHolderRoot = path.join(fixture.repoRoot, ".harness", "task-holders");
     const holderFilesBeforeDryRun = snapshotDirectory(taskHolderRoot);
     const readyDryRun = runRawJsonMaybeFail(fixture.repoRoot, [
       "task", "complete", taskId, "--approve", "--from-file", approvalPath, "--dry-run"
@@ -251,10 +144,15 @@ test("one task complete intent publishes approval and completion through the pro
     } | undefined)?.data;
     assert.deepEqual(readyCloseoutDryRunData?.report?.completionPlan?.checkedGates, ["canonical-authority-planner", "task-completion-evidence"]);
     assert.deepEqual(readyCloseoutDryRunData?.report?.completionPlan?.uncheckedGates, ["durable-transition-write"]);
+  });
+});
 
-    const closeoutCommand = [
-      "task", "closeout", taskId, "--from-file", closeoutPacketPath
-    ] as const;
+test("task closeout publishes approval and completion through the production daemon", { timeout: 60_000 }, async () => {
+  await withReviewedCompletionFixture("complete-final-step-deadzone", {}, ({
+    fixture, taskId, executionId, taskRoot, closeoutPacketPath, env
+  }) => {
+    publishCloseout(fixture.repoRoot, taskId, env);
+    const closeoutCommand = ["task", "closeout", taskId, "--from-file", closeoutPacketPath] as const;
     const original = runRawJsonMaybeFail(fixture.repoRoot, closeoutCommand, env);
     const completed = original.status === 0
       ? original
@@ -292,10 +190,7 @@ test("one task complete intent publishes approval and completion through the pro
       } | undefined)?.data?.report?.completionPlan)?.transitionId;
       assert.equal(replayTransition, transitionId, JSON.stringify({ attempt, replayed: replayed.receipt }));
     }
-  } finally {
-    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
-    rmSync(fixture.root, { recursive: true, force: true });
-  }
+  });
 });
 
 function snapshotDirectory(input: string): Readonly<Record<string, unknown>> {

--- a/packages/cli/test/helpers/production-completion-fixture.ts
+++ b/packages/cli/test/helpers/production-completion-fixture.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import { rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+  createFixture,
+  git,
+  writeColdCodexSessionLog
+} from "../production-authority-canonical-ingress/fixture.ts";
+import {
+  productionCloseout,
+  productionPlan,
+  publishSeededTaskFixture
+} from "./canonical-task-publication-fixture.ts";
+import {
+  defaultDaemonUserRoot,
+  pollUntil,
+  runDaemonCommand,
+  runRawJsonMaybeFail,
+  stopDaemon
+} from "./daemon-cli.ts";
+
+export interface ReviewedCompletionFixture {
+  readonly fixture: ReturnType<typeof createFixture>;
+  readonly taskId: string;
+  readonly executionId: string;
+  readonly taskRoot: string;
+  readonly taskHolderRoot: string;
+  readonly approvalPath: string;
+  readonly closeoutPacketPath: string;
+  readonly env: Readonly<Record<string, string>>;
+}
+
+interface ReviewedCompletionFixtureOptions {
+  readonly exercisePlanPublication?: boolean;
+  readonly assertReleasedHolder?: boolean;
+}
+
+export async function withReviewedCompletionFixture(
+  sessionId: string,
+  options: ReviewedCompletionFixtureOptions,
+  run: (context: ReviewedCompletionFixture) => void | Promise<void>
+): Promise<void> {
+  const fixture = createFixture();
+  const userRoot = defaultDaemonUserRoot(fixture.root);
+  const taskId = "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8";
+  const executionId = "exe_01KXQ4WTA7Q4XJ5GDDRS1YXNG7";
+  const taskRoot = path.join(fixture.authoredRoot, `tasks/${taskId}-production-route`);
+  const env = {
+    HARNESS_ACTOR: "agent:codex",
+    HARNESS_DAEMON_MODE: "local",
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_IDLE_MS: "60000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
+    HARNESS_DAEMON_MATERIALIZER_POLL_MS: "3600000",
+    CODEX_THREAD_ID: sessionId
+  };
+  try {
+    writeFileSync(path.join(taskRoot, "closeout.md"), productionCloseout("Original production closeout."));
+    git(fixture.authoredRoot, "add", `tasks/${taskId}-production-route/closeout.md`);
+    git(fixture.authoredRoot, "commit", "-q", "-m", "test: seed substantive production closeout");
+    writeFileSync(path.join(taskRoot, "task_plan.md"), productionPlan("Original facade completion plan."));
+    git(fixture.authoredRoot, "add", `tasks/${taskId}-production-route/task_plan.md`);
+    git(fixture.authoredRoot, "commit", "-q", "-m", "test: seed facade completion plan");
+    publishSeededTaskFixture(fixture.authoredRoot, taskRoot, taskId);
+
+    const registered = runDaemonCommand(fixture.repoRoot, [
+      "daemon", "repo", "register", "--repo-id", "canonical",
+      "--canonical-root", fixture.repoRoot, "--user-root", userRoot, "--no-link", "--json"
+    ], env);
+    assert.equal(registered.ok, true, JSON.stringify(registered));
+    try {
+      runDaemonCommand(fixture.repoRoot, [
+        "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
+      ], env);
+    } catch {
+      // Observe the same detached production service if startup outlives the CLI wait.
+    }
+    await pollUntil(
+      () => runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env),
+      (status) => status.reachable === true,
+      (status, error) => JSON.stringify({ status, error: error instanceof Error ? error.message : String(error ?? "") }),
+      { timeoutMs: 20_000 }
+    );
+
+    writeColdCodexSessionLog(fixture.repoRoot, sessionId);
+    const exported = runRawJsonMaybeFail(fixture.repoRoot, [
+      "session", "export", "--session", sessionId, "--runtime", "codex", "--source", "runtime",
+      "--detected-at", "2026-07-31T00:00:00.000Z", "--transcript-file", fixture.transcriptPath
+    ], env);
+    assert.equal(exported.status, 0, JSON.stringify(exported.receipt));
+    const started = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "start", taskId, "--execution-id", executionId
+    ], env);
+    assert.equal(started.status, 0, JSON.stringify(started.receipt));
+
+    const submissionPath = path.join(fixture.root, `${sessionId}-submission.json`);
+    writeFileSync(submissionPath, JSON.stringify({
+      completionClaim: "The production facade deadzone regression is ready for approval.",
+      deliverables: ["Facade completion regression"],
+      outputs: ["Full-chain production daemon evidence"],
+      verificationNotes: ["Production daemon setup completed."],
+      knownGaps: [],
+      residualRisks: []
+    }));
+    const submitted = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "submit", taskId, "--execution-id", executionId, "--from-file", submissionPath
+    ], env);
+    assert.equal(submitted.status, 0, JSON.stringify(submitted.receipt));
+    if (options.assertReleasedHolder === true) {
+      const holder = runRawJsonMaybeFail(fixture.repoRoot, ["task", "holder", taskId], env);
+      assert.equal(holder.status, 0, JSON.stringify(holder.receipt));
+      const holderData = (holder.receipt.details as {
+        readonly data?: { readonly effectiveHolder?: unknown };
+      } | undefined)?.data;
+      assert.equal(holderData?.effectiveHolder, null, JSON.stringify(holder.receipt));
+    }
+
+    if (options.exercisePlanPublication === true) {
+      writeFileSync(path.join(taskRoot, "task_plan.md"), productionPlan("Updated by the final facade chain."));
+      const synced = runRawJsonMaybeFail(fixture.repoRoot, [
+        "doc", "sync", "--submit", "--path", `tasks/${taskId}-production-route/task_plan.md`
+      ], env);
+      assert.equal(synced.status, 0, JSON.stringify(synced.receipt));
+      const publishedProse = runRawJsonMaybeFail(fixture.repoRoot, [
+        "materializer", "run", "--current-session-only"
+      ], env);
+      assert.equal(publishedProse.status, 0, JSON.stringify(publishedProse.receipt));
+    }
+
+    const reconciled = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "code-doc", "reconcile", taskId,
+      "--commit", fixture.publicHead, "--path", "README.md", "--force"
+    ], env);
+    assert.equal(reconciled.status, 0, JSON.stringify(reconciled.receipt));
+    const publishedWitness = runRawJsonMaybeFail(fixture.repoRoot, [
+      "materializer", "run", "--current-session-only"
+    ], env);
+    assert.equal(publishedWitness.status, 0, JSON.stringify(publishedWitness.receipt));
+
+    const approvalPath = path.join(fixture.root, `${sessionId}-approval.json`);
+    writeFileSync(approvalPath, JSON.stringify({
+      executionId,
+      verdict: "approved",
+      findings: "The submitted evidence and public code anchor satisfy the task.",
+      evidenceChecked: ["ev_cli_1"],
+      rationale: "The production daemon path proves the requested full-chain behavior.",
+      archiveWarningsAcknowledged: true,
+      consentAssertedRationale: "Approval was received through an external channel.",
+      consentActions: ["approve_execution", "complete_task"],
+      commit: fixture.publicHead,
+      paths: ["README.md"],
+      ci: "passed",
+      reviewerId: "person_alice",
+      externalCheckpointRefs: []
+    }));
+    const reviewed = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "review-execution", taskId, "--from-file", approvalPath
+    ], env);
+    assert.equal(reviewed.status, 0, JSON.stringify(reviewed.receipt));
+
+    writeFileSync(path.join(taskRoot, "closeout.md"), productionCloseout("Closeout amended after the first reconciliation."));
+    const closeoutPacketPath = path.join(fixture.root, `${sessionId}-closeout.json`);
+    writeFileSync(closeoutPacketPath, JSON.stringify({
+      completionClaim: "The production facade deadzone regression is ready for approval.",
+      deliverables: ["Facade completion regression"],
+      outputs: ["Full-chain production daemon evidence"],
+      verificationNotes: ["Production daemon setup completed."],
+      knownGaps: [],
+      residualRisks: [],
+      executionId,
+      verdict: "approved",
+      findings: "The submitted evidence and public code anchor satisfy the task.",
+      evidenceChecked: ["ev_cli_1"],
+      rationale: "The production daemon path proves the requested full-chain behavior.",
+      archiveWarningsAcknowledged: true,
+      consentAssertedRationale: "Approval was received through an external channel.",
+      consentActions: ["approve_execution", "complete_task"],
+      commit: fixture.publicHead,
+      paths: ["README.md"],
+      ci: "passed",
+      reviewerId: "person_alice"
+    }));
+
+    await run({
+      fixture,
+      taskId,
+      executionId,
+      taskRoot,
+      taskHolderRoot: path.join(fixture.repoRoot, ".harness", "task-holders"),
+      approvalPath,
+      closeoutPacketPath,
+      env
+    });
+  } finally {
+    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+}
+
+export function publishCloseout(
+  repoRoot: string,
+  taskId: string,
+  env: Readonly<Record<string, string>>
+): void {
+  const syncedCloseout = runRawJsonMaybeFail(repoRoot, [
+    "doc", "sync", "--submit", "--path", `tasks/${taskId}-production-route/closeout.md`
+  ], env);
+  assert.equal(syncedCloseout.status, 0, JSON.stringify(syncedCloseout.receipt));
+  const publishedCloseout = runRawJsonMaybeFail(repoRoot, [
+    "materializer", "run", "--current-session-only"
+  ], env);
+  assert.equal(publishedCloseout.status, 0, JSON.stringify(publishedCloseout.receipt));
+}


### PR DESCRIPTION
# English

## Summary

**main is red.** `integration-shard (1)` reports `fail 0 / cancelled 1` — not an assertion failure, a stall abort. The aborted test is `one task complete intent publishes approval and completion through the production daemon`.

The abort is not Node's per-test timeout (180s). It is the runner's stall policy: `isolationAbortAfterMs = abortWindows(2) × diagnosticIntervalMs(30_000)` = **60 seconds**. This test has been sitting just under that line for three merges:

| commit | | CI duration | share of the 60s window |
|---|---|---:|---:|
| `999ae84b` | before #1237 | 44.587s | 74% |
| `e9b9394a` | #1237 merged | 58.218s | 97% |
| `bebc2a1d` | #1238 merged | 57.671s | 96% |
| `26ecef5b` | #1239 merged | aborted (60.9s, 66.2s) | over |

#1237 moved this test from 74% of the abort window to 97%, and it stayed there, green, across two more merges until it crossed. **The green light hid a 30% cost regression for three merges.** #1239 is the commit it crossed on, not the reason it got expensive — reverting #1239 buys back about two seconds.

This PR is the minimal fix: split that one test into independent scenarios so each has real headroom. Test organization only.

## What Changed

- `packages/cli/test/complete-final-step-deadzone.test.ts`: the single sequential test is split into four independent tests — help contract, unpublished-closeout rejection, published-completion dry run, and real closeout plus replay.
- `packages/cli/test/helpers/production-completion-fixture.ts` (new): the shared fixture setup those scenarios need.

Each split scenario builds its own real `start → submit → reconcile → materialize → review` state. No hand-written intermediate state was substituted for the real path, and the original plan-publication and holder-release assertions are retained inside the unpublished-rejection scenario.

## Task And Scope

- Harness task: `task_01KZ9RVM26VC72KTBA8H3WMQX0`
- Branch: `codex/split-completion-stall-window`
- Public scope: `packages/cli/test/complete-final-step-deadzone.test.ts` and one new test helper under `packages/cli/test/helpers/`.
- Private planning/evidence updated: yes
- Out of scope: the underlying cost regression itself (tracked on the provenance-capacity task); building a gate that makes this class of regression visible while still green (tracked on `task_01KZ9JFNGPFBFDP3J9ZW0B99CN`); PR #1240, which rebases onto this afterwards.

## Version Impact

- Version: no version change because this changes test organization only.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none. The three surfaces that would have made this green the easy way — `--test-timeout`, the stall-policy windows in `tools/node-test-stall-policy.mjs`, and the shard weights in `tools/test-tier-manifest.mjs` — were declared out of bounds in the task plan precisely because they are the cheap path, and none of them is touched by this diff.
- Authority: `task_01KZ9RVM26VC72KTBA8H3WMQX0`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable. main is red, but the fix here is to split a test, not to relax a gate, so no bypass is needed.
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `26ecef5b9271d97b93d41d11873f1b38952387ae`
- Branch merge-base with `origin/main`: `26ecef5b9271d97b93d41d11873f1b38952387ae`
- Last `git fetch origin` time: 2026-08-05T20:11Z
- Sync method: none needed
- Public diff command: `git diff --stat origin/main...codex/split-completion-stall-window`
- Private evidence commit/path: `harness/tasks/task_01KZ9RVM26VC72KTBA8H3WMQX0-main-60s-stall-completion/`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending on this PR — this PR's own run is the ground truth for per-test duration, and supersedes the extrapolation below.
- [x] `git diff --check`
- [x] `npm run check:stop-point` — via `npm run check:local`, 35.7s, 27 stop-point gates green, fast 426/426, contract 94/94
- [x] Targeted tests for the change surface, named with their counts: `packages/cli/test/complete-final-step-deadzone.test.ts` — split scenarios 4/4 pass (74.060s); whole file 7/7 pass, **cancelled 0**
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending
- Not run, and why: `npm run check:ci` was not run. Its omitted gates are CI's authority and run on this PR. No local run of it would have added discrimination here, because the failure mode being fixed is only observable at CI's speed.

Measured timings, with the CI extrapolation stated rather than implied:

| scenario | local | CI est. (×1.595) | headroom to 60s |
|---|---:|---:|---:|
| before split (one test) | 36.147s | 57.671s (measured, not estimated) | 2.329s |
| help contract | 2.820s | 3.666s | 56.3s |
| unpublished closeout rejection | 22.354s | 35.66s | 24.3s |
| published completion dry run | 22.928s | 36.57s | 23.4s |
| real closeout + replay | 25.233s | 40.26s | 19.7s |

The ×1.595 ratio comes from this very test: CI measured 57.671s where local measured 36.147s. A rounder guess would be worse, because **local timings have no discrimination on this failure** — the test never approaches 60s on a developer machine, which is exactly why the regression stayed invisible for three merges.

Also verified unchanged: `integration shard check` reports `current=257 previous=257 delta=0`; timeout config, stall policy, shard weights, tier manifest, production source, and CI-gate authority are all untouched.

## Review Evidence

- Self-review: the implementer produced the timing table above and replaced the maintainer's suggested ×1.30 CI ratio with the more conservative ×1.595 derived from this test's own measured CI-versus-local gap.
- Reviewer subagent: none for this diff. The change is test reorganization whose correctness claim is "same scenarios, same real state transitions, measured faster" — that claim is settled by the timing table and by `cancelled 0`, not by reading.
- Human review: the maintainer supplied the CI timing history and the stall-policy arithmetic, and **rejected two of its own earlier diagnoses** before landing on this one — first attributing the failure to an in-flight branch's test edit, then to CI runner contention. A same-SHA controlled rerun with nothing else in CI reproduced the abort and falsified the contention theory; the duration history is what finally identified the cause.
- Blocking findings: none.

## Residual Risk

- **Total shard time grows.** The four scenarios each rebuild their own fixture: 36.1s becomes 74.1s of aggregate wall time. That is the deliberate trade — per-test headroom bought with total runtime.
- **The underlying cost is untouched.** The completion path really did get ~30% more expensive at #1237. This PR only stops one test from being the place that discovers it.
- **Nothing yet prevents the next silent approach to the window.** A test at 97% of an abort budget looked identical to a healthy one for three merges. Making that visible *while still green* is the subject of `task_01KZ9JFNGPFBFDP3J9ZW0B99CN`, where the implementer's suggestion is recorded: surface stall-window occupancy and relative regression against multiple CI baselines, and do not infer causation from n=2 jitter.

## References

- Task: `task_01KZ9RVM26VC72KTBA8H3WMQX0`
- Evidence: `harness/tasks/task_01KZ9RVM26VC72KTBA8H3WMQX0-main-60s-stall-completion/`
- Review: recorded in the same task package; related fact history on `task_01KZ9JFNGPFBFDP3J9ZW0B99CN`

---

# 中文

## 概要

**main 现在是红的。** `integration-shard (1)` 报的是 `fail 0 / cancelled 1`——不是断言失败，是 stall 中止。被中止的测试是 `one task complete intent publishes approval and completion through the production daemon`。

中止它的不是 Node 的 per-test 超时（180 秒），是 runner 的 stall 策略：`isolationAbortAfterMs = abortWindows(2) × diagnosticIntervalMs(30_000)` = **60 秒**。这个测试已经在这条线下面贴了三次合并：

| commit | | CI 耗时 | 占 60s 窗口 |
|---|---|---:|---:|
| `999ae84b` | #1237 之前 | 44.587s | 74% |
| `e9b9394a` | #1237 合入 | 58.218s | 97% |
| `bebc2a1d` | #1238 合入 | 57.671s | 96% |
| `26ecef5b` | #1239 合入 | 被中止（60.9s、66.2s） | 越线 |

#1237 把它从占中止窗口的 74% 推到 97%，此后它顶着绿灯又过了两次合并，直到越线。**绿灯把一次 30% 的成本回归藏了三次合并。** #1239 是它越线的那个 commit，不是它变贵的原因——回滚 #1239 只买回约两秒。

本 PR 是最小修法：把那个测试按内部独立场景拆开，让每个都有真实余量。只动测试组织。

## 改动内容

- `packages/cli/test/complete-final-step-deadzone.test.ts`：原来一条串行测试拆成四条独立测试——help 合同、未发布 closeout 拒绝、已发布 completion dry-run、真实 closeout + replay。
- `packages/cli/test/helpers/production-completion-fixture.ts`（新增）：这些场景需要的共享夹具搭建。

拆分后每个场景各自建立真实的 `start → submit → reconcile → materialize → review` 状态，没有用手写中间状态替代真实路径；原有的 plan 发布与 holder 释放断言保留在「未发布拒绝」场景内。

## 任务与范围

- Harness 任务：`task_01KZ9RVM26VC72KTBA8H3WMQX0`
- 分支：`codex/split-completion-stall-window`
- 公开范围：`packages/cli/test/complete-final-step-deadzone.test.ts` 与 `packages/cli/test/helpers/` 下一个新增测试 helper。
- 私有计划 / 证据是否已更新：yes
- 范围外：底层成本回归本身（归 provenance 容量任务）；「让这类回归在还是绿的时候就可见」的门（归 `task_01KZ9JFNGPFBFDP3J9ZW0B99CN`）；PR #1240，它在本 PR 之后 rebase 上来。

## 版本影响

- 版本：不改版本，原因是本次只改测试组织。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：无。三个「让它省事变绿」的面——`--test-timeout`、`tools/node-test-stall-policy.mjs` 的 stall 窗口、`tools/test-tier-manifest.mjs` 的分片权重——在任务计划里被划为禁区，**正因为它们是最省事的那条路**；本次 diff 一个都没碰。
- 依据：`task_01KZ9RVM26VC72KTBA8H3WMQX0`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用。main 虽然红着，但这里的修法是拆测试而不是放宽门，不需要绕行。
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`26ecef5b9271d97b93d41d11873f1b38952387ae`
- 当前分支与 `origin/main` 的 merge-base：`26ecef5b9271d97b93d41d11873f1b38952387ae`
- 最近一次 `git fetch origin` 时间：2026-08-05T20:11Z
- 同步方式：不需要
- 公开 diff 命令：`git diff --stat origin/main...codex/split-completion-stall-window`
- 私有证据 commit/path：`harness/tasks/task_01KZ9RVM26VC72KTBA8H3WMQX0-main-60s-stall-completion/`
- Reviewer 证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：待本 PR 跑出——**本 PR 自己的 run 才是每个测试耗时的 ground truth**，它覆盖下面的外推值。
- [x] `git diff --check`
- [x] `npm run check:stop-point`——经由 `npm run check:local`，35.7s，27 个 stop-point gate 绿，fast 426/426，contract 94/94
- [x] 改动面的定向测试，写明测试名与通过数：`packages/cli/test/complete-final-step-deadzone.test.ts`——拆出的场景 4/4 pass（74.060s）；整文件 7/7 pass，**cancelled 0**
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）——待跑
- 未跑项及原因：未跑 `npm run check:ci`。它省略的门是 CI 的权威面，会在本 PR 上跑。本地再跑一遍也不会增加分辨力，因为**被修的这个失败形态只在 CI 的速度下才可观察**。

实测耗时，CI 换算写明而不是暗含：

| 场景 | 本地 | CI 预估（×1.595） | 距 60s 余量 |
|---|---:|---:|---:|
| 拆分前（单条） | 36.147s | 57.671s（实测值，非估计） | 2.329s |
| help 合同 | 2.820s | 3.666s | 56.3s |
| 未发布 closeout 拒绝 | 22.354s | 35.66s | 24.3s |
| 已发布 completion dry-run | 22.928s | 36.57s | 23.4s |
| 真实 closeout + replay | 25.233s | 40.26s | 19.7s |

×1.595 这个比值就是从这个测试自己身上得来的：CI 实测 57.671s，本地实测 36.147s。用一个更圆的估计反而更糟，因为**本地耗时对这个失败根本没有分辨力**——这个测试在开发机上永远碰不到 60 秒，而这正是这次回归被藏了三次合并的原因。

同时验证未变：`integration shard check` 报 `current=257 previous=257 delta=0`；超时配置、stall 策略、分片权重、tier manifest、生产源码与 CI 门权威面全部未动。

## 审查证据

- 自查：实现者给出了上面那张耗时表，并把维护者建议的 ×1.30 换算比替换成从这个测试自身 CI-对-本地 实测差得来的、更保守的 ×1.595。
- Reviewer subagent：本次未派。改动是测试重组，其正确性主张是「同样的场景、同样的真实状态转移、量出来更快」——这条由耗时表与 `cancelled 0` 结算，不由通读结算。
- 人工审查：维护者提供了 CI 耗时史与 stall 策略的算术，并在落到这个结论之前**否掉了自己的两个诊断**——先是把失败归给一条在飞分支的测试改动，再是归给 CI runner 争用。同 SHA、CI 中无其他任务的受控重跑复现了中止、证伪了争用假设；最终定因靠的是那张耗时史。
- 阻塞发现：无。

## 残余风险

- **分片总时长上升。** 四个场景各自重建夹具：36.1s 变成合计 74.1s 墙钟。这是有意的交换——用总运行时间换每个测试的余量。
- **底层成本没有被触碰。** 完成路径在 #1237 确实贵了约 30%。本 PR 只是让某一个测试不再是发现它的地方。
- **目前仍没有东西能拦住下一次悄悄逼近窗口。** 一个占中止预算 97% 的测试，在三次合并里看起来和健康的一模一样。让这种情况**在还是绿的时候**就可见，是 `task_01KZ9JFNGPFBFDP3J9ZW0B99CN` 的主题；实现者的建议已记在那里：同时展示 CI 上的 stall 窗口占用率与相对多次 CI 基线的回归，并且不要用 n=2 的抖动直接判因果。

## 关联材料

- 任务：`task_01KZ9RVM26VC72KTBA8H3WMQX0`
- 证据：`harness/tasks/task_01KZ9RVM26VC72KTBA8H3WMQX0-main-60s-stall-completion/`
- 审查：记录在同一任务包；相关 fact 历史在 `task_01KZ9JFNGPFBFDP3J9ZW0B99CN`

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚：squash 合并，合并后删远端分支并清理本地 worktree。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
