### PR TITLE
chore(ci): stop dependabot version-update pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,18 @@
 version: 2
 updates:
+  # Version-update pull requests are switched off (limit 0). They cost two manual
+  # repairs this bot cannot perform — a bilingual governance PR body, and a lock
+  # normalization, because dependabot writes an exact version into package.json but a
+  # caret range into the lock's workspace spec, which the dependency-policy gate rejects.
+  # The security half is already covered harder elsewhere: `npm audit --audit-level=high`
+  # runs in the required `supply-chain` CI job, so a high-severity advisory blocks every
+  # merge rather than merely opening a pull request. Raise the limit to resume version
+  # updates; security updates are governed by repository settings, not by this file.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "security"


### PR DESCRIPTION
# English

## Summary

Dependabot opens weekly version-update pull requests in this repository. Every one of them costs two manual repairs the bot cannot perform, and the half of Dependabot that would be worth the cost — security advisories — is switched off here and already covered harder by an existing required gate. This sets `open-pull-requests-limit` to `0`, stopping version-update pull requests while keeping the file, its grouping configuration, and the reason it was stopped.

## What Changed

- `.github/dependabot.yml`: `open-pull-requests-limit` `5` -> `0`, with a comment recording why version updates are off, where the security surface actually lives, and how to resume (raise the limit).

Measured basis, not assumed:

- The repository's Dependabot alerts and security updates are **disabled** — `security_and_analysis.dependabot_security_updates.status` is `disabled`, and the alerts API returns HTTP 403 "Dependabot alerts are disabled for this repository". Dependabot has never carried the advisory function here.
- The required `supply-chain` job runs `npm audit --audit-level=high` through `tools/check-supply-chain.mjs`, so a high-severity advisory blocks every merge — stricter enforcement than an alert or a pull request.
- The two manual repairs, from this round's four pull requests: a fully bilingual governance body (Dependabot's generated body fails `pr-body-lint`), and a lock normalization via `npm install --package-lock-only`, because Dependabot writes an exact version into `package.json` but a caret range into the lock's workspace spec, which `dependency-policy` rejects. #1273 and #1275 merged after both repairs; #1479 and #1276 carry real type errors and were not merged.

## Task And Scope

- Harness task: `task_3b835e62c2c5a2462407850db1`
- Branch: `codex/dependabot-off`
- Public scope: `.github/dependabot.yml` only.
- Private planning/evidence updated: yes — decision `dec_709EB942A437AFC9889D19A90E` (active), with facts `F-022ABA6F` and `F-ECC7EFAD` attached as claim evidence.
- Out of scope: repository security settings (Dependabot alerts stay as they are — see `RJ3`), the audit gate itself, and the two open Dependabot pull requests.

## Version Impact

- Version: no version change because this touches only repository automation configuration.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: **yes**.
- Protected surface scope: `.github/**` — `.github/dependabot.yml`. No workflow, gate threshold, exclusion list, assertion, or allowlist entry was modified; no required check was added or removed.
- Authority: decision `dec_709EB942A437AFC9889D19A90E` (state `active`), anchor `CH1`, derived onto `task_3b835e62c2c5a2462407850db1`. Originating instruction from the repository owner: "这个 bot 要是不方便直接停掉也行 你告诉我这个 bot 有没有意义".
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Follow-up governance task: none. `RJ3` deliberately leaves "enable Dependabot alerts" unadjudicated until there is evidence the audit gate is too late.

Production-Delta: +0/-0

## Verification

- Base `origin/main` SHA: `6c57a181`
- Sync method: none needed — branched from `main` at `6c57a181`.
- Public diff command: `git diff 6c57a181...HEAD`
- [x] `gh api repos/FairladyZ625/harness-anything` — `dependabot_security_updates.status=disabled`.
- [x] `gh api repos/FairladyZ625/harness-anything/dependabot/alerts` — HTTP 403, alerts disabled.
- [x] Traced the audit path by hand: `.github/workflows/rewrite-ci.yml:228` (`supply-chain`) -> `tools/run-manifest-gates.mjs --workflow-job supply-chain` -> `tools/check-supply-chain.mjs:61` (`policy.auditCommands`) -> `npm audit --audit-level=high`.
- Not run: the local test matrix. This PR changes no code; GitHub Actions is the authority.

## Review Evidence

- Self-review: the claim that stopping the bot does not weaken dependency security is not an argument — it rests on two recorded facts, one measuring that Dependabot's security half is off, one tracing the audit gate to a required job.
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none

## Residual Risk

