### PR TITLE
perf(daemon): resolve publication evidence with one synchronous git spawn instead of eight

### DIFF
--- a/packages/daemon/src/authority/production/publication-evidence.ts
+++ b/packages/daemon/src/authority/production/publication-evidence.ts
@@ -14,7 +14,8 @@ import {
 } from "@harness-anything/kernel";
 import {
   scanFirstParentPublicationMetadata,
-  type AuthorityBatchCommitMetadata
+  type AuthorityBatchCommitMetadata,
+  type FirstParentPublicationMetadata
 } from "./publication-history.ts";
 import {
   assertNoUnanchoredAuthorityBatchPrefix,
@@ -203,6 +204,7 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
         readonly commitSha: string;
         readonly previousCommit: string;
         readonly opIds: ReadonlyArray<string>;
+        readonly metadata: FirstParentPublicationMetadata;
       }>>;
       readonly unanchoredByOperationId: ReadonlyMap<string, ReadonlyArray<AuthorityBatchCommitMetadata>>;
     }>;
@@ -217,6 +219,7 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
         readonly commitSha: string;
         readonly previousCommit: string;
         readonly opIds: ReadonlyArray<string>;
+        readonly metadata: typeof commits[number];
       }>>();
       for (const commit of commits) {
         if (commit.parents.length !== 2) continue;
@@ -224,7 +227,8 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
         const anchor = {
           commitSha: commit.commitSha,
           previousCommit: commit.parents[0]!,
-          opIds
+          opIds,
+          metadata: commit
         };
         for (const opId of opIds) {
           const known = byOperationId.get(opId) ?? [];
@@ -334,23 +338,30 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
   const inspectPublication = async (
     expectedPreviousHead: string | null,
     expectedOpIds: ReadonlyArray<string>,
-    expectedCommitSha?: string
+    expectedCommitSha?: string,
+    indexedMetadata?: FirstParentPublicationMetadata
   ): Promise<CanonicalPublicationEvidence> => {
     const head = expectedCommitSha ?? await currentHead();
     if (!head) throw new Error("AUTHORITY_CANONICAL_PUBLICATION_MISSING");
-    const row = publicationGitText(rootDir, "rev-list", "--parents", "-n", "1", head).split(" ");
-    const parentCommits = row.slice(1);
+    const metadata = indexedMetadata?.commitSha === head ? indexedMetadata : undefined;
+    const parentCommits = metadata?.parents
+      ?? publicationGitText(rootDir, "rev-list", "--parents", "-n", "1", head).split(" ").slice(1);
     const sessionCommit = parentCommits[1];
     const sessionParents = sessionCommit
-      ? publicationGitText(rootDir, "rev-list", "--parents", "-n", "1", sessionCommit).split(" ").slice(1)
+      ? metadata?.sessionParents
+        ?? publicationGitText(rootDir, "rev-list", "--parents", "-n", "1", sessionCommit).split(" ").slice(1)
       : [];
-    const mergeSubject = publicationGitText(rootDir, "show", "-s", "--format=%s", head);
+    const mergeSubject = metadata?.subject
+      ?? publicationGitText(rootDir, "show", "-s", "--format=%s", head);
     const sessionSubject = sessionCommit
-      ? publicationGitText(rootDir, "show", "-s", "--format=%s", sessionCommit)
+      ? metadata?.sessionSubject
+        ?? publicationGitText(rootDir, "show", "-s", "--format=%s", sessionCommit)
       : "";
-    const mergeMessage = publicationGitText(rootDir, "show", "-s", "--format=%B", head);
+    const mergeMessage = metadata?.message
+      ?? publicationGitText(rootDir, "show", "-s", "--format=%B", head);
     const sessionMessage = sessionCommit
-      ? publicationGitText(rootDir, "show", "-s", "--format=%B", sessionCommit)
+      ? metadata?.sessionMessage
+        ?? publicationGitText(rootDir, "show", "-s", "--format=%B", sessionCommit)
       : "";
     const {
       mergeMessageMatchesSession,
@@ -364,7 +375,9 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
       expectedOpIds
     });
     const mergeTreeMatchesSession = sessionCommit
-      ? publicationGitExitCode(rootDir, "diff", "--quiet", head, sessionCommit) === 0
+      ? metadata?.treeSha && metadata.sessionTreeSha
+        ? metadata.treeSha === metadata.sessionTreeSha
+        : publicationGitExitCode(rootDir, "diff", "--quiet", head, sessionCommit) === 0
       : false;
     if (!expectedPreviousHead
       || parentCommits.length !== 2
@@ -445,7 +458,12 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
     const unanchored = history?.unanchoredByOperationId.get(opId) ?? [];
     if (unanchored.length > 0) throw unanchoredBatchError(unanchored);
     return findUniquePublication(opId, history?.byOperationId.get(opId) ?? [], {
-      inspect: (anchor) => inspectPublication(anchor.previousCommit, anchor.opIds, anchor.commitSha),
+      inspect: (anchor) => inspectPublication(
+        anchor.previousCommit,
+        anchor.opIds,
+        anchor.commitSha,
+        anchor.metadata
+      ),
       notFound: (expectedOpId) => new AuthorityCanonicalPublicationNotFoundError(expectedOpId)
     });
   };
@@ -467,7 +485,8 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
         matches.push(await inspectPublication(
           commit.parents[0]!,
           expectedOpIds,
-          commit.commitSha
+          commit.commitSha,
+          commit
         ));
       }
       if (matches.length !== 1) {
@@ -558,6 +577,11 @@ export function readAuthorityGitBatchBytes(
   input: Buffer
 ): Buffer {
   return execFileSync("git", ["-C", rootDir, ...args], {
-    encoding: "buffer", input, stdio: ["pipe", "pipe", "pipe"], windowsHide: true, maxBuffer: 64 * 1024 * 1024
+    encoding: "buffer",
+    ...(input.length > 0
+      ? { input, stdio: ["pipe", "pipe", "pipe"] as const }
+      : { stdio: ["ignore", "pipe", "pipe"] as const }),
+    windowsHide: true,
+    maxBuffer: 64 * 1024 * 1024
   });
 }

--- a/packages/daemon/src/authority/production/publication-history.ts
+++ b/packages/daemon/src/authority/production/publication-history.ts
@@ -77,15 +77,18 @@ export async function scanFirstParentPublicationMetadata(input: {
       });
     }
   }
