### PR TITLE
perf(cli): sparsify script-run staging

### DIFF
--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { isCloseoutPlaceholderMarkdown, isTaskDocumentPlaceholderMarkdown, parseReviewMarkdown, type TaskDocumentPlaceholderPolicy } from "@harness-anything/application";
 import { checkTaskProjection, extractMarkdownSection, findEntityRefs, markdownHeadingSections } from "@harness-anything/kernel";
-import type { HarnessLayoutInput, HarnessLayoutOverrides } from "@harness-anything/kernel";
+import type { HarnessLayoutInput } from "@harness-anything/kernel";
 import { listTaskIndexPaths, normalizeRelativeDocumentPath, resolveHarnessLayout } from "@harness-anything/kernel";
 import { readFrontmatter, readScalar } from "@harness-anything/kernel";
 import { cliError, CliErrorCode } from "../cli/error-codes.ts";
@@ -15,6 +15,7 @@ import { validateJournalActorAttribution } from "./actor-attribution-checker.ts"
 import { resolveLiveTaskSectionPolicies } from "./check-live-section-policy.ts";
 import { resolveTaskContractDocuments } from "./check-task-contract.ts";
 import { validateGateArchitectureRetrospectiveGate } from "./gate-retro-checker.ts";
+import { layoutOverridesFromInput } from "./harness-layout-input.ts";
 import { readProjectHarnessSettings, settingsIssue, type ProjectHarnessSettings } from "./settings.ts";
 import { bundledTaskDocumentPlaceholderPolicy } from "./core/task-document-placeholders.ts";
 import { discoverScriptEntries } from "./extensions/script.ts";
@@ -139,6 +140,7 @@ function runCheckScripts(rootInput: HarnessLayoutInput): {
       rootInput,
       commandName: "check",
       script,
+      presets: discovered.presets,
       allowFailedScriptResult: true
     });
     if (!run.ok) {
@@ -592,8 +594,4 @@ function validateMilestoneDossierGate(rootInput: HarnessLayoutInput, taskDirs: R
     }
   }
   return issues;
-}
-
-function layoutOverridesFromInput(rootInput: HarnessLayoutInput): HarnessLayoutOverrides | undefined {
-  return typeof rootInput === "string" ? undefined : rootInput.layoutOverrides;
 }

