### PR TITLE
refactor(gates): thaw the line-budget ratchet and collapse the receipt pile

### DIFF
--- a/tools/gates/line-budgets.json
+++ b/tools/gates/line-budgets.json
@@ -1,19 +1,19 @@
 {
   "version": 1,
   "ceilings": {
-    "kernel": 7962,
-    "task-lifecycle": 375,
-    "write-contract": 292,
-    "doc-sync": 350,
-    "preset": 372,
-    "cli": 171,
-    "gui": 18494,
-    "daemon": 1613,
-    "fleet": 222,
+    "kernel": 11943,
+    "task-lifecycle": 563,
+    "write-contract": 350,
+    "doc-sync": 525,
+    "preset": 558,
+    "cli": 257,
+    "gui": 27741,
+    "daemon": 2420,
+    "fleet": 350,
     "authority-write-path": 0,
-    "identity-rbac": 416,
-    "agent-runtime": 360,
-    "decision-fact": 452,
+    "identity-rbac": 624,
+    "agent-runtime": 520,
+    "decision-fact": 480,
     "test-infra": 0
   }
 }

--- a/tools/gates/receipts/line-budget-agent-runtime-520.json
+++ b/tools/gates/receipts/line-budget-agent-runtime-520.json
@@ -1,8 +1,8 @@
 {
-  "decisionId": "dec_01KZV78NDZ1XMZAGDMK3NWYCJH",
+  "decisionId": "dec_407E904F6938FA9FD304D3E34E",
   "scope": "module:agent-runtime",
   "kind": "line-budget",
   "limit": 520,
-  "expiry": "2026-09-13T00:00:00Z",
-  "signature": "495c6a9c9c47b96d7ee854f2a24f80b2fdd71e6d2b5f578baabc7ba6ec71d988"
+  "expiry": "2027-08-31T00:00:00Z",
+  "signature": "89538061d059ee3a39f89f6e0e4732e65bfad2d0825b2e3779cd251af5cb3bd7"
 }

--- a/tools/gates/receipts/line-budget-cli-158.json
+++ b/tools/gates/receipts/line-budget-cli-158.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_J4M8XZQ2TB7WCE9RKHP5NYD3FA",
-  "scope": "module:cli",
-  "kind": "line-budget",
-  "limit": 158,
-  "expiry": "2026-10-31T00:00:00Z",
-  "signature": "457d0ae94f7643618f27166a8dd3b2260578f1ff58546e97ac9c6233bdb0ea83"
-}

--- a/tools/gates/receipts/line-budget-cli-171.json
+++ b/tools/gates/receipts/line-budget-cli-171.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01M034D285TVBZH7HHG8J51VXY",
-  "scope": "module:cli",
-  "kind": "line-budget",
-  "limit": 171,
-  "expiry": "2026-09-30T00:00:00Z",
-  "signature": "4286acfc66eb2922f0316afddea2f307efed02681d0764bc817754ce9a6bf5b5"
-}

--- a/tools/gates/receipts/line-budget-cli-257.json
+++ b/tools/gates/receipts/line-budget-cli-257.json
@@ -1,0 +1,8 @@
+{
+  "decisionId": "dec_407E904F6938FA9FD304D3E34E",
+  "scope": "module:cli",
+  "kind": "line-budget",
+  "limit": 257,
+  "expiry": "2027-08-31T00:00:00Z",
+  "signature": "7aceba3be95876d009cd081b319077d52b92186a649070ec1aabd2e3267d635c"
+}

--- a/tools/gates/receipts/line-budget-daemon-1000.json
+++ b/tools/gates/receipts/line-budget-daemon-1000.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01KZWTAPXF24FR62Q53Y42JGMV",
-  "scope": "module:daemon",
-  "kind": "line-budget",
-  "limit": 1000,
-  "expiry": "2026-09-30T00:00:00Z",
-  "signature": "518b1634c7c34819ad6d39007211f23d8f20273bbce90b0a95870039695fbb63"
-}

