### PR TITLE
fix(daemon): stop test daemon leaks and share socket endpoint policy

### DIFF
--- a/packages/cli/test/daemon-cold-start-launch-spec.test.ts
+++ b/packages/cli/test/daemon-cold-start-launch-spec.test.ts
@@ -1,11 +1,9 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { execFile, execFileSync, spawn, spawnSync } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
-import net from "node:net";
 import path from "node:path";
 import test from "node:test";
-import { promisify } from "node:util";
 import {
   localUserDaemonEndpoint,
   readOrCreateDaemonMachineId,
@@ -28,8 +26,6 @@ import {
 } from "./helpers/daemon-cli.ts";
 import { cliTestEnv } from "./helpers/cli-test-env.ts";
 import { createFixture } from "./production-authority-canonical-ingress/fixture.ts";
-
-const execFileAsync = promisify(execFile);
 
 test("service cold start restores, overrides, and diagnoses the persisted launch spec", { timeout: 90_000 }, async () => {
   const fixture = createFixture();
@@ -437,87 +433,6 @@ test("registry-inferred authority cold start preserves disabled manifest reposit
   } finally {
     await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
     rmSync(fixture.root, { recursive: true, force: true });
-  }
-});
-
-test("occupied daemon socket does not persist a new authority manifest registry pointer", { timeout: 30_000 }, async () => {
-  const fixture = createFixture();
-  const userRoot = defaultDaemonUserRoot(fixture.root);
-  const endpoint = localUserDaemonEndpoint(userRoot);
-  const ownerSockets = new Set<net.Socket>();
-  const owner = net.createServer((socket) => {
-    ownerSockets.add(socket);
-    socket.once("close", () => ownerSockets.delete(socket));
-  });
-  try {
-    mkdirSync(userRoot, { recursive: true });
-    const registryBefore = readDaemonRegistry({ userRoot });
-    await new Promise<void>((resolve, reject) => {
-      owner.once("error", reject);
-      owner.listen(endpoint, () => resolve());
-    });
-    writeFileSync(`${endpoint}.owner`, JSON.stringify({
-      schema: "daemon-socket-owner/v1",
-      pid: process.pid,
-      ownerToken: "occupied-socket-test-owner"
-    }));
-
-    await assert.rejects(execFileAsync(process.execPath, [
-      path.resolve("packages/cli/src/index.ts"),
-      "--root", fixture.repoRoot,
-      "daemon", "serve",
-      "--repo", "canonical",
-      "--socket", endpoint,
-      "--user-root", userRoot,
-      "--authority-manifest", fixture.manifestPath
-    ], {
-      encoding: "utf8",
-      env: cliTestEnv({ HARNESS_DAEMON_USER_ROOT: userRoot }),
-      timeout: 10_000,
-      killSignal: "SIGKILL"
-    }), /already owned/u);
-
-    assert.deepEqual(readDaemonRegistry({ userRoot }), registryBefore);
-  } finally {
-    for (const socket of ownerSockets) socket.destroy();
-    if (owner.listening) await new Promise<void>((resolve) => owner.close(() => resolve()));
-    rmSync(fixture.root, { recursive: true, force: true });
-  }
-});
-
-test("transport bind failure after socket ownership does not persist any registry change", {
-  skip: process.platform === "win32",
-  timeout: 30_000
-}, async () => {
-  const fixture = createFixture();
-  const userRoot = defaultDaemonUserRoot(fixture.root);
-  const endpoint = localUserDaemonEndpoint(userRoot);
-  try {
-    mkdirSync(userRoot, { recursive: true });
-    mkdirSync(endpoint);
-    const registryBefore = readDaemonRegistry({ userRoot });
-
-    await assert.rejects(execFileAsync(process.execPath, [
-      path.resolve("packages/cli/src/index.ts"),
-      "--root", fixture.repoRoot,
-      "daemon", "serve",
-      "--repo", "canonical",
-      "--socket", endpoint,
-      "--user-root", userRoot,
-      "--authority-manifest", fixture.manifestPath
-    ], {
-      encoding: "utf8",
-      env: cliTestEnv({ HARNESS_DAEMON_USER_ROOT: userRoot }),
-      timeout: 10_000,
-      killSignal: "SIGKILL"
-    }), /EISDIR|Path is a directory/u);
-
-    assert.deepEqual(readDaemonRegistry({ userRoot }), registryBefore);
-    assert.equal(existsSync(`${endpoint}.owner`), false);
-  } finally {
-    rmSync(endpoint, { recursive: true, force: true });
-    rmSync(fixture.root, { recursive: true, force: true });
-    assert.equal(existsSync(endpoint), false, `test leaked socket endpoint directory: ${endpoint}`);
   }
 });
 

--- a/packages/cli/test/daemon-cold-start-launch-spec.test.ts
+++ b/packages/cli/test/daemon-cold-start-launch-spec.test.ts
@@ -515,7 +515,9 @@ test("transport bind failure after socket ownership does not persist any registr
     assert.deepEqual(readDaemonRegistry({ userRoot }), registryBefore);
     assert.equal(existsSync(`${endpoint}.owner`), false);
   } finally {
+    rmSync(endpoint, { recursive: true, force: true });
     rmSync(fixture.root, { recursive: true, force: true });
+    assert.equal(existsSync(endpoint), false, `test leaked socket endpoint directory: ${endpoint}`);
   }
 });
 