-  return history.map((row) => ({
-    ...row,
-    ...(row.parents[1] ? {
-      sessionSubject: sessions.get(row.parents[1])?.subject ?? "",
-      sessionParents: sessions.get(row.parents[1])?.parents ?? [],
-      sessionTreeSha: sessions.get(row.parents[1])?.treeSha ?? "",
-      sessionMessage: sessions.get(row.parents[1])?.message ?? ""
-    } : {})
-  }));
+  return history.map((row) => {
+    const session = row.parents[1] ? sessions.get(row.parents[1]) : undefined;
+    return {
+      ...row,
+      ...(session ? {
+        sessionSubject: session.subject,
+        sessionParents: session.parents,
+        sessionTreeSha: session.treeSha,
+        sessionMessage: session.message
+      } : {})
+    };
+  });
 }
 
 export async function scanAuthorityBatchCommits(input: {

--- a/packages/daemon/src/authority/production/publication-history.ts
+++ b/packages/daemon/src/authority/production/publication-history.ts
@@ -8,9 +8,13 @@ const subjectBatchSize = 256;
 export interface FirstParentPublicationMetadata {
   readonly commitSha: string;
   readonly parents: ReadonlyArray<string>;
+  readonly treeSha: string;
   readonly subject: string;
+  readonly message: string;
   readonly sessionSubject?: string;
   readonly sessionParents?: ReadonlyArray<string>;
+  readonly sessionTreeSha?: string;
+  readonly sessionMessage?: string;
 }
 
 export interface AuthorityBatchCommitMetadata {
@@ -31,16 +35,18 @@ export async function scanFirstParentPublicationMetadata(input: {
   const revision = input.exclusiveCommit
     ? `${input.exclusiveCommit}..${input.headCommit}`
     : input.headCommit;
-  const history = parseTriples(await publicationHistoryGitText(
+  const history = parseCommitRows(await publicationHistoryGitText(
     input.rootDir,
     "log",
     "--first-parent",
-    "--format=%H%x00%P%x00%s%x00",
+    "--format=%H%x00%P%x00%T%x00%s%x00%B%x00",
     revision
-  )).map(([commitSha, parents, subject]) => ({
+  )).map(([commitSha, parents, treeSha, subject, message]) => ({
     commitSha,
     parents: parents.split(" ").filter(Boolean),
-    subject
+    treeSha,
+    subject,
+    message
   }));
   const sessionCommits = [...new Set(history
     .filter((row) =>
@@ -50,20 +56,24 @@ export async function scanFirstParentPublicationMetadata(input: {
     .map((row) => row.parents[1]!))];
   const sessions = new Map<string, {
     readonly parents: ReadonlyArray<string>;
+    readonly treeSha: string;
     readonly subject: string;
+    readonly message: string;
   }>();
   for (let start = 0; start < sessionCommits.length; start += subjectBatchSize) {
     const batch = sessionCommits.slice(start, start + subjectBatchSize);
-    for (const [commitSha, parents, subject] of parseTriples(await publicationHistoryGitText(
+    for (const [commitSha, parents, treeSha, subject, message] of parseCommitRows(await publicationHistoryGitText(
       input.rootDir,
       "log",
       "--no-walk=unsorted",
-      "--format=%H%x00%P%x00%s%x00",
+      "--format=%H%x00%P%x00%T%x00%s%x00%B%x00",
       ...batch
     ))) {
       sessions.set(commitSha, {
         parents: parents.split(" ").filter(Boolean),
-        subject
+        treeSha,
+        subject,
+        message
       });
     }
   }
@@ -71,7 +81,9 @@ export async function scanFirstParentPublicationMetadata(input: {
     ...row,
     ...(row.parents[1] ? {
       sessionSubject: sessions.get(row.parents[1])?.subject ?? "",
-      sessionParents: sessions.get(row.parents[1])?.parents ?? []
+      sessionParents: sessions.get(row.parents[1])?.parents ?? [],
+      sessionTreeSha: sessions.get(row.parents[1])?.treeSha ?? "",
+      sessionMessage: sessions.get(row.parents[1])?.message ?? ""
     } : {})
   }));
 }
@@ -124,14 +136,16 @@ function parsePairs(value: string): ReadonlyArray<readonly [string, string]> {
   return pairs;
 }
 
-function parseTriples(value: string): ReadonlyArray<readonly [string, string, string]> {
+function parseCommitRows(value: string): ReadonlyArray<readonly [string, string, string, string, string]> {
   const fields = value.split("\0");
-  const triples: Array<readonly [string, string, string]> = [];
-  for (let index = 0; index + 2 < fields.length; index += 3) {
+  const rows: Array<readonly [string, string, string, string, string]> = [];
+  for (let index = 0; index + 4 < fields.length; index += 5) {
     const first = fields[index]!.trim();
     const second = fields[index + 1]!.trim();
     const third = fields[index + 2]!.trim();
-    if (first) triples.push([first, second, third]);
+    const fourth = fields[index + 3]!.trim();
+    const fifth = fields[index + 4]!.trim();
+    if (first) rows.push([first, second, third, fourth, fifth]);
   }
-  return triples;
+  return rows;
 }

--- a/packages/daemon/test/publication-evidence-responsiveness.test.ts
+++ b/packages/daemon/test/publication-evidence-responsiveness.test.ts
@@ -54,10 +54,30 @@ test("publication evidence yields between blob reads so recovery admission timer
     [opId],
     mergeCommit
   );
-  assert.deepEqual(await inspector.findHistoricalPublicationForOperation(opId), {
-    commitSha: mergeCommit,
-    semanticDigest
-  });
+  const tracePath = path.join(root, "historical-publication-git-trace.jsonl");
+  const previousTrace = process.env.GIT_TRACE2_EVENT;
+  process.env.GIT_TRACE2_EVENT = tracePath;
+  try {
+    assert.deepEqual(await inspector.findHistoricalPublicationForOperation(opId), {
+      commitSha: mergeCommit,
+      semanticDigest
+    });
+  } finally {
+    if (previousTrace === undefined) delete process.env.GIT_TRACE2_EVENT;
+    else process.env.GIT_TRACE2_EVENT = previousTrace;
+  }
+
+  const lookupCommands = gitTraceCommands(tracePath);
+  assert.equal(lookupCommands.filter(([command]) => command === "rev-list").length, 0);
+  assert.equal(lookupCommands.filter((args) =>
+    args[0] === "show" && args.includes("-s")
+  ).length, 0);
+  assert.equal(lookupCommands.filter((args) =>
+    args[0] === "diff" && args.includes("--quiet")
+  ).length, 0);
+  assert.equal(lookupCommands.filter((args) =>
+    args[0] === "diff" && args.includes("--name-only")
+  ).length, 1);
 
   assert.equal(timerFired, true);
 });
@@ -101,13 +121,25 @@ test("missing-operation recovery search yields and reuses one bounded history sc
   }
 
   assert.equal(timerFired, true);
-  const starts = readFileSync(tracePath, "utf8")
-    .trim()
-    .split("\n")
-    .map((line) => JSON.parse(line) as { readonly event: string })
-    .filter((event) => event.event === "start");
+  const starts = gitTraceCommands(tracePath);
   assert.ok(starts.length <= 3, `expected one history scan plus HEAD checks, observed ${starts.length} Git processes`);
 });
+
+function gitTraceCommands(tracePath: string): ReadonlyArray<ReadonlyArray<string>> {
+  return readFileSync(tracePath, "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as {
+      readonly event: string;
+      readonly argv?: ReadonlyArray<string>;
+    })
+    .filter((event) => event.event === "start")
+    .map((event) => {
+      const argv = event.argv ?? [];
+      const rootFlag = argv.indexOf("-C");
+      return rootFlag >= 0 ? argv.slice(rootFlag + 2) : argv.slice(1);
+    });
+}
 
 function git(root: string, ...args: ReadonlyArray<string>): string {
   return execFileSync("git", ["-C", root, ...args], {

--- a/packages/daemon/test/publication-evidence-topology.test.ts
+++ b/packages/daemon/test/publication-evidence-topology.test.ts
@@ -2,17 +2,19 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { createGitCanonicalPublicationInspector } from "../src/authority/production/publication-evidence.ts";
+import { scanFirstParentPublicationMetadata } from "../src/authority/production/publication-history.ts";
 import {
   authorityBatchTrailerName,
   buildAuthorityBatchIntegrity
 } from "../../kernel/test/authority-batch-fixture.ts";
 
 const opId = "namespace-test:publication-topology";
+const posixTest = process.platform === "win32" ? test.skip : test;
 
 test("publication proof accepts the existing two-parent materializer shape", async (context) => {
   const fixture = publicationFixture(context);
@@ -263,6 +265,46 @@ test("indexed publication lookup preserves message and tree topology checks", as
     createGitCanonicalPublicationInspector(fixture.root).findPublicationForOperation(opId),
     topologyError
   );
+});
+
+posixTest("missing indexed session metadata preserves the Git message fallback", async (context) => {
+  const fixture = publicationFixture(context);
+  fixtureGit(fixture.root, "update-ref", "refs/heads/master", fixture.validMerge);
+  const realGit = execFileSync("sh", ["-c", "command -v git"], { encoding: "utf8" }).trim();
+  const binDir = mkdtempSync(path.join(tmpdir(), "ha-publication-git-wrapper-"));
+  context.after(() => rmSync(binDir, { recursive: true, force: true }));
+  const wrapperPath = path.join(binDir, "git");
+  writeFileSync(wrapperPath, [
+    "#!/bin/sh",
+    "for arg in \"$@\"; do",
+    "  if [ \"$arg\" = \"--no-walk=unsorted\" ]; then exit 0; fi",
+    "done",
+    `exec ${JSON.stringify(realGit)} "$@"`,
+    ""
+  ].join("\n"));
+  chmodSync(wrapperPath, 0o755);
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${binDir}${path.delimiter}${previousPath ?? ""}`;
+  let commits;
+  try {
+    commits = await scanFirstParentPublicationMetadata({
+      rootDir: fixture.root,
+      headCommit: fixture.validMerge
+    });
+  } finally {
+    if (previousPath === undefined) delete process.env.PATH;
+    else process.env.PATH = previousPath;
+  }
+
+  const metadata = commits.find((commit) => commit.commitSha === fixture.validMerge);
+  assert.ok(metadata);
+  let fallbackObserved = false;
+  const sessionMessage = metadata.sessionMessage ?? (() => {
+    fallbackObserved = true;
+    return fixture.sessionMessage;
+  })();
+  assert.equal(fallbackObserved, true);
+  assert.equal(sessionMessage, fixture.sessionMessage);
 });
 
 test("publication proof rejects a publication missing its inline attribution shard", async (context) => {

--- a/packages/daemon/test/publication-evidence-topology.test.ts
+++ b/packages/daemon/test/publication-evidence-topology.test.ts
@@ -236,6 +236,35 @@ test("publication proof rejects a merge tree that differs from the session tree"
   );
 });
 
+test("indexed publication lookup preserves message and tree topology checks", async (context) => {
+  const fixture = publicationFixture(context);
+  const changedMessage = commitTree(
+    fixture.root,
+    fixture.sessionTree,
+    [fixture.base, fixture.session],
+    `${fixture.sessionMessage}\n\nunexpected`
+  );
+  fixtureGit(fixture.root, "update-ref", "refs/heads/master", changedMessage);
+
+  await assert.rejects(
+    createGitCanonicalPublicationInspector(fixture.root).findPublicationForOperation(opId),
+    topologyError
+  );
+
+  const mismatchedTree = commitTree(
+    fixture.root,
+    fixture.baseTree,
+    [fixture.base, fixture.session],
+    "materializer: merge session topology"
+  );
+  fixtureGit(fixture.root, "update-ref", "refs/heads/master", mismatchedTree);
+
+  await assert.rejects(
+    createGitCanonicalPublicationInspector(fixture.root).findPublicationForOperation(opId),
+    topologyError
+  );
+});
+
 test("publication proof rejects a publication missing its inline attribution shard", async (context) => {
   const fixture = publicationFixture(context, { includeAttribution: false });
 


### PR DESCRIPTION
## Summary

Resolving one historical publication used to start **8 synchronous `git` processes**. On macOS each piped `spawnSync` needs three AF_UNIX socketpairs, and XNU's `socreate_internal()` returns `ENOBUFS` when socket allocation fails — *before* `posix_spawn()` ever runs. That is the amplifier behind the 2026-08-08 outage: every historical recovery attempt failed, the pre-READY loop never finished, and the daemon restarted every ~35s with all four repositories unusable.

This makes the per-lookup cost **1 synchronous spawn instead of 8**. The indexed history scan already ran a batched `git log --first-parent`; it now also collects `%T` and `%B`, so the six per-lookup `rev-list`/`show` calls read from the index, and `diff --quiet` becomes a tree-OID comparison. The only remaining synchronous call is `diff --name-only -z`, which is genuinely per-publication.

Publication semantics are unchanged — `dec_01KYA8MCRFZ39H03ZPK721D8Z0` (exact publication anchor, append-only) holds in full. Equivalence is demonstrated on the 26 real stranded proceedings, not asserted.

## What Changed

- `publication-history.ts`: the batched first-parent scan now reads `%H/%P/%T/%s/%B` (was `%H/%P/%s`) for both merge and session commits, keeping NUL framing and the 256-commit session batch bound.
- `publication-evidence.ts`: the existing HEAD-keyed in-memory index carries full metadata; indexed lookups use it instead of re-spawning. Cache lifetime is unchanged and there is still no cross-child state.
- Tree-OID equality replaces `git diff --quiet <merge> <session>`. Git trees are content-addressed, so OID equality *is* tree equality. This also removes a latent failure mode: a spawn error inside `diff --quiet` was swallowed into a non-zero status and read as "trees differ".
- Synchronous read-only git with no stdin now uses `stdio: "ignore"` for stdin, dropping one socketpair per call.
- `inspectPublication()` without index metadata keeps the original per-call git observation path untouched.

## Version Impact

- Version: no version change — internal daemon evidence path, no published surface change.

## Verification

Measured on the 26 real stranded proceedings of `drg-grouper-dingwen`, read-only, same machine and build:

| metric | before | after |
|---|---:|---:|
| synchronous git spawns (26 proceedings) | 184 | 23 |
| synchronous git per successful lookup | 8 | **1** |
| all git process starts | 338 | 177 |
| total batch time | 3765.403 ms | 2478.325 ms |
| median per proceeding | 148.946 ms | 89.918 ms |

**Semantic equivalence** — the load-bearing evidence, since existing tests alone would not have the resolution:

- Ordered observation SHA-256 identical before and after: `c48788698907cae163ac1cf8fbf9ffb72395c86afdf10e20788b3dcf0a6c9e49`.
- 23/23 successes match per-proceeding on `commitSha` + `semanticDigest`, and each `semanticDigest` agrees with the durable authority digest stored in that proceeding — an external anchor, not self-comparison.
- 3/3 not-found cases remain the same `AuthorityCanonicalPublicationNotFoundError` with the same message. No previously-failing lookup was newly "resolved".
- Negative fixtures cover altered semantic messages and unequal merge/session trees, so the indexed path still fails closed.

Gates:

- [x] `npm run check:local` — local stop point, green in 65.9s: 27 manifest gates, affected fast 309/309, affected contract 159 pass + 1 skip.
- [x] Targeted daemon tests 25/25 on the rebased commit.
- [ ] `npm test` / `npm run check` — Not run: the full matrix is CI's job per `harness/AGENTS.md`.
- [ ] `npm run smoke:dashboard`, `pack:dry-run`, `check --profile target-project`, GUI build — Not applicable: this touches only the daemon authority evidence path.

One full-gate run reported a flake in an untouched 3s autostart timing test (3006.788 ms vs a 3000 ms bound); it passed on rerun at 2910.900 ms and the second full gate was green. No test or gate was modified to accommodate it.

## Review Evidence

- Adversarial review found one issue not in the original change, now fixed in `91338a53`: `publication-history.ts` filled absent session metadata with `?? ""`, while the new consumer reads `metadata?.sessionMessage ?? gitText(...)`. Since `??` does not fall back on an empty string, a missing session commit would have contributed an **empty message** to anchor adjudication where the old path always fetched the real one.
  - Not reachable on this code: anchor eligibility requires non-empty `publicationMetadataOperationIds`, and that condition is a subset of the `sessionCommits` filter, so an anchor always has real session metadata.
  - Fixed anyway because the correctness was coincidental, not structural — the same `?? ""` is *safe* on `sessionTreeSha` (its consumer uses a falsy check and correctly falls back) and *unsafe* on `sessionMessage`. Anyone later narrowing that filter would break it silently, in the direction of wrongly terminalizing a write.
  - The fix leaves absent session fields `undefined` so `??` reaches the original git fallback.
  - Locked by a test that makes the condition real — a PATH `git` wrapper makes the `--no-walk=unsorted` query return empty — and its **resolution was measured**: reverting the fix turns it red (1 test, 0 pass, 1 fail, `false !== true`), restoring it turns it green.
- Blocking findings: none outstanding.

## Residual Risk

- **115 asynchronous object reads are untouched**, which is why wall time drops 34% while synchronous spawns drop 87.5%. Reducing them further needs a long-lived `git cat-file --batch` — process lifecycle, backpressure, protocol framing, crash recovery. Deliberately **not** done here; it is a load-bearing runtime choice that should be decided before it is built.
- `ENOBUFS` was never deliberately reproduced under real socket memory pressure — doing so would have required stressing the machine hosting a daemon the user is actively connected to. This change reduces the population of the failure, and does not claim to prove the failure is gone.
- This branch was not deployed to the running daemon; no production daemon, WAL, outcome, or recovery file was touched at any point.
- Commit-message `%B` is parsed with NUL framing. Git commit messages containing a literal NUL would misalign the parse — the same exposure the previous `%s` framing already had, not widened in kind, but widened in surface.

## References

- Task: task_01KZJFDSBR41XN0BKBJ1DE37QR
- Root cause report: task_01KZJ3F4HCRK1D7SQ8Z16JV4GQ (`spawnSync git ENOBUFS`)
- Follow-on outage fixes already on main: #1286 (recovery budget), #1288 (pre-READY instrumentation)

## Governance Declaration

- `dec_01KYA8MCRFZ39H03ZPK721D8Z0` — cross-generation terminalization requires an exact publication anchor and stays append-only. Preserved: adjudication inputs are unchanged, only their retrieval path is.
- `dec_01KZJ1633T8TWH5TFPRTKEKGED` — historical recovery moves off the pre-READY path. Complementary, not superseded: this reduces the cost, that decision changes when it runs.
- `dec_01KZJF4YGRH57R3NPW0PQ5AFGW` — automatic retries must be bounded and escalate when the budget is spent. Complementary: this shrinks the failure population, that decision stops silent infinite retry.
- No CI/gate authority surface was modified.

---

## 摘要

解析一笔 historical publication 过去要启动 **8 个同步 `git` 进程**。macOS 上每个带 pipe 的 `spawnSync` 需要三组 AF_UNIX socketpair，而 XNU 的 `socreate_internal()` 在 socket 分配失败时返回 `ENOBUFS`——发生在 `posix_spawn()` 之前。这正是 2026-08-08 事故的放大器：每次 historical recovery 尝试都失败，pre-READY 循环永远跑不完，daemon 每约 35 秒重启一轮，四个仓库全部不可用。

本 PR 把每次 lookup 的开销从 **8 个同步 spawn 降到 1 个**。索引扫描本来就在跑批量的 `git log --first-parent`，现在让它同时取 `%T` 与 `%B`，于是逐笔那 6 次 `rev-list`/`show` 改为从索引读取，`diff --quiet` 换成 tree OID 比较。唯一剩下的同步调用是 `diff --name-only -z`，那一次确实必须逐 publication 算。

publication 语义完全不变——`dec_01KYA8MCRFZ39H03ZPK721D8Z0`（精确 publication anchor、只追加不重写）完整成立。等价性是在 26 笔真实搁浅 proceeding 上**证明**的，不是断言的。

## 改动内容

- `publication-history.ts`：批量 first-parent 扫描改读 `%H/%P/%T/%s/%B`（原为 `%H/%P/%s`），merge 与 session commit 都取，保持 NUL framing 与 256 个 session commit 一批的上界。
- `publication-evidence.ts`：既有的按 HEAD 失效的内存索引携带完整 metadata，indexed lookup 直接使用而不再重新 spawn。cache 生命周期不变，仍然没有跨 child 状态。
- 用 tree OID 相等替代 `git diff --quiet <merge> <session>`。git tree 是内容寻址的，OID 相等**就是**树相等。这同时消除了一个潜在失败模式：`diff --quiet` 内部的 spawn 错误会被吞成非零状态，被读作「两棵树不同」。
- 无 stdin 输入的同步只读 git 改用 `stdio: "ignore"`，每次调用少一组 socketpair。
- 没有 index metadata 的 `inspectPublication()` 保留原有的逐次 git observation 路径，未做改动。

## 版本影响

- 版本：不改版本——daemon 内部取证路径，不改变任何发布面。

## 验证

在 `drg-grouper-dingwen` 的 26 笔真实搁浅 proceeding 上实测，只读，同机同构建：

| 指标 | 优化前 | 优化后 |
|---|---:|---:|
| 同步 git spawn（26 笔） | 184 | 23 |
| 每笔成功 lookup 的同步 git | 8 | **1** |
| 全部 git 进程启动 | 338 | 177 |
| 批量总耗时 | 3765.403 ms | 2478.325 ms |
| 单笔中位数 | 148.946 ms | 89.918 ms |

**语义等价证据**——这是承重的部分，因为仅靠现有测试不具备分辨力：

- 前后两轮有序 observation 的 SHA-256 完全相同：`c48788698907cae163ac1cf8fbf9ffb72395c86afdf10e20788b3dcf0a6c9e49`。
- 23/23 成功结果逐笔 `commitSha` + `semanticDigest` 一致，且每个 `semanticDigest` 与该 proceeding 中持久化的 authority digest 相符——这是外部锚，不是自我比对。
- 3/3 not-found 仍是同名同 message 的 `AuthorityCanonicalPublicationNotFoundError`。没有任何原本失败的 lookup 被新路径「解析成功」。
- 负向 fixture 覆盖 semantic message 被改动与 merge/session tree 不相等两种情形，indexed 路径仍然 fail closed。

门：

- [x] `npm run check:local` —— 本地停止点，65.9 秒全绿：27 个 manifest gate，affected fast 309/309，affected contract 159 通过 + 1 跳过。
- [x] rebase 后的 commit 上定向 daemon 测试 25/25。
- [ ] `npm test` / `npm run check` —— 未运行：按 `harness/AGENTS.md`，完整门矩阵是 CI 的活。
- [ ] `npm run smoke:dashboard`、`pack:dry-run`、`check --profile target-project`、GUI 构建 —— 不适用：本 PR 只触及 daemon authority 取证路径。

某次完整门运行中一个未被触碰的 3 秒 autostart 计时测试出现 flake（3006.788 ms 超出 3000 ms 上界）；单独复跑为 2910.900 ms，第二次完整门整体通过。没有为此修改任何测试或 gate。

## 审查证据

- 对抗复核发现了一处原改动之外的问题，已在 `91338a53` 修复：`publication-history.ts` 用 `?? ""` 填充缺失的 session metadata，而新的消费方写的是 `metadata?.sessionMessage ?? gitText(...)`。由于 `??` 对空字符串不 fallback，一旦 session commit 缺失，参与 anchor 判定的会是一个**空 message**，而旧路径必定去取真实值。
  - 在当前代码上不可触发：成为 anchor 要求 `publicationMetadataOperationIds` 非空，而该条件是 `sessionCommits` filter 的子集，所以 anchor 必然带有真实的 session metadata。
  - 仍然修复，因为这个正确性是**巧合而非结构**——同一个 `?? ""` 在 `sessionTreeSha` 上是*安全*的（消费方用 falsy 检查，会正确回退），在 `sessionMessage` 上是*不安全*的。以后谁收窄那个 filter，破坏是静默的，且方向是错误终态化一笔写。
  - 修法是让缺失的 session 字段保持 `undefined`，使 `??` 真正回退到原有的 git 查询。
  - 由一个把该条件真实造出来的测试锁住——用 PATH 上的 `git` wrapper 让 `--no-walk=unsorted` 查询返回空——并且**实测了它的分辨力**：回退修复它变红（1 个测试，0 通过，1 失败，`false !== true`），恢复修复它变绿。
- 阻塞发现：无未处置项。

## 残余风险

- **115 次异步 object read 完全未动**，这就是为什么墙钟时间只降 34% 而同步 spawn 降 87.5%。要继续摊薄它需要长寿命的 `git cat-file --batch`——涉及进程生命周期、backpressure、协议 framing、崩溃恢复。本 PR **刻意不做**：那是承重的运行时选择，应当先裁决再建造。
- 从未在真实 socket 内存压力下刻意复现 `ENOBUFS`——那需要对正托管着用户在用 daemon 的机器施压。本改动降低了该故障的发生基数，但不声称证明了故障已消失。
- 本分支未部署到运行中的 daemon；全程没有触碰任何生产 daemon、WAL、outcome 或 recovery 文件。
- commit message 的 `%B` 用 NUL framing 解析。若 commit message 内含字面 NUL 会导致解析错位——这与既有 `%s` framing 的暴露同类，性质未扩大，但面扩大了。

## 关联材料

- 任务：task_01KZJFDSBR41XN0BKBJ1DE37QR
- 根因报告：task_01KZJ3F4HCRK1D7SQ8Z16JV4GQ（`spawnSync git ENOBUFS`）
- 同一事故已合入 main 的修复：#1286（恢复循环预算）、#1288（pre-READY 插桩）

## 治理声明

- `dec_01KYA8MCRFZ39H03ZPK721D8Z0` —— 跨代终态化必须有精确 publication anchor 且只追加不重写。已保持：判定的输入完全不变，改变的只是它们的取回路径。
- `dec_01KZJ1633T8TWH5TFPRTKEKGED` —— historical recovery 移出 pre-READY 路径。互补而非取代：本 PR 降低其开销，该决策改变它何时运行。
- `dec_01KZJF4YGRH57R3NPW0PQ5AFGW` —— 自动重试必须有界并在预算耗尽时升级。互补：本 PR 缩小故障基数，该决策终止静默的无限重试。
- 未修改任何 CI/gate 权威面。
