### PR TITLE
fix(doc-sync): read git status on NUL boundaries so non-ASCII paths reach the write road

### DIFF
--- a/packages/adapters/local/src/index.ts
+++ b/packages/adapters/local/src/index.ts
@@ -370,18 +370,28 @@ const gitMaxBuffer = resolveGitMaxBufferBytes();
 function readTaskTreeStatus(rootInput: HarnessLayoutInput, taskId: string): LocalTaskTreeStatusResult {
   const packagePath = taskPackagePath(rootInput, taskId);
   if (!gitTopLevel(packagePath)) return { taskId, dirty: false, entries: [] };
-  const output = execFileSync("git", ["-C", packagePath, "status", "--porcelain", "-uall", "--", "."], {
+  const output = execFileSync("git", ["-C", packagePath, "status", "--porcelain=v1", "-z", "-uall", "--", "."], {
     encoding: "utf8",
     maxBuffer: gitMaxBuffer,
     stdio: ["ignore", "pipe", "pipe"],
     windowsHide: true
   });
-  const entries = output
-    .split(/\r?\n/u)
-    .map((entry) => entry.trim())
-    .filter(Boolean)
+  const entries = porcelainStatusEntries(output)
     .filter((entry) => !statusEntryPath(entry).endsWith(".log"));
   return { taskId, dirty: entries.length > 0, entries };
+}
+
+function porcelainStatusEntries(output: string): ReadonlyArray<string> {
+  const records = output.split("\0");
+  const entries: string[] = [];
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index];
+    if (!record) continue;
+    entries.push(record);
+    const code = record.slice(0, 2);
+    if (code.includes("R") || code.includes("C")) index += 1;
+  }
+  return entries;
 }
 
 function gitTopLevel(inputPath: string): string | null {
@@ -398,10 +408,7 @@ function gitTopLevel(inputPath: string): string | null {
 }
 
 function statusEntryPath(entry: string): string {
-  const renamedSeparator = " -> ";
-  const pathText = entry.slice(3);
-  const renamedIndex = pathText.indexOf(renamedSeparator);
-  return renamedIndex >= 0 ? pathText.slice(renamedIndex + renamedSeparator.length) : pathText;
+  return entry.slice(3);
 }
 
 function archiveTask(

--- a/packages/adapters/local/test/task-writes.test.ts
+++ b/packages/adapters/local/test/task-writes.test.ts
@@ -1,5 +1,6 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -78,6 +79,32 @@ test("local task supersede preserves a structured provenance write rejection", (
 
     assert.equal(failure, rejection);
     assert.equal(enqueued.length, 0);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("local task tree status preserves non-ASCII paths while ignoring log files", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-local-tree-status-"));
+  const harnessRoot = path.join(rootDir, "harness");
+  const artifactsRoot = path.join(harnessRoot, "tasks", executionTaskId, "artifacts");
+  try {
+    writeTaskIndex(rootDir, "active");
+    initGitRepository(harnessRoot);
+    mkdirSync(artifactsRoot, { recursive: true });
+    writeFileSync(path.join(artifactsRoot, "ascii.log"), "log\n", "utf8");
+    writeFileSync(path.join(artifactsRoot, "中文日志.log"), "日志\n", "utf8");
+    writeFileSync(path.join(artifactsRoot, "report.md"), "report\n", "utf8");
+    writeFileSync(path.join(artifactsRoot, "实测报告.md"), "实测\n", "utf8");
+    const engine = makeLocalLifecycleEngine({ rootDir });
+
+    const status = Effect.runSync(engine.taskTreeStatus({ taskId: executionTaskId }));
+
+    assert.equal(status.dirty, true);
+    assert.deepEqual(status.entries, [
+      `?? tasks/${executionTaskId}/artifacts/report.md`,
+      `?? tasks/${executionTaskId}/artifacts/实测报告.md`
+    ]);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }
@@ -167,6 +194,14 @@ function writeTaskIndex(rootDir: string, status: "active" | "in_review"): void {
     "# Execution Task",
     ""
   ].join("\n"), "utf8");
+}
+
+function initGitRepository(rootDir: string): void {
+  execFileSync("git", ["-C", rootDir, "init"], { stdio: "ignore" });
+  execFileSync("git", ["-C", rootDir, "config", "user.name", "Harness Test"], { stdio: "ignore" });
+  execFileSync("git", ["-C", rootDir, "config", "user.email", "harness@example.test"], { stdio: "ignore" });
+  execFileSync("git", ["-C", rootDir, "add", "."], { stdio: "ignore" });
+  execFileSync("git", ["-C", rootDir, "commit", "-m", "seed"], { stdio: "ignore" });
 }
 
 function stableHash(value: unknown): string {

--- a/packages/cli/test/doc-sync-cli.test.ts
+++ b/packages/cli/test/doc-sync-cli.test.ts
@@ -224,6 +224,38 @@ test("CLI doc sync materializes an exact log artifact", async () => {
   });
 });
 
+test("CLI doc status and sync preserve a non-ASCII artifact path", async () => {
+  await withTempRoot(async (rootDir) => {
+    const harnessRoot = path.join(rootDir, "harness");
+    const taskId = "task_01KX3W4V1EDPHPTGWYYBQQ2J75";
+    const taskRoot = path.join(harnessRoot, "tasks", taskId);
+    const relativePath = `tasks/${taskId}/artifacts/实测报告.md`;
+    const targetPath = path.join(harnessRoot, relativePath);
+    const sessionBranch = "sessions/doc-sync-cli-test";
+    const body = "# 实测报告\n\n中文文件名写路证据。\n";
+    mkdirSync(taskRoot, { recursive: true });
+    seedDocSyncWriteRoadRegistry(rootDir);
+    writeFileSync(path.join(taskRoot, "INDEX.md"), taskIndex());
+    initHarnessGit(harnessRoot);
+
+    mkdirSync(path.dirname(targetPath), { recursive: true });
+    writeFileSync(targetPath, body, "utf8");
+
+    const status = runJson(rootDir, ["doc", "status"]);
+    assert.deepEqual(status.report.dirtyFiles.map((entry: Record<string, any>) => entry.path), [relativePath]);
+    assert.deepEqual(status.report.candidateBlobs.map((entry: Record<string, any>) => entry.path), [relativePath]);
+    assert.deepEqual(status.report.unresolvedTouches, []);
+
+    const submitted = runJson(rootDir, ["doc", "sync", "--submit", "--path", relativePath]);
+    assert.equal(submitted.ok, true, JSON.stringify(submitted));
+    assert.equal(submitted.report.appliedChanges[0].path, relativePath);
+    assert.equal(
+      execFileSync("git", ["-C", harnessRoot, "show", `${sessionBranch}:${relativePath}`], { encoding: "utf8" }),
+      body
+    );
+  });
+});
+
 test("task artifact add submits UTF-8 evidence through the existing doc-sync governance commit", async () => {
   await withTempRoot(async (rootDir) => {
     const harnessRoot = path.join(rootDir, "harness");

--- a/packages/daemon/src/service/doc-sync-git-status.ts
+++ b/packages/daemon/src/service/doc-sync-git-status.ts
@@ -1,5 +1,15 @@
-import type { DirtyEntry } from "@harness-anything/application/doc-sync";
 import { gitText } from "./doc-sync-applied-ledger.ts";
+
+/**
+ * The row shape this reader produces. Declaring it structurally keeps the check off the
+ * deep `application/doc-sync` subpath, which is under a sunset ratchet; the shape is
+ * validated where doc-sync-service assigns these rows to its registry contract. This
+ * mirrors what doc-sync-consumer-surface.ts and doc-sync-cas.ts already do.
+ */
+interface DirtyEntry {
+  readonly status: "added" | "modified" | "deleted" | "renamed";
+  readonly path: string;
+}
 
 export function readDocSyncDirtyEntries(authoredRoot: string): ReadonlyArray<DirtyEntry> {
   const output = gitText(authoredRoot, ["status", "--porcelain=v1", "-z", "--untracked-files=all", "--", "."]) ?? "";

--- a/packages/daemon/src/service/doc-sync-git-status.ts
+++ b/packages/daemon/src/service/doc-sync-git-status.ts
@@ -1,0 +1,24 @@
+import type { DirtyEntry } from "@harness-anything/application/doc-sync";
+import { gitText } from "./doc-sync-applied-ledger.ts";
+
+export function readDocSyncDirtyEntries(authoredRoot: string): ReadonlyArray<DirtyEntry> {
+  const output = gitText(authoredRoot, ["status", "--porcelain=v1", "-z", "--untracked-files=all", "--", "."]) ?? "";
+  const records = output.split("\0");
+  const entries: DirtyEntry[] = [];
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index];
+    if (!record) continue;
+    const code = record.slice(0, 2);
+    entries.push(parsePorcelainRecord(record));
+    if (code.includes("R") || code.includes("C")) index += 1;
+  }
+  return entries;
+}
+
+function parsePorcelainRecord(record: string): DirtyEntry {
+  const code = record.slice(0, 2);
+  const status = code === "??" || code.includes("A")
+    ? "added"
+    : code.includes("D") ? "deleted" : code.includes("R") ? "renamed" : "modified";
+  return { status, path: record.slice(3) };
+}

--- a/packages/daemon/src/service/doc-sync-service.ts
+++ b/packages/daemon/src/service/doc-sync-service.ts
@@ -34,6 +34,7 @@ import { DocSyncJournalFailure, docSyncWriteFailure } from "./doc-sync-journal-f
 import { gitText, resolveDocSyncAppliedLedgerSha } from "./doc-sync-applied-ledger.ts";
 import { isStandaloneCasObject } from "./doc-sync-cas.ts";
 import { consumerDocSyncRows, isConsumerGovernedTaskDocument } from "./doc-sync-consumer-surface.ts";
+import { readDocSyncDirtyEntries } from "./doc-sync-git-status.ts";
 import { resolveDocSyncChangePath } from "./doc-sync-writer-working-tree.ts";
 import { renderDocSyncSelectionHint } from "./doc-sync-selection-hint.ts";
 
@@ -55,7 +56,7 @@ export function buildDocSyncReport(rootInput: HarnessLayoutInput, hostServices: 
   const layout = resolveHarnessLayout(rootInput);
   const authoredRoot = path.relative(layout.rootDir, layout.authoredRoot).split(path.sep).join("/") || ".";
   const registry = loadRegistry(layout.rootDir);
-  const dirtyEntries = gitDirtyEntries(layout.authoredRoot)
+  const dirtyEntries = readDocSyncDirtyEntries(layout.authoredRoot)
     .filter((entry) => !isStandaloneCasObject(layout.authoredRoot, entry));
   // The dogfood registry is not installed in consumer repositories. Keep their scan
   // fail-closed by admitting only task prose whose installed preset/template resolves a
@@ -531,21 +532,6 @@ function loadRegistry(rootDir: string): { readonly present: boolean; readonly sh
 
 function registryPath(rootDir: string): string {
   return path.join(rootDir, "tools", "write-road-registry.json");
-}
-
-function gitDirtyEntries(authoredRoot: string): ReadonlyArray<DirtyEntry> {
-  const output = gitText(authoredRoot, ["status", "--porcelain", "--untracked-files=all", "--", "."]) ?? "";
-  return output.split(/\r?\n/u).filter(Boolean).map(parsePorcelainLine);
-}
-
-function parsePorcelainLine(line: string): DirtyEntry {
-  const code = line.slice(0, 2);
-  const rawPath = line.slice(3);
-  const renamedPath = rawPath.includes(" -> ") ? rawPath.split(" -> ").at(-1)! : rawPath;
-  const status = code === "??" || code.includes("A")
-    ? "added"
-    : code.includes("D") ? "deleted" : code.includes("R") ? "renamed" : "modified";
-  return { status, path: renamedPath };
 }
 
 function headBlobBody(authoredRoot: string, relativePath: string): string | null {


### PR DESCRIPTION
# English

## Summary

A file with a non-ASCII name can never be submitted through the doc-sync write road.

`core.quotePath` defaults to true, so `git status --porcelain` emits non-ASCII paths **quoted and octal-escaped**. Doc-sync consumed that line as the path, so the path it reported never matched anything on disk:

```
$ git status --porcelain
?? "tasks/…/artifacts/\345\256\236\346\265\213\346\212\245\345\221\212.md"

$ ha doc status --json
  unresolvedTouches[].path == the quoted, escaped string above
```

This repository's documents are largely written in Chinese, so a Chinese-named artifact is the normal case, not an edge case. The live instance is `tasks/task_01KZG0Y6ZB4DKZ5T2BNMMRPJXP-…/artifacts/实测报告.md`, which has been stuck in `ha doc status` unable to be submitted.

**The sharp part is that the codebase otherwise gets this right.** Every other call site that parses porcelain output already passes `-z`, and `packages/kernel/src/persistence/git/local-version-control-system.ts:33` passes `-c core.quotePath=false`. The guarantee held everywhere except the two doc-sync consumers — correctness by coincidence at adjacent call sites, not a systemic oversight.

## What Changed

- `packages/daemon/src/service/doc-sync-git-status.ts` (new): porcelain v1 with `-z`, parsing on NUL boundaries, including the two-record form that rename/copy entries take under `-z`.
- `packages/daemon/src/service/doc-sync-service.ts`: consumes the new module instead of splitting quoted lines.
- `packages/adapters/local/src/index.ts:370`: the local task-tree status read moves to NUL parsing for the same reason.

Every other porcelain consumer was audited and left alone, with the reason recorded: `git-diff-evidence.ts`, `projection-source-fence.ts`, `authority-evidence-tree.ts`, and `production-scanner.ts` already pass `-z`; `worktree.ts`, `snapshot.ts`, `write-build-provenance.ts`, and `daemon-deployment-identity.ts` only test whether the output is empty and never parse a path.

## Task And Scope

- Harness task: `task_01KZK2N4SE93GJ20R0AN1FBWB1`
- Branch: `codex/quotepath-writeroad`
- Public scope: doc-sync git-status reading in `packages/daemon`, the local adapter's task-tree status read, and their tests
- Private planning/evidence updated: yes
- Out of scope: a check that would make the raw, quoting-sensitive form impossible in new code. The audit shows the knowledge exists in the codebase but is not enforced, so the durable fix is enforcement, not another sweep.

## Version Impact

- Version: no version change; a behaviour fix inside existing packages with no published entrypoint added or removed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KZK2N4SE93GJ20R0AN1FBWB1`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: enforcement for quoting-sensitive porcelain reads

## Verification

- Base `origin/main` SHA: `18eee627`
- Branch merge-base with `origin/main`: `18eee627`
- Last `git fetch origin` time: 2026-08-09, immediately before this stop-point run
- Sync method: rebase
- Public diff command: `git diff 18eee627..20ad5f78 -- packages/`
- Private evidence commit/path: `harness/tasks/task_01KZK2N4SE93GJ20R0AN1FBWB1-ascii-porcelain-quotepath-artifact/artifacts/sol-run-quotepath.md`
- Reviewer evidence path: same report
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` — `npm run check:local`, "Local check passed in 139.7s", 27 manifest gates green, after rebase onto `18eee627`
- [x] **Positive control before the fix**: the new test ran red on the pre-fix tree — 1 test, 0 pass, 1 fail, with the actual value being the quoted octal-escaped path and the expected value `…/实测报告.md`. Without this the test would have no discriminating power.
- [x] Targeted tests with their counts: `doc-sync-cli.test.ts` integration 14/14; `packages/adapters/local/test/task-writes.test.ts` fast 7/7; doc-sync service fast 23/23; integration shard 6 261/261. The integration tier was run explicitly because the local stop point does not run it by design — that blind spot produced four separate reds in this repository today.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: `npm run check:ci` was not run locally; CI is authoritative for the gates outside the local stop point. The production ledger's existing Chinese-named artifact was deliberately **not** submitted as part of this work; the tests reproduce the same filename in a fixture instead.

## Review Evidence

- Self-review (CEO, semantic acceptance): re-ran the family audit independently rather than trusting the report. Confirmed case-insensitively that `local-version-control-system.ts:33` already used `core.quotePath=false`, and read each of the four remaining `--porcelain=v1|v2` call sites to confirm each already passes `-z`. This corrects the CEO's own earlier claim that no call site handled quoting: the correct statement is that all of them did except these two.
- Reviewer subagent: the implementation audited every porcelain consumer and classified each as path-parsing or dirty-only rather than repairing only the reported site.
- Human review: pending
- Blocking findings: none

## Residual Risk

- `-z` changes the record format for renames and copies. The new parser handles the two-record form; a future porcelain flag combination that changes framing again would need the same care.
- Nothing prevents the next new call site from using the quoting-sensitive form. That enforcement is the follow-up task, not this PR.
- Architecture-check advisory reports `snapshot-missing`, and the integration runner reports a test-weight drift warning. Both are pre-existing and report-only; no shard or gate weight was modified.

## References

- Task: `task_01KZK2N4SE93GJ20R0AN1FBWB1`
- Evidence: `artifacts/sol-run-quotepath.md`

---

# 中文

## 概要

**非 ASCII 文件名的文件永远无法经 doc-sync 写路提交。**

`core.quotePath` 默认为 true，于是 `git status --porcelain` 把非 ASCII 路径**加引号并做八进制转义**输出。doc-sync 把这一行原样当作路径，于是它报出来的路径永远匹配不上磁盘上的任何东西：

```
$ git status --porcelain
?? "tasks/…/artifacts/\345\256\236\346\265\213\346\212\245\345\221\212.md"

$ ha doc status --json
  unresolvedTouches[].path 就是上面那个带引号的转义串
```

本仓的文档大量是中文，**中文命名的 artifact 是常态而非边角**。现场实例是
`tasks/task_01KZG0Y6ZB4DKZ5T2BNMMRPJXP-…/artifacts/实测报告.md`，一直卡在 `ha doc status` 里提交不掉。

**扎人的地方在于：这个代码库别处全都做对了。** 所有其它解析 porcelain 输出的调用点都已经带 `-z`，
`packages/kernel/src/persistence/git/local-version-control-system.ts:33` 更是显式传了
`-c core.quotePath=false`。保证在每一处都成立，唯独 doc-sync 这两个消费者不成立 ——
这是**相邻调用点上正确性靠巧合**，不是系统性遗漏。

## 改动内容

- `packages/daemon/src/service/doc-sync-git-status.ts`（新增）：porcelain v1 加 `-z`，按 NUL 边界解析，包含 rename/copy 在 `-z` 下的双记录形式。
- `packages/daemon/src/service/doc-sync-service.ts`：改用新模块，不再按行切带引号的输出。
- `packages/adapters/local/src/index.ts:370`：本地 task-tree status 读取出于同样原因改为 NUL 解析。

其余 porcelain 消费者**逐个审计后保持不动，并记录了理由**：`git-diff-evidence.ts`、
`projection-source-fence.ts`、`authority-evidence-tree.ts`、`production-scanner.ts` 已带 `-z`；
`worktree.ts`、`snapshot.ts`、`write-build-provenance.ts`、`daemon-deployment-identity.ts`
只判断输出是否为空，从不解析路径。

## 任务与范围

- Harness task：`task_01KZK2N4SE93GJ20R0AN1FBWB1`
- 分支：`codex/quotepath-writeroad`
- 公开范围：`packages/daemon` 的 doc-sync git-status 读取、local adapter 的 task-tree status 读取，及其测试
- 私有规划/证据已更新：是
- 不在范围内：一道让「对引号敏感的裸写法」在新代码里不可能出现的检查。审计表明这个知识在代码库里已经存在、只是没有被强制，**所以长效解法是强制，不是再扫一遍**。

## 版本影响

- 版本：无变更；既有 package 内的行为修复，未增删已发布入口
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：`task_01KZK2N4SE93GJ20R0AN1FBWB1`
- 机检边界：本 PR 只断言声明存在；是否属实、是否充分由评审判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：为对引号敏感的 porcelain 读取加强制检查

## 验证

- 基线 `origin/main` SHA：`18eee627`
- 分支与 `origin/main` 的 merge-base：`18eee627`
- 最近一次 `git fetch origin`：2026-08-09，就在本次停止点之前
- 同步方式：rebase
- 公开 diff 命令：`git diff 18eee627..20ad5f78 -- packages/`
- 私有证据 commit/路径：`harness/tasks/task_01KZK2N4SE93GJ20R0AN1FBWB1-ascii-porcelain-quotepath-artifact/artifacts/sol-run-quotepath.md`
- 评审证据路径：同一份报告
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑
- [x] `git diff --check`
- [x] `npm run check:stop-point` —— `npm run check:local`，"Local check passed in 139.7s"，27 个 manifest 门绿，在 rebase 到 `18eee627` 之后
- [x] **修复前阳性对照**：新测试在修复前的树上是红的 —— 1 test、0 pass、1 fail，实际值为带引号八进制转义路径，期望值为 `…/实测报告.md`。没有这一条，这个测试就没有分辨力。
- [x] 定向测试及计数：`doc-sync-cli.test.ts` integration 14/14；`packages/adapters/local/test/task-writes.test.ts` fast 7/7；doc-sync service fast 23/23；integration shard 6 261/261。**integration tier 是显式跑到的**，因为本地停止点按设计不跑它 —— 这个盲区今天在本仓已经造成四次独立的红。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威完整门）
- 未跑及原因：本地未跑 `npm run check:ci`；本地停止点之外的门以 CI 为权威。生产账本里现存的那个中文 artifact **刻意没有**在本次工作中提交，测试改为在 fixture 里复现同名场景。

## 评审证据

- 自审（CEO 语义验收）：**没有采信报告，自己重跑了家族审计。** 不分大小写地确认
  `local-version-control-system.ts:33` 早已使用 `core.quotePath=false`，并逐个读了剩余四处
  `--porcelain=v1|v2` 调用点、确认它们都已带 `-z`。这同时更正了 CEO 自己此前的说法
  「没有任何调用点处理过引号」：正确的说法是**除了这两处，其余全都处理了**。
- 评审子代理：实现者审计了每一个 porcelain 消费者并逐个分类为「解析路径」或「只判脏」，
  而不是只修被报出来的那一处。
- 人工评审：待办
- 阻断性发现：无

## 残留风险

- `-z` 会改变 rename/copy 的记录格式。新解析器处理了双记录形式；将来若有别的 porcelain 参数组合再次改变分帧，需要同等谨慎。
- 没有任何机制阻止下一个新调用点再用对引号敏感的写法。那道强制是后续任务，不在本 PR。
- architecture-check advisory 报 `snapshot-missing`，integration runner 报 test-weight drift 警告。两者均为既有且仅报告性质；未修改任何 shard 或门的权重。

## 参考

- Task：`task_01KZK2N4SE93GJ20R0AN1FBWB1`
- 证据：`artifacts/sol-run-quotepath.md`
