### PR TITLE
fix(daemon): doc-sync dirty scan excludes .harness layer and fails loudly on git errors

### DIFF
--- a/packages/daemon/src/service/doc-sync-applied-ledger.ts
+++ b/packages/daemon/src/service/doc-sync-applied-ledger.ts
@@ -33,8 +33,16 @@ export function resolveDocSyncAppliedLedgerSha(
 
 export function gitText(cwd: string, args: ReadonlyArray<string>): string | null {
   try {
-    return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], windowsHide: true }).trimEnd();
-  } catch {
+    return execFileSync("git", ["-C", cwd, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+      windowsHide: true
+    }).trimEnd();
+  } catch (error) {
+    // A swallowed ENOBUFS once rendered a 5.6MB status as "clean tree" (issue #1340);
+    // callers keep the null contract, but the failure must not be invisible.
+    process.stderr.write(`[doc-sync] git ${args[0] ?? ""} failed in ${cwd}: ${error instanceof Error ? error.message.split("\n")[0] : String(error)}\n`);
     return null;
   }
 }

--- a/packages/daemon/src/service/doc-sync-git-status.ts
+++ b/packages/daemon/src/service/doc-sync-git-status.ts
@@ -12,7 +12,10 @@ interface DirtyEntry {
 }
 
 export function readDocSyncDirtyEntries(authoredRoot: string): ReadonlyArray<DirtyEntry> {
-  const output = gitText(authoredRoot, ["status", "--porcelain=v1", "-z", "--untracked-files=all", "--", "."]) ?? "";
+  const output = gitText(authoredRoot, [
+    "status", "--porcelain=v1", "-z", "--untracked-files=all",
+    "--", ".", ":(exclude).harness"
+  ]) ?? "";
   const records = output.split("\0");
   const entries: DirtyEntry[] = [];
   for (let index = 0; index < records.length; index += 1) {

--- a/packages/daemon/test/doc-sync-git-status.test.ts
+++ b/packages/daemon/test/doc-sync-git-status.test.ts
@@ -1,0 +1,41 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { readDocSyncDirtyEntries } from "../src/service/doc-sync-git-status.ts";
+
+test("doc-sync dirty scan ignores the machine-internal .harness layer but still sees authored edits", () => {
+  const authoredRoot = mkdtempSync(path.join(tmpdir(), "ha-doc-sync-status-"));
+  try {
+    writeFileSync(path.join(authoredRoot, "tracked.md"), "seed\n");
+    git(authoredRoot, "init", "-b", "main");
+    git(authoredRoot, "config", "user.name", "Harness Test");
+    git(authoredRoot, "config", "user.email", "harness@example.test");
+    git(authoredRoot, "add", ".");
+    git(authoredRoot, "commit", "-m", "seed");
+
+    // Machine layer: preserved snapshots must never surface as dirty prose (issue #1340).
+    const preserved = path.join(authoredRoot, ".harness", "preserved-worktree-edits", "snap", "tasks");
+    mkdirSync(preserved, { recursive: true });
+    writeFileSync(path.join(preserved, "progress.md"), "machine snapshot\n");
+    assert.deepEqual(readDocSyncDirtyEntries(authoredRoot), []);
+
+    // Positive control: an authored edit is still reported.
+    writeFileSync(path.join(authoredRoot, "tracked.md"), "edited\n");
+    writeFileSync(path.join(authoredRoot, "new.md"), "fresh\n");
+    const entries = readDocSyncDirtyEntries(authoredRoot);
+    assert.deepEqual(
+      entries.map((entry) => `${entry.status}:${entry.path}`).sort(),
+      ["added:new.md", "modified:tracked.md"]
+    );
+  } finally {
+    rmSync(authoredRoot, { recursive: true, force: true });
+  }
+});
+
+function git(repoRoot: string, ...args: ReadonlyArray<string>): void {
+  execFileSync("git", ["-C", repoRoot, ...args], { stdio: ["ignore", "pipe", "ignore"] });
+}


### PR DESCRIPTION
## Summary

Real fix for issue #1340 (closed with a machine-local `.gitignore` mitigation only): the doc-sync dirty scanner ran `git status --untracked-files=all` over the whole authored root — including `harness/.harness/`, whose ~39k preserved-worktree-edit machine files pushed the porcelain output to 5.6MB, past `execFileSync`'s default 1MB maxBuffer. The resulting ENOBUFS was swallowed by `gitText`'s bare catch, so the scanner reported a **clean tree**: every `doc sync --submit` rejected with *not dirty or unknown* and task-complete auto-materialization was blocked repo-wide. Same family as #1338 (machine layer scanned as authored content) compounded by the silent-continue family.

## What Changed

- `doc-sync-git-status.ts`: the status scan excludes the machine-internal layer with the `:(exclude).harness` pathspec — mirrors #1338's conflict-marker preflight exclusion.
- `doc-sync-applied-ledger.ts` (`gitText`): maxBuffer raised to 64MB (consistent with the other git call sites) and the catch now writes a one-line stderr diagnostic before returning null — callers keep the null contract, but an ENOBUFS can never again render as "clean tree" invisibly.
- `packages/daemon/test/doc-sync-git-status.test.ts` (new, fast tier): red→green — `.harness` snapshot files never surface as dirty; positive control pins that authored modified/added files still do.

## Version Impact

- No version change because this is an internal scanner scoping fix with no public CLI surface change.

## Verification

- [x] Red evidence: with the src fix stashed, the new test fails (snapshot file reported dirty); green after restore (1/1).
- [x] `npm run check:local` — all stop-point gates green.
- [x] `git diff --check`
- Not run: full `npm test` locally (GitHub CI is the authority).

## Review Evidence

- Self-review: exclusion semantics match #1338 — `.harness` is machine storage, not authored prose; the null contract of `gitText` is unchanged so no control flow moves (only a diagnostic line is added).
- Additional review: root cause and fix shape were independently diagnosed in issue #1340 by the C-line investigation; this PR implements exactly that recommendation.
- Blocking findings: none.

## Residual Risk

- The interim mitigation on this machine (`.harness` in the inner ledger's `.gitignore`) becomes redundant but harmless; it can be reverted at leisure.
- The 20k-snapshot growth in `preserved-worktree-edits` remains a separate cleanup task.

## References

- Task: task_01KZNV1PD6M2BE1BKDCXX1K8VZ (write-chain diet campaign)
- Evidence: issue #1340; incident doc `harness/context/research/2026-08-10-daemon-write-stall-incident.md`

---

## 摘要

issue #1340 的真修（此前仅有本机 `.gitignore` 止血）：doc-sync 脏文件扫描对整个 authored 根跑 `git status --untracked-files=all`，把 `harness/.harness/` 下 ~39k 个快照机器文件也算进去，porcelain 输出 5.6MB 超过 `execFileSync` 默认 1MB maxBuffer，ENOBUFS 被 `gitText` 裸 catch 吞掉 → 扫描报「树是干净的」→ 全部 `doc sync --submit` 被拒、task-complete 自动物化全仓被堵。与 #1338 同族（机器层被当 authored 内容扫）+ 静默吞错族叠加。

## 改动内容

- 状态扫描加 `:(exclude).harness` pathspec（与 #1338 同刀法）。
- `gitText`：maxBuffer 提到 64MB（与其他 git 调用点一致）；catch 里加一行 stderr 诊断后仍返回 null——调用方契约不变、控制流不动，但 ENOBUFS 不再隐形。
- 新 fast 测试先红后绿：快照文件永不上报为 dirty；阳性对照钉住 authored 修改/新增仍被上报。

## 版本影响

- 不改版本，原因是内部扫描范围修复，无公开 CLI 面变化。

## 验证

- [x] 红证：stash 掉 src 修复后新测试失败（快照被报 dirty）；恢复后 1/1 绿
- [x] `npm run check:local` 停止点门全绿
- [x] `git diff --check`
- 未运行：本地全量 `npm test`（GitHub CI 是完整权威）

## 审查证据

- 自查：排除语义与 #1338 一致；`gitText` null 契约未变（仅加诊断行），无控制流移动。
- 额外审查：根因与修法由 C 线在 issue #1340 独立诊断，本 PR 按其建议实现。
- 阻塞发现：无。

## 残余风险

- 本机止血（内层台账 `.gitignore` 的 `.harness` 条目）变冗余但无害，可择机回退。
- preserved-worktree-edits 两万快照的增长治理另立任务。

## 关联材料

- 任务：task_01KZNV1PD6M2BE1BKDCXX1K8VZ
- 证据：issue #1340；事故文档 `harness/context/research/2026-08-10-daemon-write-stall-incident.md`
