### PR TITLE
feat(daemon): record repo-scoped requests to a rolling local log

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -13,6 +13,7 @@ export { jsonRpcMethodContracts } from "./protocol/daemon-protocol.contract.ts";
 export { currentDaemonProtocolVersion } from "./protocol/version.ts";
 export type { JsonObject, JsonRpcRequest, JsonRpcResponse, JsonValue } from "./protocol/json-rpc-types.ts";
 export { openRepoCell, type RepoCell, type RepoCellBinding, type RepoCellStatus, type RepoTaskAction } from "./repo-cell.ts";
+export { DAEMON_REQUEST_LOG_SCHEMA, daemonRequestLogPath, openDaemonRequestLog, type DaemonRequestLog, type DaemonRequestLogEntry, type DaemonRequestLogRecord } from "./request-log.ts";
 export { daemonPidPath, readDaemonPid, startDaemon, type RunningDaemon } from "./runtime.ts";
 export type { DaemonAuthenticationContext, DaemonTransportKind } from "./transport/auth-context.ts";
 export { createJsonLineFrameReader, encodeJsonLineFrame, isJsonRpcRequestLike } from "./transport/frame-codec.ts";

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -1,21 +1,30 @@
+import { randomUUID } from "node:crypto";
+import { consumeKnownError } from "../../../kernel/src/index.ts";
 import type { DaemonHost } from "../daemon-host.ts";
+import type { DaemonRequestLogEntry } from "../request-log.ts";
 import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
-import { actionForDaemonMethod, daemonGuiStreamFacets, daemonProtocolError, isDaemonGuiActionMethod, isDaemonGuiReadMethod, isDaemonGuiStreamMethod, jsonRpcMethodContracts, parseDaemonRpcParams } from "./daemon-protocol.contract.ts";
+import { actionForDaemonMethod, commandClassForAction, daemonGuiStreamFacets, daemonProtocolError, isDaemonGuiActionMethod, isDaemonGuiReadMethod, isDaemonGuiStreamMethod, jsonRpcMethodContracts, parseDaemonRpcParams } from "./daemon-protocol.contract.ts";
 import { parseDaemonGuiActionResult, parseDaemonGuiReadResult, parseDaemonGuiStreamResult } from "./gui-result-validation.ts";
-import { type JsonObject, type JsonRpcId, type JsonRpcRequest, type JsonRpcResponse } from "./json-rpc-types.ts";
+import { isJsonObject, type JsonObject, type JsonRpcId, type JsonRpcRequest, type JsonRpcResponse } from "./json-rpc-types.ts";
 import { currentDaemonProtocolVersion } from "./version.ts";
 export interface JsonRpcProtocolServer { readonly handle: (message: JsonRpcRequest | JsonRpcRequest[]) => Promise<JsonRpcResponse | JsonRpcResponse[] | undefined>; readonly close: () => void }
