### PR TITLE
test(cli): control the autostart exited-process precondition instead of racing the probe budget

### DIFF
--- a/packages/cli/test/daemon-autostart-startup-diagnostics.test.ts
+++ b/packages/cli/test/daemon-autostart-startup-diagnostics.test.ts
@@ -37,6 +37,24 @@ test("autostart does not describe an exited daemon process as still starting", {
   const userRoot = path.join(fixture.root, "autostart-exited-user");
   const daemon = testDaemonLocation(userRoot);
   const endpoint = daemon.socketPath;
+  const preloadPath = path.join(fixture.root, "exit-before-readiness-preload.mjs");
+  const namespaceDiagnosticUrl = new URL(
+    "../../daemon/src/transport/daemon-socket-namespace.ts",
+    import.meta.url
+  ).href;
+  // The preceding test exercises the daemon's real namespace failure. This test
+  // controls the separate exited-process condition while preserving that startup
+  // diagnostic as input to the caller-facing classification.
+  writeFileSync(preloadPath, [
+    `import { daemonSocketNamespaceError } from ${JSON.stringify(namespaceDiagnosticUrl)};`,
+    'if (process.env.HARNESS_DAEMON_SERVER_HOST === "1") {',
+    "  const socketPath = process.env.HARNESS_TEST_DAEMON_SOCKET_PATH;",
+    '  const cause = Object.assign(new Error("controlled daemon exit"), { code: "ERR_FS_EISDIR" });',
+    "  process.stderr.write(`${String(daemonSocketNamespaceError(socketPath, cause))}\\n`);",
+    "  process.exit(17);",
+    "}",
+    ""
+  ].join("\n"), "utf8");
   mkdirSync(endpoint, { recursive: true });
   writeFileSync(path.join(endpoint, "blocker"), "keep the occupied endpoint non-empty\n", "utf8");
   t.after(() => {
@@ -45,7 +63,11 @@ test("autostart does not describe an exited daemon process as still starting", {
     rmSync(daemon.runtimeRoot, { recursive: true, force: true });
   });
 
-  const failed = runRawJsonMaybeFail(fixture.repoRoot, ["task", "list"], daemon.env);
+  const failed = runRawJsonMaybeFail(fixture.repoRoot, ["task", "list"], {
+    ...daemon.env,
+    HARNESS_TEST_DAEMON_SOCKET_PATH: endpoint,
+    NODE_OPTIONS: `--import=${preloadPath}`
+  });
 
   assert.notEqual(failed.status, 0, JSON.stringify(failed.receipt));
   const error = failed.receipt.error as { readonly hint?: string };


### PR DESCRIPTION
## Summary

`autostart does not describe an exited daemon process as still starting` failed intermittently in CI (run `31298460891`, `integration-shard (5)`, on #1290). The diagnostic was not lying — it said `pid 3672 is alive` and the process genuinely was. What failed was an assumption inside the test: it waited for the daemon to die on its own after hitting an invalid socket namespace, and assumed that would happen inside the 5s probe budget. On a slow runner it does not, so the assertion saw `DAEMON_AUTOSTART_TIMEOUT` instead of `DAEMON_AUTOSTART_PROCESS_EXITED`.

The test now **controls** the exited-process precondition instead of racing for it. All three original assertions are unchanged.

The behavior this test protects is load-bearing — it came out of the work on error messages that taught users to bypass the single-writer path, and the `Do NOT run 'ha daemon restart'` / `Do NOT use HARNESS_DAEMON_MODE=direct` wording is that work's output. Nothing here weakens it.

## What Changed

- `packages/cli/test/daemon-autostart-startup-diagnostics.test.ts` only. The target case writes a preload that runs **only** when `HARNESS_DAEMON_SERVER_HOST=1`: it calls the real `daemonSocketNamespaceError()` to produce the genuine namespace startup diagnostic, writes it to launch stderr, then `process.exit(17)`. The parent CLI process never takes that branch.
- This splits two responsibilities that were tangled: the **preceding** case still covers a real daemon namespace startup failure; the target case controls only the "spawned child has exited" precondition and keeps verifying the caller-facing classification.
- No production source changed. No process is killed.

## Version Impact

- Version: no version change — integration test fixture only.

## Verification

**The CI failure was reproduced first**, which is what establishes the root cause rather than assuming it. Without touching production code, a preload blocked the child for 7000 ms against the test's 5000 ms budget:

```
✖ autostart does not describe an exited daemon process as still starting (6287.327708ms)
AssertionError: The input did not match /DAEMON_AUTOSTART_PROCESS_EXITED:.*exited before readiness/u
Input: "The daemon is still starting (spawned pid 75255 is alive; waited 5s). ...
DAEMON_AUTOSTART_TIMEOUT: readiness was not confirmed within the normal 5000ms startup budget..."
```

The probe ended around 7.25s, confirming the child outlived the 5s deadline and then exited on its own once the block lapsed. Unmodified, the same test goes green in ~3.46s under normal local load — which is exactly why this was low-frequency rather than always-red.

**Resolution was measured against production code, not the test.** The `DaemonAutostartProcessExitedError` message was temporarily changed from "exited" to "still starting" (reverted, not committed) — the test fails:

```
✖ autostart does not describe an exited daemon process as still starting (1755.543375ms)
tests 1, pass 0, fail 1
```

Restoring the message returns it to green. A test that cannot fail on the defect it guards is worse than no test, so this was checked rather than asserted.

Assertions retained in full:

1. `DAEMON_AUTOSTART_PROCESS_EXITED: ... exited before readiness` must appear.
2. `may still be starting` must not appear.
3. `DAEMON_SOCKET_NAMESPACE_INVALID ... connectCode=ERR_FS_EISDIR` for the target endpoint must be preserved.

- [x] Whole test file 4/4; target case 12/12 consecutive runs.
- [x] Incremental `tsc -b`; ESLint on the changed file.
- [ ] **`npm run check:local` did not complete — and this is not claimed as green.** It was blocked by an environment race between two concurrent local test runners (JUnit cleanup race plus `kill EPERM`), caused by another worker running tests on this machine at the same time, not by this change. Per `harness/AGENTS.md` the gate was not modified and nothing was forced green; the narrow verification above is reported as narrow verification. GitHub CI on this PR is the complete authority.
- [ ] `npm test` / `smoke:dashboard` / `pack:dry-run` / GUI build — Not applicable or CI's job.

## Review Evidence

- The root cause was independently re-derived by the implementer and agrees with the reviewer's reading: the diagnostic branch is correct, the test's timing premise was not.
- Confirm the preload cannot leak into the parent process (`HARNESS_DAEMON_SERVER_HOST=1` guard) and that the namespace diagnostic is the real one rather than a fabricated string.
- Blocking findings: none.

## Residual Risk

- The concurrent-runner failure mode that blocked `check:local` (JUnit cleanup race, `kill EPERM`) may be a defect in the runner rather than mere resource contention — running two workers on one machine is normal here. Recorded as worth treating separately; deliberately not touched in this task.
- The architecture-check advisory returned only pending progress and never a final receipt, so it is not listed as passing evidence. Architecture impact is N/A: test fixture only, `component.cli` / `relation.code.cli-daemon` / `relation.daemon-host-runtime` unchanged.
- The test now depends on `NODE_OPTIONS` preload support in the daemon host spawn path; if that spawn stops honoring `NODE_OPTIONS`, the case would stop controlling its precondition. It would fail loudly rather than silently pass, but the coupling is new.

## References

- Task: task_01KZJX1B1C2FB5PKHENHMRYKSE
- Flake origin: run 31298460891, job 93207245645 (`integration-shard (5)`) on #1290

## Governance Declaration

- No CI/gate authority surface was modified; no test shard or tier manifest was touched to avoid this test.
- No production source changed.

---

## 摘要

`autostart does not describe an exited daemon process as still starting` 在 CI 上间歇失败（run `31298460891`，`integration-shard (5)`，发生在 #1290 上）。诊断消息并没有撒谎——它说 `pid 3672 is alive`，而进程确实还活着。失败的是测试内部的一个假定：它等待 daemon 撞上无效 socket namespace 后自行死亡，并假定这会发生在 5 秒探测预算之内。慢 runner 上不会，于是断言看到的是 `DAEMON_AUTOSTART_TIMEOUT` 而不是 `DAEMON_AUTOSTART_PROCESS_EXITED`。

现在测试**控制**「进程已退出」这个前置条件，而不是去和它赛跑。三条原始断言一条未改。

这条测试保护的行为是承重的——它出自治理「错误消息教用户绕过单写者路径」那次工作，消息里 `Do NOT run 'ha daemon restart'`、`Do NOT use HARNESS_DAEMON_MODE=direct` 就是那次的成果。本 PR 没有削弱它的任何部分。

## 改动内容

- 仅 `packages/cli/test/daemon-autostart-startup-diagnostics.test.ts`。目标 case 写入一个**只在** `HARNESS_DAEMON_SERVER_HOST=1` 时执行的 preload：它调用真实的 `daemonSocketNamespaceError()` 生成原有的 namespace 启动诊断、写入 launch stderr，然后 `process.exit(17)`。调用 CLI 的父进程不会命中该分支。
- 这把原本纠缠在一起的两个责任拆开了：**前一个** case 继续覆盖真实的 daemon namespace 启动失败；目标 case 只控制「spawned child 已退出」这个前置状态，并继续验证 caller-facing 的分类。
- 未改任何生产源码。未 kill 任何进程。

## 版本影响

- 版本：不改版本——仅 integration 测试 fixture。

## 验证

**先复现了 CI 的失败**，这才是确立根因的方式而不是假定它。在不触碰生产代码的前提下，用 preload 把子进程阻塞 7000 ms，对抗测试的 5000 ms 预算：

```
✖ autostart does not describe an exited daemon process as still starting (6287.327708ms)
AssertionError: The input did not match /DAEMON_AUTOSTART_PROCESS_EXITED:.*exited before readiness/u
Input: "The daemon is still starting (spawned pid 75255 is alive; waited 5s). ...
DAEMON_AUTOSTART_TIMEOUT: readiness was not confirmed within the normal 5000ms startup budget..."
```

探针在约 7.25 秒结束，确认子进程确实活过了 5 秒截止点，并在阻塞结束后自行退出。未做改动时同一测试在普通本机负载下约 3.46 秒转绿——这正是它低频而非常红的原因。

**分辨力是针对生产代码实测的，不是针对测试。** 把 `DaemonAutostartProcessExitedError` 的消息临时从「已退出」改成「仍在启动」（已恢复，未提交），测试失败：

```
✖ autostart does not describe an exited daemon process as still starting (1755.543375ms)
tests 1, pass 0, fail 1
```

恢复消息后转绿。一个不会因它所守护的缺陷而失败的测试比没有测试更糟，所以这一条是实测的而不是声称的。

断言完整保留：

1. 必须出现 `DAEMON_AUTOSTART_PROCESS_EXITED: ... exited before readiness`。
2. 不得出现 `may still be starting`。
3. 必须保留目标 endpoint 的 `DAEMON_SOCKET_NAMESPACE_INVALID ... connectCode=ERR_FS_EISDIR`。

- [x] 完整测试文件 4/4；目标 case 连续 12/12。
- [x] 增量 `tsc -b`；对改动文件跑 ESLint。
- [ ] **`npm run check:local` 未跑完——并且不声称它是绿的。** 它被本机两个并行测试 runner 的环境竞态挡住（JUnit 清理竞态加 `kill EPERM`），成因是同机另一个 worker 同时在跑测试，与本改动无关。按 `harness/AGENTS.md`，未修改 gate、未硬凑绿；上面的窄验证就按窄验证如实呈现。本 PR 的 GitHub CI 是完整权威。
- [ ] `npm test` / `smoke:dashboard` / `pack:dry-run` / GUI 构建 —— 不适用或属 CI 的活。

## 审查证据

- 根因由实施者独立重新推导，与复核者的读法一致：诊断分支是对的，测试的时序前提不成立。
- 请确认 preload 不会泄漏到父进程（`HARNESS_DAEMON_SERVER_HOST=1` 守卫），以及那条 namespace 诊断是真实产生的而非伪造的字符串。
- 阻塞发现：无。

## 残余风险

- 挡住 `check:local` 的并行 runner 失败模式（JUnit 清理竞态、`kill EPERM`）可能是 runner 本身的缺陷而不只是资源不足——本机同时跑两个 worker 在这里是常态。已记录为值得单独治理，本任务刻意未动。
- architecture-check advisory 只返回了 pending progress，从未拿到最终 receipt，因此不列为通过证据。架构影响 N/A：仅测试 fixture，`component.cli` / `relation.code.cli-daemon` / `relation.daemon-host-runtime` 均未变化。
- 该测试现在依赖 daemon host spawn 路径对 `NODE_OPTIONS` preload 的支持；若该 spawn 将来不再遵循 `NODE_OPTIONS`，这个 case 就不再控制它的前置条件。它会响亮地失败而不是静默通过，但这层耦合是新增的。

## 关联材料

- 任务：task_01KZJX1B1C2FB5PKHENHMRYKSE
- flake 来源：#1290 上的 run 31298460891，job 93207245645（`integration-shard (5)`）

## 治理声明

- 未修改任何 CI/gate 权威面；未通过改 test shard 或 tier manifest 来回避该测试。
- 未改动任何生产源码。
