### PR TITLE
feat(skills): report the legacy .harness/ at hand-over without deleting it

### DIFF
--- a/skills/harness-migration/SKILL.md
+++ b/skills/harness-migration/SKILL.md
@@ -336,6 +336,51 @@ Move `$TARGET_REPO` to where the user wants it, then tell them:
 - the migration daemon lives under `$HARNESS_DAEMON_USER_ROOT` and can be removed with the work directory;
 - to use the new repository with their normal installation, register it there.
 
+### Report the old runtime directory — do not delete it
+
+The source repository has a `.harness/` directory beside the `harness/` ledger.
+It is git-ignored runtime state, the importer never read it, and none of it was
+migrated. On a long-lived repository it can be very large: previous generations
+wrote a **full copy of the ledger** into a `staging/` directory on every script
+or preset run and never removed them, so `.harness/` can reach hundreds of
+gigabytes while the ledger itself is a fraction of that. Measure it and tell
+the user the number:
+
+```bash
+du -sh "$ARCHIVE_SOURCE/.harness" "$ARCHIVE_SOURCE/harness"
+du -sh "$ARCHIVE_SOURCE"/.harness/* 2>/dev/null | sort -rh | head
+```
+
+**Do not delete it, and do not offer to.** Report it and hand them the command:
+
+```bash
+# after you are satisfied with the new repository — reclaims the ledger copies,
+# keeps each run's context/result/stderr metadata
+chmod -R u+w "$ARCHIVE_SOURCE"/.harness/script-runs/*/staging \
+             "$ARCHIVE_SOURCE"/.harness/evidence/presets/*/*/staging 2>/dev/null
+rm -rf "$ARCHIVE_SOURCE"/.harness/script-runs/*/staging \
+       "$ARCHIVE_SOURCE"/.harness/evidence/presets/*/*/staging
+```
+
+Name those two paths exactly. A shorter `.harness/*/staging` also matches
+`.harness/preset-runs/staging`, which the **current** generation uses while a
+run is in flight.
+
+The `chmod` is not optional. Some staged copies contain read-only archives —
+benchmark fixtures are stored `dr-xr-xr-x`/`-r--r--r--` on purpose — and `rm`
+stops on them with `Permission denied`, leaving the reclaim silently partial.
+Only the *copies* are made writable; the originals under `harness/` keep their
+protection.
+
+Deleting is theirs to decide, for two reasons worth saying out loud: the moment
+right after a one-shot migration is exactly when the old installation is most
+likely to be needed again, and this skill has no way to restore what it removes.
+The same reasoning already governs why it does not stop their daemon.
+
+Tell them the current generation does not accumulate this way — run staging now
+holds a preset package rather than the ledger, and is removed on both the
+success and failure paths.
+
 ## Done when
 
 - Apply exited zero and the final dry-run had `Reconciliation: PASS`.


### PR DESCRIPTION
# English

## Summary

Migration leaves the source repository's `.harness/` untouched — the importer never reads it and none of it is migrated. On a long-lived repository that directory can dwarf the thing being migrated. Measured here: **208 GB of `.harness/` against a 1.2 GB ledger**, because previous generations copied the *entire ledger* into a per-run `staging/` directory on every script and preset run and never removed them.

Saying nothing about that at hand-over is wrong. Deleting it is also wrong. Hand-over now measures it, reports the number, and hands over the command instead of running it.

Production-Delta: +0/-0

## What Changed

Section 9 gains a measurement, a plain explanation of what produced the size, and a reclaim command the **user** runs when they choose.

The skill does not delete, and does not offer to. It already refuses to stop or uninstall the user's Harness on the grounds that it cannot restore what it disrupts; removing runtime state is that same call one step further, and the moment right after a one-shot migration is precisely when the old installation is most likely to be needed again.

Two details in the command exist because the command was run:

- It names `script-runs/*/staging` and `evidence/presets/*/*/staging` **explicitly**. A shorter `.harness/*/staging` also matches `.harness/preset-runs/staging`, which the current generation uses while a run is in flight.
- It **chmods first**. Some staged copies hold read-only benchmark fixtures stored `dr-xr-xr-x`/`-r--r--r--` on purpose; `rm` stops on them with `Permission denied` and leaves the reclaim silently partial. That is exactly what happened on the first pass here.

The section also tells the user the current generation does not accumulate this way: run staging holds a preset package rather than the ledger, and is removed on both the success and failure paths.

## Task And Scope

- Harness task: `task_01M022AR425YG81NS1TRH8BDKR`
- Branch: `codex/handover-cleanup`
- Out of scope: deleting anything on the user's behalf, and any change to the old generation — it is being retired, and the current one does not have the defect.

## Version Impact

- Version: no version change
- Publish impact: skill documentation only.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task `task_01M022AR425YG81NS1TRH8BDKR`; owner asked whether hand-over should clean up the legacy `.harness/`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable

## Verification

- Base `origin/rebuild/main` SHA: `d952a7d6`
- Branch merge-base with `origin/rebuild/main`: `d952a7d6`
- Public diff command: `git diff d952a7d6..codex/handover-cleanup`

The documented command was executed on this repository before being written down, with the owner's authorization:

| | before | after |
| --- | --- | --- |
| `.harness/` | 208 GB | **599 MB** |
| `script-runs` staging dirs | 394 | 0 |
| `evidence` staging dirs | 48 | 0 |
| run metadata (`context.json`/`stderr.txt`/`stdout.txt`) | 711 runs | **711 runs, intact** |
| `.harness/preset-runs/staging` (current generation) | present | **untouched** |

