### PR TITLE
feat(skills): add a self-contained harness-migration skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,27 @@ Ready to use it on a project? Continue with the
 
 The ledger format has changed by a generation and this project keeps no
 backward compatibility, so existing repositories cannot be upgraded in place.
-If you have a repository with an older-format ledger, follow the
-[migration guide](./docs-release/migration-genesis-replay.md) — the old
-repository is archived read-only and replayed into a new one; it is never at
-risk.
+The old repository is archived read-only and replayed into a new one; it is
+never at risk.
+
+**You do not have to do this by hand, and you do not need the current version
+installed first.** Paste this to a coding agent working in the repository you
+want to migrate:
+
+> Read `skills/harness-migration/SKILL.md` from
+> https://github.com/FairladyZ625/harness-anything (branch `rebuild/main`) and
+> follow it to migrate this project's `harness/` ledger to the current format.
+> Ask me before each decision the skill says to ask about.
+
+The skill fetches the current source into a temporary directory and runs
+everything from there, so an older Harness installation on the same machine —
+including a running daemon — is left untouched. It stops and asks you at each
+point where a choice destroys something: file conflicts between your ledger and
+the freshly initialized one, records the strict format rejects, and presets that
+must be rebuilt rather than copied.
+
+Prefer to drive it yourself? The [migration guide](./docs-release/migration-genesis-replay.md)
+is the same procedure in reference form.
 
 ## How It Works
 
@@ -142,6 +159,7 @@ The result is a repository that remembers more than its code:
 - [Learn](./docs-release/learn/en/00-overview.md) — understand the memory model, gates, and compounding loop. ([中文](./docs-release/learn/zh/00-overview.md))
 - [Architecture](./docs-release/architecture/en/00-overview.md) — explore the kernel, storage model, write path, and projections. ([中文](./docs-release/architecture/zh/00-overview.md))
 - [Release posture](./docs-release/release-posture.md) — see what is shipped, foundational, or planned.
+- [Migration](./docs-release/migration-genesis-replay.md) — replay an older-generation ledger into the current format. ([agent skill](./skills/harness-migration/SKILL.md))
 - [Minimal example](./examples/minimal-project/) — inspect the smallest working project.
 
 ## Contributing

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,7 +99,17 @@ Demo 会构建 CLI、创建一个临时项目、跑通一条真实任务循环�
 
 ## 破坏性变更：已有仓库需要迁移
 
-台账格式发生了代差变更，本项目不保留向后兼容，因此已有仓库无法原地升级。如果你本地有老格式的台账仓，请阅读[迁移指南](./docs-release/migration-genesis-replay.zh-CN.md)——老仓会被归档为只读底稿并重放进新仓，全程不受损害。
+台账格式发生了代差变更，本项目不保留向后兼容，因此已有仓库无法原地升级。老仓会被归档为只读底稿并重放进新仓，全程不受损害。
+
+**这件事不必手工做，也不需要你先装好当前版本。** 把下面这段话交给一个在待迁移仓库里工作的编码 agent：
+
+> 读取 https://github.com/FairladyZ625/harness-anything （分支 `rebuild/main`）的
+> `skills/harness-migration/SKILL.md`，按它把本项目的 `harness/` 台账迁移到当前格式。
+> skill 里说要问我的每个决定，都先问我。
+
+该 skill 会把当前源码拉到一个临时目录并全程在那里运行，因此同一台机器上已有的老版 Harness——包括正在运行的 daemon——不受任何影响。凡是「做出选择就会毁掉某样东西」的地方它都会停下来问你：你的台账与新初始化仓库之间的文件冲突、被严格校验拒收的记录、以及必须重做而非搬运的 preset。
+
+想自己动手？[迁移指南](./docs-release/migration-genesis-replay.zh-CN.md)是同一套流程的参考文档形态。
 
 ## 它如何工作
 
