### PR TITLE
docs(skills): correct why the ledger goes outside the project

### DIFF
--- a/skills/harness-migration/SKILL.md
+++ b/skills/harness-migration/SKILL.md
@@ -337,13 +337,19 @@ that use it. Copying it inside a project would give every project its own
 divergent copy, and on a public project it would publish the ledger outright.
 
 Say this explicitly, because the old layout was different. Previous generations
-kept `harness/` as a git repository nested inside the project directory. **Do
-not reproduce that.** The daemon rejects it — a nested standalone ledger fails
-with `publication_indeterminate: Canonical and authored refs must agree` — and
-the ledger is no longer reachable for writes.
+kept `harness/` as a git repository nested inside the project directory. That
+shape is intended and will be supported again, but **on this version place the
+ledger outside the project**, for a reason that has nothing to do with nesting:
+
+`ha init` currently treats the repository it runs in as the ledger's git
+carrier, tracking state in `refs/ha/canonical`. An ordinary project commit
+moves `HEAD` while that ref stays put, and the next ledger write fails with
+`publication_indeterminate: Canonical and authored refs must agree`. A ledger
+sharing a repository with project code is therefore locked by the project's own
+development. Keeping it in a repository of its own avoids that entirely.
 
 ```bash
-mv "$TARGET_REPO" /absolute/path/the/user/chooses      # outside any project checkout
+mv "$TARGET_REPO" /absolute/path/the/user/chooses      # a directory of its own
 $HA daemon repo register --repo-id <new-repo-id> --root /absolute/path/the/user/chooses
 ```
 


### PR DESCRIPTION
# English

## Summary

#1438 told agents that a ledger nested inside a project directory is rejected by the daemon, citing `publication_indeterminate`. **That attribution was wrong.** The probe behind it had made several ordinary commits to the outer repository after `init`, and those commits — not the nesting — caused the failure.

Production-Delta: +0/-0

## What Changed

Section 9 now gives the real reason. The recommendation is unchanged — place the migrated ledger in a repository of its own — but the cause behind it is corrected, and the nested layout is described as intended and temporarily unavailable rather than forbidden.

Stating a wrong cause is worse than stating none: an agent that hits `publication_indeterminate` while following the old text would go looking for nesting it had already avoided, and would not find the project commit that actually caused it.

## The defect that the correction exposes

`ha init` treats the repository it runs in as the ledger's git carrier, tracking state in `refs/ha/canonical`. A/B on `2c4e6a40`, isolated daemon user root:

| | `HEAD` | `refs/ha/canonical` | ledger write |
| --- | --- | --- | --- |
| after `init`, outer untouched | `286f2d6` | `286f2d6` | succeeds (`commit: none`) |
| after one ordinary project commit | `b0b0322` | `286f2d6` | **`publication_indeterminate`** |

So a ledger that shares a repository with project code is locked by that project's own development — one `git commit` is enough. That is a production defect well beyond this skill, and it is being fixed separately so the ledger owns its own git repository and both layouts work. This PR only stops the skill from misdescribing it.

## Task And Scope

- Harness task: `task_01M022AR425YG81NS1TRH8BDKR`
- Branch: `codex/fix-claim`
- Out of scope: the fix itself — dispatched separately against `packages/daemon` and `packages/kernel`.

## Version Impact

- Version: no version change
- Publish impact: skill documentation only.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task `task_01M022AR425YG81NS1TRH8BDKR`; correcting a claim this session introduced in #1438
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable

## Verification

- Base `origin/rebuild/main` SHA: `2c4e6a40`
- Branch merge-base with `origin/rebuild/main`: `2c4e6a40`
- Public diff command: `git diff 2c4e6a40..codex/fix-claim`

