### PR TITLE
test(cli): prove stale-head publication race topology

### DIFF
--- a/packages/cli/test/authority-indeterminate-receipt-honesty.test.ts
+++ b/packages/cli/test/authority-indeterminate-receipt-honesty.test.ts
@@ -93,18 +93,67 @@ test("task relate reports an inspect-first indeterminate receipt when canonical 
       { timeoutMs: 10_000 }
     );
 
+    const staleExpectedPreviousHead = readFileSync(shimCaptured, "utf8").trim();
+    assert.equal(git(fixture.authoredRoot, "rev-parse", "HEAD"), staleExpectedPreviousHead);
+
     const controlledAdvanceHead = publishControlledAuthorityAdvance(fixture.repoRoot);
+    const headAfterControlledAdvance = git(fixture.authoredRoot, "rev-parse", "HEAD");
+    assert.equal(headAfterControlledAdvance, controlledAdvanceHead);
+    assert.notEqual(staleExpectedPreviousHead, headAfterControlledAdvance);
+    assert.equal(
+      git(fixture.authoredRoot, "rev-parse", `${controlledAdvanceHead}^1`),
+      staleExpectedPreviousHead
+    );
+    assert.equal(
+      git(
+        fixture.authoredRoot,
+        "merge-base",
+        "--is-ancestor",
+        staleExpectedPreviousHead,
+        controlledAdvanceHead
+      ),
+      ""
+    );
     writeFileSync(shimRelease, "release\n");
 
     const result = await relate;
     if (process.env.HARNESS_CAPTURE_RECEIPT_HONESTY === "1") {
       process.stdout.write(`RECEIPT_HONESTY_CLI_OUTPUT_START\n${result.stdout}RECEIPT_HONESTY_CLI_OUTPUT_END\n`);
     }
-    const capturedHead = readFileSync(shimCaptured, "utf8").trim();
-    const finalParents = git(fixture.authoredRoot, "rev-list", "--parents", "-n", "1", "HEAD").split(" ").slice(1);
+    const finalHead = git(fixture.authoredRoot, "rev-parse", "HEAD");
+    const finalParents = git(
+      fixture.authoredRoot,
+      "rev-list",
+      "--parents",
+      "-n",
+      "1",
+      finalHead
+    ).split(" ").slice(1);
+    assert.equal(finalParents.length, 2);
+    const finalSessionCommit = finalParents[1];
+    assert.ok(finalSessionCommit);
+    const finalSessionParents = git(
+      fixture.authoredRoot,
+      "rev-list",
+      "--parents",
+      "-n",
+      "1",
+      finalSessionCommit
+    ).split(" ").slice(1);
     const operation = latestAuthorityOperation(fixture.serviceRoot);
-    assert.notEqual(capturedHead, controlledAdvanceHead);
     assert.equal(finalParents[0], controlledAdvanceHead);
+    assert.deepEqual(finalSessionParents, [controlledAdvanceHead]);
+    assert.equal(
+      git(
+        fixture.authoredRoot,
+        "merge-base",
+        "--is-ancestor",
+        staleExpectedPreviousHead,
+        finalHead
+      ),
+      ""
+    );
+    assert.equal(git(fixture.authoredRoot, "diff", "--quiet", finalHead, finalSessionCommit), "");
     assert.equal(operation.state, "INDETERMINATE", JSON.stringify(operation));
     assert.equal(operation.receipt?.tag, "INDETERMINATE", JSON.stringify(operation));
     assert.equal(result.status, 1, result.stdout);
@@ -112,6 +161,11 @@ test("task relate reports an inspect-first indeterminate receipt when canonical 
     const error = result.receipt.error as { readonly code?: unknown; readonly hint?: unknown; readonly context?: unknown } | undefined;
     assert.equal(error?.code, "write_rejected", result.stdout);
     assert.match(String(error?.hint), /publication outcome is indeterminate/iu);
+    assert.match(String(error?.hint), /AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR/u);
+    assert.match(String(error?.hint), new RegExp(`expectedPreviousHead=${staleExpectedPreviousHead}`, "u"));
+    assert.match(String(error?.hint), new RegExp(`head=${finalHead}`, "u"));
+    assert.match(String(error?.hint), new RegExp(`actualParents=${finalParents.join(",")}`, "u"));
+    assert.match(String(error?.hint), new RegExp(`actualSessionParents=${finalSessionParents.join(",")}`, "u"));
     assert.match(String(error?.hint), /actualParents=/u);
     assert.match(String(error?.hint), /mergeTreeMatchesSession=true/u);
     assert.match(String(error?.hint), /inspect[\s\S]*before retrying/iu);
@@ -124,12 +178,39 @@ test("task relate reports an inspect-first indeterminate receipt when canonical 
       opId: (error?.context as { readonly opId?: unknown } | undefined)?.opId,
       evidence: (error?.context as { readonly evidence?: unknown } | undefined)?.evidence
     });
