### PR TITLE
feat(cli): report repo-write child pre-READY phase timings

### DIFF
--- a/packages/cli/src/composition/repo-write-child-entrypoint.ts
+++ b/packages/cli/src/composition/repo-write-child-entrypoint.ts
@@ -59,11 +59,18 @@ function remainingStartupRecoveryBudgetMs(): number {
 export async function runRepoWriteChildEntrypoint(
   encodedConfig: string | undefined
 ): Promise<void> {
+  // The parent kills this child when it does not announce READY inside
+  // readyTimeoutMs. Without per-phase evidence a timeout is undiagnosable from
+  // outside the process, so every startup phase reports its own cost on stderr,
+  // which the launcher already captures next to the timeout stack.
+  const startupPhase = makeRepoWriteChildStartupPhaseReporter();
   if (!encodedConfig) throw new Error("REPO_WRITE_CHILD_LAUNCH_CONFIG_REQUIRED");
   const config = decodeRepoWriteChildLaunchConfig(encodedConfig);
+  startupPhase.mark("decode-launch-config");
   const entrypointArtifactIdentity = calculateDaemonArtifactIdentity(
     process.argv[1] ?? ""
   ).identity;
+  startupPhase.mark("artifact-identity");
   if (entrypointArtifactIdentity !== config.entrypointArtifactIdentity) {
     throw new Error("REPO_WRITE_CHILD_ENTRYPOINT_ARTIFACT_MISMATCH");
   }
@@ -73,6 +80,7 @@ export async function runRepoWriteChildEntrypoint(
       && canonicalExistingRoot(repo.canonicalRoot) === canonicalExistingRoot(config.canonicalRoot)
   );
   if (!authorityRepo) throw new Error("REPO_WRITE_CHILD_REPO_NOT_CONFIGURED");
+  startupPhase.mark("load-authority-manifest");
 
   const layoutOverrides = config.authoredRoot
     ? { authoredRoot: config.authoredRoot }
@@ -84,6 +92,7 @@ export async function runRepoWriteChildEntrypoint(
   // Establish the generation baseline before the child advertises readiness so
   // no request pays for a full authored-tree conflict-marker scan.
   conflictMarkerPreflight.read();
+  startupPhase.mark("conflict-marker-preflight");
   const witness = createDaemonGenerationWitness({
     userRoot: config.userRoot,
     endpointIdentity: config.endpointIdentity,
@@ -127,7 +136,9 @@ export async function runRepoWriteChildEntrypoint(
     }
   });
   runtimeBox.current = runtime;
+  startupPhase.mark("create-daemon-runtime");
   await runtime.start();
+  startupPhase.mark("runtime-start");
 
   const outcomes = new DurableRepoWriteOutcomeStoreV1({
     directory: path.join(
@@ -181,7 +192,9 @@ export async function runRepoWriteChildEntrypoint(
     repoId: config.repoId,
     canonicalRoot: config.canonicalRoot
   };
+  startupPhase.mark("compose-authority-lifecycle");
   const started = await authorityLifecycle.startRepo(repo, lifecycleRuntime);
+  startupPhase.mark("authority-start-repo");
   if (!started.ok) {
     await runtime.stop();
     throw new Error(started.error);
@@ -195,12 +208,18 @@ export async function runRepoWriteChildEntrypoint(
   const transport = new RepoWriteChildIpcTransport();
   const startupRecoveryBudgetMs = remainingStartupRecoveryBudgetMs();
   const startupRecoveryDeadline = Date.now() + startupRecoveryBudgetMs;
+  const historicalProceedings = outcomes.listHistoricalProceedings();
+  startupPhase.mark("list-historical-proceedings", {
+    proceedingCount: historicalProceedings.length
+  });
   let proceedingsLeftByBudget = 0;
-  for (const proceeding of outcomes.listHistoricalProceedings()) {
+  let recoveredProceedings = 0;
+  for (const proceeding of historicalProceedings) {
     if (Date.now() >= startupRecoveryDeadline) {
       proceedingsLeftByBudget += 1;
       continue;
     }
+    const proceedingStartedAt = startupPhase.now();
     try {
       const recovery = await recoveryGate.recoverHistoricalProceeding(proceeding);
       if (recovery.disposition === "permanently-rejected") {
@@ -231,7 +250,15 @@ export async function runRepoWriteChildEntrypoint(
         diagnostic: boundedRecoveryError(error)
       });
     }
+    recoveredProceedings += 1;
+    startupPhase.observeProceeding(proceedingStartedAt);
   }
+  startupPhase.mark("historical-recovery-loop", {
+    proceedingCount: recoveredProceedings,
+    slowestProceedingMs: startupPhase.slowestProceedingMs(),
+    budgetMs: startupRecoveryBudgetMs,
+    leftByBudget: proceedingsLeftByBudget
+  });
   if (proceedingsLeftByBudget > 0) {
     process.stderr.write(
       `[repo-write-child] repo=${config.repoId} left ${proceedingsLeftByBudget} historical `
@@ -343,11 +370,68 @@ export async function runRepoWriteChildEntrypoint(
     transport.onDisconnect(() => {
       void cleanup().then(resolve, reject);
     });
-    void childHost.start().catch(async (error: unknown) => {
+    void childHost.start().then(() => {
+      startupPhase.mark("child-host-start-ready");
+      startupPhase.reportTotal();
+    }).catch(async (error: unknown) => {
       await cleanup().catch(() => undefined);
       reject(error);
     });
   });
+}
+
+interface RepoWriteChildStartupPhaseReporter {
+  readonly now: () => number;
+  readonly mark: (phase: string, detail?: Record<string, number>) => void;
+  readonly observeProceeding: (startedAt: number) => void;
+  readonly slowestProceedingMs: () => number;
+  readonly reportTotal: () => void;
+}
+
+/**
+ * Emits one NDJSON frame per pre-READY phase on stderr. The daemon launcher
+ * already persists child stderr beside the READY-timeout stack, so a timeout
+ * carries its own phase breakdown instead of requiring a live reproduction.
+ */
+function makeRepoWriteChildStartupPhaseReporter(): RepoWriteChildStartupPhaseReporter {
+  const startedAt = performance.now();
+  let previous = startedAt;
+  let slowestProceedingMs = 0;
+  const emit = (frame: Record<string, unknown>) => {
+    try {
+      process.stderr.write(`${JSON.stringify({
+        schema: "repo-write-child-startup-phase/v1",
+        pid: process.pid,
+        ...frame
+      })}\n`);
+    } catch {
+      // Startup diagnostics must never take the writer child down.
+    }
+  };
+  return {
+    now: () => performance.now(),
+    mark: (phase, detail) => {
+      const at = performance.now();
+      emit({
+        phase,
+        phaseMs: Math.round(at - previous),
+        sinceEntrypointMs: Math.round(at - startedAt),
+        ...(detail ?? {})
+      });
+      previous = at;
+    },
+    observeProceeding: (proceedingStartedAt) => {
+      slowestProceedingMs = Math.max(
+        slowestProceedingMs,
+        Math.round(performance.now() - proceedingStartedAt)
+      );
+    },
+    slowestProceedingMs: () => slowestProceedingMs,
+    reportTotal: () => emit({
+      phase: "ready",
+      sinceEntrypointMs: Math.round(performance.now() - startedAt)
+    })
+  };
 }
 
 function canonicalExistingRoot(rootDir: string): string {


### PR DESCRIPTION
## Summary

The pre-READY path of the repo-write child had **zero instrumentation**, which is why a 20–30s stall inside it was undiagnosable from outside the process: the only signal was a `RepoWriteReadyTimeoutError` stack with no breakdown of where the time went. This adds per-phase timing frames so the next timeout explains itself.

It also settles what the time actually was. Phase measurement on a real forked child shows **everything except the historical-recovery loop costs ~0.70s** — so the observed 20–30s is the loop, not setup. The loop's cost is dominated by iterations that *succeed*: failures each write a `recovery-deferred` log (~0.5s apiece) while successes write nothing at all, which is exactly why the stall looked like an unexplained prelude.

**Stacked on #1286** (same file, adjacent lines). Merge #1286 first; this branch is rebased on top of it and its diff against `main` will collapse to just the instrumentation once that lands.

## What Changed

- `packages/cli/src/composition/repo-write-child-entrypoint.ts`: added `makeRepoWriteChildStartupPhaseReporter()` and 11 `mark()` call sites covering every pre-READY phase, plus per-proceeding observation inside the recovery loop (`proceedingCount`, `slowestProceedingMs`).
- Frames are one NDJSON line each on **stderr**, schema `repo-write-child-startup-phase/v1`. The launcher already persists child stderr into `~/.harness/logs/daemon-startup/launch-*.stderr.log`, right next to the timeout stack — so the next timeout carries its own phase breakdown with no live reproduction needed.
- The emitter is wrapped in `try/catch`: startup diagnostics must never take the writer child down.
- Merged with #1286's budget during rebase: the `historical-recovery-loop` frame now also carries `budgetMs` and `leftByBudget`, so a truncated recovery round is visible as data rather than only as a stderr sentence.

## Version Impact

- Version: no version change because this is diagnostic instrumentation on an internal daemon path with no published surface change.

## Verification

- [x] `npm run check:local` — local stop point, green in 282.3s after the rebase: 27 manifest gates green.
- [x] `packages/cli/test/repo-write-child-production-cutover.test.ts` (integration tier, the only test that forks this entrypoint) — 4/4 with phase frames visible in child stderr.
- [x] Instrumented daemon run for real in an isolated scratch environment (own socket, own `--user-root`, own single-repo authority manifest, `cp -Rc` clone of the repo and authority state). Production daemons were never touched.
- [ ] `npm test` / `npm run check` — Not run: full matrix is CI's job per `harness/AGENTS.md`.
- Not run: the broader `--tier integration --prefix packages/cli` sweep was interrupted by the shell harness (exit 144) before reporting a summary; no failing assertion appeared in the output it did produce, but that sweep is **not** part of the verified set.

Measured phase table from the instrumented run:

| phase | Δ ms | cumulative ms |
|---|---:|---:|
| `artifact-identity` (1048 dist files) | 47 | 48 |
| `conflict-marker-preflight` | 315 | 363 |
| `create-daemon-runtime` | 43 | 407 |
| `runtime-start` | 247 | 653 |
| `authority-start-repo` | 43 | 699 |
| `ready` | — | **708** |

## Review Evidence

- Self-review: confirmed the emitter cannot throw into the startup path, and that no frame carries repository content — only phase names, durations, counts, and pid.
- Additional review: pending.
- Blocking findings: none.

## Residual Risk

- The `~3.5s per successful recovery iteration` figure quoted in #1286's discussion is **arithmetic from two measured quantities, not a stopwatch reading**: the isolated repro reported `proceedingCount: 0`, so the loop never executed there. Forcing it would have required writing to production authority state or fabricating proceedings, both judged out of bounds. **This instrumentation is what will produce that number directly on the next real restart.**
- Instrumentation only makes the cost visible; it does not reduce it. The durable fix is moving historical recovery off the pre-READY path — proposed separately as `dec_01KZJ1633T8TWH5TFPRTKEKGED`.

## References

- Task: task_01KZGYV22SGZ2MPCBR5JW741FT
- Decision: dec_01KZJ1633T8TWH5TFPRTKEKGED (move historical recovery off the pre-READY path)
- Stacked on: #1286

---

## 摘要

repo-write child 的 pre-READY 路径此前**完全没有插桩**，这正是它内部 20–30 秒的停顿从进程外无法诊断的原因：唯一的信号是一条 `RepoWriteReadyTimeoutError` 堆栈，不含任何耗时分解。本 PR 加上阶段级计时帧，让下一次超时能自己解释自己。

它同时也定案了那段时间究竟是什么。在真实 fork 出的 child 上做阶段测量后显示：**除 historical-recovery 循环之外的一切只花费约 0.70 秒**——所以观察到的 20–30 秒是循环本身，不是启动准备。循环的开销由*成功*的迭代主导：失败的每次会写一条 `recovery-deferred` 日志（各约 0.5 秒），而成功的一行都不写，这恰恰是那段停顿看起来像「无法解释的前奏」的原因。

**本 PR 叠在 #1286 之上**（同文件、相邻行）。请先合 #1286；本分支已 rebase 在其之上，待其合入后本分支对 `main` 的 diff 将收敛为纯插桩。

## 改动内容

- `packages/cli/src/composition/repo-write-child-entrypoint.ts`：新增 `makeRepoWriteChildStartupPhaseReporter()` 与 11 个 `mark()` 调用点，覆盖每个 pre-READY 阶段，并在恢复循环内做逐 proceeding 观测（`proceedingCount`、`slowestProceedingMs`）。
- 每帧是 **stderr** 上的一行 NDJSON，schema 为 `repo-write-child-startup-phase/v1`。launcher 本来就会把 child stderr 持久化到 `~/.harness/logs/daemon-startup/launch-*.stderr.log`，恰好与超时堆栈相邻——因此下一次超时会自带阶段分解，无需在线复现。
- 发射器包在 `try/catch` 中：启动诊断绝不允许拖垮 writer child。
- rebase 时与 #1286 的预算合并：`historical-recovery-loop` 帧现在还带上 `budgetMs` 与 `leftByBudget`，使被预算截断的恢复轮次成为可读数据，而不只是一句 stderr 文本。

## 版本影响

- 版本：不改版本，原因是这是 daemon 内部路径上的诊断插桩，不改变任何发布面。

## 验证

- [x] `npm run check:local` —— 本地停止点，rebase 后 282.3 秒全绿：27 个 manifest gate 绿。
- [x] `packages/cli/test/repo-write-child-production-cutover.test.ts`（integration tier，唯一会 fork 该入口的测试）—— 4/4 通过，且 child stderr 中可见 phase 帧。
- [x] 在隔离的临时环境中真实运行了插桩后的 daemon（独立 socket、独立 `--user-root`、独立单仓 authority manifest、`cp -Rc` 克隆的仓库与 authority 状态）。全程未触碰生产 daemon。
- [ ] `npm test` / `npm run check` —— 未运行：按 `harness/AGENTS.md`，完整门矩阵是 CI 的活。
- 未运行：更大范围的 `--tier integration --prefix packages/cli` 扫描被 shell harness 中断（exit 144），未输出汇总；已产生的输出中没有出现失败断言，但该扫描**不属于**已验证集合。

插桩运行实测的阶段表：

| 阶段 | Δ 毫秒 | 累计毫秒 |
|---|---:|---:|
| `artifact-identity`（1048 个 dist 文件） | 47 | 48 |
| `conflict-marker-preflight` | 315 | 363 |
| `create-daemon-runtime` | 43 | 407 |
| `runtime-start` | 247 | 653 |
| `authority-start-repo` | 43 | 699 |
| `ready` | — | **708** |

## 审查证据

- 自查：确认发射器不会向启动路径抛出异常，且没有任何帧携带仓库内容——只有阶段名、耗时、计数与 pid。
- 额外审查：待补。
- 阻塞发现：无。

## 残余风险

- #1286 讨论中引用的「每次成功恢复迭代约 3.5 秒」是**两个实测量的算术推导，不是秒表读数**：隔离复现报告 `proceedingCount: 0`，循环在那里从未执行。要强行触发它，就得写入生产 authority 状态或伪造 proceeding，两者均判定越界。**本插桩正是用来在下一次真实重启时直接产出该数字的。**
- 插桩只让开销可见，并不减少开销。根治办法是把 historical recovery 移出 pre-READY 路径，已单独提案为 `dec_01KZJ1633T8TWH5TFPRTKEKGED`。

## 关联材料

- 任务：task_01KZGYV22SGZ2MPCBR5JW741FT
- 决策：dec_01KZJ1633T8TWH5TFPRTKEKGED（历史恢复移出 pre-READY 路径）
- 叠加于：#1286
