### PR TITLE
fix(daemon): free a repoId for rebinding after unregister

### DIFF
--- a/packages/kernel/src/daemon/registry.ts
+++ b/packages/kernel/src/daemon/registry.ts
@@ -80,11 +80,11 @@ export function registerDaemonRepo(input: DaemonRegistryRegisterInput): DaemonRe
 
   const reservedRepoIds = [...registry.repos.map(({ repoId }) => repoId), ...registry.invalidRepos.flatMap(({ repoId }) => repoId ? [repoId] : [])];
   const repoId = explicitRepoId ?? generateRepoId(displayName, canonicalRoot, reservedRepoIds);
-  const conflictingRepo = registry.repos.find((repo) => repo.repoId === repoId);
+  const conflictingRepo = registry.repos.find((repo) => repo.repoId === repoId && repo.state === "enabled");
   if (conflictingRepo) {
     throw new Error(`repoId "${repoId}" is already registered for ${conflictingRepo.canonicalRoot}`);
   }
-  if (registry.invalidRepos.some((repo) => repo.repoId === repoId)) throw new Error(`repoId "${repoId}" has an invalid daemon registry entry; unregister it before reusing the id`);
+  if (registry.invalidRepos.some((repo) => repo.repoId === repoId && repo.state !== "disabled")) throw new Error(`repoId "${repoId}" has an invalid daemon registry entry; unregister it before reusing the id`);
 
   const repo: DaemonRegistryRepo = {
     repoId,
@@ -94,7 +94,7 @@ export function registerDaemonRepo(input: DaemonRegistryRegisterInput): DaemonRe
     state: "enabled",
     registeredAt: (input.now ?? (() => new Date()))().toISOString()
   };
-  const next = sortDaemonRegistry({ ...registry, repos: [...registry.repos, repo] });
+  const next = sortDaemonRegistry({ ...registry, repos: [...registry.repos.filter((existing) => existing.repoId !== repoId), repo], invalidRepos: registry.invalidRepos.filter((existing) => existing.repoId !== repoId) });
   writeDaemonRegistry(next, input);
   warnings.push(...syncConvenienceLink(repo, input));
   return { registry: next, repo, registryPath: paths.registryPath, changed: true, warnings };

--- a/packages/kernel/test/store/daemon-registry.test.ts
+++ b/packages/kernel/test/store/daemon-registry.test.ts
@@ -128,6 +128,30 @@ test("daemon registry unregister disables a repo without deleting registry histo
   });
 });
 
