### PR TITLE
fix(doc-sync): open the consumer artifacts write road and stop silent artifact reuse

### DIFF
--- a/packages/cli/src/daemon/artifact-ingest.ts
+++ b/packages/cli/src/daemon/artifact-ingest.ts
@@ -90,7 +90,16 @@ export function buildArtifactIngestPlan(input: {
         const portable = portablePathRelative(layout.authoredRoot, source.absolutePath);
         rewrittenByInput.set(source.sourceInput, portable);
         targetPaths.push(portable);
-        reusedPaths.push(portable);
+        const publishedBody = gitBlob(layout.authoredRoot, portable);
+        // Being under version control means the path was published once, not that the
+        // current content was. Republish whenever the working tree diverges from HEAD;
+        // a body of null is a non-UTF-8 artifact this text-only route cannot resubmit.
+        if (source.body === null || publishedBody === source.body) {
+          reusedPaths.push(portable);
+          continue;
+        }
+        changes.push(docSyncChange(portable, source.body, publishedBody === null ? null : sha256Text(publishedBody)));
+        submittedPaths.push(portable);
         continue;
       }
       const name = path.basename(source.absolutePath);
@@ -314,7 +323,11 @@ export function remoteArtifactSafetyReceipt(command: ParsedCommand, repoId: stri
   return receipt;
 }
 
-function classifySource(input: { readonly sourceInput: string; readonly cwd: string; readonly rootDir: string; readonly authoredRoot: string }) {
+type ClassifiedArtifactSource =
+  | { readonly sourceInput: string; readonly absolutePath: string; readonly tracked: true; readonly body: string | null }
+  | { readonly sourceInput: string; readonly absolutePath: string; readonly tracked: false; readonly body: string };
+
+function classifySource(input: { readonly sourceInput: string; readonly cwd: string; readonly rootDir: string; readonly authoredRoot: string }): ClassifiedArtifactSource {
   const absolutePath = resolveSource(input.sourceInput, input.cwd, input.rootDir, input.authoredRoot);
   if (!existsSync(absolutePath)) throw readFailure(`Evidence file does not exist: ${input.sourceInput}.`);
   let sourceStat: ReturnType<typeof statSync>;
@@ -324,8 +337,14 @@ function classifySource(input: { readonly sourceInput: string; readonly cwd: str
   if (!isHarnessInternal(absolutePath, input.rootDir)) {
     throw readFailure(`Evidence artifact is outside this harness repository: ${input.sourceInput}. Move it into the repository or task package before retrying.`);
   }
-  const tracked = isGitTracked(absolutePath);
-  return { sourceInput: input.sourceInput, absolutePath, tracked, body: tracked ? "" : readUtf8(absolutePath, input.sourceInput) };
+  return isGitTracked(absolutePath)
+    ? { sourceInput: input.sourceInput, absolutePath, tracked: true, body: optionalUtf8(absolutePath) }
+    : { sourceInput: input.sourceInput, absolutePath, tracked: false, body: readUtf8(absolutePath, input.sourceInput) };
+}
+
+function optionalUtf8(absolutePath: string): string | null {
+  try { return readUtf8(absolutePath, absolutePath); }
+  catch { return null; }
 }
 
 function readUtf8(absolutePath: string, displayPath: string): string {
@@ -363,10 +382,14 @@ function artifactRequest(input: {
   };
 }
 
-function docSyncChange(portablePath: string, body: string): DocSyncSubmitRequestV1["payload"]["changes"][number] {
+function docSyncChange(
+  portablePath: string,
+  body: string,
+  baseBlobSha256: string | null = null
+): DocSyncSubmitRequestV1["payload"]["changes"][number] {
   return {
     path: portablePath,
-    baseBlobSha256: null,
+    baseBlobSha256,
     newBlobSha256: sha256Text(body),
     mediaType: mediaTypeFor(portablePath),
     size: Buffer.byteLength(body),

--- a/packages/cli/test/artifact-ingest-plan.test.ts
+++ b/packages/cli/test/artifact-ingest-plan.test.ts
@@ -5,6 +5,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { sha256Text } from "@harness-anything/kernel";
 import { buildArtifactIngestPlan, ArtifactIngestError, normalizeProgressAfterArtifact, portableGitPathRelative, progressRetryCommand } from "../src/daemon/artifact-ingest.ts";
 import { CliErrorCode, cliError } from "../src/cli/error-codes.ts";
 import { toCommandReceipt } from "../src/cli/receipt.ts";
@@ -79,6 +80,45 @@ test("artifact planner reuses an identical committed artifact so a failed progre
   assert.ok(plan);
   assert.equal(plan.request, null);
   assert.deepEqual(plan.reusedPaths, [`tasks/${taskId}/artifacts/retry.txt`]);
+}));
+
+test("artifact add republishes a tracked task artifact whose working tree content changed", () => withFixture(({ rootDir, harnessRoot, taskId }) => {
+  const target = seedPublishedArtifact(harnessRoot, taskId, "report.md", "# first\n");
+  const updated = "# first\n\n## added section\n";
+  writeFileSync(target, updated, "utf8");
+  const plan = buildArtifactIngestPlan({ command: artifactCommand(rootDir, taskId, target), repoId: "canonical", cwd: rootDir });
+  const portable = `tasks/${taskId}/artifacts/report.md`;
+  assert.ok(plan?.request, "a changed tracked artifact must produce a doc-sync submit request");
+  assert.deepEqual(plan.submittedPaths, [portable]);
+  assert.deepEqual(plan.reusedPaths, []);
+  const change = plan.request.payload.changes[0];
+  assert.equal(change?.path, portable);
+  assert.equal(change?.content.kind === "inline" ? change.content.body : null, updated);
+  // Submit rejects with base_blob_changed unless the base names the current HEAD body.
+  assert.equal(change?.baseBlobSha256, sha256Text("# first\n"));
+  assert.equal(change?.newBlobSha256, sha256Text(updated));
+}));
+
+test("artifact add still reuses a tracked task artifact whose content already matches HEAD", () => withFixture(({ rootDir, harnessRoot, taskId }) => {
+  const target = seedPublishedArtifact(harnessRoot, taskId, "stable.md", "# unchanged\n");
+  const plan = buildArtifactIngestPlan({ command: artifactCommand(rootDir, taskId, target), repoId: "canonical", cwd: rootDir });
+  assert.ok(plan);
+  assert.equal(plan.request, null);
+  assert.deepEqual(plan.reusedPaths, [`tasks/${taskId}/artifacts/stable.md`]);
+  assert.deepEqual(plan.submittedPaths, []);
+}));
+
+test("artifact add keeps reusing a tracked binary artifact instead of failing on UTF-8", () => withFixture(({ rootDir, harnessRoot, taskId }) => {
+  const target = path.join(harnessRoot, "tasks", taskId, "artifacts", "capture.bin");
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, Buffer.from([0xff, 0x00, 0xfe]));
+  git(harnessRoot, "add", ".");
+  git(harnessRoot, "commit", "-m", "seed published binary artifact");
+  writeFileSync(target, Buffer.from([0xff, 0x00, 0xfd]));
+  const plan = buildArtifactIngestPlan({ command: artifactCommand(rootDir, taskId, target), repoId: "canonical", cwd: rootDir });
+  assert.ok(plan);
+  assert.equal(plan.request, null);
+  assert.deepEqual(plan.reusedPaths, [`tasks/${taskId}/artifacts/capture.bin`]);
 }));
 
 test("progress failure reports the retained governed artifact and an exact retry command", () => withFixture(({ rootDir, taskId }) => {
@@ -167,6 +207,15 @@ function withFixture(run: (fixture: { readonly rootDir: string; readonly harness
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }
+}
+
+function seedPublishedArtifact(harnessRoot: string, taskId: string, name: string, body: string): string {
+  const target = path.join(harnessRoot, "tasks", taskId, "artifacts", name);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, body, "utf8");
+  git(harnessRoot, "add", ".");
+  git(harnessRoot, "commit", "-m", `seed published ${name}`);
+  return target;
 }
 
 function git(root: string, ...args: ReadonlyArray<string>): string {

--- a/packages/cli/test/doc-sync-consumer-closeout.test.ts
+++ b/packages/cli/test/doc-sync-consumer-closeout.test.ts
@@ -90,6 +90,45 @@ test("doc sync publishes a consumer task plan through the governed prose road wi
   });
 });
 
+test("doc sync publishes a consumer task artifact through the governed prose road without a registry", async () => {
+  await withHarnessFixture(async ({ rootDir, harnessRoot, taskRoot }) => {
+    const relativePath = `tasks/${taskId}/artifacts/report.md`;
+    const artifactPath = path.join(taskRoot, "artifacts", "report.md");
+    mkdirSync(path.dirname(artifactPath), { recursive: true });
+    writeFileSync(artifactPath, "# Consumer artifact\n\nFirst body.\n", "utf8");
+
+    const report = buildDocSyncReport(rootDir, cliDaemonServiceHostServices.docSync);
+    assert.deepEqual(report.candidateBlobs.map((entry) => entry.path), [relativePath]);
+    assert.equal(report.readyToSubmitPreview, true);
+
+    const request = buildDocSyncSubmitRequest(
+      rootDir,
+      "consumer",
+      [relativePath],
+      { kind: "agent", id: "codex-test" },
+      cliDaemonServiceHostServices.docSync
+    );
+    const result = await makeDocSyncService({
+      rootDir,
+      coordinator: attributedCoordinator(rootDir),
+      hostServices: cliDaemonServiceHostServices.docSync
+    }).submit(request);
+
+    assert.equal(result.ok, true, JSON.stringify(result));
+    if (result.ok) assert.deepEqual(result.appliedChanges.map((change) => change.path), [relativePath]);
+    assert.equal(git(harnessRoot, "status", "--short"), "");
+  });
+});
+
+test("doc sync keeps ignoring a consumer task package free file that is not under artifacts", async () => {
+  await withHarnessFixture(({ rootDir, taskRoot }) => {
+    writeFileSync(path.join(taskRoot, "notes.txt"), "edited notes\n", "utf8");
+    const report = buildDocSyncReport(rootDir, cliDaemonServiceHostServices.docSync);
+    assert.deepEqual(report.candidateBlobs.map((entry) => entry.path), []);
+    assert.deepEqual(report.dirtyFiles.map((entry) => entry.path), []);
+  });
+});
+
 test("doc sync rejects a template-shaped consumer document whose declared preset is invalid", async () => {
   await withHarnessFixture(({ rootDir, harnessRoot, taskRoot }) => {
     const relativePath = `tasks/${taskId}/task_plan.md`;

--- a/packages/daemon/src/service/doc-sync-consumer-surface.ts
+++ b/packages/daemon/src/service/doc-sync-consumer-surface.ts
@@ -20,6 +20,14 @@ export const consumerDocSyncRows = [{
   }
 }] as const;
 
+/**
+ * Task package artifacts are free-form authored files, so no preset template declares a
+ * managed section policy for them and the policy probe below can never admit them. They
+ * are still the same governed task-document lane the self-hosted repo publishes them
+ * through, so admit them by path instead of leaving consumer repos without a road.
+ */
+const consumerTaskArtifactPath = /^tasks\/[^/]+\/artifacts\/.+/u;
+
 export function isConsumerGovernedTaskDocument(
   rootDir: string,
   authoredRoot: string,
@@ -27,6 +35,7 @@ export function isConsumerGovernedTaskDocument(
   hostServices: DaemonDocSyncHostServices
 ): boolean {
   if (entry.status === "deleted" || !/^tasks\/[^/]+\/.+/u.test(entry.path)) return false;
+  if (consumerTaskArtifactPath.test(entry.path)) return true;
   return hostServices.resolveDeclaredManagedSectionPolicy({
     rootDir,
     layoutOverrides: { authoredRoot: path.relative(rootDir, authoredRoot) }


### PR DESCRIPTION
# English

## Summary

Consumer repositories could not publish task package artifacts at all, while the self-hosted repository published the same files through the same lane every day. This PR closes that capability gap and stops `ha task artifact add` from reporting success without publishing anything.

## What Changed

- `isConsumerGovernedTaskDocument` now admits `tasks/<id>/artifacts/**` by path. Consumer repos do not install `tools/write-road-registry.json`, so their status scan falls back to a policy probe that only admits paths whose installed preset template resolves a managed section policy; free-form artifacts never resolve one and were therefore permanently invisible to `ha doc status` and unreachable for `ha doc sync --submit --path`.
- `buildArtifactIngestPlan` no longer treats "the path is version controlled" as "the current content is published". It compares the working tree against the published blob and resubmits when they diverge, carrying the published body hash as `baseBlobSha256` so the submit side does not reject the change as `base_blob_changed`.
- Non-UTF-8 tracked artifacts keep reusing instead of failing, so the existing binary pointer behaviour is unchanged.

Submit-side behaviour is untouched: task artifacts already classify into the `task-document` / `task-authored-prose-or-stage` lane that the single consumer registry row declares, which is exactly the lane `artifact add` has always submitted through.

## Task And Scope

- Harness task: `task_01KZJF0S02BCQH3SNBY80GYFX8`
- Branch: `codex/consumer-artifacts-write-road`
- Public scope: `packages/daemon/src/service/doc-sync-consumer-surface.ts`, `packages/cli/src/daemon/artifact-ingest.ts`, and their two test files.
- Private planning/evidence updated: yes
- Out of scope: the completion witness contract over task packages (every file in HEAD, content matching the working tree, published by an attributed authority merge) is unchanged; binary/CAS artifact ingestion; the pre-existing `check-write-road-registry` findings described under Residual Risk.

## Version Impact

- Version: no version change because this is a behaviour fix inside existing packages with no public API surface change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes (declared conservatively; `tools/check-pr-governance.mjs` skips this PR, reporting no manifest-derived protected surface among its 129 rules)
- Protected surface scope: the doc-sync consumer admission predicate and the artifact ingestion plan. Neither path is manifest-derived, but both decide what may enter the governed write road, so the declaration is filled rather than skipped.
- Authority: `dec_01KZJESK0X0YJJVB5B1XKVPXCP` CH1 and CH2 (this PR implements them); refines `dec_01KZ8VJPTHGBD3JER3R022ZSJ7` CH1, whose consumer write road opened only as far as documents with a managed section policy; enforces `dec_01KYEBBBQH57GNESDJ1EAEN1S0` CH3, which requires the facade command to be an alias of the doc-sync lane rather than a second write road.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: `dec_01KZJESK0X0YJJVB5B1XKVPXCP` CH4 records that ADR-0016 D1 (prose may be hand-committed) and the PREPUBLISH gate (task documents must be published through the write road, not bare-committed) contradict each other, and asks for a separate adjudication.

## Verification

- Base `origin/main` SHA: `6fb9ead77a4b5ba9bbc6065f63803158fc0a5c66`
- Branch merge-base with `origin/main`: `6fb9ead77a4b5ba9bbc6065f63803158fc0a5c66`
- Last `git fetch origin` time: 2026-08-09, immediately before the branch was created
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/consumer-artifacts-write-road`
- Private evidence commit/path: harness task package `task_01KZJF0S02BCQH3SNBY80GYFX8`
- Reviewer evidence path: harness task package `task_01KZJF0S02BCQH3SNBY80GYFX8`
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` (the gate set is derived from `tools/gate-manifest.json`; do not enumerate gates by hand) — passed in 158.4s, 27 complete manifest gates green
- [x] Targeted tests for the change surface, named with their counts: `node tools/run-node-tests.mjs --tier fast --prefix packages/cli/test` — 457 tests, 457 pass, 0 fail. Five of them are new:
  - `artifact add republishes a tracked task artifact whose working tree content changed`
  - `artifact add still reuses a tracked task artifact whose content already matches HEAD`
  - `artifact add keeps reusing a tracked binary artifact instead of failing on UTF-8`
  - `doc sync publishes a consumer task artifact through the governed prose road without a registry`
  - `doc sync keeps ignoring a consumer task package free file that is not under artifacts`
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: the integration and nightly tiers were not run locally — the stop point covers only fast/contract tests under affected prefixes, and CI is the authoritative full gate. `npm run harness:check-write-road-registry` was run and fails, but it fails identically on trees without this change (see Residual Risk).

Negative controls were taken before each fix, which is the load-bearing part of this verification:

- Before the artifact-ingest change, `artifact add republishes a tracked task artifact whose working tree content changed` failed on its assertion (`a changed tracked artifact must produce a doc-sync submit request`), while the two guard cases already passed.
- Before the consumer-surface change, `doc sync publishes a consumer task artifact through the governed prose road without a registry` failed, while the boundary case (`a consumer task package free file that is not under artifacts` stays ignored) already passed.

## Review Evidence

- Self-review: read the full submit-side path before changing the scan, confirming that `classifyTouchedZones` routes `tasks/<id>/artifacts/*.md` to the `task-document` lane, that the `sectionManaged` probe matches only two-segment task documents, and that the typed-only machine surfaces cover sessions/executions/reviews but not artifacts. Admission therefore changes what is *visible*, not how it is *classified*.
- Reviewer subagent: not used
- Human review: pending
- Blocking findings: none

## Residual Risk

- `npm run harness:check-write-road-registry` fails locally, reporting direct-write call sites with no covering registry row. This is pre-existing and unrelated: the same gate fails on a tree without this change (84 findings there, 73 here), and neither list mentions the two files this PR touches. It is left alone deliberately because this task is not authorised to modify the CI/gate authority surface.
- Admission is widened by path rather than by declaration. The regex is anchored to `tasks/<id>/artifacts/` and a boundary test asserts that a free file directly under a task package is still ignored, but a future layout change under `artifacts/` would inherit the admission without a new decision.

## References

- Task: `task_01KZJF0S02BCQH3SNBY80GYFX8`
- Evidence: harness task package `task_01KZJF0S02BCQH3SNBY80GYFX8`
- Review: pending

---

# 中文

## 概要

消费者仓根本无法发布任务包 artifacts，而自宿主仓每天都在用同一条通道发布同样的文件。本 PR 补齐这道能力断层，并让 `ha task artifact add` 不再「报成功但什么都没发布」。

## 改动内容

- `isConsumerGovernedTaskDocument` 现在按路径放行 `tasks/<id>/artifacts/**`。消费者仓不安装 `tools/write-road-registry.json`，其 status 扫描落到一个只放行「已安装 preset 模板能解析出 managed section policy」的探测上；artifacts 是自由文件永远解析不出，因此对 `ha doc status` 恒不可见，`ha doc sync --submit --path` 也恒不可达。
- `buildArtifactIngestPlan` 不再把「路径已在版本控制内」当作「当前内容已发布」。它比对工作区与已发布 blob，不一致就重新提交，并把已发布内容的哈希作为 `baseBlobSha256` 带上，否则 submit 侧会以 `base_blob_changed` 拒收。
- 已跟踪的非 UTF-8 artifact 仍走 reuse 而不是报错，既有的二进制指针行为不变。

submit 侧行为未动：任务 artifacts 本来就被分类进消费者注册表唯一那行声明的 `task-document` / `task-authored-prose-or-stage` 通道，而这正是 `artifact add` 一直在用的那条通道。

## 任务与范围

- Harness task：`task_01KZJF0S02BCQH3SNBY80GYFX8`
- 分支：`codex/consumer-artifacts-write-road`
- 公开范围：`packages/daemon/src/service/doc-sync-consumer-surface.ts`、`packages/cli/src/daemon/artifact-ingest.ts` 及其两个测试文件。
- 私有计划 / 证据已更新：是
- 不在范围内：completion witness 对任务包的契约（每个文件在 HEAD、内容与工作区一致、由带归属的 authority merge 发布）保持不变；二进制 / CAS artifact 入库；残余风险里描述的既存 `check-write-road-registry` 报告。

## 版本影响

- 版本：不变更版本，因为这是既有 package 内部的行为修复，无公开 API 面变化。
- 发布影响：不发布

## 治理声明

- 触碰 protected surface：是（保守声明；`tools/check-pr-governance.mjs` 对本 PR 判定为跳过，其 129 条 manifest 派生规则中没有命中项）
- Protected surface 范围：doc-sync 消费者放行判据与 artifact 入库计划。两者都不是 manifest 派生路径，但都决定什么可以进入治理写路，故填写声明而非跳过。
- 依据：`dec_01KZJESK0X0YJJVB5B1XKVPXCP` CH1 与 CH2（本 PR 即其实现）；refines `dec_01KZ8VJPTHGBD3JER3R022ZSJ7` CH1，该裁决开的消费者写路只到「有 managed section policy 的文档」；执行 `dec_01KYEBBBQH57GNESDJ1EAEN1S0` CH3，该裁决要求门面命令是 doc-sync 通道的别名而非第二条写路。
- 机器检查边界：本 PR 只断言声明存在；是否属实与是否充分由评审者判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：`dec_01KZJESK0X0YJJVB5B1XKVPXCP` CH4 记录了 ADR-0016 D1（prose 可手工 commit）与 PREPUBLISH 门（任务文档必须经写路发布而非裸提交）互相矛盾，要求另立裁决。

## 验证

- 基线 `origin/main` SHA：`6fb9ead77a4b5ba9bbc6065f63803158fc0a5c66`
- 与 `origin/main` 的 merge-base：`6fb9ead77a4b5ba9bbc6065f63803158fc0a5c66`
- 最近一次 `git fetch origin` 时间：2026-08-09，建分支前即刻
- 同步方式：无需同步
- 公开 diff 命令：`git diff origin/main...codex/consumer-artifacts-write-road`
- 私有证据 commit/路径：harness 任务包 `task_01KZJF0S02BCQH3SNBY80GYFX8`
- 评审证据路径：harness 任务包 `task_01KZJF0S02BCQH3SNBY80GYFX8`
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑
- [x] `git diff --check`
- [x] `npm run check:stop-point`（门集从 `tools/gate-manifest.json` 派生，不要手工枚举门名）——158.4 秒通过，27 个完整 manifest gate 全绿
- [x] 改动面的定向测试，写明测试名与通过数：`node tools/run-node-tests.mjs --tier fast --prefix packages/cli/test` —— 457 个测试，457 通过，0 失败。其中 5 个是新增：
  - `artifact add republishes a tracked task artifact whose working tree content changed`
  - `artifact add still reuses a tracked task artifact whose content already matches HEAD`
  - `artifact add keeps reusing a tracked binary artifact instead of failing on UTF-8`
  - `doc sync publishes a consumer task artifact through the governed prose road without a registry`
  - `doc sync keeps ignoring a consumer task package free file that is not under artifacts`
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）
- 未跑及原因：integration 与 nightly tier 本地未跑——停止点只覆盖受影响前缀下的 fast/contract 测试，权威全量门是 CI。`npm run harness:check-write-road-registry` 跑了且失败，但它在不含本改动的树上以同样方式失败（见残余风险）。

每处修复前都取了阴性对照，这是本次验证的承重部分：

- 改 artifact-ingest 之前，`artifact add republishes a tracked task artifact whose working tree content changed` 红在断言 `a changed tracked artifact must produce a doc-sync submit request`，而两条保护用例当时已绿。
- 改 consumer-surface 之前，`doc sync publishes a consumer task artifact through the governed prose road without a registry` 红，而边界用例（任务包内 artifacts 之外的自由文件仍被忽略）当时已绿。

## 审查证据

- 自审：改扫描之前先读完了 submit 侧整条路径，确认 `classifyTouchedZones` 把 `tasks/<id>/artifacts/*.md` 路由到 `task-document` 通道、`sectionManaged` 探测只匹配两段式任务文档、typed-only 机读面覆盖 sessions/executions/reviews 但不含 artifacts。因此放行改变的是**可见性**，不是**分类方式**。
- 评审子代理：未使用
- 人工评审：待进行
- 阻塞性发现：无

## 残余风险

- `npm run harness:check-write-road-registry` 本地失败，报告若干无注册行覆盖的直接写调用点。这是既存问题且与本改动无关：同一个门在不含本改动的树上同样失败（那边 84 条，这边 73 条），两份清单都不包含本 PR 触碰的两个文件。刻意不处理，因为本任务未被授权修改 CI/gate 权威面。
- 放行是按路径而非按声明扩大的。正则锚定在 `tasks/<id>/artifacts/`，并有边界测试断言任务包直属自由文件仍被忽略；但未来若在 `artifacts/` 下引入新布局，会在没有新裁决的情况下继承这份放行。

## 关联材料

- 任务：`task_01KZJF0S02BCQH3SNBY80GYFX8`
- 证据：harness 任务包 `task_01KZJF0S02BCQH3SNBY80GYFX8`
- 评审：待进行
