### PR TITLE
fix(kernel): apply relation and recovery adjudications (CH3/CH4/CH8)

### DIFF
--- a/packages/kernel/src/domain/relation-direction.ts
+++ b/packages/kernel/src/domain/relation-direction.ts
@@ -34,9 +34,7 @@ export const canonicalRelationDirections: readonly CanonicalRelationDirection[] 
   { type: "narrows", sourceKind: "decision", targetKind: "decision", reads: "the decision narrows the target decision", registration: "ratified" },
   { type: "relates", sourceKind: "decision", targetKind: "decision", reads: "the decision relates to the target decision", registration: "ratified" },
   { type: "derives", sourceKind: "decision", targetKind: "decision", reads: "the decision spawns the target decision", registration: "ratified" },
-  // 4 active edges exist in this shape but no semantics are registered for
-  // decision-to-decision support; the owner must register or migrate them (slice 4 closeout).
-  { type: "supports", sourceKind: "decision", targetKind: "decision", reads: "the decision supports the target decision", registration: "unregistered" },
+  { type: "supports", sourceKind: "decision", targetKind: "decision", reads: "the decision supports the target decision", registration: "ratified" },
   // Allowed by the ratified sentence grammar; zero stored edges and no registered semantics.
   { type: "blocks", sourceKind: "decision", targetKind: "decision", reads: "the decision blocks the target decision", registration: "unregistered" },
   // decision → task

