### PR TITLE
ci(gates): reopen seven repaired boundary gates on the rebuild lane

### DIFF
--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -208,7 +208,7 @@ jobs:
         if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' && startsWith(github.base_ref, 'rebuild/') }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: node tools/run-manifest-gates.mjs --workflow-job boundaries --exclude mergify-queue-metadata-edit-noop,check-cli-structure,check-import-boundaries,check-write-road-registry,check-duplicate-definitions,check-integration-test-shards,check-mergify-queue-contexts,check-github-required-contexts,check-legacy-intake-readiness
+        run: node tools/run-manifest-gates.mjs --workflow-job boundaries --exclude mergify-queue-metadata-edit-noop,check-duplicate-definitions
 
   package-policy:
     if: github.event_name == 'pull_request'

--- a/tools/check-gate-surface.test.mjs
+++ b/tools/check-gate-surface.test.mjs
@@ -18,18 +18,14 @@ test("rewrite CI runs the integration tier on every PR and scopes baseline retir
   const integrationBlock = workflow.slice(workflow.indexOf("  integration-shard:"), workflow.indexOf("  boundaries:"));
   assert.doesNotMatch(integrationBlock, /base_ref/u);
 
+  // The rebuild lane once excluded eight boundary gates. Seven were repaired and
+  // reopened; the exclusion list is a ratchet, so it is asserted exactly rather
+  // than by membership — re-excluding a gate has to be a deliberate edit here.
   const rebuildBoundaryCommand = workflow.split(/\r?\n/u)
-    .find((line) => line.includes("--workflow-job boundaries") && line.includes("check-cli-structure"));
-  assert.ok(rebuildBoundaryCommand, "rebuild boundary command must explicitly retire replaced baseline checks");
-  for (const gateId of [
-    "check-import-boundaries",
-    "check-write-road-registry",
-    "check-duplicate-definitions",
-    "check-integration-test-shards",
-    "check-mergify-queue-contexts",
-    "check-github-required-contexts",
-    "check-legacy-intake-readiness"
-  ]) assert.match(rebuildBoundaryCommand, new RegExp(`(?:^|,)${gateId}(?:,|$)`, "u"));
+    .find((line) => line.includes("--workflow-job boundaries") && line.includes("startsWith") === false && line.includes("--exclude") && line.includes("check-duplicate-definitions"));
+  assert.ok(rebuildBoundaryCommand, "rebuild boundary command must declare its remaining exclusions");
+  const excluded = /--exclude\s+(\S+)/u.exec(rebuildBoundaryCommand)?.[1].split(",");
+  assert.deepEqual(excluded, ["mergify-queue-metadata-edit-noop", "check-duplicate-definitions"]);
 
   for (const job of ["pr-body-lint", "typecheck", "fast-contract", "integration-shard", "boundaries", "package-policy", "supply-chain", "gui-build", "node26-compatibility"]) {
     assert.match(workflow, new RegExp(`^  ${job}:`, "mu"), `${job} must remain a general PR lane`);


### PR DESCRIPTION
# English

## Summary

The rebuild lane's boundary job excluded eight gates. Seven of them pass on `rebuild/main` today, so they are reopened; the eighth stays excluded with a named owner.

Measured on `0a8bce3e` by running the whole boundaries lane and reading the per-gate result, not by inspecting the checkers:

| gate | result |
| --- | --- |
| `check-cli-structure` | pass |
| `check-import-boundaries` | pass |
| `check-write-road-registry` | pass |
| `check-integration-test-shards` | pass |
| `check-mergify-queue-contexts` | pass |
| `check-github-required-contexts` | pass |
| `check-legacy-intake-readiness` | pass |
| `check-duplicate-definitions` | **fail** — stays excluded |

Three of these were repaired in #1463 but never reopened; the exclusion list had not been revisited since. `check-github-required-contexts` was failing for a different reason: the GitHub ruleset was missing `pr-body-lint` and `node26-compatibility` and still required `direct-recovery`, a job that no longer exists in any workflow. The ruleset now matches what the gate manifest declares — fourteen contexts, up from thirteen, with the dead one removed. That is the ruleset moving toward the manifest, not the manifest being relaxed toward the ruleset.

`check-duplicate-definitions` remains red against 50 duplicate groups spread across the rebuild line (daemon, kernel, gui, preset). It is owned by `task_b2f3446bc16cac2ff36c149ccc` and is blocked on three files that in-flight PRs still hold. It is recorded here as a known red rather than allowed to pass silently through the cutover.

The contract test is rewritten from membership to exact equality. It used to assert that seven named gates appear in the exclusion list, which made the list only ever able to grow. It now asserts the list is exactly `mergify-queue-metadata-edit-noop,check-duplicate-definitions`, so re-excluding anything is a deliberate edit to a ratchet rather than an appended argument.

## Verification

- Full boundaries lane on this branch with only `check-duplicate-definitions` excluded: exit 0, every gate green (per-gate output captured, not a tail).
- `node --test tools/check-gate-surface.test.mjs` — 9/9 pass.
- `node --test tools/gates/test/workflow-base-sha.test.mjs` — 2/2 pass.
- `tools/run-local-check.mjs` derives its exclusion set from this workflow step, so `check:local` picks the shorter list up automatically: `rebuildExcludedGateIds()` now returns exactly the two remaining ids. Six of the seven reopened gates are `deterministic: true` and join the local fast tier; `check-github-required-contexts` is `deterministic: false` and stays cloud-only, which is correct — it queries GitHub.
- `npm run check:local` green.

## Governance Declaration

- Task: `task_48683aa8ef5888eb57f6b82c9a`
- `dec_A5A21DA3FBA36809287A2A6C6C` CH3 — the eight excluded gates must be handled one at a time: reopen what passes, and record what does not as a named known red with its own task. Nothing may be promoted silently by the cutover. This PR discharges seven of the eight; `check-duplicate-definitions` is the named exception.

Production-Delta: +0/-0

## Review Evidence

The GitHub ruleset is protected surface and was changed under CH3: `direct-recovery` removed, `pr-body-lint` and `node26-compatibility` added, everything else untouched, enforcement unchanged. The ruleset targets `~DEFAULT_BRANCH`, which is still the pre-rebuild `main`, so the edit is inert until the rename — it was applied now so `check-github-required-contexts` could be verified green before being reopened, rather than being reopened on the promise that it would pass later. The gate itself is the authority: it reports required contexts declared by `tools/gate-manifest.json` and missing from the branch rules, and it now passes with 14 contexts.

## Residual Risk

Reopening seven gates on every rebuild-base PR means a latent violation in any in-flight branch will now surface as a red on that branch rather than at cutover. That is the intent, but it will look like new breakage to whoever hits it first. `check-duplicate-definitions` stays excluded, so the duplicate-definition surface remains unenforced until `task_b2f3446bc16cac2ff36c149ccc` lands; the exact-equality assertion means reopening it later is a one-line edit to a test that will fail loudly if the workflow and the test disagree.

---

# 中文

## 摘要

rebuild 线的 boundary job 排除了 8 条门。其中 7 条在今天的 `rebuild/main` 上是过的,故恢复;第 8 条继续排除,但有明确归属。

实测于 `0a8bce3e`,做法是整条 boundaries 跑一遍读逐门结果,不是去读 checker 源码:

| 门 | 结果 |
| --- | --- |
| `check-cli-structure` | 过 |
| `check-import-boundaries` | 过 |
| `check-write-road-registry` | 过 |
| `check-integration-test-shards` | 过 |
| `check-mergify-queue-contexts` | 过 |
| `check-github-required-contexts` | 过 |
| `check-legacy-intake-readiness` | 过 |
| `check-duplicate-definitions` | **红** —— 继续排除 |

其中 3 条在 #1463 已修好但没人回来打开;这份排除清单自那以后没被重新审视过。`check-github-required-contexts` 红的是另一个原因:GitHub ruleset 缺 `pr-body-lint` 与 `node26-compatibility`,却还要求 `direct-recovery`——一个任何 workflow 里都已不存在的 job。现在 ruleset 与 gate manifest 的声明对齐了:14 条 context(原 13 条),死的那条删掉。**是 ruleset 向 manifest 靠,不是 manifest 向 ruleset 松。**

`check-duplicate-definitions` 仍红,面是 rebuild 线上 50 组重复定义(daemon / kernel / gui / preset)。它归 `task_b2f3446bc16cac2ff36c149ccc`,当前卡在三个还被在飞 PR 占着的文件上。这里把它记为**已知红**,而不是让它随 cutover 静默转正。

契约测试从「成员判定」改写成「精确相等」。原来它断言 7 条具名门**出现在**排除清单里——这种写法只能让清单越来越长。现在它断言清单**正好是** `mergify-queue-metadata-edit-noop,check-duplicate-definitions`,于是再排除任何一条门,都变成对一个棘轮的刻意修改,而不是往参数后面多加一个逗号。

## 验证

- 本分支上整条 boundaries 只排除 `check-duplicate-definitions`:exit 0,逐门全绿(逐门输出已完整留存,不是 tail)。
- `node --test tools/check-gate-surface.test.mjs` —— 9/9 通过。
- `node --test tools/gates/test/workflow-base-sha.test.mjs` —— 2/2 通过。
- `tools/run-local-check.mjs` 的排除集是从这个 workflow step 派生的,所以 `check:local` 自动跟着变短:`rebuildExcludedGateIds()` 现在正好返回剩下那两个 id。恢复的 7 条里有 6 条 `deterministic: true`,进本地 fast tier;`check-github-required-contexts` 是 `deterministic: false`,仍然只在云端跑——这是对的,它要查 GitHub。
- `npm run check:local` 全绿。

## 治理声明

- 任务:`task_48683aa8ef5888eb57f6b82c9a`
- `dec_A5A21DA3FBA36809287A2A6C6C` CH3 —— 那 8 条排除的门必须逐条处置:能过的恢复,过不了的单独记为已知红并另立任务,不得随 cutover 静默转正。本 PR 处置掉 7 条,`check-duplicate-definitions` 是那条具名例外。

## 复核证据

GitHub ruleset 是 protected surface,本次按 CH3 修改:删 `direct-recovery`,加 `pr-body-lint` 与 `node26-compatibility`,其余一字未动,enforcement 未变。该 ruleset 的作用面是 `~DEFAULT_BRANCH`,而默认分支目前仍是 rebuild 之前的 `main`,所以这次修改在改名前是惰性的——之所以现在就改,是为了让 `check-github-required-contexts` **先被验成绿**再被恢复,而不是凭「以后会过」的承诺恢复它。判据以门本身为准:它报的是 `tools/gate-manifest.json` 声明、而分支规则里缺失的 context,现在 14 条全对上、通过。

## 残留风险

7 条门在每个 rebuild-base PR 上恢复后,任何在飞分支里潜伏的违规会以那条分支变红的形式冒出来,而不是等到 cutover。这正是目的,但第一个撞上的人会觉得是新坏的。`check-duplicate-definitions` 仍排除,所以重复定义这个面在 `task_b2f3446bc16cac2ff36c149ccc` 落地前仍无人执法;精确相等的断言意味着将来恢复它是改测试里的一行,而且一旦 workflow 与测试对不上会立刻大声红。
