### PR TITLE
docs(skill): land the migrated ledger in place, local or central

### DIFF
--- a/skills/harness-migration/SKILL.md
+++ b/skills/harness-migration/SKILL.md
@@ -328,39 +328,79 @@ forward. Keep the current file's structure and add to it — do not paste the ol
 file over it, which would undo the resolution that was just applied. Show the
 user the resulting diff. This is the last write of the migration.
 
-## 9. Hand over
+## 9. Land the ledger
 
-`$TARGET_REPO` is a **standalone ledger repository**. It holds `harness/` and
-nothing else — no project code — and it is meant to live **outside** the
-project it serves. A ledger is central: one ledger, mirrored by the checkouts
-that use it. Copying it inside a project would give every project its own
-divergent copy, and on a public project it would publish the ledger outright.
+`$TARGET_REPO/harness` is a **standalone git repository** — its own `.git`, its
+own history, its own remote. That is true in both placements below, and it is
+the thing that must not be lost: a ledger is never a subdirectory of the
+project's repository. One ledger, mirrored by the checkouts that use it.
 
-Say this explicitly, because the old layout was different. Previous generations
-kept `harness/` as a git repository nested inside the project directory. That
-shape is intended and will be supported again, but **on this version place the
-ledger outside the project**, for a reason that has nothing to do with nesting:
+**Local — the default.** The ledger lives inside the project directory as
+`<project>/harness`, a repository of its own, and the project ignores it. This
+is the shape `ha init` produces for a new project and the shape previous
+generations used. Choose it unless the user says otherwise.
 
-`ha init` currently treats the repository it runs in as the ledger's git
-carrier, tracking state in `refs/ha/canonical`. An ordinary project commit
-moves `HEAD` while that ref stays put, and the next ledger write fails with
-`publication_indeterminate: Canonical and authored refs must agree`. A ledger
-sharing a repository with project code is therefore locked by the project's own
-development. Keeping it in a repository of its own avoids that entirely.
+**Central.** The ledger lives outside any project, in a directory of its own,
+and is registered by absolute path. Choose it when the user tells you the
+ledger is shared — several machines mirroring one authoritative copy.
+
+The procedure below is the same for both. Only `LEDGER_HOME` differs.
 
 ```bash
-mv "$TARGET_REPO" /absolute/path/the/user/chooses      # a directory of its own
-$HA daemon repo register --repo-id <new-repo-id> --root /absolute/path/the/user/chooses
+# local (default) — the project directory the user is migrating
+export LEDGER_HOME="/absolute/path/to/the/project"
+# central — a directory of its own, outside every project
+# export LEDGER_HOME="/absolute/path/the/user/chooses"
+
+cd "$LEDGER_HOME"
+rm -rf harness                                        # superseded; step 2 archived it
+cp -R "$TARGET_REPO/harness" ./harness
 ```
 
-The old `harness/` still sits in the project directory. It is superseded, the
-step 2 archive holds it, and the project already ignores it, so removing it is
-safe — but it is the user's directory, so show the path and let them decide.
+In a project, isolate the ledger from the project's own repository before
+committing anything. `ha init` does this on a fresh project, but registering an
+existing ledger does not, so do it here:
+
+```bash
+git check-ignore -q harness || printf '/harness/\n/.harness/\n' >> .gitignore
+git rm -r -q --cached --ignore-unmatch -- harness .harness
+```
+
+The `git rm --cached` is not redundant. `.gitignore` has no effect on paths the
+index already tracks, so a project that had committed any part of the old
+`harness/` keeps tracking it — and the ledger is private while the project may
+well be public.
+
+Then bind the repo id to its new location and commit the project side:
+
+```bash
+$HA daemon repo unregister --repo-id <new-repo-id>
+$HA daemon repo register   --repo-id <new-repo-id> --root "$LEDGER_HOME"
+git add -A && git commit -m "adopt migrated ledger"    # local placement only
+```
+
+`--root` takes `$LEDGER_HOME`, not `$LEDGER_HOME/harness`. Both are accepted and
+resolve to the same canonical root, but the runtime's `.harness/` directory and
+its writer lock are placed relative to the root you pass, and only the former
+puts them where the ignore rules above expect them.
+
+Check the landing before handing over. All five must hold:
+
+```bash
+test -d harness/.git                         && echo "ledger has its own git"
+git check-ignore -q harness                  && echo "project ignores the ledger"
+test -z "$(git ls-files harness/ .harness/)" && echo "project tracks no ledger file"
+git status --porcelain                       # expected: empty
+$HA task create --title "landing check" --kind chore   # expected: created task ...
+```
+
+The last one is the only proof that the ledger is writable where it now sits;
+the other four only prove it is shaped correctly.
 
 Then tell them:
 
 - their existing Harness installation was not modified;
