### PR TITLE
test(cli): judge thin CLI overhead against a bare process spawn

### DIFF
--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -251,11 +251,32 @@ test("resident daemon CLI write p50 includes process startup through parsed rece
       samples.push(performance.now() - started);
       assert.equal(receipt.outcome, "applied", JSON.stringify(receipt));
     }
+    const bareSamples: number[] = [];
+    for (let index = 0; index < 11; index += 1) {
+      const started = performance.now();
+      spawnSync(process.execPath, ["-e", ""], { stdio: "ignore" });
+      bareSamples.push(performance.now() - started);
+    }
     const ordered = [...samples].sort((left, right) => left - right), p50 = ordered[Math.floor(ordered.length / 2)]!;
     const daemonOrdered = [...daemonSamples].sort((left, right) => left - right), daemonP50 = daemonOrdered[Math.floor(daemonOrdered.length / 2)]!;
+    const bareOrdered = [...bareSamples].sort((left, right) => left - right), bareP50 = bareOrdered[Math.floor(bareOrdered.length / 2)]!;
+    const cliOverhead = p50 - daemonP50, overheadRatio = cliOverhead / bareP50;
     context.diagnostic(`latency-window=before-cli-process-spawn-through-exit-and-parsed-receipt daemon=resident samples=${samples.length} p50=${p50.toFixed(3)}ms min=${ordered[0]!.toFixed(3)}ms max=${ordered.at(-1)!.toFixed(3)}ms`);
