### PR TITLE
docs(skills): correct the migration skill against a real cold-start run

### DIFF
--- a/skills/harness-migration/SKILL.md
+++ b/skills/harness-migration/SKILL.md
@@ -18,7 +18,7 @@ already on the machine — including a running daemon — is left untouched.
 keep it exported for the whole session:
 
 ```bash
-export HARNESS_MIGRATION_WORK="$(mktemp -d "${TMPDIR:-/tmp}/ha-migration.XXXXXX")"
+export HARNESS_MIGRATION_WORK="$(mktemp -d "${TMPDIR:-/tmp}"/ha-migration.XXXXXX)"
 export HARNESS_DAEMON_USER_ROOT="$HARNESS_MIGRATION_WORK/daemon-user-root"
 mkdir -p "$HARNESS_DAEMON_USER_ROOT"
 ```
@@ -41,18 +41,57 @@ Do **not** stop or uninstall the user's existing Harness to work around it:
 isolation is sufficient, and stopping their daemon interrupts work you are not
 responsible for restoring.
 
+The quoting around `mktemp` is deliberate. On macOS `$TMPDIR` already ends in a
+slash, so the more natural `"${TMPDIR:-/tmp}/ha-migration.XXXXXX"` yields a path
+with a doubled slash in it. Harmless, but it appears in every path the migration
+prints from here on, and it makes the receipts hard to read against the
+filesystem.
+
 ## 1. Fetch the current source
+
+**Node 24 or newer is required.** Check before cloning:
+
+```bash
+node --version
+```
+
+The CLI is run from its TypeScript entry point, which relies on Node's native
+type stripping. On an older Node every command fails with
+
+```
+TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"
+```
+
+which reads like a missing build step and is not one — no amount of `npm run
+build` fixes it. Stop and tell the user to upgrade Node; nothing below works
+until they do.
 
 ```bash
 cd "$HARNESS_MIGRATION_WORK"
 git clone --depth 1 --branch rebuild/main https://github.com/FairladyZ625/harness-anything.git ha-src
 cd ha-src
 npm install --no-audit --no-fund
-export HA="node $HARNESS_MIGRATION_WORK/ha-src/packages/cli/src/index.ts"
-$HA --version
+export HA_ENTRY="$HARNESS_MIGRATION_WORK/ha-src/packages/cli/src/index.ts"
+ha() { node "$HA_ENTRY" "$@"; }
+ha --version
 ```
 
 Expect a version line. The repository is about 10 MB and install takes seconds.
+
+**`ha` here is a shell function, not an exported variable.** The obvious
+`export HA="node …/index.ts"` followed by `$HA --version` works in bash and
+silently fails in zsh, which does not word-split unquoted parameters: zsh passes
+`node …/index.ts` as a **single** argument and the receipt comes back
+`unsupported_command`. A function behaves identically in both shells.
+
+Two consequences worth knowing now rather than at step 8:
+
+- The function lives in this shell only. Anything that runs in a **detached**
+  process — see step 8 — must spell out `node "$HA_ENTRY" …` instead.
+- `env -u HARNESS_DAEMON_USER_ROOT ha …`, which step 9 uses on purpose, does
+  **not** see the function. `env` execs a program, so it resolves `ha` from
+  `PATH` — the machine's own installation. That is exactly what step 9 wants,
+  and step 9 says so again where it matters.
 
 **Do not look for `node_modules/.bin/ha`.** The published `bin` points at
 `dist/`, which a source checkout does not contain, so the linked binary is
@@ -72,7 +111,7 @@ export WORK_SOURCE="$HARNESS_MIGRATION_WORK/legacy-copy"
 mkdir -p "$HARNESS_MIGRATION_WORK/backups" "$WORK_SOURCE"
 export LEDGER_ARCHIVE="$HARNESS_MIGRATION_WORK/backups/legacy-harness.tar"
 COPYFILE_DISABLE=1 tar -cf "$LEDGER_ARCHIVE" -C "$ARCHIVE_SOURCE" harness
-export SOURCE_SHA_BEFORE="$(COPYFILE_DISABLE=1 tar -cf - -C "$ARCHIVE_SOURCE" harness | shasum -a 256 | awk '{print $1}')"
+export SOURCE_SHA_BEFORE="$(COPYFILE_DISABLE=1 tar -cf - --exclude='harness/.git' -C "$ARCHIVE_SOURCE" harness | shasum -a 256 | awk '{print $1}')"
 printf 'source-before %s\n' "$SOURCE_SHA_BEFORE"
 tar -xf "$LEDGER_ARCHIVE" -C "$WORK_SOURCE"
 ```
@@ -96,6 +135,15 @@ Three things this deliberately does **not** do, each for a reason worth knowing:
 - **No `cp -a` of the root.** It copies `node_modules` and the whole `.git`
   directory, which the importer never reads.
 
+The digest excludes `harness/.git` for the same reason the root digest is
+excluded entirely: it is live metadata, not content. A `git fetch` from any
+mirror or a background maintenance run rewrites `packed-refs`, `FETCH_HEAD` and
+the reflog without touching a single ledger file, and the closing comparison
+then fails for a reason unrelated to the importer. This bit a real migration —
+an unrelated mirror fetch landed mid-run and the source looked modified when it
+was not. **The archive is not filtered**: a backup must carry the ledger's own
+git history, and only the digest needs the exclusion.
+
 On a large ledger the digest takes tens of seconds and prints nothing while it
 runs — that is normal, do not kill it. If it runs for many minutes you are
 digesting more than `harness/`; check the `-C` argument. Nothing may write to
@@ -105,6 +153,14 @@ differ for a reason that has nothing to do with the importer.
 Show the user `$LEDGER_ARCHIVE` and **stop until they confirm one independent
 copy exists off this machine.** Migration is one-shot; this is the only point
 where that confirmation is cheap.
+
+If you are a dispatched agent with no way to reach the user, you cannot satisfy
+that stop — say so rather than pretending you did. Record the archive path and
+its size, state plainly in your report that the off-machine copy was never
+confirmed, and continue. The rest of the migration writes only to
+`$HARNESS_MIGRATION_WORK`, so nothing before step 9 can lose the source; step 9
+is where the missing confirmation actually matters, and step 9 is not yours to
+execute anyway.
 
 Every repair below targets `$WORK_SOURCE`. `$ARCHIVE_SOURCE` is read-only and
 its `harness/` digest is re-checked at the end.
@@ -117,7 +173,7 @@ Ask the user for the new repository id, owner person id, and display name.
 export TARGET_REPO="$HARNESS_MIGRATION_WORK/new-repository"
 mkdir -p "$TARGET_REPO" && cd "$TARGET_REPO"
 git init -q . && git commit -q --allow-empty -m "base"
-$HA init --repo-id <new-repo-id> --person-id <owner-person-id> --display-name '<display-name>'
+ha init --repo-id <new-repo-id> --person-id <owner-person-id> --display-name '<display-name>'
 ```
 
 Expect a receipt listing created paths and a commit sha. The first command in a
