### PR TITLE
fix(daemon): let ha migrate ledger run through the data-shape latch

### DIFF
--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -91,9 +91,12 @@ export async function openRepoCell(input: { readonly repoId: WorkspaceId; readon
   const catalog = openGuiCatalog({ repoId: input.repoId, rootDir, now }), terminal = openTerminalHost({ repoId: input.repoId, rootDir, daemonGeneration: generation, now });
   const run = (action: RepoTaskAction, binding: RepoCellBinding): Promise<WriteReceipt> => {
     if (state !== "attached") attemptRecovery();
-    if (state !== "attached") return Promise.resolve(rejected(operationId(action, binding, input.repoId, 0), "repo_unavailable", latched()));
+    // ledger-migrate is the repair the data-shape latch message routes the operator to; gating it
+    // behind the attach it exists to restore would deadlock the ledger, so it runs through the latch.
+    const repairsLatch = state !== "attached" && action.kind === "ledger-migrate" && causeClass === "data-shape";
+    if (state !== "attached" && !repairsLatch) return Promise.resolve(rejected(operationId(action, binding, input.repoId, 0), "repo_unavailable", latched()));
     queueDepth += 1;
-    const pending = tail.then(async () => { queueDepth -= 1; assertCurrentWriter(activeWriter, writerToken, input.repoId); return withLayoutAdvisory(withHumanSummary(await executeAction(action, binding))); });
+    const pending = tail.then(async () => { queueDepth -= 1; assertCurrentWriter(activeWriter, writerToken, input.repoId); const receipt = withLayoutAdvisory(withHumanSummary(await executeAction(action, binding))); if (repairsLatch && receipt.outcome === "applied") { state = "attached"; lastError = null; causeClass = null; } return receipt; });
     tail = pending.then(() => undefined, () => undefined); void pending.then(() => replica.kick(), () => replica.kick()); const result = pending.catch((error) => { if (fatalCellError(error)) latchWith(error);
       return failed(errorOperationId(error) ?? operationId(action, binding, input.repoId, 0), error); });
     return result;

--- a/packages/daemon/test/ledger-layout-consistency.test.ts
+++ b/packages/daemon/test/ledger-layout-consistency.test.ts
@@ -58,6 +58,26 @@ test("a mixed ledger is repaired by ha migrate ledger, replays idempotently, and
   } finally { await cell?.close(); rmSync(rootDir, { recursive: true, force: true }); }
 });
 
+test("ha migrate ledger runs through a data-shape latch instead of being rejected by it", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-ledger-latched-migrate-")); let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    const flatEvents = [flatTaskEvent(1, "task_latched_one")], shardedEvent = flatTaskEvent(2, "task_latched_two");
+    initMixedLedger(rootDir, flatEvents, shardedEvent);
+    cell = await openRepoCell({ repoId: workspaceId("ledger-latched-migrate"), rootDir: canonicalRoot(rootDir), ownerId: "ledger-latched-migrate", now: () => "2026-08-18T00:00:01.000Z" });
+    // A read latches the cell on the mixed layout first — the shape the CLI hits in the field,
+    // where the latch message itself routes the operator to ha migrate ledger.
+    const latchedTaskList = await cell.run({ kind: "task-list" }, { actor, source: "local" });
+    assert.equal(latchedTaskList.outcome, "rejected");
+    assert.equal(cell.status().state, "unavailable"); assert.equal(cell.status().causeClass, "data-shape");
+    const migrated = await cell.run({ kind: "ledger-migrate" }, { actor, source: "local" }) as Record<string, unknown>;
+    assert.equal(migrated.outcome, "applied", JSON.stringify(migrated));
+    assert.equal(cell.status().state, "attached"); assert.equal(cell.status().lastError, null);
+    const listed = await cell.run({ kind: "task-list" }, { actor, source: "local" });
+    assert.equal(listed.outcome, "applied", JSON.stringify(listed));
+    assert.match(String(listed.evidence), /task_latched_two/u);
+  } finally { await cell?.close(); rmSync(rootDir, { recursive: true, force: true }); }
+});
+
 function flatTaskEvent(revision: number, taskId: string): TaskEventV1 {
   const opId = `op_flat_${String(revision).padStart(5, "0")}`;
   return { schema: "task-event/v1", eventId: `event-flat-${revision}`, workspaceRevision: revision, opId, taskId, type: "task_created", actor, source: "local", occurredAt: "2026-08-18T00:00:00.000Z", payload: { task: { schema: "task/v1", taskId, title: `Flat task ${revision}`, taskClass: "standard", status: "planned", graph: REPLAY_TASK_GRAPH, currentNode: "implementation", iteration: 0, createdBy: actor, completionGateIds: [], presetSnapshotDigest: null } } } as TaskEventV1;


### PR DESCRIPTION
# English

## Summary

Field-discovered deadlock during the kty-web ledger rescue: a mixed-layout ledger latches the RepoCell as `data-shape`, the latch message tells the operator to run `ha migrate ledger` — and the `run()` attach gate rejects that very migrate action with the same latch. The repair command was gated behind the door it exists to repair.

`ledger-migrate` now runs through a data-shape latch and clears it once the migration receipt is `applied`; infrastructure latches (broken Git/lock) still reject it. #1517's mixed-ledger test only covered the shape where migrate is the *first* command on a fresh cell; this adds the field shape — latched by a read first, then migrated.

## Verification

- New test: mixed ledger → `task-list` latches (`data-shape`) → `ledger-migrate` applied → latch cleared → next `task-list` applied. Suites `ledger-layout-consistency` + `repo-cell-latch-recovery`: 6/6 green.
- Red-end executed: with the run-gate change stashed, the new test fails (1 fail).
- `npx tsc -b` clean; `npm run check:local` green.

## Residual Risk

- None beyond scope: the bypass admits exactly one action kind under exactly one cause class.

## Governance Declaration

Production-Delta: +5/-2

Derived from task_3084f542e54bb6f94068b537b9 (migrate-through-latch), same defect family as task_a1c3ba170740983e0767172fca / PR #1517 (kty-web D1–D3). No CI/gate configuration touched.

---

# 中文

## 摘要

kty-web 账本救援实跑中发现的死锁:mixed 布局账本把 RepoCell latch 成 `data-shape`,latch 报错文案让操作者去跑 `ha migrate ledger`——而 `run()` 的 attach 门用同一个 latch 把这条 migrate 命令拒收。修复命令被它要修的门拦死。

现在 `ledger-migrate` 可穿过 data-shape latch 执行,迁移回执 `applied` 后当场清除 latch;infrastructure 类 latch(Git/锁损坏)仍拒收。#1517 的 mixed 测试只覆盖了「migrate 是新 cell 第一条命令」的形状;本 PR 补上现场形状——先被读 latch,再迁移。

## 验证

- 新测试:mixed 账本 → `task-list` latch(`data-shape`)→ `ledger-migrate` applied → latch 清除 → 后续 `task-list` applied。`ledger-layout-consistency` + `repo-cell-latch-recovery` 套件 6/6 绿。
- 红端已执行:stash 掉 run 门改动,新测试变红(fail 1)。
- `npx tsc -b` 干净;`npm run check:local` 绿。

## 残余风险

- 放行面精确到一种 action kind × 一种 cause class,无额外暴露。

## 治理声明

派生自 task_3084f542e54bb6f94068b537b9(migrate-through-latch),与 task_a1c3ba170740983e0767172fca / PR #1517(kty-web D1–D3)同缺陷族。未触碰 CI/gate 配置。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
