### PR TITLE
feat(task): auto-materialize completion documents and prove doc-sync canonical settlement

### DIFF
--- a/docs-release/operations-server-daemon.md
+++ b/docs-release/operations-server-daemon.md
@@ -184,6 +184,24 @@ registered doc-sync surface. Keep using its governed repository workflow until
 the write-road registry explicitly classifies those paths; `doc sync` fails
 closed instead of treating an unknown Markdown file as prose.
 
+### Automatic materialization during task completion
+
+When `ha task complete` detects unpublished registered task prose or files under
+the task's `artifacts/` directory, the daemon submits exactly those dirty paths
+through the existing doc-sync/artifact publication road, waits for canonical
+settlement, and then reruns the prepublish check. This automation only performs
+the mechanical publication step; closeout truthfulness, execution review,
+code-doc reconciliation, and consent checks still run in their original order.
+Tracked artifacts are supported, so editing a previously published artifact
+does not require manually removing it from the Git index first.
+
+Dry runs remain read-only and report the original prepublish finding. If
+automatic materialization fails, completion fails too. Its receipt identifies
+each file, the rejection or settlement reason, and an executable recovery step.
+Start with `ha doc status --json`; after repairing the named file, use
+`ha doc sync --submit` and retry task completion. For settlement failures, run
+the receipt-status command printed in the failure receipt.
+
 ## Remote SSH Relay
 
 Remote mode is a client of a persistent remote daemon. Declare the repository

--- a/docs-release/operations-server-daemon.zh-CN.md
+++ b/docs-release/operations-server-daemon.zh-CN.md
@@ -136,6 +136,19 @@ raw Git commit。
 write-road registry 明确分类这些路径前，继续使用其既有治理仓库流程。`doc sync` 会对未知
 Markdown fail closed，不会因为扩展名像 prose 就擅自放行。
 
+### task complete 自动物化
+
+当 `ha task complete` 发现尚未发布的已登记 task prose，或 task 自身 `artifacts/` 目录下的
+文件时，daemon 会把恰好这些 dirty path 交给既有 doc-sync/artifact 发布写路，等待 canonical
+settlement，再重跑 prepublish 检查。自动化只代办机械发布；closeout 写实、execution review、
+code-doc reconcile 与 consent 门仍按原顺序执行。已发布并被 Git 跟踪的 artifact 也能直接
+更新，不再需要先手工从 Git index 移除。
+
+dry-run 仍然只读，并返回原始 prepublish 发现。若自动物化失败，complete 也会失败；回执会
+逐个给出文件、拒收或 settlement 原因、以及可直接执行的修复步骤。先运行
+`ha doc status --json`；修复指定文件后，运行 `ha doc sync --submit` 并重试 task complete。
+若是 settlement 故障，则运行失败回执中打印的 receipt-status 命令。
+
 ## Remote SSH Relay
 
 Remote 模式连接持久远程 daemon。先在 repo config 声明 `settings.identity.mode: remote`，

