### PR TITLE
fix(daemon): detect stalled writer startup by progress, not elapsed time

### DIFF
--- a/packages/cli/src/composition/repo-write-child-entrypoint.ts
+++ b/packages/cli/src/composition/repo-write-child-entrypoint.ts
@@ -34,16 +34,16 @@ import {
 } from "./production-authority-lifecycle.ts";
 import { makeDaemonReservationReconciler } from "@harness-anything/daemon";
 
+type RepoWriteStartupProgressPhase = Extract<
+  Parameters<RepoWriteChildIpcTransport["send"]>[0],
+  { readonly kind: "startup-progress" }
+>["phase"];
+
 /**
- * Everything before READY must fit inside the parent's READY deadline
- * (`readyTimeoutMs`, default 30_000ms), so this caps the child's *total* time to
- * announcement rather than just the recovery loop. Measured on a real forked
- * child, everything other than the recovery loop costs ~0.7s, so the loop is the
- * only part that can grow with data — and it grows invisibly, because iterations
- * that succeed emit no log. A budget sized from the visible (deferred)
- * iterations undercounts badly, so recovery instead gets whatever time is left
- * under this cap and nothing more; proceedings it does not reach stay proceeding
- * and are retried on the next start.
+ * Historical recovery keeps its existing admission budget, which is strictly
+ * smaller than the parent's startup-stall window. The parent now renews that
+ * window only when it sees a previously unseen startup phase/work-unit pair;
+ * this budget remains an admission boundary, not the liveness signal.
  *
  * Reuses the authority admission deadline rather than restating it: both exist
  * to return before the same parent transport deadline so the supervisor leaves a
@@ -59,14 +59,28 @@ function remainingStartupRecoveryBudgetMs(): number {
 export async function runRepoWriteChildEntrypoint(
   encodedConfig: string | undefined
 ): Promise<void> {
-  // The parent kills this child when it does not announce READY inside
-  // readyTimeoutMs. Without per-phase evidence a timeout is undiagnosable from
-  // outside the process, so every startup phase reports its own cost on stderr,
-  // which the launcher already captures next to the timeout stack.
+  // The parent kills this child only when it sees no new semantic startup work
+  // inside readyTimeoutMs. The independent stderr timings keep each phase's
+  // actual cost diagnosable from the launch log.
   const startupPhase = makeRepoWriteChildStartupPhaseReporter();
   if (!encodedConfig) throw new Error("REPO_WRITE_CHILD_LAUNCH_CONFIG_REQUIRED");
   const config = decodeRepoWriteChildLaunchConfig(encodedConfig);
+  const transport = new RepoWriteChildIpcTransport();
+  const reportStartupProgress = async (
+    phase: RepoWriteStartupProgressPhase,
+    workUnit = config.repoId
+  ): Promise<void> => {
+    await transport.send({
+      protocol: "harness-repo-write-ipc/v1",
+      repoId: config.repoId,
+      generation: config.generation,
+      kind: "startup-progress",
+      phase,
+      workUnit
+    });
+  };
   startupPhase.mark("decode-launch-config");
+  await reportStartupProgress("artifact-identity");
   const entrypointArtifactIdentity = calculateDaemonArtifactIdentity(
     process.argv[1] ?? ""
   ).identity;
@@ -74,6 +88,7 @@ export async function runRepoWriteChildEntrypoint(
   if (entrypointArtifactIdentity !== config.entrypointArtifactIdentity) {
     throw new Error("REPO_WRITE_CHILD_ENTRYPOINT_ARTIFACT_MISMATCH");
   }
+  await reportStartupProgress("authority-manifest");
   const manifest = loadAuthorityProductionManifest(config.authorityManifest);
   const authorityRepo = manifest.repos.find((repo) =>
     repo.repoId === config.repoId
@@ -91,8 +106,10 @@ export async function runRepoWriteChildEntrypoint(
   });
   // Establish the generation baseline before the child advertises readiness so
   // no request pays for a full authored-tree conflict-marker scan.
+  await reportStartupProgress("conflict-marker-preflight");
   conflictMarkerPreflight.read();
   startupPhase.mark("conflict-marker-preflight");
+  await reportStartupProgress("runtime-create");
   const witness = createDaemonGenerationWitness({
     userRoot: config.userRoot,
     endpointIdentity: config.endpointIdentity,
@@ -137,9 +154,11 @@ export async function runRepoWriteChildEntrypoint(
   });
   runtimeBox.current = runtime;
   startupPhase.mark("create-daemon-runtime");
+  await reportStartupProgress("runtime-start");
   await runtime.start();
   startupPhase.mark("runtime-start");
 
+  await reportStartupProgress("authority-lifecycle-compose");
   const outcomes = new DurableRepoWriteOutcomeStoreV1({
     directory: path.join(
       manifest.serviceStateRoot,
@@ -193,6 +212,7 @@ export async function runRepoWriteChildEntrypoint(
     canonicalRoot: config.canonicalRoot
   };
   startupPhase.mark("compose-authority-lifecycle");
+  await reportStartupProgress("authority-start-repo");
   const started = await authorityLifecycle.startRepo(repo, lifecycleRuntime);
   startupPhase.mark("authority-start-repo");
   if (!started.ok) {
@@ -205,9 +225,9 @@ export async function runRepoWriteChildEntrypoint(
     }
     return started.component.recoverCommittedReceipt(outcome.innerOpId);
   };
-  const transport = new RepoWriteChildIpcTransport();
   const startupRecoveryBudgetMs = remainingStartupRecoveryBudgetMs();
   const startupRecoveryDeadline = Date.now() + startupRecoveryBudgetMs;
+  await reportStartupProgress("historical-recovery-scan");
   const historicalProceedings = outcomes.listHistoricalProceedings();
   startupPhase.mark("list-historical-proceedings", {
     proceedingCount: historicalProceedings.length
@@ -219,6 +239,7 @@ export async function runRepoWriteChildEntrypoint(
       proceedingsLeftByBudget += 1;
       continue;
     }
+    await reportStartupProgress("historical-recovery", proceeding.outerOpId);
     const proceedingStartedAt = startupPhase.now();
     try {
       const recovery = await recoveryGate.recoverHistoricalProceeding(proceeding);
@@ -267,6 +288,7 @@ export async function runRepoWriteChildEntrypoint(
       + "retried on the next start\n"
     );
   }
+  await reportStartupProgress("child-host-start");
   const operation = new ProductionRepoWriteOperationHost({
     repoId: config.repoId,
     workspaceId: authorityRepo.workspaceId,

--- a/packages/cli/test/repo-write-child-production-cutover.test.ts
+++ b/packages/cli/test/repo-write-child-production-cutover.test.ts
@@ -59,6 +59,77 @@ const entrypoint = fileURLToPath(new URL("../src/index.ts", import.meta.url));
 const entrypointArtifactIdentity =
   calculateDaemonArtifactIdentity(entrypoint).identity;
 
+cutoverTest("production child reports semantic startup phases before READY", async (t) => {
+  const fixture = createProductionAuthorityLifecycleFixture();
+  const userRoot = path.join(fixture.root, "daemon-user");
+  const endpoint = path.join(userRoot, "daemon.sock");
+  const startupProgress: Array<{ readonly phase: string; readonly workUnit: string }> = [];
+  let transport: ReturnType<typeof forkRepoWriteProcess> | undefined;
+  let supervisor: RepoWriteProcessSupervisor | undefined;
+  try {
+    const machineId = readOrCreateDaemonMachineId(userRoot);
+    const generationRecord = publishNextDaemonGeneration({
+      userRoot,
+      endpointIdentity: endpoint,
+      machineId,
+      daemonInstanceId: "production-child-startup-progress-test"
+    });
+    supervisor = new RepoWriteProcessSupervisor({
+      repoId: "canonical",
+      generation: generationRecord.daemonGeneration,
+      expectedArtifactIdentity: entrypointArtifactIdentity,
+      spawn: () => {
+        transport = forkRepoWriteProcess({
+          modulePath: entrypoint,
+          args: [
+            "__repo-write-child",
+            encodeRepoWriteChildLaunchConfig({
+              schema: repoWriteChildLaunchConfigSchema,
+              repoId: "canonical",
+              canonicalRoot: fixture.repoRoot,
+              authoredRoot: "harness",
+              authorityManifest: fixture.manifestPath,
+              userRoot,
+              endpointIdentity: endpoint,
+              machineId,
+              generation: generationRecord.daemonGeneration,
+              entrypointArtifactIdentity,
+              runtimePolicy: defaultDaemonRuntimePolicy
+            })
+          ],
+          cwd: fixture.repoRoot,
+          env: { ...process.env, HARNESS_DAEMON_SERVER_HOST: "1" }
+        });
+        return transport;
+      }
+    });
+    const starting = supervisor.start();
+    assert.ok(transport);
+    transport.onMessage((message) => {
+      if (message.kind === "startup-progress") {
+        startupProgress.push({ phase: message.phase, workUnit: message.workUnit });
+      }
+    });
+    await starting;
+
+    assert.deepEqual(startupProgress, [
+      { phase: "artifact-identity", workUnit: "canonical" },
+      { phase: "authority-manifest", workUnit: "canonical" },
+      { phase: "conflict-marker-preflight", workUnit: "canonical" },
+      { phase: "runtime-create", workUnit: "canonical" },
+      { phase: "runtime-start", workUnit: "canonical" },
+      { phase: "authority-lifecycle-compose", workUnit: "canonical" },
+      { phase: "authority-start-repo", workUnit: "canonical" },
+      { phase: "historical-recovery-scan", workUnit: "canonical" },
+      { phase: "child-host-start", workUnit: "canonical" }
+    ]);
+    t.diagnostic(JSON.stringify({ startupProgress }));
+  } finally {
+    await supervisor?.stop().catch(() => undefined);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
 cutoverTest("two signed production repos own distinct child locks and route through one daemon", { timeout: 60_000 }, async (t) => {
   const fixture = createProductionAuthorityLifecycleFixture({ repoIds: ["alpha", "beta"] });
   const userRoot = path.join(fixture.root, "daemon-user");

--- a/packages/daemon/src/runtime/repo-write-client-contract.ts
+++ b/packages/daemon/src/runtime/repo-write-client-contract.ts
@@ -25,6 +25,7 @@ export interface RepoWriteClientTransport {
 
 export interface RepoWriteClientLimits {
   readonly maxPendingRequests: number;
+  /** Maximum time without a previously unseen startup phase/work-unit pair. */
   readonly readyTimeoutMs: number;
   readonly requestTimeoutMs: number;
   /**

--- a/packages/daemon/src/runtime/repo-write-client-errors.ts
+++ b/packages/daemon/src/runtime/repo-write-client-errors.ts
@@ -156,6 +156,31 @@ export class RepoWriteReadyTimeoutError extends RepoWriteNotStartedError {
   }
 }
 
+export class RepoWriteStartupStalledError extends RepoWriteNotStartedError {
+  readonly phase: string | undefined;
+  readonly workUnit: string | undefined;
+  readonly repeatedProgressFrames: number;
+
+  constructor(input: {
+    readonly stallTimeoutMs: number;
+    readonly phase?: string;
+    readonly workUnit?: string;
+    readonly repeatedProgressFrames: number;
+  }) {
+    const lastProgress = input.phase === undefined || input.workUnit === undefined
+      ? "no startup progress frame was observed"
+      : `last phase=${input.phase}, workUnit=${input.workUnit}, repeatedFrames=${input.repeatedProgressFrames}`;
+    super(
+      "REPO_WRITE_STARTUP_STALLED",
+      `Repo writer startup stalled: no new phase/work unit for ${input.stallTimeoutMs}ms; ${lastProgress}.`
+    );
+    this.name = "RepoWriteStartupStalledError";
+    this.phase = input.phase;
+    this.workUnit = input.workUnit;
+    this.repeatedProgressFrames = input.repeatedProgressFrames;
+  }
+}
+
 export class RepoWriteLookupError extends Error {
   readonly code: string;
   readonly opId: string;

--- a/packages/daemon/src/runtime/repo-write-client-pending.ts
+++ b/packages/daemon/src/runtime/repo-write-client-pending.ts
@@ -42,13 +42,6 @@ export interface PendingShutdown {
   sent: boolean;
 }
 
-export interface PendingReady {
-  readonly promise: Promise<void>;
-  readonly resolve: () => void;
-  readonly reject: (error: Error) => void;
-  readonly timer: NodeJS.Timeout;
-}
-
 export function createPendingRepoWriteSubmit(input: Pick<
   PendingSubmit,
   "requestId" | "command" | "resolve" | "reject"

--- a/packages/daemon/src/runtime/repo-write-client-ready.ts
+++ b/packages/daemon/src/runtime/repo-write-client-ready.ts
@@ -1,0 +1,96 @@
+import { RepoWriteStartupStalledError } from "./repo-write-client-errors.ts";
+import type { RepoWriteStartupProgressFrame } from "./repo-write-protocol.ts";
+
+interface PendingReady {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+  readonly reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+/** Owns READY waiting and semantic pre-READY progress without request-lane state. */
+export class RepoWriteClientReadyGate {
+  private readonly stallTimeoutMs: number;
+  private readonly onStall: (error: RepoWriteStartupStalledError) => void;
+  private readonly progressSeen = new Set<string>();
+  private pending: PendingReady | undefined;
+  private lastProgress: RepoWriteStartupProgressFrame | undefined;
+  private repeatedProgressFrames = 0;
+
+  constructor(input: {
+    readonly stallTimeoutMs: number;
+    readonly onStall: (error: RepoWriteStartupStalledError) => void;
+  }) {
+    this.stallTimeoutMs = input.stallTimeoutMs;
+    this.onStall = input.onStall;
+  }
+
+  wait(): Promise<void> {
+    if (this.pending) return this.pending.promise;
+    let resolveReady: (() => void) | undefined;
+    let rejectReady: ((error: Error) => void) | undefined;
+    const promise = new Promise<void>((resolve, reject) => {
+      resolveReady = resolve;
+      rejectReady = reject;
+    });
+    this.pending = {
+      promise,
+      resolve: resolveReady!,
+      reject: rejectReady!,
+      timer: this.armStallTimer()
+    };
+    return promise;
+  }
+
+  observe(message: RepoWriteStartupProgressFrame): void {
+    const progressKey = `${message.phase}\u0000${message.workUnit}`;
+    this.lastProgress = message;
+    if (this.progressSeen.has(progressKey)) {
+      this.repeatedProgressFrames += 1;
+      return;
+    }
+    this.progressSeen.add(progressKey);
+    this.repeatedProgressFrames = 0;
+    if (!this.pending) return;
+    clearTimeout(this.pending.timer);
+    this.pending.timer = this.armStallTimer();
+  }
+
+  resolve(): void {
+    if (!this.pending) return;
+    clearTimeout(this.pending.timer);
+    const pending = this.pending;
+    this.pending = undefined;
+    pending.resolve();
+  }
+
+  reject(error: Error): void {
+    if (!this.pending) return;
+    clearTimeout(this.pending.timer);
+    const pending = this.pending;
+    this.pending = undefined;
+    pending.reject(error);
+  }
+
+  private armStallTimer(): NodeJS.Timeout {
+    const timer = setTimeout(() => this.expire(), this.stallTimeoutMs);
+    timer.unref();
+    return timer;
+  }
+
+  private expire(): void {
+    const pending = this.pending;
+    if (!pending) return;
+    this.pending = undefined;
+    const error = new RepoWriteStartupStalledError({
+      stallTimeoutMs: this.stallTimeoutMs,
+      ...(this.lastProgress === undefined ? {} : {
+        phase: this.lastProgress.phase,
+        workUnit: this.lastProgress.workUnit
+      }),
+      repeatedProgressFrames: this.repeatedProgressFrames
+    });
+    this.onStall(error);
+    pending.reject(error);
+  }
+}

