### PR TITLE
fix(daemon): make writer shutdown outcomes honest and diagnosable

### DIFF
--- a/packages/cli/test/daemon-control-drain-timeout.test.ts
+++ b/packages/cli/test/daemon-control-drain-timeout.test.ts
@@ -4,7 +4,10 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { createDaemonServiceHost } from "@harness-anything/daemon";
+import {
+  createDaemonServiceHost,
+  type RepoWriteProcessSupervisor
+} from "@harness-anything/daemon";
 import { cliDaemonServiceHostServices } from "../src/composition/daemon-service-host-services.ts";
 
 const batch4Golden = JSON.parse(readFileSync(new URL("../../daemon/test/fixtures/batch4-equivalence-golden.json", import.meta.url), "utf8")) as Record<string, string>;
@@ -83,6 +86,103 @@ test("daemon control reports a stuck drain and does not run transport shutdown",
     assert.equal(JSON.stringify({ phase: activeControl?.phase, failure: activeControl?.failure }), batch4Golden.ownerExitReceipt);
     assert.deepEqual(events, ["runtime:stop-stuck"]);
     assert.equal(stopSettled, false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("daemon stop runs later cleanup handlers after a repo writer stop failure", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-daemon-stop-handlers-"));
+  const serviceRoot = path.join(root, "service");
+  const repoRoot = path.join(root, "repo");
+  mkdirSync(serviceRoot, { recursive: true });
+  mkdirSync(repoRoot, { recursive: true });
+  const events: string[] = [];
+  const repo = { repoId: "alpha", canonicalRoot: repoRoot };
+  const repoRuntime = runtimeStatus(repo);
+  const runtime = {
+    start: async () => managerStatus(repo),
+    stop: async () => { events.push("runtime:stop"); },
+    status: () => managerStatus(repo),
+    attachRepo: async () => { throw new Error("fixture attach not used"); },
+    detachRepo: async () => { throw new Error("fixture detach not used"); },
+    retryUnavailableRepos: async () => [],
+    getRepoRuntime: () => repoRuntime,
+    enqueueInteractiveWrite: async () => { throw new Error("fixture enqueue not used"); },
+    enqueueBackgroundBatch: async () => { throw new Error("fixture background not used"); },
+    enqueueMaterializerBatch: async () => { throw new Error("fixture materializer not used"); }
+  };
+  let observedWriterStopTimeoutMs: number | undefined;
+  const supervisors = new Map<string, RepoWriteProcessSupervisor>([[
+    repo.repoId,
+    {
+      status: () => ({
+        repoId: repo.repoId,
+        generation: 1,
+        connected: true
+      }),
+      submit: async () => { throw new Error("fixture submit not used"); },
+      direct: async () => { throw new Error("fixture direct not used"); },
+      stop: async (options?: { readonly timeoutMs?: number }) => {
+        observedWriterStopTimeoutMs = options?.timeoutMs;
+        events.push("repo-writer:stop");
+        throw new Error("repo writer could not be terminated");
+      }
+    } as RepoWriteProcessSupervisor
+  ]]);
+
+  try {
+    const entrypoint = path.resolve("packages/cli/src/index.ts");
+    const host = await createDaemonServiceHost(
+      runtime as Parameters<typeof createDaemonServiceHost>[0],
+      [repo],
+      repo.repoId,
+      undefined,
+      0,
+      path.join(serviceRoot, "daemon.sock"),
+      { active: 0, total: 0 },
+      serviceRoot,
+      {
+        entrypoint,
+        loadedIdentity: `sha256:${"0".repeat(64)}`,
+        startedAt: "2026-08-06T00:00:00.000Z",
+        launchConfiguration: {
+          execPath: process.execPath,
+          execArgv: [],
+          entrypoint,
+          args: ["--root", repoRoot, "daemon", "serve"]
+        },
+        preflightReplacement: async () => undefined
+      },
+      cliDaemonServiceHostServices,
+      undefined,
+      undefined,
+      supervisors
+    );
+    host.onStop(async () => {
+      events.push("transport:stop");
+    });
+    const control = await host.requestControl("restart", {
+      reason: "verify aggregate stop deadline",
+      drainTimeoutMs: 500
+    });
+    assert.equal(control.ok, true);
+    if (!control.ok) assert.fail(control.error.hint);
+    control.afterResponse();
+    await host.waitForStopRequest();
+
+    await assert.rejects(host.stop(), (error: unknown) => {
+      assert.ok(error instanceof AggregateError);
+      return true;
+    });
+    assert.deepEqual(events, [
+      "runtime:stop",
+      "repo-writer:stop",
+      "transport:stop"
+    ]);
+    assert.ok(observedWriterStopTimeoutMs !== undefined);
+    assert.ok(observedWriterStopTimeoutMs > 0);
+    assert.ok(observedWriterStopTimeoutMs < 500);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/cli/test/daemon-shutdown-record-cli.test.ts
+++ b/packages/cli/test/daemon-shutdown-record-cli.test.ts
@@ -1,0 +1,75 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import {
+  runDaemonServe,
+  type DaemonServeHooks
+} from "@harness-anything/daemon";
+import { cliDaemonServiceHostServices } from "../src/composition/daemon-service-host-services.ts";
+import {
+  defaultDaemonUserRoot,
+  runRawJson,
+  withTempRootAsync
+} from "./helpers/daemon-cli.ts";
+
+test("persisted daemon termination diagnostics retain a stop handler's nested reason", async () => {
+  await withTempRootAsync(async (rootDir) => {
+    const userRoot = defaultDaemonUserRoot(rootDir);
+    runRawJson(rootDir, ["init"], {
+      HARNESS_DAEMON_MODE: "direct",
+      HARNESS_DIRECT_WRITE_REASON: "recovery",
+      HARNESS_DAEMON_USER_ROOT: userRoot
+    });
+    const endpoint = path.join(rootDir, "daemon-diagnostic.sock");
+    const hooks: DaemonServeHooks = {
+      onStop: async () => {
+        throw new AggregateError([
+          new Error("fixture nested stop cause")
+        ], "fixture stop aggregate");
+      }
+    };
+
+    await assert.rejects(runDaemonServe({
+      rootDir,
+      userRoot,
+      endpoint,
+      requestedRepoId: "canonical",
+      entrypoint: path.resolve("packages/cli/src/index.ts"),
+      idleMs: 1,
+      preflightReplacement: async () => undefined
+    }, cliDaemonServiceHostServices, {
+      persistLaunchConfiguration: () => undefined,
+      createAuthorityLifecycle: () => {
+        throw new Error("fixture authority lifecycle is not used");
+      },
+      projectStartedStatus: () => ({})
+    }, hooks), (error: unknown) => error instanceof AggregateError);
+
+    const recordText = persistedTerminationRecord(userRoot);
+    const record = JSON.parse(recordText) as {
+      readonly event?: unknown;
+      readonly hint?: unknown;
+    };
+    assert.equal(record.event, "daemon.lifecycle.terminated");
+    assert.match(String(record.hint), /AggregateError: fixture stop aggregate/u);
+    assert.match(String(record.hint), /Error: fixture nested stop cause/u);
+    assert.match(recordText, /fixture nested stop cause/u);
+  });
+});
+
+function persistedTerminationRecord(userRoot: string): string {
+  const logRoot = path.join(userRoot, "logs", "harness-anything");
+  const lines = readdirSync(logRoot)
+    .filter((name) => name.endsWith(".ndjson"))
+    .sort()
+    .flatMap((name) => readFileSync(path.join(logRoot, name), "utf8").split("\n"))
+    .filter((line) => line.trim().length > 0);
+  const record = lines.findLast((line) => {
+    const parsed = JSON.parse(line) as { readonly event?: unknown };
+    return parsed.event === "daemon.lifecycle.terminated";
+  });
+  assert.ok(record, "expected a persisted daemon.lifecycle.terminated record");
+  return record;
+}

--- a/packages/daemon/src/lifecycle/daemon-failure-diagnostic.ts
+++ b/packages/daemon/src/lifecycle/daemon-failure-diagnostic.ts
@@ -1,0 +1,40 @@
+export function formatDaemonFailure(error: unknown): string {
+  const messages: string[] = [];
+  collectDaemonFailure(error, messages, new Set<unknown>());
+  return messages.join(" | ") || String(error);
+}
+
+export function repoWriteGracefulFailureLog(error: unknown) {
+  return {
+    level: "warn" as const,
+    source: "daemon" as const,
+    component: "repo-write-child",
+    event: "repo-write.stop.graceful-failed",
+    message: `Repo writer graceful shutdown failed, but child exit was confirmed: ${formatDaemonFailure(error)}`,
+    errorCode: error instanceof Error
+      && "code" in error
+      && typeof error.code === "string"
+      ? error.code
+      : "REPO_WRITE_GRACEFUL_SHUTDOWN_FAILED"
+  };
+}
+
+function collectDaemonFailure(
+  error: unknown,
+  messages: string[],
+  seen: Set<unknown>
+): void {
+  if (error !== null && typeof error === "object") {
+    if (seen.has(error)) return;
+    seen.add(error);
+  }
+  if (error instanceof Error) {
+    messages.push(`${error.name}: ${error.message}`);
+    if (error instanceof AggregateError) {
+      for (const nested of error.errors) collectDaemonFailure(nested, messages, seen);
+    }
+    if (error.cause !== undefined) collectDaemonFailure(error.cause, messages, seen);
+    return;
+  }
+  messages.push(String(error));
+}

--- a/packages/daemon/src/lifecycle/run-daemon-serve.ts
+++ b/packages/daemon/src/lifecycle/run-daemon-serve.ts
@@ -50,6 +50,10 @@ import {
   createProvenanceCapacityTelemetryTrigger
 } from "../observability/provenance-capacity-trigger.ts";
 import { scheduleProvenanceCapacityLog } from "../observability/provenance-capacity-log.ts";
+import {
+  formatDaemonFailure,
+  repoWriteGracefulFailureLog
+} from "./daemon-failure-diagnostic.ts";
 
 export type DaemonServeRepo = DaemonRepoNamespace & Pick<DaemonRegistryRepo, "displayName" | "authorityManifestPath">;
 
@@ -369,6 +373,9 @@ export async function runDaemonServe<
                 errorCode: diagnostic.code,
                 requestId: diagnostic.requestId
               }, { repo }).catch(() => undefined);
+            },
+            onGracefulStopFailure: async (error) => {
+              await daemonLogService.append(repoWriteGracefulFailureLog(error), { repo });
             }
           });
           repoWriteSupervisors.set(repo.repoId, supervisor);
