### PR TITLE
fix(daemon): default to resident for interactive single-writer daemons

### DIFF
--- a/packages/cli/test/daemon-idle-default-invariant.test.ts
+++ b/packages/cli/test/daemon-idle-default-invariant.test.ts
@@ -1,0 +1,41 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createDaemonLaunchConfiguration,
+  defaultDaemonIdleExitMs
+} from "@harness-anything/daemon";
+
+// dec_01KZA1ZS0JHS9ZRQXESMC1W5HB: the code default for the daemon idle-exit
+// timer must not be a subsecond value. Interactive single-writer daemons
+// (dev / self-hosted) stay resident by default; a subsecond idle charged every
+// normal thinking pause a full cold restart. Either 0 (resident / never
+// idle-exit) or >= 1s satisfies the invariant. This test nails the invariant,
+// not the specific number, so a future tuning adjustment won't trip a
+// content-free red.
+
+test("default daemon idle-exit is not subsecond (interactive single-writer daemons stay resident)", () => {
+  assert.ok(
+    defaultDaemonIdleExitMs === 0 || defaultDaemonIdleExitMs >= 1000,
+    `defaultDaemonIdleExitMs must not be subsecond (either 0 = resident, or >= 1000ms); got ${defaultDaemonIdleExitMs}`
+  );
+});
+
+test("an explicit idleExitMs override is rendered into the daemon launch args", () => {
+  const configuration = createDaemonLaunchConfiguration({
+    target: {
+      canonicalRoot: "/repo",
+      repoId: "canonical",
+      socketPath: "/repo/daemon.sock",
+      userRoot: "/user-root"
+    },
+    entrypoint: "/repo/packages/cli/src/index.ts",
+    idleExitMs: 5_000,
+    execPath: "/usr/bin/node",
+    execArgv: [],
+    env: {}
+  });
+  const idleMsIndex = configuration.args.indexOf("--idle-ms");
+  assert.notEqual(idleMsIndex, -1, "launch args must include --idle-ms");
+  assert.equal(configuration.args[idleMsIndex + 1], "5000");
+});

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -49,7 +49,8 @@ export {
 
 // Cold authority readiness measured ~7.2s, so a 6s budget could never confirm it.
 export const defaultDaemonAutostartTimeoutMs = 30_000;
-export const defaultDaemonIdleExitMs = 750;
+// dec_01KZA1ZS0JHS9ZRQXESMC1W5HB: resident by default; 750ms misread pauses as session end. Override: --idle-ms.
+export const defaultDaemonIdleExitMs = 0;
 export const localDaemonRetryIntervalMs = 100;
 const minimumReadyProbeResponseTimeoutMs = 500;
 


### PR DESCRIPTION
# English

## Summary

The daemon idle-exit code default was `750`ms. Measurement over a real self-hosting session
(1,899 requests / 1,898 adjacent intervals) found **97.37% of gaps exceed 750ms**, with a
**p50 of 18.190s** — and 23 observed idle exits, each followed by a cold start (autostart
agent p50 4.704s, max 19.518s). A subsecond idle timer models "occasional traffic"; the real
shape is "a person working continuously, with thinking pauses of tens of seconds to minutes."
It charged a full cold restart for every normal pause.

Per `dec_01KZA1ZS0JHS9ZRQXESMC1W5HB`, interactive single-writer daemons (dev / self-hosted)
are **resident by default**. `defaultDaemonIdleExitMs` becomes `0`, which
`idle-exit-scheduler.ts:14` (`if (input.idleMs <= 0 ...) return`) already treats as
"never arm the idle timer."

**This is a code-default fix, not a live-config fix.** Both persisted launch specs on this
machine already carry `--idle-ms 0`; the decision was explicitly scoped that way.

## What Changed

- `packages/daemon/src/client/local-json-rpc-client.ts` — `defaultDaemonIdleExitMs` `750` → `0`,
  with a one-line decision reference. This is the only production change.
- `packages/cli/test/daemon-idle-default-invariant.test.ts` (new, fast tier) — pins the
  **invariant** (`=== 0 || >= 1000`), not the number, plus an override regression proving an
  explicit `idleExitMs` still renders into `--idle-ms`.

The override path is untouched: `HARNESS_DAEMON_IDLE_MS` and `--idle-ms` still work. This value
stays an ordinary tunable, it did not become a hardcoded constant.

Not changed, deliberately: the GUI keeps its own `defaultDaemonIdleExitMs = 5 * 60_000`
(`packages/gui/src/main/local-composition-root.ts:17`). GUI depends on `daemon-client`, not
`daemon`, so it cannot import the constant. Different value, already compliant, out of scope.

## Task And Scope

- Harness task: `task_01KZA3BN8CPXENJ4JJTP0JRFG6`
- Branch: `codex/idle-default`
- Public scope: one daemon client default + one new CLI test
- Private planning/evidence updated: yes
- Out of scope: autostart budget (the 2026-08-05 incident review separated idle exit from
  autostart deliberately — idle exit is a *consequence* of the client giving up, not the cause);
  the GUI's independent constant; converging both definitions into one (that is a package
  boundary refactor).

