### PR TITLE
feat(kernel): bound every automatic retry through one seam and escalate exhausted budgets

### DIFF
--- a/packages/adapters/local/src/types.ts
+++ b/packages/adapters/local/src/types.ts
@@ -1,5 +1,5 @@
 import type { Effect } from "effect";
-import type { DomainStatus, EngineError, PackageDisposition, PriorityTier, TaskId, TaskWorkKind, WriteAttribution, WriteError } from "@harness-anything/kernel";
+import type { DomainStatus, EngineError, PackageDisposition, PriorityTier, RetryBudgetSignal, TaskId, TaskWorkKind, WriteAttribution, WriteError } from "@harness-anything/kernel";
 import type { HarnessLayoutOverrides } from "@harness-anything/kernel";
 import type { ProvenancePayload, WriteCoordinator } from "@harness-anything/kernel";
 
@@ -33,6 +33,7 @@ export interface LocalWriteCoordinatorOptions {
     readonly name: string;
     readonly email: string;
   };
+  readonly onLockConflictRetrySignal?: (signal: RetryBudgetSignal) => void;
 }
 
 export interface AdapterProviderMetadata {

--- a/packages/cli/src/composition/command-executor.ts
+++ b/packages/cli/src/composition/command-executor.ts
@@ -16,7 +16,7 @@ import {
   type ProvenanceSessionExportResult,
   type TaskHolderPrincipal
 } from "@harness-anything/application";
-import type { CurrentSessionProbePort, CurrentSessionRef, OperationalActor, WriteCoordinator, WriteError } from "@harness-anything/kernel";
+import type { CurrentSessionProbePort, CurrentSessionRef, OperationalActor, RetryBudgetSignal, WriteCoordinator, WriteError } from "@harness-anything/kernel";
 import { createHarnessRuntimeContext, findConflictMarkerWarnings, makeOperationalJournaledWriteCoordinator } from "@harness-anything/kernel";
 import { toCliError } from "../cli/error-mapper.ts";
 import { normalizeCommandSemantics } from "../cli/command-semantic-normalizer.ts";
@@ -56,6 +56,7 @@ export interface ParsedCommandExecutionOptions {
   readonly syncExportedSession?: (result: ProvenanceSessionExportResult) => Effect.Effect<void, ProvenanceSessionExporterRejected>;
   /** Explicit local composition scopes outside the daemon-owned product route. */
   readonly localCoordinatorScope?: LocalCoordinatorScope;
+  readonly onLockConflictRetrySignal?: (signal: RetryBudgetSignal) => void;
   readonly onTelemetry?: DaemonHostCommandExecutionOptions["onTelemetry"];
   readonly onCommandTelemetry?: DaemonHostCommandExecutionOptions["onCommandTelemetry"];
   readonly conflictMarkerPreflight?: DaemonHostCommandExecutionOptions["conflictMarkerPreflight"];
@@ -149,7 +150,10 @@ export async function runRegisteredCommandWithCliComposition(
       layoutOverrides: command.layoutOverrides,
       attribution: getActorAttribution().writeAttribution,
       commitAuthor: getActorAttribution().commitAuthor,
-      sessionId: getSessionBranchId()
+      sessionId: getSessionBranchId(),
+      ...(options.onLockConflictRetrySignal ? {
+        onLockConflictRetrySignal: options.onLockConflictRetrySignal
+      } : {})
     }), getActorAttribution, options.missingActorAttributionMessage, actor)) : missingInjectedWriteCoordinator);
   const makeWriteCoordinator = requiresConflictMarkerPreflight(command.action)
     ? (actor: OperationalActor) => withConflictMarkerFlushRecheck(
@@ -167,7 +171,10 @@ export async function runRegisteredCommandWithCliComposition(
         layoutOverrides: command.layoutOverrides,
         attribution: migrationWriteAttribution(resolved.writeAttribution, evidenceRef),
         commitAuthor: resolved.commitAuthor,
-        sessionId: getSessionBranchId()
+        sessionId: getSessionBranchId(),
+        ...(options.onLockConflictRetrySignal ? {
+          onLockConflictRetrySignal: options.onLockConflictRetrySignal
+        } : {})
       });
     }, getActorAttribution, options.missingActorAttributionMessage, actor)) : missingInjectedMigrationWriteCoordinator);
   const makeMigrationWriteCoordinator = requiresConflictMarkerPreflight(command.action)
