### PR TITLE
fix(cli): map daemon command errors by semantic origin, not catch position

### DIFF
--- a/packages/cli/src/cli/error-codes.ts
+++ b/packages/cli/src/cli/error-codes.ts
@@ -55,6 +55,7 @@ export const CliErrorCode = {
   InvalidEvidence: "invalid_evidence",
   InvalidFactConfidence: "invalid_fact_confidence",
   InvalidFactId: "invalid_fact_id",
+  InvalidDaemonLogInput: "invalid_daemon_log_input",
   InvalidJsonInput: "invalid_json_input",
   InvalidFactMemoryClass: "invalid_fact_memory_class",
   InvalidFactMemoryTag: "invalid_fact_memory_tag",
@@ -98,6 +99,7 @@ export const CliErrorCode = {
   MissingPreset: "missing_preset",
   MissingProfile: "missing_profile",
   MissingReason: "missing_reason",
+  MissingRequiredOption: "missing_required_option",
   MissingSession: "missing_session",
   MissingSupersedeTarget: "missing_supersede_target",
   MissingTask: "missing_task",
@@ -152,6 +154,7 @@ export const CliErrorCode = {
   TerminalReopenRequiresSupersede: "terminal_reopen_requires_supersede",
   TerminalServiceUnavailable: "terminal_service_unavailable",
   TerminalStatusRequiresTaskComplete: "terminal_status_requires_task_complete",
+  UnclassifiedCommandFailure: "unclassified_command_failure",
   UnknownCommand: "unknown_command",
   UnknownHelpTopic: "unknown_help_topic",
   UserSettingsInvalid: "user_settings_invalid",
@@ -281,6 +284,7 @@ export const cliErrorCodeRegistry = {
   [CliErrorCode.InvalidDecisionTier]: { category: "parse", defaultHint: "The Decision tier is invalid because `--risk-tier` and `--urgency` accept only low, medium, or high. Correct the rejected option, then rerun the original `ha decision ...` command." },
   [CliErrorCode.InvalidEntrypoint]: { category: "parse", defaultHint: "The preset invocation was rejected because the named entrypoint is not declared by that preset. Run `ha preset inspect <id> --json`, choose a listed entrypoint, then retry." },
   [CliErrorCode.InvalidEvidence]: { category: "parse", defaultHint: "The evidence input was rejected because it does not match `type:PATH:summary`. Run `ha task progress append --help`, correct the `--evidence` value, then retry." },
+  [CliErrorCode.InvalidDaemonLogInput]: { category: "parse", defaultHint: "The daemon log query was rejected because `--limit`, `--cursor`, `--levels`, `--since`, or `--errors` failed validation. Run `ha daemon logs --help`, correct the reported option, then retry." },
   [CliErrorCode.InvalidFactConfidence]: { category: "parse", defaultHint: "The Fact input was rejected because confidence must be low, medium, or high. Run `ha fact record --help`, correct `--confidence`, then retry." },
   [CliErrorCode.InvalidFactId]: { category: "parse", defaultHint: "The Fact input was rejected because the id does not match the Fact id format. Run `ha fact list --task <task-id> --json`, copy an existing id or omit generated-id input, then retry." },
   [CliErrorCode.InvalidJsonInput]: { category: "parse", defaultHint: "The command input was rejected because `--json-input` or `--from-file` is malformed or conflicts with another input source. Run `ha capabilities --json`, correct the JSON against the command schema, then retry." },
@@ -326,6 +330,7 @@ export const cliErrorCodeRegistry = {
   [CliErrorCode.MissingPreset]: { category: "parse", defaultHint: "The preset command was rejected because its required preset id is missing. Run `ha preset list --json`, choose an id, then retry." },
   [CliErrorCode.MissingProfile]: { category: "parse", defaultHint: "The command was rejected because its required profile id is missing. Run `ha doctor --json`, select a configured profile, then retry with `--profile <id>`." },
   [CliErrorCode.MissingReason]: { category: "parse", defaultHint: "The lifecycle write was rejected because its auditable reason is missing. Run `ha task transition --help`, add `--reason <text>`, then retry." },
+  [CliErrorCode.MissingRequiredOption]: { category: "parse", defaultHint: "The command was rejected because a required option is missing or empty. Run the command with `--help`, add the reported option with a non-empty value, then retry." },
   [CliErrorCode.MissingSession]: { category: "parse", defaultHint: "The session command was rejected because its required session id is missing. Run `ha session show --help`, add `--session <session-id>` or the required positional id, then retry." },
   [CliErrorCode.MissingSupersedeTarget]: { category: "parse", defaultHint: "The supersede request was rejected because no replacement was selected. Run `ha task supersede --help`, provide `--title <title>` or `--by <task-id>`, then retry." },
   [CliErrorCode.MissingTask]: { category: "parse", defaultHint: "The command was rejected because its required task id is missing. Run `ha task list --json`, choose a task id, then retry." },
@@ -386,6 +391,7 @@ export const cliErrorCodeRegistry = {
   [CliErrorCode.TerminalReopenRequiresSupersede]: { category: "domain", defaultHint: "Reopen was rejected because terminal tasks require an auditable replacement. Run `ha task supersede <task-id> --title <follow-up-title>`, then continue work on the returned task." },
   [CliErrorCode.TerminalServiceUnavailable]: { category: "command", defaultHint: "The terminal operation failed because its local service is unavailable. Run `ha doctor --json`, restore the reported service dependency, then retry." },
   [CliErrorCode.TerminalStatusRequiresTaskComplete]: { category: "command", defaultHint: "Preferred path: ha task complete <id> --approve. If the task is already terminal and more work is required, run ha task supersede <id> --title <follow-up-title>." },
+  [CliErrorCode.UnclassifiedCommandFailure]: { category: "command", defaultHint: "The command failed for an unexpected reason that the command group could not classify. Rerun the command; if it repeats, run `ha doctor --json` and inspect the reported condition, then contact maintenance with the receipt." },
   [CliErrorCode.UnknownCommand]: { category: "parse", defaultHint: "Unknown command. Run 'ha help' to inspect valid commands." },
   [CliErrorCode.UnknownHelpTopic]: { category: "parse", defaultHint: "Unknown help topic. Run 'ha help' to inspect valid commands." },
   [CliErrorCode.UserSettingsInvalid]: { category: "settings", defaultHint: "User settings were rejected because one or more values failed validation. Run `ha doctor --json`, correct the reported user setting, then retry." },
@@ -413,6 +419,29 @@ export function cliError(code: CliErrorCode, hint?: string, context?: Readonly<R
 
 export function isCliErrorCode(value: unknown): value is CliErrorCode {
   return typeof value === "string" && Object.hasOwn(cliErrorCodeRegistry, value);
+}
+
+/**
+ * Reads a {@link CliErrorCode} that a throw site attached to an error so a
+ * catch block can pass it through without guessing. Catch blocks should
+ * always fall back to an honest "unclassified" code when this returns
+ * undefined — never to a specific diagnosis that the error did not carry.
+ */
+export function errorCodeFromThrown(error: unknown): CliErrorCode | undefined {
+  if (error !== null && typeof error === "object" && "cliErrorCode" in error) {
+    const code = (error as { readonly cliErrorCode?: unknown }).cliErrorCode;
+    return isCliErrorCode(code) ? code : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Attaches a {@link CliErrorCode} to an Error so a catch block can pass it
+ * through. Use this at throw sites that know the honest semantic class of
+ * the failure (parameter validation, missing option, etc.).
+ */
+export function withCliErrorCode(error: Error, code: CliErrorCode): Error & { readonly cliErrorCode: CliErrorCode } {
+  return Object.assign(error, { cliErrorCode: code });
 }
 
 export function cliErrorFamily(code: CliErrorCode): CliErrorFamily {

--- a/packages/cli/src/commands/daemon/command.ts
+++ b/packages/cli/src/commands/daemon/command.ts
@@ -1,4 +1,4 @@
-import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
+import { cliError, CliErrorCode, errorCodeFromThrown } from "../../cli/error-codes.ts";
 import type { DaemonCommandInput } from "./command-types.ts";
 import {
   runDaemonProductCommand as runBaselineDaemonProductCommand
@@ -21,7 +21,8 @@ export async function runDaemonCommand(input: DaemonCommandInput): Promise<numbe
     emitDaemonStatusResult(status.result, input.json);
     return status.exitCode;
   } catch (error) {
-    emitDaemonStatusError(error instanceof Error ? error.message : String(error), input.json);
+    const code = errorCodeFromThrown(error) ?? CliErrorCode.UnclassifiedCommandFailure;
+    emitDaemonStatusError(code, error instanceof Error ? error.message : String(error), input.json);
     return 1;
   }
 }
@@ -51,15 +52,15 @@ function isDaemonCommandRecord(value: unknown): value is Record<string, unknown>
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function emitDaemonStatusError(message: string, json: boolean): void {
+function emitDaemonStatusError(code: CliErrorCode, message: string, json: boolean): void {
   if (json) {
     console.log(JSON.stringify({
       ok: false,
       schema: "daemon-command/v1",
       command: "daemon",
-      error: cliError(CliErrorCode.JournalUnavailable, message)
+      error: cliError(code, message)
     }));
     return;
   }
-  console.error(`error code=${CliErrorCode.JournalUnavailable} hint=${message}`);
+  console.error(`error code=${code} hint=${message}`);
 }

--- a/packages/cli/src/commands/daemon/logs.ts
+++ b/packages/cli/src/commands/daemon/logs.ts
@@ -5,6 +5,7 @@ import {
   type DaemonLogPageV1
 } from "@harness-anything/application";
 import type { JsonObject } from "@harness-anything/daemon";
+import { CliErrorCode, withCliErrorCode } from "../../cli/error-codes.ts";
 import { readOption } from "../../cli/parse-options.ts";
 import { requestLocalDaemonJsonRpc, resolveLocalDaemonTarget } from "../../daemon/client.ts";
 import type { DaemonCommandInput } from "./productization.ts";
@@ -41,8 +42,7 @@ export async function runDaemonLogsCommand(input: DaemonCommandInput): Promise<n
   );
   const details = isDaemonLogReceiptRecord(receipt.details) ? receipt.details : {};
   if (receipt.ok !== true) {
-    const error = isDaemonLogReceiptRecord(receipt.error) ? receipt.error : {};
-    throw new Error(typeof error.hint === "string" ? error.hint : "Daemon log query failed.");
+    throw daemonLogReceiptError(receipt.error);
   }
   emitDaemonLogs(decodeDaemonLogPage(details.data), input.json);
   return 0;
@@ -62,4 +62,19 @@ function emitDaemonLogs(page: DaemonLogPageV1, json: boolean): void {
 
 function isDaemonLogReceiptRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function daemonLogReceiptError(errorValue: unknown): Error {
+  const error = isDaemonLogReceiptRecord(errorValue) ? errorValue : {};
+  const hint = readOptionalString(error, "hint") ?? "Daemon log query failed.";
+  const tag = readOptionalString(error, "code");
+  if (tag === "invalid_daemon_log_list_input") {
+    return withCliErrorCode(new Error(hint), CliErrorCode.InvalidDaemonLogInput);
+  }
+  return new Error(hint);
+}
+
+function readOptionalString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
 }

--- a/packages/cli/src/commands/daemon/productization-options.ts
+++ b/packages/cli/src/commands/daemon/productization-options.ts
@@ -1,8 +1,9 @@
+import { CliErrorCode, withCliErrorCode } from "../../cli/error-codes.ts";
 import { readOption } from "../../cli/parse-options.ts";
 
 export function requiredDaemonOption(args: ReadonlyArray<string>, name: string): string {
   const value = readOption(args, name);
-  if (!value || value.startsWith("--")) throw new Error(`Use ${name} <value>.`);
+  if (!value || value.startsWith("--")) throw withCliErrorCode(new Error(`Use ${name} <value>.`), CliErrorCode.MissingRequiredOption);
   return value;
 }
 

--- a/packages/cli/src/commands/daemon/productization.ts
+++ b/packages/cli/src/commands/daemon/productization.ts
@@ -18,7 +18,7 @@ import {
 } from "@harness-anything/daemon";
 import { initializeHarness } from "../init.ts";
 import { resolveCliVersion } from "../core/version.ts";
-import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
+import { cliError, CliErrorCode, errorCodeFromThrown, withCliErrorCode } from "../../cli/error-codes.ts";
 import { readOption } from "../../cli/parse-options.ts";
 import { resolveLocalDaemonTarget } from "../../daemon/client.ts";
 import {
@@ -112,7 +112,8 @@ export async function runDaemonProductCommand(input: DaemonCommandInput): Promis
     const context = error instanceof DaemonServiceStartupError
       ? error.diagnostic
       : undefined;
-    emitDaemonError(CliErrorCode.JournalUnavailable, message, input.json, context);
+    const code = errorCodeFromThrown(error) ?? CliErrorCode.UnclassifiedCommandFailure;
+    emitDaemonError(code, message, input.json, context);
     return 1;
   }
 }
@@ -250,7 +251,7 @@ async function stopDaemon(input: DaemonCommandInput): Promise<number> {
 
 function installTemplates(input: DaemonCommandInput): number {
   const requestedOutDir = readOption(input.args, "--out");
-  if (!requestedOutDir) throw new Error("Use ha daemon install-templates --out <directory>.");
+  if (!requestedOutDir) throw withCliErrorCode(new Error("Use ha daemon install-templates --out <directory>."), CliErrorCode.MissingRequiredOption);
   const outDir = requireDaemonProductOutputPath({
     requestedPath: requestedOutDir, rootDir: input.rootDir, label: "Daemon template output path"
   });

--- a/packages/cli/src/commands/daemon/repo-registry.ts
+++ b/packages/cli/src/commands/daemon/repo-registry.ts
@@ -4,7 +4,7 @@ import {
   unregisterDaemonRepo,
   type DaemonRegistryRepo
 } from "@harness-anything/kernel";
-import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
+import { cliError, CliErrorCode, errorCodeFromThrown, withCliErrorCode } from "../../cli/error-codes.ts";
 import { readOption } from "../../cli/parse-options.ts";
 import { readDaemonUserRoot } from "../../daemon/client.ts";
 
@@ -53,7 +53,7 @@ export function runDaemonRepoCommand(input: DaemonRepoCommandInput): number {
     }
     if (action === "unregister") {
       const repoId = readOption(input.args, "--repo-id");
-      if (!repoId || repoId.startsWith("--")) throw new Error("Use --repo-id <value>.");
+      if (!repoId || repoId.startsWith("--")) throw withCliErrorCode(new Error("Use --repo-id <value>."), CliErrorCode.MissingRequiredOption);
       const result = unregisterDaemonRepo(repoId, options);
       emitDaemonRepoResult("daemon-repo-unregister", {
         registryPath: result.registryPath,
@@ -70,7 +70,8 @@ export function runDaemonRepoCommand(input: DaemonRepoCommandInput): number {
     );
     return 2;
   } catch (error) {
-    emitDaemonRepoError(CliErrorCode.JournalUnavailable, error instanceof Error ? error.message : String(error), input.json);
+    const code = errorCodeFromThrown(error) ?? CliErrorCode.UnclassifiedCommandFailure;
+    emitDaemonRepoError(code, error instanceof Error ? error.message : String(error), input.json);
     return 1;
   }
 }

--- a/packages/cli/test/daemon-command-errors.test.ts
+++ b/packages/cli/test/daemon-command-errors.test.ts
@@ -20,6 +20,30 @@ test("unknown daemon product commands use parse errors with focused next steps",
   assert.match(repoCommand.receipt.error.hint, /ha daemon repo --help/u);
 });
 
+test("missing --repo-id on daemon repo unregister reports a parse error, not a journal failure", () => {
+  const result = runDaemonFailure(["daemon", "repo", "unregister"]);
+  assert.equal(result.status, 1);
+  assert.equal(result.receipt.error.code, "missing_required_option");
+  assert.equal(result.receipt.error.hint, "Use --repo-id <value>.");
+  assert.doesNotMatch(result.receipt.error.code, /journal/u);
+});
+
+test("missing --out on daemon install-templates reports a parse error, not a journal failure", () => {
+  const result = runDaemonFailure(["daemon", "install-templates"]);
+  assert.equal(result.status, 1);
+  assert.equal(result.receipt.error.code, "missing_required_option");
+  assert.match(result.receipt.error.hint, /Use ha daemon install-templates --out/u);
+  assert.doesNotMatch(result.receipt.error.code, /journal/u);
+});
+
+test("unregistering an unknown repo id reports an honest unclassified failure, not a journal failure", () => {
+  const result = runDaemonFailure(["daemon", "repo", "unregister", "--repo-id", "nonexistent-repo"]);
+  assert.equal(result.status, 1);
+  assert.equal(result.receipt.error.code, "unclassified_command_failure");
+  assert.match(result.receipt.error.hint, /not registered/u);
+  assert.doesNotMatch(result.receipt.error.code, /journal/u);
+});
+
 function runDaemonFailure(args: ReadonlyArray<string>): {
   readonly status: number | null;
   readonly receipt: { readonly error: { readonly code: string; readonly hint: string } };

--- a/packages/cli/test/daemon-log-input-validation.test.ts
+++ b/packages/cli/test/daemon-log-input-validation.test.ts
@@ -1,0 +1,42 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
+import { defaultDaemonUserRoot, runDaemonCommand, runRawJson, withTempRootAsync } from "./helpers/daemon-cli.ts";
+
+const cliEntry = path.resolve("packages/cli/src/index.ts");
+
+test("daemon logs out-of-range limit reports a parse error, not a journal failure", async () => {
+  await withTempRootAsync(async (rootDir) => {
+    const userRoot = defaultDaemonUserRoot(rootDir);
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_USER_ROOT: userRoot });
+    runDaemonCommand(rootDir, ["daemon", "start", "--service", "--json"], { HARNESS_DAEMON_USER_ROOT: userRoot });
+    try {
+      const result = runCliMaybeFail(rootDir, ["daemon", "logs", "--limit", "500", "--json"], { HARNESS_DAEMON_USER_ROOT: userRoot });
+      assert.equal(result.status, 1);
+      assert.equal(result.receipt.ok, false);
+      const error = (result.receipt as { readonly error?: { readonly code: string; readonly hint: string } }).error;
+      assert.equal(error?.code, "invalid_daemon_log_input");
+      assert.match(error?.hint ?? "", /limit must be an integer from 1 through 200/u);
+      assert.doesNotMatch(error?.code ?? "", /journal/u);
+    } finally {
+      runDaemonCommand(rootDir, ["daemon", "stop", "--timeout-ms", "5000", "--json"], { HARNESS_DAEMON_USER_ROOT: userRoot });
+    }
+  });
+});
+
+function runCliMaybeFail(rootDir: string, args: ReadonlyArray<string>, env: Readonly<Record<string, string>>): {
+  readonly status: number | null;
+  readonly receipt: Record<string, unknown>;
+} {
+  const result = spawnSync(process.execPath, [cliEntry, "--root", rootDir, ...args], {
+    encoding: "utf8",
+    env: cliTestEnv({ ...env })
+  });
+  return {
+    status: result.status,
+    receipt: JSON.parse(result.stdout) as Record<string, unknown>
+  };
+}

--- a/packages/cli/test/task-lifecycle-facade.test.ts
+++ b/packages/cli/test/task-lifecycle-facade.test.ts
@@ -14,6 +14,9 @@ import type { CliResult, ParsedCommand } from "../src/cli/types.ts";
 import { canonicalTaskStartResult } from "../src/commands/core/task-holder-support.ts";
 import { runTaskLifecycleWithDemotions } from "../src/commands/core/task-lifecycle-demotions.ts";
 import {
+  dispatchLifecycleFacadeSteps
+} from "../src/commands/core/task-lifecycle-facade-guidance.ts";
+import {
   runTaskStartFacade,
   taskCloseoutFacadeSteps,
   taskStartFacadeSteps
@@ -275,5 +278,75 @@ for (const scenario of [
       return aliasReceipt;
     });
     assert.deepEqual(startReceipt, aliasReceipt);
+  });
+}
+
+test("dispatchLifecycleFacadeSteps soft-warns when doc-sync fails because the daemon-backed path is required", async () => {
+  const docSyncStep = {
+    rootDir: "/fixture",
+    json: true,
+    action: { kind: "doc-sync", mode: "submit", paths: ["tasks/task_FIXTURE/task_plan.md"] }
+  } as ParsedCommand;
+
+  const result = await dispatchLifecycleFacadeSteps(
+    [docSyncStep],
+    () => Promise.resolve(failureReceipt(
+      CliErrorCode.JournalUnavailable,
+      "Doc sync submit requires the daemon-backed CLI path; remove HARNESS_DAEMON_MODE=direct and retry."
+    )),
+    "task-complete"
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.warnings.length, 1);
+  assert.equal(result.warnings[0]?.code, "doc_sync_dirty");
+});
+
+test("dispatchLifecycleFacadeSteps soft-warns when doc-sync fails because the daemon is unreachable", async () => {
+  const docSyncStep = {
+    rootDir: "/fixture",
+    json: true,
+    action: { kind: "doc-sync", mode: "submit", paths: ["tasks/task_FIXTURE/task_plan.md"] }
+  } as ParsedCommand;
+
+  const result = await dispatchLifecycleFacadeSteps(
+    [docSyncStep],
+    () => Promise.resolve(failureReceipt(
+      CliErrorCode.JournalUnavailable,
+      "Daemon unavailable. Start the daemon with 'ha daemon start --service' or check 'ha daemon status'. If the daemon is stuck and this write must be recovered locally, run 'HARNESS_DAEMON_MODE=direct HARNESS_DIRECT_WRITE_REASON=recovery ha --json doc sync --submit'."
+    )),
+    "task-closeout"
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.warnings.length, 1);
+  assert.equal(result.warnings[0]?.code, "doc_sync_dirty");
+});
+
+test("dispatchLifecycleFacadeSteps hard-fails when doc-sync is rejected for a non-journal reason", async () => {
+  const docSyncStep = {
+    rootDir: "/fixture",
+    json: true,
+    action: { kind: "doc-sync", mode: "submit", paths: ["tasks/task_FIXTURE/task_plan.md"] }
+  } as ParsedCommand;
+
+  const result = await dispatchLifecycleFacadeSteps(
+    [docSyncStep],
+    () => Promise.resolve(failureReceipt(
+      CliErrorCode.WriteRejected,
+      "Doc sync selected path is outside the authored root."
+    )),
+    "task-complete"
+  );
+
+  assert.equal(result.ok, false);
+  assert.equal(result.receipt.ok, false);
+});
+
+function failureReceipt(code: CliErrorCode, hint: string) {
+  return toCommandReceipt({
+    ok: false,
+    command: "doc-sync-submit",
+    error: cliError(code, hint)
   });
 }


### PR DESCRIPTION
# English

## Summary

Two `ha daemon` failures, two entirely different real causes, one error code:

```
$ ha daemon logs --limit 500 --json
{"ok":false,...,"error":{"code":"journal_unavailable","hint":"limit must be an integer from 1 through 200"}}
$ ha daemon repo unregister --json
{"ok":false,...,"error":{"code":"journal_unavailable","hint":"Use --repo-id <value>."}}
```

**Both hints tell the truth. The code is what lies.** And the lie is not cosmetic: the
registered default hint for `journal_unavailable` tells the user to run
`ha daemon status --json` and "restore the reported daemon or journal condition" — the
system actively sends people to inspect a perfectly healthy daemon when they simply
mistyped a flag.

The cause is structural, not per-instance: three top-level `catch (error)` blocks in the
`ha daemon` command group stamped `JournalUnavailable` on **anything** thrown beneath
them. The error code was determined by *where the catch was written*, not by *what
failed*. This is the second instance of that shape in this task's ledger, so it is fixed
as a shape.

## What Changed

- **The code now travels with the throw.** `withCliErrorCode(error, code)` attaches a
  semantic code at the throw site; `errorCodeFromThrown(error)` reads it at the catch.
  Argument problems get argument codes; the fallback only applies when nothing classified
  it.
- **The fallback is honest.** The three catches now fall back to
  `UnclassifiedCommandFailure` — "this command group cannot classify this failure" —
  instead of impersonating a specific journal diagnosis. Its hint points at
  `ha doctor --json`, not at a healthy journal.
- **Three new codes, each justified against the existing registry** rather than added by
  reflex: `InvalidDaemonLogInput` (mirrors the daemon's own
  `invalid_daemon_log_list_input`; no existing parse-class code covered daemon log
  arguments), `MissingRequiredOption` (the existing `Missing*` codes are dispatched
  per-option for five specific options and do not cover the daemon flags; one code per
  daemon option would have been over-engineering), and `UnclassifiedCommandFailure` (no
  existing code meant "I don't know, and I won't pretend").
- **The three catch blocks keep their structure.** No middleware, no error-handling
  framework, no new abstraction layer — the change is which code is chosen.

After:

```
$ ha daemon logs --limit 500 --json
{"ok":false,...,"error":{"code":"invalid_daemon_log_input","hint":"limit must be an integer from 1 through 200"}}
$ ha daemon repo unregister --json
{"ok":false,...,"error":{"code":"missing_required_option","hint":"Use --repo-id <value>."}}
```

Not one hint changed.

## Task And Scope

- Harness task: `task_01KXV0HEYVWW6X237K43Q3R2AC` (long-running standing line; this PR
  closes the `journal_unavailable` shape row, not the whole table)
- Branch: `codex/daemon-error-codes`
- Public scope: `packages/cli/src/cli/error-codes.ts`,
  `packages/cli/src/commands/daemon/**`, and their tests
- Private planning/evidence updated: yes (task plan)
- Out of scope: every other row of that table. Each has its own review state and some
  descriptions are known to be stale.

## Version Impact

- Version: no version change because no published API changes; the affected surface is
  CLI error codes in failure receipts.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `dec_01KXV0BEVX113BA2CPRQRVAKAB` (active) — fail-closed rejections must point
  at the real cause; the error's own name must indicate it
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide
  whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `b78320faf47026da3e774927082858b524524627`
- Branch merge-base with `origin/main`: `b78320faf47026da3e774927082858b524524627`
- Last `git fetch origin` time: 2026-08-06, immediately before opening this PR
- Sync method: rebase
- Public diff command: `git diff b78320fa..760cbc2f`
- Private evidence commit/path: `harness/tasks/task_01KXV0HEYVWW6X237K43Q3R2AC-cli-fail-closed/task_plan.md`
- Reviewer evidence path: same package
- GitHub Actions `rewrite-ci` run URL: this PR's run
- [x] `git diff --check`
- [x] `npm run check:stop-point` — `npm run check:local` passed in 45.1s, 27 gates green
- [x] Targeted tests for the change surface, named with their counts:
  `daemon-command-errors.test.ts` 4/4; `task-lifecycle-facade.test.ts` 14/14;
  `daemon-log-input-validation.test.ts` 1/1; regressions `error-mapper.test.ts` 8/8,
  `doc-sync-cli.test.ts` 12/12, `daemon-command-outcomes.test.ts` 4/4
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: `npm run check:ci` was not run; `check:local` covered the
  change-aware integration tests and CI is the authority for the full matrix.

**Both positive controls were re-run by the reviewer, not taken on report.** Against the
canonical root, `ha daemon logs --limit 500 --json` now returns `invalid_daemon_log_input`
with the same hint, and `--limit 2` still returns `ok:true` with real entries — so the
valid path was checked too, not just the rejection. `ha daemon repo unregister --json`
returns `missing_required_option`.

An unplanned third control appeared while verifying: running `daemon logs` from an
unregistered worktree now returns `unclassified_command_failure` with the hint
`current root is not registered with the user daemon registry. Run: ha daemon repo
register …`. The old code would have called that `journal_unavailable` too. **The honest
fallback is visibly better than the confident wrong answer** — the user is told the real
problem and the exact next command.

## Review Evidence

- Self-review: CEO read the full diff and re-ran both controls plus the valid-input path.
  The `withCliErrorCode` / `errorCodeFromThrown` pair does implement "code chosen at the
  throw site", not a rename. One thing was checked rather than assumed: during
  implementation the `check-cli-error-codes` gate went red and was worked around by
  extracting a `readOptionalString` helper. Reading the gate
  (`tools/check-cli-error-codes.mjs:98-113`) confirms this was a **gate false positive**,
  not an evasion: the rule targets hand-built inline `{code, hint}` result objects, but
  its line-level regex also matches the `: undefined` branch of a ternary that merely
  *reads* `error.code`. The rule was never actually violated. That false positive is
  recorded as its own row in the task's table — a gate that fires on correct code trains
  people to route around it, which is the same disease as the always-true warning already
  listed there.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- **`DaemonServiceStartupError` now surfaces as `UnclassifiedCommandFailure`.** That is
  honest but less specific than it could be. A dedicated `DaemonServiceStartFailed` code
  was deliberately not added this round; the hint and diagnostic context still carry the
  specifics.
- **`unregisterDaemonRepo("nonexistent")` also lands on the fallback.** There is no
  "repo not registered" CLI code. The hint says `repoId "…" is not registered`, so the
  user is not stranded, but the code is coarse.
- **The dual predicate in `task-lifecycle-facade-guidance.ts` was deliberately left
  alone**, and the reasoning is worth recording: both legitimate `journal_unavailable`
  sources (`daemon/client.ts` and `commands/core/doc.ts:16`) are outside these three
  catches, so minting a new code for `doc.ts` would force the consumer to match *two*
  codes instead of one — more complex, not less. What did improve is that the doc-sync
  step can no longer receive `journal_unavailable` from catch pollution, so the predicate
  is now cleaner than it was. Three tests pin the soft-warning path (both hint shapes plus
  the hard-fail case) so it cannot be silently broken.
- The table row this PR closes is one of many in a **long-running** task; the standing
  line remains open.

## References

- Task: `task_01KXV0HEYVWW6X237K43Q3R2AC`
- Evidence: `harness/tasks/task_01KXV0HEYVWW6X237K43Q3R2AC-cli-fail-closed/task_plan.md`
- Review: `dec_01KXV0BEVX113BA2CPRQRVAKAB`

---

# 中文

## 概要

两条 `ha daemon` 失败,两个完全不同的真因,同一个错误码:

```
$ ha daemon logs --limit 500 --json
{"ok":false,...,"error":{"code":"journal_unavailable","hint":"limit must be an integer from 1 through 200"}}
$ ha daemon repo unregister --json
{"ok":false,...,"error":{"code":"journal_unavailable","hint":"Use --repo-id <value>."}}
```

**两条 hint 都说了真话,撒谎的是码。** 而这个谎不只是不好看:
`journal_unavailable` 注册的默认 hint 是「Run `ha daemon status --json`,
restore the reported daemon or journal condition」——**系统会主动把人指去检查一个完全健康的
daemon**,而真因只是命令行 flag 敲错了。

病根是结构性的,不是逐例的:`ha daemon` 命令组里三处顶层 `catch (error)`,
把 `JournalUnavailable` 无条件盖在其下**任何**抛出上。
**错误码由「catch 写在哪」决定,而不是由「什么坏了」决定。**
这是本任务台账里同一形状的第二例,所以按形状修。

## 改动内容

- **码跟着抛出走。** `withCliErrorCode(error, code)` 在抛出点附着语义码,
  `errorCodeFromThrown(error)` 在 catch 处读取。参数问题拿参数码;
  只有没人分类过的失败才会落到兜底。
- **兜底是诚实的。** 三处 catch 现在兜底到 `UnclassifiedCommandFailure`
  ——「这个命令组无法分类这次失败」——而不是冒充一个具体的 journal 诊断。
  它的 hint 指向 `ha doctor --json`,不再指向一个健康的日志。
- **三个新码,每个都对着现有码集论证过**,不是反射式新增:
  `InvalidDaemonLogInput`(对齐 daemon 自己的 `invalid_daemon_log_list_input`;
  现有 parse 类码没有覆盖 daemon 日志参数的)、
  `MissingRequiredOption`(现有 `Missing*` 码按 option 名分发、只支持 5 个特定选项,
  不覆盖 daemon 的 flag;为每个 daemon 选项各建一个码是过度工程)、
  `UnclassifiedCommandFailure`(不存在任何表达「我不知道,但我不假装知道」的码)。
- **三处 catch 结构不变。** 没有中间件、没有错误处理框架、没有新抽象层——改的只是码的选取。

修后:

```
$ ha daemon logs --limit 500 --json
{"ok":false,...,"error":{"code":"invalid_daemon_log_input","hint":"limit must be an integer from 1 through 200"}}
$ ha daemon repo unregister --json
{"ok":false,...,"error":{"code":"missing_required_option","hint":"Use --repo-id <value>."}}
```

没有一条 hint 被改动。

## 任务与范围

- Harness 任务:`task_01KXV0HEYVWW6X237K43Q3R2AC`(long-running 常设线;
  本 PR 收口的是 `journal_unavailable` 那一行形状,不是整张表)
- 分支:`codex/daemon-error-codes`
- 公开范围:`packages/cli/src/cli/error-codes.ts`、
  `packages/cli/src/commands/daemon/**` 及其测试
- 私有规划/证据已更新:是(task plan)
- 不在本 PR 范围:该表的其余各行。它们各有各的复核状态,且已知有些描述已经过期。

## 版本影响

- 版本:不变,无已发布 API 变更;受影响的是失败回执里的 CLI 错误码。
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:否
- Protected surface 范围:不适用
- 授权依据:`dec_01KXV0BEVX113BA2CPRQRVAKAB`(active)——fail-closed 拒绝必须指向真因,
  且错误的名字本身必须指向真因
- 机器检查边界:本 PR 只断言声明存在;声明是否属实、是否充分由评审者判断。
- Break-glass:否
- Break-glass 理由:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- 基线 `origin/main` SHA:`b78320faf47026da3e774927082858b524524627`
- 分支与 `origin/main` 的 merge-base:`b78320faf47026da3e774927082858b524524627`
- 最近一次 `git fetch origin`:2026-08-06,开 PR 前
- 同步方式:rebase
- 公开 diff 命令:`git diff b78320fa..760cbc2f`
- 私有证据 commit/路径:`harness/tasks/task_01KXV0HEYVWW6X237K43Q3R2AC-cli-fail-closed/task_plan.md`
- 评审证据路径:同任务包
- GitHub Actions `rewrite-ci` run URL:本 PR 的 run
- [x] `git diff --check`
- [x] `npm run check:stop-point` —— `npm run check:local` 45.1s 通过,27 道 gate 全绿
- [x] 改动面定向测试(带计数):
  `daemon-command-errors.test.ts` 4/4;`task-lifecycle-facade.test.ts` 14/14;
  `daemon-log-input-validation.test.ts` 1/1;回归 `error-mapper.test.ts` 8/8、
  `doc-sync-cli.test.ts` 12/12、`daemon-command-outcomes.test.ts` 4/4
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- 未跑及原因:未跑 `npm run check:ci`;`check:local` 已覆盖 change-aware integration 测试,
  全量矩阵以 CI 为权威。

**两条阳性对照由评审者重跑过,不是照报告采信。** 对着 canonical root,
`ha daemon logs --limit 500 --json` 现在返回 `invalid_daemon_log_input` 且 hint 未变;
`--limit 2` 仍返回 `ok:true` 与真实条目——**正常路径也核了,不只核拒绝路径**。
`ha daemon repo unregister --json` 返回 `missing_required_option`。

核验时冒出一条计划外的第三个对照:从**未注册的 worktree** 里跑 `daemon logs`,
现在返回 `unclassified_command_failure`,hint 是
`current root is not registered with the user daemon registry. Run: ha daemon repo register …`。
旧代码会把这个也叫 `journal_unavailable`。**诚实的兜底肉眼可见地优于一个自信的错答**
——使用者被告知真实问题和下一条该敲的命令。

## 审查证据

- 自审:CEO 通读全部 diff,并重跑了两条对照与正常输入路径。
  `withCliErrorCode` / `errorCodeFromThrown` 这一对确实实现了「码在抛出点选定」,不是改名。
  有一点是**核过**而非假定:实现过程中 `check-cli-error-codes` 门曾红,
  worker 靠抽 `readOptionalString` helper 绕开。读门源码
  (`tools/check-cli-error-codes.mjs:98-113`)确认这是**门的误报**而非规避:
  规则针对的是手搓的内联 `{code, hint}` 结果对象,但它的行级正则同样会匹配到
  仅仅**读取** `error.code` 的三元表达式里的 `: undefined` 分支。规则从未被真正违反。
  该误报已作为独立一行记进任务表——**一道会对正确代码开火的门,只会教人绕过它**,
  这与表里已有的「恒真告警」是同一种病。
- 复核 subagent:未使用
- 人工审查:待办
- 阻塞性发现:无

## 残余风险

- **`DaemonServiceStartupError` 现在呈现为 `UnclassifiedCommandFailure`。**
  诚实,但不够具体。本轮刻意没有新增 `DaemonServiceStartFailed`;
  hint 与 diagnostic context 仍携带具体信息。
- **`unregisterDaemonRepo("nonexistent")` 同样落到兜底。** 没有「repo 未注册」的 CLI 码。
  hint 会说 `repoId "…" is not registered`,使用者不至于卡住,但码偏粗。
- **`task-lifecycle-facade-guidance.ts` 的双重判据被刻意保留**,理由值得记下来:
  两个合法的 `journal_unavailable` 来源(`daemon/client.ts` 与 `commands/core/doc.ts:16`)
  都不在这三处 catch 里,所以给 `doc.ts` 单造一个新码,只会让消费者从匹配一个码变成匹配**两个**
  ——更复杂而非更简单。真正改善的是:doc-sync 那一步现在不可能再从 catch 污染里拿到
  `journal_unavailable`,判据比以前干净了。三条测试钉住软警告路径(两种 hint 形态 + 硬失败),
  它不会被悄悄改哑。
- 本 PR 收口的是一张表里的一行,而该任务是**常设线**,整条线仍然开着。

## 关联材料

- 任务:`task_01KXV0HEYVWW6X237K43Q3R2AC`
- 证据:`harness/tasks/task_01KXV0HEYVWW6X237K43Q3R2AC-cli-fail-closed/task_plan.md`
- 复核:`dec_01KXV0BEVX113BA2CPRQRVAKAB`
