### PR TITLE
fix(skills): resolve migration conflicts in one batch with a stated default

### DIFF
--- a/skills/harness-migration/SKILL.md
+++ b/skills/harness-migration/SKILL.md
@@ -154,7 +154,7 @@ Branch on those rows:
 | any other `required` row | show the exact row to the user and stop — this workflow does not cover it |
 | no `required`, no `SKIP` | section 8 |
 
-## 5. Resolve destination conflicts — ask, one at a time
+## 5. Resolve destination conflicts — one batch, one decision
 
 `ha init` seeds README, ADR, milestone, walls and `people.yaml` files. A source
 ledger usually has its own versions of those paths. Each conflict row prints
@@ -167,10 +167,52 @@ both sides and the exact flag to use:
   resolve with --resolve harness/people.yaml=destination|source |
 ```
 
-For every conflict row, show the user both sides and ask for one answer:
-`destination` (keep what `ha init` produced, discard the source version) or
-`source` (replace with the source version). **Do not pick a default.** If it
-helps them decide, print the two files.
+**Handle every conflict in one pass. Never ask about them one at a time** — a
+migration has a handful of these and each round trip costs the user an
+interruption for a decision that is usually the same one.
+
+Read both sides of all of them first:
+
+```bash
+CONFLICTS=($(grep -o -- '--resolve [^=]*=' "$DRY_RUN" | sed 's/--resolve //;s/=$//' | sort -u))
+printf 'conflicts: %s\n' "${#CONFLICTS[@]}"
+for c in "${CONFLICTS[@]}"; do
+  printf '\n===== %s :: DESTINATION =====\n' "$c"; cat "$TARGET_REPO/$c" 2>/dev/null
+  printf '\n===== %s :: SOURCE =====\n' "$c"; cat "$WORK_SOURCE/$c" 2>/dev/null
+done
+```
+
+**The default is `destination` for every row.** The destination file is the
+current format's skeleton and the migration exists to adopt it — a source file
+that merely says the same thing in the old shape has nothing to preserve.
+
+What the source file *may* have is project-specific substance the skeleton does
+not carry: local conventions, routing rules, directory contracts, a
+project's own standards. **Carry that content forward into the destination
+file.** Merging is an edit you make, not something the importer does; the flag
+is still `=destination`.
+
+So present **one table** and ask for **one confirmation**:
+
+| path | resolution | what carries over from the old file |
+| --- | --- | --- |
+| `harness/adr/README.md` | destination | when a lightweight ADR fits, `ha decision propose` for load-bearing choices, back-link rule |
+| `harness/context/architecture/README.md` | destination | manifest read order, `architecture-check`, model update boundary |
+| `harness/people.yaml` | **choose** | nothing — see below |
+
+Say plainly: this is the default, and they can override any row to `source` if
+they want the old file kept verbatim. One answer covers the whole table.
+
+**`people.yaml` is the exception and must be asked.** It is the person roster
+and it cannot be merged — roster merging is not yet available — so it is a
+genuine either/or where both answers lose something. `destination` leaves the
+migrated history referencing people absent from the new roster; `source`
+replaces the roster the new repository was initialized with. Keep it as its own
+question inside the same message; do not fold it into the default.
+
+**Do the merge edits after the final apply in step 8, not now.** Step 8
+recreates the destination from scratch, which would discard anything edited
+earlier. Record the third column now; apply it once at the end.
 
 Collect the answers into repeated flags and re-run:
 
@@ -185,12 +227,6 @@ $HA migrate import --source "$WORK_SOURCE" "${RESOLVE_ARGS[@]}" --dry-run > "$DR
 Each answer comes back as a row beginning `resolved: destination` or
 `resolved: source`, carrying both digests so the discarded side stays visible.
 A conflict left out of the flags stays `required`.
-
-**`people.yaml` deserves a word to the user.** It is the person roster. Picking
-`destination` means the migrated ledger's history references people who are not
-in the new roster; picking `source` means the roster the new repository was
-initialized with is replaced. Roster merging is not yet available, so say this
-plainly and let them choose.
 
 A directory target accepts only `=destination`. If `=source` reports that the
 target is a directory, show the error and have the user handle that path.
@@ -279,6 +315,19 @@ test "$SOURCE_SHA_BEFORE" = "$SOURCE_SHA_AFTER" && echo "source ledger untouched
 If apply exits nonzero, keep its output, move the target aside, and restart from
 a fresh `ha init`. **Never re-run apply against a partially imported target.**
 
+Now execute the merge column recorded in step 5. `$HARNESS_MIGRATION_WORK/preview-repository`
+still holds the previous destination, and `$WORK_SOURCE` still holds the old
+files, so both sides remain readable:
+
+```bash
+diff -u "$TARGET_REPO/harness/adr/README.md" "$WORK_SOURCE/harness/adr/README.md" | head -40
+```
+
+For each row, edit the destination file to carry the project-specific content
+forward. Keep the current file's structure and add to it — do not paste the old
+file over it, which would undo the resolution that was just applied. Show the
+user the resulting diff. This is the last write of the migration.
+
 ## 9. Hand over
 
 Move `$TARGET_REPO` to where the user wants it, then tell them:
@@ -293,6 +342,7 @@ Move `$TARGET_REPO` to where the user wants it, then tell them:
 - All five entity classes show `Old = Expected = New`, `Skipped = 0`.
 - Authored coverage has no `required` row.
 - Every conflict appears as an explicit `resolved:` row.
+- Every merge recorded in the step 5 table has been applied to the destination.
 - Every legacy preset has a validated v3 replacement installed.
 - `source-before` equals `source-after`.
 


### PR DESCRIPTION
# English

## Summary

The conflict step told the agent to ask "one at a time" and to "not pick a default". A live cold-start run showed exactly what that produces: read one conflict, ask, wait, read the next, ask again. A migration has a handful of these and the answer is nearly always the same, so every round trip spent a user interruption on a decision the skill was in a position to propose.

The step now reads both sides of every conflict first, presents one table, and asks for one confirmation.

Production-Delta: +0/-0

## What Changed

**The default is `destination` for every row.** The destination file is the current format's skeleton and adopting it is what the migration is for; a source file that says the same thing in the old shape has nothing worth preserving.

That default would lose something on its own, so the table carries a third column. A source file may hold project-specific substance the skeleton does not — local conventions, routing rules, directory contracts, a project's own standards — and that content is carried forward into the destination file. Merging is an edit the agent makes; the flag stays `=destination` and the importer is unchanged.

**The merge edits run after the final apply.** Step 8 recreates the destination from scratch, so anything edited during step 5 would be discarded. Step 5 records the column, step 8 executes it, and `Done when` gained a line for it so the column cannot be silently skipped — without that line, an agent could satisfy every existing check while dropping the content the whole third column exists to preserve.

**`people.yaml` stays an explicit question.** It cannot be merged while roster merging is unavailable, so it is a real either/or where both answers lose something. It does not belong under a default, and it is asked inside the same message rather than as a second round trip.

## Task And Scope

- Harness task: `task_01M022AR425YG81NS1TRH8BDKR`
- Branch: `codex/conflict-batch`
- Out of scope: roster merging for `people.yaml`, which is `task_01M0209RE440FSW6EXFBEF5K6R`. Until it lands, that row stays a two-way choice.

## Version Impact

- Version: no version change
- Publish impact: skill documentation only; no CLI surface or importer behaviour changed.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task `task_01M022AR425YG81NS1TRH8BDKR`; owner instruction after observing the one-at-a-time flow in a live run — state one default, present the conflicts together, merge what the old files uniquely carry
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable

## Verification

- Base `origin/rebuild/main` SHA: `e0703515`
- Branch merge-base with `origin/rebuild/main`: `e0703515`
- Public diff command: `git diff e0703515..codex/conflict-batch`

- [x] `npm run check:local` — passed, 47.8s (includes the skill contract test)
- [x] `node tools/gates/line-budget.mjs --base e0703515` — G32 pass
- [x] `node tools/gates/production-delta.mjs --base e0703515` — computed `+0/-0`, matches the declaration
- [x] re-read the whole file for remaining one-at-a-time language; the only surviving occurrence is the new instruction forbidding it
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: the batched flow has not been executed end to end. The run that motivated it was interrupted at this step; the next cold-start run is the test.

## Review Evidence

- Reviewer subagent: not used
- Blocking findings: none

## Residual Risk

- The merge column is judgement, and the skill cannot enumerate what counts as project-specific substance for a repository it has never seen. It gives the criterion and shows both files; a thin old file will correctly produce an empty column, and an agent that reads carelessly will under-merge. The final diff is shown to the user for exactly this reason.
- Deferring merges to after apply means the destination is briefly correct-but-incomplete. That window is inside one run and ends before hand-over.

## References

- Task: `task_01M022AR425YG81NS1TRH8BDKR`
- Skill: `skills/harness-migration/SKILL.md`
- Predecessors: #1432, #1433, #1434, #1435

---

# 中文

## 概要

冲突这一步原本写着「逐条问」并且「不要预设默认值」。一次实跑的冷启动运行把后果暴露得很清楚:读一条冲突、问、等、再读下一条、再问。一次迁移就这么几条,而答案几乎总是同一个——于是每一次往返,都把用户的一次打断花在了一个 skill 本来有能力提出建议的决定上。

现在这一步先读完所有冲突的双方,呈现一张表,只要一次确认。

生产行数变更声明见英文段。

## 改动内容

**每一行的默认都是 `destination`。** 目标文件是当前格式的骨架,采用它正是迁移的目的;一个只是用旧形状说同样事情的源文件,没有什么值得保留。

但只有这个默认会丢东西,所以表格带第三列。源文件可能承载骨架没有的**项目特有内容**——本地约定、路由规则、目录契约、项目自己的标准——这些内容要被带进目标文件。融合是 agent 做的编辑;flag 仍然是 `=destination`,importer 不变。

**融合编辑在最终 apply 之后执行。** 第 8 步会从零重建目标,所以在第 5 步做的任何编辑都会被丢掉。第 5 步记录该列,第 8 步执行它,`Done when` 为此加了一条——否则 agent 可以让所有既有检查全绿,同时把这第三列存在的全部意义丢掉。

**`people.yaml` 仍然是显式提问。** 在名册合并能力落地前它无法融合,所以是一个两边都有损失的真二选一。它不该被塞进默认,而且是在**同一条消息里**问,不是再来一次往返。

## 任务与范围

- Harness 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- 分支:`codex/conflict-batch`
- 范围外:`people.yaml` 的名册合并,属于 `task_01M0209RE440FSW6EXFBEF5K6R`。在它落地前,该行保持二选一。

## 版本影响

- 版本:不改版本
- 发布影响:仅 skill 文档;CLI 命令面与 importer 行为均未变。

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:任务 `task_01M022AR425YG81NS1TRH8BDKR`;所有者在实跑中观察到逐条询问流程后的指示——给出统一默认、一次性呈现冲突、把旧文件独有的内容融合进来
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用

## 验证

- `origin/rebuild/main` 基准 SHA:`e0703515`
- 当前分支与 `origin/rebuild/main` 的 merge-base:`e0703515`
- 公开 diff 命令:`git diff e0703515..codex/conflict-batch`

- [x] `npm run check:local` — 通过,47.8 秒(含 skill 契约测试)
- [x] `node tools/gates/line-budget.mjs --base e0703515` — G32 通过
- [x] `node tools/gates/production-delta.mjs --base e0703515` — 实测 `+0/-0`,与声明一致
- [x] 通读全文复查残留的「逐条询问」表述;唯一还出现的一处,正是新增的那条禁止它的指令
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- **未跑项及原因**:批量流程尚未端到端跑过。促成本次改动的那次运行正是在这一步被打断的;下一次冷启动运行就是它的测试。

## 复核证据

- Reviewer subagent:未使用
- 阻塞发现:无

## 残留风险

- 融合那一列是判断,skill 无法为一个它从未见过的仓库穷举「什么算项目特有内容」。它给出判据并展示双方原文;旧文件本就单薄时,该列正确地为空,而读得粗心的 agent 会融合不足。最终 diff 要展示给用户,正是为此。
- 把融合推迟到 apply 之后,意味着目标仓有一小段时间是「正确但不完整」的。该窗口在同一次运行内,并在交付前结束。

## 参考

- 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- Skill:`skills/harness-migration/SKILL.md`
- 前序:#1432、#1433、#1434、#1435