@@ -125,6 +135,7 @@ Harness Anything 用三个长期存在的原语承载 agent 工作：
 - [理解（Learn）](./docs-release/learn/zh/00-overview.md)：理解记忆模型、门禁与复利循环。（[English](./docs-release/learn/en/00-overview.md)）
 - [架构（Architecture）](./docs-release/architecture/zh/00-overview.md)：了解内核、存储模型、写入路径与投影。（[English](./docs-release/architecture/en/00-overview.md)）
 - [发布态势](./docs-release/release-posture.md)：查看哪些能力已经发布、仍是基础设施或尚在规划。
+- [迁移](./docs-release/migration-genesis-replay.zh-CN.md)：把上一代台账重放进当前格式。（[agent skill](./skills/harness-migration/SKILL.md)）
 - [最小示例](./examples/minimal-project/)：查看最小可运行项目。
 
 ## 贡献

--- a/skills/harness-migration/SKILL.md
+++ b/skills/harness-migration/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: harness-migration
+description: Migrate a previous-generation Harness Anything repository into the current format, from a machine that does not have the current Harness installed. Use when a project's harness/ ledger predates the current generation, when ha commands fail against an existing repository because its layout is from an older release, or when a user asks to upgrade, migrate, or replay an old Harness ledger. Fetches the current source into a temporary location, so it works with no prior installation and does not disturb an existing Harness install.
+---
+
+# Harness Migration
+
+Replay a previous-generation `harness/` ledger into a freshly initialized
+current-format repository. The source is never written to.
+
+**This skill assumes nothing is installed.** It fetches the current source into
+a throwaway directory and runs everything from there. A Harness installation
+already on the machine — including a running daemon — is left untouched.
+
+## The one rule that makes this work
+
+**Every command runs against an isolated daemon user root.** Export it once and
+keep it exported for the whole session:
+
+```bash
+export HARNESS_MIGRATION_WORK="$(mktemp -d "${TMPDIR:-/tmp}/ha-migration.XXXXXX")"
+export HARNESS_DAEMON_USER_ROOT="$HARNESS_MIGRATION_WORK/daemon-user-root"
+mkdir -p "$HARNESS_DAEMON_USER_ROOT"
+```
+
+Without it, the CLI connects to whatever Harness daemon is already running on
+the machine and that daemon serves a different generation of the code. The
+observed failure is not a helpful conflict message — it is:
+
+```
+error code=missing_vertical hint=[object Object]
+```
+
+with `"origin":"daemon"` in the JSON receipt. If you see that, `HARNESS_DAEMON_USER_ROOT`
+is not set. Do **not** stop or uninstall the user's existing Harness to work
+around it: isolation is sufficient, and stopping their daemon interrupts work
+you are not responsible for restoring.
+
+## 1. Fetch the current source
+
+```bash
+cd "$HARNESS_MIGRATION_WORK"
+git clone --depth 1 --branch rebuild/main https://github.com/FairladyZ625/harness-anything.git ha-src
+cd ha-src
+npm install --no-audit --no-fund
+export HA="node $HARNESS_MIGRATION_WORK/ha-src/packages/cli/src/index.ts"
+$HA --version
+```
+
+Expect a version line. The repository is about 10 MB and install takes seconds.
+
+**Do not look for `node_modules/.bin/ha`.** The published `bin` points at
+`dist/`, which a source checkout does not contain, so the linked binary is
+absent. Running the TypeScript entry directly is the supported path here and
+needs no build step.
+
+## 2. Freeze and back up the source ledger
+
+Ask the user for the absolute path of the repository holding the old `harness/`
+directory.
+
+```bash
+export ARCHIVE_SOURCE="$(cd /absolute/path/to/legacy-repository && pwd -P)"
+export WORK_SOURCE="$HARNESS_MIGRATION_WORK/legacy-copy"
+mkdir -p "$HARNESS_MIGRATION_WORK/backups"
+export SOURCE_SHA_BEFORE="$(COPYFILE_DISABLE=1 tar -cf - -C "$ARCHIVE_SOURCE" . | shasum -a 256 | awk '{print $1}')"
+printf 'source-before %s\n' "$SOURCE_SHA_BEFORE"
+git -C "$ARCHIVE_SOURCE" bundle create "$HARNESS_MIGRATION_WORK/backups/legacy.bundle" --all
+git -C "$ARCHIVE_SOURCE" bundle verify "$HARNESS_MIGRATION_WORK/backups/legacy.bundle"
+cp -a "$ARCHIVE_SOURCE" "$WORK_SOURCE"
+```
+
+Show the user both backup paths and **stop until they confirm one independent
+copy exists off this machine.** Migration is one-shot; this is the only point
+where that confirmation is cheap.
+
+Every repair below targets `$WORK_SOURCE`. `$ARCHIVE_SOURCE` is read-only and
+its digest is re-checked at the end.
+
+## 3. Initialize the destination
+
+Ask the user for the new repository id, owner person id, and display name.
+
+```bash
+export TARGET_REPO="$HARNESS_MIGRATION_WORK/new-repository"
+mkdir -p "$TARGET_REPO" && cd "$TARGET_REPO"
+git init -q . && git commit -q --allow-empty -m "base"
+$HA init --repo-id <new-repo-id> --person-id <owner-person-id> --display-name '<display-name>'
+```
+
+Expect a receipt listing created paths and a commit sha. The first command in a
+fresh user root starts an isolated daemon on its own; that is expected and it
+belongs to this migration, not to the user's installation.
+
+If init fails, move this directory aside and start a new empty one. Do not
+repair a half-initialized target in place.
+
+## 4. Dry-run and read the output
+
+```bash
+export DRY_RUN="$HARNESS_MIGRATION_WORK/dry-run.txt"
+$HA migrate import --source "$WORK_SOURCE" --dry-run > "$DRY_RUN" 2>&1; echo "exit=$?"
+cat "$DRY_RUN"
+```
+
+**Use the importer as the classifier.** Do not inventory the old repository or
+invent categories of your own. Act only on what the report prints:
+
+- five entity rows (task / decision / fact / relation / coverage)
+- `Format validation` and each `- SKIP` line
+- `Attribution`
+- the authored coverage table and each `required` row
+- `Authored reconciliation`
+
+Branch on those rows:
+
+| What the report shows | Go to |
+| --- | --- |
+| a `required` row saying `destination content differs` | section 5 |
+| `required` on `presets/**` | section 6 |
+| any `- SKIP` line | section 7 |
+| any other `required` row | show the exact row to the user and stop — this workflow does not cover it |
+| no `required`, no `SKIP` | section 8 |
+
+## 5. Resolve destination conflicts — ask, one at a time
+
+`ha init` seeds README, ADR, milestone, walls and `people.yaml` files. A source
+ledger usually has its own versions of those paths. Each conflict row prints
+both sides and the exact flag to use:
+
+```
+| people.yaml | required | 1 | FAIL | destination content differs:
+  source kind=file, source sha256=240b9a55…, source bytes=561;
+  destination kind=file, destination sha256=39e0af13…, destination bytes=512;
+  resolve with --resolve harness/people.yaml=destination|source |
+```
+
+For every conflict row, show the user both sides and ask for one answer:
+`destination` (keep what `ha init` produced, discard the source version) or
+`source` (replace with the source version). **Do not pick a default.** If it
+helps them decide, print the two files.
+
+Collect the answers into repeated flags and re-run:
+
+```bash
+export RESOLVE_ARGS=(
+  --resolve 'harness/context/README.md=destination'
+  --resolve 'harness/people.yaml=source'
+)
+$HA migrate import --source "$WORK_SOURCE" "${RESOLVE_ARGS[@]}" --dry-run > "$DRY_RUN" 2>&1; echo "exit=$?"
+```
+
+Each answer comes back as a row beginning `resolved: destination` or
+`resolved: source`, carrying both digests so the discarded side stays visible.
+A conflict left out of the flags stays `required`.
+
+**`people.yaml` deserves a word to the user.** It is the person roster. Picking
+`destination` means the migrated ledger's history references people who are not
+in the new roster; picking `source` means the roster the new repository was
+initialized with is replaced. Roster merging is not yet available, so say this
+plainly and let them choose.
+
+A directory target accepts only `=destination`. If `=source` reports that the
+target is a directory, show the error and have the user handle that path.
+
+## 6. Rebuild legacy presets as v3 packages
+
+Legacy preset packages are not carried over — they are rebuilt against the
+current format.
+
+```bash
+find "$WORK_SOURCE/harness/presets" -mindepth 1 -maxdepth 1 -type d | sort
+$HA preset inspect standard-task --profile baseline --vertical software/coding --locale en-US --json
+```
+
+The `legacy-migration` preset bundled with the current release documents the
+exact v2 → v3 field mapping. Read it:
+
+```bash
+cat "$HARNESS_MIGRATION_WORK/ha-src/packages/preset/assets/software-coding/presets/legacy-migration/PRESET.md"
+```
+
+Build each replacement under `$HARNESS_MIGRATION_WORK/rebuilt-presets/<id>/`,
+then validate and install from the destination:
+
+```bash
+cd "$TARGET_REPO"
+for NEW_PRESET in "$HARNESS_MIGRATION_WORK/rebuilt-presets"/*; do
+  $HA preset validate --source "$NEW_PRESET" --json
+  $HA preset install --source "$NEW_PRESET" --json
+done
+$HA preset audit --vertical software/coding --json
+```
+
+Continue only when every validation reports `"valid": true` and the audit shows
+no blocked package. Then take the old packages out of the copy being imported —
+the archived original still has them:
+
+```bash
+mv "$WORK_SOURCE/harness/presets" "$HARNESS_MIGRATION_WORK/legacy-presets-rebuilt"
+```
+
+Re-run the dry-run from section 4 with `"${RESOLVE_ARGS[@]}"`. The `presets/**`
+row must be gone.
+
+## 7. Repair strict format failures on the working copy
+
+```bash
+grep '^- SKIP ' "$DRY_RUN"
+```
+
+Each line names one rejected entity, its source path, and why strict validation
+refused it — for example a decision whose `occurredAt` is invalid. Show every
+line to the user.
+
+Fix only the named record, **under `$WORK_SOURCE`**. If a value cannot be
+recovered from the record itself, ask the user for it. **Never add a
+compatibility rule to the importer** — a one-time historical artifact does not
+belong in product logic.
+
+Exit code `3` means strict failures remain. Repeat until `Format validation`
+reports none and every entity row has `Skipped = 0`.
+
+## 8. Recreate the destination, then apply once
+
+Source repairs must be replayed into a target that never saw the broken data.
+
+```bash
+cd "$HARNESS_MIGRATION_WORK"
+mv "$TARGET_REPO" "$HARNESS_MIGRATION_WORK/preview-repository"
+mkdir -p "$TARGET_REPO" && cd "$TARGET_REPO"
+git init -q . && git commit -q --allow-empty -m "base"
+$HA init --repo-id <new-repo-id> --person-id <owner-person-id> --display-name '<display-name>'
+for NEW_PRESET in "$HARNESS_MIGRATION_WORK/rebuilt-presets"/*; do $HA preset install --source "$NEW_PRESET" --json; done
+$HA migrate import --source "$WORK_SOURCE" "${RESOLVE_ARGS[@]}" --dry-run; echo "exit=$?"
+```
+
+Apply only when that exits zero, all five rows show `Old = Expected = New` with
+`Skipped = 0`, authored coverage has no `required`, and reconciliation passes.
+
+```bash
+$HA migrate import --source "$WORK_SOURCE" "${RESOLVE_ARGS[@]}"; echo "apply-exit=$?"
+export SOURCE_SHA_AFTER="$(COPYFILE_DISABLE=1 tar -cf - -C "$ARCHIVE_SOURCE" . | shasum -a 256 | awk '{print $1}')"
+test "$SOURCE_SHA_BEFORE" = "$SOURCE_SHA_AFTER" && echo "source untouched"
+```
+
+If apply exits nonzero, keep its output, move the target aside, and restart from
+a fresh `ha init`. **Never re-run apply against a partially imported target.**
+
+## 9. Hand over
+
+Move `$TARGET_REPO` to where the user wants it, then tell them:
+
+- their existing Harness installation was not modified;
+- the migration daemon lives under `$HARNESS_DAEMON_USER_ROOT` and can be removed with the work directory;
+- to use the new repository with their normal installation, register it there.
+
+## Done when
+
+- Apply exited zero and the final dry-run had `Reconciliation: PASS`.
+- All five entity classes show `Old = Expected = New`, `Skipped = 0`.
+- Authored coverage has no `required` row.
+- Every conflict appears as an explicit `resolved:` row.
+- Every legacy preset has a validated v3 replacement installed.
+- `source-before` equals `source-after`.
+
+## Known rough edges
+
+- Connecting to a foreign daemon reports `missing_vertical` with
+  `hint=[object Object]`. That message does not describe the real problem;
+  the cause is a missing `HARNESS_DAEMON_USER_ROOT`.
+- `--daemon-mode direct` does not support `init` — it rejects with
+  `unsupported_command`. Isolation is done with the user root, not with direct mode.

