### PR TITLE
fix(kernel): registry lock release proves ownership before deleting

### DIFF
--- a/packages/kernel/src/daemon/registry.ts
+++ b/packages/kernel/src/daemon/registry.ts
@@ -1,5 +1,5 @@
 // @slice-activation PLT-Boundary W1 exposes this module through the package root API.
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import {
   existsSync,
   lstatSync,
@@ -18,6 +18,11 @@ import { resolveHarnessLayout } from "../layout/index.ts";
 import { isExclusiveCreateConflict } from "../local/local-layout-file-system.ts";
 
 export const daemonRegistrySchema = "harness-daemon-registry/v1";
+
+interface DaemonRegistryMutationLockRecord {
+  readonly schema: "daemon-registry-mutation-lock/v1";
+  readonly ownerToken: string;
+}
 
 export type DaemonRepoState = "enabled" | "disabled";
 
@@ -56,6 +61,7 @@ export interface DaemonRegistryOptions {
   readonly now?: () => Date;
   readonly platform?: NodeJS.Platform;
   readonly createConvenienceLinks?: boolean;
+  readonly mutationLockStaleMs?: number;
 }
 
 export interface DaemonRegistryRegisterInput extends DaemonRegistryOptions {
@@ -361,15 +367,18 @@ function replaceRepo(registry: DaemonRegistry, replacement: DaemonRegistryRepo):
 function withDaemonRegistryMutationLock<T>(options: DaemonRegistryOptions, mutate: () => T): T {
   const { userRoot, registryPath } = daemonRegistryPaths(options);
   const lockPath = `${registryPath}.lock`;
+  const staleMs = options.mutationLockStaleMs ?? 30_000;
+  const ownerToken = randomBytes(12).toString("hex");
   mkdirSync(userRoot, { recursive: true });
   const deadline = Date.now() + 5_000;
   while (true) {
+    if (Date.now() >= deadline) throw new Error(`timed out acquiring daemon registry mutation lock: ${lockPath}`);
     try {
       mkdirSync(lockPath);
-      break;
+      if (createDaemonRegistryMutationLockRecord(lockPath, ownerToken)) break;
     } catch (error) {
       if (!isExclusiveCreateConflict(error, options.platform)) throw error;
-      if (registryLockIsStale(lockPath)) {
+      if (registryLockIsStale(lockPath, staleMs)) {
         try {
           rmSync(lockPath, { recursive: true });
         } catch {
@@ -377,20 +386,54 @@ function withDaemonRegistryMutationLock<T>(options: DaemonRegistryOptions, mutat
         }
         continue;
       }
-      if (Date.now() >= deadline) throw new Error(`timed out acquiring daemon registry mutation lock: ${lockPath}`);
-      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
     }
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
   }
   try {
     return mutate();
   } finally {
-    rmSync(lockPath, { recursive: true, force: true });
+    releaseDaemonRegistryMutationLock(lockPath, ownerToken);
   }
 }
 
-function registryLockIsStale(lockPath: string): boolean {
+function createDaemonRegistryMutationLockRecord(lockPath: string, ownerToken: string): boolean {
+  const record = {
+    schema: "daemon-registry-mutation-lock/v1",
+    ownerToken
+  } satisfies DaemonRegistryMutationLockRecord;
   try {
-    return Date.now() - statSync(lockPath).mtimeMs > 30_000;
+    // Acquisition completes at the exclusive record write; stale recovery may replace the directory after mkdir.
+    writeFileSync(path.join(lockPath, "owner.json"), `${JSON.stringify(record)}\n`, { encoding: "utf8", flag: "wx" });
+    return true;
+  } catch (error) {
+    const code = typeof error === "object" && error !== null && "code" in error ? error.code : undefined;
+    if (code === "EEXIST" || code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function releaseDaemonRegistryMutationLock(lockPath: string, ownerToken: string): void {
+  const record = readDaemonRegistryMutationLockRecord(lockPath);
+  // Missing, unreadable, or replaced records cannot prove ownership and are left to stale recovery.
+  if (record?.ownerToken === ownerToken) rmSync(lockPath, { recursive: true, force: true });
+}
+
+function readDaemonRegistryMutationLockRecord(lockPath: string): DaemonRegistryMutationLockRecord | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path.join(lockPath, "owner.json"), "utf8")) as unknown;
+    return isDaemonRegistryRecord(parsed)
+      && parsed.schema === "daemon-registry-mutation-lock/v1"
+      && typeof parsed.ownerToken === "string"
+      ? { schema: "daemon-registry-mutation-lock/v1", ownerToken: parsed.ownerToken }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function registryLockIsStale(lockPath: string, staleMs: number): boolean {
+  try {
+    return Date.now() - statSync(lockPath).mtimeMs > staleMs;
   } catch {
     return false;
   }

--- a/packages/kernel/test/store/daemon-registry.test.ts
+++ b/packages/kernel/test/store/daemon-registry.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { pathToFileURL } from "node:url";
+import { Worker } from "node:worker_threads";
 import {
   daemonRegistryPaths,
   daemonRegistrySchema,
@@ -61,6 +62,138 @@ test("register classifies a Windows lock-create EPERM after the lock disappears 
   });
 
   assert.equal(result.repo.repoId, "project");
+});
+
+test("owner-record loss retries honor the registry lock acquisition deadline", (context) => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-daemon-registry-owner-loss-"));
+  const userRoot = path.join(root, "user-harness");
+  const canonicalRoot = createHarnessRepo(path.join(root, "project"));
+  const lockPath = `${daemonRegistryPaths({ userRoot }).registryPath}.lock`;
+  const ownerPath = path.join(lockPath, "owner.json");
+  const originalWriteFileSync = fs.writeFileSync;
+  const originalDateNow = Date.now;
+  let ownerRecordAttempts = 0;
+  let clockReads = 0;
+  fs.writeFileSync = ((
+    inputPath: Parameters<typeof fs.writeFileSync>[0],
+    data: Parameters<typeof fs.writeFileSync>[1],
+    options?: Parameters<typeof fs.writeFileSync>[2]
+  ) => {
+    if (inputPath === ownerPath) {
+      ownerRecordAttempts += 1;
+      if (ownerRecordAttempts >= 3) throw new Error("owner-record retry bypassed registry lock deadline");
+      rmSync(lockPath, { recursive: true, force: true });
+    }
+    return Reflect.apply(originalWriteFileSync, fs, [inputPath, data, options]);
+  }) as typeof fs.writeFileSync;
+  Date.now = () => {
+    clockReads += 1;
+    return clockReads <= 2 ? 0 : 5_000;
+  };
+  syncBuiltinESMExports();
+  context.after(() => {
+    fs.writeFileSync = originalWriteFileSync;
+    Date.now = originalDateNow;
+    syncBuiltinESMExports();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  assert.throws(
+    () => registerDaemonRepo({
+      userRoot,
+      canonicalRoot,
+      repoId: "project",
+      createConvenienceLinks: false,
+      mutationLockStaleMs: 0
+    }),
+    /timed out acquiring daemon registry mutation lock/u
+  );
+  assert.equal(ownerRecordAttempts, 1);
+});
+
+test("a stale registry lock owner cannot release a replacement owner's lock", { timeout: 10_000 }, async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-daemon-registry-owner-"));
+  const userRoot = path.join(root, "user-harness");
+  const firstRoot = createHarnessRepo(path.join(root, "first"));
+  const secondRoot = createHarnessRepo(path.join(root, "second"));
+  const lockPath = `${daemonRegistryPaths({ userRoot }).registryPath}.lock`;
+  const moduleUrl = pathToFileURL(path.resolve("packages/kernel/src/daemon/registry.ts")).href;
+  const state = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 4));
+  const first = startPausedRegistryMutationWorker({
+    moduleUrl, userRoot, canonicalRoot: firstRoot, repoId: "first", state, enteredIndex: 0, releaseIndex: 1
+  });
+  let second: ReturnType<typeof startPausedRegistryMutationWorker> | undefined;
+  try {
+    await waitForWorkerState(state, 0);
+    fs.utimesSync(lockPath, new Date(0), new Date(0));
+    second = startPausedRegistryMutationWorker({
+      moduleUrl,
+      userRoot,
+      canonicalRoot: secondRoot,
+      repoId: "second",
+      state,
+      enteredIndex: 2,
+      releaseIndex: 3,
+      mutationLockStaleMs: 0
+    });
+    await waitForWorkerState(state, 2);
+
+    releasePausedRegistryMutation(state, 1);
+    await first.finished;
+
+    assert.equal(existsSync(lockPath), true, "the stale owner removed the replacement owner's lock");
+  } finally {
+    releasePausedRegistryMutation(state, 1);
+    releasePausedRegistryMutation(state, 3);
+    await Promise.allSettled([first.finished, ...(second ? [second.finished] : [])]);
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("an uncontended registry mutation changes the registry and releases its lock", () => {
+  withTempDir((root) => {
+    const userRoot = path.join(root, "user-harness");
+    const canonicalRoot = createHarnessRepo(path.join(root, "project"));
+    const lockPath = `${daemonRegistryPaths({ userRoot }).registryPath}.lock`;
+
+    const registered = registerDaemonRepo({
+      userRoot,
+      canonicalRoot,
+      repoId: "project",
+      createConvenienceLinks: false
+    });
+
+    assert.equal(registered.changed, true);
+    assert.equal(readDaemonRegistry({ userRoot }).repos[0]?.state, "enabled");
+    assert.equal(existsSync(lockPath), false);
+
+    const unregistered = unregisterDaemonRepo("project", { userRoot, createConvenienceLinks: false });
+    assert.equal(unregistered.changed, true);
+    assert.equal(readDaemonRegistry({ userRoot }).repos[0]?.state, "disabled");
+    assert.equal(existsSync(lockPath), false);
+  });
+});
+
+test("a registry mutation recovers a stale tokenless legacy lock", () => {
+  withTempDir((root) => {
+    const userRoot = path.join(root, "user-harness");
+    const canonicalRoot = createHarnessRepo(path.join(root, "project"));
+    const lockPath = `${daemonRegistryPaths({ userRoot }).registryPath}.lock`;
+    mkdirSync(lockPath, { recursive: true });
+    fs.utimesSync(lockPath, new Date(0), new Date(0));
+
+    const result = registerDaemonRepo({
+      userRoot,
+      canonicalRoot,
+      repoId: "project",
+      createConvenienceLinks: false,
+      mutationLockStaleMs: 0
+    });
+
+    assert.equal(result.changed, true);
+    assert.equal(readDaemonRegistry({ userRoot }).repos[0]?.repoId, "project");
+    assert.equal(existsSync(lockPath), false);
+  });
 });
 
 test("daemon registry register realpaths canonical roots and writes registry-only when links are disabled", () => {
@@ -461,4 +594,79 @@ async function runRegistryMutationChild(source: string): Promise<void> {
     child.on("error", reject);
     child.on("exit", (code) => code === 0 ? resolve() : reject(new Error(`registry mutation child exited ${String(code)}: ${stderr}`)));
   });
+}
+
+function startPausedRegistryMutationWorker(input: {
+  readonly moduleUrl: string;
+  readonly userRoot: string;
+  readonly canonicalRoot: string;
+  readonly repoId: string;
+  readonly state: Int32Array;
+  readonly enteredIndex: number;
+  readonly releaseIndex: number;
+  readonly mutationLockStaleMs?: number;
+}): { readonly finished: Promise<void> } {
+  const source = `
+    const fs = require("node:fs");
+    const path = require("node:path");
+    const { syncBuiltinESMExports } = require("node:module");
+    const { workerData } = require("node:worker_threads");
+    const state = new Int32Array(workerData.sharedState);
+    const registryPath = path.join(workerData.userRoot, "registry.json");
+    const originalExistsSync = fs.existsSync;
+    let paused = false;
+    fs.existsSync = (inputPath) => {
+      if (!paused && inputPath === registryPath) {
+        paused = true;
+        Atomics.store(state, workerData.enteredIndex, 1);
+        Atomics.notify(state, workerData.enteredIndex);
+        Atomics.wait(state, workerData.releaseIndex, 0);
+      }
+      return originalExistsSync(inputPath);
+    };
+    syncBuiltinESMExports();
+    void import(workerData.moduleUrl).then(({ registerDaemonRepo }) => {
+      registerDaemonRepo({
+        userRoot: workerData.userRoot,
+        canonicalRoot: workerData.canonicalRoot,
+        repoId: workerData.repoId,
+        createConvenienceLinks: false,
+        ...(workerData.mutationLockStaleMs === undefined
+          ? {}
+          : { mutationLockStaleMs: workerData.mutationLockStaleMs })
+      });
+    }).catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+  `;
+  const worker = new Worker(source, {
+    eval: true,
+    workerData: {
+      moduleUrl: input.moduleUrl,
+      userRoot: input.userRoot,
+      canonicalRoot: input.canonicalRoot,
+      repoId: input.repoId,
+      sharedState: input.state.buffer,
+      enteredIndex: input.enteredIndex,
+      releaseIndex: input.releaseIndex,
+      mutationLockStaleMs: input.mutationLockStaleMs
+    }
+  });
+  const finished = new Promise<void>((resolve, reject) => {
+    worker.once("error", reject);
+    worker.once("exit", (code) => code === 0 ? resolve() : reject(new Error(`registry mutation worker exited ${code}`)));
+  });
+  return { finished };
+}
+
+async function waitForWorkerState(state: Int32Array, index: number): Promise<void> {
+  while (Atomics.load(state, index) === 0) {
+    await Atomics.waitAsync(state, index, 0).value;
+  }
+}
+
+function releasePausedRegistryMutation(state: Int32Array, index: number): void {
+  Atomics.store(state, index, 1);
+  Atomics.notify(state, index);
 }


### PR DESCRIPTION
# English

## Summary

`withDaemonRegistryMutationLock` released its lock with an unconditional
`finally { rmSync(lockPath, { recursive: true, force: true }) }` — **it never checked whether it
was still the holder**. Combined with the 30s stale reclamation in the same function, there is a
deterministic failure sequence: A holds the lock and its `mutate()` runs past the stale threshold →
B judges the lock stale, deletes it and creates its own → A finishes and deletes **B's** lock →
mutual exclusion is gone and a third party can enter while B is still writing.

"Low probability" was not accepted as "does not hold." All three registry `mutate()` calls are
synchronous file reads/writes and are normally fast, but they have **no structural upper bound**:
a paused process, a disk stall, or a very large registry can each cross a 30s wall clock.

Governed by `dec_01KZA6R4YKKSQQJPMFZSXYP29S` (active).

**This is not a new lock format — it aligns the registry with the shape the repo already uses.**
A same-shape scan confirmed the task-holder lock, the write-coordinator lock, and the
daemon-generation lock all already carry an `ownerToken` check. The registry was the only exception.

## What Changed

- `packages/kernel/src/daemon/registry.ts`
  - The lock directory now holds an `owner.json` record with a random `ownerToken`.
  - **Release only deletes a lock it can prove is its own.** A missing, tokenless, unparseable,
    unreadable, or mismatched record all mean "not ours" — leave it to stale recovery.
  - **Acquisition now completes at the exclusive record write, not at `mkdir`.** The record is
    written with `flag: "wx"`. This came out of asking what a concurrent observer sees in the
    window between `mkdir` and the token write: if a reclaimer replaces the directory in that
    window, a plain overwrite write would clobber the replacement's token. `wx` makes exactly one
    contender win, and only the winner considers itself the holder.
  - Stale reclamation **still** claims tokenless (old-version) locks, so automatic recovery does
    not regress.
  - The acquisition deadline is now checked at the top of **every** loop iteration.
  - `mutationLockStaleMs` is injectable so the race can be tested without waiting 30s.

- `packages/kernel/test/store/daemon-registry.test.ts` — deterministic race reproduction,
  normal-path regression, tokenless-legacy reclamation, and a deadline-bound test.

## Task And Scope

- Harness task: `task_01KZA1E17BP467JDKEDY53HYYH`
- Branch: `codex/registry-release`
- Public scope: the daemon registry mutation lock and its tests
- Private planning/evidence updated: yes
- Out of scope: the deferred-release marker protocol from `task-holder-mutation-lock.ts` (that
  mechanism exists to handle Windows `EPERM` blocking an ownership read; the registry has no
  evidence of needing it, and the decision explicitly does not require it); raising the stale
  threshold (that moves the window rather than removing it, and afterwards nobody can prove
  whether it is still there).

## Version Impact

- Version: no version change because this is internal behavior in an unpublished workspace package
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `dec_01KZA6R4YKKSQQJPMFZSXYP29S` (active) — the lock's on-disk representation changes,
  which is observable and involves old/new version coexistence, so it was adjudicated before
  implementation rather than after.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `caff243a2f3a6620442d0cf645515d61791f49cb`
- Branch merge-base with `origin/main`: `caff243a2f3a6620442d0cf645515d61791f49cb`
- Last `git fetch origin` time: 2026-08-06, immediately before opening this PR
- Sync method: rebase
- Public diff command: `git diff caff243a...codex/registry-release`
- Private evidence commit/path: `harness/tasks/task_01KZA1E17BP467JDKEDY53HYYH-daemon-registry-stale-finally-rmsync/`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending, linked after the run reports
- [x] `git diff --check`
- [x] `npm run check:local` — 27 complete manifest gates green; 85 affected fast tests; 93 contract tests
- [x] Targeted tests for the change surface, named with their counts:
  `packages/kernel/test/store/daemon-registry.test.ts` 23 pass / 0 fail
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: full `npm run check:ci` was not run locally — one machine running every job
  serially is strictly slower than CI running them in parallel and would hold the whole-machine
  slot budget against the other in-flight workers. CI is the authority.

**Negative controls were actually run; "it is green after the fix" was not accepted as evidence.**

| Mutation | Observed |
|---|---|
| Remove the ownership check from release | `AssertionError: the stale owner removed the replacement owner's lock, false !== true` — `pass 0 / fail 1` |
| Restore it | `✔ a stale registry lock owner cannot release a replacement owner's lock` — `pass 1 / fail 0` |
| Old loop (deadline escape) | expected `/timed out acquiring daemon registry mutation lock/`, got the sentinel `Error: owner-record retry bypassed registry lock deadline` — `pass 0 / fail 1` |
| Fixed loop | `✔ owner-record loss retries honor the registry lock acquisition deadline` — `pass 1 / fail 0` |

**The tests decide on events, not on elapsed time.** Ordering is controlled by
`SharedArrayBuffer`/`Atomics` fences; the race case runs in ~84ms rather than waiting the real 30s;
the deadline test injects `mutationLockStaleMs: 0` and advances a logical `Date.now`. The 10s test
timeout is hang protection only and takes no part in any correctness decision.

## Review Evidence

- Self-review: CEO review found one defect the first round introduced and sent it back —
  the acquisition loop could escape its own 5s bounded-wait guarantee. A failed owner-record
  write did `continue` straight back to `mkdirSync` with no deadline check and no backoff; on the
  `ENOENT` branch (our directory reclaimed between `mkdir` and the token write) `mkdirSync` would
  succeed again, so that path never reached the deadline check. Production `staleMs = 30_000`
  makes it narrow, but `mutationLockStaleMs` is now injectable, so a caller passing a small value
  reaches it trivially. The fix moved the deadline check to the top of every iteration. The
  invariant was stated to the implementer ("every iteration of the loop must be bounded by the
  same deadline"); the specific edit was not prescribed.
- Reviewer subagent: not used
- Human review: CEO semantic acceptance against `dec_01KZA6R4YKKSQQJPMFZSXYP29S`, plus a direct
  read of the final acquisition loop
- Blocking findings: one, listed above, fixed and covered by a test before this PR was opened

## Residual Risk

- **Release is narrowed, not made atomic.** `releaseDaemonRegistryMutationLock` reads the record,
  compares the token, then `rmSync`s. Between the read and the delete our lock could be judged
  stale, reclaimed, and rebuilt by a new owner — and we would still delete that new owner's lock.
  The window drops from ~30s to microseconds, and reaching it requires that we already exceeded
  `staleMs`. **This is deliberately not written up as fully fixed.** Node's cross-platform
  filesystem API has no atomic compare-and-delete; eliminating it would need a native advisory
  lock or a fuller claim/quarantine/restore protocol, which is out of proportion to this fix.
  All three sibling locks (task-holder, write-coordinator, daemon-generation) accept the same
  residual window today.
- **The stale-reclaim path spins without backoff**, bounded only by the 5s acquisition deadline.
  It is bounded, which was the invariant required; it is not smooth.
- **Mixed old/new processes still have the original race window**, because an old holder's release
  is still unconditional. This is today's behavior, not newly introduced risk, and it disappears
  as old processes exit. The decision chose this over refusing to reclaim tokenless locks, which
  would trade an intermittent mutual-exclusion failure for a lock nobody can reclaim without
  manual `rm`.

## References

- Task: `task_01KZA1E17BP467JDKEDY53HYYH`
- Evidence: `dec_01KZA6R4YKKSQQJPMFZSXYP29S`, `dec_01KZ9YXZMCKAZEC5MQF9RK8GWK` (the sibling line
  that rejected the same "safer-looking permanent deadlock" shape)
- Review: task package `review.md`

---

# 中文

## 概要

`withDaemonRegistryMutationLock` 的释放是无条件的
`finally { rmSync(lockPath, { recursive: true, force: true }) }`——**它从不校验自己是否仍是持有者**。
与同函数里的 30s 陈旧回收叠加,存在确定性失效序列:
A 持锁且 `mutate()` 跑过陈旧阈值 → B 判定陈旧、删掉 A 的锁并重建 → A 收尾时删掉**B 的**锁
→ 互斥失效,第三方可在 B 仍在写时进入。

**「概率低」没有被当成「不成立」。** registry 的三个 `mutate()` 都是同步文件读写、通常很快,
但**没有任何结构性上界**:进程暂停、磁盘阻塞、极大 registry 都能跨过 30s 墙钟。

治理依据:`dec_01KZA6R4YKKSQQJPMFZSXYP29S`(active)。

**这不是发明一种新锁格式,而是把 registry 并回本仓既有的形状。** 同族扫描确认:
task-holder 锁、write-coordinator 锁、daemon-generation 锁三者都已经有 `ownerToken` 校验,
**registry 是唯一的例外**。

## 改动内容

- `packages/kernel/src/daemon/registry.ts`
  - 锁目录内持久化一份带随机 `ownerToken` 的 `owner.json` 记录。
  - **释放只删能证明是自己的那把锁。** 记录缺失、无 token、解析失败、读不出来、token 不匹配,
    一律视为「不是我的」,交给陈旧回收处理。
  - **获取的完成点从 `mkdir` 移到 owner 记录的排他写入**,记录用 `flag: "wx"` 写。
    这来自追问「`mkdir` 之后、token 落盘之前,并发观察者看到的是什么」:
    若回收者在这个窗口里替换了目录,覆盖式写入会盖掉接替者的 token。
    `wx` 让恰好一个竞争者获胜,且只有获胜者认为自己是持有者。
  - 陈旧回收**继续**认领无 token 的旧版本锁,自动恢复能力不退化。
  - 获取的 deadline 现在在**每一轮**循环入口检查。
  - `mutationLockStaleMs` 可注入,使竞态无需真等 30s 即可测试。

- `packages/kernel/test/store/daemon-registry.test.ts` —— 确定性竞态复现、正常路径回归、
  tokenless 旧锁回收、以及 deadline 有界性测试。

## 任务与范围

- Harness 任务:`task_01KZA1E17BP467JDKEDY53HYYH`
- 分支:`codex/registry-release`
- 公开范围:daemon registry 的变更锁及其测试
- 私有规划/证据已更新:是
- 不在范围内:`task-holder-mutation-lock.ts` 那套 deferred-release marker 协议
  (该机制是为应对 Windows `EPERM` 下读不到归属而生;registry 无此证据,裁决也明确不要求它);
  调大陈旧阈值(那是把窗口挪远而非消除,此后没人能证明它还在不在)。

## 版本影响

- 版本:无版本变更,因为这是未发布 workspace 包的内部行为
- 发布影响:不发布

## 治理声明

- 触碰 protected surface:否
- Protected surface 范围:不适用
- 授权依据:`dec_01KZA6R4YKKSQQJPMFZSXYP29S`(active)——锁的磁盘表示发生了可观察的变更、
  涉及新旧版本共存,因此在实现**之前**先行裁决,而不是事后补。
- 机器检查边界:本 PR 只断言声明存在;声明是否属实且充分由评审者判断。
- Break-glass:否
- Break-glass 理由:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- Base `origin/main` SHA:`caff243a2f3a6620442d0cf645515d61791f49cb`
- 与 `origin/main` 的 merge-base:`caff243a2f3a6620442d0cf645515d61791f49cb`
- 最后一次 `git fetch origin` 时间:2026-08-06,开 PR 前刚跑
- 同步方式:rebase
- 公开 diff 命令:`git diff caff243a...codex/registry-release`
- 私有证据 commit/路径:`harness/tasks/task_01KZA1E17BP467JDKEDY53HYYH-daemon-registry-stale-finally-rmsync/`
- 评审证据路径:同一任务包
- GitHub Actions `rewrite-ci` run URL:待 run 报告后回填
- [x] `git diff --check`
- [x] `npm run check:local` —— 27 个 manifest gate 绿;受影响 fast 测试 85 通过;contract 测试 93 通过
- [x] 本次改动面的定向测试及计数:
  `packages/kernel/test/store/daemon-registry.test.ts` 23 pass / 0 fail
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威完整门)
- 未跑及原因:本地未跑完整 `npm run check:ci` —— 一台机器顺序跑完所有 job 严格慢于 CI 并行跑,
  而且会占住全机槽预算、把同机其他在飞 worker 堵在后面。CI 是权威。

**阴性对照真跑了;「修完是绿的」没有被当成证据。**

| Mutation | 实际观测 |
|---|---|
| 撤掉释放处的归属校验 | `AssertionError: the stale owner removed the replacement owner's lock, false !== true` —— `pass 0 / fail 1` |
| 恢复 | `✔ a stale registry lock owner cannot release a replacement owner's lock` —— `pass 1 / fail 0` |
| 旧循环(deadline 逃逸) | 期待 `/timed out acquiring daemon registry mutation lock/`,实得哨兵 `Error: owner-record retry bypassed registry lock deadline` —— `pass 0 / fail 1` |
| 修正后的循环 | `✔ owner-record loss retries honor the registry lock acquisition deadline` —— `pass 1 / fail 0` |

**测试的判定取决于事件,不取决于耗时。** 先后由 `SharedArrayBuffer`/`Atomics` 栅栏控制;
竞态用例约 84ms 而不是真等 30 秒;deadline 测试注入 `mutationLockStaleMs: 0` 并推进逻辑 `Date.now`。
10 秒的测试 timeout 只防挂死,不参与任何正确性判定。

## 评审证据

- 自审:CEO 复核发现第一轮引入的一处缺陷并打回——**获取循环能逃出它自己的 5s 有界等待保证**。
  owner 记录写失败后直接 `continue` 回到 `mkdirSync`,既不查 deadline 也不退避;
  在 `ENOENT` 分支(我们刚建的目录在写 token 之前被回收)`mkdirSync` 会再次成功,
  于是这条路径永远走不到 deadline 检查。生产默认 `staleMs = 30_000` 让它很窄,
  但 `mutationLockStaleMs` 现已可注入,调用方传小值即可轻易触发。
  修法是把 deadline 检查提到每一轮循环入口。**向实现者陈述的是不变量**
  (「循环的每一次迭代都必须受同一个上界约束」),没有指定具体改法。
- 评审 subagent:未使用
- 人工评审:CEO 对照 `dec_01KZA6R4YKKSQQJPMFZSXYP29S` 做语义验收,并直读最终的获取循环
- 阻塞性发现:一处,即上述,已在开 PR 前修好并有测试覆盖

## 残留风险

- **释放被收窄了,但没有变成原子操作。** `releaseDaemonRegistryMutationLock` 先读记录、
  比对 token、再 `rmSync`。这两步之间,我们的锁仍可能被判陈旧、被回收、被新持有者重建,
  而我们照样会删掉新持有者的锁。窗口从约 30 秒降到微秒量级,且要触发它我们本来就已超过
  `staleMs`。**这里刻意不写成已根治。** Node 的跨平台文件系统 API 没有原子的
  compare-and-delete;彻底消除需要 native advisory lock 或更完整的
  claim/quarantine/restore 协议,与本次修复的体量不相称。
  三个姊妹锁(task-holder、write-coordinator、daemon-generation)今天同样接受这一残余窗口。
- **陈旧回收路径无退避地自旋**,只受 5s 获取 deadline 约束。它是有界的
  ——有界正是本轮要求的不变量——但并不平滑。
- **新旧进程混跑期仍存在原竞态窗口**,因为旧 holder 的释放依然无条件。
  这是今天已有的行为,不是新引入的风险,它随旧进程退出自然消失。
  裁决在此与「拒绝回收 tokenless 旧锁」之间选择了前者:后者会把一个间歇性的互斥失效,
  换成一把没有人工 `rm` 就无法回收的锁。

## 参考

- 任务:`task_01KZA1E17BP467JDKEDY53HYYH`
- 证据:`dec_01KZA6R4YKKSQQJPMFZSXYP29S`、`dec_01KZ9YXZMCKAZEC5MQF9RK8GWK`
  (姊妹线,否掉了同一个「看着更安全的持久死锁」形状)
- 评审:任务包 `review.md`
