### PR TITLE
ci(gates): decouple rebuild-gates from the trunk branch name

### DIFF
--- a/.github/workflows/rebuild-gates.yml
+++ b/.github/workflows/rebuild-gates.yml
@@ -3,14 +3,17 @@ name: rebuild-gates
 on:
   pull_request:
     branches:
+      - "main"
       - "rebuild/**"
     types: [opened, reopened, synchronize, edited]
   pull_request_target:
     branches:
+      - "main"
       - "rebuild/**"
     types: [opened, reopened, synchronize, edited]
   push:
     branches:
+      - "main"
       - "rebuild/main"
 
 permissions:
@@ -95,7 +98,7 @@ jobs:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
         run: |
           if [ -z "$BASE_SHA" ] || ! git cat-file -e "$BASE_SHA^{tree}" 2>/dev/null; then
-            BASE_SHA=$(git rev-parse origin/rebuild/main)
+            BASE_SHA=$(git rev-parse origin/rebuild/main 2>/dev/null || git rev-parse origin/main)
           fi
           node tools/gates/test-selection.mjs --base "$BASE_SHA"
 
@@ -140,7 +143,7 @@ jobs:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
         run: |
           if [ -z "$BASE_SHA" ] || ! git cat-file -e "$BASE_SHA^{tree}" 2>/dev/null; then
-            BASE_SHA=$(git rev-parse origin/rebuild/main)
+            BASE_SHA=$(git rev-parse origin/rebuild/main 2>/dev/null || git rev-parse origin/main)
           fi
           node tools/gates/line-budget.mjs --base "$BASE_SHA"
 

--- a/tools/gates/test/workflow-base-sha.test.mjs
+++ b/tools/gates/test/workflow-base-sha.test.mjs
@@ -6,14 +6,19 @@ import test from "node:test";
 
 const workflowPath = path.join(process.cwd(), ".github/workflows/rebuild-gates.yml");
 
