### PR TITLE
fix(cli): raise the CLI overhead bound to 4 against the corrected measurement

### DIFF
--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -272,10 +272,23 @@ test("resident daemon CLI write p50 includes process startup through parsed rece
     // pair — an absolute millisecond bound here would only assert how fast the runner
     // is, and dec_01KY6X4J486MZ35RW1QN51V2V1 restricts performance gates to relative
     // overhead. It fails if the CLI grows eager module loading, or stops delegating to
-    // the resident daemon and starts doing the write in its own process. The bound is
-    // unchanged at 3: it was never the problem, and raising it to accommodate an
-    // unstable reading would have treated the display instead of the instrument.
-    assert.equal(overheadRatio <= 3, true,
+    // the resident daemon and starts doing the write in its own process.
+    //
+    // The bound is 4, derived rather than chosen. The old bound of 3 was calibrated
+    // against a measurement that systematically under-read: the bare-spawn batch ran
+    // last, after ~22 spawns had warmed the page cache, so the denominator was too
+    // small and the reading too low. With the denominator fixed, the enforcement lane
+    // (full-check) reads 3.086 / 3.106 / 3.072 / 3.071 — stable to ±0.6%, and above the
+    // old bound. Keeping 3 would have failed every run; the bound was never calibrated
+    // against a correct instrument in the first place.
+    //
+    // 4 preserves the original design's sensitivity in absolute terms, which is what
+    // the gate actually protects. Old: (3 - 2.028) x 37.9ms bare = 36.8ms of added CLI
+    // startup before it fires. New: (4 - 3.08) x 33.7ms bare = 31.0ms. The gate gets
+    // slightly stricter in milliseconds while gaining 1.29x headroom over the worst
+    // observed reading. 3.5 leaves only 1.13x headroom; 4.5 relaxes sensitivity to
+    // 47.9ms, looser than the design it replaces.
+    assert.equal(overheadRatio <= 4, true,
       `thin CLI overhead was ${overheadRatio.toFixed(3)}x a bare Node spawn (paired p50; spread ${orderedRatios[0]!.toFixed(3)}x-${orderedRatios.at(-1)!.toFixed(3)}x, cli=${p50.toFixed(3)}ms, bare=${bareP50.toFixed(3)}ms, daemon=${daemonP50.toFixed(3)}ms)`);
   } finally { stop(fixture.alpha, fixture.userRoot, builtCli); rmSync(fixture.root, { recursive: true, force: true }); }
 });


### PR DESCRIPTION
# English

## Summary

`#1491` paired the samples of the CLI overhead gate and removed a real defect: the bare-spawn batch ran last, after ~22 spawns had warmed the page cache, so the denominator was systematically the most favourable number in the run. With that fixed the instrument became stable — and it stably reads above the bound on the enforcement lane. `main` went red on every run.

The bound of 3 was never calibrated against a correct instrument. This PR raises it to 4, derived from the sensitivity the original design was protecting rather than from the number that makes the red go away. **Adjudicated by the repository owner**, who owns the gate's judgment; I did not move it on my own authority, and `#1491` explicitly promised not to.

## What Changed

- `packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts:280` — `overheadRatio <= 3` becomes `overheadRatio <= 4`.
- Same file — the comment block now records the derivation and the two rejected alternatives, so the next person to touch this number sees why it is 4 and not a rounder figure.

## The derivation

The gate protects against the CLI growing eager module loading or doing the write in its own process. What it can actually detect is an increase in the CLI's own startup cost, in milliseconds. That is the quantity to hold constant across a recalibration.

| | baseline reading | bare spawn | bound | fires after |
| --- | --- | --- | --- | --- |
| Original design | 2.028x | 37.9ms | 3 | **36.8ms** of added CLI startup |
| Corrected instrument | 3.08x | 33.7ms | **4** | **31.0ms** |
| — rejected: 3.5 | 3.08x | 33.7ms | 3.5 | 14.2ms, but only 1.13x headroom over the worst observed reading |
| — rejected: 4.5 | 3.08x | 33.7ms | 4.5 | 47.9ms, looser than the design it replaces |