-- the new ledger is a repository of its own, registered by path, and does not belong inside a project checkout;
+- the ledger is a git repository of its own, and the project must never track it;
 - the migration daemon lives under `$HARNESS_DAEMON_USER_ROOT` and can be removed with the work directory;
 - the previous ledger's git history is not carried forward — this migration rebuilds the ledger from its events, and the old history remains in the step 2 archive.
 
@@ -418,6 +458,8 @@ success and failure paths.
 - Every merge recorded in the step 5 table has been applied to the destination.
 - Every legacy preset has a validated v3 replacement installed.
 - `source-before` equals `source-after`.
+- The ledger has its own `.git` at its landed location, the project tracks no
+  ledger file, and `ha task create` succeeded there.
 
 ## Known rough edges
 
@@ -427,3 +469,10 @@ success and failure paths.
   `HARNESS_DAEMON_USER_ROOT`. Route on the code and origin, not the wording.
 - `--daemon-mode direct` does not support `init` — it rejects with
   `unsupported_command`. Isolation is done with the user root, not with direct mode.
+- `daemon repo register` does not isolate a ledger from the project repository
+  around it; only `ha init` does. That is why step 9 writes the ignore rules and
+  runs `git rm --cached` by hand rather than trusting registration to do it.
+- The writer lock is created as a sibling of the root you register — for a local
+  placement that is `<parent-of-project>/<project-name>.harness-anything-writer.lock`.
+  It is outside the project, so it does not dirty the working tree, but it is
+  visible next to the project directory while the daemon holds the ledger.


### PR DESCRIPTION
# English

## Summary

Step 9 told the agent to place the ledger outside the project, and gave a reason: `ha init` treated the surrounding repository as the ledger's git carrier, so an ordinary project commit moved `HEAD` away from `refs/ha/canonical` and the next ledger write failed with `publication_indeterminate`. #1440 removed that — the ledger now owns its own git repository — so the reason no longer holds and the instruction built on it is wrong.

The owner's adjudication is that both placements are supported and the local one is the default: a ledger sitting inside the project directory as its own repository is the intuitive local shape, and an external ledger registered by path is the central shape for several machines mirroring one authoritative copy.

Step 9 is rewritten around that, and around what the landing actually requires — which turned out to be more than a `mv`.

Production-Delta: +0/-0

## What Changed

**Two placements, one procedure.** Only `LEDGER_HOME` differs between them. The invariant stated up front is the one that must survive either choice: the ledger is a git repository of its own and is never a subdirectory of the project's repository.

**The isolation is now explicit, because registration does not do it.** `isolateLedgerFromProject` is called from the bootstrap publication path that `ha init` runs; `daemon repo register` on an existing ledger never reaches it. Landing a ledger by copy and register therefore leaves the project with no ignore rules and the entire ledger untracked-but-visible. Step 9 writes the rules and runs `git rm --cached` itself, and says why the second command is not redundant: `.gitignore` does not apply to paths the index already tracks, and the ledger is private while the project may be public.

**The rebind is now a step.** After the ledger moves, its repo id still points at the old path, and registration failed with `bootstrap_failed: repoId "..." is already registered for ...`. #1441 made `unregister` actually free the id; step 9 calls both commands in order.

**`--root` takes the project, not the ledger path.** Both resolve to the same canonical root, so both appear to work — but the runtime `.harness/` directory and the writer lock are placed relative to the argument, and only `$LEDGER_HOME` puts them where the ignore rules expect. Passing `$LEDGER_HOME/harness` drops `harness/.harness/` and `harness.harness-anything-writer.lock` into the project working tree.

**A landing check with a real write.** Four structural assertions plus `ha task create`. The structural four only prove the layout is right; the write is the only evidence the ledger is usable where it now sits.

## Task And Scope

- Harness task: `task_01M022AR425YG81NS1TRH8BDKR`
- Branch: `codex/skill-landing`
- Out of scope: making `daemon repo register` isolate the ledger by itself. It is recorded as a rough edge, and step 9 does the work by hand until it does.

## Version Impact

- Version: no version change
- Publish impact: skill documentation only; no CLI surface or importer behaviour changed.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task `task_01M022AR425YG81NS1TRH8BDKR`; owner adjudication that the ledger is a standalone repository and that both the local-nested and central placements are supported, with local as the intuitive default
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable

