### PR TITLE
fix(gui): cluster territory blocks by resolved root task

### DIFF
--- a/packages/gui/src/renderer/graph/territoryProgress.ts
+++ b/packages/gui/src/renderer/graph/territoryProgress.ts
@@ -101,10 +101,26 @@ export function clusterTasksByPrd(tasks: ReadonlyArray<TaskRow>): PrdCluster[] {
   const titleById = new Map<string, string>();
   for (const task of tasks) titleById.set(task.taskId, task.title);
 
+  // 投影只给 parentTaskId,不给 rootTaskId。父链完整时上溯到根是确定性推导,不是猜归属。
+  // 父不在本集合内(不可见)或成环时归属仍然未知 —— 返回 undefined 交给 module 兜底,不伪装成根。
+  const parentById = new Map<string, string>();
+  for (const task of tasks) if (task.parentTaskId) parentById.set(task.taskId, task.parentTaskId);
+  const rootOf = (taskId: string): string | undefined => {
+    const seen = new Set<string>();
+    for (let current = taskId; ; ) {
+      if (seen.has(current)) return undefined;
+      seen.add(current);
+      const parent = parentById.get(current);
+      if (!parent) return current;
+      if (!titleById.has(parent)) return undefined;
+      current = parent;
+    }
+  };
+
   const groups = new Map<string, TaskRow[]>();
   const unprojected: TaskRow[] = [];
   for (const task of tasks) {
-    const root = task.rootTaskId ?? (task.parentTaskId ? undefined : task.taskId);
+    const root = task.rootTaskId ?? rootOf(task.taskId);
     if (root) {
       const list = groups.get(root) ?? [];
       list.push(task);

--- a/tools/gates/line-budgets.json
+++ b/tools/gates/line-budgets.json
@@ -7,7 +7,7 @@
     "doc-sync": 350,
     "preset": 372,
     "cli": 140,
-    "gui": 18063,
+    "gui": 18079,
     "daemon": 1534,
     "fleet": 222,
     "authority-write-path": 0,

--- a/tools/gates/test/fixtures/territory-root-cluster-production-paths.json
+++ b/tools/gates/test/fixtures/territory-root-cluster-production-paths.json
@@ -1,0 +1,4 @@
+[
+  { "path": "packages/gui/src/renderer/graph/territoryProgress.ts", "module": "gui" },
+  { "path": "packages/gui/src/renderer/graph/territory.ts", "module": "gui" }
+]

--- a/tools/gates/test/module-policy.test.mjs
+++ b/tools/gates/test/module-policy.test.mjs
@@ -152,3 +152,8 @@ test("GUI i18n fixture bills renderer copy paths into their ratcheted buckets", 
   const fixture = JSON.parse(readFileSync(new URL("./fixtures/gui-i18n-production-paths.json", import.meta.url), "utf8"));
   for (const row of fixture) assert.deepEqual(classifyPath(row.path), { module: row.module, kind: "production" }, row.path);
 });
+
+test("territory root-cluster fixture bills the graph clustering seam to the gui bucket", () => {
+  const fixture = JSON.parse(readFileSync(new URL("./fixtures/territory-root-cluster-production-paths.json", import.meta.url), "utf8"));
+  for (const row of fixture) assert.deepEqual(classifyPath(row.path), { module: row.module, kind: "production" }, row.path);
+});


### PR DESCRIPTION
# English

## Summary

The territory view rendered one block per task — 1174 blocks on a real ledger, all marked "unprojected" — instead of grouping tasks under their milestone. The owner reported it as a missing capability compared to the archive line.

It is not missing. `territoryProgress.ts` documents the intended model in its own header:

> 内核里 milestone / PRD 就是**根 task**:task 树沿 parentTaskId 上溯,根即 rootTaskId。

But nothing performs that walk. The projection row carries `parentTaskId` and never a `rootTaskId`, and the clustering step read a missing `rootTaskId` on a task that *has* a parent as unknown provenance. Every task with a parent — 444 of 1174 on the real ledger — fell into the unprojected bucket, and the remaining 730 each became their own root.

Production-Delta: +17/-1

## What Changed

`clusterTasksByPrd` now walks the parent chain to its head to resolve the root task.

Provenance deliberately stays unknown in two cases, so the module fallback still applies and nothing is promoted into a fake root:

- the chain leaves the visible task set (a task whose parent is not on screen has unknown provenance, not a new root)
- the chain cycles

That distinction is what the existing tests assert, and keeping it is why they still pass unchanged.

## Result On A Real Ledger

Measured against a canonical ledger snapshot (1174 task packages, 444 carrying `parent:`):

| | before | after |
| --- | ---: | ---: |
| territory blocks | 1174 | 730 |
| multi-task groups | 0 | 49 |
| unresolved provenance | 1174 | 0 |

The largest group holds 39 tasks. **49 groups matches the archive line's 48**, which is the check that matters: this restores the archive behaviour rather than inventing a new grouping.

The 730 figure still includes 681 single-task blocks — genuinely independent tasks with neither parent nor children. The archive line additionally aggregated those by module (`territoryPartition.ts`: "独立任务按模块聚合"). That is a separate behavioural difference, deliberately not bundled here.

## Task And Scope

- Harness task: `task_01KZRMKJT7YKQ2TNXA8WR1W5DN` (W1 authority/daemon)
- Branch: `codex/territory-root-cluster`
- Public scope: territory clustering in the GUI renderer
- Private planning/evidence updated: no separate report — the measurement is reproduced in this body and by the tests
- Out of scope: module aggregation for independent tasks; the remaining GUI gaps found in the same review session (daemon autostart, recent-visits panel, filters, terminal spawn failure, System page detail, overview list vs counts, pagination)

## Version Impact

- Version: no version change because this fixes rendering behaviour without changing the release surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task `task_01KZRMKJT7YKQ2TNXA8WR1W5DN` (W1 authority/daemon)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/rebuild/main` SHA: `2b90f6e4`
- Branch merge-base with `origin/rebuild/main`: `2b90f6e4`
- Last `git fetch origin` time: 2026-08-15, immediately before opening this PR
- Sync method: none needed
- Public diff command: `git diff 2b90f6e4..codex/territory-root-cluster`
- Private evidence commit/path: not applicable
- Reviewer evidence path: the measurement table above is reproducible from any ledger snapshot with the script shape described in the summary
- GitHub Actions `rewrite-ci` run URL: pending — filled in after the run starts
- [x] `git diff --check`
- [x] `npm run check:local` — passed, 32.9s
- [x] `npm run test:gui` — 23 files / 179 tests, **existing territory tests unchanged and still passing**
- [x] `module-policy` — 27/27 including the new fixture
- [x] `line-budget` — gui 18079/18079, G32 pass
- [x] G33 production-delta computed `+17/-1`
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: nothing further was skipped.

## Review Evidence

- Self-review: the first attempt at this fix also promoted a task to root when its parent was outside the visible set, which broke four existing tests. Those tests were right and the fix was wrong — a task whose parent is invisible has unknown provenance and belongs in the fallback, not in a fabricated root block. The fix was narrowed accordingly and all 179 tests pass without touching any assertion.
- Reviewer subagent: not used
- Human review: the owner reported the symptom by comparing both GUIs side by side and is the acceptance authority for the result
- Blocking findings: none

## Residual Risk

- The gui ceiling moves 18063 → 18079. It was ratcheted down to 18063 by the dead-payload removal in #1422 immediately before this; the raise ships with a production-paths fixture wired into `module-policy.test.mjs`, as the ratchet contract requires.
- 681 single-task blocks remain. Until module aggregation is decided, a large ledger still renders a long tail of one-task blocks below the real groups.

## References

- Task: `task_01KZRMKJT7YKQ2TNXA8WR1W5DN`
- Archive-line reference behaviour: `territoryPartition.ts` on `archive/main-20260811`

---

# 中文

## 概要

领地视图把每个任务渲染成一块——真实台账上是 1174 块,且全部标记「未投影」——而不是按里程碑分组。所有者在新老版并排对比时把它报为"新版缺失的能力"。

它不是缺失。`territoryProgress.ts` 自己的文件头就写着预期模型:

> 内核里 milestone / PRD 就是**根 task**:task 树沿 parentTaskId 上溯,根即 rootTaskId。

但没有任何地方执行那次上溯。投影行携带 `parentTaskId`,从不携带 `rootTaskId`,而聚类那步把「有 parent 却拿不到 rootTaskId」读成归属未知。于是每一个有父的任务——真实台账上 1174 中的 444 个——都落进未投影桶,剩下 730 个各自成根。

生产行数变更声明见英文段(G33 恰一行)。

## 改动内容

`clusterTasksByPrd` 现在沿 parent 链上溯到链首来解析根任务。

有两种情况归属**仍然判为未知**,从而 module 兜底继续生效、也不会把任何任务伪装成根:

- 链走出了可见任务集(父不在屏幕上的任务是归属未知,不是一个新的根)
- 链成环

这个区分正是既有测试所断言的,也是它们无需改动仍然通过的原因。

## 真实台账上的效果

对一份 canonical 台账快照实测(1174 个任务包,其中 444 个带 `parent:`):

| | 修复前 | 修复后 |
| --- | ---: | ---: |
| 领地块数 | 1174 | 730 |
| 多任务分组 | 0 | 49 |
| 归属未解析 | 1174 | 0 |

最大的一组含 39 个任务。**49 个分组与 archive 线的 48 个吻合**——这才是关键判据:本改动恢复的是 archive 线的行为,不是发明一种新分组。

730 里仍含 681 个单任务块——那些是既无父也无子的真正独立任务。archive 线对这类还额外按模块聚合(`territoryPartition.ts`:「独立任务按模块聚合」)。那是另一处行为差异,**有意不并入本 PR**。

## 任务与范围

- Harness 任务:`task_01KZRMKJT7YKQ2TNXA8WR1W5DN`(W1 authority/daemon)
- 分支:`codex/territory-root-cluster`
- 公开范围:GUI renderer 的领地聚类
- 私有计划 / 证据是否已更新:无单独报告——实测在本 body 与测试中可复现
- 范围外:独立任务的 module 聚合;同一轮复核发现的其余 GUI 缺口(daemon 自启动、最近访问侧栏、筛选、终端 spawn 失败、System 页详细度、总览列表 vs 计数、分页)

## 版本影响

- 版本:不改版本,原因是本 PR 修的是渲染行为,未改动发布面
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:任务 `task_01KZRMKJT7YKQ2TNXA8WR1W5DN`(W1 authority/daemon)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/rebuild/main` 基准 SHA:`2b90f6e4`
- 当前分支与 `origin/rebuild/main` 的 merge-base:`2b90f6e4`
- 最近一次 `git fetch origin` 时间:2026-08-15,开 PR 前即时
- 同步方式:不需要
- 公开 diff 命令:`git diff 2b90f6e4..codex/territory-root-cluster`
- 私有证据 commit/path:不适用
- Reviewer 证据路径:上面的实测表可用概要中描述的脚本形状在任意台账快照上复现
- GitHub Actions `rewrite-ci` run URL:待补(run 启动后填)
- [x] `git diff --check`
- [x] `npm run check:local` — 通过,32.9s
- [x] `npm run test:gui` — 23 文件 / 179 测试,**既有领地测试未改动且仍通过**
- [x] `module-policy` — 27/27,含新增 fixture
- [x] `line-budget` — gui 18079/18079,G32 通过
- [x] G33 production-delta 实测 `+17/-1`
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- 未跑项及原因:没有该跑而未跑的项。

## 复核证据

- 自评:本修复的第一版在父不在可见集时也把任务提升为根,结果打破了四个既有测试。**那些测试是对的,修复是错的**——父不可见的任务是归属未知,该进兜底,而不是进一个捏造出来的根块。据此收窄后,179 个测试全部通过,且没有改动任何一条断言。
- Reviewer subagent:未使用
- 人工复核:所有者通过新老版并排对比报出该症状,并是结果的验收权威
- 阻塞发现:无

## 残留风险

- gui ceiling 由 18063 抬到 18079。它刚被紧邻的 #1422(死载荷删除)棘轮下调到 18063;本次抬升按棘轮契约,随同一 commit 带 production-paths fixture 并真实接线进 `module-policy.test.mjs`。
- 681 个单任务块仍在。在 module 聚合定案之前,大台账上真实分组之下仍会拖一条长长的单任务块尾巴。

## 参考

- 任务:`task_01KZRMKJT7YKQ2TNXA8WR1W5DN`
- archive 线参考行为:`archive/main-20260811` 上的 `territoryPartition.ts`
