### PR TITLE
feat(gui): land execution evidence view (W5 GUI S2-C)

### DIFF
--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   Kanban,
   FolderSimple,
@@ -13,6 +14,7 @@ import {
   WarningCircle,
   GitBranch,
   FirstAidKit,
+  Package,
 } from "@phosphor-icons/react";
 import type { SnapshotStatus } from "./model/types.ts";
 import {
@@ -27,6 +29,7 @@ import { BoardView } from "./views/BoardView.tsx";
 import { DecisionsView } from "./views/DecisionsView.tsx";
 import { DecisionPoolView } from "./views/DecisionPoolView.tsx";
 import { FactTriageView } from "./views/FactTriageView.tsx";
+import { ExecutionEvidenceView } from "./views/ExecutionEvidenceView.tsx";
 import { EntityWorkspace } from "./components/EntityWorkspace.tsx";
 import { PresetsView } from "./views/PresetsView.tsx";
 import { AdaptersView } from "./views/AdaptersView.tsx";
@@ -41,7 +44,7 @@ import {
   type TaskFilters,
 } from "./model/taskFilters.ts";
 import { adaptProjectionRows, buildRealProject } from "./task-adapter.ts";
-import { useTasksQuery } from "./task-data.ts";
+import { taskQueryKeys, useTasksQuery } from "./task-data.ts";
 import { useTriadicProjectionQuery } from "./triadic-data.ts";
 import { useFavorites } from "./model/favorites.ts";
 import type { LaneGroupBy } from "./views/SwimlaneBoard.tsx";
@@ -56,6 +59,7 @@ type ViewId =
   | "decisions"
   | "decisionPool"
   | "factTriage"
+  | "executionEvidence"
   | "graph"
   | "presets"
   | "adapters"
@@ -76,6 +80,7 @@ const WORKSPACE_NAV: { id: ViewId; label: string; icon: React.ReactNode }[] = [
   { id: "decisions", label: "决策批准", icon: <Scales weight="duotone" /> },
   { id: "decisionPool", label: "决策池", icon: <GitBranch weight="duotone" /> },
   { id: "factTriage", label: "事实分诊", icon: <FirstAidKit weight="duotone" /> },
+  { id: "executionEvidence", label: "执行证据", icon: <Package weight="duotone" /> },
   { id: "graph", label: "关系图", icon: <Graph weight="duotone" /> },
 ];
 
@@ -93,6 +98,7 @@ const VIEW_LABEL: Record<ViewId, string> = {
   decisions: "决策批准",
   decisionPool: "决策池",
   factTriage: "事实分诊",
+  executionEvidence: "执行证据",
   graph: "关系图",
   presets: "Preset / Vertical",
   adapters: "引擎 Adapter",
@@ -102,6 +108,7 @@ const VIEW_LABEL: Record<ViewId, string> = {
 
 function AppShell() {
   const [view, setView] = useState<ViewId>("overview");
+  const queryClient = useQueryClient();
   const tasksQuery = useTasksQuery();
   const triadicQuery = useTriadicProjectionQuery();
   const taskActions = useTaskActions();
@@ -499,6 +506,16 @@ function AppShell() {
                   focusedEntityRef?.startsWith("fact/") ? focusedEntityRef : null
                 }
                 onFocusGraph={focusEntityInGraph}
+              />
+            ) : view === "executionEvidence" ? (
+              <ExecutionEvidenceView
+                rows={tasksQuery.data?.rows ?? []}
+                queryStatus={tasksQuery.isError ? "error" : tasksQuery.isLoading ? "loading" : "ready"}
+                projectionStatus={tasksQuery.data?.status}
+                isFetching={tasksQuery.isFetching}
+                error={tasksQuery.error}
+                onReload={() => { void tasksQuery.refetch(); }}
+                onReloadFromFirst={() => { void queryClient.invalidateQueries({ queryKey: taskQueryKeys.list() }); }}
               />
             ) : view === "decisions" ? (
               <DecisionsView

--- a/packages/gui/src/renderer/app-model.ts
+++ b/packages/gui/src/renderer/app-model.ts
@@ -12,7 +12,7 @@ export const rendererCapabilityModel: RendererCapabilityModel = {
 };
 
 export interface RendererNavigationItem {
-  readonly id: "workspace" | "board" | "list" | "detail" | "doc-viewer" | "review-queue" | "graph";
+  readonly id: "workspace" | "board" | "list" | "detail" | "doc-viewer" | "review-queue" | "execution-evidence" | "graph";
   readonly label: string;
 }
 
@@ -23,5 +23,6 @@ export const rendererNavigation: readonly RendererNavigationItem[] = [
   { id: "detail", label: "Detail" },
   { id: "doc-viewer", label: "Docs" },
   { id: "review-queue", label: "Review" },
+  { id: "execution-evidence", label: "Execution evidence" },
   { id: "graph", label: "Graph" }
 ];

--- a/packages/gui/src/renderer/model/execution-evidence.ts
+++ b/packages/gui/src/renderer/model/execution-evidence.ts
@@ -1,0 +1,247 @@
+import type { TaskSnapshotProjectionRow } from "../../api/renderer-dto.ts";
+
+export const EXECUTION_EVIDENCE_PAGE_SIZE = 25;
+export const UNKNOWN_EVIDENCE_FIELD = "unknown / 未投影";
+
+type Snapshot = TaskSnapshotProjectionRow["snapshot"];
+type Execution = Snapshot["executions"][number];
+type Review = Snapshot["reviews"][number];
+type Consent = Snapshot["consents"][number];
+type GateWitness = Snapshot["gateWitnesses"][number];
+type ProjectedEvidence = TaskSnapshotProjectionRow["executionEvidence"][number];
+type ProjectedOutput = ProjectedEvidence["outputs"][number];
+
+export interface ExecutionEvidenceOutput {
+  readonly evidenceId?: string;
+  readonly locator?: string;
+  readonly substrate?: "repository-path" | "uri" | "canonical-event" | "opaque";
+  readonly checkerReceiptRef?: string | null;
+  readonly checkerResult?: "pass" | "fail" | "unknown";
+  readonly isPassingReceipt: boolean;
+  readonly raw: unknown;
+}
+
+export interface ExecutionEvidenceRow {
+  readonly taskId: string;
+  readonly taskTitle: string;
+  readonly taskUpdatedAt: string;
+  readonly executionId: string;
+  readonly state?: string;
+  readonly iteration?: number;
+  readonly commitSha?: string;
+  readonly claimedAt?: string;
+  readonly submittedAt?: string | null;
+  readonly closedAt?: string | null;
+  readonly origin?: "native" | "archival";
+  readonly outputs: readonly ExecutionEvidenceOutput[];
+  readonly reviews: readonly Review[];
+  readonly consents: readonly Consent[];
+  readonly gateWitnesses: readonly GateWitness[];
+  readonly witnessAvailability: TaskSnapshotProjectionRow["snapshotAvailability"];
+  readonly rawTask: unknown;
+  readonly rawExecution: unknown;
+}
+
+export interface ExecutionEvidenceStats {
+  readonly executions: number;
+  readonly tasksWithExecutions: number;
+  readonly outputs: number;
+  readonly nativeExecutions: number;
+  readonly archivalExecutions: number;
+  readonly unknownOriginExecutions: number;
+  readonly passingReceiptOutputs: number;
+}
+
+export interface ExecutionEvidenceModel {
+  readonly executions: readonly ExecutionEvidenceRow[];
+  readonly stats: ExecutionEvidenceStats;
+}
+
+export interface ExecutionEvidenceFilters {
+  readonly receipt: "all" | "passing" | "no-receipt";
+  readonly origin: "all" | "native" | "archival";
+}
+
+export interface ExecutionEvidencePage {
+  readonly executions: readonly ExecutionEvidenceRow[];
+  readonly pageNumber: number;
+  readonly totalPages: number;
+  readonly hasPreviousPage: boolean;
+  readonly hasNextPage: boolean;
+}
+
+export function aggregateExecutionEvidence(rows: readonly TaskSnapshotProjectionRow[]): ExecutionEvidenceModel {
+  const executions = rows.flatMap(adaptTaskExecutions).sort(compareExecutions);
+  const taskIds = new Set(executions.map(({ taskId }) => taskId));
+  return {
+    executions,
+    stats: {
+      executions: executions.length,
+      tasksWithExecutions: taskIds.size,
+      outputs: executions.reduce((total, item) => total + item.outputs.length, 0),
+      nativeExecutions: executions.filter(({ origin }) => origin === "native").length,
+      archivalExecutions: executions.filter(({ origin }) => origin === "archival").length,
+      unknownOriginExecutions: executions.filter(({ origin }) => origin === undefined).length,
+      passingReceiptOutputs: executions.reduce((total, item) => total + item.outputs.filter(({ isPassingReceipt }) => isPassingReceipt).length, 0),
+    },
+  };
+}
+
+export function filterExecutionEvidence(
+  executions: readonly ExecutionEvidenceRow[],
+  filters: ExecutionEvidenceFilters,
+): ExecutionEvidenceRow[] {
+  return executions.flatMap((execution) => {
+    if (filters.origin !== "all" && execution.origin !== filters.origin) return [];
+    if (filters.receipt === "all") return [execution];
+    const outputs = execution.outputs.filter((output) => filters.receipt === "passing"
+      ? output.isPassingReceipt
+      : output.checkerReceiptRef === null);
+    return outputs.length > 0 ? [{ ...execution, outputs }] : [];
+  });
+}
+
+export function paginateExecutionEvidence(
+  executions: readonly ExecutionEvidenceRow[],
+  requestedPageIndex: number,
+): ExecutionEvidencePage {
+  const totalPages = Math.max(1, Math.ceil(executions.length / EXECUTION_EVIDENCE_PAGE_SIZE));
+  const pageIndex = Math.min(Math.max(0, requestedPageIndex), totalPages - 1);
+  const start = pageIndex * EXECUTION_EVIDENCE_PAGE_SIZE;
+  return {
+    executions: executions.slice(start, start + EXECUTION_EVIDENCE_PAGE_SIZE),
+    pageNumber: pageIndex + 1,
+    totalPages,
+    hasPreviousPage: pageIndex > 0,
+    hasNextPage: pageIndex + 1 < totalPages,
+  };
+}
+
+export function buildExecutionEvidenceContext(
+  execution: ExecutionEvidenceRow,
+  output: ExecutionEvidenceOutput,
+  now: () => string = () => new Date().toISOString(),
+): string {
+  return [
+    "# Harness 执行证据上下文",
+    "",
+    `copiedAt: ${now()}`,
+    `taskId: ${execution.taskId}`,
+    `executionId: ${execution.executionId}`,
+    `iteration: ${field(execution.iteration)}`,
+    `commitSha: ${field(execution.commitSha)}`,
+    `origin: ${field(execution.origin)}`,
+    `evidenceId: ${field(output.evidenceId)}`,
+    `substrate: ${field(output.substrate)}`,
+    `locator: ${field(output.locator)}`,
+    `checkerReceiptRef: ${receiptField(output.checkerReceiptRef)}`,
+    `checkerResult: ${checkerResultField(output.checkerResult)}`,
+    "",
+    "## task 原文",
+    json(execution.rawTask),
+    "",
+    "## execution 原文",
+    json(execution.rawExecution),
+    "",
+    "## output 原文",
+    json(output.raw),
+  ].join("\n");
+}
+
+export function field(value: unknown): string {
+  return value === undefined || value === null || value === "" ? UNKNOWN_EVIDENCE_FIELD : String(value);
+}
+
+export function receiptField(value: string | null | undefined): string {
+  return value === null ? "none / 无 receipt" : field(value);
+}
+
+export function checkerResultField(value: ExecutionEvidenceOutput["checkerResult"]): string {
+  return value === "unknown" ? UNKNOWN_EVIDENCE_FIELD : field(value);
+}
+
+function adaptTaskExecutions(row: TaskSnapshotProjectionRow): ExecutionEvidenceRow[] {
+  const taskTitle = row.snapshot.task?.title ?? row.taskId;
+  return row.snapshot.executions.map((execution) => adaptExecution(row, execution, taskTitle));
+}
+
+function adaptExecution(row: TaskSnapshotProjectionRow, execution: Execution, taskTitle: string): ExecutionEvidenceRow {
+  const projections = row.executionEvidence.filter((item) => item.executionId === execution.executionId);
+  const projection = projections.length === 1 ? projections[0] : undefined;
+  const commitSha = text(execution.submission?.commitSha);
+  const iteration = Number.isInteger(execution.iteration) ? execution.iteration : undefined;
+  const reviews = commitSha === undefined || iteration === undefined ? [] : row.snapshot.reviews.filter((review) =>
+    review.executionId === execution.executionId && review.commitSha === commitSha && review.iteration === iteration);
+  const reviewIds = new Set(reviews.map(({ reviewId }) => reviewId));
+  const consents = row.snapshot.consents.filter((consent) =>
+    consent.executionId === execution.executionId && reviewIds.has(consent.reviewId));
+  const gateWitnesses = commitSha === undefined || iteration === undefined ? [] : row.snapshot.gateWitnesses.filter((witness) =>
+    witness.executionId === execution.executionId && witness.commitSha === commitSha && witness.iteration === iteration);
+  return {
+    taskId: row.taskId,
+    taskTitle,
+    taskUpdatedAt: row.updatedAt,
+    executionId: execution.executionId,
+    state: text(execution.state),
+    iteration,
+    commitSha,
+    claimedAt: text(execution.claimedAt),
+    submittedAt: nullableText(execution.submittedAt),
+    closedAt: nullableText(execution.closedAt),
+    origin: projection?.origin === "native" || projection?.origin === "archival" ? projection.origin : undefined,
+    outputs: adaptOutputs(execution, projection),
+    reviews,
+    consents,
+    gateWitnesses,
+    witnessAvailability: row.snapshotAvailability,
+    rawTask: row.snapshot.task,
+    rawExecution: execution,
+  };
+}
+
+function adaptOutputs(execution: Execution, projection: ProjectedEvidence | undefined): ExecutionEvidenceOutput[] {
+  const projected = projection?.outputs ?? [];
+  const submitted = execution.submission?.outputs ?? [];
+  const count = Math.max(projected.length, submitted.length);
+  return Array.from({ length: count }, (_, index) => adaptOutput(projected[index], submitted[index]));
+}
+
+function adaptOutput(output: ProjectedOutput | undefined, submittedLocator: string | undefined): ExecutionEvidenceOutput {
+  const candidate = output as Partial<ProjectedOutput> | undefined;
+  const checkerReceiptRef = candidate?.checkerReceiptRef === null ? null : text(candidate?.checkerReceiptRef);
+  const checkerResult = candidate?.checkerResult === "pass" || candidate?.checkerResult === "fail" || candidate?.checkerResult === "unknown"
+    ? candidate.checkerResult : undefined;
+  return {
+    evidenceId: text(candidate?.evidenceId),
+    locator: text(candidate?.locator),
+    substrate: candidate?.substrate === "repository-path" || candidate?.substrate === "uri"
+      || candidate?.substrate === "canonical-event" || candidate?.substrate === "opaque" ? candidate.substrate : undefined,
+    checkerReceiptRef,
+    checkerResult,
+    isPassingReceipt: checkerReceiptRef !== undefined && checkerReceiptRef !== null && checkerResult === "pass",
+    raw: { submission: submittedLocator, projection: output ?? null },
+  };
+}
+
+function compareExecutions(left: ExecutionEvidenceRow, right: ExecutionEvidenceRow): number {
+  const byTime = latestStamp(right).localeCompare(latestStamp(left));
+  if (byTime !== 0) return byTime;
+  const byTask = left.taskId.localeCompare(right.taskId);
+  return byTask !== 0 ? byTask : left.executionId.localeCompare(right.executionId);
+}
+
+function latestStamp(execution: ExecutionEvidenceRow): string {
+  return execution.closedAt ?? execution.submittedAt ?? execution.claimedAt ?? execution.taskUpdatedAt;
+}
+
+function text(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function nullableText(value: unknown): string | null | undefined {
+  return value === null ? null : text(value);
+}
+
+function json(value: unknown): string {
+  return JSON.stringify(value, null, 2) ?? UNKNOWN_EVIDENCE_FIELD;
+}

--- a/packages/gui/src/renderer/views/ExecutionEvidenceView.tsx
+++ b/packages/gui/src/renderer/views/ExecutionEvidenceView.tsx
@@ -1,0 +1,357 @@
+import { useEffect, useMemo, useState } from "react";
+import { CaretDown, Funnel, Lightning, Package, WarningCircle } from "@phosphor-icons/react";
+import type { TaskSnapshotProjectionRow } from "../../api/renderer-dto.ts";
+import { CopyContextButton } from "../components/CopyContextButton.tsx";
+import {
+  aggregateExecutionEvidence,
+  buildExecutionEvidenceContext,
+  checkerResultField,
+  field,
+  filterExecutionEvidence,
+  paginateExecutionEvidence,
+  receiptField,
+  type ExecutionEvidenceFilters,
+  type ExecutionEvidenceOutput,
+  type ExecutionEvidenceRow,
+  type ExecutionEvidenceStats,
+} from "../model/execution-evidence.ts";
+
+interface ExecutionEvidenceViewProps {
+  readonly rows: readonly TaskSnapshotProjectionRow[];
+  readonly queryStatus: "loading" | "ready" | "error";
+  readonly projectionStatus?: "ready" | "pending";
+  readonly isFetching?: boolean;
+  readonly error?: unknown;
+  readonly onReload: () => void;
+  readonly onReloadFromFirst: () => void;
+}
+
+export function ExecutionEvidenceView({
+  rows,
+  queryStatus,
+  projectionStatus = "ready",
+  isFetching = false,
+  error,
+  onReload,
+  onReloadFromFirst,
+}: ExecutionEvidenceViewProps) {
+  const [receipt, setReceipt] = useState<ExecutionEvidenceFilters["receipt"]>("all");
+  const [origin, setOrigin] = useState<ExecutionEvidenceFilters["origin"]>("all");
+  const [pageIndex, setPageIndex] = useState(0);
+  const model = useMemo(() => aggregateExecutionEvidence(rows), [rows]);
+  const filtered = useMemo(() => filterExecutionEvidence(model.executions, { receipt, origin }), [model.executions, receipt, origin]);
+  const page = useMemo(() => paginateExecutionEvidence(filtered, pageIndex), [filtered, pageIndex]);
+  const groups = useMemo(() => groupExecutions(page.executions), [page.executions]);
+
+  useEffect(() => setPageIndex(0), [receipt, origin]);
+  useEffect(() => {
+    if (pageIndex >= page.totalPages) setPageIndex(page.totalPages - 1);
+  }, [pageIndex, page.totalPages]);
+
+  const reloadFromFirst = () => {
+    setPageIndex(0);
+    onReloadFromFirst();
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-1 flex-col">
+      <header className="border-b border-border px-4 py-3">
+        <div className="flex flex-wrap items-baseline gap-3">
+          <h1 className="ui-title font-semibold">执行证据</h1>
+          <span className="font-mono text-[13px] text-text-faint">task → execution → output · verified snapshot</span>
+        </div>
+        <p className="mt-1 max-w-3xl text-[12px] leading-relaxed text-text-muted">
+          origin 与 checker receipt 均直接消费 daemon 投影；execution-level witness 只说明 execution cut，不等同 output receipt。
+        </p>
+      </header>
+
+      <StatsStrip stats={model.stats} />
+      <FilterBar
+        receipt={receipt}
+        origin={origin}
+        visible={filtered.length}
+        fetching={isFetching}
+        onReceipt={setReceipt}
+        onOrigin={setOrigin}
+      />
+
+      {projectionStatus === "pending" && queryStatus !== "error" && (
+        <div className="border-b border-stale/30 bg-stale/10 px-4 py-2 font-mono text-[11px] text-stale">
+          task snapshot 正在追赶 source revision；当前页可读但标记 stale，reload 会重读同一 query。
+        </div>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        {queryStatus === "loading" ? (
+          <EmptyState>正在读取 execution evidence projection…</EmptyState>
+        ) : queryStatus === "error" ? (
+          <ErrorState error={error} onReload={onReload} onReloadFromFirst={reloadFromFirst} />
+        ) : groups.length === 0 ? (
+          <EmptyState>当前 snapshot 在所选 filter 下没有 execution evidence。</EmptyState>
+        ) : (
+          <div className="space-y-3">
+            {groups.map((group) => <TaskEvidenceGroup key={group.taskId} group={group} />)}
+          </div>
+        )}
+      </div>
+
+      {queryStatus === "ready" && (
+        <PageControls
+          pageNumber={page.pageNumber}
+          totalPages={page.totalPages}
+          hasPrevious={page.hasPreviousPage}
+          hasNext={page.hasNextPage}
+          disabled={isFetching}
+          onPrevious={() => setPageIndex((value) => Math.max(0, value - 1))}
+          onNext={() => setPageIndex((value) => value + 1)}
+          onReload={onReload}
+          onReloadFromFirst={reloadFromFirst}
+        />
+      )}
+    </div>
+  );
+}
+
+function StatsStrip({ stats }: { readonly stats: ExecutionEvidenceStats }) {
+  const values = [
+    ["executions", stats.executions],
+    ["有 execution 的 tasks", stats.tasksWithExecutions],
+    ["outputs", stats.outputs],
+    ["origin=archival", stats.archivalExecutions],
+    ["origin=native", stats.nativeExecutions],
+    ["passing receipt outputs", stats.passingReceiptOutputs],
+  ] as const;
+  return (
+    <div className="flex flex-wrap gap-x-4 gap-y-1 border-b border-border bg-surface px-4 py-2 font-mono text-[11px]">
+      {values.map(([label, value]) => (
+        <span key={label} className="inline-flex items-baseline gap-1 text-text-faint">
+          <strong className="text-[13px] text-text">{value}</strong>{label}
+        </span>
+      ))}
+      {stats.unknownOriginExecutions > 0 && (
+        <span className="text-status-unknown">unknown origin {stats.unknownOriginExecutions}</span>
+      )}
+    </div>
+  );
+}
+
+function FilterBar({ receipt, origin, visible, fetching, onReceipt, onOrigin }: {
+  readonly receipt: ExecutionEvidenceFilters["receipt"];
+  readonly origin: ExecutionEvidenceFilters["origin"];
+  readonly visible: number;
+  readonly fetching: boolean;
+  readonly onReceipt: (value: ExecutionEvidenceFilters["receipt"]) => void;
+  readonly onOrigin: (value: ExecutionEvidenceFilters["origin"]) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 border-b border-border bg-surface/50 px-4 py-2">
+      <Funnel weight="bold" className="text-[12px] text-text-faint" />
+      <span className="mr-1 font-mono text-[10px] uppercase text-text-faint">receipt</span>
+      <FilterChip label="全部" active={receipt === "all"} onClick={() => onReceipt("all")} />
+      <FilterChip label="有通过 receipt" active={receipt === "passing"} tone="good" onClick={() => onReceipt("passing")} />
+      <FilterChip label="无 receipt" active={receipt === "no-receipt"} tone="warn" onClick={() => onReceipt("no-receipt")} />
+      <span className="ml-2 mr-1 font-mono text-[10px] uppercase text-text-faint">origin</span>
+      <FilterChip label="全部" active={origin === "all"} onClick={() => onOrigin("all")} />
+      <FilterChip label="归档" active={origin === "archival"} tone="warn" onClick={() => onOrigin("archival")} />
+      <FilterChip label="原生" active={origin === "native"} tone="good" onClick={() => onOrigin("native")} />
+      <span className="ml-auto font-mono text-[11px] text-text-faint">{fetching ? "reload…" : `${visible} visible executions`}</span>
+    </div>
+  );
+}
+
+function FilterChip({ label, active, tone = "neutral", onClick }: {
+  readonly label: string;
+  readonly active: boolean;
+  readonly tone?: "neutral" | "good" | "warn";
+  readonly onClick: () => void;
+}) {
+  const activeTone = tone === "good" ? "border-success/40 bg-success/10 text-success"
+    : tone === "warn" ? "border-stale/40 bg-stale/10 text-stale" : "border-border-strong bg-surface-raised text-text";
+  return (
+    <button type="button" aria-pressed={active} onClick={onClick}
+      className={`rounded-md border px-2 py-1 font-mono text-[11px] ${active ? activeTone : "border-border text-text-faint opacity-65 hover:opacity-100"}`}>
+      {label}
+    </button>
+  );
+}
+
+interface TaskEvidenceGroupModel {
+  readonly taskId: string;
+  readonly title: string;
+  readonly executions: readonly ExecutionEvidenceRow[];
+}
+
+function TaskEvidenceGroup({ group }: { readonly group: TaskEvidenceGroupModel }) {
+  const [expanded, setExpanded] = useState(true);
+  const outputCount = group.executions.reduce((total, item) => total + item.outputs.length, 0);
+  return (
+    <section className="overflow-hidden rounded-lg border border-border bg-surface">
+      <button type="button" aria-expanded={expanded} onClick={() => setExpanded((value) => !value)}
+        className="flex w-full items-center gap-2 px-3 py-2.5 text-left hover:bg-surface-raised/50">
+        <CaretDown weight="bold" className={`shrink-0 text-text-faint transition-transform ${expanded ? "" : "-rotate-90"}`} />
+        <span className="min-w-0 flex-1">
+          <strong className="block truncate text-[14px] text-text">{group.title}</strong>
+          <span className="block truncate font-mono text-[11px] text-text-faint">{group.taskId}</span>
+        </span>
+        <span className="font-mono text-[11px] text-text-muted">{group.executions.length} executions · {outputCount} outputs</span>
+      </button>
+      {expanded && (
+        <div className="space-y-2 border-t border-border p-2">
+          {group.executions.map((execution) => <ExecutionBlock key={execution.executionId} execution={execution} />)}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ExecutionBlock({ execution }: { readonly execution: ExecutionEvidenceRow }) {
+  const [expanded, setExpanded] = useState(false);
+  const passing = execution.outputs.filter(({ isPassingReceipt }) => isPassingReceipt).length;
+  return (
+    <article className="rounded-md border border-border bg-bg/35">
+      <button type="button" aria-expanded={expanded} onClick={() => setExpanded((value) => !value)}
+        className="flex w-full flex-wrap items-center gap-2 px-3 py-2 text-left hover:bg-surface-raised/45">
+        <CaretDown weight="bold" className={`text-text-faint transition-transform ${expanded ? "" : "-rotate-90"}`} />
+        <OriginBadge origin={execution.origin} />
+        <span className="rounded border border-border px-1.5 py-0.5 font-mono text-[10px] text-text-muted">{field(execution.state)}</span>
+        <strong className="font-mono text-[12px] text-text">{execution.executionId}</strong>
+        <span className="font-mono text-[11px] text-text-faint">iteration {field(execution.iteration)} · commit {short(execution.commitSha)}</span>
+        <span className="ml-auto font-mono text-[11px] text-text-muted">{execution.outputs.length} outputs · {passing} passing</span>
+      </button>
+
+      <div className="border-t border-border/70 px-3 py-2">
+        <div className="mb-1.5 flex flex-wrap gap-3 font-mono text-[10px] text-text-faint">
+          <span>output 摘要（展开查看全量原文）</span>
+          <span>execution-level witnesses: review {execution.reviews.length} · consent {execution.consents.length} · gate {execution.gateWitnesses.length}</span>
+          <span className="text-status-unknown">不等同 output receipt</span>
+        </div>
+        {execution.outputs.length === 0 ? (
+          <div className="rounded border border-dashed border-border px-2 py-2 font-mono text-[11px] text-text-faint">该 execution 没有 output。</div>
+        ) : (
+          <div className="space-y-1">
+            {execution.outputs.slice(0, 3).map((output, index) => (
+              <OutputSummary key={`${output.evidenceId ?? "unknown"}-${index}`} output={output} />
+            ))}
+            {execution.outputs.length > 3 && <div className="font-mono text-[10px] text-text-faint">+ {execution.outputs.length - 3} outputs，展开查看</div>}
+          </div>
+        )}
+      </div>
+
+      {expanded && (
+        <div className="space-y-3 border-t border-border px-3 py-3">
+          <div className="space-y-2">
+            {execution.outputs.map((output, index) => <OutputDetail key={`${output.evidenceId ?? "unknown"}-${index}`} execution={execution} output={output} />)}
+          </div>
+          <WitnessPanel execution={execution} />
+        </div>
+      )}
+    </article>
+  );
+}
+
+function OriginBadge({ origin }: { readonly origin: ExecutionEvidenceRow["origin"] }) {
+  if (origin === "native") return <span className="inline-flex items-center gap-1 rounded border border-success/30 bg-success/10 px-1.5 py-0.5 font-mono text-[10px] text-success"><Lightning weight="bold" />原生</span>;
+  if (origin === "archival") return <span className="inline-flex items-center gap-1 rounded border border-stale/30 bg-stale/10 px-1.5 py-0.5 font-mono text-[10px] text-stale"><Package weight="bold" />归档</span>;
+  return <span className="inline-flex items-center gap-1 rounded border border-status-unknown/30 px-1.5 py-0.5 font-mono text-[10px] text-status-unknown"><WarningCircle weight="bold" />{field(origin)}</span>;
+}
+
+function OutputSummary({ output }: { readonly output: ExecutionEvidenceOutput }) {
+  return (
+    <div className="grid gap-x-3 gap-y-0.5 rounded border border-border/70 bg-surface-raised/35 px-2 py-1.5 font-mono text-[10px] md:grid-cols-[minmax(11rem,0.8fr)_minmax(14rem,1.4fr)_minmax(10rem,0.8fr)]">
+      <span className="truncate text-text">{field(output.evidenceId)}</span>
+      <span className="truncate text-text-muted">{field(output.substrate)} · {field(output.locator)}</span>
+      <span className={output.isPassingReceipt ? "text-success" : output.checkerReceiptRef === null ? "text-stale" : "text-status-unknown"}>
+        {receiptField(output.checkerReceiptRef)} · {checkerResultField(output.checkerResult)}
+      </span>
+    </div>
+  );
+}
+
+function OutputDetail({ execution, output }: { readonly execution: ExecutionEvidenceRow; readonly output: ExecutionEvidenceOutput }) {
+  return (
+    <section className="rounded-md border border-border bg-surface-raised/30 p-2.5">
+      <div className="grid gap-1 font-mono text-[11px] sm:grid-cols-2">
+        <Field label="evidenceId" value={field(output.evidenceId)} />
+        <Field label="substrate" value={field(output.substrate)} />
+        <Field label="locator" value={field(output.locator)} />
+        <Field label="checker receipt ref" value={receiptField(output.checkerReceiptRef)} />
+        <Field label="checker result" value={checkerResultField(output.checkerResult)} />
+      </div>
+      <div className="mt-2 flex justify-end">
+        <CopyContextButton compact buildText={() => buildExecutionEvidenceContext(execution, output)} />
+      </div>
+    </section>
+  );
+}
+
+function WitnessPanel({ execution }: { readonly execution: ExecutionEvidenceRow }) {
+  return (
+    <section className="rounded-md border border-status-unknown/25 bg-status-unknown/5 p-2.5">
+      <div className="flex items-center gap-2 text-[11px] text-status-unknown">
+        <WarningCircle weight="bold" />
+        <strong>execution-level witnesses · 不等同 output receipt</strong>
+      </div>
+      <div className="mt-2 grid gap-2 font-mono text-[10px] text-text-muted md:grid-cols-3">
+        <WitnessList label="reviews · snapshot-validated" values={execution.reviews.map((item) => `${item.reviewId} · ${item.verdict}`)} />
+        <WitnessList label={`consents · ${execution.witnessAvailability.consents}`} values={execution.consents.map((item) => `${item.consentId} → ${item.reviewId}`)} />
+        <WitnessList label={`gate · ${execution.witnessAvailability.gateWitnesses}`} values={execution.gateWitnesses.map((item) => `${item.gateId} · ${item.receiptId} · ${item.result}`)} />
+      </div>
+    </section>
+  );
+}
+
+function WitnessList({ label, values }: { readonly label: string; readonly values: readonly string[] }) {
+  return <div><strong className="text-text-faint">{label}</strong>{values.length ? values.map((value) => <div key={value} className="mt-1 break-all">{value}</div>) : <div className="mt-1 text-text-faint">none / 当前 cut 无记录</div>}</div>;
+}
+
+function Field({ label, value }: { readonly label: string; readonly value: string }) {
+  return <span className="min-w-0"><strong className="text-text-faint">{label}: </strong><span className="break-all text-text-muted">{value}</span></span>;
+}
+
+function PageControls({ pageNumber, totalPages, hasPrevious, hasNext, disabled, onPrevious, onNext, onReload, onReloadFromFirst }: {
+  readonly pageNumber: number; readonly totalPages: number; readonly hasPrevious: boolean; readonly hasNext: boolean; readonly disabled: boolean;
+  readonly onPrevious: () => void; readonly onNext: () => void; readonly onReload: () => void; readonly onReloadFromFirst: () => void;
+}) {
+  const button = "rounded border border-border px-2.5 py-1 font-mono text-[11px] text-text-muted disabled:cursor-not-allowed disabled:opacity-40";
+  return (
+    <nav aria-label="execution evidence 分页" className="flex flex-wrap items-center justify-center gap-2 border-t border-border bg-surface px-4 py-2">
+      <button type="button" className={button} disabled={disabled || !hasPrevious} onClick={onPrevious}>上一页</button>
+      <span className="min-w-20 text-center font-mono text-[11px] text-text-faint">第 {pageNumber} / {totalPages} 页</span>
+      <button type="button" className={button} disabled={disabled || !hasNext} onClick={onNext}>下一页</button>
+      <button type="button" className={button} disabled={disabled} onClick={onReload}>reload 当前 query</button>
+      <button type="button" className={button} disabled={disabled} onClick={onReloadFromFirst}>从第一页重新加载</button>
+    </nav>
+  );
+}
+
+function ErrorState({ error, onReload, onReloadFromFirst }: { readonly error: unknown; readonly onReload: () => void; readonly onReloadFromFirst: () => void }) {
+  return (
+    <div className="rounded-lg border border-danger/40 bg-danger/5 px-4 py-8 text-center text-[13px] text-danger">
+      <WarningCircle weight="duotone" className="mx-auto mb-2 text-xl" />
+      <div>读取 execution evidence 失败：{error instanceof Error ? error.message : String(error ?? "unknown")}</div>
+      <div className="mt-3 flex justify-center gap-2">
+        <button type="button" className="rounded border border-danger/40 px-3 py-1.5 font-mono text-[11px]" onClick={onReload}>重试当前查询</button>
+        <button type="button" className="rounded border border-danger/40 px-3 py-1.5 font-mono text-[11px]" onClick={onReloadFromFirst}>从第一页重新加载</button>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ children }: { readonly children: string }) {
+  return <div className="rounded-lg border border-dashed border-border px-4 py-8 text-center text-[13px] text-text-faint">{children}</div>;
+}
+
+function groupExecutions(executions: readonly ExecutionEvidenceRow[]): TaskEvidenceGroupModel[] {
+  const groups = new Map<string, TaskEvidenceGroupModel>();
+  for (const execution of executions) {
+    const current = groups.get(execution.taskId);
+    groups.set(execution.taskId, current
+      ? { ...current, executions: [...current.executions, execution] }
+      : { taskId: execution.taskId, title: execution.taskTitle, executions: [execution] });
+  }
+  return [...groups.values()];
+}
+
+function short(value: string | undefined): string {
+  return value ? value.slice(0, 10) : field(value);
+}

--- a/packages/gui/test/execution-evidence.vitest.ts
+++ b/packages/gui/test/execution-evidence.vitest.ts
@@ -1,0 +1,169 @@
+// harness-test-tier: fast
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { REPLAY_TASK_GRAPH } from "../../kernel/src/index.ts";
+import type { TaskSnapshotProjectionRow } from "../src/api/renderer-dto.ts";
+import {
+  EXECUTION_EVIDENCE_PAGE_SIZE,
+  aggregateExecutionEvidence,
+  buildExecutionEvidenceContext,
+  filterExecutionEvidence,
+  paginateExecutionEvidence,
+} from "../src/renderer/model/execution-evidence.ts";
+import { ExecutionEvidenceView } from "../src/renderer/views/ExecutionEvidenceView.tsx";
+
+const SHA_A = "a".repeat(40);
+const SHA_B = "b".repeat(40);
+const DIGEST = `sha256:${"c".repeat(64)}` as const;
+const ACTOR = { principal: { personId: "person-owner" }, executor: { kind: "agent" as const, id: "fact-execution-migration" } };
+
+describe("execution evidence model", () => {
+  it("uses projected origin and joins witnesses only through the exact execution cut", () => {
+    const model = aggregateExecutionEvidence([row()]);
+    const execution = model.executions[0]!;
+
+    expect(execution.origin).toBe("native");
+    expect(execution.reviews.map(({ reviewId }) => reviewId)).toEqual(["review-matching"]);
+    expect(execution.consents.map(({ consentId }) => consentId)).toEqual(["consent-matching"]);
+    expect(execution.gateWitnesses.map(({ witnessId }) => witnessId)).toEqual(["gate-matching"]);
+    expect(model.stats).toEqual({
+      executions: 1,
+      tasksWithExecutions: 1,
+      outputs: 2,
+      nativeExecutions: 1,
+      archivalExecutions: 0,
+      unknownOriginExecutions: 0,
+      passingReceiptOutputs: 1,
+    });
+  });
+
+  it("keeps output receipts separate from execution gate witnesses and exposes missing projection fields", () => {
+    const source = row();
+    const malformed = {
+      ...source,
+      executionEvidence: [{ executionId: "execution-1", origin: "archival", outputs: [
+        { checkerReceiptRef: null, checkerResult: "unknown" },
+      ] }],
+      snapshot: {
+        ...source.snapshot,
+        executions: [{ ...source.snapshot.executions[0]!, submission: {
+          ...source.snapshot.executions[0]!.submission!, outputs: ["artifacts/unprojected.txt"],
+        } }],
+      },
+    } as unknown as TaskSnapshotProjectionRow;
+
+    const output = aggregateExecutionEvidence([malformed]).executions[0]!.outputs[0]!;
+    expect(output).toMatchObject({ evidenceId: undefined, locator: undefined, substrate: undefined, checkerReceiptRef: null, checkerResult: "unknown" });
+    expect(output.checkerReceiptRef).not.toBe("gate-receipt-matching");
+  });
+
+  it("filters by output receipt and explicit origin, then paginates a stable 25-execution order", () => {
+    const executions = Array.from({ length: 26 }, (_, index) => execution(`execution-${String(index).padStart(2, "0")}`, index));
+    const source = row({
+      snapshot: { ...row().snapshot, executions },
+      executionEvidence: executions.map((item, index) => ({
+        executionId: item.executionId,
+        origin: index % 2 === 0 ? "native" as const : "archival" as const,
+        outputs: [{ evidenceId: `evidence_${String(index).padStart(24, "0")}`, locator: `output-${index}.txt`, substrate: "repository-path" as const,
+          checkerReceiptRef: index % 3 === 0 ? `receipt-${index}` : null, checkerResult: index % 3 === 0 ? "pass" as const : "unknown" as const }],
+      })),
+    });
+    const model = aggregateExecutionEvidence([source]);
+
+    expect(EXECUTION_EVIDENCE_PAGE_SIZE).toBe(25);
+    expect(paginateExecutionEvidence(model.executions, 0)).toMatchObject({ pageNumber: 1, totalPages: 2, hasNextPage: true });
+    expect(paginateExecutionEvidence(model.executions, 0).executions).toHaveLength(25);
+    expect(paginateExecutionEvidence(model.executions, 1).executions).toHaveLength(1);
+    expect(model.executions.map(({ executionId }) => executionId).slice(0, 3)).toEqual(["execution-25", "execution-24", "execution-23"]);
+    expect(filterExecutionEvidence(model.executions, { receipt: "passing", origin: "archival" })
+      .every((item) => item.origin === "archival" && item.outputs.some((output) => output.isPassingReceipt))).toBe(true);
+    expect(filterExecutionEvidence(model.executions, { receipt: "no-receipt", origin: "native" })
+      .every((item) => item.origin === "native" && item.outputs.some((output) => output.checkerReceiptRef === null))).toBe(true);
+  });
+
+  it("copies task, execution, output originals, projected fields, receipt, and copy time", () => {
+    const executionRow = aggregateExecutionEvidence([row()]).executions[0]!;
+    const context = buildExecutionEvidenceContext(executionRow, executionRow.outputs[0]!, () => "2026-08-14T12:34:56.000Z");
+
+    for (const text of ["task 原文", "execution 原文", "output 原文", "evidenceId", "checkerReceiptRef", "receipt-pass", "2026-08-14T12:34:56.000Z"]) {
+      expect(context).toContain(text);
+    }
+  });
+});
+
+describe("ExecutionEvidenceView", () => {
+  it("renders stats, filters, compact output summaries, explicit unknown, and separate execution witnesses", () => {
+    const source = row();
+    const malformed = { ...source, executionEvidence: [{ executionId: "execution-1", origin: "native", outputs: [
+      { locator: "artifacts/result.txt", checkerReceiptRef: null, checkerResult: "unknown" },
+    ] }] } as unknown as TaskSnapshotProjectionRow;
+    const markup = renderToStaticMarkup(createElement(ExecutionEvidenceView, {
+      rows: [malformed], queryStatus: "ready", onReload: vi.fn(), onReloadFromFirst: vi.fn(),
+    }));
+
+    for (const text of ["执行证据", "有通过 receipt", "无 receipt", "归档", "原生", "unknown / 未投影", "execution-level witnesses", "不等同 output receipt"]) {
+      expect(markup).toContain(text);
+    }
+    expect(markup).toContain('aria-expanded="true"');
+    expect(markup).toContain('aria-expanded="false"');
+  });
+
+  it("offers current-query retry and a first-page invalidation path on failure", () => {
+    const markup = renderToStaticMarkup(createElement(ExecutionEvidenceView, {
+      rows: [], queryStatus: "error", error: new Error("bridge offline"), onReload: vi.fn(), onReloadFromFirst: vi.fn(),
+    }));
+    expect(markup).toContain("重试当前查询");
+    expect(markup).toContain("从第一页重新加载");
+    expect(markup).toContain("bridge offline");
+  });
+});
+
+function row(overrides: Partial<TaskSnapshotProjectionRow> = {}): TaskSnapshotProjectionRow {
+  const taskId = overrides.taskId ?? "task-evidence";
+  const base: TaskSnapshotProjectionRow = {
+    taskId, packagePath: `tasks/${taskId}`, workspaceRevision: 9, updatedAt: "2026-08-14T09:00:00.000Z",
+    snapshot: {
+      revision: 9,
+      task: { schema: "task/v1", taskId, title: "Evidence truth", taskClass: "standard", status: "in_review", graph: REPLAY_TASK_GRAPH,
+        currentNode: "review", iteration: 0, createdBy: ACTOR, completionGateIds: ["build"], presetSnapshotDigest: null },
+      executions: [execution("execution-1", 1)],
+      reviews: [review("review-matching", SHA_A, 0), review("review-other-cut", SHA_B, 1)],
+      consents: [consent("consent-matching", "review-matching"), consent("consent-other-cut", "review-other-cut")],
+      codeDocWitnesses: [],
+      gateWitnesses: [gate("gate-matching", SHA_A, 0), gate("gate-other-cut", SHA_B, 1)],
+      edgesTaken: [], lease: null,
+    },
+    snapshotAvailability: { consents: "known", codeDocWitnesses: "known", gateWitnesses: "known" },
+    placement: { moduleKeys: ["gui"], productLines: ["harness"], parentTaskId: null, origin: "native", engine: "kernel/task-lifecycle/v1",
+      packageDisposition: "active", provenance: [{ kind: "canonical-event", ref: `task/${taskId}` }] },
+    executionEvidence: [{ executionId: "execution-1", origin: "native", outputs: [
+      { evidenceId: `evidence_${"1".repeat(24)}`, locator: "artifacts/result.txt", substrate: "repository-path", checkerReceiptRef: "receipt-pass", checkerResult: "pass" },
+      { evidenceId: `evidence_${"2".repeat(24)}`, locator: "https://example.test/log", substrate: "uri", checkerReceiptRef: null, checkerResult: "unknown" },
+    ] }],
+  };
+  return { ...base, ...overrides };
+}
+
+function execution(executionId: string, minute: number) {
+  return { schema: "execution/v1" as const, executionId, taskId: "task-evidence", nodeId: "implementation" as const, iteration: 0 as const,
+    state: "submitted" as const, actor: ACTOR, claimedAt: `2026-08-14T08:${String(minute).padStart(2, "0")}:00.000Z`, submittedAt: `2026-08-14T08:${String(minute).padStart(2, "0")}:30.000Z`, closedAt: null,
+    submission: { completionClaim: "Evidence delivered", deliverables: ["result"], outputs: ["artifacts/result.txt", "https://example.test/log"],
+      verificationNotes: ["checked"], knownGaps: [], residualRisks: [], commitSha: SHA_A } };
+}
+
+function review(reviewId: string, commitSha: string, iteration: 0 | 1) {
+  return { schema: "review/v1" as const, reviewId, taskId: "task-evidence", executionId: "execution-1", verdict: "approved" as const, actor: ACTOR,
+    capabilityRef: "capability/review", reason: "verified", evidenceChecked: ["artifacts/result.txt"], commitSha, iteration, contentDigest: DIGEST, reviewedAt: "2026-08-14T08:10:00.000Z" };
+}
+
+function consent(consentId: string, reviewId: string) {
+  return { schema: "review-consent/v1" as const, consentId, taskId: "task-evidence", executionId: "execution-1", reviewId,
+    reviewDigest: DIGEST, contentDigest: DIGEST, actor: ACTOR, source: "local" as const, consentedAt: "2026-08-14T08:11:00.000Z" };
+}
+
+function gate(witnessId: string, commitSha: string, iteration: 0 | 1) {
+  return { schema: "completion-gate-witness/v1" as const, witnessId, receiptId: witnessId === "gate-matching" ? "gate-receipt-matching" : "gate-receipt-other",
+    checkerId: "build", gateId: "build", result: "pass" as const, taskId: "task-evidence", executionId: "execution-1", commitSha, iteration,
+    actor: ACTOR, source: "local" as const, verifiedAt: "2026-08-14T08:12:00.000Z" };
+}

--- a/packages/gui/test/renderer-app-model.vitest.ts
+++ b/packages/gui/test/renderer-app-model.vitest.ts
@@ -38,6 +38,7 @@ describe("renderer app model", () => {
       "detail",
       "doc-viewer",
       "review-queue",
+      "execution-evidence",
       "graph"
     ]);
   });

--- a/packages/gui/test/renderer-no-node.test.ts
+++ b/packages/gui/test/renderer-no-node.test.ts
@@ -15,6 +15,7 @@ test("renderer model has no Node or Electron privileged surface", () => {
     "detail",
     "doc-viewer",
     "review-queue",
+    "execution-evidence",
     "graph"
   ]);
 });

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -78,6 +78,11 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
     assert.equal(submitted.ok, true, JSON.stringify(submitted)); assert.equal(submitted.outcome, "applied");
     const afterSubmit = parseDaemonGuiReadResult("repo.tasks.list", await bridge.invoke("getTasks", null));
     assert.equal(afterSubmit.rows[0]?.snapshot.task?.status, "in_review"); assert.equal(afterSubmit.rows[0]?.snapshot.lease, null);
+    const evidence = afterSubmit.rows[0]?.executionEvidence.find((item) => item.executionId === executionId), output = evidence?.outputs[0];
+    assert.equal(evidence?.origin, "native"); assert.match(output?.evidenceId ?? "", /^evidence_[0-9a-f]{24}$/u);
+    assert.deepEqual(output && { locator: output.locator, substrate: output.substrate, checkerReceiptRef: output.checkerReceiptRef, checkerResult: output.checkerResult }, {
+      locator: "packages/gui/test/service-bridge.test.ts", substrate: "repository-path", checkerReceiptRef: null, checkerResult: "unknown"
+    });
   } finally {
     await fixture.stop();
     restoreEnv("HARNESS_DAEMON_USER_ROOT", previous.userRoot); restoreEnv("HARNESS_DAEMON_ID", previous.daemonId);

--- a/tools/gates/line-budgets.json
+++ b/tools/gates/line-budgets.json
@@ -7,7 +7,7 @@
     "doc-sync": 349,
     "preset": 366,
     "cli": 140,
-    "gui": 17769,
+    "gui": 18391,
     "daemon": 992,
     "fleet": 165,
     "authority-write-path": 0,

--- a/tools/gates/test/fixtures/gui-s2c-execution-evidence-production-paths.json
+++ b/tools/gates/test/fixtures/gui-s2c-execution-evidence-production-paths.json
@@ -1,0 +1,6 @@
+[
+  { "path": "packages/gui/src/renderer/App.tsx", "module": "gui" },
+  { "path": "packages/gui/src/renderer/app-model.ts", "module": "gui" },
+  { "path": "packages/gui/src/renderer/model/execution-evidence.ts", "module": "gui" },
+  { "path": "packages/gui/src/renderer/views/ExecutionEvidenceView.tsx", "module": "gui" }
+]

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -10,6 +10,7 @@ export const guiVitestManifest = [
   "packages/gui/test/graph-colormode.vitest.ts",
   "packages/gui/test/graph-view.vitest.ts",
   "packages/gui/test/decisions-verdict.vitest.ts",
+  "packages/gui/test/execution-evidence.vitest.ts",
   "packages/gui/test/entity-workspace.vitest.ts",
   "packages/gui/test/navigation-history.vitest.ts"
 ];


### PR DESCRIPTION
# English

## Summary

W5 GUI S2-C — the closing S2 slice: the execution evidence view (REQ-08) lands on canonical truth. Tasks aggregate to executions to outputs on the validated task snapshot; review/gate witnesses join by exact executionId+commitSha+iteration, consents indirectly via the same-cut reviewId. Every output renders the U-12 tuple (stable evidenceId, locator/substrate, checkerReceiptRef + result) with per-field honesty: anything missing or invalid shows `unknown / 未投影`, `passing` requires the output's own checker receipt with result=pass — execution-level gate witnesses are never promoted into output receipts, and origin comes only from the projection's explicit native/archival field (no archive migration-constant guessing). Stats (executions/tasks/outputs/origin/passing), passing/no-receipt and archival/native filters, collapsible task/execution groups with summary-first outputs, stable 25-per-page client paging, reload-current-query and reset-to-first-page-then-invalidate recovery, and a copy context carrying task/execution/output raw text + full tuple + receipt + timestamp. A new「执行证据」workspace joins App navigation with no paged read, no generic run, no new backend contract.

## What Changed

- `feat(gui): land execution evidence view` (fe60d8b9): evidence aggregation model (sort/filter/paging/join); output truth + unknown handling; copy context; ExecutionEvidenceView with loading/pending/error/empty states; App wiring via existing `useTasksQuery`.
- Gate surfaces: line-budgets gui 17769→18391 (+624/-2; within existing verified gui-22100 receipt, headroom 3,709); fixture `gui-s2c-execution-evidence-production-paths.json` same-commit; new fast-tier test registered in `tools/gui-test-manifest.mjs`. Only the gui key touched; daemon/kernel/preset untouched.

## Task And Scope

- Harness task: task_01KZX9CY7KP100X0QM5TAYPAS4 (gui-s2-design.md §4.3/§6 S2-C; gui-s2-adjudication.md U-12 adopted)
- Branch: codex/gui-s2c-execution-evidence (base rebuild/main 95d76551, current)
- Public scope: packages/gui only + gate budgets/fixture/test-manifest
- Out of scope: GUI S3 (needs its own design/adjudication round); U-13 deferred.

## Version Impact

- Version: no version change (pre-cutover rebuild line).
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: line-budgets.json gui key (within existing verified receipt), governance fixture + gui test manifest same-commit
- Authority: dec_01KZWTAPXF24FR62Q53Y42JGMV (restoration charter) + gui-s2-adjudication.md (U-12 adopted)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

Production-Delta: +624/-2

- Base `origin/rebuild/main` SHA: 95d76551
- Branch merge-base with `origin/rebuild/main`: 95d76551
- Last `git fetch origin` time: 2026-08-14 ~15:45 CST
- Sync method: none needed (base current)
- Public diff command: `git diff 95d76551..fe60d8b9`
- Private evidence commit/path: harness/tasks/task_01KZX9CY7KP100X0QM5TAYPAS4-.../artifacts/report-gui-s2c.md
- Reviewer evidence path: same artifacts; mechanical verify-findings ALL-VERIFIED
- GitHub Actions `rewrite-ci` run URL: pending (green before merge)
- [x] `git diff --check`
- [x] `npm run check:local` exit 0
- [x] Targeted tests: explicit-origin (archive-constant executor stays native), three-key join, output/gate receipt isolation, unknown matrix, filters, stable 25-paging, copy raw text, failure-recovery UI; real resident-daemon start→progress→structured submit→reread with stable evidenceId/origin/locator/substrate and null/unknown checker tuple
- [x] GUI production build green
- [ ] GitHub Actions `rewrite-ci` passed (authoritative full gate — pending at PR-open time)
- Not run, and why: Electron desktop E2E per mission stays CI unverified; CEO desktop hands-on happens post-merge with the S2-A/B items.

## Review Evidence

- Self-review: CEO checked the implementation against design §4.3 line-by-line (aggregation/join keys, no-witness-promotion, no origin guessing, summary-first rendering, paging/recovery semantics, copy context contents); confirmed only packages/gui touched and fixture+manifest present.
- Reviewer subagent: mechanical verify-findings ALL-VERIFIED.
- Human review: pending (this PR + post-merge desktop hands-on)
- Blocking findings: none

## Residual Risk

- Electron desktop E2E pending CEO hands-on after merge (S2-A/B/C batch).
- Output-level checker facts remain empty authority-side today; the view honestly shows unknown until a real fact source exists.

---

# 中文

## 概要

W5 GUI S2-C——S2 收官片:execution evidence 视图(REQ-08)落 canonical 真值。task → execution → output 在已验证 snapshot 上聚合;review/gate witness 按 executionId+commitSha+iteration 精确 join,consent 经同 cut reviewId 间接 join。每个 output 渲染 U-12 tuple(stable evidenceId、locator/substrate、checkerReceiptRef+result),逐字段诚实:缺失/非法显 `unknown / 未投影`,`passing` 只在 output 自身 checker receipt result=pass 时成立——execution 级 gate witness 绝不冒充 output receipt,origin 只来自投影显式 native/archival 字段(不用 archive 迁移常量猜)。stats(executions/tasks/outputs/origin/passing)、passing/no-receipt 与 archival/native filters、task/execution 折叠+摘要先行、稳定每页 25 条前端分页、reload 当前 query 与「从第一页」清态后 invalidate 恢复、copy context 带 task/execution/output 原文+完整 tuple+receipt+时间。新增「执行证据」工作区导航,无 paged read、无 generic run、无新后端契约。

## 改了什么

- `feat(gui): land execution evidence view`(fe60d8b9):evidence 聚合模型(排序/筛选/分页/join);output 真值与 unknown 处理;copy context;ExecutionEvidenceView 全状态;App 经既有 `useTasksQuery` 接线。
- 门面:line-budgets gui 17769→18391(+624/-2;在现役 gui-22100 receipt 内,余 3,709);fixture `gui-s2c-execution-evidence-production-paths.json` 同 commit;新 fast-tier 测试登记 `tools/gui-test-manifest.mjs`。只动 gui key;daemon/kernel/preset 零接触。

## 任务与范围

- Harness task:task_01KZX9CY7KP100X0QM5TAYPAS4(设计 §4.3/§6 S2-C;裁决 U-12 采纳)
- 分支:codex/gui-s2c-execution-evidence(base rebuild/main 95d76551,当前)
- 公开范围:仅 packages/gui + gate budgets/fixture/test-manifest
- 范围外:GUI S3(需自己的设计/裁决轮);U-13 defer。

## 版本影响

- 版本:无变化(cutover 前 rebuild 线)。
- 发布影响:不发布。

## 治理声明

- 触碰 protected surface:是
- 范围:line-budgets.json gui key(在现役 receipt 内)、治理 fixture + gui test manifest 同 commit
- 授权:dec_01KZWTAPXF24FR62Q53Y42JGMV(恢复章程)+ gui-s2-adjudication.md(U-12 采纳)
- 机器检查边界:本 PR 仅断言声明存在;是否真实充分由评审判断。
- Break-glass:否

## 验证

- Base `origin/rebuild/main` SHA:95d76551
- merge-base:95d76551
- 最近 fetch:2026-08-14 约 15:45 CST
- 同步方式:无需(base 即当前)
- 公开 diff 命令:`git diff 95d76551..fe60d8b9`
- 私有证据:任务包 artifacts/report-gui-s2c.md
- 评审证据:verify-findings ALL-VERIFIED
- [x] `git diff --check`
- [x] `npm run check:local` exit 0
- [x] 定向测试:显式 origin(archive 常量 executor 仍 native)、三键 join、output/gate receipt 隔离、unknown 矩阵、filters、稳定 25 分页、copy 原文、失败恢复 UI;真实 resident-daemon 全链含 stable evidenceId/origin/locator/substrate 与 null/unknown checker tuple
- [x] GUI 生产 build 绿
- [ ] GitHub Actions `rewrite-ci`(权威全量门,开 PR 时待跑)
- 未跑及原因:Electron 桌面 E2E 按 mission 归 CI;CEO 桌面亲验合并后与 S2-A/B 一批做。

## 评审证据

- 自评:CEO 按设计 §4.3 逐行对照(聚合/join 键、不冒充 witness、不猜 origin、摘要先行、分页/恢复语义、copy context 内容);确认只动 packages/gui 且 fixture+manifest 齐。
- 评审 subagent:verify-findings ALL-VERIFIED。
- 人工评审:待定(本 PR + 合并后桌面亲验)
- 阻塞 findings:无

## 残余风险

- Electron 桌面 E2E 待合并后 CEO 亲验(S2-A/B/C 一批)。
- output 级 checker 事实权威侧当前为空;真实事实源出现前视图诚实显 unknown。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
