### PR TITLE
fix(gui): render the absent task-contract projection as the empty state

### DIFF
--- a/packages/gui/src/renderer/views/TaskDetailView.tsx
+++ b/packages/gui/src/renderer/views/TaskDetailView.tsx
@@ -98,11 +98,13 @@ export function TaskDetailView({
   const external = isExternal(task);
   const canonicalPackage = typeof task.packagePath === "string", contract = useTaskDocumentQuery(task.projectId, task.taskId, canonicalPackage ? "task-contract.json" : null);
   const contractModel = useMemo(() => {
-    if (!canonicalPackage) return { docs: task.packagePath === undefined ? task.docs : [], issue: null as string | null };
-    if (contract.isError) return { docs: [], issue: contract.error.message };
-    if (!contract.data || contract.data.status !== "ready") return { docs: [], issue: null };
-    try { return { docs: parseTaskContractDocuments(task.taskId, contract.data.body), issue: null }; }
-    catch (error) { return { docs: [], issue: error instanceof Error ? error.message : String(error) }; }
+    if (!canonicalPackage) return { docs: task.packagePath === undefined ? task.docs : [], issue: null as string | null, absent: false };
+    if (contract.isError) return { docs: [], issue: contract.error.message, absent: false };
+    if (!contract.data || contract.data.status !== "ready") return { docs: [], issue: null, absent: false };
+    // blobSha256 === null 的 ready 读数是「台账没有 contract 投影」(同 DocBody 的文档未物化信号),不是坏数据。
+    if (contract.data.blobSha256 === null) return { docs: [], issue: null, absent: true };
+    try { return { docs: parseTaskContractDocuments(task.taskId, contract.data.body), issue: null, absent: false }; }
+    catch (error) { return { docs: [], issue: error instanceof Error ? error.message : String(error), absent: false }; }
   }, [canonicalPackage, contract.data, contract.error, contract.isError, task.docs, task.packagePath, task.taskId]);
   const documentReads = useQueries({ queries: contractModel.docs.map((entry) => ({ ...taskDocumentQuery(task.projectId, task.taskId, entry.path) })) });
   const realDocs = useMemo(() => contractModel.docs.map((entry, index) => { const read = documentReads[index];
@@ -175,7 +177,7 @@ export function TaskDetailView({
         <nav className="w-56 shrink-0 overflow-y-auto border-r border-border bg-surface p-3">
           {docGroups.length === 0 ? (
             <div className="rounded-md border border-dashed border-border px-2 py-3 text-[12px] text-text-faint">
-              {contractModel.issue ? `task-contract ${t("views.taskDetailView.documentReadingFailed")}：${contractModel.issue}` : canonicalPackage && contract.isPending ? `${t("views.taskDetailView.reading")} canonical task-contract…` : t("views.taskDetailView.localLedgerBridgeDidNotReturn")}
+              {contractModel.issue ? `task-contract ${t("views.taskDetailView.documentReadingFailed")}：${contractModel.issue}` : contractModel.absent ? t("views.taskDetailView.thereNoProjectionDocumentTask") : canonicalPackage && contract.isPending ? `${t("views.taskDetailView.reading")} canonical task-contract…` : t("views.taskDetailView.localLedgerBridgeDidNotReturn")}
             </div>
           ) : (
             docGroups.map((g) => {

--- a/packages/gui/test/renderer-app-model.vitest.ts
+++ b/packages/gui/test/renderer-app-model.vitest.ts
@@ -255,6 +255,44 @@ describe("renderer app model", () => {
     }
   });
 
+  it("renders the projection empty state, not corruption, when the task has no task-contract projection", async () => {
+    const getTaskDocument = vi.fn(async ({ path }: { path: string }) => ({ ok: true, status: "ready", taskId: "task-legacy", path,
+      body: "", blobSha256: null, watermark: 9, sourceRevision: 9 }));
+    vi.stubGlobal("window", { harness: { getTaskDocument } });
+    const queryClient = new QueryClient();
+    try {
+      await queryClient.fetchQuery(taskDocumentQuery("project-1", "task-legacy", "task-contract.json"));
+      const task: TaskRow = { taskId: "task-legacy", title: "Legacy", projectId: "project-1", coordinationStatus: "planned", rawStatus: "planned",
+        freshness: "fresh", packageDisposition: "active", closeoutReadiness: "not_required", engine: "local", source: "snapshot-cache",
+        module: "gui", packagePath: "tasks/task-legacy-legacy", lastKnownAt: "2026-08-13T00:00:00.000Z", gates: [], docs: [] };
+      const markup = renderToStaticMarkup(createElement(QueryClientProvider, { client: queryClient }, createElement(TaskDetailView,
+        { task, onBack: () => undefined, projectName: "Harness" })));
+      expect(markup).toContain("该任务无投影文档");
+      expect(markup).not.toContain("文档读取失败");
+      expect(markup).not.toContain("not valid JSON");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("still reports a materialized but malformed task-contract body as invalid JSON", async () => {
+    const getTaskDocument = vi.fn(async ({ path }: { path: string }) => ({ ok: true, status: "ready", taskId: "task-broken", path,
+      body: "{ this is not json", blobSha256: "sha256:broken", watermark: 9, sourceRevision: 9 }));
+    vi.stubGlobal("window", { harness: { getTaskDocument } });
+    const queryClient = new QueryClient();
+    try {
+      await queryClient.fetchQuery(taskDocumentQuery("project-1", "task-broken", "task-contract.json"));
+      const task: TaskRow = { taskId: "task-broken", title: "Broken", projectId: "project-1", coordinationStatus: "planned", rawStatus: "planned",
+        freshness: "fresh", packageDisposition: "active", closeoutReadiness: "not_required", engine: "local", source: "snapshot-cache",
+        module: "gui", packagePath: "tasks/task-broken-broken", lastKnownAt: "2026-08-13T00:00:00.000Z", gates: [], docs: [] };
+      const markup = renderToStaticMarkup(createElement(QueryClientProvider, { client: queryClient }, createElement(TaskDetailView,
+        { task, onBack: () => undefined, projectName: "Harness" })));
+      expect(markup).toContain("task-contract 文档读取失败：task-contract projection is not valid JSON");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("parses canonical task-contract descriptors without inventing document presence", () => {
     expect(parseTaskContractDocuments("task-1", JSON.stringify({ schema: "task-contract/v1", taskId: "task-1", documents: [
       { slot: "task.plan", path: "task_plan.md", owner: "doc-sync", materializeAs: "task_plan.md", requiredAnchors: [], templateRef: "template://plan@1", contentSha256: "abc" },


### PR DESCRIPTION
# English

## Summary

Owner-reported from the GUI: opening an older task shows `task-contract 文档读取失败: task-contract projection is not valid JSON`. The message accuses the data of corruption. The measured reality: `getTaskDocument` returns a **successful** read with `body: ""` and `blobSha256: null` for a task whose contract projection was never materialized — absence, not corruption. `JSON.parse("")` throwing is what minted the error.

The fix is two production lines at the caller: `ready` + `blobSha256 === null` renders the existing empty state ("该任务无投影文档"). The parser is untouched — genuinely malformed JSON still reports malformed JSON.

The task's checkpoint also corrected its own premise: the plan said 2362 tasks lack a contract projection. That number was double-counted from the dry-run receipt, which prints every manual task twice (`report` and `manual` sections; 2×1181+64=2426 matches exactly). The real population is **1181 manual of 1247 tasks**, of which **290 are non-terminal** (240 planned / 42 active / 8 in_review). The 891 terminal ones are cosmetic. That breakdown is the evidence the owner asked for; no `--apply` was run.

## What Changed

- `packages/gui/src/renderer/views/TaskDetailView.tsx` — the contract model gains an absence branch: a `ready` document with `blobSha256 === null` is the not-materialized signal (the same signal `DocBody` already consumes) and renders the existing empty state instead of entering the parser.
- `packages/gui/test/renderer-app-model.vitest.ts` — a test that fails without the change (absent projection → empty state), plus the negative control: a materialized but malformed body still reports `task-contract projection is not valid JSON`.

## Task And Scope

- Harness task: `task_f27b6bf4db2a1642750c327893`
- Branch: `codex/contract-absence`
- Public scope: one renderer view plus one test file. Production delta +2/-2 in the view.
- Private planning/evidence updated: yes — plan checkpoint answers and `artifacts/report-contract-absence.md` with the measured daemon response, the queue breakdown, and before/after renders.
- Out of scope, reported not fixed: the dry-run receipt double-printing its `manual` section (the direct source of the 2362 misreading) is CLI contract surface and stays a reported finding. What to do with the 290 non-terminal manual tasks is the owner's policy call; this PR only produces the number.

## Version Impact

- Version: no version change. No command, flag, or field added or removed.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable — no changes to `tools/`, `.github/`, `gate-manifest.json`, any gate script, or any workflow.
- Authority: `task_f27b6bf4db2a1642750c327893`, opened from the owner's GUI report. No new command surface.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `8e4d376c43f618856c81d205958373674e111fca`
- Branch merge-base with `origin/main`: equals `origin/main` HEAD
- Sync method: none needed
- Public diff command: `git diff --stat origin/main...codex/contract-absence` → 2 files, 46 insertions, 6 deletions
Production-Delta: +8/-6
- Private evidence path: task package `task_f27b6bf4db2a1642750c327893`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] The owner's exact case (`task_01KWKRQAM9YA2SRQRB9NBYZRJM`) measured against the live daemon through the GUI's own bridge; the real response is in the report and drives the test fixture.
- [x] Positive test run red against HEAD before the fix, green after. Negative control (malformed materialized body) reports malformed before and after.
- [x] `npx tsc -b` exit 0; `test:gui` 26 files / 193 tests green; `npm run check:local` green.
- [x] Electron end-to-end cannot run from a worktree; stated plainly in the report. The rendered-state assertions are vitest-level.
- [ ] GitHub Actions `rewrite-ci` passed — pending on this PR

## Review Evidence

- CEO review: read the full diff. Confirmed the absence branch keys on `blobSha256 === null` (the daemon's explicit not-materialized signal) rather than on the body being empty, the parser is not widened, and the contract-present path is byte-identical.
- Implemented by a delegated worker (`agent:glm`); reviewed by the CEO before landing.
- Human review: pending
- Blocking findings: none

## Residual Risk

- The absence signal is `blobSha256 === null`; if the daemon ever materializes an empty-but-real contract, it would carry a hash and still route to the parser — which then correctly reports it malformed. No silent path.
- The 290 non-terminal manual tasks remain unable to render a contract until the owner decides on the queue; this PR makes that state legible, it does not drain it.

---

# 中文

## 摘要

泽宇在 GUI 里报告：打开旧任务显示 `task-contract 文档读取失败: task-contract projection is not valid JSON`。这句话在指控数据损坏。实测事实是：对从未物化 contract 投影的任务，`getTaskDocument` 返回**成功**读取，`body: ""` 且 `blobSha256: null`——是「没有」，不是「坏了」。是 `JSON.parse("")` 抛错铸造了这条错误。

修复是调用方两行生产代码：`ready` + `blobSha256 === null` 走既有空态（「该任务无投影文档」）。parser 一字未动——真正畸形的 JSON 仍报畸形。

Checkpoint 还纠正了任务自己的前提：plan 写 2362 个任务无 contract 投影，该数是 dry-run 回执**双重计数**（`report` 与 `manual` 两段把每个 manual 任务打印两遍；2×1181+64=2426 严丝合缝）。真实规模 **1247 任务中 1181 manual**，其中**非终态 290**（planned 240 / active 42 / in_review 8），终态 891 纯属观感。这就是要带给 owner 的数；未跑任何 `--apply`。

## 变更内容

- `packages/gui/src/renderer/views/TaskDetailView.tsx` — contract model 增加缺席分支：`ready` 且 `blobSha256 === null` 即「未物化」信号（`DocBody` 已在消费同一信号），渲染既有空态而不进 parser。
- `packages/gui/test/renderer-app-model.vitest.ts` — 没有本改动就红的测试（缺席投影 → 空态），以及阴性对照：已物化但畸形的 body 前后都报 `not valid JSON`。

## 任务与范围

- Harness 任务：`task_f27b6bf4db2a1642750c327893`
- 分支：`codex/contract-absence`
- 公开范围：一个 renderer 视图 + 一个测试文件；视图内生产 delta +2/-2。
- 私有规划/证据已更新：是——checkpoint 答案与 `artifacts/report-contract-absence.md`（实测 daemon 响应、队列分布、前后渲染）。
- 范围外（已报告未修）：dry-run 回执把 `manual` 段打印两遍（2362 误读的直接来源）属 CLI 契约面，留作 finding；290 个非终态 manual 任务怎么处理是 owner 的政策裁决，本 PR 只产出这个数字。

## 版本影响

- 版本：无变更。未增删任何命令、flag 或字段。
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用——未改 `tools/`、`.github/`、`gate-manifest.json`、任何门脚本或 workflow。
- 授权来源：`task_f27b6bf4db2a1642750c327893`，源自 owner 的 GUI 报告。无新命令面。
- 机器检查边界：本 PR 仅断言声明存在；是否真实充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- Base `origin/main` SHA：`8e4d376c43f618856c81d205958373674e111fca`
- 分支与 `origin/main` 的 merge-base：等于 `origin/main` HEAD
- 同步方式：无需
- 公开 diff 命令：`git diff --stat origin/main...codex/contract-absence` → 2 files, 46 insertions, 6 deletions
- 私有证据路径：任务包 `task_f27b6bf4db2a1642750c327893`
- 评审证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑
- [x] owner 原始用例（`task_01KWKRQAM9YA2SRQRB9NBYZRJM`）经 GUI 自己的桥对在线 daemon 实测；真实响应在报告里并作为测试 fixture。
- [x] 阳性测试对修复前 HEAD 实跑红、修复后绿；阴性对照（畸形已物化 body）前后都报畸形。
- [x] `npx tsc -b` 退出 0；`test:gui` 26 文件 / 193 测试全绿；`npm run check:local` 绿。
- [x] Electron 端到端在 worktree 跑不了，报告如实注明；渲染态断言在 vitest 层。
- [ ] GitHub Actions `rewrite-ci` 通过——本 PR 上待跑

## 评审证据

- CEO 评审：通读全 diff。确认缺席分支锚 `blobSha256 === null`（daemon 的显式未物化信号）而非「body 为空」，parser 未放宽，有 contract 的路径逐字节不变。
- 由受托 worker（`agent:glm`）实现；落地前经 CEO 评审。
- 人工评审：待定
- 阻塞性发现：无

## 残余风险

- 缺席信号是 `blobSha256 === null`；若 daemon 未来物化出「空但真实」的 contract，它会带 hash 并仍进 parser——届时正确地报畸形，没有静默路径。
- 290 个非终态 manual 任务在 owner 裁决队列政策前仍渲染不出 contract；本 PR 让这个状态可读，不负责清空它。