--- a/tools/gates/receipts/line-budget-daemon-1570.json
+++ b/tools/gates/receipts/line-budget-daemon-1570.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_A7K3PQWTX9M2RBHZC4EYN5VD6Q",
-  "scope": "module:daemon",
-  "kind": "line-budget",
-  "limit": 1570,
-  "expiry": "2026-10-31T00:00:00Z",
-  "signature": "3a2d817c4d828ddaa1dc55a1e8a81823e1f8730e3fc133bdec1e3a18e2c3a03a"
-}

--- a/tools/gates/receipts/line-budget-daemon-1573.json
+++ b/tools/gates/receipts/line-budget-daemon-1573.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01KZWTAPXF24FR62Q53Y42JGMV",
-  "scope": "module:daemon",
-  "kind": "line-budget",
-  "limit": 1573,
-  "expiry": "2026-09-30T00:00:00Z",
-  "signature": "f1997fa260a6619bb4af6a20392a91025d5f23c83a4c22105117dbc098ecf8a8"
-}

--- a/tools/gates/receipts/line-budget-daemon-1609.json
+++ b/tools/gates/receipts/line-budget-daemon-1609.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01M034D285TVBZH7HHG8J51VXY",
-  "scope": "module:daemon",
-  "kind": "line-budget",
-  "limit": 1609,
-  "expiry": "2026-09-30T00:00:00Z",
-  "signature": "671b86cd769a92150d63fdd112c2d21f0f0eafae193c02310d3ab7a3c338924a"
-}

--- a/tools/gates/receipts/line-budget-daemon-1613.json
+++ b/tools/gates/receipts/line-budget-daemon-1613.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_0F467430C4E7DCFDDFFCC5D1E7",
-  "scope": "module:daemon",
-  "kind": "line-budget",
-  "limit": 1613,
-  "expiry": "2026-09-30T00:00:00Z",
-  "signature": "e193294867c780227cf633f3cc46b958226e8bcd16d01b1cc64d4a5abcf249ec"
-}

--- a/tools/gates/receipts/line-budget-daemon-2050.json
+++ b/tools/gates/receipts/line-budget-daemon-2050.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01KZWTAPXF24FR62Q53Y42JGMV",
-  "scope": "module:daemon",
-  "kind": "line-budget",
-  "limit": 2050,
-  "expiry": "2026-09-30T00:00:00Z",
-  "signature": "ccbca20c723995097973fb6f5d69335c2785c9bf6c2e531bda1f6aae1bdff8a6"
-}

--- a/tools/gates/receipts/line-budget-daemon-2420.json
+++ b/tools/gates/receipts/line-budget-daemon-2420.json
@@ -1,0 +1,8 @@
+{
+  "decisionId": "dec_407E904F6938FA9FD304D3E34E",
+  "scope": "module:daemon",
+  "kind": "line-budget",
+  "limit": 2420,
+  "expiry": "2027-08-31T00:00:00Z",
+  "signature": "4b02728eec160c0e28ac47670dbbe6411de8bd98fda10f99a298184a3d6db238"
+}

--- a/tools/gates/receipts/line-budget-daemon-808.json
+++ b/tools/gates/receipts/line-budget-daemon-808.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01KZTPDWY337MF6E6JC9638W7F",
-  "scope": "module:daemon",
-  "kind": "line-budget",
-  "limit": 808,
-  "expiry": "2026-09-12T00:00:00Z",
-  "signature": "4c878061c2be94125952f0dbda2d0a186128e826842f3e839f92f226449b4f81"
-}

--- a/tools/gates/receipts/line-budget-daemon-831.json
+++ b/tools/gates/receipts/line-budget-daemon-831.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01KZTRVZ0RE5P41YXBNZ9JMJ54",
-  "scope": "module:daemon",
-  "kind": "line-budget",
-  "limit": 831,
-  "expiry": "2026-09-12T00:00:00Z",
-  "signature": "c5fb1f3bdeb61f25a6b5a1ec74bb4b31b83ac6ebf14bdfc5aa92131fff4667a8"
-}

--- a/tools/gates/receipts/line-budget-daemon-867.json
+++ b/tools/gates/receipts/line-budget-daemon-867.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01KZVA9GQFJ0T6H05RHCSTV4CE",
-  "scope": "module:daemon",
-  "kind": "line-budget",
-  "limit": 867,
-  "expiry": "2026-09-14T00:00:00Z",
-  "signature": "e8edced0617647851724fd3fd35e90e20848ef5308b1a03156d51ace1c5789ed"
-}

