### PR TITLE
docs(skill): land the ledger onto the daemon that will serve it

### DIFF
--- a/skills/harness-migration/SKILL.md
+++ b/skills/harness-migration/SKILL.md
@@ -353,9 +353,28 @@ export LEDGER_HOME="/absolute/path/to/the/project"
 # export LEDGER_HOME="/absolute/path/the/user/chooses"
 
 cd "$LEDGER_HOME"
+# If the machine's own daemon already serves a ledger here, release it FIRST -- see below.
 mv harness "harness.pre-migration-$(date +%Y%m%d-%H%M%S)"    # superseded, not disposable
 cp -R "$TARGET_REPO/harness" ./harness
 ```
+
+**If the destination is already a live Harness workspace, release it before the
+`mv`, not after.** Everything up to here ran against the throwaway migration
+daemon; the ledger you are replacing belongs to the machine's own daemon, which
+is a different registry and is holding an open cell and a writer lock on the
+directory you are about to move. Release it first, with `HARNESS_DAEMON_USER_ROOT`
+**unset** so the commands reach that daemon rather than the migration one:
+
+```bash
+env -u HARNESS_DAEMON_USER_ROOT ha daemon repo unregister --repo-id <existing-repo-id>
+```
+
+The daemon keeps running and keeps serving its other repositories; only this
+ledger is released, which you can confirm by the writer lock next to it
+disappearing. Then do the `mv` and `cp` above.
+
+A destination with no Harness yet has nothing to release, and this step is
+skipped.
 
 **Move the old ledger aside; do not delete it.** The step 2 archive holds its
 content, but the directory is also a git repository with its own history, and
@@ -379,13 +398,21 @@ index already tracks, so a project that had committed any part of the old
 `harness/` keeps tracking it — and the ledger is private while the project may
 well be public.
 
-Then bind the repo id to its new location and commit the project side:
+Then attach the landed ledger to the daemon that will actually serve it, and
+commit the project side:
 
 ```bash
-$HA daemon repo unregister --repo-id <new-repo-id>
-$HA daemon repo register   --repo-id <new-repo-id> --root "$LEDGER_HOME"
+env -u HARNESS_DAEMON_USER_ROOT ha daemon repo register --repo-id <repo-id> --root "$LEDGER_HOME"
 git add -A && git commit -m "adopt migrated ledger"    # local placement only
 ```
+
+`HARNESS_DAEMON_USER_ROOT` is unset here for the same reason as above: the
+migration daemon is throwaway and its registry dies with the work directory.
+Registering the landed ledger there would leave the user with a ledger nothing
+serves — and the command would succeed, so nothing would say so.
+
+Reuse `<existing-repo-id>` if you released one; otherwise pick the id the user
+wants. A previously released id is free to reuse at the new path.
 
 `--root` takes `$LEDGER_HOME`, not `$LEDGER_HOME/harness`. Both are accepted and
 resolve to the same canonical root, but the runtime's `.harness/` directory and
@@ -399,11 +426,13 @@ test -d harness/.git                         && echo "ledger has its own git"
 git check-ignore -q harness                  && echo "project ignores the ledger"
 test -z "$(git ls-files harness/ .harness/)" && echo "project tracks no ledger file"
 git status --porcelain                       # expected: empty
-$HA task create --title "landing check" --kind chore   # expected: created task ...
+env -u HARNESS_DAEMON_USER_ROOT ha task create --title "landing check" --kind chore
 ```
 
-The last one is the only proof that the ledger is writable where it now sits;
-the other four only prove it is shaped correctly.
+The last one is the only proof that the ledger is writable where it now sits,
+and it has to run against the serving daemon to prove anything — through the
+migration daemon it would pass while telling you nothing about what the user
+will actually experience. The other four only prove the layout is right.
 
 Then tell them:
 


### PR DESCRIPTION
# English

## Summary

Step 9 rebound the repo id with `$HA`, which carries `HARNESS_DAEMON_USER_ROOT` — the throwaway migration daemon. That is the wrong daemon. The migration daemon's registry lives inside the work directory and dies with it; the ledger the user is about to rely on has to be attached to the daemon on their machine.

The command succeeds either way. That is what makes it bad: the migration ends with a green landing check, and the user is left with a ledger that nothing serves.

The same conflation hides a second problem. When the destination is already a live Harness workspace — which is the case for any repository being upgraded rather than adopted — the machine's daemon holds an open cell and a writer lock on the very directory step 9 moves. Step 9 released nothing before the `mv`.

