### PR TITLE
fix(daemon): return task writes at durable acceptance instead of full settlement

### DIFF
--- a/packages/daemon/src/runtime/authority-durable-acceptance-context.ts
+++ b/packages/daemon/src/runtime/authority-durable-acceptance-context.ts
@@ -92,20 +92,44 @@ export function waitForCurrentAuthoritySettlementRelease(): Promise<void> {
   return settlementReleaseStorage.getStore() ?? Promise.resolve();
 }
 
-export async function runBeforeBackgroundAuthoritySettlement<Result>(
+export interface HeldBackgroundAuthoritySettlement<Result> {
+  readonly result: Result;
+  readonly releaseAfterResponse: () => void;
+}
+
+/**
+ * Hold same-command canonical settlement until the child has delivered the
+ * durable acceptance receipt. A failed command releases immediately so no
+ * background publication can remain parked without a response owner.
+ */
+export async function holdBackgroundAuthoritySettlement<Result>(
   operation: () => Promise<Result>
-): Promise<Result> {
+): Promise<HeldBackgroundAuthoritySettlement<Result>> {
   let release!: () => void;
   const released = new Promise<void>((resolve) => {
     release = resolve;
   });
-  try {
-    return await runWithAuthoritySettlementRelease(released, operation);
-  } finally {
-    // Let the operation host construct and return its durable receipt before a
-    // synchronous materializer can occupy this child process.
+  let scheduled = false;
+  const releaseAfterResponse = () => {
+    if (scheduled) return;
+    scheduled = true;
     setImmediate(release);
+  };
+  try {
+    const result = await runWithAuthoritySettlementRelease(released, operation);
+    return { result, releaseAfterResponse };
+  } catch (error) {
+    releaseAfterResponse();
+    throw error;
   }
+}
+
+export async function runBeforeBackgroundAuthoritySettlement<Result>(
+  operation: () => Promise<Result>
+): Promise<Result> {
+  const held = await holdBackgroundAuthoritySettlement(operation);
+  held.releaseAfterResponse();
+  return held.result;
 }
 
 export function reportCurrentAuthorityDurableAcceptance(

--- a/packages/daemon/src/runtime/production-progress-append-operation.ts
+++ b/packages/daemon/src/runtime/production-progress-append-operation.ts
@@ -44,9 +44,13 @@ import {
 import { DurableRepoWriteOutcomeStoreV1 } from "./durable-repo-write-outcome-store.ts";
 import { ReceiptSettlementStore } from "./receipt-settlement-store.ts";
 import {
-  runBeforeBackgroundAuthoritySettlement,
+  holdBackgroundAuthoritySettlement,
   type AuthorityDurableAcceptance
 } from "./authority-durable-acceptance-context.ts";
+import {
+  repoWriteDirectResponseDelivery,
+  type RepoWriteDirectExecutionResult
+} from "./repo-write-child-direct.ts";
 import type {
   ProductionAuthorityAttemptPlanV1,
   ProductionAuthorityCommandPlanInput
@@ -198,7 +202,7 @@ export class ProductionRepoWriteOperationHost<
     });
   }
 
-  async direct(input: RepoWriteDirectInput): Promise<import("./repo-write-protocol.ts").RepoWriteJsonObject> {
+  async direct(input: RepoWriteDirectInput): Promise<RepoWriteDirectExecutionResult> {
     const decoded = decodeRepoWriteCommand(input.command);
     const binding = this.options.authorityComponent.bindConnection(
       decoded.authorityConnection
@@ -252,7 +256,7 @@ export class ProductionRepoWriteOperationHost<
         } : {})
       }
     );
-    const receipt = await runBeforeBackgroundAuthoritySettlement(() => commandService.runCommand(
+    const held = await holdBackgroundAuthoritySettlement(() => commandService.runCommand(
       input.command.payload as unknown as JsonObject,
       {
         actor: decoded.actor,
@@ -264,15 +268,23 @@ export class ProductionRepoWriteOperationHost<
         }
       }
     ));
-    if (command.action.kind === "materializer-run") {
-      await this.options.recoverSettlements?.();
+    try {
+      if (command.action.kind === "materializer-run") {
+        await this.options.recoverSettlements?.();
+      }
+      return repoWriteDirectResponseDelivery(
+        commandReceiptJsonObject(settleDirectAuthorityCommandReceipt({
+          receipt: held.result,
+          submissions: durableSubmissions,
+          store: this.options.settlementStore,
+          now: this.options.now
+        })),
+        held.releaseAfterResponse
+      );
+    } catch (error) {
+      held.releaseAfterResponse();
+      throw error;
     }
-    return commandReceiptJsonObject(settleDirectAuthorityCommandReceipt({
-      receipt,
-      submissions: durableSubmissions,
-      store: this.options.settlementStore,
-      now: this.options.now
-    }));
   }
 
   async lookup(input: RepoWriteLookupInput): Promise<RepoWriteCanonicalLookupResult> {
@@ -479,10 +491,14 @@ export class ProductionRepoWriteOperationHost<
       },
       submitDurable: async (input: Parameters<typeof submission.submitDurable>[0]) => {
         const durable = await submission.submitDurable(input);
+        const settlement = durable.settlement.then((evidence) => {
+          authorityEvidence = evidence;
+          return evidence;
+        });
         const captured: {
           acceptance?: AuthorityDurableAcceptance;
           readonly settlement: Promise<AuthorityOperationReceipt>;
-        } = { settlement: durable.settlement };
+        } = { settlement };
         durableSubmissions.push(captured);
         return {
           admission: durable.admission.then((admission) => {
@@ -490,10 +506,7 @@ export class ProductionRepoWriteOperationHost<
             else authorityEvidence = admission.receipt;
             return admission;
           }),
-          settlement: durable.settlement.then((evidence) => {
-            authorityEvidence = evidence;
-            return evidence;
-          })
+          settlement
         };
       }
     };
@@ -509,7 +522,7 @@ export class ProductionRepoWriteOperationHost<
         } : {})
       }
     );
-    const receipt = exactRepoWriteReceipt(await runBeforeBackgroundAuthoritySettlement(() => commandService.runCommand(
+    const held = await holdBackgroundAuthoritySettlement(() => commandService.runCommand(
       currentCommand.payload as unknown as JsonObject,
       {
         actor: decoded.actor,
@@ -520,28 +533,36 @@ export class ProductionRepoWriteOperationHost<
           assertActive: () => undefined
         }
       }
-    )), proceeding, authorityEvidence);
-    const accepted = durableSubmissions
-      .map((entry) => entry.acceptance)
-      .find((entry) => entry?.flush.watermark === proceeding.innerOpId)
-      ?? durableSubmissions.at(-1)?.acceptance;
-    if (accepted) {
-      return {
-        kind: "accepted",
-        receipt,
-        acceptance: accepted,
-        acceptedCommitSha: accepted.acceptedCommitSha,
-        settlement: Promise.all(durableSubmissions.map((entry) => entry.settlement)).then((evidence) => {
-          const exact = evidence.find((entry) => entry.opId === proceeding.innerOpId) ?? evidence.at(-1);
-          if (!exact || exact.tag === "INDETERMINATE") {
-            throw new Error(`AUTHORITY_SETTLEMENT_INDETERMINATE:${exact?.tag === "INDETERMINATE" ? exact.reason : "terminal evidence missing"}`);
-          }
-          return exact;
-        })
-      };
+    ));
+    try {
+      const receipt = exactRepoWriteReceipt(held.result, proceeding, authorityEvidence);
+      const accepted = durableSubmissions
+        .map((entry) => entry.acceptance)
+        .find((entry) => entry?.flush.watermark === proceeding.innerOpId)
+        ?? durableSubmissions.at(-1)?.acceptance;
+      if (accepted) {
+        return {
+          kind: "accepted",
+          receipt,
+          acceptance: accepted,
+          acceptedCommitSha: accepted.acceptedCommitSha,
+          settlement: Promise.all(durableSubmissions.map((entry) => entry.settlement)).then((evidence) => {
+            const exact = evidence.find((entry) => entry.opId === proceeding.innerOpId) ?? evidence.at(-1);
+            if (!exact || exact.tag === "INDETERMINATE") {
+              throw new Error(`AUTHORITY_SETTLEMENT_INDETERMINATE:${exact?.tag === "INDETERMINATE" ? exact.reason : "terminal evidence missing"}`);
+            }
+            return exact;
+          }),
+          releaseSettlement: held.releaseAfterResponse
+        };
+      }
+      held.releaseAfterResponse();
+      const evidence = terminalEvidence(authorityEvidence, receipt, proceeding);
+      return { kind: "terminal", receipt, authorityEvidence: evidence };
+    } catch (error) {
+      held.releaseAfterResponse();
+      throw error;
     }
