### PR TITLE
refactor(kernel,gui,gates): DDD slice 4 — one canonical direction per relation, with its ratchet gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "harness:check-write-road-registry": "node tools/check-write-road-registry.mjs",
     "harness:check-kernel-dead-exports": "node tools/check-kernel-dead-exports.mjs",
     "harness:check-relation-cycle-substrate": "node tools/check-relation-cycle-substrate.mjs",
+    "harness:check-relation-canonical-direction": "node tools/check-relation-canonical-direction.mjs",
     "harness:check-enforcement-debt-sunset": "node tools/check-enforcement-debt-sunset.mjs",
     "pr:doctor": "node tools/pr-doctor.mjs"
   },

--- a/packages/gui/src/renderer/components/FactInspector.tsx
+++ b/packages/gui/src/renderer/components/FactInspector.tsx
@@ -1,6 +1,7 @@
 import { ArrowSquareOut, Graph, GitBranch, WarningCircle, X } from "@phosphor-icons/react";
 import type { DecisionRow, FactRef, RelationEdge, TaskRow } from "../model/types";
 import { normalizeDecisionId } from "../model/triadic";
+import { incomingRelations } from "../model/relation-direction.ts";
 import { CopyContextButton } from "./CopyContextButton";
 import { buildEntityJumpContext } from "../model/copy-context";
 import type { RelationCoverageRow } from "../../api/renderer-dto";
