### PR TITLE
build(hooks): reject commits authored outside the CLA identity

### DIFF
--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh
+set -eu
+
+# Installed by pointing git at this directory:
+#   git config core.hooksPath tools/git-hooks   (or: npm run hooks:install)
+#
+# Rejects commits whose author email is not one the CLA assistant accepts.
+#
+# Why this exists as a hook rather than as advice: the repository's local
+# git config has been correct every time this went wrong. What goes wrong is
+# that an agent runs `git -c user.email=... commit` and overrides it, using
+# whatever identity looked most authoritative to it -- an actor registry's real
+# address, a hermetic test fixture's fake identity, or its own vendor identity.
+# Each time, the failure surfaced only on CI as a red cla-assistant, after a
+# push, and cost a force-push to repair. `git var` below resolves the identity
+# git will actually stamp, including `-c` overrides, so this catches it at the
+# moment the commit is created.
+#
+# This defends against accidents, not against a determined author: `--no-verify`
+# skips it, and that is the correct escape hatch for someone who knows why they
+# need a different identity.
+
+allowed_email="33339424+FairladyZ625@users.noreply.github.com"
+
+author_ident=$(git var GIT_AUTHOR_IDENT)
+author_email=$(printf '%s' "$author_ident" | sed -n 's/.*<\(.*\)>.*/\1/p')
+
+if [ "$author_email" = "$allowed_email" ]; then
+  exit 0
+fi
+
+printf 'Refusing to create a commit authored by <%s>.\n' "$author_email" >&2
+printf '\n' >&2
+printf 'This repository requires the CLA-signing identity:\n' >&2
+printf '  %s\n' "$allowed_email" >&2
+printf '\n' >&2
+printf 'The repository config is probably already correct -- check whether\n' >&2
+printf 'something overrode it, such as `git -c user.email=...` on the command\n' >&2
+printf 'line, or GIT_AUTHOR_EMAIL in the environment. Do not copy an identity\n' >&2
+printf 'out of the actor registry or out of a test fixture; neither is the CLA\n' >&2
+printf 'identity. Current setting:\n' >&2
+printf '  user.name  = %s\n' "$(git config user.name || echo '(unset)')" >&2
+printf '  user.email = %s\n' "$(git config user.email || echo '(unset)')" >&2
+printf '\n' >&2
+printf 'To set it for this repository:\n' >&2
+printf '  git config user.name "ZeyuLi"\n' >&2
+printf '  git config user.email "%s"\n' "$allowed_email" >&2
+printf '\n' >&2
+printf 'To repair commits that already carry the wrong author:\n' >&2
+printf '  git rebase --exec "git commit --amend --no-edit --reset-author" origin/main\n' >&2
+printf '\n' >&2
+printf 'If you genuinely need a different author, bypass with `git commit --no-verify`.\n' >&2
+exit 1

