### PR TITLE
fix(gui): restore two-level territory layout and structured preset provenance

### DIFF
--- a/packages/gui/src/renderer/graph/nodes/TerritoryNode.tsx
+++ b/packages/gui/src/renderer/graph/nodes/TerritoryNode.tsx
@@ -1,6 +1,27 @@
-import { Handle, Position } from "@xyflow/react";
+import type { NodeProps } from "@xyflow/react";
+import { ArrowsOutSimple } from "@phosphor-icons/react";
 import type { TerritoryChip, TerritoryZone } from "../territory";
 import type { ZoneProgress } from "../territoryProgress";
+import { zoneHeaderH, ZONE_PROGRESS_H } from "../territoryLayout";
+
+/**
+ * L1 领地总览的两级节点(REQ-GUI-03 territory,archive 两级结构):
+ *   TerritoryZoneNode  — zone 壳(标题 + 进度信号 + 折叠钮),自身不参与点击选中,
+ *                        chip 是独立 React Flow 节点叠在壳的 body 区上。
+ *   TerritoryChipNode  — zone 内实体 chip,单击进聚光灯;fold 变体是折叠态底部
+ *                        「▸ 还有 N 项」提示行,单击展开 zone。
+ *
+ * 节点尺寸由 territoryLayout.ts 算好,style.width/height 与顶层 width/height 同时给
+ * (顶层必给,否则 MiniMap 不画)。头部高度必须与布局常量同源(zoneHeaderH)。
+ */
+
+type Entity = "task" | "decision" | "fact";
+
+const AXIS_VAR: Record<Entity, string> = {
+  task: "var(--color-axis-execution)",
+  decision: "var(--color-axis-authority)",
+  fact: "var(--color-axis-evidence)",
+};
 
 /** 状态段配色(等亮度状态色,与视觉系统同源)。 */
 const PROGRESS_SEGMENTS: ReadonlyArray<{ key: keyof ZoneProgress; label: string; color: string }> = [
@@ -12,14 +33,86 @@ const PROGRESS_SEGMENTS: ReadonlyArray<{ key: keyof ZoneProgress; label: string;
   { key: "other", label: "其他", color: "var(--color-status-unknown)" },
 ];
 
+interface ZoneNodeData {
+  zone: TerritoryZone;
+  folded: boolean;
+  variant: "zone" | "landing";
+  onFold: (zoneId: string) => void;
+}
+
+export function TerritoryZoneNode({ data }: NodeProps) {
+  const d = data as unknown as ZoneNodeData;
+  const zone = d.zone;
+  const axis = AXIS_VAR[zone.entity] ?? AXIS_VAR.task;
+  const headerH = zoneHeaderH(zone);
+  const landing = d.variant === "landing";
+
+  return (
+    <div
+      data-testid="territory-zone"
+      data-zone-id={zone.zoneId}
+      className={`flex h-full w-full flex-col overflow-hidden rounded-xl border bg-surface ${
+        landing ? "border-dashed" : ""
+      }`}
+      style={{
+        borderColor: zone.progress?.unprojected
+          ? "color-mix(in oklch, var(--color-stale) 45%, var(--color-border))"
+          : "var(--color-border)",
+      }}
+    >
+      {/* zone header:高度与布局常量同源,固定不死(negative flex 由 body 吸收) */}
+      <div
+        className="flex shrink-0 flex-col border-b border-border"
+        style={{ height: headerH }}
+      >
+        <div
+          className="flex min-h-0 flex-1 items-center gap-2 px-3 pt-2"
+          data-testid="territory-zone-header"
+        >
+          <span
+            className="inline-block size-2.5 shrink-0 rounded-sm"
+            style={{ backgroundColor: axis, opacity: 0.75 }}
+          />
+          <span className="ui-body min-w-0 flex-1 truncate text-[13px] font-semibold text-text">
+            {zone.title}
+          </span>
+          <span className="shrink-0 rounded bg-surface-raised px-1.5 py-0.5 font-mono text-[10px] text-text-faint">
+            {zone.chips.length}
+          </span>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              d.onFold(zone.zoneId);
+            }}
+            title={d.folded ? "展开全部 chip" : "折叠(只显热点)"}
+            className="shrink-0 rounded border border-border px-1.5 py-0.5 font-mono text-[10px] text-text-muted hover:border-border-strong hover:text-text"
+          >
+            {d.folded ? "▸" : "▾"}
+          </button>
+        </div>
+        {zone.progress && zone.progress.total > 0 && (
+          <ZoneProgressBar progress={zone.progress} />
+        )}
+      </div>
+      {/* chip 底板:实际 chip 是独立 RF 节点叠在这里 */}
+      <div className="min-h-0 flex-1" />
+    </div>
+  );
+}
+
 /**
  * PRD 块进度条:状态比例条 + 完成率 + 阻塞计数。
  * 老版领地的核心可读性来源 —— 一眼看出「这个 PRD 推到哪了、卡没卡住」。
+ * 高度占 ZONE_PROGRESS_H,与布局常量同源。
  */
 function ZoneProgressBar({ progress }: { progress: ZoneProgress }) {
   return (
-    <div className="flex flex-col gap-1 px-3 pb-2" data-testid="zone-progress">
-      <div className="flex h-1.5 w-full overflow-hidden rounded-full bg-surface">
+    <div
+      className="flex flex-col gap-1 px-3 pb-2"
+      style={{ height: ZONE_PROGRESS_H }}
+      data-testid="zone-progress"
+    >
+      <div className="flex h-1.5 w-full overflow-hidden rounded-full bg-surface-raised">
         {PROGRESS_SEGMENTS.map((segment) => {
           const count = progress[segment.key] as number;
           if (!count) return null;
@@ -43,112 +136,88 @@ function ZoneProgressBar({ progress }: { progress: ZoneProgress }) {
   );
 }
 
-/**
- * 领地总览的两类节点(REQ-GUI-03 territory):
- *   TerritoryZoneNode  — 可折叠卡片(zone 标题 + chip 计数),单击折叠/展开。
- *   TerritoryChipNode  — zone 内实体 chip,单击进聚光灯。
- *
- * 无关系线(领地是 zone 总览,不是图)。两个渲染函数共用本文件。
- */
+interface ChipNodeData {
+  chip: TerritoryChip | null;
+  /** chip 为 null 时是 fold 提示行。 */
+  fold?: { zoneId: string; hidden: number };
+  onOpen: (navRef: string) => void;
+  onFold: (zoneId: string) => void;
+}
 
-export function TerritoryZoneNode({ data }: any) {
-  const zone = data.zone as TerritoryZone;
-  const collapsed = Boolean(data.collapsed);
-  const entityColor =
-    zone.entity === "task"
-      ? "var(--color-border-strong)"
-      : zone.entity === "decision"
-        ? "var(--color-accent)"
-        : "var(--color-stale)";
-  return (
-    <div
-      className="flex min-w-[180px] flex-col rounded-lg border bg-surface-raised shadow-sm"
-      style={{ borderColor: entityColor, opacity: collapsed ? 0.55 : 1 }}
-    >
-      <Handle type="target" position={Position.Top} className="opacity-0" />
-      <div
-        className="flex cursor-pointer items-center gap-2 border-b border-border px-3 py-2 select-none"
+export function TerritoryChipNode({ data }: NodeProps) {
+  const d = data as unknown as ChipNodeData;
+
+  if (!d.chip) {
+    const fold = d.fold!;
+    return (
+      <button
         onClick={(e) => {
           e.stopPropagation();
-          data.onFold?.(zone.zoneId);
+          d.onFold(fold.zoneId);
         }}
-        data-testid="territory-zone-header"
-        data-zone-id={zone.zoneId}
+        data-testid="territory-fold"
+        data-zone-id={fold.zoneId}
+        className="flex h-full w-full items-center justify-center rounded-lg border border-dashed border-border text-[11.5px] text-text-muted transition-colors hover:border-border-strong hover:text-text"
       >
-        <span className="inline-block h-2.5 w-2.5 rounded-sm" style={{ background: entityColor }} />
-        <span className="min-w-0 flex-1 truncate font-mono text-[12px] font-semibold text-text">
-          {zone.title}
+        ▸ 还有 {fold.hidden} 项{fold.hidden >= 50 ? "(展开也只显前 50)" : ""} —— 点击展开
+      </button>
+    );
+  }
+
+  const chip = d.chip;
+  const axis = AXIS_VAR[chip.entity] ?? AXIS_VAR.task;
+  return (
+    <div
+      onClick={(e) => {
+        e.stopPropagation();
+        d.onOpen(chip.navRef);
+      }}
+      data-testid="territory-chip"
+      data-nav-ref={chip.navRef}
+      className="flex h-full w-full cursor-pointer items-center gap-2 overflow-hidden rounded-lg border border-border bg-surface-raised px-2.5 transition-colors hover:border-border-strong"
+    >
+      <span
+        className="grid size-[18px] shrink-0 place-items-center rounded font-mono text-[10px] font-bold"
+        style={{
+          backgroundColor: `color-mix(in srgb, ${axis} 18%, transparent)`,
+          color: axis,
+        }}
+      >
+        {chip.entity === "task" ? "T" : chip.entity === "decision" ? "D" : "F"}
+      </span>
+      <span
+        className="size-[7px] shrink-0 rounded-full"
+        style={{
+          backgroundColor:
+            chip.entity === "task"
+              ? statusDot(chip.sub)
+              : chip.entity === "decision"
+                ? "var(--color-axis-authority)"
+                : "var(--color-axis-evidence)",
+        }}
+      />
+      <span className="ui-body min-w-0 flex-1 truncate text-[12.5px] text-text">
+        {chip.label}
+      </span>
+      {chip.sub && (
+        <span className="shrink-0 rounded bg-surface px-1.5 py-0.5 font-mono text-[10px] text-text-faint">
+          {chip.sub}
         </span>
-        <span className="rounded bg-surface px-1.5 py-0.5 font-mono text-[10px] text-text-faint">
-          {zone.chips.length}
-        </span>
-        <span className="font-mono text-[10px] text-text-faint">{collapsed ? "▸" : "▾"}</span>
-      </div>
-      {zone.progress && zone.progress.total > 0 && <ZoneProgressBar progress={zone.progress} />}
-      {!collapsed && (
-        <div className="flex max-h-[220px] flex-col gap-1 overflow-y-auto px-2 py-2">
-          {zone.chips.slice(0, 24).map((chip: TerritoryChip) => (
-            <button
-              key={chip.navRef}
-              data-testid="territory-chip"
-              data-nav-ref={chip.navRef}
-              onClick={(e) => {
-                e.stopPropagation();
-                data.onOpen?.(chip.navRef);
-              }}
-              className="flex items-center gap-1.5 rounded px-1.5 py-1 text-left hover:bg-surface"
-            >
-              <span
-                className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
-                style={{
-                  background:
-                    chip.entity === "task"
-                      ? "var(--color-border-strong)"
-                      : chip.entity === "decision"
-                        ? "var(--color-accent)"
-                        : "var(--color-stale)",
-                }}
-              />
-              <span className="min-w-0 flex-1 truncate text-[11px] text-text">{chip.label}</span>
-              {chip.sub && (
-                <span className="shrink-0 font-mono text-[9px] text-text-faint">{chip.sub}</span>
-              )}
-            </button>
-          ))}
-          {zone.chips.length > 24 && (
-            <span className="px-1.5 font-mono text-[9px] text-text-faint">
-              …还有 {zone.chips.length - 24}
-            </span>
-          )}
-        </div>
       )}
-      <Handle type="source" position={Position.Bottom} className="opacity-0" />
+      <ArrowsOutSimple weight="bold" className="shrink-0 text-[11px] text-text-faint" />
     </div>
   );
 }
 
-/** 未投影实体 landing chip(孤立 decision 等无 zone 归属的)。 */
-export function TerritoryLandingNode({ data }: any) {
-  const chips = (data.chips ?? []) as TerritoryChip[];
-  return (
-    <div className="flex min-w-[180px] flex-col rounded-lg border border-dashed border-border bg-surface px-3 py-2">
-      <span className="font-mono text-[11px] text-text-faint">孤立 / landing</span>
-      <div className="mt-1 flex flex-col gap-1">
-        {chips.map((chip) => (
-          <button
-            key={chip.navRef}
-            data-testid="territory-chip"
-            data-nav-ref={chip.navRef}
-            onClick={(e) => {
-              e.stopPropagation();
-              data.onOpen?.(chip.navRef);
-            }}
-            className="flex items-center gap-1.5 rounded px-1.5 py-1 text-left hover:bg-surface-raised"
-          >
-            <span className="min-w-0 flex-1 truncate text-[11px] text-text-muted">{chip.label}</span>
-          </button>
-        ))}
-      </div>
-    </div>
-  );
+/** task 状态 → 状态色点(coordinationStatus 即 chip.sub);未知回落 planned。 */
+function statusDot(status: string | undefined): string {
+  switch (status) {
+    case "blocked": return "var(--color-status-blocked)";
+    case "active": return "var(--color-status-active)";
+    case "in_review": return "var(--color-status-in-review)";
+    case "planned": return "var(--color-status-planned)";
+    case "done": return "var(--color-status-done)";
+    case "cancelled": return "var(--color-status-cancelled)";
+    default: return "var(--color-status-unknown)";
+  }
 }

--- a/packages/gui/src/renderer/graph/territoryLayout.ts
+++ b/packages/gui/src/renderer/graph/territoryLayout.ts
@@ -1,0 +1,195 @@
+import type { Node } from "@xyflow/react";
+import type { TerritoryChip, TerritoryPartition, TerritoryZone } from "./territory";
+
+/**
+ * L1 领地总览布局(两级结构:zone 壳 + 独立 chip 节点)。
+ *
+ * 恢复 archive 老版(territoryLayout.ts @ be94cc68)的做法:分区数据(territory.ts,
+ * 本线的 PRD 聚簇 / decision family / fact 异常分区)不变,这里只负责几何 ——
+ *   · 列数由容器宽度派生(deriveGridCols),窄屏 1-2 列、宽屏最多 6 列,
+ *     而不是把上千实体挤进固定 3 列 × 260px 的槽位;
+ *   · zone 盒高跟随它实际发射的 chip 数(零重叠),折叠态只显前 FOLDED_CHIP_CAP
+ *     个 chip + fold 提示行,展开态封顶 EXPANDED_CHIP_CAP;
+ *   · chip 是独立 React Flow 节点(可点击进聚光灯),不是 zone DOM 里的静态按钮,
+ *     顶层 width/height 必给(MiniMap 需要)。
+ *
+ * 纯函数 + 确定性:输入 partition + expandedZones + containerWidth → 节点。无边
+ * (L1 是空间形状,关系线在 L2 聚光灯画)。
+ */
+
+// ── 几何常量(zone 节点渲染必须与这些值同源:nodes/TerritoryNode.tsx 引用) ──
+export const ZONE_W = 340;
+/** zone 头部基础高(色点 + 标题 + 计数 + 折叠钮)。 */
+export const ZONE_HEADER_H = 46;
+/** task zone 头部额外增加的进度条块高(状态比例条 + 完成率行)。 */
+export const ZONE_PROGRESS_H = 38;
+export const ZONE_BODY_PAD_Y = 8;
+export const ZONE_BODY_PAD_X = 8;
+export const CHIP_H = 30;
+export const CHIP_GAP = 4;
+export const ZONE_GAP_X = 20;
+export const ZONE_GAP_Y = 20;
+export const ZONE_MIN_BODY_H = 36;
+/** 折叠态展示 chip 数(重要性已由分区排序,头部即热点)。 */
+export const FOLDED_CHIP_CAP = 8;
+/** 展开态封顶(超过进 fold 提示,避免单块数千 px)。 */
+export const EXPANDED_CHIP_CAP = 50;
+export const DEFAULT_GRID_COLS = 3;
+const GRID_COLS_MAX = 6;
+const TOP_PAD = 16;
+const LEFT_PAD = 24;
+
+/**
+ * 由容器宽度派生领地列数。接受「zone 摆放区」净宽(已扣两侧 LEFT_PAD);
+ * 每列净宽 = ZONE_W + ZONE_GAP_X。无效/未测量 → 兜底 DEFAULT_GRID_COLS。
+ */
+export function deriveGridCols(zoneAreaWidth: number): number {
+  if (!Number.isFinite(zoneAreaWidth) || zoneAreaWidth <= 0) return DEFAULT_GRID_COLS;
+  const perCol = ZONE_W + ZONE_GAP_X;
+  const cols = Math.floor((zoneAreaWidth + ZONE_GAP_X) / perCol);
+  return Math.max(1, Math.min(GRID_COLS_MAX, cols));
+}
+
+export interface TerritoryLayoutInput {
+  partition: TerritoryPartition;
+  /** 已展开(不折叠)的 zone id 集;默认折叠 = 只显前 FOLDED_CHIP_CAP 个 chip。 */
+  expandedZones: ReadonlySet<string>;
+  /** 领地摆放区容器宽(像素,含两侧 LEFT_PAD);未测量回落 DEFAULT_GRID_COLS。 */
+  containerWidth?: number;
+  onOpen: (navRef: string) => void;
+  onFold: (zoneId: string) => void;
+}
+
+export interface TerritoryLayout {
+  nodes: Node[];
+  bounds: { width: number; height: number };
+}
+
+/** landing(孤立实体)伪 zone:复用 zone 壳的虚线变体。 */
+function landingZone(chips: ReadonlyArray<TerritoryChip>): TerritoryZone {
+  return {
+    zoneId: "__landing__",
+    title: "孤立 / landing",
+    entity: chips[0]?.entity ?? "decision",
+    moduleId: "__landing__",
+    chips: [...chips],
+  };
+}
+
+export function layoutTerritory(input: TerritoryLayoutInput): TerritoryLayout {
+  const { partition, expandedZones, onOpen, onFold } = input;
+  const gridCols = deriveGridCols((input.containerWidth ?? 0) - LEFT_PAD * 2);
+
+  const zones: TerritoryZone[] = [...partition.zones];
+  if (partition.landing.length > 0) zones.push(landingZone(partition.landing));
+
+  const nodes: Node[] = [];
+  let cursorY = TOP_PAD;
+  let maxX = LEFT_PAD;
+
+  const rows = chunk(zones, gridCols);
+  for (const row of rows) {
+    // 先算整行高度(盒子跟着 chip 走),再统一摆放 → 行内零重叠。
+    const heights = row.map((zone) =>
+      expandedZones.has(zone.zoneId) ? zoneHeight(zone, false) : zoneHeight(zone, true),
+    );
+    const rowH = Math.max(...heights);
+
+    let cursorX = LEFT_PAD;
+    for (const [i, zone] of row.entries()) {
+      const folded = !expandedZones.has(zone.zoneId);
+      const h = heights[i] ?? ZONE_HEADER_H;
+      const shown = visibleChips(zone, folded);
+
+      nodes.push({
+        id: `territory-zone:${zone.zoneId}`,
+        type: "territoryZone",
+        position: { x: cursorX, y: cursorY },
+        width: ZONE_W,
+        height: h,
+        style: { width: ZONE_W, height: h },
+        data: {
+          zone,
+          folded,
+          variant: zone.zoneId === "__landing__" ? "landing" : "zone",
+          onFold,
+        },
+        zIndex: 0,
+        selectable: false,
+        draggable: false,
+      });
+
+      const bodyTop = cursorY + zoneHeaderH(zone) + ZONE_BODY_PAD_Y;
+      let chipY = bodyTop;
+      for (const chip of shown) {
+        nodes.push({
+          id: `territory-chip:${chip.navRef}`,
+          type: "territoryChip",
+          position: { x: cursorX + ZONE_BODY_PAD_X, y: chipY },
+          width: ZONE_W - ZONE_BODY_PAD_X * 2,
+          height: CHIP_H,
+          style: { width: ZONE_W - ZONE_BODY_PAD_X * 2, height: CHIP_H },
+          data: { chip, onOpen },
+          zIndex: 2,
+        });
+        chipY += CHIP_H + CHIP_GAP;
+      }
+      if (shown.length < zone.chips.length) {
+        const hidden = zone.chips.length - shown.length;
+        nodes.push({
+          id: `territory-fold:${zone.zoneId}`,
+          type: "territoryChip",
+          position: { x: cursorX + ZONE_BODY_PAD_X, y: chipY },
+          width: ZONE_W - ZONE_BODY_PAD_X * 2,
+          height: CHIP_H,
+          style: { width: ZONE_W - ZONE_BODY_PAD_X * 2, height: CHIP_H },
+          data: {
+            chip: null,
+            fold: { zoneId: zone.zoneId, hidden },
+            onFold,
+          },
+          zIndex: 2,
+        });
+      }
+
+      cursorX += ZONE_W + ZONE_GAP_X;
+      maxX = Math.max(maxX, cursorX);
+    }
+    cursorY += rowH + ZONE_GAP_Y;
+  }
+
+  return {
+    nodes,
+    bounds: {
+      width: Math.max(maxX, LEFT_PAD + gridCols * ZONE_W) - LEFT_PAD,
+      height: cursorY - TOP_PAD - ZONE_GAP_Y,
+    },
+  };
+}
+
+/** zone 头部高:基础 + (task 进度条块)。渲染端按同一常量排,几何与视觉同源。 */
+export function zoneHeaderH(zone: TerritoryZone): number {
+  return zone.progress ? ZONE_HEADER_H + ZONE_PROGRESS_H : ZONE_HEADER_H;
+}
+
+function zoneHeight(zone: TerritoryZone, folded: boolean): number {
+  const shown = visibleChips(zone, folded);
+  const extra = shown.length < zone.chips.length ? 1 : 0; // fold 提示行
+  const count = shown.length + extra;
+  const bodyH = Math.max(
+    ZONE_MIN_BODY_H,
+    count * CHIP_H + Math.max(0, count - 1) * CHIP_GAP,
+  );
+  return zoneHeaderH(zone) + ZONE_BODY_PAD_Y * 2 + bodyH;
+}
+
+function visibleChips(zone: TerritoryZone, folded: boolean): TerritoryChip[] {
+  const cap = folded ? FOLDED_CHIP_CAP : EXPANDED_CHIP_CAP;
+  return zone.chips.slice(0, cap);
+}
+
+function chunk<T>(items: ReadonlyArray<T>, size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}

--- a/packages/gui/src/renderer/views/GraphView.tsx
+++ b/packages/gui/src/renderer/views/GraphView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import {
   ReactFlow,
   MiniMap,
@@ -15,7 +15,7 @@ import type { FactAnchorRow, RelationCoverageRow } from "../../api/renderer-dto"
 import { parseEndpoint, endpointToNodeId } from "../graph/endpoint";
 import { GraphDrawer } from "../graph/GraphDrawer";
 import { EgoNode } from "../graph/nodes/EgoNode";
-import { TerritoryZoneNode, TerritoryLandingNode } from "../graph/nodes/TerritoryNode";
+import { TerritoryZoneNode, TerritoryChipNode } from "../graph/nodes/TerritoryNode";
 import { InteractiveEdge } from "../graph/edges/InteractiveEdge";
 import { GraphFilterPanel, type GraphFilters } from "../components/GraphFilterPanel";
 import { GraphLegend } from "../components/GraphLegend.tsx";
@@ -25,7 +25,7 @@ import { useColorMode, minimapMaskColor } from "../graph/colorMode";
 import { layoutEgoCanvas } from "../graph/egoCanvas";
 import { useEgoCanvas } from "../graph/useEgoCanvas";
 import { partitionForSkel } from "../graph/territory";
-import { UNPROJECTED_MODULE } from "../graph/moduleAssignment";
+import { layoutTerritory } from "../graph/territoryLayout";
 import {
   defaultKindFilter,
   defaultAxisFilter,
@@ -49,7 +49,7 @@ export type ViewMode = "territory" | "spotlight";
 const nodeTypes = {
   ego: EgoNode,
   territoryZone: TerritoryZoneNode,
-  territoryLanding: TerritoryLandingNode,
+  territoryChip: TerritoryChipNode,
 };
 
 const edgeTypes = {
@@ -84,12 +84,28 @@ function GraphViewInner({
   onViewModeChange: (m: ViewMode) => void;
 }) {
   const colorMode = useColorMode();
-  const { fitView } = useReactFlow();
+  const { fitView, setViewport } = useReactFlow();
 
   const [skel, setSkel] = useState<TerritorySkel>("unified");
-  const [collapsedZones, setCollapsedZones] = useState<Set<string>>(() => new Set());
+  // 折叠语义与老版同源:默认折叠(只显每块前 N 个热点 chip),expandedZones 是
+  // 用户手动展开的 zone 集。上千实体的真实数据下,折叠态保证首屏可读。
+  const [expandedZones, setExpandedZones] = useState<Set<string>>(() => new Set());
   const [flowMode, setFlowMode] = useState<FlowAnimMode>("focus");
   const [focusEdgeId, setFocusEdgeId] = useState<string | null>(null);
+
+  // 领地摆放区宽度(ResizeObserver 实测):列数由它派生,而非固定 3 列。
+  const canvasHostRef = useRef<HTMLDivElement | null>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  useEffect(() => {
+    const host = canvasHostRef.current;
+    if (!host) return;
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width ?? 0;
+      setContainerWidth((prev) => (Math.abs(prev - width) > 1 ? width : prev));
+    });
+    observer.observe(host);
+    return () => observer.disconnect();
+  }, []);
 
   const availableModules = useMemo(
     () => Array.from(new Set(tasks.map((t) => t.module))).sort(),
@@ -182,7 +198,7 @@ function GraphViewInner({
   }, [viewMode, skel, tasks, decisions, facts, factAnchors, relations, coverageRows]);
 
   const toggleZone = useCallback((zoneId: string) => {
-    setCollapsedZones((prev) => {
+    setExpandedZones((prev) => {
       const next = new Set(prev);
       if (next.has(zoneId)) next.delete(zoneId);
       else next.add(zoneId);
@@ -190,49 +206,18 @@ function GraphViewInner({
     });
   }, []);
 
-  // 未投影 zone 默认折叠(降权:不许占 C 位)。用户手动展开后不再被覆盖。
-  const [autoCollapsedSkel, setAutoCollapsedSkel] = useState<string | null>(null);
-  useEffect(() => {
-    if (!territory || autoCollapsedSkel === skel) return;
-    const unprojected = territory.zones
-      .filter((z) => z.moduleId === UNPROJECTED_MODULE)
-      .map((z) => z.zoneId);
-    setAutoCollapsedSkel(skel);
-    if (unprojected.length > 0) {
-      setCollapsedZones((prev) => new Set([...prev, ...unprojected]));
-    }
-  }, [territory, skel, autoCollapsedSkel]);
-
+  // 两级布局(archive 结构):zone 壳 + 独立 chip 节点,列数随容器宽派生,
+  // 盒高跟随 chip 数(行推进用行内最大高,零重叠)。分区数据见 graph/territory.ts。
   const territoryNodes = useMemo(() => {
     if (!territory) return [];
-    const nodes: any[] = [];
-    const colW = 300;
-    const colGap = 32;
-    const maxPerCol = 3;
-    territory.zones.forEach((zone, i) => {
-      const col = i % maxPerCol;
-      const row = Math.floor(i / maxPerCol);
-      nodes.push({
-        id: zone.zoneId,
-        type: "territoryZone",
-        position: { x: col * (colW + colGap), y: row * 260 },
-        data: { zone, collapsed: collapsedZones.has(zone.zoneId), onOpen: enterSpotlight, onFold: toggleZone },
-        draggable: false,
-      });
-    });
-    if (territory.landing.length > 0) {
-      const landingCol = territory.zones.length % maxPerCol;
-      const landingRow = Math.floor(territory.zones.length / maxPerCol);
-      nodes.push({
-        id: "__landing__",
-        type: "territoryLanding",
-        position: { x: landingCol * (colW + colGap), y: landingRow * 260 },
-        data: { chips: territory.landing, onOpen: enterSpotlight },
-        draggable: false,
-      });
-    }
-    return nodes;
-  }, [territory, collapsedZones, enterSpotlight, toggleZone]);
+    return layoutTerritory({
+      partition: territory,
+      expandedZones,
+      containerWidth,
+      onOpen: enterSpotlight,
+      onFold: toggleZone,
+    }).nodes;
+  }, [territory, expandedZones, containerWidth, enterSpotlight, toggleZone]);
 
   // ---- 聚光灯布局(纯函数:焦点 + 累积集 + 筛选 → 位置) ----
   const spotlight = useMemo(() => {
@@ -297,12 +282,18 @@ function GraphViewInner({
     });
   }, [viewMode, spotlight, filters.kinds, statusVisibleIds]);
 
-  // fitView 只在换焦点 / 换模式时跑 —— 展开、收起、单击都不重排视口(决策 CH1)。
+  // 视口策略(与老版同源):聚光灯 fitView(一屏装下 ego 图);领地**不 fitView** ——
+  // 上千块 fit 进一屏正是「块被压成几像素细横条」的成因,领地以默认视口(zoom 1,
+  // 左上角)打开,块保持可读尺寸,漫游交给 pan/zoom + MiniMap。
   useEffect(() => {
+    if (viewMode === "territory") {
+      const frame = requestAnimationFrame(() => void setViewport({ x: 0, y: 0, zoom: 1 }, { duration: 200 }));
+      return () => cancelAnimationFrame(frame);
+    }
     if (displayNodes.length === 0) return;
     const frame = requestAnimationFrame(() => fitView({ padding: 0.12, duration: 200 }));
     return () => cancelAnimationFrame(frame);
-  }, [canvas.focusId, fitView, viewMode, skel]);
+  }, [canvas.focusId, fitView, setViewport, viewMode, skel]);
 
   // Esc 清选/清边。
   useEffect(() => {
@@ -454,7 +445,7 @@ function GraphViewInner({
         />
       )}
 
-      <div className="flex min-h-0 flex-1 relative">
+      <div ref={canvasHostRef} className="flex min-h-0 flex-1 relative">
         <ReactFlow
           nodes={displayNodes}
           edges={displayEdges}
@@ -470,8 +461,6 @@ function GraphViewInner({
           zoomOnDoubleClick={false}
           nodesDraggable={false}
           nodesConnectable={false}
-          fitView
-          fitViewOptions={{ padding: 0.12 }}
           attributionPosition="bottom-right"
         >
           <Background variant={BackgroundVariant.Dots} gap={24} size={1} color="var(--color-border)" />
@@ -480,7 +469,14 @@ function GraphViewInner({
             data-testid="graph-minimap"
             bgColor="var(--color-surface)"
             nodeColor={(n) => {
-              if (n.type === "territoryZone" || n.type === "territoryLanding") return "var(--color-border)";
+              if (n.type === "territoryZone") return "var(--color-border)";
+              if (n.type === "territoryChip") {
+                const entity = (n.data as any)?.chip?.entity;
+                if (entity === "decision") return "var(--color-axis-authority)";
+                if (entity === "fact") return "var(--color-axis-evidence)";
+                if (entity === "task") return "var(--color-axis-execution)";
+                return "var(--color-border-strong)";
+              }
               const entity = (n.data as any)?.entity;
               if (entity === "decision") return "var(--color-axis-authority)";
               if (entity === "fact") return "var(--color-axis-evidence)";
@@ -499,11 +495,11 @@ function GraphViewInner({
                 <button
                   onClick={() => {
                     const all = new Set(territory?.zones.map((z) => z.zoneId) ?? []);
-                    setCollapsedZones((cur) => (cur.size === all.size ? new Set() : all));
+                    setExpandedZones((cur) => (cur.size === all.size ? new Set() : all));
                   }}
                   className="rounded px-1 font-mono text-[11px] hover:bg-surface"
                 >
-                  {territory && collapsedZones.size === territory.zones.length ? "全部展开" : "全部折叠"}
+                  {territory && expandedZones.size > 0 && expandedZones.size >= territory.zones.length ? "全部折叠" : "全部展开"}
                 </button>
               </div>
             </Panel>

--- a/packages/gui/src/renderer/views/PresetsView.tsx
+++ b/packages/gui/src/renderer/views/PresetsView.tsx
@@ -27,10 +27,56 @@ export function PresetsView({ repoId }: { readonly repoId: string }) {
         {tab === "verticals" && data.verticals.map((vertical) => <article key={vertical.id} className="rounded-lg border border-border bg-surface p-3"><div className="flex items-center gap-2"><b>{vertical.title}</b><code className="text-[11px] text-text-faint">{vertical.id}@{vertical.version}</code><Truth value={vertical.valid ? "valid" : "invalid"}/><Truth value={vertical.available ? "available" : "unavailable"}/></div><p className="mt-1 font-mono text-[11px] text-text-faint">source {vertical.source}</p>{vertical.issues.length > 0 && <pre className="mt-2 whitespace-pre-wrap text-[11px] text-status-blocked">{JSON.stringify(vertical.issues, null, 2)}</pre>}</article>)}
         {tab === "templates" && data.templates.map((template) => <article key={`${template.slot}:${template.templateRef}`} className="rounded-lg border border-border bg-surface p-3"><b className="text-[13px]">{template.slot}</b><p className="mt-1 break-all font-mono text-[11px] text-text-muted">{template.templateRef} → {template.materializeAs}</p><p className="mt-1 text-[11px] text-text-faint">locale: {template.locales.join(", ") || "unknown / 未投影"} · snapshot default {data.defaults.locale}</p></article>)}
       </section>
-      <aside className="h-fit rounded-lg border border-border bg-surface p-3"><h2 className="text-[13px] font-semibold">Resolved preset</h2>{detail.isPending ? <p className="mt-2 text-[12px] text-text-faint">按 {data.defaults.locale} 解析…</p> : detail.isError || !detail.data ? <p className="mt-2 text-[12px] text-status-blocked">unknown / 未投影：{detail.error instanceof Error ? detail.error.message : "未选择 preset"}</p> : <dl className="mt-2 grid gap-2 text-[12px]"><Field name="id" value={detail.data.preset.id}/><Field name="vertical" value={detail.data.preset.verticalId}/><Field name="extends" value={detail.data.preset.extends ?? "none"}/><Field name="digest" value={detail.data.resolved.digest}/><Field name="locale" value={data.defaults.locale}/><Field name="capability imports" value={detail.data.preset.capabilityImports.length ? JSON.stringify(detail.data.preset.capabilityImports) : "none"}/><Field name="provenance" value={JSON.stringify(detail.data.resolved.provenance)}/></dl>}</aside>
+      <aside className="h-fit rounded-lg border border-border bg-surface p-3"><h2 className="text-[13px] font-semibold">Resolved preset</h2>{detail.isPending ? <p className="mt-2 text-[12px] text-text-faint">按 {data.defaults.locale} 解析…</p> : detail.isError || !detail.data ? <p className="mt-2 text-[12px] text-status-blocked">unknown / 未投影：{detail.error instanceof Error ? detail.error.message : "未选择 preset"}</p> : <dl className="mt-2 grid gap-2 text-[12px]"><Field name="id" value={detail.data.preset.id}/><Field name="vertical" value={detail.data.preset.verticalId}/><Field name="extends" value={detail.data.preset.extends ?? "none"}/><ShaField name="digest" value={detail.data.resolved.digest}/><Field name="locale" value={data.defaults.locale}/><Field name="capability imports" value={detail.data.preset.capabilityImports.length ? JSON.stringify(detail.data.preset.capabilityImports) : "none"}/><ProvenanceFields provenance={detail.data.resolved.provenance}/></dl>}</aside>
     </div>
   </div>;
 }
 function Truth({ value }: { readonly value: string }) { return <span className="rounded border border-border px-1.5 py-0.5 font-mono text-[10px] text-text-muted">{value}</span>; }
 function Field({ name, value }: { readonly name: string; readonly value: string }) { return <div><dt className="font-mono text-[10px] uppercase text-text-faint">{name}</dt><dd className="break-all text-text-muted">{value}</dd></div>; }
+
+/** 长哈希一行:截断显示,悬停看全量(title),单击复制。 */
+function ShaField({ name, value }: { readonly name: string; readonly value: string }) {
+  const [copied, setCopied] = useState(false);
+  const short = value.length > 22 ? `${value.slice(0, 14)}…${value.slice(-6)}` : value;
+  return (
+    <div data-testid="preset-sha-field" data-field={name}>
+      <dt className="font-mono text-[10px] uppercase text-text-faint">{name}</dt>
+      <dd className="flex min-w-0 items-center gap-1.5">
+        <button
+          title={value}
+          onClick={() => { void navigator.clipboard?.writeText(value).then(() => setCopied(true)); }}
+          className="min-w-0 flex-1 truncate rounded px-1 py-0.5 text-left font-mono text-[11px] text-text-muted hover:bg-surface-raised hover:text-text"
+        >{short}</button>
+        <span className={`shrink-0 font-mono text-[10px] text-status-done ${copied ? "" : "hidden"}`}>已复制</span>
+      </dd>
+    </div>
+  );
+}
+
+/** resolved.provenance(preset-snapshot/v1):4 个 sha256 逐字段 + resolverVersion + ancestry 列表 —— 不糊原始 JSON。 */
+function ProvenanceFields({ provenance }: { readonly provenance: Readonly<Record<string, unknown>> }) {
+  const shaFields: ReadonlyArray<{ readonly name: string; readonly label: string }> = [
+    { name: "manifestSha256", label: "provenance.manifestSha256" },
+    { name: "packageSha256", label: "provenance.packageSha256" },
+    { name: "verticalSha256", label: "provenance.verticalSha256" },
+    { name: "templateCatalogSha256", label: "provenance.templateCatalogSha256" },
+  ];
+  const ancestry = Array.isArray(provenance.ancestry)
+    ? provenance.ancestry.filter((item): item is string => typeof item === "string")
+    : [];
+  return (<>
+    {shaFields.map(({ name, label }) => (
+      <ShaField key={name} name={label} value={typeof provenance[name] === "string" ? provenance[name] as string : "unknown / 未投影"}/>
+    ))}
+    <Field name="provenance.resolverVersion" value={typeof provenance.resolverVersion === "string" ? provenance.resolverVersion : "unknown / 未投影"}/>
+    <div>
+      <dt className="font-mono text-[10px] uppercase text-text-faint">provenance.ancestry</dt>
+      <dd className="mt-0.5 flex flex-wrap gap-1" data-testid="preset-ancestry">
+        {ancestry.length > 0
+          ? ancestry.map((id) => <span key={id} className="rounded border border-border px-1.5 py-0.5 font-mono text-[10px] text-text-muted">{id}</span>)
+          : <span className="text-text-faint">none</span>}
+      </dd>
+    </div>
+  </>);
+}
 function State({ text, danger = false }: { readonly text: string; readonly danger?: boolean }) { return <div className={`p-6 text-[13px] ${danger ? "text-status-blocked" : "text-text-faint"}`}>{text}</div>; }

--- a/packages/gui/test/territory-layout.vitest.ts
+++ b/packages/gui/test/territory-layout.vitest.ts
@@ -1,0 +1,177 @@
+// harness-test-tier: integration
+import { describe, expect, it } from "vitest";
+import type { TaskRow } from "../src/renderer/model/types.ts";
+import { partitionForSkel } from "../src/renderer/graph/territory.ts";
+import {
+  deriveGridCols,
+  layoutTerritory,
+  CHIP_H,
+  CHIP_GAP,
+  EXPANDED_CHIP_CAP,
+  FOLDED_CHIP_CAP,
+  zoneHeaderH,
+  ZONE_BODY_PAD_Y,
+} from "../src/renderer/graph/territoryLayout.ts";
+
+/**
+ * 领地两级布局回归(archive 结构恢复):
+ *   · deriveGridCols 按可用宽度派生列数;
+ *   · zone 壳 + 独立 chip 节点,chip 落在 zone body 内、互不重叠;
+ *   · 折叠态只显前 FOLDED_CHIP_CAP 个 chip + fold 提示行;
+ *   · 行推进按行内最大 zone 高,下一行不压上一行;
+ *   · landing(孤立实体)渲染为虚线 zone 变体,chip 同样可布局。
+ */
+
+function task(overrides: Partial<TaskRow> = {}): TaskRow {
+  return {
+    taskId: "task_a",
+    title: "Task A",
+    projectId: "proj",
+    coordinationStatus: "active",
+    rawStatus: "active",
+    freshness: "fresh",
+    packageDisposition: "active",
+    closeoutReadiness: "not_required",
+    engine: "local",
+    source: "local-document",
+    module: "kernel",
+    lastKnownAt: "2026-08-01T00:00:00.000Z",
+    gates: [],
+    docs: [],
+    ...overrides,
+  };
+}
+
+function noop() {}
+
+function layout(opts: {
+  tasks: TaskRow[];
+  expandedZones?: ReadonlySet<string>;
+  containerWidth?: number;
+}) {
+  const partition = partitionForSkel("task", opts.tasks, [], [], [], []);
+  return layoutTerritory({
+    partition,
+    expandedZones: opts.expandedZones ?? new Set(),
+    containerWidth: opts.containerWidth,
+    onOpen: noop,
+    onFold: noop,
+  });
+}
+
+describe("deriveGridCols", () => {
+  it("derives columns from available width (narrow → 1, wide → capped 6)", () => {
+    expect(deriveGridCols(0)).toBe(3); // 未测量兜底
+    expect(deriveGridCols(-10)).toBe(3);
+    expect(deriveGridCols(Number.NaN)).toBe(3);
+    expect(deriveGridCols(300)).toBe(1);
+    expect(deriveGridCols(360 * 3)).toBe(3);
+    expect(deriveGridCols(360 * 8)).toBe(6); // 封顶
+  });
+});
+
+describe("layoutTerritory (two-level zone + chip)", () => {
+  const many = Array.from({ length: 40 }, (_, i) =>
+    task({ taskId: `t${i}`, title: `T${i}`, rootTaskId: "root", rootTitle: "PRD" }),
+  );
+
+  it("emits chips as separate nodes placed inside the zone body", () => {
+    const { nodes } = layout({ tasks: many, containerWidth: 360 });
+    const zone = nodes.find((n) => n.type === "territoryZone")!;
+    const chips = nodes.filter((n) => n.type === "territoryChip" && (n.data as any).chip);
+    expect(zone).toBeDefined();
+    expect(chips.length).toBeGreaterThan(0);
+    for (const chip of chips) {
+      expect(chip.position.x).toBeGreaterThanOrEqual(zone.position.x);
+      expect(chip.position.x + chip.width!).toBeLessThanOrEqual(zone.position.x + zone.width!);
+      expect(chip.position.y).toBeGreaterThanOrEqual(
+        zone.position.y + zoneHeaderH((zone.data as any).zone) + ZONE_BODY_PAD_Y,
+      );
+      expect(chip.position.y + chip.height!).toBeLessThanOrEqual(zone.position.y + zone.height!);
+    }
+  });
+
+  it("folds by default: FOLDED_CHIP_CAP chips + one fold row, not all 40", () => {
+    const { nodes } = layout({ tasks: many, containerWidth: 360 });
+    const chips = nodes.filter((n) => n.type === "territoryChip" && (n.data as any).chip);
+    const folds = nodes.filter((n) => (n.data as any)?.fold);
+    expect(chips).toHaveLength(FOLDED_CHIP_CAP);
+    expect(folds).toHaveLength(1);
+    expect((folds[0]!.data as any).fold.hidden).toBe(40 - FOLDED_CHIP_CAP);
+  });
+
+  it("expands to the cap but never dumps thousands of chips", () => {
+    const huge = Array.from({ length: 1174 }, (_, i) =>
+      task({ taskId: `t${i}`, title: `T${i}`, rootTaskId: "root", rootTitle: "PRD" }),
+    );
+    const partition = partitionForSkel("task", huge, [], [], [], []);
+    const { nodes } = layoutTerritory({
+      partition,
+      expandedZones: new Set(partition.zones.map((z) => z.zoneId)),
+      containerWidth: 360,
+      onOpen: noop,
+      onFold: noop,
+    });
+    const chips = nodes.filter((n) => n.type === "territoryChip" && (n.data as any).chip);
+    expect(chips.length).toBeLessThanOrEqual(EXPANDED_CHIP_CAP);
+    expect(chips.length).toBeGreaterThan(FOLDED_CHIP_CAP);
+  });
+
+  it("stacks chips with constant pitch so they never overlap", () => {
+    const { nodes } = layout({ tasks: many, containerWidth: 360 });
+    const chips = nodes
+      .filter((n) => n.type === "territoryChip")
+      .sort((a, b) => a.position.y - b.position.y);
+    for (let i = 1; i < chips.length; i += 1) {
+      expect(chips[i]!.position.y - chips[i - 1]!.position.y).toBe(CHIP_H + CHIP_GAP);
+    }
+  });
+
+  it("advances rows by the tallest zone in the row (no vertical overlap)", () => {
+    // 三个独立 PRD 根(三个 zone),单列宽 → 3 行。
+    const tasks = [
+      ...Array.from({ length: 12 }, (_, i) => task({ taskId: `a${i}`, rootTaskId: "ra", rootTitle: "A" })),
+      ...Array.from({ length: 2 }, (_, i) => task({ taskId: `b${i}`, rootTaskId: "rb", rootTitle: "B" })),
+      task({ taskId: "c0", rootTaskId: "rc", rootTitle: "C" }),
+    ];
+    const { nodes } = layout({ tasks, containerWidth: 360 });
+    const zones = nodes
+      .filter((n) => n.type === "territoryZone")
+      .sort((a, b) => a.position.y - b.position.y);
+    expect(zones).toHaveLength(3);
+    for (let i = 1; i < zones.length; i += 1) {
+      const prev = zones[i - 1]!;
+      expect(zones[i]!.position.y).toBeGreaterThanOrEqual(prev.position.y + prev.height!);
+    }
+  });
+
+  it("places multiple zones side by side when the container is wide", () => {
+    const tasks = [
+      task({ taskId: "a0", rootTaskId: "ra", rootTitle: "A" }),
+      task({ taskId: "b0", rootTaskId: "rb", rootTitle: "B" }),
+    ];
+    const { nodes } = layout({ tasks, containerWidth: 360 * 3 });
+    const zones = nodes.filter((n) => n.type === "territoryZone");
+    expect(zones).toHaveLength(2);
+    expect(zones[0]!.position.y).toBe(zones[1]!.position.y);
+    expect(zones[1]!.position.x).toBeGreaterThan(zones[0]!.position.x);
+  });
+
+  it("renders landing chips inside a landing pseudo-zone", () => {
+    const partition = partitionForSkel("unified", [task()], [], [], [], []);
+    const { nodes } = layoutTerritory({
+      partition,
+      expandedZones: new Set(),
+      containerWidth: 360,
+      onOpen: noop,
+      onFold: noop,
+    });
+    const zoneNodes = nodes.filter((n) => n.type === "territoryZone");
+    // task 自成 PRD 块 + landing 壳(decision landing 为空时仍可能有 task 块)。
+    for (const zone of zoneNodes) {
+      expect(zone.width).toBeGreaterThan(0);
+      expect(zone.height).toBeGreaterThan(0);
+    }
+    expect(zoneNodes.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tools/gates/line-budgets.json
+++ b/tools/gates/line-budgets.json
@@ -7,7 +7,7 @@
     "doc-sync": 350,
     "preset": 373,
     "cli": 140,
-    "gui": 17776,
+    "gui": 18150,
     "daemon": 1479,
     "fleet": 222,
     "authority-write-path": 0,

--- a/tools/gates/test/fixtures/gui-territory-rebuild-production-paths.json
+++ b/tools/gates/test/fixtures/gui-territory-rebuild-production-paths.json
@@ -1,0 +1,18 @@
+[
+  {
+    "path": "packages/gui/src/renderer/graph/territoryLayout.ts",
+    "module": "gui"
+  },
+  {
+    "path": "packages/gui/src/renderer/graph/nodes/TerritoryNode.tsx",
+    "module": "gui"
+  },
+  {
+    "path": "packages/gui/src/renderer/views/GraphView.tsx",
+    "module": "gui"
+  },
+  {
+    "path": "packages/gui/src/renderer/views/PresetsView.tsx",
+    "module": "gui"
+  }
+]

--- a/tools/gates/test/module-policy.test.mjs
+++ b/tools/gates/test/module-policy.test.mjs
@@ -137,3 +137,8 @@ test("preset provider fixture keeps catalog resolution and its public contract i
   const fixture = JSON.parse(readFileSync(new URL("./fixtures/preset-provider-production-paths.json", import.meta.url), "utf8"));
   for (const row of fixture) assert.deepEqual(classifyPath(row.path), { module: row.module, kind: "production" }, row.path);
 });
+
+test("GUI territory rebuild fixture bills the two-level layout paths to gui", () => {
+  const fixture = JSON.parse(readFileSync(new URL("./fixtures/gui-territory-rebuild-production-paths.json", import.meta.url), "utf8"));
+  for (const row of fixture) assert.deepEqual(classifyPath(row.path), { module: row.module, kind: "production" }, row.path);
+});

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -8,6 +8,7 @@ export const guiVitestManifest = [
   "packages/gui/test/terminal-renderer.vitest.ts",
   "packages/gui/test/genealogy.vitest.ts",
   "packages/gui/test/territory.vitest.ts",
+  "packages/gui/test/territory-layout.vitest.ts",
   "packages/gui/test/ego-canvas.vitest.ts",
   "packages/gui/test/territory-progress.vitest.ts",
   "packages/gui/test/graph-colormode.vitest.ts",


### PR DESCRIPTION
# English

## Summary

Restores the territory view's two-level structure and replaces the raw-JSON preset provenance panel with structured fields.

With 1174 tasks loaded, the territory view rendered every block as a few-pixel-tall sliver stacked in a single column down the middle of the canvas — titles unreadable, no spacing, most of the width empty, and nothing clickable even though the header still advertised "click a chip inside a block → spotlight". The cause was structural: this line's rewrite collapsed the territory from two levels to one. The archive line had `Section → Zone → Member` partitioning, `deriveGridCols(zoneAreaWidth)` deriving column count from available width, and separate `TerritoryZoneNode` / `TerritoryChipNode` nodes. The rewrite kept a single `TerritoryNode` and no partition layer, so there was nothing to group 1174 blocks into and no column count to lay them out against.

Production-Delta: +462/-156

## What Changed

- Territory is two-level again: zones group members, chips lay out inside a zone on a width-derived grid, and a chip click reaches the spotlight view.
- The collapsed single-level implementation is removed in the same commit — the two do not coexist.
- Preset provenance panel renders `preset-snapshot/v1` as structured fields: digest plus four sha256 rows, each truncated with the full value on hover and click-to-copy.
- The archive implementation was used as a reference, not copied: the two lines differ in data sources, node registration and colorMode, so this is a reimplementation against the current API.

## Task And Scope

- Harness task: `task_01KZRMKJT7YKQ2TNXA8WR1W5DN` (W1 authority/daemon)
- Branch: `codex/gui-territory`
- Public scope: GUI renderer — territory graph and preset detail panel
- Private planning/evidence updated: yes (`artifacts/report-glm-gui-territory-preset.md`)
- Out of scope: the data-side reason every block currently reports as unprojected (handled by the migration line); the archive's card-style decision chip

## Version Impact

- Version: no version change because this is a renderer fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gui-test-manifest.mjs` — the new territory layout test is registered here alongside `tools/test-tier-manifest.mjs`
- Authority: task `task_01KZRMKJT7YKQ2TNXA8WR1W5DN` (W1 authority/daemon); defect reported by the repository owner on 2026-08-15 from desktop use, with the archive line named as the visual and structural baseline
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/rebuild/main` SHA: `69ef256d`
- Branch merge-base with `origin/rebuild/main`: `69ef256d`
- Last `git fetch origin` time: 2026-08-15, immediately before opening this PR
- Sync method: rebase onto `69ef256d`, resolving a `line-budgets.json` conflict against #1418
- Public diff command: `git diff 69ef256d..codex/gui-territory`
- Private evidence commit/path: `harness/tasks/task_01KZRMKJT7YKQ2TNXA8WR1W5DN-w1-authority-daemon/artifacts/report-glm-gui-territory-preset.md`
- Reviewer evidence path: same report
- GitHub Actions `rewrite-ci` run URL: pending — filled in after the run starts
- [x] `git diff --check`
- [x] `npm run test:gui` — 178 tests across 23 files
- [x] `npm run test:e2e` — 2/2, including the territory-chip-to-spotlight path, which is the interaction that was broken
- [x] New `territory-layout.vitest.ts` registered in `tools/test-tier-manifest.mjs` and `tools/gui-test-manifest.mjs`
- [x] Renderer complexity gate and banned-token gate pass; duplicate-definition gate adds no new GUI violations
- [x] `line-budget`: the GUI ceiling is raised to 18150 against an actual 18082 (68 lines of headroom), with a production-paths fixture wired into `module-policy.test.mjs`. Restoring a level of structure costs lines; the ratchet is loosened by the minimum that covers it, not by a round number. The `daemon` ceiling stays at #1418's tightened 1479 — this change does not touch daemon.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: the implementing worker ran `check:local` at fast tier rather than the full set, and could not verify against the owner's running desktop instance — the dev renderer is pinned to port 5173 and that port was occupied by the owner's session, so a second dev instance was not possible. It verified through the GUI test and e2e suites instead. `rewrite-ci` covers the remainder and is the authoritative gate.

## Review Evidence

- Self-review: CEO located the root cause before commissioning the work by diffing the two lines' node sets and territory modules, and wrote that comparison into the work packet so the fix would restore a known-good structure rather than invent a new one. The first attempt was cancelled and re-dispatched precisely because it lacked this reference.
- Reviewer subagent: not used
- Human review: pending — this is a visual change and the owner is the acceptance authority
- Blocking findings: none

## Residual Risk

- Every block currently classifies as unprojected, which is a data-side condition from the incomplete ledger migration, not a rendering bug. The layout was deliberately required to look right under that condition rather than filter it away, but the view will look different again once projections are populated.
- The archive line's card-style decision chip (with coverage indicator and stacking) was not restored; decision chips remain compact rows with a state badge. Out of scope here, worth a look during the owner's visual pass.

## References

- Task: `task_01KZRMKJT7YKQ2TNXA8WR1W5DN`
- Evidence: `artifacts/report-glm-gui-territory-preset.md`
- Review: `artifacts/mission-glm-gui-territory-preset.md`

---

# 中文

## 概要

恢复领地视图的两级结构,并把 preset 溯源面板从裸 JSON 改为结构化字段。

在装载 1174 个 task 的情况下,领地视图把每个块渲染成几像素高的细条、沿画布中央堆成一竖列——标题读不出、块间没有间距、画布左右大片空白、而且点不动,尽管头部仍写着「块内 chip 单击 → 聚光灯」。根因是结构性的:本线重写时把领地从两级塌成了一级。archive 线有 `Section → Zone → Member` 分区、`deriveGridCols(zoneAreaWidth)` 按可用宽度派生列数、以及 `TerritoryZoneNode` / `TerritoryChipNode` 两种节点;重写只保留了单个 `TerritoryNode` 且没有分区层,于是既没有东西把 1174 个块聚成组,也没有列数可供排布。

生产行数变更声明见英文段(G33 恰一行)。

## 改动内容

- 领地恢复两级:zone 聚合 member,chip 在 zone 内按宽度派生的网格排布,chip 单击可抵达聚光灯视图。
- 塌陷的单级实现在同一 commit 中删除——两者不并存。
- preset 溯源面板按 `preset-snapshot/v1` 契约结构化渲染:digest 加四行 sha256,每行截断显示、悬停看全量、单击复制。
- archive 实现是参考而非照搬:两条线在数据源、节点注册方式与 colorMode 上都不同,本 PR 是基于当前 API 的重新实现。

## 任务与范围

- Harness 任务:`task_01KZRMKJT7YKQ2TNXA8WR1W5DN`(W1 authority/daemon)
- 分支:`codex/gui-territory`
- 公开范围:GUI renderer——领地关系图与 preset 详情面板
- 私有计划 / 证据是否已更新:yes(`artifacts/report-glm-gui-territory-preset.md`)
- 范围外:当前所有块都报为「未投影」的数据侧原因(由迁移线处理);archive 的卡片式 decision chip

## 版本影响

- 版本:不改版本,原因是这是 renderer 修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:yes
- protected surface 范围:`tools/gui-test-manifest.mjs`——新增的领地布局测试在此登记,与 `tools/test-tier-manifest.mjs` 并列
- 依据:任务 `task_01KZRMKJT7YKQ2TNXA8WR1W5DN`(W1 authority/daemon);仓库所有者 2026-08-15 在桌面使用中报告的缺陷,并点名 archive 线为视觉与结构基准
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/rebuild/main` 基准 SHA:`69ef256d`
- 当前分支与 `origin/rebuild/main` 的 merge-base:`69ef256d`
- 最近一次 `git fetch origin` 时间:2026-08-15,开 PR 前即时
- 同步方式:rebase 到 `69ef256d`,并针对 #1418 解了 `line-budgets.json` 冲突
- 公开 diff 命令:`git diff 69ef256d..codex/gui-territory`
- 私有证据 commit/path:`harness/tasks/task_01KZRMKJT7YKQ2TNXA8WR1W5DN-w1-authority-daemon/artifacts/report-glm-gui-territory-preset.md`
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待补(run 启动后填)
- [x] `git diff --check`
- [x] `npm run test:gui` — 23 个文件 178 个测试
- [x] `npm run test:e2e` — 2/2,含 territory-chip → 聚光灯链路,正是原先坏掉的那个交互
- [x] 新增 `territory-layout.vitest.ts` 已登记 `tools/test-tier-manifest.mjs` 与 `tools/gui-test-manifest.mjs`
- [x] renderer 复杂度门与禁符号门通过;重复定义门无新增 GUI 违例
- [x] `line-budget`:GUI ceiling 抬到 18150,实测占用 18082(余量 68 行),并带 production-paths fixture 真实接线 `module-policy.test.mjs`。恢复一层结构必然增行,棘轮只按刚好覆盖的幅度放松,不取整数留白。`daemon` ceiling 保持 #1418 收紧后的 1479——本改动不碰 daemon。
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- 未跑项及原因:实现方跑的是 fast tier 的 `check:local` 而非全量;也无法在所有者正在运行的桌面实例上验证——dev renderer 端口被钉死在 5173,而该端口被所有者的会话占用,起不了第二个 dev 实例,因此改用 GUI 测试套件与 e2e 验证。其余由 `rewrite-ci` 覆盖,它是权威门。

## 复核证据

- 自评:CEO 在委托前先对比了两条线的节点集合与领地模块,定位到根因,并把这份对比写进任务包,使修复去恢复一个已知可用的结构而不是重新发明一个。第一次派发正是因为缺这份参考而被中止重派。
- Reviewer subagent:未使用
- 人工复核:待泽宇——这是视觉改动,所有者是验收权威
- 阻塞发现:无

## 残留风险

- 当前每个块都归类为「未投影」,这是台账迁移未完成造成的数据侧状态,不是渲染缺陷。本次刻意要求布局在该状态下也要好看、而不是把它过滤掉;但投影补齐后视图观感会再次变化。
- archive 线的卡片式 decision chip(带覆盖灯与堆叠效果)未恢复,decision chip 目前仍是紧凑行加 state 徽章。本包范围外,值得在所有者视觉验收时一并看。

## 参考

- 任务:`task_01KZRMKJT7YKQ2TNXA8WR1W5DN`
- 证据:`artifacts/report-glm-gui-territory-preset.md`
- 复核:`artifacts/mission-glm-gui-territory-preset.md`
