### PR TITLE
fix(cli): pair the CLI overhead perf samples instead of dividing batch medians

### DIFF
--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -234,49 +234,49 @@ test("resident daemon CLI write p50 includes process startup through parsed rece
     execFileSync("npm", ["run", "build", "--workspace", "@harness-anything/cli"], { cwd: process.cwd(), stdio: "pipe" });
     assert.equal(run(fixture.alpha, fixture.userRoot, ["daemon", "start", "--service"], builtCli).ok, true);
     register(fixture.alpha, fixture.userRoot, "alpha", builtCli);
-    const daemonSamples: number[] = [];
+    // All three terms are measured adjacently inside one iteration, and the ratio is
+    // formed per iteration. Collecting them as three sequential batches and dividing
+    // p50 by p50 does not cancel machine speed: the batches see different moments, and
+    // the bare-spawn batch ran last, after ~22 spawns had already warmed the page cache
+    // for the Node binary, so the denominator was systematically the most favourable
+    // number in the run. That is how this gate reported 6.450x and 1.650x for the same
+    // commit with no diff (runs 32002647956 and its rerun).
+    const daemonSamples: number[] = [], cliSamples: number[] = [], bareSamples: number[] = [], ratios: number[] = [];
     for (let index = 0; index < 11; index += 1) {
-      const started = performance.now();
+      const daemonStarted = performance.now();
       const response = await requestLocalDaemonJsonRpc(fixture.alpha, "repo.task.create", { repo: { repoId: "alpha" },
         payload: { taskId: `task-daemon-latency-${index}`, title: `Daemon latency ${index}` } }, 1_000,
       { userRoot: fixture.userRoot });
-      daemonSamples.push(performance.now() - started);
+      const daemonElapsed = performance.now() - daemonStarted;
       assert.equal(response.ok, true, JSON.stringify(response));
-    }
-    const samples: number[] = [];
-    for (let index = 0; index < 11; index += 1) {
-      const started = performance.now();
+      const cliStarted = performance.now();
       const receipt = run(fixture.alpha, fixture.userRoot,
         ["task", "create", "--id", `task-latency-${index}`, "--admin", "--title", `Latency ${index}`], builtCli);
-      samples.push(performance.now() - started);
+      const cliElapsed = performance.now() - cliStarted;
       assert.equal(receipt.outcome, "applied", JSON.stringify(receipt));
-    }
-    const bareSamples: number[] = [];
-    for (let index = 0; index < 11; index += 1) {
-      const started = performance.now();
+      const bareStarted = performance.now();
       spawnSync(process.execPath, ["-e", ""], { stdio: "ignore" });
-      bareSamples.push(performance.now() - started);
+      const bareElapsed = performance.now() - bareStarted;
+      daemonSamples.push(daemonElapsed); cliSamples.push(cliElapsed); bareSamples.push(bareElapsed);
+      ratios.push((cliElapsed - daemonElapsed) / bareElapsed);
     }
-    const ordered = [...samples].sort((left, right) => left - right), p50 = ordered[Math.floor(ordered.length / 2)]!;
-    const daemonOrdered = [...daemonSamples].sort((left, right) => left - right), daemonP50 = daemonOrdered[Math.floor(daemonOrdered.length / 2)]!;
-    const bareOrdered = [...bareSamples].sort((left, right) => left - right), bareP50 = bareOrdered[Math.floor(bareOrdered.length / 2)]!;
-    const cliOverhead = p50 - daemonP50, overheadRatio = cliOverhead / bareP50;
-    context.diagnostic(`latency-window=before-cli-process-spawn-through-exit-and-parsed-receipt daemon=resident samples=${samples.length} p50=${p50.toFixed(3)}ms min=${ordered[0]!.toFixed(3)}ms max=${ordered.at(-1)!.toFixed(3)}ms`);
-    context.diagnostic(`latency-segment=resident-daemon-socket-through-parsed-receipt samples=${daemonSamples.length} p50=${daemonP50.toFixed(3)}ms min=${daemonOrdered[0]!.toFixed(3)}ms max=${daemonOrdered.at(-1)!.toFixed(3)}ms inferred-cli-process-startup-parse-render-p50=${cliOverhead.toFixed(3)}ms`);
-    context.diagnostic(`latency-baseline=bare-node-process-spawn samples=${bareSamples.length} p50=${bareP50.toFixed(3)}ms cli-overhead-over-bare-spawn=${overheadRatio.toFixed(3)}x`);
+    const p50 = median(cliSamples), daemonP50 = median(daemonSamples), bareP50 = median(bareSamples), overheadRatio = median(ratios);
+    const orderedRatios = [...ratios].sort((left, right) => left - right);
+    context.diagnostic(`latency-window=before-cli-process-spawn-through-exit-and-parsed-receipt daemon=resident samples=${cliSamples.length} p50=${p50.toFixed(3)}ms min=${Math.min(...cliSamples).toFixed(3)}ms max=${Math.max(...cliSamples).toFixed(3)}ms`);
+    context.diagnostic(`latency-segment=resident-daemon-socket-through-parsed-receipt samples=${daemonSamples.length} p50=${daemonP50.toFixed(3)}ms min=${Math.min(...daemonSamples).toFixed(3)}ms max=${Math.max(...daemonSamples).toFixed(3)}ms`);
+    context.diagnostic(`latency-baseline=bare-node-process-spawn samples=${bareSamples.length} p50=${bareP50.toFixed(3)}ms min=${Math.min(...bareSamples).toFixed(3)}ms max=${Math.max(...bareSamples).toFixed(3)}ms`);
+    context.diagnostic(`latency-ratio=paired-cli-overhead-over-bare-spawn samples=${ratios.length} p50=${overheadRatio.toFixed(3)}x min=${orderedRatios[0]!.toFixed(3)}x max=${orderedRatios.at(-1)!.toFixed(3)}x`);
     // The thin CLI's own cost is everything outside the daemon round-trip: spawning a
     // process, loading its modules, parsing, rendering. Measured against a bare Node
-    // spawn on the same machine in the same window, so machine speed and load cancel —
-    // an absolute millisecond bound here would only assert how fast the runner is, and
-    // dec_01KY6X4J486MZ35RW1QN51V2V1 restricts performance gates to relative overhead.
-    // It fails if the CLI grows eager module loading, or stops delegating to the
-    // resident daemon and starts doing the write in its own process. Measured basis:
-    // 1.26x across repeated local runs at load average 7.9 (both terms are process
-    // spawns, so the ratio barely moves with load); injecting 120 ms of synthetic
-    // startup into the CLI entry raised it to 2.50x. The bound is set so a doubling
-    // of the thin CLI's own cost fails.
+    // spawn taken immediately after it, so machine speed and load cancel within each
+    // pair — an absolute millisecond bound here would only assert how fast the runner
+    // is, and dec_01KY6X4J486MZ35RW1QN51V2V1 restricts performance gates to relative
+    // overhead. It fails if the CLI grows eager module loading, or stops delegating to
+    // the resident daemon and starts doing the write in its own process. The bound is
+    // unchanged at 3: it was never the problem, and raising it to accommodate an
+    // unstable reading would have treated the display instead of the instrument.
     assert.equal(overheadRatio <= 3, true,
-      `thin CLI overhead was ${overheadRatio.toFixed(3)}x a bare Node spawn (cli=${cliOverhead.toFixed(3)}ms, bare=${bareP50.toFixed(3)}ms, total=${p50.toFixed(3)}ms, daemon=${daemonP50.toFixed(3)}ms)`);
+      `thin CLI overhead was ${overheadRatio.toFixed(3)}x a bare Node spawn (paired p50; spread ${orderedRatios[0]!.toFixed(3)}x-${orderedRatios.at(-1)!.toFixed(3)}x, cli=${p50.toFixed(3)}ms, bare=${bareP50.toFixed(3)}ms, daemon=${daemonP50.toFixed(3)}ms)`);
   } finally { stop(fixture.alpha, fixture.userRoot, builtCli); rmSync(fixture.root, { recursive: true, force: true }); }
 });
 
