### PR TITLE
fix(cli): dedupe dry-run manual receipts (morning adjudication CH9)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { cliCommandDomains, deriveCliCapabilities, firstCliCommand, helpDomain, parseThinCommand, renderThinCapabilities, renderThinHelp, unsupportedCommandHint } from "./cli/thin-command.ts";
-import { daemonAutostartFailureCode, runCommandThroughDaemon } from "./daemon/client.ts";
+import { consumeKnownError, daemonAutostartFailureCode, runCommandThroughDaemon } from "./daemon/client.ts";
 
 export async function main(argv: readonly string[] = process.argv.slice(2)): Promise<number> {
   const command = firstCliCommand(argv); if (argv.includes("--version") || argv.includes("-v") || command === "version") return emitMeta("version", argv.includes("--json")); if (command === "capabilities") return emitMeta("capabilities", argv.includes("--json"));
@@ -23,8 +23,18 @@ async function taskCreateHelpCatalog(argv: readonly string[]): Promise<Array<{ i
 function cliFailure(command: string, code: string, nextAction: string): Record<string, unknown> { return { schema: "command-receipt/v2", ok: false, command, outcome: "rejected", opId: "N/A", origin: "cli", code, evidence: `rejection:${code}`, error: { code, hint: nextAction }, nextAction }; }
 export function emit(receipt: Record<string, unknown>, json: boolean): void {
   if (json) console.log(JSON.stringify(receipt));
-  else if (receipt.ok === true || receipt.command === "migrate-import" && typeof receipt.summary === "string") console.log(String(receipt.command === "doc-show" ? receipt.evidence : receipt.command === "init" ? [String(receipt.summary), `outcome: ${receipt.outcome ?? "applied"}`, ...["created", "updated", "preserved", "drifted"].map((key) => `${key}: ${JSON.stringify(receipt[key] ?? [])}`), `commit: ${String(receipt.commit ?? "none")}`, `next: ${String(receipt.next ?? "")}`].join("\n") : receipt.summary ?? `${receipt.command ?? "command"}: ${receipt.outcome ?? "applied"}`));
+  else if (receipt.ok === true || receipt.command === "migrate-import" && typeof receipt.summary === "string") { const summary = contractMigrationDryRunSummary(receipt); console.log(String(summary ?? (receipt.command === "doc-show" ? receipt.evidence : receipt.command === "init" ? [String(receipt.summary), `outcome: ${receipt.outcome ?? "applied"}`, ...["created", "updated", "preserved", "drifted"].map((key) => `${key}: ${JSON.stringify(receipt[key] ?? [])}`), `commit: ${String(receipt.commit ?? "none")}`, `next: ${String(receipt.next ?? "")}`].join("\n") : receipt.summary ?? `${receipt.command ?? "command"}: ${receipt.outcome ?? "applied"}`))); }
   else console.error(`error code=${String((receipt.error as { code?: unknown } | undefined)?.code ?? "unknown")} hint=${String(receipt.nextAction ?? receipt.next ?? "Command failed.")}`);
 }
+function contractMigrationDryRunSummary(receipt: Record<string, unknown>): string | undefined {
+  if (receipt.command !== "task-contract-migrate" || typeof receipt.evidence !== "string") return undefined;
+  let payload: unknown; try { payload = JSON.parse(receipt.evidence); } catch (error) { consumeKnownError(error); return undefined; }
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return undefined;
+  const report = (payload as Record<string, unknown>).report, manual = (payload as Record<string, unknown>).manual;
+  if ((payload as Record<string, unknown>).applied !== false || !Array.isArray(report) || !Array.isArray(manual)) return undefined;
+  const rows = report.map(renderReceiptRow), scalars = Object.entries(payload).filter(([key, value]) => key !== "report" && key !== "manual" && (value === null || typeof value !== "object")).map(([key, value]) => `${key}=${String(value)}`).join("  ");
+  return [`report:\n${rows.length ? rows.join("\n") : "(none)"}`, scalars].filter(Boolean).join("\n");
+}
+function renderReceiptRow(row: unknown): string { return row && typeof row === "object" && !Array.isArray(row) ? Object.values(row).filter((value) => value === null || typeof value !== "object").map((value) => String(value)).join("\t") : String(row); }
 function isCliEntrypoint(): boolean { const invoked = process.argv[1]; if (!invoked) return false; try { return realpathSync(invoked) === realpathSync(fileURLToPath(import.meta.url)); } catch { return invoked.endsWith("packages/cli/src/index.ts"); } }
 if (isCliEntrypoint()) process.exitCode = await main();

--- a/packages/cli/test/daemon-autostart-cli.test.ts
+++ b/packages/cli/test/daemon-autostart-cli.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import test from "node:test";
 import { localUserDaemonEndpoint } from "../../daemon/src/client/local-daemon-target.ts";
 import { readDaemonPid } from "../../daemon/src/runtime.ts";
+import { makeTaskEventStore, REPLAY_TASK_GRAPH, taskLifecycleWritePlan, type TaskEventV1 } from "../../kernel/src/index.ts";
 
 const cli = path.resolve("packages/cli/src/index.ts");
 
@@ -72,6 +73,24 @@ test("semantic sources and agent execution cross the daemon before transport-bou
   }
 });
 
