### PR TITLE
test(cli): publish completion fixture documents

### DIFF
--- a/packages/cli/test/helpers/canonical-task-publication-fixture.ts
+++ b/packages/cli/test/helpers/canonical-task-publication-fixture.ts
@@ -39,6 +39,15 @@ export function publishSeededTaskFixture(authoredRoot: string, taskRoot: string,
   Effect.runSync(coordinator.flush("explicit"));
 }
 
+export function publishSeededTaskFixtureById(
+  authoredRoot: string,
+  taskId: string,
+  packageSlug?: string
+): void {
+  const packageName = packageSlug ? `${taskId}-${packageSlug}` : taskId;
+  publishSeededTaskFixture(authoredRoot, path.join(authoredRoot, "tasks", packageName), taskId);
+}
+
 const fixtureAttribution = {
   actor: {
     principal: { kind: "person" as const, personId: "person_fixture" },

--- a/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts
@@ -37,6 +37,7 @@ import {
   runRawJsonMaybeFail,
   stopDaemon
 } from "../helpers/daemon-cli.ts";
+import { publishSeededTaskFixtureById } from "../helpers/canonical-task-publication-fixture.ts";
 import {
   authorityEventBodies,
   authorityOperationRecords,
@@ -61,10 +62,11 @@ import {
   verifyExplicitTaskSubmitIngress,
   verifyInferredTaskSubmitIngress
 } from "./task-submit-ingress.ts";
-import { exerciseIdenticalCodeDocForce } from "./code-doc-force-replay.ts";
+import { exerciseIdenticalCodeDocForce, exerciseUnpublishedCloseoutPositiveControl } from "./code-doc-force-replay.ts";
 
-test("production service route preserves progress dry-run and publishes canonical task writes", { timeout: 240_000 }, async () => {
+test("production service route preserves progress dry-run and publishes canonical task writes", { timeout: 240_000 }, async (context) => {
   const fixture = createFixture();
+  publishSeededTaskFixtureById(fixture.authoredRoot, "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG8", "production-route");
   const userRoot = defaultDaemonUserRoot(fixture.root);
   const env = {
     HARNESS_ACTOR: "agent:codex",
@@ -259,6 +261,15 @@ test("production service route preserves progress dry-run and publishes canonica
       prRef: "https://github.com/example/repo/pull/999",
       reviewerId: "person_alice"
     }));
+    exerciseUnpublishedCloseoutPositiveControl({
+      fixture,
+      taskId: sluggedLifecycleTaskId,
+      taskRoot: sluggedTaskRoot,
+      completionPacketPath,
+      env: sluggedLifecycleEnv,
+      diagnostic: (message) => context.diagnostic(message)
+    });
+
     const completed = runRawJsonMaybeFail(fixture.repoRoot, [
       "task", "complete", sluggedLifecycleTaskId, "--approve", "--from-file", completionPacketPath
     ], sluggedLifecycleEnv);
@@ -369,6 +380,7 @@ test("production service route preserves progress dry-run and publishes canonica
 
 test("production generic canonical ingress accepts and journals one write for every directly compiled kind", async () => {
   const fixture = createFixture();
+  publishSeededTaskFixtureById(fixture.authoredRoot, "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG0");
   const daemon = defaultCliAdapterProvider().createMultiRepoDaemonRuntime({
     repos: [{ repoId: "canonical", rootDir: fixture.repoRoot }],
     materializerPollMs: 5,

--- a/packages/cli/test/production-authority-canonical-ingress/code-doc-force-replay.ts
+++ b/packages/cli/test/production-authority-canonical-ingress/code-doc-force-replay.ts
@@ -3,7 +3,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { createGitCanonicalPublicationInspector } from "../../../daemon/src/index.ts";
 import { runRawJsonMaybeFail } from "../helpers/daemon-cli.ts";
-import { git, latestAuthorityOperation } from "./fixture.ts";
+import { latestAuthorityOperation } from "./fixture.ts";
 
 interface CanonicalFixtureRoots {
   readonly authoredRoot: string;
@@ -20,8 +20,12 @@ export async function exerciseIdenticalCodeDocForce(
   const taskRoot = path.join(fixture.authoredRoot, `tasks/${taskId}-production-route`);
   const closeoutPath = path.join(taskRoot, "closeout.md");
   writeFileSync(closeoutPath, `${readFileSync(closeoutPath, "utf8")}\nAmended after implementation review.\n`);
-  git(fixture.authoredRoot, "add", `tasks/${taskId}-production-route/closeout.md`);
-  git(fixture.authoredRoot, "commit", "-q", "-m", "amend closeout before force reconciliation");
+  const syncedCloseout = runRawJsonMaybeFail(fixture.repoRoot, [
+    "doc", "sync", "--submit", "--path", `tasks/${taskId}-production-route/closeout.md`
+  ], env);
+  assert.equal(syncedCloseout.status, 0, JSON.stringify(syncedCloseout.receipt));
+  const publishedCloseout = runRawJsonMaybeFail(fixture.repoRoot, ["materializer", "run"], env);
+  assert.equal(publishedCloseout.status, 0, JSON.stringify(publishedCloseout.receipt));
 
   const forceArgs = [
     "task", "code-doc", "reconcile", taskId,
@@ -48,4 +52,37 @@ export async function exerciseIdenticalCodeDocForce(
     /repo_write_outcome_unknown|execution_outcome_unknown|outcome remains unknown/u
   );
   return taskRoot;
+}
+
+export function exerciseUnpublishedCloseoutPositiveControl(input: {
+  readonly fixture: CanonicalFixtureRoots;
+  readonly taskId: string;
+  readonly taskRoot: string;
+  readonly completionPacketPath: string;
+  readonly env: Readonly<Record<string, string>>;
+  readonly diagnostic: (message: string) => void;
+}): void {
+  const closeoutPath = path.join(input.taskRoot, "closeout.md");
+  writeFileSync(
+    closeoutPath,
+    `${readFileSync(closeoutPath, "utf8")}\nUnpublished positive-control amendment.\n`
+  );
+  const unpublishedCompletion = runRawJsonMaybeFail(input.fixture.repoRoot, [
+    "task", "complete", input.taskId, "--approve", "--from-file", input.completionPacketPath
+  ], input.env);
+  assert.notEqual(unpublishedCompletion.status, 0, JSON.stringify(unpublishedCompletion.receipt));
+  assert.equal(unpublishedCompletion.receipt.ok, false, JSON.stringify(unpublishedCompletion.receipt));
+  assert.match(
+    JSON.stringify(unpublishedCompletion.receipt),
+    /AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:.*closeout\.md/u,
+    "positive control: completion must reject a current task document without canonical publication evidence"
+  );
+  input.diagnostic("positive control: prepublish gate rejected the unpublished closeout.md amendment before doc sync");
+
+  const syncedCloseout = runRawJsonMaybeFail(input.fixture.repoRoot, [
+    "doc", "sync", "--submit", "--path", `tasks/${input.taskId}-production-route/closeout.md`
+  ], input.env);
+  assert.equal(syncedCloseout.status, 0, JSON.stringify(syncedCloseout.receipt));
+  const publishedCloseout = runRawJsonMaybeFail(input.fixture.repoRoot, ["materializer", "run"], input.env);
+  assert.equal(publishedCloseout.status, 0, JSON.stringify(publishedCloseout.receipt));
 }


### PR DESCRIPTION
# English

## Summary

`nightly-integration` had been red for at least twelve days — thirteen of its last fifteen runs
failed, the earliest traceable failure was 2026-07-25, and every night it fell over in the same
place. It is not a required check, so pull requests stayed green and merges continued. The
advisory issue the notifier opened (#1231) stayed open and unread.

Two of the three failing tests are fixed here. They were **stale fixtures**, not a product
defect: the fixture hand-seeded task documents with `writeFileSync`, bypassing the canonical
publication road, and completion then correctly refused them with
`AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED` — "no canonical publication changed this
path to its current content". The witness is right; the fixture had been left behind by it.

The third failure is a separate root cause (adapter golden byte drift) and is deliberately left
red here. See "Out of scope".

## What Changed

- `packages/cli/test/helpers/canonical-task-publication-fixture.ts`: add
  `publishSeededTaskFixtureById`, so a fixture task can be seeded through the publication road by id.
- `packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts`: publish the
  two fixture task packages instead of leaving them as raw file writes.
- `packages/cli/test/production-authority-canonical-ingress/code-doc-force-replay.ts`: replace the
  hand-rolled `git add` + `git commit` seeding with `doc sync --submit` + `materializer run`, and
  add `exerciseUnpublishedCloseoutPositiveControl`.

No product code changed. The prepublish witness was not touched.

## Task And Scope

- Harness task: `task_01KZB5KCC7YSJYDX7JKJE215B6`
- Branch: `codex/nightly-red`
- Public scope: three test files under `packages/cli/test`
- Private planning/evidence updated: yes
- Out of scope: `all four production ingress adapters retain canonical envelope and receipt bytes`
  stays red. Its drift predates the change that first looked responsible — the test was already
  failing on 2026-07-26 and 2026-08-04, both before `feat(cli): add success next-step receipts`
  (#1226) landed on 08-05 — so the drift is layered across at least two weeks of changes.
  Re-capturing the golden would bless every one of those layers at once, unexamined. It is tracked
  by `task_01KZB6WN5DCNPCGVFED1JS1TAS`, whose contract is to attribute each layer to a specific
  commit **before** anyone decides whether the baseline moves.

## Version Impact

- Version: no version change because only test fixtures changed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KZB5KCC7YSJYDX7JKJE215B6`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether
  it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: `dec_01KZB8HMV2WFT2C5X7WQP8S0GG` proposes how a non-blocking nightly
  failure should be picked up and escalated. It is a proposal only; nothing in this PR changes a
  workflow, a required check, or branch protection.

## Verification

- Base `origin/main` SHA: `587ffe575104a955a48364c66bb38321636be9a2`
- Branch merge-base with `origin/main`: `587ffe575104a955a48364c66bb38321636be9a2`
- Last `git fetch origin` time: 2026-08-06, before the branch was pushed
- Sync method: rebase
- Public diff command: `git diff 587ffe57...codex/nightly-red`
- Private evidence commit/path: task ledger and artifacts for `task_01KZB5KCC7YSJYDX7JKJE215B6`
- Reviewer evidence path: the same task's review record
- GitHub Actions `rewrite-ci` run URL: see the checks on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` — 27 manifest gates green, affected fast 443/443, affected contract 94/94
- [x] Targeted tests for the change surface, named with their counts:
  - `production generic canonical ingress accepts and journals one write for every directly
    compiled kind` — passed, reproduced independently by the reviewer (139s)
  - `production service route preserves progress dry-run and publishes canonical task writes` —
    passed for the implementer (161s); see the timing note below
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending on this PR
- **The authoritative gate for this change is `nightly-integration`, not `rewrite-ci`.** Both test
  files carry `// harness-test-tier: nightly`, so the integration shards on a pull request never
  execute them: a green `rewrite-ci` proves nothing about this fix. `nightly-integration` was
  therefore dispatched manually against this branch rather than merging and waiting for the
  scheduled run. That structural gap — the tier holding these tests sits on no merge path — is the
  reason a red survived twelve days, and it is what `dec_01KZB8HMV2WFT2C5X7WQP8S0GG` is about.
- Not run, and why: the full `npm run test:nightly` tier was not run locally to completion; the
  third test in it is knowingly red and out of scope.

## Review Evidence

- Self-review: the positive control is the load-bearing part, because "the red went away" is not
  evidence — deleting the seeding would also make it go away. The test now writes an **unpublished**
  amendment to `closeout.md`, runs the real `task complete`, and asserts it **fails** with
  `AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED` naming `closeout.md`, then syncs and
  continues. A weakened witness cannot pass that assertion.
- Reviewer subagent: not used; the reviewer ran the tests directly.
- Human review: the reviewer independently re-ran both tests rather than accepting the
  implementer's summary, and read the diff to confirm the fix seeds through the publication road
  rather than relaxing the witness.
- Blocking findings: none. One premise supplied by the reviewer was **refuted** by the implementer
  and the refutation is the reason this scope is correct: the reviewer believed `closeout.md` and
  `task_plan.md` had already been doc-synced by a sibling helper, which would have meant publication
  evidence was being lost — a product defect. Runtime V8 coverage showed
  `productionCompletionFixtureLoaded:false`: the sibling helper is never loaded by the failing run,
  and the two fixtures share a static task id while using different roots.

## Residual Risk

- **The surviving test is close to its own timeout.** It declares `{ timeout: 240_000 }` and takes
  roughly 161s for the implementer; on the reviewer's machine it exceeded 240s twice and was
  recorded as a timeout rather than an assertion failure — the positive-control diagnostic had
  already printed by then, so the logic ran. Publishing the fixture through the canonical road is
  real work, so this change makes the test slower than the version that has been failing. The
  verdict therefore partly depends on runner load racing a fixed deadline. This is not fixed here,
  because raising a timeout to make something pass is exactly the move this repository forbids; it
  needs its own decision about whether to split the test or re-express its cost.
- The third nightly failure remains red until `task_01KZB6WN5DCNPCGVFED1JS1TAS` completes, so
  `nightly-integration` as a whole will stay red after this merges. Anyone reading the workflow
  status must not treat that as "the fix did not work".

## References

- Task: `task_01KZB5KCC7YSJYDX7JKJE215B6`
- Evidence: that task's `artifacts/` — runtime publication differential, runtime module coverage
  summary, the original CI failure log, and the before/after runner output
- Review: that task's review record

---

# 中文

## 概要

`nightly-integration` 已经红了至少十二天——最近十五次跑红了十三次,最早可追到 2026-07-25,
而且每晚倒在同一个地方。它不是必需检查,所以 PR 照常全绿、照常合并。
通知机制开出的 advisory issue(#1231)一直开着,没人看。

三条失败测试中的两条在本 PR 修复。它们是**陈旧 fixture**,不是产品缺陷:
fixture 用 `writeFileSync` 手工种任务文档,绕过了 canonical publication road,
completion 于是正确地拒绝了它们——
`AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED`,即
"没有任何一次 canonical publication 把这个路径变成现在这个内容"。
**证据门是对的,是 fixture 被它甩在了后面。**

第三条失败是另一个根因(adapter golden 字节漂移),本 PR **刻意留红**,见"范围外"。

## 改动内容

- `packages/cli/test/helpers/canonical-task-publication-fixture.ts`:新增
  `publishSeededTaskFixtureById`,使 fixture 任务可以按 id 走发布路种下去。
- `packages/cli/test/production-authority-canonical-ingress/canonical-ingress.test.ts`:
  两个 fixture 任务包改为发布,而不是裸写文件。
- `packages/cli/test/production-authority-canonical-ingress/code-doc-force-replay.ts`:
  把手搓的 `git add` + `git commit` 种子换成 `doc sync --submit` + `materializer run`,
  并新增 `exerciseUnpublishedCloseoutPositiveControl`。

**无产品代码改动。prepublish 证据门一行未动。**

## 任务与范围

- Harness 任务:`task_01KZB5KCC7YSJYDX7JKJE215B6`
- 分支:`codex/nightly-red`
- 公开范围:`packages/cli/test` 下三个测试文件
- 私有计划 / 证据是否已更新:yes
- 范围外:`all four production ingress adapters retain canonical envelope and receipt bytes`
  保持红。它的漂移**早于**那个一开始看起来该负责的改动——该测试在 2026-07-26 与 08-04 就已经红了,
  而 `feat(cli): add success next-step receipts`(#1226)是 08-05 才落的——
  所以漂移是跨至少两周多个改动**层层累积**的。重新 capture 基线会把每一层未经审视地**一次性全部封进去**。
  该项由 `task_01KZB6WN5DCNPCGVFED1JS1TAS` 承接,其契约是**先**把每一层归因到具体 commit,
  **然后**才谈基线动不动。

## 版本影响

- 版本:不改版本,原因是只改了测试 fixture
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:`task_01KZB5KCC7YSJYDX7JKJE215B6`
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:`dec_01KZB8HMV2WFT2C5X7WQP8S0GG` 提案"每晚都红但不阻挡合并的信号应如何被承接与升级"。
  它**只是提案**;本 PR 不改任何 workflow、必需检查或分支保护。

## 验证

- `origin/main` 基准 SHA:`587ffe575104a955a48364c66bb38321636be9a2`
- 当前分支与 `origin/main` 的 merge-base:`587ffe575104a955a48364c66bb38321636be9a2`
- 最近一次 `git fetch origin` 时间:2026-08-06,推分支之前
- 同步方式:rebase
- 公开 diff 命令:`git diff 587ffe57...codex/nightly-red`
- 私有证据 commit/path:`task_01KZB5KCC7YSJYDX7JKJE215B6` 的任务台账与 artifacts
- Reviewer 证据路径:同一任务的 review 记录
- GitHub Actions `rewrite-ci` run URL:见本 PR 的 checks
- [x] `git diff --check`
- [x] `npm run check:stop-point`——27 个 manifest gate 全绿,affected fast 443/443,affected contract 94/94
- [x] 改动面的定向测试,写明测试名与通过数:
  - `production generic canonical ingress accepts and journals one write for every directly
    compiled kind`——通过,复核者独立复跑确认(139s)
  - `production service route preserves progress dry-run and publishes canonical task writes`——
    实现者侧通过(161s);计时问题见下面的残余风险
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)——本 PR 上待跑
- **本改动的权威门是 `nightly-integration`,不是 `rewrite-ci`。**
  两个测试文件都带 `// harness-test-tier: nightly`,因此 PR 上的 integration shard **从不执行它们**:
  `rewrite-ci` 全绿对本修复**零证明力**。故已用 `workflow_dispatch` 对本分支**手动触发**
  `nightly-integration`,而不是先合并再等当晚的定时跑。
  **那个结构性缺口——承载这两条测试的 tier 不在任何合并路径上——正是一条红能活十二天的原因**,
  也正是 `dec_01KZB8HMV2WFT2C5X7WQP8S0GG` 要处理的事。
- 未跑项及原因:本地未把完整 `npm run test:nightly` tier 跑完;其中第三条测试已知为红且属范围外。

## 审查证据

- 自查:**阳性对照是承重的那一部分**,因为"红消失了"不是证据——把种子删掉同样能让它消失。
  现在测试会写入一个**未发布**的 `closeout.md` 修改,跑真实的 `task complete`,
  断言它**必须失败**且错误里同时出现 `AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED`
  与 `closeout.md`,然后再 sync 并继续。**证据门一旦被削弱,这条断言不可能通过。**
- Reviewer subagent:未使用;复核者直接跑测试。
- 人工审查:复核者未采信实现者摘要,独立复跑两条测试,并读 diff 确认修法是让种子走发布路,
  而不是放宽证据门。
- 阻塞发现:无。复核者提供的一条前提被实现者**证伪**,而这次证伪正是本 PR 范围正确的原因:
  复核者以为 `closeout.md` 与 `task_plan.md` 已被兄弟 helper doc-sync 过——若果真如此,
  那意味着发布证据在丢失,是产品缺陷。运行时 V8 覆盖显示
  `productionCompletionFixtureLoaded:false`:失败运行从未加载那个兄弟 helper,
  两个 fixture 只是共用同一个静态 task id 而 root 不同。

## 残余风险

- **存活的那条测试离它自己的超时很近。**它声明 `{ timeout: 240_000 }`,实现者侧约 161s;
  在复核者机器上两次都超过 240s 并被记为**超时**而非断言失败——
  彼时阳性对照的诊断行已经打印,说明逻辑跑到了。
  让 fixture 走发布路是真花时间的,因此**本改动使这条测试比此前那个一直在红的版本更慢**。
  于是它的判决部分取决于 runner 负载与一个固定 deadline 的赛跑。
  **本 PR 不修它**,因为"为了让某个东西通过而抬高超时"正是本仓明令禁止的动作;
  该问题需要自己的决策:拆分该测试,还是重新表达它的成本。
- 第三条 nightly 失败在 `task_01KZB6WN5DCNPCGVFED1JS1TAS` 完成前保持红,
  因此本 PR 合入后 `nightly-integration` **整体仍是红的**。
  读工作流状态的人**不得**把它当成"修复没生效"。

## 关联材料

- 任务:`task_01KZB5KCC7YSJYDX7JKJE215B6`
- 证据:该任务的 `artifacts/`——运行时 publication 差分、运行时模块覆盖摘要、
  原始 CI 失败日志、以及改前/改后的 runner 输出
- 审查:该任务的 review 记录
