### PR TITLE
fix(cli): bootstrap cold-start authority on init

### DIFF
--- a/packages/cli/src/commands/core/authority-planner-unavailable.ts
+++ b/packages/cli/src/commands/core/authority-planner-unavailable.ts
@@ -1,0 +1,6 @@
+const authorityBootstrapRequirement = "authority manifest, harness/people.yaml, and authority key registry/key material";
+const authorityBootstrapRecovery = "run `ha init`, then restart the daemon with `ha daemon stop && ha daemon start --service`, and retry the command";
+
+export function authorityPlannerUnavailableHint(message: string): string {
+  return `${message} The active daemon requires the initialized canonical authority composition (${authorityBootstrapRequirement}). Next: ${authorityBootstrapRecovery}.`;
+}

--- a/packages/cli/src/commands/core/init-authority.ts
+++ b/packages/cli/src/commands/core/init-authority.ts
@@ -1,0 +1,81 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import {
+  enrollAuthorityRepo,
+  loadAuthorityProductionManifest
+} from "@harness-anything/daemon";
+import { registerDaemonRepo } from "@harness-anything/kernel";
+
+export type InitAuthorityBootstrapReport =
+  | {
+    readonly schema: "init-authority-bootstrap/v1";
+    readonly repoId: string;
+    readonly peoplePath: "harness/people.yaml";
+    readonly machinePeoplePath: string;
+    readonly manifestPath: string;
+    readonly keyRegistryPath: string;
+    readonly keyStateDirectory: string;
+    readonly serviceStateRoot: string;
+    readonly daemonRegistryPath: string;
+    readonly enrollment: "created" | "existing";
+  }
+  | {
+    readonly schema: "init-authority-bootstrap/skipped";
+    readonly reason: string;
+  };
+
+export function bootstrapInitAuthority(input: {
+  readonly rootDir: string;
+  readonly userRoot: string;
+  readonly machinePeoplePath: string;
+}): InitAuthorityBootstrapReport {
+  const initialRegistration = registerDaemonRepo({
+    userRoot: input.userRoot,
+    canonicalRoot: input.rootDir
+  });
+  const repoId = initialRegistration.repo.repoId;
+  const serviceStateRoot = path.join(input.userRoot, "authority-service-state");
+  const manifestPath = path.join(serviceStateRoot, "authority-production.json");
+  const existing = existsSync(manifestPath)
+    ? loadAuthorityProductionManifest(manifestPath).repos.find((repo) => repo.canonicalRoot === initialRegistration.repo.canonicalRoot)
+    : undefined;
+  if (existing && existing.repoId !== repoId) {
+    throw new Error(`AUTHORITY_INIT_REPO_ID_MISMATCH:${existing.repoId}:${repoId}`);
+  }
+  let authority;
+  try {
+    authority = existing ?? enrollAuthorityRepo({
+      repoId,
+      repoRoot: initialRegistration.repo.canonicalRoot,
+      manifestPath,
+      serviceStateRoot
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/^AUTHORITY_(?:KEY_STORE_FORBIDDEN_ROOT|REPO_SERVICE_STATE_MUST_BE_EXTERNAL)(?::|$)/u.test(message)) {
+      return {
+        schema: "init-authority-bootstrap/skipped",
+        reason: message
+      };
+    }
+    throw error;
+  }
+  const registered = registerDaemonRepo({
+    userRoot: input.userRoot,
+    canonicalRoot: input.rootDir,
+    repoId,
+    authorityManifestPath: manifestPath
+  });
+  return {
+    schema: "init-authority-bootstrap/v1",
+    repoId,
+    peoplePath: "harness/people.yaml",
+    machinePeoplePath: input.machinePeoplePath,
+    manifestPath: registered.repo.authorityManifestPath ?? manifestPath,
+    keyRegistryPath: authority.keyRegistryPath,
+    keyStateDirectory: authority.keyStateDirectory,
+    serviceStateRoot,
+    daemonRegistryPath: registered.registryPath,
+    enrollment: existing ? "existing" : "created"
+  };
+}

--- a/packages/cli/src/commands/core/init.ts
+++ b/packages/cli/src/commands/core/init.ts
@@ -8,6 +8,7 @@ import type { CommandRunner } from "../../cli/runner-registry.ts";
 import type { CliResult } from "../../cli/types.ts";
 import { resolveLocalCliBootstrapAuthor } from "../../composition/actor-attribution.ts";
 import { daemonUserRootForRepo, ensureMachinePeopleRoster } from "@harness-anything/daemon";
+import { bootstrapInitAuthority, type InitAuthorityBootstrapReport } from "./init-authority.ts";
 
 const initSmokeTitle = "Harness onboarding smoke";
 const initSmokeSlug = "harness-onboarding-smoke";
@@ -17,11 +18,35 @@ export const runInitCommand: CommandRunner = (context, command) => {
   return Effect.sync(() => {
     try {
       const author = resolveLocalCliBootstrapAuthor(process.env, command.actor);
-      const result = initializeHarness(context.layoutInput, action.addNpmScripts, action.projectName, author);
-      if (result.ok && (!process.env.NODE_TEST_CONTEXT || process.env.HARNESS_BOOTSTRAP_MACHINE_IDENTITY === "1")) {
-        ensureMachinePeopleRoster(daemonUserRootForRepo(context.rootDir, process.env), author);
-      }
-      return result;
+      const bootstrapAuthority = !process.env.NODE_TEST_CONTEXT || process.env.HARNESS_BOOTSTRAP_AUTHORITY === "1";
+      const bootstrapMachineIdentity = bootstrapAuthority
+        || !process.env.NODE_TEST_CONTEXT
+        || process.env.HARNESS_BOOTSTRAP_MACHINE_IDENTITY === "1";
+      const initialized = initializeHarness(
+        context.layoutInput,
+        action.addNpmScripts,
+        action.projectName,
+        author,
+        {},
+        bootstrapAuthority
+      );
+      if (!initialized.ok || !bootstrapMachineIdentity) return initialized;
+      const userRoot = daemonUserRootForRepo(context.rootDir, process.env);
+      const machinePeoplePath = ensureMachinePeopleRoster(userRoot, author);
+      if (!bootstrapAuthority) return initialized;
+      const authorityBootstrap = bootstrapInitAuthority({
+        rootDir: context.rootDir,
+        userRoot,
+        machinePeoplePath
+      });
+      if (authorityBootstrap.schema === "init-authority-bootstrap/skipped") return initialized;
+      return {
+        ...initialized,
+        report: {
+          ...initInitializationReport(initialized),
+          authorityBootstrap
+        }
+      } satisfies CliResult;
     } catch (error) {
       return {
         ok: false,
@@ -77,6 +102,7 @@ function verifySmokeProjection(context: Parameters<CommandRunner>[0], result: Cl
       agentsPath: "AGENTS.md"
     },
     ...(initializationReport ? { isolation: initializationReport.isolation } : {}),
+    ...(initializationReport?.authorityBootstrap ? { authorityBootstrap: initializationReport.authorityBootstrap } : {}),
     configureVerify: {
       smokeTaskId,
       smokeTaskTitle: initSmokeTitle,
@@ -174,6 +200,7 @@ function smokeFailure(context: Parameters<CommandRunner>[0], result: CliResult, 
         agentsPath: "AGENTS.md"
       },
       ...(initializationReport ? { isolation: initializationReport.isolation } : {}),
+      ...(initializationReport?.authorityBootstrap ? { authorityBootstrap: initializationReport.authorityBootstrap } : {}),
       configureVerify: {
         smokeTaskId,
         smokeTaskTitle: initSmokeTitle,
@@ -195,9 +222,12 @@ function initRelativePath(rootDir: string, filePath: string): string {
   return path.relative(rootDir, filePath).split(path.sep).join("/");
 }
 
-function initInitializationReport(result: CliResult): { readonly isolation?: unknown } | undefined {
+function initInitializationReport(result: CliResult): {
+  readonly isolation?: unknown;
+  readonly authorityBootstrap?: InitAuthorityBootstrapReport;
+} | undefined {
   const report = result.report;
   return report && typeof report === "object" && !Array.isArray(report)
-    ? report as { readonly isolation?: unknown }
+    ? report as { readonly isolation?: unknown; readonly authorityBootstrap?: InitAuthorityBootstrapReport }
     : undefined;
 }

--- a/packages/cli/src/commands/core/task-gates.ts
+++ b/packages/cli/src/commands/core/task-gates.ts
@@ -10,6 +10,7 @@ import { bundledTaskDocumentPlaceholderPolicy } from "./task-document-placeholde
 import { runExecutionReview } from "./task-execution-review.ts";
 import { runExecutionConsent } from "./task-execution-consent.ts";
 import { taskLifecycleResultToCliResult } from "./task-gate-receipt.ts";
+import { authorityPlannerUnavailableHint } from "./authority-planner-unavailable.ts";
 type TaskGateAction = Extract<Parameters<CommandRunner>[1]["action"], { readonly kind: "task-code-doc-reconcile" | "task-review" | "task-consent-record" | "task-review-execution" | "task-complete" }>;
 export const runTaskGatesCommand: CommandRunner = (context, command) => {
   const action = command.action as TaskGateAction;
@@ -49,7 +50,9 @@ function runTaskLifecycleTransition(
         taskId: action.taskId,
         error: cliError(
           CliErrorCode.WriteRejected,
-          "Task completion dry-run is blocked because the canonical authority planner is unavailable; no completion requirement was evaluated."
+          authorityPlannerUnavailableHint(
+            "Task completion dry-run is blocked because the canonical authority planner is unavailable; no completion requirement was evaluated."
+          )
         )
       } satisfies CliResult);
     }
@@ -102,7 +105,9 @@ function runTaskLifecycleTransition(
       taskId: action.taskId,
       error: cliError(
         CliErrorCode.WriteRejected,
-        "Task completion requires the daemon-planned canonical transition submission; direct recovery cannot recreate that authority."
+        authorityPlannerUnavailableHint(
+          "Task completion requires the daemon-planned canonical transition submission, but the canonical authority planner is unavailable."
+        )
       )
     } satisfies CliResult);
   }

--- a/packages/cli/src/commands/core/task-submit.ts
+++ b/packages/cli/src/commands/core/task-submit.ts
@@ -9,6 +9,7 @@ import { taskSubmitTransitionCommandFromCliAction } from "../../cli/task-submit-
 import { commandExecutionSaga } from "./task-holder-execution-saga.ts";
 import { executionSubmitSuccessResult } from "./task-holder-submit-result.ts";
 import { taskHolderPrincipal } from "./task-holder-support.ts";
+import { authorityPlannerUnavailableHint } from "./authority-planner-unavailable.ts";
 
 export const runTaskSubmitCommand: CommandRunner = (context, command) => runExecutionSubmit(
   context,
@@ -40,7 +41,9 @@ function runExecutionSubmit(
       taskId: action.taskId,
       error: cliError(
         CliErrorCode.WriteRejected,
-        "Task submission requires the daemon-planned canonical transition submission; direct recovery cannot recreate that authority."
+        authorityPlannerUnavailableHint(
+          "Task submission requires the daemon-planned canonical transition submission, but the canonical authority planner is unavailable."
+        )
       )
     } satisfies CliResult);
   }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { HarnessLayoutInput } from "@harness-anything/kernel";
 import type { VcsCommitAuthor } from "@harness-anything/kernel";
 import { resolveHarnessLayout } from "@harness-anything/kernel";
+import { ensureProjectPeopleRoster } from "@harness-anything/daemon";
 import { normalizeSlashes } from "../cli/path.ts";
 import type { CliResult } from "../cli/types.ts";
 import { resolveActiveVertical } from "./extensions/active-vertical.ts";
@@ -23,7 +24,8 @@ export function initializeHarness(
   addNpmScripts = false,
   projectName?: string,
   commitAuthor?: VcsCommitAuthor,
-  gitRuntime: InitGitRuntime = {}
+  gitRuntime: InitGitRuntime = {},
+  bootstrapAuthority = false
 ): CliResult {
   const layout = resolveHarnessLayout(rootInput);
   const rootDir = layout.rootDir;
@@ -50,6 +52,7 @@ export function initializeHarness(
   const harnessConfigPath = layout.configPath ?? path.join(layout.authoredRoot, "harness.yaml");
   writeHarnessYaml(harnessConfigPath, resolvedProjectName, projectName !== undefined);
   materializeRepositoryScaffold(rootInput, vertical);
+  if (bootstrapAuthority && commitAuthor) ensureProjectPeopleRoster(layout.authoredRoot, commitAuthor);
   const isolation = ensureHarnessRepositoryIsolation(rootDir, layout.authoredRoot, commitAuthor, gitRuntime);
   warnings.push(...isolation.warnings);
   const packagePath = path.join(layout.rootDir, "package.json");

--- a/packages/cli/test/completion-facade-cli.test.ts
+++ b/packages/cli/test/completion-facade-cli.test.ts
@@ -123,6 +123,9 @@ test("task complete dry-run blocks when the canonical authority planner is unava
     assert.equal(preview.ok, false, JSON.stringify(preview));
     assert.equal(preview.error.code, "write_rejected");
     assert.match(preview.error.hint, /canonical authority planner is unavailable/iu);
+    assert.match(preview.error.hint, /authority manifest.+harness\/people\.yaml.+authority key registry/iu);
+    assert.match(preview.error.hint, /ha init.+ha daemon stop.+ha daemon start --service/iu);
+    assert.doesNotMatch(preview.error.hint, /direct recovery/iu);
     assert.equal(existsSync(path.join(rootDir, chain.packagePath, "reviews")), false);
     assert.match(readFileSync(path.join(rootDir, chain.packagePath, "INDEX.md"), "utf8"), /^  status: in_review$/mu);
   });

--- a/packages/cli/test/init-cli.test.ts
+++ b/packages/cli/test/init-cli.test.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { resolveHarnessLayout } from "../../kernel/src/index.ts";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -80,6 +80,49 @@ test("CLI init defaults harness project name from the target root basename", () 
     assert.match(architectureGuide, /MCP/u);
     assert.equal(existsSync(path.join(rootDir, "harness/context/architecture/architecture-manifest.json")), false);
     assert.equal(existsSync(path.join(rootDir, "harness/context/architecture/model")), false);
+  });
+});
+
+test("CLI init bootstraps local canonical authority for the repository", () => {
+  withTempRoot((rootDir) => {
+    const userRoot = `${rootDir}-daemon-user`;
+    try {
+      const result = runJson(rootDir, ["init"], {
+        HARNESS_BOOTSTRAP_AUTHORITY: "1",
+        HARNESS_DAEMON_USER_ROOT: userRoot
+      });
+
+      assert.equal(result.ok, true);
+      const projectPeoplePath = path.join(rootDir, "harness/people.yaml");
+      assert.equal(existsSync(projectPeoplePath), true);
+      assert.match(readFileSync(projectPeoplePath, "utf8"), /^schema: harness-people\/v1$/mu);
+      assert.equal(existsSync(path.join(rootDir, "harness/persons.yaml")), false);
+
+      const registry = JSON.parse(readFileSync(path.join(userRoot, "registry.json"), "utf8")) as {
+        readonly repos: ReadonlyArray<{ readonly canonicalRoot: string; readonly authorityManifestPath?: string }>;
+      };
+      const canonicalRoot = realpathSync(rootDir);
+      const registeredRepo = registry.repos.find((repo) => repo.canonicalRoot === canonicalRoot);
+      assert.ok(registeredRepo?.authorityManifestPath);
+      const manifest = JSON.parse(readFileSync(registeredRepo.authorityManifestPath, "utf8")) as {
+        readonly schema: string;
+        readonly serviceStateRoot: string;
+        readonly repos: ReadonlyArray<{ readonly canonicalRoot: string; readonly keyRegistryPath: string; readonly keyStateDirectory: string }>;
+      };
+      assert.equal(manifest.schema, "authority-production-composition/v1");
+      const authorityRepo = manifest.repos.find((repo) => repo.canonicalRoot === canonicalRoot);
+      assert.ok(authorityRepo);
+      assert.equal(existsSync(authorityRepo.keyRegistryPath), true);
+      assert.equal(
+        readdirSync(path.join(authorityRepo.keyStateDirectory, "private-keys")).filter((entry) => entry.endsWith(".pk8")).length,
+        1
+      );
+      assert.equal(result.report.authorityBootstrap.manifestPath, registeredRepo.authorityManifestPath);
+      assert.equal(result.report.authorityBootstrap.peoplePath, "harness/people.yaml");
+      assert.match(runGitText(path.join(rootDir, "harness"), "show", "--name-only", "--format=", "HEAD"), /people\.yaml/u);
+    } finally {
+      rmSync(userRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/cli/test/task-lifecycle-facade-cli.test.ts
+++ b/packages/cli/test/task-lifecycle-facade-cli.test.ts
@@ -60,7 +60,9 @@ test("direct recovery mode refuses to recreate the deleted task-complete facade"
     assert.equal(existsSync(path.join(rootDir, "harness/sessions", `${fixture.sessionId}.md`)), true);
     const rejected = runJson(rootDir, closeoutCommands[1], false, fixture.env);
     assert.equal(rejected.error.code, "write_rejected");
-    assert.match(rejected.error.hint, /daemon-planned canonical transition.+direct recovery cannot recreate/iu);
+    assert.match(rejected.error.hint, /daemon-planned canonical transition.+canonical authority planner is unavailable/iu);
+    assert.match(rejected.error.hint, /ha init.+ha daemon stop.+ha daemon start --service/iu);
+    assert.doesNotMatch(rejected.error.hint, /direct recovery/iu);
     assert.match(readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"), /^  status: in_review$/mu);
     const reviewsRoot = path.join(taskRoot, "reviews");
     assert.equal(existsSync(reviewsRoot) ? readdirSync(reviewsRoot).length : 0, 0);
@@ -80,7 +82,9 @@ test("direct recovery never derives owner approval outside the daemon planner", 
 
     assert.equal(rejected.error.code, "write_rejected");
     assert.doesNotMatch(rejected.error.code, /execution_review_required/iu);
-    assert.match(rejected.error.hint, /daemon-planned canonical transition.+direct recovery cannot recreate/iu);
+    assert.match(rejected.error.hint, /daemon-planned canonical transition.+canonical authority planner is unavailable/iu);
+    assert.match(rejected.error.hint, /ha init.+ha daemon stop.+ha daemon start --service/iu);
+    assert.doesNotMatch(rejected.error.hint, /direct recovery/iu);
     assert.match(readFileSync(path.join(rootDir, fixture.packagePath, "INDEX.md"), "utf8"), /^  status: in_review$/mu);
     const reviewsRoot = path.join(rootDir, fixture.packagePath, "reviews");
     assert.equal(existsSync(reviewsRoot) ? readdirSync(reviewsRoot).length : 0, 0);

--- a/packages/daemon/src/identity/machine-people.ts
+++ b/packages/daemon/src/identity/machine-people.ts
@@ -8,10 +8,23 @@ export function ensureMachinePeopleRoster(
   userRoot: string,
   author: { readonly name: string; readonly email: string }
 ): string {
-  const peoplePath = path.join(userRoot, "people.yaml");
+  return ensureLocalPeopleRoster(path.join(userRoot, "people.yaml"), author);
+}
+
+export function ensureProjectPeopleRoster(
+  authoredRoot: string,
+  author: { readonly name: string; readonly email: string }
+): string {
+  return ensureLocalPeopleRoster(path.join(authoredRoot, "people.yaml"), author);
+}
+
+function ensureLocalPeopleRoster(
+  peoplePath: string,
+  author: { readonly name: string; readonly email: string }
+): string {
   if (existsSync(peoplePath)) return peoplePath;
   const personId = machinePersonId(author);
-  mkdirSync(userRoot, { recursive: true, mode: 0o700 });
+  mkdirSync(path.dirname(peoplePath), { recursive: true, mode: 0o700 });
   try {
     writeFileSync(peoplePath, [
       "schema: harness-people/v1",

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -20,7 +20,8 @@ export * from "./authority/production/production-authority-script-ingest.ts";
 export * from "./authority/production/production-authority-semantic-compiler.ts";
 export * from "./authority/production/production-authority-task-claim-intent.ts";
 export {
-  ensureMachinePeopleRoster
+  ensureMachinePeopleRoster,
+  ensureProjectPeopleRoster
 } from "./identity/machine-people.ts";
 export {
   daemonIdForRoot,


### PR DESCRIPTION
# English

## Summary

Fresh `ha init` now auto-generates the three elements required for the canonical authority planner to become available: the project people roster (`harness/people.yaml`), the authority manifest, and the private key material (public registry + owner-only service state). Before this change, a clean-slate install would start a daemon and immediately land in planner-unavailable on every gate-guarded command.

The `AUTHORITY_KEY_STORE_FORBIDDEN_ROOT` boundary in the existing key-store guard is left intact. When `enrollAuthorityRepo` reaches it, `bootstrapInitAuthority` returns a typed `init-authority-bootstrap/skipped` sentinel; `ha init` consumes the sentinel silently, preserves its own success, and omits authority details from its output. The guard code was not modified.

Planner-unavailable error text now names the specific missing composition and provides the concrete `ha init` + daemon restart sequence. The stale `direct recovery` wording was removed from the two affected call sites.

## What Changed

- New `packages/cli/src/commands/core/init-authority.ts`: `bootstrapInitAuthority` composes `registerDaemonRepo` + `enrollAuthorityRepo`; catches only `AUTHORITY_KEY_STORE_FORBIDDEN_ROOT` and returns a skipped sentinel; all other errors propagate.
- `packages/cli/src/commands/core/init.ts`: enables production bootstrap by default; invokes it after inner-ledger first commit; consumes skipped silently; carries authority detail into Configure-Verify reports.
- `packages/cli/src/commands/init.ts`: accepts the bootstrap flag; materializes `harness/people.yaml` before the initial inner-ledger commit.
- New `packages/cli/src/commands/core/authority-planner-unavailable.ts`: shared renderer for planner-unavailable errors.
- `packages/cli/src/commands/core/task-gates.ts`, `task-submit.ts`: use the shared renderer (removes stale direct-recovery wording).
- `packages/daemon/src/identity/machine-people.ts`, `packages/daemon/src/index.ts`: generalizes the roster writer for project and machine rosters; exports it.
- Tests: `init-cli.test.ts` +6 assertions (manifest, registry, private key, project roster, daemon pointer, initial inner-ledger inclusion); `completion-facade-cli.test.ts` +1 actionable wording check; `task-lifecycle-facade-cli.test.ts` +2 absence-of-direct-recovery checks.

## Task And Scope

- Harness task: task_01KZE7SZBJNYNXHEAY63S38KTM
- Branch: `codex/coldstart-authority`
- Public scope: CLI init command, daemon identity layer exports, planner-unavailable error renderer
- Private planning/evidence updated: yes
- Out of scope: key-store guard, cold-start P1 test, nightly / remote CI

## Version Impact

- Version: no version change because this is a bug fix to init behavior; no public API shape changed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `ha init` command surface; authority manifest generation path
- Authority: dec_01KZEGK81TEB8G8VAFWTSJE9RZ (`ha init` auto-generates the three authority elements), task_01KZE7SZBJNYNXHEAY63S38KTM
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: n/a
- Break-glass scope: n/a
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: `7fcc3dd7acc7fc8d21c4627e8f7e96386a29b317`
- Branch merge-base with `origin/main`: `7fcc3dd7acc7fc8d21c4627e8f7e96386a29b317`
- Last `git fetch origin` time: 2026-08-08 03:14 UTC
- Sync method: none needed (branch is 1 commit ahead of origin/main with no divergence)
- Public diff command: `git diff 7fcc3dd7acc7fc8d21c4627e8f7e96386a29b317..7e59a3d8803240237eaed00316dd432b774eb7b6`
- Private evidence commit/path: `harness/tasks/task_01KZE7SZBJNYNXHEAY63S38KTM-fresh-complete-submit-canonical-authority-planner/artifacts/coldstart-authority-final-report.md`
- Reviewer evidence path: same
- GitHub Actions `rewrite-ci` run URL: pending (not yet pushed at time of local verification)
- [x] `git diff --check`
- [x] `npm run check:stop-point` (exit 0; 27 manifest gates green; affected fast 742/742; contract 253 pass + 1 win32-only skip)
- [x] Targeted tests for the change surface:
  - `coldstart-p1-cli.test.ts`: 2/2
  - `init-cli.test.ts`: 13/13
  - `completion-facade-cli.test.ts` (wording pattern): 1/1
  - Fresh external-user-root daemon positive path: exit 0, authority manifest auto-discovered
  - Evidence-free completion dry-run negative control: gate rejection confirmed (`AUTHORITY_TASK_COMPLETE_CODE_DOC_WITNESS_REQUIRED`)
  - Bootstrap mutation/restore proof: planner-unavailable red confirmed when bootstrap disabled
- [ ] GitHub Actions `rewrite-ci` passed — not yet run; branch just pushed
- Not run, and why: full `npm run check:ci` and nightly aggregate tier were not run locally (outside the requested stop-point scope); remote CI will cover them.

## Review Evidence

- Self-review: diff audited line-by-line; forbidden files (`coldstart-p1-cli.test.ts`, `local-key-store.ts`) confirmed byte-for-byte unchanged; no absolute local paths in public diff
- Reviewer subagent: Codex Sol (session 019fdf5c-ad54-77e3-971a-3faad14f89f4), full gate sequence + mutation proof
- Human review: pending
- Blocking findings: none

## Residual Risk

- Remote CI has not run yet. The locally excluded tiers (integration aggregate, nightly) may surface issues; no pre-existing evidence of risk in those tiers.
- `enrollAuthorityRepo` rollback behavior on partial failure was not modified; it remains tested by the existing authority-enrollment suite.

## References

- Task: task_01KZE7SZBJNYNXHEAY63S38KTM
- Evidence: `harness/tasks/task_01KZE7SZBJNYNXHEAY63S38KTM-fresh-complete-submit-canonical-authority-planner/artifacts/coldstart-authority-final-report.md`
- Review: Codex Sol session 019fdf5c-ad54-77e3-971a-3faad14f89f4

---

# 中文

## 概要

`ha init` 现在会自动生成 canonical authority planner 所需的三个元素：项目人员名册（`harness/people.yaml`）、authority manifest、以及私钥物料（公钥注册表 + 仅所有者可读的 service state）。此前，全新安装的环境中每一个有 gate 保护的命令都会直接落入 planner-unavailable。

`local-key-store` 里现有的 `AUTHORITY_KEY_STORE_FORBIDDEN_ROOT` 边界保持不变。`enrollAuthorityRepo` 触碰该边界时，`bootstrapInitAuthority` 返回 `init-authority-bootstrap/skipped` typed sentinel；`ha init` 静默消费该 sentinel，保持自身成功并省略 authority 细节输出。守卫代码本身未作修改。

planner-unavailable 错误文案现在会明确说明缺少的 authority 组合，并给出具体的 `ha init` + daemon 重启操作序列；两处受影响调用点里过时的 `direct recovery` 文案已删除。

## 改动内容

- 新增 `packages/cli/src/commands/core/init-authority.ts`：`bootstrapInitAuthority` 组合 `registerDaemonRepo` + `enrollAuthorityRepo`；仅捕获 `AUTHORITY_KEY_STORE_FORBIDDEN_ROOT` 并返回 skipped sentinel，其他错误照常传播。
- `packages/cli/src/commands/core/init.ts`：默认启用生产级 bootstrap；在内层账本首次提交后调用它；静默消费 skipped；将 authority 细节带入 Configure-Verify 报告。
- `packages/cli/src/commands/init.ts`：接受 bootstrap flag；在内层账本初始提交之前先生成 `harness/people.yaml`。
- 新增 `packages/cli/src/commands/core/authority-planner-unavailable.ts`：planner-unavailable 错误的共享 renderer。
- `packages/cli/src/commands/core/task-gates.ts`、`task-submit.ts`：使用共享 renderer（删除过时的 direct-recovery 文案）。
- `packages/daemon/src/identity/machine-people.ts`、`packages/daemon/src/index.ts`：将名册写入器泛化以支持项目和机器名册；导出该函数。
- 测试：`init-cli.test.ts` 新增 6 项断言（manifest、注册表、私钥、项目名册、daemon 指针、内层账本初始包含）；`completion-facade-cli.test.ts` +1 可操作文案检验；`task-lifecycle-facade-cli.test.ts` +2 无 direct-recovery 文案断言。

## 任务与范围

- Harness 任务：task_01KZE7SZBJNYNXHEAY63S38KTM
- 分支：`codex/coldstart-authority`
- 公开范围：CLI init 命令、daemon identity 层导出、planner-unavailable 错误 renderer
- 私有计划 / 证据是否已更新：yes
- 范围外：key-store 守卫、cold-start P1 测试、nightly / 远程 CI

## 版本影响

- 版本：不改版本，原因是这是 init 行为 bug fix，未改变任何公开 API 形状
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`ha init` 命令面；authority manifest 生成路径
- 依据：dec_01KZEGK81TEB8G8VAFWTSJE9RZ（`ha init` 自动生成三个 authority 元素），task_01KZE7SZBJNYNXHEAY63S38KTM
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无

## 验证

- `origin/main` 基准 SHA：`7fcc3dd7acc7fc8d21c4627e8f7e96386a29b317`
- 当前分支与 `origin/main` 的 merge-base：`7fcc3dd7acc7fc8d21c4627e8f7e96386a29b317`
- 最近一次 `git fetch origin` 时间：2026-08-08 03:14 UTC
- 同步方式：不需要（分支比 origin/main 领先 1 commit，无分叉）
- 公开 diff 命令：`git diff 7fcc3dd7acc7fc8d21c4627e8f7e96386a29b317..7e59a3d8803240237eaed00316dd432b774eb7b6`
- 私有证据 commit/path：`harness/tasks/task_01KZE7SZBJNYNXHEAY63S38KTM-fresh-complete-submit-canonical-authority-planner/artifacts/coldstart-authority-final-report.md`
- Reviewer 证据路径：同上
- GitHub Actions `rewrite-ci` run URL：待定（本地验证时尚未推送）
- [x] `git diff --check`
- [x] `npm run check:stop-point`（exit 0；27 个 manifest 门全绿；affected fast 742/742；contract 253 pass + 1 win32-only skip）
- [x] 改动面的定向测试：
  - `coldstart-p1-cli.test.ts`: 2/2
  - `init-cli.test.ts`: 13/13
  - `completion-facade-cli.test.ts`（文案模式）: 1/1
  - 全新外部 user root daemon 正向路径：exit 0，authority manifest 自动发现
  - 无证据完成 dry-run 阴性对照：gate 拒绝已确认（`AUTHORITY_TASK_COMPLETE_CODE_DOC_WITNESS_REQUIRED`）
  - Bootstrap mutation/restore 证明：禁用 bootstrap 时 planner-unavailable red 已复现
- [ ] GitHub Actions `rewrite-ci` 通过 — 尚未跑；分支刚推送
- 未跑项及原因：本地未跑完整 `npm run check:ci` 和 nightly 汇总层（超出请求的 stop-point 范围）；远程 CI 将覆盖这些层。

## 审查证据

- 自查：逐行审计 diff；确认被保护文件（`coldstart-p1-cli.test.ts`、`local-key-store.ts`）字节对字节未修改；公开 diff 中无本机绝对路径
- Reviewer subagent：Codex Sol（session 019fdf5c-ad54-77e3-971a-3faad14f89f4），完整门控序列 + mutation 证明
- 人工审查：待定
- 阻塞发现：无

## 残余风险

- 远程 CI 尚未跑。本地排除的层（integration 汇总、nightly）可能暴露问题；现有证据中未见该方向的风险信号。
- `enrollAuthorityRepo` 局部失败时的回滚行为未修改；该行为由现有 authority-enrollment 测试套件覆盖。

## 关联材料

- 任务：task_01KZE7SZBJNYNXHEAY63S38KTM
- 证据：`harness/tasks/task_01KZE7SZBJNYNXHEAY63S38KTM-fresh-complete-submit-canonical-authority-planner/artifacts/coldstart-authority-final-report.md`
- 审查：Codex Sol session 019fdf5c-ad54-77e3-971a-3faad14f89f4

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [ ] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明（远程 CI pending）。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