@@ -447,7 +454,7 @@ export async function runDaemonServe<
     } catch (error) {
       failure = error;
       terminalReason = `unexpected-error:${error instanceof Error ? error.name : "unknown"}`;
-      terminalMessage = `Daemon service terminated after an unexpected error: ${error instanceof Error ? `${error.name}: ${error.message}` : String(error)}`;
+      terminalMessage = `Daemon service terminated after an unexpected error: ${formatDaemonFailure(error)}`;
     }
     try {
       let stoppedByHost = false;
@@ -473,9 +480,10 @@ export async function runDaemonServe<
       }
     } catch (error) {
       failure ??= error;
+      const cleanupTrigger = terminalReason ?? "unknown stop trigger";
       terminalClean = false;
       terminalReason = `shutdown-error:${error instanceof Error ? error.name : "unknown"}`;
-      terminalMessage = `Daemon service cleanup failed: ${error instanceof Error ? `${error.name}: ${error.message}` : String(error)}`;
+      terminalMessage = `Daemon service cleanup after ${cleanupTrigger} failed: ${formatDaemonFailure(error)}`;
     }
     if (lifecycleStarted && serviceHost) {
       try {

--- a/packages/daemon/src/lifecycle/run-daemon-serve.ts
+++ b/packages/daemon/src/lifecycle/run-daemon-serve.ts
@@ -59,6 +59,7 @@ export type DaemonServeRepo = DaemonRepoNamespace & Pick<DaemonRegistryRepo, "di
 
 export interface DaemonServeHooks {
   readonly onStarted?: (status: Record<string, unknown>) => void;
+  readonly onStop?: () => Promise<void>;
   readonly authorityLifecycle?: AuthorityRepoLifecycleController;
 }
 
@@ -420,6 +421,7 @@ export async function runDaemonServe<
         transportStarted = false;
         await transport.stop();
       });
+      if (hooks.onStop) serviceHost.onStop(hooks.onStop);
       if (input.requestedAuthorityManifest) {
         persistAuthorityManifestPointer(input.requestedAuthorityManifest, userRoot);
       }

--- a/packages/daemon/src/runtime/repo-write-child-exit.ts
+++ b/packages/daemon/src/runtime/repo-write-child-exit.ts
@@ -1,0 +1,43 @@
+import type { ChildProcess } from "node:child_process";
+
+export function terminateRepoWriteChildAndWait(
+  child: ChildProcess,
+  signal: NodeJS.Signals,
+  timeoutMs: number
+): Promise<void> {
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    return Promise.reject(new Error("repo writer child exit timeout must be a positive safe integer"));
+  }
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.off("exit", onExit);
+      child.off("error", onError);
+      if (error) reject(error);
+      else resolve();
+    };
+    const onExit = () => finish();
+    const onError = (error: Error) => finish(error);
+    const timer = setTimeout(() => {
+      finish(new Error(
+        `Repo writer child pid ${child.pid ?? "unknown"} did not exit after ${signal}.`
+      ));
+    }, timeoutMs);
+    timer.unref();
+    child.once("exit", onExit);
+    child.once("error", onError);
+    if (child.exitCode !== null || child.signalCode !== null) {
+      finish();
+      return;
+    }
+    try {
+      child.kill(signal);
+    } catch (error) {
+      finish(error instanceof Error ? error : new Error(String(error)));
+    }
+  });
+}

