### PR TITLE
fix(ci): narrow rebuild-gates push trigger to rebuild/main

### DIFF
--- a/.github/workflows/rebuild-gates.yml
+++ b/.github/workflows/rebuild-gates.yml
@@ -11,7 +11,7 @@ on:
     types: [opened, reopened, synchronize, edited]
   push:
     branches:
-      - "rebuild/**"
+      - "rebuild/main"
 
 permissions:
   contents: read

--- a/tools/gates/test/workflow-base-sha.test.mjs
+++ b/tools/gates/test/workflow-base-sha.test.mjs
@@ -6,6 +6,17 @@ import test from "node:test";
 
 const workflowPath = path.join(process.cwd(), ".github/workflows/rebuild-gates.yml");
 
+test("push trigger covers only rebuild/main — feature branches gate through pull_request runs, whose diff is the full PR; a feature-branch push run would re-evaluate walls against the narrow event.before diff and mint contradictory conclusions on the same head SHA (dec_01KZTQ1KRG17545YMSFKXJGEPN)", () => {
+  const workflow = readFileSync(workflowPath, "utf8");
+  const pushBlock = workflow.match(/\n {2}push:\n {4}branches:\n((?: {6}- .*\n)+)/u);
+  assert.ok(pushBlock, "rebuild-gates must keep an explicit push trigger for post-merge main gating");
+  assert.deepEqual(
+    pushBlock[1].trim().split("\n").map((line) => line.trim()),
+    ['- "rebuild/main"'],
+    "push trigger must list exactly rebuild/main"
+  );
+});
+
 test("diff-based gates guard BASE_SHA against the zero SHA of a first branch push", () => {
   const workflow = readFileSync(workflowPath, "utf8");
   for (const gate of ["tools/gates/test-selection.mjs", "tools/gates/line-budget.mjs"]) {


### PR DESCRIPTION
# English

## Summary

Narrow the rebuild-gates `push` trigger from `rebuild/**` to `rebuild/main`. Feature branches are already fully gated by the `pull_request` run (whole-PR diff); the extra push-event run re-evaluated diff-scoped walls (test-selection governance-fixture, line-budget) against the narrow `github.event.before` increment and minted contradictory conclusions on the same head SHA — red push runs beside green PR runs, three times during PR #1353, polluting every watcher.

## What Changed

- `.github/workflows/rebuild-gates.yml`: `push.branches` now lists exactly `rebuild/main` (post-merge main gating retained; one line changed).
- `tools/gates/test/workflow-base-sha.test.mjs`: new assertion pinning the push-trigger shape, with the rationale and decision id in the test name. Mutation-checked: restoring `rebuild/**` makes the test fail.

## Task And Scope

- Harness task: task_01KZTQ29PG3M8ZFWAKZXJTZYSX under dec_01KZTQ1KRG17545YMSFKXJGEPN (accepted), parent task_01KZRMKJT7YKQ2TNXA8WR1W5DN (reset-rebuild write-chain program)
- Branch: `rebuild/gates-push-narrow` → `rebuild/main`
- Public scope: one workflow trigger line + one gate test
- Private planning/evidence updated: yes (decision + task ledger)
- Out of scope: any change to gate semantics, wall strength, or job composition

## Version Impact

- Version: no version change because the rebuild line does not publish per-slice.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: .github/workflows/rebuild-gates.yml (trigger only), tools/gates/test/ (assertion added)
- Authority: dec_01KZTQ1KRG17545YMSFKXJGEPN via task_01KZTQ29PG3M8ZFWAKZXJTZYSX. No gate is weakened: every wall keeps running with identical strength on pull_request runs and on rebuild/main pushes; the change deletes a duplicate execution surface whose diff scoping was wrong, and the governance-fixture wall requirement is satisfied by the new tools/gates/test assertion in the same change.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/rebuild/main` SHA: 46f6d3245bf6c2d90ddee53c3f986ec85a7333e8 (merge-base identical, fast-forward)
- Local: `node --test tools/gates/test/workflow-base-sha.test.mjs` 2/2 pass; mutation control (revert trigger to `rebuild/**`) fails 3 assertions; `node tools/gates/test-selection.mjs --base origin/rebuild/main` ok=true (governance-fixture wall satisfied by same-change test).
- CI: pull_request run on this PR is the authoritative gate surface.

Production-Delta: +0/-0

Dependency-Change: none.

## Residual Risk

- Feature branches named `rebuild/*` no longer get push-event runs; anything not covered by a PR run (none known — all merges go through PRs) would lose that redundant signal.

---

# 中文

## 摘要

把 rebuild-gates 的 `push` 触发从 `rebuild/**` 收窄到 `rebuild/main`。feature 分支本就由 pull_request run(全 PR diff)完整守门;多出来的 push run 用窄增量(`github.event.before`)重评 diff 口径的墙(test-selection governance-fixture、line-budget),在同一 head SHA 上铸出与 PR run 相反的结论——PR #1353 期间三次出现"push run 红、PR run 绿",持续污染观测面。

## 变更内容

- workflow:`push.branches` 只留 `rebuild/main`(合并后 main 守门保留;改动一行)。
- `tools/gates/test/workflow-base-sha.test.mjs`:新增触发面断言,断言名内嵌理由与 decision id;已做突变对照(改回 `rebuild/**` 测试即红)。

## 任务与范围

- 任务:task_01KZTQ29PG3M8ZFWAKZXJTZYSX,决策 dec_01KZTQ1KRG17545YMSFKXJGEPN(已 accept),父任务 task_01KZRMKJT7YKQ2TNXA8WR1W5DN
- 分支:`rebuild/gates-push-narrow` → `rebuild/main`
- 范围:一行触发面 + 一个门测试;不动任何门语义与强度

## 版本影响

- 无版本变更(rebuild 线不按片发布)。

## 治理声明

- 触碰 protected surface:是(workflow 触发面 + gate test)
- 授权:dec_01KZTQ1KRG17545YMSFKXJGEPN。未削任何门:全部墙在 pull_request 与 rebuild/main push 上强度不变;删除的是 diff 口径错误的重复执行面;governance-fixture 墙由同变更的新测试满足。
- Break-glass:否;后续治理任务:无

## 验证

- 基线 46f6d324(fast-forward);本地 workflow-base-sha 测试 2/2 绿 + 突变对照 3 断言红;test-selection 墙 ok=true。
- CI 以本 PR 的 pull_request run 为权威。

## 残余风险

- `rebuild/*` 命名的 feature 分支不再有 push run;所有合并都走 PR,无已知未覆盖路径。
