### PR TITLE
fix(daemon): degrade doc-sync watching to polling when watch registration fails

### DIFF
--- a/packages/daemon/src/doc-sync-watcher.ts
+++ b/packages/daemon/src/doc-sync-watcher.ts
@@ -11,9 +11,10 @@ export interface DocSyncWatcher { readonly wake: (logicalPath?: string) => void;
 type Runner = (action: { readonly kind: "doc-dry-run" | "doc-submit"; readonly paths: readonly string[] }, attribution?: WatchAttribution) => Promise<WriteReceipt>;
 interface ScanRow { readonly path: string; readonly state: "clean" | "eligible" | "blocked" | "deletion" | "conflict"; readonly reason: string | null; readonly candidateBlobSha256: string | null }
 
-export function openDocSyncWatcher(input: { readonly rootDir: string; readonly personId: string; readonly run: Runner; readonly debounceMs?: number; readonly watchFilesystem?: boolean; readonly startupScan?: boolean }): DocSyncWatcher {
+export function openDocSyncWatcher(input: { readonly rootDir: string; readonly personId: string; readonly run: Runner; readonly debounceMs?: number; readonly pollMs?: number; readonly watchFilesystem?: boolean; readonly startupScan?: boolean }): DocSyncWatcher {
   const sessionId = `watch-${randomUUID()}`, debounceMs = input.debounceMs ?? 75, pending = new Set<string>(), observations = new Map<string, { fingerprint: string; count: number }>(), submitted = new Map<string, string>();
-  const metrics = { scans: 0, intents: 0, commits: 0, writes: 0 }, directories = new Map<string, FSWatcher>(); let state: DocSyncWatchStatus["state"] = "active", lastReceipt: DocSyncWatchStatus["lastReceipt"] = null, timer: NodeJS.Timeout | null = null, tail = Promise.resolve();
+  const metrics = { scans: 0, intents: 0, commits: 0, writes: 0 }, directories = new Map<string, FSWatcher>(); let state: DocSyncWatchStatus["state"] = "active", lastReceipt: DocSyncWatchStatus["lastReceipt"] = null, timer: NodeJS.Timeout | null = null, pollTimer: NodeJS.Timeout | null = null, tail = Promise.resolve();
+  const pollMs = input.pollMs ?? 30_000;
   const schedule = () => { if (timer || state === "closed") return; timer = setTimeout(() => { timer = null; enqueue(false); }, debounceMs); };
   const wake = (logicalPath?: string) => { if (state === "closed") return; const normalized = logicalPath && normalize(logicalPath); pending.add(normalized ?? fullScan); schedule(); };
   const enqueue = (drain: boolean) => { tail = tail.then(async () => { do { await scanOnce(); } while (drain && pending.size > 0); }, () => undefined); };
@@ -39,16 +40,22 @@ export function openDocSyncWatcher(input: { readonly rootDir: string; readonly p
   // seen it; an editor save writes a temporary file and renames it over the target, which
   // unlinks the watched inode, so on Linux the second and every later save of the same
   // file is delivered nowhere. Directory inodes survive rename-over.
+  // A directory whose watch registration fails (Linux inotify watch exhaustion throws
+  // ENOSPC/EMFILE here) becomes a silent dead zone: its subtree reports no events and the
+  // "blocked" state below only covers total failure. Instead of tracking which subtrees
+  // are blind, degrade to one periodic full-scan wake — wake() already reconciles every
+  // authored path, so a missed trigger costs latency, never data.
+  const degradeToPolling = (): void => { if (pollTimer || state === "closed") return; pollTimer = setInterval(() => wake(), pollMs); pollTimer.unref?.(); };
   const watchDirectory = (directory: string): void => {
     if (directories.has(directory) || state === "closed" || path.basename(directory) === ".git") return; let watcher: FSWatcher;
     try { watcher = watch(directory, (_event, filename) => { if (filename === null) { wake(); return; } const child = path.join(directory, String(filename));
-      try { if (lstatSync(child).isDirectory()) watchDirectory(child); } catch (error) { consumeKnownError(error); } wake(path.relative(authoredRoot, child)); }); } catch (error) { consumeKnownError(error); return; }
-    watcher.on("error", () => { watcher.close(); directories.delete(directory); wake(); }); directories.set(directory, watcher);
+      try { if (lstatSync(child).isDirectory()) watchDirectory(child); } catch (error) { consumeKnownError(error); } wake(path.relative(authoredRoot, child)); }); } catch (error) { consumeKnownError(error); degradeToPolling(); return; }
+    watcher.on("error", () => { watcher.close(); directories.delete(directory); degradeToPolling(); wake(); }); directories.set(directory, watcher);
     try { for (const entry of readdirSync(directory, { withFileTypes: true })) if (entry.isDirectory()) watchDirectory(path.join(directory, entry.name)); } catch (error) { consumeKnownError(error); } };
   if (input.watchFilesystem !== false) { watchDirectory(authoredRoot); if (directories.size === 0) state = "blocked"; }
   if (input.startupScan !== false) wake();
   return { wake, overflow: () => wake(), flush: async () => { if (timer) { clearTimeout(timer); timer = null; } enqueue(true); await tail; }, status: () => ({ sessionId, personId: input.personId, state, pendingPaths: [...pending].sort(), lastReceipt, metrics: { ...metrics } }),
-    close: async () => { if (state === "closed") return; state = "closed"; if (timer) clearTimeout(timer); timer = null; for (const watcher of directories.values()) watcher.close(); directories.clear(); await tail; } };
+    close: async () => { if (state === "closed") return; state = "closed"; if (timer) clearTimeout(timer); timer = null; if (pollTimer) clearInterval(pollTimer); pollTimer = null; for (const watcher of directories.values()) watcher.close(); directories.clear(); await tail; } };
   function remember(receipt: WriteReceipt): void { const nextAction = receipt.nextAction ?? receipt.detail?.nextAction; lastReceipt = { outcome: receipt.outcome, opId: receipt.opId, ...(receipt.code ? { code: receipt.code } : {}), ...(nextAction ? { nextAction } : {}) }; }
 }
 

