### PR TITLE
fix(errors): make next-step guidance executable, and gate the family so it cannot regrow

### DIFF
--- a/packages/application/src/authority/daemon-host-contract.ts
+++ b/packages/application/src/authority/daemon-host-contract.ts
@@ -342,7 +342,7 @@ export interface DaemonCommandHostServices<
   readonly isActorAttributionError: (error: unknown) => boolean;
   readonly isDryRunAction: (command: Command) => boolean;
   readonly executeCommand: (command: Command, options: DaemonHostCommandExecutionOptions) => Promise<Result>;
-  readonly materializerCommandResult: (report: MaterializerCommandReport) => Result;
+  readonly materializerCommandResult: (report: MaterializerCommandReport, rootInput: HarnessLayoutInput) => Result;
   readonly toReceipt: (result: DaemonHostCommandResult) => import("../command-receipt.ts").CommandReceiptEnvelope;
   readonly toErrorReceipt: (input: {
     readonly command: string;

--- a/packages/application/src/authority/publication-outcome.ts
+++ b/packages/application/src/authority/publication-outcome.ts
@@ -71,10 +71,13 @@ export function classifyAuthorityPublicationOutcome(input:
 
 function isWriteError(error: unknown): error is WriteError {
   if (typeof error !== "object" || error === null || !("_tag" in error)) return false;
-  return error._tag === "WriteRejected"
-    || error._tag === "WriteConflict"
-    || error._tag === "GlobalWriteConflict"
-    || error._tag === "JournalUnavailable";
+  if (error._tag === "WriteRejected") {
+    return "reason" in error && typeof error.reason === "string";
+  }
+  if (error._tag === "WriteConflict" || error._tag === "GlobalWriteConflict") {
+    return !("owner" in error) || error.owner === undefined || typeof error.owner === "string";
+  }
+  return error._tag === "JournalUnavailable";
 }
 
 function writeErrorDescription(error: Exclude<WriteError, { readonly _tag: "JournalUnavailable" }>): string {
@@ -83,10 +86,47 @@ function writeErrorDescription(error: Exclude<WriteError, { readonly _tag: "Jour
 }
 
 function errorDescription(error: unknown): string {
-  if (error instanceof Error) return error.message;
+  return describeUnknownFailure(error, new Set<object>());
+}
+
+function describeUnknownFailure(error: unknown, ancestors: Set<object>): string {
+  if (error instanceof Error) return error.message || error.name;
+  if (typeof error === "string") return error;
+  if (typeof error === "number" || typeof error === "bigint" || typeof error === "boolean") return String(error);
+  if (error === null) return "null";
+  if (error === undefined) return "undefined";
+  if (typeof error !== "object") return typeof error;
+  if (ancestors.has(error)) return "[Circular]";
+  ancestors.add(error);
   if (isWriteError(error)) {
-    if (error._tag === "JournalUnavailable") return errorDescription(error.cause);
+    if (error._tag === "JournalUnavailable") return describeUnknownFailure(error.cause, ancestors);
     return writeErrorDescription(error);
   }
-  return String(error);
+  for (const field of ["reason", "message", "cause", "error"] as const) {
+    const value = readObjectField(error, field);
+    if (value !== undefined && value !== error) return describeUnknownFailure(value, ancestors);
+  }
+  return safeJsonDescription(error);
+}
+
+function readObjectField(value: object, field: string): unknown {
+  try {
+    return field in value ? (value as Record<string, unknown>)[field] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function safeJsonDescription(value: object): string {
+  const visited = new WeakSet<object>();
+  try {
+    return JSON.stringify(value, (_key, member: unknown) => {
+      if (typeof member !== "object" || member === null) return member;
+      if (visited.has(member)) return "[Circular]";
+      visited.add(member);
+      return member;
+    }) || "unrenderable object";
+  } catch {
+    return "unrenderable object";
+  }
 }

--- a/packages/application/src/command-receipt.ts
+++ b/packages/application/src/command-receipt.ts
@@ -73,12 +73,20 @@ export function failureReceiptNextActions(
   const repoId = receiptString(repo?.repoId);
   if (!repoId) return undefined;
   const canonicalRoot = receiptString(repo?.canonicalRoot);
+  if (code === "repo_lock_held") {
+    const lockPath = receiptString(repo?.lockPath) ?? "the reported writer lock";
+    const lockOwner = receiptString(repo?.lockOwnerToken) ?? receiptString(repo?.lastError) ?? "unknown";
+    return [{
+      command: `ha --repo ${shellArgument(repoId)} daemon status --json`,
+      description: `The repo writer lock is held at ${lockPath} (owner: ${lockOwner}). Wait for the current writer to release it, then rerun this status command before retrying. Do not register, purge, stop, or restart the repo while the lock is held.`
+    }];
+  }
   return [{
     command: `ha --repo ${shellArgument(repoId)} daemon status --json`,
-    description: "Inspect this repo's daemon attachment state; unavailable repos are retried automatically."
+    description: "Inspect this repo's daemon attachment and recovery state before choosing a repair."
   }, ...(canonicalRoot ? [{
     command: `ha daemon repo register --repo-id ${shellArgument(repoId)} --root ${shellArgument(canonicalRoot)}`,
-    description: "Register or re-enable this repo if it is missing or disabled, then retry the original command."
+    description: "Register or re-enable this repo only if status reports that it is missing or disabled, then retry the original command."
   }] : [])];
 }
 

--- a/packages/application/src/local-controller-service.ts
+++ b/packages/application/src/local-controller-service.ts
@@ -47,11 +47,17 @@ export function makeLocalControllerService(options: LocalControllerServiceOption
   return {
     getAgentRuntimes: () => options.agentRuntimeInventoryReader?.() ?? Promise.resolve({
       ok: false,
-      error: { code: "agent_runtime_unavailable", hint: "Missing required agent runtime discovery service. Run `ha daemon restart`, then retry." }
+      error: {
+        code: "agent_runtime_unavailable",
+        hint: "Agent runtime discovery is unavailable because this controller composition has no agentRuntimeInventoryReader. This request made no runtime changes. Inspect the controller host configuration and logs; use `ha daemon status --json` only to verify the active daemon before retrying through a controller that exposes runtime discovery."
+      }
     }),
     getAgentHolders: (payload) => options.agentHolderProjection?.query(payload) ?? Promise.resolve({
       ok: false,
-      error: { code: "agent_holder_projection_unavailable", hint: "Agent holder projection service is missing. Run `ha daemon restart`, then retry." }
+      error: {
+        code: "agent_holder_projection_unavailable",
+        hint: "Agent holder projection is unavailable because this controller composition has no agentHolderProjection. This request made no runtime changes. Inspect the controller host configuration and logs; use `ha daemon status --json` only to verify the active daemon before retrying through a controller that exposes holder projection."
+      }
     }),
     profiles: () => options.agentRuntimeControl?.profiles() ?? runtimeControlUnavailable(),
     spawn: (payload) => options.agentRuntimeControl?.spawn(payload) ?? runtimeControlUnavailable(),
@@ -61,7 +67,10 @@ export function makeLocalControllerService(options: LocalControllerServiceOption
     result: (payload) => options.agentRuntimeControl?.result(payload) ?? runtimeControlUnavailable(),
     getCatalogSnapshot: () => options.catalogSnapshotReader?.() ?? ({
       ok: false,
-      error: { code: "catalog_unavailable", hint: "Catalog access failed because the snapshot reader is not configured. Run `ha daemon restart --json`, verify with `ha daemon status --json`, then retry." }
+      error: {
+        code: "catalog_unavailable",
+        hint: "Catalog snapshot is unavailable because this controller composition has no catalogSnapshotReader. This request made no runtime changes. Inspect the controller host configuration and logs; use `ha daemon status --json` only to verify the active daemon before retrying through a controller that exposes catalog snapshots."
+      }
     }),
     getTasks: () => {
       const result = queryTaskProjection({ rootDir, layoutOverrides: options.layoutOverrides, filters: {} });
@@ -230,7 +239,10 @@ export function makeLocalControllerService(options: LocalControllerServiceOption
 function runtimeControlUnavailable() {
   return Promise.resolve({
     ok: false as const,
-    error: { code: "agent_runtime_control_unavailable", hint: "Agent runtime control is unavailable. Run `ha daemon restart`." }
+    error: {
+      code: "agent_runtime_control_unavailable",
+      hint: "Agent runtime control is unavailable because this controller composition has no agentRuntimeControl. This request made no runtime changes. Inspect the controller host configuration and logs; use `ha daemon status --json` only to verify the active daemon before retrying through a controller that exposes runtime control."
+    }
   });
 }
 
@@ -261,7 +273,10 @@ function decisionNotFound(decisionId: string): LocalControllerFailure {
 function decisionMutationUnavailable(): Promise<LocalControllerFailure> {
   return Promise.resolve({
     ok: false,
-    error: { code: "decision_mutation_unavailable", hint: "Decision mutation failed because the controller write port is not configured. Run `ha daemon restart --json`, verify with `ha daemon status --json`, then retry." }
+    error: {
+      code: "decision_mutation_unavailable",
+      hint: "Decision mutation is unavailable because this controller composition has no decisionMutationPort. This request made no decision write. Inspect the controller host configuration and logs; use `ha daemon status --json` only to verify the active daemon before retrying through a controller that exposes governed decision mutation."
+    }
   });
 }
 

--- a/packages/application/src/task-completion-requirements.ts
+++ b/packages/application/src/task-completion-requirements.ts
@@ -34,19 +34,11 @@ export function collectCompletionRequirementIssues(input: {
     ));
   }
   for (const issue of input.completionAuthority.issues) {
-    issues.push({
-      code: issue.code,
-      message: issue.message,
-      ...(issue.nextCommand
-        ? { nextCommand: issue.nextCommand }
-        : issue.code === "execution_review_required" && input.completionAuthority.executionId
-        ? { nextCommand: `ha task review-execution ${input.taskId} --execution-id ${input.completionAuthority.executionId} --verdict approved --findings <text> --rationale <text>` }
-        : issue.code === "execution_submission_required"
-          ? { nextCommand: `Claim and submit one Execution for ${input.taskId}, then rerun ha task complete.` }
-          : issue.code === "archive_warnings_acknowledgement_required" && input.completionAuthority.executionId
-            ? { nextCommand: `Review Execution ${input.completionAuthority.executionId} with --acknowledge-archive-warnings.` }
-            : {})
-    });
+    issues.push(completionAuthorityRequirement(
+      input.taskId,
+      input.completionAuthority.executionId,
+      issue
+    ));
   }
   return issues;
 }
@@ -112,6 +104,36 @@ function requirementFromFailure(failure: TaskLifecycleFailure, nextCommand: stri
     message: detailedIssues.length > 0 ? detailedIssues.map((issue) => issue.message).join(" ") : failure.error.hint,
     nextCommand
   };
+}
+
+function completionAuthorityRequirement(
+  taskId: string,
+  executionId: string | undefined,
+  issue: { readonly code: string; readonly message: string; readonly nextCommand?: string }
+): TaskCompletionRequirementIssue {
+  if (issue.nextCommand) return { ...issue };
+  if (issue.code === "execution_review_required" && executionId) {
+    return {
+      code: issue.code,
+      message: `${issue.message} Execution ${executionId} for task ${taskId} still requires an approved review, but this completion check cannot synthesize the required findings, rationale, or exact consent.`,
+      nextCommand: "ha task review-execution --help"
+    };
+  }
+  if (issue.code === "archive_warnings_acknowledgement_required" && executionId) {
+    return {
+      code: issue.code,
+      message: `${issue.message} Execution ${executionId} for task ${taskId} has archive warnings, but this completion check cannot synthesize the required review findings, rationale, archive-warning acknowledgement, or exact consent.`,
+      nextCommand: "ha task review-execution --help"
+    };
+  }
+  if (issue.code === "execution_submission_required") {
+    return {
+      code: issue.code,
+      message: `${issue.message} Task ${taskId} has no submitted Execution. This completion check cannot synthesize the required Holder claim or submission packet; inspect the governed submission contract, submit the Execution, then rerun the original completion command for task ${taskId}.`,
+      nextCommand: "ha task submit --help"
+    };
+  }
+  return { code: issue.code, message: issue.message };
 }
 
 function renderCompletionRequirement(issue: TaskCompletionRequirementIssue): string {

--- a/packages/application/src/task-lifecycle-orchestrator-helpers.ts
+++ b/packages/application/src/task-lifecycle-orchestrator-helpers.ts
@@ -8,13 +8,12 @@ export function taskFailure(taskId: string, code: string, hint: string): TaskLif
 }
 
 export function terminalStatusFailure(taskId: string, status: DomainStatus): TaskLifecycleFailure {
-  const preferred = `Preferred path: ha task complete ${taskId} --approve. If the task is already terminal and more work is required, run ha task supersede ${taskId} --title <follow-up-title>.`;
   return taskFailure(
     taskId,
     "terminal_status_requires_task_complete",
     status === "done"
-      ? `Direct done is blocked because completion consent is recorded only by task complete. ${preferred}`
-      : `Direct cancellation requires an audited recovery path. ${preferred}`
+      ? `Direct done is blocked because completion consent is recorded only by the typed completion transaction. Run \`ha task show ${taskId} --json\` to confirm the current state. If the task is not terminal, inspect \`ha task complete --help\` and prepare the required approval packet before retrying completion. If it is already terminal and follow-up work is needed, inspect \`ha task supersede --help\` before creating replacement work.`
+      : `Direct cancellation is blocked unless it is an audited recovery. Run \`ha task show ${taskId} --json\` to confirm the current state. If the task is not terminal and cancellation is still intended, inspect \`ha task transition --help\` and supply a truthful audited reason. If it is already terminal and follow-up work is needed, inspect \`ha task supersede --help\` before creating replacement work.`
   );
 }
 

--- a/packages/application/test/authority-exact-publication.test.ts
+++ b/packages/application/test/authority-exact-publication.test.ts
@@ -74,6 +74,48 @@ test("deterministic exact batch rejection remains rejected instead of indetermin
   }), { kind: "rejected", reason: "scope mismatch" });
 });
 
+test("publication outcome preserves structured journal failure causes", () => {
+  const outcome = classifyAuthorityPublicationOutcome({
+    kind: "error",
+    error: {
+      _tag: "JournalUnavailable",
+      cause: { name: "Error", message: "durable write may have committed", code: "EIO" }
+    }
+  });
+
+  assert.deepEqual(outcome, {
+    kind: "indeterminate",
+    reason: "PUBLICATION_OUTCOME_UNKNOWN:durable write may have committed"
+  });
+});
+
+test("publication outcome does not trust object-valued WriteRejected.reason", () => {
+  const outcome = classifyAuthorityPublicationOutcome({
+    kind: "error",
+    error: { _tag: "WriteRejected", reason: { message: "structured rejection" }, retryable: false }
+  });
+
+  assert.deepEqual(outcome, {
+    kind: "indeterminate",
+    reason: "PUBLICATION_OUTCOME_UNKNOWN:structured rejection"
+  });
+});
+
+test("publication outcome formatting is total for circular and null-prototype values", () => {
+  const circular: Record<string, unknown> = { code: "CIRCULAR_FAILURE" };
+  circular.self = circular;
+  const nullPrototype = Object.create(null) as Record<string, unknown>;
+  nullPrototype.message = "null-prototype failure";
+
+  for (const error of [circular, nullPrototype]) {
+    const outcome = classifyAuthorityPublicationOutcome({ kind: "error", error });
+    assert.equal(outcome.kind, "indeterminate");
+    assert.doesNotMatch(outcome.reason, /\[object Object\]/u);
+  }
+  assert.match(classifyAuthorityPublicationOutcome({ kind: "error", error: circular }).reason, /CIRCULAR_FAILURE/u);
+  assert.match(classifyAuthorityPublicationOutcome({ kind: "error", error: nullPrototype }).reason, /null-prototype failure/u);
+});
+
 function authorityFixture(
   report: (input: {
     readonly reason: FlushReport["reason"];

--- a/packages/application/test/command-receipt-recovery.test.ts
+++ b/packages/application/test/command-receipt-recovery.test.ts
@@ -30,9 +30,23 @@ test("repo recovery commands use structured repo identity and remain shell-copya
     }
   }), [{
     command: "ha --repo 'team repo' daemon status --json",
-    description: "Inspect this repo's daemon attachment state; unavailable repos are retried automatically."
+    description: "Inspect this repo's daemon attachment and recovery state before choosing a repair."
   }, {
     command: "ha daemon repo register --repo-id 'team repo' --root '/tmp/team'\"'\"'s repo'",
-    description: "Register or re-enable this repo if it is missing or disabled, then retry the original command."
+    description: "Register or re-enable this repo only if status reports that it is missing or disabled, then retry the original command."
+  }]);
+});
+
+test("repo lock recovery waits for the current writer and never mutates registry state", () => {
+  assert.deepEqual(failureReceiptNextActions("repo_lock_held", {
+    repo: {
+      repoId: "canonical",
+      canonicalRoot: "/tmp/canonical",
+      lockPath: ".harness/locks/global.lock",
+      lastError: "lock already held by daemon owner"
+    }
+  }), [{
+    command: "ha --repo canonical daemon status --json",
+    description: "The repo writer lock is held at .harness/locks/global.lock (owner: lock already held by daemon owner). Wait for the current writer to release it, then rerun this status command before retrying. Do not register, purge, stop, or restart the repo while the lock is held."
   }]);
 });

--- a/packages/application/test/local-controller-service.test.ts
+++ b/packages/application/test/local-controller-service.test.ts
@@ -8,6 +8,98 @@ import { Effect } from "effect";
 import { makeLocalControllerService } from "../src/index.ts";
 import { makeMarkdownArtifactStore } from "../../kernel/src/index.ts";
 
+test("missing runtime discovery reports a controller composition gap without recommending restart", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-app-"));
+  try {
+    const result = await makeUnconfiguredController(rootDir).getAgentRuntimes();
+
+    assert.deepEqual(result, {
+      ok: false,
+      error: {
+        code: "agent_runtime_unavailable",
+        hint: "Agent runtime discovery is unavailable because this controller composition has no agentRuntimeInventoryReader. This request made no runtime changes. Inspect the controller host configuration and logs; use `ha daemon status --json` only to verify the active daemon before retrying through a controller that exposes runtime discovery."
+      }
+    });
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("missing holder projection reports a controller composition gap without recommending restart", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-app-"));
+  try {
+    const result = await makeUnconfiguredController(rootDir).getAgentHolders({});
+
+    assert.deepEqual(result, {
+      ok: false,
+      error: {
+        code: "agent_holder_projection_unavailable",
+        hint: "Agent holder projection is unavailable because this controller composition has no agentHolderProjection. This request made no runtime changes. Inspect the controller host configuration and logs; use `ha daemon status --json` only to verify the active daemon before retrying through a controller that exposes holder projection."
+      }
+    });
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("missing catalog reader reports a controller composition gap without recommending restart", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-app-"));
+  try {
+    const result = makeUnconfiguredController(rootDir).getCatalogSnapshot();
+
+    assert.deepEqual(result, {
+      ok: false,
+      error: {
+        code: "catalog_unavailable",
+        hint: "Catalog snapshot is unavailable because this controller composition has no catalogSnapshotReader. This request made no runtime changes. Inspect the controller host configuration and logs; use `ha daemon status --json` only to verify the active daemon before retrying through a controller that exposes catalog snapshots."
+      }
+    });
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("missing runtime control reports a controller composition gap without recommending restart", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-app-"));
+  try {
+    const result = await makeUnconfiguredController(rootDir).profiles();
+
+    assert.deepEqual(result, {
+      ok: false,
+      error: {
+        code: "agent_runtime_control_unavailable",
+        hint: "Agent runtime control is unavailable because this controller composition has no agentRuntimeControl. This request made no runtime changes. Inspect the controller host configuration and logs; use `ha daemon status --json` only to verify the active daemon before retrying through a controller that exposes runtime control."
+      }
+    });
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("missing decision mutation port reports a controller composition gap without recommending restart", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-app-"));
+  try {
+    const result = await makeUnconfiguredController(rootDir).proposeDecision({
+      title: "Decision",
+      question: "Choose?",
+      chosen: [{ text: "Chosen" }],
+      rejected: [{ text: "Rejected", why_not: "Not selected" }],
+      riskTier: "low",
+      urgency: "low"
+    });
+
+    assert.deepEqual(result, {
+      ok: false,
+      error: {
+        code: "decision_mutation_unavailable",
+        hint: "Decision mutation is unavailable because this controller composition has no decisionMutationPort. This request made no decision write. Inspect the controller host configuration and logs; use `ha daemon status --json` only to verify the active daemon before retrying through a controller that exposes governed decision mutation."
+      }
+    });
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("local controller service reads projection and writes through injected task writer", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-app-"));
   try {
@@ -195,14 +287,14 @@ test("local controller service reads projection and writes through injected task
       ok: false,
       error: {
         code: "terminal_status_requires_task_complete",
-        hint: "Direct done is blocked because completion consent is recorded only by task complete. Preferred path: ha task complete task-1 --approve. If the task is already terminal and more work is required, run ha task supersede task-1 --title <follow-up-title>."
+        hint: "Direct done is blocked because completion consent is recorded only by the typed completion transaction. Run `ha task show task-1 --json` to confirm the current state. If the task is not terminal, inspect `ha task complete --help` and prepare the required approval packet before retrying completion. If it is already terminal and follow-up work is needed, inspect `ha task supersede --help` before creating replacement work."
       }
     });
     assert.deepEqual(await service.setTaskStatus({ taskId: "task-1", status: "cancelled" }), {
       ok: false,
       error: {
         code: "terminal_status_requires_task_complete",
-        hint: "Direct cancellation requires an audited recovery path. Preferred path: ha task complete task-1 --approve. If the task is already terminal and more work is required, run ha task supersede task-1 --title <follow-up-title>."
+        hint: "Direct cancellation is blocked unless it is an audited recovery. Run `ha task show task-1 --json` to confirm the current state. If the task is not terminal and cancellation is still intended, inspect `ha task transition --help` and supply a truthful audited reason. If it is already terminal and follow-up work is needed, inspect `ha task supersede --help` before creating replacement work."
       }
     });
     assert.deepEqual(writes, ["status:task-1:active"]);
@@ -377,6 +469,17 @@ function writeTaskFacts(rootDir: string, taskId: string): void {
     "- {fact_id: F-12345678, statement: \"Projection fact\", source: \"test\", observedAt: \"2026-07-07T00:00:00.000Z\", confidence: high, memoryClass: semantic, memoryTags: [pattern], provenance: [{runtime: \"codex\", sessionId: \"session-1\", boundAt: \"2026-07-07T00:00:00.000Z\"}]}",
     ""
   ].join("\n"), "utf8");
+}
+
+function makeUnconfiguredController(rootDir: string) {
+  return makeLocalControllerService({
+    rootDir,
+    artifactStore: makeMarkdownArtifactStore({ rootDir }),
+    taskWriter: {
+      setStatus: (payload) => Effect.succeed({ taskId: payload.taskId, status: payload.status }),
+      appendProgress: (payload) => Effect.succeed({ taskId: payload.taskId, path: "progress.md" })
+    }
+  });
 }
 
 function writeDecision(rootDir: string, decisionId: string): void {

--- a/packages/application/test/task-lifecycle-write-failure.test.ts
+++ b/packages/application/test/task-lifecycle-write-failure.test.ts
@@ -9,6 +9,10 @@ import {
   type ArtifactStore,
   type TaskPackageRead
 } from "../../kernel/src/index.ts";
+import {
+  collectCompletionRequirementIssues,
+  completionRequirementsFailure
+} from "../src/task-completion-requirements.ts";
 import { makeTaskLifecycleOrchestrator, type TaskLifecycleWriter } from "../src/task-lifecycle-orchestrator.ts";
 import { runEffect } from "./effect-test-helpers.ts";
 
@@ -20,6 +24,74 @@ test("task lifecycle orchestrator exposes no completion mutation authority", () 
   });
 
   assert.equal("completeTask" in orchestrator, false);
+});
+
+test("completion requirements do not present approval as runnable without exact review consent", () => {
+  const completionGate = { ok: false, issues: [] } as never;
+  const issues = collectCompletionRequirementIssues({
+    taskId: "task_RENDER",
+    documentPlaceholder: null,
+    codeDocReconciliation: null,
+    completionGate,
+    completionAuthority: {
+      executionId: "exe_RENDER",
+      issues: [{ code: "execution_review_required", message: "execution_review_required message" }]
+    }
+  });
+
+  const rendered = completionRequirementsFailure("task_RENDER", issues, completionGate).error.hint;
+
+  assert.equal(
+    rendered,
+    "Task completion has 1 unmet requirement: [execution_review_required] execution_review_required message Execution exe_RENDER for task task_RENDER still requires an approved review, but this completion check cannot synthesize the required findings, rationale, or exact consent. Next: ha task review-execution --help"
+  );
+  assert.doesNotMatch(rendered, /--verdict approved/u);
+});
+
+test("archive warning requirements route to executable review help when approval inputs are absent", () => {
+  const completionGate = { ok: false, issues: [] } as never;
+  const issues = collectCompletionRequirementIssues({
+    taskId: "task_ARCHIVE",
+    documentPlaceholder: null,
+    codeDocReconciliation: null,
+    completionGate,
+    completionAuthority: {
+      executionId: "exe_ARCHIVE",
+      issues: [{
+        code: "archive_warnings_acknowledgement_required",
+        message: "archive warnings message"
+      }]
+    }
+  });
+
+  const rendered = completionRequirementsFailure("task_ARCHIVE", issues, completionGate).error.hint;
+
+  assert.equal(
+    rendered,
+    "Task completion has 1 unmet requirement: [archive_warnings_acknowledgement_required] archive warnings message Execution exe_ARCHIVE for task task_ARCHIVE has archive warnings, but this completion check cannot synthesize the required review findings, rationale, archive-warning acknowledgement, or exact consent. Next: ha task review-execution --help"
+  );
+  assert.doesNotMatch(rendered, /--verdict approved|<[^>]+>/u);
+});
+
+test("missing execution submission names the task and routes to the packet-backed submit contract", () => {
+  const completionGate = { ok: false, issues: [] } as never;
+  const issues = collectCompletionRequirementIssues({
+    taskId: "task_SUBMIT",
+    documentPlaceholder: null,
+    codeDocReconciliation: null,
+    completionGate,
+    completionAuthority: {
+      issues: [{ code: "execution_submission_required", message: "submission required message" }]
+    }
+  });
+
+  const rendered = completionRequirementsFailure("task_SUBMIT", issues, completionGate).error.hint;
+
+  assert.equal(
+    rendered,
+    "Task completion has 1 unmet requirement: [execution_submission_required] submission required message Task task_SUBMIT has no submitted Execution. This completion check cannot synthesize the required Holder claim or submission packet; inspect the governed submission contract, submit the Execution, then rerun the original completion command for task task_SUBMIT. Next: ha task submit --help"
+  );
+  assert.doesNotMatch(rendered, /<[^>]+>|rerun ha task complete\./u);
 });
 
 test("setTaskStatus rejects a scaffold task plan before writing active status", async () => {

--- a/packages/cli/src/cli/error-mapper.ts
+++ b/packages/cli/src/cli/error-mapper.ts
@@ -37,7 +37,7 @@ const cliErrorMappers = {
   WriteConflict: (error) => cliError(CliErrorCode.WriteConflict, error.owner ?? "Write lock is held."),
   GlobalWriteConflict: (error) => cliError(
     CliErrorCode.WriteConflict,
-    `${error.owner ? `Global write lock is held: ${error.owner}` : "Global write lock is held."} Direct recovery remains mutually exclusive with a live daemon; stop or drain the current writer and verify with 'ha daemon status' before retrying.`
+    `${error.owner ? `Global write lock is held: ${error.owner}` : "Global write lock is held."} Wait for the current writer to release it, then run \`ha daemon status --json\` and retry only after the lock is free. Do not stop, drain, or restart a writer solely to clear this conflict.`
   ),
   WriteRejected: (error) => {
     const code = error.code;

--- a/packages/cli/src/cli/receipt.ts
+++ b/packages/cli/src/cli/receipt.ts
@@ -438,10 +438,16 @@ function initSummary(path: string, report: unknown): string {
   const boundary = isolation && typeof isolation === "object" && !Array.isArray(isolation)
     ? (isolation as { readonly boundary?: unknown }).boundary
     : undefined;
+  const nextSteps = isolation && typeof isolation === "object" && !Array.isArray(isolation)
+    ? (isolation as { readonly nextSteps?: unknown }).nextSteps
+    : undefined;
   const summary = typeof boundary === "string"
     ? `initialized harness at ${path}; ${boundary}`
     : `initialized harness at ${path}`;
-  return `${summary} Next: ha daemon repo register --root .; then ha daemon start --service; verify with ha doctor --json.`;
+  const commands = Array.isArray(nextSteps)
+    ? nextSteps.filter((step): step is string => typeof step === "string").slice(0, 2)
+    : [];
+  return commands.length > 0 ? `${summary} Next: ${commands.join("; then ")}.` : summary;
 }
 
 export function displayCommand(command: string): { readonly command: string; readonly entity?: string; readonly action: string } {

--- a/packages/cli/src/cli/shell-argument.ts
+++ b/packages/cli/src/cli/shell-argument.ts
@@ -1,0 +1,5 @@
+export function shellArgument(value: string): string {
+  return /^[A-Za-z0-9_./:@%+=,-]+$/u.test(value)
+    ? value
+    : `'${value.replaceAll("'", `'"'"'`)}'`;
+}

--- a/packages/cli/src/commands/core/authority-planner-unavailable.ts
+++ b/packages/cli/src/commands/core/authority-planner-unavailable.ts
@@ -1,5 +1,5 @@
 const authorityBootstrapRequirement = "authority manifest, harness/people.yaml, and authority key registry/key material";
-const authorityBootstrapRecovery = "run `ha init`, then restart the daemon with `ha daemon stop && ha daemon start --service`, and retry the command";
+const authorityBootstrapRecovery = "run `ha daemon status --check --json` and inspect the loaded composition. Do not stop or restart the active daemon, and do not retry completion, until an operator has supplied and verified a replacement with the required authority manifest, people roster, and key material";
 
 export function authorityPlannerUnavailableHint(message: string): string {
   return `${message} The active daemon requires the initialized canonical authority composition (${authorityBootstrapRequirement}). Next: ${authorityBootstrapRecovery}.`;

--- a/packages/cli/src/commands/core/materializer.ts
+++ b/packages/cli/src/commands/core/materializer.ts
@@ -1,5 +1,7 @@
 import { Effect } from "effect";
+import { resolveHarnessLayout, type HarnessLayoutInput } from "@harness-anything/kernel";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
+import { shellArgument } from "../../cli/shell-argument.ts";
 import type { CliResult, MaterializerCommandReport, ParsedCommand } from "../../cli/types.ts";
 import type { CommandRunnerContext, CommandRunnerEffect } from "../../cli/runner-registry.ts";
 
@@ -15,10 +17,14 @@ export function runMaterializerCommand(
       error: cliError(CliErrorCode.UnknownCommand, `Unsupported materializer command: ${action.kind}`)
     } satisfies CliResult);
   }
-  return Effect.sync(() => materializerCommandResult(context.runLedgerMaterializer({ dryRun: action.dryRun })));
+  return Effect.sync(() => materializerCommandResult(
+    context.runLedgerMaterializer({ dryRun: action.dryRun }),
+    context.layoutInput
+  ));
 }
 
-export function materializerCommandResult(report: MaterializerCommandReport): CliResult {
+export function materializerCommandResult(report: MaterializerCommandReport, rootInput: HarnessLayoutInput): CliResult {
+  const authoredRoot = resolveHarnessLayout(rootInput).authoredRoot;
   const failures = report.branches.filter((branch) => branch.status === "conflict");
   const operationalFailures = failures.length === 0 ? report.warnings.map(String) : [];
   const failureLabels = [
@@ -26,7 +32,7 @@ export function materializerCommandResult(report: MaterializerCommandReport): Cl
     ...operationalFailures
   ];
   const nextCommand = failures.find((branch) => branch.nextCommand)?.nextCommand
-    ?? operationalFailures.map(nextCommandForOperationalFailure).find(Boolean);
+    ?? operationalFailures.map((message) => nextCommandForOperationalFailure(message, authoredRoot)).find(Boolean);
   const summary = `Materializer merged ${report.merged} branch${report.merged === 1 ? "" : "es"}; failed ${failureLabels.length}${failureLabels.length > 0 ? `: ${failureLabels.join(", ")}` : ""}.${nextCommand ? ` Next: ${nextCommand}` : ""}`;
   const warnings = failures.length > 0
     ? failures.map((branch) => ({
@@ -40,7 +46,7 @@ export function materializerCommandResult(report: MaterializerCommandReport): Cl
       severity: "error",
       code: "materializer_operational_failure",
       message,
-      nextCommand: nextCommandForOperationalFailure(message)
+      nextCommand: nextCommandForOperationalFailure(message, authoredRoot)
     }));
   return {
     ok: failureLabels.length === 0,
@@ -56,8 +62,8 @@ export function materializerCommandResult(report: MaterializerCommandReport): Cl
   };
 }
 
-function nextCommandForOperationalFailure(message: string): string {
+function nextCommandForOperationalFailure(message: string, authoredRoot: string): string {
   if (message === "authored root is not a Git repository") return "ha init --json";
-  if (/^trunk branch .+ does not exist$/u.test(message)) return "git -C harness branch --list";
+  if (/^trunk branch .+ does not exist$/u.test(message)) return `git -C ${shellArgument(authoredRoot)} branch --list`;
   return "ha status --json";
 }

--- a/packages/cli/src/commands/core/task-lifecycle-demotions.ts
+++ b/packages/cli/src/commands/core/task-lifecycle-demotions.ts
@@ -46,7 +46,7 @@ export const runTaskLifecycleWithDemotions: CommandRunner = (context, command) =
     const result = yield* context.engine.setStatus({ taskId: action.taskId, status: action.status });
     const warning = demotedGateWarning(
       "terminal_status_requires_task_complete",
-      `External-engine terminal status completed outside the local consent transaction. Preferred path: ha task complete ${action.taskId} --approve. If the task is already terminal and more work is required, run ha task supersede ${action.taskId} --title <follow-up-title>.`
+      `External-engine terminal status completed outside the local consent transaction. Run \`ha task show ${action.taskId} --json\` to confirm the resulting state. Do not run another terminal transition from this receipt. If follow-up work is needed, inspect \`ha task supersede --help\` before creating replacement work.`
     );
     return {
       ok: true,
@@ -92,8 +92,7 @@ function runLocalAuditedCancellation(
 }
 
 function terminalStatusRecoveryHint(taskId: string, status: "done" | "cancelled"): string {
-  const preferred = `Preferred path: ha task complete ${taskId} --approve. If the task is already terminal and more work is required, run ha task supersede ${taskId} --title <follow-up-title>.`;
   return status === "done"
-    ? `Direct done is blocked because completion consent is recorded only by task complete. ${preferred}`
-    : `Direct cancellation is blocked unless it is an audited recovery. ${preferred} For cancellation recovery, run ha task transition ${taskId} cancelled --force --reason "<reason>".`;
+    ? `Direct done is blocked because completion consent is recorded only by the typed completion transaction. Run \`ha task show ${taskId} --json\` to confirm the current state. If the task is not terminal, inspect \`ha task complete --help\` and prepare the required approval packet before retrying completion. If it is already terminal and follow-up work is needed, inspect \`ha task supersede --help\` before creating replacement work.`
+    : `Direct cancellation is blocked unless it is an audited recovery. Run \`ha task show ${taskId} --json\` to confirm the current state. If the task is not terminal and cancellation is still intended, inspect \`ha task transition --help\` and supply a truthful audited reason. If it is already terminal and follow-up work is needed, inspect \`ha task supersede --help\` before creating replacement work.`;
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import type { HarnessLayoutInput } from "@harness-anything/kernel";
 import type { VcsCommitAuthor } from "@harness-anything/kernel";
 import { resolveHarnessLayout } from "@harness-anything/kernel";
-import { ensureProjectPeopleRoster } from "@harness-anything/daemon";
+import { ensureProjectPeopleRoster, resolveCanonicalHarnessRootResolution } from "@harness-anything/daemon";
 import { normalizeSlashes } from "../cli/path.ts";
 import type { CliResult } from "../cli/types.ts";
 import { resolveActiveVertical } from "./extensions/active-vertical.ts";
@@ -27,11 +27,12 @@ export function initializeHarness(
   gitRuntime: InitGitRuntime = {},
   bootstrapAuthority = false
 ): CliResult {
-  const layout = resolveHarnessLayout(rootInput);
+  const initializationInput = canonicalInitializationInput(rootInput);
+  const layout = resolveHarnessLayout(initializationInput);
   const rootDir = layout.rootDir;
   const warnings: unknown[] = [];
   const resolvedProjectName = projectName ?? path.basename(rootDir);
-  const activeVertical = resolveActiveVertical(rootInput, "init");
+  const activeVertical = resolveActiveVertical(initializationInput, "init");
   if (!activeVertical.ok) return activeVertical.result;
   const vertical = activeVertical.definition.manifest;
   for (const directory of [
@@ -51,7 +52,7 @@ export function initializeHarness(
 
   const harnessConfigPath = layout.configPath ?? path.join(layout.authoredRoot, "harness.yaml");
   writeHarnessYaml(harnessConfigPath, resolvedProjectName, projectName !== undefined);
-  materializeRepositoryScaffold(rootInput, vertical);
+  materializeRepositoryScaffold(initializationInput, vertical);
   if (bootstrapAuthority && commitAuthor) ensureProjectPeopleRoster(layout.authoredRoot, commitAuthor);
   const isolation = ensureHarnessRepositoryIsolation(rootDir, layout.authoredRoot, commitAuthor, gitRuntime);
   warnings.push(...isolation.warnings);
@@ -148,15 +149,26 @@ function ensureHarnessRepositoryIsolation(
       outerGitignore: gitignore.report,
       boundary: "Code PRs must not include harness/ changes; commit ledger changes inside harness/ as its own private git repository.",
       nextSteps: [
-        "ha daemon repo register --root .",
-        "ha daemon start --service",
-        "ha doctor --json",
+        `ha daemon repo register --root ${initShellArgument(rootDir)}`,
+        `ha --root ${initShellArgument(rootDir)} doctor --json`,
         "git status",
         `git -C ${authoredRootRelative} status`,
         `git -C ${authoredRootRelative} add . && git -C ${authoredRootRelative} commit`
       ]
     }
   };
+}
+
+function canonicalInitializationInput(input: HarnessLayoutInput): HarnessLayoutInput {
+  const resolution = resolveCanonicalHarnessRootResolution(input);
+  if (resolution.source === "local-layout") return input;
+  return typeof input === "string"
+    ? resolution.canonicalRoot
+    : { ...input, rootDir: resolution.canonicalRoot };
+}
+
+function initShellArgument(value: string): string {
+  return /^[A-Za-z0-9_./:@%+=,-]+$/u.test(value) ? value : `'${value.replaceAll("'", `'"'"'`)}'`;
 }
 
 function ensureOuterGitRepository(

--- a/packages/cli/src/commands/legacy-rebuild.ts
+++ b/packages/cli/src/commands/legacy-rebuild.ts
@@ -9,6 +9,7 @@ import type { HarnessLayoutInput } from "@harness-anything/kernel";
 import { createTaskPackagePath, generateTaskId, resolveHarnessLayout, slugifyTaskTitle } from "@harness-anything/kernel";
 import { LegacyIndexSchema, type LegacyIndexEntry } from "@harness-anything/kernel";
 import { cliError, CliErrorCode } from "../cli/error-codes.ts";
+import { shellArgument } from "../cli/shell-argument.ts";
 import type { CliResult, ParsedCommand } from "../cli/types.ts";
 
 type NewTaskAction = Extract<ParsedCommand["action"], { readonly kind: "new-task" }>;
@@ -112,12 +113,17 @@ function readLegacyRebuildSource(rootInput: HarnessLayoutInput, legacyId: string
   const layout = resolveHarnessLayout(rootInput);
   const rootDir = layout.rootDir;
   if (!existsSync(layout.legacyIndexPath)) {
+    const root = shellArgument(rootDir);
+    const index = path.relative(rootDir, layout.legacyIndexPath).split(path.sep).join("/");
     return {
       ok: false,
       result: {
         ok: false,
         command: "new-task",
-        error: cliError(CliErrorCode.LegacyIndexMissing, "harness/legacy/index.json is missing. Run legacy index <path> --apply before rebuilding from legacy.")
+        error: cliError(
+          CliErrorCode.LegacyIndexMissing,
+          `${index} is missing. Run \`ha legacy index --help\` to identify and index the actual legacy source path, then rerun \`ha --root ${root} task create --from-legacy ${shellArgument(legacyId)}\`.`
+        )
       }
     };
   }

--- a/packages/cli/src/commands/migration.ts
+++ b/packages/cli/src/commands/migration.ts
@@ -9,6 +9,7 @@ import { cliError, CliErrorCode } from "../cli/error-codes.ts";
 import { demotedGateWarning } from "../cli/demoted-gate-warning.ts";
 import { resolveContainedOutputPath } from "../cli/output-path.ts";
 import { isGeneratedOrVendorPath, isPathInside, normalizeSlashes } from "../cli/path.ts";
+import { shellArgument } from "../cli/shell-argument.ts";
 import type { CliResult } from "../cli/types.ts";
 import { applyCollisionReport, buildLegacyCopyPlan, readCollisionReport, writeCollisionReport } from "./migration-collision.ts";
 import { collectLegacyProvenanceWarnings } from "./legacy-provenance-verify.ts";
@@ -247,11 +248,16 @@ export function runLegacyVerify(rootInput: HarnessLayoutInput, _action: LegacyVe
   const layout = resolveHarnessLayout(rootInput);
   const rootDir = layout.rootDir;
   if (!existsSync(layout.legacyIndexPath)) {
+    const root = shellArgument(rootDir);
+    const index = normalizeSlashes(path.relative(rootDir, layout.legacyIndexPath));
     return {
       ok: false,
       command: "legacy-verify",
       report: { schema: "legacy-intake-verify-report/v1", ok: false, missingIndex: true },
-      error: cliError(CliErrorCode.LegacyIndexMissing, "harness/legacy/index.json is missing. Run legacy index <path> --apply.")
+      error: cliError(
+        CliErrorCode.LegacyIndexMissing,
+        `${index} is missing. Run \`ha legacy index --help\` to identify and index the actual legacy source path, then run \`ha --root ${root} legacy verify\`.`
+      )
     };
   }
   let index: LegacyIndex;

--- a/packages/cli/src/composition/local-principal.ts
+++ b/packages/cli/src/composition/local-principal.ts
@@ -125,6 +125,7 @@ function readConfiguredLocalPrincipalWithSource(rootInput: HarnessLayoutInput, r
   const layout = resolveHarnessLayout(rootInput);
   const peoplePath = path.join(layout.authoredRoot, "people.yaml");
   const machineUserRoot = localMachineIdentityRoot(layout.rootDir, env);
+  const machinePeoplePath = machineUserRoot ? path.join(machineUserRoot, "people.yaml") : undefined;
   const resolvedRegistry = registryInput
     ? undefined
     : resolvedPersonRegistry(rootInput, peoplePath, machineUserRoot);
@@ -139,7 +140,7 @@ function readConfiguredLocalPrincipalWithSource(rootInput: HarnessLayoutInput, r
   const personId = credentialPersonId ?? identity?.personId;
   if (!personId) {
     throw new CliPrincipalResolutionError(
-      "Local writes require a machine identity. Run: ha init with HARNESS_GIT_AUTHOR_NAME and HARNESS_GIT_AUTHOR_EMAIL set, or add the current host/uid credential to ~/.harness/people.yaml."
+      `Local writes require a machine identity. Resolved daemon user root: ${machineUserRoot ?? "unavailable"}. Machine roster path: ${machinePeoplePath ?? "unavailable"}. Run: ha init with HARNESS_GIT_AUTHOR_NAME and HARNESS_GIT_AUTHOR_EMAIL set, or add the current host/uid credential to ${machinePeoplePath ?? "the resolved machine roster"}.`
     );
   }
   if (!registry) {

--- a/packages/cli/test/authority-planner-unavailable.test.ts
+++ b/packages/cli/test/authority-planner-unavailable.test.ts
@@ -1,0 +1,15 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { authorityPlannerUnavailableHint } from "../src/commands/core/authority-planner-unavailable.ts";
+
+test("missing authority planner preserves the active daemon until a replacement composition is verified", () => {
+  const rendered = authorityPlannerUnavailableHint(
+    "Task completion dry-run is blocked because the canonical authority planner is unavailable; no completion requirement was evaluated."
+  );
+
+  assert.equal(
+    rendered,
+    "Task completion dry-run is blocked because the canonical authority planner is unavailable; no completion requirement was evaluated. The active daemon requires the initialized canonical authority composition (authority manifest, harness/people.yaml, and authority key registry/key material). Next: run `ha daemon status --check --json` and inspect the loaded composition. Do not stop or restart the active daemon, and do not retry completion, until an operator has supplied and verified a replacement with the required authority manifest, people roster, and key material."
+  );
+});

--- a/packages/cli/test/completion-facade-cli.test.ts
+++ b/packages/cli/test/completion-facade-cli.test.ts
@@ -124,7 +124,9 @@ test("task complete dry-run blocks when the canonical authority planner is unava
     assert.equal(preview.error.code, "write_rejected");
     assert.match(preview.error.hint, /canonical authority planner is unavailable/iu);
     assert.match(preview.error.hint, /authority manifest.+harness\/people\.yaml.+authority key registry/iu);
-    assert.match(preview.error.hint, /ha init.+ha daemon stop.+ha daemon start --service/iu);
+    assert.match(preview.error.hint, /ha daemon status --check --json/iu);
+    assert.match(preview.error.hint, /Do not stop or restart the active daemon/iu);
+    assert.doesNotMatch(preview.error.hint, /ha init|ha daemon stop|ha daemon start --service/iu);
     assert.doesNotMatch(preview.error.hint, /direct recovery/iu);
     assert.equal(existsSync(path.join(rootDir, chain.packagePath, "reviews")), false);
     assert.match(readFileSync(path.join(rootDir, chain.packagePath, "INDEX.md"), "utf8"), /^  status: in_review$/mu);

--- a/packages/cli/test/direct-mode-fail-close.test.ts
+++ b/packages/cli/test/direct-mode-fail-close.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import test from "node:test";
 import { defaultDaemonUserRoot, runDaemonCommand, runRawJson, runRawJsonMaybeFail, withTempRoot, withTempRootAsync } from "./helpers/daemon-cli.ts";
 import { cliTestEnv } from "./helpers/cli-test-env.ts";
+import { validateCommandOptions } from "../src/cli/option-claims.ts";
 
 test("initialized ledgers fail closed when an ordinary caller requests a direct canonical write", () => {
   withTempRoot((rootDir) => {
@@ -83,9 +84,21 @@ test("direct recovery is rejected by the global write lock while the daemon is l
 
     assert.equal(failed.status, 1);
     assert.equal(failed.receipt.ok, false);
-    assert.equal((failed.receipt.error as Record<string, unknown>).code, "write_conflict");
-    assert.match(JSON.stringify(failed.receipt), /Global write lock is held/iu);
-    assert.match(JSON.stringify(failed.receipt), /mutually exclusive with a live daemon/iu);
+    const error = failed.receipt.error as Record<string, unknown>;
+    const hint = String(error.hint);
+    assert.equal(error.code, "write_conflict");
+    assert.match(hint, /Global write lock is held/iu);
+    assert.match(hint, /Wait for the current writer to release it/iu);
+    assert.match(hint, /retry only after the lock is free/iu);
+    assert.match(hint, /`ha daemon status --json`/u);
+    assert.doesNotMatch(hint, /<[^>\n]+>|\{[^}\n]+\}|\.\.\./u);
+    assert.doesNotMatch(
+      hint,
+      /\bha(?:\s+--root\s+\S+)?\s+daemon\s+(?:start|stop|restart|repo\s+(?:register|unregister|purge))\b|HARNESS_(?:DAEMON_MODE|DIRECT_WRITE_REASON)|--daemon-mode(?:=|\s+)direct/iu
+    );
+    const statusContract = validateCommandOptions(["daemon", "status", "--json"]);
+    assert.equal(statusContract.ok, true);
+    assert.equal(statusContract.ok ? statusContract.claim?.kind : undefined, "daemon-status");
     assert.equal(canonicalHead(rootDir), initialHead, "conflicting direct recovery must not move the canonical ref");
   });
 });

--- a/packages/cli/test/doctor-cli.test.ts
+++ b/packages/cli/test/doctor-cli.test.ts
@@ -113,9 +113,9 @@ test("doctor sees initialized authored and generated harness roots without repai
     const initialized = runJson(rootDir, ["init"]);
 
     assert.deepEqual(initialized.report.isolation.nextSteps.slice(0, 3), [
-      "ha daemon repo register --root .",
-      "ha daemon start --service",
-      "ha doctor --json"
+      `ha daemon repo register --root ${rootDir}`,
+      `ha --root ${rootDir} doctor --json`,
+      "git status"
     ]);
 
     const result = runJson(rootDir, ["doctor"]);

--- a/packages/cli/test/doctor-cli.test.ts
+++ b/packages/cli/test/doctor-cli.test.ts
@@ -10,6 +10,8 @@ import test from "node:test";
 import { commandGroups } from "../src/cli/command-spec/command-groups.ts";
 import { commandSpecs } from "../src/cli/command-spec/index.ts";
 import { commandRegistry } from "../src/cli/command-registry.ts";
+import { validateCommandOptions } from "../src/cli/option-claims.ts";
+import { parseArgs } from "../src/cli/parse-args.ts";
 import { writeIndex } from "./helpers/local-lifecycle-fixtures.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
@@ -309,13 +311,32 @@ test("task delete help exposes production soft delete and hard-delete alternativ
   });
 });
 
-test("init text receipt gives the daemon registration and startup path", () => {
+test("init text receipt names canonical registration and read-only diagnosis without daemon lifecycle control", () => {
   withTempRoot((rootDir) => {
     const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "init"], {
       encoding: "utf8"
     });
+    const summaryMatch = /\bsummary="([^"]+)"\s*$/u.exec(stdout.trim());
+    assert.ok(summaryMatch, stdout);
+    const summary = summaryMatch[1]!;
 
-    assert.match(stdout, /Next: ha daemon repo register --root \.; then ha daemon start --service; verify with ha doctor --json\./u);
+    assert.match(summary, /\bNext:/u);
+    assert.equal(summary.includes(`ha daemon repo register --root ${rootDir}`), true);
+    assert.equal(summary.includes(`ha --root ${rootDir} doctor --json`), true);
+    assert.doesNotMatch(summary, /<[^>\n]+>|\{[^}\n]+\}|\.\.\./u);
+    assert.doesNotMatch(
+      summary,
+      /\bha(?:\s+--root\s+\S+)?\s+daemon\s+(?:start|stop|restart|repo\s+(?:unregister|purge))\b|HARNESS_(?:DAEMON_MODE|DIRECT_WRITE_REASON)|--daemon-mode(?:=|\s+)direct/iu
+    );
+
+    const registerContract = validateCommandOptions(["daemon", "repo", "register", "--root", rootDir]);
+    assert.equal(registerContract.ok, true);
+    assert.equal(registerContract.ok ? registerContract.claim?.kind : undefined, "daemon-repo-register");
+    const doctorContract = parseArgs(["--root", rootDir, "doctor", "--json"]);
+    assert.equal(doctorContract.ok, true);
+    if (!doctorContract.ok) return;
+    assert.equal(doctorContract.value.rootDir, rootDir);
+    assert.equal(doctorContract.value.action.kind, "doctor");
   });
 });
 

--- a/packages/cli/test/error-mapper.test.ts
+++ b/packages/cli/test/error-mapper.test.ts
@@ -36,7 +36,7 @@ test("journal failures always retain their cause and teach a concrete diagnostic
 test("global write conflicts explain that direct recovery cannot race a live daemon", () => {
   assert.deepEqual(toCliError({ _tag: "GlobalWriteConflict", owner: ".harness/locks/global.lock" }), {
     code: "write_conflict",
-    hint: "Global write lock is held: .harness/locks/global.lock Direct recovery remains mutually exclusive with a live daemon; stop or drain the current writer and verify with 'ha daemon status' before retrying."
+    hint: "Global write lock is held: .harness/locks/global.lock Wait for the current writer to release it, then run `ha daemon status --json` and retry only after the lock is free. Do not stop, drain, or restart a writer solely to clear this conflict."
   });
 });
 

--- a/packages/cli/test/helpers/temp-root-cleanup.ts
+++ b/packages/cli/test/helpers/temp-root-cleanup.ts
@@ -1,0 +1,46 @@
+import { rmSync } from "node:fs";
+import { setTimeout as waitFor } from "node:timers/promises";
+
+const retriableRemovalCodes = new Set([
+  "EBUSY",
+  "EMFILE",
+  "ENFILE",
+  "ENOTEMPTY",
+  "EPERM"
+]);
+
+interface TemporaryTestRootCleanupOptions {
+  readonly remove?: (rootDir: string) => void;
+  readonly wait?: (milliseconds: number) => Promise<void>;
+  readonly maxRetries?: number;
+  readonly retryDelayMs?: number;
+}
+
+export async function removeTemporaryTestRoot(
+  rootDir: string,
+  options: TemporaryTestRootCleanupOptions = {}
+): Promise<void> {
+  const remove = options.remove ?? ((candidateRoot: string) => {
+    rmSync(candidateRoot, { recursive: true, force: true });
+  });
+  const wait = options.wait ?? ((milliseconds: number) => waitFor(milliseconds));
+  const maxRetries = options.maxRetries ?? 7;
+  const retryDelayMs = options.retryDelayMs ?? 25;
+
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      remove(rootDir);
+      return;
+    } catch (error) {
+      if (!isRetriableRemovalError(error) || attempt >= maxRetries) throw error;
+      await wait(retryDelayMs * (attempt + 1));
+    }
+  }
+}
+
+function isRetriableRemovalError(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && retriableRemovalCodes.has(String((error as { readonly code?: unknown }).code));
+}

--- a/packages/cli/test/init-linked-worktree.test.ts
+++ b/packages/cli/test/init-linked-worktree.test.ts
@@ -1,0 +1,47 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { toCommandReceipt } from "../src/cli/receipt.ts";
+import { initializeHarness } from "../src/commands/init.ts";
+
+test("init from a linked worktree initializes and names the canonical repository", () => {
+  const container = mkdtempSync(path.join(tmpdir(), "ha-init-linked-worktree-"));
+  const canonicalRoot = path.join(container, "canonical");
+  const worktreeRoot = path.join(container, "linked");
+  try {
+    execFileSync("git", ["init", "--initial-branch=main", canonicalRoot]);
+    execFileSync("git", ["-C", canonicalRoot, "config", "user.name", "Harness Test"]);
+    execFileSync("git", ["-C", canonicalRoot, "config", "user.email", "harness-test@example.invalid"]);
+    writeFileSync(path.join(canonicalRoot, "README.md"), "fixture\n", "utf8");
+    execFileSync("git", ["-C", canonicalRoot, "add", "README.md"]);
+    execFileSync("git", ["-C", canonicalRoot, "commit", "-m", "fixture"]);
+    execFileSync("git", ["-C", canonicalRoot, "worktree", "add", "-b", "linked", worktreeRoot]);
+
+    const result = initializeHarness({ rootDir: worktreeRoot }, false, "Linked fixture");
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    const canonical = realpathSync.native(canonicalRoot);
+    assert.equal(existsSync(path.join(canonical, "harness/harness.yaml")), true);
+    assert.equal(existsSync(path.join(worktreeRoot, "harness/harness.yaml")), false);
+    assert.deepEqual(result.report.isolation.nextSteps.slice(0, 2), [
+      `ha daemon repo register --root ${canonical}`,
+      `ha --root ${canonical} doctor --json`
+    ]);
+    assert.equal(result.report.isolation.nextSteps.includes("ha daemon start --service"), false);
+    const receipt = toCommandReceipt(result);
+    assert.equal(receipt.ok, true);
+    assert.match(receipt.summary, new RegExp(`Next: ha daemon repo register --root ${escapeRegExp(canonical)}; then ha --root ${escapeRegExp(canonical)} doctor --json\\.$`, "u"));
+    assert.doesNotMatch(receipt.summary, /--root \.|daemon start/u);
+  } finally {
+    rmSync(container, { recursive: true, force: true });
+  }
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}

--- a/packages/cli/test/legacy-missing-index-guidance.test.ts
+++ b/packages/cli/test/legacy-missing-index-guidance.test.ts
@@ -1,0 +1,67 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { Effect } from "effect";
+import { runNewTaskFromLegacy } from "../src/commands/legacy-rebuild.ts";
+import { runLegacyVerify } from "../src/commands/migration.ts";
+import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
+
+test("legacy rebuild missing-index branch renders concrete commands before composition", () => {
+  withTempRoot((rootDir) => {
+    const result = Effect.runSync(runNewTaskFromLegacy(
+      rootDir,
+      { kind: "new-task", fromLegacyId: "legacy_missing" } as never,
+      () => { throw new Error("missing-index branch must not create a write coordinator"); }
+    ));
+
+    assert.equal(result.ok, false);
+    assert.equal(
+      result.error?.hint,
+      `harness/legacy/index.json is missing. Run \`ha legacy index --help\` to identify and index the actual legacy source path, then rerun \`ha --root ${shellArgument(rootDir)} task create --from-legacy legacy_missing\`.`
+    );
+  });
+});
+
+test("missing legacy index guidance uses the resolved authored root and shell-safe repository root", () => {
+  withTempRoot((temporaryRoot) => {
+    const rootDir = path.join(temporaryRoot, "workspace's root");
+    mkdirSync(rootDir, { recursive: true });
+    const rootInput = {
+      rootDir,
+      layoutOverrides: { authoredRoot: ".custom-harness", projectRootBoundary: true }
+    };
+    const rebuild = Effect.runSync(runNewTaskFromLegacy(
+      rootInput,
+      { kind: "new-task", fromLegacyId: "legacy special" } as never,
+      () => { throw new Error("missing-index branch must not create a write coordinator"); }
+    ));
+    const verify = runLegacyVerify(rootInput, { kind: "legacy-verify" });
+    const root = shellArgument(rootDir);
+
+    assert.equal(
+      rebuild.error?.hint,
+      `.custom-harness/legacy/index.json is missing. Run \`ha legacy index --help\` to identify and index the actual legacy source path, then rerun \`ha --root ${root} task create --from-legacy 'legacy special'\`.`
+    );
+    assert.equal(
+      verify.error?.hint,
+      `.custom-harness/legacy/index.json is missing. Run \`ha legacy index --help\` to identify and index the actual legacy source path, then run \`ha --root ${root} legacy verify\`.`
+    );
+  });
+});
+
+function withTempRoot<T>(run: (rootDir: string) => T): T {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-legacy-guidance-"));
+  try {
+    ensureTestHarnessIdentity(rootDir);
+    return run(rootDir);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function shellArgument(value: string): string {
+  return /^[A-Za-z0-9_./:@%+=,-]+$/u.test(value) ? value : `'${value.replaceAll("'", `'"'"'`)}'`;
+}

--- a/packages/cli/test/local-lifecycle-cli.test.ts
+++ b/packages/cli/test/local-lifecycle-cli.test.ts
@@ -6,6 +6,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync
 import path from "node:path";
 import test from "node:test";
 import { commandDescriptors } from "../src/cli/command-registry.ts";
+import { parseArgs } from "../src/cli/parse-args.ts";
 import { capabilityExcludedCommandKinds } from "../src/commands/core/capabilities.ts";
 import { writeSubstantiveTaskPlan } from "./helpers/task-plan-fixture.ts";
 import {
@@ -145,8 +146,7 @@ test("CLI blocks direct done, keeps audited cancellation recovery, and gives own
     const invalidForce = runJson(rootDir, ["task", "status", "set", taskId, "done", "--force", "--reason", "invalid recovery"], false);
     assert.equal(invalidForce.ok, false);
     assert.equal(invalidForce.error?.code, "terminal_status_requires_task_complete");
-    assert.match(invalidForce.error?.hint ?? "", new RegExp(`ha task complete ${taskId} --approve`, "u"));
-    assert.match(invalidForce.error?.hint ?? "", new RegExp(`ha task supersede ${taskId}`, "u"));
+    assertTerminalRecoveryHint(invalidForce.error?.hint ?? "", taskId, "done");
     assert.equal(existsSync(path.join(rootDir, `harness/tasks/${taskId}-task-one/progress.md`)), false);
 
     writeSubstantiveTaskPlan(rootDir, String(created.packagePath));
@@ -155,13 +155,12 @@ test("CLI blocks direct done, keeps audited cancellation recovery, and gives own
     const doneFailure = runJson(rootDir, ["task", "status", "set", taskId, "done"], false);
     assert.equal(doneFailure.ok, false);
     assert.equal(doneFailure.error?.code, "terminal_status_requires_task_complete");
-    assert.match(doneFailure.error?.hint ?? "", new RegExp(`ha task complete ${taskId} --approve`, "u"));
-    assert.match(doneFailure.error?.hint ?? "", new RegExp(`ha task supersede ${taskId}`, "u"));
+    assertTerminalRecoveryHint(doneFailure.error?.hint ?? "", taskId, "done");
 
     const cancelFailure = runJson(rootDir, ["task", "status", "set", taskId, "cancelled"], false);
     assert.equal(cancelFailure.ok, false);
     assert.equal(cancelFailure.error?.code, "terminal_status_requires_task_complete");
-    assert.match(cancelFailure.error?.hint ?? "", new RegExp(`ha task transition ${taskId} cancelled --force --reason`, "u"));
+    assertTerminalRecoveryHint(cancelFailure.error?.hint ?? "", taskId, "cancelled");
 
     const missingReason = runJson(rootDir, ["task", "status", "set", taskId, "cancelled", "--force"], false);
     assert.equal(missingReason.ok, false);
@@ -184,6 +183,25 @@ test("CLI blocks direct done, keeps audited cancellation recovery, and gives own
     assert.equal(check.warnings.some((warning: Record<string, unknown>) => warning.code === "forced_terminal_status_set" && warning.severity === "warning"), true);
   });
 });
+
+function assertTerminalRecoveryHint(hint: string, taskId: string, status: "done" | "cancelled"): void {
+  const ownerCommand = status === "done" ? "complete" : "transition";
+  assert.match(hint, new RegExp(`ha task show ${taskId} --json`, "u"));
+  assert.match(hint, new RegExp(`ha task ${ownerCommand} --help`, "u"));
+  assert.match(hint, /ha task supersede --help/u);
+  assert.doesNotMatch(hint, /<[^>\n]+>|\{[^}\n]+\}|\.\.\./u);
+  assert.doesNotMatch(
+    hint,
+    /\bha(?:\s+--root\s+\S+)?\s+daemon\s+(?:start|stop|restart|repo\s+(?:register|unregister|purge))\b|HARNESS_(?:DAEMON_MODE|DIRECT_WRITE_REASON)|--daemon-mode(?:=|\s+)direct/iu
+  );
+  for (const argv of [
+    ["task", "show", taskId, "--json"],
+    ["task", ownerCommand, "--help"],
+    ["task", "supersede", "--help"]
+  ]) {
+    assert.equal(parseArgs(argv).ok, true, `suggested command must match the CLI contract: ha ${argv.join(" ")}`);
+  }
+}
 
 test("CLI rejects unknown six-state lifecycle values", () => {
   withTempRoot((rootDir) => {

--- a/packages/cli/test/local-principal-errors.test.ts
+++ b/packages/cli/test/local-principal-errors.test.ts
@@ -1,0 +1,45 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { resolveLocalCliActorAttribution } from "../src/composition/local-principal.ts";
+import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
+
+test("missing machine identity reports the resolved daemon user root and roster path", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-cli-principal-"));
+  try {
+    ensureTestHarnessIdentity(rootDir);
+    writeFileSync(path.join(rootDir, "harness/harness.yaml"), [
+      "schema: harness-anything/v1",
+      "layout:",
+      "  authoredRoot: harness",
+      "  localRoot: .harness",
+      ""
+    ].join("\n"), "utf8");
+    const userRoot = path.join(rootDir, "custom daemon root");
+    const machineRosterPath = path.join(userRoot, "people.yaml");
+
+    assert.throws(
+      () => resolveLocalCliActorAttribution(
+        { rootDir },
+        {
+          HARNESS_ACTOR: "agent:codex",
+          HARNESS_GIT_AUTHOR_NAME: "Harness Writer",
+          HARNESS_GIT_AUTHOR_EMAIL: "writer@example.test",
+          HARNESS_DAEMON_USER_ROOT: userRoot
+        }
+      ),
+      (error) => {
+        assert.equal(
+          (error as Error).message,
+          `Local writes require a machine identity. Resolved daemon user root: ${userRoot}. Machine roster path: ${machineRosterPath}. Run: ha init with HARNESS_GIT_AUTHOR_NAME and HARNESS_GIT_AUTHOR_EMAIL set, or add the current host/uid credential to ${machineRosterPath}.`
+        );
+        return true;
+      }
+    );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/test/materializer-error-guidance.test.ts
+++ b/packages/cli/test/materializer-error-guidance.test.ts
@@ -1,0 +1,28 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { materializerCommandResult } from "../src/commands/core/materializer.ts";
+
+test("materializer operational recovery command uses the resolved custom authored root", () => {
+  const rootDir = path.resolve("/tmp/materializer custom root");
+  const authoredRoot = path.join(rootDir, ".custom ledger");
+  const result = materializerCommandResult({
+    dryRun: false,
+    merged: 0,
+    considered: 0,
+    branches: [],
+    warnings: ["trunk branch main does not exist"]
+  }, {
+    rootDir,
+    layoutOverrides: { authoredRoot: ".custom ledger" }
+  });
+  const warning = result.warnings?.[0] as { readonly nextCommand?: string } | undefined;
+  const expectedCommand = `git -C '${authoredRoot}' branch --list`;
+
+  assert.equal(warning?.nextCommand, expectedCommand);
+  assert.equal(
+    result.error?.hint,
+    `Materializer merged 0 branches; failed 1: trunk branch main does not exist. Next: ${expectedCommand}`
+  );
+});

--- a/packages/cli/test/migration-adopt-cli.test.ts
+++ b/packages/cli/test/migration-adopt-cli.test.ts
@@ -352,6 +352,10 @@ test("CLI legacy verify detects missing, invalid, and valid index states", () =>
   withTempRoot((rootDir) => {
     const missing = runJson(rootDir, ["legacy", "verify"], false);
     assert.equal(missing.error.code, "legacy_index_missing");
+    assert.equal(
+      missing.error.hint,
+      `harness/legacy/index.json is missing. Run \`ha legacy index --help\` to identify and index the actual legacy source path, then run \`ha --root ${shellArgument(rootDir)} legacy verify\`.`
+    );
 
     mkdirSync(path.join(rootDir, "harness/legacy"), { recursive: true });
     writeFileSync(path.join(rootDir, "harness/legacy/index.json"), "{\"schema\":\"wrong\"}\n", "utf8");
@@ -379,6 +383,10 @@ test("CLI rebuilds a fresh local task from a legacy index entry with provenance"
 
     const missing = runJson(rootDir, ["new-task", "--from-legacy", "legacy_missing"], false);
     assert.equal(missing.error.code, "legacy_index_missing");
+    assert.equal(
+      missing.error.hint,
+      `harness/legacy/index.json is missing. Run \`ha legacy index --help\` to identify and index the actual legacy source path, then rerun \`ha --root ${shellArgument(rootDir)} task create --from-legacy legacy_missing\`.`
+    );
 
     mkdirSync(path.join(rootDir, "harness/legacy"), { recursive: true });
     writeFileSync(path.join(rootDir, "harness/legacy/index.json"), "{\"schema\":\"wrong\"}\n", "utf8");
@@ -431,6 +439,17 @@ test("CLI rebuilds a fresh local task from a legacy index entry with provenance"
     assert.equal(verified.ok, true);
     assert.equal(verified.warnings.some((warning: Record<string, unknown>) => warning.code === "legacy_provenance_target_missing" && warning.legacyId === legacyEntry.id), true);
   });
+});
+
+test("legacy index help parses without inventing a source path", () => {
+  const help = execFileSync(process.execPath, [cliEntry, "legacy", "index", "--help"], {
+    encoding: "utf8",
+    env: cliTestEnv()
+  });
+
+  assert.match(help, /Usage: harness-anything legacy index <path> \[--apply\]/u);
+  assert.match(help, /ha legacy index <path> \[--apply\]/u);
+  assert.doesNotMatch(help, /legacy index \. --apply/u);
 });
 
 test("CLI migrate aliases now emit Legacy Intake semantics and retire full cutover", () => {
@@ -619,6 +638,10 @@ function runJson(
     if (expectSuccess) assert.fail(body);
     return unwrapCommandReceipt(parsed);
   }
+}
+
+function shellArgument(value: string): string {
+  return /^[A-Za-z0-9_./:@%+=,-]+$/u.test(value) ? value : `'${value.replaceAll("'", `'"'"'`)}'`;
 }
 
 function withTempRoot<T>(fn: (rootDir: string) => T): T {

--- a/packages/cli/test/production-authority-semantic-publication-recovery.test.ts
+++ b/packages/cli/test/production-authority-semantic-publication-recovery.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -21,9 +21,11 @@ import {
   createGitCanonicalPublicationInspector,
   recoverPendingProductionEvents
 } from "@harness-anything/daemon";
+import { removeTemporaryTestRoot } from "./helpers/temp-root-cleanup.ts";
 
 test("recovery crosses old-to-semantic shape while V2 evidence is delayed without terminalizing the published operation", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-authority-recovery-semantic-boundary-"));
+  const publicationInspector = createGitCanonicalPublicationInspector(root);
   const watermarkPath = path.join(root, "recovery-watermark.json");
   const workspaceId = "workspace-production";
   const oldOpId = "namespace-production:old-shape";
@@ -116,7 +118,7 @@ test("recovery crosses old-to-semantic shape while V2 evidence is delayed withou
       operationRegistry,
       replicaChangeLog,
       eventLog: {} as ReturnType<typeof makeLocalAuthorityAttributionEventV2Log>,
-      publicationInspector: createGitCanonicalPublicationInspector(root),
+      publicationInspector,
       recover,
       watermarkPath
     };
@@ -136,12 +138,14 @@ test("recovery crosses old-to-semantic shape while V2 evidence is delayed withou
       scannedAt: JSON.parse(readFileSync(watermarkPath, "utf8")).scannedAt
     });
   } finally {
-    rmSync(root, { recursive: true, force: true });
+    await publicationInspector.shutdown();
+    await removeTemporaryTestRoot(root);
   }
 });
 
 test("same-session retry cannot hide an unanchored authority batch from recovery", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-authority-recovery-unanchored-prefix-"));
+  const inspector = createGitCanonicalPublicationInspector(root);
   const watermarkPath = path.join(root, "recovery-watermark.json");
   const workspaceId = "workspace-production";
   const firstOpId = "namespace-production:unanchored-first";
@@ -192,7 +196,6 @@ test("same-session retry cannot hide an unanchored authority batch from recovery
     git("checkout", "-q", "master");
     git("merge", "-q", "--no-ff", "sessions/materialization-retry", "-m", "materializer: merge session materialization-retry");
 
-    const inspector = createGitCanonicalPublicationInspector(root);
     let proofFailure: unknown;
     try {
       await inspector.inspectPublication(expectedPreviousHead, [secondOpId]);
@@ -253,7 +256,8 @@ test("same-session retry cannot hide an unanchored authority batch from recovery
       && entry.error.message.startsWith("AUTHORITY_CANONICAL_PUBLICATION_UNANCHORED_BATCH_PREFIX")
     ), true, deferred.map((entry) => String(entry.error)).join("\n"));
   } finally {
-    rmSync(root, { recursive: true, force: true });
+    await inspector.shutdown();
+    await removeTemporaryTestRoot(root);
   }
 });
 

--- a/packages/cli/test/task-lifecycle-facade-cli.test.ts
+++ b/packages/cli/test/task-lifecycle-facade-cli.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { writeSubstantiveTaskPlan } from "./helpers/task-plan-fixture.ts";
 import { initializeGitRepo, runGit, runJson, withTempRoot, writeCloseout } from "./helpers/task-document-gates-fixtures.ts";
+import { validateCommandOptions } from "../src/cli/option-claims.ts";
 
 const workerEnv = {
   HARNESS_ACTOR: "agent:facade-worker",
@@ -60,9 +61,7 @@ test("direct recovery mode refuses to recreate the deleted task-complete facade"
     assert.equal(existsSync(path.join(rootDir, "harness/sessions", `${fixture.sessionId}.md`)), true);
     const rejected = runJson(rootDir, closeoutCommands[1], false, fixture.env);
     assert.equal(rejected.error.code, "write_rejected");
-    assert.match(rejected.error.hint, /daemon-planned canonical transition.+canonical authority planner is unavailable/iu);
-    assert.match(rejected.error.hint, /ha init.+ha daemon stop.+ha daemon start --service/iu);
-    assert.doesNotMatch(rejected.error.hint, /direct recovery/iu);
+    assertAuthorityPlannerRecoveryHint(rejected.error.hint);
     assert.match(readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"), /^  status: in_review$/mu);
     const reviewsRoot = path.join(taskRoot, "reviews");
     assert.equal(existsSync(reviewsRoot) ? readdirSync(reviewsRoot).length : 0, 0);
@@ -82,14 +81,28 @@ test("direct recovery never derives owner approval outside the daemon planner", 
 
     assert.equal(rejected.error.code, "write_rejected");
     assert.doesNotMatch(rejected.error.code, /execution_review_required/iu);
-    assert.match(rejected.error.hint, /daemon-planned canonical transition.+canonical authority planner is unavailable/iu);
-    assert.match(rejected.error.hint, /ha init.+ha daemon stop.+ha daemon start --service/iu);
-    assert.doesNotMatch(rejected.error.hint, /direct recovery/iu);
+    assertAuthorityPlannerRecoveryHint(rejected.error.hint);
     assert.match(readFileSync(path.join(rootDir, fixture.packagePath, "INDEX.md"), "utf8"), /^  status: in_review$/mu);
     const reviewsRoot = path.join(rootDir, fixture.packagePath, "reviews");
     assert.equal(existsSync(reviewsRoot) ? readdirSync(reviewsRoot).length : 0, 0);
   });
 });
+
+function assertAuthorityPlannerRecoveryHint(hint: string): void {
+  assert.match(hint, /daemon-planned canonical transition.+canonical authority planner is unavailable/iu);
+  assert.match(hint, /`ha daemon status --check --json`/u);
+  assert.match(hint, /Do not stop or restart the active daemon/iu);
+  assert.match(hint, /do not retry completion/iu);
+  assert.match(hint, /supplied and verified a replacement/iu);
+  assert.doesNotMatch(hint, /<[^>\n]+>|\{[^}\n]+\}|\.\.\./u);
+  assert.doesNotMatch(
+    hint,
+    /\bha(?:\s+--root\s+\S+)?\s+daemon\s+(?:start|stop|restart|repo\s+(?:register|unregister|purge))\b|HARNESS_(?:DAEMON_MODE|DIRECT_WRITE_REASON)|--daemon-mode(?:=|\s+)direct/iu
+  );
+  const statusContract = validateCommandOptions(["daemon", "status", "--check", "--json"]);
+  assert.equal(statusContract.ok, true);
+  assert.equal(statusContract.ok ? statusContract.claim?.kind : undefined, "daemon-status");
+}
 
 test("approved closeout without consent is rejected before any lifecycle write", () => {
   withTempRoot((rootDir) => {

--- a/packages/cli/test/task-lifecycle-facade.test.ts
+++ b/packages/cli/test/task-lifecycle-facade.test.ts
@@ -59,9 +59,59 @@ test("non-local terminal status success preserves the owner-visible demotion war
 
   assert.equal(result.ok, true);
   assert.equal(result.warnings?.[0]?.code, "terminal_status_requires_task_complete");
-  assert.match(result.warnings?.[0]?.message ?? "", /ha task complete task-external --approve/u);
+  assert.equal(
+    result.warnings?.[0]?.message,
+    "External-engine terminal status completed outside the local consent transaction. Run `ha task show task-external --json` to confirm the resulting state. Do not run another terminal transition from this receipt. If follow-up work is needed, inspect `ha task supersede --help` before creating replacement work."
+  );
+  assert.doesNotMatch(result.warnings?.[0]?.message ?? "", /<[^>]+>/u);
   assert.match(result.warnings?.[0]?.revivalCondition ?? "", /third independent user/u);
 });
+
+for (const [status, expectedHint] of [
+  [
+    "done",
+    "Direct done is blocked because completion consent is recorded only by the typed completion transaction. Run `ha task show task-local --json` to confirm the current state. If the task is not terminal, inspect `ha task complete --help` and prepare the required approval packet before retrying completion. If it is already terminal and follow-up work is needed, inspect `ha task supersede --help` before creating replacement work."
+  ],
+  [
+    "cancelled",
+    "Direct cancellation is blocked unless it is an audited recovery. Run `ha task show task-local --json` to confirm the current state. If the task is not terminal and cancellation is still intended, inspect `ha task transition --help` and supply a truthful audited reason. If it is already terminal and follow-up work is needed, inspect `ha task supersede --help` before creating replacement work."
+  ]
+] as const) {
+  test(`local direct ${status} renders only concrete inspection commands`, () => {
+    const context = {
+      artifactStore: {
+        readTaskPackage: () => Effect.succeed({
+          taskId: "task-local",
+          rootPath: "/fixture/task-local",
+          disposition: "active",
+          documents: [{
+            path: "INDEX.md",
+            kind: "document",
+            body: ["---", "lifecycle:", "  engine: local", "  status: active", "---"].join("\n")
+          }]
+        })
+      }
+    } as unknown as CommandRunnerContext;
+    const command = {
+      rootDir: "/fixture",
+      json: true,
+      action: { kind: "status-set", taskId: "task-local", status, force: false }
+    } as ParsedCommand;
+
+    const result = Effect.runSync(runTaskLifecycleWithDemotions(context, command));
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error?.hint, expectedHint);
+    assert.doesNotMatch(result.error?.hint ?? "", /<[^>]+>/u);
+    for (const argv of [
+      ["task", "show", "task-local", "--json"],
+      status === "done" ? ["task", "complete", "--help"] : ["task", "transition", "--help"],
+      ["task", "supersede", "--help"]
+    ]) {
+      assert.equal(parseArgs(argv).ok, true, argv.join(" "));
+    }
+  });
+}
 
 test("failed audited cancellation leaves no unpaired audit progress", () => {
   const taskId = "task-audit-atomic";

--- a/packages/cli/test/temp-root-cleanup.test.ts
+++ b/packages/cli/test/temp-root-cleanup.test.ts
@@ -1,0 +1,77 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { removeTemporaryTestRoot } from "./helpers/temp-root-cleanup.ts";
+
+test("temporary-root cleanup retries transient filesystem errors with linear backoff", async () => {
+  const attempts: string[] = [];
+  const waits: number[] = [];
+
+  await removeTemporaryTestRoot("/fixture", {
+    remove: () => {
+      attempts.push("remove");
+      if (attempts.length === 1) throw filesystemError("EPERM");
+      if (attempts.length === 2) throw filesystemError("EBUSY");
+    },
+    wait: async (milliseconds) => { waits.push(milliseconds); },
+    maxRetries: 2,
+    retryDelayMs: 25
+  });
+
+  assert.equal(attempts.length, 3);
+  assert.deepEqual(waits, [25, 50]);
+});
+
+test("temporary-root cleanup covers every recursive-removal transient errno", async () => {
+  for (const code of ["EBUSY", "EMFILE", "ENFILE", "ENOTEMPTY", "EPERM"]) {
+    let attempts = 0;
+    await removeTemporaryTestRoot("/fixture", {
+      remove: () => {
+        attempts += 1;
+        if (attempts === 1) throw filesystemError(code);
+      },
+      wait: async () => undefined,
+      maxRetries: 1
+    });
+    assert.equal(attempts, 2, code);
+  }
+});
+
+test("temporary-root cleanup rejects non-transient filesystem errors immediately", async () => {
+  const error = filesystemError("EACCES");
+  let attempts = 0;
+
+  await assert.rejects(
+    removeTemporaryTestRoot("/fixture", {
+      remove: () => {
+        attempts += 1;
+        throw error;
+      },
+      wait: async () => undefined
+    }),
+    (observed) => observed === error
+  );
+  assert.equal(attempts, 1);
+});
+
+test("temporary-root cleanup preserves the final transient error after its retry budget", async () => {
+  const error = filesystemError("EPERM");
+  let attempts = 0;
+
+  await assert.rejects(
+    removeTemporaryTestRoot("/fixture", {
+      remove: () => {
+        attempts += 1;
+        throw error;
+      },
+      wait: async () => undefined,
+      maxRetries: 2
+    }),
+    (observed) => observed === error
+  );
+  assert.equal(attempts, 3);
+});
+
+function filesystemError(code: string): Error & { readonly code: string } {
+  return Object.assign(new Error(code), { code });
+}

--- a/packages/daemon/src/authority/production/authority-repo-enrollment-support.ts
+++ b/packages/daemon/src/authority/production/authority-repo-enrollment-support.ts
@@ -364,7 +364,7 @@ function pathEntryExists(filePath: string): boolean {
   }
 }
 
-function shellArgument(value: string): string {
+function jsonShellArgument(value: string): string {
   return JSON.stringify(value);
 }
 
@@ -434,4 +434,4 @@ function authorityRepoIsMissing(error: unknown): boolean {
   return typeof error === "object" && error !== null && "code" in error && (error as { readonly code?: unknown }).code === "ENOENT";
 }
 
-export { defaultNamespaceTtlMs, createNamespace, signedNamespaceJson, manifestRepoJson, authorityDomainSnapshot, signWithAuthorityKey, signedNamespaceSnapshot, switchRecordJson, verifyNamespaceAgainstRegistry, readRegistry, readManifest, readOptionalManifest, readJsonManifest, appendManifestRepo, replaceManifestRepo, writeManifestAtomically, writeJsonExclusive, writeJsonAtomically, existingRealPath, resolveManifestPath, authorityRepoAbsolutePath, assertExternalServiceState, assertNewFile, rejectExistingSymlink, pathEntryExists, shellArgument, ensureParentDirectory, removeCreatedFile, readManifestRepoId, oneEpochJson, requiredRepoId, authorityRepoRequiredText, authorityRepoPositiveInteger, authorityRepoNonNegativeInteger, samePath, authorityRepoRealpathIfPresent, authorityRepoIsDescendant, authorityRepoIsMissing };
+export { defaultNamespaceTtlMs, createNamespace, signedNamespaceJson, manifestRepoJson, authorityDomainSnapshot, signWithAuthorityKey, signedNamespaceSnapshot, switchRecordJson, verifyNamespaceAgainstRegistry, readRegistry, readManifest, readOptionalManifest, readJsonManifest, appendManifestRepo, replaceManifestRepo, writeManifestAtomically, writeJsonExclusive, writeJsonAtomically, existingRealPath, resolveManifestPath, authorityRepoAbsolutePath, assertExternalServiceState, assertNewFile, rejectExistingSymlink, pathEntryExists, jsonShellArgument, ensureParentDirectory, removeCreatedFile, readManifestRepoId, oneEpochJson, requiredRepoId, authorityRepoRequiredText, authorityRepoPositiveInteger, authorityRepoNonNegativeInteger, samePath, authorityRepoRealpathIfPresent, authorityRepoIsDescendant, authorityRepoIsMissing };

--- a/packages/daemon/src/authority/production/authority-repo-enrollment.ts
+++ b/packages/daemon/src/authority/production/authority-repo-enrollment.ts
@@ -31,7 +31,7 @@ import {
   replaceManifestRepo,
   requiredRepoId,
   samePath,
-  shellArgument,
+  jsonShellArgument,
   signWithAuthorityKey,
   signedNamespaceJson,
   switchRecordJson,
@@ -207,8 +207,8 @@ export function enrollAuthorityRepo(input: AuthorityRepoEnrollmentInput): Author
           note: "The daemon merges the machine roster first and the repository roster as an overlay."
         },
         nextCommands: {
-          daemonStart: "ha --repo " + repoId + " daemon start --service --authority-manifest " + shellArgument(manifestPath),
-          firstGovernanceWrite: "ha --repo " + repoId + " task create --title " + shellArgument("first governance write")
+          daemonStart: "ha --repo " + repoId + " daemon start --service --authority-manifest " + jsonShellArgument(manifestPath),
+          firstGovernanceWrite: "ha --repo " + repoId + " task create --title " + jsonShellArgument("first governance write")
         }
       }
     };

--- a/packages/daemon/src/authority/production/production-recovery-admission.ts
+++ b/packages/daemon/src/authority/production/production-recovery-admission.ts
@@ -26,7 +26,7 @@ export async function waitForProductionRecovery(
   if (timer) clearTimeout(timer);
   if (!timedOut) return recoveryUnavailableReason(material);
   if (material.recovery.status !== "recovering") return recoveryUnavailableReason(material);
-  return `AUTHORITY_RECOVERY_WAIT_TIMEOUT:repoId=${material.repoId};waitedMs=${timeoutMs}; run \`ha daemon start --service\`, then retry this command against the service daemon so recovery progress is preserved`;
+  return `AUTHORITY_RECOVERY_WAIT_TIMEOUT:repoId=${material.repoId};waitedMs=${timeoutMs}; recovery is still running. Do not start, stop, or restart any daemon and do not replay the write. Wait for the current recovery to finish, then run \`ha --repo ${material.repoId} daemon status --json\`; retry the original command only after the repo is no longer recovering.`;
 }
 
 function recoveryUnavailableReason(material: {

--- a/packages/daemon/src/client/daemon-autostart-flight.ts
+++ b/packages/daemon/src/client/daemon-autostart-flight.ts
@@ -12,6 +12,7 @@ import {
   daemonAutostartFailureError,
   daemonAutostartProcessExitedError,
   daemonProcessIsAlive,
+  DaemonAutostartTimeoutError,
   type SpawnedDaemonAutostartProcess
 } from "./daemon-autostart-process.ts";
 import {
@@ -40,6 +41,7 @@ export interface DaemonStartupFlight {
   deadline: number;
   lastError: unknown;
   spawnedPid?: number;
+  observedSocketOwnerPid?: number;
   launchStderrPath?: string;
   promise: Promise<void>;
 }
@@ -50,6 +52,9 @@ export interface DaemonAutostartFlightDeps<Target, Options extends DaemonAutosta
   ) => SpawnedDaemonAutostartProcess;
   readonly localDaemonRetryIntervalMs: number;
   readonly minimumReadyProbeResponseTimeoutMs: number;
+  readonly readDaemonSocketOwner?: (
+    socketPath: string
+  ) => { readonly pid: number; readonly alive: boolean } | undefined;
 }
 const daemonStartupFlights = new Map<string, DaemonStartupFlight>();
 export function createDaemonAutostartFlightManager<Target extends { readonly socketPath: string }, Options extends DaemonAutostartFlightPhase>(
@@ -138,20 +143,30 @@ export function createDaemonAutostartFlightManager<Target extends { readonly soc
         flight.lastError = error;
         const exited = daemonAutostartProcessExitedError(flight.lastError, flight.spawnedPid, flight.launchStderrPath);
         if (exited) {
-          reportDaemonAutostartOutcome(target.socketPath, {
-            ok: false, spawnedPid: flight.spawnedPid, processExited: true, cause: flight.lastError
-          }, circuitOptions);
-          throw exited;
+          const owner = deps.readDaemonSocketOwner?.(target.socketPath);
+          if (owner?.alive && owner.pid !== flight.spawnedPid) {
+            flight.observedSocketOwnerPid = owner.pid;
+            clearLiveDaemonStartup(target.socketPath, flight.spawnedPid);
+          } else {
+            reportDaemonAutostartOutcome(target.socketPath, {
+              ok: false, spawnedPid: flight.spawnedPid, processExited: true, cause: flight.lastError
+            }, circuitOptions);
+            throw exited;
+          }
         }
         const retryDelayMs = Math.min(deps.localDaemonRetryIntervalMs, flight.deadline - Date.now());
         if (retryDelayMs > 0) await delay(retryDelayMs);
       }
     }
+    const observedOwner = observedLiveSocketOwner(target.socketPath, flight);
     const processExited = flight.spawnedPid !== undefined && !daemonProcessIsAlive(flight.spawnedPid);
     reportDaemonAutostartOutcome(target.socketPath, {
-      ok: false, spawnedPid: flight.spawnedPid, processExited, cause: flight.lastError
+      ok: false,
+      spawnedPid: observedOwner ? undefined : flight.spawnedPid,
+      processExited: observedOwner ? false : processExited,
+      cause: flight.lastError
     }, circuitOptions);
-    throw daemonAutostartFailureError(flight.deadline - flight.startedAt, flight.lastError, flight.spawnedPid, flight.launchStderrPath);
+    throw daemonStartupFlightFailure(flight, target.socketPath, flight.deadline - flight.startedAt);
   }
   async function joinLiveDaemonStartup(
     target: Target,
@@ -202,12 +217,12 @@ export function createDaemonAutostartFlightManager<Target extends { readonly soc
     const remainingMs = deadline - Date.now();
     if (remainingMs <= 0) {
       if (deadline >= flight.deadline) clearDaemonStartupFlight(socketPath, flight);
-      throw daemonAutostartFailureError(autostartTimeoutMs, flight.lastError, flight.spawnedPid, flight.launchStderrPath);
+      throw daemonStartupFlightFailure(flight, socketPath, autostartTimeoutMs);
     }
     return new Promise<void>((resolve, reject) => {
       const timer = setTimeout(() => {
         if (deadline >= flight.deadline) clearDaemonStartupFlight(socketPath, flight);
-        reject(daemonAutostartFailureError(autostartTimeoutMs, flight.lastError, flight.spawnedPid, flight.launchStderrPath));
+        reject(daemonStartupFlightFailure(flight, socketPath, autostartTimeoutMs));
       }, remainingMs);
       flight.promise.then(
         () => { clearTimeout(timer); resolve(); },
@@ -217,6 +232,26 @@ export function createDaemonAutostartFlightManager<Target extends { readonly soc
   }
   function clearDaemonStartupFlight(socketPath: string, flight: DaemonStartupFlight): void {
     if (daemonStartupFlights.get(socketPath) === flight) daemonStartupFlights.delete(socketPath);
+  }
+  function observedLiveSocketOwner(
+    socketPath: string,
+    flight: DaemonStartupFlight
+  ): { readonly pid: number; readonly alive: true } | undefined {
+    if (flight.observedSocketOwnerPid === undefined) return undefined;
+    const owner = deps.readDaemonSocketOwner?.(socketPath);
+    return owner?.alive && owner.pid === flight.observedSocketOwnerPid
+      ? { pid: owner.pid, alive: true }
+      : undefined;
+  }
+  function daemonStartupFlightFailure(
+    flight: DaemonStartupFlight,
+    socketPath: string,
+    timeoutMs: number
+  ): Error {
+    const owner = observedLiveSocketOwner(socketPath, flight);
+    return owner
+      ? new DaemonAutostartTimeoutError(timeoutMs, flight.lastError, owner.pid, "observed-socket-owner")
+      : daemonAutostartFailureError(timeoutMs, flight.lastError, flight.spawnedPid, flight.launchStderrPath);
   }
   function readyProbeResponseTimeout(deadline: number): number {
     const remainingMs = Math.max(1, deadline - Date.now());

--- a/packages/daemon/src/client/daemon-autostart-process.ts
+++ b/packages/daemon/src/client/daemon-autostart-process.ts
@@ -19,11 +19,19 @@ export class DaemonAutostartTimeoutError extends Error {
   readonly timeoutMs: number;
   readonly spawnedPid?: number;
 
-  constructor(timeoutMs: number, lastError: unknown, spawnedPid?: number) {
+  constructor(
+    timeoutMs: number,
+    lastError: unknown,
+    spawnedPid?: number,
+    processSource: "launched" | "observed-socket-owner" = "launched"
+  ) {
     const cause = errorMessage(lastError, "no ready probe completed");
+    const processDescription = processSource === "observed-socket-owner"
+      ? `the live socket owner${spawnedPid === undefined ? "" : ` pid ${spawnedPid}`}`
+      : `the launched process${spawnedPid === undefined ? "" : ` pid ${spawnedPid}`}`;
     super(
       `DAEMON_AUTOSTART_TIMEOUT: readiness was not confirmed within the normal ${timeoutMs}ms startup budget; `
-      + `the launched process${spawnedPid === undefined ? "" : ` pid ${spawnedPid}`} may still be starting. Last probe: ${cause}`
+      + `${processDescription} may still be starting. Last probe: ${cause}`
     );
     this.name = "DaemonAutostartTimeoutError";
     this.timeoutMs = timeoutMs;

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -13,6 +13,7 @@ import {
 import { currentDaemonProtocolVersion } from "../protocol/method-registry.ts";
 import type { JsonObject } from "../protocol/json-rpc-types.ts";
 import { defaultNamedPipePath } from "../transport/named-pipe.ts";
+import { readDaemonSocketOwner } from "../transport/local-service-transport.ts";
 import { defaultUnixSocketPath, type UnixSocketPathOptions } from "../transport/unix-socket.ts";
 import {
   createDaemonLaunchConfiguration,
@@ -148,7 +149,8 @@ let spawnLocalDaemonImplementation: SpawnLocalDaemon = spawnLocalDaemonProcess;
 const daemonAutostartFlight = createDaemonAutostartFlightManager<LocalDaemonTarget, LocalDaemonAutostartOptions>({
   launchLocalDaemon: (target, options) => launchLocalDaemon(target, options),
   localDaemonRetryIntervalMs,
-  minimumReadyProbeResponseTimeoutMs
+  minimumReadyProbeResponseTimeoutMs,
+  readDaemonSocketOwner
 });
 
 export function daemonIdForRoot(rootDir: string): string {

--- a/packages/daemon/src/identity/authorization.ts
+++ b/packages/daemon/src/identity/authorization.ts
@@ -29,7 +29,7 @@ export function authorizePersonForMethod(
   return {
     ok: false,
     code: "rbac_forbidden",
-    message: `Person ${personId} is forbidden from ${action.commandClass} method ${action.method} because no assigned role grants that command class. Update the person's roles in harness/people.yaml, then run \`ha daemon restart --json\` before retrying.`
+    message: `Person ${personId} is forbidden from ${action.commandClass} method ${action.method} because the active PeopleRoster grants none of their assigned roles that command class. This authorization check does not know the roster source path and made no configuration change. Inspect the owning identity configuration and logs; use \`ha daemon status --json\` only to verify the active daemon before retrying after the role grant is confirmed.`
   };
 }
 
@@ -55,7 +55,7 @@ export function makePersonAuthorizationProvider(
       return {
         ok: false,
         code: "rbac_forbidden",
-        message: `Person ${candidate} is forbidden from ${action.commandClass} method ${action.method} because the configured command-class grant is missing. Update the person's roles in harness/people.yaml, then run \`ha daemon restart --json\` before retrying.`
+        message: `Person ${candidate} is forbidden from ${action.commandClass} method ${action.method} because this authorization provider's configured command-class grant is missing. The grant comes from provider composition, not from a roster path, and this check made no configuration change. Inspect the owning authorization configuration and logs; use \`ha daemon status --json\` only to verify the active daemon before retrying after the grant is confirmed.`
       };
     }
   };

--- a/packages/daemon/src/protocol/forced-command-root.ts
+++ b/packages/daemon/src/protocol/forced-command-root.ts
@@ -1,5 +1,6 @@
 import { realpathSync } from "node:fs";
 import path from "node:path";
+import { shellArgument } from "../shell-argument.ts";
 import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
 import type { JsonRpcMethodContract } from "./method-registry.ts";
 import { failureReceipt } from "./receipt-envelope.ts";
@@ -20,8 +21,8 @@ export function commandRootMismatch(
   if (!rootDir || sameRoot(rootDir, repo.canonicalRoot)) return undefined;
   const forcedRoot = authContext?.sshForcedCommand?.canonicalRoot;
   return failureReceipt("repo.command.run", forcedRoot ? "forced_command_root_mismatch" : "repo_command_root_mismatch", forcedRoot
-    ? "Client --root is invalid because it does not match the canonical root pinned by the SSH forced command. Reconnect with `ha --root <canonical-root> daemon connect --stdio`."
-    : "payload.command.rootDir is invalid because it does not match params.repo.repoId. Retry the CLI command with `ha --root <registered-root> <command>`.", {
+    ? `Root mismatch: client --root ${rootDir} does not match the SSH forced-command root ${forcedRoot}. Reconnect with \`ha --root ${shellArgument(forcedRoot)} daemon connect --stdio\`.`
+    : `Root mismatch: payload.command.rootDir ${rootDir} does not match repo ${repo.repoId} at ${repo.canonicalRoot}. Set payload.command.rootDir to ${repo.canonicalRoot}, then retry the original CLI command.`, {
     repo: { repoId: repo.repoId, canonicalRoot: repo.canonicalRoot },
     command: { rootDir },
     ...(forcedRoot ? { forcedCommand: { canonicalRoot: forcedRoot } } : {})
@@ -40,18 +41,18 @@ export function validateForcedCommandRoot(
     ? params.repo.canonicalRoot
     : undefined;
   if (!requestedRoot) {
-    return failureReceipt(contract.method, "forced_command_root_required", "SSH forced-command requests require the server root configured by authorized_keys, but params.repo.canonicalRoot is missing. Reconnect with `ha --root <canonical-root> daemon connect --stdio`.", {
+    return failureReceipt(contract.method, "forced_command_root_required", `SSH forced-command requests require params.repo.canonicalRoot=${forcedRoot}. Reconnect with \`ha --root ${shellArgument(forcedRoot)} daemon connect --stdio\`.`, {
       forcedCommand: { canonicalRoot: forcedRoot }
     });
   }
   if (!sameRoot(requestedRoot, forcedRoot)) {
-    return failureReceipt(contract.method, "forced_command_root_mismatch", "Client --root is invalid because it does not match the canonical root pinned by the SSH forced command. Reconnect with `ha --root <canonical-root> daemon connect --stdio`.", {
+    return failureReceipt(contract.method, "forced_command_root_mismatch", `Root mismatch: client --root ${requestedRoot} does not match the SSH forced-command root ${forcedRoot}. Reconnect with \`ha --root ${shellArgument(forcedRoot)} daemon connect --stdio\`.`, {
       requested: { canonicalRoot: requestedRoot },
       forcedCommand: { canonicalRoot: forcedRoot }
     });
   }
   if (sameRoot(forcedRoot, repo.canonicalRoot)) return undefined;
-  return failureReceipt(contract.method, "forced_command_root_mismatch", "The requested repo is invalid because it does not match the canonical root pinned by the SSH forced command. Register that root with `ha daemon repo register --root <canonical-root>` before reconnecting.", {
+  return failureReceipt(contract.method, "forced_command_root_mismatch", `Forced-command root mismatch: repo ${repo.repoId} is registered at ${repo.canonicalRoot}, but the SSH forced command pins ${forcedRoot}. Run \`ha daemon repo list --json\` and ask an administrator to rebind repo ${repo.repoId} to ${forcedRoot} before reconnecting. Do not register a second repo id.`, {
     repo: { repoId: repo.repoId, canonicalRoot: repo.canonicalRoot },
     forcedCommand: { canonicalRoot: forcedRoot }
   });

--- a/packages/daemon/src/protocol/identity-dispatch.ts
+++ b/packages/daemon/src/protocol/identity-dispatch.ts
@@ -49,7 +49,7 @@ async function resolveIdentityActor(
     return identityFailure(
       options.identityProvider.providerId,
       "person_registry_unavailable",
-      "Authenticated daemon requests require a core person registry, but no roster was loaded. Add the principal to harness/people.yaml and run `ha daemon restart --json` before retrying."
+      "Authenticated daemon requests require a core person registry, but no active roster source is available to this identity dispatcher. No authentication state was changed. Inspect the active daemon identity configuration and logs; use `ha daemon status --json` only to verify the endpoint and loaded build before retrying."
     );
   }
   const authentication = await options.identityProvider.authenticate(authContext);
@@ -59,7 +59,7 @@ async function resolveIdentityActor(
     return identityFailure(
       options.identityProvider.providerId,
       "person_unregistered",
-      `Identity provider authenticated personId ${authentication.personId}, but that person is not registered in the active roster. Add the person to harness/people.yaml and run \`ha daemon restart --json\` before retrying.`,
+      `Identity provider authenticated personId ${authentication.personId}, but that person is not registered in the active person registry. This dispatcher does not know the registry source path and made no identity change. Inspect the active daemon identity configuration and logs; use \`ha daemon status --json\` only to verify the endpoint and loaded build before retrying.`,
       authentication.credential
     );
   }
@@ -67,7 +67,7 @@ async function resolveIdentityActor(
     return identityFailure(
       options.identityProvider.providerId,
       "person_disabled",
-      `Person ${person.personId} is disabled in the active roster, so the request is rejected. Re-enable the person in harness/people.yaml and run \`ha daemon restart --json\` before retrying.`,
+      `Person ${person.personId} is disabled in the active person registry, so the request is rejected. This dispatcher does not know the registry source path and made no identity change. Inspect the active daemon identity configuration and logs; use \`ha daemon status --json\` only to verify the endpoint and loaded build before retrying.`,
       authentication.credential
     );
   }

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -358,10 +358,10 @@ async function callServiceMethod(
     if (rootMismatch) return rootMismatch;
   }
   const services = repo ? resolveServicesForRepo(contract.method, repo, options) : options.services;
-  if (!services) return failureReceipt(contract.method, "repo_service_unavailable", `Repo service host for ${repo?.repoId ?? "unknown"} is unavailable because that repository has no active composition. Run \`ha daemon repo register --root <canonical-root>\`, then \`ha daemon restart --json\` before retrying.`);
+  if (!services) return failureReceipt(contract.method, "repo_service_unavailable", `Repo service host for ${repo?.repoId ?? "unknown"} is absent from the running daemon composition. Run \`ha daemon logs --errors --json\` to capture the missing repo composition. Do not register, stop, or restart the repo; retry only after an operator supplies and verifies a composition for ${repo?.repoId ?? "unknown"}.`);
   if (contract.method === "repo.daemon.status") {
     if (!services.DaemonStatusService) {
-      return failureReceipt(contract.method, "daemon_status_service_unavailable", "Daemon status service is unavailable because the running service composition is incomplete. Run `ha daemon restart --json`, then verify the replacement with `ha daemon status --check --json`.");
+      return failureReceipt(contract.method, "daemon_status_service_unavailable", "Daemon status service is absent from the running composition. Run `ha daemon logs --errors --json` to capture the missing service. Leave the daemon running; an operator must verify a replacement composition before any restart.");
     }
     try {
       const request = validateDaemonStatusRequest(params);
@@ -383,7 +383,7 @@ async function callServiceMethod(
   }
   if (contract.method === "repo.command.run") {
     if (!services.CliCommandService) {
-      return failureReceipt(contract.method, "cli_command_service_unavailable", "Daemon command service is unavailable because the repository command host is not configured. Run `ha daemon restart --json`, then verify the replacement with `ha daemon status --check --json`.");
+      return failureReceipt(contract.method, "cli_command_service_unavailable", "Daemon command service is absent from the repository composition. Run `ha daemon logs --errors --json` to capture the missing command host. Leave the daemon running; retry only after an operator supplies and verifies a replacement composition.");
     }
     return services.CliCommandService.runCommand(payload, {
       actor,
@@ -397,7 +397,7 @@ async function callServiceMethod(
   }
   if (contract.method === "repo.doc.sync.submit") {
     if (!services.DocSyncService) {
-      return failureReceipt(contract.method, "doc_sync_service_unavailable", "Doc sync submit service is unavailable because the repository write composition is incomplete. Run `ha daemon restart --json`, then retry the governed write with `ha doc sync --submit --path <authored-path>`.");
+      return failureReceipt(contract.method, "doc_sync_service_unavailable", "Required doc sync submit service is missing from the repository write composition, so no write was submitted. Run `ha doc status --json` to preserve and inspect the dirty prose. Leave the daemon running; do not resubmit until an operator verifies a replacement composition.");
     }
     const result = await services.DocSyncService.submit(params as unknown as DocSyncSubmitRequestV1, {
       actor,
@@ -426,15 +426,15 @@ async function callTaskHolderMethod(
   actor: AuthenticatedActor | undefined
 ): Promise<ReturnType<typeof successReceipt> | ReturnType<typeof failureReceipt>> {
   if (!services.TaskHolderService) {
-    return failureReceipt(contract.method, "task_holder_service_unavailable", "Task holder service is unavailable because the running daemon composition is incomplete. Run `ha daemon restart --json`, then verify it with `ha daemon status --check --json` before retrying.");
+    return failureReceipt(contract.method, "task_holder_service_unavailable", "Task holder service is absent from the running composition. Run `ha daemon logs --errors --json` to capture the missing service. Leave the daemon and current lease state unchanged; retry only after an operator verifies a replacement composition.");
   }
   const taskId = typeof payload?.taskId === "string" ? payload.taskId : undefined;
-  if (!taskId) return failureReceipt(contract.method, "task_id_required", "Task holder methods require payload.taskId, but the request omitted it. Inspect the intended task with `ha task holder <task-id> --json`, then retry the task-scoped CLI command.");
+  if (!taskId) return failureReceipt(contract.method, "task_id_required", "Required payload.taskId is missing from the raw RPC request, so no holder lookup ran. Supply the intended concrete task id in payload.taskId and retry the same RPC; no task state was changed.");
   try {
     if (contract.method === "repo.task.holder") {
       return successReceipt(contract.method, "read task holder", toJsonValue(await services.TaskHolderService.holder({ taskId })) as JsonObject);
     }
-    if (!actor) return failureReceipt(contract.method, "actor_required", "Task holder writes require a per-request authenticated actor, but this request has none. Verify the authenticated task path with `ha task holder <task-id> --json`, then retry the original CLI command.");
+    if (!actor) return failureReceipt(contract.method, "actor_required", `Task holder writes require a per-request authenticated actor, but this request has none. Run \`ha task holder ${taskId} --json\` through an authenticated CLI session, then retry the original command only if the holder state permits it.`);
     const executor = readTaskHolderExecutor(payload);
     const principal = taskHolderPrincipalFromActor(actor, { executor });
     if (contract.method === "repo.task.claim") {
@@ -497,7 +497,7 @@ async function handleAdminMethod(
     return successReceipt(contract.method, `accepted daemon ${result.accepted.kind}`, toJsonValue(result.accepted) as JsonObject);
   }
   if (!options.identityAdminSnapshot) {
-    return failureReceipt(contract.method, "people_roster_unavailable", "Admin identity methods require a loaded people roster, but none is available to this daemon. Add the roster at harness/people.yaml and run `ha daemon restart --json` before retrying.");
+    return failureReceipt(contract.method, "people_roster_unavailable", "Admin identity methods cannot run because the active daemon composition has no loaded people roster. Run `ha daemon status --check --json` and inspect the reported daemon user root and roster state. Leave the daemon running; an operator must load and verify the roster before retrying.");
   }
   if (contract.method === "admin.people.list") {
     return successReceipt(contract.method, "listed people", {

--- a/packages/daemon/src/protocol/projection-notification-subscription.ts
+++ b/packages/daemon/src/protocol/projection-notification-subscription.ts
@@ -50,7 +50,7 @@ export function handleProjectionNotificationSubscription(
     return failureReceipt(
       method,
       "notifications_unavailable",
-      "Projection notification transport is not configured. Run `ha daemon start`, reconnect through a daemon transport, then retry the subscription."
+      "Projection notification subscription is unavailable because this connection is missing at least one required capability: a notification sink or a projection-change subscriber. This request created no subscription. Inspect the current transport configuration and reconnect through an endpoint configured with both notification capabilities; use `ha daemon status --json` only to verify the active daemon."
     );
   }
   current?.();

--- a/packages/daemon/src/protocol/repo-runtime-validation.ts
+++ b/packages/daemon/src/protocol/repo-runtime-validation.ts
@@ -11,5 +11,19 @@ export function validateRepoRuntime(
   if (!repo || !contract.requiresRepo || !options.resolveRepoAvailability || isRepoDiagnosticMethod(contract)) return undefined;
   const failure = options.resolveRepoAvailability(repo);
   if (!failure) return undefined;
-  return failureReceipt(contract.method, failure.code, `Repo ${repo.repoId} is not attached to this daemon.`, { repo: failure.repo });
+  return failureReceipt(contract.method, failure.code, repoRuntimeFailureHint(repo, failure), { repo: failure.repo });
+}
+
+function repoRuntimeFailureHint(
+  repo: DaemonRepoNamespace,
+  failure: NonNullable<ReturnType<NonNullable<JsonRpcServerOptions["resolveRepoAvailability"]>>>
+): string {
+  const statusCommand = `ha --repo ${repo.repoId} daemon status --json`;
+  if (failure.code === "repo_lock_held") {
+    const lockPath = failure.repo.lockPath ?? "the reported writer lock";
+    const owner = failure.repo.lockOwnerToken ?? failure.repo.lastError ?? "owner unknown";
+    return `Repo ${repo.repoId} is attached, but its writer lock is held at ${lockPath} (${owner}). Wait for the current writer to release the lock, then run \`${statusCommand}\` before retrying. Do not register, purge, stop, or restart the repo while the lock is held.`;
+  }
+  const cause = failure.repo.lastError ? `: ${failure.repo.lastError}` : "";
+  return `Repo ${repo.repoId} is attached, but its runtime is unavailable${cause}. Run \`${statusCommand}\` to inspect recovery or availability before choosing a repair.`;
 }

--- a/packages/daemon/src/protocol/task-holder-write-policy.ts
+++ b/packages/daemon/src/protocol/task-holder-write-policy.ts
@@ -35,11 +35,11 @@ export async function validateTaskLeaseForServiceWrite(
   if (!repo || !options.leaseEnforcementEnabled?.(repo) || contract.leaseRequired !== true) return undefined;
   if (contract.method === "repo.tasks.status.set" && !taskStatusLeaseRequired(payload?.status)) return undefined;
   const taskId = typeof payload?.taskId === "string" ? payload.taskId : undefined;
-  if (!taskId) return failureReceipt(contract.method, "task_id_required", "Task lease enforcement requires payload.taskId, but the request omitted it. Inspect the intended task with `ha task holder <task-id> --json`, then retry the task-scoped CLI command.");
+  if (!taskId) return failureReceipt(contract.method, "task_id_required", "Required payload.taskId is missing from the raw RPC request, so lease enforcement did not run. Supply the intended concrete task id in payload.taskId and retry the same RPC; no task state was changed.");
   if (!services.TaskHolderService) {
-    return failureReceipt(contract.method, "task_holder_service_unavailable", "Task holder service is unavailable because the running daemon composition is incomplete. Run `ha daemon restart --json`, then verify it with `ha daemon status --check --json` before retrying.");
+    return failureReceipt(contract.method, "task_holder_service_unavailable", "Task holder service is absent from the running composition. Run `ha daemon logs --errors --json` to capture the missing service. Leave the daemon and current lease state unchanged; retry only after an operator verifies a replacement composition.");
   }
-  if (!actor) return failureReceipt(contract.method, "actor_required", "Task lease enforcement requires a per-request authenticated actor, but this request has none. Verify the authenticated task path with `ha task holder <task-id> --json`, then retry the original CLI command.");
+  if (!actor) return failureReceipt(contract.method, "actor_required", `Task lease enforcement requires a per-request authenticated actor, but this request has none. Run \`ha task holder ${taskId} --json\` through an authenticated CLI session, then retry the original command only if the holder state permits it.`);
   try {
     const executor = readTaskHolderExecutor(payload);
     await services.TaskHolderService.assertActiveLease({ taskId, principal: taskHolderPrincipalFromActor(actor, { executor }) });

--- a/packages/daemon/src/service/command-service.ts
+++ b/packages/daemon/src/service/command-service.ts
@@ -41,6 +41,10 @@ import {
   RepoWriteOutcomeUnknownError
 } from "../runtime/repo-write-client.ts";
 import { reportCurrentRepoWriteTelemetry } from "../runtime/repo-write-telemetry-context.ts";
+import {
+  repoWriteOutcomeQuery,
+  repoWriteOutcomeUnknownHint
+} from "./repo-write-outcome-guidance.ts";
 
 export interface DaemonCommandService {
   readonly runCommand: (payload?: JsonObject, context?: {
@@ -163,6 +167,9 @@ export function createDaemonCommandService<
               : undefined;
             const outcomeUnknown = error instanceof RepoWriteOutcomeUnknownError
               || error instanceof RepoWriteDirectOutcomeUnknownError;
+            const outcomeQuery = outcomeUnknown
+              ? repoWriteOutcomeQuery(parsedCommand.action)
+              : undefined;
             return childRouteFailure(
               parsedCommand.action.kind,
               outcomeUnknown
@@ -170,9 +177,15 @@ export function createDaemonCommandService<
                 : error instanceof RepoWriteNotStartedError
                   ? error.code
                 : "repo_write_child_unavailable",
-              error instanceof Error ? error.message : String(error),
+              outcomeUnknown && outcomeQuery
+                ? repoWriteOutcomeUnknownHint(
+                  parsedCommand.action,
+                  error instanceof Error ? error.message : String(error),
+                  outcomeQuery
+                )
+                : error instanceof Error ? error.message : String(error),
               outerOpId,
-              outcomeUnknown ? repoWriteOutcomeQuery(parsedCommand.action, outerOpId) : undefined
+              outcomeQuery
             );
           }
         }
@@ -197,7 +210,10 @@ export function createDaemonCommandService<
             dryRun: parsedCommand.action.dryRun,
             ...(parsedCommand.action.currentSessionOnly ? { sessionId: currentSession.sessionId } : {})
           });
-          return hostServices.toReceipt(hostServices.materializerCommandResult(report));
+          return hostServices.toReceipt(hostServices.materializerCommandResult(report, {
+            rootDir: parsedCommand.rootDir,
+            ...(parsedCommand.layoutOverrides ? { layoutOverrides: parsedCommand.layoutOverrides } : {})
+          }));
         }
         const attribution = daemonActor
           ? hostServices.actorAttribution(daemonActor, parsedCommand, context?.executor ?? null)
@@ -343,29 +359,6 @@ function childRouteFailure(
     } : query ? {
       details: { data: { outcome: "unknown", query } }
     } : {})
-  };
-}
-
-function repoWriteOutcomeQuery(
-  action: { readonly kind?: unknown; readonly taskId?: unknown },
-  outerOpId?: string
-): JsonObject {
-  if (outerOpId) {
-    return {
-      schema: "command-outcome-query/v1",
-      method: "repo-write.lookup",
-      parameters: { opId: outerOpId },
-      retry: "forbidden-until-queried"
-    };
-  }
-  const taskId = typeof action.taskId === "string" && action.taskId.trim().length > 0
-    ? action.taskId
-    : undefined;
-  return {
-    schema: "command-outcome-query/v1",
-    method: taskId ? "task.show" : "task.list",
-    parameters: taskId ? { taskId } : {},
-    retry: "forbidden-until-queried"
   };
 }
 

--- a/packages/daemon/src/service/repo-write-outcome-guidance.ts
+++ b/packages/daemon/src/service/repo-write-outcome-guidance.ts
@@ -1,0 +1,59 @@
+import type { JsonObject } from "../protocol/json-rpc-types.ts";
+
+export function repoWriteOutcomeQuery(
+  action: { readonly kind?: unknown; readonly taskId?: unknown; readonly decisionId?: unknown }
+): JsonObject {
+  const decisionId = concreteId(action.decisionId);
+  if (decisionId) {
+    return {
+      schema: "command-outcome-query/v1",
+      method: "decision.show",
+      command: `ha decision show ${decisionId} --json`,
+      parameters: { decisionId },
+      retry: "forbidden-after-absence"
+    };
+  }
+  const taskId = concreteId(action.taskId);
+  if (taskId) {
+    return {
+      schema: "command-outcome-query/v1",
+      method: "task.show",
+      command: `ha task show ${taskId} --json`,
+      parameters: { taskId },
+      retry: "forbidden-after-absence"
+    };
+  }
+  return {
+    schema: "command-outcome-query/v1",
+    method: "daemon.logs",
+    command: "ha daemon logs --errors --json",
+    parameters: {},
+    retry: "forbidden"
+  };
+}
+
+export function repoWriteOutcomeUnknownHint(
+  action: { readonly kind?: unknown },
+  diagnostic: string,
+  query: JsonObject
+): string {
+  const command = typeof query.command === "string"
+    ? query.command
+    : "ha daemon logs --errors --json";
+  const kind = typeof action.kind === "string" ? action.kind : "write";
+  const reason = diagnostic
+    .replace(/\s*Exact repo-write outcome lookup failed[\s\S]*$/u, "")
+    .replace(/\s*query the stable outer opId[\s\S]*$/u, "")
+    .replace(/[.\s]+$/u, "");
+  if (query.method === "decision.show") {
+    return `The child writer may already have committed ${kind}, but its final outcome is unknown: ${reason}. Run \`${command}\` to inspect the canonical projection. If the decision is absent, the outcome is still unknown; do not replay the write.`;
+  }
+  if (query.method === "task.show") {
+    return `The child writer may already have committed ${kind}, but its final outcome is unknown: ${reason}. Run \`${command}\` to inspect the canonical projection. If the task state does not prove the write, the outcome is still unknown; do not replay it.`;
+  }
+  return `The child writer may already have committed ${kind}, but its final outcome is unknown: ${reason}. Run \`${command}\` to capture diagnostics. The result does not authorize replay; an operator must reconcile the final state first.`;
+}
+
+function concreteId(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}

--- a/packages/daemon/src/shell-argument.ts
+++ b/packages/daemon/src/shell-argument.ts
@@ -1,0 +1,5 @@
+export function shellArgument(value: string): string {
+  return /^[A-Za-z0-9_./:@%+=,-]+$/u.test(value)
+    ? value
+    : `'${value.replaceAll("'", `'"'"'`)}'`;
+}

--- a/packages/daemon/src/transport/ssh-forced-command.ts
+++ b/packages/daemon/src/transport/ssh-forced-command.ts
@@ -1,5 +1,6 @@
 import type { DaemonAuthenticationContext } from "./auth-context.ts";
 import type { TransportAuthenticationResult } from "./json-rpc-stream.ts";
+import { shellArgument } from "../shell-argument.ts";
 
 export interface SshForcedCommandBootstrapInput {
   readonly personId: string;
@@ -87,10 +88,11 @@ export function authenticateSshAuthorityWireFrame(
     };
   }
   if (!accept(frame)) {
+    const root = shellArgument(frame.canonicalRoot);
     return {
       ok: false,
       code: "authority_wire_repo_unavailable",
-      message: "The requested canonical root is unavailable; run `ha daemon repo register --root <path>` and start with `--authority-manifest <path>`."
+      message: `The requested canonical root ${JSON.stringify(frame.canonicalRoot)} is unavailable to this authority service. Run \`ha --root ${root} daemon status --json\` on the authority host to inspect its registered state. Do not register a second repo id or start, stop, or restart a daemon based on this error.`
     };
   }
   return {

--- a/packages/daemon/test/authority-submission-error.test.ts
+++ b/packages/daemon/test/authority-submission-error.test.ts
@@ -14,8 +14,7 @@ import {
 } from "../src/authority/authority-command-submission.ts";
 import { gateCutoverAdmission } from "../src/authority/production/cutover-admission.ts";
 import {
-  defaultProductionRecoveryAdmissionTimeoutMs,
-  waitForProductionRecovery
+  defaultProductionRecoveryAdmissionTimeoutMs
 } from "../src/authority/production/production-recovery-admission.ts";
 import {
   createProductionPlannedCommandSubmission
@@ -505,35 +504,6 @@ test("recovery gate preserves unresolved outer recovery instead of returning a t
     /AUTHORITY_RECOVERY_IN_PROGRESS:repoId=canonical/u
   );
   assert.equal(recoverySubmissions, 0);
-});
-
-test("production recovery admission times out with a reachable service-daemon next step", async () => {
-  let submissions = 0;
-  const service = gateAuthoritySubmissionForRecovery({
-    submit: async () => {
-      submissions += 1;
-      throw new Error("timed-out recovery must stay gated");
-    },
-    getOperation: async () => undefined
-  }, () => waitForProductionRecovery({
-    repoId: "canonical",
-    recovery: { status: "recovering", promise: new Promise<void>(() => undefined) }
-  }, 5));
-  const receipt = await service.submit({
-    workspaceId: "workspace-recovery-timeout",
-    opId: "op-recovery-timeout",
-    claimedDigest: "a".repeat(64),
-    command: "task.append",
-    operation: { opId: "op-recovery-timeout", entityId: "task/task_RECOVERY", kind: "progress_append", payload: { path: "progress.md", append: "x" } },
-    delegationToken: "token",
-    channelNonceDigest: "b".repeat(64),
-    protocol: { wire: 1, event: 1, receipt: 1, digest: 1, commandRegistry: 1 }
-  });
-
-  assert.equal(receipt.tag, "RETRYABLE_NOT_COMMITTED");
-  assert.match(receipt.reason, /^AUTHORITY_RECOVERY_WAIT_TIMEOUT:repoId=canonical;waitedMs=5;/u);
-  assert.match(receipt.reason, /ha daemon start --service/u);
-  assert.equal(submissions, 0);
 });
 
 test("stale daemon generation receipts expose a stable retryable write error code", () => {

--- a/packages/daemon/test/authorization-errors.test.ts
+++ b/packages/daemon/test/authorization-errors.test.ts
@@ -1,0 +1,50 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  authorizePersonForMethod,
+  makePersonAuthorizationProvider
+} from "../src/identity/authorization.ts";
+import { peopleRosterFromDocument } from "../src/identity/people-roster.ts";
+
+test("missing role grant reports the active roster boundary without guessing its source path", () => {
+  const roster = peopleRosterFromDocument([
+    "schema: harness-people/v1",
+    "people:",
+    "  - personId: person_probe",
+    "    displayName: Probe",
+    "    roles: []",
+    "    credentials: []",
+    "roles: []",
+    ""
+  ].join("\n"));
+
+  const result = authorizePersonForMethod("person_probe", {
+    method: "repo.tasks.review",
+    commandClass: "arbiter"
+  }, roster);
+
+  assert.deepEqual(result, {
+    ok: false,
+    code: "rbac_forbidden",
+    message: "Person person_probe is forbidden from arbiter method repo.tasks.review because the active PeopleRoster grants none of their assigned roles that command class. This authorization check does not know the roster source path and made no configuration change. Inspect the owning identity configuration and logs; use `ha daemon status --json` only to verify the active daemon before retrying after the role grant is confirmed."
+  });
+});
+
+test("missing provider grant points to provider composition instead of a roster file", async () => {
+  const provider = makePersonAuthorizationProvider("person_probe", []);
+
+  const result = await provider.authorize({
+    personId: "person_probe",
+    action: {
+      method: "repo.tasks.review",
+      commandClass: "arbiter"
+    }
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    code: "rbac_forbidden",
+    message: "Person person_probe is forbidden from arbiter method repo.tasks.review because this authorization provider's configured command-class grant is missing. The grant comes from provider composition, not from a roster path, and this check made no configuration change. Inspect the owning authorization configuration and logs; use `ha daemon status --json` only to verify the active daemon before retrying after the grant is confirmed."
+  });
+});

--- a/packages/daemon/test/daemon-autostart-lost-election.test.ts
+++ b/packages/daemon/test/daemon-autostart-lost-election.test.ts
@@ -1,0 +1,146 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { rmSync, writeFileSync } from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import { createInterface } from "node:readline";
+import test from "node:test";
+import {
+  DaemonAutostartTimeoutError,
+  replaceSpawnLocalDaemonForTest,
+  requestLocalDaemonJsonRpcForTarget,
+  type LocalDaemonTarget
+} from "../src/client/local-json-rpc-client.ts";
+import { encodeJsonLineFrame, type JsonRpcRequest } from "../src/index.ts";
+
+test("autostart joins a live socket owner after its own launch loses the election", async (t) => {
+  if (process.platform === "win32") return;
+  const socketPath = uniqueSocketPath("ha-daemon-lost-election");
+  const ownerPath = `${socketPath}.owner`;
+  const launchStderrPath = `${socketPath}.launch.stderr.log`;
+  let server: net.Server | undefined;
+  let serverStartTimer: ReturnType<typeof setTimeout> | undefined;
+  writeLiveOwner(ownerPath);
+  writeFileSync(
+    launchStderrPath,
+    `DaemonSocketAlreadyOwnedError: daemon socket ${socketPath} is already owned by pid ${process.pid}\n`
+  );
+  const restoreSpawn = replaceSpawnLocalDaemonForTest(() => {
+    serverStartTimer = setTimeout(() => {
+      void startJsonRpcServer(socketPath).then((started) => {
+        server = started;
+      });
+    }, 75);
+    return { pid: unusedPid(), launchStderrPath };
+  });
+  t.after(async () => {
+    if (serverStartTimer) clearTimeout(serverStartTimer);
+    restoreSpawn();
+    await closeServer(server);
+    rmSync(socketPath, { force: true });
+    rmSync(ownerPath, { force: true });
+    rmSync(launchStderrPath, { force: true });
+  });
+
+  const result = await requestLocalDaemonJsonRpcForTarget(
+    makeTarget(socketPath),
+    "repo.tasks.list",
+    {},
+    20,
+    { entryPath: "/unused", timeoutMs: 1_000 }
+  );
+
+  assert.deepEqual(result, { ok: true, method: "repo.tasks.list" });
+});
+
+test("autostart reports a live socket owner as starting after its own launch loses", async (t) => {
+  if (process.platform === "win32") return;
+  const socketPath = uniqueSocketPath("ha-daemon-lost-election-timeout");
+  const ownerPath = `${socketPath}.owner`;
+  writeLiveOwner(ownerPath);
+  const restoreSpawn = replaceSpawnLocalDaemonForTest(() => ({ pid: unusedPid() }));
+  t.after(() => {
+    restoreSpawn();
+    rmSync(socketPath, { force: true });
+    rmSync(ownerPath, { force: true });
+  });
+
+  await assert.rejects(
+    requestLocalDaemonJsonRpcForTarget(
+      makeTarget(socketPath),
+      "repo.tasks.list",
+      {},
+      20,
+      { entryPath: "/unused", timeoutMs: 140 }
+    ),
+    (error: unknown) => error instanceof DaemonAutostartTimeoutError
+      && error.spawnedPid === process.pid
+      && /live socket owner pid .* may still be starting/u.test(error.message)
+      && !/DAEMON_AUTOSTART_PROCESS_EXITED/u.test(error.message)
+  );
+});
+
+function writeLiveOwner(ownerPath: string): void {
+  writeFileSync(ownerPath, JSON.stringify({
+    schema: "daemon-socket-owner/v1",
+    pid: process.pid,
+    ownerToken: "winning-owner"
+  }));
+}
+
+function makeTarget(socketPath: string): LocalDaemonTarget {
+  return {
+    repoId: "canonical",
+    canonicalRoot: "/tmp/canonical",
+    userRoot: "/tmp/ha-user-root",
+    daemonId: "default",
+    socketPath,
+    legacySocketPath: `${socketPath}.legacy`,
+    registered: true
+  };
+}
+
+function uniqueSocketPath(prefix: string): string {
+  return path.join("/tmp", `${prefix}-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}.sock`);
+}
+
+function unusedPid(): number {
+  for (let candidate = 999_999; candidate >= 999_000; candidate -= 1) {
+    try {
+      process.kill(candidate, 0);
+    } catch (error) {
+      if (typeof error === "object" && error !== null && "code" in error && error.code === "ESRCH") {
+        return candidate;
+      }
+    }
+  }
+  throw new Error("could not find an unused high pid for the autostart fixture");
+}
+
+function startJsonRpcServer(socketPath: string): Promise<net.Server> {
+  const server = net.createServer((socket) => {
+    const lines = createInterface({ input: socket });
+    lines.on("line", (line) => {
+      const request = JSON.parse(line) as JsonRpcRequest;
+      socket.write(encodeJsonLineFrame({
+        jsonrpc: "2.0",
+        id: request.id ?? null,
+        result: request.method === "protocol.hello" ? { ok: true } : { ok: true, method: request.method }
+      }));
+    });
+  });
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve(server);
+    });
+  });
+}
+
+function closeServer(server: net.Server | undefined): Promise<void> {
+  if (!server?.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+}

--- a/packages/daemon/test/forced-command-root.test.ts
+++ b/packages/daemon/test/forced-command-root.test.ts
@@ -1,0 +1,62 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { commandRootMismatch, validateForcedCommandRoot } from "../src/protocol/forced-command-root.ts";
+import { jsonRpcMethodContract } from "../src/protocol/method-registry.ts";
+
+test("forced-command root mismatch names both roots and refuses blind registration", () => {
+  const receipt = validateForcedCommandRoot(
+    jsonRpcMethodContract("repo.tasks.list")!,
+    { repo: { repoId: "locked", canonicalRoot: "/tmp/forced" } },
+    { repoId: "locked", canonicalRoot: "/tmp/registered" },
+    {
+      transportKind: "ssh-exec",
+      sshForcedCommand: {
+        personId: "person_operator",
+        canonicalRoot: "/tmp/forced",
+        source: "sshd-authorized-keys-forced-command"
+      }
+    }
+  );
+
+  assert.equal(receipt?.error?.code, "forced_command_root_mismatch");
+  assert.equal(
+    receipt?.error?.hint,
+    "Forced-command root mismatch: repo locked is registered at /tmp/registered, but the SSH forced command pins /tmp/forced. Run `ha daemon repo list --json` and ask an administrator to rebind repo locked to /tmp/forced before reconnecting. Do not register a second repo id."
+  );
+});
+
+test("repo command root mismatch names the rejected payload field and canonical value", () => {
+  const receipt = commandRootMismatch(
+    { command: { rootDir: "/tmp/requested" } },
+    { repoId: "locked", canonicalRoot: "/tmp/canonical" },
+    undefined
+  );
+
+  assert.equal(receipt?.error?.code, "repo_command_root_mismatch");
+  assert.equal(
+    receipt?.error?.hint,
+    "Root mismatch: payload.command.rootDir /tmp/requested does not match repo locked at /tmp/canonical. Set payload.command.rootDir to /tmp/canonical, then retry the original CLI command."
+  );
+});
+
+test("forced command root mismatch renders a pasteable reconnect command", () => {
+  const receipt = commandRootMismatch(
+    { command: { rootDir: "/tmp/requested" } },
+    { repoId: "locked", canonicalRoot: "/tmp/canonical" },
+    {
+      transportKind: "ssh-exec",
+      sshForcedCommand: {
+        personId: "person_operator",
+        canonicalRoot: "/tmp/forced root",
+        source: "sshd-authorized-keys-forced-command"
+      }
+    }
+  );
+
+  assert.equal(receipt?.error?.code, "forced_command_root_mismatch");
+  assert.equal(
+    receipt?.error?.hint,
+    "Root mismatch: client --root /tmp/requested does not match the SSH forced-command root /tmp/forced root. Reconnect with `ha --root '/tmp/forced root' daemon connect --stdio`."
+  );
+});

--- a/packages/daemon/test/identity-dispatch-errors.test.ts
+++ b/packages/daemon/test/identity-dispatch-errors.test.ts
@@ -1,0 +1,67 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { IdentityProvider } from "../src/identity/types.ts";
+import { personRegistryFromRecords } from "../src/identity/person-registry.ts";
+import { resolveIdentityActorForMethod } from "../src/protocol/identity-dispatch.ts";
+import { jsonRpcMethodContracts } from "../src/protocol/method-registry.ts";
+
+const writeContract = jsonRpcMethodContracts.find((contract) => contract.method === "repo.task.claim")!;
+
+test("missing person registry reports unavailable source without guessing a roster path or recommending restart", async () => {
+  const result = await resolveIdentityActorForMethod(writeContract, {
+    identityProvider: identityProvider("person_probe")
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    code: "person_registry_unavailable",
+    providerId: "provider_test",
+    message: "Authenticated daemon requests require a core person registry, but no active roster source is available to this identity dispatcher. No authentication state was changed. Inspect the active daemon identity configuration and logs; use `ha daemon status --json` only to verify the endpoint and loaded build before retrying."
+  });
+});
+
+test("unregistered person reports the active registry gap without guessing its source path", async () => {
+  const result = await resolveIdentityActorForMethod(writeContract, {
+    identityProvider: identityProvider("person_probe"),
+    personRegistry: personRegistryFromRecords([])
+  });
+
+  assert.equal(
+    result && !result.ok ? result.message : undefined,
+    "Identity provider authenticated personId person_probe, but that person is not registered in the active person registry. This dispatcher does not know the registry source path and made no identity change. Inspect the active daemon identity configuration and logs; use `ha daemon status --json` only to verify the endpoint and loaded build before retrying."
+  );
+});
+
+test("disabled person reports the active registry state without guessing its source path", async () => {
+  const result = await resolveIdentityActorForMethod(writeContract, {
+    identityProvider: identityProvider("person_probe"),
+    personRegistry: personRegistryFromRecords([{
+      personId: "person_probe",
+      displayName: "Probe",
+      disabled: true
+    }])
+  });
+
+  assert.equal(
+    result && !result.ok ? result.message : undefined,
+    "Person person_probe is disabled in the active person registry, so the request is rejected. This dispatcher does not know the registry source path and made no identity change. Inspect the active daemon identity configuration and logs; use `ha daemon status --json` only to verify the endpoint and loaded build before retrying."
+  );
+});
+
+function identityProvider(personId: string): IdentityProvider {
+  return {
+    providerId: "provider_test",
+    authenticate: async () => ({
+      ok: true,
+      personId,
+      providerId: "provider_test",
+      credential: {
+        kind: "email-address",
+        issuer: "email:primary",
+        subject: "probe@example.test"
+      }
+    }),
+    authorize: async () => ({ ok: true })
+  };
+}

--- a/packages/daemon/test/json-rpc-error-guidance.test.ts
+++ b/packages/daemon/test/json-rpc-error-guidance.test.ts
@@ -1,0 +1,125 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { TaskHolderService } from "../../application/src/index.ts";
+import { createInMemoryTerminalSessionService } from "../src/terminal/session-registry.ts";
+import { jsonRpcMethodContract } from "../src/protocol/method-registry.ts";
+import { validateTaskLeaseForServiceWrite } from "../src/protocol/task-holder-write-policy.ts";
+import {
+  commandRunRequest,
+  emptyLocalController,
+  makeServer,
+  readFixture,
+  resultReceipt,
+  rosterIdentityOptions,
+  sampleRoster
+} from "./json-rpc-protocol-fixtures.ts";
+
+test("missing daemon service composition gives observation-only recovery guidance", async () => {
+  const server = makeServer({ resolveRepoServices: () => undefined });
+  await server.handle(readFixture("hello-compatible.json"));
+  const receipt = resultReceipt(await server.handle(readFixture("repo-request.json")));
+
+  assert.equal(receipt.error?.code, "repo_service_unavailable");
+  assert.equal(receipt.error?.hint, "Repo service host for canonical is absent from the running daemon composition. Run `ha daemon logs --errors --json` to capture the missing repo composition. Do not register, stop, or restart the repo; retry only after an operator supplies and verifies a composition for canonical.");
+});
+
+test("missing status and command services do not prescribe daemon replacement", async () => {
+  const server = makeServer();
+  await server.handle(readFixture("hello-compatible.json"));
+
+  const status = resultReceipt(await server.handle({
+    jsonrpc: "2.0", id: "missing-status", method: "repo.daemon.status",
+    params: { repo: { repoId: "canonical" }, payload: {} }
+  }));
+  assert.equal(status.error?.code, "daemon_status_service_unavailable");
+  assert.equal(status.error?.hint, "Daemon status service is absent from the running composition. Run `ha daemon logs --errors --json` to capture the missing service. Leave the daemon running; an operator must verify a replacement composition before any restart.");
+
+  const command = resultReceipt(await server.handle(commandRunRequest("version", "missing-command")));
+  assert.equal(command.error?.code, "cli_command_service_unavailable");
+  assert.equal(command.error?.hint, "Daemon command service is absent from the repository composition. Run `ha daemon logs --errors --json` to capture the missing command host. Leave the daemon running; retry only after an operator supplies and verifies a replacement composition.");
+});
+
+test("missing task-holder service and task id preserve lease state", async () => {
+  const server = makeServer();
+  await server.handle(readFixture("hello-compatible.json"));
+  const missingService = resultReceipt(await server.handle({
+    jsonrpc: "2.0", id: "missing-holder-service", method: "repo.task.holder",
+    params: { repo: { repoId: "canonical" }, payload: { taskId: "task_RENDER" } }
+  }));
+  assert.equal(missingService.error?.code, "task_holder_service_unavailable");
+  assert.equal(missingService.error?.hint, "Task holder service is absent from the running composition. Run `ha daemon logs --errors --json` to capture the missing service. Leave the daemon and current lease state unchanged; retry only after an operator verifies a replacement composition.");
+
+  const taskHolderService = {
+    holder: async () => null,
+    claim: async () => null,
+    release: async () => null,
+    assertActiveLease: async () => undefined
+  } as unknown as TaskHolderService;
+  const missingTaskIdServer = makeServer({
+    services: {
+      LocalControllerService: emptyLocalController(),
+      TerminalSessionService: createInMemoryTerminalSessionService({ createId: () => "term-1" }),
+      TaskHolderService: taskHolderService
+    }
+  });
+  await missingTaskIdServer.handle(readFixture("hello-compatible.json"));
+  const missingTaskId = resultReceipt(await missingTaskIdServer.handle({
+    jsonrpc: "2.0", id: "missing-task-id", method: "repo.task.holder",
+    params: { repo: { repoId: "canonical" }, payload: {} }
+  }));
+  assert.equal(missingTaskId.error?.code, "task_id_required");
+  assert.equal(missingTaskId.error?.hint, "Required payload.taskId is missing from the raw RPC request, so no holder lookup ran. Supply the intended concrete task id in payload.taskId and retry the same RPC; no task state was changed.");
+
+  const missingLeaseTaskId = await validateTaskLeaseForServiceWrite(
+    jsonRpcMethodContract("repo.tasks.status.set")!,
+    { status: "in_progress" },
+    { TaskHolderService: taskHolderService },
+    undefined,
+    { repoId: "canonical", canonicalRoot: "/tmp/canonical" },
+    { leaseEnforcementEnabled: () => true }
+  );
+  assert.equal(missingLeaseTaskId?.error?.code, "task_id_required");
+  assert.equal(missingLeaseTaskId?.error?.hint, "Required payload.taskId is missing from the raw RPC request, so lease enforcement did not run. Supply the intended concrete task id in payload.taskId and retry the same RPC; no task state was changed.");
+});
+
+test("missing admin roster reports the loaded-composition boundary without restart", async () => {
+  const roster = sampleRoster();
+  const identity = rosterIdentityOptions(roster);
+  const server = makeServer({
+    identityProvider: identity.identityProvider,
+    personRegistry: identity.personRegistry,
+    authContext: { transportKind: "ssh-exec", sshExecUser: { username: "alice", host: "team-host", source: "ssh-authenticated-exec" } }
+  });
+  await server.handle(readFixture("hello-compatible.json"));
+  const receipt = resultReceipt(await server.handle({ jsonrpc: "2.0", id: "missing-admin-roster", method: "admin.people.list", params: {} }));
+
+  assert.equal(receipt.error?.code, "people_roster_unavailable");
+  assert.equal(receipt.error?.hint, "Admin identity methods cannot run because the active daemon composition has no loaded people roster. Run `ha daemon status --check --json` and inspect the reported daemon user root and roster state. Leave the daemon running; an operator must load and verify the roster before retrying.");
+});
+
+test("missing doc-sync and lease services preserve the pending write", async () => {
+  const roster = sampleRoster();
+  const identity = rosterIdentityOptions(roster);
+  const server = makeServer({
+    identityProvider: identity.identityProvider,
+    personRegistry: identity.personRegistry,
+    authContext: { transportKind: "ssh-exec", sshExecUser: { username: "alice", host: "team-host", source: "ssh-authenticated-exec" } },
+    leaseEnforcementEnabled: () => true
+  });
+  await server.handle(readFixture("hello-compatible.json"));
+
+  const docSync = resultReceipt(await server.handle({
+    jsonrpc: "2.0", id: "missing-doc-sync", method: "repo.doc.sync.submit",
+    params: { repo: { repoId: "canonical" }, payload: { baseLedgerSha: "base", intentId: "intent-preserved", declaredIntent: "prose-edit", changes: [] } }
+  }));
+  assert.equal(docSync.error?.code, "doc_sync_service_unavailable");
+  assert.equal(docSync.error?.hint, "Required doc sync submit service is missing from the repository write composition, so no write was submitted. Run `ha doc status --json` to preserve and inspect the dirty prose. Leave the daemon running; do not resubmit until an operator verifies a replacement composition.");
+
+  const lease = resultReceipt(await server.handle({
+    jsonrpc: "2.0", id: "missing-lease-service", method: "repo.tasks.status.set",
+    params: { repo: { repoId: "canonical" }, payload: { taskId: "task_RENDER", status: "in_progress" } }
+  }));
+  assert.equal(lease.error?.code, "task_holder_service_unavailable");
+  assert.equal(lease.error?.hint, "Task holder service is absent from the running composition. Run `ha daemon logs --errors --json` to capture the missing service. Leave the daemon and current lease state unchanged; retry only after an operator verifies a replacement composition.");
+});

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -217,7 +217,6 @@ test("repo namespace rejects unknown canonical repositories", async () => {
   assert.equal(receipt.error.code, "repo_namespace_unknown");
 });
 
-
 test("repo methods fail closed when the repo runtime is unavailable", async () => {
   let serviceCalls = 0;
   const server = makeServer({
@@ -259,14 +258,14 @@ test("repo methods fail closed when the repo runtime is unavailable", async () =
 
   assert.equal(receipt.ok, false);
   assert.equal(receipt.error?.code, "repo_lock_held");
-  assert.equal(receipt.error?.hint, "Repo locked is not attached to this daemon.");
+  assert.equal(
+    receipt.error?.hint,
+    "Repo locked is attached, but its writer lock is held at .harness/locks/global.lock (lock already held: daemon owner). Wait for the current writer to release the lock, then run `ha --repo locked daemon status --json` before retrying. Do not register, purge, stop, or restart the repo while the lock is held."
+  );
   assert.equal((receipt.details.repo as { state?: string }).state, "unavailable");
   assert.deepEqual(receipt.next, [{
     command: "ha --repo locked daemon status --json",
-    description: "Inspect this repo's daemon attachment state; unavailable repos are retried automatically."
-  }, {
-    command: "ha daemon repo register --repo-id locked --root /tmp/locked",
-    description: "Register or re-enable this repo if it is missing or disabled, then retry the original command."
+    description: "The repo writer lock is held at .harness/locks/global.lock (owner: lock already held: daemon owner). Wait for the current writer to release it, then rerun this status command before retrying. Do not register, purge, stop, or restart the repo while the lock is held."
   }]);
   assert.equal(serviceCalls, 0);
 });
@@ -303,7 +302,10 @@ test("repo methods fail closed when the repo runtime context is missing", async 
 
   assert.equal(receipt.ok, false);
   assert.equal(receipt.error?.code, "repo_unavailable");
-  assert.equal(receipt.error?.hint, "Repo canonical is not attached to this daemon.");
+  assert.equal(
+    receipt.error?.hint,
+    "Repo canonical is attached, but its runtime is unavailable: runtime context not found. Run `ha --repo canonical daemon status --json` to inspect recovery or availability before choosing a repair."
+  );
   assert.equal((receipt.details.repo as { lastError?: string }).lastError, "runtime context not found");
   assert.deepEqual(receipt.next?.map((action: { command: string }) => action.command), [
     "ha --repo canonical daemon status --json",

--- a/packages/daemon/test/production-recovery-admission-errors.test.ts
+++ b/packages/daemon/test/production-recovery-admission-errors.test.ts
@@ -1,0 +1,36 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { gateAuthoritySubmissionForRecovery } from "../src/index.ts";
+import { waitForProductionRecovery } from "../src/authority/production/production-recovery-admission.ts";
+
+test("production recovery admission timeout preserves the active recovery and offers only a read-only check", async () => {
+  let submissions = 0;
+  const service = gateAuthoritySubmissionForRecovery({
+    submit: async () => {
+      submissions += 1;
+      throw new Error("timed-out recovery must stay gated");
+    },
+    getOperation: async () => undefined
+  }, () => waitForProductionRecovery({
+    repoId: "canonical",
+    recovery: { status: "recovering", promise: new Promise<void>(() => undefined) }
+  }, 5));
+  const receipt = await service.submit({
+    workspaceId: "workspace-recovery-timeout",
+    opId: "op-recovery-timeout",
+    claimedDigest: "a".repeat(64),
+    command: "task.append",
+    operation: { opId: "op-recovery-timeout", entityId: "task/task_RECOVERY", kind: "progress_append", payload: { path: "progress.md", append: "x" } },
+    delegationToken: "token",
+    channelNonceDigest: "b".repeat(64),
+    protocol: { wire: 1, event: 1, receipt: 1, digest: 1, commandRegistry: 1 }
+  });
+
+  assert.equal(receipt.tag, "RETRYABLE_NOT_COMMITTED");
+  assert.equal(
+    receipt.reason,
+    "AUTHORITY_RECOVERY_WAIT_TIMEOUT:repoId=canonical;waitedMs=5; recovery is still running. Do not start, stop, or restart any daemon and do not replay the write. Wait for the current recovery to finish, then run `ha --repo canonical daemon status --json`; retry the original command only after the repo is no longer recovering."
+  );
+  assert.equal(submissions, 0);
+});

--- a/packages/daemon/test/projection-notification-protocol.test.ts
+++ b/packages/daemon/test/projection-notification-protocol.test.ts
@@ -7,6 +7,24 @@ import {
   resultReceipt
 } from "./json-rpc-protocol-fixtures.ts";
 
+test("missing notification transport reports the connection composition gap without recommending start", async () => {
+  const server = makeServer();
+  await server.handle(readFixture("hello-compatible.json"));
+
+  const receipt = resultReceipt(await server.handle({
+    jsonrpc: "2.0",
+    id: "subscribe-unavailable",
+    method: "repo.notifications.subscribe",
+    params: { repo: { repoId: "canonical" } }
+  })) as ReturnType<typeof resultReceipt> & { readonly error?: { readonly hint?: string } };
+
+  assert.equal(
+    receipt.error?.hint,
+    "Projection notification subscription is unavailable because this connection is missing at least one required capability: a notification sink or a projection-change subscriber. This request created no subscription. Inspect the current transport configuration and reconnect through an endpoint configured with both notification capabilities; use `ha daemon status --json` only to verify the active daemon."
+  );
+  await server.close();
+});
+
 test("repo notification subscription forwards projection changes and cleans up on disconnect", async () => {
   const notifications: unknown[] = [];
   let listener: ((event: unknown) => void) | undefined;

--- a/packages/daemon/test/repo-write-command-cutover.test.ts
+++ b/packages/daemon/test/repo-write-command-cutover.test.ts
@@ -58,6 +58,47 @@ test("current-session materializer barrier fails closed without a runtime sessio
   assert.match(receipt.error?.hint ?? "", /requires a runtime session/u);
 });
 
+test("materializer rendering receives the parsed harness layout input", async () => {
+  let receivedRootInput: Parameters<DaemonCommandHostServices<
+    TestCommand,
+    TestResult,
+    ReturnType<typeof productionAuthorityActor>
+  >["materializerCommandResult"]>[1] | undefined;
+  const runtime = {
+    ...unusedRuntime(),
+    enqueueMaterializerBatch: async () => ({
+      dryRun: false,
+      merged: 0,
+      considered: 0,
+      branches: [],
+      warnings: []
+    })
+  };
+  const service = createDaemonCommandService(
+    runtime,
+    hostServices(() => { throw new Error("materializer must not reach command execution"); }, {
+      materializerCommandResult: (_report, rootInput) => {
+        receivedRootInput = rootInput;
+        return { ok: true, command: "materializer" };
+      }
+    })
+  );
+
+  await service.runCommand({
+    command: {
+      rootDir: "/repo with custom layout",
+      layoutOverrides: { authoredRoot: ".custom-ledger" },
+      json: true,
+      action: { kind: "materializer-run", dryRun: false }
+    }
+  });
+
+  assert.deepEqual(receivedRootInput, {
+    rootDir: "/repo with custom layout",
+    layoutOverrides: { authoredRoot: ".custom-ledger" }
+  });
+});
+
 test("authority-backed runtime writes do not enqueue a second current-session materializer barrier", async () => {
   let materializerCalls = 0;
   const runtime = {
@@ -309,7 +350,7 @@ test("parent command service preserves a structured child rejection before proce
   assert.match(receipt.error?.hint ?? "", /AUTHORITY_MANUAL_ENTITY_ID_FORBIDDEN/u);
 });
 
-test("unknown child receipts expose a machine-readable final-state query", async () => {
+test("unknown child receipts expose a caller-executable final-state query", async () => {
   const actor = productionAuthorityActor();
   for (const [kind, failure] of [
     ["durable", new RepoWriteOutcomeUnknownError("EXECUTION_OUTCOME_UNKNOWN", "write may have committed", "outer-op")],
@@ -357,8 +398,79 @@ test("unknown child receipts expose a machine-readable final-state query", async
     const query = data.query as Record<string, unknown>;
     assert.equal(data.outcome, "unknown");
     assert.equal(query.schema, "command-outcome-query/v1");
-    assert.equal(query.method, kind === "durable" ? "repo-write.lookup" : "task.show");
+    assert.equal(query.method, "task.show");
+    assert.equal(query.command, "ha task show task-queryable --json");
+    assert.match(receipt.error?.hint ?? "", /ha task show task-queryable --json/u);
+    assert.doesNotMatch(receipt.error?.hint ?? "", /query the stable outer opId|repo-write\.lookup/u);
   }
+});
+
+test("decision outcome-unknown receipts give a concrete read-only projection check", async () => {
+  const actor = productionAuthorityActor();
+  const service = createDaemonCommandService(
+    unusedRuntime(),
+    hostServices(() => undefined),
+    {
+      repoWriteDispatch: {
+        repoId: "canonical",
+        submit: async () => {
+          throw new RepoWriteOutcomeUnknownError(
+            "EXECUTION_OUTCOME_UNKNOWN",
+            "AUTHORITY_INDETERMINATE:PUBLICATION_OUTCOME_UNKNOWN:durable write may have committed. Exact repo-write outcome lookup failed for repo-write:decision-live; query the stable outer opId repo-write:decision-live.",
+            "repo-write:decision-live"
+          );
+        },
+        direct: async () => { throw new Error("unexpected direct route"); }
+      }
+    }
+  );
+
+  const receipt = await service.runCommand({
+    command: {
+      rootDir: "/repo",
+      json: true,
+      action: {
+        kind: "decision-propose",
+        decisionId: "dec_live",
+        proposedAt: "2026-08-09T00:00:00.000Z",
+        title: "Live decision",
+        question: "Did the write commit?",
+        chosen: [{ text: "Verify the projection" }],
+        rejected: [{ text: "Replay immediately" }],
+        claims: [],
+        claimLoadBearing: false,
+        fulfillments: [],
+        riskTier: "high",
+        urgency: "high",
+        modules: [],
+        productLines: [],
+        evidenceRelations: [],
+        dryRun: false
+      }
+    },
+    session: session()
+  }, {
+    actor,
+    executor: { kind: "agent", id: "codex" },
+    authorityConnection: {
+      available: true,
+      context: productionAuthorityConnection(actor),
+      assertActive: () => undefined
+    }
+  });
+
+  assert.equal(receipt.error?.code, "repo_write_outcome_unknown");
+  assert.equal(
+    receipt.error?.hint,
+    "The child writer may already have committed decision-propose, but its final outcome is unknown: AUTHORITY_INDETERMINATE:PUBLICATION_OUTCOME_UNKNOWN:durable write may have committed. Run `ha decision show dec_live --json` to inspect the canonical projection. If the decision is absent, the outcome is still unknown; do not replay the write."
+  );
+  assert.deepEqual(receipt.details?.data?.query, {
+    schema: "command-outcome-query/v1",
+    method: "decision.show",
+    command: "ha decision show dec_live --json",
+    parameters: { decisionId: "dec_live" },
+    retry: "forbidden-after-absence"
+  });
 });
 
 function hostServices(onExecute: () => void, overrides: {
@@ -368,6 +480,11 @@ function hostServices(onExecute: () => void, overrides: {
     executor: TaskHolderExecutor | null
   ) => AuthorityHostAttribution;
   readonly authorityCommand?: (command: TestCommand) => AuthorityHostCommand | undefined;
+  readonly materializerCommandResult?: DaemonCommandHostServices<
+    TestCommand,
+    TestResult,
+    ReturnType<typeof productionAuthorityActor>
+  >["materializerCommandResult"];
 } = {}): DaemonCommandHostServices<
   TestCommand,
   TestResult,
@@ -398,10 +515,10 @@ function hostServices(onExecute: () => void, overrides: {
       onExecute();
       return { ok: true, command: command.action.kind };
     },
-    materializerCommandResult: () => ({
+    materializerCommandResult: overrides.materializerCommandResult ?? (() => ({
       ok: true,
       command: "materializer"
-    }),
+    })),
     toReceipt: () => committedReceipt(),
     toErrorReceipt: ({ command, error }) => ({
       ok: false,

--- a/packages/daemon/test/ssh-authority-wire-guidance.test.ts
+++ b/packages/daemon/test/ssh-authority-wire-guidance.test.ts
@@ -1,0 +1,24 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { authenticateSshAuthorityWireFrame } from "../src/index.ts";
+
+test("unavailable authority-wire roots render a concrete read-only diagnostic", () => {
+  const canonicalRoot = "/srv/team's canonical";
+  const result = authenticateSshAuthorityWireFrame(
+    {
+      type: "harness-daemon.ssh-forced-command/v2",
+      streamProtocol: "harness-authority-wire/v1",
+      personId: "person_alice",
+      canonicalRoot
+    },
+    { transportKind: "unix-socket", endpoint: "/tmp/authority-wire.sock" },
+    () => false
+  );
+
+  assert.deepEqual(result, {
+    ok: false,
+    code: "authority_wire_repo_unavailable",
+    message: "The requested canonical root \"/srv/team's canonical\" is unavailable to this authority service. Run `ha --root '/srv/team'\"'\"'s canonical' daemon status --json` on the authority host to inspect its registered state. Do not register a second repo id or start, stop, or restart a daemon based on this error."
+  });
+});

--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -113,6 +113,12 @@ interface GuiDaemonBridgeState {
   layoutOverrideDaemonStarted: boolean;
 }
 
+type GuiLocalFailureStage = "module-load" | "settings" | "target" | "node-runtime" | "launch-configuration" | "request";
+type GuiFailureReceipt = {
+  readonly ok: false;
+  readonly error: { readonly code: string; readonly hint: string };
+};
+
 export function createLocalGuiServiceBridge(rootDir: string, layoutOverrides?: HarnessLayoutOverrides): GuiServiceBridge {
   const resolvedRootDir = path.resolve(rootDir);
   validateProjectPath(resolvedRootDir, ".");
@@ -152,13 +158,7 @@ export function createGuiServiceBridge(
         jsonRpcParamsForGuiRoute(route, transport.repoId, payload, transport.remoteRoot) as never
       ) as JsonObject;
     } catch (error) {
-      return {
-        ok: false,
-        error: {
-          code: "daemon_unavailable",
-          hint: `Remote Harness daemon is unavailable through ${transport.host}: ${error instanceof Error ? error.message : String(error)}`
-        }
-      };
+      return guiRemoteFailureReceipt(transport.host, error);
     }
   });
   return {
@@ -222,11 +222,24 @@ async function requestGuiRouteViaDaemon(
   route: ApiRouteContract,
   payload: unknown
 ): Promise<JsonObject> {
+  let daemonClient: LocalDaemonClientModule;
+  let daemonSettings: DaemonSettingsModule;
   try {
-    const [daemonClient, daemonSettings] = await Promise.all([loadDaemonClientModule(), loadDaemonSettingsModule()]);
-    const userRoot = daemonSettings.readDaemonUserRoot(process.env, rootDir, layoutOverrides);
-    const daemonId = daemonClient.daemonIdFromEnv();
-    const target = daemonClient.resolveLocalDaemonTarget({
+    [daemonClient, daemonSettings] = await Promise.all([loadDaemonClientModule(), loadDaemonSettingsModule()]);
+  } catch (error) {
+    return guiLocalFailureReceipt("module-load", error);
+  }
+  let userRoot: string;
+  let daemonId: string;
+  try {
+    userRoot = daemonSettings.readDaemonUserRoot(process.env, rootDir, layoutOverrides);
+    daemonId = daemonClient.daemonIdFromEnv();
+  } catch (error) {
+    return guiLocalFailureReceipt("settings", error);
+  }
+  let target: LocalDaemonTarget;
+  try {
+    target = daemonClient.resolveLocalDaemonTarget({
       rootDir,
       repoIdOverride: process.env.HARNESS_DAEMON_REPO_ID,
       userRoot,
@@ -234,22 +247,29 @@ async function requestGuiRouteViaDaemon(
       autoRegisterSingleRepo: true,
       layoutOverrides
     });
-    const customLayout = hasLayoutOverride(layoutOverrides);
-    if (customLayout && !state.layoutOverrideDaemonStarted && await daemonAlreadyRunning(daemonClient, target)) {
-      return {
-        ok: false,
-        error: {
-          code: "daemon_layout_conflict",
-          hint: "A Harness daemon is already running for this repo without a verifiable matching authored layout. Stop the daemon or restart the GUI without HARNESS_AUTHORED_ROOT."
-        }
-      };
-    }
-    const nodeRuntime = resolveGuiDaemonNodeRuntime();
-    const method = jsonRpcMethodForGuiRoute(route);
-    const params = jsonRpcParamsForGuiRoute(route, target.repoId, payload);
-    // Admin control (restart) waits for accept + drain; allow a longer socket timeout.
-    const timeoutMs = route.commandClass === "admin" ? 5_000 : 200;
-    const launchConfiguration = daemonClient.createDaemonLaunchConfigurationFromPersistedPolicy({
+  } catch (error) {
+    return guiLocalFailureReceipt("target", error);
+  }
+  const customLayout = hasLayoutOverride(layoutOverrides);
+  if (customLayout && !state.layoutOverrideDaemonStarted && await daemonAlreadyRunning(daemonClient, target)) {
+    return guiLayoutConflictReceipt(
+      target,
+      path.resolve(rootDir, layoutOverrides!.authoredRoot!)
+    );
+  }
+  let nodeRuntime: GuiDaemonNodeRuntime;
+  try {
+    nodeRuntime = resolveGuiDaemonNodeRuntime();
+  } catch (error) {
+    return guiLocalFailureReceipt("node-runtime", error);
+  }
+  const method = jsonRpcMethodForGuiRoute(route);
+  const params = jsonRpcParamsForGuiRoute(route, target.repoId, payload);
+  // Admin control (restart) waits for accept + drain; allow a longer socket timeout.
+  const timeoutMs = route.commandClass === "admin" ? 5_000 : 200;
+  let launchConfiguration: ReturnType<LocalDaemonClientModule["createDaemonLaunchConfigurationFromPersistedPolicy"]>;
+  try {
+    launchConfiguration = daemonClient.createDaemonLaunchConfigurationFromPersistedPolicy({
       target,
       entrypoint: cliEntrypointPath(),
       idleExitMs: resolveGuiDaemonIdleExitMs(),
@@ -258,6 +278,10 @@ async function requestGuiRouteViaDaemon(
       env: nodeRuntime.env,
       ...(layoutOverrides?.authoredRoot !== undefined ? { authoredRoot: layoutOverrides.authoredRoot } : {})
     });
+  } catch (error) {
+    return guiLocalFailureReceipt("launch-configuration", error);
+  }
+  try {
     const receipt = await daemonClient.requestLocalDaemonJsonRpcForTarget(target, method, params, timeoutMs, {
       entryPath: launchConfiguration.entrypoint,
       timeoutMs: daemonAutostartTimeoutMs(),
@@ -268,13 +292,76 @@ async function requestGuiRouteViaDaemon(
     if (customLayout) state.layoutOverrideDaemonStarted = true;
     return receipt;
   } catch (error) {
-    return {
-      ok: false,
-      error: {
-        code: "daemon_unavailable",
-        hint: `Harness daemon is unavailable: ${error instanceof Error ? error.message : String(error)}`
-      }
-    };
+    return guiLocalFailureReceipt("request", error);
+  }
+}
+
+export function guiLocalFailureReceipt(stage: GuiLocalFailureStage, error: unknown): GuiFailureReceipt {
+  const message = guiErrorMessage(error);
+  if (stage === "module-load") {
+    return guiFailure("gui_runtime_load_failed", `GUI could not load local daemon support: ${message}. Rebuild or reinstall the GUI before retrying. The daemon was not contacted.`);
+  }
+  if (stage === "settings") {
+    return guiFailure("gui_configuration_invalid", `GUI daemon configuration is invalid: ${message}. Correct HARNESS_DAEMON_USER_ROOT or the repository settings before retrying. The daemon was not contacted.`);
+  }
+  if (stage === "target") {
+    return guiFailure("harness_root_unresolved", `GUI could not resolve the requested repo target: ${message}. Run \`ha daemon repo list --json\` and select the registered canonical root before retrying.`);
+  }
+  if (stage === "node-runtime") {
+    return guiFailure("node_runtime_unavailable", `GUI cannot launch a local daemon because ${message}. Configure HARNESS_NODE_BIN with a Node executable before retrying. The daemon was not contacted.`);
+  }
+  if (stage === "launch-configuration") {
+    return guiFailure("daemon_launch_configuration_invalid", `GUI daemon launch configuration is invalid: ${message}. Run \`ha daemon status --json\` to inspect any existing service; do not restart it until the launch configuration is repaired.`);
+  }
+  const unavailable = /(?:ECONNREFUSED|no persistent daemon|not listening)/iu.test(message);
+  return guiFailure(
+    unavailable ? "daemon_unavailable" : "daemon_request_failed",
+    `Local Harness daemon request failed: ${message}. Run \`ha daemon status --json\` to inspect the current service before retrying; do not restart it solely because this request failed.`
+  );
+}
+
+export function guiLayoutConflictReceipt(
+  target: Pick<LocalDaemonTarget, "repoId" | "canonicalRoot">,
+  requestedAuthoredRoot: string
+): GuiFailureReceipt {
+  return guiFailure(
+    "daemon_layout_conflict",
+    `A Harness daemon is already running for repo ${target.repoId}, and the GUI could not verify its existing layout against the requested authored root ${JSON.stringify(requestedAuthoredRoot)}; the GUI did not apply that root. Leave the daemon running and keep HARNESS_AUTHORED_ROOT unchanged. Run \`ha --repo ${target.repoId} daemon status --json\`; reopen the GUI only after an operator verifies that the daemon uses that authored root.`
+  );
+}
+
+function guiRemoteFailureReceipt(host: string, error: unknown): GuiFailureReceipt {
+  const message = guiErrorMessage(error);
+  if (/(?:authenticat|permission denied|publickey)/iu.test(message)) {
+    return guiFailure(
+      "remote_authentication_failed",
+      `Remote SSH authentication failed for ${host}: ${message}. Verify the SSH principal and authorized_keys forced command, then reconnect. Do not restart the remote daemon.`
+    );
+  }
+  if (/(?:timed? out|timeout)/iu.test(message)) {
+    return guiFailure("remote_transport_timeout", `Remote transport to ${host} timed out: ${message}. Verify SSH reachability, then retry without restarting the remote daemon.`);
+  }
+  if (/(?:protocol|frame|decode|invalid json)/iu.test(message)) {
+    return guiFailure("remote_protocol_error", `Remote daemon protocol failed through ${host}: ${message}. Verify that the local and remote Harness versions are compatible before reconnecting.`);
+  }
+  if (/(?:ECONNREFUSED|no persistent daemon|not listening)/iu.test(message)) {
+    return guiFailure("daemon_unavailable", `Remote Harness daemon is unavailable through ${host}: ${message}`);
+  }
+  return guiFailure("remote_transport_failed", `Remote transport through ${host} failed: ${message}. Inspect the SSH transport before retrying; do not restart the remote daemon.`);
+}
+
+function guiFailure(code: string, hint: string): GuiFailureReceipt {
+  return { ok: false, error: { code, hint } };
+}
+
+function guiErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object" && "message" in error && typeof error.message === "string") return error.message;
+  try {
+    return JSON.stringify(error) ?? String(error);
+  } catch {
+    return String(error);
   }
 }
 

--- a/packages/gui/test/local-composition-root-errors.test.ts
+++ b/packages/gui/test/local-composition-root-errors.test.ts
@@ -1,0 +1,33 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  guiLayoutConflictReceipt,
+  guiLocalFailureReceipt
+} from "../src/main/local-composition-root.ts";
+
+test("GUI configuration failure is not labeled as daemon unavailability", () => {
+  assert.deepEqual(
+    guiLocalFailureReceipt("settings", new Error("GUI authored-root configuration is invalid")),
+    {
+      ok: false,
+      error: {
+        code: "gui_configuration_invalid",
+        hint: "GUI daemon configuration is invalid: GUI authored-root configuration is invalid. Correct HARNESS_DAEMON_USER_ROOT or the repository settings before retrying. The daemon was not contacted."
+      }
+    }
+  );
+});
+
+test("GUI layout conflict preserves the requested root and the running daemon", () => {
+  assert.deepEqual(guiLayoutConflictReceipt(
+    { repoId: "canonical", canonicalRoot: "/srv/repo" },
+    "/srv/repo/.custom-authored"
+  ), {
+    ok: false,
+    error: {
+      code: "daemon_layout_conflict",
+      hint: "A Harness daemon is already running for repo canonical, and the GUI could not verify its existing layout against the requested authored root \"/srv/repo/.custom-authored\"; the GUI did not apply that root. Leave the daemon running and keep HARNESS_AUTHORED_ROOT unchanged. Run `ha --repo canonical daemon status --json`; reopen the GUI only after an operator verifies that the daemon uses that authored root."
+    }
+  });
+});

--- a/packages/gui/test/service-bridge-remote.test.ts
+++ b/packages/gui/test/service-bridge-remote.test.ts
@@ -181,6 +181,34 @@ test("GUI remote mode fails closed when the persistent daemon is unavailable", a
   }
 });
 
+test("GUI remote mode preserves SSH authentication failure identity", async () => {
+  const nearRoot = mkdtempSync(path.join(tmpdir(), "ha-gui-near-"));
+  const bridge = createGuiServiceBridge(nearRoot, undefined, {
+    env: { ...remoteDaemonEnv("/srv/harness/gui-remote"), HARNESS_DAEMON_SSH_HOST: "team-host" },
+    createSshTransport: () => ({
+      open: async () => {
+        throw new Error("SSH authentication failed for operator");
+      }
+    })
+  });
+  try {
+    const tasks = await bridge.invoke("getTasks", null) as {
+      readonly ok: boolean;
+      readonly error?: { readonly code?: string; readonly hint?: string };
+    };
+
+    assert.equal(tasks.ok, false, JSON.stringify(tasks));
+    assert.equal(tasks.error?.code, "remote_authentication_failed");
+    assert.equal(
+      tasks.error?.hint,
+      "Remote SSH authentication failed for team-host: SSH authentication failed for operator. Verify the SSH principal and authorized_keys forced command, then reconnect. Do not restart the remote daemon."
+    );
+  } finally {
+    await bridge.dispose?.();
+    rmSync(nearRoot, { recursive: true, force: true });
+  }
+});
+
 function remoteDaemonEnv(remoteRoot: string): NodeJS.ProcessEnv {
   return {
     ...process.env,

--- a/packages/vscode-ext/src/routing/workspace-router.ts
+++ b/packages/vscode-ext/src/routing/workspace-router.ts
@@ -9,7 +9,7 @@ export interface ResolvedWorkspaceRepo {
 
 export interface UnknownWorkspaceRoot {
   readonly folder: vscode.WorkspaceFolder;
-  readonly action: "Register workspace folder with Harness";
+  readonly action: string;
 }
 
 export interface WorkspaceRouterOptions {
@@ -44,7 +44,7 @@ export class WorkspaceRouter {
       const resolved = await this.#options.resolveFolder(folder);
       if (!resolved) {
         this.#routes.set(key, { folder });
-        this.#options.onUnknownRoot({ folder, action: "Register workspace folder with Harness" });
+        this.#options.onUnknownRoot({ folder, action: unknownWorkspaceRootAction(folder) });
         continue;
       }
       const repo = Object.freeze({ endpoint: resolved.endpoint, repoId: resolved.repoId });
@@ -77,4 +77,13 @@ function contains(root: vscode.Uri, candidate: vscode.Uri): boolean {
   if (root.scheme !== candidate.scheme || root.authority !== candidate.authority) return false;
   const base = root.path.endsWith("/") ? root.path : `${root.path}/`;
   return candidate.path === root.path || candidate.path.startsWith(base);
+}
+
+function unknownWorkspaceRootAction(folder: vscode.WorkspaceFolder): string {
+  const requestedRoot = shellArgument(folder.uri.fsPath);
+  return `Run \`ha --root ${requestedRoot} daemon status --json\` to resolve and inspect this workspace's canonical Harness root before registering or starting anything.`;
+}
+
+function shellArgument(value: string): string {
+  return /^[A-Za-z0-9_./:@%+=,-]+$/u.test(value) ? value : `'${value.replaceAll("'", `'"'"'`)}'`;
 }

--- a/packages/vscode-ext/test/workspace-router.test.ts
+++ b/packages/vscode-ext/test/workspace-router.test.ts
@@ -19,11 +19,13 @@ test("unknown roots fail closed with an explicit action and zero transport reque
     resolveFolder: async () => undefined,
     onUnknownRoot: ({ action }) => notices.push(action)
   });
-  await router.reconcile([folder("unknown", "/unknown")]);
-  assert.equal(router.route(uri("/unknown/file.ts")), undefined);
-  assert.equal(router.connection(uri("/unknown/file.ts")), undefined);
+  await router.reconcile([folder("unknown", "/unknown workspace")]);
+  assert.equal(router.route(uri("/unknown workspace/file.ts")), undefined);
+  assert.equal(router.connection(uri("/unknown workspace/file.ts")), undefined);
   assert.equal(clients, 0);
-  assert.deepEqual(notices, ["Register workspace folder with Harness"]);
+  assert.deepEqual(notices, [
+    "Run `ha --root '/unknown workspace' daemon status --json` to resolve and inspect this workspace's canonical Harness root before registering or starting anything."
+  ]);
   await router.dispose();
 });
 

--- a/tools/check-error-next-step-commands.mjs
+++ b/tools/check-error-next-step-commands.mjs
@@ -1,0 +1,567 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { entryValues, loadGateAllowlist } from "./gate-allowlists/load-gate-allowlist.mjs";
+
+const gateId = "check-error-next-step-commands";
+const repositoryRoot = path.resolve(fileURLToPath(new URL("../", import.meta.url)));
+const fixtureRoot = path.join(repositoryRoot, "tools/fixtures/check-error-next-step-commands");
+const commandSpecRoot = "packages/cli/src/cli/command-spec";
+
+export function inspectErrorNextStepCommands(rootDir = process.cwd()) {
+  const registry = collectCommandContracts(rootDir);
+  const { contracts } = registry;
+  const findings = [];
+  for (const occurrence of collectErrorHints(rootDir)) {
+    const commandOrdinals = new Map();
+    for (const candidate of extractCommandCandidates(occurrence.hint)) {
+      const { command, quoted } = candidate;
+      const tokens = tokenize(command);
+      const hasLauncher = /^(?:ha|harness-anything)$/u.test(tokens[0] ?? "");
+      let routeStart = hasLauncher ? 1 : 0;
+      while (hasLauncher && registry.globalOptions.has(tokens[routeStart])) {
+        const consumesValue = registry.globalOptions.get(tokens[routeStart]);
+        routeStart += consumesValue ? 2 : 1;
+      }
+      const routeTokens = tokens.slice(routeStart);
+      const contract = contracts
+        .filter((candidate) => candidate.route.every((token, index) => routeTokens[index] === token))
+        .sort((left, right) => right.route.length - left.route.length)[0];
+      const commandKind = contract?.route.join(" ")
+        ?? routeTokens.filter((token) => !token.startsWith("--") && !/^<[^>]+>$/u.test(token)).slice(0, 3).join(" ")
+        ?? "unknown";
+      const commandOrdinal = (commandOrdinals.get(commandKind) ?? 0) + 1;
+      commandOrdinals.set(commandKind, commandOrdinal);
+      const findingScope = `${commandKind || "unknown"}#${commandOrdinal}`;
+      if (hasLauncher || contract) addPlaceholderFindings(findings, occurrence, command, findingScope);
+      if (command.includes("...")) continue;
+      if (!contract) {
+        if (hasLauncher && quoted) {
+          findings.push({
+            ...occurrence,
+            command,
+            rule: "unknown-command-path",
+            findingIdentity: `${findingScope}:path`,
+            detail: `copied command path is not registered: ${routeTokens.filter((token) => !token.startsWith("--")).join(" ")}`
+          });
+        }
+        continue;
+      }
+      if (!hasLauncher) {
+        findings.push({
+          ...occurrence,
+          command,
+          rule: "bare-command",
+          findingIdentity: `${findingScope}:launcher`,
+          detail: "copied registered command is missing the ha launcher"
+        });
+      }
+      const suppliedOptions = new Set(tokens.filter((token) => token.startsWith("--")));
+      for (const supplied of suppliedOptions) {
+        if (!contract.options.has(supplied)) {
+          findings.push({
+            ...occurrence,
+            command,
+            rule: "unknown-option",
+            findingIdentity: `${findingScope}:${supplied}`,
+            detail: `copied command uses option ${supplied}, which is not declared for ${contract.route.join(" ")}`
+          });
+        }
+      }
+      if (!suppliedOptions.has("--help")) {
+        for (const required of contract.requiredOptions) {
+          if (suppliedOptions.has(required)) continue;
+          findings.push({
+            ...occurrence,
+            command,
+            rule: "missing-required-option",
+            findingIdentity: `${findingScope}:${required}`,
+            detail: `copied command is missing required option ${required}`
+          });
+        }
+        for (const alternatives of contract.requiredOptionGroups) {
+          if (alternatives.some((branch) => branch.every((option) => suppliedOptions.has(option)))) continue;
+          findings.push({
+            ...occurrence,
+            command,
+            rule: "missing-required-option",
+            findingIdentity: `${findingScope}:group:${alternatives.map((branch) => branch.join(" ")).join("|")}`,
+            detail: `copied command must include one complete required option branch: ${alternatives.map((branch) => branch.join(" ")).join(" | ")}`
+          });
+        }
+      }
+    }
+  }
+  return { contracts, findings: findings.map(withFindingKey) };
+}
+
+export function assessErrorNextStepCommandBaseline(findings, allowedDebtKeys) {
+  const allowed = new Set(allowedDebtKeys);
+  const current = new Set(findings.map((finding) => finding.key));
+  const warnings = findings
+    .filter((finding) => allowed.has(finding.key))
+    .map((finding) => `known debt ${formatFinding(finding)}`);
+  const violations = findings
+    .filter((finding) => !allowed.has(finding.key))
+    .map((finding) => `new finding ${formatFinding(finding)}`);
+  for (const key of allowed) {
+    if (!current.has(key)) violations.push(`stale baseline ${key}: remove the repaid entry`);
+  }
+  return { warnings, violations };
+}
+
+export function assessErrorNextStepCommandBaselineRatchet(currentAllowedKeys, previousAllowedKeys) {
+  const previous = new Set(previousAllowedKeys);
+  return currentAllowedKeys
+    .filter((key) => !previous.has(key))
+    .map((key) => `baseline growth is forbidden; ${key} was not present in the previous baseline`);
+}
+
+function collectCommandContracts(rootDir) {
+  const absoluteRoot = path.join(rootDir, commandSpecRoot);
+  if (!existsSync(absoluteRoot)) return { contracts: [], globalOptions: new Map() };
+  const contracts = [];
+  const globalOptions = new Map();
+  for (const filePath of walkTypeScriptFiles(absoluteRoot)) {
+    const sourceFile = parseSource(filePath);
+    const declarations = variableInitializers(sourceFile);
+    const globalOptionsNode = unwrapExpression(variableInitializer(sourceFile, "globalCommandOptions"));
+    if (globalOptionsNode && ts.isArrayLiteralExpression(globalOptionsNode)) {
+      for (const option of globalOptionsNode.elements.filter(ts.isObjectLiteralExpression)) {
+        const declaration = staticString(propertyInitializer(option, "flag"));
+        if (!declaration) continue;
+        const [flag, operand] = declaration.split(/\s+/u);
+        if (flag) globalOptions.set(flag, operand !== undefined);
+      }
+    }
+    const specialClaimsNode = unwrapExpression(variableInitializer(sourceFile, "specialCommandOptionClaims"));
+    if (specialClaimsNode && ts.isArrayLiteralExpression(specialClaimsNode)) {
+      for (const claimNode of specialClaimsNode.elements) {
+        if (!ts.isCallExpression(claimNode) || !ts.isIdentifier(claimNode.expression) || claimNode.expression.text !== "claim") continue;
+        const routes = evaluateStringMatrix(claimNode.arguments[1]);
+        const options = new Set(evaluateOptionFlags(claimNode.arguments[2], declarations));
+        for (const route of routes) {
+          contracts.push({
+            usage: `special:${route.join(" ")}`,
+            route,
+            options,
+            requiredOptions: [],
+            requiredOptionGroups: []
+          });
+        }
+      }
+    }
+    const visit = (node) => {
+      if (ts.isObjectLiteralExpression(node)) {
+        const usage = staticString(propertyInitializer(node, "usage"));
+        const optionsNode = propertyInitializer(node, "options");
+        if (usage && optionsNode && ts.isArrayLiteralExpression(optionsNode)) {
+          const required = requiredOptionContractFromUsage(usage);
+          const options = optionsNode.elements
+            .filter(ts.isObjectLiteralExpression)
+            .map((option) => staticString(propertyInitializer(option, "flag")))
+            .filter(Boolean)
+            .map((flag) => flag.split(/\s+/u)[0]);
+          contracts.push({
+            usage,
+            route: routeFromUsage(usage),
+            options: new Set(options),
+            requiredOptions: required.options,
+            requiredOptionGroups: required.groups
+          });
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+  }
+  return {
+    globalOptions,
+    contracts: contracts.filter((contract) => contract.route.length > 0).map((contract) => ({
+      ...contract,
+      options: new Set([...contract.options, ...globalOptions.keys()])
+    }))
+  };
+}
+
+function collectErrorHints(rootDir) {
+  const occurrences = [];
+  const absoluteCommandSpecRoot = path.join(rootDir, commandSpecRoot);
+  for (const absoluteRoot of discoverCallerSourceRoots(rootDir)) {
+    for (const filePath of walkTypeScriptFiles(absoluteRoot)) {
+      if (filePath === absoluteCommandSpecRoot || filePath.startsWith(`${absoluteCommandSpecRoot}${path.sep}`)) continue;
+      const sourceFile = parseSource(filePath);
+      const relative = path.relative(rootDir, filePath).split(path.sep).join("/");
+      const addHints = (node, owner, identity) => {
+        for (const hint of staticStrings(node)) {
+          occurrences.push({
+            hint,
+            location: `${relative}:${sourceFile.getLineAndCharacterOfPosition(owner.getStart()).line + 1}`,
+            sourcePath: relative,
+            sourceOffset: owner.getStart(),
+            identity
+          });
+        }
+      };
+      const visit = (node) => {
+        if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "cliError") {
+          addHints(node.arguments[1], node, `call:cliError:${sourceText(node.arguments[0], sourceFile)}`);
+        }
+        if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+          const hintPosition = node.expression.text === "failureReceipt" || node.expression.text === "identityFailure"
+            ? 2
+            : undefined;
+          if (hintPosition !== undefined) {
+            addHints(
+              node.arguments[hintPosition],
+              node,
+              `call:${node.expression.text}:${sourceText(node.arguments[1], sourceFile)}`
+            );
+          }
+        }
+        if (ts.isPropertyAssignment(node)) {
+          const name = propertyNameText(node.name);
+          if (name === "defaultHint" || name === "hint" || name === "nextCommand") {
+            addHints(node.initializer, node, `property:${name}:${propertyOwnerIdentity(node, sourceFile)}`);
+          } else if (name === "message" && ts.isObjectLiteralExpression(node.parent) && objectBoolean(node.parent, "ok") === false) {
+            addHints(node.initializer, node, `property:message:${propertyOwnerIdentity(node, sourceFile)}`);
+          }
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(sourceFile);
+    }
+  }
+  const unique = [...new Map(occurrences.map((occurrence) => [
+    `${occurrence.sourcePath}\u0000${occurrence.sourceOffset}\u0000${occurrence.hint}`,
+    occurrence
+  ])).values()];
+  const ordinals = new Map();
+  return unique.map((occurrence) => {
+    const group = `${occurrence.sourcePath}\u0000${occurrence.identity}`;
+    const ordinal = (ordinals.get(group) ?? 0) + 1;
+    ordinals.set(group, ordinal);
+    return {
+      hint: occurrence.hint,
+      location: occurrence.location,
+      sourceIdentity: `${occurrence.sourcePath}#${occurrence.identity}#${ordinal}`
+    };
+  });
+}
+
+function discoverCallerSourceRoots(rootDir) {
+  const packagesRoot = path.join(rootDir, "packages");
+  if (!existsSync(packagesRoot)) return [];
+  return readdirSync(packagesRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(packagesRoot, entry.name, "src"))
+    .filter(existsSync);
+}
+
+function routeFromUsage(usage) {
+  const route = [];
+  for (const token of tokenize(usage)) {
+    if (/^(?:--|\[|\(|<)/u.test(token)) break;
+    route.push(token);
+  }
+  return route;
+}
+
+function requiredOptionContractFromUsage(usage) {
+  const visible = [...usage];
+  let squareDepth = 0;
+  for (let index = 0; index < visible.length; index += 1) {
+    if (usage[index] === "[") squareDepth += 1;
+    if (squareDepth > 0) visible[index] = " ";
+    if (usage[index] === "]") squareDepth = Math.max(0, squareDepth - 1);
+  }
+
+  const requiredText = visible.join("");
+  const withoutGroups = [...requiredText];
+  const groups = [];
+  for (const match of requiredText.matchAll(/\(([^()]*)\)/gu)) {
+    const branches = match[1]
+      .split("|")
+      .map((branch) => [...new Set(branch.match(/--[a-z][a-z0-9-]*/giu) ?? [])]);
+    if (branches.length > 0 && branches.every((branch) => branch.length > 0)) groups.push(branches);
+    const start = match.index ?? 0;
+    for (let index = start; index < start + match[0].length; index += 1) withoutGroups[index] = " ";
+  }
+  return {
+    options: [...new Set(withoutGroups.join("").match(/--[a-z][a-z0-9-]*/giu) ?? [])],
+    groups
+  };
+}
+
+function extractCommandCandidates(hint) {
+  const commands = [];
+  const quoted = /`([^`\n]+)`/gu;
+  for (const match of hint.matchAll(quoted)) {
+    for (const command of splitCommandChain(match[1])) commands.push({ command, quoted: true });
+  }
+  if (commands.length > 0) return commands;
+  const inline = /\b(?:ha|harness-anything)\s+[^\n.;]+/giu;
+  for (const match of hint.matchAll(inline)) {
+    for (const command of splitCommandChain(match[0])) commands.push({ command, quoted: false });
+  }
+  if (commands.length > 0) return commands;
+  const imperativeBare = /\brun\s+([a-z][^\n.;]+)/giu;
+  for (const match of hint.matchAll(imperativeBare)) {
+    const instruction = match[1].split(/\b(?:after|before|then)\b/iu)[0].trim();
+    for (const command of splitCommandChain(instruction)) commands.push({ command, quoted: false });
+  }
+  return commands;
+}
+
+function splitCommandChain(command) {
+  return command.split(/\s*(?:&&|\|\|)\s*/u).map((part) => part.trim()).filter(Boolean);
+}
+
+function addPlaceholderFindings(findings, occurrence, command, findingScope) {
+  const placeholders = [...command.matchAll(/<[^>\n]+>/gu)].map((match) => ({
+    text: match[0],
+    offset: match.index ?? 0
+  }));
+  const ellipsisOffset = command.indexOf("...");
+  if (ellipsisOffset >= 0) placeholders.push({ text: "...", offset: ellipsisOffset });
+  const ordinals = new Map();
+  for (const placeholder of placeholders) {
+    if (placeholder.text === "<context>") continue;
+    const ordinal = (ordinals.get(placeholder.text) ?? 0) + 1;
+    ordinals.set(placeholder.text, ordinal);
+    findings.push({
+      ...occurrence,
+      command,
+      rule: "unresolved-placeholder",
+      findingIdentity: `${findingScope}:${placeholder.text}#${ordinal}`,
+      detail: `copied command contains unresolved placeholder ${placeholder.text} at character ${placeholder.offset + 1}`
+    });
+  }
+}
+
+function tokenize(text) {
+  return (text.match(/"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\S+/gu) ?? [])
+    .map((token) => token.replace(/^['"]|['"]$/gu, "").replace(/[,'".:;]+$/gu, ""));
+}
+
+function staticStrings(node) {
+  if (!node) return [];
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return [node.text];
+  if (ts.isTemplateExpression(node)) {
+    return [node.head.text + node.templateSpans.map((span) => `<context>${span.literal.text}`).join("")];
+  }
+  if (ts.isConditionalExpression(node)) return [...staticStrings(node.whenTrue), ...staticStrings(node.whenFalse)];
+  if (ts.isParenthesizedExpression(node)) return staticStrings(node.expression);
+  if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+    const left = staticStrings(node.left);
+    const right = staticStrings(node.right);
+    if (left.length > 0 && right.length > 0) return left.flatMap((a) => right.map((b) => a + b));
+  }
+  return [];
+}
+
+function staticString(node) {
+  return staticStrings(node)[0];
+}
+
+function propertyInitializer(object, name) {
+  const property = object.properties.find((candidate) =>
+    ts.isPropertyAssignment(candidate) && propertyNameText(candidate.name) === name
+  );
+  return property?.initializer;
+}
+
+function objectBoolean(object, name) {
+  const value = propertyInitializer(object, name);
+  if (value?.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (value?.kind === ts.SyntaxKind.FalseKeyword) return false;
+  return undefined;
+}
+
+function propertyOwnerIdentity(property, sourceFile) {
+  const object = ts.isObjectLiteralExpression(property.parent) ? property.parent : undefined;
+  const code = object ? propertyInitializer(object, "code") : undefined;
+  if (code) return `code:${sourceText(code, sourceFile)}`;
+  if (object && ts.isPropertyAssignment(object.parent)) {
+    return `entry:${sourceText(object.parent.name, sourceFile)}`;
+  }
+  for (let current = property.parent; current; current = current.parent) {
+    if (ts.isFunctionDeclaration(current) && current.name) return `function:${current.name.text}`;
+    if (ts.isMethodDeclaration(current)) return `method:${sourceText(current.name, sourceFile)}`;
+    if (ts.isVariableDeclaration(current) && ts.isIdentifier(current.name)) return `variable:${current.name.text}`;
+  }
+  return "module";
+}
+
+function sourceText(node, sourceFile) {
+  return node ? node.getText(sourceFile).replace(/\s+/gu, " ").trim() : "unknown";
+}
+
+function propertyNameText(name) {
+  return ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)
+    ? name.text
+    : undefined;
+}
+
+function variableInitializer(sourceFile, name) {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (ts.isIdentifier(declaration.name) && declaration.name.text === name) return declaration.initializer;
+    }
+  }
+  return undefined;
+}
+
+function variableInitializers(sourceFile) {
+  const declarations = new Map();
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (ts.isIdentifier(declaration.name) && declaration.initializer) {
+        declarations.set(declaration.name.text, declaration.initializer);
+      }
+    }
+  }
+  return declarations;
+}
+
+function evaluateStringMatrix(node) {
+  const value = unwrapExpression(node);
+  if (!value || !ts.isArrayLiteralExpression(value)) return [];
+  return value.elements
+    .map((row) => {
+      const array = unwrapExpression(row);
+      if (!array || !ts.isArrayLiteralExpression(array)) return [];
+      return array.elements.map(staticString).filter(Boolean);
+    })
+    .filter((row) => row.length > 0);
+}
+
+function evaluateOptionFlags(node, declarations, seen = new Set()) {
+  const value = unwrapExpression(node);
+  if (!value) return [];
+  if (ts.isIdentifier(value)) {
+    if (seen.has(value.text)) return [];
+    const initializer = declarations.get(value.text);
+    if (!initializer) return [];
+    return evaluateOptionFlags(initializer, declarations, new Set([...seen, value.text]));
+  }
+  if (ts.isArrayLiteralExpression(value)) {
+    return value.elements.flatMap((element) => {
+      if (!ts.isObjectLiteralExpression(element)) return [];
+      const flag = staticString(propertyInitializer(element, "flag"));
+      return flag ? [flag.split(/\s+/u)[0]] : [];
+    });
+  }
+  if (ts.isCallExpression(value) && ts.isIdentifier(value.expression)) {
+    if (value.expression.text === "options") return value.arguments.map(staticString).filter(Boolean);
+    if (value.expression.text === "mergeOptions") {
+      return [...new Set(value.arguments.flatMap((argument) => evaluateOptionFlags(argument, declarations, seen)))];
+    }
+  }
+  return [];
+}
+
+function unwrapExpression(node) {
+  let current = node;
+  while (current && (
+    ts.isAsExpression(current)
+    || ts.isSatisfiesExpression(current)
+    || ts.isParenthesizedExpression(current)
+  )) current = current.expression;
+  return current;
+}
+
+function parseSource(filePath) {
+  return ts.createSourceFile(filePath, readFileSync(filePath, "utf8"), ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
+
+function walkTypeScriptFiles(rootDir) {
+  const files = [];
+  for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
+    const absolute = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) files.push(...walkTypeScriptFiles(absolute));
+    else if (entry.isFile() && /\.tsx?$/u.test(entry.name) && !/\.(?:test|spec)\.tsx?$/u.test(entry.name)) files.push(absolute);
+  }
+  return files;
+}
+
+function withFindingKey(finding) {
+  const digest = createHash("sha256")
+    .update(JSON.stringify({
+      sourceIdentity: finding.sourceIdentity,
+      rule: finding.rule,
+      findingIdentity: finding.findingIdentity
+    }))
+    .digest("hex")
+    .slice(0, 16);
+  return { ...finding, key: `${finding.sourceIdentity}#${finding.rule}#${digest}` };
+}
+
+function formatFinding(finding) {
+  return `${finding.key} ${finding.detail}: ${finding.command}`;
+}
+
+function previousBaselineKeys() {
+  try {
+    const raw = execFileSync("git", [
+      "show",
+      "HEAD^:tools/gate-allowlists/check-error-next-step-commands.json"
+    ], {
+      cwd: repositoryRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+    const parsed = JSON.parse(raw);
+    return entryValues(parsed.entries?.knownDebt ?? []);
+  } catch {
+    return null;
+  }
+}
+
+function isMain() {
+  return process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+}
+
+if (isMain()) {
+  const fixtureIndex = process.argv.indexOf("--fixture");
+  if (fixtureIndex >= 0) {
+    const fixtureName = process.argv[fixtureIndex + 1] ?? "";
+    if (!/^[a-z0-9-]+$/u.test(fixtureName)) throw new Error(`${gateId}: invalid fixture name`);
+    const selectedFixture = path.join(fixtureRoot, fixtureName);
+    if (!existsSync(selectedFixture)) throw new Error(`${gateId}: unknown fixture ${fixtureName}`);
+    const result = inspectErrorNextStepCommands(selectedFixture);
+    for (const finding of result.findings) console.error(`ERROR ${formatFinding(finding)}`);
+    if (result.findings.length > 0) {
+      console.error(`${gateId}: fixture ${fixtureName} failed with ${result.findings.length} finding(s)`);
+      process.exitCode = 1;
+    } else {
+      console.log(`${gateId}: fixture ${fixtureName} passed`);
+    }
+  } else {
+    const result = inspectErrorNextStepCommands();
+    const entries = loadGateAllowlist(gateId, {
+      requiredSections: ["knownDebt"],
+      ratchetSections: ["knownDebt"]
+    });
+    const allowedDebtKeys = entryValues(entries.knownDebt);
+    const assessed = assessErrorNextStepCommandBaseline(result.findings, allowedDebtKeys);
+    const previous = previousBaselineKeys();
+    if (previous !== null) {
+      assessed.violations.push(...assessErrorNextStepCommandBaselineRatchet(allowedDebtKeys, previous));
+    }
+    for (const warning of assessed.warnings) console.warn(`BASELINE ${warning}`);
+    for (const violation of assessed.violations) console.error(`ERROR ${violation}`);
+    if (assessed.violations.length > 0) {
+      console.error(`${gateId}: failed with ${assessed.violations.length} violation(s)`);
+      process.exitCode = 1;
+    } else {
+      console.log(`${gateId}: passed (${result.contracts.length} command contracts; ${result.findings.length} baseline finding(s))`);
+    }
+  }
+}

--- a/tools/check-error-next-step-commands.test.mjs
+++ b/tools/check-error-next-step-commands.test.mjs
@@ -1,0 +1,406 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  assessErrorNextStepCommandBaselineRatchet,
+  assessErrorNextStepCommandBaseline,
+  inspectErrorNextStepCommands
+} from "./check-error-next-step-commands.mjs";
+
+test("rejects a copied command that omits an obviously required option", () => {
+  withFixture((rootDir) => {
+    writeCommandSpec(rootDir);
+    write(rootDir, "packages/cli/src/commands/review.ts", `
+      cliError("review_failed", "Review failed. Run \`ha task review-execution task_1 --verdict changes_requested --findings evidence_missing\`.");
+    `);
+
+    const result = inspectErrorNextStepCommands(rootDir);
+    assert.equal(result.findings.some((finding) =>
+      finding.rule === "missing-required-option"
+      && finding.detail.includes("--rationale")
+    ), true);
+  });
+});
+
+test("rejects an unresolved angle-bracket placeholder in a copied command", () => {
+  withFixture((rootDir) => {
+    writeCommandSpec(rootDir);
+    write(rootDir, "packages/cli/src/commands/review.ts", `
+      cliError("review_failed", "Review failed. Run \`ha task review-execution <task-id> --verdict changes_requested --findings evidence_missing --rationale missing_evidence\`.");
+    `);
+
+    const result = inspectErrorNextStepCommands(rootDir);
+    assert.equal(result.findings.some((finding) =>
+      finding.rule === "unresolved-placeholder"
+      && finding.detail.includes("<task-id>")
+    ), true);
+  });
+});
+
+test("rejects a bare registered command without the ha launcher", () => {
+  withFixture((rootDir) => {
+    writeCommandSpec(rootDir);
+    write(rootDir, "packages/cli/src/commands/review.ts", `
+      cliError("review_failed", "Review failed. Run \`task review-execution task_1 --verdict changes_requested --findings evidence_missing --rationale missing_evidence\`.");
+    `);
+
+    const result = inspectErrorNextStepCommands(rootDir);
+    assert.equal(result.findings.some((finding) => finding.rule === "bare-command"), true);
+  });
+});
+
+test("rejects an unknown ha command path", () => {
+  withFixture((rootDir) => {
+    writeCommandSpec(rootDir);
+    write(rootDir, "packages/cli/src/commands/review.ts", `
+      cliError("review_failed", "Review failed. Run \`ha task review-dance task_1\`.");
+    `);
+
+    const result = inspectErrorNextStepCommands(rootDir);
+    assert.equal(result.findings.some((finding) => finding.rule === "unknown-command-path"), true);
+  });
+});
+
+test("rejects an option that is not declared for the matched command", () => {
+  withFixture((rootDir) => {
+    writeCommandSpec(rootDir);
+    write(rootDir, "packages/cli/src/commands/review.ts", `
+      cliError("review_failed", "Review failed. Run \`ha task review-execution task_1 --verdict changes_requested --findings evidence_missing --rationale missing_evidence --magic\`.");
+    `);
+
+    const result = inspectErrorNextStepCommands(rootDir);
+    assert.equal(result.findings.some((finding) =>
+      finding.rule === "unknown-option"
+      && finding.detail.includes("--magic")
+    ), true);
+  });
+});
+
+test("accepts one complete branch of a required option alternative", () => {
+  withFixture((rootDir) => {
+    write(rootDir, "packages/cli/src/cli/command-spec/task-complete.ts", `
+      export const taskCompleteCommandSpec = {
+        kind: "task-complete",
+        usage: "task complete <id> (--approve --from-file <approval.json> | --commit-anchor <anchor> --judgment <reason>) [--dry-run]",
+        options: [
+          { flag: "--approve" },
+          { flag: "--from-file <approval.json>" },
+          { flag: "--commit-anchor <anchor>" },
+          { flag: "--judgment <reason>" },
+          { flag: "--dry-run" }
+        ]
+      };
+    `);
+    write(rootDir, "packages/cli/src/commands/complete.ts", `
+      cliError("completion_blocked", "Completion is blocked. Run \`ha task complete task_1 --approve --from-file approval.json\` after addressing the failure.");
+    `);
+
+    const result = inspectErrorNextStepCommands(rootDir);
+    assert.equal(result.findings.some((finding) => finding.rule === "missing-required-option"), false);
+  });
+});
+
+test("accepts a globally declared option on a registered command", () => {
+  withFixture((rootDir) => {
+    writeCommandSpec(rootDir);
+    write(rootDir, "packages/cli/src/cli/command-spec/command-groups.ts", `
+      export const globalCommandOptions = [{ flag: "--json" }] as const;
+    `);
+    write(rootDir, "packages/cli/src/commands/review.ts", `
+      cliError("review_failed", "Review failed. Run \`ha task review-execution task_1 --verdict changes_requested --findings evidence_missing --rationale missing_evidence --json\`.");
+    `);
+
+    const result = inspectErrorNextStepCommands(rootDir);
+    assert.equal(result.findings.some((finding) => finding.rule === "unknown-option"), false);
+  });
+});
+
+test("does not treat natural-language ha words as an unknown command", () => {
+  withFixture((rootDir) => {
+    writeCommandSpec(rootDir);
+    write(rootDir, "packages/cli/src/commands/review.ts", `
+      cliError("review_failed", "Choose one ha command so every lifecycle gate enters admission independently.");
+    `);
+
+    const result = inspectErrorNextStepCommands(rootDir);
+    assert.equal(result.findings.some((finding) => finding.rule === "unknown-command-path"), false);
+  });
+});
+
+test("accepts a command and option declared by special command claims", () => {
+  withFixture((rootDir) => {
+    writeCommandSpec(rootDir);
+    write(rootDir, "packages/cli/src/cli/command-spec/special-command-option-claims.ts", `
+      export const specialCommandOptionClaims = [
+        claim("daemon-status", [["daemon", "status"]], options("--check"))
+      ];
+    `);
+    write(rootDir, "packages/cli/src/commands/daemon.ts", `
+      cliError("daemon_failed", "Inspect it with \`ha daemon status --check\`.");
+    `);
+
+    const result = inspectErrorNextStepCommands(rootDir);
+    assert.equal(result.findings.some((finding) =>
+      finding.rule === "unknown-command-path" || finding.rule === "unknown-option"
+    ), false);
+  });
+});
+
+test("scans registry defaultHint command text", () => {
+  withFixture((rootDir) => {
+    writeCommandSpec(rootDir);
+    write(rootDir, "packages/cli/src/cli/error-codes.ts", `
+      export const cliErrorCodeRegistry = {
+        review_failed: {
+          defaultHint: "Review failed. Run \`ha task review-execution <task-id> --verdict changes_requested --findings evidence_missing --rationale missing_evidence\`."
+        }
+      };
+    `);
+
+    const result = inspectErrorNextStepCommands(rootDir);
+    assert.equal(result.findings.some((finding) => finding.rule === "unresolved-placeholder"), true);
+  });
+});
+
+test("does not require execution options when the copied command requests help", () => {
+  withFixture((rootDir) => {
+    writeCommandSpec(rootDir);
+    write(rootDir, "packages/cli/src/commands/review.ts", `
+      cliError("review_failed", "Review failed. Run \`ha task review-execution --help\` and choose the correct inputs.");
+    `);
+
+    const result = inspectErrorNextStepCommands(rootDir);
+    assert.equal(result.findings.some((finding) => finding.rule === "missing-required-option"), false);
+  });
+});
+
+test("does not require option branches when a required group permits a positional operand", () => {
+  withFixture((rootDir) => {
+    write(rootDir, "packages/cli/src/cli/command-spec/task-archive.ts", `
+      export const taskArchiveCommandSpec = {
+        kind: "task-archive",
+        usage: "task archive (<id> | --ids <id,id> | --filter state:<state>) --reason <reason>",
+        options: [
+          { flag: "--ids <id,id>" },
+          { flag: "--filter state:<state>" },
+          { flag: "--reason <reason>" }
+        ]
+      };
+    `);
+    write(rootDir, "packages/cli/src/commands/archive.ts", `
+      cliError("archive_blocked", "Archive the task with \`ha task archive task_1 --reason obsolete\`.");
+    `);
+
+    const result = inspectErrorNextStepCommands(rootDir);
+    assert.equal(result.findings.some((finding) => finding.rule === "missing-required-option"), false);
+  });
+});
+
+test("baseline is exact: new and stale findings fail while current debt only warns", () => {
+  withFixture((rootDir) => {
+    writeCommandSpec(rootDir);
+    write(rootDir, "packages/cli/src/commands/review.ts", `
+      cliError("review_failed", "Review failed. Run \`ha task review-execution task_1 --verdict changes_requested --findings evidence_missing\`.");
+    `);
+    const { findings } = inspectErrorNextStepCommands(rootDir);
+    const key = findings[0].key;
+
+    assert.deepEqual(assessErrorNextStepCommandBaseline(findings, [key]).violations, []);
+    assert.equal(assessErrorNextStepCommandBaseline(findings, []).violations[0].includes("new finding"), true);
+    assert.equal(assessErrorNextStepCommandBaseline([], [key]).violations[0].includes("stale baseline"), true);
+  });
+});
+
+test("bundled mutation fixtures prove two bad hints red and one good hint green", () => {
+  const missing = runFixture("missing-required-option");
+  assert.equal(missing.status, 1);
+  assert.match(missing.stderr, /missing-required-option.*--rationale/u);
+
+  const placeholder = runFixture("unresolved-placeholder");
+  assert.equal(placeholder.status, 1);
+  assert.match(placeholder.stderr, /unresolved-placeholder.*<task-id>/u);
+
+  const good = runFixture("good");
+  assert.equal(good.status, 0, good.stderr);
+  assert.match(good.stdout, /passed/u);
+});
+
+test("resolves a registered route after a value-taking global option", () => {
+  withFixture((rootDir) => {
+    writeCommandSpec(rootDir);
+    write(rootDir, "packages/cli/src/cli/command-spec/command-groups.ts", `
+      export const globalCommandOptions = [{ flag: "--root DIR" }] as const;
+    `);
+    write(rootDir, "packages/cli/src/cli/command-spec/special-command-option-claims.ts", `
+      export const specialCommandOptionClaims = [
+        claim("daemon-connect", [["daemon", "connect"]], options("--stdio"))
+      ];
+    `);
+    write(rootDir, "packages/cli/src/commands/daemon.ts", `
+      cliError("daemon_failed", "Reconnect with \`ha --root /tmp/repo daemon connect --stdio\`.");
+    `);
+
+    const result = inspectErrorNextStepCommands(rootDir);
+    assert.equal(result.findings.some((finding) => finding.rule === "unknown-command-path"), false);
+  });
+});
+
+test("validates each command in a chained copied next step independently", () => {
+  withFixture((rootDir) => {
+    writeCommandSpec(rootDir);
+    write(rootDir, "packages/cli/src/cli/command-spec/special-command-option-claims.ts", `
+      export const specialCommandOptionClaims = [
+        claim("daemon-stop", [["daemon", "stop"]], []),
+        claim("daemon-start", [["daemon", "start"]], options("--service"))
+      ];
+    `);
+    write(rootDir, "packages/cli/src/commands/daemon.ts", `
+      cliError("daemon_failed", "Restart with \`ha daemon stop && ha daemon start --service\`.");
+    `);
+
+    const result = inspectErrorNextStepCommands(rootDir);
+    assert.deepEqual(result.findings, []);
+  });
+});
+
+test("rejects a placeholder even when the copied ha route is unknown", () => {
+  withFixture((rootDir) => {
+    writeCommandSpec(rootDir);
+    write(rootDir, "packages/cli/src/commands/review.ts", `
+      cliError("review_failed", "Review failed. Run \`ha task review-dance <task-id>\`.");
+    `);
+
+    const result = inspectErrorNextStepCommands(rootDir);
+    assert.equal(result.findings.some((finding) => finding.rule === "unresolved-placeholder"), true);
+  });
+});
+
+test("assigns distinct baseline keys to repeated placeholder occurrences", () => {
+  withFixture((rootDir) => {
+    writeCommandSpec(rootDir);
+    write(rootDir, "packages/cli/src/commands/review.ts", `
+      cliError("review_failed", "Review failed. Run \`ha task review-execution <id> --verdict <id> --findings evidence_missing --rationale missing_evidence\`.");
+    `);
+
+    const findings = inspectErrorNextStepCommands(rootDir).findings
+      .filter((finding) => finding.rule === "unresolved-placeholder");
+    assert.equal(new Set(findings.map((finding) => finding.key)).size, 2);
+  });
+});
+
+test("baseline ratchet permits only a subset of the previous finding keys", () => {
+  assert.deepEqual(
+    assessErrorNextStepCommandBaselineRatchet(["finding-a"], ["finding-a", "finding-b"]),
+    []
+  );
+  assert.equal(
+    assessErrorNextStepCommandBaselineRatchet(["finding-a", "finding-c"], ["finding-a", "finding-b"])[0]
+      .includes("finding-c"),
+    true
+  );
+});
+
+test("baseline identity is stable when unrelated lines move an unchanged hint", () => {
+  withFixture((rootDir) => {
+    writeCommandSpec(rootDir);
+    const errorPath = "packages/cli/src/commands/review.ts";
+    const hint = `cliError("review_failed", "Review failed. Run \`ha task review-execution <id> --verdict changes_requested --findings evidence_missing --rationale missing_evidence\`.");`;
+    write(rootDir, errorPath, hint);
+    const before = inspectErrorNextStepCommands(rootDir).findings[0].key;
+
+    write(rootDir, errorPath, `\n\n${hint}`);
+    const after = inspectErrorNextStepCommands(rootDir).findings[0].key;
+    assert.equal(after, before);
+  });
+});
+
+test("repairing one placeholder preserves the baseline identity of another", () => {
+  withFixture((rootDir) => {
+    writeCommandSpec(rootDir);
+    const errorPath = "packages/cli/src/commands/review.ts";
+    write(rootDir, errorPath, `
+      cliError("review_failed", "Run \`ha task review-execution <task-id> --verdict changes_requested --findings <findings> --rationale evidence_missing\`.");
+    `);
+    const before = inspectErrorNextStepCommands(rootDir).findings
+      .find((finding) => finding.findingIdentity.includes(":<findings>#"))?.key;
+    assert.notEqual(before, undefined);
+
+    write(rootDir, errorPath, `
+      cliError("review_failed", "Run \`ha task review-execution task_1 --verdict changes_requested --findings <findings> --rationale evidence_missing\`.");
+    `);
+    const after = inspectErrorNextStepCommands(rootDir).findings
+      .find((finding) => finding.findingIdentity.includes(":<findings>#"))?.key;
+    assert.notEqual(after, undefined);
+    assert.equal(after, before);
+  });
+});
+
+test("rejects an unquoted bare command introduced as a Run instruction", () => {
+  withFixture((rootDir) => {
+    writeCommandSpec(rootDir);
+    write(rootDir, "packages/cli/src/commands/review.ts", `
+      cliError("review_failed", "Review failed. Run task review-execution task_1 --verdict changes_requested --findings evidence_missing --rationale missing_evidence before retrying.");
+    `);
+
+    const result = inspectErrorNextStepCommands(rootDir);
+    assert.equal(result.findings.some((finding) => finding.rule === "bare-command"), true);
+  });
+});
+
+test("discovers caller-facing hint sinks in every top-level package src tree", () => {
+  withFixture((rootDir) => {
+    writeCommandSpec(rootDir);
+    write(rootDir, "packages/vscode-ext/src/routing/error.ts", `
+      export const failure = {
+        hint: "Workspace routing failed. Run \`ha task review-execution <task-id> --verdict changes_requested --findings evidence_missing --rationale missing_evidence\`."
+      };
+    `);
+
+    const result = inspectErrorNextStepCommands(rootDir);
+    assert.equal(result.findings.some((finding) =>
+      finding.location.startsWith("packages/vscode-ext/src/")
+      && finding.rule === "unresolved-placeholder"
+    ), true);
+  });
+});
+
+function writeCommandSpec(rootDir) {
+  write(rootDir, "packages/cli/src/cli/command-spec/task-review-execution.ts", `
+    export const taskReviewExecutionCommandSpec = {
+      kind: "task-review-execution",
+      usage: "task review-execution <id> --verdict <verdict> --findings <text> --rationale <text>",
+      options: [
+        { flag: "--verdict <verdict>" },
+        { flag: "--findings <text>" },
+        { flag: "--rationale <text>" }
+      ]
+    };
+  `);
+}
+
+function withFixture(fn) {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-error-next-step-commands-"));
+  try {
+    fn(rootDir);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function write(rootDir, relativePath, body) {
+  const filePath = path.join(rootDir, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, body);
+}
+
+function runFixture(name) {
+  return spawnSync(process.execPath, [
+    path.join(process.cwd(), "tools/check-error-next-step-commands.mjs"),
+    "--fixture",
+    name
+  ], { cwd: process.cwd(), encoding: "utf8" });
+}

--- a/tools/fixtures/check-error-next-step-commands/good/packages/cli/src/cli/command-spec/task-review-execution.ts
+++ b/tools/fixtures/check-error-next-step-commands/good/packages/cli/src/cli/command-spec/task-review-execution.ts
@@ -1,0 +1,9 @@
+export const taskReviewExecutionCommandSpec = {
+  kind: "task-review-execution",
+  usage: "task review-execution <id> --verdict <verdict> --findings <text> --rationale <text>",
+  options: [
+    { flag: "--verdict <verdict>" },
+    { flag: "--findings <text>" },
+    { flag: "--rationale <text>" }
+  ]
+};

--- a/tools/fixtures/check-error-next-step-commands/good/packages/cli/src/commands/review.ts
+++ b/tools/fixtures/check-error-next-step-commands/good/packages/cli/src/commands/review.ts
@@ -1,0 +1,4 @@
+cliError(
+  "review_failed",
+  "Review failed. Run `ha task review-execution task_1 --verdict changes_requested --findings evidence_missing --rationale missing_evidence`."
+);

--- a/tools/fixtures/check-error-next-step-commands/missing-required-option/packages/cli/src/cli/command-spec/task-review-execution.ts
+++ b/tools/fixtures/check-error-next-step-commands/missing-required-option/packages/cli/src/cli/command-spec/task-review-execution.ts
@@ -1,0 +1,9 @@
+export const taskReviewExecutionCommandSpec = {
+  kind: "task-review-execution",
+  usage: "task review-execution <id> --verdict <verdict> --findings <text> --rationale <text>",
+  options: [
+    { flag: "--verdict <verdict>" },
+    { flag: "--findings <text>" },
+    { flag: "--rationale <text>" }
+  ]
+};

--- a/tools/fixtures/check-error-next-step-commands/missing-required-option/packages/cli/src/commands/review.ts
+++ b/tools/fixtures/check-error-next-step-commands/missing-required-option/packages/cli/src/commands/review.ts
@@ -1,0 +1,4 @@
+cliError(
+  "review_failed",
+  "Review failed. Run `ha task review-execution task_1 --verdict changes_requested --findings evidence_missing`."
+);

--- a/tools/fixtures/check-error-next-step-commands/unresolved-placeholder/packages/cli/src/cli/command-spec/task-review-execution.ts
+++ b/tools/fixtures/check-error-next-step-commands/unresolved-placeholder/packages/cli/src/cli/command-spec/task-review-execution.ts
@@ -1,0 +1,9 @@
+export const taskReviewExecutionCommandSpec = {
+  kind: "task-review-execution",
+  usage: "task review-execution <id> --verdict <verdict> --findings <text> --rationale <text>",
+  options: [
+    { flag: "--verdict <verdict>" },
+    { flag: "--findings <text>" },
+    { flag: "--rationale <text>" }
+  ]
+};

--- a/tools/fixtures/check-error-next-step-commands/unresolved-placeholder/packages/cli/src/commands/review.ts
+++ b/tools/fixtures/check-error-next-step-commands/unresolved-placeholder/packages/cli/src/commands/review.ts
@@ -1,0 +1,4 @@
+cliError(
+  "review_failed",
+  "Review failed. Run `ha task review-execution <task-id> --verdict changes_requested --findings evidence_missing --rationale missing_evidence`."
+);

--- a/tools/gate-allowlists/check-error-next-step-commands.json
+++ b/tools/gate-allowlists/check-error-next-step-commands.json
@@ -1,0 +1,688 @@
+{
+  "schema": "harness-anything/gate-allowlist/v1",
+  "gateId": "check-error-next-step-commands",
+  "entries": {
+    "knownDebt": [
+      {
+        "value": "packages/application/src/execution-completion-service.ts#property:nextCommand:code:\"execution_review_required\"#1#unresolved-placeholder#2d4930206b6c0293",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task review-execution <context> --execution-id <context> --verdict approved --findings \"<what was verified>\" --rationale \"<why the evidence satisfies the task>\" --consent-utterance \"<the human's exact words>\""
+      },
+      {
+        "value": "packages/application/src/execution-completion-service.ts#property:nextCommand:code:\"execution_review_required\"#1#unresolved-placeholder#b02f7315eded7396",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task review-execution <context> --execution-id <context> --verdict approved --findings \"<what was verified>\" --rationale \"<why the evidence satisfies the task>\" --consent-utterance \"<the human's exact words>\""
+      },
+      {
+        "value": "packages/application/src/execution-completion-service.ts#property:nextCommand:code:\"execution_review_required\"#1#unresolved-placeholder#efa683ef48a8c266",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task review-execution <context> --execution-id <context> --verdict approved --findings \"<what was verified>\" --rationale \"<why the evidence satisfies the task>\" --consent-utterance \"<the human's exact words>\""
+      },
+      {
+        "value": "packages/application/src/local-controller-service.ts#property:hint:code:\"unsupported_in_kr09\"#1#unresolved-placeholder#851a3c9d81c03f55",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task archive <task-id> --reason <reason>"
+      },
+      {
+        "value": "packages/application/src/local-controller-service.ts#property:hint:code:\"unsupported_in_kr09\"#1#unresolved-placeholder#d5d57e10e0d607f1",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task archive <task-id> --reason <reason>"
+      },
+      {
+        "value": "packages/application/src/task-lifecycle-orchestrator-helpers.ts#property:hint:code:\"review_schema_invalid\"#1#unresolved-placeholder#371cb43ebf1c1138",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task complete <task-id> --approve --from-file approval.json"
+      },
+      {
+        "value": "packages/application/src/task-lifecycle-orchestrator-helpers.ts#property:hint:code:\"review_schema_invalid\"#2#unresolved-placeholder#a53236909994c977",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task review <task-id>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.ArchivedHardDeleteForbidden]#1#unresolved-placeholder#0be86171cea2ef2f",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task supersede <task-id> --title <follow-up-title>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.ArchivedHardDeleteForbidden]#1#unresolved-placeholder#2cb28f701b2d7240",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task supersede <task-id> --title <follow-up-title>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.ArchivedHardDeleteForbidden]#1#unresolved-placeholder#877296284a80d619",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task show <task-id> --view trace"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.ArchiveReferenceUnresolved]#1#unresolved-placeholder#bfcac36f23523004",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha relation list --entity task/<task-id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.ArtifactReadFailed]#1#unresolved-placeholder#ef1ba9eb26b6e2a9",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task show <task-id> --view trace"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.ConflictingMigrationMode]#1#unknown-command-path#a567b606dbdcfa1a",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unknown-command-path; ha migrate --help"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.CustomVerticalContractMissing]#1#unresolved-placeholder#95ee50aed7411fbf",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha vertical validate <path> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.CustomVerticalUserDevModeRequired]#1#unresolved-placeholder#4f843ee2f07c3dbf",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha vertical validate <path> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.DaemonGenerationFenced]#1#unknown-option#48ef014709a02467",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unknown-option; ha daemon status --json --include-generation-axes"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.DaemonRequestOutcomeUnknown]#1#unresolved-placeholder#6bee0f2bde3e9450",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task show <task-id>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.DecisionBodyFileReadFailed]#1#unresolved-placeholder#65dff7ce5bdd8c76",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha decision ... --body-file <path>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.DecisionBodyFileReadFailed]#1#unresolved-placeholder#e517769ae8ab3fdc",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha decision ... --body-file <path>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.DecisionWriteRejected]#1#unresolved-placeholder#883c7780eff409a6",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha decision ..."
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.DuplicateAdoptClaim]#1#unresolved-placeholder#7378fcccb5fabfd0",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task show <task-id> --view trace"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.DuplicateExternalBinding]#1#unresolved-placeholder#a22f67a8a18f4adb",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha external snapshot <github|multica> <ref> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.DuplicateExternalBinding]#1#unresolved-placeholder#c3fb3270be69f83d",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha external snapshot <github|multica> <ref> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.EngineOwnsStatus]#1#unresolved-placeholder#4baf206136448548",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task show <task-id> --view trace"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.FullCutoverRetired]#1#missing-required-option#854f2f63879075a0",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: missing-required-option; ha task create --from-legacy <legacy-id>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.FullCutoverRetired]#1#unresolved-placeholder#0a69b62561352dc4",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task create --from-legacy <legacy-id>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.GeneratedTaskIdRequired]#1#unresolved-placeholder#cda24d6e0bca169b",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task create --title <title>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.HarnessRootUnresolved]#1#unknown-command-path#c15e896030910d5b",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unknown-command-path; ha --root <canonical-root>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.HarnessRootUnresolved]#1#unresolved-placeholder#23fbdfbc3b28092f",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha --root <canonical-root>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.InvalidDecisionActor]#1#unresolved-placeholder#88234786a8ad7444",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha decision ..."
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.InvalidDecisionAmendPatch]#1#unresolved-placeholder#f225a587b24765a6",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha decision amend <decision-id> --help"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.InvalidDecisionEvidenceRelation]#1#unresolved-placeholder#69f3d0d54b7c1c36",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha decision propose ..."
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.InvalidDecisionTier]#1#unresolved-placeholder#4556992f31eab108",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha decision ..."
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.InvalidEntrypoint]#1#unresolved-placeholder#48aa2815219c3276",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha preset inspect <id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.InvalidFactId]#1#unresolved-placeholder#73bdca1485e8a6b3",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha fact list --task <task-id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.InvalidSession]#1#unresolved-placeholder#7429c30627e3669e",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha session show <session-id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.InvalidStatus]#1#unresolved-placeholder#1fdb1a617f107280",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task show <task-id>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.InvalidTransition]#1#unresolved-placeholder#5f4b42f6fdec2642",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task show <task-id>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.LegacyCollisionReportInvalid]#1#unresolved-placeholder#85306d626b649f21",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha legacy index <source-path> --apply"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.LegacyDuplicateTarget]#1#unresolved-placeholder#8fb058b6bbe5a6ca",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha legacy index <source-path> --apply"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.LegacyEntryNotFound]#1#missing-required-option#16f4780391638e2b",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: missing-required-option; ha task create --from-legacy <legacy-id>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.LegacyEntryNotFound]#1#unresolved-placeholder#b414d6fbf74fe0ed",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task create --from-legacy <legacy-id>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.LegacyIndexInvalid]#1#unresolved-placeholder#cd6054ec0dcdf1d0",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha legacy index <source-path> --apply"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.LegacyIndexMissing]#1#unresolved-placeholder#2596ef04e5603a5c",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha legacy index <source-path> --apply"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.LegacyIndexSchemaInvalid]#1#unresolved-placeholder#a124bd91a5aa2d3f",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha legacy index <source-path> --apply"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.LegacyRebuildManualIdForbidden]#1#missing-required-option#3351eddfee7652a1",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: missing-required-option; ha task create --from-legacy <legacy-id>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.LegacyRebuildManualIdForbidden]#1#unresolved-placeholder#9b61338bdeb81e9d",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task create --from-legacy <legacy-id>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.LegacyRebuildPresetForbidden]#1#missing-required-option#5c36a9e5f6820155",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: missing-required-option; ha task create --from-legacy <legacy-id>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.LegacyRebuildPresetForbidden]#1#unresolved-placeholder#e2ffae77b0dbb16f",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task create --from-legacy <legacy-id>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.LegacyUnsafeSource]#1#unresolved-placeholder#7a59bd1c3c13f2c4",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha legacy index <source-path> --apply"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.MalformedSnapshot]#1#unresolved-placeholder#74f14b3c4851e238",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha external snapshot <github|multica> <ref> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.MalformedSnapshot]#1#unresolved-placeholder#7c1e9d1907b745d1",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha external snapshot <github|multica> <ref> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.ManualTaskIdForbidden]#1#unresolved-placeholder#1a7db204404c6858",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task create --title <title>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.MissingDecisionChoice]#1#unresolved-placeholder#0dad3443e36f5d19",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha decision propose ..."
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.MissingDecisionQuestion]#1#unresolved-placeholder#8ebced31e714d866",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha decision propose ..."
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.MissingDecisionRejected]#1#unresolved-placeholder#146d2f519521d6b7",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha decision propose ..."
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.MissingFactSource]#1#unresolved-placeholder#566c1fa9c3125ebf",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha fact record --task <task-id> --statement <text> --source <source>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.MissingFactSource]#1#unresolved-placeholder#c28bb28e1dcd2b4d",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha fact record --task <task-id> --statement <text> --source <source>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.MissingFactSource]#1#unresolved-placeholder#f1886432533c7627",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha fact record --task <task-id> --statement <text> --source <source>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.MissingFactStatement]#1#unresolved-placeholder#4ce04fe8b0c12b0b",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha fact record --task <task-id> --statement <text>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.MissingFactStatement]#1#unresolved-placeholder#53f86bfe634c5477",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha fact record --task <task-id> --statement <text>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.MissingLegacyId]#1#missing-required-option#89bdbfcf14f7b48e",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: missing-required-option; ha task create --from-legacy <legacy-id>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.MissingLegacyId]#1#unresolved-placeholder#7e7707046cb6c0e3",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task create --from-legacy <legacy-id>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.MissingModuleFields]#1#unresolved-placeholder#5fe22b6919cffc60",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha module register <key> --title <title> --scope <path>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.MissingModuleFields]#1#unresolved-placeholder#676c7b74b8448d87",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha module register <key> --title <title> --scope <path>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.MissingModuleFields]#1#unresolved-placeholder#fd231cbd9c52c83d",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha module register <key> --title <title> --scope <path>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.MissingName]#1#unresolved-placeholder#2474f7c3652460dd",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha init --name <name>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.MissingText]#1#unresolved-placeholder#9bc54f3f18f8a70d",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task progress append <task-id> --text <update>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.MissingText]#1#unresolved-placeholder#c4c1311e06cb0b2f",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task progress append <task-id> --text <update>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.MissingTitle]#1#unresolved-placeholder#a48c3acf58b1d8c7",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task create --title <title>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.PresetManifestInvalid]#1#unresolved-placeholder#4e46f4089f1b6f39",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha preset validate <manifest> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.PresetMaterializationFailed]#1#unresolved-placeholder#403f2df14f50cdf9",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha preset validate <manifest> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.PresetPolicyInvalid]#1#unresolved-placeholder#815c3a7eb0198d7b",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha preset check <id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.PresetReadScopeInvalid]#1#unresolved-placeholder#f601c064d6ae0e32",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha preset validate <manifest> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.PresetReadScopeViolation]#1#unresolved-placeholder#1b79eb0d39eef6d5",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha preset inspect <id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.PresetRuntimeUnavailable]#1#unresolved-placeholder#b045aeb00e100829",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha preset inspect <id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.PresetScriptFailed]#1#unresolved-placeholder#a80f81c57aae8b7e",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha preset check <id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.PresetScriptNotFound]#1#unresolved-placeholder#9d6966e7443194ba",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha preset validate <manifest> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.PresetScriptResultFailed]#1#unresolved-placeholder#10b8a7e180be7303",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha preset check <id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.PresetScriptResultInvalid]#1#unresolved-placeholder#9a969f9da9aa7765",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha preset check <id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.PresetUninstallBlocked]#1#unresolved-placeholder#929ad158510c033b",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task list --preset <id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.PresetWriteScopeInvalid]#1#unresolved-placeholder#83c6fc2aa8079b04",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha preset validate <manifest> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.PresetWriteScopeViolation]#1#unresolved-placeholder#abd6eb19f7fe5ee2",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha preset inspect <id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.RefNotFound]#1#unresolved-placeholder#b9a2664bc1289bc0",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha external snapshot github <ref> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.RelatedTaskHardDeleteForbidden]#1#unresolved-placeholder#0217205f3a34292e",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha relation list --entity task/<task-id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.RuntimeEventLedgerRejected]#1#unresolved-placeholder#cd931cd9b3c9dbb1",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha event list --session <session-id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.ScriptContractInvalid]#1#unresolved-placeholder#fb7efbc7f1588cd4",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha script inspect <id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.ScriptDeclaredProduceMismatch]#1#unresolved-placeholder#9df5a25052017590",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha script inspect <id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.ScriptFailed]#1#unresolved-placeholder#7e6af99e19acf310",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha script run <id> --dry-run --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.ScriptResultFailed]#1#unresolved-placeholder#967e2538a285c331",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha script run <id> --dry-run --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.ScriptResultInvalid]#1#unresolved-placeholder#db5046f8482db159",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha script inspect <id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.ScriptScopeInvalidRead]#1#unresolved-placeholder#45b8bc4c858d67dd",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha script inspect <id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.ScriptScopeInvalidWrite]#1#unresolved-placeholder#a0d029fd7cd32d6e",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha script inspect <id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.ScriptScopeViolationRead]#1#unresolved-placeholder#a04d4eb2b9ff9a71",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha script inspect <id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.ScriptScopeViolationWrite]#1#unresolved-placeholder#3fa78234bcde1f01",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha script inspect <id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.SessionExportFailed]#1#unresolved-placeholder#92066ce83706df7f",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha session export --transcript-file <path> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.StaleSnapshotRefused]#1#unresolved-placeholder#0d3a7cc6d0f9d7a0",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha external snapshot <github|multica> <ref> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.StaleSnapshotRefused]#1#unresolved-placeholder#ad91de5c0a2248ae",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha external snapshot <github|multica> <ref> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.StatusUnmapped]#1#unresolved-placeholder#1c8888584e020c92",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha external snapshot <github|multica> <ref> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.StatusUnmapped]#1#unresolved-placeholder#ba337c567c607533",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha external snapshot <github|multica> <ref> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.TaskAlreadyExists]#1#unresolved-placeholder#d11d13d94d861f32",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task create --title <title>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.TaskAlreadyExists]#1#unresolved-placeholder#e944a78852e8e28b",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task show <task-id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.TaskLeaseRequired]#1#unresolved-placeholder#5ea6728d6c2ba3e3",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task start <task-id>' before retrying"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.TaskReturnToIdeaBlocked]#1#unresolved-placeholder#30e0c007c9b48572",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task release <task-id>', then 'ha task retire-execution <task-id> --execution-id <execution-id> --reason <reason>' before retrying"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.TaskReturnToIdeaBlocked]#1#unresolved-placeholder#54ae549ed7ec514b",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task release <task-id>', then 'ha task retire-execution <task-id> --execution-id <execution-id> --reason <reason>' before retrying"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.TaskReturnToIdeaBlocked]#1#unresolved-placeholder#8bd0721a1cd2acfd",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task release <task-id>', then 'ha task retire-execution <task-id> --execution-id <execution-id> --reason <reason>' before retrying"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.TaskReturnToIdeaBlocked]#1#unresolved-placeholder#aecb20f110760284",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task release <task-id>', then 'ha task retire-execution <task-id> --execution-id <execution-id> --reason <reason>' before retrying"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.TaskWipLimitReached]#1#unresolved-placeholder#0ee0f9bbb1d7789d",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task transition <named-task-id> planned', or complete/archive a named task, then retry activation"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.TemplateCatalogInvalid]#1#unresolved-placeholder#0c2f07ad94ee7860",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha template list --catalog <path> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.TemplateRenderFailed]#1#unresolved-placeholder#482ca87f628d5678",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha template render <template-ref> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.TerminalHardDeleteForbidden]#1#unresolved-placeholder#6608fc5a306d81cb",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task archive <task-id> --reason <reason>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.TerminalHardDeleteForbidden]#1#unresolved-placeholder#c8be69c4bd47fe87",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task show <task-id> --view trace"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.TerminalHardDeleteForbidden]#1#unresolved-placeholder#dce3497745a212a3",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task archive <task-id> --reason <reason>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.TerminalReopenRequiresSupersede]#1#unresolved-placeholder#1e81f3ff1f1ac874",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task supersede <task-id> --title <follow-up-title>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.TerminalReopenRequiresSupersede]#1#unresolved-placeholder#2d44ba88fe149292",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task supersede <task-id> --title <follow-up-title>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.TerminalStatusRequiresTaskComplete]#1#missing-required-option#c4335ea1cea4afb4",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: missing-required-option; ha task complete <id> --approve"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.TerminalStatusRequiresTaskComplete]#1#unresolved-placeholder#09280a8fba030e47",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task complete <id> --approve"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.TerminalStatusRequiresTaskComplete]#1#unresolved-placeholder#2ee1d4afcf71155a",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task supersede <id> --title <follow-up-title>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.TerminalStatusRequiresTaskComplete]#1#unresolved-placeholder#c47fdc39ed3dd77d",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task supersede <id> --title <follow-up-title>"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.VerticalDefinitionInvalid]#1#unresolved-placeholder#bc519c5123c4a16e",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha vertical validate <path> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.WorktreeBindingMissing]#1#unresolved-placeholder#a3c1f30e3cdb9a4a",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha worktree create --task <task-id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.WorktreeCommandFailed]#1#unresolved-placeholder#1635bd12fe8feea4",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha worktree status --task <task-id> --json"
+      },
+      {
+        "value": "packages/cli/src/cli/error-codes.ts#property:defaultHint:entry:[CliErrorCode.WriteConflict]#1#unresolved-placeholder#a0051671e67dee36",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task show <task-id> --view trace"
+      },
+      {
+        "value": "packages/cli/src/cli/error-mapper.ts#call:cliError:CliErrorCode.TerminalReopenRequiresSupersede#1#missing-required-option#a77611ed1c9d29fa",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: missing-required-option; harness-anything task supersede"
+      },
+      {
+        "value": "packages/cli/src/cli/parsers/core-task.ts#call:cliError:CliErrorCode.MissingText#1#unresolved-placeholder#7dbf83e586253f36",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task progress append <context> --text \"<update>\""
+      },
+      {
+        "value": "packages/cli/src/cli/parsers/new-task.ts#call:cliError:CliErrorCode.MissingTitle#1#unresolved-placeholder#6fc921449d1fb0bf",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task create --title \"<title>\""
+      },
+      {
+        "value": "packages/cli/src/commands/core/task-holder-support.ts#call:cliError:CliErrorCode.TerminalReopenRequiresSupersede#1#unresolved-placeholder#2c66e858aa13ad5a",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task create --title <follow-up-title>"
+      },
+      {
+        "value": "packages/cli/src/commands/core/task-holder-support.ts#call:cliError:CliErrorCode.TerminalReopenRequiresSupersede#1#unresolved-placeholder#9b55fa906cffbc4f",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha task supersede <context> --title <follow-up-title>"
+      },
+      {
+        "value": "packages/cli/src/commands/extensions/preset-script-runner.ts#call:cliError:CliErrorCode.PresetScriptNotFound#1#unresolved-placeholder#9bdefcc26299245d",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha preset validate <preset-package>/preset"
+      },
+      {
+        "value": "packages/cli/src/commands/legacy-rebuild.ts#call:cliError:CliErrorCode.LegacyIndexMissing#1#missing-required-option#348ddbf57961d641",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: missing-required-option; ha --root <context> task create --from-legacy <context>"
+      },
+      {
+        "value": "packages/daemon/src/authority/authority-cutover-command.ts#property:hint:code:\"write_rejected\"#1#unresolved-placeholder#b34fb3139859c8b6",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha authority cutover confirm --first-scan <id> --second-scan <id> --json"
+      },
+      {
+        "value": "packages/daemon/src/authority/authority-cutover-command.ts#property:hint:code:\"write_rejected\"#1#unresolved-placeholder#e8df872abab75ef1",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha authority cutover confirm --first-scan <id> --second-scan <id> --json"
+      },
+      {
+        "value": "packages/daemon/src/authority/authority-cutover-command.ts#property:hint:code:\"write_rejected\"#2#unresolved-placeholder#e453f12c701f679f",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha authority cutover drain --classify <op-id|disposition|tuple-digest|evidence-ref> --json"
+      },
+      {
+        "value": "packages/daemon/src/protocol/daemon-control-request.ts#property:hint:code:\"daemon_control_unavailable\"#4#unresolved-placeholder#d61b20d47d2eb5e5",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha daemon upgrade --version <snapshot-version>"
+      },
+      {
+        "value": "packages/daemon/src/protocol/daemon-control-request.ts#property:hint:code:\"daemon_control_unavailable\"#5#unknown-option#927ccf44cdab3508",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unknown-option; ha daemon status --json --include-generation-axes"
+      },
+      {
+        "value": "packages/daemon/src/protocol/json-rpc-server.ts#call:failureReceipt:\"daemon_launch_spec_unavailable\"#1#unresolved-placeholder#820166309ad8b4b3",
+        "ref": "task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "reason": "Existing lexical error-hint debt: unresolved-placeholder; ha daemon start --service --authority-manifest <path>"
+      }
+    ]
+  }
+}

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -1644,6 +1644,83 @@
       }
     },
     {
+      "id": "check-error-next-step-commands",
+      "command": "node tools/check-error-next-step-commands.mjs",
+      "category": "local-consistency",
+      "tier": "pr-required",
+      "tierReason": null,
+      "authoritySource": [
+        "task/task_01KZJF8PRC8E1XM9R95P4BKEP1",
+        "packages/cli/src/cli/command-spec",
+        "tools/check-error-next-step-commands.mjs"
+      ],
+      "consumerScope": [
+        "copied ha commands in caller-facing error-hint sinks under every packages/*/src production tree",
+        "registered command paths, declared options, and lexically required options derived from usage text"
+      ],
+      "githubContext": {
+        "requiredContexts": [
+          "boundaries"
+        ],
+        "workflowJobs": [
+          "boundaries"
+        ],
+        "nodeVersions": [
+          24
+        ]
+      },
+      "allowlistPolicy": {
+        "allowed": true,
+        "location": "tools/gate-allowlists/check-error-next-step-commands.json",
+        "adrOrDecisionRequired": true,
+        "notes": "The task-scoped exact lexical-debt baseline may only shrink: new finding keys fail and repaired entries become stale failures."
+      },
+      "changeControl": {
+        "ordinaryImplementationMayModify": false,
+        "requiresGovernanceEvidence": true,
+        "protectedSurfaces": [
+          "tools/check-error-next-step-commands.mjs",
+          "tools/check-error-next-step-commands.test.mjs",
+          "tools/fixtures/check-error-next-step-commands/**",
+          "tools/gate-allowlists/check-error-next-step-commands.json",
+          "tools/gate-manifest.json"
+        ]
+      },
+      "bypassFixtureRequired": false,
+      "executionSurfaces": {
+        "packageJson": {
+          "check": false,
+          "checkPr": false,
+          "script": null
+        },
+        "rewriteCi": {
+          "pullRequestJobs": [
+            "boundaries"
+          ],
+          "nonPullRequestJobs": []
+        },
+        "branchProtection": {
+          "required": true,
+          "contexts": [
+            "boundaries"
+          ]
+        },
+        "classes": [
+          "pr"
+        ]
+      },
+      "deterministic": true,
+      "positiveControl": {
+        "status": "covered",
+        "evidence": [
+          "tools/check-error-next-step-commands.test.mjs",
+          "tools/fixtures/check-error-next-step-commands/missing-required-option/packages/cli/src/commands/review.ts",
+          "tools/fixtures/check-error-next-step-commands/unresolved-placeholder/packages/cli/src/commands/review.ts",
+          "tools/fixtures/check-error-next-step-commands/good/packages/cli/src/commands/review.ts"
+        ]
+      }
+    },
+    {
       "id": "check-error-next-steps",
       "command": "npm run harness:check-error-next-steps",
       "category": "local-consistency",

--- a/tools/node-test-file-scheduler.mjs
+++ b/tools/node-test-file-scheduler.mjs
@@ -514,22 +514,31 @@ async function forceTerminateOwnedTree(child, graceMs) {
 
 async function terminateResidualOwnedGroup(child, graceMs) {
   if (ownedTreeTerminationAdapter() === "windows-taskkill-tree" || child.pid === undefined) return;
-  if (!signalOwnedGroup(child.pid, "SIGTERM")) return;
+  if (!signalOwnedGroup(child.pid, "SIGTERM", { afterNaturalClose: true })) return;
   console.error(
     `[node-test-stall] direct worker pid=${child.pid} closed with lingering descendants; terminating its owned process tree`
   );
   await delay(graceMs);
-  signalOwnedGroup(child.pid, "SIGKILL");
+  signalOwnedGroup(child.pid, "SIGKILL", { afterNaturalClose: true });
 }
 
-function signalOwnedGroup(pid, signal) {
+function signalOwnedGroup(pid, signal, { afterNaturalClose = false } = {}) {
   try {
     process.kill(-pid, signal);
     return true;
   } catch (error) {
-    if (error?.code !== "ESRCH") throw error;
-    return false;
+    if (error?.code === "ESRCH") return false;
+    // A detached QoS wrapper can finish after proof and Darwin can report EPERM
+    // for its former group rather than ESRCH. This exception is safe only after
+    // the directly owned child has emitted close; active timeout and
+    // signal-forwarding paths remain strict and still surface EPERM.
+    if (afterNaturalClose && residualGroupCleanupShouldStop(error)) return false;
+    throw error;
   }
+}
+
+export function residualGroupCleanupShouldStop(error) {
+  return error?.code === "ESRCH" || error?.code === "EPERM";
 }
 
 function runTaskkill(pid, graceMs) {

--- a/tools/run-node-tests-lifecycle.test.mjs
+++ b/tools/run-node-tests-lifecycle.test.mjs
@@ -5,7 +5,10 @@ import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { ownedTreeTerminationAdapter } from "./node-test-file-scheduler.mjs";
+import {
+  ownedTreeTerminationAdapter,
+  residualGroupCleanupShouldStop
+} from "./node-test-file-scheduler.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
@@ -13,6 +16,13 @@ test("owned-tree termination uses one POSIX adapter for macOS and Linux", () => 
   assert.equal(ownedTreeTerminationAdapter("darwin"), "posix-owned-process-group");
   assert.equal(ownedTreeTerminationAdapter("linux"), "posix-owned-process-group");
   assert.equal(ownedTreeTerminationAdapter("win32"), "windows-taskkill-tree");
+});
+
+test("natural-close cleanup stops only when the former owned group cannot be signalled", () => {
+  assert.equal(residualGroupCleanupShouldStop({ code: "ESRCH" }), true);
+  assert.equal(residualGroupCleanupShouldStop({ code: "EPERM" }), true);
+  assert.equal(residualGroupCleanupShouldStop({ code: "EACCES" }), false);
+  assert.equal(residualGroupCleanupShouldStop(new Error("unknown signal failure")), false);
 });
 
 test("terminating the runner also terminates its detached test process group", {


### PR DESCRIPTION
# English

## Summary

An audit found 51 candidate error messages that tell the reader to do something unsafe, false, or impossible. This PR proves each candidate against the real renderer, repairs the confirmed ones, and adds a machine gate so the family cannot regrow.

The organising question is not "is the wording nice" but **"does this text tell the operator what to repair, or does it route them around the road?"** Two shapes dominate the confirmed set:

- **Identity collapse** — an authentication failure, a held lock, or a bad local config is reported as "the daemon is unavailable" / "the repo is not attached". The reader then fixes the wrong thing.
- **Unexecutable next step** — the suggested command cannot fix the stated condition (`ha daemon repo register` for a lock that is legitimately held; `ha daemon restart` for a dependency that restarting cannot inject; `ha init` before instructing the reader to stop a live daemon without establishing that a replacement composition exists).

Both shapes end the same way: the operator is pushed toward stopping a healthy service or mutating a registry, which is exactly what the message should have prevented.

## Verdicts

| Population | Confirmed | Rejected | Duplicate | Deferred | Missing path |
| --- | ---: | ---: | ---: | ---: | ---: |
| 52 entries (51 audited + #52 found live) | 44 | 4 | 1 | 1 | 2 |
| Original 51-entry checkpoint before the scope change | 39 | 4 | 1 | 7 | 0 |

Every verdict names the file, the **real rendered text**, and how the branch was triggered. Where a branch is rendered but its production reachability was not established, the verdict says so rather than implying it. The four rejections are recorded with the path that contradicts the claim — the audit's confidence labels turned out conservative, not inflated.

**Two items are reclassified as `missing-path` rather than fixed.** #45/#46 promise an operation for which no executable product path exists. Inventing plausible-looking wording would have reproduced the defect in a politer voice, so they are registered as missing roads instead.

## The gate

`tools/check-error-next-step-commands.mjs` extracts the commands that error text tells the reader to run and checks them against 147 command contracts. It is a **ratchet in one direction only**:

- a baseline entry that no longer reproduces must be removed (`stale baseline <key>: remove the repaid entry`);
- `baseline growth is forbidden` — a new violation cannot be silenced by appending to the baseline.

136 known-debt entries are recorded explicitly. Discrimination was demonstrated by mutation rather than by reading the code: two deliberately bad fixtures turn the gate red and the good fixture passes, with all three checked in under `tools/fixtures/`.

## #52 and the receipt this PR was itself written against

`repo_write_outcome_unknown` used to render `[object Object]` and tell the reader to "query the stable outer opId `repo-write:<uuid>`" — for which **no command exists**. The new `packages/daemon/src/service/repo-write-outcome-guidance.ts` emits a runnable projection query (`ha task show <id> --json`, `ha decision show <id> --json`) *and* refuses to overstate it:

> If the task state does not prove the write, the outcome is still unknown; do not replay it.

The public outer-op lookup remains registered as a missing path. This is the honest shape: give the road that exists, name the one that does not.

## Two defects found in passing and fixed

- A concurrent cold-start election **loser** reported the daemon as dead rather than as "another process won"; covered by `daemon-autostart-lost-election.test.ts`.
- The stop gate leaked a Darwin `EPERM` during teardown.

## Task And Scope

- Harness task: `task_01KZJF8PRC8E1XM9R95P4BKEP1`
- Branch: `codex/error-surface-gate`
- Public scope: error text and its next-step actions across `packages/{cli,daemon,application,gui,vscode-ext}`, the new gate under `tools/`, and their tests
- Private planning/evidence updated: yes
- Out of scope: the protected doc-sync dispatch surface (one deferred item), and the two missing-path items, which need their own product path

## Version Impact

- Version: no version change; message and diagnostics repair plus a new repository gate, no published entrypoint added or removed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gate-manifest.json` — one new gate entry registering `check-error-next-step-commands`; no existing gate was weakened, removed, or made non-blocking
- Authority: `task_01KZJF8PRC8E1XM9R95P4BKEP1`; the family is the subject of the PLT-Honest line, and the CEO scope ruling of 2026-08-09 unlocked #4/#7/#15/#51 after verifying no in-flight change overlapped those files
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: the two `missing-path` items need a product path before their text can be honest

## Verification

- Base `origin/main` SHA: `d65da8bb`
- Branch merge-base with `origin/main`: `d65da8bb`
- Last `git fetch origin` time: 2026-08-09, immediately before this stop-point run
- Sync method: rebase
- Public diff command: `git diff d65da8bb..2eba0876 -- packages/ tools/`
- Private evidence commit/path: `harness/tasks/task_01KZJF8PRC8E1XM9R95P4BKEP1-47/artifacts/verdicts-error-surface.md` and `report-error-surface-implementation.md`, both submitted through `ha doc sync`
- Reviewer evidence path: the verdicts table — one row per candidate with its real rendered text
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` — `npm run check:local`, "Local check passed in 237.5s", **28** manifest gates green (27 before, plus the new one), run after rebase onto `d65da8bb`
- [x] Targeted tests for the change surface, named with their counts: the worker's own serialized run recorded fast 1067/1067, contract 845 pass + 1 skip, GUI 380/380. New coverage lands with the branches it describes: `json-rpc-error-guidance.test.ts`, `authorization-errors.test.ts`, `identity-dispatch-errors.test.ts`, `forced-command-root.test.ts`, `production-recovery-admission-errors.test.ts`, `ssh-authority-wire-guidance.test.ts`, `daemon-autostart-lost-election.test.ts`, `local-composition-root-errors.test.ts`, plus `tools/check-error-next-step-commands.test.mjs` for the gate itself.
- [x] Gate discrimination shown by mutation: two bad fixtures red, good fixture green.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: `npm run check:ci` was not run locally; CI is authoritative for the 31 gates outside the local stop point, including `check-error-next-step-commands` itself.

## Review Evidence

- Self-review (CEO, semantic acceptance — traced propagation rather than reading the diff): confirmed the ratchet only descends, at `tools/check-error-next-step-commands.mjs:112` (a repaid entry must be deleted) and `:121` (baseline growth forbidden), so the gate cannot be satisfied by appending. Confirmed the `repo_write_outcome_unknown` guidance gives an executable projection query while explicitly denying that the query settles the outcome, and that no repaired text suggests `ha daemon restart` or `HARNESS_DAEMON_MODE=direct` as a way around the stated condition.
- Reviewer subagent: the implementation corrected the CEO's structural model of the family mid-flight — shape A covers only #2/#3, #1 is state-mapping collapse, and shape C is not merely literal drift. That correction is recorded in the verdicts document rather than silently absorbed.
- Human review: pending
- Blocking findings: none outstanding

## Residual Risk

- Several confirmed branches render correctly but their production reachability was not established. They are labelled `production reachability unverified` in the verdicts table; repairing text that cannot currently be reached is cheap, but the labels should not be read as proof those paths occur in production.
- The gate parses command-shaped text out of messages. Text that describes an action in prose without a command form is outside its reach, so the family can still regrow in that shape.
- 136 baseline entries remain as known debt. The ratchet stops growth but does not schedule repayment.

## References

- Task: `task_01KZJF8PRC8E1XM9R95P4BKEP1`
- Evidence: `artifacts/verdicts-error-surface.md`, `artifacts/report-error-surface-implementation.md`
- Fact: `F-NGJ5PJM2`

---

# 中文

## 概要

一次审计列出 51 条候选报错，它们让读者去做不安全、不成立或做不到的事。本 PR 对每条候选**用真实渲染器取证**，修掉成立的，并加一道机检门让这一族长不回来。

组织问题不是「文案好不好听」，而是 **「这段文字是在说该修什么，还是在教人绕过正路」**。成立的那批里有两种形状占主导：

- **身份坍缩** —— 认证失败、锁被合法持有、本地配置坏了，统统被报成「daemon 不可用」／「repo 未附着」。读者于是去修错的东西。
- **不可执行的下一步** —— 建议的命令根本治不了它说的那个状况：对一把**被合法持有**的锁建议 `ha daemon repo register`；对一个「重启也注入不进去」的缺失依赖建议 `ha daemon restart`；先让人 `ha init`、再让人停掉活着的 daemon，却从未确立替身组合会存在。

两种形状的终点是同一个：操作者被推着去停一个健康的服务、或去改注册表 —— 而那恰恰是这段报错本该阻止的事。

## 判定

| 总体 | confirmed | rejected | duplicate | deferred | missing-path |
| --- | ---: | ---: | ---: | ---: | ---: |
| 52 条（审计 51 条 + 现场发现的 #52） | 44 | 4 | 1 | 1 | 2 |
| 范围变更前的原始 51 条 checkpoint | 39 | 4 | 1 | 7 | 0 |

每条判定都点名文件、**真实渲染出的文本**、以及这个分支是怎么被触发的。分支能渲染但**生产可达性未确立**的，判定里直说，不暗示。四条 rejected 都附了与指控矛盾的实际路径 —— 审计的置信标注结果偏保守，不是虚高。

**两条被重分类为 `missing-path` 而非「修好」。** #45/#46 承诺了一个**不存在可执行产品路径**的操作。编一段看着像样的文案等于用更礼貌的语气把同一个缺陷再犯一遍，所以它们被登记为「缺路」。

## 那道门

`tools/check-error-next-step-commands.mjs` 把报错文本里「让你去跑」的命令抽出来，对着 147 个命令契约核。它是**单向 ratchet**：

- 已经不复现的基线条目必须删掉（`stale baseline <key>: remove the repaid entry`）；
- `baseline growth is forbidden` —— 新违规不能靠往基线里追加来消音。

136 条 known-debt 显式在册。**分辨力是跑 mutation 证出来的，不是读代码读出来的**：两个故意做坏的 fixture 让门变红、好的通过，三个 fixture 都在 `tools/fixtures/` 里入库。

## #52：本 PR 自己就是顶着这条回执写出来的

`repo_write_outcome_unknown` 以前渲染出 `[object Object]`，并让人「query the stable outer opId `repo-write:<uuid>`」—— 而**根本没有这个命令**。新的 `packages/daemon/src/service/repo-write-outcome-guidance.ts` 给出可执行的投影查询（`ha task show <id> --json`、`ha decision show <id> --json`），**同时拒绝把它说过头**：

> If the task state does not prove the write, the outcome is still unknown; do not replay it.

公共 outer-op 查询仍然登记为缺路。这才是诚实的形状：**有的路给出来，没有的路点名说没有。**

## 顺带发现并修掉的两个缺陷

- 并发冷启动选举的**输家**把 daemon 报成死了，而不是「另一个进程赢了」；由 `daemon-autostart-lost-election.test.ts` 覆盖。
- 停止门在 Darwin 上收尾时漏出 `EPERM`。

## 任务与范围

- Harness task：`task_01KZJF8PRC8E1XM9R95P4BKEP1`
- 分支：`codex/error-surface-gate`
- 公开范围：`packages/{cli,daemon,application,gui,vscode-ext}` 的报错文本与其 next-step 动作、`tools/` 下的新门、以及它们的测试
- 私有规划/证据已更新：是
- 不在范围内：受保护的 doc-sync dispatch 面（一条 deferred）；两条 missing-path 需要先有产品路径

## 版本影响

- 版本：无变更；报错与诊断修复加一道仓内门，未增删已发布入口
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是
- 受保护面范围：`tools/gate-manifest.json` —— 新增一条门条目登记 `check-error-next-step-commands`；**未削弱、未移除、未把任何既有门改为非阻塞**
- 授权：`task_01KZJF8PRC8E1XM9R95P4BKEP1`；该缺陷族是 PLT-Honest 线的题目，2026-08-09 CEO 的范围裁定在核实无在飞改动重叠后解锁了 #4/#7/#15/#51
- 机检边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：两条 `missing-path` 需要先有产品路径，其文案才可能诚实

## 验证

- 基线 `origin/main` SHA：`d65da8bb`
- 分支与 `origin/main` 的 merge-base：`d65da8bb`
- 最近一次 `git fetch origin`：2026-08-09，就在本次停止点之前
- 同步方式：rebase
- 公开 diff 命令：`git diff d65da8bb..2eba0876 -- packages/ tools/`
- 私有证据 commit/路径：`harness/tasks/task_01KZJF8PRC8E1XM9R95P4BKEP1-47/artifacts/verdicts-error-surface.md` 与 `report-error-surface-implementation.md`，均已走 `ha doc sync` 提交
- 评审证据路径：判定表 —— 每条候选一行，附真实渲染文本
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑
- [x] `git diff --check`
- [x] `npm run check:stop-point` —— `npm run check:local`，"Local check passed in 237.5s"，**28** 个 manifest 门绿（原 27 + 新增 1），在 rebase 到 `d65da8bb` 之后跑
- [x] 针对改动面的定向测试及计数：worker 自己的串行跑记录 fast 1067/1067、contract 845 pass + 1 skip、GUI 380/380。新覆盖与它描述的分支同时落地：`json-rpc-error-guidance.test.ts`、`authorization-errors.test.ts`、`identity-dispatch-errors.test.ts`、`forced-command-root.test.ts`、`production-recovery-admission-errors.test.ts`、`ssh-authority-wire-guidance.test.ts`、`daemon-autostart-lost-election.test.ts`、`local-composition-root-errors.test.ts`，门自身由 `tools/check-error-next-step-commands.test.mjs` 覆盖。
- [x] 门的分辨力用 mutation 证明：两个坏 fixture 变红，好 fixture 绿。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威完整门）
- 未跑及原因：本地未跑 `npm run check:ci`；本地停止点之外的 31 个门以 CI 为权威，其中就包括 `check-error-next-step-commands` 自己。

## 评审证据

- 自审（CEO 语义验收，**追传播不读 diff**）：确认 ratchet 只降不抬 —— `tools/check-error-next-step-commands.mjs:112`（已修的条目必须删除）与 `:121`（禁止基线增长），因此这道门无法靠追加来满足。确认 `repo_write_outcome_unknown` 的新文案给出可执行的投影查询，**同时明确否认该查询能定论**；并确认所有修好的文案都没有把 `ha daemon restart` 或 `HARNESS_DAEMON_MODE=direct` 当作绕过既述状况的手段。
- 评审子代理：实现者在过程中**纠正了 CEO 对这个族的结构模型** —— 形状 A 只覆盖 #2/#3，#1 是状态映射坍缩，形状 C 不只是字面漂移。该纠正被写进判定文档，而不是被默默吸收。
- 人工评审：待办
- 阻断性发现：无遗留

## 残留风险

- 若干 confirmed 分支渲染正确，但**生产可达性未确立**，判定表里标为 `production reachability unverified`。修一段当前到不了的文案很便宜，但这些标注不应被读成「这些路径在生产会发生」的证明。
- 这道门抽取的是报错里**命令形状**的文本。用散文描述动作、不给命令形式的，它够不着 —— 这一族仍可能以那种形状长回来。
- 136 条基线仍是 known debt。ratchet 只挡住增长，没有安排偿还。

## 参考

- Task：`task_01KZJF8PRC8E1XM9R95P4BKEP1`
- 证据：`artifacts/verdicts-error-surface.md`、`artifacts/report-error-surface-implementation.md`
- Fact：`F-NGJ5PJM2`