@@ -292,6 +292,8 @@ function initialize(root: string): void { mkdirSync(path.join(root, "harness"), 
   writeFileSync(path.join(root, "harness/people.yaml"), `schema: harness-people/v1\npeople:\n  - personId: owner\n    displayName: Owner\n    primaryEmail: owner@example.test\n    roles: [owner]\n    credentials:\n      - kind: unix-socket-owner-boundary\n        issuer: host:${hostname()}\n        subject: ${process.getuid?.() ?? 0}\nroles:\n  - roleId: owner\n    commandClasses: [admin, repo-write, repo-read, arbiter]\n`, "utf8");
   git(root, "init", "--quiet");
   git(root, "add", "harness/harness.yaml", "harness/people.yaml"); git(root, "commit", "--quiet", "-m", "fixture"); }
+function median(values: readonly number[]): number { const ordered = [...values].sort((left, right) => left - right); return ordered[Math.floor(ordered.length / 2)]!; }
+
 function register(root: string, userRoot: string, repoId: string, entry = cli): void { assert.equal(run(root, userRoot,
   ["daemon", "repo", "register", "--repo-id", repoId, "--root", root, "--no-link"], entry).ok, true); }
 function run(root: string, userRoot: string, args: readonly string[], entry = cli): Record<string, unknown> { const result = runMaybe(root, userRoot, args, entry);


### PR DESCRIPTION
# English

## Summary

`resident daemon CLI write p50` reported `6.450x` and `1.650x` for commit `9485139f` with no diff between the two runs. It is a required-shaped assertion on `main` that reds at some probability rather than on a regression.

The cause is not the bound. The gate collected its three terms as **sequential batches** — 11 daemon round-trips, then 11 CLI invocations, then 11 bare `node` spawns — and then divided `p50` by `p50`. Sequential batches do not cancel machine speed, and the bare-spawn batch ran **last**, after roughly 22 process spawns had already warmed the page cache for the Node binary. The denominator was therefore systematically the most favourable number in the run, and the run that red had the fastest bare spawn ever observed (`19.1ms` against `36–42ms` everywhere else). The gate reported its worst number on the machine that was quickest at the thing in its denominator.

This PR measures all three terms adjacently inside one iteration and takes the median of the per-iteration ratios. **The bound stays at 3.**

## What Changed

- `packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts:237` — one interleaved loop replaces three sequential ones. Each iteration measures a daemon round-trip, a CLI invocation, and a bare spawn back-to-back, and pushes `(cli - daemon) / bare` as that iteration's ratio.
- Same file, `:260` — the assertion reads the median of the ratios rather than a ratio of medians.
- Same file — new `latency-ratio=paired-cli-overhead-over-bare-spawn` diagnostic carrying `p50/min/max`, so the next person debugging a red sees the distribution. The old `cli-overhead-over-bare-spawn` suffix on the baseline line is gone: it described a number that is no longer what is asserted.
- Same file, `:295` — small `median` helper, since three call sites now need it.
- The comment block above the assertion records why the batch form was wrong, so the next reader does not re-introduce it.

## Task And Scope

- Harness task: `task_efb427d448f511657ad3267ebf`
- Branch: `codex/perf-gate-pairing`
- Public scope: one test file. No production file is touched.
- Private planning/evidence updated: yes — plan, and fact `F-69B1D578` carrying the two contradictory readings.
- Out of scope: the sample count stays at 11. The plan allowed raising it if the paired spread was still wide; it is not (±5%), so raising it would be a change with no evidence behind it.

## Version Impact

- Version: no version change. Test-only.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: `packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts` is not `tools/`, `.github/`, `gate-manifest.json`, a gate script, or a workflow. It does carry a gate's judgment, which is why the change was routed through its own task rather than folded into unrelated work. The assertion runs on pull requests through `integration-shard` as well as on `main` through `full-check`; the reds that prompted this work were the `full-check` ones, which is why they were only visible by inspecting `main` directly.
- Authority: `task_efb427d448f511657ad3267ebf`, opened after the same-SHA rerun falsified the regression reading. `dec_01KY6X4J486MZ35RW1QN51V2V1` restricts performance gates to relative overhead; this PR does not change that, it makes the relative measurement actually relative.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `e2dd925cda2b4b49d77e185b4d9a3265ba72d25e`
- Branch merge-base with `origin/main`: equals `origin/main` HEAD
- Sync method: none needed
- Public diff command: `git diff --stat origin/main...codex/perf-gate-pairing` → 1 file, 32 insertions, 30 deletions
Production-Delta: +0/-0
- Private evidence path: task package `task_efb427d448f511657ad3267ebf`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `npm run check:local` — green.
- [x] `npx tsc -b` — exit 0.
- [x] `node tools/gates/line-budget.mjs --base origin/main` — pass. Run explicitly because `check:local` does not cover it.
- [x] **Negative control — the one the old instrument fails.** Six consecutive runs on unchanged code, host load average 8.45–9.99: `2.292, 2.438, 2.333, 2.485, 2.303, 2.234`. Spread `2.234–2.485`, about ±5%. The old scheme's observed spread on identical code was `1.215–6.450`, a factor of 5.3.
- [x] **Positive control.** Injecting a 120 ms synthetic busy-wait after the last import in `packages/cli/src/index.ts` moved the ratio to `3.149x` and **the gate failed**, with the spread reported in the assertion message. Injection reverted; `git diff` on that file is empty.
- [x] The test was confirmed to actually execute (`pass 1`, not a zero-test green).
- [ ] GitHub Actions `rewrite-ci` passed — pending on this PR
- [x] **CI baseline under the paired scheme.** This assertion runs in two lanes — `integration-shard` on pull requests and `full-check` on `main` — so the PR run measures it directly. Run `32011738804`, `integration-shard (2)`, twice: `p50=2.535x` and `p50=2.593x` (bare baseline `25.7ms`). Combined with the six local runs, eight samples across two hosts whose bare-spawn cost differs by more than 2x (`25.7ms` on CI, `59ms` locally) span `2.234–2.593`, about ±7%. That is the point of the change: the reading no longer tracks the machine. The old scheme spanned `1.215–6.450` on unchanged code.

## Review Evidence

- Self-review: CEO wrote and verified this change. The diagnosis was reached by first suspecting an own merge (`#1488` converted an `import type` to a value import, a textbook startup regression) and then falsifying that structurally — the CLI's runtime import graph is `thin-command.ts` + `daemon/client.ts` → `daemon/src/protocol/*` and `daemon/src/client/local-daemon-target.ts`, which never reaches kernel. The same-SHA rerun then confirmed it.
- Reviewer subagent: not used.
- Human review: pending
- Blocking findings: none

## Residual Risk

- The per-pair difference `cli - daemon` can go negative when a daemon round-trip spikes above the CLI invocation it is paired with; the observed minima run to about `-3x`. The median is unaffected — the spread across six runs is ±5% — and the negative tail is now visible in the diagnostic, where it correctly indicates a daemon-side spike. Clamping it would hide that.
- Pairing measures the daemon round-trip adjacent to the CLI invocation rather than inside it. That is the closest available measurement without instrumenting the CLI itself, which would change the thing being measured.
- The headroom between the paired baseline (~2.35 locally) and the bound (3) is narrower than the old scheme's apparent headroom. That apparent headroom was not real — the old instrument crossed 3 on unchanged code. A tight bound over a stable measurement is worth more than a loose bound over a noisy one, but it does mean a legitimate CLI startup increase of roughly 40 ms will now red. That is the gate working.

## References

- Task: `task_efb427d448f511657ad3267ebf`
- Fact: `F-69B1D578`
- Evidence runs: `32002647956` (red, 6.450x) and its rerun on the same SHA (green, 1.650x)

---

# 中文

## 概要

`resident daemon CLI write p50` 在 commit `9485139f` 上，两次运行之间零 diff，读出了 `6.450x` 和 `1.650x`。它在 `main` 上按某个概率报红，而不是按回归报红。

病根不在阈值。这个门把三个量按**顺序分三批**采集——11 次 daemon 往返，然后 11 次 CLI 调用，然后 11 次裸 `node` spawn——再拿 `p50` 除 `p50`。顺序批次抵消不了机器快慢；而裸 spawn 那批跑在**最后**，此时已有约 22 次进程 spawn 把 Node 二进制的 page cache 焐热。于是分母系统性地取到全程最有利的数，报红那次的裸 spawn 是所有观测里最快的（`19.1ms`，别处都是 `36–42ms`）。**门在「最擅长做分母那件事」的机器上报出了最差的数。**

本 PR 把三个量交错到同一次迭代里相邻测量，取逐次比值的中位数。**阈值仍是 3。**

## 改动内容

- `packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts:237` —— 一个交错循环取代三个顺序循环。每次迭代背靠背测 daemon 往返、CLI 调用、裸 spawn，并压入该次的 `(cli - daemon) / bare`。
- 同文件 `:260` —— 断言读的是**比值的中位数**，不再是中位数的比值。
- 同文件 —— 新增 `latency-ratio=paired-cli-overhead-over-bare-spawn` 诊断，带 `p50/min/max`，让下一个排查红灯的人看到分布而不是一个孤零零的数。基线行上原来的 `cli-overhead-over-bare-spawn` 后缀已删除：它描述的数已经不是被断言的那个了。
- 同文件 `:295` —— 小 `median` 辅助函数，三处调用点都需要。
- 断言上方的注释写清了批次形态错在哪，免得下一个读者把它改回去。

## 任务与范围

- Harness 任务：`task_efb427d448f511657ad3267ebf`
- 分支：`codex/perf-gate-pairing`
- 公开范围：一个测试文件。不触碰任何生产文件。
- 私有计划 / 证据是否已更新：yes —— plan，以及承载两个互相矛盾读数的 fact `F-69B1D578`。
- 范围外：采样数仍是 11。plan 允许在配对后离散度仍大时调高它；实测不大（±5%），调高就成了没有证据支撑的改动。

## 版本影响

- 版本：不改版本。纯测试。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：`packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts` 不属于 `tools/`、`.github/`、`gate-manifest.json`、门脚本或 workflow。但它承载门的判定，所以这次改动走了独立任务，而不是塞进无关工作里。这条断言在 PR 上通过 `integration-shard` 运行、在 `main` 上通过 `full-check` 运行；引出本次工作的红灯是 `full-check` 那一侧，所以只有直查 `main` 才看得见。
- 依据：`task_efb427d448f511657ad3267ebf`，在同 SHA 重跑证伪「这是回归」之后开出。`dec_01KY6X4J486MZ35RW1QN51V2V1` 规定性能门只测相对开销；本 PR 不改这条，只是让这个「相对」真正相对起来。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`e2dd925cda2b4b49d77e185b4d9a3265ba72d25e`
- 当前分支与 `origin/main` 的 merge-base：等于 `origin/main` HEAD
- 同步方式：不需要
- 公开 diff 命令：`git diff --stat origin/main...codex/perf-gate-pairing` → 1 文件，32 增，30 删
- 生产代码行数增减：`+0/-0`（机读声明行在英文块）
- 私有证据路径：任务包 `task_efb427d448f511657ad3267ebf`
- Reviewer 证据路径：同上
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑
- [x] `npm run check:local` —— 绿。
- [x] `npx tsc -b` —— 退出码 0。
- [x] `node tools/gates/line-budget.mjs --base origin/main` —— pass。显式单跑，因为 `check:local` 不覆盖它。
- [x] **阴性对照 —— 正是旧仪器过不了的那一关。** 同码连跑 6 次，宿主 load average 8.45–9.99：`2.292, 2.438, 2.333, 2.485, 2.303, 2.234`。跨度 `2.234–2.485`，约 ±5%。旧方案在同一份代码上的实测跨度是 `1.215–6.450`，5.3 倍。
- [x] **阳性对照。** 在 `packages/cli/src/index.ts` 最后一条 import 之后注入 120ms 合成忙等，比值升到 `3.149x`，**门失败**，报错里带上了 spread。注入已还原，该文件 `git diff` 为空。
- [x] 已确认测试真的执行了（`pass 1`，不是跑了 0 个测试的假绿）。
- [ ] GitHub Actions `rewrite-ci` passed —— 本 PR 上待跑
- [x] **配对方案在 CI 上的基线。** 这条断言跑在两条道上——PR 上走 `integration-shard`，`main` 上走 `full-check`——所以本 PR 的 run 直接量到了它。run `32011738804`、`integration-shard (2)` 跑了两次：`p50=2.535x` 与 `p50=2.593x`（裸 spawn 基线 `25.7ms`）。连同本机六次，八个样本横跨两台裸 spawn 成本相差一倍以上的机器（CI `25.7ms`，本机 `59ms`），跨度 `2.234–2.593`，约 ±7%。这正是本次改动的要点：读数不再跟着机器走。旧方案在同一份代码上的跨度是 `1.215–6.450`。

## 审查证据

- 自查：CEO 亲自实现并验证。诊断路径是先怀疑自己合的东西（`#1488` 把 `import type` 改成了值导入，教科书式启动回归），再从结构上证伪它——CLI 的运行时 import 图是 `thin-command.ts` + `daemon/client.ts` → `daemon/src/protocol/*` 与 `daemon/src/client/local-daemon-target.ts`，**根本到不了 kernel**。随后同 SHA 重跑确认。
- Reviewer subagent：未使用。
- 人工审查：待泽宇
- 阻塞发现：无

## 残余风险

- 逐对差 `cli - daemon` 在 daemon 往返 spike 超过与之配对的 CLI 调用时会变负，实测最小值到约 `-3x`。中位数不受影响（6 次跨度 ±5%），且负尾现在显示在诊断里，它正确地指示了 daemon 侧的 spike。把它 clamp 掉反而会藏住这个信息。
- 配对测的是与 CLI 调用**相邻**的 daemon 往返，不是嵌在其内部的那次。在不给 CLI 自身埋点的前提下这是最接近的测法；埋点会改变被测对象本身。
- 配对基线（本机约 `2.35`）到阈值 3 的余量，比旧方案表面上的余量更窄。但旧方案那个余量是假的——它在同码上就越过了 3。稳定测量上的紧阈值，比噪声测量上的松阈值更值钱；不过这确实意味着 CLI 启动**正当地**增加约 40ms 也会红。那是门在工作。

## 关联材料

- 任务：`task_efb427d448f511657ad3267ebf`
- 事实：`F-69B1D578`
- 证据 run：`32002647956`（红，6.450x）与其同 SHA 重跑（绿，1.650x）
