### PR TITLE
fix: keep foreground writes ahead of materialization and allow multi-op revisions

### DIFF
--- a/packages/application/src/authority/authority-batcher.ts
+++ b/packages/application/src/authority/authority-batcher.ts
@@ -33,7 +33,9 @@ export class BoundedAuthorityBatcher<Input, Result> {
     runBatch: (inputs: ReadonlyArray<Input>) => Promise<ReadonlyArray<Result>>,
     maxBatchSize: number,
     maxWaitMs: number,
-    options: { readonly allowOverlappingBatches?: boolean } = {}
+    options: {
+      readonly allowOverlappingBatches?: boolean;
+    } = {}
   ) {
     this.runBatch = runBatch;
     this.maxBatchSize = maxBatchSize;

--- a/packages/application/src/authority/authority-v2-preparation.ts
+++ b/packages/application/src/authority/authority-v2-preparation.ts
@@ -107,27 +107,33 @@ export async function prepareAuthorityV2(input: {
             identity
           )
         } : {}),
-        persist: (receipt) => input.put(
-          identity,
-          semanticDigest,
-          "COMMITTED",
-          receipt,
-          known.commitSha,
-          known.authorityIntegrity,
-          known.canonicalRequestEnvelope,
-          known.canonicalOperation,
-          known.recoveryPublicationPolicy,
-          known.fixedOperationBinding
-        )
+        persist: (receipt) => {
+          const persist = () => input.put(
+            identity,
+            semanticDigest,
+            "COMMITTED",
+            receipt,
+            known.commitSha,
+            known.authorityIntegrity,
+            known.canonicalRequestEnvelope,
+            known.canonicalOperation,
+            known.recoveryPublicationPolicy,
+            known.fixedOperationBinding
+          );
+          return options.generationFenceWitness
+            ? options.generationFenceWitness.runExclusive(
+              "before-terminal-journal",
+              identity,
+              async () => {
+                await options.generationFenceWitness!.assertHeld("before-terminal-journal", identity);
+                await persist();
+              }
+            )
+            : persist();
+        }
       });
       try {
-        const recovered = options.generationFenceWitness
-          ? await options.generationFenceWitness.runExclusive(
-            "before-terminal-journal",
-            identity,
-            recover
-          )
-          : await recover();
+        const recovered = await recover();
         if (recovered) return terminal(recovered);
       } catch (error) {
         if (!isDaemonGenerationFenced(error)) throw error;

--- a/packages/application/src/authority/generation-fence-execution.ts
+++ b/packages/application/src/authority/generation-fence-execution.ts
@@ -1,0 +1,63 @@
+import type {
+  AuthorityFenceStage,
+  AuthorityGenerationFence
+} from "./types.ts";
+import type { PreparedAuthoritySubmission } from "./service-admission-types.ts";
+import type { PutAuthorityOperationRecord } from "./operation-record-persistence.ts";
+
+type AuthorityFenceContext = {
+  readonly workspaceId: string;
+  readonly opId: string;
+};
+
+export async function runWithAuthorityGenerationFence<Result>(
+  fence: AuthorityGenerationFence | undefined,
+  stage: AuthorityFenceStage,
+  context: AuthorityFenceContext,
+  operation: () => Promise<Result>
+): Promise<Result> {
+  return fence ? fence.runExclusive(stage, context, operation) : operation();
+}
+
+export async function persistPreparedAuthorityEntry(
+  fence: AuthorityGenerationFence | undefined,
+  entry: PreparedAuthoritySubmission,
+  put: PutAuthorityOperationRecord
+): Promise<void> {
+  await runWithAuthorityGenerationFence(fence, "before-prepare", entry, async () => {
+    await fence?.assertHeld("before-prepare", entry);
+    await put(
+      entry,
+      entry.semanticDigest,
+      "PREPARED",
+      undefined,
+      undefined,
+      entry.authorityIntegrity,
+      entry.canonicalRequestEnvelope,
+      entry.operation,
+      entry.recoveryPublicationPolicy,
+      entry.fixedOperationBinding
+    );
+  });
+}
+
+export async function startAuthorityCommitAtDurableCut<Result>(input: {
+  readonly fence: AuthorityGenerationFence | undefined;
+  readonly context: AuthorityFenceContext;
+  readonly durableAcceptance: Promise<void> | undefined;
+  readonly commit: () => Promise<Result>;
+}): Promise<Result> {
+  let pendingCommit: Promise<Result> | undefined;
+  await runWithAuthorityGenerationFence(
+    input.fence,
+    "before-canonical-publish",
+    input.context,
+    async () => {
+      pendingCommit = input.commit();
+      await (input.durableAcceptance
+        ? Promise.race([input.durableAcceptance, pendingCommit.then(() => undefined)])
+        : pendingCommit);
+    }
+  );
+  return pendingCommit!;
+}

--- a/packages/application/src/authority/operation-record-persistence.ts
+++ b/packages/application/src/authority/operation-record-persistence.ts
@@ -40,22 +40,24 @@ export type PersistAuthorityTerminal = (
   fixedOperationBinding?: AuthorityFixedOperationBindingV1
 ) => Promise<AuthorityOperationReceipt>;
 
+export type PutAuthorityOperationRecord = (
+  envelope: OperationIdentity,
+  semanticDigest: string,
+  state: AuthorityOperationState,
+  receipt?: AuthorityOperationReceipt,
+  commitSha?: string,
+  authorityIntegrity?: AuthorityOperationIntegrity,
+  canonicalRequestEnvelope?: string,
+  canonicalOperation?: WriteOp,
+  recoveryPublicationPolicy?: AuthorityRecoveryPublicationPolicyV1,
+  fixedOperationBinding?: AuthorityFixedOperationBindingV1
+) => Promise<void>;
+
 export function createAuthorityOperationRecordPersistence(
   operationRegistry: AuthorityOperationRegistry,
   generationFence?: AuthorityGenerationFence
 ): {
-  readonly put: (
-    envelope: OperationIdentity,
-    semanticDigest: string,
-    state: AuthorityOperationState,
-    receipt?: AuthorityOperationReceipt,
-    commitSha?: string,
-    authorityIntegrity?: AuthorityOperationIntegrity,
-    canonicalRequestEnvelope?: string,
-    canonicalOperation?: WriteOp,
-    recoveryPublicationPolicy?: AuthorityRecoveryPublicationPolicyV1,
-    fixedOperationBinding?: AuthorityFixedOperationBindingV1
-  ) => Promise<void>;
+  readonly put: PutAuthorityOperationRecord;
   readonly putMany: (records: ReadonlyArray<AuthorityOperationRecordTransition>) => Promise<void>;
   readonly persistTerminal: PersistAuthorityTerminal;
 } {

--- a/packages/application/src/authority/service-options.ts
+++ b/packages/application/src/authority/service-options.ts
@@ -47,6 +47,10 @@ export interface AuthoritySubmissionServiceOptions {
 
 export interface AuthorityPublicationExecutionContext {
   readonly allowDurableSuccessor: boolean;
+  /** Resolves when the nested session publication has reached its durable cut. */
+  readonly durableAcceptance?: Promise<void>;
+  /** Release only the in-process publication slot after the session commit is durable. */
+  readonly reportDurableCut?: () => void;
 }
 
 export type AuthoritySubmissionTelemetryPhase =

--- a/packages/application/src/authority/service.ts
+++ b/packages/application/src/authority/service.ts
@@ -69,6 +69,7 @@ import { authorityOperationPublicView } from "./operation-record-public-view.ts"
 import { prepareAuthorityV2 } from "./authority-v2-preparation.ts";
 import { classifyAuthorityPublicationOutcome } from "./publication-outcome.ts";
 import { completedPublicationCut, segmentedPublicationCut, settleAuthorityPublicationCut, type AuthorityPublicationCut } from "./publication-cut.ts";
+import { persistPreparedAuthorityEntry, runWithAuthorityGenerationFence, startAuthorityCommitAtDurableCut } from "./generation-fence-execution.ts";
 export type {
   AuthorityPublicationExecutionContext,
   AuthoritySubmissionServiceOptions,
@@ -180,7 +181,7 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
           writableEntityRegistry: writableEntityRegistry!,
           put,
           persistTerminal
-        }))
+          }))
       )
     });
   }
@@ -294,19 +295,7 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
           const acknowledgement = await Effect.runPromise(entry.coordinator.enqueue(entry.operation));
           options.onTelemetry?.("authority-coordinator-enqueued");
           batchEntries.set(entry, acknowledgement);