+test("daemon registry rebinds an unregistered repoId to a new canonical root", () => {
+  withTempDir((root) => {
+    const userRoot = path.join(root, "user-harness");
+    const firstRoot = createHarnessRepo(path.join(root, "before-move"));
+    const secondRoot = createHarnessRepo(path.join(root, "after-move"));
+
+    registerDaemonRepo({ userRoot, canonicalRoot: firstRoot, repoId: "land", createConvenienceLinks: false });
+    assert.throws(
+      () => registerDaemonRepo({ userRoot, canonicalRoot: secondRoot, repoId: "land", createConvenienceLinks: false }),
+      /already registered for/u
+    );
+
+    unregisterDaemonRepo("land", { userRoot, createConvenienceLinks: false });
+    const rebound = registerDaemonRepo({ userRoot, canonicalRoot: secondRoot, repoId: "land", createConvenienceLinks: false });
+
+    assert.equal(rebound.repo.canonicalRoot, secondRoot);
+    assert.equal(rebound.repo.state, "enabled");
+    assert.deepEqual(
+      readDaemonRegistry({ userRoot }).repos.map((repo) => [repo.repoId, repo.canonicalRoot, repo.state]),
+      [["land", secondRoot, "enabled"]]
+    );
+  });
+});
+
 test("daemon registry fails closed for malformed registries and uninitialized roots", () => {
   withTempDir((root) => {
     const userRoot = path.join(root, "user-harness");


### PR DESCRIPTION
# English

## Summary

`daemon repo unregister` advertises that it frees a repoId, and the registry's own error text says so twice — `unregister it before registering the root again`, `unregister it before reusing the id`. It does not. Unregister marks the entry `state: "disabled"` and leaves it in `registry.repos`; register's conflict check reads that list with no state filter. So the id stays taken forever, and the escape hatch the error names is itself a dead end.

The path that surfaces this is moving a ledger. Registering repoId `land` at a new canonical root after unregistering it returns:

```
error code=bootstrap_failed hint=repoId "land" is already registered for .../target
```

`unregister` then `register` reproduces it exactly. There is no id-reuse path at all today: the only registration that succeeds against a disabled entry is one at the *same* root, which re-enables it.

Production-Delta: +3/-3

## What Changed

Register now protects enabled entries only, and a registration that reuses a disabled id replaces the stale row rather than appending beside it. Both halves are needed: without the state filter the register throws; without the replacement it would write two rows sharing one repoId.

The `disabled` state is kept as-is. It is load-bearing — `daemon-host` attaches `state === "enabled"` repos and the GUI renders disabled ones as `registrationState: "disabled" / cellState: "not_loaded"` — so unregister still disables rather than deletes. What changes is only that a disabled id is no longer treated as an occupant.

The same filter is applied to `invalidRepos`, where the dead end was more literal: the error there names `unregister` explicitly, and unregister on an invalid entry also only sets `disabled`.

## Task And Scope

- Harness task: `task_01M022AR425YG81NS1TRH8BDKR`
- Branch: `codex/repoid-rebind`
- Out of scope, found in the same end-to-end run and reported below: the workspace writer lock lands untracked inside the user's project tree.

## Version Impact

- Version: no version change
- Publish impact: `ha daemon repo register` accepts a registration it previously rejected. No command surface, flag, or receipt shape changed.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task `task_01M022AR425YG81NS1TRH8BDKR`; owner adjudication that the ledger is a standalone repository which may sit inside the project — moving a ledger into place is the flow this blocks
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable

## Verification

- Base `origin/rebuild/main` SHA: `ce393015`
- Branch merge-base with `origin/rebuild/main`: `ce393015`
- Public diff command: `git diff ce393015..codex/repoid-rebind`

- [x] `npm run check:local` — passed, 37.8s
- [x] `node tools/gates/line-budget.mjs --base ce393015` — G32 pass. The fix is written as one dense statement to match this file's established density (`registry.ts:111` is the same shape), which is why it needs no receipt. No unrelated code was reformatted to buy budget.
- [x] `node tools/gates/production-delta.mjs --base ce393015` — computed `+3/-3`, matches the declaration
- [x] New test `daemon registry rebinds an unregistered repoId to a new canonical root`, in the existing fast-tier file. It first asserts the *enabled* case still conflicts, then unregisters and rebinds, then asserts the registry holds exactly one row: `[["land", secondRoot, "enabled"]]`.
- [x] Mutation, both halves, each independently: dropping `&& repo.state === "enabled"` → red; restoring the plain `[...registry.repos, repo]` append → red. Pass 8/fail 0 restored after each.
- [x] End-to-end, the flow this unblocks, on an isolated `HARNESS_DAEMON_USER_ROOT`: `ha init` into a scratch target → copy `harness/` into a committed user project → ignore `/harness/` and `/.harness/` → `unregister` → `register --root <project>/harness` → `ha task create`. Result: `created task task_f86efb2be2260636bb0abe7ea3`; the ledger's own repository holds 2 commits; the project repository tracks 0 ledger files. Before this change the register step failed with `bootstrap_failed`.
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: the integration tier is not in the fast tier and `integration-shard` is skipped on PRs by test-selection, so the two pre-existing failures on `rebuild/main` are not re-checked here. They are unrelated to registration and are being diagnosed separately.

## Review Evidence

- Reviewer subagent: not used
- Blocking findings: none

## Residual Risk

- Rebinding a disabled id to a new root drops the old row entirely, so the previous canonical root ends up with no registry entry. That is what "unregister" means, but it is a silent consequence: nothing warns that the old root is now unregistered. Re-registering it produces a fresh id, which is correct but not obvious.
- Found during the end-to-end run and deliberately not fixed here: the workspace writer lock is created as `${root}.harness-anything-writer.lock`, which for a ledger at `<project>/harness` puts `harness.harness-anything-writer.lock` inside the user's project working tree. It is unlinked on close, so it is present for as long as the daemon holds the cell — i.e. normally — and the ignore rules `ha init` writes do not cover it. It is a concurrency artifact and moving it is a correctness change that deserves its own test, so it gets its own change rather than riding along here.

## References

- Task: `task_01M022AR425YG81NS1TRH8BDKR`
- Predecessor: #1440 (ledger owns its git repository) — this PR unblocks the landing step that #1440 made possible

---

# 中文

## 概要

`daemon repo unregister` 对外宣称它释放 repoId,registry 自己的报错文案也说了两遍——`unregister it before registering the root again`、`unregister it before reusing the id`。它并不释放。unregister 把条目置为 `state: "disabled"` 并**留在** `registry.repos` 里,而 register 的冲突检查读这个列表时**完全不看 state**。于是这个 id 被永久占住,**报错指名的那条正路,本身是死路。**

暴露它的路径是「搬台账」。unregister 之后把 repoId `land` 注册到新的 canonical root:

```
error code=bootstrap_failed hint=repoId "land" is already registered for .../target
```

先 `unregister` 再 `register`,原样复现。今天根本不存在任何 id 复用路径:面对一个 disabled 条目,唯一能成功的注册是注册到**同一个** root——那走的是重新启用分支。

生产行数变更声明见英文段。

## 改动内容

register 现在只保护 **enabled** 条目;复用一个 disabled id 的注册会**替换**那条陈旧记录,而不是并排追加。两半缺一不可:没有 state 过滤,register 直接抛错;没有替换,就会写出两条共用同一个 repoId 的记录。

`disabled` 状态原样保留。它是承重的——`daemon-host` 只挂载 `state === "enabled"` 的 repo,GUI 把 disabled 的渲染成 `registrationState: "disabled" / cellState: "not_loaded"`——所以 unregister 依然是禁用而不是删除。改变的只有一点:**disabled 的 id 不再被当作占用者。**

同一个过滤也施加到 `invalidRepos`。那一侧的死路更直白:报错原文直接点名 `unregister`,而 unregister 对 invalid 条目做的同样只是置 `disabled`。

## 任务与范围

- Harness 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- 分支:`codex/repoid-rebind`
- 范围外(同一次端到端实跑中发现,已在下方如实报告):workspace writer 锁文件会以未跟踪状态落进用户项目工作树。

## 版本影响

- 版本:不改版本
- 发布影响:`ha daemon repo register` 现在接受一类它此前拒绝的注册。命令面、flag、回执形状均未变。

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:任务 `task_01M022AR425YG81NS1TRH8BDKR`;所有者裁决「台账是独立仓库,可以放在项目内部」——把台账搬到位,正是被这个缺陷卡住的流程
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用

## 验证

- `origin/rebuild/main` 基准 SHA:`ce393015`
- 当前分支与 `origin/rebuild/main` 的 merge-base:`ce393015`
- 公开 diff 命令:`git diff ce393015..codex/repoid-rebind`

- [x] `npm run check:local` — 通过,37.8 秒
- [x] `node tools/gates/line-budget.mjs --base ce393015` — G32 通过。修复写成一条高密度语句,与本文件既有密度一致(`registry.ts:111` 就是这个形状),因此不需要 receipt。**没有为了腾预算去重排任何无关代码。**
- [x] `node tools/gates/production-delta.mjs --base ce393015` — 实测 `+3/-3`,与声明一致
- [x] 新测试 `daemon registry rebinds an unregistered repoId to a new canonical root`,落在既有 fast-tier 文件。它先断言 **enabled** 情形仍然冲突,再 unregister、重绑,最后断言 registry 里恰好只有一行:`[["land", secondRoot, "enabled"]]`。
- [x] Mutation,两半各自独立验:去掉 `&& repo.state === "enabled"` → 红;恢复成裸 `[...registry.repos, repo]` 追加 → 红。每次复原后回到 pass 8 / fail 0。
- [x] 端到端跑通被它卡住的那条流程(隔离 `HARNESS_DAEMON_USER_ROOT`):在 scratch target 里 `ha init` → 把 `harness/` 拷进一个已提交的用户项目 → 忽略 `/harness/` 与 `/.harness/` → `unregister` → `register --root <project>/harness` → `ha task create`。结果:`created task task_f86efb2be2260636bb0abe7ea3`;台账自有仓 2 个提交;项目仓跟踪 0 个台账文件。**本改动之前,register 那一步以 `bootstrap_failed` 失败。**
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- **未跑项及原因**:integration tier 不在 fast tier 内,且 `integration-shard` 在 PR 上被 test-selection 跳过,因此 `rebuild/main` 上那两个既有失败没有在此复检。它们与注册无关,正在单独排查。

## 复核证据

- Reviewer subagent:未使用
- 阻塞发现:无

## 残留风险

- 把 disabled id 重绑到新 root 会整条丢弃旧记录,于是旧 canonical root 最终没有任何 registry 条目。这正是「unregister」的字面含义,但它是个**静默后果**:没有任何提示告诉你旧 root 现在未注册了。重新注册它会得到一个新 id——正确,但不直观。
- 端到端实跑中发现、**刻意不在本 PR 修**的问题:workspace writer 锁的路径是 `${root}.harness-anything-writer.lock`,当台账位于 `<project>/harness` 时,它会在用户项目工作树里留下 `harness.harness-anything-writer.lock`。该文件在 close 时才 unlink,所以只要 daemon 持有该 cell 它就在——也就是常态——而 `ha init` 写入的忽略规则并不覆盖它。它是并发原语的产物,挪动它属于正确性变更、应当自带测试,所以单独出一个改动,不搭本 PR 的车。

## 参考

- 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- 前序:#1440(台账拥有自己的 git 仓库)——本 PR 打通的正是 #1440 使之成为可能的那个落地步骤