--- a/packages/kernel/src/domain/status-vocabulary.ts
+++ b/packages/kernel/src/domain/status-vocabulary.ts
@@ -98,7 +98,7 @@ export const statusWordRegister: readonly StatusWordRegistration[] = [
   { word: "active", entity: "Task", field: "status", meaning: "Task is in an open executing state and occupies a WIP slot.", divergence: "divergent", resolution: "One of six unrelated `active` concepts; rename is stored data (task snapshots and events), so this slice registers the meaning instead — CH2 proposal only." },
   { word: "blocked", entity: "Task", field: "status", meaning: "Task is held by an external condition; still open, still occupies WIP.", divergence: "entity-scoped" },
   { word: "in_review", entity: "Task", field: "status", meaning: "Task is in the review node; review artifacts are required.", divergence: "entity-scoped" },
-  { word: "done", entity: "Task", field: "status", meaning: "Task reached its delivery terminal state.", divergence: "divergent", resolution: "Recovery.done is a batch bookkeeping word, not delivery; Recovery is runtime-only so its rename (e.g. exhausted) is executable later — proposal in slice report." },
+  { word: "done", entity: "Task", field: "status", meaning: "Task reached its delivery terminal state.", divergence: "entity-scoped" },
   { word: "cancelled", entity: "Task", field: "status", meaning: "Task was abandoned; terminal.", divergence: "entity-scoped" },
   { word: "open", entity: "Task", field: "coarse class", meaning: "Coarse class of every non-terminal task status.", divergence: "entity-scoped" },
   { word: "terminal", entity: "Task", field: "coarse class", meaning: "Coarse class of done/cancelled; no further transitions.", divergence: "entity-scoped" },
@@ -107,7 +107,7 @@ export const statusWordRegister: readonly StatusWordRegistration[] = [
   { word: "proposed", entity: "Decision", field: "state", meaning: "Decision awaits judgment.", divergence: "entity-scoped" },
   { word: "active", entity: "Decision", field: "state", meaning: "Decision was accepted and its policy is in effect (accept writes active; there is no separate accepted state).", divergence: "divergent", resolution: "Diverges from Task/Execution/Lease/Relation/Package `active`; stored in decision documents and events, so registration only — CH2 proposal (e.g. in_effect) in slice report." },
   { word: "rejected", entity: "Decision", field: "state", meaning: "Judgment refused the decision; a persistent policy state that feeds later adjudication.", divergence: "divergent", resolution: "Preset-run and write-receipt `rejected` are one-shot operation results; the decision word is stored policy. Receipt/preset renames are public surfaces — CH2 proposal only." },
-  { word: "deferred", entity: "Decision", field: "state", meaning: "Judgment postponed; a persistent policy state.", divergence: "divergent", resolution: "Recovery.deferred is an ops deferral of queued work, not adjudication; runtime-only vocabulary, rename executable later — proposal in slice report." },
+  { word: "deferred", entity: "Decision", field: "state", meaning: "Judgment postponed; a persistent policy state.", divergence: "entity-scoped" },
   { word: "superseded", entity: "Decision", field: "state", meaning: "A later decision replaced this one (ADR-0020 D1: consumers must preserve this state, never fold it back into proposed).", divergence: "entity-scoped" },
   { word: "retired", entity: "Decision", field: "state", meaning: "A human ended the decision's standing deliberately.", divergence: "divergent", resolution: "Edge-retired is bookkeeping and fact-retired is derivation; decision-retired is a chosen outcome stored in the ledger (34 live rows at scout time) — CH2 proposal only." },
   { word: "active", entity: "Decision", field: "judgment targetState", meaning: "Judgment consent target when the action is accept.", divergence: "entity-scoped" },
@@ -164,9 +164,9 @@ export const statusWordRegister: readonly StatusWordRegistration[] = [
   // ---- Recovery.state (write-chain recovery batches; runtime-only) ----
   { word: "queued", entity: "Recovery", field: "state", meaning: "Recovery items still queued behind the cursor.", divergence: "entity-scoped" },
   { word: "running", entity: "Recovery", field: "state", meaning: "Recovery batch is executing.", divergence: "entity-scoped" },
-  { word: "deferred", entity: "Recovery", field: "state", meaning: "Recovery batch ran out of deadline budget and deferred the remainder.", divergence: "divergent", resolution: "Ops deferral, not adjudication (Decision.deferred); Recovery is runtime-only, rename executable later — proposal in slice report." },
+  { word: "exhausted", entity: "Recovery", field: "state", meaning: "Recovery batch exhausted its current budget with items remaining.", divergence: "entity-scoped" },
   { word: "failed", entity: "Recovery", field: "state", meaning: "Recovery exhausted its retries.", divergence: "entity-scoped" },
-  { word: "done", entity: "Recovery", field: "state", meaning: "Recovery batch drained its items.", divergence: "divergent", resolution: "Batch bookkeeping, not delivery (Task.done); runtime-only, rename executable later — proposal in slice report." },
+  { word: "drained", entity: "Recovery", field: "state", meaning: "Recovery batch drained its items.", divergence: "entity-scoped" },
 
   // ---- PresetRun outcome/phase (documented; declared in packages/preset) ----
   { word: "started", entity: "PresetRun", field: "outcome", meaning: "Preset run was launched.", divergence: "entity-scoped" },
@@ -235,7 +235,7 @@ export const statusVocabularies: readonly StatusVocabulary[] = [
   { id: "runtime.outcome", entity: "RuntimeSession", field: "outcome", module: "packages/kernel/src/domain/agent-runtime.ts", anchor: "#outcome", words: ["succeeded", "failed", "unknown"] },
   { id: "receipt.outcome", entity: "WriteReceipt", field: "outcome", module: "packages/kernel/src/domain/write-chain.contract.ts", anchor: "writeReceiptOutcomes", words: ["applied", "pending", "indeterminate", "rejected"] },
   { id: "receipt.detail.outcome", entity: "WriteReceipt", field: "outcome", module: "packages/kernel/src/domain/receipt-domain-registry.ts", anchor: "#outcome", words: ["applied", "pending", "indeterminate", "rejected"], subsetOf: "receipt.outcome", note: "The WriteReceipt interface repeats the outcome vocabulary; must stay equal to writeReceiptOutcomes." },
-  { id: "recovery.state", entity: "Recovery", field: "state", module: "packages/kernel/src/domain/write-chain.contract.ts", anchor: "recoveryStates", words: ["queued", "running", "deferred", "failed", "done"] },
+  { id: "recovery.state", entity: "Recovery", field: "state", module: "packages/kernel/src/domain/write-chain.contract.ts", anchor: "recoveryStates", words: ["queued", "running", "exhausted", "failed", "drained"] },
   { id: "closeout.readiness", entity: "TaskCloseout", field: "readiness", module: "packages/kernel/src/domain/closeout-readiness.ts", anchor: "closeoutReadinesses", words: ["not_required", "missing", "incomplete", "ready", "passed", "failed"] },
   { id: "task.session-disposition", entity: "Task", field: "sessionBinding disposition", module: "packages/kernel/src/domain/task-lifecycle.contract.ts", anchor: "#sessionDisposition", words: ["complete", "partial", "unavailable"], note: "Witness availability, not entity standing." },
   { id: "vertical-script.disposition", entity: "VerticalScript", field: "disposition", module: "packages/kernel/src/domain/vertical-script-action.ts", anchor: "#disposition", words: ["create", "replace"] },

--- a/packages/kernel/src/domain/write-chain.contract.ts
+++ b/packages/kernel/src/domain/write-chain.contract.ts
@@ -37,7 +37,7 @@ export interface RecoveryBudget {
   readonly retry: number;
 }
 export const RECOVERY_BUDGET: Readonly<RecoveryBudget> = Object.freeze({ deadline: 100, maxItems: 64, retry: 1 });
-export const recoveryStates = Object.freeze(["queued", "running", "deferred", "failed", "done"] as const);
+export const recoveryStates = Object.freeze(["queued", "running", "exhausted", "failed", "drained"] as const);
 export type RecoveryState = (typeof recoveryStates)[number];
 export interface RecoveryWindow { readonly elapsed: number; readonly attempt: number }
 
@@ -55,12 +55,12 @@ export function nextRecoveryBatch<T>(items: readonly T[], cursor = 0, budget: Re
     || !Number.isInteger(window.elapsed) || window.elapsed < 0 || !Number.isInteger(window.attempt) || window.attempt < 0) {
     throw new WriteChainContractError("invalid_contract", "recovery cursor, budget, and window must be non-negative integers with a positive item limit");
   }
-  const exhausted: RecoveryState | null = window.attempt > budget.retry ? "failed" : window.elapsed >= budget.deadline ? "deferred" : null;
-  if (exhausted !== null) return Object.freeze({ items: Object.freeze([]) as readonly T[], deferred: Math.max(0, items.length - cursor), nextCursor: cursor, state: exhausted });
+  const stopped: RecoveryState | null = window.attempt > budget.retry ? "failed" : window.elapsed >= budget.deadline ? "exhausted" : null;
+  if (stopped !== null) return Object.freeze({ items: Object.freeze([]) as readonly T[], deferred: Math.max(0, items.length - cursor), nextCursor: cursor, state: stopped });
   const batch = Object.freeze(items.slice(cursor, cursor + budget.maxItems));
   const nextCursor = cursor + batch.length;
   const deferred = Math.max(0, items.length - nextCursor);
-  return Object.freeze({ items: batch, deferred, nextCursor, state: deferred === 0 ? "done" : "deferred" });
+  return Object.freeze({ items: batch, deferred, nextCursor, state: deferred === 0 ? "drained" : "exhausted" });
 }
 
 export interface EventEnvelope<S extends string, T extends string, A extends ActorIdentity, P> {

--- a/packages/kernel/src/projection/fact-event-projection.ts
+++ b/packages/kernel/src/projection/fact-event-projection.ts
@@ -125,9 +125,9 @@ export function assertFactAdmission(db: DatabaseSync, event: FactEventV1): void 
     throw new FactProjectionError("invalid_transition", `Fact ${ownRef} already exists.`);
   const supersedes = event.payload.supersedes;
   if (!supersedes) return;
-  const target = db.prepare("SELECT 1 FROM fact WHERE ref = ?").get(supersedes.factRef);
+  const target = db.prepare("SELECT ref FROM fact WHERE ref = ?").get(supersedes.factRef) as { readonly ref: string } | undefined;
   if (!target) throw new FactProjectionError("entity_not_found", `Superseded endpoint ${supersedes.factRef} does not exist.`);
-  if (db.prepare("SELECT 1 FROM relation_edge WHERE target_ref = ? AND relation_type = 'supersedes-fact' AND state = 'active'").get(supersedes.factRef))
+  if (factLiveness(target, livenessRelations(db)) === "retired")
     throw new FactProjectionError("relation_invalid", `Superseded endpoint ${supersedes.factRef} is already retired.`);
 }
 

--- a/packages/kernel/test/domain/relation-direction.test.ts
+++ b/packages/kernel/test/domain/relation-direction.test.ts
@@ -77,8 +77,8 @@ test("semantics with no registered reading are flagged, not silently ratified", 
   const unregistered = canonicalRelationDirections.filter(({ registration }) => registration === "unregistered");
   assert.deepEqual(
     unregistered.map(({ type }) => type).sort(),
-    ["blocks", "supports"],
-    "exactly the decision->decision blocks/supports cells lack registered semantics"
+    ["blocks"],
+    "only the decision->decision blocks cell lacks registered semantics"
   );
   for (const direction of unregistered) {
     assert.equal(direction.sourceKind, "decision");

--- a/packages/kernel/test/store/fact-admission-liveness.test.ts
+++ b/packages/kernel/test/store/fact-admission-liveness.test.ts
@@ -1,0 +1,47 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import type { FactEventV1 } from "../../src/domain/fact-event.ts";
+import { createFactProjectionTables, FactProjectionError, readFactRow, reduceFactEvent } from "../../src/projection/fact-event-projection.ts";
+
+const actor = { principal: { personId: "fact-admission" }, executor: null } as const;
+
+test("Fact admission accepts superseding a live target", () => {
+  const db = new DatabaseSync(":memory:");
+  try {
+    createFactProjectionTables(db);
+    reduceFactEvent(db, fact(1, "F-ABCDEFGH"));
+    reduceFactEvent(db, fact(2, "F-BCDEFGHJ", "fact/task-fact/F-ABCDEFGH"));
+    assert.equal(readFactRow(db, "task-fact", "F-ABCDEFGH")?.state, "retired");
+    assert.equal(readFactRow(db, "task-fact", "F-BCDEFGHJ")?.state, "live");
+  } finally {
+    db.close();
+  }
+});
+
+test("Fact admission rejects superseding an already-retired target", () => {
+  const db = new DatabaseSync(":memory:");
+  try {
+    createFactProjectionTables(db);
+    reduceFactEvent(db, fact(1, "F-ABCDEFGH"));
+    reduceFactEvent(db, fact(2, "F-BCDEFGHJ", "fact/task-fact/F-ABCDEFGH"));
+    assert.throws(
+      () => reduceFactEvent(db, fact(3, "F-CDEFGHJK", "fact/task-fact/F-ABCDEFGH")),
+      (error: unknown) => error instanceof FactProjectionError && error.code === "relation_invalid" && /already retired/u.test(error.message)
+    );
+  } finally {
+    db.close();
+  }
+});
+
+function fact(revision: number, factId: string, supersedesRef?: string): FactEventV1 {
+  return {
+    schema: "fact-event/v1", eventId: `event-${revision}`, workspaceRevision: revision, opId: `op-${revision}`,
+    taskId: "task-fact", factId, type: "fact_recorded", actor, source: "local", occurredAt: "2026-08-18T00:00:00.000Z",
+    payload: { statement: `Fact ${factId}`, evidenceSource: "admission test", observedAt: "2026-08-18T00:00:00.000Z",
+      confidence: "high", memoryClass: "semantic", memoryTags: [], provenance: [],
+      ...(supersedesRef ? { supersedes: { factRef: supersedesRef, rationale: "New observation replaces the target." } } : {}),
+      factsDocumentClaim: { path: "tasks/task-fact/facts.md", sha256: "0".repeat(64), size: 0, mediaType: "text/markdown", policyId: "typed-machine-writer/v1" } }
+  };
+}

--- a/tools/gates/test/write-chain-contract.test.mjs
+++ b/tools/gates/test/write-chain-contract.test.mjs
@@ -114,7 +114,7 @@ test("G02/G07 expose one four-state receipt and bounded recovery contract", asyn
   }), WriteChainContractError);
 });
 
-test("G08 recovery cursor is monotonic, visits once, defers exhausted budgets, and escalates exhausted retry", () => {
+test("G08 recovery cursor is monotonic, visits once, reports exhausted budgets, drains, and escalates exhausted retry", () => {
   const budget = { deadline: 100, maxItems: 2, retry: 1 };
   for (const invalid of [{ ...budget, deadline: -1 }, { ...budget, maxItems: -1 }, { ...budget, retry: -1 }]) {
     assert.throws(() => nextRecoveryBatch([0, 1], 0, invalid), WriteChainContractError);
@@ -124,9 +124,9 @@ test("G08 recovery cursor is monotonic, visits once, defers exhausted budgets, a
   const third = nextRecoveryBatch([0, 1, 2, 3, 4], second.nextCursor, budget);
   assert.deepEqual([first.nextCursor, second.nextCursor, third.nextCursor], [2, 4, 5]);
   assert.deepEqual([...first.items, ...second.items, ...third.items], [0, 1, 2, 3, 4]);
-  assert.deepEqual([first.deferred, first.state, third.deferred, third.state], [3, "deferred", 0, "done"]);
+  assert.deepEqual([first.deferred, first.state, third.deferred, third.state], [3, "exhausted", 0, "drained"]);
   assert.deepEqual(nextRecoveryBatch([0, 1], 0, budget, { elapsed: 100, attempt: 0 }),
-    { items: [], deferred: 2, nextCursor: 0, state: "deferred" });
+    { items: [], deferred: 2, nextCursor: 0, state: "exhausted" });
   assert.deepEqual(nextRecoveryBatch([0, 1], 0, budget, { elapsed: 0, attempt: 2 }),
     { items: [], deferred: 2, nextCursor: 0, state: "failed" });
 });


### PR DESCRIPTION
# English

## Summary

Three kernel-side items from the morning adjudications (dec_566B561008877A3E1C1369705F):

1. **CH4** — `supports` (decision→decision) is now a ratified type in the relation-direction registry with its canonical direction pinned; the 4 existing active edges move from ratchet-tolerated to legal. `blocks` stays unregistered by checkpoint ruling: its measured backlog is **zero** (the skeleton's mention traces to legacy fenced-frontmatter text that never reached the canonical projection — CH5's territory); registering a type with no uses would be speculative vocabulary. If CH5's recovery later surfaces a real blocks edge, it gets registered against actual endpoint semantics.
2. **CH3 (executable group)** — `Recovery.deferred → exhausted`, `Recovery.done → drained`: the only rename group with zero storage face (runtime-only). Status-vocabulary register updated; the two divergent rows collapse.
3. **CH8 (kernel side)** — the Fact write admission in `fact-event-projection.ts` judged "target already retired" with a raw SQL `EXISTS`, bypassing the single `factLiveness` judgment; it now routes through the named domain judgment with behavior-equivalence tests (live and retired targets, before/after).

## What Changed

- `domain/relation-direction.ts` — supports ratified, direction pinned.
- `domain/status-vocabulary.ts` — Recovery vocabulary renamed; divergent rows resolved.
- `domain/write-chain.contract.ts` + `projection/fact-event-projection.ts` — admission via `factLiveness`; renamed words threaded.
- `tools/gates/test/write-chain-contract.test.mjs` — the gate's **test** updated to the renamed vocabulary (no gate script, manifest, or gate semantics touched — declared here for transparency since it lives under `tools/`).
- New `fact-admission-liveness.test.ts` — red-green equivalence for the admission path.

## Task And Scope

- Harness task: `task_ad7f05175502513cd3bb9e537c` (derives from dec_566B561008877A3E1C1369705F CH4)
- Branch: `codex/kernel-adjudications`
- Public scope: 7 files, +64/−19 (production **+12/−14, net −2**).
- Out of scope: the 5 stored-face rename groups (design line in flight, data untouched); blocks registration (deferred, zero backlog).

## Version Impact

- Version: no version change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no gate script, manifest, or workflow; one **test file under `tools/gates/test/`** updated solely to follow the adjudicated vocabulary rename (no enforcement semantics changed; the vocabulary gate itself passes on the new register).
- Protected surface scope: as stated above.
- Authority: dec_566B561008877A3E1C1369705F CH3/CH4/CH8 (Zeyu's 2026-08-18 morning adjudications); checkpoint ruling on blocks recorded in the task package.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: 8e6b05f8bbd72af45d58bb0c8bb880e6c6c45399
- Sync method: rebase; merge-base equals origin/main
- Public diff command: `git diff --stat origin/main...codex/kernel-adjudications` → 7 files, 64 insertions, 19 deletions
Production-Delta: +12/-14
- Private evidence path: task package `task_ad7f05175502513cd3bb9e537c` + report in milestone artifacts
- Reviewer evidence path: same
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] Admission equivalence: live and retired targets behave identically before/after (new test file, red-green both directions).
- [x] All four DDD gates run individually: exit 0 (direction gate now counts the 4 supports edges as legal; vocabulary gate green on renamed register).
- [x] `npm run check:local` green (41 steps); `node --test packages/cli/test/daemon-autostart-cli.test.ts packages/application/test/execution-saga-v1.test.ts` 5/5; `npx tsc -b` exit 0.
- [ ] GitHub Actions `rewrite-ci` passed — pending on this PR

## Review Evidence

- CEO review: checkpoint on blocks adjudicated with enumeration evidence (zero backlog); supports direction read against the 4 real edges; the tools/ test edit inspected — vocabulary-follow only.
- Implemented by a delegated worker (`gpt-5.6-sol`).
- Human review: pending
- Blocking findings: none

## Residual Risk

- Renamed Recovery words are package-public API (`RecoveryBatch`); any external consumer of the old words (none found by full grep) would break loudly at compile.

---

# 中文

## 摘要

晨会裁决(dec_566B561008877A3E1C1369705F)的三件 kernel 侧:

1. **CH4**——`supports`(decision→decision)登记进 relation-direction 注册表并钉死规范方向;存量 4 条 active 边由 ratchet 容忍转合法。`blocks` 按 checkpoint 裁定**不登记**:实测存量为**零**(骨架提及溯源到未进 canonical 投影的 legacy fenced 文本——属 CH5 辖区);零使用的类型登记是投机性词汇。CH5 恢复线若日后浮出真实 blocks 边,按实际端点语义再登记。
2. **CH3(可执行组)**——`Recovery.deferred → exhausted`、`Recovery.done → drained`:唯一零存储面改名组(runtime-only)。词汇 register 同步,两行 divergent 消除。
3. **CH8(kernel 侧)**——`fact-event-projection.ts` 的 Fact 写入 admission 用裸 SQL `EXISTS` 判「目标已 retired」,绕过单一判定 `factLiveness`;现经命名 domain 判定,行为等价双向测试(live/retired 目标,改前改后)。

## 变更内容

- `domain/relation-direction.ts`——supports 登记,方向钉死。
- `domain/status-vocabulary.ts`——Recovery 词改名;divergent 行收敛。
- `domain/write-chain.contract.ts` + `projection/fact-event-projection.ts`——admission 走 `factLiveness`;改名词贯通。
- `tools/gates/test/write-chain-contract.test.mjs`——门的**测试**随词改名同步(未动任何门脚本/manifest/门语义;因在 `tools/` 下特此透明申报)。
- 新增 `fact-admission-liveness.test.ts`——admission 路径红绿等价。

## 任务与范围

- Harness 任务:`task_ad7f05175502513cd3bb9e537c`(derives 自 dec_566B561008877A3E1C1369705F CH4)
- 分支:`codex/kernel-adjudications`
- 公开范围:7 文件,+64/−19(生产 **+12/−14,净 −2**)。
- 范围外:5 组存储面改名(设计线在飞,数据未动);blocks 登记(缓,零存量)。

## 版本影响

- 版本:无变更。
- 发布影响:不发布

## 治理声明

- 触碰受保护面:未动任何门脚本/manifest/workflow;`tools/gates/test/` 下**一个测试文件**仅随裁决改名同步(执法语义零变化;词汇门在新 register 上自证绿)。
- 受保护面范围:如上申报。
- 授权来源:dec_566B561008877A3E1C1369705F CH3/CH4/CH8(泽宇 2026-08-18 晨裁);blocks 的 checkpoint 裁定记录于任务包。
- 机器检查边界:本 PR 仅断言声明存在;是否真实充分由评审判断。
- Break-glass:否
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无

## 验证

- Base `origin/main` SHA:8e6b05f8bbd72af45d58bb0c8bb880e6c6c45399
- 同步方式:rebase;merge-base 等于 origin/main
- 公开 diff 命令:`git diff --stat origin/main...codex/kernel-adjudications` → 7 files, 64 insertions, 19 deletions
- 私有证据路径:任务包 `task_ad7f05175502513cd3bb9e537c` + milestone artifacts 报告
- 评审证据路径:同上
- GitHub Actions `rewrite-ci` run URL:本 PR 上待跑
- [x] admission 等价:live/retired 目标改前改后行为一致(新测试文件,双向红绿)。
- [x] 四个 DDD 门单跑全 exit 0(方向门现认 4 条 supports 边合法;词汇门在改名 register 上绿)。
- [x] `check:local` 绿(41 步);autostart+saga 5/5;`tsc -b` 0。
- [ ] GitHub Actions `rewrite-ci` 通过——本 PR 上待跑

## 评审证据

- CEO 评审:blocks checkpoint 以枚举证据裁定(零存量);supports 方向对照 4 条真实边;tools/ 测试改动逐行看过——仅随词跟改。
- 由受托 worker(`gpt-5.6-sol`)实现。
- 人工评审:待定
- 阻塞性发现:无

## 残余风险

- Recovery 改名词是包内公开 API(`RecoveryBatch`);外部旧词消费者(全仓 grep 未见)会在编译期响亮地断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