--- a/packages/cli/src/commands/extensions/preset-capability-runtime.ts
+++ b/packages/cli/src/commands/extensions/preset-capability-runtime.ts
@@ -250,7 +250,10 @@ export function materializeSemanticPresetExecution(options: {
   readonly runId: string;
   readonly resultPath: string;
 }): MaterializationResult {
-  const executionRootInput = options.stage?.rootInput ?? options.rootInput;
+  // Sparse stages contain only declared writer roots. Capability requirements
+  // remain canonical read projections and are materialized into immutable run
+  // handles; only produced artifacts are remapped into the stage below.
+  const executionRootInput = options.rootInput;
   const capabilitiesRoot = path.join(options.runDir, "capabilities");
   mkdirSync(capabilitiesRoot, { recursive: true });
   const readBindings: Record<string, unknown[]> = {};

--- a/packages/cli/src/commands/extensions/preset-entrypoint-runtime.ts
+++ b/packages/cli/src/commands/extensions/preset-entrypoint-runtime.ts
@@ -86,6 +86,7 @@ export function runPresetEntrypoint(
     const run = runScriptHost({
       rootInput,
       commandName,
+      presets: [preset],
       script: {
         ...semanticPresetScriptEntry({ ...preset, manifest: preset.manifest }, entrypoint, semanticEntrypoint),
         context: {

--- a/packages/cli/src/commands/extensions/preset-script-runner.ts
+++ b/packages/cli/src/commands/extensions/preset-script-runner.ts
@@ -25,6 +25,7 @@ import {
   canonicalizeScriptResult,
   createCanonicalScriptStage,
   remapScope,
+  scriptExecutionLayout,
   ScriptStageScopeError,
   scriptIngestOp
 } from "./script-staging.ts";
@@ -151,7 +152,7 @@ export function runLegacyPresetScriptEntrypoint(
       }
     };
   }
-  const executionLayout = stage.layout;
+  const executionLayout = scriptExecutionLayout(stage, writeScope);
   const executionOutputRoot = stage.outputRoot;
   const executionWriteScope = remapScope(stage, writeScope, { retainOriginalPermissions: false });
   const executionReadScope = remapScope(stage, readScope);
@@ -184,7 +185,7 @@ export function runLegacyPresetScriptEntrypoint(
       }
     };
   }
-  const executionBoundaries = [executionLayout.rootDir, layout.rootDir];
+  const executionBoundaries = [stage.layout.rootDir, layout.rootDir];
   if (!resolvedScopeSetIsSafe(executionReadScope, executionBoundaries, "read")) {
     return invalidExecutionScope(commandName, presetSummary, "read");
   }
@@ -205,8 +206,12 @@ export function runLegacyPresetScriptEntrypoint(
     outputBoundary: { kind: "roots", roots: executionWriteScope.roots, inspect: "all" }
   });
 
-  writeFileSync(path.join(evidenceDir, "stdout.txt"), execution.stdout, "utf8");
-  writeFileSync(path.join(evidenceDir, "stderr.txt"), execution.stderr, "utf8");
+  if (execution.stdout.length > 0) {
+    writeFileSync(path.join(evidenceDir, "stdout.txt"), execution.stdout, "utf8");
+  }
+  if (execution.stderr.length > 0) {
+    writeFileSync(path.join(evidenceDir, "stderr.txt"), execution.stderr, "utf8");
+  }
   if (!execution.ok) {
     const generated = execution.failure === "produced-outside-boundary"
       ? execution.generated?.map((filePath) => path.relative(rootDir, filePath).split(path.sep).join("/"))

--- a/packages/cli/src/commands/extensions/preset-smoke.ts
+++ b/packages/cli/src/commands/extensions/preset-smoke.ts
@@ -60,6 +60,7 @@ export function smokePresetEntrypoints(
       smoke = runScriptHost({
         rootInput,
         commandName: "preset-check",
+        presets: [preset],
         script,
         outputRoot,
         allowFailedScriptResult: true,
@@ -118,6 +119,7 @@ function smokePresetV3Entrypoints(
     const smoke = runScriptHost({
       rootInput,
       commandName: "preset-check",
+      presets: [preset],
       script: {
         ...semanticPresetScriptEntry(semanticPreset, name, entrypoint),
         context: {

--- a/packages/cli/src/commands/extensions/script-host.ts
+++ b/packages/cli/src/commands/extensions/script-host.ts
@@ -1,10 +1,10 @@
 import { randomBytes } from "node:crypto";
-import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { HarnessLayoutInput, WriteOp } from "@harness-anything/kernel";
 import { resolveHarnessLayout } from "@harness-anything/kernel";
+import { reportCurrentRepoWriteTelemetry } from "@harness-anything/daemon";
 import { CliErrorCode } from "../../cli/error-codes.ts";
 import type { CliResult } from "../../cli/types.ts";
 import { resolveScriptPolicy } from "./preset-policy.ts";
@@ -12,8 +12,9 @@ import { buildPresetContextProjections } from "./preset-script-context.ts";
 import { scriptChildEnvironment } from "./script-environment.ts";
 import { executeScript } from "./script-executor.ts";
 import { trustedScriptRepositoryContext } from "./script-repository-context.ts";
+import { cachedScriptSyntaxCheck } from "./script-syntax-check.ts";
 import { invalidScriptOrPolicy, scriptFailure, validateResolvedScript } from "./script-host-validation.ts";
-import { discoverPresets } from "./state.ts";
+import type { ResolvedPreset } from "./state.ts";
 import {
   materializeSemanticPresetExecution,
   prepareSemanticPresetExecution,
@@ -35,6 +36,7 @@ import {
   canonicalizeScriptResult,
   createCanonicalScriptStage,
   remapScope,
+  scriptExecutionLayout,
   ScriptStageScopeError,
   scriptIngestOp
 } from "./script-staging.ts";
@@ -86,6 +88,7 @@ export type ScriptHostRunResult = ScriptHostSuccess | {
 export function runScriptHost(options: {
   readonly rootInput: HarnessLayoutInput;
   readonly script: ResolvedScriptEntry;
+  readonly presets: ReadonlyArray<ResolvedPreset>;
   readonly commandName: string;
   readonly inputs?: Record<string, string>;
   readonly outputRoot?: string;
@@ -95,7 +98,7 @@ export function runScriptHost(options: {
 }): ScriptHostRunResult {
   const layout = resolveHarnessLayout(options.rootInput);
   const validation = validateResolvedScript(options.script);
-  const policy = resolveScriptPolicy(options.rootInput, discoverPresets(options.rootInput, options.script.verticalId), {
+  const policy = resolveScriptPolicy(options.rootInput, options.presets, {
     source: options.script.entry.source,
     scriptId: options.script.entry.id,
     presetId: typeof options.script.context?.presetId === "string" ? options.script.context.presetId : undefined
@@ -112,19 +115,7 @@ export function runScriptHost(options: {
       "Script manifest packages must contain only regular files and directories, never symbolic links."
     );
   }
-  const syntax = spawnSync(process.execPath, ["--check", realpathSync.native(scriptPath)], {
-    cwd: options.script.manifestRoot,
-    encoding: "utf8",
-    env: {}
-  });
-  if (syntax.status !== 0) {
-    return scriptFailure(
-      options.commandName,
-      CliErrorCode.ScriptFailed,
-      `Script command is not executable JavaScript: ${(syntax.stderr || syntax.stdout || "syntax check failed").trim()}`
-    );
-  }
-
+  reportCurrentRepoWriteTelemetry("script-scope");
   const fallbackOutputRoot = options.outputRoot ?? path.join(layout.authoredRoot, "context");
   const semanticPreparation = options.script.semantic
     ? prepareSemanticPresetExecution({
@@ -171,6 +162,18 @@ export function runScriptHost(options: {
     );
   }
 
+  if (options.dryRun || options.commandName === "preset-check") {
+    reportCurrentRepoWriteTelemetry("script-syntax");
+    const syntax = cachedScriptSyntaxCheck(scriptPath, options.script.manifestRoot);
+    if (!syntax.ok) {
+      return scriptFailure(
+        options.commandName,
+        CliErrorCode.ScriptFailed,
+        `Script command is not executable JavaScript: ${syntax.hint}`
+      );
+    }
+  }
+
   const runId = `${Date.now().toString(36)}-${randomBytes(4).toString("hex")}`;
   const runDir = path.join(layout.localRoot, "script-runs", runId);
   const contextPath = path.join(runDir, "context.json");
@@ -182,6 +185,9 @@ export function runScriptHost(options: {
 
   let stage: ReturnType<typeof createCanonicalScriptStage> | undefined;
   try {
+    if (!options.dryRun && writeScope.roots.length > 0) {
+      reportCurrentRepoWriteTelemetry("script-stage");
+    }
     stage = !options.dryRun && writeScope.roots.length > 0
       ? createCanonicalScriptStage(options.rootInput, runDir, outputRoot, {
         protectedScopes: [
@@ -198,7 +204,7 @@ export function runScriptHost(options: {
       "Script staging scopes must not contain symbolic links."
     );
   }
-  const executionLayout = stage?.layout ?? layout;
+  const executionLayout = stage ? scriptExecutionLayout(stage, writeScope) : layout;
   const executionOutputRoot = stage?.outputRoot ?? outputRoot;
   const executionReadScope = stage
     ? remapScope(stage, readScope)
@@ -303,7 +309,7 @@ export function runScriptHost(options: {
     );
   }
   const executionBoundaries = stage
-    ? [executionLayout.rootDir, layout.rootDir]
+    ? [stage.layout.rootDir, layout.rootDir]
     : [layout.rootDir];
   if (!resolvedScopeSetIsSafe(executionReadScope, executionBoundaries, "read")) {
     return scriptFailure(options.commandName, CliErrorCode.ScriptScopeInvalidRead, "Script read scope changed to an unsafe filesystem shape before execution.");
@@ -311,6 +317,7 @@ export function runScriptHost(options: {
   if (!resolvedScopeSetIsSafe(executionWriteScope, executionBoundaries, "write")) {
     return scriptFailure(options.commandName, CliErrorCode.ScriptScopeInvalidWrite, "Script write scope changed to an unsafe filesystem shape before execution.");
   }
+  reportCurrentRepoWriteTelemetry("script-execute");
   const execution = executeScript({
     scriptPath: realpathSync.native(scriptPath),
     cwd: options.script.manifestRoot,
@@ -342,8 +349,8 @@ export function runScriptHost(options: {
       substitutions: materializedSemantic ? {} : producePatternSubstitutions(executionLayout, executionOutputRoot)
     }
   });
-  writeFileSync(path.join(runDir, "stdout.txt"), execution.stdout, "utf8");
-  writeFileSync(path.join(runDir, "stderr.txt"), execution.stderr, "utf8");
+  writeScriptOutputIfPresent(path.join(runDir, "stdout.txt"), execution.stdout);
+  writeScriptOutputIfPresent(path.join(runDir, "stderr.txt"), execution.stderr);
   if (!execution.ok) {
     if (execution.failure === "produced-outside-boundary") {
       return scriptFailure(
@@ -397,7 +404,11 @@ export function runScriptHost(options: {
     );
   }
   const generatedPaths = stage ? canonicalGeneratedPaths(stage, execution.generated) : execution.generated;
-  const ingestOp = stage ? scriptIngestOp(stage, materializedSemantic?.writerRoots ?? executionWriteScope.roots, runId) : undefined;
+  let ingestOp: WriteOp | undefined;
+  if (stage) {
+    reportCurrentRepoWriteTelemetry("script-ingest");
+    ingestOp = scriptIngestOp(stage, materializedSemantic?.writerRoots ?? executionWriteScope.roots, runId);
+  }
   const canonicalResult = stage ? canonicalizeScriptResult(stage, scriptedResult.value) : scriptedResult.value;
   if (scriptedResult.value.ok !== true && options.allowFailedScriptResult !== true) {
     const failure = scriptFailure(options.commandName, CliErrorCode.ScriptResultFailed, "Script reported a failed result.", runDir, layout.rootDir);
@@ -426,6 +437,10 @@ export function runScriptHost(options: {
     ...(preparedSemantic ? { capabilityReceipt: preparedSemantic.receipt } : {}),
     ...(ingestOp ? { ingestOp } : {})
   };
+}
+
+function writeScriptOutputIfPresent(filePath: string, body: string): void {
+  if (body.length > 0) writeFileSync(filePath, body, "utf8");
 }
 
 function reportsNoOverwriteLeafConflicts(entry: ScriptEntry): boolean {

--- a/packages/cli/src/commands/extensions/script-staging.ts
+++ b/packages/cli/src/commands/extensions/script-staging.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { cpSync, existsSync, lstatSync, mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import {
   normalizeRelativeDocumentPath,
@@ -30,6 +30,7 @@ export interface CanonicalScriptStage {
   readonly realOutputRoot: string;
   readonly baseline: ReadonlyMap<string, string>;
   readonly baselineBodies: ReadonlyMap<string, string>;
+  readonly semanticContextBodies: ReadonlyMap<string, string>;
 }
 
 export class ScriptStageScopeError extends Error {
@@ -63,16 +64,11 @@ export function createCanonicalScriptStage(
   const authoredRelative = path.relative(realLayout.rootDir, realLayout.authoredRoot);
   const stageAuthoredRoot = path.join(stageRootDir, authoredRelative);
   mkdirSync(stageAuthoredRoot, { recursive: true });
-  if (existsSync(realLayout.authoredRoot)) {
-    cpSync(realLayout.authoredRoot, stageAuthoredRoot, {
-      recursive: true,
-      filter: (source) => path.basename(source) !== ".git"
-    });
-  }
   const stagedRootInput = {
     rootDir: stageRootDir,
     layoutOverrides: {
-      authoredRoot: authoredRelative.split(path.sep).join("/")
+      authoredRoot: authoredRelative.split(path.sep).join("/"),
+      projectRootBoundary: true
     }
   };
   const layout = resolveHarnessLayout(stagedRootInput);
@@ -85,18 +81,34 @@ export function createCanonicalScriptStage(
     realLayout,
     realOutputRoot,
     baseline: new Map(),
-    baselineBodies: new Map()
+    baselineBodies: new Map(),
+    semanticContextBodies: new Map()
   };
-  assertProtectedStageScopes(stageWithoutBaseline, options.protectedScopes ?? []);
-  const baselineBodies = new Map(listGeneratedFiles(layout.authoredRoot).map((filePath) => [
+  const protectedScopes = options.protectedScopes ?? [];
+  assertProtectedRealScopes(stageWithoutBaseline, protectedScopes);
+  const realWriteRoots = sparseRealWriteRoots(stageWithoutBaseline, protectedScopes);
+  materializeSparseWriteRoots(stageWithoutBaseline, realWriteRoots);
+  assertProtectedStagedWriteScopes(stageWithoutBaseline, protectedScopes);
+  const stagedWriteRoots = realWriteRoots.map((root) => stageMirrorPath(stageWithoutBaseline, root));
+  const baselineBodies = new Map(listFilesWithinRoots(stagedWriteRoots).map((filePath) => [
     filePath,
     readFileSync(filePath, "utf8")
   ]));
   const baseline = new Map([...baselineBodies].map(([filePath, body]) => [filePath, sha256Text(body)]));
-  return { rootInput: stagedRootInput, layout, outputRoot, realLayout, realOutputRoot, baseline, baselineBodies };
+  const semanticContextBodies = snapshotSemanticContextBodies(realLayout, realWriteRoots);
+  return {
+    rootInput: stagedRootInput,
+    layout,
+    outputRoot,
+    realLayout,
+    realOutputRoot,
+    baseline,
+    baselineBodies,
+    semanticContextBodies
+  };
 }
 
-function assertProtectedStageScopes(
+function assertProtectedRealScopes(
   stage: CanonicalScriptStage,
   scopes: ReadonlyArray<{
     readonly mode: "read" | "write";
@@ -104,15 +116,92 @@ function assertProtectedStageScopes(
   }>
 ): void {
   for (const protectedScope of scopes) {
-    const stagedScope = remapScope(stage, protectedScope.scope, { retainOriginalPermissions: false });
     if (!resolvedScopeSetIsSafe(
-      stagedScope,
-      [stage.layout.rootDir, stage.realLayout.rootDir],
+      protectedScope.scope,
+      stage.realLayout.rootDir,
       protectedScope.mode
     )) {
       throw new ScriptStageScopeError(protectedScope.mode);
     }
   }
+}
+
+function assertProtectedStagedWriteScopes(
+  stage: CanonicalScriptStage,
+  scopes: ReadonlyArray<{
+    readonly mode: "read" | "write";
+    readonly scope: ResolvedScopeSet;
+  }>
+): void {
+  for (const protectedScope of scopes) {
+    if (protectedScope.mode !== "write") continue;
+    const stagedScope = remapScope(stage, protectedScope.scope, { retainOriginalPermissions: false });
+    if (!resolvedScopeSetIsSafe(stagedScope, stage.layout.rootDir, "write")) {
+      throw new ScriptStageScopeError("write");
+    }
+  }
+}
+
+function sparseRealWriteRoots(
+  stage: CanonicalScriptStage,
+  scopes: ReadonlyArray<{
+    readonly mode: "read" | "write";
+    readonly scope: ResolvedScopeSet;
+  }>
+): ReadonlyArray<string> {
+  const declared = scopes
+    .filter((protectedScope) => protectedScope.mode === "write")
+    .flatMap((protectedScope) => protectedScope.scope.roots);
+  const candidates = declared.length > 0 ? declared : [stage.realOutputRoot];
+  const unique = [...new Set(candidates.map((root) => path.resolve(root)))];
+  return unique.filter((root, index) => !unique.some((candidate, candidateIndex) => (
+    candidateIndex !== index && sameOrInside(candidate, root)
+  )));
+}
+
+function materializeSparseWriteRoots(
+  stage: CanonicalScriptStage,
+  realWriteRoots: ReadonlyArray<string>
+): void {
+  for (const realRoot of realWriteRoots) {
+    const stagedRoot = stageMirrorPath(stage, realRoot);
+    if (stagedRoot === realRoot) throw new ScriptStageScopeError("write");
+    let stat;
+    try {
+      stat = lstatSync(realRoot);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      mkdirSync(path.dirname(stagedRoot), { recursive: true });
+      continue;
+    }
+    if (stat.isSymbolicLink() || (!stat.isFile() && !stat.isDirectory())) {
+      throw new ScriptStageScopeError("write");
+    }
+    mkdirSync(path.dirname(stagedRoot), { recursive: true });
+    cpSync(realRoot, stagedRoot, {
+      recursive: stat.isDirectory(),
+      filter: (source) => path.basename(source) !== ".git"
+    });
+  }
+}
+
+function snapshotSemanticContextBodies(
+  realLayout: ReturnType<typeof resolveHarnessLayout>,
+  realWriteRoots: ReadonlyArray<string>
+): ReadonlyMap<string, string> {
+  const indexPaths = new Set(realWriteRoots.flatMap((root) => {
+    const relative = path.relative(realLayout.authoredRoot, root).split(path.sep).join("/");
+    const match = /^(tasks\/[^/]+)(?:\/|$)/u.exec(relative);
+    return match?.[1] ? [`${match[1]}/INDEX.md`] : [];
+  }));
+  return new Map([...indexPaths].sort().flatMap((indexPath) => {
+    const absolutePath = path.join(realLayout.authoredRoot, indexPath);
+    return existsSync(absolutePath) ? [[indexPath, readFileSync(absolutePath, "utf8")] as const] : [];
+  }));
+}
+
+function listFilesWithinRoots(roots: ReadonlyArray<string>): ReadonlyArray<string> {
+  return [...new Set(roots.flatMap((root) => listGeneratedFiles(root)))].sort();
 }
 
 export function canonicalGeneratedPaths(stage: CanonicalScriptStage, stagedPaths: ReadonlyArray<string>): ReadonlyArray<string> {
@@ -130,6 +219,14 @@ export function canonicalizeScriptResult(stage: CanonicalScriptStage, value: Rec
       const absoluteStagePrefix = `${stage.layout.authoredRoot}${path.sep}`;
       if (input.startsWith(absoluteStagePrefix)) {
         return path.join(stage.realLayout.authoredRoot, path.relative(stage.layout.authoredRoot, input));
+      }
+      const stageFromRealRoot = path.relative(
+        stage.realLayout.rootDir,
+        stage.layout.authoredRoot
+      ).split(path.sep).join("/");
+      if (input === stageFromRealRoot || input.startsWith(`${stageFromRealRoot}/`)) {
+        const realRelative = path.relative(stage.realLayout.rootDir, stage.realLayout.authoredRoot).split(path.sep).join("/");
+        return `${realRelative}${input.slice(stageFromRealRoot.length)}`;
       }
       const stageRelative = path.relative(stage.layout.rootDir, stage.layout.authoredRoot).split(path.sep).join("/");
       if (input === stageRelative || input.startsWith(`${stageRelative}/`)) {
@@ -153,23 +250,50 @@ export function stageMirrorPath(stage: CanonicalScriptStage, realPath: string): 
   return insideAuthored ? path.join(stage.layout.authoredRoot, relative) : realPath;
 }
 
+export function scriptExecutionLayout(
+  stage: CanonicalScriptStage,
+  realWriteScope: ResolvedScopeSet
+): CanonicalScriptStage["realLayout"] {
+  const writablePath = (realPath: string): string => realWriteScope.roots.some((writeRoot) => (
+    sameOrInside(writeRoot, realPath)
+  )) ? stageMirrorPath(stage, realPath) : realPath;
+  return {
+    ...stage.realLayout,
+    authoredRoot: writablePath(stage.realLayout.authoredRoot),
+    standardsRoot: writablePath(stage.realLayout.standardsRoot),
+    contextRoot: writablePath(stage.realLayout.contextRoot),
+    tasksRoot: writablePath(stage.realLayout.tasksRoot),
+    decisionsRoot: writablePath(stage.realLayout.decisionsRoot),
+    sessionsRoot: writablePath(stage.realLayout.sessionsRoot),
+    adrRoot: writablePath(stage.realLayout.adrRoot),
+    milestonesRoot: writablePath(stage.realLayout.milestonesRoot),
+    legacyRoot: writablePath(stage.realLayout.legacyRoot),
+    attributionEventsRoot: writablePath(stage.realLayout.attributionEventsRoot),
+    authorityAttributionEventsV2Root: writablePath(stage.realLayout.authorityAttributionEventsV2Root)
+  };
+}
+
 export function remapScope(
   stage: CanonicalScriptStage,
   scope: ResolvedScopeSet,
   options: { readonly retainOriginalPermissions?: boolean } = {}
 ) {
-  const roots = scope.roots.map((root) => stageMirrorPath(stage, root));
-  const remappedPermissions = roots.flatMap((root, index) => (
+  const retainOriginal = options.retainOriginalPermissions !== false;
+  const stagedRoots = scope.roots.map((root) => stageMirrorPath(stage, root));
+  const roots = retainOriginal ? scope.roots : stagedRoots;
+  const remappedPermissions = stagedRoots.flatMap((root, index) => (
     permissionPathsForScope(root, scopeRootIsRecursive(scope, scope.roots[index] ?? root))
   ));
   return {
     ok: true as const,
     roots,
     ...(scope.reportedLeafConflicts ? {
-      reportedLeafConflicts: scope.reportedLeafConflicts.map((candidate) => stageMirrorPath(stage, candidate))
+      reportedLeafConflicts: retainOriginal
+        ? scope.reportedLeafConflicts
+        : scope.reportedLeafConflicts.map((candidate) => stageMirrorPath(stage, candidate))
     } : {}),
     permissions: [...new Set([
-      ...(options.retainOriginalPermissions === false ? [] : scope.permissions),
+      ...(retainOriginal ? scope.permissions : []),
       ...remappedPermissions
     ])]
   };
@@ -180,8 +304,7 @@ export function scriptIngestOp(
   stagedWriteRoots: ReadonlyArray<string>,
   operationId: string
 ): WriteOp | undefined {
-  const writes = listGeneratedFiles(stage.layout.authoredRoot).flatMap((filePath) => {
-    if (!stagedWriteRoots.some((root) => sameOrInside(root, filePath))) return [];
+  const writes = listFilesWithinRoots(stagedWriteRoots).flatMap((filePath) => {
     const body = readFileSync(filePath, "utf8");
     const stagedHash = sha256Text(body);
     if (stage.baseline.get(filePath) === stagedHash) return [];
@@ -259,9 +382,9 @@ function taskIndexContexts(
     const match = /^(tasks\/[^/]+)\//u.exec(documentPath);
     return match?.[1] ? [`${match[1]}/INDEX.md`] : [];
   }))].sort().map((indexPath) => {
-    const absolutePath = path.join(stage.layout.authoredRoot, indexPath);
-    if (!existsSync(absolutePath)) throw new Error(`SEMANTIC_DIFF_REQUIRED: task identity context missing: ${indexPath}`);
-    return { path: indexPath, body: readFileSync(absolutePath, "utf8") };
+    const body = stage.semanticContextBodies.get(indexPath);
+    if (body === undefined) throw new Error(`SEMANTIC_DIFF_REQUIRED: task identity context missing: ${indexPath}`);
+    return { path: indexPath, body };
   });
 }
 

--- a/packages/cli/src/commands/extensions/script-syntax-check.ts
+++ b/packages/cli/src/commands/extensions/script-syntax-check.ts
@@ -1,0 +1,32 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync, realpathSync } from "node:fs";
+import { sha256Text } from "@harness-anything/kernel";
+
+type ScriptSyntaxResult = { readonly ok: true } | { readonly ok: false; readonly hint: string };
+
+const scriptSyntaxCache = new Map<string, ScriptSyntaxResult>();
+const maximumScriptSyntaxCacheEntries = 128;
+
+export function cachedScriptSyntaxCheck(scriptPath: string, manifestRoot: string): ScriptSyntaxResult {
+  const realScriptPath = realpathSync.native(scriptPath);
+  const cacheKey = `${process.version}:${sha256Text(readFileSync(realScriptPath, "utf8"))}`;
+  const cached = scriptSyntaxCache.get(cacheKey);
+  if (cached) return cached;
+  const syntax = spawnSync(process.execPath, ["--check", realScriptPath], {
+    cwd: manifestRoot,
+    encoding: "utf8",
+    env: {}
+  });
+  const result = syntax.status === 0
+    ? { ok: true as const }
+    : {
+      ok: false as const,
+      hint: (syntax.stderr || syntax.stdout || "syntax check failed").trim()
+    };
+  if (scriptSyntaxCache.size >= maximumScriptSyntaxCacheEntries) {
+    const oldest = scriptSyntaxCache.keys().next().value;
+    if (oldest !== undefined) scriptSyntaxCache.delete(oldest);
+  }
+  scriptSyntaxCache.set(cacheKey, result);
+  return result;
+}

--- a/packages/cli/src/commands/extensions/script.ts
+++ b/packages/cli/src/commands/extensions/script.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import type { HarnessLayoutInput, WriteOp } from "@harness-anything/kernel";
 import { resolveHarnessLayout, taskPackagePath } from "@harness-anything/kernel";
+import { reportCurrentRepoWriteTelemetry } from "@harness-anything/daemon";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
 import type { CliResult, ParsedCommand } from "../../cli/types.ts";
 import { resolveActiveVertical } from "./active-vertical.ts";
@@ -83,6 +84,7 @@ function runScriptRun(rootInput: HarnessLayoutInput, action: Extract<ScriptActio
   const run = runScriptHost({
     rootInput,
     commandName: "script-run",
+    presets: discovered.presets,
     script: action.taskId ? {
       ...script,
       context: {
@@ -123,7 +125,8 @@ function scriptUsesTaskOwnedArtifacts(script: ResolvedScriptEntry): boolean {
 export function discoverScriptEntries(
   rootInput: HarnessLayoutInput,
   command: string
-): { readonly ok: true; readonly scripts: ReadonlyArray<ResolvedScriptEntry> } | { readonly ok: false; readonly result: CliResult } {
+): { readonly ok: true; readonly scripts: ReadonlyArray<ResolvedScriptEntry>; readonly presets: ReturnType<typeof discoverPresets> } | { readonly ok: false; readonly result: CliResult } {
+  reportCurrentRepoWriteTelemetry("script-manifest");
   const activeVertical = resolveActiveVertical(rootInput, command);
   if (!activeVertical.ok) return activeVertical;
 
@@ -146,7 +149,8 @@ export function discoverScriptEntries(
       verticalTitle: vertical.manifest.title
     } : undefined
   }));
-  const presetScripts = discoverPresets(rootInput, activeVertical.id)
+  const presets = discoverPresets(rootInput, activeVertical.id);
+  const presetScripts = presets
     .flatMap((preset) => Object.entries(preset.manifest.entrypoints ?? {})
       .flatMap(([entrypointName, entrypoint]) => {
         if (entrypoint.type !== "script") return [];
@@ -167,7 +171,8 @@ export function discoverScriptEntries(
       }));
   return {
     ok: true,
-    scripts: [...verticalScripts, ...presetScripts].sort((left, right) => left.entry.id.localeCompare(right.entry.id))
+    scripts: [...verticalScripts, ...presetScripts].sort((left, right) => left.entry.id.localeCompare(right.entry.id)),
+    presets
   };
 }
 

--- a/packages/cli/src/commands/governance.ts
+++ b/packages/cli/src/commands/governance.ts
@@ -5,6 +5,7 @@ import type { HarnessLayoutInput } from "@harness-anything/kernel";
 import { listTaskIndexPaths, resolveHarnessLayout } from "@harness-anything/kernel";
 import { relativePath } from "../cli/path.ts";
 import type { CliResult, GovernanceRebuildMode } from "../cli/types.ts";
+import { layoutOverridesFromInput } from "./harness-layout-input.ts";
 
 export function runGovernanceRebuild(rootInput: HarnessLayoutInput, mode: GovernanceRebuildMode): CliResult {
   const rootDir = resolveHarnessLayout(rootInput).rootDir;
@@ -83,8 +84,4 @@ function writeGovernanceArchive(rootInput: HarnessLayoutInput, plannedRows: numb
     plannedRows
   }, null, 2), "utf8");
   return relativePath(rootDir, archivePath);
-}
-
-function layoutOverridesFromInput(rootInput: HarnessLayoutInput) {
-  return typeof rootInput === "string" ? undefined : rootInput.layoutOverrides;
 }

--- a/packages/cli/src/commands/harness-layout-input.ts
+++ b/packages/cli/src/commands/harness-layout-input.ts
@@ -1,0 +1,5 @@
+import type { HarnessLayoutInput, HarnessLayoutOverrides } from "@harness-anything/kernel";
+
+export function layoutOverridesFromInput(rootInput: HarnessLayoutInput): HarnessLayoutOverrides | undefined {
+  return typeof rootInput === "string" ? undefined : rootInput.layoutOverrides;
+}

--- a/packages/cli/test/preset-script-cli.test.ts
+++ b/packages/cli/test/preset-script-cli.test.ts
@@ -215,8 +215,8 @@ test("CLI script command discovers and runs the vertical ADR seed scaffold", () 
     assert.match(gitRead(rootDir, "log", "--format=%s"), /script-ingest/u);
     assert.equal(gitRead(rootDir, "status", "--short"), "");
     assert.equal(existsSync(path.join(rootDir, result.evidenceBundle, "context.json")), true);
-    assert.equal(existsSync(path.join(rootDir, result.evidenceBundle, "stdout.txt")), true);
-    assert.equal(existsSync(path.join(rootDir, result.evidenceBundle, "stderr.txt")), true);
+    assert.equal(existsSync(path.join(rootDir, result.evidenceBundle, "stdout.txt")), false);
+    assert.equal(existsSync(path.join(rootDir, result.evidenceBundle, "stderr.txt")), false);
   });
 });
 

--- a/packages/cli/test/preset-script-staging-boundary.test.ts
+++ b/packages/cli/test/preset-script-staging-boundary.test.ts
@@ -40,6 +40,30 @@ test("CLI preset action cannot write directly to the canonical output root", () 
   });
 });
 
+test("CLI script run remains fail closed on runtime syntax errors without pre-execution syntax check", () => {
+  withTempRoot((rootDir) => {
+    initializeHarness(rootDir);
+    writeProcessActionPreset(rootDir, "runtime-syntax-error", "scaffold", [
+      "const broken = ;"
+    ]);
+
+    const result = runJson(rootDir, [
+      "script", "run", "preset:runtime-syntax-error:scaffold",
+      "--task", "task-runtime-syntax-error"
+    ], false);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error.code, "script_failed");
+    assert.equal(existsSync(path.join(
+      rootDir,
+      "harness/tasks/task-runtime-syntax-error"
+    )), false);
+    const stderrPath = path.join(rootDir, result.evidenceBundle, "stderr.txt");
+    assert.equal(existsSync(stderrPath), true);
+    assert.match(readFileSync(stderrPath, "utf8"), /SyntaxError/u);
+  });
+});
+
 test("CLI preset action rejects descendant write symlinks targeting canonical and dangling paths", {
   skip: process.platform === "win32"
 }, () => {

--- a/packages/cli/test/script-staging-cas.test.ts
+++ b/packages/cli/test/script-staging-cas.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -46,6 +46,38 @@ test("script ingest rejects a canonical file modified after staging instead of o
 
     assertCoordinatorRejects(rootDir, op, "snapshot.json");
     assert.equal(readFileSync(targetPath, "utf8"), "concurrent modifier\n");
+  });
+});
+
+test("canonical stage materializes only declared write roots and keeps read-only roots canonical", () => {
+  withFixture(({ rootDir, outputRoot }) => {
+    const unrelatedRoot = path.join(rootDir, "harness/context/unrelated-payload");
+    const unrelatedFile = path.join(unrelatedRoot, "large.bin");
+    const baseFile = path.join(outputRoot, "snapshot.json");
+    write(unrelatedFile, "unrelated\n".repeat(1_024));
+    write(baseFile, "staged base\n");
+    const writeScope = {
+      roots: [outputRoot],
+      permissions: [outputRoot, `${outputRoot}/**`]
+    };
+    const stage = createCanonicalScriptStage(
+      rootDir,
+      path.join(rootDir, ".harness/runs/sparse"),
+      outputRoot,
+      { protectedScopes: [{ mode: "write", scope: writeScope }] }
+    );
+
+    assert.equal(existsSync(path.join(stage.outputRoot, "snapshot.json")), true);
+    assert.equal(existsSync(path.join(stage.layout.authoredRoot, "context/unrelated-payload/large.bin")), false);
+    assert.deepEqual([...stage.baseline.keys()], [path.join(stage.outputRoot, "snapshot.json")]);
+
+    const remappedRead = remapScope(stage, {
+      roots: [unrelatedRoot],
+      permissions: [unrelatedRoot, `${unrelatedRoot}/**`]
+    });
+    assert.deepEqual(remappedRead.roots, [unrelatedRoot]);
+    assert.equal(remappedRead.permissions.includes(unrelatedRoot), true);
+    assert.equal(remappedRead.permissions.includes(path.join(stage.layout.authoredRoot, "context/unrelated-payload")), true);
   });
 });
 

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -105,6 +105,7 @@ export * from "./runtime/command-receipt-settlement.ts";
 export * from "./runtime/direct-command-receipt-settlement.ts";
 export * from "./runtime/repo-write-authority-recovery-gate.ts";
 export * from "./runtime/repo-write-progress-command.ts";
+export { reportCurrentRepoWriteTelemetry } from "./runtime/repo-write-telemetry-context.ts";
 export * from "./runtime/production-progress-append-operation.ts";
 export * from "./runtime/repo-write-child-host.ts";
 export * from "./runtime/repo-write-child-process-transport.ts";

--- a/packages/daemon/src/runtime/production-progress-append-operation.ts
+++ b/packages/daemon/src/runtime/production-progress-append-operation.ts
@@ -71,6 +71,7 @@ import {
   type RepoWriteDocSyncExecution
 } from "./repo-write-doc-sync-operation.ts";
 import { exactRepoWriteReceipt } from "./repo-write-exact-receipt.ts";
+import { repoWriteCommandReceiptJsonObject } from "./repo-write-command-receipt.ts";
 
 export type { RepoWriteDocSyncExecution } from "./repo-write-doc-sync-operation.ts";
 
@@ -214,7 +215,7 @@ export class ProductionRepoWriteOperationHost<
       if (directExecution.durable) {
         throw new Error("DOC_SYNC_DURABLE_WRITE_REQUIRES_DURABLE_LANE");
       }
-      return commandReceiptJsonObject(directExecution.receipt);
+      return repoWriteCommandReceiptJsonObject(directExecution.receipt);
     }
     reportCurrentRepoWriteTelemetry("compile-command-normalize");
     const command = await this.options.hostServices.normalizeCommand(
@@ -273,7 +274,7 @@ export class ProductionRepoWriteOperationHost<
         await this.options.recoverSettlements?.();
       }
       return repoWriteDirectResponseDelivery(
-        commandReceiptJsonObject(settleDirectAuthorityCommandReceipt({
+        repoWriteCommandReceiptJsonObject(settleDirectAuthorityCommandReceipt({
           receipt: held.result,
           submissions: durableSubmissions,
           store: this.options.settlementStore,
@@ -293,17 +294,17 @@ export class ProductionRepoWriteOperationHost<
       const current = this.options.outcomeStore.lookup(input.opId);
       return current.state === "terminal"
         ? { state: "terminal", outcome: current.outcome }
-        : { state: "canonical-visible", receipt: commandReceiptJsonObject(settlement.receipt) };
+        : { state: "canonical-visible", receipt: repoWriteCommandReceiptJsonObject(settlement.receipt) };
     }
     if (settlement?.state === "pending") {
       const current = this.options.outcomeStore.lookup(input.opId);
       if (current.state === "terminal") {
         return { state: "terminal", outcome: current.outcome };
       }
-      return { state: "accepted", receipt: commandReceiptJsonObject(settlement.receipt) };
+      return { state: "accepted", receipt: repoWriteCommandReceiptJsonObject(settlement.receipt) };
     }
     if (settlement?.state === "failed") {
-      return { state: "settlement-failed", receipt: commandReceiptJsonObject(settlement.receipt) };
+      return { state: "settlement-failed", receipt: repoWriteCommandReceiptJsonObject(settlement.receipt) };
     }
     const current = this.options.outcomeStore.lookup(input.opId);
     if (current.state === "not-found") return { state: "not-found" };
@@ -313,7 +314,7 @@ export class ProductionRepoWriteOperationHost<
     if (current.state === "outcome-unknown") return { state: "unknown" };
     const resumed = await this.operations.resume(input.opId);
     if ("kind" in resumed && resumed.kind === "accepted") {
-      return { state: "accepted", receipt: commandReceiptJsonObject(resumed.receipt) };
+      return { state: "accepted", receipt: repoWriteCommandReceiptJsonObject(resumed.receipt) };
     }
     if ("phase" in resumed && resumed.phase === "TERMINAL") {
       return { state: "terminal", outcome: resumed };
@@ -569,12 +570,6 @@ export class ProductionRepoWriteOperationHost<
 export {
   ProductionRepoWriteOperationHost as ProductionProgressAppendOperationHost
 };
-
-function commandReceiptJsonObject(
-  value: unknown
-): import("./repo-write-protocol.ts").RepoWriteJsonObject {
-  return JSON.parse(JSON.stringify(value)) as import("./repo-write-protocol.ts").RepoWriteJsonObject;
-}
 
 function terminalEvidence(
   evidence: AuthorityOperationReceipt | undefined,

--- a/packages/daemon/src/runtime/repo-write-child-direct.ts
+++ b/packages/daemon/src/runtime/repo-write-child-direct.ts
@@ -6,6 +6,10 @@ import type {
 import type { WriteError } from "@harness-anything/kernel";
 import { failureReceipt } from "../protocol/receipt-envelope.ts";
 import type { JsonObject } from "../protocol/json-rpc-types.ts";
+import {
+  repoWriteJsonBudget,
+  repoWriteJsonObjectAt
+} from "./repo-write-json-budget.ts";
 import type { RepoWriteChildResponseWriter } from "./repo-write-child-response-writer.ts";
 import type { RepoWriteExecutionSequencer } from "./repo-write-execution-sequencer.ts";
 import {
@@ -124,7 +128,7 @@ export async function executeRepoWriteChildDirect(
     const executed = await runWithRepoWriteTelemetry(
       telemetry.report,
       () => options.sequencer.run(() => {
-        reportCurrentRepoWriteTelemetry("compile");
+        reportCurrentRepoWriteTelemetry("direct-command-started");
         return options.execute({
           repoId: options.repoId,
           workspaceId: options.workspaceId,
@@ -200,10 +204,12 @@ function directWriteRejectionReceipt(
 
 function jsonObjectForReceipt(value: Readonly<Record<string, unknown>>): JsonObject | undefined {
   try {
-    const parsed: unknown = JSON.parse(JSON.stringify(value));
-    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
-      ? parsed as JsonObject
-      : undefined;
+    return repoWriteJsonObjectAt(
+      value,
+      "$.receipt.details",
+      repoWriteJsonBudget(),
+      0
+    ) as JsonObject;
   } catch {
     return undefined;
   }

--- a/packages/daemon/src/runtime/repo-write-command-receipt.ts
+++ b/packages/daemon/src/runtime/repo-write-command-receipt.ts
@@ -2,7 +2,7 @@ import type {
   CommandReceiptEnvelope,
   CommandReceiptSettlement
 } from "@harness-anything/application";
-import type { RepoWriteJsonValue } from "./repo-write-protocol.ts";
+import type { RepoWriteJsonObject, RepoWriteJsonValue } from "./repo-write-protocol.ts";
 import { RepoWriteOutcomeValidationError } from "./repo-write-outcome-errors.ts";
 import {
   repoWriteJsonBudget,
@@ -112,6 +112,10 @@ export function decodeRepoWriteCommandReceiptV2(
     ...(settlement ? { settlement } : {}),
     ...(details ? { details } : {})
   };
+}
+
+export function repoWriteCommandReceiptJsonObject(value: unknown): RepoWriteJsonObject {
+  return decodeRepoWriteCommandReceiptV2(value, "$.receipt") as unknown as RepoWriteJsonObject;
 }
 
 function repoWriteCommandReceiptSettlementAt(

--- a/packages/daemon/src/runtime/repo-write-diagnostic-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-diagnostic-protocol.ts
@@ -5,7 +5,9 @@ interface RepoWriteDiagnosticFrameBase {
 }
 
 export const repoWriteTelemetryPhases = [
-  "queue", "compile", "compile-command-normalize", "compile-authority-plan",
+  "queue", "direct-command-started", "script-manifest", "script-scope",
+  "script-stage", "script-syntax", "script-execute", "script-ingest",
+  "compile", "compile-command-normalize", "compile-authority-plan",
   "compile-task-load", "compile-task-holder", "compile-task-witness",
   "compile-task-plan", "compile-outcome", "journal", "command-conflict-preflight",
   "command-conflict-recheck", "git", "authority-replica-change-read",

--- a/packages/daemon/src/runtime/repo-write-json-budget.ts
+++ b/packages/daemon/src/runtime/repo-write-json-budget.ts
@@ -71,6 +71,10 @@ export function repoWriteJsonValueAt(
     if (key === "__proto__" || key === "prototype" || key === "constructor") {
       repoWriteJsonBudgetInvalid(path, "safe JSON object keys");
     }
+    // Match JSON object encoding at the in-process/wire boundary. Optional
+    // command fields are represented as undefined before serialization and
+    // therefore must be omitted before strict semantic decoding.
+    if (entry === undefined) continue;
     repoWriteJsonBudgetConsumeBytes(budget, key, `${path} key`);
     result[key] = repoWriteJsonValueAt(
       entry,

--- a/packages/daemon/src/runtime/repo-write-progress-command.ts
+++ b/packages/daemon/src/runtime/repo-write-progress-command.ts
@@ -16,6 +16,10 @@ import {
   type RepoWriteCommandDto,
   type RepoWriteJsonObject
 } from "./repo-write-protocol.ts";
+import {
+  repoWriteJsonBudget,
+  repoWriteJsonObjectAt
+} from "./repo-write-json-budget.ts";
 import { makeRepoWriteStrictCodec } from "./repo-write-strict-codec.ts";
 
 const {
@@ -49,10 +53,10 @@ export function encodeRepoWriteCommand(input: {
   if (authority.actor.personId !== input.context.actor.personId) {
     throw new Error("REPO_WRITE_PROGRESS_ACTOR_CONTEXT_MISMATCH");
   }
-  return repoWriteCommandDtoFromDecodedFields({
+  const decoded = repoWriteCommandDtoFromDecodedFields({
     commandName,
     actor: actorStampJson(input.context.actor),
-    context: progressJsonObject({
+    context: {
       authorityConnection: {
         schema: authority.schema,
         connectionId: authority.connectionId,
@@ -69,16 +73,35 @@ export function encodeRepoWriteCommand(input: {
           digest: encodeRepoWriteBytes(authority.channelBinding.digest),
           source: authority.channelBinding.source
         },
-        peerCredential: authority.peerCredential
+        peerCredential: {
+          schema: authority.peerCredential.schema,
+          platform: authority.peerCredential.platform,
+          source: authority.peerCredential.source,
+          uid: authority.peerCredential.uid,
+          ...(authority.peerCredential.gid === undefined ? {} : { gid: authority.peerCredential.gid }),
+          ...(authority.peerCredential.pid === undefined ? {} : { pid: authority.peerCredential.pid })
+        }
       },
-      currentSession: input.context.currentSession,
+      currentSession: {
+        runtime: input.context.currentSession.runtime,
+        sessionId: input.context.currentSession.sessionId,
+        source: input.context.currentSession.source,
+        detectedAt: input.context.currentSession.detectedAt,
+        ...(input.context.currentSession.user === undefined ? {} : { user: input.context.currentSession.user })
+      },
       executor: input.context.executor
-    }),
-    payload: progressJsonObject({
+    } as unknown as RepoWriteJsonObject,
+    payload: {
       command: input.command,
       session: input.context.currentSession
-    })
+    } as unknown as RepoWriteJsonObject
   });
+  return repoWriteJsonObjectAt(
+    decoded,
+    "$.command",
+    repoWriteJsonBudget(),
+    0
+  ) as unknown as RepoWriteCommandDto;
 }
 
 export function encodeRepoWriteProgressCommand(input: {
@@ -289,9 +312,4 @@ function decodeExecutor(value: unknown): TaskHolderExecutor | null {
   exactKeys(executor, ["kind", "id"], "$.context.executor");
   if (executor.kind !== "agent") invalid("$.context.executor.kind");
   return { kind: "agent", id: text(executor.id, "$.context.executor.id") };
-}
-
-function progressJsonObject(value: unknown): RepoWriteJsonObject {
-  const normalized = JSON.parse(JSON.stringify(value)) as unknown;
-  return record(normalized, "$") as RepoWriteJsonObject;
 }

--- a/packages/daemon/src/runtime/repo-write-progress-command.ts
+++ b/packages/daemon/src/runtime/repo-write-progress-command.ts
@@ -53,8 +53,7 @@ export function encodeRepoWriteCommand(input: {
   if (authority.actor.personId !== input.context.actor.personId) {
     throw new Error("REPO_WRITE_PROGRESS_ACTOR_CONTEXT_MISMATCH");
   }
-  const decoded = repoWriteCommandDtoFromDecodedFields({
-    commandName,
+  const fields = repoWriteJsonObjectAt({
     actor: actorStampJson(input.context.actor),
     context: {
       authorityConnection: {
@@ -94,14 +93,14 @@ export function encodeRepoWriteCommand(input: {
     payload: {
       command: input.command,
       session: input.context.currentSession
-    } as unknown as RepoWriteJsonObject
+    }
+  }, "$.command", repoWriteJsonBudget(), 0);
+  return repoWriteCommandDtoFromDecodedFields({
+    commandName,
+    actor: fields.actor as RepoWriteJsonObject,
+    context: fields.context as RepoWriteJsonObject,
+    payload: fields.payload as RepoWriteJsonObject
   });
-  return repoWriteJsonObjectAt(
-    decoded,
-    "$.command",
-    repoWriteJsonBudget(),
-    0
-  ) as unknown as RepoWriteCommandDto;
 }
 
 export function encodeRepoWriteProgressCommand(input: {

--- a/packages/daemon/src/runtime/repo-write-stall-diagnostic.ts
+++ b/packages/daemon/src/runtime/repo-write-stall-diagnostic.ts
@@ -12,6 +12,20 @@ export function repoWriteWaitingStage(
   switch (phase) {
     case "queue":
       return "child-command-admission";
+    case "direct-command-started":
+      return "direct-command-execution";
+    case "script-manifest":
+      return "script-manifest-discovery";
+    case "script-scope":
+      return "script-scope-resolution";
+    case "script-stage":
+      return "script-sparse-staging";
+    case "script-syntax":
+      return "script-syntax-validation";
+    case "script-execute":
+      return "script-execution";
+    case "script-ingest":
+      return "script-cas-ingest";
     case "compile":
       return "command-or-authority-attempt-compilation";
     case "compile-command-normalize":

--- a/packages/daemon/test/repo-write-child-host-terminal.test.ts
+++ b/packages/daemon/test/repo-write-child-host-terminal.test.ts
@@ -154,7 +154,7 @@ test("volatile direct returns an exact receipt without durable frames or lookup"
     messages
       .filter((message) => message.kind === "telemetry")
       .map((message) => message.phase),
-    ["queue", "compile"]
+    ["queue", "direct-command-started"]
   );
   assert.deepEqual(messages.at(-1), {
     ...childBase("direct-result"),


### PR DESCRIPTION
## Summary

Delete the full-authoredRoot staging copy on every non-dry-run script-run (measured 33.5MB→837 bytes staged, 40,089x reduction; production tree would be ~685MiB per write). Stage only declared write roots; keep read roots canonical read-only. Also removes the non-dry-run \`node --check\` pre-pass (real execution stays fail-closed), the duplicate in-command \`discoverPresets\`, target DTO/receipt JSON roundtrips, and empty stdout/stderr artifact files. The misleading \`compile\` telemetry envelope is split into real phases (manifest/scope/stage/syntax/execute/ingest).

Part of the PLT-WriteChain-Diet campaign (charter dec_01KZNZFH272P9W72CG2J8XZPPW): W2 mapping identified this staging copy as the highest-confidence cause of the deterministic 30s script-run wall and today's 22-minute write-path wedge (incident doc 2026-08-10).

## What Changed

- \`script-staging.ts\`: sparse stage — copy declared write roots only; baseline/hash only those roots; ingest walks stagedWriteRoots instead of the whole authored root.
- Three invariants preserved and pinned by hermetic tests: scripts cannot write canonical directly; write set keeps a frozen CAS base (stale-write detection intact); managed docs still go through the semantic differ.
- \`script-host.ts\` / \`script-syntax-check.ts\`: no \`node --check\` on real runs; dry-run/inspect cached by (Node version, script digest).
- \`script.ts\`: presets discovered once and passed into the host.
- \`repo-write-progress-command.ts\` / \`repo-write-command-receipt.ts\`: boundary codec, no extra JSON deep-copy roundtrips.
- \`repo-write-diagnostic-protocol.ts\` / \`repo-write-stall-diagnostic.ts\`: real phase markers replace the catch-all \`compile\`.

## Version Impact

- No version change: internal write-path performance work, no public CLI surface change.

## Verification

- [x] \`npm run check:local\` — 27 local manifest gates green (149.5s; fast 288 tests, contract green)
- [x] Targeted hermetic invariants 8/8 (canonical isolation, stale CAS reject ×2, semantic differ tampering reject, sparse-stage materialization, fail-closed syntax)
- [x] Before/after benchmark same harness & scope: stagedAuthoredBytes 33,554,834 → 837; elapsed 7,807ms → 2,439ms
- [x] \`git diff --check\`
- Not run: full \`npm run check:ci\` (GitHub CI is the authority; local stop point per repo standard)

## Review Evidence

- Self-review: worker report with per-item before/after numbers at \`harness/tasks/task_01KZP28SQ0XPW5NC5XQVMWXACJ-k1-script-run-staging-sparse-stage/artifacts/worker-report-k1.md\`
- Additional review: CEO semantic acceptance against W2 mapping report (map-full-w2-coordinator.md) and knife-order.md wave-1 mandate
- Blocking findings: none

## Residual Risk

- Read roots are now served from the canonical tree (read-only) instead of a frozen copy; scripts observing mid-write canonical state was already possible via daemon reads and is unchanged in trust level.
- Deferred by design: 4x normalize consolidation, scope-check refactor, moving script exec out of the direct FIFO (wave-2/3 lines).

## References

- Task: task_01KZP28SQ0XPW5NC5XQVMWXACJ (milestone PLT-WriteChain-Diet, root task_01KZNZHRHRMQP6JBFQ7S13HCTE)
- Evidence: harness/milestones/platform/write-chain-diet/knife-order.md; harness/context/research/2026-08-10-daemon-write-stall-incident.md

---

## 摘要

删除每次非 dry-run script-run 的全 authoredRoot staging 复制（实测 staged 字节 33.5MB→837B，降 40,089 倍；生产树口径约 685MiB/次）。只 stage 声明的 write roots，read roots 保持 canonical 只读。同时删除非 dry-run 的 \`node --check\` 前置、同命令第二遍 \`discoverPresets\`、DTO/receipt 的重复 JSON 往返、空 stdout/stderr 落盘；误导性的 \`compile\` 遥测包络拆为真实相位。

属于写链路减重战役（charter dec_01KZNZFH272P9W72CG2J8XZPPW）：W2 测绘将此项判定为 script-run 确定性 30s 墙与今日 22 分钟写路楔死的最高置信首因。

## 改动内容

- \`script-staging.ts\`：sparse stage——只复制声明 write roots；baseline/哈希只算这些 roots；ingest 只遍历 stagedWriteRoots。
- 三条不变量保留并有 hermetic 测试钉住：脚本不能直写 canonical；write set 保有 frozen CAS base；managed 文档仍走 semantic differ。
- \`script-host.ts\`/\`script-syntax-check.ts\`：真实执行不再 \`node --check\`（天然 fail-closed）；dry-run 按 (Node 版本, 脚本 digest) 缓存。
- \`script.ts\`：preset 只发现一次传入 host。
- \`repo-write-progress-command.ts\`/\`repo-write-command-receipt.ts\`：边界 codec，删中间深拷贝。
- 遥测 \`compile\` 包络拆为 manifest/scope/stage/syntax/execute/ingest 真相位。

## 版本影响

- 不改版本：内部写路性能工作，无公开 CLI 面变更。

## 验证

- [x] \`npm run check:local\`——27 个本地 manifest gate 全绿（149.5s）
- [x] 定向 hermetic 不变量测试 8/8
- [x] 同口径删前删后基准：staged 字节 33,554,834 → 837；墙钟 7,807ms → 2,439ms
- [x] \`git diff --check\`
- 未运行：完整 \`npm run check:ci\`（GitHub CI 是权威门）

## 审查证据

- 自查：worker 报告（逐项删前删后数字）\`harness/tasks/task_01KZP28SQ0XPW5NC5XQVMWXACJ-k1-script-run-staging-sparse-stage/artifacts/worker-report-k1.md\`
- 额外审查：CEO 按 W2 测绘报告与 knife-order 波次 1 授权做语义验收
- 阻塞发现：无

## 残余风险

- read roots 改为 canonical 只读直读；脚本可观测写中状态这一点与 daemon 读路径既有行为一致，信任级别不变。
- 按边界递延：4 遍 normalize 收敛、scope 检查重构、脚本执行移出 FIFO（波次 2/3）。

## 关联材料

- 任务：task_01KZP28SQ0XPW5NC5XQVMWXACJ（milestone PLT-WriteChain-Diet，root task_01KZNZHRHRMQP6JBFQ7S13HCTE）
- 证据：harness/milestones/platform/write-chain-diet/knife-order.md；harness/context/research/2026-08-10-daemon-write-stall-incident.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)