--- a/tools/gates/receipts/line-budget-daemon-873.json
+++ b/tools/gates/receipts/line-budget-daemon-873.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01KZV78NDZ1XMZAGDMK3NWYCJH",
-  "scope": "module:daemon",
-  "kind": "line-budget",
-  "limit": 873,
-  "expiry": "2026-09-13T00:00:00Z",
-  "signature": "c238634889fed3329e0ecf31496d398365f38d92adb3ca21b786e7c9a1aea9e1"
-}

--- a/tools/gates/receipts/line-budget-daemon-899.json
+++ b/tools/gates/receipts/line-budget-daemon-899.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01KZVM5NBQFV92QJQKMF1HF77R",
-  "scope": "module:daemon",
-  "kind": "line-budget",
-  "limit": 899,
-  "expiry": "2026-09-14T00:00:00Z",
-  "signature": "86c07fd21d94319bd03484d8bd15da9424684adb3726ab5f401c3f12341e86ac"
-}

--- a/tools/gates/receipts/line-budget-daemon-920.json
+++ b/tools/gates/receipts/line-budget-daemon-920.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01KZQ92VEPTDRS2HS8CKDBKW2Q",
-  "scope": "module:daemon",
-  "kind": "line-budget",
-  "limit": 920,
-  "expiry": "2026-09-14T00:00:00Z",
-  "signature": "e6b7f78b1d261d11a33b3fd41ab8e2b9744b8c66f459c46f82a7dbacd0f68730"
-}

--- a/tools/gates/receipts/line-budget-daemon-940.json
+++ b/tools/gates/receipts/line-budget-daemon-940.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01KZWTAPXF24FR62Q53Y42JGMV",
-  "scope": "module:daemon",
-  "kind": "line-budget",
-  "limit": 940,
-  "expiry": "2026-09-30T00:00:00Z",
-  "signature": "6f5a0b829e0b6f59ae6f07d8bdb2d264aec1819675f52d98aa2eb0963dbbe782"
-}

--- a/tools/gates/receipts/line-budget-decision-fact-480.json
+++ b/tools/gates/receipts/line-budget-decision-fact-480.json
@@ -1,8 +1,8 @@
 {
-  "decisionId": "dec_01KZVM5NBQFV92QJQKMF1HF77R",
+  "decisionId": "dec_407E904F6938FA9FD304D3E34E",
   "scope": "module:decision-fact",
   "kind": "line-budget",
   "limit": 480,
-  "expiry": "2026-09-14T00:00:00Z",
-  "signature": "1b4df2bfe18a4b99a773ea9c5e309433df35aa1a423b542652b7d8712bee149d"
+  "expiry": "2027-08-31T00:00:00Z",
+  "signature": "f11ac30a9f7ce72aca17bc0efa8e07b4622499fca431690ed89303f364dbd29d"
 }

--- a/tools/gates/receipts/line-budget-doc-sync-300.json
+++ b/tools/gates/receipts/line-budget-doc-sync-300.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01KZTX02KPWXJ5WRK8JTRPC55M",
-  "scope": "module:doc-sync",
-  "kind": "line-budget",
-  "limit": 300,
-  "expiry": "2026-09-12T00:00:00Z",
-  "signature": "3700e5a68e9320cf4081380e1d27f85b713111d906f19041f9c3fb52356f13a5"
-}

--- a/tools/gates/receipts/line-budget-doc-sync-525.json
+++ b/tools/gates/receipts/line-budget-doc-sync-525.json
@@ -1,0 +1,8 @@
+{
+  "decisionId": "dec_407E904F6938FA9FD304D3E34E",
+  "scope": "module:doc-sync",
+  "kind": "line-budget",
+  "limit": 525,
+  "expiry": "2027-08-31T00:00:00Z",
+  "signature": "5b4ed9499a6be28116826d9d39ae974dd94f74222636d6eaef1e5a2a7da792b5"
+}

