### PR TITLE
fix(daemon): report the requested autostart budget instead of a resampled clock span

### DIFF
--- a/packages/daemon/src/client/daemon-autostart-flight.ts
+++ b/packages/daemon/src/client/daemon-autostart-flight.ts
@@ -39,6 +39,10 @@ export interface DaemonAutostartFlightPhase {
 export interface DaemonStartupFlight {
   startedAt: number;
   deadline: number;
+  // The caller-requested startup budget. Failure messages must report this
+  // value, not `deadline - startedAt`: those two clocks are sampled separately,
+  // so the recomputed span drifts (1200 -> 1199) under scheduling jitter.
+  timeoutMs: number;
   lastError: unknown;
   spawnedPid?: number;
   observedSocketOwnerPid?: number;
@@ -74,6 +78,7 @@ export function createDaemonAutostartFlightManager<Target extends { readonly soc
         daemonStartupFlights.delete(target.socketPath);
       } else {
         existing.deadline = Math.max(existing.deadline, deadline);
+        existing.timeoutMs = Math.max(existing.timeoutMs, autostartTimeoutMs);
         return waitForDaemonStartupFlight(target.socketPath, existing, deadline, autostartTimeoutMs);
       }
     }
@@ -85,6 +90,7 @@ export function createDaemonAutostartFlightManager<Target extends { readonly soc
       const flight: DaemonStartupFlight = {
         startedAt: Date.now(),
         deadline,
+        timeoutMs: autostartTimeoutMs,
         lastError: undefined,
         spawnedPid: livePid,
         promise: Promise.resolve()
@@ -104,6 +110,7 @@ export function createDaemonAutostartFlightManager<Target extends { readonly soc
     const flight: DaemonStartupFlight = {
       startedAt: Date.now(),
       deadline,
+      timeoutMs: autostartTimeoutMs,
       lastError: undefined,
       promise: Promise.resolve()
     };
@@ -166,7 +173,7 @@ export function createDaemonAutostartFlightManager<Target extends { readonly soc
       processExited: observedOwner ? false : processExited,
       cause: flight.lastError
     }, circuitOptions);
-    throw daemonStartupFlightFailure(flight, target.socketPath, flight.deadline - flight.startedAt);
+    throw daemonStartupFlightFailure(flight, target.socketPath, flight.timeoutMs);
   }
   async function joinLiveDaemonStartup(
     target: Target,
@@ -206,7 +213,7 @@ export function createDaemonAutostartFlightManager<Target extends { readonly soc
     reportDaemonAutostartOutcome(target.socketPath, {
       ok: false, spawnedPid: flight.spawnedPid, processExited, cause: flight.lastError
     }, circuitOptions);
-    throw daemonAutostartFailureError(flight.deadline - flight.startedAt, flight.lastError, flight.spawnedPid, flight.launchStderrPath);
+    throw daemonAutostartFailureError(flight.timeoutMs, flight.lastError, flight.spawnedPid, flight.launchStderrPath);
   }
   async function waitForDaemonStartupFlight(
     socketPath: string,


### PR DESCRIPTION
# English

## Summary

Fix an intermittent CI red on main (`fast-contract`, run 31328419128): the autostart timeout error recomputed the startup budget as `deadline - startedAt`, two separately sampled clocks, so scheduling jitter shrank the reported budget (1200ms → 1199ms), failing the pinned assertion `autostart bounds a never-responding ready probe by the total startup budget` and making `error.timeoutMs` diverge from the caller's request.

## What Changed

- `packages/daemon/src/client/daemon-autostart-flight.ts`: the startup flight now carries the caller-requested `timeoutMs`; both owner-side failure sites report it instead of a resampled clock span, matching the waiter-side path which already reported the original value. Deadline-extension by joiners maxes the stored budget alongside the deadline.

## Task And Scope

- Harness task: 发现即修 standing authorization (auto-dispatch-fixes-default); main-red follow-up of PR #1300's test surface
- Branch: `codex/autostart-budget-honest`
- Public scope: one daemon client file, message/field honesty only; no behavior change to probing or deadlines
- Private planning/evidence updated: not applicable
- Out of scope: autostart probe scheduling, circuit breaker

## Version Impact

- Version: no version change because this is an internal error-reporting fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: 895b2131f458ecc932a33099efbde184f1b7bd0e
- Branch merge-base with `origin/main`: 895b2131f458ecc932a33099efbde184f1b7bd0e
- Last `git fetch origin` time: 2026-08-10 (this session, immediately before push)
- Sync method: none needed (branched from current origin/main)
- Public diff command: `git diff origin/main...codex/autostart-budget-honest`
- Private evidence commit/path: not applicable
- Reviewer evidence path: not applicable
- GitHub Actions `rewrite-ci` run URL: pending (will be attached by CI on this PR)
- [x] `git diff --check`
- [x] `npm run check:stop-point` (via `npm run check:local`: 27 manifest gates green, 60.0s)
- [x] Targeted tests for the change surface, named with their counts: `packages/daemon/test/local-json-rpc-client.test.ts` full file — 17 pass / 0 fail
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: integration/nightly tiers not run locally by design of the local stop point; CI runs them on this PR.

## Review Evidence

- Self-review: root cause traced from the failing run's assertion fingerprint to the two throw sites that recompute the span; the fix aligns them with the waiter-side path that already reports the requested budget.
- Reviewer subagent: not used (single-file, single-concern fix)
- Human review: requested via PR
- Blocking findings: none

## Residual Risk

- The pinned test asserted the exact budget before this fix and passed intermittently; after this fix the reported budget is deterministic. If a future caller intentionally extends a flight's deadline beyond the maxed budget, the message reports the largest requested budget, which is the honest configured bound.

---

# 中文

## 摘要

修 main 上的间歇性 CI 红（`fast-contract`，run 31328419128）：autostart 超时错误用 `deadline - startedAt` 重算启动预算，这两个时钟是分别采样的，调度抖动会把上报预算从 1200ms 缩成 1199ms，导致钉子测试 `autostart bounds a never-responding ready probe by the total startup budget` 断言失败，且 `error.timeoutMs` 与调用方请求值漂移。

## 变更内容

- `packages/daemon/src/client/daemon-autostart-flight.ts`：startup flight 现在携带调用方请求的 `timeoutMs`；owner 侧两处失败抛错改为上报该值而非重采样的时钟差，与 waiter 侧既有路径（本就上报原值）对齐。joiner 延长 deadline 时同步取 max 存储预算。

## 任务与范围

- Harness 任务：发现即修常设授权；PR #1300 测试面的 main 红跟进
- 分支：`codex/autostart-budget-honest`
- 公开范围：单个 daemon client 文件，仅消息/字段诚实性；不改探测与 deadline 行为
- 私有规划/证据更新：不适用
- 范围外：autostart 探测调度、熔断器

## 版本影响

- 版本：无版本变更，内部错误上报修复
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 仅断言声明存在；声明是否真实充分由 reviewer 判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无

## 验证

- 基线 `origin/main` SHA：895b2131f458ecc932a33099efbde184f1b7bd0e
- 分支与 `origin/main` 的 merge-base：895b2131f458ecc932a33099efbde184f1b7bd0e
- 最近 `git fetch origin` 时间：2026-08-10（本会话，push 前）
- 同步方式：无需（自当前 origin/main 切出）
- 公开 diff 命令：`git diff origin/main...codex/autostart-budget-honest`
- 私有证据 commit/路径：不适用
- Reviewer 证据路径：不适用
- GitHub Actions `rewrite-ci` run URL：待 CI 附加
- [x] `git diff --check`
- [x] `npm run check:stop-point`（经 `npm run check:local`：27 个 manifest gate 全绿，60.0s）
- [x] 变更面定向测试及计数：`packages/daemon/test/local-json-rpc-client.test.ts` 整文件 — 17 过 / 0 挂
- [ ] GitHub Actions `rewrite-ci` 全绿（权威完整门）
- 未跑及原因：integration/nightly 层按本地停止点设计不在本地跑；由本 PR 的 CI 执行。

## 评审证据

- 自评：从失败 run 的断言指纹追到两处重算时钟差的抛错点；修法与 waiter 侧既有上报原值的路径对齐。
- Reviewer 子代理：未用（单文件单关注点修复）
- 人工评审：经 PR 请求
- 阻塞发现：无

## 残余风险

- 修复前钉子测试断言精确预算且间歇通过；修复后上报预算确定。若未来调用方有意把 flight deadline 延长超过取 max 的预算，消息上报的是最大请求预算，即诚实的配置上界。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