--- a/packages/cli/test/daemon-command-outcomes.test.ts
+++ b/packages/cli/test/daemon-command-outcomes.test.ts
@@ -8,7 +8,14 @@ import test from "node:test";
 import { promisify } from "node:util";
 import { localUserDaemonEndpoint } from "../../daemon/src/index.ts";
 import { cliTestEnv } from "./helpers/cli-test-env.ts";
-import { defaultDaemonUserRoot, runRawJson, withTempRootAsync } from "./helpers/daemon-cli.ts";
+import {
+  defaultDaemonUserRoot,
+  pollUntil,
+  runDaemonCommand,
+  runRawJson,
+  stopDaemon,
+  withTempRootAsync
+} from "./helpers/daemon-cli.ts";
 import { closeServer, listen } from "./helpers/daemon-transport.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
@@ -104,15 +111,31 @@ test("an unreachable daemon remains unavailable with the direct recovery guidanc
     initializeFixtureWithoutDaemon(rootDir);
     const unreachableUserRoot = path.join(rootDir, "u".repeat(180));
     const daemon = testDaemonLocation(rootDir, unreachableUserRoot);
-    const result = await runCliFailure(rootDir, ["task", "create", "--title", "Unreachable Write"], {
-      ...testDaemonEnv(daemon),
-      HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "40"
-    });
+    let daemonPid: number | undefined;
+    try {
+      const result = await runCliFailure(rootDir, ["task", "create", "--title", "Unreachable Write"], {
+        ...testDaemonEnv(daemon),
+        HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "40"
+      });
 
-    assert.equal(result.error.code, "daemon_unavailable");
-    assert.match(result.error.hint, /Daemon unavailable/iu);
-    assert.match(result.error.hint, /HARNESS_DAEMON_MODE=direct/iu);
-    assert.doesNotMatch(result.error.hint, /outcome is unknown/iu);
+      assert.equal(result.error.code, "daemon_unavailable");
+      assert.match(result.error.hint, /Daemon unavailable/iu);
+      assert.match(result.error.hint, /HARNESS_DAEMON_MODE=direct/iu);
+      assert.doesNotMatch(result.error.hint, /outcome is unknown/iu);
+    } finally {
+      const lateStatus = await pollUntil(
+        () => runDaemonCommand(rootDir, [
+          "daemon", "status", "--user-root", unreachableUserRoot, "--json"
+        ], testDaemonEnv(daemon)),
+        (status) => status.started === true && status.reachable === true,
+        (status, error) => JSON.stringify({ status, error: String(error ?? "") }),
+        { timeoutMs: 15_000 }
+      );
+      daemonPid = typeof lateStatus.pid === "number" ? lateStatus.pid : undefined;
+      await stopDaemon(rootDir, unreachableUserRoot);
+      assert.equal(typeof daemonPid, "number", JSON.stringify(lateStatus));
+    }
+    assert.equal(processIsAlive(daemonPid), false, `test leaked late daemon pid ${String(daemonPid)}`);
   });
 });
 
@@ -224,4 +247,16 @@ async function runCli(
     })
   });
   return JSON.parse(stdout) as { readonly ok: boolean; readonly command: string };
+}
+
+function processIsAlive(pid: number | undefined): boolean {
+  if (pid === undefined) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error
+      && (error as { readonly code?: unknown }).code === "ESRCH") return false;
+    throw error;
+  }
 }