--- a/packages/daemon/src/runtime/repo-write-child-process-transport.ts
+++ b/packages/daemon/src/runtime/repo-write-child-process-transport.ts
@@ -24,6 +24,7 @@ import {
   type RepoWriteParentMessage,
   type RepoWriteProtocolLimits
 } from "./repo-write-protocol.ts";
+import { terminateRepoWriteChildAndWait } from "./repo-write-child-exit.ts";
 
 export interface RepoWriteProcessTransportLimits {
   readonly maxBufferedMessages: number;
@@ -167,6 +168,10 @@ export class RepoWriteParentProcessTransport implements RepoWriteClientTransport
 
   terminate(signal: NodeJS.Signals = "SIGTERM"): boolean {
     return this.child.kill(signal);
+  }
+
+  terminateAndWait(signal: NodeJS.Signals, timeoutMs: number): Promise<void> {
+    return terminateRepoWriteChildAndWait(this.child, signal, timeoutMs);
   }
 
   private readonly handleMessage = (value: unknown): void => {

--- a/packages/daemon/src/runtime/repo-write-process-supervisor.ts
+++ b/packages/daemon/src/runtime/repo-write-process-supervisor.ts
@@ -25,12 +25,19 @@ export interface RepoWriteProcessSupervisorOptions {
   readonly onDiagnostic?: ConstructorParameters<typeof RepoWriteClient>[0]["onDiagnostic"];
   readonly onRequestTimeout?: ConstructorParameters<typeof RepoWriteClient>[0]["onRequestTimeout"];
   readonly onRequestFailure?: ConstructorParameters<typeof RepoWriteClient>[0]["onRequestFailure"];
+  readonly onGracefulStopFailure?: (error: unknown) => void | Promise<void>;
 }
 
 interface ActiveWriter {
   readonly transport: RepoWriteParentProcessTransport;
   readonly client: RepoWriteClient;
 }
+
+export interface RepoWriteProcessSupervisorStopOptions {
+  readonly timeoutMs?: number;
+}
+
+const defaultRepoWriteStopTimeoutMs = 4_000;
 
 /**
  * Keeps one child process bound to one repo/writer generation. A submission is
@@ -114,16 +121,44 @@ export class RepoWriteProcessSupervisor {
     }
   }
 
-  async stop(): Promise<void> {
+  async stop(options: RepoWriteProcessSupervisorStopOptions = {}): Promise<void> {
     this.closing = true;
     const writer = this.active;
     if (!writer) return;
+    const timeoutMs = options.timeoutMs ?? defaultRepoWriteStopTimeoutMs;
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+      throw new Error("repo writer stop timeout must be a positive safe integer");
+    }
+    const deadline = Date.now() + timeoutMs;
+    let gracefulError: unknown;
     try {
       if (this.writerConnected(writer)) {
-        await writer.client.shutdown();
+        try {
+          await writer.client.shutdown({ timeoutMs: phaseTimeout(deadline, 2) });
+        } catch (error) {
+          gracefulError = error;
+        }
+      }
+      try {
+        await writer.transport.terminateAndWait("SIGTERM", phaseTimeout(deadline, 2));
+      } catch (termError) {
+        try {
+          await writer.transport.terminateAndWait("SIGKILL", remainingTimeout(deadline));
+        } catch (killError) {
+          throw new AggregateError(
+            [gracefulError, termError, killError].filter((error) => error !== undefined),
+            "failed to terminate repo writer child"
+          );
+        }
+      }
+      if (gracefulError !== undefined) {
+        try {
+          await this.options.onGracefulStopFailure?.(gracefulError);
+        } catch {
+          // A diagnostic observer cannot turn a confirmed child exit into a stop failure.
+        }
       }
     } finally {
-      writer.transport.terminate("SIGTERM");
       if (this.active === writer) this.active = undefined;
     }
   }
@@ -253,6 +288,14 @@ export class RepoWriteProcessSupervisor {
       && writer.transport.child.exitCode === null
       && writer.transport.child.signalCode === null;
   }
+}
+
+function phaseTimeout(deadline: number, phasesRemaining: number): number {
+  return Math.max(1, Math.floor(remainingTimeout(deadline) / phasesRemaining));
+}
+
+function remainingTimeout(deadline: number): number {
+  return Math.max(1, deadline - Date.now());
 }
 
 function decodeReceipt(

--- a/packages/daemon/src/runtime/repo-write-process-supervisor.ts
+++ b/packages/daemon/src/runtime/repo-write-process-supervisor.ts
@@ -37,7 +37,10 @@ export interface RepoWriteProcessSupervisorStopOptions {
   readonly timeoutMs?: number;
 }
 
-const defaultRepoWriteStopTimeoutMs = 4_000;
+// Parent runtime drain does not own in-flight child IPC submissions. Without an
+// outer stop deadline, retain the client's established graceful-drain window.
+const defaultRepoWriteGracefulStopTimeoutMs = 30_000;
+const defaultRepoWriteTerminationPhaseTimeoutMs = 2_000;
 
 /**
  * Keeps one child process bound to one repo/writer generation. A submission is
@@ -125,25 +128,41 @@ export class RepoWriteProcessSupervisor {
     this.closing = true;
     const writer = this.active;
     if (!writer) return;
-    const timeoutMs = options.timeoutMs ?? defaultRepoWriteStopTimeoutMs;
-    if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    if (options.timeoutMs !== undefined
+      && (!Number.isSafeInteger(options.timeoutMs) || options.timeoutMs <= 0)) {
       throw new Error("repo writer stop timeout must be a positive safe integer");
     }
-    const deadline = Date.now() + timeoutMs;
+    const deadline = options.timeoutMs === undefined
+      ? undefined
+      : Date.now() + options.timeoutMs;
     let gracefulError: unknown;
     try {
       if (this.writerConnected(writer)) {
         try {
-          await writer.client.shutdown({ timeoutMs: phaseTimeout(deadline, 2) });
+          await writer.client.shutdown({
+            timeoutMs: deadline === undefined
+              ? defaultRepoWriteGracefulStopTimeoutMs
+              : phaseTimeout(deadline, 2)
+          });
         } catch (error) {
           gracefulError = error;
         }
       }
       try {
-        await writer.transport.terminateAndWait("SIGTERM", phaseTimeout(deadline, 2));
+        await writer.transport.terminateAndWait(
+          "SIGTERM",
+          deadline === undefined
+            ? defaultRepoWriteTerminationPhaseTimeoutMs
+            : phaseTimeout(deadline, 2)
+        );
       } catch (termError) {
         try {
-          await writer.transport.terminateAndWait("SIGKILL", remainingTimeout(deadline));
+          await writer.transport.terminateAndWait(
+            "SIGKILL",
+            deadline === undefined
+              ? defaultRepoWriteTerminationPhaseTimeoutMs
+              : remainingTimeout(deadline)
+          );
         } catch (killError) {
           throw new AggregateError(
             [gracefulError, termError, killError].filter((error) => error !== undefined),

--- a/packages/daemon/src/service/repo-write-service-policy.ts
+++ b/packages/daemon/src/service/repo-write-service-policy.ts
@@ -10,12 +10,18 @@ export function remainWedgedAfterFailedDrain(): Promise<never> {
 
 export function registerRepoWriteSupervisorStops(
   stopHandlers: Array<() => Promise<void>>,
-  supervisors: ReadonlyMap<string, RepoWriteProcessSupervisor> | undefined
+  supervisors: ReadonlyMap<string, RepoWriteProcessSupervisor> | undefined,
+  stopTimeoutMs?: () => number | undefined
 ): void {
   if (!supervisors) return;
   stopHandlers.push(async () => {
     const results = await Promise.allSettled(
-      [...supervisors.values()].map((supervisor) => supervisor.stop())
+      [...supervisors.values()].map((supervisor) => {
+        const timeoutMs = stopTimeoutMs?.();
+        return timeoutMs === undefined
+          ? supervisor.stop()
+          : supervisor.stop({ timeoutMs });
+      })
     );
     const failures = results
       .filter((result): result is PromiseRejectedResult =>

--- a/packages/daemon/src/service/service-host.ts
+++ b/packages/daemon/src/service/service-host.ts
@@ -133,7 +133,6 @@ export async function createDaemonServiceHost<
   const daemonLogService = providedDaemonLogService
     ?? makeDaemonLogService({ store: makeDaemonLogFileStore({ userRoot }) });
   const stopHandlers: Array<() => Promise<void>> = [];
-  registerRepoWriteSupervisorStops(stopHandlers, repoWriteSupervisors);
   const reposById = new Map(repos.map((repo) => [repo.repoId, repo]));
   const buildIdentity = installDaemonBuildWriteGuard({
     runtime, repos, defaultRepoId, build, daemonLogService
@@ -146,7 +145,13 @@ export async function createDaemonServiceHost<
   let reconciling = false;
   let stopping = false;
   let drainTimeoutMs: number | undefined;
+  let stopDeadlineAt: number | undefined;
   let activeControl: DaemonActiveControlStatus | null = null;
+  registerRepoWriteSupervisorStops(
+    stopHandlers,
+    repoWriteSupervisors,
+    () => remainingStopTimeout(stopDeadlineAt)
+  );
   const idleExit = createDaemonIdleExitScheduler({
     idleMs,
     isStopping: () => stopping,
@@ -163,7 +168,9 @@ export async function createDaemonServiceHost<
       await drainDaemonRuntime({
         authorityLifecycle,
         runtime,
-        drainTimeoutMs
+        drainTimeoutMs: stopDeadlineAt === undefined
+          ? drainTimeoutMs
+          : Math.max(0, stopDeadlineAt - Date.now())
       });
     } catch (error) {
       if (isDaemonDrainTimeout(error) && activeControl) {
@@ -179,8 +186,16 @@ export async function createDaemonServiceHost<
       }
       throw error;
     }
+    const failures: unknown[] = [];
     for (const handler of stopHandlers.splice(0, stopHandlers.length)) {
-      await handler();
+      try {
+        await handler();
+      } catch (error) {
+        failures.push(error);
+      }
+    }
+    if (failures.length > 0) {
+      throw new AggregateError(failures, "failed to stop daemon service handlers");
     }
   };
   const scheduleIdleExit = idleExit.schedule;
@@ -200,7 +215,10 @@ export async function createDaemonServiceHost<
     status: () => serviceStatus(defaultRepoId),
     activeControl: () => activeControl,
     setActiveControl: (active) => { activeControl = active; },
-    setDrainTimeout: (timeoutMs) => { drainTimeoutMs = timeoutMs; },
+    setDrainTimeout: (timeoutMs) => {
+      drainTimeoutMs = timeoutMs;
+      stopDeadlineAt = Date.now() + timeoutMs;
+    },
     requestStop: (request) => requestStop?.(request)
   }, hostServices.errors);
   publishRuntimeRegistrationSnapshot({ userRoot, ...build, runtimeStatus: runtime.status() });
@@ -401,6 +419,10 @@ export async function createDaemonServiceHost<
       ...(includeGenerationAxes ? { includeGenerationAxes: true as const } : {})
     });
   }
+}
+
+function remainingStopTimeout(deadline: number | undefined): number | undefined {
+  return deadline === undefined ? undefined : Math.max(1, deadline - Date.now() - 1);
 }
 
 function createRepoServiceBinding<

--- a/packages/daemon/test/daemon-autostart-recovery.test.ts
+++ b/packages/daemon/test/daemon-autostart-recovery.test.ts
@@ -1,0 +1,133 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { rmSync } from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import { createInterface } from "node:readline";
+import test from "node:test";
+import {
+  DaemonAutostartTimeoutError,
+  replaceSpawnLocalDaemonForTest,
+  requestLocalDaemonJsonRpcForTarget,
+  type LocalDaemonTarget
+} from "../src/client/local-json-rpc-client.ts";
+import {
+  encodeJsonLineFrame,
+  type JsonObject,
+  type JsonRpcRequest
+} from "../src/index.ts";
+
+const legacyAutostartBudgetMs = 6_000;
+const injectedColdStartDelayMs = legacyAutostartBudgetMs + 250;
+
+test("two commands recover through one daemon whose cold readiness exceeds the legacy budget", async (context) => {
+  if (process.platform === "win32") return;
+  const socketPath = uniqueSocketPath("ha-daemon-cold-recovery");
+  const target = makeTarget(socketPath);
+  const launches: Array<Promise<void>> = [];
+  const servers: net.Server[] = [];
+  let spawnCalls = 0;
+  const restoreSpawn = replaceSpawnLocalDaemonForTest(() => {
+    spawnCalls += 1;
+    launches.push(startInjectedColdDaemon(socketPath, servers));
+  });
+  context.after(async () => {
+    restoreSpawn();
+    await Promise.allSettled(servers.map((server) => closeServer(server)));
+    rmSync(socketPath, { force: true });
+  });
+
+  const outcomes: Array<JsonObject | string> = [];
+  for (let command = 0; command < 2; command += 1) {
+    const outcome = await requestLocalDaemonJsonRpcForTarget(
+      target,
+      "repo.tasks.list",
+      { command },
+      100,
+      { entryPath: "/unused" }
+    ).catch((error: unknown) => error instanceof DaemonAutostartTimeoutError
+      ? error.message
+      : Promise.reject(error));
+    outcomes.push(outcome);
+    if (typeof outcome === "string") await launches.at(-1);
+  }
+
+  assert.deepEqual(outcomes, [
+    { ok: true, method: "repo.tasks.list" },
+    { ok: true, method: "repo.tasks.list" }
+  ]);
+  assert.equal(spawnCalls, 1);
+});
+
+function startInjectedColdDaemon(
+  socketPath: string,
+  servers: net.Server[]
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      void startJsonRpcServer(socketPath).then((server) => {
+        servers.push(server);
+        const idleExit = setTimeout(() => {
+          void closeServer(server).then(resolve, reject);
+        }, 100);
+        server.on("request-served", () => clearTimeout(idleExit));
+      }, reject);
+    }, injectedColdStartDelayMs);
+  });
+}
+
+async function startJsonRpcServer(socketPath: string): Promise<net.Server> {
+  rmSync(socketPath, { force: true });
+  const server = net.createServer((socket) => {
+    const lines = createInterface({ input: socket });
+    lines.on("line", (line) => {
+      const request = JSON.parse(line) as JsonRpcRequest;
+      const result: JsonObject = request.method === "protocol.hello"
+        ? { ok: true }
+        : { ok: true, method: request.method };
+      socket.write(encodeJsonLineFrame({
+        jsonrpc: "2.0",
+        id: request.id ?? null,
+        result
+      }));
+      if (request.method !== "protocol.hello") server.emit("request-served");
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  return server;
+}
+
+function closeServer(server: net.Server): Promise<void> {
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+function makeTarget(socketPath: string): LocalDaemonTarget {
+  return {
+    repoId: "canonical",
+    canonicalRoot: "/tmp/canonical",
+    userRoot: "/tmp/ha-user-root",
+    daemonId: "default",
+    socketPath,
+    legacySocketPath: `${socketPath}.legacy`,
+    registered: true
+  };
+}
+
+function uniqueSocketPath(prefix: string): string {
+  return path.join(
+    "/tmp",
+    `${prefix}-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}.sock`
+  );
+}

--- a/packages/daemon/test/daemon-shutdown-diagnostic.test.ts
+++ b/packages/daemon/test/daemon-shutdown-diagnostic.test.ts
@@ -1,0 +1,31 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  formatDaemonFailure,
+  repoWriteGracefulFailureLog
+} from "../src/lifecycle/daemon-failure-diagnostic.ts";
+
+test("daemon cleanup diagnostics retain every nested AggregateError reason", () => {
+  const failure = new AggregateError([
+    new Error("repo alpha graceful drain failed"),
+    new AggregateError([
+      new Error("repo beta did not exit after SIGKILL")
+    ], "repo beta termination failed")
+  ], "failed to stop daemon service handlers");
+
+  const diagnostic = formatDaemonFailure(failure);
+
+  assert.match(diagnostic, /AggregateError: failed to stop daemon service handlers/u);
+  assert.match(diagnostic, /Error: repo alpha graceful drain failed/u);
+  assert.match(diagnostic, /AggregateError: repo beta termination failed/u);
+  assert.match(diagnostic, /Error: repo beta did not exit after SIGKILL/u);
+});
+
+test("confirmed child exit preserves the graceful shutdown failure as a warning", () => {
+  const log = repoWriteGracefulFailureLog(new Error("fixture drain failed"));
+
+  assert.equal(log.event, "repo-write.stop.graceful-failed");
+  assert.match(log.message, /child exit was confirmed/u);
+  assert.match(log.message, /Error: fixture drain failed/u);
+});

--- a/packages/daemon/test/repo-write-process-supervisor.test.ts
+++ b/packages/daemon/test/repo-write-process-supervisor.test.ts
@@ -7,7 +7,8 @@ import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 import {
-  forkRepoWriteProcess
+  forkRepoWriteProcess,
+  type RepoWriteParentProcessTransport
 } from "../src/runtime/repo-write-child-process-transport.ts";
 import {
   RepoWriteProcessSupervisor,
@@ -30,6 +31,7 @@ import {
 } from "../src/observability/request-performance.ts";
 import { classifyProvenanceCapacitySample } from "../src/observability/provenance-capacity-trigger.ts";
 import { repoWriteProductionCommandFixture } from "./support/repo-write-production-command-fixture.ts";
+import { forceTerminateChildAndWait } from "../../../tools/test-child-process-lifecycle.mjs";
 
 const fixturePath = fileURLToPath(
   new URL("./support/repo-write-ipc-child.ts", import.meta.url)
@@ -81,6 +83,72 @@ test("supervisor submits through one child and drains it without inline fallback
   assert.equal(supervisor.status().connected, true);
   await supervisor.stop();
   assert.equal(supervisor.status().connected, false);
+});
+
+test("a failed graceful drain still stops the child without reporting a false stop failure", {
+  skip: process.platform === "win32" ? "POSIX child signal semantics are required" : false
+}, async (context) => {
+  let transport: RepoWriteParentProcessTransport | undefined;
+  const gracefulStopFailures: unknown[] = [];
+  const supervisor = new RepoWriteProcessSupervisor({
+    repoId: "repo-transport",
+    generation: 1,
+    onGracefulStopFailure: (error) => {
+      gracefulStopFailures.push(error);
+    },
+    spawn: () => {
+      transport = forkRepoWriteProcess({
+        modulePath: fixturePath,
+        args: ["shutdown-failure"]
+      });
+      return transport;
+    }
+  });
+  context.after(async () => {
+    if (transport?.child.exitCode === null && transport.child.signalCode === null) {
+      await forceTerminateChildAndWait(transport.child, {
+        label: "failed-drain repo writer cleanup"
+      });
+    }
+  });
+
+  await supervisor.start();
+  await supervisor.stop({ timeoutMs: 500 });
+
+  assert.equal(supervisor.status().connected, false);
+  assert.equal(transport?.child.signalCode, "SIGTERM");
+  assert.equal(gracefulStopFailures.length, 1);
+  assert.match(String(gracefulStopFailures[0]), /fixture graceful drain failed/u);
+});
+
+test("stop escalates past an ignored SIGTERM and confirms the child is gone", {
+  skip: process.platform === "win32" ? "POSIX child signal semantics are required" : false
+}, async (context) => {
+  let transport: RepoWriteParentProcessTransport | undefined;
+  const supervisor = new RepoWriteProcessSupervisor({
+    repoId: "repo-transport",
+    generation: 1,
+    spawn: () => {
+      transport = forkRepoWriteProcess({
+        modulePath: fixturePath,
+        args: ["ignore-sigterm-shutdown-failure"]
+      });
+      return transport;
+    }
+  });
+  context.after(async () => {
+    if (transport?.child.exitCode === null && transport.child.signalCode === null) {
+      await forceTerminateChildAndWait(transport.child, {
+        label: "SIGTERM-resistant repo writer cleanup"
+      });
+    }
+  });
+
+  await supervisor.start();
+  await supervisor.stop({ timeoutMs: 500 });
+
+  assert.equal(supervisor.status().connected, false);
+  assert.equal(transport?.child.signalCode, "SIGKILL");
 });
 
 test("expected direct rejection returns a failed receipt without replacing the writer", async (context) => {

--- a/packages/daemon/test/repo-write-process-supervisor.test.ts
+++ b/packages/daemon/test/repo-write-process-supervisor.test.ts
@@ -121,6 +121,40 @@ test("a failed graceful drain still stops the child without reporting a false st
   assert.match(String(gracefulStopFailures[0]), /fixture graceful drain failed/u);
 });
 
+test("the default stop budget does not preempt a child that drains gracefully", {
+  skip: process.platform === "win32" ? "POSIX child signal semantics are required" : false
+}, async (context) => {
+  let transport: RepoWriteParentProcessTransport | undefined;
+  const gracefulStopFailures: unknown[] = [];
+  const supervisor = new RepoWriteProcessSupervisor({
+    repoId: "repo-transport",
+    generation: 1,
+    onGracefulStopFailure: (error) => {
+      gracefulStopFailures.push(error);
+    },
+    spawn: () => {
+      transport = forkRepoWriteProcess({
+        modulePath: fixturePath,
+        args: ["slow-shutdown-success"]
+      });
+      return transport;
+    }
+  });
+  context.after(async () => {
+    if (transport?.child.exitCode === null && transport.child.signalCode === null) {
+      await forceTerminateChildAndWait(transport.child, {
+        label: "slow-drain repo writer cleanup"
+      });
+    }
+  });
+
+  await supervisor.start();
+  await supervisor.stop();
+
+  assert.deepEqual(gracefulStopFailures, []);
+  assert.equal(transport?.child.signalCode, "SIGTERM");
+});
+
 test("stop escalates past an ignored SIGTERM and confirms the child is gone", {
   skip: process.platform === "win32" ? "POSIX child signal semantics are required" : false
 }, async (context) => {

--- a/packages/daemon/test/support/repo-write-ipc-child.ts
+++ b/packages/daemon/test/support/repo-write-ipc-child.ts
@@ -179,6 +179,18 @@ if (mode === "expected-direct-rejection") {
       return;
     }
     if (message.kind === "shutdown") {
+      if (mode === "slow-shutdown-success") {
+        setTimeout(() => {
+          void transport.send({
+            protocol: repoWriteProtocolType,
+            repoId: message.repoId,
+            generation: message.generation,
+            kind: "drained",
+            requestId: message.requestId
+          });
+        }, 2_250);
+        return;
+      }
       if (mode === "shutdown-failure" || mode === "ignore-sigterm-shutdown-failure") {
         void transport.send({
           protocol: repoWriteProtocolType,

--- a/packages/daemon/test/support/repo-write-ipc-child.ts
+++ b/packages/daemon/test/support/repo-write-ipc-child.ts
@@ -9,6 +9,10 @@ import { appendFileSync } from "node:fs";
 const mode = process.argv[2] ?? "roundtrip";
 const tracePath = process.argv[3];
 
+if (mode === "ignore-sigterm-shutdown-failure") {
+  process.on("SIGTERM", () => undefined);
+}
+
 if (mode === "expected-direct-rejection") {
   const transport = new RepoWriteChildIpcTransport();
   transport.onDisconnect(() => setImmediate(() => process.exit()));
@@ -175,6 +179,21 @@ if (mode === "expected-direct-rejection") {
       return;
     }
     if (message.kind === "shutdown") {
+      if (mode === "shutdown-failure" || mode === "ignore-sigterm-shutdown-failure") {
+        void transport.send({
+          protocol: repoWriteProtocolType,
+          repoId: message.repoId,
+          generation: message.generation,
+          kind: "failure",
+          requestId: message.requestId,
+          phase: "before-proceed",
+          outcome: "not-started",
+          replay: "caller-may-retry",
+          code: "SHUTDOWN_FAILED",
+          diagnostic: "fixture graceful drain failed"
+        });
+        return;
+      }
       void transport.send({
         protocol: repoWriteProtocolType,
         repoId: message.repoId,


### PR DESCRIPTION
# English

## Summary

Over five days this repo's daemon terminated 87 times. **83 were clean. The other 4 all
reported the same thing and none of them could be diagnosed:**

```
reason:  shutdown-error:AggregateError
hint:    Daemon service cleanup failed: AggregateError: failed to stop repo writer children
```

`AggregateError.errors[]` never reached the log, so after four incidents the question
"why couldn't it stop them?" was still unanswerable from the record. Worse, one of those
unclean exits is what fed the write-path self-wedge on 2026-08-05: an unclean daemon exit
is what autostart then has to recover from.

This PR makes the stop path **honest about what actually happened** and makes the record
**able to answer why** the next time.

## What Changed

**1. "Failed to stop" now means it actually failed.** The old `stop()` awaited
`client.shutdown()` and, in a `finally`, called `transport.terminate("SIGTERM")` — which
only returns `child.kill()`'s boolean and **never waits for `exit`**. So a failed graceful
drain was escalated straight into a daemon-fatal `clean: false`, with no evidence either
way about whether the child had died. Now: graceful shutdown → SIGTERM **and wait for
exit** → if needed SIGKILL **and wait for exit**. A stop failure is reported only when the
child is still unconfirmed after SIGKILL. A graceful drain that failed while the child
exit *was* confirmed is recorded as a `repo-write.stop.graceful-failed` warning instead of
claiming the daemon died unexpectedly.

**2. The terminal record now carries nested causes.** `formatDaemonFailure` walks
`AggregateError.errors[]` and `cause` chains, and the terminal message keeps the original
stop trigger (`cleanup after idle-timeout failed: …`) rather than discarding it.

**3. One failing stop handler no longer cancels the rest.** `service-host.ts` ran
`for (const handler of stopHandlers) await handler()` with no `try`, and the repo-write
supervisor stop was registered *first*. Every handler now runs; failures aggregate at the
end.

**4. Child stop deadlines are strictly inside the parent's.** The client's shutdown
default was 30s while the CLI control parent budget defaults to 5s — a deadline inversion.
When an outer stop deadline exists, the remaining budget is now split so the child's
deadline is strictly under the parent's.

**5. A behavioural autostart-recovery gate.** After an unclean daemon exit, the next
command recovers. The gate asserts behaviour with an injected slow start; **it asserts no
millisecond literal**, because startup time is an environment quantity and pinning it
would build an instrument that stays green while lying.

## Task And Scope

- Harness task: `task_01KZ8VYVMDDRP2XXH211FFVA0T`
- Branch: `codex/daemon-stop-honesty`
- Public scope: `packages/daemon/src/{lifecycle,runtime,service}` and tests in
  `packages/daemon/test`, `packages/cli/test`
- Private planning/evidence updated: yes (task plan, decision)
- Out of scope: the idle-timeout policy itself. The measurement was done here, but
  changing the default is a separate adjudicated change — see below.

## Version Impact

- Version: no version change because this is an internal correctness fix with no published
  surface change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KZ8VYVMDDRP2XXH211FFVA0T` scope items 1–2. The idle-policy finding
  from item 3 was adjudicated separately as `dec_01KZA1ZS0JHS9ZRQXESMC1W5HB` (active) and
  **is deliberately not implemented in this PR**.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide
  whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: implementation of `dec_01KZA1ZS0JHS9ZRQXESMC1W5HB`

## Verification

- Base `origin/main` SHA: `b78320faf47026da3e774927082858b524524627`
- Branch merge-base with `origin/main`: `b78320faf47026da3e774927082858b524524627`
- Last `git fetch origin` time: 2026-08-06, immediately before opening this PR
- Sync method: rebase (main advanced twice during the work; both advances were in this
  branch's forbidden path set and the diff contains none of them)
- Public diff command: `git diff b78320fa..26f8c12d`
- Private evidence commit/path: `harness/tasks/task_01KZ8VYVMDDRP2XXH211FFVA0T-daemon-autostart-idle-timeout/`
- Reviewer evidence path: same package
- GitHub Actions `rewrite-ci` run URL: this PR's run
- [x] `git diff --check`
- [x] `npm run check:stop-point` — `npm run check:local` exit 0, 78.1s, 27 gates green;
  fast 721/721; contract 253 pass, 1 expected skip, 0 fail
- [x] Targeted tests for the change surface, named with their counts: 31/31, plus the new
  persisted-record integration test 1/1
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: nothing was skipped that should have run.

**Negative controls — each fix has one, and each was actually executed:**

| Fix | Control | Observed when the fix is withdrawn |
|---|---|---|
| Honest stop outcome | supervisor stop with a child whose graceful drain fails | red with `RepoWriteDrainError: fixture graceful drain failed` |
| SIGKILL escalation | child that ignores SIGTERM | red — exit never confirmed |
| Nested-cause diagnostics | revert the call site to `error.message` | red; the on-disk record was literally `Daemon service cleanup after idle-timeout failed: failed to stop daemon service handlers`, missing both nested reasons |
| Handler aggregation | remove the aggregation | red — actual events were `["runtime:stop","repo-writer:stop"]`, `transport:stop` never ran |
| Autostart budget | restore the old budget under injected slow start | red with two consecutive `DAEMON_AUTOSTART_TIMEOUT` |

**The diagnostics gate is pinned to the artifact, not to the formatter.** An earlier round
tested `formatDaemonFailure` as a pure function. That would have stayed green if someone
reverted the call site — i.e. the exact defect (a record that cannot answer why) would
have come back under a green test. The gate now starts a real `runDaemonServe`, registers
a stop handler that throws a nested `AggregateError`, waits for the daemon to stop, then
**reads the `.ndjson` off disk** and asserts the persisted `daemon.lifecycle.terminated`
message contains the inner reasons.

## Review Evidence

- Self-review: CEO read both commits in full and raised two findings, both of which
  changed the PR:
  1. the diagnostics gate tested the formatter rather than the persisted record (fixed
     above);
  2. the first round introduced `defaultRepoWriteStopTimeoutMs = 4_000`, shrinking the
     graceful drain window from 30s to ~2s. **CEO's own reasoning that this was safe was
     falsified.** `drainDaemonRuntime()` drains the *parent reader runtime* queue, but
     repo-write commands reach the child through `repoWriteDispatch → supervisor`, which
     is not in that queue — so after drain the child may still be flushing. A ~2s cut
     could turn a completable accepted write into outcome-unknown/recovery, and the direct
     lane has no equivalent replay guarantee. The constant was removed: with no outer
     deadline the established 30s graceful window stands, with 2s confirmation windows for
     SIGTERM/SIGKILL. A behavioural gate now covers it — a child that legitimately delays
     before returning `drained` is **red** under the 4s budget and green under 30s.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none outstanding; both findings above were resolved before this PR
  was opened.

## Residual Risk

- **The four historical incidents remain undiagnosed and always will be.** Their records
  do not contain the causes; this PR only guarantees the *next* one is answerable. The
  30s-vs-5s deadline inversion is a strong hypothesis — the 2026-08-03 incident's
  lifecycle-started→fatal interval was `31.021s` — but that is an inference from timing,
  not proof, and it is recorded as such.
- `DaemonServeHooks.onStop` is new public-ish surface on the serve hooks object, added so
  the persisted-record gate can inject a failing handler into a real daemon lifecycle. It
  forwards to the already-existing `serviceHost.onStop` registration and adds no new
  lifecycle machinery, but it is API surface that exists primarily for testability.
- Item 3 of the task produced a measurement and an adjudication, **not** an
  implementation. The 750ms idle default is still in the code. Note that the two persisted
  launch specs are already `--idle-ms 0`, so this is a code-default problem, not a
  live-configuration problem.

## References

- Task: `task_01KZ8VYVMDDRP2XXH211FFVA0T`
- Evidence: `harness/tasks/task_01KZ8VYVMDDRP2XXH211FFVA0T-daemon-autostart-idle-timeout/`
- Review: `dec_01KZA1ZS0JHS9ZRQXESMC1W5HB` (idle policy, activated from this task's
  measurement)

---

# 中文

## 概要

五天里这个仓的 daemon 终止了 87 次。**83 次干净,另外 4 次报的全是同一句话,而且一次都诊断不了:**

```
reason:  shutdown-error:AggregateError
hint:    Daemon service cleanup failed: AggregateError: failed to stop repo writer children
```

`AggregateError.errors[]` 从未进日志,所以四次事故过去了,「它为什么停不掉」这个问题
**在记录上无法回答**。更要紧的是,其中一次非正常退出正是 2026-08-05 写路自锁的上游——
autostart 要去恢复的,就是这种非正常退出。

本 PR 让停止路径**对实际发生的事说实话**,并让记录**下次能答出为什么**。

## 改动内容

**1.「停不掉」现在真的意味着停不掉。** 旧 `stop()` await `client.shutdown()`,并在
`finally` 里调 `transport.terminate("SIGTERM")`——那个函数**只返回 `child.kill()` 的
boolean,根本不等 `exit`**。于是一次失败的优雅 drain 被直接升格成 daemon fatal 的
`clean: false`,而「孩子到底死没死」两边都没有证据。现在是:优雅 shutdown →
SIGTERM **并等待退出** → 必要时 SIGKILL **并等待退出**;只有 SIGKILL 之后仍无法确认退出,
才报 stop failure。优雅 drain 失败但子进程退出**已确认**的情形,记为一条
`repo-write.stop.graceful-failed` warning,而不再声称 daemon 非正常退出。

**2. 终止记录现在带嵌套原因。** `formatDaemonFailure` 递归展开
`AggregateError.errors[]` 与 `cause` 链,终止消息还保留了原始的停止触发原因
(`cleanup after idle-timeout failed: …`),而不是把它丢掉。

**3. 一个 stop handler 失败不再掐掉其余。** `service-host.ts` 原本是无 `try` 的
`for (const handler of stopHandlers) await handler()`,而 repo-write supervisor 的 stop
恰好注册在**第一个**。现在所有 handler 依次执行,失败在最后聚合。

**4. 子进程停止 deadline 严格在父 deadline 之内。** client shutdown 默认 30s,
而 CLI control 父预算默认 5s——**时限反转**。存在外层 stop deadline 时,
剩余预算现在会被分割,保证子 deadline 严格小于父 deadline。

**5. 一道行为性的 autostart 恢复门。** daemon 非正常退出后,下一条命令能自行恢复。
该门用注入的慢启动断言行为,**不断言任何毫秒字面量**——启动耗时是环境量,
钉住它等于造一个会绿着骗人的仪器。

## 任务与范围

- Harness 任务:`task_01KZ8VYVMDDRP2XXH211FFVA0T`
- 分支:`codex/daemon-stop-honesty`
- 公开范围:`packages/daemon/src/{lifecycle,runtime,service}` 与
  `packages/daemon/test`、`packages/cli/test` 里的测试
- 私有规划/证据已更新:是(task plan、decision)
- 不在本 PR 范围:idle-timeout 策略本身。测量在本任务完成,但改默认值是另一件被单独裁决的事,见下。

## 版本影响

- 版本:不变,内部正确性修复,不改变已发布接口面。
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:否
- Protected surface 范围:不适用
- 授权依据:`task_01KZ8VYVMDDRP2XXH211FFVA0T` 范围第 1–2 项。第 3 项的 idle 策略结论已单独
  裁决为 `dec_01KZA1ZS0JHS9ZRQXESMC1W5HB`(active),**刻意不在本 PR 实现**。
- 机器检查边界:本 PR 只断言声明存在;声明是否属实、是否充分由评审者判断。
- Break-glass:否
- Break-glass 理由:不适用
- Break-glass 范围:不适用
- 后续治理任务:`dec_01KZA1ZS0JHS9ZRQXESMC1W5HB` 的落地实现

## 验证

- 基线 `origin/main` SHA:`b78320faf47026da3e774927082858b524524627`
- 分支与 `origin/main` 的 merge-base:`b78320faf47026da3e774927082858b524524627`
- 最近一次 `git fetch origin`:2026-08-06,开 PR 前
- 同步方式:rebase(工作期间 main 前进两次,两次都落在本分支的禁区路径里,diff 不含任何一处)
- 公开 diff 命令:`git diff b78320fa..26f8c12d`
- 私有证据 commit/路径:`harness/tasks/task_01KZ8VYVMDDRP2XXH211FFVA0T-daemon-autostart-idle-timeout/`
- 评审证据路径:同任务包
- GitHub Actions `rewrite-ci` run URL:本 PR 的 run
- [x] `git diff --check`
- [x] `npm run check:stop-point` —— `npm run check:local` 退出 0,78.1s,27 道 gate 全绿;
  fast 721/721;contract 253 pass、1 个预期 skip、0 fail
- [x] 改动面定向测试(带计数):31/31,外加新增的落盘记录 integration 测试 1/1
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- 未跑及原因:没有该跑而未跑的项。

**阴性对照——每条修复都有,而且都实跑过:**

| 修复 | 对照 | 撤掉修复后的实际观测 |
|---|---|---|
| 停止结果诚实 | 用一个优雅 drain 必失败的子进程跑 supervisor stop | 红,`RepoWriteDrainError: fixture graceful drain failed` |
| SIGKILL 升级 | 忽略 SIGTERM 的子进程 | 红——退出始终无法确认 |
| 嵌套原因诊断 | 把调用点退回 `error.message` | 红;磁盘上的记录字面是 `Daemon service cleanup after idle-timeout failed: failed to stop daemon service handlers`,两条嵌套原因都缺失 |
| handler 聚合 | 去掉聚合 | 红——实际事件是 `["runtime:stop","repo-writer:stop"]`,`transport:stop` 从未执行 |
| autostart 预算 | 注入慢启动下换回旧预算 | 红,连续两条 `DAEMON_AUTOSTART_TIMEOUT` |

**诊断那道门钉的是产物,不是格式化器。** 上一轮它测的是 `formatDaemonFailure` 这个纯函数——
那种门在有人把调用点改回 `error.message` 时**照样绿**,也就是说这个缺陷
(记录答不出为什么)会在一片绿灯下复活。现在的门会启动真实 `runDaemonServe`、
注册一个抛嵌套 `AggregateError` 的 stop handler、等 daemon 停下,
然后**从磁盘读 `.ndjson`**,断言落盘的 `daemon.lifecycle.terminated` 消息里含有内层原因。

## 审查证据

- 自审:CEO 通读两个 commit,提了两条,**两条都改变了本 PR**:
  1. 诊断那道门测的是格式化器而不是落盘记录(已按上文修正);
  2. 第一轮引入了 `defaultRepoWriteStopTimeoutMs = 4_000`,把优雅 drain 窗口从 30s
     压到约 2s。**CEO 自己「这样是安全的」的推理被证伪。**
     `drainDaemonRuntime()` 排空的是**父 reader runtime** 的队列,而 repo-write 命令
     经 `repoWriteDispatch → supervisor` 直接进入子进程,**不在那个队列里**——
     所以 drain 之后子进程仍可能在刷盘。约 2s 就切断,可能把一次本可完成的、已接受的写
     变成 outcome-unknown/recovery,而 direct lane 没有同等的 replay 保证。
     该常量已撤除:无外层 deadline 时保留既有 30s 优雅窗口,SIGTERM/SIGKILL 各有 2s 确认窗口。
     并补了行为门——一个会合法延迟后返回 `drained` 的子进程,在 4s 预算下**红**,30s 下绿。
- 复核 subagent:未使用
- 人工审查:待办
- 阻塞性发现:无未决项;上面两条都在开 PR 之前处置完毕。

## 残余风险

- **那四次历史事故仍然无法诊断,而且永远无法。** 它们的记录里没有原因;本 PR 只保证
  **下一次**能答。30s vs 5s 的时限反转是一个很有说服力的假设——2026-08-03 那次
  lifecycle-started→fatal 恰好是 `31.021s`——但那是从时序做的**推断而非证明**,并已如实记录。
- `DaemonServeHooks.onStop` 是 serve hooks 对象上新增的对外面,加它是为了让落盘记录那道门
  能把一个会失败的 handler 注入真实 daemon 生命周期。它只是转发到已经存在的
  `serviceHost.onStop` 注册,没有新增生命周期机制,但它确实是主要为可测性而存在的 API 面。
- 任务第 3 项产出的是**测量与裁决,不是实现**。750ms 的 idle 默认值仍在代码里。
  注意两份持久化 launch spec 已经是 `--idle-ms 0`,所以这是代码默认值的问题,
  不是现役配置的问题。

## 关联材料

- 任务:`task_01KZ8VYVMDDRP2XXH211FFVA0T`
- 证据:`harness/tasks/task_01KZ8VYVMDDRP2XXH211FFVA0T-daemon-autostart-idle-timeout/`
- 复核:`dec_01KZA1ZS0JHS9ZRQXESMC1W5HB`(idle 策略,由本任务的测量派生并已 active)