-    const evidence = terminalEvidence(authorityEvidence, receipt, proceeding);
-    return { kind: "terminal", receipt, authorityEvidence: evidence };
   }
 }
 

--- a/packages/daemon/src/runtime/repo-write-child-contract.ts
+++ b/packages/daemon/src/runtime/repo-write-child-contract.ts
@@ -1,12 +1,14 @@
 import type {
-  RepoWriteCommandDto,
-  RepoWriteJsonObject
+  RepoWriteCommandDto
 } from "./repo-write-protocol.ts";
 import type { RepoWriteExecutionOutcome } from "./repo-write-durable-operation-controller.ts";
 import type { RepoWriteCanonicalLookupResult } from "./repo-write-child-lookup.ts";
 import type { RepoWriteChildTransport } from "./repo-write-child-response-writer.ts";
 import type { RepoWriteExecutionSequencer } from "./repo-write-execution-sequencer.ts";
-import type { RepoWriteDirectInput } from "./repo-write-child-direct.ts";
+import type {
+  RepoWriteDirectExecutionResult,
+  RepoWriteDirectInput
+} from "./repo-write-child-direct.ts";
 
 export interface RepoWritePrepareInput {
   readonly repoId: string;
@@ -39,7 +41,7 @@ export interface RepoWriteChildHostHooks {
   ) => RepoWritePreparedOperation | Promise<RepoWritePreparedOperation>;
   readonly direct?: (
     input: RepoWriteDirectInput
-  ) => RepoWriteJsonObject | Promise<RepoWriteJsonObject>;
+  ) => RepoWriteDirectExecutionResult | Promise<RepoWriteDirectExecutionResult>;
   readonly lookup: (
     input: RepoWriteLookupInput
   ) => RepoWriteCanonicalLookupResult | Promise<RepoWriteCanonicalLookupResult>;

--- a/packages/daemon/src/runtime/repo-write-child-direct.ts
+++ b/packages/daemon/src/runtime/repo-write-child-direct.ts
@@ -22,12 +22,35 @@ export interface RepoWriteDirectInput {
   readonly command: RepoWriteCommandDto;
 }
 
