### PR TITLE
fix(tools): restore signal in the package-policy and CLI error-code gates

### DIFF
--- a/tools/check-cli-error-codes.mjs
+++ b/tools/check-cli-error-codes.mjs
@@ -100,10 +100,10 @@ function inlineCliResultErrorViolations(relativePath, source) {
   const lines = source.split("\n");
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
-    if (!/\bcode\s*:/u.test(line)) continue;
+    if (!/(?:^|[{,])\s*\bcode\s*:/u.test(line)) continue;
     if (/\bfunction\b/u.test(line)) continue;
-    const windowText = lines.slice(Math.max(0, index - 3), Math.min(lines.length, index + 5)).join("\n");
-    if (!/\bhint\s*:/u.test(windowText)) continue;
+    const windowLines = lines.slice(Math.max(0, index - 3), Math.min(lines.length, index + 5));
+    if (!windowLines.some((candidate) => /(?:^|[{,])\s*\bhint\s*:/u.test(candidate))) continue;
     if (/\breadonly\s+code\s*:/u.test(line)) continue;
     const match = line.match(/\bcode\s*:\s*(["'`][^"'`]*["'`]|CliErrorCode\.[A-Za-z0-9]+|[A-Za-z0-9_$]+\()/u);
     const value = match?.[1] ?? "dynamic code";

--- a/tools/check-cli-error-codes.test.mjs
+++ b/tools/check-cli-error-codes.test.mjs
@@ -85,6 +85,44 @@ test("CLI error code gate accepts registry helpers and validation issue codes", 
   });
 });
 
+test("CLI error code gate accepts PR 1250 property-read ternaries", () => {
+  withTempRoot((rootDir) => {
+    writeFile(rootDir, "packages/cli/src/cli/error-codes.ts", `
+      export const CliErrorCode = {
+        InvalidDaemonLogInput: "invalid_daemon_log_input",
+        UnknownCommand: "unknown_command"
+      } as const;
+      export type CliErrorCode = typeof CliErrorCode[keyof typeof CliErrorCode];
+      export const cliKernelMappedErrorCodes = new Set<CliErrorCode>([]);
+      export const cliCommandLocalErrorCodes = new Set<CliErrorCode>(
+        Object.values(CliErrorCode).filter((code): code is CliErrorCode => !cliKernelMappedErrorCodes.has(code as CliErrorCode))
+      );
+      export const cliErrorCodeRegistry = {
+        [CliErrorCode.InvalidDaemonLogInput]: { category: "parse", defaultHint: "Invalid daemon log input." },
+        [CliErrorCode.UnknownCommand]: { category: "parse", defaultHint: "Unknown command." }
+      };
+      export function cliError(code: CliErrorCode, hint?: string) {
+        return { code, hint: hint ?? cliErrorCodeRegistry[code].defaultHint };
+      }
+      export function isCliErrorCode(value: string): value is CliErrorCode {
+        return Object.values(CliErrorCode).includes(value as CliErrorCode);
+      }
+      export function cliErrorFamily(code: CliErrorCode) {
+        return cliKernelMappedErrorCodes.has(code) ? "kernel-mapped" : "command-local";
+      }
+    `);
+    writeFile(rootDir, "packages/cli/src/commands/daemon/logs.ts", `
+      export function daemonLogReceiptError(error: Record<string, unknown>) {
+        const hint = typeof error.hint === "string" ? error.hint : "Daemon log query failed.";
+        const tag = typeof error.code === "string" ? error.code : undefined;
+        return { hint, tag };
+      }
+    `);
+
+    assert.deepEqual(findCliErrorCodeViolations(rootDir), []);
+  });
+});
+
 test("CLI error code gate rejects PascalCase adapter codes outside the kernel mapped family", () => {
   withTempRoot((rootDir) => {
     writeFile(rootDir, "packages/cli/src/cli/error-codes.ts", `

--- a/tools/check-package-policy.mjs
+++ b/tools/check-package-policy.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { discoverWorkspacePackages } from "./workspace-packages.mjs";
@@ -12,9 +12,16 @@ export function checkPackagePolicy(root = process.cwd()) {
   const rootPackage = readJson(path.join(root, "package.json"));
   const lockfile = readJson(path.join(root, "package-lock.json"));
   const workspacePackages = discoverWorkspacePackages(root);
+  const workspaceManifestPaths = new Set(workspacePackages.map(({ manifestPath }) => manifestPath));
 
   if (rootPackage.name !== "harness-anything") record("root package name must remain harness-anything");
   if (rootPackage.private !== true) record("root package must remain private until an explicit publish task");
+
+  for (const manifestPath of packageManifestPaths(root)) {
+    if (!workspaceManifestPaths.has(manifestPath)) {
+      record(`${manifestPath} is not covered by a root workspace pattern`);
+    }
+  }
 
   const names = new Map();
   for (const workspacePackage of workspacePackages) {
@@ -65,6 +72,25 @@ function checkPrivateWorkspacePolicy(packageJson, manifestPath, record) {
 
 function readJson(filePath) {
   return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function packageManifestPaths(root) {
+  const packagesRoot = path.join(root, "packages");
+  if (!existsSync(packagesRoot)) return [];
+  const manifests = [];
+  const visit = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      if (entry.name === "node_modules") continue;
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(entryPath);
+      } else if (entry.isFile() && entry.name === "package.json") {
+        manifests.push(path.relative(root, entryPath).split(path.sep).join("/"));
+      }
+    }
+  };
+  visit(packagesRoot);
+  return manifests.sort();
 }
 
 function main() {

--- a/tools/check-package-policy.test.mjs
+++ b/tools/check-package-policy.test.mjs
@@ -6,6 +6,78 @@ import path from "node:path";
 import test from "node:test";
 import { checkPackagePolicy } from "./check-package-policy.mjs";
 
+test("package policy rejects package manifests outside the declared workspaces", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-package-policy-"));
+  try {
+    writeJson(root, "package.json", {
+      name: "harness-anything",
+      private: true,
+      workspaces: ["packages/cli"]
+    });
+    writeJson(root, "packages/cli/package.json", {
+      name: "@harness-anything/cli",
+      version: "0.1.0",
+      publishConfig: { access: "public" },
+      repository: { directory: "packages/cli" },
+      engines: { node: ">=24" }
+    });
+    writeJson(root, "packages/unregistered/package.json", {
+      name: "@harness-anything/unregistered",
+      version: "0.1.0",
+      private: true
+    });
+    writeJson(root, "package-lock.json", {
+      packages: {
+        "packages/cli": { name: "@harness-anything/cli", version: "0.1.0" }
+      }
+    });
+
+    const result = checkPackagePolicy(root);
+
+    assert.equal(result.ok, false);
+    assert.match(result.violations.join("\n"), /packages\/unregistered\/package\.json is not covered by a root workspace pattern/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("package policy accepts packages covered by workspaces and the lockfile", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-package-policy-"));
+  try {
+    writeJson(root, "package.json", {
+      name: "harness-anything",
+      private: true,
+      workspaces: ["packages/*"]
+    });
+    writeJson(root, "packages/cli/package.json", {
+      name: "@harness-anything/cli",
+      version: "0.1.0",
+      publishConfig: { access: "public" },
+      repository: { directory: "packages/cli" },
+      engines: { node: ">=24" }
+    });
+    writeJson(root, "packages/registered/package.json", {
+      name: "@harness-anything/registered",
+      version: "0.1.0",
+      private: true
+    });
+    writeJson(root, "package-lock.json", {
+      packages: {
+        "packages/cli": { name: "@harness-anything/cli", version: "0.1.0" },
+        "packages/registered": { name: "@harness-anything/registered", version: "0.1.0" }
+      }
+    });
+
+    const result = checkPackagePolicy(root);
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.violations, []);
+    assert.equal(result.workspaceCount, 2);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("package policy derives and rejects an unregistered shell workspace package", () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-package-policy-"));
   try {


### PR DESCRIPTION
# English

## Summary

Two gates in this repo were broken, in mirror-image ways. `check-package-policy` was **always
silent** where it could not see; `check-cli-error-codes` was **always loud** on correct code.
A gate's green only carries information when both hold: it goes red when it should, and it does
not go red when it should not. A silent gate makes people *believe* they are compliant; a
false-firing gate teaches people to *route around* it.

**The second one had already cost us.** In PR #1250 a worker extracted a `readOptionalString`
helper specifically to dodge a text coincidence in this gate. That is not satisfying the gate —
that is bypassing it.

## What Changed

**`tools/check-package-policy.mjs` — fail-open closed.**
The baseline had already been partly repaired (`f045249e` moved it from a hardcoded nine-package
list to workspace discovery), so the task's original description was stale. The residual hole was
still real: a `package.json` present on disk but not covered by any workspace pattern was
completely invisible. Now every `packages/**/package.json` is enumerated recursively (only
`node_modules` is skipped) and compared against the actual workspace expansion; anything not
covered **fails closed and names the path**. There is no whitelist and no silent exemption.

**`tools/check-cli-error-codes.mjs` — false positive removed without loosening the gate.**
The old predicate was "this line contains `code:` and some nearby line contains `hint:`", so
`typeof error.code === "string" ? error.code : undefined` matched — a pure property *read* was
treated as an inline error construction. Both `code` and `hint` must now appear in object-property
position: at line start, or immediately after `{` or `,`. Member access reached through `.` no
longer matches. A genuine inline `{ code, hint }` error object is still caught and still reports
its line number.

## Verification of both gates, in both directions

**"It is green after the fix" was not accepted as evidence.** Each gate has a positive control
proving it still fires, and a negative control proving it no longer fires on correct code.

`check-package-policy` positive:

```
exit=1
Package policy check failed:
- packages/_gate-positive-control/nested/package.json is not covered by a root workspace pattern
```

`check-package-policy` negative:

```
exit=0
Package policy check passed (12 workspace package(s))
```

`check-cli-error-codes` positive:

```
exit=1
CLI error code gate failed:
- packages/cli/src/commands/_gate-positive-control.ts:5 uses inline CliResult error code "gate_positive_control"; use cliError(CliErrorCode.*)
```

`check-cli-error-codes` negative — **this used the real shape from PR #1250**, not a
freshly-invented easier example:

```ts
const hint = typeof error.hint === "string" ? error.hint : "Daemon log query failed.";
const tag = typeof error.code === "string" ? error.code : undefined;
```

```
exit=0
```

That same fixture's pre-fix RED was:

```
packages/cli/src/commands/daemon/logs.ts:4 uses inline CliResult error code dynamic code
```

All temporary control files were deleted and are not in the commit (verified:
`git diff --name-only origin/main...HEAD` contains no `_gate-positive-control` path).

## Two questions the task asked, answered

- **Did the regex predicate hit its limit?** No. Object-property context is enough to separate
  this repo's inline constructions from PR #1250's ternary property reads without a parser. It
  remains a proximity heuristic: if a future requirement is to *prove* that `code` and `hint`
  belong to the same AST object, or to fully distinguish destructuring and type members, that is
  the point to stop and evaluate a parser. **A parser was deliberately not introduced now** —
  that would be disproportionate to the defect.
- **Did tightening `check-package-policy` expose pre-existing unregistered packages?** **Zero.**

## Task And Scope

- Harness task: `task_01KZA7Z3DX67R972QY7JJ3VN17`
- Branch: `codex/broken-gates`
- Public scope: four `tools/` files (two gates and their tests)
- Private planning/evidence updated: yes
- Out of scope: `readOptionalString` from PR #1250 — see Residual Risk; other gates; any
  `packages/**` source.

## Version Impact

- Version: no version change because only repository tooling changed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: **yes**
- Protected surface scope: `tools/check-package-policy.mjs` and `tools/check-cli-error-codes.mjs`
  — the decision logic of two CI gates.
- Authority: `dec_01KXV0BEVX113BA2CPRQRVAKAB`/CH1 (the diagnosability contract must be made a gate,
  and the gate itself must have a positive control) and `dec_01KXV2R6W3CPBNW8XWKY20ANKB` ruling 2
  (the package-policy fail-open). The task plan authorizes exactly these two files' decision logic
  and nothing else; no workflow, branch protection, or other gate was touched.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `fb510dba61b1029e506e90cc803242356e9239b9`
- Branch merge-base with `origin/main`: `fb510dba61b1029e506e90cc803242356e9239b9`
- Last `git fetch origin` time: 2026-08-06, immediately before opening this PR
- Sync method: rebase
- Public diff command: `git diff fb510dba...codex/broken-gates`
- Private evidence commit/path: `harness/tasks/task_01KZA7Z3DX67R972QY7JJ3VN17-check-package-policy-fail-open-check-cli-error-codes/`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending, linked after the run reports
- [x] `git diff --check`
- [x] `npm run check:local` — passed on the rebased baseline
- [x] Targeted tests for the change surface, named with their counts:
  `npm run test:contract -- --prefix tools --concurrency 1` — **243/243**
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: full `npm run check:ci` was not run locally — one machine running every job
  serially is strictly slower than CI running them in parallel and would hold the whole-machine
  slot budget. CI is the authority. Note that `check-package-policy` and `check-cli-error-codes`
  are both in the CI-only set that `check:local` names in its own receipt, so **CI is the first
  place these two run in their real configuration**.

## Review Evidence

- Self-review: CEO read both predicates rather than trusting the report. For
  `check-cli-error-codes`, the new anchor `(?:^|[{,])\s*\bcode\s*:` was checked against the shapes
  that must still fire (`{ code: …, hint: … }` on one line, and the multi-line object form where
  `code:` sits at line start) and against the shape that must not (`? error.code : undefined`,
  where the character before `code` is `.`). It separates them correctly. For
  `check-package-policy`, the enumeration was confirmed to have no whitelist and to fail closed
  with the offending path named.
- Reviewer subagent: not used
- Human review: CEO semantic acceptance against the two authorizing decisions
- Blocking findings: none

## Residual Risk

- **The recursive enumeration skips only `node_modules`, not build output.** Today that is safe —
  `find packages -name package.json -not -path "*/node_modules/*" | grep -E "dist/|out/|build/"`
  returns **0**, verified directly. But if a bundler ever emits a `package.json` into `dist/`,
  this gate will fail with a confusing message about an "uncovered" package that is not source.
  A `dist` exclusion was **deliberately not added now**: adding an exclusion with no evidence for
  it is how fail-open holes get introduced in the first place. If that emitter ever appears, the
  exclusion should be added as a *designed* exclusion with a stated reason, not as a silence.
- **`check-cli-error-codes` is still a proximity heuristic, not a parser.** It anchors on
  object-property position within a 9-line window. It can still be fooled by sufficiently unusual
  formatting in either direction. The stopping condition for escalating to a parser is stated
  above so the next person does not have to re-derive it.
- **`readOptionalString` from PR #1250 is no longer required to keep this gate quiet** — writing
  the two ternary reads directly now passes. It was deliberately left unmodified: it may still be
  worth keeping for local deduplication, but it is no longer a gate constraint. That judgment is
  recorded rather than acted on, because changing it is not this task's job.
- No third broken gate of this class was found **within this task's scope**; no repo-wide audit
  of gate instruments was performed, so this is not a claim that none exists.

---

# 中文

## 概要

本仓有两道门自己坏了,而且坏法互为镜像:`check-package-policy` 在它看不见的地方**恒假**(静默放行),
`check-cli-error-codes` 对正确代码**恒真**(误报)。
一道门的绿只有在两件事同时成立时才携带信息:**该红时会红**、**不该红时不会红**。
恒假的门让人**误以为**合规;恒真的门教人**绕过**它。

**第二道已经产生过实际代价**:PR #1250 里,一个 worker 专门抽了个 `readOptionalString` helper
去避开这道门的文本巧合。**那不是满足门,那是绕过门。**

## 改动内容

**`tools/check-package-policy.mjs` —— 堵上 fail-open。**
基线其实已被部分修过(`f045249e` 把九包硬枚举改成了 workspace 发现),
所以任务原始描述是过期的。但残余的洞是真的:磁盘上存在、却不被任何 workspace 模式覆盖的
`package.json` 仍然完全不可见。现在递归枚举每一个 `packages/**/package.json`
(只跳过 `node_modules`),与 workspace 的实际展开结果对照;
任何未被覆盖的 manifest **fail closed 并报出路径**。没有白名单,没有静默豁免。

**`tools/check-cli-error-codes.mjs` —— 消除误报但不放松门。**
旧判据是「本行含 `code:` 且附近某行含 `hint:`」,于是
`typeof error.code === "string" ? error.code : undefined` 会命中
——一次纯粹的属性**读取**被当成了内联错误构造。
现在 `code` 与 `hint` 都必须出现在**对象属性位置**:行首,或紧跟 `{` / `,`。
经由 `.` 的成员访问不再命中。真正的内联 `{ code, hint }` 错误对象仍然被拦,并仍然报出行号。

## 两道门、两个方向,全部有真实输出

**「修完是绿的」没有被当成证据。** 每道门都有阳性对照证明它仍会响,
以及阴性对照证明它不再对正确代码开火。

`check-package-policy` 阳性:

```
exit=1
Package policy check failed:
- packages/_gate-positive-control/nested/package.json is not covered by a root workspace pattern
```

`check-package-policy` 阴性:

```
exit=0
Package policy check passed (12 workspace package(s))
```

`check-cli-error-codes` 阳性:

```
exit=1
CLI error code gate failed:
- packages/cli/src/commands/_gate-positive-control.ts:5 uses inline CliResult error code "gate_positive_control"; use cliError(CliErrorCode.*)
```

`check-cli-error-codes` 阴性 —— **直接用了 PR #1250 里那个真实形状**,
而不是另造一个更容易过的例子:

```ts
const hint = typeof error.hint === "string" ? error.hint : "Daemon log query failed.";
const tag = typeof error.code === "string" ? error.code : undefined;
```

```
exit=0
```

同一 fixture 在修复前的实际 RED 是:

```
packages/cli/src/commands/daemon/logs.ts:4 uses inline CliResult error code dynamic code
```

所有临时控制文件均已删除、未进入 commit(已核:`git diff --name-only origin/main...HEAD`
中不含任何 `_gate-positive-control` 路径)。

## 任务问的两个问题,答案

- **正则判据撞到上限了吗?** 没有。对象属性上下文足以把本仓的内联构造与 PR #1250 的三元属性读取
  区分开,不需要解析器。它仍然是一个邻近窗口启发式:
  若将来要求**证明** `code` 与 `hint` 属于同一个 AST 对象,或要完整区分解构与类型成员,
  那才是停下来评估解析器的时点。**现在刻意没有引入解析器**——那与缺陷的体量不相称。
- **收紧 `check-package-policy` 后照出了多少既存未登记的包?** **0 个。**

## 任务与范围

- Harness 任务:`task_01KZA7Z3DX67R972QY7JJ3VN17`
- 分支:`codex/broken-gates`
- 公开范围:四个 `tools/` 文件(两道门及其测试)
- 私有规划/证据已更新:是
- 不在范围内:PR #1250 的 `readOptionalString`(见残余风险);其他门;任何 `packages/**` 源码。

## 版本影响

- 版本:无版本变更,因为只改了仓库工具
- 发布影响:不发布

## 治理声明

- 触碰 protected surface:**是**
- Protected surface 范围:`tools/check-package-policy.mjs` 与 `tools/check-cli-error-codes.mjs`
  —— 两道 CI 门的判定逻辑。
- 授权依据:`dec_01KXV0BEVX113BA2CPRQRVAKAB`/CH1(可诊断性契约须做成门,且门本身须有阳性对照)
  与 `dec_01KXV2R6W3CPBNW8XWKY20ANKB` 裁决二(package policy 的 fail-open)。
  任务契约授权的正是这两个文件的判定逻辑,不含其他;未触碰任何 workflow、分支保护或别的门。
- 机器检查边界:本 PR 只断言声明存在;声明是否属实且充分由评审者判断。
- Break-glass:否
- Break-glass 理由:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- Base `origin/main` SHA:`fb510dba61b1029e506e90cc803242356e9239b9`
- 与 `origin/main` 的 merge-base:`fb510dba61b1029e506e90cc803242356e9239b9`
- 最后一次 `git fetch origin` 时间:2026-08-06,开 PR 前刚跑
- 同步方式:rebase
- 公开 diff 命令:`git diff fb510dba...codex/broken-gates`
- 私有证据 commit/路径:`harness/tasks/task_01KZA7Z3DX67R972QY7JJ3VN17-check-package-policy-fail-open-check-cli-error-codes/`
- 评审证据路径:同一任务包
- GitHub Actions `rewrite-ci` run URL:待 run 报告后回填
- [x] `git diff --check`
- [x] `npm run check:local` —— 在 rebase 后的基线上通过
- [x] 本次改动面的定向测试及计数:
  `npm run test:contract -- --prefix tools --concurrency 1` —— **243/243**
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威完整门)
- 未跑及原因:本地未跑完整 `npm run check:ci` —— 一台机器顺序跑完所有 job 严格慢于 CI 并行跑,
  且会占住全机槽预算。CI 是权威。**注意**:`check-package-policy` 与 `check-cli-error-codes`
  都在 `check:local` 自己回执里点名的 CI-only 集合中,
  所以 **CI 是这两道门以真实配置运行的第一现场**。

## 评审证据

- 自审:CEO 直读两条判据而非采信报告。对 `check-cli-error-codes`,
  新锚 `(?:^|[{,])\s*\bcode\s*:` 被对照了「必须仍然命中」的形状
  (单行 `{ code: …, hint: … }`,以及 `code:` 位于行首的多行对象写法)
  与「必须不再命中」的形状(`? error.code : undefined`,`code` 前一个字符是 `.`),
  区分正确。对 `check-package-policy`,确认枚举无白名单、fail closed 且报出违规路径。
- 评审 subagent:未使用
- 人工评审:CEO 对照两条授权裁决做语义验收
- 阻塞性发现:无

## 残留风险

- **递归枚举只跳过 `node_modules`,不跳过构建产物。** 今天是安全的——
  `find packages -name package.json -not -path "*/node_modules/*" | grep -E "dist/|out/|build/"`
  返回 **0**,已直接核实。但若将来某个打包器往 `dist/` 里吐出一个 `package.json`,
  这道门会以一条关于「未覆盖的包」的令人困惑的消息变红,而那根本不是源码。
  **现在刻意没有加 `dist` 排除**:在没有证据的情况下加排除,正是 fail-open 洞最初的来源。
  若那个打包器真的出现,应当把排除作为**设计性排除**加入并写明理由,而不是作为一次沉默。
- **`check-cli-error-codes` 仍是邻近窗口启发式而非解析器。** 它在 9 行窗口内锚定对象属性位置,
  两个方向上都仍可能被足够反常的排版骗过。升级到解析器的停止条件已写在上面,
  下一个人不必重新推导。
- **PR #1250 的 `readOptionalString` 现在已不再是让这道门闭嘴所必需的**
  ——直接写那两条三元读取现在也能过。它被刻意保留未改:
  出于局部去重它也许仍值得留着,但它已不是门的约束。这个判断被记录下来而非被执行,
  因为改它不是本任务的活。
- **在本任务范围内**未发现第三道同类坏门;未做全仓门仪器专项审计,
  故这不是「不存在第三道」的断言。
