### PR TITLE
fix(daemon): scan publication proof history once (unwedge task-complete 30s watchdog livelock)

### DIFF
--- a/packages/daemon/src/authority/production/task-complete-prepublish-publication.ts
+++ b/packages/daemon/src/authority/production/task-complete-prepublish-publication.ts
@@ -42,7 +42,7 @@ export async function findAttributedMaterializedPublication(
       materializationMismatches(repositoryPaths, currentBlobs, expectedBlobs)
     );
   }
-  const historyPromise = firstParentHistory(rootDir, repositoryPaths, headRef);
+  const historyPromise = firstParentPublicationHistory(rootDir, repositoryPaths, headRef);
   reportCurrentRepoWriteTelemetry("authority-publication-proof", {
     stage: "history-start",
     pathCount: repositoryPaths.length
@@ -121,7 +121,10 @@ async function findPathMaterializedPublications(
   history: ReadonlyArray<{
     readonly commit: string;
     readonly parents: ReadonlyArray<string>;
-    readonly subject: string;
+    readonly changes: ReadonlyMap<string, {
+      readonly before: string;
+      readonly after: string;
+    }>;
   }>
 ): Promise<ReadonlyArray<{ readonly commit: string; readonly operationIds: ReadonlyArray<string> } | null>> {
   const attributions: Array<{ readonly commit: string; readonly operationIds: ReadonlyArray<string> } | null> =
@@ -129,14 +132,16 @@ async function findPathMaterializedPublications(
   let remaining = repositoryPaths.length;
   for (const entry of history) {
     if (entry.parents.length !== 2) continue;
-    const actualBlobs = await gitBlobIds(rootDir, entry.commit, repositoryPaths);
-    const candidates = repositoryPaths.flatMap((_repositoryPath, index) =>
-      attributions[index] === null && actualBlobs[index] === expectedBlobs[index] ? [index] : []
-    );
+    const candidates = repositoryPaths.flatMap((repositoryPath, index) => {
+      const change = entry.changes.get(repositoryPath);
+      return attributions[index] === null
+        && change?.after === expectedBlobs[index]
+        && change.before !== change.after
+        ? [index]
+        : [];
+    });
     if (candidates.length === 0) continue;
-    const firstParentBlobs = await gitBlobIds(rootDir, entry.parents[0]!, repositoryPaths);
     for (const index of candidates) {
-      if (firstParentBlobs[index] === actualBlobs[index]) continue;
       const operationIds = await attributedPathOperationIds(
         rootDir,
         entry.parents[0]!,
@@ -197,32 +202,70 @@ function materializationMismatches(
   });
 }
 
-async function firstParentHistory(rootDir: string, repositoryPaths: ReadonlyArray<string>, headRef = "HEAD"): Promise<ReadonlyArray<{
+async function firstParentPublicationHistory(
+  rootDir: string,
+  repositoryPaths: ReadonlyArray<string>,
+  headRef = "HEAD"
+): Promise<ReadonlyArray<{
   readonly commit: string;
   readonly parents: ReadonlyArray<string>;
-  readonly subject: string;
+  readonly changes: ReadonlyMap<string, { readonly before: string; readonly after: string }>;
 }>> {
+  if (repositoryPaths.length === 0) return [];
   const output = await taskCompletePublicationGitText(rootDir, [
     "log",
     "--first-parent",
     "--full-history",
-    "--format=%H%x00%P%x00%s%x00",
+    "--diff-merges=first-parent",
+    "--raw",
+    "--no-renames",
+    "--no-abbrev",
+    "-z",
+    "--format=%x1e%H%x00%P",
     headRef,
     "--",
-    ...repositoryPaths.map((repositoryPath) => `:(literal)${repositoryPath}`)
+    ...attributionHistoryPathspecs(repositoryPaths).map((repositoryPath) => `:(literal)${repositoryPath}`)
   ]);
-  const fields = output.split("\0");
-  const rows: Array<{ commit: string; parents: ReadonlyArray<string>; subject: string }> = [];
-  for (let index = 0; index + 2 < fields.length; index += 3) {
-    const commit = fields[index]!.trim();
+  const rows: Array<{
+    commit: string;
+    parents: ReadonlyArray<string>;
+    changes: ReadonlyMap<string, { readonly before: string; readonly after: string }>;
+  }> = [];
+  for (const record of output.split("\x1e")) {
+    const fields = record.split("\0");
+    const commit = fields[0]?.trim();
     if (!commit) continue;
+    const changes = new Map<string, { readonly before: string; readonly after: string }>();
+    for (let index = 2; index < fields.length;) {
+      const header = fields[index++]!.replace(/^\r?\n/u, "");
+      if (!header.startsWith(":")) continue;
+      const [, , before, after] = header.slice(1).split(" ");
+      const repositoryPath = fields[index++];
+      if (before && after && repositoryPath !== undefined) {
+        changes.set(repositoryPath, { before, after });
+      }
+    }
     rows.push({
       commit,
-      parents: fields[index + 1]!.trim().split(" ").filter(Boolean),
-      subject: fields[index + 2]!.trim()
+      parents: fields[1]!.trim().split(" ").filter(Boolean),
+      changes
     });
   }
   return rows;
+}
+
+function attributionHistoryPathspecs(repositoryPaths: ReadonlyArray<string>): ReadonlyArray<string> {
+  if (repositoryPaths.length < 2) return repositoryPaths;
+  const first = repositoryPaths[0]!.split("/");
+  let sharedSegments = first.length - 1;
+  for (const repositoryPath of repositoryPaths.slice(1)) {
+    const segments = repositoryPath.split("/");
+    sharedSegments = Math.min(sharedSegments, segments.length - 1);
+    let index = 0;
+    while (index < sharedSegments && segments[index] === first[index]) index += 1;
+    sharedSegments = index;
+  }
+  return sharedSegments > 0 ? [first.slice(0, sharedSegments).join("/")] : repositoryPaths;
 }
 
 function publicationOperationIds(subject: string): ReadonlyArray<string> {

--- a/packages/daemon/test/task-complete-prepublish-publication-parity.test.ts
+++ b/packages/daemon/test/task-complete-prepublish-publication-parity.test.ts
@@ -1,0 +1,322 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { stableStringify } from "@harness-anything/kernel";
+import {
+  assertAttributedMaterializedPublication,
+  findAttributedMaterializedPublication,
+  TaskCompletePrepublishNotMaterializedError
+} from "../src/authority/production/task-complete-prepublish-publication.ts";
+
+test("single-pass publication proof matches the baseline attribution outcomes", async (context) => {
+  const fixture = parityRepository();
+  const successPaths = [fixture.renamedPath, fixture.restoredPath];
+  const successBodies = [fixture.renamedBody, fixture.restoredBody];
+  try {
+    await context.test("attribution succeeds with the same canonical commit and operation IDs", async () => {
+      await assertSameOutcome(
+        () => legacyFindAttributedMaterializedPublication(fixture.rootDir, successPaths, successBodies),
+        () => findAttributedMaterializedPublication(fixture.rootDir, successPaths, successBodies)
+      );
+    });
+
+    await context.test("a path whose publication changed only its mode remains unattributed", async () => {
+      await assertSameOutcome(
+        () => legacyFindAttributedMaterializedPublication(
+          fixture.rootDir,
+          [fixture.modeOnlyPath],
+          [fixture.modeOnlyBody]
+        ),
+        () => findAttributedMaterializedPublication(
+          fixture.rootDir,
+          [fixture.modeOnlyPath],
+          [fixture.modeOnlyBody]
+        )
+      );
+    });
+
+    await context.test("an inconsistent attributed commit is rejected identically", async () => {
+      await assertSameOutcome(
+        () => legacyAssertAttributedMaterializedPublication(
+          fixture.rootDir,
+          fixture.initialCommit,
+          successPaths,
+          successBodies,
+          fixture.operationIds
+        ),
+        () => assertAttributedMaterializedPublication(
+          fixture.rootDir,
+          fixture.initialCommit,
+          successPaths,
+          successBodies,
+          fixture.operationIds
+        )
+      );
+    });
+
+    await context.test("inconsistent operation IDs are rejected identically", async () => {
+      await assertSameOutcome(
+        () => legacyAssertAttributedMaterializedPublication(
+          fixture.rootDir,
+          fixture.restoredMerge,
+          successPaths,
+          successBodies,
+          ["op_inconsistent"]
+        ),
+        () => assertAttributedMaterializedPublication(
+          fixture.rootDir,
+          fixture.restoredMerge,
+          successPaths,
+          successBodies,
+          ["op_inconsistent"]
+        )
+      );
+    });
+  } finally {
+    rmSync(fixture.rootDir, { recursive: true, force: true });
+  }
+});
+
+function parityRepository() {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-prepublish-publication-parity-"));
+  const taskRoot = "tasks/task_01KZXJJQ2864Q3S37B8J199R1D-parity";
+  const draftPath = `${taskRoot}/draft.md`;
+  const renamedPath = `${taskRoot}/renamed.md`;
+  const modeOnlyPath = `${taskRoot}/mode-only.md`;
+  const restoredPath = `${taskRoot}/restored-after-delete.md`;
+  const renamedBody = "# Renamed publication\n";
+  const modeOnlyBody = "# Mode-only publication\n";
+  const restoredBody = "# Restored publication\n";
+  mkdirSync(path.join(rootDir, taskRoot), { recursive: true });
+  git(rootDir, "init", "-q", "-b", "main");
+  git(rootDir, "config", "user.name", "Harness Test");
+  git(rootDir, "config", "user.email", "harness@example.test");
+  writeFileSync(path.join(rootDir, draftPath), renamedBody);
+  writeFileSync(path.join(rootDir, modeOnlyPath), modeOnlyBody);
+  writeFileSync(path.join(rootDir, restoredPath), "# Before historical deletion\n");
+  git(rootDir, "add", ".");
+  git(rootDir, "commit", "-q", "-m", "test: seed parity documents");
+  const initialCommit = git(rootDir, "rev-parse", "HEAD");
+
+  git(rootDir, "checkout", "-q", "-b", "first-publication");
+  git(rootDir, "mv", draftPath, renamedPath);
+  chmodSync(path.join(rootDir, modeOnlyPath), 0o755);
+  rmSync(path.join(rootDir, restoredPath));
+  git(rootDir, "add", "-A");
+  git(rootDir, "commit", "-q", "-m", "test: rename mode and delete publication [op_batch_one]");
+  git(rootDir, "checkout", "-q", "main");
+  git(rootDir, "merge", "-q", "--no-ff", "first-publication", "-m", "materialize first parity publication");
+
+  git(rootDir, "checkout", "-q", "-b", "restored-publication");
+  writeFileSync(path.join(rootDir, restoredPath), restoredBody);
+  git(rootDir, "add", restoredPath);
+  git(rootDir, "commit", "-q", "-m", "test: restore deleted publication [op_restore]");
+  git(rootDir, "checkout", "-q", "main");
+  git(rootDir, "merge", "-q", "--no-ff", "restored-publication", "-m", "materialize restored parity publication");
+  const restoredMerge = git(rootDir, "rev-parse", "HEAD");
+
+  return {
+    rootDir,
+    initialCommit,
+    restoredMerge,
+    renamedPath,
+    renamedBody,
+    modeOnlyPath,
+    modeOnlyBody,
+    restoredPath,
+    restoredBody,
+    operationIds: ["op_batch_one", "op_restore"]
+  };
+}
+
+async function assertSameOutcome<Value>(
+  baseline: () => Promise<Value>,
+  singlePass: () => Promise<Value>
+): Promise<void> {
+  assert.deepEqual(await capture(singlePass), await capture(baseline));
+}
+
+async function capture<Value>(operation: () => Promise<Value>): Promise<unknown> {
+  try {
+    return { status: "fulfilled", value: await operation() };
+  } catch (error) {
+    return {
+      status: "rejected",
+      error: error instanceof TaskCompletePrepublishNotMaterializedError
+        ? { name: error.name, message: error.message, code: error.code, details: error.details }
+        : error instanceof Error
+          ? { name: error.name, message: error.message }
+          : String(error)
+    };
+  }
+}
+
+async function legacyAssertAttributedMaterializedPublication(
+  rootDir: string,
+  repositoryCommit: string,
+  repositoryPaths: ReadonlyArray<string>,
+  bodies: ReadonlyArray<string>,
+  expectedOperationIds: ReadonlyArray<string>
+): Promise<void> {
+  const publication = await legacyFindAttributedMaterializedPublication(rootDir, repositoryPaths, bodies);
+  if (publication.commit !== repositoryCommit) {
+    throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_COMMIT_NOT_PATH_ATTRIBUTED");
+  }
+  if (stableStringify(publication.operationIds) !== stableStringify(expectedOperationIds)) {
+    throw new Error("AUTHORITY_TASK_COMPLETE_WITNESS_OPERATION_MISMATCH");
+  }
+}
+
+async function legacyFindAttributedMaterializedPublication(
+  rootDir: string,
+  repositoryPaths: ReadonlyArray<string>,
+  bodies: ReadonlyArray<string>
+): Promise<{ readonly commit: string; readonly operationIds: ReadonlyArray<string> }> {
+  const expectedBlobs = bodies.map((body) => gitWithInput(rootDir, body, "hash-object", "--stdin"));
+  const currentBlobs = legacyBlobIds(rootDir, "HEAD", repositoryPaths);
+  if (currentBlobs.some((actual, index) => actual !== expectedBlobs[index])) {
+    throw new TaskCompletePrepublishNotMaterializedError(repositoryPaths.flatMap((repositoryPath, index) => {
+      const actual = currentBlobs[index];
+      return actual === expectedBlobs[index] ? [] : [{
+        path: repositoryPath,
+        reason: actual === null ? "missing from HEAD" : "content differs from expected"
+      }];
+    }));
+  }
+  const history = legacyFirstParentHistory(rootDir, repositoryPaths);
+  const attributions: Array<{ readonly commit: string; readonly operationIds: ReadonlyArray<string> } | null> =
+    repositoryPaths.map(() => null);
+  for (const entry of history) {
+    if (entry.parents.length !== 2) continue;
+    const actualBlobs = legacyBlobIds(rootDir, entry.commit, repositoryPaths);
+    const candidates = repositoryPaths.flatMap((_repositoryPath, index) =>
+      attributions[index] === null && actualBlobs[index] === expectedBlobs[index] ? [index] : []
+    );
+    if (candidates.length === 0) continue;
+    const firstParentBlobs = legacyBlobIds(rootDir, entry.parents[0]!, repositoryPaths);
+    for (const index of candidates) {
+      if (firstParentBlobs[index] === actualBlobs[index]) continue;
+      const operationIds = legacyAttributedPathOperationIds(
+        rootDir,
+        entry.parents[0]!,
+        entry.parents[1]!,
+        repositoryPaths[index]!,
+        expectedBlobs[index]!
+      );
+      if (operationIds.length > 0) attributions[index] = { commit: entry.commit, operationIds };
+    }
+  }
+  const missing = attributions.flatMap((attribution, index) => attribution ? [] : [repositoryPaths[index]!]);
+  if (missing.length > 0) {
+    throw new TaskCompletePrepublishNotMaterializedError(missing.map((repositoryPath) => ({
+      path: repositoryPath,
+      reason: "no canonical publication changed this path to its current content"
+    })));
+  }
+  const attributed = attributions.filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+  const attributedCommits = new Set(attributed.map((entry) => entry.commit));
+  const representative = history.find((entry) => attributedCommits.has(entry.commit));
+  if (!representative) {
+    throw new TaskCompletePrepublishNotMaterializedError(repositoryPaths.map((repositoryPath) => ({
+      path: repositoryPath,
+      reason: "attributed publication missing from first-parent history"
+    })));
+  }
+  return {
+    commit: representative.commit,
+    operationIds: [...new Set(attributed.flatMap((entry) => entry.operationIds))].sort()
+  };
+}
+
+function legacyFirstParentHistory(rootDir: string, repositoryPaths: ReadonlyArray<string>): ReadonlyArray<{
+  readonly commit: string;
+  readonly parents: ReadonlyArray<string>;
+}> {
+  const fields = git(rootDir,
+    "log",
+    "--first-parent",
+    "--full-history",
+    "--format=%H%x00%P%x00%s%x00",
+    "HEAD",
+    "--",
+    ...repositoryPaths.map((repositoryPath) => `:(literal)${repositoryPath}`)
+  ).split("\0");
+  const rows: Array<{ commit: string; parents: ReadonlyArray<string> }> = [];
+  for (let index = 0; index + 2 < fields.length; index += 3) {
+    const commit = fields[index]!.trim();
+    if (commit) rows.push({
+      commit,
+      parents: fields[index + 1]!.trim().split(" ").filter(Boolean)
+    });
+  }
+  return rows;
+}
+
+function legacyAttributedPathOperationIds(
+  rootDir: string,
+  firstParent: string,
+  authorityTip: string,
+  repositoryPath: string,
+  expectedBlob: string
+): ReadonlyArray<string> {
+  const commits = git(rootDir,
+    "rev-list",
+    "--reverse",
+    "--topo-order",
+    `${firstParent}..${authorityTip}`,
+    "--",
+    `:(literal)${repositoryPath}`
+  ).split(/\r?\n/u).map((entry) => entry.trim()).filter(Boolean);
+  const lastChangingCommit = commits.at(-1);
+  if (!lastChangingCommit) return [];
+  if (legacyBlobIds(rootDir, lastChangingCommit, [repositoryPath])[0] !== expectedBlob) return [];
+  return publicationOperationIds(git(rootDir, "show", "-s", "--format=%s", lastChangingCommit));
+}
+
+function legacyBlobIds(
+  rootDir: string,
+  commitRef: string,
+  repositoryPaths: ReadonlyArray<string>
+): ReadonlyArray<string | null> {
+  const byPath = new Map<string, string>();
+  for (const row of git(rootDir,
+    "ls-tree",
+    "-z",
+    "--full-tree",
+    commitRef,
+    "--",
+    ...repositoryPaths.map((repositoryPath) => `:(literal)${repositoryPath}`)
+  ).split("\0")) {
+    const separator = row.indexOf("\t");
+    if (separator < 0) continue;
+    const [, type, objectId] = row.slice(0, separator).split(" ");
+    if (type === "blob" && objectId) byPath.set(row.slice(separator + 1), objectId);
+  }
+  return repositoryPaths.map((repositoryPath) => byPath.get(repositoryPath) ?? null);
+}
+
+function publicationOperationIds(subject: string): ReadonlyArray<string> {
+  const match = /\[([^\]]+)\]$/u.exec(subject);
+  return match?.[1]
+    ? [...new Set(match[1].split(",").map((entry) => entry.trim()).filter(Boolean))].sort()
+    : [];
+}
+
+function git(rootDir: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", rootDir, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}
+
+function gitWithInput(rootDir: string, input: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", rootDir, ...args], {
+    input,
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"]
+  }).trim();
+}

--- a/packages/daemon/test/task-complete-prepublish-scale.test.ts
+++ b/packages/daemon/test/task-complete-prepublish-scale.test.ts
@@ -9,10 +9,12 @@ import { produceDocumentPublicationWitness } from "../src/authority/production/t
 
 const taskId = "task_01KZ9JFNGPFBFDP3J9ZW0B99CN";
 
-test("full first-parent history scan count stays constant as publication path count grows", async (context) => {
+test("publication attribution subprocess overhead stays constant as path count grows", async (context) => {
   const observations: Array<{
     readonly pathCount: number;
     readonly scanCount: number;
+    readonly historyPathspecCount: number;
+    readonly treeCallOverhead: number;
   }> = [];
   for (const pathCount of [3, 30]) {
     const fixture = pathScaleWitnessRepository(pathCount);
@@ -21,16 +23,27 @@ test("full first-parent history scan count stays constant as publication path co
         Promise.resolve(produceDocumentPublicationWitness(fixture))
       );
       const calls = traced.commands.filter(isUnboundedFirstParentHistoryCall);
-      observations.push({ pathCount, scanCount: calls.length });
+      const historyPathspecCount = calls[0]
+        ? calls[0].slice(calls[0].indexOf("--") + 1).length
+        : 0;
+      const treeCallCount = traced.commands.filter((args) => args.includes("ls-tree")).length;
+      observations.push({
+        pathCount,
+        scanCount: calls.length,
+        historyPathspecCount,
+        treeCallOverhead: treeCallCount - pathCount
+      });
     } finally {
       rmSync(fixture.fixtureRoot, { recursive: true, force: true });
     }
   }
 
-  context.diagnostic(`unbounded first-parent history scans: ${observations
-    .map((entry) => `${entry.pathCount} paths=${entry.scanCount}`)
+  context.diagnostic(`publication attribution scans: ${observations
+    .map((entry) => `${entry.pathCount} paths: history=${entry.scanCount}, pathspecs=${entry.historyPathspecCount}, tree-overhead=${entry.treeCallOverhead}`)
     .join(", ")}`);
   assert.equal(observations[0]!.scanCount, observations[1]!.scanCount, JSON.stringify(observations));
+  assert.deepEqual(observations.map((entry) => entry.historyPathspecCount), [1, 1]);
+  assert.deepEqual(observations.map((entry) => entry.treeCallOverhead), [1, 1]);
 });
 
 test("history scan tracing recognizes unbounded first-parent log and rev-list calls", () => {

--- a/packages/daemon/test/task-complete-prepublish-witness.test.ts
+++ b/packages/daemon/test/task-complete-prepublish-witness.test.ts
@@ -77,7 +77,7 @@ test("daemon-produced prepublish witnesses bind immutable publication history, c
   }
 });
 
-test("one multi-path publication proof scans first-parent history once", async () => {
+test("one multi-path publication proof reads attribution history in one raw pass", async () => {
   const fixture = witnessRepository();
   try {
     const traced = await withTracedGit(fixture.fixtureRoot, 0, () =>
@@ -92,7 +92,8 @@ test("one multi-path publication proof scans first-parent history once", async (
       event.event === "start" && event.args.includes("ls-tree")
     );
     assert.equal(historyCalls.length, 1, JSON.stringify(historyCalls));
-    assert.equal(treeCalls.length, 5, JSON.stringify(treeCalls));
+    assert.equal(historyCalls[0]!.args.includes("--raw"), true, JSON.stringify(historyCalls));
+    assert.equal(treeCalls.length, fixture.documents.length + 1, JSON.stringify(treeCalls));
   } finally {
     rmSync(fixture.fixtureRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
# English

## Summary

`ha task complete` was deterministically failing in production: the authority publication proof for a 50-path task needed ~60s under load while the daemon's per-request watchdog is a hard 30s, so the repo-write child was killed mid-proof every time (self-reinforcing livelock: each failure adds an unsettled outcome to the recovery backlog). This PR rewrites the attribution scan to read first-parent history **once** (`git log --first-parent --diff-merges=first-parent --raw --no-renames`) and attribute in memory, instead of running O(mergeCommits × paths) serial `git ls-tree` subprocesses. Proof semantics are unchanged: every path must still attribute to an exact canonical publication commit and operation-id set, otherwise `TaskCompletePrepublishNotMaterializedError` is thrown as before. The 30s watchdog is deliberately untouched (dec_01KZXJF9CABZVV3ZNA091C35K7 rejected widening it).

## What Changed

- `packages/daemon/src/authority/production/task-complete-prepublish-publication.ts`: `firstParentHistory` becomes `firstParentPublicationHistory` — one raw first-parent scan carrying per-commit `{before, after}` blob transitions; candidate detection (`after === expected && before !== after`) replaces the two per-merge `ls-tree` calls; `attributionHistoryPathspecs` collapses paths sharing a directory prefix into one pathspec; operation-id extraction (second-parent rev-list per attributed path) is preserved as-is.
- `packages/daemon/test/task-complete-prepublish-publication-parity.test.ts` (new): a faithful in-test transcription of the legacy algorithm as oracle; `deepEqual` on both sides across the four outcome classes (successful attribution / not materialized / witness commit mismatch / operation-id mismatch) plus rename, mode-only, and historical-deletion fixtures that specifically probe `--raw` representation differences.
- `packages/daemon/test/task-complete-prepublish-scale.test.ts`: structural ratchet — history must be exactly one subprocess and `ls-tree` overhead exactly `pathCount + 1` (HEAD check), asserted at 3 and 30 paths; no absolute-ms thresholds.
- `packages/daemon/test/task-complete-prepublish-witness.test.ts`: tracer asserting the single raw history pass on the public witness path.

## Task And Scope

- Harness task: task_01KZXJJQ2864Q3S37B8J199R1D (derives from dec_01KZXJF9CABZVV3ZNA091C35K7)
- Branch: codex/proof-singlepass
- Public scope: packages/daemon (1 production file + 3 test files)
- Private planning/evidence updated: yes (task package artifacts: mission, worker report with 16 Finding/Verify-Command pairs)
- Out of scope: watchdog default (`defaultRepoWriteRequestTimeoutMs`), recovery/sweep paths, CLI/protocol contracts.

## Version Impact

- Version: no version change because this is a behavior-preserving internal performance fix.
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: no (production write road implementation file, but no gate/CI/protected-surface list entry; the watchdog constant is intentionally untouched)
- Protected surface scope: not applicable
- Authority: dec_01KZXJF9CABZVV3ZNA091C35K7 (active): fix the scan cost, do not raise the watchdog
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 85f003f4
- Branch merge-base with `origin/main`: 85f003f4
- Last `git fetch origin` time: 2026-08-13 ~20:49 CST
- Sync method: none needed (branch is base+1)
- Public diff command: `git diff 85f003f4..ac3f7411`
- Private evidence commit/path: harness/tasks/task_01KZXJJQ2864Q3S37B8J199R1D-task-complete-publication-proof-30s-watchdog/artifacts/worker-report-sol-singlepass.md
- Reviewer evidence path: same artifacts dir (mechanical verify-findings run over 16 Finding/Verify-Command pairs)
- GitHub Actions `rewrite-ci` run URL: pending (will be green before merge)
- [x] `git diff --check`
- [x] `npm run check:stop-point` equivalent: `npm run check:local` exit 0, 48.6s, 27 complete manifest gates green
- [x] Targeted tests: parity 5 tests, scale + witness + parity via tier runner: 16 tests, 0 fail, 15.34s
- [ ] GitHub Actions `rewrite-ci` passed (authoritative full gate — pending at PR-open time)
- Not run, and why: production E2E replay of the wedged `ha task complete` requires this merged + dist rebuild + daemon restart; it is the explicit post-merge verification step and is tracked in the task plan.

## Review Evidence

- Self-review: CEO read the full production diff; candidate semantics verified equivalent to the two-ls-tree legacy logic (mode-only excluded by `before !== after`, deletion excluded by zero blob, renames flattened by `--no-renames`).
- Reviewer subagent: mechanical verify-findings over the worker report's 16 Finding/Verify-Command pairs.
- Human review: pending (this PR)
- Blocking findings: none

## Residual Risk

- `attributionHistoryPathspecs` widening: when touched paths span multiple top-level directories with a shallow shared prefix (e.g. two different task packages), the single pathspec degrades to a broad directory and the raw scan output grows (bounded by the 64MB maxBuffer, one subprocess, in-memory filtering — never back to O(mergeCommits × paths) subprocesses). Fallback when no prefix is shared is the literal path list, measured at 4.6s on the production-scale ledger.
- Measured production-fixture proof time is 3.57s idle (was 8.4s idle / ~60s under recovery contention). Contention headroom to the 30s watchdog is now ~8×; if a future ledger grows past that, the structural scale test pins the subprocess shape so the regression would be a git-side cost, not a fan-out reintroduction.

---

# 中文

## 概要

生产环境 `ha task complete` 确定性失败:50 个 touched path 的 authority publication proof 在负载下需要约 60s,而 daemon 每请求 watchdog 硬定 30s,writer child 每次都在证明中途被杀(自增强活锁:每次失败向 recovery backlog 增加一条未结算 outcome)。本 PR 把归属扫描改为**单趟** first-parent 历史读取(`git log --first-parent --diff-merges=first-parent --raw --no-renames`)+ 内存归属,替代 O(mergeCommits × paths) 的串行 `git ls-tree` 子进程扇出。证明语义不变:每个 path 仍必须归属到确切的 canonical publication commit 与 operationIds,归属不到照旧抛 `TaskCompletePrepublishNotMaterializedError`。30s watchdog 刻意不动(dec_01KZXJF9CABZVV3ZNA091C35K7 已拒绝抬预算方案)。

## 改了什么

- `packages/daemon/src/authority/production/task-complete-prepublish-publication.ts`:`firstParentHistory` 改为 `firstParentPublicationHistory`——一次 raw first-parent 扫描携带每 commit 的 `{before, after}` blob 变迁;候选判定(`after === expected && before !== after`)替代每个 merge commit 的两次 `ls-tree`;`attributionHistoryPathspecs` 把共享目录前缀的 path 收敛为单一 pathspec;operationIds 提取(每个 attributed path 的第二父 rev-list)原样保留。
- `packages/daemon/test/task-complete-prepublish-publication-parity.test.ts`(新增):旧算法的忠实测试内转写作 oracle,四类结果(归属成功/未物化/witness commit 不一致/operationIds 不一致)双侧 `deepEqual`,并含 rename、mode-only、历史删除 fixture,专门探测 `--raw` 表达差异。
- `packages/daemon/test/task-complete-prepublish-scale.test.ts`:结构性 ratchet——history 必须恰好一个子进程,`ls-tree` 开销恰好 `pathCount + 1`,在 3 与 30 path 双点断言;不用绝对毫秒阈值。
- `packages/daemon/test/task-complete-prepublish-witness.test.ts`:tracer 断言公共 witness 路径只发起一次 raw history 扫描。

## 任务与范围

- Harness task:task_01KZXJJQ2864Q3S37B8J199R1D(derives 自 dec_01KZXJF9CABZVV3ZNA091C35K7)
- 分支:codex/proof-singlepass
- 公开范围:packages/daemon(1 个生产文件 + 3 个测试文件)
- 私有规划/证据已更新:是(任务包 artifacts:mission 与含 16 组 Finding/Verify-Command 的 worker 报告)
- 范围外:watchdog 默认值、recovery/sweep 路径、CLI/协议契约。

## 版本影响

- 版本:无变化,行为保持的内部性能修复。
- 发布影响:不发布。

## 治理声明

- 触碰 protected surface:否(生产写路实现文件,但不在 gate/CI/protected-surface 清单;watchdog 常量刻意不动)
- Protected surface 范围:不适用
- 授权:dec_01KZXJF9CABZVV3ZNA091C35K7(active):根修扫描成本,不抬 watchdog
- 机器检查边界:本 PR 仅断言声明存在;声明是否真实充分由评审判断。
- Break-glass:否

## 验证

- Base `origin/main` SHA:85f003f4
- 分支与 `origin/main` 的 merge-base:85f003f4
- 最近 `git fetch origin` 时间:2026-08-13 约 20:49 CST
- 同步方式:无需(分支为 base+1)
- 公开 diff 命令:`git diff 85f003f4..ac3f7411`
- 私有证据 commit/路径:harness/tasks/task_01KZXJJQ2864Q3S37B8J199R1D-task-complete-publication-proof-30s-watchdog/artifacts/worker-report-sol-singlepass.md
- 评审证据路径:同 artifacts 目录(对 16 组 Finding/Verify-Command 的机械复核)
- GitHub Actions `rewrite-ci` run URL:待定(合并前必绿)
- [x] `git diff --check`
- [x] 停止点等价:`npm run check:local` exit 0,48.6s,27 个 complete manifest gates 全绿
- [x] 定向测试:parity 5 tests;tier runner 下 parity+scale+witness 共 16 tests,0 fail,15.34s
- [ ] GitHub Actions `rewrite-ci` 通过(权威全量门——开 PR 时待跑)
- 未跑及原因:被楔死的 `ha task complete` 生产 E2E 重放需要本 PR 合入 + dist 重建 + daemon 重启,是任务计划中显式的合并后验证步骤。

## 评审证据

- 自评:CEO 通读生产 diff;候选判定与旧双 ls-tree 逻辑逐位等价(mode-only 被 `before !== after` 排除、删除被零 blob 排除、rename 被 `--no-renames` 摊平)。
- 评审 subagent:对 worker 报告 16 组 Finding/Verify-Command 的机械复核。
- 人工评审:待定(本 PR)
- 阻塞 findings:无

## 残余风险

- `attributionHistoryPathspecs` 收窄的退化面:touched paths 跨多个顶层目录、共享前缀很浅时(如跨两个 task 包),单一 pathspec 退化为宽目录,raw 扫描输出膨胀(受 64MB maxBuffer 约束、单子进程、内存过滤——绝不回到 O(mergeCommits × paths) 子进程扇出)。完全不共享前缀时回退 literal path 列表,生产规模台账实测 4.6s。
- 生产 fixture 的 proof 实测空闲 3.57s(原空闲 8.4s / recovery 争用下约 60s)。对 30s watchdog 的争用余量约 8×;若未来台账增长超过该余量,结构性 scale 测试钉死了子进程形状,回归只会是 git 侧成本,不会是扇出复发。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
