### PR TITLE
chore: retarget the trunk anchors to main after the rename

### DIFF
--- a/.github/workflows/rebuild-gates.yml
+++ b/.github/workflows/rebuild-gates.yml
@@ -4,17 +4,14 @@ on:
   pull_request:
     branches:
       - "main"
-      - "rebuild/**"
     types: [opened, reopened, synchronize, edited]
   pull_request_target:
     branches:
       - "main"
-      - "rebuild/**"
     types: [opened, reopened, synchronize, edited]
   push:
     branches:
       - "main"
-      - "rebuild/main"
 
 permissions:
   contents: read
@@ -98,7 +95,7 @@ jobs:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
         run: |
           if [ -z "$BASE_SHA" ] || ! git cat-file -e "$BASE_SHA^{tree}" 2>/dev/null; then
-            BASE_SHA=$(git rev-parse origin/rebuild/main 2>/dev/null || git rev-parse origin/main)
+            BASE_SHA=$(git rev-parse origin/main)
           fi
           node tools/gates/test-selection.mjs --base "$BASE_SHA"
 
@@ -143,7 +140,7 @@ jobs:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
         run: |
           if [ -z "$BASE_SHA" ] || ! git cat-file -e "$BASE_SHA^{tree}" 2>/dev/null; then
-            BASE_SHA=$(git rev-parse origin/rebuild/main 2>/dev/null || git rev-parse origin/main)
+            BASE_SHA=$(git rev-parse origin/main)
           fi
           node tools/gates/line-budget.mjs --base "$BASE_SHA"
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ installed first.** Paste this to a coding agent working in the repository you
 want to migrate:
 
 > Read `skills/harness-migration/SKILL.md` from
-> https://github.com/FairladyZ625/harness-anything (branch `rebuild/main`) and
+> https://github.com/FairladyZ625/harness-anything and
 > follow it to migrate this project's `harness/` ledger to the current format.
 > Ask me before each decision the skill says to ask about.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -103,7 +103,7 @@ Demo 会构建 CLI、创建一个临时项目、跑通一条真实任务循环�
 
 **这件事不必手工做，也不需要你先装好当前版本。** 把下面这段话交给一个在待迁移仓库里工作的编码 agent：
 
-> 读取 https://github.com/FairladyZ625/harness-anything （分支 `rebuild/main`）的
+> 读取 https://github.com/FairladyZ625/harness-anything 的
 > `skills/harness-migration/SKILL.md`，按它把本项目的 `harness/` 台账迁移到当前格式。
 > skill 里说要问我的每个决定，都先问我。
 

--- a/skills/harness-migration/SKILL.md
+++ b/skills/harness-migration/SKILL.md
@@ -15,14 +15,14 @@ already on the machine — including a running daemon — is left untouched.
 ## Before anything: confirm this is the right document
 
 This skill is versioned in the `harness-anything` repository as
-`skills/harness-migration/SKILL.md` on **`rebuild/main`**, and that branch is the
+`skills/harness-migration/SKILL.md` on **`main`**, and that branch is the
 authority. **Read it from a git ref, never from whatever working tree happens to
 be at hand** — a checkout parked on another branch may not carry this file at
 all, or may carry an older revision, and neither difference is visible once the
 text is in front of you.
 
 ```bash
-git -C <any-checkout-of-harness-anything> show origin/rebuild/main:skills/harness-migration/SKILL.md
+git -C <any-checkout-of-harness-anything> show origin/main:skills/harness-migration/SKILL.md
 ```
 
 A machine may also carry a separately maintained skill with a similar name —
