### PR TITLE
fix(cli): exclude machine-internal .harness layer from conflict-marker preflight

### DIFF
--- a/packages/cli/src/composition/incremental-conflict-marker-preflight.ts
+++ b/packages/cli/src/composition/incremental-conflict-marker-preflight.ts
@@ -120,7 +120,7 @@ function readChangedGitPaths(
     return [...new Set([...state.worktreePaths, ...committedPaths])]
       .filter((entry) => safeRepoRelativePath(entry))
       .filter((entry) => !entry.split(/[\\/]/u).some((part) =>
-        part === ".git" || part === "node_modules"
+        part === ".git" || part === "node_modules" || part === ".harness"
       ));
   } catch {
     return null;

--- a/packages/cli/test/incremental-conflict-marker-preflight.test.ts
+++ b/packages/cli/test/incremental-conflict-marker-preflight.test.ts
@@ -89,6 +89,38 @@ test("generation conflict preflight observes committed deltas and root policy fi
   }
 });
 
+test("machine-internal .harness snapshots never trip the conflict preflight in full or incremental mode", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-conflict-marker-harness-layer-"));
+  const authoredRoot = path.join(rootDir, "harness");
+  const preservedDir = path.join(
+    authoredRoot, ".harness", "preserved-worktree-edits", "snap-1", "tasks"
+  );
+  try {
+    mkdirSync(preservedDir, { recursive: true });
+    writeFileSync(path.join(authoredRoot, "harness.yaml"), "schema: harness-anything/v1\n");
+    writeFileSync(path.join(preservedDir, "progress.md"), conflictMarker());
+    git(authoredRoot, "init", "-b", "main");
+    git(authoredRoot, "config", "user.name", "Harness Test");
+    git(authoredRoot, "config", "user.email", "harness@example.test");
+    git(authoredRoot, "add", ".");
+    git(authoredRoot, "commit", "-m", "seed with preserved snapshot marker");
+
+    const preflight = makeIncrementalConflictMarkerPreflight({ rootDir });
+    // Full-mode scan: the snapshot marker must not pin the preflight in full mode.
+    assert.equal(preflight.read(), undefined);
+
+    // Incremental mode: a fresh snapshot with markers stays invisible.
+    writeFileSync(path.join(preservedDir, "late-snapshot.md"), conflictMarker());
+    assert.equal(preflight.read(), undefined);
+
+    // Positive control: an authored marker is still caught.
+    writeFileSync(path.join(authoredRoot, "authored.md"), conflictMarker());
+    assert.equal(preflight.read()?.code, "conflict_marker_present");
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 function conflictMarker(): string {
   return "<<<<<<< HEAD\nleft\n=======\nright\n>>>>>>> branch\n";
 }

--- a/packages/kernel/src/projection/post-merge-checks.ts
+++ b/packages/kernel/src/projection/post-merge-checks.ts
@@ -493,7 +493,7 @@ function listTextFiles(inputPath: string): ReadonlyArray<string> {
     const entries = readDirIfPresent(dir);
     if (entries === null) continue;
     for (const entry of entries) {
-      if (entry.name === ".git" || entry.name === "node_modules") continue;
+      if (entry.name === ".git" || entry.name === "node_modules" || entry.name === ".harness") continue;
       const childPath = path.join(dir, entry.name);
       if (entry.isSymbolicLink()) continue;
       if (entry.isDirectory()) {


### PR DESCRIPTION
## Summary

After the daemon came back up (#1337), every production ledger write still timed out at ~36s inside the `command-conflict-recheck` phase. Root cause is a double defect in the conflict-marker preflight: (1) the scan walks `harness/.harness/` — machine-internal storage — where 20,125 preserved-worktree-edit snapshot files (104MB) live, and (2) one snapshot legitimately contains Git conflict markers (snapshots preserve conflicted user edits by design), which permanently produced a warning, so `cleanAuthoredHead` was never set and the incremental preflight stayed pinned in full-scan mode for every write. This PR excludes the `.harness` layer at both chokepoints.

## What Changed

- `packages/kernel/src/projection/post-merge-checks.ts`: `listTextFiles` skips `.harness` directory entries alongside `.git`/`node_modules` (covers full-mode scan and all other prose checks routed through it).
- `packages/cli/src/composition/incremental-conflict-marker-preflight.ts`: the incremental changed-path filter also excludes `.harness` path segments.
- `packages/cli/test/incremental-conflict-marker-preflight.test.ts`: new case pinning the semantics red→green — a marker inside `.harness/preserved-worktree-edits` never trips the preflight in full or incremental mode; positive control asserts an authored-tree marker is still caught.

## Version Impact

- No version change because this is an internal preflight scoping fix with no public CLI surface change.

## Verification

- [x] Red evidence: with src fix stashed, the new test fails with `conflict_marker_present` pointing at the snapshot path; green after restore (4/4 in file).
- [x] `npm run check:local` — 27 gates green (88.1s).
- [x] `git diff --check`
- Not run: full `npm test` locally (GitHub CI is the authority; check:local is the sanctioned local stop point).

## Review Evidence

- Self-review: exclusion is semantically correct — `.harness` is the machine layer (locks, write journal, preserved snapshots); preserved snapshots may legitimately contain conflict markers because they preserve conflicted user edits, so rejecting every write on their content was itself the defect. Authored-tree markers remain hard-fail.
- Additional review: production reproduction — live writes stuck 36s in `command-conflict-recheck`, first rejected by a marker inside `preserved-worktree-edits/msnlt0d5-f1567b/.../progress.md`.
- Blocking findings: none.

## Residual Risk

- The 20,125-snapshot growth in `preserved-worktree-edits` (no pruning) is a separate defect tracked for follow-up; this PR only stops it from taxing and blocking the write path.

## References

- Task: task_01KZNV1PD6M2BE1BKDCXX1K8VZ (write-chain diet campaign)
- Evidence: incident doc `harness/context/research/2026-08-10-daemon-write-stall-incident.md`; campaign decision dec_01KZNZFH272P9W72CG2J8XZPPW

---

## 摘要

daemon 恢复（#1337）后，生产台账写仍在 `command-conflict-recheck` 相位烧 ~36s 后超时。根因是冲突标记 preflight 的双重缺陷：(1) 扫描走进了机器内部层 `harness/.harness/`——那里有 20,125 个 preserved-worktree-edits 快照文件（104MB）；(2) 其中一个快照合法地含有 Git 冲突标记（快照保存的正是用户冲突现场），永久产生 warning → `cleanAuthoredHead` 永不落位 → 增量 preflight 被钉死在全量扫描模式。本 PR 在两个 chokepoint 排除 `.harness` 层。

## 改动内容

- `post-merge-checks.ts`：`listTextFiles` 跳过 `.harness` 目录（覆盖全量扫描及所有经它路由的 prose 检查）。
- `incremental-conflict-marker-preflight.ts`：增量变更路径过滤同样排除 `.harness` 段。
- 新测试先红后绿钉住语义：快照内标记在全量/增量两模式都不再拦写；阳性对照确认 authored 树内标记仍被捕获。

## 版本影响

- 不改版本，原因是内部 preflight 范围修复，无公开 CLI 面变化。

## 验证

- [x] 红证：stash 掉 src 修复后新测试以 `conflict_marker_present` 失败并指向快照路径；恢复后全绿（4/4）
- [x] `npm run check:local` — 27 门全绿（88.1s）
- [x] `git diff --check`
- 未运行：本地全量 `npm test`（GitHub CI 是完整权威）

## 审查证据

- 自查：`.harness` 是机器层（锁/写 journal/保存快照）；快照允许含冲突标记是设计使然，据其拒掉全部写本身即缺陷。authored 树内标记仍硬性拦截。
- 额外审查：生产复现——写请求卡 `command-conflict-recheck` 36s，首笔被 `preserved-worktree-edits/.../progress.md` 内标记拒绝。
- 阻塞发现：无。

## 残余风险

- `preserved-worktree-edits` 无修剪机制导致的 2 万快照增长是独立缺陷，另立后续任务；本 PR 只解除其对写路的拖累与阻塞。

## 关联材料

- 任务：task_01KZNV1PD6M2BE1BKDCXX1K8VZ（写链路减肥战役）
- 证据：事故文档 `harness/context/research/2026-08-10-daemon-write-stall-incident.md`；dec_01KZNZFH272P9W72CG2J8XZPPW