--- a/skills/harness-migration/agents/openai.yaml
+++ b/skills/harness-migration/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness Migration"
+  short_description: "Migrate a previous-generation Harness ledger into the current format"
+  default_prompt: "Use $harness-migration to replay this project's older-format harness/ ledger into a freshly initialized current-format repository, fetching the current source into a temporary directory so no prior installation is required."

--- a/tools/skill-contracts.test.mjs
+++ b/tools/skill-contracts.test.mjs
@@ -15,8 +15,8 @@ test("repository decision skills are discoverable with agent metadata", () => {
     .map((entry) => entry.name)
     .sort();
 
-  assert.deepEqual(skillNames, ["decision", "decisions", "graph-panorama", "preset-creator", "preset-trigger", "vertical-creator"]);
-  for (const skillName of ["decision", "decisions", "graph-panorama", "preset-trigger"]) {
+  assert.deepEqual(skillNames, ["decision", "decisions", "graph-panorama", "harness-migration", "preset-creator", "preset-trigger", "vertical-creator"]);
+  for (const skillName of ["decision", "decisions", "graph-panorama", "harness-migration", "preset-trigger"]) {
     assert.equal(existsSync(path.join(skillsRoot, skillName, "SKILL.md")), true, skillName);
     assert.equal(existsSync(path.join(skillsRoot, skillName, "agents", "openai.yaml")), true, skillName);
   }


### PR DESCRIPTION
# English

## Summary

Migration is the one workflow that cannot assume Harness is installed. The repository being migrated runs the previous generation, and the preset documenting the procedure only becomes reachable *after* a working current-generation install exists — so the guidance was unreachable exactly when it was needed.

`skills/harness-migration/SKILL.md` closes that gap. It fetches the current source into a throwaway directory and runs everything from there, so it works with nothing installed.

**It also isolates the daemon user root for the entire session**, which turned out to matter more than expected. Without it the CLI connects to whatever Harness daemon is already running on the machine — that daemon serves a different generation of the code, and the observed failure is:

```
error code=missing_vertical hint=[object Object]
```

with `"origin":"daemon"` in the JSON receipt. Nothing in that message says "you are talking to a foreign daemon".

Isolation is used rather than stopping or uninstalling the existing Harness. Stopping a user's daemon interrupts work this procedure is not responsible for restoring, and isolation was verified sufficient.

Production-Delta: +0/-0

## What Changed

The skill covers fetch → back up → init → dry-run → resolve conflicts → rebuild presets → repair strict rejects → recreate destination → apply, each step a command, an output to read, and a branch rule. Where a choice destroys something it stops and asks: file conflicts against the freshly initialized ledger, records the strict format rejects, and presets that must be rebuilt rather than copied.

Both READMEs gain a paste-to-your-agent instruction and a documentation-list link. The skill contract test and its inventory assertion are updated, and the skill carries `agents/openai.yaml` like its peers.

## Task And Scope

- Harness task: `task_01M022AR425YG81NS1TRH8BDKR`
- Branch: `codex/migration-skill`
- Out of scope: the skill points at `rebuild/main` by name. When that branch becomes the default, the clone line needs updating — a rename, not a redesign.

## Version Impact

- Version: no version change
- Publish impact: documentation and skills only; no CLI surface changed.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task `task_01M022AR425YG81NS1TRH8BDKR`; owner adjudication in session — a preset requires an install before it can be used, so migration needs a skill that requires nothing, and it must handle colliding with an older installation
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable

## Verification

- Base `origin/rebuild/main` SHA: `55d68ad0`
- Branch merge-base with `origin/rebuild/main`: `55d68ad0`
- Public diff command: `git diff 55d68ad0..codex/migration-skill`

**Every step was executed from a clean clone before being written down**, on a machine that already runs a production Harness daemon — which is what surfaced the collision:

| Step | Result |
| --- | --- |
| `git clone --depth 1 --branch rebuild/main` from GitHub | 2.8s, ~10 MB, lands on `55d68ad0` |
| `npm install --no-audit --no-fund` | seconds; **`node_modules/.bin/ha` is absent** because `bin` targets `dist/`, which a source checkout lacks |
| `node packages/cli/src/index.ts --version` | `0.1.0` — the supported path, no build step |
| `ha init` **without** an isolated user root | `missing_vertical`, `"origin":"daemon"` — reached the machine's existing daemon |
| `ha init` **with** `HARNESS_DAEMON_USER_ROOT` | succeeded, `commit ace48380` |
| `--daemon-mode direct` as an alternative | rejected: `Only task lifecycle, receipt show, and explicit daemon commands exist on rebuild` |
| `ha migrate import --dry-run` against the real legacy corpus | five classes PASS, `required=34`, each conflict printing both digests and its own `--resolve` flag |

The clone was verified to land on the intended commit rather than a stale local branch — an earlier attempt cloned a local ref pinned at `785fc04d` and produced a false "autostart is missing" reading.

- [x] `git diff --check`
- [x] `npm run check:local` — passed, 25.9s
- [x] `node tools/gates/line-budget.mjs --base 55d68ad0` — G32 pass (run separately; `check:local` does not include it)
- [x] repository confirmed `PUBLIC` and `rebuild/main` present on the remote, so the clone line works for an outside user
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: the skill has not yet been executed end-to-end by an agent that lacks this session's context. That is the acceptance test the owner intends to run.

## Review Evidence

- Reviewer subagent: not used
- Blocking findings: none

## Residual Risk

- `missing_vertical` with `hint=[object Object]` is a real defect: the message neither describes the cause nor points anywhere useful. The skill documents the symptom so an agent is not stranded, but the error itself should be fixed.
- The skill records a procedure verified once, on macOS, against one legacy corpus. A repository whose old ledger differs in shape may hit a `required` row the workflow does not cover; it is told to stop and show the row rather than guess.
- `git clone --depth 1 --branch rebuild/main` names a branch that is expected to be renamed at cutover.

## References

- Task: `task_01M022AR425YG81NS1TRH8BDKR`
- Skill: `skills/harness-migration/SKILL.md`
- Spec: `docs-release/migration-genesis-replay.md`
- Predecessors: #1428, #1429, #1430, #1431

---

# 中文

## 概要

迁移是唯一一个**不能假定 Harness 已安装**的工作流。待迁移的仓库跑在上一代格式上,而记录了迁移流程的 preset 只有在当前版本装好之后才够得着——于是恰恰在最需要它的时刻,指引是不可达的。

`skills/harness-migration/SKILL.md` 补上这个缺口:把当前源码拉进一个临时目录,全程在那里运行,因此在什么都没装的机器上也能用。

**它同时把 daemon user root 隔离到整个会话**,这一点比预期更要紧。不隔离时,CLI 会连上机器上已经在跑的那个 Harness daemon——那个 daemon 服务的是另一代代码,实测报错是:

```
error code=missing_vertical hint=[object Object]
```

JSON 回执里 `"origin":"daemon"`。这条消息里没有任何一处说「你连到了别的 daemon」。

采用隔离而不是停掉或卸载已有的 Harness:停掉用户的 daemon 会中断本流程无力恢复的工作,而隔离已实测足够。

生产行数变更声明见英文段。

## 改动内容

skill 覆盖 拉源码 → 备份 → init → dry-run → 处置冲突 → 重做 preset → 修复严格拒收 → 重建目标 → apply,每一步都是命令、要读的输出、分支规则。凡是「做出选择就会毁掉某样东西」的地方它停下来问:与新初始化台账的文件冲突、被严格格式拒收的记录、必须重做而非搬运的 preset。

中英 README 各加了一段可直接粘给 agent 的话,并在文档清单里链接该 skill。skill 契约测试及其清单断言已更新,skill 与同侪一样带 `agents/openai.yaml`。

## 任务与范围

- Harness 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- 分支:`codex/migration-skill`
- 范围外:skill 里按名字指向 `rebuild/main`。该分支成为默认分支后,clone 那行需要改——是改名,不是重新设计。

## 版本影响

- 版本:不改版本
- 发布影响:仅文档与 skills;CLI 命令面未变。

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:任务 `task_01M022AR425YG81NS1TRH8BDKR`;所有者在会话中的裁决——preset 得先装好才能用,所以迁移需要一个什么都不要求的 skill,并且它必须处理与老版本安装的撞车
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用

## 验证

- `origin/rebuild/main` 基准 SHA:`55d68ad0`
- 当前分支与 `origin/rebuild/main` 的 merge-base:`55d68ad0`
- 公开 diff 命令:`git diff 55d68ad0..codex/migration-skill`

**每一步都先在干净克隆上实跑过再写进文档**,而且是在一台已经跑着生产 Harness daemon 的机器上——撞车正是这样暴露的:

| 步骤 | 结果 |
| --- | --- |
| 从 GitHub `git clone --depth 1 --branch rebuild/main` | 2.8 秒,约 10 MB,落在 `55d68ad0` |
| `npm install --no-audit --no-fund` | 数秒;**`node_modules/.bin/ha` 不存在**,因为 `bin` 指向 `dist/`,而源码检出没有它 |
| `node packages/cli/src/index.ts --version` | `0.1.0`——这是受支持的路径,无需构建 |
| **不带**隔离 user root 跑 `ha init` | `missing_vertical`,`"origin":"daemon"`——连到了机器上已有的 daemon |
| **带** `HARNESS_DAEMON_USER_ROOT` 跑 `ha init` | 成功,`commit ace48380` |
| 试 `--daemon-mode direct` 作为替代 | 被拒:`Only task lifecycle, receipt show, and explicit daemon commands exist on rebuild` |
| 对真实老仓语料跑 `ha migrate import --dry-run` | 五类 PASS,`required=34`,每条冲突打印双方摘要与它自己的 `--resolve` flag |

克隆结果经核对确实落在预期 commit 而非陈旧的本地分支——先前一次尝试克隆到停在 `785fc04d` 的本地 ref,得出了「自启动缺失」的错误读数。

- [x] `git diff --check`
- [x] `npm run check:local` — 通过,25.9 秒
- [x] `node tools/gates/line-budget.mjs --base 55d68ad0` — G32 通过(单独跑;`check:local` 不含它)
- [x] 已确认仓库为 `PUBLIC` 且远端存在 `rebuild/main`,因此 clone 那行对外部用户成立
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- **未跑项及原因**:该 skill 尚未由一个不带本会话上下文的 agent 端到端跑过一遍。那正是所有者打算做的验收测试。

## 复核证据

- Reviewer subagent:未使用
- 阻塞发现:无

## 残留风险

- `missing_vertical` 配 `hint=[object Object]` 是一个真实缺陷:该消息既没描述成因,也没指向任何有用的地方。skill 记录了这个症状以免 agent 卡死,但错误本身应当修复。
- skill 记录的是一次验证过的流程,在 macOS 上、针对一份老仓语料。老台账形态不同的仓库可能撞上工作流未覆盖的 `required` 行;届时它被要求停下并展示该行,而不是猜。
- `git clone --depth 1 --branch rebuild/main` 按名字指向一个预期会在 cutover 时改名的分支。

## 参考

- 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- Skill:`skills/harness-migration/SKILL.md`
- 规格:`docs-release/migration-genesis-replay.md`
- 前序:#1428、#1429、#1430、#1431
