### PR TITLE
fix(kernel): make stableStringify emit valid JSON for undefined values

### DIFF
--- a/packages/daemon/src/runtime/receipt-settlement-store.ts
+++ b/packages/daemon/src/runtime/receipt-settlement-store.ts
@@ -148,11 +148,20 @@ export class ReceiptSettlementStore {
     return readdirSync(this.directory)
       .filter((name) => name.startsWith(prefix) && name.endsWith(acceptedSuffix))
       .sort()
-      .map((name) => readRecord(
-        path.join(this.directory, name),
-        this.hooks,
-        "pending"
-      ) as ReceiptSettlementAcceptedRecord)
+      .flatMap((name) => {
+        // One unreadable acceptance must not halt the recovery sweep for
+        // every other receipt; report it and keep sweeping.
+        try {
+          return [readRecord(
+            path.join(this.directory, name),
+            this.hooks,
+            "pending"
+          ) as ReceiptSettlementAcceptedRecord];
+        } catch (error) {
+          this.onWarning(`RECEIPT_SETTLEMENT_PENDING_SKIPPED:${name}:${describe(error)}`);
+          return [];
+        }
+      })
       .filter((record) => !repoWriteOutcomeDurablePathExists(paths(this.directory, record.receiptId).visible));
   }
 
@@ -230,7 +239,15 @@ function readRecord(
 ): ReceiptSettlementSnapshot {
   const { descriptor, text } = repoWriteOutcomeReadPrivateText(file);
   try {
-    const parsed = JSON.parse(text) as Record<string, unknown>;
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(text) as Record<string, unknown>;
+    } catch {
+      // Surface unparseable sidecars as typed corruption so callers can skip
+      // or report them instead of leaking a raw SyntaxError across the
+      // daemon boundary.
+      throw new Error(`RECEIPT_SETTLEMENT_CORRUPT:${path.basename(file)}`);
+    }
     if (parsed.schema !== "receipt-settlement-record/v1"
       || parsed.state !== expectedState
       || typeof parsed.receiptId !== "string"

--- a/packages/daemon/test/receipt-settlement-store.test.ts
+++ b/packages/daemon/test/receipt-settlement-store.test.ts
@@ -1,6 +1,7 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
-import { chmodSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { chmodSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -178,6 +179,65 @@ test("corrupt failure evidence is skipped with a warning while valid settlement 
 
     assert.equal(current?.state, "failed");
     assert.match(warnings.join("\n"), /RECEIPT_SETTLEMENT_FAILURE_SKIPPED/u);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("an in-process receipt with undefined values persists as parseable JSON", durableSettlementStore, () => {
+  withStores(({ directory, first }) => {
+    // Direct-mode receipts never cross a JSON round-trip, so undefined-valued
+    // keys reach the sidecar writer verbatim. The serializer used to emit the
+    // literal text `undefined`, corrupting the record on disk.
+    const accepted = acceptedReceipt("receipt-undefined-values", "session-undefined", "a");
+    const poisoned = {
+      ...accepted,
+      details: { report: { module: undefined, preset: "standard-task" } }
+    } as unknown as CommandReceipt;
+    first.accept(poisoned);
+
+    for (const name of readdirSync(directory)) {
+      const text = readFileSync(path.join(directory, name), "utf8");
+      assert.doesNotThrow(() => JSON.parse(text), `sidecar ${name} must be valid JSON`);
+    }
+    assert.equal(first.lookup("receipt-undefined-values")?.state, "pending");
+  });
+});
+
+test("a corrupt accepted sidecar is skipped by the recovery sweep and reported as typed corruption", durableSettlementStore, () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "ha-receipt-settlement-"));
+  const warnings: string[] = [];
+  try {
+    const receipts = new ReceiptSettlementStore({
+      directory,
+      repoId: "repo-settlement",
+      workspaceId: "workspace-settlement",
+      generation: 7,
+      onWarning: (warning) => warnings.push(warning)
+    });
+    const healthy = acceptedReceipt("receipt-healthy", "session-healthy", "a");
+    receipts.accept(healthy);
+    const corruptName = `receipt-settlement-v1.${"0".repeat(64)}.accepted.json`;
+    writeFileSync(path.join(directory, corruptName), "{\"module\":undefined,\n", { mode: 0o600 });
+    chmodSync(path.join(directory, corruptName), 0o600);
+
+    // One unreadable acceptance must not halt settlement for every receipt.
+    assert.deepEqual(
+      receipts.listUnsettled().map((record) => record.receiptId),
+      ["receipt-healthy"]
+    );
+    assert.match(warnings.join("\n"), /RECEIPT_SETTLEMENT_PENDING_SKIPPED/u);
+
+    // A direct lookup of the broken record reports typed corruption, not a
+    // raw JSON SyntaxError leaked through the daemon boundary.
+    const key = createHash("sha256").update("receipt-healthy", "utf8").digest("hex");
+    const target = path.join(directory, `receipt-settlement-v1.${key}.visible.json`);
+    writeFileSync(target, "{\"module\":undefined,\n", { mode: 0o600 });
+    chmodSync(target, 0o600);
+    assert.throws(
+      () => receipts.lookup("receipt-healthy"),
+      /RECEIPT_SETTLEMENT_CORRUPT/u
+    );
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }

--- a/packages/kernel/src/integrity/stable-hash.ts
+++ b/packages/kernel/src/integrity/stable-hash.ts
@@ -13,12 +13,22 @@ export function stablePayloadHash(value: unknown): string {
 }
 
 export function stableStringify(value: unknown): string {
+  // Mirror JSON.stringify semantics for non-JSON values: undefined-valued
+  // object keys are omitted and undefined array items become null. For
+  // scalars JSON.stringify already returns undefined for undefined, function,
+  // and symbol; interpolating that result verbatim wrote the literal text
+  // `undefined` into persisted records, producing unparseable JSON.
   if (value === null || typeof value !== "object") return JSON.stringify(value);
-  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item) ?? "null").join(",")}]`;
+  }
 
   const record = value as Record<string, unknown>;
   return `{${Object.keys(record)
     .sort()
-    .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+    .flatMap((key) => {
+      const text = stableStringify(record[key]);
+      return text === undefined ? [] : [`${JSON.stringify(key)}:${text}`];
+    })
     .join(",")}}`;
 }

--- a/packages/kernel/test/integrity/stable-hash.test.ts
+++ b/packages/kernel/test/integrity/stable-hash.test.ts
@@ -10,6 +10,15 @@ test("stable stringify sorts object keys recursively", () => {
   );
 });
 
+test("stable stringify emits valid JSON when values are undefined", () => {
+  // JSON.stringify semantics: undefined-valued keys are omitted, undefined
+  // array items become null. The naive recursion interpolated the literal
+  // text `undefined`, which produced unparseable persisted records.
+  const text = stableStringify({ module: undefined, preset: "standard-task", list: [1, undefined, 2] });
+  assert.equal(text, "{\"list\":[1,null,2],\"preset\":\"standard-task\"}");
+  assert.deepEqual(JSON.parse(text), { list: [1, null, 2], preset: "standard-task" });
+});
+
 test("stable payload hash ignores object insertion order", () => {
   assert.equal(
     stablePayloadHash({ nested: { b: "two", a: "one" }, list: [3, 2, 1] }),


### PR DESCRIPTION
# English

## Summary

Production canary of PR #1310 exposed a P1 in the settlement sidecar: `stableStringify` interpolated `JSON.stringify(undefined)` verbatim, writing the literal text `undefined` into serialized output (`"module":undefined`). Direct-mode command receipts never cross a JSON round-trip, so an in-process `task create` report object with an undefined-valued key corrupted its settlement sidecar on disk. The corrupt acceptance then (a) broke `ha receipt status` — a raw `SyntaxError` leaked through the daemon boundary as `daemon_unavailable` — and (b) would break the entire recovery sweep: `listUnsettled` reads every acceptance with no per-file guard, so one unreadable file throws for all receipts.

## What Changed

- `packages/kernel/src/integrity/stable-hash.ts`: `stableStringify` now mirrors `JSON.stringify` semantics — undefined-valued object keys are omitted, undefined array items become `null` — so output always parses. Canonical text of previously valid records is unchanged (parsed-from-JSON inputs cannot contain undefined).
- `packages/daemon/src/runtime/receipt-settlement-store.ts`: `readRecord` wraps JSON parsing into a typed `RECEIPT_SETTLEMENT_CORRUPT:<file>` error; `listUnsettled` skips an unreadable acceptance with a `RECEIPT_SETTLEMENT_PENDING_SKIPPED` warning and keeps sweeping.
- Red-first pins in `packages/kernel/test/integrity/stable-hash.test.ts` and `packages/daemon/test/receipt-settlement-store.test.ts` (no new test files; existing registered files extended).

## Task And Scope

- Harness task: 发现即修 standing authorization; production-canary follow-up of PR #1310 (receipt tiering)
- Branch: `codex/stable-stringify-undefined`
- Public scope: kernel serializer + settlement store read-path hardening + tests
- Private planning/evidence updated: not applicable
- Out of scope: upstream producers that place undefined-valued keys in reports (harmless post-fix); remediation/deletion of the two already-corrupted sidecar files in the operator's user root (they now surface as typed corruption)

## Version Impact

- Version: no version change because this is an internal correctness fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: settlement history/audit query API is already filed (F-09 follow-up task task_01KZKWK7WQYCPDSJ9Q6A5R6NGA)

## Verification

- Base `origin/main` SHA: 895b2131f458ecc932a33099efbde184f1b7bd0e
- Branch merge-base with `origin/main`: 895b2131f458ecc932a33099efbde184f1b7bd0e
- Last `git fetch origin` time: 2026-08-10 (this session)
- Sync method: none needed (branched from current origin/main)
- Public diff command: `git diff origin/main...codex/stable-stringify-undefined`
- Private evidence commit/path: corrupted sidecar reproduced at `~/.harness/authority/harness-anything-production/receipt-settlements/` (operator machine)
- Reviewer evidence path: not applicable
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` (via `npm run check:local`: 27 manifest gates green)
- [x] Targeted tests for the change surface, named with their counts: `packages/kernel/test/integrity/stable-hash.test.ts` 4 pass; `packages/daemon/test/receipt-settlement-store.test.ts` 8 pass (2 new pins verified red-first against the unfixed code)
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: integration/nightly tiers run in CI on this PR, not locally, per local stop-point design.

## Review Evidence

- Self-review: hash-drift audit over all 213 `stableStringify`/`stablePayloadHash` call sites — output changes only for undefined-containing payloads, which previously produced invalid JSON (the defect); persisted-hash consumers all hash JSON-parsed inputs which cannot contain undefined, and `readRecord`'s canonical-text check is unchanged for valid files.
- Reviewer subagent: not used (root cause reproduced deterministically in production, fix pinned red-first)
- Human review: requested via PR
- Blocking findings: none

## Residual Risk

- Two sidecar files written before this fix remain unparseable on the operator machine; after this fix they surface as typed `RECEIPT_SETTLEMENT_CORRUPT` on direct lookup and are skipped by the sweep with a warning. The underlying write settled canonically, so no ledger data is at risk.
- Any externally persisted hash that was computed over an undefined-containing payload before this fix would not match a recomputation; audit found no consumer that persists such hashes across the boundary.

---

# 中文

## 摘要

PR #1310 的生产金丝雀暴露 settlement sidecar 的 P1：`stableStringify` 把 `JSON.stringify(undefined)` 的返回值直接插进模板，序列化输出出现字面量 `undefined`（`"module":undefined`）。direct 模式的命令回执不经过 JSON 往返，`task create` 报告对象里一个值为 undefined 的键就把落定 sidecar 写坏。损坏的受理文件进而 (a) 打断 `ha receipt status`——裸 `SyntaxError` 穿过 daemon 边界伪装成 `daemon_unavailable`；(b) 会打断整个恢复扫描：`listUnsettled` 逐文件读取无防护，一个坏文件让所有回执的扫描一起抛错。

## 变更内容

- `packages/kernel/src/integrity/stable-hash.ts`：`stableStringify` 对齐 `JSON.stringify` 语义——对象中值为 undefined 的键省略、数组中 undefined 项变 `null`，输出恒可解析。既有合法记录的 canonical 文本不变（JSON.parse 来的输入不可能含 undefined）。
- `packages/daemon/src/runtime/receipt-settlement-store.ts`：`readRecord` 把 JSON 解析失败包成有类型的 `RECEIPT_SETTLEMENT_CORRUPT:<file>`；`listUnsettled` 对不可读受理文件发 `RECEIPT_SETTLEMENT_PENDING_SKIPPED` 告警并继续扫描。
- 红先行钉子测试写在 `packages/kernel/test/integrity/stable-hash.test.ts` 与 `packages/daemon/test/receipt-settlement-store.test.ts`（扩展既有已登记文件，无新增测试文件）。

## 任务与范围

- Harness 任务：发现即修常设授权；PR #1310（回执分层）生产金丝雀跟进
- 分支：`codex/stable-stringify-undefined`
- 公开范围：kernel 序列化器 + settlement store 读路径加固 + 测试
- 私有规划/证据更新：不适用
- 范围外：在报告里放 undefined 键的上游生产方（修复后无害）；操作者 user root 里两个已损坏 sidecar 的清理（现以有类型损坏呈现）

## 版本影响

- 版本：无版本变更，内部正确性修复
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：本 PR 仅断言声明存在；声明是否真实充分由 reviewer 判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：settlement 历史/审计查询 API 已立案（F-09 后续任务 task_01KZKWK7WQYCPDSJ9Q6A5R6NGA）

## 验证

- 基线 `origin/main` SHA：895b2131f458ecc932a33099efbde184f1b7bd0e
- 分支与 `origin/main` 的 merge-base：895b2131f458ecc932a33099efbde184f1b7bd0e
- 最近 `git fetch origin` 时间：2026-08-10（本会话）
- 同步方式：无需（自当前 origin/main 切出）
- 公开 diff 命令：`git diff origin/main...codex/stable-stringify-undefined`
- 私有证据 commit/路径：损坏 sidecar 在操作者机器 `~/.harness/authority/harness-anything-production/receipt-settlements/` 复现
- Reviewer 证据路径：不适用
- GitHub Actions `rewrite-ci` run URL：待本 PR CI
- [x] `git diff --check`
- [x] `npm run check:stop-point`（经 `npm run check:local`：27 个 manifest gate 全绿）
- [x] 变更面定向测试及计数：`packages/kernel/test/integrity/stable-hash.test.ts` 4 过；`packages/daemon/test/receipt-settlement-store.test.ts` 8 过（2 条新钉子先红后绿）
- [ ] GitHub Actions `rewrite-ci` 全绿（权威完整门）
- 未跑及原因：integration/nightly 层按本地停止点设计由本 PR 的 CI 执行。

## 评审证据

- 自评：对全部 213 个 `stableStringify`/`stablePayloadHash` 调用点做哈希漂移审计——输出只对含 undefined 的载荷变化，而这类载荷旧行为即本缺陷（非法 JSON）；持久化哈希的消费方输入全部来自 JSON.parse（不可能含 undefined），`readRecord` 的 canonical 文本校验对合法文件不变。
- Reviewer 子代理：未用（生产可确定性复现，修复红先行钉住）
- 人工评审：经 PR 请求
- 阻塞发现：无

## 残余风险

- 修复前写坏的两个 sidecar 文件仍不可解析；修复后直接查询呈现有类型 `RECEIPT_SETTLEMENT_CORRUPT`，扫描告警跳过。底层写入已 canonical 落定，账本数据无风险。
- 修复前对含 undefined 载荷算出的外部持久化哈希与重算不匹配；审计未发现跨边界持久化此类哈希的消费方。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