So the gate becomes slightly **stricter** in the units that matter, while gaining 1.29x headroom over the worst observed reading (`3.106x`).

## Task And Scope

- Harness task: `task_efb427d448f511657ad3267ebf`
- Branch: `codex/perf-gate-bound`
- Public scope: one test file, one assertion constant and its comment.
- Private planning/evidence updated: yes — facts `F-69B1D578` (the two contradictory readings that opened this) and `F-E5504512` (the paired distribution).
- Out of scope, and recorded as a residual finding rather than fixed here: the numerator `cli_total - daemon_segment` is a difference between two *different* operations — a CLI `task create` and a standalone `repo.task.create` round-trip. Across runs on effectively the same code that difference has read 44, 77, 94 and 104ms. Pairing removed the denominator's bias; it does not make the numerator a measurement of one thing. That is a redesign, not a constant.

## Version Impact

- Version: no version change. Test-only.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: `packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts` is not `tools/`, `.github/`, `gate-manifest.json`, a gate script, or a workflow. It carries a gate's judgment, which is why the bound was taken to the repository owner rather than moved during triage.
- Authority: `task_efb427d448f511657ad3267ebf`, plus the owner's explicit adjudication to raise the bound. `dec_01KY6X4J486MZ35RW1QN51V2V1` restricts performance gates to relative overhead; the assertion stays relative.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `c36a6bbe57afbef32e26ce9b9b6619eb46e7db95`
- Branch merge-base with `origin/main`: equals `origin/main` HEAD at branch creation
- Sync method: none needed
- Public diff command: `git diff --stat origin/main...codex/perf-gate-bound` → 1 file, 17 insertions, 4 deletions
Production-Delta: +0/-0
- Private evidence path: task package `task_efb427d448f511657ad3267ebf`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `npm run check:local` — green.
- [x] `npx tsc -b` — exit 0.
- [x] `node tools/gates/line-budget.mjs --base origin/main` — pass.
- [x] **Negative control at the new bound.** Baseline run: `p50=2.270x`, green.
- [x] **Positive control re-run at the new bound.** The 120ms injection used for `#1491` is no longer sufficient evidence once the bound moves, so it was redone: injecting a 300 ms busy-wait after the last import in `packages/cli/src/index.ts` produced `p50=6.433x` and **the gate failed**. Injection reverted; `git diff` on that file is empty.
- [x] The enforcement-lane readings this recalibration is based on are four real measurements: `3.086 / 3.106 / 3.072 / 3.071` from `full-check (24)` and `(26)` on `c36a6bbe`. **Corrected after merge:** those four come from one run and its same-SHA rerun, so they are correlated, not four independent samples. Later independent runs read `2.950`, `2.822` and `2.663`. The honest observed CI range is `2.663-3.106`. See fact `F-410AB5C9`.
- [ ] GitHub Actions `rewrite-ci` passed — pending on this PR
- Also observed on those runs and **not** addressed here: `startup recovery is independent of 100 versus 10,000-event history` red with `ratio=2.490`, then read `2.886` and `1.145` on the same SHA. It is a second ratio-of-timings assertion in the same family, it is genuinely unstable rather than stably over its bound, and `c36a6bbe` was a test-only change that cannot slow event recovery. It needs its own task; this PR does not touch it.

## Review Evidence

- Self-review: CEO wrote and verified this change. The chain of reasoning is recorded honestly in the task and in `#1491`: an own merge was suspected first and falsified structurally, then the denominator defect was found and fixed, and only then did the corrected instrument show the bound itself was mis-calibrated.
- Reviewer subagent: not used.
- Human review: the bound was adjudicated by the repository owner before this PR was written.
- Blocking findings: none

## Residual Risk

