### PR TITLE
fix(cli): bound decision conformance reads

### DIFF
--- a/packages/cli/src/commands/extensions/assets/software-coding/vertical.json
+++ b/packages/cli/src/commands/extensions/assets/software-coding/vertical.json
@@ -341,8 +341,14 @@
       "type": "script",
       "command": "scripts/decision-conformance-check.mjs",
       "reads": [
-        "{{paths.authoredRoot}}/**",
-        "{{paths.localRoot}}/**"
+        "{{paths.tasksRoot}}/**",
+        "{{paths.decisionsRoot}}/**",
+        "{{paths.sessionsRoot}}/**",
+        "{{paths.authoredRoot}}/attribution-events/**",
+        "{{paths.authoredRoot}}/authority-attribution-events/v2/**",
+        "{{paths.authoredRoot}}/people*.yaml",
+        "{{paths.localRoot}}/cache/**",
+        "{{paths.localRoot}}/task-holders/**"
       ],
       "writes": [],
       "inputs": {},

--- a/packages/cli/test/preset-script-cli.test.ts
+++ b/packages/cli/test/preset-script-cli.test.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 import { gitRead, runJson, withTempRoot, writeFile } from "./helpers/preset-script-fixtures.ts";
-import { existsSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 
@@ -96,6 +96,44 @@ test("CLI check reports decision conformance violations without failing when pol
     assert.equal(passed.report.scriptChecks.some((entry: Record<string, any>) => (
       entry.scriptId === "vertical:software-coding:decision-conformance" &&
       entry.report?.summary?.findingCount === 0
+    )), true);
+  });
+});
+
+test("CLI check runs decision conformance with unsafe entries outside its bounded read scopes", {
+  skip: process.platform === "win32"
+}, () => {
+  withTempRoot((rootDir) => {
+    ensureTestHarnessIdentity(rootDir);
+    runJson(rootDir, ["init"]);
+    runJson(rootDir, ["task", "create", "--title", "Bounded Conformance Reads"]);
+    runJson(rootDir, [
+      "decision", "propose",
+      "--id", "dec_BOUNDED_CONFORMANCE_READS",
+      "--title", "Bounded conformance reads",
+      "--question", "Should the checker ignore unrelated filesystem entries?",
+      "--chosen", "Read only the conformance projection sources",
+      "--rejected", "Read the entire authored and local roots",
+      "--why-not", "Unbounded roots contain unrelated runtime entries"
+    ]);
+    runJson(rootDir, [
+      "decision", "accept", "dec_BOUNDED_CONFORMANCE_READS",
+      "--judgment-only", "Exercise the negative conformance path through the public check command."
+    ]);
+    symlinkSync("missing-unrelated-target", path.join(rootDir, "harness/unrelated-link"));
+    symlinkSync("missing-unrelated-target", path.join(rootDir, ".harness/unrelated-link"));
+
+    const audited = runJson(rootDir, ["check", "--profile", "source-package"]);
+    const conformance = audited.report.scriptChecks.find((entry: Record<string, any>) => (
+      entry.scriptId === "vertical:software-coding:decision-conformance"
+    ));
+
+    assert.equal(conformance?.ok, true);
+    assert.equal(conformance?.report?.schema, "decision-conformance-report/v1");
+    assert.equal(conformance?.report?.summary?.violationCount > 0, true);
+    assert.equal(conformance?.report?.violations?.some((violation: Record<string, unknown>) => (
+      violation.type === "accepted-decision-missing-task-or-defer" &&
+      violation.ref === "decision/dec_BOUNDED_CONFORMANCE_READS"
     )), true);
   });
 });