@@ -131,7 +187,7 @@ repair a half-initialized target in place.
 
 ```bash
 export DRY_RUN="$HARNESS_MIGRATION_WORK/dry-run.txt"
-$HA migrate import --source "$WORK_SOURCE" --dry-run > "$DRY_RUN" 2>&1; echo "exit=$?"
+ha migrate import --source "$WORK_SOURCE" --dry-run > "$DRY_RUN" 2>&1; echo "exit=$?"
 cat "$DRY_RUN"
 ```
 
@@ -221,7 +277,7 @@ export RESOLVE_ARGS=(
   --resolve 'harness/context/README.md=destination'
   --resolve 'harness/people.yaml=source'
 )
-$HA migrate import --source "$WORK_SOURCE" "${RESOLVE_ARGS[@]}" --dry-run > "$DRY_RUN" 2>&1; echo "exit=$?"
+ha migrate import --source "$WORK_SOURCE" "${RESOLVE_ARGS[@]}" --dry-run > "$DRY_RUN" 2>&1; echo "exit=$?"
 ```
 
 Each answer comes back as a row beginning `resolved: destination` or
@@ -238,7 +294,7 @@ current format.
 
 ```bash
 find "$WORK_SOURCE/harness/presets" -mindepth 1 -maxdepth 1 -type d | sort
