### PR TITLE
fix(daemon): stop orphaned autostart daemons when their root disappears

### DIFF
--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -8,6 +8,8 @@ import { readOption, stripGlobalOptions } from "./cli/parse-options.ts";
 import { appendParseFailureRuntimeEvent } from "./cli/parse-failure-runtime-event.ts";
 import {
   checkDaemonServeConfiguration as checkDaemonServeConfigurationRoot,
+  daemonAutostartRootIdentity,
+  daemonAutostartRootLifetimeEnabled,
   resolveDaemonRuntimePolicy,
   runDaemonServe as runDaemonServeRoot
 } from "@harness-anything/daemon";
@@ -263,6 +265,9 @@ async function runDaemonServe(
     ...(restoredLaunchOptions.authorityManifest ? { requestedAuthorityManifest: restoredLaunchOptions.authorityManifest } : {}),
     entrypoint,
     idleMs: parsePositiveIntegerOr(readOption(args, "--idle-ms"), 0, { allowZero: true }),
+    ...(daemonAutostartRootLifetimeEnabled(process.env)
+      ? { expectedRootIdentity: daemonAutostartRootIdentity(process.env) }
+      : {}),
     preflightReplacement: preflightDaemonLaunch,
     runtimePolicy: resolveDaemonRuntimePolicy(process.env, projectSettings.settings.daemonRuntime),
     ...daemonServeAdmissionOptions(projectSettings.settings)

--- a/packages/cli/test/daemon-autostart-root-lifetime.test.ts
+++ b/packages/cli/test/daemon-autostart-root-lifetime.test.ts
@@ -1,0 +1,102 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  resolveLocalDaemonTarget,
+  spawnLocalDaemon
+} from "../../daemon/src/index.ts";
+import {
+  defaultDaemonUserRoot,
+  pollUntil,
+  runDaemonCommand,
+  runRawJson
+} from "./helpers/daemon-cli.ts";
+
+const cliEntry = path.resolve("packages/cli/src/index.ts");
+
+test("an autostarted resident daemon exits after its canonical root disappears", { timeout: 30_000 }, async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-daemon-root-lifetime-"));
+  let daemonPid: number | undefined;
+  try {
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "local" });
+    const status = runDaemonCommand(rootDir, [
+      "daemon", "status", "--user-root", defaultDaemonUserRoot(rootDir), "--json"
+    ]);
+    assert.equal(typeof status.pid, "number", JSON.stringify(status));
+    daemonPid = status.pid as number;
+
+    assert.equal(processIsAlive(daemonPid), true, "the resident daemon must outlive its launching CLI command");
+    rmSync(rootDir, { recursive: true, force: true });
+
+    await pollUntil(
+      () => processIsAlive(daemonPid),
+      (alive) => !alive,
+      (alive, error) => JSON.stringify({ daemonPid, alive, error: String(error ?? "") }),
+      { timeoutMs: 8_000 }
+    );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+    if (daemonPid !== undefined && processIsAlive(daemonPid)) {
+      process.kill(daemonPid, "SIGTERM");
+      await pollUntil(
+        () => processIsAlive(daemonPid),
+        (alive) => !alive,
+        (alive, error) => JSON.stringify({ daemonPid, alive, error: String(error ?? "") }),
+        { timeoutMs: 8_000 }
+      );
+    }
+  }
+});
+
+test("an autostarted daemon cannot revive a canonical root removed during cold start", { timeout: 30_000 }, async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-daemon-cold-root-lifetime-"));
+  let daemonPid: number | undefined;
+  try {
+    initializeFixtureWithoutDaemon(rootDir);
+    const userRoot = defaultDaemonUserRoot(rootDir);
+    const target = resolveLocalDaemonTarget({ rootDir, userRoot, autoRegisterSingleRepo: true });
+    daemonPid = spawnLocalDaemon(target, { entryPath: cliEntry, idleExitMs: 0 });
+    assert.equal(typeof daemonPid, "number");
+
+    rmSync(rootDir, { recursive: true, force: true });
+    await pollUntil(
+      () => processIsAlive(daemonPid),
+      (alive) => !alive,
+      (alive, error) => JSON.stringify({ daemonPid, alive, rootDir, error: String(error ?? "") }),
+      { timeoutMs: 8_000 }
+    );
+  } finally {
+    if (daemonPid !== undefined && processIsAlive(daemonPid)) {
+      process.kill(daemonPid, "SIGTERM");
+      await pollUntil(
+        () => processIsAlive(daemonPid),
+        (alive) => !alive,
+        (alive, error) => JSON.stringify({ daemonPid, alive, error: String(error ?? "") }),
+        { timeoutMs: 8_000 }
+      );
+    }
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+function initializeFixtureWithoutDaemon(rootDir: string): void {
+  runRawJson(rootDir, ["init"], {
+    HARNESS_DAEMON_MODE: "direct",
+    HARNESS_DIRECT_WRITE_REASON: "recovery"
+  });
+}
+
+function processIsAlive(pid: number | undefined): boolean {
+  if (pid === undefined) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error
+      && (error as { readonly code?: unknown }).code === "ESRCH") return false;
+    throw error;
+  }
+}

