### PR TITLE
fix(daemon): defer initial settlement recovery until after READY

### DIFF
--- a/packages/cli/src/composition/receipt-settlement-runtime.ts
+++ b/packages/cli/src/composition/receipt-settlement-runtime.ts
@@ -20,6 +20,24 @@ type PendingSettlement = Extract<
   { readonly canonicalVisibility: "pending" }
 >;
 
+export const receiptSettlementRecoveryPhases = [
+  "inspect",
+  "materializer",
+  "canonical-proof",
+  "authority-receipt",
+  "canonical-publication",
+  "settlement-store"
+] as const;
+
+export type ReceiptSettlementRecoveryPhase =
+  typeof receiptSettlementRecoveryPhases[number];
+
+export interface ReceiptSettlementRecoveryProgress {
+  readonly receiptId: string;
+  readonly phase: ReceiptSettlementRecoveryPhase;
+  readonly status: "started" | "visible" | "failed" | "pending" | "timed-out";
+}
+
 export interface ReceiptSettlementRecoveryLoop {
   readonly trigger: () => Promise<void>;
   readonly stop: () => void;
@@ -60,10 +78,13 @@ export async function settleAcceptedSession(input: {
   readonly authoredRoot: string;
   readonly acceptedReceipt: CommandReceiptEnvelope;
   readonly pending: PendingSettlement;
+  readonly onRecoveryPhase?: (phase: ReceiptSettlementRecoveryPhase) => void;
 }): Promise<void> {
   try {
     await nextEventLoopTurn();
+    input.onRecoveryPhase?.("materializer");
     await input.runtime.enqueueMaterializerBatch({ sessionId: input.pending.sessionId });
+    input.onRecoveryPhase?.("canonical-proof");
     const visible = withCommandReceiptSettlement(
       input.acceptedReceipt,
       visibleCommandReceiptSettlement(
@@ -73,6 +94,7 @@ export async function settleAcceptedSession(input: {
       )
     );
     if (!visible.ok) throw new Error("DOC_SYNC_VISIBLE_RECEIPT_REVERSED");
+    input.onRecoveryPhase?.("settlement-store");
     input.settlements.visible(visible);
   } catch (error) {
     failSettlement(input.settlements, input.acceptedReceipt, input.pending, error);
@@ -85,6 +107,8 @@ export async function recoverPendingSettlementMaterialization(input: {
   readonly runtime: HarnessDaemonRuntime;
   readonly authoredRoot: string;
   readonly deadlineAt: number;
+  readonly perReceiptTimeoutMs?: number;
+  readonly onReceiptProgress?: (progress: ReceiptSettlementRecoveryProgress) => void;
   readonly recoverCommittedReceipt: (opId: string) => Promise<AuthorityCommittedReceipt>;
   readonly recoverCanonicalPublication?: (input: {
     readonly outerOpId: string;
@@ -103,55 +127,130 @@ export async function recoverPendingSettlementMaterialization(input: {
       && observedSettlement.receipt.settlement.failure.retryable === false) {
       continue;
     }
-    if (durable.state === "proceeding"
-      && durable.outcome.canonicalCommand.commandName === "doc-sync-submit") {
-      try {
-        await nextEventLoopTurn();
-        await input.runtime.enqueueMaterializerBatch({ sessionId: pending.sessionId });
-        const canonicalCommitSha = canonicalCommitContaining(
-          input.authoredRoot,
-          pending.acceptedCommitSha
+    let lastPhase: ReceiptSettlementRecoveryPhase = "inspect";
+    const onRecoveryPhase = (phase: ReceiptSettlementRecoveryPhase): void => {
+      lastPhase = phase;
+      input.onReceiptProgress?.({
+        receiptId: record.receiptId,
+        phase,
+        status: "started"
+      });
+    };
+    onRecoveryPhase("inspect");
+    const recovery = recoverPendingSettlementRecord({
+      ...input,
+      record,
+      pending,
+      onRecoveryPhase
+    });
+    try {
+      if (input.perReceiptTimeoutMs === undefined) {
+        await recovery;
+      } else {
+        await waitForReceiptRecovery(
+          recovery,
+          Math.min(
+            Math.max(1, input.perReceiptTimeoutMs),
+            Math.max(1, input.deadlineAt - Date.now())
+          )
         );
-        if (!input.recoverCanonicalPublication) {
-          throw new Error("DOC_SYNC_CANONICAL_PUBLICATION_RECOVERY_UNAVAILABLE");
-        }
-        await input.recoverCanonicalPublication({
-          outerOpId: record.receiptId,
-          canonicalCommitSha
-        });
-      } catch (error) {
-        failSettlement(input.settlements, record.receipt, pending, error);
       }
-      continue;
-    }
-    if (record.receiptId.startsWith("doc-sync:")) {
-      await settleAcceptedSession({
-        settlements: input.settlements,
-        runtime: input.runtime,
-        authoredRoot: input.authoredRoot,
-        acceptedReceipt: record.receipt,
-        pending
+    } catch (error) {
+      if (!(error instanceof ReceiptSettlementRecoveryTimeoutError)) throw error;
+      input.onReceiptProgress?.({
+        receiptId: record.receiptId,
+        phase: lastPhase,
+        status: "timed-out"
       });
       continue;
     }
-    if (record.receiptId.startsWith("repo-write-direct:")) {
-      await recoverDirectSettlement({ ...input, acceptedReceipt: record.receipt, pending });
-      continue;
-    }
+    const recovered = input.settlements.lookup(record.receiptId);
+    input.onReceiptProgress?.({
+      receiptId: record.receiptId,
+      phase: lastPhase,
+      status: recovered?.state === "canonical-visible"
+        ? "visible"
+        : recovered?.state ?? "pending"
+    });
+  }
+}
+
+async function recoverPendingSettlementRecord(input: {
+  readonly settlements: ReceiptSettlementStore;
+  readonly outcomes: DurableRepoWriteOutcomeStoreV1;
+  readonly runtime: HarnessDaemonRuntime;
+  readonly authoredRoot: string;
+  readonly recoverCommittedReceipt: (opId: string) => Promise<AuthorityCommittedReceipt>;
+  readonly recoverCanonicalPublication?: (input: {
+    readonly outerOpId: string;
+    readonly canonicalCommitSha: string;
+  }) => Promise<"live-owner" | "recovered" | "terminal" | "blocked">;
+  readonly record: ReturnType<ReceiptSettlementStore["listUnsettled"]>[number];
+  readonly pending: PendingSettlement;
+  readonly onRecoveryPhase: (phase: ReceiptSettlementRecoveryPhase) => void;
+}): Promise<void> {
+  const { record, pending } = input;
+  const durable = input.outcomes.lookup(record.receiptId);
+  if (durable.state === "proceeding"
+    && durable.outcome.canonicalCommand.commandName === "doc-sync-submit") {
     try {
+      await nextEventLoopTurn();
+      input.onRecoveryPhase("materializer");
       await input.runtime.enqueueMaterializerBatch({ sessionId: pending.sessionId });
-      const visible = withCommandReceiptSettlement(
-        record.receipt,
-        visibleCommandReceiptSettlement(
-          pending,
-          canonicalCommitContaining(input.authoredRoot, pending.acceptedCommitSha),
-          new Date().toISOString()
-        )
+      input.onRecoveryPhase("canonical-proof");
+      const canonicalCommitSha = canonicalCommitContaining(
+        input.authoredRoot,
+        pending.acceptedCommitSha
       );
-      input.settlements.visible(visible);
+      if (!input.recoverCanonicalPublication) {
+        throw new Error("DOC_SYNC_CANONICAL_PUBLICATION_RECOVERY_UNAVAILABLE");
+      }
+      input.onRecoveryPhase("canonical-publication");
+      await input.recoverCanonicalPublication({
+        outerOpId: record.receiptId,
+        canonicalCommitSha
+      });
     } catch (error) {
       failSettlement(input.settlements, record.receipt, pending, error);
     }
+    return;
+  }
+  if (record.receiptId.startsWith("doc-sync:")) {
+    await settleAcceptedSession({
+      settlements: input.settlements,
+      runtime: input.runtime,
+      authoredRoot: input.authoredRoot,
+      acceptedReceipt: record.receipt,
+      pending,
+      onRecoveryPhase: input.onRecoveryPhase
+    });
+    return;
+  }
+  if (record.receiptId.startsWith("repo-write-direct:")) {
+    await recoverDirectSettlement({
+      ...input,
+      acceptedReceipt: record.receipt,
+      pending,
+      onRecoveryPhase: input.onRecoveryPhase
+    });
+    return;
+  }
+  try {
+    input.onRecoveryPhase("materializer");
+    await input.runtime.enqueueMaterializerBatch({ sessionId: pending.sessionId });
+    input.onRecoveryPhase("canonical-proof");
+    const visible = withCommandReceiptSettlement(
+      record.receipt,
+      visibleCommandReceiptSettlement(
+        pending,
+        canonicalCommitContaining(input.authoredRoot, pending.acceptedCommitSha),
+        new Date().toISOString()
+      )
+    );
+    input.onRecoveryPhase("settlement-store");
+    input.settlements.visible(visible);
+  } catch (error) {
+    failSettlement(input.settlements, record.receipt, pending, error);
   }
 }
 
@@ -193,14 +292,18 @@ async function recoverDirectSettlement(input: {
   readonly recoverCommittedReceipt: (opId: string) => Promise<AuthorityCommittedReceipt>;
   readonly acceptedReceipt: CommandReceiptEnvelope;
   readonly pending: PendingSettlement;
+  readonly onRecoveryPhase: (phase: ReceiptSettlementRecoveryPhase) => void;
 }): Promise<void> {
   try {
+    input.onRecoveryPhase("materializer");
     await input.runtime.enqueueMaterializerBatch({ sessionId: input.pending.sessionId });
     const operationIds = input.pending.authorityOperationIds ?? [];
     if (operationIds.length === 0) {
       throw new Error("AUTHORITY_DIRECT_RECOVERY_OPERATION_IDS_MISSING");
     }
+    input.onRecoveryPhase("authority-receipt");
     await Promise.all(operationIds.map(input.recoverCommittedReceipt));
+    input.onRecoveryPhase("canonical-proof");
     const visible = withCommandReceiptSettlement(
       input.acceptedReceipt,
       visibleCommandReceiptSettlement(
@@ -209,9 +312,38 @@ async function recoverDirectSettlement(input: {
         new Date().toISOString()
       )
     );
+    input.onRecoveryPhase("settlement-store");
     input.settlements.visible(visible);
   } catch (error) {
     failSettlement(input.settlements, input.acceptedReceipt, input.pending, error);
+  }
+}
+
+class ReceiptSettlementRecoveryTimeoutError extends Error {
+  constructor() {
+    super("RECEIPT_SETTLEMENT_RECOVERY_TIMEOUT");
+    this.name = "ReceiptSettlementRecoveryTimeoutError";
+  }
+}
+
+async function waitForReceiptRecovery(
+  recovery: Promise<void>,
+  timeoutMs: number
+): Promise<void> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      recovery,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new ReceiptSettlementRecoveryTimeoutError()),
+          timeoutMs
+        );
+        timer.unref();
+      })
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }
 
@@ -235,12 +367,17 @@ export function canonicalCommitContaining(authoredRoot: string, acceptedCommitSh
   const canonicalCommitSha = execFileSync(
     "git",
     ["-C", authoredRoot, "rev-parse", "--verify", "HEAD^{commit}"],
-    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], windowsHide: true }
+    {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+      timeout: 5_000
+    }
   ).trim();
   execFileSync(
     "git",
     ["-C", authoredRoot, "merge-base", "--is-ancestor", acceptedCommitSha, canonicalCommitSha],
-    { stdio: ["ignore", "ignore", "pipe"], windowsHide: true }
+    { stdio: ["ignore", "ignore", "pipe"], windowsHide: true, timeout: 5_000 }
   );
   return canonicalCommitSha;
 }

--- a/packages/cli/src/composition/repo-write-child-entrypoint.ts
+++ b/packages/cli/src/composition/repo-write-child-entrypoint.ts
@@ -6,7 +6,6 @@ import {
   createGitCanonicalPublicationInspector,
   createRepoWriteChildHost,
   decodeRepoWriteChildLaunchConfig,
-  defaultProductionRecoveryAdmissionTimeoutMs,
   DurableRepoWriteOutcomeStoreV1,
   loadAuthorityProductionManifest,
   ProductionRepoWriteOperationHost,
@@ -22,9 +21,9 @@ import { defaultCliAdapterProvider } from "./adapter-registry.ts";
 import { cliDaemonCommandHostServices } from "./daemon-command-host-services.ts";
 import { makeIncrementalConflictMarkerPreflight } from "./incremental-conflict-marker-preflight.ts";
 import {
-  reconcileTerminalSettlements,
-  recoverPendingSettlementMaterialization,
-} from "./receipt-settlement-runtime.ts";
+  boundedRecoveryError,
+  createRepoWriteChildPostReadyRecovery
+} from "./repo-write-child-post-ready-recovery.ts";
 import { createRepoWriteChildDocSyncExecutor } from "./repo-write-child-doc-sync-executor.ts";
 import {
   createCliProductionAuthorityLifecycle
@@ -36,23 +35,6 @@ type RepoWriteStartupProgressPhase = Extract<
   Parameters<RepoWriteChildIpcTransport["send"]>[0],
   { readonly kind: "startup-progress" }
 >["phase"];
-
-/**
- * Historical recovery keeps its existing admission budget, which is strictly
- * smaller than the parent's startup-stall window. The parent now renews that
- * window only when it sees a previously unseen startup phase/work-unit pair;
- * this budget remains an admission boundary, not the liveness signal.
- *
- * Reuses the authority admission deadline rather than restating it: both exist
- * to return before the same parent transport deadline so the supervisor leaves a
- * recovering child alive. One deadline, one constant.
- */
-const startupReadyBudgetMs = defaultProductionRecoveryAdmissionTimeoutMs;
-
-/** Time this child may still spend on historical recovery before announcing READY. */
-function remainingStartupRecoveryBudgetMs(): number {
-  return Math.max(0, startupReadyBudgetMs - Math.round(process.uptime() * 1000));
-}
 
 export async function runRepoWriteChildEntrypoint(
   encodedConfig: string | undefined
@@ -221,6 +203,21 @@ export async function runRepoWriteChildEntrypoint(
     manifestPath: config.authorityManifest,
     ...(layoutOverrides ? { layoutOverrides } : {}),
     onPublicationRetryBudgetSignal,
+    onServiceStateReplayProgress: (progressRepo, progress) => {
+      void reportStartupProgress(
+        "authority-start-repo",
+        [
+          progressRepo.repoId,
+          "authority-state",
+          progress.fileName,
+          String(progress.replayedRows)
+        ].join(":")
+      ).catch((error) => {
+        process.stderr.write(
+          `[repo-write-child] authority state replay progress deferred: ${boundedRecoveryError(error)}\n`
+        );
+      });
+    },
     backgroundRecovery: true
   });
   const repo = {
@@ -253,85 +250,21 @@ export async function runRepoWriteChildEntrypoint(
       readonly canonicalCommitSha: string;
     }) => Promise<"live-owner" | "recovered" | "terminal" | "blocked">;
   } = {};
-  const recoverSettlements = async (budgetMs = 5_000) => {
-    await recoverPendingSettlementMaterialization({
-      settlements,
-      outcomes,
-      runtime,
-      authoredRoot,
-      deadlineAt: Date.now() + budgetMs,
-      recoverCommittedReceipt: recoverAuthorityCommittedReceipt,
-      recoverCanonicalPublication: (input) => canonicalPublicationRecovery.current
-        ? canonicalPublicationRecovery.current(input)
-        : Promise.resolve("blocked")
-    });
-    reconcileTerminalSettlements(settlements, outcomes);
-  };
-  await recoverSettlements(remainingStartupRecoveryBudgetMs());
-  const startupRecoveryBudgetMs = remainingStartupRecoveryBudgetMs();
-  const startupRecoveryDeadline = Date.now() + startupRecoveryBudgetMs;
-  await reportStartupProgress("historical-recovery-scan");
-  const historicalProceedings = outcomes.listHistoricalProceedings();
-  startupPhase.mark("list-historical-proceedings", {
-    proceedingCount: historicalProceedings.length
+  const postReadyRecovery = createRepoWriteChildPostReadyRecovery({
+    repoId: config.repoId,
+    generation: config.generation,
+    transport,
+    settlements,
+    outcomes,
+    runtime,
+    authoredRoot,
+    recoveryGate,
+    recoverCommittedReceipt: recoverAuthorityCommittedReceipt,
+    recoverCanonicalPublication: (recovery) => canonicalPublicationRecovery.current
+      ? canonicalPublicationRecovery.current(recovery)
+      : Promise.resolve("blocked")
   });
-  let proceedingsLeftByBudget = 0;
-  let recoveredProceedings = 0;
-  for (const proceeding of historicalProceedings) {
-    if (Date.now() >= startupRecoveryDeadline) {
-      proceedingsLeftByBudget += 1;
-      continue;
-    }
-    await reportStartupProgress("historical-recovery", proceeding.outerOpId);
-    const proceedingStartedAt = startupPhase.now();
-    try {
-      const recovery = await recoveryGate.recoverHistoricalProceeding(proceeding);
-      if (recovery.disposition === "permanently-rejected") {
-        await transport.send({
-          protocol: "harness-repo-write-ipc/v1",
-          repoId: config.repoId,
-          generation: config.generation,
-          kind: "recovery-rejected",
-          outerOpId: proceeding.outerOpId,
-          code: recovery.code,
-          diagnostic:
-            "Historical recovery evidence permanently conflicts with the canonical publication. "
-            + "The outer operation remains outcome-unknown; no authority terminal proof was created.",
-          next:
-            "Run `ha daemon logs --errors --json`, then escalate this outer op for "
-            + "operator-reviewed canonical Git and authority-state repair. "
-            + "Do not delete WAL, outcome, or recovery files."
-        });
-      }
-    } catch (error) {
-      await transport.send({
-        protocol: "harness-repo-write-ipc/v1",
-        repoId: config.repoId,
-        generation: config.generation,
-        kind: "recovery-deferred",
-        outerOpId: proceeding.outerOpId,
-        code: recoveryErrorCode(error),
-        diagnostic: boundedRecoveryError(error)
-      });
-    }
-    recoveredProceedings += 1;
-    startupPhase.observeProceeding(proceedingStartedAt);
-  }
-  startupPhase.mark("historical-recovery-loop", {
-    proceedingCount: recoveredProceedings,
-    slowestProceedingMs: startupPhase.slowestProceedingMs(),
-    budgetMs: startupRecoveryBudgetMs,
-    leftByBudget: proceedingsLeftByBudget
-  });
-  if (proceedingsLeftByBudget > 0) {
-    process.stderr.write(
-      `[repo-write-child] repo=${config.repoId} left ${proceedingsLeftByBudget} historical `
-      + `proceeding(s) unrecovered after spending the ${startupRecoveryBudgetMs}ms still left `
-      + `of the ${startupReadyBudgetMs}ms startup budget; they remain proceeding and are `
-      + "retried on the next start\n"
-    );
-  }
-  reconcileTerminalSettlements(settlements, outcomes);
+  const recoverSettlements = postReadyRecovery.recoverSettlements;
   await reportStartupProgress("child-host-start");
   const operation = new ProductionRepoWriteOperationHost({
     repoId: config.repoId,
@@ -352,15 +285,33 @@ export async function runRepoWriteChildEntrypoint(
       runtime
     })
   });
-  canonicalPublicationRecovery.current = (input) =>
-    operation.recoverCanonicalPublicationSettlement(input);
-  await recoverSettlements(remainingStartupRecoveryBudgetMs());
+  canonicalPublicationRecovery.current = (recovery) =>
+    operation.recoverCanonicalPublicationSettlement(recovery);
+  let initialRecovery: Promise<void> | undefined;
+  const startInitialRecovery = (): void => {
+    initialRecovery ??= postReadyRecovery.runInitialSweep().catch(async (error) => {
+      const diagnostic = boundedRecoveryError(error);
+      process.stderr.write(
+        `[repo-write-child] post-READY recovery deferred: ${diagnostic}\n`
+      );
+      await transport.send({
+        protocol: "harness-repo-write-ipc/v1",
+        repoId: config.repoId,
+        generation: config.generation,
+        kind: "recovery-deferred",
+        outerOpId: `post-ready-recovery:${config.repoId}`,
+        code: "POST_READY_RECOVERY_DEFERRED",
+        diagnostic
+      }).catch(() => undefined);
+    });
+  };
   let cleanupPromise: Promise<void> | undefined;
   const cleanup = () => {
     cleanupPromise ??= (async () => {
+      await initialRecovery;
       await operation.settlementIdle();
       await authorityLifecycle.stopRepo(repo, "daemon-shutdown");
-      await runtime!.stop();
+      await runtime.stop();
     })();
     return cleanupPromise;
   };
@@ -391,6 +342,7 @@ export async function runRepoWriteChildEntrypoint(
     void childHost.start().then(() => {
       startupPhase.mark("child-host-start-ready");
       startupPhase.reportTotal();
+      startInitialRecovery();
     }).catch(async (error: unknown) => {
       await cleanup().catch(() => undefined);
       reject(error);
@@ -399,10 +351,7 @@ export async function runRepoWriteChildEntrypoint(
 }
 
 interface RepoWriteChildStartupPhaseReporter {
-  readonly now: () => number;
   readonly mark: (phase: string, detail?: Record<string, number>) => void;
-  readonly observeProceeding: (startedAt: number) => void;
-  readonly slowestProceedingMs: () => number;
   readonly reportTotal: () => void;
 }
 
@@ -414,7 +363,6 @@ interface RepoWriteChildStartupPhaseReporter {
 function makeRepoWriteChildStartupPhaseReporter(): RepoWriteChildStartupPhaseReporter {
   const startedAt = performance.now();
   let previous = startedAt;
-  let slowestProceedingMs = 0;
   const emit = (frame: Record<string, unknown>) => {
     try {
       process.stderr.write(`${JSON.stringify({
@@ -427,7 +375,6 @@ function makeRepoWriteChildStartupPhaseReporter(): RepoWriteChildStartupPhaseRep
     }
   };
   return {
-    now: () => performance.now(),
     mark: (phase, detail) => {
       const at = performance.now();
       emit({
@@ -438,13 +385,6 @@ function makeRepoWriteChildStartupPhaseReporter(): RepoWriteChildStartupPhaseRep
       });
       previous = at;
     },
-    observeProceeding: (proceedingStartedAt) => {
-      slowestProceedingMs = Math.max(
-        slowestProceedingMs,
-        Math.round(performance.now() - proceedingStartedAt)
-      );
-    },
-    slowestProceedingMs: () => slowestProceedingMs,
     reportTotal: () => emit({
       phase: "ready",
       sinceEntrypointMs: Math.round(performance.now() - startedAt)
@@ -454,27 +394,4 @@ function makeRepoWriteChildStartupPhaseReporter(): RepoWriteChildStartupPhaseRep
 
 function canonicalExistingRoot(rootDir: string): string {
   return realpathSync.native(path.resolve(rootDir));
-}
-
-function recoveryErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
-function recoveryErrorCode(error: unknown): string {
-  if (error instanceof Error && "code" in error
-    && typeof error.code === "string" && error.code.trim()) {
-    return error.code;
-  }
-  const message = recoveryErrorMessage(error);
-  const match = /^([A-Z][A-Z0-9_]+)(?::|$)/u.exec(message);
-  return match?.[1] ?? "HISTORICAL_RECOVERY_DEFERRED";
-}
-
-function boundedRecoveryError(error: unknown): string {
-  const value = `${error instanceof Error ? `${error.name}: ` : ""}${recoveryErrorMessage(error)}`
-    .replace(/[\u0000-\u001f\u007f]+/gu, " ")
-    .trim();
-  const bytes = Buffer.from(value || "Historical recovery deferred.", "utf8");
-  if (bytes.length <= 2_048) return bytes.toString("utf8");
-  return bytes.subarray(0, 2_048).toString("utf8").replace(/\uFFFD$/u, "");
 }

--- a/packages/cli/src/composition/repo-write-child-post-ready-recovery.ts
+++ b/packages/cli/src/composition/repo-write-child-post-ready-recovery.ts
@@ -1,0 +1,257 @@
+import type { AuthorityCommittedReceipt } from "@harness-anything/application";
+import {
+  defaultProductionRecoveryAdmissionTimeoutMs,
+  type DurableRepoWriteOutcomeStoreV1,
+  type HarnessDaemonRuntime,
+  type ReceiptSettlementStore,
+  type RepoWriteAuthorityRecoveryGate,
+  type RepoWriteChildIpcTransport
+} from "@harness-anything/daemon";
+import {
+  reconcileTerminalSettlements,
+  recoverPendingSettlementMaterialization,
+  type ReceiptSettlementRecoveryProgress
+} from "./receipt-settlement-runtime.ts";
+
+const defaultReceiptRecoveryTimeoutMs = 5_000;
+
+export interface RepoWriteChildPostReadyRecovery {
+  readonly recoverSettlements: (budgetMs?: number) => Promise<void>;
+  readonly runInitialSweep: () => Promise<void>;
+}
+
+export function createRepoWriteChildPostReadyRecovery(input: {
+  readonly repoId: string;
+  readonly generation: number;
+  readonly transport: RepoWriteChildIpcTransport;
+  readonly settlements: ReceiptSettlementStore;
+  readonly outcomes: DurableRepoWriteOutcomeStoreV1;
+  readonly runtime: HarnessDaemonRuntime;
+  readonly authoredRoot: string;
+  readonly recoveryGate: Pick<RepoWriteAuthorityRecoveryGate, "recoverHistoricalProceeding">;
+  readonly recoverCommittedReceipt: (opId: string) => Promise<AuthorityCommittedReceipt>;
+  readonly recoverCanonicalPublication: (recovery: {
+    readonly outerOpId: string;
+    readonly canonicalCommitSha: string;
+  }) => Promise<"live-owner" | "recovered" | "terminal" | "blocked">;
+  readonly totalBudgetMs?: number;
+  readonly perReceiptTimeoutMs?: number;
+}): RepoWriteChildPostReadyRecovery {
+  const totalBudgetMs = input.totalBudgetMs ?? defaultProductionRecoveryAdmissionTimeoutMs;
+  const perReceiptTimeoutMs = input.perReceiptTimeoutMs ?? defaultReceiptRecoveryTimeoutMs;
+  const reporter = createPostReadyRecoveryReporter(input.repoId, input.generation);
+  const diagnosticDeliveries = new Set<Promise<void>>();
+  let activeSettlementSweep: Promise<void> | undefined;
+
+  const sendDeferred = (outerOpId: string, code: string, diagnostic: string): void => {
+    let delivery: Promise<void>;
+    try {
+      delivery = Promise.resolve(input.transport.send({
+        protocol: "harness-repo-write-ipc/v1",
+        repoId: input.repoId,
+        generation: input.generation,
+        kind: "recovery-deferred",
+        outerOpId,
+        code,
+        diagnostic
+      })).catch((error) => {
+        reporter.mark("diagnostic-delivery", outerOpId, "deferred", {
+          lastPhase: boundedRecoveryError(error)
+        });
+      });
+    } catch (error) {
+      reporter.mark("diagnostic-delivery", outerOpId, "deferred", {
+        lastPhase: boundedRecoveryError(error)
+      });
+      return;
+    }
+    diagnosticDeliveries.add(delivery);
+    void delivery.finally(() => diagnosticDeliveries.delete(delivery));
+  };
+
+  const reportReceiptProgress = (progress: ReceiptSettlementRecoveryProgress): void => {
+    reporter.mark("receipt-settlement", progress.receiptId, progress.status, {
+      lastPhase: progress.phase
+    });
+    if (progress.status !== "timed-out") return;
+    sendDeferred(
+      progress.receiptId,
+      "RECEIPT_SETTLEMENT_RECOVERY_TIMEOUT",
+      `Receipt settlement recovery exceeded ${perReceiptTimeoutMs}ms; `
+        + `receiptId=${progress.receiptId}; lastPhase=${progress.phase}. `
+        + "The durable receipt remains pending and replayable."
+    );
+  };
+
+  const recoverSettlements = (budgetMs = totalBudgetMs): Promise<void> => {
+    if (activeSettlementSweep) return activeSettlementSweep;
+    const sweep = (async () => {
+      await recoverPendingSettlementMaterialization({
+        settlements: input.settlements,
+        outcomes: input.outcomes,
+        runtime: input.runtime,
+        authoredRoot: input.authoredRoot,
+        deadlineAt: Date.now() + Math.max(0, budgetMs),
+        perReceiptTimeoutMs,
+        onReceiptProgress: reportReceiptProgress,
+        recoverCommittedReceipt: input.recoverCommittedReceipt,
+        recoverCanonicalPublication: input.recoverCanonicalPublication
+      });
+      reconcileTerminalSettlements(input.settlements, input.outcomes);
+    })();
+    activeSettlementSweep = sweep.finally(() => {
+      activeSettlementSweep = undefined;
+    });
+    return activeSettlementSweep;
+  };
+
+  const runInitialSweep = async (): Promise<void> => {
+    const startedAt = Date.now();
+    const deadlineAt = startedAt + totalBudgetMs;
+    reporter.mark("initial-sweep", input.repoId, "started", { budgetMs: totalBudgetMs });
+    await recoverSettlements(Math.max(0, deadlineAt - Date.now()));
+
+    reporter.mark("historical-recovery-scan", input.repoId, "started");
+    const proceedings = input.outcomes.listHistoricalProceedings();
+    let attempted = 0;
+    let leftByBudget = 0;
+    for (const proceeding of proceedings) {
+      const remainingMs = deadlineAt - Date.now();
+      if (remainingMs <= 0) {
+        leftByBudget += 1;
+        continue;
+      }
+      const timeoutMs = Math.min(perReceiptTimeoutMs, remainingMs);
+      reporter.mark("historical-recovery", proceeding.outerOpId, "started");
+      try {
+        const recovery = await waitForRecoveryItem(
+          input.recoveryGate.recoverHistoricalProceeding(proceeding),
+          timeoutMs
+        );
+        if (recovery.disposition === "permanently-rejected") {
+          await input.transport.send({
+            protocol: "harness-repo-write-ipc/v1",
+            repoId: input.repoId,
+            generation: input.generation,
+            kind: "recovery-rejected",
+            outerOpId: proceeding.outerOpId,
+            code: recovery.code,
+            diagnostic:
+              "Historical recovery evidence permanently conflicts with the canonical publication. "
+              + "The outer operation remains outcome-unknown; no authority terminal proof was created.",
+            next:
+              "Run `ha daemon logs --errors --json`, then escalate this outer op for "
+              + "operator-reviewed canonical Git and authority-state repair. "
+              + "Do not delete WAL, outcome, or recovery files."
+          });
+        }
+        reporter.mark("historical-recovery", proceeding.outerOpId, "completed");
+      } catch (error) {
+        const timedOut = error instanceof PostReadyRecoveryTimeoutError;
+        const code = timedOut
+          ? "AUTHORITY_HISTORICAL_RECOVERY_TIMEOUT"
+          : recoveryErrorCode(error);
+        const diagnostic = timedOut
+          ? `Historical recovery exceeded ${timeoutMs}ms; receiptId=${proceeding.outerOpId}; `
+            + "lastPhase=historical-recovery. The durable proceeding remains replayable."
+          : boundedRecoveryError(error);
+        reporter.mark("historical-recovery", proceeding.outerOpId, "deferred", {
+          lastPhase: "historical-recovery"
+        });
+        sendDeferred(proceeding.outerOpId, code, diagnostic);
+      }
+      attempted += 1;
+    }
+    reporter.mark("initial-sweep", input.repoId, "completed", {
+      attempted,
+      leftByBudget,
+      elapsedMs: Date.now() - startedAt
+    });
+    if (diagnosticDeliveries.size > 0) {
+      await Promise.allSettled([...diagnosticDeliveries]);
+    }
+  };
+
+  return { recoverSettlements, runInitialSweep };
+}
+
+interface PostReadyRecoveryReporter {
+  readonly mark: (
+    phase: string,
+    workUnit: string,
+    status: string,
+    detail?: Readonly<Record<string, string | number>>
+  ) => void;
+}
+
+function createPostReadyRecoveryReporter(
+  repoId: string,
+  generation: number
+): PostReadyRecoveryReporter {
+  let startedAt: number | undefined;
+  return {
+    mark: (phase, workUnit, status, detail) => {
+      try {
+        const now = performance.now();
+        startedAt ??= now;
+        process.stderr.write(`${JSON.stringify({
+          schema: "repo-write-child-post-ready-recovery/v1",
+          pid: process.pid,
+          repoId,
+          generation,
+          phase,
+          workUnit,
+          status,
+          sinceReadyMs: Math.round(now - startedAt),
+          ...(detail ?? {})
+        })}\n`);
+      } catch {
+        // Diagnostics must never alter durable recovery semantics.
+      }
+    }
+  };
+}
+
+class PostReadyRecoveryTimeoutError extends Error {
+  constructor() {
+    super("POST_READY_RECOVERY_TIMEOUT");
+    this.name = "PostReadyRecoveryTimeoutError";
+  }
+}
+
+async function waitForRecoveryItem<T>(recovery: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      recovery,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new PostReadyRecoveryTimeoutError()), timeoutMs);
+        timer.unref();
+      })
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function recoveryErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function recoveryErrorCode(error: unknown): string {
+  if (error instanceof Error && "code" in error
+    && typeof error.code === "string" && error.code.trim()) {
+    return error.code;
+  }
+  const match = /^([A-Z][A-Z0-9_]+)(?::|$)/u.exec(recoveryErrorMessage(error));
+  return match?.[1] ?? "HISTORICAL_RECOVERY_DEFERRED";
+}
+
+export function boundedRecoveryError(error: unknown): string {
+  const value = `${error instanceof Error ? `${error.name}: ` : ""}${recoveryErrorMessage(error)}`
+    .replace(/[\u0000-\u001f\u007f]+/gu, " ")
+    .trim();
+  const bytes = Buffer.from(value || "Historical recovery deferred.", "utf8");
+  if (bytes.length <= 2_048) return bytes.toString("utf8");
+  return bytes.subarray(0, 2_048).toString("utf8").replace(/\uFFFD$/u, "");
+}

--- a/packages/cli/test/receipt-settlement-runtime.test.ts
+++ b/packages/cli/test/receipt-settlement-runtime.test.ts
@@ -198,6 +198,114 @@ test("generic authority pending is promoted from canonical ancestry even before 
   }
 });
 
+test("a poisoned receipt times out without blocking later settlement recovery", durableSettlementStore, async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "ha-receipt-poison-"));
+  try {
+    const authoredRoot = path.join(root, "harness");
+    mkdirSync(authoredRoot);
+    git(authoredRoot, "init");
+    git(authoredRoot, "config", "user.name", "Receipt Recovery");
+    git(authoredRoot, "config", "user.email", "receipt-recovery@example.test");
+    writeFileSync(path.join(authoredRoot, "README.md"), "canonical\n");
+    git(authoredRoot, "add", "README.md");
+    git(authoredRoot, "commit", "-m", "canonical base");
+    const acceptedCommitSha = git(authoredRoot, "rev-parse", "HEAD");
+    const settlements = settlementStore(path.join(root, "settlements"), 2);
+    const poisonReceiptId = "repo-write-direct:00-poison";
+    const healthyReceiptId = "repo-write:01-healthy";
+    acceptPending(settlements, {
+      receiptId: poisonReceiptId,
+      sessionId: "session-poison",
+      acceptedCommitSha,
+      authorityOperationIds: ["op-poison"]
+    });
+    acceptPending(settlements, {
+      receiptId: healthyReceiptId,
+      sessionId: "session-healthy",
+      acceptedCommitSha,
+      authorityOperationIds: ["op-healthy"]
+    });
+    const outcomes = new DurableRepoWriteOutcomeStoreV1({
+      directory: path.join(root, "outcomes"),
+      repoId: "canonical",
+      workspaceId: "workspace-recovery",
+      generation: 2
+    });
+    const runtime = {
+      enqueueMaterializerBatch: async () => ({ branches: [] })
+    } as unknown as HarnessDaemonRuntime;
+    const progress: Array<{
+      readonly receiptId: string;
+      readonly phase: string;
+      readonly status: string;
+    }> = [];
+
+    await Promise.race([
+      recoverPendingSettlementMaterialization({
+        settlements,
+        outcomes,
+        runtime,
+        authoredRoot,
+        deadlineAt: Date.now() + 1_000,
+        perReceiptTimeoutMs: 25,
+        onReceiptProgress: (event) => progress.push(event),
+        recoverCommittedReceipt: async (opId) => {
+          if (opId === "op-poison") return new Promise(() => undefined);
+          throw new Error(`unexpected authority recovery: ${opId}`);
+        }
+      }),
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error("settlement sweep did not skip poison receipt")), 250);
+      })
+    ]);
+
+    assert.equal(settlements.lookup(poisonReceiptId)?.state, "pending");
+    assert.equal(settlements.lookup(healthyReceiptId)?.state, "canonical-visible");
+    const timeout = progress.find((event) =>
+      event.receiptId === poisonReceiptId && event.status === "timed-out");
+    assert.deepEqual(timeout, {
+      receiptId: poisonReceiptId,
+      phase: "authority-receipt",
+      status: "timed-out"
+    });
+    assert.ok(progress.findIndex((event) => event === timeout)
+      < progress.findIndex((event) =>
+        event.receiptId === healthyReceiptId && event.status === "visible"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function acceptPending(
+  settlements: ReceiptSettlementStore,
+  input: {
+    readonly receiptId: string;
+    readonly sessionId: string;
+    readonly acceptedCommitSha: string;
+    readonly authorityOperationIds: ReadonlyArray<string>;
+  }
+): void {
+  const pending = pendingCommandReceiptSettlement({
+    receiptId: input.receiptId,
+    acceptedAt: "2026-08-09T10:00:00.000Z",
+    sessionId: input.sessionId,
+    acceptedCommitSha: input.acceptedCommitSha,
+    authorityOperationIds: input.authorityOperationIds
+  });
+  settlements.accept(withCommandReceiptSettlement({
+    ok: true,
+    schema: "command-receipt/v2",
+    command: "task create",
+    action: "create",
+    summary: "accepted",
+    next: [],
+    meta: {
+      generatedAt: "2026-08-09T10:00:00.000Z",
+      compatibility: { legacyReceipt: "CommandReceipt/v1" }
+    }
+  }, pending));
+}
+
 function settlementStore(directory: string, generation: number): ReceiptSettlementStore {
   return new ReceiptSettlementStore({
     directory,

--- a/packages/cli/test/repo-write-child-production-cutover.test.ts
+++ b/packages/cli/test/repo-write-child-production-cutover.test.ts
@@ -61,6 +61,7 @@ const entrypointArtifactIdentity =
 
 cutoverTest("production child reports semantic startup phases before READY", async (t) => {
   const fixture = createProductionAuthorityLifecycleFixture();
+  seedLargeAuthorityStartupLog(fixture.serviceRoot);
   const userRoot = path.join(fixture.root, "daemon-user");
   const endpoint = path.join(userRoot, "daemon.sock");
   const startupProgress: Array<{ readonly phase: string; readonly workUnit: string }> = [];
@@ -120,7 +121,14 @@ cutoverTest("production child reports semantic startup phases before READY", asy
       { phase: "runtime-start", workUnit: "canonical" },
       { phase: "authority-lifecycle-compose", workUnit: "canonical" },
       { phase: "authority-start-repo", workUnit: "canonical" },
-      { phase: "historical-recovery-scan", workUnit: "canonical" },
+      {
+        phase: "authority-start-repo",
+        workUnit: "canonical:authority-state:operations.jsonl:2048"
+      },
+      {
+        phase: "authority-start-repo",
+        workUnit: "canonical:authority-state:operations.jsonl:4096"
+      },
       { phase: "child-host-start", workUnit: "canonical" }
     ]);
     t.diagnostic(JSON.stringify({ startupProgress }));
@@ -129,6 +137,27 @@ cutoverTest("production child reports semantic startup phases before READY", asy
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });
+
+function seedLargeAuthorityStartupLog(serviceRoot: string): void {
+  const stateDirectory = path.join(
+    serviceRoot,
+    "authority",
+    Buffer.from("canonical", "utf8").toString("base64url")
+  );
+  mkdirSync(stateDirectory, { recursive: true });
+  const rows = Array.from({ length: 4_097 }, (_, index) => JSON.stringify({
+    schema: "authority-service-state/v1",
+    table: "operation",
+    key: `workspace-startup-noise\u0000op-${index}`,
+    value: {
+      workspaceId: "workspace-startup-noise",
+      opId: `op-${index}`,
+      semanticDigest: "a".repeat(64),
+      state: "RECEIVED"
+    }
+  }));
+  writeFileSync(path.join(stateDirectory, "operations.jsonl"), `${rows.join("\n")}\n`);
+}
 
 cutoverTest("two signed production repos own distinct child locks and route through one daemon", { timeout: 60_000 }, async (t) => {
   const fixture = createProductionAuthorityLifecycleFixture({ repoIds: ["alpha", "beta"] });

--- a/packages/daemon/src/authority/authority-lifecycle.ts
+++ b/packages/daemon/src/authority/authority-lifecycle.ts
@@ -21,6 +21,7 @@ import {
   openDurableAuthorityServiceState,
   type CanonicalPublicationEvidence,
   type DurableAuthorityServiceState,
+  type DurableAuthorityServiceStateReplayProgress,
   type GitCanonicalPublicationInspector
 } from "@harness-anything/daemon";
 import {
@@ -256,6 +257,10 @@ type PublicationInspectorOptions = NonNullable<
 export function createAuthorityRepoLifecycleController(input: {
   readonly hooks: AuthorityRepoLifecycleHooks;
   readonly serviceStateRoot: string;
+  readonly onServiceStateReplayProgress?: (
+    repo: DaemonRepoNamespace,
+    progress: DurableAuthorityServiceStateReplayProgress
+  ) => void;
   readonly resolveCompositionData: (
     repo: DaemonRepoNamespace,
     state: DurableAuthorityServiceState,
@@ -313,13 +318,17 @@ export function createAuthorityRepoLifecycleController(input: {
     repo: DaemonRepoNamespace,
     runtime: AuthorityLifecycleRuntime
   ): Promise<AuthorityRepoStartResult> {
+    const onServiceStateReplayProgress = input.onServiceStateReplayProgress;
     let state: DurableAuthorityServiceState | undefined;
     let component: AuthorityRepoComponent | undefined;
     let publicationInspector: GitCanonicalPublicationInspector | undefined;
     try {
       state = openDurableAuthorityServiceState({
         serviceStateRoot: input.serviceStateRoot,
-        repoId: repo.repoId
+        repoId: repo.repoId,
+        ...(onServiceStateReplayProgress ? {
+          onReplayProgress: (progress) => onServiceStateReplayProgress(repo, progress)
+        } : {})
       });
       const serverData = await input.resolveCompositionData(repo, state, runtime);
       validateServerData(repo, serverData, input.allowInMemoryFixture === true);

--- a/packages/daemon/src/authority/production/production-authority-lifecycle.ts
+++ b/packages/daemon/src/authority/production/production-authority-lifecycle.ts
@@ -1,6 +1,4 @@
 // @slice-activation PLT-Boundary W2 exports the daemon-owned production authority lifecycle to CLI host composition.
-import { createHash } from "node:crypto";
-import { readFileSync, realpathSync } from "node:fs";
 import {
   createAuthorityCutoverEntityRegistryQualification,
   createAuthorityCutoverControlService,
@@ -81,6 +79,10 @@ import type { RetryBudgetSignal } from "../../observability/visible-retry-budget
 import { settleProductionRecovery, type ProductionRecoveryState } from "./production-recovery-state.ts";
 import { productionPublicationRetryOptions } from "./production-publication-retry-options.ts";
 import { createSerialPublicationExecutor } from "./serial-publication-executor.ts";
+import {
+  authorityManifestSourceDigest,
+  canonicalProductionAuthorityRoot
+} from "./production-authority-manifest-identity.ts";
 export { createSerialPublicationExecutor } from "./serial-publication-executor.ts";
 export { recoverPendingProductionEvents } from "./recovery.ts";
 
@@ -114,6 +116,9 @@ export function createProductionAuthorityLifecycle(input: {
   readonly layoutOverrides?: { readonly authoredRoot?: string };
   readonly daemonLogService?: DaemonLogService;
   readonly onPublicationRetryBudgetSignal?: (signal: RetryBudgetSignal) => void;
+  readonly onServiceStateReplayProgress?: Parameters<
+    typeof createAuthorityRepoLifecycleController
+  >[0]["onServiceStateReplayProgress"];
   readonly backgroundRecovery?: true;
   readonly hostServices: ProductionAuthorityHostServices<ProductionAuthorityIdentity>;
 }): AuthorityRepoLifecycleController {
@@ -124,13 +129,18 @@ export function createProductionAuthorityLifecycle(input: {
   const controller = createAuthorityRepoLifecycleController({
     hooks,
     serviceStateRoot: manifest.serviceStateRoot,
+    ...(input.onServiceStateReplayProgress ? {
+      onServiceStateReplayProgress: input.onServiceStateReplayProgress
+    } : {}),
     resolvePublicationInspectorOptions: (repo) => {
       const config = manifest.repos.find((candidate) => candidate.repoId === repo.repoId);
       return config ? productionPublicationRetryOptions(input, config) : {};
     },
     resolveCompositionData: async (repo, state, runtime) => {
       const config = manifest.repos.find((candidate) => candidate.repoId === repo.repoId);
-      if (!config || canonicalRoot(config.canonicalRoot) !== canonicalRoot(repo.canonicalRoot)) {
+      if (!config
+        || canonicalProductionAuthorityRoot(config.canonicalRoot)
+          !== canonicalProductionAuthorityRoot(repo.canonicalRoot)) {
         throw new Error("AUTHORITY_PRODUCTION_REPO_NOT_CONFIGURED");
       }
       const identity = input.hostServices.loadDaemonIdentity(
@@ -578,19 +588,4 @@ function assertConnectionContext(
     || config.sessionId !== input.serverData.sessionId) {
     throw new Error("AUTHORITY_SERVER_AXIS_MISMATCH");
   }
-}
-
-function canonicalRoot(value: string): string {
-  try {
-    return realpathSync(value);
-  } catch {
-    return value;
-  }
-}
-
-function authorityManifestSourceDigest(manifestPath: string): string {
-  return createHash("sha256")
-    .update("ha/authority-production-manifest-source/v1\0", "utf8")
-    .update(readFileSync(manifestPath))
-    .digest("hex");
 }

--- a/packages/daemon/src/authority/production/production-authority-manifest-identity.ts
+++ b/packages/daemon/src/authority/production/production-authority-manifest-identity.ts
@@ -1,0 +1,17 @@
+import { createHash } from "node:crypto";
+import { readFileSync, realpathSync } from "node:fs";
+
+export function canonicalProductionAuthorityRoot(value: string): string {
+  try {
+    return realpathSync(value);
+  } catch {
+    return value;
+  }
+}
+
+export function authorityManifestSourceDigest(manifestPath: string): string {
+  return createHash("sha256")
+    .update("ha/authority-production-manifest-source/v1\0", "utf8")
+    .update(readFileSync(manifestPath))
+    .digest("hex");
+}

--- a/packages/daemon/src/authority/production/service-state.ts
+++ b/packages/daemon/src/authority/production/service-state.ts
@@ -20,6 +20,7 @@ import { stableStringify } from "@harness-anything/kernel";
 
 const serviceStateSchema = "authority-service-state/v1" as const;
 const operationTransitionSchema = "authority-operation-transition-batch/v1" as const;
+const replayProgressRowInterval = 2_048;
 
 interface DurableStateEnvelope {
   readonly schema: typeof serviceStateSchema;
@@ -57,6 +58,12 @@ export interface DurableAuthorityServiceState {
   readonly close: () => Promise<void>;
 }
 
+export interface DurableAuthorityServiceStateReplayProgress {
+  readonly fileName: string;
+  readonly table: DurableStateEnvelope["table"];
+  readonly replayedRows: number;
+}
+
 /**
  * Opens restart-recoverable daemon service state. All logs are replayed before
  * this function returns, so lifecycle serve cannot race recovery.
@@ -64,6 +71,9 @@ export interface DurableAuthorityServiceState {
 export function openDurableAuthorityServiceState(input: {
   readonly serviceStateRoot: string;
   readonly repoId: string;
+  readonly onReplayProgress?: (
+    progress: DurableAuthorityServiceStateReplayProgress
+  ) => void;
 }): DurableAuthorityServiceState {
   const repoId = requiredKey(input.repoId, "repoId");
   const stateDirectory = path.join(
@@ -72,17 +82,47 @@ export function openDurableAuthorityServiceState(input: {
     Buffer.from(repoId, "utf8").toString("base64url")
   );
   mkdirSync(stateDirectory, { recursive: true, mode: 0o700 });
-  const operationLog = openLog(stateDirectory, "operations.jsonl", "operation");
-  const replicaLog = openLog(stateDirectory, "replica-changes.jsonl", "replica-change");
+  const operationLog = openLog(
+    stateDirectory,
+    "operations.jsonl",
+    "operation",
+    input.onReplayProgress
+  );
+  const replicaLog = openLog(
+    stateDirectory,
+    "replica-changes.jsonl",
+    "replica-change",
+    input.onReplayProgress
+  );
   for (const [key, value] of replicaLog.values) {
     const normalized = normalizePersistedReplicaChange(value);
     validateReplicaChange(normalized);
     replicaLog.values.set(key, normalized);
   }
-  const bindingLog = openLog(stateDirectory, "bindings.jsonl", "binding");
-  const namespaceLog = openLog(stateDirectory, "namespaces.jsonl", "namespace");
-  const cutoverLog = openLog(stateDirectory, "cutover.jsonl", "cutover");
-  const replicationLog = openLog(stateDirectory, "replication.jsonl", "replication");
+  const bindingLog = openLog(
+    stateDirectory,
+    "bindings.jsonl",
+    "binding",
+    input.onReplayProgress
+  );
+  const namespaceLog = openLog(
+    stateDirectory,
+    "namespaces.jsonl",
+    "namespace",
+    input.onReplayProgress
+  );
+  const cutoverLog = openLog(
+    stateDirectory,
+    "cutover.jsonl",
+    "cutover",
+    input.onReplayProgress
+  );
+  const replicationLog = openLog(
+    stateDirectory,
+    "replication.jsonl",
+    "replication",
+    input.onReplayProgress
+  );
   const replicaListeners = new Map<string, Set<(record: ReplicaChangeRecord) => void>>();
   let closed = false;
 
@@ -200,7 +240,10 @@ export function openDurableAuthorityServiceState(input: {
 function openLog(
   stateDirectory: string,
   fileName: string,
-  table: DurableStateEnvelope["table"]
+  table: DurableStateEnvelope["table"],
+  onReplayProgress?: (
+    progress: DurableAuthorityServiceStateReplayProgress
+  ) => void
 ): {
   readonly values: Map<string, unknown>;
   readonly append: (key: string, value: unknown) => void;
@@ -210,6 +253,7 @@ function openLog(
   const values = new Map<string, unknown>();
   if (existsSync(logPath)) {
     const lines = readFileSync(logPath, "utf8").split("\n");
+    let replayedRows = 0;
     for (let index = 0; index < lines.length; index += 1) {
       const line = lines[index]!;
       if (!line) continue;
@@ -224,12 +268,16 @@ function openLog(
           throw new Error(`AUTHORITY_SERVICE_STATE_INVALID_ROW:${fileName}:${index + 1}`);
         }
         applyOperationTransitions(values, envelope.transitions, fileName, index + 1);
+        replayedRows += 1;
+        reportReplayProgress(onReplayProgress, fileName, table, replayedRows);
         continue;
       }
       if (envelope.schema !== serviceStateSchema || envelope.table !== table || !envelope.key) {
         throw new Error(`AUTHORITY_SERVICE_STATE_INVALID_ROW:${fileName}:${index + 1}`);
       }
       values.set(envelope.key, envelope.value);
+      replayedRows += 1;
+      reportReplayProgress(onReplayProgress, fileName, table, replayedRows);
     }
   }
   return {
@@ -249,6 +297,16 @@ function openLog(
       applyOperationTransitions(values, transitions, fileName);
     }
   };
+}
+
+function reportReplayProgress(
+  onReplayProgress: ((progress: DurableAuthorityServiceStateReplayProgress) => void) | undefined,
+  fileName: string,
+  table: DurableStateEnvelope["table"],
+  replayedRows: number
+): void {
+  if (!onReplayProgress || replayedRows % replayProgressRowInterval !== 0) return;
+  onReplayProgress({ fileName, table, replayedRows });
 }
 
 function applyOperationTransitions(

--- a/packages/daemon/test/authority-production-state.test.ts
+++ b/packages/daemon/test/authority-production-state.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -18,6 +18,45 @@ import {
   openDurableAuthorityServiceState,
   type DurableAuthorityStateTable
 } from "../src/authority/production/service-state.ts";
+
+test("large durable service-state replay reports bounded startup work without changing final values", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-authority-replay-progress-"));
+  try {
+    const stateDirectory = path.join(
+      root,
+      "authority",
+      Buffer.from("repo-1", "utf8").toString("base64url")
+    );
+    mkdirSync(stateDirectory, { recursive: true });
+    const rows = Array.from({ length: 4_097 }, (_, index) => JSON.stringify({
+      schema: "authority-service-state/v1",
+      table: "replication",
+      key: `replication-${index % 2}`,
+      value: { revision: index }
+    }));
+    writeFileSync(path.join(stateDirectory, "replication.jsonl"), `${rows.join("\n")}\n`);
+    const progress: Array<{ readonly fileName: string; readonly replayedRows: number }> = [];
+
+    const state = openDurableAuthorityServiceState({
+      serviceStateRoot: root,
+      repoId: "repo-1",
+      onReplayProgress: (event) => progress.push({
+        fileName: event.fileName,
+        replayedRows: event.replayedRows
+      })
+    });
+
+    assert.deepEqual(progress, [
+      { fileName: "replication.jsonl", replayedRows: 2_048 },
+      { fileName: "replication.jsonl", replayedRows: 4_096 }
+    ]);
+    assert.deepEqual(state.replicationState.get("replication-0"), { revision: 4_096 });
+    assert.deepEqual(state.replicationState.get("replication-1"), { revision: 4_095 });
+    await state.close();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test("durable binding consumption is idempotent for the same inner op and bounded across distinct ops", async () => {
   const table = memoryTable();


### PR DESCRIPTION
## Summary

Production daemon cold start hit a deterministic ready-gate death (30s no-phase inactivity) once the authority JSONL logs grew to ~518MB and the first settlement sweep wedged on a poisoned pending receipt. This PR moves the initial settlement/historical-proceeding recovery out of the pre-READY critical path into a bounded post-READY background sweep, and makes large authority JSONL replay observable via progress frames. Production-size read-only copy: cold READY **4.643s** (was: never), first sweep completes in 15.9s with the poison receipt named and skipped after a 5s per-receipt deadline.

## What Changed

- `repo-write-child-entrypoint.ts`: pre-READY path no longer runs the full settlement sweep or historical proceeding scan; initial recovery starts only after `childHost.start()` sends READY. Cleanup awaits the in-flight initial recovery.
- `repo-write-child-post-ready-recovery.ts` (new): bounded post-READY initial sweep — production recovery admission budget (25s), 5s per-receipt deadline, NDJSON progress frames (`repo-write-child-post-ready-recovery/v1`), honest `recovery-deferred`/`recovery-rejected` IPC diagnostics preserved, serialized sweep requests.
- `receipt-settlement-runtime.ts`: per-receipt recovery phases reported (`inspect`/`materializer`/`canonical-proof`/`authority-receipt`/`canonical-publication`/`settlement-store`); optional per-receipt deadline with `RECEIPT_SETTLEMENT_RECOVERY_TIMEOUT` continuation; completion diagnostic derived from actual settlement-store state; Git proof subprocesses bounded at 5s.
- `service-state.ts` + lifecycle threading: observation-only replay progress callbacks every 2,048 valid rows per authority JSONL table (parse order, folding, failure behavior, durable format unchanged).
- `production-authority-manifest-identity.ts` (new): mechanical extraction to stay under the 600-line complexity gate; no identity semantics changed.
- Tests: poison-receipt isolation (red→green), READY-before-recovery ordering (red→green), replay progress cadence + unchanged folded state.

## Version Impact

- No version change because this is an internal daemon startup-path fix with no public CLI surface change.

## Verification

- [x] `npm run check:local` — 27 gates green; affected fast 842/842, affected contract 289 pass / 1 skip (Windows-only)
- [x] Startup/recovery integration group: 39/39
- [x] Nightly startup/recovery benchmark: 2/2 (`coldRecoveryMs` 10397)
- [x] Production-size read-only APFS-clone fixture: READY 4,643ms; initial sweep completed, 23 attempted, 0 left by budget; poison receipt `RECEIPT_SETTLEMENT_RECOVERY_TIMEOUT` at phase `authority-receipt`, remains pending, sweep continues
- [x] `git diff --check`
- Not run: `npm test` full tier locally (GitHub CI is the authority; check:local is the sanctioned local stop point)

## Review Evidence

- Self-review: worker red→green evidence for both new semantics; no test assertion weakened; corrupt-sidecar skip path untouched.
- Additional review: CEO semantic acceptance against the round-7 adjudication (pre-READY = authority replay + minimal setup only; recovery post-READY, bounded, honest) — verified `recovery-rejected` for `permanently-rejected` dispositions is preserved in the new module.
- Blocking findings: none.

## Residual Risk

- `Promise.race` deadlines cannot interrupt a truly synchronous event-loop stall; Git proof subprocesses are separately bounded and the observed poison was an async authority-receipt wait.
- JSONL replay remains memory-heavy (~1.89GiB RSS on the production copy); rolling compaction is deliberately deferred to Wave 3 with a written proposal.
- Production-copy sweep surfaced historical invalid/not-found/indeterminate outcomes; they stay honest and replayable as operator-review items.

## References

- Task: task_01KZNV1PD6M2BE1BKDCXX1K8VZ (artifacts: mission-round7-settlement-sweep-post-ready.md, worker-report-round7-ready-post-settlement-sweep.md)
- Evidence: production incident doc `harness/context/research/2026-08-10-daemon-write-stall-incident.md`; campaign decision dec_01KZNZFH272P9W72CG2J8XZPPW

---

## 摘要

生产 daemon 冷启动出现确定性 ready-gate 死墙（30 秒无相位帧判死）：authority JSONL 日志涨到 ~518MB 后，首轮 settlement sweep 又被一条中毒 pending receipt 楔死。本 PR 把首轮 settlement/历史 proceeding 恢复移出 READY 前关键路径，改为 READY 后有界后台 sweep，并让大 JSONL 重放通过进度帧可观测。生产规模只读副本实测：冷启动 READY **4.643s**（此前永远起不来），首轮 sweep 15.9s 完成，毒 receipt 在 5s 单条 deadline 后被点名跳过。

## 改动内容

- `repo-write-child-entrypoint.ts`：READY 前不再做全量 settlement sweep 与历史 proceeding 扫描；首轮恢复在 `childHost.start()` 发出 READY 后才启动；cleanup 等待在飞的首轮恢复。
- `repo-write-child-post-ready-recovery.ts`（新）：有界后台首轮 sweep——25s 准入预算、5s 单 receipt deadline、NDJSON 进度帧、诚实的 `recovery-deferred`/`recovery-rejected` IPC 诊断全保留、sweep 请求串行化。
- `receipt-settlement-runtime.ts`：单 receipt 恢复相位上报；可选单条 deadline，超时 `RECEIPT_SETTLEMENT_RECOVERY_TIMEOUT` 后继续处理后续项；完成诊断从 settlement-store 真实状态派生；Git proof 子进程 5s 有界。
- `service-state.ts` + lifecycle 穿线：每表每 2,048 有效行发观察性重放进度回调（解析顺序、状态折叠、失败行为、持久格式不变）。
- `production-authority-manifest-identity.ts`（新）：为过 600 行复杂度门做的机械抽取，身份语义不变。
- 测试：毒 receipt 隔离（先红后绿）、READY 先于恢复的顺序（先红后绿）、重放进度节律 + 折叠终态不变。

## 版本影响

- 不改版本，原因是 daemon 内部启动路径修复，无公开 CLI 面变化。

## 验证

- [x] `npm run check:local` — 27 门全绿；受影响 fast 842/842、contract 289 过 / 1 跳（仅 Windows）
- [x] 启动/恢复 integration 组：39/39
- [x] nightly 启动/恢复基准：2/2
- [x] 生产规模只读 APFS 克隆 fixture：READY 4,643ms；首轮 sweep 完成 23 项、0 项因预算遗留；毒 receipt 超时点名后保持 pending，sweep 继续
- [x] `git diff --check`
- 未运行：本地全量 `npm test`（GitHub CI 是完整权威；check:local 是既定本地停止点）

## 审查证据

- 自查：worker 对两个新语义的先红后绿证据；未削弱任何测试断言；corrupt-sidecar skip 路径未动。
- 额外审查：CEO 按第七轮裁决做语义验收（READY 前=authority 重放+最小装配；恢复后置、有界、诚实）——已核验 `permanently-rejected` 的 `recovery-rejected` 帧在新模块中保留。
- 阻塞发现：无。

## 残余风险

- `Promise.race` deadline 无法打断真正同步的事件循环卡死；Git proof 子进程已单独有界，本次实测毒源是异步 authority-receipt 等待。
- JSONL 重放仍是内存大户（生产副本 ~1.89GiB RSS）；滚动 compaction 有成文方案，刻意留给波次 3。
- 生产副本 sweep 暴露的历史 invalid/not-found/indeterminate 结果保持诚实可重放，作为运维复核项。

## 关联材料

- 任务：task_01KZNV1PD6M2BE1BKDCXX1K8VZ（artifacts：mission-round7-settlement-sweep-post-ready.md、worker-report-round7-ready-post-settlement-sweep.md）
- 证据：生产事故文档 `harness/context/research/2026-08-10-daemon-write-stall-incident.md`；战役决策 dec_01KZNZFH272P9W72CG2J8XZPPW