-    assert.match(String((error?.context as { readonly evidence?: unknown } | undefined)?.evidence), /actualParents=/u);
-    assert.match(String((error?.context as { readonly evidence?: unknown } | undefined)?.evidence), /mergeTreeMatchesSession=true/u);
+    const publicationEvidence = String(
+      (error?.context as { readonly evidence?: unknown } | undefined)?.evidence
+    );
+    assert.match(publicationEvidence, new RegExp(`expectedPreviousHead=${staleExpectedPreviousHead}`, "u"));
+    assert.match(publicationEvidence, new RegExp(`head=${finalHead}`, "u"));
+    assert.match(publicationEvidence, new RegExp(`actualParents=${finalParents.join(",")}`, "u"));
+    assert.match(publicationEvidence, new RegExp(`actualSessionParents=${finalSessionParents.join(",")}`, "u"));
+    assert.match(publicationEvidence, /mergeTreeMatchesSession=true/u);
 
     const sourceIndex = readFileSync(path.join(fixture.authoredRoot, "tasks", sourceTaskId, "INDEX.md"), "utf8");
     assert.match(sourceIndex, new RegExp(`relation_id: ${relationId}`, "u"));
     assert.match(sourceIndex, new RegExp(`target: task/${targetTaskId}`, "u"));
