### PR TITLE
fix(kernel): eliminate publisher worktree clobber + preserve divergent edits

### DIFF
--- a/packages/cli/test/production-authority-canonical-ingress-tracer.test.ts
+++ b/packages/cli/test/production-authority-canonical-ingress-tracer.test.ts
@@ -302,7 +302,7 @@ test("doc sync submit dispatches prose to the production writer child", { timeou
       "-c", "user.email=harness@example.test",
       "commit", "-q", "-m", "seed doc sync fixture"
     ], { cwd: fixture.authoredRoot });
-    const trunkHead = execFileSync("git", ["rev-parse", "HEAD"], {
+    const trunkBranch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
       cwd: fixture.authoredRoot,
       encoding: "utf8"
     }).trim();
@@ -346,27 +346,27 @@ test("doc sync submit dispatches prose to the production writer child", { timeou
       `tasks/${taskId}/task_plan.md`,
       JSON.stringify(submitted.receipt)
     );
+    // Worktree contract (dec_01KZJMH1CZX3ZXBRJYG8WZA1F3): the publisher must
+    // never checkout/reset the shared user worktree. HEAD stays on the trunk
+    // branch (the sha may advance if the background materializer merges the
+    // session before this assertion runs), and the authored file keeps the
+    // user's submitted content through the whole publication window. The
+    // path may read as modified until the materializer lands the merge, so
+    // index cleanliness is intentionally not asserted here.
     assert.equal(
-      execFileSync("git", ["rev-parse", "HEAD"], {
+      execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
         cwd: fixture.authoredRoot,
         encoding: "utf8"
       }).trim(),
-      trunkHead
+      trunkBranch
     );
-    assert.match(readFileSync(planPath, "utf8"), /Original governed prose/u);
+    assert.match(readFileSync(planPath, "utf8"), /Updated through the writer child/u);
     assert.match(
       execFileSync("git", ["show", `${sessionBranch}:tasks/${taskId}/task_plan.md`], {
         cwd: fixture.authoredRoot,
         encoding: "utf8"
       }),
       /Updated through the writer child/u
-    );
-    assert.equal(
-      execFileSync("git", ["status", "--short", "--", `tasks/${taskId}/task_plan.md`], {
-        cwd: fixture.authoredRoot,
-        encoding: "utf8"
-      }).trim(),
-      ""
     );
     assert.match(
       execFileSync("git", ["log", "-1", "--format=%s", sessionBranch], {

--- a/packages/cli/test/repo-write-child-production-cutover.test.ts
+++ b/packages/cli/test/repo-write-child-production-cutover.test.ts
@@ -409,7 +409,17 @@ cutoverTest("doc-sync submits a working-tree file larger than the repo-writer IP
     });
 
     assert.equal(result.ok, true, JSON.stringify(result));
-    assert.equal(fixtureGit(fixture.authoredRoot, "status", "--short"), "");
+    // Publication commits with zero checkout, so it must not touch anything the
+    // worktree already tracks. It also must not delete the author's own file:
+    // the previous checkout-based publisher reached an empty `status --short`
+    // only by removing large.raw.jsonl from the worktree after committing it,
+    // which is the clobber this path exists to eliminate. Untracked generated
+    // and authored paths therefore remain until the materializer merges.
+    const trackedWorktreeChanges = fixtureGit(fixture.authoredRoot, "status", "--short")
+      .split("\n")
+      .filter((line) => line.length > 0 && !line.startsWith("??"));
+    assert.deepEqual(trackedWorktreeChanges, []);
+    assert.equal(existsSync(largeAbsolutePath), true, "publication must leave the authored file in place");
     assert.equal(fixtureGit(
       fixture.authoredRoot,
       "cat-file",

--- a/packages/daemon/test/runtime/repo-runtime.test.ts
+++ b/packages/daemon/test/runtime/repo-runtime.test.ts
@@ -506,7 +506,9 @@ test("daemon interactive writes route sessionId commits to authored session bran
     assert.equal(git(rootDir, "rev-parse", "--abbrev-ref", "HEAD"), "master");
     assert.equal(git(rootDir, "branch", "--list", "sessions/daemon-session-1"), "sessions/daemon-session-1");
     assert.match(git(rootDir, "log", "master..sessions/daemon-session-1", "--oneline"), /op-daemon-session/u);
-    assert.equal(existsSync(path.join(rootDir, "harness/tasks/task-daemon-session/note.md")), false);
+    // Zero-checkout publisher preserves the worktree file; it is on the session
+    // branch but not yet on trunk until the materializer merges.
+    assert.equal(existsSync(path.join(rootDir, "harness/tasks/task-daemon-session/note.md")), true);
 
     await runtime.stop();
   });

--- a/packages/kernel/src/persistence/git/headless-branch-commit.ts
+++ b/packages/kernel/src/persistence/git/headless-branch-commit.ts
@@ -1,0 +1,127 @@
+import path from "node:path";
+import type { VcsCommitAuthor, VcsCommitPhase } from "../../ports/version-control-system.ts";
+import type { ScopedIndexGitOperations } from "./scoped-index-commit.ts";
+
+/**
+ * Commit the working-tree state of specific paths to a Git branch without
+ * checking out that branch. The working tree, the shared index, and HEAD are
+ * never touched — the commit is assembled entirely with plumbing commands on a
+ * temporary alternate index.
+ *
+ * This eliminates the publication window in which the old checkout-based
+ * publisher restored the worktree to trunk (clobbering user-authored content)
+ * between session commit and materializer merge.
+ */
+export function commitPathsToBranchHeadless(
+  repoRoot: string,
+  input: {
+    readonly branchName: string;
+    readonly baseBranchName: string;
+    readonly stagePaths: ReadonlyArray<string>;
+    readonly excludePaths: ReadonlySet<string>;
+    readonly message: string;
+    readonly author?: VcsCommitAuthor;
+    readonly onPhase?: (phase: VcsCommitPhase) => void;
+  },
+  git: ScopedIndexGitOperations
+): string {
+  const report = (phase: VcsCommitPhase): void => {
+    try {
+      input.onPhase?.(phase);
+    } catch {
+      // Telemetry is deliberately non-authoritative.
+    }
+  };
+
+  // Determine base ref: append to the session branch if it exists, otherwise
+  // branch from trunk. refExists is resolved via rev-parse so there is no
+  // working-tree or HEAD movement.
+  const branchExists = canResolveRef(repoRoot, input.branchName, git);
+  const baseRef = branchExists ? input.branchName : input.baseBranchName;
+  const baseSha = git.runGitWithEnvironment(repoRoot, undefined, {}, "rev-parse", baseRef).trim();
+  const baseTreeSha = git
+    .runGitWithEnvironment(repoRoot, undefined, {}, "rev-parse", `${baseRef}^{tree}`)
+    .trim();
+
+  const temporaryIndexDirectory = git.fileSystem.makeTemporaryDirectory("ha-git-branch-commit-");
+  const temporaryIndex = path.join(temporaryIndexDirectory, "index");
+  try {
+    const indexEnv: Readonly<Record<string, string>> = { GIT_INDEX_FILE: temporaryIndex };
+    git.runGitWithEnvironment(repoRoot, undefined, indexEnv, "read-tree", baseSha);
+
+    report("stage-start");
+    for (const relativePath of input.stagePaths) {
+      if (input.excludePaths.has(relativePath)) continue;
+      if (worktreePathExists(repoRoot, relativePath, git)) {
+        git.runGitWithEnvironment(repoRoot, undefined, indexEnv, "update-index", "--add", "--", relativePath);
+      } else {
+        git.runGitWithEnvironment(
+          repoRoot,
+          undefined,
+          indexEnv,
+          "update-index",
+          "--force-remove",
+          "--",
+          relativePath
+        );
+      }
+    }
+    report("stage-done");
+
+    const treeSha = git.runGitWithEnvironment(repoRoot, undefined, indexEnv, "write-tree").trim();
+    if (treeSha === baseTreeSha) {
+      // Nothing changed relative to the base tree; no commit to create.
+      return baseSha;
+    }
+
+    report("commit-call-start");
+    const commitSha = git
+      .runGitWithEnvironment(
+        repoRoot,
+        input.author,
+        {},
+        "commit-tree",
+        treeSha,
+        "-p",
+        baseSha,
+        "-m",
+        input.message
+      )
+      .trim();
+    git.runGitWithEnvironment(
+      repoRoot,
+      undefined,
+      {},
+      "update-ref",
+      `refs/heads/${input.branchName}`,
+      commitSha
+    );
+    report("commit-call-done");
+
+    return commitSha;
+  } finally {
+    git.fileSystem.removeTemporaryDirectory(temporaryIndexDirectory);
+  }
+}
+
+function canResolveRef(repoRoot: string, ref: string, git: ScopedIndexGitOperations): boolean {
+  try {
+    git.runGitWithEnvironment(repoRoot, undefined, {}, "rev-parse", "--verify", "--quiet", `${ref}^{commit}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function worktreePathExists(repoRoot: string, relativePath: string, git: ScopedIndexGitOperations): boolean {
+  const absolutePath = path.join(repoRoot, ...relativePath.split("/"));
+  try {
+    // lstat (not exists) so broken symlinks are still detected as present —
+    // Git stores symlinks as their target text, and update-index --add handles
+    // them correctly regardless of whether the target resolves.
+    git.fileSystem.lstat(absolutePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/kernel/src/persistence/git/local-version-control-system.ts
+++ b/packages/kernel/src/persistence/git/local-version-control-system.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import type { VcsCommitAuthor, VcsCommitOptions, VersionControlSystem } from "../../ports/version-control-system.ts";
 import { VcsCommandError } from "../../ports/version-control-system.ts";
 import { resolveGitMaxBufferBytes } from "../../runtime/operational-limits.ts";
+import { commitPathsToBranchHeadless } from "./headless-branch-commit.ts";
 import { commitWithScopedIndex, nullDelimitedGitPaths } from "./scoped-index-commit.ts";
 
 const gitMaxBuffer = resolveGitMaxBufferBytes();
@@ -211,6 +212,57 @@ export function makeLocalVersionControlSystem(): VersionControlSystem {
     resetQuiet: (repoRoot, pathspecs) => {
       if (pathspecs.length === 0) return;
       runGit(repoRoot, "reset", "-q", "--", ...pathspecs);
+    },
+    commitPathsToBranch: (repoRoot, input) => commitPathsToBranchHeadless(
+      repoRoot,
+      input,
+      {
+        runGitBytes,
+        runGitWithInput,
+        runGitWithEnvironment,
+        runGitWithInputEnvironment,
+        fileSystem: {
+          exists: existsSync,
+          lstat: lstatSync,
+          readFile: readFileSync,
+          readLink: readlinkSync,
+          makeTemporaryDirectory: (prefix) => mkdtempSync(path.join(tmpdir(), prefix)),
+          removeTemporaryDirectory: (inputPath) => rmSync(inputPath, { recursive: true, force: true })
+        }
+      }
+    ),
+    resetWorktreePaths: (repoRoot, ref, paths) => {
+      if (paths.length === 0) return;
+      const refSha = runGit(repoRoot, "rev-parse", ref).trim();
+      for (const relativePath of paths) {
+        const absolutePath = path.join(repoRoot, ...relativePath.split("/"));
+        let existsAtRef = false;
+        try {
+          runGit(repoRoot, "cat-file", "-e", `${refSha}:${relativePath}`);
+          existsAtRef = true;
+        } catch {
+          // Path does not exist in ref — it will be removed below.
+        }
+        if (existsAtRef) {
+          try {
+            runGit(repoRoot, "checkout", ref, "--", relativePath);
+          } catch {
+            // If checkout fails (e.g. path is a directory in ref), skip —
+            // the merge will surface any real conflict.
+          }
+        } else {
+          try {
+            runGit(repoRoot, "reset", "-q", "HEAD", "--", relativePath);
+          } catch {
+            // Path may not be in the index; ignore.
+          }
+          try {
+            rmSync(absolutePath, { force: true });
+          } catch {
+            // Worktree file may already be gone; ignore.
+          }
+        }
+      }
     }
   };
 }

--- a/packages/kernel/src/persistence/git/local-version-control-system.ts
+++ b/packages/kernel/src/persistence/git/local-version-control-system.ts
@@ -1,9 +1,10 @@
 import { execFileSync } from "node:child_process";
 import type { ExecFileSyncOptionsWithStringEncoding } from "node:child_process";
-import { existsSync, lstatSync, mkdtempSync, readFileSync, readlinkSync, realpathSync, rmSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import type { VcsCommitAuthor, VcsCommitOptions, VersionControlSystem } from "../../ports/version-control-system.ts";
+import type { PreservedWorktreeEdit, VcsCommitAuthor, VcsCommitOptions, VersionControlSystem } from "../../ports/version-control-system.ts";
 import { VcsCommandError } from "../../ports/version-control-system.ts";
 import { resolveGitMaxBufferBytes } from "../../runtime/operational-limits.ts";
 import { commitPathsToBranchHeadless } from "./headless-branch-commit.ts";
@@ -231,11 +232,20 @@ export function makeLocalVersionControlSystem(): VersionControlSystem {
         }
       }
     ),
-    resetWorktreePaths: (repoRoot, ref, paths) => {
-      if (paths.length === 0) return;
+    resetWorktreePaths: (repoRoot, ref, paths, options) => {
+      if (paths.length === 0) return [];
       const refSha = runGit(repoRoot, "rev-parse", ref).trim();
+      const preserved: PreservedWorktreeEdit[] = [];
       for (const relativePath of paths) {
         const absolutePath = path.join(repoRoot, ...relativePath.split("/"));
+        const rescued = preserveDivergentWorktreeEdit({
+          repoRoot,
+          relativePath,
+          absolutePath,
+          restoreRef: options?.restoreRef,
+          preserveDir: options?.preserveDir
+        });
+        if (rescued) preserved.push(rescued);
         let existsAtRef = false;
         try {
           runGit(repoRoot, "cat-file", "-e", `${refSha}:${relativePath}`);
@@ -263,8 +273,42 @@ export function makeLocalVersionControlSystem(): VersionControlSystem {
           }
         }
       }
+      return preserved;
     }
   };
+}
+
+function preserveDivergentWorktreeEdit(input: {
+  readonly repoRoot: string;
+  readonly relativePath: string;
+  readonly absolutePath: string;
+  readonly restoreRef: string | undefined;
+  readonly preserveDir: string | undefined;
+}): PreservedWorktreeEdit | undefined {
+  if (!input.restoreRef) return undefined;
+  let worktreeBytes: Buffer;
+  try {
+    worktreeBytes = readFileSync(input.absolutePath);
+  } catch {
+    return undefined;
+  }
+  let restoreBytes: Buffer | undefined;
+  try {
+    restoreBytes = Buffer.from(runGitBytes(input.repoRoot, "cat-file", "blob", `${input.restoreRef}:${input.relativePath}`));
+  } catch {
+    restoreBytes = undefined;
+  }
+  if (restoreBytes && restoreBytes.equals(worktreeBytes)) return undefined;
+  const preserveRoot = input.preserveDir ?? path.join(input.repoRoot, ".harness", "preserved-worktree-edits");
+  const stamp = `${Date.now().toString(36)}-${randomBytes(3).toString("hex")}`;
+  const target = path.join(preserveRoot, stamp, ...input.relativePath.split("/"));
+  try {
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, worktreeBytes);
+  } catch {
+    return undefined;
+  }
+  return { path: input.relativePath, preservedAt: target };
 }
 
 export function gitProtectedPaths(

--- a/packages/kernel/src/ports/version-control-system.ts
+++ b/packages/kernel/src/ports/version-control-system.ts
@@ -101,7 +101,31 @@ export interface VersionControlSystem {
       readonly onPhase?: (phase: VcsCommitPhase) => void;
     }
   ) => string;
-  readonly resetWorktreePaths: (repoRoot: string, ref: string, paths: ReadonlyArray<string>) => void;
+  readonly resetWorktreePaths: (
+    repoRoot: string,
+    ref: string,
+    paths: ReadonlyArray<string>,
+    options?: {
+      /**
+       * Ref whose content the caller will restore immediately after the reset
+       * (for a materializer merge, the session branch). When the worktree
+       * already matches this ref the reset is content-neutral. When it differs,
+       * the worktree holds an edit that no ref carries, so the reset would
+       * destroy it; such paths are copied aside and reported instead.
+       */
+      readonly restoreRef?: string;
+      readonly preserveDir?: string;
+    }
+  ) => ReadonlyArray<PreservedWorktreeEdit>;
+}
+
+/**
+ * A worktree edit that no ref carried at reset time, copied aside so the reset
+ * could proceed without destroying it.
+ */
+export interface PreservedWorktreeEdit {
+  readonly path: string;
+  readonly preservedAt: string;
 }
 
 export class VcsCommandError extends Error {

--- a/packages/kernel/src/ports/version-control-system.ts
+++ b/packages/kernel/src/ports/version-control-system.ts
@@ -89,6 +89,19 @@ export interface VersionControlSystem {
   readonly commitsNotInTrunk: (repoRoot: string, trunkBranch: string, branch: string) => ReadonlyArray<string>;
   readonly changedFilesBetween: (repoRoot: string, before: string, after: string) => ReadonlyArray<string>;
   readonly resetQuiet: (repoRoot: string, pathspecs: ReadonlyArray<string>) => void;
+  readonly commitPathsToBranch: (
+    repoRoot: string,
+    input: {
+      readonly branchName: string;
+      readonly baseBranchName: string;
+      readonly stagePaths: ReadonlyArray<string>;
+      readonly excludePaths: ReadonlySet<string>;
+      readonly message: string;
+      readonly author?: VcsCommitAuthor;
+      readonly onPhase?: (phase: VcsCommitPhase) => void;
+    }
+  ) => string;
+  readonly resetWorktreePaths: (repoRoot: string, ref: string, paths: ReadonlyArray<string>) => void;
 }
 
 export class VcsCommandError extends Error {

--- a/packages/kernel/src/write-coordination/journal/publication/git.ts
+++ b/packages/kernel/src/write-coordination/journal/publication/git.ts
@@ -45,6 +45,34 @@ export function commitTouchedPaths(
     layoutInput,
     vcs
   );
+  const sessionBranch = sessionBranchName(sessionId);
+  const commitMessage = message ?? `harness write ${opIds.join(",")}`;
+
+  if (sessionBranch) {
+    // Zero-checkout session commit: assemble the commit entirely with Git
+    // plumbing on a temporary alternate index. The shared worktree is never
+    // touched, eliminating the publication window in which the old
+    // checkout-based publisher clobbered user-authored content by restoring
+    // the worktree to trunk between session commit and materializer merge.
+    const trunkBranch = resolveTrunkBranch(plan.repoRoot, undefined, vcs);
+    const excludePaths = new Set(
+      plan.relativePaths.filter(
+        (relativePath) => relativePath.endsWith(".log") && !preserveExplicitLogs.has(relativePath)
+      )
+    );
+    const commitSha = vcs.commitPathsToBranch(plan.repoRoot, {
+      branchName: sessionBranch,
+      baseBranchName: trunkBranch,
+      stagePaths: plan.relativePaths,
+      excludePaths,
+      message: commitMessage,
+      ...(options.author ? { author: options.author } : {}),
+      ...(options.onCommitPhase ? { onPhase: options.onCommitPhase } : {})
+    });
+    return commitSha;
+  }
+
+  // Non-session path: commit on the current branch via the shared index.
   // A failed commit can leave a hard-delete already staged while its path no
   // longer exists in either the worktree or index. Re-adding that path fails;
   // preserve its staged deletion and continue the recovery commit.
@@ -52,43 +80,25 @@ export function commitTouchedPaths(
     const staged = vcs.stagedFiles(plan.repoRoot, [relativePath]).trim().length > 0;
     return !staged || hasUnstagedChanges(vcs.workingTreeFiles(plan.repoRoot, [relativePath]));
   });
-  const sessionBranch = sessionBranchName(sessionId);
-  // Resolve the trunk branch while HEAD still points at it, before checkoutSessionBranch
-  // moves us onto the session branch; the finally must return to the same trunk.
-  const trunkBranch = sessionBranch ? resolveTrunkBranch(plan.repoRoot, undefined, vcs) : undefined;
-
-  if (sessionBranch) {
-    report("session-checkout-start");
-    checkoutSessionBranch(plan.repoRoot, sessionBranch, trunkBranch!, vcs);
-    report("session-checkout-done");
+  if (addablePaths.length > 0) {
+    report("stage-start");
+    vcs.add(plan.repoRoot, { paths: addablePaths });
+    report("stage-done");
   }
-  try {
-    if (addablePaths.length > 0) {
-      report("stage-start");
-      vcs.add(plan.repoRoot, { paths: addablePaths });
-      report("stage-done");
-    }
-    report("unstage-logs-start");
-    unstageLogFiles(plan.repoRoot, plan.relativePaths, vcs);
-    report("unstage-logs-done");
-    const preservedLogs = plan.relativePaths.filter((relativePath) => preserveExplicitLogs.has(relativePath));
-    if (preservedLogs.length > 0) vcs.add(plan.repoRoot, { paths: preservedLogs });
-    const staged = vcs.stagedFiles(plan.repoRoot, plan.relativePaths).trim();
-    if (staged.length === 0) return vcs.currentHead(plan.repoRoot);
+  report("unstage-logs-start");
+  unstageLogFiles(plan.repoRoot, plan.relativePaths, vcs);
+  report("unstage-logs-done");
+  const preservedLogs = plan.relativePaths.filter((relativePath) => preserveExplicitLogs.has(relativePath));
+  if (preservedLogs.length > 0) vcs.add(plan.repoRoot, { paths: preservedLogs });
+  const staged = vcs.stagedFiles(plan.repoRoot, plan.relativePaths).trim();
+  if (staged.length === 0) return vcs.currentHead(plan.repoRoot);
 
-    report("commit-call-start");
-    vcs.commit(plan.repoRoot, message ?? `harness write ${opIds.join(",")}`, options.author, {
-      ...(options.onCommitPhase ? { onPhase: options.onCommitPhase } : {})
-    });
-    report("commit-call-done");
-    return vcs.currentHead(plan.repoRoot);
-  } finally {
-    if (sessionBranch && trunkBranch) {
-      report("trunk-checkout-start");
-      vcs.checkout(plan.repoRoot, trunkBranch);
-      report("trunk-checkout-done");
-    }
-  }
+  report("commit-call-start");
+  vcs.commit(plan.repoRoot, commitMessage, options.author, {
+    ...(options.onCommitPhase ? { onPhase: options.onCommitPhase } : {})
+  });
+  report("commit-call-done");
+  return vcs.currentHead(plan.repoRoot);
 }
 
 export function resolveCommitPlan(
@@ -228,18 +238,6 @@ function logPathspecsFor(relativePath: string): ReadonlyArray<string> {
   if (normalized.length === 0 || normalized === ".") return [":(glob)**/*.log", "*.log"];
   if (normalized.endsWith(".log")) return [normalized];
   return [`:(glob)${normalized}/**/*.log`, `${normalized}/*.log`];
-}
-
-function checkoutSessionBranch(repoRoot: string, branchName: string, trunkBranch: string, vcs: VersionControlSystem): void {
-  vcs.checkout(repoRoot, trunkBranch);
-  if (!branchExists(repoRoot, branchName, vcs)) {
-    vcs.createBranch(repoRoot, branchName);
-  }
-  vcs.checkout(repoRoot, branchName);
-}
-
-function branchExists(repoRoot: string, branchName: string, vcs: VersionControlSystem): boolean {
-  return vcs.refExists(repoRoot, branchName);
 }
 
 export function sessionBranchName(sessionId: string | undefined): string | undefined {

--- a/packages/kernel/src/write-coordination/materialization/ledger-materializer.ts
+++ b/packages/kernel/src/write-coordination/materialization/ledger-materializer.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { parseAuthorityBatchCommitMessage } from "../../integrity/authority-batch-integrity.ts";
 import type { HarnessLayoutInput } from "../../layout/index.ts";
 import { resolveHarnessLayout } from "../../layout/index.ts";
-import type { VersionControlSystem } from "../../ports/version-control-system.ts";
+import type { VersionControlSystem, PreservedWorktreeEdit } from "../../ports/version-control-system.ts";
 import { updateTaskProjectionIncrementally } from "../../projection/sqlite-task-incremental-projection.ts";
 import type { IncrementalProjectionDiagnostic, IncrementalProjectionPhase } from "../../projection/sqlite-task-incremental-projection.ts";
 import { countAttributionProjectionRows } from "../../projection/sqlite-attribution-projection.ts";
@@ -35,6 +35,7 @@ export interface LedgerMaterializerBranchReport {
   readonly nextCommand?: string;
   readonly conflictPaths?: ReadonlyArray<string>;
   readonly preservedArtifacts?: ReadonlyArray<PreservedMachineArtifact>;
+  readonly preservedWorktreeEdits?: ReadonlyArray<PreservedWorktreeEdit>;
 }
 
 export interface LedgerMaterializerReport {
@@ -184,7 +185,18 @@ function materializeBranches(
     // or untracked files) would be overwritten by the merge. Revert only the
     // paths this merge will touch to trunk state so the merge proceeds; the
     // merge immediately restores the session's content for those paths.
-    vcs.resetWorktreePaths(repoRoot, trunkBranch, vcs.changedFilesBetween(repoRoot, trunkBranch, branch));
+    // `restoreRef` is what makes the reset non-destructive: for a path whose
+    // worktree bytes already equal the session branch, the merge restores the
+    // identical content, so resetting changes nothing observable. A path that
+    // differs from the session branch carries an edit no ref holds — authored
+    // after the submission — and resetting would destroy it. Those are copied
+    // aside and reported rather than discarded or allowed to wedge the merge.
+    const preservedWorktreeEdits = vcs.resetWorktreePaths(
+      repoRoot,
+      trunkBranch,
+      vcs.changedFilesBetween(repoRoot, trunkBranch, branch),
+      { restoreRef: branch }
+    );
     const beforeMergeHead = vcs.currentHead(repoRoot);
     let preservedArtifacts: ReadonlyArray<PreservedMachineArtifact> = [];
     try {
@@ -240,7 +252,8 @@ function materializeBranches(
       commitCount: commits.length,
       status: "merged",
       commits,
-      ...(preservedArtifacts.length > 0 ? { preservedArtifacts } : {})
+      ...(preservedArtifacts.length > 0 ? { preservedArtifacts } : {}),
+      ...(preservedWorktreeEdits.length > 0 ? { preservedWorktreeEdits } : {})
     });
     if (reachedBranchLimit(processed, maxBranches)) break;
   }

--- a/packages/kernel/src/write-coordination/materialization/ledger-materializer.ts
+++ b/packages/kernel/src/write-coordination/materialization/ledger-materializer.ts
@@ -179,6 +179,12 @@ function materializeBranches(
     const mergeMessage = semanticMergeMessage(commits, repoRoot, branch, vcs)
       ?? `materializer: merge session ${branch.slice("sessions/".length)}`;
     vcs.checkout(repoRoot, trunkBranch);
+    // The zero-checkout publisher preserves user-authored content in the
+    // worktree. git merge refuses when local changes (tracked modifications
+    // or untracked files) would be overwritten by the merge. Revert only the
+    // paths this merge will touch to trunk state so the merge proceeds; the
+    // merge immediately restores the session's content for those paths.
+    vcs.resetWorktreePaths(repoRoot, trunkBranch, vcs.changedFilesBetween(repoRoot, trunkBranch, branch));
     const beforeMergeHead = vcs.currentHead(repoRoot);
     let preservedArtifacts: ReadonlyArray<PreservedMachineArtifact> = [];
     try {

--- a/packages/kernel/test/store/git-publication-worktree-preservation.test.ts
+++ b/packages/kernel/test/store/git-publication-worktree-preservation.test.ts
@@ -1,0 +1,91 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { commitTouchedPaths } from "../../src/write-coordination/journal/publication/git.ts";
+import { withTempStore } from "./helpers.ts";
+
+test("session publication preserves worktree content throughout every commit phase (temporal assertion)", () => {
+  withTempStore((rootDir) => {
+    const harnessRoot = path.join(rootDir, "harness");
+    mkdirSync(harnessRoot, { recursive: true });
+    runGit(harnessRoot, "init");
+    runGit(harnessRoot, "symbolic-ref", "HEAD", "refs/heads/main");
+    writeFileSync(path.join(harnessRoot, "harness.yaml"), "schema: harness-anything/v1\n", "utf8");
+
+    // Seed trunk with a placeholder task plan — the exact "data corruption"
+    // scenario from the field: correct content exists only after the write,
+    // and trunk holds the old template.
+    const planPath = path.join(harnessRoot, "tasks/task-corruption/task_plan.md");
+    mkdirSync(path.dirname(planPath), { recursive: true });
+    writeFileSync(planPath, "# Placeholder\n\nTEMPLATE\n", "utf8");
+    runGit(harnessRoot, "add", "harness.yaml", "tasks/task-corruption/task_plan.md");
+    runGit(harnessRoot, "commit", "-m", "seed trunk placeholder");
+
+    // Simulate the user/worker replacing the placeholder with real content.
+    const realContent = "# Real Plan\n\nThis is the authoritative task plan.\nLine 2\n";
+    writeFileSync(planPath, realContent, "utf8");
+
+    // Temporal assertion: at every commit phase, the worktree file must be
+    // byte-identical to the pre-commit content. This assertion runs DURING
+    // the commit call — inside the publication window, before the materializer
+    // has any chance to merge. If the old checkout-based publisher restored
+    // the worktree to trunk at "trunk-checkout-done", the assertion fires on
+    // the clobbered placeholder and fails.
+    const observations: Array<{ readonly phase: string; readonly content: string }> = [];
+    const commitSha = commitTouchedPaths(
+      rootDir,
+      [planPath],
+      ["op-worktree-preservation"],
+      rootDir,
+      "test worktree preservation",
+      "worktree-preservation-session",
+      {
+        author: { name: "Harness Test", email: "harness-test@example.invalid" },
+        onCommitPhase: (phase) => {
+          const content = readFileSync(planPath, "utf8");
+          observations.push({ phase, content });
+        }
+      }
+    );
+
+    // Every phase observation must see the uncorrupted worktree.
+    const corrupted = observations.filter((observation) => observation.content !== realContent);
+    assert.equal(
+      corrupted.length,
+      0,
+      `worktree was clobbered at phases: ${corrupted.map((entry) => entry.phase).join(", ")}`
+    );
+    // Sanity: at least the commit and stage phases fired, proving the
+    // assertion was actually inside the publication window.
+    const observedPhases = observations.map((entry) => entry.phase);
+    assert.ok(observedPhases.includes("commit-call-done"), `expected commit-call-done phase; got ${JSON.stringify(observedPhases)}`);
+
+    // The commit on the session branch must contain the real content.
+    assert.equal(
+      runGit(harnessRoot, "show", `${commitSha}:tasks/task-corruption/task_plan.md`),
+      realContent.trim()
+    );
+
+    // HEAD must remain on trunk — the publisher never checked out the session branch.
+    assert.equal(runGit(harnessRoot, "rev-parse", "--abbrev-ref", "HEAD"), "main");
+
+    // The worktree file is still the real content post-publish.
+    assert.equal(readFileSync(planPath, "utf8"), realContent);
+  });
+});
+
+function runGit(repoRoot: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", repoRoot, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Harness Test",
+      GIT_AUTHOR_EMAIL: "harness-test@example.invalid",
+      GIT_COMMITTER_NAME: "Harness Test",
+      GIT_COMMITTER_EMAIL: "harness-test@example.invalid"
+    }
+  }).trim();
+}

--- a/packages/kernel/test/store/global-committer-lock.test.ts
+++ b/packages/kernel/test/store/global-committer-lock.test.ts
@@ -672,6 +672,8 @@ function fakeVersionControlSystem(repoRoot: string): VersionControlSystem {
     sessionBranches: () => [],
     commitsNotInTrunk: () => [],
     changedFilesBetween: () => [],
-    resetQuiet: () => undefined
+    resetQuiet: () => undefined,
+    commitPathsToBranch: () => `fake-branch-head-${commitCount}`,
+    resetWorktreePaths: () => undefined
   };
 }

--- a/packages/kernel/test/store/ledger-materializer.test.ts
+++ b/packages/kernel/test/store/ledger-materializer.test.ts
@@ -37,7 +37,10 @@ test("WriteCoordinator commits session-routed writes to a session branch", () =>
     assert.equal(git(rootDir, "rev-parse", "--abbrev-ref", "HEAD"), "master");
     assert.equal(git(rootDir, "branch", "--list", "sessions/codex-session-1").trim(), "sessions/codex-session-1");
     assert.match(git(rootDir, "log", "master..sessions/codex-session-1", "--oneline"), /op-session-branch/u);
-    assert.equal(existsSync(path.join(rootDir, "harness/tasks/task-1/note.md")), false);
+    // The zero-checkout publisher preserves the worktree: the file written by
+    // applyRecord stays visible. It is NOT yet on trunk — only on the session
+    // branch — until the materializer merges.
+    assert.equal(existsSync(path.join(rootDir, "harness/tasks/task-1/note.md")), true);
   });
 });
 
@@ -67,7 +70,7 @@ test("session publication defers projection notification until materializer merg
     assert.ok(postCommitPhases.includes("projection-hash-start"));
     assert.ok(postCommitPhases.includes("projection-hash-done"));
     assert.deepEqual(projectionChanges, []);
-    assert.equal(existsSync(path.join(rootDir, "harness/tasks/task-deferred-projection/INDEX.md")), false);
+    assert.equal(existsSync(path.join(rootDir, "harness/tasks/task-deferred-projection/INDEX.md")), true);
 
     const materialized = runLedgerMaterializer(rootDir);
     assert.equal(materialized.merged, 1);
@@ -95,7 +98,7 @@ test("ledger materializer dry-runs and merges pending session branches", () => {
     assert.equal(dryRun.dryRun, true);
     assert.equal(dryRun.merged, 0);
     assert.equal(dryRun.branches.find((branch) => branch.branch === "sessions/codex-session-2")?.status, "would_merge");
-    assert.equal(existsSync(path.join(rootDir, "harness/tasks/task-2/note.md")), false);
+    assert.equal(existsSync(path.join(rootDir, "harness/tasks/task-2/note.md")), true);
 
     const progress: string[] = [];
     const merged = runLedgerMaterializer(rootDir, {


### PR DESCRIPTION
# English

## Summary

A real consumer repo reported data loss: after `doc sync --submit` succeeded, the worktree `task_plan.md` became the placeholder template while the correct content remained only in HEAD. The root cause was the publisher using the shared worktree as a temporary staging area for session-branch commits, leaving a timing window where git restored the worktree to trunk (the template) before the materializer merged the session content back.

This PR eliminates that window. Publication now uses zero-checkout git plumbing (temp index + `commit-tree` → `update-ref`), and materialization gained preservation for divergent worktree edits—content authored after submission that no ref carries is copied aside rather than silently discarded.

## What Changed

### Publication (zero-checkout)

- New `commitPathsToBranch` VCS method in `headless-branch-commit.ts`: assembles a commit from working-tree blobs via `hash-object` → temp `GIT_INDEX_FILE` → `write-tree` → `commit-tree` → `update-ref`, never touching the shared worktree or index.
- `git.ts` publication: replaced `checkoutSessionBranch()` + `finally { checkout(trunk) }` with a call to `commitPathsToBranch`. The session commit materializes headlessly; the worktree is untouched.
- Removed `checkoutSessionBranch` function entirely.

### Materialization (preserve divergent edits)

- `resetWorktreePaths` gained an optional `restoreRef` parameter (the session branch the merge will restore). Before overwriting a path, it checks whether the worktree content already equals `restoreRef`. If equal, the reset is content-neutral (merge restores identical bytes). If divergent, that content is an edit authored after submission—copied to `.harness/preserved-worktree-edits/<stamp>/<path>` before reset.
- Returns `PreservedWorktreeEdit[]` naming what was copied and where.
- Materializer wires `restoreRef: branch` and surfaces `preservedWorktreeEdits` in the branch report, alongside the existing `preservedArtifacts`.

### Tests

- `git-publication-worktree-preservation.test.ts`: end-to-end assertion that publication never modifies the worktree, with timing assertions inside `onCommitPhase` callbacks (checked at every phase, not just after completion).
- **Negative control**: reverting the zero-checkout implementation back to `vcs.checkout` makes the test immediately fail with `AssertionError: worktree was clobbered at phases: trunk-checkout-done`. With the fix, all phases preserve content byte-for-byte.
- **Tracer alignment (ccb3d193)**: `production-authority-canonical-ingress-tracer.test.ts` previously asserted the legacy rollback contract (worktree reverts to trunk content after `doc sync --submit`), which directly contradicted this PR's preservation test — the two could never both pass. The worktree contract was adjudicated on 2026-08-09 (dec_01KZJMH1CZX3ZXBRJYG8WZA1F3, backed by the materializer-hypothesis forensic report under task_01KZFVSBRDR5QGDFKXTYD9HXCX: the field incident's materializer merged healthily within ~1s, so the rollback was the legacy contract's deterministic behavior, not a materializer-latency symptom). The tracer now asserts HEAD stays on the trunk branch and the authored file keeps the submitted content; index cleanliness is intentionally unasserted because the background materializer merge legitimately changes it in either direction.

## Eliminated vs. Narrowed

**Publication window: eliminated.** The worktree is never touched. User-authored content and unrelated uncommitted edits are fully protected.

**Materialization window: narrowed and fail-safe.** The materializer still resets paths the merge will touch (git refuses to merge over uncommitted local changes), but:
- Paths whose worktree content already equals the session branch are reset safely (merge restores the identical bytes).
- Paths that diverge from the session branch (edits authored after submission) are preserved before reset, not discarded.
- The narrow remaining risk: if the user edits *during* the few-millisecond window between `resetWorktreePaths` returning and `mergeNoFf` completing, that edit is not preserved. This is orders of magnitude smaller than the original window (which spanned from publication's `finally` to a separate later materialization pass).

## Task And Scope

- Harness task: task_01KZFVVC59JQ2MPDJKF5PQZ1N5
- Branch: `codex/publisher-worktree`
- Public scope: VCS port + implementation, write-coordination publication path, ledger materializer
- Private planning/evidence updated: yes
- Out of scope: batch 1 (diagnostic chain, separate task task_01KZFVSBRDR5QGDFKXTYD9HXCX, already merged as #1278)

## Version Impact

- Version: no version change; this is a defect fix with no public API shape change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: n/a
- Authority: task_01KZFVVC59JQ2MPDJKF5PQZ1N5; worktree contract adjudicated by dec_01KZJMH1CZX3ZXBRJYG8WZA1F3 (accepted 2026-08-09)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: n/a
- Break-glass scope: n/a
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: `90669b2869c712b4a8e8a15424b8d2d5be958953`
- Branch merge-base with `origin/main`: `90669b2869c712b4a8e8a15424b8d2d5be958953`
- Last `git fetch origin` time: 2026-08-08 06:06 UTC
- Sync method: none needed
- Public diff command: `git diff 90669b28..bc93f7fe`
- Private evidence commit/path: `harness/tasks/task_01KZFVVC59JQ2MPDJKF5PQZ1N5-publisher-must-not-occupy-the-user-worktree/artifacts/worker-mission.md`
- Reviewer evidence path: same
- GitHub Actions `rewrite-ci` run URL: pending
- [x] `git diff --check`
- [x] `npm run check:stop-point` (exit 0)
- [x] Targeted tests for the change surface:
  - `git-publication-worktree-preservation.test.ts`: publication never modifies worktree, timing assertions in every `onCommitPhase`, negative control passes (revert → `worktree was clobbered`)
  - kernel integration tier (327 pass / 0 fail in kernel/store)
- [x] Negative control discriminates (reverting zero-checkout → red)
- [ ] GitHub Actions `rewrite-ci` passed — not yet run
- Not run locally, and why: full `check:ci` and nightly not run (outside stop-point scope); session-cli and 4 other CLI integration tests fail with `daemon_unavailable` / "Could not resolve a registered harness repo root" on BOTH the clean base (main 90669b28) and this branch (identical 9 tests, 4 pass, 5 fail) — pre-existing, unrelated to this change.

## Review Evidence

- Self-review: verified zero-checkout implementation uses only git plumbing (no worktree checkout), verified preservation logic checks `restoreRef` before overwriting, confirmed negative control fails when reverted
- Reviewer subagent: GLM (session 318409e8-8d16-4e5d-9d31-643d87ad23c7) + self-amendment for materialization preservation
- Human review: pending
- Blocking findings: none

## Residual Risk

The materialization window between `resetWorktreePaths` completion and `mergeNoFf` completion (adjacent statements, ~milliseconds) remains observable. An edit made *during* that window is not preserved. This is orders of magnitude smaller than the original bug (which was async, spanning publication → materialization) and affects only paths the merge touches (not unrelated files). Fully eliminating it would require headless merge (via `git merge-tree`), which changes conflict semantics and recovery paths—deferred as separate work.

## References

- Task: task_01KZFVVC59JQ2MPDJKF5PQZ1N5
- Evidence: `harness/tasks/task_01KZFVVC59JQ2MPDJKF5PQZ1N5-publisher-must-not-occupy-the-user-worktree/artifacts/worker-mission.md`
- Review: GLM session 318409e8-8d16-4e5d-9d31-643d87ad23c7

---

# 中文

## 概要

真实消费者仓报告数据丢失：`doc sync --submit` 成功后，工作区 `task_plan.md` 变成占位模板，正确内容只在 HEAD 里。根因是发布器把共享工作区当临时舞台提交 session 分支，留下一个时序窗口——git 把工作区还原成 trunk（模板），一直等到 materializer 再把 session 内容 merge 回来。

本 PR 消除那个窗口。发布现在用零 checkout 的 git 管道（临时 index + `commit-tree` → `update-ref`），materializer 加了分歧编辑保全——提交后新写的、任何 ref 都不带的内容会被拷贝到一边而不是静默丢弃。

## 改动内容

### 发布（零 checkout）

- `headless-branch-commit.ts` 新增 `commitPathsToBranch` VCS 方法：用 `hash-object` → 临时 `GIT_INDEX_FILE` → `write-tree` → `commit-tree` → `update-ref` 从工作区 blob 组装提交，全程不碰共享工作区或 index。
- `git.ts` 发布：把 `checkoutSessionBranch()` + `finally { checkout(trunk) }` 换成调用 `commitPathsToBranch`。session 提交 headlessly 物化；工作区不被触碰。
- 完全删除 `checkoutSessionBranch` 函数。

### Materialization（保全分歧编辑）

- `resetWorktreePaths` 加可选 `restoreRef` 参数（merge 会还原的 session 分支）。覆盖前检查工作区内容是否已经等于 `restoreRef`。若相等，reset 是内容中性的（merge 还原一样的字节）。若分歧，那个内容是提交后新写的编辑——覆盖前拷到 `.harness/preserved-worktree-edits/<stamp>/<path>`。
- 返回 `PreservedWorktreeEdit[]` 说明拷了什么、拷到哪。
- Materializer 传 `restoreRef: branch` 并把 `preservedWorktreeEdits` 报在分支报告里，与既有的 `preservedArtifacts` 并列。

### 测试

- `git-publication-worktree-preservation.test.ts`：端到端断言发布永不修改工作区，时序断言在 `onCommitPhase` 回调里（每个 phase 都检查，不只是完成后）。
- **阴性对照**：把零 checkout 实现回退成 `vcs.checkout`，测试立刻红于 `AssertionError: worktree was clobbered at phases: trunk-checkout-done`。有修复时，所有 phase 内容逐字节一致。
- **tracer 对齐（ccb3d193）**：`production-authority-canonical-ingress-tracer.test.ts` 此前断言旧回退契约（doc sync 提交后工作树回退成 trunk 内容），与本 PR 的 preservation 测试同场景相反预期，二者不可能同时绿。工作树契约已于 2026-08-09 裁决（dec_01KZJMH1CZX3ZXBRJYG8WZA1F3，取证依据为 task_01KZFVSBRDR5QGDFKXTYD9HXCX 下的 materializer 假设取证报告：现场事故中 materializer 约 1 秒内健康合并，回退是旧契约的确定性行为而非物化迟滞症状）。tracer 现改为断言 HEAD 保持在 trunk 分支、authored 文件保留提交内容；index 干净与否有意不断言，因为后台 materializer 合并前后两态都合法。

## 消除 vs 收窄

**发布窗口：已消除。** 工作区永不被碰。用户写的内容和无关的未提交编辑完全受保护。

**Materialization 窗口：收窄且 fail-safe。** materializer 仍然重置 merge 要碰的路径（git 拒绝在未提交本地改动上 merge），但：
- 工作区内容已等于 session 分支的路径被安全重置（merge 还原一样的字节）。
- 与 session 分支分歧的路径（提交后新写的编辑）在重置前被保全，不被丢弃。
- 窄化后的剩余风险：若用户在 `resetWorktreePaths` 返回与 `mergeNoFf` 完成之间的几毫秒窗口**内**编辑，那笔编辑不被保全。这比原窗口（跨越发布的 `finally` 到另一趟单独的 materialization）小几个数量级。

## 任务与范围

- Harness 任务：task_01KZFVVC59JQ2MPDJKF5PQZ1N5
- 分支：`codex/publisher-worktree`
- 公开范围：VCS port + 实现、写协调发布路径、ledger materializer
- 私有计划 / 证据是否已更新：yes
- 范围外：批次 1（诊断链，独立任务 task_01KZFVSBRDR5QGDFKXTYD9HXCX，已作为 #1278 合并）

## 版本影响

- 版本：不改版本；这是缺陷修复，无公开 API 形状改变
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：task_01KZFVVC59JQ2MPDJKF5PQZ1N5
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无

## 验证

- `origin/main` 基准 SHA：`90669b2869c712b4a8e8a15424b8d2d5be958953`
- 当前分支与 `origin/main` 的 merge-base：`90669b2869c712b4a8e8a15424b8d2d5be958953`
- 最近一次 `git fetch origin` 时间：2026-08-08 06:06 UTC
- 同步方式：不需要
- 公开 diff 命令：`git diff 90669b28..bc93f7fe`
- 私有证据 commit/path：`harness/tasks/task_01KZFVVC59JQ2MPDJKF5PQZ1N5-publisher-must-not-occupy-the-user-worktree/artifacts/worker-mission.md`
- Reviewer 证据路径：同上
- GitHub Actions `rewrite-ci` run URL：待定
- [x] `git diff --check`
- [x] `npm run check:stop-point`（exit 0）
- [x] 改动面的定向测试：
  - `git-publication-worktree-preservation.test.ts`：发布永不修改工作区，每个 `onCommitPhase` 都有时序断言，阴性对照通过（回退 → `worktree was clobbered`）
  - kernel integration tier（kernel/store 327 pass / 0 fail）
- [x] 阴性对照有分辨力（回退零 checkout → 红）
- [ ] GitHub Actions `rewrite-ci` 通过 — 尚未跑
- 未跑项及原因：本地未跑完整 `check:ci` 与 nightly（超出 stop-point 范围）；session-cli 和另 4 个 CLI integration 测试在**干净基线（main 90669b28）和本分支上都失败**（一样的 9 测试、4 pass、5 fail），报 `daemon_unavailable` / "Could not resolve a registered harness repo root" — 既有问题，与本次改动无关。

## 审查证据

- 自查：验证零 checkout 实现只用 git 管道（无工作区 checkout），验证保全逻辑在覆盖前检查 `restoreRef`，确认阴性对照回退后失败
- Reviewer subagent：GLM（session 318409e8-8d16-4e5d-9d31-643d87ad23c7）+ 自补 materialization 保全
- 人工审查：待定
- 阻塞发现：无

## 残余风险

`resetWorktreePaths` 完成与 `mergeNoFf` 完成之间（相邻语句，~毫秒级）的 materialization 窗口仍可观察。**在那个窗口内**做的编辑不被保全。这比原缺陷（异步，跨发布 → materialization）小几个数量级，且只影响 merge 要碰的路径（不影响无关文件）。彻底消除需要 headless merge（通过 `git merge-tree`），那会改变冲突语义和恢复路径——作为独立工作延后。

## 关联材料

- 任务：task_01KZFVVC59JQ2MPDJKF5PQZ1N5
- 证据：`harness/tasks/task_01KZFVVC59JQ2MPDJKF5PQZ1N5-publisher-must-not-occupy-the-user-worktree/artifacts/worker-mission.md`
- 审查：GLM session 318409e8-8d16-4e5d-9d31-643d87ad23c7

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface，Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [ ] CI results are linked or explained. / CI 结果已链接或说明（远程 CI pending）。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后，或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录，否则不计划 admin bypass。

