### PR TITLE
docs(skills): state that the migrated ledger is a standalone repository

### DIFF
--- a/skills/harness-migration/SKILL.md
+++ b/skills/harness-migration/SKILL.md
@@ -330,11 +330,33 @@ user the resulting diff. This is the last write of the migration.
 
 ## 9. Hand over
 
-Move `$TARGET_REPO` to where the user wants it, then tell them:
+`$TARGET_REPO` is a **standalone ledger repository**. It holds `harness/` and
+nothing else — no project code — and it is meant to live **outside** the
+project it serves. A ledger is central: one ledger, mirrored by the checkouts
+that use it. Copying it inside a project would give every project its own
+divergent copy, and on a public project it would publish the ledger outright.
+
+Say this explicitly, because the old layout was different. Previous generations
+kept `harness/` as a git repository nested inside the project directory. **Do
+not reproduce that.** The daemon rejects it — a nested standalone ledger fails
+with `publication_indeterminate: Canonical and authored refs must agree` — and
+the ledger is no longer reachable for writes.
+
+```bash
+mv "$TARGET_REPO" /absolute/path/the/user/chooses      # outside any project checkout
+$HA daemon repo register --repo-id <new-repo-id> --root /absolute/path/the/user/chooses
+```
+
+The old `harness/` still sits in the project directory. It is superseded, the
+step 2 archive holds it, and the project already ignores it, so removing it is
+safe — but it is the user's directory, so show the path and let them decide.
+
+Then tell them:
 
 - their existing Harness installation was not modified;
+- the new ledger is a repository of its own, registered by path, and does not belong inside a project checkout;
 - the migration daemon lives under `$HARNESS_DAEMON_USER_ROOT` and can be removed with the work directory;
-- to use the new repository with their normal installation, register it there.
+- the previous ledger's git history is not carried forward — this migration rebuilds the ledger from its events, and the old history remains in the step 2 archive.
 
 ### Report the old runtime directory — do not delete it
 


### PR DESCRIPTION
# English

## Summary

Hand-over said "move `$TARGET_REPO` to where the user wants it" and never stated what the result *is*. A reader who knows the old layout — where `harness/` was a git repository nested inside the project directory — reasonably concludes the new ledger belongs back inside the project, replacing the old `harness/` in place. The owner read it that way, which is how the gap surfaced.

It does not, and reproducing the old shape does not work.

Production-Delta: +0/-0

## What Changed

Hand-over now states that `$TARGET_REPO` is a **standalone ledger repository** that lives outside the project it serves and is attached by path through `daemon repo register`.

It names the old shape as the thing not to reproduce and quotes the error that shape produces, so an agent that tries it recognizes the failure instead of debugging it.

It also states that the previous ledger's git history is not carried forward. The migration is a genesis replay: entities are rebuilt from `harness/events/` and `harness/objects/`, and the old repository's commit history stays in the step 2 archive. Silence on that point invites the assumption that history travels with the migration.

## Task And Scope

- Harness task: `task_01M022AR425YG81NS1TRH8BDKR`
- Branch: `codex/land-in-place`
- Out of scope: making `ha init` produce a standalone ledger directly, and configuring a remote for the new ledger. Both were explicitly deferred by the owner.

## Version Impact

- Version: no version change
- Publish impact: skill documentation only.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task `task_01M022AR425YG81NS1TRH8BDKR`; owner adjudication in session — the ledger is central and must not travel inside a project repository
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable

## Verification

- Base `origin/rebuild/main` SHA: `bc670d1a`
- Branch merge-base with `origin/rebuild/main`: `bc670d1a`
- Public diff command: `git diff bc670d1a..codex/land-in-place`

The claim that the nested shape fails was **measured, not reasoned**. Against the current source, in an isolated daemon user root:

| Step | Result |
| --- | --- |
| `ha init` into a repo containing project code | `harness/**` plus `CLAUDE.md`/`AGENTS.md` committed to the **outer** repo; no `harness/.git` |
| make `harness/` standalone (`git init` inside it) and add `/harness/` to `.gitignore` | ignore rule inert — the paths were already tracked |
| `git rm -r --cached harness` then commit | outer tracking drops to 0, ignore rule applies, working tree intact |
| any write against that nested standalone ledger | **`publication_indeterminate: Canonical and authored refs must agree before init publication`** |

The last row is the load-bearing one: the nested shape does not fail at landing time, it lands and then refuses writes — the worst failure ordering, since the damage appears after the migration is declared done.

A second observation from the same probe, recorded here because it is evidence for #1433 rather than for this PR: pointing the isolated daemon at a deleted source checkout produced `missing_vertical` with the hint `Required regular file …/vertical.json is unavailable.` — readable text naming the real cause, where before #1433 it read `[object Object]`. #1433 stated it had no end-to-end confirmation; this is one.

- [x] `npm run check:local` — passed, 27.9s (includes the skill contract test)
- [x] `node tools/gates/line-budget.mjs --base bc670d1a` — G32 pass
- [x] `node tools/gates/production-delta.mjs --base bc670d1a` — computed `+0/-0`, matches the declaration
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: no cold-start run has reached hand-over. The probe above exercised the shapes directly instead.

## Review Evidence