--- a/tools/gates/receipts/line-budget-doc-sync-730.json
+++ b/tools/gates/receipts/line-budget-doc-sync-730.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01KZWTAPXF24FR62Q53Y42JGMV",
-  "scope": "module:doc-sync",
-  "kind": "line-budget",
-  "limit": 730,
-  "expiry": "2026-09-30T00:00:00Z",
-  "signature": "c927f094c20769c3137e3b49f5e3cb005414ee55b3e7c7fedcb2025f247eea78"
-}

--- a/tools/gates/receipts/line-budget-gui-18467.json
+++ b/tools/gates/receipts/line-budget-gui-18467.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_FVH916YC1ZSG49GCGNQ82PXG64",
-  "scope": "module:gui",
-  "kind": "line-budget",
-  "limit": 18467,
-  "expiry": "2026-10-31T00:00:00Z",
-  "signature": "6a230cb4031cff52d3500fc17b49dea28a7b6fe7d0e95ac8a7ea798a0a2a4c9c"
-}

--- a/tools/gates/receipts/line-budget-gui-18494.json
+++ b/tools/gates/receipts/line-budget-gui-18494.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_V9T2WKN6CQ4XRZ8HJM3BPE7DY",
-  "scope": "module:gui",
-  "kind": "line-budget",
-  "limit": 18494,
-  "expiry": "2026-10-31T00:00:00Z",
-  "signature": "dcf66bde5c9c8efb0d5f0a23b85a35c1b840fa1962461c8c20c419dae3fe516b"
-}

--- a/tools/gates/receipts/line-budget-gui-22100.json
+++ b/tools/gates/receipts/line-budget-gui-22100.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01KZWTAPXF24FR62Q53Y42JGMV",
-  "scope": "module:gui",
-  "kind": "line-budget",
-  "limit": 22100,
-  "expiry": "2026-09-30T00:00:00Z",
-  "signature": "8f7550bad4bb2eb43e769cd547eed30337572da1b28e1ce41f43108405666830"
-}

--- a/tools/gates/receipts/line-budget-gui-27741.json
+++ b/tools/gates/receipts/line-budget-gui-27741.json
@@ -1,0 +1,8 @@
+{
+  "decisionId": "dec_407E904F6938FA9FD304D3E34E",
+  "scope": "module:gui",
+  "kind": "line-budget",
+  "limit": 27741,
+  "expiry": "2027-08-31T00:00:00Z",
+  "signature": "b42d6fd02da99b2a8b5a97a2f29eadc6244505e3898d4d7d832016fe99c169ec"
+}

--- a/tools/gates/receipts/line-budget-identity-rbac-624.json
+++ b/tools/gates/receipts/line-budget-identity-rbac-624.json
@@ -1,0 +1,8 @@
+{
+  "decisionId": "dec_407E904F6938FA9FD304D3E34E",
+  "scope": "module:identity-rbac",
+  "kind": "line-budget",
+  "limit": 624,
+  "expiry": "2027-08-31T00:00:00Z",
+  "signature": "8b980aa3d8b85c3033ffe981ef9149521d22925d69d7b75a8d49a06c3e655b43"
+}

--- a/tools/gates/receipts/line-budget-kernel-11943.json
+++ b/tools/gates/receipts/line-budget-kernel-11943.json
@@ -1,0 +1,8 @@
+{
+  "decisionId": "dec_407E904F6938FA9FD304D3E34E",
+  "scope": "module:kernel",
+  "kind": "line-budget",
+  "limit": 11943,
+  "expiry": "2027-08-31T00:00:00Z",
+  "signature": "36d6622459da649e2cd2678b30da00190710fb6db147114846fa520d67ef58b1"
+}

--- a/tools/gates/receipts/line-budget-kernel-7962.json
+++ b/tools/gates/receipts/line-budget-kernel-7962.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01KZWTAPXF24FR62Q53Y42JGMV",
-  "scope": "module:kernel",
-  "kind": "line-budget",
-  "limit": 7962,
-  "expiry": "2026-09-30T00:00:00Z",
-  "signature": "13fd9c09882226fcbd1b54ddff68a6c08055b09da11dac2f21d24efa8e5c89f3"
-}

