### PR TITLE
feat(gui): land task truth control surface (W5 GUI S2-A)

### DIFF
--- a/packages/gui/src/api/renderer-dto.ts
+++ b/packages/gui/src/api/renderer-dto.ts
@@ -1,4 +1,4 @@
-import type { DaemonGuiActionResult, DaemonGuiReadPayloadMap, DaemonGuiReadResultMap, DaemonGuiStreamPayloadMap } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
+import type { DaemonGuiActionResult, DaemonGuiReadPayloadMap, DaemonGuiReadResultMap, DaemonGuiStreamPayloadMap, GuiSubmissionV1 } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
 export type {
   DecisionProjectionRow,
   ProjectionWarning,
@@ -9,3 +9,4 @@ export type {
 } from "../../../kernel/src/index.ts";
 export type TaskSnapshotProjectionRow = DaemonGuiReadResultMap["repo.tasks.list"]["rows"][number]; export type TaskDocumentProjectionRead = DaemonGuiReadResultMap["repo.tasks.document.read"]; export type AgentRuntimeOverviewPayload = DaemonGuiReadPayloadMap["repo.agentRuntime.overview"]; export type AgentRuntimeSessionPayload = DaemonGuiReadPayloadMap["repo.agentRuntime.sessions.read"]; export type AgentRuntimeEventsPayload = DaemonGuiReadPayloadMap["repo.agentRuntime.events.read"]; export type AgentRuntimeAttachPayload = DaemonGuiStreamPayloadMap["repo.agentRuntime.attach"];
 export type GuiActionResult = DaemonGuiActionResult; export type GuiBridgeMethod = (typeof import("../../../daemon/src/protocol/daemon-protocol.contract.ts").daemonGuiReadMethods)[number]["guiBridgeMethod"] | (typeof import("../../../daemon/src/protocol/daemon-protocol.contract.ts").daemonGuiActionMethods)[number]["guiBridgeMethod"] | (typeof import("../../../daemon/src/protocol/daemon-protocol.contract.ts").daemonGuiStreamFacets)[number]["guiBridgeMethod"];
+export type { GuiSubmissionV1 };

--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -16,7 +16,6 @@ import {
 } from "@phosphor-icons/react";
 import type { SnapshotStatus } from "./model/types.ts";
 import {
-  MOCK_TASK_RELATIONS,
   MOCK_PRESETS,
   MOCK_ADAPTERS,
   MOCK_EVENTS,
@@ -47,6 +46,7 @@ import { useTriadicProjectionQuery } from "./triadic-data.ts";
 import { useFavorites } from "./model/favorites.ts";
 import type { LaneGroupBy } from "./views/SwimlaneBoard.tsx";
 import { AgentRuntimeView } from "./views/agent-runtime-view.tsx";
+import { useTaskActions } from "./task-actions.ts";
 
 type ViewId =
   | "home"
@@ -103,12 +103,18 @@ function AppShell() {
   const [view, setView] = useState<ViewId>("overview");
   const tasksQuery = useTasksQuery();
   const triadicQuery = useTriadicProjectionQuery();
+  const taskActions = useTaskActions();
   const realTasks = useMemo(
-    () => adaptProjectionRows(tasksQuery.data?.rows ?? [], tasksQuery.data?.status),
-    [tasksQuery.data],
+    () => adaptProjectionRows(tasksQuery.data?.rows ?? [], tasksQuery.data?.status, {
+      relationState: triadicQuery.relationState,
+      relations: triadicQuery.relations,
+      decisions: triadicQuery.decisions,
+      relationWarnings: triadicQuery.relationWarnings
+    }),
+    [tasksQuery.data, triadicQuery.relationState, triadicQuery.relations, triadicQuery.decisions, triadicQuery.relationWarnings],
   );
   const [tasks, setTasks] = useState<import("./model/types.ts").TaskRow[]>([]);
-  // 台账投影是权威真数据源;查询刷新时重播到本地态(拖拽等乐观更新为原型内交互)。
+  // 台账投影是唯一任务真值；mutation 不做 optimistic status，reread 后才更新。
   useEffect(() => {
     setTasks(realTasks);
   }, [realTasks]);
@@ -140,11 +146,6 @@ function AppShell() {
     () => tasks.filter((t) => t.projectId === projectId),
     [tasks, projectId],
   );
-  const projectEvents = useMemo(
-    () => MOCK_EVENTS.filter((e) => e.projectId === projectId),
-    [projectId],
-  );
-
   const activeCount = projectTasks.filter(
     (t) => t.coordinationStatus === "active" || t.coordinationStatus === "blocked" || t.coordinationStatus === "in_review",
   ).length;
@@ -432,6 +433,9 @@ function AppShell() {
                 fromViewLabel={VIEW_LABEL[view]}
                 onNavigateDecision={navigateToDecision}
                 onNavigateEntity={navigateToEntity}
+                mutationFeedback={taskActions.feedback.get(selected.taskId)}
+                onProgress={(input) => taskActions.appendProgress(selected, input)}
+                onSubmit={(submission) => taskActions.submitTask(selected, submission)}
               />
             ) : view === "home" ? (
               <HomeView
@@ -461,9 +465,11 @@ function AppShell() {
                 onFiltersChange={setTaskFilters}
                 onSelect={openTaskPreview}
                 drill={drill}
-                relations={MOCK_TASK_RELATIONS}
+                relations={relations}
                 favorites={favorites}
                 onToggleFavorite={toggleFavorite}
+                onStartTask={taskActions.startTask}
+                mutationFeedback={(taskId) => taskActions.feedback.get(taskId)}
               />
             ) : view === "graph" ? (
               <EntityWorkspace
@@ -536,8 +542,7 @@ function AppShell() {
       <TaskPreviewDrawer
         task={previewTask}
         tasks={projectTasks}
-        relations={MOCK_TASK_RELATIONS}
-        events={projectEvents}
+        relations={relations}
         onClose={() => setPreviewId(null)}
         onOpenDetail={openTaskDetail}
         onPreviewTask={openTaskPreview}

--- a/packages/gui/src/renderer/api-client.ts
+++ b/packages/gui/src/renderer/api-client.ts
@@ -1,6 +1,7 @@
 import type {
   DecisionProjectionRow,
   FactAnchorRow, FactProjectionRow,
+  GuiActionResult, GuiSubmissionV1,
   GuiBridgeMethod,
   ProjectionWarning,
   RelationCoverageRow,
@@ -45,7 +46,11 @@ export const harnessClient = {
   async getTasks(): Promise<TaskListSuccess> { return readTaskListResult(await invokeBridge("getTasks")); },
   async getTaskDocument(payload: { readonly taskId: string; readonly path: string }): Promise<TaskDocumentProjectionRead> { return readTaskDocumentResult(await invokeBridge("getTaskDocument", payload)); },
   async getRelationGraph(): Promise<RelationGraphSuccess> { return readRelationGraphResult(await invokeBridge("getRelationGraph")); },
-  async getDecisions(): Promise<DecisionListSuccess> { return readDecisionListResult(await invokeBridge("getDecisions")); }
+  async getDecisions(): Promise<DecisionListSuccess> { return readDecisionListResult(await invokeBridge("getDecisions")); },
+  async startTask(payload: { readonly taskId: string; readonly executionId: string }): Promise<GuiActionResult> { return readGuiActionResult(await invokeBridge("startTask", payload)); },
+  async appendTaskProgress(payload: { readonly taskId: string; readonly executionId?: string; readonly text: string; readonly evidence?: ReadonlyArray<{ readonly type: string; readonly path: string; readonly summary: string }>; readonly baseDocumentSha256?: string | null }): Promise<GuiActionResult> { return readGuiActionResult(await invokeBridge("appendTaskProgress", payload)); },
+  async submitTask(payload: { readonly taskId: string; readonly executionId: string; readonly submission: GuiSubmissionV1 }): Promise<GuiActionResult> { return readGuiActionResult(await invokeBridge("submitTask", payload)); },
+  async showReceipt(payload: { readonly opId: string }): Promise<GuiActionResult> { return readGuiActionResult(await invokeBridge("showReceipt", payload)); }
 };
 
 async function invokeBridge(method: GuiBridgeMethod, payload: object | null = null): Promise<unknown> { const bridge = window.harness;
@@ -95,6 +100,15 @@ function readDecisionListResult(value: unknown): DecisionListSuccess {
     decisions: result.decisions.filter(isDecisionProjectionRow),
     warnings: Array.isArray(result.warnings) ? result.warnings : []
   };
+}
+
+function readGuiActionResult(value: unknown): GuiActionResult {
+  const result = value as Partial<GuiActionResult>;
+  if (!result || result.schema !== "command-receipt/v2" || typeof result.ok !== "boolean" || typeof result.command !== "string"
+    || !["applied", "pending", "indeterminate", "rejected"].includes(String(result.outcome)) || typeof result.opId !== "string") {
+    throw new Error(localErrorHint(value, "GUI action bridge returned an invalid receipt."));
+  }
+  return result as GuiActionResult;
 }
 
 function isTaskSnapshotProjectionRow(value: unknown): value is TaskSnapshotProjectionRow {

--- a/packages/gui/src/renderer/components/TaskControlPanel.tsx
+++ b/packages/gui/src/renderer/components/TaskControlPanel.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import type { GuiSubmissionV1 } from "../../api/renderer-dto.ts";
+import type { TaskMutationFeedback } from "../task-actions.ts";
+import type { TaskRow } from "../model/types.ts";
+
+const lines = (value: FormDataEntryValue | null) => String(value ?? "").split(/\r?\n/u).map((item) => item.trim()).filter(Boolean);
+
+function readEvidence(value: FormDataEntryValue | null): ReadonlyArray<{ type: string; path: string; summary: string }> | null {
+  const result = [];
+  for (const line of lines(value)) {
+    const [type, path, ...summary] = line.split(":");
+    if (!type || !path || summary.length === 0) return null;
+    result.push({ type, path, summary: summary.join(":") });
+  }
+  return result;
+}
+
+export function TaskControlPanel({ task, feedback, onProgress, onSubmit }: {
+  task: TaskRow;
+  feedback?: TaskMutationFeedback;
+  onProgress?: (input: { text: string; evidence: ReadonlyArray<{ type: string; path: string; summary: string }> }) => Promise<unknown>;
+  onSubmit?: (submission: GuiSubmissionV1) => Promise<unknown>;
+}) {
+  const [localError, setLocalError] = useState<string | null>(null), pending = feedback?.state === "pending";
+  const reason = task.origin === "external" ? "外部任务由来源引擎管理，本 GUI 只读。"
+    : task.origin === "archival" || task.packageDisposition !== "active" ? "归档或非 active package 只读。"
+      : task.canonicalStatus === "in_review" ? "任务已进入 review；progress 与 submission 已关闭。"
+        : task.canonicalStatus === "done" ? "任务已完成，控制面只读。"
+          : task.canonicalStatus === "planned" ? task.blocking === "blocked" ? "Blocked 是 relation overlay，不是状态机节点；请在 canonical relation 来源处理后再启动。" : "在看板列模式拖到 Active 以申请 execution lease。"
+            : task.canonicalStatus === "active" && !task.activeExecutionId ? "Active task 没有可见 lease，不能追加 progress 或提交 review。" : null;
+
+  return <section className="rounded-md border border-border bg-bg/50 p-2.5" data-testid="task-control-panel">
+    <div className="font-mono text-[10px] uppercase tracking-wide text-text-faint">Task control</div>
+    {task.blocking && <p className={`mt-1 text-[11px] ${task.blocking === "unknown" ? "text-stale" : task.blocking === "blocked" ? "text-status-blocked" : "text-text-faint"}`}>
+      {task.blockingLabel}{task.blockers?.length ? ` · ${task.blockers.length} blocker(s)` : ""}
+    </p>}
+    {task.blockingWarnings?.map((warning) => <p key={warning} className="mt-1 text-[11px] text-stale">warning: {warning}</p>)}
+    {task.blockers?.map((blocker) => <div key={blocker.relationId} className="mt-1 rounded border border-status-blocked/20 px-2 py-1 font-mono text-[10px] text-text-muted">
+      {blocker.relationId} · {blocker.sourceTaskId} --{blocker.kind}→ {blocker.targetTaskId}
+      {blocker.rationale && <p className="mt-0.5 font-sans text-[11px]">{blocker.rationale}</p>}
+    </div>)}
+    {reason && <p className="mt-2 text-[11px] leading-relaxed text-text-muted">{reason}</p>}
+    {task.canonicalStatus === "active" && task.activeExecutionId && task.origin === "native" && task.packageDisposition === "active" && <div className="mt-2 space-y-2">
+      <p className="font-mono text-[10px] text-text-faint">lease · {task.activeExecutionId}</p>
+      <details className="rounded border border-border bg-surface p-2">
+        <summary className="cursor-pointer text-[12px] font-medium text-text">追加 progress</summary>
+        <form className="mt-2 space-y-2" onSubmit={(event) => { event.preventDefault(); const form = new FormData(event.currentTarget), evidence = readEvidence(form.get("evidence"));
+          if (!evidence) { setLocalError("evidence 每行必须是 type:path:summary"); return; } setLocalError(null); void onProgress?.({ text: String(form.get("text") ?? ""), evidence }); }}>
+          <textarea name="text" required placeholder="进展原文" className="min-h-20 w-full rounded border border-border bg-bg px-2 py-1.5 text-[12px] text-text" />
+          <textarea name="evidence" placeholder="可选，每行 type:path:summary" className="min-h-16 w-full rounded border border-border bg-bg px-2 py-1.5 font-mono text-[11px] text-text" />
+          <button disabled={pending} className="rounded bg-accent px-2.5 py-1.5 text-[12px] font-semibold text-accent-fg disabled:opacity-50">写入 progress</button>
+        </form>
+      </details>
+      <details className="rounded border border-border bg-surface p-2">
+        <summary className="cursor-pointer text-[12px] font-medium text-text">Request review · atomic SubmissionV1</summary>
+        <form className="mt-2 space-y-2" onSubmit={(event) => { event.preventDefault(); const form = new FormData(event.currentTarget); setLocalError(null); void onSubmit?.({
+          completionClaim: String(form.get("completionClaim") ?? ""), deliverables: lines(form.get("deliverables")), outputs: lines(form.get("outputs")),
+          verificationNotes: lines(form.get("verificationNotes")), knownGaps: lines(form.get("knownGaps")), residualRisks: lines(form.get("residualRisks")), commitSha: String(form.get("commitSha") ?? "")
+        }); }}>
+          <input name="completionClaim" required placeholder="Completion claim" className="w-full rounded border border-border bg-bg px-2 py-1.5 text-[12px] text-text" />
+          {(["deliverables", "outputs", "verificationNotes", "knownGaps", "residualRisks"] as const).map((name) => <textarea key={name} name={name} required placeholder={`${name} · 每行一项`} className="min-h-14 w-full rounded border border-border bg-bg px-2 py-1.5 text-[11px] text-text" />)}
+          <input name="commitSha" required pattern="[0-9a-f]{40}" placeholder="40-char commit SHA" className="w-full rounded border border-border bg-bg px-2 py-1.5 font-mono text-[11px] text-text" />
+          <button disabled={pending} className="rounded bg-accent px-2.5 py-1.5 text-[12px] font-semibold text-accent-fg disabled:opacity-50">原子提交并进入 review</button>
+        </form>
+      </details>
+    </div>}
+    {localError && <p className="mt-2 text-[11px] text-danger">{localError}</p>}
+    {feedback && <div data-testid="task-mutation-feedback" className={`mt-2 rounded border px-2 py-1.5 text-[11px] ${feedback.state === "error" ? "border-danger/40 text-danger" : feedback.state === "pending" ? "border-stale/40 text-stale" : "border-status-done/40 text-text-muted"}`}>
+      <span className="font-mono">{feedback.kind} · {feedback.state} · opId={feedback.opId}</span>
+      {feedback.code && <span className="ml-1 font-mono">code={feedback.code}</span>}
+      <p className="mt-0.5">{feedback.hint}</p>
+    </div>}
+  </section>;
+}

--- a/packages/gui/src/renderer/components/TaskFilterBar.tsx
+++ b/packages/gui/src/renderer/components/TaskFilterBar.tsx
@@ -16,7 +16,6 @@ import {
   type TaskFilters,
 } from "../model/taskFilters";
 
-const ENGINES: (EngineId | "all")[] = ["all", "local", "multica", "github", "linear"];
 const CLOSEOUTS: (CloseoutReadiness | "all")[] = [
   "all",
   "ready",
@@ -166,7 +165,8 @@ export function TaskFilterBar({
   contextLabel: string;
   favorites?: ReadonlySet<string>;
 }) {
-  const modules = [...new Set(tasks.map((task) => task.module))].sort();
+  const modules = [...new Set(tasks.flatMap((task) => task.moduleKeys?.length ? task.moduleKeys : [task.module]))].sort();
+  const engines: (EngineId | "all")[] = ["all", ...new Set(tasks.map((task) => task.engine))];
   const chips = taskFilterSummary(filters);
   const active = hasActiveTaskFilters(filters);
   const favoriteCount = favorites ? tasks.filter((t) => favorites.has(t.taskId)).length : 0;
@@ -192,7 +192,7 @@ export function TaskFilterBar({
           values={["all", ...modules]}
           onChange={(module) => patch({ module })}
         />
-        <Select label="engine" value={filters.engine} values={ENGINES} onChange={(engine) => patch({ engine })} />
+        <Select label="engine" value={filters.engine} values={engines} onChange={(engine) => patch({ engine })} />
         <StatusMultiSelect
           selected={filters.status}
           onChange={(status) => patch({ status })}

--- a/packages/gui/src/renderer/components/TaskPreviewDrawer.tsx
+++ b/packages/gui/src/renderer/components/TaskPreviewDrawer.tsx
@@ -6,8 +6,9 @@ import {
   X,
   XCircle,
 } from "@phosphor-icons/react";
-import type { EventEntry, RelationEdge, TaskRow } from "../model/types";
+import type { RelationEdge, TaskRow } from "../model/types";
 import { isExternal } from "../model/types";
+import { normalizeTaskId } from "../model/triadic.ts";
 import {
   CloseoutBadge,
   EngineBadge,
@@ -38,7 +39,6 @@ export function TaskPreviewDrawer({
   task,
   tasks,
   relations,
-  events,
   onClose,
   onOpenDetail,
   onPreviewTask,
@@ -46,7 +46,6 @@ export function TaskPreviewDrawer({
   task: TaskRow | null;
   tasks: TaskRow[];
   relations: RelationEdge[];
-  events: EventEntry[];
   onClose: () => void;
   onOpenDetail: (id: string) => void;
   onPreviewTask: (id: string) => void;
@@ -63,15 +62,14 @@ export function TaskPreviewDrawer({
   if (!task) return null;
 
   const related = relations
-    .filter((edge) => edge.from === task.taskId || edge.to === task.taskId)
+    .filter((edge) => (edge.from.startsWith("task/") && normalizeTaskId(edge.from) === task.taskId) || (edge.to.startsWith("task/") && normalizeTaskId(edge.to) === task.taskId))
     .map((edge) => {
-      const otherId = edge.from === task.taskId ? edge.to : edge.from;
+      const otherRef = normalizeTaskId(edge.from) === task.taskId ? edge.to : edge.from, otherId = otherRef.startsWith("task/") ? normalizeTaskId(otherRef) : "";
       return { edge, task: tasks.find((candidate) => candidate.taskId === otherId) };
     })
     .filter((item) => item.task);
-  const missingDocs = task.docs.filter((doc) => doc.required && !doc.present);
-  const taskEvents = events
-    .filter((event) => event.taskId === task.taskId)
+  const missingDocs = task.docs.filter((doc) => doc.required && doc.presence !== "unknown" && !doc.present);
+  const taskEvents = (task.events ?? [])
     .sort((a, b) => b.at.localeCompare(a.at))
     .slice(0, 4);
 
@@ -107,6 +105,8 @@ export function TaskPreviewDrawer({
           </div>
           <div className="mt-3 flex flex-wrap items-center gap-2">
             <StatusBadge status={task.coordinationStatus} />
+            {task.coordinationStatus === "blocked" && task.canonicalStatus && <span className="font-mono text-[11px] text-status-blocked">canonical {task.canonicalStatus}</span>}
+            {task.blocking === "unknown" && <span className="text-[11px] text-stale">阻塞关系未能确定</span>}
             <CloseoutBadge value={task.closeoutReadiness} />
             <FreshnessTag freshness={task.freshness} lastKnownAt={task.lastKnownAt} />
           </div>
@@ -129,7 +129,15 @@ export function TaskPreviewDrawer({
               </div>
               <div>
                 <dt className="font-mono text-[12px] text-text-faint">source</dt>
-                <dd className="font-mono text-text">{task.source}</dd>
+                <dd className="font-mono text-text">{task.origin ?? task.source}</dd>
+              </div>
+              <div>
+                <dt className="font-mono text-[12px] text-text-faint">product lines</dt>
+                <dd className="font-mono text-text">{task.productLines?.join(", ") || "未投影"}</dd>
+              </div>
+              <div>
+                <dt className="font-mono text-[12px] text-text-faint">parent / root</dt>
+                <dd className="font-mono text-text">{task.parentTaskId ?? "root"} / {task.rootTaskId ?? task.taskId}</dd>
               </div>
             </dl>
           </Section>
@@ -176,7 +184,9 @@ export function TaskPreviewDrawer({
           </Section>
 
           <Section title="收口材料">
-            {missingDocs.length === 0 ? (
+            {task.docs.length === 0 ? (
+              <p className="text-[14px] text-stale">文档清单未在预览投影；打开完整详情读取 task-contract。</p>
+            ) : missingDocs.length === 0 ? (
               <p className="text-[14px] text-text-muted">必需文档齐备。</p>
             ) : (
               <div className="space-y-1.5">

--- a/packages/gui/src/renderer/components/badges.tsx
+++ b/packages/gui/src/renderer/components/badges.tsx
@@ -120,7 +120,7 @@ export function CloseoutBadge({ value }: { value: CloseoutReadiness }) {
   );
 }
 
-const ENGINE_LABEL: Record<EngineId, string> = {
+const ENGINE_LABEL: Record<string, string> = {
   local: "local",
   multica: "multica",
   github: "github",
@@ -131,7 +131,7 @@ export function EngineBadge({ engine, locked }: { engine: EngineId; locked: bool
   return (
     <span className="inline-flex items-center gap-1 rounded border border-border px-1.5 py-px font-mono text-[12px] text-text-muted">
       {locked && <Lock weight="bold" className="text-[12px]" />}
-      {ENGINE_LABEL[engine]}
+      {ENGINE_LABEL[engine] ?? engine}
     </span>
   );
 }

--- a/packages/gui/src/renderer/components/taskDetail/PhaseSteps.tsx
+++ b/packages/gui/src/renderer/components/taskDetail/PhaseSteps.tsx
@@ -7,7 +7,7 @@ export function PhaseSteps({ status }: { status: SnapshotStatus }) {
   if (idx < 0) {
     const note =
       status === "blocked"
-        ? "blocked：暂离主流程，解除后回到 active"
+        ? "blocked：relation overlay，不是 Task/v1 状态机节点"
         : status === "cancelled"
           ? "cancelled：终态，不参与阶段流"
           : "unknown：快照展示值，无阶段位置";

--- a/packages/gui/src/renderer/components/taskDetail/constants.ts
+++ b/packages/gui/src/renderer/components/taskDetail/constants.ts
@@ -1,14 +1,5 @@
 import type { CanonicalStatus, RelationKind } from "../../model/types";
 
-export const LOCAL_TRANSITIONS: CanonicalStatus[] = [
-  "planned",
-  "active",
-  "blocked",
-  "in_review",
-  "done",
-  "cancelled",
-];
-
 export const STEP_FLOW: CanonicalStatus[] = ["planned", "active", "in_review", "done"];
 
 export const OUT_LABEL: Record<RelationKind, string> = {

--- a/packages/gui/src/renderer/components/taskDetail/widgets.tsx
+++ b/packages/gui/src/renderer/components/taskDetail/widgets.tsx
@@ -11,6 +11,7 @@ export function AxisRow({ label, children }: { label: string; children: React.Re
 }
 
 export function DocPresence({ doc }: { doc: DocEntry }) {
+  if (doc.presence === "unknown") return <Circle weight="duotone" className="shrink-0 text-[13px] text-stale" />;
   if (doc.present) {
     return <CheckCircle weight="bold" className="shrink-0 text-[13px]" style={{ color: "var(--color-status-done)" }} />;
   }

--- a/packages/gui/src/renderer/model/taskFilters.ts
+++ b/packages/gui/src/renderer/model/taskFilters.ts
@@ -66,6 +66,8 @@ export function matchesTask(
       task.taskId,
       task.title,
       task.module,
+      ...(task.moduleKeys ?? []),
+      ...(task.productLines ?? []),
       task.engine,
       task.rawStatus,
       task.coordinationStatus,
@@ -77,9 +79,9 @@ export function matchesTask(
     if (!haystack.includes(query)) return false;
   }
 
-  if (filters.module !== "all" && task.module !== filters.module) return false;
+  if (filters.module !== "all" && task.module !== filters.module && !task.moduleKeys?.includes(filters.module)) return false;
   if (filters.engine !== "all" && task.engine !== filters.engine) return false;
-  if (filters.status.length > 0 && !filters.status.includes(task.coordinationStatus))
+  if (filters.status.length > 0 && !filters.status.includes(task.coordinationStatus) && !(task.blocking === "unknown" && filters.status.includes("unknown")))
     return false;
   if (filters.closeout !== "all" && task.closeoutReadiness !== filters.closeout)
     return false;

--- a/packages/gui/src/renderer/model/triadic.ts
+++ b/packages/gui/src/renderer/model/triadic.ts
@@ -9,13 +9,16 @@ export function normalizeTaskId(raw: string): string {
 }
 
 export function spawningDecisionOf(task: TaskRow, relations: RelationEdge[]): string | undefined {
-  const edge = relations.find(
+  const decisionIds = [...new Set(relations.filter(
     (relation) =>
       relation.kind === "derives" &&
+      relation.state === "active" &&
+      relation.direction === "directed" &&
       relation.from.startsWith("decision/") &&
       normalizeTaskId(relation.to) === task.taskId,
-  );
-  if (edge) return normalizeDecisionId(edge.from);
+  ).map((edge) => normalizeDecisionId(edge.from)))];
+  if (decisionIds.length === 1) return decisionIds[0];
+  if (decisionIds.length > 1) return undefined;
   return task.spawningDecision
     ? normalizeDecisionId(task.spawningDecision)
     : undefined;
@@ -27,7 +30,7 @@ export function derivedTasks(
   tasks: TaskRow[],
 ): TaskRow[] {
   const taskIds = relations
-    .filter((relation) => relation.from === `decision/${decision.decisionId}` && relation.kind === "derives")
+    .filter((relation) => relation.from === `decision/${decision.decisionId}` && relation.kind === "derives" && relation.state === "active" && relation.direction === "directed")
     .map((relation) => normalizeTaskId(relation.to));
   return tasks.filter((task) => taskIds.includes(task.taskId));
 }

--- a/packages/gui/src/renderer/model/types.ts
+++ b/packages/gui/src/renderer/model/types.ts
@@ -3,12 +3,10 @@ import type { RelationType } from "../../api/renderer-dto.ts";
 export type CanonicalStatus =
   | "planned"
   | "active"
-  | "blocked"
   | "in_review"
-  | "done"
-  | "cancelled";
+  | "done";
 
-export type SnapshotStatus = CanonicalStatus | "unknown";
+export type SnapshotStatus = CanonicalStatus | "blocked" | "cancelled" | "unknown";
 
 export type Freshness = "fresh" | "stale-but-usable" | "unavailable-no-cache";
 
@@ -22,7 +20,7 @@ export type CloseoutReadiness =
   | "passed"
   | "failed";
 
-export type EngineId = "local" | "multica" | "github" | "linear";
+export type EngineId = string;
 
 export type DocGroup = "必读" | "计划" | "设计" | "进度" | "收口" | "证据";
 
@@ -33,13 +31,25 @@ export interface DocEntry {
   required: boolean;
   /** 文档完成度：true=已存在，false=缺失（required+missing 即收口阻塞项） */
   present: boolean;
+  /** 未完成文档 read 时不能把 absent 当 missing。 */
+  presence?: "present" | "missing" | "unknown";
 }
 
 /** materialization gate / check 结果——任务详情收口区的"原因"维度 */
 export interface GateResult {
   name: string;
-  ok: boolean;
+  ok: boolean | null;
   detail?: string;
+}
+
+export type BlockingState = "blocked" | "clear" | "unknown";
+
+export interface BlockingContributor {
+  relationId: string;
+  kind: "blocks" | "depends-on";
+  sourceTaskId: string;
+  targetTaskId: string;
+  rationale?: string;
 }
 
 export interface TaskRow {
@@ -47,13 +57,30 @@ export interface TaskRow {
   title: string;
   projectId: string;
   coordinationStatus: SnapshotStatus;
+  /** Task/v1 真状态；relation overlay 永不覆写此字段。 */
+  canonicalStatus?: CanonicalStatus;
+  blocking?: BlockingState;
+  blockingLabel?: string;
+  blockers?: BlockingContributor[];
+  blockingWarnings?: string[];
   rawStatus: string;
   freshness: Freshness;
   packageDisposition: PackageDisposition;
   closeoutReadiness: CloseoutReadiness;
   engine: EngineId;
+  origin?: "native" | "archival" | "external";
   source: "local-document" | "external-engine" | "snapshot-cache";
   module: string;
+  moduleKeys?: string[];
+  productLines?: string[];
+  placementWarning?: string;
+  placementProvenance?: ReadonlyArray<{ kind: "l2" | "decision-relation" | "canonical-event"; ref: string }>;
+  packagePath?: string | null;
+  currentNode?: "implementation" | "review";
+  iteration?: 0 | 1;
+  activeExecutionId?: string;
+  leaseExpiresAt?: string;
+  events?: EventEntry[];
   lastKnownAt: string;
   /** closeoutReadiness=ready 的起始时间，用于等待时长统计 */
   waitingSince?: string;
@@ -84,6 +111,7 @@ export interface TaskRow {
 export type RelationKind = RelationType;
 
 export interface RelationEdge {
+  relationId?: string;
   /**
    * from/to 形如 <entity>/<id>[/anchor]，实体 ∈ task|decision|fact。
    * 例：task/task_x、decision/dec_y、fact/task_x/F-a3f2、decision/dec_y/C1（锚到 claim）。
@@ -92,6 +120,8 @@ export interface RelationEdge {
   from: string;
   to: string;
   kind: RelationKind;
+  direction?: "directed" | "undirected";
+  state?: "active" | "retired" | "deleted";
   /** ⚠️ 同名陷阱消歧：这是「边的来源」标量；entity 顶层的 provenance 是 session 原文溯源数组（见 DecisionRow/TaskRow），同名不同义 */
   provenance: "local-document" | "external-engine";
   /** 强 relation 的 rationale 必填非空（INV-5）；evidenced-by/derives/supersedes 承重边在此给决策卡证据栏展示 */
@@ -145,6 +175,7 @@ export interface DecisionRow {
   chosen: DecisionClaim[]; // 决定了什么策略
   rejected: DecisionClaim[]; // ⚠️ 必填非空，每条带 evidence + why_not（否决比选择更重要）
   claims: { id: string; text: string }[]; // 承重论点（覆盖度查询的锚点）
+  appliesTo?: { modules: string[]; productLines: string[] };
   /** entity 原文溯源（⚠️ 与 RelationEdge.provenance 同名不同义） */
   provenance?: ReadonlyArray<ProvenanceEntry>;
   lastChangedAt?: string;
@@ -287,7 +318,7 @@ export interface EventEntry {
   summary: string;
 }
 
-export const isExternal = (t: TaskRow) => t.engine !== "local";
+export const isExternal = (t: TaskRow) => t.origin === "external" || (t.origin === undefined && t.engine !== "local");
 export const isTerminal = (s: SnapshotStatus) => s === "done" || s === "cancelled";
 
 export const BOARD_COLUMNS: SnapshotStatus[] = [

--- a/packages/gui/src/renderer/task-actions.ts
+++ b/packages/gui/src/renderer/task-actions.ts
@@ -1,0 +1,101 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useRef, useState } from "react";
+import type { GuiActionResult } from "../api/renderer-dto.ts";
+import type { GuiSubmissionV1 } from "../api/renderer-dto.ts";
+import { harnessClient, type TaskListSuccess } from "./api-client.ts";
+import type { TaskRow } from "./model/types.ts";
+import { taskQueryKeys } from "./task-data.ts";
+
+type ReceiptRecord = GuiActionResult & {
+  readonly revision?: number;
+  readonly code?: string;
+  readonly nextAction?: string;
+  readonly error?: { readonly code?: string; readonly hint?: string };
+  readonly proof?: {
+    readonly committedRevision?: number;
+    readonly appliedCut?: number;
+    readonly durable?: boolean;
+    readonly canonicalVisible?: boolean;
+    readonly worktreeVisible?: boolean | null;
+  };
+};
+
+export interface TaskSettlement {
+  readonly state: "applied" | "pending" | "rejected";
+  readonly opId: string;
+  readonly code?: string;
+  readonly hint?: string;
+  readonly revision?: number;
+  readonly receipt: GuiActionResult;
+}
+
+export async function settleTaskReceipt(
+  initial: GuiActionResult,
+  showReceipt: (payload: { readonly opId: string }) => Promise<GuiActionResult>
+): Promise<TaskSettlement> {
+  let receipt = initial as ReceiptRecord;
+  if ((receipt.outcome === "pending" || receipt.outcome === "indeterminate") && receipt.opId !== "N/A") {
+    receipt = await showReceipt({ opId: receipt.opId }) as ReceiptRecord;
+  }
+  const proof = receipt.proof;
+  if (receipt.outcome === "applied" && proof?.durable === true && proof.canonicalVisible === true
+    && proof.worktreeVisible === true && proof.committedRevision === proof.appliedCut) {
+    return { state: "applied", opId: receipt.opId, ...(Number.isInteger(receipt.revision) ? { revision: receipt.revision } : {}), receipt };
+  }
+  if (receipt.outcome === "pending" || receipt.outcome === "indeterminate" || receipt.outcome === "applied") {
+    return { state: "pending", opId: receipt.opId, code: receipt.outcome === "applied" ? "canonical_not_visible" : receipt.code ?? receipt.outcome,
+      hint: receipt.nextAction ?? "用 opId 查询 canonical receipt；不要重放 mutation。", ...(Number.isInteger(receipt.revision) ? { revision: receipt.revision } : {}), receipt };
+  }
+  return { state: "rejected", opId: receipt.opId, code: receipt.error?.code ?? receipt.code ?? "write_rejected",
+    hint: receipt.error?.hint ?? receipt.nextAction ?? "Inspect the canonical rejection.", receipt };
+}
+
+export function isTaskStartable(task: TaskRow): boolean {
+  return task.origin === "native" && task.packageDisposition === "active" && task.canonicalStatus === "planned" && task.blocking === "clear";
+}
+
+export function createGuiExecutionId(randomUUID: () => string = () => crypto.randomUUID()): string {
+  return `execution-gui-${randomUUID()}`;
+}
+
+export interface TaskMutationFeedback {
+  readonly state: "pending" | "success" | "error";
+  readonly kind: "start" | "progress" | "submit";
+  readonly opId: string;
+  readonly code?: string;
+  readonly hint: string;
+}
+
+export function useTaskActions() {
+  const queryClient = useQueryClient(), locks = useRef(new Map<string, Promise<TaskMutationFeedback>>()), [feedback, setFeedback] = useState<ReadonlyMap<string, TaskMutationFeedback>>(new Map());
+  const publish = (taskId: string, value: TaskMutationFeedback): TaskMutationFeedback => { setFeedback((current) => new Map(current).set(taskId, value)); return value; };
+  const reread = async (taskId: string, kind: TaskMutationFeedback["kind"], settlement: TaskSettlement, visible: (data: TaskListSuccess) => boolean): Promise<TaskMutationFeedback> => {
+    if (settlement.state !== "applied") return publish(taskId, { state: settlement.state === "rejected" ? "error" : "pending", kind, opId: settlement.opId, code: settlement.code, hint: settlement.hint ?? "canonical receipt 尚未 settled；不要重放 mutation。" });
+    const data = await queryClient.fetchQuery({ queryKey: taskQueryKeys.list(), queryFn: () => harnessClient.getTasks(), staleTime: 0 });
+    const revisionVisible = settlement.revision === undefined || data.watermark >= settlement.revision;
+    return revisionVisible && visible(data)
+      ? publish(taskId, { state: "success", kind, opId: settlement.opId, hint: "canonical projection 已重读并确认。" })
+      : publish(taskId, { state: "pending", kind, opId: settlement.opId, code: "projection_not_visible", hint: "receipt 已 applied，但 task projection 尚未显示目标 cut；用 opId 继续查询，勿重放 mutation。" });
+  };
+  const once = (key: string, taskId: string, run: () => Promise<TaskMutationFeedback>): Promise<TaskMutationFeedback> => {
+    const held = locks.current.get(key); if (held) return held;
+    const promise = run().then((result) => { if (result.state !== "pending") locks.current.delete(key); return result; }, (error) => { locks.current.delete(key); return publish(taskId, { state: "error", kind: key.split(":")[0] as TaskMutationFeedback["kind"], opId: "N/A", code: "bridge_error", hint: error instanceof Error ? error.message : String(error) }); });
+    locks.current.set(key, promise); return promise;
+  };
+  const startTask = (task: TaskRow): Promise<TaskMutationFeedback> => once(`start:${task.taskId}`, task.taskId, async () => {
+    const executionId = createGuiExecutionId(); publish(task.taskId, { state: "pending", kind: "start", opId: "awaiting-receipt", hint: `正在申请 lease · ${executionId}` });
+    const settlement = await settleTaskReceipt(await harnessClient.startTask({ taskId: task.taskId, executionId }), harnessClient.showReceipt);
+    return reread(task.taskId, "start", settlement, (data) => data.rows.some((row) => row.taskId === task.taskId && row.snapshot.task?.status === "active" && row.snapshot.lease?.executionId === executionId));
+  });
+  const appendProgress = (task: TaskRow, input: { readonly text: string; readonly evidence: ReadonlyArray<{ readonly type: string; readonly path: string; readonly summary: string }> }): Promise<TaskMutationFeedback> => once(`progress:${task.taskId}`, task.taskId, async () => {
+    publish(task.taskId, { state: "pending", kind: "progress", opId: "awaiting-receipt", hint: "正在追加 typed progress…" });
+    const settlement = await settleTaskReceipt(await harnessClient.appendTaskProgress({ taskId: task.taskId, executionId: task.activeExecutionId, ...input }), harnessClient.showReceipt);
+    return reread(task.taskId, "progress", settlement, (data) => data.rows.some((row) => row.taskId === task.taskId && row.snapshot.task?.status === "active" && row.snapshot.lease?.executionId === task.activeExecutionId));
+  });
+  const submitTask = (task: TaskRow, submission: GuiSubmissionV1): Promise<TaskMutationFeedback> => once(`submit:${task.taskId}`, task.taskId, async () => {
+    publish(task.taskId, { state: "pending", kind: "submit", opId: "awaiting-receipt", hint: "正在原子提交 SubmissionV1…" });
+    const settlement = await settleTaskReceipt(await harnessClient.submitTask({ taskId: task.taskId, executionId: task.activeExecutionId ?? "", submission }), harnessClient.showReceipt);
+    return reread(task.taskId, "submit", settlement, (data) => data.rows.some((row) => row.taskId === task.taskId && row.snapshot.task?.status === "in_review" && row.snapshot.lease === null));
+  });
+  return { feedback, startTask, appendProgress, submitTask };
+}

--- a/packages/gui/src/renderer/task-adapter.ts
+++ b/packages/gui/src/renderer/task-adapter.ts
@@ -1,5 +1,5 @@
 import type { TaskSnapshotProjectionRow } from "../api/renderer-dto.ts";
-import type { Project, TaskRow } from "./model/types.ts";
+import type { BlockingContributor, DecisionRow, GateResult, Project, RelationEdge, TaskRow } from "./model/types.ts";
 
 /**
  * Maps the rebuild L2 task snapshot onto the renderer view model. UI-only
@@ -9,24 +9,104 @@ import type { Project, TaskRow } from "./model/types.ts";
 
 const REAL_PROJECT_ID = "harness-anything";
 
-function adaptProjectionRow(row: TaskSnapshotProjectionRow, projectionStatus: "ready" | "pending"): TaskRow {
+export interface TaskAdaptContext {
+  readonly relationState?: "ready" | "loading" | "error";
+  readonly relations?: ReadonlyArray<RelationEdge>;
+  readonly decisions?: ReadonlyArray<DecisionRow>;
+  readonly relationWarnings?: ReadonlyArray<{ readonly severity?: string; readonly code?: string; readonly message?: string }>;
+}
+
+function adaptProjectionRow(row: TaskSnapshotProjectionRow, projectionStatus: "ready" | "pending", context: TaskAdaptContext): TaskRow {
   const task = row.snapshot.task!;
+  const placement = placementFor(row, context);
+  const gates = gateResults(row);
   return {
     taskId: row.taskId,
     title: task.title,
     projectId: REAL_PROJECT_ID,
     coordinationStatus: task.status,
+    canonicalStatus: task.status,
+    blocking: "clear",
+    blockingLabel: "当前投影无 active blocking relation",
+    blockers: [],
+    blockingWarnings: [],
     rawStatus: `${task.status}/${task.currentNode}`,
     freshness: projectionStatus === "ready" ? "fresh" : "stale-but-usable",
-    packageDisposition: "active",
-    closeoutReadiness: task.status === "done" ? "passed" : task.status === "in_review" ? "ready" : "not_required",
-    engine: "local",
-    source: "snapshot-cache",
-    module: "unassigned",
+    packageDisposition: row.placement.packageDisposition,
+    closeoutReadiness: closeoutReadiness(row, gates),
+    engine: row.placement.engine,
+    origin: row.placement.origin,
+    source: row.placement.origin === "external" ? "external-engine" : row.placement.origin === "archival" ? "snapshot-cache" : "local-document",
+    module: placement.moduleKeys.length === 0 ? "unassigned" : placement.moduleKeys.length === 1 ? placement.moduleKeys[0]! : `multiple (${placement.moduleKeys.join(", ")})`,
+    moduleKeys: placement.moduleKeys,
+    productLines: placement.productLines,
+    ...(placement.warning ? { placementWarning: placement.warning } : {}),
+    placementProvenance: row.placement.provenance,
+    packagePath: row.packagePath,
+    parentTaskId: row.placement.parentTaskId ?? undefined,
+    ...(placement.spawningDecision ? { spawningDecision: placement.spawningDecision } : {}),
+    currentNode: task.currentNode,
+    iteration: task.iteration,
+    ...(row.snapshot.lease ? { activeExecutionId: row.snapshot.lease.executionId, leaseExpiresAt: row.snapshot.lease.expiresAt } : {}),
     lastKnownAt: row.updatedAt,
-    gates: [],
-    docs: []
+    gates,
+    docs: [],
+    events: lifecycleEvents(row)
   };
+}
+
+function placementFor(row: TaskSnapshotProjectionRow, context: TaskAdaptContext): { moduleKeys: string[]; productLines: string[]; spawningDecision?: string; warning?: string } {
+  if ((context.relationState !== undefined && context.relationState !== "ready") || (context.relationWarnings ?? []).some((warning) => warning.severity === "hard-fail")) {
+    return { moduleKeys: [], productLines: [], warning: "relation projection 未就绪，无法判定 derived placement" };
+  }
+  const relations = context.relations ?? [], decisionById = new Map((context.decisions ?? []).map((decision) => [decision.decisionId, decision]));
+  const derives = relations.filter((edge) => edge.kind === "derives" && edge.state === "active" && edge.direction === "directed" && edge.to === `task/${row.taskId}` && edge.from.startsWith("decision/"));
+  if (derives.length === 0) return { moduleKeys: [...row.placement.moduleKeys], productLines: [...row.placement.productLines] };
+  const ids = [...new Set(derives.map((edge) => edge.from.split("/")[1]).filter((id): id is string => Boolean(id)))], scopes = ids.map((id) => decisionById.get(id)?.appliesTo);
+  if (scopes.some((scope) => scope === undefined)) return { moduleKeys: [], productLines: [], warning: "派生决策 scope 未完整投影" };
+  return {
+    moduleKeys: [...new Set(scopes.flatMap((scope) => scope!.modules))].sort(),
+    productLines: [...new Set(scopes.flatMap((scope) => scope!.productLines))].sort(),
+    ...(ids.length === 1 ? { spawningDecision: ids[0] } : { warning: "存在多个 spawning decision，placement 已合并但来源不唯一" })
+  };
+}
+
+function gateResults(row: TaskSnapshotProjectionRow): GateResult[] {
+  const { snapshot, snapshotAvailability } = row, task = snapshot.task!, execution = snapshot.executions.find((item) => item.iteration === task.iteration && item.submission !== null), commitSha = execution?.submission?.commitSha;
+  return task.completionGateIds.map((name) => {
+    const codeDoc = name === "code-doc-reconciliation", availability = codeDoc ? snapshotAvailability.codeDocWitnesses : snapshotAvailability.gateWitnesses;
+    if (availability === "unknown") return { name, ok: null, detail: "witness projection unknown" };
+    const found = codeDoc
+      ? snapshot.codeDocWitnesses.some((item) => item.executionId === execution?.executionId && item.commitSha === commitSha && item.iteration === task.iteration)
+      : snapshot.gateWitnesses.some((item) => item.gateId === name && item.executionId === execution?.executionId && item.commitSha === commitSha && item.iteration === task.iteration && item.result === "pass");
+    return { name, ok: found, ...(!found ? { detail: execution ? "当前 execution cut 未见 witness" : "尚无 submitted execution" } : {}) };
+  });
+}
+
+function closeoutReadiness(row: TaskSnapshotProjectionRow, gates: ReadonlyArray<GateResult>): TaskRow["closeoutReadiness"] {
+  const { snapshot, snapshotAvailability } = row, task = snapshot.task!;
+  if (task.status === "done") return "passed";
+  if (task.status !== "in_review") return "not_required";
+  const execution = snapshot.executions.find((item) => item.iteration === task.iteration && item.state === "submitted" && item.submission !== null);
+  if (!execution) return "missing";
+  if (Object.values(snapshotAvailability).includes("unknown") || gates.some((gate) => gate.ok === null)) return "incomplete";
+  const review = snapshot.reviews.find((item) => item.executionId === execution.executionId && item.verdict === "approved"), consent = review && snapshot.consents.find((item) => item.executionId === execution.executionId && item.reviewId === review.reviewId && item.contentDigest === review.contentDigest);
+  return review && consent && gates.every((gate) => gate.ok === true) ? "ready" : "incomplete";
+}
+
+function lifecycleEvents(row: TaskSnapshotProjectionRow): TaskRow["events"] {
+  const projectId = REAL_PROJECT_ID, taskId = row.taskId, events = [
+    ...row.snapshot.executions.flatMap((execution) => [
+      { at: execution.claimedAt, projectId, taskId, summary: `Execution ${execution.executionId} started` },
+      ...(execution.submittedAt ? [{ at: execution.submittedAt, projectId, taskId, summary: `Execution ${execution.executionId} submitted` }] : []),
+      ...(execution.closedAt ? [{ at: execution.closedAt, projectId, taskId, summary: `Execution ${execution.executionId} closed (${execution.state})` }] : [])
+    ]),
+    ...row.snapshot.reviews.map((review) => ({ at: review.reviewedAt, projectId, taskId, summary: `Review ${review.reviewId}: ${review.verdict}` })),
+    ...row.snapshot.consents.map((consent) => ({ at: consent.consentedAt, projectId, taskId, summary: `Consent ${consent.consentId} recorded` })),
+    ...row.snapshot.codeDocWitnesses.map((witness) => ({ at: witness.reconciledAt, projectId, taskId, summary: `Code/doc witness ${witness.witnessId}` })),
+    ...row.snapshot.gateWitnesses.map((witness) => ({ at: witness.verifiedAt, projectId, taskId, summary: `Gate ${witness.gateId}: ${witness.result}` }))
+  ];
+  return events.sort((left, right) => right.at.localeCompare(left.at));
 }
 
 /**
@@ -53,8 +133,8 @@ export function computeRootTaskId(
  * 在 adaptProjectionRow 之上补齐 rootTaskId / rootTitle。两阶段:先建 parentById
  * 查找表,再按表给每个 row 标根与根标题。
  */
-export function adaptProjectionRows(rows: ReadonlyArray<TaskSnapshotProjectionRow>, projectionStatus: "ready" | "pending" = "ready"): TaskRow[] {
-  const base = rows.map((row) => adaptProjectionRow(row, projectionStatus));
+export function adaptProjectionRows(rows: ReadonlyArray<TaskSnapshotProjectionRow>, projectionStatus: "ready" | "pending" = "ready", context: TaskAdaptContext = {}): TaskRow[] {
+  const base = deriveBlocking(rows.map((row) => adaptProjectionRow(row, projectionStatus, context)), context);
   const parentById = new Map<string, string | undefined>();
   const titleById = new Map<string, string>();
   for (const task of base) {
@@ -66,6 +146,41 @@ export function adaptProjectionRows(rows: ReadonlyArray<TaskSnapshotProjectionRo
     const rootTitle = titleById.get(rootTaskId) ?? task.title;
     return { ...task, rootTaskId, rootTitle };
   });
+}
+
+export function deriveBlocking(tasks: ReadonlyArray<TaskRow>, context: TaskAdaptContext): TaskRow[] {
+  const taskById = new Map(tasks.map((task) => [task.taskId, task])), blockers = new Map<string, BlockingContributor[]>(), unknown = new Map<string, string[]>(), cycleNodes = new Set<string>();
+  const globalUnknown = context.relationState !== undefined && context.relationState !== "ready" || (context.relationWarnings ?? []).some((warning) => warning.severity === "hard-fail");
+  if (globalUnknown) for (const task of tasks) add(unknown, task.taskId, context.relationState === "error" ? "relation query failed" : context.relationState === "loading" ? "relation query loading" : "relation projection hard-fail warning");
+  const graph = new Map<string, string[]>();
+  for (const edge of context.relations ?? []) {
+    if (edge.kind !== "blocks" && edge.kind !== "depends-on") continue;
+    const sourceId = exactTaskId(edge.from), targetId = exactTaskId(edge.to), knownIds = [sourceId, targetId].filter((id): id is string => Boolean(id && taskById.has(id)));
+    if (edge.state === "retired" || edge.state === "deleted") continue;
+    if (edge.state !== "active" || edge.direction !== "directed" || !sourceId || !targetId || !taskById.has(sourceId) || !taskById.has(targetId)) {
+      const message = !sourceId || !targetId ? `invalid blocking endpoint: ${edge.from} → ${edge.to}` : !taskById.has(sourceId) || !taskById.has(targetId) ? `blocking endpoint missing from task snapshot: ${!taskById.has(sourceId) ? sourceId : targetId}` : `blocking relation ${edge.relationId ?? "unknown"} is not active directed`;
+      for (const id of knownIds.length ? knownIds : tasks.map((task) => task.taskId)) add(unknown, id, message);
+      continue;
+    }
+    add(graph, sourceId, targetId);
+    const blockedId = edge.kind === "blocks" ? targetId : taskById.get(targetId)?.canonicalStatus === "done" ? null : sourceId;
+    if (blockedId) add(blockers, blockedId, { relationId: edge.relationId ?? "unknown", kind: edge.kind, sourceTaskId: sourceId, targetTaskId: targetId, ...(edge.rationale ? { rationale: edge.rationale } : {}) });
+  }
+  findCycleNodes(graph).forEach((id) => cycleNodes.add(id));
+  for (const id of cycleNodes) add(unknown, id, "active blocking relation cycle detected; cycle nodes remain blocked");
+  return tasks.map((task) => {
+    const taskBlockers = blockers.get(task.taskId) ?? [], warnings = unknown.get(task.taskId) ?? [], blocking = taskBlockers.length || cycleNodes.has(task.taskId) ? "blocked" : warnings.length ? "unknown" : "clear";
+    const coordinationStatus = blocking === "blocked" && (task.canonicalStatus === "planned" || task.canonicalStatus === "active") ? "blocked" : task.canonicalStatus ?? task.coordinationStatus;
+    return { ...task, coordinationStatus, blocking, blockingLabel: blocking === "blocked" ? `${taskBlockers.length || "cycle"} 个 active blocking relation` : blocking === "unknown" ? "阻塞关系未能确定" : "当前投影无 active blocking relation", blockers: taskBlockers, blockingWarnings: [...new Set(warnings)] };
+  });
+}
+
+function exactTaskId(ref: string): string | null { const match = /^task\/([^/]+)$/u.exec(ref); return match?.[1] ?? null; }
+function add<K, V>(map: Map<K, V[]>, key: K, value: V): void { map.set(key, [...map.get(key) ?? [], value]); }
+function findCycleNodes(graph: ReadonlyMap<string, ReadonlyArray<string>>): Set<string> {
+  const cycle = new Set<string>(), visited = new Set<string>(), stack: string[] = [], active = new Set<string>();
+  const visit = (id: string): void => { if (active.has(id)) { stack.slice(stack.indexOf(id)).forEach((node) => cycle.add(node)); return; } if (visited.has(id)) return; visited.add(id); active.add(id); stack.push(id); for (const next of graph.get(id) ?? []) visit(next); stack.pop(); active.delete(id); };
+  for (const id of graph.keys()) visit(id); return cycle;
 }
 
 export function buildRealProject(tasks: ReadonlyArray<TaskRow>): Project {

--- a/packages/gui/src/renderer/task-data.ts
+++ b/packages/gui/src/renderer/task-data.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { harnessClient } from "./api-client.ts";
+import type { DocEntry, DocGroup } from "./model/types.ts";
 
 export const taskQueryKeys = {
   all: ["harness", "tasks"] as const,
@@ -17,3 +18,18 @@ export function useTasksQuery() {
 export function taskDocumentQuery(taskId: string, path: string) { return { queryKey: taskQueryKeys.document(taskId, path), queryFn: () => harnessClient.getTaskDocument({ taskId, path }), staleTime: 10_000 }; }
 
 export function useTaskDocumentQuery(taskId: string, path: string | null) { return useQuery({ ...taskDocumentQuery(taskId, path ?? ""), enabled: path !== null }); }
+
+export function parseTaskContractDocuments(taskId: string, body: string): DocEntry[] {
+  let value: unknown; try { value = JSON.parse(body); } catch { throw new Error("task-contract projection is not valid JSON"); }
+  if (!record(value) || value.schema !== "task-contract/v1" || value.taskId !== taskId || !Array.isArray(value.documents)) throw new Error("task-contract projection does not match this task");
+  return value.documents.map((item, index) => {
+    if (!record(item) || typeof item.slot !== "string" || typeof item.path !== "string" || !item.path || item.path.startsWith("/") || item.path.split("/").includes("..")) throw new Error(`task-contract document ${index} is invalid`);
+    return { path: item.path, title: item.path.split("/").at(-1) ?? item.path, group: groupForSlot(item.slot), required: !item.path.endsWith("/.gitkeep") && item.path !== ".gitkeep", present: false, presence: "unknown" as const };
+  });
+}
+
+function groupForSlot(slot: string): DocGroup {
+  if (slot.includes("plan")) return "计划"; if (slot.includes("design")) return "设计"; if (slot.includes("artifact") || slot.includes("evidence")) return "证据";
+  if (slot.includes("progress") || slot.endsWith(".facts")) return "进度"; if (slot.includes("closeout")) return "收口"; return "必读";
+}
+function record(value: unknown): value is Record<string, unknown> { return value !== null && typeof value === "object" && !Array.isArray(value); }

--- a/packages/gui/src/renderer/triadic-data.ts
+++ b/packages/gui/src/renderer/triadic-data.ts
@@ -39,6 +39,8 @@ export function useTriadicProjectionQuery() {
   return {
     isLoading,
     isError,
+    relationState: graph.isError ? "error" as const : graph.isLoading ? "loading" as const : "ready" as const,
+    relationWarnings: graph.data?.warnings ?? [],
     ...rendererData
   };
 }
@@ -91,9 +93,12 @@ function adaptRelationRows(rows: ReadonlyArray<RelationGraphEdgeRow>): RelationE
   for (const row of rows) {
     if (!isKernelRelationKind(row.relationType)) continue;
     edges.push({
+      relationId: row.relationId,
       from: row.sourceRef,
       to: row.targetRef,
       kind: row.relationType,
+      direction: row.direction,
+      state: row.state,
       provenance: row.origin === "imported_snapshot" ? "external-engine" : "local-document",
       rationale: row.rationale
     });
@@ -146,6 +151,7 @@ function adaptDecisionRows(
       chosen,
       rejected,
       claims: row.claims.map((claim) => ({ id: claim.id, text: claim.text })),
+      appliesTo: { modules: [...row.appliesTo.modules], productLines: [...row.appliesTo.productLines] },
       lastChangedAt: row.decidedAt ?? row.proposedAt
     };
   });

--- a/packages/gui/src/renderer/views/BoardView.tsx
+++ b/packages/gui/src/renderer/views/BoardView.tsx
@@ -12,7 +12,7 @@ import {
 } from "@dnd-kit/core";
 import { Lock, Archive, Star } from "@phosphor-icons/react";
 import type { TaskRow, SnapshotStatus, RelationEdge } from "../model/types";
-import { BOARD_COLUMNS, isExternal, isTerminal } from "../model/types";
+import { BOARD_COLUMNS, isExternal } from "../model/types";
 import {
   STATUS_META,
   CloseoutBadge,
@@ -27,12 +27,22 @@ import type { TaskFilters } from "../model/taskFilters";
 import { sortByFavoritesFirst } from "../model/taskFilters";
 import { spawningDecisionOf } from "../model/triadic";
 import { ListView } from "./ListView";
+import { isTaskStartable, type TaskMutationFeedback } from "../task-actions.ts";
 
 const ENGINE_HINT: Record<string, string> = {
   multica: "由 Multica 管理，去 Multica 改状态",
   github: "由 GitHub Issues 管理，去 GitHub 改状态",
   linear: "由 Linear 管理，去 Linear 改状态",
 };
+
+function taskControlHint(task: TaskRow): string {
+  if (isExternal(task)) return ENGINE_HINT[task.engine] ?? `由外部引擎 ${task.engine} 管理，GUI 只读`;
+  if (task.packageDisposition !== "active") return `${task.packageDisposition} package 只读`;
+  if (task.blocking === "blocked") return "Blocked 是 relation overlay，不可拖；关系在 canonical 来源处理";
+  if (task.canonicalStatus === "in_review") return "已进入 review；只能查看 canonical settlement";
+  if (task.canonicalStatus === "done") return "任务已完成，状态只读";
+  return task.canonicalStatus === "planned" ? "可拖到 Active 申请 execution lease" : "Active 状态请在详情追加 progress 或 request review";
+}
 
 function Card({
   task,
@@ -55,7 +65,7 @@ function Card({
   return (
     <div
       onClick={() => onSelect?.(task.taskId)}
-      title={external ? ENGINE_HINT[task.engine] : undefined}
+      title={taskControlHint(task)}
       className={`group relative cursor-pointer rounded-lg bg-surface-raised p-2.5 ${freshnessBorder(
         task.freshness,
       )} ${archived ? "opacity-50" : ""} ${dragging ? "shadow-lg" : "hover:border-border-strong"} ${isFavorite ? "ring-1 ring-accent/40" : ""}`}
@@ -88,6 +98,8 @@ function Card({
       </div>
       <p className="mt-1.5 text-[15px] leading-snug text-text">{task.title}</p>
       <div className="mt-2 flex flex-wrap items-center gap-1.5">
+        {task.coordinationStatus === "blocked" && task.canonicalStatus && <span className="rounded border border-status-blocked/30 px-1 font-mono text-[10px] text-status-blocked">canonical {task.canonicalStatus}</span>}
+        {task.blocking === "unknown" && <span className="rounded border border-stale/30 px-1 text-[10px] text-stale">阻塞关系未能确定</span>}
         {spawningDecision && <DecisionSourceBadge decisionId={spawningDecision} compact />}
         <CloseoutBadge value={task.closeoutReadiness} />
         <FreshnessTag freshness={task.freshness} lastKnownAt={task.lastKnownAt} />
@@ -109,8 +121,7 @@ function DraggableCard({
   isFavorite: boolean;
   onToggleFavorite: (id: string) => void;
 }) {
-  // external 任务允许拿起、落下被拒，让护栏可感知；终态完全锁定
-  const draggable = !isTerminal(task.coordinationStatus);
+  const draggable = isTaskStartable(task);
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: task.taskId,
     disabled: !draggable,
@@ -213,6 +224,8 @@ export function BoardView({
   onToggleFavorite,
   initialLayout,
   initialGroupBy,
+  onStartTask,
+  mutationFeedback,
 }: {
   tasks: TaskRow[];
   allTasks: TaskRow[];
@@ -225,6 +238,8 @@ export function BoardView({
   onToggleFavorite: (id: string) => void;
   initialLayout?: BoardLayout;
   initialGroupBy?: LaneGroupBy;
+  onStartTask?: (task: TaskRow) => Promise<unknown>;
+  mutationFeedback?: (taskId: string) => TaskMutationFeedback | undefined;
 }) {
   // coding preset 默认按 root 分组(milestone=root task)。drill 携带 groupBy 提示。
   const [layout, setLayout] = useState<BoardLayout>(
@@ -245,12 +260,18 @@ export function BoardView({
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
   );
   const [activeTask, setActiveTask] = useState<TaskRow | null>(null);
+  const [dragMessage, setDragMessage] = useState<string | null>(null);
+  const [lastMutationTaskId, setLastMutationTaskId] = useState<string | null>(null);
 
   const onDragStart = (e: DragStartEvent) =>
     setActiveTask(tasks.find((t) => t.taskId === e.active.id) ?? null);
 
-  const onDragEnd = (_event: DragEndEvent) => {
+  const onDragEnd = (event: DragEndEvent) => {
+    const task = activeTask;
     setActiveTask(null);
+    if (!task) return;
+    if (event.over?.id !== "active") { setDragMessage("唯一允许的 transition 是 planned → active；Blocked 不是状态机节点。"); return; }
+    setDragMessage(null); setLastMutationTaskId(task.taskId); void onStartTask?.(task);
   };
 
   const seg = (active: boolean) =>
@@ -290,7 +311,7 @@ export function BoardView({
         </div>
         <span className="text-[12px] text-text-faint">
           {layout === "column"
-            ? "coordinationStatus 轴 · local 任务可拖拽"
+            ? "仅 native planned + blocking clear 可拖到 Active"
             : layout === "list"
               ? "审计面 · 支持 ID 复制与批量操作"
               : "拖拽改状态请在列模式 · 外部任务任何模式都只读"}
@@ -321,6 +342,9 @@ export function BoardView({
           </div>
         )}
       </header>
+      {(dragMessage || (lastMutationTaskId && mutationFeedback?.(lastMutationTaskId))) && <div className="border-b border-border px-4 py-2 text-[12px] text-text-muted" data-testid="board-mutation-feedback">
+        {dragMessage ?? (() => { const item = mutationFeedback?.(lastMutationTaskId!); return item ? `${item.kind} · ${item.state} · opId=${item.opId}${item.code ? ` · code=${item.code}` : ""} · ${item.hint}` : ""; })()}
+      </div>}
       <TaskFilterBar
         tasks={allTasks}
         filteredCount={tasks.length}

--- a/packages/gui/src/renderer/views/ListView.tsx
+++ b/packages/gui/src/renderer/views/ListView.tsx
@@ -85,6 +85,8 @@ function AuditRow({
         <div className="mt-1 flex flex-wrap items-center gap-2 font-mono text-[12px] text-text-faint">
           <span>{task.module === "unassigned" || !task.module ? "未投影" : task.module}</span>
           <span>{task.rawStatus}</span>
+          {task.coordinationStatus === "blocked" && task.canonicalStatus && <span>canonical={task.canonicalStatus}</span>}
+          {task.blocking === "unknown" && <span className="text-stale">阻塞关系未能确定</span>}
           {spawningDecision && <DecisionSourceBadge decisionId={spawningDecision} compact />}
           {isExternal(task) && (
             <span className="inline-flex items-center gap-1">

--- a/packages/gui/src/renderer/views/SwimlaneBoard.tsx
+++ b/packages/gui/src/renderer/views/SwimlaneBoard.tsx
@@ -88,6 +88,8 @@ function LaneCard({
         {task.title}
       </p>
       <div className="mt-auto flex flex-wrap items-center gap-1.5 pt-3">
+        {task.coordinationStatus === "blocked" && task.canonicalStatus && <span className="font-mono text-[10px] text-status-blocked">canonical {task.canonicalStatus}</span>}
+        {task.blocking === "unknown" && <span className="text-[10px] text-stale">阻塞关系未能确定</span>}
         {spawningDecision && <DecisionSourceBadge decisionId={spawningDecision} compact />}
         <CloseoutBadge value={task.closeoutReadiness} />
         <FreshnessTag freshness={task.freshness} lastKnownAt={task.lastKnownAt} />

--- a/packages/gui/src/renderer/views/TaskDetailView.tsx
+++ b/packages/gui/src/renderer/views/TaskDetailView.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
+import { useQueries } from "@tanstack/react-query";
 import {
   ArrowLeft,
   CaretRight,
   FileText,
   CheckCircle,
   XCircle,
+  Question,
 } from "@phosphor-icons/react";
 import type {
   DecisionRow,
@@ -20,12 +22,15 @@ import {
   FreshnessTag,
 } from "../components/badges";
 import { DocReader } from "../components/DocReader";
-import { useTaskDocumentQuery } from "../task-data";
+import { parseTaskContractDocuments, taskDocumentQuery, useTaskDocumentQuery } from "../task-data";
 import { OUT_LABEL, IN_LABEL } from "../components/taskDetail/constants";
 import { AxisRow, DocPresence } from "../components/taskDetail/widgets";
 import { PhaseSteps } from "../components/taskDetail/PhaseSteps";
 import { RelationRow } from "../components/taskDetail/RelationRow";
 import { normalizeTaskId, spawningDecisionOf } from "../model/triadic";
+import { TaskControlPanel } from "../components/TaskControlPanel.tsx";
+import type { GuiSubmissionV1 } from "../../api/renderer-dto.ts";
+import type { TaskMutationFeedback } from "../task-actions.ts";
 
 function DocBody({
   taskId,
@@ -53,7 +58,7 @@ function DocBody({
     );
   }
   if (document.isError) return <p className="text-[13px] text-status-blocked">文档投影读取失败：{document.error.message}</p>;
-  return <><span data-testid="task-document-status" className="mb-3 block font-mono text-[11px] text-text-faint">L2 · {document.data.status}</span>{document.data.status === "ready" ? <DocReader content={document.data.body} /> : <p className="text-[13px] text-text-muted">canonical document projection 尚未追平</p>}</>;
+  return <><span data-testid="task-document-status" className="mb-3 block font-mono text-[11px] text-text-faint">L2 · {document.data.status}</span>{document.data.status !== "ready" ? <p className="text-[13px] text-text-muted">canonical document projection 尚未追平</p> : document.data.blobSha256 === null ? <p className="text-[13px] text-stale">canonical document 未投影</p> : <DocReader content={document.data.body} />}</>;
 }
 
 export function TaskDetailView({
@@ -67,6 +72,9 @@ export function TaskDetailView({
   fromViewLabel = "工作区",
   onNavigateDecision,
   onNavigateEntity,
+  mutationFeedback,
+  onProgress,
+  onSubmit,
 }: {
   task: TaskRow;
   onBack: () => void;
@@ -80,9 +88,24 @@ export function TaskDetailView({
   onNavigateDecision?: (decisionId: string) => void;
   /** W2B 活链接:RelationRow 跨实体(decision/fact peer)跳转 */
   onNavigateEntity?: (ref: string) => void;
+  mutationFeedback?: TaskMutationFeedback;
+  onProgress?: (input: { text: string; evidence: ReadonlyArray<{ type: string; path: string; summary: string }> }) => Promise<unknown>;
+  onSubmit?: (submission: GuiSubmissionV1) => Promise<unknown>;
 }) {
   const external = isExternal(task);
-  const realDocs = task.docs.length ? task.docs : [{ path: "INDEX.md", title: "INDEX", group: "必读" as const, required: true, present: true }];
+  const canonicalPackage = typeof task.packagePath === "string", contract = useTaskDocumentQuery(task.taskId, canonicalPackage ? "task-contract.json" : null);
+  const contractModel = useMemo(() => {
+    if (!canonicalPackage) return { docs: task.packagePath === undefined ? task.docs : [], issue: null as string | null };
+    if (contract.isError) return { docs: [], issue: contract.error.message };
+    if (!contract.data || contract.data.status !== "ready") return { docs: [], issue: null };
+    try { return { docs: parseTaskContractDocuments(task.taskId, contract.data.body), issue: null }; }
+    catch (error) { return { docs: [], issue: error instanceof Error ? error.message : String(error) }; }
+  }, [canonicalPackage, contract.data, contract.error, contract.isError, task.docs, task.packagePath, task.taskId]);
+  const documentReads = useQueries({ queries: contractModel.docs.map((entry) => ({ ...taskDocumentQuery(task.taskId, entry.path) })) });
+  const realDocs = useMemo(() => contractModel.docs.map((entry, index) => { const read = documentReads[index];
+    if (!read || read.isPending || read.isError || !read.data || read.data.status !== "ready") return { ...entry, present: false, presence: "unknown" as const };
+    return { ...entry, present: read.data.blobSha256 !== null, presence: read.data.blobSha256 !== null ? "present" as const : "missing" as const };
+  }), [contractModel.docs, documentReads]);
   // 文档清单只看必读/计划/设计/进度/收口/证据 6 组;其他归入进度(滚动日志)。
   const docGroups = useMemo(
     () => DOC_GROUPS.filter((g) => realDocs.some((d) => d.group === g)),
@@ -149,7 +172,7 @@ export function TaskDetailView({
         <nav className="w-56 shrink-0 overflow-y-auto border-r border-border bg-surface p-3">
           {docGroups.length === 0 ? (
             <div className="rounded-md border border-dashed border-border px-2 py-3 text-[12px] text-text-faint">
-              投影未返回文档清单
+              {contractModel.issue ? `task-contract 读取失败：${contractModel.issue}` : canonicalPackage && contract.isPending ? "读取 canonical task-contract…" : "投影未返回文档清单"}
             </div>
           ) : (
             docGroups.map((g) => {
@@ -182,7 +205,7 @@ export function TaskDetailView({
                           必需
                         </span>
                       )}
-                      {!d.present && d.required && (
+                      {d.presence === "missing" && d.required && (
                         <span
                           className="shrink-0 text-[10px]"
                           style={{ color: "var(--color-danger)" }}
@@ -234,7 +257,7 @@ export function TaskDetailView({
             <AxisRow label="coordinationStatus">
               <StatusBadge status={task.coordinationStatus} />
               <span className="w-full font-mono text-[11px] text-text-faint">
-                原文: {task.rawStatus}
+                canonical: {task.canonicalStatus ?? "unknown"} · 原文: {task.rawStatus}
               </span>
               <FreshnessTag freshness={task.freshness} lastKnownAt={task.lastKnownAt} />
             </AxisRow>
@@ -249,12 +272,23 @@ export function TaskDetailView({
               </span>
             </AxisRow>
 
+            <AxisRow label="placement">
+              <span className="w-full font-mono text-[11px] text-text-muted">modules: {task.moduleKeys?.join(", ") || "未投影"}</span>
+              <span className="w-full font-mono text-[11px] text-text-muted">productLines: {task.productLines?.join(", ") || "未投影"}</span>
+              <span className="w-full font-mono text-[11px] text-text-muted">parent/root: {task.parentTaskId ?? "root"} / {task.rootTaskId ?? task.taskId}</span>
+              <span className="w-full font-mono text-[11px] text-text-muted">origin/engine: {task.origin ?? "unknown"} / {task.engine}</span>
+              {task.placementWarning && <span className="w-full text-[11px] text-stale">{task.placementWarning}</span>}
+              {task.placementProvenance?.map((entry) => <span key={`${entry.kind}:${entry.ref}`} className="w-full truncate font-mono text-[10px] text-text-faint">{entry.kind}: {entry.ref}</span>)}
+            </AxisRow>
+
             <div className="flex flex-col gap-1.5">
               <span className="font-mono text-[10px] uppercase tracking-wide text-text-faint">
                 阶段
               </span>
-              <PhaseSteps status={task.coordinationStatus} />
+              <PhaseSteps status={task.canonicalStatus ?? "unknown"} />
             </div>
+
+            <TaskControlPanel task={task} feedback={mutationFeedback} onProgress={onProgress} onSubmit={onSubmit} />
 
             {spawningDecision && (
               <div className="flex flex-col gap-1.5 rounded-md border border-accent/20 bg-accent/5 px-2.5 py-2">
@@ -285,22 +319,22 @@ export function TaskDetailView({
               ) : (
                 task.gates.map((g) => (
                   <div key={g.name} className="flex items-center gap-1.5 text-[11px]">
-                    {g.ok ? (
+                    {g.ok === true ? (
                       <CheckCircle
                         weight="bold"
                         className="shrink-0 text-[12px]"
                         style={{ color: "var(--color-status-done)" }}
                       />
-                    ) : (
+                    ) : g.ok === false ? (
                       <XCircle
                         weight="bold"
                         className="shrink-0 text-[12px]"
                         style={{ color: "var(--color-danger)" }}
                       />
-                    )}
+                    ) : <Question weight="bold" className="shrink-0 text-[12px] text-stale" />}
                     <span className="shrink-0 font-mono text-text-muted">{g.name}</span>
                     {g.detail && (
-                      <span className="min-w-0 truncate text-danger">{g.detail}</span>
+                      <span className={`min-w-0 truncate ${g.ok === null ? "text-stale" : "text-danger"}`}>{g.detail}</span>
                     )}
                   </div>
                 ))
@@ -311,6 +345,7 @@ export function TaskDetailView({
               <span className="font-mono text-[10px] uppercase tracking-wide text-text-faint">
                 关系
               </span>
+              <span className="text-[10px] text-text-faint">只读 · 请在 canonical relation 来源处理</span>
               {outEdges.length === 0 && inEdges.length === 0 ? (
                 <span className="text-[11px] text-text-faint">无关联任务</span>
               ) : (

--- a/packages/gui/test/fact-triage.vitest.ts
+++ b/packages/gui/test/fact-triage.vitest.ts
@@ -89,6 +89,8 @@ function edge(
     from,
     to,
     kind,
+    direction: "directed",
+    state: "active",
     provenance: "local-document",
     ...extra,
   };

--- a/packages/gui/test/renderer-app-model.vitest.ts
+++ b/packages/gui/test/renderer-app-model.vitest.ts
@@ -15,7 +15,8 @@ import { rendererCapabilityModel, rendererNavigation } from "../src/renderer/app
 import { GraphView } from "../src/renderer/views/GraphView.tsx";
 import { DecisionPoolView } from "../src/renderer/views/DecisionPoolView.tsx";
 import { TaskDetailView } from "../src/renderer/views/TaskDetailView.tsx";
-import { taskDocumentQuery } from "../src/renderer/task-data.ts";
+import { parseTaskContractDocuments, taskDocumentQuery } from "../src/renderer/task-data.ts";
+import { isTaskStartable, settleTaskReceipt } from "../src/renderer/task-actions.ts";
 
 describe("renderer app model", () => {
   it("keeps the renderer capability model privilege-free", () => {
@@ -143,6 +144,39 @@ describe("renderer app model", () => {
     });
   });
 
+  it("settles task writes only from durable canonical receipts and resolves pending by opId", async () => {
+    const showReceipt = vi.fn(async () => receipt({ outcome: "applied", opId: "op-pending" }));
+    const settled = await settleTaskReceipt(receipt({ outcome: "pending", opId: "op-pending", proof: {
+      committedRevision: 8, appliedCut: 7, durable: true, canonicalVisible: false, worktreeVisible: true
+    }, nextAction: "ha receipt show op-pending" }), showReceipt);
+
+    expect(showReceipt).toHaveBeenCalledOnce();
+    expect(showReceipt).toHaveBeenCalledWith({ opId: "op-pending" });
+    expect(settled).toMatchObject({ state: "applied", opId: "op-pending" });
+    expect(await settleTaskReceipt(receipt({ proof: {
+      committedRevision: 8, appliedCut: 8, durable: true, canonicalVisible: false, worktreeVisible: true
+    } }), showReceipt)).toMatchObject({ state: "pending", code: "canonical_not_visible" });
+  });
+
+  it("preserves raw rejection code, hint, and opId", async () => {
+    const settled = await settleTaskReceipt({
+      schema: "command-receipt/v2", ok: false, command: "task-submit", outcome: "rejected", opId: "op-rejected",
+      code: "invalid_submission", origin: "daemon", evidence: "rejection:invalid_submission", nextAction: "Fix the packet.",
+      error: { code: "invalid_submission", hint: "Completion claim is required." }
+    }, vi.fn());
+    expect(settled).toMatchObject({ state: "rejected", opId: "op-rejected", code: "invalid_submission", hint: "Completion claim is required." });
+  });
+
+  it("allows drag start only for native planned clear active packages", () => {
+    const planned: TaskRow = { taskId: "task-1", title: "One", projectId: "p", coordinationStatus: "planned", canonicalStatus: "planned",
+      blocking: "clear", rawStatus: "planned/implementation", freshness: "fresh", packageDisposition: "active", closeoutReadiness: "not_required",
+      engine: "kernel/task-lifecycle/v1", origin: "native", source: "local-document", module: "gui", lastKnownAt: "2026-08-14T00:00:00.000Z", gates: [], docs: [] };
+    expect(isTaskStartable(planned)).toBe(true);
+    expect(isTaskStartable({ ...planned, blocking: "blocked", coordinationStatus: "blocked" })).toBe(false);
+    expect(isTaskStartable({ ...planned, origin: "external" })).toBe(false);
+    expect(isTaskStartable({ ...planned, canonicalStatus: "active", coordinationStatus: "active" })).toBe(false);
+  });
+
   it("renders an explicit empty state when the triadic ledger has no entities", () => {
     const markup = renderToStaticMarkup(
       createElement(GraphView, { tasks: [], decisions: [], facts: [], relations: [] })
@@ -153,23 +187,53 @@ describe("renderer app model", () => {
   });
 
   it("renders the daemon L2 document body and status through the renderer query", async () => {
-    const getTaskDocument = vi.fn(async () => ({ ok: true, status: "ready", taskId: "task-1", path: "INDEX.md",
-      body: "# Canonical renderer document", blobSha256: null, watermark: 7, sourceRevision: 7 }));
+    const contract = JSON.stringify({ schema: "task-contract/v1", taskId: "task-1", documents: [
+      { slot: "task.index", path: "INDEX.md", owner: "machine", materializeAs: "INDEX.md", requiredAnchors: [], templateRef: null, contentSha256: null }
+    ] });
+    const getTaskDocument = vi.fn(async ({ path }: { path: string }) => ({ ok: true, status: "ready", taskId: "task-1", path,
+      body: path === "task-contract.json" ? contract : "# Canonical renderer document", blobSha256: "sha256:canonical", watermark: 7, sourceRevision: 7 }));
     vi.stubGlobal("window", { harness: { getTaskDocument } });
     const queryClient = new QueryClient();
     try {
+      await queryClient.fetchQuery(taskDocumentQuery("task-1", "task-contract.json"));
       await queryClient.fetchQuery(taskDocumentQuery("task-1", "INDEX.md"));
       const task: TaskRow = { taskId: "task-1", title: "One", projectId: "project-1", coordinationStatus: "active", rawStatus: "active",
         freshness: "fresh", packageDisposition: "active", closeoutReadiness: "not_required", engine: "local", source: "snapshot-cache",
-        module: "gui", lastKnownAt: "2026-08-13T00:00:00.000Z", gates: [], docs: [] };
+        module: "gui", packagePath: "tasks/task-1-one", lastKnownAt: "2026-08-13T00:00:00.000Z", gates: [], docs: [] };
       const markup = renderToStaticMarkup(createElement(QueryClientProvider, { client: queryClient }, createElement(TaskDetailView,
         { task, onBack: () => undefined, projectName: "Harness" })));
+      expect(getTaskDocument).toHaveBeenCalledWith({ taskId: "task-1", path: "task-contract.json" });
       expect(getTaskDocument).toHaveBeenCalledWith({ taskId: "task-1", path: "INDEX.md" });
       expect(markup).toContain("Canonical renderer document");
       expect(markup).toContain("L2 · ready");
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+
+  it("parses canonical task-contract descriptors without inventing document presence", () => {
+    expect(parseTaskContractDocuments("task-1", JSON.stringify({ schema: "task-contract/v1", taskId: "task-1", documents: [
+      { slot: "task.plan", path: "task_plan.md", owner: "doc-sync", materializeAs: "task_plan.md", requiredAnchors: [], templateRef: "template://plan@1", contentSha256: "abc" },
+      { slot: "task.artifacts.keep", path: "artifacts/.gitkeep", owner: "doc-sync", materializeAs: "artifacts/.gitkeep", requiredAnchors: [], templateRef: null, contentSha256: "def" }
+    ] }))).toEqual([
+      expect.objectContaining({ path: "task_plan.md", group: "计划", required: true, presence: "unknown" }),
+      expect.objectContaining({ path: "artifacts/.gitkeep", group: "证据", required: false, presence: "unknown" })
+    ]);
+    expect(() => parseTaskContractDocuments("task-1", JSON.stringify({ schema: "task-contract/v1", taskId: "other", documents: [] }))).toThrow("task-contract");
+  });
+
+  it("renders explicit active lease forms and read-only blocking explanations", () => {
+    const active: TaskRow = { taskId: "task-active", title: "Active", projectId: "p", coordinationStatus: "active", canonicalStatus: "active", blocking: "clear",
+      blockingLabel: "当前投影无 active blocking relation", rawStatus: "active/implementation", freshness: "fresh", packageDisposition: "active", closeoutReadiness: "not_required",
+      engine: "kernel/task-lifecycle/v1", origin: "native", source: "local-document", module: "gui", lastKnownAt: "2026-08-14T00:00:00.000Z", activeExecutionId: "execution-gui-1", gates: [], docs: [] };
+    const activeMarkup = renderToStaticMarkup(createElement(QueryClientProvider, { client: new QueryClient() }, createElement(TaskDetailView,
+      { task: active, onBack: () => undefined, projectName: "Harness" })));
+    expect(activeMarkup).toContain("追加 progress"); expect(activeMarkup).toContain("atomic SubmissionV1"); expect(activeMarkup).toContain("execution-gui-1");
+
+    const blockedMarkup = renderToStaticMarkup(createElement(QueryClientProvider, { client: new QueryClient() }, createElement(TaskDetailView,
+      { task: { ...active, canonicalStatus: "planned", coordinationStatus: "blocked", blocking: "blocked", blockingLabel: "1 个 active blocking relation", activeExecutionId: undefined,
+        blockers: [{ relationId: "rel_1", kind: "blocks", sourceTaskId: "task-upstream", targetTaskId: "task-active", rationale: "wait" }] }, onBack: () => undefined, projectName: "Harness" })));
+    expect(blockedMarkup).toContain("Blocked 是 relation overlay"); expect(blockedMarkup).toContain("rel_1"); expect(blockedMarkup).not.toContain("解除");
   });
 
   it("keeps the selected decision card visible and focused under all filters", () => {
@@ -212,6 +276,14 @@ function taskRow(overrides: Partial<TaskProjectionRow>): TaskProjectionRow {
     updatedAt: "2026-07-07T00:00:00.000Z",
     source: "local-document",
     sourcePath: "harness/tasks/task-default/INDEX.md",
+    ...overrides
+  };
+}
+
+function receipt(overrides: Record<string, unknown> = {}) {
+  return {
+    schema: "command-receipt/v2", ok: true, command: "task-start", outcome: "applied", opId: "op-applied", revision: 8,
+    evidence: "event-object:op-applied", visibility: "center", proof: { committedRevision: 8, appliedCut: 8, durable: true, canonicalVisible: true, worktreeVisible: true },
     ...overrides
   };
 }

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -16,20 +16,22 @@ import { makeTaskEventStore, type AgentRuntimeEventV1, type FrozenWritePlan } fr
 import { streamAgentRuntimeAt } from "../src/main/agent-runtime-stream-client.ts";
 
 test("GUI client reaches every shipped read through a real resident daemon", async () => {
-  const fixture = await startGuiResidentDaemonFixture({ task: { taskId: "task-gui-smoke", title: "Resident GUI task" }, beforeStop: async (endpoint: string, repoId: string) => { const started = await requestDaemonJsonRpcAt(endpoint, "repo.task.start", { repo: { repoId }, payload: { taskId: "task-gui-smoke", executionId: "execution-gui" } }, 1_000); assert.equal(started.ok, true, JSON.stringify(started)); }, beforeRestart: seedRuntime });
+  const fixture = await startGuiResidentDaemonFixture({ task: { taskId: "task-gui-smoke", title: "Resident GUI task" }, beforeRestart: seedRuntime });
   const previous = { userRoot: process.env.HARNESS_DAEMON_USER_ROOT, daemonId: process.env.HARNESS_DAEMON_ID,
     repoId: process.env.HARNESS_DAEMON_REPO_ID };
   Object.assign(process.env, fixture.env);
   try {
     writeTriadicLedger(fixture.rootDir);
+    const bridge = createLocalGuiServiceBridge(fixture.rootDir), executionId = "execution-gui-bridge";
+    const started = parseDaemonGuiActionResponse("repo.task.start", await bridge.invoke("startTask", { taskId: "task-gui-smoke", executionId }));
+    assert.equal(started.ok, true, JSON.stringify(started)); assert.equal(started.outcome, "applied");
     const documentBody = "# Canonical GUI document\n", documentPath = "tasks/task-gui-smoke-resident-gui-task/notes.md", authored = path.join(fixture.rootDir, "harness", documentPath);
     mkdirSync(path.dirname(authored), { recursive: true }); writeFileSync(authored, documentBody);
     const status = await requestDaemonJsonRpcAt(fixture.endpoint, "repo.task.run", { repo: { repoId: fixture.repoId },
       payload: { action: { kind: "doc-status", paths: [documentPath] } } }, 1_000);
     assert.equal(status.ok, true, JSON.stringify(status)); const synced = await requestDaemonJsonRpcAt(fixture.endpoint, "repo.task.run", { repo: { repoId: fixture.repoId }, payload: { action: { kind: "doc-submit",
-      executionId: "execution-gui", paths: [documentPath] } } }, 1_000);
+      executionId, paths: [documentPath] } } }, 1_000);
     assert.equal(synced.ok, true, JSON.stringify(synced)); writeFileSync(authored, "# Uncommitted filesystem edit\n");
-    const bridge = createLocalGuiServiceBridge(fixture.rootDir);
     const results = new Map<DaemonGuiReadMethod, unknown>();
     for (const contract of daemonGuiReadMethods) {
       const payload = contract.id === "tasks.document.read" ? { taskId: "task-gui-smoke", path: "notes.md" } : contract.id === "agentRuntime.sessions.read" ? { runtimeSessionId: "runtime-gui" } : contract.id === "agentRuntime.events.read" ? { runtimeSessionId: "runtime-gui", afterCursor: "lifecycle:0" } : null;
@@ -41,6 +43,8 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
     const tasks = parseDaemonGuiReadResult("repo.tasks.list", results.get("repo.tasks.list"));
     assert.deepEqual(tasks.rows.map(({ taskId }) => taskId), ["task-gui-smoke"]);
     assert.equal(tasks.rows[0]?.snapshot.task?.title, "Resident GUI task");
+    assert.equal(tasks.rows[0]?.snapshot.task?.status, "active"); assert.equal(tasks.rows[0]?.snapshot.lease?.executionId, executionId);
+    assert.deepEqual(tasks.rows[0]?.placement.moduleKeys, ["gui"]); assert.equal(tasks.rows[0]?.placement.origin, "native");
     const graph = parseDaemonGuiReadResult("repo.triadic.relationGraph", results.get("repo.triadic.relationGraph"));
     assert.equal(graph.edges.length, 3); assert.equal(graph.factAnchors.length, 1); assert.equal(graph.facts.length, 1);
     assert.equal(graph.facts[0]?.statement, "The GUI renderer received event-backed triadic rows.");
@@ -49,6 +53,16 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
     const controlled = parseDaemonGuiActionResponse("repo.decision.list", await bridge.invoke("listDecisions", {})); assert.equal(controlled.ok, true); assert.match(String(controlled.evidence), /dec_gui_smoke/u);
     const document = parseDaemonGuiReadResult("repo.tasks.document.read", results.get("repo.tasks.document.read"));
     assert.equal(document.body, documentBody); assert.equal(document.path, "notes.md"); assert.equal(document.status, "ready");
+    const progress = parseDaemonGuiActionResponse("repo.task.progress.append", await bridge.invoke("appendTaskProgress", { taskId: "task-gui-smoke", executionId, text: "Renderer sent typed progress.", evidence: [{ type: "test", path: "packages/gui/test/service-bridge.test.ts", summary: "resident daemon bridge" }], baseDocumentSha256: null }));
+    assert.equal(progress.ok, true, JSON.stringify(progress)); assert.equal(progress.outcome, "applied");
+    const commitSha = String(progress.commitSha); assert.match(commitSha, /^[0-9a-f]{40}$/u);
+    const submitted = parseDaemonGuiActionResponse("repo.task.submit", await bridge.invoke("submitTask", { taskId: "task-gui-smoke", executionId, submission: {
+      completionClaim: "GUI task mutation bridge is exercised.", deliverables: ["Task action bridge"], outputs: ["packages/gui/test/service-bridge.test.ts"],
+      verificationNotes: ["resident daemon"], knownGaps: ["Electron E2E unverified"], residualRisks: ["manual desktop verification pending"], commitSha
+    } }));
+    assert.equal(submitted.ok, true, JSON.stringify(submitted)); assert.equal(submitted.outcome, "applied");
+    const afterSubmit = parseDaemonGuiReadResult("repo.tasks.list", await bridge.invoke("getTasks", null));
+    assert.equal(afterSubmit.rows[0]?.snapshot.task?.status, "in_review"); assert.equal(afterSubmit.rows[0]?.snapshot.lease, null);
   } finally {
     await fixture.stop();
     restoreEnv("HARNESS_DAEMON_USER_ROOT", previous.userRoot); restoreEnv("HARNESS_DAEMON_ID", previous.daemonId);

--- a/packages/gui/test/task-adapter.vitest.ts
+++ b/packages/gui/test/task-adapter.vitest.ts
@@ -2,13 +2,22 @@ import { describe, expect, it } from "vitest";
 import { REPLAY_TASK_GRAPH } from "../../kernel/src/index.ts";
 import type { TaskSnapshotProjectionRow } from "../src/api/renderer-dto.ts";
 import { adaptProjectionRows, computeRootTaskId } from "../src/renderer/task-adapter.ts";
+import type { DecisionRow, RelationEdge } from "../src/renderer/model/types.ts";
 
 function row(overrides: Partial<TaskSnapshotProjectionRow> = {}): TaskSnapshotProjectionRow {
   const taskId = overrides.taskId ?? "task-x";
   return { taskId, workspaceRevision: 1, updatedAt: "2026-08-12T00:00:00.000Z", snapshot: { revision: 1,
     task: { schema: "task/v1", taskId, title: "X", taskClass: "standard", status: "planned", graph: REPLAY_TASK_GRAPH, currentNode: "implementation", iteration: 0,
-      createdBy: { principal: { personId: "person-owner" }, executor: null }, completionGateIds: [], presetSnapshotDigest: null }, executions: [], reviews: [], edgesTaken: [], lease: null }, ...overrides };
+      createdBy: { principal: { personId: "person-owner" }, executor: null }, completionGateIds: [], presetSnapshotDigest: null }, executions: [], reviews: [], consents: [], codeDocWitnesses: [], gateWitnesses: [], edgesTaken: [], lease: null },
+    packagePath: `tasks/${taskId}-x`, snapshotAvailability: { consents: "known", codeDocWitnesses: "known", gateWitnesses: "known" },
+    placement: { moduleKeys: ["gui"], productLines: ["harness"], parentTaskId: null, origin: "native", engine: "kernel/task-lifecycle/v1", packageDisposition: "active", provenance: [{ kind: "l2", ref: `tasks/${taskId}-x/INDEX.md` }] },
+    executionEvidence: [], ...overrides };
 }
+
+const relation = (overrides: Partial<RelationEdge>): RelationEdge => ({
+  relationId: "rel_0000000000000001", from: "task/task-a", to: "task/task-b", kind: "blocks",
+  direction: "directed", state: "active", provenance: "local-document", rationale: "B waits for A", ...overrides
+});
 
 describe("computeRootTaskId", () => {
   it("walks a parent chain and terminates cycles", () => {
@@ -21,10 +30,73 @@ describe("adaptProjectionRows", () => {
   it("derives renderer state from the canonical lifecycle snapshot", () => {
     const [task] = adaptProjectionRows([row()]);
     expect(task).toMatchObject({ taskId: "task-x", title: "X", coordinationStatus: "planned", rawStatus: "planned/implementation",
-      freshness: "fresh", rootTaskId: "task-x", rootTitle: "X" });
+      canonicalStatus: "planned", blocking: "clear", blockingLabel: "当前投影无 active blocking relation",
+      freshness: "fresh", rootTaskId: "task-x", rootTitle: "X", module: "gui", moduleKeys: ["gui"], productLines: ["harness"],
+      origin: "native", engine: "kernel/task-lifecycle/v1" });
   });
 
   it("marks a pending projection stale but usable", () => {
     expect(adaptProjectionRows([row()], "pending")[0]?.freshness).toBe("stale-but-usable");
+  });
+
+  it("keeps canonical status separate while blocks and depends-on derive the blocked display lane", () => {
+    const rows = [row({ taskId: "task-a" }), row({ taskId: "task-b" }), row({ taskId: "task-c", snapshot: {
+      ...row().snapshot, task: { ...row().snapshot.task!, taskId: "task-c", status: "done" }
+    } })];
+    const relations = [
+      relation({ from: "task/task-a", to: "task/task-b", kind: "blocks" }),
+      relation({ relationId: "rel_0000000000000002", from: "task/task-b", to: "task/task-c", kind: "depends-on" })
+    ];
+    const tasks = adaptProjectionRows(rows, "ready", { relationState: "ready", relations });
+
+    expect(tasks.find((task) => task.taskId === "task-b")).toMatchObject({
+      canonicalStatus: "planned", coordinationStatus: "blocked", blocking: "blocked",
+      blockers: [{ relationId: "rel_0000000000000001", sourceTaskId: "task-a", targetTaskId: "task-b" }]
+    });
+    expect(tasks.find((task) => task.taskId === "task-c")?.blocking).toBe("clear");
+  });
+
+  it("fails closed to unknown for unavailable relation truth, malformed blocking edges, and missing endpoints", () => {
+    const unavailable = adaptProjectionRows([row()], "ready", { relationState: "loading", relations: [] })[0]!;
+    expect(unavailable).toMatchObject({ blocking: "unknown", coordinationStatus: "planned", blockingLabel: "阻塞关系未能确定",
+      module: "unassigned", moduleKeys: [], productLines: [], placementWarning: "relation projection 未就绪，无法判定 derived placement" });
+
+    const tasks = adaptProjectionRows([row({ taskId: "task-a" }), row({ taskId: "task-b" })], "ready", {
+      relationState: "ready",
+      relations: [
+        relation({ direction: "undirected" }),
+        relation({ relationId: "rel_0000000000000003", from: "task/task-missing", to: "task/task-a" })
+      ]
+    });
+    expect(tasks.map(({ blocking }) => blocking)).toEqual(["unknown", "unknown"]);
+    expect(tasks[0]?.blockingWarnings).toEqual(expect.arrayContaining([expect.stringContaining("task-missing")]));
+  });
+
+  it("recomputes active dependency cycles and shows every node as blocked with a cycle warning", () => {
+    const tasks = adaptProjectionRows([row({ taskId: "task-a" }), row({ taskId: "task-b" })], "ready", {
+      relationState: "ready",
+      relations: [
+        relation({ kind: "depends-on" }),
+        relation({ relationId: "rel_0000000000000002", kind: "depends-on", from: "task/task-b", to: "task/task-a" })
+      ]
+    });
+    expect(tasks.map(({ blocking }) => blocking)).toEqual(["blocked", "blocked"]);
+    expect(tasks.every((task) => task.blockingWarnings.some((warning) => warning.includes("cycle")))).toBe(true);
+  });
+
+  it("prioritizes decision-derived scopes and uses the supplement for independent placement and parent roots", () => {
+    const parent = row({ taskId: "task-parent", placement: { ...row().placement, moduleKeys: ["kernel"], productLines: ["platform"] } });
+    const child = row({ taskId: "task-child", placement: { ...row().placement, moduleKeys: ["stale-supplement"], productLines: ["stale"], parentTaskId: "task-parent" } });
+    const decision = { decisionId: "dec-scope", title: "Scope", state: "active", question: "Where?", chosen: [], rejected: [], claims: [],
+      appliesTo: { modules: ["gui"], productLines: ["desktop"] } } satisfies DecisionRow;
+    const tasks = adaptProjectionRows([parent, child], "ready", { relationState: "ready", decisions: [decision], relations: [relation({
+      relationId: "rel_0000000000000004", from: "decision/dec-scope", to: "task/task-child", kind: "derives"
+    })] });
+
+    expect(tasks.find((task) => task.taskId === "task-child")).toMatchObject({
+      module: "gui", moduleKeys: ["gui"], productLines: ["desktop"], parentTaskId: "task-parent",
+      rootTaskId: "task-parent", rootTitle: "X", spawningDecision: "dec-scope"
+    });
+    expect(tasks.find((task) => task.taskId === "task-parent")).toMatchObject({ module: "kernel", productLines: ["platform"] });
   });
 });

--- a/packages/gui/test/taskFilters.vitest.ts
+++ b/packages/gui/test/taskFilters.vitest.ts
@@ -63,6 +63,12 @@ describe("taskFilters status multi-select", () => {
     const chips = taskFilterSummary({ ...DEFAULT_TASK_FILTERS, status: ["active", "blocked"] });
     expect(chips).toContain("status=active|blocked");
   });
+
+  it("makes relation unknown and every projected module explicitly filterable", () => {
+    const task = makeTask({ coordinationStatus: "planned", canonicalStatus: "planned", blocking: "unknown", module: "multiple (gui, kernel)", moduleKeys: ["gui", "kernel"] });
+    expect(matchesTask(task, { ...DEFAULT_TASK_FILTERS, status: ["unknown"] })).toBe(true);
+    expect(matchesTask(task, { ...DEFAULT_TASK_FILTERS, module: "gui" })).toBe(true);
+  });
 });
 
 describe("taskFilters favoritesOnly", () => {

--- a/tools/gates/line-budgets.json
+++ b/tools/gates/line-budgets.json
@@ -7,7 +7,7 @@
     "doc-sync": 349,
     "preset": 328,
     "cli": 140,
-    "gui": 17448,
+    "gui": 17881,
     "daemon": 982,
     "fleet": 165,
     "authority-write-path": 0,

--- a/tools/gates/test/fixtures/gui-s2a-task-truth-production-paths.json
+++ b/tools/gates/test/fixtures/gui-s2a-task-truth-production-paths.json
@@ -1,0 +1,23 @@
+[
+  { "path": "packages/gui/src/api/renderer-dto.ts", "module": "gui" },
+  { "path": "packages/gui/src/renderer/App.tsx", "module": "gui" },
+  { "path": "packages/gui/src/renderer/api-client.ts", "module": "gui" },
+  { "path": "packages/gui/src/renderer/components/TaskControlPanel.tsx", "module": "gui" },
+  { "path": "packages/gui/src/renderer/components/TaskFilterBar.tsx", "module": "gui" },
+  { "path": "packages/gui/src/renderer/components/TaskPreviewDrawer.tsx", "module": "gui" },
+  { "path": "packages/gui/src/renderer/components/badges.tsx", "module": "gui" },
+  { "path": "packages/gui/src/renderer/components/taskDetail/PhaseSteps.tsx", "module": "gui" },
+  { "path": "packages/gui/src/renderer/components/taskDetail/constants.ts", "module": "gui" },
+  { "path": "packages/gui/src/renderer/components/taskDetail/widgets.tsx", "module": "gui" },
+  { "path": "packages/gui/src/renderer/model/taskFilters.ts", "module": "gui" },
+  { "path": "packages/gui/src/renderer/model/triadic.ts", "module": "gui" },
+  { "path": "packages/gui/src/renderer/model/types.ts", "module": "gui" },
+  { "path": "packages/gui/src/renderer/task-actions.ts", "module": "gui" },
+  { "path": "packages/gui/src/renderer/task-adapter.ts", "module": "gui" },
+  { "path": "packages/gui/src/renderer/task-data.ts", "module": "gui" },
+  { "path": "packages/gui/src/renderer/triadic-data.ts", "module": "gui" },
+  { "path": "packages/gui/src/renderer/views/BoardView.tsx", "module": "gui" },
+  { "path": "packages/gui/src/renderer/views/ListView.tsx", "module": "gui" },
+  { "path": "packages/gui/src/renderer/views/SwimlaneBoard.tsx", "module": "gui" },
+  { "path": "packages/gui/src/renderer/views/TaskDetailView.tsx", "module": "gui" }
+]


### PR DESCRIPTION
# English

## Summary

W5 GUI S2-A: the task control surface moves onto canonical truth. Board/detail/filter consume one derived TaskRow from real task/relation projections — the task-side mock relation/event paths are deleted. U-02 lands as adjudicated: canonical status and a relation-derived blocking overlay are kept separate (`blocked/clear/unknown`), all blockers are shown with relationId/rationale, dependency cycles are recomputed client-side with a warning, and every uncertainty (query error, missing endpoint, invalid direction) renders as explicit unknown — never a green light; relations stay read-only (no dismiss button, REQ-10). Three mutations ship through the typed facets only: drag is allowed solely for native active-package planned+clear → Active with an `execution-gui-<uuid>` idempotency lock; request-review is an explicit atomic structured-SubmissionV1 form; progress is an explicit form under an active lease. Success renders only on `applied+durable+canonicalVisible+worktreeVisible` at a consistent cut followed by a projection reread — no optimistic status, no mutation replay; failures show raw code/hint/opId. REQ-03 placement consumes the U-11 supplement (independent/external/root) while derived tasks keep relation+Decision.appliesTo precedence.

## What Changed

- `feat(gui): land task truth control surface` (34c46345): triadic-data preserves relation state/direction/id losslessly; task-adapter derives blocking + placement; task-actions wires typed start/progress/structured-submit/receipt-show with settlement discipline; BoardView drag guard; TaskControlPanel explicit forms with read-only reasons for every non-writable state; TaskDetailView/App unified on projections, canonical task-contract descriptors, per-doc presence.
- Gate surfaces: line-budgets gui 17448→17881 (+433 actual vs +850 design estimate; within existing verified gui-22100 receipt, headroom 4,219); fixture `gui-s2a-task-truth-production-paths.json` (21 paths) same-commit. Only the gui key touched; packages/daemon/kernel/preset untouched.

## Task And Scope

- Harness task: task_01KZX9CY7KP100X0QM5TAYPAS4 (gui-s2-design.md §3/§3.4/§6 S2-A; gui-s2-adjudication.md U-02 adopted)
- Branch: codex/gui-s2a-task-truth (base rebuild/main 12a59f45)
- Public scope: packages/gui only + gate budgets/fixture
- Out of scope: S2-B decision control, S2-C execution evidence; U-13 deferred.

## Version Impact

- Version: no version change (pre-cutover rebuild line).
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: line-budgets.json gui key (within existing verified gui-22100 receipt), governance fixture same-commit
- Authority: dec_01KZWTAPXF24FR62Q53Y42JGMV (restoration charter) + gui-s2-adjudication.md (U-02 adopted; blocked-drag narrowing on record)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

Production-Delta: +513/-80

- Base `origin/rebuild/main` SHA: 12a59f45
- Branch merge-base with `origin/rebuild/main`: 12a59f45
- Last `git fetch origin` time: 2026-08-14 ~14:15 CST
- Sync method: none needed (base+1)
- Public diff command: `git diff 12a59f45..34c46345`
- Private evidence commit/path: harness/tasks/task_01KZX9CY7KP100X0QM5TAYPAS4-.../artifacts/report-gui-s2a.md
- Reviewer evidence path: same artifacts; CEO re-ran the full verify chain personally (typecheck, GUI vitest 13 files/120 tests, real resident-daemon bridge 4/4, vite build, G32, check:local — all green)
- GitHub Actions `rewrite-ci` run URL: pending (green before merge)
- [x] `git diff --check`
- [x] `npm run check:local` exit 0
- [x] Targeted tests: blocks/depends-on/unknown/cycle/placement adapter matrix; settlement/raw-rejection/drag-guard/docs/control-form model tests; real resident-daemon start→progress→structured submit→projection reread
- [x] GUI production build green (single-chunk >500kB warning pre-existing, no perf work in scope)
- [ ] GitHub Actions `rewrite-ci` passed (authoritative full gate — pending at PR-open time)
- Not run, and why: Electron desktop E2E stays CI unverified per mission; CEO desktop hands-on acceptance happens post-merge.

## Review Evidence

- Self-review: CEO checked the implementation against design §3 (three-state derivation, all-blockers display, cycle warning, unknown wording), §3.4 (drag/forms/read-only reasons), §4.1.5 (settlement discipline), and the U-02 adjudication; confirmed only packages/gui touched and the governance fixture is present this time.
- Reviewer subagent: verify-findings could not parse the report's Verify-Command section format; CEO ran the full chain manually instead (all green above).
- Human review: pending (this PR + post-merge desktop hands-on)
- Blocking findings: none

## Residual Risk

- Electron desktop E2E pending CEO hands-on after merge (drag, forms, receipt, three layouts).
- Vite single-chunk size warning pre-existing; packaging refactor out of scope.

---

# 中文

## 概要

W5 GUI S2-A:task 控制面切上 canonical 真值。Board/detail/filter 消费同一份由真实 task/relation projection 派生的 TaskRow——task 侧 mock relation/event 路径删除。U-02 按裁决落地:canonical status 与 relation 派生的阻塞 overlay 分离(`blocked/clear/unknown`),全部 blocker 带 relationId/rationale 展示,依赖环前端复算并 warning,一切不确定性(查询错误/缺端点/非法方向)显式 unknown——绝不当绿灯;relation 保持只读(无解除按钮,REQ-10)。三类 mutation 只走 typed facets:拖拽仅允许 native active-package 的 planned+clear → Active,带 `execution-gui-<uuid>` 幂等锁;request-review 是显式 atomic structured-SubmissionV1 form;progress 是 active lease 下的显式 form。仅在一致 cut 上 `applied+durable+canonicalVisible+worktreeVisible` 且 projection reread 后才渲染成功——无 optimistic status、不重放 mutation;失败原样显示 code/hint/opId。REQ-03 placement 消费 U-11 supplement(independent/external/root),derived task 保持 relation+Decision.appliesTo 优先。

## 改了什么

- `feat(gui): land task truth control surface`(34c46345):triadic-data 无损保留 relation state/direction/id;task-adapter 派生 blocking+placement;task-actions 接 typed start/progress/structured-submit/receipt-show 与 settlement 纪律;BoardView 拖拽 guard;TaskControlPanel 显式 forms 与每种不可写状态的只读原因;TaskDetailView/App 统一投影、canonical task-contract descriptors、逐文档 presence。
- 门面:line-budgets gui 17448→17881(实测 +433 vs 设计预估 +850;在现役 gui-22100 receipt 内,余 4,219);fixture `gui-s2a-task-truth-production-paths.json`(21 路径)同 commit。只动 gui key;daemon/kernel/preset 零接触。

## 任务与范围

- Harness task:task_01KZX9CY7KP100X0QM5TAYPAS4(设计 §3/§3.4/§6 S2-A;裁决 U-02 采纳)
- 分支:codex/gui-s2a-task-truth(base rebuild/main 12a59f45)
- 公开范围:仅 packages/gui + gate budgets/fixture
- 范围外:S2-B decision control、S2-C execution evidence;U-13 defer。

## 版本影响

- 版本:无变化(cutover 前 rebuild 线)。
- 发布影响:不发布。

## 治理声明

- 触碰 protected surface:是
- 范围:line-budgets.json gui key(在现役 gui-22100 receipt 内)、治理 fixture 同 commit
- 授权:dec_01KZWTAPXF24FR62Q53Y42JGMV(恢复章程)+ gui-s2-adjudication.md(U-02 采纳;blocked 拖拽收窄在册)
- 机器检查边界:本 PR 仅断言声明存在;是否真实充分由评审判断。
- Break-glass:否

## 验证

- Base `origin/rebuild/main` SHA:12a59f45
- merge-base:12a59f45
- 最近 fetch:2026-08-14 约 14:15 CST
- 同步方式:无需(base+1)
- 公开 diff 命令:`git diff 12a59f45..34c46345`
- 私有证据:任务包 artifacts/report-gui-s2a.md
- 评审证据:CEO 亲跑完整验证链(typecheck、GUI vitest 13 文件/120 测试、真实 daemon bridge 4/4、vite build、G32、check:local 全绿)
- [x] `git diff --check`
- [x] `npm run check:local` exit 0
- [x] 定向测试:blocks/depends-on/unknown/cycle/placement adapter 矩阵;settlement/raw-rejection/drag-guard/docs/control-form 模型测试;真实 resident-daemon start→progress→structured submit→projection reread
- [x] GUI 生产 build 绿(单 chunk >500kB warning 既有,性能不在本片范围)
- [ ] GitHub Actions `rewrite-ci`(权威全量门,开 PR 时待跑)
- 未跑及原因:Electron 桌面 E2E 按 mission 归 CI/合并后 CEO 本机亲验。

## 评审证据

- 自评:CEO 按设计 §3(三态派生/全 blocker 展示/cycle warning/unknown 文案)、§3.4(拖拽/forms/只读原因)、§4.1.5(settlement 纪律)与 U-02 裁决逐条对照;确认只动 packages/gui 且本次带了 governance fixture。
- 评审 subagent:verify-findings 因报告 Verify-Command 小节格式解析失败;CEO 改为亲跑全链(如上全绿)。
- 人工评审:待定(本 PR + 合并后桌面亲验)
- 阻塞 findings:无

## 残余风险

- Electron 桌面 E2E 待合并后 CEO 亲验(拖拽/forms/receipt/三 layout)。
- Vite 单 chunk 体积 warning 既有;分包重构不在范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