@@ -129,7 +129,7 @@ until they do.
 
 ```bash
 cd "$HARNESS_MIGRATION_WORK"
-git clone --depth 1 --branch rebuild/main https://github.com/FairladyZ625/harness-anything.git ha-src
+git clone --depth 1 https://github.com/FairladyZ625/harness-anything.git ha-src
 cd ha-src
 npm install --no-audit --no-fund
 export HA_ENTRY="$HARNESS_MIGRATION_WORK/ha-src/packages/cli/src/index.ts"

--- a/tools/gates/test/workflow-base-sha.test.mjs
+++ b/tools/gates/test/workflow-base-sha.test.mjs
@@ -6,10 +6,9 @@ import test from "node:test";
 
 const workflowPath = path.join(process.cwd(), ".github/workflows/rebuild-gates.yml");
 
-// The trunk carries two names while the rebuild line is being renamed to main:
-// "rebuild/main" today, "main" after the rename, never both at once in practice.
+// The rename landed: the trunk is "main" and the triggers name only it.
 // Drop the retired name from this list the moment the rename lands.
-const TRUNK_BRANCHES = ['- "main"', '- "rebuild/main"'];
+const TRUNK_BRANCHES = ['- "main"'];
 
 test("push trigger covers only trunk branches — feature branches gate through pull_request runs, whose diff is the full PR; a feature-branch push run would re-evaluate walls against the narrow event.before diff and mint contradictory conclusions on the same head SHA (dec_01KZTQ1KRG17545YMSFKXJGEPN)", () => {
   const workflow = readFileSync(workflowPath, "utf8");
@@ -30,8 +29,8 @@ test("diff-based gates guard BASE_SHA against the zero SHA of a first branch pus
     const runBlock = workflow.slice(Math.max(0, invocation - 400), invocation);
     assert.match(
       runBlock,
-      /git cat-file -e "\$BASE_SHA\^\{tree\}"[\s\S]*git rev-parse origin\/rebuild\/main/u,
-      `${gate} must fall back to origin/rebuild/main when BASE_SHA is unresolvable (github.event.before is the zero SHA on a first branch push)`
+      /git cat-file -e "\$BASE_SHA\^\{tree\}"[\s\S]*git rev-parse origin\/main/u,
+      `${gate} must fall back to origin/main when BASE_SHA is unresolvable (github.event.before is the zero SHA on a first branch push)`
     );
   }
 });


### PR DESCRIPTION
# English

## Summary

The rename landed: `rebuild/main` is now `main`, the old pre-rebuild trunk is archived at `archive/main-prerebuild-da297d68`, and the default branch points at the rebuild line. This PR is the follow-through — the references that would otherwise keep naming a branch that no longer exists. None of them fail loudly; they fail silently, which is why they ship in the same window as the rename.

**Docs.** `skills/harness-migration/SKILL.md` told a cold-start agent to `git clone --branch rebuild/main`, and both READMEs named that branch in the paste-to-an-agent block. The fix is not to rename them to `main` — it is to **delete the qualifier**. The trunk is the default branch now, so the URL resolves on its own, and a redundant branch name is exactly the kind that goes stale again next time. SKILL.md keeps an explicit ref in the two places that earn one: the `git show origin/main:<path>` command, where git syntax requires a ref, and the sentence arguing that a ref rather than a working tree is the authority.

**CI.** `rebuild-gates.yml` listed `rebuild/**` and `rebuild/main` across three trigger blocks and carried a two-armed `BASE_SHA` fallback whose first arm is now dead. Both collapse to `main`. `workflow-base-sha.test.mjs` pins the collapsed shape.

Ordering was load-bearing and is worth recording: this could not merge *before* the rename. While the trunk was still `rebuild/main`, removing `rebuild/**` from the `pull_request` trigger would have silently stopped gating every open PR based on it. Now that the base is `main`, this PR gates itself under both the old and the new trigger list.

## Task And Scope

- Harness task: `task_01KZRMMDWAM9PMG3ECJYQ1KJTE` (W4 production cutover)
- Branch: `codex/rename-prep`; five files, no production code.

## Governance Declaration

- Protected surface touched: **yes** — `.github/workflows/rebuild-gates.yml`. The change is a strict narrowing: trigger branches and a dead fallback arm are removed, no threshold, exclusion, or assertion is weakened.
- Authority: `dec_A5A21DA3FBA36809287A2A6C6C` CH1 (archive the old trunk before replacing it — done, `archive/main-prerebuild-da297d68`, verified to contain old `main` in full including the four commits `archive/main-20260811` did not cover) and CH3 (the rename makes `main` the base for every PR).

Production-Delta: +0/-0

## Verification

- `node --test tools/gates/test/workflow-base-sha.test.mjs` → 2 pass, 0 fail, against the collapsed workflow.
- `grep -rn "rebuild/main"` over the two READMEs, the migration skill, the workflow, and the workflow test → no matches. The one remaining repo-wide reference is `tools/gates/no-swallowed-failure-baseline.mjs`, which cites `rebuild/main@5c9d1f3a` as the commit the baseline was minted at. That is a historical anchor, and `5c9d1f3a` is in fact the merge-base of the old and rebuilt lines — editing it would falsify a record, so it stays.
- `node tools/gates/production-delta.mjs` → `production +0/-0`, pass.
- Cutover itself verified on the remote: `main` → `88caad65`, `protected=true`, default branch `main`, `rebuild/main` returns 404.

## Review Evidence

- The rename sequence was chosen against the ruleset rather than around it. Ruleset 18576233 targets `~DEFAULT_BRANCH` with `deletion` and `non_fast_forward` rules and an **empty bypass list** — no admin override exists. So each destructive step was performed while its branch was not the default: the default moved to `rebuild/main`, `main` was replaced there, the default moved back, and only then was `rebuild/main` deleted. No gate was disabled, softened, or bypassed at any point.

## Residual Risk

The five open Dependabot PRs were cut from the old `main` and still target `main`, whose history is now the rebuild line. Their diffs are meaningless against the new base, so they need `@dependabot recreate` rather than a rebase. Tracked separately; not fixed here.

---

# 中文

## 概要

改名已执行:`rebuild/main` 现在是 `main`,重写前的旧主干归档在 `archive/main-prerebuild-da297d68`,默认分支指向重写线。本 PR 是跟进——那些否则会继续指向一个不存在分支的引用。它们都不会报错,只会静默失灵,所以必须和改名同窗口落地。

**文档。** `skills/harness-migration/SKILL.md` 让冷启动 agent 执行 `git clone --branch rebuild/main`,两个 README 也在「粘给 agent」的那段里点名了该分支。修法不是把它们改成 `main`,而是**把这个限定词删掉**:主干现在就是默认分支,URL 自己解析得到;而一个冗余的分支名,正是下次还会过期的那种东西。SKILL.md 只在两处保留显式 ref——`git show origin/main:<path>` 命令(git 语法要求 ref),以及那句「权威是 ref 而不是手边的工作树」的论证。

**CI。** `rebuild-gates.yml` 在三个触发块里列着 `rebuild/**` 与 `rebuild/main`,还带着一个第一支已死的双支 `BASE_SHA` 回退。两者都收敛到 `main`。`workflow-base-sha.test.mjs` 钉死收敛后的形状。

顺序是承重的,值得记录:本 PR **不能在改名之前**合入。主干还是 `rebuild/main` 时,从 `pull_request` 触发面里删掉 `rebuild/**` 会**静默地**让所有以它为 base 的 PR 失去门禁。现在 base 是 `main`,本 PR 在新旧两份触发清单下都能给自己跑门。

## 任务与范围

- Harness 任务:`task_01KZRMMDWAM9PMG3ECJYQ1KJTE`(W4 生产 cutover)
- 分支:`codex/rename-prep`;五个文件,无生产代码。

## 治理声明

- 是否触碰 protected surface:**yes** —— `.github/workflows/rebuild-gates.yml`。改动是严格收窄:删掉触发分支与一条已死的回退支,没有削弱任何阈值、排除或断言。
- 依据:`dec_A5A21DA3FBA36809287A2A6C6C` CH1(替换前先归档旧主干——已完成,`archive/main-prerebuild-da297d68`,实测完整包含旧 `main`,含 `archive/main-20260811` 未覆盖的那 4 个提交)与 CH3(改名后每个 PR 的 base 都是 `main`)。生产 delta 见英文段声明行(门要求全文恰好一行)。

## 验证

- `node --test tools/gates/test/workflow-base-sha.test.mjs` → 2 pass, 0 fail(对收敛后的 workflow)。
- 对两个 README、迁移 skill、workflow 及其测试 `grep -rn "rebuild/main"` → 无命中。全仓仅剩的一处是 `tools/gates/no-swallowed-failure-baseline.mjs`,它把 `rebuild/main@5c9d1f3a` 作为基线铸造点引用。那是历史锚,而 `5c9d1f3a` 恰恰就是新旧两线的 merge-base——改它等于篡改记录,保留。
- `node tools/gates/production-delta.mjs` → `production +0/-0`,pass。
- 切换本身在远端核验:`main` → `88caad65`、`protected=true`、默认分支 `main`、`rebuild/main` 返回 404。

## 审查证据

- 改名顺序是**顺着 ruleset 设计的,不是绕过它**。Ruleset 18576233 作用于 `~DEFAULT_BRANCH`,规则含 `deletion` 与 `non_fast_forward`,且 **bypass 名单为空**——不存在管理员豁免。因此每个破坏性步骤都发生在「该分支不是 default」的窗口:default 先移到 `rebuild/main`,在那个窗口替换 `main`,default 移回,最后才删 `rebuild/main`。全程没有关闭、削弱或绕过任何门。

## 残余风险

5 个在飞的 Dependabot PR 是从旧 `main` 切出来的,且仍以 `main` 为 base,而 `main` 的历史现在是重写线。它们对新 base 的 diff 没有意义,需要 `@dependabot recreate` 而不是 rebase。另行跟踪,不在本 PR 修。