--- a/packages/kernel/src/projection/entity-attribution-projection.ts
+++ b/packages/kernel/src/projection/entity-attribution-projection.ts
@@ -26,7 +26,12 @@ export function legacyEntityAttribution(
 
 export function readLegacyPersonIds(rootInput: HarnessLayoutInput): ReadonlySet<string> {
   const peoplePath = `${resolveHarnessLayout(rootInput).authoredRoot}/people.yaml`;
-  if (!localLayoutFileSystem.exists(peoplePath)) return new Set();
+  try {
+    if (!localLayoutFileSystem.exists(peoplePath)) return new Set();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ERR_ACCESS_DENIED") return new Set();
+    throw error;
+  }
   const body = localLayoutFileSystem.readText(peoplePath);
   const ids = [...body.matchAll(/(?:^|\n)\s*(?:-\s*)?personId:\s*["']?([^\s"'#]+)["']?/gu)].map((match) => match[1]!);
   try {

--- a/packages/kernel/src/projection/entity-declaration-projection.ts
+++ b/packages/kernel/src/projection/entity-declaration-projection.ts
@@ -69,7 +69,7 @@ export interface DeclaredEntitySourceResult {
 
 interface DeclaredEntitySourceCacheEntry {
   readonly result: DeclaredEntitySourceResult;
-  readonly directorySignatures: ReadonlyMap<string, string>;
+  readonly directorySignatures: ReadonlyMap<string, string | null>;
   readonly fileSignatures: ReadonlyMap<string, string>;
 }
 
@@ -495,16 +495,28 @@ function templateMatcher(template: string): { readonly pattern: RegExp; readonly
 function listTemplateFiles(rootPath: string, template: string): {
   readonly files: ReadonlyArray<string>;
   readonly directories: ReadonlyArray<string>;
-  readonly directorySignatures: ReadonlyMap<string, string>;
+  readonly directorySignatures: ReadonlyMap<string, string | null>;
   readonly directoriesVisited: number;
   readonly entriesVisited: number;
 } {
-  if (!localLayoutFileSystem.exists(rootPath)) return { files: [], directories: [], directorySignatures: new Map(), directoriesVisited: 0, entriesVisited: 0 };
   const segments = template.split("/");
+  const dynamicSegmentIndex = segments.findIndex((segment) => segment.includes("{"));
+  const staticPrefixLength = dynamicSegmentIndex < 0 ? 0 : dynamicSegmentIndex;
+  const relativePrefix = segments.slice(0, staticPrefixLength);
+  const traversalRoot = path.join(rootPath, ...relativePrefix);
+  if (!localLayoutFileSystem.exists(traversalRoot)) {
+    return {
+      files: [],
+      directories: [],
+      directorySignatures: new Map([[traversalRoot, null]]),
+      directoriesVisited: 0,
+      entriesVisited: 0
+    };
+  }
   const segmentMatchers = segments.map(templateSegmentMatcher);
   const files: string[] = [];
   const directories: string[] = [];
-  const directorySignatures = new Map<string, string>();
+  const directorySignatures = new Map<string, string | null>();
   let directoriesVisited = 0;
   let entriesVisited = 0;
   function visit(directory: string, segmentIndex: number, relativeSegments: ReadonlyArray<string>): void {
@@ -524,7 +536,7 @@ function listTemplateFiles(rootPath: string, template: string): {
       }
     }
   }
-  visit(rootPath, 0, []);
+  visit(traversalRoot, staticPrefixLength, relativePrefix);
   return { files: files.sort(), directories, directorySignatures, directoriesVisited, entriesVisited };
 }
 
@@ -537,7 +549,7 @@ function sourceCacheEntryMatches(
     (validation === "verify" || pathSignaturesMatch(signatures));
 }
 
-function pathSignaturesMatch(signatures: ReadonlyMap<string, string>): boolean {
+function pathSignaturesMatch(signatures: ReadonlyMap<string, string | null>): boolean {
   for (const [inputPath, expected] of signatures) {
     if (readPathSignature(inputPath) !== expected) return false;
   }


### PR DESCRIPTION
# English

## Summary

`ha check --task <any-id> --strict` hard-failed for every task, and not because of the task
being checked: the `decision-conformance` check script could not start. It declared
`{{paths.authoredRoot}}/**` + `{{paths.localRoot}}/**` as its read scope, the scope validator
correctly rejected those unbounded roots, and the check reported
`Script attempted filesystem read outside its declared permission scope.`

That is worse than a gate that silently goes green. The user gets a red they cannot fix, so
they learn to stop passing `--strict` — the gate dies while still looking like it works.

The fix narrows `reads` to the subtrees the script actually reads. The validator is not
touched: rejecting unbounded read scopes is correct behaviour, and silencing it would kill
this gate a second time.

## What Changed

- `packages/cli/src/commands/extensions/assets/software-coding/vertical.json`: replace the two
  whole-tree roots with `tasksRoot`, `decisionsRoot`, `sessionsRoot`, both attribution event
  families, the optional `people*.yaml`, and the two `localRoot` subtrees the script reads.
- `packages/kernel/src/projection/entity-declaration-projection.ts`: start declared-source
  traversal at the template's static prefix instead of the authored root, so a template such as
  `tasks/{taskId}/…` never has to enumerate the authored root. An absent static prefix is
  recorded as an explicit `null` signature rather than as a missing entry, which keeps
  incremental task verification local.
- `packages/kernel/src/projection/entity-attribution-projection.ts`: treat an access-denied
  probe of the optional `people.yaml` as absence; any other error still throws.
- `packages/cli/test/preset-script-cli.test.ts`: add a public-CLI positive control.

## Task And Scope

- Harness task: `task_01KZAX3NNXXK1Q57T7PJH35X1P`
- Branch: `codex/dc-reads`
- Public scope: one vertical asset declaration, two kernel projection functions, one CLI test file
- Private planning/evidence updated: yes
- Out of scope: the scope validator itself, `tools/**`, CI configuration, gate manifest,
  branch protection

## Version Impact

- Version: no version change because this is a behaviour fix inside an existing bundled asset
  and two internal projection helpers
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KZAX3NNXXK1Q57T7PJH35X1P`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether
  it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `399a954575085fccd53ed5b935bf8c427f07e1c5`
- Branch merge-base with `origin/main`: `399a954575085fccd53ed5b935bf8c427f07e1c5`
- Last `git fetch origin` time: 2026-08-06, immediately before the rebase onto `399a9545`
- Sync method: rebase
- Public diff command: `git diff 399a9545...codex/dc-reads`
- Private evidence commit/path: task ledger for `task_01KZAX3NNXXK1Q57T7PJH35X1P`
- Reviewer evidence path: task ledger review record for the same task
- GitHub Actions `rewrite-ci` run URL: see the checks on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` (the gate set is derived from `tools/gate-manifest.json`; do not enumerate gates by hand)
- [x] Targeted tests for the change surface, named with their counts:
  - `packages/cli/test/preset-script-cli.test.ts` 17/17
  - `packages/kernel/test/store/sqlite-projection-source-cache.test.ts` 10/10
  - `packages/kernel/test/store/sqlite-incremental-projection.test.ts`,
    `attribution-union-projection.test.ts`, `sqlite-projection-integrity.test.ts` 37/37
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending on this PR
- Not run, and why: the full kernel and CLI integration tiers were not run locally; the
  authoritative full gate is `rewrite-ci` on this PR. The three reproduction commands were
  re-run against a copy-on-write snapshot of canonical data, not against the live production
  daemon, because that daemon still serves the previously installed assets; they should be
  re-run on the canonical root after this merges and the CLI/daemon are refreshed.

## Review Evidence

- Self-review: the positive control asserts more than "the red disappeared". Removing the
  script from the check would also make the red disappear, so the new test asserts that the
  script produces a `decision-conformance-report/v1` **and** reports a specific real violation
  (`accepted-decision-missing-task-or-defer` on a named decision) while unrelated broken
  symlinks exist in both the authored and local roots. A gate that is merely never-red cannot
  pass that assertion.
- Reviewer subagent: not used; the reviewer ran the checks directly (see below)
- Human review: the reviewer independently re-ran each targeted suite rather than accepting the
  implementer's summary, and ran single-factor reverts to establish that both kernel changes are
  load-bearing: reverting either one alone takes `preset-script-cli.test.ts` from 17/17 to
  13 pass / 4 fail with `script_scope_violation_read`.
- Blocking findings: one, now fixed. The first round of this change narrowed the traversal root
  but did not preserve a watch for an absent static prefix. That made the declared-source cache
  miss on every incremental run, which tripped the verification race guard and stat'd unrelated
  task sources — breaking the locality invariant in
  `sqlite-projection-source-cache.test.ts` ("single task verification never stats unrelated task
  source files"): 9/10 with 11 unrelated task directories and their `INDEX.md` stat'd. A
  negative control confirmed the regression belonged to this change: checking both kernel files
  back out to `399a9545` restored 10/10. The invariant assertion was not modified.

## Residual Risk

- `projectionSourceStatSignature` returns `null` for any stat error, not only for a missing
  path. A declared-source prefix that exists but becomes unreadable therefore reads as absent
  and the cache hits. This is pre-existing behaviour that the new absence watch inherits rather
  than introduces, but it is now on a path that depends on absence being meaningful.
- The optional `people*.yaml` read scope is an existence-dependent glob: it grants nothing when
  the file is missing, which is why the access-denied probe must be treated as absence. The
  script scope model has no way to declare "this file, if it exists" — a non-recursive read
  scope on a missing path fails scope resolution outright. Worth a separate follow-up.
- The three reproduction commands have not been re-run against the live canonical root; see the
  "Not run, and why" note above.

## References

- Task: `task_01KZAX3NNXXK1Q57T7PJH35X1P`
- Evidence: task ledger progress entries for that task, including the round-one regression, the
  mechanism, and the A/B evidence
- Review: task ledger review record for that task

---

# 中文

## 概要

`ha check --task <任何 id> --strict` 对每个任务都稳定 hard-fail，原因不在被检查的任务，
而在 `decision-conformance` 这个检查脚本**自己起不来**：它把读取范围声明成
`{{paths.authoredRoot}}/**` + `{{paths.localRoot}}/**`，范围校验器正确地拒绝了这两个无界根，
检查因此报 `Script attempted filesystem read outside its declared permission scope.`

这比一道静默变绿的门更阴：使用者永远得到一个自己修不掉的红，于是学会不再传 `--strict`——
门就这么死了，还死得像在工作。

修法是把 `reads` 收窄到脚本真正读取的子树。**校验器一行未动**：它拒绝无界读取范围是对的，
让它闭嘴等于把这道门第二次杀死。

## 改动内容

- `packages/cli/src/commands/extensions/assets/software-coding/vertical.json`：把两个整树根
  替换为 `tasksRoot`、`decisionsRoot`、`sessionsRoot`、两类 attribution 事件、可选的
  `people*.yaml`，以及脚本实际读取的两个 `localRoot` 子树。
- `packages/kernel/src/projection/entity-declaration-projection.ts`：声明源遍历从模板的静态前缀
  开始，而不是从 authored 根开始，使 `tasks/{taskId}/…` 这类模板不必枚举 authored 根。
  静态前缀不存在时**显式记录为 `null` 签名**而不是「没有这个条目」，从而保住增量任务验证的局部性。
- `packages/kernel/src/projection/entity-attribution-projection.ts`：探测可选的 `people.yaml`
  时若得到 access-denied，按不存在处理；其他错误照常抛出。
- `packages/cli/test/preset-script-cli.test.ts`：新增公共 CLI 阳性对照。

## 任务与范围

- Harness 任务：`task_01KZAX3NNXXK1Q57T7PJH35X1P`
- 分支：`codex/dc-reads`
- 公开范围：一个 vertical 资产声明、两个 kernel 投影函数、一个 CLI 测试文件
- 私有计划 / 证据是否已更新：yes
- 范围外：范围校验器本身、`tools/**`、CI 配置、gate manifest、分支保护

## 版本影响

- 版本：不改版本，原因是本次是既有 bundled 资产与两个内部投影辅助函数的行为修复
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`task_01KZAX3NNXXK1Q57T7PJH35X1P`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`399a954575085fccd53ed5b935bf8c427f07e1c5`
- 当前分支与 `origin/main` 的 merge-base：`399a954575085fccd53ed5b935bf8c427f07e1c5`
- 最近一次 `git fetch origin` 时间：2026-08-06，就在 rebase 到 `399a9545` 之前
- 同步方式：rebase
- 公开 diff 命令：`git diff 399a9545...codex/dc-reads`
- 私有证据 commit/path：`task_01KZAX3NNXXK1Q57T7PJH35X1P` 的任务台账
- Reviewer 证据路径：同一任务的台账 review 记录
- GitHub Actions `rewrite-ci` run URL：见本 PR 的 checks
- [x] `git diff --check`
- [x] `npm run check:stop-point`（门集从 `tools/gate-manifest.json` 派生，不要手工枚举门名）
- [x] 改动面的定向测试，写明测试名与通过数：
  - `packages/cli/test/preset-script-cli.test.ts` 17/17
  - `packages/kernel/test/store/sqlite-projection-source-cache.test.ts` 10/10
  - `packages/kernel/test/store/sqlite-incremental-projection.test.ts`、
    `attribution-union-projection.test.ts`、`sqlite-projection-integrity.test.ts` 合计 37/37
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）——本 PR 上待跑
- 未跑项及原因：本地未跑完整 kernel 与 CLI integration tier，权威全量门是本 PR 上的
  `rewrite-ci`。三条复现命令是在 canonical 数据的 CoW 快照上复跑的，不是对着在跑的生产
  daemon——那个 daemon 仍加载着此前安装的资产；合入并刷新 CLI/daemon 后，应在 canonical 根
  重跑这三条。

## 审查证据

- 自查：阳性对照断言的不只是「红没了」。把脚本从检查里摘掉也能让红消失，所以新测试断言的是：
  在 authored 与 local 两个根里都存在无关坏符号链接的前提下，脚本**产出**
  `decision-conformance-report/v1`**并且**报出一条具体的真实违规
  （点名 decision 的 `accepted-decision-missing-task-or-defer`）。
  一道永远绿的门过不了这个断言。
- Reviewer subagent：未使用；复核者直接跑门（见下）
- 人工审查：复核者未采信实现者摘要，逐个重跑了定向测试，并做单因子回退确认两处 kernel 改动
  都是承重的——单独回退其中任何一个，`preset-script-cli.test.ts` 都从 17/17 掉到
  13 通过 / 4 失败（`script_scope_violation_read`）。
- 阻塞发现：一条，已修。本改动第一轮收窄了遍历根，但没有为「静态前缀不存在」保留 watch，
  导致声明源缓存在每次增量运行时都失配，触发验证 race guard 的全量校验，进而 stat 了无关任务源，
  破坏了 `sqlite-projection-source-cache.test.ts` 的局部性不变量
  （single task verification never stats unrelated task source files）：9/10，且实际多 stat 了
  11 个无关 task 目录及其 `INDEX.md`。**阴性对照**确认该回归属于本改动：把两个 kernel 文件
  checkout 回 `399a9545` 后同一条测试恢复 10/10。该不变量断言未被修改。

## 残余风险

- `projectionSourceStatSignature` 对**任何** stat 错误都返回 `null`，不只是路径缺失。
  因此一个存在但变得不可读的声明源前缀会被读成「不存在」而命中缓存。这是新增的 absence watch
  **继承**的既有行为而非引入的，但它现在落在了一条以「不存在有意义」为前提的路径上。
- 可选的 `people*.yaml` 读取范围是一个依赖存在性的 glob：文件缺失时它什么也不授予，
  这正是 access-denied 探测必须按不存在处理的原因。脚本范围模型没有办法声明
  「这个文件，如果它存在的话」——对缺失路径的非递归读取范围会直接让范围解析失败。
  值得单开一条后续任务。
- 三条复现命令尚未对着在跑的 canonical 根重跑；见上面「未跑项及原因」。

## 关联材料

- 任务：`task_01KZAX3NNXXK1Q57T7PJH35X1P`
- 证据：该任务的台账 progress 记录，含第一轮回归、机制与 A/B 证据
- 审查：该任务的台账 review 记录