--- a/tools/gates/receipts/line-budget-kernel-8200.json
+++ b/tools/gates/receipts/line-budget-kernel-8200.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01KZWTAPXF24FR62Q53Y42JGMV",
-  "scope": "module:kernel",
-  "kind": "line-budget",
-  "limit": 8200,
-  "expiry": "2026-09-30T00:00:00Z",
-  "signature": "172079ade53f5ba6dd28fe9a11c880476f412e03dd4653e8211d11d8e72a7c6c"
-}

--- a/tools/gates/receipts/line-budget-kernel-8210.json
+++ b/tools/gates/receipts/line-budget-kernel-8210.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01KZWTAPXF24FR62Q53Y42JGMV",
-  "scope": "module:kernel",
-  "kind": "line-budget",
-  "limit": 8210,
-  "expiry": "2026-09-30T00:00:00Z",
-  "signature": "db65b253ebbb23c2e8ab287ffe650cd88f6dc28464c3a7c3696e9ff3fafd485c"
-}

--- a/tools/gates/receipts/line-budget-kernel-8240.json
+++ b/tools/gates/receipts/line-budget-kernel-8240.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01KZWTAPXF24FR62Q53Y42JGMV",
-  "scope": "module:kernel",
-  "kind": "line-budget",
-  "limit": 8240,
-  "expiry": "2026-09-30T00:00:00Z",
-  "signature": "f5b1b3e3f3bad4dd195a55bf68afe01aee4db1f1fd69e92b4ab329cb8e14d9e4"
-}

--- a/tools/gates/receipts/line-budget-preset-420.json
+++ b/tools/gates/receipts/line-budget-preset-420.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_01KZVA9GQFJ0T6H05RHCSTV4CE",
-  "scope": "module:preset",
-  "kind": "line-budget",
-  "limit": 420,
-  "expiry": "2026-09-14T00:00:00Z",
-  "signature": "ed7d66bfb8b9eeff24d7f1ade6b0fe746b6d30b39089a2aee0dcd50ceb9ba68e"
-}

--- a/tools/gates/receipts/line-budget-preset-558.json
+++ b/tools/gates/receipts/line-budget-preset-558.json
@@ -1,0 +1,8 @@
+{
+  "decisionId": "dec_407E904F6938FA9FD304D3E34E",
+  "scope": "module:preset",
+  "kind": "line-budget",
+  "limit": 558,
+  "expiry": "2027-08-31T00:00:00Z",
+  "signature": "1d88b6f2b327657860db820dbff97f35a87bb1e10d301c4075fe291d666492e6"
+}

--- a/tools/gates/receipts/line-budget-task-lifecycle-563.json
+++ b/tools/gates/receipts/line-budget-task-lifecycle-563.json
@@ -1,0 +1,8 @@
+{
+  "decisionId": "dec_407E904F6938FA9FD304D3E34E",
+  "scope": "module:task-lifecycle",
+  "kind": "line-budget",
+  "limit": 563,
+  "expiry": "2027-08-31T00:00:00Z",
+  "signature": "38dddbd3aaf46b4e9312a16e2eaf324de5c23c1fd61372093cfc9b45ecdbaa8b"
+}

--- a/tools/gates/receipts/line-budget-write-contract-350.json
+++ b/tools/gates/receipts/line-budget-write-contract-350.json
@@ -1,8 +1,8 @@
 {
   "decisionId": "dec_407E904F6938FA9FD304D3E34E",
-  "scope": "module:fleet",
+  "scope": "module:write-contract",
   "kind": "line-budget",
   "limit": 350,
   "expiry": "2027-08-31T00:00:00Z",
-  "signature": "0ffb2207469c916330cf2085083fb38c7928a0c77ba53b4c8ae631002b502492"
+  "signature": "97cff0a005a43e329a0ff3c1df946d8db2fafe4db84e64c17fba94253e064426"
 }

--- a/tools/gates/test/line-budget.test.mjs
+++ b/tools/gates/test/line-budget.test.mjs
@@ -118,10 +118,21 @@ test("every committed line-budget receipt verifies, and the raised ceilings are 
   }
   // A receipt may outlive the ceiling it was minted for -- the ratchet only ever
   // falls -- so the reverse direction is the one worth asserting: every ceiling
