### PR TITLE
docs(skill): move the superseded ledger aside instead of deleting it

### DIFF
--- a/skills/harness-migration/SKILL.md
+++ b/skills/harness-migration/SKILL.md
@@ -353,9 +353,17 @@ export LEDGER_HOME="/absolute/path/to/the/project"
 # export LEDGER_HOME="/absolute/path/the/user/chooses"
 
 cd "$LEDGER_HOME"
-rm -rf harness                                        # superseded; step 2 archived it
+mv harness "harness.pre-migration-$(date +%Y%m%d-%H%M%S)"    # superseded, not disposable
 cp -R "$TARGET_REPO/harness" ./harness
 ```
+
+**Move the old ledger aside; do not delete it.** The step 2 archive holds its
+content, but the directory is also a git repository with its own history, and
+this is the one moment in the migration where a mistake is discovered late. The
+same reasoning already governs the old runtime directory below: report it, hand
+over the path, and let the user delete it when they are satisfied. A rename is
+reversible in one command; `rm -rf` against a directory the skill does not own
+is not.
 
 In a project, isolate the ledger from the project's own repository before
 committing anything. `ha init` does this on a fresh project, but registering an
@@ -402,7 +410,8 @@ Then tell them:
 - their existing Harness installation was not modified;
 - the ledger is a git repository of its own, and the project must never track it;
 - the migration daemon lives under `$HARNESS_DAEMON_USER_ROOT` and can be removed with the work directory;
-- the previous ledger's git history is not carried forward — this migration rebuilds the ledger from its events, and the old history remains in the step 2 archive.
+- the previous ledger's git history is not carried forward — this migration rebuilds the ledger from its events, and the old history remains in the step 2 archive and in the `harness.pre-migration-*` directory beside the new one;
+- that directory is theirs to delete once they are satisfied, and nothing in the migration depends on it any more — give them the path.
 
 ### Report the old runtime directory — do not delete it
 
@@ -460,6 +469,8 @@ success and failure paths.
 - `source-before` equals `source-after`.
 - The ledger has its own `.git` at its landed location, the project tracks no
   ledger file, and `ha task create` succeeded there.
+- The superseded `harness.pre-migration-*` directory still exists, and the user
+  has been told where it is and that deleting it is theirs to decide.
 
 ## Known rough edges
 


### PR DESCRIPTION
# English

## Summary

The landing step opened with `rm -rf harness` against a directory the skill does not own, justified by the step 2 archive. That justification is thin in exactly the place it matters. The old `harness/` is a git repository with its own history — on a long-lived workspace, tens of thousands of commits — and landing is the last step, which is where a mistake is discovered late and where the migrated result has had the least use.

The skill already holds the opposite position one section further down, for the old `.harness/` runtime directory: *"Do not delete it, and do not offer to."* This applies that same standard to the ledger.

Production-Delta: +0/-0

## What Changed

`rm -rf harness` becomes `mv harness "harness.pre-migration-$(date …)"`. The rename is timestamped so a second migration attempt cannot collide with the first.

The hand-over list gains the path and states that deleting it is the user's call, and `Done when` gains a line so the directory cannot be quietly disposed of by an agent taking the shorter route.

## Task And Scope

- Harness task: `task_01M022AR425YG81NS1TRH8BDKR`
- Branch: `codex/skill-landing2`
- Out of scope: the step 2 archive, which is unchanged and still the authoritative backup.

## Version Impact

- Version: no version change
- Publish impact: skill documentation only.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task `task_01M022AR425YG81NS1TRH8BDKR`; the owner authorized migrating this repository's own production ledger tonight, which is what made the deletion's blast radius concrete
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable

## Verification

- Base `origin/rebuild/main` SHA: `3bba2f44`
- Branch merge-base with `origin/rebuild/main`: `3bba2f44`
- Public diff command: `git diff 3bba2f44..codex/skill-landing2`

- [x] `npm run check:local` — passed, 34.6s (includes the skill contract test)
- [x] `node tools/gates/line-budget.mjs --base 3bba2f44` — G32 pass
- [x] `node tools/gates/production-delta.mjs --base 3bba2f44` — computed `+0/-0`, matches the declaration
- [x] the surrounding step re-read: nothing downstream referenced the deleted directory, and `$LEDGER_HOME/harness` is recreated by the next line either way
- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: the landing procedure itself was executed end to end when it was written (#1442) and this changes only which of two commands disposes of the old directory. Tonight's cold-start run against this repository's own ledger is the real test of it.

## Review Evidence

- Reviewer subagent: not used
- Blocking findings: none

## Residual Risk

- A renamed directory is still a full copy. On a workspace whose ledger is large this doubles its footprint until the user removes it, and the skill does not measure or warn about that the way it does for `.harness/`. The trade is deliberate: disk is recoverable, a deleted ledger is not.

## References

- Task: `task_01M022AR425YG81NS1TRH8BDKR`
- Skill: `skills/harness-migration/SKILL.md`
- Predecessor: #1442 (the landing step this amends)

---

# 中文

## 概要

落地那一步开头是 `rm -rf harness` ——对一个 **skill 并不拥有的目录**执行删除,理由是第 2 步有归档。这个理由恰恰在最要紧的地方站不住:旧的 `harness/` 是一个带着自己历史的 git 仓库,在长期使用的工作区里是**几万个提交**;而落地是最后一步——**错误恰恰在这一步最晚被发现,而迁移结果在这一刻被使用得最少。**

skill 自己在下一节对旧的 `.harness/` 运行时目录持的正是相反立场:**「不要删除它,也不要提议删除它。」** 本 PR 把同一标准施加到台账上。

生产行数变更声明见英文段。

## 改动内容

`rm -rf harness` 改为 `mv harness "harness.pre-migration-$(date …)"`。重命名带时间戳,于是第二次迁移尝试不会和第一次撞名。

交接清单里加上这个路径,并写明删不删是用户的决定;`Done when` 也加了一条,于是**这个目录不会被一个想走近路的 agent 悄悄处理掉**。

## 任务与范围

- Harness 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- 分支:`codex/skill-landing2`
- 范围外:第 2 步的归档,未改动,仍是权威备份。

## 版本影响

- 版本:不改版本
- 发布影响:仅 skill 文档。

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:任务 `task_01M022AR425YG81NS1TRH8BDKR`;所有者授权今晚迁移**本仓自己的生产台账**,正是这件事让那条删除命令的爆炸半径变得具体
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用

## 验证

- `origin/rebuild/main` 基准 SHA:`3bba2f44`
- 当前分支与 `origin/rebuild/main` 的 merge-base:`3bba2f44`
- 公开 diff 命令:`git diff 3bba2f44..codex/skill-landing2`

- [x] `npm run check:local` — 通过,34.6 秒(含 skill 契约测试)
- [x] `node tools/gates/line-budget.mjs --base 3bba2f44` — G32 通过
- [x] `node tools/gates/production-delta.mjs --base 3bba2f44` — 实测 `+0/-0`,与声明一致
- [x] 重读该步上下文:下游没有任何东西引用那个被删的目录,而 `$LEDGER_HOME/harness` 无论如何都由下一行重建
- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- **未跑项及原因**:落地流程本身在写它的时候(#1442)已端到端跑过,本 PR 只改「用两条命令中的哪一条处置旧目录」。**今晚对本仓自己台账的冷启动实跑,才是它真正的测试。**

## 复核证据

- Reviewer subagent:未使用
- 阻塞发现:无

## 残留风险

- 重命名后的目录仍是一份完整副本。台账大的工作区里,这会让占用翻倍直到用户自己清理,而 skill 并没有像对 `.harness/` 那样去测量它、提醒它。这个取舍是**刻意**的:磁盘可以再要回来,删掉的台账要不回来。

## 参考

- 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- Skill:`skills/harness-migration/SKILL.md`
- 前序:#1442(本 PR 修订的正是它写的落地步骤)
