### PR TITLE
docs(skills): route the foreign-daemon check on code and origin, not hint text

### DIFF
--- a/skills/harness-migration/SKILL.md
+++ b/skills/harness-migration/SKILL.md
@@ -25,16 +25,21 @@ mkdir -p "$HARNESS_DAEMON_USER_ROOT"
 
 Without it, the CLI connects to whatever Harness daemon is already running on
 the machine and that daemon serves a different generation of the code. The
-observed failure is not a helpful conflict message — it is:
+failure does not announce itself as a conflict — it arrives as:
 
 ```
-error code=missing_vertical hint=[object Object]
+error code=missing_vertical
 ```
 
-with `"origin":"daemon"` in the JSON receipt. If you see that, `HARNESS_DAEMON_USER_ROOT`
-is not set. Do **not** stop or uninstall the user's existing Harness to work
-around it: isolation is sufficient, and stopping their daemon interrupts work
-you are not responsible for restoring.
+with `"origin":"daemon"` in the JSON receipt. **Match on those two fields, not on
+the hint text**: the hint describes an unavailable vertical, which is true but
+misleading, and it reads differently depending on which generation the running
+daemon serves. `code=missing_vertical` together with `"origin":"daemon"` means
+`HARNESS_DAEMON_USER_ROOT` is not set.
+
+Do **not** stop or uninstall the user's existing Harness to work around it:
+isolation is sufficient, and stopping their daemon interrupts work you are not
+responsible for restoring.
 
 ## 1. Fetch the current source
 
@@ -267,7 +272,8 @@ Move `$TARGET_REPO` to where the user wants it, then tell them:
 ## Known rough edges
 
 - Connecting to a foreign daemon reports `missing_vertical` with
-  `hint=[object Object]`. That message does not describe the real problem;
-  the cause is a missing `HARNESS_DAEMON_USER_ROOT`.
+  `"origin":"daemon"`. The hint is readable text about an unavailable vertical,
+  but it still does not name the real cause — a missing
+  `HARNESS_DAEMON_USER_ROOT`. Route on the code and origin, not the wording.
 - `--daemon-mode direct` does not support `init` — it rejects with
   `unsupported_command`. Isolation is done with the user root, not with direct mode.


### PR DESCRIPTION
# English

## Summary

#1433 fixed the `[object Object]` hint. That fix invalidated a landmark the migration skill was using: `skills/harness-migration/SKILL.md` told agents that seeing `hint=[object Object]` meant `HARNESS_DAEMON_USER_ROOT` was unset. After #1433 that string no longer appears, so an agent following the skill would see readable prose where it expected the marker and conclude it was looking at a different problem.

The check now routes on `code=missing_vertical` **together with** `"origin":"daemon"`.

Production-Delta: +0/-0

## What Changed

Two passages in `SKILL.md` — the isolation rationale near the top and the "Known rough edges" entry — now name the two fields to match and say explicitly not to match on the hint wording.

This is the more durable anchor, not merely the currently-correct one. The hint text is produced by whichever generation of the daemon happens to be running on the user's machine, so it varies by definition; `code` and `origin` are wire-contract fields validated by `validateDaemonProtocolError`. Pinning to the wording is what let one PR invalidate the instruction.

The skill still records that the message does not name the real cause. #1433 made it readable, not accurate: it describes an unavailable vertical, which is true and still misleading. Saying "you reached a daemon from another generation" needs information the daemon does not have.

## Task And Scope

- Harness task: `task_01M022AR425YG81NS1TRH8BDKR`
- Branch: `codex/skill-symptom`
- Out of scope: the hint text itself. See #1433 for why the daemon cannot currently name the generation mismatch.

## Version Impact

- Version: no version change
- Publish impact: skill documentation only.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task `task_01M022AR425YG81NS1TRH8BDKR`; follow-through on #1433, which changed the observable this skill depended on
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable

## Verification

- Base `origin/rebuild/main` SHA: `ea8fa49d`
- Branch merge-base with `origin/rebuild/main`: `ea8fa49d`
- Public diff command: `git diff ea8fa49d..codex/skill-symptom`