- The recalibration rests on readings from one lane on one day. If `full-check` drifts upward for unrelated reasons, 1.29x headroom is not generous. **Corrected after merge:** this section originally claimed the reading is "stable to ±0.6%". That figure came from a correlated sample of four and was wrong. The independently observed spread is `2.663-3.106`, about ±8%. The bound of 4 still clears the observed maximum by 1.29x, so the recalibration stands, but the stability claim as published was too flattering.
- The numerator's construction is unchanged and remains the dominant source of run-to-run movement in this measurement. Recorded above as out of scope; it deserves a task of its own rather than another constant.
- The second red assertion in the same family is left running. Leaving a known-unstable gate in place is a deliberate choice to keep this PR to one judgment, not an oversight.

## References

- Task: `task_efb427d448f511657ad3267ebf`
- Facts: `F-69B1D578`, `F-E5504512`
- Prior PR: `#1491` (pairing), `#1490` (the CLI/lease fixes that were briefly and wrongly suspected)

---

# 中文

## 概要

`#1491` 把 CLI 开销门的采样改成配对，修掉了一个真实缺陷：裸 spawn 那批跑在最后，此时已有约 22 次 spawn 把 page cache 焐热，分母系统性地取到全程最有利的数。修完之后仪器稳了——而它**稳定地**在执法道上读出高于阈值的值，`main` 每跑必红。

阈值 3 从来没有对着一个正确的仪器校准过。本 PR 把它提到 4，依据是**原设计要守护的灵敏度**，不是「让红灯消失的那个数」。**由仓库所有者裁定**——门的判定归他，我没有自决，`#1491` 里也白纸黑字承诺过不动它。

## 改动内容

- `packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts:280` —— `overheadRatio <= 3` 改为 `overheadRatio <= 4`。
- 同文件 —— 注释块记录了推导过程与两个被否掉的候选，让下一个碰这个数的人看得到它为什么是 4 而不是某个更圆的数。

## 推导

这个门要防的是 CLI 变成 eager module loading、或不再委托 daemon 而自己写。它**实际能探测的**是 CLI 自身启动成本的增量，单位是毫秒。重新校准时该守恒的就是这个量。

| | 基线读数 | 裸 spawn | 阈值 | 多少增量才触发 |
| --- | --- | --- | --- | --- |
| 原设计 | 2.028x | 37.9ms | 3 | **36.8ms** |
| 修正后仪器 | 3.08x | 33.7ms | **4** | **31.0ms** |
| —— 否掉：3.5 | 3.08x | 33.7ms | 3.5 | 14.2ms，但对最差观测值只剩 1.13x 余量 |
| —— 否掉：4.5 | 3.08x | 33.7ms | 4.5 | 47.9ms，比它取代的设计还松 |

所以门在真正要紧的单位上反而**更严**了一点，同时对最差观测值（`3.106x`）拿到 1.29x 余量。

## 任务与范围

- Harness 任务：`task_efb427d448f511657ad3267ebf`
- 分支：`codex/perf-gate-bound`
- 公开范围：一个测试文件，一个断言常量及其注释。
- 私有计划 / 证据是否已更新：yes —— fact `F-69B1D578`（引出此事的两个互相矛盾的读数）与 `F-E5504512`（配对后的分布）。
- 范围外，作为残余发现记录而非在此修复：分子 `cli_total - daemon_segment` 是两个**不同操作**之差——CLI 的 `task create` 与独立的 `repo.task.create` 往返。在实质相同的代码上，这个差历次读出 44、77、94、104ms。配对消除了分母的偏置，但没能让分子变成对同一件事的测量。那是重新设计，不是一个常量。

## 版本影响

