### PR TITLE
fix(skills): back up harness/ only, and drop a bundle that held no ledger

### DIFF
--- a/skills/harness-migration/SKILL.md
+++ b/skills/harness-migration/SKILL.md
@@ -64,23 +64,50 @@ needs no build step.
 Ask the user for the absolute path of the repository holding the old `harness/`
 directory.
 
+Back up and digest **`harness/` only** — never the repository root.
+
 ```bash
 export ARCHIVE_SOURCE="$(cd /absolute/path/to/legacy-repository && pwd -P)"
 export WORK_SOURCE="$HARNESS_MIGRATION_WORK/legacy-copy"
-mkdir -p "$HARNESS_MIGRATION_WORK/backups"
-export SOURCE_SHA_BEFORE="$(COPYFILE_DISABLE=1 tar -cf - -C "$ARCHIVE_SOURCE" . | shasum -a 256 | awk '{print $1}')"
+mkdir -p "$HARNESS_MIGRATION_WORK/backups" "$WORK_SOURCE"
+export LEDGER_ARCHIVE="$HARNESS_MIGRATION_WORK/backups/legacy-harness.tar"
+COPYFILE_DISABLE=1 tar -cf "$LEDGER_ARCHIVE" -C "$ARCHIVE_SOURCE" harness
+export SOURCE_SHA_BEFORE="$(COPYFILE_DISABLE=1 tar -cf - -C "$ARCHIVE_SOURCE" harness | shasum -a 256 | awk '{print $1}')"
 printf 'source-before %s\n' "$SOURCE_SHA_BEFORE"
-git -C "$ARCHIVE_SOURCE" bundle create "$HARNESS_MIGRATION_WORK/backups/legacy.bundle" --all
-git -C "$ARCHIVE_SOURCE" bundle verify "$HARNESS_MIGRATION_WORK/backups/legacy.bundle"
-cp -a "$ARCHIVE_SOURCE" "$WORK_SOURCE"
+tar -xf "$LEDGER_ARCHIVE" -C "$WORK_SOURCE"
 ```
 
-Show the user both backup paths and **stop until they confirm one independent
+`$WORK_SOURCE` now contains `harness/` and nothing else, which is all the
+importer reads — `--source` takes the repository root and descends into
+`harness/` itself.
+
+Three things this deliberately does **not** do, each for a reason worth knowing:
+
+- **No `git bundle`.** `harness/` is its own git repository and the outer repo
+  ignores it (`/harness/` in `.gitignore`, `git ls-files harness/` returns
+  nothing). A bundle of the outer repo therefore contains **zero** ledger
+  content — it looks like a backup and protects nothing.
+- **No repository-root digest.** The root contains `.harness/`, which is
+  ignored runtime state — locks, `write-journal`, `cache`, `script-runs`,
+  `task-holders` — that any running daemon rewrites continuously. A root digest
+  changes on its own between the before and after reads, so the "source
+  untouched" check would report a false failure every time. A check that must be
+  ignored to proceed is worse than no check.
+- **No `cp -a` of the root.** It copies `node_modules` and the whole `.git`
+  directory, which the importer never reads.
+
+On a large ledger the digest takes tens of seconds and prints nothing while it
+runs — that is normal, do not kill it. If it runs for many minutes you are
+digesting more than `harness/`; check the `-C` argument. Nothing may write to
+`$ARCHIVE_SOURCE/harness/` while the migration runs, or the closing digest will
+differ for a reason that has nothing to do with the importer.
+
+Show the user `$LEDGER_ARCHIVE` and **stop until they confirm one independent
 copy exists off this machine.** Migration is one-shot; this is the only point
 where that confirmation is cheap.
 
 Every repair below targets `$WORK_SOURCE`. `$ARCHIVE_SOURCE` is read-only and
-its digest is re-checked at the end.
+its `harness/` digest is re-checked at the end.
 
 ## 3. Initialize the destination
 
@@ -245,8 +272,8 @@ Apply only when that exits zero, all five rows show `Old = Expected = New` with
 
 ```bash
 $HA migrate import --source "$WORK_SOURCE" "${RESOLVE_ARGS[@]}"; echo "apply-exit=$?"
-export SOURCE_SHA_AFTER="$(COPYFILE_DISABLE=1 tar -cf - -C "$ARCHIVE_SOURCE" . | shasum -a 256 | awk '{print $1}')"
-test "$SOURCE_SHA_BEFORE" = "$SOURCE_SHA_AFTER" && echo "source untouched"
+export SOURCE_SHA_AFTER="$(COPYFILE_DISABLE=1 tar -cf - -C "$ARCHIVE_SOURCE" harness | shasum -a 256 | awk '{print $1}')"
+test "$SOURCE_SHA_BEFORE" = "$SOURCE_SHA_AFTER" && echo "source ledger untouched"
 ```
 
 If apply exits nonzero, keep its output, move the target aside, and restart from