-$HA preset inspect standard-task --profile baseline --vertical software/coding --locale en-US --json
+ha preset inspect standard-task --profile baseline --vertical software/coding --locale en-US --json
 ```
 
 The `legacy-migration` preset bundled with the current release documents the
@@ -254,15 +310,24 @@ then validate and install from the destination:
 ```bash
 cd "$TARGET_REPO"
 for NEW_PRESET in "$HARNESS_MIGRATION_WORK/rebuilt-presets"/*; do
-  $HA preset validate --source "$NEW_PRESET" --json
-  $HA preset install --source "$NEW_PRESET" --json
+  ha preset validate --source "$NEW_PRESET" --json
+  ha preset install --source "$NEW_PRESET" --json
 done
-$HA preset audit --vertical software/coding --json
+ha preset audit --vertical software/coding --json
 ```
 
 Continue only when every validation reports `"valid": true` and the audit shows
-no blocked package. Then take the old packages out of the copy being imported —
-the archived original still has them:
+no blocked package.
+
+`preset audit --json` answers about the vertical as a whole — a count of
+packages and a count of issues — not one row per package. So it tells you
+*whether* something is blocked, not *which* package it is. The per-package
+verdict is the `validate` output in the loop above; if the audit reports issues,
+read back the validations rather than looking for a package list in the audit
+receipt that is not there.
+
+Then take the old packages out of the copy being imported — the archived
+original still has them:
 
 ```bash
 mv "$WORK_SOURCE/harness/presets" "$HARNESS_MIGRATION_WORK/legacy-presets-rebuilt"
@@ -298,22 +363,71 @@ cd "$HARNESS_MIGRATION_WORK"
 mv "$TARGET_REPO" "$HARNESS_MIGRATION_WORK/preview-repository"
 mkdir -p "$TARGET_REPO" && cd "$TARGET_REPO"
 git init -q . && git commit -q --allow-empty -m "base"
-$HA init --repo-id <new-repo-id> --person-id <owner-person-id> --display-name '<display-name>'
-for NEW_PRESET in "$HARNESS_MIGRATION_WORK/rebuilt-presets"/*; do $HA preset install --source "$NEW_PRESET" --json; done
-$HA migrate import --source "$WORK_SOURCE" "${RESOLVE_ARGS[@]}" --dry-run; echo "exit=$?"
+ha init --repo-id <new-repo-id> --person-id <owner-person-id> --display-name '<display-name>'
+for NEW_PRESET in "$HARNESS_MIGRATION_WORK/rebuilt-presets"/*; do ha preset install --source "$NEW_PRESET" --json; done
+ha migrate import --source "$WORK_SOURCE" "${RESOLVE_ARGS[@]}" --dry-run; echo "exit=$?"
 ```
 
 Apply only when that exits zero, all five rows show `Old = Expected = New` with
 `Skipped = 0`, authored coverage has no `required`, and reconciliation passes.
 
+**Run apply detached, and poll it.** On a large ledger it takes over an hour —
+a 21,000-event ledger took 1h22m — and it prints **nothing at all** until it
+finishes. There is no progress output to read, so a foreground run is
+indistinguishable from a hang, and any caller with a command timeout will kill
+it partway. That has already happened once: an agent harness terminated a real
+apply at around the 60-minute mark, and a half-imported target is not
+recoverable — step 8 has to start over from `ha init`.
+
 ```bash
-$HA migrate import --source "$WORK_SOURCE" "${RESOLVE_ARGS[@]}"; echo "apply-exit=$?"
-export SOURCE_SHA_AFTER="$(COPYFILE_DISABLE=1 tar -cf - -C "$ARCHIVE_SOURCE" harness | shasum -a 256 | awk '{print $1}')"
+cd "$TARGET_REPO"
+nohup node "$HA_ENTRY" migrate import --source "$WORK_SOURCE" "${RESOLVE_ARGS[@]}" \
+  > "$HARNESS_MIGRATION_WORK/apply.log" 2>&1 &
+echo "apply pid=$!"
+```
+
+Note `node "$HA_ENTRY"` rather than `ha`: the shell function from step 1 does
+not exist inside `nohup`.
+
+Poll until the process is gone, then read the exit line out of the log:
+
+```bash
+ps -p <pid> >/dev/null && echo "still running" || tail -20 "$HARNESS_MIGRATION_WORK/apply.log"
+```
+
+While it runs, `du -sh "$TARGET_REPO/harness"` and the commit count in
+`$TARGET_REPO/harness` both climb — that is the only live progress signal there
+is. A stalled apply shows neither growing for many minutes.
+
+Once it has finished, confirm the source was never written to:
+
+```bash
+export SOURCE_SHA_AFTER="$(COPYFILE_DISABLE=1 tar -cf - --exclude='harness/.git' -C "$ARCHIVE_SOURCE" harness | shasum -a 256 | awk '{print $1}')"
 test "$SOURCE_SHA_BEFORE" = "$SOURCE_SHA_AFTER" && echo "source ledger untouched"
 ```
 
+The `--exclude` must match step 2's exactly. Digesting different sets on the two
+sides guarantees a mismatch and tells you nothing.
+
 If apply exits nonzero, keep its output, move the target aside, and restart from
 a fresh `ha init`. **Never re-run apply against a partially imported target.**
+
+**Then pack the new ledger's git repository.** The importer commits once per
+event and never packs, so a freshly imported ledger is all loose objects — the
+21,000-event migration produced **218,213 loose objects, zero packs, and an 18 GB
+`.git`** for about 850 MB of actual content.
+
+```bash
+git -C "$TARGET_REPO/harness" gc --aggressive --prune=now
+du -sh "$TARGET_REPO/harness/.git" "$TARGET_REPO/harness"
+git -C "$TARGET_REPO/harness" rev-list --count HEAD
+git -C "$TARGET_REPO/harness" fsck --no-progress
+```
+
+That run took the same ledger from 18 GB to a 181 MB `.git` in a single pack,
+with the commit count unchanged and `fsck` clean. Do this before step 9 — it is
+the difference between handing the user a 19 GB directory and a 862 MB one, and
+after landing the daemon holds the repository.
 
 Now execute the merge column recorded in step 5. `$HARNESS_MIGRATION_WORK/preview-repository`
 still holds the previous destination, and `$WORK_SOURCE` still holds the old
@@ -344,7 +458,55 @@ generations used. Choose it unless the user says otherwise.
 and is registered by absolute path. Choose it when the user tells you the
 ledger is shared — several machines mirroring one authoritative copy.
 
-The procedure below is the same for both. Only `LEDGER_HOME` differs.
+### First: the machine needs a current-generation CLI that outlives this work directory
+
+**Read this before touching the destination.** Everything up to here ran from
+`$HARNESS_MIGRATION_WORK`, which is disposable. The landed ledger is not: it
+needs a daemon serving it from here on, and **that daemon must be the current
+generation** — the whole reason for this migration is that the machine's
+installed `ha` belongs to the previous one, and a previous-generation daemon
+cannot serve a current-format ledger.
+
+Check what the machine actually has:
+
+```bash
+env -u HARNESS_DAEMON_USER_ROOT command ha --version
+```
+
+A current-generation CLI prints a version. A previous-generation one rejects the
+flag outright:
+
+```
+{"ok":false,"command":"parse","error":{"code":"unknown_option",
+ "hint":"Unknown option '--version' for 'ha'. …"}}
+```
+
+If it rejects, **the installed CLI cannot serve what you are about to land**, and
+there is no package to upgrade to: `@harness-anything/cli` is not on npm
+(`npm view` returns 404), and a source checkout has no `dist/`, so the `bin`
+entry points at a file that does not exist. The working answer today is to keep
+a source checkout permanently and call it by path:
+
+```bash
+export HA_HOME="$HOME/.harness-cli-src"          # anywhere durable; not $HARNESS_MIGRATION_WORK
+cp -R "$HARNESS_MIGRATION_WORK/ha-src" "$HA_HOME"
+export HA_ENTRY="$HA_HOME/packages/cli/src/index.ts"
+node "$HA_ENTRY" --version
+```
+
+Then hand the user that invocation, and say plainly that it replaces their
+existing `ha` for this ledger. **This is a real rough edge, not a preference** —
+until the CLI ships as an installable artifact, a migrated ledger is served by a
+checkout the user has to keep. Tell them so rather than leaving them to discover
+it the first time `ha task list` fails.
+
+Note also that `env -u HARNESS_DAEMON_USER_ROOT ha …` below resolves `ha` from
+`PATH`, which skips any shell function or alias the user has defined around it.
+If theirs injects flags — `--actor`, a default `--root` — those are silently
+dropped. Check `type ha` before relying on it, and use `command ha` explicitly
+when you mean the binary.
+
+The procedure below is the same for both placements. Only `LEDGER_HOME` differs.
 
 ```bash
 # local (default) — the project directory the user is migrating
@@ -399,17 +561,30 @@ index already tracks, so a project that had committed any part of the old
 well be public.
 
 Then attach the landed ledger to the daemon that will actually serve it, and
-commit the project side:
+commit the project side. **Start that daemon first** — `register` does not
+autostart one, and against a stopped daemon it fails with:
+
+```
+error code=daemon_unavailable hint=connect ENOENT /var/folders/…/daemon-501-u-….sock
+```
 
 ```bash
-env -u HARNESS_DAEMON_USER_ROOT ha daemon repo register --repo-id <repo-id> --root "$LEDGER_HOME"
+export HARNESS_DAEMON_USER_ROOT="$HOME/.harness"    # the serving root, not the migration one
+node "$HA_ENTRY" daemon start --service
+node "$HA_ENTRY" daemon repo register --repo-id <repo-id> --root "$LEDGER_HOME"
 git add -A && git commit -m "adopt migrated ledger"    # local placement only
 ```
 
-`HARNESS_DAEMON_USER_ROOT` is unset here for the same reason as above: the
-migration daemon is throwaway and its registry dies with the work directory.
-Registering the landed ledger there would leave the user with a ledger nothing
-serves — and the command would succeed, so nothing would say so.
+If the machine's installed CLI *is* current-generation, `env -u
+HARNESS_DAEMON_USER_ROOT ha daemon repo register …` does the same thing and is
+shorter. Use whichever matches what you found at the top of this step; do not
+register through the throwaway migration root either way — its registry dies
+with the work directory, and the command would succeed while leaving the user
+with a ledger nothing serves.
+
+**The first attach is slow.** The daemon builds its projection over every event
+in the ledger — for a 21,000-event ledger that took several minutes with no
+output. Do not conclude it is stuck, and do not run it under a short timeout.
 
 Reuse `<existing-repo-id>` if you released one; otherwise pick the id the user
 wants. A previously released id is free to reuse at the new path.
@@ -419,26 +594,63 @@ resolve to the same canonical root, but the runtime's `.harness/` directory and
 its writer lock are placed relative to the root you pass, and only the former
 puts them where the ignore rules above expect them.
 
-Check the landing before handing over. All five must hold:
+Check the landing before handing over. All six must hold:
 
 ```bash
-test -d harness/.git                         && echo "ledger has its own git"
-git check-ignore -q harness                  && echo "project ignores the ledger"
-test -z "$(git ls-files harness/ .harness/)" && echo "project tracks no ledger file"
-git status --porcelain                       # expected: empty
-env -u HARNESS_DAEMON_USER_ROOT ha task create --title "landing check" --kind chore
+test -d harness/.git                                   && echo "ledger has its own git"
+git check-ignore -q harness                            && echo "project ignores the ledger"
+test -z "$(git ls-files harness/ .harness/)"           && echo "project tracks no ledger file"
+git --no-optional-locks status --porcelain             # project tree — expected: empty
+git --no-optional-locks -C harness status --porcelain  # LEDGER tree — expected: empty
+node "$HA_ENTRY" task create --title "landing check" --kind chore
 ```
 
 The last one is the only proof that the ledger is writable where it now sits,
-and it has to run against the serving daemon to prove anything — through the
+and it has to run against the **serving** daemon to prove anything — through the
 migration daemon it would pass while telling you nothing about what the user
-will actually experience. The other four only prove the layout is right.
+will actually experience. The others only prove the layout is right.
+
+**The ledger tree check is not a formality.** The importer commits event data,
+but the project-specific authored content merged at the end of step 8 is written
+to the working tree and is **not** part of any commit. On a real migration this
+left `governance/walls/walls.json` uncommitted — with the committed version
+holding an empty `walls: []` array and seventeen governance walls existing only
+in the unstaged file. One `git checkout` would have erased them silently.
+
+If that tree is dirty, do not reach for `git commit` — read the next paragraph
+first, then carry the content forward by whatever CLI path owns those files.
+
+**Never run `git commit` inside the ledger directory.** The ledger's HEAD must
+be exactly the last event commit; the daemon derives that expectation from
+`harness/events/head.json`, whose `opId` is the last event commit's message. Any
+extra commit on top breaks the compare-and-swap and every write starts failing:
+
+```
+error code=publication_indeterminate hint=authored or canonical ref advanced outside
+the daemon; reconcile before publishing: cannot lock ref 'refs/heads/master':
+is at <your commit> but expected <last event commit>
+```
+
+Two things about that message are worth knowing in advance, because they cost a
+real operator most of an hour:
+
+- **Restarting the daemon does not fix it.** It re-reads the ref but not the
+  expectation. The only recovery is `git reset` back to the expected commit —
+  the sha the message calls `expected` — and that sha appears nowhere on disk to
+  search for.
+- **`reconcile` names no command.** There is no `ha reconcile`; the word
+  describes an outcome, not a path. The recovery is the `git reset` above.
+
+Editing files in the ledger tree without committing is safe: the daemon commits
+by explicit pathspec and leaves unrelated working-tree changes alone.
 
 Then tell them:
 
 - their existing Harness installation was not modified;
+- **which CLI now serves this ledger, spelled out as a command they can run** — if the machine's `ha` was previous-generation, that is the durable checkout from the top of this step, and their old `ha` will not work against this ledger;
+- **never `git commit` inside the ledger directory**, and what to do if they already have (the `git reset` above);
 - the ledger is a git repository of its own, and the project must never track it;
-- the migration daemon lives under `$HARNESS_DAEMON_USER_ROOT` and can be removed with the work directory;
+- the migration daemon lives under the migration `HARNESS_DAEMON_USER_ROOT` and can be removed with the work directory;
 - the previous ledger's git history is not carried forward — this migration rebuilds the ledger from its events, and the old history remains in the step 2 archive and in the `harness.pre-migration-*` directory beside the new one;
 - that directory is theirs to delete once they are satisfied, and nothing in the migration depends on it any more — give them the path.
 
@@ -449,8 +661,12 @@ It is git-ignored runtime state, the importer never read it, and none of it was
 migrated. On a long-lived repository it can be very large: previous generations
 wrote a **full copy of the ledger** into a `staging/` directory on every script
 or preset run and never removed them, so `.harness/` can reach hundreds of
-gigabytes while the ledger itself is a fraction of that. Measure it and tell
-the user the number:
+gigabytes while the ledger itself is a fraction of that.
+
+**Measure before quoting any of that.** The staging directories are the usual
+culprit but not a given — on a repository where someone has already reclaimed
+them, the cleanup below frees nothing and `cache/` and `write-journal/` are what
+is left. Report the actual numbers:
 
 ```bash
 du -sh "$ARCHIVE_SOURCE/.harness" "$ARCHIVE_SOURCE/harness"
@@ -497,7 +713,10 @@ success and failure paths.
 - Every legacy preset has a validated v3 replacement installed.
 - `source-before` equals `source-after`.
 - The ledger has its own `.git` at its landed location, the project tracks no
-  ledger file, and `ha task create` succeeded there.
+  ledger file, and `task create` succeeded there **through the serving daemon**.
+- The ledger's own working tree is clean — no authored content left uncommitted.
+- The ledger's git repository has been packed (`git gc`) and `fsck` is clean.
+- The user has been handed the exact command that now drives this ledger.
 - The superseded `harness.pre-migration-*` directory still exists, and the user
   has been told where it is and that deleting it is theirs to decide.
 
@@ -516,3 +735,25 @@ success and failure paths.
   placement that is `<parent-of-project>/<project-name>.harness-anything-writer.lock`.
   It is outside the project, so it does not dirty the working tree, but it is
   visible next to the project directory while the daemon holds the ledger.
+- **There is no installable current-generation CLI.** `@harness-anything/cli` is
+  not published (`npm view` → 404) and a source checkout has no `dist/`, so the
+  package's own `bin` entry points at a missing file. A migrated ledger is
+  therefore served by a source checkout the user has to keep around and invoke
+  by path. Step 9 says how; there is no better answer available today.
+- **`migrate import` prints nothing until it finishes** — no progress, no
+  heartbeat, over an hour on a large ledger. Run it detached (step 8). A
+  half-imported target cannot be repaired, only discarded.
+- **The importer never packs.** It commits once per event, so the delivered
+  ledger is entirely loose objects: 218,213 of them and an 18 GB `.git` in one
+  real migration. `git gc` is a required step, not an optimization.
+- **`git commit` inside the ledger wedges every write** with
+  `publication_indeterminate`, restarting the daemon does not clear it, and the
+  hint's word "reconcile" corresponds to no command. Recovery is `git reset` to
+  the sha the message calls `expected`. See step 9.
+- **`decision list` returns at most 100 rows** and does not say so — no
+  pagination flag exists. A migrated ledger with more decisions than that is
+  complete on disk while the CLI shows a truncated view.
+- **Most read commands print only `<command>: applied`.** The rows are in the
+  `--json` receipt's `evidence` field, as a JSON **string** needing a second
+  parse. `doc sync --dry-run` is affected too, which makes the dry-run's whole
+  purpose invisible unless you read the JSON.


### PR DESCRIPTION
# English

## Summary

A dispatched agent ran `skills/harness-migration` end to end, cold, against a 21,000-event production ledger, with no context beyond the skill itself. That was deliberate — the owner is about to migrate several more repositories on this machine using the same document, so "can a stranger complete it from the text alone" is a deliverable, not a nicety.

It completed. Every change in this PR is something it hit on the way, or something the landing that followed hit.

Production-Delta: +0/-0

## What Changed

Six were blocking, ordered by cost:

**`migrate import` prints nothing for over an hour.** No progress, no heartbeat; 1h22m on this ledger. A foreground run is indistinguishable from a hang, and an agent harness terminated the first attempt at roughly the 60-minute mark. A half-imported target is not repairable — step 8 restarts from `ha init`. Apply now runs detached, with the two signals that actually indicate progress (`du` and the commit count).

**The importer never packs.** It commits once per event, so the delivered ledger was **218,213 loose objects, zero packs, an 18 GB `.git`** for ~850 MB of content. `git gc --aggressive` took it to a 181 MB `.git` in one pack, commit count unchanged, `fsck` clean. Now a required step before landing, since afterwards the daemon holds the repository.

**There is no current-generation CLI to install.** This is structural, not incidental: the skill exists because the machine's `ha` is previous-generation, and a previous-generation daemon cannot serve a current-format ledger. But `@harness-anything/cli` is unpublished (`npm view` → 404) and a source checkout has no `dist/`, so the package's own `bin` points at a missing file. Step 9 previously assumed `env -u HARNESS_DAEMON_USER_ROOT ha …` would work; against the very installation this skill is written for, it does not. Step 9 now probes for it and keeps a durable source checkout, and says out loud that this is a rough edge rather than a preference.

**`daemon repo register` does not autostart a daemon.** It fails `daemon_unavailable` with a socket ENOENT — at the final step of the landing, after the old ledger has already been moved aside.

**`export HA="node …/index.ts"` is bash-only.** zsh does not word-split unquoted parameters, so `$HA --version` passes `node …/index.ts` as a single argument and returns `unsupported_command`. Now a shell function, with the two places that must *not* use it spelled out: `nohup` (no function) and `env -u … ha` (resolves from `PATH` — which step 9 wants, and which also silently drops any flags a user's own `ha` wrapper injects, `--actor` included).

**Node ≥ 24 is an unstated hard prerequisite.** Below it every command dies with `ERR_UNKNOWN_FILE_EXTENSION ".ts"`, which reads as a missing build step and sends the reader toward `npm run build`, which cannot help. Checked before the clone.

Three were about the checks being wrong rather than missing:

- **The source digest covered `harness/.git`** — live metadata. An unrelated mirror fetch landed mid-run and rewrote `packed-refs`/`FETCH_HEAD`, so `source-before` ≠ `source-after` for a reason the importer had nothing to do with. Excluded from the digest on both sides; the archive still carries `.git`, because a backup must.
- **The landing verified the project's working tree, never the ledger's.** The project-specific authored content merged at the end of step 8 is written to the working tree and joins no commit. On this migration that left `governance/walls/walls.json` uncommitted, with the committed copy holding `"walls": []` — seventeen governance walls existing only in an unstaged file. One `git checkout` erases them silently. Now a checked condition with the reason attached.
- **`git commit` inside the ledger wedges every write.** The ledger's HEAD must be exactly the last event commit; the daemon derives that from `harness/events/head.json`, whose `opId` is that commit's message. Any commit on top breaks the CAS and every write returns `publication_indeterminate`. Two things about recovering cost most of an hour: restarting the daemon does **not** clear it (it re-reads the ref, not the expectation), and the hint's word "reconcile" corresponds to no command — `ha capabilities` has no such verb. Documented with the actual recovery, which is `git reset` to the sha the message calls `expected`.

And four smaller ones: `preset audit --json` returns per-vertical aggregates, not a package list, so a blocked package is found by re-reading the `validate` output; the `.harness` reclaim paths free nothing on a repository whose staging directories were already cleared, so the text now says measure before quoting; `mktemp` doubled a slash because macOS `$TMPDIR` ends in one; and step 2's "stop until the user confirms an off-machine copy" is unreachable for a dispatched agent, which should be reported rather than silently skipped.

Two entries in **Known rough edges** describe live CLI defects (`decision list` truncating at 100 without saying so; read commands printing only `<command>: applied` with the rows locked inside `evidence` as a JSON string). Both are under repair on a separate branch. They are recorded here because they are true today and a migrating user meets them immediately; they should be removed when that work lands, not carried.

## Task And Scope

- Harness task: `task_ca5665cdb936cab82df20d4560`
- Branch: `codex/skill-coldstart`
- Out of scope: the CLI defects themselves (separate branch); publishing an installable CLI artifact, which is the real fix for the third item above and is a product decision, not a documentation one.

## Version Impact

- Version: no version change
- Publish impact: documentation only. No runtime behaviour changes.

## Governance Declaration

- Protected surface touched: no
- Authority: task `task_ca5665cdb936cab82df20d4560`; owner instruction that the migration be completable cold, because they intend to run it themselves on further repositories
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable

## Verification

- Base `origin/rebuild/main` SHA: `835cd6c5`
- Branch merge-base with `origin/rebuild/main`: `835cd6c5`
- Public diff command: `git diff 835cd6c5..codex/skill-coldstart`

- [x] `npm run check:local` — passed, 32.8s
- [x] `node tools/gates/line-budget.mjs --base 835cd6c5` — G32 pass
- [x] `node --test tools/skill-contracts.test.mjs` — 4/4
- [x] the cold-start run itself: apply exit 0, all five entity classes `Old = Expected = New`, `Skipped = 0`, `Reconciliation: PASS`, nine conflicts resolved explicitly, `source-before` == `source-after`
- [x] the landing: ledger has its own `.git` (21,409 commits), project ignores it, `git ls-files harness/ .harness/` empty, and a real `task create` succeeded against the serving daemon
- [x] `npm view @harness-anything/cli version` → E404, which is the basis for the unpublished-CLI claim
- [x] `env -u HARNESS_DAEMON_USER_ROOT command ha --version` → `unknown_option` with a `CommandReceipt/v1` compatibility envelope, which is the basis for the previous-generation claim
- [x] `publication_indeterminate` reproduced deliberately and recovered via `git reset`, twice, confirming a daemon restart alone does not clear it
- [ ] GitHub Actions `rewrite-ci` passed (authoritative full gate)
- Not run, and why: nothing further. A second cold-start run against a fresh 21,000-event ledger is the only test that would exercise the corrected text end to end, and it costs another 1h22m of apply; the corrections are each anchored to a transcript from the run that produced them.

## Review Evidence

- Reviewer subagent: not used. The findings are the migration agent's own report plus the dispatcher's landing session; each is anchored to a command and its output rather than to a reading of the code.
- The migration agent raised four dissents against the mission it was given. All four were substantive and all were accepted; two of them (the `.git` digest and the stale `.harness` reclaim figures) are corrected here.
- Blocking findings: none

## Residual Risk

- **The corrected text has not itself been cold-started.** Every change is anchored to an observed failure, but the document as a whole has not been re-run by a fresh agent. The next migration is that test, and it should be treated as one.
- **The durable-checkout answer in step 9 is a workaround, not a design.** It leaves the user with a source tree they must keep and invoke by path. The real fix is an installable artifact; until then this skill hands out a rough edge with instructions.
- **The two CLI defects recorded under Known rough edges will go stale.** They are accurate now and being fixed on another branch. If that branch lands and these entries are not removed, the skill starts describing problems that no longer exist — the same rot this PR is correcting elsewhere.
- **`git gc --aggressive` on a large ledger is slow and was measured once.** The 18 GB → 181 MB figure is from a single run on one ledger; the ratio will differ, the requirement will not.

## References

- Task: `task_ca5665cdb936cab82df20d4560`
- Mission given to the cold-start agent: `harness/tasks/task_01M022AR425YG81NS1TRH8BDKR-…/artifacts/mission-opus-coldstart-migration.md` (private ledger)

---

# 中文

## 概要

一个被派遣的 agent **冷启动**跑完了 `skills/harness-migration` 全程,对象是一个两万一千条事件的**生产台账**,除了 skill 本身没有任何上下文。

这是**刻意的**:所有者接下来要用同一份文档,自己迁移本机另外几个仓库。所以「一个陌生人能不能只凭这份文本走通」本身就是交付物,不是附赠品。

它走通了。**本 PR 里的每一条改动,都是那次运行、或紧随其后的落地,真实撞上的东西。**

生产行数变更声明见英文段。

## 改动内容

六条是阻塞级的,按代价排序:

**`migrate import` 一个多小时不打印任何东西。** 没有进度、没有心跳;这个台账跑了 1 小时 22 分。前台运行和挂死**长得一模一样**,于是第一次尝试在大约 60 分钟处被 agent harness 杀掉了。而导入到一半的目标**修不了**——第 8 步只能从 `ha init` 重来。现在 apply 改为 detached 运行,并写明了两个真正能表示进度的信号(`du` 与提交数)。

**导入器从不打包。** 它逐事件 commit,所以交付出来的台账是 **218,213 个松散对象、零个 pack、18 GB 的 `.git`**,而实际内容约 850 MB。`git gc --aggressive` 把它压到单个 pack、`.git` 181 MB,提交数不变,`fsck` 干净。现在这是落地前的**必需步骤**——落地之后台账就被 daemon 持有了。

**没有可安装的当前世代 CLI。** 这是结构性的,不是偶然:**这个 skill 存在的前提就是机器上的 `ha` 是上一代**,而上一代 daemon 服务不了当前格式的台账。但 `@harness-anything/cli` 未发布(`npm view` → 404),源码 checkout 没有 `dist/`,所以包自己的 `bin` 指向一个不存在的文件。第 9 步原本假设 `env -u HARNESS_DAEMON_USER_ROOT ha …` 能用——**面对这个 skill 本来就是为之而写的那种安装,它不能用。** 现在第 9 步会先探测,并保留一份持久的源码 checkout,而且**明说这是粗糙边缘而不是偏好**。

**`daemon repo register` 不会自启 daemon。** 它报 `daemon_unavailable` 加一个 socket ENOENT ——而且是在落地的**最后一步**,此时旧台账已经被移开了。

**`export HA="node …/index.ts"` 是 bash 专用的。** zsh 不对未加引号的参数做单词分割,于是 `$HA --version` 把 `node …/index.ts` 当**一个**参数传出去,回执 `unsupported_command`。现在改成 shell 函数,并点明两处**不能**用它的地方:`nohup`(看不见函数)和 `env -u … ha`(从 `PATH` 解析——这正是第 9 步想要的,同时也会**静默丢掉**用户自己的 `ha` 包装注入的任何 flag,包括 `--actor`)。

**Node ≥ 24 是一条没写出来的硬前置。** 低于它每条命令都死于 `ERR_UNKNOWN_FILE_EXTENSION ".ts"`,而这个报错**读起来像缺了构建步骤**,会把人引向 `npm run build` ——那没用。现在在 clone 之前就检查。

三条是「检查本身是错的」而不是「缺检查」:

- **源摘要把 `harness/.git` 算进去了** ——那是活元数据。一次无关的 mirror fetch 在运行中途落地,重写了 `packed-refs`/`FETCH_HEAD`,于是 `source-before` ≠ `source-after`,**原因和导入器毫无关系**。现在两侧摘要都排除它;归档仍然包含 `.git`,因为备份必须包含。
- **落地检查验的是项目工作树,从没验过台账工作树。** 第 8 步末尾融合进去的项目特有 authored 内容,是写进工作树的,**不进任何一个 commit**。这次迁移因此把 `governance/walls/walls.json` 留在未提交状态,而已提交的那份是 `"walls": []` ——**十七条治理墙只活在一个未暂存的文件里**。一次 `git checkout` 就会静默清零。现在它是一条带理由的受检条件。
- **在台账目录里 `git commit` 会把所有写入楔死。** 台账的 HEAD 必须**恰好**是最后一个事件 commit;daemon 从 `harness/events/head.json` 推导出这一点——那里面的 `opId` 正是该 commit 的 message。其上任何 commit 都会打断 CAS,之后每次写入都返回 `publication_indeterminate`。关于恢复,有两件事花掉了将近一小时:**重启 daemon 并不能解除**(它重读 ref,但不重读期望值),以及 hint 里那个词 "reconcile" **对应不到任何命令**——`ha capabilities` 里没有这个动词。现在把真正的恢复动作写了进去:`git reset` 回报错中称为 `expected` 的那个 sha。

另有四条小的:`preset audit --json` 返回的是**按 vertical 的聚合**而不是包列表,所以要找出被 block 的包得回头读 `validate` 的输出;`.harness` 回收路径在一个 staging 目录已被清理过的仓上**一个字节都回收不到**,所以正文改成先量再报数;`mktemp` 在 macOS 上多出一个斜杠(`$TMPDIR` 自带结尾斜杠);以及第 2 步那句「停下,等用户确认异地副本」对**被派遣的 agent 不可达**——那应当如实报告,而不是默默跳过。

**Known rough edges** 里有两条记的是**当前存在的 CLI 缺陷**(`decision list` 静默截断到 100;读命令只打印 `<command>: applied`,数据锁在 `evidence` 里且是 JSON 字符串)。**这两条正在另一个分支上修。** 写在这里是因为它们**今天是真的**,而且迁移用户立刻就会遇到;那条分支合入后**应当删掉它们,而不是留着**。

## 任务与范围

- Harness 任务:`task_ca5665cdb936cab82df20d4560`
- 分支:`codex/skill-coldstart`
- 范围外:CLI 缺陷本身(另一分支);发布可安装的 CLI 工件——那才是上面第三条的真正修复,但那是产品决策,不是文档改动。

## 版本影响

- 版本:不改版本
- 发布影响:纯文档。无运行时行为变更。

## 治理声明

- 是否触碰 protected surface:no
- 依据:任务 `task_ca5665cdb936cab82df20d4560`;所有者要求这套迁移必须能冷启动走通,因为他打算自己在更多仓库上跑
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用

## 验证

- `origin/rebuild/main` 基准 SHA:`835cd6c5`
- 当前分支与 `origin/rebuild/main` 的 merge-base:`835cd6c5`
- 公开 diff 命令:`git diff 835cd6c5..codex/skill-coldstart`

- [x] `npm run check:local` — 通过,32.8 秒
- [x] `node tools/gates/line-budget.mjs --base 835cd6c5` — G32 通过
- [x] `node --test tools/skill-contracts.test.mjs` — 4/4
- [x] 冷启动运行本身:apply 退出码 0,五类实体全部 `Old = Expected = New`,`Skipped = 0`,`Reconciliation: PASS`,九个冲突全部显式解决,`source-before` == `source-after`
- [x] 落地:台账自有 `.git`(21,409 提交),项目忽略它,`git ls-files harness/ .harness/` 为空,并且一次**真实的** `task create` 在服务它的 daemon 上成功
- [x] `npm view @harness-anything/cli version` → E404 ——这是「CLI 未发布」这一断言的依据
- [x] `env -u HARNESS_DAEMON_USER_ROOT command ha --version` → `unknown_option`,回执带 `CommandReceipt/v1` 兼容层 ——这是「机器上是上一代」这一断言的依据
- [x] `publication_indeterminate` **刻意复现并用 `git reset` 恢复了两次**,确认单独重启 daemon 解除不了
- [ ] GitHub Actions `rewrite-ci` 通过(权威全量门)
- **未跑项及原因**:没有可再跑的。唯一能端到端检验修正后文本的测试,是再拿一个全新的两万一千条事件台账冷启动跑一遍,而 apply 一次就是 1 小时 22 分;每一条修正都锚定在产生它的那次运行的实录上。

## 复核证据

- Reviewer subagent:未使用。这些发现来自迁移 agent 自己的报告,加上调度方的落地会话;每一条都锚在**一条命令及其输出**上,而不是锚在对代码的阅读上。
- 迁移 agent 对它收到的 mission 提了**四条异议**。四条都成立,全部采纳;其中两条(`.git` 摘要、`.harness` 回收数字过时)在本 PR 中修正。
- 阻塞发现:无

## 残留风险

- **修正后的文本自己没有被冷启动验证过。** 每条改动都锚在一次实际失败上,但整份文档没有被一个全新 agent 重跑过。**下一次迁移就是这个测试**,应当当成测试来对待。
- **第 9 步那个「持久 checkout」是绕行,不是设计。** 它给用户留下一棵必须保留、且要按路径调用的源码树。真正的修复是可安装的工件;在那之前,这个 skill 是**带着说明书发一个粗糙边缘**给用户。
- **Known rough edges 里那两条 CLI 缺陷会过期。** 它们现在准确,并且正在另一条分支上修。如果那条分支合入而这两条没被删掉,skill 就开始描述**不再存在的问题**——正是本 PR 在别处修正的那种腐烂。
- **大台账上 `git gc --aggressive` 很慢,而且只量过一次。** 18 GB → 181 MB 这个数字来自单次运行、单个台账;比例会不同,**但这一步的必需性不会变**。

## 参考

- 任务:`task_ca5665cdb936cab82df20d4560`
- 给冷启动 agent 的 mission:`harness/tasks/task_01M022AR425YG81NS1TRH8BDKR-…/artifacts/mission-opus-coldstart-migration.md`(私有台账)