-    context.diagnostic(`latency-segment=resident-daemon-socket-through-parsed-receipt samples=${daemonSamples.length} p50=${daemonP50.toFixed(3)}ms min=${daemonOrdered[0]!.toFixed(3)}ms max=${daemonOrdered.at(-1)!.toFixed(3)}ms inferred-cli-process-startup-parse-render-p50=${(p50 - daemonP50).toFixed(3)}ms`);
-    assert.equal(p50 <= 300, true, `built resident daemon CLI write p50 was ${p50.toFixed(3)}ms`);
+    context.diagnostic(`latency-segment=resident-daemon-socket-through-parsed-receipt samples=${daemonSamples.length} p50=${daemonP50.toFixed(3)}ms min=${daemonOrdered[0]!.toFixed(3)}ms max=${daemonOrdered.at(-1)!.toFixed(3)}ms inferred-cli-process-startup-parse-render-p50=${cliOverhead.toFixed(3)}ms`);
+    context.diagnostic(`latency-baseline=bare-node-process-spawn samples=${bareSamples.length} p50=${bareP50.toFixed(3)}ms cli-overhead-over-bare-spawn=${overheadRatio.toFixed(3)}x`);
+    // The thin CLI's own cost is everything outside the daemon round-trip: spawning a
+    // process, loading its modules, parsing, rendering. Measured against a bare Node
+    // spawn on the same machine in the same window, so machine speed and load cancel —
+    // an absolute millisecond bound here would only assert how fast the runner is, and
+    // dec_01KY6X4J486MZ35RW1QN51V2V1 restricts performance gates to relative overhead.
+    // It fails if the CLI grows eager module loading, or stops delegating to the
+    // resident daemon and starts doing the write in its own process. Measured basis:
+    // 1.26x across repeated local runs at load average 7.9 (both terms are process
+    // spawns, so the ratio barely moves with load); injecting 120 ms of synthetic
+    // startup into the CLI entry raised it to 2.50x. The bound is set so a doubling
+    // of the thin CLI's own cost fails.
+    assert.equal(overheadRatio <= 3, true,
+      `thin CLI overhead was ${overheadRatio.toFixed(3)}x a bare Node spawn (cli=${cliOverhead.toFixed(3)}ms, bare=${bareP50.toFixed(3)}ms, total=${p50.toFixed(3)}ms, daemon=${daemonP50.toFixed(3)}ms)`);
   } finally { stop(fixture.alpha, fixture.userRoot, builtCli); rmSync(fixture.root, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
# English

## Summary

`resident daemon CLI write p50` asserted `p50 <= 300` on a window that spans spawning a Node process eleven times. That is an absolute wall-clock bound on a measurement dominated by machine speed, and it has been failing on an unmodified tree.

Ground truth, measured by reverting an in-flight branch's production diff and running the test on the same tree in the same window at load average 7.9:

```
p50=363.929ms  daemonP50=282.716ms  cli-overhead=81.214ms   → FAIL (clean tree)
```

So the red is not caused by any change under review. Three separate workstreams stopped on it today, each correctly refusing to touch the threshold, and each concluding it was blocked by an unrelated pre-existing failure.

The assertion is replaced with a relative one. The test already computed both halves of the number and printed their difference as a diagnostic; it now measures a third term — eleven bare `node -e ""` spawns in the same window — and asserts:

```
(p50 - daemonP50) / bareSpawnP50 <= 3
```

The numerator is everything the thin CLI costs outside the daemon round-trip: process spawn, module loading, parsing, rendering. The denominator is a bare process spawn on the same machine at the same moment. Machine speed and load cancel, which is why the ratio barely moves while the raw milliseconds do.

This is the same policy violation as the two removed earlier today — `elapsed < 250` in the event-store recovery test (#1464) and `recovery.elapsedMs > 250` in `repo-cell.ts` production control flow (#1465). This is the third instance in the family, so the shape is the finding, not the instance.

The daemon round-trip's own cost (`daemonP50` ≈ 283 ms per write) is deliberately **not** bounded here. That number is real and it is the ledger-scaling line's problem — the flat `harness/events/` tree makes every write pay for a 1.5 MB tree object. Bounding it from a CLI lifecycle test would restate a scaling defect as a CLI regression, and it is already gated relatively by the store's `10k/100` ratio test.

## Verification

- Clean tree, old assertion: `p50=363.929ms` → **fail**. Same tree, new assertion: `1.263x` → pass.
- Repeated runs at load average 7.9: ratio `1.256x`, `1.263x`, `1.256x`. Both terms are process spawns, so the ratio is stable while the raw p50 moves between 364 ms and 440 ms.
- **Positive control** (the instrument must respond to what it claims to measure): injecting a 120 ms busy-wait immediately after the shebang in `packages/cli/src/index.ts` moved `cli-overhead` from 80 ms to 156 ms and the ratio from `1.26x` to `2.50x`, with `daemonP50` unchanged at 284 ms. The source was restored; `git status` clean apart from the test.
- The bound is set at 3 so a doubling of the thin CLI's own cost fails, with roughly 2.4x headroom over the observed value.
- `npm run check:local` green.

## Governance Declaration

- `dec_01KY6X4J486MZ35RW1QN51V2V1` — performance gates express relative overhead, never absolute wall-clock. This assertion violated it directly, in the same way as the two removed in #1464 and #1465.

Production-Delta: +0/-0

## Review Evidence

Attribution was established before the assertion was touched, not after: the executor-axis branch's production diff was reverted in place and the test re-run on the resulting clean tree, which failed at 363.9 ms — worse than the 298.5 ms that branch measured standalone. Without that A/B the honest reading would have been "an in-flight change made writes slower", and the fix would have been aimed at the wrong thing.

## Residual Risk

The bound of 3 is calibrated on local measurements only; no CI value for this ratio exists yet, and a runner whose module-load-to-spawn profile differs could sit higher than 1.26x. The diagnostic prints the ratio on every run, so the first CI runs supply the data to tighten or loosen it deliberately rather than by guess. If it turns out CI sits well above 3, that is itself a finding about the built CLI on Linux, not a reason to raise the number quietly.

Per-write daemon latency of roughly 283 ms is now unbounded by any test in this file. It remains covered relatively by `packages/kernel/test/store/task-event-store.test.ts`'s history-independence ratio, and it is the subject of the ledger sharding work.

---

# 中文

## 摘要

`resident daemon CLI write p50` 断言 `p50 <= 300`,而这个窗口里包含**十一次 Node 进程启动**。这是一条压在「机器有多快」上的绝对墙钟界,而且它在**未经修改的树上就是红的**。

真值是这样测出来的:把一条在飞分支的生产 diff 就地回滚,在同一棵树、同一个时间窗、load average 7.9 下重跑:

```
p50=363.929ms  daemonP50=282.716ms  cli-overhead=81.214ms   → 干净树 FAIL
```

所以这条红与任何被复核的改动无关。今天有**三条独立工作线**卡在它上面,每一条都正确地拒绝去动阈值,每一条都得出「被一个无关的既有失败挡住」的结论。

断言改成相对的。这个测试本来就算出了那个数的两半、并把差值打成 diagnostic;现在它在同一个窗口里多测一项——十一次裸 `node -e ""` 启动——然后断言:

```
(p50 - daemonP50) / bareSpawnP50 <= 3
```

分子是 thin CLI 在 daemon 往返之外的全部开销:起进程、加载模块、解析、渲染。分母是同一台机器同一时刻的一次裸进程启动。机器速度与负载在两者之间相消——这正是为什么原始毫秒数在动而这个比值几乎不动。

这与今天已经删掉的两处是**同一条政策违规**:event-store 恢复测试里的 `elapsed < 250`(#1464),以及 `repo-cell.ts` 生产控制流里的 `recovery.elapsedMs > 250`(#1465)。这是同族第三例,所以**发现是这个形状,不是这一个实例**。

daemon 往返自身的开销(`daemonP50` ≈ 每次写 283ms)在这里**刻意不设界**。那个数字是真的,但它是台账规模化那条线的问题——扁平的 `harness/events/` 树让每次写都要为一个 1.5MB 的 tree 对象买单。在一个 CLI 生命周期测试里去卡它,等于把一个规模化缺陷改写成 CLI 回归;而它已经被 store 那条 `10k/100` 比值测试相对地门住了。

## 验证

- 干净树 + 旧断言:`p50=363.929ms` → **红**。同一棵树 + 新断言:`1.263x` → 绿。
- load average 7.9 下重复跑:比值 `1.256x`、`1.263x`、`1.256x`。两项都是进程启动,所以原始 p50 在 364ms 到 440ms 之间晃时,比值几乎不动。
- **阳性对照**(仪器必须对它声称测量的东西有反应):在 `packages/cli/src/index.ts` 的 shebang 之后注入 120ms 忙等,`cli-overhead` 从 80ms 涨到 156ms、比值从 `1.26x` 涨到 `2.50x`,而 `daemonP50` 稳在 284ms 不动。源码已还原,`git status` 除测试文件外干净。
- 上界取 3,使 thin CLI 自身开销**翻倍即红**,相对实测值约有 2.4 倍余量。
- `npm run check:local` 全绿。

## 治理声明

- `dec_01KY6X4J486MZ35RW1QN51V2V1` —— 性能门只表达相对开销,不用绝对墙钟。这条断言直接违反它,与 #1464、#1465 删掉的那两处是同一回事。

## 复核证据

归因是在**动断言之前**做的,不是之后:把 executor 轴那条分支的生产 diff 就地回滚,在得到的干净树上重跑,红在 363.9ms——比那条分支自己 standalone 测到的 298.5ms **还差**。没有这次 A/B,诚实的读法会是「某个在飞改动让写变慢了」,修复也就会瞄错地方。

## 残留风险

上界 3 只由本机实测标定,这个比值目前**没有任何 CI 数值**;某个模块加载与进程启动比例不同的 runner 可能天然高于 1.26x。diagnostic 每次都会打印比值,所以头几次 CI run 就会提供数据,让收紧或放宽成为一个有依据的决定而不是猜。**如果 CI 明显高于 3,那本身是一个关于 Linux 上构建产物的发现,而不是悄悄调高数字的理由。**

每次写约 283ms 的 daemon 延迟,现在在本文件里不再被任何测试卡住。它仍由 `packages/kernel/test/store/task-event-store.test.ts` 的历史无关性比值相对地覆盖,并且正是台账分片那条线要解决的对象。