--- a/packages/daemon/src/runtime/repo-write-client.ts
+++ b/packages/daemon/src/runtime/repo-write-client.ts
@@ -11,12 +11,12 @@ import {
   createPendingRepoWriteLookup,
   createPendingRepoWriteSubmit,
   type PendingLookup,
-  type PendingReady,
   type PendingShutdown,
   type PendingSubmit
 } from "./repo-write-client-pending.ts";
 import type { RepoWriteClientLimits, RepoWriteClientOptions } from "./repo-write-client-contract.ts";
 import { resolveRepoWriteClientLimits } from "./repo-write-client-limits.ts";
+import { RepoWriteClientReadyGate } from "./repo-write-client-ready.ts";
 import { disconnectRepoWritePendingRequests } from "./repo-write-client-disconnect.ts";
 import {
   expireRepoWritePendingSubmit,
@@ -52,7 +52,6 @@ import {
   RepoWriteNotStartedError,
   RepoWriteOutcomeUnknownError,
   RepoWriteProtocolViolationError,
-  RepoWriteReadyTimeoutError,
   RepoWriteSendDeliveryError,
   RepoWriteShutdownTimeoutError
 } from "./repo-write-client-errors.ts";
@@ -65,13 +64,14 @@ export {
   RepoWriteNotStartedError,
   RepoWriteOutcomeUnknownError,
   RepoWriteProtocolViolationError,
-  RepoWriteReadyTimeoutError,
+  RepoWriteStartupStalledError,
   RepoWriteSendDeliveryError,
   RepoWriteShutdownTimeoutError,
   type RepoWriteSendDelivery
 } from "./repo-write-client-errors.ts";
 export {
-  RepoWriteDirectOutcomeUnknownError
+  RepoWriteDirectOutcomeUnknownError,
+  RepoWriteReadyTimeoutError
 } from "./repo-write-client-errors.ts";
 
 export class RepoWriteClient {
@@ -80,7 +80,7 @@ export class RepoWriteClient {
   private readonly pending = new Map<string, PendingSubmit>();
   private readonly directLane: RepoWriteDirectClientLane;
   private readonly pendingLookups = new Map<string, PendingLookup>();
-  private readyPending: PendingReady | undefined;
+  private readonly readyGate: RepoWriteClientReadyGate;
   private ready = false;
   private sequence = 0;
   private terminalError: Error | undefined;
@@ -103,6 +103,13 @@ export class RepoWriteClient {
       onRequestTimeout: options.onRequestTimeout,
       onRequestFailure: options.onRequestFailure
     });
+    this.readyGate = new RepoWriteClientReadyGate({
+      stallTimeoutMs: this.limits.readyTimeoutMs,
+      onStall: (error) => {
+        this.terminalError = error;
+        rejectRepoWriteQueuedRequests(this.pending, this.directLane, this.pendingLookups, error);
+      }
+    });
     options.transport.onMessage((message) => this.handleMessage(message));
     options.transport.onDisconnect((error) => this.handleDisconnect(error));
   }
@@ -115,30 +122,7 @@ export class RepoWriteClient {
     if (this.ready) return Promise.resolve();
     if (this.terminalError) return Promise.reject(this.terminalError);
     if (this.closing) return Promise.reject(new RepoWriteClientClosedError());
-    if (this.readyPending) return this.readyPending.promise;
-    let resolveReady: (() => void) | undefined;
-    let rejectReady: ((error: Error) => void) | undefined;
-    const promise = new Promise<void>((resolve, reject) => {
-      resolveReady = resolve;
-      rejectReady = reject;
-    });
-    const timer = setTimeout(() => {
-      const pending = this.readyPending;
-      if (!pending || pending.promise !== promise) return;
-      this.readyPending = undefined;
-      const error = new RepoWriteReadyTimeoutError(this.limits.readyTimeoutMs);
-      this.terminalError = error;
-      rejectRepoWriteQueuedRequests(this.pending, this.directLane, this.pendingLookups, error);
-      pending.reject(error);
-    }, this.limits.readyTimeoutMs);
-    timer.unref();
-    this.readyPending = {
-      promise,
-      resolve: resolveReady!,
-      reject: rejectReady!,
-      timer
-    };
-    return promise;
+    return this.readyGate.wait();
   }
 
   submit(command: RepoWriteCommandDto): Promise<RepoWriteJsonObject> {
@@ -205,9 +189,7 @@ export class RepoWriteClient {
     }
     this.closing = true;
     const closed = new RepoWriteClientClosedError();
-    if (this.readyPending) clearTimeout(this.readyPending.timer);
-    this.readyPending?.reject(closed);
-    this.readyPending = undefined;
+    this.readyGate.reject(closed);
     rejectRepoWriteQueuedRequests(this.pending, this.directLane, this.pendingLookups, closed);
     const requestId = this.nextRequestId();
     let resolveShutdown: (() => void) | undefined;
@@ -260,6 +242,14 @@ export class RepoWriteClient {
       return;
     }
     if (this.terminalError) return;
+    if (message.kind === "startup-progress") {
+      if (this.ready) {
+        this.failProtocol("Repo writer sent startup progress after READY.");
+        return;
+      }
+      this.readyGate.observe(message);
+      return;
+    }
     if (message.kind === "ready") {
       if (this.options.expectedArtifactIdentity !== undefined
         && message.artifactIdentity !== this.options.expectedArtifactIdentity) {
@@ -269,9 +259,7 @@ export class RepoWriteClient {
         return;
       }
       this.ready = true;
-      if (this.readyPending) clearTimeout(this.readyPending.timer);
-      this.readyPending?.resolve();
-      this.readyPending = undefined;
+      this.readyGate.resolve();
       for (const requestId of this.pending.keys()) this.dispatchSubmit(requestId);
       this.directLane.dispatchAll();
       for (const requestId of this.pendingLookups.keys()) this.dispatchLookup(requestId);
@@ -431,9 +419,7 @@ export class RepoWriteClient {
       "CAPSULE_DISCONNECTED",
       `Repo writer disconnected before the request started: ${error.message}`
     );
-    if (this.readyPending) clearTimeout(this.readyPending.timer);
-    this.readyPending?.reject(notStarted);
-    this.readyPending = undefined;
+    this.readyGate.reject(notStarted);
     disconnectRepoWritePendingRequests(
       this.pending,
       this.directLane,
@@ -458,9 +444,7 @@ export class RepoWriteClient {
     } catch {
       // A diagnostic observer cannot prevent the client from failing closed.
     }
-    if (this.readyPending) clearTimeout(this.readyPending.timer);
-    this.readyPending?.reject(violation);
-    this.readyPending = undefined;
+    this.readyGate.reject(violation);
     for (const [requestId, pending] of this.pending) {
       clearTimeout(pending.timer);
       this.pending.delete(requestId);

--- a/packages/daemon/src/runtime/repo-write-protocol-startup.ts
+++ b/packages/daemon/src/runtime/repo-write-protocol-startup.ts
@@ -1,0 +1,56 @@
+import type { RepoWriteProtocolLimits } from "./repo-write-protocol.ts";
+import {
+  repoWriteStartupProgressPhases,
+  type RepoWriteStartupProgressFrame,
+  type RepoWriteStartupProgressPhase
+} from "./repo-write-startup-protocol.ts";
+import {
+  invalidRepoWriteProtocol as invalid,
+  limitRepoWriteProtocol as limit
+} from "./repo-write-protocol-errors.ts";
+
+type StartupFrameRecord = Record<string, unknown> & { readonly kind: string };
+type StartupBaseFields = Pick<
+  RepoWriteStartupProgressFrame,
+  "protocol" | "repoId" | "generation"
+>;
+
+export function decodeRepoWriteStartupProgress(
+  frame: StartupFrameRecord,
+  limits: RepoWriteProtocolLimits,
+  baseFields: StartupBaseFields
+): RepoWriteStartupProgressFrame {
+  assertExactStartupKeys(frame);
+  if (!repoWriteStartupProgressPhases.includes(frame.phase as RepoWriteStartupProgressPhase)) {
+    invalid("$.phase", "startup progress phase");
+  }
+  return {
+    ...baseFields,
+    kind: "startup-progress",
+    phase: frame.phase as RepoWriteStartupProgressPhase,
+    workUnit: startupIdentifier(frame.workUnit, "$.workUnit", limits)
+  };
+}
+
+function assertExactStartupKeys(frame: Record<string, unknown>): void {
+  const required = ["protocol", "repoId", "generation", "kind", "phase", "workUnit"];
+  if (required.some((key) => !Object.hasOwn(frame, key))
+    || Object.keys(frame).some((key) => !required.includes(key))) {
+    invalid("$", "exact message fields");
+  }
+}
+
+function startupIdentifier(
+  value: unknown,
+  path: string,
+  limits: RepoWriteProtocolLimits
+): string {
+  if (typeof value !== "string") invalid(path, "string");
+  const maximumBytes = Math.min(limits.maxStringBytes, 4_096);
+  const actualBytes = Buffer.byteLength(value, "utf8");
+  if (actualBytes > maximumBytes) {
+    limit(path, "string byte length", actualBytes, maximumBytes);
+  }
+  if (!value.trim()) invalid(path, "non-empty identifier");
+  return value;
+}

--- a/packages/daemon/src/runtime/repo-write-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-protocol.ts
@@ -4,6 +4,13 @@ export * from "./repo-write-command-dto.ts";
 import { repoWriteTerminalReceiptMatches } from "./repo-write-terminal-receipt.ts";
 import { type RepoWriteRecoveryDeferredFrame, type RepoWriteRecoveryDiagnosticFrame, type RepoWriteRecoveryRejectedFrame, type RepoWriteTelemetryFrame } from "./repo-write-diagnostic-protocol.ts";
 import { decodeRepoWriteTelemetry } from "./repo-write-protocol-telemetry.ts";
+import { decodeRepoWriteStartupProgress } from "./repo-write-protocol-startup.ts";
+import type { RepoWriteStartupProgressFrame } from "./repo-write-startup-protocol.ts";
+export {
+  repoWriteStartupProgressPhases,
+  type RepoWriteStartupProgressFrame,
+  type RepoWriteStartupProgressPhase
+} from "./repo-write-startup-protocol.ts";
 export type { RepoWriteRecoveryDeferredFrame, RepoWriteRecoveryDiagnosticFrame, RepoWriteRecoveryRejectedFrame, RepoWriteTelemetryDetail, RepoWriteTelemetryDetails, RepoWriteTelemetryFrame, RepoWriteTelemetryPhase } from "./repo-write-diagnostic-protocol.ts";
 export { boundedRepoWriteDiagnostic } from "./repo-write-protocol-diagnostic.ts";
 import {
@@ -137,7 +144,8 @@ export type RepoWriteOperationLookupResult =
 export type RepoWriteStatusFrame = RepoWriteOperationFrame<"status"> & RepoWriteOperationLookupResult;
 
 export type RepoWriteChildMessage =
-  RepoWriteReadyFrame | RepoWritePreparedFrame | RepoWriteTerminalFrame | RepoWriteFailureFrame
+  RepoWriteReadyFrame | RepoWriteStartupProgressFrame
+  | RepoWritePreparedFrame | RepoWriteTerminalFrame | RepoWriteFailureFrame
   | RepoWriteDirectResultFrame | RepoWriteDirectFailureFrame
   | RepoWriteStatusFrame | RepoWriteTelemetryFrame | RepoWriteRecoveryDiagnosticFrame
   | RepoWriteDrainedFrame;
@@ -182,6 +190,9 @@ export function decodeRepoWriteChildMessage(
   const limits = resolveLimits(overrides);
   const budget = { nodes: 0 };
   const frame = frameBase(value, limits, budget);
+  if (frame.kind === "startup-progress") {
+    return decodeRepoWriteStartupProgress(frame, limits, baseFields(frame));
+  }
   if (frame.kind === "ready") return decodeReady(frame, limits);
   if (frame.kind === "prepared") return decodeOperationFrame(frame, limits, "prepared");
   if (frame.kind === "terminal") return decodeTerminal(frame, limits, budget);

--- a/packages/daemon/src/runtime/repo-write-startup-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-startup-protocol.ts
@@ -1,0 +1,26 @@
+interface RepoWriteStartupFrameBase {
+  readonly protocol: "harness-repo-write-ipc/v1";
+  readonly repoId: string;
+  readonly generation: number;
+}
+
+export const repoWriteStartupProgressPhases = [
+  "artifact-identity",
+  "authority-manifest",
+  "conflict-marker-preflight",
+  "runtime-create",
+  "runtime-start",
+  "authority-lifecycle-compose",
+  "authority-start-repo",
+  "historical-recovery-scan",
+  "historical-recovery",
+  "child-host-start"
+] as const;
+
+export type RepoWriteStartupProgressPhase = typeof repoWriteStartupProgressPhases[number];
+
+export interface RepoWriteStartupProgressFrame extends RepoWriteStartupFrameBase {
+  readonly kind: "startup-progress";
+  readonly phase: RepoWriteStartupProgressPhase;
+  readonly workUnit: string;
+}

--- a/packages/daemon/test/repo-write-client-startup.test.ts
+++ b/packages/daemon/test/repo-write-client-startup.test.ts
@@ -1,0 +1,135 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  RepoWriteClient,
+  RepoWriteProtocolViolationError,
+  RepoWriteStartupStalledError
+} from "../src/runtime/repo-write-client.ts";
+import {
+  FakeRepoWriteTransport,
+  childFrame,
+  command,
+  fixtureClient,
+  readyFrame
+} from "./support/repo-write-client-fixture.ts";
+
+test("rejects queued work when writer startup makes no semantic progress", async () => {
+  const transport = new FakeRepoWriteTransport();
+  const client = new RepoWriteClient({
+    repoId: "repo-canonical",
+    generation: 7,
+    transport,
+    limits: { readyTimeoutMs: 10, requestTimeoutMs: 50 },
+    onTelemetry: () => undefined
+  });
+  const ready = client.waitUntilReady().then(
+    () => ({ kind: "resolved" as const }),
+    (error: unknown) => ({ kind: "rejected" as const, error })
+  );
+  const submission = client.submit(command("task.create")).then(
+    () => ({ kind: "resolved" as const }),
+    (error: unknown) => ({ kind: "rejected" as const, error })
+  );
+
+  const outcome = await Promise.race([
+    submission,
+    new Promise<{ readonly kind: "still-pending" }>((resolve) => {
+      setTimeout(() => resolve({ kind: "still-pending" }), 100);
+    })
+  ]);
+
+  assert.equal(outcome.kind, "rejected");
+  assert.ok(outcome.kind === "rejected" && outcome.error instanceof RepoWriteStartupStalledError);
+  assert.equal(outcome.error.code, "REPO_WRITE_STARTUP_STALLED");
+  assert.match(outcome.error.message, /startup stalled: no new phase\/work unit/u);
+  assert.doesNotMatch(outcome.error.message, /still starting/u);
+  const readyOutcome = await ready;
+  assert.ok(readyOutcome.kind === "rejected" && readyOutcome.error instanceof RepoWriteStartupStalledError);
+  assert.deepEqual(transport.sent, []);
+});
+
+test("previously unseen startup work units extend readiness beyond the total stall window", async (context) => {
+  context.mock.timers.enable({ apis: ["setTimeout"] });
+  const transport = new FakeRepoWriteTransport();
+  const client = new RepoWriteClient({
+    repoId: "repo-canonical",
+    generation: 7,
+    transport,
+    limits: { readyTimeoutMs: 100 },
+    onTelemetry: () => undefined
+  });
+  const ready = client.waitUntilReady();
+
+  context.mock.timers.tick(90);
+  transport.emit({
+    ...childFrame("startup-progress"),
+    phase: "runtime-start",
+    workUnit: "repo-canonical"
+  });
+  context.mock.timers.tick(90);
+  transport.emit({
+    ...childFrame("startup-progress"),
+    phase: "historical-recovery",
+    workUnit: "repo-write:outer-op-1"
+  });
+  context.mock.timers.tick(90);
+  transport.emit(readyFrame());
+
+  await ready;
+});
+
+test("repeated startup frames for the same work unit do not conceal a stall", async (context) => {
+  context.mock.timers.enable({ apis: ["setTimeout"] });
+  const transport = new FakeRepoWriteTransport();
+  const client = new RepoWriteClient({
+    repoId: "repo-canonical",
+    generation: 7,
+    transport,
+    limits: { readyTimeoutMs: 100 },
+    onTelemetry: () => undefined
+  });
+  const ready = client.waitUntilReady().then(
+    () => ({ kind: "resolved" as const }),
+    (error: unknown) => ({ kind: "rejected" as const, error })
+  );
+  const repeated = {
+    ...childFrame("startup-progress"),
+    phase: "historical-recovery" as const,
+    workUnit: "repo-write:outer-op-stuck"
+  };
+
+  transport.emit(repeated);
+  context.mock.timers.tick(60);
+  transport.emit(repeated);
+  context.mock.timers.tick(39);
+  transport.emit(repeated);
+  context.mock.timers.tick(1);
+
+  const outcome = await ready;
+  assert.equal(outcome.kind, "rejected");
+  assert.ok(outcome.kind === "rejected" && outcome.error instanceof RepoWriteStartupStalledError);
+  assert.equal(outcome.error.phase, "historical-recovery");
+  assert.equal(outcome.error.workUnit, "repo-write:outer-op-stuck");
+  assert.equal(outcome.error.repeatedProgressFrames, 2);
+  assert.match(outcome.error.message, /workUnit=repo-write:outer-op-stuck, repeatedFrames=2/u);
+});
+
+test("startup progress after READY is a protocol violation", async () => {
+  const transport = new FakeRepoWriteTransport();
+  const client = fixtureClient(transport);
+  transport.emit(readyFrame());
+  await client.waitUntilReady();
+
+  transport.emit({
+    ...childFrame("startup-progress"),
+    phase: "runtime-start",
+    workUnit: "repo-canonical"
+  });
+
+  await assert.rejects(client.submit(command("task.create")), (error) => {
+    assert.ok(error instanceof RepoWriteProtocolViolationError);
+    assert.match(error.message, /startup progress after READY/u);
+    return true;
+  });
+});

--- a/packages/daemon/test/repo-write-client.test.ts
+++ b/packages/daemon/test/repo-write-client.test.ts
@@ -10,7 +10,6 @@ import {
   RepoWriteNotStartedError,
   RepoWriteOutcomeUnknownError,
   RepoWriteProtocolViolationError,
-  RepoWriteReadyTimeoutError,
   RepoWriteShutdownTimeoutError
 } from "../src/runtime/repo-write-client.ts";
 import {
@@ -101,38 +100,6 @@ test("starts the durable request deadline only after READY dispatches the reques
   });
 
   assert.deepEqual(await outcome, { kind: "resolved", receipt });
-});
-
-test("rejects a queued durable request when the writer misses its READY deadline", async () => {
-  const transport = new FakeRepoWriteTransport();
-  const client = new RepoWriteClient({
-    repoId: "repo-canonical",
-    generation: 7,
-    transport,
-    limits: { readyTimeoutMs: 10, requestTimeoutMs: 50 },
-    onTelemetry: () => undefined
-  });
-  const ready = client.waitUntilReady().then(
-    () => ({ kind: "resolved" as const }),
-    (error: unknown) => ({ kind: "rejected" as const, error })
-  );
-  const submission = client.submit(command("task.create")).then(
-    () => ({ kind: "resolved" as const }),
-    (error: unknown) => ({ kind: "rejected" as const, error })
-  );
-
-  const outcome = await Promise.race([
-    submission,
-    new Promise<{ readonly kind: "still-pending" }>((resolve) => {
-      setTimeout(() => resolve({ kind: "still-pending" }), 100);
-    })
-  ]);
-
-  assert.equal(outcome.kind, "rejected");
-  assert.ok(outcome.kind === "rejected" && outcome.error instanceof RepoWriteReadyTimeoutError);
-  const readyOutcome = await ready;
-  assert.ok(readyOutcome.kind === "rejected" && readyOutcome.error instanceof RepoWriteReadyTimeoutError);
-  assert.deepEqual(transport.sent, []);
 });
 
 test("shutdown rejects a queued durable request before READY", async () => {

--- a/packages/daemon/test/repo-write-process-supervisor.test.ts
+++ b/packages/daemon/test/repo-write-process-supervisor.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
@@ -18,7 +18,7 @@ import {
   RepoWriteDirectOutcomeUnknownError,
   RepoWriteOutcomeUnknownError,
   RepoWriteProtocolViolationError,
-  RepoWriteReadyTimeoutError
+  RepoWriteStartupStalledError
 } from "../src/runtime/repo-write-client.ts";
 import {
   calculateDaemonArtifactIdentity
@@ -290,7 +290,7 @@ test("replacement child gets a fresh client whose first request is cold-start se
   assert.equal(classifyProvenanceCapacitySample(telemetryRequestIds[1]!, 1), "cold-start");
 });
 
-test("connected child that never announces READY is terminated at the readiness deadline", async (context) => {
+test("connected child with no startup progress is terminated after the stall window", async (context) => {
   const supervisor = new RepoWriteProcessSupervisor({
     repoId: "repo-transport",
     generation: 1,
@@ -305,8 +305,67 @@ test("connected child that never announces READY is terminated at the readiness 
   context.after(() => supervisor.stop().catch(() => undefined));
 
   await assert.rejects(supervisor.start(), (error) => {
-    assert.ok(error instanceof RepoWriteReadyTimeoutError);
-    assert.equal(error.code, "REPO_WRITE_READY_TIMEOUT");
+    assert.ok(error instanceof RepoWriteStartupStalledError);
+    assert.equal(error.code, "REPO_WRITE_STARTUP_STALLED");
+    assert.match(error.message, /startup stalled/u);
+    return true;
+  });
+  assert.equal(supervisor.status().connected, false);
+});
+
+test("slow startup with distinct work units may exceed one stall window", async (context) => {
+  const supervisor = new RepoWriteProcessSupervisor({
+    repoId: "repo-transport",
+    generation: 1,
+    limits: { readyTimeoutMs: 1_000 },
+    spawn: () => forkRepoWriteProcess({
+      modulePath: fixturePath,
+      args: ["slow-startup-progress"]
+    })
+  });
+  context.after(() => supervisor.stop().catch(() => undefined));
+
+  const startedAt = performance.now();
+  await supervisor.start();
+
+  assert.ok(performance.now() - startedAt > 1_000);
+  assert.equal(supervisor.status().connected, true);
+});
+
+test("alive child repeating one startup work unit is terminated as stalled", async (context) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "ha-repo-write-startup-stall-"));
+  const tracePath = path.join(root, "trace.log");
+  let transport: RepoWriteParentProcessTransport | undefined;
+  const supervisor = new RepoWriteProcessSupervisor({
+    repoId: "repo-transport",
+    generation: 1,
+    limits: { readyTimeoutMs: 1_000 },
+    spawn: () => {
+      transport = forkRepoWriteProcess({
+        modulePath: fixturePath,
+        args: ["repeat-startup-work-unit", tracePath]
+      });
+      return transport;
+    }
+  });
+  context.after(async () => {
+    await supervisor.stop().catch(() => undefined);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const starting = supervisor.start();
+  await waitFor(() => existsSync(tracePath));
+  assert.ok(transport);
+  assert.equal(transport.child.exitCode, null);
+  assert.equal(transport.child.signalCode, null);
+
+  await assert.rejects(starting, (error) => {
+    assert.ok(error instanceof RepoWriteStartupStalledError);
+    assert.equal(error.phase, "historical-recovery");
+    assert.equal(error.workUnit, "repo-write:outer-op-stuck");
+    assert.ok(error.repeatedProgressFrames > 0);
+    assert.match(error.message, /startup stalled/u);
+    assert.doesNotMatch(error.message, /still starting/u);
     return true;
   });
   assert.equal(supervisor.status().connected, false);

--- a/packages/daemon/test/repo-write-protocol.test.ts
+++ b/packages/daemon/test/repo-write-protocol.test.ts
@@ -374,8 +374,13 @@ test("failure after proceed requires outcome-unknown, stable opId, and no replay
   assert.throws(() => decodeRepoWriteChildMessage(withoutOpId), protocolInvalid);
 });
 
-test("ready, terminal, status, telemetry, shutdown, and drained frames have exact schemas", () => {
+test("startup progress, ready, terminal, status, telemetry, shutdown, and drained frames have exact schemas", () => {
   const committedReceipt = committedCommandReceipt();
+  const startupProgress = decodeRepoWriteChildMessage({
+    ...base("startup-progress"),
+    phase: "historical-recovery",
+    workUnit: "repo-write:outer-op-1"
+  });
   const ready = decodeRepoWriteChildMessage({
     ...base("ready"),
     artifactIdentity: `sha256:${"a".repeat(64)}`
@@ -423,6 +428,11 @@ test("ready, terminal, status, telemetry, shutdown, and drained frames have exac
     requestId: "shutdown-1"
   });
 
+  assert.deepEqual(startupProgress, {
+    ...base("startup-progress"),
+    phase: "historical-recovery",
+    workUnit: "repo-write:outer-op-1"
+  });
   assert.equal(ready.kind, "ready");
   assert.equal(terminal.kind, "terminal");
   assert.equal(statusRequest.kind, "status");
@@ -439,6 +449,18 @@ test("ready, terminal, status, telemetry, shutdown, and drained frames have exac
   );
   assert.equal(shutdown.kind, "shutdown");
   assert.equal(drained.kind, "drained");
+  assert.throws(() => decodeRepoWriteChildMessage({
+    ...startupProgress,
+    requestId: "not-allowed"
+  }), protocolInvalid);
+  assert.throws(() => decodeRepoWriteChildMessage({
+    ...startupProgress,
+    phase: "tick"
+  }), protocolInvalid);
+  assert.throws(() => decodeRepoWriteChildMessage({
+    ...startupProgress,
+    workUnit: ""
+  }), protocolInvalid);
   assert.throws(() => decodeRepoWriteChildMessage({ ...ready, requestId: "not-allowed" }), protocolInvalid);
   assert.throws(() => decodeRepoWriteParentMessage({ ...shutdown, deadlineMs: 5_000 }), protocolInvalid);
   assert.throws(() => decodeRepoWriteChildMessage({ ...telemetry, payload: "not telemetry" }), protocolInvalid);

--- a/packages/daemon/test/support/repo-write-ipc-child.ts
+++ b/packages/daemon/test/support/repo-write-ipc-child.ts
@@ -243,7 +243,28 @@ if (mode === "expected-direct-rejection") {
     }
   });
 
-  if (mode === "never-ready") {
+  if (mode === "slow-startup-progress") {
+    await transport.send(startupProgress("runtime-start", "repo-transport"));
+    await delay(600);
+    await transport.send(startupProgress("historical-recovery", "repo-write:outer-op-1"));
+    await delay(600);
+    await transport.send(startupProgress("historical-recovery", "repo-write:outer-op-2"));
+    await delay(600);
+    await transport.send({
+      protocol: repoWriteProtocolType,
+      repoId: "repo-transport",
+      generation: 1,
+      kind: "ready",
+      artifactIdentity: `sha256:${"a".repeat(64)}`
+    });
+  } else if (mode === "repeat-startup-work-unit") {
+    const repeated = startupProgress("historical-recovery", "repo-write:outer-op-stuck");
+    await transport.send(repeated);
+    trace("startup-progress:repo-write:outer-op-stuck");
+    setInterval(() => {
+      void transport.send(repeated);
+    }, 10).unref();
+  } else if (mode === "never-ready") {
     // Stay connected so the parent must enforce its readiness deadline.
   } else if (mode === "malformed-child") {
     process.send?.({ protocol: "wrong", kind: "ready" });
@@ -267,6 +288,24 @@ if (mode === "expected-direct-rejection") {
       artifactIdentity: `sha256:${"a".repeat(64)}`
     });
   }
+}
+
+function startupProgress(
+  phase: "runtime-start" | "historical-recovery",
+  workUnit: string
+) {
+  return {
+    protocol: repoWriteProtocolType,
+    repoId: "repo-transport",
+    generation: 1,
+    kind: "startup-progress",
+    phase,
+    workUnit
+  } as const;
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 function trace(event: string): void {


### PR DESCRIPTION
# English

## Summary

PR #1287 stopped the client from calling a slow cold start "dead": it now checks whether the spawned pid is alive instead of treating a 30-second timeout as death. That closed the false-negative, but it opened a false-positive — a pid that is alive proves the process has not exited, not that it is making progress. A genuinely wedged writer was reported as `daemon_starting` forever.

This change gives the pre-READY phase a progress signal and switches the readiness wait from a total-duration timeout to a stall timeout.

The load-bearing detail is what counts as progress. On 2026-08-08, 26 repo-write proceedings had been re-proving themselves on every daemon startup since 08-05, each failing with `spawnSync git ENOBUFS`, filling the child's entire pre-READY budget. **A heartbeat that only says "I am still doing something" would have reported healthy through all four days.** So only a *previously unseen* phase/work-unit pair renews the stall window; repeating the same work unit does not count as progress.

## What Changed

- `packages/daemon/src/runtime/repo-write-startup-protocol.ts` and `repo-write-protocol-startup.ts` (new): a `startup-progress` frame carrying `phase` and `workUnit`, with **no `requestId`**, accepted only before READY. The existing `telemetry` frame could not be reused — it requires a `requestId`, and before READY no request has been sent to the child, so no legal id exists.
- `packages/daemon/src/runtime/repo-write-client-ready.ts` (new): the readiness wait tracks the set of phase/work-unit pairs seen this child generation and renews its window only on a new one.
- `packages/daemon/src/runtime/repo-write-client-errors.ts`: `RepoWriteStartupStalledError` (`REPO_WRITE_STARTUP_STALLED`), extending `RepoWriteNotStartedError` so `command-service.ts` propagates its code and message to the caller receipt intact rather than flattening it into a generic unavailability.
- `packages/cli/src/composition/repo-write-child-entrypoint.ts`: the writer emits progress frames around its startup phases, built on the stderr NDJSON phase instrumentation that #1288 already landed.
- `readyTimeoutMs` is unchanged. Raising it was rejected in #1287 as treating the symptom, and it is still the wrong lever: the client would still be guessing from elapsed time.

The stalled error names what is stuck, not merely that something is:

```
Repo writer startup stalled: no new phase/work unit for 1000ms;
last phase=historical-recovery, workUnit=repo-write:outer-op-stuck, repeatedFrames=2.
```

## Task And Scope

- Harness task: `task_01KZJFGNMC82SM7BNTSRTDMCVB`
- Authority: `dec_01KZJGY93FQQEKSVVC8HJJ9YJV` (active) — CH1 the frame carries no `requestId` and is pre-READY only; CH2 the payload must name the phase and work unit, not merely tick; CH3 do not alter `telemetry`, `proceededStallTimeoutMs`, or `readyTimeoutMs`
- Branch: `codex/writer-child-heartbeat`
- Public scope: `packages/daemon/src/runtime/**` (startup protocol, ready wait, client errors), `packages/cli/src/composition/repo-write-child-entrypoint.ts`, and their tests
- Private planning/evidence updated: yes
- Out of scope: bounded automatic retry itself, which belongs to `dec_01KZJF4YGRH57R3NPW0PQ5AFGW` and its own task — this change makes the pathology *visible*, it does not bound it

## Version Impact

- Version: no version change because this is a behavior fix inside existing packages, with no published entrypoint added or removed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `dec_01KZJGY93FQQEKSVVC8HJJ9YJV`, `task_01KZJFGNMC82SM7BNTSRTDMCVB`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `220661b4`
- Branch merge-base with `origin/main`: `220661b4`
- Last `git fetch origin` time: 2026-08-09, immediately before the rebase that produced `7da2fe46`
- Sync method: rebase
- Public diff command: `git diff 220661b4..7da2fe46 -- packages/`
- Private evidence commit/path: `harness/tasks/task_01KZJFGNMC82SM7BNTSRTDMCVB-writer-child/artifacts/sol-startup-progress-report.md`
- Reviewer evidence path: same report, plus `sol-blocker-protocol-semantics.md` recording the three premises that were falsified before implementation started
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` — `npm run check:local`, 27 manifest gates green in 287.5s, after the rebase onto `220661b4`
- [x] Targeted tests for the change surface, named with their counts: repo-write client/protocol targeted 37/37; repo-write process supervisor integration 16/16; production repo-write child cutover fixture passes. Both directions are covered with a real forked child, not a mock:
  - *slow startup with distinct work units may exceed one stall window* — `readyTimeoutMs=1000`, a new work unit every 600 ms, total startup ≈ 2376 ms, still reaches READY.
  - *alive child repeating one startup work unit is terminated as stalled* — the child re-reports `historical-recovery/repo-write:outer-op-stuck` every 10 ms; the trace confirms its pid is alive at the moment of judgement; `REPO_WRITE_STARTUP_STALLED` after ≈ 1545 ms.
- [x] Performance: 10 paired samples, median 137 ms → 140 ms (+3 ms). No regression observed.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: `npm run check:ci` was not run locally; CI is the authoritative full gate for the gates outside the local stop point.

## Review Evidence

- Self-review: traced the new error to the caller, not just to the throw site. `RepoWriteStartupStalledError` extends `RepoWriteNotStartedError`, and `packages/daemon/src/service/command-service.ts:165` uses `error.code` and `error.message` directly, so the stall reason reaches the receipt with its phase and work unit intact instead of collapsing into "repo is not attached". Confirmed the text suggests neither `ha daemon restart` nor `HARNESS_DAEMON_MODE=direct`.
- Reviewer subagent: the implementation stopped before writing code and falsified all three premises it was given — `telemetry` mandates `requestId`, `proceededStallTimeoutMs` governs only PROCEED operations with an `opId`, and the writer entrypoint had moved to `packages/cli/src/composition/`. It also found #1288 had already landed the pre-READY phase instrumentation. The protocol addition was adjudicated as `dec_01KZJGY93FQQEKSVVC8HJJ9YJV` before implementation resumed.
- Human review: pending
- Blocking findings: none outstanding

## Residual Risk

- The seen-set is per child generation. The same proceeding failing again across generations is not bounded by this change; that is `dec_01KZJF4YGRH57R3NPW0PQ5AFGW`'s aspect and is deliberately not duplicated here.
- A single legitimate work unit that blocks for longer than the window will be judged stalled. That is the intended semantics, but a future unit with provably bounded work longer than the window must expose sub-phases rather than reverting to a bare tick.
- This touches the production child entrypoint next to the recovery line's surface. This commit only emits progress before the recovery call; a merge must preserve the other line's recovery changes.

## References

- Task: `task_01KZJFGNMC82SM7BNTSRTDMCVB`
- Decision: `dec_01KZJGY93FQQEKSVVC8HJJ9YJV`; context in `dec_01KZJF4YGRH57R3NPW0PQ5AFGW`
- Evidence: `harness/tasks/task_01KZJFGNMC82SM7BNTSRTDMCVB-writer-child/artifacts/sol-startup-progress-report.md`

---

# 中文

## 概要

PR #1287 让客户端不再把冷启动慢当成「已死」：改为检查 spawned pid 是否还活着，而不是把 30 秒超时当死亡。那堵住了假阴性，却开了一个假阳性 —— pid 活着只证明进程没退出，不证明它在进展。真正卡死的 writer 会被永远报成 `daemon_starting`。

本改动给 pre-READY 阶段一个进展信号，并把 ready 等待从「总时长超时」换成「停滞超时」。

**承重的细节是「什么才算进展」。** 2026-08-08 那天，26 笔 repo-write proceeding 自 08-05 起每次 daemon 启动都被重新取证一遍，每次因 `spawnSync git ENOBUFS` 失败，把 child 的整个 pre-READY 预算填满。**一个只说「我还在做事」的心跳，会在这四天里全程报健康。** 所以只有**此前没见过的** phase/workUnit 组合才续期停滞窗口；重复同一个工作单元不算进展。

## 改动内容

- `packages/daemon/src/runtime/repo-write-startup-protocol.ts` 与 `repo-write-protocol-startup.ts`（新增）：`startup-progress` 帧，携带 `phase` 与 `workUnit`，**不带 `requestId`**，只在 READY 之前被接受。现有 `telemetry` 帧无法复用 —— 它强制要求 `requestId`，而 READY 前没有任何请求发给 child，因此不存在合法 id。
- `packages/daemon/src/runtime/repo-write-client-ready.ts`（新增）：ready 等待记录本 child generation 内见过的 phase/workUnit 集合，只在出现新组合时续期窗口。
- `packages/daemon/src/runtime/repo-write-client-errors.ts`：新增 `RepoWriteStartupStalledError`（`REPO_WRITE_STARTUP_STALLED`），继承 `RepoWriteNotStartedError`，使 `command-service.ts` 把它的 code 与 message 原样传到调用方回执，而不是压扁成一句泛泛的不可用。
- `packages/cli/src/composition/repo-write-child-entrypoint.ts`：writer 在其启动阶段前后发出进展帧，建立在 #1288 已落地的 stderr NDJSON 阶段插桩之上。
- `readyTimeoutMs` 未改。调大它在 #1287 已被判定为治标，现在依然是错的杠杆：客户端仍然只是在用耗时猜。

停滞错误点名的是**卡在哪**，而不只是「有东西卡了」：

```
Repo writer startup stalled: no new phase/work unit for 1000ms;
last phase=historical-recovery, workUnit=repo-write:outer-op-stuck, repeatedFrames=2.
```

## 任务与范围

- Harness task：`task_01KZJFGNMC82SM7BNTSRTDMCVB`
- 授权：`dec_01KZJGY93FQQEKSVVC8HJJ9YJV`（active）—— CH1 帧不带 `requestId` 且只在 READY 前；CH2 载荷必须点名阶段与工作单元，不得只报滴答；CH3 不改 `telemetry`、`proceededStallTimeoutMs`、`readyTimeoutMs`
- 分支：`codex/writer-child-heartbeat`
- 公开范围：`packages/daemon/src/runtime/**`（启动协议、ready 等待、client errors）、`packages/cli/src/composition/repo-write-child-entrypoint.ts` 及其测试
- 私有规划/证据已更新：是
- 不在范围内：有界自动重试本身，那归 `dec_01KZJF4YGRH57R3NPW0PQ5AFGW` 及其自己的任务 —— 本改动让病理**可见**，不负责给它加界

## 版本影响

- 版本：无变更，因为这是既有 package 内的行为修复，未增删任何已发布入口
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：`dec_01KZJGY93FQQEKSVVC8HJJ9YJV`、`task_01KZJFGNMC82SM7BNTSRTDMCVB`
- 机检边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`220661b4`
- 分支与 `origin/main` 的 merge-base：`220661b4`
- 最近一次 `git fetch origin`：2026-08-09，就在产出 `7da2fe46` 的那次 rebase 之前
- 同步方式：rebase
- 公开 diff 命令：`git diff 220661b4..7da2fe46 -- packages/`
- 私有证据 commit/路径：`harness/tasks/task_01KZJFGNMC82SM7BNTSRTDMCVB-writer-child/artifacts/sol-startup-progress-report.md`
- 评审证据路径：同一份报告，另加 `sol-blocker-protocol-semantics.md`，记录了动手前被证伪的三条前提
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑
- [x] `git diff --check`
- [x] `npm run check:stop-point` —— `npm run check:local`，27 个 manifest 门绿，287.5s，在 rebase 到 `220661b4` 之后
- [x] 针对改动面的定向测试及计数：repo-write client/protocol 定向 37/37；repo-write process supervisor 集成 16/16；生产 repo-write child cutover fixture 通过。**两个方向都用真实 fork 出来的 child 覆盖，不是 mock**：
  - *slow startup with distinct work units may exceed one stall window* —— `readyTimeoutMs=1000`，每 600 ms 报一个新工作单元，总启动约 2376 ms，仍然到达 READY。
  - *alive child repeating one startup work unit is terminated as stalled* —— child 每 10 ms 重报 `historical-recovery/repo-write:outer-op-stuck`；trace 在判定时刻确认其 pid 仍活着；约 1545 ms 后得到 `REPO_WRITE_STARTUP_STALLED`。
- [x] 性能：10 组配对样本，中位数 137 ms → 140 ms（+3 ms），未观察到回归。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威的完整门）
- 未跑及原因：本地未跑 `npm run check:ci`；本地停止点之外的门以 CI 为权威。

## 评审证据

- 自审：把新错误**一路追到调用方**，而不只看抛出点。`RepoWriteStartupStalledError` 继承 `RepoWriteNotStartedError`，而 `packages/daemon/src/service/command-service.ts:165` 直接使用 `error.code` 与 `error.message`，所以停滞原因带着 phase 与 workUnit 原样进入回执，不会坍缩成「repo 未附着」。并确认文案既不建议 `ha daemon restart`，也不建议 `HARNESS_DAEMON_MODE=direct`。
- 评审子代理：实现者在写代码前先停住，把交给它的三条前提**全部证伪** —— `telemetry` 强制 `requestId`、`proceededStallTimeoutMs` 只管带 `opId` 的 PROCEED 操作、writer 入口已搬到 `packages/cli/src/composition/`。它还查到 #1288 已经落了 pre-READY 阶段插桩。协议新增在恢复实现前被裁为 `dec_01KZJGY93FQQEKSVVC8HJJ9YJV`。
- 人工评审：待办
- 阻断性发现：无遗留

## 残留风险

- 「见过集合」按单个 child generation 保存。同一 proceeding 跨 generation 反复失败不受本改动约束；那是 `dec_01KZJF4YGRH57R3NPW0PQ5AFGW` 的切面，此处刻意不重复实现。
- 单个合法工作单元若自身阻塞超过窗口，会被判停滞。这正是当前语义；但若未来存在可证明的、单单元内超过窗口的有界工作，该单元需要暴露语义子阶段，而不是退回裸滴答。
- 本改动触及生产 child 入口，与 recovery 那条线的面相邻。本提交只在 recovery 调用**之前**发进展帧；合并时须保留对方对 recovery 行为的改动。

## 参考

- Task：`task_01KZJFGNMC82SM7BNTSRTDMCVB`
- 决策：`dec_01KZJGY93FQQEKSVVC8HJJ9YJV`；背景见 `dec_01KZJF4YGRH57R3NPW0PQ5AFGW`
- 证据：`harness/tasks/task_01KZJFGNMC82SM7BNTSRTDMCVB-writer-child/artifacts/sol-startup-progress-report.md`
