### PR TITLE
fix(gui): supersede a fact only via an active supersedes-fact edge (CH8/CH10)

### DIFF
--- a/packages/gui/src/renderer/components/FactInspector.tsx
+++ b/packages/gui/src/renderer/components/FactInspector.tsx
@@ -1,7 +1,7 @@
 import { ArrowSquareOut, Graph, GitBranch, WarningCircle, X } from "@phosphor-icons/react";
 import type { DecisionRow, FactRef, RelationEdge, TaskRow } from "../model/types";
 import { normalizeDecisionId } from "../model/triadic";
-import { incomingRelations } from "../model/relation-direction.ts";
+import { activeIncomingRelations, incomingRelations } from "../model/relation-direction.ts";
 import { CopyContextButton } from "./CopyContextButton";
 import { buildEntityJumpContext } from "../model/copy-context";
 import type { RelationCoverageRow } from "../../api/renderer-dto";
@@ -44,7 +44,9 @@ export function FactInspector({
   const task = fact ? tasks.find((candidate) => candidate.taskId === fact.taskId) : undefined;
   const inbound = relations.filter((relation) => relation.to === fullRef);
   const contradictions = incomingRelations(fullRef, "refuted-by", relations);
-  const supersedingRelations = incomingRelations(fullRef, "supersedes-fact", relations);
+  // Kernel fact-liveness criterion: only an active supersedes-fact edge marks the
+  // fact replaced; retired/deleted edges are audit history (see activeIncomingRelations).
+  const supersedingRelations = activeIncomingRelations(fullRef, "supersedes-fact", relations);
   const directlySupportedDecisionIds = incomingRelations(fullRef, "evidenced-by", relations)
     .map((relation) => normalizeDecisionId(relation.from));
   const coveredDecisionIds = coverageRows

--- a/packages/gui/src/renderer/graph/territory.ts
+++ b/packages/gui/src/renderer/graph/territory.ts
@@ -1,6 +1,6 @@
 import type { TaskRow, DecisionRow, FactRef, RelationEdge } from "../model/types";
 import type { FactAnchorRow, RelationCoverageRow } from "../../api/renderer-dto";
-import { incomingRelations } from "../model/relation-direction.ts";
+import { activeIncomingRelations, incomingRelations } from "../model/relation-direction.ts";
 import {
   resolveTaskModule,
   resolveFactModule,
@@ -172,8 +172,9 @@ export function classifyFactAnomaly(
   // contradictory:fact.invalidated 标记,或作为 decision --refuted-by--> fact 的 target(规范方向反查)。
   if (fact?.invalidated) return "contradictory";
   if (incomingRelations(factRef, "refuted-by", relations).length > 0) return "contradictory";
-  // superseded:被 supersedes-fact 指向(是 target)。
-  if (incomingRelations(factRef, "supersedes-fact", relations).length > 0) return "superseded";
+  // superseded:被 state=active 的 supersedes-fact 指向(是 target;判据照抄 kernel
+  // fact-liveness,retired/deleted 边是审计历史,不算取代)。
+  if (activeIncomingRelations(factRef, "supersedes-fact", relations).length > 0) return "superseded";
   // low-confidence。
   if (fact?.confidence === "low") return "low-confidence";
   // orphan:无 decision 引用(不在 coveredRefs 且无 evidenced-by 边指向它)。

--- a/packages/gui/src/renderer/model/fact-triage.ts
+++ b/packages/gui/src/renderer/model/fact-triage.ts
@@ -2,7 +2,7 @@ import type {
   FactAnchorRow,
   RelationCoverageRow,
 } from "../../api/renderer-dto";
-import { incomingRelations } from "./relation-direction.ts";
+import { activeIncomingRelations, incomingRelations } from "./relation-direction.ts";
 import type { FactRef, RelationEdge } from "./types";
 
 /**
@@ -98,9 +98,11 @@ export function computeFactTriageSignals(
     });
   }
 
-  // Kernel grammar: fact --supersedes-fact--> old fact. Only the
-  // target is stale; the source is the replacement and must not be penalized.
-  const supersedingRefs = incomingRelations(factRef, "supersedes-fact", relations).map((edge) => edge.from);
+  // Kernel grammar: fact --supersedes-fact--> old fact. Only the target is stale;
+  // the source is the replacement and must not be penalized. Kernel criterion
+  // (fact-liveness): the edge must be state "active" — retired/deleted edges are
+  // audit history and do not supersede.
+  const supersedingRefs = activeIncomingRelations(factRef, "supersedes-fact", relations).map((edge) => edge.from);
   if (supersedingRefs.length > 0) {
     signals.push({
       kind: "SUPERSEDED",

--- a/packages/gui/src/renderer/model/relation-direction.ts
+++ b/packages/gui/src/renderer/model/relation-direction.ts
@@ -13,3 +13,15 @@ import type { RelationEdge, RelationKind } from "./types";
 export function incomingRelations(targetRef: string, kind: RelationKind, relations: ReadonlyArray<RelationEdge>): ReadonlyArray<RelationEdge> {
   return relations.filter((relation) => relation.to === targetRef && relation.kind === kind);
 }
+
+/**
+ * Kernel parity filter for fact supersession
+ * (packages/kernel/src/domain/fact-liveness.ts): only an incoming edge with
+ * state "active" carries its relation semantics forward; retired/deleted edges
+ * are audit history. Every renderer derivation that treats an incoming edge as
+ * current (e.g. "this fact is superseded") must compose this predicate instead
+ * of re-deriving the criterion, so the two layers cannot drift.
+ */
+export function activeIncomingRelations(targetRef: string, kind: RelationKind, relations: ReadonlyArray<RelationEdge>): ReadonlyArray<RelationEdge> {
+  return incomingRelations(targetRef, kind, relations).filter((edge) => edge.state === "active");
+}

--- a/packages/gui/test/fact-triage.vitest.ts
+++ b/packages/gui/test/fact-triage.vitest.ts
@@ -239,6 +239,29 @@ describe("fact-triage signal computation", () => {
     expect(oldItem.signals.map((signal) => signal.kind)).toContain("SUPERSEDED");
     expect(newItem.signals.map((signal) => signal.kind)).not.toContain("SUPERSEDED");
   });
+
+  it("does not flag SUPERSEDED from a retired or deleted supersedes-fact edge", () => {
+    // Kernel criterion (packages/kernel/src/domain/fact-liveness.ts): only an
+    // ACTIVE incoming supersedes-fact edge supersedes the target. Retired/deleted
+    // edges are audit history and must not surface the old fact in the triage queue.
+    const oldFact = baseFact({ anchor: "task_a/F-old" });
+    for (const state of ["retired", "deleted"] as const) {
+      const relations = [
+        edge("fact/task_a/F-new", "fact/task_a/F-old", "supersedes-fact", { state }),
+      ];
+
+      const item = computeFactTriageSignals(
+        oldFact,
+        relations,
+        [coverage(oldFact)],
+        [anchor(oldFact)],
+      );
+
+      expect(item.signals.map((signal) => signal.kind)).not.toContain("SUPERSEDED");
+      expect(item.severity).toBe(0);
+      expect(rankFactTriage([item])).toEqual([]);
+    }
+  });
 });
 
 describe("fact-triage ranking", () => {
@@ -483,6 +506,30 @@ describe("cross-entity navigation projection", () => {
 
     expect(markup).toContain("支撑的 decision");
     expect(markup).toContain("dec_1");
+  });
+
+  it("does not show the replaced-by panel in FactInspector from a retired supersedes-fact edge", () => {
+    // Same kernel criterion as the triage signal: a retired supersedes-fact edge is
+    // audit history and must not render the fact as replaced.
+    const fact = baseFact();
+    const markup = renderToStaticMarkup(
+      createElement(FactInspector, {
+        factRef: `fact/${fact.anchor}`,
+        facts: [fact],
+        tasks: [baseTask()],
+        decisions: [baseDecision()],
+        relations: [
+          edge("fact/task_a/F-new", `fact/${fact.anchor}`, "supersedes-fact", {
+            state: "retired",
+          }),
+        ],
+        coverageRows: [coverage(fact)],
+        onClose: () => undefined,
+      }),
+    );
+
+    expect(markup).not.toContain("危险关系");
+    expect(markup).not.toContain("已被");
   });
 });
 

--- a/packages/gui/test/territory.vitest.ts
+++ b/packages/gui/test/territory.vitest.ts
@@ -210,9 +210,23 @@ describe("fact anomaly classification (TERRITORY-001)", () => {
   it("classifies a fact targeted by supersedes-fact as superseded", () => {
     const f = fact({ anchor: "task_a/F-old" });
     const relations: RelationEdge[] = [
-      { from: "fact/task_a/F-new", to: `fact/${f.anchor}`, kind: "supersedes-fact", provenance: "local-document" },
+      { from: "fact/task_a/F-new", to: `fact/${f.anchor}`, kind: "supersedes-fact", state: "active", provenance: "local-document" },
     ];
     expect(classifyFactAnomaly(`fact/${f.anchor}`, f, relations, new Set())).toBe("superseded");
+  });
+
+  it("does not classify a fact as superseded when the supersedes-fact edge is retired or deleted", () => {
+    // Kernel criterion (packages/kernel/src/domain/fact-liveness.ts): only an
+    // ACTIVE incoming supersedes-fact edge retires the fact. Retired/deleted
+    // edges are audit history and must not drive the territory anomaly display.
+    const f = fact({ anchor: "task_a/F-old" });
+    const covered = new Set([`fact/${f.anchor}`]);
+    for (const state of ["retired", "deleted"] as const) {
+      const relations: RelationEdge[] = [
+        { from: "fact/task_a/F-new", to: `fact/${f.anchor}`, kind: "supersedes-fact", state, provenance: "local-document" },
+      ];
+      expect(classifyFactAnomaly(`fact/${f.anchor}`, f, relations, covered)).toBe("normal");
+    }
   });
 
   it("classifies a low-confidence fact as low-confidence", () => {
@@ -242,7 +256,7 @@ describe("fact anomaly partition (partitionFactsByAnomaly)", () => {
     const fSuper = fact({ anchor: "task_a/F-old" });
     const fOk = fact({ anchor: "task_a/F-ok" });
     const relations: RelationEdge[] = [
-      { from: "fact/task_a/F-new", to: "fact/task_a/F-old", kind: "supersedes-fact", provenance: "local-document" },
+      { from: "fact/task_a/F-new", to: "fact/task_a/F-old", kind: "supersedes-fact", state: "active", provenance: "local-document" },
       { from: "decision/dec_1/CH1", to: "fact/task_a/F-ok", kind: "evidenced-by", provenance: "local-document" },
     ];
     const coverage: RelationCoverageRow[] = [];


### PR DESCRIPTION
# English

## Summary

Morning adjudications CH8 + CH10 (dec_566B561008877A3E1C1369705F): the GUI derived "this fact is superseded" from **any** incoming `supersedes-fact` edge, while the kernel's single judgment (`fact-liveness.ts`) counts only edges with `state === "active"` — retired/deleted edges are audit history, not liveness. Per Zeyu's ruling ("if the GUI disagrees with the kernel, make the GUI match the kernel"), the three GUI derivation sites now share one strict predicate. A whole-repo sweep found a third instance beyond the two adjudicated ones (FactInspector's danger panel) — same defect class, folded in and declared here.

Honest note: the production bridge (`adaptRelationRows`) already dropped non-active edges at the DTO boundary, so the on-screen symptom was largely masked by coincidence. The fix moves the judgment into the derivation functions themselves, so correctness no longer depends on the adapter's accidental filtering.

## What Changed

- `packages/gui/src/renderer/model/relation-direction.ts` — new shared helper `activeIncomingRelations` (strict `=== "active"`, mirroring kernel fact-liveness verbatim), placed in the kernel-parity mirror module both call sites already import.
- `graph/territory.ts:176`, `model/fact-triage.ts:103`, `components/FactInspector.tsx:47` — all three superseded derivations route through the helper; inactive edges no longer classify a fact as superseded, generate triage signals, or render the danger panel.
- Tests: one inactive-edge case per site (retired + deleted both covered); two stateless fixtures corrected to production shape (`state:"active"`).

## Task And Scope

- Harness authority: dec_566B561008877A3E1C1369705F CH8/CH10 (task package backfill pending — ledger write path latched until PR #1508 lands; will be recorded immediately after).
- Branch: `codex/gui-kernel-parity`
- Public scope: 6 files, +89/−11 (production +26/−9).
- Out of scope (reported, not fixed): the GUI's refuted-by derivations share the same drift pattern against `decision-coverage.ts` (active-only) — different judgment (refutation, not liveness), outside this adjudication; queued as its own follow-up slice. The FactInspector `inbound` edge list deliberately keeps showing all edges — it is an audit list, not a status judgment.

## Version Impact

- Version: no version change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable — no changes to `tools/`, `.github/`, `gate-manifest.json`, any gate script, or any workflow.
- Authority: dec_566B561008877A3E1C1369705F CH8 + CH10 (Zeyu's 2026-08-18 morning adjudication: GUI matches kernel).
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: refuted-by parity slice (reported above); task record backfill after unlatch.

## Verification

- Base `origin/main` SHA: e232a205f4bd44a2eaa4eaaacbc813738f19c2e7
- Sync method: rebase (once, across #1507; gates re-run after)
- Public diff command: `git diff --stat origin/main...codex/gui-kernel-parity` → 6 files, 89 insertions, 11 deletions
Production-Delta: +26/-9
- Private evidence path: `tmp/orch/morning-adjudications/report-w3.md`
- Reviewer evidence path: same
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] Per-site inactive-edge tests: retired/deleted supersedes-fact edges → normal classification, no SUPERSEDED signal, no danger panel; 46 targeted tests green.
- [x] `npm run test:gui` 27 files / 202 tests green; `npm run check:local` green (41 gates incl. relation-direction, status-vocabulary, dup-def); `npx tsc -b` exit 0.
- [x] GUI e2e not runnable in a worktree (known environment gap) — stated per handbook.
- [ ] GitHub Actions `rewrite-ci` passed — pending on this PR

## Review Evidence

- CEO review: read the helper against `fact-liveness.ts` (strict active, no default-state leniency), confirmed the three call sites and the declared third-instance expansion, and verified the refuted-by finding is reported rather than silently expanded into.
- Implemented by a delegated worker (`glm-5.3`).
- Human review: pending
- Blocking findings: none

## Residual Risk

- The masked-by-adapter history means no visible behavior change is expected in the running GUI today; the risk removed is latent (any relations source that bypasses the adapter).
- Refuted-by drift remains until its follow-up slice lands (reported above).

---

# 中文

## 摘要

晨会裁决 CH8+CH10(dec_566B561008877A3E1C1369705F):GUI 用**任意** incoming `supersedes-fact` 边派生「fact 已被取代」,而 kernel 单一判定(`fact-liveness.ts`)只认 `state === "active"` 的边——retired/deleted 边是审计历史,不是活性判定。按泽宇裁定(「GUI 不对就让 GUI 匹配内核」),三处 GUI 派生现共用一个 strict 谓词。全仓扫描在裁决点名的两处之外发现同类第三处(FactInspector 危险面板)——同缺陷类,一并收编并在此申报。

诚实备注:生产桥接层(`adaptRelationRows`)已在 DTO 边界丢弃非 active 边,屏上症状此前被巧合遮蔽。本修把判定移进派生函数自身,正确性不再依赖适配层的偶然过滤。

## 变更内容

- `packages/gui/src/renderer/model/relation-direction.ts`——新共享 helper `activeIncomingRelations`(strict `=== "active"`,逐字镜像 kernel fact-liveness),落在两处调用点已 import 的 kernel-parity 镜像模块。
- `graph/territory.ts:176`、`model/fact-triage.ts:103`、`components/FactInspector.tsx:47`——三处已取代派生全部走 helper;inactive 边不再判取代、不再产 triage 信号、不再渲染危险面板。
- 测试:每处一条 inactive 边用例(retired+deleted 双态);两个 stateless fixture 修正为生产形态(`state:"active"`)。

## 任务与范围

- 授权:dec_566B561008877A3E1C1369705F CH8/CH10(任务包待回填——台账写路被 latch,#1508 落地后立即补记)。
- 分支:`codex/gui-kernel-parity`
- 公开范围:6 文件,+89/−11(生产 +26/−9)。
- 范围外(已上报未修):GUI 的 refuted-by 派生与 `decision-coverage.ts`(只吃 active)同型漂移——判据不同(refutation 非 liveness),超出本裁决,已排为后续切片。FactInspector 的 `inbound` 入边清单刻意保留全量——审计列表不是状态判定。

## 版本影响

- 版本:无变更。
- 发布影响:不发布

## 治理声明

- 触碰受保护面:否
- 受保护面范围:不适用——未改 `tools/`、`.github/`、`gate-manifest.json`、任何门脚本或 workflow。
- 授权来源:dec_566B561008877A3E1C1369705F CH8+CH10(泽宇 2026-08-18 晨裁:GUI 匹配内核)。
- 机器检查边界:本 PR 仅断言声明存在;是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:refuted-by 对齐切片(上文已报);解楔后回填任务记录。

## 验证

- Base `origin/main` SHA:e232a205f4bd44a2eaa4eaaacbc813738f19c2e7
- 同步方式:rebase(跨 #1507 一次,rebase 后全部门复跑)
- 公开 diff 命令:`git diff --stat origin/main...codex/gui-kernel-parity` → 6 files, 89 insertions, 11 deletions
- 私有证据路径:`tmp/orch/morning-adjudications/report-w3.md`
- 评审证据路径:同上
- GitHub Actions `rewrite-ci` run URL:本 PR 上待跑
- [x] 每处 inactive 边用例:retired/deleted 边 → normal 分类、无 SUPERSEDED 信号、无危险面板;定向 46 测绿。
- [x] `test:gui` 27 文件/202 测绿;`check:local` 绿(41 门,含 relation-direction/status-vocabulary/dup-def);`tsc -b` 0。
- [x] GUI e2e 在 worktree 验不了(已知环境缺口)——按手册如实列出。
- [ ] GitHub Actions `rewrite-ci` 通过——本 PR 上待跑

## 评审证据

- CEO 评审:对照 `fact-liveness.ts` 读 helper(strict active,不宽待缺省 state),核实三个调用点与申报的第三处扩面,确认 refuted-by 发现是上报而非静默扩面。
- 由受托 worker(`glm-5.3`)实现。
- 人工评审:待定
- 阻塞性发现:无

## 残余风险

- 适配层遮蔽史意味着今日运行中的 GUI 预期无可见行为变化;消除的是潜伏风险(任何绕过适配层的 relations 来源)。
- refuted-by 漂移待后续切片(上文已报)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
