### PR TITLE
fix(daemon): accept init --configure-only on the daemon.repo.bootstrap wire

### DIFF
--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -149,7 +149,7 @@ export function daemonProtocolError(command: string, code: string, hint: string)
 export const daemonProtocolMethods = Object.freeze([
   { id: "protocol.hello", phase: "W3", method: "protocol.hello", requiresRepo: false, params: shape({ protocolVersion: "number" }) },
   { id: "daemon.status", phase: "W3", method: "daemon.status", requiresRepo: false, params: shape({}) },
-  { id: "daemon.repo.bootstrap", phase: "W3", method: "daemon.repo.bootstrap", requiresRepo: false, params: shape({ rootDir: "string", repoId: "string", personId: "string", displayName: "string", name: "string?", addNpmScripts: "boolean?" }) },
+  { id: "daemon.repo.bootstrap", phase: "W3", method: "daemon.repo.bootstrap", requiresRepo: false, params: shape({ rootDir: "string", repoId: "string", personId: "string", displayName: "string", name: "string?", addNpmScripts: "boolean?", configureOnly: "boolean?" }) },
   { id: "daemon.repo.register", phase: "W3", method: "daemon.repo.register", requiresRepo: false, params: shape({ rootDir: "string", repoId: "string" }) },
   { id: "daemon.repo.unregister", phase: "W3", method: "daemon.repo.unregister", requiresRepo: false, params: shape({ repoId: "string" }) },
   { id: "repo.task.run", phase: "W3", method: "repo.task.run", requiresRepo: true, params: shape({ repo: shape({ repoId: "string" }), payload: shape({ action: shape({ kind: "string" }, true) }) }) }

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -31,7 +31,7 @@ export function createJsonRpcProtocolServer(options: { readonly host: DaemonHost
     if (!handshaken) return reply(daemonProtocolError(request.method, "hello_required", "Call protocol.hello first.") as unknown as JsonObject);
     if (request.method === "daemon.status") return reply({ ok: true, ...options.host.status() } as unknown as JsonObject);
     if (request.method === "daemon.repo.bootstrap") {
-      try { return reply(await options.host.bootstrap(params as unknown as { rootDir: string; repoId: string; personId: string; displayName: string; name?: string; addNpmScripts?: boolean }, options.authContext) as JsonObject); }
+      try { return reply(await options.host.bootstrap(params as unknown as Parameters<DaemonHost["bootstrap"]>[0], options.authContext) as JsonObject); }
       catch (error) { return reply(daemonProtocolError("init", rpcServerErrorCode(error), error instanceof Error ? error.message : String(error)) as unknown as JsonObject); }
     }
     if (request.method === "daemon.repo.register" || request.method === "daemon.repo.unregister") {

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -9,7 +9,7 @@ import test from "node:test";
 import { openDaemonHost } from "../src/daemon-host.ts";
 import { eventObjectTarget, makeTaskEventStore, makeTaskProjection, readDaemonRegistry, REPLAY_TASK_GRAPH, serializeCanonicalEvent, serializeEventHead, sha256Text, type AgentRuntimeEventV1, type FrozenWritePlan, type TaskEventV1 } from "../../kernel/src/index.ts";
 import { projectDecisionReadiness, reviewDigest } from "../../kernel/src/index.ts";
-import { actionForDaemonMethod, canonicalRoot, commandClassForAction, daemonGuiActionMethods, parseDaemonRpcParams, validateDaemonDecisionList, validateDaemonGuiCommandReceipt, validateDaemonRelationGraph, validateDaemonTaskSnapshotList, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { actionForDaemonMethod, canonicalRoot, commandClassForAction, daemonGuiActionMethods, daemonProtocolCommands, parseDaemonRpcParams, validateDaemonDecisionList, validateDaemonGuiCommandReceipt, validateDaemonRelationGraph, validateDaemonTaskSnapshotList, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { createJsonRpcProtocolServer } from "../src/protocol/json-rpc-server.ts";
 import { currentDaemonProtocolVersion } from "../src/protocol/version.ts";
 import { openRepoCell } from "../src/repo-cell.ts";
@@ -552,6 +552,21 @@ test("decision readiness survives the wire when the canonical Git cut is unavail
 
   const verdictWithoutBasis = { ...noCut[0]!, appliesToDrift: { ...noCut[0]!.appliesToDrift, state: "clear" as const } };
   assert.deepEqual(validateDaemonDecisionList(decisionList(verdictWithoutBasis)), ["daemon decision list is invalid"]);
+});
+
+// A flag can be declared on the init command, parsed by the CLI, and honored by the bootstrap
+// implementation while the wire shape still rejects it — the CLI and the RPC params are two
+// separate declarations of the same request. This walks the declared flags so the next one added
+// to init cannot repeat that.
+test("every declared ha init flag survives the daemon.repo.bootstrap wire params", () => {
+  const command = daemonProtocolCommands.find((candidate) => candidate.id === "repo-bootstrap");
+  assert.ok(command, "the init command must stay declared as repo-bootstrap");
+  const base = { rootDir: "/tmp/workspace", repoId: "alpha", personId: "owner", displayName: "Owner" };
+  for (const input of command.inputs) {
+    const field = (input as { readonly field?: string }).field ?? input.name.slice(2).replace(/-([a-z])/gu, (_match, letter: string) => letter.toUpperCase());
+    const parsed = parseDaemonRpcParams("daemon.repo.bootstrap", { ...base, [field]: input.kind === "boolean" ? true : "value" });
+    assert.equal(parsed.ok, true, `${input.name} reaches the daemon as params.${field}, which the wire shape rejects`);
+  }
 });
 
 function decisionList(readiness: unknown): Record<string, unknown> {


### PR DESCRIPTION
# English

## Summary

`ha init --configure-only`, added in #1485, never reached the daemon. The flag is declared on the CLI command, parsed into the request payload, and honored by `bootstrapRepo` — but `daemon.repo.bootstrap` validates its params against a separately declared closed shape that does not list `configureOnly`, so every invocation is rejected before the implementation runs:

```
{"ok":false,"code":"invalid_request","error":{"hint":"params.configureOnly is not allowed"}}
```

Found by running the command against a real workspace rather than by reading code. #1485's tests covered the CLI parse and the bootstrap implementation and passed while the feature was unreachable, because neither test crosses the wire.

## What Changed

- `packages/daemon/src/protocol/daemon-protocol.contract.ts`: adds `configureOnly: "boolean?"` to the `daemon.repo.bootstrap` params shape.
- `packages/daemon/src/protocol/json-rpc-server.ts`: the bootstrap handler cast was a hand-written duplicate of the request shape, listing every field again. It is now `Parameters<DaemonHost["bootstrap"]>[0]`, so the third declaration is deleted rather than extended — it cannot drift from the host signature again.
- `packages/daemon/test/json-rpc-protocol.test.ts`: walks every declared `repo-bootstrap` CLI input and asserts the wire params shape accepts the field it arrives as. The next flag added to `init` fails here instead of at a user's terminal.

## Task And Scope

- Harness task: `task_51c3971379585fcd86b79be297`
- Branch: `codex/wire-configure-only`
- Public scope: two daemon protocol source files and one test file.
- Private planning/evidence updated: not applicable
- Out of scope: a general CLI-to-wire parity harness across all commands. This is the first observed instance of this specific pair; the check added here is scoped to `init`, where the defect actually occurred.

## Version Impact

- Version: no version change because this repairs an unreleased flag added in #1485.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: **no**. No workflow, gate threshold, exclusion list, assertion, or allowlist entry was modified.
- Protected surface scope: not applicable
- Authority: repairs `ha init --configure-only`, added under `task_51c3971379585fcd86b79be297` in #1485.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Follow-up governance task: none

Production-Delta: +2/-2

## Verification

- Base `origin/main` SHA: `ab49ecc2`
- Sync method: none needed — branched from `main` at `ab49ecc2`.
- Public diff command: `git diff ab49ecc2...HEAD`
- [x] Reproduced the defect against a real workspace before fixing: `ha --root <workspace> init --repo-id kty-web --person-id person_zeyu --display-name "Zeyu Li" --configure-only --json` returned `params.configureOnly is not allowed`.
- [x] Positive control on the new test: with `configureOnly` removed from the params shape it fails with `--configure-only reaches the daemon as params.configureOnly, which the wire shape rejects`; with the shape restored it passes. The assertion is therefore known to bite.
- [x] `npm run check:local` — passed (fast tier, 45.7s).
- Not run: end-to-end `ha init --configure-only` against a live daemon. Wire validation is server-side, and the resident daemon runs the pre-merge build; the real end-to-end run happens after this merges and the daemon restarts.

## Review Evidence

- Self-review: the failure mode here is that a feature can be declared, parsed, implemented, and tested while remaining unreachable, because the request shape is declared twice. The fix removes one of the two duplicate declarations rather than synchronizing them.
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none

## Residual Risk

- The new check walks the `repo-bootstrap` inputs only. Other commands still declare their CLI surface and their wire params separately, and nothing yet proves those two agree — the same defect can occur elsewhere. Generalizing was deliberately not done here: one observed instance is not yet evidence of a shape.
- The flag-to-field mapping in the test assumes `field ?? camelCase(flag)`. A future input whose payload key follows neither rule would need the test updated alongside it.

---

# 中文

## 概要

#1485 加的 `ha init --configure-only` **从未到达 daemon**。这个 flag 在 CLI 命令上声明了、被解析进了请求 payload、`bootstrapRepo` 也认它——但 `daemon.repo.bootstrap` 用一份**另行声明的封闭 shape** 校验 params，那份 shape 里没有 `configureOnly`，于是每次调用都在实现跑起来之前就被拒：

```
{"ok":false,"code":"invalid_request","error":{"hint":"params.configureOnly is not allowed"}}
```

是拿真实工作区跑这条命令发现的，不是读代码读出来的。#1485 的测试覆盖了 CLI 解析和 bootstrap 实现，功能不可达却全绿——因为两条测试都不过线。

## 改动内容

- `packages/daemon/src/protocol/daemon-protocol.contract.ts`：给 `daemon.repo.bootstrap` 的 params shape 加上 `configureOnly: "boolean?"`。
- `packages/daemon/src/protocol/json-rpc-server.ts`：bootstrap handler 里的类型断言原本是把请求结构**又手抄了一遍**的第三份声明。现在改成 `Parameters<DaemonHost["bootstrap"]>[0]`——不是给它补一个字段，是把这份重复声明删掉，它再也不可能和 host 签名漂移。
- `packages/daemon/test/json-rpc-protocol.test.ts`：遍历 `repo-bootstrap` 声明的每一个 CLI input，断言 wire params shape 接受它到达时的字段名。下一个加到 `init` 的 flag 会在这里红，而不是在用户终端里红。

## 任务与范围

- Harness 任务：`task_51c3971379585fcd86b79be297`
- 分支：`codex/wire-configure-only`
- 公开范围：两个 daemon protocol 源文件加一个测试文件。
- 私有计划 / 证据是否已更新：不适用
- 范围外：覆盖全部命令的通用 CLI↔wire 对账机制。这是这一对声明面上观察到的**第一例**，本 PR 的检查只收在 `init`——缺陷实际发生的地方。

## 版本影响

- 版本：不改版本，原因是本 PR 修的是 #1485 加入、尚未发布的一个 flag。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：**否**。未修改任何 workflow、门阈值、排除清单、断言或 allowlist 条目。
- protected surface 范围：不适用
- 依据：修复 `ha init --configure-only`，该功能在 #1485 中由 `task_51c3971379585fcd86b79be297` 引入。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- 后续治理任务：无

生产 delta 见英文段的声明行（门要求全文恰好一行）。

## 验证

- `origin/main` 基准 SHA：`ab49ecc2`
- 同步方式：不需要——从 `main` 的 `ab49ecc2` 切出。
- 公开 diff 命令：`git diff ab49ecc2...HEAD`
- [x] 修之前先在真实工作区复现了缺陷：`ha --root <workspace> init --repo-id kty-web --person-id person_zeyu --display-name "Zeyu Li" --configure-only --json` 返回 `params.configureOnly is not allowed`。
- [x] 新测试跑了阳性对照：把 `configureOnly` 从 params shape 里拿掉，它红在 `--configure-only reaches the daemon as params.configureOnly, which the wire shape rejects`；shape 恢复后转绿。所以这条断言是会咬人的。
- [x] `npm run check:local`——通过（fast tier，45.7s）。
- 未运行：对活 daemon 的端到端 `ha init --configure-only`。wire 校验发生在服务端，而常驻 daemon 跑的是合并前的构建；真正的端到端在本 PR 合入、daemon 重启之后跑。

## 审查证据

- 自查：这里的失效形态是——一个功能可以被声明、解析、实现、测试，同时保持不可达，因为请求结构被声明了两遍。修法是**删掉两份中的一份**，而不是把它们同步起来。
- Reviewer subagent：无
- 人工审查：待办
- 阻塞发现：无

## 残余风险

- 新检查只遍历 `repo-bootstrap` 的 inputs。其它命令仍然各自分开声明 CLI 面与 wire params，没有任何东西证明这两者一致——同型缺陷可以在别处发生。这里刻意没有泛化：观察到一例还不构成形状证据。
- 测试里的 flag→字段映射假定是 `field ?? camelCase(flag)`。将来若有 input 的 payload 键两条规则都不遵守，需要连同测试一起改。
