### PR TITLE
fix(cli): bound repo-write child startup recovery under the parent READY deadline

### DIFF
--- a/packages/cli/src/composition/repo-write-child-entrypoint.ts
+++ b/packages/cli/src/composition/repo-write-child-entrypoint.ts
@@ -6,6 +6,7 @@ import {
   createGitCanonicalPublicationInspector,
   createRepoWriteChildHost,
   decodeRepoWriteChildLaunchConfig,
+  defaultProductionRecoveryAdmissionTimeoutMs,
   DurableRepoWriteOutcomeStoreV1,
   loadAuthorityProductionManifest,
   ProductionRepoWriteOperationHost,
@@ -36,15 +37,19 @@ import { makeDaemonReservationReconciler } from "@harness-anything/daemon";
 /**
  * Everything before READY must fit inside the parent's READY deadline
  * (`readyTimeoutMs`, default 30_000ms), so this caps the child's *total* time to
- * announcement rather than just the recovery loop. Measured on a wedged daemon,
- * the work preceding recovery alone consumed 20.1-29.9s, so a fixed recovery
- * budget cannot keep the total under the deadline — the budget has to be
- * whatever time is still left. Recovery therefore gets the remainder of this cap
- * and nothing more; proceedings it does not reach stay proceeding and are
- * retried on the next start. The margin below the parent default absorbs spawn
- * and IPC latency the child cannot observe.
+ * announcement rather than just the recovery loop. Measured on a real forked
+ * child, everything other than the recovery loop costs ~0.7s, so the loop is the
+ * only part that can grow with data — and it grows invisibly, because iterations
+ * that succeed emit no log. A budget sized from the visible (deferred)
+ * iterations undercounts badly, so recovery instead gets whatever time is left
+ * under this cap and nothing more; proceedings it does not reach stay proceeding
+ * and are retried on the next start.
+ *
+ * Reuses the authority admission deadline rather than restating it: both exist
+ * to return before the same parent transport deadline so the supervisor leaves a
+ * recovering child alive. One deadline, one constant.
  */
-const startupReadyBudgetMs = 25_000;
+const startupReadyBudgetMs = defaultProductionRecoveryAdmissionTimeoutMs;
 
 /** Time this child may still spend on historical recovery before announcing READY. */
 function remainingStartupRecoveryBudgetMs(): number {

--- a/packages/cli/src/composition/repo-write-child-entrypoint.ts
+++ b/packages/cli/src/composition/repo-write-child-entrypoint.ts
@@ -33,6 +33,15 @@ import {
 } from "./production-authority-lifecycle.ts";
 import { makeDaemonReservationReconciler } from "@harness-anything/daemon";
 
+/**
+ * Historical recovery runs before this child announces READY, so it has to fit
+ * inside the parent's READY deadline (`readyTimeoutMs`, default 30_000ms).
+ * A repository whose proceedings all fail recovery would otherwise never reach
+ * the announcement and wedge the daemon into a restart loop that never serves.
+ * Proceedings skipped by this budget stay proceeding and are retried next start.
+ */
+const startupHistoricalRecoveryBudgetMs = 10_000;
+
 export async function runRepoWriteChildEntrypoint(
   encodedConfig: string | undefined
 ): Promise<void> {
@@ -170,7 +179,13 @@ export async function runRepoWriteChildEntrypoint(
     return started.component.recoverCommittedReceipt(outcome.innerOpId);
   };
   const transport = new RepoWriteChildIpcTransport();
+  const startupRecoveryDeadline = Date.now() + startupHistoricalRecoveryBudgetMs;
+  let proceedingsLeftByBudget = 0;
   for (const proceeding of outcomes.listHistoricalProceedings()) {
+    if (Date.now() >= startupRecoveryDeadline) {
+      proceedingsLeftByBudget += 1;
+      continue;
+    }
     try {
       const recovery = await recoveryGate.recoverHistoricalProceeding(proceeding);
       if (recovery.disposition === "permanently-rejected") {
@@ -201,6 +216,13 @@ export async function runRepoWriteChildEntrypoint(
         diagnostic: boundedRecoveryError(error)
       });
     }
+  }
+  if (proceedingsLeftByBudget > 0) {
+    process.stderr.write(
+      `[repo-write-child] repo=${config.repoId} left ${proceedingsLeftByBudget} historical `
+      + `proceeding(s) unrecovered after the ${startupHistoricalRecoveryBudgetMs}ms startup `
+      + "budget; they remain proceeding and are retried on the next start\n"
+    );
   }
   const operation = new ProductionRepoWriteOperationHost({
     repoId: config.repoId,

--- a/packages/cli/src/composition/repo-write-child-entrypoint.ts
+++ b/packages/cli/src/composition/repo-write-child-entrypoint.ts
@@ -34,13 +34,22 @@ import {
 import { makeDaemonReservationReconciler } from "@harness-anything/daemon";
 
 /**
- * Historical recovery runs before this child announces READY, so it has to fit
- * inside the parent's READY deadline (`readyTimeoutMs`, default 30_000ms).
- * A repository whose proceedings all fail recovery would otherwise never reach
- * the announcement and wedge the daemon into a restart loop that never serves.
- * Proceedings skipped by this budget stay proceeding and are retried next start.
+ * Everything before READY must fit inside the parent's READY deadline
+ * (`readyTimeoutMs`, default 30_000ms), so this caps the child's *total* time to
+ * announcement rather than just the recovery loop. Measured on a wedged daemon,
+ * the work preceding recovery alone consumed 20.1-29.9s, so a fixed recovery
+ * budget cannot keep the total under the deadline — the budget has to be
+ * whatever time is still left. Recovery therefore gets the remainder of this cap
+ * and nothing more; proceedings it does not reach stay proceeding and are
+ * retried on the next start. The margin below the parent default absorbs spawn
+ * and IPC latency the child cannot observe.
  */
-const startupHistoricalRecoveryBudgetMs = 10_000;
+const startupReadyBudgetMs = 25_000;
+
+/** Time this child may still spend on historical recovery before announcing READY. */
+function remainingStartupRecoveryBudgetMs(): number {
+  return Math.max(0, startupReadyBudgetMs - Math.round(process.uptime() * 1000));
+}
 
 export async function runRepoWriteChildEntrypoint(
   encodedConfig: string | undefined
@@ -179,7 +188,8 @@ export async function runRepoWriteChildEntrypoint(
     return started.component.recoverCommittedReceipt(outcome.innerOpId);
   };
   const transport = new RepoWriteChildIpcTransport();
-  const startupRecoveryDeadline = Date.now() + startupHistoricalRecoveryBudgetMs;
+  const startupRecoveryBudgetMs = remainingStartupRecoveryBudgetMs();
+  const startupRecoveryDeadline = Date.now() + startupRecoveryBudgetMs;
   let proceedingsLeftByBudget = 0;
   for (const proceeding of outcomes.listHistoricalProceedings()) {
     if (Date.now() >= startupRecoveryDeadline) {
@@ -220,8 +230,9 @@ export async function runRepoWriteChildEntrypoint(
   if (proceedingsLeftByBudget > 0) {
     process.stderr.write(
       `[repo-write-child] repo=${config.repoId} left ${proceedingsLeftByBudget} historical `
-      + `proceeding(s) unrecovered after the ${startupHistoricalRecoveryBudgetMs}ms startup `
-      + "budget; they remain proceeding and are retried on the next start\n"
+      + `proceeding(s) unrecovered after spending the ${startupRecoveryBudgetMs}ms still left `
+      + `of the ${startupReadyBudgetMs}ms startup budget; they remain proceeding and are `
+      + "retried on the next start\n"
     );
   }
   const operation = new ProductionRepoWriteOperationHost({

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -5,6 +5,10 @@ export * from "./authority/production/production-scanner.ts";
 export * from "./authority/production/publication-evidence.ts";
 export * from "./authority/production/publication-proof-error.ts";
 export * from "./authority/production/recovery.ts";
+// Shared so every pre-READY path sizes itself against one deadline, not a copy.
+export {
+  defaultProductionRecoveryAdmissionTimeoutMs
+} from "./authority/production/production-recovery-admission.ts";
 export * from "./authority/production/semantic-state.ts";
 export * from "./authority/production/service-state.ts";
 export * from "./authority/production/authority-attribution-event-v2-production-recovery.ts";


### PR DESCRIPTION
## Summary

The repo-write child ran historical recovery for every proceeding **before** announcing READY, with no budget smaller than the parent's `readyTimeoutMs` (30s default, not configurable). When recovery starts failing, the child can miss the announcement entirely; the parent then kills it on the deadline and respawns it, which itself drives more load and makes the next round more likely to fail. Observed live: a daemon restarting every ~35s for minutes, with every CLI and GUI read returning "daemon unavailable".

The trigger here is intermittent and load-sensitive rather than deterministic — the same repository with the same 26 unrecovered proceedings later started fine once the machine went quiet. That is precisely the problem: **an unbounded recovery loop on the READY path converts a transient recovery failure into a self-sustaining restart loop.** This bounds that loop so a bad recovery round can no longer cost the daemon its ability to serve.

## What Changed

- `packages/cli/src/composition/repo-write-child-entrypoint.ts`: capped the child's **total** time to READY at 25s (5s under the parent default). Historical recovery gets whatever is left of that cap after the work preceding it, computed from `process.uptime()`. Once exhausted, remaining proceedings are skipped and the child proceeds to announce READY.
- The budget is a remainder rather than a fixed span because the loop's own cost is not knowable in advance. Phase-level instrumentation on a real forked child showed everything *before* the loop costs **0.70s** (artifact identity 47ms, conflict-marker preflight 315ms, `runtime.start()` 247ms, `startRepo` 43ms; ~2s including Node process start) — so the observed 20–30s **is the loop**. Its cost is dominated by iterations that *succeed*: 21 of 26 proceedings emit a `deferred` log at ~0.5s each, while ~5 successful ones emit nothing and absorb ~17.5s. Any budget sized from the visible (deferred) iterations undercounts by roughly 3×; a remaining-time budget is correct precisely because it assumes nothing about the split.
- Skipped proceedings are **not** treated as recovered: they stay `proceeding` and are retried on the next start. No WAL, outcome, or recovery file is touched.
- The count left unrecovered is written to the child's stderr (inherited by the daemon startup log) so the cap is never silent.

## Version Impact

- Version: no version change because this is an internal daemon startup-path fix with no published surface change.

## Verification

- [x] `npm run check:local` — local stop point, green in 157.4s: 27 manifest gates green, 94 contract tests pass, 0 fail.
- [ ] `npm test` / `npm run check` — Not run: full matrix is CI's job per `harness/AGENTS.md`; the local stop point is `check:local` plus a local commit.
- Not run: `npm run smoke:dashboard`, `node dist/harness.mjs check --profile target-project`, `npm run pack:dry-run`, GUI build — none is on this change's surface (single CLI composition file, no GUI or packaging surface).

Observed failure before the fix (daemon startup log, repeating every ~35s):

```
RepoWriteReadyTimeoutError: Repo writer did not announce READY within 30000ms.
  code: 'REPO_WRITE_READY_TIMEOUT', outcome: 'not-started'
```

## Review Evidence

- Self-review: confirmed the skip path preserves recovery semantics — skipped proceedings keep their `.proceeding.json` and are re-listed by `listHistoricalProceedings()` on the next start. Verified the affected repository's 26 proceeding files are untouched.
- Additional review: pending.
- Blocking findings: none.

## Residual Risk

- The 25s cap is a constant assumption about the parent's `readyTimeoutMs` default, not a value received from the parent. If that default is ever lowered the cap stops being strictly smaller; the durable fix is to pass the parent deadline down through the child launch config, which is a cross-component contract change and out of scope here.
- **This does not make the startup fast — it makes it bounded.** The better fix is to move historical recovery off the pre-READY path entirely: recovering *past* proceedings is not a precondition for serving *new* writes, and `createProductionAuthorityLifecycle` already supports `backgroundRecovery: true`. Measured pre-READY cost without the loop is ~0.7s, so that would take startup from ~30s to ~2s. It changes what READY *means*, so it is a deliberate follow-up decision rather than something to slip into this PR.
- The underlying `spawnSync git ENOBUFS` that makes each recovery attempt fail (~0.51s each, consistently) is **not** fixed here — it is an amplifier, not the wedge, and its root cause is still open.
- The sentinel topology in `production-repo-lock-topology.ts` means the alphabetically first repo must start alone before the others fan out, so one slow repository can withhold every other repository in the manifest. Not changed here, but worth review.

## References

- Task: task_01KZGVFQKQPWSQXM1EVC8QZKZT
- Evidence: same-family prior defect task_01KYVK7KFF81NAFSNCZH7Z6FBV (production write-path livelock against a 30s deadline)

---

## 摘要

repo-write child 在宣告 READY **之前**，要串行跑完全部 historical proceeding 的恢复循环，而这个循环没有任何小于父进程 `readyTimeoutMs`（默认 30 秒、且不可配置）的预算保护。一旦恢复开始失败，child 就可能完全走不到宣告那一步；父进程到点杀掉它再重拉，而重拉本身又推高负载，让下一轮更容易失败。线上实测：daemon 每约 35 秒重启一轮持续数分钟，其间所有 CLI 与 GUI 读取都报 "daemon unavailable"。

需要说明的是，触发条件是**间歇性、与负载相关**的，而非确定性的——同一个仓库、同样 26 个未恢复的 proceeding，等机器安静下来之后 daemon 又能正常启动。而这恰恰是问题所在：**READY 路径上一个无界的恢复循环，把一次瞬态恢复失败放大成了自我维持的重启循环。** 本 PR 给这段循环加上边界，使得一轮糟糕的恢复不再能让 daemon 失去服务能力。

## 改动内容

- `packages/cli/src/composition/repo-write-child-entrypoint.ts`：把 child 到 READY 的**总时长**上限设为 25 秒（比父进程默认值低 5 秒）。historical recovery 只能用掉这个上限在前置工作之后**剩下的**部分，用 `process.uptime()` 计算。预算耗尽后跳过剩余 proceeding，直接进入 READY 路径。
- 之所以用剩余时间而非固定值：循环自身的开销无法事先知晓。在真实 fork 出的 child 上做阶段级插桩后测得，循环**之前**的全部工作仅 **0.70 秒**（artifact identity 47ms、conflict-marker preflight 315ms、`runtime.start()` 247ms、`startRepo` 43ms；含 Node 进程启动约 2 秒）——所以观察到的 20–30 秒**就是循环本身**。其开销由*成功*的迭代主导：26 个 proceeding 中 21 个各写一条 `deferred` 日志（各约 0.5 秒），而约 5 个成功迭代不写任何日志、吸收约 17.5 秒。任何按可见（deferred）迭代估算的预算都会少算约 3 倍；剩余时间预算之所以正确，恰恰因为它对这个比例不作任何假设。
- 被跳过的 proceeding **不等于**已恢复：它们保持 `proceeding` 状态，下次启动继续重试。不触碰任何 WAL、outcome、recovery 文件。
- 未恢复的数量写入 child 的 stderr（由 daemon 启动日志继承），保证这个上限不是静默截断。

## 版本影响

- 版本：不改版本，原因是这是 daemon 启动路径的内部修复，不改变任何发布面。

## 验证

- [x] `npm run check:local` —— 本地停止点，157.4 秒全绿：27 个 manifest gate 绿，94 个 contract 测试通过，0 失败。
- [ ] `npm test` / `npm run check` —— 未运行：按 `harness/AGENTS.md`，完整门矩阵是 CI 的活，本地停止点是 `check:local` 加本地 commit。
- 未运行：`npm run smoke:dashboard`、`node dist/harness.mjs check --profile target-project`、`npm run pack:dry-run`、GUI 构建 —— 均不在本次改动面上（单个 CLI composition 文件，不涉及 GUI 或打包面）。

修复前观察到的故障（daemon 启动日志，每约 35 秒重复一次）：

```
RepoWriteReadyTimeoutError: Repo writer did not announce READY within 30000ms.
  code: 'REPO_WRITE_READY_TIMEOUT', outcome: 'not-started'
```

## 审查证据

- 自查：确认跳过路径保持恢复语义——被跳过的 proceeding 保留其 `.proceeding.json`，下次启动仍会被 `listHistoricalProceedings()` 重新列出。已核实受影响仓库的 26 个 proceeding 文件未被改动。
- 额外审查：待补。
- 阻塞发现：无。

## 残余风险

- 25 秒上限是对父进程 `readyTimeoutMs` 默认值的常量假设，并非从父进程接收而来。若该默认值将来被调低，这个上限就不再严格更小；根治办法是通过 child launch config 把父 deadline 传下来，那属于跨组件契约变更，不在本 PR 范围内。
- **本改动不会让启动变快，只是让它有界。** 更好的修法是把 historical recovery 整个移出 pre-READY 路径：恢复*过去*的 proceeding 并不是服务*新*写入的前提，而 `createProductionAuthorityLifecycle` 已经支持 `backgroundRecovery: true`。实测不含循环的 pre-READY 成本约 0.7 秒，因此那样能把启动从约 30 秒降到约 2 秒。但它改变了 READY 的语义，属于需要专门裁决的后续动作，不宜夹带进本 PR。
- 让每次 recovery 失败的底层 `spawnSync git ENOBUFS`（稳定约 0.51 秒一次）**未在本 PR 修复**——它是放大器而非楔子，根因仍未定位。
- `production-repo-lock-topology.ts` 的 sentinel 拓扑意味着字母序第一个仓库必须先单独启动成功，其余才 fan out，因此一个慢仓库可以扣住 manifest 里所有其他仓库。本 PR 未改动，但值得复核。

## 关联材料

- 任务：task_01KZGVFQKQPWSQXM1EVC8QZKZT
- 证据：同族历史缺陷 task_01KYVK7KFF81NAFSNCZH7Z6FBV（生产写路 livelock 撞 30s deadline）
