### PR TITLE
fix(ci): collapse boundaries to one gate set and reopen check-duplicate-definitions

### DIFF
--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -199,16 +199,11 @@ jobs:
           cache: npm
       - if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
         run: npm ci
-      - name: Run baseline boundary gates
-        if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' && !startsWith(github.base_ref, 'rebuild/') }}
+      - name: Run boundary gates
+        if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: node tools/run-manifest-gates.mjs --workflow-job boundaries --exclude mergify-queue-metadata-edit-noop
-      - name: Run rebuild-compatible boundary gates
-        if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' && startsWith(github.base_ref, 'rebuild/') }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: node tools/run-manifest-gates.mjs --workflow-job boundaries --exclude mergify-queue-metadata-edit-noop,check-duplicate-definitions
 
   package-policy:
     if: github.event_name == 'pull_request'

--- a/tools/check-gate-surface.test.mjs
+++ b/tools/check-gate-surface.test.mjs
@@ -18,14 +18,14 @@ test("rewrite CI runs the integration tier on every PR and scopes baseline retir
   const integrationBlock = workflow.slice(workflow.indexOf("  integration-shard:"), workflow.indexOf("  boundaries:"));
   assert.doesNotMatch(integrationBlock, /base_ref/u);
 
-  // The rebuild lane once excluded eight boundary gates. Seven were repaired and
-  // reopened; the exclusion list is a ratchet, so it is asserted exactly rather
-  // than by membership — re-excluding a gate has to be a deliberate edit here.
-  const rebuildBoundaryCommand = workflow.split(/\r?\n/u)
-    .find((line) => line.includes("--workflow-job boundaries") && line.includes("startsWith") === false && line.includes("--exclude") && line.includes("check-duplicate-definitions"));
-  assert.ok(rebuildBoundaryCommand, "rebuild boundary command must declare its remaining exclusions");
-  const excluded = /--exclude\s+(\S+)/u.exec(rebuildBoundaryCommand)?.[1].split(",");
-  assert.deepEqual(excluded, ["mergify-queue-metadata-edit-noop", "check-duplicate-definitions"]);
+  // The rebuild lane once excluded eight boundary gates and ran them from a second
+  // step the baseline lane never took. All eight are repaired, so the job is back to
+  // one step and one exclusion. Both facts are asserted exactly, not by membership:
+  // re-excluding a gate, or re-splitting the job by base branch so a gate can be
+  // satisfied by a lane no pull request travels, has to be a deliberate edit here.
+  const boundaryCommands = [...workflow.matchAll(/--workflow-job boundaries\s+--exclude\s+(\S+)/gu)];
+  assert.equal(boundaryCommands.length, 1, "boundaries must run one gate set for every base branch");
+  assert.deepEqual(boundaryCommands[0][1].split(","), ["mergify-queue-metadata-edit-noop"]);
 
   for (const job of ["pr-body-lint", "typecheck", "fast-contract", "integration-shard", "boundaries", "package-policy", "supply-chain", "gui-build", "node26-compatibility"]) {
     assert.match(workflow, new RegExp(`^  ${job}:`, "mu"), `${job} must remain a general PR lane`);

--- a/tools/run-local-check.mjs
+++ b/tools/run-local-check.mjs
@@ -44,19 +44,25 @@ const LOCK_PID_FILE = path.join(LOCK_DIR, "pid");
 // context needed).
 const LOCAL_MANIFEST_JOBS = new Set(["boundaries", "package-policy"]);
 
-// The rebuild line's boundaries job runs with an exclude list declared in the
-// workflow itself ("Run rebuild-compatible boundary gates"). Read it from there
-// so this runner never grows a second hand-maintained copy of that list.
-export function rebuildExcludedGateIds() {
+// The boundaries job declares its exclude list in the workflow itself. Read it from
+// there so this runner never grows a second hand-maintained copy. Anchored on the
+// command, not on a step name: a step's prose label is free to change, and the
+// previous anchor ("Run rebuild-compatible boundary gates") named a step that the
+// rebuild-lane collapse deleted. Exactly one such command must exist — two would
+// mean the job runs different gate sets on different lanes again, and this runner
+// would have to pick one and be silently wrong on the other.
+export function excludedBoundaryGateIds() {
   const workflow = readFileSync(path.join(repoRoot, ".github/workflows/rewrite-ci.yml"), "utf8");
-  const step = workflow.match(/Run rebuild-compatible boundary gates[\s\S]*?--exclude\s+(\S+)/u);
-  if (!step) throw new Error("run-local-check: rebuild-compatible boundary gates step not found in rewrite-ci.yml");
-  return new Set(step[1].split(","));
+  const commands = [...workflow.matchAll(/--workflow-job boundaries\s+--exclude\s+(\S+)/gu)];
+  if (commands.length !== 1) {
+    throw new Error(`run-local-check: expected exactly one boundaries gate command in rewrite-ci.yml, found ${commands.length}`);
+  }
+  return new Set(commands[0][1].split(","));
 }
 
 function manifestDerivedSteps() {
   const manifest = JSON.parse(readFileSync(path.join(repoRoot, "tools/gate-manifest.json"), "utf8"));
-  const excluded = rebuildExcludedGateIds();
+  const excluded = excludedBoundaryGateIds();
   return manifest.gates
     .filter((gate) => {
       const surfaces = gate.executionSurfaces ?? {};

--- a/tools/run-local-check.test.mjs
+++ b/tools/run-local-check.test.mjs
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
-import { buildSteps, parseLocalCheckArgs, rebuildExcludedGateIds, selectQosPrefix } from "./run-local-check.mjs";
+import { buildSteps, parseLocalCheckArgs, excludedBoundaryGateIds, selectQosPrefix } from "./run-local-check.mjs";
 
 test("parseLocalCheckArgs defaults to the waiting fast tier", () => {
   assert.deepEqual(parseLocalCheckArgs([]), { full: false, wait: true, pollMs: 2000 });
@@ -35,7 +35,7 @@ test("buildSteps appends integration and gui lanes only in the full tier", () =>
   // Fast tier derives the CI boundaries + package-policy surface from the gate
   // manifest, so every deterministic checkPr gate in those jobs must be present.
   const manifest = JSON.parse(readFileSync(new URL("./gate-manifest.json", import.meta.url), "utf8"));
-  const excluded = rebuildExcludedGateIds();
+  const excluded = excludedBoundaryGateIds();
   const expectedScripts = manifest.gates
     .filter((gate) => {
       const surfaces = gate.executionSurfaces ?? {};
@@ -52,9 +52,11 @@ test("buildSteps appends integration and gui lanes only in the full tier", () =>
   assert.ok(fastScripts.includes("lint"));
   // Positive control: the gate PR #1358 slipped through on must be present.
   assert.ok(fastScripts.includes("harness:check-cli-help-contract"));
-  // The rebuild line's CI exclusions must be honored locally too.
-  assert.ok(excluded.has("check-duplicate-definitions"));
-  assert.ok(!fastScripts.includes("harness:check-duplicate-definitions"));
+  // CI's boundaries exclusions must be honored locally too — and only those. The
+  // rebuild lane used to exclude check-duplicate-definitions here; with all 50 groups
+  // cleared the gate is back in CI, so it has to be back in the local set as well.
+  assert.deepEqual([...excluded], ["mergify-queue-metadata-edit-noop"]);
+  assert.ok(fastScripts.includes("harness:check-duplicate-definitions"));
   assert.deepEqual(fastScripts.slice(-2), ["check:local:derived-contracts", "check:local:schema-closure"]);
 });
 


### PR DESCRIPTION
# English

## Summary

The `boundaries` job ran two steps: a baseline step with the full gate list and a rebuild step that excluded `check-duplicate-definitions`. Nothing targets the pre-rebuild `main`, so the baseline step never executed on any pull request — the exclusion was a dead lane that silently kept a red gate out of every PR. With all 50 duplicate-definition groups cleared (#1470 preset+gui, #1473 daemon+kernel), the exclusion has no reason to exist.

This PR collapses the two steps into one, excluding only `mergify-queue-metadata-edit-noop` (which genuinely needs PR context), and re-anchors `tools/run-local-check.mjs`: it previously found the exclusion list by matching a step's **prose label** ("Run rebuild-compatible boundary gates") — a label this collapse deletes. It now matches the gate command itself and requires exactly one such command to exist, so a second lane can never silently reappear.

## Task And Scope

- Follow-up declared out of scope in #1473's body; completes the boundaries-collapse line.
- Branch: `codex/boundaries-collapse`
- Files: `rewrite-ci.yml`, `run-local-check.mjs`, and both tools tests. Nothing else.

## Governance Declaration

- Protected surface touched: **yes** — `.github/workflows/rewrite-ci.yml` and `tools/` gate infrastructure.
- Authority: `dec_A5A21DA3FBA36809287A2A6C6C` CH3 — after the rename every PR's base is `main` and the baseline lane becomes the live one; collapsing to a single lane and reopening the gate is the prerequisite CI change for the rename. No gate was weakened: the change strictly *adds* `check-duplicate-definitions` to what PRs run.

Production-Delta: +0/-0

## Verification

- Positive control, both halves on the same gate: on base `b06ffb2e` (before #1473) `npm run check:local` stopped red at `boundaries: check-duplicate-definitions` — proving the reopened gate genuinely entered the local set. Rebased onto `10e7921d` (with #1473), the same run is green in 44.2s and the log shows the gate executing.
- `node --test tools/run-local-check.test.mjs tools/check-gate-surface.test.mjs` → 16 pass, 0 fail.
- `grep -n "rebuild/" .github/workflows/rewrite-ci.yml` → no matches; the dead lane is gone, not renamed.
- `node tools/gates/production-delta.mjs` → `production +0/-0`, pass (workflow and tools files are not production surface).

## Review Evidence

- Self-review focus: the re-anchor is the risky half. The regex matches `--workflow-job boundaries --exclude <list>` and **throws** if it finds zero or two commands, so drift between CI and the local runner is a hard error rather than a silent pick. The tests assert the single-command shape and that `check-duplicate-definitions` is now in the local fast set.

## Residual Risk

`rewrite-ci.yml`'s `push` trigger still lists only the dead `main`, so full CI on the rebuild trunk only runs when manually dispatched. This self-heals at the rename and is tracked on the rename checklist, not here.

---

# 中文

## 概要

`boundaries` job 原来有两个 step:baseline 跑完整门清单,rebuild step 排除 `check-duplicate-definitions`。没有任何东西以重写前的 `main` 为 base,所以 baseline 那个 step 从未在任何 PR 上执行——这个排除是一条死车道,静默地把一个红门挡在所有 PR 之外。50 组重复定义已全部清完(#1470 preset+gui、#1473 daemon+kernel),排除已无存在理由。

本 PR 把两个 step 收成一个,只保留真正需要 PR 上下文的 `mergify-queue-metadata-edit-noop` 排除;并给 `tools/run-local-check.mjs` 换锚:它原先靠匹配 step 的**文案标签**(「Run rebuild-compatible boundary gates」)找排除清单,而这次收口恰好删掉了那个标签。现在改为匹配门命令本身,且要求**恰好存在一条**这样的命令——第二条车道永远无法再静默出现。

## 任务与范围

- #1473 body 里明确声明的范围外后续;本 PR 完成 boundaries 收口线。
- 分支:`codex/boundaries-collapse`
- 文件面:`rewrite-ci.yml`、`run-local-check.mjs` 与两个 tools 测试,无其他。

## 治理声明

- 是否触碰 protected surface:**yes** —— `.github/workflows/rewrite-ci.yml` 与 `tools/` 门设施。
- 依据:`dec_A5A21DA3FBA36809287A2A6C6C` CH3 —— 改名之后每个 PR 的 base 都是 `main`,baseline 车道成为活车道;收成单车道并重开这个门是改名的前置 CI 变更。没有削弱任何门:本变更严格地**增加**了 PR 要跑的门(`check-duplicate-definitions`)。生产 delta 见英文段声明行(门要求全文恰好一行)。

## 验证

- 阳性对照,同一个门的两半:在 base `b06ffb2e`(#1473 合入前)上 `npm run check:local` 红停在 `boundaries: check-duplicate-definitions`——证明重开的门真的进了本地集合;rebase 到 `10e7921d`(含 #1473)后同一命令 44.2s 全绿,日志里该门确实执行。
- `node --test tools/run-local-check.test.mjs tools/check-gate-surface.test.mjs` → 16 pass, 0 fail。
- `grep -n "rebuild/" .github/workflows/rewrite-ci.yml` → 无命中;死车道是删掉了,不是改了名。
- `node tools/gates/production-delta.mjs` → `production +0/-0`,pass(workflow 与 tools 文件不计生产面)。

## 审查证据

- 自查重点在换锚这一半:正则匹配 `--workflow-job boundaries --exclude <list>`,找到 0 条或 2 条都**直接 throw**,CI 与本地 runner 的漂移是硬错误而不是静默选边。测试断言单命令形状、以及 `check-duplicate-definitions` 已进本地 fast 集合。

## 残余风险

`rewrite-ci.yml` 的 `push` 触发器仍然只列着死掉的 `main`,rebuild trunk 上的全量 CI 只有手工 dispatch 才跑。这一条在改名时自愈,已在 rename checklist 上,不在本 PR 范围内。
