### PR TITLE
fix(gui): derive refutations from active relations only (CH10 follow-up)

### DIFF
--- a/packages/gui/src/renderer/components/FactInspector.tsx
+++ b/packages/gui/src/renderer/components/FactInspector.tsx
@@ -43,7 +43,9 @@ export function FactInspector({
   const fact = facts.find((candidate) => candidate.anchor === anchor);
   const task = fact ? tasks.find((candidate) => candidate.taskId === fact.taskId) : undefined;
   const inbound = relations.filter((relation) => relation.to === fullRef);
-  const contradictions = incomingRelations(fullRef, "refuted-by", relations);
+  // Current contradiction status follows kernel decision coverage: retired/deleted
+  // refuted-by edges remain visible in the incoming audit list, but do not warn here.
+  const contradictions = activeIncomingRelations(fullRef, "refuted-by", relations);
   // Kernel fact-liveness criterion: only an active supersedes-fact edge marks the
   // fact replaced; retired/deleted edges are audit history (see activeIncomingRelations).
   const supersedingRelations = activeIncomingRelations(fullRef, "supersedes-fact", relations);

--- a/packages/gui/src/renderer/graph/territory.ts
+++ b/packages/gui/src/renderer/graph/territory.ts
@@ -169,9 +169,10 @@ export function classifyFactAnomaly(
   relations: ReadonlyArray<RelationEdge>,
   coveredRefs: ReadonlySet<string>,
 ): FactAnomaly {
-  // contradictory:fact.invalidated 标记,或作为 decision --refuted-by--> fact 的 target(规范方向反查)。
+  // contradictory: fact.invalidated 标记,或作为 active decision --refuted-by--> fact
+  // 的 target(规范方向反查; retired/deleted 边是审计历史)。
   if (fact?.invalidated) return "contradictory";
-  if (incomingRelations(factRef, "refuted-by", relations).length > 0) return "contradictory";
+  if (activeIncomingRelations(factRef, "refuted-by", relations).length > 0) return "contradictory";
   // superseded:被 state=active 的 supersedes-fact 指向(是 target;判据照抄 kernel
   // fact-liveness,retired/deleted 边是审计历史,不算取代)。
   if (activeIncomingRelations(factRef, "supersedes-fact", relations).length > 0) return "superseded";

--- a/packages/gui/src/renderer/model/fact-triage.ts
+++ b/packages/gui/src/renderer/model/fact-triage.ts
@@ -58,8 +58,9 @@ export function computeFactTriageSignals(
 
   // Kernel grammar (canonical direction): decision --refuted-by--> fact. The fact that
   // refutes a decision is the contradictory observation that deserves attention; the
-  // reverse question goes through the domain query, never the retired invalidated-by alias.
-  const refutingDecisionRefs = incomingRelations(factRef, "refuted-by", relations).map((edge) => edge.from);
+  // edge must be active, while retired/deleted edges remain audit history. The reverse
+  // question goes through the domain query, never the retired invalidated-by alias.
+  const refutingDecisionRefs = activeIncomingRelations(factRef, "refuted-by", relations).map((edge) => edge.from);
   if (refutingDecisionRefs.length > 0) {
     signals.push({
       kind: "INVALIDATED",

--- a/packages/gui/src/renderer/model/relation-direction.ts
+++ b/packages/gui/src/renderer/model/relation-direction.ts
@@ -15,12 +15,12 @@ export function incomingRelations(targetRef: string, kind: RelationKind, relatio
 }
 
 /**
- * Kernel parity filter for fact supersession
- * (packages/kernel/src/domain/fact-liveness.ts): only an incoming edge with
+ * Kernel parity filter for current incoming relation semantics
+ * (packages/kernel/src/domain/decision-coverage.ts): only an incoming edge with
  * state "active" carries its relation semantics forward; retired/deleted edges
  * are audit history. Every renderer derivation that treats an incoming edge as
- * current (e.g. "this fact is superseded") must compose this predicate instead
- * of re-deriving the criterion, so the two layers cannot drift.
+ * current (e.g. "this fact is superseded" or contradicted) must compose this
+ * predicate instead of re-deriving the criterion, so the two layers cannot drift.
  */
 export function activeIncomingRelations(targetRef: string, kind: RelationKind, relations: ReadonlyArray<RelationEdge>): ReadonlyArray<RelationEdge> {
   return incomingRelations(targetRef, kind, relations).filter((edge) => edge.state === "active");

--- a/packages/gui/test/fact-triage.vitest.ts
+++ b/packages/gui/test/fact-triage.vitest.ts
@@ -158,6 +158,21 @@ describe("fact-triage signal computation", () => {
     expect(retiredAlias.signals.map((signal) => signal.kind)).not.toContain("INVALIDATED");
   });
 
+  it("does not flag INVALIDATED from a retired or deleted refuted-by edge", () => {
+    const fact = baseFact();
+    for (const state of ["retired", "deleted"] as const) {
+      const item = computeFactTriageSignals(
+        fact,
+        [edge("decision/dec_2", `fact/${fact.anchor}`, "refuted-by", { state })],
+        [coverage(fact)],
+        [anchor(fact)],
+      );
+
+      expect(item.signals.map((signal) => signal.kind)).not.toContain("INVALIDATED");
+      expect(item.severity).toBe(0);
+    }
+  });
+
   it("flags an orphan from factAnchors minus covered coverageRows", () => {
     const fact = baseFact();
 
@@ -530,6 +545,29 @@ describe("cross-entity navigation projection", () => {
 
     expect(markup).not.toContain("危险关系");
     expect(markup).not.toContain("已被");
+  });
+
+  it("keeps retired and deleted refuted-by edges in the audit list but out of the FactInspector danger panel", () => {
+    const fact = baseFact();
+    for (const state of ["retired", "deleted"] as const) {
+      const markup = renderToStaticMarkup(
+        createElement(FactInspector, {
+          factRef: `fact/${fact.anchor}`,
+          facts: [fact],
+          tasks: [baseTask()],
+          decisions: [baseDecision()],
+          relations: [
+            edge("decision/dec_2", `fact/${fact.anchor}`, "refuted-by", { state }),
+          ],
+          coverageRows: [coverage(fact)],
+          onClose: () => undefined,
+        }),
+      );
+
+      expect(markup).toContain("refuted-by");
+      expect(markup).not.toContain("危险关系");
+      expect(markup).not.toContain("矛盾于");
+    }
   });
 });
 

--- a/packages/gui/test/territory.vitest.ts
+++ b/packages/gui/test/territory.vitest.ts
@@ -197,9 +197,20 @@ describe("fact anomaly classification (TERRITORY-001)", () => {
   it("classifies a fact targeted by refuted-by as contradictory", () => {
     const f = fact({ anchor: "task_a/F-contr" });
     const relations: RelationEdge[] = [
-      { from: "decision/dec_1", to: `fact/${f.anchor}`, kind: "refuted-by", provenance: "local-document" },
+      { from: "decision/dec_1", to: `fact/${f.anchor}`, kind: "refuted-by", state: "active", provenance: "local-document" },
     ];
     expect(classifyFactAnomaly(`fact/${f.anchor}`, f, relations, new Set())).toBe("contradictory");
+  });
+
+  it("does not classify a fact as contradictory from a retired or deleted refuted-by edge", () => {
+    const f = fact({ anchor: "task_a/F-contr" });
+    const covered = new Set([`fact/${f.anchor}`]);
+    for (const state of ["retired", "deleted"] as const) {
+      const relations: RelationEdge[] = [
+        { from: "decision/dec_1", to: `fact/${f.anchor}`, kind: "refuted-by", state, provenance: "local-document" },
+      ];
+      expect(classifyFactAnomaly(`fact/${f.anchor}`, f, relations, covered)).toBe("normal");
+    }
   });
 
   it("classifies a fact with invalidated flag as contradictory", () => {


### PR DESCRIPTION
# English

## Summary

Follow-up slice to #1509, same adjudication spirit (dec_566B561008877A3E1C1369705F CH10: the GUI matches the kernel). #1509's worker reported an adjacent drift while fixing supersedes-fact: the GUI's **refuted-by** derivations also counted edges of any state, while the kernel (`decision-coverage.ts`) consumes refuted-by from **active** edges only. All three GUI consumption sites now route through the shared `activeIncomingRelations` helper introduced in #1509. A whole-repo rescan found no fourth derivation site (remaining hits are kernel/schema/gates, protocol, or pure display vocabulary).

## What Changed

- `graph/territory.ts` — a fact is "contradicted" only via an active refuted-by edge.
- `model/fact-triage.ts` — retired/deleted edges no longer raise the `INVALIDATED` signal.
- `components/FactInspector.tsx` — the danger panel is active-only; the full inbound audit list keeps showing all edges (audit list, not a status judgment).
- `model/relation-direction.ts` — helper doc extended to name the decision-coverage active-only criterion.
- Tests: retired + deleted cases per site; audit-list-retention asserted.

## Task And Scope

- Harness authority: dec_566B561008877A3E1C1369705F CH10 + the standing fix-on-sight authorization (drift reported by #1509's worker); task record backfill pending unlatch (same batch as the other morning lines).
- Branch: `codex/gui-refutedby`
- Public scope: +63/−10 (production +13/-9).
- Out of scope: kernel, CLI, tools, workflows (untouched).

## Version Impact

- Version: no version change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable — no changes to `tools/`, `.github/`, `gate-manifest.json`, any gate script, or any workflow.
- Authority: dec_566B561008877A3E1C1369705F CH10; drift finding recorded in PR #1509's body.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: task record backfill after unlatch.

## Verification

- Base `origin/main` SHA: fc681044271ae662bdb337cd414086fbee4e393e
- Sync method: branched from current origin/main; merge-base equals origin/main
- Public diff command: `git diff --stat origin/main...codex/gui-refutedby`
Production-Delta: +13/-9
- Private evidence path: `tmp/orch/morning-adjudications/report-w4.md`
- Reviewer evidence path: same
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] Per-site retired/deleted cases green; audit list retention asserted.
- [x] `npm run test:gui` 27 files / 205 tests green; `npm run check:local` green; `npx tsc -b` exit 0.
- [x] GUI e2e not runnable in a worktree (known gap) — stated per handbook.
- [ ] GitHub Actions `rewrite-ci` passed — pending on this PR

## Review Evidence

- CEO review: read the three sites against `decision-coverage.ts` (active-only), confirmed the audit list is deliberately untouched and the rescan claim covers derivation sites only.
- Implemented by a delegated worker (`gpt-5.6-terra`, failover from GLM 529).
- Human review: pending
- Blocking findings: none

## Residual Risk

- None identified; same masked-by-adapter caveat as #1509 applies (the fix removes latent, not visible, misjudgment).

---

# 中文

## 摘要

#1509 的后续切片,同一裁决精神(dec_566B561008877A3E1C1369705F CH10:GUI 匹配内核)。#1509 的 worker 在修 supersedes-fact 时上报相邻漂移:GUI 的 **refuted-by** 派生同样不分边 state,而 kernel(`decision-coverage.ts`)只从 **active** 边消费 refuted-by。三处 GUI 消费点现全部走 #1509 引入的共享 `activeIncomingRelations` helper。全仓复扫无第四个派生消费点(其余命中为 kernel/schema/门、协议或纯展示词表)。

## 变更内容

- `graph/territory.ts`——仅 active refuted-by 边判「矛盾」。
- `model/fact-triage.ts`——retired/deleted 边不再触发 `INVALIDATED` 信号。
- `components/FactInspector.tsx`——危险面板 active-only;全量入边审计列表保留(审计列表非状态判定)。
- `model/relation-direction.ts`——helper 文档扩展点名 decision-coverage 的 active-only 判据。
- 测试:每处 retired+deleted 双态;审计列表保留断言。

## 任务与范围

- 授权:dec_566B561008877A3E1C1369705F CH10 + 发现即修常设授权(漂移由 #1509 worker 上报);任务记录解楔后与其他晨会线同批回填。
- 分支:`codex/gui-refutedby`
- 公开范围:+63/−10(生产 +13/-9)。
- 范围外:kernel、CLI、tools、workflows(未触碰)。

## 版本影响

- 版本:无变更。
- 发布影响:不发布

## 治理声明

- 触碰受保护面:否
- 受保护面范围:不适用——未改 `tools/`、`.github/`、`gate-manifest.json`、任何门脚本或 workflow。
- 授权来源:dec_566B561008877A3E1C1369705F CH10;漂移发现记录于 PR #1509 body。
- 机器检查边界:本 PR 仅断言声明存在;是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:解楔后回填任务记录。

## 验证

- Base `origin/main` SHA:fc681044271ae662bdb337cd414086fbee4e393e
- 同步方式:自当前 origin/main 开分支;merge-base 等于 origin/main
- 公开 diff 命令:`git diff --stat origin/main...codex/gui-refutedby`
- 私有证据路径:`tmp/orch/morning-adjudications/report-w4.md`
- 评审证据路径:同上
- GitHub Actions `rewrite-ci` run URL:本 PR 上待跑
- [x] 每处 retired/deleted 双态绿;审计列表保留断言。
- [x] `test:gui` 27 文件/205 测绿;`check:local` 绿;`tsc -b` 0。
- [x] GUI e2e worktree 验不了(已知缺口)——按手册如实列出。
- [ ] GitHub Actions `rewrite-ci` 通过——本 PR 上待跑

## 评审证据

- CEO 评审:对照 `decision-coverage.ts`(active-only)读三处修点,确认审计列表刻意未动、复扫断言只覆盖派生消费点。
- 由受托 worker(`gpt-5.6-terra`,GLM 529 后互备接手)实现。
- 人工评审:待定
- 阻塞性发现:无

## 残余风险

- 未发现;与 #1509 同样适用「适配层遮蔽」备注(消除的是潜伏误判,非可见症状)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
