### PR TITLE
fix(cli): restore doc sync diagnostic chain

### DIFF
--- a/packages/application/test/task-decision-module-semantic-compiler-v2.test.ts
+++ b/packages/application/test/task-decision-module-semantic-compiler-v2.test.ts
@@ -145,7 +145,7 @@ test("host-prose policies allow undeclared sections without weakening their decl
   }, {
     documents: [index, { path: documentPath, body: managedBody("Plan", "## Purpose", "Old") }]
   }, [policy], [{ kind: "task", semanticDiff: entityRegistry.task.semanticDiff }]),
-  /SEMANTIC_DIFF_AMBIGUOUS:section identity changed/u);
+  /SEMANTIC_DIFF_AMBIGUOUS:.*## Goal/u);
 });
 
 test("all task actions compile to one exact package-hosted StoragePlan", async () => {

--- a/packages/cli/src/cli/receipt.ts
+++ b/packages/cli/src/cli/receipt.ts
@@ -83,6 +83,7 @@ export function renderReceiptText(receipt: CommandReceiptEnvelope): string {
   if (receipt.command === "completion") return renderCompletionText(receipt);
   if (receipt.command === "capabilities") return renderCapabilitiesText(receipt);
   if (receipt.command === "preset list") return renderPresetListText(receipt);
+  if (receipt.command === "doc status") return renderDocStatusText(receipt);
   return renderSuccessReceiptText(receipt);
 }
 
@@ -152,6 +153,34 @@ function renderPresetListText(receipt: CommandReceipt): string {
     return [`${preset.id} — ${title} — ${description}`];
   });
   return [rows.length > 0 ? rows.join("\n") : "No presets installed.", renderSuccessReceiptText(receipt)].join("\n");
+}
+
+function renderDocStatusText(receipt: CommandReceipt): string {
+  const rows = (receipt.items ?? []).flatMap((item) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return [];
+    const dirtyFile = item as {
+      readonly path?: unknown;
+      readonly status?: unknown;
+      readonly unresolvedTouches?: unknown;
+      readonly forbiddenTouches?: unknown;
+    };
+    if (typeof dirtyFile.path !== "string") return [];
+    const details = [
+      ...(Array.isArray(dirtyFile.unresolvedTouches)
+        ? dirtyFile.unresolvedTouches.flatMap((touch) => {
+          if (!touch || typeof touch !== "object" || Array.isArray(touch)) return [];
+          const reason = (touch as { readonly reason?: unknown }).reason;
+          return typeof reason === "string" ? [`unresolved: ${reason}`] : [];
+        })
+        : []),
+      ...(Array.isArray(dirtyFile.forbiddenTouches) && dirtyFile.forbiddenTouches.length > 0
+        ? [`forbidden touch${dirtyFile.forbiddenTouches.length === 1 ? "" : "s"}`]
+        : []),
+      ...(dirtyFile.status === "deleted" ? ["deletion"] : [])
+    ];
+    return [`${dirtyFile.path}${details.length > 0 ? ` — ${details.join("; ")}` : ""}`];
+  });
+  return [rows.length > 0 ? rows.join("\n") : "No dirty files.", renderSuccessReceiptText(receipt)].join("\n");
 }
 
 function receiptWarningCode(value: unknown): string | undefined {
@@ -345,6 +374,7 @@ function summarizeResult(raw: Record<string, unknown>): string {
   const rows = typeof raw.rows === "number" ? raw.rows : undefined;
   const version = typeof raw.version === "string" ? raw.version : undefined;
 
+  if (command === "doc-status") return summarizeDocStatus(raw, rows);
   if (command === "materializer-run") return summarizeMaterializer(raw.report);
   if (command === "new-task" && taskId && packagePath) {
     const report = raw.report;
@@ -361,6 +391,17 @@ function summarizeResult(raw: Record<string, unknown>): string {
   if (rows !== undefined) return `completed ${displayCommand(command).command} with ${rows} row${rows === 1 ? "" : "s"}`;
   if (taskId) return `completed ${displayCommand(command).command} for ${taskId}`;
   return `completed ${displayCommand(command).command}`;
+}
+
+function summarizeDocStatus(raw: Record<string, unknown>, rows: number | undefined): string {
+  const report = raw.report;
+  if (!report || typeof report !== "object" || Array.isArray(report)) {
+    return `doc status: ${rows ?? 0} dirty, 0 blocked`;
+  }
+  const record = report as Record<string, unknown>;
+  const blocked = ["forbiddenTouches", "unresolvedTouches", "deletions"]
+    .reduce((total, key) => total + (Array.isArray(record[key]) ? record[key].length : 0), 0);
+  return `doc status: ${rows ?? 0} dirty, ${blocked} blocked`;
 }
 
 function summarizeMaterializer(report: unknown): string {
@@ -442,7 +483,7 @@ function entityFromData(kind: string | undefined, data: Record<string, unknown>)
 }
 
 function itemsFromData(data: Record<string, unknown>, report: Record<string, unknown> | undefined): ReadonlyArray<unknown> | undefined {
-  for (const key of ["items", "ops", "decisions", "tasks", "templates", "presets", "scripts", "modules", "commands"] as const) {
+  for (const key of ["items", "ops", "decisions", "tasks", "templates", "presets", "scripts", "modules", "commands", "dirtyFiles"] as const) {
     const value = report?.[key] ?? data[key];
     if (Array.isArray(value)) return value;
   }

--- a/packages/cli/test/doc-sync-cli.test.ts
+++ b/packages/cli/test/doc-sync-cli.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: integration
 import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -74,6 +74,43 @@ test("CLI doc status reports prose candidates and forbidden structured touches",
     assert.equal(rejected.error.code, "write_rejected");
     assert.match(rejected.error.hint, /preview is not ready/u);
     assert.notEqual(gitStatus(harnessRoot), "");
+  });
+});
+
+test("CLI doc sync exposes renamed anchor diagnostics and still accepts the restored anchor", async () => {
+  await withTempRoot(async (rootDir) => {
+    const harnessRoot = path.join(rootDir, "harness");
+    const taskId = "task_01KX3W4V1EDPHPTGWYYBQQ2J75";
+    const taskRoot = path.join(harnessRoot, "tasks", taskId);
+    mkdirSync(taskRoot, { recursive: true });
+    seedWriteRoadRegistry(rootDir);
+    writeFileSync(path.join(harnessRoot, "harness.yaml"), [
+      "schema: harness-anything/v1",
+      "settings:",
+      "  identity:",
+      "    personId: person_doc_sync",
+      "    displayName: Doc Sync User",
+      ""
+    ].join("\n"));
+    writeFileSync(path.join(taskRoot, "INDEX.md"), taskIndex());
+    writeFileSync(path.join(taskRoot, "task_plan.md"), taskPlan("Original prose."));
+    initHarnessGit(harnessRoot);
+
+    const renamedPlan = taskPlan("Updated prose.").replace("## Goal", "## Purpose");
+    writeFileSync(path.join(taskRoot, "task_plan.md"), renamedPlan);
+    const rejected = runJson(rootDir, ["doc", "sync", "--submit"], false);
+    assert.match(rejected.error?.hint ?? "", /## Goal/u);
+    assert.match(rejected.error?.hint ?? "", /deleted or renamed/u);
+
+    const statusText = runText(rootDir, ["doc", "status"]);
+    assert.match(statusText, new RegExp(`tasks/${taskId}/task_plan\\.md`));
+    assert.match(statusText, /SEMANTIC_DIFF_AMBIGUOUS.*## Goal/u);
+    assert.match(statusText, /summary="doc status: 1 dirty, 1 blocked"/u);
+
+    writeFileSync(path.join(taskRoot, "task_plan.md"), taskPlan("Updated prose."));
+    const submitted = runJson(rootDir, ["doc", "sync", "--submit"]);
+    assert.equal(submitted.ok, true);
+    assert.equal(submitted.report.status, "accepted");
   });
 });
 
@@ -441,4 +478,13 @@ function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = t
     const failure = error as { readonly stdout?: string };
     return unwrapCommandReceipt(JSON.parse(failure.stdout ?? "{}") as Record<string, any>);
   }
+}
+
+function runText(rootDir: string, args: ReadonlyArray<string>): string {
+  const result = spawnSync(process.execPath, [cliEntry, "--root", rootDir, ...args], {
+    encoding: "utf8",
+    env: cliTestEnv({ CODEX_THREAD_ID: "doc-sync-cli-test", HARNESS_ACTOR: "agent:doc-sync-cli-test", HARNESS_GIT_AUTHOR_NAME: "Harness Test", HARNESS_GIT_AUTHOR_EMAIL: "harness@example.test", HARNESS_DAEMON_MODE: "fixture", HARNESS_DAEMON_USER_ROOT: path.join(rootDir, ".daemon-user"), HARNESS_DAEMON_IDLE_MS: "250", GIT_CONFIG_GLOBAL: "/dev/null" })
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout;
 }

--- a/packages/cli/test/doc-sync-service.test.ts
+++ b/packages/cli/test/doc-sync-service.test.ts
@@ -184,7 +184,11 @@ test("doc sync rejects renamed task host-prose skeleton sections", async () => {
     });
 
     assert.equal(validation.ok, false);
-    assert.match(validation.unresolvedTouches[0]?.reason ?? "", /SEMANTIC_DIFF_AMBIGUOUS:section identity changed/u);
+    const reason = validation.unresolvedTouches[0]?.reason ?? "";
+    assert.match(reason, /SEMANTIC_DIFF_AMBIGUOUS:declared section ## Goal disappeared from submitted content .*\(it was deleted or renamed\)/u);
+    assert.match(reason, /keep the declared heading exactly as written/u);
+    assert.match(reason, /edit its body freely/u);
+    assert.match(reason, /new sections are allowed/u);
   });
 });
 

--- a/packages/daemon/src/service/doc-sync-service.ts
+++ b/packages/daemon/src/service/doc-sync-service.ts
@@ -131,9 +131,9 @@ export function buildDocSyncSubmitRequest(
   const deletions = report.deletions.filter((entry) => filePaths.has(entry.path));
   if (forbiddenTouches.length > 0 || unresolvedTouches.length > 0 || deletions.length > 0) {
     const scope = selected.size > 0 ? ` for selected path(s): ${[...selected].sort().join(", ")}` : "";
-    const blockers = [...forbiddenTouches.map((touch) => `forbidden:${touch.path}`), ...unresolvedTouches.map((touch) => `unresolved:${touch.path}`), ...deletions.map((entry) => `deletion:${entry.path}`)];
+    const blockers = [...forbiddenTouches.map((touch) => `forbidden:${touch.path}`), ...unresolvedTouches.map((touch) => `unresolved:${touch.path}: ${touch.reason}`), ...deletions.map((entry) => `deletion:${entry.path}`)];
     throw new Error(selected.size === 0
-      ? `Doc sync preview is not ready: ${forbiddenTouches.length} forbidden touch(es), ${unresolvedTouches.length} unresolved touch(es), ${deletions.length} deletion(s). Run 'ha doc status'.`
+      ? `Doc sync preview is not ready: ${forbiddenTouches.length} forbidden touch(es), ${unresolvedTouches.length} unresolved touch(es), ${deletions.length} deletion(s). Blockers: ${blockers.join(", ")}. Run 'ha doc status'.`
       : `Doc sync preview is not ready${scope}: ${blockers.join(", ")}. Only paths in this request are blockers; unrelated dirty paths are excluded. Run 'ha doc status'.`);
   }
   if (!report.baseLedgerSha) throw new Error("Doc sync submit requires an initialized authored Git repository.");

--- a/packages/kernel/src/entity/managed-semantic-diff.ts
+++ b/packages/kernel/src/entity/managed-semantic-diff.ts
@@ -101,7 +101,10 @@ function changedRegions(
     for (const section of policy!.sections) {
       const baseHas = hasHeading(baseBody, section.anchor);
       const candidateHas = hasHeading(candidateBody, section.anchor);
-      if (baseHas !== candidateHas) semanticDiffError("SEMANTIC_DIFF_AMBIGUOUS", `section identity changed: ${filePath} ${section.anchor}`);
+      if (baseHas !== candidateHas) semanticDiffError(
+        "SEMANTIC_DIFF_AMBIGUOUS",
+        `declared section ${section.anchor} disappeared from submitted content for ${filePath} (it was deleted or renamed); keep the declared heading exactly as written, edit its body freely, and new sections are allowed`
+      );
       const baseSection = extractMarkdownSection(baseBody, section.anchor);
       const candidateSection = extractMarkdownSection(candidateBody, section.anchor);
       if (baseSection === candidateSection) continue;


### PR DESCRIPTION
# English

## Summary

A real consumer repo (`kty-web`) lost a full working round to a broken diagnostic chain in `doc sync`. The product already computed the exact reason a submission was blocked, then discarded it at three successive rendering layers, leaving the user with "path X is unresolved" and a pointer to a command that printed nothing.

This restores the chain end to end. The concrete reason (`SEMANTIC_DIFF_AMBIGUOUS: declared section ## Goal disappeared...`) now reaches the user at the point of rejection, and `ha doc status` renders it without `--json`.

## What Changed

- `packages/daemon/src/service/doc-sync-service.ts:134`: blocker strings now carry `touch.reason`, not just `touch.path`. The no-selection branch also gained the blocker list, which previously reported only counts.
- `packages/cli/src/cli/receipt.ts`: added a `doc-status` text rendering branch — one line per dirty file, with the reason printed for unresolved entries. The summary now states `N dirty, M blocked` instead of a single ambiguous `rows=N`.
- `packages/kernel/src/entity/managed-semantic-diff.ts:103`: the rename rejection is now self-teaching. It states that the declared heading must be preserved verbatim, that body prose may change freely, and that adding new sections is allowed — the last point being both true (`undeclaredSections=allow`) and counter-intuitive.
- Tests: end-to-end coverage in `doc-sync-cli.test.ts` asserting the reason reaches the error, the non-JSON `doc status` output, and a negative control (restoring the anchor must make the same path submittable).

## Task And Scope

- Harness task: task_01KZFVSBRDR5QGDFKXTYD9HXCX
- Branch: `codex/diagnostic-chain`
- Public scope: doc sync blocker assembly, CLI receipt rendering, managed semantic diff wording
- Private planning/evidence updated: yes
- Out of scope: the publisher-occupies-worktree defect (separate task task_01KZFVVC59JQ2MPDJKF5PQZ1N5); reforming the error-quality gate

## Version Impact

- Version: no version change because this is a diagnostics fix with no public API shape change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: n/a
- Authority: task_01KZFVSBRDR5QGDFKXTYD9HXCX
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: n/a
- Break-glass scope: n/a
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: `90669b2869c712b4a8e8a15424b8d2d5be958953`
- Branch merge-base with `origin/main`: `90669b2869c712b4a8e8a15424b8d2d5be958953`
- Last `git fetch origin` time: 2026-08-08 04:56 UTC
- Sync method: none needed
- Public diff command: `git diff 90669b28..200dd711`
- Private evidence commit/path: `harness/tasks/task_01KZFVSBRDR5QGDFKXTYD9HXCX-fix-doc-sync-diagnostic-chain-breakage/artifacts/worker-mission.md`
- Reviewer evidence path: same
- GitHub Actions `rewrite-ci` run URL: pending
- [x] `git diff --check`
- [x] `npm run check:stop-point` (exit 0; fast 827/827; contract 346 pass + 1 skip)
- [x] Targeted tests for the change surface:
  - `doc-sync-cli.test.ts`: 13/13
  - `doc-sync-service.test.ts`: 45/45
  - End-to-end acceptance, actual output captured: rejection hint contains `## Goal` and `deleted or renamed`; `doc status` text output contains the path plus `SEMANTIC_DIFF_AMBIGUOUS ... ## Goal` and `summary="doc status: 1 dirty, 1 blocked"`; negative control restoring the anchor returns `status: accepted`
- [ ] GitHub Actions `rewrite-ci` passed — not yet run
- Not run, and why: full `npm run check:ci` and the nightly aggregate tier were not run locally (outside the stop-point scope by design); remote CI covers them.

## Review Evidence

- Self-review: verified all three diffs against the reported source locations; confirmed the added test drives the non-JSON renderer and includes a negative control that would fail against a fake fix
- Reviewer subagent: Luna (session 019fdfc1-7af8-7231-b983-9980585c4f7d)
- Human review: pending
- Blocking findings: none

## Residual Risk

- `tools/check-error-next-steps.mjs` was already green on all 228 caller-facing rejection codes before this change, including every defect fixed here. That gate validates hint template shape, not whether runtime values reach the user, so it has no discriminating power for this class. A structural fix (making the criterion/actual/expected triple a typed structure rather than a string) is deliberately not attempted here and needs its own decision.
- Remote CI has not run yet.

## References

- Task: task_01KZFVSBRDR5QGDFKXTYD9HXCX
- Evidence: `harness/tasks/task_01KZFVSBRDR5QGDFKXTYD9HXCX-fix-doc-sync-diagnostic-chain-breakage/artifacts/worker-mission.md`
- Review: Luna session 019fdfc1-7af8-7231-b983-9980585c4f7d

---

# 中文

## 概要

真实消费者仓（`kty-web`）因 `doc sync` 的诊断链断裂损失了一整轮工作时间。产品**已经算出**提交被阻塞的确切原因，却在三个渲染层依次把它丢掉，用户最终只看到「路径 X 未解析」，以及一条指向什么都不打印的命令的提示。

本 PR 把这条链端到端接通。具体原因（`SEMANTIC_DIFF_AMBIGUOUS: declared section ## Goal disappeared...`）现在会在拒绝的当场到达用户面前，且 `ha doc status` 不带 `--json` 也能渲染出来。

## 改动内容

- `packages/daemon/src/service/doc-sync-service.ts:134`：blocker 字符串现在带上 `touch.reason`，不再只有 `touch.path`。无选择路径的那个分支原来只报计数，现在也带上 blocker 列表。
- `packages/cli/src/cli/receipt.ts`：新增 `doc-status` 文本渲染分支——每个脏文件一行，unresolved 的把 reason 打出来。summary 改为 `N dirty, M blocked`，取代原来含义不清的单个 `rows=N`。
- `packages/kernel/src/entity/managed-semantic-diff.ts:103`：改名拒绝现在能自解释。它说明已声明标题必须逐字保留、正文可自由修改、**另加新章节是允许的**——最后这点既是事实（`undeclaredSections=allow`）又反直觉。
- 测试：`doc-sync-cli.test.ts` 端到端覆盖，断言 reason 进入错误、断言不带 `--json` 的 `doc status` 输出、以及一条阴性对照（改回锚点后同一路径必须可提交）。

## 任务与范围

- Harness 任务：task_01KZFVSBRDR5QGDFKXTYD9HXCX
- 分支：`codex/diagnostic-chain`
- 公开范围：doc sync blocker 组装、CLI receipt 渲染、managed semantic diff 措辞
- 私有计划 / 证据是否已更新：yes
- 范围外：发布器占用工作区那条缺陷（独立任务 task_01KZFVVC59JQ2MPDJKF5PQZ1N5）；错误质量门的结构性改造

## 版本影响

- 版本：不改版本，原因是这是诊断修复，未改变任何公开 API 形状
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：task_01KZFVSBRDR5QGDFKXTYD9HXCX
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无

## 验证

- `origin/main` 基准 SHA：`90669b2869c712b4a8e8a15424b8d2d5be958953`
- 当前分支与 `origin/main` 的 merge-base：`90669b2869c712b4a8e8a15424b8d2d5be958953`
- 最近一次 `git fetch origin` 时间：2026-08-08 04:56 UTC
- 同步方式：不需要
- 公开 diff 命令：`git diff 90669b28..200dd711`
- 私有证据 commit/path：`harness/tasks/task_01KZFVSBRDR5QGDFKXTYD9HXCX-fix-doc-sync-diagnostic-chain-breakage/artifacts/worker-mission.md`
- Reviewer 证据路径：同上
- GitHub Actions `rewrite-ci` run URL：待定
- [x] `git diff --check`
- [x] `npm run check:stop-point`（exit 0；fast 827/827；contract 346 pass + 1 skip）
- [x] 改动面的定向测试：
  - `doc-sync-cli.test.ts`: 13/13
  - `doc-sync-service.test.ts`: 45/45
  - 端到端验收，实际输出已捕获：拒绝 hint 含 `## Goal` 与 `deleted or renamed`；`doc status` 文本输出含路径及 `SEMANTIC_DIFF_AMBIGUOUS ... ## Goal` 与 `summary="doc status: 1 dirty, 1 blocked"`；阴性对照改回锚点后返回 `status: accepted`
- [ ] GitHub Actions `rewrite-ci` 通过 — 尚未跑
- 未跑项及原因：本地未跑完整 `npm run check:ci` 与 nightly 汇总层（按设计超出 stop-point 范围）；远程 CI 覆盖这些层。

## 审查证据

- 自查：三处 diff 已逐条对照报告给出的源码位置核实；确认新增测试驱动的是不带 `--json` 的渲染器，且含一条对假修复会失败的阴性对照
- Reviewer subagent：Luna（session 019fdfc1-7af8-7231-b983-9980585c4f7d）
- 人工审查：待定
- 阻塞发现：无

## 残余风险

- `tools/check-error-next-steps.mjs` 在本次改动**之前**对全部 228 条面向调用者的拒绝码就已经是绿的，包括本 PR 修的每一条缺陷。那个门验的是 hint 模板的文本形状，不是运行时值有没有到达用户，因此对这一类缺陷零分辨力。结构性修复（把「判据+实际值+期望值」变成类型结构而非字符串）本 PR 刻意不做，需要独立 decision。
- 远程 CI 尚未跑。

## 关联材料

- 任务：task_01KZFVSBRDR5QGDFKXTYD9HXCX
- 证据：`harness/tasks/task_01KZFVSBRDR5QGDFKXTYD9HXCX-fix-doc-sync-diagnostic-chain-breakage/artifacts/worker-mission.md`
- 审查：Luna session 019fdfc1-7af8-7231-b983-9980585c4f7d

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明（远程 CI pending）。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。