Production-Delta: +0/-0

## What Changed

The landing commands that must reach the serving daemon now run under `env -u HARNESS_DAEMON_USER_ROOT`, and the section says why: through the migration daemon the check would pass while telling you nothing about what the user will experience.

A release step is added before the `mv`, for destinations that already have a Harness. It names the ordering explicitly, because the failure of getting it wrong is moving a directory out from under an open handle, which does not announce itself.

The register step notes that a released id is free to reuse at the new path — true since #1441, and the reason the rebind is one command rather than a new id and a lost identity.

## Task And Scope

- Harness task: `task_01M022AR425YG81NS1TRH8BDKR`
- Branch: `codex/live-swap`
- Out of scope: whether `daemon repo register` should perform the project isolation itself. Still a rough edge, still done by hand in step 9.

## Version Impact

- Version: no version change
- Publish impact: skill documentation only.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task `task_01M022AR425YG81NS1TRH8BDKR`; owner authorized migrating this repository's live production ledger, and intends to run the same skill against several other live workspaces afterwards — the live-destination case is the normal case for that, not an edge
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable

## Verification

- Base `origin/rebuild/main` SHA: `78fce570`
- Branch merge-base with `origin/rebuild/main`: `78fce570`
- Public diff command: `git diff 78fce570..codex/live-swap`

- [x] `npm run check:local` — passed, 27.2s (includes the skill contract test)
- [x] `node tools/gates/line-budget.mjs --base 78fce570` — G32 pass
- [x] `node tools/gates/production-delta.mjs --base 78fce570` — computed `+0/-0`, matches the declaration
- [x] `node tools/gates/test-selection.mjs --base 78fce570` — no errors

Two runs, both against a real running daemon rather than a description of one.

**Single daemon, ledger live and served.** `ha init` a project, write a task, confirm the daemon is up and holding `proj.harness-anything-writer.lock`. Then `unregister` → the lock disappears **while the daemon keeps running** → `mv` the ledger aside → `cp` the replacement in → `register` → `ha task create` succeeds. The ledger's own repository goes to 3 commits, its task list shows the replacement's content plus the new write, and the superseded directory still holds its original task.

**Two daemons, which is the shape of the real cutover.** A "machine" daemon on one user root serving the old ledger, an isolated migration daemon on another building the replacement. Releasing and re-registering against the machine root only, with the isolation variable unset: the write lands in the migrated content, and the pre-migration directory still holds `legacy work`. Twenty daemons were running on the host throughout; none was stopped.

- [ ] GitHub Actions `rewrite-ci` passed (this is the authoritative full gate)
- Not run, and why: steps 1–8 were not re-executed; this changes step 9 only. A cold-start agent is running the full skill against this repository's own ledger tonight, and stops before step 9 — this landing is executed separately, by hand, against the production ledger.

## Review Evidence

- Reviewer subagent: not used
- Blocking findings: none

## Residual Risk

- The release/swap/register sequence has a window in which the ledger is registered nowhere. It is seconds long and single-operator, but a write attempted inside it fails rather than queues — correctly, and confusingly.
- The two runs used synthetic ledgers of two or three commits. The production ledger is roughly thirty thousand, and the `cp -R` is the step whose cost scales with that. Nothing in the sequence is size-sensitive apart from the copy itself, but that has not been timed at scale.
- `env -u HARNESS_DAEMON_USER_ROOT` assumes the user's daemon is the default one for their account. A machine running more than one Harness root — this one does — needs the right root named explicitly, and the skill does not cover that.

## References

- Task: `task_01M022AR425YG81NS1TRH8BDKR`
- Skill: `skills/harness-migration/SKILL.md`
- Predecessors: #1442 (the landing step), #1445 (move aside instead of delete), #1441 (releasing an id frees it for rebinding)

---

# 中文

## 概要

第 9 步用 `$HA` 做 repo id 重绑,而 `$HA` 带着 `HARNESS_DAEMON_USER_ROOT` ——那是**用完即弃的迁移 daemon**。挂错了 daemon:迁移 daemon 的 registry 就住在工作目录里,随工作目录一起消失;而用户接下来要依赖的这个台账,必须挂在**他自己机器上那个 daemon** 上。

**两种挂法命令都会成功。这正是它糟糕的地方**:迁移以一片绿色的落地检查收尾,而用户拿到的是一个**没有任何 daemon 在服务的台账**。

