### PR TITLE
fix(daemon,application): route authority cutover to the writer child and scope task supersede writes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13658,6 +13658,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.3",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
@@ -13854,7 +13869,8 @@
         "@harness-anything/adapter-local": "0.1.0",
         "@harness-anything/api-contracts": "0.1.0",
         "@harness-anything/application": "0.1.0",
-        "@harness-anything/kernel": "0.1.0"
+        "@harness-anything/kernel": "0.1.0",
+        "yaml": "^2.9.0"
       },
       "optionalDependencies": {
         "node-pty": "^1.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13658,21 +13658,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yargs": {
       "version": "17.7.3",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
@@ -13869,8 +13854,7 @@
         "@harness-anything/adapter-local": "0.1.0",
         "@harness-anything/api-contracts": "0.1.0",
         "@harness-anything/application": "0.1.0",
-        "@harness-anything/kernel": "0.1.0",
-        "yaml": "^2.9.0"
+        "@harness-anything/kernel": "0.1.0"
       },
       "optionalDependencies": {
         "node-pty": "^1.1.0"

--- a/packages/application/src/agent-runtime-control.ts
+++ b/packages/application/src/agent-runtime-control.ts
@@ -52,6 +52,10 @@ export interface AgentRuntimeSessionStatus {
     readonly taskId?: string;
     readonly executionId?: string;
   };
+  readonly spawnMetadata?: {
+    readonly profileKind: string;
+    readonly effectiveBaseUrl?: string;
+  };
 }
 
 export interface AgentRuntimeSessionResult {

--- a/packages/application/src/authority/repo-write-authority-cutover-action-schemas.ts
+++ b/packages/application/src/authority/repo-write-authority-cutover-action-schemas.ts
@@ -1,0 +1,56 @@
+import {
+  strictArray,
+  strictEnum,
+  strictLiteral,
+  strictObject,
+  strictString
+} from "./strict-command-schema.ts";
+
+const pendingClassification = strictObject({
+  opId: strictString,
+  disposition: strictEnum("retryable-not-committed", "indeterminate"),
+  recordedTupleDigest: strictString,
+  evidenceRef: strictString
+});
+
+/**
+ * Authority cutover controls cross the repo-write child boundary because the
+ * production daemon keeps no authority engine of its own; the engine lives in
+ * the child. These schemas are the wire shape for that crossing.
+ */
+export const repoWriteAuthorityCutoverActionSchemas = {
+  "authority-cutover-status": strictObject({
+    kind: strictLiteral("authority-cutover-status")
+  }),
+  "authority-cutover-drain": strictObject({
+    kind: strictLiteral("authority-cutover-drain"),
+    classifications: strictArray(pendingClassification)
+  }),
+  "authority-cutover-scan": strictObject({
+    kind: strictLiteral("authority-cutover-scan"),
+    profileId: strictLiteral("production-final-scan/v1")
+  }),
+  "authority-cutover-confirm": strictObject({
+    kind: strictLiteral("authority-cutover-confirm"),
+    firstScanId: strictString,
+    secondScanId: strictString
+  }),
+  "authority-cutover-boundary": strictObject({
+    kind: strictLiteral("authority-cutover-boundary"),
+    boundaryId: strictString,
+    equalityReceiptId: strictString,
+    expectedSelectedSchemaTupleDigest: strictString
+  }),
+  "authority-cutover-freeze": strictObject({
+    kind: strictLiteral("authority-cutover-freeze"),
+    reason: strictString,
+    expectedBoundaryReceiptDigest: strictString
+  }),
+  "authority-cutover-re-enable": strictObject({
+    kind: strictLiteral("authority-cutover-re-enable"),
+    boundaryId: strictString,
+    expectedFreezeReceiptDigest: strictString,
+    equalityReceiptId: strictString,
+    forwardFixRef: strictString
+  })
+} as const;

--- a/packages/application/src/authority/repo-write-command-action.ts
+++ b/packages/application/src/authority/repo-write-command-action.ts
@@ -1,3 +1,4 @@
+import { repoWriteAuthorityCutoverActionSchemas } from "./repo-write-authority-cutover-action-schemas.ts";
 import { repoWriteKnowledgeActionSchemas } from "./repo-write-knowledge-action-schemas.ts";
 import { repoWriteOperationsActionSchemas } from "./repo-write-operations-action-schemas.ts";
 import { repoWriteTaskActionSchemas } from "./repo-write-task-action-schemas.ts";
@@ -10,7 +11,8 @@ import {
 const repoWriteCommandActionSchemas = {
   ...repoWriteTaskActionSchemas,
   ...repoWriteKnowledgeActionSchemas,
-  ...repoWriteOperationsActionSchemas
+  ...repoWriteOperationsActionSchemas,
+  ...repoWriteAuthorityCutoverActionSchemas
 } as const;
 
 type RepoWriteCommandActionSchemaMap = typeof repoWriteCommandActionSchemas;

--- a/packages/application/src/authority/task-decision-module-semantic-compiler-v2.ts
+++ b/packages/application/src/authority/task-decision-module-semantic-compiler-v2.ts
@@ -30,27 +30,19 @@ import {
   type DecisionStatePayloadV2,
   type TaskAppendPayloadV2,
   type TaskAmendPayloadV2,
-  type TaskArchivePayloadV2,
   type TaskCreatePayloadV2,
   type TaskDecisionModuleCommandPayloadV2,
   type TaskDocumentPayloadV2,
-  type TaskDeletePayloadV2,
   type TaskRelatePayloadV2,
-  type TaskReopenPayloadV2,
-  type TaskSupersedePayloadV2,
   type TaskTransitionPayloadV2
 } from "./task-decision-module-command-v2.ts";
-import {
-  type AuthoritySemanticCompilerV2,
-  type RegistryEntityRefV2
-} from "./semantic-mutation-envelope-v2.ts";
+import { type AuthoritySemanticCompilerV2 } from "./semantic-mutation-envelope-v2.ts";
 import {
   semanticAdmissionV2 as admission,
   semanticMutationPlanV2 as taskDecisionModulePlan,
   verifySemanticBaseCasV2,
   verifySemanticPathCasV2
 } from "./semantic-authority-helpers-v2.ts";
-import type { HostedDocumentSnapshotV2 } from "./fact-relation-semantic-compiler-v2.ts";
 import {
   compileDecisionAmendV2,
   compileDecisionRelationReplaceV2,
@@ -79,7 +71,7 @@ import {
   taskDecisionModuleEntityRef,
   taskDecisionModulePath as taskPath
 } from "./task-decision-module-refs.ts";
-import { parseTaskIndex, sameTaskLifecycleCore } from "./task-index-v2.ts";
+import { parseTaskIndex } from "./task-index-v2.ts";
 import { enteringExecutionWip } from "./task-wip-policy.ts";
 import { taskTransitionAlreadySatisfiedVerifierV1 } from "./task-transition-already-satisfied-v1.ts";
 import type {
@@ -88,7 +80,7 @@ import type {
   TaskDecisionModuleSemanticCompilerV2Options
 } from "./task-decision-module-semantic-compiler-types.ts";
 import { taskReturnToIdeaPublicationRevalidation } from "./task-return-to-idea-policy.ts";
-import { taskExecutionAdmissionPublicationRevalidation, type TaskExecutionAdmissionPortsV1 } from "./task-execution-admission-policy.ts";
+import { taskExecutionAdmissionPublicationRevalidation } from "./task-execution-admission-policy.ts";
 
 export {
   encodeTaskDecisionModuleCommandPayloadV2,
@@ -106,15 +98,11 @@ export {
   type ModuleUnregisterPayloadV2,
   type TaskAppendPayloadV2,
   type TaskAmendPayloadV2,
-  type TaskArchivePayloadV2,
   type TaskCreatePayloadV2,
   type TaskDecisionModuleCommandPayloadV2,
   type TaskDecisionModuleTypedCommandV2,
   type TaskDocumentPayloadV2,
-  type TaskDeletePayloadV2,
   type TaskRelatePayloadV2,
-  type TaskReopenPayloadV2,
-  type TaskSupersedePayloadV2,
   type TaskTransitionPayloadV2
 } from "./task-decision-module-command-v2.ts";
 

--- a/packages/application/src/authority/task-decision-module-semantic-compiler-v2.ts
+++ b/packages/application/src/authority/task-decision-module-semantic-compiler-v2.ts
@@ -62,6 +62,14 @@ import {
   compileModuleStepV2,
   compileModuleUnregisterV2
 } from "./task-decision-module-module-mutations-v2.ts";
+import {
+  compileTaskDisposition,
+  compileTaskSupersede
+} from "./task-decision-module-task-disposition-mutations-v2.ts";
+import {
+  requiredTaskDecisionModuleDocument,
+  taskCompilation
+} from "./task-decision-module-task-compilation-v2.ts";
 import { taskCreateModuleReadDependencyV2 } from "./task-decision-module-task-create-module-selection-v2.ts";
 import {
   assertTaskDocumentSurfaceV2
@@ -282,77 +290,6 @@ async function compileTaskAmend(
   ], [{ path, snapshot }]);
 }
 
-async function compileTaskDisposition(
-  state: TaskDecisionModuleAuthorityStateV2,
-  payload: TaskArchivePayloadV2 | TaskDeletePayloadV2 | TaskReopenPayloadV2,
-  disposition: "active" | "archived" | "tombstoned",
-  kind: "package_archive" | "package_tombstone" | "package_reopen",
-  executionAdmission?: TaskExecutionAdmissionPortsV1
-): Promise<CompiledTaskDecisionModuleCommandV2> {
-  const path = taskPath(payload.taskId, "INDEX.md");
-  const snapshot = await requiredTaskDecisionModuleDocument(state, path, "TASK_INDEX_NOT_FOUND");
-  const current = parseTaskIndex(snapshot.body);
-  const next = parseTaskIndex(payload.body);
-  if (current.taskId !== payload.taskId || next.taskId !== payload.taskId) throw admission("TASK_ID_MISMATCH");
-  if (next.packageDisposition !== disposition || !sameTaskLifecycleCore(current, next)) {
-    throw admission("TASK_DISPOSITION_BODY_INVALID");
-  }
-  if (!payload.body.includes(payload.reason)) throw admission("TASK_DISPOSITION_REASON_REQUIRED");
-  const compiled = taskCompilation(payload.taskId, "document", kind, { path: "INDEX.md", body: payload.body }, [
-    taskDecisionModuleEntityRef("task", `task/${payload.taskId}`)
-  ], [{ path, snapshot }]);
-  return enteringExecutionWip(
-    current.status,
-    current.packageDisposition,
-    next.status,
-    next.packageDisposition
-  )
-    ? {
-      ...compiled,
-      publicationRevalidation: taskExecutionAdmissionPublicationRevalidation(executionAdmission ?? {}, payload.taskId)
-    }
-    : compiled;
-}
-
-async function compileTaskSupersede(
-  state: TaskDecisionModuleAuthorityStateV2,
-  payload: TaskSupersedePayloadV2
-): Promise<CompiledTaskDecisionModuleCommandV2> {
-  if (payload.body !== undefined) {
-    if (!payload.replacementTaskId || payload.writes) throw admission("TASK_SUPERSEDE_PAYLOAD_INVALID");
-    const compiled = await compileTaskDisposition(state, {
-      schema: "task.archive/v1", taskId: payload.taskId, reason: `supersededBy=${payload.replacementTaskId}`, body: payload.body
-    }, "archived", "package_archive");
-    const replacementPath = taskPath(payload.replacementTaskId, "INDEX.md");
-    const replacementSnapshot = await requiredTaskDecisionModuleDocument(state, replacementPath, "TASK_SUPERSEDE_TARGET_NOT_FOUND");
-    return {
-      ...compiled,
-      requiredBaseRefs: [...compiled.requiredBaseRefs, taskDecisionModuleEntityRef("task", `task/${payload.replacementTaskId}`)],
-      requiredPathSnapshots: [...compiled.requiredPathSnapshots, { path: replacementPath, snapshot: replacementSnapshot }]
-    };
-  }
-  if (!payload.replacementTaskId || !payload.writes) throw admission("TASK_SUPERSEDE_PAYLOAD_INVALID");
-  const oldPath = taskPath(payload.taskId, "INDEX.md");
-  const oldSnapshot = await requiredTaskDecisionModuleDocument(state, oldPath, "TASK_INDEX_NOT_FOUND");
-  const oldWrite = payload.writes.find((write) => write.taskId === payload.taskId && write.path === "INDEX.md");
-  const newWrite = payload.writes.find((write) => write.taskId === payload.replacementTaskId && write.path === "INDEX.md");
-  const relationWrite = payload.writes.find((write) => write.taskId === payload.replacementTaskId && write.path === "relations.md");
-  if (!oldWrite || !newWrite || !relationWrite || parseTaskIndex(oldWrite.body).packageDisposition !== "archived"
-    || parseTaskIndex(newWrite.body).status !== "planned"
-    || !relationWrite.body.includes(`task/${payload.replacementTaskId} supersedes task/${payload.taskId}`)) {
-    throw admission("TASK_SUPERSEDE_WRITES_INVALID");
-  }
-  return {
-    mutationPlan: taskDecisionModulePlan([
-      { entityKind: "task", identity: { taskId: payload.taskId }, action: "document", storageContext: { documentPath: "INDEX.md" } },
-      { entityKind: "task", identity: { taskId: payload.replacementTaskId }, action: "create" }
-    ]),
-    operation: { opId: "authority-overrides-this", entityId: taskEntityId(payload.taskId), kind: "package_supersede", payload: { writes: payload.writes } },
-    requiredBaseRefs: [taskDecisionModuleEntityRef("task", `task/${payload.taskId}`), taskDecisionModuleEntityRef("task", `task/${payload.replacementTaskId}`)],
-    requiredPathSnapshots: [{ path: oldPath, snapshot: oldSnapshot }]
-  };
-}
-
 async function compileTaskRelate(
   state: TaskDecisionModuleAuthorityStateV2,
   payload: TaskRelatePayloadV2
@@ -381,25 +318,6 @@ async function compileTaskRelate(
       taskDecisionModuleEntityRef("relation", `relation/${relation.relation_id}`)
     ],
     requiredPathSnapshots: [{ path, snapshot }, { path: targetPath, snapshot: targetSnapshot }]
-  };
-}
-
-function taskCompilation(
-  taskId: string,
-  action: "create" | "transition" | "append" | "document",
-  kind: WriteOpKind,
-  payload: unknown,
-  requiredBaseRefs: ReadonlyArray<RegistryEntityRefV2>,
-  requiredPathSnapshots: ReadonlyArray<{ readonly path: string; readonly snapshot: HostedDocumentSnapshotV2 }> = []
-): CompiledTaskDecisionModuleCommandV2 {
-  const documentPath = "path" in (payload as object)
-    ? (payload as { readonly path: string }).path
-    : "INDEX.md";
-  return {
-    mutationPlan: taskDecisionModulePlan([{ entityKind: "task", identity: { taskId }, action, storageContext: { documentPath } }]),
-    operation: { opId: "authority-overrides-this", entityId: taskEntityId(taskId), kind, payload },
-    requiredBaseRefs,
-    requiredPathSnapshots
   };
 }
 
@@ -574,16 +492,6 @@ function relationCreateIntent(relation: EntityRelationRecord): RegistryMutationP
     action: "create",
     storageContext: { sourceRef: relation.source }
   };
-}
-
-async function requiredTaskDecisionModuleDocument(
-  state: TaskDecisionModuleAuthorityStateV2,
-  path: string,
-  code: string
-): Promise<HostedDocumentSnapshotV2> {
-  const snapshot = await state.readHostedDocument(path);
-  if (!snapshot) throw admission(code);
-  return snapshot;
 }
 
 function decisionPath(decisionId: string): string {

--- a/packages/application/src/authority/task-decision-module-task-compilation-v2.ts
+++ b/packages/application/src/authority/task-decision-module-task-compilation-v2.ts
@@ -1,0 +1,42 @@
+import { taskEntityId, type WriteOpKind } from "@harness-anything/kernel";
+import { semanticAdmissionV2 as admission, semanticMutationPlanV2 as taskDecisionModulePlan } from "./semantic-authority-helpers-v2.ts";
+import type { HostedDocumentSnapshotV2 } from "./fact-relation-semantic-compiler-v2.ts";
+import type { RegistryEntityRefV2 } from "./semantic-mutation-envelope-v2.ts";
+import type {
+  CompiledTaskDecisionModuleCommandV2,
+  TaskDecisionModuleAuthorityStateV2
+} from "./task-decision-module-semantic-compiler-types.ts";
+
+/**
+ * Shared task compilation primitives. These live outside the command compilers
+ * so that per-family modules (lifecycle, disposition, relations) can use them
+ * without importing each other.
+ */
+export function taskCompilation(
+  taskId: string,
+  action: "create" | "transition" | "append" | "document",
+  kind: WriteOpKind,
+  payload: unknown,
+  requiredBaseRefs: ReadonlyArray<RegistryEntityRefV2>,
+  requiredPathSnapshots: ReadonlyArray<{ readonly path: string; readonly snapshot: HostedDocumentSnapshotV2 }> = []
+): CompiledTaskDecisionModuleCommandV2 {
+  const documentPath = "path" in (payload as object)
+    ? (payload as { readonly path: string }).path
+    : "INDEX.md";
+  return {
+    mutationPlan: taskDecisionModulePlan([{ entityKind: "task", identity: { taskId }, action, storageContext: { documentPath } }]),
+    operation: { opId: "authority-overrides-this", entityId: taskEntityId(taskId), kind, payload },
+    requiredBaseRefs,
+    requiredPathSnapshots
+  };
+}
+
+export async function requiredTaskDecisionModuleDocument(
+  state: TaskDecisionModuleAuthorityStateV2,
+  path: string,
+  code: string
+): Promise<HostedDocumentSnapshotV2> {
+  const snapshot = await state.readHostedDocument(path);
+  if (!snapshot) throw admission(code);
+  return snapshot;
+}

--- a/packages/application/src/authority/task-decision-module-task-disposition-mutations-v2.ts
+++ b/packages/application/src/authority/task-decision-module-task-disposition-mutations-v2.ts
@@ -1,0 +1,110 @@
+import { taskEntityId } from "@harness-anything/kernel";
+import type {
+  TaskArchivePayloadV2,
+  TaskDeletePayloadV2,
+  TaskReopenPayloadV2,
+  TaskSupersedePayloadV2
+} from "./task-decision-module-command-v2.ts";
+import { semanticAdmissionV2 as admission, semanticMutationPlanV2 as taskDecisionModulePlan } from "./semantic-authority-helpers-v2.ts";
+import type {
+  CompiledTaskDecisionModuleCommandV2,
+  TaskDecisionModuleAuthorityStateV2
+} from "./task-decision-module-semantic-compiler-types.ts";
+import {
+  taskDecisionModuleEntityRef,
+  taskDecisionModulePath as taskPath
+} from "./task-decision-module-refs.ts";
+import {
+  requiredTaskDecisionModuleDocument,
+  taskCompilation
+} from "./task-decision-module-task-compilation-v2.ts";
+import { parseTaskIndex, sameTaskLifecycleCore } from "./task-index-v2.ts";
+import { enteringExecutionWip } from "./task-wip-policy.ts";
+import { taskExecutionAdmissionPublicationRevalidation, type TaskExecutionAdmissionPortsV1 } from "./task-execution-admission-policy.ts";
+
+export async function compileTaskDisposition(
+  state: TaskDecisionModuleAuthorityStateV2,
+  payload: TaskArchivePayloadV2 | TaskDeletePayloadV2 | TaskReopenPayloadV2,
+  disposition: "active" | "archived" | "tombstoned",
+  kind: "package_archive" | "package_tombstone" | "package_reopen",
+  executionAdmission?: TaskExecutionAdmissionPortsV1
+): Promise<CompiledTaskDecisionModuleCommandV2> {
+  const path = taskPath(payload.taskId, "INDEX.md");
+  const snapshot = await requiredTaskDecisionModuleDocument(state, path, "TASK_INDEX_NOT_FOUND");
+  const current = parseTaskIndex(snapshot.body);
+  const next = parseTaskIndex(payload.body);
+  if (current.taskId !== payload.taskId || next.taskId !== payload.taskId) throw admission("TASK_ID_MISMATCH");
+  if (next.packageDisposition !== disposition || !sameTaskLifecycleCore(current, next)) {
+    throw admission("TASK_DISPOSITION_BODY_INVALID");
+  }
+  if (!payload.body.includes(payload.reason)) throw admission("TASK_DISPOSITION_REASON_REQUIRED");
+  const compiled = taskCompilation(payload.taskId, "document", kind, { path: "INDEX.md", body: payload.body }, [
+    taskDecisionModuleEntityRef("task", `task/${payload.taskId}`)
+  ], [{ path, snapshot }]);
+  return enteringExecutionWip(
+    current.status,
+    current.packageDisposition,
+    next.status,
+    next.packageDisposition
+  )
+    ? {
+      ...compiled,
+      publicationRevalidation: taskExecutionAdmissionPublicationRevalidation(executionAdmission ?? {}, payload.taskId)
+    }
+    : compiled;
+}
+
+export async function compileTaskSupersede(
+  state: TaskDecisionModuleAuthorityStateV2,
+  payload: TaskSupersedePayloadV2
+): Promise<CompiledTaskDecisionModuleCommandV2> {
+  if (payload.body !== undefined) {
+    if (!payload.replacementTaskId || payload.writes) throw admission("TASK_SUPERSEDE_PAYLOAD_INVALID");
+    const compiled = await compileTaskDisposition(state, {
+      schema: "task.archive/v1", taskId: payload.taskId, reason: `supersededBy=${payload.replacementTaskId}`, body: payload.body
+    }, "archived", "package_archive");
+    const replacementPath = taskPath(payload.replacementTaskId, "INDEX.md");
+    const replacementSnapshot = await requiredTaskDecisionModuleDocument(state, replacementPath, "TASK_SUPERSEDE_TARGET_NOT_FOUND");
+    return {
+      ...compiled,
+      requiredBaseRefs: [...compiled.requiredBaseRefs, taskDecisionModuleEntityRef("task", `task/${payload.replacementTaskId}`)],
+      requiredPathSnapshots: [...compiled.requiredPathSnapshots, { path: replacementPath, snapshot: replacementSnapshot }]
+    };
+  }
+  if (!payload.replacementTaskId || !payload.writes) throw admission("TASK_SUPERSEDE_PAYLOAD_INVALID");
+  const oldPath = taskPath(payload.taskId, "INDEX.md");
+  const oldSnapshot = await requiredTaskDecisionModuleDocument(state, oldPath, "TASK_INDEX_NOT_FOUND");
+  const oldWrite = payload.writes.find((write) => write.taskId === payload.taskId && write.path === "INDEX.md");
+  const newWrite = payload.writes.find((write) => write.taskId === payload.replacementTaskId && write.path === "INDEX.md");
+  const relationWrite = payload.writes.find((write) => write.taskId === payload.replacementTaskId && write.path === "relations.md");
+  if (!oldWrite || !newWrite || !relationWrite || parseTaskIndex(oldWrite.body).packageDisposition !== "archived"
+    || parseTaskIndex(newWrite.body).status !== "planned"
+    || !relationWrite.body.includes(`task/${payload.replacementTaskId} supersedes task/${payload.taskId}`)) {
+    throw admission("TASK_SUPERSEDE_WRITES_INVALID");
+  }
+  // Every replacement document must be declared. An undeclared create locates
+  // the package directory itself, and that bare prefix path is never covered by
+  // the exact portable-path scopes minted from the observed write set.
+  const replacementDocumentPaths = [...new Set(payload.writes
+    .filter((write) => write.taskId === payload.replacementTaskId)
+    .map((write) => write.path))].sort();
+  const [replacementDocumentPath, ...additionalReplacementDocumentPaths] = replacementDocumentPaths;
+  if (!replacementDocumentPath) throw admission("TASK_SUPERSEDE_WRITES_INVALID");
+  return {
+    mutationPlan: taskDecisionModulePlan([
+      { entityKind: "task", identity: { taskId: payload.taskId }, action: "document", storageContext: { documentPath: "INDEX.md" } },
+      {
+        entityKind: "task",
+        identity: { taskId: payload.replacementTaskId },
+        action: "create",
+        storageContext: { documentPath: replacementDocumentPath },
+        ...(additionalReplacementDocumentPaths.length > 0 ? {
+          additionalStorageContexts: additionalReplacementDocumentPaths.map((documentPath) => ({ documentPath }))
+        } : {})
+      }
+    ]),
+    operation: { opId: "authority-overrides-this", entityId: taskEntityId(payload.taskId), kind: "package_supersede", payload: { writes: payload.writes } },
+    requiredBaseRefs: [taskDecisionModuleEntityRef("task", `task/${payload.taskId}`), taskDecisionModuleEntityRef("task", `task/${payload.replacementTaskId}`)],
+    requiredPathSnapshots: [{ path: oldPath, snapshot: oldSnapshot }]
+  };
+}

--- a/packages/application/test/task-decision-module-managed-prose-regions-v2.test.ts
+++ b/packages/application/test/task-decision-module-managed-prose-regions-v2.test.ts
@@ -1,0 +1,136 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { compileManagedCandidateTreeV2 } from "../src/index.ts";
+import {
+  compileRegistryMutationPlan,
+  createWritableEntityRegistry,
+  entityRegistry,
+  ManagedSemanticDiffError
+} from "../../kernel/src/index.ts";
+
+test("managed heading regions merge multi-file task prose without guessing the subject from its path", () => {
+  const taskId = "task_T";
+  const indexPath = `tasks/${taskId}-folder/INDEX.md`;
+  const planPath = `tasks/${taskId}-folder/task_plan.md`;
+  const briefPath = `tasks/${taskId}-folder/brief.md`;
+  const base = {
+    documents: [
+      { path: indexPath, body: taskIndex(taskId, "active") },
+      { path: planPath, body: managedBody("Plan", "## Goal", "Old goal") },
+      { path: briefPath, body: managedBody("Brief", "## Summary", "Old summary") }
+    ]
+  };
+  const candidate = {
+    documents: [
+      { path: indexPath, body: taskIndex(taskId, "active") },
+      { path: planPath, body: managedBody("Plan", "## Goal", "New goal") },
+      { path: briefPath, body: managedBody("Brief", "## Summary", "New summary") }
+    ]
+  };
+  const mutationPlan = compileManagedCandidateTreeV2(base, candidate, [
+    freeProsePolicy(planPath, "## Goal"),
+    freeProsePolicy(briefPath, "## Summary")
+  ], [{ kind: "task", semanticDiff: entityRegistry.task.semanticDiff }]);
+  assert.equal(mutationPlan.mutations.length, 1);
+  assert.deepEqual(mutationPlan.mutations[0]?.identity, { taskId });
+  assert.equal(mutationPlan.mutations[0]?.action, "document");
+  const compiled = compileRegistryMutationPlan(createWritableEntityRegistry([entityRegistry.task]), mutationPlan);
+  assert.deepEqual(compiled.storagePlan.touchedPaths, [briefPath, planPath]);
+
+  assert.throws(() => compileManagedCandidateTreeV2({
+    documents: [{ path: planPath, body: managedBody("Plan", "## Goal", "Old goal") }]
+  }, {
+    documents: [{ path: planPath, body: managedBody("Plan", "## Goal", "New goal") }]
+  }, [freeProsePolicy(planPath, "## Goal")], [{ kind: "task", semanticDiff: entityRegistry.task.semanticDiff }]), /SEMANTIC_DIFF_REQUIRED:task identity must come from INDEX\.md/u);
+});
+
+test("managed heading regions fail closed on undeclared, duplicate, machine-written, and forbidden edits", () => {
+  const documentPath = "tasks/task_T-folder/task_plan.md";
+  const index = { path: "tasks/task_T-folder/INDEX.md", body: taskIndex("task_T", "active") };
+  const compile = (baseBody: string, candidateBody: string, writeMode: "free-prose" | "machine-written" | "forbidden") =>
+    compileManagedCandidateTreeV2({ documents: [index, { path: documentPath, body: baseBody }] }, {
+      documents: [index, { path: documentPath, body: candidateBody }]
+    }, [{
+      path: documentPath,
+      sections: [{
+        anchor: "## Goal",
+        writeMode,
+        ...(writeMode === "free-prose" ? { semanticClass: "host-prose-only" as const } : {})
+      }]
+    }], [{ kind: "task", semanticDiff: entityRegistry.task.semanticDiff }]);
+
+  assert.throws(() => compile(
+    managedBody("Plan", "## Goal", "Old"),
+    `${managedBody("Plan", "## Goal", "New")}\n## Surprise\n\nUndeclared.\n`,
+    "free-prose"
+  ), (error: unknown) => error instanceof ManagedSemanticDiffError
+    && error.code === "SEMANTIC_DIFF_REQUIRED"
+    && /undeclared section/u.test(error.message));
+  assert.throws(() => compile(
+    managedBody("Plan", "## Goal", "Old"),
+    `${managedBody("Plan", "## Goal", "New")}\n## Goal\n\nDuplicate.\n`,
+    "free-prose"
+  ), (error: unknown) => error instanceof ManagedSemanticDiffError
+    && error.code === "SEMANTIC_DIFF_AMBIGUOUS"
+    && /duplicate heading/u.test(error.message));
+  assert.throws(() => compile(
+    managedBody("Plan", "## Goal", "Old"), managedBody("Plan", "## Goal", "New"), "machine-written"
+  ), /SEMANTIC_DIFF_REQUIRED:machine-written section requires typed command/u);
+  assert.throws(() => compile(
+    managedBody("Plan", "## Goal", "Old"), managedBody("Plan", "## Goal", "New"), "forbidden"
+  ), /SEMANTIC_DIFF_REQUIRED:forbidden section changed/u);
+});
+
+test("host-prose policies allow undeclared sections without weakening their declared skeleton", () => {
+  const taskId = "task_T";
+  const documentPath = `tasks/${taskId}-folder/task_plan.md`;
+  const index = { path: `tasks/${taskId}-folder/INDEX.md`, body: taskIndex(taskId, "active") };
+  const policy = {
+    ...freeProsePolicy(documentPath, "## Goal"),
+    undeclaredSections: "allow" as const
+  };
+
+  assert.doesNotThrow(() => compileManagedCandidateTreeV2({
+    documents: [index, { path: documentPath, body: managedBody("Plan", "## Goal", "Old") }]
+  }, {
+    documents: [index, {
+      path: documentPath,
+      body: `${managedBody("Plan", "## Goal", "Old")}\n## Review Addendum\n\nNew context.\n`
+    }]
+  }, [policy], [{ kind: "task", semanticDiff: entityRegistry.task.semanticDiff }]));
+
+  assert.throws(() => compileManagedCandidateTreeV2({
+    documents: [index, { path: documentPath, body: managedBody("Plan", "## Goal", "Old") }]
+  }, {
+    documents: [index, { path: documentPath, body: managedBody("Plan", "## Purpose", "Old") }]
+  }, [policy], [{ kind: "task", semanticDiff: entityRegistry.task.semanticDiff }]),
+  /SEMANTIC_DIFF_AMBIGUOUS:.*## Goal/u);
+});
+
+function taskIndex(
+  taskId: string,
+  status: string,
+  packageDisposition: "active" | "archived" | "tombstoned" = "active"
+): string {
+  return [
+    "---", "schema: task-package/v2", `task_id: ${taskId}`, `title: ${taskId}`,
+    "lifecycle:", "  bindingSchema: lifecycle-binding/v1", "  engine: local", `  status: ${status}`,
+    "  ref: ", `  titleSnapshot: ${taskId}`, "  url: ",
+    "  bindingCreatedAt: 2026-07-14T00:00:00.000Z", `  bindingFingerprint: sha256:${"b".repeat(64)}`,
+    `packageDisposition: ${packageDisposition}`, "vertical: default", "preset: default",
+    "provenance:", "  - {runtime: codex, sessionId: session-w3, boundAt: 2026-07-14T00:00:00.000Z}",
+    "---", "", `# ${taskId}`, ""
+  ].join("\n");
+}
+
+function managedBody(title: string, anchor: string, body: string): string {
+  return [`# ${title}`, "", anchor, "", body, ""].join("\n");
+}
+
+function freeProsePolicy(pathValue: string, anchor: string) {
+  return {
+    path: pathValue,
+    sections: [{ anchor, writeMode: "free-prose" as const, semanticClass: "host-prose-only" as const }]
+  };
+}

--- a/packages/application/test/task-decision-module-semantic-compiler-v2.test.ts
+++ b/packages/application/test/task-decision-module-semantic-compiler-v2.test.ts
@@ -7,7 +7,6 @@ import test from "node:test";
 import {
   assertMutationClaimMatchesV2,
   canonicalPayloadDigestV2,
-  compileManagedCandidateTreeV2,
   encodeFactRelationCommandPayloadV2,
   encodeTaskDecisionModuleCommandPayloadV2,
   makeFactRelationSemanticCompilerV2,
@@ -35,7 +34,6 @@ import {
   createWritableEntityRegistry,
   deriveRelationId,
   entityRegistry,
-  ManagedSemanticDiffError,
   type DecisionPackage,
   type EntityRegistration,
   type EntityRelationRecord
@@ -48,105 +46,6 @@ const registry = createWritableEntityRegistry([
   entityRegistry.relation
 ]);
 const stateDigest = Buffer.alloc(32, 0x11);
-
-test("managed heading regions merge multi-file task prose without guessing the subject from its path", () => {
-  const taskId = "task_T";
-  const indexPath = `tasks/${taskId}-folder/INDEX.md`;
-  const planPath = `tasks/${taskId}-folder/task_plan.md`;
-  const briefPath = `tasks/${taskId}-folder/brief.md`;
-  const base = {
-    documents: [
-      { path: indexPath, body: taskIndex(taskId, "active") },
-      { path: planPath, body: managedBody("Plan", "## Goal", "Old goal") },
-      { path: briefPath, body: managedBody("Brief", "## Summary", "Old summary") }
-    ]
-  };
-  const candidate = {
-    documents: [
-      { path: indexPath, body: taskIndex(taskId, "active") },
-      { path: planPath, body: managedBody("Plan", "## Goal", "New goal") },
-      { path: briefPath, body: managedBody("Brief", "## Summary", "New summary") }
-    ]
-  };
-  const mutationPlan = compileManagedCandidateTreeV2(base, candidate, [
-    freeProsePolicy(planPath, "## Goal"),
-    freeProsePolicy(briefPath, "## Summary")
-  ], [{ kind: "task", semanticDiff: entityRegistry.task.semanticDiff }]);
-  assert.equal(mutationPlan.mutations.length, 1);
-  assert.deepEqual(mutationPlan.mutations[0]?.identity, { taskId });
-  assert.equal(mutationPlan.mutations[0]?.action, "document");
-  const compiled = compileRegistryMutationPlan(createWritableEntityRegistry([entityRegistry.task]), mutationPlan);
-  assert.deepEqual(compiled.storagePlan.touchedPaths, [briefPath, planPath]);
-
-  assert.throws(() => compileManagedCandidateTreeV2({
-    documents: [{ path: planPath, body: managedBody("Plan", "## Goal", "Old goal") }]
-  }, {
-    documents: [{ path: planPath, body: managedBody("Plan", "## Goal", "New goal") }]
-  }, [freeProsePolicy(planPath, "## Goal")], [{ kind: "task", semanticDiff: entityRegistry.task.semanticDiff }]), /SEMANTIC_DIFF_REQUIRED:task identity must come from INDEX\.md/u);
-});
-
-test("managed heading regions fail closed on undeclared, duplicate, machine-written, and forbidden edits", () => {
-  const documentPath = "tasks/task_T-folder/task_plan.md";
-  const index = { path: "tasks/task_T-folder/INDEX.md", body: taskIndex("task_T", "active") };
-  const compile = (baseBody: string, candidateBody: string, writeMode: "free-prose" | "machine-written" | "forbidden") =>
-    compileManagedCandidateTreeV2({ documents: [index, { path: documentPath, body: baseBody }] }, {
-      documents: [index, { path: documentPath, body: candidateBody }]
-    }, [{
-      path: documentPath,
-      sections: [{
-        anchor: "## Goal",
-        writeMode,
-        ...(writeMode === "free-prose" ? { semanticClass: "host-prose-only" as const } : {})
-      }]
-    }], [{ kind: "task", semanticDiff: entityRegistry.task.semanticDiff }]);
-
-  assert.throws(() => compile(
-    managedBody("Plan", "## Goal", "Old"),
-    `${managedBody("Plan", "## Goal", "New")}\n## Surprise\n\nUndeclared.\n`,
-    "free-prose"
-  ), (error: unknown) => error instanceof ManagedSemanticDiffError
-    && error.code === "SEMANTIC_DIFF_REQUIRED"
-    && /undeclared section/u.test(error.message));
-  assert.throws(() => compile(
-    managedBody("Plan", "## Goal", "Old"),
-    `${managedBody("Plan", "## Goal", "New")}\n## Goal\n\nDuplicate.\n`,
-    "free-prose"
-  ), (error: unknown) => error instanceof ManagedSemanticDiffError
-    && error.code === "SEMANTIC_DIFF_AMBIGUOUS"
-    && /duplicate heading/u.test(error.message));
-  assert.throws(() => compile(
-    managedBody("Plan", "## Goal", "Old"), managedBody("Plan", "## Goal", "New"), "machine-written"
-  ), /SEMANTIC_DIFF_REQUIRED:machine-written section requires typed command/u);
-  assert.throws(() => compile(
-    managedBody("Plan", "## Goal", "Old"), managedBody("Plan", "## Goal", "New"), "forbidden"
-  ), /SEMANTIC_DIFF_REQUIRED:forbidden section changed/u);
-});
-
-test("host-prose policies allow undeclared sections without weakening their declared skeleton", () => {
-  const taskId = "task_T";
-  const documentPath = `tasks/${taskId}-folder/task_plan.md`;
-  const index = { path: `tasks/${taskId}-folder/INDEX.md`, body: taskIndex(taskId, "active") };
-  const policy = {
-    ...freeProsePolicy(documentPath, "## Goal"),
-    undeclaredSections: "allow" as const
-  };
-
-  assert.doesNotThrow(() => compileManagedCandidateTreeV2({
-    documents: [index, { path: documentPath, body: managedBody("Plan", "## Goal", "Old") }]
-  }, {
-    documents: [index, {
-      path: documentPath,
-      body: `${managedBody("Plan", "## Goal", "Old")}\n## Review Addendum\n\nNew context.\n`
-    }]
-  }, [policy], [{ kind: "task", semanticDiff: entityRegistry.task.semanticDiff }]));
-
-  assert.throws(() => compileManagedCandidateTreeV2({
-    documents: [index, { path: documentPath, body: managedBody("Plan", "## Goal", "Old") }]
-  }, {
-    documents: [index, { path: documentPath, body: managedBody("Plan", "## Purpose", "Old") }]
-  }, [policy], [{ kind: "task", semanticDiff: entityRegistry.task.semanticDiff }]),
-  /SEMANTIC_DIFF_AMBIGUOUS:.*## Goal/u);
-});
 
 test("all task actions compile to one exact package-hosted StoragePlan", async () => {
   const taskId = "task_T";
@@ -640,16 +539,7 @@ function taskIndex(
   ].join("\n");
 }
 
-function managedBody(title: string, anchor: string, body: string): string {
-  return [`# ${title}`, "", anchor, "", body, ""].join("\n");
-}
 
-function freeProsePolicy(pathValue: string, anchor: string) {
-  return {
-    path: pathValue,
-    sections: [{ anchor, writeMode: "free-prose" as const, semanticClass: "host-prose-only" as const }]
-  };
-}
 
 function snapshot(body: string): HostedDocumentSnapshotV2 {
   return { body, epoch: "epoch-w3", revision: 7n, blobDigest: Buffer.alloc(32, 0x22) };

--- a/packages/application/test/task-decision-module-semantic-compiler-v2.test.ts
+++ b/packages/application/test/task-decision-module-semantic-compiler-v2.test.ts
@@ -697,3 +697,40 @@ const schemaTuple = {
   wire: 2, event: 2, receipt: 2, digest: 2, policy: 1,
   commandRegistry: 1, entityRegistry: 1, mutationRegistry: 1, localState: 1, applyJournal: 1
 } as const;
+
+test("task supersede declares every replacement document so no touched path escapes the minted portable-path scopes", async () => {
+  const oldTaskId = "task_OLD";
+  const newTaskId = "task_NEW";
+  const oldIndexPath = `tasks/${oldTaskId}/INDEX.md`;
+  const oldSnapshot = snapshot(taskIndex(oldTaskId, "planned"));
+  const writes = [
+    { taskId: oldTaskId, path: "INDEX.md", body: taskIndex(oldTaskId, "planned", "archived") },
+    { taskId: newTaskId, path: "INDEX.md", body: taskIndex(newTaskId, "planned") },
+    { taskId: newTaskId, path: "task_plan.md", body: "# Plan\n" },
+    { taskId: newTaskId, path: "artifacts/.gitkeep", body: "" },
+    {
+      taskId: newTaskId,
+      path: "relations.md",
+      body: `task/${newTaskId} supersedes task/${oldTaskId}\n`
+    }
+  ];
+  const oldRef = ref("task", `task/${oldTaskId}`);
+  const newRef = ref("task", `task/${newTaskId}`);
+  const compiler = makeTaskDecisionModuleSemanticCompilerV2({
+    state: authorityState(new Map([[key(oldRef), base("task-v2")]]), new Map([[oldIndexPath, oldSnapshot]]))
+  });
+  const compiled = await compiler.compile(envelope(
+    { schema: "task.supersede/v1", taskId: oldTaskId, replacementTaskId: newTaskId, writes },
+    [present(oldRef, "task-v2"), absent(newRef)],
+    [cas(oldIndexPath, oldSnapshot)]
+  ));
+  const plan = compileRegistryMutationPlan(registry, compiled.mutationPlan);
+
+  // The production intent mints one exact portable-path resource scope per
+  // observed write. Any touched path outside that set is TOKEN_PATH_SCOPE_DENIED
+  // at admission, which is how a fresh task became unsupersedable.
+  const mintedScopes = new Set(writes.map((write) => `tasks/${write.taskId}/${write.path}`));
+  const uncovered = plan.storagePlan.touchedPaths.filter((touched) => !mintedScopes.has(touched));
+  assert.deepEqual(uncovered, [], `uncovered touched paths: ${uncovered.join(", ")}`);
+  assert.ok(plan.storagePlan.touchedPaths.includes(`tasks/${newTaskId}/relations.md`));
+});

--- a/packages/cli/src/cli/types.ts
+++ b/packages/cli/src/cli/types.ts
@@ -229,13 +229,6 @@ export interface ParsedCommand {
     | { readonly kind: "legacy-verify" }
     | { readonly kind: "doctor"; readonly repair?: boolean }
     | { readonly kind: "diagnostics-command-usage" }
-    | { readonly kind: "authority-cutover-status" }
-    | { readonly kind: "authority-cutover-drain"; readonly classifications: ReadonlyArray<{ readonly opId: string; readonly disposition: "retryable-not-committed" | "indeterminate"; readonly recordedTupleDigest: string; readonly evidenceRef: string }> }
-    | { readonly kind: "authority-cutover-scan"; readonly profileId: "production-final-scan/v1" }
-    | { readonly kind: "authority-cutover-confirm"; readonly firstScanId: string; readonly secondScanId: string }
-    | { readonly kind: "authority-cutover-boundary"; readonly boundaryId: string; readonly equalityReceiptId: string; readonly expectedSelectedSchemaTupleDigest: string }
-    | { readonly kind: "authority-cutover-freeze"; readonly reason: string; readonly expectedBoundaryReceiptDigest: string }
-    | { readonly kind: "authority-cutover-re-enable"; readonly boundaryId: string; readonly expectedFreezeReceiptDigest: string; readonly equalityReceiptId: string; readonly forwardFixRef: string }
     | { readonly kind: "authority-repo-enroll"; readonly repoId: string; readonly repoRoot: string; readonly manifestPath: string; readonly serviceStateRoot: string; readonly keyRegistryPath?: string; readonly namespaceTtlMs?: number; readonly allowedExecutorAgentIds: ReadonlyArray<string> }
     | { readonly kind: "authority-repo-resign"; readonly repoId: string; readonly manifestPath: string; readonly keyRegistryPath?: string; readonly switchRecordPath?: string; readonly namespaceTtlMs?: number }
     | { readonly kind: "worktree-status"; readonly taskId: string }

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -13,7 +13,8 @@
     "@harness-anything/adapter-local": "0.1.0",
     "@harness-anything/api-contracts": "0.1.0",
     "@harness-anything/application": "0.1.0",
-    "@harness-anything/kernel": "0.1.0"
+    "@harness-anything/kernel": "0.1.0",
+    "yaml": "^2.9.0"
   },
   "optionalDependencies": {
     "node-pty": "^1.1.0"

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -13,8 +13,7 @@
     "@harness-anything/adapter-local": "0.1.0",
     "@harness-anything/api-contracts": "0.1.0",
     "@harness-anything/application": "0.1.0",
-    "@harness-anything/kernel": "0.1.0",
-    "yaml": "^2.9.0"
+    "@harness-anything/kernel": "0.1.0"
   },
   "optionalDependencies": {
     "node-pty": "^1.1.0"

--- a/packages/daemon/src/agent-runtime/auth-profiles.ts
+++ b/packages/daemon/src/agent-runtime/auth-profiles.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import type { RuntimeAuthenticationProfileProjection } from "@harness-anything/application/agent-runtime-control";
+import { resolveCredentials } from "./credential-resolver.ts";
 
 export interface RuntimeAuthStatusResult {
   readonly exitCode: number;
@@ -10,6 +11,7 @@ export interface RuntimeAuthStatusResult {
 export interface RuntimeAuthenticationProbeOptions {
   readonly env?: Readonly<Record<string, string | undefined>>;
   readonly runStatus?: (kindId: "claude-code" | "codex") => Promise<RuntimeAuthStatusResult>;
+  readonly userRoot?: string;
 }
 
 export async function probeRuntimeAuthenticationProfiles(
@@ -18,6 +20,15 @@ export async function probeRuntimeAuthenticationProfiles(
   const env = options.env ?? process.env;
   const runStatus = options.runStatus ?? ((kindId) => runRuntimeAuthStatus(kindId, env));
   const [claudeStatus, codexStatus] = await Promise.all([runStatus("claude-code"), runStatus("codex")]);
+
+  // Resolve credentials from env or YAML for api-key profiles
+  const claudeApiKeyCreds = options.userRoot
+    ? resolveCredentials("claude-code", "api-key", options.userRoot, env)
+    : { apiKey: env.ANTHROPIC_API_KEY };
+  const codexApiKeyCreds = options.userRoot
+    ? resolveCredentials("codex", "api-key", options.userRoot, env)
+    : { apiKey: env.OPENAI_API_KEY };
+
   return [
     {
       kindId: "claude-code",
@@ -29,7 +40,7 @@ export async function probeRuntimeAuthenticationProfiles(
     {
       kindId: "claude-code",
       profileKind: "api-key",
-      state: configuredEnvironmentValue(env.ANTHROPIC_API_KEY),
+      state: configuredEnvironmentValue(claudeApiKeyCreds.apiKey),
       assurance: "configuration-presence",
       guidance: "Configure ANTHROPIC_API_KEY in the daemon environment."
     },
@@ -43,7 +54,7 @@ export async function probeRuntimeAuthenticationProfiles(
     {
       kindId: "codex",
       profileKind: "api-key",
-      state: configuredEnvironmentValue(env.OPENAI_API_KEY),
+      state: configuredEnvironmentValue(codexApiKeyCreds.apiKey),
       assurance: "configuration-presence",
       guidance: "Configure OPENAI_API_KEY in the daemon environment."
     }

--- a/packages/daemon/src/agent-runtime/auth-profiles.ts
+++ b/packages/daemon/src/agent-runtime/auth-profiles.ts
@@ -29,11 +29,6 @@ export async function probeRuntimeAuthenticationProfiles(
     ? resolveCredentials("codex", "api-key", options.userRoot, env)
     : { apiKey: env.OPENAI_API_KEY };
 
-  // DEBUG
-  console.error("DEBUG auth-profiles: userRoot=", options.userRoot);
-  console.error("DEBUG claudeApiKeyCreds:", claudeApiKeyCreds.apiKey ? "FOUND" : "NOT FOUND");
-  console.error("DEBUG codexApiKeyCreds:", codexApiKeyCreds.apiKey ? "FOUND" : "NOT FOUND");
-
   return [
     {
       kindId: "claude-code",

--- a/packages/daemon/src/agent-runtime/auth-profiles.ts
+++ b/packages/daemon/src/agent-runtime/auth-profiles.ts
@@ -29,6 +29,11 @@ export async function probeRuntimeAuthenticationProfiles(
     ? resolveCredentials("codex", "api-key", options.userRoot, env)
     : { apiKey: env.OPENAI_API_KEY };
 
+  // DEBUG
+  console.error("DEBUG auth-profiles: userRoot=", options.userRoot);
+  console.error("DEBUG claudeApiKeyCreds:", claudeApiKeyCreds.apiKey ? "FOUND" : "NOT FOUND");
+  console.error("DEBUG codexApiKeyCreds:", codexApiKeyCreds.apiKey ? "FOUND" : "NOT FOUND");
+
   return [
     {
       kindId: "claude-code",

--- a/packages/daemon/src/agent-runtime/control-host.ts
+++ b/packages/daemon/src/agent-runtime/control-host.ts
@@ -29,8 +29,8 @@ export function createLocalAgentRuntimeControlHost(rootDir: string): {
   };
   const control = createAgentRuntimeSessionService({
     adapters: [
-      createClaudeCodeRuntimeAdapter({ executablePath: () => executablePath("claude-code") }),
-      createCodexRuntimeAdapter({ executablePath: () => executablePath("codex") })
+      createClaudeCodeRuntimeAdapter({ executablePath: () => executablePath("claude-code"), userRoot: rootDir }),
+      createCodexRuntimeAdapter({ executablePath: () => executablePath("codex"), userRoot: rootDir })
     ],
     store: createFileRuntimeSessionStore(rootDir),
     authProfiles: probeRuntimeAuthenticationProfiles,

--- a/packages/daemon/src/agent-runtime/control-host.ts
+++ b/packages/daemon/src/agent-runtime/control-host.ts
@@ -33,7 +33,7 @@ export function createLocalAgentRuntimeControlHost(rootDir: string): {
       createCodexRuntimeAdapter({ executablePath: () => executablePath("codex"), userRoot: rootDir })
     ],
     store: createFileRuntimeSessionStore(rootDir),
-    authProfiles: probeRuntimeAuthenticationProfiles,
+    authProfiles: () => probeRuntimeAuthenticationProfiles({ userRoot: rootDir }),
     workspaceRoot: rootDir
   });
   const service = makeAgentRuntimeService({

--- a/packages/daemon/src/agent-runtime/control-host.ts
+++ b/packages/daemon/src/agent-runtime/control-host.ts
@@ -16,7 +16,7 @@ import { probeRuntimeAuthenticationProfiles } from "./auth-profiles.ts";
 import { createLocalAgentRuntimeDiscoveryProbe } from "./host-discovery.ts";
 import { createFileRuntimeSessionStore } from "./session-store.ts";
 
-export function createLocalAgentRuntimeControlHost(rootDir: string): {
+export function createLocalAgentRuntimeControlHost(rootDir: string, userRoot: string): {
   readonly control: AgentRuntimeControlService;
   readonly inventoryReader: ReturnType<typeof makeAgentRuntimeService>["inventoryProjection"];
 } {
@@ -29,11 +29,11 @@ export function createLocalAgentRuntimeControlHost(rootDir: string): {
   };
   const control = createAgentRuntimeSessionService({
     adapters: [
-      createClaudeCodeRuntimeAdapter({ executablePath: () => executablePath("claude-code"), userRoot: rootDir }),
-      createCodexRuntimeAdapter({ executablePath: () => executablePath("codex"), userRoot: rootDir })
+      createClaudeCodeRuntimeAdapter({ executablePath: () => executablePath("claude-code"), userRoot }),
+      createCodexRuntimeAdapter({ executablePath: () => executablePath("codex"), userRoot })
     ],
     store: createFileRuntimeSessionStore(rootDir),
-    authProfiles: () => probeRuntimeAuthenticationProfiles({ userRoot: rootDir }),
+    authProfiles: () => probeRuntimeAuthenticationProfiles({ userRoot }),
     workspaceRoot: rootDir
   });
   const service = makeAgentRuntimeService({
@@ -44,8 +44,8 @@ export function createLocalAgentRuntimeControlHost(rootDir: string): {
   return { control, inventoryReader: service.inventoryProjection };
 }
 
-export function makeLocalAgentRuntimeControllerOptions(rootDir: string) {
-  const host = createLocalAgentRuntimeControlHost(rootDir);
+export function makeLocalAgentRuntimeControllerOptions(rootDir: string, userRoot: string) {
+  const host = createLocalAgentRuntimeControlHost(rootDir, userRoot);
   return { agentRuntimeInventoryReader: host.inventoryReader, agentRuntimeControl: host.control };
 }
 

--- a/packages/daemon/src/agent-runtime/control-host.ts
+++ b/packages/daemon/src/agent-runtime/control-host.ts
@@ -34,7 +34,8 @@ export function createLocalAgentRuntimeControlHost(rootDir: string, userRoot: st
     ],
     store: createFileRuntimeSessionStore(rootDir),
     authProfiles: () => probeRuntimeAuthenticationProfiles({ userRoot }),
-    workspaceRoot: rootDir
+    workspaceRoot: rootDir,
+    userRoot
   });
   const service = makeAgentRuntimeService({
     discovery,

--- a/packages/daemon/src/agent-runtime/credential-resolver.ts
+++ b/packages/daemon/src/agent-runtime/credential-resolver.ts
@@ -1,5 +1,4 @@
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import path from "node:path";
 import YAML from "yaml";
 
@@ -20,25 +19,13 @@ interface CredentialsYaml {
 }
 
 /**
- * Resolve actual user root where credentials are stored.
- * Priority: userRoot arg > ~/.harness-production > ~/.harness
- */
-function resolveActualUserRoot(userRoot: string | undefined): string {
-  if (userRoot) return userRoot;
-  const home = homedir();
-  const production = path.join(home, ".harness-production");
-  const standard = path.join(home, ".harness");
-  return existsSync(production) ? production : standard;
-}
-
-/**
  * Resolve API credentials and endpoint for an agent runtime profile.
  *
  * Priority: process.env > credentials YAML file > empty
  *
  * @param kindId - Runtime kind (claude-code / codex)
  * @param profileKind - Profile kind (api-key / subscription-account / etc)
- * @param userRoot - Daemon user root (e.g. ~/.harness-production)
+ * @param userRoot - User root directory (e.g. ~/.harness-production)
  * @param processEnv - Process environment (usually process.env)
  * @returns Resolved credentials with env object to pass to AdapterOptions
  */
@@ -66,11 +53,8 @@ export function resolveCredentials(
   }
 
   // Priority 2: YAML file
-  const actualUserRoot = resolveActualUserRoot(userRoot);
-  const credentialsPath = path.join(actualUserRoot, "agent-runtime-credentials.yaml");
-  console.error(`[credential-resolver] checking ${credentialsPath} for ${kindId}/${profileKind}`);
+  const credentialsPath = path.join(userRoot, "agent-runtime-credentials.yaml");
   if (!existsSync(credentialsPath)) {
-    console.error(`[credential-resolver] file not found: ${credentialsPath}`);
     return { env: { ...processEnv } };
   }
 

--- a/packages/daemon/src/agent-runtime/credential-resolver.ts
+++ b/packages/daemon/src/agent-runtime/credential-resolver.ts
@@ -43,42 +43,37 @@ export function resolveCredentials(
   const envKeyName = kindId === "claude-code" ? "ANTHROPIC_API_KEY" : "OPENAI_API_KEY";
   const envBaseUrlName = kindId === "claude-code" ? "ANTHROPIC_BASE_URL" : "OPENAI_BASE_URL";
 
-  // Priority 1: environment variables
-  if (processEnv[envKeyName]) {
-    return {
-      apiKey: processEnv[envKeyName],
-      baseUrl: processEnv[envBaseUrlName],
-      env: { ...processEnv }
-    };
+  // Resolve API key: env > YAML > empty
+  let apiKey = processEnv[envKeyName];
+  let baseUrl = processEnv[envBaseUrlName];
+
+  // If API key not in env, try YAML
+  if (!apiKey) {
+    const credentialsPath = path.join(userRoot, "agent-runtime-credentials.yaml");
+    if (existsSync(credentialsPath)) {
+      try {
+        const content = readFileSync(credentialsPath, "utf-8");
+        const yaml = YAML.parse(content) as CredentialsYaml;
+        const profile = yaml.profiles?.find((p) => p.kindId === kindId && p.profileKind === profileKind);
+        if (profile) {
+          apiKey = profile.apiKey;
+          // Base URL from YAML only if not in env
+          if (!baseUrl) baseUrl = profile.baseUrl;
+        }
+      } catch {
+        // YAML parse error or file unreadable: continue with env values
+      }
+    }
   }
 
-  // Priority 2: YAML file
-  const credentialsPath = path.join(userRoot, "agent-runtime-credentials.yaml");
-  if (!existsSync(credentialsPath)) {
-    return { env: { ...processEnv } };
-  }
-
-  let yaml: CredentialsYaml;
-  try {
-    const content = readFileSync(credentialsPath, "utf-8");
-    yaml = YAML.parse(content) as CredentialsYaml;
-  } catch {
-    return { env: { ...processEnv } };
-  }
-
-  const profile = yaml.profiles?.find((p) => p.kindId === kindId && p.profileKind === profileKind);
-  if (!profile?.apiKey) {
-    return { env: { ...processEnv } };
-  }
-
-  // Build env with credentials from YAML
+  // Build env with resolved credentials
   const env = { ...processEnv };
-  if (profile.apiKey) env[envKeyName] = profile.apiKey;
-  if (profile.baseUrl) env[envBaseUrlName] = profile.baseUrl;
+  if (apiKey) env[envKeyName] = apiKey;
+  if (baseUrl) env[envBaseUrlName] = baseUrl;
 
   return {
-    apiKey: profile.apiKey,
-    baseUrl: profile.baseUrl,
+    apiKey,
+    baseUrl,
     env
   };
 }

--- a/packages/daemon/src/agent-runtime/credential-resolver.ts
+++ b/packages/daemon/src/agent-runtime/credential-resolver.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import YAML from "yaml";
 
@@ -16,6 +17,18 @@ interface CredentialsYaml {
     readonly apiKey?: string;
     readonly baseUrl?: string;
   }>;
+}
+
+/**
+ * Resolve actual user root where credentials are stored.
+ * Priority: userRoot arg > ~/.harness-production > ~/.harness
+ */
+function resolveActualUserRoot(userRoot: string | undefined): string {
+  if (userRoot) return userRoot;
+  const home = homedir();
+  const production = path.join(home, ".harness-production");
+  const standard = path.join(home, ".harness");
+  return existsSync(production) ? production : standard;
 }
 
 /**
@@ -53,8 +66,11 @@ export function resolveCredentials(
   }
 
   // Priority 2: YAML file
-  const credentialsPath = path.join(userRoot, "agent-runtime-credentials.yaml");
+  const actualUserRoot = resolveActualUserRoot(userRoot);
+  const credentialsPath = path.join(actualUserRoot, "agent-runtime-credentials.yaml");
+  console.error(`[credential-resolver] checking ${credentialsPath} for ${kindId}/${profileKind}`);
   if (!existsSync(credentialsPath)) {
+    console.error(`[credential-resolver] file not found: ${credentialsPath}`);
     return { env: { ...processEnv } };
   }
 

--- a/packages/daemon/src/agent-runtime/credential-resolver.ts
+++ b/packages/daemon/src/agent-runtime/credential-resolver.ts
@@ -1,6 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
-import YAML from "yaml";
 
 export interface ResolvedCredentials {
   readonly apiKey?: string;
@@ -53,8 +52,8 @@ export function resolveCredentials(
     if (existsSync(credentialsPath)) {
       try {
         const content = readFileSync(credentialsPath, "utf-8");
-        const yaml = YAML.parse(content) as CredentialsYaml;
-        const profile = yaml.profiles?.find((p) => p.kindId === kindId && p.profileKind === profileKind);
+        const parsed = parseCredentialsDocument(content);
+        const profile = parsed.profiles?.find((p) => p.kindId === kindId && p.profileKind === profileKind);
         if (profile) {
           apiKey = profile.apiKey;
           // Base URL from YAML only if not in env
@@ -76,4 +75,58 @@ export function resolveCredentials(
     baseUrl,
     env
   };
+}
+
+/**
+ * The credentials document is a fixed four-field profile list that this
+ * repository both writes and reads, so it is parsed directly rather than by
+ * adding a YAML dependency to the only publishable artifact. JSON is accepted
+ * as a strict YAML subset, matching how the people roster is read.
+ */
+function parseCredentialsDocument(content: string): Partial<CredentialsYaml> {
+  try {
+    return JSON.parse(content) as CredentialsYaml;
+  } catch {
+    // The canonical document is YAML; JSON is accepted for fixtures.
+  }
+  const profiles: Array<{ kindId: string; profileKind: string; apiKey?: string; baseUrl?: string }> = [];
+  let current: Record<string, string> | undefined;
+  const commit = () => {
+    if (current?.kindId && current.profileKind) {
+      profiles.push({
+        kindId: current.kindId,
+        profileKind: current.profileKind,
+        ...(current.apiKey ? { apiKey: current.apiKey } : {}),
+        ...(current.baseUrl ? { baseUrl: current.baseUrl } : {})
+      });
+    }
+    current = undefined;
+  };
+  for (const rawLine of content.split(/\r?\n/u)) {
+    const line = rawLine.replace(/\s+#.*$/u, "");
+    if (!line.trim()) continue;
+    const item = /^\s*-\s*(.*)$/u.exec(line);
+    if (item) {
+      commit();
+      current = {};
+      if (!item[1]?.trim()) continue;
+      assignCredentialField(current, item[1]);
+      continue;
+    }
+    if (!current) continue;
+    // A key at or left of the list marker's own indent ends the list.
+    if (!/^\s\s/u.test(line)) { commit(); continue; }
+    assignCredentialField(current, line);
+  }
+  commit();
+  return { profiles };
+}
+
+function assignCredentialField(target: Record<string, string>, line: string): void {
+  const match = /^\s*([A-Za-z][A-Za-z0-9_]*)\s*:\s*(.*)$/u.exec(line);
+  if (!match) return;
+  const value = match[2]?.trim() ?? "";
+  if (!value) return;
+  const unquoted = /^(["'])(.*)\1$/u.exec(value);
+  target[match[1]!] = unquoted ? unquoted[2]! : value;
 }

--- a/packages/daemon/src/agent-runtime/credential-resolver.ts
+++ b/packages/daemon/src/agent-runtime/credential-resolver.ts
@@ -1,0 +1,84 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
+
+export interface ResolvedCredentials {
+  readonly apiKey?: string;
+  readonly baseUrl?: string;
+  readonly env: NodeJS.ProcessEnv;
+}
+
+interface CredentialsYaml {
+  readonly schema: string;
+  readonly profiles: ReadonlyArray<{
+    readonly kindId: string;
+    readonly profileKind: string;
+    readonly apiKey?: string;
+    readonly baseUrl?: string;
+  }>;
+}
+
+/**
+ * Resolve API credentials and endpoint for an agent runtime profile.
+ *
+ * Priority: process.env > credentials YAML file > empty
+ *
+ * @param kindId - Runtime kind (claude-code / codex)
+ * @param profileKind - Profile kind (api-key / subscription-account / etc)
+ * @param userRoot - Daemon user root (e.g. ~/.harness-production)
+ * @param processEnv - Process environment (usually process.env)
+ * @returns Resolved credentials with env object to pass to AdapterOptions
+ */
+export function resolveCredentials(
+  kindId: string,
+  profileKind: string,
+  userRoot: string,
+  processEnv: NodeJS.ProcessEnv
+): ResolvedCredentials {
+  // Only resolve for api-key profiles; others use native auth flows
+  if (profileKind !== "api-key") {
+    return { env: { ...processEnv } };
+  }
+
+  const envKeyName = kindId === "claude-code" ? "ANTHROPIC_API_KEY" : "OPENAI_API_KEY";
+  const envBaseUrlName = kindId === "claude-code" ? "ANTHROPIC_BASE_URL" : "OPENAI_BASE_URL";
+
+  // Priority 1: environment variables
+  if (processEnv[envKeyName]) {
+    return {
+      apiKey: processEnv[envKeyName],
+      baseUrl: processEnv[envBaseUrlName],
+      env: { ...processEnv }
+    };
+  }
+
+  // Priority 2: YAML file
+  const credentialsPath = path.join(userRoot, "agent-runtime-credentials.yaml");
+  if (!existsSync(credentialsPath)) {
+    return { env: { ...processEnv } };
+  }
+
+  let yaml: CredentialsYaml;
+  try {
+    const content = readFileSync(credentialsPath, "utf-8");
+    yaml = YAML.parse(content) as CredentialsYaml;
+  } catch {
+    return { env: { ...processEnv } };
+  }
+
+  const profile = yaml.profiles?.find((p) => p.kindId === kindId && p.profileKind === profileKind);
+  if (!profile?.apiKey) {
+    return { env: { ...processEnv } };
+  }
+
+  // Build env with credentials from YAML
+  const env = { ...processEnv };
+  if (profile.apiKey) env[envKeyName] = profile.apiKey;
+  if (profile.baseUrl) env[envBaseUrlName] = profile.baseUrl;
+
+  return {
+    apiKey: profile.apiKey,
+    baseUrl: profile.baseUrl,
+    env
+  };
+}

--- a/packages/daemon/src/agent-runtime/holder-projection-host.ts
+++ b/packages/daemon/src/agent-runtime/holder-projection-host.ts
@@ -18,6 +18,7 @@ import { makeDaemonQueuedOperationalWriteCoordinator } from "../lifecycle/queued
 
 export function makeLocalAgentHolderServices(
   rootDir: string,
+  userRoot: string,
   layoutOverrides: HarnessLayoutOverrides | undefined,
   runtime: Parameters<typeof makeDaemonQueuedOperationalWriteCoordinator>[0]
 ) {
@@ -31,7 +32,7 @@ export function makeLocalAgentHolderServices(
   }));
   const appendLeaseEvent: NonNullable<TaskHolderServiceOptions["appendLeaseEvent"]> = appendRuntimeEvent;
   const taskHolderService = makeTaskHolderService({ rootInput: { rootDir, layoutOverrides }, appendLeaseEvent });
-  const agentRuntimeControllerOptions = makeLocalAgentRuntimeControllerOptions(rootDir);
+  const agentRuntimeControllerOptions = makeLocalAgentRuntimeControllerOptions(rootDir, userRoot);
   return {
     appendRuntimeEvent,
     taskHolderService,

--- a/packages/daemon/src/agent-runtime/protocol-adapters.ts
+++ b/packages/daemon/src/agent-runtime/protocol-adapters.ts
@@ -1,5 +1,7 @@
 // @slice-activation PLT-Boundary W1 exposes this module through the package root API.
 import { spawn } from "node:child_process";
+import type { AgentRuntimeSpawnPayload } from "@harness-anything/application/agent-runtime-control";
+import { resolveCredentials } from "./credential-resolver.ts";
 import type {
   RuntimeAdapterProcess,
   RuntimeAdapterProcessEvent,
@@ -33,6 +35,7 @@ interface AdapterOptions {
   readonly executablePath: string | (() => Promise<string>);
   readonly spawnChild?: RuntimeChildSpawner;
   readonly env?: NodeJS.ProcessEnv;
+  readonly userRoot?: string;
 }
 
 export function createClaudeCodeRuntimeAdapter(options: AdapterOptions): RuntimeProtocolAdapter {
@@ -47,8 +50,11 @@ export function createClaudeCodeRuntimeAdapter(options: AdapterOptions): Runtime
       resize: false,
       events: true
     },
-    spawn: async (payload) => {
+    spawn: async (payload: AgentRuntimeSpawnPayload) => {
       const executablePath = await resolveExecutablePath(options.executablePath);
+      const credentials = options.userRoot
+        ? resolveCredentials("claude-code", payload.authenticationProfileKind, options.userRoot, options.env ?? process.env)
+        : { env: options.env ?? process.env };
       const args = [
         "--print",
         "--verbose",
@@ -57,7 +63,7 @@ export function createClaudeCodeRuntimeAdapter(options: AdapterOptions): Runtime
         ...(payload.resumeProviderSessionId ? ["--resume", payload.resumeProviderSessionId] : []),
         payload.prompt
       ];
-      const child = spawnRuntimeChild(options, executablePath, args, payload.cwd);
+      const child = spawnRuntimeChild({ ...options, env: credentials.env }, executablePath, args, payload.cwd);
       const events = eventChannel();
       let providerSessionId = payload.resumeProviderSessionId;
       readJsonLines(child.stdout, (message) => {
@@ -87,9 +93,12 @@ export function createCodexRuntimeAdapter(options: AdapterOptions): RuntimeProto
       resize: false,
       events: true
     },
-    spawn: async (payload) => {
+    spawn: async (payload: AgentRuntimeSpawnPayload) => {
       const executablePath = await resolveExecutablePath(options.executablePath);
-      const child = spawnRuntimeChild(options, executablePath, ["app-server", "--listen", "stdio://"], payload.cwd);
+      const credentials = options.userRoot
+        ? resolveCredentials("codex", payload.authenticationProfileKind, options.userRoot, options.env ?? process.env)
+        : { env: options.env ?? process.env };
+      const child = spawnRuntimeChild({ ...options, env: credentials.env }, executablePath, ["app-server", "--listen", "stdio://"], payload.cwd);
       const events = eventChannel();
       const write = (message: unknown) => child.stdin.write(`${JSON.stringify(message)}\n`);
       readJsonLines(child.stdout, (message) => {

--- a/packages/daemon/src/agent-runtime/protocol-adapters.ts
+++ b/packages/daemon/src/agent-runtime/protocol-adapters.ts
@@ -1,6 +1,5 @@
 // @slice-activation PLT-Boundary W1 exposes this module through the package root API.
 import { spawn } from "node:child_process";
-import type { AgentRuntimeSpawnPayload } from "@harness-anything/application/agent-runtime-control";
 import { resolveCredentials } from "./credential-resolver.ts";
 import type {
   RuntimeAdapterProcess,
@@ -50,7 +49,7 @@ export function createClaudeCodeRuntimeAdapter(options: AdapterOptions): Runtime
       resize: false,
       events: true
     },
-    spawn: async (payload: AgentRuntimeSpawnPayload) => {
+    spawn: async (payload) => {
       const executablePath = await resolveExecutablePath(options.executablePath);
       const credentials = options.userRoot
         ? resolveCredentials("claude-code", payload.authenticationProfileKind, options.userRoot, options.env ?? process.env)
@@ -93,7 +92,7 @@ export function createCodexRuntimeAdapter(options: AdapterOptions): RuntimeProto
       resize: false,
       events: true
     },
-    spawn: async (payload: AgentRuntimeSpawnPayload) => {
+    spawn: async (payload) => {
       const executablePath = await resolveExecutablePath(options.executablePath);
       const credentials = options.userRoot
         ? resolveCredentials("codex", payload.authenticationProfileKind, options.userRoot, options.env ?? process.env)

--- a/packages/daemon/src/agent-runtime/session-service.ts
+++ b/packages/daemon/src/agent-runtime/session-service.ts
@@ -9,6 +9,7 @@ import type {
 import type { RuntimeCapabilityMatrix } from "@harness-anything/application/agent-runtime-adapter";
 import { realpathSync } from "node:fs";
 import path from "node:path";
+import { resolveCredentials } from "./credential-resolver.ts";
 
 export type RuntimeAdapterProcessEvent =
   | { readonly kind: "provider-session"; readonly providerSessionId: string }
@@ -88,6 +89,10 @@ export function createAgentRuntimeSessionService(
       if (!profile || profile.state !== "configured") {
         return failure("runtime_authentication_required", profile?.guidance ?? `Configure ${payload.authenticationProfileKind} for ${payload.kindId}.`);
       }
+      // Resolve credentials to capture effectiveBaseUrl for audit
+      const credentials = options.workspaceRoot
+        ? resolveCredentials(payload.kindId, payload.authenticationProfileKind, options.workspaceRoot, process.env)
+        : { baseUrl: undefined };
       let handle: RuntimeAdapterProcess;
       try {
         handle = await adapter.spawn(payload);
@@ -102,6 +107,10 @@ export function createAgentRuntimeSessionService(
         process: { state: "alive", pid: handle.pid, startedAt, heartbeatAt: startedAt },
         attachable: adapter.capabilities.attach,
         capabilities: adapter.capabilities,
+        spawnMetadata: {
+          profileKind: payload.authenticationProfileKind,
+          effectiveBaseUrl: credentials.baseUrl
+        },
         ...(payload.resumeProviderSessionId ? { providerSessionId: payload.resumeProviderSessionId } : {}),
         ...((payload.taskId || payload.executionId) ? {
           clientBinding: {

--- a/packages/daemon/src/agent-runtime/session-service.ts
+++ b/packages/daemon/src/agent-runtime/session-service.ts
@@ -48,6 +48,7 @@ export interface AgentRuntimeSessionServiceOptions {
   readonly createId?: () => string;
   readonly now?: () => string;
   readonly workspaceRoot?: string;
+  readonly userRoot?: string;
 }
 
 export function createAgentRuntimeSessionService(
@@ -90,8 +91,8 @@ export function createAgentRuntimeSessionService(
         return failure("runtime_authentication_required", profile?.guidance ?? `Configure ${payload.authenticationProfileKind} for ${payload.kindId}.`);
       }
       // Resolve credentials to capture effectiveBaseUrl for audit
-      const credentials = options.workspaceRoot
-        ? resolveCredentials(payload.kindId, payload.authenticationProfileKind, options.workspaceRoot, process.env)
+      const credentials = options.userRoot
+        ? resolveCredentials(payload.kindId, payload.authenticationProfileKind, options.userRoot, process.env)
         : { baseUrl: undefined };
       let handle: RuntimeAdapterProcess;
       try {

--- a/packages/daemon/src/runtime/production-progress-append-operation.ts
+++ b/packages/daemon/src/runtime/production-progress-append-operation.ts
@@ -189,6 +189,7 @@ export class ProductionRepoWriteOperationHost<
       this.options.hostServices,
       {
         resolveAuthoritySubmissionV2: () => binding,
+        authorityCutoverControl: this.options.authorityComponent.cutoverControl,
         ...(this.options.conflictMarkerPreflight ? {
           conflictMarkerPreflight: this.options.conflictMarkerPreflight
         } : {})

--- a/packages/daemon/src/service/command-service.ts
+++ b/packages/daemon/src/service/command-service.ts
@@ -124,9 +124,14 @@ export function createDaemonCommandService<
             if (!receipt.ok) throw childPreflightRejected(receipt);
           }
           : undefined;
+        // A production daemon keeps no authority engine of its own: the engine
+        // lives in the repo-write child. Authority cutover controls must follow
+        // it there, otherwise they read an engine that is never enabled.
         if (options.repoWriteDispatch
           && !dryRun
-          && (commandClass === "repo-write" || commandClass === "arbiter")) {
+          && (commandClass === "repo-write"
+            || commandClass === "arbiter"
+            || isAuthorityCutoverAction(parsedCommand.action))) {
           const authority = context?.authorityConnection;
           if (!daemonActor || !authority || !authority.available) {
             return childRouteFailure(

--- a/packages/daemon/src/service/service-host.ts
+++ b/packages/daemon/src/service/service-host.ts
@@ -463,6 +463,7 @@ function createRepoServiceBinding<
   readonly appendRuntimeEvent: ReturnType<typeof makeLocalAgentHolderServices>["appendRuntimeEvent"];
 } {
   const rootDir = repo.canonicalRoot;
+  const userRoot = statusOptions?.userRoot ?? rootDir;
   const identity = loadRepoIdentity(rootDir, layoutOverrides, statusOptions?.endpoint, statusOptions?.userRoot, hostServices);
   const taskWriter = makeLocalLifecycleEngine({
     rootDir,
@@ -470,7 +471,7 @@ function createRepoServiceBinding<
     coordinator: failClosedReservationReconcilerCoordinator()
   });
   const { appendRuntimeEvent, taskHolderService, agentRuntimeControllerOptions, agentHolderProjection } =
-    makeLocalAgentHolderServices(rootDir, layoutOverrides, runtime);
+    makeLocalAgentHolderServices(rootDir, userRoot, layoutOverrides, runtime);
   const localController = makeLocalControllerService({
     rootDir,
     layoutOverrides,

--- a/packages/daemon/test/agent-runtime-credential-resolver.test.ts
+++ b/packages/daemon/test/agent-runtime-credential-resolver.test.ts
@@ -1,0 +1,97 @@
+// harness-test-tier: fast
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { resolveCredentials } from "../src/agent-runtime/credential-resolver.ts";
+
+test("resolveCredentials prioritizes env over YAML", () => {
+  const userRoot = mkdtempSync(path.join(tmpdir(), "cred-test-"));
+  const credFile = path.join(userRoot, "agent-runtime-credentials.yaml");
+
+  writeFileSync(credFile, `schema: agent-runtime-credentials/v1
+profiles:
+  - kindId: codex
+    profileKind: api-key
+    apiKey: sk-yaml-key
+    baseUrl: https://yaml.example.com
+`);
+
+  try {
+    // Test 1: env wins
+    const withEnv = resolveCredentials("codex", "api-key", userRoot, { OPENAI_API_KEY: "sk-env-key" });
+    assert.equal(withEnv.apiKey, "sk-env-key");
+    assert.equal(withEnv.env.OPENAI_API_KEY, "sk-env-key");
+    assert.equal(withEnv.baseUrl, undefined); // env didn't set base URL
+
+    // Test 2: YAML used when env empty
+    const withoutEnv = resolveCredentials("codex", "api-key", userRoot, {});
+    assert.equal(withoutEnv.apiKey, "sk-yaml-key");
+    assert.equal(withoutEnv.baseUrl, "https://yaml.example.com");
+    assert.equal(withoutEnv.env.OPENAI_API_KEY, "sk-yaml-key");
+    assert.equal(withoutEnv.env.OPENAI_BASE_URL, "https://yaml.example.com");
+
+    // Test 3: non-api-key profile returns env as-is
+    const subscriptionProfile = resolveCredentials("claude-code", "subscription-account", userRoot, { FOO: "bar" });
+    assert.equal(subscriptionProfile.apiKey, undefined);
+    assert.equal(subscriptionProfile.env.FOO, "bar");
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
+});
+
+test("resolveCredentials handles missing YAML file", () => {
+  const userRoot = mkdtempSync(path.join(tmpdir(), "cred-test-"));
+  try {
+    const result = resolveCredentials("codex", "api-key", userRoot, {});
+    assert.equal(result.apiKey, undefined);
+    assert.deepEqual(result.env, {});
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
+});
+
+test("resolveCredentials reads the document without a YAML dependency", () => {
+  const userRoot = mkdtempSync(path.join(tmpdir(), "cred-test-"));
+  const credFile = path.join(userRoot, "agent-runtime-credentials.yaml");
+  // Quoting, comments, blank lines and a sibling profile all appear in files
+  // people hand-edit, so the direct parser has to survive them.
+  writeFileSync(credFile, `schema: agent-runtime-credentials/v1
+profiles:
+  - kindId: claude-code
+    profileKind: api-key
+    apiKey: "sk-quoted-claude"
+
+  - kindId: codex   # trailing comment
+    profileKind: api-key
+    apiKey: 'sk-quoted-codex'
+    baseUrl: https://codex.example.com
+`);
+  try {
+    const claude = resolveCredentials("claude-code", "api-key", userRoot, {});
+    assert.equal(claude.apiKey, "sk-quoted-claude");
+    assert.equal(claude.baseUrl, undefined);
+    const codex = resolveCredentials("codex", "api-key", userRoot, {});
+    assert.equal(codex.apiKey, "sk-quoted-codex");
+    assert.equal(codex.baseUrl, "https://codex.example.com");
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
+});
+
+test("resolveCredentials accepts JSON as a strict YAML subset", () => {
+  const userRoot = mkdtempSync(path.join(tmpdir(), "cred-test-"));
+  const credFile = path.join(userRoot, "agent-runtime-credentials.yaml");
+  writeFileSync(credFile, JSON.stringify({
+    schema: "agent-runtime-credentials/v1",
+    profiles: [{ kindId: "codex", profileKind: "api-key", apiKey: "sk-json", baseUrl: "https://json.example.com" }]
+  }));
+  try {
+    const resolved = resolveCredentials("codex", "api-key", userRoot, {});
+    assert.equal(resolved.apiKey, "sk-json");
+    assert.equal(resolved.baseUrl, "https://json.example.com");
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/daemon/test/repo-write-command-action-negative.test.ts
+++ b/packages/daemon/test/repo-write-command-action-negative.test.ts
@@ -11,20 +11,27 @@ import {
   commandClassForCliActionKind,
   repoCommandRunClassifiedActionKinds
 } from "../src/protocol/method-registry.ts";
+import { isAuthorityCutoverAction } from "../src/authority/authority-cutover-command.ts";
 
-test("application action authority exactly covers every classified CLI writer kind", () => {
+test("application action authority exactly covers every CLI kind routed to the writer child", () => {
   const classifiedWriterKinds = repoCommandRunClassifiedActionKinds
     .filter((kind) => kind !== "task-complete" && kind !== "task-submit")
     .filter((kind) => {
       const commandClass = commandClassForCliActionKind(kind);
-      return commandClass === "repo-write" || commandClass === "arbiter";
+      // Authority cutover controls are admin-class yet still cross the child
+      // boundary: a production daemon keeps no authority engine of its own, so
+      // the controls must reach the child that owns it. Deriving the expected
+      // set from the same predicate the router uses keeps both sides together.
+      return commandClass === "repo-write"
+        || commandClass === "arbiter"
+        || isAuthorityCutoverAction({ kind });
     })
     .sort();
   assert.deepEqual([...repoWriteCommandActionKinds].sort(), classifiedWriterKinds);
 });
 
-test("all 63 classified CLI writer actions reject a wrong wire shape", async (t) => {
-  assert.equal(repoWriteCommandActionKinds.length, 63);
+test("all 70 classified CLI writer actions reject a wrong wire shape", async (t) => {
+  assert.equal(repoWriteCommandActionKinds.length, 70);
   for (const commandName of repoWriteCommandActionKinds) {
     await t.test(commandName, () => {
       assert.throws(() => decodeRepoWriteParentMessage(frame(commandName, {

--- a/packages/daemon/test/repo-write-real-producer-acceptance.test.ts
+++ b/packages/daemon/test/repo-write-real-producer-acceptance.test.ts
@@ -44,7 +44,7 @@ test("every CLI repo-write producer survives normalization, DTO decode, and IPC 
           ? closeoutArgs()
           : spec.kind === "record-fact"
             ? recordFactArgs()
-            : shellSplit(spec.examples[0]!).slice(1),
+            : cutoverDigestArgs(spec.kind) ?? shellSplit(spec.examples[0]!).slice(1),
         root
       );
       produced.push(spec.kind);
@@ -132,6 +132,23 @@ function closeoutArgs(): ReadonlyArray<string> {
       ci: "passed"
     })
   ];
+}
+
+// Cutover controls that pin a digest publish `<sha256>` as their documented
+// placeholder, which is deliberately unparseable. Supply a real digest here so
+// the producer still crosses the same parse/normalize/IPC path as its peers.
+function cutoverDigestArgs(kind: string): ReadonlyArray<string> | undefined {
+  const digest = "a".repeat(64);
+  if (kind === "authority-cutover-boundary") {
+    return ["authority", "cutover", "boundary", "--id", "sme-v2", "--equality", "equality_1", "--expected-v2-tuple-digest", digest];
+  }
+  if (kind === "authority-cutover-freeze") {
+    return ["authority", "cutover", "freeze", "--reason", "forward fix", "--boundary-receipt-digest", digest];
+  }
+  if (kind === "authority-cutover-re-enable") {
+    return ["authority", "cutover", "re-enable", "--boundary", "sme-v2", "--freeze-receipt-digest", digest, "--equality", "equality_2", "--forward-fix", "fix/w6-1"];
+  }
+  return undefined;
 }
 
 function recordFactArgs(): ReadonlyArray<string> {

--- a/tools/coldstart-exhaustive-exercise.mjs
+++ b/tools/coldstart-exhaustive-exercise.mjs
@@ -1,0 +1,539 @@
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import {
+  cleanupFixture,
+  createFixture,
+  discoverCapabilities,
+  git,
+  receiptValue,
+  renderMarkdownReport,
+  runCli,
+  writeJson,
+  writeText
+} from "./coldstart-exhaustive-runtime.mjs";
+import { coldstartOperationManifest } from "./coldstart-exhaustive-manifest.mjs";
+
+const reportPath = parseReportPath(process.argv.slice(2));
+const fixture = createFixture();
+const results = new Map();
+const setupResults = [];
+let discovery;
+let fatalError = null;
+
+const KNOWN_A_FAILURES = new Map([
+  ["authority.cutover-status", {
+    code: "EngineNotEnabled",
+    symptom: "The fixture daemon was started with the manifest returned by ha init, but cutover status says the authority engine is not enabled."
+  }],
+  ["task.supersede", {
+    code: "authority_ingress_rejected",
+    hint: "TOKEN_PATH_SCOPE_DENIED",
+    symptom: "A freshly created task cannot be superseded because admission rejects the generated replacement path scope."
+  }]
+]);
+
+try {
+  discovery = discoverCapabilities(fixture);
+  verifyInventory(discovery);
+  for (const row of coldstartOperationManifest) {
+    if (!row.excludedByDesign) continue;
+    const runtime = discovery.operations.find((operation) => operation.id === row.id);
+    results.set(row.id, {
+      ...row,
+      status: "excluded-by-design",
+      reason: row.excludedByDesign,
+      commandTemplate: runtime?.capability.command ?? null,
+      exitCode: null,
+      receiptOk: null,
+      errorCode: null,
+      errorHint: null,
+      stdout: "",
+      stderr: ""
+    });
+  }
+  await exerciseOperations();
+} catch (error) {
+  fatalError = error instanceof Error ? `${error.stack ?? error.message}` : String(error);
+} finally {
+  const cleanup = await cleanupFixture(fixture).catch((error) => ({
+    baseRemoved: false,
+    protectedUnchanged: false,
+    errors: [error instanceof Error ? error.stack ?? error.message : String(error)]
+  }));
+  const report = buildReport(cleanup);
+  writeJson(jsonReportPath(reportPath), report);
+  writeText(reportPath, renderMarkdownReport(report));
+  process.stdout.write(`${JSON.stringify({
+    report: reportPath,
+    jsonReport: jsonReportPath(reportPath),
+    coverage: report.coverage,
+    signature: report.signature,
+    reproducibleSignatureInput: report.signatureInput,
+    cleanup: {
+      baseRemoved: report.cleanup.baseRemoved,
+      protectedUnchanged: report.cleanup.protectedUnchanged,
+      errors: report.cleanup.errors
+    }
+  }, null, 2)}\n`);
+  process.exitCode = report.coverage.failed > 0 || report.cleanup.errors.length > 0 || fatalError ? 1 : 0;
+}
+
+async function exerciseOperations() {
+  const init = exercise("init.init", ["init", "--name", "coldstart-exhaustive"]);
+  const manifestPath = stringOr(receiptValue(init, "manifestPath"), path.join(fixture.daemonUserRoot, "authority-service-state/authority-production.json"));
+  if (init.receipt?.details?.data?.report?.authorityBootstrap?.schema !== "init-authority-bootstrap/v1") {
+    init.status = "failed";
+    init.errorCode = init.errorCode ?? "authority_bootstrap_missing";
+    init.errorHint = init.errorHint ?? "ha init did not return init-authority-bootstrap/v1 with external authority state.";
+  }
+  exercise("daemon.register", ["daemon", "repo", "register", "--root", fixture.root, "--user-root", fixture.daemonUserRoot]);
+  exercise("daemon.start", ["daemon", "start", "--service", "--user-root", fixture.daemonUserRoot, "--authority-manifest", manifestPath], { timeoutMs: 30_000 });
+  exercise("daemon.status", ["daemon", "status", "--user-root", fixture.daemonUserRoot]);
+  exercise("daemon.logs", ["daemon", "logs", "--errors"]);
+
+  writeText(path.join(fixture.root, "README.md"), "# Cold-start exhaustive fixture\n");
+  git(fixture, "add", "--all");
+  git(fixture, "commit", "-m", "test: seed cold-start public anchor");
+  const publicHead = git(fixture, "rev-parse", "HEAD");
+
+  exercise("status.status", ["status"]);
+  exercise("doctor.doctor", ["doctor"]);
+  exercise("check.check", ["check", "--profile", "target-project"]);
+  exercise("authority.cutover-status", ["authority", "cutover", "status"]);
+  exercise("vertical.validate", ["vertical", "validate", "software/coding"]);
+  exercise("preset.seed", ["preset", "seed"]);
+
+  const primary = exercise("task.create", taskCreateArgs("Cold-start primary completion"));
+  const tasks = {
+    primary: taskFrom(primary, "primary"),
+    relationSource: prepareTask("Task relation source"),
+    relationTarget: prepareTask("Task relation target"),
+    transition: prepareTask("Task transition target"),
+    retire: prepareTask("Task retired execution"),
+    archive: prepareTask("Task archive target"),
+    supersede: prepareTask("Task supersede target"),
+    disposition: prepareTask("Task delete reopen target"),
+    amend: prepareTask("Task amend target"),
+    review: prepareTask("Task review lint target"),
+    worktree: prepareTask("Task worktree target"),
+    closeout: prepareTask("Task closeout facade target")
+  };
+  for (const task of Object.values(tasks)) writeTaskDocuments(task);
+  writeText(path.join(fixture.root, tasks.archive.packagePath, "closeout.md"), closeoutBody("Archive evidence is substantive and retained."));
+  exercise("doc.status", ["doc", "status"]);
+  const authoredDocs = Object.values(tasks).flatMap((task) => [authoredPath(task, "task_plan.md"), authoredPath(task, "closeout.md")]);
+  exercise("doc.sync", ["doc", "sync", "--submit", ...authoredDocs.flatMap((documentPath) => ["--path", documentPath])]);
+  exercise("materializer.run", ["materializer", "run"]);
+  exercise("worktree.create", ["worktree", "create", "--task", tasks.worktree.taskId, "--agent", "coldstart-exhaustive", "--base", "HEAD", "--path", path.join(fixture.base, "worktree")]);
+  exercise("worktree.status", ["worktree", "status", "--task", tasks.worktree.taskId]);
+  writeText(path.join(fixture.root, "evidence.txt"), "Cold-start artifact evidence.\n");
+  writeText(path.join(fixture.root, "source-note.md"), "A repeatable cold-start exercise records durable evidence.\n");
+  exercise("task.list", ["task", "list"]);
+  exercise("task.show", ["task", "show", tasks.primary.taskId]);
+  exercise("task.transition", ["task", "transition", tasks.transition.taskId, "active"]);
+  exercise("task.progress-append", ["task", "progress", "append", tasks.primary.taskId, "--text", "Exercised the cold-start CLI graph."]);
+  exercise("task.artifact-add", ["task", "artifact", "add", tasks.primary.taskId, "evidence.txt"]);
+  exercise("task.amend", ["task", "amend", tasks.amend.taskId, "--set", "taskClass:milestone"]);
+  exercise("task.contract-migrate", ["task", "contract", "migrate", "--apply"]);
+  exercise("task.relate", ["task", "relate", tasks.relationSource.taskId, "depends-on", tasks.relationTarget.taskId, "--rationale", "The source verifies the target fixture first."]);
+
+  const firstFact = exercise("fact.record", ["fact", "record", "--task", tasks.primary.taskId, "--statement", "The isolated fixture initialized successfully.", "--source", "coldstart exercise", "--confidence", "high"]);
+  const firstFactId = stringOr(receiptValue(firstFact, "factId"), "F-MISSING01");
+  const secondFact = prepare("fact record invalidator", ["fact", "record", "--task", tasks.primary.taskId, "--statement", "The newer fixture observation supersedes the initial observation.", "--source", "coldstart exercise", "--confidence", "high"]);
+  const secondFactId = stringOr(receiptValue(secondFact, "factId"), "F-MISSING02");
+  exercise("fact.list", ["fact", "list", "--task", tasks.primary.taskId]);
+  exercise("fact.show", ["fact", "show", "--task", tasks.primary.taskId, "--id", firstFactId]);
+  exercise("fact.invalidate", ["fact", "invalidate", "--task", tasks.primary.taskId, "--id", firstFactId, "--by", secondFactId, "--rationale", "A later direct observation is more precise."]);
+
+  const candidate = exercise("distill.candidate", ["distill", "candidate", "--task", tasks.primary.taskId, "--input", "source-note.md"]);
+  const candidatePath = stringOr(receiptValue(candidate, "path", "candidatePath"), ".harness/generated/distill/missing.json");
+  exercise("distill.promote", ["distill", "promote", "--task", tasks.primary.taskId, "--candidate", candidatePath, "--claim", "Cold-start exercise evidence is reproducible.", "--id", "F-C01D0001", "--confidence", "high", "--memory-class", "procedural", "--memory-tag", "pattern"]);
+
+  exercise("module.register", ["module", "register", "coldstart-module", "--title", "Cold-start Module", "--scope", "src/**", "--prefix", "CSE", "--current-step", "plan"]);
+  exercise("module.list", ["module", "list"]);
+  exercise("module.inspect", ["module", "inspect", "coldstart-module"]);
+  exercise("module.scaffold", ["module", "scaffold", "coldstart-module"]);
+  exercise("module.step", ["module", "step", "coldstart-module", "plan", "--state", "done"]);
+
+  const decision = exercise("decision.propose", [
+    "decision", "propose", "--title", "Cold-start exhaustive policy", "--question", "Should the fixture exercise every applicable op?",
+    "--chosen", "Exercise every applicable operation", "--rejected", "Sample only common commands", "--why-not", "Sampling hides cold-start dependencies",
+    "--claim", "Every applicable operation has executable evidence", "--non-load-bearing", "--body", "## Background\n\nThe fixture validates a new user path.\n\n## Decision\n\nExercise the whole applicable surface."
+  ]);
+  const decisionId = stringOr(receiptValue(decision, "decisionId"), "dec_MISSING");
+  exercise("decision.transition", ["--actor", "human:person_coldstart_exhaustive_2bfb590688", "decision", "transition", "active", decisionId, "--judgment-only", "The isolated socket owner approves this disposable fixture decision."]);
+  exercise("decision.amend", ["decision", "amend", decisionId, "--body", "## Background\n\nThe cold-start run is disposable.\n\n## Decision\n\nKeep the fixture decision concise and non-load-bearing."]);
+  const related = exercise("decision.relate", ["decision", "relate", decisionId, "--anchor", "CH1", "--type", "relates", "--target", `task/${tasks.primary.taskId}`, "--rationale", "The decision describes the exercise task."]);
+  const relationRows = exercise("relation.list", ["relation", "list"]);
+  const relatedId = findRelationId(relationRows.receipt, decisionId, "relates", `task/${tasks.primary.taskId}`) ?? stringOr(receiptValue(related, "relationId"), "rel_missing");
+  const replace = exercise("relation.relation-replace", ["decision", "relation", "replace", decisionId, "--relation", relatedId, "--anchor", "CH1", "--type", "relates", "--target", `task/${tasks.relationTarget.taskId}`, "--rationale", "The replacement edge points to the verification fixture."]);
+  const replacedRows = prepare("list replaced decision relation", ["relation", "list"]);
+  const replacementId = findRelationId(replacedRows.receipt, decisionId, "relates", `task/${tasks.relationTarget.taskId}`) ?? stringOr(receiptValue(replace, "relationId", "newRelationId"), relatedId);
+  exercise("relation.relation-retire", ["decision", "relation", "retire", decisionId, "--relation", replacementId, "--body", "The fixture retires its temporary evidence edge."]);
+  exercise("decision.list", ["decision", "list"]);
+  exercise("decision.show", ["decision", "show", decisionId]);
+  exercise("decision.verify", ["decision", "verify", decisionId]);
+  exercise("decision.reckon", ["decision", "reckon", decisionId, "--task", tasks.primary.taskId]);
+
+  const presetSource = writePresetSource();
+  exercise("preset.validate", ["preset", "validate", path.join(presetSource, "preset.json"), "--kernel-version", "1.0.0"]);
+  exercise("preset.install", ["preset", "install", presetSource, "--project"]);
+  exercise("preset.list", ["preset", "list"]);
+  exercise("preset.inspect", ["preset", "inspect", "coldstart-action"]);
+  exercise("preset.check", ["preset", "check", "coldstart-action"]);
+  const customTask = prepareTask("Custom preset task", ["--preset", "coldstart-action"]);
+  exercise("preset.entrypoint", ["preset", "entrypoint", "coldstart-action", "plan", "--task", customTask.taskId, "--allow-scripts"]);
+  const scripts = exercise("script.list", ["script", "list"]);
+  const scriptId = findScriptId(scripts.receipt) ?? "preset:coldstart-action:plan";
+  exercise("script.inspect", ["script", "inspect", scriptId]);
+  exercise("script.run", ["script", "run", scriptId, "--task", customTask.taskId]);
+  exercise("preset.audit", ["preset", "audit"]);
+  prepare("terminal custom preset task", ["task", "transition", customTask.taskId, "cancelled", "--force", "--reason", "fixture preset uninstall"]);
+  exercise("preset.uninstall", ["preset", "uninstall", "coldstart-action", "--project"]);
+
+  const templates = exercise("template.list", ["template", "list"]);
+  const templateRef = findTemplateRef(templates.receipt) ?? "task_plan";
+  exercise("template.render", ["template", "render", templateRef, "--locale", "en-US"]);
+
+  const primarySession = "coldstart-primary-session";
+  const retireSession = "coldstart-retire-session";
+  const closeoutSession = "coldstart-closeout-session";
+  const transcripts = createSessionTranscripts([primarySession, retireSession, closeoutSession]);
+  exercise("session.export", sessionExportArgs(primarySession, transcripts[primarySession]));
+  prepare("export retire session", sessionExportArgs(retireSession, transcripts[retireSession]));
+  prepare("export closeout session", sessionExportArgs(closeoutSession, transcripts[closeoutSession]));
+  exercise("session.show", ["session", "show", primarySession]);
+  exercise("session.backfill", ["session", "backfill", "--runtime", "codex", "--limit", "20"]);
+  exercise("session.sync", ["session", "sync", "--apply"]);
+  exercise("event.append", ["event", "append", "--session", "coldstart-event-session", "--kind", "tool", "--tool", "ha", "--summary", "Exhaustive CLI exercise"]);
+  exercise("event.list", ["event", "list", "--session", "coldstart-event-session"]);
+  exercise("diagnostics.command-usage", ["diagnostics", "command-usage"]);
+
+  const started = exercise("task.start", ["task", "start", tasks.primary.taskId], { env: sessionEnv(primarySession) });
+  const primaryExecutionId = stringOr(receiptValue(started, "executionId"), "exe_MISSING_PRIMARY");
+  exercise("execution.show", ["execution", "show", primaryExecutionId]);
+  exercise("execution.list", ["execution", "list", "--task", tasks.primary.taskId]);
+
+  const retireStarted = prepare("start retire execution", ["task", "start", tasks.retire.taskId], { env: sessionEnv(retireSession) });
+  const retireExecutionId = stringOr(receiptValue(retireStarted, "executionId"), "exe_MISSING_RETIRE");
+  exercise("task.holder", ["task", "holder", tasks.retire.taskId]);
+  exercise("task.release", ["task", "release", tasks.retire.taskId]);
+  exercise("task.retire-execution", ["task", "retire-execution", tasks.retire.taskId, "--execution-id", retireExecutionId, "--reason", "Exercise explicit abandoned round retirement."]);
+
+  const submissionPath = path.join(fixture.base, "submission.json");
+  writeJson(submissionPath, submissionPacket());
+  exercise("task.submit", ["task", "submit", tasks.primary.taskId, "--from-file", submissionPath], { env: sessionEnv(primarySession) });
+  exercise("task.code-doc-reconcile", ["task", "code-doc", "reconcile", tasks.primary.taskId, "--commit", publicHead, "--path", "README.md", "--force"]);
+  prepare("publish primary reconciliation", ["materializer", "run"]);
+  const consent = exercise("task.consent-record", ["task", "consent-record", tasks.primary.taskId, "--execution-id", primaryExecutionId, "--asserted", "Fixture owner approved through the isolated local channel.", "--consent-action", "approve_execution", "--consent-action", "complete_task"]);
+  const consentId = stringOr(receiptValue(consent, "consentId"), "consent_MISSING");
+  const reviewed = exercise("task.review-execution", [
+    "task", "review-execution", tasks.primary.taskId, "--execution-id", primaryExecutionId,
+    "--verdict", "approved", "--findings", "All exercised evidence is present.", "--rationale", "The isolated run demonstrates the applicable surface.",
+    "--consent", consentId, "--evidence-checked", "ev_cli_1", "--acknowledge-archive-warnings"
+  ]);
+  const reviewId = stringOr(receiptValue(reviewed, "reviewId"), "rev_MISSING");
+  exercise("review.show", ["review", "show", reviewId]);
+  const approvalPath = path.join(fixture.base, "approval.json");
+  writeJson(approvalPath, approvalPacket(primaryExecutionId, publicHead));
+  exercise("task.complete", ["task", "complete", tasks.primary.taskId, "--approve", "--from-file", approvalPath], { env: sessionEnv(primarySession) });
+  exercise("audit.provenance", ["audit", "provenance", "--task", tasks.primary.taskId]);
+
+  const closeoutStarted = prepare("start closeout task", ["task", "start", tasks.closeout.taskId], { env: sessionEnv(closeoutSession) });
+  const closeoutExecutionId = stringOr(receiptValue(closeoutStarted, "executionId"), "exe_MISSING_CLOSEOUT");
+  prepare("submit closeout task", ["task", "submit", tasks.closeout.taskId, "--from-file", submissionPath], { env: sessionEnv(closeoutSession) });
+  prepare("reconcile closeout task", ["task", "code-doc", "reconcile", tasks.closeout.taskId, "--commit", publicHead, "--path", "README.md", "--force"]);
+  prepare("publish closeout reconciliation", ["materializer", "run"]);
+  const closeoutPacketPath = path.join(fixture.base, "closeout-packet.json");
+  writeJson(closeoutPacketPath, { ...submissionPacket(), ...approvalPacket(closeoutExecutionId, publicHead) });
+  exercise("task.closeout", ["task", "closeout", tasks.closeout.taskId, "--from-file", closeoutPacketPath], { env: sessionEnv(closeoutSession) });
+
+  writeText(path.join(fixture.root, tasks.review.packagePath, "review.md"), "# Review\n\n## Verdict\n\nPASS\n\n## Findings\n\nNo open findings.\n");
+  exercise("task.review", ["task", "review", tasks.review.taskId]);
+  exercise("task.archive", ["task", "archive", tasks.archive.taskId, "--reason", "Fixture archive lifecycle exercised."]);
+  exercise("task.supersede", ["task", "supersede", tasks.supersede.taskId, "--title", "Replacement cold-start task", "--reason", "Fixture replacement lifecycle exercised."]);
+  exercise("task.delete", ["task", "delete", "--soft", tasks.disposition.taskId, "--reason", "Fixture tombstone lifecycle exercised."]);
+  exercise("task.reopen", ["task", "reopen", tasks.disposition.taskId, "--reason", "Fixture reopen lifecycle exercised."]);
+  exercise("cas.gc", ["cas", "gc", "--apply"]);
+  exercise("governance.rebuild", ["governance", "rebuild", "--apply"]);
+  exercise("graph.graph", ["graph", "--out", path.join(fixture.root, "coldstart-relations.html")]);
+  exercise("git.diff", ["git", "diff", "--base", "HEAD"]);
+  exercise("module.unregister", ["module", "unregister", "coldstart-module"]);
+  exercise("daemon.restart", ["daemon", "restart", "--user-root", fixture.daemonUserRoot], { timeoutMs: 45_000 });
+  exercise("daemon.refresh", ["daemon", "refresh", "--user-root", fixture.daemonUserRoot, "--reason", "coldstart exhaustive fixture"], { timeoutMs: 45_000 });
+  exercise("daemon.stop", ["daemon", "stop", "--timeout-ms", "10000", "--user-root", fixture.daemonUserRoot], { timeoutMs: 20_000 });
+}
+
+function exercise(id, args, options = {}) {
+  if (results.has(id)) throw new Error(`Operation already recorded: ${id}`);
+  const manifest = coldstartOperationManifest.find((row) => row.id === id);
+  if (!manifest) throw new Error(`Operation is absent from manifest: ${id}`);
+  if (manifest.excludedByDesign) throw new Error(`Excluded operation must not execute: ${id}`);
+  const runtime = discovery.operations.find((operation) => operation.id === id);
+  const record = runCli(fixture, args, options);
+  const result = {
+    ...manifest,
+    commandTemplate: runtime?.capability.command ?? null,
+    status: record.exitCode === 0 && record.receiptOk ? "passed" : "failed",
+    ...record
+  };
+  Object.assign(result, failureTriage(result));
+  results.set(id, result);
+  process.stderr.write(`[${result.status}] ${id} exit=${String(result.exitCode)} ok=${String(result.receiptOk)}${result.errorCode ? ` code=${result.errorCode}` : ""}\n`);
+  return result;
+}
+
+function prepare(label, args, options = {}) {
+  const record = runCli(fixture, args, options);
+  setupResults.push({ label, ...record });
+  process.stderr.write(`[setup:${record.exitCode === 0 && record.receiptOk ? "passed" : "failed"}] ${label}${record.errorCode ? ` code=${record.errorCode}` : ""}\n`);
+  return record;
+}
+
+function prepareTask(title, extraArgs = []) {
+  return taskFrom(prepare(`create task: ${title}`, taskCreateArgs(title, extraArgs)), title.toLowerCase().replaceAll(/[^a-z0-9]+/gu, "-"));
+}
+
+function taskCreateArgs(title, extraArgs = []) {
+  return ["task", "create", "--title", title, "--vertical", "software/coding", ...extraArgs, ...(extraArgs.includes("--preset") ? [] : ["--preset", "standard-task"])];
+}
+
+function taskFrom(record, fallback) {
+  const receipt = record?.receipt ?? record;
+  const packagePath = receipt?.details?.pathsByRole?.package
+    ?? receipt?.paths?.find?.((entry) => entry?.role === "package")?.path;
+  return {
+    taskId: stringOr(receiptValue(record, "taskId"), `task_MISSING_${fallback}`),
+    packagePath: stringOr(packagePath, `harness/tasks/task_MISSING_${fallback}`)
+  };
+}
+
+function authoredPath(task, filename) {
+  return `${task.packagePath.replace(/^harness\//u, "")}/${filename}`;
+}
+
+function writeTaskDocuments(task) {
+  const directory = path.join(fixture.root, task.packagePath);
+  if (!existsSync(directory)) return;
+  writeText(path.join(directory, "task_plan.md"), substantivePlan());
+  writeText(path.join(directory, "closeout.md"), closeoutBody("The isolated operation exercise completed with recorded evidence."));
+}
+
+function writePresetSource() {
+  const source = path.join(fixture.base, "coldstart-action-preset");
+  const scripts = path.join(source, "scripts");
+  mkdirSync(scripts, { recursive: true });
+  writeJson(path.join(source, "preset.json"), {
+    schema: "preset-manifest/v2",
+    id: "coldstart-action",
+    title: "Cold-start Action",
+    vertical: "software/coding",
+    version: "0.1.0",
+    kind: "process-action",
+    kernelVersionRange: { min: "1.0.0", maxExclusive: "2.0.0" },
+    capabilityImports: [],
+    entrypoints: {
+      plan: { type: "script", command: "scripts/plan.mjs", reads: ["{{outputRoot}}/**"], writes: ["{{outputRoot}}/**"] }
+    },
+    profiles: [{ id: "baseline", title: "Baseline", checkerProfile: "standard", completionGates: [], templateSelections: [] }],
+    defaultProfile: "baseline"
+  });
+  const scriptPath = path.join(scripts, "plan.mjs");
+  writeText(scriptPath, [
+    "#!/usr/bin/env node",
+    "import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';",
+    "import path from 'node:path';",
+    "let target = process.env.HARNESS_SCRIPT_RESULT;",
+    "if (!target) {",
+    "  const context = JSON.parse(readFileSync(process.env.HARNESS_PRESET_CONTEXT, 'utf8'));",
+    "  const artifacts = path.join(context.outputRoot, 'artifacts');",
+    "  mkdirSync(artifacts, { recursive: true });",
+    "  target = path.join(artifacts, 'preset-result.json');",
+    "}",
+    "writeFileSync(target, JSON.stringify({ schema: 'script-result/v1', ok: true, report: {}, produced: [] }));",
+    ""
+  ].join("\n"));
+  chmodSync(scriptPath, 0o755);
+  return source;
+}
+
+function createSessionTranscripts(sessionIds) {
+  const directory = path.join(fixture.home, ".codex/sessions");
+  mkdirSync(directory, { recursive: true });
+  return Object.fromEntries(sessionIds.map((sessionId, index) => {
+    const transcriptPath = path.join(directory, `${sessionId}.jsonl`);
+    writeText(transcriptPath, [
+      JSON.stringify({ timestamp: `2026-08-08T00:00:0${index}.000Z`, type: "event_msg", payload: { type: "user_message", message: `Exercise ${sessionId}` } }),
+      JSON.stringify({ timestamp: `2026-08-08T00:00:1${index}.000Z`, type: "response_item", payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "verified" }] } }),
+      ""
+    ].join("\n"));
+    return [sessionId, transcriptPath];
+  }));
+}
+
+function sessionExportArgs(sessionId, transcriptPath) {
+  return ["session", "export", "--session", sessionId, "--runtime", "codex", "--source", "runtime", "--detected-at", "2026-08-08T00:00:00.000Z", "--transcript-file", transcriptPath];
+}
+
+function sessionEnv(sessionId) {
+  return { CODEX_THREAD_ID: sessionId, CODEX_SESSION_ID: sessionId };
+}
+
+function submissionPacket() {
+  return {
+    completionClaim: "The cold-start CLI operation is exercised.",
+    deliverables: ["Structured exhaustive report"],
+    outputs: ["Cold-start execution evidence"],
+    verificationNotes: ["The isolated daemon path was invoked."],
+    knownGaps: [],
+    residualRisks: []
+  };
+}
+
+function approvalPacket(executionId, commit) {
+  return {
+    executionId,
+    verdict: "approved",
+    findings: "The submitted evidence and public code anchor satisfy this fixture task.",
+    evidenceChecked: ["ev_cli_1"],
+    rationale: "The isolated daemon path provides direct cold-start evidence.",
+    archiveWarningsAcknowledged: true,
+    consentAssertedRationale: "Fixture owner approval was received through the isolated local channel.",
+    consentActions: ["approve_execution", "complete_task"],
+    commit,
+    paths: ["README.md"],
+    ci: "passed",
+    reviewerId: "person_coldstart_exhaustive_2bfb590688",
+    externalCheckpointRefs: []
+  };
+}
+
+function substantivePlan() {
+  return [
+    "# Substantive Plan", "", "Task Contract: harness-task v1", "", "## Brief", "", "Exercise one cold-start CLI operation.", "",
+    "## Goal", "", "Produce and verify a concrete isolated receipt.", "", "## Context", "", "Use the temporary project and fixture daemon.", "",
+    "## Constraints", "", "Keep all writes inside the temporary fixture roots.", "", "## Checkpoint", "", "Stop if isolation cannot be proven.", "",
+    "## CI/Gate Authority Stop Condition", "", "This fixture does not alter gate authority.", "", "## Implementation Plan", "", "- Prepare state, invoke the operation, and record its receipt.", "",
+    "## Verification", "", "- Inspect exit code, receipt ok, persisted output, and cleanup.", ""
+  ].join("\n");
+}
+
+function closeoutBody(summary) {
+  return `# Closeout\n\n## Summary\n\n${summary}\n\n## Verification\n\nThe disposable fixture captured the command receipt.\n\n## Residual Risk\n\nNo fixture state is retained.\n`;
+}
+
+function findScriptId(receipt) {
+  return findObject(receipt, (value) => typeof value.id === "string" && value.id.includes("coldstart-action"))?.id;
+}
+
+function findTemplateRef(receipt) {
+  const row = findObject(receipt, (value) => ["templateRef", "ref", "id"].some((key) => typeof value[key] === "string"));
+  return row?.templateRef ?? row?.ref ?? row?.id;
+}
+
+function findRelationId(receipt, decisionId, relationType, targetRef) {
+  return findObject(receipt, (value) => value.relationType === relationType
+    && typeof value.sourceRef === "string"
+    && value.sourceRef.startsWith(`decision/${decisionId}/`)
+    && value.state === "active"
+    && (!targetRef || value.targetRef === targetRef)
+    && typeof value.relationId === "string")?.relationId;
+}
+
+function findObject(root, predicate) {
+  const queue = [root];
+  const seen = new Set();
+  while (queue.length > 0) {
+    const value = queue.shift();
+    if (!value || typeof value !== "object" || seen.has(value)) continue;
+    seen.add(value);
+    if (!Array.isArray(value) && predicate(value)) return value;
+    for (const child of Object.values(value)) if (child && typeof child === "object") queue.push(child);
+  }
+  return undefined;
+}
+
+function verifyInventory(runtime) {
+  const expected = coldstartOperationManifest.map((row) => row.id).sort();
+  const actual = runtime.operations.map((row) => row.id).sort();
+  if (runtime.kindCount !== 35 || runtime.opCount !== 121 || JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`Capability inventory mismatch: expected 35/121, received ${runtime.kindCount}/${runtime.opCount}; missing=${expected.filter((id) => !actual.includes(id)).join(",")}; extra=${actual.filter((id) => !expected.includes(id)).join(",")}`);
+  }
+}
+
+function buildReport(cleanup) {
+  for (const row of coldstartOperationManifest) {
+    if (results.has(row.id)) continue;
+    results.set(row.id, {
+      ...row,
+      status: "failed",
+      commandTemplate: discovery?.operations.find((operation) => operation.id === row.id)?.capability.command ?? null,
+      commandLine: null,
+      exitCode: null,
+      receiptOk: false,
+      errorCode: "exercise_aborted_before_invocation",
+      errorHint: fatalError ?? "The runner did not reach this operation.",
+      failureClass: "untriaged",
+      failureSymptom: "The exercise aborted before this operation was invoked.",
+      stdout: "",
+      stderr: ""
+    });
+  }
+  const ordered = coldstartOperationManifest.map((row) => results.get(row.id));
+  const signatureInput = ordered.map(({ id, status, errorCode }) => `${id}:${status}:${errorCode ?? "-"}`).join("\n");
+  return {
+    schema: "coldstart-exhaustive-report/v1",
+    generatedAt: new Date().toISOString(),
+    node: process.version,
+    cliEntry: "packages/cli/dist/cli/src/index.js",
+    fixture: {
+      root: fixture.root,
+      daemonUserRoot: fixture.daemonUserRoot,
+      daemonId: fixture.daemonId,
+      userRootExternal: !fixture.daemonUserRoot.startsWith(`${fixture.root}${path.sep}`)
+    },
+    discovery: discovery ?? { kindCount: 0, opCount: 0, index: [], kinds: [], operations: [], advertisedFailures: [] },
+    inventory: coldstartOperationManifest.map((row) => ({
+      ...row,
+      commandTemplate: discovery?.operations.find((operation) => operation.id === row.id)?.capability.command ?? null
+    })),
+    coverage: {
+      total: ordered.length,
+      passed: ordered.filter((result) => result.status === "passed").length,
+      failed: ordered.filter((result) => result.status === "failed").length,
+      excludedByDesign: ordered.filter((result) => result.status === "excluded-by-design").length
+    },
+    signatureInput,
+    signature: createHash("sha256").update(signatureInput).digest("hex"),
+    results: ordered,
+    setupResults,
+    fatalError,
+    cleanup
+  };
+}
+
+function parseReportPath(args) {
+  const index = args.indexOf("--report");
+  const selected = index >= 0 ? args[index + 1] : "/tmp/coldstart-exhaustive-report.md";
+  if (!selected || !path.isAbsolute(selected)) throw new Error("--report must be followed by an absolute path");
+  return selected;
+}
+
+function jsonReportPath(markdownPath) {
+  return markdownPath.endsWith(".md") ? `${markdownPath.slice(0, -3)}.json` : `${markdownPath}.json`;
+}
+
+function stringOr(value, fallback) {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+function failureTriage(result) {
+  if (result.status !== "failed") return { failureClass: null, failureSymptom: null };
+  const expected = KNOWN_A_FAILURES.get(result.id);
+  const codeMatches = expected?.code === result.errorCode;
+  const hintMatches = !expected?.hint || result.errorHint?.includes(expected.hint);
+  return codeMatches && hintMatches
+    ? { failureClass: "A", failureSymptom: expected.symptom }
+    : { failureClass: "untriaged", failureSymptom: "Unexpected executable-op failure; preserve the receipt and triage it before changing exclusions." };
+}

--- a/tools/coldstart-exhaustive-manifest.mjs
+++ b/tools/coldstart-exhaustive-manifest.mjs
@@ -1,0 +1,149 @@
+const OPERATIONS_BY_KIND = {
+  adopt: ["multica"],
+  audit: ["provenance"],
+  authority: ["cutover status", "cutover drain", "cutover scan", "cutover confirm", "cutover boundary", "cutover freeze", "cutover re-enable", "repo enroll", "repo resign"],
+  cas: ["gc"],
+  check: ["check"],
+  consent: [],
+  daemon: ["register", "start", "status", "logs", "stop", "restart", "refresh", "upgrade"],
+  decision: ["list", "show", "verify", "repin", "propose", "transition", "amend", "relate", "reckon"],
+  diagnostics: ["command-usage"],
+  distill: ["candidate", "promote"],
+  doc: ["status", "sync"],
+  doctor: ["doctor"],
+  event: ["append", "list"],
+  execution: ["show", "list"],
+  external: ["snapshot", "list github"],
+  fact: ["list", "show", "record", "invalidate"],
+  git: ["diff"],
+  governance: ["rebuild"],
+  graph: ["graph"],
+  gui: ["gui"],
+  init: ["init"],
+  legacy: ["scan", "plan", "copy-docs", "index", "verify"],
+  materializer: ["run"],
+  migrate: ["plan", "structure", "anchors", "fact-execution", "retired-attribution-fields", "provenance", "run", "verify"],
+  module: ["list", "inspect", "register", "scaffold", "unregister", "step"],
+  preset: ["validate", "list", "inspect", "check", "install", "seed", "audit", "uninstall", "entrypoint"],
+  relation: ["list", "relation retire", "relation replace"],
+  review: ["show"],
+  script: ["list", "inspect", "run"],
+  session: ["show", "export", "backfill", "sync"],
+  status: ["status"],
+  task: ["retire-execution", "submit", "create", "start", "holder", "release", "closeout", "transition", "progress append", "artifact add", "amend", "contract migrate", "archive", "supersede", "delete", "reopen", "code-doc reconcile", "review", "consent-record", "review-execution", "complete", "show", "relate", "list"],
+  template: ["list", "render"],
+  vertical: ["validate"],
+  worktree: ["create", "status"]
+};
+
+const LIFECYCLE_IDS = new Set([
+  "authority.cutover-drain", "authority.cutover-scan", "authority.cutover-confirm",
+  "authority.cutover-boundary", "authority.cutover-freeze", "authority.cutover-re-enable",
+  "authority.repo-enroll", "authority.repo-resign",
+  "daemon.register", "daemon.start", "daemon.stop", "daemon.restart", "daemon.refresh", "daemon.upgrade",
+  "gui.gui", "init.init", "legacy.copy-docs", "legacy.index",
+  "migrate.structure", "migrate.anchors", "migrate.fact-execution",
+  "migrate.retired-attribution-fields", "migrate.provenance", "migrate.run",
+  "preset.entrypoint", "script.run", "task.archive", "task.closeout", "task.complete",
+  "task.delete", "task.reopen", "task.start", "task.submit", "task.supersede",
+  "task.transition", "worktree.create"
+]);
+
+const READ_IDS = new Set([
+  "audit.provenance", "authority.cutover-status", "check.check", "daemon.logs", "daemon.status",
+  "decision.list", "decision.show", "decision.verify", "diagnostics.command-usage", "doc.status",
+  "doctor.doctor", "event.list", "execution.list", "execution.show", "external.list-github",
+  "external.snapshot", "fact.list", "fact.show", "git.diff", "graph.graph", "legacy.plan",
+  "legacy.scan", "legacy.verify", "migrate.plan", "migrate.verify", "module.inspect", "module.list",
+  "preset.audit", "preset.check", "preset.inspect", "preset.list", "preset.validate", "relation.list",
+  "review.show", "script.inspect", "script.list", "session.show", "status.status", "task.holder",
+  "task.list", "task.review", "task.show", "template.list", "template.render", "vertical.validate",
+  "worktree.status"
+]);
+
+const EXCLUDED = new Map([
+  ["adopt.multica", "Requires a reachable, configured Multica provider and a real external issue; cold-start is intentionally offline."],
+  ["external.snapshot", "Requires a reachable configured GitHub or Multica provider; cold-start is intentionally offline."],
+  ["external.list-github", "Requires a reachable configured GitHub provider and repository; cold-start is intentionally offline."],
+  ["gui.gui", "Launches the Electron desktop controller and requires an interactive display/event loop, not a headless CLI fixture."],
+  ["decision.repin", "Only applies to a pre-existing verified stale decision pin and requires migration evidence; fresh decisions are correctly pinned."],
+  ["daemon.upgrade", "Requires a managed daemon deployment, versioned snapshot build, and supervisor convergence; a disposable project daemon is not that deployment boundary."],
+  ["authority.cutover-drain", "Belongs to an explicit production V1-to-V2 authority cutover campaign; init creates a fresh V2 authority with no V1 admission backlog."],
+  ["authority.cutover-scan", "Requires a drained production cutover campaign and independent final-scan evidence; a fresh V2 repo has no cutover campaign."],
+  ["authority.cutover-confirm", "Requires two persisted production cutover scans; a fresh V2 repo has no cutover campaign."],
+  ["authority.cutover-boundary", "Activates a production cutover boundary from confirmed scan equality; init already creates the fresh V2 boundary."],
+  ["authority.cutover-freeze", "Freezes a previously activated production cutover boundary; no such migration boundary exists after fresh init."],
+  ["authority.cutover-re-enable", "Re-enables a frozen production cutover after a verified forward fix; a fresh init has neither freeze nor forward-fix incident."],
+  ["authority.repo-enroll", "Administrative adoption of a pre-existing repository into a trust domain; ha init already enrolls the cold-start repository."],
+  ["authority.repo-resign", "Administrative trust-domain rotation for an already enrolled repository; cold-start has no prior domain to retire."],
+  ...["scan", "plan", "copy-docs", "index", "verify"].map((op) => [
+    `legacy.${op}`,
+    "Legacy Intake requires a pre-Harness source tree; a genuinely fresh project intentionally has no legacy content."
+  ]),
+  ...["plan", "structure", "anchors", "fact-execution", "retired-attribution-fields", "provenance", "run", "verify"].map((op) => [
+    `migrate.${op}`,
+    "Migration tooling requires historical schema/session/attribution data; a freshly initialized workspace intentionally has none."
+  ])
+]);
+
+const TASK_REQUIRED = new Set([
+  "audit.provenance", "decision.reckon", "distill.candidate", "distill.promote", "execution.list",
+  "fact.invalidate", "fact.list", "fact.record", "fact.show", "preset.entrypoint", "task.amend",
+  "task.archive", "task.artifact-add", "task.closeout", "task.code-doc-reconcile", "task.complete",
+  "task.consent-record", "task.delete", "task.holder", "task.progress-append", "task.relate",
+  "task.release", "task.reopen", "task.retire-execution", "task.review", "task.review-execution",
+  "task.show", "task.start", "task.submit", "task.supersede", "task.transition", "worktree.create",
+  "worktree.status"
+]);
+
+const DECISION_REQUIRED = new Set([
+  "decision.amend", "decision.reckon", "decision.relate", "decision.repin", "decision.show",
+  "decision.transition", "decision.verify", "relation.relation-replace", "relation.relation-retire"
+]);
+
+const EXECUTION_REQUIRED = new Set([
+  "audit.provenance", "execution.show", "review.show", "task.closeout", "task.complete",
+  "task.consent-record", "task.release", "task.retire-execution", "task.review-execution", "task.submit"
+]);
+
+const DAEMON_REQUIRED = new Set([
+  "audit.provenance", "authority.cutover-status", "authority.cutover-drain", "authority.cutover-scan",
+  "authority.cutover-confirm", "authority.cutover-boundary", "authority.cutover-freeze",
+  "authority.cutover-re-enable", "daemon.logs", "daemon.restart", "daemon.refresh", "daemon.status",
+  "daemon.stop", "daemon.upgrade", "decision.amend", "decision.propose", "decision.reckon",
+  "decision.relate", "decision.repin", "decision.transition", "distill.promote", "doc.sync",
+  "fact.invalidate", "fact.record", "governance.rebuild", "materializer.run", "module.register",
+  "module.scaffold", "module.step", "module.unregister", "preset.entrypoint", "preset.install",
+  "preset.seed", "preset.uninstall", "relation.relation-replace", "relation.relation-retire",
+  "script.run", "task.amend", "task.archive", "task.artifact-add", "task.closeout",
+  "task.code-doc-reconcile", "task.complete", "task.consent-record", "task.contract-migrate",
+  "task.create", "task.delete", "task.progress-append", "task.relate", "task.release", "task.reopen",
+  "task.retire-execution", "task.review-execution", "task.start", "task.submit", "task.supersede",
+  "task.transition", "worktree.create"
+]);
+
+export function operationId(kind, name) {
+  return `${kind}.${name.replaceAll(" ", "-")}`;
+}
+
+export const coldstartOperationManifest = Object.entries(OPERATIONS_BY_KIND).flatMap(([kind, names]) =>
+  names.map((name) => {
+    const id = operationId(kind, name);
+    const prerequisites = id === "init.init" ? [] : ["initialized-workspace"];
+    if (TASK_REQUIRED.has(id)) prerequisites.push("task");
+    if (DECISION_REQUIRED.has(id)) prerequisites.push("decision");
+    if (EXECUTION_REQUIRED.has(id)) prerequisites.push("execution");
+    if (["task.closeout", "task.complete", "task.review-execution"].includes(id)) prerequisites.push("submitted-execution", "human-consent");
+    if (id.startsWith("session.")) prerequisites.push("isolated-runtime-session");
+    if (id.startsWith("preset.") || id.startsWith("script.")) prerequisites.push("installed-extension");
+    return {
+      id,
+      kind,
+      op: name,
+      category: LIFECYCLE_IDS.has(id) ? "lifecycle" : READ_IDS.has(id) ? "read" : "write",
+      prerequisites: [...new Set(prerequisites)],
+      daemonRequired: DAEMON_REQUIRED.has(id),
+      excludedByDesign: EXCLUDED.get(id) ?? null
+    };
+  })
+);

--- a/tools/coldstart-exhaustive-runtime.mjs
+++ b/tools/coldstart-exhaustive-runtime.mjs
@@ -1,0 +1,466 @@
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
+import { devNull, tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { operationId } from "./coldstart-exhaustive-manifest.mjs";
+
+const protectedDaemonPids = [...new Set([4919, 26328, ...discoverExistingDaemonPids()])];
+const repositoryRoot = realpathSync(path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."));
+const cliEntry = path.join(repositoryRoot, "packages/cli/dist/cli/src/index.js");
+
+export function createFixture() {
+  assertNode24();
+  if (!existsSync(cliEntry)) throw new Error(`CLI dist entry is missing: ${cliEntry}; run npm run build -w @harness-anything/cli`);
+  const base = realpathSync(mkdtempSync(path.join(tmpdir(), "ha-coldstart-exhaustive-")));
+  const root = makePrivateDirectory(path.join(base, "project"));
+  const home = makePrivateDirectory(path.join(base, "home"));
+  const daemonUserRoot = makePrivateDirectory(path.join(base, "daemon-user"));
+  const xdgRuntime = makePrivateDirectory(path.join(base, "xdg-runtime"));
+  const temp = makePrivateDirectory(path.join(base, "tmp"));
+  const discoveryRoot = makePrivateDirectory(path.join(base, "discovery-project"));
+  const discoveryHome = makePrivateDirectory(path.join(base, "discovery-home"));
+  const discoveryDaemonRoot = makePrivateDirectory(path.join(base, "discovery-daemon-user"));
+  assertExternal(root, daemonUserRoot);
+  assertNotProtectedUserRoot(daemonUserRoot);
+  const daemonId = `coldstart-exhaustive-${process.pid}-${randomUUID().slice(0, 8)}`;
+  const baseEnv = isolatedEnvironment({ home, daemonUserRoot, daemonId, xdgRuntime, temp });
+  const discoveryEnv = isolatedEnvironment({
+    home: discoveryHome,
+    daemonUserRoot: discoveryDaemonRoot,
+    daemonId: `${daemonId}-discovery`,
+    xdgRuntime,
+    temp
+  });
+  return {
+    base,
+    root,
+    home,
+    daemonUserRoot,
+    discoveryRoot,
+    discoveryHome,
+    discoveryDaemonRoot,
+    daemonId,
+    baseEnv,
+    discoveryEnv,
+    protectedBefore: daemonFingerprints(),
+    fixturePids: new Set(),
+    endpoint: null
+  };
+}
+
+export function runCli(fixture, args, options = {}) {
+  const root = options.root ?? fixture.root;
+  const env = { ...fixture.baseEnv, ...(options.env ?? {}) };
+  const argv = [cliEntry, "--root", root, "--json", ...args];
+  const startedAt = new Date().toISOString();
+  const result = spawnSync(process.execPath, argv, {
+    cwd: root,
+    encoding: "utf8",
+    env,
+    timeout: options.timeoutMs ?? 120_000,
+    maxBuffer: 32 * 1024 * 1024
+  });
+  const receipt = parseJson(result.stdout);
+  const record = {
+    commandLine: renderCommand(root, args),
+    argv: args,
+    startedAt,
+    exitCode: result.status,
+    signal: result.signal,
+    receiptOk: receipt?.ok === true,
+    receiptSchema: typeof receipt?.schema === "string" ? receipt.schema : null,
+    errorCode: nestedError(receipt)?.code ?? (result.error?.code ? String(result.error.code) : null),
+    errorHint: nestedError(receipt)?.hint ?? result.error?.message ?? null,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    receipt
+  };
+  observeDaemonIdentity(fixture, record);
+  return record;
+}
+
+export function discoverCapabilities(fixture) {
+  const run = (args) => runCli(fixture, args, {
+    root: fixture.discoveryRoot,
+    env: fixture.discoveryEnv
+  });
+  const indexAttempt = run(["capabilities"]);
+  const index = indexAttempt.receipt;
+  if (!indexAttempt.receiptOk || !Array.isArray(index?.items)) {
+    throw new Error(`capability index failed: ${indexAttempt.stdout}${indexAttempt.stderr}`);
+  }
+  const kinds = [];
+  const advertisedFailures = [];
+  for (const item of index.items) {
+    const advertised = run([item.kind, "capabilities"]);
+    let selected = advertised;
+    let spelling = "advertised";
+    if (!validCapabilityReceipt(advertised, item.ops)) {
+      const failure = withoutReceipt(advertised);
+      if (advertised.exitCode === 0 && advertised.receiptOk) {
+        failure.errorCode = "capability_dispatch_mismatch";
+        failure.errorHint = `Advertised '${item.kind} capabilities' dispatched to '${String(advertised.receipt?.command ?? "unknown")}' instead of returning the ${item.kind} capability list.`;
+      }
+      advertisedFailures.push({
+        kind: item.kind,
+        declaredOps: item.ops,
+        failureClass: "A",
+        failureSymptom: "The advertised per-kind capability command did not return that kind's capability receipt; discovery had to use the root --kind fallback.",
+        ...failure
+      });
+      selected = run(["capabilities", "--kind", item.kind]);
+      spelling = "fallback--kind";
+    }
+    if (!validCapabilityReceipt(selected, item.ops)) {
+      throw new Error(`capability discovery failed for ${item.kind}: ${selected.stdout}${selected.stderr}`);
+    }
+    kinds.push({ kind: item.kind, declaredOps: item.ops, spelling, items: selected.receipt.items });
+  }
+  const operations = kinds.flatMap(({ kind, items }) => items.map((item) => ({
+    id: operationId(kind, item.name),
+    kind,
+    op: item.name,
+    capability: item
+  })));
+  safeRemoveWithinBase(fixture, fixture.discoveryRoot);
+  safeRemoveWithinBase(fixture, fixture.discoveryHome);
+  safeRemoveWithinBase(fixture, fixture.discoveryDaemonRoot);
+  return {
+    index: index.items,
+    kindCount: kinds.length,
+    opCount: operations.length,
+    kinds,
+    operations,
+    advertisedFailures
+  };
+}
+
+export function writeJson(filePath, value) {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+export function writeText(filePath, body) {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, body, "utf8");
+}
+
+export function receiptValue(recordOrReceipt, ...keys) {
+  const receipt = recordOrReceipt?.receipt ?? recordOrReceipt;
+  const wanted = new Set(keys);
+  const queue = [receipt];
+  const seen = new Set();
+  while (queue.length > 0) {
+    const value = queue.shift();
+    if (!value || typeof value !== "object" || seen.has(value)) continue;
+    seen.add(value);
+    for (const [key, child] of Object.entries(value)) {
+      if (wanted.has(key) && (typeof child === "string" || typeof child === "number")) return child;
+      if (child && typeof child === "object") queue.push(child);
+    }
+  }
+  return undefined;
+}
+
+export function git(fixture, ...args) {
+  const result = spawnSync("git", ["-C", fixture.root, ...args], {
+    encoding: "utf8",
+    env: fixture.baseEnv,
+    timeout: 30_000
+  });
+  if (result.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${result.stdout}${result.stderr}`);
+  return result.stdout.trim();
+}
+
+export async function cleanupFixture(fixture) {
+  const cleanup = {
+    stopAttempts: [],
+    fixturePids: [...fixture.fixturePids],
+    endpoint: fixture.endpoint,
+    socketResidue: [],
+    baseRemoved: false,
+    protectedBefore: fixture.protectedBefore,
+    protectedAfter: null,
+    protectedUnchanged: false,
+    errors: []
+  };
+  const status = runCli(fixture, ["daemon", "status", "--user-root", fixture.daemonUserRoot], { timeoutMs: 20_000 });
+  const livePid = daemonPid(status.receipt);
+  if (livePid !== undefined) rememberFixturePid(fixture, livePid);
+  const reachable = status.receipt?.reachable === true || status.receipt?.started === true;
+  if (reachable && livePid !== undefined && !protectedDaemonPids.includes(livePid)) {
+    const stopped = runCli(fixture, ["daemon", "stop", "--timeout-ms", "10000", "--user-root", fixture.daemonUserRoot], { timeoutMs: 20_000 });
+    cleanup.stopAttempts.push(withoutReceipt(stopped));
+  } else if (reachable) {
+    cleanup.errors.push(`Refused cleanup stop for unresolved/protected daemon pid: ${String(livePid)}`);
+  }
+  await pollUntil(() => [...fixture.fixturePids].every((pid) => !processAlive(pid)), 10_000);
+  const liveFixturePids = [...fixture.fixturePids].filter(processAlive);
+  if (liveFixturePids.length > 0) cleanup.errors.push(`Fixture daemon still alive: ${liveFixturePids.join(",")}`);
+  cleanup.socketResidue = socketResidue(fixture.endpoint);
+  if (cleanup.socketResidue.length > 0 && liveFixturePids.length === 0) {
+    for (const entry of cleanup.socketResidue) rmSync(entry, { recursive: true, force: true });
+    cleanup.errors.push(`Canonical stop left socket residue; removed exact fixture entries: ${cleanup.socketResidue.join(", ")}`);
+  }
+  if (liveFixturePids.length === 0) {
+    safeRemoveBase(fixture.base);
+    cleanup.baseRemoved = !existsSync(fixture.base);
+  }
+  cleanup.protectedAfter = daemonFingerprints();
+  cleanup.protectedUnchanged = JSON.stringify(cleanup.protectedAfter) === JSON.stringify(cleanup.protectedBefore);
+  if (!cleanup.protectedUnchanged) cleanup.errors.push("Protected daemon fingerprints changed during the exercise.");
+  if (!cleanup.baseRemoved) cleanup.errors.push(`Fixture base was not removed: ${fixture.base}`);
+  return cleanup;
+}
+
+export function renderMarkdownReport(report) {
+  const lines = [
+    "# Cold-start exhaustive CLI exercise",
+    "",
+    `Generated: ${report.generatedAt}`,
+    "",
+    "## Coverage",
+    "",
+    "| total | passed | failed | excluded-by-design |",
+    "| ---: | ---: | ---: | ---: |",
+    `| ${report.coverage.total} | ${report.coverage.passed} | ${report.coverage.failed} | ${report.coverage.excludedByDesign} |`,
+    "",
+    `Repeat signature: \`${report.signature}\``,
+    "",
+    "## Capability discovery anomalies",
+    ""
+  ];
+  if (report.discovery.advertisedFailures.length === 0) lines.push("None.", "");
+  for (const failure of report.discovery.advertisedFailures) {
+    lines.push(`- \`${failure.kind}.capabilities\` [${failure.failureClass}]: exit ${failure.exitCode}; ${failure.errorCode ?? "invalid capability receipt"} — ${failure.errorHint ?? "advertised spelling did not return entity capabilities"}`);
+  }
+  lines.push("", "## Failed operations", "");
+  const failed = report.results.filter((result) => result.status === "failed");
+  if (failed.length === 0) lines.push("None.", "");
+  for (const result of failed) {
+    lines.push(
+      `### ${result.id}`,
+      "",
+      `- Command: \`${result.commandLine}\``,
+      `- Exit: ${String(result.exitCode)}; receipt ok: ${String(result.receiptOk)}`,
+      `- Classification: ${result.failureClass ?? "untriaged"} — ${result.failureSymptom ?? "not triaged"}`,
+      `- Error: \`${result.errorCode ?? "none"}\` — ${result.errorHint ?? "no structured hint"}`,
+      "",
+      "```text",
+      `${result.stdout}${result.stderr}`.trimEnd(),
+      "```",
+      ""
+    );
+  }
+  lines.push("## Excluded by design", "");
+  for (const result of report.results.filter((item) => item.status === "excluded-by-design")) {
+    lines.push(`- \`${result.id}\`: ${result.reason}`);
+  }
+  lines.push("", "## Cleanup", "", `- Base removed: ${String(report.cleanup.baseRemoved)}`, `- Protected daemons unchanged: ${String(report.cleanup.protectedUnchanged)}`);
+  for (const error of report.cleanup.errors) lines.push(`- ERROR: ${error}`);
+  lines.push("");
+  return lines.join("\n");
+}
+
+function isolatedEnvironment({ home, daemonUserRoot, daemonId, xdgRuntime, temp }) {
+  return {
+    ...process.env,
+    PATH: `${path.dirname(process.execPath)}:${process.env.PATH ?? ""}`,
+    HOME: home,
+    USERPROFILE: home,
+    HARNESS_USER_HOME: home,
+    XDG_RUNTIME_DIR: xdgRuntime,
+    TMPDIR: temp,
+    GIT_CONFIG_GLOBAL: devNull,
+    GIT_CONFIG_SYSTEM: devNull,
+    HARNESS_ACTOR: "agent:codex",
+    HARNESS_GIT_AUTHOR_NAME: "Coldstart Exhaustive",
+    HARNESS_GIT_AUTHOR_EMAIL: "coldstart-exhaustive@example.invalid",
+    GIT_AUTHOR_NAME: "Coldstart Exhaustive",
+    GIT_AUTHOR_EMAIL: "coldstart-exhaustive@example.invalid",
+    GIT_COMMITTER_NAME: "Coldstart Exhaustive",
+    GIT_COMMITTER_EMAIL: "coldstart-exhaustive@example.invalid",
+    HARNESS_DAEMON_MODE: "local",
+    HARNESS_DAEMON_PROFILE: "isolated",
+    HARNESS_DAEMON_USER_ROOT: daemonUserRoot,
+    HARNESS_DAEMON_ID: daemonId,
+    HARNESS_BOOTSTRAP_AUTHORITY: "1",
+    HARNESS_AUTHORITY_MANIFEST: "",
+    HARNESS_AUTHORED_ROOT: "",
+    HARNESS_DAEMON_REPO_ID: "",
+    HARNESS_DIRECT_WRITE_REASON: "",
+    HARNESS_CLI_TEST_FIXTURE_PRELOAD: "",
+    HARNESS_DAEMON_IDLE_MS: "0",
+    HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "20000",
+    HARNESS_DAEMON_MATERIALIZER_POLL_MS: "3600000",
+    NODE_OPTIONS: "",
+    CODEX_THREAD_ID: "coldstart-exhaustive-default",
+    CODEX_SESSION_ID: "coldstart-exhaustive-default"
+  };
+}
+
+function validCapabilityReceipt(record, declaredOps) {
+  return record.exitCode === 0
+    && record.receiptOk
+    && record.receipt?.schema === "command-receipt/v2"
+    && record.receipt?.rows === declaredOps
+    && Array.isArray(record.receipt?.items)
+    && record.receipt.items.length === declaredOps;
+}
+
+function observeDaemonIdentity(fixture, record) {
+  const pid = daemonPid(record.receipt);
+  if (pid !== undefined && /daemon-(?:start|status|restart|refresh|stop)/u.test(String(record.receipt?.command ?? ""))) {
+    rememberFixturePid(fixture, pid);
+  }
+  const endpoint = receiptValue(record, "endpoint", "socketPath");
+  if (typeof endpoint === "string" && endpoint.includes("harness-anything")) fixture.endpoint = endpoint;
+}
+
+function rememberFixturePid(fixture, pid) {
+  if (protectedDaemonPids.includes(pid)) throw new Error(`Refusing to treat protected production PID ${pid} as fixture daemon`);
+  fixture.fixturePids.add(pid);
+}
+
+function daemonPid(receipt) {
+  if (typeof receipt?.pid === "number" && Number.isSafeInteger(receipt.pid) && receipt.pid > 0) return receipt.pid;
+  if (typeof receipt?.daemonId === "string") {
+    const match = /^ha-(\d+)$/u.exec(receipt.daemonId);
+    if (match) return Number.parseInt(match[1], 10);
+  }
+  return undefined;
+}
+
+function nestedError(receipt) {
+  if (receipt?.error && typeof receipt.error === "object") return receipt.error;
+  if (receipt?.details?.data?.error && typeof receipt.details.data.error === "object") return receipt.details.data.error;
+  return undefined;
+}
+
+function parseJson(stdout) {
+  const text = stdout.trim();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function renderCommand(root, args) {
+  return ["ha", "--root", root, "--json", ...args].map(shellQuote).join(" ");
+}
+
+function shellQuote(value) {
+  const text = String(value);
+  return /^[A-Za-z0-9_./:@=-]+$/u.test(text) ? text : `'${text.replaceAll("'", `'"'"'`)}'`;
+}
+
+function withoutReceipt(record) {
+  const { receipt: _receipt, ...rest } = record;
+  return rest;
+}
+
+function makePrivateDirectory(directory) {
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  chmodSync(directory, 0o700);
+  if (lstatSync(directory).isSymbolicLink()) throw new Error(`Fixture directory must not be a symlink: ${directory}`);
+  return realpathSync(directory);
+}
+
+function assertExternal(root, daemonUserRoot) {
+  if (root === daemonUserRoot || root.startsWith(`${daemonUserRoot}${path.sep}`) || daemonUserRoot.startsWith(`${root}${path.sep}`)) {
+    throw new Error(`Daemon user root must be external to repository: ${root} <> ${daemonUserRoot}`);
+  }
+}
+
+function assertNotProtectedUserRoot(candidate) {
+  const hostHome = process.env.HOME ? realpathIfExists(process.env.HOME) : null;
+  for (const name of [".harness", ".harness-production"]) {
+    if (!hostHome) continue;
+    const protectedRoot = path.join(hostHome, name);
+    if (candidate === protectedRoot || candidate.startsWith(`${protectedRoot}${path.sep}`) || protectedRoot.startsWith(`${candidate}${path.sep}`)) {
+      throw new Error(`Fixture daemon user root overlaps protected root: ${protectedRoot}`);
+    }
+  }
+}
+
+function safeRemoveWithinBase(fixture, target) {
+  if (!target.startsWith(`${fixture.base}${path.sep}`)) throw new Error(`Unsafe fixture cleanup target: ${target}`);
+  rmSync(target, { recursive: true, force: true });
+}
+
+function safeRemoveBase(base) {
+  const resolvedTmp = realpathSync(tmpdir());
+  if (!base.startsWith(`${resolvedTmp}${path.sep}ha-coldstart-exhaustive-`)) throw new Error(`Unsafe fixture base cleanup target: ${base}`);
+  rmSync(base, { recursive: true, force: true });
+}
+
+function daemonFingerprints() {
+  return Object.fromEntries(protectedDaemonPids.map((pid) => {
+    const result = spawnSync("ps", ["-p", String(pid), "-o", "pid=", "-o", "lstart=", "-o", "command="], { encoding: "utf8" });
+    return [pid, result.stdout.trim()];
+  }));
+}
+
+function discoverExistingDaemonPids() {
+  const result = spawnSync("ps", ["-axo", "pid=,command="], { encoding: "utf8" });
+  return result.stdout.split("\n").flatMap((line) => {
+    if (!/packages\/cli\/dist\/cli\/src\/index\.js .* daemon serve(?: |$)/u.test(line)) return [];
+    const match = /^\s*(\d+)\s/u.exec(line);
+    return match ? [Number.parseInt(match[1], 10)] : [];
+  });
+}
+
+function socketResidue(endpoint) {
+  if (!endpoint || !path.isAbsolute(endpoint)) return [];
+  const parent = path.dirname(endpoint);
+  if (!existsSync(parent)) return [];
+  const base = path.basename(endpoint);
+  return readdirSync(parent)
+    .filter((entry) => entry === base || entry.startsWith(`${base}.`))
+    .map((entry) => path.join(parent, entry));
+}
+
+function processAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function pollUntil(predicate, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return predicate();
+}
+
+function realpathIfExists(candidate) {
+  try {
+    return realpathSync(candidate);
+  } catch {
+    return path.resolve(candidate);
+  }
+}
+
+function assertNode24() {
+  const major = Number.parseInt(process.versions.node.split(".")[0], 10);
+  if (major !== 24) throw new Error(`Node 24 is required; received ${process.version}. Prepend /opt/homebrew/opt/node@24/bin to PATH.`);
+}


### PR DESCRIPTION
# English

## Summary

Fixes the two A-class defects the exhaustive cold-start CLI exercise found. Both reproduce on the live production governance daemon, not only in the cold-start fixture.

`ha authority cutover status` answered `EngineNotEnabled` even on a daemon started with `--authority-manifest`, because a production daemon keeps no authority engine of its own — the engine lives in the repo-write child, and cutover commands were never routed there. `ha task supersede` was rejected with `TOKEN_PATH_SCOPE_DENIED` because the replacement task's create mutation declared no storage context, so the registry located the package directory itself and that bare prefix path fell outside every minted portable-path scope.

## What Changed

- Route authority cutover actions to the repo-write child, register their IPC wire schemas, and wire the child's `cutoverControl`. The CLI no longer redeclares these action kinds inline; they derive from the application wire authority.
- Declare every replacement document on `task supersede` via `storageContext` plus `additionalStorageContexts`, so the storage plan's touched paths stay inside the token's resource scopes.
- Split the task disposition compilers and their shared compilation primitives into their own modules, and split managed prose region tests out of the compiler suite, keeping both within the complexity budget.

## Task And Scope

- Harness task: `task_01KZG7GN35X6TW4EEPH27XFMR5` (cutover routing), `task_01KZG7FWTKXMPH3SS8SZRESYR2` (supersede scope)
- Branch: `codex/coldstart-exhaustive`
- Public scope: `packages/application`, `packages/daemon`, `packages/cli/src/cli/types.ts`
- Private planning/evidence updated: yes
- Out of scope: `authority.repo-enroll` / `authority.repo-resign` share the same admin-class routing gap by inspection, but no measurement shows them failing, so they are not touched here.

## Version Impact

- Version: no version change because this is a defect fix within the existing command surface.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable — defect repair under the standing fix-on-discovery authorization; no ADR or decision semantics change.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `6434f410a8e0920bc53b72aca943a7230c642303`
- Branch merge-base with `origin/main`: `6434f410a8e0920bc53b72aca943a7230c642303`
- Last `git fetch origin` time: 2026-08-08, immediately before the rebase in this branch.
- Sync method: rebase
- Public diff command: `git diff 6434f410a8e0920bc53b72aca943a7230c642303...2d3feb1ce93598886f60d21987916943089af0af`
- Private evidence commit/path: `harness/tasks/task_01KZG7GN35X6TW4EEPH27XFMR5-.../artifacts/a1-修复报告.md`, `harness/tasks/task_01KZG7FWTKXMPH3SS8SZRESYR2-.../artifacts/a2-修复报告.md`
- Reviewer evidence path: same two artifacts
- GitHub Actions `rewrite-ci` run URL: pending on this push
- [x] `git diff --check`
- [x] `npm run check:local` — 28 manifest gates green (this repository's documented local stop point; `check:stop-point` is not the current command name)
- [x] Targeted tests for the change surface, named with their counts:
  - `packages/application/test/task-decision-module-semantic-compiler-v2.test.ts` + `task-decision-module-managed-prose-regions-v2.test.ts`: 13 pass, 0 fail
  - `packages/daemon/test/repo-write-command-action-negative.test.ts`: 78 pass, 0 fail
  - `packages/daemon/test/repo-write-real-producer-acceptance.test.ts`: 1 pass, 0 fail
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate) — pending
- Not run, and why: integration and nightly tiers are not part of the local stop point; they run in CI. No live rehearsal of `drain`/`scan`/`confirm`/`boundary`/`freeze`/`re-enable` was performed, because that needs a real V1-to-V2 migration campaign; only the `status` read path has live proof.

**Live proof, same production daemon, before and after:**

Before: `{"ok":false,"error":{"code":"EngineNotEnabled",...}}`
After: `{"ok":true,...,"report":{"admission":"open","boundary":{"boundaryId":"w6-boundary-2026-07-17","status":"BOUNDARY_ACTIVE"...}}}` — real historical cutover state, not an empty shell.

`ha task supersede` on a disposable task returned `ok: true` with the replacement package created.

**Negative control:** reverting the supersede fix to its single original line turns the new regression test red with `uncovered touched paths: tasks/task_NEW`.

## Review Evidence

- Self-review: traced each defect from throw site to the wiring that produces it before changing anything; the initial reading of the cutover defect as a false positive was wrong and was corrected by measuring on the live daemon.
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none

## Residual Risk

- `task create` with a multi-document scaffold still declares only `INDEX.md` in its storage plan. This under-declares rather than over-declares, so it cannot be rejected, but the plan's consistency scope is narrower than the real write surface.
- The deeper shape problem is unchanged: `storagePlan.touchedPaths` and the token's portable-path scopes are computed by two independent code paths with no mechanical link. The new test pins one instance; it does not make the family impossible.
- `authority.repo-enroll` / `authority.repo-resign` remain unrouted, as stated above.

## References

- Task: `task_01KZG7GN35X6TW4EEPH27XFMR5`, `task_01KZG7FWTKXMPH3SS8SZRESYR2`
- Evidence: the two artifact reports named under Verification
- Review: pending

---

# 中文

## 概要

修复冷启动穷尽 CLI 演练发现的两个 A 类缺陷。两个都能在**真实生产治理 daemon** 上复现，不只存在于冷启动 fixture 里。

`ha authority cutover status` 即便在带 `--authority-manifest` 启动的 daemon 上也返回 `EngineNotEnabled`：生产 daemon 的父进程本就不持有 authority 引擎，引擎住在 repo-write 子进程，而 cutover 命令从未被路由过去。`ha task supersede` 被 `TOKEN_PATH_SCOPE_DENIED` 拒绝：替代任务的 create 变更没声明 storage context，registry 因此定位到包目录本身，那个裸前缀路径不在任何铸出的 portable-path scope 内。

## 改动内容

- 把 authority cutover 动作路由到 repo-write 子进程，登记其 IPC wire schema，并接上子进程的 `cutoverControl`。CLI 不再内联重复声明这些 action kind，改由 application 侧 wire 权威派生。
- `task supersede` 如实申报每一个替代文档（`storageContext` + `additionalStorageContexts`），让 storage plan 的 touched paths 落在 token 的 resource scope 内。
- 按职责拆分 task disposition 编译器与其共享编译原语，并把 managed prose region 测试从编译器套件中拆出，使两者回到复杂度预算内。

## 任务与范围

- Harness 任务：`task_01KZG7GN35X6TW4EEPH27XFMR5`（cutover 路由）、`task_01KZG7FWTKXMPH3SS8SZRESYR2`（supersede 作用域）
- 分支：`codex/coldstart-exhaustive`
- 公开范围：`packages/application`、`packages/daemon`、`packages/cli/src/cli/types.ts`
- 私有计划/证据已更新：是
- 不在范围内：`authority.repo-enroll` / `authority.repo-resign` 从机制上看同属这条死路，但没有任何实测说明它们坏了，因此本 PR 不动它们。

## 版本影响

- 版本：不变，因为这是既有命令面内的缺陷修复。
- 发布影响：不发布

## 治理声明

- 触碰 protected surface：否
- Protected surface 范围：不适用
- 授权依据：不适用——在「发现即修」常设授权下的缺陷修复，未改动任何 ADR 或 decision 语义。
- 机器检查边界：本 PR 只断言声明存在；是否属实、是否充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`6434f410a8e0920bc53b72aca943a7230c642303`
- 与 `origin/main` 的 merge-base：`6434f410a8e0920bc53b72aca943a7230c642303`
- 最近 `git fetch origin` 时间：2026-08-08，本分支 rebase 前刚执行。
- 同步方式：rebase
- 公开 diff 命令：`git diff 6434f410a8e0920bc53b72aca943a7230c642303...2d3feb1ce93598886f60d21987916943089af0af`
- 私有证据路径：`harness/tasks/task_01KZG7GN35X6TW4EEPH27XFMR5-.../artifacts/a1-修复报告.md`、`harness/tasks/task_01KZG7FWTKXMPH3SS8SZRESYR2-.../artifacts/a2-修复报告.md`
- 评审证据路径：同上两份
- GitHub Actions `rewrite-ci` run URL：本次推送后待生成
- [x] `git diff --check`
- [x] `npm run check:local`——28 门全绿（本仓文档化的本地停止点；`check:stop-point` 不是当前命令名）
- [x] 针对改动面的定向测试及其计数：
  - `task-decision-module-semantic-compiler-v2.test.ts` + `task-decision-module-managed-prose-regions-v2.test.ts`：13 通过 0 失败
  - `repo-write-command-action-negative.test.ts`：78 通过 0 失败
  - `repo-write-real-producer-acceptance.test.ts`：1 通过 0 失败
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）——待跑
- 未跑的部分及原因：integration 与 nightly tier 不属于本地停止点，由 CI 跑。未做 `drain`/`scan`/`confirm`/`boundary`/`freeze`/`re-enable` 的活体演练，因为那需要一次真实的 V1→V2 迁移活动；只有 `status` 这条读路有活体证据。

**活体前后对照（同一台生产 daemon）：**

修复前：`{"ok":false,"error":{"code":"EngineNotEnabled",...}}`
修复后：`{"ok":true,...,"report":{"boundary":{"boundaryId":"w6-boundary-2026-07-17","status":"BOUNDARY_ACTIVE"...}}}`——返回的是真实历史 cutover 状态，不是空壳结构。

一次性任务上 `ha task supersede` 返回 `ok: true`，替代任务包已生成。

**阴性对照：** 把 supersede 修复回退成原来那一行，新增回归测试立刻变红并报出 `uncovered touched paths: tasks/task_NEW`。

## 评审证据

- 自评审：动手前把两个缺陷各自从 throw 点追到产生它的接线；我最初把 cutover 判为误报是错的，靠在生产 daemon 上实测纠正。
- 评审子代理：无
- 人工评审：待进行
- 阻塞性发现：无

## 残余风险

- `task create` 走多文档 scaffold 时，storage plan 仍只申报 `INDEX.md`。这是申报不足而非过度，不会被拒，但 plan 的一致性作用域比真实写入面窄。
- 更深的形状问题未变：`storagePlan.touchedPaths` 与 token 的 portable-path scope 由两条互不相干的代码路径算出，中间无机械联系。新测试只钉住一个实例，没有让这一族在编译期不可能。
- `authority.repo-enroll` / `authority.repo-resign` 仍未路由，理由见上。

## 参考

- 任务：`task_01KZG7GN35X6TW4EEPH27XFMR5`、`task_01KZG7FWTKXMPH3SS8SZRESYR2`
- 证据：验证节中列出的两份 artifact 报告
- 评审：待进行
