### PR TITLE
fix(authority): make publication event bytes deterministic

### DIFF
--- a/packages/application/src/authority/durable-committed-event-publisher-v2.ts
+++ b/packages/application/src/authority/durable-committed-event-publisher-v2.ts
@@ -12,7 +12,6 @@ export interface AuthorityCommittedPhysicalObservationV2 {
   readonly commitSha: string;
   readonly previousCommit: string | null;
   readonly physicalChanges: ReadonlyArray<PhysicalChangeV2>;
-  readonly recordedAt: string;
 }
 
 export interface AuthorityCommittedPhysicalObservationPortV2 {
@@ -46,7 +45,7 @@ export function createDurableAuthorityCommittedEventPublisherV2(options: {
         actorAxesBinding: input.actorAxesBinding,
         physicalChanges: observed.physicalChanges,
         occurredAt: input.occurredAt,
-        recordedAt: observed.recordedAt
+        recordedAt: input.occurredAt
       });
       const ensured = options.eventLog.ensure(event);
       const stored = options.eventLog.read(event.workspaceId, event.opId);

--- a/packages/application/test/durable-committed-event-publisher-v2.test.ts
+++ b/packages/application/test/durable-committed-event-publisher-v2.test.ts
@@ -75,6 +75,40 @@ test("publisher adapter ensures and exact-reads the production V2 log with byte-
   });
 });
 
+test("same operation derives byte-identical publication bytes after observation time advances", async () => {
+  await withTempEventLog(async (eventLog) => {
+    const recordedAtByDerivation = [
+      "2026-07-16T00:00:01.000Z",
+      "2026-07-16T00:00:02.000Z"
+    ];
+    let derivation = 0;
+    const publisher = createDurableAuthorityCommittedEventPublisherV2({
+      eventLog,
+      observation: {
+        observe: async (input) => ({
+          commitSha: input.commitSha,
+          previousCommit: input.previousCommit,
+          physicalChanges: [
+            { path: "task.md", beforeDigest: null, afterDigest: "55".repeat(32) }
+          ],
+          // Legacy/parallel observers may still carry their own wall clock.
+          // It is observation metadata, not a publish-once byte input.
+          recordedAt: recordedAtByDerivation[derivation++]!
+        })
+      }
+    });
+    const input = publicationInput();
+
+    const first = await publisher.publish(input);
+    const firstBytes = eventLog.readBytes(first.workspaceId, first.opId);
+    const rederived = await publisher.publish(input);
+    const rederivedBytes = eventLog.readBytes(rederived.workspaceId, rederived.opId);
+
+    assert.deepEqual(rederivedBytes, firstBytes);
+    assert.equal(rederived.recordedAt, input.occurredAt);
+  });
+});
+
 test("publisher adapter preserves protocol damage when the same durable key receives different bytes", async () => {
   await withTempEventLog(async (eventLog) => {
     let afterDigest = "55".repeat(32);
@@ -169,8 +203,7 @@ function physicalObservation(
     }) => ({
       commitSha: boundary?.commitSha ?? input.commitSha,
       previousCommit: boundary?.previousCommit ?? input.previousCommit,
-      physicalChanges: changes(),
-      recordedAt: "2026-07-16T00:00:01.000Z"
+      physicalChanges: changes()
     })
   };
 }

--- a/packages/daemon/src/authority/production/production-authority-lifecycle.ts
+++ b/packages/daemon/src/authority/production/production-authority-lifecycle.ts
@@ -225,7 +225,7 @@ export function createProductionAuthorityLifecycle(input: {
               registryVersion: 1,
               mutations: mutationSets.flatMap((mutationSet) => mutationSet.mutations)
             });
-            return { ...evidence, recordedAt: new Date().toISOString() };
+            return evidence;
           }
         }
       });


### PR DESCRIPTION
# English

## Summary

The same operation re-derived different publication bytes, so publish-once storage rejected the second derivation with `different bytes already exist`. Root cause, established by byte diff rather than code reading: the observation path injected a fresh `new Date()` as `recordedAt`, which is observation metadata, not a publish-once byte input. The fix derives `recordedAt` from the deterministic `occurredAt` input. Strict publish-once conflict detection is unchanged.

## What Changed