-  // that a receipt was needed for still has one that reaches it.
-  for (const moduleName of ["cli", "daemon"]) {
+  // that a receipt was needed for still has one that reaches it. The module list
+  // is derived from what is committed rather than named here, so a module whose
+  // receipt is minted below its ceiling fails instead of going unchecked.
+  const receiptModules = [...new Set(receipts.map(({ receipt }) => receipt.scope.replace(/^module:/u, "")))];
+  for (const moduleName of receiptModules) {
     assert.ok(receipts.some(({ receipt }) => verifyReceipt(receipt, {
       scope: `module:${moduleName}`, kind: "line-budget", minimumLimit: ceilings[moduleName], now
     }).ok), `${moduleName}: ceiling ${ceilings[moduleName]} has no receipt the gate would accept`);
   }
+  // Superseded receipts are deleted, not stacked: the gate reads whichever one
+  // verifies, so a module carrying several is carrying expiries nobody is
+  // tracking -- and this test fails the day the oldest of them lapses.
+  assert.deepEqual(
+    receiptModules.filter((moduleName) => receipts.filter(({ receipt }) => receipt.scope === `module:${moduleName}`).length > 1),
+    [],
+    "each module keeps exactly one line-budget receipt; supersede by replacing the file"
+  );
 });


### PR DESCRIPTION
# English

## Summary

All fourteen modules sat at exactly 100% of their line-budget ceiling. That is not a budget, it is a freeze: every feature PR had to mint a decision and sign a receipt first, and the gate could no longer distinguish quiet bloat from a change that legitimately needs forty lines. This thaws it per `dec_407E904F6938FA9FD304D3E34E`, and collapses a receipt pile that was on a schedule to turn the contract suite red by itself.

## What Changed

- **Ceilings raised.** Eight unconstrained modules by 50% (kernel, task-lifecycle, doc-sync, preset, cli, gui, daemon, identity-rbac). Four modules constrained by `INITIAL_MODULE_CEILINGS` go to their design limit and no further — write-contract 350, agent-runtime 520, decision-fact 480, fleet 350. The two modules whose actual is 0 (authority-write-path, test-infra) stay at 0; budgeting a deliberately empty module invites it to grow.
- **`INITIAL_MODULE_CEILINGS` and every line of gate logic untouched.** Raising the design limits is deferred to separate adjudication by the decision's RJ3; `git diff --name-only -- tools/gates/line-budget.mjs` is empty.
- **Receipts 28 → 12.** One per raised module, all anchored to the decision, sharing a 2027-08-31 expiry. Twenty-five stale ones deleted after confirming G33 is the only other reader of that directory and matches on `kind: "retained-path"` only.
- **Gate test coverage widened.** The committed-receipt test derived its module list from a hardcoded `["cli","daemon"]`, silently skipping the other ten; it now derives the list from the receipts themselves.

## Task And Scope

- Task: `task_8a5bb2fea2cab0ace2d9f0e04f`
- Scope: `tools/gates/line-budgets.json`, `tools/gates/receipts/`, `tools/gates/test/line-budget.test.mjs`. No product source.

## Version Impact

None. No package version change, no published interface change.