--- a/packages/cli/test/daemon-autostart-root-lifetime.test.ts
+++ b/packages/cli/test/daemon-autostart-root-lifetime.test.ts
@@ -9,6 +9,11 @@ import {
   spawnLocalDaemon
 } from "../../daemon/src/index.ts";
 import {
+  daemonRootIdentity,
+  daemonRootWatchTerminatesProcess,
+  monitorDaemonRootLifetime
+} from "../../daemon/src/lifecycle/daemon-root-lifetime.ts";
+import {
   defaultDaemonUserRoot,
   pollUntil,
   runDaemonCommand,
@@ -88,6 +93,28 @@ function initializeFixtureWithoutDaemon(rootDir: string): void {
     HARNESS_DIRECT_WRITE_REASON: "recovery"
   });
 }
+
+test("root loss is still detected when the watcher is suppressed", { timeout: 15_000 }, async () => {
+  // Windows suppresses the watcher because watching a disappearing directory kills the process
+  // with 0xC0000409. That leaves the interval as the only detector, so it has to be sufficient
+  // on its own. Forcing the suppressed branch here keeps that provable on every host rather
+  // than only on the Windows runner.
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-daemon-poll-only-root-"));
+  const monitor = monitorDaemonRootLifetime(rootDir, daemonRootIdentity(rootDir), true);
+  try {
+    assert.equal(monitor.rootAvailable(), true);
+    rmSync(rootDir, { recursive: true, force: true });
+    assert.deepEqual(await monitor.rootLost, { reason: "root-unavailable" });
+  } finally {
+    monitor.stop();
+  }
+});
+
+test("the watcher is suppressed on Windows and kept everywhere else", () => {
+  assert.equal(daemonRootWatchTerminatesProcess("win32"), true);
+  assert.equal(daemonRootWatchTerminatesProcess("darwin"), false);
+  assert.equal(daemonRootWatchTerminatesProcess("linux"), false);
+});
 
 function processIsAlive(pid: number | undefined): boolean {
   if (pid === undefined) return false;

--- a/packages/cli/test/daemon-command-outcomes.test.ts
+++ b/packages/cli/test/daemon-command-outcomes.test.ts
@@ -16,7 +16,7 @@ const execFileAsync = promisify(execFile);
 
 test("a timed-out write reports an unknown outcome after the daemon accepted the request", { skip: process.platform === "win32" }, async () => {
   await withSocketTempRootAsync(async (rootDir) => {
-    runRawJson(rootDir, ["init"]);
+    initializeFixtureWithoutDaemon(rootDir);
     const daemon = testDaemonLocation(rootDir);
     let acceptedRequest = false;
     const server = await startCommandServer(daemon, (request, socket) => {
@@ -50,7 +50,7 @@ test("a timed-out write reports an unknown outcome after the daemon accepted the
 
 test("a daemon JSON-RPC rejection remains a known request failure", { skip: process.platform === "win32" }, async () => {
   await withSocketTempRootAsync(async (rootDir) => {
-    runRawJson(rootDir, ["init"]);
+    initializeFixtureWithoutDaemon(rootDir);
     const daemon = testDaemonLocation(rootDir);
     const server = await startCommandServer(daemon, (request, socket) => {
       socket.end(`${JSON.stringify({
@@ -76,7 +76,7 @@ test("a daemon JSON-RPC rejection remains a known request failure", { skip: proc
 
 test("a timed-out local materializer request keeps its intentional local fallback", { skip: process.platform === "win32" }, async () => {
   await withSocketTempRootAsync(async (rootDir) => {
-    runRawJson(rootDir, ["init"]);
+    initializeFixtureWithoutDaemon(rootDir);
     const daemon = testDaemonLocation(rootDir);
     let acceptedRequest = false;
     const server = await startCommandServer(daemon, (request, socket) => {
@@ -101,7 +101,7 @@ test("a timed-out local materializer request keeps its intentional local fallbac
 
 test("an unreachable daemon remains unavailable with the direct recovery guidance", { skip: process.platform === "win32" }, async () => {
   await withTempRootAsync(async (rootDir) => {
-    runRawJson(rootDir, ["init"]);
+    initializeFixtureWithoutDaemon(rootDir);
     const unreachableUserRoot = path.join(rootDir, "u".repeat(180));
     const daemon = testDaemonLocation(rootDir, unreachableUserRoot);
     const result = await runCliFailure(rootDir, ["task", "create", "--title", "Unreachable Write"], {
@@ -166,6 +166,13 @@ function testDaemonEnv(daemon: TestDaemonLocation): Readonly<Record<string, stri
     XDG_RUNTIME_DIR: daemon.runtimeDir,
     TMPDIR: daemon.runtimeDir
   };
+}
+
+function initializeFixtureWithoutDaemon(rootDir: string): void {
+  runRawJson(rootDir, ["init"], {
+    HARNESS_DAEMON_MODE: "direct",
+    HARNESS_DIRECT_WRITE_REASON: "recovery"
+  });
 }
 
 async function withSocketTempRootAsync<T>(fn: (rootDir: string) => Promise<T>): Promise<T> {

--- a/packages/daemon/src/client/daemon-server-host-environment.ts
+++ b/packages/daemon/src/client/daemon-server-host-environment.ts
@@ -1,0 +1,22 @@
+import { daemonAutostartRootLifetimeEnvironmentVariable } from "../lifecycle/daemon-root-lifetime.ts";
+
+export interface DaemonServerHostTarget {
+  readonly userRoot: string;
+  readonly daemonId: string;
+}
+
+export function daemonServerHostEnvironment(
+  base: NodeJS.ProcessEnv,
+  target: DaemonServerHostTarget
+): NodeJS.ProcessEnv {
+  const env = { ...base };
+  delete env.HARNESS_DAEMON_MODE;
+  delete env.HARNESS_DIRECT_WRITE_REASON;
+  delete env[daemonAutostartRootLifetimeEnvironmentVariable];
+  return {
+    ...env,
+    HARNESS_DAEMON_SERVER_HOST: "1",
+    HARNESS_DAEMON_USER_ROOT: target.userRoot,
+    HARNESS_DAEMON_ID: target.daemonId
+  };
+}

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -27,6 +27,11 @@ import {
   defaultDaemonJsonRpcRequestTimeoutMs,
   JsonRpcLineClient
 } from "./json-rpc-line-client.ts";
+import {
+  daemonAutostartRootLifetimeEnvironmentVariable,
+  daemonRootIdentity
+} from "../lifecycle/daemon-root-lifetime.ts";
+import { daemonServerHostEnvironment } from "./daemon-server-host-environment.ts";
 
 export {
   createDaemonLaunchConfiguration,
@@ -46,6 +51,12 @@ export {
   type DaemonLaunchOptions,
   type ParsedDaemonLaunchArgv
 } from "./daemon-launch-spec-store.ts";
+export { daemonServerHostEnvironment } from "./daemon-server-host-environment.ts";
+export {
+  daemonAutostartRootIdentity,
+  daemonAutostartRootLifetimeEnabled,
+  daemonAutostartRootLifetimeEnvironmentVariable
+} from "../lifecycle/daemon-root-lifetime.ts";
 
 // Cold authority readiness measured ~7.2s, so a 6s budget could never confirm it.
 export const defaultDaemonAutostartTimeoutMs = 30_000;
@@ -308,21 +319,6 @@ export function spawnLocalDaemon(target: LocalDaemonTarget, options: LocalDaemon
   return typeof pid === "number" ? pid : undefined;
 }
 
-export function daemonServerHostEnvironment(
-  base: NodeJS.ProcessEnv,
-  target: Pick<LocalDaemonTarget, "userRoot" | "daemonId">
-): NodeJS.ProcessEnv {
-  const env = { ...base };
-  delete env.HARNESS_DAEMON_MODE;
-  delete env.HARNESS_DIRECT_WRITE_REASON;
-  return {
-    ...env,
-    HARNESS_DAEMON_SERVER_HOST: "1",
-    HARNESS_DAEMON_USER_ROOT: target.userRoot,
-    HARNESS_DAEMON_ID: target.daemonId
-  };
-}
-
 export function replaceSpawnLocalDaemonForTest(replacement: SpawnLocalDaemon): () => void {
   const previous = spawnLocalDaemonImplementation;
   spawnLocalDaemonImplementation = replacement;
@@ -332,6 +328,7 @@ export function replaceSpawnLocalDaemonForTest(replacement: SpawnLocalDaemon): (
 }
 
 function spawnLocalDaemonProcess(target: LocalDaemonTarget, options: LocalDaemonAutostartOptions): number | undefined {
+  const expectedRootIdentity = daemonRootIdentity(target.canonicalRoot) ?? "missing";
   const launchConfiguration = options.launchConfiguration ?? createDaemonLaunchConfiguration({
     target,
     entrypoint: options.entryPath,
@@ -348,7 +345,10 @@ function spawnLocalDaemonProcess(target: LocalDaemonTarget, options: LocalDaemon
   ], {
     detached: true,
     stdio: "ignore",
-    env: daemonServerHostEnvironment(options.env ?? process.env, target)
+    env: {
+      ...daemonServerHostEnvironment(options.env ?? process.env, target),
+      [daemonAutostartRootLifetimeEnvironmentVariable]: expectedRootIdentity
+    }
   });
   child.unref();
   return child.pid;

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -101,6 +101,7 @@ export * from "./lifecycle/queued-write-coordinator.ts";
 export * from "./lifecycle/daemon-control-service.ts";
 export * from "./lifecycle/reservation-reconciler.ts";
 export * from "./lifecycle/run-daemon-serve.ts";
+export * from "./lifecycle/daemon-root-lifetime.ts";
 export * from "./service/command-service.ts";
 export * from "./service/doc-sync-service.ts";
 export * from "./service/doc-sync-writer-working-tree.ts";

--- a/packages/daemon/src/lifecycle/daemon-root-lifetime.ts
+++ b/packages/daemon/src/lifecycle/daemon-root-lifetime.ts
@@ -34,6 +34,10 @@ export function daemonAutostartRootIdentity(env: NodeJS.ProcessEnv): string | un
   return value ? value : undefined;
 }
 
+export function daemonRootWatchTerminatesProcess(platform: NodeJS.Platform = process.platform): boolean {
+  return platform === "win32";
+}
+
 export function daemonRootIdentity(rootDir: string): string | undefined {
   try {
     const stat = statSync(rootDir, { bigint: true });
@@ -45,7 +49,8 @@ export function daemonRootIdentity(rootDir: string): string | undefined {
 
 export function monitorDaemonRootLifetime(
   rootDir: string,
-  expectedIdentity = daemonRootIdentity(rootDir) ?? "missing"
+  expectedIdentity = daemonRootIdentity(rootDir) ?? "missing",
+  watchTerminatesProcess = daemonRootWatchTerminatesProcess()
 ): DaemonRootLifetimeMonitor {
   let watcher: FSWatcher | undefined;
   let timer: ReturnType<typeof setInterval> | undefined;
@@ -72,14 +77,22 @@ export function monitorDaemonRootLifetime(
 
   inspect();
   if (!stopped) {
-    try {
-      watcher = watch(rootDir, { persistent: false }, inspect);
-      watcher.on("error", () => {
-        watcher?.close();
-        watcher = undefined;
-      });
-    } catch {
-      // The interval is the cross-platform fallback for unavailable watchers.
+    // The watcher is only a latency accelerant over the interval below. On Windows it also
+    // terminates the process: watching a directory that is being removed crashes Node with
+    // STATUS_STACK_BUFFER_OVERRUN (0xC0000409), its __fastfail path, which no `error` handler
+    // or `catch` can observe. Removing the watcher there was proved sufficient by an A/B
+    // control run on CI: with it disabled the autostart child reached steady state instead of
+    // dying. The cost is bounded by daemonRootLifetimePollMs of extra detection latency.
+    if (!watchTerminatesProcess) {
+      try {
+        watcher = watch(rootDir, { persistent: false }, inspect);
+        watcher.on("error", () => {
+          watcher?.close();
+          watcher = undefined;
+        });
+      } catch {
+        // The interval is the cross-platform fallback for unavailable watchers.
+      }
     }
     timer = setInterval(inspect, daemonRootLifetimePollMs);
     timer.unref();

--- a/packages/daemon/src/lifecycle/daemon-root-lifetime.ts
+++ b/packages/daemon/src/lifecycle/daemon-root-lifetime.ts
@@ -1,0 +1,121 @@
+import { statSync, watch, type FSWatcher } from "node:fs";
+
+export const daemonRootLifetimePollMs = 250;
+export const daemonAutostartRootLifetimeEnvironmentVariable = "HARNESS_DAEMON_AUTOSTART_ROOT_IDENTITY";
+
+export type DaemonRootAwareStopTrigger =
+  | { readonly reason: "root-unavailable" }
+  | { readonly reason: "signal"; readonly signal: "SIGINT" | "SIGTERM" }
+  | { readonly reason: "control"; readonly kind: "restart" | "refresh" | "upgrade" }
+  | { readonly reason: "idle-timeout" };
+
+export interface DaemonRootLifetimeMonitor {
+  readonly rootLost: Promise<{ readonly reason: "root-unavailable" }>;
+  readonly rootAvailable: () => boolean;
+  readonly stop: () => void;
+}
+
+export interface DaemonRootLifetimeGuard {
+  readonly assertAvailable: () => void;
+  readonly waitForStop: (
+    signal: Promise<Extract<DaemonRootAwareStopTrigger, { readonly reason: "signal" }>>,
+    request: Promise<Exclude<DaemonRootAwareStopTrigger, { readonly reason: "signal" | "root-unavailable" }>>
+  ) => Promise<DaemonRootAwareStopTrigger>;
+  readonly terminalReason: (trigger: DaemonRootAwareStopTrigger) => string;
+  readonly stop: () => void;
+}
+
+export function daemonAutostartRootLifetimeEnabled(env: NodeJS.ProcessEnv): boolean {
+  return daemonAutostartRootIdentity(env) !== undefined;
+}
+
+export function daemonAutostartRootIdentity(env: NodeJS.ProcessEnv): string | undefined {
+  const value = env[daemonAutostartRootLifetimeEnvironmentVariable]?.trim();
+  return value ? value : undefined;
+}
+
+export function daemonRootIdentity(rootDir: string): string | undefined {
+  try {
+    const stat = statSync(rootDir, { bigint: true });
+    return `${stat.dev}:${stat.ino}:${stat.birthtimeNs}`;
+  } catch {
+    return undefined;
+  }
+}
+
+export function monitorDaemonRootLifetime(
+  rootDir: string,
+  expectedIdentity = daemonRootIdentity(rootDir) ?? "missing"
+): DaemonRootLifetimeMonitor {
+  let watcher: FSWatcher | undefined;
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let stopped = false;
+  let lost = false;
+  let resolveRootLost: ((trigger: { readonly reason: "root-unavailable" }) => void) | undefined;
+  const rootLost = new Promise<{ readonly reason: "root-unavailable" }>((resolve) => {
+    resolveRootLost = resolve;
+  });
+  const stop = () => {
+    if (stopped) return;
+    stopped = true;
+    watcher?.close();
+    watcher = undefined;
+    if (timer) clearInterval(timer);
+    timer = undefined;
+  };
+  const inspect = () => {
+    if (stopped || daemonRootIdentity(rootDir) === expectedIdentity) return;
+    lost = true;
+    stop();
+    resolveRootLost?.({ reason: "root-unavailable" });
+  };
+
+  inspect();
+  if (!stopped) {
+    try {
+      watcher = watch(rootDir, { persistent: false }, inspect);
+      watcher.on("error", () => {
+        watcher?.close();
+        watcher = undefined;
+      });
+    } catch {
+      // The interval is the cross-platform fallback for unavailable watchers.
+    }
+    timer = setInterval(inspect, daemonRootLifetimePollMs);
+    timer.unref();
+  }
+  return {
+    rootLost,
+    rootAvailable: () => {
+      inspect();
+      return !lost;
+    },
+    stop
+  };
+}
+
+export function daemonRootLifetimeGuard(
+  rootDir: string,
+  expectedIdentity: string | undefined
+): DaemonRootLifetimeGuard {
+  const monitor = expectedIdentity === undefined
+    ? undefined
+    : monitorDaemonRootLifetime(rootDir, expectedIdentity);
+  const rootLost = monitor?.rootLost ?? new Promise<never>(() => {});
+  return {
+    assertAvailable: () => {
+      if (monitor?.rootAvailable() === false) {
+        throw new Error(`DAEMON_AUTOSTART_ROOT_UNAVAILABLE:${rootDir}`);
+      }
+    },
+    waitForStop: (signal, request) => Promise.race([signal, request, rootLost]),
+    terminalReason: (trigger) => trigger.reason === "root-unavailable"
+      ? "root-unavailable"
+      : trigger.reason === "signal"
+        ? `signal:${trigger.signal}`
+        : trigger.reason === "control"
+          ? `control:${trigger.kind}`
+          : "idle-timeout",
+    stop: () => monitor?.stop()
+  };
+}

--- a/packages/daemon/src/lifecycle/daemon-stop-signal.ts
+++ b/packages/daemon/src/lifecycle/daemon-stop-signal.ts
@@ -1,0 +1,16 @@
+export function waitForDaemonStopSignal(): Promise<{
+  readonly reason: "signal";
+  readonly signal: "SIGINT" | "SIGTERM";
+}> {
+  return new Promise((resolve) => {
+    const stop = (signal: "SIGINT" | "SIGTERM") => {
+      process.off("SIGINT", onSigint);
+      process.off("SIGTERM", onSigterm);
+      resolve({ reason: "signal", signal });
+    };
+    const onSigint = () => stop("SIGINT");
+    const onSigterm = () => stop("SIGTERM");
+    process.on("SIGINT", onSigint);
+    process.on("SIGTERM", onSigterm);
+  });
+}

--- a/packages/daemon/src/lifecycle/run-daemon-serve.ts
+++ b/packages/daemon/src/lifecycle/run-daemon-serve.ts
@@ -54,6 +54,8 @@ import {
   formatDaemonFailure,
   repoWriteGracefulFailureLog
 } from "./daemon-failure-diagnostic.ts";
+import { daemonRootLifetimeGuard } from "./daemon-root-lifetime.ts";
+import { waitForDaemonStopSignal } from "./daemon-stop-signal.ts";
 
 export type DaemonServeRepo = DaemonRepoNamespace & Pick<DaemonRegistryRepo, "displayName" | "authorityManifestPath">;
 
@@ -73,6 +75,7 @@ export interface DaemonServeInput {
   readonly requestedAuthorityManifest?: string;
   readonly entrypoint: string;
   readonly idleMs: number;
+  readonly expectedRootIdentity?: string;
   readonly preflightReplacement: (configuration: DaemonLaunchConfiguration) => Promise<void>;
   readonly platform?: NodeJS.Platform;
   readonly runtimePolicy?: DaemonRuntimePolicy;
@@ -126,7 +129,9 @@ export async function runDaemonServe<
     let terminalClean = false;
     let terminalMessage: string | undefined;
     let failure: unknown;
+    const rootLifetime = daemonRootLifetimeGuard(rootDir, input.expectedRootIdentity);
     try {
+      rootLifetime.assertAvailable();
       // Endpoint ownership is already published, while connections remain
       // deferred. Replacement control can therefore observe a live owner
       // during this potentially expensive non-RPC startup scan.
@@ -169,6 +174,7 @@ export async function runDaemonServe<
       });
       await transport.start();
       transportStarted = true;
+      rootLifetime.assertAvailable();
       const registry = readDaemonRegistry({ userRoot });
       const priorGeneration = registry.machineId !== undefined && registry.daemonGeneration !== undefined
         ? { machineId: registry.machineId, daemonGeneration: registry.daemonGeneration }
@@ -256,6 +262,7 @@ export async function runDaemonServe<
         }))
       });
       const startStatus = await runtime.start();
+      rootLifetime.assertAvailable();
       if (startStatus.repoCount > 0 && startStatus.attachedCount === 0 && startStatus.unavailableCount > 0) {
         throw new Error(`daemon did not attach any registered repo: ${startStatus.repos.map((repo) => `${repo.repoId}:${repo.lastError ?? repo.state}`).join("; ")}`);
       }
@@ -446,18 +453,15 @@ export async function runDaemonServe<
       lifecycleStarted = true;
       hooks.onStarted?.(serveHostServices.projectStartedStatus(serviceHost.status()));
       serviceHost.scheduleIdleExit();
-      const trigger = await Promise.race([waitForStopSignal(), serviceHost.waitForStopRequest()]);
-      terminalReason = trigger.reason === "signal"
-        ? `signal:${trigger.signal}`
-        : trigger.reason === "control"
-          ? `control:${trigger.kind}`
-          : "idle-timeout";
+      const trigger = await rootLifetime.waitForStop(waitForDaemonStopSignal(), serviceHost.waitForStopRequest());
+      terminalReason = rootLifetime.terminalReason(trigger);
       terminalClean = true;
     } catch (error) {
       failure = error;
       terminalReason = `unexpected-error:${error instanceof Error ? error.name : "unknown"}`;
       terminalMessage = `Daemon service terminated after an unexpected error: ${formatDaemonFailure(error)}`;
     }
+    rootLifetime.stop();
     try {
       let stoppedByHost = false;
       try {
@@ -572,20 +576,6 @@ function defaultDaemonServeRepoId(repos: ReadonlyArray<DaemonServeRepo>, rootDir
   if (repos.some((repo) => repo.repoId === requestedRepoId)) return requestedRepoId;
   const matchingRoot = repos.find((repo) => realpathOrResolvedServeRoot(repo.canonicalRoot) === realpathOrResolvedServeRoot(rootDir));
   return matchingRoot?.repoId ?? repos[0]?.repoId ?? requestedRepoId;
-}
-
-function waitForStopSignal(): Promise<{ readonly reason: "signal"; readonly signal: "SIGINT" | "SIGTERM" }> {
-  return new Promise((resolve) => {
-    const stop = (signal: "SIGINT" | "SIGTERM") => {
-      process.off("SIGINT", onSigint);
-      process.off("SIGTERM", onSigterm);
-      resolve({ reason: "signal", signal });
-    };
-    const onSigint = () => stop("SIGINT");
-    const onSigterm = () => stop("SIGTERM");
-    process.on("SIGINT", onSigint);
-    process.on("SIGTERM", onSigterm);
-  });
 }
 
 function realpathOrResolvedServeRoot(input: string): string {

--- a/packages/daemon/test/local-json-rpc-client.test.ts
+++ b/packages/daemon/test/local-json-rpc-client.test.ts
@@ -8,6 +8,9 @@ import { PassThrough } from "node:stream";
 import test from "node:test";
 import {
   createDaemonLaunchConfiguration,
+  daemonAutostartRootLifetimeEnabled,
+  daemonAutostartRootLifetimeEnvironmentVariable,
+  daemonServerHostEnvironment,
   daemonLaunchOptionsResolvedFlag,
   DaemonAutostartTimeoutError,
   DaemonJsonRpcRequestTimeoutError,
@@ -66,6 +69,14 @@ test("daemon launch configuration is the canonical argv derivation for every spa
       daemonLaunchOptionsResolvedFlag
     ]
   });
+});
+
+test("ordinary daemon server launches cannot inherit the internal autostart root lifetime", () => {
+  const env = daemonServerHostEnvironment({
+    [daemonAutostartRootLifetimeEnvironmentVariable]: "1"
+  }, makeTarget("/tmp/ha-daemon-autostart-lifetime.sock"));
+
+  assert.equal(daemonAutostartRootLifetimeEnabled(env), false);
 });
 
 test("legacy socket fallback diagnoses and removes an unowned empty directory occupying the socket path", async (t) => {


### PR DESCRIPTION
# English

## Summary

An autostarted resident daemon now exits when the canonical root it was launched for disappears. Residency exists so a session that pauses can come back; when the root itself is gone, nobody is coming back, and residency becomes a leak.

This repairs a regression introduced by PR #1253, which changed the autostart idle default from 750ms to `0` (semantics: never arm the idle-exit timer). The reason for `0` remains valid — a 750ms window misreads an in-session pause as the end of the session — so this change does not revisit the default. It fixes the consequence instead: before #1253 a leaked test daemon self-cleaned in under a second; after it, the same leak was immortal.

Observed impact before the fix: 31 orphaned daemons accumulated on one machine in about half an hour, each consuming 35-42% CPU, driving load average to 73 and stalling the governed write path with 30-second repo-writer readiness timeouts.

## What Changed

- Every locally autostarted daemon records the canonical root's filesystem identity (`dev:ino:birthtimeNs`) at spawn time, passed through a dedicated environment marker.
- The daemon checks that identity at its cold-start checkpoint and continuously at runtime (250ms poll, accelerated by a filesystem watch where that watch is safe). If the root is deleted, or replaced at the same path, the daemon stops gracefully.
- **The filesystem watch is suppressed on Windows.** Watching the canonical root while it is being removed crashes Node with `STATUS_STACK_BUFFER_OVERRUN` (`0xC0000409`) — its `__fastfail` path, which bypasses `exit`, `beforeExit`, `uncaughtException` and every `catch`, which is why the watcher's own `error` handler never helped. The watch was only ever a latency accelerant over the interval, so suppressing it costs at most one poll interval of detection latency.
- The marker is stripped from the inherited environment and recomputed for each autostart spawn, so a stale marker can never be inherited by a different process.
- Coverage is by launch path, not by a list of test files: everything that converges on the shared `spawnLocalDaemon` is covered. Explicit `daemon serve`, `daemon start --service`, and the production service are deliberately **not** covered — they have an external owner or service manager, so a missing root does not mean nobody is coming back.


**Windows root cause, established by an A/B control rather than by reading code.** Two hypotheses were refuted first: parent/child root-identity mismatch (a probe showed bit-identical `dev:ino:birthtimeNs`) and slow startup causing a collateral kill (232ms to runtime-ready against a 27.4s parent receipt). The third probe disabled only the watcher and kept the poll; the autostart child then reached `daemon-steady-state` and stayed alive instead of dying at 2.56s. All five diagnostic commits have been removed from this branch; the branch now carries the repair and the watcher fix only.

The poll-only path is pinned by its own test rather than left to the Windows runner: `monitorDaemonRootLifetime` takes the suppression flag, so any host can exercise the branch. Mutation check: removing the interval under suppression fails that test and only that test (15s timeout), while the other three keep passing — so the assertion is anchored to the poll, not passing incidentally.

## Task And Scope

Regression repair for the defect PR #1253 introduced. The invariant test that shipped with #1253 asserted the default value's numeric range and stayed green throughout, because the harm occurred in a different dimension: process lifetime, not milliseconds.

## Version Impact

No published CLI surface changes. The idle default is unchanged. Behaviour changes only for autostarted daemons whose canonical root no longer exists — previously they lived forever, now they exit.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable — no CI configuration, gate manifest, branch protection, or `tools/**` file is modified
- Authority: task-scoped regression repair; the accepted decision governing the idle default is deliberately **not** revisited by this change
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: `399a954575085fccd53ed5b935bf8c427f07e1c5`
- Branch merge-base with `origin/main`: `399a954575085fccd53ed5b935bf8c427f07e1c5`
- Last `git fetch origin` time: immediately before this PR was opened
- Sync method: rebase; the five temporary Windows diagnostic commits were dropped, leaving the repair plus the Windows watcher fix
- Public diff command: `git diff 399a9545...codex/idle-orphan`
- Private evidence commit/path: recorded in the private task package
- Reviewer evidence path: recorded in the private task package
- GitHub Actions `rewrite-ci` run URL: see the checks on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` — green, 27 complete manifest gates, 738 fast and 253 contract tests passing with one platform skip
- [x] Targeted tests for the change surface, named with their counts: `packages/cli/test/daemon-autostart-root-lifetime.test.ts` 4/4 pass (two pre-existing plus two pinning the Windows-suppressed path). **A/B control on one machine, same command, two trees:** on the unfixed base both tests fail (`condition did not converge within 8000ms`, `alive: true` — the daemon survives removal of its root); on this branch both pass in 2987ms and 1743ms against the same 8000ms deadline. Full `packages/cli/test` integration collection 780/780; daemon unit and default-invariant tests 19/19.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending at the time this body was written
- Not run, and why: the full CI-equivalent matrix (`npm run check:ci`) was not run locally; `check:stop-point` reports the gates it does not cover, and the integration test carrying this change's load-bearing signal was run directly instead.

## Review Evidence

- Self-review: the reviewer independently reproduced the A/B control described above rather than accepting the author's report, and separately audited the fail-safe property — the monitor arms only when the environment marker is present, so any launch path that does not set it (including the production service) keeps its previous behaviour exactly.
- Reviewer subagent: not used; verification was performed directly.
- Human review: pending.
- Blocking findings: none.

## Residual Risk

The behavioural assertion cannot live in the fast unit tier: it needs a real detached child process, a real root removal, and a real convergence window, costing roughly 4-6 seconds. It is not a race between two comparable timers — convergence is driven by a filesystem event with a 250ms poll fallback, measured at 1.7-3.0s against an 8s deadline — but it is an integration-tier cost. The cheap unit boundary only guarantees that a service launch does not inherit the internal marker.

`packages/cli/src/daemon/client.ts` still parses `HARNESS_DAEMON_IDLE_MS` without `allowZero`, so an explicit `0` falls back to the default. This is inert today because the default is `0`, and is deliberately left alone: changing it belongs to a decision about the default's semantics, not to this repair.

## References

- Residency is for sessions that may return. The launching context disappearing is the cheapest available proof that none will.

# 中文

## 概要

自动拉起的常驻 daemon 现在会在它所服务的 canonical root 消失后退出。**驻留是给"可能还会回来"的会话准备的;当 root 本身都没了,没有人会回来,驻留就变成了泄漏。**

本 PR 修复的是 PR #1253 引入的回归:该 PR 把 autostart 的 idle 默认值从 750ms 改成 `0`(语义 = 永不 arm idle 退出定时器)。**`0` 的理由仍然成立**——750ms 的窗口会把会话中的停顿误读成会话结束——所以本次**不重开那个默认值**,只修它的后果:#1253 之前泄漏的测试 daemon 一秒内自清,之后同样的泄漏变成不死。

修前实测影响:一台机器上约半小时累积 **31 个孤儿 daemon**,各占 35-42% CPU,把 load average 顶到 **73**,治理写路因 repo writer 30 秒就绪超时而实际停摆。

## 改动内容

- 每个本地 autostart 的 daemon 在 spawn 时记录 canonical root 的文件系统身份(`dev:ino:birthtimeNs`),经一个专用环境标记传入。
- daemon 在冷启动检查点与运行期持续核对该身份(250ms 轮询为主,文件系统 watch 只在安全的平台上作为提速器)。root 被删除、或在同路径被重建,daemon 优雅退出。
- **Windows 上不建 watch。**监视正在被删除的 canonical root 会让 Node 以 `STATUS_STACK_BUFFER_OVERRUN`(`0xC0000409`)崩溃——那是它的 `__fastfail` 路径,绕过 `exit`、`beforeExit`、`uncaughtException` 与任何 `catch`,这正是 watcher 自己的 `error` 处理器从来不起作用的原因。watch 本来就只是轮询之上的提速器,去掉它的代价最多是一个轮询周期的检测延迟。
- **该标记在每次 autostart spawn 时先从继承环境中剥除、再按本次 root 现算写入**,因此陈旧标记不可能被别的进程继承。
- **覆盖面按启动路径划分,不按测试文件清单**:凡汇聚到共享 `spawnLocalDaemon` 的路径全覆盖。显式 `daemon serve`、`daemon start --service` 与 production service **刻意不覆盖**——它们有外部 owner 或 service manager,root 不在不等于没人管。


**Windows 根因由 A/B 对照确立,不是读代码推断的。**先证伪了两个假设:父子 root 身份不匹配(探针显示 `dev:ino:birthtimeNs` 逐位相同)、启动慢导致误杀(232ms 就 runtime-ready,父进程却等了 27.4s)。第三轮只关掉 watcher、保留轮询,autostart 子进程随即走到 `daemon-steady-state` 并存活,而不是在 2.56s 死掉。五个诊断提交已全部从本分支摘除,分支现在只带修复本体与 watcher 修复。

poll-only 这条路由它自己的测试钉住,不依赖 Windows runner:`monitorDaemonRootLifetime` 接收 suppression 参数,任何主机都能跑到那个分支。变异检查:在 suppression 下去掉 interval,**只有**那条测试变红(15s 超时),另外三条照过——说明断言确实钉在轮询上,不是顺带绿的。

## 任务与范围

对 PR #1253 引入缺陷的回归修复。#1253 随附的不变量测试断言的是默认值的**数值区间**,全程绿灯,因为伤害发生在另一个量纲上:**进程生命周期,而不是毫秒**。

## 版本影响

无已发布 CLI 面变化,idle 默认值不变。行为变化仅限于 canonical root 已不存在的 autostart daemon——此前永生,现在退出。

## 治理声明

- 触碰 protected surface:否
- protected surface 范围:不适用——未修改任何 CI 配置、gate manifest、分支保护或 `tools/**` 文件
- 依据:任务范围内的回归修复;管辖 idle 默认值的既有裁决**刻意不在本次重开**
- 机器检查边界:本 PR 只断言声明存在;是否属实与是否充分由评审判断。
- Break-glass:否
- Break-glass 理由:不适用
- Break-glass 范围:不适用
- 后续治理任务:无

## 验证

- 基线 `origin/main` SHA:`56e694e58bf5a946c18a69f329be296b2165506f`
- 与 `origin/main` 的 merge-base:`56e694e58bf5a946c18a69f329be296b2165506f`
- 最近一次 `git fetch origin` 时间:开 PR 前即刻
- 同步方式:无需同步
- 公开 diff 命令:`git diff origin/main...codex/idle-orphan`
- 私有证据 commit/路径:记录于私有任务包
- 评审证据路径:记录于私有任务包
- GitHub Actions `rewrite-ci` run URL:见本 PR 的 checks
- [x] `git diff --check`
- [x] `npm run check:stop-point`——绿,27 个完整 manifest 门,fast 738 / contract 253 通过,1 个平台 skip
- [x] 本次改动面的定向测试及其计数:`packages/cli/test/daemon-autostart-root-lifetime.test.ts` **2/2 通过**。**同机同命令两棵树的 A/B 对照**:未修复基线上两条测试**双双失败**(`condition did not converge within 8000ms`、`alive: true`——root 被删后 daemon 仍存活);本分支上两条分别以 2987ms 与 1743ms 通过,对同一个 8000ms 期限有 2.7-4.6 倍余量。完整 `packages/cli/test` integration 780/780;daemon 单元与默认不变量 19/19。
- [ ] GitHub Actions `rewrite-ci` 通过(权威完整门)——撰写本正文时仍在进行
- 未跑及原因:本机未跑完整 CI 等价矩阵(`npm run check:ci`);`check:stop-point` 会列出它未覆盖的门,承载本次承重信号的 integration 测试已单独直跑。

## 审查证据

- 自查:复核方**自己复现了上述 A/B 对照**,而非采信作者报告;另外单独审计了 fail-safe 性质——监视器**仅在环境标记存在时武装**,因此任何不设置它的启动路径(含 production service)行为与此前逐字相同。
- 评审 subagent:未使用,验证直接进行。
- 人工评审:待进行。
- 阻塞性 findings:无。

## 残余风险

该行为断言**无法放进 fast 单元层**:它需要真实的 detached 子进程、真实的 root 删除与真实的收敛窗口,单文件约 4-6 秒。它**不是两个量级相当的计时器在竞速**——收敛由文件系统事件驱动、250ms 轮询兜底,实测 1.7-3.0s 对 8s 期限——但确实是 integration 层的成本。便宜的单元边界测试只保证 service launch 不继承内部标记。

`packages/cli/src/daemon/client.ts` 解析 `HARNESS_DAEMON_IDLE_MS` 时仍无 `allowZero`,显式传 `0` 会回落到默认。今天默认就是 `0`,故无行为差异;**刻意不动**——改它属于"重新裁决默认值语义"那条路,不属于本次修复。

## 关联材料

- 驻留是给可能回来的会话准备的。**启动它的那个上下文消失,是"没有人会回来"最便宜的证明。**