- `packages/application/src/authority/durable-committed-event-publisher-v2.ts`: `recordedAt` now comes from `input.occurredAt` instead of the observer's wall clock; the observer's own `recordedAt` is no longer part of the published bytes.
- `packages/daemon/src/authority/production/production-authority-lifecycle.ts`: stop stamping `{...evidence, recordedAt: new Date().toISOString()}` onto observed evidence.
- Red-first pin `same operation derives byte-identical publication bytes after observation time advances`: the observer deliberately keeps returning advancing wall clocks; the test asserts both derivations produce identical bytes.

Measurement, not inference: a real conflicting op's stored bytes and re-derived bytes differed only in `recordedAt` (SHA-256 `81fdb4…f56d5` → `ec1afc…8388`). Field ordering, optional-field presence, attribution, physical changes and `occurredAt` were each measured and ruled out.

## Task And Scope

- Harness task: task_01KZN54KZM0NYCN7YVYCB39JPX
- Branch: codex/publication-byte-determinism
- Public scope: packages/application authority publisher, packages/daemon production lifecycle, application tests
- Private planning/evidence updated: yes
- Out of scope: `AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH` (measured to be a separate defect); `AUTHORITY_CANONICAL_PUBLICATION_NOT_FOUND` (pre-existing on main, see Residual Risk)

## Version Impact

- Version: no version change because this is a runtime determinism fix within existing surfaces
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: authority publication event byte derivation
- Authority: task_01KZN54KZM0NYCN7YVYCB39JPX
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: `AUTHORITY_CANONICAL_PUBLICATION_NOT_FOUND` filed separately; production observation window for zero new `different bytes` failures

## Verification

- Base `origin/main` SHA: c623f1c2a482df49f019ac3ea5ac11526d5aa9aa
- Branch merge-base with `origin/main`: c623f1c2a482df49f019ac3ea5ac11526d5aa9aa
- Last `git fetch origin` time: 2026-08-10 (this session, pre-push)
- Sync method: none needed
- Public diff command: `git diff c623f1c2..347750a2`
- Private evidence commit/path: harness task task_01KZN54KZM0NYCN7YVYCB39JPX (progress + Fact F-ACBJJD9C)
- Reviewer evidence path: worker report on the task
- GitHub Actions `rewrite-ci` run URL: pending (queued on PR open)
- [x] `git diff --check`
- [x] `npm run check:local` (27/27 gates; fast 390/390; contract 424 pass / 1 skip)
- [x] Targeted tests for the change surface, named with their counts: red-first publisher pin fails with `different bytes already exist` before the fix, contract 239/239 after; `production-authority-in-review-submit` run 5 consecutive times: fail/pass/pass/pass/fail, with **zero** `different bytes` occurrences
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: production observation window for the byte-conflict rate (requires deployment; planned post-merge)

## Review Evidence

- Self-review: CEO verified the fix derives from a deterministic input rather than loosening comparison, and that the pin keeps an advancing observer clock so it would fail again if the wall clock re-entered the bytes
- Reviewer subagent: Codex worker, measurement-first (byte diff of a real conflicting op), candidate causes eliminated by measurement rather than code shape
- Human review: 泽宇 escalated this defect family after it bit two unrelated PRs
- Blocking findings: none outstanding

## Residual Risk

- The 2 failures in the 5 consecutive runs are `AUTHORITY_CANONICAL_PUBLICATION_NOT_FOUND`, a **different** fingerprint. A negative control was run on unmodified `main` (c623f1c2): the same fingerprint appears there too (2 of 3 runs), so it is pre-existing and not introduced by this change. It is filed as its own defect and is not addressed here.
- `AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH` (24 production instances) is measured to be a separate cause and remains open.
- Production rate of `different bytes` failures should be observed post-deployment before declaring the family closed.

## References

- Task: task_01KZN54KZM0NYCN7YVYCB39JPX
- Evidence: Fact F-ACBJJD9C; production settlement forensics recorded on task_01KZMS30SBMPJNT1JGRCR57A3C (26 of 45 receipts detoured through `different bytes`)
- Review: red-first output and 5-run series in the worker report

---

# 中文

## 概要

同一 op 重新推导时产出不同的发布字节，publish-once 存储以 `different bytes already exist` 拒收。根因由**字节 diff 测量**而非读代码得出：观察路径把一个新的 `new Date()` 作为 `recordedAt` 注入，而它是观察元数据，不是 publish-once 的字节输入。修复让 `recordedAt` 由确定性的 `occurredAt` 派生。严格的 publish-once 冲突检测保持不变。

## 改动内容