-export function createJsonRpcProtocolServer(options: { readonly host: DaemonHost; readonly authContext: DaemonAuthenticationContext; readonly emit: (method: string, params: JsonObject) => Promise<void> }): JsonRpcProtocolServer {
+interface ObservedRequest { readonly repoId: string; readonly command: string; readonly commandClass: string | null; readonly executor: DaemonRequestLogEntry["executor"] }
+export function createJsonRpcProtocolServer(options: { readonly host: DaemonHost; readonly authContext: DaemonAuthenticationContext; readonly emit: (method: string, params: JsonObject) => Promise<void>; readonly recordRequest?: (entry: DaemonRequestLogEntry) => void }): JsonRpcProtocolServer {
   let handshaken = false;
+  // Every client — CLI, GUI, fleet — converges on this server, and every dispatched response is
+  // built by the reply() below, so one hook there observes the whole request surface.
+  const connectionId = randomUUID();
   type Subscription = { readonly initial: unknown; readonly next: () => Promise<JsonObject | null>; readonly detach: () => void }; const subscriptions = new Set<Subscription>();
   const one = async (request: JsonRpcRequest): Promise<JsonRpcResponse | undefined> => {
-    const id = request.id ?? null;
+    const id = request.id ?? null, startedAt = Date.now();
+    let observed: ObservedRequest = { repoId: "", command: typeof request.method === "string" ? request.method : "", commandClass: null, executor: null };
     if (request.jsonrpc !== "2.0" || typeof request.method !== "string") return rpcError(id, -32600, "Invalid Request");
     if (!jsonRpcMethodContracts.some((entry) => entry.method === request.method)) return rpcError(id, -32601, "Method not found");
-    const reply = (result: JsonObject): JsonRpcResponse | undefined => request.id === undefined ? undefined : { jsonrpc: "2.0", id, result };
+    const reply = (result: JsonObject): JsonRpcResponse | undefined => { record(request.method, observed, result, Date.now() - startedAt); return request.id === undefined ? undefined : { jsonrpc: "2.0", id, result }; };
     const parsed = parseDaemonRpcParams(request.method, request.params);
     if (!parsed.ok) return reply(daemonProtocolError(request.method, "invalid_request", parsed.errors.join("; ")) as unknown as JsonObject);
     const params = parsed.params;
+    observed = { ...observed, repoId: repoIdFromParams(params) };
     if (request.method === "protocol.hello") {
       if (params.protocolVersion !== currentDaemonProtocolVersion) return reply(daemonProtocolError("protocol.hello", "incompatible_protocol_version", "Use the daemon protocol version reported by this binary.") as unknown as JsonObject);
       handshaken = true; return reply({ ok: true, protocolVersion: currentDaemonProtocolVersion, methods: jsonRpcMethodContracts.map((entry) => entry.method) });
@@ -45,6 +54,7 @@ export function createJsonRpcProtocolServer(options: { readonly host: DaemonHost
     if (request.method === "repo.agentRuntime.spawn") { const repo = (params.repo as JsonObject).repoId as string; try { return reply(parseDaemonGuiActionResult(request.method, await options.host.spawnRuntime(repo, params.payload as JsonObject, options.authContext)) as unknown as JsonObject); } catch (error) { return reply(daemonProtocolError(request.method, rpcServerErrorCode(error), error instanceof Error ? error.message : String(error)) as unknown as JsonObject); } }
     if (request.method === "repo.gui.catalog.reread" || request.method.startsWith("repo.terminal.")) { const repo = (params.repo as JsonObject).repoId as string; try { return reply(parseDaemonGuiActionResult(request.method as import("./daemon-protocol.contract.ts").DaemonGuiActionMethod, await options.host.terminalAction(repo, request.method, params.payload as JsonObject, options.authContext)) as unknown as JsonObject); } catch (error) { return reply(daemonProtocolError(request.method, rpcServerErrorCode(error), error instanceof Error ? error.message : String(error)) as unknown as JsonObject); } }
     const repo = (params.repo as JsonObject).repoId as string; let action: JsonObject & { readonly kind: string }; try { action = actionForDaemonMethod(request.method, params.payload as JsonObject); } catch (error) { return reply(daemonProtocolError(request.method, rpcServerErrorCode(error), error instanceof Error ? error.message : String(error)) as unknown as JsonObject); }
+    observed = { ...observed, command: action.kind, commandClass: commandClassOrNull(action.kind), executor: declaredExecutorOrNull(action) };
     if (action.kind === "preset-run-start" || action.kind === "preset-run-status") return reply(await options.host.presetRun(repo, action, options.authContext) as unknown as JsonObject);
     const receipt = await options.host.run(repo, action, options.authContext);
     const ok = receipt.outcome === "applied" || receipt.outcome === "pending";
@@ -54,6 +64,34 @@ export function createJsonRpcProtocolServer(options: { readonly host: DaemonHost
   return { handle: async (message) => Array.isArray(message)
     ? (await Promise.all(message.map(one))).filter((item): item is JsonRpcResponse => item !== undefined) : one(message), close: () => { for (const subscription of subscriptions) subscription.detach(); subscriptions.clear(); } };
   async function pump(subscription: Subscription, eventMethod: string): Promise<void> { try { for (;;) { const event = await subscription.next(); if (!event) break; await options.emit(eventMethod, event); } } finally { subscription.detach(); subscriptions.delete(subscription); } }
+  // Repo-scoped by design: the log lives in the repository's local root, so a request that binds no
+  // repository (protocol.hello, daemon.status, registry admin) has nowhere to be filed and is skipped.
+  function record(method: string, observed: ObservedRequest, result: JsonObject, durationMs: number): void {
+    if (!options.recordRequest || !observed.repoId) return;
+    options.recordRequest({ method, repoId: observed.repoId, command: observed.command, commandClass: observed.commandClass,
+      connectionId, auth: options.authContext, executor: observed.executor, ok: result.ok === true,
+      outcome: typeof result.outcome === "string" ? result.outcome : null, code: resultErrorCode(result),
+      opId: typeof result.opId === "string" ? result.opId : null, durationMs });
+  }
+}
+function repoIdFromParams(params: JsonObject): string {
+  const repo = params.repo;
+  return isJsonObject(repo) && typeof repo.repoId === "string" ? repo.repoId : "";
+}
+// The executor rides on the resolved action, which is where the daemon reads it for attribution:
+// repo.task.run carries it inside payload.action, every other method merges payload into the action.
+function declaredExecutorOrNull(action: JsonObject): DaemonRequestLogEntry["executor"] {
+  const executor = action.executor;
+  return isJsonObject(executor) && executor.kind === "agent" && typeof executor.id === "string" ? { kind: "agent", id: executor.id } : null;
+}
+function commandClassOrNull(kind: string): string | null {
+  // An action the contract cannot classify is still worth recording under its kind alone.
+  try { return commandClassForAction(kind); } catch (error) { consumeKnownError(error); return null; }
+}
+function resultErrorCode(result: JsonObject): string | null {
+  if (typeof result.code === "string") return result.code;
+  const error = result.error;
+  return isJsonObject(error) && typeof error.code === "string" ? error.code : null;
 }
 function rpcError(id: JsonRpcId, errorCode: number, message: string): JsonRpcResponse { return { jsonrpc: "2.0", id, error: { code: errorCode, message } }; }
 function rpcServerErrorCode(error: unknown): string { return typeof error === "object" && error !== null && "code" in error && typeof error.code === "string" ? error.code : "bootstrap_failed"; }

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -1,14 +1,13 @@
 import { randomUUID } from "node:crypto";
-import { consumeKnownError } from "../../../kernel/src/index.ts";
 import type { DaemonHost } from "../daemon-host.ts";
 import type { DaemonRequestLogEntry } from "../request-log.ts";
 import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
-import { actionForDaemonMethod, commandClassForAction, daemonGuiStreamFacets, daemonProtocolError, isDaemonGuiActionMethod, isDaemonGuiReadMethod, isDaemonGuiStreamMethod, jsonRpcMethodContracts, parseDaemonRpcParams } from "./daemon-protocol.contract.ts";
+import { actionForDaemonMethod, daemonGuiStreamFacets, daemonProtocolError, isDaemonGuiActionMethod, isDaemonGuiReadMethod, isDaemonGuiStreamMethod, jsonRpcMethodContracts, parseDaemonRpcParams } from "./daemon-protocol.contract.ts";
 import { parseDaemonGuiActionResult, parseDaemonGuiReadResult, parseDaemonGuiStreamResult } from "./gui-result-validation.ts";
 import { isJsonObject, type JsonObject, type JsonRpcId, type JsonRpcRequest, type JsonRpcResponse } from "./json-rpc-types.ts";
 import { currentDaemonProtocolVersion } from "./version.ts";
 export interface JsonRpcProtocolServer { readonly handle: (message: JsonRpcRequest | JsonRpcRequest[]) => Promise<JsonRpcResponse | JsonRpcResponse[] | undefined>; readonly close: () => void }
-interface ObservedRequest { readonly repoId: string; readonly command: string; readonly commandClass: string | null; readonly executor: DaemonRequestLogEntry["executor"] }
+interface ObservedRequest { readonly repoId: string; readonly command: string; readonly executor: DaemonRequestLogEntry["executor"] }
 export function createJsonRpcProtocolServer(options: { readonly host: DaemonHost; readonly authContext: DaemonAuthenticationContext; readonly emit: (method: string, params: JsonObject) => Promise<void>; readonly recordRequest?: (entry: DaemonRequestLogEntry) => void }): JsonRpcProtocolServer {
   let handshaken = false;
   // Every client — CLI, GUI, fleet — converges on this server, and every dispatched response is
@@ -17,7 +16,7 @@ export function createJsonRpcProtocolServer(options: { readonly host: DaemonHost
   type Subscription = { readonly initial: unknown; readonly next: () => Promise<JsonObject | null>; readonly detach: () => void }; const subscriptions = new Set<Subscription>();
   const one = async (request: JsonRpcRequest): Promise<JsonRpcResponse | undefined> => {
     const id = request.id ?? null, startedAt = Date.now();
-    let observed: ObservedRequest = { repoId: "", command: typeof request.method === "string" ? request.method : "", commandClass: null, executor: null };
+    let observed: ObservedRequest = { repoId: "", command: typeof request.method === "string" ? request.method : "", executor: null };
     if (request.jsonrpc !== "2.0" || typeof request.method !== "string") return rpcError(id, -32600, "Invalid Request");
     if (!jsonRpcMethodContracts.some((entry) => entry.method === request.method)) return rpcError(id, -32601, "Method not found");
     const reply = (result: JsonObject): JsonRpcResponse | undefined => { record(request.method, observed, result, Date.now() - startedAt); return request.id === undefined ? undefined : { jsonrpc: "2.0", id, result }; };
@@ -54,7 +53,7 @@ export function createJsonRpcProtocolServer(options: { readonly host: DaemonHost
     if (request.method === "repo.agentRuntime.spawn") { const repo = (params.repo as JsonObject).repoId as string; try { return reply(parseDaemonGuiActionResult(request.method, await options.host.spawnRuntime(repo, params.payload as JsonObject, options.authContext)) as unknown as JsonObject); } catch (error) { return reply(daemonProtocolError(request.method, rpcServerErrorCode(error), error instanceof Error ? error.message : String(error)) as unknown as JsonObject); } }
     if (request.method === "repo.gui.catalog.reread" || request.method.startsWith("repo.terminal.")) { const repo = (params.repo as JsonObject).repoId as string; try { return reply(parseDaemonGuiActionResult(request.method as import("./daemon-protocol.contract.ts").DaemonGuiActionMethod, await options.host.terminalAction(repo, request.method, params.payload as JsonObject, options.authContext)) as unknown as JsonObject); } catch (error) { return reply(daemonProtocolError(request.method, rpcServerErrorCode(error), error instanceof Error ? error.message : String(error)) as unknown as JsonObject); } }
     const repo = (params.repo as JsonObject).repoId as string; let action: JsonObject & { readonly kind: string }; try { action = actionForDaemonMethod(request.method, params.payload as JsonObject); } catch (error) { return reply(daemonProtocolError(request.method, rpcServerErrorCode(error), error instanceof Error ? error.message : String(error)) as unknown as JsonObject); }
-    observed = { ...observed, command: action.kind, commandClass: commandClassOrNull(action.kind), executor: declaredExecutorOrNull(action) };
+    observed = { ...observed, command: action.kind, executor: declaredExecutorOrNull(action) };
     if (action.kind === "preset-run-start" || action.kind === "preset-run-status") return reply(await options.host.presetRun(repo, action, options.authContext) as unknown as JsonObject);
     const receipt = await options.host.run(repo, action, options.authContext);
     const ok = receipt.outcome === "applied" || receipt.outcome === "pending";
@@ -68,7 +67,7 @@ export function createJsonRpcProtocolServer(options: { readonly host: DaemonHost
   // repository (protocol.hello, daemon.status, registry admin) has nowhere to be filed and is skipped.
   function record(method: string, observed: ObservedRequest, result: JsonObject, durationMs: number): void {
     if (!options.recordRequest || !observed.repoId) return;
-    options.recordRequest({ method, repoId: observed.repoId, command: observed.command, commandClass: observed.commandClass,
+    options.recordRequest({ method, repoId: observed.repoId, command: observed.command,
       connectionId, auth: options.authContext, executor: observed.executor, ok: result.ok === true,
       outcome: typeof result.outcome === "string" ? result.outcome : null, code: resultErrorCode(result),
       opId: typeof result.opId === "string" ? result.opId : null, durationMs });
@@ -83,10 +82,6 @@ function repoIdFromParams(params: JsonObject): string {
 function declaredExecutorOrNull(action: JsonObject): DaemonRequestLogEntry["executor"] {
   const executor = action.executor;
   return isJsonObject(executor) && executor.kind === "agent" && typeof executor.id === "string" ? { kind: "agent", id: executor.id } : null;
-}
-function commandClassOrNull(kind: string): string | null {
-  // An action the contract cannot classify is still worth recording under its kind alone.
-  try { return commandClassForAction(kind); } catch (error) { consumeKnownError(error); return null; }
 }
 function resultErrorCode(result: JsonObject): string | null {
   if (typeof result.code === "string") return result.code;

--- a/packages/daemon/src/request-log.ts
+++ b/packages/daemon/src/request-log.ts
@@ -1,6 +1,10 @@
 import { appendFileSync, mkdirSync, renameSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
 import { consumeKnownError, resolveHarnessLayout } from "../../kernel/src/index.ts";
+// Classification lives here rather than at the dispatch point: the schema registry names the
+// protocol server as a writer, so schema-closure imports it without node_modules and it must stay
+// clear of anything that reaches into the kernel.
+import { commandClassForAction } from "./protocol/daemon-protocol.contract.ts";
 import type { DaemonAuthenticationContext } from "./transport/auth-context.ts";
 
 // Observability, not accountability. Write receipts are the accountability record and live in the
@@ -17,8 +21,7 @@ const defaultKeptFiles = 4;
 export interface DaemonRequestLogEntry {
   readonly method: string;
   readonly repoId: string;
-  readonly command: string | null;
-  readonly commandClass: string | null;
+  readonly command: string;
   readonly connectionId: string;
   readonly auth: DaemonAuthenticationContext;
   readonly executor: { readonly kind: "agent"; readonly id: string } | null;
@@ -118,7 +121,7 @@ function buildRecord(entry: DaemonRequestLogEntry, at: Date): DaemonRequestLogRe
     executor: entry.executor,
     method: entry.method,
     command: entry.command,
-    commandClass: entry.commandClass,
+    commandClass: commandClassOrNull(entry.command),
     repoId: entry.repoId,
     ok: entry.ok,
     outcome: entry.outcome,
@@ -126,6 +129,12 @@ function buildRecord(entry: DaemonRequestLogEntry, at: Date): DaemonRequestLogRe
     opId: entry.opId,
     durationMs: entry.durationMs
   };
+}
+
+// A transport method that resolves to no action kind (protocol.hello and friends) has no command
+// class; the record still carries the method it was reached by.
+function commandClassOrNull(command: string): string | null {
+  try { return commandClassForAction(command); } catch (error) { consumeKnownError(error); return null; }
 }
 
 function rotate(logPath: string, maxBytes: number, keptFiles: number): void {

--- a/packages/daemon/src/request-log.ts
+++ b/packages/daemon/src/request-log.ts
@@ -1,0 +1,169 @@
+import { appendFileSync, mkdirSync, renameSync, rmSync, statSync } from "node:fs";
+import path from "node:path";
+import { consumeKnownError, resolveHarnessLayout } from "../../kernel/src/index.ts";
+import type { DaemonAuthenticationContext } from "./transport/auth-context.ts";
+
+// Observability, not accountability. Write receipts are the accountability record and live in the
+// git ledger; this file answers "which requests reached this daemon" for every client (CLI, GUI,
+// future remote) at the one place they all converge. It is local-only, rolls over, and never
+// carries request payloads.
+export const DAEMON_REQUEST_LOG_SCHEMA = Object.freeze({ id: "daemon-request-log/v1" });
+
+const requestLogDirName = "requests";
+const requestLogFileName = "requests.jsonl";
+const defaultMaxBytes = 4 * 1024 * 1024;
+const defaultKeptFiles = 4;
+
+export interface DaemonRequestLogEntry {
+  readonly method: string;
+  readonly repoId: string;
+  readonly command: string | null;
+  readonly commandClass: string | null;
+  readonly connectionId: string;
+  readonly auth: DaemonAuthenticationContext;
+  readonly executor: { readonly kind: "agent"; readonly id: string } | null;
+  readonly ok: boolean;
+  readonly outcome: string | null;
+  readonly code: string | null;
+  readonly opId: string | null;
+  readonly durationMs: number;
+}
+
+export interface DaemonRequestLogRecord {
+  readonly schema: string;
+  readonly at: string;
+  readonly connectionId: string;
+  readonly transport: string;
+  readonly ownerUid: number | null;
+  readonly principalId: string | null;
+  readonly executor: { readonly kind: "agent"; readonly id: string } | null;
+  readonly method: string;
+  readonly command: string | null;
+  readonly commandClass: string | null;
+  readonly repoId: string;
+  readonly ok: boolean;
+  readonly outcome: string | null;
+  readonly code: string | null;
+  readonly opId: string | null;
+  readonly durationMs: number;
+}
+
+export interface DaemonRequestLog {
+  readonly record: (entry: DaemonRequestLogEntry) => void;
+}
+
+export interface DaemonRequestLogOptions {
+  // Repo-scoped by construction: a request that binds no repository has no local root to file under.
+  readonly resolveRootDir: (repoId: string) => string | undefined;
+  readonly maxBytes?: number;
+  readonly keptFiles?: number;
+  readonly now?: () => Date;
+  readonly onFailure?: (error: unknown) => void;
+}
+
+export function daemonRequestLogPath(rootDir: string): string {
+  return path.join(resolveHarnessLayout(rootDir).localRoot, requestLogDirName, requestLogFileName);
+}
+
+export function openDaemonRequestLog(options: DaemonRequestLogOptions): DaemonRequestLog {
+  const maxBytes = options.maxBytes ?? defaultMaxBytes;
+  const keptFiles = options.keptFiles ?? defaultKeptFiles;
+  const now = options.now ?? (() => new Date());
+  // resolveHarnessLayout walks the filesystem for harness.yaml; hold the resolved path per repo so
+  // that cost is paid once instead of on every request.
+  const logPaths = new Map<string, string>();
+  let reportedFailure = false;
+
+  return {
+    record: (entry) => {
+      try {
+        const logPath = resolveLogPath(entry.repoId);
+        if (!logPath) return;
+        mkdirSync(path.dirname(logPath), { recursive: true });
+        rotate(logPath, maxBytes, keptFiles);
+        appendFileSync(logPath, `${JSON.stringify(buildRecord(entry, now()))}\n`, "utf8");
+      } catch (error) {
+        // An observability sink must never fail the request it observes, but a sink that fails
+        // forever in silence is worse than no sink: report the first failure, then stay quiet.
+        consumeKnownError(error);
+        if (reportedFailure) return;
+        reportedFailure = true;
+        (options.onFailure ?? defaultFailureReporter)(error);
+      }
+    }
+  };
+
+  function resolveLogPath(repoId: string): string | undefined {
+    const cached = logPaths.get(repoId);
+    if (cached) return cached;
+    const rootDir = options.resolveRootDir(repoId);
+    if (!rootDir) return undefined;
+    const logPath = daemonRequestLogPath(rootDir);
+    logPaths.set(repoId, logPath);
+    return logPath;
+  }
+}
+
+function buildRecord(entry: DaemonRequestLogEntry, at: Date): DaemonRequestLogRecord {
+  return {
+    schema: DAEMON_REQUEST_LOG_SCHEMA.id,
+    at: at.toISOString(),
+    connectionId: entry.connectionId,
+    transport: entry.auth.transportKind,
+    ownerUid: entry.auth.unixSocketOwnerBoundary?.ownerUid ?? null,
+    // The daemon resolves the principal inside the write binding, which the protocol layer cannot
+    // observe. Fleet assignment ingress carries it on the auth context, so record it where it is
+    // genuinely known and leave it null rather than guessing.
+    principalId: entry.auth.assignmentBinding?.actor.principal.personId ?? null,
+    executor: entry.executor,
+    method: entry.method,
+    command: entry.command,
+    commandClass: entry.commandClass,
+    repoId: entry.repoId,
+    ok: entry.ok,
+    outcome: entry.outcome,
+    code: entry.code,
+    opId: entry.opId,
+    durationMs: entry.durationMs
+  };
+}
+
+function rotate(logPath: string, maxBytes: number, keptFiles: number): void {
+  if (fileSize(logPath) < maxBytes) return;
+  if (keptFiles < 1) {
+    rmSync(logPath, { force: true });
+    return;
+  }
+  rmSync(`${logPath}.${keptFiles}`, { force: true });
+  for (let index = keptFiles - 1; index >= 1; index -= 1) {
+    if (fileExists(`${logPath}.${index}`)) renameSync(`${logPath}.${index}`, `${logPath}.${index + 1}`);
+  }
+  renameSync(logPath, `${logPath}.1`);
+}
+
+function fileSize(filePath: string): number {
+  try {
+    return statSync(filePath).size;
+  } catch (error) {
+    if (isMissingFile(error)) return 0;
+    throw error;
+  }
+}
+
+function fileExists(filePath: string): boolean {
+  try {
+    statSync(filePath);
+    return true;
+  } catch (error) {
+    if (isMissingFile(error)) return false;
+    throw error;
+  }
+}
+
+function isMissingFile(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}
+
+function defaultFailureReporter(error: unknown): void {
+  process.stderr.write(`harness daemon: request log disabled after write failure: ${error instanceof Error ? error.message : String(error)}\n`);
+}

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -3,13 +3,16 @@ import path from "node:path";
 import { localUserDaemonEndpoint } from "./client/local-daemon-target.ts";
 import { openDaemonHost } from "./daemon-host.ts";
 import { createJsonRpcProtocolServer } from "./protocol/json-rpc-server.ts";
+import { openDaemonRequestLog } from "./request-log.ts";
 import { createUnixSocketTransportServer } from "./transport/unix-socket.ts";
 
 export interface RunningDaemon { readonly endpoint: string; readonly stop: () => Promise<void> }
 export async function startDaemon(input: { readonly daemonId: string; readonly userRoot: string }): Promise<RunningDaemon> {
   const endpoint = localUserDaemonEndpoint(input.userRoot, input.daemonId), host = await openDaemonHost({ ...input, endpoint });
+  // One sink for the daemon; the protocol server is created per connection and reports into it.
+  const requestLog = openDaemonRequestLog({ resolveRootDir: (repoId) => host.status().repos.find((repo) => repo.repoId === repoId)?.rootDir });
   const transport = createUnixSocketTransportServer({ daemonId: input.daemonId, socketPath: endpoint,
-    createProtocolServer: (authContext, emit) => createJsonRpcProtocolServer({ host, authContext, emit }) });
+    createProtocolServer: (authContext, emit) => createJsonRpcProtocolServer({ host, authContext, emit, recordRequest: requestLog.record }) });
   try { await transport.start(); }
   catch (error) { await host.close(); throw error; }
   const pidPath = daemonPidPath(input.userRoot, input.daemonId);

--- a/packages/daemon/test/request-log.test.ts
+++ b/packages/daemon/test/request-log.test.ts
@@ -1,0 +1,145 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import type { DaemonHost } from "../src/daemon-host.ts";
+import { createJsonRpcProtocolServer } from "../src/protocol/json-rpc-server.ts";
+import { currentDaemonProtocolVersion } from "../src/protocol/version.ts";
+import { daemonRequestLogPath, openDaemonRequestLog, type DaemonRequestLogEntry, type DaemonRequestLogRecord } from "../src/request-log.ts";
+
+function tempRoot(): string {
+  return mkdtempSync(path.join(os.tmpdir(), "harness-request-log-"));
+}
+
+function stubHost(rootDir: string): DaemonHost {
+  return {
+    run: async () => ({ outcome: "applied" as const, opId: "op_test_0001", revision: 7 }),
+    status: () => ({ daemonId: "test-daemon", pid: 1, repos: [{ repoId: "logged", rootDir, state: "attached" as const, generation: 1, queueDepth: 0, lastError: null, recoveryMs: 0 }] })
+  } as unknown as DaemonHost;
+}
+
+async function handshake(server: ReturnType<typeof createJsonRpcProtocolServer>): Promise<void> {
+  await server.handle({ jsonrpc: "2.0", id: 1, method: "protocol.hello", params: { protocolVersion: currentDaemonProtocolVersion } });
+}
+
+function readRecords(rootDir: string): readonly DaemonRequestLogRecord[] {
+  return readFileSync(daemonRequestLogPath(rootDir), "utf8").split("\n").filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as DaemonRequestLogRecord);
+}
+
+function openServerWithLog(rootDir: string, host: DaemonHost = stubHost(rootDir)) {
+  const log = openDaemonRequestLog({ resolveRootDir: (repoId) => host.status().repos.find((repo) => repo.repoId === repoId)?.rootDir });
+  return createJsonRpcProtocolServer({ host, authContext: { transportKind: "unix-socket", unixSocketOwnerBoundary: { ownerUid: 501, source: "unix-socket-filesystem-owner-boundary" } }, emit: async () => undefined, recordRequest: log.record });
+}
+
+test("a repo-scoped read request is recorded in the repository local root", async () => {
+  const rootDir = tempRoot(), server = openServerWithLog(rootDir);
+  await handshake(server);
+  await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.run", params: { repo: { repoId: "logged" }, payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } } } });
+  server.close();
+
+  const records = readRecords(rootDir);
+  assert.equal(records.length, 1);
+  const [record] = records;
+  assert.equal(record.schema, "daemon-request-log/v1");
+  assert.equal(record.method, "repo.task.run");
+  // The user-facing command, not just the transport method: this is what "which commands did I run" asks for.
+  assert.equal(record.command, "task-show");
+  assert.equal(record.commandClass, "repo-read");
+  assert.equal(record.repoId, "logged");
+  assert.equal(record.transport, "unix-socket");
+  assert.equal(record.ownerUid, 501);
+  assert.equal(record.opId, "op_test_0001");
+  assert.equal(record.outcome, "applied");
+  assert.equal(typeof record.durationMs, "number");
+  assert.ok(Date.parse(record.at) > 0);
+  // The log is local-only state, never the authored ledger.
+  assert.ok(daemonRequestLogPath(rootDir).startsWith(path.join(rootDir, ".harness")));
+});
+
+test("the declared agent executor is recorded so a request can be attributed to the agent that made it", async () => {
+  const rootDir = tempRoot(), server = openServerWithLog(rootDir);
+  await handshake(server);
+  // The CLI puts the declared executor inside payload.action for repo.task.run; that is the shape
+  // the daemon attributes from, so it is the shape the log has to read.
+  await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.run", params: { repo: { repoId: "logged" }, payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV", executor: { kind: "agent", id: "codex-worker" } } } } });
+  server.close();
+
+  assert.deepEqual(readRecords(rootDir)[0].executor, { kind: "agent", id: "codex-worker" });
+});
+
+test("requests from one connection share a connection id", async () => {
+  const rootDir = tempRoot(), server = openServerWithLog(rootDir);
+  await handshake(server);
+  const payload = { repo: { repoId: "logged" }, payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } } };
+  await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.run", params: payload });
+  await server.handle({ jsonrpc: "2.0", id: 3, method: "repo.task.run", params: payload });
+  server.close();
+
+  const records = readRecords(rootDir);
+  assert.equal(records.length, 2);
+  assert.equal(records[0].connectionId, records[1].connectionId);
+  assert.ok(records[0].connectionId.length > 0);
+});
+
+test("a rejected request is recorded with its error code", async () => {
+  const rootDir = tempRoot(), host = stubHost(rootDir);
+  const rejecting = { ...host, run: async () => ({ outcome: "rejected" as const, opId: "rejected:task-show", code: "repo_unavailable", nextAction: "Attach the repository." }) } as unknown as DaemonHost;
+  const server = openServerWithLog(rootDir, rejecting);
+  await handshake(server);
+  await server.handle({ jsonrpc: "2.0", id: 2, method: "repo.task.run", params: { repo: { repoId: "logged" }, payload: { action: { kind: "task-show", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } } } });
+  server.close();
+
+  const records = readRecords(rootDir);
+  assert.equal(records.length, 1);
+  assert.equal(records[0].ok, false);
+  assert.equal(records[0].code, "repo_unavailable");
+  assert.equal(records[0].outcome, "rejected");
+});
+
+test("a request that binds no repository is not recorded", async () => {
+  const rootDir = tempRoot(), server = openServerWithLog(rootDir);
+  await handshake(server);
+  await server.handle({ jsonrpc: "2.0", id: 2, method: "daemon.status", params: {} });
+  server.close();
+
+  // protocol.hello and daemon.status have no repository whose local root could hold the record.
+  assert.equal(readdirSync(rootDir).length, 0);
+});
+
+test("rotation holds the log to a bounded number of files", () => {
+  const rootDir = tempRoot();
+  const log = openDaemonRequestLog({ resolveRootDir: () => rootDir, maxBytes: 512, keptFiles: 2 });
+  for (let index = 0; index < 400; index += 1) log.record(entry({ opId: `op_${index}` }));
+
+  const logDir = path.dirname(daemonRequestLogPath(rootDir)), files = readdirSync(logDir).sort();
+  assert.deepEqual(files, ["requests.jsonl", "requests.jsonl.1", "requests.jsonl.2"]);
+  // The ceiling is the point: without it an always-on request log is an unbounded disk write.
+  for (const file of files) assert.ok(readFileSync(path.join(logDir, file), "utf8").length < 512 + 1024);
+  // The newest record survives rotation; the oldest is the one that was dropped.
+  const live = readRecords(rootDir);
+  assert.equal(live.at(-1)?.opId, "op_399");
+});
+
+test("a sink that cannot write neither throws nor keeps reporting", () => {
+  const rootDir = tempRoot();
+  // A file where the log directory must be: mkdir fails for every record.
+  mkdirSync(path.join(rootDir, ".harness"), { recursive: true });
+  writeFileSync(path.join(rootDir, ".harness", "requests"), "not a directory", "utf8");
+  const failures: unknown[] = [];
+  const log = openDaemonRequestLog({ resolveRootDir: () => rootDir, onFailure: (error) => failures.push(error) });
+
+  assert.doesNotThrow(() => { log.record(entry({})); log.record(entry({})); log.record(entry({})); });
+  // Reported once, then silent: an observability sink must not become a log spammer either.
+  assert.equal(failures.length, 1);
+});
+
+function entry(overrides: Partial<DaemonRequestLogEntry>): DaemonRequestLogEntry {
+  return {
+    method: "repo.task.run", repoId: "logged", command: "task-show", commandClass: "repo-read",
+    connectionId: "connection-1", auth: { transportKind: "unix-socket" }, executor: null,
+    ok: true, outcome: "applied", code: null, opId: "op_test", durationMs: 1, ...overrides
+  };
+}

--- a/packages/daemon/test/request-log.test.ts
+++ b/packages/daemon/test/request-log.test.ts
@@ -138,7 +138,7 @@ test("a sink that cannot write neither throws nor keeps reporting", () => {
 
 function entry(overrides: Partial<DaemonRequestLogEntry>): DaemonRequestLogEntry {
   return {
-    method: "repo.task.run", repoId: "logged", command: "task-show", commandClass: "repo-read",
+    method: "repo.task.run", repoId: "logged", command: "task-show",
     connectionId: "connection-1", auth: { transportKind: "unix-socket" }, executor: null,
     ok: true, outcome: "applied", code: null, opId: "op_test", durationMs: 1, ...overrides
   };

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -39,6 +39,7 @@
     "packages/daemon/src/fleet/replica-cut-store.ts",
     "packages/daemon/src/repo-bootstrap.ts",
     "packages/daemon/src/repo-cell.ts",
+    "packages/daemon/src/request-log.ts",
     "packages/daemon/src/runtime.ts",
     "packages/daemon/src/transport/unix-socket.ts",
     "packages/kernel/src/daemon/registry.ts",


### PR DESCRIPTION
# English

## Summary

Write commands have always left a trace — every one is a ledger event with `opId`, dual-axis attribution, and a commit sha. Read commands left none: they returned a receipt and vanished. So "which commands did I run" was answerable for a fraction of them, and only for the fraction that changed something.

This adds a request log at the daemon's single dispatch point. Every repo-scoped request — read and write, from the CLI, the GUI, or a future remote client — appends one line to `<repo>/.harness/requests/requests.jsonl`.

**The record point is the daemon, and that is the deliberate difference from the previous generation.** The archive line recorded on the CLI side (`packages/cli/src/cli/command-event-policy.ts`), which made GUI actions invisible, because the GUI speaks to the daemon and never goes through the CLI. In the rebuilt line every client converges on one dispatcher — `one()` inside `createJsonRpcProtocolServer` — so one record point covers all of them. There is no direct or in-process mode to miss: `HARNESS_DAEMON_MODE` does not exist anywhere in `packages/*/src`; it is archive-line vocabulary that survives only in local agent docs. Every CLI path terminates at `net.createConnection` in `local-json-rpc-client.ts`.

**Two kinds of record, kept apart on purpose.** Writes are *accountability*: they belong in the git ledger, permanently, with principal and executor. Requests are *observability*: they belong in `localRoot`, ungitted and rolled. Feeding high-frequency reads into the git ledger would undo the sharding work that just landed, which existed precisely because the tree grows with history. This PR touches no write semantics.

## Task And Scope

- Harness task: `task_01M01MXGK7MR5SCV391KKZ6F2M` (session/context capture)
- Branch: `codex/request-log`; seven files.

## Governance Declaration

- Protected surface touched: **no**. No workflow, gate threshold, exclusion list, assertion, or allowlist entry was modified. `tools/write-road-registry.json` gained one entry, which is that gate's **declaration** channel — the mechanism by which a new physical write sink is registered, not an exemption from it.
- Authority: adjudicated directly by the repository owner — "都要的,并进去然后 cutover 后开始派工实现", answering "每一次的命令调用都被存储的那个东西还有没有在存方便查". Tracked on `task_01M01MXGK7MR5SCV391KKZ6F2M`.

Production-Delta: +220/-5

## Verification

- `npm run check:local` → `Local check passed (fast tier) in 35.6s`, re-run by the reviewer rather than taken on report. New sink tests plus protocol contract tests: **52/52**.
- `node tools/gates/line-budget.mjs --base main` → pass (not covered by `check:local`).
- **Live, against an isolated daemon** (its own user root and daemon id; production daemon pid 16955 never touched):

  ```
  task-list      repo-read   ok=True   opId=op_3a108277…    4ms  exec=-
  task-create    repo-write  ok=True   opId=op_ad6ab57f…  528ms  exec=-
  task-list      repo-read   ok=True   opId=op_3136e701…    5ms  exec=codex-worker
  ```

  Reads are recorded — the actual gap — with agent attribution carried through `HARNESS_ACTOR`, and a read costs 4–5 ms *with* logging enabled.
- Rotation verified at the sink (maxBytes 512, keptFiles 2, 400 records): files settle at exactly `requests.jsonl`, `.1`, `.2`; the newest record survives and the oldest is dropped. 20 MiB of live traffic was **not** driven; rotation is exercised through the same `openDaemonRequestLog` path production uses.

## Review Evidence

**The first CI red, and how the diagnosis was corrected.** `schema-closure` failed on this branch with `Cannot find package 'effect' imported from packages/kernel/src/entity/session.ts`, green on `main` and green locally. That job deliberately runs on a **bare checkout** — 9 of the 13 jobs in `rebuild-gates.yml` have no `npm ci`, and the gate `await import()`s every module a contract registry names, so every registry-referenced module must load without `node_modules`.

The first diagnosis blamed the new `DAEMON_REQUEST_LOG_SCHEMA` export dragging `request-log.ts` into the traversal, and proposed splitting a contract module. **It was wrong on both counts, and the evidence that produced it was a broken instrument** — a regex import-graph tracer that counted type-only imports and string content as edges. It was thrown away rather than quoted.

A real bare-checkout harness (tree copied outside the repository, no `node_modules` up-tree) reproduced the CI failure byte-identically and isolated it:

```
packages/kernel/src/layout/index.ts        bare-import OK
packages/kernel/src/error-consumption.ts   bare-import OK
packages/daemon/src/request-log.ts         bare-import OK
packages/kernel/src/index.ts  (control)    FAIL: Cannot find package 'effect'
```

`DAEMON_REQUEST_LOG_SCHEMA` is referenced by no contract declaration, so `request-log.ts` was never in the traversal at all — `json-rpc-server.ts` imports it only as `import type`, erased at runtime. The real trigger is that `json-rpc-server.ts` has long been a registry-referenced `writer:`, and this branch added one import of the **kernel barrel** to it. The barrel reaches `effect`; the specific modules do not.

**The standing tension this exposed, and why the fix is a deletion.** `no-restricted-imports` requires importing the kernel through its public barrel rather than deep `src` paths — but the barrel is exactly what breaks a bare checkout. Every registry-referenced module is caught between the two rules. Rather than route around either gate, the work moved: `commandClass` is now computed in `request-log.ts` (the sink, which loads the kernel through the barrel legitimately and is not registry-referenced), so `json-rpc-server.ts` imports **nothing** from the kernel. No contract module was added — that would have introduced a module, parser, writer, error type, and negative fixture to fix a file that was never loaded. The record shape is unchanged.

**The invariant is self-enforcing.** Re-adding a kernel-barrel import to `json-rpc-server.ts` fails `schema-closure` on the bare CI job. No new test is needed to hold it.

- The premises were verified before building rather than assumed, and one needed correcting. `.harness/generated/runtime-events/` holds 1,303 residual jsonl files and one received an append *while this work was underway*, even though no source in the rebuilt tree produces the `runtime-event/v2` schema. The implementer flagged it as an unattributed writer rather than explaining it away. It was then traced to the launchd agent `com.harness-anything.coldstart-v1`, which runs a benchmark script daily at 09:15 — attributable, not a ledger-integrity problem. The new sink deliberately does **not** reuse that directory name, so residue and new data stay distinguishable.
- Two defects were caught by the implementer's own tests rather than by inspection: the executor lives at `payload.action.executor`, not `payload.executor` (which param validation rejects outright); and requests that fail param validation are never recorded, because no `repoId` is trustworthy yet.
- `appendFileSync` is deliberate, not an oversight. A buffered stream loses exactly the last records — the ones you want after a daemon crash. The live timings above are the cost measurement.
- `test:integration` was additionally run: 368/370. Both failures are **contention, not regression** — stashing the diff in the same tree produced a *different* failure, and both pass in isolation with the changes applied, including the p50 latency test, which was checked specifically because a synchronous write was added. A heavy worker was running on the machine at the time.

## Residual Risk

- **`principalId` is `null` for local requests, and was left that way rather than guessed.** The daemon resolves the principal inside `binding()` in daemon-host, invisible to the protocol layer, and `WriteReceipt` does not carry it; plumbing it out would change the write path's return shape, which this task forbids. `ownerUid` — what the principal is *derived from* — is recorded instead, and `principalId` is populated only for fleet-assignment ingress where `authContext.assignmentBinding.actor` genuinely has it. The agent axis is fully recorded. A `--person` filter cannot be offered until this gap closes.
- **The query surface is proposed, not built.** `ha request list [--limit] [--command <kind>] [--class read|write] [--agent <id>] [--failed] [--since] [--json]` — domain-verb, matching `task list` / `decision list`. Wiring is four touches: a command descriptor, a read-side dispatch branch, a parser, and a result schema; the reader must span rotated files. New CLI command surface requires the repository owner's adjudication, so it is deliberately left for a follow-up rather than smuggled in here.
- **Client-local commands are not recorded, and no second record point was added.** `ha daemon start/stop` short-circuit in `packages/cli/src/index.ts` and never reach the daemon; `ha daemon status` reaches it but binds no repo. A CLI-side sink would fragment the record.
- `tools/gates/no-swallowed-failure-baseline.mjs:7` still references the deleted `packages/cli/src/cli/command-runtime-events.ts` — a stale baseline entry, noticed here and left for a separate cleanup.
- **`DAEMON_REQUEST_LOG_SCHEMA` is an exported constant with no registered contract.** That is fine while nothing reads the log. The moment `ha request list` exists, its result schema wants registering, `request-log.ts` becomes registry-referenced, and it inherits the barrel-versus-bare-checkout conflict described above. That is the point at which a contract module genuinely earns its place — not before.

---

# 中文

## 概要

写命令一直是留痕的——每一次都是台账事件,带 `opId`、双轴归属、commit sha。**读命令什么都不留**:回执一返回就消失。于是「我到底跑过哪些命令」只对其中一小部分可答,而且只对改动过东西的那部分可答。

本 PR 在 daemon 的**单一分发点**加上请求日志。每一个 repo 作用域的请求——读与写,来自 CLI、GUI 或未来的远程客户端——都往 `<repo>/.harness/requests/requests.jsonl` 追加一行。

**记录点在 daemon,而这是相对上一代的有意改进。** 老线记在 CLI 侧(`packages/cli/src/cli/command-event-policy.ts`),后果是 GUI 的操作完全不可见——GUI 走 daemon,不经过 CLI。重写线所有客户端汇聚到同一个分发器(`createJsonRpcProtocolServer` 里的 `one()`),所以一个记录点覆盖全部。也不存在会漏掉的 direct/进程内模式:`HARNESS_DAEMON_MODE` 在 `packages/*/src` 里**根本不存在**,那是老线词汇,只在本地 agent 文档里存活;每条 CLI 路径都终止于 `local-json-rpc-client.ts` 的 `net.createConnection`。

**两类记录,有意分开存。** 写是**问责**:进 git 台账、永久、带 principal 与 executor。请求是**可观测性**:进 `localRoot`、不入 git、滚动淘汰。把高频读灌进 git 台账会当场毁掉刚落地的分片工作——那份工作存在的理由正是「树随历史增长」。本 PR 不动任何写语义。

## 任务与范围

- Harness 任务:`task_01M01MXGK7MR5SCV391KKZ6F2M`(会话/上下文捕获)
- 分支:`codex/request-log`;六个文件。

## 治理声明

- 是否触碰 protected surface:**no**。未修改任何 workflow、门阈值、排除清单、断言或 allowlist 条目。`tools/write-road-registry.json` 增加了一条,那是该门的**声明**通道——新增物理写入落点的登记方式,不是对它的豁免。
- 依据:泽宇直接裁定——「都要的,并进去然后 cutover 后开始派工实现」,回应的是「每一次的命令调用都被存储的那个东西还有没有在存方便查」。记在 `task_01M01MXGK7MR5SCV391KKZ6F2M`。生产 delta 见英文段声明行(门要求全文恰好一行)。

## 验证

- `npm run check:local` → `Local check passed (fast tier) in 35.6s`,由复核者重跑,不采信汇报。新增落点测试加协议契约测试:**52/52**。
- `node tools/gates/line-budget.mjs --base main` → pass(`check:local` 不覆盖此门)。
- **真机实测,对着隔离 daemon**(独立 user root 与 daemon id;生产 daemon pid 16955 全程未被触碰):

  ```
  task-list      repo-read   ok=True   opId=op_3a108277…    4ms  exec=-
  task-create    repo-write  ok=True   opId=op_ad6ab57f…  528ms  exec=-
  task-list      repo-read   ok=True   opId=op_3136e701…    5ms  exec=codex-worker
  ```

  读被记录下来了——那正是缺口所在——且经 `HARNESS_ACTOR` 带上 agent 归属;开着日志,一次读仍是 4–5 ms。
- 滚动淘汰在落点处实测(maxBytes 512、keptFiles 2、400 条记录):文件恰好稳定在 `requests.jsonl`、`.1`、`.2`,最新记录存活、最旧被丢弃。**没有**灌满 20 MiB 真实流量;滚动是走生产同一条 `openDaemonRequestLog` 路径验的。

## 审查证据

**第一次 CI 红,以及诊断是怎么被纠正的。** 本分支的 `schema-closure` 报 `Cannot find package 'effect' imported from packages/kernel/src/entity/session.ts`,而 `main` 绿、本地也绿。那个 job **有意跑在裸 checkout 上**——`rebuild-gates.yml` 的 13 个 job 里有 9 个没有 `npm ci`;而该门会对契约注册表点名的每个模块做 `await import()`,所以**凡被注册表引用的模块都必须能在没有 `node_modules` 的情况下加载**。

第一版诊断把锅扣在「新增的 `DAEMON_REQUEST_LOG_SCHEMA` 导出把 `request-log.ts` 拖进了遍历」,并提议拆一个 contract 模块。**两处都错,而且产出这个结论的仪器本身是坏的**——一个正则 import 图追踪器,把 type-only import 和字符串内容也算成了边。它被丢弃,而不是拿它的数字去汇报。

真实的裸 checkout 环境(把整棵树复制到仓库之外,向上无 `node_modules`)逐字节复现了 CI 的失败,并把它隔离出来:

```
packages/kernel/src/layout/index.ts        bare-import OK
packages/kernel/src/error-consumption.ts   bare-import OK
packages/daemon/src/request-log.ts         bare-import OK
packages/kernel/src/index.ts  (阳性对照)    FAIL: Cannot find package 'effect'
```

`DAEMON_REQUEST_LOG_SCHEMA` 没有被任何契约声明引用,所以 `request-log.ts` **压根不在遍历里**——`json-rpc-server.ts` 只以 `import type` 引它,运行时被擦除。真正的触发点是:`json-rpc-server.ts` 早就是注册表里的 `writer:`,而本分支给它加了一行 **kernel barrel** import。**barrel 通向 `effect`,具体模块不通。**

**它暴露的常设张力,以及为什么修法是删除。** `no-restricted-imports` 要求经 kernel 的公共 barrel 而不是深层 `src` 路径导入——而 barrel 恰恰是裸 checkout 会炸的那个东西。任何被注册表引用的模块都夹在这两条规则中间。没有绕开其中任何一个门,而是**把工作挪位**:`commandClass` 改在 `request-log.ts` 里计算(它是落点,经 barrel 加载 kernel 是正当的,且不被注册表引用),于是 `json-rpc-server.ts` 对 kernel **零 import**。没有新增 contract 模块——那会为了修一个从未被加载的文件而引入模块、parser、writer、错误类型和负向 fixture。记录形状不变。

**这个不变量自我执行。** 任何人再往 `json-rpc-server.ts` 加回 kernel barrel import,裸 checkout 的 `schema-closure` 当场抓住。不需要新增测试来守它。

- 前提是**动手前先核验**的,不是假定的,而且其中一条需要修正。`.harness/generated/runtime-events/` 里有 1303 个残留 jsonl,并且在本工作进行期间**还有一个被追加了内容**——尽管重写线源码里没有任何东西产出 `runtime-event/v2` schema。实现者把它标成「无主写入者」而不是搪塞过去。随后追查到是 launchd 任务 `com.harness-anything.coldstart-v1`,每天 09:15 跑一个 benchmark 脚本——可归属,不是台账完整性问题。新落点**有意不复用**那个目录名,好让残留与新数据始终可区分。
- 有两个缺陷是被实现者自己的测试抓到的,不是读代码看出来的:executor 在 `payload.action.executor` 而非 `payload.executor`(后者会被参数校验直接拒绝);以及参数校验失败的请求不会被记录,因为此时还没有可信的 `repoId`。
- 用 `appendFileSync` 是有意的,不是疏漏。带缓冲的流丢掉的恰好是最后那几条——而那正是 daemon 崩溃后你最想要的。上面那组真机耗时就是它的代价测量。
- 另外跑了 `test:integration`:368/370。两条失败是**争用而非回归**——在同一棵树里 stash 掉本改动会产生**不同的**失败,而这两条在隔离运行下带着本改动都通过,包括 p50 延迟那条(因为新增了同步写,专门单独验了它)。当时机器上有重负载 worker 在跑。

## 残余风险

- **本地请求的 `principalId` 是 `null`,而且是如实留空而不是猜一个。** daemon 在 daemon-host 的 `binding()` 内部解析 principal,协议层看不见,`WriteReceipt` 也不携带它;把它引出来会改变写路径的返回形状,而本任务禁止动写路径。改为记录 `ownerUid`——principal 正是**从它派生**的——并且只在 fleet assignment 入口填 `principalId`,因为那里的 `authContext.assignmentBinding.actor` 真的有。agent 轴是完整记录的。这个缺口不补上,就提供不了 `--person` 过滤。
- **查询面是提案,不是已建。** `ha request list [--limit] [--command <kind>] [--class read|write] [--agent <id>] [--failed] [--since] [--json]`——用领域动词,与 `task list`/`decision list` 同形。接线是四处改动:命令描述符、读侧分发分支、解析器、结果 schema;读取器必须跨滚动文件。新增 CLI 命令面需要仓库所有者亲裁,所以有意留作后续,不夹带进本 PR。
- **客户端本地命令不记录,也没有为它们再造第二个记录点。** `ha daemon start/stop` 在 `packages/cli/src/index.ts` 就短路了,根本到不了 daemon;`ha daemon status` 到得了但不绑定 repo。在 CLI 侧再开一个落点只会把记录切碎。
- `tools/gates/no-swallowed-failure-baseline.mjs:7` 仍引用着已删除的 `packages/cli/src/cli/command-runtime-events.ts`——一条陈旧的基线条目,在此处发现,留作单独清理。
- **`DAEMON_REQUEST_LOG_SCHEMA` 是一个没有注册契约的导出常量。** 在没有东西读这份日志之前无妨。但 `ha request list` 一旦存在,它的结果 schema 就需要注册,`request-log.ts` 随之被注册表引用,于是继承上面那条 barrel 与裸 checkout 的冲突。**那才是 contract 模块真正挣到位置的时刻**,不是现在。