同一处混淆还藏着第二个问题。当目标本身已经是一个活的 Harness 工作区——**任何「升级」而非「新接入」的仓库都是这种情况**——本机 daemon 正对着第 9 步要移动的那个目录持有打开的 cell 和 writer 锁。而第 9 步在 `mv` 之前什么都没释放。

生产行数变更声明见英文段。

## 改动内容

那些必须打到**服务方 daemon** 的落地命令,现在跑在 `env -u HARNESS_DAEMON_USER_ROOT` 下,并写明了为什么:走迁移 daemon 的话,这个检查会通过,**而它对「用户实际会遇到什么」一无所知**。

`mv` 之前加了一个释放步骤,针对已有 Harness 的目标。顺序被显式点명,因为搞错的后果是**把目录从一个打开的句柄底下抽走**——这种事不会自己吭声。

register 那一步注明:被释放过的 id 可以在新路径上直接复用——这是 #1441 之后才成立的事,也正是重绑只需要一条命令、而不用换个新 id 丢掉原有身份的原因。

## 任务与范围

- Harness 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- 分支:`codex/live-swap`
- 范围外:`daemon repo register` 该不该自己做项目隔离。仍是 rough edge,第 9 步仍然手工做。

## 版本影响

- 版本:不改版本
- 发布影响:仅 skill 文档。

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:任务 `task_01M022AR425YG81NS1TRH8BDKR`;所有者授权迁移本仓的**生产台账**,并打算随后用同一套 skill 迁本机另外几个活的工作区——**对他而言「目标是活的」是常态,不是边角情况**
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用

## 验证

- `origin/rebuild/main` 基准 SHA:`78fce570`
- 当前分支与 `origin/rebuild/main` 的 merge-base:`78fce570`
- 公开 diff 命令:`git diff 78fce570..codex/live-swap`

- [x] `npm run check:local` — 通过,27.2 秒(含 skill 契约测试)
- [x] `node tools/gates/line-budget.mjs --base 78fce570` — G32 通过
- [x] `node tools/gates/production-delta.mjs --base 78fce570` — 实测 `+0/-0`,与声明一致
- [x] `node tools/gates/test-selection.mjs --base 78fce570` — 无错误

**两次实跑,都对着真实在跑的 daemon,不是对着对它的描述。**

**其一:单 daemon,台账在线被服务。** `ha init` 一个项目、写一条 task,确认 daemon 起着并持有 `proj.harness-anything-writer.lock`。然后 `unregister` → **daemon 继续运行**而那把锁消失 → `mv` 旧台账 → `cp` 替换件进来 → `register` → `ha task create` 成功。台账自有仓到 3 个提交,task 列表显示替换件的内容加上这次新写入,而被取代的目录里仍原样躺着它自己的 task。

**其二:双 daemon,这才是真实 cutover 的形态。** 一个 user root 上的「本机」daemon 服务旧台账,另一个隔离的迁移 daemon 构建替换件。只对本机 root 做释放与重挂、隔离变量不带:写入落进迁移后的内容,`pre-migration` 目录里仍是 `legacy work`。全程宿主机上有 20 个 daemon 在跑,**一个都没被停掉**。

- [ ] GitHub Actions `rewrite-ci` 通过(这是权威全量门)
- **未跑项及原因**:第 1–8 步未重跑,本 PR 只改第 9 步。今晚有一个冷启动 agent 正在对本仓自己的台账跑完整 skill,并在第 9 步之前停下——落地由人另行执行,对着生产台账。

## 复核证据

- Reviewer subagent:未使用
- 阻塞发现:无

## 残留风险

- 释放 / 替换 / 重挂这个序列里有一个**台账不挂在任何地方**的窗口。它只有几秒、且是单操作者场景,但**在窗口内发起的写入是失败,不是排队**——正确,且令人困惑。
- 两次实跑用的是两三个提交的合成台账。生产台账约三万个提交,而 `cp -R` 正是那个开销随规模上涨的步骤。序列里除了这次复制之外没有对规模敏感的地方,**但那次复制没有在真实规模上计过时**。
- `env -u HARNESS_DAEMON_USER_ROOT` 假定用户的 daemon 就是他账户下的默认那个。**一台机器上跑着不止一个 Harness root 时——本机正是如此——需要显式点名正确的 root,而 skill 没有覆盖这一点。**

## 参考

- 任务:`task_01M022AR425YG81NS1TRH8BDKR`
- Skill:`skills/harness-migration/SKILL.md`
- 前序:#1442(落地步骤)、#1445(移走而非删除)、#1441(释放后的 id 可以重绑)