--- a/packages/daemon/test/doc-sync-watcher.test.ts
+++ b/packages/daemon/test/doc-sync-watcher.test.ts
@@ -22,6 +22,22 @@ test("watch notifications are hints and two stable fingerprints admit one RepoCe
   } finally { await watcher.close(); }
 });
 
+test("watch registration failure degrades to periodic full-scan polling instead of a silent dead zone", async () => {
+  // Missing authored root makes every watch() registration throw, the same failure shape
+  // as Linux inotify watch exhaustion (ENOSPC). The watcher must keep reconciling via
+  // periodic wakes rather than silently reporting nothing.
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-watch-degrade-")); let scans = 0;
+  const watcher = openDocSyncWatcher({ rootDir, personId: "person-owner", startupScan: false, debounceMs: 1, pollMs: 5,
+    run: async () => { scans += 1; return scan("f".repeat(40), []); } });
+  try {
+    assert.equal(watcher.status().state, "blocked");
+    await new Promise((resolve) => setTimeout(resolve, 60)); await watcher.flush();
+    assert.ok(scans >= 1, `expected the poll fallback to trigger at least one scan, saw ${scans}`);
+    const settled = scans; await watcher.close(); await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(scans, settled, "closed watcher must stop polling");
+  } finally { await watcher.close(); rmSync(rootDir, { recursive: true, force: true }); }
+});
+
 test("temporary and unnormalizable filesystem hints fall back to a full scan", async () => {
   const actions: Array<{ kind: string; paths: readonly string[] }> = [], canonical = "context/notes.md", fingerprint = "d".repeat(64);
   const watcher = openDocSyncWatcher({ rootDir: process.cwd(), personId: "person-owner", watchFilesystem: false, startupScan: false, debounceMs: 1,


### PR DESCRIPTION
# English

## Summary

A directory whose watch registration throws — the failure shape of Linux inotify watch exhaustion (`ENOSPC`/`EMFILE`) — became a **silent dead zone**: `consumeKnownError` swallowed the throw, the subtree reported no events, and the `blocked` state only covered the case where *zero* watchers registered. On a large authored tree a user could save files forever without doc-sync noticing.

The fix does not track which subtrees are blind. A single registration failure (or a watcher `error` event) arms **one periodic full-scan wake** (`pollMs`, default 30s, unref'd, cleared on close). `wake()` already reconciles every authored path through the doc-scan road, so a missed filesystem trigger costs latency, never data.

## Task And Scope

- Branch: `codex/inotify-degrade`; two files: the watcher and its test.

## Governance Declaration

- Protected surface touched: no.
- Authority: rebuild-line robustness item from the migration stabilization sweep (doc-sync watching must survive a Linux inotify limit).

Production-Delta: +12/-5

## Verification

- Two-sided control on the new test (`watch registration failure degrades to periodic full-scan polling`): against the base watcher it **fails** (0 pass / 1 fail); with the fix it passes (1 pass / 0 fail). The test drives the real failure path — a missing authored root makes every `watch()` registration throw — and also pins that `close()` stops the polling.
- `node --test packages/daemon/test/doc-sync-watcher.test.ts` → all tests pass.
- `npm run check:local` → exit 0 (53.5s), including the reopened `check-duplicate-definitions`.

## Review Evidence

- Self-review: the poll interval is armed at most once (`if (pollTimer …) return`), unref'd so it never holds the process open, and cleared in `close()`. The degraded path reuses the existing `wake()`/debounce/queue machinery — no second scan pipeline.

## Residual Risk

Polling latency is up to `pollMs` for edits in blind subtrees; healthy subtrees keep event-driven latency. The watcher does not attempt to re-register watches after exhaustion clears — the poll keeps covering; a restart re-attempts registration.

---

# 中文

## 概要

某个目录的 watch 注册一旦抛错——Linux inotify watch 耗尽(`ENOSPC`/`EMFILE`)正是这个形状——就变成**静默死区**:`consumeKnownError` 吞掉异常,该子树不再上报任何事件,而 `blocked` 态只覆盖「零个 watcher 注册成功」的全灭情形。authored 树一大,用户可以一直保存文件而 doc-sync 毫无察觉。

修法不去追踪哪些子树瞎了:任何一次注册失败(或 watcher `error` 事件)就武装**一个周期性全量扫描唤醒**(`pollMs`,默认 30s,unref,close 时清除)。`wake()` 本来就通过 doc-scan 路对账所有 authored 路径,所以丢一次文件系统触发只损失延迟,永不损失数据。

## 任务与范围

- 分支:`codex/inotify-degrade`;两个文件:watcher 与它的测试。

## 治理声明

- 是否触碰 protected surface:no。
- 依据:迁移稳定化清扫中的 rebuild 线健壮性事项(doc-sync 监视必须在 Linux inotify 限额下存活)。生产 delta 见英文段声明行(门要求全文恰好一行)。

## 验证

- 新测试(`watch registration failure degrades to periodic full-scan polling`)双侧对照:对 base watcher **红**(0 pass / 1 fail);带修复绿(1 pass / 0 fail)。测试驱动真实失败路径——authored root 缺失使每次 `watch()` 注册都抛——并钉死 `close()` 停止轮询。
- `node --test packages/daemon/test/doc-sync-watcher.test.ts` → 全部通过。
- `npm run check:local` → exit 0(53.5s),含重开的 `check-duplicate-definitions`。

## 审查证据

- 自查:轮询 interval 至多武装一次(`if (pollTimer …) return`),unref 不阻止进程退出,`close()` 中清除。降级路径复用既有 `wake()`/debounce/队列机制——没有第二条扫描管线。

## 残余风险

盲区子树的编辑延迟上限为 `pollMs`;健康子树保持事件驱动延迟。耗尽解除后不尝试重新注册 watch——轮询持续兜底,重启时重试注册。