--- a/packages/application/src/task-lifecycle-orchestrator.ts
+++ b/packages/application/src/task-lifecycle-orchestrator.ts
@@ -67,6 +67,7 @@ export interface TaskLifecycleOrchestratorOptions {
 export interface TaskLifecycleError {
   readonly code: string;
   readonly hint: string;
+  readonly context?: Readonly<Record<string, unknown>>;
 }
 
 export interface TaskLifecycleFailure {
@@ -281,7 +282,19 @@ export function readTaskLifecyclePolicy(artifactStore: Pick<ArtifactStore, "read
 }
 
 function writeFailure(taskId: string, error: EngineError | WriteError, fallbackHint: string): TaskLifecycleFailure {
-  return taskFailure(taskId, writeFailureCode(error), `${fallbackHint} ${writeFailureCauseHint(error)}`);
+  const failure = taskFailure(taskId, writeFailureCode(error), `${fallbackHint} ${writeFailureCauseHint(error)}`);
+  return error._tag === "WriteRejected"
+    && error.code === "task_complete_prepublish_not_materialized"
+    && error.context
+    ? {
+        ...failure,
+        error: {
+          ...failure.error,
+          code: error.code,
+          context: error.context
+        }
+      }
+    : failure;
 }
 
 // Canonical kernel-tag -> CLI error-code mapping. Kept exhaustive by the mapped

--- a/packages/application/test/task-lifecycle-write-failure.test.ts
+++ b/packages/application/test/task-lifecycle-write-failure.test.ts
@@ -233,6 +233,38 @@ test("setTaskStatus accepts active when a scaffold section contains substantive 
   if (result.ok) assert.equal(result.status, "active");
 });
 
+test("task lifecycle preserves typed task-complete prepublish rejection details", async () => {
+  const details = {
+    schema: "task-complete-prepublish-failure/v1",
+    code: "task_complete_prepublish_not_materialized",
+    files: [{ path: "work-items/task-1/closeout.md", reason: "content differs from expected" }]
+  } as const;
+  const writer: TaskLifecycleWriter = {
+    ...successfulWriter(),
+    setStatus: () => Effect.fail({
+      _tag: "WriteRejected" as const,
+      code: "task_complete_prepublish_not_materialized",
+      reason: "AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED",
+      retryable: false,
+      context: details
+    })
+  };
+  const orchestrator = makeTaskLifecycleOrchestrator({
+    rootDir: "/unused",
+    taskWriter: writer,
+    artifactStore: inMemoryTaskPackageStore("task-1", {
+      "task_plan.md": "# Plan\n\n## Goal\n\nPublish the completion package.\n"
+    })
+  });
+
+  const result = await runEffect(orchestrator.setTaskStatus({ taskId: "task-1", status: "active" }));
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.error.code, "task_complete_prepublish_not_materialized");
+  assert.deepEqual(result.error.context, details);
+});
+
 test("reviewTask accepts zero Facts through ArtifactStore under dec_mrg3z1we/CH4", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-task-artifact-store-"));
   try {

--- a/packages/cli/src/composition/receipt-settlement-runtime.ts
+++ b/packages/cli/src/composition/receipt-settlement-runtime.ts
@@ -86,12 +86,44 @@ export async function recoverPendingSettlementMaterialization(input: {
   readonly authoredRoot: string;
   readonly deadlineAt: number;
   readonly recoverCommittedReceipt: (opId: string) => Promise<AuthorityCommittedReceipt>;
+  readonly recoverCanonicalPublication?: (input: {
+    readonly outerOpId: string;
+    readonly canonicalCommitSha: string;
+  }) => Promise<"live-owner" | "recovered" | "terminal" | "blocked">;
 }): Promise<void> {
   for (const record of input.settlements.listUnsettled()) {
     if (Date.now() >= input.deadlineAt) return;
     const pending = record.receipt.settlement;
     if (!pending || pending.canonicalVisibility !== "pending") continue;
-    if (input.outcomes.lookup(record.receiptId).state === "terminal") continue;
+    const durable = input.outcomes.lookup(record.receiptId);
+    if (durable.state === "terminal") continue;
+    const observedSettlement = input.settlements.lookup(record.receiptId);
+    if (observedSettlement?.state === "failed"
+      && observedSettlement.receipt.settlement?.canonicalVisibility === "failed"
+      && observedSettlement.receipt.settlement.failure.retryable === false) {
+      continue;
+    }
+    if (durable.state === "proceeding"
+      && durable.outcome.canonicalCommand.commandName === "doc-sync-submit") {
+      try {
+        await nextEventLoopTurn();
+        await input.runtime.enqueueMaterializerBatch({ sessionId: pending.sessionId });
+        const canonicalCommitSha = canonicalCommitContaining(
+          input.authoredRoot,
+          pending.acceptedCommitSha
+        );
+        if (!input.recoverCanonicalPublication) {
+          throw new Error("DOC_SYNC_CANONICAL_PUBLICATION_RECOVERY_UNAVAILABLE");
+        }
+        await input.recoverCanonicalPublication({
+          outerOpId: record.receiptId,
+          canonicalCommitSha
+        });
+      } catch (error) {
+        failSettlement(input.settlements, record.receipt, pending, error);
+      }
+      continue;
+    }
     if (record.receiptId.startsWith("doc-sync:")) {
       await settleAcceptedSession({
         settlements: input.settlements,
@@ -133,7 +165,7 @@ export function reconcileTerminalSettlements(
     const durable = outcomes.lookup(record.receiptId);
     if (durable.state !== "terminal") continue;
     const evidence = durable.outcome.terminalProof.evidence;
-    if (evidence.tag !== "COMMITTED") {
+    if (evidence.tag !== "COMMITTED" && evidence.tag !== "CANONICAL_PUBLICATION") {
       const failed = withCommandReceiptSettlement(
         record.receipt,
         failedCommandReceiptSettlement(pending, {

--- a/packages/cli/src/composition/repo-write-child-doc-sync-executor.ts
+++ b/packages/cli/src/composition/repo-write-child-doc-sync-executor.ts
@@ -1,0 +1,140 @@
+import { setImmediate as nextEventLoopTurn } from "node:timers/promises";
+import { Effect } from "effect";
+import type {
+  DocSyncSubmitRequestV1,
+  DocSyncSubmitResultV1
+} from "@harness-anything/application";
+import {
+  failureReceipt,
+  makeDaemonQueuedWriteCoordinator,
+  makeDocSyncService,
+  materializeDocSyncWriterWorkingTree,
+  type HarnessDaemonRuntime,
+  type RepoWriteCommandContext,
+  type RepoWriteDocSyncExecution
+} from "@harness-anything/daemon";
+import {
+  isIndeterminateFlushReport,
+  resolveHarnessLayout,
+  type FlushReport,
+  type WriteCoordinator
+} from "@harness-anything/kernel";
+import { daemonActorAttribution } from "./actor-attribution.ts";
+import { cliDaemonServiceHostServices } from "./daemon-service-host-services.ts";
+import { buildDocSyncCommandReceipt } from "./doc-sync-command-receipt.ts";
+import { canonicalCommitContaining } from "./receipt-settlement-runtime.ts";
+
+export function createRepoWriteChildDocSyncExecutor(input: {
+  readonly canonicalRoot: string;
+  readonly layoutOverrides?: { readonly authoredRoot: string };
+  readonly runtime: HarnessDaemonRuntime;
+}) {
+  return async ({ command, decoded }: {
+    readonly command: { readonly payload: { readonly command?: unknown } };
+    readonly decoded: RepoWriteCommandContext;
+  }): Promise<RepoWriteDocSyncExecution> => {
+    const wireCommand = command.payload.command as {
+      readonly request?: DocSyncSubmitRequestV1;
+    };
+    if (!wireCommand.request) {
+      return { receipt: failureReceipt(
+        "repo.doc.sync.submit",
+        "doc_sync_invalid_payload",
+        "The writer child received no doc-sync request."
+      ) };
+    }
+    const materialized = materializeDocSyncWriterWorkingTree(
+      {
+        rootDir: input.canonicalRoot,
+        ...(input.layoutOverrides ? { layoutOverrides: input.layoutOverrides } : {})
+      },
+      wireCommand.request
+    );
+    if (!materialized.ok) {
+      const result: DocSyncSubmitResultV1 = {
+        ok: false,
+        _tag: "WriteRejected",
+        schema: "daemon.doc-sync-submit-result/v1",
+        status: "rejected",
+        intentId: wireCommand.request.payload.intentId,
+        code: "doc_sync_invalid_payload",
+        reason: `The writer child rejected a working-tree reference: ${materialized.reason}`,
+        retryable: false
+      };
+      return { receipt: failureReceipt(
+        "repo.doc.sync.submit",
+        result.code,
+        result.reason,
+        { data: result as unknown as import("@harness-anything/daemon").JsonObject }
+      ) };
+    }
+    const attribution = daemonActorAttribution(decoded.actor, decoded.executor);
+    const queued = makeDaemonQueuedWriteCoordinator(
+      input.runtime,
+      `doc-sync-submit:${wireCommand.request.payload.intentId}`,
+      {
+        attribution: attribution.writeAttribution,
+        commitAuthor: attribution.commitAuthor,
+        ...(wireCommand.request.session?.sessionId
+          ? { sessionId: wireCommand.request.session.sessionId }
+          : {})
+      }
+    );
+    let durableFlush: FlushReport | undefined;
+    const coordinator: WriteCoordinator = {
+      enqueue: queued.enqueue,
+      flush: (reason) => Effect.tap(queued.flush(reason), (flush) => Effect.sync(() => {
+        durableFlush = flush;
+      })),
+      recover: queued.recover
+    };
+    const result = await makeDocSyncService({
+      rootDir: input.canonicalRoot,
+      ...(input.layoutOverrides ? { layoutOverrides: input.layoutOverrides } : {}),
+      hostServices: cliDaemonServiceHostServices.docSync,
+      coordinator
+    }).submit(materialized.request);
+    if (!result.ok) {
+      return { receipt: failureReceipt("repo.doc.sync.submit", result.code, result.reason, {
+        data: result as unknown as import("@harness-anything/daemon").JsonObject
+      }) };
+    }
+    const receipt = buildDocSyncCommandReceipt({
+      result,
+      sessionId: decoded.currentSession.sessionId,
+      acceptedAt: new Date().toISOString(),
+      includeSettlement: false
+    });
+    if (result.appliedChanges.length === 0) {
+      return {
+        receipt,
+        terminalCommitSha: result.appliedLedgerSha,
+        terminalPreviousCommitSha: result.baseLedgerSha
+      };
+    }
+    if (!durableFlush || isIndeterminateFlushReport(durableFlush)
+      || !durableFlush.committed || !durableFlush.watermark) {
+      throw new Error("DOC_SYNC_DURABLE_FLUSH_PROOF_MISSING");
+    }
+    const authoredRoot = resolveHarnessLayout({
+      rootDir: input.canonicalRoot,
+      ...(input.layoutOverrides ? { layoutOverrides: input.layoutOverrides } : {})
+    }).authoredRoot;
+    return {
+      receipt,
+      durable: {
+        sessionId: decoded.currentSession.sessionId,
+        acceptedCommitSha: result.appliedLedgerSha,
+        previousCommitSha: result.baseLedgerSha,
+        flush: { ...durableFlush, committed: true, watermark: durableFlush.watermark },
+        settle: async () => {
+          await nextEventLoopTurn();
+          await input.runtime.enqueueMaterializerBatch({
+            sessionId: decoded.currentSession.sessionId
+          });
+          return canonicalCommitContaining(authoredRoot, result.appliedLedgerSha);
+        }
+      }
+    };
+  };
+}

--- a/packages/cli/src/composition/repo-write-child-entrypoint.ts
+++ b/packages/cli/src/composition/repo-write-child-entrypoint.ts
@@ -1,7 +1,5 @@
 import { realpathSync } from "node:fs";
 import path from "node:path";
-import { setImmediate as nextEventLoopTurn } from "node:timers/promises";
-import { Effect } from "effect";
 import {
   createDaemonGenerationWitness,
   calculateDaemonArtifactIdentity,
@@ -15,34 +13,20 @@ import {
   ReceiptSettlementStore,
   RepoWriteAuthorityRecoveryGate,
   RepoWriteChildIpcTransport,
-  failureReceipt,
-  makeDaemonQueuedWriteCoordinator,
-  makeDocSyncService,
-  materializeDocSyncWriterWorkingTree,
   type HarnessDaemonRuntime
 } from "@harness-anything/daemon";
-import type {
-  DocSyncSubmitRequestV1,
-  DocSyncSubmitResultV1
-} from "@harness-anything/application";
 import {
-  isIndeterminateFlushReport,
-  resolveHarnessLayout,
-  type FlushReport,
-  type WriteCoordinator
+  resolveHarnessLayout
 } from "@harness-anything/kernel";
 import { defaultCliAdapterProvider } from "./adapter-registry.ts";
 import { cliDaemonCommandHostServices } from "./daemon-command-host-services.ts";
-import { cliDaemonServiceHostServices } from "./daemon-service-host-services.ts";
-import { daemonActorAttribution } from "./actor-attribution.ts";
 import { makeIncrementalConflictMarkerPreflight } from "./incremental-conflict-marker-preflight.ts";
 import {
   reconcileTerminalSettlements,
-  canonicalCommitContaining,
   createReceiptSettlementRecoveryLoop,
   recoverPendingSettlementMaterialization,
 } from "./receipt-settlement-runtime.ts";
-import { buildDocSyncCommandReceipt } from "./doc-sync-command-receipt.ts";
+import { createRepoWriteChildDocSyncExecutor } from "./repo-write-child-doc-sync-executor.ts";
 import {
   createCliProductionAuthorityLifecycle
 } from "./production-authority-lifecycle.ts";
@@ -264,6 +248,12 @@ export async function runRepoWriteChildEntrypoint(
     rootDir: config.canonicalRoot,
     ...(layoutOverrides ? { layoutOverrides } : {})
   }).authoredRoot;
+  const canonicalPublicationRecovery: {
+    current?: (input: {
+      readonly outerOpId: string;
+      readonly canonicalCommitSha: string;
+    }) => Promise<"live-owner" | "recovered" | "terminal" | "blocked">;
+  } = {};
   const recoverSettlements = async (budgetMs = 5_000) => {
     await recoverPendingSettlementMaterialization({
       settlements,
@@ -271,7 +261,10 @@ export async function runRepoWriteChildEntrypoint(
       runtime,
       authoredRoot,
       deadlineAt: Date.now() + budgetMs,
-      recoverCommittedReceipt: recoverAuthorityCommittedReceipt
+      recoverCommittedReceipt: recoverAuthorityCommittedReceipt,
+      recoverCanonicalPublication: (input) => canonicalPublicationRecovery.current
+        ? canonicalPublicationRecovery.current(input)
+        : Promise.resolve("blocked")
     });
     reconcileTerminalSettlements(settlements, outcomes);
   };
@@ -355,104 +348,15 @@ export async function runRepoWriteChildEntrypoint(
     recoverHistoricalCommittedReceipt: historicalRecovery.recover,
     conflictMarkerPreflight: conflictMarkerPreflight.read,
     recoverSettlements,
-    executeDocSyncSubmit: async ({ command, decoded }) => {
-      const wireCommand = command.payload.command as {
-        readonly request?: DocSyncSubmitRequestV1;
-      };
-      if (!wireCommand.request) {
-        return { receipt: failureReceipt(
-          "repo.doc.sync.submit",
-          "doc_sync_invalid_payload",
-          "The writer child received no doc-sync request."
-        ) };
-      }
-      const materialized = materializeDocSyncWriterWorkingTree(
-        {
-          rootDir: config.canonicalRoot,
-          ...(layoutOverrides ? { layoutOverrides } : {})
-        },
-        wireCommand.request
-      );
-      if (!materialized.ok) {
-        const result: DocSyncSubmitResultV1 = {
-          ok: false,
-          _tag: "WriteRejected",
-          schema: "daemon.doc-sync-submit-result/v1",
-          status: "rejected",
-          intentId: wireCommand.request.payload.intentId,
-          code: "doc_sync_invalid_payload",
-          reason: `The writer child rejected a working-tree reference: ${materialized.reason}`,
-          retryable: false
-        };
-        return { receipt: failureReceipt(
-          "repo.doc.sync.submit",
-          result.code,
-          result.reason,
-          { data: result as unknown as import("@harness-anything/daemon").JsonObject }
-        ) };
-      }
-      const attribution = daemonActorAttribution(decoded.actor, decoded.executor);
-      const queued = makeDaemonQueuedWriteCoordinator(
-        runtime,
-        `doc-sync-submit:${wireCommand.request.payload.intentId}`,
-        {
-          attribution: attribution.writeAttribution,
-          commitAuthor: attribution.commitAuthor,
-          ...(wireCommand.request.session?.sessionId
-            ? { sessionId: wireCommand.request.session.sessionId }
-            : {})
-        }
-      );
-      let durableFlush: FlushReport | undefined;
-      const coordinator: WriteCoordinator = {
-        enqueue: queued.enqueue,
-        flush: (reason) => Effect.tap(queued.flush(reason), (flush) => Effect.sync(() => {
-          durableFlush = flush;
-        })),
-        recover: queued.recover
-      };
-      const result = await makeDocSyncService({
-        rootDir: config.canonicalRoot,
-        ...(layoutOverrides ? { layoutOverrides } : {}),
-        hostServices: cliDaemonServiceHostServices.docSync,
-        coordinator
-      }).submit(materialized.request);
-      if (result.ok) {
-        const receipt = buildDocSyncCommandReceipt({
-          result,
-          sessionId: decoded.currentSession.sessionId,
-          acceptedAt: new Date().toISOString(),
-          includeSettlement: false
-        });
-        if (result.appliedChanges.length === 0) {
-          return { receipt, terminalCommitSha: result.appliedLedgerSha };
-        }
-        if (!durableFlush || isIndeterminateFlushReport(durableFlush) || !durableFlush.committed || !durableFlush.watermark) {
-          throw new Error("DOC_SYNC_DURABLE_FLUSH_PROOF_MISSING");
-        }
-        const authoredRoot = resolveHarnessLayout({
-          rootDir: config.canonicalRoot,
-          ...(layoutOverrides ? { layoutOverrides } : {})
-        }).authoredRoot;
-        return {
-          receipt,
-          durable: {
-            sessionId: decoded.currentSession.sessionId,
-            acceptedCommitSha: result.appliedLedgerSha,
-            flush: { ...durableFlush, committed: true, watermark: durableFlush.watermark },
-            settle: async () => {
-              await nextEventLoopTurn();
-              await runtime.enqueueMaterializerBatch({ sessionId: decoded.currentSession.sessionId });
-              return canonicalCommitContaining(authoredRoot, result.appliedLedgerSha);
-            }
-          }
-        };
-      }
-      return { receipt: failureReceipt("repo.doc.sync.submit", result.code, result.reason, {
-          data: result as unknown as import("@harness-anything/daemon").JsonObject
-        }) };
-    }
+    executeDocSyncSubmit: createRepoWriteChildDocSyncExecutor({
+      canonicalRoot: config.canonicalRoot,
+      ...(layoutOverrides ? { layoutOverrides } : {}),
+      runtime
+    })
   });
+  canonicalPublicationRecovery.current = (input) =>
+    operation.recoverCanonicalPublicationSettlement(input);
+  await recoverSettlements(remainingStartupRecoveryBudgetMs());
   let cleanupPromise: Promise<void> | undefined;
   const cleanup = () => {
     cleanupPromise ??= (async () => {

--- a/packages/cli/test/complete-final-step-deadzone.test.ts
+++ b/packages/cli/test/complete-final-step-deadzone.test.ts
@@ -8,7 +8,8 @@ import {
   pollUntil,
   runDaemonCommand,
   runRawJsonMaybeFail,
-  stopDaemon
+  stopDaemon,
+  waitForReceiptCommitted
 } from "./helpers/daemon-cli.ts";
 import { assertHelpOrder, cliHelp, packetTemplate } from "./helpers/cli-help-fixture.ts";
 import {
@@ -73,35 +74,100 @@ test("completion help documents the canonical production sequence", () => {
   }
 });
 
-test("unpublished closeout blocks task complete and task closeout through the production daemon", { timeout: 60_000 }, async () => {
+test("task complete automatically materializes unpublished task prose while dry-run remains read-only", { timeout: 90_000 }, async () => {
   await withReviewedCompletionFixture("complete-unpublished-closeout", {
     exercisePlanPublication: true,
     assertReleasedHolder: true
-  }, ({ fixture, taskId, approvalPath, closeoutPacketPath, env }) => {
+  }, async ({ fixture, taskId, taskRoot, approvalPath, closeoutPacketPath, env }) => {
+    const artifactPath = path.join(taskRoot, "artifacts", "completion-evidence.md");
+    mkdirSync(path.dirname(artifactPath), { recursive: true });
+    writeFileSync(artifactPath, "# Initial evidence\n", "utf8");
+    const artifactAdded = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "artifact", "add", taskId, artifactPath
+    ], env);
+    assert.equal(artifactAdded.status, 0, JSON.stringify(artifactAdded.receipt));
+    const artifactSettlement = (((artifactAdded.receipt.details as {
+      readonly data?: { readonly report?: { readonly docSync?: { readonly settlement?: unknown } } };
+    } | undefined)?.data?.report?.docSync?.settlement) ?? artifactAdded.receipt.settlement) as {
+      readonly receiptId?: unknown;
+    } | undefined;
+    assert.equal(typeof artifactSettlement?.receiptId, "string", JSON.stringify(artifactAdded.receipt));
+    await waitForReceiptCommitted(fixture.repoRoot, String(artifactSettlement?.receiptId), env);
+    const settledSetup = runRawJsonMaybeFail(fixture.repoRoot, ["materializer", "run"], env);
+    assert.equal(settledSetup.status, 0, JSON.stringify(settledSetup.receipt));
+    writeFileSync(artifactPath, "# Updated evidence\n\nThe tracked artifact changed before completion.\n", "utf8");
+    writeFileSync(path.join(taskRoot, "task_plan.md"), productionPlan("Plan amended immediately before completion."));
+    const headBeforeDryRun = git(fixture.authoredRoot, "rev-parse", "HEAD");
+
     const blockedCompleteDryRun = runRawJsonMaybeFail(fixture.repoRoot, [
       "task", "complete", taskId, "--approve", "--from-file", approvalPath, "--dry-run"
     ], env);
     const blockedCloseoutDryRun = runRawJsonMaybeFail(fixture.repoRoot, [
       "task", "closeout", taskId, "--from-file", closeoutPacketPath, "--dry-run"
     ], env);
-    const blockedCompleteReal = runRawJsonMaybeFail(fixture.repoRoot, [
-      "task", "complete", taskId, "--approve", "--from-file", approvalPath
-    ], env);
-    for (const blocked of [blockedCompleteDryRun, blockedCloseoutDryRun, blockedCompleteReal]) {
+    for (const blocked of [blockedCompleteDryRun, blockedCloseoutDryRun]) {
       assert.equal(blocked.status, 1, JSON.stringify(blocked.receipt));
       assert.match(JSON.stringify(blocked.receipt), /AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED[\s\S]*closeout\.md/u);
     }
-    const blockedErrors = [blockedCompleteDryRun, blockedCloseoutDryRun, blockedCompleteReal]
+    const blockedErrors = [blockedCompleteDryRun, blockedCloseoutDryRun]
       .map(({ receipt }) => JSON.stringify(receipt).match(/AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED[\s\S]*?closeout\.md/u)?.[0]);
     assert.deepEqual(
       blockedErrors.map((error) => error?.match(/^AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED/u)?.[0]),
       [
         "AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED",
-        "AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED",
         "AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED"
       ]
     );
     for (const error of blockedErrors) assert.match(error ?? "", /closeout\.md/u);
+    assert.equal(git(fixture.authoredRoot, "rev-parse", "HEAD"), headBeforeDryRun);
+    const blockedCompleteReal = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "complete", taskId, "--approve", "--from-file", approvalPath
+    ], env);
+    assert.equal(blockedCompleteReal.status, 0, JSON.stringify(blockedCompleteReal.receipt));
+    assert.equal(blockedCompleteReal.receipt.ok, true, JSON.stringify(blockedCompleteReal.receipt));
+    assert.match(readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"), /^  status: done$/mu);
+    assert.equal(
+      git(fixture.authoredRoot, "show", `HEAD:tasks/${taskId}-production-route/closeout.md`),
+      readFileSync(path.join(taskRoot, "closeout.md"), "utf8").trim()
+    );
+    assert.equal(
+      git(fixture.authoredRoot, "show", `HEAD:tasks/${taskId}-production-route/task_plan.md`),
+      readFileSync(path.join(taskRoot, "task_plan.md"), "utf8").trim()
+    );
+    assert.equal(
+      git(fixture.authoredRoot, "show", `HEAD:tasks/${taskId}-production-route/artifacts/completion-evidence.md`),
+      readFileSync(artifactPath, "utf8").trim()
+    );
+  });
+});
+
+test("task complete reports file reason and repair when automatic doc sync rejects a task document", { timeout: 60_000 }, async () => {
+  await withReviewedCompletionFixture("complete-auto-materialize-rejected", {
+    exercisePlanPublication: true,
+    assertReleasedHolder: true
+  }, ({ fixture, taskId, taskRoot, approvalPath, env }) => {
+    writeFileSync(
+      path.join(taskRoot, "task_plan.md"),
+      productionPlan("Invalid completion plan edit.").replace("## Goal", "## Objective"),
+      "utf8"
+    );
+    const taskIndexBefore = readFileSync(path.join(taskRoot, "INDEX.md"), "utf8");
+    const rejected = runRawJsonMaybeFail(fixture.repoRoot, [
+      "task", "complete", taskId, "--approve", "--from-file", approvalPath
+    ], env);
+
+    assert.equal(rejected.status, 1, JSON.stringify(rejected.receipt));
+    assert.match(
+      String((rejected.receipt.error as { readonly code?: unknown } | undefined)?.code),
+      /^task_complete_auto_materialization_/u
+    );
+    const diagnostic = JSON.stringify(rejected.receipt);
+    assert.match(diagnostic, new RegExp(`file=tasks/${taskId}-production-route/task_plan\\.md`, "u"));
+    assert.match(diagnostic, /reason=/u);
+    assert.match(diagnostic, /fix=/u);
+    assert.match(diagnostic, /ha doc status --json/u);
+    assert.match(diagnostic, /ha doc sync --submit/u);
+    assert.equal(readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"), taskIndexBefore);
   });
 });
 

--- a/packages/cli/test/complete-final-step-deadzone.test.ts
+++ b/packages/cli/test/complete-final-step-deadzone.test.ts
@@ -141,36 +141,6 @@ test("task complete automatically materializes unpublished task prose while dry-
   });
 });
 
-test("task complete reports file reason and repair when automatic doc sync rejects a task document", { timeout: 60_000 }, async () => {
-  await withReviewedCompletionFixture("complete-auto-materialize-rejected", {
-    exercisePlanPublication: true,
-    assertReleasedHolder: true
-  }, ({ fixture, taskId, taskRoot, approvalPath, env }) => {
-    writeFileSync(
-      path.join(taskRoot, "task_plan.md"),
-      productionPlan("Invalid completion plan edit.").replace("## Goal", "## Objective"),
-      "utf8"
-    );
-    const taskIndexBefore = readFileSync(path.join(taskRoot, "INDEX.md"), "utf8");
-    const rejected = runRawJsonMaybeFail(fixture.repoRoot, [
-      "task", "complete", taskId, "--approve", "--from-file", approvalPath
-    ], env);
-
-    assert.equal(rejected.status, 1, JSON.stringify(rejected.receipt));
-    assert.match(
-      String((rejected.receipt.error as { readonly code?: unknown } | undefined)?.code),
-      /^task_complete_auto_materialization_/u
-    );
-    const diagnostic = JSON.stringify(rejected.receipt);
-    assert.match(diagnostic, new RegExp(`file=tasks/${taskId}-production-route/task_plan\\.md`, "u"));
-    assert.match(diagnostic, /reason=/u);
-    assert.match(diagnostic, /fix=/u);
-    assert.match(diagnostic, /ha doc status --json/u);
-    assert.match(diagnostic, /ha doc sync --submit/u);
-    assert.equal(readFileSync(path.join(taskRoot, "INDEX.md"), "utf8"), taskIndexBefore);
-  });
-});
-
 test("published completion dry-runs report checked gates without mutating holders", { timeout: 60_000 }, async () => {
   await withReviewedCompletionFixture("complete-ready-dry-run", {}, ({
     fixture, taskId, approvalPath, closeoutPacketPath, taskHolderRoot, env

--- a/packages/daemon/src/authority/authority-command-submission.ts
+++ b/packages/daemon/src/authority/authority-command-submission.ts
@@ -89,26 +89,35 @@ export interface DaemonAuthorityDurableSubmissionV2 {
 
 export class AuthorityCompileRejectedError extends Error {
   readonly code: string;
+  readonly details: Readonly<Record<string, unknown>> | undefined;
   readonly outcome = "not-started" as const;
   readonly replay = "caller-may-retry" as const;
 
-  constructor(code: string, message: string, options: { readonly cause?: unknown } = {}) {
+  constructor(code: string, message: string, options: {
+    readonly cause?: unknown;
+    readonly details?: Readonly<Record<string, unknown>>;
+  } = {}) {
     super(
       message,
       options.cause === undefined ? undefined : { cause: options.cause }
     );
     this.name = "AuthorityCompileRejectedError";
     this.code = code;
+    this.details = options.details;
   }
 }
 
 export function authorityCompileRejected(cause: unknown): AuthorityCompileRejectedError {
   if (cause instanceof AuthorityCompileRejectedError) return cause;
   const reason = cause instanceof Error ? cause.message : String(cause);
+  const details = compileRejectionDetails(cause);
+  const structuredCode = details && typeof (cause as { readonly code?: unknown }).code === "string"
+    ? (cause as { readonly code: string }).code
+    : undefined;
   return new AuthorityCompileRejectedError(
-    authorityRejectionCode(reason),
+    structuredCode ?? authorityRejectionCode(reason),
     reason,
-    { cause }
+    { cause, ...(details ? { details } : {}) }
   );
 }
 
@@ -135,7 +144,8 @@ export function createDaemonAuthorityCommandSubmissionV2(options: {
       throw authorityWriteRejected(
         rejected.message,
         false,
-        rejected.code
+        rejected.code,
+        rejected.details
       );
     }
   };
@@ -160,6 +170,14 @@ export function createDaemonAuthorityCommandSubmissionV2(options: {
     submit: (input) => compileAndSubmit(() => options.attemptCompiler.compile(input)),
     submitDurable: (input) => compileAndSubmitDurable(() => options.attemptCompiler.compile(input))
   };
+}
+
+function compileRejectionDetails(cause: unknown): Readonly<Record<string, unknown>> | undefined {
+  if (!cause || typeof cause !== "object" || !("details" in cause)) return undefined;
+  const details = cause.details;
+  return details && typeof details === "object" && !Array.isArray(details)
+    ? details as Readonly<Record<string, unknown>>
+    : undefined;
 }
 
 /** Preserve one settlement promise while exposing its durable publication cut. */

--- a/packages/daemon/src/authority/production/task-complete-prepublish-publication.ts
+++ b/packages/daemon/src/authority/production/task-complete-prepublish-publication.ts
@@ -5,6 +5,28 @@ import { reportCurrentRepoWriteTelemetry } from "../../runtime/repo-write-teleme
 
 const execFileAsync = promisify(execFile);
 
+export const taskCompletePrepublishFailureSchema = "task-complete-prepublish-failure/v1" as const;
+export const taskCompletePrepublishFailureCode = "task_complete_prepublish_not_materialized" as const;
+
+export interface TaskCompletePrepublishFailureDetails {
+  readonly schema: typeof taskCompletePrepublishFailureSchema;
+  readonly code: typeof taskCompletePrepublishFailureCode;
+  readonly files: ReadonlyArray<{ readonly path: string; readonly reason: string }>;
+}
+
+export class TaskCompletePrepublishNotMaterializedError extends Error {
+  readonly code = taskCompletePrepublishFailureCode;
+  readonly details: TaskCompletePrepublishFailureDetails;
+
+  constructor(files: TaskCompletePrepublishFailureDetails["files"]) {
+    super(`AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:${files.map((entry) =>
+      `${entry.path} (${entry.reason})`
+    ).join(", ")}`);
+    this.name = "TaskCompletePrepublishNotMaterializedError";
+    this.details = { schema: taskCompletePrepublishFailureSchema, code: this.code, files };
+  }
+}
+
 export async function findAttributedMaterializedPublication(
   rootDir: string,
   repositoryPaths: ReadonlyArray<string>,
@@ -16,8 +38,8 @@ export async function findAttributedMaterializedPublication(
   for (const body of bodies) expectedBlobs.push(await gitHashObject(rootDir, body));
   const currentBlobs = await gitBlobIds(rootDir, headRef, repositoryPaths);
   if (currentBlobs.some((actual, index) => actual !== expectedBlobs[index])) {
-    throw new Error(
-      `AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:${describeMaterializationMismatches(repositoryPaths, currentBlobs, expectedBlobs)}`
+    throw new TaskCompletePrepublishNotMaterializedError(
+      materializationMismatches(repositoryPaths, currentBlobs, expectedBlobs)
     );
   }
   const historyPromise = firstParentHistory(rootDir, repositoryPaths, headRef);
@@ -39,16 +61,20 @@ export async function findAttributedMaterializedPublication(
   );
   const missing = attributions.flatMap((attribution, index) => attribution ? [] : [repositoryPaths[index]!]);
   if (missing.length > 0) {
-    throw new Error(
-      `AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:${missing.map((repositoryPath) =>
-        `${repositoryPath} (no canonical publication changed this path to its current content)`
-      ).join(", ")}`
-    );
+    throw new TaskCompletePrepublishNotMaterializedError(missing.map((repositoryPath) => ({
+      path: repositoryPath,
+      reason: "no canonical publication changed this path to its current content"
+    })));
   }
   const attributed = attributions.filter((entry): entry is NonNullable<typeof entry> => entry !== null);
   const attributedCommits = new Set(attributed.map((entry) => entry.commit));
   const representative = history.find((entry) => attributedCommits.has(entry.commit));
-  if (!representative) throw new Error("AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:attributed publication missing from first-parent history");
+  if (!representative) {
+    throw new TaskCompletePrepublishNotMaterializedError(repositoryPaths.map((repositoryPath) => ({
+      path: repositoryPath,
+      reason: "attributed publication missing from first-parent history"
+    })));
+  }
   return {
     commit: representative.commit,
     operationIds: [...new Set(attributed.flatMap((entry) => entry.operationIds))].sort()
@@ -156,18 +182,19 @@ async function attributedPathOperationIds(
   return publicationOperationIds(subject);
 }
 
-function describeMaterializationMismatches(
+function materializationMismatches(
   repositoryPaths: ReadonlyArray<string>,
   actualBlobs: ReadonlyArray<string | null>,
   expectedBlobs: ReadonlyArray<string>
-): string {
+): TaskCompletePrepublishFailureDetails["files"] {
   return repositoryPaths.flatMap((repositoryPath, index) => {
     const actual = actualBlobs[index];
     if (actual === expectedBlobs[index]) return [];
-    return [actual === null
-      ? `${repositoryPath} (missing from HEAD)`
-      : `${repositoryPath} (content differs from expected)`];
-  }).join(", ");
+    return [{
+      path: repositoryPath,
+      reason: actual === null ? "missing from HEAD" : "content differs from expected"
+    }];
+  });
 }
 
 async function firstParentHistory(rootDir: string, repositoryPaths: ReadonlyArray<string>, headRef = "HEAD"): Promise<ReadonlyArray<{

--- a/packages/daemon/src/runtime/durable-repo-write-outcome-store.ts
+++ b/packages/daemon/src/runtime/durable-repo-write-outcome-store.ts
@@ -269,9 +269,11 @@ export class DurableRepoWriteOutcomeStoreV1 {
       );
     }
     const historicalPublication = input.historicalPublicationCommitSha;
+    const committedEvidence = input.authorityEvidence.tag === "COMMITTED"
+      || input.authorityEvidence.tag === "CANONICAL_PUBLICATION";
     if (current.generation !== this.axes.generation
       && (current.generation >= this.axes.generation
-        || input.authorityEvidence.tag !== "COMMITTED"
+        || !committedEvidence
         || input.authorityEvidence.commitSha !== historicalPublication)) {
       throw new RepoWriteOutcomeConflictError(
         `historical-generation repo-write outcome requires fenced resume: ${repoWriteOutcomeSafeIdentity(input.outerOpId)}`

--- a/packages/daemon/src/runtime/production-progress-append-operation.ts
+++ b/packages/daemon/src/runtime/production-progress-append-operation.ts
@@ -156,6 +156,12 @@ export class ProductionRepoWriteOperationHost<
 
   readonly settlementIdle = (): Promise<void> => this.operations.settlementIdle();
 
+  readonly recoverCanonicalPublicationSettlement = (input: {
+    readonly outerOpId: string;
+    readonly canonicalCommitSha: string;
+  }): Promise<"live-owner" | "recovered" | "terminal" | "blocked"> =>
+    this.operations.recoverCanonicalPublicationSettlement(input);
+
   async prepare(input: RepoWritePrepareInput): Promise<RepoWritePreparedOperation> {
     if (input.command.commandName === "doc-sync-submit") {
       return this.prepareDocSync(input);

--- a/packages/daemon/src/runtime/repo-write-canonical-publication-proof.ts
+++ b/packages/daemon/src/runtime/repo-write-canonical-publication-proof.ts
@@ -1,0 +1,167 @@
+import { RepoWriteOutcomeValidationError } from "./repo-write-outcome-errors.ts";
+import {
+  repoWriteJsonBudget,
+  repoWriteJsonObjectAt
+} from "./repo-write-json-budget.ts";
+
+export const repoWriteCanonicalPublicationEvidenceSchema =
+  "repo-write-canonical-publication-evidence/v1" as const;
+export const repoWriteCanonicalAncestryAnchorSchema =
+  "repo-write-canonical-ancestry-anchor/v1" as const;
+
+const digestPattern = /^[a-f0-9]{64}$/u;
+const commitPattern = /^(?:[a-f0-9]{40}|[a-f0-9]{64})$/u;
+
+export interface RepoWriteCanonicalPublicationEvidenceV1 {
+  readonly schema: typeof repoWriteCanonicalPublicationEvidenceSchema;
+  readonly tag: "CANONICAL_PUBLICATION";
+  readonly workspaceId: string;
+  readonly opId: string;
+  readonly semanticDigest: string;
+  readonly revision: number;
+  readonly commitSha: string;
+  readonly previousCommit: string | null;
+  readonly canonicalAncestry: {
+    readonly schema: typeof repoWriteCanonicalAncestryAnchorSchema;
+    readonly acceptedCommitSha: string;
+    readonly canonicalCommitSha: string;
+  };
+}
+
+export function createRepoWriteCanonicalPublicationEvidenceV1(input: {
+  readonly workspaceId: string;
+  readonly opId: string;
+  readonly semanticDigest: string;
+  readonly revision: number;
+  readonly commitSha: string;
+  readonly previousCommit: string | null;
+  readonly acceptedCommitSha: string;
+}): RepoWriteCanonicalPublicationEvidenceV1 {
+  return decodeRepoWriteCanonicalPublicationEvidenceV1({
+    schema: repoWriteCanonicalPublicationEvidenceSchema,
+    tag: "CANONICAL_PUBLICATION",
+    workspaceId: input.workspaceId,
+    opId: input.opId,
+    semanticDigest: input.semanticDigest,
+    revision: input.revision,
+    commitSha: input.commitSha,
+    previousCommit: input.previousCommit,
+    canonicalAncestry: {
+      schema: repoWriteCanonicalAncestryAnchorSchema,
+      acceptedCommitSha: input.acceptedCommitSha,
+      canonicalCommitSha: input.commitSha
+    }
+  });
+}
+
+export function decodeRepoWriteCanonicalPublicationEvidenceV1(
+  value: unknown,
+  path = "$.evidence"
+): RepoWriteCanonicalPublicationEvidenceV1 {
+  repoWriteJsonObjectAt(value, path, repoWriteJsonBudget(), 0);
+  const record = recordAt(value, path);
+  canonicalPublicationExactKeys(record, [
+    "schema", "tag", "workspaceId", "opId", "semanticDigest", "revision",
+    "commitSha", "previousCommit", "canonicalAncestry"
+  ], path);
+  if (record.schema !== repoWriteCanonicalPublicationEvidenceSchema) {
+    invalid(`${path}.schema`, repoWriteCanonicalPublicationEvidenceSchema);
+  }
+  if (record.tag !== "CANONICAL_PUBLICATION") {
+    invalid(`${path}.tag`, "CANONICAL_PUBLICATION");
+  }
+  const commitSha = commitAt(record.commitSha, `${path}.commitSha`);
+  const previousCommit = record.previousCommit === null
+    ? null
+    : commitAt(record.previousCommit, `${path}.previousCommit`);
+  const ancestry = recordAt(record.canonicalAncestry, `${path}.canonicalAncestry`);
+  canonicalPublicationExactKeys(ancestry, [
+    "schema", "acceptedCommitSha", "canonicalCommitSha"
+  ], `${path}.canonicalAncestry`);
+  if (ancestry.schema !== repoWriteCanonicalAncestryAnchorSchema) {
+    invalid(`${path}.canonicalAncestry.schema`, repoWriteCanonicalAncestryAnchorSchema);
+  }
+  const acceptedCommitSha = commitAt(
+    ancestry.acceptedCommitSha,
+    `${path}.canonicalAncestry.acceptedCommitSha`
+  );
+  const canonicalCommitSha = commitAt(
+    ancestry.canonicalCommitSha,
+    `${path}.canonicalAncestry.canonicalCommitSha`
+  );
+  if (canonicalCommitSha !== commitSha) {
+    invalid(`${path}.canonicalAncestry.canonicalCommitSha`, "exact equality with commitSha");
+  }
+  return {
+    schema: repoWriteCanonicalPublicationEvidenceSchema,
+    tag: "CANONICAL_PUBLICATION",
+    workspaceId: identifierAt(record.workspaceId, `${path}.workspaceId`),
+    opId: identifierAt(record.opId, `${path}.opId`),
+    semanticDigest: digestAt(record.semanticDigest, `${path}.semanticDigest`),
+    revision: uintAt(record.revision, `${path}.revision`),
+    commitSha,
+    previousCommit,
+    canonicalAncestry: {
+      schema: repoWriteCanonicalAncestryAnchorSchema,
+      acceptedCommitSha,
+      canonicalCommitSha
+    }
+  };
+}
+
+function recordAt(value: unknown, path: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    invalid(path, "plain object");
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) invalid(path, "plain object");
+  return value as Record<string, unknown>;
+}
+
+function canonicalPublicationExactKeys(
+  record: Record<string, unknown>,
+  required: ReadonlyArray<string>,
+  path: string
+): void {
+  const allowed = new Set(required);
+  if (required.some((key) => !Object.hasOwn(record, key))
+    || Object.keys(record).some((key) => !allowed.has(key))) {
+    invalid(path, "exact canonical publication evidence fields");
+  }
+}
+
+function identifierAt(value: unknown, path: string): string {
+  if (typeof value !== "string" || !value.trim()
+    || Buffer.byteLength(value, "utf8") > 4_096
+    || /[\u0000-\u001f\u007f]/u.test(value)) {
+    invalid(path, "non-empty bounded identifier");
+  }
+  return value;
+}
+
+function digestAt(value: unknown, path: string): string {
+  if (typeof value !== "string" || !digestPattern.test(value)) {
+    invalid(path, "lowercase SHA-256 digest");
+  }
+  return value;
+}
+
+function commitAt(value: unknown, path: string): string {
+  if (typeof value !== "string" || !commitPattern.test(value)) {
+    invalid(path, "lowercase Git object id");
+  }
+  return value;
+}
+
+function uintAt(value: unknown, path: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    invalid(path, "non-negative safe integer");
+  }
+  return value;
+}
+
+function invalid(path: string, expected: string): never {
+  throw new RepoWriteOutcomeValidationError(
+    `Invalid ${repoWriteCanonicalPublicationEvidenceSchema} at ${path}: expected ${expected}.`
+  );
+}

--- a/packages/daemon/src/runtime/repo-write-child-direct.ts
+++ b/packages/daemon/src/runtime/repo-write-child-direct.ts
@@ -148,11 +148,14 @@ function directWriteRejectionReceipt(
     ...(error.context ?? {}),
     ...(error.taskId ? { taskId: error.taskId } : {})
   });
+  const details = error.code === "task_complete_prepublish_not_materialized" && context
+    ? { data: context }
+    : undefined;
   return failureReceipt(
     commandName,
     error.code ?? "write_rejected",
     error.reason,
-    {},
+    details,
     context
   ) as unknown as RepoWriteJsonObject;
 }

--- a/packages/daemon/src/runtime/repo-write-doc-sync-operation.ts
+++ b/packages/daemon/src/runtime/repo-write-doc-sync-operation.ts
@@ -9,6 +9,7 @@ import type {
 import type { RepoWriteCommandDto, RepoWriteJsonObject } from "./repo-write-protocol.ts";
 import { decodeRepoWriteCommand } from "./repo-write-progress-command.ts";
 import {
+  createRepoWriteCanonicalPublicationEvidenceV1,
   repoWriteActorStampDigestV1,
   repoWriteCurrentCommandForExecution,
   repoWriteReceiptSeedSchema,
@@ -22,11 +23,13 @@ export interface RepoWriteDocSyncExecution {
   readonly durable?: {
     readonly sessionId: string;
     readonly acceptedCommitSha: string;
+    readonly previousCommitSha: string;
     readonly flush: FlushReport & { readonly committed: true; readonly watermark: string };
     readonly settle: () => Promise<string>;
   };
   /** Canonical observation anchoring a mutation-free terminal result. */
   readonly terminalCommitSha?: string;
+  readonly terminalPreviousCommitSha?: string;
 }
 
 export async function prepareRepoWriteDocSyncOperation(input: {
@@ -66,7 +69,8 @@ export async function prepareRepoWriteDocSyncOperation(input: {
     },
     recoveryContext: {
       schema: "repo-write-doc-sync-recovery/v1",
-      intentId
+      intentId,
+      baseLedgerSha: docSyncBaseLedgerSha(request)
     }
   };
   reportCurrentRepoWriteTelemetry("compile-outcome");
@@ -103,30 +107,31 @@ export async function executeRepoWriteDocSyncOperation(input: {
         flush: durable.flush
       },
       acceptedCommitSha: durable.acceptedCommitSha,
-      settlement: durable.settle().then((commitSha) => ({
-        tag: "COMMITTED" as const,
-        workspaceId: input.proceeding.workspaceId,
-        opId: input.proceeding.innerOpId,
-        semanticDigest: input.proceeding.authoritySemanticDigest,
-        revision: 0,
-        commitSha,
-        previousCommit: null
-      }))
+      settlement: durable.settle().then((commitSha) =>
+        createRepoWriteCanonicalPublicationEvidenceV1({
+          workspaceId: input.proceeding.workspaceId,
+          opId: input.proceeding.innerOpId,
+          semanticDigest: input.proceeding.authoritySemanticDigest,
+          revision: 0,
+          commitSha,
+          previousCommit: durable.previousCommitSha,
+          acceptedCommitSha: durable.acceptedCommitSha
+        }))
     };
   }
   if (receipt.ok && execution.terminalCommitSha) {
     return {
       kind: "terminal",
       receipt,
-      authorityEvidence: {
-        tag: "COMMITTED",
+      authorityEvidence: createRepoWriteCanonicalPublicationEvidenceV1({
         workspaceId: input.proceeding.workspaceId,
         opId: input.proceeding.innerOpId,
         semanticDigest: input.proceeding.authoritySemanticDigest,
         revision: 0,
         commitSha: execution.terminalCommitSha,
-        previousCommit: null
-      }
+        previousCommit: execution.terminalPreviousCommitSha ?? null,
+        acceptedCommitSha: execution.terminalCommitSha
+      })
     };
   }
   if (receipt.ok) throw new Error("DOC_SYNC_TERMINAL_SUCCESS_PROOF_MISSING");
@@ -165,4 +170,16 @@ function docSyncIntentId(request: RepoWriteJsonObject): string {
     throw new Error("DOC_SYNC_INTENT_ID_REQUIRED");
   }
   return intentId;
+}
+
+function docSyncBaseLedgerSha(request: RepoWriteJsonObject): string {
+  const payload = request.payload;
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("DOC_SYNC_REQUEST_PAYLOAD_REQUIRED");
+  }
+  const baseLedgerSha = (payload as RepoWriteJsonObject).baseLedgerSha;
+  if (typeof baseLedgerSha !== "string" || baseLedgerSha.length === 0) {
+    throw new Error("DOC_SYNC_BASE_LEDGER_SHA_REQUIRED");
+  }
+  return baseLedgerSha;
 }

--- a/packages/daemon/src/runtime/repo-write-durable-operation-controller.ts
+++ b/packages/daemon/src/runtime/repo-write-durable-operation-controller.ts
@@ -5,6 +5,7 @@ import {
   RepoWriteOutcomeGenerationFenceError
 } from "./durable-repo-write-outcome-store.ts";
 import {
+  createRepoWriteCanonicalPublicationEvidenceV1,
   assertRepoWriteOutcomeAxesV1,
   createRepoWriteProceedingOutcomeV1,
   type RepoWriteOutcomeAxesV1,
@@ -13,6 +14,7 @@ import {
   type RepoWriteTerminalEvidenceV1,
   type RepoWriteTerminalOutcomeV1
 } from "./repo-write-outcome-schema.ts";
+import { RepoWriteOutcomeValidationError } from "./repo-write-outcome-errors.ts";
 import type { RepoWritePreparedOperation } from "./repo-write-child-host.ts";
 import type { AuthorityDurableAcceptance } from "./authority-durable-acceptance-context.ts";
 import {
@@ -79,7 +81,7 @@ export class RepoWriteDurableOperationController {
   private readonly settlements: ReceiptSettlementStore;
   private readonly now: () => Date;
   private executionTail: Promise<void> = Promise.resolve();
-  private readonly activeSettlements = new Set<Promise<void>>();
+  private readonly activeSettlements = new Map<string, Promise<void>>();
 
   constructor(options: RepoWriteDurableOperationControllerOptions) {
     this.axes = {
@@ -108,8 +110,20 @@ export class RepoWriteDurableOperationController {
 
   async settlementIdle(): Promise<void> {
     while (this.activeSettlements.size > 0) {
-      await Promise.all([...this.activeSettlements]);
+      await Promise.all([...this.activeSettlements.values()]);
     }
+  }
+
+  async recoverCanonicalPublicationSettlement(input: {
+    readonly outerOpId: string;
+    readonly canonicalCommitSha: string;
+  }): Promise<"live-owner" | "recovered" | "terminal" | "blocked"> {
+    const active = this.activeSettlements.get(input.outerOpId);
+    if (active) {
+      await active;
+      return "live-owner";
+    }
+    return this.serialize(async () => this.recoverCanonicalPublicationExclusive(input));
   }
 
   private async resumeExclusive(
@@ -193,9 +207,56 @@ export class RepoWriteDurableOperationController {
       (evidence) => this.completeSettlement(proceeding, receipt, pending, evidence),
       (error) => this.failSettlement(receipt, pending, error)
     );
-    this.activeSettlements.add(completion);
-    void completion.finally(() => this.activeSettlements.delete(completion));
+    this.activeSettlements.set(proceeding.outerOpId, completion);
+    void completion.finally(() => {
+      if (this.activeSettlements.get(proceeding.outerOpId) === completion) {
+        this.activeSettlements.delete(proceeding.outerOpId);
+      }
+    });
     return { kind: "accepted", outerOpId: proceeding.outerOpId, receipt };
+  }
+
+  private recoverCanonicalPublicationExclusive(input: {
+    readonly outerOpId: string;
+    readonly canonicalCommitSha: string;
+  }): "recovered" | "terminal" | "blocked" {
+    const current = this.store.lookup(input.outerOpId);
+    if (current.state === "terminal") return "terminal";
+    if (current.state !== "proceeding") {
+      throw new RepoWriteOutcomeConflictError(
+        `canonical publication recovery requires current PROCEEDING: ${input.outerOpId}`
+      );
+    }
+    const settlement = this.settlements.lookup(input.outerOpId);
+    if (settlement?.state === "failed"
+      && settlement.receipt.settlement?.canonicalVisibility === "failed"
+      && settlement.receipt.settlement.failure.retryable === false) {
+      return "blocked";
+    }
+    const accepted = this.settlements.listUnsettled()
+      .find((record) => record.receiptId === input.outerOpId)?.receipt;
+    const pending = accepted?.settlement;
+    if (!accepted || !pending || pending.canonicalVisibility !== "pending") {
+      throw new RepoWriteOutcomeConflictError(
+        `canonical publication recovery requires durable acceptance: ${input.outerOpId}`
+      );
+    }
+    const recovery = current.outcome.recoveryContext;
+    const previousCommit = recovery.schema === "repo-write-doc-sync-recovery/v1"
+      && typeof recovery.baseLedgerSha === "string"
+      ? recovery.baseLedgerSha
+      : null;
+    const evidence = createRepoWriteCanonicalPublicationEvidenceV1({
+      workspaceId: current.outcome.workspaceId,
+      opId: current.outcome.innerOpId,
+      semanticDigest: current.outcome.authoritySemanticDigest,
+      revision: 0,
+      commitSha: input.canonicalCommitSha,
+      previousCommit,
+      acceptedCommitSha: pending.acceptedCommitSha
+    });
+    this.completeSettlement(current.outcome, accepted, pending, evidence);
+    return this.store.lookup(input.outerOpId).state === "terminal" ? "recovered" : "blocked";
   }
 
   private completeSettlement(
@@ -204,7 +265,7 @@ export class RepoWriteDurableOperationController {
     pending: Extract<NonNullable<typeof acceptedReceipt.settlement>, { readonly canonicalVisibility: "pending" }>,
     evidence: RepoWriteTerminalEvidenceV1
   ): void {
-    if (evidence.tag !== "COMMITTED") {
+    if (evidence.tag !== "COMMITTED" && evidence.tag !== "CANONICAL_PUBLICATION") {
       this.failSettlement(
         acceptedReceipt,
         pending,
@@ -214,6 +275,12 @@ export class RepoWriteDurableOperationController {
     }
     let terminalized = false;
     try {
+      if (evidence.tag === "CANONICAL_PUBLICATION"
+        && evidence.canonicalAncestry.acceptedCommitSha !== pending.acceptedCommitSha) {
+        throw new RepoWriteOutcomeValidationError(
+          "canonical publication proof is not bound to the accepted doc-sync commit"
+        );
+      }
       const visible = visibleCommandReceiptSettlement(
         pending,
         evidence.commitSha,
@@ -234,19 +301,30 @@ export class RepoWriteDurableOperationController {
       // Keep the accepted sidecar pending for startup reconciliation instead
       // of manufacturing a false failed-while-visible successor.
       if (terminalized) return;
-      this.failSettlement(acceptedReceipt, pending, error);
+      this.failSettlement(
+        acceptedReceipt,
+        pending,
+        error,
+        !(error instanceof RepoWriteOutcomeValidationError)
+      );
     }
   }
 
   private failSettlement(
     acceptedReceipt: CommandReceiptEnvelope,
     pending: Extract<NonNullable<typeof acceptedReceipt.settlement>, { readonly canonicalVisibility: "pending" }>,
-    error: unknown
+    error: unknown,
+    retryable = true
   ): void {
+    if (this.store.lookup(pending.receiptId).state === "terminal"
+      || this.settlements.lookup(pending.receiptId)?.state === "canonical-visible") {
+      return;
+    }
     const failure = settlementFailure(error);
     const failed = failedCommandReceiptSettlement(pending, {
       failedAt: this.now().toISOString(),
-      ...failure
+      ...failure,
+      retryable
     });
     const receipt = withCommandReceiptSettlement(acceptedReceipt, failed);
     this.settlements.fail(receipt);

--- a/packages/daemon/src/runtime/repo-write-outcome-schema.ts
+++ b/packages/daemon/src/runtime/repo-write-outcome-schema.ts
@@ -27,7 +27,11 @@ import {
 
 export { RepoWriteOutcomeValidationError } from "./repo-write-outcome-errors.ts";
 export {
+  createRepoWriteCanonicalPublicationEvidenceV1,
+  repoWriteCanonicalAncestryAnchorSchema,
+  repoWriteCanonicalPublicationEvidenceSchema,
   repoWriteTerminalProofSchema,
+  type RepoWriteCanonicalPublicationEvidenceV1,
   type RepoWriteTerminalEvidenceV1,
   type RepoWriteTerminalProofV1
 } from "./repo-write-terminal-proof.ts";

--- a/packages/daemon/src/runtime/repo-write-terminal-proof.ts
+++ b/packages/daemon/src/runtime/repo-write-terminal-proof.ts
@@ -2,7 +2,6 @@ import {
   isCompleteAuthorityCommittedReceiptV2,
   type AuthorityAlreadySatisfiedReceipt,
   type AuthorityCommittedReceipt,
-  type AuthorityOperationReceipt,
   type AuthorityRejectedReceipt,
   type AuthorityRetryableReceipt,
   type DaemonGenerationWriteRejectionV1
@@ -13,6 +12,17 @@ import {
   repoWriteJsonBudget,
   repoWriteJsonObjectAt
 } from "./repo-write-json-budget.ts";
+import {
+  decodeRepoWriteCanonicalPublicationEvidenceV1,
+  type RepoWriteCanonicalPublicationEvidenceV1
+} from "./repo-write-canonical-publication-proof.ts";
+
+export {
+  createRepoWriteCanonicalPublicationEvidenceV1,
+  repoWriteCanonicalAncestryAnchorSchema,
+  repoWriteCanonicalPublicationEvidenceSchema,
+  type RepoWriteCanonicalPublicationEvidenceV1
+} from "./repo-write-canonical-publication-proof.ts";
 
 export const repoWriteTerminalProofSchema = "repo-write-terminal-proof/v1" as const;
 const evidenceDigestSchema = "repo-write-authority-evidence-digest/v1" as const;
@@ -23,7 +33,8 @@ export type RepoWriteTerminalEvidenceV1 =
   | AuthorityCommittedReceipt
   | AuthorityAlreadySatisfiedReceipt
   | AuthorityRejectedReceipt
-  | AuthorityRetryableReceipt;
+  | AuthorityRetryableReceipt
+  | RepoWriteCanonicalPublicationEvidenceV1;
 
 export interface RepoWriteTerminalProofV1 {
   readonly schema: typeof repoWriteTerminalProofSchema;
@@ -33,7 +44,7 @@ export interface RepoWriteTerminalProofV1 {
 }
 
 export function createRepoWriteTerminalProofV1(
-  evidence: AuthorityOperationReceipt
+  evidence: RepoWriteTerminalEvidenceV1
 ): RepoWriteTerminalProofV1 {
   const normalized = decodeAuthorityTerminalEvidenceV1(evidence, "$.evidence");
   return {
@@ -91,6 +102,9 @@ export function decodeAuthorityTerminalEvidenceV1(
   repoWriteJsonObjectAt(value, path, repoWriteJsonBudget(), 0);
   const record = repoWriteTerminalProofRecordAt(value, path);
   const tag = record.tag;
+  if (tag === "CANONICAL_PUBLICATION") {
+    return decodeRepoWriteCanonicalPublicationEvidenceV1(record, path);
+  }
   if (tag === "COMMITTED") return repoWriteTerminalProofCommittedEvidenceAt(record, path);
   if (tag === "ALREADY_SATISFIED") {
     return repoWriteTerminalProofAlreadySatisfiedEvidenceAt(record, path);
@@ -101,12 +115,14 @@ export function decodeAuthorityTerminalEvidenceV1(
   }
   repoWriteTerminalProofInvalid(
     `${path}.tag`,
-    "COMMITTED, ALREADY_SATISFIED, REJECTED, or RETRYABLE_NOT_COMMITTED"
+    "CANONICAL_PUBLICATION, COMMITTED, ALREADY_SATISFIED, REJECTED, or RETRYABLE_NOT_COMMITTED"
   );
 }
 
 function successfulAuthorityEvidence(evidence: RepoWriteTerminalEvidenceV1): boolean {
-  return evidence.tag === "COMMITTED" || evidence.tag === "ALREADY_SATISFIED";
+  return evidence.tag === "CANONICAL_PUBLICATION"
+    || evidence.tag === "COMMITTED"
+    || evidence.tag === "ALREADY_SATISFIED";
 }
 
 function repoWriteTerminalProofAlreadySatisfiedEvidenceAt(

--- a/packages/daemon/src/service/command-service.ts
+++ b/packages/daemon/src/service/command-service.ts
@@ -45,6 +45,10 @@ import {
   repoWriteOutcomeQuery,
   repoWriteOutcomeUnknownHint
 } from "./repo-write-outcome-guidance.ts";
+import {
+  dispatchTaskCompleteWithAutoMaterialization,
+  type TaskCompleteAutoMaterializer
+} from "./task-complete-auto-materialization.ts";
 
 export interface DaemonCommandService {
   readonly runCommand: (payload?: JsonObject, context?: {
@@ -73,6 +77,7 @@ export interface DaemonCommandServiceOptions {
     connection: AuthorityConnectionDispatch | undefined
   ) => DaemonAuthorityCommandSubmissionV2 | undefined;
   readonly authorityCutoverControl?: AuthorityCutoverControlService;
+  readonly autoMaterializeTaskComplete?: TaskCompleteAutoMaterializer;
 }
 
 export function createDaemonCommandService<
@@ -155,12 +160,21 @@ export function createDaemonCommandService<
                   executor: context?.executor ?? null
                 }
               });
-            return await measureCurrentDaemonRequestPerformancePhase(
+            const dispatch = () => measureCurrentDaemonRequestPerformancePhase(
               "command-execute",
               () => hostServices.repoWriteChildExecutionMode(parsedCommand) === "durable"
                 ? options.repoWriteDispatch!.submit(childCommand)
                 : options.repoWriteDispatch!.direct(childCommand)
             );
+            return await dispatchTaskCompleteWithAutoMaterialization({
+              command: parsedCommand,
+              currentSession,
+              actor: daemonActor,
+              executor: context?.executor ?? null,
+              authorityConnection: authority,
+              autoMaterialize: options.autoMaterializeTaskComplete,
+              dispatch
+            });
           } catch (error) {
             const outerOpId = error instanceof RepoWriteOutcomeUnknownError
               ? error.opId

--- a/packages/daemon/src/service/command-service.ts
+++ b/packages/daemon/src/service/command-service.ts
@@ -167,6 +167,7 @@ export function createDaemonCommandService<
                 : options.repoWriteDispatch!.direct(childCommand)
             );
             return await dispatchTaskCompleteWithAutoMaterialization({
+              repoId: options.repoWriteDispatch.repoId,
               command: parsedCommand,
               currentSession,
               actor: daemonActor,

--- a/packages/daemon/src/service/service-host.ts
+++ b/packages/daemon/src/service/service-host.ts
@@ -56,7 +56,7 @@ import {
   sortedDaemonRepos
 } from "./daemon-host-boundary-policy.ts";
 import { repoWriteCommandDispatch } from "./repo-write-command-dispatch.ts";
-import { makeDocSyncSubmitHandler } from "./doc-sync-submit-handler.ts";
+import { makeTaskCompleteDocumentMaterializationServices } from "./task-complete-auto-materialization.ts";
 
 export { localAuthorityPeerPolicy } from "./daemon-host-boundary-policy.ts";
 
@@ -494,10 +494,20 @@ function createRepoServiceBinding<
     ...agentRuntimeControllerOptions,
     agentHolderProjection
   });
+  const documentMaterialization = makeTaskCompleteDocumentMaterializationServices({
+    rootDir,
+    layoutOverrides,
+    repoId: repo.repoId,
+    runtime,
+    hostServices: hostServices.docSync,
+    actorAttribution: hostServices.daemonActorAttribution,
+    ...(repoWriteSupervisor ? { supervisor: repoWriteSupervisor } : {})
+  });
   const daemonCommandService = createDaemonCommandService(runtime, hostServices.command, {
     ...commandOptions,
     ...(repoWriteSupervisor ? {
-      repoWriteDispatch: repoWriteCommandDispatch(repoWriteSupervisor)
+      repoWriteDispatch: repoWriteCommandDispatch(repoWriteSupervisor),
+      autoMaterializeTaskComplete: documentMaterialization.autoMaterializeTaskComplete
     } : {}),
     ...(authorityComponent ? { authorityCutoverControl: authorityComponent.cutoverControl } : {}),
     ...(authorityComponent ? {
@@ -561,16 +571,7 @@ function createRepoServiceBinding<
           lookup: (receiptId: string) => repoWriteSupervisor.lookup(receiptId)
         }
       } : {}),
-      DocSyncService: {
-        submit: makeDocSyncSubmitHandler({
-          rootDir,
-          layoutOverrides,
-          runtime,
-          hostServices: hostServices.docSync,
-          actorAttribution: hostServices.daemonActorAttribution,
-          ...(repoWriteSupervisor ? { supervisor: repoWriteSupervisor } : {})
-        })
-      }
+      DocSyncService: { submit: documentMaterialization.docSyncSubmit }
     },
     appendRuntimeEvent
   };

--- a/packages/daemon/src/service/task-complete-auto-materialization-orchestration.ts
+++ b/packages/daemon/src/service/task-complete-auto-materialization-orchestration.ts
@@ -1,0 +1,365 @@
+import type {
+  CommandReceiptEnvelope,
+  DaemonHostCommand,
+  TaskHolderExecutor
+} from "@harness-anything/application";
+import type { CurrentSessionRef } from "@harness-anything/kernel";
+import type { AuthenticatedActor } from "../identity/types.ts";
+import type { AuthorityConnectionDispatch } from "../protocol/connection-context.ts";
+
+export interface TaskCompletePrepublishFailure {
+  readonly path: string;
+  readonly reason: string;
+}
+
+export interface TaskCompleteMaterializationFailureFile extends TaskCompletePrepublishFailure {
+  readonly fix: string;
+  readonly fixArgv: ReadonlyArray<string>;
+}
+
+export type TaskCompleteAutoMaterializationResult =
+  | { readonly ok: true; readonly paths: ReadonlyArray<string> }
+  | {
+      readonly ok: false;
+      readonly code: string;
+      readonly hint: string;
+      readonly files: ReadonlyArray<TaskCompleteMaterializationFailureFile>;
+      readonly reason?: string;
+      readonly recovery?: {
+        readonly receiptId: string;
+        readonly statusCommand: string;
+        readonly argv: ReadonlyArray<string>;
+      };
+    };
+
+export type TaskCompleteAutoMaterializer = (input: {
+  readonly taskId: string;
+  readonly currentSession: CurrentSessionRef;
+  readonly actor: AuthenticatedActor;
+  readonly executor: TaskHolderExecutor | null;
+  readonly authorityConnection: Extract<AuthorityConnectionDispatch, { readonly available: true }>;
+  readonly prepublishFailures: ReadonlyArray<TaskCompletePrepublishFailure>;
+}) => Promise<TaskCompleteAutoMaterializationResult>;
+
+export interface TaskCompleteAutoMaterializationDispatchInput {
+  readonly repoId: string;
+  readonly command: DaemonHostCommand;
+  readonly currentSession: CurrentSessionRef;
+  readonly actor: AuthenticatedActor;
+  readonly executor: TaskHolderExecutor | null;
+  readonly authorityConnection: Extract<AuthorityConnectionDispatch, { readonly available: true }>;
+  readonly autoMaterialize?: TaskCompleteAutoMaterializer;
+  readonly dispatch: () => Promise<CommandReceiptEnvelope>;
+}
+
+export async function dispatchTaskCompleteWithAutoMaterialization(
+  input: TaskCompleteAutoMaterializationDispatchInput
+): Promise<CommandReceiptEnvelope> {
+  const taskId = taskCompleteTaskId(input.command);
+  const enabled = input.command.action.kind === "task-complete"
+    && input.command.action.dryRun !== true
+    && input.autoMaterialize !== undefined
+    && taskId !== undefined;
+  const first = await dispatchTaskCompleteAttempt(input.dispatch);
+  if (!enabled) return unwrapTaskCompleteAttempt(first);
+  const firstPrepublish = taskCompletePrepublishObservation(first);
+  if (!firstPrepublish.matched) return unwrapTaskCompleteAttempt(first);
+  return withTaskCompleteMaterializationFlight(`${input.repoId}\0${taskId}`, async () => {
+    input.authorityConnection.assertActive();
+    const revalidated = await dispatchTaskCompleteAttempt(input.dispatch);
+    const prepublish = taskCompletePrepublishObservation(revalidated);
+    if (!prepublish.matched) return unwrapTaskCompleteAttempt(revalidated);
+    if (!prepublish.valid) {
+      return invalidPrepublishDetailsReceipt(input.command.action.kind, prepublish.reason);
+    }
+    const materialized = await runAutoMaterializer(input, taskId, prepublish.files);
+    if (!materialized.ok) {
+      if (materialized.code === "task_complete_auto_materialization_no_candidate") {
+        input.authorityConnection.assertActive();
+        const afterNoCandidate = await dispatchTaskCompleteAttempt(input.dispatch);
+        const remaining = taskCompletePrepublishObservation(afterNoCandidate);
+        if (!remaining.matched) return unwrapTaskCompleteAttempt(afterNoCandidate);
+        if (!remaining.valid) {
+          return invalidPrepublishDetailsReceipt(input.command.action.kind, remaining.reason);
+        }
+        return materializationFailureReceipt(input.command.action.kind,
+          materialized.files.length > 0
+            ? materialized
+            : taskCompleteMaterializationFailure(materialized.code, remaining.files, materialized.hint));
+      }
+      return materializationFailureReceipt(input.command.action.kind, materialized);
+    }
+    input.authorityConnection.assertActive();
+    const retried = await dispatchTaskCompleteAttempt(input.dispatch);
+    const remaining = taskCompletePrepublishObservation(retried);
+    if (!remaining.matched) return unwrapTaskCompleteAttempt(retried);
+    if (!remaining.valid) {
+      return invalidPrepublishDetailsReceipt(input.command.action.kind, remaining.reason);
+    }
+    return incompleteMaterializationFailure(input.command.action.kind, remaining.files);
+  });
+}
+
+type TaskCompleteDispatchAttempt =
+  | { readonly receipt: CommandReceiptEnvelope }
+  | { readonly error: unknown };
+
+type TaskCompletePrepublishObservation =
+  | { readonly matched: false }
+  | { readonly matched: true; readonly valid: true; readonly files: ReadonlyArray<TaskCompletePrepublishFailure> }
+  | { readonly matched: true; readonly valid: false; readonly reason: string };
+
+const taskCompleteMaterializationFlights = new Map<string, Promise<void>>();
+
+async function withTaskCompleteMaterializationFlight<T>(key: string, action: () => Promise<T>): Promise<T> {
+  const predecessor = taskCompleteMaterializationFlights.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const owned = new Promise<void>((resolve) => { release = resolve; });
+  const tail = predecessor.catch(() => undefined).then(() => owned);
+  taskCompleteMaterializationFlights.set(key, tail);
+  await predecessor.catch(() => undefined);
+  try {
+    return await action();
+  } finally {
+    release();
+    if (taskCompleteMaterializationFlights.get(key) === tail) {
+      taskCompleteMaterializationFlights.delete(key);
+    }
+  }
+}
+
+async function dispatchTaskCompleteAttempt(
+  dispatch: () => Promise<CommandReceiptEnvelope>
+): Promise<TaskCompleteDispatchAttempt> {
+  try {
+    return { receipt: await dispatch() };
+  } catch (error) {
+    return { error };
+  }
+}
+
+function unwrapTaskCompleteAttempt(attempt: TaskCompleteDispatchAttempt): CommandReceiptEnvelope {
+  if ("receipt" in attempt) return attempt.receipt;
+  throw attempt.error;
+}
+
+async function runAutoMaterializer(
+  input: TaskCompleteAutoMaterializationDispatchInput,
+  taskId: string,
+  failures: ReadonlyArray<TaskCompletePrepublishFailure>
+): Promise<TaskCompleteAutoMaterializationResult> {
+  try {
+    return await input.autoMaterialize!({
+      taskId,
+      currentSession: input.currentSession,
+      actor: input.actor,
+      executor: input.executor,
+      authorityConnection: input.authorityConnection,
+      prepublishFailures: failures
+    });
+  } catch (error) {
+    const reason = `Unexpected automatic publication failure: ${taskCompleteErrorMessage(error)}`;
+    const recovery = orchestrationInternalRecovery();
+    return taskCompleteMaterializationFailure(
+      "task_complete_auto_materialization_internal",
+      failures,
+      reason,
+      { fix: recovery.fix, argv: recovery.argv }
+    );
+  }
+}
+
+export function taskCompleteMaterializationFailure(
+  code: string,
+  files: ReadonlyArray<TaskCompletePrepublishFailure>,
+  reason: string,
+  recovery?: {
+    readonly fix: string;
+    readonly argv: ReadonlyArray<string>;
+    readonly receiptId?: string;
+    readonly statusCommand?: string;
+  },
+  preserveFileReasons = false
+): Extract<TaskCompleteAutoMaterializationResult, { readonly ok: false }> {
+  const detailed = files.map((entry) => ({
+    ...entry,
+    reason: preserveFileReasons ? entry.reason : reason,
+    ...(recovery
+      ? { fix: recovery.fix, fixArgv: recovery.argv }
+      : docSyncRecovery(entry.path))
+  }));
+  return {
+    ok: false,
+    code,
+    hint: failureHint(detailed),
+    files: detailed,
+    reason,
+    ...(recovery?.receiptId && recovery.statusCommand ? {
+      recovery: {
+        receiptId: recovery.receiptId,
+        statusCommand: recovery.statusCommand,
+        argv: recovery.argv
+      }
+    } : {})
+  };
+}
+
+function taskCompleteTaskId(command: DaemonHostCommand): string | undefined {
+  const action = command.action as DaemonHostCommand["action"] & { readonly taskId?: unknown };
+  return typeof action.taskId === "string" && action.taskId ? action.taskId : undefined;
+}
+
+function taskCompletePrepublishObservation(attempt: TaskCompleteDispatchAttempt): TaskCompletePrepublishObservation {
+  const receipt = "receipt" in attempt ? attempt.receipt : undefined;
+  if (receipt?.ok) return { matched: false };
+  const errorRecord = "error" in attempt && taskCompleteRecord(attempt.error) ? attempt.error : undefined;
+  const code = receipt?.error?.code ?? taskCompleteStringField(errorRecord, "code");
+  const text = receipt
+    ? `${receipt.summary}\n${receipt.error?.hint ?? ""}`
+    : taskCompleteErrorMessage("error" in attempt ? attempt.error : "");
+  const matched = code === "task_complete_prepublish_not_materialized"
+    || text.includes("AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:");
+  if (!matched) return { matched: false };
+  const structured = receipt?.details?.data
+    ?? receipt?.error?.context
+    ?? errorRecord?.details;
+  const decoded = decodeTaskCompletePrepublishDetails(structured);
+  if (decoded) return { matched: true, valid: true, files: decoded };
+  const legacy = taskCompletePrepublishFailuresFromText(text);
+  if (legacy.length > 0) return { matched: true, valid: true, files: legacy };
+  return {
+    matched: true,
+    valid: false,
+    reason: "The structured prepublish details were missing or invalid, and the compatibility text did not contain a parseable file list."
+  };
+}
+
+function decodeTaskCompletePrepublishDetails(value: unknown): ReadonlyArray<TaskCompletePrepublishFailure> | undefined {
+  if (!taskCompleteRecord(value)
+    || value.schema !== "task-complete-prepublish-failure/v1"
+    || value.code !== "task_complete_prepublish_not_materialized"
+    || !Array.isArray(value.files)
+    || value.files.length === 0) return undefined;
+  const files: TaskCompletePrepublishFailure[] = [];
+  for (const entry of value.files) {
+    if (!taskCompleteRecord(entry)
+      || typeof entry.path !== "string" || entry.path.length === 0
+      || typeof entry.reason !== "string" || entry.reason.length === 0) return undefined;
+    files.push({ path: entry.path, reason: entry.reason });
+  }
+  return files;
+}
+
+function taskCompletePrepublishFailuresFromText(text: string): ReadonlyArray<TaskCompletePrepublishFailure> {
+  const marker = "AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:";
+  if (!text.includes(marker)) return [];
+  const failures: TaskCompletePrepublishFailure[] = [];
+  const reasons = [
+    "missing from HEAD",
+    "content differs from expected",
+    "no canonical publication changed this path to its current content",
+    "attributed publication missing from first-parent history"
+  ].join("|");
+  const pattern = new RegExp(`(?:^|, )(.+?) \\((${reasons})\\)(?=, |\\n|$)`, "gu");
+  for (const payload of text.split(marker).slice(1).map((entry) => entry.split("\n", 1)[0] ?? "")) {
+    for (const match of payload.matchAll(pattern)) {
+      const pathValue = match[1]?.trim();
+      const reason = match[2]?.trim();
+      if (pathValue && reason && !failures.some((entry) => entry.path === pathValue)) {
+        failures.push({ path: pathValue, reason });
+      }
+    }
+  }
+  return failures;
+}
+
+function incompleteMaterializationFailure(
+  command: string,
+  remaining: ReadonlyArray<TaskCompletePrepublishFailure>
+): CommandReceiptEnvelope {
+  return materializationFailureReceipt(command, taskCompleteMaterializationFailure(
+    "task_complete_auto_materialization_incomplete",
+    remaining,
+    "The file remained unpublished after automatic materialization and completion revalidation.",
+    undefined,
+    true
+  ));
+}
+
+function invalidPrepublishDetailsReceipt(command: string, reason: string): CommandReceiptEnvelope {
+  return materializationFailureReceipt(command, {
+    ok: false,
+    code: "task_complete_auto_materialization_prepublish_details_invalid",
+    hint: `Task completion requires valid structured prepublish failure details. ${reason} Run \`ha daemon logs --json\` and retry task completion after the daemon and writer are on compatible versions.`,
+    reason,
+    files: []
+  });
+}
+
+function materializationFailureReceipt(
+  command: string,
+  failure: Extract<TaskCompleteAutoMaterializationResult, { readonly ok: false }>
+): CommandReceiptEnvelope {
+  return {
+    ok: false,
+    schema: "command-receipt/v2",
+    command,
+    action: "run",
+    summary: failure.hint,
+    error: { code: failure.code, hint: failure.hint },
+    details: {
+      data: {
+        schema: "task-complete-auto-materialization-failure/v1",
+        files: failure.files,
+        ...(failure.reason ? { reason: failure.reason } : {}),
+        ...(failure.recovery ? { recovery: failure.recovery } : {})
+      }
+    },
+    meta: {
+      generatedAt: new Date().toISOString(),
+      compatibility: { legacyReceipt: "CommandReceipt/v1" }
+    }
+  };
+}
+
+function failureHint(files: ReadonlyArray<TaskCompleteMaterializationFailureFile>): string {
+  return `Task completion could not automatically materialize its document package. ${files.map((entry) =>
+    `file=${entry.path}; reason=${entry.reason}; fix=${entry.fix}`
+  ).join(" | ")}`;
+}
+
+function docSyncRecovery(filePath: string): Pick<TaskCompleteMaterializationFailureFile, "fix" | "fixArgv"> {
+  const fixArgv = ["ha", "doc", "sync", "--submit", "--path", filePath];
+  return {
+    fix: `Run \`${renderShellCommand(fixArgv)}\` after repairing this file, then retry task completion.`,
+    fixArgv
+  };
+}
+
+function orchestrationInternalRecovery() {
+  const argv = ["ha", "daemon", "logs", "--json"];
+  return {
+    argv,
+    fix: `Run \`${renderShellCommand(argv)}\` and inspect the internal daemon failure before retrying task completion.`
+  };
+}
+
+function renderShellCommand(argv: ReadonlyArray<string>): string {
+  return argv.map((entry) => /^[A-Za-z0-9_./:-]+$/u.test(entry)
+    ? entry
+    : `'${entry.replaceAll("'", `'\\''`)}'`
+  ).join(" ");
+}
+
+function taskCompleteRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function taskCompleteStringField(value: Readonly<Record<string, unknown>> | undefined, key: string): string | undefined {
+  const field = value?.[key];
+  return typeof field === "string" ? field : undefined;
+}
+
+export function taskCompleteErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/daemon/src/service/task-complete-auto-materialization-settlement.ts
+++ b/packages/daemon/src/service/task-complete-auto-materialization-settlement.ts
@@ -1,0 +1,133 @@
+import type { DocSyncSubmitResultV1 } from "@harness-anything/application";
+import { decodeRepoWriteCommandReceiptV2 } from "../runtime/repo-write-command-receipt.ts";
+import type { RepoWriteOperationLookupResult } from "../runtime/repo-write-protocol.ts";
+import { taskCompleteErrorMessage } from "./task-complete-auto-materialization-orchestration.ts";
+
+export const defaultTaskCompleteSettlementTimeoutMs = 20_000;
+const initialSettlementPollIntervalMs = 25;
+const maximumSettlementPollIntervalMs = 1_000;
+
+export async function waitForTaskCompleteCanonicalSettlement(
+  result: Extract<DocSyncSubmitResultV1, { readonly ok: true }>,
+  lookup: ((receiptId: string) => Promise<RepoWriteOperationLookupResult>) | undefined,
+  timing: {
+    readonly timeoutMs?: number;
+    readonly now?: () => number;
+    readonly sleep?: (milliseconds: number) => Promise<void>;
+  } = {}
+): Promise<
+  | { readonly settled: true }
+  | {
+      readonly settled: false;
+      readonly code: string;
+      readonly reason: string;
+      readonly fix: string;
+      readonly receiptId?: string;
+      readonly statusCommand?: string;
+      readonly recoveryArgv?: ReadonlyArray<string>;
+    }
+> {
+  const settlement = result.settlement;
+  if (result.settlementMode === "synchronous-canonical-final/v1"
+    || settlement?.canonicalVisibility === "visible") return { settled: true };
+  if (settlement?.canonicalVisibility === "failed") {
+    return {
+      settled: false,
+      code: "task_complete_auto_materialization_settlement_failed",
+      reason: `${settlement.failure.code}: ${settlement.failure.message}`,
+      ...settlementRecovery(settlement.receiptId, settlement.statusQuery.command,
+        "The document settlement failed. Inspect the receipt before retrying task completion.")
+    };
+  }
+  if (!settlement || !lookup) {
+    const recovery = settlementInternalRecovery();
+    return {
+      settled: false,
+      code: "task_complete_auto_materialization_settlement_unavailable",
+      reason: "doc sync returned no proof of canonical settlement",
+      fix: recovery.fix,
+      recoveryArgv: recovery.argv
+    };
+  }
+  const now = timing.now ?? Date.now;
+  const sleep = timing.sleep ?? waitBeforeTaskCompleteSettlementPoll;
+  const timeoutMs = timing.timeoutMs ?? defaultTaskCompleteSettlementTimeoutMs;
+  const deadline = now() + timeoutMs;
+  let state = "accepted";
+  let pollIntervalMs = initialSettlementPollIntervalMs;
+  while (now() < deadline) {
+    let observed: RepoWriteOperationLookupResult;
+    try {
+      observed = await lookup(settlement.receiptId);
+    } catch (error) {
+      return {
+        settled: false,
+        code: "task_complete_auto_materialization_settlement_lookup_failed",
+        reason: `Settlement lookup failed: ${taskCompleteErrorMessage(error)}`,
+        ...settlementRecovery(settlement.receiptId, settlement.statusQuery.command,
+          "Do not resubmit this unknown result. Restore receipt lookup and inspect the known receipt before retrying task completion.")
+      };
+    }
+    state = observed.state;
+    if (observed.state === "committed") return { settled: true };
+    if (observed.state === "rejected" || observed.state === "settlement-failed"
+      || observed.state === "failed" || observed.state === "unknown") {
+      const reason = observed.state === "settlement-failed"
+        ? settlementFailureReason(observed.receipt)
+        : `doc sync settlement ended in ${observed.state}`;
+      return {
+        settled: false,
+        code: "task_complete_auto_materialization_settlement_failed",
+        reason,
+        ...settlementRecovery(settlement.receiptId, settlement.statusQuery.command,
+          "The document settlement failed. Inspect the receipt before retrying task completion.")
+      };
+    }
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0) break;
+    await sleep(Math.min(pollIntervalMs, remainingMs));
+    pollIntervalMs = Math.min(pollIntervalMs * 2, maximumSettlementPollIntervalMs);
+  }
+  return {
+    settled: false,
+    code: "task_complete_auto_materialization_settlement_pending",
+    reason: `doc sync settlement remained ${state} after ${timeoutMs}ms`,
+    ...settlementRecovery(settlement.receiptId, settlement.statusQuery.command,
+      "Do not resubmit this unknown result. Inspect the receipt and wait for canonical visibility before retrying task completion.")
+  };
+}
+
+function settlementFailureReason(receipt: unknown): string {
+  try {
+    const decoded = decodeRepoWriteCommandReceiptV2(receipt, "$.taskCompleteSettlementReceipt");
+    const failure = decoded.settlement?.canonicalVisibility === "failed"
+      ? decoded.settlement.failure
+      : undefined;
+    return failure
+      ? `${failure.code}: ${failure.message}`
+      : "settlement-failed receipt did not contain a failed settlement";
+  } catch (error) {
+    return `settlement-failed receipt could not be decoded: ${taskCompleteErrorMessage(error)}`;
+  }
+}
+
+function settlementRecovery(receiptId: string, statusCommand: string, guidance: string) {
+  return {
+    receiptId,
+    statusCommand,
+    recoveryArgv: ["ha", "receipt", "status", receiptId, "--json"],
+    fix: `${guidance} Run \`${statusCommand}\`.`
+  };
+}
+
+function settlementInternalRecovery() {
+  const argv = ["ha", "daemon", "logs", "--json"];
+  return {
+    argv,
+    fix: "Run `ha daemon logs --json` and inspect the internal daemon failure before retrying task completion."
+  };
+}
+
+function waitBeforeTaskCompleteSettlementPoll(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/packages/daemon/src/service/task-complete-auto-materialization.ts
+++ b/packages/daemon/src/service/task-complete-auto-materialization.ts
@@ -1,102 +1,82 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import type {
   AuthorityHostAttribution,
-  CommandReceiptEnvelope,
   DaemonDocSyncHostServices,
-  DaemonHostCommand,
   DocSyncSubmitRequestV1,
   DocSyncSubmitResultV1,
   TaskHolderExecutor
 } from "@harness-anything/application";
 import {
   resolveHarnessLayout,
+  sha256Text,
   taskPackagePath,
-  type CurrentSessionRef,
   type HarnessLayoutOverrides
 } from "@harness-anything/kernel";
 import type { AuthenticatedActor } from "../identity/types.ts";
-import type { AuthorityConnectionDispatch } from "../protocol/connection-context.ts";
 import type { DocSyncServiceContext } from "../protocol/doc-sync-service-context.ts";
 import type { RepoWriteOperationLookupResult } from "../runtime/repo-write-protocol.ts";
 import type { HarnessDaemonRuntime } from "../runtime/repo-runtime.ts";
 import type { RepoWriteProcessSupervisor } from "../runtime/repo-write-process-supervisor.ts";
-import {
-  buildDocSyncReport,
-  buildDocSyncSubmitRequest
-} from "./doc-sync-service.ts";
+import { buildDocSyncReport } from "./doc-sync-service.ts";
 import { makeDocSyncSubmitHandler } from "./doc-sync-submit-handler.ts";
+import {
+  taskCompleteErrorMessage,
+  taskCompleteMaterializationFailure,
+  type TaskCompleteAutoMaterializationResult,
+  type TaskCompleteAutoMaterializer,
+  type TaskCompletePrepublishFailure
+} from "./task-complete-auto-materialization-orchestration.ts";
+import { waitForTaskCompleteCanonicalSettlement } from "./task-complete-auto-materialization-settlement.ts";
 
-const settlementPollIntervalMs = 25;
-const settlementPollLimit = 200;
+export {
+  dispatchTaskCompleteWithAutoMaterialization,
+  type TaskCompleteAutoMaterializationResult,
+  type TaskCompleteAutoMaterializer,
+  type TaskCompleteMaterializationFailureFile,
+  type TaskCompletePrepublishFailure
+} from "./task-complete-auto-materialization-orchestration.ts";
+export {
+  defaultTaskCompleteSettlementTimeoutMs,
+  waitForTaskCompleteCanonicalSettlement
+} from "./task-complete-auto-materialization-settlement.ts";
 
-export interface TaskCompletePrepublishFailure {
+export interface TaskCompleteMaterializationSnapshot {
   readonly path: string;
-  readonly reason: string;
+  readonly baseBlobSha256: string | null;
+  readonly body: string;
+  readonly bodySha256: string;
+  readonly mediaType: string;
+  readonly size: number;
+  readonly pathClass: string | null;
 }
 
-export type TaskCompleteAutoMaterializationResult =
-  | { readonly ok: true; readonly paths: ReadonlyArray<string> }
-  | {
-      readonly ok: false;
-      readonly code: string;
-      readonly hint: string;
-      readonly files: ReadonlyArray<TaskCompletePrepublishFailure & { readonly fix: string }>;
-    };
-
-export type TaskCompleteAutoMaterializer = (input: {
-  readonly taskId: string;
-  readonly currentSession: CurrentSessionRef;
-  readonly actor: AuthenticatedActor;
-  readonly executor: TaskHolderExecutor | null;
-  readonly authorityConnection: Extract<AuthorityConnectionDispatch, { readonly available: true }>;
-  readonly prepublishFailures: ReadonlyArray<TaskCompletePrepublishFailure>;
-}) => Promise<TaskCompleteAutoMaterializationResult>;
-
-export async function dispatchTaskCompleteWithAutoMaterialization(input: {
-  readonly command: DaemonHostCommand;
-  readonly currentSession: CurrentSessionRef;
-  readonly actor: AuthenticatedActor;
-  readonly executor: TaskHolderExecutor | null;
-  readonly authorityConnection: Extract<AuthorityConnectionDispatch, { readonly available: true }>;
-  readonly autoMaterialize?: TaskCompleteAutoMaterializer;
-  readonly dispatch: () => Promise<CommandReceiptEnvelope>;
-}): Promise<CommandReceiptEnvelope> {
-  const taskId = taskCompleteTaskId(input.command);
-  const enabled = input.command.action.kind === "task-complete"
-    && input.command.action.dryRun !== true
-    && input.autoMaterialize !== undefined
-    && taskId !== undefined;
-  const materializeAndRetry = async (
-    prepublishFailures: ReadonlyArray<TaskCompletePrepublishFailure>
-  ): Promise<CommandReceiptEnvelope> => {
-    const materialized = await runAutoMaterializer(input, taskId!, prepublishFailures);
-    if (!materialized.ok) return materializationFailureReceipt(input.command.action.kind, materialized);
-    input.authorityConnection.assertActive();
+export function verifyTaskCompleteMaterializationSnapshot(
+  snapshots: ReadonlyArray<TaskCompleteMaterializationSnapshot>,
+  readBody: (filePath: string) => string
+): {
+  readonly path: string;
+  readonly expectedBodySha256: string;
+  readonly actualBodySha256: string | null;
+} | undefined {
+  for (const snapshot of snapshots) {
+    let actualBodySha256: string | null;
     try {
-      const retried = await input.dispatch();
-      if (!retried.ok) {
-        const remaining = taskCompletePrepublishFailures(retried);
-        if (remaining.length > 0) return incompleteMaterializationFailure(input.command.action.kind, remaining);
-      }
-      return retried;
-    } catch (error) {
-      const remaining = taskCompletePrepublishFailuresFromText(taskCompleteErrorMessage(error));
-      if (remaining.length > 0) return incompleteMaterializationFailure(input.command.action.kind, remaining);
-      throw error;
+      actualBodySha256 = sha256Text(readBody(snapshot.path));
+    } catch {
+      actualBodySha256 = null;
     }
-  };
-  let receipt: CommandReceiptEnvelope;
-  try {
-    receipt = await input.dispatch();
-  } catch (error) {
-    const failures = enabled ? taskCompletePrepublishFailuresFromText(taskCompleteErrorMessage(error)) : [];
-    if (failures.length > 0) return materializeAndRetry(failures);
-    throw error;
+    if (actualBodySha256 !== snapshot.bodySha256) {
+      return {
+        path: snapshot.path,
+        expectedBodySha256: snapshot.bodySha256,
+        actualBodySha256
+      };
+    }
   }
-  if (!enabled || receipt.ok) return receipt;
-  const failures = taskCompletePrepublishFailures(receipt);
-  return failures.length > 0 ? materializeAndRetry(failures) : receipt;
+  return undefined;
 }
+
 
 export function makeTaskCompleteDocumentMaterializationServices(options: {
   readonly rootDir: string;
@@ -132,32 +112,6 @@ export function makeTaskCompleteDocumentMaterializationServices(options: {
       })
     } : {})
   };
-}
-
-async function runAutoMaterializer(
-  input: Parameters<typeof dispatchTaskCompleteWithAutoMaterialization>[0],
-  taskId: string,
-  failures: ReadonlyArray<TaskCompletePrepublishFailure>
-): Promise<TaskCompleteAutoMaterializationResult> {
-  try {
-    return await input.autoMaterialize!({
-      taskId,
-      currentSession: input.currentSession,
-      actor: input.actor,
-      executor: input.executor,
-      authorityConnection: input.authorityConnection,
-      prepublishFailures: failures
-    });
-  } catch (error) {
-    const fix = docSyncFix();
-    const files = failures.map((entry) => ({ ...entry, reason: taskCompleteErrorMessage(error), fix }));
-    return {
-      ok: false,
-      code: "task_complete_auto_materialization_failed",
-      hint: `Automatic task document publication failed. Run \`ha doc status --json\`, repair the named file, then run \`ha doc sync --submit\`. ${failureHint(files)}`,
-      files
-    };
-  }
 }
 
 export function makeTaskCompleteAutoMaterializer(options: {
@@ -202,18 +156,63 @@ export function makeTaskCompleteAutoMaterializer(options: {
         "doc sync found no eligible dirty change for the prepublish path"
       );
     }
+    if (!report.baseLedgerSha) {
+      return taskCompleteMaterializationFailure(
+        "task_complete_auto_materialization_preflight_failed",
+        input.prepublishFailures,
+        "Doc sync submit requires an initialized authored Git repository."
+      );
+    }
+    const snapshots: TaskCompleteMaterializationSnapshot[] = [];
+    for (const selectedPath of selectedPaths) {
+      const candidate = report.candidateBlobs.find((entry) => entry.path === selectedPath);
+      if (!candidate?.newBlobSha256) {
+        const diagnostic = report.unresolvedTouches.find((entry) => entry.path === selectedPath)?.reason
+          ?? report.forbiddenTouches.find((entry) => entry.path === selectedPath)?.hunks[0]?.summary
+          ?? "doc sync did not classify the dirty path as an eligible candidate";
+        return taskCompleteMaterializationFailure(
+          "task_complete_auto_materialization_preflight_failed",
+          selectedFailures(input.prepublishFailures, [selectedPath]),
+          diagnostic
+        );
+      }
+      const body = readFileSync(path.join(layout.authoredRoot, selectedPath), "utf8");
+      const bodySha256 = sha256Text(body);
+      if (bodySha256 !== candidate.newBlobSha256) {
+        return taskCompleteMaterializationFailure(
+          "task_complete_auto_materialization_working_tree_changed",
+          selectedFailures(input.prepublishFailures, [selectedPath]),
+          "Working tree content changed while the automatic publication snapshot was being captured."
+        );
+      }
+      snapshots.push({
+        path: selectedPath,
+        baseBlobSha256: candidate.baseBlobSha256,
+        body,
+        bodySha256,
+        mediaType: candidate.mediaType,
+        size: candidate.size,
+        pathClass: candidate.pathClass
+      });
+    }
     const artifactRoot = `${packageRoot}/artifacts/`;
     const groups: ReadonlyArray<{
       readonly intent: DocSyncSubmitRequestV1["payload"]["declaredIntent"];
-      readonly paths: ReadonlyArray<string>;
+      readonly snapshots: ReadonlyArray<TaskCompleteMaterializationSnapshot>;
     }> = [
-      { intent: "manual-artifact", paths: selectedPaths.filter((entry) => entry.startsWith(artifactRoot)) },
-      { intent: "prose-edit", paths: selectedPaths.filter((entry) => !entry.startsWith(artifactRoot)) }
+      { intent: "manual-artifact", snapshots: snapshots.filter((entry) => entry.path.startsWith(artifactRoot)) },
+      { intent: "prose-edit", snapshots: snapshots.filter((entry) => !entry.path.startsWith(artifactRoot)) }
     ];
     const appliedPaths: string[] = [];
     for (const group of groups) {
-      if (group.paths.length === 0) continue;
-      const submitted = await submitMaterializationGroup(options, input, rootInput, group);
+      if (group.snapshots.length === 0) continue;
+      const submitted = await submitMaterializationGroup(
+        options,
+        input,
+        layout.authoredRoot,
+        report.baseLedgerSha,
+        group
+      );
       if (!submitted.ok) return submitted.failure;
       appliedPaths.push(...submitted.paths);
     }
@@ -224,10 +223,11 @@ export function makeTaskCompleteAutoMaterializer(options: {
 async function submitMaterializationGroup(
   options: Parameters<typeof makeTaskCompleteAutoMaterializer>[0],
   input: Parameters<TaskCompleteAutoMaterializer>[0],
-  rootInput: { readonly rootDir: string; readonly layoutOverrides?: HarnessLayoutOverrides },
+  authoredRoot: string,
+  baseLedgerSha: string,
   group: {
     readonly intent: DocSyncSubmitRequestV1["payload"]["declaredIntent"];
-    readonly paths: ReadonlyArray<string>;
+    readonly snapshots: ReadonlyArray<TaskCompleteMaterializationSnapshot>;
   }
 ): Promise<
   | { readonly ok: true; readonly paths: ReadonlyArray<string> }
@@ -235,23 +235,27 @@ async function submitMaterializationGroup(
 > {
   let request: DocSyncSubmitRequestV1;
   try {
-    const docSyncRequest = buildDocSyncSubmitRequest(
-      rootInput,
-      options.repoId,
-      group.paths,
-      input.executor,
-      options.hostServices,
-      input.currentSession
+    const changed = verifyTaskCompleteMaterializationSnapshot(
+      group.snapshots,
+      (filePath) => readFileSync(path.join(authoredRoot, filePath), "utf8")
     );
-    request = group.intent === docSyncRequest.payload.declaredIntent
-      ? docSyncRequest
-      : { ...docSyncRequest, payload: { ...docSyncRequest.payload, declaredIntent: group.intent } };
+    if (changed) {
+      return {
+        ok: false,
+        failure: taskCompleteMaterializationFailure(
+          "task_complete_auto_materialization_working_tree_changed",
+          selectedFailures(input.prepublishFailures, [changed.path]),
+          `Working tree content changed after snapshot capture for ${changed.path}.`
+        )
+      };
+    }
+    request = taskCompleteDocSyncRequest(options.repoId, baseLedgerSha, group, input);
   } catch (error) {
     return {
       ok: false,
       failure: taskCompleteMaterializationFailure(
         "task_complete_auto_materialization_preflight_failed",
-        selectedFailures(input.prepublishFailures, group.paths),
+        selectedFailures(input.prepublishFailures, group.snapshots.map((entry) => entry.path)),
         taskCompleteErrorMessage(error)
       )
     };
@@ -268,76 +272,81 @@ async function submitMaterializationGroup(
       ok: false,
       failure: taskCompleteMaterializationFailure(
         "task_complete_auto_materialization_submit_failed",
-        selectedFailures(input.prepublishFailures, group.paths),
+        selectedFailures(input.prepublishFailures, group.snapshots.map((entry) => entry.path)),
         taskCompleteErrorMessage(error)
       )
     };
   }
   if (!result.ok) {
-    return { ok: false, failure: rejectedResultFailure(result, input.prepublishFailures, group.paths) };
+    return {
+      ok: false,
+      failure: rejectedResultFailure(
+        result,
+        input.prepublishFailures,
+        group.snapshots.map((entry) => entry.path)
+      )
+    };
   }
-  const settlement = await waitForCanonicalSettlement(result, options.lookup);
+  const settlement = await waitForTaskCompleteCanonicalSettlement(result, options.lookup);
   if (!settlement.settled) {
     return {
       ok: false,
       failure: taskCompleteMaterializationFailure(
         settlement.code,
-        selectedFailures(input.prepublishFailures, group.paths),
+        selectedFailures(input.prepublishFailures, group.snapshots.map((entry) => entry.path)),
         settlement.reason,
-        settlement.fix
+        {
+          fix: settlement.fix,
+          argv: settlement.recoveryArgv ?? ["ha", "daemon", "logs", "--json"],
+          ...(settlement.receiptId && settlement.statusCommand ? {
+            receiptId: settlement.receiptId,
+            statusCommand: settlement.statusCommand
+          } : {})
+        }
       )
     };
   }
   return { ok: true, paths: result.appliedChanges.map((entry) => entry.path) };
 }
 
-async function waitForCanonicalSettlement(
-  result: Extract<DocSyncSubmitResultV1, { readonly ok: true }>,
-  lookup: ((receiptId: string) => Promise<RepoWriteOperationLookupResult>) | undefined
-): Promise<
-  | { readonly settled: true }
-  | { readonly settled: false; readonly code: string; readonly reason: string; readonly fix: string }
-> {
-  const settlement = result.settlement;
-  if (result.settlementMode === "synchronous-canonical-final/v1"
-    || settlement?.canonicalVisibility === "visible") return { settled: true };
-  if (settlement?.canonicalVisibility === "failed") {
-    return {
-      settled: false,
-      code: "task_complete_auto_materialization_settlement_failed",
-      reason: `${settlement.failure.code}: ${settlement.failure.message}`,
-      fix: `Run \`${settlement.statusQuery.command}\` and follow the reported recovery guidance before retrying task completion.`
-    };
-  }
-  if (!settlement || !lookup) {
-    return {
-      settled: false,
-      code: "task_complete_auto_materialization_settlement_unavailable",
-      reason: "doc sync returned no proof of canonical settlement",
-      fix: docSyncFix()
-    };
-  }
-  let state = "accepted";
-  for (let attempt = 0; attempt < settlementPollLimit; attempt += 1) {
-    const observed = await lookup(settlement.receiptId);
-    state = observed.state;
-    if (observed.state === "committed") return { settled: true };
-    if (observed.state === "rejected" || observed.state === "settlement-failed"
-      || observed.state === "failed" || observed.state === "unknown") {
-      return {
-        settled: false,
-        code: "task_complete_auto_materialization_settlement_failed",
-        reason: `doc sync settlement ended in ${observed.state}`,
-        fix: `Run \`${settlement.statusQuery.command}\` and repair the reported settlement before retrying task completion.`
-      };
-    }
-    await waitBeforeTaskCompleteSettlementPoll(settlementPollIntervalMs);
-  }
+function taskCompleteDocSyncRequest(
+  repoId: string,
+  baseLedgerSha: string,
+  group: {
+    readonly intent: DocSyncSubmitRequestV1["payload"]["declaredIntent"];
+    readonly snapshots: ReadonlyArray<TaskCompleteMaterializationSnapshot>;
+  },
+  input: Parameters<TaskCompleteAutoMaterializer>[0]
+): DocSyncSubmitRequestV1 {
+  const changes = group.snapshots.map((snapshot) => ({
+    path: snapshot.path,
+    baseBlobSha256: snapshot.baseBlobSha256,
+    newBlobSha256: snapshot.bodySha256,
+    mediaType: snapshot.mediaType,
+    size: snapshot.size,
+    declaredBearing: "task-document",
+    declaredZoneClass: "task-authored-prose-or-stage",
+    ...(snapshot.pathClass ? { declaredPathClass: snapshot.pathClass } : {}),
+    content: { kind: "inline" as const, body: snapshot.body }
+  }));
+  const intentMaterial = JSON.stringify({
+    baseLedgerSha,
+    changes: changes.map(({ path: changePath, baseBlobSha256, newBlobSha256 }) => ({
+      path: changePath,
+      baseBlobSha256,
+      newBlobSha256
+    }))
+  });
   return {
-    settled: false,
-    code: "task_complete_auto_materialization_settlement_pending",
-    reason: `doc sync settlement remained ${state} after ${settlementPollIntervalMs * settlementPollLimit}ms`,
-    fix: `Run \`${settlement.statusQuery.command}\` and wait for canonical visibility before retrying task completion.`
+    repo: { repoId },
+    ...(input.executor !== undefined ? { executor: input.executor } : {}),
+    session: input.currentSession,
+    payload: {
+      baseLedgerSha,
+      intentId: `intent_${sha256Text(intentMaterial).slice(0, 24)}`,
+      declaredIntent: group.intent,
+      changes
+    }
   };
 }
 
@@ -360,14 +369,19 @@ function rejectedResultFailure(
     ...entry,
     reason: diagnostics.find((diagnostic) => diagnostic.path === entry.path)?.reason ?? result.reason
   }));
-  const fix = "outcomeUnknown" in result && result.outcomeUnknown
-    ? `Run \`${result.outcomeUnknown.statusCommand}\` and resolve the reported write outcome before retrying task completion.`
-    : docSyncFix();
+  const recovery = "outcomeUnknown" in result && result.outcomeUnknown
+    ? {
+        fix: `Do not resubmit this unknown result. Run \`${result.outcomeUnknown.statusCommand}\` before retrying task completion.`,
+        argv: ["ha", "receipt", "status", result.outcomeUnknown.receiptId, "--json"],
+        receiptId: result.outcomeUnknown.receiptId,
+        statusCommand: result.outcomeUnknown.statusCommand
+      }
+    : undefined;
   return taskCompleteMaterializationFailure(
     `task_complete_auto_materialization_${result.code}`,
     files,
     result.reason,
-    fix,
+    recovery,
     true
   );
 }
@@ -380,106 +394,6 @@ function selectedFailures(
   return failures.filter((entry) => selected.has(entry.path));
 }
 
-function taskCompleteMaterializationFailure(
-  code: string,
-  files: ReadonlyArray<TaskCompletePrepublishFailure>,
-  reason: string,
-  fix = docSyncFix(),
-  preserveFileReasons = false
-): Extract<TaskCompleteAutoMaterializationResult, { readonly ok: false }> {
-  const detailed = files.map((entry) => ({
-    ...entry,
-    reason: preserveFileReasons ? entry.reason : reason,
-    fix
-  }));
-  return {
-    ok: false,
-    code,
-    hint: failureHint(detailed),
-    files: detailed
-  };
-}
-
-function taskCompleteTaskId(command: DaemonHostCommand): string | undefined {
-  const action = command.action as DaemonHostCommand["action"] & { readonly taskId?: unknown };
-  return typeof action.taskId === "string" && action.taskId ? action.taskId : undefined;
-}
-
-function taskCompletePrepublishFailures(receipt: CommandReceiptEnvelope): ReadonlyArray<TaskCompletePrepublishFailure> {
-  if (receipt.ok) return [];
-  return taskCompletePrepublishFailuresFromText(`${receipt.summary}\n${receipt.error?.hint ?? ""}`);
-}
-
-function taskCompletePrepublishFailuresFromText(text: string): ReadonlyArray<TaskCompletePrepublishFailure> {
-  if (!text.includes("AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:")) return [];
-  const failures: TaskCompletePrepublishFailure[] = [];
-  const pattern = /(tasks\/[^(,\n]+?) \(([^)]+)\)/gu;
-  for (const match of text.matchAll(pattern)) {
-    const pathValue = match[1]?.trim();
-    const reason = match[2]?.trim();
-    if (pathValue && reason && !failures.some((entry) => entry.path === pathValue)) {
-      failures.push({ path: pathValue, reason });
-    }
-  }
-  return failures;
-}
-
-function incompleteMaterializationFailure(
-  command: string,
-  remaining: ReadonlyArray<TaskCompletePrepublishFailure>
-): CommandReceiptEnvelope {
-  const fix = docSyncFix();
-  const files = remaining.map((entry) => ({ ...entry, fix }));
-  return materializationFailureReceipt(command, {
-    ok: false,
-    code: "task_complete_auto_materialization_incomplete",
-    hint: `Task document publication failed to materialize every file after retry. Run \`ha doc status --json\`, repair the named file, then run \`ha doc sync --submit\`. ${failureHint(files)}`,
-    files
-  });
-}
-
-function materializationFailureReceipt(
-  command: string,
-  failure: Extract<TaskCompleteAutoMaterializationResult, { readonly ok: false }>
-): CommandReceiptEnvelope {
-  return {
-    ok: false,
-    schema: "command-receipt/v2",
-    command,
-    action: "run",
-    summary: failure.hint,
-    error: { code: failure.code, hint: failure.hint },
-    details: {
-      data: {
-        schema: "task-complete-auto-materialization-failure/v1",
-        files: failure.files
-      }
-    },
-    meta: {
-      generatedAt: new Date().toISOString(),
-      compatibility: { legacyReceipt: "CommandReceipt/v1" }
-    }
-  };
-}
-
-function failureHint(files: ReadonlyArray<TaskCompletePrepublishFailure & { readonly fix: string }>): string {
-  return `Task completion could not automatically materialize its document package. ${files.map((entry) =>
-    `file=${entry.path}; reason=${entry.reason}; fix=${entry.fix}`
-  ).join(" | ")}`;
-}
-
-function docSyncFix(): string {
-  return "Run `ha doc status --json`, repair the named file, then run `ha doc sync --submit` and retry task completion.";
-}
-
 function portable(value: string): string {
   return value.split(path.sep).join("/");
-}
-
-function waitBeforeTaskCompleteSettlementPoll(milliseconds: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, milliseconds));
-}
-
-function taskCompleteErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/daemon/src/service/task-complete-auto-materialization.ts
+++ b/packages/daemon/src/service/task-complete-auto-materialization.ts
@@ -1,0 +1,485 @@
+import path from "node:path";
+import type {
+  AuthorityHostAttribution,
+  CommandReceiptEnvelope,
+  DaemonDocSyncHostServices,
+  DaemonHostCommand,
+  DocSyncSubmitRequestV1,
+  DocSyncSubmitResultV1,
+  TaskHolderExecutor
+} from "@harness-anything/application";
+import {
+  resolveHarnessLayout,
+  taskPackagePath,
+  type CurrentSessionRef,
+  type HarnessLayoutOverrides
+} from "@harness-anything/kernel";
+import type { AuthenticatedActor } from "../identity/types.ts";
+import type { AuthorityConnectionDispatch } from "../protocol/connection-context.ts";
+import type { DocSyncServiceContext } from "../protocol/doc-sync-service-context.ts";
+import type { RepoWriteOperationLookupResult } from "../runtime/repo-write-protocol.ts";
+import type { HarnessDaemonRuntime } from "../runtime/repo-runtime.ts";
+import type { RepoWriteProcessSupervisor } from "../runtime/repo-write-process-supervisor.ts";
+import {
+  buildDocSyncReport,
+  buildDocSyncSubmitRequest
+} from "./doc-sync-service.ts";
+import { makeDocSyncSubmitHandler } from "./doc-sync-submit-handler.ts";
+
+const settlementPollIntervalMs = 25;
+const settlementPollLimit = 200;
+
+export interface TaskCompletePrepublishFailure {
+  readonly path: string;
+  readonly reason: string;
+}
+
+export type TaskCompleteAutoMaterializationResult =
+  | { readonly ok: true; readonly paths: ReadonlyArray<string> }
+  | {
+      readonly ok: false;
+      readonly code: string;
+      readonly hint: string;
+      readonly files: ReadonlyArray<TaskCompletePrepublishFailure & { readonly fix: string }>;
+    };
+
+export type TaskCompleteAutoMaterializer = (input: {
+  readonly taskId: string;
+  readonly currentSession: CurrentSessionRef;
+  readonly actor: AuthenticatedActor;
+  readonly executor: TaskHolderExecutor | null;
+  readonly authorityConnection: Extract<AuthorityConnectionDispatch, { readonly available: true }>;
+  readonly prepublishFailures: ReadonlyArray<TaskCompletePrepublishFailure>;
+}) => Promise<TaskCompleteAutoMaterializationResult>;
+
+export async function dispatchTaskCompleteWithAutoMaterialization(input: {
+  readonly command: DaemonHostCommand;
+  readonly currentSession: CurrentSessionRef;
+  readonly actor: AuthenticatedActor;
+  readonly executor: TaskHolderExecutor | null;
+  readonly authorityConnection: Extract<AuthorityConnectionDispatch, { readonly available: true }>;
+  readonly autoMaterialize?: TaskCompleteAutoMaterializer;
+  readonly dispatch: () => Promise<CommandReceiptEnvelope>;
+}): Promise<CommandReceiptEnvelope> {
+  const taskId = taskCompleteTaskId(input.command);
+  const enabled = input.command.action.kind === "task-complete"
+    && input.command.action.dryRun !== true
+    && input.autoMaterialize !== undefined
+    && taskId !== undefined;
+  const materializeAndRetry = async (
+    prepublishFailures: ReadonlyArray<TaskCompletePrepublishFailure>
+  ): Promise<CommandReceiptEnvelope> => {
+    const materialized = await runAutoMaterializer(input, taskId!, prepublishFailures);
+    if (!materialized.ok) return materializationFailureReceipt(input.command.action.kind, materialized);
+    input.authorityConnection.assertActive();
+    try {
+      const retried = await input.dispatch();
+      if (!retried.ok) {
+        const remaining = taskCompletePrepublishFailures(retried);
+        if (remaining.length > 0) return incompleteMaterializationFailure(input.command.action.kind, remaining);
+      }
+      return retried;
+    } catch (error) {
+      const remaining = taskCompletePrepublishFailuresFromText(taskCompleteErrorMessage(error));
+      if (remaining.length > 0) return incompleteMaterializationFailure(input.command.action.kind, remaining);
+      throw error;
+    }
+  };
+  let receipt: CommandReceiptEnvelope;
+  try {
+    receipt = await input.dispatch();
+  } catch (error) {
+    const failures = enabled ? taskCompletePrepublishFailuresFromText(taskCompleteErrorMessage(error)) : [];
+    if (failures.length > 0) return materializeAndRetry(failures);
+    throw error;
+  }
+  if (!enabled || receipt.ok) return receipt;
+  const failures = taskCompletePrepublishFailures(receipt);
+  return failures.length > 0 ? materializeAndRetry(failures) : receipt;
+}
+
+export function makeTaskCompleteDocumentMaterializationServices(options: {
+  readonly rootDir: string;
+  readonly layoutOverrides?: HarnessLayoutOverrides;
+  readonly repoId: string;
+  readonly runtime: HarnessDaemonRuntime;
+  readonly hostServices: DaemonDocSyncHostServices;
+  readonly actorAttribution: (
+    actor: AuthenticatedActor,
+    executor: TaskHolderExecutor | null
+  ) => AuthorityHostAttribution;
+  readonly supervisor?: RepoWriteProcessSupervisor;
+}) {
+  const docSyncSubmit = makeDocSyncSubmitHandler({
+    rootDir: options.rootDir,
+    layoutOverrides: options.layoutOverrides,
+    runtime: options.runtime,
+    hostServices: options.hostServices,
+    actorAttribution: options.actorAttribution,
+    ...(options.supervisor ? { supervisor: options.supervisor } : {})
+  });
+  const supervisor = options.supervisor;
+  return {
+    docSyncSubmit,
+    ...(supervisor ? {
+      autoMaterializeTaskComplete: makeTaskCompleteAutoMaterializer({
+        rootDir: options.rootDir,
+        layoutOverrides: options.layoutOverrides,
+        repoId: options.repoId,
+        hostServices: options.hostServices,
+        submit: docSyncSubmit,
+        lookup: (receiptId) => supervisor.lookup(receiptId)
+      })
+    } : {})
+  };
+}
+
+async function runAutoMaterializer(
+  input: Parameters<typeof dispatchTaskCompleteWithAutoMaterialization>[0],
+  taskId: string,
+  failures: ReadonlyArray<TaskCompletePrepublishFailure>
+): Promise<TaskCompleteAutoMaterializationResult> {
+  try {
+    return await input.autoMaterialize!({
+      taskId,
+      currentSession: input.currentSession,
+      actor: input.actor,
+      executor: input.executor,
+      authorityConnection: input.authorityConnection,
+      prepublishFailures: failures
+    });
+  } catch (error) {
+    const fix = docSyncFix();
+    const files = failures.map((entry) => ({ ...entry, reason: taskCompleteErrorMessage(error), fix }));
+    return {
+      ok: false,
+      code: "task_complete_auto_materialization_failed",
+      hint: `Automatic task document publication failed. Run \`ha doc status --json\`, repair the named file, then run \`ha doc sync --submit\`. ${failureHint(files)}`,
+      files
+    };
+  }
+}
+
+export function makeTaskCompleteAutoMaterializer(options: {
+  readonly rootDir: string;
+  readonly layoutOverrides?: HarnessLayoutOverrides;
+  readonly repoId: string;
+  readonly hostServices: DaemonDocSyncHostServices;
+  readonly submit: (
+    request: DocSyncSubmitRequestV1,
+    context?: DocSyncServiceContext
+  ) => Promise<DocSyncSubmitResultV1>;
+  readonly lookup?: (receiptId: string) => Promise<RepoWriteOperationLookupResult>;
+}): TaskCompleteAutoMaterializer {
+  const rootInput = options.layoutOverrides
+    ? { rootDir: options.rootDir, layoutOverrides: options.layoutOverrides }
+    : { rootDir: options.rootDir };
+  return async (input) => {
+    const layout = resolveHarnessLayout(rootInput);
+    const packageRoot = portable(path.relative(
+      layout.authoredRoot,
+      taskPackagePath(rootInput, input.taskId as import("@harness-anything/kernel").TaskId)
+    ));
+    const requested = new Map(input.prepublishFailures.map((entry) => [entry.path, entry]));
+    let report: ReturnType<typeof buildDocSyncReport>;
+    try {
+      report = buildDocSyncReport(rootInput, options.hostServices);
+    } catch (error) {
+      return taskCompleteMaterializationFailure(
+        "task_complete_auto_materialization_preflight_failed",
+        input.prepublishFailures,
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+    const selectedPaths = report.dirtyFiles
+      .map((entry) => entry.path)
+      .filter((entryPath) => requested.has(entryPath)
+        && (entryPath === packageRoot || entryPath.startsWith(`${packageRoot}/`)));
+    if (selectedPaths.length === 0) {
+      return taskCompleteMaterializationFailure(
+        "task_complete_auto_materialization_no_candidate",
+        input.prepublishFailures,
+        "doc sync found no eligible dirty change for the prepublish path"
+      );
+    }
+    const artifactRoot = `${packageRoot}/artifacts/`;
+    const groups: ReadonlyArray<{
+      readonly intent: DocSyncSubmitRequestV1["payload"]["declaredIntent"];
+      readonly paths: ReadonlyArray<string>;
+    }> = [
+      { intent: "manual-artifact", paths: selectedPaths.filter((entry) => entry.startsWith(artifactRoot)) },
+      { intent: "prose-edit", paths: selectedPaths.filter((entry) => !entry.startsWith(artifactRoot)) }
+    ];
+    const appliedPaths: string[] = [];
+    for (const group of groups) {
+      if (group.paths.length === 0) continue;
+      const submitted = await submitMaterializationGroup(options, input, rootInput, group);
+      if (!submitted.ok) return submitted.failure;
+      appliedPaths.push(...submitted.paths);
+    }
+    return { ok: true, paths: appliedPaths };
+  };
+}
+
+async function submitMaterializationGroup(
+  options: Parameters<typeof makeTaskCompleteAutoMaterializer>[0],
+  input: Parameters<TaskCompleteAutoMaterializer>[0],
+  rootInput: { readonly rootDir: string; readonly layoutOverrides?: HarnessLayoutOverrides },
+  group: {
+    readonly intent: DocSyncSubmitRequestV1["payload"]["declaredIntent"];
+    readonly paths: ReadonlyArray<string>;
+  }
+): Promise<
+  | { readonly ok: true; readonly paths: ReadonlyArray<string> }
+  | { readonly ok: false; readonly failure: TaskCompleteAutoMaterializationResult }
+> {
+  let request: DocSyncSubmitRequestV1;
+  try {
+    const docSyncRequest = buildDocSyncSubmitRequest(
+      rootInput,
+      options.repoId,
+      group.paths,
+      input.executor,
+      options.hostServices,
+      input.currentSession
+    );
+    request = group.intent === docSyncRequest.payload.declaredIntent
+      ? docSyncRequest
+      : { ...docSyncRequest, payload: { ...docSyncRequest.payload, declaredIntent: group.intent } };
+  } catch (error) {
+    return {
+      ok: false,
+      failure: taskCompleteMaterializationFailure(
+        "task_complete_auto_materialization_preflight_failed",
+        selectedFailures(input.prepublishFailures, group.paths),
+        taskCompleteErrorMessage(error)
+      )
+    };
+  }
+  let result: DocSyncSubmitResultV1;
+  try {
+    result = await options.submit(request, {
+      actor: input.actor,
+      executor: input.executor,
+      authorityConnection: input.authorityConnection
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      failure: taskCompleteMaterializationFailure(
+        "task_complete_auto_materialization_submit_failed",
+        selectedFailures(input.prepublishFailures, group.paths),
+        taskCompleteErrorMessage(error)
+      )
+    };
+  }
+  if (!result.ok) {
+    return { ok: false, failure: rejectedResultFailure(result, input.prepublishFailures, group.paths) };
+  }
+  const settlement = await waitForCanonicalSettlement(result, options.lookup);
+  if (!settlement.settled) {
+    return {
+      ok: false,
+      failure: taskCompleteMaterializationFailure(
+        settlement.code,
+        selectedFailures(input.prepublishFailures, group.paths),
+        settlement.reason,
+        settlement.fix
+      )
+    };
+  }
+  return { ok: true, paths: result.appliedChanges.map((entry) => entry.path) };
+}
+
+async function waitForCanonicalSettlement(
+  result: Extract<DocSyncSubmitResultV1, { readonly ok: true }>,
+  lookup: ((receiptId: string) => Promise<RepoWriteOperationLookupResult>) | undefined
+): Promise<
+  | { readonly settled: true }
+  | { readonly settled: false; readonly code: string; readonly reason: string; readonly fix: string }
+> {
+  const settlement = result.settlement;
+  if (result.settlementMode === "synchronous-canonical-final/v1"
+    || settlement?.canonicalVisibility === "visible") return { settled: true };
+  if (settlement?.canonicalVisibility === "failed") {
+    return {
+      settled: false,
+      code: "task_complete_auto_materialization_settlement_failed",
+      reason: `${settlement.failure.code}: ${settlement.failure.message}`,
+      fix: `Run \`${settlement.statusQuery.command}\` and follow the reported recovery guidance before retrying task completion.`
+    };
+  }
+  if (!settlement || !lookup) {
+    return {
+      settled: false,
+      code: "task_complete_auto_materialization_settlement_unavailable",
+      reason: "doc sync returned no proof of canonical settlement",
+      fix: docSyncFix()
+    };
+  }
+  let state = "accepted";
+  for (let attempt = 0; attempt < settlementPollLimit; attempt += 1) {
+    const observed = await lookup(settlement.receiptId);
+    state = observed.state;
+    if (observed.state === "committed") return { settled: true };
+    if (observed.state === "rejected" || observed.state === "settlement-failed"
+      || observed.state === "failed" || observed.state === "unknown") {
+      return {
+        settled: false,
+        code: "task_complete_auto_materialization_settlement_failed",
+        reason: `doc sync settlement ended in ${observed.state}`,
+        fix: `Run \`${settlement.statusQuery.command}\` and repair the reported settlement before retrying task completion.`
+      };
+    }
+    await waitBeforeTaskCompleteSettlementPoll(settlementPollIntervalMs);
+  }
+  return {
+    settled: false,
+    code: "task_complete_auto_materialization_settlement_pending",
+    reason: `doc sync settlement remained ${state} after ${settlementPollIntervalMs * settlementPollLimit}ms`,
+    fix: `Run \`${settlement.statusQuery.command}\` and wait for canonical visibility before retrying task completion.`
+  };
+}
+
+function rejectedResultFailure(
+  result: Exclude<DocSyncSubmitResultV1, { readonly ok: true }>,
+  prepublishFailures: ReadonlyArray<TaskCompletePrepublishFailure>,
+  selectedPaths: ReadonlyArray<string>
+): TaskCompleteAutoMaterializationResult {
+  const diagnostics = "conflicts" in result
+    ? [
+        ...(result.conflicts ?? []).map((entry) => ({ path: entry.path, reason: `${entry.code}: ${entry.message}` })),
+        ...(result.unresolvedTouches ?? []).map((entry) => ({ path: entry.path, reason: entry.reason })),
+        ...(result.forbiddenTouches ?? []).map((entry) => ({
+          path: entry.path,
+          reason: entry.hunks.map((hunk) => hunk.summary).join("; ") || result.reason
+        }))
+      ]
+    : [];
+  const files = selectedFailures(prepublishFailures, selectedPaths).map((entry) => ({
+    ...entry,
+    reason: diagnostics.find((diagnostic) => diagnostic.path === entry.path)?.reason ?? result.reason
+  }));
+  const fix = "outcomeUnknown" in result && result.outcomeUnknown
+    ? `Run \`${result.outcomeUnknown.statusCommand}\` and resolve the reported write outcome before retrying task completion.`
+    : docSyncFix();
+  return taskCompleteMaterializationFailure(
+    `task_complete_auto_materialization_${result.code}`,
+    files,
+    result.reason,
+    fix,
+    true
+  );
+}
+
+function selectedFailures(
+  failures: ReadonlyArray<TaskCompletePrepublishFailure>,
+  selectedPaths: ReadonlyArray<string>
+): ReadonlyArray<TaskCompletePrepublishFailure> {
+  const selected = new Set(selectedPaths);
+  return failures.filter((entry) => selected.has(entry.path));
+}
+
+function taskCompleteMaterializationFailure(
+  code: string,
+  files: ReadonlyArray<TaskCompletePrepublishFailure>,
+  reason: string,
+  fix = docSyncFix(),
+  preserveFileReasons = false
+): Extract<TaskCompleteAutoMaterializationResult, { readonly ok: false }> {
+  const detailed = files.map((entry) => ({
+    ...entry,
+    reason: preserveFileReasons ? entry.reason : reason,
+    fix
+  }));
+  return {
+    ok: false,
+    code,
+    hint: failureHint(detailed),
+    files: detailed
+  };
+}
+
+function taskCompleteTaskId(command: DaemonHostCommand): string | undefined {
+  const action = command.action as DaemonHostCommand["action"] & { readonly taskId?: unknown };
+  return typeof action.taskId === "string" && action.taskId ? action.taskId : undefined;
+}
+
+function taskCompletePrepublishFailures(receipt: CommandReceiptEnvelope): ReadonlyArray<TaskCompletePrepublishFailure> {
+  if (receipt.ok) return [];
+  return taskCompletePrepublishFailuresFromText(`${receipt.summary}\n${receipt.error?.hint ?? ""}`);
+}
+
+function taskCompletePrepublishFailuresFromText(text: string): ReadonlyArray<TaskCompletePrepublishFailure> {
+  if (!text.includes("AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:")) return [];
+  const failures: TaskCompletePrepublishFailure[] = [];
+  const pattern = /(tasks\/[^(,\n]+?) \(([^)]+)\)/gu;
+  for (const match of text.matchAll(pattern)) {
+    const pathValue = match[1]?.trim();
+    const reason = match[2]?.trim();
+    if (pathValue && reason && !failures.some((entry) => entry.path === pathValue)) {
+      failures.push({ path: pathValue, reason });
+    }
+  }
+  return failures;
+}
+
+function incompleteMaterializationFailure(
+  command: string,
+  remaining: ReadonlyArray<TaskCompletePrepublishFailure>
+): CommandReceiptEnvelope {
+  const fix = docSyncFix();
+  const files = remaining.map((entry) => ({ ...entry, fix }));
+  return materializationFailureReceipt(command, {
+    ok: false,
+    code: "task_complete_auto_materialization_incomplete",
+    hint: `Task document publication failed to materialize every file after retry. Run \`ha doc status --json\`, repair the named file, then run \`ha doc sync --submit\`. ${failureHint(files)}`,
+    files
+  });
+}
+
+function materializationFailureReceipt(
+  command: string,
+  failure: Extract<TaskCompleteAutoMaterializationResult, { readonly ok: false }>
+): CommandReceiptEnvelope {
+  return {
+    ok: false,
+    schema: "command-receipt/v2",
+    command,
+    action: "run",
+    summary: failure.hint,
+    error: { code: failure.code, hint: failure.hint },
+    details: {
+      data: {
+        schema: "task-complete-auto-materialization-failure/v1",
+        files: failure.files
+      }
+    },
+    meta: {
+      generatedAt: new Date().toISOString(),
+      compatibility: { legacyReceipt: "CommandReceipt/v1" }
+    }
+  };
+}
+
+function failureHint(files: ReadonlyArray<TaskCompletePrepublishFailure & { readonly fix: string }>): string {
+  return `Task completion could not automatically materialize its document package. ${files.map((entry) =>
+    `file=${entry.path}; reason=${entry.reason}; fix=${entry.fix}`
+  ).join(" | ")}`;
+}
+
+function docSyncFix(): string {
+  return "Run `ha doc status --json`, repair the named file, then run `ha doc sync --submit` and retry task completion.";
+}
+
+function portable(value: string): string {
+  return value.split(path.sep).join("/");
+}
+
+function waitBeforeTaskCompleteSettlementPoll(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function taskCompleteErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/daemon/test/authority-submission-error.test.ts
+++ b/packages/daemon/test/authority-submission-error.test.ts
@@ -22,6 +22,9 @@ import {
 import {
   productionAuthorityCommandHasPurePlan
 } from "../src/authority/production/production-authority-pure-command-plan.ts";
+import {
+  TaskCompletePrepublishNotMaterializedError
+} from "../src/authority/production/task-complete-prepublish-publication.ts";
 import type {
   ProductionAuthorityCommandPlanInput,
   ProductionCanonicalAttemptCompilerV2
@@ -70,6 +73,17 @@ test("task-plan publication rejection keeps its stable public code and repair co
 
   assert.equal(error.code, "task_plan_placeholder");
   assert.equal(error.message, reason);
+});
+
+test("task-complete prepublish rejection preserves typed file details through compile rejection", () => {
+  const source = new TaskCompletePrepublishNotMaterializedError([{
+    path: "work-items/task_01ABC/artifacts/proof, (final).md",
+    reason: "missing from HEAD"
+  }]);
+  const error = authorityCompileRejected(source);
+
+  assert.equal(error.code, "task_complete_prepublish_not_materialized");
+  assert.deepEqual(error.details, source.details);
 });
 
 test("return-to-idea publication rejection keeps its stable public code and cleanup commands", () => {

--- a/packages/daemon/test/doc-sync-durable-recovery-operation.test.ts
+++ b/packages/daemon/test/doc-sync-durable-recovery-operation.test.ts
@@ -127,6 +127,7 @@ function docSyncAcceptedExecution(): RepoWriteDocSyncExecution {
     durable: {
       sessionId: "session-doc-sync-recovery",
       acceptedCommitSha: "b".repeat(40),
+      previousCommitSha: "a".repeat(40),
       flush: {
         reason: "explicit",
         opCount: 1,

--- a/packages/daemon/test/repo-write-durable-operation-controller.test.ts
+++ b/packages/daemon/test/repo-write-durable-operation-controller.test.ts
@@ -9,6 +9,7 @@ import {
   ReceiptSettlementStore,
   RepoWriteDurableOperationController,
   repoWriteActorStampDigestV1,
+  type RepoWriteCanonicalPublicationEvidenceV1,
   type RepoWriteProceedingInputV1,
   type RepoWriteTerminalEvidenceV1
 } from "../src/index.ts";
@@ -241,6 +242,77 @@ controllerTest("visible sidecar publish failure does not overwrite a terminal ca
   }
 });
 
+controllerTest("doc-sync live settlement owns terminalization regardless of recovery interleaving", async () => {
+  const terminalByOrder = await Promise.all([
+    docSyncSettlementInterleaving("live-first"),
+    docSyncSettlementInterleaving("recovery-first")
+  ]);
+
+  assert.deepEqual(terminalByOrder[0], terminalByOrder[1]);
+  assert.equal(terminalByOrder[0].outcome.phase, "TERMINAL");
+  assert.equal(terminalByOrder[0].settlement.state, "canonical-visible");
+  assert.equal(
+    terminalByOrder[0].outcome.phase === "TERMINAL"
+      ? terminalByOrder[0].outcome.terminalProof.evidence.tag
+      : undefined,
+    "CANONICAL_PUBLICATION"
+  );
+});
+
+controllerTest("invalid doc-sync proof remains failed and ancestry recovery cannot wash it visible", async () => {
+  await withController(async ({ controller, proceeding, options }) => {
+    const prepared = controller.prepare({
+      proceeding: {
+        ...proceeding,
+        recoveryContext: {
+          schema: "repo-write-doc-sync-recovery/v1",
+          intentId: "intent-invalid-proof",
+          baseLedgerSha: "9".repeat(40)
+        }
+      },
+      executeFresh: async () => ({
+        kind: "accepted" as const,
+        receipt: committedCommandReceipt(),
+        acceptance: {
+          sessionId: "session-invalid-proof",
+          acceptedCommitSha: "b".repeat(40),
+          flush: {
+            reason: "explicit",
+            opCount: 1,
+            committed: true,
+            watermark: proceeding.innerOpId
+          }
+        },
+        acceptedCommitSha: "b".repeat(40),
+        settlement: Promise.resolve({
+          ...canonicalPublicationEvidence(proceeding),
+          canonicalAncestry: {
+            ...canonicalPublicationEvidence(proceeding).canonicalAncestry,
+            acceptedCommitSha: "d".repeat(40)
+          }
+        })
+      })
+    });
+
+    await prepared.execute();
+    await controller.settlementIdle();
+    assert.equal(options.settlements.lookup(proceeding.outerOpId)?.state, "failed");
+    assert.equal(
+      options.settlements.lookup(proceeding.outerOpId)?.receipt.settlement?.canonicalVisibility === "failed"
+        ? options.settlements.lookup(proceeding.outerOpId)?.receipt.settlement?.failure.retryable
+        : undefined,
+      false
+    );
+
+    assert.equal(await controller.recoverCanonicalPublicationSettlement({
+      outerOpId: proceeding.outerOpId,
+      canonicalCommitSha: "c".repeat(40)
+    }), "blocked");
+    assert.equal(options.store.lookup(proceeding.outerOpId).state, "proceeding");
+    assert.equal(options.settlements.lookup(proceeding.outerOpId)?.state, "failed");
+  });
+});
+
 controllerTest("replacement recovery completes an earlier PROCEEDING before a later append", async () => {
   const directory = mkdtempSync(path.join(os.tmpdir(), "ha-repo-write-order-"));
   const store = new DurableRepoWriteOutcomeStoreV1({
@@ -337,6 +409,75 @@ async function withController(
   });
   try {
     await run({ directory, events, proceeding, options: { store, settlements }, controller });
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+async function docSyncSettlementInterleaving(order: "live-first" | "recovery-first") {
+  const directory = mkdtempSync(path.join(os.tmpdir(), `ha-doc-sync-${order}-`));
+  const store = new DurableRepoWriteOutcomeStoreV1({ directory, ...axes() });
+  const settlements = settlementStore(directory);
+  const proceeding = {
+    ...proceedingInput(),
+    recoveryContext: {
+      schema: "repo-write-doc-sync-recovery/v1",
+      intentId: "intent-controller",
+      baseLedgerSha: "9".repeat(40)
+    }
+  };
+  let settle!: (evidence: RepoWriteTerminalEvidenceV1) => void;
+  const settlement = new Promise<RepoWriteTerminalEvidenceV1>((resolve) => {
+    settle = resolve;
+  });
+  const controller = new RepoWriteDurableOperationController({
+    ...axes(),
+    store,
+    settlements,
+    now: () => new Date("2026-08-10T10:00:00.000Z"),
+    recover: async () => assert.fail("authority recovery should not run")
+  });
+  try {
+    const prepared = controller.prepare({
+      proceeding,
+      executeFresh: async () => ({
+        kind: "accepted" as const,
+        receipt: committedCommandReceipt(),
+        acceptance: {
+          sessionId: "session-doc-sync",
+          acceptedCommitSha: "b".repeat(40),
+          flush: {
+            reason: "explicit",
+            opCount: 1,
+            committed: true,
+            watermark: proceeding.innerOpId
+          }
+        },
+        acceptedCommitSha: "b".repeat(40),
+        settlement
+      })
+    });
+    await prepared.execute();
+    const recover = () => controller.recoverCanonicalPublicationSettlement({
+      outerOpId: proceeding.outerOpId,
+      canonicalCommitSha: "c".repeat(40)
+    });
+    if (order === "recovery-first") {
+      const recovery = recover();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      settle(canonicalPublicationEvidence(proceeding));
+      await recovery;
+    } else {
+      settle(canonicalPublicationEvidence(proceeding));
+      await controller.settlementIdle();
+      await recover();
+    }
+    await controller.settlementIdle();
+    const outcome = store.get(proceeding.outerOpId);
+    const receiptSettlement = settlements.lookup(proceeding.outerOpId);
+    assert.ok(outcome);
+    assert.ok(receiptSettlement);
+    return { outcome, settlement: receiptSettlement };
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
@@ -445,6 +586,26 @@ function terminalEvidence(
       changeSetDigest: "5".repeat(64),
       semanticMutationSetDigest: "2".repeat(64),
       actorAxesBindingDigest: "3".repeat(64)
+    }
+  };
+}
+
+function canonicalPublicationEvidence(
+  proceeding: RepoWriteProceedingInputV1
+): RepoWriteCanonicalPublicationEvidenceV1 {
+  return {
+    schema: "repo-write-canonical-publication-evidence/v1",
+    tag: "CANONICAL_PUBLICATION",
+    workspaceId: proceeding.workspaceId,
+    opId: proceeding.innerOpId,
+    semanticDigest: proceeding.authoritySemanticDigest,
+    revision: 0,
+    commitSha: "c".repeat(40),
+    previousCommit: "9".repeat(40),
+    canonicalAncestry: {
+      schema: "repo-write-canonical-ancestry-anchor/v1",
+      acceptedCommitSha: "b".repeat(40),
+      canonicalCommitSha: "c".repeat(40)
     }
   };
 }

--- a/packages/daemon/test/repo-write-outcome-store.test.ts
+++ b/packages/daemon/test/repo-write-outcome-store.test.ts
@@ -166,6 +166,44 @@ outcomeTest("TERMINAL committed receipt survives restart byte-for-byte and canno
   });
 });
 
+outcomeTest("TERMINAL accepts a strict canonical-publication proof without authority integrity", () => {
+  withStore(({ options, store }) => {
+    const input = proceedingInput("outer-canonical-publication");
+    const proceeding = store.begin(input);
+    const evidence = canonicalPublicationEvidence(input);
+    const terminal = store.terminalize({
+      ...axes(),
+      outerOpId: input.outerOpId,
+      requestDigest: proceeding.requestDigest,
+      receipt: successReceipt(),
+      authorityEvidence: evidence
+    });
+
+    assert.equal(terminal.terminalKind, "committed");
+    assert.deepEqual(terminal.terminalProof.evidence, evidence);
+    assert.deepEqual(new DurableRepoWriteOutcomeStoreV1(options).get(input.outerOpId), terminal);
+  });
+
+  withStore(({ store }) => {
+    const input = proceedingInput("outer-invalid-canonical-publication");
+    const proceeding = store.begin(input);
+    const evidence = canonicalPublicationEvidence(input);
+    assert.throws(() => store.terminalize({
+      ...axes(),
+      outerOpId: input.outerOpId,
+      requestDigest: proceeding.requestDigest,
+      receipt: successReceipt(),
+      authorityEvidence: {
+        ...evidence,
+        canonicalAncestry: {
+          ...evidence.canonicalAncestry,
+          canonicalCommitSha: "d".repeat(40)
+        }
+      }
+    }), /exact equality with commitSha/u);
+  });
+});
+
 outcomeTest("TERMINAL preserves an exact rejected command-receipt/v2", () => {
   withStore(({ options, store }) => {
     const input = proceedingInput("outer-rejected");
@@ -530,3 +568,23 @@ outcomeTest("receipt arrays and aggregate JSON bytes are bounded before persiste
     assert.deepEqual(files(directory, "terminal"), []);
   });
 });
+
+function canonicalPublicationEvidence(
+  input: ReturnType<typeof proceedingInput>
+) {
+  return {
+    schema: "repo-write-canonical-publication-evidence/v1" as const,
+    tag: "CANONICAL_PUBLICATION" as const,
+    workspaceId: input.workspaceId,
+    opId: input.innerOpId,
+    semanticDigest: input.authoritySemanticDigest,
+    revision: 0,
+    commitSha: "c".repeat(40),
+    previousCommit: "a".repeat(40),
+    canonicalAncestry: {
+      schema: "repo-write-canonical-ancestry-anchor/v1" as const,
+      acceptedCommitSha: "b".repeat(40),
+      canonicalCommitSha: "c".repeat(40)
+    }
+  };
+}

--- a/packages/daemon/test/task-complete-auto-materialization.test.ts
+++ b/packages/daemon/test/task-complete-auto-materialization.test.ts
@@ -1,0 +1,452 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  CommandReceiptEnvelope,
+  DaemonHostCommand,
+  DocSyncSubmitResultV1
+} from "@harness-anything/application";
+import { sha256Text } from "@harness-anything/kernel";
+import type { RepoWriteJsonObject } from "../src/runtime/repo-write-protocol.ts";
+import {
+  defaultTaskCompleteSettlementTimeoutMs,
+  dispatchTaskCompleteWithAutoMaterialization,
+  verifyTaskCompleteMaterializationSnapshot,
+  waitForTaskCompleteCanonicalSettlement
+} from "../src/service/task-complete-auto-materialization.ts";
+
+test("task-complete settlement state machine uses the 20s class with bounded backoff", async () => {
+  let now = 0;
+  const delays: number[] = [];
+  const result = await waitForTaskCompleteCanonicalSettlement(
+    pendingDocSyncResult(),
+    async () => ({ state: "accepted", receipt: {} }),
+    {
+      timeoutMs: 100,
+      now: () => now,
+      sleep: async (milliseconds) => {
+        delays.push(milliseconds);
+        now += milliseconds;
+      }
+    }
+  );
+
+  assert.equal(defaultTaskCompleteSettlementTimeoutMs, 20_000);
+  assert.equal(result.settled, false);
+  if (result.settled) return;
+  assert.equal(result.code, "task_complete_auto_materialization_settlement_pending");
+  assert.equal(result.receiptId, "repo-write:pending");
+  assert.equal(result.statusCommand, "ha receipt status repo-write:pending --json");
+  assert.deepEqual(result.recoveryArgv, ["ha", "receipt", "status", "repo-write:pending", "--json"]);
+  assert.match(result.fix, /Do not resubmit/u);
+  assert.ok(delays.length > 1, JSON.stringify(delays));
+  assert.deepEqual(delays, [25, 50, 25]);
+  assert.equal(delays.reduce((total, delay) => total + delay, 0), 100);
+});
+
+test("task-complete settlement lookup failure preserves the known recovery handle", async () => {
+  const result = await waitForTaskCompleteCanonicalSettlement(
+    pendingDocSyncResult(),
+    async () => { throw new Error("writer lookup connection closed"); }
+  );
+
+  assert.equal(result.settled, false);
+  if (result.settled) return;
+  assert.equal(result.code, "task_complete_auto_materialization_settlement_lookup_failed");
+  assert.equal(result.reason, "Settlement lookup failed: writer lookup connection closed");
+  assert.equal(result.receiptId, "repo-write:pending");
+  assert.equal(result.statusCommand, "ha receipt status repo-write:pending --json");
+  assert.deepEqual(result.recoveryArgv, ["ha", "receipt", "status", "repo-write:pending", "--json"]);
+  assert.match(result.fix, /Do not resubmit/u);
+});
+
+test("task-complete settlement failure reports the writer root cause", async () => {
+  const result = await waitForTaskCompleteCanonicalSettlement(
+    pendingDocSyncResult(),
+    async () => ({ state: "settlement-failed", receipt: failedSettlementReceipt() })
+  );
+
+  assert.equal(result.settled, false);
+  if (result.settled) return;
+  assert.equal(result.code, "task_complete_auto_materialization_settlement_failed");
+  assert.equal(result.reason, "MATERIALIZER_APPLY_FAILED: canonical merge conflict");
+  assert.equal(result.receiptId, "repo-write:pending");
+  assert.equal(result.statusCommand, "ha receipt status repo-write:pending --json");
+  assert.deepEqual(result.recoveryArgv, ["ha", "receipt", "status", "repo-write:pending", "--json"]);
+});
+
+test("task-complete revalidates after obtaining the automatic materialization flight", async () => {
+  const target = "work-items/task_01ABC/artifacts/proof, (final).md";
+  const receipts = [prepublishReceipt([{ path: target, reason: "missing from HEAD" }]), successReceipt()];
+  let materializeCalls = 0;
+
+  const result = await dispatchTaskCompleteWithAutoMaterialization({
+    ...dispatchContext(),
+    repoId: "repo-single-flight",
+    autoMaterialize: async () => {
+      materializeCalls += 1;
+      return { ok: true, paths: [target] };
+    },
+    dispatch: async () => receipts.shift() ?? successReceipt()
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(materializeCalls, 0);
+  assert.equal(receipts.length, 0);
+});
+
+test("task-complete revalidates a no-candidate result before failing", async () => {
+  const target = "work-items/task_01ABC/closeout.md";
+  const failure = prepublishReceipt([{ path: target, reason: "content differs from expected" }]);
+  const receipts = [failure, failure, successReceipt()];
+
+  const result = await dispatchTaskCompleteWithAutoMaterialization({
+    ...dispatchContext(),
+    repoId: "repo-no-candidate",
+    autoMaterialize: async () => ({
+      ok: false,
+      code: "task_complete_auto_materialization_no_candidate",
+      hint: "no candidate",
+      files: []
+    }),
+    dispatch: async () => receipts.shift() ?? successReceipt()
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(receipts.length, 0);
+});
+
+test("task-complete failure receipt has exact per-file recovery argv", async () => {
+  const target = "work-items/task_01ABC/task plan (final).md";
+  const failure = prepublishReceipt([{ path: target, reason: "content differs from expected" }]);
+  const receipts = [failure, failure];
+
+  const result = await dispatchTaskCompleteWithAutoMaterialization({
+    ...dispatchContext(),
+    repoId: "repo-failure-schema",
+    autoMaterialize: async () => ({
+      ok: false,
+      code: "task_complete_auto_materialization_submit_failed",
+      hint: "rejected",
+      files: [{
+        path: target,
+        reason: "SEMANTIC_DIFF_REQUIRED: managed heading changed",
+        fix: `Run \`ha doc sync --submit --path '${target}'\`.`,
+        fixArgv: ["ha", "doc", "sync", "--submit", "--path", target]
+      }]
+    }),
+    dispatch: async () => receipts.shift() ?? failure
+  });
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.error?.code, "task_complete_auto_materialization_submit_failed");
+  assert.deepEqual(result.details?.data, {
+    schema: "task-complete-auto-materialization-failure/v1",
+    files: [{
+      path: target,
+      reason: "SEMANTIC_DIFF_REQUIRED: managed heading changed",
+      fix: `Run \`ha doc sync --submit --path '${target}'\`.`,
+      fixArgv: ["ha", "doc", "sync", "--submit", "--path", target]
+    }]
+  });
+});
+
+test("task-complete reports malformed structured prepublish details explicitly", async () => {
+  const malformed = prepublishReceipt([], { schema: "wrong/v1", code: "wrong", files: "not-an-array" });
+  const receipts = [malformed, malformed];
+  let materializeCalls = 0;
+
+  const result = await dispatchTaskCompleteWithAutoMaterialization({
+    ...dispatchContext(),
+    repoId: "repo-malformed-prepublish",
+    autoMaterialize: async () => {
+      materializeCalls += 1;
+      return { ok: true, paths: [] };
+    },
+    dispatch: async () => receipts.shift() ?? malformed
+  });
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(materializeCalls, 0);
+  assert.equal(result.error?.code, "task_complete_auto_materialization_prepublish_details_invalid");
+  assert.equal(result.details?.data?.schema, "task-complete-auto-materialization-failure/v1");
+  assert.deepEqual(result.details?.data?.files, []);
+  assert.match(String(result.details?.data?.reason), /structured prepublish details/u);
+});
+
+test("task-complete rejects a working-tree body changed after candidate capture", () => {
+  const snapshot = [{
+    path: "work-items/task_01ABC/closeout.md",
+    baseBlobSha256: "base",
+    body: "caller A body\n",
+    bodySha256: sha256Text("caller A body\n"),
+    mediaType: "text/markdown",
+    size: 14,
+    pathClass: "doc-sync-allowed"
+  }];
+
+  assert.deepEqual(
+    verifyTaskCompleteMaterializationSnapshot(snapshot, () => "caller B body\n"),
+    {
+      path: "work-items/task_01ABC/closeout.md",
+      expectedBodySha256: sha256Text("caller A body\n"),
+      actualBodySha256: sha256Text("caller B body\n")
+    }
+  );
+});
+
+test("task-complete reports only the remaining files after partial materialization", async () => {
+  const artifact = "work-items/task_01ABC/artifacts/proof.md";
+  const prose = "work-items/task_01ABC/task plan (final).md";
+  const both = prepublishReceipt([
+    { path: artifact, reason: "missing from HEAD" },
+    { path: prose, reason: "content differs from expected" }
+  ]);
+  const remaining = prepublishReceipt([{ path: prose, reason: "content differs from expected" }]);
+  const receipts = [both, both, remaining];
+
+  const result = await dispatchTaskCompleteWithAutoMaterialization({
+    ...dispatchContext(),
+    repoId: "repo-partial",
+    autoMaterialize: async () => ({ ok: true, paths: [artifact] }),
+    dispatch: async () => receipts.shift() ?? remaining
+  });
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.error?.code, "task_complete_auto_materialization_incomplete");
+  const data = result.details?.data as {
+    readonly schema?: unknown;
+    readonly files?: ReadonlyArray<Record<string, unknown>>;
+  };
+  assert.equal(data.schema, "task-complete-auto-materialization-failure/v1");
+  assert.equal(data.files?.length, 1);
+  assert.equal(data.files?.[0]?.path, prose);
+  assert.equal(data.files?.[0]?.reason, "content differs from expected");
+  assert.equal(
+    data.files?.[0]?.fix,
+    `Run \`ha doc sync --submit --path '${prose}'\` after repairing this file, then retry task completion.`
+  );
+  assert.deepEqual(data.files?.[0]?.fixArgv, ["ha", "doc", "sync", "--submit", "--path", prose]);
+});
+
+test("task-complete single-flight serializes materialization and lets the waiter revalidate", async () => {
+  const target = "work-items/task_01ABC/closeout.md";
+  const failure = prepublishReceipt([{ path: target, reason: "content differs from expected" }]);
+  const firstReceipts = [failure, failure, successReceipt()];
+  const secondReceipts = [failure, successReceipt()];
+  let releaseMaterializer!: () => void;
+  let announceMaterializer!: () => void;
+  const materializerStarted = new Promise<void>((resolve) => { announceMaterializer = resolve; });
+  const holdMaterializer = new Promise<void>((resolve) => { releaseMaterializer = resolve; });
+  let materializeCalls = 0;
+  const autoMaterialize = async () => {
+    materializeCalls += 1;
+    announceMaterializer();
+    await holdMaterializer;
+    return { ok: true as const, paths: [target] };
+  };
+
+  const first = dispatchTaskCompleteWithAutoMaterialization({
+    ...dispatchContext(),
+    repoId: "repo-concurrent",
+    autoMaterialize,
+    dispatch: async () => firstReceipts.shift() ?? successReceipt()
+  });
+  await materializerStarted;
+  const second = dispatchTaskCompleteWithAutoMaterialization({
+    ...dispatchContext(),
+    repoId: "repo-concurrent",
+    autoMaterialize,
+    dispatch: async () => secondReceipts.shift() ?? successReceipt()
+  });
+  releaseMaterializer();
+
+  const results = await Promise.all([first, second]);
+  assert.deepEqual(results.map((entry) => entry.ok), [true, true]);
+  assert.equal(materializeCalls, 1);
+  assert.equal(firstReceipts.length, 0);
+  assert.equal(secondReceipts.length, 0);
+});
+
+test("task-complete legacy text fallback accepts layout-derived paths with punctuation", async () => {
+  const target = "work-items/task_01ABC/artifacts/proof, (final).md";
+  const legacy = legacyPrepublishReceipt(target, "missing from HEAD");
+  const receipts = [legacy, legacy, successReceipt()];
+  let observed: ReadonlyArray<{ readonly path: string; readonly reason: string }> = [];
+
+  const result = await dispatchTaskCompleteWithAutoMaterialization({
+    ...dispatchContext(),
+    repoId: "repo-legacy-fallback",
+    autoMaterialize: async (input) => {
+      observed = input.prepublishFailures;
+      return {
+        ok: false,
+        code: "task_complete_auto_materialization_no_candidate",
+        hint: "already materialized",
+        files: []
+      };
+    },
+    dispatch: async () => receipts.shift() ?? successReceipt()
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(observed, [{ path: target, reason: "missing from HEAD" }]);
+});
+
+test("task-complete classifies an unexpected materializer exception as internal", async () => {
+  const target = "work-items/task_01ABC/closeout.md";
+  const failure = prepublishReceipt([{ path: target, reason: "content differs from expected" }]);
+  const receipts = [failure, failure];
+
+  const result = await dispatchTaskCompleteWithAutoMaterialization({
+    ...dispatchContext(),
+    repoId: "repo-internal-failure",
+    autoMaterialize: async () => { throw new Error("unexpected programmer defect"); },
+    dispatch: async () => receipts.shift() ?? failure
+  });
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.error?.code, "task_complete_auto_materialization_internal");
+  const data = result.details?.data as { readonly files?: ReadonlyArray<Record<string, unknown>> };
+  assert.equal(data.files?.[0]?.path, target);
+  assert.match(String(data.files?.[0]?.reason), /unexpected programmer defect/u);
+  assert.deepEqual(data.files?.[0]?.fixArgv, ["ha", "daemon", "logs", "--json"]);
+  assert.doesNotMatch(String(data.files?.[0]?.fix), /doc sync --submit/u);
+});
+
+function pendingDocSyncResult(): Extract<DocSyncSubmitResultV1, { readonly ok: true }> {
+  return {
+    ok: true,
+    schema: "daemon.doc-sync-submit-result/v1",
+    status: "accepted",
+    intentId: "intent_pending",
+    baseLedgerSha: "base",
+    appliedLedgerSha: "accepted",
+    appliedChanges: [],
+    settlement: {
+      schema: "command-receipt-settlement/v1",
+      receiptId: "repo-write:pending",
+      durability: "session-durable",
+      canonicalVisibility: "pending",
+      acceptedAt: "2026-08-10T00:00:00.000Z",
+      sessionId: "session-pending",
+      acceptedCommitSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      statusQuery: {
+        method: "repo.write.receipt.status",
+        command: "ha receipt status repo-write:pending --json",
+        receiptId: "repo-write:pending"
+      }
+    }
+  };
+}
+
+function failedSettlementReceipt(): RepoWriteJsonObject {
+  return {
+    ok: false,
+    schema: "command-receipt/v2",
+    command: "repo.doc.sync.submit",
+    action: "submit",
+    summary: "canonical settlement failed",
+    error: { code: "repo_write_settlement_failed", hint: "inspect the settlement" },
+    settlement: {
+      schema: "command-receipt-settlement/v1",
+      receiptId: "repo-write:pending",
+      durability: "session-durable",
+      canonicalVisibility: "failed",
+      acceptedAt: "2026-08-10T00:00:00.000Z",
+      sessionId: "session-pending",
+      acceptedCommitSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      failedAt: "2026-08-10T00:00:01.000Z",
+      failure: {
+        stage: "materializer",
+        code: "MATERIALIZER_APPLY_FAILED",
+        message: "canonical merge conflict",
+        retryable: true,
+        recoveryCommand: "ha materializer run --json"
+      },
+      statusQuery: {
+        method: "repo.write.receipt.status",
+        command: "ha receipt status repo-write:pending --json",
+        receiptId: "repo-write:pending"
+      }
+    },
+    meta: {
+      generatedAt: "2026-08-10T00:00:01.000Z",
+      compatibility: { legacyReceipt: "CommandReceipt/v1" }
+    }
+  };
+}
+
+function dispatchContext() {
+  return {
+    command: {
+      action: { kind: "task-complete", taskId: "task_01ABC", dryRun: false }
+    } as unknown as DaemonHostCommand,
+    currentSession: { source: "manual" as const },
+    actor: { kind: "human", id: "actor-test" } as never,
+    executor: null,
+    authorityConnection: {
+      available: true as const,
+      context: {} as never,
+      assertActive: () => undefined
+    }
+  };
+}
+
+function prepublishReceipt(
+  files: ReadonlyArray<{ readonly path: string; readonly reason: string }>,
+  data: unknown = {
+    schema: "task-complete-prepublish-failure/v1",
+    code: "task_complete_prepublish_not_materialized",
+    files
+  }
+): CommandReceiptEnvelope {
+  return {
+    ok: false,
+    schema: "command-receipt/v2",
+    command: "task-complete",
+    action: "run",
+    summary: "task completion prepublish rejected",
+    error: { code: "task_complete_prepublish_not_materialized", hint: "structured details attached" },
+    details: { data: data as never },
+    meta: {
+      generatedAt: "2026-08-10T00:00:00.000Z",
+      compatibility: { legacyReceipt: "CommandReceipt/v1" }
+    }
+  };
+}
+
+function successReceipt(): CommandReceiptEnvelope {
+  return {
+    ok: true,
+    schema: "command-receipt/v2",
+    command: "task-complete",
+    action: "run",
+    summary: "completed",
+    next: [],
+    meta: {
+      generatedAt: "2026-08-10T00:00:00.000Z",
+      compatibility: { legacyReceipt: "CommandReceipt/v1" }
+    }
+  };
+}
+
+function legacyPrepublishReceipt(pathValue: string, reason: string): CommandReceiptEnvelope {
+  const message = `AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED:${pathValue} (${reason})`;
+  return {
+    ok: false,
+    schema: "command-receipt/v2",
+    command: "task-complete",
+    action: "run",
+    summary: message,
+    error: { code: "authority_ingress_rejected", hint: message },
+    meta: {
+      generatedAt: "2026-08-10T00:00:00.000Z",
+      compatibility: { legacyReceipt: "CommandReceipt/v1" }
+    }
+  };
+}

--- a/packages/daemon/test/task-complete-prepublish-witness.test.ts
+++ b/packages/daemon/test/task-complete-prepublish-witness.test.ts
@@ -219,6 +219,17 @@ test("unpublished document rejection names only the path whose body is not mater
         assert.match(message, /closeout\.md/u);
         assert.doesNotMatch(message, /code-doc-anchors\.json/u);
         assert.match(message, /content differs from expected/u);
+        assert.deepEqual(
+          (error as { readonly details?: unknown }).details,
+          {
+            schema: "task-complete-prepublish-failure/v1",
+            code: "task_complete_prepublish_not_materialized",
+            files: [{
+              path: `tasks/${taskId}-witness/closeout.md`,
+              reason: "content differs from expected"
+            }]
+          }
+        );
         return true;
       }
     );


### PR DESCRIPTION
# English

## Summary

`ha task complete` now auto-materializes unpublished task-package documents before the prepublish gate re-checks, so agents no longer have to hand-walk `artifact add` / `doc sync` roads (or discover them from an error that names no road). It also fixes a latent #1310 defect this work exposed: doc-sync durable settlements synthesized a `COMMITTED` evidence that could not pass terminal-proof validation, racing reconciliation into dual terminal states (production forensics: 27 of 45 receipts carried both a failure and a visible record).

## What Changed

- New completion orchestration (`task-complete-auto-materialization*.ts`): on `AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED`, classify the task package's dirty documents (artifacts → manual-artifact intent, registered prose → prose-edit intent), publish through the existing doc-sync/WriteCoordinator roads, await canonical settlement, retry complete once; remaining gaps fail with per-file `path/reason/fix` (+`fixArgv`) receipts.
- Structured prepublish protocol `task-complete-prepublish-failure/v1` (typed files list) replaces free-text parsing; text parsing kept only as legacy fallback without a hardcoded `tasks/` root.
- Snapshot binding (frozen `{path, baseBlob, bodySha}` per candidate; `working_tree_changed` on drift), per-`{repoId,taskId}` single-flight with revalidation, settlement wait raised to 20s with backoff, recovery handles (`receiptId` + `statusQuery`) preserved on every failure branch.
- Dedicated honest terminal proof for doc-sync durable writes: `repo-write-canonical-publication-evidence/v1` with a canonical-ancestry anchor (no fabricated authority integrity tuple); durable controller owns terminalization with live-settlement ownership; recovery only acts when no live owner and acceptance is durable; interleaving-determinism test pins one terminal state per outcome.
- Dry-run stays read-only; substantive completion gates (closeout truthfulness, review chain, code-doc reconcile, consent) untouched.
- Bilingual operator docs updated (`docs-release/operations-server-daemon*.md`).

## Task And Scope

- Harness task: task_01KZMS30SBMPJNT1JGRCR57A3C
- Branch: codex/complete-auto-materialize
- Public scope: packages/daemon (service + runtime), packages/cli (composition, tests), packages/application, docs-release
- Private planning/evidence updated: yes
- Out of scope: deferred review findings F6 (preflight isolation), F7 (materializedFiles in failure schema), F8 (supervisor-less in-process composition parity); publication byte re-derivation determinism family

## Version Impact

- Version: no version change because runtime behavior change within existing surfaces
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: production write path (task complete orchestration, doc-sync durable settlement terminal proof)
- Authority: decision dec_01KZMSRXFBQZJH870QTJSC2849 (accepted; C1 derives task_01KZMS30SBMPJNT1JGRCR57A3C)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: F6/F7/F8 deferral recorded in task ledger; settlement byte-determinism family to be filed at closeout

## Verification

- Base `origin/main` SHA: 7c73fe2873907a2543f5b9cc52e44b02b1e242b3
- Branch merge-base with `origin/main`: 7c73fe2873907a2543f5b9cc52e44b02b1e242b3
- Last `git fetch origin` time: 2026-08-10 (this session, pre-push)
- Sync method: none needed
- Public diff command: `git diff 7c73fe28..4040bebf`
- Private evidence commit/path: harness/tasks/task_01KZMS30SBMPJNT1JGRCR57A3C-complete-artifact-add-doc-sync/artifacts/
- Reviewer evidence path: artifacts/review-adversarial-findings-auto-mat.md, artifacts/review-glm-blind-findings-auto-mat.md, artifacts/round3-terminal-proof-report.md
- GitHub Actions `rewrite-ci` run URL: pending (queued on PR open)
- [x] `git diff --check`
- [x] `npm run check:local` (27/27 manifest gates green)
- [x] Targeted tests for the change surface, named with their counts: complete-final-step-deadzone 8/8 ×3 consecutive full runs; task-complete-auto-materialization + prepublish-witness + authority-submission-error + task-lifecycle-write-failure 55/55; durable-operation-controller + outcome-store additions green
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: full `check:ci` locally (GitHub CI is the authority and runs on this PR); remote SSH daemon live acceptance (post-merge deployment canary planned); settlement fault-injection beyond differ-rejection and interleaving tests (deferred with F7)

## Review Evidence

- Self-review: CEO semantic acceptance — substantive gates untouched, honest failure receipts, existing write roads reused, terminal-state single ownership verified in diff
- Reviewer subagent: adversarial review (Codex, 0 P0 / 5 P1 / 4 P2) + independent blind review (GLM, 2 medium / 5 low), run in parallel without shared context
- Human review: 泽宇 adjudicated the auto-materialize direction (decision dec_01KZMSRXFBQZJH870QTJSC2849)
- Blocking findings: F1/F2/F3/F4/F5/F9+M-1 all fixed with red-first tests (fix round 2 + round 3 reports in task artifacts); F6/F7/F8 deferred by explicit triage

## Residual Risk

- Deferred F6: whole-repo doc-sync preflight can be perturbed by another task's pathological dirty file before package filtering (writer-side no-follow remains the second line of defense).
- Deferred F7: failure receipts do not yet enumerate already-published groups (`materializedFiles`); partial success is inferable only via receipt status.
- Deferred F8: supervisor-less in-process compositions keep legacy prepublish semantics (test/migration surface).
- Publication byte re-derivation nondeterminism (26 SETTLEMENT_FAILED production detours, retry-masked) is a pre-existing family, not addressed here; to be filed separately.

## References

- Task: task_01KZMS30SBMPJNT1JGRCR57A3C
- Evidence: harness/tasks/task_01KZMS30SBMPJNT1JGRCR57A3C-complete-artifact-add-doc-sync/artifacts/
- Review: review-adversarial-findings-auto-mat.md, review-glm-blind-findings-auto-mat.md, codex-report-complete-auto-materialize-round2.md, round3-terminal-proof-report.md

---

# 中文

## 概要

`ha task complete` 现在会在 prepublish 门复查前自动物化任务包内未发布的文档——agent 不再需要手工走 `artifact add` / `doc sync`（也不再需要从一条不指路的报错里自己摸出路）。同时修复了本工作暴露的 #1310 潜伏缺陷：doc-sync durable 落定合成的 `COMMITTED` 证据过不了 terminal proof 校验，与 reconciliation 竞态形成双终态（生产取证：45 个回执中 27 个同时存在 failure 与 visible 记录）。

## 改动内容

- 新增 complete 编排（`task-complete-auto-materialization*.ts`）：撞 `AUTHORITY_TASK_COMPLETE_PREPUBLISH_NOT_MATERIALIZED` 时对任务包 dirty 文档分类（artifacts → manual-artifact intent，registered prose → prose-edit intent），走既有 doc-sync/WriteCoordinator 写路发布，等 canonical 落定后重试一次 complete；仍缺则逐文件返回 `path/reason/fix`（+`fixArgv`）。
- 结构化 prepublish 协议 `task-complete-prepublish-failure/v1`（类型化文件清单）替代自由文本解析；文本解析仅作旧版兼容回退，不再硬编码 `tasks/` 根。
- 快照绑定（候选冻结 `{path, baseBlob, bodySha}`，漂移返回 `working_tree_changed`）、按 `{repoId,taskId}` single-flight 并带重验、settlement 等待提升至 20s 带退避、所有失败分支保留恢复句柄（`receiptId` + `statusQuery`）。
- doc-sync durable 写的专用诚实 terminal proof：`repo-write-canonical-publication-evidence/v1` 带 canonical ancestry 锚（不伪造 authority integrity tuple）；durable controller 以 live-settlement 所有权独占终态写入，recovery 仅在无 live owner 且受理已 durable 时接手；interleaving 确定性测试钉住单一终态。
- dry-run 保持只读；实质性完成门（closeout 写实、review 链、code-doc reconcile、consent）未动。
- 中英文运维文档更新（`docs-release/operations-server-daemon*.md`）。

## 任务与范围

- Harness 任务：task_01KZMS30SBMPJNT1JGRCR57A3C
- 分支：codex/complete-auto-materialize
- 公开范围：packages/daemon（service + runtime）、packages/cli（composition、tests）、packages/application、docs-release
- 私有规划/证据已更新：是
- 范围外：递延 findings F6（preflight 隔离）、F7（failure schema 增 materializedFiles）、F8（无 supervisor in-process composition parity）；发布字节重推导确定性缺陷族

## 版本影响

- 版本：无版本变更，原因：既有 surface 内的运行时行为变更
- 发布影响：不发布

## 治理声明

- 触碰 protected surface：是
- Protected surface 范围：生产写路（task complete 编排、doc-sync durable 落定 terminal proof）
- 授权：decision dec_01KZMSRXFBQZJH870QTJSC2849（accepted；C1 derives task_01KZMS30SBMPJNT1JGRCR57A3C）
- 机器检查边界：本 PR 仅断言声明存在；是否真实充分由 reviewer 判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：F6/F7/F8 递延已记任务台账；落定字节确定性缺陷族收口时另立

## 验证

- Base `origin/main` SHA：7c73fe2873907a2543f5b9cc52e44b02b1e242b3
- 与 `origin/main` 的 merge-base：7c73fe2873907a2543f5b9cc52e44b02b1e242b3
- 最近 `git fetch origin` 时间：2026-08-10（本会话，push 前）
- 同步方式：无需同步
- 公开 diff 命令：`git diff 7c73fe28..4040bebf`
- 私有证据 commit/路径：harness/tasks/task_01KZMS30SBMPJNT1JGRCR57A3C-complete-artifact-add-doc-sync/artifacts/
- Reviewer 证据路径：artifacts/review-adversarial-findings-auto-mat.md、review-glm-blind-findings-auto-mat.md、round3-terminal-proof-report.md
- GitHub Actions `rewrite-ci` run URL：开 PR 后排队
- [x] `git diff --check`
- [x] `npm run check:local`（27/27 manifest gates 全绿）
- [x] 变更面定向测试及计数：complete-final-step-deadzone 8/8 连续 3 次全量；auto-materialization+prepublish-witness+authority-submission-error+task-lifecycle-write-failure 55/55；durable-operation-controller 与 outcome-store 新增测试绿
- [ ] GitHub Actions `rewrite-ci` 通过（权威完整门）
- 未运行及原因：本地未跑完整 `check:ci`（GitHub CI 为权威且在本 PR 上运行）；remote SSH daemon 实机验收（合并部署后金丝雀）；differ 拒收与 interleaving 之外的 settlement 故障注入（随 F7 递延）

## Review 证据

- 自查：CEO 语义验收——实质门未动、失败回执诚实、复用既有写路、终态单一所有权已读 diff 核实
- Reviewer subagent：对抗复核（Codex，0 P0 / 5 P1 / 4 P2）+ 独立盲评（GLM，2 中 / 5 低），并行互不透题
- 人工 review：泽宇裁决自动物化方向（decision dec_01KZMSRXFBQZJH870QTJSC2849）
- 阻塞 findings：F1/F2/F3/F4/F5/F9+M-1 已全部红先行修复（round 2/3 报告在任务 artifacts）；F6/F7/F8 显式分流递延

## 残余风险

- 递延 F6：doc-sync 全仓 preflight 在包过滤前可能被其他 task 的异常 dirty 文件干扰（writer 侧 no-follow 为第二道防线）。
- 递延 F7：失败回执暂不枚举已发布组（`materializedFiles`），部分成功只能经 receipt status 推断。
- 递延 F8：无 supervisor 的 in-process composition 保留旧 prepublish 语义（测试/迁移面）。
- 发布字节重推导非确定性（生产 26 次 SETTLEMENT_FAILED 弯路，被重试掩护）为既有缺陷族，本 PR 不处理，另立案。

## 参考

- 任务：task_01KZMS30SBMPJNT1JGRCR57A3C
- 证据：harness/tasks/task_01KZMS30SBMPJNT1JGRCR57A3C-complete-artifact-add-doc-sync/artifacts/
- Review：review-adversarial-findings-auto-mat.md、review-glm-blind-findings-auto-mat.md、codex-report-complete-auto-materialize-round2.md、round3-terminal-proof-report.md