## Verification

- Base `origin/rebuild/main` SHA: `a5096786`
- Branch merge-base with `origin/rebuild/main`: `a5096786`
- Public diff command: `git diff a5096786..codex/skill-landing`

- [x] `npm run check:local` — passed, 35.1s (includes the skill contract test)
- [x] `node tools/gates/line-budget.mjs --base a5096786` — G32 pass
- [x] `node tools/gates/production-delta.mjs --base a5096786` — computed `+0/-0`, matches the declaration

The procedure was executed, not composed. Every command in step 9 comes from a run on an isolated `HARNESS_DAEMON_USER_ROOT`, against a project that already tracked an old `harness/OLD.md` — the worst case for the `git rm --cached` line:

| Assertion | Result |
| --- | --- |
| ledger has its own git at the landed location | `harness/.git` present |
| project ignores the ledger | `git check-ignore harness` hits |
| project tracks no ledger file | `git ls-files harness/ .harness/` → 0 |
| project working tree is clean | `git status --porcelain` → empty |
| the ledger is writable there | `created task task_13f6737de87ee461748f4957cf`; ledger repository at 2 commits |
| the writer lock stays out of the project | `land7/proj.harness-anything-writer.lock`, a sibling of the project |

Three earlier runs are what produced the corrections rather than the confirmations, and each is why a specific line exists:

- registering with `--root <project>/harness` put `harness/.harness/` and `harness.harness-anything-writer.lock` inside the working tree — hence the `--root` paragraph;
- landing without the ignore rules left eleven untracked ledger entries plus a deleted `harness/OLD.md` — hence the isolation block;
- registering after the move failed with `bootstrap_failed: repoId "land" is already registered for .../target` — hence the rebind step, and #1441.

- [x] re-read the whole file for wording that assumed the external-only placement; no occurrence survives
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: steps 1–8 were not re-executed. This PR changes step 9 only, and nothing in it feeds back into the earlier steps.

## Review Evidence

- Reviewer subagent: not used
- Blocking findings: none

## Residual Risk

- The landing is destructive by instruction: `rm -rf harness` in the user's project. It is guarded by the step 2 archive and by the fact that the old ledger is a separate repository, but it is the one irreversible command in the skill and it runs against a directory the skill does not own.
- Step 9 reproduces by hand what `ha init` does automatically. If registration later grows the isolation, these lines become a second implementation of it. The rough-edge entry names that so it is removed rather than left to drift.
- The two placements share one procedure, but only the local one was executed end to end here. The central one is the shape that already worked before this PR and is unchanged by it.

## References

- Task: `task_01M022AR425YG81NS1TRH8BDKR`
- Skill: `skills/harness-migration/SKILL.md`
- Predecessors: #1440 (ledger owns its git repository), #1441 (unregister frees the repoId)

---

# 中文

## 概要

第 9 步原本要求把台账放在项目**之外**,并给了理由:`ha init` 把它所在的仓库当作台账的 git 载体,于是用户提交一次项目代码就会让 `HEAD` 与 `refs/ha/canonical` 分叉,下一次台账写入以 `publication_indeterminate` 失败。#1440 把这个前提拆掉了——台账现在拥有自己的 git 仓库——**理由不再成立,建立在它之上的那条指令就是错的。**

所有者的裁决是:两种放置都支持,**本地那种是默认**。台账作为独立仓库待在项目目录里,是本地使用最符合直觉的形态;挂在项目外、按路径注册,是多台机器镜像同一份权威副本的中心形态。

第 9 步围绕这一点重写,也围绕落地**真正需要的动作**重写——实测发现它远不止一个 `mv`。

生产行数变更声明见英文段。

## 改动内容

**两种放置,一套流程。** 两者只差一个 `LEDGER_HOME`。开头点明的不变量,是无论选哪种都必须活下来的那条:**台账是它自己的 git 仓库,永远不是项目仓库的子目录。**

**隔离动作现在写明了,因为注册不做这件事。** `isolateLedgerFromProject` 挂在 `ha init` 走的 bootstrap publication 路径上;`daemon repo register` 对一个既有台账根本走不到那里。于是「拷贝 + 注册」这种落地方式,会让用户项目**没有任何忽略规则**、整个台账以未跟踪状态铺在工作树里。第 9 步自己写规则、自己跑 `git rm --cached`,并说清第二条命令为什么不是多余:**`.gitignore` 对索引已跟踪的路径无效**,而台账是私有的、项目却可能是公开的。