+test("dry-run contract migration prints each manual task once", () => {
+  const fixture = setup(), repoId = "contract-receipt", taskId = "task_legacy_l1";
+  try {
+    seedLegacyTask(fixture.root, repoId, taskId);
+    assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
+    register(fixture.root, fixture.userRoot, repoId);
+    const result = spawnSync(process.execPath, [cli, "--root", fixture.root, "task", "contract", "migrate", "--dry-run", "--task", taskId], { encoding: "utf8", env: cliEnv(fixture.root, fixture.userRoot) });
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+    assert.equal((result.stdout.match(new RegExp(taskId, "gu")) ?? []).length, 1, result.stdout);
+    const receipt = run(fixture.root, fixture.userRoot, ["task", "contract", "migrate", "--dry-run", "--task", taskId]);
+    const evidence = JSON.parse(String(receipt.evidence)) as { report: readonly { taskId: string; status: string; reason: string }[]; manual: readonly { taskId: string; status: string; reason: string }[] };
+    assert.deepEqual(evidence.manual, [evidence.report[0]], "JSON keeps the manual subset for machine consumers");
+  } finally {
+    stop(fixture.root, fixture.userRoot);
+    rmSync(fixture.parent, { recursive: true, force: true });
+  }
+});
+
 test("autostart gives up after two attempts with a classified bind-timeout error", { skip: process.platform === "win32" || process.getuid?.() === 0 ? "requires POSIX non-root permission semantics" : false }, () => {
   const fixture = setup();
   try {
@@ -110,3 +129,7 @@ function waitForDaemonDown(userRoot: string): void { const socketPath = localUse
   throw new Error("previous daemon did not drain before the autostart probe"); }
 function stop(root: string, userRoot: string): void { if (readDaemonPid(userRoot, "default") !== null) spawnSync(process.execPath, [cli, "--root", root, "--json", "daemon", "stop"], { encoding: "utf8", env: cliEnv(root, userRoot) }); }
 function git(root: string, ...args: string[]): string { return execFileSync("git", ["-C", root, ...args], { encoding: "utf8" }).trim(); }
+function seedLegacyTask(root: string, repoId: string, taskId: string): void {
+  const actor = { principal: { personId: "owner" }, executor: null } as const, event: TaskEventV1 = { schema: "task-event/v1", eventId: "event-contract-receipt", workspaceRevision: 1, opId: "op-contract-receipt", taskId, type: "task_created", actor, source: "local", occurredAt: "2026-08-18T00:00:00.000Z", payload: { task: { schema: "task/v1", taskId, title: "Legacy contract receipt", taskClass: "standard", status: "planned", graph: REPLAY_TASK_GRAPH, currentNode: "implementation", iteration: 0, createdBy: actor, completionGateIds: [], presetSnapshotDigest: null } } };
+  makeTaskEventStore({ repoId, rootDir: root }).append({ event, plan: taskLifecycleWritePlan(event), blobs: [] });
+}


### PR DESCRIPTION
# English

## Summary

Morning adjudication CH9 (dec_566B561008877A3E1C1369705F): the human-readable receipt of `task-contract-migrate --dry-run` printed every manual-queue task twice — the daemon returns both the full `report` and its `manual` subset, and the CLI rendered both sections. This double-count already caused one real statistics misread (1181 manual tasks reported as 2362). The CLI now renders only the full `report` section for this receipt; the JSON receipt keeps both fields unchanged (the `manual` subset carries no fields the report lacks, so no information is lost in the human view).

## What Changed

- `packages/cli/src/index.ts` — the dry-run human rendering skips the redundant `manual` subset section.
- `packages/cli/test/daemon-autostart-cli.test.ts` — real CLI→daemon regression: a manual task must appear exactly once in human output (red on the old code with 2 occurrences, green after), and the JSON receipt must still contain the `manual` subset.

## Task And Scope

- Harness authority: dec_566B561008877A3E1C1369705F CH9 (formal task package pending — the ledger write path is currently latched by the decision-order projection bug fixed in the parallel P0 line; the task record will be backfilled once it lands).
- Branch: `codex/dryrun-dedupe`
- Public scope: 2 files, +35/−2 (production +12/−2).
- Out of scope: the daemon receipt shape (unchanged by design — JSON consumers keep both fields).

## Version Impact

- Version: no version change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable — no changes to `tools/`, `.github/`, `gate-manifest.json`, any gate script, or any workflow.
- Authority: dec_566B561008877A3E1C1369705F CH9 (Zeyu's 2026-08-18 morning adjudication: fix the dry-run double print).
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: ce21712d9d2166a72f8553aeae53895e7a10ea8e
- Sync method: branched from current origin/main; merge-base equals origin/main
- Public diff command: `git diff --stat origin/main...codex/dryrun-dedupe` → 2 files, 35 insertions, 2 deletions
Production-Delta: +12/-2
- Private evidence path: report `tmp/orch/morning-adjudications/report-w2.md` (worker report; task package backfill pending per above)
- Reviewer evidence path: same
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] Red→green: manual task appears twice before, exactly once after; JSON `manual` subset asserted present.
- [x] `npm run check:local` green; `node --test packages/cli/test/daemon-autostart-cli.test.ts packages/application/test/execution-saga-v1.test.ts` 5/5; `npx tsc -b` exit 0.
- [ ] GitHub Actions `rewrite-ci` passed — pending on this PR

## Review Evidence

- CEO review: read the diff against CH9's adjudicated scope — human output deduped, JSON contract untouched, regression exercised over a real CLI→daemon round trip.
- Implemented by a delegated worker (`gpt-5.6-terra`).
- Human review: pending
- Blocking findings: none

## Residual Risk

- None beyond display semantics: any consumer that scraped the duplicated human text would now see one section; the JSON contract they should be using is unchanged.

---

# 中文

## 摘要

晨会裁决 CH9(dec_566B561008877A3E1C1369705F):`task-contract-migrate --dry-run` 的人类可读回执把每个 manual 队列任务打印两遍——daemon 同时返回全量 `report` 与其 `manual` 子集,CLI 两段都渲染。该双重计数已造成一次真实统计误读(1181 被读成 2362)。现 CLI 对该回执只渲染完整 `report` 段;JSON 回执两个字段原样保留(`manual` 子集没有 report 缺少的字段,人类视图零信息损失)。

## 变更内容

- `packages/cli/src/index.ts`——dry-run 人类渲染跳过冗余的 `manual` 子集段。
- `packages/cli/test/daemon-autostart-cli.test.ts`——真实 CLI→daemon 回归:manual 任务在人类输出恰好出现一次(旧代码红:出现 2 次;修后绿),并断言 JSON 回执仍含 `manual` 子集。

## 任务与范围

- 授权:dec_566B561008877A3E1C1369705F CH9(正式任务包待补——台账写路当前被 decision 顺序投影 bug latch,并行 P0 线修复落地后回填任务记录)。
- 分支:`codex/dryrun-dedupe`
- 公开范围:2 文件,+35/−2(生产 +12/−2)。
- 范围外:daemon 回执形状(设计上不动——JSON 消费者两字段照旧)。

## 版本影响

- 版本:无变更。
- 发布影响:不发布

## 治理声明

- 触碰受保护面:否
- 受保护面范围:不适用——未改 `tools/`、`.github/`、`gate-manifest.json`、任何门脚本或 workflow。
- 授权来源:dec_566B561008877A3E1C1369705F CH9(泽宇 2026-08-18 晨裁:修 dry-run 双重打印)。
- 机器检查边界:本 PR 仅断言声明存在;是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- Base `origin/main` SHA:ce21712d9d2166a72f8553aeae53895e7a10ea8e
- 同步方式:自当前 origin/main 开分支;merge-base 等于 origin/main
- 公开 diff 命令:`git diff --stat origin/main...codex/dryrun-dedupe` → 2 files, 35 insertions, 2 deletions
- 私有证据路径:worker 报告 `tmp/orch/morning-adjudications/report-w2.md`(任务包按上述回填)
- 评审证据路径:同上
- GitHub Actions `rewrite-ci` run URL:本 PR 上待跑
- [x] 红→绿:manual 任务修前出现两次、修后恰一次;JSON `manual` 子集断言仍在。
- [x] `check:local` 绿;autostart+saga 5/5;`tsc -b` 0。
- [ ] GitHub Actions `rewrite-ci` 通过——本 PR 上待跑

## 评审证据

- CEO 评审:对照 CH9 裁决范围读 diff——人类输出去重、JSON 契约未动、回归走真实 CLI→daemon 往返。
- 由受托 worker(`gpt-5.6-terra`)实现。
- 人工评审:待定
- 阻塞性发现:无

## 残余风险

- 仅展示语义:若有人抓取过重复的人类文本,现在只见一段;应使用的 JSON 契约未变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