@@ -183,7 +190,10 @@ export async function runRegisteredCommandWithCliComposition(
       rootDir: command.rootDir,
       layoutOverrides: command.layoutOverrides,
       attribution: getActorAttribution().writeAttribution,
-      commitAuthor: getActorAttribution().commitAuthor
+      commitAuthor: getActorAttribution().commitAuthor,
+      ...(options.onLockConflictRetrySignal ? {
+        onLockConflictRetrySignal: options.onLockConflictRetrySignal
+      } : {})
     }), getActorAttribution, options.missingActorAttributionMessage, actor)) : missingInjectedWriteCoordinator);
   const makeSessionWriteCoordinator = requiresConflictMarkerPreflight(command.action)
     ? (actor: OperationalActor) => withConflictMarkerFlushRecheck(

--- a/packages/cli/src/composition/repo-write-child-entrypoint.ts
+++ b/packages/cli/src/composition/repo-write-child-entrypoint.ts
@@ -23,7 +23,10 @@ import type {
   DocSyncSubmitRequestV1,
   DocSyncSubmitResultV1
 } from "@harness-anything/application";
-import { resolveHarnessLayout } from "@harness-anything/kernel";
+import {
+  resolveHarnessLayout,
+  type RetryBudgetSignal
+} from "@harness-anything/kernel";
 import { defaultCliAdapterProvider } from "./adapter-registry.ts";
 import { cliDaemonCommandHostServices } from "./daemon-command-host-services.ts";
 import { cliDaemonServiceHostServices } from "./daemon-service-host-services.ts";
@@ -66,6 +69,33 @@ export async function runRepoWriteChildEntrypoint(
   if (!encodedConfig) throw new Error("REPO_WRITE_CHILD_LAUNCH_CONFIG_REQUIRED");
   const config = decodeRepoWriteChildLaunchConfig(encodedConfig);
   const transport = new RepoWriteChildIpcTransport();
+  const onPublicationRetryBudgetSignal = (signal: RetryBudgetSignal): void => {
+    const deliveryFailure = (error: unknown): void => {
+      process.emitWarning(
+        `Repo-write child could not forward publication retry-budget visibility to the parent daemon: ${boundedRecoveryError(error)}`,
+        { code: "REPO_WRITE_RETRY_BUDGET_SIGNAL_DELIVERY_FAILED" }
+      );
+    };
+    try {
+      void transport.send({
+        protocol: "harness-repo-write-ipc/v1",
+        repoId: config.repoId,
+        generation: config.generation,
+        kind: "retry-budget-signal",
+        phase: signal.phase,
+        operation: signal.event.operation,
+        cause: boundedRecoveryError(signal.event.cause),
+        failures: signal.event.failures,
+        retriesUsed: signal.event.retriesUsed,
+        elapsedMs: signal.event.elapsedMs,
+        ...(signal.event.remainingMs === undefined ? {} : {
+          remainingMs: signal.event.remainingMs
+        })
+      }).catch(deliveryFailure);
+    } catch (error) {
+      deliveryFailure(error);
+    }
+  };
   const reportStartupProgress = async (
     phase: RepoWriteStartupProgressPhase,
     workUnit = config.repoId
@@ -173,7 +203,8 @@ export async function runRepoWriteChildEntrypoint(
     resolveHarnessLayout({
       rootDir: config.canonicalRoot,
       ...(layoutOverrides ? { layoutOverrides } : {})
-    }).authoredRoot
+    }).authoredRoot,
+    { onRetryBudgetSignal: onPublicationRetryBudgetSignal }
   );
   const resolveHistoricalPublication = (
     outcome: import("@harness-anything/daemon").RepoWriteProceedingOutcomeV1
@@ -205,6 +236,7 @@ export async function runRepoWriteChildEntrypoint(
   const authorityLifecycle = createCliProductionAuthorityLifecycle({
     manifestPath: config.authorityManifest,
     ...(layoutOverrides ? { layoutOverrides } : {}),
+    onPublicationRetryBudgetSignal,
     backgroundRecovery: true
   });
   const repo = {

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -6,10 +6,13 @@ import { parseArgs } from "./cli/parse-args.ts";
 import { deprecationWarning } from "./cli/command-deprecations.ts";
 import { readOption, stripGlobalOptions } from "./cli/parse-options.ts";
 import { appendParseFailureRuntimeEvent } from "./cli/parse-failure-runtime-event.ts";
+import { makeDaemonLogService } from "@harness-anything/application";
 import {
   checkDaemonServeConfiguration as checkDaemonServeConfigurationRoot,
+  createDaemonRetryBudgetSignalSink,
   daemonAutostartRootIdentity,
   daemonAutostartRootLifetimeEnabled,
+  makeDaemonLogFileStore,
   resolveDaemonRuntimePolicy,
   runDaemonServe as runDaemonServeRoot
 } from "@harness-anything/daemon";
@@ -26,7 +29,7 @@ import {
 import { daemonStatusCliProjection } from "./commands/daemon/status-payload.ts";
 import { runDaemonConnect } from "./commands/daemon/connect.ts";
 import { runRegisteredCommandWithCliComposition } from "./composition/command-executor.ts";
-import { daemonIdFromEnv, daemonUserRoot, localUserDaemonEndpoint, runCommandThroughDaemon } from "./daemon/client.ts";
+import { daemonIdFromEnv, daemonUserRoot, localUserDaemonEndpoint, readDaemonUserRoot, runCommandThroughDaemon } from "./daemon/client.ts";
 import {
   parseDaemonLaunchArgv,
   preflightDaemonLaunch,
@@ -125,12 +128,30 @@ async function runDaemonBackedCommand<T>(run: () => Promise<T>): Promise<T> {
 async function runLocalRegisteredCommand(
   command: Parameters<typeof runRegisteredCommand>[0]
 ): Promise<CommandReceipt | CommandFailureReceipt> {
+  const localCoordinatorScope = isDeclaredLocalMigrationCommand(command.action)
+    ? "migration" as const
+    : process.env.HARNESS_DAEMON_MODE === "direct" && process.env.HARNESS_DIRECT_WRITE_REASON === "recovery"
+      ? "recovery" as const
+      : undefined;
+  const onLockConflictRetrySignal = localCoordinatorScope
+    ? createDaemonRetryBudgetSignalSink(
+        makeDaemonLogService({
+          store: makeDaemonLogFileStore({
+            userRoot: readDaemonUserRoot(process.env, command.rootDir, command.layoutOverrides)
+          })
+        }),
+        {
+          repo: {
+            repoId: command.daemonRepoId ?? "canonical",
+            canonicalRoot: path.resolve(command.rootDir)
+          }
+        },
+        { source: "cli" }
+      )
+    : undefined;
   return runTimedCommand(async () => toCommandReceipt(await runRegisteredCommand(command, {
-    ...(isDeclaredLocalMigrationCommand(command.action)
-      ? { localCoordinatorScope: "migration" }
-      : process.env.HARNESS_DAEMON_MODE === "direct" && process.env.HARNESS_DIRECT_WRITE_REASON === "recovery"
-        ? { localCoordinatorScope: "recovery" }
-        : {})
+    ...(localCoordinatorScope ? { localCoordinatorScope } : {}),
+    ...(onLockConflictRetrySignal ? { onLockConflictRetrySignal } : {})
   })));
 }
 

--- a/packages/cli/test/authority-lifecycle-seam.test.ts
+++ b/packages/cli/test/authority-lifecycle-seam.test.ts
@@ -381,6 +381,7 @@ test("production composition reads publication evidence from the repo's real aut
     git(authoredRoot, "checkout", "-q", trunk);
     git(authoredRoot, "merge", "-q", "--no-ff", "sessions/session-test", "-m", "materializer: merge session session-test");
     let observed: ReadonlyArray<string> = [];
+    const publicationVisibilityRepos: string[] = [];
     const hooks: AuthorityRepoLifecycleHooks = {
       ...hooksFixture([]),
       start: async ({ repo, inspectPublication }) => {
@@ -391,6 +392,10 @@ test("production composition reads publication evidence from the repo's real aut
     const controller = createAuthorityRepoLifecycleController({
       hooks,
       serviceStateRoot: serviceRoot,
+      resolvePublicationInspectorOptions: (repo) => {
+        publicationVisibilityRepos.push(repo.repoId);
+        return { onRetryBudgetSignal: () => undefined };
+      },
       resolveCompositionData: async (repo) => compositionFixture(repo)
     });
     const result = await controller.startRepo({ repoId: "alpha", canonicalRoot: alphaRoot }, runtimeFixture());
@@ -399,6 +404,7 @@ test("production composition reads publication evidence from the repo's real aut
       "tasks/task_T/INDEX.md",
       `attribution-events/${sha256Text("op-test")}.jsonl`
     ]);
+    assert.deepEqual(publicationVisibilityRepos, ["alpha"]);
     await controller.stopAll("daemon-shutdown");
   });
 });

--- a/packages/daemon/src/authority/authority-lifecycle.ts
+++ b/packages/daemon/src/authority/authority-lifecycle.ts
@@ -246,6 +246,10 @@ interface StartedAuthorityRepo {
   stopping?: Promise<void>;
 }
 
+type PublicationInspectorOptions = NonNullable<
+  Parameters<typeof createGitCanonicalPublicationInspector>[1]
+>;
+
 export function createAuthorityRepoLifecycleController(input: {
   readonly hooks: AuthorityRepoLifecycleHooks;
   readonly serviceStateRoot: string;
@@ -255,6 +259,9 @@ export function createAuthorityRepoLifecycleController(input: {
     runtime: AuthorityLifecycleRuntime
   ) => Promise<AuthorityRepoCompositionData>;
   readonly resolvePublicationRoot?: (repo: DaemonRepoNamespace) => string;
+  readonly resolvePublicationInspectorOptions?: (
+    repo: DaemonRepoNamespace
+  ) => PublicationInspectorOptions;
   /** Test-only escape hatch; production composition must carry durable adapter markers. */
   readonly allowInMemoryFixture?: true;
 }): AuthorityRepoLifecycleController {
@@ -314,7 +321,8 @@ export function createAuthorityRepoLifecycleController(input: {
       const serverData = await input.resolveCompositionData(repo, state, runtime);
       validateServerData(repo, serverData, input.allowInMemoryFixture === true);
       publicationInspector = createGitCanonicalPublicationInspector(
-        input.resolvePublicationRoot?.(repo) ?? resolveHarnessLayout(repo.canonicalRoot).authoredRoot
+        input.resolvePublicationRoot?.(repo) ?? resolveHarnessLayout(repo.canonicalRoot).authoredRoot,
+        input.resolvePublicationInspectorOptions?.(repo)
       );
       const attributedCoordinatorFactory = makeHeldLockAttributedCoordinatorFactory(runtime);
       component = await input.hooks.start({

--- a/packages/daemon/src/authority/production/production-authority-lifecycle.ts
+++ b/packages/daemon/src/authority/production/production-authority-lifecycle.ts
@@ -44,7 +44,8 @@ import { gateCutoverAdmission } from "./cutover-admission.ts";
 import {
   assertPublicationMatchesMutationSet,
   createGitAuthorityAttributionEvidenceCommitterV2,
-  createGitCanonicalPublicationInspector
+  createGitCanonicalPublicationInspector,
+  publicationRetryOptions
 } from "./publication-evidence.ts";
 import { createAuthorityProductionScanner } from "./production-scanner.ts";
 import {
@@ -88,6 +89,7 @@ interface RepoProductionMaterial {
   readonly replicationState: Parameters<typeof createPrewarmedAuthorityReplication>[0]["state"];
   readonly replicationContent: AuthorityReplicationContentStore;
   readonly replicaChangeLog: ReplicaChangeLog;
+  readonly daemonLogService?: DaemonLogService;
   readonly recovery: ProductionRecoveryState;
 }
 
@@ -164,7 +166,7 @@ export function createProductionAuthorityLifecycle(input: {
       });
       const replicationContent = replication.content;
       const replicaChangeLog = replication.changeLog;
-      const publicationInspector = createGitCanonicalPublicationInspector(authoredRoot);
+      const publicationInspector = createGitCanonicalPublicationInspector(authoredRoot, publicationRetryOptions(input.daemonLogService, config));
       const recoveryGenerationFence = createRuntimeDaemonGenerationWitnessFence({
         runtime,
         workspaceId: config.workspaceId,
@@ -239,6 +241,7 @@ export function createProductionAuthorityLifecycle(input: {
         replicationState: state.replicationState,
         replicationContent,
         replicaChangeLog,
+        ...(input.daemonLogService ? { daemonLogService: input.daemonLogService } : {}),
         recovery
       };
       materials.set(repo.repoId, material);
@@ -507,7 +510,7 @@ function createConnectionAuthorityService(
   },
   hostServices: ProductionAuthorityHostServices<ProductionAuthorityIdentity>
 ): AuthoritySubmissionService {
-  const publicationInspector = createGitCanonicalPublicationInspector(material.authoredRoot);
+  const publicationInspector = createGitCanonicalPublicationInspector(material.authoredRoot, publicationRetryOptions(material.daemonLogService, material.config));
   const writerGeneration = input.runtime.daemonGenerationContext?.()?.daemonGeneration;
   const generationFence = createRuntimeDaemonGenerationWitnessFence({
     runtime: input.runtime,

--- a/packages/daemon/src/authority/production/production-authority-lifecycle.ts
+++ b/packages/daemon/src/authority/production/production-authority-lifecycle.ts
@@ -76,6 +76,9 @@ import { connectionBoundRuntime } from "./connection-bound-runtime.ts";
 import { waitForProductionRecovery } from "./production-recovery-admission.ts";
 import { attestSubmissionService } from "./transport-attested-submission-service.ts";
 import { recoverProductionCommittedReceipt } from "./production-committed-receipt-recovery.ts";
+import type { RetryBudgetSignal } from "../../observability/visible-retry-budget.ts";
+import { settleProductionRecovery, type ProductionRecoveryState } from "./production-recovery-state.ts";
+import { createSerialPublicationExecutor } from "./serial-publication-executor.ts";
 export { recoverPendingProductionEvents } from "./recovery.ts";
 
 interface RepoProductionMaterial {
@@ -90,13 +93,13 @@ interface RepoProductionMaterial {
   readonly replicationContent: AuthorityReplicationContentStore;
   readonly replicaChangeLog: ReplicaChangeLog;
   readonly daemonLogService?: DaemonLogService;
+  readonly onPublicationRetryBudgetSignal?: (signal: RetryBudgetSignal) => void;
   readonly recovery: ProductionRecoveryState;
 }
 
-interface ProductionRecoveryState {
-  status: "recovering" | "complete" | "failed";
-  error?: string;
-  promise: Promise<void>;
+interface PublicationRetryVisibility {
+  readonly daemonLogService?: DaemonLogService;
+  readonly onPublicationRetryBudgetSignal?: (signal: RetryBudgetSignal) => void;
 }
 
 const productionAuthorityV2EntityKinds = [
@@ -112,6 +115,7 @@ export function createProductionAuthorityLifecycle(input: {
   readonly userRoot?: string;
   readonly layoutOverrides?: { readonly authoredRoot?: string };
   readonly daemonLogService?: DaemonLogService;
+  readonly onPublicationRetryBudgetSignal?: (signal: RetryBudgetSignal) => void;
   readonly backgroundRecovery?: true;
   readonly hostServices: ProductionAuthorityHostServices<ProductionAuthorityIdentity>;
 }): AuthorityRepoLifecycleController {
@@ -122,6 +126,10 @@ export function createProductionAuthorityLifecycle(input: {
   const controller = createAuthorityRepoLifecycleController({
     hooks,
     serviceStateRoot: manifest.serviceStateRoot,
+    resolvePublicationInspectorOptions: (repo) => {
+      const config = manifest.repos.find((candidate) => candidate.repoId === repo.repoId);
+      return config ? productionPublicationRetryOptions(input, config) : {};
+    },
     resolveCompositionData: async (repo, state, runtime) => {
       const config = manifest.repos.find((candidate) => candidate.repoId === repo.repoId);
       if (!config || canonicalRoot(config.canonicalRoot) !== canonicalRoot(repo.canonicalRoot)) {
@@ -166,7 +174,10 @@ export function createProductionAuthorityLifecycle(input: {
       });
       const replicationContent = replication.content;
       const replicaChangeLog = replication.changeLog;
-      const publicationInspector = createGitCanonicalPublicationInspector(authoredRoot, publicationRetryOptions(input.daemonLogService, config));
+      const publicationInspector = createGitCanonicalPublicationInspector(
+        authoredRoot,
+        productionPublicationRetryOptions(input, config)
+      );
       const recoveryGenerationFence = createRuntimeDaemonGenerationWitnessFence({
         runtime,
         workspaceId: config.workspaceId,
@@ -242,6 +253,9 @@ export function createProductionAuthorityLifecycle(input: {
         replicationContent,
         replicaChangeLog,
         ...(input.daemonLogService ? { daemonLogService: input.daemonLogService } : {}),
+        ...(input.onPublicationRetryBudgetSignal ? {
+          onPublicationRetryBudgetSignal: input.onPublicationRetryBudgetSignal
+        } : {}),
         recovery
       };
       materials.set(repo.repoId, material);
@@ -487,20 +501,6 @@ function createRepoComponent(
   };
 }
 
-async function settleProductionRecovery(
-  recovery: ProductionRecoveryState,
-  run: () => Promise<void>
-): Promise<void> {
-  try {
-    await run();
-    recovery.status = "complete";
-    recovery.error = undefined;
-  } catch (error) {
-    recovery.status = "failed";
-    recovery.error = recoveryErrorSummary(error);
-  }
-}
-
 function createConnectionAuthorityService(
   input: Parameters<AuthorityRepoLifecycleHooks["start"]>[0],
   material: RepoProductionMaterial,
@@ -510,7 +510,10 @@ function createConnectionAuthorityService(
   },
   hostServices: ProductionAuthorityHostServices<ProductionAuthorityIdentity>
 ): AuthoritySubmissionService {
-  const publicationInspector = createGitCanonicalPublicationInspector(material.authoredRoot, publicationRetryOptions(material.daemonLogService, material.config));
+  const publicationInspector = createGitCanonicalPublicationInspector(
+    material.authoredRoot,
+    productionPublicationRetryOptions(material, material.config)
+  );
   const writerGeneration = input.runtime.daemonGenerationContext?.()?.daemonGeneration;
   const generationFence = createRuntimeDaemonGenerationWitnessFence({
     runtime: input.runtime,
@@ -553,17 +556,13 @@ function createConnectionAuthorityService(
   });
 }
 
-function createSerialPublicationExecutor(): {
-  readonly run: <Result>(publication: () => Promise<Result>) => Promise<Result>;
-} {
-  let tail = Promise.resolve();
-  return {
-    run: <Result>(publication: () => Promise<Result>): Promise<Result> => {
-      const result = tail.then(publication, publication);
-      tail = result.then(() => undefined, () => undefined);
-      return result;
-    }
-  };
+function productionPublicationRetryOptions(
+  visibility: PublicationRetryVisibility,
+  config: AuthorityProductionRepoConfigV1
+): ReturnType<typeof publicationRetryOptions> {
+  return visibility.onPublicationRetryBudgetSignal
+    ? { onRetryBudgetSignal: visibility.onPublicationRetryBudgetSignal }
+    : publicationRetryOptions(visibility.daemonLogService, config);
 }
 
 function assertConnectionContext(

--- a/packages/daemon/src/authority/production/production-recovery-state.ts
+++ b/packages/daemon/src/authority/production/production-recovery-state.ts
@@ -1,0 +1,21 @@
+import { recoveryErrorSummary } from "./recovery.ts";
+
+export interface ProductionRecoveryState {
+  status: "recovering" | "complete" | "failed";
+  error?: string;
+  promise: Promise<void>;
+}
+
+export async function settleProductionRecovery(
+  recovery: ProductionRecoveryState,
+  run: () => Promise<void>
+): Promise<void> {
+  try {
+    await run();
+    recovery.status = "complete";
+    recovery.error = undefined;
+  } catch (error) {
+    recovery.status = "failed";
+    recovery.error = recoveryErrorSummary(error);
+  }
+}

--- a/packages/daemon/src/authority/production/publication-evidence.ts
+++ b/packages/daemon/src/authority/production/publication-evidence.ts
@@ -2,7 +2,7 @@ import { execFile, execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import path from "node:path";
 import { promisify } from "node:util";
-import type { CanonicalPublicationInspector } from "@harness-anything/application";
+import type { CanonicalPublicationInspector, DaemonLogService } from "@harness-anything/application";
 import {
   encodeCanonicalCbor,
   makeLocalAuthorityAttributionEventV2Log,
@@ -42,8 +42,19 @@ import {
   readPublicationGitObject,
   shutdownPublicationGitObjectReader
 } from "./publication-object-reader.ts";
+import type { RetryBudgetSignal } from "../../observability/visible-retry-budget.ts";
+import { createDaemonRetryBudgetSignalSink } from "../../observability/daemon-retry-budget-log.ts";
 
 export { assertPublicationMatchesMutationSet } from "./publication-mutation-proof.ts";
+
+export function publicationRetryOptions(
+  logs: DaemonLogService | undefined,
+  repo: { readonly repoId: string; readonly canonicalRoot: string }
+): { readonly onRetryBudgetSignal?: (signal: RetryBudgetSignal) => void } {
+  return logs
+    ? { onRetryBudgetSignal: createDaemonRetryBudgetSignalSink(logs, { repo }) }
+    : {};
+}
 
 const materializerCommitter = {
   name: "Harness Anything Materializer",
@@ -197,7 +208,10 @@ function assertEvidenceOnlyStaged(stagedText: string, pendingPaths: ReadonlySet<
   }
 }
 
-export function createGitCanonicalPublicationInspector(canonicalRoot: string): GitCanonicalPublicationInspector {
+export function createGitCanonicalPublicationInspector(
+  canonicalRoot: string,
+  options: { readonly onRetryBudgetSignal?: (signal: RetryBudgetSignal) => void } = {}
+): GitCanonicalPublicationInspector {
   const rootDir = path.resolve(canonicalRoot);
   const currentHead = async (): Promise<string | null> =>
     gitOptionalAsync(rootDir, "rev-parse", "--verify", "HEAD");
@@ -420,8 +434,8 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
     for (const changedPath of changedPaths) {
       physicalChanges.push({
         path: changedPath,
-        beforeDigest: await blobDigestAsync(rootDir, publicationBase, changedPath),
-        afterDigest: await blobDigestAsync(rootDir, head, changedPath)
+        beforeDigest: await blobDigestAsync(rootDir, publicationBase, changedPath, options),
+        afterDigest: await blobDigestAsync(rootDir, head, changedPath, options)
       });
     }
     physicalChanges.sort((left, right) => Buffer.compare(
@@ -509,7 +523,7 @@ export function createGitCanonicalPublicationInspector(canonicalRoot: string): G
         opId,
         publication,
         readAtCommit: (commitSha, eventPath) =>
-          readPublicationGitObject(rootDir, `${commitSha}:${eventPath}`)
+          readPublicationGitObject(rootDir, `${commitSha}:${eventPath}`, options)
       });
     }
   };
@@ -522,10 +536,11 @@ function yieldToEventLoop(): Promise<void> {
 async function blobDigestAsync(
   rootDir: string,
   revision: string,
-  changedPath: string
+  changedPath: string,
+  options: { readonly onRetryBudgetSignal?: (signal: RetryBudgetSignal) => void }
 ): Promise<string | null> {
   try {
-    const bytes = await readPublicationGitObject(rootDir, `${revision}:${changedPath}`);
+    const bytes = await readPublicationGitObject(rootDir, `${revision}:${changedPath}`, options);
     return createHash("sha256").update(bytes).digest("hex");
   } catch {
     return null;

--- a/packages/daemon/src/authority/production/publication-object-reader.ts
+++ b/packages/daemon/src/authority/production/publication-object-reader.ts
@@ -7,6 +7,8 @@ import { createHash } from "node:crypto";
 import { realpathSync } from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
+import { createBoundedRetryBudget, type BoundedRetryBudget } from "@harness-anything/kernel";
+import type { RetryBudgetSignal } from "../../observability/visible-retry-budget.ts";
 
 const maximumBatchHeaderBytes = 64 * 1024;
 const maximumGitObjectBytes = 64 * 1024 * 1024;
@@ -59,14 +61,20 @@ export function assertVerifiedGitObjectContent(input: {
   }
 }
 
-export function readPublicationGitObject(rootDir: string, objectName: string): Promise<Buffer> {
+export function readPublicationGitObject(
+  rootDir: string,
+  objectName: string,
+  options: { readonly onRetryBudgetSignal?: (signal: RetryBudgetSignal) => void } = {}
+): Promise<Buffer> {
   const inputRoot = path.resolve(rootDir);
   const canonicalRoot = canonicalGitRoot(rootDir);
   canonicalRootsByInput.set(inputRoot, canonicalRoot);
   let reader = readersByRoot.get(canonicalRoot);
   if (!reader) {
-    reader = new PublicationGitObjectReader(canonicalRoot);
+    reader = new PublicationGitObjectReader(canonicalRoot, options.onRetryBudgetSignal);
     readersByRoot.set(canonicalRoot, reader);
+  } else if (options.onRetryBudgetSignal) {
+    reader.useRetryBudgetSignal(options.onRetryBudgetSignal);
   }
   return reader.read(objectName);
 }
@@ -92,10 +100,32 @@ class PublicationGitObjectReader {
   private queue: Promise<void> = Promise.resolve();
   private closed = false;
   private batchDisabled = false;
-  private consecutiveRebuilds = 0;
+  private readonly retryBudget: BoundedRetryBudget;
+  private onRetryBudgetSignal: ((signal: RetryBudgetSignal) => void) | undefined;
 
-  constructor(rootDir: string) {
+  constructor(rootDir: string, onRetryBudgetSignal?: (signal: RetryBudgetSignal) => void) {
     this.rootDir = rootDir;
+    this.onRetryBudgetSignal = onRetryBudgetSignal;
+    this.retryBudget = createBoundedRetryBudget({
+      operation: "publication-git-object-batch",
+      budget: { maxRetries: maximumConsecutiveRebuilds },
+      onExhausted: (event) => {
+        if (this.onRetryBudgetSignal) {
+          this.onRetryBudgetSignal({ phase: "exhausted", event });
+        } else {
+          reportBatchFailure(
+            "AUTHORITY_GIT_OBJECT_BATCH_RETRY_BUDGET_EXHAUSTED",
+            this.rootDir,
+            event.cause,
+            "batch=disabled;request=fork"
+          );
+        }
+      }
+    });
+  }
+
+  useRetryBudgetSignal(signal: (signal: RetryBudgetSignal) => void): void {
+    this.onRetryBudgetSignal = signal;
   }
 
   read(objectName: string): Promise<Buffer> {
@@ -127,27 +157,21 @@ class PublicationGitObjectReader {
       this.batch = undefined;
       await batch.terminate();
       if (this.closed) throw error;
-      if (this.consecutiveRebuilds < maximumConsecutiveRebuilds) {
-        this.consecutiveRebuilds += 1;
+      const decision = this.retryBudget.recordFailure(error);
+      if (decision.status === "retry-allowed") {
         this.batch = new GitCatFileBatchProcess(this.rootDir);
         reportBatchFailure(
           "AUTHORITY_GIT_OBJECT_BATCH_RESTARTED",
           this.rootDir,
           error,
-          `rebuild=${this.consecutiveRebuilds}/${maximumConsecutiveRebuilds};request=fork`
+          `rebuild=${decision.retriesUsed + 1}/${maximumConsecutiveRebuilds};request=fork`
         );
       } else {
         this.batchDisabled = true;
-        reportBatchFailure(
-          "AUTHORITY_GIT_OBJECT_BATCH_RETRY_BUDGET_EXHAUSTED",
-          this.rootDir,
-          error,
-          "batch=disabled;request=fork"
-        );
       }
       return oneShotGitObject(this.rootDir, objectName);
     }
-    this.consecutiveRebuilds = 0;
+    this.retryBudget.reset();
     if (response.missing) throw new GitObjectBatchMissingError(objectName);
     return response.content;
   }

--- a/packages/daemon/src/authority/production/serial-publication-executor.ts
+++ b/packages/daemon/src/authority/production/serial-publication-executor.ts
@@ -1,0 +1,12 @@
+export function createSerialPublicationExecutor(): {
+  readonly run: <Result>(publication: () => Promise<Result>) => Promise<Result>;
+} {
+  let tail = Promise.resolve();
+  return {
+    run: <Result>(publication: () => Promise<Result>): Promise<Result> => {
+      const result = tail.then(publication, publication);
+      tail = result.then(() => undefined, () => undefined);
+      return result;
+    }
+  };
+}

--- a/packages/daemon/src/broker/remote-broker-runtime.ts
+++ b/packages/daemon/src/broker/remote-broker-runtime.ts
@@ -12,6 +12,8 @@ import {
   RemoteReadDownSession,
   type RemoteReadDownSessionOptions
 } from "./remote-read-down-session.ts";
+import { defaultRetryBudget } from "./remote-read-down-contract.ts";
+import { createVisibleRetryBudget } from "../observability/visible-retry-budget.ts";
 import {
   asRemoteReadDownError,
   classifyRemoteReadDownFailure
@@ -261,6 +263,15 @@ export class RemoteBrokerRuntime {
       maximumMs: this.options.session.backoff?.maximumMs ?? 5_000,
       multiplier: this.options.session.backoff?.multiplier ?? 2
     };
+    const retryBudgetOptions = { ...defaultRetryBudget, ...this.options.session.retryBudget };
+    const retryBudget = createVisibleRetryBudget({
+      operation: "remote-broker-synchronization",
+      budget: { maxRetries: retryBudgetOptions.maxRetries },
+      reminderEveryFailures: retryBudgetOptions.reminderEveryFailures,
+      ...(this.options.session.onRetryBudgetSignal
+        ? { signal: this.options.session.onRetryBudgetSignal }
+        : {})
+    });
     let delay = backoff.initialMs;
     while (!this.stopped && !this.terminalFailure && this.lifecycle === "ACTIVE") {
       await this.retryWait(delay);
@@ -268,13 +279,18 @@ export class RemoteBrokerRuntime {
       try {
         await this.session.refresh();
         const state = await this.broker.synchronize();
-        if (state.mode === "READY") return;
+        if (state.mode === "READY") {
+          retryBudget.recovered();
+          return;
+        }
+        retryBudget.recordFailure(new Error(`remote broker remained in ${state.mode}`));
       } catch (error) {
         const failure = asRemoteReadDownError(error);
         if (classifyRemoteReadDownFailure(failure) === "TERMINAL") {
           this.latchTerminal(failure);
           return;
         }
+        retryBudget.recordFailure(failure);
         this.options.session.onDiagnostic?.(
           `remote broker synchronization retry deferred: ${failure.message}`
         );

--- a/packages/daemon/src/broker/remote-read-down-contract.ts
+++ b/packages/daemon/src/broker/remote-read-down-contract.ts
@@ -4,6 +4,7 @@ import type {
   AuthoritySnapshotReservation
 } from "../authority/protocol.ts";
 import type { PersistentSshAuthorityClient } from "../transport/persistent-ssh-authority-client.ts";
+import type { RetryBudgetSignal } from "../observability/visible-retry-budget.ts";
 
 export interface RemoteReadDownBackoff {
   readonly initialMs: number;
@@ -16,6 +17,11 @@ export interface RemoteReadDownChangeCacheLimits {
   readonly maxBytes: number;
 }
 
+export interface RemoteReadDownRetryBudget {
+  readonly maxRetries: number;
+  readonly reminderEveryFailures: number;
+}
+
 export interface RemoteReadDownSessionOptions {
   readonly client: PersistentSshAuthorityClient;
   readonly workspaceId: string;
@@ -25,8 +31,10 @@ export interface RemoteReadDownSessionOptions {
   readonly sleep?: (milliseconds: number) => Promise<void>;
   readonly schedule?: (milliseconds: number, callback: () => void) => { readonly dispose: () => void };
   readonly changeCache?: Partial<RemoteReadDownChangeCacheLimits>;
+  readonly retryBudget?: Partial<RemoteReadDownRetryBudget>;
   readonly expectedResume?: ResumeCursor;
   readonly onDiagnostic?: (text: string) => void;
+  readonly onRetryBudgetSignal?: (signal: RetryBudgetSignal) => void;
   readonly onTerminal?: (failure: Error) => void;
 }
 
@@ -91,6 +99,11 @@ export const defaultChangeCache: RemoteReadDownChangeCacheLimits = {
   maxBytes: 8 * 1024 * 1024
 };
 
+export const defaultRetryBudget: RemoteReadDownRetryBudget = {
+  maxRetries: 5,
+  reminderEveryFailures: 5
+};
+
 export function assertBackoff(backoff: RemoteReadDownBackoff): void {
   if (!Number.isFinite(backoff.initialMs)
     || !Number.isFinite(backoff.maximumMs)
@@ -98,7 +111,7 @@ export function assertBackoff(backoff: RemoteReadDownBackoff): void {
     || backoff.initialMs < 0
     || backoff.maximumMs < backoff.initialMs
     || backoff.multiplier < 1) {
-    throw new Error("remote read-down backoff must be finite, non-negative, and bounded");
+    throw new Error("remote read-down backoff must be finite, non-negative, and interval-capped");
   }
 }
 
@@ -108,5 +121,14 @@ export function assertChangeCache(cache: RemoteReadDownChangeCacheLimits): void 
     || cache.maxCount < 1
     || cache.maxBytes < 1) {
     throw new Error("remote read-down change cache limits must be positive safe integers");
+  }
+}
+
+export function assertRetryBudget(budget: RemoteReadDownRetryBudget): void {
+  if (!Number.isSafeInteger(budget.maxRetries)
+    || !Number.isSafeInteger(budget.reminderEveryFailures)
+    || budget.maxRetries < 0
+    || budget.reminderEveryFailures < 1) {
+    throw new Error("remote read-down retry budget must use non-negative retries and positive reminders");
   }
 }

--- a/packages/daemon/src/broker/remote-read-down-fetch.ts
+++ b/packages/daemon/src/broker/remote-read-down-fetch.ts
@@ -11,6 +11,7 @@ import {
   advanceRemoteReadDownBackoff,
   createRemoteResyncError
 } from "./remote-read-down-state.ts";
+import { createVisibleRetryBudget, type RetryBudgetSignal } from "../observability/visible-retry-budget.ts";
 
 export async function fetchRemoteChanges(input: {
   readonly active: ActiveSnapshot;
@@ -27,7 +28,15 @@ export async function fetchRemoteChanges(input: {
   readonly ready: () => Promise<ActiveSnapshot>;
   readonly sleep: (milliseconds: number) => Promise<void>;
   readonly stopped: () => boolean;
+  readonly retryBudget: { readonly maxRetries: number; readonly reminderEveryFailures: number };
+  readonly retryBudgetSignal: ((signal: RetryBudgetSignal) => void) | undefined;
 }): Promise<ReadonlyArray<ReplicaChangeRecord>> {
+  const retryBudget = createVisibleRetryBudget({
+    operation: "remote-read-down-fetch",
+    budget: { maxRetries: input.retryBudget.maxRetries },
+    reminderEveryFailures: input.retryBudget.reminderEveryFailures,
+    ...(input.retryBudgetSignal ? { signal: input.retryBudgetSignal } : {})
+  });
   let current = input.active;
   let delay = input.backoff.initialMs;
   for (;;) {
@@ -37,6 +46,7 @@ export async function fetchRemoteChanges(input: {
       input.assertCurrent(current);
       validateChanges(result.changes, input.revision, input.workspaceId);
       for (const change of result.changes) input.storeChange(current, change);
+      retryBudget.recovered();
       return result.changes;
     } catch (error) {
       if (input.stopped()) throw asRemoteReadDownError(error);
@@ -45,6 +55,7 @@ export async function fetchRemoteChanges(input: {
         throw createRemoteResyncError(await input.ready(), error.message);
       }
       if (!(error instanceof AuthorityTransportDisconnectedError)) throw error;
+      retryBudget.recordFailure(error);
       input.invalidate(current);
       await input.sleep(delay);
       delay = advanceRemoteReadDownBackoff(delay, input.backoff);

--- a/packages/daemon/src/broker/remote-read-down-recovery.ts
+++ b/packages/daemon/src/broker/remote-read-down-recovery.ts
@@ -8,6 +8,7 @@ import {
   classifyRemoteReadDownFailure
 } from "./remote-read-down-failure.ts";
 import { advanceRemoteReadDownBackoff } from "./remote-read-down-state.ts";
+import { createVisibleRetryBudget, type RetryBudgetSignal } from "../observability/visible-retry-budget.ts";
 
 export async function recoverRemoteSnapshot(input: {
   readonly resume: ResumeCursor | undefined;
@@ -19,7 +20,15 @@ export async function recoverRemoteSnapshot(input: {
   readonly sleep: (milliseconds: number) => Promise<void>;
   readonly terminal: (error: unknown) => Error;
   readonly diagnostic: ((text: string) => void) | undefined;
+  readonly retryBudget: { readonly maxRetries: number; readonly reminderEveryFailures: number };
+  readonly retryBudgetSignal: ((signal: RetryBudgetSignal) => void) | undefined;
 }): Promise<ActiveSnapshot> {
+  const retryBudget = createVisibleRetryBudget({
+    operation: "remote-read-down-recovery",
+    budget: { maxRetries: input.retryBudget.maxRetries },
+    reminderEveryFailures: input.retryBudget.reminderEveryFailures,
+    ...(input.retryBudgetSignal ? { signal: input.retryBudgetSignal } : {})
+  });
   let delay = input.backoff.initialMs;
   let replaceConnection = input.resume !== undefined;
   for (;;) {
@@ -31,6 +40,7 @@ export async function recoverRemoteSnapshot(input: {
       if (classifyRemoteReadDownFailure(error) === "TERMINAL") {
         throw input.terminal(error);
       }
+      retryBudget.recordFailure(error);
       await retry(input, error, delay);
       delay = advanceRemoteReadDownBackoff(delay, input.backoff);
       replaceConnection = true;
@@ -39,12 +49,14 @@ export async function recoverRemoteSnapshot(input: {
     try {
       const active = await input.openSnapshot(input.resume);
       input.assertCurrent();
+      retryBudget.recovered();
       return active;
     } catch (error) {
       if (input.stopped()) throw asRemoteReadDownError(error);
       if (classifyRemoteReadDownFailure(error) === "TERMINAL") {
         throw input.terminal(error);
       }
+      retryBudget.recordFailure(error);
       await retry(input, error, delay);
       delay = advanceRemoteReadDownBackoff(delay, input.backoff);
       replaceConnection = true;

--- a/packages/daemon/src/broker/remote-read-down-session.ts
+++ b/packages/daemon/src/broker/remote-read-down-session.ts
@@ -10,11 +10,14 @@ import { BrokerCasStore } from "./cas-store.ts";
 import {
   assertBackoff,
   assertChangeCache,
+  assertRetryBudget,
   defaultBackoff,
   defaultChangeCache,
+  defaultRetryBudget,
   type ActiveSnapshot,
   type RemoteReadDownBackoff,
   type RemoteReadDownChangeCacheLimits,
+  type RemoteReadDownRetryBudget,
   type RemoteReadDownSessionHealth,
   type RemoteReadDownSessionOptions,
   type ResumeCursor
@@ -53,6 +56,7 @@ export {
   RemoteReplicaResyncRequiredError,
   type RemoteReadDownBackoff,
   type RemoteReadDownChangeCacheLimits,
+  type RemoteReadDownRetryBudget,
   type RemoteReadDownSessionHealth,
   type RemoteReadDownSessionOptions
 } from "./remote-read-down-contract.ts";
@@ -63,6 +67,7 @@ export class RemoteReadDownSession {
   private readonly blobReader: RemoteBlobReader;
   private readonly backoff: RemoteReadDownBackoff;
   private readonly changeCache: RemoteReadDownChangeCacheLimits;
+  private readonly retryBudget: RemoteReadDownRetryBudget;
   private readonly now: () => number;
   private readonly sleep: (milliseconds: number) => Promise<void>;
   private readonly listeners = new Set<(change: ReplicaChangeRecord) => void>();
@@ -89,6 +94,7 @@ export class RemoteReadDownSession {
     this.blobReader = new RemoteBlobReader(this.cas, options.client, () => this.assertOpen());
     this.backoff = { ...defaultBackoff, ...options.backoff };
     this.changeCache = { ...defaultChangeCache, ...options.changeCache };
+    this.retryBudget = { ...defaultRetryBudget, ...options.retryBudget };
     this.resumeCursor = options.expectedResume ? { ...options.expectedResume } : undefined;
     this.now = options.now ?? Date.now;
     this.sleep = options.sleep ?? ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
@@ -97,6 +103,7 @@ export class RemoteReadDownSession {
     });
     assertBackoff(this.backoff);
     assertChangeCache(this.changeCache);
+    assertRetryBudget(this.retryBudget);
     const listeners = registerRemoteReadDownListeners(
       options.client,
       (change) => this.receiveNotification(change),
@@ -273,7 +280,9 @@ export class RemoteReadDownSession {
       stopped: () => this.stopped,
       sleep: (milliseconds) => this.interruptibleSleep(milliseconds),
       terminal: (error) => this.setTerminal(error),
-      diagnostic: this.options.onDiagnostic
+      diagnostic: this.options.onDiagnostic,
+      retryBudget: this.retryBudget,
+      retryBudgetSignal: this.options.onRetryBudgetSignal
     });
     if (this.active) return this.active;
     this.active = active;
@@ -322,7 +331,9 @@ export class RemoteReadDownSession {
       },
       ready: () => this.ready(),
       sleep: (milliseconds) => this.interruptibleSleep(milliseconds),
-      stopped: () => this.stopped
+      stopped: () => this.stopped,
+      retryBudget: this.retryBudget,
+      retryBudgetSignal: this.options.onRetryBudgetSignal
     });
   }
 

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -113,6 +113,7 @@ export * from "./runtime/runtime-policy.ts";
 export * from "./lifecycle/daemon-lifecycle.ts";
 export * from "./lifecycle/daemon-generation.ts";
 export * from "./lifecycle/daemon-log-file-store.ts";
+export * from "./observability/daemon-retry-budget-log.ts";
 export * from "./lifecycle/compound-receipt-composition.ts";
 export * from "./lifecycle/compound-receipt-runner.ts";
 export * from "./lifecycle/daemon-drain.ts";

--- a/packages/daemon/src/lifecycle/compound-receipt-composition.ts
+++ b/packages/daemon/src/lifecycle/compound-receipt-composition.ts
@@ -8,6 +8,7 @@ import {
   type AuthorityOperationReceipt,
   type CompoundOperationReceiptV2,
   type GetWaiterFrameV1,
+  type DaemonLogService,
   type ReplicaChangeLog,
   type ReceiptIdentityV2,
   type ResultPreparedFrameV1,
@@ -21,6 +22,7 @@ import {
   type RemoteReadDownSessionOptions
 } from "@harness-anything/daemon";
 import { createDurableCompoundReceiptStoreV2 } from "./durable-compound-receipt-store.ts";
+import { createDaemonRetryBudgetSignalSink } from "../observability/daemon-retry-budget-log.ts";
 
 /**
  * The daemon-owned compound path.  Keeping this owner beside the daemon
@@ -64,8 +66,13 @@ export function createProductionCompoundReceiptComposition(input: {
   readonly viewId: string;
   readonly canonicalRoot: string;
   readonly stateDirectory: string;
+  readonly repoId?: string;
+  readonly daemonLogService?: DaemonLogService;
   readonly replicaChangeLog?: ReplicaChangeLog;
-  readonly remoteReadDown?: Omit<RemoteReadDownSessionOptions, "workspaceId" | "stateRoot">;
+  readonly remoteReadDown?: Omit<
+    RemoteReadDownSessionOptions,
+    "workspaceId" | "stateRoot" | "onRetryBudgetSignal"
+  >;
   readonly generationFence?: {
     readonly runExclusive: <Result>(
       input: { readonly workspaceId: string; readonly opId: string },
@@ -80,6 +87,9 @@ export function createProductionCompoundReceiptComposition(input: {
     };
   };
 }): ProductionCompoundReceiptComposition {
+  if (input.remoteReadDown && (!input.daemonLogService || !input.repoId)) {
+    throw new Error("production remote read-down requires daemon error-log visibility");
+  }
   mkdirSync(input.stateDirectory, { recursive: true, mode: 0o700 });
   const receipts = createCompoundReceiptServiceV2({
     store: createDurableCompoundReceiptStoreV2({
@@ -94,7 +104,13 @@ export function createProductionCompoundReceiptComposition(input: {
         viewId: input.viewId,
         viewRoot: input.canonicalRoot,
         stateRoot: brokerStateRoot,
-        session: input.remoteReadDown,
+        session: {
+          ...input.remoteReadDown,
+          onRetryBudgetSignal: createDaemonRetryBudgetSignalSink(
+            input.daemonLogService!,
+            { repo: { repoId: input.repoId!, canonicalRoot: input.canonicalRoot } }
+          )
+        },
         writerExclusion: processWriterExclusion(),
         watcherFence: processWatcherFence()
       })

--- a/packages/daemon/src/lifecycle/run-daemon-serve.ts
+++ b/packages/daemon/src/lifecycle/run-daemon-serve.ts
@@ -50,6 +50,7 @@ import {
   createProvenanceCapacityTelemetryTrigger
 } from "../observability/provenance-capacity-trigger.ts";
 import { scheduleProvenanceCapacityLog } from "../observability/provenance-capacity-log.ts";
+import { createRepoWriteRetryBudgetSignalSink } from "../observability/repo-write-retry-budget-log.ts";
 import {
   formatDaemonFailure,
   repoWriteGracefulFailureLog
@@ -281,6 +282,10 @@ export async function runDaemonServe<
             );
           }
           const provenanceCapacityTrigger = createProvenanceCapacityTelemetryTrigger();
+          const publicationRetryBudgetSignal = createRepoWriteRetryBudgetSignalSink(
+            daemonLogService,
+            { repo }
+          );
           const authoredGitRoot = resolveHarnessLayout({
             rootDir: repo.canonicalRoot,
             ...(layoutOverrides ? { layoutOverrides } : {})
@@ -360,6 +365,7 @@ export async function runDaemonServe<
                 requestId: frame.outerOpId
               }, { repo }).catch(() => undefined);
             },
+            onRetryBudgetSignal: publicationRetryBudgetSignal,
             onRequestTimeout: (diagnostic) => {
               void daemonLogService.append({
                 level: "error",

--- a/packages/daemon/src/observability/daemon-retry-budget-log.ts
+++ b/packages/daemon/src/observability/daemon-retry-budget-log.ts
@@ -1,0 +1,26 @@
+import type { DaemonLogRepoContext, DaemonLogService } from "@harness-anything/application";
+import type { RetryBudgetSignal } from "./visible-retry-budget.ts";
+
+export function createDaemonRetryBudgetSignalSink(
+  logs: DaemonLogService,
+  context: DaemonLogRepoContext
+): (signal: RetryBudgetSignal) => void {
+  return (signal) => {
+    const ongoing = signal.phase !== "recovered";
+    const event = signal.event;
+    const cause = event.cause instanceof Error ? event.cause.message : String(event.cause);
+    void logs.append({
+      level: ongoing ? "error" : "info",
+      source: "daemon",
+      component: "retry-budget",
+      event: `retry-budget.${signal.phase}`,
+      message: ongoing
+        ? `${event.operation} ${signal.phase === "exhausted" ? "exhausted its automatic retry budget" : "remains in escalated recovery"}; retriesUsed=${event.retriesUsed}; elapsedMs=${event.elapsedMs}; lastError=${cause}`
+        : `${event.operation} recovered after retry-budget escalation; retriesUsed=${event.retriesUsed}; elapsedMs=${event.elapsedMs}`,
+      ...(ongoing ? {
+        errorCode: "RETRY_BUDGET_EXHAUSTED",
+        hint: "Automatic recovery remains active; inspect the upstream dependency and continue monitoring ha daemon logs --errors."
+      } : {})
+    }, context).catch(() => undefined);
+  };
+}

--- a/packages/daemon/src/observability/daemon-retry-budget-log.ts
+++ b/packages/daemon/src/observability/daemon-retry-budget-log.ts
@@ -3,7 +3,8 @@ import type { RetryBudgetSignal } from "./visible-retry-budget.ts";
 
 export function createDaemonRetryBudgetSignalSink(
   logs: DaemonLogService,
-  context: DaemonLogRepoContext
+  context: DaemonLogRepoContext,
+  options: { readonly source?: "daemon" | "cli" } = {}
 ): (signal: RetryBudgetSignal) => void {
   return (signal) => {
     const ongoing = signal.phase !== "recovered";
@@ -11,7 +12,7 @@ export function createDaemonRetryBudgetSignalSink(
     const cause = event.cause instanceof Error ? event.cause.message : String(event.cause);
     void logs.append({
       level: ongoing ? "error" : "info",
-      source: "daemon",
+      source: options.source ?? "daemon",
       component: "retry-budget",
       event: `retry-budget.${signal.phase}`,
       message: ongoing

--- a/packages/daemon/src/observability/repo-write-retry-budget-log.ts
+++ b/packages/daemon/src/observability/repo-write-retry-budget-log.ts
@@ -1,0 +1,28 @@
+import type {
+  DaemonLogRepoContext,
+  DaemonLogService
+} from "@harness-anything/application";
+import type {
+  RepoWriteRetryBudgetSignalFrame
+} from "../runtime/repo-write-protocol.ts";
+import { createDaemonRetryBudgetSignalSink } from "./daemon-retry-budget-log.ts";
+
+export function createRepoWriteRetryBudgetSignalSink(
+  logs: DaemonLogService,
+  context: DaemonLogRepoContext
+): (frame: RepoWriteRetryBudgetSignalFrame) => void {
+  const sink = createDaemonRetryBudgetSignalSink(logs, context);
+  return (frame) => sink({
+    phase: frame.phase,
+    event: {
+      operation: frame.operation,
+      cause: frame.cause,
+      failures: frame.failures,
+      retriesUsed: frame.retriesUsed,
+      elapsedMs: frame.elapsedMs,
+      ...(frame.remainingMs === undefined ? {} : {
+        remainingMs: frame.remainingMs
+      })
+    }
+  });
+}

--- a/packages/daemon/src/observability/visible-retry-budget.ts
+++ b/packages/daemon/src/observability/visible-retry-budget.ts
@@ -1,62 +1,6 @@
-import {
-  createBoundedRetryBudget,
-  type RetryBudgetDecision,
-  type RetryBudgetEvent,
-  type RetryBudgetLimits
+export {
+  createVisibleRetryBudget,
+  type RetryBudgetSignal,
+  type RetryBudgetSignalPhase,
+  type VisibleRetryBudget
 } from "@harness-anything/kernel";
-
-export type RetryBudgetSignalPhase = "exhausted" | "still-retrying" | "recovered";
-
-export interface RetryBudgetSignal {
-  readonly phase: RetryBudgetSignalPhase;
-  readonly event: RetryBudgetEvent;
-}
-
-export interface VisibleRetryBudget {
-  recordFailure(cause: unknown): RetryBudgetDecision;
-  recovered(): void;
-}
-
-export function createVisibleRetryBudget(input: {
-  readonly operation: string;
-  readonly budget: RetryBudgetLimits;
-  readonly reminderEveryFailures: number;
-  readonly signal?: (signal: RetryBudgetSignal) => void;
-}): VisibleRetryBudget {
-  if (!Number.isSafeInteger(input.reminderEveryFailures) || input.reminderEveryFailures < 1) {
-    throw new Error("retry escalation reminderEveryFailures must be a positive safe integer");
-  }
-  let escalated = false;
-  let lastSignalFailure = 0;
-  let lastEvent: RetryBudgetEvent | undefined;
-  const retry = createBoundedRetryBudget({
-    operation: input.operation,
-    budget: input.budget,
-    onExhausted: (event) => {
-      escalated = true;
-      lastSignalFailure = event.failures;
-      lastEvent = event;
-      input.signal?.({ phase: "exhausted", event });
-    }
-  });
-  return {
-    recordFailure(cause) {
-      const decision = retry.recordFailure(cause);
-      lastEvent = decision;
-      if (decision.status === "budget-exhausted"
-        && escalated
-        && decision.failures - lastSignalFailure >= input.reminderEveryFailures) {
-        lastSignalFailure = decision.failures;
-        input.signal?.({ phase: "still-retrying", event: decision });
-      }
-      return decision;
-    },
-    recovered() {
-      if (escalated && lastEvent) input.signal?.({ phase: "recovered", event: lastEvent });
-      retry.reset();
-      escalated = false;
-      lastSignalFailure = 0;
-      lastEvent = undefined;
-    }
-  };
-}

--- a/packages/daemon/src/observability/visible-retry-budget.ts
+++ b/packages/daemon/src/observability/visible-retry-budget.ts
@@ -1,0 +1,62 @@
+import {
+  createBoundedRetryBudget,
+  type RetryBudgetDecision,
+  type RetryBudgetEvent,
+  type RetryBudgetLimits
+} from "@harness-anything/kernel";
+
+export type RetryBudgetSignalPhase = "exhausted" | "still-retrying" | "recovered";
+
+export interface RetryBudgetSignal {
+  readonly phase: RetryBudgetSignalPhase;
+  readonly event: RetryBudgetEvent;
+}
+
+export interface VisibleRetryBudget {
+  recordFailure(cause: unknown): RetryBudgetDecision;
+  recovered(): void;
+}
+
+export function createVisibleRetryBudget(input: {
+  readonly operation: string;
+  readonly budget: RetryBudgetLimits;
+  readonly reminderEveryFailures: number;
+  readonly signal?: (signal: RetryBudgetSignal) => void;
+}): VisibleRetryBudget {
+  if (!Number.isSafeInteger(input.reminderEveryFailures) || input.reminderEveryFailures < 1) {
+    throw new Error("retry escalation reminderEveryFailures must be a positive safe integer");
+  }
+  let escalated = false;
+  let lastSignalFailure = 0;
+  let lastEvent: RetryBudgetEvent | undefined;
+  const retry = createBoundedRetryBudget({
+    operation: input.operation,
+    budget: input.budget,
+    onExhausted: (event) => {
+      escalated = true;
+      lastSignalFailure = event.failures;
+      lastEvent = event;
+      input.signal?.({ phase: "exhausted", event });
+    }
+  });
+  return {
+    recordFailure(cause) {
+      const decision = retry.recordFailure(cause);
+      lastEvent = decision;
+      if (decision.status === "budget-exhausted"
+        && escalated
+        && decision.failures - lastSignalFailure >= input.reminderEveryFailures) {
+        lastSignalFailure = decision.failures;
+        input.signal?.({ phase: "still-retrying", event: decision });
+      }
+      return decision;
+    },
+    recovered() {
+      if (escalated && lastEvent) input.signal?.({ phase: "recovered", event: lastEvent });
+      retry.reset();
+      escalated = false;
+      lastSignalFailure = 0;
+      lastEvent = undefined;
+    }
+  };
+}

--- a/packages/daemon/src/runtime/repo-write-client-contract.ts
+++ b/packages/daemon/src/runtime/repo-write-client-contract.ts
@@ -2,6 +2,7 @@ import type {
   RepoWriteChildMessage,
   RepoWriteParentMessage,
   RepoWriteRecoveryDiagnosticFrame,
+  RepoWriteRetryBudgetSignalFrame,
   RepoWriteTelemetryFrame
 } from "./repo-write-protocol.ts";
 import type {
@@ -61,6 +62,7 @@ export interface RepoWriteClientOptions {
   readonly limits?: Partial<RepoWriteClientLimits>;
   readonly onTelemetry: (frame: RepoWriteTelemetryFrame) => void;
   readonly onDiagnostic?: (frame: RepoWriteRecoveryDiagnosticFrame) => void;
+  readonly onRetryBudgetSignal?: (frame: RepoWriteRetryBudgetSignalFrame) => void;
   readonly onRequestTimeout?: (
     diagnostic: RepoWriteRequestTimeoutDiagnostic
   ) => void;

--- a/packages/daemon/src/runtime/repo-write-client-observers.ts
+++ b/packages/daemon/src/runtime/repo-write-client-observers.ts
@@ -1,5 +1,6 @@
 import type {
   RepoWriteRecoveryDiagnosticFrame,
+  RepoWriteRetryBudgetSignalFrame,
   RepoWriteTelemetryFrame
 } from "./repo-write-protocol.ts";
 import { repoWriteProtocolType } from "./repo-write-protocol.ts";
@@ -23,6 +24,17 @@ export function observeRepoWriteTelemetry(
 export function observeRepoWriteRecoveryDiagnostic(
   observer: ((frame: RepoWriteRecoveryDiagnosticFrame) => void) | undefined,
   frame: RepoWriteRecoveryDiagnosticFrame
+): void {
+  try {
+    observer?.(frame);
+  } catch {
+    // Operational logging cannot change writer protocol or recovery state.
+  }
+}
+
+export function observeRepoWriteRetryBudgetSignal(
+  observer: ((frame: RepoWriteRetryBudgetSignalFrame) => void) | undefined,
+  frame: RepoWriteRetryBudgetSignalFrame
 ): void {
   try {
     observer?.(frame);

--- a/packages/daemon/src/runtime/repo-write-client.ts
+++ b/packages/daemon/src/runtime/repo-write-client.ts
@@ -34,6 +34,7 @@ import {
 } from "./repo-write-client-telemetry.ts";
 import {
   observeRepoWriteRecoveryDiagnostic,
+  observeRepoWriteRetryBudgetSignal,
   observeRepoWriteTelemetry,
   repoWriteClientFrameBase
 } from "./repo-write-client-observers.ts";
@@ -353,6 +354,10 @@ export class RepoWriteClient {
     }
     if (message.kind === "recovery-deferred" || message.kind === "recovery-rejected") {
       observeRepoWriteRecoveryDiagnostic(this.options.onDiagnostic, message);
+      return;
+    }
+    if (message.kind === "retry-budget-signal") {
+      observeRepoWriteRetryBudgetSignal(this.options.onRetryBudgetSignal, message);
       return;
     }
     if (message.kind === "failure") {

--- a/packages/daemon/src/runtime/repo-write-diagnostic-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-diagnostic-protocol.ts
@@ -141,5 +141,23 @@ export interface RepoWriteRecoveryRejectedFrame extends RepoWriteDiagnosticFrame
   readonly next: string;
 }
 
+export const repoWriteRetryBudgetSignalPhases = [
+  "exhausted", "still-retrying", "recovered"
+] as const;
+
+export type RepoWriteRetryBudgetSignalPhase =
+  typeof repoWriteRetryBudgetSignalPhases[number];
+
+export interface RepoWriteRetryBudgetSignalFrame extends RepoWriteDiagnosticFrameBase {
+  readonly kind: "retry-budget-signal";
+  readonly phase: RepoWriteRetryBudgetSignalPhase;
+  readonly operation: string;
+  readonly cause: string;
+  readonly failures: number;
+  readonly retriesUsed: number;
+  readonly elapsedMs: number;
+  readonly remainingMs?: number;
+}
+
 export type RepoWriteRecoveryDiagnosticFrame =
   RepoWriteRecoveryDeferredFrame | RepoWriteRecoveryRejectedFrame;

--- a/packages/daemon/src/runtime/repo-write-process-supervisor.ts
+++ b/packages/daemon/src/runtime/repo-write-process-supervisor.ts
@@ -23,6 +23,7 @@ export interface RepoWriteProcessSupervisorOptions {
   readonly limits?: ConstructorParameters<typeof RepoWriteClient>[0]["limits"];
   readonly onTelemetry?: ConstructorParameters<typeof RepoWriteClient>[0]["onTelemetry"];
   readonly onDiagnostic?: ConstructorParameters<typeof RepoWriteClient>[0]["onDiagnostic"];
+  readonly onRetryBudgetSignal?: ConstructorParameters<typeof RepoWriteClient>[0]["onRetryBudgetSignal"];
   readonly onRequestTimeout?: ConstructorParameters<typeof RepoWriteClient>[0]["onRequestTimeout"];
   readonly onRequestFailure?: ConstructorParameters<typeof RepoWriteClient>[0]["onRequestFailure"];
   readonly onGracefulStopFailure?: (error: unknown) => void | Promise<void>;
@@ -281,6 +282,7 @@ export class RepoWriteProcessSupervisor {
         ...(this.options.limits ? { limits: this.options.limits } : {}),
         onTelemetry: this.options.onTelemetry ?? (() => undefined),
         onDiagnostic: this.options.onDiagnostic,
+        onRetryBudgetSignal: this.options.onRetryBudgetSignal,
         onRequestTimeout: this.options.onRequestTimeout,
         onRequestFailure: this.options.onRequestFailure
       });

--- a/packages/daemon/src/runtime/repo-write-protocol-recovery.ts
+++ b/packages/daemon/src/runtime/repo-write-protocol-recovery.ts
@@ -1,0 +1,78 @@
+import type {
+  RepoWriteRecoveryDeferredFrame,
+  RepoWriteRecoveryRejectedFrame
+} from "./repo-write-diagnostic-protocol.ts";
+import type { RepoWriteProtocolLimits } from "./repo-write-protocol.ts";
+import {
+  invalidRepoWriteProtocol as invalid,
+  limitRepoWriteProtocol as limit
+} from "./repo-write-protocol-errors.ts";
+
+type RecoveryFrameRecord = Record<string, unknown> & {
+  readonly kind: string;
+};
+
+type RecoveryBaseFields = Pick<
+  RepoWriteRecoveryDeferredFrame,
+  "protocol" | "repoId" | "generation"
+>;
+
+export function decodeRepoWriteRecoveryDeferred(
+  frame: RecoveryFrameRecord,
+  limits: RepoWriteProtocolLimits,
+  baseFields: RecoveryBaseFields
+): RepoWriteRecoveryDeferredFrame {
+  assertExactRecoveryKeys(frame, ["outerOpId", "code", "diagnostic"]);
+  return {
+    ...baseFields,
+    kind: "recovery-deferred",
+    outerOpId: recoveryIdentifier(frame.outerOpId, "$.outerOpId", limits),
+    code: recoveryIdentifier(frame.code, "$.code", limits),
+    diagnostic: recoveryText(frame.diagnostic, "$.diagnostic", limits.maxDiagnosticBytes)
+  };
+}
+
+export function decodeRepoWriteRecoveryRejected(
+  frame: RecoveryFrameRecord,
+  limits: RepoWriteProtocolLimits,
+  baseFields: RecoveryBaseFields
+): RepoWriteRecoveryRejectedFrame {
+  assertExactRecoveryKeys(frame, ["outerOpId", "code", "diagnostic", "next"]);
+  return {
+    ...baseFields,
+    kind: "recovery-rejected",
+    outerOpId: recoveryIdentifier(frame.outerOpId, "$.outerOpId", limits),
+    code: recoveryIdentifier(frame.code, "$.code", limits),
+    diagnostic: recoveryText(frame.diagnostic, "$.diagnostic", limits.maxDiagnosticBytes),
+    next: recoveryText(frame.next, "$.next", limits.maxDiagnosticBytes)
+  };
+}
+
+function assertExactRecoveryKeys(
+  frame: Record<string, unknown>,
+  fields: ReadonlyArray<string>
+): void {
+  const required = ["protocol", "repoId", "generation", "kind", ...fields];
+  const allowed = new Set(required);
+  if (required.some((key) => !Object.hasOwn(frame, key))
+    || Object.keys(frame).some((key) => !allowed.has(key))) {
+    invalid("$", "exact message fields");
+  }
+}
+
+function recoveryIdentifier(
+  value: unknown,
+  path: string,
+  limits: RepoWriteProtocolLimits
+): string {
+  const text = recoveryText(value, path, Math.min(limits.maxStringBytes, 4_096));
+  if (!text.trim()) invalid(path, "non-empty identifier");
+  return text;
+}
+
+function recoveryText(value: unknown, path: string, maxBytes: number): string {
+  if (typeof value !== "string") invalid(path, "string");
+  const bytes = Buffer.byteLength(value, "utf8");
+  if (bytes > maxBytes) limit(path, "string byte length", bytes, maxBytes);
+  return value;
+}

--- a/packages/daemon/src/runtime/repo-write-protocol-retry-budget.ts
+++ b/packages/daemon/src/runtime/repo-write-protocol-retry-budget.ts
@@ -1,0 +1,72 @@
+import {
+  repoWriteRetryBudgetSignalPhases,
+  type RepoWriteRetryBudgetSignalFrame,
+  type RepoWriteRetryBudgetSignalPhase
+} from "./repo-write-diagnostic-protocol.ts";
+import type { RepoWriteProtocolLimits } from "./repo-write-protocol.ts";
+import {
+  invalidRepoWriteProtocol as invalid,
+  limitRepoWriteProtocol as limit
+} from "./repo-write-protocol-errors.ts";
+
+type RetryBudgetFrameRecord = Record<string, unknown> & {
+  readonly kind: string;
+};
+
+type RetryBudgetBaseFields = Pick<
+  RepoWriteRetryBudgetSignalFrame,
+  "protocol" | "repoId" | "generation"
+>;
+
+export function decodeRepoWriteRetryBudgetSignal(
+  frame: RetryBudgetFrameRecord,
+  limits: RepoWriteProtocolLimits,
+  baseFields: RetryBudgetBaseFields
+): RepoWriteRetryBudgetSignalFrame {
+  assertExactRetryBudgetKeys(frame);
+  if (!repoWriteRetryBudgetSignalPhases.includes(
+    frame.phase as RepoWriteRetryBudgetSignalPhase
+  )) {
+    invalid("$.phase", "retry-budget signal phase");
+  }
+  return {
+    ...baseFields,
+    kind: "retry-budget-signal",
+    phase: frame.phase as RepoWriteRetryBudgetSignalPhase,
+    operation: retryBudgetText(frame.operation, "$.operation", limits.maxStringBytes),
+    cause: retryBudgetText(frame.cause, "$.cause", limits.maxDiagnosticBytes),
+    failures: nonNegativeSafeInteger(frame.failures, "$.failures"),
+    retriesUsed: nonNegativeSafeInteger(frame.retriesUsed, "$.retriesUsed"),
+    elapsedMs: nonNegativeSafeInteger(frame.elapsedMs, "$.elapsedMs"),
+    ...(Object.hasOwn(frame, "remainingMs") ? {
+      remainingMs: nonNegativeSafeInteger(frame.remainingMs, "$.remainingMs")
+    } : {})
+  };
+}
+
+function assertExactRetryBudgetKeys(frame: Record<string, unknown>): void {
+  const required = [
+    "protocol", "repoId", "generation", "kind", "phase", "operation",
+    "cause", "failures", "retriesUsed", "elapsedMs"
+  ];
+  const allowed = new Set([...required, "remainingMs"]);
+  if (required.some((key) => !Object.hasOwn(frame, key))
+    || Object.keys(frame).some((key) => !allowed.has(key))) {
+    invalid("$", "exact message fields");
+  }
+}
+
+function nonNegativeSafeInteger(value: unknown, path: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    invalid(path, "non-negative safe integer");
+  }
+  return value;
+}
+
+function retryBudgetText(value: unknown, path: string, maxBytes: number): string {
+  if (typeof value !== "string") invalid(path, "string");
+  const bytes = Buffer.byteLength(value, "utf8");
+  if (bytes > maxBytes) limit(path, "string byte length", bytes, maxBytes);
+  if (!value.trim()) invalid(path, "non-empty string");
+  return value;
+}

--- a/packages/daemon/src/runtime/repo-write-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-protocol.ts
@@ -2,8 +2,17 @@
 import { repoWriteCommandDtoFromDecodedFields, type RepoWriteCommandDto } from "./repo-write-command-dto.ts";
 export * from "./repo-write-command-dto.ts";
 import { repoWriteTerminalReceiptMatches } from "./repo-write-terminal-receipt.ts";
-import { type RepoWriteRecoveryDeferredFrame, type RepoWriteRecoveryDiagnosticFrame, type RepoWriteRecoveryRejectedFrame, type RepoWriteTelemetryFrame } from "./repo-write-diagnostic-protocol.ts";
+import {
+  type RepoWriteRecoveryDiagnosticFrame,
+  type RepoWriteRetryBudgetSignalFrame,
+  type RepoWriteTelemetryFrame
+} from "./repo-write-diagnostic-protocol.ts";
 import { decodeRepoWriteTelemetry } from "./repo-write-protocol-telemetry.ts";
+import { decodeRepoWriteRetryBudgetSignal } from "./repo-write-protocol-retry-budget.ts";
+import {
+  decodeRepoWriteRecoveryDeferred,
+  decodeRepoWriteRecoveryRejected
+} from "./repo-write-protocol-recovery.ts";
 import { decodeRepoWriteStartupProgress } from "./repo-write-protocol-startup.ts";
 import type { RepoWriteStartupProgressFrame } from "./repo-write-startup-protocol.ts";
 export {
@@ -11,7 +20,17 @@ export {
   type RepoWriteStartupProgressFrame,
   type RepoWriteStartupProgressPhase
 } from "./repo-write-startup-protocol.ts";
-export type { RepoWriteRecoveryDeferredFrame, RepoWriteRecoveryDiagnosticFrame, RepoWriteRecoveryRejectedFrame, RepoWriteTelemetryDetail, RepoWriteTelemetryDetails, RepoWriteTelemetryFrame, RepoWriteTelemetryPhase } from "./repo-write-diagnostic-protocol.ts";
+export type {
+  RepoWriteRecoveryDeferredFrame,
+  RepoWriteRecoveryDiagnosticFrame,
+  RepoWriteRecoveryRejectedFrame,
+  RepoWriteRetryBudgetSignalFrame,
+  RepoWriteRetryBudgetSignalPhase,
+  RepoWriteTelemetryDetail,
+  RepoWriteTelemetryDetails,
+  RepoWriteTelemetryFrame,
+  RepoWriteTelemetryPhase
+} from "./repo-write-diagnostic-protocol.ts";
 export { boundedRepoWriteDiagnostic } from "./repo-write-protocol-diagnostic.ts";
 import {
   decodeRepoWriteBigInt,
@@ -148,6 +167,7 @@ export type RepoWriteChildMessage =
   | RepoWritePreparedFrame | RepoWriteTerminalFrame | RepoWriteFailureFrame
   | RepoWriteDirectResultFrame | RepoWriteDirectFailureFrame
   | RepoWriteStatusFrame | RepoWriteTelemetryFrame | RepoWriteRecoveryDiagnosticFrame
+  | RepoWriteRetryBudgetSignalFrame
   | RepoWriteDrainedFrame;
 
 export type RepoWriteMessage = RepoWriteParentMessage | RepoWriteChildMessage;
@@ -201,8 +221,15 @@ export function decodeRepoWriteChildMessage(
   if (frame.kind === "failure") return decodeFailure(frame, limits);
   if (frame.kind === "status") return decodeStatus(frame, limits, budget);
   if (frame.kind === "telemetry") return decodeRepoWriteTelemetry(frame, limits, baseFields(frame));
-  if (frame.kind === "recovery-deferred") return decodeRecoveryDeferred(frame, limits);
-  if (frame.kind === "recovery-rejected") return decodeRecoveryRejected(frame, limits);
+  if (frame.kind === "retry-budget-signal") {
+    return decodeRepoWriteRetryBudgetSignal(frame, limits, baseFields(frame));
+  }
+  if (frame.kind === "recovery-deferred") {
+    return decodeRepoWriteRecoveryDeferred(frame, limits, baseFields(frame));
+  }
+  if (frame.kind === "recovery-rejected") {
+    return decodeRepoWriteRecoveryRejected(frame, limits, baseFields(frame));
+  }
   if (frame.kind === "drained") return decodeRequestFrame(frame, limits, "drained");
   invalid("$.kind", "child message kind");
 }
@@ -422,33 +449,6 @@ function assertTerminalReceipt(
   if (!repoWriteTerminalReceiptMatches(outcome, receipt)) {
     invalid(path, "exact command-receipt/v2");
   }
-}
-function decodeRecoveryDeferred(
-  frame: FrameRecord,
-  limits: RepoWriteProtocolLimits
-): RepoWriteRecoveryDeferredFrame {
-  assertExactKeys(frame, baseKeys(["outerOpId", "code", "diagnostic"]), [], "$");
-  return {
-    ...baseFields(frame),
-    kind: "recovery-deferred",
-    outerOpId: identifier(frame.outerOpId, "$.outerOpId", limits),
-    code: identifier(frame.code, "$.code", limits),
-    diagnostic: stringAt(frame.diagnostic, "$.diagnostic", limits.maxDiagnosticBytes)
-  };
-}
-function decodeRecoveryRejected(
-  frame: FrameRecord,
-  limits: RepoWriteProtocolLimits
-): RepoWriteRecoveryRejectedFrame {
-  assertExactKeys(frame, baseKeys(["outerOpId", "code", "diagnostic", "next"]), [], "$");
-  return {
-    ...baseFields(frame),
-    kind: "recovery-rejected",
-    outerOpId: identifier(frame.outerOpId, "$.outerOpId", limits),
-    code: identifier(frame.code, "$.code", limits),
-    diagnostic: stringAt(frame.diagnostic, "$.diagnostic", limits.maxDiagnosticBytes),
-    next: stringAt(frame.next, "$.next", limits.maxDiagnosticBytes)
-  };
 }
 function frameBase(value: unknown, limits: RepoWriteProtocolLimits, budget: { nodes: number }): FrameRecord {
   const frame = recordAt(value, "$");

--- a/packages/daemon/test/publication-evidence-responsiveness.test.ts
+++ b/packages/daemon/test/publication-evidence-responsiveness.test.ts
@@ -112,32 +112,30 @@ posixTest("a half-read response never reaches the caller and falls back", async 
   assert.equal(readLogEntries(fixture.fallbackLog).length, 1);
 });
 
-posixTest("consecutive batch failures exhaust one rebuild and emit a visible warning", async (context) => {
+posixTest("consecutive batch failures exhaust one rebuild and emit retry-budget escalation", async (context) => {
   const fixture = faultyPublicationRepo("offset");
   context.after(async () => await removeTemporaryTestRoot(fixture.root));
-  const warnings: string[] = [];
-  const onWarning = (warning: Error) => warnings.push(warning.message);
-  process.on("warning", onWarning);
+  const signals: Array<{ readonly phase: string; readonly operation: string }> = [];
   try {
     const results: string[] = [];
     for (let attempt = 0; attempt < 3; attempt += 1) {
-      results.push(await readPublicationGitObject(fixture.root, "HEAD:seed.txt")
+      results.push(await readPublicationGitObject(fixture.root, "HEAD:seed.txt", {
+        onRetryBudgetSignal: (signal) => signals.push({
+          phase: signal.phase,
+          operation: signal.event.operation
+        })
+      })
         .then((content) => content.toString("utf8")));
     }
     assert.deepEqual(results, ["seed\n", "seed\n", "seed\n"]);
-    await new Promise<void>((resolve) => setImmediate(resolve));
   } finally {
-    process.off("warning", onWarning);
     await shutdownPublicationGitObjectReader(fixture.root);
     fixture.restorePath();
   }
 
   assert.equal(readBatchPids(fixture.batchLog).length, 2);
   assert.equal(readLogEntries(fixture.fallbackLog).length, 3);
-  assert.equal(
-    warnings.some((warning) => warning.includes("AUTHORITY_GIT_OBJECT_BATCH_RETRY_BUDGET_EXHAUSTED")),
-    true
-  );
+  assert.deepEqual(signals, [{ phase: "exhausted", operation: "publication-git-object-batch" }]);
 });
 
 posixTest("shutdown terminates a stuck half-read and rejects queued requests", async (context) => {

--- a/packages/daemon/test/publication-evidence-responsiveness.test.ts
+++ b/packages/daemon/test/publication-evidence-responsiveness.test.ts
@@ -250,12 +250,22 @@ test("missing-operation recovery search yields and reuses one bounded history sc
   writeFileSync(path.join(root, "seed.txt"), "seed\n");
   git(root, "add", ".");
   git(root, "commit", "-q", "-m", "seed");
-  const tree = git(root, "rev-parse", "HEAD^{tree}");
-  let parent = git(root, "rev-parse", "HEAD");
-  for (let index = 0; index < 2_048; index += 1) {
-    parent = git(root, "commit-tree", tree, "-p", parent, "-m", `history ${index}`);
+  const historyRef = git(root, "symbolic-ref", "HEAD");
+  const historyParent = git(root, "rev-parse", "HEAD");
+  const historyTracePath = path.join(root, "history-construction-git-trace.jsonl");
+  const previousHistoryTrace = process.env.GIT_TRACE2_EVENT;
+  process.env.GIT_TRACE2_EVENT = historyTracePath;
+  try {
+    appendLinearHistory(root, historyRef, historyParent, 2_048);
+  } finally {
+    if (previousHistoryTrace === undefined) delete process.env.GIT_TRACE2_EVENT;
+    else process.env.GIT_TRACE2_EVENT = previousHistoryTrace;
   }
-  git(root, "update-ref", "HEAD", parent);
+  assert.equal(
+    gitTraceCommands(historyTracePath).length,
+    1,
+    "history fixture construction must use one bounded Git process"
+  );
 
   let timerFired = false;
   const tracePath = path.join(root, "git-trace.jsonl");
@@ -305,6 +315,34 @@ function git(root: string, ...args: ReadonlyArray<string>): string {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"]
   }).trim();
+}
+
+function appendLinearHistory(
+  root: string,
+  ref: string,
+  parent: string,
+  count: number
+): void {
+  const commands: string[] = [];
+  let from = parent;
+  for (let index = 0; index < count; index += 1) {
+    const mark = index + 1;
+    const message = `history ${index}`;
+    commands.push(
+      `commit ${ref}`,
+      `mark :${mark}`,
+      `committer Harness Test <harness@example.test> ${mark} +0000`,
+      `data ${Buffer.byteLength(message)}`,
+      message,
+      `from ${from}`,
+      ""
+    );
+    from = `:${mark}`;
+  }
+  execFileSync("git", ["-C", root, "fast-import", "--quiet"], {
+    input: commands.join("\n"),
+    stdio: ["pipe", "pipe", "pipe"]
+  });
 }
 
 function readBatchPids(batchLog: string): ReadonlyArray<string> {

--- a/packages/daemon/test/remote-broker-runtime-failure-support.ts
+++ b/packages/daemon/test/remote-broker-runtime-failure-support.ts
@@ -32,6 +32,7 @@ export class ReadDownClient {
   authoritativeChanges: ReplicaChangeRecord[] = [];
   invalidEmptyCutChange = false;
   reconnectRequests = 0;
+  connectFailuresRemaining = 0;
   fetchFailuresRemaining = 0;
   closeFailuresRemaining = 0;
   disconnectRegistrationFailure: Error | undefined;
@@ -42,10 +43,19 @@ export class ReadDownClient {
     this.fixture = fixture;
   }
 
-  async connect(): Promise<void> {}
+  async connect(): Promise<void> {
+    if (this.connectFailuresRemaining > 0) {
+      this.connectFailuresRemaining -= 1;
+      throw new AuthorityTransportDisconnectedError("scripted connect disconnect");
+    }
+  }
 
   async reconnect(): Promise<void> {
     this.reconnectRequests += 1;
+    if (this.connectFailuresRemaining > 0) {
+      this.connectFailuresRemaining -= 1;
+      throw new AuthorityTransportDisconnectedError("scripted reconnect disconnect");
+    }
   }
 
   async beginSnapshotAndSubscribe(): Promise<AuthoritySnapshotReservation> {
@@ -160,6 +170,8 @@ export function makeRuntime(
       readonly maximumMs: number;
       readonly multiplier: number;
     };
+    readonly retryBudget?: { readonly maxRetries: number; readonly reminderEveryFailures: number };
+    readonly onRetryBudgetSignal?: (signal: import("../src/observability/visible-retry-budget.ts").RetryBudgetSignal) => void;
   } = {}
 ): RemoteBrokerRuntime {
   return new RemoteBrokerRuntime({
@@ -170,7 +182,9 @@ export function makeRuntime(
     session: {
       client: client as unknown as PersistentSshAuthorityClient,
       backoff: session.backoff ?? { initialMs: 0, maximumMs: 0, multiplier: 1 },
-      ...(session.sleep ? { sleep: session.sleep } : {})
+      ...(session.sleep ? { sleep: session.sleep } : {}),
+      ...(session.retryBudget ? { retryBudget: session.retryBudget } : {}),
+      ...(session.onRetryBudgetSignal ? { onRetryBudgetSignal: session.onRetryBudgetSignal } : {})
     }
   });
 }

--- a/packages/daemon/test/remote-broker-runtime.test.ts
+++ b/packages/daemon/test/remote-broker-runtime.test.ts
@@ -5,7 +5,11 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import type { ReplicaChangeLog, ReplicaChangeRecord } from "../../application/src/index.ts";
+import {
+  makeDaemonLogService,
+  type ReplicaChangeLog,
+  type ReplicaChangeRecord
+} from "../../application/src/index.ts";
 import {
   BrokerDurableStateStore,
   RemoteBrokerRuntime,
@@ -199,11 +203,20 @@ test("remote runtime and optional production composition start and stop their pe
     assert.equal(directClient.disconnectListeners.size, 0);
 
     const composedClient = new EmptyReadDownClient();
+    const daemonLogService = makeDaemonLogService({
+      store: {
+        append: async () => undefined,
+        read: async () => ({ records: [], droppedCount: 0 })
+      },
+      cursorSecret: "remote-composition-test-secret"
+    });
     const composition = createProductionCompoundReceiptComposition({
       workspaceId,
       viewId: "view-composed",
       canonicalRoot: path.join(root, "composed-view"),
       stateDirectory: path.join(root, "composed-state"),
+      repoId: "repo-remote-composed",
+      daemonLogService,
       remoteReadDown: {
         client: composedClient as unknown as PersistentSshAuthorityClient,
         backoff: { initialMs: 0, maximumMs: 0, multiplier: 1 }

--- a/packages/daemon/test/repo-write-client.test.ts
+++ b/packages/daemon/test/repo-write-client.test.ts
@@ -136,12 +136,14 @@ test("shutdown rejects a queued durable request before READY", async () => {
 test("reports historical recovery diagnostics before READY without failing the writer", async () => {
   const transport = new FakeRepoWriteTransport();
   const diagnostics: unknown[] = [];
+  const retryBudgetSignals: unknown[] = [];
   const client = new RepoWriteClient({
     repoId: "repo-canonical",
     generation: 7,
     transport,
     onTelemetry: () => undefined,
-    onDiagnostic: (frame) => diagnostics.push(frame)
+    onDiagnostic: (frame) => diagnostics.push(frame),
+    onRetryBudgetSignal: (frame) => retryBudgetSignals.push(frame)
   });
   transport.emit({
     ...childFrame("recovery-deferred"),
@@ -174,6 +176,25 @@ test("reports historical recovery diagnostics before READY without failing the w
     diagnostic: "Historical recovery evidence conflicts with the canonical publication.",
     next: "Run `ha daemon logs --errors --json`, then escalate for operator-reviewed repair."
   });
+
+  transport.emit({
+    ...childFrame("retry-budget-signal"),
+    phase: "exhausted",
+    operation: "publication-git-object-batch",
+    cause: "GitObjectBatchValidationError: batch response was offset",
+    failures: 2,
+    retriesUsed: 1,
+    elapsedMs: 14
+  });
+  assert.deepEqual(retryBudgetSignals, [{
+    ...childFrame("retry-budget-signal"),
+    phase: "exhausted",
+    operation: "publication-git-object-batch",
+    cause: "GitObjectBatchValidationError: batch response was offset",
+    failures: 2,
+    retriesUsed: 1,
+    elapsedMs: 14
+  }]);
 });
 
 test("resolves an exact rejected terminal receipt instead of converting it to transport failure", async () => {

--- a/packages/daemon/test/repo-write-process-supervisor.test.ts
+++ b/packages/daemon/test/repo-write-process-supervisor.test.ts
@@ -235,6 +235,34 @@ test("supervisor forwards startup recovery diagnostics before READY", async (con
   }]);
 });
 
+test("supervisor forwards child retry-budget signals before READY", async (context) => {
+  const signals: unknown[] = [];
+  const supervisor = new RepoWriteProcessSupervisor({
+    repoId: "repo-transport",
+    generation: 1,
+    spawn: () => forkRepoWriteProcess({
+      modulePath: fixturePath,
+      args: ["retry-budget-signal"]
+    }),
+    onRetryBudgetSignal: (frame) => signals.push(frame)
+  });
+  context.after(() => supervisor.stop().catch(() => undefined));
+
+  await supervisor.start();
+  assert.deepEqual(signals, [{
+    protocol: "harness-repo-write-ipc/v1",
+    repoId: "repo-transport",
+    generation: 1,
+    kind: "retry-budget-signal",
+    phase: "exhausted",
+    operation: "publication-git-object-batch",
+    cause: "GitObjectBatchValidationError: batch response was offset",
+    failures: 2,
+    retriesUsed: 1,
+    elapsedMs: 14
+  }]);
+});
+
 test("post-proceed child crash performs one exact op lookup in a replacement capsule", async (context) => {
   let forks = 0;
   const supervisor = new RepoWriteProcessSupervisor({

--- a/packages/daemon/test/repo-write-protocol.test.ts
+++ b/packages/daemon/test/repo-write-protocol.test.ts
@@ -275,6 +275,32 @@ test("historical recovery diagnostics carry a bounded startup failure without re
   }), protocolInvalid);
 });
 
+test("retry-budget visibility crosses the child IPC boundary without request correlation", () => {
+  const signal: RepoWriteChildMessage = {
+    ...base("retry-budget-signal"),
+    phase: "exhausted",
+    operation: "publication-git-object-batch",
+    cause: "GitObjectBatchValidationError: batch response was offset",
+    failures: 2,
+    retriesUsed: 1,
+    elapsedMs: 14,
+    remainingMs: 0
+  };
+
+  assert.deepEqual(
+    parseRepoWriteChildMessage(stringifyRepoWriteChildMessage(signal)),
+    signal
+  );
+  assert.throws(() => decodeRepoWriteChildMessage({
+    ...signal,
+    retriesUsed: -1
+  }), protocolInvalid);
+  assert.throws(() => decodeRepoWriteChildMessage({
+    ...signal,
+    unboundedDetail: "not allowed"
+  }), protocolInvalid);
+});
+
 test("volatile direct execution carries an exact receipt without durable recovery fields", () => {
   const request: RepoWriteParentMessage = {
     ...base("direct"),

--- a/packages/daemon/test/retry-budget/daemon-retry-budget-log.test.ts
+++ b/packages/daemon/test/retry-budget/daemon-retry-budget-log.test.ts
@@ -1,0 +1,39 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { makeDaemonLogService, type DaemonLogEntryV1 } from "../../../application/src/index.ts";
+import { createDaemonRetryBudgetSignalSink } from "../../src/observability/daemon-retry-budget-log.ts";
+
+test("daemon error log retains entry and periodic retry-budget escalation while recovery continues", async () => {
+  const records: DaemonLogEntryV1[] = [];
+  const logs = makeDaemonLogService({
+    store: {
+      append: async (entry) => { records.push(entry); },
+      read: async () => ({ records, droppedCount: 0 })
+    },
+    cursorSecret: "retry-budget-test-secret"
+  });
+  const context = { repo: { repoId: "repo-visible", canonicalRoot: "/repo/visible" } };
+  const sink = createDaemonRetryBudgetSignalSink(logs, context);
+  const event = {
+    operation: "remote-read-down-recovery",
+    cause: new Error("authority unavailable"),
+    failures: 6,
+    retriesUsed: 5,
+    elapsedMs: 50,
+    remainingMs: undefined
+  };
+
+  sink({ phase: "exhausted", event });
+  sink({ phase: "still-retrying", event: { ...event, failures: 11, retriesUsed: 10, elapsedMs: 100 } });
+  sink({ phase: "recovered", event: { ...event, failures: 12, retriesUsed: 11, elapsedMs: 110 } });
+
+  const errors = await logs.list({ errorOnly: true }, context);
+  assert.deepEqual(
+    errors.entries.map((entry) => entry.event).sort(),
+    ["retry-budget.exhausted", "retry-budget.still-retrying"]
+  );
+  assert.ok(errors.entries.every((entry) => entry.level === "error"));
+  const all = await logs.list({}, context);
+  assert.ok(all.entries.some((entry) => entry.event === "retry-budget.recovered" && entry.level === "info"));
+});

--- a/packages/daemon/test/retry-budget/daemon-retry-budget-log.test.ts
+++ b/packages/daemon/test/retry-budget/daemon-retry-budget-log.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { makeDaemonLogService, type DaemonLogEntryV1 } from "../../../application/src/index.ts";
 import { createDaemonRetryBudgetSignalSink } from "../../src/observability/daemon-retry-budget-log.ts";
+import { createRepoWriteRetryBudgetSignalSink } from "../../src/observability/repo-write-retry-budget-log.ts";
 
 test("daemon error log retains entry and periodic retry-budget escalation while recovery continues", async () => {
   const records: DaemonLogEntryV1[] = [];
@@ -36,4 +37,41 @@ test("daemon error log retains entry and periodic retry-budget escalation while 
   assert.ok(errors.entries.every((entry) => entry.level === "error"));
   const all = await logs.list({}, context);
   assert.ok(all.entries.some((entry) => entry.event === "retry-budget.recovered" && entry.level === "info"));
+});
+
+test("repo-write IPC retry-budget frames retain production error-log visibility", async () => {
+  const records: DaemonLogEntryV1[] = [];
+  const logs = makeDaemonLogService({
+    store: {
+      append: async (entry) => { records.push(entry); },
+      read: async () => ({ records, droppedCount: 0 })
+    },
+    cursorSecret: "repo-write-retry-budget-test-secret"
+  });
+  const context = { repo: { repoId: "repo-writer", canonicalRoot: "/repo/writer" } };
+  const sink = createRepoWriteRetryBudgetSignalSink(logs, context);
+
+  sink({
+    protocol: "harness-repo-write-ipc/v1",
+    repoId: "repo-writer",
+    generation: 3,
+    kind: "retry-budget-signal",
+    phase: "exhausted",
+    operation: "publication-git-object-batch",
+    cause: "GitObjectBatchValidationError: batch response was offset",
+    failures: 2,
+    retriesUsed: 1,
+    elapsedMs: 14
+  });
+
+  const errors = await logs.list({ errorOnly: true }, context);
+  assert.deepEqual(errors.entries.map((entry) => ({
+    event: entry.event,
+    component: entry.component,
+    errorCode: entry.errorCode
+  })), [{
+    event: "retry-budget.exhausted",
+    component: "retry-budget",
+    errorCode: "RETRY_BUDGET_EXHAUSTED"
+  }]);
 });

--- a/packages/daemon/test/retry-budget/journal-lock-retry-budget.test.ts
+++ b/packages/daemon/test/retry-budget/journal-lock-retry-budget.test.ts
@@ -31,6 +31,7 @@ test("journal foreign-committer wait stays receipt-honest and visible after retr
       heartbeatAt: new Date().toISOString(),
       ownerToken: "foreign-committer"
     }), "utf8");
+    const retrySignalSink = createDaemonRetryBudgetSignalSink(logs, context);
     const coordinator = makeJournaledWriteCoordinator({
       attribution: testWriteAttribution(),
       rootDir,
@@ -41,7 +42,10 @@ test("journal foreign-committer wait stays receipt-honest and visible after retr
         maxDelayMs: 1,
         reminderEveryFailures: 1
       },
-      onLockConflictRetrySignal: createDaemonRetryBudgetSignalSink(logs, context)
+      onLockConflictRetrySignal: (signal) => {
+        retrySignalSink(signal);
+        if (signal.phase === "still-retrying") rmSync(lockPath, { force: true });
+      }
     });
     Effect.runSync(coordinator.enqueue({
       opId: "op-journal-visible-retry",
@@ -50,12 +54,10 @@ test("journal foreign-committer wait stays receipt-honest and visible after retr
       payload: { path: "receipt.md", body: "committed\n" }
     }));
 
-    const release = setTimeout(() => rmSync(lockPath, { force: true }), 25);
     try {
       const report = await runEffect(coordinator.flush("explicit"));
       assert.equal(report.committed, true);
     } finally {
-      clearTimeout(release);
       rmSync(lockPath, { force: true });
     }
 

--- a/packages/daemon/test/retry-budget/journal-lock-retry-budget.test.ts
+++ b/packages/daemon/test/retry-budget/journal-lock-retry-budget.test.ts
@@ -1,0 +1,79 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { hostname, tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { makeDaemonLogService, type DaemonLogEntryV1 } from "../../../application/src/index.ts";
+import { Effect, type Exit } from "effect";
+import { makeJournaledWriteCoordinator, taskEntityId } from "../../../kernel/src/index.ts";
+import { testWriteAttribution } from "../../../kernel/test/test-attribution.ts";
+import { createDaemonRetryBudgetSignalSink } from "../../src/observability/daemon-retry-budget-log.ts";
+
+test("journal foreign-committer wait stays receipt-honest and visible after retry budget exhaustion", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-journal-visible-retry-"));
+  try {
+    const records: DaemonLogEntryV1[] = [];
+    const logs = makeDaemonLogService({
+      store: {
+        append: async (entry) => { records.push(entry); },
+        read: async () => ({ records, droppedCount: 0 })
+      },
+      cursorSecret: "journal-visible-retry-secret"
+    });
+    const context = { repo: { repoId: "repo-journal-visible", canonicalRoot: rootDir } };
+    const lockPath = path.join(rootDir, ".harness/locks/global.lock");
+    mkdirSync(path.dirname(lockPath), { recursive: true });
+    writeFileSync(lockPath, JSON.stringify({
+      pid: process.pid + 10_000,
+      hostname: `${hostname()}-foreign`,
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      ownerToken: "foreign-committer"
+    }), "utf8");
+    const coordinator = makeJournaledWriteCoordinator({
+      attribution: testWriteAttribution(),
+      rootDir,
+      lockTtlMs: 60_000,
+      lockConflictRetry: {
+        maxWaitMs: 1,
+        initialDelayMs: 1,
+        maxDelayMs: 1,
+        reminderEveryFailures: 1
+      },
+      onLockConflictRetrySignal: createDaemonRetryBudgetSignalSink(logs, context)
+    });
+    Effect.runSync(coordinator.enqueue({
+      opId: "op-journal-visible-retry",
+      entityId: taskEntityId("task-journal-visible-retry"),
+      kind: "doc_write",
+      payload: { path: "receipt.md", body: "committed\n" }
+    }));
+
+    const release = setTimeout(() => rmSync(lockPath, { force: true }), 25);
+    try {
+      const report = await runEffect(coordinator.flush("explicit"));
+      assert.equal(report.committed, true);
+    } finally {
+      clearTimeout(release);
+      rmSync(lockPath, { force: true });
+    }
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    const errors = await logs.list({ errorOnly: true }, context);
+    assert.ok(errors.entries.some((entry) => entry.event === "retry-budget.exhausted"));
+    assert.ok(errors.entries.some((entry) => entry.event === "retry-budget.still-retrying"));
+    const all = await logs.list({}, context);
+    assert.ok(all.entries.some((entry) => entry.event === "retry-budget.recovered"));
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+async function runEffect<A, E>(effect: Effect.Effect<A, E>): Promise<A> {
+  const exit = await new Promise<Exit.Exit<A, E>>((resolve) => {
+    Effect.runCallback(effect, { onExit: resolve });
+  });
+  if (exit._tag === "Success") return exit.value;
+  throw new Error(String(exit.cause));
+}

--- a/packages/daemon/test/retry-budget/remote-broker-runtime-retry-budget.test.ts
+++ b/packages/daemon/test/retry-budget/remote-broker-runtime-retry-budget.test.ts
@@ -1,0 +1,46 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import test from "node:test";
+import { AuthorityTransportDisconnectedError } from "../../src/index.ts";
+import {
+  makeRuntime,
+  notifyRuntime,
+  ReadDownClient,
+  record,
+  snapshotFixture,
+  waitFor,
+  withRoots
+} from "../remote-broker-runtime-failure-support.ts";
+
+test("remote broker remains recoverable and repeatedly visible after retry budget exhaustion", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const client = new ReadDownClient(snapshotFixture(0, "epoch-broker-visible"));
+    const phases: string[] = [];
+    const runtime = makeRuntime(client, viewRoot, stateRoot, {
+      retryBudget: { maxRetries: 1, reminderEveryFailures: 1 },
+      onRetryBudgetSignal: (signal) => {
+        if (signal.event.operation === "remote-broker-synchronization") phases.push(signal.phase);
+      }
+    });
+    await runtime.start();
+    const refresh = runtime.session.refresh.bind(runtime.session);
+    let refreshFailures = 3;
+    runtime.session.refresh = async () => {
+      if (refreshFailures > 0) {
+        refreshFailures -= 1;
+        throw new AuthorityTransportDisconnectedError("scripted broker retry disconnect");
+      }
+      await refresh();
+    };
+    runtime.broker.onNotification = async () => {
+      throw new AuthorityTransportDisconnectedError("start broker retry loop");
+    };
+
+    notifyRuntime(runtime, record(1, "commit-1", null));
+    await waitFor(() => phases.at(-1) === "recovered");
+
+    assert.deepEqual(phases, ["exhausted", "still-retrying", "recovered"]);
+    assert.deepEqual(runtime.health(), { status: "RUNNING" });
+    await runtime.stop();
+  });
+});

--- a/packages/daemon/test/retry-budget/remote-production-log-wiring.test.ts
+++ b/packages/daemon/test/retry-budget/remote-production-log-wiring.test.ts
@@ -1,0 +1,28 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { PersistentSshAuthorityClient } from "../../src/index.ts";
+import { createProductionCompoundReceiptComposition } from "../../src/lifecycle/compound-receipt-composition.ts";
+import {
+  ReadDownClient,
+  snapshotFixture,
+  withRoots,
+  workspaceId
+} from "../remote-broker-runtime-failure-support.ts";
+
+test("production remote composition refuses an unwatched retry-budget callback", async () => {
+  await withRoots(async ({ viewRoot, stateRoot }) => {
+    const client = new ReadDownClient(snapshotFixture(0, "epoch-production-log"));
+
+    assert.throws(() => createProductionCompoundReceiptComposition({
+      workspaceId,
+      viewId: "view-production-log",
+      canonicalRoot: viewRoot,
+      stateDirectory: stateRoot,
+      remoteReadDown: {
+        client: client as unknown as PersistentSshAuthorityClient,
+        onRetryBudgetSignal: () => undefined
+      }
+    }), /remote read-down requires daemon error-log visibility/u);
+  });
+});

--- a/packages/daemon/test/retry-budget/remote-read-down-retry-budget.test.ts
+++ b/packages/daemon/test/retry-budget/remote-read-down-retry-budget.test.ts
@@ -1,0 +1,35 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  RemoteReadDownSession,
+  type PersistentSshAuthorityClient
+} from "../../src/index.ts";
+import {
+  ReadDownClient,
+  snapshotFixture,
+  withRoots,
+  workspaceId
+} from "../remote-broker-runtime-failure-support.ts";
+
+test("remote read-down keeps an exhausted recovery episode visibly escalated until it recovers", async () => {
+  await withRoots(async ({ stateRoot }) => {
+    const client = new ReadDownClient(snapshotFixture(0, "epoch-visible"));
+    client.connectFailuresRemaining = 3;
+    const phases: string[] = [];
+    const session = new RemoteReadDownSession({
+      client: client as unknown as PersistentSshAuthorityClient,
+      workspaceId,
+      stateRoot,
+      backoff: { initialMs: 0, maximumMs: 0, multiplier: 1 },
+      retryBudget: { maxRetries: 1, reminderEveryFailures: 1 },
+      onRetryBudgetSignal: (signal) => phases.push(signal.phase)
+    });
+
+    await session.latest();
+
+    assert.deepEqual(phases, ["exhausted", "still-retrying", "recovered"]);
+    assert.deepEqual(session.health(), { status: "READY" });
+    await session.close();
+  });
+});

--- a/packages/daemon/test/support/repo-write-ipc-child.ts
+++ b/packages/daemon/test/support/repo-write-ipc-child.ts
@@ -286,6 +286,19 @@ if (mode === "expected-direct-rejection") {
         code: "GIT_PATH_NOT_SAFE",
         diagnostic: "historical recovery remains fail-closed"
       });
+    } else if (mode === "retry-budget-signal") {
+      await transport.send({
+        protocol: repoWriteProtocolType,
+        repoId: "repo-transport",
+        generation: 1,
+        kind: "retry-budget-signal",
+        phase: "exhausted",
+        operation: "publication-git-object-batch",
+        cause: "GitObjectBatchValidationError: batch response was offset",
+        failures: 2,
+        retriesUsed: 1,
+        elapsedMs: 14
+      });
     }
     await transport.send({
       protocol: repoWriteProtocolType,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -106,6 +106,7 @@ export * from "./projection/declared-identity-repair.ts";
 export * from "./projection/relation-flow-frontmatter.ts";
 export * from "./projection/relation-graph-projection.ts";
 export * from "./runtime/operational-limits.ts";
+export * from "./runtime/bounded-retry.ts";
 export {
   auditTaskProvenance,
   queryExecutionProjection,

--- a/packages/kernel/src/runtime/bounded-retry.ts
+++ b/packages/kernel/src/runtime/bounded-retry.ts
@@ -1,0 +1,85 @@
+export interface RetryBudgetLimits {
+  readonly maxRetries?: number;
+  readonly maxElapsedMs?: number;
+}
+
+export interface RetryBudgetEvent {
+  readonly operation: string;
+  readonly cause: unknown;
+  readonly failures: number;
+  readonly retriesUsed: number;
+  readonly elapsedMs: number;
+  readonly remainingMs?: number;
+}
+
+export type RetryBudgetDecision = RetryBudgetEvent & {
+  readonly status: "retry-allowed" | "budget-exhausted";
+};
+
+export interface BoundedRetryBudget {
+  recordFailure(cause: unknown): RetryBudgetDecision;
+  reset(): void;
+}
+
+export interface BoundedRetryBudgetOptions {
+  readonly operation: string;
+  readonly budget: RetryBudgetLimits;
+  readonly onExhausted: (event: RetryBudgetEvent) => void;
+}
+
+export function createBoundedRetryBudget(options: BoundedRetryBudgetOptions): BoundedRetryBudget {
+  assertBudget(options.budget);
+  let episodeStartedAt: number | undefined;
+  let failures = 0;
+  let exhaustionReported = false;
+
+  return {
+    recordFailure(cause) {
+      const now = Date.now();
+      episodeStartedAt ??= now;
+      failures += 1;
+      const elapsedMs = now - episodeStartedAt;
+      const retriesUsed = failures - 1;
+      const remainingMs = options.budget.maxElapsedMs === undefined
+        ? undefined
+        : Math.max(0, options.budget.maxElapsedMs - elapsedMs);
+      const event: RetryBudgetEvent = {
+        operation: options.operation,
+        cause,
+        failures,
+        retriesUsed,
+        elapsedMs,
+        ...(remainingMs === undefined ? {} : { remainingMs })
+      };
+      const exhausted = (
+        options.budget.maxRetries !== undefined
+        && retriesUsed >= options.budget.maxRetries
+      ) || (
+        options.budget.maxElapsedMs !== undefined
+        && elapsedMs >= options.budget.maxElapsedMs
+      );
+      if (exhausted && !exhaustionReported) {
+        exhaustionReported = true;
+        options.onExhausted(event);
+      }
+      return { ...event, status: exhausted ? "budget-exhausted" : "retry-allowed" };
+    },
+    reset() {
+      episodeStartedAt = undefined;
+      failures = 0;
+      exhaustionReported = false;
+    }
+  };
+}
+
+function assertBudget(budget: RetryBudgetLimits): void {
+  if (budget.maxRetries === undefined && budget.maxElapsedMs === undefined) {
+    throw new Error("bounded retry requires maxRetries or maxElapsedMs");
+  }
+  if (budget.maxRetries !== undefined && (!Number.isSafeInteger(budget.maxRetries) || budget.maxRetries < 0)) {
+    throw new Error("bounded retry maxRetries must be a non-negative safe integer");
+  }
+  if (budget.maxElapsedMs !== undefined && (!Number.isFinite(budget.maxElapsedMs) || budget.maxElapsedMs <= 0)) {
+    throw new Error("bounded retry maxElapsedMs must be a positive finite number");
+  }
+}

--- a/packages/kernel/src/runtime/bounded-retry.ts
+++ b/packages/kernel/src/runtime/bounded-retry.ts
@@ -1,9 +1,9 @@
-export interface RetryBudgetLimits {
+interface RetryBudgetLimits {
   readonly maxRetries?: number;
   readonly maxElapsedMs?: number;
 }
 
-export interface RetryBudgetEvent {
+interface RetryBudgetEvent {
   readonly operation: string;
   readonly cause: unknown;
   readonly failures: number;
@@ -12,7 +12,7 @@ export interface RetryBudgetEvent {
   readonly remainingMs?: number;
 }
 
-export type RetryBudgetDecision = RetryBudgetEvent & {
+type RetryBudgetDecision = RetryBudgetEvent & {
   readonly status: "retry-allowed" | "budget-exhausted";
 };
 
@@ -21,7 +21,7 @@ export interface BoundedRetryBudget {
   reset(): void;
 }
 
-export interface BoundedRetryBudgetOptions {
+interface BoundedRetryBudgetOptions {
   readonly operation: string;
   readonly budget: RetryBudgetLimits;
   readonly onExhausted: (event: RetryBudgetEvent) => void;
@@ -82,4 +82,60 @@ function assertBudget(budget: RetryBudgetLimits): void {
   if (budget.maxElapsedMs !== undefined && (!Number.isFinite(budget.maxElapsedMs) || budget.maxElapsedMs <= 0)) {
     throw new Error("bounded retry maxElapsedMs must be a positive finite number");
   }
+}
+
+export type RetryBudgetSignalPhase = "exhausted" | "still-retrying" | "recovered";
+
+export interface RetryBudgetSignal {
+  readonly phase: RetryBudgetSignalPhase;
+  readonly event: RetryBudgetEvent;
+}
+
+export interface VisibleRetryBudget {
+  recordFailure(cause: unknown): RetryBudgetDecision;
+  recovered(): void;
+}
+
+export function createVisibleRetryBudget(input: {
+  readonly operation: string;
+  readonly budget: RetryBudgetLimits;
+  readonly reminderEveryFailures: number;
+  readonly signal?: (signal: RetryBudgetSignal) => void;
+}): VisibleRetryBudget {
+  if (!Number.isSafeInteger(input.reminderEveryFailures) || input.reminderEveryFailures < 1) {
+    throw new Error("retry escalation reminderEveryFailures must be a positive safe integer");
+  }
+  let escalated = false;
+  let lastSignalFailure = 0;
+  let lastEvent: RetryBudgetEvent | undefined;
+  const retry = createBoundedRetryBudget({
+    operation: input.operation,
+    budget: input.budget,
+    onExhausted: (event) => {
+      escalated = true;
+      lastSignalFailure = event.failures;
+      lastEvent = event;
+      input.signal?.({ phase: "exhausted", event });
+    }
+  });
+  return {
+    recordFailure(cause) {
+      const decision = retry.recordFailure(cause);
+      lastEvent = decision;
+      if (decision.status === "budget-exhausted"
+        && escalated
+        && decision.failures - lastSignalFailure >= input.reminderEveryFailures) {
+        lastSignalFailure = decision.failures;
+        input.signal?.({ phase: "still-retrying", event: decision });
+      }
+      return decision;
+    },
+    recovered() {
+      if (escalated && lastEvent) input.signal?.({ phase: "recovered", event: lastEvent });
+      retry.reset();
+      escalated = false;
+      lastSignalFailure = 0;
+      lastEvent = undefined;
+    }
+  };
 }

--- a/packages/kernel/src/write-coordination/journal/coordinator.ts
+++ b/packages/kernel/src/write-coordination/journal/coordinator.ts
@@ -45,8 +45,7 @@ import {
 } from "./operations/transaction-plan.ts";
 import {
   reconcileDurableExactFlush,
-  reconcileDurableFlush,
-  shouldWaitForForeignCommitter
+  reconcileDurableFlush
 } from "./receipt.ts";
 import { semanticCommitMessage } from "./publication/authority-trailer.ts";
 import { recoverJournalIntegrityDomains } from "./recovery/integrity-domains.ts";
@@ -180,10 +179,6 @@ function makeJournaledWriteCoordinatorInternal(
     reconcileDurable: (reason, witnesses) => reconcileDurableExactFlush(
       reason, witnesses, exactJournalAuthorizations, pending,
       journalPath, watermarkPath, rootDir
-    ),
-    shouldContinueAfterTimeout: (error) => shouldWaitForForeignCommitter(
-      error,
-      path.join(layout.locksRoot, "global.lock")
     )
   });
   const flushExactJournalRecords = createExactJournalRecordsFlusher({
@@ -205,10 +200,6 @@ function makeJournaledWriteCoordinatorInternal(
     reconcileDurable: (reason, witnesses) => reconcileDurableExactFlush(
       reason, witnesses, exactJournalAuthorizations, pending,
       journalPath, watermarkPath, rootDir
-    ),
-    shouldContinueAfterTimeout: (error) => shouldWaitForForeignCommitter(
-      error,
-      path.join(layout.locksRoot, "global.lock")
     )
   });
 
@@ -276,10 +267,7 @@ function makeJournaledWriteCoordinatorInternal(
         ? retryWriteLockConflict(
           () => flushOnce(reason),
           lockConflictRetry,
-          Date.now(),
-          0,
-          reconcileDurable,
-          (error) => shouldWaitForForeignCommitter(error, path.join(layout.locksRoot, "global.lock"))
+          reconcileDurable
         )
         : flushOnce(reason).pipe(Effect.catchAll((error) => {
           const reconciled = isWriteLockConflict(error) ? reconcileDurable() : undefined;
@@ -290,7 +278,7 @@ function makeJournaledWriteCoordinatorInternal(
     flushExactJournalRecords,
     flushExactJournalRecord,
     recover: lockConflictRetry
-      ? retryWriteLockConflict(() => recoverOnce, lockConflictRetry, Date.now(), 0)
+      ? retryWriteLockConflict(() => recoverOnce, lockConflictRetry)
       : recoverOnce
   };
   return withJournalExactCommit(coordinator, flushExactJournalRecords, options.exactWriteScope);

--- a/packages/kernel/src/write-coordination/journal/coordinator.ts
+++ b/packages/kernel/src/write-coordination/journal/coordinator.ts
@@ -45,7 +45,8 @@ import {
 } from "./operations/transaction-plan.ts";
 import {
   reconcileDurableExactFlush,
-  reconcileDurableFlush
+  reconcileDurableFlush,
+  shouldWaitForForeignCommitter
 } from "./receipt.ts";
 import { semanticCommitMessage } from "./publication/authority-trailer.ts";
 import { recoverJournalIntegrityDomains } from "./recovery/integrity-domains.ts";
@@ -111,6 +112,7 @@ function makeJournaledWriteCoordinatorInternal(
   const operationalActor = options.operationalActor ?? defaultOperationalActor;
   const lockTtlMs = options.lockTtlMs ?? 60_000;
   const lockConflictRetry = options.lockConflictRetry;
+  const globalLockPath = path.join(layout.locksRoot, "global.lock");
   const heldGlobalLock = options.heldGlobalLock;
   const commitAuthor = options.commitAuthor;
   const versionControlSystem = options.versionControlSystem;
@@ -179,7 +181,11 @@ function makeJournaledWriteCoordinatorInternal(
     reconcileDurable: (reason, witnesses) => reconcileDurableExactFlush(
       reason, witnesses, exactJournalAuthorizations, pending,
       journalPath, watermarkPath, rootDir
-    )
+    ),
+    shouldContinueAfterExhaustion: (error) => shouldWaitForForeignCommitter(error, globalLockPath),
+    ...(options.onLockConflictRetrySignal ? {
+      onRetryBudgetSignal: options.onLockConflictRetrySignal
+    } : {})
   });
   const flushExactJournalRecords = createExactJournalRecordsFlusher({
     run: (reason, witnesses) => flushExactAuthorizedJournalRecords({
@@ -200,7 +206,11 @@ function makeJournaledWriteCoordinatorInternal(
     reconcileDurable: (reason, witnesses) => reconcileDurableExactFlush(
       reason, witnesses, exactJournalAuthorizations, pending,
       journalPath, watermarkPath, rootDir
-    )
+    ),
+    shouldContinueAfterExhaustion: (error) => shouldWaitForForeignCommitter(error, globalLockPath),
+    ...(options.onLockConflictRetrySignal ? {
+      onRetryBudgetSignal: options.onLockConflictRetrySignal
+    } : {})
   });
 
   const coordinator: WriteCoordinator = {
@@ -267,7 +277,11 @@ function makeJournaledWriteCoordinatorInternal(
         ? retryWriteLockConflict(
           () => flushOnce(reason),
           lockConflictRetry,
-          reconcileDurable
+          reconcileDurable,
+          {
+            shouldContinueAfterExhaustion: (error) => shouldWaitForForeignCommitter(error, globalLockPath),
+            ...(options.onLockConflictRetrySignal ? { signal: options.onLockConflictRetrySignal } : {})
+          }
         )
         : flushOnce(reason).pipe(Effect.catchAll((error) => {
           const reconciled = isWriteLockConflict(error) ? reconcileDurable() : undefined;
@@ -278,7 +292,12 @@ function makeJournaledWriteCoordinatorInternal(
     flushExactJournalRecords,
     flushExactJournalRecord,
     recover: lockConflictRetry
-      ? retryWriteLockConflict(() => recoverOnce, lockConflictRetry)
+      ? retryWriteLockConflict(
+          () => recoverOnce,
+          lockConflictRetry,
+          undefined,
+          options.onLockConflictRetrySignal ? { signal: options.onLockConflictRetrySignal } : {}
+        )
       : recoverOnce
   };
   return withJournalExactCommit(coordinator, flushExactJournalRecords, options.exactWriteScope);

--- a/packages/kernel/src/write-coordination/journal/exact-journal-flush.ts
+++ b/packages/kernel/src/write-coordination/journal/exact-journal-flush.ts
@@ -142,7 +142,6 @@ export function createExactJournalRecordFlusher(input: {
     reason: "recovery",
     witnesses: ReadonlyArray<JournalRecordWitnessV1>
   ) => FlushReport | undefined;
-  readonly shouldContinueAfterTimeout?: (error: WriteError) => boolean;
 }): NonNullable<import("../../ports/write-coordinator.ts").WriteCoordinator[
   "flushExactJournalRecord"
 ]> {
@@ -154,10 +153,7 @@ export function createExactJournalRecordFlusher(input: {
       ...(input.lockConflictRetry ? { lockConflictRetry: input.lockConflictRetry } : {}),
       ...(input.reconcileDurable ? {
         reconcileDurable: () => input.reconcileDurable!(reason, [exactWitness])
-      } : {}),
-      ...(input.shouldContinueAfterTimeout
-        ? { shouldContinueAfterTimeout: input.shouldContinueAfterTimeout }
-        : {})
+      } : {})
     }));
   };
 }
@@ -176,7 +172,6 @@ export function createExactJournalRecordsFlusher(input: {
     reason: import("../../ports/write-coordinator.ts").FlushReason,
     witnesses: ReadonlyArray<JournalRecordWitnessV1>
   ) => FlushReport | undefined;
-  readonly shouldContinueAfterTimeout?: (error: WriteError) => boolean;
 }): NonNullable<import("../../ports/write-coordinator.ts").WriteCoordinator[
   "flushExactJournalRecords"
 ]> {
@@ -188,10 +183,7 @@ export function createExactJournalRecordsFlusher(input: {
       ...(input.lockConflictRetry ? { lockConflictRetry: input.lockConflictRetry } : {}),
       ...(input.reconcileDurable ? {
         reconcileDurable: () => input.reconcileDurable!(reason, exactWitnesses)
-      } : {}),
-      ...(input.shouldContinueAfterTimeout
-        ? { shouldContinueAfterTimeout: input.shouldContinueAfterTimeout }
-        : {})
+      } : {})
     }));
   };
 }
@@ -201,7 +193,6 @@ function runExactFlush(input: {
   readonly mapError: (cause: unknown) => WriteError;
   readonly lockConflictRetry?: LockConflictRetryOptions;
   readonly reconcileDurable?: () => FlushReport | undefined;
-  readonly shouldContinueAfterTimeout?: (error: WriteError) => boolean;
 }): Effect.Effect<FlushReport, WriteError> {
   const runOnce = (): Effect.Effect<FlushReport, WriteError> => Effect.try({
     try: input.run,
@@ -211,10 +202,7 @@ function runExactFlush(input: {
     return retryWriteLockConflict(
       runOnce,
       input.lockConflictRetry,
-      Date.now(),
-      0,
-      input.reconcileDurable,
-      input.shouldContinueAfterTimeout
+      input.reconcileDurable
     );
   }
   return runOnce().pipe(Effect.catchAll((error) => {

--- a/packages/kernel/src/write-coordination/journal/exact-journal-flush.ts
+++ b/packages/kernel/src/write-coordination/journal/exact-journal-flush.ts
@@ -5,6 +5,7 @@ import type {
   WriteOp
 } from "../../ports/write-coordinator.ts";
 import type { HarnessLayoutInput } from "../../layout/index.ts";
+import type { RetryBudgetSignal } from "../../runtime/bounded-retry.ts";
 import { readDurableState } from "./durable.ts";
 import { withRepoLocks } from "./locks.ts";
 import { journalRecordWitnessV1 } from "./records.ts";
@@ -142,6 +143,8 @@ export function createExactJournalRecordFlusher(input: {
     reason: "recovery",
     witnesses: ReadonlyArray<JournalRecordWitnessV1>
   ) => FlushReport | undefined;
+  readonly shouldContinueAfterExhaustion?: (error: WriteError) => boolean;
+  readonly onRetryBudgetSignal?: (signal: RetryBudgetSignal) => void;
 }): NonNullable<import("../../ports/write-coordinator.ts").WriteCoordinator[
   "flushExactJournalRecord"
 ]> {
@@ -153,7 +156,11 @@ export function createExactJournalRecordFlusher(input: {
       ...(input.lockConflictRetry ? { lockConflictRetry: input.lockConflictRetry } : {}),
       ...(input.reconcileDurable ? {
         reconcileDurable: () => input.reconcileDurable!(reason, [exactWitness])
-      } : {})
+      } : {}),
+      ...(input.shouldContinueAfterExhaustion ? {
+        shouldContinueAfterExhaustion: input.shouldContinueAfterExhaustion
+      } : {}),
+      ...(input.onRetryBudgetSignal ? { onRetryBudgetSignal: input.onRetryBudgetSignal } : {})
     }));
   };
 }
@@ -172,6 +179,8 @@ export function createExactJournalRecordsFlusher(input: {
     reason: import("../../ports/write-coordinator.ts").FlushReason,
     witnesses: ReadonlyArray<JournalRecordWitnessV1>
   ) => FlushReport | undefined;
+  readonly shouldContinueAfterExhaustion?: (error: WriteError) => boolean;
+  readonly onRetryBudgetSignal?: (signal: RetryBudgetSignal) => void;
 }): NonNullable<import("../../ports/write-coordinator.ts").WriteCoordinator[
   "flushExactJournalRecords"
 ]> {
@@ -183,7 +192,11 @@ export function createExactJournalRecordsFlusher(input: {
       ...(input.lockConflictRetry ? { lockConflictRetry: input.lockConflictRetry } : {}),
       ...(input.reconcileDurable ? {
         reconcileDurable: () => input.reconcileDurable!(reason, exactWitnesses)
-      } : {})
+      } : {}),
+      ...(input.shouldContinueAfterExhaustion ? {
+        shouldContinueAfterExhaustion: input.shouldContinueAfterExhaustion
+      } : {}),
+      ...(input.onRetryBudgetSignal ? { onRetryBudgetSignal: input.onRetryBudgetSignal } : {})
     }));
   };
 }
@@ -193,6 +206,8 @@ function runExactFlush(input: {
   readonly mapError: (cause: unknown) => WriteError;
   readonly lockConflictRetry?: LockConflictRetryOptions;
   readonly reconcileDurable?: () => FlushReport | undefined;
+  readonly shouldContinueAfterExhaustion?: (error: WriteError) => boolean;
+  readonly onRetryBudgetSignal?: (signal: RetryBudgetSignal) => void;
 }): Effect.Effect<FlushReport, WriteError> {
   const runOnce = (): Effect.Effect<FlushReport, WriteError> => Effect.try({
     try: input.run,
@@ -202,7 +217,13 @@ function runExactFlush(input: {
     return retryWriteLockConflict(
       runOnce,
       input.lockConflictRetry,
-      input.reconcileDurable
+      input.reconcileDurable,
+      {
+        ...(input.shouldContinueAfterExhaustion ? {
+          shouldContinueAfterExhaustion: input.shouldContinueAfterExhaustion
+        } : {}),
+        ...(input.onRetryBudgetSignal ? { signal: input.onRetryBudgetSignal } : {})
+      }
     );
   }
   return runOnce().pipe(Effect.catchAll((error) => {

--- a/packages/kernel/src/write-coordination/journal/lock-conflict-retry.ts
+++ b/packages/kernel/src/write-coordination/journal/lock-conflict-retry.ts
@@ -1,6 +1,9 @@
 import { Effect } from "effect";
 import type { WriteError } from "../../domain/index.ts";
-import { createBoundedRetryBudget } from "../../runtime/bounded-retry.ts";
+import {
+  createVisibleRetryBudget,
+  type RetryBudgetSignal
+} from "../../runtime/bounded-retry.ts";
 import type { LockConflictRetryOptions } from "./types.ts";
 
 const defaultRetryInitialDelayMs = 25;
@@ -9,24 +12,46 @@ const defaultRetryMaxDelayMs = 250;
 export function retryWriteLockConflict<Result>(
   runOnce: () => Effect.Effect<Result, WriteError>,
   retry: LockConflictRetryOptions,
-  reconcileDurable?: () => Result | undefined
+  reconcileDurable?: () => Result | undefined,
+  escalation: {
+    readonly shouldContinueAfterExhaustion?: (error: WriteError) => boolean;
+    readonly signal?: (signal: RetryBudgetSignal) => void;
+  } = {}
 ): Effect.Effect<Result, WriteError> {
-  let exhaustedError: WriteError | undefined;
-  const budget = createBoundedRetryBudget({
+  const budget = createVisibleRetryBudget({
     operation: "journal-write-lock-conflict",
     budget: { maxElapsedMs: retry.maxWaitMs },
-    onExhausted: (event) => {
-      exhaustedError = lockConflictBudgetExhausted(event.cause as WriteError, retry.maxWaitMs);
-    }
+    reminderEveryFailures: retry.reminderEveryFailures ?? 5,
+    ...(escalation.signal ? { signal: escalation.signal } : {})
   });
   const runAttempt = (attempt: number): Effect.Effect<Result, WriteError> => runOnce().pipe(
+    Effect.map((result) => {
+      budget.recovered();
+      return result;
+    }),
     Effect.catchAll((error) => {
       if (!isWriteLockConflict(error)) return Effect.fail(error);
       const reconciled = reconcileDurable?.();
-      if (reconciled !== undefined) return Effect.succeed(reconciled);
+      if (reconciled !== undefined) {
+        budget.recovered();
+        return Effect.succeed(reconciled);
+      }
       const decision = budget.recordFailure(error);
       if (decision.status === "budget-exhausted") {
-        return Effect.fail(exhaustedError ?? lockConflictBudgetExhausted(error, retry.maxWaitMs));
+        if (!escalation.shouldContinueAfterExhaustion?.(error)) {
+          return Effect.fail(lockConflictBudgetExhausted(error, retry.maxWaitMs));
+        }
+        // Adjudicated correctness exception: another process may already be
+        // committing this coordinator's WAL operation. The binary flush result
+        // cannot express "outcome pending", so returning failure here can lie
+        // about an operation that becomes durable moments later. Until that
+        // protocol gains an indeterminate terminal state, keep reconciling while
+        // the visible budget reports exhausted/still-retrying/recovered. This is
+        // the adjudicated exception in dec_01KZK41KHS93KDVSK149HWVQ8F; its
+        // closure path is task_01KZK5FYYKBEEVAJPKH0KR19Y1.
+        return delay(retry.maxDelayMs ?? defaultRetryMaxDelayMs).pipe(
+          Effect.flatMap(() => runAttempt(attempt + 1))
+        );
       }
       const delayMs = Math.min(
         decision.remainingMs ?? retry.maxWaitMs,

--- a/packages/kernel/src/write-coordination/journal/lock-conflict-retry.ts
+++ b/packages/kernel/src/write-coordination/journal/lock-conflict-retry.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import type { WriteError } from "../../domain/index.ts";
+import { createBoundedRetryBudget } from "../../runtime/bounded-retry.ts";
 import type { LockConflictRetryOptions } from "./types.ts";
 
 const defaultRetryInitialDelayMs = 25;
@@ -8,58 +9,44 @@ const defaultRetryMaxDelayMs = 250;
 export function retryWriteLockConflict<Result>(
   runOnce: () => Effect.Effect<Result, WriteError>,
   retry: LockConflictRetryOptions,
-  startedAt: number,
-  attempt: number,
-  reconcileDurable?: () => Result | undefined,
-  shouldContinueAfterTimeout?: (error: WriteError) => boolean
+  reconcileDurable?: () => Result | undefined
 ): Effect.Effect<Result, WriteError> {
-  return runOnce().pipe(
+  let exhaustedError: WriteError | undefined;
+  const budget = createBoundedRetryBudget({
+    operation: "journal-write-lock-conflict",
+    budget: { maxElapsedMs: retry.maxWaitMs },
+    onExhausted: (event) => {
+      exhaustedError = lockConflictBudgetExhausted(event.cause as WriteError, retry.maxWaitMs);
+    }
+  });
+  const runAttempt = (attempt: number): Effect.Effect<Result, WriteError> => runOnce().pipe(
     Effect.catchAll((error) => {
       if (!isWriteLockConflict(error)) return Effect.fail(error);
       const reconciled = reconcileDurable?.();
       if (reconciled !== undefined) return Effect.succeed(reconciled);
-      const remainingMs = retry.maxWaitMs - (Date.now() - startedAt);
-      if (remainingMs <= 0) {
-        if (!shouldContinueAfterTimeout?.(error)) {
-          return Effect.fail(lockConflictTimeout(error, retry.maxWaitMs));
-        }
-        const delayMs = retry.maxDelayMs ?? defaultRetryMaxDelayMs;
-        return delay(delayMs).pipe(
-          Effect.flatMap(() => retryWriteLockConflict(
-            runOnce,
-            retry,
-            Date.now(),
-            0,
-            reconcileDurable,
-            shouldContinueAfterTimeout
-          ))
-        );
+      const decision = budget.recordFailure(error);
+      if (decision.status === "budget-exhausted") {
+        return Effect.fail(exhaustedError ?? lockConflictBudgetExhausted(error, retry.maxWaitMs));
       }
       const delayMs = Math.min(
-        remainingMs,
+        decision.remainingMs ?? retry.maxWaitMs,
         retry.maxDelayMs ?? defaultRetryMaxDelayMs,
         (retry.initialDelayMs ?? defaultRetryInitialDelayMs) * (2 ** attempt)
       );
       return delay(delayMs).pipe(
-        Effect.flatMap(() => retryWriteLockConflict(
-          runOnce,
-          retry,
-          startedAt,
-          attempt + 1,
-          reconcileDurable,
-          shouldContinueAfterTimeout
-        ))
+        Effect.flatMap(() => runAttempt(attempt + 1))
       );
     })
   );
+  return runAttempt(0);
 }
 
 export function isWriteLockConflict(error: WriteError): boolean {
   return error._tag === "GlobalWriteConflict" || error._tag === "WriteConflict";
 }
 
-function lockConflictTimeout(error: WriteError, maxWaitMs: number): WriteError {
-  const suggestion = `timed out after ${maxWaitMs}ms; the holder may be committing, so retry the command or use the daemon-backed client when a daemon owns the lock`;
+function lockConflictBudgetExhausted(error: WriteError, maxWaitMs: number): WriteError {
+  const suggestion = `automatic retry budget exhausted after ${maxWaitMs}ms; the holder may be committing, so wait briefly and retry the command, or inspect the current lock holder before retrying`;
   if (error._tag === "WriteConflict") {
     return { ...error, owner: `${error.owner ?? "task write lock"}; ${suggestion}` };
   }

--- a/packages/kernel/src/write-coordination/journal/receipt.ts
+++ b/packages/kernel/src/write-coordination/journal/receipt.ts
@@ -1,10 +1,11 @@
+import type { WriteError } from "../../domain/index.ts";
 import type {
   FlushReason,
   FlushReport,
   JournalRecordWitnessV1,
   WriteOp
 } from "../../ports/write-coordinator.ts";
-import { readDurableState } from "./durable.ts";
+import { durableFileExists, readDurableState, readFileBytes } from "./durable.ts";
 
 export function reconcileDurableFlush(
   reason: FlushReason,
@@ -55,4 +56,16 @@ export function reconcileDurableExactFlush(
   if (!report) return undefined;
   for (const witness of witnesses) authorizations.delete(witness.opId);
   return { ...report, publicationMode: "exact-batch" };
+}
+
+export function shouldWaitForForeignCommitter(error: WriteError, globalLockPath: string): boolean {
+  if (error._tag !== "GlobalWriteConflict") return false;
+  if (!durableFileExists(globalLockPath)) return true;
+  try {
+    const lock = JSON.parse(Buffer.from(readFileBytes(globalLockPath)).toString("utf8")) as { readonly pid?: unknown };
+    return typeof lock.pid !== "number" || lock.pid !== process.pid;
+  } catch {
+    // The lock owner may still be between open("wx") and its durable JSON write.
+    return true;
+  }
 }

--- a/packages/kernel/src/write-coordination/journal/receipt.ts
+++ b/packages/kernel/src/write-coordination/journal/receipt.ts
@@ -1,11 +1,10 @@
-import type { WriteError } from "../../domain/index.ts";
 import type {
   FlushReason,
   FlushReport,
   JournalRecordWitnessV1,
   WriteOp
 } from "../../ports/write-coordinator.ts";
-import { durableFileExists, readDurableState, readFileBytes } from "./durable.ts";
+import { readDurableState } from "./durable.ts";
 
 export function reconcileDurableFlush(
   reason: FlushReason,
@@ -56,16 +55,4 @@ export function reconcileDurableExactFlush(
   if (!report) return undefined;
   for (const witness of witnesses) authorizations.delete(witness.opId);
   return { ...report, publicationMode: "exact-batch" };
-}
-
-export function shouldWaitForForeignCommitter(error: WriteError, globalLockPath: string): boolean {
-  if (error._tag !== "GlobalWriteConflict") return false;
-  if (!durableFileExists(globalLockPath)) return true;
-  try {
-    const lock = JSON.parse(Buffer.from(readFileBytes(globalLockPath)).toString("utf8")) as { readonly pid?: unknown };
-    return typeof lock.pid !== "number" || lock.pid !== process.pid;
-  } catch {
-    // The lock owner may still be between open("wx") and its durable JSON write.
-    return true;
-  }
 }

--- a/packages/kernel/src/write-coordination/journal/types.ts
+++ b/packages/kernel/src/write-coordination/journal/types.ts
@@ -4,6 +4,7 @@ import type { VcsCommitAuthor, VcsCommitPhase, VersionControlSystem } from "../.
 import type { AttributionEventStore } from "../attribution/inline-attribution-event-store.ts";
 import type { ProjectionChangeEvent } from "../../projection/projection-change-event.ts";
 import type { TrustedProjectionFingerprintDiagnostic } from "../../projection/projection-source-baseline.ts";
+import type { RetryBudgetSignal } from "../../runtime/bounded-retry.ts";
 import type { ExactWriteScope, WriteOp } from "../../ports/write-coordinator.ts";
 import type { ActorAxes, AgentRef, OperationalActor, WriteAttribution } from "../../schemas/actor-attribution.ts";
 export type { OperationalActor } from "../../schemas/actor-attribution.ts";
@@ -21,6 +22,7 @@ export interface JournaledWriteCoordinatorOptions {
   readonly operationalActor?: OperationalActor;
   readonly lockTtlMs?: number;
   readonly lockConflictRetry?: LockConflictRetryOptions;
+  readonly onLockConflictRetrySignal?: (signal: RetryBudgetSignal) => void;
   readonly heldGlobalLock?: OwnedLock;
   readonly exactWriteScope?: ExactWriteScope;
   readonly sessionId?: string;
@@ -60,6 +62,7 @@ export interface LockConflictRetryOptions {
   readonly maxWaitMs: number;
   readonly initialDelayMs?: number;
   readonly maxDelayMs?: number;
+  readonly reminderEveryFailures?: number;
 }
 
 export interface JournalActor {

--- a/packages/kernel/test/contracts/public-surface.test.ts
+++ b/packages/kernel/test/contracts/public-surface.test.ts
@@ -98,6 +98,7 @@ const publicRuntimeSurface = [
   "createJournaledBatch",
   "createTaskIdentity",
   "createTaskPackagePath",
+  "createVisibleRetryBudget",
   "createWritableEntityRegistry",
   "daemonAdmissionBytes",
   "decisionAmendFieldSupportsOperation",

--- a/packages/kernel/test/contracts/public-surface.test.ts
+++ b/packages/kernel/test/contracts/public-surface.test.ts
@@ -90,6 +90,7 @@ const publicRuntimeSurface = [
   "consentActions",
   "consentDeclaration",
   "countContentPinArbitersInDocument",
+  "createBoundedRetryBudget",
   "createEntityKindRegistry",
   "createExactWriteScope",
   "createHarnessRuntimeContext",

--- a/packages/kernel/test/runtime/bounded-retry.test.ts
+++ b/packages/kernel/test/runtime/bounded-retry.test.ts
@@ -1,0 +1,27 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createBoundedRetryBudget } from "../../src/index.ts";
+
+test("bounded retry exhausts once per episode and resets after recovery", () => {
+  const exhausted: Array<{ operation: string; retriesUsed: number }> = [];
+  const retry = createBoundedRetryBudget({
+    operation: "publication-object-read",
+    budget: { maxRetries: 1 },
+    onExhausted: (event) => exhausted.push({
+      operation: event.operation,
+      retriesUsed: event.retriesUsed
+    })
+  });
+
+  assert.equal(retry.recordFailure(new Error("first")).status, "retry-allowed");
+  assert.equal(retry.recordFailure(new Error("second")).status, "budget-exhausted");
+  assert.equal(retry.recordFailure(new Error("third")).status, "budget-exhausted");
+  assert.deepEqual(exhausted, [{ operation: "publication-object-read", retriesUsed: 1 }]);
+
+  retry.reset();
+
+  assert.equal(retry.recordFailure(new Error("new episode")).status, "retry-allowed");
+  assert.equal(retry.recordFailure(new Error("new episode exhausted")).status, "budget-exhausted");
+  assert.equal(exhausted.length, 2);
+});

--- a/packages/kernel/test/store/global-committer-lock.test.ts
+++ b/packages/kernel/test/store/global-committer-lock.test.ts
@@ -310,8 +310,10 @@ test("WriteCoordinator lock queue times out with holder identity and recovery ad
     if (result._tag !== "Left") throw new Error("expected lock timeout");
     assert.equal(result.left._tag, "GlobalWriteConflict");
     assert.match(result.left.owner ?? "", new RegExp(`held by pid ${process.pid} on ${hostname()}`, "u"));
-    assert.match(result.left.owner ?? "", /timed out after 30ms/u);
-    assert.match(result.left.owner ?? "", /retry the command or use the daemon-backed client/u);
+    assert.match(result.left.owner ?? "", /automatic retry budget exhausted after 30ms/u);
+    assert.match(result.left.owner ?? "", /wait briefly and retry the command/u);
+    assert.match(result.left.owner ?? "", /inspect the current lock holder/u);
+    assert.doesNotMatch(result.left.owner ?? "", /HARNESS_DAEMON_MODE=direct|ha daemon restart/u);
   });
 });
 

--- a/packages/kernel/test/write-coordination/bounded-lock-conflict-retry.test.ts
+++ b/packages/kernel/test/write-coordination/bounded-lock-conflict-retry.test.ts
@@ -9,13 +9,13 @@ import { makeJournaledWriteCoordinator } from "../../src/index.ts";
 import { docWrite, runEffect, withTempStoreAsync } from "../store/helpers.ts";
 import { testWriteAttribution } from "../test-attribution.ts";
 
-test("journal exhausts foreign lock retry without losing the durable write", async () => {
+test("journal exhausts non-foreign lock retry without losing the durable write", async () => {
   await withTempStoreAsync(async (rootDir) => {
     const lockPath = path.join(rootDir, ".harness/locks/global.lock");
     mkdirSync(path.dirname(lockPath), { recursive: true });
     writeFileSync(lockPath, JSON.stringify({
-      pid: process.pid + 10_000,
-      hostname: `${hostname()}-foreign`,
+      pid: process.pid,
+      hostname: hostname(),
       acquiredAt: new Date().toISOString(),
       heartbeatAt: new Date().toISOString(),
       ownerToken: "live-foreign-holder"

--- a/packages/kernel/test/write-coordination/bounded-lock-conflict-retry.test.ts
+++ b/packages/kernel/test/write-coordination/bounded-lock-conflict-retry.test.ts
@@ -1,0 +1,60 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { hostname } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { Effect } from "effect";
+import { makeJournaledWriteCoordinator } from "../../src/index.ts";
+import { docWrite, runEffect, withTempStoreAsync } from "../store/helpers.ts";
+import { testWriteAttribution } from "../test-attribution.ts";
+
+test("journal exhausts foreign lock retry without losing the durable write", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    const lockPath = path.join(rootDir, ".harness/locks/global.lock");
+    mkdirSync(path.dirname(lockPath), { recursive: true });
+    writeFileSync(lockPath, JSON.stringify({
+      pid: process.pid + 10_000,
+      hostname: `${hostname()}-foreign`,
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      ownerToken: "live-foreign-holder"
+    }), "utf8");
+    const blocked = makeJournaledWriteCoordinator({
+      attribution: testWriteAttribution(),
+      rootDir,
+      lockTtlMs: 60_000,
+      lockConflictRetry: { maxWaitMs: 1, initialDelayMs: 1, maxDelayMs: 1 }
+    });
+    Effect.runSync(blocked.enqueue(
+      docWrite("op-budget-exhausted", "task-budget-exhausted", "recovered.md", "recovered\n")
+    ));
+
+    const result = await runEffect(Effect.either(blocked.flush("explicit")));
+
+    if (result._tag !== "Left") throw new Error("expected retryable lock failure");
+    assert.equal(result.left._tag, "GlobalWriteConflict");
+    assert.match(result.left.owner ?? "", /automatic retry budget exhausted after 1ms/u);
+    assert.match(result.left.owner ?? "", /wait briefly and retry/u);
+    assert.match(result.left.owner ?? "", /inspect the current lock holder/u);
+    assert.doesNotMatch(result.left.owner ?? "", /HARNESS_DAEMON_MODE=direct|ha daemon restart/u);
+
+    const journalPath = path.join(rootDir, ".harness/write-journal/writes.jsonl");
+    assert.match(readFileSync(journalPath, "utf8"), /op-budget-exhausted/u);
+    rmSync(lockPath);
+
+    const recovered = makeJournaledWriteCoordinator({
+      attribution: testWriteAttribution(),
+      rootDir
+    });
+    const recovery = await runEffect(recovered.recover);
+
+    assert.equal(recovery.replayedOps, 1);
+    assert.equal(recovery.recoveredWatermark, "op-budget-exhausted");
+    assert.equal(readFileSync(
+      path.join(rootDir, "harness/tasks/task-budget-exhausted/recovered.md"),
+      "utf8"
+    ), "recovered\n");
+    assert.equal(readFileSync(journalPath, "utf8").trim().split("\n").length, 1);
+  });
+});


### PR DESCRIPTION
# English

## Summary

`dec_01KZJF4YGRH57R3NPW0PQ5AFGW` (standing policy) requires that automatic retries be bounded and escalate to a human-actionable signal when the budget runs out — there must be no default that retries forever. The same "unbounded" shape had already been solved point-by-point four separate times in this repository (`dec_01KXJ0EYC9PV1NT7W8GDJ9XEBB`, `dec_01KY80QQY2696ZDD2Q1XZRX2ZG`, `dec_01KY6BAN1EJACTAGS0ZH91E2KG`, `dec_01KXFEMGFNT0QF5PTXVDGQGZ76`) without ever being raised to a seam. Turning it into a seam immediately surfaced **two live unbounded retries that none of those four fixes covered**.

Three of the four sites are now bounded with visible escalation. **The fourth is an adjudicated exception, not an oversight** — and that distinction is the most important thing in this PR.

The journal's cross-process lock wait is not "retry until success", it is **"wait until the outcome is knowable"**. Bounding it made `write-receipt-honesty` red immediately: 16 cross-process writes all landed on disk (`durable: 16`), yet only 4 receipts said so — `falseNegative: 12`. A plausible-sounding fix was falsified by experiment: adding one more `reconcileDurable()` after budget exhaustion still gave `falseNegative: 12`, because the 100ms wait budget expires long before the lock holder's fixed 500ms commit completes. **The wall is interface expressiveness, not implementation sloppiness**: a binary flush receipt (committed true/false) has no word for "I stopped waiting, the outcome is pending". Forcing a bound there means reporting `unknown` as `failure`.

So that site keeps waiting — but the fact that it is unbounded is now itself visible, via the three-phase budget signal. Its closure path is recorded: `dec_01KZK41KHS93KDVSK149HWVQ8F` (accepted) extends flush receipts to `committed / failed / indeterminate`, implemented by `task_01KZK5FYYKBEEVAJPKH0KR19Y1`. The code comment at the exception points at both, so the next reader knows it is adjudicated rather than missed.

## What Changed

- `packages/kernel/src/runtime/bounded-retry.ts` (new): `createBoundedRetryBudget` / `createVisibleRetryBudget`. `recordFailure(cause)` returns `retry-allowed | budget-exhausted` with `retriesUsed` / `elapsedMs` / `remainingMs`. It deliberately **does not** accept sleep, delay, multiplier or backoff — per `dec_01KZJF4YGRH57R3NPW0PQ5AFGW/RJ3`, retry *timing* is not being unified, only retry *boundedness*.
- `packages/daemon/src/observability/visible-retry-budget.ts` + `daemon-retry-budget-log.ts` (new): three phases — `exhausted`, `still-retrying` (throttled by `reminderEveryFailures`), `recovered` — logged at `error` while ongoing and `info` on recovery, with `errorCode: "RETRY_BUDGET_EXHAUSTED"` and a hint pointing at `ha daemon logs --errors`.
- **Bounded (3 sites)**: remote read-down, `RemoteBrokerRuntime` (`packages/daemon/src/broker/remote-broker-runtime.ts`, whose `while (!stopped && !terminalFailure && lifecycle === "ACTIVE")` loop had no attempt count, deadline or total budget), and the publication object reader.
- **Adjudicated exception (1 site)**: `packages/kernel/src/write-coordination/journal/lock-conflict-retry.ts` keeps the foreign-committer wait (`shouldContinueAfterExhaustion`, wired in `coordinator.ts` via `shouldWaitForForeignCommitter`) because that wait carries receipt honesty. Exceeding the budget now emits the visible three-phase escalation instead of waiting silently.
- The lock-conflict error message no longer suggests `use the daemon-backed client when a daemon owns the lock` — that reads as an instruction to bypass the single-writer fence. It now says `wait briefly and retry the command, or inspect the current lock holder before retrying`.
- **Publication retry visibility is wired at all three inspector construction sites**, not just one. `createGitCanonicalPublicationInspector` takes an optional signal sink; `production-authority-lifecycle.ts` supplies it directly, `authority-lifecycle.ts` receives it through `resolvePublicationInspectorOptions`, and `repo-write-child-entrypoint.ts` forwards it over child IPC to the parent daemon log.

## Version Impact

- Version: no version change — internal runtime seam plus observability wiring; no CLI surface, flag, or published contract changes.

## Verification

Red/green discrimination evidence for each bounded site (the escalation signal was disabled, the test had to go red, then restored):

| Site | RED | GREEN |
| --- | --- | --- |
| Remote read-down | `actual []` — 0/1 | 1/1 |
| `RemoteBrokerRuntime` | `timed out waiting for recovered signal` — 0/1 | 1/1 |
| Publication reader | `expected exhausted signal; actual []` — 0/1 | 1/1 |
| Journal escalation | `retry-budget.exhausted` assertion failed — 0/1 | 1/1 |

- `packages/kernel/test/store/write-receipt-honesty.test.ts`: `falseNegative = 0`, `falsePositive = 0`. **That test was not modified**, its budget was not extended, and its classification was not adjusted.
- Targeted tests 75/75. `npm run check:local`: 27 gates green.
- `packages/kernel/src/runtime/bounded-retry.ts` exports no `BoundedRetryBudgetOptions` — the kernel dead-export gate was satisfied by removing the export, **not** by adding an allowlist entry, since that gate exists to hold the kernel export surface down.

**One reviewer suspicion was checked rather than assumed.** `publication-evidence-responsiveness.test.ts` moved an assertion from `process.on("warning")` (plus an `await setImmediate`) to an injected `onRetryBudgetSignal` callback. That could have relocated the assertion from the real observable surface to an injection point, letting the production `emitWarning` drift without turning the test red. It did not: `reportBatchFailure`'s `process.emitWarning` is retained, and the callback is the same sink production injects.

## Review Evidence

- Reviewed against the diff and the call surface, not only the implementer's report. That is what surfaced the wiring gap below.
- **First-round finding, now fixed**: the signal sink was initially wired at only one of three inspector construction sites. Not a regression introduced here — #1298 only ever had `emitWarning` — but adding a sink mechanism and wiring one site leaves defence strength differing between immediate neighbours, which is correctness by coincidence. All three now carry it.
- **A load-bearing fact was established by investigation, not inference**: in a resident service daemon the repo-write child's `process.emitWarning` **is lost**. The child fork does not set `silent`, so it inherits daemon stdio (`repo-write-child-process-transport.ts:97`, `run-daemon-serve.ts:297`); the service daemon's stderr is a pipe (`productization.ts:162`); that pipe is only held by the startup observer, which calls `discard()` once ready (`productization.ts:178`, `daemon-service-startup.ts:138`); and nothing transcribes it into the daemon operational log. So "it is still visible via `emitWarning`" would have been **false** for that entry point — which is why it had to use the child IPC sink rather than be documented as an acceptable inconsistency.
- Reviewers should confirm: the journal exception comment names the adjudicating decision and its closure task; the three bounded sites fail closed rather than silently; and no consumer treats an exhausted budget as success.

## Residual Risk

- The journal site remains unbounded by design until `dec_01KZK41KHS93KDVSK149HWVQ8F` lands. It is visible, but a lock held indefinitely by a foreign committer still blocks that write indefinitely. **This PR delivers three of four; it does not claim four of four.**
- If child↔parent IPC is down, the repo-write child's retry-budget escalation falls back to `emitWarning`, which — per the finding above — is discarded in a resident service daemon. The escalation is therefore lost in exactly that window. Accepted because a child with dead IPC is already terminating, but recorded rather than papered over.
- `publication-evidence-responsiveness.test.ts:76` (`offset batch bytes fail closed …`, `batchPids.length` expected 2, actual 1) was seen red once on #1300 (run `31310311207`) and is green on `main`. It is **not** classified as flake or defect yet; `task_01KZK3QS832TK1DTDX64SWM2J9` is required to judge whether it shares a cause with the unclosed resident-child family. Deliberately untouched here.
- `npm run check:local` on this machine ran green (27 gates), but the machine hosts several concurrent workers; GitHub CI on this PR is the complete authority.

## References

- Task: `task_01KZJX501ZSKBBT0VMQJX6WMAR`
- Policy: `dec_01KZJF4YGRH57R3NPW0PQ5AFGW` (standing policy — bounded retries with visible escalation)
- Exception and its closure: `dec_01KZK41KHS93KDVSK149HWVQ8F` → `task_01KZK5FYYKBEEVAJPKH0KR19Y1`
- Prior point fixes that never became a seam: `dec_01KXJ0EYC9PV1NT7W8GDJ9XEBB`, `dec_01KY80QQY2696ZDD2Q1XZRX2ZG`, `dec_01KY6BAN1EJACTAGS0ZH91E2KG`, `dec_01KXFEMGFNT0QF5PTXVDGQGZ76`

## Governance Declaration

- No CI/gate authority surface was modified. No test tier or shard manifest was touched to avoid a test.
- `write-receipt-honesty.test.ts` was not modified; the kernel dead-export gate was satisfied by removing an export rather than by an allowlist entry.
- The journal exception is authorized by `dec_01KZK41KHS93KDVSK149HWVQ8F/CH3` and is recorded in code, in this PR, and in the task closeout.

---

# 中文

## 摘要

`dec_01KZJF4YGRH57R3NPW0PQ5AFGW`(常设政策)要求自动重试必须有界,预算耗尽时必须升级为人类可处置的信号——不允许存在"无限重来"的默认。同一个"无界"形状在本仓库已经被单点解决过四次(`dec_01KXJ0EYC9PV1NT7W8GDJ9XEBB`、`dec_01KY80QQY2696ZDD2Q1XZRX2ZG`、`dec_01KY6BAN1EJACTAGS0ZH91E2KG`、`dec_01KXFEMGFNT0QF5PTXVDGQGZ76`),却始终没有被抬成切面。这次一做切面,立刻查出**两处那四次修复都没覆盖的、活着的无界重试**。

四处里三处已经有界并带可见升级。**第四处是已裁决的例外,不是漏改**——这个区分是本 PR 最重要的内容。

journal 的跨进程锁等待不是"重试直到成功",而是**"等待直到结果可知"**。给它加上界之后 `write-receipt-honesty` 立刻红:16 次跨进程写全部真的落盘(`durable: 16`),但只有 4 次回执这么说——`falseNegative: 12`。一个听起来很像的修法被实验证伪了:在预算耗尽后补一次 `reconcileDurable()`,`falseNegative` 仍然是 12,因为 100ms 的等待预算远早于持锁方固定 500ms 的提交完成。**这面墙是接口表达力,不是实现疏忽**:二元 flush 回执(committed true/false)没有词汇说"我停止等待了,结果未决"。在那里强行有界,等于把 unknown 报成 failure。

所以那一处保持等待——但"它是无界的"这件事本身现在可见了,走三阶段预算信号。它的收口路径已经记录在案:`dec_01KZK41KHS93KDVSK149HWVQ8F`(已裁决)把 flush 回执扩为 `committed / failed / indeterminate`,由 `task_01KZK5FYYKBEEVAJPKH0KR19Y1` 实施。例外处的代码注释同时指向这两者,好让下一个读它的人知道这是已裁决的例外而不是漏掉。

## 改动内容

- `packages/kernel/src/runtime/bounded-retry.ts`(新增):`createBoundedRetryBudget` / `createVisibleRetryBudget`。`recordFailure(cause)` 返回 `retry-allowed | budget-exhausted`,带 `retriesUsed` / `elapsedMs` / `remainingMs`。它**刻意不接收** sleep、delay、multiplier 或 backoff——按 `dec_01KZJF4YGRH57R3NPW0PQ5AFGW/RJ3`,本次不统一重试**时机**,只统一重试的**有界性**。
- `packages/daemon/src/observability/visible-retry-budget.ts` + `daemon-retry-budget-log.ts`(新增):三个阶段 `exhausted`、`still-retrying`(按 `reminderEveryFailures` 节流)、`recovered`;进行中记 `error`、恢复时记 `info`,带 `errorCode: "RETRY_BUDGET_EXHAUSTED"` 与指向 `ha daemon logs --errors` 的提示。
- **已有界(三处)**:remote read-down、`RemoteBrokerRuntime`(`packages/daemon/src/broker/remote-broker-runtime.ts`,原来那个 `while (!stopped && !terminalFailure && lifecycle === "ACTIVE")` 循环既无尝试计数、也无 deadline 或总预算)、publication object reader。
- **已裁决的例外(一处)**:`packages/kernel/src/write-coordination/journal/lock-conflict-retry.ts` 保留对外来 committer 的等待(`shouldContinueAfterExhaustion`,生产接线在 `coordinator.ts` 的 `shouldWaitForForeignCommitter`),因为那个等待承载的是回执诚实性。超过预算时现在发出可见的三阶段升级,而不是静默等待。
- 锁冲突的错误消息不再建议 `use the daemon-backed client when a daemon owns the lock`——那句会被读成"绕过单写者栅栏"的指示。现在是 `wait briefly and retry the command, or inspect the current lock holder before retrying`。
- **publication 的重试可见性在三个 inspector 构造面上全部接线**,不是只接一处。`createGitCanonicalPublicationInspector` 接受可选的 signal sink:`production-authority-lifecycle.ts` 直接提供,`authority-lifecycle.ts` 通过 `resolvePublicationInspectorOptions` 拿到,`repo-write-child-entrypoint.ts` 经 child IPC 转发到父 daemon 日志。

## 版本影响

- 版本:不改版本——内部运行时切面加可观测接线;未改动 CLI 面、flag 或已发布契约。

## 验证

每一处有界站点的红绿分辨力证据(禁用升级信号后测试必须红,恢复后绿):

| 站点 | RED | GREEN |
| --- | --- | --- |
| Remote read-down | `actual []` — 0/1 | 1/1 |
| `RemoteBrokerRuntime` | `timed out waiting for recovered signal` — 0/1 | 1/1 |
| Publication reader | `expected exhausted signal; actual []` — 0/1 | 1/1 |
| Journal 升级 | `retry-budget.exhausted` 断言失败 — 0/1 | 1/1 |

- `packages/kernel/test/store/write-receipt-honesty.test.ts`:`falseNegative = 0`、`falsePositive = 0`。**该测试未被修改**,未延长它的预算,未调整它的分类口径。
- 定向测试 75/75。`npm run check:local`:27 个 gate 全绿。
- `packages/kernel/src/runtime/bounded-retry.ts` 不再导出 `BoundedRetryBudgetOptions`——kernel 死导出门是靠**删除导出**满足的,**不是**靠加 allowlist,因为那道门存在的目的正是压住 kernel 导出面。

**复核时的一个怀疑是查证过的,不是假定的。** `publication-evidence-responsiveness.test.ts` 把一条断言从 `process.on("warning")`(外加 `await setImmediate`)改成注入 `onRetryBudgetSignal` 回调。这本可能把断言从真实可观察面搬到注入点,从而让生产的 `emitWarning` 自由漂移而测试不红。查证结果不是:`reportBatchFailure` 的 `process.emitWarning` 保留了,而那个回调正是生产注入的同一个 sink。

## 审查证据

- 复核针对 diff 与调用面进行,不只读实施者的报告。正是这样才发现了下面那处接线缺口。
- **第一轮发现,已修**:signal sink 起初只接在三个 inspector 构造面中的一个上。这不是本 PR 引入的退化——#1298 原本就只有 `emitWarning`——但新增了 sink 机制却只接一处,会让相邻调用点之间的防御强度不同,那是"正确性靠巧合"。现在三处都有。
- **一条承重事实是查证得来的,不是推断的**:在常驻 service daemon 中,repo-write child 的 `process.emitWarning` **会丢失**。child fork 未设置 `silent`,因此继承 daemon stdio(`repo-write-child-process-transport.ts:97`、`run-daemon-serve.ts:297`);service daemon 的 stderr 是 pipe(`productization.ts:162`);那个 pipe 只由启动观察器持有,ready 之后它调用 `discard()`(`productization.ts:178`、`daemon-service-startup.ts:138`);且没有任何路径把它转写进 daemon operational log。所以"它仍然可以通过 `emitWarning` 看见"这句话对该入口是**错的**——这正是它必须走 child IPC sink、而不能被记成"可接受的不一致"的原因。
- 请复核者确认:journal 例外处的注释点明了裁决它的 decision 与收口 task;三处有界站点是 fail closed 而不是静默;没有任何消费方把"预算耗尽"当成成功。

## 残余风险

- 在 `dec_01KZK41KHS93KDVSK149HWVQ8F` 落地之前,journal 那一处按设计仍然无界。它是可见的,但一个被外来 committer 无限期持有的锁仍会无限期阻塞那次写。**本 PR 交付三分之四,不声称四分之四。**
- 若 child↔parent 的 IPC 断开,repo-write child 的重试预算升级会回退到 `emitWarning`,而按上面那条查证,它在常驻 service daemon 中会被 discard 丢掉。也就是说恰好在那个窗口里升级会丢失。接受它是因为 IPC 已死的 child 本身正在终止,但如实记录而不是糊过去。
- `publication-evidence-responsiveness.test.ts:76`(`offset batch bytes fail closed …`,`batchPids.length` 期望 2、实际 1)在 #1300 的一次运行里红过一次(run `31310311207`),在 `main` 上是绿的。它**尚未**被定性为 flake 或缺陷;`task_01KZK3QS832TK1DTDX64SWM2J9` 被要求判断它是否与"常驻子进程未关闭"那一族同源。本 PR 刻意未动它。
- 本机 `npm run check:local` 跑绿(27 gates),但本机同时驻有多个 worker;本 PR 的 GitHub CI 是完整权威。

## 关联材料

- 任务:`task_01KZJX501ZSKBBT0VMQJX6WMAR`
- 政策:`dec_01KZJF4YGRH57R3NPW0PQ5AFGW`(常设政策——有界重试与可见升级)
- 例外及其收口:`dec_01KZK41KHS93KDVSK149HWVQ8F` → `task_01KZK5FYYKBEEVAJPKH0KR19Y1`
- 从未被抬成切面的四次单点修复:`dec_01KXJ0EYC9PV1NT7W8GDJ9XEBB`、`dec_01KY80QQY2696ZDD2Q1XZRX2ZG`、`dec_01KY6BAN1EJACTAGS0ZH91E2KG`、`dec_01KXFEMGFNT0QF5PTXVDGQGZ76`

## 治理声明

- 未修改任何 CI/gate 权威面。未通过改 test tier 或 shard manifest 来回避测试。
- `write-receipt-honesty.test.ts` 未被修改;kernel 死导出门是靠删除导出满足的,不是靠 allowlist。
- journal 例外由 `dec_01KZK41KHS93KDVSK149HWVQ8F/CH3` 授权,并在代码、本 PR 与任务 closeout 中三处记录。