- [x] `npm run check:local` — passed, 33.2s (includes the skill contract test)
- [x] `node tools/gates/line-budget.mjs --base ea8fa49d` — G32 pass
- [x] `node tools/gates/production-delta.mjs --base ea8fa49d` — computed `+0/-0`, matches the declaration
- [x] repository-wide grep confirms the only remaining `[object Object]` occurrence is the regression assertion in `preset-contract.test.ts`
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: the corrected instruction has not been exercised by an agent hitting a foreign daemon on a machine running the fixed build. The same constraint described in #1433 applies — the daemon already running on this machine serves pre-#1433 code.

## Review Evidence

- Reviewer subagent: not used
- Blocking findings: none

## Residual Risk

- The skill now asserts the hint is readable, which is verified by construction in #1433 but not observed end to end against a fixed daemon. If the wording matters to a future reader, it should be captured from a real run rather than predicted.

## References

- Task: `task_01M022AR425YG81NS1TRH8BDKR`
- Fix that invalidated the old landmark: #1433
- Skill: `skills/harness-migration/SKILL.md`

---

# 中文

## 概要

#1433 修掉了 `[object Object]` 这个 hint,同时也让迁移 skill 依赖的一个路标失效:`skills/harness-migration/SKILL.md` 告诉 agent「看到 `hint=[object Object]` 就说明 `HARNESS_DAEMON_USER_ROOT` 没设」。#1433 之后那个字符串不再出现,照旧文本排查的 agent 会在预期路标的位置看到可读文字,从而判定自己遇到的是另一个问题。

判据改为 `code=missing_vertical` **加上** `"origin":"daemon"`。

生产行数变更声明见英文段。

## 改动内容

`SKILL.md` 的两处 —— 开头的隔离理由段与「Known rough edges」条目 —— 改为点名这两个字段,并明确要求**不要**按 hint 文案匹配。

这不只是「换成当前正确的说法」,而是换成更耐久的锚点。hint 文案由用户机器上碰巧在跑的那一代 daemon 产生,因此天然会变;而 `code` 与 `origin` 是 `validateDaemonProtocolError` 校验的 wire 契约字段。正是钉在文案上,才让一个 PR 就把这条指引作废。

skill 仍然记录「这条消息没有说出真实成因」。#1433 让它可读,而不是让它准确:它描述的是 vertical 不可用——属实,但仍具误导性。要说出「你连到了另一代的 daemon」,需要 daemon 不具备的信息。

## 任务与范围

- Harness 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- 分支:`codex/skill-symptom`
- 范围外:hint 文案本身。daemon 当前为何无法点名代际不匹配,见 #1433。

## 版本影响

- 版本:不改版本
- 发布影响:仅 skill 文档。

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:任务 `task_01M022AR425YG81NS1TRH8BDKR`;对 #1433 的收尾——该 PR 改变了本 skill 所依赖的可观测量
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用

## 验证

- `origin/rebuild/main` 基准 SHA:`ea8fa49d`
- 当前分支与 `origin/rebuild/main` 的 merge-base:`ea8fa49d`
- 公开 diff 命令:`git diff ea8fa49d..codex/skill-symptom`

- [x] `npm run check:local` — 通过,33.2 秒(含 skill 契约测试)
- [x] `node tools/gates/line-budget.mjs --base ea8fa49d` — G32 通过
- [x] `node tools/gates/production-delta.mjs --base ea8fa49d` — 实测 `+0/-0`,与声明一致
- [x] 全仓 grep 确认 `[object Object]` 仅剩 `preset-contract.test.ts` 里的回归断言一处
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- **未跑项及原因**:修正后的指引尚未由一个在装有修复版构建的机器上撞到外来 daemon 的 agent 实际走过。约束与 #1433 所述相同——本机已在跑的 daemon 服务的是 #1433 之前的代码。

## 复核证据

- Reviewer subagent:未使用
- 阻塞发现:无

## 残留风险

- skill 现在断言 hint 是可读的,这一点在 #1433 中由构造保证,但未对着修复后的 daemon 端到端观察过。若将来读者在意具体文案,应当从一次真实运行里抓取,而不是预测。

## 参考

- 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- 使旧路标失效的修复:#1433
- Skill:`skills/harness-migration/SKILL.md`