- Dependency versions now move only when someone chooses to move them. That is the repository's stated policy (exact pins), but it means a dependency can sit stale indefinitely without anything surfacing it, until an advisory makes the audit gate red — at which point the upgrade is urgent rather than routine.
- `open-pull-requests-limit: 0` is a documented way to disable version updates, but it is a quieter switch than deleting the entry: someone skimming the file may read a configured ecosystem as an active one. The comment above the key exists to prevent that misreading.
- The two open Dependabot pull requests (#1479, #1276) are untouched by this change and remain open with real type errors.

## References

- Task: `task_3b835e62c2c5a2462407850db1`
- Evidence: facts `F-022ABA6F`, `F-ECC7EFAD`
- Review: pending

---

# 中文

## 概要

dependabot 在本仓每周开版本升级 PR。每一个都要两次 bot 自己做不了的人工返工；而 dependabot 真正值得这个代价的那一半——安全公告——在本仓是关着的，且已经被一个既有的 required 门更硬地覆盖了。本 PR 把 `open-pull-requests-limit` 设为 `0`，停掉版本升级 PR，同时保留文件、分组配置与停用理由。

## 改动内容

- `.github/dependabot.yml`：`open-pull-requests-limit` `5` -> `0`，并加注释记录为什么停、安全面实际在哪里执法、以及怎么恢复（把 limit 改回一个数字）。

以下是实测依据，不是推断：

- 本仓的 Dependabot alerts 与 security updates 是**关闭**的——`security_and_analysis.dependabot_security_updates.status` 为 `disabled`，alerts API 返回 HTTP 403「Dependabot alerts are disabled for this repository」。dependabot 在这里从未承担过公告职责。
- required 的 `supply-chain` job 通过 `tools/check-supply-chain.mjs` 跑 `npm audit --audit-level=high`，高危公告**阻塞每一次合并**——比 alert 或开 PR 更硬。
- 两次人工返工，来自本轮 4 个 PR 的实测：完整双语治理正文（dependabot 生成的正文过不了 `pr-body-lint`），以及跑 `npm install --package-lock-only` 归一化 lock——因为 dependabot 往 `package.json` 写精确版本、却往 lock 的 workspace spec 写 caret 区间，`dependency-policy` 拒收。#1273 与 #1275 在两次返工后合入；#1479 与 #1276 带真实类型错误，未合。

## 任务与范围

- Harness 任务：`task_3b835e62c2c5a2462407850db1`
- 分支：`codex/dependabot-off`
- 公开范围：仅 `.github/dependabot.yml`。
- 私有计划 / 证据是否已更新：是——decision `dec_709EB942A437AFC9889D19A90E`（active），claim 证据挂 fact `F-022ABA6F` 与 `F-ECC7EFAD`。
- 范围外：仓库安全设置（Dependabot alerts 维持现状，见 `RJ3`）、audit 门本身、以及两个仍开着的 dependabot PR。

## 版本影响

- 版本：不改版本，原因是本 PR 只动仓库自动化配置。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：**是**。
- protected surface 范围：`.github/**` 中的 `.github/dependabot.yml`。未修改任何 workflow、门阈值、排除清单、断言或 allowlist 条目；未增删任何 required check。
- 依据：decision `dec_709EB942A437AFC9889D19A90E`（状态 `active`），锚 `CH1`，derives 到 `task_3b835e62c2c5a2462407850db1`。发起指令来自仓库 owner：「这个 bot 要是不方便直接停掉也行 你告诉我这个 bot 有没有意义」。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- 后续治理任务：无。`RJ3` 刻意把「要不要打开 Dependabot alerts」留作未裁，等有证据表明 audit 门太晚再说。

生产 delta 见英文段的声明行（门要求全文恰好一行）。

## 验证

- `origin/main` 基准 SHA：`6c57a181`
- 同步方式：不需要——从 `main` 的 `6c57a181` 切出。
- 公开 diff 命令：`git diff 6c57a181...HEAD`
- [x] `gh api repos/FairladyZ625/harness-anything`——`dependabot_security_updates.status=disabled`。
- [x] `gh api repos/FairladyZ625/harness-anything/dependabot/alerts`——HTTP 403，alerts 关闭。
- [x] 手工追了一遍 audit 路径：`.github/workflows/rewrite-ci.yml:228`（`supply-chain`）-> `tools/run-manifest-gates.mjs --workflow-job supply-chain` -> `tools/check-supply-chain.mjs:61`（`policy.auditCommands`）-> `npm audit --audit-level=high`。
- 未运行：本地测试矩阵。本 PR 不改代码，以 GitHub Actions 为权威。

## 审查证据

- 自查：「停掉 bot 不削弱依赖安全」这句不是论证，它压在两条已登记的 fact 上——一条测出 dependabot 的安全那一半是关的，一条把 audit 门追到 required job。
- Reviewer subagent：无
- 人工审查：待办
- 阻塞发现：无

## 残余风险

- 依赖版本从此只在有人主动去动的时候才动。这符合本仓「钉精确版本」的既定策略，但也意味着一个依赖可以无限期陈旧下去而没有任何东西把它顶出来，直到某条公告让 audit 门变红——那时升级就从例行变成紧急。
- `open-pull-requests-limit: 0` 是文档化的停用方式，但它比删掉整条 entry 更安静：只扫一眼文件的人可能把「配置着的 ecosystem」读成「在跑的 ecosystem」。键上方的注释就是为了防这个误读。
- 两个仍开着的 dependabot PR（#1479、#1276）不受本改动影响，仍带真实类型错误开着。

## 关联材料

- 任务：`task_3b835e62c2c5a2462407850db1`
- 证据：fact `F-022ABA6F`、`F-ECC7EFAD`
- 审查：待办