## Version Impact

- Version: no version change because this is a behavioral default inside an unpublished workspace package
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `dec_01KZA1ZS0JHS9ZRQXESMC1W5HB` (active)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `54edc6f2e66d94860700a5ae05a449d29968f61a`
- Branch merge-base with `origin/main`: `54edc6f2e66d94860700a5ae05a449d29968f61a`
- Last `git fetch origin` time: 2026-08-06, immediately before opening this PR
- Sync method: rebase
- Public diff command: `git diff 54edc6f2...codex/idle-default`
- Private evidence commit/path: `harness/tasks/task_01KZA3BN8CPXENJ4JJTP0JRFG6-dec-01kza1zs0jhs9zrqxesmc1w5hb-daemon-idle-750ms/`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending, linked after the run reports
- [x] `git diff --check`
- [x] `npm run check:local` — 27 manifest gates green, 93.4s (re-run after rebase)
- [x] Targeted tests for the change surface, named with their counts:
  `daemon-idle-default-invariant` 2/2, `daemon-launch-spec-store` 5/5,
  `local-json-rpc-client` 16/16, `daemon-autostart-recovery` 1/1,
  `daemon-control-dispatcher` 20/20, `gui/service-bridge` 22/22
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: full `npm run check:ci` was not run locally — one machine running every job
  serially is strictly slower than CI running them in parallel and would hold the whole-machine
  slot budget against other in-flight workers. CI is the authority.

## Review Evidence

- Self-review: CEO verified the load-bearing semantics at the consumption site rather than
  accepting the worker's assertion — `packages/daemon/src/service/idle-exit-scheduler.ts:14`
  is `if (input.idleMs <= 0 || ...) return`, so `0` means "never arm", not "exit immediately."
  A repo-wide grep independently confirmed `750` had exactly one definition.
- Reviewer subagent: not used; the change surface is one constant plus a data-assertion test
- Human review: CEO semantic acceptance against `dec_01KZA1ZS0JHS9ZRQXESMC1W5HB`
- Blocking findings: none

## Residual Risk

- **The invariant test asserts a range, and that is the point.** It cannot catch a future value
  that is non-subsecond but still wrong for the workload (say 2s). Pinning the exact number would
  make the gate go red with no information the next time anyone tunes it.
- **A pre-existing quirk is now moot rather than fixed**: `packages/cli/src/daemon/client.ts:130`
  calls `parsePositiveIntegerOr(env.HARNESS_DAEMON_IDLE_MS, defaultDaemonIdleExitMs)` without
  `allowZero`, so an explicit `HARNESS_DAEMON_IDLE_MS=0` used to silently fall back to 750 —
  asking for resident got you 750ms. With the default at 0 the observable result is now correct,
  but the parse path still discards an explicit `0`. Not touched here; it would matter again if
  the default ever became non-zero.
- The GUI's separate definition means "the daemon idle default" still has two homes with
  different values. Both are compliant today; convergence is a package boundary question.

## References

- Task: `task_01KZA3BN8CPXENJ4JJTP0JRFG6`
- Evidence: `dec_01KZA1ZS0JHS9ZRQXESMC1W5HB` (measurement: 1,899 requests, 97.37% > 750ms, p50 18.190s, 23 idle exits)
- Review: task package `review.md`

---

# 中文

## 概要

daemon idle 退出的代码默认值是 `750`ms。对一次真实自宿主会话的实测(1,899 次请求 / 1,898 个相邻间隔)
显示 **97.37% 的间隔超过 750ms**,**p50 为 18.190s**;并实测到 23 次 idle 退出,每次后面都跟一次冷启动
(启动代理 p50 4.704s、最大 19.518s)。亚秒级 idle 假设的是「偶尔来一下」,
实际形态是「人坐着连续干活、中间十几秒到几分钟的思考停顿」——它把每一次正常停顿都按一次完整冷重启收费。

依 `dec_01KZA1ZS0JHS9ZRQXESMC1W5HB`,开发/自宿主这类交互式唯一写者的 daemon **默认常驻**。
`defaultDaemonIdleExitMs` 改为 `0`,而 `idle-exit-scheduler.ts:14`
(`if (input.idleMs <= 0 ...) return`)本来就把它当作「永不武装 idle 定时器」。

**这修的是代码默认值,不是线上配置。** 本机两份持久化 launch spec 早已带 `--idle-ms 0`;
裁决当时就是这么划的范围。

## 改动内容

- `packages/daemon/src/client/local-json-rpc-client.ts` —— `defaultDaemonIdleExitMs` `750` → `0`,
  附一行裁决引用。这是本次唯一的生产代码改动。
- `packages/cli/test/daemon-idle-default-invariant.test.ts`(新增,fast tier)—— 钉的是
  **不变量**(`=== 0 || >= 1000`)而不是那个数字,另加一条覆盖回归,证明显式传入的
  `idleExitMs` 仍会渲染进 `--idle-ms`。

