### PR TITLE
test(daemon): decide two integration gates by protocol events, not racing timers

### DIFF
--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -50,6 +50,7 @@ export {
 // Cold authority readiness measured ~7.2s, so a 6s budget could never confirm it.
 export const defaultDaemonAutostartTimeoutMs = 30_000;
 export const defaultDaemonIdleExitMs = 750;
+export const localDaemonRetryIntervalMs = 100;
 const minimumReadyProbeResponseTimeoutMs = 500;
 
 export class DaemonAutostartTimeoutError extends Error {
@@ -383,7 +384,7 @@ async function requestLocalDaemonJsonRpcWithAutostart(
     } catch (error) {
       if (error instanceof DaemonJsonRpcResponseError || error instanceof DaemonJsonRpcRequestTimeoutError) throw error;
       lastError = error;
-      await delay(Math.min(100, Math.max(1, deadline - Date.now())));
+      await delay(Math.min(localDaemonRetryIntervalMs, Math.max(1, deadline - Date.now())));
     } finally {
       autostart.onPhase?.("request-end");
     }
@@ -442,7 +443,7 @@ async function spawnAndWaitForLocalDaemon(
       return;
     } catch (error) {
       flight.lastError = error;
-      const retryDelayMs = Math.min(100, flight.deadline - Date.now());
+      const retryDelayMs = Math.min(localDaemonRetryIntervalMs, flight.deadline - Date.now());
       if (retryDelayMs > 0) await delay(retryDelayMs);
     }
   }

--- a/packages/daemon/test/daemon-autostart-recovery.test.ts
+++ b/packages/daemon/test/daemon-autostart-recovery.test.ts
@@ -7,6 +7,7 @@ import { createInterface } from "node:readline";
 import test from "node:test";
 import {
   DaemonAutostartTimeoutError,
+  localDaemonRetryIntervalMs,
   replaceSpawnLocalDaemonForTest,
   requestLocalDaemonJsonRpcForTarget,
   type LocalDaemonTarget
@@ -19,6 +20,10 @@ import {
 
 const legacyAutostartBudgetMs = 6_000;
 const injectedColdStartDelayMs = legacyAutostartBudgetMs + 250;
+// The server starts idle, and protocol.hello deliberately does not count as a
+// served request. Keep the first-request grace structurally wider than one
+// client retry interval plus the hello and real-request loopback round trips.
+const injectedFirstRequestGraceMs = localDaemonRetryIntervalMs * 20;
 
 test("two commands recover through one daemon whose cold readiness exceeds the legacy budget", async (context) => {
   if (process.platform === "win32") return;
@@ -69,7 +74,7 @@ function startInjectedColdDaemon(
         servers.push(server);
         const idleExit = setTimeout(() => {
           void closeServer(server).then(resolve, reject);
-        }, 100);
+        }, injectedFirstRequestGraceMs);
         server.on("request-served", () => clearTimeout(idleExit));
       }, reject);
     }, injectedColdStartDelayMs);

