### PR TITLE
fix(cli): make daemon serve help side-effect free and guide planned task disposal

### DIFF
--- a/packages/application/src/command-receipt.ts
+++ b/packages/application/src/command-receipt.ts
@@ -112,15 +112,25 @@ export type CommandReceiptEnvelope<Command extends string = string> =
 
 export function failureReceiptNextActions(
   code: string | undefined,
-  details: Readonly<Record<string, unknown>> = {}
+  details: Readonly<Record<string, unknown>> = {},
+  errorContext: Readonly<Record<string, unknown>> = {}
 ): ReadonlyArray<CommandReceiptNextAction> | undefined {
   const data = receiptRecord(details.data);
   if (code === "task_lease_required") {
     const taskId = receiptString(details.taskId) ?? receiptString(data?.taskId);
-    return taskId ? [{
+    if (!taskId) return undefined;
+    if (receiptString(errorContext.taskStatus) === "planned"
+      && receiptString(errorContext.taskLeaseHolder) === "none"
+      && receiptString(errorContext.taskLeaseRecovery) === "dispose") {
+      return [{
+        command: `ha task transition ${shellArgument(taskId)} cancelled --force --reason '<reason>'`,
+        description: "Dispose of this planned task without starting it; replace <reason> with the audit rationale."
+      }];
+    }
+    return [{
       command: `ha task start ${shellArgument(taskId)}`,
       description: "Start the task and acquire its lease, then retry the original command."
-    }] : undefined;
+    }];
   }
   if (code === "daemon_build_stale" || code === "daemon_build_identity_unavailable") {
     return [{

--- a/packages/application/test/command-receipt-recovery.test.ts
+++ b/packages/application/test/command-receipt-recovery.test.ts
@@ -13,6 +13,19 @@ test("task lease recovery uses only the structured task id", () => {
   assert.equal(failureReceiptNextActions("task_lease_required", {}), undefined);
 });
 
+test("planned unheld task lease recovery points to audited cancellation", () => {
+  assert.deepEqual(failureReceiptNextActions("task_lease_required", {
+    taskId: "task_01KXN3G16TKNHCV29Z4ZWM4VY2"
+  }, {
+    taskStatus: "planned",
+    taskLeaseHolder: "none",
+    taskLeaseRecovery: "dispose"
+  }), [{
+    command: "ha task transition task_01KXN3G16TKNHCV29Z4ZWM4VY2 cancelled --force --reason '<reason>'",
+    description: "Dispose of this planned task without starting it; replace <reason> with the audit rationale."
+  }]);
+});
+
 test("daemon build drift points to a service restart", () => {
   for (const code of ["daemon_build_stale", "daemon_build_identity_unavailable"]) {
     assert.deepEqual(failureReceiptNextActions(code), [{

--- a/packages/cli/src/cli/error-mapper.ts
+++ b/packages/cli/src/cli/error-mapper.ts
@@ -46,6 +46,8 @@ const cliErrorMappers = {
         code,
         code === CliErrorCode.ModuleNotFound
           ? authorityModuleNotFoundPresentation(error.reason)
+          : code === CliErrorCode.TaskLeaseRequired
+            ? taskLeaseRequiredPresentation(error)
           : authorityIngressPresentation(error.reason),
         error.context
       )
@@ -66,6 +68,15 @@ const cliErrorMappers = {
     );
   }
 } satisfies CliErrorMapperByTag;
+
+function taskLeaseRequiredPresentation(error: Extract<WriteError, { readonly _tag: "WriteRejected" }>): string {
+  if (error.context?.taskStatus !== "planned"
+    || error.context.taskLeaseHolder !== "none"
+    || error.context.taskLeaseRecovery !== "dispose"
+    || !error.taskId) return error.reason;
+  const disposeCommand = `ha task transition ${error.taskId} cancelled --force --reason '<reason>'`;
+  return `Task ${error.taskId} is planned and has no active lease. To dispose of it without starting, run \`${disposeCommand}\`.`;
+}
 
 export function toCliError(error: CliReachableKernelError): CliResult["error"] {
   const mapper = cliErrorMappers[error._tag] as (input: typeof error) => CliResult["error"];

--- a/packages/cli/src/cli/receipt.ts
+++ b/packages/cli/src/cli/receipt.ts
@@ -292,7 +292,7 @@ function failureToReceipt(result: CliFailureResult): CommandFailureReceipt {
   const data = Object.fromEntries(Object.entries(raw).filter(([key, value]) =>
     !["ok", "command", "error", "warnings"].includes(key) && value !== undefined
   ));
-  const next = failureReceiptNextActions(result.error?.code, data);
+  const next = failureReceiptNextActions(result.error?.code, data, result.error?.context);
   return {
     ok: false,
     schema: commandReceiptEnvelope,

--- a/packages/cli/src/cli/runner-failure-result.ts
+++ b/packages/cli/src/cli/runner-failure-result.ts
@@ -1,9 +1,12 @@
+import { Effect } from "effect";
+import { readTaskLifecyclePolicy } from "@harness-anything/application";
 import {
   isIndeterminateFlushControlOutcome,
   type ArtifactStoreError,
   type EngineError,
   type WriteControl
 } from "@harness-anything/kernel";
+import type { ArtifactStore } from "@harness-anything/kernel";
 import { cliError, CliErrorCode } from "./error-codes.ts";
 import { toCliError } from "./error-mapper.ts";
 import { actionTaskId } from "./parse-args.ts";
@@ -35,4 +38,33 @@ export function commandFailureResult(
       { operationIds: error.report.operationIds, cause: error.report.cause }
     )
   };
+}
+
+export function commandFailureResultWithDispositionGuidance(
+  command: ParsedCommand,
+  error: ArtifactStoreError | EngineError | WriteControl,
+  artifactStore: Pick<ArtifactStore, "readTaskPackage">
+): Effect.Effect<CliResult> {
+  const taskId = actionTaskId(command.action);
+  const dispositionCommand = command.action.kind === "task-archive" || command.action.kind === "task-delete";
+  if (!dispositionCommand
+    || !taskId
+    || error._tag !== "WriteRejected"
+    || error.code !== "task_lease_required"
+    || error.context?.taskLeaseHolder !== "none") {
+    return Effect.succeed(commandFailureResult(command, error));
+  }
+  return readTaskLifecyclePolicy(artifactStore, taskId).pipe(
+    Effect.catchAll(() => Effect.succeed(null)),
+    Effect.map((policy) => commandFailureResult(command, policy?.status === "planned"
+      ? {
+          ...error,
+          context: {
+            ...error.context,
+            taskStatus: policy.status,
+            taskLeaseRecovery: "dispose"
+          }
+        }
+      : error))
+  );
 }

--- a/packages/cli/src/cli/runner-registry.ts
+++ b/packages/cli/src/cli/runner-registry.ts
@@ -19,7 +19,7 @@ import {
 import { cliError, CliErrorCode } from "./error-codes.ts";
 import { actionTaskId } from "./parse-args.ts";
 import { appendOrDeferCommandRuntimeEvent } from "./command-runtime-events.ts";
-import { commandFailureResult } from "./runner-failure-result.ts";
+import { commandFailureResultWithDispositionGuidance } from "./runner-failure-result.ts";
 import type { CliResult, CommandRegistryEntry, MaterializerCommandReport, ParsedCommand } from "./types.ts";
 import type { CliActorAttribution } from "../composition/actor-attribution.ts";
 
@@ -220,9 +220,9 @@ export function runRegisteredCommand(
   return runner(context, command).pipe(
     Effect.catchAll((error) => isIndeterminateFlushControlOutcome(error)
       ? Effect.fail(error)
-      : Effect.succeed(commandFailureResult(command, error))),
+      : commandFailureResultWithDispositionGuidance(command, error, context.artifactStore)),
     Effect.flatMap((result) => appendOrDeferCommandRuntimeEvent(context, command, result, execution)),
-    Effect.catchAll((error) => Effect.succeed(commandFailureResult(command, error)))
+    Effect.catchAll((error) => commandFailureResultWithDispositionGuidance(command, error, context.artifactStore))
   );
 }
 

--- a/packages/cli/src/commands/daemon/help.ts
+++ b/packages/cli/src/commands/daemon/help.ts
@@ -1,4 +1,5 @@
 import { commandGroups, globalCommandOptions } from "../../cli/command-spec/command-groups.ts";
+import type { CliResult, CommandRegistryEntry } from "../../cli/types.ts";
 
 const daemonGroup = commandGroups.find((group) => group.name === "daemon")!;
 
@@ -104,6 +105,32 @@ export function renderDaemonHelp(): string {
     "  See docs-release/operations-server-daemon.md#daemon-repository-ownership-invariants."
   ].join("\n");
 }
+
+export function daemonServeHelpResult(): CliResult {
+  return {
+    ok: true,
+    command: "help",
+    commands: [daemonServeHelpEntry],
+    report: { schema: "cli-help-report/v1", kind: "command", commandKind: "daemon-serve" }
+  };
+}
+
+const daemonServeHelpEntry: CommandRegistryEntry = {
+  kind: "daemon-serve",
+  primary: "harness-anything daemon serve [--check] [--socket PATH] [--user-root PATH]",
+  aliases: ["ha daemon serve [--check] [--socket PATH] [--user-root PATH]"],
+  commandPath: ["daemon", "serve"],
+  summary: "Run the daemon in the foreground for a selected local endpoint.",
+  options: [
+    { flag: "--check", description: "Validate daemon startup configuration without taking socket ownership." },
+    { flag: "--socket PATH", description: "Use an explicit local daemon endpoint." },
+    { flag: "--user-root PATH", description: "Isolate daemon registry and launch state under this directory." },
+    { flag: "--authority-manifest PATH", description: "Load the complete enabled repository set from this manifest." },
+    { flag: "--idle-ms MS", description: "Exit after this many idle milliseconds; zero disables idle exit." }
+  ],
+  examples: ["ha daemon serve --socket /tmp/ha.sock --user-root /tmp/ha-user"],
+  resultEnvelope: "command-receipt/v2"
+};
 
 function daemonCapabilityOperation(action: string, command: string, description: string) {
   return {

--- a/packages/cli/src/composition/command-executor.ts
+++ b/packages/cli/src/composition/command-executor.ts
@@ -427,6 +427,9 @@ function taskLeaseWriteError(error: unknown): WriteError {
       taskId: error.taskId,
       reason: error.message,
       code: error.code,
+      ...(error.code === "task_lease_required" ? {
+        context: { taskLeaseHolder: error.holder ? "present" : "none" }
+      } : {}),
       retryable: false
     };
   }

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -49,6 +49,8 @@ import { isDeclaredLocalMigrationCommand } from "./composition/local-write-scope
 import { startCliTimingPhase } from "./cli/timing.ts";
 import { readProjectHarnessSettings } from "./commands/settings.ts";
 import { validateCommandOptions } from "./cli/option-claims.ts";
+import { cliError, CliErrorCode, errorCodeFromThrown } from "./cli/error-codes.ts";
+import { daemonServeHelpResult } from "./commands/daemon/help.ts";
 
 const runRegisteredCommand = runRegisteredCommandWithCliComposition;
 type ParsedCommandRunner = (command: Parameters<typeof runRegisteredCommand>[0]) => Promise<CommandReceipt | CommandFailureReceipt>;
@@ -62,6 +64,8 @@ export async function main(argv: ReadonlyArray<string> = process.argv.slice(2)):
     await runRepoWriteChildEntrypoint(argv[1]);
     return 0;
   }
+  const daemonServeHelpExit = maybeRunDaemonServeHelp(argv);
+  if (daemonServeHelpExit !== undefined) return daemonServeHelpExit;
   const optionValidation = validateCommandOptions(argv);
   if (!optionValidation.ok) {
     await appendParseFailureRuntimeEvent(argv, optionValidation.error);
@@ -214,20 +218,26 @@ async function maybeRunDaemonCommand(argv: ReadonlyArray<string>): Promise<numbe
     try {
       launchOptions = parseDaemonLaunchArgv(argv);
     } catch (error) {
-      console.error(error instanceof Error ? error.message : String(error));
-      return 2;
+      return emitDaemonServeFailure(error, stripped.json, 2);
     }
     const serveLayoutOverrides = daemonRuntimeLayoutOverrides(launchOptions.rootDir, launchOptions.authoredRoot);
     if (daemonArgs.includes("--stdio")) {
-      console.error("daemon serve --stdio is disabled because it creates a competing runtime; start the persistent daemon and use 'ha daemon connect --stdio'.");
-      return 2;
+      return emitDaemonServeFailure(
+        new Error("daemon serve --stdio is disabled because it creates a competing runtime; start the persistent daemon and use 'ha daemon connect --stdio'."),
+        stripped.json,
+        2
+      );
     }
-    if (daemonArgs.includes("--check")) {
-      checkDaemonServeConfiguration(launchOptions.rootDir, serveLayoutOverrides, daemonArgs.filter((arg) => arg !== "--check"), launchOptions);
+    try {
+      if (daemonArgs.includes("--check")) {
+        checkDaemonServeConfiguration(launchOptions.rootDir, serveLayoutOverrides, daemonArgs.filter((arg) => arg !== "--check"), launchOptions);
+        return 0;
+      }
+      await runDaemonServe(launchOptions.rootDir, serveLayoutOverrides, daemonArgs, {}, launchOptions);
       return 0;
+    } catch (error) {
+      return emitDaemonServeFailure(error, stripped.json, 1);
     }
-    await runDaemonServe(launchOptions.rootDir, serveLayoutOverrides, daemonArgs, {}, launchOptions);
-    return 0;
   }
   return runDaemonCommand({
     rootDir: stripped.rootDir,
@@ -237,6 +247,30 @@ async function maybeRunDaemonCommand(argv: ReadonlyArray<string>): Promise<numbe
     rawArgs: argv,
     runServe: runDaemonServe
   });
+}
+
+function maybeRunDaemonServeHelp(argv: ReadonlyArray<string>): number | undefined {
+  const stripped = stripGlobalOptions(argv);
+  const args = stripped.args;
+  const helpFlag = args.includes("--help") || args.includes("-h");
+  const explicitHelp = args[0] === "help" && args[1] === "daemon" && args[2] === "serve";
+  const flaggedServe = helpFlag && (
+    (args[0] === "daemon" && args[1] === "serve")
+    || args.filter((arg) => arg !== "--help" && arg !== "-h").slice(0, 2).join(" ") === "daemon serve"
+  );
+  if (!explicitHelp && !flaggedServe) return undefined;
+  emit(toCommandReceipt(daemonServeHelpResult()), stripped.json);
+  return 0;
+}
+
+function emitDaemonServeFailure(error: unknown, json: boolean, exitCode: 1 | 2): number {
+  const code = errorCodeFromThrown(error) ?? CliErrorCode.UnclassifiedCommandFailure;
+  emit(toCommandReceipt({
+    ok: false,
+    command: "daemon-serve",
+    error: cliError(code, error instanceof Error ? error.message : String(error))
+  }), json);
+  return exitCode;
 }
 
 function checkDaemonServeConfiguration(

--- a/packages/cli/test/authority-manifest-rehydration.test.ts
+++ b/packages/cli/test/authority-manifest-rehydration.test.ts
@@ -43,6 +43,8 @@ test("daemon restart fails closed for mixed or conflicting authority registry po
 
 test("daemon serve check reuses mixed-registry startup validation without taking endpoint ownership", async () => {
   const fixtureRoot = mkdtempSync(path.join(tmpdir(), "ha-daemon-preflight-"));
+  const output: string[] = [];
+  const originalLog = console.log;
   try {
     const userRoot = path.join(fixtureRoot, "user-root");
     const protectedRoot = path.join(fixtureRoot, "protected");
@@ -62,13 +64,28 @@ test("daemon serve check reuses mixed-registry startup validation without taking
     registerDaemonRepo({ userRoot, repoId: "classic", canonicalRoot: classicRoot });
     const endpoint = localUserDaemonEndpoint(userRoot);
 
-    await assert.rejects(
-      main(["--root", protectedRoot, "daemon", "serve", "--repo", "protected", "--user-root", userRoot, "--check"]),
-      /AUTHORITY_MANIFEST_REGISTRY_INCOMPLETE/u
-    );
+    console.log = (message?: unknown) => output.push(String(message));
+    const exitCode = await main([
+      "--root", protectedRoot,
+      "daemon", "serve",
+      "--repo", "protected",
+      "--user-root", userRoot,
+      "--check", "--json"
+    ]);
+    assert.equal(exitCode, 1);
+    assert.equal(output.length, 1);
+    const receipt = JSON.parse(output[0]!) as {
+      readonly schema?: string;
+      readonly ok?: boolean;
+      readonly error?: { readonly hint?: string };
+    };
+    assert.equal(receipt.schema, "command-receipt/v2");
+    assert.equal(receipt.ok, false);
+    assert.match(receipt.error?.hint ?? "", /AUTHORITY_MANIFEST_REGISTRY_INCOMPLETE/u);
     assert.equal(existsSync(endpoint), false);
     assert.equal(existsSync(`${endpoint}.owner`), false);
   } finally {
+    console.log = originalLog;
     rmSync(fixtureRoot, { recursive: true, force: true });
   }
 });

--- a/packages/cli/test/daemon-socket-namespace-cli.test.ts
+++ b/packages/cli/test/daemon-socket-namespace-cli.test.ts
@@ -1,18 +1,73 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import net from "node:net";
 import path from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
 import { localUserDaemonEndpoint } from "../../daemon/src/index.ts";
 import { readDaemonRegistry } from "../../kernel/src/index.ts";
-import { defaultDaemonUserRoot } from "./helpers/daemon-cli.ts";
+import { defaultDaemonUserRoot, runRawJson, stopDaemon, withTempRootAsync } from "./helpers/daemon-cli.ts";
 import { cliTestEnv } from "./helpers/cli-test-env.ts";
+import {
+  connectSocket,
+  connectSocketWhenReady,
+  runDaemonCliProcess,
+  spawnDaemonCli,
+  stopSpawnedDaemon
+} from "./helpers/daemon-transport.ts";
 import { createFixture } from "./production-authority-canonical-ingress/fixture.ts";
 
 const execFileAsync = promisify(execFile);
+
+test("daemon serve help is side-effect free and socket conflicts return command receipts", async () => {
+  await withTempRootAsync(async (rootDir) => {
+    const userRoot = defaultDaemonUserRoot(rootDir);
+    runRawJson(rootDir, ["init"], { HARNESS_DAEMON_MODE: "fixture", HARNESS_DAEMON_USER_ROOT: userRoot });
+    const endpoint = path.join(rootDir, "serve-help-owned.sock");
+    const daemon = spawnDaemonCli(rootDir, ["daemon", "serve", "--socket", endpoint, "--user-root", userRoot]);
+    try {
+      const ready = await connectSocketWhenReady(endpoint);
+      ready.destroy();
+      const ownerPath = `${endpoint}.owner`;
+      const ownerBeforeHelp = readFileSync(ownerPath, "utf8");
+
+      const helpInvocations = [
+        ["daemon", "serve", "--help", "--from-file", path.join(rootDir, "missing-help-input.json")],
+        ["daemon", "serve", "-h", "--socket", endpoint, "--user-root", userRoot],
+        ["help", "daemon", "serve"]
+      ];
+      for (const args of helpInvocations) {
+        const help = await runDaemonCliProcess(rootDir, [...args, "--json"]);
+        assert.equal(help.code, 0, help.stderr);
+        assert.equal(help.stderr, "");
+        const helpReceipt = JSON.parse(help.stdout) as Record<string, unknown>;
+        assert.equal(helpReceipt.ok, true);
+        assert.equal(helpReceipt.schema, "command-receipt/v2");
+        assert.equal(helpReceipt.command, "help");
+        assert.equal(readFileSync(ownerPath, "utf8"), ownerBeforeHelp);
+        assert.equal(daemon.exitCode, null);
+        const afterHelp = await connectSocket(endpoint);
+        afterHelp.destroy();
+      }
+
+      const conflict = await runDaemonCliProcess(rootDir, ["daemon", "serve", "--socket", endpoint, "--user-root", userRoot, "--json"]);
+      assert.equal(conflict.code, 1);
+      assert.equal(conflict.stderr, "");
+      const failureReceipt = JSON.parse(conflict.stdout) as Record<string, unknown>;
+      assert.equal(failureReceipt.ok, false);
+      assert.equal(failureReceipt.schema, "command-receipt/v2");
+      assert.equal(failureReceipt.command, "daemon serve");
+      assert.doesNotMatch(conflict.stdout, /DaemonSocketAlreadyOwnedError|packages\/cli\/src\/main\.ts/iu);
+      assert.equal(readFileSync(ownerPath, "utf8"), ownerBeforeHelp);
+      assert.equal(daemon.exitCode, null);
+    } finally {
+      await stopSpawnedDaemon(daemon, endpoint);
+      await stopDaemon(rootDir, userRoot);
+    }
+  });
+});
 
 test("occupied daemon socket does not persist a new authority manifest registry pointer", { timeout: 30_000 }, async () => {
   const fixture = createFixture();

--- a/packages/cli/test/task-delete-disposition-cli.test.ts
+++ b/packages/cli/test/task-delete-disposition-cli.test.ts
@@ -9,6 +9,7 @@ import { deriveRelationId } from "../../kernel/src/index.ts";
 import { ensureTestHarnessIdentity } from "./helpers/git-fixtures.ts";
 import { unwrapCommandReceipt } from "./helpers/receipt.ts";
 import { writeSubstantiveTaskPlan } from "./helpers/task-plan-fixture.ts";
+import { cliTestEnv } from "./helpers/cli-test-env.ts";
 
 const cliEntry = path.resolve("packages/cli/src/index.ts");
 const taskIdPattern = /^task_[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/u;
@@ -130,6 +131,37 @@ test("CLI task delete soft path tombstones without invoking hard deletion", () =
   });
 });
 
+test("planned unheld task disposition points to audited cancellation", () => {
+  withTempRoot((rootDir) => {
+    const leaseEnv = { HARNESS_TASK_LEASE_ENFORCEMENT: "1" };
+    const created = runJson(rootDir, [
+      "task", "create", "--title", "Planned Disposal",
+      "--vertical", "software/coding", "--preset", "standard-task"
+    ]);
+    const taskId = assertGeneratedTaskId(created.taskId);
+    const disposalCommand = `ha task transition ${taskId} cancelled --force --reason '<reason>'`;
+
+    const deleted = runJson(rootDir, ["task", "delete", "--soft", taskId, "--reason", "discard scaffold"], false, leaseEnv);
+    assert.equal(deleted.error?.code, "task_lease_required");
+    assert.match(deleted.error?.hint ?? "", new RegExp(`ha task transition ${taskId} cancelled --force --reason`, "u"));
+    assert.deepEqual(deleted.next, [{
+      command: disposalCommand,
+      description: "Dispose of this planned task without starting it; replace <reason> with the audit rationale."
+    }]);
+
+    const archived = runJson(rootDir, ["task", "archive", taskId, "--reason", "discard scaffold"], false, leaseEnv);
+    assert.equal(archived.error?.code, "task_lease_required");
+    assert.deepEqual(archived.next, deleted.next);
+    assert.equal(runJson(rootDir, ["task", "show", taskId]).report.task.status, "planned");
+
+    const cancelled = runJson(rootDir, [
+      "task", "transition", taskId, "cancelled", "--force", "--reason", "retire empty scaffold"
+    ], true, leaseEnv);
+    assert.equal(cancelled.status, "cancelled");
+    assert.equal(cancelled.forceAudit.marker, "FORCE_STATUS_SET_AUDIT");
+  });
+});
+
 function writeDecisionRelation(rootDir: string, decisionId: string, targetRef: string, state: "active" | "retired"): void {
   const source = `decision/${decisionId}/C1`;
   const relation = {
@@ -193,9 +225,17 @@ function withTempRoot<T>(fn: (rootDir: string) => T): T {
   }
 }
 
-function runJson(rootDir: string, args: ReadonlyArray<string>, expectSuccess = true): Record<string, any> {
+function runJson(
+  rootDir: string,
+  args: ReadonlyArray<string>,
+  expectSuccess = true,
+  env: Readonly<Record<string, string>> = {}
+): Record<string, any> {
   try {
-    const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], { encoding: "utf8" });
+    const stdout = execFileSync(process.execPath, [cliEntry, "--root", rootDir, "--json", ...args], {
+      encoding: "utf8",
+      env: cliTestEnv({ HARNESS_TASK_LEASE_ENFORCEMENT: "", ...env })
+    });
     return unwrapCommandReceipt(JSON.parse(stdout) as Record<string, any>);
   } catch (error) {
     if (expectSuccess) throw error;

--- a/packages/daemon/src/protocol/receipt-envelope.ts
+++ b/packages/daemon/src/protocol/receipt-envelope.ts
@@ -41,7 +41,7 @@ export function failureReceipt(
   details: JsonObject = {},
   errorContext?: JsonObject
 ): CommandFailureReceipt {
-  const next = failureReceiptNextActions(code, details);
+  const next = failureReceiptNextActions(code, details, errorContext);
   return {
     ok: false,
     schema: commandReceiptEnvelope,


### PR DESCRIPTION
# English

## Summary

Two independent CLI flow defects found while investigating preset timeouts. Both are usability/correctness problems, not performance ones.

**A. `ha daemon serve --help` started a daemon instead of printing help.** The daemon dispatch happened before generic `parseArgs`/help handling, so `--help` carried side effects. On a machine where a daemon already owned the socket it aborted with an uncaught `DaemonSocketAlreadyOwnedError` and a raw Node stack — the only `ha` command that reported failure as a stack trace instead of a `command-receipt/v2`.

**B. `task delete` / `task archive` pointed users down a dead end.** When lease enforcement is on, disposing of a never-started task is refused with `task_lease_required`, whose next action suggested `ha task start <id>`. For a task whose plan is still the scaffold that command is itself refused (`task_plan_placeholder`), so following the guidance walks into a second wall. The repository already has the correct disposal path — `ha task transition <id> cancelled --force --reason "..."` — and it is covered by existing targeted tests. The lease contract is intentional and is left unchanged; only the guidance is corrected.

A 2×2 fixture matrix established that the variable governing B is `settings.tasks.leaseEnforcement`, not the preset used to create the task.

## What Changed

- `daemon serve --help`, `-h`, and `help daemon serve` short-circuit before any socket or daemon I/O and return structured help.
- Genuine `daemon serve` startup failures now return a `command-receipt/v2` instead of an uncaught exception with a Node stack.
- For planned/unheld tasks, the `task_lease_required` refusal from `delete`/`archive` now points at `ha task transition <id> cancelled --force --reason '<reason>'`.
- Targeted regression tests for both.

## Task And Scope

- Harness task: `task_01KZXE67B7SSWAK0F7PDM9QJKR` (parent `task_01KZX5SC9CYKD9C9GGW8K9YKK5`)
- Branch: `codex/cli-flow-fixes`
- Public scope: `packages/cli/src/main.ts` and the task disposal guidance path, plus their tests
- Private planning/evidence updated: yes
- Out of scope: the lease contract itself; `leaseRequired` declarations; command class contracts. Also out of scope: a separate defect where running `daemon serve` from one repository root resolves to another repository's socket — filed for separate scheduling, not fixed here.

## Version Impact

- Version: no version change because these are internal CLI behavior fixes with no public API or contract change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_01KZXE67B7SSWAK0F7PDM9QJKR`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `90f6b26a241dcdfb7ff67e403d7455b5e801c412`
- Branch merge-base with `origin/main`: `90f6b26a241dcdfb7ff67e403d7455b5e801c412`
- Last `git fetch origin` time: 2026-08-13
- Sync method: rebase onto `origin/main` after `#1371` landed
- Public diff command: `git diff 90f6b26a..2add4e02`
- Production delta: `+133/-16` (A `+69/-8`, B `+64/-8`); test delta: `+133/-8`
- Private evidence commit/path: task package `closeout.md` in the private harness ledger
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: see the checks on this PR
- [x] `git diff --check`
- [x] `npm run check:stop-point` (the gate set is derived from `tools/gate-manifest.json`; do not enumerate gates by hand) — 27 manifest gates green in 118.5s
- [x] Targeted tests for the change surface, named with their counts: 14/14 across both defects. A asserts that with the socket already owned, socket owner bytes are unchanged and the daemon stays reachable. B asserts the suggested command actually succeeds and emits `FORCE_STATUS_SET_AUDIT`.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: `rewrite-ci` had not completed when this body was written; it is the authoritative gate and merge waits on it. No adversarial multi-model review was commissioned: both fixes are bounded, touch no write path or protected surface, and each carries a targeted regression test.

## Review Evidence

- Self-review: defect A was verified by hand rather than taken from the implementer's report — `daemon serve --help` was run while a live daemon held the socket; it returned structured help with exit 0 and the live daemon was still running and reachable afterwards. Commit identities, rebase base, and production/test deltas were checked directly and match the report.
- Reviewer subagent: not commissioned; see the reason above.
- Human review: pending
- Blocking findings: none. Two premises supplied in the original assignment were falsified by the implementer and withdrawn: the disposal problem is governed by `settings.tasks.leaseEnforcement` rather than by the preset, and the `task_plan_placeholder` hint is not empty as originally reported.

## Residual Risk

- Defect B changes guidance only. If lease enforcement semantics change later, the guidance condition must be revisited alongside it.
- The separate socket-resolution defect noted above remains open and unscheduled.

## References

- Task: `task_01KZXE67B7SSWAK0F7PDM9QJKR`
- Evidence: task package `closeout.md`
- Review: task package `artifacts/`

---

# 中文

## 概要

排查 preset 超时问题时发现的两个独立 CLI 流转缺陷。两个都是可用性/正确性问题，不是性能问题。

**A. `ha daemon serve --help` 不打印帮助，而是真的启动 daemon。** daemon 分派发生在通用 `parseArgs`/help 处理之前，因此 `--help` 带上了副作用。在已有 daemon 持有 socket 的机器上，它以未捕获的 `DaemonSocketAlreadyOwnedError` 加一坨 Node 栈回溯中止——这是所有 `ha` 命令里唯一一个用栈回溯而不是 `command-receipt/v2` 报告失败的命令。

**B. `task delete` / `task archive` 把使用者指向死路。** 启用 lease enforcement 时，处置一个从未开始的任务会被 `task_lease_required` 拒绝，而它给出的 next action 是 `ha task start <id>`。对于 plan 仍是脚手架的任务，那条命令本身也会被拒绝（`task_plan_placeholder`），照着提示走必然撞上第二堵墙。仓库其实已经有正确的处置路径——`ha task transition <id> cancelled --force --reason "..."`——并且有既有定向测试覆盖。lease 契约是有意设计，本次不改；只纠正引导。

2×2 fixture 对照确认：支配缺陷 B 的变量是 `settings.tasks.leaseEnforcement`，与建任务所用的 preset 无关。

## 改动内容

- `daemon serve --help`、`-h` 以及 `help daemon serve` 在任何 socket 或 daemon I/O 之前短路，返回结构化帮助。
- `daemon serve` 真实启动失败现在返回 `command-receipt/v2`，不再是未捕获异常加 Node 栈。
- 对 planned/未持有 lease 的任务，`delete`/`archive` 的 `task_lease_required` 拒绝现在指向 `ha task transition <id> cancelled --force --reason '<reason>'`。
- 两个缺陷各配定向回归测试。

## 任务与范围

- Harness 任务：`task_01KZXE67B7SSWAK0F7PDM9QJKR`（父任务 `task_01KZX5SC9CYKD9C9GGW8K9YKK5`）
- 分支：`codex/cli-flow-fixes`
- 公开范围：`packages/cli/src/main.ts` 与任务处置引导路径，以及对应测试
- 私有计划 / 证据是否已更新：yes
- 范围外：lease 契约本身、`leaseRequired` 声明、command class 契约。另外范围外：一个独立缺陷——在某个仓库根执行 `daemon serve` 会解析到另一个仓库的 socket，已单独记录待排期，本次不修。

## 版本影响

- 版本：不改版本，原因是本次为内部 CLI 行为修复，未改动任何公开 API 或契约
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`task_01KZXE67B7SSWAK0F7PDM9QJKR`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`90f6b26a241dcdfb7ff67e403d7455b5e801c412`
- 当前分支与 `origin/main` 的 merge-base：`90f6b26a241dcdfb7ff67e403d7455b5e801c412`
- 最近一次 `git fetch origin` 时间：2026-08-13
- 同步方式：`#1371` 合入后 rebase 到 `origin/main`
- 公开 diff 命令：`git diff 90f6b26a..2add4e02`
- Production delta：`+133/-16`（A `+69/-8`，B `+64/-8`）；test delta：`+133/-8`
- 私有证据 commit/path：私有 harness 台账中该任务包的 `closeout.md`
- Reviewer 证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：见本 PR 的 checks
- [x] `git diff --check`
- [x] `npm run check:stop-point`（门集从 `tools/gate-manifest.json` 派生，不要手工枚举门名）——27 个 manifest gate 全绿，118.5 秒
- [x] 改动面的定向测试，写明测试名与通过数：两个缺陷合计 14/14。A 断言在 socket 已被占用时 socket owner bytes 不变、daemon 仍可达；B 断言被建议的命令确实成功并产生 `FORCE_STATUS_SET_AUDIT`。
- [ ] GitHub Actions `rewrite-ci` 通过（这是权威全量门）
- 未跑项及原因：撰写本正文时 `rewrite-ci` 尚未跑完；它是权威门，合并等它。未委托对抗式多模型复核：两个修复边界清晰，不触碰写路径或 protected surface，且各自带定向回归测试。

## 审查证据

- 自查：缺陷 A 由 CEO 亲手验证，不采信实现者汇报——在现役 daemon 持有 socket 的情况下执行 `daemon serve --help`，返回结构化帮助、exit 0，事后现役 daemon 仍在运行且可达。commit 真实性、rebase 基线、production/test delta 均直接核验，与报告一致。
- Reviewer subagent：未委托，理由见上。
- 人工审查：待进行
- 阻塞发现：无。派活时给出的两条前提被实现者证伪并已撤回：处置问题由 `settings.tasks.leaseEnforcement` 支配而非 preset；`task_plan_placeholder` 的 hint 并非最初报告的那样为空。

## 残余风险

- 缺陷 B 只改引导。若日后 lease enforcement 语义发生变化，引导条件须同步复核。
- 上文提到的 socket 解析缺陷仍然开放且未排期。

## 关联材料

- 任务：`task_01KZXE67B7SSWAK0F7PDM9QJKR`
- 证据：该任务包的 `closeout.md`
- 审查：该任务包的 `artifacts/`
