### PR TITLE
fix(preset): reorder create-milestone workflow so evidenced claims keep an evidence chain

### DIFF
--- a/packages/preset/assets/software-coding/presets/create-milestone/PRESET.md
+++ b/packages/preset/assets/software-coding/presets/create-milestone/PRESET.md
@@ -9,13 +9,14 @@ Create the milestone with normal agent tools and the repository's governed write
 
 ## Workflow
 
-1. Confirm an accepted charter decision, a stable milestone line and slug, a concise mission, and the first user or system that benefits.
-2. Create the root task with this preset using `ha task create --task-class milestone` and keep the returned task id as the durable anchor.
-3. Read `harness.yaml`, repository instructions, this preset policy, and nearby milestone examples; write only beneath the configured milestones root.
-4. Create the milestone overview, index, machine-readable summary, and human-readable status view in the established repository format.
-5. Record the mission, waves, dependencies, entry conditions, switch evidence, retirement evidence, and closeout criteria.
-6. Create child tasks and real dependency relations through governed write roads.
-7. Validate links, duplicate rows, required sections, status agreement, and rendered output.
+1. Propose the charter decision (`ha decision propose`) with a stable milestone line and slug, a concise mission, and the first user or system that benefits. Leave it `proposed`; do not accept it yet.
+2. Create the root task with this preset using `ha task create --task-class milestone` and keep the returned task id as the durable anchor. Root task creation does not require an accepted charter.
+3. Anchor the charter's load-bearing claims to evidence, then transition it to `in_effect`. Record observations as Facts on the root task and relate each claim with `evidenced-by`; a Task target is also accepted by the evidence floor. Reserve `--judgment-only` for claims that genuinely rest on judgement rather than observation — accepting an `evidenced` claim through it leaves the evidence chain empty.
+4. Read `harness.yaml`, repository instructions, this preset policy, and nearby milestone examples; write only beneath the configured milestones root.
+5. Create the milestone overview, index, machine-readable summary, and human-readable status view in the established repository format.
+6. Record the mission, waves, dependencies, entry conditions, switch evidence, retirement evidence, and closeout criteria.
+7. Create child tasks and real dependency relations through governed write roads.
+8. Validate links, duplicate rows, required sections, status agreement, and rendered output.
 
 ## Done when
 


### PR DESCRIPTION
# English

## Summary

The `create-milestone` preset workflow tells authors to confirm an accepted charter decision before creating the root task. Nothing enforces that, and following it literally makes the charter impossible to accept on evidence — so authors fall through to `--judgment-only` and every `evidenced` claim ends up with an empty evidence chain. This reorders the workflow so the evidence path is the one that actually works.

## What Changed

- Reordered the `create-milestone` PRESET.md workflow: propose the charter (leave it `proposed`) -> create the root task -> anchor claims to evidence -> transition to `in_effect`.
- Recorded that root task creation does not require an accepted charter (`policy.json` requires two capabilities; `ha task create` performs no decision check).
- Recorded that the decision evidence floor accepts a `task/<id>` target, not only `fact/<task>/F-XXXXXXXX`.
- Stated that `--judgment-only` is for claims genuinely resting on judgement, and that using it for an `evidenced` claim leaves the evidence chain empty.

## Task And Scope

- Harness task: `task_e3db63358933b1e4dfac5b24f3`
- Branch: `codex/preset-milestone-order`
- Public scope: `packages/preset/assets/software-coding/presets/create-milestone/PRESET.md` only
- Private planning/evidence updated: yes
- Out of scope: no code path, schema, policy, or checker change; the evidence floor implementation is unchanged and only documented.

## Version Impact

- Version: no version change because this is preset guidance prose with no manifest, schema, or policy change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: discovered while creating milestone charter `dec_EBCF5AB34CE5ECB95000FC244D`; no ADR or decision is amended by this PR.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

Production-Delta: +0/-0

- Base `origin/main` SHA: `445e8d388126a05ab9aa4e6a4b82a5772d965692`
- Branch merge-base with `origin/main`: `445e8d388126a05ab9aa4e6a4b82a5772d965692`
- Last `git fetch origin` time: 2026-08-18, immediately before creating the worktree
- Sync method: none needed (merge-base equals `origin/main` head)
- Public diff command: `git diff --stat origin/main...HEAD`
- Private evidence commit/path: `harness/tasks/task_e3db63358933b1e4dfac5b24f3-create-milestone-preset-md-charter-judgment-only-evidenced-claim/`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending, to be filled once the run reports
- [x] `git diff --check` — clean
- [x] `npm run check:local` — passed, fast tier, 48.3s
- [ ] `npm ci` — not run locally; the worktree seeded `node_modules` by APFS clone from the canonical tree
- [ ] `npm run check` — not run separately; covered by `check:local`
- [ ] `npm run typecheck` — not run separately; covered by `check:local`
- [ ] `npm test` — not run; this change touches no executable code
- [ ] `npm run harness:check-import-boundaries` — not run separately; covered by `check:local`
- [ ] `npm run harness:scan-forbidden-symbols` — not run separately; covered by `check:local`
- [ ] `npm run harness:check-private-boundary` — not run separately; covered by `check:local`
- [ ] `npm run harness:check-package-policy` — not run separately; covered by `check:local`
- [ ] `npm run harness:check-implementation-contracts` — not run separately; covered by `check:local`
- [ ] `npm run harness:check-schema-contracts` — not run separately; covered by `check:local`
- [ ] `npm run harness:check-legacy-intake-readiness` — not run separately; covered by `check:local`
- [ ] `npm run harness:smoke-cli-package` — not run separately; covered by `check:local`
- [ ] GitHub Actions `rewrite-ci` passed — pending