--- a/packages/daemon/test/repo-write-process-supervisor.test.ts
+++ b/packages/daemon/test/repo-write-process-supervisor.test.ts
@@ -361,12 +361,18 @@ test("child that swallows PROCEED is replaced after the bounded stall window and
 test("non-durable task-claim timeout replaces the child without replay or lookup", async (context) => {
   const root = mkdtempSync(path.join(os.tmpdir(), "ha-repo-write-direct-"));
   const tracePath = path.join(root, "trace.log");
+  const requestTimeoutMs = 40;
   let forks = 0;
+  let lastTelemetryPhase: string | undefined;
   let timeoutDiagnostic: RepoWriteRequestTimeoutDiagnostic | undefined;
+  let confirmDirectStalled!: () => void;
+  const directStalled = new Promise<void>((resolve) => {
+    confirmDirectStalled = resolve;
+  });
   const supervisor = new RepoWriteProcessSupervisor({
     repoId: "repo-transport",
     generation: 1,
-    limits: { requestTimeoutMs: 40 },
+    limits: { requestTimeoutMs },
     spawn: () => {
       forks += 1;
       return forkRepoWriteProcess({
@@ -376,6 +382,12 @@ test("non-durable task-claim timeout replaces the child without replay or lookup
     },
     onRequestTimeout: (diagnostic) => {
       timeoutDiagnostic = diagnostic;
+    },
+    onTelemetry: (frame) => {
+      lastTelemetryPhase = frame.phase;
+    },
+    onDiagnostic: (frame) => {
+      if (frame.code === "FIXTURE_DIRECT_STALLED") confirmDirectStalled();
     }
   });
   context.after(async () => {
@@ -383,15 +395,27 @@ test("non-durable task-claim timeout replaces the child without replay or lookup
     rmSync(root, { recursive: true, force: true });
   });
 
+  await supervisor.start();
+  context.mock.timers.enable({ apis: ["setTimeout"] });
+
   const trace = createDaemonRequestPerformanceTrace({
     method: "repo.command.run",
     requestId: "direct-timeout-recovery",
     receivedAtMs: performance.now()
   });
-  await runWithDaemonRequestPerformanceTrace(trace, () => assert.rejects(
-      supervisor.direct(command("", "task-claim")),
-      (error) => error instanceof RepoWriteDirectOutcomeUnknownError
-    ));
+  const outcome = runWithDaemonRequestPerformanceTrace(trace, () =>
+    supervisor.direct(command("", "task-claim")));
+  void outcome.catch(() => undefined);
+  // Wait for the child to report its phase, then advance the modeled deadline;
+  // neither assertion depends on which real-time callback the runner schedules first.
+  await directStalled;
+  assert.equal(timeoutDiagnostic, undefined);
+  context.mock.timers.tick(requestTimeoutMs);
+  await assert.rejects(
+    outcome,
+    (error) => error instanceof RepoWriteDirectOutcomeUnknownError
+  );
+  assert.equal(lastTelemetryPhase, "projection");
   const performanceSummary = trace.finish("response-written");
   assert.equal(forks, 2);
   assert.ok((performanceSummary.phasesMs["repo-write-recovery"] ?? 0) > 0);

--- a/packages/daemon/test/support/repo-write-ipc-child.ts
+++ b/packages/daemon/test/support/repo-write-ipc-child.ts
@@ -63,7 +63,17 @@ if (mode === "expected-direct-rejection") {
           requestId: message.requestId,
           phase: "projection",
           elapsedMs: 2.5
-        });
+        }).then(() => transport.send({
+          // Same-channel ordering makes this a deterministic test barrier: the
+          // parent cannot observe it before recording the telemetry above.
+          protocol: repoWriteProtocolType,
+          repoId: message.repoId,
+          generation: message.generation,
+          kind: "recovery-deferred",
+          outerOpId: `fixture-direct-stalled:${message.requestId}`,
+          code: "FIXTURE_DIRECT_STALLED",
+          diagnostic: "fixture direct request reported projection and will remain unresolved"
+        }));
         return;
       }
       void transport.send({


### PR DESCRIPTION
# English

## Summary

`main` has been red on two consecutive commits (`379640c9`, `55afca0c`) because two
integration tests decide their verdict by **which of two comparable timers wins**. The
same code was green in the PR runs that introduced/preceded them. A gate that is red on
`main` and green on the PR for identical code has no resolving power — and it teaches
everyone to re-run instead of to look.

This PR makes both tests deterministic. Neither timeout number was simply raised.

## What Changed

**Test 1 — `daemon-autostart-recovery.test.ts` (introduced by #1249).** The injected fake
daemon armed a **100ms** idle timer the moment it started listening, and the client's
connect-retry cadence is also **100ms**. Worse, `protocol.hello` deliberately does not
count as a served request, so the client had to complete *the handshake and the first real
request* — two loopback round trips — inside that same 100ms. The margin was zero by
construction.

The client's retry cadence is now a single exported constant,
`localDaemonRetryIntervalMs`, used at both of its call sites. The fixture derives its
first-request grace from it (`localDaemonRetryIntervalMs * 20`), so the margin is
structural: if the client's cadence ever changes, the fixture follows.

**Test 2 — `repo-write-process-supervisor.test.ts:361` (pre-existing).** A 40ms request
deadline raced the real child process's phase telemetry. The test now:

1. `start()`s the supervisor explicitly, so fork and READY are outside the measured window;
2. has the child fixture send an ordered barrier frame **over the same IPC channel**
   immediately after the `projection` telemetry — so the parent cannot observe the barrier
   before the telemetry it is meant to witness;
3. asserts the timeout has **not** fired yet, then advances a mocked clock by exactly
   `requestTimeoutMs`.

Ordering is now decided by protocol events; the timeout by a virtual clock. Neither
assertion depends on which real-time callback the runner happens to schedule first.

**Attribution, stated separately from the fix.** `git blame` puts this test at
`dbeb30f2`/`045c1635`; #1249 modified neither it nor the `swallow-direct` path. What #1249
added were serially-executed shutdown tests in the same file, which plausibly *exposed*
the old race without introducing it. Who introduced it and whether to fix it are two
different questions; the answer to the second is yes either way.

## Task And Scope

- Harness task: `task_01KZA3XQD83BSPC2VJ2HXS78ZA`
- Branch: `codex/timing-race-gates`
- Public scope: `packages/daemon/src/client/local-json-rpc-client.ts` (constant extraction
  only) and three test/fixture files under `packages/daemon/test`
- Private planning/evidence updated: yes (task plan, artifacts/verification-report.md)
- Out of scope: two further same-shaped races found by the scan (below); the daemon idle
  default (`dec_01KZA1ZS0JHS9ZRQXESMC1W5HB`, owned by
  `task_01KZA3BN8CPXENJ4JJTP0JRFG6`); test-weight registration.

## Version Impact

- Version: no version change because the only production edit extracts an existing literal
  into a named exported constant with identical values at both call sites.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable — this is a test-determinism fix for a red `main`, with no
  gate-authority change
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide
  whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `55afca0c`
- Branch merge-base with `origin/main`: `55afca0c`
- Last `git fetch origin` time: 2026-08-06, immediately before opening this PR
- Sync method: none needed
- Public diff command: `git diff 55afca0c..f30b40d9`
- Private evidence commit/path: `harness/tasks/task_01KZA3XQD83BSPC2VJ2HXS78ZA-integration-main-379640c9-shard-1/artifacts/verification-report.md`
- Reviewer evidence path: same package
- GitHub Actions `rewrite-ci` run URL: this PR's run
- [x] `git diff --check`
- [x] `npm run check:stop-point` — 27 complete manifest gates green; affected fast 295/295;
  contract 159 pass, 1 skip
- [x] Targeted tests for the change surface, named with their counts: three affected test
  files 31/31
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: full `check:ci` was not run locally, per the task contract's stop point.

**"It passed N times" is explicitly not the evidence here.** Both tests already passed
most of the time; re-running cannot distinguish "fixed" from "lucky". The acceptance
instrument is **mutation**:

| Mutation | Observed |
|---|---|
| client re-launches a daemon on every readiness retry | `AssertionError: 63 !== 1`, `pass 0 / fail 1` |
| child's `projection` telemetry removed, ordered barrier kept | `+ undefined  - 'projection'`, `pass 0 / fail 1` |
| both restored | `pass 1 / fail 0` each |

**Anti-jitter was proven under real load, not asserted.** 16 `node -e 'while (true) {}'`
processes saturating all 16 logical CPUs (terminated and awaited via a trap): test 1 ran
5/5 green — each run including the injected 6.25s cold start — and test 2 ran 20/20 green.

## Review Evidence

- Self-review: CEO read the full diff. Two things are worth naming because they are the
  reason to trust this beyond the green run:
  1. the added `assert.equal(timeoutDiagnostic, undefined)` **before** the clock is
     advanced proves the ordering rather than assuming it — without it, a barrier that
     arrived late would still pass;
  2. the barrier travels on the same IPC channel as the telemetry it witnesses, so the
     ordering is a channel property, not a timing hope.
  CEO's own earlier reading of test 2 — "a forked Node process cannot report a phase
  within 40ms" — was **wrong**: the 40ms deadline starts after the child is READY, so the
  race is telemetry-vs-deadline, not fork-vs-deadline. The fix addresses the real race.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- **The same shape survives in two more places**, found by scanning 250 integration-tier
  tests and deliberately left for a follow-up rather than widened into this PR:
  `repo-write-process-supervisor.test.ts`'s "child that swallows PROCEED" (real child
  against 40/80ms telemetry deadlines) and `repo-write-durable-deadline-honesty.test.ts`
  (a 40ms observation against a 60ms fixture terminal timer). This is the second and third
  instance of the shape, so the follow-up should question the shape, not patch instances.
- **`spawnCalls === 1` guards a conditional guarantee, and this is worth being precise
  about.** It now means: a cold-start flight that has launched and survives to its first
  real request will not be re-launched during readiness retry. It does **not** mean the
  daemon stays resident across arbitrary human pauses — that remains the unimplemented
  promise of `dec_01KZA1ZS0JHS9ZRQXESMC1W5HB`. Before this PR the assertion was reaching
  for the second, stronger property, which is part of why it was unstable.
- Test weight for these files remains unregistered, so shard assignment still drifts (the
  failure moved from shard 1 to shard 5 between the two red runs). Registering weight was
  deliberately **not** done here: it only changes which shard a coin flip lands on.

## References

- Task: `task_01KZA3XQD83BSPC2VJ2HXS78ZA`
- Evidence: `harness/tasks/task_01KZA3XQD83BSPC2VJ2HXS78ZA-integration-main-379640c9-shard-1/artifacts/verification-report.md`
- Review: red runs `31055692821` (`379640c9`) and `31055907176` (`55afca0c`)

---

# 中文

## 概要

`main` 连着两个 commit(`379640c9`、`55afca0c`)红着,原因是两条 integration 测试
**用「两个量级相当的计时器谁先赢」当判据**。同一份代码在引入它们的那些 PR 上是绿的。
**一道在 main 上红、在 PR 上绿、而代码完全相同的门,没有任何分辨力**——
它教会所有人「重跑一下」,而不是「去看一眼」。

本 PR 把两条测试改成确定性的。**两个超时数字都不是简单调大了事。**

## 改动内容

**失败一 —— `daemon-autostart-recovery.test.ts`(#1249 引入)。**
那个注入的假 daemon 一开始 listen 就挂 **100ms** idle 定时器,
而客户端的连接重试节奏也是 **100ms**。更窄的是:`protocol.hello` 刻意不算「已服务请求」,
所以客户端必须在同一个 100ms 内跑完**握手 + 第一条真实请求两个 loopback 往返**。
**余量在构造上就是零。**

客户端的重试节奏现在抽成单一导出常量 `localDaemonRetryIntervalMs`,两处调用点共用;
fixture 的首次请求宽限期由它派生(`localDaemonRetryIntervalMs * 20`),
**余量因此是结构性的**:客户端节奏若变,fixture 会跟着变。

**失败二 —— `repo-write-process-supervisor.test.ts:361`(既有)。**
40ms 的请求 deadline 与真实子进程的阶段 telemetry 赛跑。现在改为:

1. 显式 `start()` supervisor,把 fork 与 READY 排除在被测窗口之外;
2. 子进程 fixture 在 `projection` telemetry **之后、经同一条 IPC 通道**发一个有序屏障帧
   ——父进程不可能先于它要见证的那条 telemetry 观察到屏障;
3. 断言超时**尚未**触发,然后用 mock 时钟精确推进 `requestTimeoutMs`。

**先后由协议事件决定,超时由虚拟时钟决定。** 两条断言都不再取决于 runner 先调度了哪个实时回调。

**归因与修复分开陈述。** `git blame` 显示该测试来自 `dbeb30f2`/`045c1635`,
#1249 既没改它也没改 `swallow-direct` 路径;#1249 加的是同文件里串行执行的 shutdown 测试,
合理推断它**暴露**了旧竞态而非引入它。「谁引入的」和「该不该修」是两个问题,
第二个问题的答案无论如何都是「该修」。

## 任务与范围

- Harness 任务:`task_01KZA3XQD83BSPC2VJ2HXS78ZA`
- 分支:`codex/timing-race-gates`
- 公开范围:`packages/daemon/src/client/local-json-rpc-client.ts`(仅抽常量)
  与 `packages/daemon/test` 下三个测试/fixture 文件
- 私有规划/证据已更新:是(task plan、artifacts/verification-report.md)
- 不在本 PR 范围:扫描发现的另外两处同形竞态(见下);daemon idle 默认值
  (`dec_01KZA1ZS0JHS9ZRQXESMC1W5HB`,归 `task_01KZA3BN8CPXENJ4JJTP0JRFG6`);
  test weight 登记。

## 版本影响

- 版本:不变,唯一的生产改动是把一个已有字面量抽成具名导出常量,两处调用点取值完全相同。
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:否
- Protected surface 范围:不适用
- 授权依据:不适用——这是针对 main 变红的测试确定性修复,不改任何 gate 权威面
- 机器检查边界:本 PR 只断言声明存在;声明是否属实、是否充分由评审者判断。
- Break-glass:否
- Break-glass 理由:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- 基线 `origin/main` SHA:`55afca0c`
- 分支与 `origin/main` 的 merge-base:`55afca0c`
- 最近一次 `git fetch origin`:2026-08-06,开 PR 前
- 同步方式:无需同步
- 公开 diff 命令:`git diff 55afca0c..f30b40d9`
- 私有证据 commit/路径:`harness/tasks/task_01KZA3XQD83BSPC2VJ2HXS78ZA-integration-main-379640c9-shard-1/artifacts/verification-report.md`
- 评审证据路径:同任务包
- GitHub Actions `rewrite-ci` run URL:本 PR 的 run
- [x] `git diff --check`
- [x] `npm run check:stop-point` —— 27 个 complete manifest gate 绿;affected fast 295/295;
  contract 159 pass、1 skip
- [x] 改动面定向测试(带计数):三个受影响测试文件 31/31
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- 未跑及原因:按任务契约的停止点,本机未跑完整 `check:ci`。

**「跑了 N 次都绿」在这里明确不算证据。** 这两条本来就大多数时候绿,
重跑区分不了「修好了」和「这次运气好」。验收仪器是 **mutation**:

| Mutation | 实际观测 |
|---|---|
| 让客户端每次 readiness retry 都重新 launch | `AssertionError: 63 !== 1`,`pass 0 / fail 1` |
| 删掉子进程的 `projection` telemetry、保留有序屏障 | `+ undefined  - 'projection'`,`pass 0 / fail 1` |
| 两者恢复 | 各 `pass 1 / fail 0` |

**抗抖是在真实负载下证明的,不是断言的。** 用 16 个 `node -e 'while (true) {}'`
占满全部 16 个逻辑 CPU(退出时 trap 终止并等待):
失败一跑 5/5 绿(**每次都含注入的 6.25s 冷启动**),失败二跑 20/20 绿。

## 审查证据

- 自审:CEO 通读全部 diff。有两点值得点名,因为它们才是「除了那个绿以外」可以信任的理由:
  1. 推进时钟**之前**新增的 `assert.equal(timeoutDiagnostic, undefined)`
     **证明**了先后顺序而不是假定它——没有这一句,一个迟到的屏障照样能过;
  2. 屏障走的是与它所见证的 telemetry **同一条** IPC 通道,
     所以先后是通道性质,不是时序上的指望。
  CEO 自己此前对失败二的判读——「fork 出来的 Node 子进程不可能在 40ms 内上报阶段」——
  **是错的**:那个 40ms deadline 在子进程 READY 之后才开始,
  所以竞态是 telemetry 对 deadline,不是 fork 对 deadline。修复针对的是真实的那个竞态。
- 复核 subagent:未使用
- 人工审查:待办
- 阻塞性发现:无

## 残余风险

- **同一形状在仓里还活着两处**,由扫描 250 条 integration tier 测试发现,
  刻意留作后续而不是把本 PR 铺开:
  `repo-write-process-supervisor.test.ts` 的「child that swallows PROCEED」
  (真实子进程对 40/80ms telemetry deadline),以及
  `repo-write-durable-deadline-honesty.test.ts`(40ms observation 对 fixture 的 60ms terminal timer)。
  **这已经是该形状的第二、第三例,所以后续应当质疑形状,而不是再逐个打补丁。**
- **`spawnCalls === 1` 守的是一个条件性保证,这一点值得说准。**
  它现在的含义是:一个已启动、且存活到首条真实请求的 cold-start flight,
  不会在 readiness retry 中被重复 launch。它**不**意味着 daemon 跨任意人类停顿常驻
  ——那仍是 `dec_01KZA1ZS0JHS9ZRQXESMC1W5HB` 尚未兑现的承诺。
  本 PR 之前,这条断言够向的是后面那个更强的性质,这也是它不稳的原因之一。
- 这几个文件的 test weight 仍未登记,分片分配仍会漂
  (两次红之间,失败从 shard 1 移到了 shard 5)。**刻意没有在这里登记 weight**:
  它只改变一次抛硬币落在哪个分片上。

## 关联材料

- 任务:`task_01KZA3XQD83BSPC2VJ2HXS78ZA`
- 证据:`harness/tasks/task_01KZA3XQD83BSPC2VJ2HXS78ZA-integration-main-379640c9-shard-1/artifacts/verification-report.md`
- 复核:红 run `31055692821`(`379640c9`)与 `31055907176`(`55afca0c`)