+    if (process.env.HARNESS_CAPTURE_CANONICAL_PUBLICATION_RACE === "1") {
+      process.stdout.write([
+        "CANONICAL_PUBLICATION_RACE_EVIDENCE_START",
+        JSON.stringify({
+          expectedPreviousHead: staleExpectedPreviousHead,
+          controlledAdvanceHead,
+          publicationHead: finalHead,
+          publicationParents: finalParents,
+          sessionParents: finalSessionParents,
+          expectedPreviousHeadIsAncestorOfControlledAdvance: true,
+          expectedPreviousHeadIsAncestorOfPublication: true,
+          canonicalMutationPresent: true,
+          validatorCode: "AUTHORITY_CANONICAL_PUBLICATION_NON_LINEAR",
+          receiptCode: error?.code,
+          inspectFirst: true,
+          mergeTreeMatchesSession: true
+        }, null, 2),
+        "CANONICAL_PUBLICATION_RACE_EVIDENCE_END",
+        ""
+      ].join("\n"));
+    }
   } finally {
     writeFileSync(shimRelease, "release\n");
     await stopDaemon(fixture.repoRoot, userRoot).catch(() => undefined);


### PR DESCRIPTION
# English

## Summary

Turns the stale-head canonical publication race from a probabilistic test into a deterministic one. The existing regression test for indeterminate publication receipts could pass without ever entering the window it claims to cover: a prior randomized attempt scored 0/10 and 0/8 on window entry. This change adds pre-assertions that prove the stale-head topology was actually constructed before the receipt is asserted, so the test has real discriminating power for the receipt-honesty defect family.

## What Changed

- `packages/cli/test/authority-indeterminate-receipt-honesty.test.ts`: adds positive-control assertions before the controlled git shim is released — that `HEAD` really equals the stale `expectedPreviousHead`, that the stale head and the advanced head are genuinely different commits, that the stale head is an ancestor of the advanced head, that the final session commit's parents are exactly the controlled-advance head, and that the final tree matches. Only then is the receipt asserted.
- No production code changes. The diff is one test file: 86 insertions, 5 deletions.

## Task And Scope

- Harness task: `task_01KZDG6BR9V43GS7PGG8YCPPGB`
- Branch: `codex/canonical-pub-race`
- Public scope: one integration-tier test file under `packages/cli/test/`
- Private planning/evidence updated: yes
- Out of scope: the ancestry-aware publication-proof redesign itself. This PR only builds the instrument that a future redesign would be judged against; it does not change `publication-evidence.ts` or any proof logic.

## Version Impact

- Version: no version change because this PR adds test assertions only and ships no runtime code.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable. The node test tier manifest is discovery-based (it walks the tree and reads the `// harness-test-tier:` marker), so modifying an already-registered test file requires no manifest edit. Verified by `npm run test:list`, which resolves this file to the `integration` tier.
- Authority: `task_01KZDG6BR9V43GS7PGG8YCPPGB`. Related decision `dec_01KZD29A3BBMH05G6H8002MEH7` ("independent review of ancestry-aware canonical publication proof after the observation period") is in state `proposed` and is deliberately left unadjudicated; this PR is its evidence source, not its resolution. Merging this test does not decide that decision.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: adjudication of `dec_01KZD29A3BBMH05G6H8002MEH7` after the observation period ends.

## Verification

- Base `origin/main` SHA: `bc414b48b80ef8ed7a052caa0dbb2ac73fe4bcd9`
- Branch merge-base with `origin/main`: `bc414b48b80ef8ed7a052caa0dbb2ac73fe4bcd9` (branch is based on latest main)
- Last `git fetch origin` time: `2026-08-07T15:14:42Z`
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/canonical-pub-race`
- Private evidence commit/path: recorded under the task package for `task_01KZDG6BR9V43GS7PGG8YCPPGB`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending; to be linked on this PR
- [x] `git diff --check` — clean
- [ ] `npm run check:stop-point` — not run on this branch, see "Not run, and why"
- [ ] Targeted tests for the change surface, named with their counts: **not run locally**, see "Not run, and why"
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending
- Not run, and why:
  - **Targeted local run of this test: not performed.** The file carries `// harness-test-tier: integration`, and the integration tier is excluded from `check:stop-point` by design (the stop point states this itself: "Not covered by design: integration and nightly tiers"). The tier runner also cannot select a single file: `parseRunnerArgs` appends a trailing `/` to every `--prefix`, so a full filename becomes `…test.ts/` and matches zero files while still exiting 0. Selecting this file therefore requires the directory prefix `packages/cli/test/`, which pulls in the whole integration tier for that directory — not a proportionate stop point for a one-file test change. CI is the authority for this tier.
  - **This test has never run on Linux.** Any claim about its behaviour on CI runners is unverified until the `rewrite-ci` run on this PR reports. Reviewers should treat the CI result, not this PR body, as the first evidence of Linux behaviour.
  - **Mutation evidence is inherited, not re-run in this session.** The task ledger records that reverting the production fix flips the assertion (`+ 'journal_unavailable'` / `- 'write_rejected'`). I did not independently reproduce that mutation check while preparing this PR, so it is reported here as a ledger record rather than as a fresh measurement.

## Review Evidence

- Self-review: confirmed the branch is based on latest `origin/main`, `git diff --check` is clean, the diff touches exactly one file, and the file resolves to the `integration` tier via `npm run test:list`.
- Reviewer subagent: none for this PR.
- Human review: pending.
- Blocking findings: none open.

## Residual Risk

- The strongest residual risk is that this test greens on CI for the wrong reason — that the window is entered but the receipt assertion is weaker than believed. The pre-assertions are designed to make that failure mode visible, but only a mutation run on CI would prove it. Reviewers who want that proof should ask for a deliberate revert-and-rerun on a scratch branch rather than trusting a single green.
- The test constructs a controlled git shim and a daemon fixture. If CI runners serialize differently than the local environment, the shim handshake could time out and surface as a flake rather than a clear failure. First CI run should be read with that in mind.

## References

- Task: `task_01KZDG6BR9V43GS7PGG8YCPPGB`
- Evidence: task package for the above; `dec_01KZD29A3BBMH05G6H8002MEH7` (state `proposed`)
- Review: this PR

---

# 中文

## 概要

把 stale-head canonical publication 竞态从"靠概率撞上"变成确定性构造。原有的 indeterminate 回执回归测试有一个致命弱点：它可以在**根本没进入目标窗口**的情况下跑绿——上一轮随机化尝试的窗口命中率是 0/10 和 0/8。本 PR 补上前置断言，先证明 stale-head 拓扑真的被构造出来了，再断言回执，使这个测试对"回执撒谎"这一缺陷族真正具备分辨力。

## 改动内容

- `packages/cli/test/authority-indeterminate-receipt-honesty.test.ts`：在释放受控 git shim **之前**加入阳性对照断言——`HEAD` 确实等于 stale 的 `expectedPreviousHead`；stale head 与推进后的 head 确实是两个不同 commit；stale head 确实是推进后 head 的祖先；最终 session commit 的父节点恰好是受控推进的那个 head；最终树一致。只有这些都成立，才去断言回执。
- 无生产代码改动。diff 就是一个测试文件：86 行新增、5 行删除。

## 任务与范围

- Harness 任务：`task_01KZDG6BR9V43GS7PGG8YCPPGB`
- 分支：`codex/canonical-pub-race`
- 公开范围：`packages/cli/test/` 下一个 integration tier 测试文件
- 私有计划 / 证据是否已更新：yes
- 范围外：ancestry-aware publication proof 的重新设计本身。本 PR 只造"用来判它的仪器"，不改 `publication-evidence.ts`，不改任何 proof 逻辑。

## 版本影响

- 版本：不改版本，原因是本 PR 只加测试断言，不出运行时代码。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用。node 测试 tier manifest 是**发现式**的（遍历目录读 `// harness-test-tier:` 标记），改一个已注册的测试文件不需要改 manifest。已用 `npm run test:list` 核实，该文件解析到 `integration` tier。
- 依据：`task_01KZDG6BR9V43GS7PGG8YCPPGB`。关联决策 `dec_01KZD29A3BBMH05G6H8002MEH7`（"观察期后独立评审 ancestry-aware canonical publication proof"）当前 state 是 `proposed`，**故意保持未裁决**；本 PR 是它的证据来源，不是它的结论。合并这个测试不等于裁了那个决策。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：观察期结束后裁决 `dec_01KZD29A3BBMH05G6H8002MEH7`。

## 验证

- `origin/main` 基准 SHA：`bc414b48b80ef8ed7a052caa0dbb2ac73fe4bcd9`
- 当前分支与 `origin/main` 的 merge-base：`bc414b48b80ef8ed7a052caa0dbb2ac73fe4bcd9`（基于最新 main）
- 最近一次 `git fetch origin` 时间：`2026-08-07T15:14:42Z`
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...codex/canonical-pub-race`
- 私有证据 commit/path：记录在 `task_01KZDG6BR9V43GS7PGG8YCPPGB` 的任务包内
- Reviewer 证据路径：同上任务包
- GitHub Actions `rewrite-ci` run URL：待补，跑完后贴到本 PR
- [x] `git diff --check` —— 干净
- [ ] `npm run check:stop-point` —— 本分支未跑，见"未跑项及原因"
- [ ] 改动面的定向测试，写明测试名与通过数：**本地未跑**，见"未跑项及原因"
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）—— 待跑
- 未跑项及原因：
  - **该测试的本地定向运行：没做。** 文件带 `// harness-test-tier: integration`，而 integration tier 按设计不在 `check:stop-point` 内（停止点自己就写着："Not covered by design: integration and nightly tiers"）。并且 tier runner **点不了单个文件**：`parseRunnerArgs` 会给每个 `--prefix` 补一个尾部 `/`，完整文件名变成 `…test.ts/` 后匹配 0 个文件，**却仍然退出 0**。要选中它只能给目录前缀 `packages/cli/test/`，那会把该目录整个 integration tier 拉进来——对一个单文件测试改动不是成比例的停止点。这一层的权威在 CI。
  - **这个测试从未在 Linux 上跑过。** 在本 PR 的 `rewrite-ci` 出结果之前，任何关于它在 CI runner 上行为的说法都是未经验证的。Reviewer 应把 CI 结果、而不是本 PR 正文，当作 Linux 行为的第一份证据。
  - **mutation 证据是继承来的，本次会话没有重跑。** 任务台账记录：把生产修复回退，断言会翻（`+ 'journal_unavailable'` / `- 'write_rejected'`）。准备本 PR 时我没有独立复现这次 mutation 检查，所以这里按"台账记录"报，而不是按"本次实测"报。

## 审查证据

- 自查：已确认分支基于最新 `origin/main`、`git diff --check` 干净、diff 恰好只碰一个文件、该文件经 `npm run test:list` 解析到 `integration` tier。
- Reviewer subagent：本 PR 无。
- 人工审查：待做。
- 阻塞发现：无 open 项。

## 残余风险

- 最大的残余风险是：这个测试在 CI 上因为**错误的理由**转绿——窗口进去了，但回执断言比我们以为的更弱。前置断言的设计意图就是让这种失效模式暴露出来，但只有在 CI 上跑一次 mutation 才能真正证明。想要这份证明的 reviewer，应当要求在临时分支上做一次刻意回退再跑，而不是相信一次绿。
- 该测试会构造受控 git shim 和 daemon fixture。如果 CI runner 的串行化方式与本地不同，shim 握手可能超时，表现成 flake 而不是清晰的失败。第一次 CI 结果要带着这个前提读。

## 关联材料

- 任务：`task_01KZDG6BR9V43GS7PGG8YCPPGB`
- 证据：上述任务包；`dec_01KZD29A3BBMH05G6H8002MEH7`（state 为 `proposed`）
- 审查：本 PR
