### PR TITLE
fix(cli): bound preset validation scans

### DIFF
--- a/packages/cli/src/commands/extensions/preset-script-context.ts
+++ b/packages/cli/src/commands/extensions/preset-script-context.ts
@@ -82,18 +82,24 @@ export function buildPresetContextProjections(options: {
   readonly env?: NodeJS.ProcessEnv;
 }): Record<string, unknown> {
   const milestoneLimits = resolvePresetContextMilestoneLimits(options);
+  const markdownFiles = collectMarkdownFiles(options.readRoots);
+  const readableRoots = new Set(options.readRoots.map((root) => path.resolve(root)));
   return {
-    taskIndex: readTaskIndexContext(options.layout, options.readRoots),
-    taskEvidence: readTaskEvidenceContext(options.layout, options.outputRoot, options.readRoots),
-    milestoneCriteria: readMilestoneCriteriaContext(options.layout, options.readRoots),
-    milestoneNotes: readMilestoneNotesContext(options.layout, options.readRoots, milestoneLimits),
-    decisions: readDecisionContext(options.layout, options.readRoots),
-    factRefs: readFactRefsContext(options.layout, options.readRoots)
+    taskIndex: readTaskIndexContext(options.layout, markdownFiles, readableRoots),
+    taskEvidence: readTaskEvidenceContext(options.layout, options.outputRoot, markdownFiles, readableRoots),
+    milestoneCriteria: readMilestoneCriteriaContext(options.layout, markdownFiles),
+    milestoneNotes: readMilestoneNotesContext(options.layout, markdownFiles, milestoneLimits),
+    decisions: readDecisionContext(options.layout, markdownFiles),
+    factRefs: readFactRefsContext(options.layout, markdownFiles)
   };
 }
 