### PR DESCRIPTION
# English

## Summary

A cold-start agent running the migration skill stalled for 18 minutes inside the backup step and stopped to ask whether backing up the whole repository was necessary. It was right to ask, and the answer is worse than "no": the backup step had three defects, and the most severe one made the backup itself hollow.

**The `git bundle --all` contained zero ledger content.** `harness/` is its own git repository and the outer repo ignores it — `/harness/` is line 19 of `.gitignore`, and `git ls-files harness/` returns nothing. The bundle captured the outer repository's history, which by construction excludes every file being migrated. The skill then stopped and asked the user to confirm a backup existed. It existed and protected nothing.

**The root digest could not succeed.** It covered `.harness/` — ignored runtime state: `locks`, `write-journal`, `cache`, `script-runs` (713 entries), `task-holders` (777 entries). Any running daemon rewrites those continuously; on this machine `task-holders` changed during the investigation itself. The closing `source untouched` comparison would therefore differ for reasons unrelated to the importer, every time. A check that has to be ignored to proceed is worse than no check.

**Cost was a symptom of scope, not the disease.** It is what made the other two visible.

Production-Delta: +0/-0

## What Changed

The archive is a tar of `harness/`; the working copy is extracted from that archive rather than `cp -a`'d from the root; both digests use the identical pipe form so they are byte-comparable.

`--source` still receives the repository root — the importer descends into `harness/` itself — and `$WORK_SOURCE` now contains exactly `harness/` and nothing else. Every downstream path in the skill (`$WORK_SOURCE/harness/presets`, the repair steps) was already written against that layout and is unchanged.

The section states what is deliberately *not* done and why, so a future editor does not restore any of the three as an apparent improvement.

## Task And Scope

- Harness task: `task_01M022AR425YG81NS1TRH8BDKR`
- Branch: `codex/backup-scope`
- Out of scope: the importer, which never read the excluded content. Nothing about migration behaviour changes — only what gets copied and digested around it.

## Version Impact

- Version: no version change
- Publish impact: skill documentation only.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task `task_01M022AR425YG81NS1TRH8BDKR`; owner reported the stall during a live cold-start run and asked whether the step was necessary
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable

## Verification

- Base `origin/rebuild/main` SHA: `24ba59bc`
- Branch merge-base with `origin/rebuild/main`: `24ba59bc`
- Public diff command: `git diff 24ba59bc..codex/backup-scope`

Measured on the canonical repository, which is the corpus the failing run used:

| Claim | Measurement |
| --- | --- |
| bundle holds no ledger | `git ls-files harness/` → `0`; `.gitignore:19:/harness/` |
| `.harness/` is ignored runtime state | `git check-ignore -v` resolves `locks`, `write-journal`, `cache` to `.gitignore:32:.harness/` |
| that state mutates during a run | `task-holders` mtime equalled the wall clock at the moment of inspection; 3 daemons running |
| root digest is not viable | two consecutive attempts both exceeded a 90s timeout; `du` of the tree needed over 120s just to size it |
| the scope gap is three orders of magnitude | repository root **232 GB** vs `harness/` **1.2 GB** — `.harness/` alone is **208 GB**, of which `script-runs` is **182 GB** and `evidence` 26 GB |
| `cp -a` of the root | would have copied all 232 GB a second time, on top of digesting it |
| `harness/` digest is viable | 40.7s, and byte-identical across three consecutive runs |

The stability run is the one that matters: without it, narrowing the scope would have produced a faster check that still reported false failures.

- [x] `npm run check:local` — passed, 38.9s (includes the skill contract test)
- [x] `node tools/gates/line-budget.mjs --base 24ba59bc` — G32 pass
- [x] `node tools/gates/production-delta.mjs --base 24ba59bc` — computed `+0/-0`, matches the declaration
- [x] every `$WORK_SOURCE`/`$ARCHIVE_SOURCE` reference re-read after the edit; all downstream paths still resolve under the narrowed copy
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: the corrected step has not been executed end to end by a cold-start agent. That run is in progress and is what surfaced this.

## Review Evidence

- Reviewer subagent: not used
- Blocking findings: none

## Residual Risk

- The `harness/` digest is stable while nothing writes to the source. If a daemon or another session writes the source ledger mid-migration the closing check will differ — correctly, but the agent must not misread it as importer damage. The skill now says so.
- 40s twice is not free. It is retained because it is the only evidence that the one-shot migration left the source untouched, and it now produces a trustworthy answer.

## References

- Task: `task_01M022AR425YG81NS1TRH8BDKR`
- Skill: `skills/harness-migration/SKILL.md`
- Predecessors: #1432 (skill), #1433 (hint fix), #1434 (symptom landmark)

---

# 中文

## 概要

一个冷启动 agent 跑迁移 skill 时,卡在备份步骤 18 分钟,停下来问「备份整个仓库有必要吗」。它问得对,而答案比「没必要」更糟:这一步有三个缺陷,其中最严重的那个让备份本身是空的。

