### PR TITLE
test(daemon): replace remaining wall-clock races with ordered barriers

### DIFF
--- a/packages/daemon/test/repo-write-durable-deadline-honesty.test.ts
+++ b/packages/daemon/test/repo-write-durable-deadline-honesty.test.ts
@@ -12,14 +12,18 @@ const fixturePath = fileURLToPath(
 );
 
 test("durable deadline observes a slow canonical publication without replacing its writer", async (context) => {
+  const requestTimeoutMs = 40;
   let forks = 0;
-  const timeoutDiagnostics: RepoWriteRequestTimeoutDiagnostic[] = [];
+  let timeoutDiagnostic: RepoWriteRequestTimeoutDiagnostic | undefined;
+  let barrierError: unknown;
+  let confirmSlowTerminalReady!: () => void;
+  const slowTerminalReady = new Promise<void>((resolve) => {
+    confirmSlowTerminalReady = resolve;
+  });
   const supervisor = new RepoWriteProcessSupervisor({
     repoId: "repo-transport",
     generation: 1,
-    // Keep the 40ms observation deadline below the fixture's 60ms terminal,
-    // while leaving an order-of-magnitude margin before stall escalation.
-    limits: { requestTimeoutMs: 40, proceededStallTimeoutMs: 1_000 },
+    limits: { requestTimeoutMs },
     spawn: () => {
       forks += 1;
       return forkRepoWriteProcess({
@@ -27,20 +31,46 @@ test("durable deadline observes a slow canonical publication without replacing i
         args: ["slow-terminal"]
       });
     },
-    onRequestTimeout: (diagnostic) => timeoutDiagnostics.push(diagnostic)
+    onRequestTimeout: (diagnostic) => {
+      timeoutDiagnostic = diagnostic;
+    },
+    onDiagnostic: (frame) => {
+      if (frame.code !== "FIXTURE_SLOW_TERMINAL_READY") return;
+      try {
+        // Advance synchronously while handling the ordered barrier. Node may
+        // deliver the following terminal in the same IPC poll turn, before an
+        // awaiting continuation gets its own microtask checkpoint.
+        assert.equal(timeoutDiagnostic, undefined);
+        context.mock.timers.tick(requestTimeoutMs);
+      } catch (error) {
+        // Recovery-diagnostic observers intentionally swallow exceptions, so
+        // hand assertion failures back to the test continuation explicitly.
+        barrierError = error;
+      } finally {
+        confirmSlowTerminalReady();
+      }
+    }
   });
   context.after(() => supervisor.stop().catch(() => undefined));
 
-  const receipt = await supervisor.submit(
+  await supervisor.start();
+  context.mock.timers.enable({ apis: ["setTimeout"] });
+
+  const outcome = supervisor.submit(
     repoWriteProductionCommandFixture("record-fact", "slow publication")
   );
+  await slowTerminalReady;
+  if (barrierError) throw barrierError;
+  assert.equal(timeoutDiagnostic?.watchdogStage, "observation");
+  assert.ok(timeoutDiagnostic);
+  assert.equal(timeoutDiagnostic.deadlineMs, requestTimeoutMs);
+  assert.equal(timeoutDiagnostic.lane, "durable");
+  assert.equal(timeoutDiagnostic.lastTelemetry?.phase, "git");
+
+  const receipt = await outcome;
 
   assert.equal(receipt.ok, true);
   assert.equal(receipt.summary, "slow canonical publication");
-  assert.ok(timeoutDiagnostics.some((diagnostic) =>
-    diagnostic.watchdogStage === "observation"
-    && diagnostic.deadlineMs === 40
-    && diagnostic.lane === "durable"));
   assert.equal(forks, 1, "PROCEED transfers terminal ownership to the current writer");
   assert.equal(supervisor.status().connected, true);
 });

--- a/packages/daemon/test/repo-write-process-supervisor.test.ts
+++ b/packages/daemon/test/repo-write-process-supervisor.test.ts
@@ -313,13 +313,21 @@ test("connected child that never announces READY is terminated at the readiness 
 });
 
 test("child that swallows PROCEED is replaced after the bounded stall window and recovered by exact lookup", async (context) => {
+  const requestTimeoutMs = 40;
+  const proceededStallTimeoutMs = requestTimeoutMs * 2;
   let forks = 0;
   const timeoutDiagnostics: RepoWriteRequestTimeoutDiagnostic[] = [];
+  let timeoutDiagnostic: RepoWriteRequestTimeoutDiagnostic | undefined;
+  let confirmProceedStalled!: () => void;
+  const proceedStalled = new Promise<void>((resolve) => {
+    confirmProceedStalled = resolve;
+  });
   const supervisor = new RepoWriteProcessSupervisor({
     repoId: "repo-transport",
     generation: 1,
     limits: {
-      requestTimeoutMs: 40
+      requestTimeoutMs,
+      proceededStallTimeoutMs
     },
     spawn: () => {
       forks += 1;
@@ -328,21 +336,39 @@ test("child that swallows PROCEED is replaced after the bounded stall window and
         args: ["swallow-proceed"]
       });
     },
-    onRequestTimeout: (diagnostic) => timeoutDiagnostics.push(diagnostic)
+    onRequestTimeout: (diagnostic) => {
+      timeoutDiagnostic = diagnostic;
+      timeoutDiagnostics.push(diagnostic);
+    },
+    onDiagnostic: (frame) => {
+      if (frame.code === "FIXTURE_PROCEED_STALLED") confirmProceedStalled();
+    }
   });
   context.after(() => supervisor.stop().catch(() => undefined));
 
-  // Boundedness is asserted by awaiting the rejection itself: an unbounded
-  // regression hangs into the runner's per-test timeout instead of racing a
-  // wall-clock budget that slow CI child spawns cannot meet.
-  const outcome = await supervisor.submit(command()).then(
+  await supervisor.start();
+  context.mock.timers.enable({ apis: ["setTimeout"] });
+
+  const pendingOutcome = supervisor.submit(command());
+  const outcome = pendingOutcome.then(
     () => ({ kind: "committed" as const }),
     (error: unknown) => ({ kind: "rejected" as const, error })
   );
+  await proceedStalled;
+  assert.equal(timeoutDiagnostic, undefined);
 
-  assert.equal(outcome.kind, "rejected");
-  assert.ok(outcome.kind === "rejected" && outcome.error instanceof RepoWriteOutcomeUnknownError);
-  assert.equal(outcome.error.code, "REPO_WRITE_STALL_TIMEOUT");
+  context.mock.timers.tick(requestTimeoutMs);
+  assert.equal(timeoutDiagnostic?.watchdogStage, "observation");
+  assert.ok(timeoutDiagnostic);
+  assert.equal(timeoutDiagnostic.deadlineMs, requestTimeoutMs);
+  assert.equal(timeoutDiagnostic.lastTelemetry?.phase, "git");
+
+  context.mock.timers.tick(proceededStallTimeoutMs - requestTimeoutMs);
+  const settledOutcome = await outcome;
+
+  assert.equal(settledOutcome.kind, "rejected");
+  assert.ok(settledOutcome.kind === "rejected" && settledOutcome.error instanceof RepoWriteOutcomeUnknownError);
+  assert.equal(settledOutcome.error.code, "REPO_WRITE_STALL_TIMEOUT");
   assert.equal(forks, 2);
   assert.deepEqual(
     timeoutDiagnostics.map((diagnostic) => [
@@ -352,8 +378,8 @@ test("child that swallows PROCEED is replaced after the bounded stall window and
       diagnostic.lastTelemetry?.phase
     ]),
     [
-      ["observation", 40, timeoutDiagnostics[0]?.opId, "git"],
-      ["escalation", 80, timeoutDiagnostics[0]?.opId, "git"]
+      ["observation", requestTimeoutMs, timeoutDiagnostics[0]?.opId, "git"],
+      ["escalation", proceededStallTimeoutMs, timeoutDiagnostics[0]?.opId, "git"]
     ]
   );
 });

--- a/packages/daemon/test/support/repo-write-ipc-child.ts
+++ b/packages/daemon/test/support/repo-write-ipc-child.ts
@@ -145,7 +145,17 @@ if (mode === "expected-direct-rejection") {
           opId: message.opId,
           phase: "git",
           elapsedMs: 2.5
-        });
+        }).then(() => transport.send({
+          // Same-channel ordering makes this a deterministic test barrier: the
+          // parent cannot observe it before recording the telemetry above.
+          protocol: repoWriteProtocolType,
+          repoId: message.repoId,
+          generation: message.generation,
+          kind: "recovery-deferred",
+          outerOpId: `fixture-proceed-stalled:${message.requestId}`,
+          code: "FIXTURE_PROCEED_STALLED",
+          diagnostic: "fixture proceeded request reported git and will remain unresolved"
+        }));
         return;
       }
       if (mode === "crash-after-proceed") {
@@ -161,9 +171,17 @@ if (mode === "expected-direct-rejection") {
           opId: message.opId,
           phase: "git",
           elapsedMs: 2.5
-        });
-        setTimeout(() => {
-          void transport.send({
+        }).then(() => transport.send({
+          // The test advances its modeled observation deadline after this
+          // ordered barrier, before the following terminal can be observed.
+          protocol: repoWriteProtocolType,
+          repoId: message.repoId,
+          generation: message.generation,
+          kind: "recovery-deferred",
+          outerOpId: `fixture-slow-terminal:${message.requestId}`,
+          code: "FIXTURE_SLOW_TERMINAL_READY",
+          diagnostic: "fixture durable request reported git and is ready to publish terminal"
+        })).then(() => transport.send({
             protocol: repoWriteProtocolType,
             repoId: message.repoId,
             generation: message.generation,
@@ -172,8 +190,7 @@ if (mode === "expected-direct-rejection") {
             opId: message.opId,
             outcome: "committed",
             receipt: committedCommandReceipt("slow canonical publication")
-          });
-        }, 60);
+        }));
         return;
       }
       void transport.send({


### PR DESCRIPTION
# English

## Summary

PR #1252 fixed two integration tests whose verdicts were decided by "which of two comparable
real-time quantities wins." A same-shape scan across the integration tier found **two more**.
This PR converts both, and answers the question that matters more than the two instances:
**should this shape be stopped by a mechanism?**

A gate whose verdict is a coin flip does not report on the code — it reports on scheduler luck.
Both cases here had a real cross-process fixture racing a wall-clock deadline in the code under test.

## What Changed

- `packages/daemon/test/repo-write-process-supervisor.test.ts` — "child that swallows PROCEED"
  - Was: a real child process's telemetry racing a 40/80ms wall-clock watchdog.
  - Now: wait for the barrier the child sends **on the same IPC channel** after the telemetry,
    assert the timeout has **not** fired, then advance the 40ms observation and the derived
    remaining 40ms escalation on a mock clock.
- `packages/daemon/test/repo-write-durable-deadline-honesty.test.ts`
  - Was: a 40ms observation racing the fixture's 60ms terminal timer.
  - Now: `telemetry → barrier → terminal` ordered on one channel; the assertion and the 40ms
    advance both happen synchronously inside the barrier observer, so the deadline is observed
    before the next terminal frame is processed.
- `packages/daemon/test/support/repo-write-ipc-child.ts` — two barrier frames added; the
  slow-terminal path's bare 60ms timer removed.

**Ordering is now a channel property, not a timing hope.** No product source, no protected
surface, no `tools/` gate, and no test weight registration was touched (test weight would only
change which shard the coin lands in — that is not a fix).

## Should this shape get a gate?

**No — and the reason is precision, not preference.** Governed by `dec_01KZA811Z8R6V97B0488YTGF6Z`
(active).

A crude scan over 262 integration files for "timer + timeout/deadline" hit **14 files**, of which
only **2** — the two in this PR — are cross-process scaffolding races. The rest are polling loops,
failure fallbacks, same-event-loop timers, or genuine product wall-clock budgets. A static gate at
roughly 14% precision would fire on correct code, and a gate that fires on correct code teaches
everyone to route around it. That is the exact disease `check-cli-error-codes` currently has in
this repo.

**What replaces it must be named honestly, because review is what failed here.** The #1249 review
checked each negative control, challenged the 4s stop budget, and rejected the diagnostics gate's
anchoring — and never asked whether the new gates were themselves stable. So the replacement is
not "review more carefully"; it is one structural question that can be asked mechanically every
time, now sedimented into the orchestration review discipline: **does this gate's verdict depend
on two independent real-time quantities of the same magnitude?**

No fourth instance was found. The remaining `slow-shutdown-success` timer tests the product's real
graceful-stop wall-clock budget and is not this shape.

## Task And Scope

- Harness task: `task_01KZA5H978NF16XN35RV5WDTRE`
- Branch: `codex/timing-races`
- Public scope: two integration tests and one shared IPC child fixture
- Private planning/evidence updated: yes
- Out of scope: raising any timeout number (that moves the window rather than removing it, and
  afterwards nobody can prove whether it is still there); registering test weight; building a
  timing lint rule or a general fixture framework (both adjudicated above).

## Version Impact

- Version: no version change because only tests and a test fixture changed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `dec_01KZA811Z8R6V97B0488YTGF6Z` (active) for the "no gate" judgment
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `caff243a2f3a6620442d0cf645515d61791f49cb`
- Branch merge-base with `origin/main`: `caff243a2f3a6620442d0cf645515d61791f49cb`
- Last `git fetch origin` time: 2026-08-06, immediately before opening this PR
- Sync method: rebase
- Public diff command: `git diff caff243a...codex/timing-races`
- Private evidence commit/path: `harness/tasks/task_01KZA5H978NF16XN35RV5WDTRE-integration-tier-swallow-proceed-durable-deadline-honesty/artifacts/verification-report.md`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending, linked after the run reports
- [x] `git diff --check`
- [x] `npm run check:local` — 27 local manifest gates green, 60.3s (re-run on the rebased baseline)
- [x] Targeted tests for the change surface, named with their counts:
  the two changed test files together, 15/15 on the rebased baseline
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: full `check:ci` and the whole integration tier were not run locally — one
  machine running every job serially is strictly slower than CI running them in parallel and would
  hold the whole-machine slot budget against the other in-flight workers. CI is the authority.

**"It passed N times" is explicitly not the evidence here** — both tests were already green most
of the time, so repetition cannot separate "fixed" from "lucky." The load-bearing evidence is
discrimination, proven by mutation, with both sides' real output:

| Mutation | Observed |
|---|---|
| Break the swallow-PROCEED escalation error code | `✖ child that swallows PROCEED …` `+ 'REPO_WRITE_REQUEST_TIMEOUT' − 'REPO_WRITE_STALL_TIMEOUT'`, `exit_code=1` |
| Restore | `✔ child that swallows PROCEED …`, `pass 1 / fail 0` |
| Make the observation abort an already-PROCEEDed writer | `✖ durable deadline observes …` `RepoWriteNotStartedError: Repo writer request exceeded its 40ms deadline. Child last reported phase=git at elapsedMs=3.`, `exit_code=1` |
| Restore | `✔ durable deadline observes …`, `pass 1 / fail 0` |

**Anti-jitter was proven under real load**: 16 `node -e 'while(true){}'` processes saturating every
logical CPU (with trap cleanup), both final tests repeated together **20/20**, no leftover
busy-loop processes.

**One detail worth stating rather than hiding:** the *first* version of the fix failed on round
8 of 20 under load — the barrier and the tick were landing in the same IPC poll turn. It was
changed to advance the clock synchronously inside the barrier observer, and **the 20-count was
restarted from zero**, because a green from a superseded implementation is not evidence for the
current one.

## Review Evidence

- Self-review: CEO ground-truthed the report's boundary claim rather than accepting it — the
  worker touched `packages/daemon/src/runtime/repo-write-client-timeout.ts` mid-run (visible in
  its own log), so `git diff --name-only origin/main...HEAD` was checked directly: 3 files, zero
  under any `/src/`. The claim holds.
- Reviewer subagent: not used
- Human review: CEO semantic acceptance, including adjudicating the "no gate" decision rather
  than accepting the worker's proposal as written
- Blocking findings: none

## Residual Risk

- **The "no gate" judgment is a bet on a review question being asked**, and review is what failed
  in #1249. It is mitigated by the question being structural and mechanical rather than a matter
  of diligence, but it is not enforced by a machine. If a fourth and fifth instance appear, the
  precision argument should be recomputed rather than reused.
- The crude scan that produced the 14-candidate figure was text-based; it can miss races built
  from derived or imported constants. "No fourth instance found" is bounded by that method.
- `slow-shutdown-success` still uses a real timer deliberately, because it tests a genuine product
  wall-clock budget. It should not be "fixed" by a future sweep that pattern-matches on timers.

## References

- Task: `task_01KZA5H978NF16XN35RV5WDTRE`
- Evidence: PR #1252 (the pattern this PR copies), `dec_01KZA811Z8R6V97B0488YTGF6Z`
- Review: task package `review.md`

---

# 中文

## 概要

PR #1252 修掉了两条判定取决于「两个量级相当的实时量谁先赢」的 integration 测试。
同族扫描在 integration tier 上又找出**两处**。本 PR 把它们一并确定性化,
并回答比这两个实例更重要的问题:**这个形状要不要用机制拦住?**

一道判定是抛硬币的门,报告的不是代码,而是调度运气。
这两处都是真实的跨进程 fixture 在与被测代码里的墙钟 deadline 赛跑。

## 改动内容

- `packages/daemon/test/repo-write-process-supervisor.test.ts` —— 「child that swallows PROCEED」
  - 原判据:真实子进程的 telemetry 与 40/80ms 墙钟 watchdog 竞速。
  - 新判据:等待子进程在 telemetry **之后经同一条 IPC 通道**发出的屏障,
    先断言超时**尚未**触发,再用 mock 时钟分别推进 40ms observation
    与派生出的剩余 40ms escalation。
- `packages/daemon/test/repo-write-durable-deadline-honesty.test.ts`
  - 原判据:40ms 的 observation 与 fixture 的 60ms terminal 定时器竞速。
  - 新判据:`telemetry → barrier → terminal` 在同一通道上有序;
    断言与 40ms 推进都在 barrier observer 内同步完成,
    确保下一帧 terminal 被处理之前 deadline 已被观察到。
- `packages/daemon/test/support/repo-write-ipc-child.ts` —— 新增两条屏障帧,
  并删掉 slow-terminal 路径上的裸 60ms 定时器。

**先后现在是通道性质,不是时序指望。** 没有改产品源码、没有碰 protected surface、
没有动 `tools/` 下的门、没有登记 test weight
(登记 test weight 只会改变硬币落在哪个分片上,那不是修复)。

## 这个形状要不要立门?

**不立——理由是精度,不是偏好。** 治理依据:`dec_01KZA811Z8R6V97B0488YTGF6Z`(active)。

对 262 个 integration 文件做「timer + timeout/deadline」粗筛,命中 **14 个文件**,
其中只有 **2 个**(即本 PR 这两处)属于跨进程脚手架竞态。
其余是轮询循环、失败兜底、同事件循环 timer,或真实的产品墙钟预算。
一道精度约 14% 的静态门会对正确代码开火,而**对正确代码开火的门会教会所有人绕过它**
——这正是本仓 `check-cli-error-codes` 眼下得的病。

**替代物必须被诚实点名,因为这次失效的正是复核。** #1249 那轮复核逐条查了阴性对照、
追问了 4s 停止预算、打回了诊断门的钉法,却**从未问过这些新门自己稳不稳**。
所以替代物不是「复核得更仔细」,而是一个可以每次机械地问出口的结构性提问——
现已沉淀进编排复核纪律:**这道门的判定,是否取决于两个量级相当的独立实时量?**

未扫出第四处。剩下的 `slow-shutdown-success` 定时器测的是产品真实的
graceful-stop 墙钟预算,不属于本形状。

## 任务与范围

- Harness 任务:`task_01KZA5H978NF16XN35RV5WDTRE`
- 分支:`codex/timing-races`
- 公开范围:两条 integration 测试 + 一个共享 IPC 子进程 fixture
- 私有规划/证据已更新:是
- 不在范围内:调大任何超时数字(那是把窗口挪远而非消除,此后没人能证明它还在不在);
  登记 test weight;造 timing lint 规则或通用 fixture 框架(两者已在上面裁决)。

## 版本影响

- 版本:无版本变更,因为只改了测试与测试 fixture
- 发布影响:不发布

## 治理声明

- 触碰 protected surface:否
- Protected surface 范围:不适用
- 授权依据:`dec_01KZA811Z8R6V97B0488YTGF6Z`(active),用于「不立门」这一判断
- 机器检查边界:本 PR 只断言声明存在;声明是否属实且充分由评审者判断。
- Break-glass:否
- Break-glass 理由:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- Base `origin/main` SHA:`caff243a2f3a6620442d0cf645515d61791f49cb`
- 与 `origin/main` 的 merge-base:`caff243a2f3a6620442d0cf645515d61791f49cb`
- 最后一次 `git fetch origin` 时间:2026-08-06,开 PR 前刚跑
- 同步方式:rebase
- 公开 diff 命令:`git diff caff243a...codex/timing-races`
- 私有证据 commit/路径:`harness/tasks/task_01KZA5H978NF16XN35RV5WDTRE-integration-tier-swallow-proceed-durable-deadline-honesty/artifacts/verification-report.md`
- 评审证据路径:同一任务包
- GitHub Actions `rewrite-ci` run URL:待 run 报告后回填
- [x] `git diff --check`
- [x] `npm run check:local` —— 27 个本地 manifest gate 全绿,60.3s(在 rebase 后的基线上重跑)
- [x] 本次改动面的定向测试及计数:两个被改测试文件合跑,rebase 后基线上 15/15
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威完整门)
- 未跑及原因:本地未跑完整 `check:ci` 与整个 integration tier —— 一台机器顺序跑完所有 job
  严格慢于 CI 并行跑,而且会占住全机槽预算、把同机其他在飞 worker 堵住。CI 是权威。

**「跑了 N 次都绿」在本 PR 里明确不算证据** —— 这两条测试本来就大多数时候绿,
重跑区分不了「修好了」和「这次运气好」。承重证据是分辨力,由 mutation 证明,两侧真实输出:

| Mutation | 实际观测 |
|---|---|
| 破坏 swallow-PROCEED 的 escalation 错误码 | `✖ child that swallows PROCEED …` `+ 'REPO_WRITE_REQUEST_TIMEOUT' − 'REPO_WRITE_STALL_TIMEOUT'`,`exit_code=1` |
| 恢复 | `✔ child that swallows PROCEED …`,`pass 1 / fail 0` |
| 让 observation 去中止一个已经 PROCEED 的 writer | `✖ durable deadline observes …` `RepoWriteNotStartedError: Repo writer request exceeded its 40ms deadline. Child last reported phase=git at elapsedMs=3.`,`exit_code=1` |
| 恢复 | `✔ durable deadline observes …`,`pass 1 / fail 0` |

**抗抖在真实负载下证明**:16 个 `node -e 'while(true){}'` 占满全部逻辑 CPU(带 trap 清理),
最终版两条测试一起重复 **20/20**,无残留 busy-loop 进程。

**有一处细节值得写出来而不是藏起来**:修法的**初版**在负载下第 8/20 轮失败
——屏障与 tick 落在了同一个 IPC poll turn 里。改为在 barrier observer 内同步推进时钟后,
**20 次计数从零重新开始**,因为一个已被替换的实现所产生的绿,不能当作当前实现的证据。

## 评审证据

- 自审:CEO 对报告里的边界声明做了 ground-truth 而不是采信——worker 在运行中动过
  `packages/daemon/src/runtime/repo-write-client-timeout.ts`(它自己的日志里可见),
  故直接跑 `git diff --name-only origin/main...HEAD`:3 个文件,零个位于任何 `/src/` 下。
  声明属实。
- 评审 subagent:未使用
- 人工评审:CEO 语义验收,并亲自裁决了「不立门」这条,而不是照单接受 worker 的提案
- 阻塞性发现:无

## 残留风险

- **「不立门」是在赌一个复核提问会被问出口**,而复核正是 #1249 那次失效的东西。
  缓解在于这个提问是结构性、机械可问的,而不是靠尽责程度;但它没有机器强制。
  **若出现第四、第五例,应重算那个精度论证,而不是复用它。**
- 产出 14 个候选的粗筛是基于文本的,抓不到由派生常量或导入常量构成的竞态。
  「未扫出第四处」受这个方法的边界约束。
- `slow-shutdown-success` 仍然刻意使用真实定时器,因为它测的是真实的产品墙钟预算。
  将来若有按 timer 做模式匹配的清扫,**不要把它一并「修」掉**。

## 参考

- 任务:`task_01KZA5H978NF16XN35RV5WDTRE`
- 证据:PR #1252(本 PR 照抄的范本)、`dec_01KZA811Z8R6V97B0488YTGF6Z`
- 评审:任务包 `review.md`
