### PR TITLE
refactor(kernel): reuse canonical relation allowlists in the frontmatter parser

### DIFF
--- a/packages/kernel/src/projection/relation-flow-frontmatter.ts
+++ b/packages/kernel/src/projection/relation-flow-frontmatter.ts
@@ -1,4 +1,4 @@
-import type { EntityRelationRecord } from "../domain/index.ts";
+import { relationDirections, relationOrigins, relationStates, relationStrengths, relationTypes, type EntityRelationRecord } from "../domain/index.ts";
 
 export function parseRelationFlowRecords(body: string): ReadonlyArray<EntityRelationRecord> {
   const records: EntityRelationRecord[] = [];
@@ -90,21 +90,21 @@ function parseRelationFlowValue(value: string): string {
 }
 
 function isRelationType(value: string): value is EntityRelationRecord["type"] {
-  return ["supports", "supersedes", "refines", "narrows", "derives", "blocks", "relates", "implements", "depends-on", "produces", "evidences", "evidenced-by", "invalidated-by", "supersedes-fact"].includes(value);
+  return relationTypes.includes(value as EntityRelationRecord["type"]);
 }
 
 function isRelationStrength(value: string): value is EntityRelationRecord["strength"] {
-  return value === "strong" || value === "weak";
+  return relationStrengths.includes(value as EntityRelationRecord["strength"]);
 }
 
 function isRelationDirection(value: string): value is EntityRelationRecord["direction"] {
-  return value === "directed" || value === "undirected";
+  return relationDirections.includes(value as EntityRelationRecord["direction"]);
 }
 
 function isRelationOrigin(value: string): value is EntityRelationRecord["origin"] {
-  return value === "declared" || value === "imported_snapshot" || value === "generated" || value === "inferred";
+  return relationOrigins.includes(value as EntityRelationRecord["origin"]);
 }
 
 function isRelationState(value: string): value is EntityRelationRecord["state"] {
-  return value === "active" || value === "retired" || value === "deleted";
+  return relationStates.includes(value as EntityRelationRecord["state"]);
 }


### PR DESCRIPTION
# English

## Summary

`relation-flow-frontmatter.ts` hand-copied five relation vocabularies (type / strength / direction / origin / state) that `entity-relation.ts` already exports as canonical constants. Four of the five copies happened to match; the `type` copy had drifted and was missing `refuted-by`. This PR makes all five derive from the canonical constants and deletes every hard-coded literal from the file.

`refuted-by` becoming acceptable to the parser is a **by-product of the reuse**, not a patch applied to the array. That distinction is the point of the change: the defect was not the missing entry, it was that nothing prevented a hand-copy from existing in the first place.

## What Changed

- `packages/kernel/src/projection/relation-flow-frontmatter.ts:1` — widened the existing `import type` from `../domain/index.ts` to also bring in the five canonical constants.
- Same file, `:92-110` — `isRelationType`, `isRelationStrength`, `isRelationDirection`, `isRelationOrigin`, `isRelationState` now test membership against `relationTypes` / `relationStrengths` / `relationDirections` / `relationOrigins` / `relationStates`. All five remain type guards with unchanged signatures.
- Zero relation vocabulary literals remain in the file.
- Canonical (`entity-relation.ts`) and the barrel (`domain/index.ts`) are untouched — the constants were already exported.

## Task And Scope

- Harness task: `task_75cc4c9cfcbe1acd10a5338441`
- Branch: `codex/relation-allowlist`
- Public scope: one file, `packages/kernel/src/projection/relation-flow-frontmatter.ts`
- Private planning/evidence updated: yes
- Out of scope: the other three relation allowlists identified during research (`ha task relate` narrowing to `depends-on`, the daemon protocol shape, the GUI axis map). Each has its own justification or needs separate adjudication; none is touched here.

## Version Impact

- Version: no version change because this is an internal refactor with no API or behavior surface change beyond the parser accepting one additional already-canonical relation type.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable — no changes to `tools/`, `.github/`, `gate-manifest.json`, any gate script, or any workflow.
- Authority: `task_75cc4c9cfcbe1acd10a5338441`. The defect was found by the DDD domain-modeling research pack, second round, family two (relation direction and allowlists). Canonical `relationTypes` is already the authority; this PR only stops a consumer from hand-copying it.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `ee304ff951cfe49dcd7cccd26c21c773f9a0fd20`
- Branch merge-base with `origin/main`: `ee304ff951cfe49dcd7cccd26c21c773f9a0fd20`
- Last `git fetch origin` time: 2026-08-17T06:28:24Z
- Sync method: none needed — merge-base equals `origin/main` HEAD
- Public diff command: `git diff --stat origin/main...codex/relation-allowlist` → 1 file, 6 insertions, 6 deletions
Production-Delta: +6/-6
- Private evidence commit/path: task package `task_75cc4c9cfcbe1acd10a5338441`, `artifacts/report-relation-allowlist-reuse.md`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `npm run check:local` — the repo's local stop point, derived from the gate manifest. 37 steps, all green.
- [x] `npx tsc -b` — exit 0. Required because the five functions are type guards; narrowing had to survive the rewrite.
- [x] Targeted kernel tests covering relation frontmatter and relation graph projection — 11/11 passing.
- [x] Positive/negative control: `refuted-by` now passes `isRelationType`; `not-a-relation` is still rejected. Both directions were asserted — proving only the first would not show the guard still works.
- [ ] GitHub Actions `rewrite-ci` passed — pending on this PR
- Not run: the individual `npm run harness:*` commands listed in the template were not invoked one by one. `npm run check:local` derives its step list from the gate manifest and covers them; running them serially on one machine is strictly slower than CI running them in parallel. The full matrix is GitHub CI's job.

## Review Evidence

- Self-review: CEO reviewed the diff directly against the four acceptance criteria in the task plan. Confirmed: zero vocabulary literals remain; all five functions are still type guards with unchanged signatures; `refuted-by` arrives via reuse rather than as an added array entry; canonical is byte-identical.
- Reviewer subagent: not used — the change is six lines of mechanical substitution in one file, fully covered by the acceptance criteria and the positive/negative control.
- Human review: pending
- Blocking findings: none

## Residual Risk

- The `.includes(value as T)` cast is required because the canonical constants are `as const` readonly tuples. The cast is confined inside each type guard and cannot widen the accepted set: a non-member value still returns `false`. Behavior is unchanged.
- The parser now accepts `refuted-by` where it previously silently skipped it. No evidence was found that this path is reachable under supported usage — `relation-source-manifest.ts` declares only Task `INDEX.md` frontmatter as the parser's source, and `refuted-by` is a `decision→fact` edge that the canonical kind matrix does not permit on a task host. This PR is therefore graded as removing a hand-copy, not as fixing active data loss.
- The other three relation allowlists remain divergent by design or by unexamined default. They are recorded in the research pack and left for separate adjudication.

## References

- Task: `task_75cc4c9cfcbe1acd10a5338441`
- Evidence: task package `artifacts/report-relation-allowlist-reuse.md`
- Review: DDD domain-modeling research pack, second round, family two

---

# 中文

## 概要

`relation-flow-frontmatter.ts` 手抄了五份 relation 词表（type / strength / direction / origin / state），而 `entity-relation.ts` 早已把这五个 canonical 常量导出。五份里有四份的值恰好一致，只有 `type` 那份漂了——缺 `refuted-by`。本 PR 让五个判定全部由 canonical 常量派生，并删掉文件里所有硬编码字面量。

`refuted-by` 因此被 parser 接受，是**复用的副产物**，不是往数组里补的一项。这个区别正是本次改动的要点：缺陷不是「少了一个条目」，而是**没有任何机制阻止手抄存在**。

## 改动内容

- `packages/kernel/src/projection/relation-flow-frontmatter.ts:1` —— 把已有的 `import type` 扩宽，同时引入五个 canonical 常量。
- 同文件 `:92-110` —— `isRelationType`、`isRelationStrength`、`isRelationDirection`、`isRelationOrigin`、`isRelationState` 改为对 `relationTypes` / `relationStrengths` / `relationDirections` / `relationOrigins` / `relationStates` 做成员判定。五个仍是类型守卫，签名未变。
- 文件内零 relation 词表字面量。
- canonical（`entity-relation.ts`）与 barrel（`domain/index.ts`）一字未改——常量本来就已导出。

## 任务与范围

- Harness 任务：`task_75cc4c9cfcbe1acd10a5338441`
- 分支：`codex/relation-allowlist`
- 公开范围：单文件 `packages/kernel/src/projection/relation-flow-frontmatter.ts`
- 私有计划 / 证据是否已更新：yes
- 范围外：研究中识别出的另外三套 relation allowlist（`ha task relate` 收窄到 `depends-on`、daemon protocol 形状、GUI axis 映射）。它们各有正当理由或需单独裁决，本 PR 一处不碰。

## 版本影响

- 版本：不改版本，原因是这是内部重构；除 parser 多接受一个本来就 canonical 的关系类型外，无 API 或行为面变化。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用——未改动 `tools/`、`.github/`、`gate-manifest.json`、任何门脚本或 workflow。
- 依据：`task_75cc4c9cfcbe1acd10a5338441`。缺陷由 DDD 领域建模研究 pack 第二轮族二（关系方向与 allowlist）发现。canonical `relationTypes` 本来就是权威，本 PR 只是让一个消费方停止手抄它。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`ee304ff951cfe49dcd7cccd26c21c773f9a0fd20`
- 当前分支与 `origin/main` 的 merge-base：`ee304ff951cfe49dcd7cccd26c21c773f9a0fd20`
- 最近一次 `git fetch origin` 时间：2026-08-17T06:28:24Z
- 同步方式：不需要——merge-base 等于 `origin/main` HEAD
- 公开 diff 命令：`git diff --stat origin/main...codex/relation-allowlist` → 1 文件，6 增，6 删
- 生产代码行数增减：`+6/-6`（门要求的机读声明行在英文块）
- 私有证据 commit/path：任务包 `task_75cc4c9cfcbe1acd10a5338441`，`artifacts/report-relation-allowlist-reuse.md`
- Reviewer 证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑
- [x] `npm run check:local` —— 本仓本地停止点，步骤由 gate manifest 派生。37 步全绿。
- [x] `npx tsc -b` —— 退出码 0。必跑，因为五个函数是类型守卫，改写后 narrowing 必须仍然成立。
- [x] 覆盖 relation frontmatter 与 relation graph projection 的定向 kernel 测试 —— 11/11 通过。
- [x] 阳性 / 阴性对照：`refuted-by` 现在能通过 `isRelationType`；`not-a-relation` 仍被拒。两个方向都做了断言——只证前者无法说明守卫还在工作。
- [ ] GitHub Actions `rewrite-ci` passed —— 本 PR 上待跑
- 未运行：模板中逐条列出的 `npm run harness:*` 命令未逐个单独调用。`npm run check:local` 的步骤清单由 gate manifest 派生并已覆盖它们；在一台机器上串行跑完全量，严格慢于 CI 并行跑。完整门矩阵是 GitHub CI 的职责。

## 审查证据

- 自查：CEO 直接对照 task plan 的四条验收判据审阅了 diff。确认：文件内零词表字面量；五个函数仍是类型守卫且签名未变；`refuted-by` 来自复用而非新增数组条目；canonical 逐字节未改。
- Reviewer subagent：未使用——本次是单文件六行机械替换，验收判据与阳性/阴性对照已完整覆盖。
- 人工审查：待泽宇
- 阻塞发现：无

## 残余风险

- `.includes(value as T)` 的 cast 是必需的，因为 canonical 常量是 `as const` 只读元组。该 cast 局限在每个类型守卫内部，无法扩大被接受的集合：非成员值仍返回 `false`，行为不变。
- parser 现在接受 `refuted-by`，此前是静默跳过。**没有找到证据表明这条路径在受支持用法下可达**——`relation-source-manifest.ts` 只声明 Task `INDEX.md` frontmatter 作为 parser 来源，而 `refuted-by` 是 `decision→fact` 边，canonical kind matrix 不允许它挂在 task host 上。因此本 PR 按「消除手抄副本」定级，不按「修复正在发生的数据丢失」定级。
- 另外三套 relation allowlist 仍然分歧——有的是设计使然，有的是未经审视的默认。它们已记录在研究 pack 里，留待单独裁决。

## 关联材料

- 任务：`task_75cc4c9cfcbe1acd10a5338441`
- 证据：任务包 `artifacts/report-relation-allowlist-reuse.md`
- 审查：DDD 领域建模研究 pack 第二轮族二
