### PR TITLE
perf(daemon): read publication objects through one verified long-lived git cat-file --batch

### DIFF
--- a/packages/daemon/src/authority/authority-lifecycle.ts
+++ b/packages/daemon/src/authority/authority-lifecycle.ts
@@ -20,7 +20,8 @@ import {
   createGitCanonicalPublicationInspector,
   openDurableAuthorityServiceState,
   type CanonicalPublicationEvidence,
-  type DurableAuthorityServiceState
+  type DurableAuthorityServiceState,
+  type GitCanonicalPublicationInspector
 } from "@harness-anything/daemon";
 import {
   resolveHarnessLayout,
@@ -240,6 +241,7 @@ interface StartedAuthorityRepo {
   readonly repo: DaemonRepoNamespace;
   readonly component: AuthorityRepoComponent;
   readonly state: DurableAuthorityServiceState;
+  readonly publicationInspector: GitCanonicalPublicationInspector;
   published: boolean;
   stopping?: Promise<void>;
 }
@@ -303,6 +305,7 @@ export function createAuthorityRepoLifecycleController(input: {
   ): Promise<AuthorityRepoStartResult> {
     let state: DurableAuthorityServiceState | undefined;
     let component: AuthorityRepoComponent | undefined;
+    let publicationInspector: GitCanonicalPublicationInspector | undefined;
     try {
       state = openDurableAuthorityServiceState({
         serviceStateRoot: input.serviceStateRoot,
@@ -310,7 +313,7 @@ export function createAuthorityRepoLifecycleController(input: {
       });
       const serverData = await input.resolveCompositionData(repo, state, runtime);
       validateServerData(repo, serverData, input.allowInMemoryFixture === true);
-      const publicationInspector = createGitCanonicalPublicationInspector(
+      publicationInspector = createGitCanonicalPublicationInspector(
         input.resolvePublicationRoot?.(repo) ?? resolveHarnessLayout(repo.canonicalRoot).authoredRoot
       );
       const attributedCoordinatorFactory = makeHeldLockAttributedCoordinatorFactory(runtime);
@@ -331,11 +334,12 @@ export function createAuthorityRepoLifecycleController(input: {
         admissionBudget: runtime.admissionBudget
       });
       await input.hooks.serve({ repo, component });
-      started.set(repo.repoId, { repo, component, state, published: true });
+      started.set(repo.repoId, { repo, component, state, publicationInspector, published: true });
       unavailable.delete(repo.repoId);
       return { ok: true, component };
     } catch (error) {
       if (component) await stopStartedComponent(repo, component, "repo-detached").catch(() => undefined);
+      await publicationInspector?.shutdown().catch(() => undefined);
       await state?.close().catch(() => undefined);
       const message = authorityLifecycleErrorMessage(error);
       unavailable.set(repo.repoId, message);
@@ -352,8 +356,12 @@ export function createAuthorityRepoLifecycleController(input: {
       try {
         await stopStartedComponent(repo, entry.component, reason);
       } finally {
-        await entry.state.close();
-        started.delete(repo.repoId);
+        try {
+          await entry.publicationInspector.shutdown();
+        } finally {
+          await entry.state.close();
+          started.delete(repo.repoId);
+        }
       }
     })();
     await entry.stopping;

--- a/packages/daemon/src/authority/production/publication-evidence.ts
+++ b/packages/daemon/src/authority/production/publication-evidence.ts
@@ -38,6 +38,10 @@ import { findUniquePublication } from "./publication-operation-lookup.ts";
 import { publicationGitExitCode } from "./publication-git-observation.ts";
 import { AuthorityImmutablePublicationProofError } from "./publication-proof-error.ts";
 import { reportCurrentRepoWriteTelemetry } from "../../runtime/repo-write-telemetry-context.ts";
+import {
+  readPublicationGitObject,
+  shutdownPublicationGitObjectReader
+} from "./publication-object-reader.ts";
 
 export { assertPublicationMatchesMutationSet } from "./publication-mutation-proof.ts";
 
@@ -58,6 +62,7 @@ export interface CanonicalPublicationEvidence {
 }
 
 export interface GitCanonicalPublicationInspector extends CanonicalPublicationInspector {
+  readonly shutdown: () => Promise<void>;
   readonly inspectPublication: (
     expectedPreviousHead: string | null,
     expectedOpIds: ReadonlyArray<string>,
@@ -497,13 +502,14 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
       return matches[0]!;
     },
     findPublicationForOperation,
+    shutdown: () => shutdownPublicationGitObjectReader(rootDir),
     findHistoricalPublicationForOperation: async (opId) => {
       const publication = await findPublicationForOperation(opId);
       return historicalPublicationEvidence({
         opId,
         publication,
         readAtCommit: (commitSha, eventPath) =>
-          publicationGitBytesAsync(rootDir, "show", `${commitSha}:${eventPath}`)
+          readPublicationGitObject(rootDir, `${commitSha}:${eventPath}`)
       });
     }
   };
@@ -519,7 +525,7 @@ async function blobDigestAsync(
   changedPath: string
 ): Promise<string | null> {
   try {
-    const bytes = await publicationGitBytesAsync(rootDir, "show", `${revision}:${changedPath}`);
+    const bytes = await readPublicationGitObject(rootDir, `${revision}:${changedPath}`);
     return createHash("sha256").update(bytes).digest("hex");
   } catch {
     return null;
@@ -547,15 +553,6 @@ function publicationGitText(rootDir: string, ...args: ReadonlyArray<string>): st
 }
 
 const execFileAsync = promisify(execFile);
-
-async function publicationGitBytesAsync(rootDir: string, ...args: ReadonlyArray<string>): Promise<Buffer> {
-  const { stdout } = await execFileAsync("git", ["-C", rootDir, ...args], {
-    encoding: "buffer",
-    windowsHide: true,
-    maxBuffer: 64 * 1024 * 1024
-  });
-  return stdout;
-}
 
 async function publicationGitTextAsync(rootDir: string, ...args: ReadonlyArray<string>): Promise<string> {
   const { stdout } = await execFileAsync("git", ["-C", rootDir, ...args], {

--- a/packages/daemon/src/authority/production/publication-object-reader.ts
+++ b/packages/daemon/src/authority/production/publication-object-reader.ts
@@ -1,0 +1,365 @@
+import {
+  execFile,
+  spawn,
+  type ChildProcessWithoutNullStreams
+} from "node:child_process";
+import { createHash } from "node:crypto";
+import { realpathSync } from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const maximumBatchHeaderBytes = 64 * 1024;
+const maximumGitObjectBytes = 64 * 1024 * 1024;
+const exactSha1Pattern = /^[a-f0-9]{40}$/u;
+const batchHeaderPattern = /^([a-f0-9]{40}) ([a-z]+) ([0-9]+)$/u;
+const maximumConsecutiveRebuilds = 1;
+const readersByRoot = new Map<string, PublicationGitObjectReader>();
+const canonicalRootsByInput = new Map<string, string>();
+const execFileAsync = promisify(execFile);
+
+export class GitObjectBatchValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GitObjectBatchValidationError";
+  }
+}
+
+export class GitObjectBatchMissingError extends Error {
+  constructor(objectName: string) {
+    super(`AUTHORITY_GIT_OBJECT_MISSING:object=${objectName}`);
+    this.name = "GitObjectBatchMissingError";
+  }
+}
+
+export function assertVerifiedGitObjectContent(input: {
+  readonly requestedOid: string;
+  readonly objectType: string;
+  readonly declaredSize: number;
+  readonly content: Buffer;
+  readonly trailingByte: number;
+}): void {
+  if (input.content.length !== input.declaredSize) {
+    throw new GitObjectBatchValidationError(
+      `AUTHORITY_GIT_OBJECT_SIZE_MISMATCH:expected=${input.declaredSize};actual=${input.content.length}`
+    );
+  }
+  if (input.trailingByte !== 0x0a) {
+    throw new GitObjectBatchValidationError(
+      `AUTHORITY_GIT_OBJECT_TRAILING_LF_MISSING:actual=${input.trailingByte}`
+    );
+  }
+  const observedOid = createHash("sha1")
+    .update(`${input.objectType} ${input.declaredSize}\0`)
+    .update(input.content)
+    .digest("hex");
+  if (observedOid !== input.requestedOid) {
+    throw new GitObjectBatchValidationError(
+      `AUTHORITY_GIT_OBJECT_HASH_MISMATCH:requested=${input.requestedOid};observed=${observedOid}`
+    );
+  }
+}
+
+export function readPublicationGitObject(rootDir: string, objectName: string): Promise<Buffer> {
+  const inputRoot = path.resolve(rootDir);
+  const canonicalRoot = canonicalGitRoot(rootDir);
+  canonicalRootsByInput.set(inputRoot, canonicalRoot);
+  let reader = readersByRoot.get(canonicalRoot);
+  if (!reader) {
+    reader = new PublicationGitObjectReader(canonicalRoot);
+    readersByRoot.set(canonicalRoot, reader);
+  }
+  return reader.read(objectName);
+}
+
+export async function shutdownPublicationGitObjectReader(rootDir: string): Promise<void> {
+  const inputRoot = path.resolve(rootDir);
+  const canonicalRoot = canonicalRootsByInput.get(inputRoot) ?? existingCanonicalGitRoot(inputRoot);
+  if (!canonicalRoot) return;
+  const reader = readersByRoot.get(canonicalRoot);
+  if (!reader) return;
+  await reader.close();
+  if (readersByRoot.get(canonicalRoot) === reader) {
+    readersByRoot.delete(canonicalRoot);
+    for (const [knownInput, knownCanonical] of canonicalRootsByInput) {
+      if (knownCanonical === canonicalRoot) canonicalRootsByInput.delete(knownInput);
+    }
+  }
+}
+
+class PublicationGitObjectReader {
+  readonly rootDir: string;
+  private batch: GitCatFileBatchProcess | undefined;
+  private queue: Promise<void> = Promise.resolve();
+  private closed = false;
+  private batchDisabled = false;
+  private consecutiveRebuilds = 0;
+
+  constructor(rootDir: string) {
+    this.rootDir = rootDir;
+  }
+
+  read(objectName: string): Promise<Buffer> {
+    const result = this.queue.then(() => this.readSerial(objectName));
+    this.queue = result.then(() => undefined, () => undefined);
+    return result;
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    const batch = this.batch;
+    this.batch = undefined;
+    if (batch) await batch.terminate();
+    await this.queue;
+  }
+
+  private async readSerial(objectName: string): Promise<Buffer> {
+    if (this.closed) throw new Error("AUTHORITY_GIT_OBJECT_READER_CLOSED");
+    if (this.batchDisabled || objectName.includes("\n")) {
+      return oneShotGitObject(this.rootDir, objectName);
+    }
+    this.batch ??= new GitCatFileBatchProcess(this.rootDir);
+    const batch = this.batch;
+    let response: Awaited<ReturnType<GitCatFileBatchProcess["read"]>>;
+    try {
+      response = await batch.read(objectName);
+    } catch (error) {
+      this.batch = undefined;
+      await batch.terminate();
+      if (this.closed) throw error;
+      if (this.consecutiveRebuilds < maximumConsecutiveRebuilds) {
+        this.consecutiveRebuilds += 1;
+        this.batch = new GitCatFileBatchProcess(this.rootDir);
+        reportBatchFailure(
+          "AUTHORITY_GIT_OBJECT_BATCH_RESTARTED",
+          this.rootDir,
+          error,
+          `rebuild=${this.consecutiveRebuilds}/${maximumConsecutiveRebuilds};request=fork`
+        );
+      } else {
+        this.batchDisabled = true;
+        reportBatchFailure(
+          "AUTHORITY_GIT_OBJECT_BATCH_RETRY_BUDGET_EXHAUSTED",
+          this.rootDir,
+          error,
+          "batch=disabled;request=fork"
+        );
+      }
+      return oneShotGitObject(this.rootDir, objectName);
+    }
+    this.consecutiveRebuilds = 0;
+    if (response.missing) throw new GitObjectBatchMissingError(objectName);
+    return response.content;
+  }
+}
+
+class GitCatFileBatchProcess {
+  private readonly child: ChildProcessWithoutNullStreams;
+  private readonly output: BufferedBatchOutput;
+  private stderr = "";
+  private spawnError: Error | undefined;
+
+  constructor(rootDir: string) {
+    this.child = spawn("git", ["-C", rootDir, "cat-file", "--batch"], {
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true
+    });
+    this.output = new BufferedBatchOutput(this.child.stdout);
+    this.child.stderr.on("data", (chunk: Buffer | string) => {
+      if (this.stderr.length < maximumBatchHeaderBytes) {
+        this.stderr += Buffer.from(chunk).toString("utf8");
+      }
+    });
+    this.child.on("error", (error) => {
+      this.spawnError = error;
+    });
+    unrefChild(this.child);
+  }
+
+  async read(objectName: string): Promise<
+    | { readonly missing: true }
+    | { readonly missing: false; readonly content: Buffer }
+  > {
+    refChild(this.child);
+    try {
+      await writeBatchRequest(this.child, objectName);
+      const header = (await this.output.readLine()).toString("utf8");
+      if (header === `${objectName} missing`) return { missing: true };
+      const parsed = batchHeaderPattern.exec(header);
+      if (!parsed) {
+        throw new GitObjectBatchValidationError(
+          `AUTHORITY_GIT_OBJECT_BATCH_HEADER_INVALID:header=${JSON.stringify(header)}`
+        );
+      }
+      const [, resolvedOid, objectType, sizeText] = parsed;
+      // The repository queue permits only one outstanding request. Git's header
+      // therefore resolves this exact object expression to the oid checked below;
+      // a prior response cannot remain buffered after its size and LF validated.
+      if (exactSha1Pattern.test(objectName) && resolvedOid !== objectName) {
+        throw new GitObjectBatchValidationError(
+          `AUTHORITY_GIT_OBJECT_RESPONSE_OID_MISMATCH:requested=${objectName};resolved=${resolvedOid}`
+        );
+      }
+      const declaredSize = Number(sizeText);
+      if (!Number.isSafeInteger(declaredSize) || declaredSize < 0 || declaredSize > maximumGitObjectBytes) {
+        throw new GitObjectBatchValidationError(
+          `AUTHORITY_GIT_OBJECT_SIZE_INVALID:size=${sizeText}`
+        );
+      }
+      const content = await this.output.readExactly(declaredSize);
+      const trailing = await this.output.readExactly(1);
+      assertVerifiedGitObjectContent({
+        requestedOid: resolvedOid!,
+        objectType: objectType!,
+        declaredSize,
+        content,
+        trailingByte: trailing[0] ?? -1
+      });
+      return { missing: false, content };
+    } catch (error) {
+      if (error instanceof GitObjectBatchValidationError) throw error;
+      throw new GitObjectBatchValidationError(
+        `AUTHORITY_GIT_OBJECT_BATCH_READ_FAILED:${gitObjectReadErrorMessage(this.spawnError ?? error)}${this.stderr ? `;stderr=${this.stderr.trim()}` : ""}`
+      );
+    } finally {
+      unrefChild(this.child);
+    }
+  }
+
+  async terminate(): Promise<void> {
+    if (this.child.exitCode !== null || this.child.signalCode !== null) return;
+    this.child.stdin.destroy();
+    this.child.kill("SIGTERM");
+    if (await waitForExit(this.child, 250)) return;
+    this.child.kill("SIGKILL");
+    await waitForExit(this.child, 250);
+  }
+}
+
+class BufferedBatchOutput {
+  private readonly iterator: AsyncIterator<string | Buffer>;
+  private buffered = Buffer.alloc(0);
+
+  constructor(output: NodeJS.ReadableStream & AsyncIterable<string | Buffer>) {
+    this.iterator = output[Symbol.asyncIterator]();
+  }
+
+  async readLine(): Promise<Buffer> {
+    while (true) {
+      const newline = this.buffered.indexOf(0x0a);
+      if (newline >= 0) {
+        const line = this.buffered.subarray(0, newline);
+        this.buffered = this.buffered.subarray(newline + 1);
+        return line;
+      }
+      if (this.buffered.length > maximumBatchHeaderBytes) {
+        throw new GitObjectBatchValidationError("AUTHORITY_GIT_OBJECT_BATCH_HEADER_TOO_LARGE");
+      }
+      await this.readChunk();
+    }
+  }
+
+  async readExactly(size: number): Promise<Buffer> {
+    while (this.buffered.length < size) await this.readChunk();
+    const result = this.buffered.subarray(0, size);
+    this.buffered = this.buffered.subarray(size);
+    return result;
+  }
+
+  private async readChunk(): Promise<void> {
+    const next = await this.iterator.next();
+    if (next.done) {
+      throw new GitObjectBatchValidationError("AUTHORITY_GIT_OBJECT_BATCH_HALF_READ");
+    }
+    this.buffered = this.buffered.length === 0
+      ? Buffer.from(next.value)
+      : Buffer.concat([this.buffered, Buffer.from(next.value)]);
+  }
+}
+
+function canonicalGitRoot(rootDir: string): string {
+  return realpathSync.native(path.resolve(rootDir));
+}
+
+function existingCanonicalGitRoot(rootDir: string): string | undefined {
+  try {
+    return canonicalGitRoot(rootDir);
+  } catch (error) {
+    if (isMissingPathError(error)) return undefined;
+    throw error;
+  }
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function writeBatchRequest(child: ChildProcessWithoutNullStreams, objectName: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    child.stdin.write(`${objectName}\n`, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+function refChild(child: ChildProcessWithoutNullStreams): void {
+  child.ref();
+  refStream(child.stdin);
+  refStream(child.stdout);
+  refStream(child.stderr);
+}
+
+function unrefChild(child: ChildProcessWithoutNullStreams): void {
+  child.unref();
+  unrefStream(child.stdin);
+  unrefStream(child.stdout);
+  unrefStream(child.stderr);
+}
+
+function refStream(stream: NodeJS.ReadableStream | NodeJS.WritableStream): void {
+  (stream as typeof stream & { ref?: () => void }).ref?.();
+}
+
+function unrefStream(stream: NodeJS.ReadableStream | NodeJS.WritableStream): void {
+  (stream as typeof stream & { unref?: () => void }).unref?.();
+}
+
+function waitForExit(child: ChildProcessWithoutNullStreams, timeoutMs: number): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => finish(false), timeoutMs);
+    const onExit = () => finish(true);
+    const finish = (exited: boolean) => {
+      clearTimeout(timeout);
+      child.off("exit", onExit);
+      resolve(exited);
+    };
+    child.once("exit", onExit);
+  });
+}
+
+function gitObjectReadErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function oneShotGitObject(rootDir: string, objectName: string): Promise<Buffer> {
+  const { stdout } = await execFileAsync("git", ["-C", rootDir, "show", objectName], {
+    encoding: "buffer",
+    windowsHide: true,
+    maxBuffer: maximumGitObjectBytes
+  });
+  return stdout;
+}
+
+function reportBatchFailure(
+  code: string,
+  rootDir: string,
+  error: unknown,
+  action: string
+): void {
+  process.emitWarning(
+    `${code}:root=${rootDir};failure=${gitObjectReadErrorMessage(error)};${action}`,
+    { type: "GitCatFileBatchWarning", code }
+  );
+}

--- a/packages/daemon/test/publication-evidence-responsiveness.test.ts
+++ b/packages/daemon/test/publication-evidence-responsiveness.test.ts
@@ -1,7 +1,15 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -10,6 +18,150 @@ import {
   AuthorityCanonicalPublicationNotFoundError,
   createGitCanonicalPublicationInspector
 } from "../src/authority/production/publication-evidence.ts";
+import {
+  readPublicationGitObject,
+  shutdownPublicationGitObjectReader
+} from "../src/authority/production/publication-object-reader.ts";
+
+const posixTest = process.platform === "win32" ? test.skip : test;
+
+test("concurrent object reads share one lazily spawned batch process", async (context) => {
+  const root = mkdtempSync(path.join(tmpdir(), "publication-object-reader-"));
+  context.after(() => rmSync(root, { recursive: true, force: true }));
+  git(root, "init", "-q");
+  git(root, "config", "user.name", "Harness Test");
+  git(root, "config", "user.email", "harness@example.test");
+  writeFileSync(path.join(root, "seed.txt"), "seed\n");
+  git(root, "add", ".");
+  git(root, "commit", "-q", "-m", "seed");
+  const tracePath = path.join(root, "git-trace.jsonl");
+  const previousTrace = process.env.GIT_TRACE2_EVENT;
+  process.env.GIT_TRACE2_EVENT = tracePath;
+  const inspector = createGitCanonicalPublicationInspector(root);
+  try {
+    assert.equal(existsSync(tracePath), false);
+    const results = await Promise.all(Array.from(
+      { length: 8 },
+      () => readPublicationGitObject(root, "HEAD:seed.txt")
+    ));
+    assert.deepEqual(results, Array.from({ length: 8 }, () => Buffer.from("seed\n")));
+  } finally {
+    await inspector.shutdown();
+    if (previousTrace === undefined) delete process.env.GIT_TRACE2_EVENT;
+    else process.env.GIT_TRACE2_EVENT = previousTrace;
+  }
+
+  assert.equal(
+    gitTraceCommands(tracePath).filter((args) =>
+      args[0] === "cat-file" && args.includes("--batch")
+    ).length,
+    1
+  );
+});
+
+posixTest("offset batch bytes fail closed and the request falls back to one-shot Git", async (context) => {
+  const fixture = faultyPublicationRepo("offset");
+  context.after(() => rmSync(fixture.root, { recursive: true, force: true }));
+  try {
+    assert.equal(
+      await readPublicationGitObject(fixture.root, "HEAD:seed.txt").then((content) => content.toString("utf8")),
+      "seed\n"
+    );
+  } finally {
+    await shutdownPublicationGitObjectReader(fixture.root);
+    fixture.restorePath();
+  }
+
+  const batchPids = readBatchPids(fixture.batchLog);
+  assert.equal(batchPids.length, 2);
+  assert.equal(new Set(batchPids).size, 2);
+  assert.equal(readLogEntries(fixture.fallbackLog).length, 1);
+});
+
+posixTest("a batch process death falls back and creates only one replacement", async (context) => {
+  const fixture = faultyPublicationRepo("die");
+  context.after(() => rmSync(fixture.root, { recursive: true, force: true }));
+  try {
+    assert.equal(
+      await readPublicationGitObject(fixture.root, "HEAD:seed.txt").then((content) => content.toString("utf8")),
+      "seed\n"
+    );
+  } finally {
+    await shutdownPublicationGitObjectReader(fixture.root);
+    fixture.restorePath();
+  }
+
+  assert.equal(readBatchPids(fixture.batchLog).length, 2);
+  assert.equal(readLogEntries(fixture.fallbackLog).length, 1);
+});
+
+posixTest("a half-read response never reaches the caller and falls back", async (context) => {
+  const fixture = faultyPublicationRepo("half-read");
+  context.after(() => rmSync(fixture.root, { recursive: true, force: true }));
+  try {
+    assert.equal(
+      await readPublicationGitObject(fixture.root, "HEAD:seed.txt").then((content) => content.toString("utf8")),
+      "seed\n"
+    );
+  } finally {
+    await shutdownPublicationGitObjectReader(fixture.root);
+    fixture.restorePath();
+  }
+
+  assert.equal(readBatchPids(fixture.batchLog).length, 2);
+  assert.equal(readLogEntries(fixture.fallbackLog).length, 1);
+});
+
+posixTest("consecutive batch failures exhaust one rebuild and emit a visible warning", async (context) => {
+  const fixture = faultyPublicationRepo("offset");
+  context.after(() => rmSync(fixture.root, { recursive: true, force: true }));
+  const warnings: string[] = [];
+  const onWarning = (warning: Error) => warnings.push(warning.message);
+  process.on("warning", onWarning);
+  try {
+    const results: string[] = [];
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      results.push(await readPublicationGitObject(fixture.root, "HEAD:seed.txt")
+        .then((content) => content.toString("utf8")));
+    }
+    assert.deepEqual(results, ["seed\n", "seed\n", "seed\n"]);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  } finally {
+    process.off("warning", onWarning);
+    await shutdownPublicationGitObjectReader(fixture.root);
+    fixture.restorePath();
+  }
+
+  assert.equal(readBatchPids(fixture.batchLog).length, 2);
+  assert.equal(readLogEntries(fixture.fallbackLog).length, 3);
+  assert.equal(
+    warnings.some((warning) => warning.includes("AUTHORITY_GIT_OBJECT_BATCH_RETRY_BUDGET_EXHAUSTED")),
+    true
+  );
+});
+
+posixTest("shutdown terminates a stuck half-read and rejects queued requests", async (context) => {
+  const fixture = faultyPublicationRepo("hang-half");
+  context.after(() => rmSync(fixture.root, { recursive: true, force: true }));
+  const active = readPublicationGitObject(fixture.root, "HEAD:seed.txt");
+  const queued = readPublicationGitObject(fixture.root, "HEAD:seed.txt");
+  const activeRejected = assert.rejects(active, /AUTHORITY_GIT_OBJECT_BATCH_HALF_READ/u);
+  const queuedRejected = assert.rejects(queued, /AUTHORITY_GIT_OBJECT_READER_CLOSED/u);
+  while (!existsSync(fixture.batchLog)) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+  const shutdownStarted = performance.now();
+  try {
+    await shutdownPublicationGitObjectReader(fixture.root);
+    assert.ok(performance.now() - shutdownStarted < 1_000);
+    await Promise.all([activeRejected, queuedRejected]);
+  } finally {
+    fixture.restorePath();
+  }
+
+  assert.equal(readBatchPids(fixture.batchLog).length, 1);
+  assert.equal(readLogEntries(fixture.fallbackLog).length, 0);
+});
 
 test("publication evidence yields between blob reads so recovery admission timers remain live", async (context) => {
   const root = mkdtempSync(path.join(tmpdir(), "publication-evidence-responsive-"));
@@ -54,15 +206,18 @@ test("publication evidence yields between blob reads so recovery admission timer
     [opId],
     mergeCommit
   );
+  await inspector.shutdown();
   const tracePath = path.join(root, "historical-publication-git-trace.jsonl");
   const previousTrace = process.env.GIT_TRACE2_EVENT;
   process.env.GIT_TRACE2_EVENT = tracePath;
+  const historicalInspector = createGitCanonicalPublicationInspector(root);
   try {
-    assert.deepEqual(await inspector.findHistoricalPublicationForOperation(opId), {
+    assert.deepEqual(await historicalInspector.findHistoricalPublicationForOperation(opId), {
       commitSha: mergeCommit,
       semanticDigest
     });
   } finally {
+    await historicalInspector.shutdown();
     if (previousTrace === undefined) delete process.env.GIT_TRACE2_EVENT;
     else process.env.GIT_TRACE2_EVENT = previousTrace;
   }
@@ -77,6 +232,12 @@ test("publication evidence yields between blob reads so recovery admission timer
   ).length, 0);
   assert.equal(lookupCommands.filter((args) =>
     args[0] === "diff" && args.includes("--name-only")
+  ).length, 1);
+  assert.equal(lookupCommands.filter((args) =>
+    args[0] === "show" && !args.includes("-s")
+  ).length, 0);
+  assert.equal(lookupCommands.filter((args) =>
+    args[0] === "cat-file" && args.includes("--batch")
   ).length, 1);
 
   assert.equal(timerFired, true);
@@ -146,4 +307,98 @@ function git(root: string, ...args: ReadonlyArray<string>): string {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"]
   }).trim();
+}
+
+function readBatchPids(batchLog: string): ReadonlyArray<string> {
+  return readLogEntries(batchLog);
+}
+
+function readLogEntries(logPath: string): ReadonlyArray<string> {
+  if (!existsSync(logPath)) return [];
+  return readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
+}
+
+type GitBatchFault = "offset" | "die" | "half-read" | "hang-half";
+
+function faultyPublicationRepo(fault: GitBatchFault): {
+  readonly root: string;
+  readonly batchLog: string;
+  readonly fallbackLog: string;
+  readonly restorePath: () => void;
+} {
+  const root = mkdtempSync(path.join(tmpdir(), `publication-object-${fault}-`));
+  git(root, "init", "-q");
+  git(root, "config", "user.name", "Harness Test");
+  git(root, "config", "user.email", "harness@example.test");
+  writeFileSync(path.join(root, "seed.txt"), "seed\n");
+  git(root, "add", ".");
+  git(root, "commit", "-q", "-m", "seed");
+  const realGit = execFileSync("sh", ["-c", "command -v git"], { encoding: "utf8" }).trim();
+  const binDir = path.join(root, "fault-bin");
+  const batchLog = path.join(root, "batch-starts.log");
+  const fallbackLog = path.join(root, "fallback-starts.log");
+  mkdirSync(binDir);
+  const wrapper = path.join(binDir, "git");
+  writeFileSync(wrapper, faultyGitWrapperSource(realGit, batchLog, fallbackLog, fault));
+  chmodSync(wrapper, 0o755);
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${binDir}${path.delimiter}${previousPath ?? ""}`;
+  return {
+    root,
+    batchLog,
+    fallbackLog,
+    restorePath: () => {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+    }
+  };
+}
+
+function faultyGitWrapperSource(
+  realGit: string,
+  batchLog: string,
+  fallbackLog: string,
+  fault: GitBatchFault
+): string {
+  return [
+    "#!/usr/bin/env node",
+    'import { appendFileSync } from "node:fs";',
+    'import { spawnSync } from "node:child_process";',
+    `const realGit = ${JSON.stringify(realGit)};`,
+    `const batchLog = ${JSON.stringify(batchLog)};`,
+    `const fallbackLog = ${JSON.stringify(fallbackLog)};`,
+    `const fault = ${JSON.stringify(fault)};`,
+    "const args = process.argv.slice(2);",
+    "if (!args.includes(\"--batch\")) {",
+    "  appendFileSync(fallbackLog, `${process.pid}\\n`);",
+    "  const delegated = spawnSync(realGit, args, { stdio: \"inherit\" });",
+    "  process.exit(delegated.status ?? 1);",
+    "}",
+    "appendFileSync(batchLog, `${process.pid}\\n`);",
+    "const rootFlag = args.indexOf(\"-C\");",
+    "const root = rootFlag >= 0 ? args[rootFlag + 1] : process.cwd();",
+    "let pending = \"\";",
+    "process.stdin.setEncoding(\"utf8\");",
+    "process.stdin.on(\"data\", (chunk) => {",
+    "  pending += chunk;",
+    "  const newline = pending.indexOf(\"\\n\");",
+    "  if (newline < 0) return;",
+    "  const objectName = pending.slice(0, newline);",
+    "  if (fault === \"die\") process.exit(17);",
+    "  const contentResult = spawnSync(realGit, [\"-C\", root, \"show\", objectName]);",
+    "  const oidResult = spawnSync(realGit, [\"-C\", root, \"rev-parse\", objectName], { encoding: \"utf8\" });",
+    "  const typeResult = spawnSync(realGit, [\"-C\", root, \"cat-file\", \"-t\", objectName], { encoding: \"utf8\" });",
+    "  if (contentResult.status !== 0 || oidResult.status !== 0 || typeResult.status !== 0) process.exit(2);",
+    "  const content = Buffer.from(contentResult.stdout);",
+    "  const corrupted = fault === \"offset\"",
+    "    ? Buffer.concat([content.subarray(1), content.subarray(0, 1)])",
+    "    : fault === \"half-read\" || fault === \"hang-half\" ? content.subarray(0, -1)",
+    "    : content;",
+    "  process.stdout.write(`${oidResult.stdout.trim()} ${typeResult.stdout.trim()} ${content.length}\\n`);",
+    "  process.stdout.write(corrupted);",
+    "  if (fault === \"hang-half\") setTimeout(() => process.exit(0), 2_000);",
+    "  else process.stdout.write(\"\\n\", () => { if (fault === \"half-read\") process.exit(0); });",
+    "});",
+    ""
+  ].join("\n");
 }

--- a/packages/daemon/test/publication-evidence-topology.test.ts
+++ b/packages/daemon/test/publication-evidence-topology.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import test from "node:test";
 import { createGitCanonicalPublicationInspector } from "../src/authority/production/publication-evidence.ts";
 import { scanFirstParentPublicationMetadata } from "../src/authority/production/publication-history.ts";
+import { assertVerifiedGitObjectContent } from "../src/authority/production/publication-object-reader.ts";
 import {
   authorityBatchTrailerName,
   buildAuthorityBatchIntegrity
@@ -15,6 +16,45 @@ import {
 
 const opId = "namespace-test:publication-topology";
 const posixTest = process.platform === "win32" ? test.skip : test;
+
+test("publication object verification rejects same-size offset bytes", () => {
+  const expected = Buffer.from("publication object\n");
+  const requestedOid = createHash("sha1")
+    .update(`blob ${expected.length}\0`)
+    .update(expected)
+    .digest("hex");
+  const offset = Buffer.concat([expected.subarray(1), expected.subarray(0, 1)]);
+
+  assert.throws(
+    () => assertVerifiedGitObjectContent({
+      requestedOid,
+      objectType: "blob",
+      declaredSize: expected.length,
+      content: offset,
+      trailingByte: 0x0a
+    }),
+    /AUTHORITY_GIT_OBJECT_HASH_MISMATCH/u
+  );
+});
+
+test("publication object verification requires LF immediately after content", () => {
+  const content = Buffer.from("publication object\n");
+  const requestedOid = createHash("sha1")
+    .update(`blob ${content.length}\0`)
+    .update(content)
+    .digest("hex");
+
+  assert.throws(
+    () => assertVerifiedGitObjectContent({
+      requestedOid,
+      objectType: "blob",
+      declaredSize: content.length,
+      content,
+      trailingByte: 0x00
+    }),
+    /AUTHORITY_GIT_OBJECT_TRAILING_LF_MISSING/u
+  );
+});
 
 test("publication proof accepts the existing two-parent materializer shape", async (context) => {
   const fixture = publicationFixture(context);


### PR DESCRIPTION
## Summary

Publication evidence read 115 git objects per recovery batch, each one a fresh `fork`/`exec`. On macOS every piped child needs three AF_UNIX socketpairs, and XNU returns `ENOBUFS` when socket allocation fails — the amplifier behind the 2026-08-08 outage. #1290 removed the synchronous spawns; these 115 asynchronous ones were what remained.

They now go through **one long-lived `git cat-file --batch` process per repository**, lazily started. Object read processes drop from 115 to 1.

**The load-bearing part of this change is not the speedup — it is what makes the speedup safe to have.** `--batch` frames responses by byte count, so a single byte read short or long silently desynchronizes every subsequent response: the caller receives the previous object's bytes believing they are this one's. On a path that feeds publication anchor adjudication, that means potentially terminalizing a write against the wrong evidence. Per-fork reads have no such failure mode.

That risk is not defended by writing the parser carefully. Git is content-addressed, so **every response is verified end to end**: recompute SHA-1 over `<type> <size>\0<content>` and require it to equal the oid git declared. A desynchronized response cannot produce the right hash. The check does not depend on the framing parser being correct, on process state being clean, or on nothing having been dropped — it is independent of everything that happened in between.

Authorized by `dec_01KZJQ024BF17T5BX25KC6EG1X`.

## What Changed

- **New** `packages/daemon/src/authority/production/publication-object-reader.ts` — one lazily-spawned `cat-file --batch` child per canonical repo root, a serial request queue (one outstanding request per process), and `assertVerifiedGitObjectContent()`.
- Verification is three checks, all mandatory: content length equals the declared `size`; the byte after the content is `LF`; recomputed SHA-1 equals the oid in git's header. When the request is a full 40-hex oid, the resolved oid must also equal the requested one.
- **Failure is fail-closed, never degraded silently.** Any validation failure or process death terminates that child, and the current request completes via a one-shot `fork` — the unverified bytes never reach the caller. Rebuild budget is 1 consecutive rebuild (reset on success); exhausting it disables batch mode for that repo and emits a visible process warning, after which reads keep working via one-shot git.
- `publication-evidence.ts` routes object reads through the reader; `diff --name-only` and every adjudication contract are untouched.
- `authority-lifecycle.ts` shuts the reader down on stop/detach, including terminating a child stuck mid-response and rejecting queued requests.

## Version Impact

- Version: no version change — internal daemon evidence path, no published surface change.

## Verification

Measured on the same 26 real stranded proceedings, read-only, both runs from the same base commit with identical Node (`v24.18.0`) and Git (`2.52.0`), classified by per-run `GIT_TRACE2_EVENT`:

| metric | before | after |
|---|---:|---:|
| object read processes | 115 | **1** |
| all git process starts | 177 | 63 |
| batch total time | 2563.109 ms | 838.273 ms |
| results | 23 success / 3 not-found | identical, per proceeding |

**Verification resolution was measured, not asserted.** The offset-bytes test was written before the reader existed; then the hash comparison was temporarily made unreachable to confirm the test can actually fail:

```
RED   ✖ publication object verification rejects same-size offset bytes
      AssertionError: Missing expected exception.   tests 1, pass 0, fail 1
GREEN ✔ publication object verification rejects same-size offset bytes (1.222625ms)
      tests 1, pass 1, fail 0
```

The mutation is not in this diff. At the integration layer a real executable `git` wrapper makes `--batch` return correct-length but offset content; the caller receives the correct bytes from one-shot git, and the trace shows the distrusted child and its replacement are two distinct PIDs with exactly one fork for that request.

Failure paths are covered by tests that create the condition rather than mock it: offset bytes, non-LF trailing byte, process death mid-batch, half-read response, consecutive failures exhausting the rebuild budget, 8 concurrent reads sharing one lazily-spawned child, and shutdown terminating a stuck half-read while rejecting queued requests.

Semantic equivalence: per-proceeding `commitSha + semanticDigest` for all 23 successes and `name + message` for all 3 failures, hashed as one ordered array — identical across both runs.

- [x] `npm run check:local` — 27 manifest gates green.
- [x] Targeted daemon behavior/recovery regressions, plus daemon lifecycle start-failure / detach / shutdown.
- [ ] `npm test` / `npm run check` / `check:ci` — Not run: the full matrix is CI's job per `harness/AGENTS.md`.
- [ ] `smoke:dashboard`, `pack:dry-run`, GUI build — Not applicable: daemon-internal evidence path only.

## Review Evidence

- Reviewer focus: `publication-object-reader.ts:34-60` (content-addressed verification), `:101-153` (queue and rebuild semantics), `:179-236` (protocol framing and termination); `publication-evidence.ts:505-529` (object read replaced, `diff --name-only` and adjudication untouched); `authority-lifecycle.ts:302-367` (shutdown ordering).
- Also confirm the 3 not-found proceedings were not newly "resolved" by the batch path.
- Blocking findings: none outstanding.

## Residual Risk

- **The escalation channel is a `process.emitWarning`, not an error-level log or a health item.** `dec_01KZJF4YGRH57R3NPW0PQ5AFGW/CH2` asks for exhausted retry budgets to surface on an already-watched surface — `ha doctor` or daemon status qualify, a process warning is weaker. Consequence is bounded (reads stay correct via one-shot git, only the optimization is lost), but a repo that permanently fell back could go unnoticed. Worth a follow-up; deliberately not widened here.
- Batch mode, once disabled for a repo after consecutive failures, stays disabled for that process lifetime. There is no re-probe.
- SHA-256 object-format repositories fail closed on the strict 40-hex header and fall back to one-shot git — correct, but they get no batch speedup. Not exercised; every real sample is SHA-1.
- Fault-injection wrappers are POSIX and were measured on macOS; those cases skip on Win32. The reader compiles for Windows but its child-signal and framing behavior there is not measured by this task.
- Objects near the 64 MiB ceiling are not exercised; every object on this path is far below it.
- Timing is a single back-to-back sample. Process counts and per-proceeding results are deterministic evidence; the wall-clock number is not presented as a guaranteed gain.
- Not deployed to the running daemon, and no `ENOBUFS` reproduction under real socket pressure — that would have required stressing the machine hosting a daemon the user is connected to.

## References

- Task: task_01KZJQ4EKG405DQABZDZFD0Y3W
- Decision: dec_01KZJQ024BF17T5BX25KC6EG1X
- Predecessor: #1290 (synchronous git spawns 8 → 1 per lookup)

## Governance Declaration

- `dec_01KZJQ024BF17T5BX25KC6EG1X` — authorizes this change and fixes its boundaries: one lazily-started process per repo, mandatory content-addressed verification, no silent degradation. All three hold.
- `dec_01KYA8MCRFZ39H03ZPK721D8Z0` — cross-generation terminalization requires an exact publication anchor, append-only. Preserved: only the retrieval of bytes changed, never their adjudication.
- `dec_01KZJF4YGRH57R3NPW0PQ5AFGW` — automatic retries must be bounded and escalate when the budget is spent. Bounded (1 consecutive rebuild, reset on success) and escalating; the strength of the escalation surface is flagged under Residual Risk.
- No CI/gate authority surface was modified. `libgit2`/`nodegit` were not introduced (explicitly rejected in the decision).

---

## 摘要

publication 取证每批 recovery 要读 115 个 git object，每一个都是一次完整的 `fork`/`exec`。macOS 上每个带 pipe 的子进程需要三组 AF_UNIX socketpair，XNU 在 socket 分配失败时返回 `ENOBUFS`——这正是 2026-08-08 事故的放大器。#1290 消除了同步 spawn，剩下的就是这 115 次异步的。

现在它们走**每仓一个、懒启动的长寿命 `git cat-file --batch` 进程**。object read 进程从 115 降到 1。

**本 PR 承重的部分不是提速，而是让提速可以被安全地拥有。** `--batch` 按字节数分帧，因此少读或多读一个字节会静默地让之后所有响应错位：调用方会拿到上一个对象的字节，却以为是这一个的。在一条参与 publication anchor 判定的路径上，这意味着可能拿错误的证据去终态化一笔写。逐次 fork 的老写法没有这个失败模式。

而这个风险不是靠把解析器写仔细来防的。git 是内容寻址存储，所以**每个响应都做端到端校验**：按 `<type> <size>\0<content>` 重算 SHA-1，必须等于 git 声明的 oid。错位的响应算不出正确的 hash。这个校验不依赖 framing 解析正确、不依赖进程状态干净、不依赖有没有漏掉字节——它与中间发生过什么无关。

授权决策：`dec_01KZJQ024BF17T5BX25KC6EG1X`。

## 改动内容

- **新增** `packages/daemon/src/authority/production/publication-object-reader.ts`——每个 canonical 仓库根一个懒启动的 `cat-file --batch` child，串行请求队列（每进程同时只有一个未完成请求），以及 `assertVerifiedGitObjectContent()`。
- 校验是三项，全部必过：内容长度等于声明的 `size`；内容之后紧跟的字节是 `LF`；重算的 SHA-1 等于 git 头部声明的 oid。当请求是完整 40 位 oid 时，解析出的 oid 还必须等于请求的那个。
- **失败一律 fail-closed，绝不静默降级。** 任何校验失败或进程死亡都会终止该 child，当前请求改由单次 `fork` 完成——未通过校验的字节永远到不了调用方。重建预算为连续 1 次（成功即清零）；预算耗尽则对该仓禁用 batch 模式并发出可见的 process warning，之后读取继续通过单次 git 正常工作。
- `publication-evidence.ts` 把 object read 接到该 reader；`diff --name-only` 与全部判定契约未动。
- `authority-lifecycle.ts` 在 stop/detach 时关闭 reader，包括终止卡在响应中途的 child 并拒绝排队请求。

## 版本影响

- 版本：不改版本——daemon 内部取证路径，不改变任何发布面。

## 验证

在同一批 26 笔真实搁浅 proceeding 上只读实测，两轮同 base commit、同 Node（`v24.18.0`）同 Git（`2.52.0`），按每轮独立的 `GIT_TRACE2_EVENT` 分类：

| 指标 | 前 | 后 |
|---|---:|---:|
| object read 进程 | 115 | **1** |
| 全部 git 进程启动 | 177 | 63 |
| 批量总耗时 | 2563.109 ms | 838.273 ms |
| 结果 | 23 success / 3 not-found | 逐笔完全一致 |

**校验的分辨力是实测的，不是断言的。** 错位字节测试先于 reader 存在而写；随后临时把 hash 比较改成不可达条件，确认该测试真的会失败：

```
RED   ✖ publication object verification rejects same-size offset bytes
      AssertionError: Missing expected exception.   tests 1, pass 0, fail 1
GREEN ✔ publication object verification rejects same-size offset bytes (1.222625ms)
      tests 1, pass 1, fail 0
```

该 mutation 不在本 diff 中。集成层还用一个真实可执行的 `git` wrapper 让 `--batch` 返回长度正确但内容错位的响应；调用方拿到的是单次 git 返回的正确字节，trace 同时证明失信 child 与其替身是两个不同 PID，该请求只 fork 了一次。

失败路径由**制造真实条件而非 mock** 的测试覆盖：错位字节、尾字节不是 LF、进程中途死亡、half-read 响应、连续失败耗尽重建预算、8 个并发读共享一个懒启动 child，以及 shutdown 终止卡住的 half-read 并拒绝排队请求。

语义等价：23 笔成功的 `commitSha + semanticDigest` 与 3 笔失败的 `name + message`，作为一个有序数组取 SHA-256——两轮完全相同。

- [x] `npm run check:local` —— 27 个 manifest gate 全绿。
- [x] 定向 daemon 行为/恢复回归，以及 daemon lifecycle 的 start-failure / detach / shutdown。
- [ ] `npm test` / `npm run check` / `check:ci` —— 未运行：按 `harness/AGENTS.md`，完整门矩阵是 CI 的活。
- [ ] `smoke:dashboard`、`pack:dry-run`、GUI 构建 —— 不适用：仅 daemon 内部取证路径。

## 审查证据

- Reviewer 重点：`publication-object-reader.ts:34-60`（内容寻址校验）、`:101-153`（队列与重建语义）、`:179-236`（协议 framing 与终止路径）；`publication-evidence.ts:505-529`（只替换 object read，`diff --name-only` 与判定契约未变）；`authority-lifecycle.ts:302-367`（shutdown 顺序）。
- 另请确认 3 笔 not-found 没有被 batch 路径新"解析成功"。
- 阻塞发现：无未处置项。

## 残余风险

- **升级通道是 `process.emitWarning`，不是错误级日志或健康项。** `dec_01KZJF4YGRH57R3NPW0PQ5AFGW/CH2` 要求预算耗尽后落在已被关注的可见面上——`ha doctor` 或 daemon status 符合，一条 process warning 弱于此。后果有界（读取仍通过单次 git 保持正确，丢的只是优化），但一个已永久回退的仓库可能无人察觉。值得后续处理；本 PR 刻意不扩大范围。
- batch 模式在连续失败后对该仓禁用，将持续到该进程生命周期结束，没有重新探测的路径。
- SHA-256 object-format 仓库会在严格 40 位 header 处 fail closed 并回退单次 git——正确，但拿不到 batch 提速。未实测；全部真实样本均为 SHA-1。
- 故障注入 wrapper 是 POSIX 的，在 macOS 实测；相应用例在 Win32 会 skip。reader 可为 Windows 编译，但其 child-signal 与 framing 行为未由本任务实测。
- 未实测接近 64 MiB 上界的对象；本路径上的对象都远低于该界限。
- 耗时是一次背靠背样本。进程计数与逐笔结果是确定性证据，墙钟数字不作为确定收益呈现。
- 未部署到运行中的 daemon，也未在真实 socket 压力下复现 `ENOBUFS`——那需要对正托管着用户在用 daemon 的机器施压。

## 关联材料

- 任务：task_01KZJQ4EKG405DQABZDZFD0Y3W
- 决策：dec_01KZJQ024BF17T5BX25KC6EG1X
- 前序：#1290（每笔 lookup 的同步 git spawn 8 → 1）

## 治理声明

- `dec_01KZJQ024BF17T5BX25KC6EG1X` —— 授权本改动并钉住其边界：每仓一个懒启动进程、强制内容寻址校验、不得静默降级。三条均成立。
- `dec_01KYA8MCRFZ39H03ZPK721D8Z0` —— 跨代终态化必须有精确 publication anchor、只追加不重写。已保持：改变的只是字节的取回方式，从未改变对它们的判定。
- `dec_01KZJF4YGRH57R3NPW0PQ5AFGW` —— 自动重试必须有界并在预算耗尽时升级。已有界（连续 1 次重建，成功即清零）并升级；升级面的强度不足已在残余风险中标出。
- 未修改任何 CI/gate 权威面。未引入 `libgit2`/`nodegit`（决策中已显式否决）。