Production-Delta: +0/-0

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gates/` — budget data and decision receipts. Gate logic and `INITIAL_MODULE_CEILINGS` deliberately untouched.
- Authority: `dec_407E904F6938FA9FD304D3E34E` (active). Its claim C4 is the authoritative module partition — CH1's prose says "ten modules" and that is a miscount, corrected by C4 to eight.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: raising `INITIAL_MODULE_CEILINGS` itself, when `decision-fact` next hits its cap.

## Verification

- Base `origin/main` SHA: `f28e6e57` (`origin/rebuild/main`)
- Branch merge-base with `origin/main`: `f28e6e57`
- Last `git fetch origin` time: 2026-08-16, immediately before branching
- Sync method: none needed
- Public diff command: `git diff f28e6e57 codex/budget-thaw`
- Private evidence commit/path: `harness/tasks/task_8a5bb2fea2cab0ace2d9f0e04f-start-release-progress-append/artifacts/mission-budget-thaw.md`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending — filled after the run starts
- [x] `node tools/gates/line-budget.mjs --base f28e6e57` — `G32 line-budget-ratchet: pass`, all fourteen ceilings verified against the decision table
- [x] `node tools/gates/test-selection.mjs --base f28e6e57` — `ok=true`, required `[fast, contract]`
- [x] `npm run check:local` — passed (fast tier)
- [x] `npm run test:contract` — 405 pass, 0 fail. **Run because `check:local` alone does not reach the changed test**: `line-budget.test.mjs` is contract tier, so the fast tier is false comfort for a `tools/gates/` change. The implementing agent raised this against the mission's own stop point and was right.
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: integration tier. It is not selected for this diff, and on the rebuild line no CI job executes it — a separate line (`dec_A7FEB0536A4D054DE117B11469`) is restoring that coverage.

## Review Evidence

- Self-review: ceilings checked one by one against the decision's C4 partition; `line-budget.mjs` confirmed unchanged; the deleted receipts' sole-reader claim re-checked against G33.
- Reviewer subagent: the implementing agent mutation-tested both test edits. Undersized-receipt mutation fails with the derived module list and **passes** with the old hardcoded one, so the widened coverage is a genuine regression net. It also reported honestly that the duplicate-receipt rule it added is test-only policy the gate itself does not enforce.
- Human review: pending
- Blocking findings: none

## Residual Risk

- **The receipts this PR deletes were a scheduled red.** Measured against base: 0/28 expired today, 5/28 by 2026-09-13, 11/28 by 2026-09-15, 24/28 by 2026-10-01. `verifyReceipt` checks expiry, and the committed-receipt test asserts every receipt still verifies — so the base tree's contract suite was going to fail around 2026-09-12 from the clock alone. Spot-checked: `line-budget-agent-runtime-520.json` expires 2026-09-13. This PR removes that cliff, but the new receipts inherit the same shape one year out.
- **`decision-fact` is barely thawed**: +28 lines (+6.2%), because its design limit is 480 and it sits at 452. It will be back at 100% after roughly one modest change, and the next PR to hit it has no receipt path out — only a decision to raise the design limit.
- On the committed tree both the old and new versions of the changed test pass. What proves the twelve ceilings are backed is G32 itself, not the test edit; the edit only extends coverage to future raises.

## References

- Task: `task_8a5bb2fea2cab0ace2d9f0e04f`
- Evidence: `mission-budget-thaw.md` and `dec-budget-thaw-body.md` in that task package
- Review: `dec_407E904F6938FA9FD304D3E34E`

---

# 中文

## 概要

十四个模块全部**正好**卡在 line-budget 上限。那不是预算,是冻结:每个功能 PR 都得先铸决策、签 receipt,而门也不再能区分"悄悄膨胀"和"这个改动确实需要四十行"。本 PR 按 `dec_407E904F6938FA9FD304D3E34E` 解冻,并清掉一堆**本来会自己把 contract 套件变红**的 receipt。

## 改动内容

- **抬升上限。** 八个无约束模块各抬 50%(kernel、task-lifecycle、doc-sync、preset、cli、gui、daemon、identity-rbac)。四个受 `INITIAL_MODULE_CEILINGS` 约束的抬到设计上限为止——write-contract 350、agent-runtime 520、decision-fact 480、fleet 350。两个 actual 为 0 的模块(authority-write-path、test-infra)维持 0:给一个刻意保持为空的模块发预算,等于邀请它长东西。
- **`INITIAL_MODULE_CEILINGS` 与门逻辑一行未动。** 抬高设计上限由决策 RJ3 划为单独裁决事项;`git diff --name-only -- tools/gates/line-budget.mjs` 为空。
- **receipt 28 → 12。** 每个抬升模块一张,全部锚本决策,统一 2027-08-31 到期。删掉 25 张陈旧的,删前确认 G33 是该目录唯一的另一个读者且只匹配 `kind: "retained-path"`。
- **门测试覆盖面加宽。** 那个"已提交 receipt 全部可验证"的测试,模块清单原本硬编码成 `["cli","daemon"]`,**静默跳过另外十个**;现在从 receipt 自身派生。

## 任务与范围

- 任务:`task_8a5bb2fea2cab0ace2d9f0e04f`
- 范围:`tools/gates/line-budgets.json`、`tools/gates/receipts/`、`tools/gates/test/line-budget.test.mjs`。无产品源码改动。

## 版本影响

无。无包版本变更,无已发布接口变更。

## 治理声明

- 触碰 protected surface:是
- Protected surface 范围:`tools/gates/`——预算数据与决策 receipt。门逻辑与 `INITIAL_MODULE_CEILINGS` 刻意未动。
- 授权依据:`dec_407E904F6938FA9FD304D3E34E`(active)。其 claim **C4 是权威分区**——CH1 正文写的"十个模块"是笔误,已由 C4 更正为八个。
- 机器检查边界:本 PR 只断言声明存在;声明是否属实与是否充分由审查者判断。
- Break-glass:否
- Break-glass 理由:不适用
- Break-glass 范围:不适用
- 后续治理任务:抬高 `INITIAL_MODULE_CEILINGS` 本身,待 `decision-fact` 下次撞顶时。

## 验证

- `origin/main` 基准 SHA:`f28e6e57`(`origin/rebuild/main`)
- 当前分支与 `origin/main` 的 merge-base:`f28e6e57`
- 最近一次 `git fetch origin` 时间:2026-08-16,开分支前即刻
- 同步方式:不需要
- 公开 diff 命令:`git diff f28e6e57 codex/budget-thaw`
- 私有证据 commit/path:`harness/tasks/task_8a5bb2fea2cab0ace2d9f0e04f-start-release-progress-append/artifacts/mission-budget-thaw.md`
- Reviewer 证据路径:同一任务包
- GitHub Actions `rewrite-ci` run URL:待补
- [x] `node tools/gates/line-budget.mjs --base f28e6e57` —— `G32 line-budget-ratchet: pass`,十四个上限逐条对照决策表核过
- [x] `node tools/gates/test-selection.mjs --base f28e6e57` —— `ok=true`,required `[fast, contract]`
- [x] `npm run check:local` —— 通过(fast tier)
- [x] `npm run test:contract` —— 405 通过,0 失败。**之所以单跑,是因为 `check:local` 够不到被改的那个测试**:`line-budget.test.mjs` 是 contract tier,对 `tools/gates/` 类改动,fast tier 是假安心。实现者对着 mission 自己的停止点提了这条异议,他是对的。
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:integration tier。本 diff 未选中它,且 rebuild 线上无任何 CI job 执行它——另一条线(`dec_A7FEB0536A4D054DE117B11469`)正在恢复该覆盖。

## 审查证据

- 自审:十四个上限逐条对照决策 C4 分区;确认 `line-budget.mjs` 未改;被删 receipt 的"唯一读者"断言对 G33 复核过。
- Reviewer subagent:实现者对两处测试改动各做了变异测试。用"上限不足的 receipt"变异,派生清单版本红、旧硬编码版本**绿**,证明加宽的覆盖是真回归网。他同时如实报告:他新增的"每模块只允许一张 receipt"是**测试侧策略,门本身并不强制**。
- 人工审查:待泽宇
- 阻塞性发现:无

## 残余风险

- **本 PR 删掉的那些 receipt 是一颗定时红。** 对基线实测:今天 0/28 过期,到 2026-09-13 有 5/28,09-15 有 11/28,10-01 有 24/28。`verifyReceipt` 会校验 expiry,而那个测试断言"每张 receipt 仍可验证"——**基线那棵树的 contract 套件会在 2026-09-12 前后因为时钟自己变红**。抽查印证:`line-budget-agent-runtime-520.json` 的 expiry 是 2026-09-13。本 PR 移除了这个悬崖,但新 receipt 继承同样形状,只是推到一年后。
- **`decision-fact` 几乎没被解冻**:+28 行(+6.2%),因为它设计上限 480 而现值 452。大约一个中等改动之后它就会重新顶满,而下一个撞上它的 PR **没有 receipt 出路**,只能靠抬设计上限的决策。
- 在已提交的树上,被改测试的新旧两版都通过。证明这十二个上限有背书的是 G32 本身,不是这次测试改动;改动只把覆盖延伸到未来的抬升。

## 关联材料

- 任务:`task_8a5bb2fea2cab0ace2d9f0e04f`
- 证据:该任务包内 `mission-budget-thaw.md` 与 `dec-budget-thaw-body.md`
- 审查:`dec_407E904F6938FA9FD304D3E34E`
