### PR TITLE
fix(daemon): stop reporting indeterminate publications as write failures

### DIFF
--- a/packages/cli/test/authority-indeterminate-receipt-honesty.test.ts
+++ b/packages/cli/test/authority-indeterminate-receipt-honesty.test.ts
@@ -1,0 +1,235 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { Effect } from "effect";
+import { makeJournaledWriteCoordinator, runLedgerMaterializer, taskEntityId } from "../../kernel/src/index.ts";
+import {
+  pollUntil,
+  runDaemonCommand,
+  runRawJsonAsyncMaybeFail,
+  stopDaemon
+} from "./helpers/daemon-cli.ts";
+import {
+  createFixture,
+  git,
+  latestAuthorityOperation
+} from "./production-authority-canonical-ingress/fixture.ts";
+import { publishSeededTaskFixture } from "./helpers/canonical-task-publication-fixture.ts";
+import { writeSubstantiveTaskPlan } from "./helpers/task-plan-fixture.ts";
+
+const sourceTaskId = "task_01KZBDD4300HV864TP0F7YZK1J";
+const targetTaskId = "task_01KZBCN84T1MDXM2643C07J9FT";
+const relationId = "rel_41a981ddac2537bb";
+const rationale = "本任务的全部起点数据(265 个 integration 测试的前缀分布、100 提交回放的 97.1% 命中率、回放方法本身)由那条线第一轮产出;它落盘之后本任务才有可比的基准。";
+
+test("task relate reports an inspect-first indeterminate receipt when canonical publication proof races a legal head advance", { timeout: 60_000 }, async () => {
+  const fixture = createFixture();
+  const userRoot = path.join(fixture.root, ".daemon-user");
+  const gitShimRoot = path.join(fixture.root, "controlled-git-shim");
+  const shimArmed = path.join(fixture.root, "stale-head-shim-armed");
+  const shimReady = path.join(fixture.root, "stale-head-captured");
+  const shimRelease = path.join(fixture.root, "release-stale-head");
+  const shimCounter = path.join(fixture.root, "git-shim-head-count");
+  const shimCaptured = path.join(fixture.root, "git-shim-captured-head");
+  const realGit = execFileSync("/usr/bin/which", ["git"], { encoding: "utf8" }).trim();
+  const env = {
+    HARNESS_ACTOR: "agent:codex",
+    HARNESS_DAEMON_MODE: "local",
+    HARNESS_DAEMON_PROFILE: "isolated",
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_IDLE_MS: "60000",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
+    HARNESS_DAEMON_MATERIALIZER_POLL_MS: "3600000",
+    PATH: `${gitShimRoot}:${process.env.PATH ?? ""}`,
+    CODEX_THREAD_ID: "receipt-honesty-controlled-relate"
+  };
+  try {
+    seedIncidentTask(fixture.authoredRoot, sourceTaskId);
+    seedIncidentTask(fixture.authoredRoot, targetTaskId);
+    mkdirSync(gitShimRoot, { recursive: true });
+    const gitShimPath = path.join(gitShimRoot, "git");
+    writeFileSync(gitShimPath, controlledStaleHeadGitShim({
+      realGit,
+      authoredRoot: fixture.authoredRoot,
+      armedPath: shimArmed,
+      readyPath: shimReady,
+      releasePath: shimRelease,
+      counterPath: shimCounter,
+      capturedPath: shimCaptured,
+      captureCall: 3
+    }));
+    chmodSync(gitShimPath, 0o755);
+
+    const registered = runDaemonCommand(fixture.repoRoot, [
+      "daemon", "repo", "register", "--repo-id", "canonical", "--canonical-root", fixture.repoRoot,
+      "--user-root", userRoot, "--no-link", "--json"
+    ], env);
+    assert.equal(registered.ok, true, JSON.stringify(registered));
+    try {
+      runDaemonCommand(fixture.repoRoot, [
+        "daemon", "start", "--service", "--authority-manifest", fixture.manifestPath, "--json"
+      ], env);
+    } catch {
+      // The detached service can outlive the CLI's fixed startup wait.
+    }
+    await pollUntil(
+      () => runDaemonCommand(fixture.repoRoot, ["daemon", "status", "--user-root", userRoot, "--json"], env),
+      (status) => status.reachable === true,
+      (status, error) => JSON.stringify({ status, error: String(error ?? "") }),
+      { timeoutMs: 20_000 }
+    );
+
+    writeFileSync(shimArmed, "armed\n");
+    const relate = runRawJsonAsyncMaybeFail(fixture.repoRoot, [
+      "task", "relate", sourceTaskId, "depends-on", targetTaskId, "--rationale", rationale
+    ], env);
+    await pollUntil(
+      () => ({ paused: existsSync(shimReady) }),
+      (state) => state.paused,
+      (state) => JSON.stringify(state),
+      { timeoutMs: 10_000 }
+    );
+
+    const controlledAdvanceHead = publishControlledAuthorityAdvance(fixture.repoRoot);
+    writeFileSync(shimRelease, "release\n");
+
+    const result = await relate;
+    if (process.env.HARNESS_CAPTURE_RECEIPT_HONESTY === "1") {
+      process.stdout.write(`RECEIPT_HONESTY_CLI_OUTPUT_START\n${result.stdout}RECEIPT_HONESTY_CLI_OUTPUT_END\n`);
+    }
+    const capturedHead = readFileSync(shimCaptured, "utf8").trim();
+    const finalParents = git(fixture.authoredRoot, "rev-list", "--parents", "-n", "1", "HEAD").split(" ").slice(1);
+    const operation = latestAuthorityOperation(fixture.serviceRoot);
+    assert.notEqual(capturedHead, controlledAdvanceHead);
+    assert.equal(finalParents[0], controlledAdvanceHead);
+    assert.equal(operation.state, "INDETERMINATE", JSON.stringify(operation));
+    assert.equal(operation.receipt?.tag, "INDETERMINATE", JSON.stringify(operation));
+    assert.equal(result.status, 1, result.stdout);
+    assert.equal(result.receipt.ok, false, result.stdout);
+    const error = result.receipt.error as { readonly code?: unknown; readonly hint?: unknown; readonly context?: unknown } | undefined;
+    assert.equal(error?.code, "write_rejected", result.stdout);
+    assert.match(String(error?.hint), /publication outcome is indeterminate/iu);
+    assert.match(String(error?.hint), /actualParents=/u);
+    assert.match(String(error?.hint), /mergeTreeMatchesSession=true/u);
+    assert.match(String(error?.hint), /inspect[\s\S]*before retrying/iu);
+    assert.match(String(error?.hint), /do not retry this exact command blindly/iu);
+    assert.doesNotMatch(String(error?.hint), /then retry the command/iu);
+    assert.deepEqual(error?.context, {
+      schema: "authority-publication-outcome-indeterminate/v1",
+      authorityState: "INDETERMINATE",
+      workspaceId: "workspace-production",
+      opId: (error?.context as { readonly opId?: unknown } | undefined)?.opId,
+      evidence: (error?.context as { readonly evidence?: unknown } | undefined)?.evidence
+    });
+    assert.match(String((error?.context as { readonly evidence?: unknown } | undefined)?.evidence), /actualParents=/u);
+    assert.match(String((error?.context as { readonly evidence?: unknown } | undefined)?.evidence), /mergeTreeMatchesSession=true/u);
+
+    const sourceIndex = readFileSync(path.join(fixture.authoredRoot, "tasks", sourceTaskId, "INDEX.md"), "utf8");
+    assert.match(sourceIndex, new RegExp(`relation_id: ${relationId}`, "u"));
+    assert.match(sourceIndex, new RegExp(`target: task/${targetTaskId}`, "u"));
+  } finally {
+    writeFileSync(shimRelease, "release\n");
+    await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+function publishControlledAuthorityAdvance(rootDir: string): string {
+  const lockPath = path.join(rootDir, ".harness/locks/global.lock");
+  const lock = JSON.parse(readFileSync(lockPath, "utf8")) as {
+    readonly ownerToken: string;
+    readonly ownerKind?: "daemon";
+  };
+  const coordinator = makeJournaledWriteCoordinator({
+    rootDir,
+    heldGlobalLock: { path: lockPath, ownerToken: lock.ownerToken, ownerKind: lock.ownerKind },
+    attribution: {
+      actor: {
+        principal: { kind: "person", personId: "person_fixture" },
+        executor: { kind: "agent", id: "fixture-writer" }
+      },
+      principalSource: {
+        kind: "local-configured",
+        authority: "harness.yaml",
+        authoritySha256: `sha256:${"0".repeat(64)}`
+      },
+      executorSource: "client-asserted"
+    },
+    sessionId: "receipt-honesty-controlled-advance",
+    commitAuthor: { name: "Harness Test", email: "harness@example.test" }
+  });
+  Effect.runSync(coordinator.enqueue({
+    opId: "op_receipt_honesty_controlled_advance",
+    entityId: taskEntityId("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4"),
+    kind: "progress_append",
+    payload: {
+      path: "progress.md",
+      append: "controlled canonical head advance before relate publication proof\n"
+    }
+  }));
+  const report = Effect.runSync(coordinator.flush("explicit"));
+  assert.equal(report.committed, true);
+  assert.equal(report.opCount, 1);
+  const materialized = runLedgerMaterializer(rootDir, {
+    heldGlobalLock: { path: lockPath, ownerToken: lock.ownerToken, ownerKind: lock.ownerKind },
+    sessionId: "receipt-honesty-controlled-advance"
+  });
+  assert.equal(materialized.merged, 1, JSON.stringify(materialized));
+  return git(path.join(rootDir, "harness"), "rev-parse", "HEAD");
+}
+
+function seedIncidentTask(authoredRoot: string, taskId: string): void {
+  const taskRoot = path.join(authoredRoot, "tasks", taskId);
+  mkdirSync(taskRoot, { recursive: true });
+  const template = readFileSync(path.join(
+    authoredRoot,
+    "tasks/task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4/INDEX.md"
+  ), "utf8");
+  writeFileSync(
+    path.join(taskRoot, "INDEX.md"),
+    template.replaceAll("task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4", taskId)
+  );
+  writeSubstantiveTaskPlan(authoredRoot, `tasks/${taskId}`);
+  git(authoredRoot, "add", `tasks/${taskId}`);
+  git(authoredRoot, "commit", "-q", "-m", `test: stage ${taskId} publication fixture`);
+  publishSeededTaskFixture(authoredRoot, taskRoot, taskId);
+}
+
+function controlledStaleHeadGitShim(input: {
+  readonly realGit: string;
+  readonly authoredRoot: string;
+  readonly armedPath: string;
+  readonly readyPath: string;
+  readonly releasePath: string;
+  readonly counterPath: string;
+  readonly capturedPath: string;
+  readonly captureCall: number;
+}): string {
+  return [
+    "#!/bin/sh",
+    `if [ -e '${input.armedPath}' ] && [ "$1" = '-C' ] && [ "$2" = '${input.authoredRoot}' ] \\`,
+    "  && [ \"$3\" = 'rev-parse' ] && [ \"$4\" = '--verify' ] && [ \"$5\" = 'HEAD' ]; then",
+    `  count=$(test -e '${input.counterPath}' && cat '${input.counterPath}' || printf '0')`,
+    "  count=$((count + 1))",
+    `  printf '%s\\n' "$count" > '${input.counterPath}'`,
+    `  if [ "$count" -eq '${input.captureCall}' ]; then`,
+    `    captured=$('${input.realGit}' "$@") || exit $?`,
+    `    printf '%s\\n' "$captured" > '${input.capturedPath}'`,
+    `    : > '${input.readyPath}'`,
+    "    attempts=0",
+    `    while [ ! -e '${input.releasePath}' ]; do`,
+    "      attempts=$((attempts + 1))",
+    "      if [ \"$attempts\" -gt 400 ]; then exit 91; fi",
+    "      sleep 0.05",
+    "    done",
+    "    printf '%s\\n' \"$captured\"",
+    "    exit 0",
+    "  fi",
+    "fi",
+    `exec '${input.realGit}' "$@"`,
+    ""
+  ].join("\n");
+}

--- a/packages/cli/test/helpers/daemon-cli.ts
+++ b/packages/cli/test/helpers/daemon-cli.ts
@@ -76,6 +76,30 @@ export async function runRawJsonAsync(rootDir: string, args: ReadonlyArray<strin
   return JSON.parse(stdout) as Record<string, unknown>;
 }
 
+export async function runRawJsonAsyncMaybeFail(
+  rootDir: string,
+  args: ReadonlyArray<string>,
+  env: Readonly<Record<string, string>> = {}
+): Promise<{ readonly status: number; readonly receipt: Record<string, unknown>; readonly stdout: string; readonly stderr: string }> {
+  const result = await new Promise<{ readonly status: number; readonly stdout: string; readonly stderr: string }>((resolve) => {
+    execFile(
+      process.execPath,
+      [cliEntry, "--root", rootDir, "--json", ...args],
+      { encoding: "utf8", env: daemonTestEnv(rootDir, env) },
+      (error, stdout, stderr) => resolve({
+        status: typeof error?.code === "number" ? error.code : error ? 1 : 0,
+        stdout,
+        stderr
+      })
+    );
+  });
+  assert.equal(stderrWithoutDeprecationWarnings(result.stderr), "");
+  return {
+    ...result,
+    receipt: JSON.parse(result.stdout) as Record<string, unknown>
+  };
+}
+
 export function runDaemonCommand(rootDir: string, args: ReadonlyArray<string>, env: Readonly<Record<string, string>> = {}): Record<string, unknown> {
   const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, ...args], {
     encoding: "utf8",

--- a/packages/daemon/src/authority/authority-command-submission.ts
+++ b/packages/daemon/src/authority/authority-command-submission.ts
@@ -86,6 +86,16 @@ export class AuthorityCompileRejectedError extends Error {
   }
 }
 
+export class AuthorityPublicationOutcomeIndeterminateError extends Error {
+  readonly receipt: Extract<AuthorityOperationReceipt, { readonly tag: "INDETERMINATE" }>;
+
+  constructor(receipt: Extract<AuthorityOperationReceipt, { readonly tag: "INDETERMINATE" }>) {
+    super(`AUTHORITY_INDETERMINATE:${receipt.reason}`);
+    this.name = "AuthorityPublicationOutcomeIndeterminateError";
+    this.receipt = receipt;
+  }
+}
+
 export function authorityCompileRejected(cause: unknown): AuthorityCompileRejectedError {
   if (cause instanceof AuthorityCompileRejectedError) return cause;
   const reason = cause instanceof Error ? cause.message : String(cause);
@@ -352,13 +362,32 @@ export function receiptToFlushReport(receipt: AuthorityOperationReceipt, reason:
         receipt.errorCode,
         receipt.errorContext ? { ...receipt.errorContext } : undefined
       );
-      throw new Error(`AUTHORITY_INDETERMINATE:${receipt.reason}`);
+      throw new AuthorityPublicationOutcomeIndeterminateError(receipt);
     }
   }
 }
 
 export function authoritySubmissionWriteError(cause: unknown): WriteError {
   if (isAuthorityWriteError(cause)) return cause;
+  if (cause instanceof AuthorityPublicationOutcomeIndeterminateError) {
+    const receipt = cause.receipt;
+    return authorityWriteRejected(
+      [
+        "Authority publication outcome is indeterminate; the canonical mutation may already be committed.",
+        receipt.reason,
+        `Inspect canonical state for operation ${receipt.opId} before retrying; do not retry this exact command blindly.`
+      ].join(" "),
+      false,
+      "write_rejected",
+      {
+        schema: "authority-publication-outcome-indeterminate/v1",
+        authorityState: "INDETERMINATE",
+        workspaceId: receipt.workspaceId,
+        opId: receipt.opId,
+        evidence: receipt.reason
+      }
+    );
+  }
   if (cause instanceof AuthorityProtocolDamagedError) {
     return authorityWriteRejected(cause.message, false, "PROTOCOL_DAMAGED");
   }

--- a/packages/daemon/test/authority-publication-outcome-indeterminate.test.ts
+++ b/packages/daemon/test/authority-publication-outcome-indeterminate.test.ts
@@ -1,0 +1,50 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  authoritySubmissionWriteError,
+  AuthorityPublicationOutcomeIndeterminateError,
+  receiptToFlushReport
+} from "../src/authority/authority-command-submission.ts";
+
+test("authority publication indeterminate remains typed and carries proof evidence to an inspect-first rejection", () => {
+  const reason = [
+    "PUBLICATION_PROOF_FAILED:AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR",
+    "expectedPreviousHead=old-head",
+    "actualParents=advanced-head,session-head",
+    "actualSessionParents=advanced-head",
+    "mergeMessageMatchesSession=true",
+    "semanticSubjectShape=true",
+    "mergeTreeMatchesSession=true"
+  ].join(";");
+  let failure: unknown;
+  try {
+    receiptToFlushReport({
+      tag: "INDETERMINATE",
+      workspaceId: "workspace-production",
+      opId: "namespace-production:receipt-honesty",
+      semanticDigest: "a".repeat(64),
+      reason
+    }, "explicit");
+  } catch (error) {
+    failure = error;
+  }
+
+  assert.equal(failure instanceof AuthorityPublicationOutcomeIndeterminateError, true);
+  assert.deepEqual(authoritySubmissionWriteError(failure), {
+    _tag: "WriteRejected",
+    code: "write_rejected",
+    reason: [
+      "Authority publication outcome is indeterminate; the canonical mutation may already be committed.",
+      reason,
+      "Inspect canonical state for operation namespace-production:receipt-honesty before retrying; do not retry this exact command blindly."
+    ].join(" "),
+    context: {
+      schema: "authority-publication-outcome-indeterminate/v1",
+      authorityState: "INDETERMINATE",
+      workspaceId: "workspace-production",
+      opId: "namespace-production:receipt-honesty",
+      evidence: reason
+    }
+  });
+});

--- a/packages/daemon/test/authority-submission-error.test.ts
+++ b/packages/daemon/test/authority-submission-error.test.ts
@@ -42,16 +42,16 @@ import {
 } from "@harness-anything/application";
 import { v2Claims, v2Envelope } from "./authority-v2-fixtures.ts";
 
-test("authority JournalUnavailable errors serialize diagnostic fields without stacks", () => {
-  const failure = new Error("AUTHORITY_PRODUCTION_PUBLICATION_OBSERVATION_MISMATCH") as Error & { code: string };
-  failure.code = "EOBSERVE";
+test("genuine authority journal failures remain JournalUnavailable and serialize without stacks", () => {
+  const failure = new Error("EACCES: authority journal cannot append") as Error & { code: string };
+  failure.code = "EACCES";
   const writeError = authoritySubmissionWriteError(failure);
   assert.deepEqual(writeError, {
     _tag: "JournalUnavailable",
     cause: {
       name: "Error",
-      message: "AUTHORITY_PRODUCTION_PUBLICATION_OBSERVATION_MISMATCH",
-      code: "EOBSERVE"
+      message: "EACCES: authority journal cannot append",
+      code: "EACCES"
     }
   });
   assert.doesNotMatch(JSON.stringify(writeError), /stack/u);


### PR DESCRIPTION
## Summary

When a canonical write succeeded but the publication proof could not confirm linearity, the receipt claimed the write had failed: `journal_unavailable` with "then retry the command". Callers who trusted it would retry an already-committed mutation. The fourth recurrence of the `AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR` family was traced not to the three previously fixed causes but to the translation layer itself: an INDETERMINATE authority outcome was stripped of its type mid-flight and impersonated a journal failure. Indeterminate outcomes now cross the daemon boundary as a dedicated typed error and reach the caller as the existing inspect-first `write_rejected` shape, evidence intact.

## What Changed

- `packages/daemon/src/authority/authority-command-submission.ts`: an application receipt with `tag=INDETERMINATE` and no `errorCode` is no longer thrown as a bare `Error` (which downstream degraded to `JournalUnavailable`). It becomes `AuthorityPublicationOutcomeIndeterminateError` carrying the full receipt, and translates to `WriteRejected/write_rejected` with structured context `authority-publication-outcome-indeterminate/v1` — authorityState, workspaceId, opId, and the complete proof evidence (`actualParents`, `mergeTreeMatchesSession`, …). The message states the mutation may already be committed, names the opId to inspect, and says not to retry blindly.
- Genuine journal failures are untouched: a real append error still surfaces as `JournalUnavailable/journal_unavailable` with its journal-health guidance.
- `packages/cli/test/authority-indeterminate-receipt-honesty.test.ts` (new, integration): reproduces the incident scene end-to-end in an isolated daemon profile — concurrent head advance, write lands on disk, proof reports NON_LINEAR — and asserts the receipt is not a write failure.
- `packages/daemon/test/authority-publication-outcome-indeterminate.test.ts` (new) + `authority-submission-error.test.ts`: unit coverage for the typed path.
- `packages/cli/test/helpers/daemon-cli.ts`: helper support for the isolated-profile scene.

Deliberately unchanged: `publication-evidence.ts` predicates, the linearity rule, and retry logic. The validator's first-parent strictness (which makes this INDETERMINATE recur under legitimate concurrent head advance) is recorded as proposed decision `dec_01KZD29A3BBMH05G6H8002MEH7` — deliberately NOT implemented here; changing proof semantics needs its own review.

## Version Impact

Additive: one new exported error type and one new structured-context schema id. Existing error codes keep their meanings; no code that previously succeeded now fails.

## Verification

Same-scene before/after (controlled replay of the incident relate, isolated profile):

- Before: `journal_unavailable` — "Journal is unavailable … then retry the command", while the relation was already on disk.
- After: `write_rejected` — "Authority publication outcome is indeterminate; the canonical mutation may already be committed … Inspect canonical state for operation <opId> before retrying; do not retry this exact command blindly", full evidence retained.

`npm run check:local` on Node v24.18.0: exit 0 — 27 manifest gates green, fast 742 pass, contract 253 pass + 1 skip. Integration scene test 1/1 (~16s, run directly — `check:local` does not run the integration tier). Targeted negative/mapper tests 33/33.

Mutation: reverting the translation turns the scene assertion red (`journal_unavailable` ≠ `write_rejected`). Negative control: a genuine `EACCES` journal append failure still maps to `journal_unavailable`; uncertainty is not turned into success (exit status stays 1).

Production daemon untouched throughout; reproduction ran only against isolated-profile daemons, all stopped afterwards.

## Review Evidence

Worker hit the plan's mandatory checkpoint before implementing: 0/18 controlled concurrency rounds reproduced the incident, so the mechanism was established from the incident's own Git objects instead (expectedPreviousHead was an ancestor of the advanced first parent; session commit, merge message, tree, and opId all matched — the only failing condition was the stale first-parent equality). All three previously-done fixes in this family were re-verified as still holding, each with the reason it could not cover this case. CEO adjudicated: fix the translation layer only; validator semantics deferred to the proposed decision.

## Residual Risk

The spurious INDETERMINATE itself still occurs under concurrent head advance until `dec_01KZD29A3BBMH05G6H8002MEH7` is adjudicated — but it is now reported honestly and no longer instructs a retry. Windows lane relies on CI.

## References

- `task_01KZBDK7APT0KYTA7R0ZMEV994`
- Proposed follow-up decision: `dec_01KZD29A3BBMH05G6H8002MEH7` (`rel_45324047706c6c6d`)
- Prior family fixes: `task_01KYW3BH9NGMZJKH957YGP29DJ`, `task_01KYV26EJH8VJFGSMH6FTR4RZB`, `task_01KZ4ZYAKB8ZM9W6CVMRVQEQRA`

---

## 摘要

canonical 写入成功、但发布证明无法确认线性时,回执谎称写失败:`journal_unavailable` + "then retry the command"。相信回执的调用方会把一个已落盘的变更再写一遍。`AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR` 族第四次复发,取证结果不是前三次修过的任何一个原因,而是翻译层本身:INDETERMINATE 的 authority 结果在中途被剥掉类型,冒名成 journal 故障。现在不确定结果以专用类型跨过 daemon 边界,以既有的 inspect-first `write_rejected` 形态抵达调用方,证据完整保留。

## 改动内容

- `authority-command-submission.ts`:`tag=INDETERMINATE` 且无 `errorCode` 的 receipt 不再被抛成裸 `Error`(下游会把它降格成 `JournalUnavailable`),改为携带完整 receipt 的 `AuthorityPublicationOutcomeIndeterminateError`,翻译为 `write_rejected` + 结构化 context(authorityState、workspaceId、opId、全部证明证据)。消息明确说"变更可能已提交,先查该 opId,不要盲目重试"。
- 真实 journal 故障不受影响:仍报 `journal_unavailable` 及其健康检查指引。
- 新增 integration 场景测试(隔离 profile 端到端重演事故:并发推进 head、写落盘、证明报 NON_LINEAR,断言回执不是写失败)+ 两个单元测试文件。

有意不动:`publication-evidence.ts` 判定、线性规则、重试逻辑。校验器 first-parent 严格性(它使这个 INDETERMINATE 在合法并发推进下规律性复发)已立为 proposed 决策 `dec_01KZD29A3BBMH05G6H8002MEH7`,**本 PR 有意不实现**——改证明语义需要独立评审。

## 版本影响

纯新增:一个错误类型、一个 context schema id。既有错误码语义不变;此前成功的路径没有任何一条现在会失败。

## 验证

同景重演对照:修前 `journal_unavailable` 教人重试(而关系已在盘上);修后 `write_rejected`,明说"可能已提交,先查 opId,别盲目重试",证据全留。Node v24.18.0 `check:local` 退出 0(27 门全绿,fast 742,contract 253+1 skip);integration 场景 1/1 单独跑(该层不在 check:local 内);定向阴性/mapper 测试 33/33。mutation:回退翻译,场景断言变红。阴性对照:真实 EACCES 仍是 `journal_unavailable`;不确定不被说成成功(退出码仍为 1)。复现只打隔离 profile daemon,事后全部停掉,生产 daemon 全程未动。

## 评审证据

worker 在动手前命中任务包强制 checkpoint:受控并发 0/18 未复现,改从事故自身的 Git 对象取证确立机制(expectedPreviousHead 是被推进后 first parent 的祖先;session commit、merge message、tree、opId 全部同一,唯一失败项是过期的 first-parent 等式)。三条已 done 同族修复逐条复核仍成立,并各给出"为什么盖不住本次"。CEO 裁决:只修翻译层;校验器语义留给 proposed 决策。

## 残留风险

在 `dec_01KZD29A3BBMH05G6H8002MEH7` 裁决前,合法并发推进仍会触发这个(现已诚实的)不确定回执,但不再诱导重试。Windows lane 依赖 CI。

## 参考

- `task_01KZBDK7APT0KYTA7R0ZMEV994`
- 待裁决策:`dec_01KZD29A3BBMH05G6H8002MEH7`(`rel_45324047706c6c6d`)
- 同族前三修:`task_01KYW3BH9NGMZJKH957YGP29DJ`、`task_01KYV26EJH8VJFGSMH6FTR4RZB`、`task_01KZ4ZYAKB8ZM9W6CVMRVQEQRA`