+export interface RepoWriteDirectResponseDelivery {
+  readonly kind: "repo-write-direct-response-delivery/v1";
+  readonly receipt: RepoWriteJsonObject;
+  readonly releaseSettlement: () => void;
+}
+
+export type RepoWriteDirectExecutionResult =
+  | RepoWriteJsonObject
+  | RepoWriteDirectResponseDelivery;
+
+export function repoWriteDirectResponseDelivery(
+  receipt: RepoWriteJsonObject,
+  releaseSettlement: () => void
+): RepoWriteDirectResponseDelivery {
+  return {
+    kind: "repo-write-direct-response-delivery/v1",
+    receipt,
+    releaseSettlement
+  };
+}
+
 export interface RepoWriteChildDirectOptions {
   readonly message: Extract<RepoWriteParentMessage, { kind: "direct" }>;
   readonly repoId: string;
   readonly workspaceId: string;
   readonly generation: number;
-  readonly execute: (input: RepoWriteDirectInput) => unknown | Promise<unknown>;
+  readonly execute: (
+    input: RepoWriteDirectInput
+  ) => RepoWriteDirectExecutionResult | Promise<RepoWriteDirectExecutionResult>;
   readonly responses: RepoWriteChildResponseWriter;
   readonly sequencer: RepoWriteExecutionSequencer;
   readonly requestIds: Set<string>;
@@ -91,13 +114,14 @@ export async function executeRepoWriteChildDirect(
   options.requestIds.add(message.requestId);
   options.admit();
   let telemetry: ReturnType<typeof createRepoWriteTelemetryDelivery> | undefined;
+  let releaseSettlement: (() => void) | undefined;
   try {
     await options.responses.telemetry(message.requestId, "queue", 0);
     telemetry = createRepoWriteTelemetryDelivery(
       (phase, elapsedMs, details) =>
         options.responses.telemetry(message.requestId, phase, elapsedMs, details)
     );
-    const receipt = await runWithRepoWriteTelemetry(
+    const executed = await runWithRepoWriteTelemetry(
       telemetry.report,
       () => options.sequencer.run(() => {
         reportCurrentRepoWriteTelemetry("compile");
@@ -110,6 +134,12 @@ export async function executeRepoWriteChildDirect(
         });
       })
     );
+    const receipt = isRepoWriteDirectResponseDelivery(executed)
+      ? executed.receipt
+      : executed;
+    if (isRepoWriteDirectResponseDelivery(executed)) {
+      releaseSettlement = executed.releaseSettlement;
+    }
     await telemetry.flush();
     telemetry.close();
     await options.responses.directResult(message.requestId, receipt);
@@ -129,8 +159,16 @@ export async function executeRepoWriteChildDirect(
       error
     );
   } finally {
+    releaseSettlement?.();
     options.release();
   }
+}
+
+function isRepoWriteDirectResponseDelivery(
+  value: RepoWriteDirectExecutionResult
+): value is RepoWriteDirectResponseDelivery {
+  return value.kind === "repo-write-direct-response-delivery/v1"
+    && typeof value.releaseSettlement === "function";
 }
 
 function isExpectedDirectWriteRejection(error: unknown): error is Extract<WriteError, { readonly _tag: "WriteRejected" }> {

--- a/packages/daemon/src/runtime/repo-write-child-host-response.ts
+++ b/packages/daemon/src/runtime/repo-write-child-host-response.ts
@@ -1,5 +1,6 @@
 import type { RepoWriteChildResponseWriter } from "./repo-write-child-response-writer.ts";
 import type { RepoWriteHostedOperationSnapshot } from "./repo-write-child-lookup.ts";
+import type { RepoWriteJsonObject } from "./repo-write-protocol.ts";
 
 export interface RepoWriteChildOperationResponseState {
   readonly requestId: string;
@@ -78,4 +79,32 @@ export async function sendRepoWriteRepeatedProceed(
     "operation is not in prepared state",
     operation.opId
   );
+}
+
+export async function sendRepoWriteAcceptedDelivery(
+  responses: RepoWriteChildResponseWriter,
+  requestId: string,
+  opId: string,
+  receipt: RepoWriteJsonObject,
+  releaseSettlement?: () => void
+): Promise<void> {
+  try {
+    await responses.accepted(requestId, opId, receipt);
+  } finally {
+    releaseSettlement?.();
+  }
+}
+
+export async function sendRepoWriteUnknownOutcomeDelivery(
+  responses: RepoWriteChildResponseWriter,
+  requestId: string,
+  opId: string,
+  error: unknown,
+  releaseSettlement?: () => void
+): Promise<void> {
+  try {
+    await responses.unknown(requestId, opId, "EXECUTION_OUTCOME_UNKNOWN", error);
+  } finally {
+    releaseSettlement?.();
+  }
 }

--- a/packages/daemon/src/runtime/repo-write-child-host.ts
+++ b/packages/daemon/src/runtime/repo-write-child-host.ts
@@ -12,13 +12,13 @@ import {
   repoWriteLocalLookupResult,
   type RepoWriteHostedOperationSnapshot
 } from "./repo-write-child-lookup.ts";
+import { RepoWriteChildResponseWriter } from "./repo-write-child-response-writer.ts";
 import {
-  RepoWriteChildResponseWriter
-} from "./repo-write-child-response-writer.ts";
-import {
+  sendRepoWriteAcceptedDelivery,
   sendRepoWriteDuplicateSubmit,
   sendRepoWriteRejectedProceed,
-  sendRepoWriteRepeatedProceed
+  sendRepoWriteRepeatedProceed,
+  sendRepoWriteUnknownOutcomeDelivery
 } from "./repo-write-child-host-response.ts";
 import { RepoWriteExecutionSequencer } from "./repo-write-execution-sequencer.ts";
 import {
@@ -323,6 +323,7 @@ export class RepoWriteChildHost {
     }
 
     operation.state = { phase: advanceRepoWritePhase("child", "proceed", operation.state.phase) };
+    let releaseSettlement: (() => void) | undefined;
     try {
       let receipt: RepoWriteJsonObject;
       try {
@@ -334,6 +335,7 @@ export class RepoWriteChildHost {
           if (executed.outerOpId !== operation.opId) {
             throw new Error("execution did not return the matching durable accepted outer outcome");
           }
+          releaseSettlement = executed.releaseSettlement;
           receipt = executed.receipt as unknown as RepoWriteJsonObject;
           operation.state = {
             phase: advanceRepoWritePhase("child", "accepted", "proceeding"),
@@ -358,11 +360,12 @@ export class RepoWriteChildHost {
           phase: advanceRepoWritePhase("child", "outcome-unknown", "proceeding")
         };
         this.release(operation);
-        await this.responses.unknown(
+        await sendRepoWriteUnknownOutcomeDelivery(
+          this.responses,
           operation.requestId,
           operation.opId!,
-          "EXECUTION_OUTCOME_UNKNOWN",
-          error
+          error,
+          releaseSettlement
         );
         return;
       }
@@ -370,10 +373,12 @@ export class RepoWriteChildHost {
       await this.closeTelemetry(operation);
       this.release(operation);
       if (operation.state.phase === "accepted") {
-        await this.responses.accepted(
+        await sendRepoWriteAcceptedDelivery(
+          this.responses,
           operation.requestId,
           operation.opId!,
-          operation.state.receipt
+          operation.state.receipt,
+          releaseSettlement
         );
         return;
       }

--- a/packages/daemon/src/runtime/repo-write-durable-operation-controller.ts
+++ b/packages/daemon/src/runtime/repo-write-durable-operation-controller.ts
@@ -38,6 +38,7 @@ export interface RepoWriteAcceptedExecutionResult {
   readonly acceptance: AuthorityDurableAcceptance;
   readonly acceptedCommitSha: string;
   readonly settlement: Promise<RepoWriteTerminalEvidenceV1>;
+  readonly releaseSettlement?: () => void;
 }
 
 export type RepoWriteDurableExecutionResult =
@@ -48,6 +49,7 @@ export interface RepoWriteAcceptedResult {
   readonly kind: "accepted";
   readonly outerOpId: string;
   readonly receipt: CommandReceiptEnvelope;
+  readonly releaseSettlement?: () => void;
 }
 
 export type RepoWriteExecutionOutcome = RepoWriteTerminalOutcomeV1 | RepoWriteAcceptedResult;
@@ -194,26 +196,39 @@ export class RepoWriteDurableOperationController {
     proceeding: RepoWriteProceedingOutcomeV1,
     result: RepoWriteAcceptedExecutionResult
   ): RepoWriteAcceptedResult {
-    const pending = pendingCommandReceiptSettlement({
-      receiptId: proceeding.outerOpId,
-      acceptedAt: this.now().toISOString(),
-      sessionId: result.acceptance.sessionId,
-      acceptedCommitSha: result.acceptedCommitSha,
-      authorityOperationIds: [result.acceptance.flush.watermark]
-    });
-    const receipt = withCommandReceiptSettlement(result.receipt, pending);
-    this.settlements.accept(receipt);
-    const completion = result.settlement.then(
-      (evidence) => this.completeSettlement(proceeding, receipt, pending, evidence),
-      (error) => this.failSettlement(receipt, pending, error)
-    );
-    this.activeSettlements.set(proceeding.outerOpId, completion);
-    void completion.finally(() => {
-      if (this.activeSettlements.get(proceeding.outerOpId) === completion) {
-        this.activeSettlements.delete(proceeding.outerOpId);
-      }
-    });
-    return { kind: "accepted", outerOpId: proceeding.outerOpId, receipt };
+    try {
+      const pending = pendingCommandReceiptSettlement({
+        receiptId: proceeding.outerOpId,
+        acceptedAt: this.now().toISOString(),
+        sessionId: result.acceptance.sessionId,
+        acceptedCommitSha: result.acceptedCommitSha,
+        authorityOperationIds: [result.acceptance.flush.watermark]
+      });
+      const receipt = withCommandReceiptSettlement(result.receipt, pending);
+      this.settlements.accept(receipt);
+      const completion = result.settlement.then(
+        (evidence) => this.completeSettlement(proceeding, receipt, pending, evidence),
+        (error) => this.failSettlement(receipt, pending, error)
+      );
+      this.activeSettlements.set(proceeding.outerOpId, completion);
+      void completion.finally(() => {
+        if (this.activeSettlements.get(proceeding.outerOpId) === completion) {
+          this.activeSettlements.delete(proceeding.outerOpId);
+        }
+      });
+      return {
+        kind: "accepted",
+        outerOpId: proceeding.outerOpId,
+        receipt,
+        ...(result.releaseSettlement ? {
+          releaseSettlement: result.releaseSettlement
+        } : {})
+      };
+    } catch (error) {
+      result.releaseSettlement?.();
+      void result.settlement.catch(() => undefined);
+      throw error;
+    }
   }
 
   private recoverCanonicalPublicationExclusive(input: {

--- a/packages/daemon/test/repo-write-acceptance-early-return.test.ts
+++ b/packages/daemon/test/repo-write-acceptance-early-return.test.ts
@@ -1,0 +1,246 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { makeTaskHolderService, taskHolderActor } from "@harness-anything/kernel";
+import {
+  DurableRepoWriteOutcomeStoreV1,
+  createRepoWriteChildHost,
+  encodeRepoWriteCommand,
+  type RepoWriteChildMessage
+} from "../src/index.ts";
+import { daemonActorAttribution } from "../../cli/src/composition/actor-attribution.ts";
+import {
+  productionAuthorityActor,
+  productionAuthorityConnection
+} from "../../cli/test/helpers/production-authority-connection.ts";
+import {
+  createProductionAuthorityLifecycleFixture
+} from "../../cli/test/helpers/production-authority-lifecycle-fixture.ts";
+import {
+  enableProgressOperationLease,
+  installProgressOperationTask,
+  newTaskOperationCommand,
+  newTaskOperationDirectMessage,
+  productionProgressOperationAxes,
+  productionProgressOperationHost,
+  progressOperationCommand,
+  progressOperationDurabilityEvents,
+  progressOperationProceedMessage,
+  progressOperationSubmitMessage,
+  progressOperationTaskId,
+  slowFailedDirectAuthorityComponent,
+  slowFailedProgressAuthorityComponent
+} from "./support/production-progress-operation-fixture.ts";
+
+const operationTest = process.platform === "win32" ? test.skip : test;
+
+operationTest("child returns durable acceptance before deliberately slow failed canonical settlement", async (t) => {
+  const fixture = createProductionAuthorityLifecycleFixture();
+  const outcomeDirectory = mkdtempSync(path.join(os.tmpdir(), "ha-progress-early-return-"));
+  const events: string[] = [];
+  const messages: Array<{ readonly frame: RepoWriteChildMessage; readonly at: number }> = [];
+  const settlementDelayMs = 180;
+  const settlementTiming: { startedAt?: number; finishedAt?: number } = {};
+  try {
+    enableProgressOperationLease(fixture.authoredRoot);
+    installProgressOperationTask(fixture.authoredRoot);
+    const actor = productionAuthorityActor();
+    const attribution = daemonActorAttribution(actor, { kind: "agent", id: "codex" });
+    await makeTaskHolderService({ rootInput: fixture.repoRoot }).claim({
+      taskId: progressOperationTaskId,
+      principal: taskHolderActor(attribution.taskHolderPrincipal, attribution.executor),
+      ttlMs: 60_000
+    });
+    const store = new DurableRepoWriteOutcomeStoreV1({
+      directory: outcomeDirectory,
+      ...productionProgressOperationAxes(),
+      __testOnlyDurabilityHooks: progressOperationDurabilityEvents(events)
+    });
+    const operation = productionProgressOperationHost(
+      store,
+      slowFailedProgressAuthorityComponent(events, settlementDelayMs, settlementTiming),
+      events,
+      outcomeDirectory
+    );
+    let proceeding = false;
+    const child = createRepoWriteChildHost({
+      ...productionProgressOperationAxes(),
+      artifactIdentity: `sha256:${"a".repeat(64)}`,
+      transport: {
+        send: async (frame) => {
+          if (proceeding && frame.kind === "telemetry") {
+            await new Promise<void>((resolve) => setImmediate(resolve));
+          }
+          messages.push({ frame, at: performance.now() });
+        }
+      },
+      hooks: {
+        prepare: (input) => operation.prepare(input),
+        direct: (input) => operation.direct(input),
+        lookup: (input) => operation.lookup(input),
+        shutdown: async () => operation.settlementIdle()
+      }
+    });
+    await child.start();
+    await child.receive(progressOperationSubmitMessage(encodeRepoWriteCommand({
+      command: progressOperationCommand(fixture.repoRoot) as unknown as Record<string, unknown>,
+      context: {
+        actor,
+        authorityConnection: productionAuthorityConnection(actor),
+        currentSession: {
+          runtime: "codex",
+          sessionId: "session-progress-early-return",
+          source: "manual",
+          detectedAt: "2026-07-24T00:00:00.000Z"
+        },
+        executor: { kind: "agent", id: "codex" }
+      }
+    })));
+    const prepared = messages.find(({ frame }) => frame.kind === "prepared")?.frame;
+    assert.equal(prepared?.kind, "prepared");
+    if (prepared?.kind !== "prepared") return;
+
+    proceeding = true;
+    const startedAt = performance.now();
+    await child.receive(progressOperationProceedMessage(prepared.requestId, prepared.opId));
+    const accepted = messages.find(({ frame }) => frame.kind === "accepted");
+    assert.equal(accepted?.frame.kind, "accepted");
+    if (!accepted || accepted.frame.kind !== "accepted") return;
+    const responseMs = accepted.at - startedAt;
+    await operation.settlementIdle();
+    const failed = await operation.lookup({
+      ...productionProgressOperationAxes(),
+      opId: prepared.opId
+    });
+
+    assert.equal(accepted.frame.receipt.settlement?.canonicalVisibility, "pending");
+    assert.equal(typeof accepted.frame.receipt.settlement?.statusQuery, "object");
+    assert.equal(failed.state, "settlement-failed");
+    assert.equal(failed.state === "settlement-failed"
+      ? failed.receipt.settlement?.canonicalVisibility
+      : undefined, "failed");
+    assert.equal(failed.state === "settlement-failed"
+      ? failed.receipt.settlement?.statusQuery.command
+      : undefined, accepted.frame.receipt.settlement?.statusQuery.command);
+    assert.match(failed.state === "settlement-failed"
+      && failed.receipt.settlement?.canonicalVisibility === "failed"
+      ? failed.receipt.settlement.failure.message
+      : "", /simulated slow canonical settlement failure/u);
+    assert.ok(settlementTiming.startedAt !== undefined);
+    assert.ok(settlementTiming.finishedAt !== undefined);
+    assert.ok(
+      accepted.at < settlementTiming.startedAt,
+      `accepted response took ${responseMs.toFixed(1)}ms and followed slow settlement ${JSON.stringify(settlementTiming)}`
+    );
+    t.diagnostic(JSON.stringify({
+      responseMs,
+      settlementDelayMs,
+      settlementStartedAfterMs: settlementTiming.startedAt - startedAt,
+      settlementFinishedAfterMs: settlementTiming.finishedAt - startedAt
+    }));
+  } finally {
+    rmSync(outcomeDirectory, { recursive: true, force: true });
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+operationTest("direct task create returns pending before its deliberately slow failed settlement", async (t) => {
+  const fixture = createProductionAuthorityLifecycleFixture();
+  const outcomeDirectory = mkdtempSync(path.join(os.tmpdir(), "ha-task-create-early-return-"));
+  const events: string[] = [];
+  const messages: Array<{ readonly frame: RepoWriteChildMessage; readonly at: number }> = [];
+  const settlementDelayMs = 180;
+  const settlementTiming: { startedAt?: number; finishedAt?: number } = {};
+  try {
+    const actor = productionAuthorityActor();
+    const store = new DurableRepoWriteOutcomeStoreV1({
+      directory: outcomeDirectory,
+      ...productionProgressOperationAxes()
+    });
+    const operation = productionProgressOperationHost(
+      store,
+      slowFailedDirectAuthorityComponent(events, settlementDelayMs, settlementTiming),
+      events,
+      outcomeDirectory,
+      undefined,
+      false
+    );
+    let executing = false;
+    const child = createRepoWriteChildHost({
+      ...productionProgressOperationAxes(),
+      artifactIdentity: `sha256:${"a".repeat(64)}`,
+      transport: {
+        send: async (frame) => {
+          if (executing && frame.kind === "telemetry") {
+            await new Promise<void>((resolve) => setImmediate(resolve));
+          }
+          messages.push({ frame, at: performance.now() });
+        }
+      },
+      hooks: {
+        prepare: (input) => operation.prepare(input),
+        direct: (input) => operation.direct(input),
+        lookup: (input) => operation.lookup(input),
+        shutdown: async () => operation.settlementIdle()
+      }
+    });
+    await child.start();
+    executing = true;
+    const startedAt = performance.now();
+    await child.receive(newTaskOperationDirectMessage(encodeRepoWriteCommand({
+      command: newTaskOperationCommand(fixture.repoRoot) as unknown as Record<string, unknown>,
+      context: {
+        actor,
+        authorityConnection: productionAuthorityConnection(actor),
+        currentSession: {
+          runtime: "codex",
+          sessionId: "session-task-create-early-return",
+          source: "manual",
+          detectedAt: "2026-07-24T00:00:00.000Z"
+        },
+        executor: { kind: "agent", id: "codex" }
+      }
+    })));
+    const response = messages.find(({ frame }) => frame.kind === "direct-result");
+    assert.equal(response?.frame.kind, "direct-result");
+    if (!response || response.frame.kind !== "direct-result") return;
+    while (settlementTiming.finishedAt === undefined) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    const settlement = response.frame.receipt.settlement;
+    assert.equal(settlement?.canonicalVisibility, "pending");
+    assert.equal(typeof settlement?.statusQuery, "object");
+    if (!settlement) return;
+    const failed = await operation.lookup({
+      ...productionProgressOperationAxes(),
+      opId: settlement.receiptId
+    });
+
+    assert.equal(events.filter((event) => event === "inner-submit").length, 1);
+    assert.equal(failed.state, "settlement-failed");
+    assert.equal(failed.state === "settlement-failed"
+      ? failed.receipt.settlement?.canonicalVisibility
+      : undefined, "failed");
+    assert.equal(failed.state === "settlement-failed"
+      ? failed.receipt.settlement?.statusQuery.command
+      : undefined, settlement.statusQuery.command);
+    assert.match(failed.state === "settlement-failed"
+      && failed.receipt.settlement?.canonicalVisibility === "failed"
+      ? failed.receipt.settlement.failure.message
+      : "", /simulated slow direct canonical settlement failure/u);
+    assert.ok(settlementTiming.startedAt !== undefined);
+    assert.ok(response.at < settlementTiming.startedAt);
+    t.diagnostic(JSON.stringify({
+      responseMs: response.at - startedAt,
+      settlementDelayMs,
+      settlementStartedAfterMs: settlementTiming.startedAt - startedAt,
+      settlementFinishedAfterMs: settlementTiming.finishedAt - startedAt
+    }));
+  } finally {
+    rmSync(outcomeDirectory, { recursive: true, force: true });
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});

--- a/packages/daemon/test/repo-write-child-host-terminal.test.ts
+++ b/packages/daemon/test/repo-write-child-host-terminal.test.ts
@@ -1,6 +1,11 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
+import {
+  pendingCommandReceiptSettlement,
+  withCommandReceiptSettlement
+} from "../src/runtime/command-receipt-settlement.ts";
+import { repoWriteDirectResponseDelivery } from "../src/runtime/repo-write-child-direct.ts";
 import { createRepoWriteChildHost } from "../src/runtime/repo-write-child-host.ts";
 import {
   repoWriteProtocolType,
@@ -156,6 +161,73 @@ test("volatile direct returns an exact receipt without durable frames or lookup"
     requestId: "direct-receipt",
     receipt: rejectedCommandReceipt()
   });
+});
+
+test("direct task write delivers its pending receipt before releasing slow settlement", async (t) => {
+  const messages: Array<{ readonly frame: RepoWriteChildMessage; readonly at: number }> = [];
+  const settlementDelayMs = 120;
+  const settled = deferred<void>();
+  let settlementStartedAt: number | undefined;
+  let settlementFinishedAt: number | undefined;
+  const receipt = withCommandReceiptSettlement(
+    committedCommandReceipt("accepted task create"),
+    pendingCommandReceiptSettlement({
+      receiptId: "repo-write-direct:op-task-create",
+      acceptedAt: "2026-08-05T00:00:00.000Z",
+      sessionId: "session-task-create",
+      acceptedCommitSha: "a".repeat(40),
+      authorityOperationIds: ["op-task-create"]
+    })
+  );
+  const host = createRepoWriteChildHost({
+    repoId: "repo-canonical",
+    workspaceId: "workspace-canonical",
+    generation: 3,
+    artifactIdentity: `sha256:${"a".repeat(64)}`,
+    transport: {
+      send: (frame) => {
+        messages.push({ frame, at: performance.now() });
+      }
+    },
+    hooks: {
+      prepare: async () => { throw new Error("direct must not prepare"); },
+      direct: async () => repoWriteDirectResponseDelivery(
+        receipt as unknown as import("../src/runtime/repo-write-protocol.ts").RepoWriteJsonObject,
+        () => setImmediate(() => {
+          settlementStartedAt = performance.now();
+          const deadline = settlementStartedAt + settlementDelayMs;
+          while (performance.now() < deadline) {
+            // Deliberately model synchronous Git/projection work in the child.
+          }
+          settlementFinishedAt = performance.now();
+          settled.resolve();
+        })
+      ),
+      lookup: async () => ({ state: "not-found" }),
+      shutdown: async () => undefined
+    }
+  });
+  await host.start();
+
+  const startedAt = performance.now();
+  await host.receive(direct("direct-task-create"));
+  const response = messages.find(({ frame }) => frame.kind === "direct-result");
+  assert.equal(response?.frame.kind, "direct-result");
+  if (!response || response.frame.kind !== "direct-result") return;
+  await settled.promise;
+
+  assert.equal(response.frame.receipt.settlement?.canonicalVisibility, "pending");
+  assert.equal(response.frame.receipt.settlement?.statusQuery.command,
+    "ha receipt status repo-write-direct:op-task-create --json");
+  assert.ok(settlementStartedAt !== undefined);
+  assert.ok(settlementFinishedAt !== undefined);
+  assert.ok(response.at < settlementStartedAt);
+  t.diagnostic(JSON.stringify({
+    responseMs: response.at - startedAt,
+    settlementDelayMs,
+    settlementStartedAfterMs: settlementStartedAt - startedAt,
+    settlementFinishedAfterMs: settlementFinishedAt - startedAt
+  }));
 });
 
 test("durable proceed, replacement recovery, and volatile direct share one FIFO", async () => {

--- a/packages/daemon/test/support/production-progress-operation-fixture.ts
+++ b/packages/daemon/test/support/production-progress-operation-fixture.ts
@@ -1,0 +1,536 @@
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+  DurableRepoWriteOutcomeStoreV1,
+  ProductionProgressAppendOperationHost,
+  ReceiptSettlementStore,
+  encodeRepoWriteCommand,
+  type AuthorityRepoComponent,
+  type AuthorityRepoConnectionBinding,
+  type HarnessDaemonRuntime,
+  type ProductionProgressAppendCompileInput,
+  type RepoWriteDocSyncExecution,
+  type RepoWriteParentMessage
+} from "../../src/index.ts";
+import { waitForCurrentAuthoritySettlementRelease } from "../../src/runtime/authority-durable-acceptance-context.ts";
+import { repoWriteProtocolType } from "../../src/runtime/repo-write-protocol.ts";
+import { cliDaemonCommandHostServices } from "../../../cli/src/composition/daemon-command-host-services.ts";
+import { parseNewTaskArgs } from "../../../cli/src/cli/parsers/new-task.ts";
+import type { ParsedCommand } from "../../../cli/src/cli/types.ts";
+
+export const progressOperationTaskId = "task_01KXQ4WTA7Q4XJ5GDDRS1YXNG4";
+
+export function productionProgressOperationHost(
+  store: DurableRepoWriteOutcomeStoreV1,
+  authorityComponent: AuthorityRepoComponent,
+  events: string[],
+  outcomeDirectory: string,
+  executeDocSyncSubmit?: () => Promise<RepoWriteDocSyncExecution>,
+  requireOuterProceeding = true
+) {
+  return new ProductionProgressAppendOperationHost({
+    ...productionProgressOperationAxes(),
+    runtime: progressOperationRuntime(events, requireOuterProceeding),
+    authorityComponent,
+    hostServices: cliDaemonCommandHostServices,
+    outcomeStore: store,
+    settlementStore: new ReceiptSettlementStore({
+      directory: path.join(outcomeDirectory, "settlements"),
+      ...productionProgressOperationAxes()
+    }),
+    now: () => new Date("2026-07-24T00:00:00.000Z"),
+    newOuterOpId: () => "outer-progress-operation",
+    ...(executeDocSyncSubmit ? { executeDocSyncSubmit } : {})
+  });
+}
+
+export function progressOperationAuthorityComponent(
+  events: string[],
+  expectedRecovery?: {
+    readonly outerOpId: string;
+    readonly outerRequestDigest: string;
+  },
+  outcome: "committed" | "already-satisfied" = "committed"
+): AuthorityRepoComponent {
+  const bindConnection = (): AuthorityRepoConnectionBinding => ({
+    ...terminalDurableSubmission(async () => { throw new Error("unplanned authority submit"); }),
+    planCommand: async (expected) => {
+      events.push("plan-fixed-attempt");
+      return progressOperationPlan({
+        ...expected,
+        canonicalEntityId: `task/${progressOperationTaskId}`
+      });
+    },
+    plannedCommandSubmission: ({ expected, plan: fixed, recovery }) => terminalDurableSubmission(
+      async (actual) => {
+        assert.deepEqual(actual, {
+          ...expected,
+          ingress: "generic",
+          canonicalEntityId: fixed.targetEntityId
+        });
+        assert.equal(fixed.innerOpId, "inner-progress-operation");
+        if (expectedRecovery) {
+          assert.deepEqual(recovery, {
+            ...expectedRecovery,
+            outerGeneration: productionProgressOperationAxes().generation
+          });
+          events.push("inner-submit-recovery");
+        } else {
+          assert.equal(recovery, undefined);
+          events.push("inner-submit");
+        }
+        return outcome === "already-satisfied"
+          ? alreadySatisfiedEvidence(fixed.semanticDigest)
+          : committedEvidence(fixed.semanticDigest);
+      }
+    ),
+    planProgressAppend: async (expected) => {
+      events.push("plan-fixed-attempt");
+      return progressOperationPlan(expected);
+    },
+    plannedProgressAppendSubmission: ({ expected, plan: fixed, recovery }) => terminalDurableSubmission(
+      async (actual) => {
+        assert.deepEqual(actual, {
+          ...expected,
+          ingress: "generic"
+        });
+        assert.equal(fixed.innerOpId, "inner-progress-operation");
+        if (expectedRecovery) {
+          assert.deepEqual(recovery, {
+            ...expectedRecovery,
+            outerGeneration: productionProgressOperationAxes().generation
+          });
+          events.push("inner-submit-recovery");
+        } else {
+          assert.equal(recovery, undefined);
+          events.push("inner-submit");
+        }
+        return committedEvidence(fixed.semanticDigest);
+      }
+    )
+  });
+  return {
+    commandSubmissionV2: terminalDurableSubmission(
+      async () => { throw new Error("unbound"); }
+    ),
+    cutoverControl: {} as AuthorityRepoComponent["cutoverControl"],
+    bindConnection,
+    stop: async () => undefined
+  };
+}
+
+export function slowFailedProgressAuthorityComponent(
+  events: string[],
+  settlementDelayMs: number,
+  timing: { startedAt?: number; finishedAt?: number }
+): AuthorityRepoComponent {
+  const bindConnection = (): AuthorityRepoConnectionBinding => ({
+    ...terminalDurableSubmission(async () => { throw new Error("unplanned authority submit"); }),
+    planCommand: async (expected) => {
+      events.push("plan-fixed-attempt");
+      return progressOperationPlan({
+        ...expected,
+        canonicalEntityId: `task/${progressOperationTaskId}`
+      });
+    },
+    plannedCommandSubmission: ({ expected, plan: fixed }) => ({
+      submit: async () => { throw new Error("durable acceptance fixture requires submitDurable"); },
+      submitDurable: async (actual) => {
+        assert.deepEqual(actual, {
+          ...expected,
+          ingress: "generic",
+          canonicalEntityId: fixed.targetEntityId
+        });
+        events.push("inner-submit");
+        const release = waitForCurrentAuthoritySettlementRelease();
+        const settlement = release.then(() => {
+          timing.startedAt = performance.now();
+          const deadline = timing.startedAt + settlementDelayMs;
+          while (performance.now() < deadline) {
+            // Deliberately model synchronous Git/projection work in the child.
+          }
+          timing.finishedAt = performance.now();
+          throw new Error("simulated slow canonical settlement failure");
+        });
+        return {
+          admission: Promise.resolve({
+            kind: "accepted",
+            acceptance: {
+              sessionId: "session-progress-early-return",
+              acceptedCommitSha: "a".repeat(40),
+              flush: {
+                reason: "explicit",
+                opCount: 1,
+                committed: true,
+                watermark: fixed.innerOpId
+              }
+            }
+          }),
+          settlement
+        };
+      }
+    })
+  });
+  return {
+    commandSubmissionV2: terminalDurableSubmission(
+      async () => { throw new Error("unbound"); }
+    ),
+    cutoverControl: {} as AuthorityRepoComponent["cutoverControl"],
+    bindConnection,
+    stop: async () => undefined
+  };
+}
+
+export function slowFailedDirectAuthorityComponent(
+  events: string[],
+  settlementDelayMs: number,
+  timing: { startedAt?: number; finishedAt?: number }
+): AuthorityRepoComponent {
+  let submissionCount = 0;
+  const bindConnection = (): AuthorityRepoConnectionBinding => ({
+    ...terminalDurableSubmission(async () => {
+      throw new Error("direct durable acceptance fixture requires submitDurable");
+    }),
+    submitDurable: async (actual) => {
+      assert.equal(actual.ingress, "generic");
+      assert.equal(actual.command.action.kind, "new-task");
+      submissionCount += 1;
+      events.push("inner-submit");
+      const release = waitForCurrentAuthoritySettlementRelease();
+      const settlement = release.then(() => {
+        timing.startedAt ??= performance.now();
+        const deadline = performance.now() + settlementDelayMs;
+        while (performance.now() < deadline) {
+          // Deliberately model synchronous Git/projection work in the child.
+        }
+        timing.finishedAt = performance.now();
+        throw new Error("simulated slow direct canonical settlement failure");
+      });
+      return {
+        admission: Promise.resolve({
+          kind: "accepted",
+          acceptance: {
+            sessionId: "session-task-create-early-return",
+            acceptedCommitSha: "a".repeat(40),
+            flush: {
+              reason: "explicit",
+              opCount: 1,
+              committed: true,
+              watermark: `inner-task-create-${submissionCount}`
+            }
+          }
+        }),
+        settlement
+      };
+    }
+  });
+  return {
+    commandSubmissionV2: terminalDurableSubmission(
+      async () => { throw new Error("unbound"); }
+    ),
+    cutoverControl: {} as AuthorityRepoComponent["cutoverControl"],
+    bindConnection,
+    stop: async () => undefined
+  };
+}
+
+function terminalDurableSubmission(
+  submit: AuthorityRepoConnectionBinding["submit"]
+): Pick<AuthorityRepoConnectionBinding, "submit" | "submitDurable"> {
+  return {
+    submit,
+    submitDurable: async (input) => {
+      const receipt = await submit(input);
+      return {
+        admission: Promise.resolve({ kind: "terminal", receipt }),
+        settlement: Promise.resolve(receipt)
+      };
+    }
+  };
+}
+
+function progressOperationPlan(expected: ProductionProgressAppendCompileInput) {
+  return {
+    schema: "production-authority-attempt-plan/v1" as const,
+    commandKind: "progress-append" as const,
+    targetEntityId: expected.canonicalEntityId,
+    requestId: "authority-command:progress-operation",
+    innerOpId: "inner-progress-operation",
+    semanticDigest: "1".repeat(64),
+    tokenId: "token-progress-operation",
+    bindingId: "binding-progress-operation",
+    plannedAtMs: "1",
+    expiresAtMs: "300001",
+    presentationTokenBase64url: "AQ",
+    envelopeBase64url: "Ag",
+    attribution: expected.attribution.writeAttribution
+  };
+}
+
+function committedEvidence(semanticDigest: string) {
+  return {
+    tag: "COMMITTED" as const,
+    workspaceId: productionProgressOperationAxes().workspaceId,
+    opId: "inner-progress-operation",
+    semanticDigest,
+    revision: 1,
+    commitSha: "a".repeat(40),
+    previousCommit: null,
+    authorityIntegrity: {
+      schema: "authority-operation-integrity/v2" as const,
+      semanticRequestDigest: semanticDigest,
+      semanticMutationSetDigest: "2".repeat(64),
+      mutationRegistryVersion: 1,
+      actorAxesBindingDigest: "3".repeat(64),
+      canonicalMutationSet: {
+        registryVersion: 1,
+        mutations: [{
+          entity: {
+            registryVersion: 1,
+            entityKind: "task",
+            canonicalRef: `task/${progressOperationTaskId}`
+          },
+          action: { registryVersion: 1, action: "progress-append" }
+        }]
+      }
+    },
+    integrityTuple: {
+      schema: "authority-integrity-tuple/v2" as const,
+      canonicalEventDigest: "4".repeat(64),
+      changeSetDigest: "5".repeat(64),
+      semanticMutationSetDigest: "2".repeat(64),
+      actorAxesBindingDigest: "3".repeat(64)
+    }
+  };
+}
+
+function alreadySatisfiedEvidence(semanticDigest: string) {
+  const integrity = committedEvidence(semanticDigest).authorityIntegrity;
+  return {
+    tag: "ALREADY_SATISFIED" as const,
+    workspaceId: productionProgressOperationAxes().workspaceId,
+    opId: "inner-progress-operation",
+    semanticDigest,
+    message: "目标状态已满足,本次无变更" as const,
+    stateProof: {
+      schema: "authority-already-satisfied-state-proof/v1" as const,
+      entityKind: "task",
+      canonicalRef: `task/${progressOperationTaskId}`,
+      path: `tasks/${progressOperationTaskId}/INDEX.md`,
+      field: "status",
+      requestedValue: "active",
+      observedValue: "active",
+      observedEpoch: "epoch-status",
+      observedRevision: "0",
+      observedBlobDigest: "6".repeat(64)
+    },
+    authorityIntegrity: {
+      ...integrity,
+      canonicalMutationSet: {
+        ...integrity.canonicalMutationSet,
+        mutations: integrity.canonicalMutationSet.mutations.map((mutation) => ({
+          ...mutation,
+          action: { registryVersion: 1, action: "transition" }
+        }))
+      }
+    }
+  };
+}
+
+function progressOperationRuntime(
+  events: string[],
+  requireOuterProceeding: boolean
+): HarnessDaemonRuntime {
+  return {
+    start: async () => { throw new Error("not used"); },
+    stop: async () => undefined,
+    status: () => ({ started: true }) as ReturnType<HarnessDaemonRuntime["status"]>,
+    enqueueInteractiveWrite: async (request) => {
+      if (requireOuterProceeding && !events.includes("outer-proceeding-fsynced")) {
+        throw new Error("operational write started before durable PROCEEDING");
+      }
+      events.push("runtime-event-write");
+      return {
+        commandId: request.commandId,
+        opIds: request.ops.map((op) => op.opId),
+        durable: true,
+        flush: {
+          reason: "explicit",
+          opCount: request.ops.length,
+          committed: true
+        }
+      };
+    },
+    enqueueBackgroundBatch: async () => { throw new Error("not used"); },
+    enqueueMaterializerBatch: async () => ({
+      dryRun: false,
+      merged: 0,
+      considered: 0,
+      branches: [],
+      warnings: []
+    }),
+    enqueueAuthorityPublication: async () => { throw new Error("not used"); },
+    queryExecutionEvidencePage: async () => ({ rows: [], nextCursor: null }),
+    createAttributedCoordinator: () => { throw new Error("not used"); },
+    assertWriteFenceHeld: async () => {
+      if (!events.includes("outer-proceeding-fsynced")) {
+        throw new Error("writer fence checked before durable PROCEEDING");
+      }
+    },
+    admissionBudget: {
+      acquire: () => { throw new Error("not used"); },
+      snapshot: () => ({}) as never
+    } as HarnessDaemonRuntime["admissionBudget"],
+    subscribeProjectionChanges: () => () => undefined
+  };
+}
+
+export function progressOperationCommand(rootDir: string): ParsedCommand {
+  return {
+    rootDir,
+    json: true,
+    action: {
+      kind: "progress-append",
+      taskId: progressOperationTaskId,
+      text: "child operation progress\n",
+      evidence: [],
+      dryRun: false
+    }
+  };
+}
+
+export function newTaskOperationCommand(rootDir: string): ParsedCommand {
+  const parsed = parseNewTaskArgs(
+    ["task", "create", "--title", "Direct early return task"],
+    rootDir,
+    true
+  );
+  if (!parsed?.ok) throw new Error("failed to build new-task fixture command");
+  return parsed.value;
+}
+
+export function statusOperationCommand(rootDir: string): ParsedCommand {
+  return {
+    rootDir,
+    json: true,
+    action: {
+      kind: "status-set",
+      taskId: progressOperationTaskId,
+      status: "active",
+      force: false,
+      dryRun: false
+    }
+  };
+}
+
+export function enableProgressOperationLease(authoredRoot: string): void {
+  writeFileSync(path.join(authoredRoot, "harness.yaml"), [
+    "schema: harness-anything/v1",
+    "project: progress-operation",
+    "settings:",
+    "  tasks:",
+    "    leaseEnforcement: true",
+    ""
+  ].join("\n"));
+}
+
+export function installProgressOperationTask(authoredRoot: string): void {
+  const taskRoot = path.join(authoredRoot, "tasks", `${progressOperationTaskId}-progress-operation`);
+  mkdirSync(taskRoot, { recursive: true });
+  writeFileSync(path.join(taskRoot, "INDEX.md"), [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${progressOperationTaskId}`,
+    "title: Progress operation",
+    "lifecycle:",
+    "  bindingSchema: lifecycle-binding/v1",
+    "  engine: local",
+    "  status: active",
+    "  ref: ",
+    "  titleSnapshot: Progress operation",
+    "  url: ",
+    "  bindingCreatedAt: 2026-07-24T00:00:00.000Z",
+    `  bindingFingerprint: sha256:${"b".repeat(64)}`,
+    "packageDisposition: active",
+    "vertical: default",
+    "preset: default",
+    "provenance:",
+    "  - {runtime: \"human\", sessionId: \"fixture\", boundAt: \"2026-07-24T00:00:00.000Z\"}",
+    "---",
+    "",
+    "# Progress operation",
+    ""
+  ].join("\n"));
+  writeFileSync(path.join(taskRoot, "task_plan.md"), [
+    "# Task Plan",
+    "",
+    "## Goal",
+    "",
+    "Exercise the exact same-state transition path with a substantive plan.",
+    ""
+  ].join("\n"));
+}
+
+export function progressOperationDurabilityEvents(events: string[]) {
+  let target = "";
+  return {
+    beforePublishLink: (input: { readonly target: string }) => {
+      target = input.target;
+    },
+    afterDirectoryFsync: (reason: string) => {
+      if (reason !== "publish") return;
+      if (target.endsWith(".proceeding.json")) events.push("outer-proceeding-fsynced");
+      if (target.endsWith(".terminal.json")) events.push("outer-terminal-fsynced");
+      target = "";
+    }
+  };
+}
+
+export function progressOperationSubmitMessage(
+  command: ReturnType<typeof encodeRepoWriteCommand>
+): Extract<RepoWriteParentMessage, { readonly kind: "submit" }> {
+  return {
+    protocol: repoWriteProtocolType,
+    repoId: productionProgressOperationAxes().repoId,
+    generation: productionProgressOperationAxes().generation,
+    kind: "submit",
+    requestId: "request-progress-early-return",
+    command
+  };
+}
+
+export function progressOperationProceedMessage(
+  requestId: string,
+  opId: string
+): Extract<RepoWriteParentMessage, { readonly kind: "proceed" }> {
+  return {
+    protocol: repoWriteProtocolType,
+    repoId: productionProgressOperationAxes().repoId,
+    generation: productionProgressOperationAxes().generation,
+    kind: "proceed",
+    requestId,
+    opId
+  };
+}
+
+export function newTaskOperationDirectMessage(
+  command: ReturnType<typeof encodeRepoWriteCommand>
+): Extract<RepoWriteParentMessage, { readonly kind: "direct" }> {
+  return {
+    protocol: repoWriteProtocolType,
+    repoId: productionProgressOperationAxes().repoId,
+    generation: productionProgressOperationAxes().generation,
+    kind: "direct",
+    requestId: "request-task-create-early-return",
+    command
+  };
+}
+
+export function productionProgressOperationAxes() {
+  return {
+    repoId: "canonical",
+    workspaceId: "workspace-production",
+    generation: 2
+  } as const;
+}


### PR DESCRIPTION
# English

## Summary

Task-axis governance writes now return at durable acceptance instead of blocking on canonical settlement. The layering was already designed and written (`authority-publication.ts` reports acceptance, waits a release gate, then queues the materializer as background work), but the release gate fired from a `finally` block that only ran after the whole synchronous chain — including the materializer — had already completed. The "background" settlement was therefore never actually backgrounded on this path. Measured on production before the fix: `ha task create` wall 30.87s, durable acceptance at 4.1s, response written at 28.5s, daemon `eventLoopActiveMs` 43.56ms out of 29121ms — pure waiting.

## What Changed

- `authority-durable-acceptance-context.ts`: replace the implicit `finally`-scheduled release with an explicit `holdBackgroundAuthoritySettlement` handle whose `releaseAfterResponse()` is called at the child response boundary; a failed command releases immediately so no background publication is parked without a response owner.
- `production-progress-append-operation.ts`: both durable and direct task write paths thread the release handle to the response boundary; settlement promises unified so failures no longer produce unconsumed rejections.
- `repo-write-child-direct.ts` / `repo-write-child-host.ts`: release settlement after the direct result / accepted / unknown response has been delivered.
- `repo-write-durable-operation-controller.ts`: persist the pending sidecar and attach terminal handling before handing back the release handle (#1316 terminal-state single ownership untouched).
- New integration test `repo-write-acceptance-early-return.test.ts` with real durable and real `new-task` direct fixtures, both artificially stalling settlement by 180ms.

Wiring matrix (which command classes return where, and why):

| Command class | Returns at |
|---|---|
| pure-plan durable: status/progress, task complete main mutation, fact, decision, module, full session-export | durable acceptance, `pending + statusQuery` |
| direct typed: `new-task`, `task-submit`, task claim/review/consent, observed-write mutations | after capturing durable admissions, `pending + statusQuery` |
| `task-complete` auto doc-sync prepublication | keeps synchronous wait for canonical visibility of the prepublished documents, because completion immediately re-reads canonical; the main completion mutation still returns pending |
| `materializer-run` | keeps in-request materializer/recovery wait; it is a local control command and creates no pending authority settlement |
| rejections / no-ops / commands with no durable admission | return their known terminal state; never fabricate `pending` |

## Task And Scope

- Harness task: task_01KZKYXBS1CZ0S5J3VV8WJDFGV
- Branch: codex/accept-early-return
- Public scope: packages/daemon runtime (acceptance context, progress-append operation, child host/direct, durable operation controller), daemon tests
- Private planning/evidence updated: yes
- Out of scope: publication byte re-derivation determinism (separate branch/task), settlement cost reduction itself

## Version Impact

- Version: no version change because this is runtime behavior within existing surfaces
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: production write path response boundary and background settlement release
- Authority: task_01KZKYXBS1CZ0S5J3VV8WJDFGV (derived from the #1310 receipt-tiering line); receipt honesty contract from #1310 preserved
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: production canary re-measurement recorded on the task after deployment

## Verification

- Base `origin/main` SHA: c623f1c2a482df49f019ac3ea5ac11526d5aa9aa
- Branch merge-base with `origin/main`: c623f1c2a482df49f019ac3ea5ac11526d5aa9aa
- Last `git fetch origin` time: 2026-08-10 (this session, pre-push)
- Sync method: rebase onto c623f1c2
- Public diff command: `git diff c623f1c2..7f8e2bb0`
- Private evidence commit/path: harness/tasks/task_01KZKYXBS1CZ0S5J3VV8WJDFGV-task-pending/artifacts/
- Reviewer evidence path: artifacts/wire-early-return-report.md
- GitHub Actions `rewrite-ci` run URL: pending (queued on PR open)
- [x] `git diff --check`
- [x] `npm run check:local` (27/27 gates, fast 363/363, contract 185/185 + 1 Windows skip, 100.0s)
- [x] Targeted tests for the change surface, named with their counts: repo-write-acceptance-early-return (red-first: response 301.5ms following slow settlement → green: durable response 31.7ms / settlement finishes 211.8ms; new-task direct response 49.2ms / settlement finishes 229.3ms); production child cutover 5/5; receipt/controller/store/client/protocol groups green
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: production re-measurement of `ha task create` (requires deployment; canary planned immediately post-merge); remote SSH daemon mode

## Review Evidence

- Self-review: CEO located the defect independently before the worker reported (release gate in a `finally` that ran after the full chain) and verified the diff matches that diagnosis; settlement still runs, failures still surface with `statusQuery`, failed commands release immediately
- Reviewer subagent: implementation by Codex worker with red-first fixtures; wiring matrix reviewed for over-broad application (the two synchronous exceptions carry stated reasons)
- Human review: 泽宇 required immediate return at acceptance with everything else in the background
- Blocking findings: none outstanding

## Residual Risk

- The wiring matrix asserts no other typed governance mutation needs to wait for its own canonical settlement; a mistake here surfaces as a command reading canonical state that is not yet visible. The two known exceptions are encoded and justified.
- Settlement cost itself is unchanged (still grows with ledger size); this PR decouples the user's wait from it rather than reducing it.
- Production verification pending deployment.

## References

- Task: task_01KZKYXBS1CZ0S5J3VV8WJDFGV
- Evidence: harness/tasks/task_01KZKYXBS1CZ0S5J3VV8WJDFGV-task-pending/artifacts/wire-early-return-report.md
- Review: telemetry frames requestId 633:1 (daemon-request-performance/v1 + repo-write-request-telemetry/v1)

---

# 中文

## 概要

task 轴的治理写现在在 **durable 受理点**返回，不再阻塞等待 canonical 落定。分层本来就设计好也写下来了（`authority-publication.ts` 报告受理 → 等释放闸门 → 把 materializer 挂 `enqueueBackground`），但那个闸门是从 `finally` 里触发的，而 `finally` 要等整条同步链——包括 materializer——跑完才执行，所以这条路上的「后台落定」从未真正后台化。修复前生产实测：`ha task create` 墙钟 30.87s，durable 受理在 4.1s，响应 28.5s 才写回，daemon 侧 29121ms 里 `eventLoopActiveMs` 只有 43.56ms——纯等待。

## 改动内容

- `authority-durable-acceptance-context.ts`：把隐式的 `finally` 释放换成显式的 `holdBackgroundAuthoritySettlement` 句柄，由 child 响应边界调用 `releaseAfterResponse()`；命令失败时立即释放，避免后台发布无响应归属地滞留。
- `production-progress-append-operation.ts`：durable 与 direct 两条 task 写路都把释放句柄传到响应边界；统一 settlement promise，消除失败时的未消费 rejection。
- `repo-write-child-direct.ts` / `repo-write-child-host.ts`：direct 结果 / accepted / unknown 响应送达后释放。
- `repo-write-durable-operation-controller.ts`：先持久化 pending sidecar 并挂接既有终态处理，再返回释放句柄（#1316 的终态单一所有权未动）。
- 新增集成测试 `repo-write-acceptance-early-return.test.ts`，真实 durable 与真实 `new-task` direct 两套 fixture，均人为阻塞落定 180ms。

接线矩阵（哪类命令在哪一层返回，以及为什么）：

| 命令类 | 返回层 |
|---|---|
| pure-plan durable：status/progress、task complete 主变更、fact、decision、module、完整 session-export | durable 受理后返回 `pending + statusQuery` |
| direct typed：`new-task`、`task-submit`、task claim/review/consent、observed-write 类变更 | 捕获 durable admissions 后返回 `pending + statusQuery` |
| `task-complete` 自动 doc-sync 前置发布 | 保留同步等待前置文档 canonical 可见，因为完成流程随后立即重读 canonical；主完成变更仍返回 pending |
| `materializer-run` | 保留请求内 materializer/recovery 等待；它是本地控制命令，不制造 pending authority settlement |
| 拒绝 / no-op / 无 durable admission 的命令 | 返回已知终态，不虚构 `pending` |

## 任务与范围

- Harness 任务：task_01KZKYXBS1CZ0S5J3VV8WJDFGV
- 分支：codex/accept-early-return
- 公开范围：packages/daemon runtime（受理上下文、progress-append operation、child host/direct、durable operation controller）与 daemon 测试
- 私有规划/证据已更新：是
- 范围外：发布事件字节重推导确定性（独立分支/任务）、落定成本本身的优化

## 版本影响

- 版本：无版本变更，原因：既有 surface 内的运行时行为变更
- 发布影响：不发布

## 治理声明

- 触碰 protected surface：是
- Protected surface 范围：生产写路的响应边界与后台落定释放
- 授权：task_01KZKYXBS1CZ0S5J3VV8WJDFGV（源自 #1310 回执分层线）；#1310 的回执诚实性契约保持不变
- 机器检查边界：本 PR 仅断言声明存在；是否真实充分由 reviewer 判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：部署后的生产金丝雀复测记入该任务

## 验证

- Base `origin/main` SHA：c623f1c2a482df49f019ac3ea5ac11526d5aa9aa
- 与 `origin/main` 的 merge-base：c623f1c2a482df49f019ac3ea5ac11526d5aa9aa
- 最近 `git fetch origin` 时间：2026-08-10（本会话，push 前）
- 同步方式：rebase 到 c623f1c2
- 公开 diff 命令：`git diff c623f1c2..7f8e2bb0`
- 私有证据 commit/路径：harness/tasks/task_01KZKYXBS1CZ0S5J3VV8WJDFGV-task-pending/artifacts/
- Reviewer 证据路径：artifacts/wire-early-return-report.md
- GitHub Actions `rewrite-ci` run URL：开 PR 后排队
- [x] `git diff --check`
- [x] `npm run check:local`（27/27 gates，fast 363/363，contract 185/185 + 1 Windows skip，100.0s）
- [x] 变更面定向测试及计数：repo-write-acceptance-early-return（红先行：响应 301.5ms 跟在慢落定之后 → 绿：durable 响应 31.7ms / 落定 211.8ms 完成；new-task direct 响应 49.2ms / 落定 229.3ms 完成）；production child cutover 5/5；receipt/controller/store/client/protocol 组全绿
- [ ] GitHub Actions `rewrite-ci` 通过（权威完整门）
- 未运行及原因：`ha task create` 的生产复测（需部署，合并后立即金丝雀）；remote SSH daemon 模式

## Review 证据

- 自查：CEO 在 worker 报告前独立定位到病灶（释放闸门写在 `finally` 里、而它要等整条链跑完），并核对 diff 与该诊断一致；落定仍在跑、失败仍带 `statusQuery` 可见、命令失败立即释放
- Reviewer subagent：Codex worker 实现并带红先行 fixture；接线矩阵按「是否过度一刀切」复核，两个同步例外均有明确理由
- 人工 review：泽宇要求受理即返回、其余全部后台
- 阻塞 findings：无遗留

## 残余风险

- 接线矩阵断言「没有其他 typed governance mutation 必须等自己的 canonical 落定」；若判断有误，症状是某命令读到尚不可见的 canonical 状态。已知的两个例外已编码并说明理由。
- 落定成本本身未变（仍随台账增长）；本 PR 是把使用者的等待与它解耦，不是降低它。
- 生产验证待部署后进行。

## 参考

- 任务：task_01KZKYXBS1CZ0S5J3VV8WJDFGV
- 证据：harness/tasks/task_01KZKYXBS1CZ0S5J3VV8WJDFGV-task-pending/artifacts/wire-early-return-report.md
- Review：遥测帧 requestId 633:1（daemon-request-performance/v1 + repo-write-request-telemetry/v1）