覆盖路径未动:`HARNESS_DAEMON_IDLE_MS` 与 `--idle-ms` 照常生效。这个值仍是普通可调参数,
没有被变成硬编码常量。

**刻意没动**:GUI 保留自己的 `defaultDaemonIdleExitMs = 5 * 60_000`
(`packages/gui/src/main/local-composition-root.ts:17`)。GUI 依赖 `daemon-client` 而非 `daemon`,
无法 import 该常量。值不同、已合规、不在本任务边界内。

## 任务与范围

- Harness 任务:`task_01KZA3BN8CPXENJ4JJTP0JRFG6`
- 分支:`codex/idle-default`
- 公开范围:一个 daemon 客户端默认值 + 一个新增 CLI 测试
- 私有规划/证据已更新:是
- 不在范围内:autostart 预算(2026-08-05 的事故复盘明确把 idle 退出与 autostart 分开过一次——
  idle 退出是客户端放弃之后的**后果**,不是主因);GUI 的独立常量;把两处定义收敛为一处
  (那是包边界重构)。

## 版本影响

- 版本:无版本变更,因为这是未发布 workspace 包内部的行为默认值
- 发布影响:不发布

## 治理声明

- 触碰 protected surface:否
- Protected surface 范围:不适用
- 授权依据:`dec_01KZA1ZS0JHS9ZRQXESMC1W5HB`(active)
- 机器检查边界:本 PR 只断言声明存在;声明是否属实且充分由评审者判断。
- Break-glass:否
- Break-glass 理由:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- Base `origin/main` SHA:`54edc6f2e66d94860700a5ae05a449d29968f61a`
- 与 `origin/main` 的 merge-base:`54edc6f2e66d94860700a5ae05a449d29968f61a`
- 最后一次 `git fetch origin` 时间:2026-08-06,开 PR 前刚跑
- 同步方式:rebase
- 公开 diff 命令:`git diff 54edc6f2...codex/idle-default`
- 私有证据 commit/路径:`harness/tasks/task_01KZA3BN8CPXENJ4JJTP0JRFG6-dec-01kza1zs0jhs9zrqxesmc1w5hb-daemon-idle-750ms/`
- 评审证据路径:同一任务包
- GitHub Actions `rewrite-ci` run URL:待 run 报告后回填
- [x] `git diff --check`
- [x] `npm run check:local` —— 27 个 manifest gate 全绿,93.4s(rebase 后重跑)
- [x] 本次改动面的定向测试及计数:
  `daemon-idle-default-invariant` 2/2、`daemon-launch-spec-store` 5/5、
  `local-json-rpc-client` 16/16、`daemon-autostart-recovery` 1/1、
  `daemon-control-dispatcher` 20/20、`gui/service-bridge` 22/22
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威完整门)
- 未跑及原因:本地未跑完整 `npm run check:ci` —— 一台机器顺序跑完所有 job 严格慢于 CI 并行跑,
  而且会占住全机槽预算、把同机其他 worker 堵在后面。CI 是权威。

## 评审证据

- 自审:CEO 在消费点核实了承重语义,而不是接受 worker 的断言——
  `packages/daemon/src/service/idle-exit-scheduler.ts:14` 是
  `if (input.idleMs <= 0 || ...) return`,所以 `0` 意思是「永不武装」而非「立即退出」。
  另用全仓 grep 独立确认 `750` 确实只有一处定义。
- 评审 subagent:未使用;改动面是一个常量加一条数据断言测试
- 人工评审:CEO 对照 `dec_01KZA1ZS0JHS9ZRQXESMC1W5HB` 做语义验收
- 阻塞性发现:无

## 残留风险

- **不变量测试断言的是一个区间,这正是它的用意。** 它抓不住「非亚秒级但对这个负载仍然不对」
  的未来取值(比如 2s)。钉死具体数字则会让下次调值时门红得毫无信息量。
- **一个既有小毛病现在被绕过而非修好**:`packages/cli/src/daemon/client.ts:130` 调用
  `parsePositiveIntegerOr(env.HARNESS_DAEMON_IDLE_MS, defaultDaemonIdleExitMs)` 时未带
  `allowZero`,所以显式 `HARNESS_DAEMON_IDLE_MS=0` 过去会静默回退到 750——
  要常驻反而得到 750ms。默认值改成 0 之后可观察结果正确了,但 parse 路径仍会丢弃显式的 `0`。
  本次未动;若将来默认值再变成非零,它会重新变得重要。
- GUI 的独立定义意味着「daemon idle 默认值」仍有两个家、两个值。今天两者都合规;
  收敛与否是包边界问题。

## 参考

- 任务:`task_01KZA3BN8CPXENJ4JJTP0JRFG6`
- 证据:`dec_01KZA1ZS0JHS9ZRQXESMC1W5HB`(实测:1,899 次请求,97.37% > 750ms,p50 18.190s,23 次 idle 退出)
- 评审:任务包 `review.md`
