### PR TITLE
fix(kernel): classify registry lock EPERM by operation intent

### DIFF
--- a/packages/kernel/src/daemon/registry.ts
+++ b/packages/kernel/src/daemon/registry.ts
@@ -15,6 +15,7 @@ import {
 import os from "node:os";
 import path from "node:path";
 import { resolveHarnessLayout } from "../layout/index.ts";
+import { isExclusiveCreateConflict } from "../local/local-layout-file-system.ts";
 
 export const daemonRegistrySchema = "harness-daemon-registry/v1";
 
@@ -367,7 +368,7 @@ function withDaemonRegistryMutationLock<T>(options: DaemonRegistryOptions, mutat
       mkdirSync(lockPath);
       break;
     } catch (error) {
-      if (!isRegistryLockCollision(error, lockPath)) throw error;
+      if (!isExclusiveCreateConflict(error, options.platform)) throw error;
       if (registryLockIsStale(lockPath)) {
         try {
           rmSync(lockPath, { recursive: true });
@@ -385,12 +386,6 @@ function withDaemonRegistryMutationLock<T>(options: DaemonRegistryOptions, mutat
   } finally {
     rmSync(lockPath, { recursive: true, force: true });
   }
-}
-
-function isRegistryLockCollision(error: unknown, lockPath: string): boolean {
-  if (!(error instanceof Error) || !("code" in error)) return false;
-  const code = (error as NodeJS.ErrnoException).code;
-  return code === "EEXIST" || ((code === "EPERM" || code === "EACCES") && existsSync(lockPath));
 }
 
 function registryLockIsStale(lockPath: string): boolean {

--- a/packages/kernel/test/store/daemon-registry.test.ts
+++ b/packages/kernel/test/store/daemon-registry.test.ts
@@ -1,7 +1,8 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import fs, { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -24,6 +25,42 @@ test("daemon registry reads missing registry as an empty v1 registry", () => {
       repos: []
     });
   });
+});
+
+test("register classifies a Windows lock-create EPERM after the lock disappears as contention", (context) => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-daemon-registry-eperm-"));
+  const userRoot = path.join(root, "user-harness");
+  const canonicalRoot = createHarnessRepo(path.join(root, "project"));
+  const lockPath = `${daemonRegistryPaths({ userRoot }).registryPath}.lock`;
+  mkdirSync(userRoot, { recursive: true });
+  mkdirSync(lockPath);
+
+  const originalMkdirSync = fs.mkdirSync;
+  let injectLockFailure = true;
+  fs.mkdirSync = ((inputPath: Parameters<typeof fs.mkdirSync>[0], options?: Parameters<typeof fs.mkdirSync>[1]) => {
+    if (inputPath === lockPath && injectLockFailure) {
+      injectLockFailure = false;
+      rmSync(lockPath, { recursive: true, force: true });
+      throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+    }
+    return Reflect.apply(originalMkdirSync, fs, [inputPath, options]);
+  }) as typeof fs.mkdirSync;
+  syncBuiltinESMExports();
+  context.after(() => {
+    fs.mkdirSync = originalMkdirSync;
+    syncBuiltinESMExports();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const result = registerDaemonRepo({
+    userRoot,
+    canonicalRoot,
+    repoId: "project",
+    platform: "win32",
+    createConvenienceLinks: false
+  });
+
+  assert.equal(result.repo.repoId, "project");
 });
 
 test("daemon registry register realpaths canonical roots and writes registry-only when links are disabled", () => {


### PR DESCRIPTION
# English

## Summary

The daemon registry held the **last** copy of a defect family that #1247 removed
everywhere else: it decided whether an `EPERM` from `mkdirSync(lockPath)` meant
"someone else holds this lock" by observing the filesystem a **second** time
(`existsSync`). That second observation is not atomic with the first, so the winner
can release the lock in between, `existsSync` returns `false`, the guard concludes
"not a collision", and a bare `EPERM` leaks out of `withDaemonRegistryMutationLock`.

`mkdirSync(lockPath)` is an exclusive create — the same operation intent that
`createExclusiveText` already has a classifier for. So this PR does not write a
second classifier; it **deletes** `isRegistryLockCollision` and calls the exported
`isExclusiveCreateConflict(error, platform?)`. One family, one classifier.

Ruling: `dec_01KZ9YXZMCKAZEC5MQF9RK8GWK` (active), clause CH3.

## What Changed

- `packages/kernel/src/daemon/registry.ts`: `isRegistryLockCollision` removed;
  `withDaemonRegistryMutationLock` now classifies via
  `isExclusiveCreateConflict(error, options.platform)`.
- `packages/kernel/test/store/daemon-registry.test.ts`: deterministic injection test
  that makes the first `mkdirSync(lockPath)` delete the lock directory **and** throw
  `EPERM` in the same step — precisely the counter-example — then asserts registration
  proceeds instead of surfacing the raw error.

**`EACCES` was deliberately not folded into the shared classifier.** The old predicate
accepted `EEXIST || ((EPERM || EACCES) && existsSync(path))`. The confirmable
contention outcomes of an exclusive create are `EEXIST` and, on Windows, `EPERM`;
swallowing every `EACCES` as contention would disguise a genuine permission denial as
a five-second acquisition timeout. It stays a permission error.

**No marker protocol here.** The sibling fix introduced an `ownerToken` deferred-release
marker because *its* release path has to verify ownership before deleting. The
registry's release is an unconditional `rmSync` in a `finally`, a different shape —
copying the marker machinery would have been unjustified.

## Task And Scope

- Harness task: `task_01KZ9YYXE8P1HDC9GT4ZG3KR6K`
- Branch: `codex/registry-eperm`
- Public scope: `packages/kernel/src/daemon/registry.ts` and its store test
- Private planning/evidence updated: yes (task plan, progress)
- Out of scope: the registry's release path. See Residual Risk — a real owner-safety
  defect was confirmed there during this work and is tracked separately rather than
  smuggled into this diff.

## Version Impact

- Version: no version change because this is an internal correctness fix with no
  published surface change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `dec_01KZ9YXZMCKAZEC5MQF9RK8GWK` (active), clause CH3 — the registry copy
  is explicitly assigned to its own task by that ruling
- Machine-check boundary: this PR only asserts the declaration exists; reviewers
  decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `e5e21de8febfb1c4201563ec1615b44b30dd3f18`
- Branch merge-base with `origin/main`: `e5e21de8febfb1c4201563ec1615b44b30dd3f18`
- Last `git fetch origin` time: 2026-08-06, immediately before opening this PR
- Sync method: none needed
- Public diff command: `git diff e5e21de8..e7e10ee4`
- Private evidence commit/path: `harness/tasks/task_01KZ9YYXE8P1HDC9GT4ZG3KR6K-daemon-registry-windows-eperm-exists/progress.md`
- Reviewer evidence path: same package
- GitHub Actions `rewrite-ci` run URL: pending — this PR's run
- [x] `git diff --check`
- [x] `npm run check:stop-point` — `npm run check:local` 11.4s, 27 gates green
- [x] Targeted tests for the change surface, named with their counts:
  `packages/kernel/test/store/daemon-registry.test.ts` 19/19
- [x] `npm run harness:check-import-boundaries` — passed, allowlist count unchanged
  (16 → 16). This was run because the fix introduces a `kernel/src/daemon` →
  `kernel/src/local` import; the layering question was **checked, not assumed**.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: `windows-local-check` is deliberately not the acceptance
  instrument. The family's original symptom is intermittent, so one green Windows run
  has zero resolving power. Acceptance rests on the cross-platform injection test.

**Negative control (the load-bearing evidence).** With only the test added and the
production code untouched, `node --test packages/kernel/test/store/daemon-registry.test.ts`
gives **18 pass / 1 fail**, the failure being `Error: operation not permitted`,
`code EPERM`, stack landing in `registry.ts` `withDaemonRegistryMutationLock`. After
the fix the same file is **19 pass / 0 fail**, and the injected case completes in
~15ms — fast enough to show it took the "recognise contention → acquire next round"
path rather than being masked by a retry delay.

A repo-wide scan for the same shape (`EPERM` classified by a follow-up `exists`) found
**no sixth instance**. With this PR the family is closed.

## Review Evidence

- Self-review: CEO read the full diff. `options.platform` is optional and `undefined`
  correctly falls through to the classifier's `process.platform` default, so production
  behaviour is unchanged off-Windows. `existsSync` remains imported and used elsewhere
  in the file, so no dead import. The injection test uses `syncBuiltinESMExports()`,
  which is required for the named ESM import in `registry.ts` to observe the patched
  `fs.mkdirSync`.
- Reviewer subagent: not used; two-file diff with a proven-discriminating test.
- Human review: pending
- Blocking findings: none

## Residual Risk

- **A confirmed, unfixed owner-safety defect in the registry's release path.** The
  30-second stale reclaim can delete holder A's lock; holder B then recreates it; A's
  `finally { rmSync(lockPath, ...) }` is unconditional and deletes **B's** lock. This
  was verified during this task and deliberately kept out of this diff: it is a
  different defect from the classification family, and folding it in would have made
  this PR unreviewable against its ruling. Tracked as its own task.
- On Windows, any `EPERM` from the exclusive create is now read as contention. A
  genuine ACL denial therefore presents as an acquisition timeout after the 5s
  deadline rather than a permission error — the same trade the sibling PR accepted,
  and narrower than before, since `EACCES` was left out.

## References

- Task: `task_01KZ9YYXE8P1HDC9GT4ZG3KR6K`
- Evidence: `harness/tasks/task_01KZ9YYXE8P1HDC9GT4ZG3KR6K-daemon-registry-windows-eperm-exists/progress.md`
- Review: `dec_01KZ9YXZMCKAZEC5MQF9RK8GWK` (CH3); sibling PR #1247

---

# 中文

## 概要

daemon registry 里藏着这一族**最后**一处副本——#1247 已经把其余四处清掉了。它判断
`mkdirSync(lockPath)` 抛出的 `EPERM` 是不是「别人正持有这把锁」,靠的是在操作失败之后
**再观测一次**文件系统(`existsSync`)。两次观测并不原子:赢家可以在两次之间释放锁,
`existsSync` 返回 false,守卫判定「不是冲突」,裸 `EPERM` 就从
`withDaemonRegistryMutationLock` 漏出去了。

`mkdirSync(lockPath)` 是一次独占创建——与 `createExclusiveText` 是**同一种操作意图**,
而后者已经有分类器了。所以本 PR **不写第二个分类器**,而是**删掉** `isRegistryLockCollision`,
改调已导出的 `isExclusiveCreateConflict(error, platform?)`。**一族一个分类器。**

裁决依据:`dec_01KZ9YXZMCKAZEC5MQF9RK8GWK`(active)CH3 条。

## 改动内容

- `packages/kernel/src/daemon/registry.ts`:删除 `isRegistryLockCollision`;
  `withDaemonRegistryMutationLock` 改用
  `isExclusiveCreateConflict(error, options.platform)` 分类。
- `packages/kernel/test/store/daemon-registry.test.ts`:确定性注入测试——
  让第一次 `mkdirSync(lockPath)` 在同一步里**先删掉锁目录再抛 `EPERM`**,
  正是那个反例;随后断言注册照常推进,而不是把裸错误抛给调用方。

**`EACCES` 被刻意排除在共享分类器之外。** 旧判据是
`EEXIST || ((EPERM || EACCES) && existsSync(path))`。独占创建能确认的冲突结果是
`EEXIST` 与 Windows 上的 `EPERM`;把所有 `EACCES` 都吞成竞争,会**把一次真实的权限拒绝
伪装成 5 秒获取超时**。它继续保持权限错误的语义。

**这里没有 marker 协议。** 姊妹修复引入 `ownerToken` deferred-release marker,
是因为**它的** release 必须先校验归属再删除;registry 的释放是 `finally` 里的无条件
`rmSync`,形态不同——照抄那套机制没有理由。

## 任务与范围

- Harness 任务:`task_01KZ9YYXE8P1HDC9GT4ZG3KR6K`
- 分支:`codex/registry-eperm`
- 公开范围:`packages/kernel/src/daemon/registry.ts` 及其 store 测试
- 私有规划/证据已更新:是(task plan、progress)
- 不在本 PR 范围:registry 的释放路径。见残余风险——本次工作中**确认**了那里有一个真实的
  owner-safety 缺陷,单独立账,而不是夹带进本 diff。

## 版本影响

- 版本:不变,内部正确性修复,不改变已发布接口面。
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:否
- Protected surface 范围:不适用
- 授权依据:`dec_01KZ9YXZMCKAZEC5MQF9RK8GWK`(active)CH3 条——该裁决明文把 registry 副本
  划给单独任务
- 机器检查边界:本 PR 只断言声明存在;声明是否属实、是否充分由评审者判断。
- Break-glass:否
- Break-glass 理由:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- 基线 `origin/main` SHA:`e5e21de8febfb1c4201563ec1615b44b30dd3f18`
- 分支与 `origin/main` 的 merge-base:`e5e21de8febfb1c4201563ec1615b44b30dd3f18`
- 最近一次 `git fetch origin`:2026-08-06,开 PR 前
- 同步方式:无需同步
- 公开 diff 命令:`git diff e5e21de8..e7e10ee4`
- 私有证据 commit/路径:`harness/tasks/task_01KZ9YYXE8P1HDC9GT4ZG3KR6K-daemon-registry-windows-eperm-exists/progress.md`
- 评审证据路径:同任务包
- GitHub Actions `rewrite-ci` run URL:本 PR 的 run
- [x] `git diff --check`
- [x] `npm run check:stop-point` —— `npm run check:local` 11.4s,27 道 gate 绿
- [x] 改动面定向测试(带计数):
  `packages/kernel/test/store/daemon-registry.test.ts` 19/19
- [x] `npm run harness:check-import-boundaries` —— 通过,allowlist 数量未变(16 → 16)。
  跑它是因为本修复引入了 `kernel/src/daemon` → `kernel/src/local` 的依赖;
  **分层问题是核过的,不是假定的。**
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- 未跑及原因:**刻意不拿 `windows-local-check` 当验收仪器**——这一族的原始现象是间歇的,
  一次绿的 Windows run 零分辨力。验收落在跨平台注入测试上。

**阴性对照(承重证据)**:只加测试、不动生产代码时,
`node --test packages/kernel/test/store/daemon-registry.test.ts` 为 **18 pass / 1 fail**,
失败是 `Error: operation not permitted`、`code EPERM`,栈落在 `registry.ts`
`withDaemonRegistryMutationLock`。修复后同一文件 **19 pass / 0 fail**,
注入用例约 **15ms** 完成——够快,说明它走的是「识别为竞争 → 下一轮获取成功」,
而不是被某个重试延迟掩盖过去。

全仓扫描同一形状(用事后 `exists` 分类 `EPERM`)**未发现第六处**。本 PR 之后这一族收口。

## 审查证据

- 自审:CEO 通读全部 diff。`options.platform` 是可选的,`undefined` 会正确落到分类器的
  `process.platform` 默认值,所以非 Windows 上生产行为不变;`existsSync` 在该文件其他地方
  仍在使用,没有留下死导入;注入测试用了 `syncBuiltinESMExports()`——这是让 `registry.ts`
  的具名 ESM 导入能看见被替换的 `fs.mkdirSync` 所必需的。
- 复核 subagent:未使用;两文件 diff,且测试的分辨力已被执行证明。
- 人工审查:待办
- 阻塞性发现:无

## 残余风险

- **registry 释放路径有一个已确认、本次未修的 owner-safety 缺陷。** 30 秒 stale 回收可以删掉
  持有者 A 的锁,B 随后重建;而 A 的 `finally { rmSync(lockPath, ...) }` 是**无条件**的,
  会删掉 **B 的**新锁。本次工作中已验证成立,并**刻意留在本 diff 之外**:
  它与分类这一族是不同的缺陷,夹带进来会让本 PR 无法对着它的裁决被评审。已单独立账。
- Windows 上独占创建的任何 `EPERM` 现在都读作争用。真实的 ACL 拒绝因此会在 5 秒 deadline
  之后表现为获取超时,而不是权限错误——与姊妹 PR 接受的是同一个取舍,
  而且比原来更窄,因为 `EACCES` 被排除在外了。

## 关联材料

- 任务:`task_01KZ9YYXE8P1HDC9GT4ZG3KR6K`
- 证据:`harness/tasks/task_01KZ9YYXE8P1HDC9GT4ZG3KR6K-daemon-registry-windows-eperm-exists/progress.md`
- 复核:`dec_01KZ9YXZMCKAZEC5MQF9RK8GWK`(CH3);姊妹 PR #1247
