### PR TITLE
fix(gates): stop forcing the line budget down when production lines fall

### DIFF
--- a/tools/gates/line-budget.mjs
+++ b/tools/gates/line-budget.mjs
@@ -118,9 +118,6 @@ export function evaluateLineBudget({
     if (actual > ceiling) {
       errors.push(`${moduleName}: actual ${actual} exceeds ceiling ${ceiling}; reduce production lines to ${ceiling} or add a verified line-budget decision receipt and update the ceiling`);
     }
-    if (actual < before.counts[moduleName] && ceiling !== actual) {
-      errors.push(`${moduleName}: production lines fell from ${before.counts[moduleName]} to ${actual}; lower the ceiling to ${actual} in the same change`);
-    }
     if (baseCeilings !== null && ceiling > baseCeilings[moduleName] && !hasBudgetReceipt(receipts, moduleName, ceiling, now)) {
       errors.push(`${moduleName}: ceiling rose from ${baseCeilings[moduleName]} to ${ceiling} without a valid receipt scoped to module:${moduleName} with limit >= ${ceiling}`);
     }

--- a/tools/gates/test/line-budget.test.mjs
+++ b/tools/gates/test/line-budget.test.mjs
@@ -37,15 +37,19 @@ test("G32 rejects production lines above the ceiling", () => {
   assert.match(result.errors.join("\n"), /actual 3 exceeds ceiling 2/u);
 });
 
-test("G32 captures line reductions in the same change", () => {
+// Deleting production code must not tighten the budget. The old rule forced the
+// ceiling down to the new actual on any reduction, which is why every module sat
+// at exactly 100% before dec_407E904F6938FA9FD304D3E34E: each refactor pinned the
+// ceiling back to whatever the code happened to measure. Headroom that a
+// refactor can evaporate is not headroom, so the assertion runs the other way now.
+test("G32 leaves the ceiling alone when production lines fall", () => {
   const { rootDir, base } = fixtureRepo();
   writeRepoFile(rootDir, "packages/kernel/src/index.ts", "one\n");
-  const stale = evaluateLineBudget({ rootDir, base });
-  assert.equal(stale.ok, false);
-  assert.match(stale.errors.join("\n"), /lower the ceiling to 1/u);
+  const reduced = evaluateLineBudget({ rootDir, base });
+  assert.deepEqual({ ok: reduced.ok, actual: reduced.actual.kernel, ceiling: reduced.ceilings.kernel }, { ok: true, actual: 1, ceiling: 2 });
+  // Lowering it deliberately stays available -- it is just no longer compulsory.
   writeRepoFile(rootDir, "tools/gates/line-budgets.json", budgetBody(1));
-  const ratcheted = evaluateLineBudget({ rootDir, base });
-  assert.deepEqual({ ok: ratcheted.ok, actual: ratcheted.actual.kernel, ceiling: ratcheted.ceilings.kernel }, { ok: true, actual: 1, ceiling: 1 });
+  assert.equal(evaluateLineBudget({ rootDir, base }).ok, true);
 });
 
 test("G32 accepts a ceiling increase only with a scoped decision receipt", () => {
@@ -116,8 +120,8 @@ test("every committed line-budget receipt verifies, and the raised ceilings are 
     assert.deepEqual(verifyReceipt(receipt, { now }).errors, [], filePath);
     assert.ok(MODULES.includes(receipt.scope.replace(/^module:/u, "")), `${filePath}: scope names an unknown module`);
   }
-  // A receipt may outlive the ceiling it was minted for -- the ratchet only ever
-  // falls -- so the reverse direction is the one worth asserting: every ceiling
+  // A receipt may outlive the ceiling it was minted for -- a ceiling can still be
+  // lowered deliberately -- so the reverse direction is the one worth asserting: every ceiling
   // that a receipt was needed for still has one that reaches it. The module list
   // is derived from what is committed rather than named here, so a module whose
   // receipt is minted below its ceiling fails instead of going unchecked.


### PR DESCRIPTION
# English

## Summary

G32 required any change that reduced a module's production lines to lower that module's ceiling to the new count, in the same change:

```js
if (actual < before.counts[moduleName] && ceiling !== actual)
```

That rule is why all fourteen modules sat at **exactly** 100% before #1455 thawed the budgets. It was not a coincidence and nobody sized them that tightly: every refactor that deleted a line pinned the ceiling back to whatever the code happened to measure, and over time that pushed every module to zero headroom.

#1455 raised the numbers but left the mechanism that produced the problem in place, so the thaw only survived one PR. The very next branch — sinking a duplicated node-pty spawn-helper fix from the GUI into the daemon — dropped gui from 18494 to 18414 and was told to hand the freshly raised ceiling straight back:

```
G32 line-budget-ratchet: gui: production lines fell from 18494 to 18414; lower the ceiling to 18414 in the same change
```

This removes the rule. Raising a ceiling still requires a verified receipt scoped to the module — a separate check in the same function, untouched. Lowering a ceiling stays available; it is simply no longer compulsory.

Headroom a refactor can evaporate is not headroom.

Production-Delta: +0/-0

## Verification

- `node --test tools/gates/test/line-budget.test.mjs` → 8 tests / 8 pass / 0 fail
- Mutation: re-adding the rule turns exactly the rewritten test red (8 tests / 7 pass / 1 fail), and only that one; restoring makes it 8/8. The test discriminates.
- `npm run check:local` → exit 0, "Local check passed (fast tier) in 34.5s"
- `node tools/gates/test-selection.mjs --base 5a28ee20` → `"errors": []`

The rewritten test asserts the opposite of the old one: a fall in production lines with the ceiling left alone is accepted, and a deliberate lowering still passes. The stale comment claiming "the ratchet only ever falls" is corrected in the same change.

## Governance Declaration

- Decision: `dec_CA7133AB1A4BAA121225702BB3` (active) — 删掉 line-budget 的向下 ratchet
- Evidence: `fact/task_ca5665cdb936cab82df20d4560/F-ACE59A4C` — the gate firing on a real branch, with its output verbatim
- Rejected alternatives recorded in the decision: exempting modules that hold a receipt (a condition branch propping up a rule that should not exist); lowering the ceiling by hand on every deletion (measured cost: three levels of ceremony — lower the ceiling, which counts as a governance-mechanism change, which G25 then requires a fixture for); deriving ceilings as a fixed multiple of actual (replaces budget judgement with a formula and still tightens on deletion).

## Residual Risk

Ceilings can now drift above actual and stay there, which is the intended trade: a budget with no headroom is a freeze. The ceilings are committed data and reviewable in the diff, and the receipt check still governs every increase. If dead headroom does accumulate, lowering a ceiling remains a one-line edit.

---

# 中文

## 摘要

G32 原本要求:任何减少模块生产行数的改动,必须在同一变更里把该模块上限降到新的实测值。

这条规则就是 #1455 解冻之前十四个模块**正好**全部 100% 的成因——不是巧合,也没人把预算算得那么准:每一次删代码的重构都把上限焊回代码当时的实测值,日积月累把所有模块推到零余量。

#1455 抬了数字,却把生产这个状态的机制原样留着,于是解冻只活过一个 PR。紧接着的那条分支——把 GUI 侧重复的 node-pty spawn-helper 修复下沉到 daemon——让 gui 从 18494 降到 18414,门当场要求把刚抬起来的上限还回去。

本 PR 删掉这条规则。上抬仍需模块作用域的有效 receipt(同一函数里的另一条校验,一行未动);下调仍然可用,只是不再强制。

**余量若能被一次重构蒸发,那就不是余量。**

## 验证

- `node --test tools/gates/test/line-budget.test.mjs` → 8 项全绿
- 变异实测:把规则加回去,**恰好**这条改写后的测试变红(7 过 1 红),其余七条不动;还原后 8/8。测试有分辨力,不是摆设。
- `npm run check:local` → exit 0
- `node tools/gates/test-selection.mjs --base 5a28ee20` → `"errors": []`

改写后的测试断言与原来相反:行数下降而上限不动应当通过,主动下调也仍然通过。同一变更里改掉了那句已经失效的注释「ratchet 只降不升」。

## 治理声明

- 决策:`dec_CA7133AB1A4BAA121225702BB3`(active)
- 证据:`fact/task_ca5665cdb936cab82df20d4560/F-ACE59A4C` —— 门在真实分支上开火,输出原文在案
- 决策里记录的被否方案:给持有 receipt 的模块开豁免(在一条不该存在的规则上再加条件分支);每次删代码顺手下调上限(实测代价是三级仪式);按实测值倍数自动派生上限(把预算裁量换成公式,且删代码照样收紧)

## 残余风险

上限现在可以高于实测值并保持——这正是有意的取舍:没有余量的预算就是冻结。上限是提交在库里的数据,diff 里可审;每一次上抬仍由 receipt 校验把关。若真积出死余量,下调依然是一行编辑。