**`git bundle --all` 里一个字节的台账都没有。** `harness/` 是独立 git 仓库,外层仓忽略它——`.gitignore` 第 19 行 `/harness/`,`git ls-files harness/` 返回空。那个 bundle 打的是外层仓的历史,而外层仓按定义不含任何要迁移的文件。skill 随后停下来,让用户确认「备份已存在」。它确实存在,而且什么也没保护。

**整仓摘要不可能成功。** 它覆盖了 `.harness/` —— 被忽略的运行时状态:`locks`、`write-journal`、`cache`、`script-runs`(713 个)、`task-holders`(777 个)。任何在跑的 daemon 都在持续改写它们;在本机,`task-holders` 就在排查过程中发生了变化。于是收尾那句 `source untouched` 的比对,每一次都会因为与 importer 无关的原因而不相等。**一个必须被忽略才能往下走的检查,比没有检查更糟。**

**耗时只是范围的症状,不是病本身** —— 但正是它让另外两个暴露出来。

生产行数变更声明见英文段。

## 改动内容

归档改为 `harness/` 的 tar;工作副本从该归档解出,而不是从仓库根 `cp -a`;前后两次摘要采用完全相同的管道形式,因而逐字节可比。

`--source` 仍然接收仓库根 —— importer 自己进入 `harness/` —— 而 `$WORK_SOURCE` 现在恰好只含 `harness/`。skill 下游所有路径(`$WORK_SOURCE/harness/presets`、各修复步骤)本来就是按这个布局写的,未改动。

该节明确写出「刻意不做什么、为什么」,以免将来有人把这三样当作改进又装回去。

## 任务与范围

- Harness 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- 分支:`codex/backup-scope`
- 范围外:importer 本身,它从来就不读被排除的那些内容。迁移行为没有任何变化,变的只是它周围复制什么、摘要什么。

## 版本影响

- 版本:不改版本
- 发布影响:仅 skill 文档。

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:任务 `task_01M022AR425YG81NS1TRH8BDKR`;所有者在实跑冷启动迁移时报告卡顿,并质询该步骤是否必要
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用

## 验证

- `origin/rebuild/main` 基准 SHA:`24ba59bc`
- 当前分支与 `origin/rebuild/main` 的 merge-base:`24ba59bc`
- 公开 diff 命令:`git diff 24ba59bc..codex/backup-scope`

在 canonical 仓库上实测,那正是出问题那次运行所用的语料:

| 断言 | 实测 |
| --- | --- |
| bundle 不含台账 | `git ls-files harness/` → `0`;`.gitignore:19:/harness/` |
| `.harness/` 是被忽略的运行时状态 | `git check-ignore -v` 把 `locks`、`write-journal`、`cache` 解析到 `.gitignore:32:.harness/` |
| 该状态在运行期间变动 | 查看当刻 `task-holders` 的 mtime 等于墙上时间;3 个 daemon 在跑 |
| 整仓摘要不可行 | 连续两次尝试均超过 90 秒超时;`du` 光是量出体积就要 120 秒以上 |
| 范围差了三个数量级 | 仓库根 **232 GB** vs `harness/` **1.2 GB** —— 仅 `.harness/` 就 **208 GB**,其中 `script-runs` **182 GB**、`evidence` 26 GB |
| 仓库根 `cp -a` | 在摘要之外,还要把这 232 GB 再复制一份 |
| `harness/` 摘要可行 | 40.7 秒,且连续三次逐字节一致 |

其中稳定性那一次最关键:没有它,收窄范围只会得到一个「更快但依然误报」的检查。

- [x] `npm run check:local` — 通过,38.9 秒(含 skill 契约测试)
- [x] `node tools/gates/line-budget.mjs --base 24ba59bc` — G32 通过
- [x] `node tools/gates/production-delta.mjs --base 24ba59bc` — 实测 `+0/-0`,与声明一致
- [x] 改后重读了全部 `$WORK_SOURCE`/`$ARCHIVE_SOURCE` 引用;下游路径在收窄后的副本下依然成立
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- **未跑项及原因**:修正后的步骤尚未由冷启动 agent 端到端跑过一遍。那次运行正在进行中,本问题正是由它暴露的。

## 复核证据

- Reviewer subagent:未使用
- 阻塞发现:无

## 残留风险

- `harness/` 摘要只在源仓无人写入时稳定。若迁移期间有 daemon 或别的会话写源台账,收尾检查会不相等——这是正确的,但 agent 不能把它误读成 importer 造成的破坏。skill 已写明这一点。
- 两次 40 秒不是免费的。保留它,是因为它是「一次性迁移未触碰源仓」的唯一证据,而现在它给出的答案是可信的。

## 参考

- 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- Skill:`skills/harness-migration/SKILL.md`
- 前序:#1432(skill)、#1433(hint 修复)、#1434(症状路标)