- Reviewer subagent: not used
- Blocking findings: none

## Residual Risk

- `ha init` writes `harness/` as tracked content of whatever repository it runs in, and writes no ignore rule for the runtime `.harness/` either — the probe repository ended up tracking `.harness/cache/task.sqlite`. Neither is caused by this PR and neither blocks migration, because the target repository contains only the ledger. Both are worth fixing in `ha init` and are deliberately not fixed here.
- The skill now asserts that a nested standalone ledger is rejected. That is measured on this version; if the daemon later supports it, this passage becomes stale in the way a symptom-shaped instruction always does.

## References

- Task: `task_01M022AR425YG81NS1TRH8BDKR`
- Skill: `skills/harness-migration/SKILL.md`
- Predecessors: #1432, #1433, #1434, #1435, #1436, #1437

---

# 中文

## 概要

交付那节只写了「把 `$TARGET_REPO` 移到用户想要的地方」,却从未说明**结果是什么形态**。一个了解旧布局的读者——旧布局里 `harness/` 是嵌在项目目录内的一个 git 仓库——会合理地推断新台账应该放回项目里、原地替换掉老的 `harness/`。所有者正是这样读的,缺口因此暴露。

事实并非如此,而且照旧形态做是行不通的。

生产行数变更声明见英文段。

## 改动内容

交付那节现在明确写出:`$TARGET_REPO` 是一个**独立的台账仓库**,它存在于它所服务的项目**之外**,通过 `daemon repo register` 按路径挂接。

它点名旧形态是「不要复现的那个」,并引用该形态会产生的报错原文,好让尝试它的 agent 一眼认出失败,而不是去调试。

它同时写明:上一代台账的 git 历史**不随迁移带走**。迁移是创世重放——实体由 `harness/events/` 与 `harness/objects/` 重建,旧仓的提交历史留在第 2 步的归档里。对这一点保持沉默,等于默许「历史会跟着迁移走」的假设。

## 任务与范围

- Harness 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- 分支:`codex/land-in-place`
- 范围外:让 `ha init` 直接产出独立台账,以及为新台账配置远端。两项均由所有者明确推迟。

## 版本影响

- 版本:不改版本
- 发布影响:仅 skill 文档。

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:任务 `task_01M022AR425YG81NS1TRH8BDKR`;所有者在会话中的裁决——台账是中心化的,不得跟随项目仓走
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用

## 验证

- `origin/rebuild/main` 基准 SHA:`bc670d1a`
- 当前分支与 `origin/rebuild/main` 的 merge-base:`bc670d1a`
- 公开 diff 命令:`git diff bc670d1a..codex/land-in-place`

「嵌套形态会失败」这一断言是**实测出来的,不是推理出来的**。在隔离 daemon user root 下,针对当前源码:

| 步骤 | 结果 |
| --- | --- |
| 在含项目代码的仓库里跑 `ha init` | `harness/**` 连同 `CLAUDE.md`/`AGENTS.md` 提交进**外层**仓;不存在 `harness/.git` |
| 把 `harness/` 独立化(在其中 `git init`)并向 `.gitignore` 加 `/harness/` | ignore 规则无效——这些路径已被跟踪 |
| `git rm -r --cached harness` 后提交 | 外层跟踪降为 0,ignore 生效,工作区完好 |
| 对该嵌套式独立台账做任何写入 | **`publication_indeterminate: Canonical and authored refs must agree before init publication`** |

最后一行是承重的:嵌套形态**不是在落地时失败**,而是落地之后拒绝写入——这是最糟的失败次序,因为损害出现在迁移已被宣布完成之后。

同一次探针的另一个观察,记在这里是因为它是 #1433 的证据而非本 PR 的:把隔离 daemon 指向一个已被删除的源码检出,得到的是 `missing_vertical`,hint 为 `Required regular file …/vertical.json is unavailable.`——可读文本,且指出了真实成因;而在 #1433 之前,这里是 `[object Object]`。#1433 曾声明它没有端到端确认,这就是一次。

- [x] `npm run check:local` — 通过,27.9 秒(含 skill 契约测试)
- [x] `node tools/gates/line-budget.mjs --base bc670d1a` — G32 通过
- [x] `node tools/gates/production-delta.mjs --base bc670d1a` — 实测 `+0/-0`,与声明一致
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- **未跑项及原因**:尚无冷启动运行推进到交付步骤。上述探针直接验证了这两种形态。

## 复核证据

- Reviewer subagent:未使用
- 阻塞发现:无

## 残留风险

- `ha init` 会把 `harness/` 写成它所在仓库的跟踪内容,也没有为运行时 `.harness/` 写任何 ignore 规则——探针仓库最终跟踪了 `.harness/cache/task.sqlite`。两者都不是本 PR 造成的,也都不阻塞迁移(因为目标仓库只有台账)。两者都值得在 `ha init` 里修,并在此刻被刻意不修。
- skill 现在断言「嵌套式独立台账会被拒绝」。这是在当前版本上实测的;若 daemon 日后支持该形态,这段文字会像一切以症状为形的指引那样过时。

## 参考

- 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- Skill:`skills/harness-migration/SKILL.md`
- 前序:#1432、#1433、#1434、#1435、#1436、#1437