- 版本：不改版本。纯测试。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：`packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts` 不属于 `tools/`、`.github/`、`gate-manifest.json`、门脚本或 workflow。但它承载门的判定，所以阈值这件事是拿去给仓库所有者裁的，不是在排障途中顺手挪的。
- 依据：`task_efb427d448f511657ad3267ebf`，加上所有者明确裁定调高阈值。`dec_01KY6X4J486MZ35RW1QN51V2V1` 规定性能门只测相对开销；断言仍是相对的。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：`c36a6bbe57afbef32e26ce9b9b6619eb46e7db95`
- 当前分支与 `origin/main` 的 merge-base：等于分支创建时的 `origin/main` HEAD
- 同步方式：不需要
- 公开 diff 命令：`git diff --stat origin/main...codex/perf-gate-bound` → 1 文件，17 增，4 删
- 生产代码行数增减：`+0/-0`（机读声明行在英文块）
- 私有证据路径：任务包 `task_efb427d448f511657ad3267ebf`
- Reviewer 证据路径：同上
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑
- [x] `npm run check:local` —— 绿。
- [x] `npx tsc -b` —— 退出码 0。
- [x] `node tools/gates/line-budget.mjs --base origin/main` —— pass。
- [x] **新阈值下的阴性对照。** 基线运行 `p50=2.270x`，绿。
- [x] **新阈值下重做的阳性对照。** `#1491` 用的 120ms 注入在阈值挪动后不再构成证据，所以重做了：在 `packages/cli/src/index.ts` 最后一条 import 之后注入 300ms 忙等，读出 `p50=6.433x`，**门失败**。注入已还原，该文件 `git diff` 为空。
- [x] 本次重新校准所依据的执法道读数是四次真实测量：`c36a6bbe` 上 `full-check (24)` 与 `(26)` 的 `3.086 / 3.106 / 3.072 / 3.071`。**合并后更正**：这四个来自同一次 run 和它的同 SHA 重跑，是相关样本，不是四个独立样本。后续独立运行读出 `2.950`、`2.822`、`2.663`。诚实的 CI 观测区间是 `2.663-3.106`。见 fact `F-410AB5C9`。
- [ ] GitHub Actions `rewrite-ci` passed —— 本 PR 上待跑
- 同批运行中同时观察到、但**本 PR 不处理**的：`startup recovery is independent of 100 versus 10,000-event history` 以 `ratio=2.490` 报红，同 SHA 上又读出 `2.886` 与 `1.145`。它是同一族的第二条比值型时序断言，属于**真不稳**而非稳定超界；而 `c36a6bbe` 是纯测试改动，不可能拖慢事件恢复。它需要自己的任务，本 PR 一处不碰。

## 审查证据

- 自查：CEO 亲自实现并验证。推理链在任务与 `#1491` 里如实记录：先怀疑自己合的东西并从结构上证伪，再找到并修掉分母缺陷，直到修正后的仪器才显示出阈值本身校准有误。
- Reviewer subagent：未使用。
- 人工审查：阈值在本 PR 动笔之前已由仓库所有者裁定。
- 阻塞发现：无

## 残余风险

- 本次重新校准建立在一条道、一天之内的读数上。若 `full-check` 因无关原因整体上移，1.29x 余量并不宽裕。**合并后更正**：本节原称读数「稳定到 ±0.6%」。那个数字出自一个由四个相关样本构成的样本，是错的。独立观测到的跨度是 `2.663-3.106`，约 ±8%。阈值 4 对观测最大值仍有 1.29x 余量，重新校准的结论站得住，但已发布的那句稳定性声明比实际好看。
- 分子的构造未变，仍是这项测量中运行间波动的主要来源。已在上文记为范围外；它值得一个自己的任务，而不是又一个常量。
- 同族的第二条红断言被留着继续跑。留一条已知不稳的门在原地，是为了让本 PR 只承载一个判断，而不是疏忽。

## 关联材料

- 任务：`task_efb427d448f511657ad3267ebf`
- 事实：`F-69B1D578`、`F-E5504512`
- 前序 PR：`#1491`（配对）、`#1490`（一度被错误怀疑的 CLI/lease 修复）
