### PR TITLE
fix(application): delete the dead runPromise path and let the gate enforce the standard

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -6,7 +6,7 @@ import type {
 import type { HarnessLayoutOverrides } from "../../kernel/src/index.ts";
 export { commandReceiptEnvelope } from "./command-receipt.ts";
 export type { CommandFailureReceipt, CommandReceipt, CommandReceiptEnvelope } from "./command-receipt.ts";
-export { makeTaskLifecycleService, runTaskLifecycleEffect, TaskLifecycleOperationConflict } from "./task-lifecycle-service.ts";
+export { makeTaskLifecycleService, TaskLifecycleOperationConflict } from "./task-lifecycle-service.ts";
 export type {
   TaskLifecycleKillpoint,
   TaskLeaseRenewInput,

--- a/packages/application/src/task-lifecycle-service.ts
+++ b/packages/application/src/task-lifecycle-service.ts
@@ -1,10 +1,8 @@
 // @slice-activation P4 W2 is composed by tests; W3 owns daemon and production publication cutover.
-import { Effect } from "effect";
 import { applyTransition, canonicalizeContractValue, compileTaskLifecycleWrite, eventObjectTarget, lifecycleDocumentPaths, taskLifecycleWritePlan, validateTaskLifecycleCommandEnvelope,
   type ExecutionV1, type FrozenWritePlan, type ProofFor, type TaskEventV1, type TaskLifecycleCommand, type TaskLifecycleSnapshot,
-  type WriteError, type WriteOperationReceipt, type WriteTarget } from "../../kernel/src/index.ts";
+  type WriteOperationReceipt, type WriteTarget } from "../../kernel/src/index.ts";
 
-export async function runTaskLifecycleEffect<A>(effect: Effect.Effect<A, WriteError>): Promise<A> { const result = await Effect.runPromise(Effect.either(effect)); if (result._tag === "Left") throw result.left; return result.right; }
 export class TaskLifecycleOperationConflict extends Error {
   readonly code: string;
   constructor(message: string, code = "service_rejected") { super(message); this.name = "TaskLifecycleOperationConflict"; this.code = code; }

--- a/packages/kernel/src/domain/errors.ts
+++ b/packages/kernel/src/domain/errors.ts
@@ -36,18 +36,3 @@ export type ArtifactStoreError =
 export type TemplateLibraryError =
   | { readonly _tag: "TemplateNotFound"; readonly templateId: string; readonly locale?: string }
   | { readonly _tag: "TemplateCatalogInvalid"; readonly reason: string };
-
-export type WriteError =
-  | {
-    readonly _tag: "WriteRejected";
-    readonly taskId?: TaskId;
-    readonly entityId?: string;
-    readonly reason: string;
-    readonly code?: string;
-    readonly currentWatermark?: string | null;
-    readonly expectedWatermark?: string | null;
-    readonly retryable?: boolean;
-  }
-  | { readonly _tag: "WriteConflict"; readonly taskId: TaskId; readonly owner?: string }
-  | { readonly _tag: "GlobalWriteConflict"; readonly owner?: string }
-  | { readonly _tag: "JournalUnavailable"; readonly cause?: unknown };

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -73,8 +73,7 @@ export type {
   EngineError,
   BindingInvariantError,
   ArtifactStoreError,
-  TemplateLibraryError,
-  WriteError
+  TemplateLibraryError
 } from "./errors.ts";
 
 export {

--- a/tools/check-implementation-contracts.mjs
+++ b/tools/check-implementation-contracts.mjs
@@ -334,7 +334,7 @@ for (const file of files) {
     }
   }
 
-  if (!rel.startsWith("packages/cli/src/") && !rel.startsWith("packages/application/src/") && /\b(?:Effect|E|Fx)\.runPromise\w*\s*\(|\brunPromise\w*\s*\(/.test(text)) {
+  if (!rel.startsWith("packages/cli/src/") && /\b(?:Effect|E|Fx)\.runPromise\w*\s*\(|\brunPromise\w*\s*\(/.test(text)) {
     record(`${rel}: Effect.runPromise* is only allowed at controller composition roots`);
   }
 


### PR DESCRIPTION
# English

## Summary

The standard says `packages/application/src/` must not call `Effect.runPromise`. The gate that enforces it explicitly exempted that exact directory, while its error message still read "only allowed at controller composition roots". The gate contradicted the standard it was supposed to enforce.

The only thing in `application/` that triggered the rule was `runTaskLifecycleEffect` — an exported helper with **zero callers**, including in tests. So the fix is not to patch the gate around a live consumer; it is to delete the dead function, after which the exemption has nothing left to protect and comes out too. Standard and gate agree again, and production shrinks.

Deleting the function left `WriteError` as a zero-consumer kernel export, which `check-kernel-dead-exports` correctly flagged. That gate's allowlist is bidirectional, so "add it to the allowlist" was also a legal green path — it was rejected. The assumption such an allowlist entry would protect is "someone will use this type later", and that assumption does not hold today: `WriteError` is a correctly-shaped but never-wired error contract, unused because the write path does not go through an Effect error channel at all. When that changes, the type can be reintroduced with a real consumer.

## What Changed

- `packages/application/src/task-lifecycle-service.ts` — deleted `runTaskLifecycleEffect`, the repository's only `Effect.runPromise` call site; dropped the now-unused `Effect` import and the `WriteError` type import. `WriteOperationReceipt` and `WriteTarget` stay — both have many other consumers.
- `packages/application/src/index.ts` — removed `runTaskLifecycleEffect` from the re-export; `makeTaskLifecycleService` and `TaskLifecycleOperationConflict` unchanged.
- `packages/kernel/src/domain/errors.ts` — deleted the `WriteError` union, now a zero-consumer export.
- `packages/kernel/src/domain/index.ts` — removed the `WriteError` re-export.
- `tools/check-implementation-contracts.mjs` — removed `!rel.startsWith("packages/application/src/") && ` from the `runPromise` rule. **The detection regex is untouched and the `packages/cli/src/` exemption is retained** — CLI is the composition root the standard recognises.

No allowlist entry was added anywhere, in any gate.

## Task And Scope

- Harness task: `task_876df82f52257b923b616a254c`
- Branch: `codex/runpromise-deadcode`
- Public scope: 5 files across `packages/application`, `packages/kernel/src/domain`, and one gate script.
- Private planning/evidence updated: yes
- Out of scope: wiring the write path onto an Effect error channel. That is the real reason `WriteError` had no consumers, and it is a design question, not a cleanup.

## Version Impact

- Version: no version change because the deleted export had no consumers and no behavior depended on it.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/check-implementation-contracts.mjs` — one condition removed from the `runPromise` rule. No change to the detection regex, to `tools/gate-manifest.json`, to any workflow, to any gate's tier or required status, and no `continue-on-error` anywhere.
- Authority: `harness/governance/standards/implementation-contract-standard.md` already lists `Effect.runPromise` under the forbidden column for `packages/application/src/`. This PR does not change policy; it makes the gate execute the policy the standard already published. Task `task_876df82f52257b923b616a254c` records the CEO adjudication, including the explicit refusal to resolve the follow-on `WriteError` finding by allowlist.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `d98337d060e59838fa592fe3d8bdadbddbdb8fcb`
- Branch merge-base with `origin/main`: `d98337d060e59838fa592fe3d8bdadbddbdb8fcb`
- Last `git fetch origin` time: 2026-08-17T06:37:45Z
- Sync method: rebase onto `origin/main` after #1488 landed; merge-base now equals `origin/main` HEAD
- Public diff command: `git diff --stat origin/main...codex/runpromise-deadcode` → 5 files, 4 insertions, 22 deletions
Production-Delta: +3/-21
- Private evidence commit/path: task package `task_876df82f52257b923b616a254c`, `artifacts/report-runpromise-deadcode.md` and `artifacts/check-local-final.txt` (925 lines of runner output)
- Reviewer evidence path: same task package, `artifacts/resume-01-writeerror-adjudication.md` records the CEO ruling on the follow-on finding
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `npm run check:local` — 37 steps, all green, 41.3s. This is the repo's local stop point, derived from the gate manifest; it includes the `boundaries` surface that runs the modified gate.
- [x] `npx tsc -b` — exit 0.
- [x] `packages/application/test/` existing tests — passing.
- [x] **Negative control**: with the change applied, a temporary `Effect.runPromise(...)` was inserted into a file under `packages/application/src/`; the gate rejected it. The line was then reverted and the gate passed. Without this step "the gate now enforces the rule" would be an assertion, not evidence — a gate that never reaches the file looks identical to a gate that passes it.
- [x] Chain analysis: after deleting `WriteError`, no third-order zero-consumer export appeared. `WriteOperationReceipt` and `WriteTarget`, imported on the same line, each retain many consumers and were verified before the deletion, not after it failed.
- [ ] GitHub Actions `rewrite-ci` passed — pending on this PR
- Not run: the individual `npm run harness:*` commands listed in the template were not invoked one by one. `npm run check:local` derives its step list from the gate manifest and covers them. The full matrix is GitHub CI's job.

## Review Evidence

- Self-review: CEO reviewed the full diff. Confirmed: the gate's detection regex is byte-identical; the `packages/cli/src/` exemption is intact; no allowlist entry was added in any gate; `grep` for `runPromise` under `packages/application/src/` returns zero; `grep` for `WriteError` across `packages` and `tools` returns zero.
- Reviewer subagent: not used. The change is a deletion with a negative control; the acceptance criteria are mechanically checkable and were checked directly.
- Human review: pending
- Blocking findings: none. One checkpoint was hit mid-implementation (the `WriteError` finding); the worker stopped and reported instead of resolving it, and the CEO adjudicated before work resumed.

## Residual Risk

- `WriteError` described four write failure modes (`WriteRejected`, `WriteConflict`, `GlobalWriteConflict`, `JournalUnavailable`). Deleting it removes a written record of that taxonomy from the domain layer. It was never referenced by any contract or schema declaration, so nothing consumed it — but if the write path is later moved onto a typed error channel, this shape is a reasonable starting point and is preserved in this PR's history.
- The gate is now stricter than it was. If any future `packages/application/src/` code needs to run an Effect, it must do so at a CLI or daemon composition root instead. That is what the standard already required; this PR only makes it enforced rather than aspirational.

## References

- Task: `task_876df82f52257b923b616a254c`
- Evidence: task package `artifacts/report-runpromise-deadcode.md`, `artifacts/check-local-final.txt`
- Review: `artifacts/resume-01-writeerror-adjudication.md`; defect found by the DDD domain-modeling research pack, second round, ecosystem survey

---

# 中文

## 概要

标准写明 `packages/application/src/` 禁止调用 `Effect.runPromise`。而执行这条规则的门，恰恰显式豁免了这个目录，错误消息却仍写着「只允许在 controller composition root」。**门与它本该执行的标准相反。**

而 `application/` 里唯一触发这条规则的，是 `runTaskLifecycleEffect` —— 一个**零调用方**的导出函数，连测试里都没有。所以修法不是绕开一个活的消费者去打补丁，而是删掉这个死函数：删完之后，豁免不再有保护对象，一并撤掉。标准与门重新一致，production 净收缩。

删掉函数后，`WriteError` 变成零消费者的 kernel 导出，被 `check-kernel-dead-exports` 正确抓住。那道门的 allowlist 是双向的，所以「把它加进 allowlist」同样是一条合法的绿路——**这条路被拒绝了。** allowlist 条目所保护的假设是「将来会有人用这个类型」，而这个假设今天不成立：`WriteError` 是一个形状正确但从未接线的错误契约，它没人用的真实原因是写路径根本不走 Effect error channel。等那件事发生时，再连着真实消费者一起引入。

## 改动内容

- `packages/application/src/task-lifecycle-service.ts` —— 删除 `runTaskLifecycleEffect`，本仓唯一的 `Effect.runPromise` 调用点；同时删掉随之失去用途的 `Effect` import 与 `WriteError` 类型 import。`WriteOperationReceipt` 与 `WriteTarget` 保留——两者各有大量其他消费者。
- `packages/application/src/index.ts` —— 从 re-export 移除 `runTaskLifecycleEffect`；`makeTaskLifecycleService` 与 `TaskLifecycleOperationConflict` 不变。
- `packages/kernel/src/domain/errors.ts` —— 删除已成零消费者的 `WriteError` union。
- `packages/kernel/src/domain/index.ts` —— 移除 `WriteError` re-export。
- `tools/check-implementation-contracts.mjs` —— 从 `runPromise` 规则中删掉 `!rel.startsWith("packages/application/src/") && `。**检测正则一字未动，`packages/cli/src/` 豁免保留**——CLI 是标准认可的 composition root。

**没有在任何门里新增任何 allowlist 条目。**

## 任务与范围

- Harness 任务：`task_876df82f52257b923b616a254c`
- 分支：`codex/runpromise-deadcode`
- 公开范围：5 个文件，涉及 `packages/application`、`packages/kernel/src/domain` 与一个门脚本。
- 私有计划 / 证据是否已更新：yes
- 范围外：把写路径接到 Effect error channel 上。那才是 `WriteError` 没有消费者的真实原因，属于设计问题，不是清理。

## 版本影响

- 版本：不改版本，原因是被删导出零消费者，无任何行为依赖它。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`tools/check-implementation-contracts.mjs` —— 从 `runPromise` 规则里删掉一个条件。未改检测正则、未改 `tools/gate-manifest.json`、未改任何 workflow、未改任何门的 tier 或 required 状态、任何位置都未加 `continue-on-error`。
- 依据：`harness/governance/standards/implementation-contract-standard.md` 早已把 `Effect.runPromise` 列在 `packages/application/src/` 的禁止列。本 PR 不改政策，只是让门执行标准已经发布的政策。任务 `task_876df82f52257b923b616a254c` 记录了 CEO 裁决，含对后续 `WriteError` finding **明确拒绝用 allowlist 解决**。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`d98337d060e59838fa592fe3d8bdadbddbdb8fcb`
- 当前分支与 `origin/main` 的 merge-base：`d98337d060e59838fa592fe3d8bdadbddbdb8fcb`
- 最近一次 `git fetch origin` 时间：2026-08-17T06:37:45Z
- 同步方式：#1488 合入后 rebase 到 `origin/main`；merge-base 现已等于 `origin/main` HEAD
- 公开 diff 命令：`git diff --stat origin/main...codex/runpromise-deadcode` → 5 文件，4 增，22 删
- 生产代码行数增减：`+3/-21`（门要求的机读声明行在英文块）
- 私有证据 commit/path：任务包 `task_876df82f52257b923b616a254c`，`artifacts/report-runpromise-deadcode.md` 与 `artifacts/check-local-final.txt`（925 行 runner 输出）
- Reviewer 证据路径：同一任务包，`artifacts/resume-01-writeerror-adjudication.md` 记录了 CEO 对后续 finding 的裁决
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑
- [x] `npm run check:local` —— 37 步全绿，41.3 秒。本仓本地停止点，步骤由 gate manifest 派生，包含运行被改门的 `boundaries` 面。
- [x] `npx tsc -b` —— 退出码 0。
- [x] `packages/application/test/` 既有测试 —— 通过。
- [x] **阴性对照**：改动生效后，在 `packages/application/src/` 下某文件临时插入一行 `Effect.runPromise(...)`，门**拒绝**了它；撤销该行后门通过。没有这一步，「门现在会执法」只是断言而非证据——**一道根本没跑到该文件的门，和一道放行了它的门，输出长得一模一样。**
- [x] 连锁分析：删掉 `WriteError` 后**没有**冒出第三环零消费者导出。同行 import 的 `WriteOperationReceipt` 与 `WriteTarget` 各有大量消费者，这一点是在删除**之前**核实的，不是等门红了才发现。
- [ ] GitHub Actions `rewrite-ci` passed —— 本 PR 上待跑
- 未运行：模板中逐条列出的 `npm run harness:*` 命令未逐个单独调用。`npm run check:local` 的步骤清单由 gate manifest 派生并已覆盖它们。完整门矩阵是 GitHub CI 的职责。

## 审查证据

- 自查：CEO 审阅了完整 diff。确认：门的检测正则逐字节未改；`packages/cli/src/` 豁免完好；任何门里都没有新增 allowlist 条目；`packages/application/src/` 下 grep `runPromise` 为零；`packages` 与 `tools` 全仓 grep `WriteError` 为零。
- Reviewer subagent：未使用。本次是带阴性对照的删除，验收判据可机械核对且已直接核对。
- 人工审查：待泽宇
- 阻塞发现：无。实现过程中命中过一次 checkpoint（`WriteError` finding），worker 停手报告而非自行解决，CEO 裁决后才继续。

## 残余风险

- `WriteError` 描述了四种写入失败形态（`WriteRejected`、`WriteConflict`、`GlobalWriteConflict`、`JournalUnavailable`）。删除它，等于把这份分类从 domain 层的成文记录中移除。它从未被任何 contract 或 schema 声明引用，因此无人消费；但若日后把写路径迁到 typed error channel，这个形状是合理的起点，且保存在本 PR 的历史里。
- 门现在比以前严。若将来 `packages/application/src/` 的代码确需运行 Effect，必须改在 CLI 或 daemon 的 composition root 上。这本就是标准的要求，本 PR 只是让它从愿望变成执法。

## 关联材料

- 任务：`task_876df82f52257b923b616a254c`
- 证据：任务包 `artifacts/report-runpromise-deadcode.md`、`artifacts/check-local-final.txt`
- 审查：`artifacts/resume-01-writeerror-adjudication.md`；缺陷由 DDD 领域建模研究 pack 第二轮生态调研发现