--- a/packages/cli/test/daemon-socket-namespace-cli.test.ts
+++ b/packages/cli/test/daemon-socket-namespace-cli.test.ts
@@ -1,0 +1,117 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+import { localUserDaemonEndpoint } from "../../daemon/src/index.ts";
+import { readDaemonRegistry } from "../../kernel/src/index.ts";
+import { defaultDaemonUserRoot } from "./helpers/daemon-cli.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
+import { createFixture } from "./production-authority-canonical-ingress/fixture.ts";
+
+const execFileAsync = promisify(execFile);
+
+test("occupied daemon socket does not persist a new authority manifest registry pointer", { timeout: 30_000 }, async () => {
+  const fixture = createFixture();
+  const userRoot = defaultDaemonUserRoot(fixture.root);
+  const endpoint = localUserDaemonEndpoint(userRoot);
+  const ownerSockets = new Set<net.Socket>();
+  const owner = net.createServer((socket) => {
+    ownerSockets.add(socket);
+    socket.once("close", () => ownerSockets.delete(socket));
+  });
+  try {
+    mkdirSync(userRoot, { recursive: true });
+    const registryBefore = readDaemonRegistry({ userRoot });
+    await new Promise<void>((resolve, reject) => {
+      owner.once("error", reject);
+      owner.listen(endpoint, () => resolve());
+    });
+    writeFileSync(`${endpoint}.owner`, JSON.stringify({
+      schema: "daemon-socket-owner/v1",
+      pid: process.pid,
+      ownerToken: "occupied-socket-test-owner"
+    }));
+
+    await assert.rejects(execFileAsync(process.execPath, [
+      path.resolve("packages/cli/src/index.ts"),
+      "--root", fixture.repoRoot,
+      "daemon", "serve",
+      "--repo", "canonical",
+      "--socket", endpoint,
+      "--user-root", userRoot,
+      "--authority-manifest", fixture.manifestPath
+    ], {
+      encoding: "utf8",
+      env: cliTestEnv({ HARNESS_DAEMON_USER_ROOT: userRoot }),
+      timeout: 10_000,
+      killSignal: "SIGKILL"
+    }), /already owned/u);
+
+    assert.deepEqual(readDaemonRegistry({ userRoot }), registryBefore);
+  } finally {
+    for (const socket of ownerSockets) socket.destroy();
+    if (owner.listening) await new Promise<void>((resolve) => owner.close(() => resolve()));
+    rmSync(`${endpoint}.owner`, { force: true });
+    rmSync(fixture.root, { recursive: true, force: true });
+    assertDaemonSocketNamespaceEmpty(endpoint);
+  }
+});
+
+test("transport bind failure uses the shared namespace diagnosis without persisting registry change", {
+  skip: process.platform === "win32",
+  timeout: 30_000
+}, async () => {
+  const fixture = createFixture();
+  const userRoot = defaultDaemonUserRoot(fixture.root);
+  const endpoint = localUserDaemonEndpoint(userRoot);
+  try {
+    mkdirSync(userRoot, { recursive: true });
+    mkdirSync(endpoint);
+    const registryBefore = readDaemonRegistry({ userRoot });
+
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        path.resolve("packages/cli/src/index.ts"),
+        "--root", fixture.repoRoot,
+        "daemon", "serve",
+        "--repo", "canonical",
+        "--socket", endpoint,
+        "--user-root", userRoot,
+        "--authority-manifest", fixture.manifestPath
+      ], {
+        encoding: "utf8",
+        env: cliTestEnv({ HARNESS_DAEMON_USER_ROOT: userRoot }),
+        timeout: 10_000,
+        killSignal: "SIGKILL"
+      }),
+      new RegExp(
+        `DAEMON_SOCKET_NAMESPACE_INVALID:path=${escapeRegExp(endpoint)};shape=directory;owner=live-pid-[0-9]+;cleanup=not-attempted;connectCode=(?:ERR_FS_EISDIR|EISDIR)`,
+        "u"
+      )
+    );
+
+    assert.deepEqual(readDaemonRegistry({ userRoot }), registryBefore);
+    assert.equal(existsSync(`${endpoint}.owner`), false);
+  } finally {
+    rmSync(endpoint, { recursive: true, force: true });
+    rmSync(fixture.root, { recursive: true, force: true });
+    assertDaemonSocketNamespaceEmpty(endpoint);
+  }
+});
+
+function assertDaemonSocketNamespaceEmpty(endpoint: string): void {
+  const directory = path.dirname(endpoint);
+  const basename = path.basename(endpoint);
+  const entries = readdirSync(directory)
+    .filter((entry) => entry === basename || entry.startsWith(`${basename}.`))
+    .sort();
+  assert.deepEqual(entries, [], `test leaked daemon socket namespace entries for ${endpoint}: ${JSON.stringify(entries)}`);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -20,7 +20,7 @@ import {
   type DaemonLaunchConfiguration
 } from "./daemon-launch-configuration.ts";
 import { DaemonRepoRootResolutionError } from "./daemon-repo-root-resolution-error.ts";
-import { daemonSocketConnectError } from "./daemon-socket-namespace.ts";
+import { daemonSocketNamespaceError } from "../transport/daemon-socket-namespace.ts";
 import {
   DaemonJsonRpcRequestTimeoutError,
   DaemonJsonRpcResponseError,
@@ -537,11 +537,11 @@ async function connectUnixSocketWithLegacyFallback(socketPath: string, legacySoc
   try {
     return await connectUnixSocket(socketPath, timeoutMs);
   } catch (error) {
-    if (!legacySocketPath || legacySocketPath === socketPath) throw daemonSocketConnectError(socketPath, error);
+    if (!legacySocketPath || legacySocketPath === socketPath) throw daemonSocketNamespaceError(socketPath, error);
     try {
       return await connectUnixSocket(legacySocketPath, timeoutMs);
     } catch (legacyError) {
-      throw daemonSocketConnectError(legacySocketPath, legacyError);
+      throw daemonSocketNamespaceError(legacySocketPath, legacyError);
     }
   }
 }

--- a/packages/daemon/src/transport/daemon-socket-namespace.ts
+++ b/packages/daemon/src/transport/daemon-socket-namespace.ts
@@ -1,6 +1,6 @@
 import { existsSync, lstatSync, readFileSync, rmdirSync } from "node:fs";
 
-export function daemonSocketConnectError(socketPath: string, cause: unknown): unknown {
+export function daemonSocketNamespaceError(socketPath: string, cause: unknown): unknown {
   const shape = daemonSocketPathShape(socketPath);
   if (shape !== "directory" && socketErrorCode(cause) !== "EINVAL") return cause;
   const ownership = daemonSocketDirectoryOwnership(socketPath);

--- a/packages/daemon/src/transport/unix-socket.ts
+++ b/packages/daemon/src/transport/unix-socket.ts
@@ -18,6 +18,7 @@ import type {
 import { serveJsonRpcStream, type DaemonTransportConnection } from "./json-rpc-stream.ts";
 import { createNodeSocketAcceptedConnectionEvidenceAdapter } from "./node-socket-peer-credential.ts";
 import { gracefullyCloseSocketServer } from "./graceful-socket-shutdown.ts";
+import { daemonSocketNamespaceError } from "./daemon-socket-namespace.ts";
 import {
   authenticateSshAuthorityWireFrame,
   authenticateSshForcedCommandFrame,
@@ -206,7 +207,7 @@ export function createUnixSocketTransportServer(options: UnixSocketTransportOpti
     endpoint,
     start: async () => {
       ensurePrivateUnixSocketDirectory(path.dirname(endpoint));
-      rmSync(endpoint, { force: true });
+      removeStaleUnixSocketEndpoint(endpoint);
       await new Promise<void>((resolve, reject) => {
         server.once("error", reject);
         server.listen(endpoint, () => {
@@ -228,7 +229,7 @@ export function createUnixSocketTransportServer(options: UnixSocketTransportOpti
     },
     stop: async () => {
       await gracefullyCloseSocketServer(server, sockets);
-      rmSync(endpoint, { force: true });
+      removeStaleUnixSocketEndpoint(endpoint);
     }
   };
 }
@@ -404,6 +405,14 @@ function safeUnixSocketEndpointId(value: string): string {
 function readNonEmptyPath(value: string | undefined, pathApi: path.PlatformPath = path): string | undefined {
   const trimmed = value?.trim();
   return trimmed ? pathApi.resolve(trimmed) : undefined;
+}
+
+function removeStaleUnixSocketEndpoint(endpoint: string): void {
+  try {
+    rmSync(endpoint, { force: true });
+  } catch (error) {
+    throw daemonSocketNamespaceError(endpoint, error);
+  }
 }
 
 function privateDirectoryError(

--- a/packages/daemon/test/transport-stop-integration.test.ts
+++ b/packages/daemon/test/transport-stop-integration.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { mkdtempSync } from "node:fs";
+import { lstatSync, mkdtempSync, mkdirSync, rmSync } from "node:fs";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -43,6 +43,37 @@ test("unix socket transport stop closes an accepted idle connection without wait
   await clientClosed;
   assert.equal(settled, true);
   assert.equal(socket.destroyed, true);
+});
+
+test("unix socket transport stop applies the shared namespace cleanup to an endpoint directory", async (t) => {
+  if (process.platform === "win32") return;
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-unix-stop-directory-"));
+  const socketPath = path.join(tempDir, "daemon.sock");
+  const transport = createUnixSocketTransportServer({
+    daemonId: "daemon-stop-test",
+    socketPath,
+    createProtocolServer
+  });
+  t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+  await transport.start();
+  rmSync(socketPath, { force: true });
+  mkdirSync(socketPath);
+
+  await assert.rejects(
+    transport.stop(),
+    (error: unknown) => {
+      const message = String(error);
+      assert.match(message, /^Error: DAEMON_SOCKET_NAMESPACE_INVALID:/u);
+      assert.equal(
+        message.includes(`path=${socketPath};shape=directory;owner=unowned;cleanup=removed-empty-directory;`),
+        true,
+        message
+      );
+      assert.match(message, /connectCode=(?:ERR_FS_EISDIR|EISDIR)$/u);
+      return true;
+    }
+  );
+  assert.equal(lstatSync(socketPath, { throwIfNoEntry: false }), undefined);
 });
 
 test("unix socket transport stop flushes a buffered receipt before closing", async () => {

--- a/packages/daemon/test/unix-socket-endpoint.test.ts
+++ b/packages/daemon/test/unix-socket-endpoint.test.ts
@@ -1,0 +1,137 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { lstatSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  createUnixSocketTransportServer,
+  type JsonRpcProtocolServer
+} from "../src/index.ts";
+
+const createProtocolServer = (): JsonRpcProtocolServer => ({
+  handle: async () => undefined
+});
+
+test("unix socket transport removes an unowned empty endpoint directory with the shared namespace diagnosis", async (t) => {
+  if (process.platform === "win32") return;
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-endpoint-directory-"));
+  const socketPath = path.join(tempDir, "daemon.sock");
+  mkdirSync(socketPath);
+  t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+  const transport = createUnixSocketTransportServer({
+    daemonId: "daemon-test",
+    socketPath,
+    createProtocolServer
+  });
+
+  await assert.rejects(
+    transport.start(),
+    (error: unknown) => {
+      const message = String(error);
+      assert.match(message, /^Error: DAEMON_SOCKET_NAMESPACE_INVALID:/u);
+      assert.equal(
+        message.includes(`path=${socketPath};shape=directory;owner=unowned;cleanup=removed-empty-directory;`),
+        true,
+        message
+      );
+      assert.match(message, /connectCode=(?:ERR_FS_EISDIR|EISDIR)$/u);
+      return true;
+    }
+  );
+  assert.equal(lstatSync(socketPath, { throwIfNoEntry: false }), undefined);
+});
+
+test("unix socket transport preserves an endpoint directory with a live owner", async (t) => {
+  if (process.platform === "win32") return;
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-owned-endpoint-directory-"));
+  const socketPath = path.join(tempDir, "daemon.sock");
+  mkdirSync(socketPath);
+  writeFileSync(`${socketPath}.owner`, JSON.stringify({
+    schema: "daemon-socket-owner/v1",
+    pid: process.pid,
+    ownerToken: "live-owner-test"
+  }));
+  t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+  const transport = createUnixSocketTransportServer({
+    daemonId: "daemon-test",
+    socketPath,
+    createProtocolServer
+  });
+
+  await assert.rejects(
+    transport.start(),
+    (error: unknown) => {
+      const message = String(error);
+      assert.match(message, /^Error: DAEMON_SOCKET_NAMESPACE_INVALID:/u);
+      assert.equal(
+        message.includes(`path=${socketPath};shape=directory;owner=live-pid-${process.pid};cleanup=not-attempted;`),
+        true,
+        message
+      );
+      assert.match(message, /connectCode=(?:ERR_FS_EISDIR|EISDIR)$/u);
+      return true;
+    }
+  );
+  assert.equal(lstatSync(socketPath).isDirectory(), true);
+});
+
+test("unix socket transport preserves an unowned non-empty endpoint directory", async (t) => {
+  if (process.platform === "win32") return;
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-non-empty-endpoint-directory-"));
+  const socketPath = path.join(tempDir, "daemon.sock");
+  const occupant = path.join(socketPath, "unowned-content.txt");
+  mkdirSync(socketPath);
+  writeFileSync(occupant, "preserve me\n", "utf8");
+  t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+  const transport = createUnixSocketTransportServer({
+    daemonId: "daemon-test",
+    socketPath,
+    createProtocolServer
+  });
+
+  await assert.rejects(
+    transport.start(),
+    (error: unknown) => {
+      const message = String(error);
+      assert.match(message, /^Error: DAEMON_SOCKET_NAMESPACE_INVALID:/u);
+      assert.equal(
+        message.includes(`path=${socketPath};shape=directory;owner=unowned;cleanup=preserved-non-empty-directory;`),
+        true,
+        message
+      );
+      assert.match(message, /connectCode=(?:ERR_FS_EISDIR|EISDIR)$/u);
+      return true;
+    }
+  );
+  assert.equal(lstatSync(occupant).isFile(), true);
+});
+
+test("unix socket transport replaces a stale socket and listens on the same endpoint", async (t) => {
+  if (process.platform === "win32") return;
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "ha-daemon-stale-socket-"));
+  const socketPath = path.join(tempDir, "daemon.sock");
+  const staleOwner = spawnSync(process.execPath, [
+    "-e",
+    "const net = require('node:net'); net.createServer().listen(process.argv[1], () => process.kill(process.pid, 'SIGKILL'));",
+    socketPath
+  ], { encoding: "utf8" });
+  assert.equal(staleOwner.signal, "SIGKILL", staleOwner.stderr);
+  assert.equal(lstatSync(socketPath).isSocket(), true);
+
+  const transport = createUnixSocketTransportServer({
+    daemonId: "daemon-test",
+    socketPath,
+    createProtocolServer
+  });
+  let started = false;
+  t.after(async () => {
+    if (started) await transport.stop();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  await transport.start();
+  started = true;
+  assert.equal(lstatSync(socketPath).isSocket(), true);
+});

--- a/scripts/quickstart-demo.mjs
+++ b/scripts/quickstart-demo.mjs
@@ -101,7 +101,6 @@ try {
       gitAuthorEmail: demoAttribution.gitAuthorEmail
     }
   }, null, 2));
-  if (options.cleanup) rmSync(workspace, { recursive: true, force: true });
 } catch (error) {
   console.error(JSON.stringify({
     ok: false,
@@ -111,6 +110,20 @@ try {
     error: error instanceof Error ? error.message : String(error)
   }, null, 2));
   process.exitCode = 1;
+} finally {
+  try {
+    runCli(["daemon", "stop", "--timeout-ms", "5000"]);
+  } catch (error) {
+    console.error(JSON.stringify({
+      ok: false,
+      schema: "quickstart-demo/v1",
+      step: "daemon stop",
+      workspace,
+      error: error instanceof Error ? error.message : String(error)
+    }, null, 2));
+    process.exitCode = 1;
+  }
+  if (options.cleanup) rmSync(workspace, { recursive: true, force: true });
 }
 
 function runCli(args) {

--- a/tools/quickstart-demo.test.mjs
+++ b/tools/quickstart-demo.test.mjs
@@ -24,6 +24,7 @@ test("quickstart demo runs init to task to fact to graph with the source CLI", (
     assert.match(result.taskId, /^task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u);
     assert.match(result.factRef, /^fact\/task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}\/F-[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{8}$/u);
     assert.equal(result.graphPath.endsWith(".harness/generated/graph-panorama/quickstart.html"), true);
+    assertIsolatedDaemonStopped(rootDir);
   });
 });
 
@@ -40,6 +41,7 @@ test("quickstart demo fails closed when a middle step is deliberately broken", (
     assert.equal(failure.ok, false);
     assert.equal(failure.step, "fact record");
     assert.match(failure.error, /fact record .*exited non-zero/u);
+    assertIsolatedDaemonStopped(rootDir);
   });
 });
 
@@ -50,6 +52,26 @@ function withTempRoot(fn) {
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }
+}
+
+function assertIsolatedDaemonStopped(rootDir) {
+  const status = JSON.parse(execFileSync(process.execPath, [
+    cliEntry,
+    "--root", rootDir,
+    "--json",
+    "--daemon-profile", "isolated",
+    "daemon", "status"
+  ], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      HARNESS_DAEMON_PROFILE: "isolated"
+    }
+  }));
+  assert.equal(status.started, false, JSON.stringify(status));
+  assert.equal(status.reachable, false, JSON.stringify(status));
+  assert.notEqual(typeof status.pid, "number", JSON.stringify(status));
 }
 
 function parseLastJsonObject(output) {


### PR DESCRIPTION
## Summary

Integration tests leaked daemon processes and socket-namespace entries into the shared runtime directory, and a directory occupying a socket endpoint made the daemon fail to start with a raw `ERR_FS_EISDIR`. Tests now release every resource they create, and both the client and the server route socket-endpoint conflicts through one shared namespace policy.

## What Changed

- `scripts/quickstart-demo.mjs` and `tools/quickstart-demo.test.mjs`: the demo stops the daemon it starts in its own isolated profile, so a run without `--root` no longer leaves a resident daemon behind.
- `packages/cli/test/daemon-command-outcomes.test.ts`: the custom long-`userRoot` case waits for its late autostart and stops it. The shared `withTempRootAsync` teardown only targets `defaultDaemonUserRoot(rootDir)`, so this path was uncovered.
- `packages/daemon/src/transport/unix-socket.ts`: both the start and the stop path inspect the endpoint before removing a stale entry. A directory no longer surfaces as a raw `ERR_FS_EISDIR`.
- `packages/daemon/src/client/daemon-socket-namespace.ts` → `packages/daemon/src/transport/daemon-socket-namespace.ts`: the pre-existing namespace policy moved unchanged and became the single source for both sides. Client connect failures and server `rm` failures now call the same formatter, so `DAEMON_SOCKET_NAMESPACE_INVALID` has exactly one producer in production source.
- `packages/cli/test/daemon-socket-namespace-cli.test.ts` (new): the `occupied-socket-test-owner` fixtures moved here with exact `.owner` teardown, and the leak assertion enumerates the whole endpoint namespace — socket, directory, `.owner`, `.stale.*` — rather than directories alone.

Existing policy is unchanged and now applies on both sides: unowned empty directory → removed; live `.owner` record → preserved, `cleanup=not-attempted`; unowned non-empty directory → preserved; stale socket inode → removed and listen succeeds.

## Version Impact

No public API or CLI surface change. `daemon-socket-namespace.ts` moved between internal modules; its exported behaviour is unchanged.

## Verification

`npm run check:local` on Node v24.18.0, exit 0 — fast 961/961, contract 496 pass + 1 skip, 27 local manifest gates green.

Targeted: 26 pass / 2 Windows-only skip, plus `daemon-cold-start-launch-spec.test.ts` 9/9.

Mutation evidence, real runner output:

```text
# teardown removed — quickstart
actual started:true, leaked pid 24850
actual started:true, leaked pid 29900

# teardown removed — custom long userRoot
AssertionError: test leaked late daemon pid 48261

# teardown removed — socket namespace
AssertionError: test leaked daemon socket namespace entries for
/tmp/harness-anything-501/daemon-501-u-77944a438e889294.sock:
["daemon-501-u-77944a438e889294.sock.owner"]

# shared namespace wrapping removed — server start and stop
SystemError [ERR_FS_EISDIR]: Path is a directory: rm returned EISDIR
tests 2 / pass 0 / fail 2
```

Negative controls: a subprocess creates a real Unix socket inode and is `SIGKILL`ed; a new transport cleans it up and listens on the same endpoint. Zero test-created daemon processes and zero `occupied-socket-test-owner` entries remain after the run. Production daemon PID 27243 stayed alive with an unchanged command line throughout.

Note: the new endpoint tests are `harness-test-tier: integration`, which `check:local` does not run. They were executed directly, with output above; CI is the authority for that tier.

## Review Evidence

Adversarial review by the implementing worker against the CEO-supplied coordinates produced two upheld objections:

1. The task originally required "two distinct repo identities must not resolve to the same socket". That contradicts the design: `daemonIdForUserRoot` hashes `resolve(userRoot) + "\0" + daemonId` and deliberately excludes `repoId`, and `daemon-multi-repo-lifecycle-cli.test.ts` already asserts two registered repos share one user-level daemon with isolated routing. The requirement was withdrawn and the invariant recorded in `dec_01KZBWT8QVS5GJAKACN6ENEXN6`. No topology, socket-naming, or discovery-protocol code was changed.
2. A first attempt at the server-side fix introduced a second, prose-worded error type alongside the existing structured diagnostic. It was withdrawn and replaced by reuse of the shared policy.

## Residual Risk

`spawn(..., { stdio: "ignore" })` still discards the autostart daemon's stderr, and `DaemonAutostartTimeoutError` still reports `may still be starting` for a process that has already exited. The autostart retry loop and the readiness probe use the bare `connectUnixSocket`, so they do not emit the shared diagnostic that `connectUnixSocketWithLegacyFallback` produces. A daemon that fails to start therefore still reaches the caller as a connect timeout. Tracked in `task_01KZBXMKNJ3PJDKQFE4FGR79JC`, deliberately out of scope here.

## References

- `task_01KZBQKEE95BJN6J3F96408G93`
- `dec_01KZBWT8QVS5GJAKACN6ENEXN6`
- Follow-up: `task_01KZBXMKNJ3PJDKQFE4FGR79JC`

---

## 摘要

集成测试会把 daemon 进程和 socket 命名空间条目泄漏到共享运行目录里;而当一个目录占住 socket endpoint 时,daemon 启动会抛出裸的 `ERR_FS_EISDIR`。现在测试会释放自己创建的每一样资源,客户端与服务端也共用同一套 socket endpoint 冲突处理政策。

## 改动内容

- `scripts/quickstart-demo.mjs` 与 `tools/quickstart-demo.test.mjs`:demo 会关掉自己在隔离 profile 里起的 daemon,不带 `--root` 跑一次不再留下常驻进程。
- `packages/cli/test/daemon-command-outcomes.test.ts`:自定义长 `userRoot` 用例会等待并关掉它那个晚启动的 daemon。共享的 `withTempRootAsync` teardown 只针对 `defaultDaemonUserRoot(rootDir)`,盖不到这条路径。
- `packages/daemon/src/transport/unix-socket.ts`:启动与停机两侧在清理陈旧条目前先检查 endpoint,目录不再以裸 `ERR_FS_EISDIR` 的形式冒出。
- `packages/daemon/src/client/daemon-socket-namespace.ts` → `packages/daemon/src/transport/daemon-socket-namespace.ts`:既有的命名空间政策原样移动,成为两侧唯一来源。客户端连接失败与服务端 `rm` 失败现在调同一个 formatter,生产源码里 `DAEMON_SOCKET_NAMESPACE_INVALID` 只剩一个产出点。
- `packages/cli/test/daemon-socket-namespace-cli.test.ts`(新增):`occupied-socket-test-owner` 相关 fixture 迁到这里并补上精确的 `.owner` teardown;泄漏断言改为枚举整个 endpoint 命名空间——socket、目录、`.owner`、`.stale.*`——而不再只看目录。

既有政策未变,现在两侧一致:无主空目录 → 删除;有活 `.owner` 记录 → 保留,`cleanup=not-attempted`;无主非空目录 → 保留;陈旧 socket inode → 删除并成功 listen。

## 版本影响

无公开 API 或 CLI 面变更。`daemon-socket-namespace.ts` 在内部模块间移动,导出行为不变。

## 验证

Node v24.18.0 上 `npm run check:local` 退出 0 —— fast 961/961,contract 496 通过 + 1 跳过,27 个本地 manifest 门全绿。

定向测试:26 通过 / 2 个 Windows-only 跳过,外加 `daemon-cold-start-launch-spec.test.ts` 9/9。

Mutation 证据(runner 真实输出见英文段)。阴性对照:子进程创建真实 Unix socket inode 后被 `SIGKILL`,新 transport 清理成功并在同一 endpoint 上 listen。跑完后测试创建的 daemon 进程数为 0,`occupied-socket-test-owner` 残留为 0。生产 daemon PID 27243 全程存活且命令行未变。

注意:新增的 endpoint 测试是 `harness-test-tier: integration`,`check:local` 不跑该层。它们已单独执行并贴出输出;该层以 CI 为权威。

## 评审证据

实现者针对 CEO 给出的坐标做了对抗式复核,两条异议成立:

1. 任务原本要求「两个不同 repo 身份不得解析到同一 socket」。这与设计相反:`daemonIdForUserRoot` 对 `resolve(userRoot) + "\0" + daemonId` 取哈希,**刻意不含** `repoId`,且 `daemon-multi-repo-lifecycle-cli.test.ts` 已断言两个已注册仓库共用一个 user-level daemon 且路由隔离。该要求已撤销,不变量记入 `dec_01KZBWT8QVS5GJAKACN6ENEXN6`。未改动任何拓扑、socket 命名或发现协议代码。
2. 服务端修复的第一版在既有结构化诊断之外另造了一套散文措辞的错误类型。已撤销,改为复用共享政策。

## 残留风险

`spawn(..., { stdio: "ignore" })` 仍然丢弃 autostart daemon 的 stderr,`DaemonAutostartTimeoutError` 仍对已退出的进程报 `may still be starting`。autostart 重试循环与 readiness 探测用的是裸 `connectUnixSocket`,不产出 `connectUnixSocketWithLegacyFallback` 那套共享诊断。因此 daemon 启动失败对调用方**仍然**表现为连接超时。已由 `task_01KZBXMKNJ3PJDKQFE4FGR79JC` 跟踪,本 PR 有意不含该修复。

## 参考

- `task_01KZBQKEE95BJN6J3F96408G93`
- `dec_01KZBWT8QVS5GJAKACN6ENEXN6`
- 后续:`task_01KZBXMKNJ3PJDKQFE4FGR79JC`
