### PR TITLE
fix(daemon): surface autostart failures to the caller

### DIFF
--- a/packages/cli/test/daemon-autostart-startup-diagnostics.test.ts
+++ b/packages/cli/test/daemon-autostart-startup-diagnostics.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { localUserDaemonEndpoint } from "../../daemon/src/index.ts";
@@ -11,13 +11,14 @@ test("autostart reports the daemon child's real startup failure", { timeout: 30_
   if (process.platform === "win32") return;
   const fixture = createFixture();
   const userRoot = path.join(fixture.root, "autostart-failure-user");
-  const daemon = testDaemonLocation(fixture.root, userRoot);
+  const daemon = testDaemonLocation(userRoot);
   const endpoint = daemon.socketPath;
   mkdirSync(endpoint, { recursive: true });
   writeFileSync(path.join(endpoint, "blocker"), "keep the occupied endpoint non-empty\n", "utf8");
   t.after(() => {
     rmSync(endpoint, { recursive: true, force: true });
     rmSync(fixture.root, { recursive: true, force: true });
+    rmSync(daemon.runtimeRoot, { recursive: true, force: true });
   });
 
   const failed = runRawJsonMaybeFail(fixture.repoRoot, ["task", "list"], daemon.env);
@@ -34,13 +35,14 @@ test("autostart does not describe an exited daemon process as still starting", {
   if (process.platform === "win32") return;
   const fixture = createFixture();
   const userRoot = path.join(fixture.root, "autostart-exited-user");
-  const daemon = testDaemonLocation(fixture.root, userRoot);
+  const daemon = testDaemonLocation(userRoot);
   const endpoint = daemon.socketPath;
   mkdirSync(endpoint, { recursive: true });
   writeFileSync(path.join(endpoint, "blocker"), "keep the occupied endpoint non-empty\n", "utf8");
   t.after(() => {
     rmSync(endpoint, { recursive: true, force: true });
     rmSync(fixture.root, { recursive: true, force: true });
+    rmSync(daemon.runtimeRoot, { recursive: true, force: true });
   });
 
   const failed = runRawJsonMaybeFail(fixture.repoRoot, ["task", "list"], daemon.env);
@@ -58,7 +60,7 @@ test("autostart does not describe an exited daemon process as still starting", {
 test("autostart keeps waiting while a live daemon is slowly starting", { timeout: 45_000 }, async (t) => {
   const fixture = createFixture();
   const userRoot = path.join(fixture.root, "slow-autostart-user");
-  const daemon = testDaemonLocation(fixture.root, userRoot);
+  const daemon = testDaemonLocation(userRoot);
   const preloadPath = path.join(fixture.root, "slow-autostart-preload.mjs");
   const startupDelayMs = 1_200;
   writeFileSync(preloadPath, [
@@ -70,6 +72,7 @@ test("autostart keeps waiting while a live daemon is slowly starting", { timeout
   t.after(async () => {
     await stopDaemon(fixture.repoRoot, userRoot, daemon.runtimeEnv).catch(() => undefined);
     rmSync(fixture.root, { recursive: true, force: true });
+    rmSync(daemon.runtimeRoot, { recursive: true, force: true });
   });
 
   const startedAt = Date.now();
@@ -86,10 +89,11 @@ test("autostart keeps waiting while a live daemon is slowly starting", { timeout
 test("an autostarted daemon stays alive after its calling CLI exits", { timeout: 45_000 }, async (t) => {
   const fixture = createFixture();
   const userRoot = path.join(fixture.root, "detached-autostart-user");
-  const daemon = testDaemonLocation(fixture.root, userRoot);
+  const daemon = testDaemonLocation(userRoot);
   t.after(async () => {
     await stopDaemon(fixture.repoRoot, userRoot, daemon.runtimeEnv).catch(() => undefined);
     rmSync(fixture.root, { recursive: true, force: true });
+    rmSync(daemon.runtimeRoot, { recursive: true, force: true });
   });
 
   const launched = runRawJsonMaybeFail(fixture.repoRoot, ["task", "list"], daemon.env);
@@ -109,12 +113,18 @@ test("an autostarted daemon stays alive after its calling CLI exits", { timeout:
 
 interface TestDaemonLocation {
   readonly socketPath: string;
+  readonly runtimeRoot: string;
   readonly runtimeEnv: Readonly<Record<string, string>>;
   readonly env: Readonly<Record<string, string>>;
 }
 
-function testDaemonLocation(rootDir: string, userRoot: string): TestDaemonLocation {
-  const runtimeDir = path.join(rootDir, ".daemon-runtime");
+function testDaemonLocation(userRoot: string): TestDaemonLocation {
+  // The runtime root must NOT live under the fixture root: that path is deep
+  // enough that the socket beneath it exceeds the AF_UNIX sun_path limit
+  // (108 bytes on Linux, 104 on macOS) and the daemon dies with
+  // `listen EINVAL` before any behaviour under test is reached.
+  const runtimeDir = mkdtempSync("/tmp/ha-run-");
+  chmodSync(runtimeDir, 0o700);
   const runtimeEnv = {
     XDG_RUNTIME_DIR: runtimeDir,
     TMPDIR: runtimeDir
@@ -122,9 +132,14 @@ function testDaemonLocation(rootDir: string, userRoot: string): TestDaemonLocati
   const socketPath = localUserDaemonEndpoint(userRoot, "default", process.platform, {
     env: runtimeEnv
   });
+  assert.ok(
+    socketPath.length < 100,
+    `test socket path is ${socketPath.length} bytes, over the AF_UNIX sun_path budget: ${socketPath}`
+  );
   mkdirSync(path.dirname(socketPath), { recursive: true, mode: 0o700 });
   return {
     socketPath,
+    runtimeRoot: runtimeDir,
     runtimeEnv,
     env: daemonEnv(userRoot, runtimeEnv)
   };

--- a/packages/cli/test/daemon-autostart-startup-diagnostics.test.ts
+++ b/packages/cli/test/daemon-autostart-startup-diagnostics.test.ts
@@ -1,0 +1,114 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { localUserDaemonEndpoint } from "../../daemon/src/index.ts";
+import { createFixture } from "./production-authority-canonical-ingress/fixture.ts";
+import { delay, runRawJsonMaybeFail, stopDaemon } from "./helpers/daemon-cli.ts";
+
+test("autostart reports the daemon child's real startup failure", { timeout: 30_000 }, (t) => {
+  if (process.platform === "win32") return;
+  const fixture = createFixture();
+  const userRoot = path.join(fixture.root, "autostart-failure-user");
+  const endpoint = localUserDaemonEndpoint(userRoot);
+  mkdirSync(endpoint, { recursive: true });
+  writeFileSync(path.join(endpoint, "blocker"), "keep the occupied endpoint non-empty\n", "utf8");
+  t.after(() => {
+    rmSync(endpoint, { recursive: true, force: true });
+    rmSync(fixture.root, { recursive: true, force: true });
+  });
+
+  const failed = runRawJsonMaybeFail(fixture.repoRoot, ["task", "list"], daemonEnv(userRoot));
+
+  assert.notEqual(failed.status, 0, JSON.stringify(failed.receipt));
+  const error = failed.receipt.error as { readonly hint?: string };
+  assert.match(error.hint ?? "", new RegExp(
+    `DAEMON_SOCKET_NAMESPACE_INVALID:path=${escapeRegExp(endpoint)};.*connectCode=ERR_FS_EISDIR`,
+    "u"
+  ));
+});
+
+test("autostart does not describe an exited daemon process as still starting", { timeout: 30_000 }, (t) => {
+  if (process.platform === "win32") return;
+  const fixture = createFixture();
+  const userRoot = path.join(fixture.root, "autostart-exited-user");
+  const endpoint = localUserDaemonEndpoint(userRoot);
+  mkdirSync(endpoint, { recursive: true });
+  writeFileSync(path.join(endpoint, "blocker"), "keep the occupied endpoint non-empty\n", "utf8");
+  t.after(() => {
+    rmSync(endpoint, { recursive: true, force: true });
+    rmSync(fixture.root, { recursive: true, force: true });
+  });
+
+  const failed = runRawJsonMaybeFail(fixture.repoRoot, ["task", "list"], daemonEnv(userRoot));
+
+  assert.notEqual(failed.status, 0, JSON.stringify(failed.receipt));
+  const error = failed.receipt.error as { readonly hint?: string };
+  assert.match(error.hint ?? "", /DAEMON_AUTOSTART_PROCESS_EXITED:.*exited before readiness/u);
+  assert.doesNotMatch(error.hint ?? "", /may still be starting/u);
+});
+
+test("autostart keeps waiting while a live daemon is slowly starting", { timeout: 45_000 }, async (t) => {
+  const fixture = createFixture();
+  const userRoot = path.join(fixture.root, "slow-autostart-user");
+  const preloadPath = path.join(fixture.root, "slow-autostart-preload.mjs");
+  const startupDelayMs = 1_200;
+  writeFileSync(preloadPath, [
+    'if (process.env.HARNESS_DAEMON_SERVER_HOST === "1") {',
+    `  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ${startupDelayMs});`,
+    "}",
+    ""
+  ].join("\n"), "utf8");
+  t.after(async () => {
+    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    rmSync(fixture.root, { recursive: true, force: true });
+  });
+
+  const startedAt = Date.now();
+  const outcome = runRawJsonMaybeFail(fixture.repoRoot, ["task", "list"], {
+    ...daemonEnv(userRoot),
+    NODE_OPTIONS: `--import=${preloadPath}`,
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "10000"
+  });
+
+  assert.equal(outcome.status, 0, JSON.stringify(outcome.receipt));
+  assert.ok(Date.now() - startedAt >= startupDelayMs, "the caller returned before the injected startup delay elapsed");
+});
+
+test("an autostarted daemon stays alive after its calling CLI exits", { timeout: 45_000 }, async (t) => {
+  const fixture = createFixture();
+  const userRoot = path.join(fixture.root, "detached-autostart-user");
+  t.after(async () => {
+    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    rmSync(fixture.root, { recursive: true, force: true });
+  });
+
+  const launched = runRawJsonMaybeFail(fixture.repoRoot, ["task", "list"], daemonEnv(userRoot));
+  assert.equal(launched.status, 0, JSON.stringify(launched.receipt));
+  await delay(200);
+
+  const status = runRawJsonMaybeFail(
+    fixture.repoRoot,
+    ["daemon", "status", "--user-root", userRoot],
+    daemonEnv(userRoot)
+  );
+  assert.equal(status.status, 0, JSON.stringify(status.receipt));
+  assert.equal(status.receipt.reachable, true, JSON.stringify(status.receipt));
+  assert.equal(typeof status.receipt.pid, "number", JSON.stringify(status.receipt));
+  assert.doesNotThrow(() => process.kill(status.receipt.pid as number, 0));
+});
+
+function daemonEnv(userRoot: string): Record<string, string> {
+  return {
+    HARNESS_DAEMON_MODE: "local",
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_IDLE_MS: "60000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "5000",
+    HARNESS_DAEMON_REQUEST_TIMEOUT_MS: "10000"
+  };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}

--- a/packages/cli/test/daemon-autostart-startup-diagnostics.test.ts
+++ b/packages/cli/test/daemon-autostart-startup-diagnostics.test.ts
@@ -11,7 +11,8 @@ test("autostart reports the daemon child's real startup failure", { timeout: 30_
   if (process.platform === "win32") return;
   const fixture = createFixture();
   const userRoot = path.join(fixture.root, "autostart-failure-user");
-  const endpoint = localUserDaemonEndpoint(userRoot);
+  const daemon = testDaemonLocation(fixture.root, userRoot);
+  const endpoint = daemon.socketPath;
   mkdirSync(endpoint, { recursive: true });
   writeFileSync(path.join(endpoint, "blocker"), "keep the occupied endpoint non-empty\n", "utf8");
   t.after(() => {
@@ -19,7 +20,7 @@ test("autostart reports the daemon child's real startup failure", { timeout: 30_
     rmSync(fixture.root, { recursive: true, force: true });
   });
 
-  const failed = runRawJsonMaybeFail(fixture.repoRoot, ["task", "list"], daemonEnv(userRoot));
+  const failed = runRawJsonMaybeFail(fixture.repoRoot, ["task", "list"], daemon.env);
 
   assert.notEqual(failed.status, 0, JSON.stringify(failed.receipt));
   const error = failed.receipt.error as { readonly hint?: string };
@@ -33,7 +34,8 @@ test("autostart does not describe an exited daemon process as still starting", {
   if (process.platform === "win32") return;
   const fixture = createFixture();
   const userRoot = path.join(fixture.root, "autostart-exited-user");
-  const endpoint = localUserDaemonEndpoint(userRoot);
+  const daemon = testDaemonLocation(fixture.root, userRoot);
+  const endpoint = daemon.socketPath;
   mkdirSync(endpoint, { recursive: true });
   writeFileSync(path.join(endpoint, "blocker"), "keep the occupied endpoint non-empty\n", "utf8");
   t.after(() => {
@@ -41,17 +43,22 @@ test("autostart does not describe an exited daemon process as still starting", {
     rmSync(fixture.root, { recursive: true, force: true });
   });
 
-  const failed = runRawJsonMaybeFail(fixture.repoRoot, ["task", "list"], daemonEnv(userRoot));
+  const failed = runRawJsonMaybeFail(fixture.repoRoot, ["task", "list"], daemon.env);
 
   assert.notEqual(failed.status, 0, JSON.stringify(failed.receipt));
   const error = failed.receipt.error as { readonly hint?: string };
   assert.match(error.hint ?? "", /DAEMON_AUTOSTART_PROCESS_EXITED:.*exited before readiness/u);
   assert.doesNotMatch(error.hint ?? "", /may still be starting/u);
+  assert.match(error.hint ?? "", new RegExp(
+    `DAEMON_SOCKET_NAMESPACE_INVALID:path=${escapeRegExp(endpoint)};.*connectCode=ERR_FS_EISDIR`,
+    "u"
+  ));
 });
 
 test("autostart keeps waiting while a live daemon is slowly starting", { timeout: 45_000 }, async (t) => {
   const fixture = createFixture();
   const userRoot = path.join(fixture.root, "slow-autostart-user");
+  const daemon = testDaemonLocation(fixture.root, userRoot);
   const preloadPath = path.join(fixture.root, "slow-autostart-preload.mjs");
   const startupDelayMs = 1_200;
   writeFileSync(preloadPath, [
@@ -61,13 +68,13 @@ test("autostart keeps waiting while a live daemon is slowly starting", { timeout
     ""
   ].join("\n"), "utf8");
   t.after(async () => {
-    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    await stopDaemon(fixture.repoRoot, userRoot, daemon.runtimeEnv).catch(() => undefined);
     rmSync(fixture.root, { recursive: true, force: true });
   });
 
   const startedAt = Date.now();
   const outcome = runRawJsonMaybeFail(fixture.repoRoot, ["task", "list"], {
-    ...daemonEnv(userRoot),
+    ...daemon.env,
     NODE_OPTIONS: `--import=${preloadPath}`,
     HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "10000"
   });
@@ -79,19 +86,20 @@ test("autostart keeps waiting while a live daemon is slowly starting", { timeout
 test("an autostarted daemon stays alive after its calling CLI exits", { timeout: 45_000 }, async (t) => {
   const fixture = createFixture();
   const userRoot = path.join(fixture.root, "detached-autostart-user");
+  const daemon = testDaemonLocation(fixture.root, userRoot);
   t.after(async () => {
-    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    await stopDaemon(fixture.repoRoot, userRoot, daemon.runtimeEnv).catch(() => undefined);
     rmSync(fixture.root, { recursive: true, force: true });
   });
 
-  const launched = runRawJsonMaybeFail(fixture.repoRoot, ["task", "list"], daemonEnv(userRoot));
+  const launched = runRawJsonMaybeFail(fixture.repoRoot, ["task", "list"], daemon.env);
   assert.equal(launched.status, 0, JSON.stringify(launched.receipt));
   await delay(200);
 
   const status = runRawJsonMaybeFail(
     fixture.repoRoot,
     ["daemon", "status", "--user-root", userRoot],
-    daemonEnv(userRoot)
+    daemon.env
   );
   assert.equal(status.status, 0, JSON.stringify(status.receipt));
   assert.equal(status.receipt.reachable, true, JSON.stringify(status.receipt));
@@ -99,8 +107,35 @@ test("an autostarted daemon stays alive after its calling CLI exits", { timeout:
   assert.doesNotThrow(() => process.kill(status.receipt.pid as number, 0));
 });
 
-function daemonEnv(userRoot: string): Record<string, string> {
+interface TestDaemonLocation {
+  readonly socketPath: string;
+  readonly runtimeEnv: Readonly<Record<string, string>>;
+  readonly env: Readonly<Record<string, string>>;
+}
+
+function testDaemonLocation(rootDir: string, userRoot: string): TestDaemonLocation {
+  const runtimeDir = path.join(rootDir, ".daemon-runtime");
+  const runtimeEnv = {
+    XDG_RUNTIME_DIR: runtimeDir,
+    TMPDIR: runtimeDir
+  };
+  const socketPath = localUserDaemonEndpoint(userRoot, "default", process.platform, {
+    env: runtimeEnv
+  });
+  mkdirSync(path.dirname(socketPath), { recursive: true, mode: 0o700 });
   return {
+    socketPath,
+    runtimeEnv,
+    env: daemonEnv(userRoot, runtimeEnv)
+  };
+}
+
+function daemonEnv(
+  userRoot: string,
+  runtimeEnv: Readonly<Record<string, string>>
+): Record<string, string> {
+  return {
+    ...runtimeEnv,
     HARNESS_DAEMON_MODE: "local",
     HARNESS_DAEMON_USER_ROOT: userRoot,
     HARNESS_DAEMON_IDLE_MS: "60000",

--- a/packages/cli/test/helpers/daemon-cli.ts
+++ b/packages/cli/test/helpers/daemon-cli.ts
@@ -119,10 +119,16 @@ export async function pollDaemonConnectionCount(
   );
 }
 
-export async function stopDaemon(rootDir: string, userRoot = defaultDaemonUserRoot(rootDir)): Promise<void> {
-  const endpoint = localUserDaemonEndpoint(userRoot);
+export async function stopDaemon(
+  rootDir: string,
+  userRoot = defaultDaemonUserRoot(rootDir),
+  runtimeEnv?: Readonly<Record<string, string>>
+): Promise<void> {
+  const endpoint = localUserDaemonEndpoint(userRoot, "default", process.platform, {
+    env: runtimeEnv ?? process.env
+  });
   const ownerPath = daemonOwnerPath(endpoint);
-  const before = daemonStatus(rootDir, userRoot);
+  const before = daemonStatus(rootDir, userRoot, runtimeEnv ?? {});
   const pid = daemonPid(before) ?? daemonOwnerPid(ownerPath);
   if (pid === undefined && !existsSync(endpoint) && !existsSync(ownerPath)) return;
 
@@ -134,6 +140,7 @@ export async function stopDaemon(rootDir: string, userRoot = defaultDaemonUserRo
     }
   } else {
     runDaemonCommand(rootDir, ["daemon", "stop", "--timeout-ms", "5000", "--user-root", userRoot, "--json"], {
+      ...runtimeEnv,
       HARNESS_DAEMON_USER_ROOT: userRoot
     });
   }
@@ -150,9 +157,14 @@ export async function stopDaemon(rootDir: string, userRoot = defaultDaemonUserRo
   );
 }
 
-function daemonStatus(rootDir: string, userRoot: string): Record<string, unknown> | undefined {
+function daemonStatus(
+  rootDir: string,
+  userRoot: string,
+  runtimeEnv: Readonly<Record<string, string>>
+): Record<string, unknown> | undefined {
   try {
     return runDaemonCommand(rootDir, ["daemon", "status", "--user-root", userRoot, "--json"], {
+      ...runtimeEnv,
       HARNESS_DAEMON_USER_ROOT: userRoot
     });
   } catch {

--- a/packages/daemon/src/client/daemon-autostart-process.ts
+++ b/packages/daemon/src/client/daemon-autostart-process.ts
@@ -1,0 +1,136 @@
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { closeSync, mkdirSync, openSync, readSync } from "node:fs";
+import path from "node:path";
+
+export interface SpawnedDaemonAutostartProcess {
+  readonly pid?: number;
+  readonly launchStderrPath?: string;
+}
+
+export interface DetachedDaemonAutostartInput {
+  readonly execPath: string;
+  readonly argv: ReadonlyArray<string>;
+  readonly env: NodeJS.ProcessEnv;
+  readonly userRoot: string;
+}
+
+export class DaemonAutostartTimeoutError extends Error {
+  readonly timeoutMs: number;
+  readonly spawnedPid?: number;
+
+  constructor(timeoutMs: number, lastError: unknown, spawnedPid?: number) {
+    const cause = errorMessage(lastError, "no ready probe completed");
+    super(
+      `DAEMON_AUTOSTART_TIMEOUT: readiness was not confirmed within the normal ${timeoutMs}ms startup budget; `
+      + `the launched process${spawnedPid === undefined ? "" : ` pid ${spawnedPid}`} may still be starting. Last probe: ${cause}`
+    );
+    this.name = "DaemonAutostartTimeoutError";
+    this.timeoutMs = timeoutMs;
+    this.spawnedPid = spawnedPid;
+  }
+}
+
+export class DaemonAutostartProcessExitedError extends Error {
+  readonly spawnedPid: number;
+  readonly launchStderrPath?: string;
+
+  constructor(lastError: unknown, spawnedPid: number, launchStderrPath?: string) {
+    const lastProbe = errorMessage(lastError, "no ready probe completed");
+    const startupFailure = launchStderrPath ? daemonLaunchStderrFailure(launchStderrPath) : undefined;
+    super(
+      `DAEMON_AUTOSTART_PROCESS_EXITED: the launched process pid ${spawnedPid} exited before readiness.`
+      + `${startupFailure ? ` Startup failure: ${startupFailure}.` : " No startup stderr was captured."}`
+      + `${launchStderrPath ? ` Launch log: ${launchStderrPath}.` : ""}`
+      + ` Last probe: ${lastProbe}`
+    );
+    this.name = "DaemonAutostartProcessExitedError";
+    this.spawnedPid = spawnedPid;
+    this.launchStderrPath = launchStderrPath;
+  }
+}
+
+export function spawnDetachedDaemonAutostart(
+  input: DetachedDaemonAutostartInput
+): SpawnedDaemonAutostartProcess {
+  const launchStderrPath = daemonAutostartLaunchStderrPath(input.userRoot);
+  const launchStderrFd = openSync(launchStderrPath, "a", 0o600);
+  let child: ReturnType<typeof spawn>;
+  try {
+    child = spawn(input.execPath, [...input.argv], {
+      detached: true,
+      stdio: ["ignore", "ignore", launchStderrFd],
+      env: input.env
+    });
+  } finally {
+    closeSync(launchStderrFd);
+  }
+  child.unref();
+  return { pid: child.pid, launchStderrPath };
+}
+
+export function daemonAutostartFailureError(
+  timeoutMs: number,
+  lastError: unknown,
+  spawnedPid?: number,
+  launchStderrPath?: string
+): Error {
+  return daemonAutostartProcessExitedError(lastError, spawnedPid, launchStderrPath)
+    ?? new DaemonAutostartTimeoutError(timeoutMs, lastError, spawnedPid);
+}
+
+export function daemonAutostartProcessExitedError(
+  lastError: unknown,
+  spawnedPid?: number,
+  launchStderrPath?: string
+): DaemonAutostartProcessExitedError | undefined {
+  return spawnedPid !== undefined && !daemonProcessIsAlive(spawnedPid)
+    ? new DaemonAutostartProcessExitedError(lastError, spawnedPid, launchStderrPath)
+    : undefined;
+}
+
+function daemonAutostartLaunchStderrPath(userRoot: string): string {
+  const directory = path.join(path.resolve(userRoot), "logs", "daemon-startup");
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  return path.join(
+    directory,
+    `launch-${Date.now()}-autostart-${randomBytes(6).toString("hex")}.stderr.log`
+  );
+}
+
+function daemonProcessIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return processErrorCode(error) !== "ESRCH";
+  }
+}
+
+function daemonLaunchStderrFailure(launchStderrPath: string): string | undefined {
+  const buffer = Buffer.alloc(64 * 1024);
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(launchStderrPath, "r");
+    const bytesRead = readSync(descriptor, buffer, 0, buffer.byteLength, 0);
+    const lines = buffer.subarray(0, bytesRead).toString("utf8").split(/\r?\n/u);
+    const namespaceFailure = lines.find((line) => line.includes("DAEMON_SOCKET_NAMESPACE_INVALID:"));
+    if (namespaceFailure) return namespaceFailure.slice(namespaceFailure.indexOf("DAEMON_SOCKET_NAMESPACE_INVALID:"));
+    return lines.find((line) => /^[A-Za-z]*Error:\s+\S/u.test(line))?.trim()
+      ?? lines.find((line) => line.trim().length > 0)?.trim();
+  } catch {
+    return undefined;
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : String(error ?? fallback);
+}
+
+function processErrorCode(error: unknown): unknown {
+  return typeof error === "object" && error !== null && "code" in error
+    ? (error as { readonly code?: unknown }).code
+    : undefined;
+}

--- a/packages/daemon/src/client/daemon-socket-connection.ts
+++ b/packages/daemon/src/client/daemon-socket-connection.ts
@@ -1,0 +1,48 @@
+import net from "node:net";
+import { daemonSocketNamespaceError } from "../transport/daemon-socket-namespace.ts";
+
+export function connectUnixSocket(socketPath: string, timeoutMs: number): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(socketPath);
+    const timer = setTimeout(() => {
+      socket.destroy();
+      reject(new Error(`timed out connecting to daemon socket: ${socketPath}`));
+    }, timeoutMs);
+    socket.once("connect", () => {
+      clearTimeout(timer);
+      resolve(socket);
+    });
+    socket.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+}
+
+export async function connectUnixSocketWithLegacyFallback(
+  socketPath: string,
+  legacySocketPath: string | undefined,
+  timeoutMs: number
+): Promise<net.Socket> {
+  try {
+    return await connectUnixSocket(socketPath, timeoutMs);
+  } catch (error) {
+    if (!legacySocketPath || legacySocketPath === socketPath) throw daemonSocketNamespaceError(socketPath, error);
+    try {
+      return await connectUnixSocket(legacySocketPath, timeoutMs);
+    } catch (legacyError) {
+      throw daemonSocketNamespaceError(legacySocketPath, legacyError);
+    }
+  }
+}
+
+export async function connectUnixSocketWithNamespaceDiagnostic(
+  socketPath: string,
+  timeoutMs: number
+): Promise<net.Socket> {
+  try {
+    return await connectUnixSocket(socketPath, timeoutMs);
+  } catch (error) {
+    throw daemonSocketNamespaceError(socketPath, error);
+  }
+}

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -1,6 +1,5 @@
 // @slice-activation PLT-Boundary W1 exposes this module through the package root API.
 import { createHash } from "node:crypto";
-import { spawn } from "node:child_process";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -20,7 +19,10 @@ import {
   type DaemonLaunchConfiguration
 } from "./daemon-launch-configuration.ts";
 import { DaemonRepoRootResolutionError } from "./daemon-repo-root-resolution-error.ts";
-import { daemonSocketNamespaceError } from "../transport/daemon-socket-namespace.ts";
+import {
+  connectUnixSocketWithLegacyFallback,
+  connectUnixSocketWithNamespaceDiagnostic
+} from "./daemon-socket-connection.ts";
 import {
   DaemonJsonRpcRequestTimeoutError,
   DaemonJsonRpcResponseError,
@@ -32,6 +34,12 @@ import {
   daemonRootIdentity
 } from "../lifecycle/daemon-root-lifetime.ts";
 import { daemonServerHostEnvironment } from "./daemon-server-host-environment.ts";
+import {
+  daemonAutostartFailureError,
+  daemonAutostartProcessExitedError,
+  spawnDetachedDaemonAutostart,
+  type SpawnedDaemonAutostartProcess
+} from "./daemon-autostart-process.ts";
 
 export {
   createDaemonLaunchConfiguration,
@@ -65,21 +73,10 @@ export const defaultDaemonIdleExitMs = 0;
 export const localDaemonRetryIntervalMs = 100;
 const minimumReadyProbeResponseTimeoutMs = 500;
 
-export class DaemonAutostartTimeoutError extends Error {
-  readonly timeoutMs: number;
-  readonly spawnedPid?: number;
-
-  constructor(timeoutMs: number, lastError: unknown, spawnedPid?: number) {
-    const cause = lastError instanceof Error ? lastError.message : String(lastError ?? "no ready probe completed");
-    super(
-      `DAEMON_AUTOSTART_TIMEOUT: readiness was not confirmed within the normal ${timeoutMs}ms startup budget; `
-      + `the launched process${spawnedPid === undefined ? "" : ` pid ${spawnedPid}`} may still be starting. Last probe: ${cause}`
-    );
-    this.name = "DaemonAutostartTimeoutError";
-    this.timeoutMs = timeoutMs;
-    this.spawnedPid = spawnedPid;
-  }
-}
+export {
+  DaemonAutostartProcessExitedError,
+  DaemonAutostartTimeoutError
+} from "./daemon-autostart-process.ts";
 
 export {
   DaemonJsonRpcRequestTimeoutError,
@@ -134,13 +131,15 @@ export interface LocalDaemonJsonRpcOptions {
   readonly env?: NodeJS.ProcessEnv;
 }
 
-type SpawnLocalDaemon = (target: LocalDaemonTarget, options: LocalDaemonAutostartOptions) => number | void;
+type SpawnLocalDaemonResult = number | void | SpawnedDaemonAutostartProcess;
+type SpawnLocalDaemon = (target: LocalDaemonTarget, options: LocalDaemonAutostartOptions) => SpawnLocalDaemonResult;
 
 interface DaemonStartupFlight {
   readonly startedAt: number;
   deadline: number;
   lastError: unknown;
   spawnedPid?: number;
+  launchStderrPath?: string;
   promise: Promise<void>;
 }
 
@@ -315,8 +314,7 @@ export async function requestLocalDaemonJsonRpcForTarget(
 }
 
 export function spawnLocalDaemon(target: LocalDaemonTarget, options: LocalDaemonAutostartOptions): number | undefined {
-  const pid = spawnLocalDaemonImplementation(target, options);
-  return typeof pid === "number" ? pid : undefined;
+  return launchLocalDaemon(target, options).pid;
 }
 
 export function replaceSpawnLocalDaemonForTest(replacement: SpawnLocalDaemon): () => void {
@@ -327,7 +325,10 @@ export function replaceSpawnLocalDaemonForTest(replacement: SpawnLocalDaemon): (
   };
 }
 
-function spawnLocalDaemonProcess(target: LocalDaemonTarget, options: LocalDaemonAutostartOptions): number | undefined {
+function spawnLocalDaemonProcess(
+  target: LocalDaemonTarget,
+  options: LocalDaemonAutostartOptions
+): SpawnedDaemonAutostartProcess {
   const expectedRootIdentity = daemonRootIdentity(target.canonicalRoot) ?? "missing";
   const launchConfiguration = options.launchConfiguration ?? createDaemonLaunchConfiguration({
     target,
@@ -338,20 +339,19 @@ function spawnLocalDaemonProcess(target: LocalDaemonTarget, options: LocalDaemon
     ...(options.execArgv ? { execArgv: options.execArgv } : {}),
     env: options.env ?? process.env
   });
-  const child = spawn(launchConfiguration.execPath, [
-    ...launchConfiguration.execArgv,
-    launchConfiguration.entrypoint,
-    ...launchConfiguration.args
-  ], {
-    detached: true,
-    stdio: "ignore",
+  return spawnDetachedDaemonAutostart({
+    execPath: launchConfiguration.execPath,
+    argv: [
+      ...launchConfiguration.execArgv,
+      launchConfiguration.entrypoint,
+      ...launchConfiguration.args
+    ],
     env: {
       ...daemonServerHostEnvironment(options.env ?? process.env, target),
       [daemonAutostartRootLifetimeEnvironmentVariable]: expectedRootIdentity
-    }
+    },
+    userRoot: target.userRoot
   });
-  child.unref();
-  return child.pid;
 }
 
 async function requestLocalDaemonJsonRpcWithAutostart(
@@ -368,7 +368,10 @@ async function requestLocalDaemonJsonRpcWithAutostart(
     let socket: net.Socket;
     try {
       autostart.onPhase?.("connect-start");
-      socket = await connectUnixSocket(target.socketPath, boundedDeadlineTimeout(connectTimeoutMs, deadline));
+      socket = await connectUnixSocketWithNamespaceDiagnostic(
+        target.socketPath,
+        boundedDeadlineTimeout(connectTimeoutMs, deadline)
+      );
     } catch (error) {
       lastError = error;
       await ensureLocalDaemonStarted(target, autostart, connectTimeoutMs, deadline, autostartTimeoutMs);
@@ -390,7 +393,7 @@ async function requestLocalDaemonJsonRpcWithAutostart(
       autostart.onPhase?.("request-end");
     }
   }
-  throw daemonAutostartTimeoutError(autostartTimeoutMs, lastError);
+  throw daemonAutostartFailureError(autostartTimeoutMs, lastError);
 }
 
 async function ensureLocalDaemonStarted(
@@ -432,7 +435,9 @@ async function spawnAndWaitForLocalDaemon(
   flight: DaemonStartupFlight
 ): Promise<void> {
   autostart.onPhase?.("launch-start");
-  flight.spawnedPid = spawnLocalDaemon(target, autostart);
+  const launch = launchLocalDaemon(target, autostart);
+  flight.spawnedPid = launch.pid;
+  flight.launchStderrPath = launch.launchStderrPath;
   while (Date.now() <= flight.deadline) {
     try {
       await probeLocalDaemonReady(
@@ -444,11 +449,22 @@ async function spawnAndWaitForLocalDaemon(
       return;
     } catch (error) {
       flight.lastError = error;
+      const exited = daemonAutostartProcessExitedError(
+        flight.lastError,
+        flight.spawnedPid,
+        flight.launchStderrPath
+      );
+      if (exited) throw exited;
       const retryDelayMs = Math.min(localDaemonRetryIntervalMs, flight.deadline - Date.now());
       if (retryDelayMs > 0) await delay(retryDelayMs);
     }
   }
-  throw daemonAutostartTimeoutError(flight.deadline - flight.startedAt, flight.lastError, flight.spawnedPid);
+  throw daemonAutostartFailureError(
+    flight.deadline - flight.startedAt,
+    flight.lastError,
+    flight.spawnedPid,
+    flight.launchStderrPath
+  );
 }
 
 async function waitForDaemonStartupFlight(
@@ -460,12 +476,22 @@ async function waitForDaemonStartupFlight(
   const remainingMs = deadline - Date.now();
   if (remainingMs <= 0) {
     if (deadline >= flight.deadline) clearDaemonStartupFlight(socketPath, flight);
-    throw daemonAutostartTimeoutError(autostartTimeoutMs, flight.lastError, flight.spawnedPid);
+    throw daemonAutostartFailureError(
+      autostartTimeoutMs,
+      flight.lastError,
+      flight.spawnedPid,
+      flight.launchStderrPath
+    );
   }
   return new Promise<void>((resolve, reject) => {
     const timer = setTimeout(() => {
       if (deadline >= flight.deadline) clearDaemonStartupFlight(socketPath, flight);
-      reject(daemonAutostartTimeoutError(autostartTimeoutMs, flight.lastError, flight.spawnedPid));
+      reject(daemonAutostartFailureError(
+        autostartTimeoutMs,
+        flight.lastError,
+        flight.spawnedPid,
+        flight.launchStderrPath
+      ));
     }, remainingMs);
     flight.promise.then(
       () => {
@@ -489,7 +515,7 @@ async function probeLocalDaemonReady(
   connectTimeoutMs: number,
   responseTimeoutMs: number
 ): Promise<void> {
-  const socket = await connectUnixSocket(socketPath, connectTimeoutMs);
+  const socket = await connectUnixSocketWithNamespaceDiagnostic(socketPath, connectTimeoutMs);
   const client = new JsonRpcLineClient(socket, socket);
   try {
     await client.request("protocol.hello", { protocolVersion: currentDaemonProtocolVersion }, responseTimeoutMs);
@@ -512,37 +538,6 @@ async function requestWithSocket(
     return await client.request(method, params, remaining());
   } finally {
     socket.destroy();
-  }
-}
-
-function connectUnixSocket(socketPath: string, timeoutMs: number): Promise<net.Socket> {
-  return new Promise((resolve, reject) => {
-    const socket = net.createConnection(socketPath);
-    const timer = setTimeout(() => {
-      socket.destroy();
-      reject(new Error(`timed out connecting to daemon socket: ${socketPath}`));
-    }, timeoutMs);
-    socket.once("connect", () => {
-      clearTimeout(timer);
-      resolve(socket);
-    });
-    socket.once("error", (error) => {
-      clearTimeout(timer);
-      reject(error);
-    });
-  });
-}
-
-async function connectUnixSocketWithLegacyFallback(socketPath: string, legacySocketPath: string | undefined, timeoutMs: number): Promise<net.Socket> {
-  try {
-    return await connectUnixSocket(socketPath, timeoutMs);
-  } catch (error) {
-    if (!legacySocketPath || legacySocketPath === socketPath) throw daemonSocketNamespaceError(socketPath, error);
-    try {
-      return await connectUnixSocket(legacySocketPath, timeoutMs);
-    } catch (legacyError) {
-      throw daemonSocketNamespaceError(legacySocketPath, legacyError);
-    }
   }
 }
 
@@ -594,6 +589,10 @@ function readyProbeResponseTimeout(deadline: number): number {
   );
 }
 
-function daemonAutostartTimeoutError(timeoutMs: number, lastError: unknown, spawnedPid?: number): Error {
-  return new DaemonAutostartTimeoutError(timeoutMs, lastError, spawnedPid);
+function launchLocalDaemon(
+  target: LocalDaemonTarget,
+  options: LocalDaemonAutostartOptions
+): SpawnedDaemonAutostartProcess {
+  const launched = spawnLocalDaemonImplementation(target, options);
+  return typeof launched === "number" ? { pid: launched } : launched ?? {};
 }

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -30,6 +30,7 @@ export {
   daemonServerHostEnvironment,
   daemonUserRoot,
   daemonUserRootForRepo,
+  DaemonAutostartProcessExitedError,
   DaemonAutostartTimeoutError,
   DaemonJsonRpcRequestTimeoutError,
   DaemonJsonRpcResponseError,

--- a/packages/daemon/test/local-json-rpc-client.test.ts
+++ b/packages/daemon/test/local-json-rpc-client.test.ts
@@ -444,7 +444,7 @@ test("autostart bounds a never-responding ready probe by the total startup budge
   const target = makeTarget(socketPath);
   let helloCalls = 0;
   let server: net.Server | undefined;
-  const spawnedPid = 24_680;
+  const spawnedPid = process.pid;
   const restoreSpawn = replaceSpawnLocalDaemonForTest(() => {
     setTimeout(() => {
       void startJsonRpcServer(socketPath, {


### PR DESCRIPTION
## Summary

When an autostarted daemon failed to start, the caller only ever saw a connect timeout: the child's stderr was discarded by `stdio: "ignore"`, and `DAEMON_AUTOSTART_TIMEOUT` claimed the process "may still be starting" even when it had already exited. The only actionable suggestion in the resulting `Daemon unavailable` receipt was the direct-mode escape hatch — which is exactly how an agent in another repository was routed out of the single-writer path on 2026-08-06. Startup failures are now visible to the caller, and the timeout message distinguishes a dead process from a slow one.

## What Changed

- `packages/daemon/src/client/daemon-autostart-process.ts` (new): the autostart child's stderr is captured to a startup log under `userRoot/logs/daemon-startup`; on failure the caller reads back up to 64 KiB of it. Liveness of the spawned pid is probed so an exited process is reported as exited.
- `packages/daemon/src/client/daemon-socket-connection.ts` (new): centralizes socket connection so the autostart retry loop and the readiness probe emit the same `DAEMON_SOCKET_NAMESPACE_INVALID` structured diagnostic as the primary/legacy connect paths. Previously those two paths used the bare connector and produced no diagnostic — and autostart is the path other repositories hit on cold start.
- `packages/daemon/src/client/local-json-rpc-client.ts`: autostart failure surfaces a new `DaemonAutostartProcessExitedError` ("exited before readiness", with the captured cause) instead of the misleading "may still be starting" wording, which is now reserved for processes that are verifiably still alive.
- `packages/daemon/src/index.ts`: exports the new error type.
- Tests: `packages/cli/test/daemon-autostart-startup-diagnostics.test.ts` (new, integration tier) drives four real-subprocess scenarios through the public CLI; `packages/daemon/test/local-json-rpc-client.test.ts` verifies the slow-readiness negative control with a live pid.

Deliberately unchanged: `detached` spawn semantics and daemon lifetime independence, the direct-mode operator escape hatch, daemon topology, socket naming, userRoot derivation, and `protocol.hello` (invariant anchored by `dec_01KZBWT8QVS5GJAKACN6ENEXN6`).

## Version Impact

Additive: one new exported error type. No CLI surface or protocol change.

## Verification

Before/after on the same forced-failure scene (directory occupying the endpoint):

- Before: pid 12558 already exited, caller still told `may still be starting`, only `connect ENOTSOCK` visible.
- After: pid 75459 reported `exited before readiness`, with the real `DAEMON_SOCKET_NAMESPACE_INVALID ... connectCode=ERR_FS_EISDIR` cause.

`npm run check:local` on Node v24.18.0: exit 0 — fast 961/961, contract 496 pass + 1 skip, 27 manifest gates green. New integration file: 4/4 (re-run after rebase onto merged #1266: 4/4). daemon client tests 17/17, cold recovery 1/1, socket race 4/4.

Mutation evidence (real runner output): restoring `stdio: "ignore"` turns the real-cause assertion red (`No startup stderr was captured`); restoring the old timeout classification turns the wording assertion red (`may still be starting` reappears).

Negative controls: a slow-but-successful startup is not failed early (live-pid probe); the daemon outlives the CLI that spawned it. Production daemon and the pre-existing kty-web daemon were untouched.

Note: the new tests are `harness-test-tier: integration`, which `check:local` does not run; they were executed directly with output recorded. CI is the authority for that tier.

## Review Evidence

Worker implemented against CEO-supplied coordinates with an explicit instruction to re-verify all four line numbers rather than copy them, after a prior over-broad "no client task needed" conclusion was partially overturned (the shared diagnostic covered the primary/legacy paths but not autostart/readiness). TDD red→green through the public CLI, no internal mocks. Startup log retention noted as residual (file keeps receiving stderr for the daemon's lifetime; caller reads at most 64 KiB).

## Residual Risk

Windows named-pipe/process-lifecycle behavior not exercised on a real Windows host (CI covers the Windows lane). Startup logs accumulate under `userRoot/logs/daemon-startup` without rotation — small files, bounded by daemon start frequency. CEO cold-start acceptance in a non-harness repository is scheduled after merge.

## References

- `task_01KZBXMKNJ3PJDKQFE4FGR79JC`
- Predecessor: #1266, `task_01KZBQKEE95BJN6J3F96408G93`
- Invariant: `dec_01KZBWT8QVS5GJAKACN6ENEXN6`

---

## 摘要

autostart 起的 daemon 启动失败时,调用方过去只能看到连接超时:子进程 stderr 被 `stdio: "ignore"` 丢弃,`DAEMON_AUTOSTART_TIMEOUT` 还对已退出的进程声称"可能还在启动"。最终 `Daemon unavailable` 回执里唯一可执行的建议就是 direct 逃生口——2026-08-06 另一个仓库的 agent 正是这样被推出单写者路径的。本 PR 让启动失败对调用方可见,超时消息能区分"死了"与"慢"。

## 改动内容

- `daemon-autostart-process.ts`(新增):autostart 子进程的 stderr 落到 `userRoot/logs/daemon-startup` 下的启动日志;失败时调用方回读最多 64 KiB。探测 pid 存活,已退出的进程如实报告为已退出。
- `daemon-socket-connection.ts`(新增):集中 socket 连接,使 autostart 重试循环与 readiness 探测产出与主/legacy 路径**同一套** `DAEMON_SOCKET_NAMESPACE_INVALID` 结构化诊断。此前这两条路径用裸连接器、无诊断——而 autostart 恰是别的仓库冷启动走的路。
- `local-json-rpc-client.ts`:启动失败抛新的 `DaemonAutostartProcessExitedError`("exited before readiness",附捕获的真因);"may still be starting" 只保留给可验证仍存活的进程。
- 测试:新增 integration 层 `daemon-autostart-startup-diagnostics.test.ts`(4 个真实子进程场景,走公开 CLI);慢启动阴性对照用真实存活 pid 验证。

有意不动:`detached` 语义与 daemon 生命周期独立性、direct 逃生口、daemon 拓扑、socket 命名、userRoot 派生、`protocol.hello`(不变量锚定于 `dec_01KZBWT8QVS5GJAKACN6ENEXN6`)。

## 版本影响

纯新增:一个新导出错误类型。无 CLI 面或协议变更。

## 验证

同一强制失败现场(endpoint 被目录占住)的修前/修后对照:修前 pid 12558 已退出仍称 `may still be starting`、只见 `connect ENOTSOCK`;修后 pid 75459 明确 `exited before readiness` 并显示真实 `connectCode=ERR_FS_EISDIR`。

Node v24.18.0 `npm run check:local` 退出 0(fast 961/961,contract 496+1 skip,27 门全绿)。新 integration 文件 4/4(rebase 到已合入的 #1266 之后复跑仍 4/4)。mutation:回退 stdio ignore → 真因断言变红;回退旧超时分类 → 文案断言变红。阴性对照:慢启动不被误杀;daemon 存活独立于 CLI;生产 daemon 与既存 kty-web daemon 未触碰。

注:新测试为 integration 层,`check:local` 不跑;已单独执行并记录输出,该层以 CI 为权威。

## 评审证据

worker 按 CEO 坐标实现,且被明确要求自核全部行号(此前一条"无需客户端任务"的过宽结论已被部分驳回:共享诊断盖住了主/legacy 路径,但漏掉 autostart/readiness)。TDD 红绿走公开 CLI,无内部 mock。

## 残留风险

Windows 真实主机上的 named-pipe/进程生命周期未实机验证(CI 覆盖 Windows lane)。启动日志无轮转(体量小,受 daemon 启动频率约束)。合并后安排 CEO 在非 harness 仓库做冷启动人工验收。

## 参考

- `task_01KZBXMKNJ3PJDKQFE4FGR79JC`
- 前序:#1266、`task_01KZBQKEE95BJN6J3F96408G93`
- 不变量:`dec_01KZBWT8QVS5GJAKACN6ENEXN6`