-function readTaskIndexContext(layout: ResolvedLayout, readRoots: ReadonlyArray<string>): ReadonlyArray<PresetContextTask> {
-  return collectMarkdownFiles(readRoots)
+function readTaskIndexContext(
+  layout: ResolvedLayout,
+  markdownFiles: ReadonlyArray<string>,
+  readableRoots: ReadonlySet<string>
+): ReadonlyArray<PresetContextTask> {
+  return markdownFiles
     .filter((filePath) => path.basename(filePath) === "INDEX.md" && isPathInside(layout.tasksRoot, filePath))
     .flatMap((indexPath) => {
       const body = readOptionalFile(indexPath);
@@ -110,7 +116,7 @@ function readTaskIndexContext(layout: ResolvedLayout, readRoots: ReadonlyArray<s
         preset: scalar(frontmatter, "preset"),
         indexPath: relativeContextPath(layout.rootDir, indexPath),
         packagePath: relativeContextPath(layout.rootDir, path.dirname(indexPath)),
-        taskPlanSummary: isReadablePath(taskPlanPath, readRoots) ? summarizeMarkdown(readOptionalFile(taskPlanPath)) : ""
+        taskPlanSummary: isReadablePath(taskPlanPath, readableRoots) ? summarizeMarkdown(readOptionalFile(taskPlanPath)) : ""
       }];
     })
     .sort((left, right) => left.taskId.localeCompare(right.taskId));
@@ -119,10 +125,12 @@ function readTaskIndexContext(layout: ResolvedLayout, readRoots: ReadonlyArray<s
 function readTaskEvidenceContext(
   layout: ResolvedLayout,
   outputRoot: string,
-  readRoots: ReadonlyArray<string>
+  markdownFiles: ReadonlyArray<string>,
+  readableRoots: ReadonlySet<string>
 ): ReadonlyArray<{ readonly sourcePath: string; readonly body: string }> {
-  if (!isReadablePath(outputRoot, readRoots)) return [];
-  return collectMarkdownFiles([outputRoot])
+  if (!isReadablePath(outputRoot, readableRoots)) return [];
+  return markdownFiles
+    .filter((filePath) => isPathInside(outputRoot, filePath))
     .filter((filePath) => !toSlash(path.relative(outputRoot, filePath)).startsWith("artifacts/"))
     .map((filePath) => ({
       sourcePath: relativeContextPath(layout.rootDir, filePath),
@@ -132,9 +140,9 @@ function readTaskEvidenceContext(
 
 function readMilestoneCriteriaContext(
   layout: ResolvedLayout,
-  readRoots: ReadonlyArray<string>
+  markdownFiles: ReadonlyArray<string>
 ): ReadonlyArray<{ readonly status: "red"; readonly reason: "unclassified"; readonly sourcePath: string; readonly line: number; readonly checked: boolean; readonly text: string }> {
-  return collectMarkdownFiles(readRoots)
+  return markdownFiles
     .filter((filePath) => isPathInside(layout.milestonesRoot, filePath))
     .filter((filePath) => /(?:^|\/)(?:feature-breakdown|milestone-closeout|exit-criteria)\.md$/u.test(toSlash(filePath)))
     .flatMap((filePath) => {
@@ -156,11 +164,11 @@ function readMilestoneCriteriaContext(
 
 function readMilestoneNotesContext(
   layout: ResolvedLayout,
-  readRoots: ReadonlyArray<string>,
+  markdownFiles: ReadonlyArray<string>,
   limits: { readonly maxFiles: number; readonly maxNotes: number }
 ): ReadonlyArray<string> {
   const notes: string[] = [];
-  for (const filename of collectMarkdownFiles(readRoots).filter((filePath) => isPathInside(layout.milestonesRoot, filePath)).slice(0, limits.maxFiles)) {
+  for (const filename of markdownFiles.filter((filePath) => isPathInside(layout.milestonesRoot, filePath)).slice(0, limits.maxFiles)) {
     for (const line of readOptionalFile(filename).split(/\r?\n/u)) {
       const trimmed = line.trim();
       if (/acceptance|验收|criteria/iu.test(trimmed)) notes.push(trimmed.replace(/^[-*#\s]+/u, ""));
@@ -190,8 +198,8 @@ function contextLimit(name: string, explicit: number | undefined, raw: string | 
   return value;
 }
 
-function readDecisionContext(layout: ResolvedLayout, readRoots: ReadonlyArray<string>): ReadonlyArray<PresetContextDecision> {
-  return collectMarkdownFiles(readRoots)
+function readDecisionContext(layout: ResolvedLayout, markdownFiles: ReadonlyArray<string>): ReadonlyArray<PresetContextDecision> {
+  return markdownFiles
     .filter((filePath) => path.basename(filePath) === "decision.md" && isPathInside(layout.decisionsRoot, filePath))
     .flatMap((filePath) => {
       const body = readOptionalFile(filePath);
@@ -207,9 +215,9 @@ function readDecisionContext(layout: ResolvedLayout, readRoots: ReadonlyArray<st
     });
 }
 
-function readFactRefsContext(layout: ResolvedLayout, readRoots: ReadonlyArray<string>): ReadonlyArray<string> {
+function readFactRefsContext(layout: ResolvedLayout, markdownFiles: ReadonlyArray<string>): ReadonlyArray<string> {
   const refs = new Set<string>();
-  for (const factsPath of collectMarkdownFiles(readRoots).filter((filePath) => path.basename(filePath) === "facts.md" && isPathInside(layout.tasksRoot, filePath))) {
+  for (const factsPath of markdownFiles.filter((filePath) => path.basename(filePath) === "facts.md" && isPathInside(layout.tasksRoot, filePath))) {
     const taskDir = path.dirname(factsPath);
     const taskId = readTaskId(taskDir) || path.basename(taskDir);
     for (const match of readOptionalFile(factsPath).matchAll(/\bfact_id:\s*"?([A-Za-z0-9_-]+)"?/gu)) {
@@ -318,8 +326,14 @@ function walkMarkdown(root: string): ReadonlyArray<string> {
   });
 }
 
-function isReadablePath(candidate: string, readRoots: ReadonlyArray<string>): boolean {
-  return readRoots.some((readRoot) => isPathInside(readRoot, candidate));
+function isReadablePath(candidate: string, readableRoots: ReadonlySet<string>): boolean {
+  let current = path.resolve(candidate);
+  while (true) {
+    if (readableRoots.has(current)) return true;
+    const parent = path.dirname(current);
+    if (parent === current) return false;
+    current = parent;
+  }
 }
 
 function summarizeMarkdown(markdown: string): string {

--- a/packages/cli/src/commands/extensions/script-executor.ts
+++ b/packages/cli/src/commands/extensions/script-executor.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { writeMachineEvidenceRegistry } from "./machine-evidence-registry.ts";
 import { isPathInside, listGeneratedFiles, uniquePermissionPaths } from "./script-scope.ts";
@@ -91,6 +91,10 @@ export function executeScript(options: ScriptExecutorOptions): ScriptExecutionRe
   }
   writeMachineEvidenceRegistry(options.outputRoot, generated);
   return { ok: true, generated, stdout, stderr };
+}
+
+export function writeScriptOutputIfPresent(filePath: string, body: string): void {
+  if (body.length > 0) writeFileSync(filePath, body, "utf8");
 }
 
 function listArtifactFiles(roots: ReadonlyArray<string>): ReadonlyArray<string> {

--- a/packages/cli/src/commands/extensions/script-host-validation.ts
+++ b/packages/cli/src/commands/extensions/script-host-validation.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { cliError, CliErrorCode } from "../../cli/error-codes.ts";
 import type { CliResult } from "../../cli/types.ts";
 import type { PresetPolicyResolution } from "./preset-policy.ts";
-import type { ResolvedScriptEntry } from "./script-host.ts";
+import type { ResolvedScriptEntry, ScriptEntry } from "./script-host.ts";
 
 export function validateResolvedScript(script: ResolvedScriptEntry): { readonly ok: true } | { readonly ok: false; readonly hint: string } {
   const entry = script.entry;
@@ -17,6 +17,12 @@ export function validateResolvedScript(script: ResolvedScriptEntry): { readonly 
     return { ok: false, hint: "Script metadata kind must be action or check." };
   }
   return { ok: true };
+}
+
+export function reportsNoOverwriteLeafConflicts(entry: ScriptEntry): boolean {
+  return entry.metadata.purpose === "scaffold" &&
+    entry.writes.length > 0 &&
+    entry.writes.every((scope) => scope.endsWith("/**") && entry.reads.includes(scope));
 }
 
 export function invalidScriptOrPolicy(

--- a/packages/cli/src/commands/extensions/script-host.ts
+++ b/packages/cli/src/commands/extensions/script-host.ts
@@ -10,10 +10,15 @@ import type { CliResult } from "../../cli/types.ts";
 import { resolveScriptPolicy } from "./preset-policy.ts";
 import { buildPresetContextProjections } from "./preset-script-context.ts";
 import { scriptChildEnvironment } from "./script-environment.ts";
-import { executeScript } from "./script-executor.ts";
+import { executeScript, writeScriptOutputIfPresent } from "./script-executor.ts";
 import { trustedScriptRepositoryContext } from "./script-repository-context.ts";
 import { cachedScriptSyntaxCheck } from "./script-syntax-check.ts";
-import { invalidScriptOrPolicy, scriptFailure, validateResolvedScript } from "./script-host-validation.ts";
+import {
+  invalidScriptOrPolicy,
+  reportsNoOverwriteLeafConflicts,
+  scriptFailure,
+  validateResolvedScript
+} from "./script-host-validation.ts";
 import type { ResolvedPreset } from "./state.ts";
 import {
   materializeSemanticPresetExecution,
@@ -24,6 +29,7 @@ import {
 } from "./preset-capability-runtime.ts";
 import {
   isPathInside,
+  isolateValidationSmokeReadScope,
   permissionPathsForScope,
   resolvedScopeSetIsSafe,
   resolveDeclaredReadScopes,
@@ -144,7 +150,10 @@ export function runScriptHost(options: {
     ? { ok: true as const, ...preparedSemantic.stageEnvelope }
     : resolveDeclaredWriteScopes(options.script.entry.writes, layout, outputRoot, scopeOptions);
   if (!readScope.ok) return scriptFailure(options.commandName, CliErrorCode.ScriptScopeInvalidRead, "Script reads must declare supported project-local scopes.");
-  if (!options.dryRun && !resolvedScopeSetIsSafe(readScope, layout.rootDir, "read")) {
+  const executionSourceReadScope = options.script.context?.validationSmoke === true && !preparedSemantic
+    ? isolateValidationSmokeReadScope(readScope, layout.tasksRoot, outputRoot)
+    : readScope;
+  if (!options.dryRun && !resolvedScopeSetIsSafe(executionSourceReadScope, layout.rootDir, "read")) {
     return scriptFailure(options.commandName, CliErrorCode.ScriptScopeInvalidRead, "Script read scopes must have safe filesystem boundaries.");
   }
   if (!writeScope.ok) return scriptFailure(options.commandName, CliErrorCode.ScriptScopeInvalidWrite, "Script writes must declare approved authored content scopes.");
@@ -191,7 +200,7 @@ export function runScriptHost(options: {
     stage = !options.dryRun && writeScope.roots.length > 0
       ? createCanonicalScriptStage(options.rootInput, runDir, outputRoot, {
         protectedScopes: [
-          { mode: "read", scope: readScope },
+          { mode: "read", scope: executionSourceReadScope },
           { mode: "write", scope: writeScope }
         ]
       })
@@ -207,8 +216,8 @@ export function runScriptHost(options: {
   const executionLayout = stage ? scriptExecutionLayout(stage, writeScope) : layout;
   const executionOutputRoot = stage?.outputRoot ?? outputRoot;
   const executionReadScope = stage
-    ? remapScope(stage, readScope)
-    : readScope;
+    ? remapScope(stage, executionSourceReadScope)
+    : executionSourceReadScope;
   const executionWriteScope = stage
     ? remapScope(stage, writeScope, { retainOriginalPermissions: false })
     : writeScope;
@@ -250,7 +259,7 @@ export function runScriptHost(options: {
       ? buildPresetContextProjections({
         layout: executionLayout,
         outputRoot: executionOutputRoot,
-        readRoots: executionReadScope.roots
+        readRoots: options.script.context?.validationSmoke === true ? [] : executionReadScope.roots
       })
       : {};
     writeFileSync(contextPath, JSON.stringify({
@@ -437,16 +446,6 @@ export function runScriptHost(options: {
     ...(preparedSemantic ? { capabilityReceipt: preparedSemantic.receipt } : {}),
     ...(ingestOp ? { ingestOp } : {})
   };
-}
-
-function writeScriptOutputIfPresent(filePath: string, body: string): void {
-  if (body.length > 0) writeFileSync(filePath, body, "utf8");
-}
-
-function reportsNoOverwriteLeafConflicts(entry: ScriptEntry): boolean {
-  return entry.metadata.purpose === "scaffold" &&
-    entry.writes.length > 0 &&
-    entry.writes.every((scope) => scope.endsWith("/**") && entry.reads.includes(scope));
 }
 
 function readScriptResult(

--- a/packages/cli/src/commands/extensions/script-scope.ts
+++ b/packages/cli/src/commands/extensions/script-scope.ts
@@ -15,6 +15,8 @@ interface ScopeResolutionOptions {
   readonly reportLeafConflicts?: boolean;
 }
 
+type PortableSiblingIndex = Map<string, ReadonlyMap<string, ReadonlyArray<string>>>;
+
 export function listGeneratedFiles(rootDir: string): ReadonlyArray<string> {
   if (!existsSync(rootDir)) return [];
   let rootStat;
@@ -63,6 +65,7 @@ function resolveDeclaredScopes(
   const roots: string[] = [];
   const permissions: string[] = [];
   const reportedLeafConflicts: string[] = [];
+  const portableSiblingIndex: PortableSiblingIndex = new Map();
   for (const scope of scopes) {
     const recursive = scope.endsWith("/**");
     const root = recursive ? scope.slice(0, -3) : scope;
@@ -86,8 +89,14 @@ function resolveDeclaredScopes(
       if (recursive && absolute === path.resolve(layout.rootDir)) return { ok: false };
       if (mode === "write" && !isAllowedWriteScope(absolute, layout, outputRoot)) return { ok: false };
       if (!scopeRootRealpathIsContainedOrMissing(absolute, layout.rootDir)) return { ok: false };
-      if (scopePathContainsUnsafeComponent(absolute, layout.rootDir, options)) return { ok: false };
-      const leafConflicts = reportableLeafConflicts(absolute, layout.rootDir, recursive, options.reportLeafConflicts === true);
+      if (scopePathContainsUnsafeComponentWithIndex(absolute, layout.rootDir, options, portableSiblingIndex)) return { ok: false };
+      const leafConflicts = reportableLeafConflicts(
+        absolute,
+        layout.rootDir,
+        recursive,
+        options.reportLeafConflicts === true,
+        portableSiblingIndex
+      );
       if (leafConflicts === null) return { ok: false };
       if (
         mode === "write" &&
@@ -141,14 +150,30 @@ export function scopePathContainsUnsafeComponent(
   projectRoot: string,
   options: ScopeResolutionOptions = {}
 ): boolean {
-  return scopePathComponentsAreUnsafe(root, projectRoot, true, options.reportLeafConflicts === true);
+  return scopePathContainsUnsafeComponentWithIndex(root, projectRoot, options, new Map());
+}
+
+function scopePathContainsUnsafeComponentWithIndex(
+  root: string,
+  projectRoot: string,
+  options: ScopeResolutionOptions,
+  portableSiblingIndex: PortableSiblingIndex
+): boolean {
+  return scopePathComponentsAreUnsafe(
+    root,
+    projectRoot,
+    true,
+    options.reportLeafConflicts === true,
+    portableSiblingIndex
+  );
 }
 
 function scopePathComponentsAreUnsafe(
   root: string,
   projectRoot: string,
   rejectPortableAliases: boolean,
-  allowPortableLeafAliases = false
+  allowPortableLeafAliases = false,
+  portableSiblingIndex: PortableSiblingIndex = new Map()
 ): boolean {
   const boundary = path.resolve(projectRoot);
   const target = path.resolve(root);
@@ -162,7 +187,7 @@ function scopePathComponentsAreUnsafe(
   let current = boundary;
   const segments = relative.split(path.sep).filter(Boolean);
   for (const [index, segment] of segments.entries()) {
-    const aliases = rejectPortableAliases ? portableSiblingAliases(current, segment) : [];
+    const aliases = rejectPortableAliases ? portableSiblingAliases(current, segment, portableSiblingIndex) : [];
     const reportableLeaf = allowPortableLeafAliases && index === segments.length - 1;
     if (aliases.length > 0 && !reportableLeaf) return true;
     if (aliases.some((alias) => pathIsSymlink(path.join(current, alias)))) return true;
@@ -181,14 +206,15 @@ function reportableLeafConflicts(
   root: string,
   projectRoot: string,
   recursive: boolean,
-  enabled: boolean
+  enabled: boolean,
+  portableSiblingIndex: PortableSiblingIndex = new Map()
 ): ReadonlyArray<string> | null {
   if (!enabled) return [];
   if (!recursive) return null;
   const target = path.resolve(root);
   const boundary = path.resolve(projectRoot);
   if (!sameOrInside(boundary, target)) return null;
-  const aliases = portableSiblingAliases(path.dirname(target), path.basename(target))
+  const aliases = portableSiblingAliases(path.dirname(target), path.basename(target), portableSiblingIndex)
     .map((entry) => path.join(path.dirname(target), entry));
   if (aliases.some(pathIsSymlink)) return null;
   const targetKind = filesystemKind(target);
@@ -211,13 +237,31 @@ function filesystemKind(candidate: string): "missing" | "file" | "directory" | "
   }
 }
 
-function portableSiblingAliases(parent: string, canonicalName: string): ReadonlyArray<string> {
+function portableSiblingAliases(
+  parent: string,
+  canonicalName: string,
+  portableSiblingIndex: PortableSiblingIndex
+): ReadonlyArray<string> {
   const key = portablePathKey(canonicalName);
-  try {
-    return readdirSync(parent).filter((entry) => entry !== canonicalName && portablePathKey(entry) === key);
-  } catch {
-    return [];
+  const resolvedParent = path.resolve(parent);
+  let entriesByKey = portableSiblingIndex.get(resolvedParent);
+  if (!entriesByKey) {
+    const mutableEntriesByKey = new Map<string, string[]>();
+    try {
+      for (const entry of readdirSync(resolvedParent)) {
+        const entryKey = portablePathKey(entry);
+        const entries = mutableEntriesByKey.get(entryKey) ?? [];
+        entries.push(entry);
+        mutableEntriesByKey.set(entryKey, entries);
+      }
+    } catch {
+      // A missing or unreadable parent has no observable aliases here; the
+      // component lstat below remains responsible for rejecting unsafe paths.
+    }
+    entriesByKey = mutableEntriesByKey;
+    portableSiblingIndex.set(resolvedParent, entriesByKey);
   }
+  return (entriesByKey.get(key) ?? []).filter((entry) => entry !== canonicalName);
 }
 
 function pathIsSymlink(candidate: string): boolean {
@@ -282,17 +326,24 @@ export function resolvedScopeSetIsSafe(
   mode: "read" | "write"
 ): boolean {
   const boundaries = (Array.isArray(projectRoots) ? projectRoots : [projectRoots]).map((root) => path.resolve(root));
+  const portableSiblingIndex: PortableSiblingIndex = new Map();
   return scope.roots.every((root) => {
     const boundary = boundaries.find((candidate) => sameOrInside(candidate, root));
     if (!boundary) return false;
     const recursive = scopeRootIsRecursive(scope, root);
     const options = { reportLeafConflicts: scope.reportedLeafConflicts !== undefined };
-    const currentConflicts = reportableLeafConflicts(root, boundary, recursive, options.reportLeafConflicts);
+    const currentConflicts = reportableLeafConflicts(
+      root,
+      boundary,
+      recursive,
+      options.reportLeafConflicts,
+      portableSiblingIndex
+    );
     const conflictsRemainDeclared = currentConflicts !== null && currentConflicts.every((candidate) =>
       scope.reportedLeafConflicts?.some((declared) => path.resolve(declared) === path.resolve(candidate))
     );
     return scopeRootRealpathIsContainedOrMissing(root, boundary) &&
-      !scopePathContainsUnsafeComponent(root, boundary, options) &&
+      !scopePathContainsUnsafeComponentWithIndex(root, boundary, options, portableSiblingIndex) &&
       conflictsRemainDeclared &&
       (!recursive || filesystemKind(root) !== "directory" || !recursiveScopeContainsSymlink(root)) &&
       (validScopeTarget(root, recursive, mode) || (currentConflicts?.length ?? 0) > 0);
@@ -300,11 +351,32 @@ export function resolvedScopeSetIsSafe(
 }
 
 export function scopeRootIsRecursive(scope: ResolvedScopeSet, root: string): boolean {
-  const recursiveSuffix = `${path.sep}**`;
-  return scope.permissions.some((permission) => (
-    (permission.endsWith("/**") || permission.endsWith(recursiveSuffix)) &&
-    path.resolve(permission.slice(0, -3)) === path.resolve(root)
+  const resolvedRoot = path.resolve(root);
+  return scope.permissions.includes(`${resolvedRoot}${path.sep}**`)
+    || scope.permissions.includes(`${resolvedRoot}/**`);
+}
+
+export function isolateValidationSmokeReadScope(
+  scope: ResolvedScopeSet,
+  tasksRoot: string,
+  outputRoot: string
+): { readonly ok: true } & ResolvedScopeSet {
+  const resolvedOutputRoot = path.resolve(outputRoot);
+  const roots = scope.roots.filter((root) => (
+    path.resolve(root) === resolvedOutputRoot || !sameOrInside(tasksRoot, root)
   ));
+  const permissions = [...new Set(roots.flatMap((root) => (
+    permissionPathsForScope(root, scopeRootIsRecursive(scope, root))
+  )))];
+  const reportedLeafConflicts = scope.reportedLeafConflicts?.filter((conflict) => (
+    roots.some((root) => sameOrInside(root, conflict))
+  ));
+  return {
+    ok: true,
+    roots,
+    permissions,
+    ...(reportedLeafConflicts ? { reportedLeafConflicts } : {})
+  };
 }
 
 function isAllowedWriteScope(root: string, layout: ReturnType<typeof resolveHarnessLayout>, outputRoot: string): boolean {

--- a/packages/cli/test/preset-check-smoke-cli.test.ts
+++ b/packages/cli/test/preset-check-smoke-cli.test.ts
@@ -137,6 +137,40 @@ test("preset check treats a well-formed script-result ok false as runnable", () 
   });
 });
 
+test("preset check validation smoke does not hydrate project ledger context", () => {
+  withTempRoot((rootDir) => {
+    writePreset(rootDir, "isolated-smoke-context", {
+      check: {
+        type: "script",
+        command: "scripts/check.mjs",
+        reads: ["{{paths.tasksRoot}}/*/**"],
+        writes: ["{{outputRoot}}/**"]
+      }
+    });
+    write(rootDir, "harness/tasks/task_fixture/INDEX.md", [
+      "---",
+      "task_id: task_fixture",
+      "title: Fixture task",
+      "status:",
+      "  status: active",
+      "preset: standard-task",
+      "---",
+      ""
+    ].join("\n"));
+    write(rootDir, ".harness/presets/isolated-smoke-context/scripts/check.mjs", [
+      "import { readFileSync, writeFileSync } from 'node:fs';",
+      "const context = JSON.parse(readFileSync(process.env.HARNESS_PRESET_CONTEXT, 'utf8'));",
+      "if (context.validationSmoke !== true || context.taskIndex.length !== 0 || context.readScopes.length !== 0) throw new Error('validation smoke hydrated project ledger context');",
+      "writeFileSync(process.env.HARNESS_SCRIPT_RESULT, JSON.stringify({ schema: 'script-result/v1', ok: true, report: {}, produced: [] }));",
+      ""
+    ].join("\n"));
+
+    const result = runJson(rootDir, ["preset", "check", "isolated-smoke-context"]);
+
+    assert.equal(result.report.preflight.runtimeSmoke.ok, true);
+  });
+});
+
 test("preset check rejects scripts that finish without a script-result/v1", () => {
   withTempRoot((rootDir) => {
     writePreset(rootDir, "missing-result", {


### PR DESCRIPTION
# English

## Summary

`ha preset inspect`, `preset check`, and `preset entrypoint` walked the whole repository on every invocation. On a large ledger repo that costs 65–78s wall time, most of it in filesystem syscalls. The daemon's JSON-RPC request timeout is 9s, so on that repo these commands never completed through the daemon — they failed with `DAEMON_JSON_RPC_REQUEST_TIMEOUT`, which made preset-driven milestone creation unusable. This PR bounds the scans. Measured on the same machine, same command, same data root: `preset inspect` goes from **77.61s to 4.88s**, with system time dropping from 44.5s to 1.99s.

## What Changed

- Validation smoke no longer injects or authorizes the real task ledger into its scopes.
- The Markdown projection used by formal entrypoints is scanned once and reused instead of re-scanned per entry.
- Within one scope-validation pass, the portable-name index is built once per parent directory instead of once per candidate.
- Removed a duplicate `path.resolve` comparison in the recursive scope check.
- Added a red-then-green regression test proving validation smoke no longer reaches the real task ledger.

## Task And Scope

- Harness task: `task_01KZX86V5AGNJSKKZWQDD7Y49Q` (parent `task_01KZX5SC9CYKD9C9GGW8K9YKK5`)
- Branch: `codex/preset-scan-fix`
- Public scope: `packages/cli/src/commands/extensions/**`, `packages/cli/test/preset-check-smoke-cli.test.ts`
- Private planning/evidence updated: yes
- Out of scope: daemon idle shutdown; the `daemon serve --help` side effect; the task-delete lease deadlock. These were found during this investigation and are tracked separately, not fixed here.

## Version Impact

- Version: no version change because this is an internal performance fix with no public API or contract change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KZX86V5AGNJSKKZWQDD7Y49Q`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `b31fa6ba158f3619823bbd3ed1407ebfc1f1ae6b`
- Branch merge-base with `origin/main`: `b31fa6ba158f3619823bbd3ed1407ebfc1f1ae6b`
- Last `git fetch origin` time: 2026-08-13
- Sync method: none needed (branch is a direct descendant of `origin/main`)
- Public diff command: `git diff b31fa6ba..aea85231`
- Production delta: `+154/-59`; test delta: `+34/-0`
- Private evidence commit/path: task package `closeout.md` in the private harness ledger
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: see the checks on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` (the gate set is derived from `tools/gate-manifest.json`; do not enumerate gates by hand) — 7 manifest-derived stop-point steps green
- [x] Targeted tests for the change surface, named with their counts: `preset-check-smoke-cli.test.ts` 11/11, `script-host-boundary.test.ts` 17/17, `preset-script-imports-cli.test.ts` 16/16, `preset-script-staging-boundary.test.ts` 9/9, `preset-context-limits.test.ts` 2/2, `json-rpc-protocol.test.ts` 24/24 — 79 total
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: `rewrite-ci` had not completed when this body was written; it is the authoritative gate and merge waits on it. No adversarial multi-model review was commissioned: this is a bounded performance fix on a CLI command surface, it touches no write path or protected surface, and it carries a red-then-green regression test.

## Review Evidence

- Self-review: the before/after measurement was re-run independently rather than taken from the implementer's report — `preset inspect create-milestone` against the real large ledger root, 77.61s before and 4.88s after, with system time 44.5s to 1.99s. Commit identity, base, and diff scope were verified directly.
- Reviewer subagent: not commissioned; see the reason above.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Cold `inspect` right after daemon start measures ~5.45s, above the <5s soft target, though far inside the 9s hard timeout. Making cold <5s a hard SLO would require separately addressing daemon/client startup and polling overhead.
- The pre-implementation architecture advisory ended with `script_result_failed` on a copied fixture. It is advisory only and no architecture contract was changed.
- The verification used isolated daemons and fixtures; no production daemon was stopped or restarted and no downstream project ledger was written.

## References

- Task: `task_01KZX86V5AGNJSKKZWQDD7Y49Q`
- Evidence: task package `closeout.md`
- Review: task package `artifacts/`

---

# 中文

## 概要

`ha preset inspect`、`preset check`、`preset entrypoint` 每次调用都会遍历整个仓库。在台账规模较大的仓库上这要花 65–78 秒，其中绝大部分耗在文件系统 syscall 上。daemon 的 JSON-RPC 请求超时是 9 秒，因此在这类仓库上这些命令根本无法通过 daemon 完成，一律以 `DAEMON_JSON_RPC_REQUEST_TIMEOUT` 失败，导致基于 preset 的 milestone 创建完全不可用。本 PR 收窄扫描范围。同机、同命令、同数据根实测：`preset inspect` 从 **77.61 秒降到 4.88 秒**，system time 从 44.5 秒降到 1.99 秒。

## 改动内容

- validation smoke 不再把真实 task ledger 注入或授权进自己的 scope。
- 正式 entrypoint 使用的 Markdown 投影改为扫描一次后复用，不再逐条目重复扫描。
- 同一次 scope 校验过程中，portable-name index 改为每个父目录只构建一次，不再每个候选构建一次。
- 删除 recursive scope 判断中重复的 `path.resolve` 比较。
- 新增先红后绿的回归测试，证明 validation smoke 不再触及真实 task ledger。

## 任务与范围

- Harness 任务：`task_01KZX86V5AGNJSKKZWQDD7Y49Q`（父任务 `task_01KZX5SC9CYKD9C9GGW8K9YKK5`）
- 分支：`codex/preset-scan-fix`
- 公开范围：`packages/cli/src/commands/extensions/**`、`packages/cli/test/preset-check-smoke-cli.test.ts`
- 私有计划 / 证据是否已更新：yes
- 范围外：daemon idle 自动退出；`daemon serve --help` 的副作用；task delete 的 lease 死锁。这三项是本次排查中发现的，另行立项，不在本 PR 修复。

## 版本影响

- 版本：不改版本，原因是本次为内部性能修复，未改动任何公开 API 或契约
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`task_01KZX86V5AGNJSKKZWQDD7Y49Q`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`b31fa6ba158f3619823bbd3ed1407ebfc1f1ae6b`
- 当前分支与 `origin/main` 的 merge-base：`b31fa6ba158f3619823bbd3ed1407ebfc1f1ae6b`
- 最近一次 `git fetch origin` 时间：2026-08-13
- 同步方式：不需要（分支是 `origin/main` 的直接后继）
- 公开 diff 命令：`git diff b31fa6ba..aea85231`
- Production delta：`+154/-59`；test delta：`+34/-0`
- 私有证据 commit/path：私有 harness 台账中该任务包的 `closeout.md`
- Reviewer 证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：见本 PR 的 checks
- [x] `git diff --check`
- [x] `npm run check:stop-point`（门集从 `tools/gate-manifest.json` 派生，不要手工枚举门名）——manifest 派生的 7 个 stop-point steps 全绿
- [x] 改动面的定向测试，写明测试名与通过数：`preset-check-smoke-cli.test.ts` 11/11、`script-host-boundary.test.ts` 17/17、`preset-script-imports-cli.test.ts` 16/16、`preset-script-staging-boundary.test.ts` 9/9、`preset-context-limits.test.ts` 2/2、`json-rpc-protocol.test.ts` 24/24，合计 79
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）
- 未跑项及原因：撰写本正文时 `rewrite-ci` 尚未跑完；它是权威门，合并等它。未委托对抗式多模型复核：本次是 CLI 命令面上边界清晰的性能修复，不触碰任何写路径或 protected surface，且自带先红后绿的回归测试。

## 审查证据

- 自查：before/after 测量由 CEO 独立重跑，不采信实现者的汇报——针对真实大台账根跑 `preset inspect create-milestone`，修复前 77.61 秒、修复后 4.88 秒，system time 从 44.5 秒降到 1.99 秒。commit 真实性、base 与 diff 范围均已直接核验。
- Reviewer subagent：未委托，理由见上。
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- daemon 刚启动后的首次 cold `inspect` 约 5.45 秒，高于 <5 秒的软目标，但远在 9 秒硬超时之内。若要把 cold <5 秒定为硬 SLO，需另行处理 daemon/client 启动与轮询开销。
- 实现前的 architecture advisory 在复制出的 fixture 上以 `script_result_failed` 结束。它只是 advisory，本次未改动任何架构契约。
- 验证全程使用隔离 daemon 与 fixture；未停止或重启生产 daemon，也未写入任何下游项目台账。

## 关联材料

- 任务：`task_01KZX86V5AGNJSKKZWQDD7Y49Q`
- 证据：该任务包的 `closeout.md`
- 审查：该任务包的 `artifacts/`
