### PR TITLE
fix(daemon): tell the truth during cold start and bound the autostart respawn chain

### DIFF
--- a/packages/cli/src/cli/error-codes.ts
+++ b/packages/cli/src/cli/error-codes.ts
@@ -25,6 +25,15 @@ export const CliErrorCode = {
   DaemonGenerationFenced: "DAEMON_GENERATION_FENCED",
   DaemonQueueDrainTimeout: "daemon_queue_drain_timeout",
   DaemonRequestOutcomeUnknown: "daemon_request_outcome_unknown",
+  // PLT-Honest: daemon_unavailable used to be the only signal for every
+  // failure to reach the daemon, including "it is honestly still starting".
+  // That conflation is what made today's hint recommend `ha daemon restart`
+  // — the action that killed the user's recovering daemon. The two codes
+  // below split the honest states out without touching the existing
+  // daemon_unavailable entry (another worker is repurposing it for
+  // root-resolution failure).
+  DaemonStarting: "daemon_starting",
+  DaemonNotPresent: "daemon_not_present",
   DaemonUnavailable: "daemon_unavailable",
   DecodeFailed: "decode_failed",
   DecisionReadFailed: "decision_read_failed",
@@ -266,6 +275,8 @@ export const cliErrorCodeRegistry = {
   [CliErrorCode.DaemonQueueDrainTimeout]: { category: "domain", defaultHint: "Daemon control requires the write queue to drain within the deadline, but in-flight operations failed to settle in time. Run `ha daemon status --json`, inspect the reported queue operation tuples, resolve or recover them, then retry the control request." },
   [CliErrorCode.DaemonRequestOutcomeUnknown]: { category: "domain", defaultHint: "The daemon request timed out, so its outcome is unknown and the write may already have taken effect. Verify the target entity before deciding whether to retry; for task writes, run `ha task list` or `ha task show <task-id>`." },
   [CliErrorCode.DaemonUnavailable]: { category: "domain", defaultHint: "The daemon-backed request was rejected because the daemon is unavailable to the CLI. Run `ha daemon status --json`, start or restore the reported daemon, then retry; use the receipt's direct recovery command only for an explicit recovery." },
+  [CliErrorCode.DaemonStarting]: { category: "domain", defaultHint: "The daemon-backed write is blocked because the daemon is still starting; cold start on a large ledger can take 60-90s. Do NOT run 'ha daemon restart' — that kills the recovering daemon. Wait, then poll 'ha daemon status --json' until ready." },
+  [CliErrorCode.DaemonNotPresent]: { category: "domain", defaultHint: "The daemon-backed write was rejected because no daemon process is running for this repo. Start one with 'ha daemon start --service', then retry." },
   [CliErrorCode.DecodeFailed]: { category: "extension", defaultHint: "The registry value was rejected because it could not be decoded with the declared schema. Run `ha doctor --json`, correct the reported registry entry, then retry the original command." },
   [CliErrorCode.DecisionReadFailed]: { category: "command", defaultHint: "The Decision document is missing or unreadable. Run `ha decision list --json` to select an existing Decision, then retry the original decision command with that id." },
   [CliErrorCode.DecisionBodyFileReadFailed]: { category: "parse", defaultHint: "The Decision `--body-file` is missing or unreadable. Verify `<path>` names a readable Markdown file, then rerun the original `ha decision ... --body-file <path>` command." },

--- a/packages/cli/src/commands/daemon/control.ts
+++ b/packages/cli/src/commands/daemon/control.ts
@@ -67,6 +67,14 @@ export async function runDaemonControl(
   kind: DaemonControlKind
 ): Promise<Record<string, unknown>> {
   if (kind === "refresh") assertCanonicalRefreshCheckout(input.rootDir);
+  // PLT-Honest: 'ha daemon restart' on a daemon that is honestly still starting
+  // is the exact action that killed the user's recovering daemon today. The
+  // restart RPC can be accepted as soon as the main JSON-RPC socket accepts a
+  // connection, which happens BEFORE the writer child finishes cold start — so
+  // a naive restart mid-warm-up drains and respawns, throwing away 60-90s of
+  // ledger load for nothing. Refuse here when the endpoint is owned by a live
+  // process that is not yet serving status.
+  if (kind === "restart") await refuseRestartWhileStarting(input);
   const drainTimeoutMs = daemonControlTimeoutMs(input.args);
   const replacementTimeoutMs = daemonReplacementTimeoutMs(input.args);
   const replacementSettlingTimeoutMs = daemonReplacementSettlingTimeoutMs(input.args);
@@ -201,6 +209,46 @@ function validateAcceptedControlReceipt(
     || receipt.operationId.length === 0) {
     throw new Error(`${method} did not return daemon-control-accepted/v1`);
   }
+}
+
+/**
+ * PLT-Honest: refuse `ha daemon restart` when the endpoint is owned by a live
+ * process that is not yet serving status. The running daemon process opens
+ * its accept socket early in startup; a restart RPC that lands in that window
+ * drains and respawns, discarding the in-progress cold start. This is the
+ * exact action the user ran today to kill a daemon that was ~30s from ready.
+ *
+ * The check is best-effort: if ownership cannot be determined we proceed,
+ * because silently refusing a legitimate restart is its own dishonesty. The
+ * hard guarantee belongs at the autostart circuit breaker; this guard is a
+ * defense-in-depth against the most damaging operator action.
+ */
+async function refuseRestartWhileStarting(input: DaemonControlCommandInput): Promise<void> {
+  const lifecycle = input.daemonControlLifecycle ?? defaultDaemonControlLifecycle(input);
+  const target = lifecycle.target;
+  const owner = lifecycle.probeEndpointOwner?.(target);
+  if (owner?.pid === undefined || !owner.alive) return;
+  // The endpoint has a LIVE owner. If that owner is already serving status, it
+  // is honestly ready and a restart is the operator's informed choice. Only
+  // refuse when status is unreachable — i.e. the process is up but not ready.
+  let statusReachable: boolean;
+  try {
+    const probe = await lifecycle.probeStatus(target);
+    statusReachable = probe !== undefined && !("rpcError" in (probe as Record<string, unknown>));
+  } catch {
+    statusReachable = false;
+  }
+  if (statusReachable) return;
+  const customEndpoint = readOption(input.args, "--socket");
+  const endpointDesc = customEndpoint
+    ? `custom endpoint ${quoteDaemonRecoveryArgument(customEndpoint)}`
+    : `the daemon socket (${target.socketPath})`;
+  throw new Error(
+    `DAEMON_RESTART_REFUSED_STARTING: a live process pid ${owner.pid} owns ${endpointDesc} but is not yet serving status, so it is honestly still starting (cold start on a large ledger can take 60-90s).`
+    + " Restarting now would drain and respawn this process, discarding its in-progress startup — this is the action that killed a recovering daemon in today's incident."
+    + " Do NOT restart. Wait for readiness with 'ha daemon status --json' (poll until pid is reported and reachable), then retry restart if you still need it."
+    + " If you have confirmed the process is wedged (not progressing) and intentionally want to force a restart, stop it explicitly with 'ha daemon stop' first so the action is deliberate and auditable."
+  );
 }
 
 function defaultDaemonControlLifecycle(input: DaemonControlCommandInput): DaemonControlLifecycle {

--- a/packages/cli/src/commands/daemon/snapshot-rollback.ts
+++ b/packages/cli/src/commands/daemon/snapshot-rollback.ts
@@ -1,3 +1,4 @@
+import { resetDaemonAutostartCircuit } from "@harness-anything/daemon";
 import type { DaemonLaunchConfiguration } from "../../daemon/daemon-launch-spec.ts";
 import {
   isCompleteReplacement,
@@ -30,6 +31,12 @@ export async function rollbackDaemonReplacement(input: {
       `${rollbackErrorMessage(input.replacementFailure)}; ${restoration} was not started because the endpoint is still owned`
     );
   }
+  // The failed replacement just charged the autostart breaker, which then backs
+  // off for seconds. This restoration is a single deliberate recovery attempt
+  // made by a control operation, not the unbounded respawn chain the breaker
+  // exists to stop, and leaving the endpoint unserved is worse than one more
+  // spawn. Clear the socket's breaker state so the attempt is allowed to run.
+  resetDaemonAutostartCircuit(input.lifecycle.target.socketPath);
   try {
     const restored = await input.lifecycle.startReplacement(
       input.lifecycle.target,

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -33,6 +33,13 @@ import {
   type HarnessLayoutOverrides
 } from "@harness-anything/kernel";
 import { CliErrorCode, cliError } from "../cli/error-codes.ts";
+import {
+  classifyLocalDaemonLifecycle,
+  daemonUnavailableReceipt,
+  directRecoveryCommandLine
+} from "./daemon-lifecycle-classification.ts";
+
+export { classifyLocalDaemonLifecycle, directRecoveryCommandLine };
 import type { CommandFailureReceipt, CommandReceipt } from "../cli/receipt.ts";
 import { toCommandReceipt } from "../cli/receipt.ts";
 import { receiptCommandKind } from "../cli/receipt-command-kind.ts";
@@ -57,7 +64,7 @@ import {
 
 const docSyncHostServices = { resolveDeclaredManagedSectionPolicy, resolveManagedSectionPolicy };
 import { readProjectHarnessSettings } from "../commands/settings.ts";
-import { readRemoteConfig, remoteDaemonSshArgs, remoteDaemonUnavailableHint, type RemoteDaemonConfig } from "./remote-config.ts";
+import { readRemoteConfig, remoteDaemonSshArgs, type RemoteDaemonConfig } from "./remote-config.ts";
 import { isDeclaredLocalMigrationCommand } from "../composition/local-write-scope.ts";
 import { startCliTimingPhase } from "../cli/timing.ts";
 import { daemonRequestTimeoutReceipt } from "./request-outcome.ts";
@@ -407,18 +414,6 @@ async function runWithLineClient(
   }
 }
 
-function daemonUnavailableReceipt(command: ParsedCommand, error: unknown, remote?: RemoteDaemonConfig): CommandFailureReceipt {
-  const unavailableHint = remote
-    ? remoteDaemonUnavailableHint(remote)
-    : `Daemon unavailable. Start the daemon with 'ha daemon start --service' or check 'ha daemon status'. If the daemon is stuck and this write must be recovered locally, run '${directRecoveryCommandLine()}'.`;
-  const receipt = toCommandReceipt({
-    ok: false,
-    command: receiptCommandKind(command.action),
-    error: cliError(CliErrorCode.DaemonUnavailable, `${unavailableHint} Cause: ${error instanceof Error ? error.message : String(error)}`)
-  });
-  if (receipt.ok) throw new Error("daemon unavailable receipt unexpectedly succeeded");
-  return receipt;
-}
 
 function daemonActorAttributionReceipt(command: ParsedCommand, error: CliActorAttributionError): CommandFailureReceipt {
   const receipt = toCommandReceipt({
@@ -460,20 +455,6 @@ function directModeRejection(command: ParsedCommand): CommandFailureReceipt {
   });
   if (receipt.ok) throw new Error("direct-mode rejection unexpectedly succeeded");
   return receipt;
-}
-
-export function directRecoveryCommandLine(argv: ReadonlyArray<string> = process.argv.slice(2)): string {
-  const args = withoutOption(argv, "--daemon-mode");
-  const renderedArgs = args.map(shellQuote).join(" ");
-  return `HARNESS_DAEMON_MODE=direct HARNESS_DIRECT_WRITE_REASON=recovery ha${renderedArgs ? ` ${renderedArgs}` : " <command>"}`;
-}
-
-function withoutOption(argv: ReadonlyArray<string>, option: string): ReadonlyArray<string> {
-  return argv.filter((arg, index) => arg !== option && argv[index - 1] !== option);
-}
-
-function shellQuote(value: string): string {
-  return /^[A-Za-z0-9_./:@%+=,-]+$/u.test(value) ? value : `'${value.replaceAll("'", `'"'"'`)}'`;
 }
 
 function isInitializedHarness(command: ParsedCommand): boolean {

--- a/packages/cli/src/daemon/daemon-lifecycle-classification.ts
+++ b/packages/cli/src/daemon/daemon-lifecycle-classification.ts
@@ -1,0 +1,176 @@
+// PLT-Honest: classifies daemon lifecycle failures into one of three honest
+// states (not-present / starting / unavailable) and emits a ready-to-show
+// CliError whose hint is written so an agent following it verbatim never kills
+// a recovering daemon. Extracted from client.ts to keep that file under the
+// complexity budget. The classification is the direct fix for the incident
+// where the old "daemon_unavailable + direct-mode" hint sent an operator to
+// run ha daemon restart on a still-starting daemon.
+import {
+  DaemonAutostartCircuitOpenError,
+  DaemonAutostartProcessExitedError,
+  DaemonAutostartTimeoutError
+} from "@harness-anything/daemon";
+import { CliErrorCode, cliError, type CliError } from "../cli/error-codes.ts";
+import type { CommandFailureReceipt } from "../cli/receipt.ts";
+import { toCommandReceipt } from "../cli/receipt.ts";
+import { receiptCommandKind } from "../cli/receipt-command-kind.ts";
+import type { ParsedCommand } from "../cli/types.ts";
+import {
+  remoteDaemonUnavailableHint,
+  type RemoteDaemonConfig
+} from "./remote-config.ts";
+
+/**
+ * Renders the documented direct-mode recovery command line. Lives here so the
+ * classification hints can reference it without a circular import on
+ * client.ts; client.ts re-exports it for its own callers.
+ */
+export function directRecoveryCommandLine(argv: ReadonlyArray<string> = process.argv.slice(2)): string {
+  const args = withoutOption(argv, "--daemon-mode");
+  const renderedArgs = args.map(shellQuote).join(" ");
+  return `HARNESS_DAEMON_MODE=direct HARNESS_DIRECT_WRITE_REASON=recovery ha${renderedArgs ? ` ${renderedArgs}` : " <command>"}`;
+}
+
+function withoutOption(argv: ReadonlyArray<string>, option: string): ReadonlyArray<string> {
+  return argv.filter((arg, index) => arg !== option && argv[index - 1] !== option);
+}
+
+function shellQuote(value: string): string {
+  return /^[A-Za-z0-9_./:@%+=,-]+$/u.test(value) ? value : `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+export interface DaemonLifecycleClassificationDeps {
+  readonly directRecoveryCommandLine: (argv?: ReadonlyArray<string>) => string;
+}
+
+export function createDaemonLifecycleClassifier(deps: DaemonLifecycleClassificationDeps) {
+  return function classifyLocalDaemonLifecycle(error: unknown): CliError {
+    const cause = error instanceof Error ? error.message : String(error);
+
+    // Circuit breaker: the autostart path already gave up honestly after N
+    // consecutive daemon deaths. Surface that verbatim; it already carries the
+    // correct "do not restart" guidance.
+    if (error instanceof DaemonAutostartCircuitOpenError) {
+      return cliError(CliErrorCode.DaemonUnavailable, (error.message + " Cause: " + cause));
+    }
+
+    // Process exited before readiness: a genuine startup failure (not slow
+    // start). The daemon is NOT running, so ha daemon start is safe, but the
+    // operator-mode direct recovery hatch also applies for an explicit recovery.
+    if (error instanceof DaemonAutostartProcessExitedError) {
+      return cliError(
+        CliErrorCode.DaemonNotPresent,
+        "The daemon process exited before becoming ready, so no daemon is currently running. " + cause
+        + " This is a real startup failure, not a slow cold start. Inspect the launch log shown above, fix the cause, then start the daemon with 'ha daemon start --service'."
+        + " If this write must be recovered locally while the daemon is down, run '" + deps.directRecoveryCommandLine() + "'."
+      );
+    }
+
+    // Autostart timeout where the spawned process is STILL ALIVE: the daemon is
+    // honestly still starting. Cold start on a large ledger can take 60-90s.
+    // NEVER suggest restart or direct mode here — both kill/bypass the
+    // recovering daemon.
+    if (error instanceof DaemonAutostartTimeoutError) {
+      const waitedSeconds = Math.round(error.timeoutMs / 1000);
+      if (error.spawnedPid !== undefined && localDaemonProcessIsAlive(error.spawnedPid)) {
+        return cliError(
+          CliErrorCode.DaemonStarting,
+          "The daemon is still starting (spawned pid " + error.spawnedPid + " is alive; waited " + waitedSeconds + "s)."
+          + " Cold start on a large ledger can take 60-90s as the writer loads."
+          + " Do NOT run 'ha daemon restart' — that kills this recovering daemon."
+          + " Do NOT use HARNESS_DAEMON_MODE=direct — that bypasses the single-writer fence."
+          + " Wait, then poll 'ha daemon status --json' until it reports ready."
+          + " If the daemon is genuinely wedged (not progressing), inspect its logs before acting."
+          + " Probe failure: " + cause
+        );
+      }
+      // Timeout with a dead/unknown pid: treat as not-present; the daemon is not
+      // honestly recovering, so the start/direct guidance is safe.
+      return cliError(
+        CliErrorCode.DaemonNotPresent,
+        "The daemon did not become ready within " + waitedSeconds + "s and its spawned process is not running."
+        + " No daemon is currently running. Start one with 'ha daemon start --service', then retry."
+        + " If this write must be recovered locally while the daemon is down, run '" + deps.directRecoveryCommandLine() + "'."
+        + " Probe failure: " + cause
+      );
+    }
+
+    // Connection-refused / missing socket with no live owner: nothing is there.
+    if (isDaemonEndpointUnoccupied(error)) {
+      return cliError(
+        CliErrorCode.DaemonNotPresent,
+        "No daemon is listening at the expected socket. Start one with 'ha daemon start --service', then retry."
+        + " If this write must be recovered locally while the daemon is down, run '" + deps.directRecoveryCommandLine() + "'."
+        + " Cause: " + cause
+      );
+    }
+
+    // Fallback: truly unavailable. Keep the direct recovery hatch since the
+    // daemon is neither starting nor absent in a known way; the operator must
+    // diagnose. This preserves the pre-existing escape hatch without lying.
+    return cliError(
+      CliErrorCode.DaemonUnavailable,
+      "Daemon unavailable. Run 'ha daemon status --json' to inspect the daemon state."
+      + " If no daemon is running, start one with 'ha daemon start --service'."
+      + " If the daemon is truly stuck (not starting, not recovering) and this write must be recovered locally, run '" + deps.directRecoveryCommandLine() + "'."
+      + " Cause: " + cause
+    );
+  };
+}
+
+export function isDaemonEndpointUnoccupied(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const message = error.message;
+  // ECONNREFUSED / ENOENT on the socket, or the namespace diagnostic reporting
+  // a missing/unowned endpoint shape. These mean nothing is listening.
+  return /ECONNREFUSED|ENOENT|EACCES|ECONNRESET/u.test(message)
+    || /DAEMON_SOCKET_NAMESPACE_INVALID:[^;]*shape=missing/u.test(message)
+    || /DAEMON_SOCKET_NAMESPACE_INVALID:[^;]*owner=unowned/u.test(message);
+}
+
+const classifyLocalDaemonLifecycle = createDaemonLifecycleClassifier({
+  directRecoveryCommandLine: () => directRecoveryCommandLine()
+});
+
+/**
+ * Builds the caller-facing failure receipt for a daemon-unavailable error,
+ * routing to the honest lifecycle classification. Root-resolution failures
+ * never reach here; runCommandThroughDaemon answers them with the dedicated
+ * harness_root_unresolved receipt. Exported so client.ts stays under its
+ * complexity budget.
+ */
+export function daemonUnavailableReceipt(
+  command: ParsedCommand,
+  error: unknown,
+  remote?: RemoteDaemonConfig
+): CommandFailureReceipt {
+  if (remote) {
+    return failureReceipt(command, cliError(
+      CliErrorCode.DaemonUnavailable,
+      `${remoteDaemonUnavailableHint(remote)} Cause: ${error instanceof Error ? error.message : String(error)}`
+    ));
+  }
+  return failureReceipt(command, classifyLocalDaemonLifecycle(error));
+}
+
+function failureReceipt(command: ParsedCommand, error: CliError): CommandFailureReceipt {
+  const receipt = toCommandReceipt({
+    ok: false,
+    command: receiptCommandKind(command.action),
+    error
+  });
+  if (receipt.ok) throw new Error("daemon unavailable receipt unexpectedly succeeded");
+  return receipt;
+}
+
+export { classifyLocalDaemonLifecycle };
+
+export function localDaemonProcessIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return !(error !== null && typeof error === "object" && "code" in error
+      && (error as { readonly code?: unknown }).code === "ESRCH");
+  }
+}

--- a/packages/cli/test/daemon-command-outcomes.test.ts
+++ b/packages/cli/test/daemon-command-outcomes.test.ts
@@ -106,33 +106,44 @@ test("a timed-out local materializer request keeps its intentional local fallbac
   });
 });
 
-test("an unreachable daemon remains unavailable with the direct recovery guidance", { skip: process.platform === "win32" }, async () => {
+test("a slow-starting daemon is reported honestly as daemon_starting, never as unavailable-with-direct-mode", { skip: process.platform === "win32" }, async () => {
+  // PLT-Honest: this scenario spawns a real daemon whose cold start exceeds the
+  // tiny 40ms autostart budget. The spawned process is alive at the deadline
+  // (Node is still booting), and the daemon DOES eventually become reachable
+  // (the poll below confirms it). The old behavior falsely reported this as
+  // daemon_unavailable + HARNESS_DAEMON_MODE=direct — the hint that sent an
+  // agent to kill the recovering daemon. The honest classification is
+  // daemon_starting, and the hint must NOT suggest restart or direct mode.
   await withTempRootAsync(async (rootDir) => {
     initializeFixtureWithoutDaemon(rootDir);
-    const unreachableUserRoot = path.join(rootDir, "u".repeat(180));
-    const daemon = testDaemonLocation(rootDir, unreachableUserRoot);
+    const slowStartUserRoot = path.join(rootDir, "u".repeat(180));
+    const daemon = testDaemonLocation(rootDir, slowStartUserRoot);
     let daemonPid: number | undefined;
     try {
-      const result = await runCliFailure(rootDir, ["task", "create", "--title", "Unreachable Write"], {
+      const result = await runCliFailure(rootDir, ["task", "create", "--title", "Slow Start Write"], {
         ...testDaemonEnv(daemon),
         HARNESS_DAEMON_AUTOSTART_TIMEOUT_MS: "40"
       });
 
-      assert.equal(result.error.code, "daemon_unavailable");
-      assert.match(result.error.hint, /Daemon unavailable/iu);
-      assert.match(result.error.hint, /HARNESS_DAEMON_MODE=direct/iu);
-      assert.doesNotMatch(result.error.hint, /outcome is unknown/iu);
+      assert.equal(result.error.code, "daemon_starting");
+      assert.match(result.error.hint, /still starting/iu);
+      assert.match(result.error.hint, /60-90s/iu);
+      // The two lethal actions must be explicitly prohibited, never suggested:
+      assert.match(result.error.hint, /Do NOT run 'ha daemon restart'/u);
+      assert.match(result.error.hint, /Do NOT use HARNESS_DAEMON_MODE=direct/u);
+      // The honest corrective action is to wait + poll:
+      assert.match(result.error.hint, /ha daemon status --json/iu);
     } finally {
       const lateStatus = await pollUntil(
         () => runDaemonCommand(rootDir, [
-          "daemon", "status", "--user-root", unreachableUserRoot, "--json"
+          "daemon", "status", "--user-root", slowStartUserRoot, "--json"
         ], testDaemonEnv(daemon)),
         (status) => status.started === true && status.reachable === true,
         (status, error) => JSON.stringify({ status, error: String(error ?? "") }),
         { timeoutMs: 15_000 }
       );
       daemonPid = typeof lateStatus.pid === "number" ? lateStatus.pid : undefined;
-      await stopDaemon(rootDir, unreachableUserRoot);
+      await stopDaemon(rootDir, slowStartUserRoot);
       assert.equal(typeof daemonPid, "number", JSON.stringify(lateStatus));
     }
     assert.equal(processIsAlive(daemonPid), false, `test leaked late daemon pid ${String(daemonPid)}`);

--- a/packages/cli/test/daemon-control-recovery.test.ts
+++ b/packages/cli/test/daemon-control-recovery.test.ts
@@ -72,13 +72,21 @@ test("restart adopts a live replacement that becomes ready after the normal star
   const progress: string[] = [];
   let probes = 0;
   let replacementStarts = 0;
+  // The pre-RPC restart guard (refuseRestartWhileStarting) probes the endpoint
+  // owner once before any restart RPC. The first probe represents the
+  // pre-restart state: unoccupied, so the guard passes. Subsequent probes
+  // observe the replacement pid 84 during the post-RPC replacement phase.
+  let ownerProbes = 0;
   const lifecycle: DaemonControlLifecycle = {
     target,
     probeStatus: async () => {
       probes += 1;
       return probes === 1 ? undefined : daemonStatus(84);
     },
-    probeEndpointOwner: () => ({ pid: 84, alive: true }),
+    probeEndpointOwner: () => {
+      ownerProbes += 1;
+      return ownerProbes === 1 ? undefined : { pid: 84, alive: true };
+    },
     ownerIsAlive: (pid) => pid === 84,
     isReadinessTimeout: (error) => error instanceof DaemonAutostartTimeoutError,
     readinessTimeoutPid: (error) => error instanceof DaemonAutostartTimeoutError ? error.spawnedPid : undefined,
@@ -106,10 +114,16 @@ test("restart stops a live unreachable replacement at the settling cap before re
   let replacementAlive = true;
   let replacementStarts = 0;
   const stoppedPids: number[] = [];
+  // Pre-RPC guard probes owner first; first probe = pre-restart unoccupied so
+  // the guard passes; subsequent probes observe the replacement pid 84.
+  let ownerProbes = 0;
   const lifecycle: DaemonControlLifecycle = {
     target,
     probeStatus: async () => undefined,
-    probeEndpointOwner: () => replacementAlive ? { pid: 84, alive: true } : undefined,
+    probeEndpointOwner: () => {
+      ownerProbes += 1;
+      return ownerProbes === 1 ? undefined : (replacementAlive ? { pid: 84, alive: true } : undefined);
+    },
     ownerIsAlive: (pid) => pid === 84 && replacementAlive,
     isReadinessTimeout: (error) => error instanceof DaemonAutostartTimeoutError,
     readinessTimeoutPid: (error) => error instanceof DaemonAutostartTimeoutError ? error.spawnedPid : undefined,

--- a/packages/cli/test/daemon-lifecycle-honesty.test.ts
+++ b/packages/cli/test/daemon-lifecycle-honesty.test.ts
@@ -1,0 +1,77 @@
+// harness-test-tier: fast
+// PLT-Honest: the hint text is the layer that killed the user's daemon today.
+// These tests assert the three honest lifecycle states produce distinct codes
+// and that the "starting" hint never sends an agent to restart or use direct
+// mode — the two actions that, when followed verbatim during cold start,
+// killed the recovering system.
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  DaemonAutostartCircuitOpenError,
+  DaemonAutostartProcessExitedError,
+  DaemonAutostartTimeoutError
+} from "@harness-anything/daemon";
+import { classifyLocalDaemonLifecycle } from "../src/daemon/client.ts";
+
+const selfPid = process.pid;
+const deadPid = 999_999;
+const livePidRegex = new RegExp(`pid ${selfPid}`, "u");
+
+test("autostart timeout with a LIVE pid classifies as daemon_starting and forbids restart/direct guidance", () => {
+  const error = new DaemonAutostartTimeoutError(30_000, new Error("probe timeout"), selfPid);
+  const classification = classifyLocalDaemonLifecycle(error);
+  assert.equal(classification.code, "daemon_starting");
+  assert.match(classification.hint, /still starting/iu);
+  assert.match(classification.hint, livePidRegex);
+  assert.match(classification.hint, /60-90s/iu, "hint must set the honest cold-start expectation");
+  // The two lethal actions must appear ONLY as explicit prohibitions, never as
+  // recommendations. An agent following the hint verbatim must not be sent to
+  // kill the recovering daemon.
+  assert.match(classification.hint, /Do NOT run 'ha daemon restart'/u, "restart must be explicitly prohibited");
+  assert.match(classification.hint, /Do NOT use HARNESS_DAEMON_MODE=direct/u, "direct mode must be explicitly prohibited");
+  // The honest corrective action is to wait + poll:
+  assert.match(classification.hint, /ha daemon status --json/iu);
+  assert.match(classification.hint, /Wait/iu);
+});
+
+test("autostart timeout with a DEAD pid classifies as daemon_not_present (not starting)", () => {
+  const error = new DaemonAutostartTimeoutError(30_000, new Error("probe timeout"), deadPid);
+  const classification = classifyLocalDaemonLifecycle(error);
+  assert.equal(classification.code, "daemon_not_present");
+  assert.match(classification.hint, /ha daemon start --service/u, "must offer a safe start");
+  // A genuinely absent daemon may surface the direct recovery hatch — that is
+  // the documented escape hatch for a confirmed-down daemon, not for a starting one.
+  assert.match(classification.hint, /HARNESS_DAEMON_MODE=direct/u);
+});
+
+test("autostart process-exited classifies as daemon_not_present", () => {
+  const error = new DaemonAutostartProcessExitedError(new Error("boom"), deadPid, "/tmp/launch.log");
+  const classification = classifyLocalDaemonLifecycle(error);
+  assert.equal(classification.code, "daemon_not_present");
+  assert.match(classification.hint, /exited before becoming ready/iu);
+  assert.match(classification.hint, /ha daemon start --service/u);
+  // No bare restart recommendation.
+  assert.doesNotMatch(classification.hint, /(?:Start with|run|Run) 'ha daemon restart'/u);
+});
+
+test("circuit-open error classifies as daemon_unavailable and surfaces the honest stop condition", () => {
+  const error = new DaemonAutostartCircuitOpenError(5, 5, 0, "/tmp/daemon.sock", new Error("last death"));
+  const classification = classifyLocalDaemonLifecycle(error);
+  assert.equal(classification.code, "daemon_unavailable");
+  assert.match(classification.hint, /DAEMON_AUTOSTART_CIRCUIT_OPEN/u);
+  assert.match(classification.hint, /Do NOT/u, "the circuit message must carry its own do-not-restart guidance");
+});
+
+test("connection-refused (ECONNREFUSED) classifies as daemon_not_present", () => {
+  const error = Object.assign(new Error("connect ECONNREFUSED /tmp/daemon.sock"), { code: "ECONNREFUSED" });
+  const classification = classifyLocalDaemonLifecycle(error);
+  assert.equal(classification.code, "daemon_not_present");
+  assert.match(classification.hint, /No daemon is listening/u);
+});
+
+test("a generic unavailable error keeps the daemon_unavailable code and the recovery hatch", () => {
+  const error = new Error("some other transport failure");
+  const classification = classifyLocalDaemonLifecycle(error);
+  assert.equal(classification.code, "daemon_unavailable");
+  assert.match(classification.hint, /ha daemon status --json/u);
+});

--- a/packages/cli/test/daemon-restart-starting-guard.test.ts
+++ b/packages/cli/test/daemon-restart-starting-guard.test.ts
@@ -1,0 +1,104 @@
+// harness-test-tier: fast
+// PLT-Honest: 'ha daemon restart' on a still-starting daemon is the exact
+// action that killed the user's recovering daemon today. This test proves the
+// guard refuses restart when the endpoint is owned by a live process that is
+// not yet serving status, and that the refusal message does not instruct the
+// operator to restart.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { runDaemonControl } from "../src/commands/daemon/control.ts";
+import type { DaemonControlLifecycle } from "../src/commands/daemon/control-replacement.ts";
+
+const controlTarget = {
+  repoId: "canonical",
+  canonicalRoot: "/repo",
+  userRoot: "/user-root",
+  daemonId: "default",
+  socketPath: "/user-root/daemon.sock",
+  legacySocketPath: "/repo/legacy.sock",
+  registered: true
+} as const;
+
+function baseInput(overrides: { readonly lifecycle: Partial<DaemonControlLifecycle> }): Parameters<typeof runDaemonControl>[0] {
+  return {
+    rootDir: "/repo",
+    args: ["restart"],
+    daemonEntryPath: () => "/repo/packages/cli/src/index.ts",
+    requestDaemonControl: async () => {
+      throw new Error("restart RPC must not be issued when the guard refuses");
+    },
+    daemonControlLifecycle: {
+      target: controlTarget,
+      probeStatus: async () => undefined,
+      ownerIsAlive: () => true,
+      startReplacement: async () => {
+        throw new Error("replacement must not start when the guard refuses");
+      },
+      wait: async () => undefined,
+      ...overrides.lifecycle
+    } as DaemonControlLifecycle
+  };
+}
+
+test("restart is refused when a live owner is not yet serving status (still starting)", async () => {
+  await assert.rejects(
+    runDaemonControl(baseInput({
+      lifecycle: {
+        probeEndpointOwner: () => ({ pid: 4242, alive: true }),
+        probeStatus: async () => undefined, // not reachable = still starting
+        ownerIsAlive: () => true
+      }
+    }), "restart"),
+    (error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      assert.match(message, /DAEMON_RESTART_REFUSED_STARTING/u);
+      assert.match(message, /pid 4242/u);
+      assert.match(message, /60-90s/u, "must set the honest cold-start expectation");
+      assert.match(message, /Do NOT restart/u, "must prohibit the lethal action");
+      assert.match(message, /ha daemon status --json/u, "must steer to wait + poll");
+      assert.match(message, /ha daemon stop/u, "must offer a deliberate stop as the force path");
+      return true;
+    }
+  );
+});
+
+test("restart proceeds when the live owner is already serving status (honestly ready)", async () => {
+  // When status is reachable, the daemon is ready and restart is the
+  // operator's informed choice — the guard must NOT refuse.
+  let rpcIssued = false;
+  const result = await runDaemonControl({
+    ...baseInput({
+      lifecycle: {
+        probeEndpointOwner: () => ({ pid: 4242, alive: true }),
+        probeStatus: async () => ({ ok: true }), // reachable = ready
+        ownerIsAlive: () => true
+      }
+    }),
+    requestDaemonControl: async () => {
+      rpcIssued = true;
+      throw new Error("accepted-then-short-circuit");
+    }
+  }, "restart").catch((error: unknown) => error);
+  assert.equal(rpcIssued, true, "restart RPC must be issued when the daemon is ready");
+  assert.ok(result instanceof Error, "test short-circuits after the guard passes");
+});
+
+test("restart proceeds when no owner can be determined (no false refusal)", async () => {
+  // Best-effort: if ownership is unknown, the guard must not silently refuse a
+  // legitimate restart. Silently refusing is its own dishonesty.
+  let rpcIssued = false;
+  await runDaemonControl({
+    ...baseInput({
+      lifecycle: {
+        probeEndpointOwner: () => undefined, // unknown ownership
+        probeStatus: async () => undefined,
+        ownerIsAlive: () => false
+      }
+    }),
+    requestDaemonControl: async () => {
+      rpcIssued = true;
+      throw new Error("short-circuit-after-guard");
+    }
+  }, "restart").catch(() => undefined);
+  assert.equal(rpcIssued, true, "guard must not refuse when ownership is unknown");
+});

--- a/packages/cli/test/worktree-root-resolution-cli.test.ts
+++ b/packages/cli/test/worktree-root-resolution-cli.test.ts
@@ -154,7 +154,13 @@ test("non-git directory reports a non-harness root without worktree wording", as
   }
 });
 
-test("resolved roots retain the daemon-unavailable recovery hint for real connection failures", async () => {
+test("resolved roots report an honest daemon_starting state when autostart spawns a live process under a tiny budget", async () => {
+  // PLT-Honest: the endpoint starts as an empty directory, which the autostart
+  // namespace logic repairs, and autostart spawns a real daemon. Under the
+  // tiny 30ms budget the spawned process is still alive (Node is booting), so
+  // the honest classification is daemon_starting — never daemon_unavailable
+  // with a direct-mode hint that would send an operator to kill the recovering
+  // daemon. The previous assertion encoded the old, dangerous conflation.
   if (process.platform === "win32") return;
   const containerRoot = mkdtempSync(path.join(tmpdir(), "ha-daemon-unavailable-root-"));
   const canonicalRoot = path.join(containerRoot, "canonical");
@@ -172,9 +178,10 @@ test("resolved roots retain the daemon-unavailable recovery hint for real connec
     });
 
     assert.notEqual(failed.status, 0, failed.diagnostic);
-    assert.equal(failed.receipt.error?.code, "daemon_unavailable");
-    assert.match(String(failed.receipt.error?.hint), /Daemon unavailable/iu);
-    assert.match(String(failed.receipt.error?.hint), /HARNESS_DIRECT_WRITE_REASON=recovery/iu);
+    assert.equal(failed.receipt.error?.code, "daemon_starting");
+    assert.match(String(failed.receipt.error?.hint), /still starting/iu);
+    assert.match(String(failed.receipt.error?.hint), /Do NOT use HARNESS_DAEMON_MODE=direct/u, "direct mode must be explicitly prohibited");
+    assert.match(String(failed.receipt.error?.hint), /Do NOT run 'ha daemon restart'/u, "restart must be explicitly prohibited");
   } finally {
     rmSync(endpoint, { recursive: true, force: true });
     rmSync(`${endpoint}.owner`, { force: true });

--- a/packages/daemon/src/client/daemon-autostart-circuit.ts
+++ b/packages/daemon/src/client/daemon-autostart-circuit.ts
@@ -1,0 +1,241 @@
+// PLT-Honest: the daemon autostart path used to spawn a fresh detached daemon
+// on every request whose connection probe failed. When cold start is slow
+// (large ledgers can need 60-90s of writer warm-up) but the 30s autostart
+// budget fires, the flight is cleared and the very next request spawns a
+// SIBLING daemon — producing an unbounded resurrection chain that starves
+// the machine and erases the diagnostic scene.
+//
+// This module owns two honest invariants for a given daemon socket:
+//
+//   1. Live-startup tracking: if a spawned daemon process is still alive on
+//      this socket (slowly starting, not dead), do not spawn another. Join it
+//      by probing until it is ready or truly exits.
+//   2. Consecutive-failure breaker: only count failures where the spawned
+//      process actually died (or no process was produced). After N such
+//      deaths, stop autostarting and surface an honest "circuit open" error
+//      so an operator can diagnose instead of feeding the loop.
+
+import {
+  daemonProcessIsAlive,
+  DaemonAutostartCircuitOpenError
+} from "./daemon-autostart-process.ts";
+
+export { DaemonAutostartCircuitOpenError } from "./daemon-autostart-process.ts";
+
+export interface DaemonAutostartCircuitOptions {
+  readonly maxConsecutiveFailures: number;
+  readonly backoffBaseMs: number;
+  readonly backoffCapMs: number;
+}
+
+export const defaultDaemonAutostartMaxConsecutiveFailures = 5;
+export const defaultDaemonAutostartBackoffBaseMs = 2_000;
+export const defaultDaemonAutostartBackoffCapMs = 30_000;
+
+interface CircuitState {
+  consecutiveFailures: number;
+  nextAttemptAfterMs: number;
+  lastCause: unknown;
+  lastFailureAt: number;
+}
+
+interface LiveStartup {
+  readonly pid: number;
+  readonly recordedAt: number;
+}
+
+const circuits = new Map<string, CircuitState>();
+const liveStartups = new Map<string, LiveStartup>();
+
+export function resolveDaemonAutostartCircuitOptions(
+  env: NodeJS.ProcessEnv = process.env
+): DaemonAutostartCircuitOptions {
+  return {
+    maxConsecutiveFailures: positiveIntOr(
+      env.HARNESS_DAEMON_AUTOSTART_MAX_FAILURES,
+      defaultDaemonAutostartMaxConsecutiveFailures
+    ),
+    backoffBaseMs: positiveIntOr(
+      env.HARNESS_DAEMON_AUTOSTART_BACKOFF_MS,
+      defaultDaemonAutostartBackoffBaseMs
+    ),
+    backoffCapMs: positiveIntOr(
+      env.HARNESS_DAEMON_AUTOSTART_BACKOFF_CAP_MS,
+      defaultDaemonAutostartBackoffCapMs
+    )
+  };
+}
+
+/**
+ * Returns the live spawned pid recorded for this socket, or undefined when no
+ * live startup is in flight. A pid that has since exited is cleared and
+ * reported as absent so callers never trust a stale record.
+ */
+export function liveDaemonStartupPid(socketPath: string, now = Date.now()): number | undefined {
+  const record = liveStartups.get(socketPath);
+  if (!record) return undefined;
+  if (!daemonProcessIsAlive(record.pid)) {
+    liveStartups.delete(socketPath);
+    return undefined;
+  }
+  // Bound how long we trust a recorded startup so a wedged pid does not pin
+  // the socket forever; the caller may then spawn (subject to the breaker).
+  if (now - record.recordedAt > 5 * 60_000) {
+    liveStartups.delete(socketPath);
+    return undefined;
+  }
+  return record.pid;
+}
+
+export function recordLiveDaemonStartup(socketPath: string, pid: number | undefined): void {
+  if (pid === undefined) {
+    liveStartups.delete(socketPath);
+    return;
+  }
+  if (!daemonProcessIsAlive(pid)) return;
+  liveStartups.set(socketPath, { pid, recordedAt: Date.now() });
+}
+
+export function clearLiveDaemonStartup(socketPath: string, pid: number | undefined): void {
+  const record = liveStartups.get(socketPath);
+  if (record && pid !== undefined && record.pid === pid) {
+    liveStartups.delete(socketPath);
+  }
+}
+
+export interface DaemonAutostartOutcomeReport {
+  readonly ok: boolean;
+  readonly spawnedPid?: number;
+  readonly processExited: boolean;
+  readonly cause: unknown;
+}
+
+/**
+ * Accounts an autostart outcome. A timeout where the spawned pid is STILL
+ * ALIVE is not a failure (the daemon is honestly still starting); the pid is
+ * recorded so the next caller joins it instead of respawning. A pid death
+ * counts against the breaker. A spawn that produced NO pid is treated as
+ * neutral (neither a death nor a live startup): in production a real spawn
+ * always returns a pid, so the no-pid case is ambiguous, and silently
+ * punishing it would block legitimate retries on the next attempt.
+ */
+export function reportDaemonAutostartOutcome(
+  socketPath: string,
+  outcome: DaemonAutostartOutcomeReport,
+  options: DaemonAutostartCircuitOptions = resolveDaemonAutostartCircuitOptions(),
+  now = Date.now()
+): void {
+  if (outcome.ok) {
+    circuits.delete(socketPath);
+    liveStartups.delete(socketPath);
+    return;
+  }
+  if (outcome.spawnedPid !== undefined
+    && daemonProcessIsAlive(outcome.spawnedPid)
+    && !outcome.processExited) {
+    // Honest slow start: keep the pid so siblings join it instead of respawning.
+    recordLiveDaemonStartup(socketPath, outcome.spawnedPid);
+    return;
+  }
+  if (outcome.spawnedPid === undefined) {
+    // Ambiguous: no pid to attribute. Do not punish the breaker for what we
+    // cannot honestly classify as a death. The next attempt may proceed.
+    return;
+  }
+  liveStartups.delete(socketPath);
+  const state = circuits.get(socketPath) ?? freshCircuit(now);
+  state.consecutiveFailures += 1;
+  state.lastCause = outcome.cause;
+  state.lastFailureAt = now;
+  state.nextAttemptAfterMs = now + backoffMs(state.consecutiveFailures, options);
+  circuits.set(socketPath, state);
+}
+
+export interface DaemonAutostartCircuitDecision {
+  readonly allowSpawn: boolean;
+  readonly retryAfterMs: number;
+  readonly consecutiveFailures: number;
+  readonly lastCause: unknown;
+}
+
+/**
+ * Decides whether a new autostart spawn is permitted on this socket right
+ * now. When the breaker is open, returns an honest decision the caller can
+ * surface verbatim instead of silently feeding the resurrection chain.
+ */
+export function daemonAutostartCircuitDecision(
+  socketPath: string,
+  options: DaemonAutostartCircuitOptions = resolveDaemonAutostartCircuitOptions(),
+  now = Date.now()
+): DaemonAutostartCircuitDecision {
+  const state = circuits.get(socketPath);
+  if (!state) {
+    return { allowSpawn: true, retryAfterMs: 0, consecutiveFailures: 0, lastCause: undefined };
+  }
+  const retryAfterMs = Math.max(0, state.nextAttemptAfterMs - now);
+  return {
+    allowSpawn: retryAfterMs === 0 && state.consecutiveFailures < options.maxConsecutiveFailures,
+    retryAfterMs,
+    consecutiveFailures: state.consecutiveFailures,
+    lastCause: state.lastCause
+  };
+}
+
+export function daemonAutostartCircuitOpenError(
+  socketPath: string,
+  decision: DaemonAutostartCircuitDecision,
+  options: DaemonAutostartCircuitOptions = resolveDaemonAutostartCircuitOptions()
+): DaemonAutostartCircuitOpenError {
+  return new DaemonAutostartCircuitOpenError(
+    options.maxConsecutiveFailures,
+    decision.consecutiveFailures,
+    decision.retryAfterMs,
+    socketPath,
+    decision.lastCause
+  );
+}
+
+export function resetDaemonAutostartCircuit(socketPath?: string): void {
+  if (socketPath === undefined) {
+    circuits.clear();
+    liveStartups.clear();
+    return;
+  }
+  circuits.delete(socketPath);
+  liveStartups.delete(socketPath);
+}
+
+export function __daemonAutostartCircuitStateForTest(socketPath: string): {
+  readonly consecutiveFailures: number;
+  readonly nextAttemptAfterMs: number;
+  readonly liveStartupPid: number | undefined;
+} | undefined {
+  const state = circuits.get(socketPath);
+  return {
+    consecutiveFailures: state?.consecutiveFailures ?? 0,
+    nextAttemptAfterMs: state?.nextAttemptAfterMs ?? 0,
+    liveStartupPid: liveDaemonStartupPid(socketPath)
+  };
+}
+
+function freshCircuit(now: number): CircuitState {
+  return {
+    consecutiveFailures: 0,
+    nextAttemptAfterMs: now,
+    lastCause: undefined,
+    lastFailureAt: now
+  };
+}
+
+function backoffMs(consecutiveFailures: number, options: DaemonAutostartCircuitOptions): number {
+  // Exponential backoff with a deterministic base; the cap keeps a pathological
+  // socket from silencing autostart for minutes at a time.
+  const exp = options.backoffBaseMs * 2 ** (consecutiveFailures - 1);
+  return Math.min(options.backoffCapMs, Math.max(options.backoffBaseMs, exp));
+}
+
+function positiveIntOr(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/packages/daemon/src/client/daemon-autostart-flight.ts
+++ b/packages/daemon/src/client/daemon-autostart-flight.ts
@@ -1,0 +1,246 @@
+// PLT-Honest: owns the per-socket startup-flight lifecycle for daemon
+// autostart. Extracted from local-json-rpc-client.ts so that file stays under
+// the complexity budget. Two invariants live here:
+//
+//   1. Single-flight dedup: concurrent callers on one socket share one spawn.
+//   2. Resurrection-chain guard: a spawned daemon that is still alive (honest
+//      slow start) is JOINED by later callers instead of spawning a sibling,
+//      and a consecutive-death breaker opens after N genuine deaths. Both
+//      come from daemon-autostart-circuit.ts; this module wires them into the
+//      spawn/probe loop.
+import {
+  daemonAutostartFailureError,
+  daemonAutostartProcessExitedError,
+  daemonProcessIsAlive,
+  type SpawnedDaemonAutostartProcess
+} from "./daemon-autostart-process.ts";
+import {
+  clearLiveDaemonStartup,
+  daemonAutostartCircuitDecision,
+  daemonAutostartCircuitOpenError,
+  liveDaemonStartupPid,
+  recordLiveDaemonStartup,
+  reportDaemonAutostartOutcome,
+  resolveDaemonAutostartCircuitOptions,
+  type DaemonAutostartCircuitOptions
+} from "./daemon-autostart-circuit.ts";
+import { connectUnixSocketWithNamespaceDiagnostic } from "./daemon-socket-connection.ts";
+import { JsonRpcLineClient } from "./json-rpc-line-client.ts";
+import { currentDaemonProtocolVersion } from "../protocol/method-registry.ts";
+
+// Local type aliases avoid a circular import on local-json-rpc-client.ts.
+// Both the target and options types are generic so callers pass their full
+// concrete types through without the flight module depending on them.
+export interface DaemonAutostartFlightPhase {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly onPhase?: (phase: "connect-start" | "launch-start" | "ready" | "request-start" | "request-end") => void;
+}
+export interface DaemonStartupFlight {
+  startedAt: number;
+  deadline: number;
+  lastError: unknown;
+  spawnedPid?: number;
+  launchStderrPath?: string;
+  promise: Promise<void>;
+}
+export interface DaemonAutostartFlightDeps<Target, Options extends DaemonAutostartFlightPhase> {
+  readonly launchLocalDaemon: (
+    target: Target,
+    options: Options
+  ) => SpawnedDaemonAutostartProcess;
+  readonly localDaemonRetryIntervalMs: number;
+  readonly minimumReadyProbeResponseTimeoutMs: number;
+}
+const daemonStartupFlights = new Map<string, DaemonStartupFlight>();
+export function createDaemonAutostartFlightManager<Target extends { readonly socketPath: string }, Options extends DaemonAutostartFlightPhase>(
+  deps: DaemonAutostartFlightDeps<Target, Options>
+) {
+  const minimumReadyProbeResponseTimeoutMs = deps.minimumReadyProbeResponseTimeoutMs;
+  async function ensureLocalDaemonStarted(
+    target: Target,
+    autostart: Options,
+    connectTimeoutMs: number,
+    deadline: number,
+    autostartTimeoutMs: number
+  ): Promise<void> {
+    const existing = daemonStartupFlights.get(target.socketPath);
+    if (existing) {
+      if (Date.now() >= existing.deadline) {
+        daemonStartupFlights.delete(target.socketPath);
+      } else {
+        existing.deadline = Math.max(existing.deadline, deadline);
+        return waitForDaemonStartupFlight(target.socketPath, existing, deadline, autostartTimeoutMs);
+      }
+    }
+    // PLT-Honest resurrection-chain guard: join a live spawned pid instead of
+    // spawning a sibling. See module header.
+    const livePid = liveDaemonStartupPid(target.socketPath);
+    const circuitOptions = resolveDaemonAutostartCircuitOptions(autostart.env ?? process.env);
+    if (livePid !== undefined) {
+      const flight: DaemonStartupFlight = {
+        startedAt: Date.now(),
+        deadline,
+        lastError: undefined,
+        spawnedPid: livePid,
+        promise: Promise.resolve()
+      };
+      flight.promise = joinLiveDaemonStartup(target, connectTimeoutMs, flight, circuitOptions);
+      daemonStartupFlights.set(target.socketPath, flight);
+      flight.promise.then(
+        () => clearDaemonStartupFlight(target.socketPath, flight),
+        () => clearDaemonStartupFlight(target.socketPath, flight)
+      );
+      return waitForDaemonStartupFlight(target.socketPath, flight, deadline, autostartTimeoutMs);
+    }
+    const decision = daemonAutostartCircuitDecision(target.socketPath, circuitOptions);
+    if (!decision.allowSpawn) {
+      throw daemonAutostartCircuitOpenError(target.socketPath, decision, circuitOptions);
+    }
+    const flight: DaemonStartupFlight = {
+      startedAt: Date.now(),
+      deadline,
+      lastError: undefined,
+      promise: Promise.resolve()
+    };
+    flight.promise = spawnAndWaitForLocalDaemon(target, autostart, connectTimeoutMs, flight, circuitOptions);
+    daemonStartupFlights.set(target.socketPath, flight);
+    flight.promise.then(
+      () => clearDaemonStartupFlight(target.socketPath, flight),
+      () => clearDaemonStartupFlight(target.socketPath, flight)
+    );
+    return waitForDaemonStartupFlight(target.socketPath, flight, deadline, autostartTimeoutMs);
+  }
+  async function spawnAndWaitForLocalDaemon(
+    target: Target,
+    autostart: Options,
+    connectTimeoutMs: number,
+    flight: DaemonStartupFlight,
+    circuitOptions: DaemonAutostartCircuitOptions
+  ): Promise<void> {
+    autostart.onPhase?.("launch-start");
+    const launch = deps.launchLocalDaemon(target, autostart);
+    flight.spawnedPid = launch.pid;
+    flight.launchStderrPath = launch.launchStderrPath;
+    recordLiveDaemonStartup(target.socketPath, launch.pid);
+    while (Date.now() <= flight.deadline) {
+      try {
+        await probeLocalDaemonReady(
+          target.socketPath,
+          boundedDeadlineTimeout(connectTimeoutMs, flight.deadline),
+          readyProbeResponseTimeout(flight.deadline)
+        );
+        autostart.onPhase?.("ready");
+        reportDaemonAutostartOutcome(target.socketPath, {
+          ok: true, spawnedPid: flight.spawnedPid, processExited: false, cause: undefined
+        }, circuitOptions);
+        return;
+      } catch (error) {
+        flight.lastError = error;
+        const exited = daemonAutostartProcessExitedError(flight.lastError, flight.spawnedPid, flight.launchStderrPath);
+        if (exited) {
+          reportDaemonAutostartOutcome(target.socketPath, {
+            ok: false, spawnedPid: flight.spawnedPid, processExited: true, cause: flight.lastError
+          }, circuitOptions);
+          throw exited;
+        }
+        const retryDelayMs = Math.min(deps.localDaemonRetryIntervalMs, flight.deadline - Date.now());
+        if (retryDelayMs > 0) await delay(retryDelayMs);
+      }
+    }
+    const processExited = flight.spawnedPid !== undefined && !daemonProcessIsAlive(flight.spawnedPid);
+    reportDaemonAutostartOutcome(target.socketPath, {
+      ok: false, spawnedPid: flight.spawnedPid, processExited, cause: flight.lastError
+    }, circuitOptions);
+    throw daemonAutostartFailureError(flight.deadline - flight.startedAt, flight.lastError, flight.spawnedPid, flight.launchStderrPath);
+  }
+  async function joinLiveDaemonStartup(
+    target: Target,
+    connectTimeoutMs: number,
+    flight: DaemonStartupFlight,
+    circuitOptions: DaemonAutostartCircuitOptions
+  ): Promise<void> {
+    while (Date.now() <= flight.deadline) {
+      if (flight.spawnedPid !== undefined && !daemonProcessIsAlive(flight.spawnedPid)) {
+        clearLiveDaemonStartup(target.socketPath, flight.spawnedPid);
+        throw new Error(
+          "DAEMON_AUTOSTART_LIVE_EXITED: the daemon process pid " + flight.spawnedPid + " that was still"
+          + " starting on socket " + target.socketPath + " exited before readiness. It was not killed by this"
+          + " client; inspect its launch log. This is a genuine startup failure, not a slow cold start."
+        );
+      }
+      try {
+        await probeLocalDaemonReady(
+          target.socketPath,
+          boundedDeadlineTimeout(connectTimeoutMs, flight.deadline),
+          readyProbeResponseTimeout(flight.deadline)
+        );
+        reportDaemonAutostartOutcome(target.socketPath, {
+          ok: true, spawnedPid: flight.spawnedPid, processExited: false, cause: undefined
+        }, circuitOptions);
+        return;
+      } catch (error) {
+        flight.lastError = error;
+        const retryDelayMs = Math.min(deps.localDaemonRetryIntervalMs, flight.deadline - Date.now());
+        if (retryDelayMs > 0) await delay(retryDelayMs);
+      }
+    }
+    const processExited = flight.spawnedPid !== undefined && !daemonProcessIsAlive(flight.spawnedPid);
+    if (processExited) {
+      clearLiveDaemonStartup(target.socketPath, flight.spawnedPid);
+    }
+    reportDaemonAutostartOutcome(target.socketPath, {
+      ok: false, spawnedPid: flight.spawnedPid, processExited, cause: flight.lastError
+    }, circuitOptions);
+    throw daemonAutostartFailureError(flight.deadline - flight.startedAt, flight.lastError, flight.spawnedPid, flight.launchStderrPath);
+  }
+  async function waitForDaemonStartupFlight(
+    socketPath: string,
+    flight: DaemonStartupFlight,
+    deadline: number,
+    autostartTimeoutMs: number
+  ): Promise<void> {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      if (deadline >= flight.deadline) clearDaemonStartupFlight(socketPath, flight);
+      throw daemonAutostartFailureError(autostartTimeoutMs, flight.lastError, flight.spawnedPid, flight.launchStderrPath);
+    }
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (deadline >= flight.deadline) clearDaemonStartupFlight(socketPath, flight);
+        reject(daemonAutostartFailureError(autostartTimeoutMs, flight.lastError, flight.spawnedPid, flight.launchStderrPath));
+      }, remainingMs);
+      flight.promise.then(
+        () => { clearTimeout(timer); resolve(); },
+        (error: unknown) => { clearTimeout(timer); reject(error); }
+      );
+    });
+  }
+  function clearDaemonStartupFlight(socketPath: string, flight: DaemonStartupFlight): void {
+    if (daemonStartupFlights.get(socketPath) === flight) daemonStartupFlights.delete(socketPath);
+  }
+  function readyProbeResponseTimeout(deadline: number): number {
+    const remainingMs = Math.max(1, deadline - Date.now());
+    return Math.min(remainingMs, Math.max(minimumReadyProbeResponseTimeoutMs, Math.floor(remainingMs / 2)));
+  }
+  return { ensureLocalDaemonStarted };
+}
+export async function probeLocalDaemonReady(
+  socketPath: string,
+  connectTimeoutMs: number,
+  responseTimeoutMs: number
+): Promise<void> {
+  const socket = await connectUnixSocketWithNamespaceDiagnostic(socketPath, connectTimeoutMs);
+  const client = new JsonRpcLineClient(socket, socket);
+  try {
+    await client.request("protocol.hello", { protocolVersion: currentDaemonProtocolVersion }, responseTimeoutMs);
+  } finally {
+    socket.destroy();
+  }
+}
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function boundedDeadlineTimeout(timeoutMs: number, deadline: number): number {
+  return Math.max(1, Math.min(timeoutMs, deadline - Date.now()));
+}

--- a/packages/daemon/src/client/daemon-autostart-process.ts
+++ b/packages/daemon/src/client/daemon-autostart-process.ts
@@ -50,6 +50,47 @@ export class DaemonAutostartProcessExitedError extends Error {
   }
 }
 
+/**
+ * PLT-Honest: raised by the autostart circuit breaker after N consecutive
+ * daemon deaths on the same socket. The message is written so an operator
+ * (or an agent following it verbatim) reads an honest stop condition instead
+ * of being silently fed back into the resurrection chain. It deliberately
+ * does NOT suggest `ha daemon restart` or `HARNESS_DAEMON_MODE=direct`,
+ * because the breaker fires on the death side (not on slow start), and a
+ * blind restart is the action that kept killing the user's recovering
+ * daemon today.
+ */
+export class DaemonAutostartCircuitOpenError extends Error {
+  readonly maxConsecutiveFailures: number;
+  readonly consecutiveFailures: number;
+  readonly retryAfterMs: number;
+  readonly socketPath: string;
+
+  constructor(
+    maxConsecutiveFailures: number,
+    consecutiveFailures: number,
+    retryAfterMs: number,
+    socketPath: string,
+    lastCause: unknown
+  ) {
+    const cause = errorMessage(lastCause, "no probe completed");
+    super(
+      `DAEMON_AUTOSTART_CIRCUIT_OPEN: stopped autostarting after ${consecutiveFailures} consecutive daemon`
+      + ` startup failures on socket ${socketPath} (limit ${maxConsecutiveFailures}). The breaker is honest`
+      + ` about giving up rather than silently feeding an infinite respawn loop. Last failure: ${cause}.`
+      + ` Do NOT run 'ha daemon restart' — that kills whatever is recovering. Next: inspect the startup log`
+      + ` (see DAEMON_AUTOSTART_PROCESS_EXITED for the launch log path) or 'ha daemon status --json'; once`
+      + ` the cause is fixed, retry and the breaker resets on the first successful startup.`
+      + `${retryAfterMs > 0 ? ` Autostart will retry in ${Math.round(retryAfterMs / 1000)}s unless reset.` : ""}`
+    );
+    this.name = "DaemonAutostartCircuitOpenError";
+    this.maxConsecutiveFailures = maxConsecutiveFailures;
+    this.consecutiveFailures = consecutiveFailures;
+    this.retryAfterMs = retryAfterMs;
+    this.socketPath = socketPath;
+  }
+}
+
 export function spawnDetachedDaemonAutostart(
   input: DetachedDaemonAutostartInput
 ): SpawnedDaemonAutostartProcess {
@@ -98,7 +139,7 @@ function daemonAutostartLaunchStderrPath(userRoot: string): string {
   );
 }
 
-function daemonProcessIsAlive(pid: number): boolean {
+export function daemonProcessIsAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;

--- a/packages/daemon/src/client/daemon-autostart-process.ts
+++ b/packages/daemon/src/client/daemon-autostart-process.ts
@@ -74,14 +74,24 @@ export class DaemonAutostartCircuitOpenError extends Error {
     lastCause: unknown
   ) {
     const cause = errorMessage(lastCause, "no probe completed");
+    // Backing off is not the same state as giving up, and saying "stopped
+    // autostarting" while a retry is seconds away sends the reader looking for
+    // a cause that does not exist yet. Report whichever is actually true.
+    const givenUp = consecutiveFailures >= maxConsecutiveFailures;
+    const state = givenUp
+      ? `DAEMON_AUTOSTART_CIRCUIT_OPEN: stopped autostarting after ${consecutiveFailures} consecutive daemon`
+        + ` startup failures on socket ${socketPath} (limit ${maxConsecutiveFailures}). The breaker is honest`
+        + ` about giving up rather than silently feeding an infinite respawn loop.`
+      : `DAEMON_AUTOSTART_BACKOFF: waiting ${Math.max(1, Math.round(retryAfterMs / 1000))}s before the next`
+        + ` autostart attempt on socket ${socketPath} after ${consecutiveFailures} consecutive daemon startup`
+        + ` failure(s) (the breaker gives up at ${maxConsecutiveFailures}). Autostart has NOT given up; the`
+        + ` backoff keeps a failing spawn from becoming a respawn loop.`;
     super(
-      `DAEMON_AUTOSTART_CIRCUIT_OPEN: stopped autostarting after ${consecutiveFailures} consecutive daemon`
-      + ` startup failures on socket ${socketPath} (limit ${maxConsecutiveFailures}). The breaker is honest`
-      + ` about giving up rather than silently feeding an infinite respawn loop. Last failure: ${cause}.`
+      `${state} Last failure: ${cause}.`
       + ` Do NOT run 'ha daemon restart' — that kills whatever is recovering. Next: inspect the startup log`
       + ` (see DAEMON_AUTOSTART_PROCESS_EXITED for the launch log path) or 'ha daemon status --json'; once`
       + ` the cause is fixed, retry and the breaker resets on the first successful startup.`
-      + `${retryAfterMs > 0 ? ` Autostart will retry in ${Math.round(retryAfterMs / 1000)}s unless reset.` : ""}`
+      + `${retryAfterMs > 0 ? ` Autostart will retry in ${Math.max(1, Math.round(retryAfterMs / 1000))}s unless reset.` : ""}`
     );
     this.name = "DaemonAutostartCircuitOpenError";
     this.maxConsecutiveFailures = maxConsecutiveFailures;

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -36,10 +36,14 @@ import {
 import { daemonServerHostEnvironment } from "./daemon-server-host-environment.ts";
 import {
   daemonAutostartFailureError,
-  daemonAutostartProcessExitedError,
   spawnDetachedDaemonAutostart,
   type SpawnedDaemonAutostartProcess
 } from "./daemon-autostart-process.ts";
+import {
+  boundedDeadlineTimeout,
+  createDaemonAutostartFlightManager,
+  delay
+} from "./daemon-autostart-flight.ts";
 
 export {
   createDaemonLaunchConfiguration,
@@ -74,9 +78,11 @@ export const localDaemonRetryIntervalMs = 100;
 const minimumReadyProbeResponseTimeoutMs = 500;
 
 export {
+  DaemonAutostartCircuitOpenError,
   DaemonAutostartProcessExitedError,
   DaemonAutostartTimeoutError
 } from "./daemon-autostart-process.ts";
+export { resetDaemonAutostartCircuit } from "./daemon-autostart-circuit.ts";
 
 export {
   DaemonJsonRpcRequestTimeoutError,
@@ -134,17 +140,16 @@ export interface LocalDaemonJsonRpcOptions {
 type SpawnLocalDaemonResult = number | void | SpawnedDaemonAutostartProcess;
 type SpawnLocalDaemon = (target: LocalDaemonTarget, options: LocalDaemonAutostartOptions) => SpawnLocalDaemonResult;
 
-interface DaemonStartupFlight {
-  readonly startedAt: number;
-  deadline: number;
-  lastError: unknown;
-  spawnedPid?: number;
-  launchStderrPath?: string;
-  promise: Promise<void>;
-}
-
-const daemonStartupFlights = new Map<string, DaemonStartupFlight>();
 let spawnLocalDaemonImplementation: SpawnLocalDaemon = spawnLocalDaemonProcess;
+
+// PLT-Honest: the autostart flight manager owns single-flight dedup AND the
+// resurrection-chain guard (join a live spawned pid; open the breaker after N
+// genuine deaths). Created once with launchLocalDaemon + tuning constants.
+const daemonAutostartFlight = createDaemonAutostartFlightManager<LocalDaemonTarget, LocalDaemonAutostartOptions>({
+  launchLocalDaemon: (target, options) => launchLocalDaemon(target, options),
+  localDaemonRetryIntervalMs,
+  minimumReadyProbeResponseTimeoutMs
+});
 
 export function daemonIdForRoot(rootDir: string): string {
   return `repo-${createHash("sha256").update(rootDir).digest("hex").slice(0, 16)}`;
@@ -374,7 +379,7 @@ async function requestLocalDaemonJsonRpcWithAutostart(
       );
     } catch (error) {
       lastError = error;
-      await ensureLocalDaemonStarted(target, autostart, connectTimeoutMs, deadline, autostartTimeoutMs);
+      await daemonAutostartFlight.ensureLocalDaemonStarted(target, autostart, connectTimeoutMs, deadline, autostartTimeoutMs);
       continue;
     }
     try {
@@ -394,134 +399,6 @@ async function requestLocalDaemonJsonRpcWithAutostart(
     }
   }
   throw daemonAutostartFailureError(autostartTimeoutMs, lastError);
-}
-
-async function ensureLocalDaemonStarted(
-  target: LocalDaemonTarget,
-  autostart: LocalDaemonAutostartOptions,
-  connectTimeoutMs: number,
-  deadline: number,
-  autostartTimeoutMs: number
-): Promise<void> {
-  const existing = daemonStartupFlights.get(target.socketPath);
-  if (existing) {
-    if (Date.now() >= existing.deadline) {
-      daemonStartupFlights.delete(target.socketPath);
-    } else {
-      existing.deadline = Math.max(existing.deadline, deadline);
-      return waitForDaemonStartupFlight(target.socketPath, existing, deadline, autostartTimeoutMs);
-    }
-  }
-
-  const flight: DaemonStartupFlight = {
-    startedAt: Date.now(),
-    deadline,
-    lastError: undefined,
-    promise: Promise.resolve()
-  };
-  flight.promise = spawnAndWaitForLocalDaemon(target, autostart, connectTimeoutMs, flight);
-  daemonStartupFlights.set(target.socketPath, flight);
-  flight.promise.then(
-    () => clearDaemonStartupFlight(target.socketPath, flight),
-    () => clearDaemonStartupFlight(target.socketPath, flight)
-  );
-  return waitForDaemonStartupFlight(target.socketPath, flight, deadline, autostartTimeoutMs);
-}
-
-async function spawnAndWaitForLocalDaemon(
-  target: LocalDaemonTarget,
-  autostart: LocalDaemonAutostartOptions,
-  connectTimeoutMs: number,
-  flight: DaemonStartupFlight
-): Promise<void> {
-  autostart.onPhase?.("launch-start");
-  const launch = launchLocalDaemon(target, autostart);
-  flight.spawnedPid = launch.pid;
-  flight.launchStderrPath = launch.launchStderrPath;
-  while (Date.now() <= flight.deadline) {
-    try {
-      await probeLocalDaemonReady(
-        target.socketPath,
-        boundedDeadlineTimeout(connectTimeoutMs, flight.deadline),
-        readyProbeResponseTimeout(flight.deadline)
-      );
-      autostart.onPhase?.("ready");
-      return;
-    } catch (error) {
-      flight.lastError = error;
-      const exited = daemonAutostartProcessExitedError(
-        flight.lastError,
-        flight.spawnedPid,
-        flight.launchStderrPath
-      );
-      if (exited) throw exited;
-      const retryDelayMs = Math.min(localDaemonRetryIntervalMs, flight.deadline - Date.now());
-      if (retryDelayMs > 0) await delay(retryDelayMs);
-    }
-  }
-  throw daemonAutostartFailureError(
-    flight.deadline - flight.startedAt,
-    flight.lastError,
-    flight.spawnedPid,
-    flight.launchStderrPath
-  );
-}
-
-async function waitForDaemonStartupFlight(
-  socketPath: string,
-  flight: DaemonStartupFlight,
-  deadline: number,
-  autostartTimeoutMs: number
-): Promise<void> {
-  const remainingMs = deadline - Date.now();
-  if (remainingMs <= 0) {
-    if (deadline >= flight.deadline) clearDaemonStartupFlight(socketPath, flight);
-    throw daemonAutostartFailureError(
-      autostartTimeoutMs,
-      flight.lastError,
-      flight.spawnedPid,
-      flight.launchStderrPath
-    );
-  }
-  return new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      if (deadline >= flight.deadline) clearDaemonStartupFlight(socketPath, flight);
-      reject(daemonAutostartFailureError(
-        autostartTimeoutMs,
-        flight.lastError,
-        flight.spawnedPid,
-        flight.launchStderrPath
-      ));
-    }, remainingMs);
-    flight.promise.then(
-      () => {
-        clearTimeout(timer);
-        resolve();
-      },
-      (error: unknown) => {
-        clearTimeout(timer);
-        reject(error);
-      }
-    );
-  });
-}
-
-function clearDaemonStartupFlight(socketPath: string, flight: DaemonStartupFlight): void {
-  if (daemonStartupFlights.get(socketPath) === flight) daemonStartupFlights.delete(socketPath);
-}
-
-async function probeLocalDaemonReady(
-  socketPath: string,
-  connectTimeoutMs: number,
-  responseTimeoutMs: number
-): Promise<void> {
-  const socket = await connectUnixSocketWithNamespaceDiagnostic(socketPath, connectTimeoutMs);
-  const client = new JsonRpcLineClient(socket, socket);
-  try {
-    await client.request("protocol.hello", { protocolVersion: currentDaemonProtocolVersion }, responseTimeoutMs);
-  } finally {
-    socket.destroy();
-  }
 }
 
 async function requestWithSocket(
@@ -569,24 +446,6 @@ function tryRegisterCanonicalRepo(rootDir: string, userRoot: string): DaemonRegi
 
 function daemonTarget(input: LocalDaemonTarget): LocalDaemonTarget {
   return input;
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function boundedDeadlineTimeout(timeoutMs: number, deadline: number): number {
-  return Math.max(1, Math.min(timeoutMs, deadline - Date.now()));
-}
-
-function readyProbeResponseTimeout(deadline: number): number {
-  const remainingMs = Math.max(1, deadline - Date.now());
-  // Give a live-but-loaded daemon meaningful response time while reserving
-  // half of an ample startup budget for another bounded probe.
-  return Math.min(
-    remainingMs,
-    Math.max(minimumReadyProbeResponseTimeoutMs, Math.floor(remainingMs / 2))
-  );
 }
 
 function launchLocalDaemon(

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -64,6 +64,20 @@ export {
   type LocalDaemonJsonRpcOptions,
   type LocalDaemonTarget
 } from "./client/local-json-rpc-client.ts";
+export {
+  DaemonAutostartCircuitOpenError,
+  defaultDaemonAutostartBackoffBaseMs,
+  defaultDaemonAutostartBackoffCapMs,
+  defaultDaemonAutostartMaxConsecutiveFailures,
+  daemonAutostartCircuitDecision,
+  liveDaemonStartupPid,
+  reportDaemonAutostartOutcome,
+  resetDaemonAutostartCircuit,
+  resolveDaemonAutostartCircuitOptions,
+  type DaemonAutostartCircuitDecision,
+  type DaemonAutostartCircuitOptions,
+  type DaemonAutostartOutcomeReport
+} from "./client/daemon-autostart-circuit.ts";
 export { DaemonRepoRootResolutionError } from "./client/daemon-repo-root-resolution-error.ts";
 export * from "./authority/index.ts";
 export * from "./authority/authority-command-submission.ts";

--- a/packages/daemon/test/daemon-autostart-circuit-resurrection.test.ts
+++ b/packages/daemon/test/daemon-autostart-circuit-resurrection.test.ts
@@ -1,0 +1,176 @@
+// harness-test-tier: integration
+// PLT-Honest: proves the autostart path no longer spawns sibling daemons while
+// one is honestly still starting on the same socket, and that the breaker
+// opens after N genuine deaths. Both behaviours are direct fixes for today's
+// incident (the "复活链" that starved the user's machine).
+import assert from "node:assert/strict";
+import { rmSync } from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import { createInterface } from "node:readline";
+import test from "node:test";
+import {
+  DaemonAutostartCircuitOpenError,
+  DaemonAutostartTimeoutError,
+  localDaemonRetryIntervalMs,
+  replaceSpawnLocalDaemonForTest,
+  requestLocalDaemonJsonRpcForTarget,
+  resetDaemonAutostartCircuit,
+  type LocalDaemonTarget
+} from "../src/client/local-json-rpc-client.ts";
+import {
+  encodeJsonLineFrame,
+  type JsonRpcRequest
+} from "../src/index.ts";
+
+function makeTarget(socketPath: string): LocalDaemonTarget {
+  return {
+    repoId: "canonical",
+    canonicalRoot: "/tmp/canonical",
+    userRoot: "/tmp/ha-user-root",
+    daemonId: "default",
+    socketPath,
+    legacySocketPath: `${socketPath}.legacy`,
+    registered: true
+  };
+}
+
+function uniqueSocketPath(prefix: string): string {
+  return path.join(
+    "/tmp",
+    `${prefix}-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}.sock`
+  );
+}
+
+async function startJsonRpcServer(socketPath: string): Promise<net.Server> {
+  rmSync(socketPath, { force: true });
+  const server = net.createServer((socket) => {
+    const lines = createInterface({ input: socket });
+    lines.on("line", (line) => {
+      const request = JSON.parse(line) as JsonRpcRequest;
+      socket.write(encodeJsonLineFrame({
+        jsonrpc: "2.0",
+        id: request.id ?? null,
+        result: request.method === "protocol.hello"
+          ? { ok: true }
+          : { ok: true, method: request.method }
+      }));
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  return server;
+}
+
+function closeServer(server: net.Server): Promise<void> {
+  if (!server.listening) return Promise.resolve();
+  return new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("a slow-cold-start daemon is not respawned while its process is alive (resurrection chain broken)", async (context) => {
+  if (process.platform === "win32") return;
+  const socketPath = uniqueSocketPath("ha-resurrect-slow");
+  const target = makeTarget(socketPath);
+  resetDaemonAutostartCircuit(socketPath);
+  const servers: net.Server[] = [];
+  let spawnCalls = 0;
+  // Pretend the spawned daemon is a long-lived process: the current node test
+  // process is alive, so the breaker treats timeouts as honest slow start and
+  // records the pid for joining instead of counting a failure.
+  const restoreSpawn = replaceSpawnLocalDaemonForTest(() => {
+    spawnCalls += 1;
+    return { pid: process.pid };
+  });
+  context.after(async () => {
+    restoreSpawn();
+    resetDaemonAutostartCircuit(socketPath);
+    await Promise.allSettled(servers.map((server) => closeServer(server)));
+    rmSync(socketPath, { force: true });
+  });
+
+  // First request: autostart budget too short to see readiness, but the
+  // spawned pid (us) is alive. The outcome is an honest timeout, NOT a breaker
+  // failure, and the pid is recorded.
+  const firstOutcome = await requestLocalDaemonJsonRpcForTarget(
+    target,
+    "repo.tasks.list",
+    { command: 0 },
+    100,
+    { entryPath: "/unused", timeoutMs: 400 }
+  ).catch((error: unknown) => error instanceof DaemonAutostartTimeoutError
+    ? "timeout"
+    : Promise.reject(error));
+  assert.equal(firstOutcome, "timeout");
+  assert.equal(spawnCalls, 1, "first request must spawn exactly once");
+
+  // Bring the daemon up now; the next request must JOIN the recorded live pid
+  // (no new spawn) and succeed.
+  servers.push(await startJsonRpcServer(socketPath));
+
+  // Give the join path a generous budget so the probe can succeed.
+  const secondOutcome = await requestLocalDaemonJsonRpcForTarget(
+    target,
+    "repo.tasks.list",
+    { command: 1 },
+    100,
+    { entryPath: "/unused", timeoutMs: 3_000 }
+  );
+  assert.deepEqual(secondOutcome, { ok: true, method: "repo.tasks.list" });
+  assert.equal(spawnCalls, 1, "second request must JOIN the live pid, not spawn a sibling");
+});
+
+test("the breaker opens after N genuine spawn failures and refuses further autostart", async (context) => {
+  if (process.platform === "win32") return;
+  const socketPath = uniqueSocketPath("ha-resurrect-deaths");
+  const target = makeTarget(socketPath);
+  resetDaemonAutostartCircuit(socketPath);
+  let spawnCalls = 0;
+  // Every spawn produces a dead pid so the breaker counts a failure each time.
+  const restoreSpawn = replaceSpawnLocalDaemonForTest(() => {
+    spawnCalls += 1;
+    return { pid: 999_999 + spawnCalls }; // not alive
+  });
+  context.after(() => {
+    restoreSpawn();
+    resetDaemonAutostartCircuit(socketPath);
+    rmSync(socketPath, { force: true });
+  });
+
+  const maxFailures = 3;
+  const outcomes: Array<string> = [];
+  for (let attempt = 0; attempt < maxFailures + 1; attempt += 1) {
+    const outcome = await requestLocalDaemonJsonRpcForTarget(
+      target,
+      "repo.tasks.list",
+      { attempt },
+      50,
+      { entryPath: "/unused", timeoutMs: 120 }
+    ).then(
+      () => "ok",
+      (error: unknown) => error instanceof DaemonAutostartCircuitOpenError
+        ? "circuit-open"
+        : error instanceof DaemonAutostartTimeoutError
+          ? "timeout"
+          : `error:${String((error as Error).message).slice(0, 40)}`
+    );
+    outcomes.push(outcome);
+    // Allow backoff windows to elapse so the next attempt is not simply gated
+    // by retryAfterMs; we want to observe the failure-limit trigger.
+    if (attempt < maxFailures) {
+      await new Promise((resolve) => setTimeout(resolve, localDaemonRetryIntervalMs * 2));
+    }
+  }
+
+  // The first several attempts time out (dead pid, short budget). Once the
+  // failure limit is reached, the breaker opens and further autostart returns
+  // the honest circuit-open error instead of spawning again.
+  assert.ok(outcomes.includes("circuit-open"), `expected circuit-open in outcomes: ${JSON.stringify(outcomes)}`);
+  assert.ok(spawnCalls <= maxFailures + 1, `breaker must stop spawning: spawnCalls=${spawnCalls}`);
+});

--- a/packages/daemon/test/daemon-autostart-circuit.test.ts
+++ b/packages/daemon/test/daemon-autostart-circuit.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   __daemonAutostartCircuitStateForTest,
   daemonAutostartCircuitDecision,
+  daemonAutostartCircuitOpenError,
   defaultDaemonAutostartMaxConsecutiveFailures,
   liveDaemonStartupPid,
   recordLiveDaemonStartup,
@@ -81,6 +82,45 @@ test("after N consecutive deaths the breaker opens and refuses to spawn", () => 
   assert.equal(decision.allowSpawn, false, "breaker must open after N deaths");
   assert.equal(decision.consecutiveFailures, 3);
   assert.ok(decision.lastCause instanceof Error);
+});
+
+test("the refusal text says backing off while backing off, and giving up only once it gives up", () => {
+  reset();
+  reportDaemonAutostartOutcome(socketA, {
+    ok: false,
+    spawnedPid: 999_999,
+    processExited: true,
+    cause: new Error("exited")
+  }, options, t0);
+  const backingOff = daemonAutostartCircuitOpenError(
+    socketA,
+    daemonAutostartCircuitDecision(socketA, options, t0),
+    options
+  );
+  assert.match(backingOff.message, /DAEMON_AUTOSTART_BACKOFF/u);
+  assert.ok(
+    !backingOff.message.includes("stopped autostarting"),
+    `one failure of three is not giving up; got: ${backingOff.message}`
+  );
+
+  for (let i = 1; i < 3; i += 1) {
+    reportDaemonAutostartOutcome(socketA, {
+      ok: false,
+      spawnedPid: 999_990 + i,
+      processExited: true,
+      cause: new Error(`death ${i + 1}`)
+    }, options, t0 + i * 10_000);
+  }
+  const gaveUp = daemonAutostartCircuitOpenError(
+    socketA,
+    daemonAutostartCircuitDecision(socketA, options, t0 + 100_000),
+    options
+  );
+  assert.match(gaveUp.message, /DAEMON_AUTOSTART_CIRCUIT_OPEN: stopped autostarting/u);
+  assert.ok(
+    !gaveUp.message.includes("DAEMON_AUTOSTART_BACKOFF"),
+    `an open breaker must not also claim it is merely backing off; got: ${gaveUp.message}`
+  );
 });
 
 test("a successful ready resets the breaker completely", () => {

--- a/packages/daemon/test/daemon-autostart-circuit.test.ts
+++ b/packages/daemon/test/daemon-autostart-circuit.test.ts
@@ -1,0 +1,176 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  __daemonAutostartCircuitStateForTest,
+  daemonAutostartCircuitDecision,
+  defaultDaemonAutostartMaxConsecutiveFailures,
+  liveDaemonStartupPid,
+  recordLiveDaemonStartup,
+  reportDaemonAutostartOutcome,
+  resetDaemonAutostartCircuit,
+  resolveDaemonAutostartCircuitOptions,
+  type DaemonAutostartCircuitOptions
+} from "../src/client/daemon-autostart-circuit.ts";
+
+const socketA = `/tmp/ha-circuit-test-a-${process.pid}.sock`;
+const socketB = `/tmp/ha-circuit-test-b-${process.pid}.sock`;
+const options: DaemonAutostartCircuitOptions = {
+  maxConsecutiveFailures: 3,
+  backoffBaseMs: 100,
+  backoffCapMs: 1_000
+};
+const t0 = 10_000_000;
+
+function reset() {
+  resetDaemonAutostartCircuit(socketA);
+  resetDaemonAutostartCircuit(socketB);
+}
+
+test("a timeout with a live spawned pid is treated as honest slow start, not a breaker failure", () => {
+  reset();
+  const livePid = process.pid; // the test process itself is alive
+  reportDaemonAutostartOutcome(socketA, {
+    ok: false,
+    spawnedPid: livePid,
+    processExited: false,
+    cause: new Error("probe timeout")
+  }, options, t0);
+  const state = __daemonAutostartCircuitStateForTest(socketA);
+  assert.equal(state?.consecutiveFailures, 0, "slow start must not count against the breaker");
+  assert.equal(state?.liveStartupPid, livePid, "live pid recorded for joining");
+  // While a live pid is recorded, the decision suppresses sibling spawns even
+  // though the breaker itself has zero failures: the join path owns this.
+  const decision = daemonAutostartCircuitDecision(socketA, options, t0);
+  assert.equal(decision.consecutiveFailures, 0);
+});
+
+test("a timeout with a dead spawned pid counts against the breaker and applies backoff", () => {
+  reset();
+  const deadPid = 999_999; // not alive
+  reportDaemonAutostartOutcome(socketA, {
+    ok: false,
+    spawnedPid: deadPid,
+    processExited: true,
+    cause: new Error("exited")
+  }, options, t0);
+  const state = __daemonAutostartCircuitStateForTest(socketA);
+  assert.equal(state?.consecutiveFailures, 1);
+  assert.equal(state?.liveStartupPid, undefined);
+  // Immediately after the failure, backoff is in effect: spawn disallowed.
+  const immediate = daemonAutostartCircuitDecision(socketA, options, t0);
+  assert.equal(immediate.allowSpawn, false, "backoff must gate the retry");
+  assert.ok(immediate.retryAfterMs > 0);
+  // After the backoff window passes, spawn is allowed again (1 < 3 limit).
+  const afterBackoff = daemonAutostartCircuitDecision(socketA, options, t0 + 200);
+  assert.equal(afterBackoff.allowSpawn, true);
+});
+
+test("after N consecutive deaths the breaker opens and refuses to spawn", () => {
+  reset();
+  for (let i = 0; i < 3; i += 1) {
+    reportDaemonAutostartOutcome(socketA, {
+      ok: false,
+      spawnedPid: 999_990 + i,
+      processExited: true,
+      cause: new Error(`death ${i + 1}`)
+    }, options, t0 + i * 1_000);
+  }
+  // Even well past the last backoff, the failure limit keeps it open.
+  const decision = daemonAutostartCircuitDecision(socketA, options, t0 + 100_000);
+  assert.equal(decision.allowSpawn, false, "breaker must open after N deaths");
+  assert.equal(decision.consecutiveFailures, 3);
+  assert.ok(decision.lastCause instanceof Error);
+});
+
+test("a successful ready resets the breaker completely", () => {
+  reset();
+  reportDaemonAutostartOutcome(socketA, {
+    ok: false,
+    spawnedPid: 999_999,
+    processExited: true,
+    cause: new Error("death")
+  }, options, t0);
+  assert.equal(__daemonAutostartCircuitStateForTest(socketA)?.consecutiveFailures, 1);
+  reportDaemonAutostartOutcome(socketA, {
+    ok: true,
+    spawnedPid: undefined,
+    processExited: false,
+    cause: undefined
+  }, options, t0);
+  assert.equal(__daemonAutostartCircuitStateForTest(socketA)?.consecutiveFailures, 0);
+  assert.equal(daemonAutostartCircuitDecision(socketA, options, t0).allowSpawn, true);
+});
+
+test("circuit state is isolated per socket", () => {
+  reset();
+  reportDaemonAutostartOutcome(socketA, {
+    ok: false,
+    spawnedPid: 999_999,
+    processExited: true,
+    cause: new Error("a")
+  }, options, t0);
+  assert.equal(__daemonAutostartCircuitStateForTest(socketA)?.consecutiveFailures, 1);
+  assert.equal(__daemonAutostartCircuitStateForTest(socketB)?.consecutiveFailures, 0);
+  assert.equal(daemonAutostartCircuitDecision(socketB, options, t0).allowSpawn, true);
+});
+
+test("liveDaemonStartupPid clears a recorded pid that has since exited", () => {
+  reset();
+  recordLiveDaemonStartup(socketA, 999_999); // not alive
+  assert.equal(liveDaemonStartupPid(socketA), undefined);
+});
+
+test("backoff grows exponentially and is capped", () => {
+  reset();
+  const capOptions: DaemonAutostartCircuitOptions = {
+    maxConsecutiveFailures: 10,
+    backoffBaseMs: 100,
+    backoffCapMs: 500
+  };
+  reportDaemonAutostartOutcome(socketA, {
+    ok: false, spawnedPid: 999_998, processExited: true, cause: new Error("1")
+  }, capOptions, t0);
+  const d1 = daemonAutostartCircuitDecision(socketA, capOptions, t0);
+  assert.ok(d1.retryAfterMs >= 100, `first backoff >= base: ${d1.retryAfterMs}`);
+
+  reportDaemonAutostartOutcome(socketA, {
+    ok: false, spawnedPid: 999_997, processExited: true, cause: new Error("2")
+  }, capOptions, t0);
+  const d2 = daemonAutostartCircuitDecision(socketA, capOptions, t0);
+  assert.ok(d2.retryAfterMs > d1.retryAfterMs, "backoff must grow");
+
+  for (let i = 3; i <= 5; i += 1) {
+    reportDaemonAutostartOutcome(socketA, {
+      ok: false, spawnedPid: 999_997 - i, processExited: true, cause: new Error(String(i))
+    }, capOptions, t0);
+  }
+  const d5 = daemonAutostartCircuitDecision(socketA, capOptions, t0);
+  assert.ok(d5.retryAfterMs <= 500, `backoff must be capped: ${d5.retryAfterMs}`);
+});
+
+test("default options resolve from env", () => {
+  const opts = resolveDaemonAutostartCircuitOptions({
+    HARNESS_DAEMON_AUTOSTART_MAX_FAILURES: "7",
+    HARNESS_DAEMON_AUTOSTART_BACKOFF_MS: "1234",
+    HARNESS_DAEMON_AUTOSTART_BACKOFF_CAP_MS: "20000"
+  });
+  assert.equal(opts.maxConsecutiveFailures, 7);
+  assert.equal(opts.backoffBaseMs, 1234);
+  assert.equal(opts.backoffCapMs, 20000);
+  const defaults = resolveDaemonAutostartCircuitOptions({});
+  assert.equal(defaults.maxConsecutiveFailures, defaultDaemonAutostartMaxConsecutiveFailures);
+});
+
+test("resetDaemonAutostartCircuit clears a single socket without touching others", () => {
+  reset();
+  reportDaemonAutostartOutcome(socketA, {
+    ok: false, spawnedPid: 999_999, processExited: true, cause: new Error("a")
+  }, options, t0);
+  reportDaemonAutostartOutcome(socketB, {
+    ok: false, spawnedPid: 999_998, processExited: true, cause: new Error("b")
+  }, options, t0);
+  resetDaemonAutostartCircuit(socketA);
+  assert.equal(__daemonAutostartCircuitStateForTest(socketA)?.consecutiveFailures, 0);
+  assert.equal(__daemonAutostartCircuitStateForTest(socketB)?.consecutiveFailures, 1);
+});


### PR DESCRIPTION
# English

## Summary

Today an agent's `ha task create` was slow to start. The client reported `daemon_unavailable` and suggested `ha daemon restart`. The agent followed the suggestion and killed a daemon that was healthy and mid-cold-start. Meanwhile the GUI dev harness kept re-requesting, and every request spawned another daemon, so the machine ended up feeding a respawn chain while the original process was still loading the ledger.

Two defects, both fixed here:

1. **The client lied about what was happening.** A 30-second autostart timeout was treated as death. It is not: on a large ledger the writer takes 60–90 s to load. The client now checks whether the spawned pid is still alive and answers with one of three honest states instead of one wrong one.
2. **Nothing bounded the respawn chain.** Autostart now remembers the pid it spawned; a later request joins that live pid instead of spawning a sibling, and only genuine pid deaths count toward a circuit breaker.

The error text is the load-bearing part. `daemon_starting` never suggests `ha daemon restart` and never suggests `HARNESS_DAEMON_MODE=direct` — the two actions that destroyed a recovering daemon today. An agent following the new text waits and polls.

## What Changed

- `packages/daemon/src/client/daemon-autostart-circuit.ts` (new): per-socket consecutive-death breaker. A live spawned pid does not count as a failure; only a pid that actually exited does. Opens after 5 consecutive deaths (`HARNESS_DAEMON_AUTOSTART_MAX_FAILURES`), with exponential backoff (base 2 s, cap 30 s, both env-tunable), and resets on the first successful startup.
- `packages/daemon/src/client/daemon-autostart-flight.ts` (new): live-pid joining. Autostart records the spawned pid per socket; the next request probes and waits on that pid instead of spawning a sibling.
- `packages/cli/src/daemon/daemon-lifecycle-classification.ts` (new): maps a thrown error to `daemon_starting` (timeout, pid alive), `daemon_not_present` (process exited, or timeout with a dead pid, or `ECONNREFUSED` / unowned socket), or `daemon_unavailable` (everything else, including an open breaker).
- `packages/cli/src/cli/error-codes.ts`: adds `daemon_starting` and `daemon_not_present`. Add-only; no existing entry is edited or removed.
- `packages/cli/src/commands/daemon/control.ts`: `ha daemon restart` now refuses before it sends the RPC when a live pid owns the socket but is not yet serving status — the exact action that killed the recovering daemon. Best-effort: when ownership cannot be determined it allows the restart, so a legitimate restart is never wrongly blocked; the hard guarantee lives in the breaker.
- `packages/daemon/src/client/{local-json-rpc-client,daemon-autostart-process}.ts`, `packages/daemon/src/index.ts`: wire in the flight manager and export the new symbols.

Real `daemon_starting` output, from the test that pins it:

```
code: daemon_starting
hint: The daemon is still starting (spawned pid 58693 is alive; waited 30s). Cold start on a
large ledger can take 60-90s as the writer loads. Do NOT run 'ha daemon restart' — that kills
this recovering daemon. Do NOT use HARNESS_DAEMON_MODE=direct — that bypasses the single-writer
fence. Wait, then poll 'ha daemon status --json' until it reports ready. …
```

Every daemon spawn in the product goes through the single autostart path — `packages/gui/scripts/dev-electron.mjs` and `packages/gui/src/main/electron-main.ts` do not spawn daemons themselves — so the breaker protects the GUI dev harness too, which is where today's chain came from.

### On the 30-second timeout

The timeout value is unchanged. Raising it treats the symptom: the client would still be guessing from elapsed time. The fix is that `DaemonAutostartTimeoutError` now carries `spawnedPid`, and liveness — not elapsed time — decides whether the daemon is dead. See Residual Risk for the deeper follow-up this leaves open.


### A defect the breaker introduced, found and fixed on this branch

The first push failed `integration-shard (1)` on `restart replacement launch failure restores a reachable daemon`, and a local run of the same tier failed on the same test. Two defects, both in the new code:

1. **The breaker blocked the recovery road.** When a `daemon refresh` replacement fails to launch, `snapshot-rollback.ts` makes one deliberate attempt to restore service. That attempt goes through autostart, and the failed replacement had just charged the breaker — so a 2 s backoff refused it and the endpoint was left unserved. A mechanism added to stop an unbounded respawn chain had broken a bounded, deliberate recovery. The restoration now clears that socket's breaker state first; it is one control-initiated attempt, not a loop.
2. **The refusal text misreported its own state.** It said `stopped autostarting after 1 consecutive daemon startup failures ... (limit 5)` while also saying it would retry in 2 s — claiming to have given up while still backing off. In a change whose entire point is that error text must not mislead, that could not stand. Backoff and an open breaker are now separate messages: `DAEMON_AUTOSTART_BACKOFF` says how long it is waiting and that it has not given up; `DAEMON_AUTOSTART_CIRCUIT_OPEN` is emitted only once the failure limit is actually reached. A new case in `daemon-autostart-circuit.test.ts` pins both, including that neither message contains the other's claim.

## Task And Scope

- Harness task: `task_01KZGA6907T8ZVBWVC3NGXXS46`
- Branch: `codex/daemon-lifecycle-circuit`
- Public scope: three new source files in `packages/daemon/src/client` and `packages/cli/src/daemon`, plus `error-codes.ts`, `control.ts`, `client.ts`, `local-json-rpc-client.ts`, `daemon-autostart-process.ts`, `packages/daemon/src/index.ts`; four new test files and three updated ones
- Private planning/evidence updated: yes
- Out of scope: writer-child startup heartbeat (see Residual Risk); the root-resolution error code, which landed separately in #1285

## Version Impact

- Version: no version change because this is a behavior fix inside existing packages, with no published entrypoint added or removed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KZGA6907T8ZVBWVC3NGXXS46`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `26379d0ceab45123a2303f1a7169920e692cd7b0`
- Branch merge-base with `origin/main`: `26379d0ceab45123a2303f1a7169920e692cd7b0`
- Last `git fetch origin` time: 2026-08-08, immediately before the rebase that produced `b8fbd64f` (the fix commit `340cc432` sits on top)
- Sync method: rebase
- Public diff command: `git diff 26379d0ceab45123a2303f1a7169920e692cd7b0..340cc432 -- packages/`
- Private evidence commit/path: `harness/tasks/task_01KZGA6907T8ZVBWVC3NGXXS46-daemon-daemon-unavailable-restart/artifacts/report-glm-daemon-lifecycle.md`
- Reviewer evidence path: same report
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` — `npm run check:local`, 27 manifest gates green in 107.1s, after the rebase onto `26379d0c`
- [x] Targeted tests for the change surface, named with their counts: 20 new cases across four files — `daemon-autostart-circuit.test.ts` (9, fast), `daemon-autostart-circuit-resurrection.test.ts` (2, integration), `daemon-lifecycle-honesty.test.ts` (6, fast), `daemon-restart-starting-guard.test.ts` (3, fast). The resurrection test pins `spawnCalls == 1` across two requests where the old code spawned twice.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: `npm run check:ci` was not run locally; CI is the authoritative full gate for the 31 gates outside the local stop point.

### A note on where these gates were run

The first `check:local` attempt for this branch was run in the `daemon-lifecycle-circuit` worktree and failed 7 `doc sync` tests plus one `packages/daemon` test, all with `better_sqlite3.node ... NODE_MODULE_VERSION 147 ... requires 137`. Checking out `origin/main` in that same worktree and re-running reproduced the identical 7 failures, so they are that worktree's seeded `node_modules`, not this change. The gates reported above were then run on the branch in a worktree whose native module loads correctly, and passed.

## Review Evidence

- Self-review: read the rendered text of all three states and the restart guard, and asked of each "what does an agent do if it follows this?" — `daemon_starting` leads to waiting and polling, `daemon_not_present` leads to `ha daemon start --service` after the process is confirmed dead, and the open breaker leads to reading the launch log. None leads to killing a live daemon.
- Reviewer subagent: this branch and #1285 both modified `worktree-root-resolution-cli.test.ts` and `client.ts`. The conflict was adjudicated rather than auto-resolved: #1285's early interception of `CliRootResolutionError` is kept, this branch's relocation of `daemonUnavailableReceipt` into the classification module is kept, and the now-unreachable root-resolution branch inside that function was removed — it would otherwise have re-emitted the `daemon_unavailable` code that #1285 exists to stop emitting.
- Human review: pending
- Blocking findings: one, described above — the breaker blocked the deliberate restoration path and misreported backoff as having given up. Caught by `integration-shard (1)` on run 31264361478 and reproduced locally; fixed in `340cc432`.

## Residual Risk

- **Writer-child startup heartbeat is still missing.** Before READY, the client can only infer progress from pid liveness. A daemon that is genuinely wedged — pid alive, writer spinning — is reported as `daemon_starting` forever. The protocol already has a `telemetry` frame and the client already has a `proceededStallTimeoutMs` field; making the writer emit progress during `runtime.start()` and switching the client from a total timeout to a stall timeout is the real fix and needs its own task.
- The restart guard is best-effort by design: when `probeEndpointOwner` returns undefined it allows the restart.
- Liveness classification is point-in-time. Under the very short timeouts used in tests the pid is always still alive, so tests see `daemon_starting`; that is honest, but it means the tests do not exercise the `daemon_not_present` path via a real timeout.
- Any downstream that matched `daemon_unavailable` to detect "autostart timed out" will now see `daemon_starting` or `daemon_not_present`. Intentional, and the reason the old text was harmful.

## References

- Task: `task_01KZGA6907T8ZVBWVC3NGXXS46`
- Evidence: `harness/tasks/task_01KZGA6907T8ZVBWVC3NGXXS46-daemon-daemon-unavailable-restart/artifacts/report-glm-daemon-lifecycle.md`
- Review: https://github.com/FairladyZ625/harness-anything/pull/1285 (the root-resolution half of the same incident)

---

# 中文

## 概要

今天一个 agent 的 `ha task create` 启动很慢。客户端报了 `daemon_unavailable`，并建议 `ha daemon restart`。agent 照做，杀掉了一个健康、正处在冷启动中的 daemon。与此同时 GUI 开发脚手架不断重发请求，每次请求都再拉起一个 daemon，于是这台机器一边喂着复活链，一边那个原始进程还在加载账本。

两个缺陷，本 PR 都修了：

1. **客户端在说谎。** 30 秒 autostart 超时被当成死亡。它不是：大账本上 writer 要 60–90 秒才加载完。客户端现在检查被拉起的 pid 是否还活着，用三种诚实状态回答，而不是一种错的。
2. **复活链没有任何界。** autostart 现在记住自己拉起的那个 pid；后续请求 join 这个活 pid 而不是再拉一个兄弟进程，只有真正的 pid 死亡才计入熔断器。

**错误文案是承重的那一环。** `daemon_starting` 绝不建议 `ha daemon restart`，也绝不建议 `HARNESS_DAEMON_MODE=direct` —— 今天摧毁那个正在恢复的 daemon 的正是这两个动作。照新文案做的 agent 会等待并轮询。

## 改动内容

- `packages/daemon/src/client/daemon-autostart-circuit.ts`（新增）：per-socket 连续死亡熔断。活着的 spawned pid 不计为失败，只有真正退出的 pid 才计。连续 5 次死亡后打开（`HARNESS_DAEMON_AUTOSTART_MAX_FAILURES`），指数退避（base 2 s，cap 30 s，均可 env 调），首次成功启动即复位。
- `packages/daemon/src/client/daemon-autostart-flight.ts`（新增）：活 pid join。autostart 按 socket 记录拉起的 pid，下一次请求 probe/等待这个 pid，而不是拉兄弟进程。
- `packages/cli/src/daemon/daemon-lifecycle-classification.ts`（新增）：把抛出的错误映射为 `daemon_starting`（超时但 pid 活着）、`daemon_not_present`（进程已退出，或超时且 pid 已死，或 `ECONNREFUSED` / socket 无主）、`daemon_unavailable`（其余，含熔断打开）。
- `packages/cli/src/cli/error-codes.ts`：新增 `daemon_starting` 与 `daemon_not_present`。只增不改，既有条目未编辑也未删除。
- `packages/cli/src/commands/daemon/control.ts`：`ha daemon restart` 现在在发出 RPC **之前**就拒绝 —— 当一个活 pid 占有 socket 但尚未提供 status 时，也就是今天杀掉恢复中 daemon 的那个动作。设计为 best-effort：判不出所有权时放行，以免误拒合法 restart；硬保证在熔断器那边。
- `packages/daemon/src/client/{local-json-rpc-client,daemon-autostart-process}.ts`、`packages/daemon/src/index.ts`：接入 flight manager，导出新符号。

钉住该状态的测试给出的 `daemon_starting` 真实输出：

```
code: daemon_starting
hint: The daemon is still starting (spawned pid 58693 is alive; waited 30s). Cold start on a
large ledger can take 60-90s as the writer loads. Do NOT run 'ha daemon restart' — that kills
this recovering daemon. Do NOT use HARNESS_DAEMON_MODE=direct — that bypasses the single-writer
fence. Wait, then poll 'ha daemon status --json' until it reports ready. …
```

产品里每一次 daemon 拉起都走同一条 autostart 路径 —— `packages/gui/scripts/dev-electron.mjs` 与 `packages/gui/src/main/electron-main.ts` 自身并不 spawn daemon —— 所以熔断器同样保护 GUI 开发脚手架，而今天那条链正是从那里来的。

### 关于 30 秒超时

超时值未改。调大它是治标：客户端仍然只是在用「过了多久」猜。真正的修法是 `DaemonAutostartTimeoutError` 现在带上 `spawnedPid`，由**存活性**而非耗时来判断 daemon 是否已死。它留下的更深一刀见「残留风险」。


### 熔断器自己引入、并在本分支修掉的一个缺陷

第一次推送后 `integration-shard (1)` 红在 `restart replacement launch failure restores a reachable daemon`，本地同一 tier 也红在同一条。两个缺陷，都在新代码里：

1. **熔断器把恢复的路堵了。** `daemon refresh` 的替身启动失败后，`snapshot-rollback.ts` 会做**一次**刻意的服务恢复尝试。这次尝试走 autostart，而刚失败的那次替身启动正好给熔断器记了一笔 —— 于是 2 秒退避把它拒了，端点无人服务。一个为阻止无界复活链而加的机制，反而打断了有界的、刻意发起的恢复。现在恢复前先清掉该 socket 的熔断状态；它是一次由控制操作发起的尝试，不是循环。
2. **拒绝文案误报了自己的状态。** 它一边说 `stopped autostarting after 1 consecutive daemon startup failures ... (limit 5)`，一边又说 2 秒后会重试 —— 明明还在退避却声称已经放弃。在一个主旨就是「错误文案不许误导」的改动里，这不能留。退避与熔断打开现在是两条不同的消息：`DAEMON_AUTOSTART_BACKOFF` 说明还要等多久、并声明尚未放弃；`DAEMON_AUTOSTART_CIRCUIT_OPEN` 只在真正达到失败上限后才发出。`daemon-autostart-circuit.test.ts` 新增一条用例把两者都钉住，包括「任一消息不得含有另一方的主张」。

## 任务与范围

- Harness task：`task_01KZGA6907T8ZVBWVC3NGXXS46`
- 分支：`codex/daemon-lifecycle-circuit`
- 公开范围：`packages/daemon/src/client` 与 `packages/cli/src/daemon` 下三个新源文件，加上 `error-codes.ts`、`control.ts`、`client.ts`、`local-json-rpc-client.ts`、`daemon-autostart-process.ts`、`packages/daemon/src/index.ts`；四个新测试文件与三个被更新的测试文件
- 私有规划/证据已更新：是
- 不在范围内：writer child 启动期心跳（见残留风险）；root-resolution 错误码，已随 #1285 单独落地

## 版本影响

- 版本：无变更，因为这是既有 package 内的行为修复，未增删任何已发布入口
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：`task_01KZGA6907T8ZVBWVC3NGXXS46`
- 机检边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`26379d0ceab45123a2303f1a7169920e692cd7b0`
- 分支与 `origin/main` 的 merge-base：`26379d0ceab45123a2303f1a7169920e692cd7b0`
- 最近一次 `git fetch origin`：2026-08-08，就在产出 `b8fbd64f` 的那次 rebase 之前（修复 commit `340cc432` 叠在其上）
- 同步方式：rebase
- 公开 diff 命令：`git diff 26379d0ceab45123a2303f1a7169920e692cd7b0..340cc432 -- packages/`
- 私有证据 commit/路径：`harness/tasks/task_01KZGA6907T8ZVBWVC3NGXXS46-daemon-daemon-unavailable-restart/artifacts/report-glm-daemon-lifecycle.md`
- 评审证据路径：同一份报告
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑
- [x] `git diff --check`
- [x] `npm run check:stop-point` —— `npm run check:local`，27 个 manifest 门绿，107.1s，在 rebase 到 `26379d0c` 之后
- [x] 针对改动面的定向测试及计数：四个文件共 20 个新用例 —— `daemon-autostart-circuit.test.ts`（9，fast）、`daemon-autostart-circuit-resurrection.test.ts`（2，integration）、`daemon-lifecycle-honesty.test.ts`（6，fast）、`daemon-restart-starting-guard.test.ts`（3，fast）。resurrection 那条在两次请求间钉住 `spawnCalls == 1`，旧代码在此会 spawn 两次。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威的完整门）
- 未跑及原因：本地未跑 `npm run check:ci`；本地停止点之外的 31 个门以 CI 为权威。

### 关于这些门是在哪儿跑的

本分支第一次跑 `check:local` 是在 `daemon-lifecycle-circuit` 那棵 worktree 里，红了 7 条 `doc sync` 测试外加一条 `packages/daemon` 测试，报错一律是 `better_sqlite3.node ... NODE_MODULE_VERSION 147 ... requires 137`。在同一棵 worktree 里检出 `origin/main` 重跑，复现出**完全相同的 7 条失败**，所以那是该 worktree 播种进来的 `node_modules` 的问题，不是本改动。上面报告的门随后在一棵原生模块能正常加载的 worktree 上对本分支重跑，通过。

## 评审证据

- 自审：读了三种状态与 restart 守卫的渲染文本，对每一条都问「agent 照做会怎样」—— `daemon_starting` 导向等待与轮询，`daemon_not_present` 在进程确认已死后导向 `ha daemon start --service`，熔断打开导向去读 launch log。没有一条会导向杀死一个活着的 daemon。
- 评审子代理：本分支与 #1285 都改了 `worktree-root-resolution-cli.test.ts` 与 `client.ts`。冲突是**裁决**的而非自动合的：保留 #1285 对 `CliRootResolutionError` 的提前拦截，保留本分支把 `daemonUnavailableReceipt` 搬进分类模块，并删掉该函数内已不可达的 root-resolution 分支 —— 否则它会重新发出 #1285 存在的意义正是要停止发出的那个 `daemon_unavailable` 码。
- 人工评审：待办
- 阻断性发现：一条，见上文 —— 熔断器堵住了刻意发起的恢复路径，并把退避误报成已放弃。由 run 31264361478 的 `integration-shard (1)` 抓到并在本地复现；已在 `340cc432` 修复。

## 残留风险

- **writer child 启动期心跳仍然缺失。** READY 之前，客户端只能靠 pid 存活推断进展。一个真正卡死的 daemon —— pid 活着、writer 空转 —— 会被永远报成 `daemon_starting`。协议已有 `telemetry` frame，客户端也已有 `proceededStallTimeoutMs` 字段；让 writer 在 `runtime.start()` 期间发出进展、并把客户端从总时长超时改为停滞超时，才是真正的修法，需要单开任务。
- restart 守卫按设计是 best-effort：`probeEndpointOwner` 返回 undefined 时放行。
- 存活性分类是 point-in-time。测试里用的极短超时下 pid 必然还活着，所以测试看到的是 `daemon_starting`；这是诚实的，但也意味着测试没有通过真实超时走过 `daemon_not_present` 那条路。
- 任何靠匹配 `daemon_unavailable` 来识别「autostart 超时」的下游，现在会看到 `daemon_starting` 或 `daemon_not_present`。这是有意为之，也正是旧文案有害的原因。

## 参考

- Task：`task_01KZGA6907T8ZVBWVC3NGXXS46`
- 证据：`harness/tasks/task_01KZGA6907T8ZVBWVC3NGXXS46-daemon-daemon-unavailable-restart/artifacts/report-glm-daemon-lifecycle.md`
- 评审：https://github.com/FairladyZ625/harness-anything/pull/1285（同一起事故的 root-resolution 那一半）
