### PR TITLE
fix(kernel): classify Windows task-holder lock contention by operation intent

### DIFF
--- a/packages/kernel/src/local/local-layout-file-system.ts
+++ b/packages/kernel/src/local/local-layout-file-system.ts
@@ -74,7 +74,7 @@ export const localRuntimeStateFileSystem = {
     try {
       descriptor = openSync(inputPath, "wx");
     } catch (error) {
-      if (isExclusiveCreateConflict(error, inputPath)) return false;
+      if (isExclusiveCreateConflict(error)) return false;
       throw error;
     }
     try {
@@ -87,6 +87,7 @@ export const localRuntimeStateFileSystem = {
   exists: (inputPath: string) => existsSync(inputPath),
   mkdirp: (inputPath: string) => mkdirSync(inputPath, { recursive: true }),
   modifiedAtMs: (inputPath: string) => statSync(inputPath).mtimeMs,
+  readNames: (inputPath: string): ReadonlyArray<string> => readdirSync(inputPath),
   readText: (inputPath: string) => readFileSync(inputPath, "utf8"),
   rename: (fromPath: string, toPath: string) => renameSync(fromPath, toPath),
   remove: (inputPath: string) => rmSync(inputPath, { force: true }),
@@ -108,19 +109,17 @@ export const localDeclaredIdentityRepairFileSystem = {
 
 export function isExclusiveCreateConflict(
   error: unknown,
-  inputPath: string,
   platform: NodeJS.Platform = process.platform
 ): boolean {
   const code = nodeErrorCode(error);
-  return code === "EEXIST" || (platform === "win32" && code === "EPERM" && existsSync(inputPath));
+  return code === "EEXIST" || (platform === "win32" && code === "EPERM");
 }
 
 export function isConcurrentRenameLoss(
   error: unknown,
-  sourcePath: string,
   platform: NodeJS.Platform = process.platform
 ): boolean {
-  return platform === "win32" && nodeErrorCode(error) === "EPERM" && !existsSync(sourcePath);
+  return platform === "win32" && nodeErrorCode(error) === "EPERM";
 }
 
 function nodeErrorCode(error: unknown): unknown {

--- a/packages/kernel/src/local/task-holder-mutation-lock.ts
+++ b/packages/kernel/src/local/task-holder-mutation-lock.ts
@@ -49,7 +49,10 @@ async function acquireTaskHolderMutationLock(lockPath: string, taskId: string): 
       acquiredAt: new Date().toISOString(),
       ownerToken
     };
-    if (localRuntimeStateFileSystem.createExclusiveText(lockPath, JSON.stringify(record))) return ownerToken;
+    if (localRuntimeStateFileSystem.createExclusiveText(lockPath, JSON.stringify(record))) {
+      clearTaskHolderMutationLockReleaseMarkers(lockPath);
+      return ownerToken;
+    }
     recoverAbandonedTaskHolderMutationLock(lockPath);
     await new Promise<void>((resolve) => setTimeout(resolve, mutationLockRetryMs));
   }
@@ -61,23 +64,26 @@ function recoverAbandonedTaskHolderMutationLock(lockPath: string): void {
   try {
     record = readTaskHolderMutationLock(lockPath);
   } catch (error) {
-    if (isConcurrentWindowsLockAccess(error, lockPath)) return;
+    if (isConcurrentWindowsLockAccess(error)) return;
     throw error;
   }
+  const releaseMarkerPath = record ? taskHolderMutationLockReleaseMarkerPath(lockPath, record.ownerToken) : null;
+  const released = releaseMarkerPath ? localRuntimeStateFileSystem.exists(releaseMarkerPath) : false;
   const modifiedAtMs = record ? null : readTaskHolderMutationLockModifiedAtMs(lockPath);
   const acquiredAtMs = record ? Date.parse(record.acquiredAt) : modifiedAtMs;
   if (acquiredAtMs === null) return;
   const ageMs = Date.now() - acquiredAtMs;
-  const abandoned = record?.hostname === hostname()
+  const abandoned = released || (record?.hostname === hostname()
     ? !processIsAlive(record.pid)
-    : Number.isFinite(ageMs) && ageMs > mutationLockStaleMs;
+    : Number.isFinite(ageMs) && ageMs > mutationLockStaleMs);
   if (!abandoned) return;
   const quarantinePath = `${lockPath}.stale.${randomBytes(6).toString("hex")}`;
   try {
     localRuntimeStateFileSystem.rename(lockPath, quarantinePath);
     localRuntimeStateFileSystem.remove(quarantinePath);
+    if (releaseMarkerPath) localRuntimeStateFileSystem.remove(releaseMarkerPath);
   } catch (error) {
-    if (!isMissingFileError(error) && !isConcurrentRenameLoss(error, lockPath)) throw error;
+    if (!isMissingFileError(error) && !isConcurrentRenameLoss(error)) throw error;
   }
 }
 
@@ -85,14 +91,40 @@ function readTaskHolderMutationLockModifiedAtMs(lockPath: string): number | null
   try {
     return localRuntimeStateFileSystem.modifiedAtMs(lockPath);
   } catch (error) {
-    if (isMissingFileError(error) || isConcurrentWindowsLockAccess(error, lockPath)) return null;
+    if (isMissingFileError(error) || isConcurrentWindowsLockAccess(error)) return null;
     throw error;
   }
 }
 
 function releaseTaskHolderMutationLock(lockPath: string, ownerToken: string): void {
-  const record = readTaskHolderMutationLock(lockPath);
+  let record: TaskHolderMutationLockRecord | null;
+  try {
+    record = readTaskHolderMutationLock(lockPath);
+  } catch (error) {
+    if (isConcurrentWindowsLockAccess(error)) {
+      // Carry ownership across the sharing violation; recovery only acts on a matching lock generation.
+      localRuntimeStateFileSystem.writeText(taskHolderMutationLockReleaseMarkerPath(lockPath, ownerToken), "");
+      return;
+    }
+    throw error;
+  }
   if (record?.ownerToken === ownerToken) localRuntimeStateFileSystem.remove(lockPath);
+}
+
+function taskHolderMutationLockReleaseMarkerPath(lockPath: string, ownerToken: string): string {
+  return `${lockPath}.release.${ownerToken}`;
+}
+
+function clearTaskHolderMutationLockReleaseMarkers(lockPath: string): void {
+  const directoryPath = path.dirname(lockPath);
+  const markerPrefix = `${path.basename(lockPath)}.release.`;
+  try {
+    for (const entry of localRuntimeStateFileSystem.readNames(directoryPath)) {
+      if (entry.startsWith(markerPrefix)) localRuntimeStateFileSystem.remove(path.join(directoryPath, entry));
+    }
+  } catch {
+    // Markers belong to older generations and are safe to leave for the next acquisition.
+  }
 }
 
 function readTaskHolderMutationLock(lockPath: string): TaskHolderMutationLockRecord | null {
@@ -124,10 +156,10 @@ function isMissingFileError(error: unknown): boolean {
   return isNodeErrorCode(error, "ENOENT");
 }
 
-function isConcurrentWindowsLockAccess(error: unknown, lockPath: string): boolean {
+function isConcurrentWindowsLockAccess(error: unknown): boolean {
+  // Callers already know this failed operation targeted the mutation lock; a later exists check would be racy.
   return process.platform === "win32" &&
-    isNodeErrorCode(error, "EPERM") &&
-    localRuntimeStateFileSystem.exists(lockPath);
+    isNodeErrorCode(error, "EPERM");
 }
 
 function isNodeErrorCode(error: unknown, code: string): boolean {

--- a/packages/kernel/test/local-runtime-state-file-system.test.ts
+++ b/packages/kernel/test/local-runtime-state-file-system.test.ts
@@ -1,32 +1,19 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import test from "node:test";
 import {
   isConcurrentRenameLoss,
   isExclusiveCreateConflict
 } from "../src/local/local-layout-file-system.ts";
 
-test("Windows classifies only observed EPERM path races as runtime-state contention", () => {
-  const root = mkdtempSync(path.join(os.tmpdir(), "ha-runtime-state-race-"));
-  const existing = path.join(root, "existing.lock");
-  const missing = path.join(root, "missing.lock");
-  writeFileSync(existing, "holder", "utf8");
-  try {
-    const eperm = Object.assign(new Error("operation not permitted"), { code: "EPERM" });
-    const exists = Object.assign(new Error("already exists"), { code: "EEXIST" });
+test("Windows classifies lock EPERM by exclusive-create and rename operation context", () => {
+  const eperm = Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+  const exists = Object.assign(new Error("already exists"), { code: "EEXIST" });
 
-    assert.equal(isExclusiveCreateConflict(eperm, existing, "win32"), true);
-    assert.equal(isExclusiveCreateConflict(eperm, missing, "win32"), false);
-    assert.equal(isExclusiveCreateConflict(eperm, existing, "linux"), false);
-    assert.equal(isExclusiveCreateConflict(exists, missing, "linux"), true);
+  assert.equal(isExclusiveCreateConflict(eperm, "win32"), true);
+  assert.equal(isExclusiveCreateConflict(eperm, "linux"), false);
+  assert.equal(isExclusiveCreateConflict(exists, "linux"), true);
 
-    assert.equal(isConcurrentRenameLoss(eperm, missing, "win32"), true);
-    assert.equal(isConcurrentRenameLoss(eperm, existing, "win32"), false);
-    assert.equal(isConcurrentRenameLoss(eperm, missing, "linux"), false);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
+  assert.equal(isConcurrentRenameLoss(eperm, "win32"), true);
+  assert.equal(isConcurrentRenameLoss(eperm, "linux"), false);
 });

--- a/packages/kernel/test/task-holder-mutation-lock.test.ts
+++ b/packages/kernel/test/task-holder-mutation-lock.test.ts
@@ -1,0 +1,181 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { hostname, tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  TaskClaimCollisionError,
+  makeTaskHolderService,
+  taskHolderActor,
+  type TaskHolderPrincipal
+} from "../src/index.ts";
+import { localRuntimeStateFileSystem } from "../src/local/local-layout-file-system.ts";
+import { taskHolderRecordPath } from "../src/local/task-holder-mutation-lock.ts";
+
+const taskId = "task_01KZ9Z9D61R6JAKW0N0VR2G5JX";
+const alice = taskHolderActor({ personId: "alice", displayName: "Alice" }, null) satisfies TaskHolderPrincipal;
+const bob = taskHolderActor({ personId: "bob", displayName: "Bob" }, null) satisfies TaskHolderPrincipal;
+
+test("claim classifies a Windows lock read EPERM after the lock disappears as contention", async (context) => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-task-holder-eperm-"));
+  const lockPath = `${taskHolderRecordPath(rootDir, taskId)}.lock`;
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  const originalReadText = localRuntimeStateFileSystem.readText;
+  try {
+    const service = makeTaskHolderService({
+      rootInput: rootDir,
+      now: () => new Date("2026-08-06T00:00:00.000Z")
+    });
+    await service.claim({ taskId, principal: alice, ttlMs: 60_000 });
+    writeFileSync(lockPath, "holder", "utf8");
+
+    Object.defineProperty(process, "platform", { ...originalPlatform, value: "win32" });
+    let injectReadFailure = true;
+    context.mock.method(localRuntimeStateFileSystem, "readText", (inputPath: string) => {
+      if (inputPath === lockPath && injectReadFailure) {
+        injectReadFailure = false;
+        rmSync(lockPath, { force: true });
+        throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+      }
+      return originalReadText(inputPath);
+    });
+
+    await assert.rejects(
+      service.claim({ taskId, principal: bob, ttlMs: 60_000 }),
+      (error) => error instanceof TaskClaimCollisionError && error.code === "task_claim_collision"
+    );
+  } finally {
+    if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("claim classifies a Windows lock stat EPERM after the lock disappears as contention", async (context) => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-task-holder-stat-eperm-"));
+  const lockPath = `${taskHolderRecordPath(rootDir, taskId)}.lock`;
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  const originalModifiedAtMs = localRuntimeStateFileSystem.modifiedAtMs;
+  try {
+    const service = makeTaskHolderService({
+      rootInput: rootDir,
+      now: () => new Date("2026-08-06T00:00:00.000Z")
+    });
+    await service.claim({ taskId, principal: alice, ttlMs: 60_000 });
+    writeFileSync(lockPath, "publishing", "utf8");
+
+    Object.defineProperty(process, "platform", { ...originalPlatform, value: "win32" });
+    let injectStatFailure = true;
+    context.mock.method(localRuntimeStateFileSystem, "modifiedAtMs", (inputPath: string) => {
+      if (inputPath === lockPath && injectStatFailure) {
+        injectStatFailure = false;
+        rmSync(lockPath, { force: true });
+        throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+      }
+      return originalModifiedAtMs(inputPath);
+    });
+
+    await assert.rejects(
+      service.claim({ taskId, principal: bob, ttlMs: 60_000 }),
+      (error) => error instanceof TaskClaimCollisionError && error.code === "task_claim_collision"
+    );
+  } finally {
+    if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("release defers Windows EPERM cleanup without stranding its owned lock", async (context) => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-task-holder-release-eperm-"));
+  const lockPath = `${taskHolderRecordPath(rootDir, taskId)}.lock`;
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  const originalReadText = localRuntimeStateFileSystem.readText;
+  try {
+    const service = makeTaskHolderService({ rootInput: rootDir });
+    Object.defineProperty(process, "platform", { ...originalPlatform, value: "win32" });
+    let injectReleaseFailure = false;
+    context.mock.method(localRuntimeStateFileSystem, "readText", (inputPath: string) => {
+      if (inputPath === lockPath && injectReleaseFailure) {
+        injectReleaseFailure = false;
+        throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+      }
+      return originalReadText(inputPath);
+    });
+
+    await service.withUnheldTask({ taskId }, async () => {
+      injectReleaseFailure = true;
+    });
+
+    let reacquired = false;
+    await service.withUnheldTask({ taskId }, async () => {
+      reacquired = true;
+    });
+    assert.equal(reacquired, true);
+  } finally {
+    if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("release preserves a replacement lock generation when owner verification gets EPERM", async (context) => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-task-holder-release-owner-"));
+  const lockPath = `${taskHolderRecordPath(rootDir, taskId)}.lock`;
+  const replacementOwnerToken = "replacement-owner-token";
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  const originalReadText = localRuntimeStateFileSystem.readText;
+  try {
+    const service = makeTaskHolderService({ rootInput: rootDir });
+    Object.defineProperty(process, "platform", { ...originalPlatform, value: "win32" });
+    let injectReleaseFailure = false;
+    context.mock.method(localRuntimeStateFileSystem, "readText", (inputPath: string) => {
+      if (inputPath === lockPath && injectReleaseFailure) {
+        injectReleaseFailure = false;
+        throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+      }
+      return originalReadText(inputPath);
+    });
+
+    await service.withUnheldTask({ taskId }, async () => {
+      writeFileSync(lockPath, JSON.stringify({
+        schema: "task-holder-mutation-lock/v1",
+        pid: process.pid,
+        hostname: hostname(),
+        acquiredAt: new Date().toISOString(),
+        ownerToken: replacementOwnerToken
+      }), "utf8");
+      injectReleaseFailure = true;
+    });
+
+    const replacement = JSON.parse(readFileSync(lockPath, "utf8")) as { readonly ownerToken: string };
+    assert.equal(replacement.ownerToken, replacementOwnerToken);
+  } finally {
+    if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("stale release-marker cleanup cannot strand a newly acquired lock", async (context) => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-task-holder-release-cleanup-"));
+  const originalReadNames = localRuntimeStateFileSystem.readNames;
+  try {
+    const service = makeTaskHolderService({ rootInput: rootDir });
+    let injectCleanupFailure = true;
+    context.mock.method(localRuntimeStateFileSystem, "readNames", (inputPath: string) => {
+      if (injectCleanupFailure) {
+        injectCleanupFailure = false;
+        throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+      }
+      return originalReadNames(inputPath);
+    });
+
+    let entered = false;
+    await service.withUnheldTask({ taskId }, async () => {
+      entered = true;
+    });
+    assert.equal(entered, true);
+
+    await service.withUnheldTask({ taskId }, async () => undefined);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
# English

## Summary

On Windows, the task-holder mutation lock decided "is this EPERM a concurrency
collision?" by observing the filesystem a **second** time (`existsSync`) after the
operation had already failed. That second observation is not atomic with the first,
so a deterministic counter-example exists: the operation raises `EPERM`, the winner
then releases the lock, `existsSync` returns `false`, the guard concludes "not a
collision", and a bare `EPERM` leaks to the caller. This PR classifies these failures
by the **operation intent the call site already knows**, so the window does not exist
rather than merely being smaller.

Ruling: `dec_01KZ9YXZMCKAZEC5MQF9RK8GWK` (active).

## What Changed

- `isConcurrentWindowsLockAccess`, `isExclusiveCreateConflict` and
  `isConcurrentRenameLoss` no longer take a path and no longer call `existsSync`.
  An exclusive create that returns `EPERM` on Windows *means* someone else holds it;
  asking the filesystem again adds no information and adds a race.
- `releaseTaskHolderMutationLock` is now owner-safe under the same failure. When the
  ownership read hits `EPERM`, release writes an `ownerToken`-scoped deferred-release
  marker instead of silently doing nothing. Recovery only reclaims a lock whose
  marker matches the current record's `ownerToken`, so a lock that has already been
  recycled to a different owner is never deleted by the previous owner.
- Marker cleanup happens on the next successful acquisition of the same lock path.

Without the release half, a reader that simply returned `null` on `EPERM` would have
traded an intermittent misreport for a **persistent deadlock**: the owner would stop
deleting its own lock, and liveness-based recovery would not reclaim it because the
owning process is still alive. That failure mode is why release is treated separately
and has its own tests.

## Task And Scope

- Harness task: `task_01KZ9YC0V97S3Y4G8CFG7ZZJJB`
- Branch: `codex/windows-lock-guard`
- Public scope: `packages/kernel/src/local/{task-holder-mutation-lock,local-layout-file-system}.ts` and their tests
- Private planning/evidence updated: yes (task plan, progress, ruling)
- Out of scope: the same-shaped copy in `packages/kernel/src/daemon/registry.ts:390`.
  It is deliberately untouched here and is tracked as its own task,
  `task_01KZ9YYXE8P1HDC9GT4ZG3KR6K` — a promised follow-up that is not written down
  does not happen.

## Version Impact

- Version: no version change because this is an internal correctness fix with no
  published surface change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `dec_01KZ9YXZMCKAZEC5MQF9RK8GWK` (active) — classify lock EPERM by
  operation context, never by a second observation of shared state
- Machine-check boundary: this PR only asserts the declaration exists; reviewers
  decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `a6f39ae1b87846041f5d248045fa003429d9429e`
- Branch merge-base with `origin/main`: `a6f39ae1b87846041f5d248045fa003429d9429e`
- Last `git fetch origin` time: 2026-08-06, immediately before opening this PR
- Sync method: none needed
- Public diff command: `git diff a6f39ae1..0d866bd5`
- Private evidence commit/path: `harness/tasks/task_01KZ9YC0V97S3Y4G8CFG7ZZJJB-windows-readtext-eperm/progress.md`
- Reviewer evidence path: same package, `artifacts/`
- GitHub Actions `rewrite-ci` run URL: pending — filled in below once the run reports
- [x] `git diff --check`
- [x] `npm run check:stop-point` — `npm run check:local` exit 0, 27 stop-point gates green
- [x] Targeted tests for the change surface, named with their counts:
  `packages/kernel/test/task-holder-mutation-lock.test.ts` + injection/owner-safe cases 6/6;
  `packages/kernel/test/local-runtime-state-file-system.test.ts` create/rename classification;
  `packages/application/test/task-holder-service.test.ts` 14/14 (the file whose
  32-round race originally exposed this); kernel fast 85/85, contract 93/93.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: the `windows-local-check` job is deliberately **not** treated as
  the acceptance instrument. The original symptom is intermittent, so one green
  Windows run has zero resolving power for "is it fixed?". Acceptance rests on the
  deterministic injection test below, which runs red/green on macOS.

**Negative control (the load-bearing evidence, not the green run).** With the
read/stat fix withdrawn and the injection test kept, the `readText` + lock-disappears
case is deterministically **red 1/1** and the caller receives a bare `EPERM`. With the
fix restored the targeted suite is 6/6 green. A test that cannot be made to fail is
not evidence that anything was fixed.

## Review Evidence

- Self-review: CEO read the full source diff. Two things were checked rather than
  assumed: (1) the acquire loop is bounded by `mutationLockWaitMs`, so widening the
  EPERM classification cannot turn a genuine Windows ACL failure into an unbounded
  spin — it surfaces as an acquisition timeout; (2) leftover markers from earlier
  generations are inert, because `released` is only consulted against the *current*
  record's `ownerToken`.
- Reviewer subagent: not used; the change surface is small and the negative control
  is the decisive evidence.
- Human review: pending
- Blocking findings: none

## Residual Risk

- On Windows, any `EPERM` in these paths is now read as contention. A genuine
  permission fault (an ACL that denies the process outright) therefore presents as an
  acquisition timeout rather than a permission error. This is the deliberate trade:
  the previous behaviour did not distinguish these either, and it additionally leaked
  bare `EPERM` on a real race.
- The deferred-release marker is a new on-disk artifact. It is `ownerToken`-scoped
  and cleared on the next successful acquisition, but it is state, and state can be
  orphaned — a marker left by a process that dies between writing it and the next
  acquisition simply waits there. It is inert while it waits.
- The Windows path itself is exercised in CI but the defect is intermittent there;
  the durable guarantee comes from the cross-platform injection test, not from the
  Windows job.

## References

- Task: `task_01KZ9YC0V97S3Y4G8CFG7ZZJJB`
- Evidence: `harness/tasks/task_01KZ9YC0V97S3Y4G8CFG7ZZJJB-windows-readtext-eperm/progress.md`
- Review: `dec_01KZ9YXZMCKAZEC5MQF9RK8GWK`

---

# 中文

## 概要

Windows 上,task-holder 的互斥锁判断「这个 `EPERM` 是不是并发冲突」的方式,是在操作**已经失败之后**
再观测一次文件系统(`existsSync`)。这第二次观测与第一次并不原子,于是存在一个确定性反例:
操作抛 `EPERM` → 赢家随即释放锁 → `existsSync` 返回 false → 守卫判定「不是冲突」→
裸 `EPERM` 漏给调用方。本 PR 改为**按调用点本就知道的操作意图**分类,使那个窗口
**根本不存在**,而不是被缩小。

裁决依据:`dec_01KZ9YXZMCKAZEC5MQF9RK8GWK`(active)。

## 改动内容

- `isConcurrentWindowsLockAccess`、`isExclusiveCreateConflict`、`isConcurrentRenameLoss`
  不再接收路径参数,也不再调用 `existsSync`。一次独占创建在 Windows 上拿到 `EPERM`,
  **本身就意味着**别人正持有它;再问一遍文件系统不增加任何信息,只增加一个竞态。
- `releaseTaskHolderMutationLock` 在同一失败下具备 owner-safe 语义:归属校验读到 `EPERM` 时,
  写一条 `ownerToken` 专属的 deferred-release marker,而不是静默地什么都不做。
  回收逻辑只回收 marker 与当前记录 `ownerToken` 匹配的那一代,
  因此已经被回收给别的持有者的锁,永远不会被前一任删掉。
- marker 在同一锁路径的下一次成功获取时清理。

**没有 release 这一半,修复会把一个间歇误报换成一个持久死锁**:reader 遇 `EPERM` 简单返回 `null`,
持有者就不再删除自己的锁,而基于存活性的回收又不会认领它——因为持有进程还活着。
正是这个失效形态,决定了 release 必须单独对待并有自己的测试。

## 任务与范围

- Harness 任务:`task_01KZ9YC0V97S3Y4G8CFG7ZZJJB`
- 分支:`codex/windows-lock-guard`
- 公开范围:`packages/kernel/src/local/{task-holder-mutation-lock,local-layout-file-system}.ts` 及其测试
- 私有规划/证据已更新:是(task plan、progress、裁决)
- 不在本 PR 范围:`packages/kernel/src/daemon/registry.ts:390` 那份同形副本。
  本次**刻意不动**,已单独立账为 `task_01KZ9YYXE8P1HDC9GT4ZG3KR6K`
  ——口头承诺的后续从来不会发生。

## 版本影响

- 版本:不变,本次是内部正确性修复,不改变已发布接口面。
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:否
- Protected surface 范围:不适用
- 授权依据:`dec_01KZ9YXZMCKAZEC5MQF9RK8GWK`(active)——锁类 `EPERM` 按操作上下文分类,
  不得以对共享状态的第二次观测作为判据
- 机器检查边界:本 PR 只断言声明存在;声明是否属实、是否充分由评审者判断。
- Break-glass:否
- Break-glass 理由:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- 基线 `origin/main` SHA:`a6f39ae1b87846041f5d248045fa003429d9429e`
- 分支与 `origin/main` 的 merge-base:`a6f39ae1b87846041f5d248045fa003429d9429e`
- 最近一次 `git fetch origin`:2026-08-06,开 PR 前
- 同步方式:无需同步
- 公开 diff 命令:`git diff a6f39ae1..0d866bd5`
- 私有证据 commit/路径:`harness/tasks/task_01KZ9YC0V97S3Y4G8CFG7ZZJJB-windows-readtext-eperm/progress.md`
- 评审证据路径:同任务包 `artifacts/`
- GitHub Actions `rewrite-ci` run URL:待 run 出结果后回填
- [x] `git diff --check`
- [x] `npm run check:stop-point` —— `npm run check:local` exit 0,27 道 stop-point gate 绿
- [x] 改动面定向测试(带计数):
  `packages/kernel/test/task-holder-mutation-lock.test.ts` 注入/owner-safe 用例 6/6;
  `packages/kernel/test/local-runtime-state-file-system.test.ts` create/rename 分类;
  `packages/application/test/task-holder-service.test.ts` 14/14(最初暴露本缺陷的
  32 轮竞态所在文件);kernel fast 85/85、contract 93/93。
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- 未跑及原因:**刻意不拿 `windows-local-check` 当验收仪器**。原始现象是间歇的,
  一次绿的 Windows run 对「修没修好」零分辨力。验收依据是下面那条在 macOS 上
  确定性跑红跑绿的注入测试。

**阴性对照(承重证据,不是那个绿)**:仅撤回 read/stat 的修复、保留注入测试,
`readText` + 锁随即消失这条用例确定性 **红 1/1**,调用方拿到的正是裸 `EPERM`;
恢复修复后定向套件 6/6 绿。**一个无法被弄红的测试,不构成任何东西被修好的证据。**

## 审查证据

- 自审:CEO 通读了全部源码 diff。有两点是**核过**而不是假定的:
  (1)获取循环由 `mutationLockWaitMs` 定界,所以放宽 `EPERM` 分类不会把真实的 Windows ACL
  故障变成无界自旋——它会呈现为获取超时;
  (2)旧世代残留的 marker 是惰性的,因为 `released` 只针对**当前**记录的 `ownerToken` 判定。
- 复核 subagent:未使用;改动面小,且阴性对照才是决定性证据。
- 人工审查:待办
- 阻塞性发现:无

## 残余风险

- Windows 上这些路径里的任何 `EPERM` 现在都被读作争用。真正的权限故障
  (ACL 直接拒绝本进程)因此会表现为获取超时,而不是权限错误。这是有意的取舍:
  旧行为同样区分不了这两者,而且还会在真实竞态上漏出裸 `EPERM`。
- deferred-release marker 是一件新的磁盘状态。它以 `ownerToken` 定界、在下一次成功获取时清理,
  但它终究是状态,而状态可能被遗弃——写下它之后、下次获取之前就死掉的进程,会把它留在那里。
  它在等待期间是惰性的。
- Windows 路径本身在 CI 里会跑,但缺陷在那里是间歇的;
  持久的保证来自跨平台的注入测试,不来自那个 Windows job。

## 关联材料

- 任务:`task_01KZ9YC0V97S3Y4G8CFG7ZZJJB`
- 证据:`harness/tasks/task_01KZ9YC0V97S3Y4G8CFG7ZZJJB-windows-readtext-eperm/progress.md`
- 复核:`dec_01KZ9YXZMCKAZEC5MQF9RK8GWK`