-test("push trigger covers only rebuild/main — feature branches gate through pull_request runs, whose diff is the full PR; a feature-branch push run would re-evaluate walls against the narrow event.before diff and mint contradictory conclusions on the same head SHA (dec_01KZTQ1KRG17545YMSFKXJGEPN)", () => {
+// The trunk carries two names while the rebuild line is being renamed to main:
+// "rebuild/main" today, "main" after the rename, never both at once in practice.
+// Drop the retired name from this list the moment the rename lands.
+const TRUNK_BRANCHES = ['- "main"', '- "rebuild/main"'];
+
+test("push trigger covers only trunk branches — feature branches gate through pull_request runs, whose diff is the full PR; a feature-branch push run would re-evaluate walls against the narrow event.before diff and mint contradictory conclusions on the same head SHA (dec_01KZTQ1KRG17545YMSFKXJGEPN)", () => {
   const workflow = readFileSync(workflowPath, "utf8");
   const pushBlock = workflow.match(/\n {2}push:\n {4}branches:\n((?: {6}- .*\n)+)/u);
-  assert.ok(pushBlock, "rebuild-gates must keep an explicit push trigger for post-merge main gating");
+  assert.ok(pushBlock, "rebuild-gates must keep an explicit push trigger for post-merge trunk gating");
   assert.deepEqual(
     pushBlock[1].trim().split("\n").map((line) => line.trim()),
-    ['- "rebuild/main"'],
-    "push trigger must list exactly rebuild/main"
+    TRUNK_BRANCHES,
+    "push trigger must list exactly the trunk branch names, never a wildcard or a feature branch"
   );
 });
 


### PR DESCRIPTION
# English

## Summary

Removes `rebuild-gates.yml`'s dependency on the trunk being called `rebuild/main`, so that part of the cutover is already done when the rename happens.

- The `pull_request`, `pull_request_target`, and `push` triggers list both trunk names. A workflow scoped to a branch name goes silently dead the moment that branch is renamed — no failure, no red, just no runs at all.
- The two `BASE_SHA` fallbacks resolve `origin/rebuild/main` first and fall back to `origin/main`. **The order is load-bearing, not cosmetic.** `origin/main` exists today and points at the pre-rebuild history, which shares no ancestry with this line; trying it first would silently compute `test-selection` and `line-budget` against an unrelated tree and report a confident wrong answer. After the rename `rebuild/main` is gone and the fallback resolves the renamed trunk.

`workflow-base-sha.test.mjs` moves from pinning a literal name to pinning the invariant. It asserted the push trigger listed exactly `rebuild/main`; the invariant behind `dec_01KZTQ1KRG17545YMSFKXJGEPN` is that push gating covers trunk only and never a feature branch, because a feature-branch push run would re-evaluate walls against the narrow `event.before` diff and mint a contradictory conclusion on the same head SHA. The branch's spelling was never the point. It now compares against a named `TRUNK_BRANCHES` list holding both names, with the retirement condition written directly above it.

The other two `startsWith(github.base_ref, 'rebuild/')` conditions — both in `rewrite-ci.yml`'s boundaries job — are **not** removed here. Collapsing those two steps into one is blocked on `check-duplicate-definitions`; see Residual Risk.

## Verification

- `node --test tools/gates/test/workflow-base-sha.test.mjs` — 2/2 pass.
- `npm run check:local` green (37.5s).
- The `BASE_SHA` order was verified against the live repository, not reasoned about: `git rev-parse origin/main` resolves today, to the pre-rebuild trunk, and `git merge-base --is-ancestor` confirms it is not an ancestor of this line.

## Governance Declaration

- Task: `task_48683aa8ef5888eb57f6b82c9a`
- `dec_A5A21DA3FBA36809287A2A6C6C` CH2 — CI configuration stops coupling to the branch name, with the contract test changed alongside so it does not judge the correct new configuration a violation. This PR discharges the `rebuild-gates.yml` half.
- `dec_01KZTQ1KRG17545YMSFKXJGEPN` — push gating stays trunk-only. The invariant is preserved; only the spelling of "trunk" widens for the transition.

Production-Delta: +0/-0

## Review Evidence

Collapsing the boundaries job was attempted in this branch and reverted after `check-gate-surface` failed with `check-duplicate-definitions expects boundaries to run "npm run harness:check-duplicate-definitions", but the command is absent`. That failure is a real finding rather than an obstacle: the manifest declares `check-duplicate-definitions` as a boundaries PR gate, and the only reason the surface check has been satisfied is the **baseline** boundary step, which runs the unexcluded list and which no pull request has actually taken — nothing targets the pre-rebuild `main`. So the gate has not been enforced anywhere, and a dead lane was holding the surface check up. It follows that the duplicate-definition cleanup is required *before* the rename, not merely alongside it: after the rename every PR's base is `main`, the baseline step becomes the live one, and boundaries would go red on all 50 groups.

## Residual Risk

Both trunk names are live in the triggers and the fallback chain until the rename. While that is true, a push to the dead pre-rebuild `main` would start a `rebuild-gates` run; nothing pushes there, and such a run would gate that branch's own content rather than this line's. The retirement condition is written at each site: drop the retired name when the rename lands. `TRUNK_BRANCHES` in `workflow-base-sha.test.mjs` is the single place that must be edited for the assertion to keep meaning something, and it fails loudly if the workflow and the list disagree.

`rewrite-ci.yml` still branches on `github.base_ref` in its boundaries job. That is tracked on the same cutover task and is now known to be gated on `task_b2f3446bc16cac2ff36c149ccc`.

---

# 中文

## 摘要

去掉 `rebuild-gates.yml` 对「主干叫 `rebuild/main`」的依赖,让 cutover 的这一部分在改名之前就已经做完。

- `pull_request`、`pull_request_target`、`push` 三处触发面同时列出两个主干名。**按分支名圈定的 workflow,在那个分支被改名的瞬间会静默失效**——不报错、不变红,就是不再跑。
- 两处 `BASE_SHA` 回退改成先解 `origin/rebuild/main`,解不到再退 `origin/main`。**这个顺序是承重的,不是排版。** `origin/main` 今天存在,指向 rebuild 之前那段与本线毫无共同祖先的历史;按自然语序先试它,`test-selection` 与 `line-budget` 就会静默地对着一棵不相干的树算,然后给出一个很自信的错答案。改名之后 `rebuild/main` 消失,回退正好解到改名后的主干。

`workflow-base-sha.test.mjs` 从钉字面名字改成钉不变量。它原来断言 push 触发面正好是 `rebuild/main`;而 `dec_01KZTQ1KRG17545YMSFKXJGEPN` 背后的不变量是「push 门只覆盖主干、永不覆盖特性分支」——因为特性分支的 push run 会拿 `event.before` 那份很窄的 diff 重新评一遍 walls,在同一个 head SHA 上铸出互相矛盾的结论。**分支叫什么从来不是重点。** 现在它对照一个具名的 `TRUNK_BRANCHES` 列表(含两个名字),退役条件就写在它正上方。

另外两处 `startsWith(github.base_ref, 'rebuild/')`——都在 `rewrite-ci.yml` 的 boundaries job 里——**本 PR 不动**。把那两个 step 收成一个卡在 `check-duplicate-definitions` 上,见残留风险。

## 验证

- `node --test tools/gates/test/workflow-base-sha.test.mjs` —— 2/2 通过。
- `npm run check:local` 全绿(37.5s)。
- `BASE_SHA` 的顺序是对着真实仓库核过的,不是推理出来的:`git rev-parse origin/main` 今天能解,解出的是 rebuild 之前那条主干,`git merge-base --is-ancestor` 确认它不是本线的祖先。

## 治理声明

- 任务:`task_48683aa8ef5888eb57f6b82c9a`
- `dec_A5A21DA3FBA36809287A2A6C6C` CH2 —— CI 配置去掉对分支名的耦合,契约测试同步改,否则它会把正确的新配置判成违规。本 PR 处置 `rebuild-gates.yml` 这一半。
- `dec_01KZTQ1KRG17545YMSFKXJGEPN` —— push 门仍然只覆盖主干。不变量保留,只是「主干」这个词在过渡期有两种拼法。

## 复核证据

收拢 boundaries job 在本分支上试过并已回退,原因是 `check-gate-surface` 报 `check-duplicate-definitions expects boundaries to run "npm run harness:check-duplicate-definitions", but the command is absent`。**这条红是一个真发现,不是一个障碍**:manifest 声明 `check-duplicate-definitions` 是 boundaries 的 PR 门,而这条面检查之所以一直被满足,靠的是**baseline** 那个 boundary step——它跑的是不排除的完整清单,而没有任何一个 PR 真的走过它,因为没有人以 rebuild 之前的 `main` 为基线。也就是说,**这道门在任何地方都没有被执法过,是一条死 lane 在替它撑着面检查**。由此推出:重复定义的清理必须在**改名之前**完成,而不是与之并行——改名之后每个 PR 的 base 都是 `main`,baseline 那一支变成活的那支,boundaries 会因为 50 组重复定义直接变红。

## 残留风险

改名之前,两个主干名在触发面与回退链里同时有效。在这段时间里,往那条已死的 rebuild 前 `main` 推送会启动一次 `rebuild-gates` run;没有人往那里推,而且那次 run 门的是那条分支自己的内容,不是本线的。退役条件写在每个位置旁边:改名落地时删掉退役的那个名字。`workflow-base-sha.test.mjs` 里的 `TRUNK_BRANCHES` 是唯一必须手改才能让断言继续有意义的地方,而且一旦 workflow 与这份列表不一致它会大声红。

`rewrite-ci.yml` 的 boundaries job 里仍然按 `github.base_ref` 分支。这一条挂在同一个 cutover 任务上,并且现在已知它卡在 `task_b2f3446bc16cac2ff36c149ccc`。
