### PR TITLE
fix(gui): stabilize triadic query references to stop render loop

### DIFF
--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -113,7 +113,7 @@ function AppShell() {
   const triadicQuery = useTriadicProjectionQuery();
   const taskActions = useTaskActions();
   const decisionActions = useDecisionActions();
-  const realTasks = useMemo(
+  const tasks = useMemo(
     () => adaptProjectionRows(tasksQuery.data?.rows ?? [], tasksQuery.data?.status, {
       relationState: triadicQuery.relationState,
       relations: triadicQuery.relations,
@@ -122,11 +122,7 @@ function AppShell() {
     }),
     [tasksQuery.data, triadicQuery.relationState, triadicQuery.relations, triadicQuery.decisions, triadicQuery.relationWarnings],
   );
-  const [tasks, setTasks] = useState<import("./model/types.ts").TaskRow[]>([]);
-  // 台账投影是唯一任务真值；mutation 不做 optimistic status，reread 后才更新。
-  useEffect(() => {
-    setTasks(realTasks);
-  }, [realTasks]);
+  const realTasks = tasks;
 
   const project = useMemo(() => buildRealProject(realTasks), [realTasks]);
   const projectId = project.id;

--- a/packages/gui/src/renderer/triadic-data.ts
+++ b/packages/gui/src/renderer/triadic-data.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type {
   DecisionProjectionRow,
@@ -29,20 +30,20 @@ export function useTriadicProjectionQuery() {
     queryFn: () => harnessClient.getDecisions(),
     staleTime: 10_000
   });
-  const rendererData = buildTriadicRendererData({
+  const rendererData = useMemo(() => buildTriadicRendererData({
     graph: graph.data ?? emptyRelationGraph,
     decisions: decisions.data ?? emptyDecisionList
-  });
+  }), [graph.data, decisions.data]);
   const isLoading = graph.isLoading || decisions.isLoading;
   const isError = graph.isError || decisions.isError;
 
-  return {
+  return useMemo(() => ({
     isLoading,
     isError,
     relationState: graph.isError ? "error" as const : graph.isLoading ? "loading" as const : "ready" as const,
     relationWarnings: graph.data?.warnings ?? [],
     ...rendererData
-  };
+  }), [isLoading, isError, graph.isError, graph.isLoading, graph.data?.warnings, rendererData]);
 }
 
 export interface TriadicRendererData {

--- a/tools/gates/line-budgets.json
+++ b/tools/gates/line-budgets.json
@@ -7,7 +7,7 @@
     "doc-sync": 349,
     "preset": 366,
     "cli": 140,
-    "gui": 18389,
+    "gui": 18386,
     "daemon": 995,
     "fleet": 222,
     "authority-write-path": 0,

--- a/tools/gates/test/fixtures/gui-render-loop-fix-production-paths.json
+++ b/tools/gates/test/fixtures/gui-render-loop-fix-production-paths.json
@@ -1,0 +1,4 @@
+[
+  { "path": "packages/gui/src/renderer/App.tsx", "module": "gui" },
+  { "path": "packages/gui/src/renderer/triadic-data.ts", "module": "gui" }
+]


### PR DESCRIPTION
# English

## Summary

Fixes the red-screen `Maximum update depth exceeded` crash at GUI startup. Root cause: `useTriadicProjectionQuery` returned a freshly-built object (and freshly-built `rendererData`) on every render, so the `useMemo` deps in `AppShell` never stabilized and the `useEffect(() => setTasks(realTasks), [realTasks])` mirror re-fired every render — an infinite setState loop. Fix follows the delete-first discipline: memoize the hook's derived data and return value (`useMemo` in `triadic-data.ts`), and delete the pointless `useState`+`useEffect` state mirror in `App.tsx` entirely — `tasks` is now the memoized derivation itself. Semantics unchanged: the ledger projection remains the only task truth and no optimistic status is introduced; tasks now update in the same render as query data instead of one effect-tick later. Fix contributed externally on the local rebuild checkout; CEO verified, branched, and landed it.

## What Changed

- `fix(gui): stabilize triadic query references to stop render loop`: `triadic-data.ts` memoizes `rendererData` + return object; `App.tsx` removes the `useState`/`useEffect` mirror (net deletion).
- Gate surfaces: line-budgets gui 18389→18386 (ratchet-down, required by G32 in same change); governance fixture `gui-render-loop-fix-production-paths.json` same commit.

## Task And Scope

- Harness task: task_01KZX9CY7KP100X0QM5TAYPAS4 (GUI restoration line; startup crash blocks all desktop verification)
- Branch: fix/gui-render-loop (base rebuild/main 0230b26b)
- Public scope: 2 renderer files + gate budgets/fixture
- Out of scope: any data-flow/contract change; S3 slices.

## Version Impact

- Version: no version change (pre-cutover rebuild line).
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: line-budgets.json gui key (ratchet-down), governance fixture same commit
- Authority: dec_01KZWTAPXF24FR62Q53Y42JGMV (restoration charter); crash-fix under standing find-and-fix authorization
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

Production-Delta: +7/-10

- Base `origin/rebuild/main` SHA: 0230b26b
- Branch merge-base with `origin/rebuild/main`: 0230b26b
- Last `git fetch origin` time: 2026-08-14 ~17:05 CST
- Sync method: rebased onto 0230b26b, gates re-run on final state
- Public diff command: `git diff 0230b26b..HEAD`
- Private evidence commit/path: external contributor fix, verified in-session
- Reviewer evidence path: CEO ground-truth (below)
- GitHub Actions `rewrite-ci` run URL: pending (green before merge)
- [x] `git diff --check`
- [x] `npm run check:local` exit 0 (fast tier 34.1s)
- [x] `npm run test:gui` 14 files / 131 tests passed
- [x] `tsc -b packages/gui` clean
- [x] G32 gui 18386/18386 pass
- [ ] GitHub Actions `rewrite-ci` passed (authoritative full gate — pending at PR-open time)
- Not run, and why: Electron desktop E2E stays CI unverified; the crash itself was observed at desktop startup and the loop cause is deterministic from the code.

## Review Evidence

- Self-review: CEO read the full diff; confirmed no `setTasks` references remain, no optimistic-write introduced, deletion-first shape (state mirror removed rather than patched), only 2 renderer files + gates touched.
- Human review: fix authored externally (desktop operator), CEO verified and landed.
- Blocking findings: none

## Residual Risk

- None beyond normal: behavior change is tasks updating one render earlier (removal of the effect-tick delay), covered by the existing 131 GUI tests.

---

# 中文

## 概要

修 GUI 启动红屏 `Maximum update depth exceeded`。根因:`useTriadicProjectionQuery` 每次渲染都返回新建对象(`rendererData` 也是新建),`AppShell` 的 useMemo 依赖永不稳定,`useEffect(() => setTasks(realTasks), [realTasks])` 镜像每轮重触发 → setState 死循环。修法遵循删除优先:`triadic-data.ts` 用 `useMemo` 稳定派生数据与返回对象;`App.tsx` **整段删除**无意义的 `useState`+`useEffect` 镜像——`tasks` 直接就是 memo 派生。语义不变:台账投影仍是唯一任务真值,未引入 optimistic status;tasks 从「晚一拍」变为与 query 数据同渲染更新。修复由外部协作者在本地 rebuild checkout 完成,CEO 核验后落地。

## 改了什么

- `fix(gui): stabilize triadic query references to stop render loop`:`triadic-data.ts` memo 化 `rendererData` 与返回对象;`App.tsx` 删 state 镜像(净删除)。
- 门面:line-budgets gui 18389→18386(ratchet 下调,G32 要求同 change);fixture `gui-render-loop-fix-production-paths.json` 同 commit。

## 任务与范围

- Harness task:task_01KZX9CY7KP100X0QM5TAYPAS4(GUI 恢复线;启动崩溃阻塞全部桌面验证)
- 分支:fix/gui-render-loop(base 0230b26b)
- 公开范围:2 个 renderer 文件 + gate budgets/fixture
- 范围外:任何数据流/契约改动;S3 各片。

## 版本影响

- 版本:无变化(cutover 前 rebuild 线)。
- 发布影响:不发布。

## 治理声明

- 触碰 protected surface:是
- 范围:line-budgets.json gui key(ratchet 下调)、治理 fixture 同 commit
- 授权:dec_01KZWTAPXF24FR62Q53Y42JGMV(恢复章程);崩溃修复属发现即修常设授权
- 机器检查边界:本 PR 仅断言声明存在;是否真实充分由评审判断。
- Break-glass:否

## 验证

- Base `origin/rebuild/main` SHA:0230b26b
- merge-base:0230b26b
- 最近 fetch:2026-08-14 约 17:05 CST
- 同步方式:rebase 到 0230b26b 后在最终态复跑门
- 公开 diff 命令:`git diff 0230b26b..HEAD`
- 私有证据:外部协作者修复,session 内核验
- 评审证据:CEO ground-truth(见下)
- [x] `git diff --check`
- [x] `npm run check:local` exit 0(fast tier 34.1s)
- [x] `npm run test:gui` 14 files / 131 tests 全过
- [x] `tsc -b packages/gui` 干净
- [x] G32 gui 18386/18386 pass
- [ ] GitHub Actions `rewrite-ci`(权威全量门,开 PR 时待跑)
- 未跑及原因:Electron 桌面 E2E 归 CI unverified;崩溃在桌面启动直接观察到,死循环成因由代码可确定性推出。

## 评审证据

- 自评:CEO 通读全 diff;确认无 `setTasks` 残留、未引入 optimistic 写、修法是删除镜像而非打补丁、只动 2 个 renderer 文件+门面。
- 人工评审:修复由外部协作者(桌面操作者)完成,CEO 核验落地。
- 阻塞 findings:无

## 残余风险

- 仅正常范围:行为差异是 tasks 提前一拍更新(删除 effect 延迟),现有 131 个 GUI 测试覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