-          await options.generationFenceWitness?.assertHeld("before-prepare", entry);
-          await put(
-            entry,
-            entry.semanticDigest,
-            "PREPARED",
-            undefined,
-            undefined,
-            entry.authorityIntegrity,
-            entry.canonicalRequestEnvelope,
-            entry.operation,
-            entry.recoveryPublicationPolicy,
-            entry.fixedOperationBinding
-          );
+          await persistPreparedAuthorityEntry(options.generationFenceWitness, entry, put);
           options.onTelemetry?.("authority-prepared-persisted");
           candidates.push(entry);
         } catch (error) {
@@ -329,7 +318,6 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
       let outcome: ReturnType<typeof classifyAuthorityPublicationOutcome>;
       let publicationReport: FlushReport | undefined;
       try {
-        await options.generationFenceWitness?.assertHeld("before-canonical-publish", candidates[0]);
         const [firstCandidate, ...remainingCandidates] = candidates;
         const batchCoordinator = firstCandidate!.coordinator;
         const batch = createJournaledBatch([
@@ -337,10 +325,19 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
           ...remainingCandidates.map((candidate) => batchEntries.get(candidate)!)
         ]);
         options.onTelemetry?.("authority-flush-start");
-        const result = await Effect.runPromise(Effect.either(batchCoordinator.commitExact(
-          firstCandidate!.recoveryMode ? "recovery" : "explicit",
-          batch
-        )));
+        const commit = async () => {
+          await options.generationFenceWitness?.assertHeld("before-canonical-publish", firstCandidate!);
+          return Effect.runPromise(Effect.either(batchCoordinator.commitExact(
+            firstCandidate!.recoveryMode ? "recovery" : "explicit",
+            batch
+          )));
+        };
+        const result = await startAuthorityCommitAtDurableCut({
+          fence: options.generationFenceWitness,
+          context: firstCandidate!,
+          durableAcceptance: execution.durableAcceptance,
+          commit
+        });
         if (result._tag === "Left") {
           outcome = classifyAuthorityPublicationOutcome({ kind: "error", error: result.left });
         } else {
@@ -405,41 +402,48 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
     });
     const { change } = replicaPublication;
     try {
-      for (const entry of candidates) {
-        await options.generationFenceWitness?.assertHeld("before-terminal-visibility", entry);
-      }
-      if (!replicaPublication.existing) await options.replicaChangeLog.append(change);
-      if (!replicaPublication.existing && options.shadowPublicationLog) {
-        const priorShadow = await options.shadowPublicationLog.list(candidates[0]!.workspaceId);
-        await options.generationFenceWitness?.assertHeld("before-terminal-visibility", candidates[0]);
-        await options.shadowPublicationLog.append({
-          schema: shadowPublicationSchema,
-          workspaceId: candidates[0]!.workspaceId,
-          sequence: priorShadow.length + 1,
+      const persistIndexed = async () => {
+        for (const entry of candidates) {
+          await options.generationFenceWitness?.assertHeld("before-terminal-visibility", entry);
+        }
+        if (!replicaPublication.existing) await options.replicaChangeLog.append(change);
+        if (!replicaPublication.existing && options.shadowPublicationLog) {
+          const priorShadow = await options.shadowPublicationLog.list(candidates[0]!.workspaceId);
+          await options.shadowPublicationLog.append({
+            schema: shadowPublicationSchema,
+            workspaceId: candidates[0]!.workspaceId,
+            sequence: priorShadow.length + 1,
+            commitSha,
+            previousCommit: previousHead,
+            opIds: candidates.map((entry) => entry.opId),
+            observedAt: change.changedAt
+          });
+        }
+        await persistence.putMany(candidates.map((entry) => ({
+          envelope: entry,
+          semanticDigest: entry.semanticDigest,
+          state: "INDEXED" as const,
           commitSha,
-          previousCommit: previousHead,
-          opIds: candidates.map((entry) => entry.opId),
-          observedAt: change.changedAt
-        });
-      }
-      await options.generationFenceWitness?.assertHeld("before-terminal-visibility", candidates[0]);
-      await persistence.putMany(candidates.map((entry) => ({
-        envelope: entry,
-        semanticDigest: entry.semanticDigest,
-        state: "INDEXED" as const,
-        commitSha,
-        authorityIntegrity: entry.authorityIntegrity,
-        canonicalRequestEnvelope: entry.canonicalRequestEnvelope,
-        canonicalOperation: entry.operation,
-        recoveryPublicationPolicy: entry.recoveryPublicationPolicy,
-        fixedOperationBinding: entry.fixedOperationBinding
-      })));
+          authorityIntegrity: entry.authorityIntegrity,
+          canonicalRequestEnvelope: entry.canonicalRequestEnvelope,
+          canonicalOperation: entry.operation,
+          recoveryPublicationPolicy: entry.recoveryPublicationPolicy,
+          fixedOperationBinding: entry.fixedOperationBinding
+        })));
+      };
+      await runWithAuthorityGenerationFence(
+        options.generationFenceWitness,
+        "before-terminal-visibility",
+        candidates[0],
+        persistIndexed
+      );
     } catch (error) {
       if (isDaemonGenerationFenced(error)) throw error;
       await settlePrepared(candidates, receipts, "INDETERMINATE", (entry) =>
         indeterminate(entry, entry.semanticDigest, `INDEX_RECOVERY_REQUIRED:${describe(error)}`, commitSha));
       return completedPublicationCut(batchReceipts(admissions, receipts));
     }
+    execution.reportDurableCut?.();
 
     return { settle: async () => {
     const committed = new Map<PreparedAuthoritySubmission, AuthorityCommittedReceipt>();
@@ -526,19 +530,8 @@ export function createAuthoritySubmissionService(options: AuthoritySubmissionSer
     };
     try {
       options.onTelemetry?.("authority-generation-acquire");
-      return options.generationFenceWitness
-        ? await options.generationFenceWitness.runExclusive(
-          "before-canonical-publish",
-          prepared[0],
-          () => {
-            options.onTelemetry?.("authority-generation-held");
-            return publishWhileGenerationCurrent();
-          }
-        )
-        : await (() => {
-          options.onTelemetry?.("authority-generation-held");
-          return publishWhileGenerationCurrent();
-        })();
+      options.onTelemetry?.("authority-generation-held");
+      return await publishWhileGenerationCurrent();
     } catch (error) {
       if (!isDaemonGenerationFenced(error)) throw error;
       for (const entry of prepared) {

--- a/packages/application/src/public-exports.ts
+++ b/packages/application/src/public-exports.ts
@@ -277,7 +277,11 @@ export {
   docSyncWriterWorkingTreeContentKind,
   forbiddenTouchesForZones
 } from "./doc-sync.ts";
-export { makeRuntimeEventAppendPromise, makeRuntimeEventLedgerService } from "./runtime-event-ledger-service.ts";
+export {
+  makeLightweightRuntimeEventLedgerService,
+  makeRuntimeEventAppendPromise,
+  makeRuntimeEventLedgerService
+} from "./runtime-event-ledger-service.ts";
 export { listDecisionDocuments, readDecisionDocument } from "./decision-document-reader.ts";
 export type { CodeDocDocument, CodeDocReconciliationDraft, CodeDocReconciliationDraftInput, CodeDocReconciliationInput, CodeDocReconciliationIssue, CodeDocReconciliationResult, CodeDocReconciliationWarning } from "./code-doc-reconciliation.ts";
 export type { EnvironmentCurrentSessionProbeOptions, HumanFallbackSessionProbeOptions, RuntimeSessionEnvCandidate } from "./current-session-probe.ts";

--- a/packages/application/src/runtime-event-ledger-service.ts
+++ b/packages/application/src/runtime-event-ledger-service.ts
@@ -38,6 +38,11 @@ export interface RuntimeEventLedgerServiceOptions {
   readonly makeEventId?: () => string;
 }
 
+export type LightweightRuntimeEventLedgerServiceOptions = Omit<
+  RuntimeEventLedgerServiceOptions,
+  "coordinator"
+>;
+
 export interface RuntimeEventAppendInput {
   readonly eventId?: string;
   readonly recordedAt?: string;
@@ -120,6 +125,25 @@ export function makeRuntimeEventLedgerService(options: RuntimeEventLedgerService
   };
 }
 
+/**
+ * Automatic command audit is already a post-response, failure-observed tail.
+ * Persist that local-only JSONL evidence directly instead of manufacturing a
+ * second journal, session commit, canonical merge, and projection cycle.
+ */
+export function makeLightweightRuntimeEventLedgerService(
+  options: LightweightRuntimeEventLedgerServiceOptions
+): RuntimeEventLedgerService {
+  const timestamp = () => options.now?.() ?? new Date().toISOString();
+  const eventId = () => options.makeEventId?.() ?? makeRuntimeEventId(timestamp());
+  return {
+    append: (input) => appendRuntimeEventLightweight(
+      options.rootInput,
+      toRuntimeEventRecord(input, timestamp, eventId)
+    ),
+    readSession: (sessionId) => readRuntimeEventSession(options.rootInput, sessionId)
+  };
+}
+
 function toRuntimeEventRecord(
   input: RuntimeEventAppendInput,
   timestamp: () => string,
@@ -195,6 +219,35 @@ function appendRuntimeEvent(
       );
     })
   );
+}
+
+function appendRuntimeEventLightweight(
+  rootInput: HarnessLayoutInput,
+  event: RuntimeEventRecordV2
+): Effect.Effect<RuntimeEventLedgerAppendResult, RuntimeEventLedgerRejected> {
+  return Effect.tryPromise({
+    try: async () => {
+      const decoded = Schema.decodeUnknownSync(RuntimeEventRecordV2Schema)(event);
+      const target = resolveRuntimeEventLedgerPath(rootInput, decoded.session.sessionId);
+      const directoryPath = path.dirname(target.absolutePath);
+      await fs.promises.mkdir(directoryPath, { recursive: true, mode: 0o700 });
+      const descriptor = await fs.promises.open(target.absolutePath, "a", 0o600);
+      try {
+        await descriptor.writeFile(`${JSON.stringify(decoded)}\n`, "utf8");
+        await descriptor.sync();
+      } finally {
+        await descriptor.close();
+      }
+      const directoryDescriptor = await fs.promises.open(directoryPath, "r");
+      try {
+        await directoryDescriptor.sync();
+      } finally {
+        await directoryDescriptor.close();
+      }
+      return { event: decoded, path: target.relativePath };
+    },
+    catch: (error) => runtimeEventRejection(event.session.sessionId, runtimeEventErrorMessage(error))
+  });
 }
 
 function readRuntimeEventSession(

--- a/packages/application/test/runtime-event-ledger-service.test.ts
+++ b/packages/application/test/runtime-event-ledger-service.test.ts
@@ -5,7 +5,10 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { makeRuntimeEventLedgerService } from "../src/index.ts";
+import {
+  makeLightweightRuntimeEventLedgerService,
+  makeRuntimeEventLedgerService
+} from "../src/index.ts";
 import { makeOperationalJournaledWriteCoordinator } from "../../kernel/src/index.ts";
 import { runEffect, runEffectExit } from "./effect-test-helpers.ts";
 
@@ -56,6 +59,40 @@ test("runtime event ledger appends fsynced JSONL and reads schema-validated reco
     assert.equal("responsibleHuman" in (readBack.events[0]?.actor ?? {}), false);
     assert.equal(readBack.events[0]?.session.executionId, "exe_01KX7H00000000000000000001");
     assert.equal(readBack.events[0]?.session.reviewId, null);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("lightweight runtime audit appends durably without a second coordinated publication", async () => {
+  const rootDir = createHarnessRoot();
+  try {
+    const ledger = makeLightweightRuntimeEventLedgerService({
+      rootInput: rootDir,
+      now: () => "2026-07-03T00:00:00.000Z",
+      makeEventId: () => "evt_lightweight_audit"
+    });
+
+    const appended = await runEffect(ledger.append({
+      kind: "result",
+      session: { sessionId: "codex-lightweight-audit", runtime: "codex" },
+      actor: {
+        principal: { kind: "person", personId: "person_zeyu" },
+        executor: { kind: "agent", id: "codex" }
+      },
+      result: { status: "succeeded", summary: "automatic command audit" }
+    }));
+
+    assert.equal(
+      readFileSync(path.join(rootDir, ".harness", appended.path), "utf8").trim().split("\n").length,
+      1
+    );
+    assert.equal(
+      existsSync(path.join(rootDir, ".harness/write-journal/writes.jsonl")),
+      false,
+      "automatic audit append must not publish a second journaled authority mutation"
+    );
+    assert.deepEqual((await runEffect(ledger.readSession("codex-lightweight-audit"))).events, [appended.event]);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }

--- a/packages/cli/src/cli/command-runtime-events.ts
+++ b/packages/cli/src/cli/command-runtime-events.ts
@@ -1,15 +1,20 @@
 import { Effect } from "effect";
-import { runtimeEventActorFromTaskHolderPrincipal } from "@harness-anything/application";
+import {
+  runtimeEventActorFromTaskHolderPrincipal,
+  type RuntimeEventLedgerService
+} from "@harness-anything/application";
 import { isIndeterminateFlushControlOutcome } from "@harness-anything/kernel";
 import { runtimeEventPolicyForAction } from "./command-event-policy.ts";
 import { actionTaskId } from "./parse-args.ts";
 import type { CommandRunnerContext, CommandRunnerEffect } from "./runner-registry.ts";
+import type { ConflictMarkerExecutionBoundary } from "./conflict-preflight.ts";
 import type { CliResult, ParsedCommand } from "./types.ts";
 
 export function appendCommandRuntimeEvent(
   context: CommandRunnerContext,
   command: ParsedCommand,
-  result: CliResult
+  result: CliResult,
+  ledger: RuntimeEventLedgerService = context.runtimeEventLedgerService
 ): CommandRunnerEffect {
   if (runtimeEventPolicyForAction(command.action) !== "auto") return Effect.succeed(result);
   context.onCommandTelemetry?.("runtime-event-append-start");
@@ -23,7 +28,7 @@ export function appendCommandRuntimeEvent(
         sessionId: session.sessionId,
         reason: runtimeEventActorResolutionMessage(error)
       })
-    }).pipe(Effect.flatMap((actor) => context.runtimeEventLedgerService.append({
+    }).pipe(Effect.flatMap((actor) => ledger.append({
       kind: "result",
       actor,
       session: {
@@ -62,6 +67,26 @@ export function appendCommandRuntimeEvent(
     }),
     Effect.tap(() => Effect.sync(() => context.onCommandTelemetry?.("runtime-event-append-done")))
   );
+}
+
+export function appendOrDeferCommandRuntimeEvent(
+  context: CommandRunnerContext,
+  command: ParsedCommand,
+  result: CliResult,
+  execution: ConflictMarkerExecutionBoundary
+): CommandRunnerEffect {
+  const append = () => appendCommandRuntimeEvent(
+    context,
+    command,
+    result,
+    execution.automaticRuntimeEventLedgerService ?? context.runtimeEventLedgerService
+  );
+  if (runtimeEventPolicyForAction(command.action) !== "auto"
+    || execution.deferCommandRuntimeEvent === undefined) return append();
+  return Effect.sync(() => {
+    execution.deferCommandRuntimeEvent?.(() => Effect.runPromise(append()));
+    return result;
+  });
 }
 
 interface RuntimeEventActorRejected {

--- a/packages/cli/src/cli/conflict-preflight.ts
+++ b/packages/cli/src/cli/conflict-preflight.ts
@@ -1,4 +1,5 @@
 import type { HarnessLayoutInput, ProjectionWarning } from "@harness-anything/kernel";
+import type { RuntimeEventLedgerService } from "@harness-anything/application";
 import { findConflictMarkerWarnings } from "@harness-anything/kernel";
 import { cliError, CliErrorCode } from "./error-codes.ts";
 import { requiresConflictMarkerPreflight } from "./command-event-policy.ts";
@@ -12,6 +13,8 @@ export interface ConflictMarkerExecutionBoundary {
   readonly onTelemetry?: (phase: "command-conflict-preflight" | "command-conflict-recheck") => void;
   readonly onCommandTelemetry?: (phase: "runtime-event-append-start" | "runtime-event-append-done") => void;
   readonly deferCommandRuntimeEvent?: (append: () => Promise<CliResult>) => void;
+  /** Local-only durable sink for automatic command audit. */
+  readonly automaticRuntimeEventLedgerService?: RuntimeEventLedgerService;
   readonly conflictMarkerPreflight?: () => ProjectionWarning | undefined;
 }
 

--- a/packages/cli/src/cli/runner-registry.ts
+++ b/packages/cli/src/cli/runner-registry.ts
@@ -6,7 +6,7 @@ import type { ArtifactStoreError, DomainStatus, EngineError, PriorityTier, TaskW
 import type { HarnessLayoutInput, HarnessLayoutOverrides } from "@harness-anything/kernel";
 import { createHarnessRuntimeContext } from "@harness-anything/kernel";
 import type { WriteCoordinator } from "@harness-anything/kernel";
-import { requiresConflictMarkerPreflight, runtimeEventPolicyForAction, taskPrincipalRequiredForAction } from "./command-event-policy.ts";
+import { requiresConflictMarkerPreflight, taskPrincipalRequiredForAction } from "./command-event-policy.ts";
 import { receiptCommandKind } from "./receipt-command-kind.ts";
 import { commandSpecMap, commandSpecs, type CommandKind } from "./command-spec/index.ts";
 import type { CommandSpecDefinition } from "./command-spec/types.ts";
@@ -18,7 +18,7 @@ import {
 } from "./conflict-preflight.ts";
 import { cliError, CliErrorCode } from "./error-codes.ts";
 import { actionTaskId } from "./parse-args.ts";
-import { appendCommandRuntimeEvent } from "./command-runtime-events.ts";
+import { appendOrDeferCommandRuntimeEvent } from "./command-runtime-events.ts";
 import { commandFailureResult } from "./runner-failure-result.ts";
 import type { CliResult, CommandRegistryEntry, MaterializerCommandReport, ParsedCommand } from "./types.ts";
 import type { CliActorAttribution } from "../composition/actor-attribution.ts";
@@ -221,18 +221,7 @@ export function runRegisteredCommand(
     Effect.catchAll((error) => isIndeterminateFlushControlOutcome(error)
       ? Effect.fail(error)
       : Effect.succeed(commandFailureResult(command, error))),
-    Effect.flatMap((result) => {
-      if (runtimeEventPolicyForAction(command.action) !== "auto"
-        || execution.deferCommandRuntimeEvent === undefined) {
-        return appendCommandRuntimeEvent(context, command, result);
-      }
-      return Effect.sync(() => {
-        execution.deferCommandRuntimeEvent?.(
-          () => Effect.runPromise(appendCommandRuntimeEvent(context, command, result))
-        );
-        return result;
-      });
-    }),
+    Effect.flatMap((result) => appendOrDeferCommandRuntimeEvent(context, command, result, execution)),
     Effect.catchAll((error) => Effect.succeed(commandFailureResult(command, error)))
   );
 }

--- a/packages/cli/src/composition/command-executor.ts
+++ b/packages/cli/src/composition/command-executor.ts
@@ -6,6 +6,7 @@ import {
   makeDecisionWriteService,
   makeEnvironmentCurrentSessionProbe,
   makeFactWriteService,
+  makeLightweightRuntimeEventLedgerService,
   makeProvenanceSessionExporter,
   makeRuntimeEventLedgerService,
   makeRuntimeEventAppendPromise,
@@ -226,6 +227,9 @@ export async function runRegisteredCommandWithCliComposition(
   const appendLeaseEvent: ReturnType<typeof makeRuntimeEventAppendPromise> = async (event) => {
     await makeRuntimeEventAppendPromise(getRuntimeEventLedgerService())(event);
   };
+  const automaticRuntimeEventLedgerService = makeLightweightRuntimeEventLedgerService({
+    rootInput: layoutInput
+  });
   const makeTaskHolder = () => makeTaskHolderService({
     rootInput: layoutInput,
     appendLeaseEvent,
@@ -278,6 +282,7 @@ export async function runRegisteredCommandWithCliComposition(
     outerProceedingRecovery: options.outerProceedingRecovery === true,
     onCommandTelemetry: options.onCommandTelemetry,
     deferCommandRuntimeEvent: options.deferCommandRuntimeEvent,
+    automaticRuntimeEventLedgerService,
     onTelemetry: options.onTelemetry,
     conflictMarkerPreflight: options.conflictMarkerPreflight
   }).pipe(

--- a/packages/cli/src/composition/receipt-settlement-runtime.ts
+++ b/packages/cli/src/composition/receipt-settlement-runtime.ts
@@ -83,7 +83,7 @@ export async function settleAcceptedSession(input: {
   try {
     await nextEventLoopTurn();
     input.onRecoveryPhase?.("materializer");
-    await input.runtime.enqueueMaterializerBatch({ sessionId: input.pending.sessionId });
+    await input.runtime.enqueueMaterializerBatch({ sessionId: input.pending.sessionId, priority: "recovery" });
     input.onRecoveryPhase?.("canonical-proof");
     const visible = withCommandReceiptSettlement(
       input.acceptedReceipt,
@@ -198,7 +198,7 @@ async function recoverPendingSettlementRecord(input: {
     try {
       await nextEventLoopTurn();
       input.onRecoveryPhase("materializer");
-      await input.runtime.enqueueMaterializerBatch({ sessionId: pending.sessionId });
+      await input.runtime.enqueueMaterializerBatch({ sessionId: pending.sessionId, priority: "recovery" });
       input.onRecoveryPhase("canonical-proof");
       const canonicalCommitSha = canonicalCommitContaining(
         input.authoredRoot,
@@ -239,7 +239,7 @@ async function recoverPendingSettlementRecord(input: {
   }
   try {
     input.onRecoveryPhase("materializer");
-    await input.runtime.enqueueMaterializerBatch({ sessionId: pending.sessionId });
+    await input.runtime.enqueueMaterializerBatch({ sessionId: pending.sessionId, priority: "recovery" });
     input.onRecoveryPhase("canonical-proof");
     const visible = withCommandReceiptSettlement(
       record.receipt,
@@ -298,7 +298,7 @@ async function recoverDirectSettlement(input: {
 }): Promise<void> {
   try {
     input.onRecoveryPhase("materializer");
-    await input.runtime.enqueueMaterializerBatch({ sessionId: input.pending.sessionId });
+    await input.runtime.enqueueMaterializerBatch({ sessionId: input.pending.sessionId, priority: "recovery" });
     const operationIds = input.pending.authorityOperationIds ?? [];
     if (operationIds.length === 0) {
       throw new Error("AUTHORITY_DIRECT_RECOVERY_OPERATION_IDS_MISSING");

--- a/packages/cli/src/composition/repo-write-child-entrypoint.ts
+++ b/packages/cli/src/composition/repo-write-child-entrypoint.ts
@@ -269,6 +269,9 @@ export async function runRepoWriteChildEntrypoint(
       readonly canonicalCommitSha: string;
     }) => Promise<"live-owner" | "recovered" | "terminal" | "blocked">;
   } = {};
+  const liveSettlement: {
+    current?: (receiptId: string) => boolean;
+  } = {};
   const postReadyRecovery = createRepoWriteChildPostReadyRecovery({
     repoId: config.repoId,
     generation: config.generation,
@@ -278,6 +281,7 @@ export async function runRepoWriteChildEntrypoint(
     runtime,
     authoredRoot,
     recoveryGate,
+    isSettlementActive: (receiptId) => liveSettlement.current?.(receiptId) === true,
     recoverCommittedReceipt: recoverAuthorityCommittedReceipt,
     recoverCanonicalPublication: (recovery) => canonicalPublicationRecovery.current
       ? canonicalPublicationRecovery.current(recovery)
@@ -306,6 +310,7 @@ export async function runRepoWriteChildEntrypoint(
   });
   canonicalPublicationRecovery.current = (recovery) =>
     operation.recoverCanonicalPublicationSettlement(recovery);
+  liveSettlement.current = operation.isSettlementActive;
   let initialRecovery: Promise<void> | undefined;
   const startInitialRecovery = (): void => {
     initialRecovery ??= recoveryStartGate.wait().then(
@@ -346,6 +351,14 @@ export async function runRepoWriteChildEntrypoint(
     artifactIdentity: entrypointArtifactIdentity,
     transport,
     hooks: {
+      beginDirectAdmission: () => {
+        recoveryStartGate.activity();
+        const releaseAdmission = runtime.beginAuthorityAdmission();
+        return () => {
+          releaseAdmission();
+          recoveryStartGate.activity();
+        };
+      },
       prepare: (input) => operation.prepare(input),
       direct: (input) => operation.direct(input),
       lookup: (input) => operation.lookup(input),
@@ -377,6 +390,7 @@ export async function runRepoWriteChildEntrypoint(
 
 interface PostReadyRecoveryStartGate {
   readonly ready: () => void;
+  readonly activity: () => void;
   readonly cancel: () => void;
   readonly wait: () => Promise<boolean>;
 }
@@ -387,6 +401,7 @@ function createPostReadyRecoveryStartGate(): PostReadyRecoveryStartGate {
   let resolveStart!: (shouldStart: boolean) => void;
   let timer: NodeJS.Timeout | undefined;
   let settled = false;
+  let ready = false;
   const start = new Promise<boolean>((resolve) => {
     resolveStart = resolve;
   });
@@ -399,7 +414,13 @@ function createPostReadyRecoveryStartGate(): PostReadyRecoveryStartGate {
   };
   return {
     ready: () => {
-      if (settled || timer) return;
+      if (settled || ready) return;
+      ready = true;
+      timer = setTimeout(() => settle(true), postReadyRecoveryDelayMs);
+    },
+    activity: () => {
+      if (settled || !ready) return;
+      if (timer) clearTimeout(timer);
       timer = setTimeout(() => settle(true), postReadyRecoveryDelayMs);
     },
     cancel: () => settle(false),

--- a/packages/cli/src/composition/repo-write-child-post-ready-recovery.ts
+++ b/packages/cli/src/composition/repo-write-child-post-ready-recovery.ts
@@ -35,6 +35,7 @@ export function createRepoWriteChildPostReadyRecovery(input: {
     readonly outerOpId: string;
     readonly canonicalCommitSha: string;
   }) => Promise<"live-owner" | "recovered" | "terminal" | "blocked">;
+  readonly isSettlementActive?: (receiptId: string) => boolean;
   readonly totalBudgetMs?: number;
   readonly perReceiptTimeoutMs?: number;
 }): RepoWriteChildPostReadyRecovery {
@@ -101,7 +102,8 @@ export function createRepoWriteChildPostReadyRecovery(input: {
         deadlineAt: Date.now() + Math.max(0, budgetMs),
         perReceiptTimeoutMs,
         onReceiptProgress: reportReceiptProgress,
-        shouldRecoverReceipt: (receiptId) => !deferredReceipts.has(receiptId),
+        shouldRecoverReceipt: (receiptId) =>
+          !deferredReceipts.has(receiptId) && !input.isSettlementActive?.(receiptId),
         recoverCommittedReceipt: input.recoverCommittedReceipt,
         recoverCanonicalPublication: input.recoverCanonicalPublication
       });

--- a/packages/cli/test/actor-attribution-cli.test.ts
+++ b/packages/cli/test/actor-attribution-cli.test.ts
@@ -26,6 +26,7 @@ import {
 import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { cliTestEnv } from "./helpers/cli-test-env.ts";
+import { resolveHarnessLayout } from "@harness-anything/kernel";
 
 const createCliCommandService = (
   runtime: Parameters<typeof createDaemonCommandService>[0],
@@ -203,16 +204,23 @@ test("daemon command service preserves A/X attribution through the queued coordi
     assert.ok(requests.length > 0);
     const attributed = requests.filter((request) => "attribution" in request);
     const operational = requests.filter((request) => "operationalActor" in request);
+    const runtimeEvents = readFileSync(
+      resolveHarnessLayout(rootDir).runtimeEventLedgerPath("thread-cross-boundary"),
+      "utf8"
+    ).trim().split("\n").map((line) => JSON.parse(line) as Record<string, unknown>);
+    const runtimeEvent = runtimeEvents[0] as {
+      readonly actor?: unknown; readonly session?: { readonly sessionId?: string }; readonly tool?: { readonly toolName?: string };
+    };
     assert.equal(attributed.every((request) => request.attribution.actor.principal.personId === "person_alice"), true);
     assert.equal(attributed.every((request) => request.attribution.actor.executor?.id === "codex"), true);
     assert.equal(attributed.every((request) => request.sessionId === "thread-cross-boundary"), true);
-    assert.equal(operational.length, 1);
-    assert.deepEqual(operational[0]?.operationalActor, {
-      scope: "operational",
-      kind: "agent",
-      id: "runtime-event-cli"
-    });
-    assert.equal("attribution" in operational[0]!, false);
+    assert.equal(operational.length, 0);
+    assert.deepEqual(runtimeEvents.map((event) => event.actor), [{
+      principal: { kind: "person", personId: "person_alice" },
+      executor: { kind: "agent", id: "codex" }
+    }]);
+    assert.equal(runtimeEvent.session?.sessionId, "thread-cross-boundary");
+    assert.equal(runtimeEvent.tool?.toolName, "new-task");
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }

--- a/packages/cli/test/production-authority-event-recovery.test.ts
+++ b/packages/cli/test/production-authority-event-recovery.test.ts
@@ -182,7 +182,7 @@ test("restart recovery publishes one missing event for a committed effect withou
   assert.deepEqual(durable.receipt, receipt);
 });
 
-test("current generation recovers a PREPARED operation left by a post-publish stale process", async () => {
+test("current generation fences recovery transitions without holding the lock across terminal evidence", async () => {
   let durable: AuthorityStoredOperationRecord = {
     workspaceId: "workspace-production",
     opId: "namespace-production:prepared-stale-owner",
@@ -248,7 +248,7 @@ test("current generation recovers a PREPARED operation left by a post-publish st
       findPublicationForOperation: async () => publicationEvidence()
     } as ReturnType<typeof createGitCanonicalPublicationInspector>,
     recover: async (indexed) => {
-      assert.equal(insideGenerationLock, true);
+      assert.equal(insideGenerationLock, false);
       assert.equal(indexed.state, "INDEXED");
       assert.equal(indexed.commitSha, receipt.commitSha);
       return receipt;

--- a/packages/cli/test/receipt-settlement-runtime.test.ts
+++ b/packages/cli/test/receipt-settlement-runtime.test.ts
@@ -335,6 +335,76 @@ test("post-READY recovery backs off a poisoned receipt for the rest of the write
   }
 });
 
+test("post-READY recovery leaves a receipt with a live settlement owner alone", durableSettlementStore, async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "ha-receipt-live-owner-"));
+  try {
+    const authoredRoot = path.join(root, "harness");
+    mkdirSync(authoredRoot);
+    git(authoredRoot, "init");
+    git(authoredRoot, "config", "user.name", "Receipt Recovery");
+    git(authoredRoot, "config", "user.email", "receipt-recovery@example.test");
+    writeFileSync(path.join(authoredRoot, "README.md"), "canonical\n");
+    git(authoredRoot, "add", "README.md");
+    git(authoredRoot, "commit", "-m", "canonical base");
+    const acceptedCommitSha = git(authoredRoot, "rev-parse", "HEAD");
+    const settlements = settlementStore(path.join(root, "settlements"), 8);
+    const receiptId = "repo-write-direct:live-owner";
+    acceptPending(settlements, {
+      receiptId,
+      sessionId: "session-live-owner",
+      acceptedCommitSha,
+      authorityOperationIds: ["op-live-owner"]
+    });
+    const outcomes = new DurableRepoWriteOutcomeStoreV1({
+      directory: path.join(root, "outcomes"),
+      repoId: "canonical",
+      workspaceId: "workspace-recovery",
+      generation: 8
+    });
+    let live = true;
+    let authorityAttempts = 0;
+    const recovery = createRepoWriteChildPostReadyRecovery({
+      repoId: "canonical",
+      generation: 8,
+      transport: { send: async () => undefined } as never,
+      settlements,
+      outcomes,
+      runtime: {
+        enqueueMaterializerBatch: async () => ({ branches: [] })
+      } as unknown as HarnessDaemonRuntime,
+      authoredRoot,
+      recoveryGate: {
+        recoverHistoricalProceeding: async () => ({ disposition: "deferred" })
+      } as never,
+      isSettlementActive: (candidate) => live && candidate === receiptId,
+      recoverCommittedReceipt: async (opId) => {
+        authorityAttempts += 1;
+        return {
+          tag: "COMMITTED",
+          workspaceId: "workspace-recovery",
+          opId,
+          semanticDigest: "d".repeat(64),
+          revision: 1,
+          commitSha: acceptedCommitSha,
+          previousCommit: null
+        };
+      },
+      recoverCanonicalPublication: async () => "blocked"
+    });
+
+    await recovery.recoverSettlements();
+    assert.equal(authorityAttempts, 0);
+    assert.equal(settlements.lookup(receiptId)?.state, "pending");
+
+    live = false;
+    await recovery.recoverSettlements();
+    assert.equal(authorityAttempts, 1);
+    assert.equal(settlements.lookup(receiptId)?.state, "canonical-visible");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 function acceptPending(
   settlements: ReceiptSettlementStore,
   input: {

--- a/packages/daemon/src/authority/authority-command-submission.ts
+++ b/packages/daemon/src/authority/authority-command-submission.ts
@@ -161,9 +161,10 @@ export function createDaemonAuthorityCommandSubmissionV2(options: {
       "authority",
       () => compileAttempt(compile)
     );
-    return durableAuthoritySubmissionFromSettlement(() =>
+    const durable = durableAuthoritySubmissionFromSettlement(() =>
       measureCurrentDaemonRequestPerformancePhase("authority", () => submitAttempt(attempt))
     );
+    return durable;
   };
   return {
     submit: (input) => compileAndSubmit(() => options.attemptCompiler.compile(input)),

--- a/packages/daemon/src/authority/authority-lifecycle.ts
+++ b/packages/daemon/src/authority/authority-lifecycle.ts
@@ -139,6 +139,11 @@ export interface AuthorityRepoLifecycleHooks {
 }
 
 export interface AuthorityLifecycleRuntime {
+  readonly enqueueBackgroundBatch?: <Result>(request: {
+    readonly source: string;
+    readonly priority?: "normal" | "background" | "maintenance";
+    readonly run: () => Result | Promise<Result>;
+  }) => Promise<Result>;
   readonly createAttributedCoordinator: (input: {
     readonly attribution: WriteAttribution;
     readonly sessionId: string;
@@ -182,6 +187,7 @@ export interface AuthorityLifecycleRuntime {
     readonly canonicalCommitSha?: string;
     readonly materialization?: Awaited<ReturnType<AuthorityLifecycleRuntime["enqueueMaterializerBatch"]>>;
   }>;
+  readonly beginAuthorityAdmission: () => () => void;
   readonly admissionBudget: DaemonAdmissionBudget;
 }
 

--- a/packages/daemon/src/authority/production/authority-evidence-commit.ts
+++ b/packages/daemon/src/authority/production/authority-evidence-commit.ts
@@ -1,0 +1,19 @@
+interface AuthorityEvidenceCommitQueue {
+  readonly enqueueBackgroundBatch?: <Result>(request: {
+    readonly source: string;
+    readonly priority: "normal";
+    readonly run: () => Result | Promise<Result>;
+  }) => Promise<Result>;
+}
+
+export async function commitAuthorityEvidence(
+  queue: AuthorityEvidenceCommitQueue,
+  commit: () => Promise<void>
+): Promise<void> {
+  if (!queue.enqueueBackgroundBatch) return commit();
+  await queue.enqueueBackgroundBatch({
+    source: "authority-evidence-commit",
+    priority: "normal",
+    run: commit
+  });
+}

--- a/packages/daemon/src/authority/production/production-authority-lifecycle.ts
+++ b/packages/daemon/src/authority/production/production-authority-lifecycle.ts
@@ -80,6 +80,7 @@ import {
   authorityManifestSourceDigest,
   canonicalProductionAuthorityRoot
 } from "./production-authority-manifest-identity.ts";
+import { commitAuthorityEvidence } from "./authority-evidence-commit.ts";
 export { createSerialPublicationExecutor } from "./serial-publication-executor.ts";
 export { recoverPendingProductionEvents } from "./recovery.ts";
 
@@ -197,7 +198,7 @@ export function createProductionAuthorityLifecycle(input: {
       const commitEvidence = async (canonicalCommitSha: string): Promise<void> => {
         reportCurrentRepoWriteTelemetry("authority-evidence-commit");
         reportCurrentRepoWriteTelemetry("fsync");
-        await evidenceCommitter.commitPending(canonicalCommitSha);
+        await commitAuthorityEvidence(runtime, () => evidenceCommitter.commitPending(canonicalCommitSha));
         reportCurrentRepoWriteTelemetry("authority-evidence-publish-returned");
       };
       const basePublisher = createDurableAuthorityCommittedEventPublisherV2({

--- a/packages/daemon/src/authority/production/publication-recovery-group.ts
+++ b/packages/daemon/src/authority/production/publication-recovery-group.ts
@@ -16,6 +16,7 @@ export async function recoverReplicaPublicationGroup(input: {
   readonly replicaChangeLog: ReplicaChangeLog;
   readonly evidence: CanonicalPublicationEvidence;
   readonly beforeAppend?: () => Promise<void>;
+  readonly append?: (draft: Parameters<ReplicaChangeLog["append"]>[0]) => Promise<void>;
 }): Promise<ReplicaChangeRecord> {
   const opIds = input.evidence.opIds ?? [input.record.opId];
   if (opIds.length === 0
@@ -54,7 +55,7 @@ export async function recoverReplicaPublicationGroup(input: {
     (latest?.revision ?? 0) + 1,
     input.evidence
   );
-  await input.replicaChangeLog.append(draft);
+  await (input.append ? input.append(draft) : input.replicaChangeLog.append(draft));
   const appended = await input.replicaChangeLog.getByOperation(input.record.workspaceId, input.record.opId);
   if (!appended) throw new Error("AUTHORITY_V2_RECOVERY_CHANGE_APPEND_MISSING");
   assertChangeMatchesPublication(appended, records, input.evidence);

--- a/packages/daemon/src/authority/production/recovery.ts
+++ b/packages/daemon/src/authority/production/recovery.ts
@@ -184,7 +184,7 @@ async function recoverIncrementally(input: ProductionRecoveryInput, watermarkPat
         anchor.opIds,
         anchor.commitSha
       );
-      await runTerminalRecovery(input, record, () => recoverPublishedRecord(input, record, evidence));
+      await recoverPublishedRecord(input, record, evidence);
     } catch (error) {
       await input.onDeferred?.(record, error);
     }
@@ -211,7 +211,7 @@ async function recoverByOperationLookup(input: ProductionRecoveryInput): Promise
     for (const record of remaining) {
       try {
         const evidence = await input.publicationInspector.findPublicationForOperation(record.opId);
-        await runTerminalRecovery(input, record, () => recoverPublishedRecord(input, record, evidence));
+        await recoverPublishedRecord(input, record, evidence);
         progressed = true;
       } catch (error) {
         if (error instanceof AuthorityCanonicalPublicationNotFoundError
@@ -254,7 +254,11 @@ async function recoverPublishedRecord(
     operationRegistry: input.operationRegistry,
     replicaChangeLog: input.replicaChangeLog,
     evidence,
-    beforeAppend: () => assertRecoveryGeneration(input, record)
+    beforeAppend: () => assertRecoveryGeneration(input, record),
+    append: (draft) => runTerminalRecovery(input, record, async () => {
+      await assertRecoveryGeneration(input, record);
+      await input.replicaChangeLog.append(draft);
+    })
   });
   const changeOperation = change?.operations.find((operation) => operation.opId === record.opId);
   if (change.commitSha !== evidence.commitSha
@@ -264,12 +268,15 @@ async function recoverPublishedRecord(
     throw new Error("AUTHORITY_V2_RECOVERY_CHANGE_MISMATCH");
   }
   const indexed = { ...record, state: "INDEXED" as const, commitSha: evidence.commitSha };
-  await assertRecoveryGeneration(input, record);
-  await input.operationRegistry.put(indexed);
-  await assertRecoveryGeneration(input, record);
+  await runTerminalRecovery(input, record, async () => {
+    await assertRecoveryGeneration(input, record);
+    await input.operationRegistry.put(indexed);
+  });
   const receipt = await input.recover(indexed);
-  await assertRecoveryGeneration(input, record);
-  await input.operationRegistry.put({ ...indexed, state: "COMMITTED", receipt, commitSha: receipt.commitSha });
+  await runTerminalRecovery(input, record, async () => {
+    await assertRecoveryGeneration(input, record);
+    await input.operationRegistry.put({ ...indexed, state: "COMMITTED", receipt, commitSha: receipt.commitSha });
+  });
 }
 
 async function terminalizeConfirmedAbsent(

--- a/packages/daemon/src/authority/production/serial-publication-executor.ts
+++ b/packages/daemon/src/authority/production/serial-publication-executor.ts
@@ -1,126 +1,61 @@
 import {
   captureCurrentAuthorityPublicationContext,
-  currentAuthorityDurableAcceptanceSignal,
-  currentAuthoritySettlementReleaseSignal
+  currentAuthorityDurableAcceptanceSignal
 } from "../../runtime/authority-durable-acceptance-context.ts";
 import type { AuthorityPublicationExecutionContext } from "@harness-anything/application";
 
-interface QueuedPublication {
-  readonly commandRelease?: Promise<void>;
-  readonly durableCut?: Promise<void>;
-  readonly publication: (
-    context: AuthorityPublicationExecutionContext
-  ) => Promise<unknown>;
-  readonly runInContext: <Result>(operation: () => Result) => Result;
-  readonly resolve: (result: unknown) => void;
-  readonly reject: (error: unknown) => void;
+interface PublicationTail {
+  readonly durableCut: Promise<void>;
+  readonly terminal: Promise<void>;
+  readonly execution: { allowDurableSuccessor: boolean; reportDurableCut: () => void };
 }
 
-interface PublicationGroup {
-  readonly commandRelease?: Promise<void>;
-  readonly executionContexts: Set<{ allowDurableSuccessor: boolean }>;
-  readonly terminals: Set<Promise<void>>;
-  lastDurableCut: Promise<void>;
-  acceptingSameCommand: boolean;
-}
-
+/**
+ * Serializes only the authoritative publication cut. Canonical settlement may
+ * continue after durable acceptance, but a successor cannot enter before the
+ * preceding publication either reports that cut or terminates.
+ */
 export function createSerialPublicationExecutor(): {
   readonly run: <Result>(publication: (
     context: AuthorityPublicationExecutionContext
   ) => Promise<Result>) => Promise<Result>;
 } {
-  const queued: QueuedPublication[] = [];
-  let active: PublicationGroup | undefined;
-
-  const startPublication = (
-    entry: QueuedPublication,
-    after: Promise<void> = Promise.resolve(),
-    allowDurableSuccessor = false
-  ): {
-    readonly terminal: Promise<void>;
-    readonly durableCut: Promise<void>;
-    readonly executionContext: { allowDurableSuccessor: boolean };
-  } => {
-    const executionContext = { allowDurableSuccessor };
-    const result = after.then(() => entry.runInContext(() => entry.publication(executionContext)));
-    void result.then(entry.resolve, entry.reject);
-    const terminal = result.then(() => undefined, () => undefined);
-    return {
-      terminal,
-      executionContext,
-      durableCut: entry.durableCut
-        ? Promise.race([entry.durableCut, terminal])
-        : terminal
-    };
-  };
-
-  const finishGroup = async (group: PublicationGroup): Promise<void> => {
-    while (true) {
-      const terminals = [...group.terminals];
-      await Promise.all(terminals);
-      if (terminals.length === group.terminals.size) break;
-    }
-    group.acceptingSameCommand = false;
-    if (active !== group) return;
-    active = undefined;
-    drain();
-  };
-
-  const addToActiveGroup = (group: PublicationGroup, entry: QueuedPublication): void => {
-    for (const context of group.executionContexts) context.allowDurableSuccessor = true;
-    const started = startPublication(entry, group.lastDurableCut, true);
-    group.lastDurableCut = started.durableCut;
-    group.executionContexts.add(started.executionContext);
-    group.terminals.add(started.terminal);
-  };
-
-  const drain = (): void => {
-    if (active || queued.length === 0) return;
-    const entry = queued.shift()!;
-    const started = startPublication(entry);
-    const group: PublicationGroup = {
-      ...(entry.commandRelease ? { commandRelease: entry.commandRelease } : {}),
-      executionContexts: new Set([started.executionContext]),
-      terminals: new Set([started.terminal]),
-      lastDurableCut: started.durableCut,
-      acceptingSameCommand: entry.commandRelease !== undefined
-    };
-    active = group;
-    if (entry.commandRelease) {
-      void entry.commandRelease.then(
-        () => finishGroup(group),
-        () => finishGroup(group)
-      );
-    } else {
-      void started.terminal.then(() => finishGroup(group));
-    }
-  };
+  let tail: PublicationTail | undefined;
 
   return {
     run: <Result>(publication: (
       context: AuthorityPublicationExecutionContext
     ) => Promise<Result>): Promise<Result> => {
-      const commandRelease = currentAuthoritySettlementReleaseSignal();
-      return new Promise<Result>((resolve, reject) => {
-        const entry: QueuedPublication = {
-          ...(commandRelease ? { commandRelease } : {}),
-          ...(currentAuthorityDurableAcceptanceSignal()
-            ? { durableCut: currentAuthorityDurableAcceptanceSignal() }
-            : {}),
-          publication,
-          runInContext: captureCurrentAuthorityPublicationContext(),
-          resolve: (result) => resolve(result as Result),
-          reject
-        };
-        if (active?.acceptingSameCommand
-          && commandRelease
-          && active.commandRelease === commandRelease) {
-          addToActiveGroup(active, entry);
-          return;
-        }
-        queued.push(entry);
-        drain();
+      const previous = tail;
+      const durableAcceptance = currentAuthorityDurableAcceptanceSignal();
+      let reportDurableCut!: () => void;
+      const reportedDurableCut = new Promise<void>((resolve) => {
+        reportDurableCut = resolve;
       });
+      const execution = {
+        allowDurableSuccessor: previous !== undefined,
+        ...(durableAcceptance ? { durableAcceptance } : {}),
+        reportDurableCut
+      };
+      if (previous) previous.execution.allowDurableSuccessor = true;
+      const runInContext = captureCurrentAuthorityPublicationContext();
+      const result = (previous?.durableCut ?? Promise.resolve())
+        .then(() => runInContext(() => publication(execution)));
+      const terminal = result.then(() => undefined, () => undefined);
+      const current: PublicationTail = {
+        execution,
+        terminal,
+        durableCut: Promise.race([
+          reportedDurableCut,
+          ...(durableAcceptance ? [durableAcceptance] : []),
+          terminal
+        ])
+      };
+      tail = current;
+      void terminal.then(() => {
+        if (tail === current) tail = undefined;
+      });
+      return result;
     }
   };
 }

--- a/packages/daemon/src/runtime/authority-publication.ts
+++ b/packages/daemon/src/runtime/authority-publication.ts
@@ -1,5 +1,4 @@
 import { isIndeterminateFlushReport, type FlushReport, type LedgerMaterializerReport } from "@harness-anything/kernel";
-import { setImmediate as nextEventLoopTurn } from "node:timers/promises";
 import type { DaemonWriteQueue } from "./write-queue.ts";
 import { measureCurrentDaemonRequestPerformancePhase } from "../observability/request-performance.ts";
 import {
@@ -26,9 +25,11 @@ export interface DaemonAuthorityPublicationReport {
 export function enqueueDaemonAuthorityPublication(
   queue: DaemonWriteQueue,
   options: DaemonAuthorityPublicationOptions,
-  materialize: (sessionId: string) => LedgerMaterializerReport,
+  materialize: (sessionId: string) => LedgerMaterializerReport | Promise<LedgerMaterializerReport>,
   resolveAcceptedCommitSha: (sessionId: string) => string,
-  resolveCanonicalCommitContaining: (acceptedCommitSha: string) => string | undefined = () => undefined
+  resolveCanonicalCommitContaining: (acceptedCommitSha: string) => string | undefined = () => undefined,
+  scheduleMaterializer: <Result>(run: () => Result | Promise<Result>) => Promise<Result> = (run) =>
+    queue.enqueueBackground({ source: "authority-publication", priority: "background", run })
 ): Promise<DaemonAuthorityPublicationReport> {
   reportCurrentRepoWriteTelemetry("projection");
   const reportDurableAcceptance = captureCurrentAuthorityDurableAcceptanceReporter();
@@ -55,18 +56,11 @@ export function enqueueDaemonAuthorityPublication(
   return durableAcceptance.then(async ({ flush, acceptedCommitSha }) => {
     if (isIndeterminateFlushReport(flush) || !flush.committed || flush.opCount === 0) return { flush };
     await waitForCurrentAuthoritySettlementRelease();
-    // The production queue may begin a synchronous materializer inside
-    // enqueueBackground. Yield once so admission continuations can persist and
-    // deliver the durable receipt before that CPU/Git work starts.
-    await nextEventLoopTurn();
-    return queue.enqueueBackground({
-      source: "authority-publication",
-      priority: "background",
-      run: bindCurrentRepoWriteTelemetry(() => {
+    return scheduleMaterializer(bindCurrentRepoWriteTelemetry(async () => {
         reportCurrentRepoWriteTelemetry("materializer");
         reportCurrentRepoWriteTelemetry("git");
         reportCurrentRepoWriteTelemetry("fsync");
-        const materialization = measureCurrentDaemonRequestPerformancePhase(
+        const materialization = await measureCurrentDaemonRequestPerformancePhase(
           "materializer",
           () => materialize(options.sessionId)
         );
@@ -80,7 +74,6 @@ export function enqueueDaemonAuthorityPublication(
           ...(canonicalCommitSha ? { canonicalCommitSha } : {}),
           materialization
         };
-      })
-    });
+      }));
   });
 }

--- a/packages/daemon/src/runtime/production-progress-append-operation.ts
+++ b/packages/daemon/src/runtime/production-progress-append-operation.ts
@@ -131,6 +131,9 @@ export class ProductionRepoWriteOperationHost<
     await this.runtimeEventDrain.idle();
   };
 
+  readonly isSettlementActive = (receiptId: string): boolean =>
+    this.operations.hasActiveSettlement(receiptId);
+
   readonly recoverCanonicalPublicationSettlement = (input: {
     readonly outerOpId: string;
     readonly canonicalCommitSha: string;

--- a/packages/daemon/src/runtime/repo-materializer-execution.ts
+++ b/packages/daemon/src/runtime/repo-materializer-execution.ts
@@ -1,5 +1,4 @@
-import type { HarnessLayoutInput, LedgerMaterializerReport } from "@harness-anything/kernel";
-import type { DaemonGlobalLock } from "@harness-anything/kernel/daemon-runtime-support";
+import type { DaemonGlobalLock, HarnessLayoutInput, LedgerMaterializerReport } from "@harness-anything/kernel";
 import type { DaemonMaterializerBatchOptions } from "./repo-runtime-options.ts";
 import { bindCurrentRepoWriteTelemetry, reportCurrentRepoWriteTelemetry } from "./repo-write-telemetry-context.ts";
 import {

--- a/packages/daemon/src/runtime/repo-materializer-execution.ts
+++ b/packages/daemon/src/runtime/repo-materializer-execution.ts
@@ -1,0 +1,87 @@
+import type { HarnessLayoutInput, LedgerMaterializerReport } from "@harness-anything/kernel";
+import type { DaemonGlobalLock } from "@harness-anything/kernel/daemon-runtime-support";
+import type { DaemonMaterializerBatchOptions } from "./repo-runtime-options.ts";
+import { bindCurrentRepoWriteTelemetry, reportCurrentRepoWriteTelemetry } from "./repo-write-telemetry-context.ts";
+import {
+  materializerAttributionDecisionPhase,
+  materializerProgressPhase,
+  materializerProjectionModePhase,
+  materializerProjectionPhase,
+  materializerProjectionRebuildReasonPhase,
+  reportMaterializerProjectionDiagnostic
+} from "./repo-write-materializer-telemetry.ts";
+import type { RepoMaterializerWorker } from "./repo-materializer-worker.ts";
+
+export async function runRepoMaterializerBatch(input: {
+  readonly rootInput: HarnessLayoutInput;
+  readonly lock: DaemonGlobalLock;
+  readonly options: DaemonMaterializerBatchOptions;
+  readonly maxBranches: number;
+  readonly worker: RepoMaterializerWorker;
+  readonly knownPendingSessions: Set<string>;
+  readonly invalidateProjection: () => void;
+  readonly rememberFingerprint: (sourceHash: string) => void;
+  readonly setLastError: (value: string | undefined) => void;
+}): Promise<LedgerMaterializerReport> {
+  reportCurrentRepoWriteTelemetry("authority-materializer-start");
+  const onProgress = bindCurrentRepoWriteTelemetry((step: Parameters<typeof materializerProgressPhase>[0]) => {
+    reportCurrentRepoWriteTelemetry(materializerProgressPhase(step));
+  });
+  const onProjectionPhase = bindCurrentRepoWriteTelemetry((phase: Parameters<typeof materializerProjectionPhase>[0]) => {
+    reportCurrentRepoWriteTelemetry(materializerProjectionPhase(phase));
+  });
+  const onProjectionMode = bindCurrentRepoWriteTelemetry((
+    mode: Parameters<typeof materializerProjectionModePhase>[0],
+    reason?: Parameters<typeof materializerProjectionRebuildReasonPhase>[0]
+  ) => {
+    reportCurrentRepoWriteTelemetry(materializerProjectionModePhase(mode));
+    if (reason) reportCurrentRepoWriteTelemetry(materializerProjectionRebuildReasonPhase(reason));
+  });
+  const onProjectionAttributionDecision = bindCurrentRepoWriteTelemetry((
+    reason: Parameters<typeof materializerAttributionDecisionPhase>[0]
+  ) => reportCurrentRepoWriteTelemetry(materializerAttributionDecisionPhase(reason)));
+  const onProjectionDiagnostic = bindCurrentRepoWriteTelemetry(reportMaterializerProjectionDiagnostic);
+  let report: LedgerMaterializerReport;
+  try {
+    report = await input.worker.run(input.rootInput, {
+      heldGlobalLock: input.lock,
+      ...(input.options.dryRun ? { dryRun: true } : {}),
+      ...(input.options.sessionId
+        ? { sessionId: input.options.sessionId }
+        : { maxBranches: input.maxBranches })
+    }, {
+      onProgress,
+      onProjectionPhase,
+      onProjectionMode,
+      onProjectionAttributionDecision,
+      onProjectionDiagnostic
+    }, input.options.priority ?? "foreground");
+  } finally {
+    reportCurrentRepoWriteTelemetry("authority-materializer-end");
+  }
+  recordMaterializerOutcome(input, report);
+  return report;
+}
+
+function recordMaterializerOutcome(
+  input: Parameters<typeof runRepoMaterializerBatch>[0],
+  report: LedgerMaterializerReport
+): void {
+  if (report.projectionRebuilt) input.invalidateProjection();
+  if (report.projectionSourceHash) input.rememberFingerprint(report.projectionSourceHash);
+  if (report.warnings.length > 0) input.setLastError(report.warnings.join("; "));
+  else if (!input.options.sessionId) input.setLastError(undefined);
+
+  if (input.options.sessionId) {
+    const target = report.branches.find((branch) => branch.branch === `sessions/${input.options.sessionId}`);
+    if (report.warnings.length === 0 && (!target || target.status === "merged" || target.status === "skipped")) {
+      input.knownPendingSessions.delete(input.options.sessionId);
+    }
+    return;
+  }
+  for (const branch of report.branches) {
+    if ((branch.status === "merged" || branch.status === "skipped") && branch.branch.startsWith("sessions/")) {
+      input.knownPendingSessions.delete(branch.branch.slice("sessions/".length));
+    }
+  }
+}

--- a/packages/daemon/src/runtime/repo-materializer-scheduler.ts
+++ b/packages/daemon/src/runtime/repo-materializer-scheduler.ts
@@ -1,0 +1,86 @@
+import type { DaemonWriteQueue } from "./write-queue.ts";
+
+export type RepoMaterializerPriority = "foreground" | "recovery";
+
+/** Keeps recovery projection work behind live admissions and live settlement. */
+export class RepoMaterializerScheduler {
+  private readonly queue: DaemonWriteQueue;
+  private activeAuthorityAdmissions = 0;
+  private authorityAdmissionEpoch = 0;
+  private authorityAdmissionWaiters: Array<() => void> = [];
+  private activeForegroundMaterializers = 0;
+  private foregroundMaterializerEpoch = 0;
+  private foregroundMaterializerWaiters: Array<() => void> = [];
+
+  constructor(queue: DaemonWriteQueue) {
+    this.queue = queue;
+  }
+
+  beginAuthorityAdmission(): () => void {
+    this.activeAuthorityAdmissions += 1;
+    this.authorityAdmissionEpoch += 1;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.activeAuthorityAdmissions -= 1;
+      if (this.activeAuthorityAdmissions !== 0) return;
+      for (const resolve of this.authorityAdmissionWaiters.splice(0)) resolve();
+    };
+  }
+
+  beginForegroundMaterializer(): () => void {
+    this.activeForegroundMaterializers += 1;
+    this.foregroundMaterializerEpoch += 1;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.activeForegroundMaterializers -= 1;
+      if (this.activeForegroundMaterializers !== 0) return;
+      for (const resolve of this.foregroundMaterializerWaiters.splice(0)) resolve();
+    };
+  }
+
+  async schedule<Result>(
+    source: string,
+    run: () => Result | Promise<Result>,
+    priority: RepoMaterializerPriority = "foreground"
+  ): Promise<Result> {
+    for (;;) {
+      await this.waitForAuthorityAdmissions();
+      if (priority === "recovery") await this.waitForForegroundMaterializers();
+      const readyEpoch = this.authorityAdmissionEpoch;
+      const readyForegroundEpoch = this.foregroundMaterializerEpoch;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      if (!this.canRun(priority, readyEpoch, readyForegroundEpoch)) continue;
+      const attempt = await this.queue.enqueueBackground({
+        source,
+        priority: priority === "foreground" ? "normal" : "background",
+        run: async () => this.canRun(priority, readyEpoch, readyForegroundEpoch)
+          ? { ready: true as const, value: await run() }
+          : { ready: false as const }
+      });
+      if (attempt.ready) return attempt.value;
+    }
+  }
+
+  private canRun(priority: RepoMaterializerPriority, authorityEpoch: number, foregroundEpoch: number): boolean {
+    return this.activeAuthorityAdmissions === 0
+      && this.authorityAdmissionEpoch === authorityEpoch
+      && (priority !== "recovery" || (
+        this.activeForegroundMaterializers === 0
+        && this.foregroundMaterializerEpoch === foregroundEpoch
+      ));
+  }
+
+  private waitForAuthorityAdmissions(): Promise<void> {
+    if (this.activeAuthorityAdmissions === 0) return Promise.resolve();
+    return new Promise<void>((resolve) => this.authorityAdmissionWaiters.push(resolve));
+  }
+
+  private waitForForegroundMaterializers(): Promise<void> {
+    if (this.activeForegroundMaterializers === 0) return Promise.resolve();
+    return new Promise<void>((resolve) => this.foregroundMaterializerWaiters.push(resolve));
+  }
+}

--- a/packages/daemon/src/runtime/repo-materializer-worker-thread.ts
+++ b/packages/daemon/src/runtime/repo-materializer-worker-thread.ts
@@ -1,0 +1,49 @@
+import { parentPort } from "node:worker_threads";
+import {
+  runLedgerMaterializer
+} from "@harness-anything/kernel";
+
+interface WorkerMaterializerOptions {
+  readonly dryRun?: boolean;
+  readonly maxBranches?: number;
+  readonly sessionId?: string;
+  readonly heldGlobalLock?: {
+    readonly path: string;
+    readonly ownerToken: string;
+    readonly ownerKind?: "daemon";
+  };
+}
+
+interface MaterializerWorkerRequest {
+  readonly kind: "run";
+  readonly jobId: number;
+  readonly rootInput: Parameters<typeof runLedgerMaterializer>[0];
+  readonly options: WorkerMaterializerOptions;
+}
+
+if (!parentPort) throw new Error("REPO_MATERIALIZER_WORKER_PARENT_PORT_MISSING");
+
+parentPort.on("message", (request: MaterializerWorkerRequest) => {
+  if (request.kind !== "run") return;
+  try {
+    const report = runLedgerMaterializer(request.rootInput, {
+      ...request.options,
+      onProgress: (value) => parentPort!.postMessage({ kind: "progress", jobId: request.jobId, value }),
+      onProjectionPhase: (value) => parentPort!.postMessage({ kind: "projection-phase", jobId: request.jobId, value }),
+      onProjectionMode: (mode, reason) => parentPort!.postMessage({ kind: "projection-mode", jobId: request.jobId, mode, reason }),
+      onProjectionAttributionDecision: (value) => parentPort!.postMessage({ kind: "attribution-decision", jobId: request.jobId, value }),
+      onProjectionDiagnostic: (value) => parentPort!.postMessage({ kind: "projection-diagnostic", jobId: request.jobId, value })
+    });
+    parentPort!.postMessage({ kind: "complete", jobId: request.jobId, report });
+  } catch (error) {
+    parentPort!.postMessage({
+      kind: "failed",
+      jobId: request.jobId,
+      error: {
+        name: error instanceof Error ? error.name : "Error",
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined
+      }
+    });
+  }
+});

--- a/packages/daemon/src/runtime/repo-materializer-worker.ts
+++ b/packages/daemon/src/runtime/repo-materializer-worker.ts
@@ -1,0 +1,182 @@
+import { Worker } from "node:worker_threads";
+import type {
+  AttributionProjectionDecisionReason,
+  IncrementalProjectionDiagnostic,
+  IncrementalProjectionPhase,
+  IncrementalProjectionRebuildReason,
+  IncrementalTaskProjectionMode,
+  HarnessLayoutInput,
+  LedgerMaterializerProgressStep,
+  LedgerMaterializerReport,
+  TrustedProjectionFingerprintDiagnostic
+} from "@harness-anything/kernel";
+
+interface WorkerMaterializerOptions {
+  readonly dryRun?: boolean;
+  readonly maxBranches?: number;
+  readonly sessionId?: string;
+  readonly heldGlobalLock?: {
+    readonly path: string;
+    readonly ownerToken: string;
+    readonly ownerKind?: "daemon";
+  };
+}
+
+interface MaterializerWorkerCallbacks {
+  readonly onProgress?: (step: LedgerMaterializerProgressStep) => void;
+  readonly onProjectionPhase?: (phase: IncrementalProjectionPhase) => void;
+  readonly onProjectionMode?: (mode: IncrementalTaskProjectionMode, reason?: IncrementalProjectionRebuildReason) => void;
+  readonly onProjectionAttributionDecision?: (reason: AttributionProjectionDecisionReason) => void;
+  readonly onProjectionDiagnostic?: (
+    diagnostic: TrustedProjectionFingerprintDiagnostic | IncrementalProjectionDiagnostic
+  ) => void;
+}
+
+interface PendingMaterializerJob {
+  readonly jobId: number;
+  readonly rootInput: HarnessLayoutInput;
+  readonly options: WorkerMaterializerOptions;
+  readonly priority: "foreground" | "recovery";
+  readonly resolve: (report: LedgerMaterializerReport) => void;
+  readonly reject: (error: Error) => void;
+  readonly callbacks: MaterializerWorkerCallbacks;
+}
+
+type MaterializerWorkerMessage =
+  | { readonly kind: "progress"; readonly jobId: number; readonly value: LedgerMaterializerProgressStep }
+  | { readonly kind: "projection-phase"; readonly jobId: number; readonly value: IncrementalProjectionPhase }
+  | { readonly kind: "projection-mode"; readonly jobId: number; readonly mode: IncrementalTaskProjectionMode; readonly reason?: IncrementalProjectionRebuildReason }
+  | { readonly kind: "attribution-decision"; readonly jobId: number; readonly value: AttributionProjectionDecisionReason }
+  | { readonly kind: "projection-diagnostic"; readonly jobId: number; readonly value: TrustedProjectionFingerprintDiagnostic | IncrementalProjectionDiagnostic }
+  | { readonly kind: "complete"; readonly jobId: number; readonly report: LedgerMaterializerReport }
+  | { readonly kind: "failed"; readonly jobId: number; readonly error: { readonly name: string; readonly message: string; readonly stack?: string } };
+
+export interface RepoMaterializerWorkerPort {
+  readonly postMessage: (value: unknown) => void;
+  readonly terminate: () => Promise<unknown>;
+  readonly on: (
+    event: "message" | "error" | "exit",
+    listener: (value: unknown) => void
+  ) => unknown;
+}
+
+export class RepoMaterializerWorker {
+  private readonly createWorker: () => RepoMaterializerWorkerPort;
+  private worker: RepoMaterializerWorkerPort | undefined;
+  private readonly pending = new Map<number, PendingMaterializerJob>();
+  private readonly queued: number[] = [];
+  private activeJobId: number | undefined;
+  private nextJobId = 1;
+  private stopping = false;
+
+  constructor(createWorker?: () => RepoMaterializerWorkerPort) {
+    this.createWorker = createWorker ?? (() => {
+      const extension = import.meta.url.endsWith(".ts") ? ".ts" : ".js";
+      return new Worker(new URL(`./repo-materializer-worker-thread${extension}`, import.meta.url));
+    });
+  }
+
+  run(
+    rootInput: HarnessLayoutInput,
+    options: WorkerMaterializerOptions,
+    callbacks: MaterializerWorkerCallbacks = {},
+    priority: "foreground" | "recovery" = "foreground"
+  ): Promise<LedgerMaterializerReport> {
+    this.stopping = false;
+    const jobId = this.nextJobId++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(jobId, { jobId, rootInput, options, priority, resolve, reject, callbacks });
+      this.queued.push(jobId);
+      this.dispatchNext();
+    });
+  }
+
+  async stop(): Promise<void> {
+    this.stopping = true;
+    const worker = this.worker;
+    this.worker = undefined;
+    if (!worker) return;
+    for (const pending of this.pending.values()) pending.reject(new Error("REPO_MATERIALIZER_WORKER_STOPPED"));
+    this.pending.clear();
+    this.queued.length = 0;
+    this.activeJobId = undefined;
+    await worker.terminate();
+  }
+
+  private dispatchNext(): void {
+    if (this.stopping || this.activeJobId !== undefined || this.queued.length === 0) return;
+    const foregroundIndex = this.queued.findIndex((jobId) =>
+      this.pending.get(jobId)?.priority === "foreground"
+    );
+    const queueIndex = foregroundIndex >= 0 ? foregroundIndex : 0;
+    const [jobId] = this.queued.splice(queueIndex, 1);
+    const job = jobId === undefined ? undefined : this.pending.get(jobId);
+    if (!job) {
+      this.dispatchNext();
+      return;
+    }
+    this.activeJobId = job.jobId;
+    const heldGlobalLock = job.options.heldGlobalLock;
+    this.ensureWorker().postMessage({
+      kind: "run",
+      jobId: job.jobId,
+      rootInput: job.rootInput,
+      options: {
+        ...job.options,
+        ...(heldGlobalLock ? {
+          heldGlobalLock: {
+            path: heldGlobalLock.path,
+            ownerToken: heldGlobalLock.ownerToken,
+            ...(heldGlobalLock.ownerKind ? { ownerKind: heldGlobalLock.ownerKind } : {})
+          }
+        } : {})
+      }
+    });
+  }
+
+  private ensureWorker(): RepoMaterializerWorkerPort {
+    if (this.worker) return this.worker;
+    const worker = this.createWorker();
+    worker.on("message", (message) => this.onMessage(message as MaterializerWorkerMessage));
+    worker.on("error", (error) => this.fail(error instanceof Error ? error : new Error(String(error))));
+    worker.on("exit", (value) => {
+      const code = Number(value);
+      if (this.worker === worker) this.worker = undefined;
+      if (!this.stopping && code !== 0) this.fail(new Error(`REPO_MATERIALIZER_WORKER_EXITED:${code}`));
+    });
+    this.worker = worker;
+    return worker;
+  }
+
+  private onMessage(message: MaterializerWorkerMessage): void {
+    const pending = this.pending.get(message.jobId);
+    if (!pending) return;
+    const callbacks = pending.callbacks;
+    if (message.kind === "progress") callbacks.onProgress?.(message.value);
+    else if (message.kind === "projection-phase") callbacks.onProjectionPhase?.(message.value);
+    else if (message.kind === "projection-mode") callbacks.onProjectionMode?.(message.mode, message.reason);
+    else if (message.kind === "attribution-decision") callbacks.onProjectionAttributionDecision?.(message.value);
+    else if (message.kind === "projection-diagnostic") callbacks.onProjectionDiagnostic?.(message.value);
+    else if (message.kind === "complete") {
+      this.pending.delete(message.jobId);
+      if (this.activeJobId === message.jobId) this.activeJobId = undefined;
+      pending.resolve(message.report);
+      this.dispatchNext();
+    } else {
+      this.pending.delete(message.jobId);
+      if (this.activeJobId === message.jobId) this.activeJobId = undefined;
+      const error = new Error(message.error.message);
+      error.name = message.error.name;
+      if (message.error.stack) error.stack = message.error.stack;
+      pending.reject(error);
+      this.dispatchNext();
+    }
+  }
+
+  private fail(error: Error): void {
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+    this.queued.length = 0;
+    this.activeJobId = undefined;
+  }
+}

--- a/packages/daemon/src/runtime/repo-projection-generation.ts
+++ b/packages/daemon/src/runtime/repo-projection-generation.ts
@@ -1,0 +1,24 @@
+import { createDaemonProjectionGenerationManager } from "./projection-generation-manager.ts";
+import type { DaemonRepoRuntimeOptions } from "./repo-runtime-options.ts";
+import { defaultDaemonRuntimePolicy } from "./runtime-policy.ts";
+
+export function createRepoProjectionGenerationManager(
+  rootDir: string,
+  options: Pick<
+    DaemonRepoRuntimeOptions,
+    "layoutOverrides" | "projectionSourceFenceFactory" | "projectionReconcileIntervalMs"
+  >
+) {
+  return createDaemonProjectionGenerationManager({
+    rootDir,
+    ...(options.layoutOverrides ? { layoutOverrides: options.layoutOverrides } : {}),
+    ...(options.projectionSourceFenceFactory ? {
+      sourceFence: options.projectionSourceFenceFactory({
+        rootDir,
+        ...(options.layoutOverrides ? { layoutOverrides: options.layoutOverrides } : {})
+      })
+    } : {}),
+    reconcileIntervalMs: options.projectionReconcileIntervalMs
+      ?? defaultDaemonRuntimePolicy.projection.reconcileIntervalMs
+  });
+}

--- a/packages/daemon/src/runtime/repo-runtime-options.ts
+++ b/packages/daemon/src/runtime/repo-runtime-options.ts
@@ -30,6 +30,8 @@ import type { DaemonProjectionGenerationSnapshot } from "./projection-generation
 export interface DaemonMaterializerBatchOptions {
   readonly dryRun?: boolean;
   readonly sessionId?: string;
+  /** Recovery may finish in the background, but must not queue ahead of live settlement. */
+  readonly priority?: "foreground" | "recovery";
 }
 
 export interface DaemonDrainOptions {
@@ -103,6 +105,8 @@ export interface HarnessDaemonRuntime {
   readonly enqueueAuthorityPublication: (
     options: DaemonAuthorityPublicationOptions
   ) => Promise<DaemonAuthorityPublicationReport>;
+  /** Hold canonical settlement until every command already in admission reaches a durable cut. */
+  readonly beginAuthorityAdmission: () => () => void;
   readonly queryExecutionEvidencePage: (query: ExecutionEvidencePageQuery) => Promise<ExecutionEvidencePage>;
   /** Authority/application port backed by this runtime's current held global lock. */
   readonly createAttributedCoordinator: (input: {

--- a/packages/daemon/src/runtime/repo-runtime.ts
+++ b/packages/daemon/src/runtime/repo-runtime.ts
@@ -3,8 +3,7 @@ import { randomUUID } from "node:crypto";
 import { Effect } from "effect";
 import {
   createHarnessRuntimeContext,
-  makeJournaledWriteCoordinator,
-  makeOperationalJournaledWriteCoordinator,
+  makeLocalVersionControlSystem,
   type DaemonAdmissionBudget,
   type LedgerMaterializerReport,
   type OperationalActor,
@@ -17,6 +16,7 @@ import {
   createProjectionChangePublisher,
   createRuntimeAdmissionBudget,
   recoverJournaledWrites,
+  rememberTrustedAuthoredProjectionFingerprint,
   writeOpTouchedPaths,
   type ExecutionEvidencePage,
   type ExecutionEvidencePageQuery,
@@ -65,10 +65,7 @@ export type {
   MultiRepoDaemonRuntimeStatus,
   MultiRepoHarnessDaemonRuntime
 } from "./repo-runtime-options.ts";
-import {
-  createDaemonProjectionGenerationManager,
-  type DaemonProjectionGenerationManager
-} from "./projection-generation-manager.ts";
+import type { DaemonProjectionGenerationManager } from "./projection-generation-manager.ts";
 import { toDaemonRuntimeStatus } from "./repo-runtime-status.ts";
 import { defaultDaemonRuntimePolicy } from "./runtime-policy.ts";
 import { ReservationReconcilerRunner } from "./reservation-reconciler-runner.ts";
@@ -79,8 +76,11 @@ import { bindCurrentRepoWriteTelemetry } from "./repo-write-telemetry-context.ts
 import { resolveAuthoritySessionCommit } from "./authority-session-commit.ts";
 import { canonicalCommitContaining } from "./canonical-commit-ancestry.ts";
 import { requireContext, sortedContexts } from "./repo-runtime-context-map.ts";
-import { reportFlushGitCommitPhase, reportFlushPostCommitPhase, reportFlushProjectionFingerprintDiagnostic, reportFlushProjectionFingerprintPhase, runMaterializerWithRepoWriteTelemetry } from "./repo-write-materializer-telemetry.ts";
-
+import { RepoMaterializerWorker } from "./repo-materializer-worker.ts";
+import { RepoMaterializerScheduler } from "./repo-materializer-scheduler.ts";
+import { runRepoMaterializerBatch } from "./repo-materializer-execution.ts";
+import { makeStartedRepoWriteCoordinator } from "./repo-started-coordinator.ts";
+import { createRepoProjectionGenerationManager } from "./repo-projection-generation.ts";
 const defaultDaemonOperationalActor: OperationalActor = { scope: "operational", kind: "system", id: "daemon-runtime" };
 export type {
   BackgroundBatchRequest,
@@ -99,6 +99,7 @@ export function createDaemonRuntime(options: DaemonRuntimeOptions): HarnessDaemo
     enqueueBackgroundBatch: (request) => context.enqueueBackgroundBatch(request),
     enqueueMaterializerBatch: (batchOptions) => context.enqueueMaterializerBatch(batchOptions),
     enqueueAuthorityPublication: (publication) => context.enqueueAuthorityPublication(publication),
+    beginAuthorityAdmission: () => context.beginAuthorityAdmission(),
     queryExecutionEvidencePage: (query) => context.queryExecutionEvidencePage(query),
     createAttributedCoordinator: (input) => context.createAttributedCoordinator(input),
     assertWriteFenceHeld: () => context.assertWriteFenceHeld(),
@@ -112,11 +113,9 @@ export function createMultiRepoDaemonRuntime(options: MultiRepoDaemonRuntimeOpti
   const contexts = new Map<string, DaemonRepoRuntimeContext>();
   let started = false;
   let assertBuildCurrent = options.assertBuildCurrent;
-
   for (const repo of sortedRepoOptions(options.repos)) {
     addContext(mergeRepoRuntimeDefaults(repo, options));
   }
-
   const runtime: MultiRepoHarnessDaemonRuntime = {
     start: async () => {
       started = true;
@@ -168,7 +167,6 @@ export function createMultiRepoDaemonRuntime(options: MultiRepoDaemonRuntimeOpti
     enqueueMaterializerBatch: (repoId, batchOptions) => requireContext(contexts, repoId).enqueueMaterializerBatch(batchOptions)
   };
   return runtime;
-
   function status(): MultiRepoDaemonRuntimeStatus {
     const repos = sortedContexts(contexts).map((context) => context.status());
     return {
@@ -179,7 +177,6 @@ export function createMultiRepoDaemonRuntime(options: MultiRepoDaemonRuntimeOpti
       repos
     };
   }
-
   function addContext(repo: DaemonRepoRuntimeOptions): DaemonRepoRuntimeContext {
     if (contexts.has(repo.repoId)) throw new Error(`duplicate daemon repoId: ${repo.repoId}`);
     const rootDir = path.resolve(repo.rootDir);
@@ -195,7 +192,6 @@ export function createMultiRepoDaemonRuntime(options: MultiRepoDaemonRuntimeOpti
     return context;
   }
 }
-
 class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
   readonly repoId: string;
   readonly rootDir: string;
@@ -219,6 +215,10 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
   private lastError: string | undefined;
   private lastMaterializerError: string | undefined;
   private materializerTimer: ReturnType<typeof setInterval> | undefined;
+  private readonly knownPendingMaterializerSessions = new Set<string>();
+  private readonly materializerWorker = new RepoMaterializerWorker();
+  private readonly materializerScheduler: RepoMaterializerScheduler;
+  private readonly runtimeVersionControlSystem = makeLocalVersionControlSystem({ cacheRepositoryDiscovery: true });
   private readonly reservationReconciler: ReservationReconcilerRunner;
   private assertBuildCurrent: () => void;
   private runtimeRegistrationId: string | undefined;
@@ -240,6 +240,7 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
       options.interactiveMicroBatchMs ?? defaultDaemonRuntimePolicy.write.interactiveMicroBatchMs,
       this.admissionBudget
     );
+    this.materializerScheduler = new RepoMaterializerScheduler(this.queue);
     this.projectionGeneration = this.createProjectionGenerationManager();
     this.reservationReconciler = new ReservationReconcilerRunner(
       options.reservationReconciler,
@@ -333,6 +334,7 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
       projectionCloseError = error;
     }
     try {
+      await this.materializerWorker.stop();
       this.lock?.release();
       if (projectionCloseError !== undefined) throw projectionCloseError;
       this.lastError = undefined;
@@ -379,6 +381,12 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
     }
     const projectionWrite = this.projectionGeneration.beginCanonicalWrite(touchedPaths);
     return this.queue.enqueueInteractive(request, (batch) => this.makeStartedCoordinator(started, batch), <Result>(operation: () => Result): Result => bindCurrentRepoWriteTelemetry(operation)())
+      .then((receipt) => {
+        if (request.sessionId && receipt.flush.committed && receipt.flush.opCount > 0) {
+          this.knownPendingMaterializerSessions.add(request.sessionId);
+        }
+        return receipt;
+      })
       .catch((error: unknown) => {
         this.lastError = describeRepoRuntimeError(error);
         throw error;
@@ -395,30 +403,44 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
       });
   }
 
-  enqueueMaterializerBatch(batchOptions: DaemonMaterializerBatchOptions = {}): Promise<LedgerMaterializerReport> {
-    return this.enqueueBackgroundBatch({
-      source: "ledger-materializer",
-      priority: "background",
-      run: () => this.runMaterializerBatch(batchOptions)
-    }).catch((error: unknown) => {
+  async enqueueMaterializerBatch(batchOptions: DaemonMaterializerBatchOptions = {}): Promise<LedgerMaterializerReport> {
+    const priority = batchOptions.priority ?? "foreground";
+    const releaseForeground = priority === "foreground"
+      ? this.materializerScheduler.beginForegroundMaterializer()
+      : undefined;
+    try {
+      return await this.materializerScheduler.schedule("ledger-materializer", () =>
+        this.runMaterializerBatch(batchOptions),
+        priority
+      );
+    } catch (error) {
       this.lastMaterializerError = describeRepoRuntimeError(error);
       this.projectionGeneration.invalidate();
       throw error;
-    });
+    } finally {
+      releaseForeground?.();
+    }
   }
 
   enqueueAuthorityPublication(options: DaemonAuthorityPublicationOptions): Promise<DaemonAuthorityPublicationReport> {
     this.requireWriterAttached();
+    this.knownPendingMaterializerSessions.add(options.sessionId);
+    const releaseForeground = this.materializerScheduler.beginForegroundMaterializer();
     return enqueueDaemonAuthorityPublication(
       this.queue,
       options,
       (sessionId) => this.runMaterializerBatch({ sessionId }),
       (sessionId) => resolveAuthoritySessionCommit(this.layout.authoredRoot, sessionId),
-      (acceptedCommitSha) => canonicalCommitContaining(this.layout.authoredRoot, acceptedCommitSha)
-    ).catch((error: unknown) => {
+      (acceptedCommitSha) => canonicalCommitContaining(this.layout.authoredRoot, acceptedCommitSha),
+      (run) => this.materializerScheduler.schedule("authority-publication", run, "foreground")
+    ).finally(releaseForeground).catch((error: unknown) => {
       this.lastError = describeRepoRuntimeError(error);
       throw error;
     });
+  }
+
+  beginAuthorityAdmission(): () => void {
+    return this.materializerScheduler.beginAuthorityAdmission();
   }
 
   queryExecutionEvidencePage(query: ExecutionEvidencePageQuery): Promise<ExecutionEvidencePage> {
@@ -491,24 +513,16 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
     started: ReturnType<DaemonRepoRuntimeContext["requireWriterAttached"]>,
     request: InteractiveWriteAttribution & Partial<Parameters<HarnessDaemonRuntime["createAttributedCoordinator"]>[0]>
   ) {
-    const common = {
+    return makeStartedRepoWriteCoordinator({
       rootDir: this.rootDir,
       layoutOverrides: this.options.layoutOverrides,
       operationalActor: this.operationalActor,
       lockTtlMs: this.lockTtlMs,
-      heldGlobalLock: started.lock,
-      autoMaterialize: false,
+      lock: started.lock,
       onProjectionChange: this.projectionChanges.publish,
-      onCommitPhase: reportFlushGitCommitPhase,
-      onProjectionFingerprintPhase: reportFlushProjectionFingerprintPhase, onProjectionFingerprintDiagnostic: reportFlushProjectionFingerprintDiagnostic,
-      onPostCommitPhase: reportFlushPostCommitPhase,
-      ...(request.sessionId ? { sessionId: request.sessionId } : {}),
-      ...(request.commitAuthor ? { commitAuthor: request.commitAuthor } : {}),
-      ...(request.exactWriteScope ? { exactWriteScope: request.exactWriteScope } : {})
-    };
-    return request.attribution
-      ? makeJournaledWriteCoordinator({ ...common, attribution: request.attribution })
-      : makeOperationalJournaledWriteCoordinator({ ...common, operationalActor: request.operationalActor });
+      versionControlSystem: this.runtimeVersionControlSystem,
+      request
+    });
   }
 
   private startMaterializerTimer(): void {
@@ -526,28 +540,30 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
     try {
       this.requireWriterAttached();
       await this.reservationReconciler.run();
-      await this.enqueueMaterializerBatch();
+      const sessionId = this.knownPendingMaterializerSessions.values().next().value as string | undefined;
+      if (sessionId) await this.enqueueMaterializerBatch({ sessionId, priority: "recovery" });
     } catch (error) {
       this.lastMaterializerError = describeRepoRuntimeError(error);
     }
   }
 
-  private runMaterializerBatch(batchOptions: DaemonMaterializerBatchOptions): LedgerMaterializerReport {
+  private async runMaterializerBatch(batchOptions: DaemonMaterializerBatchOptions): Promise<LedgerMaterializerReport> {
     const started = this.requireWriterAttached();
-    const report = runMaterializerWithRepoWriteTelemetry(this.runtimeContext, {
-      heldGlobalLock: started.lock,
-      ...(batchOptions.dryRun ? { dryRun: true } : {}),
-      ...(batchOptions.sessionId
-        ? { sessionId: batchOptions.sessionId }
-        : { maxBranches: this.materializerMaxBranchesPerBatch })
+    return runRepoMaterializerBatch({
+      rootInput: this.runtimeContext,
+      lock: started.lock,
+      options: batchOptions,
+      maxBranches: this.materializerMaxBranchesPerBatch,
+      worker: this.materializerWorker,
+      knownPendingSessions: this.knownPendingMaterializerSessions,
+      invalidateProjection: () => this.projectionGeneration.invalidate(),
+      rememberFingerprint: (sourceHash) => rememberTrustedAuthoredProjectionFingerprint(
+        this.runtimeContext,
+        sourceHash,
+        this.runtimeVersionControlSystem
+      ),
+      setLastError: (value) => { this.lastMaterializerError = value; }
     });
-    if (report.projectionRebuilt) this.projectionGeneration.invalidate();
-    if (report.warnings.length > 0) {
-      this.lastMaterializerError = report.warnings.join("; ");
-    } else if (!batchOptions.sessionId) {
-      this.lastMaterializerError = undefined;
-    }
-    return report;
   }
 
   private stopMaterializerTimer(): void {
@@ -559,6 +575,7 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
     this.stopMaterializerTimer();
     this.projectionGeneration.reset();
     try {
+      await this.materializerWorker.stop();
       await this.closeProjectionGenerationManager();
     } catch {
       // Attach failure reporting should keep the original attach error.
@@ -572,17 +589,7 @@ class DaemonRepoRuntimeContext implements HarnessDaemonRuntime {
   }
 
   private createProjectionGenerationManager(): DaemonProjectionGenerationManager {
-    return createDaemonProjectionGenerationManager({
-      rootDir: this.rootDir,
-      ...(this.options.layoutOverrides ? { layoutOverrides: this.options.layoutOverrides } : {}),
-      ...(this.options.projectionSourceFenceFactory ? {
-        sourceFence: this.options.projectionSourceFenceFactory({
-          rootDir: this.rootDir,
-          ...(this.options.layoutOverrides ? { layoutOverrides: this.options.layoutOverrides } : {})
-        })
-      } : {}),
-      reconcileIntervalMs: this.options.projectionReconcileIntervalMs ?? defaultDaemonRuntimePolicy.projection.reconcileIntervalMs
-    });
+    return createRepoProjectionGenerationManager(this.rootDir, this.options);
   }
 
   private closeProjectionGenerationManager(): Promise<void> {

--- a/packages/daemon/src/runtime/repo-started-coordinator.ts
+++ b/packages/daemon/src/runtime/repo-started-coordinator.ts
@@ -1,10 +1,11 @@
 import {
   makeJournaledWriteCoordinator,
   makeOperationalJournaledWriteCoordinator,
+  type DaemonGlobalLock,
   type HarnessLayoutOverrides,
-  type OperationalActor
+  type OperationalActor,
+  type ProjectionChangeEvent
 } from "@harness-anything/kernel";
-import type { DaemonGlobalLock, ProjectionChangeEvent } from "@harness-anything/kernel/daemon-runtime-support";
 import type { HarnessDaemonRuntime } from "./repo-runtime-options.ts";
 import type { InteractiveWriteAttribution } from "./write-queue.ts";
 import {

--- a/packages/daemon/src/runtime/repo-started-coordinator.ts
+++ b/packages/daemon/src/runtime/repo-started-coordinator.ts
@@ -1,0 +1,47 @@
+import {
+  makeJournaledWriteCoordinator,
+  makeOperationalJournaledWriteCoordinator,
+  type HarnessLayoutOverrides,
+  type OperationalActor
+} from "@harness-anything/kernel";
+import type { DaemonGlobalLock, ProjectionChangeEvent } from "@harness-anything/kernel/daemon-runtime-support";
+import type { HarnessDaemonRuntime } from "./repo-runtime-options.ts";
+import type { InteractiveWriteAttribution } from "./write-queue.ts";
+import {
+  reportFlushGitCommitPhase,
+  reportFlushPostCommitPhase,
+  reportFlushProjectionFingerprintDiagnostic,
+  reportFlushProjectionFingerprintPhase
+} from "./repo-write-materializer-telemetry.ts";
+
+export function makeStartedRepoWriteCoordinator(input: {
+  readonly rootDir: string;
+  readonly layoutOverrides?: HarnessLayoutOverrides;
+  readonly operationalActor: OperationalActor;
+  readonly lockTtlMs: number;
+  readonly lock: DaemonGlobalLock;
+  readonly onProjectionChange: (event: ProjectionChangeEvent) => void;
+  readonly versionControlSystem: NonNullable<Parameters<typeof makeJournaledWriteCoordinator>[0]["versionControlSystem"]>;
+  readonly request: InteractiveWriteAttribution & Partial<Parameters<HarnessDaemonRuntime["createAttributedCoordinator"]>[0]>;
+}): ReturnType<typeof makeJournaledWriteCoordinator> {
+  const common = {
+    rootDir: input.rootDir,
+    layoutOverrides: input.layoutOverrides,
+    operationalActor: input.operationalActor,
+    lockTtlMs: input.lockTtlMs,
+    heldGlobalLock: input.lock,
+    autoMaterialize: false,
+    onProjectionChange: input.onProjectionChange,
+    onCommitPhase: reportFlushGitCommitPhase,
+    onProjectionFingerprintPhase: reportFlushProjectionFingerprintPhase,
+    onProjectionFingerprintDiagnostic: reportFlushProjectionFingerprintDiagnostic,
+    onPostCommitPhase: reportFlushPostCommitPhase,
+    versionControlSystem: input.versionControlSystem,
+    ...(input.request.sessionId ? { sessionId: input.request.sessionId } : {}),
+    ...(input.request.commitAuthor ? { commitAuthor: input.request.commitAuthor } : {}),
+    ...(input.request.exactWriteScope ? { exactWriteScope: input.request.exactWriteScope } : {})
+  };
+  return input.request.attribution
+    ? makeJournaledWriteCoordinator({ ...common, attribution: input.request.attribution })
+    : makeOperationalJournaledWriteCoordinator({ ...common, operationalActor: input.request.operationalActor });
+}

--- a/packages/daemon/src/runtime/repo-write-child-admission.ts
+++ b/packages/daemon/src/runtime/repo-write-child-admission.ts
@@ -1,11 +1,27 @@
 export async function runWithRepoWriteDirectAdmission<Result>(
   begin: (() => () => void) | undefined,
-  operation: () => Promise<Result>
+  operation: (release: () => void) => Promise<Result>
 ): Promise<Result> {
-  const release = begin?.();
+  const releaseAdmission = begin?.();
+  let released = false;
+  const release = (): void => {
+    if (released) return;
+    released = true;
+    releaseAdmission?.();
+  };
   try {
-    return await operation();
+    return await operation(release);
   } finally {
-    release?.();
+    release();
   }
+}
+
+export function releaseDirectAdmissionBeforeExecution<Input, Result>(
+  execute: (input: Input) => Result,
+  release: () => void
+): (input: Input) => Result {
+  return (input) => {
+    release();
+    return execute(input);
+  };
 }

--- a/packages/daemon/src/runtime/repo-write-child-admission.ts
+++ b/packages/daemon/src/runtime/repo-write-child-admission.ts
@@ -1,0 +1,11 @@
+export async function runWithRepoWriteDirectAdmission<Result>(
+  begin: (() => () => void) | undefined,
+  operation: () => Promise<Result>
+): Promise<Result> {
+  const release = begin?.();
+  try {
+    return await operation();
+  } finally {
+    release?.();
+  }
+}

--- a/packages/daemon/src/runtime/repo-write-child-contract.ts
+++ b/packages/daemon/src/runtime/repo-write-child-contract.ts
@@ -36,6 +36,8 @@ export interface RepoWriteShutdownInput {
 }
 
 export interface RepoWriteChildHostHooks {
+  /** Marks a direct frame known-pending before it waits behind the execution sequencer. */
+  readonly beginDirectAdmission?: () => () => void;
   readonly prepare: (
     input: RepoWritePrepareInput
   ) => RepoWritePreparedOperation | Promise<RepoWritePreparedOperation>;

--- a/packages/daemon/src/runtime/repo-write-child-host.ts
+++ b/packages/daemon/src/runtime/repo-write-child-host.ts
@@ -44,7 +44,7 @@ import type {
   RepoWritePreparedOperation
 } from "./repo-write-child-contract.ts";
 import { advanceRepoWritePhase } from "./repo-write-phase.ts";
-
+import { runWithRepoWriteDirectAdmission } from "./repo-write-child-admission.ts";
 export type { RepoWriteChildTransport } from "./repo-write-child-response-writer.ts";
 export type { RepoWriteDirectInput } from "./repo-write-child-direct.ts";
 export type {
@@ -56,7 +56,6 @@ export type {
   RepoWritePrepareInput,
   RepoWriteShutdownInput
 } from "./repo-write-child-contract.ts";
-
 interface HostedOperation {
   readonly requestId: string;
   state: RepoWriteHostedOperationSnapshot;
@@ -135,30 +134,32 @@ export class RepoWriteChildHost {
       );
       return;
     }
-    await executeRepoWriteChildDirect({
-      message,
-      repoId: this.options.repoId,
-      workspaceId: this.options.workspaceId,
-      generation: this.options.generation,
-      execute: executeDirect,
-      responses: this.responses,
-      sequencer: this.executionSequencer,
-      requestIds: this.directRequestIds,
-      requestIdOwnedByDurableLane: (requestId) =>
-        this.operationsByRequest.has(requestId),
-      admissionOpen: this.admissionOpen,
-      retainedRequestCount: this.retainedRequestCount(),
-      activeAdmissions: this.activeAdmissions,
-      maxRetainedOperations: this.limits.maxRetainedOperations,
-      maxAdmissions: this.limits.maxAdmissions,
-      boundaryError: this.boundaryError(message),
-      admit: () => {
-        this.activeAdmissions += 1;
-      },
-      release: () => {
-        this.activeAdmissions -= 1;
-      }
-    });
+    await runWithRepoWriteDirectAdmission(this.options.hooks.beginDirectAdmission, () =>
+      executeRepoWriteChildDirect({
+        message,
+        repoId: this.options.repoId,
+        workspaceId: this.options.workspaceId,
+        generation: this.options.generation,
+        execute: executeDirect,
+        responses: this.responses,
+        sequencer: this.executionSequencer,
+        requestIds: this.directRequestIds,
+        requestIdOwnedByDurableLane: (requestId) =>
+          this.operationsByRequest.has(requestId),
+        admissionOpen: this.admissionOpen,
+        retainedRequestCount: this.retainedRequestCount(),
+        activeAdmissions: this.activeAdmissions,
+        maxRetainedOperations: this.limits.maxRetainedOperations,
+        maxAdmissions: this.limits.maxAdmissions,
+        boundaryError: this.boundaryError(message),
+        admit: () => {
+          this.activeAdmissions += 1;
+        },
+        release: () => {
+          this.activeAdmissions -= 1;
+        }
+      })
+    );
     await this.maybeCompleteShutdown();
   }
 

--- a/packages/daemon/src/runtime/repo-write-child-host.ts
+++ b/packages/daemon/src/runtime/repo-write-child-host.ts
@@ -44,7 +44,7 @@ import type {
   RepoWritePreparedOperation
 } from "./repo-write-child-contract.ts";
 import { advanceRepoWritePhase } from "./repo-write-phase.ts";
-import { runWithRepoWriteDirectAdmission } from "./repo-write-child-admission.ts";
+import { releaseDirectAdmissionBeforeExecution, runWithRepoWriteDirectAdmission } from "./repo-write-child-admission.ts";
 export type { RepoWriteChildTransport } from "./repo-write-child-response-writer.ts";
 export type { RepoWriteDirectInput } from "./repo-write-child-direct.ts";
 export type {
@@ -134,13 +134,13 @@ export class RepoWriteChildHost {
       );
       return;
     }
-    await runWithRepoWriteDirectAdmission(this.options.hooks.beginDirectAdmission, () =>
+    await runWithRepoWriteDirectAdmission(this.options.hooks.beginDirectAdmission, (releaseAdmission) =>
       executeRepoWriteChildDirect({
         message,
         repoId: this.options.repoId,
         workspaceId: this.options.workspaceId,
         generation: this.options.generation,
-        execute: executeDirect,
+        execute: releaseDirectAdmissionBeforeExecution(executeDirect, releaseAdmission),
         responses: this.responses,
         sequencer: this.executionSequencer,
         requestIds: this.directRequestIds,

--- a/packages/daemon/src/runtime/repo-write-diagnostic-protocol.ts
+++ b/packages/daemon/src/runtime/repo-write-diagnostic-protocol.ts
@@ -100,6 +100,7 @@ export const repoWriteTelemetryPhases = [
   "authority-materializer-projection-attribution-decision-v1-v2-precedence",
   "authority-materializer-projection-attribution-decision-replay",
   "authority-materializer-projection-attribution-decision-new-source-path",
+  "authority-materializer-projection-attribution-decision-append-batch",
   "authority-materializer-projection-attribution-decision-v1-to-v2-replacement",
   "authority-materializer-projection-attribution-decision-op-id-collision",
   "authority-materializer-projection-attribution-decision-other",

--- a/packages/daemon/src/runtime/repo-write-durable-operation-controller.ts
+++ b/packages/daemon/src/runtime/repo-write-durable-operation-controller.ts
@@ -116,6 +116,10 @@ export class RepoWriteDurableOperationController {
     }
   }
 
+  hasActiveSettlement(outerOpId: string): boolean {
+    return this.activeSettlements.has(outerOpId);
+  }
+
   async recoverCanonicalPublicationSettlement(input: {
     readonly outerOpId: string;
     readonly canonicalCommitSha: string;

--- a/packages/daemon/src/runtime/repo-write-materializer-telemetry.ts
+++ b/packages/daemon/src/runtime/repo-write-materializer-telemetry.ts
@@ -1,5 +1,4 @@
 import {
-  runLedgerMaterializer,
   type IncrementalProjectionPhase,
   type IncrementalProjectionDiagnostic,
   type IncrementalProjectionRebuildReason,
@@ -88,6 +87,7 @@ const attributionDecisionReasons: Record<AttributionProjectionDecisionReason, Re
   "v1-v2-precedence": "authority-materializer-projection-attribution-decision-v1-v2-precedence",
   replay: "authority-materializer-projection-attribution-decision-replay",
   "new-source-path": "authority-materializer-projection-attribution-decision-new-source-path",
+  "append-batch": "authority-materializer-projection-attribution-decision-append-batch",
   "v1-to-v2-replacement": "authority-materializer-projection-attribution-decision-v1-to-v2-replacement",
   "op-id-collision": "authority-materializer-projection-attribution-decision-op-id-collision",
   other: "authority-materializer-projection-attribution-decision-other"
@@ -248,9 +248,11 @@ function reportProjectionDiagnostic(
   );
 }
 
-export function reportMaterializerProjectionDiagnostic(
-  diagnostic: IncrementalProjectionDiagnostic
-): void {
+export function reportMaterializerProjectionDiagnostic(diagnostic: ProjectionDiagnostic): void {
+  if (diagnostic.kind === "cache" || diagnostic.kind === "advance") {
+    reportProjectionDiagnostic(diagnostic, "materializer");
+    return;
+  }
   reportCurrentRepoWriteTelemetry(
     "authority-materializer-projection-source-summary",
     sourceSummaryDetails(diagnostic.summary)
@@ -295,43 +297,4 @@ function sourceSummaryDetails(summary: ProjectionSourceSummary): RepoWriteTeleme
     legacyPersonIdsHash: summary.legacyPersonIdsHash,
     fingerprint: summary.fingerprint
   };
-}
-
-export function runMaterializerWithRepoWriteTelemetry(
-  rootInput: Parameters<typeof runLedgerMaterializer>[0],
-  options: NonNullable<Parameters<typeof runLedgerMaterializer>[1]> = {}
-): ReturnType<typeof runLedgerMaterializer> {
-  reportCurrentRepoWriteTelemetry("authority-materializer-start");
-  try {
-    return runLedgerMaterializer(rootInput, {
-      ...options,
-      onProgress: (step) => {
-        reportCurrentRepoWriteTelemetry(materializerProgressPhase(step));
-        options.onProgress?.(step);
-      },
-      onProjectionPhase: (phase) => {
-        reportCurrentRepoWriteTelemetry(materializerProjectionPhase(phase));
-        options.onProjectionPhase?.(phase);
-      },
-      onProjectionMode: (mode, reason) => {
-        reportCurrentRepoWriteTelemetry(materializerProjectionModePhase(mode));
-        if (reason) reportCurrentRepoWriteTelemetry(materializerProjectionRebuildReasonPhase(reason));
-        options.onProjectionMode?.(mode, reason);
-      },
-      onProjectionDiagnostic: (diagnostic) => {
-        if (diagnostic.kind === "cache" || diagnostic.kind === "advance") {
-          reportProjectionDiagnostic(diagnostic, "materializer");
-        } else {
-          reportMaterializerProjectionDiagnostic(diagnostic);
-        }
-        options.onProjectionDiagnostic?.(diagnostic);
-      },
-      onProjectionAttributionDecision: (reason) => {
-        reportCurrentRepoWriteTelemetry(materializerAttributionDecisionPhase(reason));
-        options.onProjectionAttributionDecision?.(reason);
-      }
-    });
-  } finally {
-    reportCurrentRepoWriteTelemetry("authority-materializer-end");
-  }
 }

--- a/packages/daemon/src/runtime/repo-write-stall-diagnostic.ts
+++ b/packages/daemon/src/runtime/repo-write-stall-diagnostic.ts
@@ -201,6 +201,7 @@ export function repoWriteWaitingStage(
     case "authority-materializer-projection-attribution-decision-v1-v2-precedence":
     case "authority-materializer-projection-attribution-decision-replay":
     case "authority-materializer-projection-attribution-decision-new-source-path":
+    case "authority-materializer-projection-attribution-decision-append-batch":
     case "authority-materializer-projection-attribution-decision-v1-to-v2-replacement":
     case "authority-materializer-projection-attribution-decision-op-id-collision":
     case "authority-materializer-projection-attribution-decision-other":

--- a/packages/daemon/src/runtime/repo-write-telemetry-context.ts
+++ b/packages/daemon/src/runtime/repo-write-telemetry-context.ts
@@ -65,12 +65,12 @@ export async function executeRepoWriteChildWithTelemetry<Result>(
   });
 }
 
-export function bindCurrentRepoWriteTelemetry<Result>(
-  operation: () => Result
-): () => Result {
+export function bindCurrentRepoWriteTelemetry<Arguments extends ReadonlyArray<unknown>, Result>(
+  operation: (...args: Arguments) => Result
+): (...args: Arguments) => Result {
   const current = storage.getStore();
   return current
-    ? () => storage.run(current, operation)
+    ? (...args) => storage.run(current, () => operation(...args))
     : operation;
 }
 

--- a/packages/daemon/test/authority-generation-publication-cut.test.ts
+++ b/packages/daemon/test/authority-generation-publication-cut.test.ts
@@ -10,11 +10,18 @@ import {
   createInMemoryReplicaChangeLog
 } from "@harness-anything/application";
 import { taskEntityId, withExactCommit, type WriteAttribution } from "@harness-anything/kernel";
+import { createSerialPublicationExecutor } from "../src/authority/production/serial-publication-executor.ts";
+import {
+  captureCurrentAuthorityDurableAcceptanceReporter,
+  runWithAuthorityDurableAcceptance
+} from "../src/runtime/authority-durable-acceptance-context.ts";
 
 test("generation exclusion ends at durable replica cut before derived terminal evidence", async () => {
   const memory = createInMemoryAuthorityOperationRegistry();
   const changeLog = createInMemoryReplicaChangeLog();
   let generationLockDepth = 0;
+  const terminalGate = deferred<void>();
+  const accepted = deferred<void>();
   const registry = {
     get: memory.get,
     list: memory.list,
@@ -33,10 +40,17 @@ test("generation exclusion ends at durable replica cut before derived terminal e
       create: ({ exactWriteScope }) => withExactCommit({
         enqueue: (operation) => Effect.succeed({ opId: operation.opId, entityId: operation.entityId, accepted: true as const }),
         recover: Effect.succeed({ replayedOps: 0 })
-      }, (reason) => {
+      }, (reason) => Effect.promise(async () => {
         assert.equal(generationLockDepth > 0, true, "canonical flush escaped the generation exclusion");
-        return Effect.succeed({ reason, opCount: 1, committed: true });
-      }, exactWriteScope)
+        const flush = { reason, opCount: 1, committed: true as const, watermark: "op-flush-lock" };
+        captureCurrentAuthorityDurableAcceptanceReporter()?.({
+          sessionId: "session-generation",
+          acceptedCommitSha: "a".repeat(40),
+          flush
+        });
+        await terminalGate.promise;
+        return flush;
+      }), exactWriteScope)
     },
     tokenVerifier: validLegacyVerifier("workspace-flush-lock"),
     operationRegistry: registry,
@@ -62,10 +76,18 @@ test("generation exclusion ends at durable replica cut before derived terminal e
           generationLockDepth -= 1;
         }
       }
-    }
+    },
+    publicationExecutor: createSerialPublicationExecutor()
   });
 
-  const receipt = await service.submit(legacyEnvelope("workspace-flush-lock", "op-flush-lock"));
+  const submission = runWithAuthorityDurableAcceptance({
+    accept: () => accepted.resolve()
+  }, () => service.submit(legacyEnvelope("workspace-flush-lock", "op-flush-lock")));
+  await accepted.promise;
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(generationLockDepth, 0, "generation exclusion outlived the durable session cut");
+  terminalGate.resolve();
+  const receipt = await submission;
   assert.equal(receipt.tag, "COMMITTED");
   assert.equal(generationLockDepth, 0);
 });
@@ -87,6 +109,14 @@ function legacyEnvelope(workspaceId: string, opId: string) {
     protocol: authorityProtocolTuple
   };
   return { ...envelope, claimedDigest: canonicalAuthorityRequestDigest(envelope) };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
 }
 
 function validLegacyVerifier(workspaceId: string) {

--- a/packages/daemon/test/authority-publication-acceptance.test.ts
+++ b/packages/daemon/test/authority-publication-acceptance.test.ts
@@ -61,6 +61,54 @@ test("durable acceptance is observable while canonical reads still expose the pr
   assert.equal(canonicalValue, "new");
 });
 
+test("canonical materialization waits for admitted successors before taking the background queue", async () => {
+  const gate = deferred<void>();
+  const gateEntered = deferred<void>();
+  let enqueueCount = 0;
+  const queue = {
+    enqueueBackground: async <Result>(request: { readonly run: () => Promise<Result> | Result }) => {
+      enqueueCount += 1;
+      return request.run();
+    }
+  } as unknown as DaemonWriteQueue;
+
+  const settlement = enqueueDaemonAuthorityPublication(
+    queue,
+    {
+      sessionId: "session-quiet-gate",
+      publish: async () => ({
+        reason: "explicit",
+        opCount: 1,
+        committed: true,
+        watermark: "watermark-quiet-gate"
+      })
+    },
+    () => ({
+      dryRun: false,
+      merged: 1,
+      considered: 1,
+      branches: [],
+      warnings: [],
+      projectionRebuilt: false,
+      attributionEventsProjected: 0
+    }),
+    () => "b".repeat(40),
+    () => "c".repeat(40),
+    async (run) => {
+      gateEntered.resolve();
+      await gate.promise;
+      return queue.enqueueBackground({ source: "test-materializer", run });
+    }
+  );
+
+  await gateEntered.promise;
+  assert.equal(enqueueCount, 1, "only the durable publication may enter before the quiet gate");
+  gate.resolve();
+  const report = await settlement;
+  assert.equal(enqueueCount, 2);
+  assert.equal(report.canonicalCommitSha, "c".repeat(40));
+});
+
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
   const promise = new Promise<T>((complete) => {

--- a/packages/daemon/test/daemon-writer-reader-cutover.test.ts
+++ b/packages/daemon/test/daemon-writer-reader-cutover.test.ts
@@ -226,6 +226,57 @@ integrationTest("task create and doc sync return durable acceptance before canon
   assert.ok(docSync.wallMs < 2_500, `doc sync acceptance took ${docSync.wallMs}ms`);
 });
 
+integrationTest("three concurrent production writes all reach durable acceptance and canonical visibility", {
+  timeout: 90_000
+}, async (t) => {
+  const probe = await startProbe();
+  t.after(() => probe.close());
+  const session = {
+    runtime: "codex" as const,
+    sessionId: "receipt-tiering-three-concurrent",
+    source: "runtime" as const,
+    detectedAt: "2026-08-09T00:00:00.000Z"
+  };
+  const warmClient = await probe.openClient();
+  const warm = await requestTaskCreate(warmClient, probe.repoRoot, session, "Three concurrent warmup");
+  assert.equal(warm.receipt.ok, true, JSON.stringify(warm.receipt));
+  await waitForReceiptVisible(warmClient, settlementOf(warm.receipt).receiptId);
+
+  const clients = await Promise.all([probe.openClient(), probe.openClient(), probe.openClient()]);
+  const started = performance.now();
+  const results = await Promise.all(clients.map((client, index) =>
+    requestTaskCreate(client, probe.repoRoot, session, `Three concurrent ${index + 1}`)
+  ));
+  const batchWallMs = performance.now() - started;
+  for (const result of results) {
+    assert.equal(result.receipt.ok, true, JSON.stringify(result.receipt));
+    assert.equal(settlementOf(result.receipt).canonicalVisibility, "pending");
+  }
+  await Promise.all(results.map((result, index) =>
+    waitForReceiptVisible(clients[index]!, settlementOf(result.receipt).receiptId, 30_000)
+  ));
+  const logs = await request(
+    warmClient,
+    "repo.daemon.logs.list",
+    repoParams({ limit: 1_000 }),
+    10_000
+  );
+  t.diagnostic(JSON.stringify({
+    schema: "receipt-tiering-three-concurrent/v2",
+    warmWallMs: warm.wallMs,
+    batchWallMs,
+    requestWallMs: results.map((result) => result.wallMs),
+    gitCalls: gitCallSummary(probe.gitCalls()),
+    performance: performanceLogMessages(logs.receipt)
+  }));
+  for (const result of results) {
+    assert.ok(
+      result.wallMs < 10_000,
+      `concurrent durable acceptance exceeded 10s: ${result.wallMs.toFixed(1)}ms`
+    );
+  }
+});
+
 async function requestTaskCreate(
   client: JsonRpcLineClient,
   repoRoot: string,
@@ -279,6 +330,7 @@ interface Probe {
   readonly arm: () => void;
   readonly waitForAmplifier: () => Promise<void>;
   readonly openClient: () => Promise<JsonRpcLineClient>;
+  readonly gitCalls: () => ReadonlyArray<ReadonlyArray<string>>;
   readonly close: () => Promise<void>;
 }
 
@@ -330,6 +382,7 @@ async function startProbe(): Promise<Probe> {
       HA_WRITER_READER_ARM: amplifier.armPath,
       HA_WRITER_READER_HIT: amplifier.hitPath,
       HA_WRITER_READER_REAL_GIT: amplifier.realGit,
+      HA_WRITER_READER_GIT_LOG: amplifier.logPath,
       HA_WRITER_READER_CHECKOUT_ROOT: process.cwd()
     }, inheritedEnv),
     stdio: ["pipe", "pipe", "pipe"]
@@ -394,6 +447,10 @@ async function startProbe(): Promise<Probe> {
         + ` stdout=${stdout} stderr=${stderr}`
       );
     },
+    gitCalls: () => existsSync(amplifier.logPath)
+      ? readFileSync(amplifier.logPath, "utf8").trim().split("\n").filter(Boolean)
+        .map((line) => JSON.parse(line) as ReadonlyArray<string>)
+      : [],
     close: async () => {
       for (const client of clients) client.close();
       await stopDaemon(daemon);
@@ -416,21 +473,24 @@ function installGitAmplifier(root: string): {
   readonly armPath: string;
   readonly binDir: string;
   readonly hitPath: string;
+  readonly logPath: string;
   readonly realGit: string;
 } {
   const binDir = path.join(root, "probe-bin");
   const armPath = path.join(root, "git-amplifier.arm");
   const hitPath = path.join(root, "git-amplifier.hit");
+  const logPath = path.join(root, "git-calls.jsonl");
   const realGit = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
   const wrapperPath = path.join(binDir, "git");
   mkdirSync(binDir, { recursive: true, mode: 0o700 });
   writeFileSync(wrapperPath, [
     "#!/usr/bin/env node",
     '"use strict";',
-    'const { closeSync, existsSync, openSync } = require("node:fs");',
+    'const { appendFileSync, closeSync, existsSync, openSync } = require("node:fs");',
     'const { spawnSync } = require("node:child_process");',
     "const args = process.argv.slice(2);",
     "const env = process.env;",
+    'appendFileSync(env.HA_WRITER_READER_GIT_LOG, `${JSON.stringify(args)}\\n`);',
     'if ((args.includes("commit") || args.includes("commit-tree")) && existsSync(env.HA_WRITER_READER_ARM ?? "") && !existsSync(env.HA_WRITER_READER_HIT ?? "")) {',
     '  closeSync(openSync(env.HA_WRITER_READER_HIT, "wx", 0o600));',
     `  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ${amplifierDelayMs});`,
@@ -442,7 +502,26 @@ function installGitAmplifier(root: string): {
     ""
   ].join("\n"), { encoding: "utf8", mode: 0o700 });
   chmodSync(wrapperPath, 0o700);
-  return { armPath, binDir, hitPath, realGit };
+  return { armPath, binDir, hitPath, logPath, realGit };
+}
+
+function gitCallSummary(calls: ReadonlyArray<ReadonlyArray<string>>): Readonly<Record<string, number>> {
+  const counts: Record<string, number> = {};
+  for (const args of calls) {
+    let command = "unknown";
+    for (let index = 0; index < args.length; index += 1) {
+      const arg = args[index]!;
+      if (["-C", "-c", "--git-dir", "--work-tree"].includes(arg)) {
+        index += 1;
+        continue;
+      }
+      if (arg.startsWith("-")) continue;
+      command = arg;
+      break;
+    }
+    counts[command] = (counts[command] ?? 0) + 1;
+  }
+  return counts;
 }
 
 function installCheckoutLoader(root: string): string {
@@ -500,7 +579,8 @@ function settlementOf(receipt: JsonObject): {
 
 async function waitForReceiptVisible(
   client: JsonRpcLineClient,
-  receiptId: string
+  receiptId: string,
+  timeoutMs = 10_000
 ): Promise<void> {
   let latest = "unknown";
   let latestData = "unknown";
@@ -516,7 +596,7 @@ async function waitForReceiptVisible(
       : "invalid";
     latestData = JSON.stringify(data);
     return latest === "committed";
-  }, 10_000, () => `receipt ${receiptId} remained ${latest}: ${latestData}`);
+  }, timeoutMs, () => `receipt ${receiptId} remained ${latest}: ${latestData}`);
 }
 
 function percentile95(samples: ReadonlyArray<number>): number {

--- a/packages/daemon/test/production-progress-append-operation.test.ts
+++ b/packages/daemon/test/production-progress-append-operation.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import test from "node:test";
 import {
   makeTaskHolderService,
+  resolveHarnessLayout,
   taskHolderActor
 } from "@harness-anything/kernel";
 import {
@@ -139,14 +140,15 @@ operationTest("progress pilot orders outer fsync before read-only lease and inne
     }));
     assert.equal(terminal.innerOpId, "inner-progress-operation");
     assert.equal(readFileSync(holderPath, "utf8"), holderBefore);
+    await host.settlementIdle();
     assert.deepEqual(events, [
       "plan-fixed-attempt",
       "parent-proceed",
       "outer-proceeding-fsynced",
       "inner-submit",
-      "runtime-event-write",
       "outer-terminal-fsynced"
     ]);
+    assert.deepEqual(runtimeEventTools(fixture.repoRoot, "session-progress-operation"), ["progress-append"]);
     assert.equal(terminal.receipt.meta.generatedAt, "2026-07-24T00:00:00.000Z");
     assert.equal(terminal.receipt.details?.actor?.personId, actor.personId);
     assert.deepEqual(terminal.receipt.details?.data?.repoWrite, {
@@ -306,7 +308,7 @@ operationTest("progress pilot resumes one exact fixed attempt after a post-PROCE
     assert.equal(proceeding.state, "proceeding");
     if (proceeding.state !== "proceeding") return;
 
-    const terminal = await operationHost(
+    const recoveryHost = operationHost(
       durable,
       authorityComponent(events, {
         outerOpId: prepared.opId,
@@ -314,7 +316,9 @@ operationTest("progress pilot resumes one exact fixed attempt after a post-PROCE
       }),
       events,
       outcomeDirectory
-    ).lookup({ opId: prepared.opId });
+    );
+    const terminal = await recoveryHost.lookup({ opId: prepared.opId });
+    await recoveryHost.settlementIdle();
 
     assert.equal(terminal.state, "terminal");
     if (terminal.state !== "terminal") return;
@@ -323,9 +327,9 @@ operationTest("progress pilot resumes one exact fixed attempt after a post-PROCE
     assert.deepEqual(events, [
       "plan-fixed-attempt",
       "outer-proceeding-fsynced",
-      "inner-submit-recovery",
-      "runtime-event-write"
+      "inner-submit-recovery"
     ]);
+    assert.deepEqual(runtimeEventTools(fixture.repoRoot, "session-progress-recovery"), ["progress-append"]);
   } finally {
     rmSync(outcomeDirectory, { recursive: true, force: true });
     rmSync(fixture.root, { recursive: true, force: true });
@@ -667,6 +671,13 @@ function durabilityEvents(events: string[]) {
       target = "";
     }
   };
+}
+
+function runtimeEventTools(rootDir: string, sessionId: string): Array<unknown> {
+  const body = readFileSync(resolveHarnessLayout(rootDir).runtimeEventLedgerPath(sessionId), "utf8");
+  return body.trim().split("\n").map((line) => (
+    (JSON.parse(line) as { readonly tool?: { readonly toolName?: unknown } }).tool?.toolName
+  ));
 }
 
 function axes() {

--- a/packages/daemon/test/receipt-tiering-adversarial.test.ts
+++ b/packages/daemon/test/receipt-tiering-adversarial.test.ts
@@ -122,11 +122,11 @@ test("settlement status wire accepts a pending failure receipt with partial dura
   );
 });
 
-test("two batched publications in one command release the serial slot at durable acceptance", async () => {
+test("two batched publications in one command release the serial slot at the explicit replica cut", async () => {
   const executor = createSerialPublicationExecutor();
   const settled: string[] = [];
   const publications = new BoundedAuthorityBatcher<number, AuthorityOperationReceipt>(
-    (indexes) => executor.run(async () => {
+    (indexes) => executor.run(async (execution) => {
       const index = indexes[0]!;
       reportCurrentAuthorityDurableAcceptance(
         `session-${index}`,
@@ -138,6 +138,7 @@ test("two batched publications in one command release the serial slot at durable
           watermark: `op-${index}`
         }
       );
+      execution.reportDurableCut?.();
       await waitForCurrentAuthoritySettlementRelease();
       settled.push(`op-${index}`);
       return [committedReceipt(`op-${index}`)];
@@ -163,6 +164,70 @@ test("two batched publications in one command release the serial slot at durable
   ]), "accepted");
   await new Promise<void>((resolve) => setImmediate(() => setImmediate(resolve)));
   assert.deepEqual(settled, ["op-1", "op-2"]);
+});
+
+test("a different command enters after the durable cut while prior settlement remains pending", async () => {
+  const executor = createSerialPublicationExecutor();
+  const firstSettlement = deferred<void>();
+  const executionContexts: Array<{ allowDurableSuccessor: boolean }> = [];
+  const first = durableAuthoritySubmissionFromSettlement(() => executor.run(async (execution) => {
+    executionContexts.push(execution);
+    reportCurrentAuthorityDurableAcceptance(
+      "session-first",
+      "1".repeat(40),
+      { reason: "explicit", opCount: 1, committed: true, watermark: "op-first" }
+    );
+    execution.reportDurableCut?.();
+    await firstSettlement.promise;
+    return committedReceipt("op-first");
+  }));
+  assert.equal((await first.admission).kind, "accepted");
+
+  const second = durableAuthoritySubmissionFromSettlement(() => executor.run(async (execution) => {
+    executionContexts.push(execution);
+    reportCurrentAuthorityDurableAcceptance(
+      "session-second",
+      "2".repeat(40),
+      { reason: "explicit", opCount: 1, committed: true, watermark: "op-second" }
+    );
+    execution.reportDurableCut?.();
+    return committedReceipt("op-second");
+  }));
+  const secondAdmission = await Promise.race([
+    second.admission,
+    new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 100))
+  ]);
+
+  assert.notEqual(secondAdmission, "timeout");
+  assert.equal(executionContexts.length, 2);
+  assert.equal(executionContexts[0]?.allowDurableSuccessor, true);
+  assert.equal(executionContexts[1]?.allowDurableSuccessor, true);
+  firstSettlement.resolve();
+  await Promise.all([first.settlement, second.settlement]);
+});
+
+test("the explicit session-durable cut releases batching even when no outer acceptance context is active", async () => {
+  const executor = createSerialPublicationExecutor();
+  const firstSettlement = deferred<void>();
+  let secondEntered = false;
+  const first = executor.run(async (execution) => {
+    execution.reportDurableCut?.();
+    await firstSettlement.promise;
+    return "first";
+  });
+
+  const second = executor.run(async (execution) => {
+    secondEntered = true;
+    execution.reportDurableCut?.();
+    return "second";
+  });
+  assert.equal(await Promise.race([
+    second,
+    new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 100))
+  ]), "second");
+  assert.equal(secondEntered, true);
+  firstSettlement.resolve();
+  assert.equal(await first, "first");
 });
 
 function committedReceipt(opId = "op-queued"): AuthorityOperationReceipt {

--- a/packages/daemon/test/repo-write-child-admission.test.ts
+++ b/packages/daemon/test/repo-write-child-admission.test.ts
@@ -1,0 +1,34 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  releaseDirectAdmissionBeforeExecution,
+  runWithRepoWriteDirectAdmission
+} from "../src/runtime/repo-write-child-admission.ts";
+
+test("direct admission releases at the execution boundary before foreground continuation", async () => {
+  let activeAdmissions = 0;
+  const events: string[] = [];
+
+  await runWithRepoWriteDirectAdmission(
+    () => {
+      activeAdmissions += 1;
+      events.push("admitted");
+      return () => {
+        activeAdmissions -= 1;
+        events.push("released");
+      };
+    },
+    async (release) => {
+      assert.equal(activeAdmissions, 1, "the admission marker protects the sequencer wait");
+      const execute = releaseDirectAdmissionBeforeExecution(async () => {
+        assert.equal(activeAdmissions, 0, "foreground continuation must not wait on its own admission");
+        events.push("executed");
+      }, release);
+      await execute(undefined);
+    }
+  );
+
+  assert.equal(activeAdmissions, 0);
+  assert.deepEqual(events, ["admitted", "released", "executed"]);
+});

--- a/packages/daemon/test/repo-write-runtime-event-early-return.test.ts
+++ b/packages/daemon/test/repo-write-runtime-event-early-return.test.ts
@@ -29,6 +29,8 @@ import { resolveHarnessLayout } from "@harness-anything/kernel";
 const operationTest = process.platform === "win32" ? test.skip : test;
 
 operationTest("task create responds before its lightweight auto runtime-event append", async (t) => {
+  // Keep one-time command/schema initialization out of the steady-state tail comparison.
+  await runTaskCreate(0);
   const fast = await runTaskCreate(0);
   const slow = await runTaskCreate(180);
 
@@ -91,7 +93,7 @@ async function runTaskCreate(materializerDelayMs: number, failReason?: string) {
       outcomeDirectory,
       undefined,
       false,
-      { materializerDelayMs, timing: runtimeEventTiming, failures, ...(failReason ? { failReason } : {}) }
+      { materializerDelayMs, timing: runtimeEventTiming, failures }
     );
     const child = createRepoWriteChildHost({
       ...productionProgressOperationAxes(),

--- a/packages/daemon/test/repo-write-runtime-event-early-return.test.ts
+++ b/packages/daemon/test/repo-write-runtime-event-early-return.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -24,26 +24,21 @@ import {
   productionProgressOperationHost,
   slowFailedDirectAuthorityComponent
 } from "./support/production-progress-operation-fixture.ts";
+import { resolveHarnessLayout } from "@harness-anything/kernel";
 
 const operationTest = process.platform === "win32" ? test.skip : test;
 
-operationTest("task create responds before its auto runtime-event append and attached materializer tail", async (t) => {
+operationTest("task create responds before its lightweight auto runtime-event append", async (t) => {
   const fast = await runTaskCreate(0);
   const slow = await runTaskCreate(180);
 
   assert.equal(fast.response.settlement?.canonicalVisibility, "pending");
   assert.equal(slow.response.settlement?.canonicalVisibility, "pending");
   assert.equal(typeof slow.response.settlement?.statusQuery, "object");
-  assert.deepEqual(
-    slow.events.filter((event) => event === "runtime-event-write"),
-    ["runtime-event-write"]
-  );
-  assert.ok(slow.runtimeEventTiming.startedAt !== undefined);
-  assert.ok(slow.runtimeEventTiming.finishedAt !== undefined);
-  assert.ok(
-    slow.responseAt < slow.runtimeEventTiming.startedAt,
-    `response at ${slow.responseMs.toFixed(1)}ms followed runtime-event append at ${(slow.runtimeEventTiming.startedAt - slow.startedAt).toFixed(1)}ms`
-  );
+  assert.deepEqual(slow.events.filter((event) => event === "runtime-event-write"), []);
+  assert.equal(slow.runtimeEventPresentAtResponse, false);
+  assert.equal(slow.runtimeEvents.length, 1);
+  assert.equal(slow.runtimeEvents[0]?.kind, "result");
   assert.ok(
     Math.abs(slow.responseMs - fast.responseMs) < 90,
     `180ms runtime-event materializer changed acceptance latency from ${fast.responseMs.toFixed(1)}ms to ${slow.responseMs.toFixed(1)}ms`
@@ -51,8 +46,8 @@ operationTest("task create responds before its auto runtime-event append and att
   t.diagnostic(JSON.stringify({
     fastResponseMs: fast.responseMs,
     slowResponseMs: slow.responseMs,
-    runtimeEventStartedAfterMs: slow.runtimeEventTiming.startedAt - slow.startedAt,
-    runtimeEventFinishedAfterMs: slow.runtimeEventTiming.finishedAt - slow.startedAt
+    runtimeEventPresentAtResponse: slow.runtimeEventPresentAtResponse,
+    runtimeEventCountAfterDrain: slow.runtimeEvents.length
   }));
 });
 
@@ -60,12 +55,11 @@ operationTest("a post-response runtime-event append failure is surfaced and drai
   const run = await runTaskCreate(20, "simulated runtime-event append failure");
 
   assert.equal(run.response.settlement?.canonicalVisibility, "pending");
-  assert.ok(run.runtimeEventTiming.startedAt !== undefined);
-  assert.ok(run.responseAt < run.runtimeEventTiming.startedAt);
+  assert.equal(run.runtimeEventPresentAtResponse, false);
   assert.equal(run.failures.length, 1);
   assert.equal(run.failures[0]?.requestId, "request-task-create-early-return");
   assert.equal(run.failures[0]?.command, "new-task");
-  assert.match(run.failures[0]?.reason ?? "", /simulated runtime-event append failure/u);
+  assert.match(run.failures[0]?.reason ?? "", /EEXIST|not a directory/iu);
 });
 
 async function runTaskCreate(materializerDelayMs: number, failReason?: string) {
@@ -76,7 +70,15 @@ async function runTaskCreate(materializerDelayMs: number, failReason?: string) {
   const settlementTiming: { startedAt?: number; finishedAt?: number } = {};
   const runtimeEventTiming: { startedAt?: number; finishedAt?: number } = {};
   const failures: Array<{ readonly requestId: string; readonly command: string; readonly reason: string }> = [];
+  let runtimeEventPresentAtResponse = false;
   try {
+    const sessionId = `session-task-create-runtime-tail-${materializerDelayMs}`;
+    const runtimeEventPath = resolveHarnessLayout(fixture.repoRoot).runtimeEventLedgerPath(sessionId);
+    if (failReason) {
+      const ledgerRoot = path.dirname(runtimeEventPath);
+      mkdirSync(path.dirname(ledgerRoot), { recursive: true });
+      writeFileSync(ledgerRoot, failReason, "utf8");
+    }
     const actor = productionAuthorityActor();
     const store = new DurableRepoWriteOutcomeStoreV1({
       directory: outcomeDirectory,
@@ -97,6 +99,7 @@ async function runTaskCreate(materializerDelayMs: number, failReason?: string) {
       transport: {
         send: async (frame) => {
           messages.push({ frame, at: performance.now() });
+          if (frame.kind === "direct-result") runtimeEventPresentAtResponse = existsSync(runtimeEventPath);
         }
       },
       hooks: {
@@ -115,7 +118,7 @@ async function runTaskCreate(materializerDelayMs: number, failReason?: string) {
         authorityConnection: productionAuthorityConnection(actor),
         currentSession: {
           runtime: "codex",
-          sessionId: `session-task-create-runtime-tail-${materializerDelayMs}`,
+          sessionId,
           source: "manual",
           detectedAt: "2026-08-10T00:00:00.000Z"
         },
@@ -137,6 +140,10 @@ async function runTaskCreate(materializerDelayMs: number, failReason?: string) {
       responseAt: delivered.at,
       responseMs: delivered.at - startedAt,
       runtimeEventTiming,
+      runtimeEventPresentAtResponse,
+      runtimeEvents: existsSync(runtimeEventPath)
+        ? readFileSync(runtimeEventPath, "utf8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line) as Record<string, unknown>)
+        : [],
       failures,
       startedAt
     };

--- a/packages/daemon/test/runtime/materializer-runtime.test.ts
+++ b/packages/daemon/test/runtime/materializer-runtime.test.ts
@@ -32,6 +32,29 @@ const deterministicProjectionSourceFenceFactory: ProjectionSourceFenceFactory = 
   return { capture: () => fence };
 };
 
+test("daemon runtime does not run an empty materializer poll without known pending work", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    let reconciliations = 0;
+    const runtime = createMultiRepoDaemonRuntime({
+      repos: [{
+        repoId: "empty",
+        rootDir,
+        reservationReconciler: async () => {
+          reconciliations += 1;
+        }
+      }],
+      materializerPollMs: 10
+    });
+
+    await runtime.start();
+    await new Promise<void>((resolve) => setTimeout(resolve, 500));
+
+    assert.ok(reconciliations > 1, `expected periodic reconciliation, saw ${reconciliations}`);
+    assert.equal(runtime.status().repos[0]?.lastMaterializerError, undefined);
+    await runtime.stop();
+  });
+});
+
 test("daemon materializer producer runs bounded batches under the lifetime global lock", async () => {
   await withTempStoreAsync(async (rootDir) => {
     initAuthoredGit(rootDir);

--- a/packages/daemon/test/runtime/repo-materializer-worker.test.ts
+++ b/packages/daemon/test/runtime/repo-materializer-worker.test.ts
@@ -1,0 +1,71 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  RepoMaterializerWorker,
+  type RepoMaterializerWorkerPort
+} from "../../src/runtime/repo-materializer-worker.ts";
+
+const emptyReport = {
+  dryRun: false,
+  merged: 0,
+  considered: 0,
+  branches: [],
+  warnings: [],
+  projectionRebuilt: false,
+  attributionEventsProjected: 0
+} as const;
+
+test("live materialization overtakes timed-out recovery work still queued in the worker", async () => {
+  const port = new ControlledMaterializerWorkerPort();
+  const worker = new RepoMaterializerWorker(() => port);
+
+  const activeRecovery = worker.run("/fixture", {}, {}, "recovery");
+  const queuedRecovery = worker.run("/fixture", {}, {}, "recovery");
+  const liveSettlement = worker.run("/fixture", {}, {}, "foreground");
+
+  assert.deepEqual(port.startedJobIds(), [1]);
+  port.complete(1);
+  await activeRecovery;
+  assert.deepEqual(port.startedJobIds(), [1, 3]);
+
+  port.complete(3);
+  await liveSettlement;
+  assert.deepEqual(port.startedJobIds(), [1, 3, 2]);
+
+  port.complete(2);
+  await queuedRecovery;
+  await worker.stop();
+});
+
+class ControlledMaterializerWorkerPort implements RepoMaterializerWorkerPort {
+  private readonly listeners = new Map<string, Array<(value: unknown) => void>>();
+  private readonly posted: unknown[] = [];
+
+  readonly postMessage = (value: unknown): void => {
+    this.posted.push(value);
+  };
+
+  readonly terminate = async (): Promise<number> => 0;
+
+  readonly on = (event: "message" | "error" | "exit", listener: (value: unknown) => void): this => {
+    const listeners = this.listeners.get(event) ?? [];
+    listeners.push(listener);
+    this.listeners.set(event, listeners);
+    return this;
+  };
+
+  startedJobIds(): number[] {
+    return this.posted.map((message) => Number(
+      typeof message === "object" && message !== null && "jobId" in message
+        ? message.jobId
+        : Number.NaN
+    ));
+  }
+
+  complete(jobId: number): void {
+    for (const listener of this.listeners.get("message") ?? []) {
+      listener({ kind: "complete", jobId, report: emptyReport });
+    }
+  }
+}

--- a/packages/daemon/test/support/production-progress-operation-fixture.ts
+++ b/packages/daemon/test/support/production-progress-operation-fixture.ts
@@ -31,15 +31,16 @@ export function productionProgressOperationHost(
   runtimeEventTail?: {
     readonly materializerDelayMs: number;
     readonly timing: { startedAt?: number; finishedAt?: number };
-    readonly failReason?: string;
     readonly failures?: Array<{ readonly requestId: string; readonly command: string; readonly reason: string }>;
   }
 ) {
   return new ProductionProgressAppendOperationHost({
     ...productionProgressOperationAxes(),
-    runtime: progressOperationRuntime(events, requireOuterProceeding, runtimeEventTail),
+    runtime: progressOperationRuntime(events, requireOuterProceeding),
     authorityComponent,
-    hostServices: cliDaemonCommandHostServices,
+    hostServices: runtimeEventTail
+      ? runtimeEventTailHostServices(runtimeEventTail)
+      : cliDaemonCommandHostServices,
     outcomeStore: store,
     settlementStore: new ReceiptSettlementStore({
       directory: path.join(outcomeDirectory, "settlements"),
@@ -349,13 +350,7 @@ function alreadySatisfiedEvidence(semanticDigest: string) {
 
 function progressOperationRuntime(
   events: string[],
-  requireOuterProceeding: boolean,
-  runtimeEventTail?: {
-    readonly materializerDelayMs: number;
-    readonly timing: { startedAt?: number; finishedAt?: number };
-    readonly failReason?: string;
-    readonly failures?: Array<{ readonly requestId: string; readonly command: string; readonly reason: string }>;
-  }
+  requireOuterProceeding: boolean
 ): HarnessDaemonRuntime {
   return {
     start: async () => { throw new Error("not used"); },
@@ -366,18 +361,6 @@ function progressOperationRuntime(
         throw new Error("operational write started before durable PROCEEDING");
       }
       events.push("runtime-event-write");
-      if (runtimeEventTail) {
-        runtimeEventTail.timing.startedAt = performance.now();
-        events.push("runtime-event-materializer-start");
-        const deadline = runtimeEventTail.timing.startedAt + runtimeEventTail.materializerDelayMs;
-        while (performance.now() < deadline) {
-          // Model the real queue drain: resolving the interactive append cannot
-          // resume its promise continuation until the adjacent materializer yields.
-        }
-        runtimeEventTail.timing.finishedAt = performance.now();
-        events.push("runtime-event-materializer-end");
-        if (runtimeEventTail.failReason) throw new Error(runtimeEventTail.failReason);
-      }
       return {
         commandId: request.commandId,
         opIds: request.ops.map((op) => op.opId),
@@ -411,6 +394,27 @@ function progressOperationRuntime(
     } as HarnessDaemonRuntime["admissionBudget"],
     subscribeProjectionChanges: () => () => undefined
   };
+}
+
+function runtimeEventTailHostServices(tail: {
+  readonly materializerDelayMs: number;
+  readonly timing: { startedAt?: number; finishedAt?: number };
+}) {
+  return {
+    ...cliDaemonCommandHostServices,
+    executeCommand: (command, options) => cliDaemonCommandHostServices.executeCommand(command, {
+      ...options,
+      deferCommandRuntimeEvent: (append) => options.deferCommandRuntimeEvent?.(async () => {
+        tail.timing.startedAt = performance.now();
+        try {
+          await new Promise<void>((resolve) => setTimeout(resolve, tail.materializerDelayMs));
+          return await append();
+        } finally {
+          tail.timing.finishedAt = performance.now();
+        }
+      })
+    })
+  } satisfies typeof cliDaemonCommandHostServices;
 }
 
 export function progressOperationCommand(rootDir: string): ParsedCommand {

--- a/packages/kernel/src/daemon-runtime-support.ts
+++ b/packages/kernel/src/daemon-runtime-support.ts
@@ -9,7 +9,7 @@ export {
   acquireDaemonGlobalLock,
   assertDaemonGlobalLockHeld
 } from "./write-coordination/journal/locks.ts";
-export type { DaemonGlobalLock } from "./write-coordination/journal/locks.ts";
+export type { DaemonGlobalLock } from "./ports/write-coordinator.ts";
 export { recoverJournaledWrites } from "./write-coordination/journal/coordinator.ts";
 export {
   singleWriteIntegrityDomain,

--- a/packages/kernel/src/daemon-runtime-support.ts
+++ b/packages/kernel/src/daemon-runtime-support.ts
@@ -38,3 +38,4 @@ export type {
   ProjectionSourceFenceFactory,
   StableProjectionSourceFence
 } from "./ports/projection-source-fence.ts";
+export { rememberTrustedAuthoredProjectionFingerprint } from "./projection/projection-source-baseline.ts";

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -186,7 +186,6 @@ export { DaemonDrainTimeoutError } from "./daemon/drain-timeout.ts";
 export { daemonAdmissionBytes } from "./daemon/admission-budget.ts";
 export type { DaemonAdmissionBudget } from "./daemon/admission-budget.ts";
 export type { ProjectionChangeEvent } from "./projection/projection-change-event.ts";
-export type { DaemonGlobalLock } from "./write-coordination/journal/locks.ts";
 export {
   runLedgerMaterializer,
   type LedgerMaterializerProgressStep,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -185,6 +185,8 @@ export type {
 export { DaemonDrainTimeoutError } from "./daemon/drain-timeout.ts";
 export { daemonAdmissionBytes } from "./daemon/admission-budget.ts";
 export type { DaemonAdmissionBudget } from "./daemon/admission-budget.ts";
+export type { ProjectionChangeEvent } from "./projection/projection-change-event.ts";
+export type { DaemonGlobalLock } from "./write-coordination/journal/locks.ts";
 export {
   runLedgerMaterializer,
   type LedgerMaterializerProgressStep,

--- a/packages/kernel/src/persistence/git/batch-object-reader.ts
+++ b/packages/kernel/src/persistence/git/batch-object-reader.ts
@@ -1,0 +1,44 @@
+export interface GitObjectAtRef {
+  readonly exists: boolean;
+  readonly blobBytes?: Buffer;
+}
+
+export function readGitObjectsAtRef(
+  repoRoot: string,
+  ref: string,
+  relativePaths: ReadonlyArray<string>,
+  runBatch: (repoRoot: string, input: Uint8Array, ...args: ReadonlyArray<string>) => Uint8Array
+): ReadonlyMap<string, GitObjectAtRef> {
+  const uniquePaths = [...new Set(relativePaths)];
+  if (uniquePaths.length === 0) return new Map();
+  const input = Buffer.from(`${uniquePaths.map((relativePath) => `${ref}:${relativePath}`).join("\0")}\0`, "utf8");
+  const output = Buffer.from(runBatch(repoRoot, input, "cat-file", "--batch", "-Z"));
+  const objects = new Map<string, GitObjectAtRef>();
+  let offset = 0;
+  for (const relativePath of uniquePaths) {
+    const headerEnd = output.indexOf(0, offset);
+    if (headerEnd < 0) throw new Error("GIT_BATCH_OBJECT_HEADER_TRUNCATED");
+    const header = output.subarray(offset, headerEnd).toString("utf8");
+    offset = headerEnd + 1;
+    if (header.endsWith(" missing")) {
+      objects.set(relativePath, { exists: false });
+      continue;
+    }
+    const match = /^([0-9a-f]{40,64}) ([a-z]+) ([0-9]+)$/u.exec(header);
+    if (!match) throw new Error("GIT_BATCH_OBJECT_HEADER_INVALID");
+    const objectType = match[2];
+    const size = Number(match[3]);
+    if (!Number.isSafeInteger(size) || size < 0 || offset + size >= output.length) {
+      throw new Error("GIT_BATCH_OBJECT_BODY_TRUNCATED");
+    }
+    const body = output.subarray(offset, offset + size);
+    offset += size;
+    if (output[offset] !== 0) throw new Error("GIT_BATCH_OBJECT_BODY_TERMINATOR_INVALID");
+    offset += 1;
+    objects.set(relativePath, {
+      exists: true,
+      ...(objectType === "blob" ? { blobBytes: Buffer.from(body) } : {})
+    });
+  }
+  return objects;
+}

--- a/packages/kernel/src/persistence/git/git-command-error.ts
+++ b/packages/kernel/src/persistence/git/git-command-error.ts
@@ -1,0 +1,42 @@
+import { VcsCommandError } from "../../ports/version-control-system.ts";
+
+export function vcsCommandError(repoRoot: string, args: ReadonlyArray<string>, error: unknown): VcsCommandError {
+  return new VcsCommandError({
+    command: args[0] ?? "command",
+    cwd: repoRoot,
+    exitCode: commandErrorCode(error),
+    signal: commandErrorSignal(error),
+    stderrSummary: commandErrorSummary(error)
+  });
+}
+
+function commandErrorCode(error: unknown): string | number | undefined {
+  if (typeof error === "object" && error && "status" in error) {
+    const status = (error as { readonly status?: unknown }).status;
+    if (typeof status === "number" || typeof status === "string") return status;
+  }
+  if (typeof error === "object" && error && "code" in error) {
+    const code = (error as { readonly code?: unknown }).code;
+    if (typeof code === "number" || typeof code === "string") return code;
+  }
+  return undefined;
+}
+
+function commandErrorSignal(error: unknown): string | undefined {
+  if (typeof error === "object" && error && "signal" in error) {
+    const signal = (error as { readonly signal?: unknown }).signal;
+    if (typeof signal === "string" && signal.length > 0) return signal;
+  }
+  return undefined;
+}
+
+function commandErrorSummary(error: unknown): string | undefined {
+  if (typeof error === "object" && error && "stderr" in error) {
+    const stderr = (error as { readonly stderr?: unknown }).stderr;
+    const text = Buffer.isBuffer(stderr) ? stderr.toString("utf8") : typeof stderr === "string" ? stderr : "";
+    const firstLine = text.trim().split(/\r?\n/u).find((line) => line.trim().length > 0);
+    if (firstLine) return firstLine;
+  }
+  if (error instanceof Error) return error.message.split(/\r?\n/u)[0] ?? error.message;
+  return String(error);
+}

--- a/packages/kernel/src/persistence/git/local-version-control-system.ts
+++ b/packages/kernel/src/persistence/git/local-version-control-system.ts
@@ -9,13 +9,27 @@ import { VcsCommandError } from "../../ports/version-control-system.ts";
 import { resolveGitMaxBufferBytes } from "../../runtime/operational-limits.ts";
 import { commitPathsToBranchHeadless } from "./headless-branch-commit.ts";
 import { commitWithScopedIndex, nullDelimitedGitPaths } from "./scoped-index-commit.ts";
+import { readGitObjectsAtRef, type GitObjectAtRef } from "./batch-object-reader.ts";
+import { vcsCommandError } from "./git-command-error.ts";
 
 const gitMaxBuffer = resolveGitMaxBufferBytes();
 
-export function makeLocalVersionControlSystem(): VersionControlSystem {
+export function makeLocalVersionControlSystem(options: {
+  readonly cacheRepositoryDiscovery?: boolean;
+} = {}): VersionControlSystem {
+  const topLevels = new Map<string, string>();
   return {
     normalizePath: normalizeExistingPath,
-    topLevel: gitTopLevel,
+    topLevel: (inputPath) => {
+      const normalized = normalizeExistingPath(inputPath);
+      const cached = options.cacheRepositoryDiscovery ? topLevels.get(normalized) : undefined;
+      if (cached) return cached;
+      const resolved = gitTopLevel(normalized);
+      // Cache only positive discovery. A caller may create a repository after
+      // constructing this adapter; retaining a negative answer would hide it.
+      if (resolved && options.cacheRepositoryDiscovery) topLevels.set(normalized, resolved);
+      return resolved;
+    },
     isIgnored: (repoRoot, relativePath) => {
       try {
         runGit(repoRoot, "check-ignore", "--no-index", "-q", "--", relativePath);
@@ -238,7 +252,10 @@ export function makeLocalVersionControlSystem(): VersionControlSystem {
     ),
     resetWorktreePaths: (repoRoot, ref, paths, options) => {
       if (paths.length === 0) return [];
-      const refSha = runGit(repoRoot, "rev-parse", ref).trim();
+      const refObjects = readGitObjectsAtRef(repoRoot, ref, paths, runGitBytesWithInput);
+      const restoreObjects = options?.restoreRef
+        ? readGitObjectsAtRef(repoRoot, options.restoreRef, paths, runGitBytesWithInput)
+        : new Map<string, GitObjectAtRef>();
       const preserved: PreservedWorktreeEdit[] = [];
       for (const relativePath of paths) {
         const absolutePath = path.join(repoRoot, ...relativePath.split("/"));
@@ -246,32 +263,32 @@ export function makeLocalVersionControlSystem(): VersionControlSystem {
           repoRoot,
           relativePath,
           absolutePath,
-          restoreRef: options?.restoreRef,
+          restoreBytes: restoreObjects.get(relativePath)?.blobBytes,
+          shouldPreserve: options?.restoreRef !== undefined,
           preserveDir: options?.preserveDir
         });
         if (rescued) preserved.push(rescued);
-        let existsAtRef = false;
+      }
+      const existingPaths = paths.filter((relativePath) => refObjects.get(relativePath)?.exists === true);
+      const missingPaths = paths.filter((relativePath) => refObjects.get(relativePath)?.exists !== true);
+      if (existingPaths.length > 0) {
         try {
-          runGit(repoRoot, "cat-file", "-e", `${refSha}:${relativePath}`);
-          existsAtRef = true;
+          runGit(repoRoot, "checkout", ref, "--", ...existingPaths);
         } catch {
-          // Path does not exist in ref — it will be removed below.
+          // The merge will surface a real conflict if Git cannot restore the
+          // complete touched set (for example because a path changed type).
         }
-        if (existsAtRef) {
+      }
+      if (missingPaths.length > 0) {
+        try {
+          runGit(repoRoot, "reset", "-q", "HEAD", "--", ...missingPaths);
+        } catch {
+          // Paths may not be in the index; they still need removing below so
+          // an untracked file cannot block the merge.
+        }
+        for (const relativePath of missingPaths) {
           try {
-            runGit(repoRoot, "checkout", ref, "--", relativePath);
-          } catch {
-            // If checkout fails (e.g. path is a directory in ref), skip —
-            // the merge will surface any real conflict.
-          }
-        } else {
-          try {
-            runGit(repoRoot, "reset", "-q", "HEAD", "--", relativePath);
-          } catch {
-            // Path may not be in the index; ignore.
-          }
-          try {
-            rmSync(absolutePath, { force: true });
+            rmSync(path.join(repoRoot, ...relativePath.split("/")), { force: true });
           } catch {
             // Worktree file may already be gone; ignore.
           }
@@ -286,23 +303,18 @@ function preserveDivergentWorktreeEdit(input: {
   readonly repoRoot: string;
   readonly relativePath: string;
   readonly absolutePath: string;
-  readonly restoreRef: string | undefined;
+  readonly restoreBytes: Buffer | undefined;
+  readonly shouldPreserve: boolean;
   readonly preserveDir: string | undefined;
 }): PreservedWorktreeEdit | undefined {
-  if (!input.restoreRef) return undefined;
+  if (!input.shouldPreserve) return undefined;
   let worktreeBytes: Buffer;
   try {
     worktreeBytes = readFileSync(input.absolutePath);
   } catch {
     return undefined;
   }
-  let restoreBytes: Buffer | undefined;
-  try {
-    restoreBytes = Buffer.from(runGitBytes(input.repoRoot, "cat-file", "blob", `${input.restoreRef}:${input.relativePath}`));
-  } catch {
-    restoreBytes = undefined;
-  }
-  if (restoreBytes && restoreBytes.equals(worktreeBytes)) return undefined;
+  if (input.restoreBytes?.equals(worktreeBytes)) return undefined;
   const preserveRoot = input.preserveDir ?? path.join(input.repoRoot, ".harness", "preserved-worktree-edits");
   const stamp = `${Date.now().toString(36)}-${randomBytes(3).toString("hex")}`;
   const target = path.join(preserveRoot, stamp, ...input.relativePath.split("/"));
@@ -402,6 +414,24 @@ function runGitBytes(repoRoot: string, ...args: ReadonlyArray<string>): Uint8Arr
   }
 }
 
+function runGitBytesWithInput(
+  repoRoot: string,
+  input: string | Uint8Array,
+  ...args: ReadonlyArray<string>
+): Uint8Array {
+  try {
+    return execFileSync("git", ["-C", repoRoot, ...args], {
+      ...localGitProcessOptions(),
+      encoding: "buffer",
+      input,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true
+    });
+  } catch (error) {
+    throw vcsCommandError(repoRoot, args, error);
+  }
+}
+
 function gitPathBytesKey(input: Uint8Array): string {
   return Buffer.from(input).toString("base64");
 }
@@ -490,16 +520,6 @@ function runGitWithEnvironment(
   }
 }
 
-function vcsCommandError(repoRoot: string, args: ReadonlyArray<string>, error: unknown): VcsCommandError {
-  return new VcsCommandError({
-    command: args[0] ?? "command",
-    cwd: repoRoot,
-    exitCode: commandErrorCode(error),
-    signal: commandErrorSignal(error),
-    stderrSummary: commandErrorSummary(error)
-  });
-}
-
 export function localGitProcessOptions(author?: VcsCommitAuthor): ExecFileSyncOptionsWithStringEncoding {
   const env = { ...process.env };
   for (const key of gitRepositoryRedirectEnvironmentKeys) delete env[key];
@@ -544,34 +564,3 @@ const gitRepositoryRedirectEnvironmentKeys = [
   "GIT_CONFIG_PARAMETERS",
   "GIT_CONFIG_COUNT"
 ] as const;
-
-function commandErrorCode(error: unknown): string | number | undefined {
-  if (typeof error === "object" && error && "status" in error) {
-    const status = (error as { readonly status?: unknown }).status;
-    if (typeof status === "number" || typeof status === "string") return status;
-  }
-  if (typeof error === "object" && error && "code" in error) {
-    const code = (error as { readonly code?: unknown }).code;
-    if (typeof code === "number" || typeof code === "string") return code;
-  }
-  return undefined;
-}
-
-function commandErrorSignal(error: unknown): string | undefined {
-  if (typeof error === "object" && error && "signal" in error) {
-    const signal = (error as { readonly signal?: unknown }).signal;
-    if (typeof signal === "string" && signal.length > 0) return signal;
-  }
-  return undefined;
-}
-
-function commandErrorSummary(error: unknown): string | undefined {
-  if (typeof error === "object" && error && "stderr" in error) {
-    const stderr = (error as { readonly stderr?: unknown }).stderr;
-    const text = Buffer.isBuffer(stderr) ? stderr.toString("utf8") : typeof stderr === "string" ? stderr : "";
-    const firstLine = text.trim().split(/\r?\n/u).find((line) => line.trim().length > 0);
-    if (firstLine) return firstLine;
-  }
-  if (error instanceof Error) return error.message.split(/\r?\n/u)[0] ?? error.message;
-  return String(error);
-}

--- a/packages/kernel/src/ports/index.ts
+++ b/packages/kernel/src/ports/index.ts
@@ -42,6 +42,7 @@ export {
 } from "./write-coordinator.ts";
 export type {
   AuthorityOperationIntegrity,
+  DaemonGlobalLock,
   ExactWriteScope,
   ExactWriteCoordinator,
   WriteOp,

--- a/packages/kernel/src/ports/write-coordinator.ts
+++ b/packages/kernel/src/ports/write-coordinator.ts
@@ -234,6 +234,15 @@ export interface RecoveryReport {
   readonly deferredOps?: number;
 }
 
+/** Daemon-owned global-lock capability accepted by coordinated write runtimes. */
+export interface DaemonGlobalLock {
+  readonly path: string;
+  readonly ownerToken: string;
+  readonly ownerKind?: "daemon";
+  readonly refreshHeartbeat: () => void;
+  readonly release: () => void;
+}
+
 export interface WriteCoordinator {
   readonly enqueue: (op: WriteOp) => Effect.Effect<WriteAck, WriteError>;
   readonly flush: (reason: FlushReason) => Effect.Effect<FlushReport, WriteError>;

--- a/packages/kernel/src/projection/sqlite-attribution-event-store.ts
+++ b/packages/kernel/src/projection/sqlite-attribution-event-store.ts
@@ -9,7 +9,7 @@ export function ensureAttributionEventTables(
 ): Effect.Effect<unknown, unknown> {
   return Effect.gen(function* () {
     yield* ensureEntityAttributionSummaryTable(sql);
-    yield* migrateWorkspaceScopedRevisionIdentity(sql);
+    yield* migrateOperationScopedRevisionIdentity(sql);
     yield* sql`
       CREATE TABLE IF NOT EXISTS attribution_events (
         event_id TEXT PRIMARY KEY,
@@ -37,7 +37,7 @@ export function ensureAttributionEventTables(
         occurred_at TEXT NOT NULL,
         recorded_at TEXT NOT NULL,
         source_json TEXT NOT NULL,
-        UNIQUE (workspace_id, revision)
+        UNIQUE (workspace_id, revision, op_id)
       )
     `;
     yield* sql`
@@ -56,13 +56,18 @@ export function ensureAttributionEventTables(
   });
 }
 
-function migrateWorkspaceScopedRevisionIdentity(sql: SqlClient.SqlClient): Effect.Effect<void, unknown> {
+/**
+ * A replica publication revision identifies a physical publication group, not
+ * one operation. Every operation in that group owns a complete attribution
+ * event and therefore legitimately shares (workspace_id, revision).
+ */
+function migrateOperationScopedRevisionIdentity(sql: SqlClient.SqlClient): Effect.Effect<void, unknown> {
   return Effect.gen(function* () {
     const [header] = yield* sql<{ readonly sql: string | null }>`
       SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'attribution_event_headers'
     `;
-    if (!header?.sql || !/revision\s+INTEGER\s+NOT\s+NULL\s+UNIQUE/iu.test(header.sql)) return;
-    yield* sql`ALTER TABLE attribution_event_headers RENAME TO attribution_event_headers_global_revision`;
+    if (!header?.sql || /UNIQUE\s*\(\s*workspace_id\s*,\s*revision\s*,\s*op_id\s*\)/iu.test(header.sql)) return;
+    yield* sql`ALTER TABLE attribution_event_headers RENAME TO attribution_event_headers_legacy_revision`;
     yield* sql`
       CREATE TABLE attribution_event_headers (
         event_id TEXT PRIMARY KEY,
@@ -76,19 +81,19 @@ function migrateWorkspaceScopedRevisionIdentity(sql: SqlClient.SqlClient): Effec
         occurred_at TEXT NOT NULL,
         recorded_at TEXT NOT NULL,
         source_json TEXT NOT NULL,
-        UNIQUE (workspace_id, revision)
+        UNIQUE (workspace_id, revision, op_id)
       )
     `;
     yield* sql`
       INSERT INTO attribution_event_headers
-      SELECT * FROM attribution_event_headers_global_revision
+      SELECT * FROM attribution_event_headers_legacy_revision
     `;
     const [mutations] = yield* sql<{ readonly name: string }>`
       SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'attribution_event_mutations'
     `;
     if (mutations) {
       yield* sql`
-        CREATE TABLE attribution_event_mutations_workspace_revision (
+        CREATE TABLE attribution_event_mutations_operation_revision (
           event_id TEXT NOT NULL,
           mutation_index INTEGER NOT NULL,
           registry_version INTEGER NOT NULL,
@@ -99,11 +104,11 @@ function migrateWorkspaceScopedRevisionIdentity(sql: SqlClient.SqlClient): Effec
           FOREIGN KEY (event_id) REFERENCES attribution_event_headers(event_id) ON DELETE CASCADE
         )
       `;
-      yield* sql`INSERT INTO attribution_event_mutations_workspace_revision SELECT * FROM attribution_event_mutations`;
+      yield* sql`INSERT INTO attribution_event_mutations_operation_revision SELECT * FROM attribution_event_mutations`;
       yield* sql`DROP TABLE attribution_event_mutations`;
-      yield* sql`ALTER TABLE attribution_event_mutations_workspace_revision RENAME TO attribution_event_mutations`;
+      yield* sql`ALTER TABLE attribution_event_mutations_operation_revision RENAME TO attribution_event_mutations`;
     }
-    yield* sql`DROP TABLE attribution_event_headers_global_revision`;
+    yield* sql`DROP TABLE attribution_event_headers_legacy_revision`;
   });
 }
 

--- a/packages/kernel/src/projection/sqlite-attribution-incremental.ts
+++ b/packages/kernel/src/projection/sqlite-attribution-incremental.ts
@@ -23,6 +23,7 @@ export type AttributionProjectionDecisionReason =
   | "v1-v2-precedence"
   | "replay"
   | "new-source-path"
+  | "append-batch"
   | "v1-to-v2-replacement"
   | "op-id-collision"
   | "other";
@@ -41,39 +42,64 @@ export function buildAppendOnlyAttributionProjectionDelta(
   const deleted = change.deleteFiles.filter((row) => row.cacheKind === "attribution");
   const upserted = change.upsertFiles.filter((row) => row.cacheKind === "attribution");
   if (deleted.length > 0) return full("delete-present");
-  if (upserted.length !== 1) return full("non-single-upsert");
+  if (upserted.length === 0) return full("non-single-upsert");
+  const previousSourcePaths = new Set(change.previous.files
+    .filter((row) => row.cacheKind === "attribution")
+    .map((row) => row.sourcePath));
+  if (upserted.some((candidate) => previousSourcePaths.has(candidate.sourcePath))) {
+    return full("source-path-exists");
+  }
 
-  const [candidate] = upserted;
-  if (!candidate || change.previous.files.some((row) =>
-    row.cacheKind === "attribution" && row.sourcePath === candidate.sourcePath)) return full("source-path-exists");
-
-  let event: UnionAttributionEvent;
+  let events: ReadonlyArray<UnionAttributionEvent>;
   try {
-    event = decodeUnionAttributionEventBody(candidate.body);
+    events = upserted.map((candidate) => decodeUnionAttributionEventBody(candidate.body));
   } catch {
     return full("event-decode-failed");
   }
-
-  let projected: ReadonlyArray<UnionAttributionEvent>;
-  try {
-    projected = readProjectedAttributionEventsByOpId(projectionPath, event.opId);
-  } catch {
-    return full("projected-read-failed");
+  if (new Set(events.map((event) => event.opId)).size !== events.length) {
+    return full("op-id-ambiguous");
   }
-  if (projected.length > 1) return full("op-id-ambiguous");
 
-  const prior = projected[0];
-  if (!prior) return incremental("new-source-path", delta([], [event], eventToProjectionRows(event)));
-  if (prior.schema === "attribution-event/v2" && event.schema === "attribution-event/v1") {
-    return incremental("v1-v2-precedence", delta([], [], []));
+  const deleteEventIds = new Set<string>();
+  const upsertEvents: UnionAttributionEvent[] = [];
+  const affectedSubjects = new Set<string>();
+  let singleReason: AttributionProjectionDecisionReason = "new-source-path";
+  for (const event of events) {
+    let projected: ReadonlyArray<UnionAttributionEvent>;
+    try {
+      projected = readProjectedAttributionEventsByOpId(projectionPath, event.opId);
+    } catch {
+      return full("projected-read-failed");
+    }
+    if (projected.length > 1) return full("op-id-ambiguous");
+
+    const prior = projected[0];
+    if (!prior) {
+      upsertEvents.push(event);
+      for (const row of eventToProjectionRows(event)) affectedSubjects.add(row.subjectRef);
+      continue;
+    }
+    if (prior.schema === "attribution-event/v2" && event.schema === "attribution-event/v1") {
+      singleReason = "v1-v2-precedence";
+      continue;
+    }
+    if (stableStringify(prior) === stableStringify(event)) {
+      singleReason = "replay";
+      continue;
+    }
+    if (prior.schema === event.schema && prior.eventId !== event.eventId) return full("op-id-collision");
+    singleReason = "v1-to-v2-replacement";
+    deleteEventIds.add(prior.eventId);
+    upsertEvents.push(event);
+    for (const row of [...eventToProjectionRows(prior), ...eventToProjectionRows(event)]) {
+      affectedSubjects.add(row.subjectRef);
+    }
   }
-  if (stableStringify(prior) === stableStringify(event)) return incremental("replay", delta([], [], []));
-  if (prior.schema === event.schema && prior.eventId !== event.eventId) return full("op-id-collision");
-  return incremental("v1-to-v2-replacement", delta(
-    [prior.eventId],
-    [event],
-    [...eventToProjectionRows(prior), ...eventToProjectionRows(event)]
-  ));
+  return incremental(events.length === 1 ? singleReason : "append-batch", {
+    deleteEventIds: [...deleteEventIds],
+    upsertEvents,
+    affectedSubjects: [...affectedSubjects]
+  });
 }
 
 function full(reason: AttributionProjectionDecisionReason): AttributionProjectionDecision {
@@ -82,18 +108,6 @@ function full(reason: AttributionProjectionDecisionReason): AttributionProjectio
 
 function incremental(reason: AttributionProjectionDecisionReason, deltaValue: AttributionProjectionDelta): AttributionProjectionDecision {
   return { mode: "incremental", reason, delta: deltaValue };
-}
-
-function delta(
-  deleteEventIds: ReadonlyArray<string>,
-  upsertEvents: ReadonlyArray<UnionAttributionEvent>,
-  rows: ReadonlyArray<{ readonly subjectRef: string }>
-): AttributionProjectionDelta {
-  return {
-    deleteEventIds,
-    upsertEvents,
-    affectedSubjects: rows.map((row) => row.subjectRef)
-  };
 }
 
 function readProjectedAttributionEventsByOpId(

--- a/packages/kernel/src/projection/sqlite-projection-update-store.ts
+++ b/packages/kernel/src/projection/sqlite-projection-update-store.ts
@@ -1,5 +1,6 @@
 import { SqlClient } from "@effect/sql";
 import { Effect } from "effect";
+import { isDeepStrictEqual } from "node:util";
 import type { ProjectionMeta, TaskFieldExtensionProjection, TaskProjectionRow, DecisionProjectionRow } from "./types.ts";
 import type { ProjectionGraphRows } from "./sqlite-projection-store.ts";
 import { deleteDeclaredProjectionRows, upsertDeclaredProjectionRows } from "./entity-declaration-projection.ts";
@@ -49,6 +50,7 @@ export function updateProjectionDatabase(
     readonly upsertDecisionRows: ReadonlyArray<DecisionProjectionRow>;
     readonly meta: ProjectionMeta;
     readonly graphRows?: ProjectionGraphRows;
+    readonly previousGraphRows?: ProjectionGraphRows;
     readonly preserveGraphFactRows?: boolean;
     readonly declaredDelta: DeclaredProjectionDelta;
     readonly attributionDelta?: AttributionProjectionDelta;
@@ -64,6 +66,9 @@ export function updateProjectionDatabase(
       // Projection telemetry is non-authoritative.
     }
   };
+  const graphDelta = change.graphRows && change.previousGraphRows
+    ? projectionGraphDelta(change.previousGraphRows, change.graphRows, change.preserveGraphFactRows === true)
+    : undefined;
   report("start");
   runSqlite(projectionPath, Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient;
@@ -90,17 +95,32 @@ export function updateProjectionDatabase(
       }
       report("decision-rows-done");
       if (change.graphRows) {
-        yield* sql`DELETE FROM relation_edges`;
-        yield* sql`DELETE FROM relation_coverage`;
-        yield* insertRelationEdges(sql, change.graphRows.relationEdges);
-        yield* insertCoverageRows(sql, change.graphRows.coverageRows);
-        if (!change.preserveGraphFactRows) {
-          yield* sql`DELETE FROM task_fact_anchors`;
-          yield* sql`DELETE FROM task_fact_projection`;
-          yield* sql`DELETE FROM relation_projection_warnings`;
-          yield* insertFactAnchors(sql, change.graphRows.factAnchors);
-          yield* insertTaskFactRows(sql, change.graphRows.factRows);
-          for (const [index, row] of change.graphRows.warnings.entries()) yield* insertRelationProjectionWarning(sql, index, row);
+        if (graphDelta) {
+          for (const relationId of graphDelta.edges.deleteKeys) yield* sql`DELETE FROM relation_edges WHERE relation_id = ${relationId}`;
+          for (const claimRef of graphDelta.coverage.deleteKeys) yield* sql`DELETE FROM relation_coverage WHERE claim_ref = ${claimRef}`;
+          yield* insertRelationEdges(sql, graphDelta.edges.upsertRows);
+          yield* insertCoverageRows(sql, graphDelta.coverage.upsertRows);
+          if (!change.preserveGraphFactRows) {
+            for (const factRef of graphDelta.factAnchors.deleteKeys) yield* sql`DELETE FROM task_fact_anchors WHERE fact_ref = ${factRef}`;
+            for (const factRef of graphDelta.factRows.deleteKeys) yield* sql`DELETE FROM task_fact_projection WHERE fact_ref = ${factRef}`;
+            for (const warningIndex of graphDelta.warnings.deleteKeys) yield* sql`DELETE FROM relation_projection_warnings WHERE warning_index = ${warningIndex}`;
+            yield* insertFactAnchors(sql, graphDelta.factAnchors.upsertRows);
+            yield* insertTaskFactRows(sql, graphDelta.factRows.upsertRows);
+            for (const { index, row } of graphDelta.warnings.upsertRows) yield* insertRelationProjectionWarning(sql, index, row);
+          }
+        } else {
+          yield* sql`DELETE FROM relation_edges`;
+          yield* sql`DELETE FROM relation_coverage`;
+          yield* insertRelationEdges(sql, change.graphRows.relationEdges);
+          yield* insertCoverageRows(sql, change.graphRows.coverageRows);
+          if (!change.preserveGraphFactRows) {
+            yield* sql`DELETE FROM task_fact_anchors`;
+            yield* sql`DELETE FROM task_fact_projection`;
+            yield* sql`DELETE FROM relation_projection_warnings`;
+            yield* insertFactAnchors(sql, change.graphRows.factAnchors);
+            yield* insertTaskFactRows(sql, change.graphRows.factRows);
+            for (const [index, row] of change.graphRows.warnings.entries()) yield* insertRelationProjectionWarning(sql, index, row);
+          }
         }
       }
       report("graph-rows-done");
@@ -149,6 +169,46 @@ export function updateProjectionDatabase(
     }
   }));
   report("done");
+}
+
+function projectionGraphDelta(
+  previous: ProjectionGraphRows,
+  current: ProjectionGraphRows,
+  preserveFactRows: boolean
+) {
+  return {
+    edges: changedRows(previous.relationEdges, current.relationEdges, (row) => row.relationId),
+    coverage: changedRows(previous.coverageRows, current.coverageRows, (row) => row.claimRef),
+    factAnchors: preserveFactRows
+      ? { deleteKeys: [] as string[], upsertRows: [] as ProjectionGraphRows["factAnchors"] }
+      : changedRows(previous.factAnchors, current.factAnchors, (row) => row.factRef),
+    factRows: preserveFactRows
+      ? { deleteKeys: [] as string[], upsertRows: [] as ProjectionGraphRows["factRows"] }
+      : changedRows(previous.factRows, current.factRows, (row) => row.ref),
+    warnings: preserveFactRows
+      ? { deleteKeys: [] as number[], upsertRows: [] as Array<{ readonly index: number; readonly row: ProjectionGraphRows["warnings"][number] }> }
+      : changedRows(
+        previous.warnings.map((row, index) => ({ index, row })),
+        current.warnings.map((row, index) => ({ index, row })),
+        (entry) => entry.index
+      )
+  };
+}
+
+function changedRows<Key, Row>(
+  previous: ReadonlyArray<Row>,
+  current: ReadonlyArray<Row>,
+  keyOf: (row: Row) => Key
+): { readonly deleteKeys: ReadonlyArray<Key>; readonly upsertRows: ReadonlyArray<Row> } {
+  const previousByKey = new Map(previous.map((row) => [keyOf(row), row]));
+  const currentByKey = new Map(current.map((row) => [keyOf(row), row]));
+  return {
+    deleteKeys: [...previousByKey.keys()].filter((key) => !currentByKey.has(key)),
+    upsertRows: current.filter((row) => {
+      const previousRow = previousByKey.get(keyOf(row));
+      return previousRow === undefined || !isDeepStrictEqual(previousRow, row);
+    })
+  };
 }
 
 function canReuseAttributionRowsHash(

--- a/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
+++ b/packages/kernel/src/projection/sqlite-task-incremental-projection.ts
@@ -2,10 +2,11 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { createHarnessRuntimeContext, resolveHarnessLayout } from "../layout/index.ts";
-import { readScalar } from "../markdown/frontmatter.ts";
+import { readFrontmatter, readScalar } from "../markdown/frontmatter.ts";
 import type { RelationGraphEdgeRow } from "./relation-graph-projection.ts";
 import { buildRelationGraphProjection } from "./relation-graph-projection.ts";
 import { relationGraphFactProjectionSemanticHash, relationGraphSourceSemanticHash } from "./relation-graph-source-semantics.ts";
+import { parseRelationFlowRecords } from "./relation-flow-frontmatter.ts";
 import { compareDecisionRows, hashDecisionProjectionRows, readDecisionProjectionRowsForPathsFromSource } from "./sqlite-decision-source.ts";
 import {
   buildDeclaredProjectionDeltaFromSources,
@@ -16,7 +17,7 @@ import {
 } from "./sqlite-declared-source-manifest.ts";
 import {
   readAttributionProjectionStateHash,
-  readRelationGraphReuseSeed,
+  readRelationGraphRows,
   projectionVersion,
   tryReadProjectionDatabase
 } from "./sqlite-projection-store.ts";
@@ -193,7 +194,14 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
   if (graphSourceChange.changed && reusableGraph === null) {
     return rebuild("relation-graph-reuse-unavailable");
   }
-  const oldGraph = reusableGraph ?? { relationEdges: [], factRefs: new Set<string>() };
+  const oldGraph = reusableGraph ?? {
+    relationEdges: [],
+    coverageRows: [],
+    factAnchors: [],
+    factRows: [],
+    warnings: [],
+    factRefs: new Set<string>()
+  };
   const preserveGraphFactRows = graphSourceChange.changed && graphSourceChange.factProjectionReusable && reusableGraph !== null;
   const newGraph = declaredEntityOnly || !graphSourceChange.changed || options.touchedPaths.length === 0
     ? null
@@ -360,7 +368,7 @@ export function updateTaskProjectionIncrementally(options: TaskProjectionOptions
         factAnchors: newGraph.factAnchors,
         factRows: newGraph.factRows,
         warnings: newGraph.warnings
-      }, preserveGraphFactRows } : {}),
+      }, previousGraphRows: oldGraph, preserveGraphFactRows } : {}),
       declaredDelta,
       ...(sourceCacheChange ? { sourceCache: sourceCacheChange } : {}),
       ...(attributionDelta ? { attributionDelta } : {}),
@@ -445,9 +453,21 @@ function projectionRowsMatchMeta(existing: {
 function safeReadRelationGraphReuseSeed(projectionPath: string): {
   readonly relationEdges: ReadonlyArray<RelationGraphEdgeRow>;
   readonly factRefs: ReadonlySet<string>;
+  readonly coverageRows: ReturnType<typeof readRelationGraphRows>["coverageRows"];
+  readonly factAnchors: ReturnType<typeof readRelationGraphRows>["factAnchors"];
+  readonly factRows: ReturnType<typeof readRelationGraphRows>["factRows"];
+  readonly warnings: ReturnType<typeof readRelationGraphRows>["warnings"];
 } | null {
   try {
-    return readRelationGraphReuseSeed(projectionPath);
+    const graph = readRelationGraphRows(projectionPath);
+    const factRefs = new Set<string>();
+    for (const row of graph.factRows) factRefs.add(row.ref.slice("fact/".length));
+    for (const edge of graph.relationEdges) {
+      for (const ref of [edge.sourceRef, edge.targetRef]) {
+        if (ref.startsWith("fact/")) factRefs.add(ref.slice("fact/".length));
+      }
+    }
+    return { ...graph, factRefs };
   } catch {
     return null;
   }
@@ -467,7 +487,17 @@ function relationGraphSourceChange(
     const relativePath = sourcePath(normalizedRoot, realPathIfExists(touchedPath));
     const currentBody = currentBodies.get(relativePath);
     const previousBody = readProjectionSourceCacheBody(projectionPath, "task", relativePath);
+    // Attribution, contracts, and other non-graph files can share the same
+    // publication touched-path set. If neither task-source snapshot contains
+    // the path, it cannot affect the relation graph.
+    if (currentBody === undefined && previousBody === undefined) continue;
     if (currentBody === undefined || previousBody === undefined) {
+      if (relationFreeTaskIdentityChangeIsIsolated(
+        relativePath,
+        previousBody,
+        currentBody,
+        sourceInputs
+      )) continue;
       changed = true;
       factProjectionReusable = false;
       continue;
@@ -479,6 +509,37 @@ function relationGraphSourceChange(
         relationGraphFactProjectionSemanticHash(relativePath, currentBody)) factProjectionReusable = false;
   }
   return { changed, factProjectionReusable };
+}
+
+function relationFreeTaskIdentityChangeIsIsolated(
+  relativePath: string,
+  previousBody: string | undefined,
+  currentBody: string | undefined,
+  sourceInputs: ReturnType<typeof readMarkdownSource>["sourceInputs"]
+): boolean {
+  if (path.basename(relativePath) !== "INDEX.md") return false;
+  const taskIds = new Set<string>();
+  for (const body of [previousBody, currentBody]) {
+    if (body === undefined) continue;
+    const frontmatter = readFrontmatter(body);
+    if (!frontmatter || parseRelationFlowRecords(frontmatter).length > 0) return false;
+    const taskId = readScalar(frontmatter, "task_id");
+    if (!taskId) return false;
+    taskIds.add(taskId);
+  }
+  if (taskIds.size === 0) return false;
+
+  // A new/deleted task endpoint can make an otherwise unchanged relation
+  // valid/invalid. Prove the affected subgraph is empty by checking every
+  // other cached relation source for the exact endpoint; false positives only
+  // fall back to the full graph path.
+  for (const input of sourceInputs) {
+    if (input.sourcePath === relativePath) continue;
+    for (const taskId of taskIds) {
+      if (input.body.includes(`task/${taskId}`)) return false;
+    }
+  }
+  return true;
 }
 
 function incrementalTaskRows(

--- a/packages/kernel/src/write-coordination/journal/coordinator.ts
+++ b/packages/kernel/src/write-coordination/journal/coordinator.ts
@@ -360,7 +360,11 @@ function flushRecords(
   });
   onProjectionFingerprintPhase?.("capture-start");
   let projectionHeadWitness: string | undefined;
-  const previousProjectionSourceFingerprint = records.length > 0 && projectionRelevant
+  // A session publication does not update the canonical projection here. Its
+  // materializer captures the canonical baseline immediately before merging,
+  // so capturing the same authored tree during durable acceptance only blocks
+  // the next queued writer and cannot be consumed by this post-commit path.
+  const previousProjectionSourceFingerprint = records.length > 0 && projectionRelevant && !sessionId
     ? captureTrustedAuthoredProjectionFingerprint(rootInput, publicationVcs, undefined, {
       onDiagnostic: onProjectionFingerprintDiagnostic,
       onHeadWitness: (head) => {

--- a/packages/kernel/src/write-coordination/journal/locks.ts
+++ b/packages/kernel/src/write-coordination/journal/locks.ts
@@ -7,13 +7,9 @@ import { taskIdFromEntityId } from "../../domain/index.ts";
 import { sha256Text } from "../../integrity/stable-hash.ts";
 import type { HarnessLayoutInput } from "../../layout/index.ts";
 import { resolveHarnessLayout } from "../../layout/index.ts";
+import type { DaemonGlobalLock } from "../../ports/write-coordinator.ts";
 import { appendJsonLineDurably, fsyncDirectory, readJournal } from "./durable.ts";
 import type { LockRecord, LockTakeoverRecord, OperationalActor, OwnedLock } from "./types.ts";
-
-export interface DaemonGlobalLock extends OwnedLock {
-  readonly refreshHeartbeat: () => void;
-  readonly release: () => void;
-}
 
 export interface RepoLockOptions {
   readonly heldGlobalLock?: OwnedLock;

--- a/packages/kernel/src/write-coordination/materialization/ledger-materializer.ts
+++ b/packages/kernel/src/write-coordination/materialization/ledger-materializer.ts
@@ -44,6 +44,7 @@ export interface LedgerMaterializerReport {
   readonly branches: ReadonlyArray<LedgerMaterializerBranchReport>;
   readonly warnings: ReadonlyArray<string>;
   readonly projectionRebuilt: boolean;
+  readonly projectionSourceHash?: string;
   readonly attributionEventsProjected: number;
 }
 
@@ -77,7 +78,9 @@ export type LedgerMaterializerProgressStep =
   | "attribution-start"
   | "attribution-done";
 
-const defaultVersionControlSystem = makeLocalVersionControlSystem();
+// A materializer worker owns one stable repository topology for its lifetime.
+// Avoid rediscovering the same authored repository before every Git operation.
+const defaultVersionControlSystem = makeLocalVersionControlSystem({ cacheRepositoryDiscovery: true });
 
 export function runLedgerMaterializer(rootInput: HarnessLayoutInput, options: LedgerMaterializerOptions = {}): LedgerMaterializerReport {
   const layout = resolveHarnessLayout(rootInput);
@@ -130,6 +133,7 @@ function materializeBranches(
   let merged = 0;
   let processed = 0;
   let projectionSourceFingerprintBeforeMerge: string | undefined;
+  let projectionSourceHash: string | undefined;
   const touchedPaths = new Set<string>();
 
   const trunkBranch = resolveTrunkBranch(repoRoot, undefined, vcs);
@@ -151,7 +155,7 @@ function materializeBranches(
     // filtering on undefined would silently report "no branches to materialize".
     const targetBranch = sessionBranchName(sessionId);
     if (!targetBranch) throw new Error(`invalid materializer session id: ${sessionId}`);
-    branches = vcs.sessionBranches(repoRoot).filter((branch) => branch === targetBranch);
+    branches = vcs.refExists(repoRoot, targetBranch) ? [targetBranch] : [];
   } else {
     branches = vcs.sessionBranches(repoRoot);
   }
@@ -168,14 +172,6 @@ function materializeBranches(
       continue;
     }
 
-    if (projectionSourceFingerprintBeforeMerge === undefined) {
-      onProgress?.("baseline-start");
-      projectionSourceFingerprintBeforeMerge = captureTrustedAuthoredProjectionFingerprint(rootInput, vcs, repoRoot, {
-        onDiagnostic: onProjectionDiagnostic
-      });
-      onProgress?.("baseline-done");
-    }
-
     const mergeMessage = semanticMergeMessage(commits, repoRoot, branch, vcs)
       ?? `materializer: merge session ${branch.slice("sessions/".length)}`;
     vcs.checkout(repoRoot, trunkBranch);
@@ -190,13 +186,25 @@ function materializeBranches(
     // differs from the session branch carries an edit no ref holds — authored
     // after the submission — and resetting would destroy it. Those are copied
     // aside and reported rather than discarded or allowed to wedge the merge.
+    const branchTouchedPaths = vcs.changedFilesBetween(repoRoot, trunkBranch, branch);
     const preservedWorktreeEdits = vcs.resetWorktreePaths(
       repoRoot,
       trunkBranch,
-      vcs.changedFilesBetween(repoRoot, trunkBranch, branch),
+      branchTouchedPaths,
       { restoreRef: branch }
     );
-    const beforeMergeHead = vcs.currentHead(repoRoot);
+    if (projectionSourceFingerprintBeforeMerge === undefined) {
+      // Session publication deliberately leaves its authored bytes in the
+      // worktree. Capture the canonical projection baseline only after the
+      // touched paths have been restored to trunk, otherwise those future
+      // merge bytes make a clean trusted generation look dirty and force a
+      // full rebuild.
+      onProgress?.("baseline-start");
+      projectionSourceFingerprintBeforeMerge = captureTrustedAuthoredProjectionFingerprint(rootInput, vcs, repoRoot, {
+        onDiagnostic: onProjectionDiagnostic
+      });
+      onProgress?.("baseline-done");
+    }
     let preservedArtifacts: ReadonlyArray<PreservedMachineArtifact> = [];
     try {
       onProgress?.("merge-start");
@@ -239,8 +247,7 @@ function materializeBranches(
         continue;
       }
     }
-    const afterMergeHead = vcs.currentHead(repoRoot);
-    for (const relativePath of vcs.changedFilesBetween(repoRoot, beforeMergeHead, afterMergeHead)) {
+    for (const relativePath of branchTouchedPaths) {
       touchedPaths.add(path.join(repoRoot, relativePath));
     }
     vcs.deleteBranch(repoRoot, branch);
@@ -269,6 +276,7 @@ function materializeBranches(
       onAttributionDecision: onProjectionAttributionDecision,
       onDiagnostic: onProjectionDiagnostic
     });
+    projectionSourceHash = projectionUpdate.sourceHash;
     onProjectionMode?.(
       projectionUpdate.mode,
       projectionUpdate.mode === "rebuild" ? projectionUpdate.rebuildReason : undefined
@@ -302,6 +310,7 @@ function materializeBranches(
     branches: reports,
     warnings,
     projectionRebuilt,
+    ...(projectionSourceHash ? { projectionSourceHash } : {}),
     attributionEventsProjected: 0
   };
 }

--- a/packages/kernel/test/store/attribution-union-projection.test.ts
+++ b/packages/kernel/test/store/attribution-union-projection.test.ts
@@ -184,7 +184,7 @@ test("materializer applies V2-over-V1 precedence even when called with both vers
   });
 });
 
-test("V2 revisions are unique within a workspace across full rebuild and incremental writes", () => {
+test("V2 projection preserves every operation in a shared workspace publication revision", () => {
   withTempStore((rootDir) => {
     const projectionPath = path.join(rootDir, "projection.sqlite");
     writeFileSync(projectionPath, "", "utf8");
@@ -209,11 +209,43 @@ test("V2 revisions are unique within a workspace across full rebuild and increme
     const duplicate = v2Event([mutation("fact", "fact/task_T/F-4", "create")], {
       workspaceId: "workspace-1", opId: "v2-op-4", revision: 1
     });
-    assert.throws(() => materializeAttributionProjectionFromEvents(projectionPath, [first, duplicate]));
+    assert.equal(materializeAttributionProjectionFromEvents(projectionPath, [first, duplicate]).length, 2);
+    const sharedRevision = new DatabaseSync(projectionPath, { readOnly: true });
+    try {
+      assert.deepEqual(sharedRevision.prepare(`
+        SELECT op_id FROM attribution_event_headers
+        WHERE workspace_id = 'workspace-1' AND revision = 1
+        ORDER BY op_id
+      `).all().map((row) => row.op_id), ["v2-op", "v2-op-4"]);
+    } finally {
+      sharedRevision.close();
+    }
+
+    const batchFirst = v2Event([mutation("fact", "fact/task_T/F-5", "create")], {
+      workspaceId: "workspace-1", opId: "v2-op-5", revision: 2
+    });
+    const batchSecond = v2Event([mutation("fact", "fact/task_T/F-6", "create")], {
+      workspaceId: "workspace-1", opId: "v2-op-6", revision: 2
+    });
+    runSqlite(projectionPath, Effect.flatMap(SqlClient.SqlClient, (sql) => applyAttributionProjectionDelta(sql, {
+      deleteEventIds: [],
+      upsertEvents: [batchFirst, batchSecond],
+      affectedSubjects: ["fact/task_T/F-5", "fact/task_T/F-6"]
+    })));
+    const incrementalBatch = new DatabaseSync(projectionPath, { readOnly: true });
+    try {
+      assert.deepEqual(incrementalBatch.prepare(`
+        SELECT op_id FROM attribution_event_headers
+        WHERE workspace_id = 'workspace-1' AND revision = 2
+        ORDER BY op_id
+      `).all().map((row) => row.op_id), ["v2-op-5", "v2-op-6"]);
+    } finally {
+      incrementalBatch.close();
+    }
   });
 });
 
-test("existing global-revision SQLite projection migrates to workspace-scoped uniqueness", () => {
+test("existing global-revision SQLite projection migrates to operation-scoped revision identity", () => {
   withTempStore((rootDir) => {
     const projectionPath = path.join(rootDir, "projection.sqlite");
     const db = new DatabaseSync(projectionPath);
@@ -238,6 +270,37 @@ test("existing global-revision SQLite projection migrates to workspace-scoped un
     const first = v2Event([mutation("fact", "fact/task_T/F-1", "create")]);
     const second = v2Event([mutation("fact", "fact/task_T/F-2", "create")], {
       workspaceId: "workspace-2", opId: "v2-op-2", revision: 1
+    });
+    assert.equal(materializeAttributionProjectionFromEvents(projectionPath, [first, second]).length, 2);
+  });
+});
+
+test("existing workspace-revision SQLite projection accepts a multi-operation revision after migration", () => {
+  withTempStore((rootDir) => {
+    const projectionPath = path.join(rootDir, "projection.sqlite");
+    const db = new DatabaseSync(projectionPath);
+    try {
+      db.exec(`
+        CREATE TABLE attribution_event_headers (
+          event_id TEXT PRIMARY KEY, op_id TEXT NOT NULL UNIQUE, workspace_id TEXT NOT NULL,
+          revision INTEGER NOT NULL, commit_sha TEXT NOT NULL, previous_commit TEXT,
+          principal_person_id TEXT NOT NULL, executor_agent_id TEXT, occurred_at TEXT NOT NULL,
+          recorded_at TEXT NOT NULL, source_json TEXT NOT NULL,
+          UNIQUE (workspace_id, revision)
+        );
+        CREATE TABLE attribution_event_mutations (
+          event_id TEXT NOT NULL, mutation_index INTEGER NOT NULL, registry_version INTEGER NOT NULL,
+          entity_kind TEXT NOT NULL, subject_ref TEXT NOT NULL, operation TEXT NOT NULL,
+          PRIMARY KEY (event_id, mutation_index),
+          FOREIGN KEY (event_id) REFERENCES attribution_event_headers(event_id) ON DELETE CASCADE
+        );
+      `);
+    } finally {
+      db.close();
+    }
+    const first = v2Event([mutation("fact", "fact/task_T/F-1", "create")]);
+    const second = v2Event([mutation("fact", "fact/task_T/F-2", "create")], {
+      workspaceId: "workspace-1", opId: "v2-op-2", revision: 1
     });
     assert.equal(materializeAttributionProjectionFromEvents(projectionPath, [first, second]).length, 2);
   });

--- a/packages/kernel/test/store/ledger-materializer.test.ts
+++ b/packages/kernel/test/store/ledger-materializer.test.ts
@@ -51,6 +51,7 @@ test("session publication defers projection notification until materializer merg
     let commitExistenceReads = 0;
     let ignoredPathReads = 0;
     const postCommitPhases: string[] = [];
+    const projectionFingerprintDiagnostics: unknown[] = [];
     const projectionChanges: unknown[] = [];
     const coordinator = makeJournaledWriteCoordinator({
       attribution: testWriteAttribution(),
@@ -72,6 +73,7 @@ test("session publication defers projection notification until materializer merg
           return local.ignoredPaths!(repoRoot, relativePaths);
         }
       },
+      onProjectionFingerprintDiagnostic: (diagnostic) => projectionFingerprintDiagnostics.push(diagnostic),
       onPostCommitPhase: (phase) => postCommitPhases.push(phase),
       onProjectionChange: (event) => projectionChanges.push(event)
     });
@@ -88,6 +90,11 @@ test("session publication defers projection notification until materializer merg
     assert.ok(postCommitPhases.includes("projection-hash-start"));
     assert.ok(postCommitPhases.includes("projection-hash-done"));
     assert.deepEqual(projectionChanges, []);
+    assert.deepEqual(
+      projectionFingerprintDiagnostics,
+      [],
+      "session acceptance defers projection fingerprint work to the materializer"
+    );
     assert.equal(commitExistenceReads, 0, "path-at-commit is already the event durability check");
     assert.equal(ignoredPathReads, 1, "accepted paths are checked once before durable enqueue");
     assert.equal(existsSync(path.join(rootDir, "harness/tasks/task-deferred-projection/INDEX.md")), true);

--- a/packages/kernel/test/store/sqlite-incremental-projection-k4.test.ts
+++ b/packages/kernel/test/store/sqlite-incremental-projection-k4.test.ts
@@ -1,0 +1,151 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import { deriveRelationId, formatRelationFlowRecord, type EntityRelationRecord } from "../../src/domain/index.ts";
+import { captureProjectionSourceSnapshot } from "../../src/projection/projection-source-snapshot.ts";
+import { updateTaskProjectionIncrementally } from "../../src/projection/sqlite-task-incremental-projection.ts";
+import { rebuildTaskProjection } from "../../src/projection/sqlite-task-projection.ts";
+
+test("an unreferenced relation-free task addition leaves the persisted relation subgraph untouched", () => {
+  withProjectionRoot((rootDir) => {
+    seedRelationGraph(rootDir);
+    rebuildTaskProjection({ rootDir });
+    const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+    const database = new DatabaseSync(projectionPath);
+    let initialEdgeCount: number;
+    try {
+      initialEdgeCount = Number(database.prepare("SELECT COUNT(*) AS count FROM relation_edges").get()?.count);
+      assert.ok(initialEdgeCount > 0);
+      database.exec(`
+        CREATE TRIGGER reject_unaffected_relation_graph_delete
+        BEFORE DELETE ON relation_edges
+        BEGIN SELECT RAISE(FAIL, 'unaffected relation graph rewritten'); END
+      `);
+    } finally {
+      database.close();
+    }
+
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    const touchedPath = writeTask(rootDir, "task-isolated", []);
+    const result = updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [touchedPath],
+      previousSourceFingerprint
+    });
+
+    assert.equal(result.mode, "incremental");
+    const updated = new DatabaseSync(projectionPath, { readOnly: true });
+    try {
+      assert.equal(updated.prepare("SELECT COUNT(*) AS count FROM relation_edges").get()?.count, initialEdgeCount);
+      assert.equal(updated.prepare("SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'trigger' AND name = 'reject_unaffected_relation_graph_delete'").get()?.count, 1);
+    } finally {
+      updated.close();
+    }
+  });
+});
+
+test("a relation edit updates only changed graph rows", () => {
+  withProjectionRoot((rootDir) => {
+    const changedRelation = relation("task/task-a", "task/task-b", "before");
+    seedRelationGraph(rootDir, changedRelation);
+    rebuildTaskProjection({ rootDir });
+    const projectionPath = path.join(rootDir, ".harness/cache/projections.sqlite");
+    const database = new DatabaseSync(projectionPath);
+    let protectedRelationId: string;
+    try {
+      protectedRelationId = String(database.prepare(
+        "SELECT relation_id FROM relation_edges WHERE relation_id <> ? ORDER BY relation_id LIMIT 1"
+      ).get(changedRelation.relation_id)?.relation_id ?? "");
+      assert.ok(protectedRelationId);
+      database.exec(`
+        CREATE TRIGGER reject_unaffected_relation_delete
+        BEFORE DELETE ON relation_edges
+        WHEN OLD.relation_id = '${protectedRelationId}'
+        BEGIN SELECT RAISE(FAIL, 'unaffected relation row deleted'); END
+      `);
+    } finally {
+      database.close();
+    }
+
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    const touchedPath = writeTask(rootDir, "task-a", [{ ...changedRelation, rationale: "after" }]);
+    const result = updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths: [touchedPath],
+      previousSourceFingerprint
+    });
+
+    assert.equal(result.mode, "incremental");
+    const updated = new DatabaseSync(projectionPath, { readOnly: true });
+    try {
+      assert.equal(updated.prepare("SELECT COUNT(*) AS count FROM relation_edges WHERE relation_id = ?")
+        .get(protectedRelationId)?.count, 1);
+      assert.equal(updated.prepare("SELECT rationale FROM relation_edges WHERE relation_id = ?")
+        .get(changedRelation.relation_id)?.rationale, "after");
+    } finally {
+      updated.close();
+    }
+  });
+});
+
+function withProjectionRoot(run: (rootDir: string) => void): void {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-k4-relation-projection-"));
+  try {
+    run(rootDir);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function seedRelationGraph(rootDir: string, first = relation("task/task-a", "task/task-b", "existing")): void {
+  writeTask(rootDir, "task-a", [first]);
+  writeTask(rootDir, "task-b", [relation("task/task-b", "task/task-c", "unaffected")]);
+  writeTask(rootDir, "task-c", []);
+}
+
+function writeTask(rootDir: string, taskId: string, relations: ReadonlyArray<EntityRelationRecord>): string {
+  const taskDir = path.join(rootDir, "harness/tasks", taskId);
+  mkdirSync(taskDir, { recursive: true });
+  const indexPath = path.join(taskDir, "INDEX.md");
+  const title = `Task ${taskId}`;
+  writeFileSync(indexPath, [
+    "---",
+    "schema: task-package/v2",
+    `task_id: ${taskId}`,
+    `title: ${title}`,
+    "lifecycle:",
+    "  bindingSchema: lifecycle-binding/v1",
+    "  engine: local",
+    "  status: active",
+    "  ref: ",
+    `  titleSnapshot: ${title}`,
+    "  url: ",
+    "  bindingCreatedAt: 2026-07-07T00:00:00.000Z",
+    "  bindingFingerprint: sha256:fixture",
+    "packageDisposition: active",
+    "vertical: default",
+    "preset: default",
+    ...(relations.length > 0 ? ["relations:", ...relations.map(formatRelationFlowRecord)] : []),
+    "---",
+    "",
+    `# ${title}`,
+    ""
+  ].join("\n"));
+  return indexPath;
+}
+
+function relation(source: string, target: string, rationale: string): EntityRelationRecord {
+  const base = { source, target, type: "depends-on" as const, direction: "directed" as const };
+  return {
+    relation_id: deriveRelationId(base),
+    ...base,
+    strength: "strong",
+    origin: "declared",
+    rationale,
+    state: "active"
+  };
+}

--- a/packages/kernel/test/store/sqlite-incremental-projection.test.ts
+++ b/packages/kernel/test/store/sqlite-incremental-projection.test.ts
@@ -47,7 +47,6 @@ test("first task edit after a full rebuild stays incremental", () => {
     assert.equal(fresh.rows.find((row) => row.taskId === "task-a")?.canonicalStatus, "done");
   });
 });
-
 test("task edit with a new attribution event stays incremental and immediately fresh", () => {
   withProjectionPair((rootDir) => {
     seedHarness(rootDir);
@@ -68,6 +67,31 @@ test("task edit with a new attribution event stays incremental and immediately f
     assert.equal(fresh.warnings.some((warning) => warning.code === "projection_stale"), false);
     assert.equal(fresh.warnings.some((warning) => warning.severity === "hard-fail"), false);
     assert.equal(fresh.rows.find((row) => row.taskId === "task-a")?.attribution.latestActor?.principal.personId, "person_test");
+  });
+});
+
+test("a batch of append-only attribution events stays on the projected op-id delta path", () => {
+  withProjectionPair((rootDir) => {
+    seedHarness(rootDir);
+    rebuildTaskProjection({ rootDir });
+    const previousSourceFingerprint = captureProjectionSourceSnapshot(rootDir).fingerprint;
+    const touchedPaths = [
+      writeAttributionEvent(rootDir, "event-batch-a", "task/task-a"),
+      writeAttributionEvent(rootDir, "event-batch-b", "task/task-b"),
+      writeAttributionEvent(rootDir, "event-batch-c", "task/task-c")
+    ];
+    const decisions: string[] = [];
+
+    const result = updateTaskProjectionIncrementally({
+      rootDir,
+      touchedPaths,
+      previousSourceFingerprint,
+      onAttributionDecision: (reason) => decisions.push(reason)
+    });
+
+    assert.equal(result.mode, "incremental");
+    assert.deepEqual(decisions, ["append-batch"]);
+    assert.equal(readAttributionProjection(rootDir).length, 3);
   });
 });
 


### PR DESCRIPTION
## Summary

Two production write-path root causes, found and fixed together (round K4 of the a-durable campaign):

1. **Child event loop blocked by synchronous materializer** — foreground write acceptance was starved behind materialization work, producing the 36s batch wall and the 3-concurrent tail write loss.
2. **SQLite projection wrongly assumed one operation per workspace revision** — the same defect family as #1347 (attribution double-mint wedging all ingest): the projection layer now accepts multiple operations per revision instead of dying on UNIQUE violations.

## Measurements (production-scale copy)

- 3-concurrent batch: all writes durable, **zero loss** (previously tail loss)
- Batch wall: **36.0s → 9.861s (−72.6%)**
- Acceptance receipts: 3.970s / 6.818s / 9.138s; single warm write 8.210s
- Direct integration: 81 passed; `check:local` fully green (125.8s)

## Production source delta

`production +1367/-531, test +712/-36`. Retained legacy paths: none — the synchronous materializer path is replaced, not wrapped.

## Context

Main is now the archive/transition line (rebuild adjudicated in dec_01KZQ92VEPTDRS2HS8CKDBKW2Q); this lands as a P0-class transition fix: it removes real write loss on the line that stays in production until cutover.

## 中文摘要

一次修掉生产写路两个根因:①子进程事件循环被同步 materializer 阻塞(36s batch 墙与 3 并发队尾丢写的真因);②SQLite 投影假设每 revision 单 operation——与 #1347 双铸撞死 ingest 同族,投影侧现已接受多 operation。实测:3 并发零丢失,batch 墙 36.0s→9.861s(−72.6%),direct integration 81 通过,check:local 全绿。production +1367/-531;无保留旧路径(同步 materializer 是替换不是包裹)。main 已定位为过渡/archive 线,本 PR 属 cutover 前的 P0 级过渡修复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)