### PR TITLE
fix(kernel): charge daemon admission the real bytes of binary payloads

### DIFF
--- a/packages/application/src/provenance-binding.ts
+++ b/packages/application/src/provenance-binding.ts
@@ -24,10 +24,25 @@ export function bindCreateProvenance(
         Effect.as(provenance),
         // Optional transcript capture must not make unrelated writes depend on runtime-log availability.
         // Execution submission applies the stricter confirmed-unavailable rule at its finalization boundary.
-        Effect.catchAll((error) => error.code === "transcript_unavailable" || error.code === "read_failed"
+        Effect.catchAll((error) => transcriptCaptureIsOptionallyUnavailable(error)
           ? Effect.succeed(provenance)
           : Effect.fail(error))
       );
     })
   );
+}
+
+/**
+ * A transcript this daemon will not admit is unavailable in the same sense a
+ * missing runtime log is: the capture cannot happen here, and the unrelated
+ * write it was riding along with has no stake in it. Session transcripts grow
+ * without bound while the business write stays small, so an oversized capture
+ * must not be able to fail `task create`. Every other write rejection — fence
+ * loss, conflict, journal failure — still propagates.
+ */
+function transcriptCaptureIsOptionallyUnavailable(error: ProvenanceSessionExporterRejected): boolean {
+  if (error.code === "transcript_unavailable" || error.code === "read_failed") return true;
+  return error.code === "write_failed"
+    && error.writeError?._tag === "WriteRejected"
+    && error.writeError.code === "admission_payload_exceeds_limit";
 }

--- a/packages/application/test/provenance-binding-service.test.ts
+++ b/packages/application/test/provenance-binding-service.test.ts
@@ -160,6 +160,36 @@ test("decision and fact provenance binding preserve the underlying structured wr
   }
 });
 