- `packages/application/src/authority/durable-committed-event-publisher-v2.ts`：`recordedAt` 改由 `input.occurredAt` 派生，观察者自带的 `recordedAt` 不再进入发布字节。
- `packages/daemon/src/authority/production/production-authority-lifecycle.ts`：不再对 observed evidence 盖 `{...evidence, recordedAt: new Date().toISOString()}`。
- 红先行钉子 `same operation derives byte-identical publication bytes after observation time advances`：观察者故意持续返回递增的墙钟，测试断言两次推导字节完全相同。

测量而非推断：真实冲突 op 的已存字节与重推导字节**仅** `recordedAt` 不同（SHA-256 `81fdb4…f56d5` → `ec1afc…8388`）。字段顺序、可选字段存在性、attribution、physical changes 与 `occurredAt` 均逐一测量排除。

## 任务与范围

- Harness 任务：task_01KZN54KZM0NYCN7YVYCB39JPX
- 分支：codex/publication-byte-determinism
- 公开范围：packages/application authority publisher、packages/daemon production lifecycle、application 测试
- 私有规划/证据已更新：是
- 范围外：`AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH`（测量确认为独立缺陷）；`AUTHORITY_CANONICAL_PUBLICATION_NOT_FOUND`（main 上既有，见残余风险）

## 版本影响

- 版本：无版本变更，原因：既有 surface 内的运行时确定性修复
- 发布影响：不发布

## 治理声明

- 触碰 protected surface：是
- Protected surface 范围：authority 发布事件的字节推导
- 授权：task_01KZN54KZM0NYCN7YVYCB39JPX
- 机器检查边界：本 PR 仅断言声明存在；是否真实充分由 reviewer 判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：`AUTHORITY_CANONICAL_PUBLICATION_NOT_FOUND` 已另立案；生产观察窗验证新增 `different bytes` 失败归零

## 验证

- Base `origin/main` SHA：c623f1c2a482df49f019ac3ea5ac11526d5aa9aa
- 与 `origin/main` 的 merge-base：c623f1c2a482df49f019ac3ea5ac11526d5aa9aa
- 最近 `git fetch origin` 时间：2026-08-10（本会话，push 前）
- 同步方式：无需同步
- 公开 diff 命令：`git diff c623f1c2..347750a2`
- 私有证据 commit/路径：harness 任务 task_01KZN54KZM0NYCN7YVYCB39JPX（progress + Fact F-ACBJJD9C）
- Reviewer 证据路径：任务上的 worker 报告
- GitHub Actions `rewrite-ci` run URL：开 PR 后排队
- [x] `git diff --check`
- [x] `npm run check:local`（27/27 gates；fast 390/390；contract 424 pass / 1 skip）
- [x] 变更面定向测试及计数：红先行 publisher 钉子在修复前以 `different bytes already exist` 失败，修复后 contract 239/239；`production-authority-in-review-submit` 连续 5 次：fail/pass/pass/pass/fail，其中 `different bytes` 出现次数为 **0**
- [ ] GitHub Actions `rewrite-ci` 通过（权威完整门）
- 未运行及原因：字节冲突率的生产观察窗（需部署，合并后进行）

## Review 证据

- 自查：CEO 核实修复是「改由确定性输入派生」而非放宽比较，并核实钉子测试保留了递增的观察者时钟——若墙钟再次进入字节，它会重新变红
- Reviewer subagent：Codex worker，测量优先（真实冲突 op 的字节 diff），候选原因用测量而非代码形状排除
- 人工 review：泽宇在该缺陷族咬中两个不相关 PR 后要求处理
- 阻塞 findings：无遗留

## 残余风险

- 连续 5 次运行中的 2 次失败是 `AUTHORITY_CANONICAL_PUBLICATION_NOT_FOUND`，属**不同**指纹。已在未修改的 `main`（c623f1c2）上跑阴性对照：同一指纹在那里同样出现（3 次中 2 次），因此是既有问题、非本改动引入。已单独立案，本 PR 不处理。
- `AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH`（生产 24 例）经测量为独立成因，仍未处理。
- 宣布该缺陷族收口前，应在部署后观察生产 `different bytes` 失败率。

## 参考

- 任务：task_01KZN54KZM0NYCN7YVYCB39JPX
- 证据：Fact F-ACBJJD9C；生产 settlement 取证记录在 task_01KZMS30SBMPJNT1JGRCR57A3C（45 回执中 26 例走过 `different bytes` 弯路）
- Review：worker 报告中的红先行输出与 5 轮序列