The first pass stopped partway at `Permission denied` and reported success, which is how the read-only fixtures were found; the chmod line in the skill exists because of that failure.

- [x] `npm run check:local` — passed, 39.4s (includes the skill contract test)
- [x] `node tools/gates/line-budget.mjs --base d952a7d6` — G32 pass
- [x] `node tools/gates/production-delta.mjs --base d952a7d6` — computed `+0/-0`, matches the declaration
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: the hand-over step has not been reached by a cold-start run. The measurements above come from executing the same commands directly.

## Review Evidence

- Reviewer subagent: not used
- Blocking findings: none

## Residual Risk

- The reclaim keeps per-run metadata, which is a judgement about audit value rather than a measured need. It costs a few hundred MB against a multi-hundred-GB reclaim; a user who wants the runs gone entirely can remove the run directories.
- The size figures quoted in the skill are from one repository. Another may have a small `.harness/`, in which case the measurement step correctly reports a small number and there is nothing to act on.

## References

- Task: `task_01M022AR425YG81NS1TRH8BDKR`
- Skill: `skills/harness-migration/SKILL.md`
- Predecessors: #1432, #1433, #1434, #1435, #1436

---

# 中文

## 概要

迁移不碰源仓的 `.harness/` —— importer 从不读它,其中任何内容都不会被迁移。而在一个长期使用的仓库里,这个目录可能远大于被迁移的东西本身。本机实测:**`.harness/` 208 GB,而台账只有 1.2 GB**,原因是过去的版本在每次 script 与 preset 运行时,都把**整份台账**复制进一个按次分目录的 `staging/`,且从不删除。

交付时对此只字不提是不对的;替用户删掉也是不对的。现在交付步骤会测量它、报出数字,并把命令交给用户,而不是自己执行。

生产行数变更声明见英文段。

## 改动内容

第 9 节新增:一次测量、一段说明体积由何而来的解释,以及一条由**用户**在自己决定的时候运行的回收命令。

skill 不删,也不主动提议删。它本来就拒绝停止或卸载用户的 Harness,理由是它无力恢复自己扰乱的东西;删除运行时状态是同一判断再往前一步,而一次性迁移刚做完的那个时刻,恰恰是旧安装最可能重新被需要的时候。

命令里有两个细节,是因为这条命令真的被跑过才存在:

- 它**显式**写出 `script-runs/*/staging` 与 `evidence/presets/*/*/staging`。更短的 `.harness/*/staging` 会一并匹配 `.harness/preset-runs/staging`,而那是**当前版本**在运行期间使用的目录。
- 它**先 chmod**。部分 staged 副本里存放着刻意设为只读的 benchmark fixture(`dr-xr-xr-x`/`-r--r--r--`),`rm` 会在它们上面以 `Permission denied` 停下,让回收悄悄变成部分完成。本机第一轮正是如此。

该节同时告诉用户:当前版本不会这样堆积——运行期的 staging 存放的是 preset 包而非台账,且在成功与失败两条路径上都会删除。

## 任务与范围

- Harness 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- 分支:`codex/handover-cleanup`
- 范围外:代用户删除任何东西;以及对旧版本的任何改动——它即将退役,而当前版本没有这个缺陷。

## 版本影响

- 版本:不改版本
- 发布影响:仅 skill 文档。

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:任务 `task_01M022AR425YG81NS1TRH8BDKR`;所有者询问交付时是否应清理遗留的 `.harness/`
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用

## 验证

- `origin/rebuild/main` 基准 SHA:`d952a7d6`
- 当前分支与 `origin/rebuild/main` 的 merge-base:`d952a7d6`
- 公开 diff 命令:`git diff d952a7d6..codex/handover-cleanup`

文档里这条命令,是在所有者授权下于本仓实跑之后才写下的:

| | 前 | 后 |
| --- | --- | --- |
| `.harness/` | 208 GB | **599 MB** |
| `script-runs` staging 目录 | 394 | 0 |
| `evidence` staging 目录 | 48 | 0 |
| run 元数据(`context.json`/`stderr.txt`/`stdout.txt`) | 711 个 run | **711 个,完好** |
| `.harness/preset-runs/staging`(当前版本) | 存在 | **未被触碰** |

第一轮在 `Permission denied` 处中途停下却报告成功,只读 fixture 正是这样被发现的;skill 里那行 chmod 就是因为这次失败而存在。

- [x] `npm run check:local` — 通过,39.4 秒(含 skill 契约测试)
- [x] `node tools/gates/line-budget.mjs --base d952a7d6` — G32 通过
- [x] `node tools/gates/production-delta.mjs --base d952a7d6` — 实测 `+0/-0`,与声明一致
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- **未跑项及原因**:冷启动运行尚未推进到交付这一步。上表数字来自直接执行同样的命令。

## 复核证据

- Reviewer subagent:未使用
- 阻塞发现:无

## 残留风险

- 回收保留了每次运行的元数据,这是关于审计价值的判断,而非经过测量的需求。相对几百 GB 的回收,它只占几百 MB;想彻底清掉的用户可以删除整个 run 目录。
- skill 中引用的体积数字来自一个仓库。另一个仓库的 `.harness/` 可能很小,那时测量步骤会正确地报出一个小数字,也就无需处置。

## 参考

- 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- Skill:`skills/harness-migration/SKILL.md`
- 前序:#1432、#1433、#1434、#1435、#1436