+test("provenance binding keeps the session pointer when the transcript exceeds the admission limit", async () => {
+  const currentSessionProbe = makeHumanFallbackSessionProbe({
+    now: () => "2026-07-03T00:00:00.000Z"
+  });
+  const oversized = {
+    _tag: "ProvenanceSessionExporterRejected",
+    sessionId: "human-cli-1783036800000",
+    code: "write_failed",
+    reason: "Shared daemon admission payload exceeds the per-request limit",
+    writeError: {
+      _tag: "WriteRejected",
+      code: "admission_payload_exceeds_limit",
+      reason: "Shared daemon admission payload exceeds the per-request limit",
+      retryable: false
+    }
+  } as const satisfies ProvenanceSessionExporterRejected;
+
+  const provenance = await runEffect(bindCreateProvenance({
+    currentSessionProbe,
+    provenanceSessionExporter: failingExporter(oversized)
+  }, "2026-07-03T00:01:00.000Z"));
+
+  // An optional capture too large for this daemon must not fail the write it rode along with.
+  assert.deepEqual(provenance, {
+    runtime: "human",
+    sessionId: "human-cli-1783036800000",
+    boundAt: "2026-07-03T00:01:00.000Z"
+  });
+});
+
 test("automatic provenance binding keeps the session pointer when transcript availability is indeterminate", async () => {
   const rootDir = createHarnessRoot();
   try {

--- a/packages/kernel/src/daemon/admission-budget.ts
+++ b/packages/kernel/src/daemon/admission-budget.ts
@@ -119,13 +119,64 @@ function payloadExceedsLimitError(operations: number, operationLimit: number, by
   return {
     _tag: "WriteRejected",
     code: "admission_payload_exceeds_limit",
-    reason: `Shared daemon admission payload exceeds the per-request limit (operations: requested ${operations}, limit ${operationLimit}; bytes: requested ${bytes}, limit ${byteLimit}). Split the batch or reduce the payload, then submit each smaller request.`,
+    reason: `Shared daemon admission payload exceeds the per-request limit (operations: requested ${operations}, limit ${operationLimit}; bytes: requested ${bytes}, limit ${byteLimit}). Split the batch or reduce the payload, then submit each smaller request. A single payload that cannot be split needs a larger 'settings.daemon.admission.maxBytes'.`,
     retryable: false
   };
 }
 
+const jsonNullBytes = 4;
+
+/**
+ * Charges a request the bytes it actually occupies.
+ *
+ * Binary payloads are charged their real `byteLength`. Measuring them with
+ * `JSON.stringify` inflates the charge several fold — a `Buffer` renders as
+ * `{"type":"Buffer","data":[12,34,...]}` (~3.6x) and a bare `Uint8Array` as
+ * `{"0":12,"1":34,...}` (~11.5x) — which both reserves capacity that is not
+ * needed and makes the `admission_payload_exceeds_limit` message untrue about
+ * how large the request was. Everything else is charged its exact JSON
+ * encoding, so non-binary payloads keep the meaning they already had.
+ */
 export function daemonAdmissionBytes(value: unknown): number {
-  return Buffer.byteLength(JSON.stringify(value) ?? "null", "utf8");
+  return admissionValueBytes(value) ?? jsonNullBytes;
+}
+
+function admissionValueBytes(value: unknown): number | undefined {
+  // Only objects can be binary, so primitives take the cheap path first.
+  if (value === null || typeof value !== "object") return admissionJsonBytes(value);
+  const binary = admissionBinaryBytes(value);
+  if (binary !== undefined) return binary;
+  // `toJSON` owners (Date, and anything else that renders itself) are charged
+  // the encoding they actually produce rather than their internal slots.
+  if (typeof (value as { readonly toJSON?: unknown }).toJSON === "function") return admissionJsonBytes(value);
+  if (Array.isArray(value)) {
+    let total = 2;
+    for (let index = 0; index < value.length; index += 1) {
+      if (index > 0) total += 1;
+      total += admissionValueBytes(value[index]) ?? jsonNullBytes;
+    }
+    return total;
+  }
+  let total = 2;
+  let separators = -1;
+  for (const [key, entry] of Object.entries(value)) {
+    const measured = admissionValueBytes(entry);
+    if (measured === undefined) continue;
+    separators += 1;
+    total += Buffer.byteLength(JSON.stringify(key), "utf8") + 1 + measured;
+  }
+  return total + Math.max(0, separators);
+}
+
+function admissionBinaryBytes(value: object): number | undefined {
+  if (ArrayBuffer.isView(value)) return value.byteLength;
+  if (value instanceof ArrayBuffer) return value.byteLength;
+  return undefined;
+}
+
+function admissionJsonBytes(value: unknown): number | undefined {
+  const json = JSON.stringify(value);
+  return json === undefined ? undefined : Buffer.byteLength(json, "utf8");
 }
 
 function assertLimits(limits: DaemonAdmissionBudgetLimits): void {

--- a/packages/kernel/test/daemon/admission-budget.test.ts
+++ b/packages/kernel/test/daemon/admission-budget.test.ts
@@ -80,7 +80,7 @@ test("admission distinguishes temporary capacity pressure from a payload that ca
       error: {
         _tag: "WriteRejected",
         code: "admission_payload_exceeds_limit",
-        reason: "Shared daemon admission payload exceeds the per-request limit (operations: requested 4, limit 3; bytes: requested 301, limit 300). Split the batch or reduce the payload, then submit each smaller request.",
+        reason: "Shared daemon admission payload exceeds the per-request limit (operations: requested 4, limit 3; bytes: requested 301, limit 300). Split the batch or reduce the payload, then submit each smaller request. A single payload that cannot be split needs a larger 'settings.daemon.admission.maxBytes'.",
         retryable: false
       }
     };

--- a/packages/kernel/test/daemon/admission-bytes.test.ts
+++ b/packages/kernel/test/daemon/admission-bytes.test.ts
@@ -1,0 +1,111 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createDaemonAdmissionBudget, daemonAdmissionBytes } from "../../src/daemon/admission-budget.ts";
+
+const sessionSizedBytes = 273_127;
+
+function noise(byteLength: number): Buffer {
+  const bytes = Buffer.alloc(byteLength);
+  for (let index = 0; index < byteLength; index += 1) bytes[index] = (index * 31 + 7) % 256;
+  return bytes;
+}
+
+test("admission charges a binary payload its real byteLength", () => {
+  const bytes = noise(sessionSizedBytes);
+  const shapes: ReadonlyArray<readonly [string, ArrayBufferView | ArrayBuffer, number]> = [
+    ["Buffer", bytes, bytes.byteLength],
+    ["Uint8Array", new Uint8Array(bytes), bytes.byteLength],
+    ["DataView", new DataView(bytes.buffer, bytes.byteOffset, 64), 64],
+    ["subview", new Uint8Array(bytes.buffer, bytes.byteOffset + 8, 32), 32],
+    ["ArrayBuffer", bytes.buffer.slice(0, 128), 128]
+  ];
+  for (const [name, value, expected] of shapes) {
+    assert.equal(daemonAdmissionBytes(value), expected, `${name} must be charged its byteLength`);
+  }
+  // The defect this pins down: JSON.stringify renders a Buffer as
+  // {"type":"Buffer","data":[...]} and a Uint8Array as {"0":12,...}, so any
+  // measurement that reaches for JSON.stringify inflates binary several fold.
+  assert.ok(Buffer.byteLength(JSON.stringify(bytes), "utf8") > bytes.byteLength * 3);
+  assert.ok(Buffer.byteLength(JSON.stringify(new Uint8Array(bytes)), "utf8") > bytes.byteLength * 10);
+});
+
+test("admission charges a nested binary field its real byteLength and nothing more", () => {
+  const envelope = noise(sessionSizedBytes);
+  const empty = { requestId: "req_admission", presentationToken: noise(0), envelope: noise(0) };
+  const attempt = { requestId: "req_admission", presentationToken: noise(1_024), envelope };
+
+  const delta = daemonAdmissionBytes(attempt) - daemonAdmissionBytes(empty);
+  assert.equal(delta, 1_024 + envelope.byteLength);
+
+  const truth = Buffer.byteLength(attempt.requestId, "utf8") + 1_024 + envelope.byteLength;
+  const framing = daemonAdmissionBytes(attempt) - truth;
+  assert.ok(framing >= 0 && framing < 128, `structural framing must stay negligible, got ${framing}`);
+});
+
+test("admission keeps exact JSON accounting for payloads with no binary field", () => {
+  const values: ReadonlyArray<unknown> = [
+    null,
+    undefined,
+    0,
+    -12.5,
+    true,
+    "plain",
+    "quote\" backslash\\ newline\n tab\t accent-é han-中 emoji-\u{1f600}",
+    [],
+    {},
+    [1, "two", null, [3, { four: false }]],
+    { b: 1, a: [null, { deep: { deeper: "x" } }], skipped: undefined },
+    { taskId: "task_01", ops: [{ kind: "doc_write", payload: { body: "x".repeat(4_096) } }] }
+  ];
+  for (const value of values) {
+    assert.equal(
+      daemonAdmissionBytes(value),
+      Buffer.byteLength(JSON.stringify(value) ?? "null", "utf8"),
+      `JSON-only payload must keep its exact JSON size: ${String(JSON.stringify(value))}`
+    );
+  }
+});
+
+test("a binary payload that fits the configured limit is admitted", () => {
+  // Half a megabyte of envelope fits the shipped 1MB budget on its real bytes
+  // and does not fit it once rendered as JSON, which is how a session export
+  // well inside the limit was rejected as `admission_payload_exceeds_limit`.
+  const envelope = noise(512 * 1024);
+  const attempt = { requestId: "req_admission", presentationToken: noise(1_024), envelope };
+  const budget = createDaemonAdmissionBudget({
+    maxOperations: 1_024,
+    maxBytes: 1024 * 1024,
+    reservedOperationsPerPlane: 32,
+    reservedBytesPerPlane: 64 * 1024
+  });
+
+  assert.ok(Buffer.byteLength(JSON.stringify(attempt), "utf8") > 1024 * 1024 - 64 * 1024);
+  const bytes = daemonAdmissionBytes(attempt);
+  const admitted = budget.reserve({ plane: "authority", operations: 1, bytes });
+  assert.equal(admitted.ok, true, `a ${envelope.byteLength}-byte envelope must fit the 1MB budget, charged ${bytes}`);
+  if (admitted.ok) admitted.reservation.release();
+});
+
+test("an oversized binary payload is rejected with its real byte count", () => {
+  const envelope = noise(2 * 1024 * 1024);
+  const attempt = { requestId: "req_admission", presentationToken: noise(1_024), envelope };
+  const budget = createDaemonAdmissionBudget({
+    maxOperations: 1_024,
+    maxBytes: 1024 * 1024,
+    reservedOperationsPerPlane: 32,
+    reservedBytesPerPlane: 64 * 1024
+  });
+
+  const bytes = daemonAdmissionBytes(attempt);
+  const rejection = budget.reserve({ plane: "authority", operations: 1, bytes });
+  assert.equal(rejection.ok, false);
+  if (rejection.ok) return;
+  assert.equal(rejection.error._tag === "WriteRejected" ? rejection.error.code : undefined, "admission_payload_exceeds_limit");
+  // The number the operator reads has to be the number of bytes they sent.
+  assert.match(
+    rejection.error._tag === "WriteRejected" ? rejection.error.reason : "",
+    new RegExp(`bytes: requested ${bytes}, limit ${1024 * 1024 - 64 * 1024}`, "u")
+  );
+  assert.ok(bytes < envelope.byteLength + 4_096, `charged ${bytes} for a ${envelope.byteLength}-byte envelope`);
+});


### PR DESCRIPTION
# English

## Summary

Daemon admission was measuring binary payloads with `JSON.stringify`, inflating them 3.56x. A 274 KB session-export submission was charged 976,082 bytes against a 983,040 ceiling — 7 KB from the wall — so `ha task create` failed as soon as an agent session grew slightly longer. The meter is now honest: binary is charged its real `byteLength`, everything else its exact JSON encoding.

This is part of milestone PLT-Honest: the system must not lie about its own state, and the actions it suggests must be safe.

## What Changed

- `daemonAdmissionBytes` charges `ArrayBuffer.isView` / `ArrayBuffer` their `byteLength` at any nesting depth, and everything else its exact JSON size. Fixed in the primitive, so all **four** call sites obey the invariant without having to remember it (the fourth, `write-queue.ts:143`, needed no edit).
- Verified byte-exact against `JSON.stringify` over 20,000 random JSON trees (quotes, backslashes, control chars, accents, CJK, astral emoji, `undefined` holes) — zero mismatches. Non-binary accounting is unchanged by construction.
- The rejection message now names `settings.daemon.admission.maxBytes`, the designed knob. The previous text said "split the batch or reduce the payload", which is not actionable for one indivisible session export.
- Optional transcript capture no longer fails the primary write when it is rejected for size — narrowly, only for `WriteRejected` / `admission_payload_exceeds_limit`. Fence loss, conflicts and journal failures still propagate. The function's own comment already declared this invariant; the implementation had missed this branch.

Measured on the production shape `{requestId 27 B, presentationToken 1,024 B, envelope 273,127 B}`, truth 274,181:

| shape | before | after |
|---|---:|---:|
| production (Buffer fields) | 976,082 (3.56x) | 274,230 (1.0002x) |
| bare Uint8Array fields | 3,329,123 (12.14x) | 274,230 |

Side effect: the authority v2 meter drops from 1,872 µs to 1.0 µs, because it no longer serialises a 273 KB buffer into a 976 KB string in order to count it.

**Deliberately not done:** removing the duplicated `body` from the session-export payload. It looked redundant next to `blobRef`, but it is load-bearing — `ha session export --transcript-file` derives `blobRef` *from* `body` with no CAS object in existence; journal crash recovery reinstalls the CAS from the payload (existing killpoint `session-entity.test.ts:122`); and the CAS object is GC-eligible while the op is in flight, so a `blobRef`-only op could commit a dangling reference. Detailed reasoning in the task package report.

**The limit was not raised, on purpose.** Three sibling per-request ceilings are also 1 MiB (authority transport frame, repo-write IPC frame, repo-write JSON aggregate) and all three measure real bytes. Admission was the only one of the four that lied. Raising it alone would desynchronise admission from transport and move the rejection somewhere harder to diagnose.

## Task And Scope

- Harness task: `task_01KZG81BVTEGM99JGSN3Y6GP20` (under milestone `task_01KZGA4PPBB46DE75FY7NSXS20`, PLT-Honest)
- Branch: `codex/admission-truthful-bytes`
- Public scope: `packages/kernel/src/daemon/admission-budget.ts`, `packages/application/src/provenance-binding.ts`, plus three test files
- Private planning/evidence updated: yes
- Out of scope: removing the payload `body` (refused with evidence, see above); raising `maxBytes`; the writer cold-start path; reconciling the four 1 MiB ceilings

## Version Impact

- Version: no version change because this is a behavioural fix inside existing packages with no published surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KZG81BVTEGM99JGSN3Y6GP20`; milestone `task_01KZGA4PPBB46DE75FY7NSXS20`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `c9a27084`
- Branch merge-base with `origin/main`: `c9a27084`
- Last `git fetch origin` time: 2026-08-08, immediately before the rebase
- Sync method: rebase
- Public diff command: `git diff c9a27084...codex/admission-truthful-bytes`
- Private evidence commit/path: `harness/tasks/task_01KZG81BVTEGM99JGSN3Y6GP20-probe-admission/artifacts/report-opus-admission-fix.md`
- Reviewer evidence path: same report, sections 2 and 5
- GitHub Actions `rewrite-ci` run URL: pending, to be linked once the run appears
- [x] `git diff --check`
- [x] `npm run check:local` — 27 manifest gates green, 30.0s, re-run after the rebase onto `c9a27084`
- [x] Targeted tests for the change surface, named with their counts: `packages/kernel` + `packages/application` + `packages/daemon/test/runtime` integration tier, 499 tests, 0 fail; new `packages/kernel/test/daemon/admission-bytes.test.ts` (tier fast, 5 assertions) plus one application case for the optional-capture tolerance
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: `check:ci` and CI-only gates were not run locally — they are the authoritative set and run on this PR. No live `ha task create` end-to-end, because that needs the production daemon and restarting it was out of bounds during an active incident; evidence is the byte-level reproduction plus the gates.

**Regression gate has proven resolving power.** Deleting the two binary-awareness lines fails 4 of the 5 kernel assertions; the survivor is the non-binary negative control, which is supposed to survive. Stubbing the new provenance predicate to `false` fails exactly the new application test.

## Review Evidence

- Self-review: CEO independently verified the two load-bearing claims of the refusal — that `production-authority-attempt-compiler.ts:528` derives the digest from `body` via `readFileSync`, and that `portablePaths` feeds `canonicalBindingResourceScopes` as an authorisation scope rather than an existence proof. Both hold; the refusal is accepted.
- Reviewer subagent: implementation performed by an Opus worker; two alternative meter designs were rejected by measurement rather than argument
- Human review: pending
- Blocking findings: none

## Residual Risk

1. `settings.daemon.admission.maxBytes` is honoured and tested but absent from the generated `harness.yaml.example`; the rejection message is currently the only place a user learns it exists.
2. A raised `maxBytes` would meet a hard-coded 1 MiB transport frame limit. The four ceilings have never been reconciled; making admission honest is what will surface the mismatch.
3. `daemon-writer-reader-cutover` sits close to its own wall (`writerWallMs 18,512` against a 20,000 ms client timeout) and fails under full-tier contention while passing in isolation. Pre-existing and load-sensitive; this change cannot slow that path, but it is a detector that has gone quiet and deserves its own task.
4. Binary nested inside a `toJSON` result would still be measured the old way. No such shape exists today and the gate would not catch it.

---

# 中文

## 摘要

daemon 准入一直在用 `JSON.stringify` 计量二进制载荷，虚报 3.56 倍。一次 274 KB 的会话导出被算成 976,082 字节，而上限是 983,040 —— **距离墙只有 7 KB**，所以只要 agent 会话稍微长一点，`ha task create` 就会失败。现在计量器诚实了：二进制按真实 `byteLength` 计费，其余按精确 JSON 编码计费。

本 PR 属于里程碑 PLT-Honest：系统不得谎报自身状态，它建议的动作必须安全。

## 变更内容

- `daemonAdmissionBytes` 对任意嵌套层级的 `ArrayBuffer.isView` / `ArrayBuffer` 计其 `byteLength`，其余计其精确 JSON 大小。修在 primitive 层，因此**四个**调用点无需记住这条不变量就自动遵守（第四个 `write-queue.ts:143` 无需改动）。
- 用 20,000 棵随机 JSON 树对拍 `JSON.stringify`（引号、反斜杠、控制字符、重音、CJK、星平面 emoji、`undefined` 空洞），零不匹配。非二进制的计量在构造上保持不变。
- 拒绝消息现在会点名 `settings.daemon.admission.maxBytes` 这个被设计出来的旋钮。原文案说 "split the batch or reduce the payload"，而对一次不可分割的会话导出，这条建议无法执行。
- 可选的 transcript 捕获在因体积被拒时，不再连带搞挂主写 —— 收窄到仅 `WriteRejected` / `admission_payload_exceeds_limit`。fence 丢失、冲突、journal 故障仍然向上传播。该函数自己的注释早已声明了这条不变量，只是实现漏了这个分支。

在生产形状 `{requestId 27 B, presentationToken 1,024 B, envelope 273,127 B}`（真值 274,181）上实测：

| 形状 | 修前 | 修后 |
|---|---:|---:|
| 生产（Buffer 字段） | 976,082（3.56×） | 274,230（1.0002×） |
| 裸 Uint8Array 字段 | 3,329,123（12.14×） | 274,230 |

副作用：authority v2 计量从 1,872 µs 降到 1.0 µs —— 它不再为了数数而把 273 KB 的 buffer 序列化成 976 KB 的字符串。

**刻意没做的事**：去掉 session-export 载荷里那份看似与 `blobRef` 重复的 `body`。它是承重的 —— `ha session export --transcript-file` 是**从 body 派生** `blobRef` 的，此时根本不存在 CAS 对象；journal 崩溃恢复要从载荷重装 CAS（现成 killpoint `session-entity.test.ts:122`）；而且 op 在飞期间该 CAS 对象可被 GC 回收，`blobRef`-only 的 op 可能提交悬空引用。完整论证见任务包报告。

**上限刻意没有抬高。** 另外三个同级 per-request 上限也是 1 MiB（authority 传输帧、repo-write IPC 帧、repo-write JSON 聚合），且三者都量真实字节。准入是四个里唯一撒谎的那个。单独抬它会让准入与传输失同步，把拒绝挪到更难诊断的地方。

## 任务与范围

- Harness task：`task_01KZG81BVTEGM99JGSN3Y6GP20`（隶属里程碑 `task_01KZGA4PPBB46DE75FY7NSXS20`，PLT-Honest）
- 分支：`codex/admission-truthful-bytes`
- 公开范围：`packages/kernel/src/daemon/admission-budget.ts`、`packages/application/src/provenance-binding.ts`，以及三个测试文件
- 私有规划/证据已更新：是
- 不在范围内：删除载荷中的 `body`（已带证据拒绝，见上）；抬高 `maxBytes`；writer 冷启动路径；四个 1 MiB 上限的对账

## 版本影响

- 版本：无版本变更，因为这是既有包内部的行为修复，未改变已发布面
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：`task_01KZG81BVTEGM99JGSN3Y6GP20`；里程碑 `task_01KZGA4PPBB46DE75FY7NSXS20`
- 机器检查边界：本 PR 只断言声明存在；是否属实与充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`c9a27084`
- 分支与 `origin/main` 的 merge-base：`c9a27084`
- 最近一次 `git fetch origin` 时间：2026-08-08，rebase 前刚执行
- 同步方式：rebase
- 公开 diff 命令：`git diff c9a27084...codex/admission-truthful-bytes`
- 私有证据 commit/路径：`harness/tasks/task_01KZG81BVTEGM99JGSN3Y6GP20-probe-admission/artifacts/report-opus-admission-fix.md`
- 评审者证据路径：同一报告的第 2 节与第 5 节
- GitHub Actions `rewrite-ci` run URL：待 run 出现后补链
- [x] `git diff --check`
- [x] `npm run check:local` —— 27 个 manifest gate 全绿，30.0 秒，在 rebase 到 `c9a27084` 之后重跑
- [x] 针对改动面的定向测试及计数：`packages/kernel` + `packages/application` + `packages/daemon/test/runtime` integration tier，499 tests，0 fail；新增 `packages/kernel/test/daemon/admission-bytes.test.ts`（fast tier，5 条断言），外加一条 application 用例覆盖可选捕获容忍
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）
- 未运行项及原因：`check:ci` 与仅 CI 的门未在本地运行 —— 它们是权威集合，会在本 PR 上运行。未做真实 `ha task create` 端到端验证，因为那需要生产 daemon，而在事故处置期间重启它超出边界；证据是字节级复现加上述门。

**回归门具备已验证的分辨力**：删掉那两行二进制感知代码，5 条 kernel 断言里 4 条失败；存活的是非二进制负对照，它本来就应该存活。把新增的 provenance 谓词打桩成 `false`，恰好只让新增那条 application 测试失败。

## 评审证据

- 自审：CEO 独立核验了该拒绝的两条承重论证 —— `production-authority-attempt-compiler.ts:528` 确实通过 `readFileSync` 从 `body` 派生摘要；`portablePaths` 确实是喂给 `canonicalBindingResourceScopes` 的授权范围，而非存在性证明。两条均成立，拒绝被采纳。
- 评审 subagent：实现由 Opus worker 完成；两个替代计量方案是被测量否决的，不是被论证否决的
- 人工评审：待进行
- 阻断性发现：无

## 残留风险

1. `settings.daemon.admission.maxBytes` 被尊重且有测试，但不在生成的 `harness.yaml.example` 中；拒绝消息目前是用户得知它存在的唯一途径。
2. 抬高后的 `maxBytes` 会撞上硬编码的 1 MiB 传输帧上限。四个上限从未被对账过；让准入变诚实，正是会让这个不一致浮出水面的动作。
3. `daemon-writer-reader-cutover` 贴着自己的墙（`writerWallMs 18,512` 对 20,000 ms 客户端超时），在完整 tier 竞争下失败、单独重跑通过。既有问题且负载敏感；本改动不可能拖慢那条路径，但它是一个已经哑掉的探测器，值得单独立任务。
4. 嵌套在 `toJSON` 结果**内部**的二进制仍会按老方式计量。目前不存在这种形状，这道门也抓不住它。