@@ -42,24 +43,10 @@ export function FactInspector({
   const fact = facts.find((candidate) => candidate.anchor === anchor);
   const task = fact ? tasks.find((candidate) => candidate.taskId === fact.taskId) : undefined;
   const inbound = relations.filter((relation) => relation.to === fullRef);
-  const outbound = relations.filter((relation) => relation.from === fullRef);
-  const contradictions = outbound.filter(
-    (relation) => relation.kind === "invalidated-by",
-  );
-  const supersedingRelations = inbound.filter(
-    (relation) => relation.kind === "supersedes-fact",
-  );
-  const directlySupportedDecisionIds = [...inbound, ...outbound]
-    .filter(
-      (relation) =>
-        (relation.kind === "supports" || relation.kind === "evidenced-by") &&
-        (relation.from.startsWith("decision/") || relation.to.startsWith("decision/")),
-    )
-    .map((relation) =>
-      normalizeDecisionId(
-        relation.from.startsWith("decision/") ? relation.from : relation.to,
-      ),
-    );
+  const contradictions = incomingRelations(fullRef, "refuted-by", relations);
+  const supersedingRelations = incomingRelations(fullRef, "supersedes-fact", relations);
+  const directlySupportedDecisionIds = incomingRelations(fullRef, "evidenced-by", relations)
+    .map((relation) => normalizeDecisionId(relation.from));
   const coveredDecisionIds = coverageRows
     .filter(
       (row) => row.status === "covered" && row.coveringFactRef === fullRef,
@@ -204,7 +191,7 @@ export function FactInspector({
                     <span className="text-text-faint">{shortEndpoint(relation.from)}</span>
                     <ArrowSquareOut weight="bold" className="text-[11px] text-text-faint" />
                     <span className={
-                      relation.kind === "invalidated-by" || relation.kind === "supersedes-fact"
+                      relation.kind === "refuted-by" || relation.kind === "supersedes-fact"
                         ? "text-stale"
                         : "text-accent"
                     }>
@@ -261,7 +248,7 @@ export function FactInspector({
             </div>
             {contradictions.length > 0 && (
               <div className="mt-1 font-mono text-[11px]">
-                {t("components.factInspector.contradictsValue", { value: contradictions.map((relation) => shortEndpoint(relation.to)).join(", ") })}
+                {t("components.factInspector.contradictsValue", { value: contradictions.map((relation) => shortEndpoint(relation.from)).join(", ") })}
               </div>
             )}
             {supersedingRelations.length > 0 && (

--- a/packages/gui/src/renderer/graph/territory.ts
+++ b/packages/gui/src/renderer/graph/territory.ts
@@ -1,5 +1,6 @@
 import type { TaskRow, DecisionRow, FactRef, RelationEdge } from "../model/types";
 import type { FactAnchorRow, RelationCoverageRow } from "../../api/renderer-dto";
+import { incomingRelations } from "../model/relation-direction.ts";
 import {
   resolveTaskModule,
   resolveFactModule,
@@ -168,21 +169,15 @@ export function classifyFactAnomaly(
   relations: ReadonlyArray<RelationEdge>,
   coveredRefs: ReadonlySet<string>,
 ): FactAnomaly {
-  // contradictory:被 invalidated-by 指向 或 fact.invalidated 标记。
+  // contradictory:fact.invalidated 标记,或作为 decision --refuted-by--> fact 的 target(规范方向反查)。
   if (fact?.invalidated) return "contradictory";
-  for (const e of relations) {
-    if (e.kind === "invalidated-by" && e.from === factRef) return "contradictory";
-  }
+  if (incomingRelations(factRef, "refuted-by", relations).length > 0) return "contradictory";
   // superseded:被 supersedes-fact 指向(是 target)。
-  for (const e of relations) {
-    if (e.kind === "supersedes-fact" && e.to === factRef) return "superseded";
-  }
+  if (incomingRelations(factRef, "supersedes-fact", relations).length > 0) return "superseded";
   // low-confidence。
   if (fact?.confidence === "low") return "low-confidence";
   // orphan:无 decision 引用(不在 coveredRefs 且无 evidenced-by 边指向它)。
-  const hasEvidence = relations.some(
-    (e) => e.kind === "evidenced-by" && e.to === factRef,
-  );
+  const hasEvidence = incomingRelations(factRef, "evidenced-by", relations).length > 0;
   if (!coveredRefs.has(factRef) && !hasEvidence) return "orphan";
   return "normal";
 }

--- a/packages/gui/src/renderer/model/fact-triage.ts
+++ b/packages/gui/src/renderer/model/fact-triage.ts
@@ -2,6 +2,7 @@ import type {
   FactAnchorRow,
   RelationCoverageRow,
 } from "../../api/renderer-dto";
+import { incomingRelations } from "./relation-direction.ts";
 import type { FactRef, RelationEdge } from "./types";
 
 /**
@@ -55,18 +56,14 @@ export function computeFactTriageSignals(
   const factRef = `fact/${fact.anchor}`;
   const signals: FactTriageSignal[] = [];
 
-  // Kernel grammar: fact --invalidated-by--> decision. The source fact is the
-  // contradictory observation that deserves attention.
-  const invalidatedDecisions = relations
-    .filter(
-      (relation) =>
-        relation.from === factRef && relation.kind === "invalidated-by",
-    )
-    .map((relation) => relation.to);
-  if (invalidatedDecisions.length > 0) {
+  // Kernel grammar (canonical direction): decision --refuted-by--> fact. The fact that
+  // refutes a decision is the contradictory observation that deserves attention; the
+  // reverse question goes through the domain query, never the retired invalidated-by alias.
+  const refutingDecisionRefs = incomingRelations(factRef, "refuted-by", relations).map((edge) => edge.from);
+  if (refutingDecisionRefs.length > 0) {
     signals.push({
       kind: "INVALIDATED",
-      detail: `与 decision 冲突: ${[...new Set(invalidatedDecisions)].join(", ")}`,
+      detail: `与 decision 冲突: ${[...new Set(refutingDecisionRefs)].join(", ")}`,
     });
   }
 
@@ -81,16 +78,8 @@ export function computeFactTriageSignals(
         .map((row) => decisionIdFromRef(row.decisionRef))
         .filter((id): id is string => Boolean(id)),
   );
-  for (const relation of relations) {
-    const decisionRef =
-      relation.kind === "evidenced-by" && relation.to === factRef
-        ? relation.from
-        : relation.kind === "supports" && relation.from === factRef
-          ? relation.to
-          : undefined;
-    const decisionId = decisionRef
-      ? decisionIdFromRef(decisionRef)
-      : undefined;
+  for (const edge of incomingRelations(factRef, "evidenced-by", relations)) {
+    const decisionId = decisionIdFromRef(edge.from);
     if (decisionId) citingDecisionIdSet.add(decisionId);
   }
   const citingDecisionIds = [...citingDecisionIdSet].sort();
@@ -109,14 +98,9 @@ export function computeFactTriageSignals(
     });
   }
 
-  // Kernel grammar: decision/fact --supersedes-fact--> old fact. Only the
+  // Kernel grammar: fact --supersedes-fact--> old fact. Only the
   // target is stale; the source is the replacement and must not be penalized.
-  const supersedingRefs = relations
-    .filter(
-      (relation) =>
-        relation.to === factRef && relation.kind === "supersedes-fact",
-    )
-    .map((relation) => relation.from);
+  const supersedingRefs = incomingRelations(factRef, "supersedes-fact", relations).map((edge) => edge.from);
   if (supersedingRefs.length > 0) {
     signals.push({
       kind: "SUPERSEDED",

--- a/packages/gui/src/renderer/model/relation-direction.ts
+++ b/packages/gui/src/renderer/model/relation-direction.ts
@@ -1,0 +1,15 @@
+import type { RelationEdge, RelationKind } from "./types";
+
+/**
+ * Bridge-bounded mirror of the kernel reverse query
+ * (packages/kernel/src/domain/relation-direction.ts#incomingRelations).
+ *
+ * The renderer must not import kernel runtime values (window.harness bridge only),
+ * so the one reverse-direction query is mirrored here for the renderer's model
+ * layer. Both implementations must answer identically; the canonical-direction
+ * ratchet gate (tools/check-relation-canonical-direction.mjs) asserts their
+ * agreement against every registry row, so the mirror cannot drift.
+ */
+export function incomingRelations(targetRef: string, kind: RelationKind, relations: ReadonlyArray<RelationEdge>): ReadonlyArray<RelationEdge> {
+  return relations.filter((relation) => relation.to === targetRef && relation.kind === kind);
+}

--- a/packages/gui/src/renderer/model/triadic.ts
+++ b/packages/gui/src/renderer/model/triadic.ts
@@ -1,3 +1,4 @@
+import { incomingRelations } from "./relation-direction.ts";
 import type { DecisionRow, FactRef, RelationEdge, TaskRow } from "./types";
 
 export function normalizeDecisionId(raw: string): string {
@@ -82,10 +83,11 @@ export function factOf(ref: string, facts: FactRef[]): FactRef | undefined {
 }
 
 export function rationaleFor(ref: string, relations: RelationEdge[]): string | undefined {
-  return relations.find((relation) =>
-    (relation.to === ref && (relation.kind === "supports" || relation.kind === "evidenced-by" || relation.kind === "evidences")) ||
-    (relation.from === ref && relation.kind === "supports")
-  )?.rationale;
+  // Canonical direction only: the rationale shown on a fact's card comes from the
+  // decisions citing it (evidenced-by) or the tasks evidencing it — both read
+  // `source <verb> fact`, so the reverse question goes through the shared query.
+  const incoming = [...incomingRelations(ref, "evidenced-by", relations), ...incomingRelations(ref, "evidences", relations)];
+  return incoming[0]?.rationale;
 }
 
 export const axisRank = (value?: "high" | "medium" | "low") =>

--- a/packages/gui/src/renderer/model/types.ts
+++ b/packages/gui/src/renderer/model/types.ts
@@ -42,7 +42,8 @@ export type BlockingState = "blocked" | "clear" | "unknown";
 
 export interface BlockingContributor {
   relationId: string;
-  kind: "blocks" | "depends-on";
+  /** The only writable task→task blocking verb (canonical direction: source is blocked). */
+  kind: "depends-on";
   sourceTaskId: string;
   targetTaskId: string;
   rationale?: string;
@@ -212,7 +213,7 @@ export interface DecisionRow {
 /**
  * fact 是不可变观察，内嵌产出它的 task，不搬家。
  * 稳定短锚形如 task_x/F-a3f2（禁行号）。
- * 失效不靠状态，靠 relation 边（invalidated-by/supersedes-fact）。
+ * 失效不靠状态，靠 relation 边（规范方向：fact --supersedes-fact--> fact，仅 target 失效）。
  */
 export interface FactRef {
   anchor: string; // task_x/F-a3f2
@@ -226,7 +227,7 @@ export interface FactRef {
   source?: string;
   /** Authored fact provenance, passed through from task-fact-row/v1. */
   provenance?: ReadonlyArray<ProvenanceEntry>;
-  /** 是否已被 invalidated-by/supersedes-fact 边标记失效（由图投影推得） */
+  /** 是否已被 supersedes-fact 边指向而失效（由图投影推得） */
   invalidated?: boolean;
 }
 

--- a/packages/gui/src/renderer/task-adapter.ts
+++ b/packages/gui/src/renderer/task-adapter.ts
@@ -152,7 +152,7 @@ export function deriveBlocking(tasks: ReadonlyArray<TaskRow>, context: TaskAdapt
   if (globalUnknown) for (const task of tasks) add(unknown, task.taskId, context.relationState === "error" ? "relation query failed" : context.relationState === "loading" ? "relation query loading" : "relation projection hard-fail warning");
   const graph = new Map<string, string[]>();
   for (const edge of context.relations ?? []) {
-    if (edge.kind !== "blocks" && edge.kind !== "depends-on") continue;
+    if (edge.kind !== "depends-on") continue;
     const sourceId = exactTaskId(edge.from), targetId = exactTaskId(edge.to), knownIds = [sourceId, targetId].filter((id): id is string => Boolean(id && taskById.has(id)));
     if (edge.state === "retired" || edge.state === "deleted") continue;
     if (edge.state !== "active" || edge.direction !== "directed" || !sourceId || !targetId || !taskById.has(sourceId) || !taskById.has(targetId)) {
@@ -161,7 +161,10 @@ export function deriveBlocking(tasks: ReadonlyArray<TaskRow>, context: TaskAdapt
       continue;
     }
     add(graph, sourceId, targetId);
-    const blockedId = edge.kind === "blocks" ? targetId : taskById.get(targetId)?.canonicalStatus === "done" ? null : sourceId;
+    // Canonical direction: `task A depends-on task B` — A is the blocked party, and a
+    // done target no longer blocks its dependents. The mirrored "blocks" verb (target
+    // blocked) is retired vocabulary; the kernel registry refuses that triple.
+    const blockedId = taskById.get(targetId)?.canonicalStatus === "done" ? null : sourceId;
     if (blockedId) add(blockers, blockedId, { relationId: edge.relationId ?? "unknown", kind: edge.kind, sourceTaskId: sourceId, targetTaskId: targetId, ...(edge.rationale ? { rationale: edge.rationale } : {}) });
   }
   findCycleNodes(graph).forEach((id) => cycleNodes.add(id));

--- a/packages/gui/test/fact-triage.vitest.ts
+++ b/packages/gui/test/fact-triage.vitest.ts
@@ -126,7 +126,7 @@ describe("fact-triage signal computation", () => {
   it("flags a contradiction fact that invalidates a decision", () => {
     const fact = baseFact();
     const relations = [
-      edge("fact/task_a/F-001", "decision/dec_2", "invalidated-by", {
+      edge("decision/dec_2", "fact/task_a/F-001", "refuted-by", {
         rationale: "复现失败",
       }),
     ];
@@ -135,6 +135,27 @@ describe("fact-triage signal computation", () => {
 
     expect(item.signals.map((signal) => signal.kind)).toContain("INVALIDATED");
     expect(item.severity).toBe(SIGNAL_SEVERITY.INVALIDATED);
+  });
+
+  it("derives the INVALIDATED signal from the canonical direction, not the retired alias", () => {
+    // Before slice 4 the triage read fact --invalidated-by--> decision, a shape the
+    // kernel registry refuses; a canonical decision --refuted-by--> fact edge produced
+    // no signal. The two orientations disagreed for this input.
+    const fact = baseFact();
+    const canonical = computeFactTriageSignals(
+      fact,
+      [edge("decision/dec_2", "fact/task_a/F-001", "refuted-by")],
+      [],
+      [anchor(fact)],
+    );
+    const retiredAlias = computeFactTriageSignals(
+      fact,
+      [edge("fact/task_a/F-001", "decision/dec_2", "invalidated-by")],
+      [],
+      [anchor(fact)],
+    );
+    expect(canonical.signals.map((signal) => signal.kind)).toContain("INVALIDATED");
+    expect(retiredAlias.signals.map((signal) => signal.kind)).not.toContain("INVALIDATED");
   });
 
   it("flags an orphan from factAnchors minus covered coverageRows", () => {
@@ -230,7 +251,7 @@ describe("fact-triage ranking", () => {
     const anchors = facts.map(anchor);
     const coverageRows = [coverage(contradiction), coverage(low), coverage(superseded)];
     const relations = [
-      edge(`fact/${contradiction.anchor}`, "decision/dec_2", "invalidated-by"),
+      edge("decision/dec_2", `fact/${contradiction.anchor}`, "refuted-by"),
       edge("fact/task_a/F-new", `fact/${superseded.anchor}`, "supersedes-fact"),
     ];
 
@@ -410,10 +431,10 @@ describe("cross-entity navigation projection", () => {
         ok: true,
         edges: [
           {
-            relationId: "rel_invalidated",
-            sourceRef: `fact/${fact.anchor}`,
-            targetRef: "decision/dec_1",
-            relationType: "invalidated-by",
+            relationId: "rel_refuted",
+            sourceRef: "decision/dec_1",
+            targetRef: `fact/${fact.anchor}`,
+            relationType: "refuted-by",
             direction: "directed",
             strength: "strong",
             origin: "declared",

--- a/packages/gui/test/renderer-app-model.vitest.ts
+++ b/packages/gui/test/renderer-app-model.vitest.ts
@@ -314,7 +314,7 @@ describe("renderer app model", () => {
 
     const blockedMarkup = renderToStaticMarkup(createElement(QueryClientProvider, { client: new QueryClient() }, createElement(TaskDetailView,
       { task: { ...active, canonicalStatus: "planned", coordinationStatus: "blocked", blocking: "blocked", blockingLabel: "1 个 active blocking relation", activeExecutionId: undefined,
-        blockers: [{ relationId: "rel_1", kind: "blocks", sourceTaskId: "task-upstream", targetTaskId: "task-active", rationale: "wait" }] }, onBack: () => undefined, projectName: "Harness" })));
+        blockers: [{ relationId: "rel_1", kind: "depends-on", sourceTaskId: "task-active", targetTaskId: "task-upstream", rationale: "wait" }] }, onBack: () => undefined, projectName: "Harness" })));
     expect(blockedMarkup).toContain("Blocked 是 relation overlay"); expect(blockedMarkup).toContain("rel_1"); expect(blockedMarkup).not.toContain("解除");
   });
 

--- a/packages/gui/test/task-adapter.vitest.ts
+++ b/packages/gui/test/task-adapter.vitest.ts
@@ -15,8 +15,8 @@ function row(overrides: Partial<TaskSnapshotProjectionRow> = {}): TaskSnapshotPr
 }
 
 const relation = (overrides: Partial<RelationEdge>): RelationEdge => ({
-  relationId: "rel_0000000000000001", from: "task/task-a", to: "task/task-b", kind: "blocks",
-  direction: "directed", state: "active", provenance: "local-document", rationale: "B waits for A", ...overrides
+  relationId: "rel_0000000000000001", from: "task/task-a", to: "task/task-b", kind: "depends-on",
+  direction: "directed", state: "active", provenance: "local-document", rationale: "A waits for B", ...overrides
 });
 
 describe("computeRootTaskId", () => {
@@ -39,21 +39,33 @@ describe("adaptProjectionRows", () => {
     expect(adaptProjectionRows([row()], "repo-test", "pending")[0]?.freshness).toBe("stale-but-usable");
   });
 
-  it("keeps canonical status separate while blocks and depends-on derive the blocked display lane", () => {
+  it("derives the blocked display lane from the canonical depends-on direction", () => {
     const rows = [row({ taskId: "task-a" }), row({ taskId: "task-b" }), row({ taskId: "task-c", snapshot: {
       ...row().snapshot, task: { ...row().snapshot.task!, taskId: "task-c", status: "done" }
     } })];
     const relations = [
-      relation({ from: "task/task-a", to: "task/task-b", kind: "blocks" }),
+      relation({ from: "task/task-a", to: "task/task-b", kind: "depends-on" }),
       relation({ relationId: "rel_0000000000000002", from: "task/task-b", to: "task/task-c", kind: "depends-on" })
     ];
     const tasks = adaptProjectionRows(rows, "repo-test", "ready", { relationState: "ready", relations });
 
-    expect(tasks.find((task) => task.taskId === "task-b")).toMatchObject({
+    // `task A depends-on task B`: A (the source) is blocked; a done target stops blocking.
+    expect(tasks.find((task) => task.taskId === "task-a")).toMatchObject({
       canonicalStatus: "planned", coordinationStatus: "blocked", blocking: "blocked",
       blockers: [{ relationId: "rel_0000000000000001", sourceTaskId: "task-a", targetTaskId: "task-b" }]
     });
+    expect(tasks.find((task) => task.taskId === "task-b")?.blocking).toBe("clear");
     expect(tasks.find((task) => task.taskId === "task-c")?.blocking).toBe("clear");
+  });
+
+  it("ignores the retired blocks mirror: only depends-on expresses task blocking", () => {
+    // Before slice 4 the adapter read `blocks` with the opposite endpoint orientation;
+    // the kernel registry now refuses that triple, and the adapter no longer derives
+    // direction per verb. A legacy blocks edge must not block either endpoint.
+    const rows = [row({ taskId: "task-a" }), row({ taskId: "task-b" })];
+    const relations = [relation({ from: "task/task-a", to: "task/task-b", kind: "blocks" })];
+    const tasks = adaptProjectionRows(rows, "repo-test", "ready", { relationState: "ready", relations });
+    expect(tasks.map((task) => task.blocking)).toEqual(["clear", "clear"]);
   });
 
   it("fails closed to unknown for unavailable relation truth, malformed blocking edges, and missing endpoints", () => {

--- a/packages/gui/test/territory.vitest.ts
+++ b/packages/gui/test/territory.vitest.ts
@@ -194,10 +194,10 @@ describe("territory skeleton dispatch", () => {
 });
 
 describe("fact anomaly classification (TERRITORY-001)", () => {
-  it("classifies a fact with invalidated-by edge as contradictory", () => {
+  it("classifies a fact targeted by refuted-by as contradictory", () => {
     const f = fact({ anchor: "task_a/F-contr" });
     const relations: RelationEdge[] = [
-      { from: `fact/${f.anchor}`, to: "decision/dec_1", kind: "invalidated-by", provenance: "local-document" },
+      { from: "decision/dec_1", to: `fact/${f.anchor}`, kind: "refuted-by", provenance: "local-document" },
     ];
     expect(classifyFactAnomaly(`fact/${f.anchor}`, f, relations, new Set())).toBe("contradictory");
   });

--- a/packages/kernel/src/domain/entity-relation.ts
+++ b/packages/kernel/src/domain/entity-relation.ts
@@ -1,6 +1,7 @@
 import { sha256Text } from "../integrity/stable-hash.ts";
 import { parseEntityRef } from "./entity-ref.ts";
 import type { ParsedEntityRef } from "./entity-ref.ts";
+import { canonicalRelationDirections } from "./relation-direction.ts";
 
 export const relationTypes = [
   "supports",
@@ -150,27 +151,16 @@ export function isAllowedRelationKindTriple(
 ): boolean {
   // Ratified convention (dec_mr74sbka, 2026-07-05): every edge reads as one sentence,
   // `source <verb> target`, in the physical (host -> target) direction — no cell whose
-  // verb reads backwards. Verbs are chosen so the source is always the grammatical subject.
-  if (sourceKind === "decision" && targetKind === "decision") {
-    return type === "supersedes" || type === "refines" || type === "narrows" || type === "relates" ||
-      type === "blocks" || type === "derives" || type === "supports";
-  }
-  // derives = "the decision spawns the task"; relates = the task was not born from this
-  // decision but was later found to be connected to it.
-  if (sourceKind === "decision" && targetKind === "task") return type === "derives" || type === "relates";
-  // Evidence relation, authored from the decision side: "the decision is evidenced-by the
-  // fact" — a decision-subject verb so the sentence reads in the storage direction.
-  // The transitional "supports" alias was removed after the 2026-07-05 ledger migration
-  // moved every evidence edge to evidenced-by (dec_mr74sbka).
-  if (sourceKind === "decision" && targetKind === "fact") {
-    return type === "evidenced-by" || type === "refuted-by";
-  }
-  if (sourceKind === "task" && targetKind === "decision") return type === "implements";
-  if (sourceKind === "task" && targetKind === "task") return type === "blocks" || type === "relates" || type === "depends-on";
-  if (sourceKind === "task" && targetKind === "fact") return type === "produces" || type === "evidences";
-  if (sourceKind === "fact" && targetKind === "decision") return type === "supports" || type === "invalidated-by";
-  if (sourceKind === "fact" && targetKind === "fact") return type === "supersedes-fact";
-  return false;
+  // verb reads backwards. The canonical direction registry is the single authority:
+  // a triple is writable exactly when it has a registry row (one canonical direction
+  // per semantic relation, blueprint 铁律三). Every reversed-direction pair keeps only
+  // its canonical side writable — fact→decision supports/invalidated-by and task→task
+  // blocks were retired with zero stored active edges (2026-08-17 census); the retired
+  // aliases remain parse-only vocabulary and reverse questions go through
+  // `incomingRelations` in relation-direction.ts.
+  return canonicalRelationDirections.some(
+    (direction) => direction.sourceKind === sourceKind && direction.type === type && direction.targetKind === targetKind
+  );
 }
 
 function requiresRationale(record: EntityRelationRecord): boolean {
@@ -183,8 +173,7 @@ function requiresRationale(record: EntityRelationRecord): boolean {
     record.type === "supersedes" ||
     record.type === "refines" ||
     record.type === "narrows" ||
-    record.type === "supersedes-fact" ||
-    record.type === "invalidated-by";
+    record.type === "supersedes-fact";
 }
 
 function hostOwnsSource(host: ParsedEntityRef, source: ParsedEntityRef): boolean {

--- a/packages/kernel/src/domain/relation-direction.ts
+++ b/packages/kernel/src/domain/relation-direction.ts
@@ -1,0 +1,79 @@
+import type { RelationType } from "./entity-relation.ts";
+
+/** Endpoint kinds that can host a canonical relation edge. Parsed refs may also be
+ * "relation" or external-harness aliases; neither can host an edge. */
+export type RelationEndpointKind = "task" | "decision" | "fact";
+
+/** Whether the reading of an allowed triple has a registered semantics. */
+export type RelationDirectionRegistration = "ratified" | "unregistered";
+
+/**
+ * The canonical direction registry (blueprint 铁律三): one row per writable
+ * (source kind, type, target kind) triple. It is the single authority behind
+ * `isAllowedRelationKindTriple` — the allowlist and the direction column cannot
+ * drift apart because the allowlist is derived from this table.
+ */
+export interface CanonicalRelationDirection {
+  readonly type: RelationType;
+  readonly sourceKind: RelationEndpointKind;
+  readonly targetKind: RelationEndpointKind;
+  /** dec_mr74sbka: an active edge reads as `source <reads> target` in the storage direction. */
+  readonly reads: string;
+  /** The retired reverse alias this direction replaced, if the pair had one. The alias
+   * stays parse-only vocabulary; reverse questions go through `incomingRelations`. */
+  readonly replacedReverseAlias?: RelationType;
+  /** "ratified" = registered reading. "unregistered" = the grammar allows the triple but
+   * its semantics await an owner decision; new data should avoid leaning on it. */
+  readonly registration: RelationDirectionRegistration;
+}
+
+/** decision → decision: policy lineage among decisions. */
+export const canonicalRelationDirections: readonly CanonicalRelationDirection[] = [
+  { type: "supersedes", sourceKind: "decision", targetKind: "decision", reads: "the decision supersedes the target decision", registration: "ratified" },
+  { type: "refines", sourceKind: "decision", targetKind: "decision", reads: "the decision refines the target decision", registration: "ratified" },
+  { type: "narrows", sourceKind: "decision", targetKind: "decision", reads: "the decision narrows the target decision", registration: "ratified" },
+  { type: "relates", sourceKind: "decision", targetKind: "decision", reads: "the decision relates to the target decision", registration: "ratified" },
+  { type: "derives", sourceKind: "decision", targetKind: "decision", reads: "the decision spawns the target decision", registration: "ratified" },
+  // 4 active edges exist in this shape but no semantics are registered for
+  // decision-to-decision support; the owner must register or migrate them (slice 4 closeout).
+  { type: "supports", sourceKind: "decision", targetKind: "decision", reads: "the decision supports the target decision", registration: "unregistered" },
+  // Allowed by the ratified sentence grammar; zero stored edges and no registered semantics.
+  { type: "blocks", sourceKind: "decision", targetKind: "decision", reads: "the decision blocks the target decision", registration: "unregistered" },
+  // decision → task
+  { type: "derives", sourceKind: "decision", targetKind: "task", reads: "the decision spawns the target task", registration: "ratified" },
+  { type: "relates", sourceKind: "decision", targetKind: "task", reads: "the decision was later found to relate to the target task", registration: "ratified" },
+  // decision → fact: evidence verbs are authored from the decision side so the sentence
+  // reads in the storage direction (dec_mr74sbka; the 2026-07-05 migration moved every
+  // evidence edge off the retired "supports" alias).
+  { type: "evidenced-by", sourceKind: "decision", targetKind: "fact", reads: "the decision is evidenced-by the target fact", replacedReverseAlias: "supports", registration: "ratified" },
+  { type: "refuted-by", sourceKind: "decision", targetKind: "fact", reads: "the decision is refuted-by the target fact", replacedReverseAlias: "invalidated-by", registration: "ratified" },
+  // task → decision
+  { type: "implements", sourceKind: "task", targetKind: "decision", reads: "the task implements the target decision", registration: "ratified" },
+  // task → task: the source task is the blocked party; the mirrored "blocks" verb
+  // (target blocked) is retired vocabulary, never a writable triple.
+  { type: "depends-on", sourceKind: "task", targetKind: "task", reads: "the source task depends on the target task", replacedReverseAlias: "blocks", registration: "ratified" },
+  { type: "relates", sourceKind: "task", targetKind: "task", reads: "the task relates to the target task", registration: "ratified" },
+  // task → fact
+  { type: "produces", sourceKind: "task", targetKind: "fact", reads: "the task produces the target fact", registration: "ratified" },
+  { type: "evidences", sourceKind: "task", targetKind: "fact", reads: "the task evidences the target fact", registration: "ratified" },
+  // fact → fact: only the target is stale; the source is the replacement.
+  { type: "supersedes-fact", sourceKind: "fact", targetKind: "fact", reads: "the fact supersedes the target fact", registration: "ratified" }
+];
+
+/** Minimal structural shape the reverse query needs; callers keep their own richer rows. */
+export interface DirectedRelationEdge {
+  readonly source: string;
+  readonly target: string;
+  readonly type: RelationType;
+}
+
+/**
+ * The one reverse-direction query (blueprint 铁律三). Canonical edges read
+ * `source <verb> target`, so the reverse question at an endpoint — "which decisions
+ * cite this fact", "which tasks does this task block", "what supersedes this fact" —
+ * is always "the edges of that type whose target it is". Consumers must call this
+ * instead of re-deriving direction from endpoint shapes.
+ */
+export function incomingRelations<E extends DirectedRelationEdge>(targetRef: string, type: RelationType, edges: readonly E[]): readonly E[] {
+  return edges.filter((edge) => edge.target === targetRef && edge.type === type);
+}

--- a/packages/kernel/src/projection/cold-rebuild-source.ts
+++ b/packages/kernel/src/projection/cold-rebuild-source.ts
@@ -47,7 +47,7 @@ export function readColdRebuildSource(rootInput: HarnessLayoutInput): ColdRebuil
 
 export function buildColdCoverage(source: ColdRebuildSource, edgesInput: readonly RelationGraphEdgeRow[]): readonly RelationCoverageRow[] {
   const edges = [...edgesInput].filter(({ state }) => state === "active").sort((a, b) => `${a.sourceRef}\0${a.targetRef}\0${a.relationId}`.localeCompare(`${b.sourceRef}\0${b.targetRef}\0${b.relationId}`));
-  const evidence = new Map<string, RelationGraphEdgeRow[]>(), facts = new Set(source.facts.map(({ ref }) => ref)), invalidated = new Set(edges.filter((edge) => edge.sourceRef.startsWith("fact/") && edge.targetRef.startsWith("fact/") && (edge.relationType === "invalidated-by" || edge.relationType === "supersedes-fact")).map(({ targetRef }) => targetRef)), refuted = new Map<string, Set<string>>();
+  const evidence = new Map<string, RelationGraphEdgeRow[]>(), facts = new Set(source.facts.map(({ ref }) => ref)), invalidated = new Set(edges.filter((edge) => edge.relationType === "supersedes-fact").map(({ targetRef }) => targetRef)), refuted = new Map<string, Set<string>>();
   for (const edge of edges) {
     if (edge.relationType === "evidenced-by") evidence.set(edge.sourceRef, [...evidence.get(edge.sourceRef) ?? [], edge]);
     if (edge.relationType === "refuted-by" && edge.sourceRef.startsWith("decision/") && edge.targetRef.startsWith("fact/")) { const refs = refuted.get(edge.sourceRef) ?? new Set<string>(); refs.add(edge.targetRef); refuted.set(edge.sourceRef, refs); }

--- a/packages/kernel/test/domain/relation-direction.test.ts
+++ b/packages/kernel/test/domain/relation-direction.test.ts
@@ -1,0 +1,93 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isAllowedRelationKindTriple, relationTypes } from "../../src/domain/entity-relation.ts";
+import {
+  canonicalRelationDirections,
+  incomingRelations,
+  type CanonicalRelationDirection,
+  type RelationEndpointKind
+} from "../../src/domain/relation-direction.ts";
+
+const kinds: readonly RelationEndpointKind[] = ["task", "decision", "fact"];
+
+function row(sourceKind: RelationEndpointKind, type: (typeof relationTypes)[number], targetKind: RelationEndpointKind): CanonicalRelationDirection | undefined {
+  return canonicalRelationDirections.find((direction) => direction.sourceKind === sourceKind && direction.type === type && direction.targetKind === targetKind);
+}
+
+test("the canonical direction registry is the allowlist: every triple agrees, cell for cell", () => {
+  for (const sourceKind of kinds) {
+    for (const type of relationTypes) {
+      for (const targetKind of kinds) {
+        assert.equal(
+          isAllowedRelationKindTriple(sourceKind, type, targetKind),
+          row(sourceKind, type, targetKind) !== undefined,
+          `${sourceKind} --${type}--> ${targetKind}: allowlist and registry disagree`
+        );
+      }
+    }
+  }
+});
+
+test("every reversed-direction pair keeps exactly one canonical writable side", () => {
+  // Evidence: decision --evidenced-by--> fact is canonical; fact --supports--> decision is retired.
+  assert.equal(isAllowedRelationKindTriple("decision", "evidenced-by", "fact"), true);
+  assert.equal(isAllowedRelationKindTriple("fact", "supports", "decision"), false);
+  // Refutation: decision --refuted-by--> fact is canonical; fact --invalidated-by--> decision is retired.
+  assert.equal(isAllowedRelationKindTriple("decision", "refuted-by", "fact"), true);
+  assert.equal(isAllowedRelationKindTriple("fact", "invalidated-by", "decision"), false);
+  // Blocking: task --depends-on--> task blocks the source; the mirrored task --blocks--> task is retired.
+  assert.equal(isAllowedRelationKindTriple("task", "depends-on", "task"), true);
+  assert.equal(isAllowedRelationKindTriple("task", "blocks", "task"), false);
+});
+
+test("every replaced reverse alias is refused on the mirrored endpoint pair", () => {
+  for (const direction of canonicalRelationDirections) {
+    const alias = direction.replacedReverseAlias;
+    if (!alias) continue;
+    assert.equal(
+      isAllowedRelationKindTriple(direction.targetKind, alias, direction.sourceKind),
+      false,
+      `retired alias ${direction.targetKind} --${alias}--> ${direction.sourceKind} must stay unwritable (mirror of ${direction.sourceKind} --${direction.type}--> ${direction.targetKind})`
+    );
+  }
+});
+
+test("the reverse query agrees with the canonical direction for every registry row", () => {
+  for (const direction of canonicalRelationDirections) {
+    const source = `${direction.sourceKind}/source`;
+    const target = `${direction.targetKind}/target`;
+    const edge = { source, target, type: direction.type };
+    const noise = { source: target, target: source, type: direction.type };
+    const edges = [noise, edge];
+    assert.deepEqual(
+      incomingRelations(target, direction.type, edges).map((hit) => hit.source),
+      [source],
+      `reverse query at the target of ${direction.sourceKind} --${direction.type}--> ${direction.targetKind} must return the canonical source only`
+    );
+    assert.deepEqual(
+      incomingRelations(source, direction.type, edges),
+      [noise],
+      `asking at the source with the same verb returns only the literal target-side edges`
+    );
+  }
+});
+
+test("semantics with no registered reading are flagged, not silently ratified", () => {
+  const unregistered = canonicalRelationDirections.filter(({ registration }) => registration === "unregistered");
+  assert.deepEqual(
+    unregistered.map(({ type }) => type).sort(),
+    ["blocks", "supports"],
+    "exactly the decision->decision blocks/supports cells lack registered semantics"
+  );
+  for (const direction of unregistered) {
+    assert.equal(direction.sourceKind, "decision");
+    assert.equal(direction.targetKind, "decision");
+  }
+});
+
+test("a non-canonical active edge is refused at the write boundary", () => {
+  // The same validation the daemon and frontmatter ingest path apply to active edges.
+  assert.equal(isAllowedRelationKindTriple("fact", "invalidated-by", "decision"), false);
+  assert.equal(isAllowedRelationKindTriple("task", "blocks", "task"), false);
+});

--- a/tools/check-relation-canonical-direction.mjs
+++ b/tools/check-relation-canonical-direction.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/**
+ * G-IRONLAW3 canonical-direction ratchet gate (blueprint 铁律三 · slice 4).
+ *
+ * Authorization: dec_399F48E3547D831F1199F51E84 CH1 (add ratchet gates only —
+ * existing violations tolerated, new ones refused).
+ *
+ * The gate judges the real kernel modules, not text:
+ *   1. The canonical direction registry and the relation allowlist agree cell for
+ *      cell (the allowlist is derived from the registry and must stay that way).
+ *   2. Every reversed-direction pair keeps exactly one canonical writable side:
+ *      fact→decision supports / fact→decision invalidated-by / task→task blocks
+ *      stay refused. Retired stored edges are tolerated audit history; re-widening
+ *      the write surface is refused.
+ *   3. The single reverse query agrees with the canonical direction.
+ *   4. No production source re-reads the retired invalidated-by alias.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const KERNEL_ALLOWLIST = "../packages/kernel/src/domain/entity-relation.ts";
+const KERNEL_DIRECTION = "../packages/kernel/src/domain/relation-direction.ts";
+const GUI_MIRROR = "../packages/gui/src/renderer/model/relation-direction.ts";
+const ENDPOINT_KINDS = ["task", "decision", "fact"];
+const RETIRED_REVERSE_TRIPLES = [
+  { sourceKind: "fact", type: "supports", targetKind: "decision", mirrorOf: "decision --evidenced-by--> fact" },
+  { sourceKind: "fact", type: "invalidated-by", targetKind: "decision", mirrorOf: "decision --refuted-by--> fact" },
+  { sourceKind: "task", type: "blocks", targetKind: "task", mirrorOf: "task --depends-on--> task" }
+];
+const RETIRED_ALIAS_COMPARISON = /(?:===|!==|==|!=)\s*["']invalidated-by["']|\bcase\s+["']invalidated-by["']/u;
+const SOURCE_FILE = /\.(?:ts|tsx|mts|js|jsx|mjs)$/u;
+
+export function checkRegistryShape({ canonicalRelationDirections }, findings = []) {
+  const seen = new Set();
+  for (const [index, direction] of canonicalRelationDirections.entries()) {
+    const cell = `${direction.sourceKind} --${direction.type}--> ${direction.targetKind}`;
+    if (seen.has(cell)) findings.push(`canonicalRelationDirections: duplicate registry row ${cell}`);
+    seen.add(cell);
+    for (const field of ["type", "sourceKind", "targetKind", "reads", "registration"]) {
+      if (typeof direction[field] !== "string" || direction[field].trim() === "") {
+        findings.push(`canonicalRelationDirections[${index}]: ${field} must be a non-empty string`);
+      }
+    }
+    if (direction.registration !== "ratified" && direction.registration !== "unregistered") {
+      findings.push(`${cell}: registration must be "ratified" or "unregistered", got ${JSON.stringify(direction.registration)}`);
+    }
+    if (!ENDPOINT_KINDS.includes(direction.sourceKind) || !ENDPOINT_KINDS.includes(direction.targetKind)) {
+      findings.push(`${cell}: endpoint kinds must be task/decision/fact`);
+    }
+  }
+  if (canonicalRelationDirections.length === 0) findings.push("canonicalRelationDirections: registry is empty");
+  return findings;
+}
+
+export function checkDirectionBijection({ canonicalRelationDirections, isAllowedRelationKindTriple, relationTypes }, findings = []) {
+  const registered = new Set(canonicalRelationDirections.map((direction) => `${direction.sourceKind}|${direction.type}|${direction.targetKind}`));
+  for (const sourceKind of ENDPOINT_KINDS) {
+    for (const type of relationTypes) {
+      for (const targetKind of ENDPOINT_KINDS) {
+        const cell = `${sourceKind}|${type}|${targetKind}`;
+        const allowed = isAllowedRelationKindTriple(sourceKind, type, targetKind);
+        if (allowed !== registered.has(cell)) {
+          findings.push(`${sourceKind} --${type}--> ${targetKind}: allowlist says ${allowed}, direction registry says ${registered.has(cell)}`);
+        }
+      }
+    }
+  }
+  return findings;
+}
+
+export function checkRetiredReverseTriplesRefused({ canonicalRelationDirections, isAllowedRelationKindTriple }, findings = []) {
+  for (const triple of RETIRED_REVERSE_TRIPLES) {
+    if (isAllowedRelationKindTriple(triple.sourceKind, triple.type, triple.targetKind)) {
+      findings.push(`${triple.sourceKind} --${triple.type}--> ${triple.targetKind} must stay unwritable: it is the retired mirror of ${triple.mirrorOf} (one canonical direction per semantic relation)`);
+    }
+  }
+  for (const direction of canonicalRelationDirections) {
+    const alias = direction.replacedReverseAlias;
+    if (!alias) continue;
+    if (isAllowedRelationKindTriple(direction.targetKind, alias, direction.sourceKind)) {
+      findings.push(`${direction.targetKind} --${alias}--> ${direction.sourceKind} must stay unwritable: retired reverse alias of ${direction.sourceKind} --${direction.type}--> ${direction.targetKind}`);
+    }
+  }
+  return findings;
+}
+
+export function checkReverseQueryAgreement({ canonicalRelationDirections, incomingRelations }, findings = []) {
+  for (const direction of canonicalRelationDirections) {
+    const source = `${direction.sourceKind}/probe-source`;
+    const target = `${direction.targetKind}/probe-target`;
+    const canonical = { source, target, type: direction.type };
+    const reverse = { source: target, target: source, type: direction.type };
+    const hits = incomingRelations(target, direction.type, [reverse, canonical]);
+    if (hits.length !== 1 || hits[0] !== canonical) {
+      findings.push(`incomingRelations must answer the reverse question for ${direction.sourceKind} --${direction.type}--> ${direction.targetKind}: expected [${source}], got ${JSON.stringify(hits.map((edge) => edge.source))}`);
+    }
+  }
+  return findings;
+}
+
+export function checkGuiMirrorAgreement({ canonicalRelationDirections, incomingRelations }, guiIncomingRelations, findings = []) {
+  // The renderer may not import kernel runtime values (window.harness bridge only), so
+  // the GUI carries a mirror of the reverse query. Both must answer identically for
+  // every registry verb; this check makes the mirror drift a gate failure, not a silent
+  // second orientation.
+  const kernelEdges = [], rendererEdges = [];
+  for (const direction of canonicalRelationDirections) {
+    const source = `${direction.sourceKind}/probe-source`, target = `${direction.targetKind}/probe-target`;
+    kernelEdges.push({ source, target, type: direction.type }, { source: target, target: source, type: direction.type });
+    rendererEdges.push({ from: source, to: target, kind: direction.type }, { from: target, to: source, kind: direction.type });
+  }
+  for (const direction of canonicalRelationDirections) {
+    const target = `${direction.targetKind}/probe-target`;
+    const kernelHits = incomingRelations(target, direction.type, kernelEdges).map((edge) => edge.source);
+    const rendererHits = guiIncomingRelations(target, direction.type, rendererEdges).map((edge) => edge.from);
+    if (JSON.stringify(kernelHits) !== JSON.stringify(rendererHits)) {
+      findings.push(`renderer reverse-query mirror disagrees with the kernel for ${direction.type} at ${target}: kernel [${kernelHits}] vs renderer [${rendererHits}]`);
+    }
+  }
+  return findings;
+}
+
+export function checkNoRetiredAliasReads(root = process.cwd(), findings = []) {
+  for (const file of walk(path.join(root, "packages"))) {
+    const rel = path.relative(root, file).split(path.sep).join("/");
+    if (isTestOrFixturePath(rel)) continue;
+    if (RETIRED_ALIAS_COMPARISON.test(readFileSync(file, "utf8"))) {
+      findings.push(`${rel}: reads or writes the retired invalidated-by alias; reverse questions must go through incomingRelations`);
+    }
+  }
+  return findings;
+}
+
+async function main() {
+  const allowlist = await import(pathToFileURL(path.resolve(import.meta.dirname, KERNEL_ALLOWLIST)).href);
+  const direction = await import(pathToFileURL(path.resolve(import.meta.dirname, KERNEL_DIRECTION)).href);
+  const guiMirror = await import(pathToFileURL(path.resolve(import.meta.dirname, GUI_MIRROR)).href);
+  const modules = { ...allowlist, ...direction };
+  const findings = [
+    ...checkRegistryShape(modules),
+    ...checkDirectionBijection(modules),
+    ...checkRetiredReverseTriplesRefused(modules),
+    ...checkReverseQueryAgreement(modules),
+    ...checkGuiMirrorAgreement(modules, guiMirror.incomingRelations),
+    ...checkNoRetiredAliasReads()
+  ];
+  if (findings.length > 0) {
+    console.error("Canonical relation direction check failed:");
+    for (const finding of findings) console.error(`- ${finding}`);
+    process.exit(1);
+  }
+  console.log("Canonical relation direction check passed (registry, allowlist, and reverse query agree; retired mirrors refused).");
+}
+
+function walk(dir) {
+  const files = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === "ENOENT") return [];
+    throw error;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist" || entry.name === "out") continue;
+      files.push(...walk(full));
+    } else if (SOURCE_FILE.test(entry.name)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function isTestOrFixturePath(rel) {
+  return /(?:^|\/)(?:__fixtures__|fixtures|test|tests|e2e)\//u.test(rel) || /\.(?:test|spec|vitest)\.[cm]?[jt]sx?$/u.test(rel);
+}
+
+const invokedDirectly = process.argv[1] !== undefined && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (invokedDirectly) {
+  await main();
+}

--- a/tools/check-relation-canonical-direction.test.mjs
+++ b/tools/check-relation-canonical-direction.test.mjs
@@ -1,0 +1,107 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import {
+  checkDirectionBijection,
+  checkGuiMirrorAgreement,
+  checkNoRetiredAliasReads,
+  checkRegistryShape,
+  checkRetiredReverseTriplesRefused,
+  checkReverseQueryAgreement
+} from "./check-relation-canonical-direction.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+const realModules = await import(
+  new URL("../packages/kernel/src/domain/relation-direction.ts", import.meta.url)
+);
+const realAllowlist = await import(
+  new URL("../packages/kernel/src/domain/entity-relation.ts", import.meta.url)
+);
+const real = { ...realAllowlist, ...realModules };
+
+test("canonical direction check accepts the repository", () => {
+  const result = spawnSync("node", [path.join(repoRoot, "tools/check-relation-canonical-direction.mjs")], {
+    cwd: repoRoot, encoding: "utf8"
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Canonical relation direction check passed/);
+});
+
+test("pure checks accept the real kernel modules", () => {
+  assert.deepEqual([
+    ...checkRegistryShape(real),
+    ...checkDirectionBijection(real),
+    ...checkRetiredReverseTriplesRefused(real),
+    ...checkReverseQueryAgreement(real)
+  ], []);
+});
+
+test("bypass fixture: re-widening the write surface to a retired mirror fails", () => {
+  // Simulates a regression that re-adds fact→decision supports (or task→task blocks)
+  // to the allowlist and the registry together: the ratchet must still refuse.
+  const widened = {
+    ...real,
+    isAllowedRelationKindTriple: () => true,
+    canonicalRelationDirections: [
+      ...real.canonicalRelationDirections,
+      { type: "supports", sourceKind: "fact", targetKind: "decision", reads: "widened", registration: "ratified" }
+    ]
+  };
+  const findings = [
+    ...checkRegistryShape(widened),
+    ...checkDirectionBijection(widened),
+    ...checkRetiredReverseTriplesRefused(widened)
+  ];
+  assert.ok(findings.some((finding) => finding.includes("fact --supports--> decision must stay unwritable")), findings.join("\n"));
+});
+
+test("bypass fixture: an allowlist that drifts from the registry fails the bijection", () => {
+  const drifted = {
+    ...real,
+    isAllowedRelationKindTriple: (sourceKind, type, targetKind) =>
+      !(sourceKind === "task" && type === "depends-on" && targetKind === "task") &&
+      real.isAllowedRelationKindTriple(sourceKind, type, targetKind)
+  };
+  const findings = checkDirectionBijection(drifted);
+  assert.ok(findings.some((finding) => finding.includes("task --depends-on--> task")), findings.join("\n"));
+});
+
+test("bypass fixture: a reverse query that answers from the wrong endpoint fails", () => {
+  const flipped = {
+    ...real,
+    incomingRelations: (sourceRef, type, edges) => edges.filter((edge) => edge.source === sourceRef && edge.type === type)
+  };
+  const findings = checkReverseQueryAgreement(flipped);
+  assert.ok(findings.length > 0, "the agreement probe must catch a reverse query keyed on the wrong endpoint");
+});
+
+test("bypass fixture: a renderer mirror that drifts from the kernel query fails", async () => {
+  const guiMirror = await import(new URL("../packages/gui/src/renderer/model/relation-direction.ts", import.meta.url));
+  const drifted = (targetRef, kind, relations) =>
+    relations.filter((relation) => relation.to === targetRef && relation.kind === kind && relation.from.startsWith("decision/"));
+  const kernelFindings = checkGuiMirrorAgreement(real, guiMirror.incomingRelations);
+  assert.deepEqual(kernelFindings, []);
+  const driftedFindings = checkGuiMirrorAgreement(real, drifted);
+  assert.ok(driftedFindings.some((finding) => finding.includes("renderer reverse-query mirror disagrees")), driftedFindings.join("\n"));
+});
+
+test("bypass fixture: a production source re-reading the retired alias fails", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-ironlaw3-alias-"));
+  try {
+    mkdirSync(path.join(root, "packages/app/src"), { recursive: true });
+    writeFileSync(path.join(root, "packages/app/src/consumer.ts"),
+      'const refuted = relations.filter((r) => r.kind === "invalidated-by");\n');
+    const findings = checkNoRetiredAliasReads(root);
+    assert.ok(findings.some((finding) => finding.includes("consumer.ts")), findings.join("\n"));
+    writeFileSync(path.join(root, "packages/app/src/vocabulary.ts"),
+      'export const vocabulary = ["supports", "invalidated-by"];\n');
+    assert.deepEqual(checkNoRetiredAliasReads(root).filter((finding) => finding.includes("vocabulary.ts")), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -67,6 +67,7 @@
         "check-write-road-registry",
         "check-kernel-dead-exports",
         "check-relation-cycle-substrate",
+        "check-relation-canonical-direction",
         "scan-forbidden-symbols",
         "check-duplicate-definitions",
         "check-integrity-single-source",
@@ -109,6 +110,7 @@
         "check-write-road-registry",
         "check-kernel-dead-exports",
         "check-relation-cycle-substrate",
+        "check-relation-canonical-direction",
         "scan-forbidden-symbols",
         "check-duplicate-definitions",
         "check-integrity-single-source",
@@ -2179,6 +2181,85 @@
         "status": "covered",
         "evidence": [
           "tools/check-relation-cycle-substrate.test.mjs"
+        ]
+      }
+    },
+    {
+      "id": "check-relation-canonical-direction",
+      "command": "npm run harness:check-relation-canonical-direction",
+      "category": "boundary",
+      "tier": "pr-required",
+      "tierReason": null,
+      "authoritySource": [
+        "packages/kernel/src/domain/relation-direction.ts",
+        "packages/kernel/src/domain/entity-relation.ts#isAllowedRelationKindTriple",
+        "decision/dec_mr74sbka",
+        "decision/dec_399F48E3547D831F1199F51E84#CH1",
+        "harness/context/research/2026-08-16-ddd-domain-modeling/10-blueprint.md#铁律三--一个语义关系只有一个规范方向"
+      ],
+      "consumerScope": [
+        "kernel relation write surface (isAllowedRelationKindTriple behind validateRelationRecordsForHost)",
+        "relation reverse-direction queries consumed by packages/gui renderer models",
+        "non-test packages/** sources re-reading the retired invalidated-by alias"
+      ],
+      "githubContext": {
+        "requiredContexts": [
+          "boundaries"
+        ],
+        "workflowJobs": [
+          "boundaries"
+        ],
+        "nodeVersions": [
+          24
+        ]
+      },
+      "allowlistPolicy": {
+        "allowed": false,
+        "location": null,
+        "adrOrDecisionRequired": false,
+        "notes": "Ratchet per dec_399F48E3547D831F1199F51E84 CH1: stored retired mirror edges are tolerated audit history; re-widening the writable triples or re-reading the retired alias is refused with no allowlist."
+      },
+      "changeControl": {
+        "ordinaryImplementationMayModify": false,
+        "requiresGovernanceEvidence": true,
+        "protectedSurfaces": [
+          "tools/check-relation-canonical-direction.mjs",
+          "package.json:scripts.harness:check-relation-canonical-direction",
+          "tools/gate-manifest.json"
+        ]
+      },
+      "bypassFixtureRequired": true,
+      "executionSurfaces": {
+        "packageJson": {
+          "check": true,
+          "checkPr": true,
+          "script": "harness:check-relation-canonical-direction"
+        },
+        "rewriteCi": {
+          "pullRequestJobs": [
+            "boundaries"
+          ],
+          "nonPullRequestJobs": [
+            "full-check"
+          ]
+        },
+        "branchProtection": {
+          "required": true,
+          "contexts": [
+            "boundaries"
+          ]
+        },
+        "classes": [
+          "local",
+          "pr",
+          "main-full"
+        ]
+      },
+      "deterministic": true,
+      "positiveControl": {
+        "status": "covered",
+        "evidence": [
+          "tools/check-relation-canonical-direction.test.mjs"
         ]
       }
     },


### PR DESCRIPTION
# English

## Summary

DDD slice 4 of the PLT-DDD milestone (`task_eac9e6729331f5cacc82e2a4db`), iron law three: **one canonical direction per semantic relation.** Before this change the orientation of every relation type was re-derived wherever a caller needed it — a pre-implementation scout found not the two implementations the plan named (`fact-triage.ts`, `triadic.ts`) but four, the extra two in `territory.ts` and `FactInspector.tsx`, each with its own idea of which end of an edge points where.

The scout also corrected the plan's premise in the good direction: measured against all 1,203 stored edges, **zero active edges are non-canonical** under the proposed registry. So this slice is a schema tightening and implementation consolidation, not a data migration — no stored edge changes.

## What Changed

- `packages/kernel/src/domain/relation-direction.ts` — the direction registry, 17 rows, the single authority. The entity-relation allow-table is now derived from it cell by cell instead of hand-maintained; `incomingRelations` is the one reverse-direction query.
- Deleted the four orientation implementations: the non-canonical `invalidated-by` read and dead `supports` branch in `fact-triage.ts`, the four-branch orientation in `triadic.ts`'s `rationaleFor`, the dual-orientation `blocks` branch in `task-adapter.ts`, and the same-family code in `territory.ts` / `FactInspector.tsx`; plus the hand-written if-chain allow-table in `entity-relation.ts` and dead `invalidated-by` branches in `cold-rebuild-source.ts`.
- `packages/gui/src/renderer/model/relation-direction.ts` — a bridge-bounded mirror of the one reverse query (the renderer must not import kernel runtime values, per the existing ESLint boundary). The mirror cannot drift: the new gate asserts kernel and GUI answer identically for every registry row.
- **New ratchet gate** `tools/check-relation-canonical-direction.mjs`, registered in `gate-manifest.json` (52 gates) and picked up by the existing `boundaries` CI job via manifest dispatch — no workflow file touched. Ratchet semantics: existing edges tolerated, new non-canonical writes refused; five bypass fixtures prove it bites.
- Two relation kinds the ledger holds without registered semantics — `decision→decision supports` (4 active edges) and `blocks` — are marked `unregistered` in the registry rather than being given invented directions. Their semantics are the owner's call.

## Task And Scope

- Harness task: `task_65ae1b4402cd3db4bae8f1b26b` (PLT-DDD slice 4)
- Branch: `codex/ddd-slice-4`
- Public scope: 19 files, +658/−104 total (production +145/−90; the rest is the gate, its tests, and test updates).
- Private planning/evidence updated: yes — scout report and `artifacts/report-ddd-slice-4.md`.
- Out of scope: adjudicating `unregistered` semantics; removing `invalidated-by` from the parse vocabulary (two mirrored word lists, reported not done).

## Version Impact

- Version: no version change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: **yes**
- Protected surface scope: `tools/check-relation-canonical-direction.mjs` (new), `tools/check-relation-canonical-direction.test.mjs` (new), `gate-manifest.json` (one gate registered). No existing gate's judgment changed; no workflow touched.
- Authority: `dec_399F48E3547D831F1199F51E84` CH1 — standing authorization for this milestone to **add ratchet gates only** (existing violations tolerated, new ones refused; no existing gate tightened or loosened), each PR citing the decision. This is one of the four gates that decision names (canonical direction). Milestone Exit Criterion 2 requires it.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable — the gate lands under the cited standing authorization.

## Verification

- Base `origin/main` SHA: `d27467560fd5906a8994339390d6f95af5726dae`
- Branch merge-base with `origin/main`: equals `origin/main` HEAD (rebased)
- Sync method: rebase
- Public diff command: `git diff --stat origin/main...codex/ddd-slice-4` → 19 files, 658 insertions, 104 deletions
Production-Delta: +145/-90
Dependency-Change: root package.json gains one npm script entry (`check:relation-direction`) wiring the new ratchet gate; no dependency is added, removed, or version-changed.
- Private evidence path: task package `task_65ae1b4402cd3db4bae8f1b26b`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] Kernel registry tests 6/6: bijectivity, one-direction-per-type, alias write refusal, reverse-query agreement, `unregistered` confined to exactly its two cells.
- [x] GUI suite 26 files / 197 tests green, including two contrast tests that diverge under the old dual implementations and agree under the registry.
- [x] Gate self-tests 7/7 with five bypass fixtures — the ratchet refuses a constructed non-canonical write and passes the existing corpus.
- [x] Daemon relation surface 56/56. Integration tier 388/390; the 2 failures reproduce identically on stashed baseline (negative control) — pre-existing `daemon-l2-readiness` environment race while two other worker daemons ran on this machine, not introduced here. CI is the authority.
- [x] `npm run check:local` exit 0; `npx tsc -b` exit 0.
- [ ] GitHub Actions `rewrite-ci` passed — pending on this PR

## Review Evidence

- CEO review: read the diff surface and the gate. Confirmed the registry is the single authority (allow-table derived, not parallel), the GUI mirror is agreement-gated per registry row so it cannot drift, the gate rides the existing manifest-dispatched `boundaries` job rather than a new workflow, and `unregistered` rows refuse invention rather than encode a guess.
- Implemented by a delegated worker (`agent:glm`); scout enumeration (`agent:glm`, separate session) verified by the worker before use.
- Human review: pending
- Blocking findings: none

## Residual Risk

- The `unregistered` rows (`decision→decision supports`, `blocks`) stay outside canonical enforcement until the owner assigns semantics; the ratchet cannot protect edges whose direction is deliberately undeclared.
- The GUI mirror duplicates one filter function by design (bridge boundary). The gate makes drift impossible, but the duplication is real and recorded; if the bridge ever carries kernel domain values, the mirror should be deleted.
- `invalidated-by` remains parseable as a retired alias; removing the word touches two mirrored vocabularies and is reported, not done.

---

# 中文

## 摘要

PLT-DDD milestone（`task_eac9e6729331f5cacc82e2a4db`）第 4 片，铁律三：**一个语义关系只有一个规范方向**。此前每种关系的朝向在每个需要它的调用处各自推导——实现前侦察发现的不是 plan 点名的两处（`fact-triage.ts`、`triadic.ts`），而是**四处**（另两处在 `territory.ts` 与 `FactInspector.tsx`），各有各的「边的哪头指向哪」。

侦察还朝好的方向修正了 plan 前提：对全部 1,203 条存量边实测，按提议的登记表**非规范 active 边为零**。所以本片是 schema 收紧与实现归一，不是数据迁移——不改任何存量边。

## 变更内容

- `packages/kernel/src/domain/relation-direction.ts`——方向登记表，17 行，唯一权威。entity-relation 允许表逐格由它派生，不再手工维护；`incomingRelations` 是唯一的反向查询。
- 删除四处朝向实现：`fact-triage.ts` 的非规范 `invalidated-by` 读与死 `supports` 分支、`triadic.ts` `rationaleFor` 的四分支朝向、`task-adapter.ts` 的 `blocks` 双朝向分支、`territory.ts` / `FactInspector.tsx` 的同族代码；外加 `entity-relation.ts` 的手写 if 链允许表与 `cold-rebuild-source.ts` 的死分支。
- `packages/gui/src/renderer/model/relation-direction.ts`——桥界内的反向查询镜像（renderer 依既有 ESLint 边界不得 import kernel 运行时值）。镜像不可漂移：新门对登记表每一行断言 kernel 与 GUI 答案一致。
- **新 ratchet 门** `tools/check-relation-canonical-direction.mjs`，登记进 `gate-manifest.json`（52 门），经既有 `boundaries` CI job 的 manifest 调度生效——未碰任何 workflow 文件。ratchet 语义：存量容忍、新非规范写入拒绝；5 个 bypass fixture 证明它咬人。
- 台账里两种语义未登记的关系——`decision→decision supports`（4 条 active）与 `blocks`——在登记表中标 `unregistered` 而非发明方向；语义归 owner 裁。

## 任务与范围

- Harness 任务：`task_65ae1b4402cd3db4bae8f1b26b`（PLT-DDD 第 4 片）
- 分支：`codex/ddd-slice-4`
- 公开范围：19 文件，+658/−104（生产 +145/−90；其余为门、门测试与测试更新）。
- 私有规划/证据已更新：是——侦察报告与 `artifacts/report-ddd-slice-4.md`。
- 范围外：`unregistered` 语义的裁决；从解析词表移除 `invalidated-by`（涉两份镜像词表，已报告未做）。

## 版本影响

- 版本：无变更。
- 发布影响：不发布

## 治理声明

- 触碰受保护面：**是**
- 受保护面范围：`tools/check-relation-canonical-direction.mjs`（新增）、`tools/check-relation-canonical-direction.test.mjs`（新增）、`gate-manifest.json`（登记一个门）。未改任何既有门的判定；未碰 workflow。
- 授权来源：`dec_399F48E3547D831F1199F51E84` CH1——本 milestone 的常设授权：**仅新增 ratchet 门**（存量违规容忍、新增拒绝；不收紧不放宽既有门），每个 PR 引用该 decision。本门即该 decision 点名的四门之一（规范方向）；milestone Exit Criterion 2 要求它。
- 机器检查边界：本 PR 仅断言声明存在；是否真实充分由评审判断。
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用——门在所引常设授权下落地。

## 验证

- Base `origin/main` SHA：`d27467560fd5906a8994339390d6f95af5726dae`
- 分支与 `origin/main` 的 merge-base：等于 `origin/main` HEAD（已 rebase）
- 同步方式：rebase
- 公开 diff 命令：`git diff --stat origin/main...codex/ddd-slice-4` → 19 files, 658 insertions, 104 deletions
- 私有证据路径：任务包 `task_65ae1b4402cd3db4bae8f1b26b`
- 评审证据路径：同一任务包
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑
- [x] kernel 登记表测试 6/6：双射、每 type 单向、别名写拒收、反查一致、`unregistered` 恰限两格。
- [x] GUI 套件 26 文件 / 197 测试全绿，含两个「旧双实现下分歧、登记表下一致」的对照测试。
- [x] 门自测 7/7 带 5 个 bypass fixture——ratchet 拒收构造的非规范写入、放行存量语料。
- [x] daemon 关系面 56/56。integration tier 388/390；2 个失败在 stash 基线上同文件同因复现（阴性对照）——是本机另两条 worker 线常驻 daemon 造成的既有 `daemon-l2-readiness` 环境竞态，非本片引入。CI 是权威。
- [x] `npm run check:local` 退出 0；`npx tsc -b` 退出 0。
- [ ] GitHub Actions `rewrite-ci` 通过——本 PR 上待跑

## 评审证据

- CEO 评审：通读 diff 面与门。确认登记表是唯一权威（允许表派生而非并列）、GUI 镜像被逐行一致性门锁死不可漂移、门走既有 manifest 调度的 `boundaries` job 而非新 workflow、`unregistered` 行拒绝发明而非编码猜测。
- 由受托 worker（`agent:glm`）实现；侦察枚举（`agent:glm`，独立会话）经实现 worker 抽验后使用。
- 人工评审：待定
- 阻塞性发现：无

## 残余风险

- `unregistered` 两行（`decision→decision supports`、`blocks`）在 owner 赋予语义前不受规范方向执法；ratchet 无法保护方向被刻意未声明的边。
- GUI 镜像按设计复制了一个 filter 函数（桥边界所迫）。门使漂移不可能，但复制是真实的、已记录；若桥未来承载 kernel 领域值，镜像应删除。
- `invalidated-by` 仍作为退役别名可解析；移除该词涉两份镜像词表，已报告未做。
