### PR TITLE
perf(daemon): batch repo-write telemetry phases

### DIFF
--- a/packages/application/src/daemon-log-contract.ts
+++ b/packages/application/src/daemon-log-contract.ts
@@ -1,6 +1,16 @@
 export const daemonLogLevels = ["debug", "info", "warn", "error", "fatal"] as const;
 export type DaemonLogLevel = (typeof daemonLogLevels)[number];
 
+export const daemonLogMessageLimitBytes = 4_096;
+export const daemonLogTelemetryBatchMessageLimitBytes = 1024 * 1024;
+export const repoWriteTelemetryBatchLogEvent = "repo-write.request.telemetry-batch";
+
+export function daemonLogMessageLimitForEvent(event: string): number {
+  return event === repoWriteTelemetryBatchLogEvent
+    ? daemonLogTelemetryBatchMessageLimitBytes
+    : daemonLogMessageLimitBytes;
+}
+
 export interface DaemonLogRedactionV1 {
   readonly policy: "runtime-log-redaction/v1";
   readonly fieldsRemoved: ReadonlyArray<string>;
@@ -119,7 +129,10 @@ export function decodeDaemonLogEntry(value: unknown): DaemonLogEntryV1 {
   if (value.source !== "daemon" && value.source !== "cli") throw invalidEntry("source must be daemon or cli");
   if (!isBoundedPattern(value.component, /^[a-z0-9][a-z0-9.-]*$/u, 80)) throw invalidEntry("component is invalid");
   if (!isBoundedPattern(value.event, /^[a-z0-9][a-z0-9._-]*$/u, 120)) throw invalidEntry("event is invalid");
-  if (typeof value.message !== "string" || value.message.length > 4_096) throw invalidEntry("message is invalid");
+  if (typeof value.message !== "string"
+    || Buffer.byteLength(value.message, "utf8") > daemonLogMessageLimitForEvent(value.event as string)) {
+    throw invalidEntry("message is invalid");
+  }
   for (const key of ["errorCode", "repoId", "requestId", "taskId", "executionId"] as const) {
     if (!isOptionalNullableBoundedString(value[key], 256)) throw invalidEntry(`${key} is invalid`);
   }

--- a/packages/application/src/daemon-log-service.ts
+++ b/packages/application/src/daemon-log-service.ts
@@ -2,6 +2,7 @@
 import { createHmac, randomBytes } from "node:crypto";
 import {
   DaemonLogContractError,
+  daemonLogMessageLimitForEvent,
   decodeDaemonLogEntry,
   decodeDaemonLogListInput,
   type DaemonLogEntryV1,
@@ -27,7 +28,6 @@ export interface DaemonLogStorePort {
   readonly read: () => Promise<DaemonLogStoreReadResult>;
 }
 
-const messageLimit = 4_096;
 const hintLimit = 2_048;
 
 export function makeDaemonLogService(options: DaemonLogServiceOptions): DaemonLogService {
@@ -110,7 +110,13 @@ async function readAllEntries(
 
 function redactDaemonLogEntry(entry: DaemonLogEntryV1, canonicalRoot?: string): DaemonLogEntryV1 {
   const fieldsRemoved = new Set(entry.redaction.fieldsRemoved);
-  const message = redactText(entry.message, canonicalRoot, messageLimit, fieldsRemoved, "message");
+  const message = redactText(
+    entry.message,
+    canonicalRoot,
+    daemonLogMessageLimitForEvent(entry.event),
+    fieldsRemoved,
+    "message"
+  );
   const hintResult = typeof entry.hint === "string"
     ? redactText(entry.hint, canonicalRoot, hintLimit, fieldsRemoved, "hint")
     : undefined;

--- a/packages/application/test/daemon-log-service.test.ts
+++ b/packages/application/test/daemon-log-service.test.ts
@@ -135,6 +135,34 @@ test("daemon log message and hint limits are enforced in UTF-8 bytes", async () 
   assert.equal(entry.redaction.truncated, true);
 });
 
+test("versioned repo-write telemetry batches retain complete diagnostic payloads", async () => {
+  const service = makeDaemonLogService({
+    store: makeMemoryStore().store,
+    now: () => "2026-07-16T12:00:00.000Z"
+  });
+  const message = JSON.stringify({
+    schema: "repo-write-request-telemetry-batch/v1",
+    requestId: "request-batch",
+    spans: Array.from({ length: 140 }, (_, index) => ({
+      phase: "authority-materializer-projection-source-summary",
+      elapsedMs: index,
+      details: { fingerprint: "a".repeat(64), index }
+    }))
+  });
+  assert.ok(Buffer.byteLength(message, "utf8") > 4_096);
+
+  const entry = await service.append({
+    level: "debug",
+    source: "daemon",
+    component: "repo-write-child",
+    event: "repo-write.request.telemetry-batch",
+    message
+  }, { repo: { repoId: "canonical", canonicalRoot: "/tmp/canonical" } });
+
+  assert.equal(entry.message, message);
+  assert.equal(entry.redaction.truncated, false);
+});
+
 function makeMemoryStore(): { readonly store: DaemonLogStorePort; readonly records: unknown[] } {
   const records: unknown[] = [];
   return {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -5,6 +5,7 @@ export * from "./authority/production/production-scanner.ts";
 export * from "./authority/production/publication-evidence.ts";
 export * from "./authority/production/publication-proof-error.ts";
 export * from "./authority/production/recovery.ts";
+export * from "./observability/repo-write-telemetry-log.ts";
 // Shared so every pre-READY path sizes itself against one deadline, not a copy.
 export {
   defaultProductionRecoveryAdmissionTimeoutMs

--- a/packages/daemon/src/lifecycle/daemon-log-file-store.ts
+++ b/packages/daemon/src/lifecycle/daemon-log-file-store.ts
@@ -15,22 +15,85 @@ export interface DaemonLogFileStoreOptions {
 
 export function makeDaemonLogFileStore(options: DaemonLogFileStoreOptions): DaemonLogStorePort {
   const logRoot = path.join(options.userRoot, "logs", "harness-anything");
+  const state: DaemonLogAppendState = { logRoot };
+  let appendTail = Promise.resolve();
   return {
-    append: (entry) => appendEntry(logRoot, entry, options),
-    read: () => readRecords(logRoot)
+    append: (entry) => {
+      const operation = appendTail.then(() => appendEntry(state, entry, options));
+      appendTail = operation.then(() => undefined, () => undefined);
+      return operation;
+    },
+    read: async () => {
+      await appendTail;
+      return readRecords(logRoot);
+    }
   };
 }
 
+interface DaemonLogAppendState {
+  readonly logRoot: string;
+  rootReady?: Promise<void>;
+  segment?: {
+    readonly date: string;
+    readonly index: number;
+    readonly target: string;
+    bytes: number;
+  };
+  maintenanceDue?: boolean;
+}
+
 async function appendEntry(
-  logRoot: string,
+  state: DaemonLogAppendState,
   entry: DaemonLogEntryV1,
   options: DaemonLogFileStoreOptions
 ): Promise<void> {
-  await fs.promises.mkdir(logRoot, { recursive: true, mode: 0o700 });
+  await ensureLogRoot(state);
   const date = entry.timestamp.slice(0, 10);
-  const target = await writableSegment(logRoot, date, options.maxSegmentBytes ?? 10 * 1_024 * 1_024);
-  await fs.promises.appendFile(target, `${JSON.stringify(entry)}\n`, { encoding: "utf8", mode: 0o600 });
-  await enforceRetention(logRoot, entry.timestamp, options.retentionDays ?? 14, options.maxSegments ?? 10);
+  const maxSegmentBytes = options.maxSegmentBytes ?? 10 * 1_024 * 1_024;
+  const rotated = await ensureWritableSegment(state, date, maxSegmentBytes);
+  const line = `${JSON.stringify(entry)}\n`;
+  try {
+    await fs.promises.appendFile(state.segment!.target, line, { encoding: "utf8", mode: 0o600 });
+  } catch (error) {
+    if (isNodeError(error, "ENOENT")) {
+      state.rootReady = undefined;
+      state.segment = undefined;
+    }
+    throw error;
+  }
+  state.segment!.bytes += Buffer.byteLength(line, "utf8");
+  state.maintenanceDue ||= rotated;
+  if (state.maintenanceDue) {
+    await enforceRetention(
+      state.logRoot,
+      entry.timestamp,
+      options.retentionDays ?? 14,
+      options.maxSegments ?? 10
+    );
+    state.maintenanceDue = false;
+  }
+}
+
+async function ensureLogRoot(state: DaemonLogAppendState): Promise<void> {
+  state.rootReady ??= fs.promises.mkdir(state.logRoot, { recursive: true, mode: 0o700 })
+    .then(() => undefined)
+    .catch((error: unknown) => {
+      state.rootReady = undefined;
+      throw error;
+    });
+  await state.rootReady;
+}
+
+async function ensureWritableSegment(
+  state: DaemonLogAppendState,
+  date: string,
+  maxBytes: number
+): Promise<boolean> {
+  const current = state.segment;
+  if (current?.date === date && current.bytes < maxBytes) return false;
+  const nextIndex = current?.date === date ? current.index + 1 : 0;
+  state.segment = await writableSegment(state.logRoot, date, maxBytes, nextIndex);
+  return true;
 }
 
 async function readRecords(logRoot: string): Promise<DaemonLogStoreReadResult> {
@@ -53,8 +116,13 @@ async function readRecords(logRoot: string): Promise<DaemonLogStoreReadResult> {
   return { records, droppedCount };
 }
 
-async function writableSegment(logRoot: string, date: string, maxBytes: number): Promise<string> {
-  let index = 0;
+async function writableSegment(
+  logRoot: string,
+  date: string,
+  maxBytes: number,
+  startIndex: number
+): Promise<NonNullable<DaemonLogAppendState["segment"]>> {
+  let index = startIndex;
   while (true) {
     const name = index === 0 ? `${date}.ndjson` : `${date}.${index}.ndjson`;
     const target = path.join(logRoot, name);
@@ -62,7 +130,7 @@ async function writableSegment(logRoot: string, date: string, maxBytes: number):
       if (isNodeError(error, "ENOENT")) return 0;
       throw error;
     });
-    if (size < maxBytes) return target;
+    if (size < maxBytes) return { date, index, target, bytes: size };
     index += 1;
   }
 }

--- a/packages/daemon/src/lifecycle/run-daemon-serve.ts
+++ b/packages/daemon/src/lifecycle/run-daemon-serve.ts
@@ -46,11 +46,8 @@ import {
   encodeRepoWriteChildLaunchConfig,
   repoWriteChildLaunchConfigSchema
 } from "../runtime/repo-write-child-launch-config.ts";
-import {
-  createProvenanceCapacityTelemetryTrigger
-} from "../observability/provenance-capacity-trigger.ts";
-import { scheduleProvenanceCapacityLog } from "../observability/provenance-capacity-log.ts";
 import { createRepoWriteRetryBudgetSignalSink } from "../observability/repo-write-retry-budget-log.ts";
+import { createRepoWriteTelemetryLogObservers } from "../observability/repo-write-telemetry-log-observers.ts";
 import {
   formatDaemonFailure,
   repoWriteGracefulFailureLog
@@ -281,7 +278,6 @@ export async function runDaemonServe<
               `REPO_WRITE_CHILD_REPO_NOT_CONFIGURED:${repo.repoId}`
             );
           }
-          const provenanceCapacityTrigger = createProvenanceCapacityTelemetryTrigger();
           const publicationRetryBudgetSignal = createRepoWriteRetryBudgetSignalSink(
             daemonLogService,
             { repo }
@@ -290,6 +286,11 @@ export async function runDaemonServe<
             rootDir: repo.canonicalRoot,
             ...(layoutOverrides ? { layoutOverrides } : {})
           }).authoredRoot;
+          const telemetryObservers = createRepoWriteTelemetryLogObservers({
+            daemonLogService,
+            context: { repo },
+            authoredGitRoot
+          });
           const supervisor = new RepoWriteProcessSupervisor({
             repoId: repo.repoId,
             generation: generation.daemonGeneration,
@@ -323,32 +324,8 @@ export async function runDaemonServe<
                 HARNESS_DAEMON_SERVER_HOST: "1"
               }
             }),
-            onTelemetry: (frame) => {
-              const capacitySignal = provenanceCapacityTrigger.observe(frame);
-              void daemonLogService.append({
-                level: "debug",
-                source: "daemon",
-                component: "repo-write-child",
-                event: "repo-write.request.telemetry",
-                message: JSON.stringify({
-                  schema: "repo-write-request-telemetry/v1",
-                  requestId: frame.requestId,
-                  ...(frame.opId ? { opId: frame.opId } : {}),
-                  phase: frame.phase,
-                  elapsedMs: frame.elapsedMs,
-                  ...(frame.details ? { details: frame.details } : {})
-                }),
-                requestId: frame.requestId
-              }, { repo }).catch(() => undefined);
-              if (capacitySignal) {
-                scheduleProvenanceCapacityLog(
-                  daemonLogService,
-                  { repo },
-                  authoredGitRoot,
-                  capacitySignal
-                );
-              }
-            },
+            onTelemetry: telemetryObservers.onTelemetry,
+            onTelemetryBatch: telemetryObservers.onTelemetryBatch,
             onDiagnostic: (frame) => {
               const rejected = frame.kind === "recovery-rejected";
               void daemonLogService.append({

--- a/packages/daemon/src/observability/repo-write-telemetry-log-observers.ts
+++ b/packages/daemon/src/observability/repo-write-telemetry-log-observers.ts
@@ -1,0 +1,90 @@
+import {
+  repoWriteTelemetryBatchLogEvent,
+  type DaemonLogRepoContext,
+  type DaemonLogService
+} from "@harness-anything/application";
+import type {
+  RepoWriteTelemetryBatchFrame,
+  RepoWriteTelemetryFrame
+} from "../runtime/repo-write-protocol.ts";
+import { scheduleProvenanceCapacityLog } from "./provenance-capacity-log.ts";
+import {
+  createProvenanceCapacityTelemetryTrigger,
+  type ProvenanceCapacitySignal
+} from "./provenance-capacity-trigger.ts";
+import { encodeRepoWriteTelemetryBatchLog } from "./repo-write-telemetry-log.ts";
+
+export function createRepoWriteTelemetryLogObservers(input: {
+  readonly daemonLogService: DaemonLogService;
+  readonly context: DaemonLogRepoContext;
+  readonly authoredGitRoot: string;
+}): {
+  readonly onTelemetry: (frame: RepoWriteTelemetryFrame) => void;
+  readonly onTelemetryBatch: (frame: RepoWriteTelemetryBatchFrame) => void;
+} {
+  const capacity = createProvenanceCapacityTelemetryTrigger();
+  const observeCapacity = (frame: RepoWriteTelemetryFrame): void => {
+    scheduleCapacity(input, capacity.observe(frame));
+  };
+  return {
+    onTelemetry: (frame) => {
+      observeCapacity(frame);
+      void input.daemonLogService.append({
+        level: "debug",
+        source: "daemon",
+        component: "repo-write-child",
+        event: "repo-write.request.telemetry",
+        message: JSON.stringify({
+          schema: "repo-write-request-telemetry/v1",
+          requestId: frame.requestId,
+          ...(frame.opId ? { opId: frame.opId } : {}),
+          phase: frame.phase,
+          elapsedMs: frame.elapsedMs,
+          ...(frame.details ? { details: frame.details } : {})
+        }),
+        requestId: frame.requestId
+      }, input.context).catch(() => undefined);
+    },
+    onTelemetryBatch: (batch) => {
+      let capacitySignal: ProvenanceCapacitySignal | null = null;
+      for (const span of batch.spans) {
+        const frame: RepoWriteTelemetryFrame = {
+          protocol: batch.protocol,
+          repoId: batch.repoId,
+          generation: batch.generation,
+          kind: "telemetry",
+          requestId: batch.requestId,
+          ...(batch.opId ? { opId: batch.opId } : {}),
+          ...span
+        };
+        capacitySignal = capacity.observe(frame) ?? capacitySignal;
+      }
+      scheduleCapacity(input, capacitySignal);
+      void input.daemonLogService.append({
+        level: "debug",
+        source: "daemon",
+        component: "repo-write-child",
+        event: repoWriteTelemetryBatchLogEvent,
+        message: encodeRepoWriteTelemetryBatchLog(batch),
+        requestId: batch.requestId
+      }, input.context).catch(() => undefined);
+    }
+  };
+}
+
+function scheduleCapacity(
+  input: {
+    readonly daemonLogService: DaemonLogService;
+    readonly context: DaemonLogRepoContext;
+    readonly authoredGitRoot: string;
+  },
+  signal: ProvenanceCapacitySignal | null
+): void {
+  if (!signal) return;
+  scheduleProvenanceCapacityLog(
+    input.daemonLogService,
+    input.context,
+    input.authoredGitRoot,
+    signal
+  );
+}

--- a/packages/daemon/src/observability/repo-write-telemetry-log.ts
+++ b/packages/daemon/src/observability/repo-write-telemetry-log.ts
@@ -1,0 +1,131 @@
+import {
+  repoWriteTelemetryPhases,
+  type RepoWriteTelemetryBatchFrame,
+  type RepoWriteTelemetryDetails,
+  type RepoWriteTelemetryPhase,
+  type RepoWriteTelemetrySpan
+} from "../runtime/repo-write-diagnostic-protocol.ts";
+
+export const repoWriteTelemetryLogBatchSchema =
+  "repo-write-request-telemetry-batch/v1" as const;
+export const repoWriteTelemetryLogPhaseTable =
+  "repo-write-telemetry-phases/v1" as const;
+
+type CompactTelemetrySpan = readonly [
+  phaseIndex: number,
+  elapsedMs: number,
+  details?: RepoWriteTelemetryDetails
+];
+
+export interface DecodedRepoWriteTelemetryLog {
+  readonly requestId: string;
+  readonly opId?: string;
+  readonly spans: ReadonlyArray<RepoWriteTelemetrySpan>;
+}
+
+export function encodeRepoWriteTelemetryBatchLog(
+  frame: RepoWriteTelemetryBatchFrame
+): string {
+  const spans: ReadonlyArray<CompactTelemetrySpan> = frame.spans.map((span) => {
+    const phaseIndex = repoWriteTelemetryPhases.indexOf(span.phase);
+    if (phaseIndex < 0) throw new Error(`Unsupported repo-write telemetry phase: ${span.phase}`);
+    return span.details === undefined
+      ? [phaseIndex, span.elapsedMs]
+      : [phaseIndex, span.elapsedMs, span.details];
+  });
+  return JSON.stringify({
+    schema: repoWriteTelemetryLogBatchSchema,
+    requestId: frame.requestId,
+    ...(frame.opId ? { opId: frame.opId } : {}),
+    encoding: "json",
+    phaseTable: repoWriteTelemetryLogPhaseTable,
+    spans
+  });
+}
+
+export function decodeRepoWriteTelemetryLog(
+  value: string
+): DecodedRepoWriteTelemetryLog | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
+  if (!isTelemetryLogRecord(parsed) || typeof parsed.requestId !== "string" || !parsed.requestId.trim()) {
+    return null;
+  }
+  if (parsed.schema === "repo-write-request-telemetry/v1") {
+    const span = decodeLegacyTelemetrySpan(parsed);
+    return span ? {
+      requestId: parsed.requestId,
+      ...(typeof parsed.opId === "string" ? { opId: parsed.opId } : {}),
+      spans: [span]
+    } : null;
+  }
+  if (parsed.schema !== repoWriteTelemetryLogBatchSchema
+    || parsed.encoding !== "json"
+    || !Array.isArray(parsed.spans)) {
+    return null;
+  }
+  const indexed = parsed.phaseTable === repoWriteTelemetryLogPhaseTable;
+  const spans: RepoWriteTelemetrySpan[] = [];
+  for (const candidate of parsed.spans) {
+    const span = decodeCompactTelemetrySpan(candidate, indexed);
+    if (!span) return null;
+    spans.push(span);
+  }
+  if (spans.length === 0) return null;
+  return {
+    requestId: parsed.requestId,
+    ...(typeof parsed.opId === "string" ? { opId: parsed.opId } : {}),
+    spans
+  };
+}
+
+function decodeLegacyTelemetrySpan(value: Record<string, unknown>): RepoWriteTelemetrySpan | null {
+  return decodeTelemetryLogSpan(value.phase, value.elapsedMs, value.details);
+}
+
+function decodeCompactTelemetrySpan(
+  value: unknown,
+  indexed: boolean
+): RepoWriteTelemetrySpan | null {
+  if (!Array.isArray(value) || value.length < 2 || value.length > 3) return null;
+  const phase = indexed && Number.isSafeInteger(value[0])
+    ? repoWriteTelemetryPhases[Number(value[0])]
+    : value[0];
+  return decodeTelemetryLogSpan(phase, value[1], value[2]);
+}
+
+function decodeTelemetryLogSpan(
+  phase: unknown,
+  elapsedMs: unknown,
+  details: unknown
+): RepoWriteTelemetrySpan | null {
+  if (typeof phase !== "string"
+    || !(repoWriteTelemetryPhases as ReadonlyArray<string>).includes(phase)
+    || typeof elapsedMs !== "number"
+    || !Number.isFinite(elapsedMs)
+    || elapsedMs < 0) {
+    return null;
+  }
+  if (details !== undefined && !isTelemetryDetails(details)) return null;
+  return {
+    phase: phase as RepoWriteTelemetryPhase,
+    elapsedMs,
+    ...(details === undefined ? {} : { details })
+  };
+}
+
+function isTelemetryDetails(value: unknown): value is RepoWriteTelemetryDetails {
+  return isTelemetryLogRecord(value) && Object.values(value).every((detail) =>
+    detail === null
+    || typeof detail === "string"
+    || typeof detail === "boolean"
+    || (typeof detail === "number" && Number.isFinite(detail)));
+}
+
+function isTelemetryLogRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/daemon/src/runtime/repo-write-child-direct.ts
+++ b/packages/daemon/src/runtime/repo-write-child-direct.ts
@@ -120,11 +120,12 @@ export async function executeRepoWriteChildDirect(
   let telemetry: ReturnType<typeof createRepoWriteTelemetryDelivery> | undefined;
   let releaseSettlement: (() => void) | undefined;
   try {
-    await options.responses.telemetry(message.requestId, "queue", 0);
-    telemetry = createRepoWriteTelemetryDelivery(
-      (phase, elapsedMs, details) =>
+    telemetry = createRepoWriteTelemetryDelivery({
+      deliverBatch: (spans) => options.responses.telemetryBatch(message.requestId, spans),
+      deliverStream: (phase, elapsedMs, details) =>
         options.responses.telemetry(message.requestId, phase, elapsedMs, details)
-    );
+    });
+    telemetry.report("queue", 0);
     const executed = await runWithRepoWriteTelemetry(
       telemetry.report,
       () => options.sequencer.run(() => {
@@ -148,7 +149,7 @@ export async function executeRepoWriteChildDirect(
     telemetry.close();
     await options.responses.directResult(message.requestId, receipt);
   } catch (error) {
-    await telemetry?.flush();
+    await telemetry?.stream();
     telemetry?.close();
     if (isExpectedDirectWriteRejection(error)) {
       await options.responses.directResult(

--- a/packages/daemon/src/runtime/repo-write-child-host.ts
+++ b/packages/daemon/src/runtime/repo-write-child-host.ts
@@ -198,12 +198,14 @@ export class RepoWriteChildHost {
     this.operationsByRequest.set(message.requestId, operation);
     this.activeAdmissions += 1;
     try {
-      await this.responses.telemetry(message.requestId, "queue", 0);
-      const telemetry = createRepoWriteTelemetryDelivery(
-        (phase, elapsedMs, details) =>
+      const telemetry = createRepoWriteTelemetryDelivery({
+        deliverBatch: (spans) =>
+          this.responses.telemetryBatch(message.requestId, spans, operation.opId),
+        deliverStream: (phase, elapsedMs, details) =>
           this.responses.telemetry(message.requestId, phase, elapsedMs, details)
-      );
+      });
       operation.telemetry = telemetry;
+      telemetry.report("queue", 0);
       const prepared = await runWithRepoWriteTelemetry(telemetry.report, () => {
         reportCurrentRepoWriteTelemetry("compile");
         return this.options.hooks.prepare({
@@ -213,12 +215,11 @@ export class RepoWriteChildHost {
           command: message.command
         });
       });
-      await telemetry.flush();
       if (!prepared.opId.trim()) throw new Error("prepare returned an empty opId");
       operation.opId = prepared.opId;
       if (this.operationsById.has(prepared.opId)) {
         operation.state = { phase: advanceRepoWritePhase("child", "not-started", "preparing") };
-        await this.closeTelemetry(operation);
+        await this.closeTelemetry(operation, true);
         this.release(operation);
         await this.responses.notStarted(
           message.requestId,
@@ -231,7 +232,7 @@ export class RepoWriteChildHost {
       this.operationsById.set(prepared.opId, operation);
       if (!this.admissionOpen) {
         operation.state = { phase: advanceRepoWritePhase("child", "not-started", "preparing") };
-        await this.closeTelemetry(operation);
+        await this.closeTelemetry(operation, true);
         this.release(operation);
         await this.responses.notStarted(
           message.requestId,
@@ -249,7 +250,7 @@ export class RepoWriteChildHost {
         operation.state = {
           phase: advanceRepoWritePhase("child", "not-started", operation.state.phase)
         };
-        await this.closeTelemetry(operation);
+        await this.closeTelemetry(operation, true);
         this.release(operation);
         const rejection = classifyRepoWriteNotStartedFailure(error);
         await this.responses.notStarted(
@@ -262,7 +263,7 @@ export class RepoWriteChildHost {
         operation.state = {
           phase: advanceRepoWritePhase("child", "not-started", operation.state.phase)
         };
-        await this.closeTelemetry(operation);
+        await this.closeTelemetry(operation, true);
         this.release(operation);
         throw error;
       } else {
@@ -306,7 +307,7 @@ export class RepoWriteChildHost {
           phase: advanceRepoWritePhase("child", "shutdown-before-proceed", operation.state.phase)
         };
         operation.cancelledBeforeProceed = true;
-        await this.closeTelemetry(operation);
+        await this.closeTelemetry(operation, true);
         this.release(operation);
       }
       await this.responses.notStarted(
@@ -328,9 +329,6 @@ export class RepoWriteChildHost {
       let receipt: RepoWriteJsonObject;
       try {
         const executed = await this.executionSequencer.run(operation.execute!);
-        await operation.telemetry?.flush();
-        operation.telemetry?.reportCurrent("child-telemetry-flushed");
-        await operation.telemetry?.flush();
         if ("kind" in executed && executed.kind === "accepted") {
           if (executed.outerOpId !== operation.opId) {
             throw new Error("execution did not return the matching durable accepted outer outcome");
@@ -354,8 +352,9 @@ export class RepoWriteChildHost {
             receipt
           };
         }
+        operation.telemetry?.reportCurrent("child-telemetry-flushed");
       } catch (error) {
-        await this.closeTelemetry(operation);
+        await this.closeTelemetry(operation, true);
         operation.state = {
           phase: advanceRepoWritePhase("child", "outcome-unknown", "proceeding")
         };
@@ -495,7 +494,7 @@ export class RepoWriteChildHost {
         phase: advanceRepoWritePhase("child", "shutdown-before-proceed", operation.state.phase)
       };
       operation.cancelledBeforeProceed = true;
-      await this.closeTelemetry(operation);
+      await this.closeTelemetry(operation, true);
       this.release(operation);
       cancelled.push(operation);
     }
@@ -510,8 +509,9 @@ export class RepoWriteChildHost {
     await this.maybeCompleteShutdown();
   }
 
-  private async closeTelemetry(operation: HostedOperation): Promise<void> {
-    await operation.telemetry?.flush();
+  private async closeTelemetry(operation: HostedOperation, stream = false): Promise<void> {
+    if (stream) await operation.telemetry?.stream();
+    else await operation.telemetry?.flush();
     operation.telemetry?.close();
   }
 

--- a/packages/daemon/src/runtime/repo-write-child-response-writer.ts
+++ b/packages/daemon/src/runtime/repo-write-child-response-writer.ts
@@ -7,6 +7,7 @@ import {
   type RepoWriteOperationLookupResult,
   type RepoWriteTelemetryDetails,
   type RepoWriteTelemetryPhase,
+  type RepoWriteTelemetrySpan,
   type RepoWriteTerminalOutcome
 } from "./repo-write-protocol.ts";
 
@@ -109,6 +110,20 @@ export class RepoWriteChildResponseWriter {
       phase,
       elapsedMs,
       ...(details ? { details } : {})
+    });
+  }
+
+  telemetryBatch(
+    requestId: string,
+    spans: ReadonlyArray<RepoWriteTelemetrySpan>,
+    opId?: string
+  ): Promise<void> {
+    return this.send({
+      ...this.frameBase(),
+      kind: "telemetry-batch",
+      requestId,
+      ...(opId ? { opId } : {}),
+      spans
     });
   }
 

--- a/packages/daemon/src/runtime/repo-write-client-contract.ts
+++ b/packages/daemon/src/runtime/repo-write-client-contract.ts
@@ -3,6 +3,7 @@ import type {
   RepoWriteParentMessage,
   RepoWriteRecoveryDiagnosticFrame,
   RepoWriteRetryBudgetSignalFrame,
+  RepoWriteTelemetryBatchFrame,
   RepoWriteTelemetryFrame
 } from "./repo-write-protocol.ts";
 import type {
@@ -61,6 +62,7 @@ export interface RepoWriteClientOptions {
   readonly expectedArtifactIdentity?: string;
   readonly limits?: Partial<RepoWriteClientLimits>;
   readonly onTelemetry: (frame: RepoWriteTelemetryFrame) => void;
+  readonly onTelemetryBatch?: (frame: RepoWriteTelemetryBatchFrame) => void;
   readonly onDiagnostic?: (frame: RepoWriteRecoveryDiagnosticFrame) => void;
   readonly onRetryBudgetSignal?: (frame: RepoWriteRetryBudgetSignalFrame) => void;
   readonly onRequestTimeout?: (

--- a/packages/daemon/src/runtime/repo-write-client-direct.ts
+++ b/packages/daemon/src/runtime/repo-write-client-direct.ts
@@ -6,6 +6,7 @@ import {
   type RepoWriteDirectResultFrame,
   type RepoWriteFailureFrame,
   type RepoWriteJsonObject,
+  type RepoWriteTelemetryMessage,
   type RepoWriteTelemetryFrame
 } from "./repo-write-protocol.ts";
 import type { RepoWriteClientTransport } from "./repo-write-client-contract.ts";
@@ -193,7 +194,7 @@ export class RepoWriteDirectClientLane {
     }
   }
 
-  telemetryMatches(message: RepoWriteTelemetryFrame): boolean {
+  telemetryMatches(message: RepoWriteTelemetryMessage): boolean {
     const pending = this.pending.get(message.requestId);
     return pending?.phase === "sent" && message.opId === undefined;
   }

--- a/packages/daemon/src/runtime/repo-write-client-observers.ts
+++ b/packages/daemon/src/runtime/repo-write-client-observers.ts
@@ -1,6 +1,7 @@
 import type {
   RepoWriteRecoveryDiagnosticFrame,
   RepoWriteRetryBudgetSignalFrame,
+  RepoWriteTelemetryBatchFrame,
   RepoWriteTelemetryFrame
 } from "./repo-write-protocol.ts";
 import { repoWriteProtocolType } from "./repo-write-protocol.ts";
@@ -12,6 +13,18 @@ export function repoWriteClientFrameBase(repoId: string, generation: number) {
 export function observeRepoWriteTelemetry(
   observer: (frame: RepoWriteTelemetryFrame) => void,
   frame: RepoWriteTelemetryFrame,
+  failProtocol: () => void
+): void {
+  try {
+    observer(frame);
+  } catch {
+    failProtocol();
+  }
+}
+
+export function observeRepoWriteTelemetryBatch(
+  observer: (frame: RepoWriteTelemetryBatchFrame) => void,
+  frame: RepoWriteTelemetryBatchFrame,
   failProtocol: () => void
 ): void {
   try {

--- a/packages/daemon/src/runtime/repo-write-client-telemetry.ts
+++ b/packages/daemon/src/runtime/repo-write-client-telemetry.ts
@@ -4,11 +4,55 @@ import type {
   PendingShutdown,
   PendingSubmit
 } from "./repo-write-client-pending.ts";
-import type { RepoWriteTelemetryFrame } from "./repo-write-protocol.ts";
+import type {
+  RepoWriteTelemetryBatchFrame,
+  RepoWriteTelemetryFrame,
+  RepoWriteTelemetryMessage
+} from "./repo-write-protocol.ts";
 import { markRepoWriteChildStarted } from "./repo-write-parent-performance.ts";
+import {
+  observeRepoWriteTelemetry,
+  observeRepoWriteTelemetryBatch
+} from "./repo-write-client-observers.ts";
 
-export function repoWriteTelemetryMatchesPendingRequest(
-  message: RepoWriteTelemetryFrame,
+export function handleRepoWriteClientTelemetry(input: {
+  readonly message: RepoWriteTelemetryMessage;
+  readonly submits: Map<string, PendingSubmit>;
+  readonly lookups: Map<string, PendingLookup>;
+  readonly direct: RepoWriteDirectClientLane;
+  readonly shutdown: PendingShutdown | undefined;
+  readonly onTelemetry: (frame: RepoWriteTelemetryFrame) => void;
+  readonly onTelemetryBatch?: (frame: RepoWriteTelemetryBatchFrame) => void;
+  readonly failProtocol: (message: string) => void;
+}): boolean {
+  if (!repoWriteTelemetryMatchesPendingRequest(
+    input.message,
+    input.submits,
+    input.lookups,
+    input.direct,
+    input.shutdown
+  )) return false;
+  recordRepoWriteClientTelemetry(input.message, input.submits, input.lookups, input.direct);
+  if (input.message.kind === "telemetry-batch" && input.onTelemetryBatch) {
+    observeRepoWriteTelemetryBatch(
+      input.onTelemetryBatch,
+      input.message,
+      () => input.failProtocol("Repo writer telemetry batch observer failed.")
+    );
+    return true;
+  }
+  for (const frame of repoWriteTelemetryFrames(input.message)) {
+    observeRepoWriteTelemetry(
+      input.onTelemetry,
+      frame,
+      () => input.failProtocol("Repo writer telemetry observer failed.")
+    );
+  }
+  return true;
+}
+
+function repoWriteTelemetryMatchesPendingRequest(
+  message: RepoWriteTelemetryMessage,
   submits: ReadonlyMap<string, PendingSubmit>,
   lookups: ReadonlyMap<string, PendingLookup>,
   direct: RepoWriteDirectClientLane,
@@ -27,23 +71,40 @@ export function repoWriteTelemetryMatchesPendingRequest(
     && message.opId === undefined;
 }
 
-export function recordRepoWriteClientTelemetry(
-  message: RepoWriteTelemetryFrame,
+function recordRepoWriteClientTelemetry(
+  message: RepoWriteTelemetryMessage,
   submits: Map<string, PendingSubmit>,
   lookups: Map<string, PendingLookup>,
   direct: RepoWriteDirectClientLane
 ): void {
+  const last = repoWriteTelemetryFrames(message).at(-1);
+  if (!last) return;
   const submit = submits.get(message.requestId);
   if (submit) {
     markRepoWriteChildStarted(submit.performanceTiming);
-    submit.lastTelemetry = message;
+    submit.lastTelemetry = last;
     return;
   }
   const lookup = lookups.get(message.requestId);
   if (lookup) {
     markRepoWriteChildStarted(lookup.performanceTiming);
-    lookup.lastTelemetry = message;
+    lookup.lastTelemetry = last;
     return;
   }
-  direct.recordTelemetry(message);
+  direct.recordTelemetry(last);
+}
+
+export function repoWriteTelemetryFrames(
+  message: RepoWriteTelemetryMessage
+): ReadonlyArray<RepoWriteTelemetryFrame> {
+  if (message.kind === "telemetry") return [message];
+  return message.spans.map((span) => ({
+    protocol: message.protocol,
+    repoId: message.repoId,
+    generation: message.generation,
+    kind: "telemetry",
+    requestId: message.requestId,
+    ...(message.opId ? { opId: message.opId } : {}),
+    ...span
+  }));
 }

--- a/packages/daemon/src/runtime/repo-write-client.ts
+++ b/packages/daemon/src/runtime/repo-write-client.ts
@@ -30,13 +30,11 @@ import {
   failRepoWriteSubmit
 } from "./repo-write-client-timeout.ts";
 import {
-  recordRepoWriteClientTelemetry,
-  repoWriteTelemetryMatchesPendingRequest
+  handleRepoWriteClientTelemetry
 } from "./repo-write-client-telemetry.ts";
 import {
   observeRepoWriteRecoveryDiagnostic,
   observeRepoWriteRetryBudgetSignal,
-  observeRepoWriteTelemetry,
   repoWriteClientFrameBase
 } from "./repo-write-client-observers.ts";
 import {
@@ -337,28 +335,19 @@ export class RepoWriteClient {
       pending.resolve(repoWriteLookupResultFromStatus(message));
       return;
     }
-    if (message.kind === "telemetry") {
-      if (!repoWriteTelemetryMatchesPendingRequest(
+    if (message.kind === "telemetry" || message.kind === "telemetry-batch") {
+      if (!handleRepoWriteClientTelemetry({
         message,
-        this.pending,
-        this.pendingLookups,
-        this.directLane,
-        this.shutdownPending
-      )) {
+        submits: this.pending,
+        lookups: this.pendingLookups,
+        direct: this.directLane,
+        shutdown: this.shutdownPending,
+        onTelemetry: this.options.onTelemetry,
+        ...(this.options.onTelemetryBatch ? { onTelemetryBatch: this.options.onTelemetryBatch } : {}),
+        failProtocol: (diagnostic) => this.failProtocol(diagnostic)
+      })) {
         this.failProtocol("Repo writer telemetry does not match a pending request.");
-        return;
       }
-      recordRepoWriteClientTelemetry(
-        message,
-        this.pending,
-        this.pendingLookups,
-        this.directLane
-      );
-      observeRepoWriteTelemetry(
-        this.options.onTelemetry,
-        message,
-        () => this.failProtocol("Repo writer telemetry observer failed.")
-      );
       return;
     }
     if (message.kind === "recovery-deferred" || message.kind === "recovery-rejected") {

--- a/packages/daemon/src/runtime/repo-write-diagnostic-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-diagnostic-protocol.ts
@@ -119,14 +119,29 @@ export type RepoWriteTelemetryPhase = typeof repoWriteTelemetryPhases[number];
 export type RepoWriteTelemetryDetail = string | number | boolean | null;
 export type RepoWriteTelemetryDetails = Readonly<Record<string, RepoWriteTelemetryDetail>>;
 
-export interface RepoWriteTelemetryFrame extends RepoWriteDiagnosticFrameBase {
-  readonly kind: "telemetry";
-  readonly requestId: string;
-  readonly opId?: string;
+export interface RepoWriteTelemetrySpan {
   readonly phase: RepoWriteTelemetryPhase;
   readonly elapsedMs: number;
   readonly details?: RepoWriteTelemetryDetails;
 }
+
+export interface RepoWriteTelemetryFrame extends RepoWriteDiagnosticFrameBase {
+  readonly kind: "telemetry";
+  readonly requestId: string;
+  readonly opId?: string;
+  readonly phase: RepoWriteTelemetrySpan["phase"];
+  readonly elapsedMs: RepoWriteTelemetrySpan["elapsedMs"];
+  readonly details?: RepoWriteTelemetrySpan["details"];
+}
+
+export interface RepoWriteTelemetryBatchFrame extends RepoWriteDiagnosticFrameBase {
+  readonly kind: "telemetry-batch";
+  readonly requestId: string;
+  readonly opId?: string;
+  readonly spans: ReadonlyArray<RepoWriteTelemetrySpan>;
+}
+
+export type RepoWriteTelemetryMessage = RepoWriteTelemetryFrame | RepoWriteTelemetryBatchFrame;
 
 export interface RepoWriteRecoveryDeferredFrame extends RepoWriteDiagnosticFrameBase {
   readonly kind: "recovery-deferred";

--- a/packages/daemon/src/runtime/repo-write-process-supervisor.ts
+++ b/packages/daemon/src/runtime/repo-write-process-supervisor.ts
@@ -22,6 +22,7 @@ export interface RepoWriteProcessSupervisorOptions {
   readonly spawn: () => RepoWriteParentProcessTransport;
   readonly limits?: ConstructorParameters<typeof RepoWriteClient>[0]["limits"];
   readonly onTelemetry?: ConstructorParameters<typeof RepoWriteClient>[0]["onTelemetry"];
+  readonly onTelemetryBatch?: ConstructorParameters<typeof RepoWriteClient>[0]["onTelemetryBatch"];
   readonly onDiagnostic?: ConstructorParameters<typeof RepoWriteClient>[0]["onDiagnostic"];
   readonly onRetryBudgetSignal?: ConstructorParameters<typeof RepoWriteClient>[0]["onRetryBudgetSignal"];
   readonly onRequestTimeout?: ConstructorParameters<typeof RepoWriteClient>[0]["onRequestTimeout"];
@@ -281,6 +282,7 @@ export class RepoWriteProcessSupervisor {
         }),
         ...(this.options.limits ? { limits: this.options.limits } : {}),
         onTelemetry: this.options.onTelemetry ?? (() => undefined),
+        ...(this.options.onTelemetryBatch ? { onTelemetryBatch: this.options.onTelemetryBatch } : {}),
         onDiagnostic: this.options.onDiagnostic,
         onRetryBudgetSignal: this.options.onRetryBudgetSignal,
         onRequestTimeout: this.options.onRequestTimeout,

--- a/packages/daemon/src/runtime/repo-write-protocol-telemetry.ts
+++ b/packages/daemon/src/runtime/repo-write-protocol-telemetry.ts
@@ -1,7 +1,9 @@
 import {
   repoWriteTelemetryPhases,
+  type RepoWriteTelemetryBatchFrame,
   type RepoWriteTelemetryDetails,
   type RepoWriteTelemetryFrame,
+  type RepoWriteTelemetrySpan,
   type RepoWriteTelemetryPhase
 } from "./repo-write-diagnostic-protocol.ts";
 import type { RepoWriteProtocolLimits } from "./repo-write-protocol.ts";
@@ -39,6 +41,27 @@ export function decodeRepoWriteTelemetry(
   };
 }
 
+export function decodeRepoWriteTelemetryBatch(
+  frame: TelemetryFrameRecord,
+  limits: RepoWriteProtocolLimits,
+  baseFields: TelemetryBaseFields
+): RepoWriteTelemetryBatchFrame {
+  assertExactTelemetryBatchKeys(frame);
+  if (!Array.isArray(frame.spans) || frame.spans.length < 1) {
+    invalid("$.spans", "non-empty telemetry span array");
+  }
+  if (frame.spans.length > limits.maxArrayItems) {
+    limit("$.spans", "telemetry span count", frame.spans.length, limits.maxArrayItems);
+  }
+  return {
+    ...baseFields,
+    kind: "telemetry-batch",
+    requestId: telemetryIdentifier(frame.requestId, "$.requestId", limits),
+    ...(Object.hasOwn(frame, "opId") ? { opId: telemetryIdentifier(frame.opId, "$.opId", limits) } : {}),
+    spans: frame.spans.map((span, index) => decodeTelemetrySpan(span, `$.spans[${index}]`, limits))
+  };
+}
+
 function decodeTelemetryDetails(value: unknown, limits: RepoWriteProtocolLimits): RepoWriteTelemetryDetails {
   const record = telemetryRecordAt(value, "$.details");
   const entries = Object.entries(record);
@@ -61,6 +84,38 @@ function assertExactTelemetryKeys(frame: Record<string, unknown>): void {
   if (required.some((key) => !Object.hasOwn(frame, key)) || Object.keys(frame).some((key) => !allowed.has(key))) {
     invalid("$", "exact message fields");
   }
+}
+
+function assertExactTelemetryBatchKeys(frame: Record<string, unknown>): void {
+  const required = ["protocol", "repoId", "generation", "kind", "requestId", "spans"];
+  const allowed = new Set([...required, "opId"]);
+  if (required.some((key) => !Object.hasOwn(frame, key)) || Object.keys(frame).some((key) => !allowed.has(key))) {
+    invalid("$", "exact message fields");
+  }
+}
+
+function decodeTelemetrySpan(
+  value: unknown,
+  path: string,
+  limits: RepoWriteProtocolLimits
+): RepoWriteTelemetrySpan {
+  const span = telemetryRecordAt(value, path);
+  const required = ["phase", "elapsedMs"];
+  const allowed = new Set([...required, "details"]);
+  if (required.some((key) => !Object.hasOwn(span, key)) || Object.keys(span).some((key) => !allowed.has(key))) {
+    invalid(path, "exact telemetry span fields");
+  }
+  if (!repoWriteTelemetryPhases.includes(span.phase as RepoWriteTelemetryPhase)) {
+    invalid(`${path}.phase`, "telemetry phase");
+  }
+  if (typeof span.elapsedMs !== "number" || !Number.isFinite(span.elapsedMs) || span.elapsedMs < 0) {
+    invalid(`${path}.elapsedMs`, "non-negative finite duration");
+  }
+  return {
+    phase: span.phase as RepoWriteTelemetryPhase,
+    elapsedMs: span.elapsedMs,
+    ...(Object.hasOwn(span, "details") ? { details: decodeTelemetryDetails(span.details, limits) } : {})
+  };
 }
 
 function telemetryRecordAt(value: unknown, path: string): Record<string, unknown> {

--- a/packages/daemon/src/runtime/repo-write-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-protocol.ts
@@ -5,9 +5,13 @@ import { repoWriteTerminalReceiptMatches } from "./repo-write-terminal-receipt.t
 import {
   type RepoWriteRecoveryDiagnosticFrame,
   type RepoWriteRetryBudgetSignalFrame,
+  type RepoWriteTelemetryBatchFrame,
   type RepoWriteTelemetryFrame
 } from "./repo-write-diagnostic-protocol.ts";
-import { decodeRepoWriteTelemetry } from "./repo-write-protocol-telemetry.ts";
+import {
+  decodeRepoWriteTelemetry,
+  decodeRepoWriteTelemetryBatch
+} from "./repo-write-protocol-telemetry.ts";
 import { decodeRepoWriteRetryBudgetSignal } from "./repo-write-protocol-retry-budget.ts";
 import {
   decodeRepoWriteRecoveryDeferred,
@@ -44,8 +48,11 @@ export type {
   RepoWriteRetryBudgetSignalFrame,
   RepoWriteRetryBudgetSignalPhase,
   RepoWriteTelemetryDetail,
+  RepoWriteTelemetryBatchFrame,
   RepoWriteTelemetryDetails,
   RepoWriteTelemetryFrame,
+  RepoWriteTelemetryMessage,
+  RepoWriteTelemetrySpan,
   RepoWriteTelemetryPhase
 } from "./repo-write-diagnostic-protocol.ts";
 export { boundedRepoWriteDiagnostic } from "./repo-write-protocol-diagnostic.ts";
@@ -163,7 +170,7 @@ export type RepoWriteChildMessage =
   RepoWriteReadyFrame | RepoWriteStartupProgressFrame
   | RepoWritePreparedFrame | RepoWriteAcceptedFrame | RepoWriteTerminalFrame | RepoWriteFailureFrame
   | RepoWriteDirectResultFrame | RepoWriteDirectFailureFrame
-  | RepoWriteStatusFrame | RepoWriteTelemetryFrame | RepoWriteRecoveryDiagnosticFrame
+  | RepoWriteStatusFrame | RepoWriteTelemetryFrame | RepoWriteTelemetryBatchFrame | RepoWriteRecoveryDiagnosticFrame
   | RepoWriteRetryBudgetSignalFrame
   | RepoWriteDrainedFrame;
 
@@ -219,6 +226,9 @@ export function decodeRepoWriteChildMessage(
   if (frame.kind === "failure") return decodeFailure(frame, limits);
   if (frame.kind === "status") return decodeStatus(frame, limits, budget);
   if (frame.kind === "telemetry") return decodeRepoWriteTelemetry(frame, limits, baseFields(frame));
+  if (frame.kind === "telemetry-batch") {
+    return decodeRepoWriteTelemetryBatch(frame, limits, baseFields(frame));
+  }
   if (frame.kind === "retry-budget-signal") {
     return decodeRepoWriteRetryBudgetSignal(frame, limits, baseFields(frame));
   }

--- a/packages/daemon/src/runtime/repo-write-telemetry-context.ts
+++ b/packages/daemon/src/runtime/repo-write-telemetry-context.ts
@@ -1,6 +1,10 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { performance } from "node:perf_hooks";
-import type { RepoWriteTelemetryDetails, RepoWriteTelemetryPhase } from "./repo-write-protocol.ts";
+import type {
+  RepoWriteTelemetryDetails,
+  RepoWriteTelemetryPhase,
+  RepoWriteTelemetrySpan
+} from "./repo-write-protocol.ts";
 
 type RepoWriteTelemetryReporter = (
   phase: RepoWriteTelemetryPhase,
@@ -12,8 +16,21 @@ export interface RepoWriteTelemetryDelivery {
   readonly report: RepoWriteTelemetryReporter;
   readonly reportCurrent: (phase: RepoWriteTelemetryPhase, details?: RepoWriteTelemetryDetails) => void;
   readonly flush: () => Promise<void>;
+  readonly stream: () => Promise<void>;
   readonly close: () => void;
 }
+
+export interface RepoWriteTelemetryDeliveryOptions {
+  readonly deliverBatch: (spans: ReadonlyArray<RepoWriteTelemetrySpan>) => Promise<void>;
+  readonly deliverStream: (
+    phase: RepoWriteTelemetryPhase,
+    elapsedMs: number,
+    details?: RepoWriteTelemetryDetails
+  ) => Promise<void>;
+  readonly streamAfterMs?: number;
+}
+
+export const defaultRepoWriteTelemetryStreamAfterMs = 20_000;
 
 const storage = new AsyncLocalStorage<{
   readonly startedAt: number;
@@ -58,30 +75,63 @@ export function bindCurrentRepoWriteTelemetry<Result>(
 }
 
 export function createRepoWriteTelemetryDelivery(
-  deliver: (
-    phase: RepoWriteTelemetryPhase,
-    elapsedMs: number,
-    details?: RepoWriteTelemetryDetails
-  ) => Promise<void>
+  options: RepoWriteTelemetryDeliveryOptions
 ): RepoWriteTelemetryDelivery {
   let pending = Promise.resolve();
   let closed = false;
+  let streaming = false;
+  const buffered: RepoWriteTelemetrySpan[] = [];
   const startedAt = performance.now();
+  const streamAfterMs = options.streamAfterMs ?? defaultRepoWriteTelemetryStreamAfterMs;
+  if (!Number.isSafeInteger(streamAfterMs) || streamAfterMs <= 0) {
+    throw new Error("streamAfterMs must be a positive safe integer");
+  }
+  const enqueue = (operation: () => Promise<void>): void => {
+    pending = pending.then(operation).catch(() => undefined);
+  };
+  const flushBuffered = (): void => {
+    if (buffered.length === 0) return;
+    const spans = buffered.splice(0, buffered.length);
+    enqueue(() => options.deliverBatch(spans));
+  };
+  const enterStreaming = (): void => {
+    if (closed || streaming) return;
+    streaming = true;
+    flushBuffered();
+  };
+  const streamTimer = setTimeout(enterStreaming, streamAfterMs);
+  streamTimer.unref?.();
+  const report: RepoWriteTelemetryReporter = (phase, elapsedMs, details) => {
+    if (closed) return;
+    if (!streaming && performance.now() - startedAt >= streamAfterMs) {
+      enterStreaming();
+    }
+    const span: RepoWriteTelemetrySpan = {
+      phase,
+      elapsedMs,
+      ...(details ? { details } : {})
+    };
+    if (streaming) {
+      enqueue(() => options.deliverStream(phase, elapsedMs, details));
+      return;
+    }
+    buffered.push(span);
+  };
   return {
-    report: (phase, elapsedMs, details) => {
-      if (closed) return;
-      pending = pending
-        .then(() => deliver(phase, elapsedMs, details))
-        .catch(() => undefined);
-    },
+    report,
     reportCurrent: (phase, details) => {
-      if (closed) return;
-      pending = pending
-        .then(() => deliver(phase, Math.max(0, performance.now() - startedAt), details))
-        .catch(() => undefined);
+      report(phase, Math.max(0, performance.now() - startedAt), details);
     },
-    flush: () => pending,
+    flush: () => {
+      flushBuffered();
+      return pending;
+    },
+    stream: () => {
+      enterStreaming();
+      return pending;
+    },
     close: () => {
+      clearTimeout(streamTimer);
       closed = true;
     }
   };

--- a/packages/daemon/test/repo-write-child-host-terminal.test.ts
+++ b/packages/daemon/test/repo-write-child-host-terminal.test.ts
@@ -146,14 +146,14 @@ test("volatile direct returns an exact receipt without durable frames or lookup"
   assert.equal(lookups, 0);
   assert.deepEqual(messages.map((message) => message.kind), [
     "ready",
-    "telemetry",
-    "telemetry",
+    "telemetry-batch",
     "direct-result"
   ]);
   assert.deepEqual(
     messages
-      .filter((message) => message.kind === "telemetry")
-      .map((message) => message.phase),
+      .filter((message) => message.kind === "telemetry-batch")
+      .flatMap((message) => message.spans)
+      .map((span) => span.phase),
     ["queue", "direct-command-started"]
   );
   assert.deepEqual(messages.at(-1), {

--- a/packages/daemon/test/repo-write-child-host.test.ts
+++ b/packages/daemon/test/repo-write-child-host.test.ts
@@ -32,26 +32,21 @@ test("host announces ready and executes only after the exact prepared handshake"
   await host.receive(submit("request-1"));
   assert.deepEqual(fixture.messages.map((message) => message.kind), [
     "ready",
-    "telemetry",
-    "telemetry",
     "prepared"
   ]);
-  assert.deepEqual(
-    fixture.messages
-      .filter((message) => message.kind === "telemetry")
-      .map((message) => message.phase),
-    ["queue", "compile"]
-  );
   assert.equal(executions, 0);
 
   await host.receive(proceed("request-1", "op-request-1"));
   assert.equal(executions, 1);
+  const telemetry = fixture.messages.find((message) => message.kind === "telemetry-batch");
   assert.deepEqual(
-    fixture.messages
-      .filter((message) => message.kind === "telemetry")
-      .map((message) => message.phase),
+    telemetry?.kind === "telemetry-batch"
+      ? telemetry.spans.map((span) => span.phase)
+      : [],
     ["queue", "compile", "journal", "child-execution-returned", "child-telemetry-flushed", "child-terminal-response"]
   );
+  assert.equal(fixture.messages.filter((message) => message.kind === "telemetry-batch").length, 1);
+  assert.equal(fixture.messages.filter((message) => message.kind === "telemetry").length, 0);
   assert.deepEqual(fixture.messages.at(-1), {
     ...childBase("terminal"),
     requestId: "request-1",
@@ -78,8 +73,6 @@ test("host accepts an immediate submit as soon as ready becomes observable", asy
 
   assert.deepEqual(fixture.messages.map((message) => message.kind), [
     "ready",
-    "telemetry",
-    "telemetry",
     "prepared"
   ]);
 });
@@ -292,6 +285,13 @@ test("execution errors are outcome-unknown without replay and status uses canoni
   await host.receive(proceed("request-unknown", "op-unknown"));
 
   assert.equal(executions, 1);
+  const lastWill = fixture.messages.find((message) => message.kind === "telemetry-batch");
+  assert.deepEqual(
+    lastWill?.kind === "telemetry-batch"
+      ? lastWill.spans.map((span) => span.phase)
+      : [],
+    ["queue", "compile", "journal"]
+  );
   assertFailure(fixture.messages.at(-1), {
     requestId: "request-unknown",
     phase: "after-proceed",

--- a/packages/daemon/test/repo-write-client-telemetry-batch.test.ts
+++ b/packages/daemon/test/repo-write-client-telemetry-batch.test.ts
@@ -1,0 +1,88 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { RepoWriteClient } from "../src/runtime/repo-write-client.ts";
+import {
+  FakeRepoWriteTransport,
+  childFrame,
+  command,
+  readyFrame,
+  requestId
+} from "./support/repo-write-client-fixture.ts";
+import {
+  committedCommandReceipt,
+  rejectedCommandReceipt
+} from "./support/repo-write-terminal-fixture.ts";
+
+test("observes one correlated telemetry batch without expanding it for batch-aware consumers", async () => {
+  const transport = new FakeRepoWriteTransport();
+  const batches: unknown[] = [];
+  const legacyFrames: unknown[] = [];
+  const client = new RepoWriteClient({
+    repoId: "repo-canonical",
+    generation: 7,
+    transport,
+    onTelemetry: (frame) => legacyFrames.push(frame),
+    onTelemetryBatch: (batch) => batches.push(batch)
+  });
+  transport.emit(readyFrame());
+  const result = client.submit(command("task.create"));
+  const submit = transport.sent.at(-1);
+  transport.emit({
+    ...childFrame("prepared"),
+    requestId: requestId(submit),
+    opId: "op-batch"
+  });
+  transport.emit({
+    ...childFrame("telemetry-batch"),
+    requestId: requestId(submit),
+    opId: "op-batch",
+    spans: [
+      { phase: "queue", elapsedMs: 0 },
+      { phase: "child-terminal-response", elapsedMs: 5 }
+    ]
+  });
+  const receipt = committedCommandReceipt();
+  transport.emit({
+    ...childFrame("terminal"),
+    requestId: requestId(submit),
+    opId: "op-batch",
+    outcome: "committed",
+    receipt
+  });
+
+  assert.equal(batches.length, 1);
+  assert.deepEqual(legacyFrames, []);
+  assert.deepEqual(await result, receipt);
+});
+
+test("expands telemetry batches for legacy single-frame observers", async () => {
+  const transport = new FakeRepoWriteTransport();
+  const phases: string[] = [];
+  const client = new RepoWriteClient({
+    repoId: "repo-canonical",
+    generation: 7,
+    transport,
+    onTelemetry: (frame) => phases.push(frame.phase)
+  });
+  transport.emit(readyFrame());
+  const result = client.direct(command("task.claim"));
+  const request = transport.sent.at(-1);
+  transport.emit({
+    ...childFrame("telemetry-batch"),
+    requestId: requestId(request),
+    spans: [
+      { phase: "queue", elapsedMs: 0 },
+      { phase: "compile", elapsedMs: 1 }
+    ]
+  });
+  const receipt = rejectedCommandReceipt();
+  transport.emit({
+    ...childFrame("direct-result"),
+    requestId: requestId(request),
+    receipt
+  });
+
+  assert.deepEqual(phases, ["queue", "compile"]);
+  assert.deepEqual(await result, receipt);
+});

--- a/packages/daemon/test/repo-write-protocol-telemetry-batch.test.ts
+++ b/packages/daemon/test/repo-write-protocol-telemetry-batch.test.ts
@@ -1,0 +1,30 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  parseRepoWriteChildMessage,
+  repoWriteProtocolType,
+  stringifyRepoWriteChildMessage,
+  type RepoWriteChildMessage
+} from "../src/runtime/repo-write-protocol.ts";
+
+test("telemetry batch codec preserves every ordered phase boundary", () => {
+  const batch: RepoWriteChildMessage = {
+    protocol: repoWriteProtocolType,
+    repoId: "repo-canonical",
+    generation: 7,
+    kind: "telemetry-batch",
+    requestId: "request-telemetry-batch",
+    opId: "op-telemetry-batch",
+    spans: [
+      { phase: "queue", elapsedMs: 0 },
+      { phase: "git", elapsedMs: 12.5, details: { pathCount: 3, clean: true } },
+      { phase: "child-terminal-response", elapsedMs: 13 }
+    ]
+  };
+
+  assert.deepEqual(
+    parseRepoWriteChildMessage(stringifyRepoWriteChildMessage(batch)),
+    batch
+  );
+});

--- a/packages/daemon/test/repo-write-telemetry-context.test.ts
+++ b/packages/daemon/test/repo-write-telemetry-context.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   bindCurrentRepoWriteTelemetry,
+  createRepoWriteTelemetryDelivery,
   reportCurrentRepoWriteTelemetry,
   runWithRepoWriteTelemetry
 } from "../src/runtime/repo-write-telemetry-context.ts";
@@ -19,4 +20,44 @@ test("a queued callback retains the request telemetry context that admitted it",
   queued();
 
   assert.deepEqual(phases, ["materializer"]);
+});
+
+test("normal telemetry drains every phase in one terminal batch", async () => {
+  const batches: unknown[][] = [];
+  const streamed: string[] = [];
+  const delivery = createRepoWriteTelemetryDelivery({
+    deliverBatch: async (spans) => { batches.push([...spans]); },
+    deliverStream: async (phase) => { streamed.push(phase); },
+    streamAfterMs: 1_000
+  });
+
+  for (let index = 0; index < 140; index += 1) {
+    delivery.report("git", index, { index });
+  }
+  await delivery.flush();
+  delivery.close();
+
+  assert.equal(batches.length, 1);
+  assert.equal(batches[0]?.length, 140);
+  assert.deepEqual(streamed, []);
+});
+
+test("a slow request publishes its buffered last will and then streams phases", async () => {
+  const batches: string[][] = [];
+  const streamed: string[] = [];
+  const delivery = createRepoWriteTelemetryDelivery({
+    deliverBatch: async (spans) => { batches.push(spans.map((span) => span.phase)); },
+    deliverStream: async (phase) => { streamed.push(phase); },
+    streamAfterMs: 5
+  });
+
+  delivery.report("queue", 0);
+  delivery.report("compile", 1);
+  await new Promise((resolve) => setTimeout(resolve, 15));
+  delivery.report("git", 16);
+  await delivery.flush();
+  delivery.close();
+
+  assert.deepEqual(batches, [["queue", "compile"]]);
+  assert.deepEqual(streamed, ["git"]);
 });

--- a/packages/daemon/test/repo-write-telemetry-log.test.ts
+++ b/packages/daemon/test/repo-write-telemetry-log.test.ts
@@ -1,0 +1,100 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  DaemonLogAppendInput,
+  DaemonLogEntryV1,
+  DaemonLogService
+} from "@harness-anything/application";
+import { createRepoWriteTelemetryLogObservers } from "../src/observability/repo-write-telemetry-log-observers.ts";
+import {
+  decodeRepoWriteTelemetryLog,
+  encodeRepoWriteTelemetryBatchLog
+} from "../src/observability/repo-write-telemetry-log.ts";
+import {
+  repoWriteProtocolType,
+  type RepoWriteTelemetryBatchFrame
+} from "../src/runtime/repo-write-protocol.ts";
+
+test("compact telemetry log batches round-trip every phase and detail", () => {
+  const scriptPhases = [
+    "script-manifest",
+    "script-scope",
+    "script-stage",
+    "script-syntax",
+    "script-execute",
+    "script-ingest"
+  ] as const;
+  const frame: RepoWriteTelemetryBatchFrame = {
+    protocol: repoWriteProtocolType,
+    repoId: "canonical",
+    generation: 7,
+    kind: "telemetry-batch",
+    requestId: "request-compact",
+    opId: "op-compact",
+    spans: Array.from({ length: 140 }, (_, index) => ({
+      phase: index === 139 ? "child-terminal-response" : scriptPhases[index % scriptPhases.length]!,
+      elapsedMs: index + 0.125,
+      details: { index, fingerprint: `${index}`.padStart(64, "a") }
+    }))
+  };
+
+  const message = encodeRepoWriteTelemetryBatchLog(frame);
+  const decoded = decodeRepoWriteTelemetryLog(message);
+
+  assert.equal(JSON.parse(message).phaseTable, "repo-write-telemetry-phases/v1");
+  assert.deepEqual(decoded, {
+    requestId: frame.requestId,
+    opId: frame.opId,
+    spans: frame.spans
+  });
+});
+
+test("legacy single-frame telemetry remains readable", () => {
+  assert.deepEqual(decodeRepoWriteTelemetryLog(JSON.stringify({
+    schema: "repo-write-request-telemetry/v1",
+    requestId: "request-legacy",
+    phase: "git",
+    elapsedMs: 12,
+    details: { pathCount: 3 }
+  })), {
+    requestId: "request-legacy",
+    spans: [{ phase: "git", elapsedMs: 12, details: { pathCount: 3 } }]
+  });
+});
+
+test("a batch-aware daemon observer appends one NDJSON entry per request", () => {
+  const appended: DaemonLogAppendInput[] = [];
+  const daemonLogService: DaemonLogService = {
+    append: async (input) => {
+      appended.push(input);
+      return { ...input, schema: "daemon-log-entry/v1", timestamp: "2026-08-10T00:00:00.000Z", sequence: 0,
+        repoId: "canonical", redaction: { policy: "runtime-log-redaction/v1", fieldsRemoved: [], truncated: false }
+      } as DaemonLogEntryV1;
+    },
+    list: async () => ({
+      schema: "daemon-log-page/v1",
+      entries: [],
+      nextCursor: null,
+      truncated: false,
+      droppedCount: 0
+    })
+  };
+  const observers = createRepoWriteTelemetryLogObservers({
+    daemonLogService,
+    context: { repo: { repoId: "canonical", canonicalRoot: "/tmp/canonical" } },
+    authoredGitRoot: "/tmp/canonical/harness"
+  });
+  observers.onTelemetryBatch({
+    protocol: repoWriteProtocolType,
+    repoId: "canonical",
+    generation: 7,
+    kind: "telemetry-batch",
+    requestId: "request-one-line",
+    spans: Array.from({ length: 140 }, (_, elapsedMs) => ({ phase: "git", elapsedMs }))
+  });
+
+  assert.equal(appended.length, 1);
+  assert.equal(appended[0]?.event, "repo-write.request.telemetry-batch");
+  assert.equal(decodeRepoWriteTelemetryLog(appended[0]?.message ?? "")?.spans.length, 140);
+});

--- a/packages/daemon/test/task-complete-prepublish-witness.test.ts
+++ b/packages/daemon/test/task-complete-prepublish-witness.test.ts
@@ -104,8 +104,12 @@ test("history telemetry is delivered before a delayed Git history call completes
     let proofSettled = false;
     let observeHistoryStart!: () => void;
     const historyStart = new Promise<void>((resolve) => { observeHistoryStart = resolve; });
-    const delivery = createRepoWriteTelemetryDelivery(async (_phase, _elapsedMs, details) => {
-      if (details?.stage === "history-start") observeHistoryStart();
+    const delivery = createRepoWriteTelemetryDelivery({
+      deliverBatch: async () => undefined,
+      deliverStream: async (_phase, _elapsedMs, details) => {
+        if (details?.stage === "history-start") observeHistoryStart();
+      },
+      streamAfterMs: 20
     });
     const traced = withTracedGit(fixture.fixtureRoot, 300, async (tracePath) => {
       const proof = Promise.resolve(runWithRepoWriteTelemetry(delivery.report, () =>

--- a/packages/kernel/src/write-coordination/materialization/ledger-materializer.ts
+++ b/packages/kernel/src/write-coordination/materialization/ledger-materializer.ts
@@ -5,7 +5,6 @@ import { resolveHarnessLayout } from "../../layout/index.ts";
 import type { VersionControlSystem, PreservedWorktreeEdit } from "../../ports/version-control-system.ts";
 import { updateTaskProjectionIncrementally } from "../../projection/sqlite-task-incremental-projection.ts";
 import type { IncrementalProjectionDiagnostic, IncrementalProjectionPhase } from "../../projection/sqlite-task-incremental-projection.ts";
-import { countAttributionProjectionRows } from "../../projection/sqlite-attribution-projection.ts";
 import { rebuildTaskProjection } from "../../projection/sqlite-task-projection.ts";
 import {
   captureTrustedAuthoredProjectionFingerprint,
@@ -283,7 +282,6 @@ function materializeBranches(
   }
 
   const layout = resolveHarnessLayout(rootInput);
-  let attributionEventsProjected = 0;
   let projectionRebuilt = merged > 0;
   if (!dryRun) {
     if (!durableFileExists(layout.projectionPath)) {
@@ -295,9 +293,6 @@ function materializeBranches(
       projectionRebuilt = true;
       onProgress?.("projection-done");
     }
-    onProgress?.("attribution-start");
-    attributionEventsProjected = countAttributionProjectionRows(layout.projectionPath);
-    onProgress?.("attribution-done");
   }
 
   return {
@@ -307,7 +302,7 @@ function materializeBranches(
     branches: reports,
     warnings,
     projectionRebuilt,
-    attributionEventsProjected
+    attributionEventsProjected: 0
   };
 }
 

--- a/packages/kernel/test/store/ledger-materializer.test.ts
+++ b/packages/kernel/test/store/ledger-materializer.test.ts
@@ -129,7 +129,7 @@ test("ledger materializer dry-runs and merges pending session branches", () => {
     assert.equal(git(rootDir, "branch", "--list", "sessions/codex-session-2"), "");
     assert.equal(git(rootDir, "rev-parse", "--abbrev-ref", "HEAD"), "master");
     assert.equal(readGitFile(rootDir, "tasks/task-2/note.md"), "materialized write\n");
-    assert.equal(merged.attributionEventsProjected, 1);
+    assert.equal(merged.attributionEventsProjected, 0);
     assert.equal(readAttributionProjection(rootDir)[0]?.opId, "op-materialize");
     assert.deepEqual(progress, [
       "baseline-start",
@@ -137,9 +137,7 @@ test("ledger materializer dry-runs and merges pending session branches", () => {
       "merge-start",
       "merge-done",
       "projection-start",
-      "projection-done",
-      "attribution-start",
-      "attribution-done"
+      "projection-done"
     ]);
     assert.equal(
       git(rootDir, "show", "-s", "--format=%an <%ae>", "HEAD"),

--- a/tools/provenance-capacity-trigger.mjs
+++ b/tools/provenance-capacity-trigger.mjs
@@ -9,15 +9,21 @@ import {
   readProvenanceLedgerScale
 } from "../packages/daemon/src/observability/provenance-capacity-trigger.ts";
 import { defaultRepoWriteRequestTimeoutMs } from "../packages/daemon/src/runtime/repo-write-client-contract.ts";
+import { decodeRepoWriteTelemetryLog } from "../packages/daemon/src/observability/repo-write-telemetry-log.ts";
 
 export function summarizeRequestEntries(entries, input) {
   const ordered = entries
     .filter((entry) => entry?.repoId === input.repoId)
     .sort((left, right) => Number(left.sequence) - Number(right.sequence));
   const telemetry = ordered.flatMap((entry) => {
-    if (entry.event !== "repo-write.request.telemetry" || entry.requestId !== input.requestId) return [];
-    const message = parseObject(entry.message);
-    return message ? [{ entry, frame: message }] : [];
+    if (!["repo-write.request.telemetry", "repo-write.request.telemetry-batch"].includes(entry.event)
+      || entry.requestId !== input.requestId) return [];
+    const message = typeof entry.message === "string"
+      ? decodeRepoWriteTelemetryLog(entry.message)
+      : null;
+    return message?.requestId === input.requestId
+      ? message.spans.map((frame) => ({ entry, frame }))
+      : [];
   });
   if (telemetry.length === 0) throw new Error(`No production telemetry found for request ${input.requestId}.`);
   const witnessObserved = telemetry.some(({ frame }) => frame.phase === "compile-task-witness"

--- a/tools/provenance-capacity-trigger.test.mjs
+++ b/tools/provenance-capacity-trigger.test.mjs
@@ -65,6 +65,48 @@ test("real completion report uses child-terminal-response and crosses the relati
   assert.equal(report.headroomRatio, 0.0981);
 });
 
+test("versioned telemetry batches remain readable beside legacy single-frame entries", () => {
+  const requestId = "writer:batch";
+  const frames = [
+    ["compile-task-witness", 100, { stage: "document-produce", state: "start" }],
+    ["authority-publication-proof", 200, { stage: "history-start", pathCount: 1 }],
+    ["authority-publication-proof", 300, { stage: "history-done", pathCount: 1 }],
+    ["authority-publication-proof", 400, { stage: "history-start", pathCount: 1 }],
+    ["authority-publication-proof", 500, { stage: "history-done", pathCount: 1 }],
+    ["authority-publication-proof", 600, { stage: "history-start", pathCount: 1 }],
+    ["authority-publication-proof", 700, { stage: "history-done", pathCount: 1 }],
+    ["authority-publication-proof", 800, { stage: "history-start", pathCount: 1 }],
+    ["authority-publication-proof", 900, { stage: "history-done", pathCount: 1 }],
+    ["authority-event-published", 1_000],
+    ["child-execution-returned", 1_100],
+    ["child-terminal-response", 1_200]
+  ];
+  const entries = [{
+    schema: "daemon-log-entry/v1",
+    timestamp: "2026-08-05T19:08:00.000Z",
+    sequence: 1,
+    repoId: "canonical",
+    requestId,
+    event: "repo-write.request.telemetry-batch",
+    message: JSON.stringify({
+      schema: "repo-write-request-telemetry-batch/v1",
+      requestId,
+      encoding: "json",
+      spans: frames
+    })
+  }];
+
+  const report = summarizeRequestEntries(entries, {
+    requestId,
+    repoId: "canonical",
+    writerDeadlineMs: 30_000
+  });
+  assert.equal(report.status, "ok");
+  assert.equal(report.historyScanCount, 4);
+  assert.equal(report.writerExecutionMs, 1_100);
+  assert.equal(report.writerTerminalMs, 1_200);
+});
+
 test("text report exposes both commit-count vocabularies and the temporal measurement anchor", () => {
   const output = formatProvenanceCapacityReport({
     schema: "provenance-capacity-report/v1",


### PR DESCRIPTION
## Summary

Wave-1 K2 of the PLT-WriteChain-Diet campaign (charter dec_01KZNZFH272P9W72CG2J8XZPPW). W4 mapping proved telemetry self-amplification: one governed write emitted 140 phase frames = 140 serial IPC deliveries + 140 individually-serialized NDJSON appends, with a measured 18.011s telemetry-flush tail AFTER child execution had finished (production request 632:15) — the instrument cost more than the work it measured.

This PR batches phase spans in child memory and delivers ONE batch frame at terminal/acceptance (1 delivery, 1 compact versioned NDJSON line). Slow (>20s) and failure/shutdown paths switch to streaming last-words delivery so wedge diagnostics keep their final-phase visibility. Also deletes the unconditional attribution `COUNT(*)` on the materializer hot path and moves log-store mkdir/segment-stat/retention-readdir to init/rotation.

## What Changed

- `repo-write-telemetry-context.ts` / `repo-write-child-host.ts`: in-memory span aggregation, one terminal batch; last-words streaming on slow/error/shutdown paths.
- New strict `telemetry-batch` protocol frame; legacy `onTelemetry` consumers auto-expand single frames (backward compatible, versioned).
- `repo-write-telemetry-log*.ts`: one compact phase-array NDJSON record per request; old single-frame records remain readable.
- `daemon-log-file-store.ts`: directory/segment/retention I/O cached, refreshed at rotation.
- `ledger-materializer.ts`: unconditional attribution `COUNT(*)` deleted from hot path.
- `request.performance` single-summary path unchanged.
- Rebased over K1 (#1325): K1's six real script phases preserved; batch layer carries them verbatim.

## Version Impact

- No version change: internal telemetry/write-path performance work.

## Verification

- [x] A/B same 140-phase fixture: 140 deliveries/140 NDJSON lines/179ms → 1 delivery/1 line/1.4ms
- [x] Last-words paths (slow-switch + execution error): 2/2
- [x] telemetry round-trip + child-host targeted: 21/21 (child-host 15/15); materializer targeted 1/1
- [x] Six related integration files: 64 pass / 1 Windows-conditional skip / 0 fail
- [x] `npm run check:local`: fast 732/732, contract 785 pass/1 skip, 27 gates green; `git diff --check`
- Not run: full check:ci (GitHub CI is the authority); production traffic replay (post-merge daemon restart will verify)

## Review Evidence

- Self-review: worker reports at `harness/tasks/task_01KZP293C9FADZYAG0KAXREYX9-k2-phase/artifacts/worker-report-k2.md` and `worker-report-k2-rebase.md`
- Additional review: CEO semantic acceptance against W4 mapping report (T1/T2/P5 items) and knife-order wave-1 mandate; last-words semantics explicitly pinned by tests
- Blocking findings: none

## Residual Risk

- Wave-3 (K4) items deliberately untouched: runtime-audit second publication route, 5s empty polling.
- Cross-platform CI and real-production replay are the authority for the new batch protocol under load.

## References

- Task: task_01KZP293C9FADZYAG0KAXREYX9 (milestone PLT-WriteChain-Diet, root task_01KZNZHRHRMQP6JBFQ7S13HCTE)
- Evidence: harness/milestones/platform/write-chain-diet/knife-order.md; map-full-w4-materializer.md

---

## 摘要

写链路减重战役波次1 K2。W4 测绘实证遥测自放大:一次治理写产生 140 条 phase 帧=140 次串行 IPC+140 行独立序列化 NDJSON,child 执行结束后实测还要 18.011s 才把遥测冲完(生产请求 632:15)——测量行为比被测行为更贵。

本 PR 把 phase span 在 child 内存聚合,terminal/acceptance 时一次批量交付(1 次 delivery、1 行 compact 版本化 NDJSON);慢路径(>20s)与异常/关闭路径切换为遗言流式,楔死诊断的最后相位可见性不丢。同时删除 materializer 热路径的无条件 attribution COUNT(*),log store 的 mkdir/segment/retention I/O 移到初始化/rotation。

## 验证

- 同 140 相位 fixture A/B:140 次/140 行/179ms → 1 次/1 行/1.4ms
- 遗言路径 2/2;定向 21/21;六个相关 integration 文件 64 绿
- check:local 27 门全绿
- 未跑:完整 check:ci(GitHub CI 权威);生产流量重放(合并后重启 daemon 验证)

## 残余风险

- 波次3(K4)项有意未动:runtime audit 完整发布改道、5s 空轮询。

## 关联材料

- 任务:task_01KZP293C9FADZYAG0KAXREYX9(milestone PLT-WriteChain-Diet)
- 证据:knife-order.md;map-full-w4-materializer.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)