--- a/tools/git-hooks/pre-commit.test.mjs
+++ b/tools/git-hooks/pre-commit.test.mjs
@@ -1,0 +1,77 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const hookPath = fileURLToPath(new URL("./pre-commit", import.meta.url));
+const claEmail = "33339424+FairladyZ625@users.noreply.github.com";
+
+// The hook only earns trust if it is shown to speak as well as to stay silent,
+// so both directions are asserted: the accepting case and the rejecting one.
+
+test("pre-commit accepts the CLA-signing author", () => {
+  withRepo((root) => {
+    setIdentity(root, "ZeyuLi", claEmail);
+    assert.equal(runHook(root).status, 0);
+  });
+});
+
+test("pre-commit rejects an author the CLA assistant does not accept", () => {
+  withRepo((root) => {
+    setIdentity(root, "Codex", "codex@openai.com");
+    const result = runHook(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Refusing to create a commit authored by <codex@openai\.com>/u);
+    assert.match(result.stderr, new RegExp(claEmail.replace(/[.+]/gu, "\\$&"), "u"));
+  });
+});
+
+// This is the case that actually happened: the repository identity is correct
+// and a command-line override defeats it. A hook that read `git config`
+// instead of `git var` would pass here and catch nothing.
+test("pre-commit sees through a command-line identity override", () => {
+  withRepo((root) => {
+    setIdentity(root, "ZeyuLi", claEmail);
+    const result = runHook(root, {
+      GIT_AUTHOR_NAME: "Codex",
+      GIT_AUTHOR_EMAIL: "codex@openai.com"
+    });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /codex@openai\.com/u);
+  });
+});
+
+function withRepo(body) {
+  const root = mkdtempSync(path.join(os.tmpdir(), "ha-pre-commit-hook-"));
+  try {
+    run("git", ["init", "-q"], root);
+    writeFileSync(path.join(root, "README.md"), "one\n", "utf8");
+    run("git", ["add", "README.md"], root);
+    body(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function setIdentity(root, name, email) {
+  run("git", ["config", "user.name", name], root);
+  run("git", ["config", "user.email", email], root);
+}
+
+function runHook(root, extraEnv = {}) {
+  const result = execFileSync("sh", ["-c", `"${hookPath}" 2>&1; echo "EXIT:$?"`], {
+    cwd: root,
+    env: { ...process.env, ...extraEnv },
+    encoding: "utf8"
+  });
+  const marker = result.lastIndexOf("EXIT:");
+  return { status: Number(result.slice(marker + 5).trim()), stderr: result.slice(0, marker) };
+}
+
+function run(command, args, cwd) {
+  return execFileSync(command, args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}


### PR DESCRIPTION
# English

## Summary

Three times now, a commit has reached this repository with an author the CLA assistant does not accept. Every time, the repository's own git config was already correct, and an agent overrode it on the command line with whatever identity looked most authoritative to it:

| when | PR | identity copied from |
|---|---|---|
| 2026-07-16 | #813 | the actor registry's real address, `lizeyu990625@gmail.com` |
| 2026-08-02 | #1189 | a hermetic test fixture, `harness@example.test` |
| 2026-08-05 | #1245 | the agent's own vendor identity, `Codex <codex@openai.com>` |

Each time the failure surfaced the same way — a red `cla-assistant` seven seconds into CI, after a push — and was repaired the same way, with an amend and a force-push. The delegation standard has said "do not override the commit identity on the command line" since the first occurrence. Writing it a fourth time is not the remaining move.

This adds a `pre-commit` hook that rejects the commit at the moment it is created.

## What Changed

- `tools/git-hooks/pre-commit` (new): reads `git var GIT_AUTHOR_IDENT` — the identity git will actually stamp, **including `-c` and environment overrides** — and refuses anything other than the CLA-signing address. The rejection message prints the current config, names the two decoys explicitly (the actor registry and test fixtures), and gives copyable commands both to set the identity and to repair commits that already carry the wrong one.
- `tools/git-hooks/pre-commit.test.mjs` (new): three tests, registered into the integration tier by its first-line marker.

`--no-verify` still bypasses it, and the message says so. This defends against an accident, not against an author who knows they want a different identity.

## Task And Scope

- Harness task: `task_01KZ9XSVZ5S0813N95YDG2VC20`
- Branch: `codex/cla-author-hook`
- Public scope: two new files under `tools/git-hooks/`.
- Private planning/evidence updated: yes
- Out of scope: the CI `cla-assistant` check, which remains the authority and is unchanged. This only moves discovery earlier.

## Version Impact

- Version: no version change because this adds a local git hook and its test.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no. Verified by running `tools/check-pr-governance.mjs` against this diff: `no protected surfaces touched (129 manifest-derived rules)`.
- Protected surface scope: none. No workflow, no required check, no `tools/gate-manifest.json`. A local hook is not a gate.
- Authority: `task_01KZ9XSVZ5S0813N95YDG2VC20`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `d0180ca996def2dff5b1c30680b62ec3c6a7876c`
- Branch merge-base with `origin/main`: `d0180ca996def2dff5b1c30680b62ec3c6a7876c`
- Last `git fetch origin` time: 2026-08-05T21:20Z
- Sync method: none needed
- Public diff command: `git diff --stat origin/main...codex/cla-author-hook`
- Private evidence commit/path: `harness/tasks/task_01KZ9XSVZ5S0813N95YDG2VC20-pre-commit-cla/`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` — `check:local` green in 55.1s; 27 stop-point gates
- [x] Targeted tests for the change surface, named with their counts: `tools/git-hooks/pre-commit.test.mjs` — 3/3
- [x] `integration shard check` — `current=258 previous=257 delta=1`; the new file self-registers via its first-line tier marker
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending
- Not run, and why: `npm run check:ci` was not run; its omitted gates are CI's authority and run on this PR.

**The unit tests were not sufficient, and finding that out is the most useful thing in this PR.** With all three tests green, a real `git commit` using `codex@openai.com` was attempted as a control — and it **succeeded**. The hook never ran. `core.hooksPath` in this repository is an absolute path into the canonical root, so a hook that exists only inside a worktree is never found, no matter which directory git is invoked from.

That is worth stating plainly because it cuts both ways. It means a hook cannot be tested for real from the branch that introduces it — but it also means that once this merges, **every worktree is governed by the canonical root's copy**, which is exactly where the agents doing the overriding are working.

The real control was therefore run against the actual commit path, in a scratch repository with `core.hooksPath` pointed at this branch's hook directory:

| identity | result |
|---|---|
| `codex@openai.com` | rejected — `Refusing to create a commit authored by <codex@openai.com>`, exit 1, no commit created |
| `33339424+FairladyZ625@users.noreply.github.com` | accepted — commit created |

The third unit test covers the case that actually happened: repository config correct, identity overridden on the command line. A hook that read `git config user.email` instead of `git var GIT_AUTHOR_IDENT` would pass that test's setup and catch nothing — which is why the distinction is asserted rather than assumed.

## Review Evidence

- Self-review: the author ran the positive control before trusting the tests, which is what caught the silent hook.
- Reviewer subagent: none.
- Human review: this change was written directly rather than delegated, because the diff was known exactly and the delegation overhead would have exceeded the work.
- Blocking findings: none.

## Residual Risk

- **The allowlist is a literal in the hook.** If the CLA-signing identity ever changes, this file must change with it, and nothing links the two. The CI check reads its allowlist from the workflow; the hook does not.
- **`--no-verify` bypasses it**, by design. So does committing from an environment where `npm run hooks:install` was never run — the hook is opt-in per clone, as all hooks in this directory already are.
- **It does not check the committer, only the author.** The three recorded incidents all set both together via `-c user.email`, so the author check catches them; a case that sets only the committer would slip through.
- **This is the fourth response to the same defect family, and it is the first mechanical one.** If a fifth instance appears with an identity this hook accepts, the right conclusion will be that the boundary is drawn in the wrong place, not that the message needs rewording.

## References

- Task: `task_01KZ9XSVZ5S0813N95YDG2VC20`
- Evidence: `harness/tasks/task_01KZ9XSVZ5S0813N95YDG2VC20-pre-commit-cla/`
- Review: recorded in the same task package

---

# 中文

## 概要

到目前为止，已经有三次 commit 带着 CLA assistant 不接受的 author 进入本仓。**每一次，仓库自己的 git config 都是对的**，是 agent 在命令行上用「看起来最权威」的身份把它盖掉：

| 时间 | PR | 身份抄自 |
|---|---|---|
| 2026-07-16 | #813 | actor registry 里的真实邮箱 `lizeyu990625@gmail.com` |
| 2026-08-02 | #1189 | hermetic 测试夹具 `harness@example.test` |
| 2026-08-05 | #1245 | agent 自己的厂商身份 `Codex <codex@openai.com>` |

三次的暴露方式一样——push 之后 CI 上 `cla-assistant` 七秒变红——修法也一样：amend + force-push。而委托规范从第一次起就写着「禁止在命令行覆盖 commit 身份」。**第四次再写一遍，已经不是剩下的那个动作了。**

本 PR 加一道 `pre-commit` hook，在 commit 被创建的那一刻拒绝它。

## 改动内容

- `tools/git-hooks/pre-commit`（新增）：读 `git var GIT_AUTHOR_IDENT`——即 git **实际**会写入的身份，**包含 `-c` 与环境变量的覆盖**——非 CLA 签署地址一律拒绝。报错信息打印当前配置、**点名那两个诱饵**（actor registry 与测试夹具），并给出可照抄的命令：既包括如何设置身份，也包括已经落了错 author 的 commit 怎么改回来。
- `tools/git-hooks/pre-commit.test.mjs`（新增）：三条测试，靠首行 marker 登记进 integration tier。

`--no-verify` 仍然能绕过，报错里也写明了。这道防御防的是意外，不防一个明知自己要用别的身份的作者。

## 任务与范围

- Harness 任务：`task_01KZ9XSVZ5S0813N95YDG2VC20`
- 分支：`codex/cla-author-hook`
- 公开范围：`tools/git-hooks/` 下两个新文件。
- 私有计划 / 证据是否已更新：yes
- 范围外：CI 上的 `cla-assistant` 检查——它仍是最终权威，本次不动它。本 PR 只把发现时机提前。

## 版本影响

- 版本：不改版本，原因是本次只加一个本地 git hook 及其测试。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no。已用 `tools/check-pr-governance.mjs` 对本次 diff 实跑验证：`no protected surfaces touched (129 manifest-derived rules)`。
- protected surface 范围：无。不动 workflow、不动 required check、不动 `tools/gate-manifest.json`。本地 hook 不是门。
- 依据：`task_01KZ9XSVZ5S0813N95YDG2VC20`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`d0180ca996def2dff5b1c30680b62ec3c6a7876c`
- 当前分支与 `origin/main` 的 merge-base：`d0180ca996def2dff5b1c30680b62ec3c6a7876c`
- 最近一次 `git fetch origin` 时间：2026-08-05T21:20Z
- 同步方式：不需要
- 公开 diff 命令：`git diff --stat origin/main...codex/cla-author-hook`
- 私有证据 commit/path：`harness/tasks/task_01KZ9XSVZ5S0813N95YDG2VC20-pre-commit-cla/`
- Reviewer 证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：待本 PR 跑出
- [x] `git diff --check`
- [x] `npm run check:stop-point`——`check:local` 55.1s 绿；27 道 stop-point gate
- [x] 改动面的定向测试，写明测试名与通过数：`tools/git-hooks/pre-commit.test.mjs`——3/3
- [x] `integration shard check`——`current=258 previous=257 delta=1`；新文件靠首行 tier marker 自动登记
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）——待跑
- 未跑项及原因：未跑 `npm run check:ci`；它省略的门是 CI 的权威面，会在本 PR 上跑。

**单元测试不够，而发现这一点是本 PR 里最有用的东西。** 三条测试全绿之后，作为对照真的用 `codex@openai.com` 跑了一次 `git commit`——**它成功了**。hook 根本没触发。本仓的 `core.hooksPath` 是指向 canonical 根的**绝对路径**，所以只存在于 worktree 里的 hook 永远不会被找到，无论从哪个目录调用 git。

这一点值得写明，因为它两面都成立：它意味着**一道 hook 无法从引入它的那条分支上被真实验证**；但它同时意味着，一旦合入，**每一个 worktree 都受 canonical 根那一份管辖**——而那正是那些覆盖身份的 agent 干活的地方。

因此真正的对照是在**真实提交路径**上做的：一个临时仓，`core.hooksPath` 指向本分支的 hook 目录。

| 身份 | 结果 |
|---|---|
| `codex@openai.com` | 被拒——`Refusing to create a commit authored by <codex@openai.com>`，exit 1，未产生 commit |
| `33339424+FairladyZ625@users.noreply.github.com` | 通过——commit 已落 |

第三条单元测试打的正是真实发生过的那个形态：仓库配置正确、身份被命令行覆盖。一道读 `git config user.email` 而不是 `git var GIT_AUTHOR_IDENT` 的 hook，在那条测试的前置下会通过、却什么都抓不到——所以这个区别是被**断言**的，不是被假定的。

## 审查证据

- 自查：作者在信任测试之前先跑了阳性对照，正是这一步抓到了那道不响的 hook。
- Reviewer subagent：未派。
- 人工审查：本改动是直接写的而非派发的，因为 diff 已经确切已知，委托开销高于工作本身。
- 阻塞发现：无。

## 残余风险

- **allowlist 是 hook 里的字面量。** 将来 CLA 签署身份若变更，这个文件必须跟着改，而两者之间没有任何联系。CI 那个检查从 workflow 里读它的 allowlist，本 hook 不读。
- **`--no-verify` 能绕过**，这是设计。从未跑过 `npm run hooks:install` 的克隆同样不受管——与本目录下既有的所有 hook 一样，它是按克隆 opt-in 的。
- **它只校验 author，不校验 committer。** 三次事故都是用 `-c user.email` 同时设置两者，所以校验 author 足以抓住；只设置 committer 的情形会漏过。
- **这是同一缺陷族的第四次应对，也是第一次机械应对。** 如果出现第五例、且身份能被本 hook 接受，正确的结论应当是边界划错了地方，而不是报错文案需要再润色一遍。

## 关联材料

- 任务：`task_01KZ9XSVZ5S0813N95YDG2VC20`
- 证据：`harness/tasks/task_01KZ9XSVZ5S0813N95YDG2VC20-pre-commit-cla/`
- 审查：记录在同一任务包

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚：squash 合并，合并后删远端分支并清理本地 worktree。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