**重绑成了一个正式步骤。** 台账搬走之后,它的 repo id 仍指着旧路径,注册会以 `bootstrap_failed: repoId "..." is already registered for ...` 失败。#1441 让 `unregister` 真的释放了 id;第 9 步按序调用这两条命令。

**`--root` 传项目目录,不是台账路径。** 两者解析到同一个 canonical root,所以看起来都能用——但运行时 `.harness/` 目录与 writer 锁是**相对你传的那个参数**放置的,只有 `$LEDGER_HOME` 会把它们放到忽略规则预期的位置。传 `$LEDGER_HOME/harness` 会把 `harness/.harness/` 和 `harness.harness-anything-writer.lock` 丢进项目工作树。

**落地检查里有一次真实写入。** 四条结构断言 + `ha task create`。那四条只能证明布局对;**写入是台账在新位置真的能用的唯一证据。**

## 任务与范围

- Harness 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- 分支:`codex/skill-landing`
- 范围外:让 `daemon repo register` 自己完成台账隔离。已作为 rough edge 记录;在它落地之前,第 9 步手工做这件事。

## 版本影响

- 版本:不改版本
- 发布影响:仅 skill 文档;CLI 命令面与 importer 行为均未变。

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:任务 `task_01M022AR425YG81NS1TRH8BDKR`;所有者裁决「台账是独立仓库」,且本地内嵌与中心外挂两种放置都支持、本地为直觉默认
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用

## 验证

- `origin/rebuild/main` 基准 SHA:`a5096786`
- 当前分支与 `origin/rebuild/main` 的 merge-base:`a5096786`
- 公开 diff 命令:`git diff a5096786..codex/skill-landing`

- [x] `npm run check:local` — 通过,35.1 秒(含 skill 契约测试)
- [x] `node tools/gates/line-budget.mjs --base a5096786` — G32 通过
- [x] `node tools/gates/production-delta.mjs --base a5096786` — 实测 `+0/-0`,与声明一致

**这套流程是跑出来的,不是写出来的。** 第 9 步里的每一条命令都来自隔离 `HARNESS_DAEMON_USER_ROOT` 上的实跑,目标项目**已经跟踪着一个旧的 `harness/OLD.md`**——这正是 `git rm --cached` 那一行的最坏情况:

| 断言 | 实测 |
| --- | --- |
| 台账在落地位置有自己的 git | `harness/.git` 存在 |
| 项目忽略台账 | `git check-ignore harness` 命中 |
| 项目不跟踪任何台账文件 | `git ls-files harness/ .harness/` → 0 |
| 项目工作树干净 | `git status --porcelain` → 空 |
| 台账在那里可写 | `created task task_13f6737de87ee461748f4957cf`;台账仓 2 个提交 |
| writer 锁不落进项目 | `land7/proj.harness-anything-writer.lock`,项目目录的同级 |

真正产出修正(而不是确认)的是前三次实跑,每一次都对应文中的一句话:

- 用 `--root <project>/harness` 注册,会把 `harness/.harness/` 与 `harness.harness-anything-writer.lock` 放进工作树 —— 于是有了 `--root` 那一段;
- 不写忽略规则就落地,工作树里留下 11 条未跟踪台账条目外加一条被删的 `harness/OLD.md` —— 于是有了隔离那一块;
- 搬完之后注册,以 `bootstrap_failed: repoId "land" is already registered for .../target` 失败 —— 于是有了重绑步骤,也有了 #1441。

- [x] 通读全文复查残留的「只能放在项目外」口径;无一处幸存
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- **未跑项及原因**:第 1–8 步没有重跑。本 PR 只改第 9 步,其中没有任何东西回流到前面的步骤。

## 复核证据

- Reviewer subagent:未使用
- 阻塞发现:无

## 残留风险

- 落地是**按指令执行的破坏性操作**:在用户项目里 `rm -rf harness`。它由第 2 步的归档以及「旧台账是独立仓库」这两点兜底,但它是本 skill 里唯一不可逆的命令,而且作用在一个 skill 并不拥有的目录上。
- 第 9 步手工重复了 `ha init` 自动做的事。若将来注册也长出隔离能力,这几行就会变成它的第二份实现。rough edge 条目点名了这一点,是为了让它**被删掉**而不是放任漂移。
- 两种放置共用一套流程,但这里只端到端跑通了本地那种。中心那种在本 PR 之前就已经能工作,本 PR 也没有改动它。

## 参考

- 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- Skill:`skills/harness-migration/SKILL.md`
- 前序:#1440(台账拥有自己的 git 仓库)、#1441(unregister 真的释放 repoId)
