### PR TITLE
test(cli): let the daemon-root-lifetime delete race the live writer

### DIFF
--- a/packages/cli/test/daemon-autostart-root-lifetime.test.ts
+++ b/packages/cli/test/daemon-autostart-root-lifetime.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -19,6 +19,11 @@ import {
   runDaemonCommand,
   runRawJson
 } from "./helpers/daemon-cli.ts";
+// Removing the canonical root here is the act under test, not teardown: a live daemon is still
+// writing into it, so the delete races the writer and surfaces as ENOTEMPTY on Linux and EPERM
+// on Windows. The bounded retry lets the delete finish without weakening the assertion, which is
+// still that the daemon exits once the root is gone.
+import { removeTemporaryTestRoot } from "./helpers/temp-root-cleanup.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 
@@ -34,7 +39,7 @@ test("an autostarted resident daemon exits after its canonical root disappears",
     daemonPid = status.pid as number;
 
     assert.equal(processIsAlive(daemonPid), true, "the resident daemon must outlive its launching CLI command");
-    rmSync(rootDir, { recursive: true, force: true });
+    await removeTemporaryTestRoot(rootDir);
 
     await pollUntil(
       () => processIsAlive(daemonPid),
@@ -43,7 +48,7 @@ test("an autostarted resident daemon exits after its canonical root disappears",
       { timeoutMs: 8_000 }
     );
   } finally {
-    rmSync(rootDir, { recursive: true, force: true });
+    await removeTemporaryTestRoot(rootDir);
     if (daemonPid !== undefined && processIsAlive(daemonPid)) {
       process.kill(daemonPid, "SIGTERM");
       await pollUntil(
@@ -66,7 +71,7 @@ test("an autostarted daemon cannot revive a canonical root removed during cold s
     daemonPid = spawnLocalDaemon(target, { entryPath: cliEntry, idleExitMs: 0 });
     assert.equal(typeof daemonPid, "number");
 
-    rmSync(rootDir, { recursive: true, force: true });
+    await removeTemporaryTestRoot(rootDir);
     await pollUntil(
       () => processIsAlive(daemonPid),
       (alive) => !alive,
@@ -83,7 +88,7 @@ test("an autostarted daemon cannot revive a canonical root removed during cold s
         { timeoutMs: 8_000 }
       );
     }
-    rmSync(rootDir, { recursive: true, force: true });
+    await removeTemporaryTestRoot(rootDir);
   }
 });
 
@@ -103,7 +108,7 @@ test("root loss is still detected when the watcher is suppressed", { timeout: 15
   const monitor = monitorDaemonRootLifetime(rootDir, daemonRootIdentity(rootDir), true);
   try {
     assert.equal(monitor.rootAvailable(), true);
-    rmSync(rootDir, { recursive: true, force: true });
+    await removeTemporaryTestRoot(rootDir);
     assert.deepEqual(await monitor.rootLost, { reason: "root-unavailable" });
   } finally {
     monitor.stop();


### PR DESCRIPTION
# English

## Summary

`main` is red. The post-merge full check on `3474ffa5` (PR #1299) failed `integration-shard (1)`:

```
✖ an autostarted resident daemon exits after its canonical root disappears (5668ms)
  Error: ENOTEMPTY, Directory not empty: /tmp/ha-daemon-root-lifetime-JdiXL9
      at packages/cli/test/daemon-autostart-root-lifetime.test.ts:37
```

Line 37 is not teardown. **Deleting the canonical root while the daemon is still resident is the act under test** — the delete races a live writer, so the directory can refill between `readdir` and `rmdir` and the removal fails with `ENOTEMPTY` on Linux (and `EPERM` on Windows).

PR #1299 introduced `removeTemporaryTestRoot` for exactly this class, and its retriable set already lists `ENOTEMPTY`. **This file was never switched over.** The guarantee therefore held at some call sites and not at their immediate neighbours, which is correctness by coincidence rather than by construction.

## What Changed

- `packages/cli/test/daemon-autostart-root-lifetime.test.ts`: all five `rmSync(rootDir, …)` calls now use `removeTemporaryTestRoot`, and the raw `rmSync` import is removed so no reader has to work out which deletions were safe. A comment records why the delete races at all, so the next person does not "simplify" it back.

The assertion is untouched: the daemon must exit once the root is gone. The retry lets the delete complete; it does not weaken what is proven.

## Task And Scope

- Harness task: `task_01KZJF8PRC8E1XM9R95P4BKEP1` (repairing the post-merge fallout of its own delivery)
- Branch: `codex/temp-root-cleanup-sweep`
- Public scope: one test file
- Private planning/evidence updated: yes
- Out of scope: the wider sweep. Ten or so other daemon-hosting test files still delete temp roots with raw `rmSync`; converting them is a separate task, and the durable fix is a check that makes the raw form impossible in daemon-hosting tests rather than a hand sweep.

## Version Impact

- Version: no version change; test-only
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KZJF8PRC8E1XM9R95P4BKEP1`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: a task for the remaining raw-`rmSync` daemon tests and the check that would prevent regrowth

## Verification

- Base `origin/main` SHA: `3474ffa5`
- Branch merge-base with `origin/main`: `3474ffa5`
- Last `git fetch origin` time: 2026-08-09, immediately before branching
- Sync method: branched from `origin/main`
- Public diff command: `git diff 3474ffa5..d5fcf24d -- packages/`
- Private evidence commit/path: `harness/tasks/task_01KZJF8PRC8E1XM9R95P4BKEP1-47/progress.md`
- Reviewer evidence path: failing run https://github.com/FairladyZ625/harness-anything/actions/runs/31309529417, job `integration-shard (1)`
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` — `npm run check:local`, "Local check passed in 61.9s", 27 manifest gates green
- [x] Targeted test, with its real timings: the whole failing file passes — `an autostarted resident daemon exits after its canonical root disappears` 3796 ms, `an autostarted daemon cannot revive a canonical root removed during cold start` 1935 ms, `root loss is still detected when the watcher is suppressed` 252 ms, `the watcher is suppressed on Windows and kept everywhere else` 0.2 ms; 4/4 in 7038 ms.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate, and it is the gate that caught the failure — the file is integration tier, which the local stop point does not run)
- Not run, and why: `npm run check:ci` was not run locally; CI is authoritative for the integration tier.

## Review Evidence

- Self-review: checked that this is not a retry papering over a real defect. The retriable set is bounded to transient removal codes, the retry count is bounded at 7, and a non-transient error such as `EACCES` still throws immediately. The daemon-exit assertion that carries the test's claim is unchanged, and the test still fails if the daemon does not exit.
- Reviewer subagent: not used; the diff is one import and five call sites, and the CI trace fully explains the failure.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Retrying a delete can in principle hide a writer that never stops. Here it cannot hide the thing under test, because the daemon-exit poll is a separate assertion with its own 8 s bound.
- The same raw `rmSync` shape remains in other daemon-hosting test files and can produce the same red on a loaded runner.

## References

- Task: `task_01KZJF8PRC8E1XM9R95P4BKEP1`
- Failing run: https://github.com/FairladyZ625/harness-anything/actions/runs/31309529417
- Helper introduced by: PR #1299

---

# 中文

## 概要

`main` 是红的。`3474ffa5`（PR #1299）的 post-merge 全量检查在 `integration-shard (1)` 失败：

```
✖ an autostarted resident daemon exits after its canonical root disappears (5668ms)
  Error: ENOTEMPTY, Directory not empty: /tmp/ha-daemon-root-lifetime-JdiXL9
      at packages/cli/test/daemon-autostart-root-lifetime.test.ts:37
```

**第 37 行不是 teardown。** 在 daemon 仍然驻留时删掉 canonical root**正是被测的动作** —— 这个删除与一个活着的写入者竞态，目录可能在 `readdir` 与 `rmdir` 之间被重新填上，于是在 Linux 上以 `ENOTEMPTY` 失败（Windows 上是 `EPERM`）。

PR #1299 为的就是这一类引入了 `removeTemporaryTestRoot`，其可重试集里**已经**列了 `ENOTEMPTY`。**这个文件从来没被切过去。** 于是同一个保证在部分调用点成立、在紧邻的调用点不成立 —— 这是**正确性靠巧合**，不是靠构造。

## 改动内容

- `packages/cli/test/daemon-autostart-root-lifetime.test.ts`：五处 `rmSync(rootDir, …)` 全部改用 `removeTemporaryTestRoot`，并删掉裸 `rmSync` 的 import，**让读者不必再去判断哪几处是安全的**。加了一句注释记明这个删除为什么会竞态，免得下一个人把它「简化」回去。

承重断言没动：root 消失后 daemon 必须退出。重试只是让删除得以完成，不削弱被证明的东西。

## 任务与范围

- Harness task：`task_01KZJF8PRC8E1XM9R95P4BKEP1`（修的是它自己交付的 post-merge 余波）
- 分支：`codex/temp-root-cleanup-sweep`
- 公开范围：一个测试文件
- 私有规划/证据已更新：是
- 不在范围内：更大范围的清扫。另有十来个承载 daemon 的测试文件仍用裸 `rmSync` 删临时根；把它们改过来是独立任务，而且**长效解法是加一道让裸写法在这类测试里不可能出现的检查，不是手工扫一遍**。

## 版本影响

- 版本：无变更；纯测试
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：`task_01KZJF8PRC8E1XM9R95P4BKEP1`
- 机检边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：为剩余的裸 `rmSync` daemon 测试、以及防止其重新长出的检查另立任务

## 验证

- 基线 `origin/main` SHA：`3474ffa5`
- 分支与 `origin/main` 的 merge-base：`3474ffa5`
- 最近一次 `git fetch origin`：2026-08-09，就在开分支之前
- 同步方式：直接从 `origin/main` 开分支
- 公开 diff 命令：`git diff 3474ffa5..d5fcf24d -- packages/`
- 私有证据 commit/路径：`harness/tasks/task_01KZJF8PRC8E1XM9R95P4BKEP1-47/progress.md`
- 评审证据路径：失败 run https://github.com/FairladyZ625/harness-anything/actions/runs/31309529417，job `integration-shard (1)`
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑
- [x] `git diff --check`
- [x] `npm run check:stop-point` —— `npm run check:local`，"Local check passed in 61.9s"，27 个 manifest 门绿
- [x] 定向测试及真实耗时：整个失败文件全绿 —— `an autostarted resident daemon exits after its canonical root disappears` 3796ms、`an autostarted daemon cannot revive a canonical root removed during cold start` 1935ms、`root loss is still detected when the watcher is suppressed` 252ms、`the watcher is suppressed on Windows and kept everywhere else` 0.2ms；4/4，合计 7038ms。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威完整门，也正是它抓住了这次失败 —— 该文件属 integration tier，本地停止点按设计不跑）
- 未跑及原因：本地未跑 `npm run check:ci`；integration tier 以 CI 为权威。

## 评审证据

- 自审：核对了这不是「用重试盖住真缺陷」。可重试集只含瞬态删除码，重试次数上限 7，`EACCES` 这类非瞬态错误仍然立即抛出。承载论断的那条 daemon-exit 断言没动，daemon 不退出时测试照样红。
- 评审子代理：未用；diff 是一个 import 加五个调用点，CI trace 已完全解释失败。
- 人工评审：待办
- 阻断性发现：无

## 残留风险

- 重试删除原则上可能掩盖一个永不停止的写入者。此处掩盖不了被测对象，因为 daemon 是否退出是另一条独立断言，有自己的 8 秒上限。
- 同样的裸 `rmSync` 形状仍存在于其它承载 daemon 的测试文件里，在负载高的 runner 上可能产生同样的红。

## 参考

- Task：`task_01KZJF8PRC8E1XM9R95P4BKEP1`
- 失败 run：https://github.com/FairladyZ625/harness-anything/actions/runs/31309529417
- helper 由 PR #1299 引入