Note on the unchecked boxes: the repository stop condition is `npm run check:local`, which ran green. The individual commands above were not invoked separately, and `check:local`'s fast tier does not run `test:integration` or `test:gui`. Cloud CI remains the complete authority.

## Review Evidence

The defect was found by executing this workflow literally while creating a real milestone charter. Step 1 asks for an accepted charter; accepting it requires a claim-to-evidence relation; evidence requires a Fact; `ha fact record` requires `--task`; the root task is only created at step 2. The author is therefore pushed into `--judgment-only`, which is exactly what happened before the order was corrected.

Two facts were verified directly against the code rather than assumed:
- `packages/cli/dist/preset/assets/software-coding/presets/create-milestone/policy.json` requires only two capabilities and never references a charter.
- `assertDecisionEvidenceFloor` in `packages/kernel/src/domain/fact-event.ts` accepts `fact/<task>/F-XXXXXXXX`, `task/<id>`, or `decision/dec_.../...` as an evidence target.

## Residual Risk

Prose-only change, so no runtime behaviour moves. The residual risk is that authors who already internalised the old order keep reaching for `--judgment-only` out of habit; the added sentence about empty evidence chains is the only mitigation here, and existing charters accepted that way are not retroactively repaired by this PR.

## References

- Charter decision that exposed the defect: `dec_EBCF5AB34CE5ECB95000FC244D`
- Evidence floor implementation: `packages/kernel/src/domain/fact-event.ts`

---

# 中文

## 摘要

`create-milestone` preset 的 workflow 要求先确认「已接受的 charter decision」再创建 root task。实际上没有任何机制强制这一点,而照字面顺序执行会让 charter 无法凭证据被接受——作者只能退到 `--judgment-only`,于是每条 `evidenced` claim 的证据链都是空的。本 PR 调整顺序,让走得通的那条证据路径成为默认路径。

## 变更内容

- 调整 `create-milestone` PRESET.md 的 workflow 顺序:先 propose charter(保持 `proposed`)→ 创建 root task → 将 claim 锚到证据 → 再 transition 到 `in_effect`。
- 写明创建 root task 不需要已接受的 charter(`policy.json` 只 require 两个 capability,`ha task create` 不做 decision 校验)。
- 写明 decision 的证据门接受 `task/<id>` 作为 target,不只接受 `fact/<task>/F-XXXXXXXX`。
- 写明 `--judgment-only` 适用于真正基于判断的 claim;用它接受 `evidenced` claim 会留下空的证据链。

## 任务与范围

- Harness 任务:`task_e3db63358933b1e4dfac5b24f3`
- 分支:`codex/preset-milestone-order`
- 公开范围:仅 `packages/preset/assets/software-coding/presets/create-milestone/PRESET.md`
- 私有规划/证据已更新:是
- 不在范围内:不改任何代码路径、schema、policy 或 checker;证据门的实现未变,只是被写进文档。

## 版本影响

- 版本:无变更,因为这是 preset 指导性文字,不涉及 manifest、schema 或 policy。
- 发布影响:不发布

## 治理声明

- 触碰受保护面:否
- 受保护面范围:不适用
- 授权:在创建 milestone charter `dec_EBCF5AB34CE5ECB95000FC244D` 时发现;本 PR 不修订任何 ADR 或 decision。
- 机器校验边界:本 PR 只声明该声明存在;其是否为真、是否充分由评审者判断。
- Break-glass:否
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- Base `origin/main` SHA:`445e8d388126a05ab9aa4e6a4b82a5772d965692`
- 分支与 `origin/main` 的 merge-base:`445e8d388126a05ab9aa4e6a4b82a5772d965692`
- 最近一次 `git fetch origin` 时间:2026-08-18,创建 worktree 前
- 同步方式:无需同步(merge-base 等于 `origin/main` 头)
- 公开 diff 命令:`git diff --stat origin/main...HEAD`
- 私有证据 commit/路径:`harness/tasks/task_e3db63358933b1e4dfac5b24f3-create-milestone-preset-md-charter-judgment-only-evidenced-claim/`
- 评审证据路径:同上任务包
- GitHub Actions `rewrite-ci` run URL:待 run 报告后回填
- [x] `git diff --check` — 干净
- [x] `npm run check:local` — 通过,fast tier,48.3s
- [ ] 其余模板单项命令未单独执行:本仓停止点是 `npm run check:local`,已全绿;其 fast tier 不跑 `test:integration` 与 `test:gui`,GitHub CI 为完整权威。本改动不触及可执行代码,故未跑 `npm test`。

## 评审证据

该缺陷是在真实创建 milestone charter 时照字面执行本 workflow 发现的:第 1 步要求 charter 已接受;接受需要 claim-to-evidence 关系;证据需要 Fact;`ha fact record` 必须带 `--task`;而 root task 要到第 2 步才创建。作者因此被推向 `--judgment-only`——顺序修正之前正是这样发生的。

两条事实经代码直接核实,未凭推断:
- `policy.json` 只 require 两个 capability,全文不提 charter。
- `packages/kernel/src/domain/fact-event.ts` 的 `assertDecisionEvidenceFloor` 接受 `fact/<task>/F-XXXXXXXX`、`task/<id>`、`decision/dec_.../...` 三类证据 target。

## 残留风险

纯文字改动,运行时行为不变。残留风险是已经习惯旧顺序的作者仍会惯性伸手去拿 `--judgment-only`;本 PR 的唯一缓解手段就是那句关于空证据链的说明。已经用该方式接受的既有 charter 不会被本 PR 追溯修复。

## 参考

- 暴露该缺陷的 charter decision:`dec_EBCF5AB34CE5ECB95000FC244D`
- 证据门实现:`packages/kernel/src/domain/fact-event.ts`