- [x] the A/B above, run on this version in an isolated daemon user root; the two rows differ only by one `git commit` in the project repository
- [x] `npm run check:local` — passed, 34.5s
- [x] `node tools/gates/line-budget.mjs --base 2c4e6a40` — G32 pass
- [x] `node tools/gates/production-delta.mjs --base 2c4e6a40` — computed `+0/-0`, matches the declaration
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: no cold-start run has reached hand-over.

## Review Evidence

- Reviewer subagent: not used
- Blocking findings: none

## Residual Risk

- The corrected passage describes a limitation of this version. When the ledger owns its git repository, the paragraph should shrink to the recommendation and lose the explanation — it is written to be deleted, not maintained.

## References

- Task: `task_01M022AR425YG81NS1TRH8BDKR`
- Corrects: #1438
- Skill: `skills/harness-migration/SKILL.md`

---

# 中文

## 概要

#1438 告诉 agent:嵌在项目目录内的台账会被 daemon 拒绝,并引用了 `publication_indeterminate`。**这个归因是错的。** 支撑它的那次探针在 `init` 之后对外层仓做了数次普通提交,导致失败的是那些提交,而不是嵌套。

生产行数变更声明见英文段。

## 改动内容

第 9 节现在给出真实原因。建议本身不变——把迁移出的台账放在它自己的仓库里——但其背后的成因被更正,嵌套布局被描述为「本就该支持、当前暂不可用」,而非「禁止」。

给出一个错误的原因,比不给原因更糟:照旧文本排查的 agent 撞上 `publication_indeterminate` 时,会去找一个自己早已避开的嵌套问题,而找不到真正引发它的那次项目提交。

## 这次更正暴露出的缺陷

`ha init` 把它运行所在的那个仓库当作台账的 git 载体,用 `refs/ha/canonical` 跟踪状态。在 `2c4e6a40` 上、隔离 daemon user root 的 A/B:

| | `HEAD` | `refs/ha/canonical` | 台账写入 |
| --- | --- | --- | --- |
| `init` 后不动外层 | `286f2d6` | `286f2d6` | 成功(`commit: none`) |
| 用户提交一次项目代码后 | `b0b0322` | `286f2d6` | **`publication_indeterminate`** |

也就是说,与项目代码共用一个仓库的台账,会被该项目自身的开发锁死——**一次 `git commit` 就够了**。这是远超本 skill 范围的生产缺陷,已另行派工修复,使台账拥有自己的 git 仓库、两种布局都能工作。本 PR 只负责让 skill 不再错误地描述它。

## 任务与范围

- Harness 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- 分支:`codex/fix-claim`
- 范围外:修复本身——已另行针对 `packages/daemon` 与 `packages/kernel` 派工。

## 版本影响

- 版本:不改版本
- 发布影响:仅 skill 文档。

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:任务 `task_01M022AR425YG81NS1TRH8BDKR`;更正本会话在 #1438 中引入的一个断言
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用

## 验证

- `origin/rebuild/main` 基准 SHA:`2c4e6a40`
- 当前分支与 `origin/rebuild/main` 的 merge-base:`2c4e6a40`
- 公开 diff 命令:`git diff 2c4e6a40..codex/fix-claim`

- [x] 上述 A/B,在本版本、隔离 daemon user root 下实跑;两行之间的唯一差异是项目仓里的一次 `git commit`
- [x] `npm run check:local` — 通过,34.5 秒
- [x] `node tools/gates/line-budget.mjs --base 2c4e6a40` — G32 通过
- [x] `node tools/gates/production-delta.mjs --base 2c4e6a40` — 实测 `+0/-0`,与声明一致
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- **未跑项及原因**:尚无冷启动运行推进到交付步骤。

## 复核证据

- Reviewer subagent:未使用
- 阻塞发现:无

## 残留风险

- 被更正的这段描述的是本版本的一个限制。当台账拥有自己的 git 仓库后,该段应缩回成一句建议并删掉解释——它是**为了被删除而写的**,不是为了长期维护。

## 参考

- 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- 更正:#1438
- Skill:`skills/harness-migration/SKILL.md`
