### PR TITLE
test(daemon): size the startup stall window above child process boot

### DIFF
--- a/packages/daemon/test/repo-write-process-supervisor.test.ts
+++ b/packages/daemon/test/repo-write-process-supervisor.test.ts
@@ -313,11 +313,23 @@ test("connected child with no startup progress is terminated after the stall win
   assert.equal(supervisor.status().connected, false);
 });
 
+/**
+ * The stall window also covers the child's own process boot, because the first
+ * progress frame cannot arrive before the fork is running. A window sized below
+ * that boot cost measures runner speed rather than the detector: at 1_000ms this
+ * test failed on CI with zero frames observed while boot took ~1.2s. Production
+ * has no such squeeze (`readyTimeoutMs` is 30_000), so the window here stays
+ * several times the observed boot cost, and the fixture's inter-frame gap stays
+ * several times below the window. Both margins are load-bearing — shrink either
+ * and the test starts reporting how busy the machine is.
+ */
+const STARTUP_STALL_WINDOW_MS = 3_000;
+
 test("slow startup with distinct work units may exceed one stall window", async (context) => {
   const supervisor = new RepoWriteProcessSupervisor({
     repoId: "repo-transport",
     generation: 1,
-    limits: { readyTimeoutMs: 1_000 },
+    limits: { readyTimeoutMs: STARTUP_STALL_WINDOW_MS },
     spawn: () => forkRepoWriteProcess({
       modulePath: fixturePath,
       args: ["slow-startup-progress"]
@@ -328,7 +340,9 @@ test("slow startup with distinct work units may exceed one stall window", async 
   const startedAt = performance.now();
   await supervisor.start();
 
-  assert.ok(performance.now() - startedAt > 1_000);
+  // Reaching READY later than one whole window is the discriminating claim:
+  // without renewal on each new work unit the child would have been killed.
+  assert.ok(performance.now() - startedAt > STARTUP_STALL_WINDOW_MS);
   assert.equal(supervisor.status().connected, true);
 });
 
@@ -339,7 +353,7 @@ test("alive child repeating one startup work unit is terminated as stalled", asy
   const supervisor = new RepoWriteProcessSupervisor({
     repoId: "repo-transport",
     generation: 1,
-    limits: { readyTimeoutMs: 1_000 },
+    limits: { readyTimeoutMs: STARTUP_STALL_WINDOW_MS },
     spawn: () => {
       transport = forkRepoWriteProcess({
         modulePath: fixturePath,

--- a/packages/daemon/test/support/repo-write-ipc-child.ts
+++ b/packages/daemon/test/support/repo-write-ipc-child.ts
@@ -244,12 +244,19 @@ if (mode === "expected-direct-rejection") {
   });
 
   if (mode === "slow-startup-progress") {
+    // Each gap must stay well under the parent's stall window while the gaps
+    // together outlast a whole window, so the run proves renewal rather than
+    // proving the window was simply generous. See STARTUP_STALL_WINDOW_MS in
+    // repo-write-process-supervisor.test.ts.
+    const gapMs = 900;
     await transport.send(startupProgress("runtime-start", "repo-transport"));
-    await delay(600);
+    await delay(gapMs);
     await transport.send(startupProgress("historical-recovery", "repo-write:outer-op-1"));
-    await delay(600);
+    await delay(gapMs);
     await transport.send(startupProgress("historical-recovery", "repo-write:outer-op-2"));
-    await delay(600);
+    await delay(gapMs);
+    await transport.send(startupProgress("historical-recovery", "repo-write:outer-op-3"));
+    await delay(gapMs);
     await transport.send({
       protocol: repoWriteProtocolType,
       repoId: "repo-transport",


### PR DESCRIPTION
# English

## Summary

`main` is red. PR #1291 landed as `973fcba7` and its post-merge full check failed on `integration-shard (5)`, in a test that PR itself added:

```
✖ slow startup with distinct work units may exceed one stall window (1009ms)
  RepoWriteStartupStalledError: no new phase/work unit for 1000ms;
  no startup progress frame was observed.
  phase: undefined, workUnit: undefined, repeatedProgressFrames: 0
```

Zero frames, not a late frame. The child never emitted its **first** progress frame inside the window, because that window also has to cover the child's own fork boot — no frame can arrive before the process is running. The sibling test in the same file reaches its verdict at ~1914 ms against a 1000 ms window, which puts CI fork boot at roughly 0.9–1.2 s. A 1000 ms window sits right on that floor, so the test was reporting how loaded the runner was rather than whether the detector works.

**This is a test defect, not a product defect.** Production is not squeezed the same way: `readyTimeoutMs` is 30 000 ms against a ~2 s boot. The behaviour when boot really does exceed the window is also correct and honest — the error says "no startup progress frame was observed" rather than inventing a phase. Nothing in the shipped path changes here.

The same latent flake sat in the sibling test: had boot exceeded 1000 ms there, it would have rejected with `phase: undefined` and failed its `phase === "historical-recovery"` assertion. Both are fixed.

## What Changed

- `packages/daemon/test/repo-write-process-supervisor.test.ts`: both startup tests now use a shared `STARTUP_STALL_WINDOW_MS = 3_000`, several times the observed boot cost, with a comment recording that the margin is load-bearing and why 1000 ms failed.
- `packages/daemon/test/support/repo-write-ipc-child.ts`: the `slow-startup-progress` fixture's inter-frame gap becomes 900 ms across four gaps (3600 ms total) instead of 600 ms across three (1800 ms). Each gap stays well under the window while the gaps together outlast a whole window.

The discriminating assertion is untouched: reaching READY later than one full window still proves the window was renewed on each new work unit. Both margins moved in the direction that makes the claim harder to satisfy by accident, not easier.

## Task And Scope

- Harness task: `task_01KZJFGNMC82SM7BNTSRTDMCVB` (repairing that task's own delivery)
- Branch: `codex/startup-window-headroom`
- Public scope: two test files under `packages/daemon/test/`
- Private planning/evidence updated: yes
- Out of scope: any change to `readyTimeoutMs`, the stall semantics, or the startup protocol

## Version Impact

- Version: no version change; test-only
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KZJFGNMC82SM7BNTSRTDMCVB`, `dec_01KZJGY93FQQEKSVVC8HJJ9YJV`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `973fcba7`
- Branch merge-base with `origin/main`: `973fcba7`
- Last `git fetch origin` time: 2026-08-09, immediately before creating this branch
- Sync method: branched from `origin/main`
- Public diff command: `git diff 973fcba7..83e4a32e -- packages/`
- Private evidence commit/path: `harness/tasks/task_01KZJFGNMC82SM7BNTSRTDMCVB-writer-child/progress.md`
- Reviewer evidence path: failing run https://github.com/FairladyZ625/harness-anything/actions/runs/31299881396, job `integration-shard (5)`
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` — `npm run check:local`, "Local check passed in 281.0s", 27 manifest gates green
- [x] Targeted tests, with their real timings: both startup tests pass against the real forked child — `slow startup with distinct work units may exceed one stall window` in 4163 ms (boot + 3600 ms of gaps, comfortably past the 3000 ms window) and `alive child repeating one startup work unit is terminated as stalled` in 3797 ms (boot + one 3000 ms window). The numbers land where the new margins predict, which is the point: neither is near a cliff.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate, and it is the gate that caught the original failure)
- Not run, and why: the full local integration tier was not used as evidence. It is red locally on `production child keeps projection reader p95 below two seconds during a governed write`, which is the known shared-socket-namespace contention with long-lived daemons on this machine; that test was green on the failing CI run, and this change touches only the supervisor fixture, which that test does not use. Stopping the production daemons to clear it was not worth the disruption while `main` is red.

## Review Evidence

- Self-review: checked that this is not a case of editing a test until it passes. The assertion that carries the claim — READY later than one whole window — is unchanged, and both margins moved so the claim is harder, not easier, to satisfy: the gap-to-window ratio goes from 0.6 to 0.3, and total progress time goes from 1.8× the window to 1.2× a window three times larger. What was removed is an unstated dependency on child boot fitting inside 1000 ms, which was never part of the product's contract.
- Reviewer subagent: not used; the diff is two constants and one added fixture frame, and the failure is fully explained by the CI trace.
- Human review: pending
- Blocking findings: none

## Residual Risk

- The window is still a wall-clock constant, so a runner an order of magnitude slower than the current one would fail again. The comment records the actual observed boot cost so the next person re-derives the margin from a measurement instead of halving the number.
- These two tests now cost roughly 8 s of integration-shard wall clock, up from about 3 s.

## References

- Task: `task_01KZJFGNMC82SM7BNTSRTDMCVB`
- Decision: `dec_01KZJGY93FQQEKSVVC8HJJ9YJV`
- Failing run: https://github.com/FairladyZ625/harness-anything/actions/runs/31299881396

---

# 中文

## 概要

`main` 是红的。PR #1291 以 `973fcba7` 合入，其 post-merge 全量检查在 `integration-shard (5)` 上失败，失败的正是那个 PR 自己新增的测试：

```
✖ slow startup with distinct work units may exceed one stall window (1009ms)
  RepoWriteStartupStalledError: no new phase/work unit for 1000ms;
  no startup progress frame was observed.
  phase: undefined, workUnit: undefined, repeatedProgressFrames: 0
```

**零帧，不是迟到的帧。** child 在窗口内连**第一**帧都没发出来 —— 因为这个窗口同时得覆盖 child 自己的 fork 启动，进程没跑起来之前不可能有任何帧。同文件的姊妹测试在 1000ms 窗口下于约 1914ms 出裁决，反推 CI 上 fork 启动约 0.9–1.2 秒。1000ms 的窗口正压在这条地板线上，于是这条测试量的是 runner 有多忙，不是探测器好不好使。

**这是测试缺陷，不是产品缺陷。** 生产不受这个挤压：`readyTimeoutMs` 是 30 000ms，而启动约 2 秒。而且启动真的超过窗口时的行为本身也是对的、诚实的 —— 报文说的是 "no startup progress frame was observed"，没有编造一个阶段出来。发布路径上不改任何东西。

同一个潜伏 flake 也在姊妹测试里：那里若启动超过 1000ms，会以 `phase: undefined` 被拒，从而打挂它 `phase === "historical-recovery"` 的断言。两条一起修。

## 改动内容

- `packages/daemon/test/repo-write-process-supervisor.test.ts`：两条启动测试改用共享的 `STARTUP_STALL_WINDOW_MS = 3_000`，是实测启动耗时的数倍，并写下注释记明这个余量是承重的、以及 1000ms 为什么会挂。
- `packages/daemon/test/support/repo-write-ipc-child.ts`：`slow-startup-progress` fixture 的帧间隔由 600ms×3（合计 1800ms）改为 900ms×4（合计 3600ms）。单个间隔远小于窗口，而全部间隔加起来超过整整一个窗口。

**承重的那条断言没动**：到达 READY 的时刻晚于一整个窗口，依然证明窗口在每个新工作单元上被续期。两处余量都朝着「更难蒙对」而不是「更容易通过」的方向移动。

## 任务与范围

- Harness task：`task_01KZJFGNMC82SM7BNTSRTDMCVB`（修的是该任务自己的交付）
- 分支：`codex/startup-window-headroom`
- 公开范围：`packages/daemon/test/` 下两个测试文件
- 私有规划/证据已更新：是
- 不在范围内：`readyTimeoutMs`、停滞语义、启动协议一律不改

## 版本影响

- 版本：无变更；纯测试
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：`task_01KZJFGNMC82SM7BNTSRTDMCVB`、`dec_01KZJGY93FQQEKSVVC8HJJ9YJV`
- 机检边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`973fcba7`
- 分支与 `origin/main` 的 merge-base：`973fcba7`
- 最近一次 `git fetch origin`：2026-08-09，就在建本分支之前
- 同步方式：直接从 `origin/main` 开分支
- 公开 diff 命令：`git diff 973fcba7..83e4a32e -- packages/`
- 私有证据 commit/路径：`harness/tasks/task_01KZJFGNMC82SM7BNTSRTDMCVB-writer-child/progress.md`
- 评审证据路径：失败 run https://github.com/FairladyZ625/harness-anything/actions/runs/31299881396，job `integration-shard (5)`
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑
- [x] `git diff --check`
- [x] `npm run check:stop-point` —— `npm run check:local`，"Local check passed in 281.0s"，27 个 manifest 门绿
- [x] 定向测试及真实耗时：两条启动测试对着真实 fork 的 child 全绿 —— `slow startup with distinct work units may exceed one stall window` 用时 4163ms（启动 + 3600ms 间隔，宽松地越过 3000ms 窗口），`alive child repeating one startup work unit is terminated as stalled` 用时 3797ms（启动 + 一个 3000ms 窗口）。数字落在新余量预测的位置上，这正是重点：两条都不贴着悬崖。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威完整门，也正是它抓住了原来那次失败）
- 未跑及原因：没有把本地全量 integration tier 当证据。它在本机是红的，红在 `production child keeps projection reader p95 below two seconds during a governed write` —— 那是本机长驻 daemon 与 fixture 争用共享 socket 命名空间的已知问题；该测试在出问题的那次 CI 上是绿的，且本改动只碰 supervisor 的 fixture，那条测试并不使用它。`main` 正红着，为清掉它去停生产 daemon 不划算。

## 评审证据

- 自审：核对了这不是「改测试改到绿」。承载论断的那条断言 —— READY 晚于一整个窗口 —— 没动；两处余量都往更难的方向走：间隔与窗口之比从 0.6 降到 0.3，进展总时长从 1.8 倍窗口变为 1.2 倍**放大了三倍**的窗口。被删掉的是一条从未写出来的隐含依赖：child 启动必须挤进 1000ms —— 那从来不是产品契约的一部分。
- 评审子代理：未用；diff 就是两个常数加一帧 fixture，失败原因由 CI trace 完全解释。
- 人工评审：待办
- 阻断性发现：无

## 残留风险

- 窗口仍是墙钟常数，若换到比现在慢一个数量级的 runner 会再次失败。注释里写下了实测的启动耗时，好让下一个人从测量重新推导余量，而不是把数字对半砍。
- 这两条测试的 integration-shard 墙钟成本从约 3 秒升到约 8 秒。

## 参考

- Task：`task_01KZJFGNMC82SM7BNTSRTDMCVB`
- 决策：`dec_01KZJGY93FQQEKSVVC8HJJ9YJV`
- 失败 run：https://github.com/FairladyZ625/harness-anything/actions/runs/31299881396
