### PR TITLE
feat(tools): PLT-Center Docker testbed — center/edge full stack with GitLab-backed test project

### DIFF
--- a/tools/center-testbed/Dockerfile
+++ b/tools/center-testbed/Dockerfile
@@ -1,0 +1,33 @@
+# PLT-Center full-stack testbed image: harness-anything source + built CLI +
+# the testbed scripts. Mirrors the coldstart benchmark image recipe
+# (context/benchmark/coldstart/Dockerfile): node:24-bookworm-slim, full npm ci,
+# `npm run build -w @harness-anything/cli`. Credentials are never baked in —
+# the GitLab token arrives as runtime env, fleet TLS material is minted by the
+# seed bootstrap into a shared volume.
+
+FROM node:24-bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential ca-certificates git openssl procps python3 \
+    && rm -rf /var/lib/apt/lists/* \
+    && git config --system init.defaultBranch main \
+    && git config --system safe.directory /opt/harness-anything
+
+WORKDIR /opt/harness-anything
+
+COPY package.json package-lock.json tsconfig.json ./
+COPY packages/ packages/
+
+# electron is a GUI devDependency; the testbed never launches it, so the
+# ~100MB binary download is skipped while the package itself still installs.
+RUN ELECTRON_SKIP_BINARY_DOWNLOAD=1 npm ci --no-audit --no-fund \
+    && npm run build -w @harness-anything/cli
+
+COPY tools/center-testbed/ /opt/testbed/
+
+# `ha` prefers the built dist and falls back to source for source-tree images.
+RUN printf '#!/bin/sh\nif [ -f /opt/harness-anything/packages/cli/dist/cli/src/index.js ]; then\n  exec node /opt/harness-anything/packages/cli/dist/cli/src/index.js "$@"\nelse\n  exec node /opt/harness-anything/packages/cli/src/index.ts "$@"\nfi\n' > /usr/local/bin/ha \
+    && chmod +x /usr/local/bin/ha \
+    && ha --version
+
+WORKDIR /data

--- a/tools/center-testbed/Dockerfile.dockerignore
+++ b/tools/center-testbed/Dockerfile.dockerignore
@@ -1,0 +1,18 @@
+# Per-Dockerfile ignore (BuildKit picks <Dockerfile>.dockerignore when it sits
+# next to the Dockerfile inside the context). Patterns are relative to the
+# build context (the repo root). Keeps installed dependencies, private ledger
+# state, and build outputs out of the image so `docker compose build` always
+# compiles from source.
+node_modules
+**/node_modules
+.git
+.harness
+.harness-private
+harness
+.worktrees
+coverage
+tmp
+packages/*/dist
+packages/adapters/*/dist
+packages/gui/.runtime-cache
+packages/gui/build-resources

--- a/tools/center-testbed/README.md
+++ b/tools/center-testbed/README.md
@@ -1,0 +1,128 @@
+# PLT-Center Docker 全栈测试台
+
+为 PLT-Center M1-E/M2 验证搭的可一键起停的 Docker 台子：一个中心权威 daemon + 多个
+edge 只读节点 + 一个 harness 化测试项目 + 腾讯 GitLab 中心仓对接。**本台子只搭台，
+不实现 M2 写回/lease/同步业务功能**——那些功能测试在后续任务里跑在这个台上。
+
+拓扑（对照 `harness/tasks/task_856697c1a1b98d751bbe09034f-plt-center` design-v2 的 M1-E/M2 节）：
+
+```text
+                 ┌────────────────────────────┐
+                 │ GitLab 43.142.81.196:8929  │   canonical ledger（harness/ 授权台账，
+                 │ root/plt-center-testbed    │   refs/heads/main + refs/ha/canonical）
+                 └──────┬─────────────▲───────┘
+             clone (拉) │             │ push (推, seed bootstrap)
+                        │             │
+ ┌──────────────────┐   │   ┌─────────┴──────────────────────────────┐
+ │ seed (一次性)     │───┘   │ center 容器                             │
+ │ ha init 测试项目  │──────▶│ ha daemon serve（本容器 socket 命名空间）│
+ │ task/decision/   │       │ repo register + 冷投影重建               │
+ │ fact/progress 写入│      │ ha daemon fleet center start (TLS :7443) │
+ └──────────────────┘       └───────────────┬─────────────────────────┘
+                                            │ fleet TLS（snapshot/delta + ACK）
+                              ┌─────────────┴─────────────┐
+                              ▼                           ▼
+                     ┌────────────────┐          ┌────────────────┐
+                     │ edge-1 容器     │          │ edge-2 容器     │
+                     │ ha daemon serve │          │ ha daemon serve │
+                     │ fleet edge sync │          │ fleet edge sync │
+                     │ → /data/view    │          │ → /data/view    │
+                     │ 只读 replica 视图│          │ 只读 replica 视图│
+                     └────────────────┘          └────────────────┘
+```
+
+角色说明：
+
+| 容器 | 角色 | 关键内容 |
+| --- | --- | --- |
+| `seed`（跑完即退） | 测试项目工厂 | `ha init` 全新 harness 化小项目；写入真实 task、execution、decision、fact、progress；经 GitLab API 建仓并推 canonical ledger；生成 fleet TLS 证书 + roster（edge 节点凭证与 assignment）写入共享卷 |
+| `center` | 中心权威 daemon | 从 GitLab clone canonical ledger → `daemon repo register` → 冷投影重建 → `daemon fleet center start`（bind 0.0.0.0:7443）。ready 后落 `/data/center-ready` 标记翻转 healthcheck |
+| `edge-1` / `edge-2` | collaborator 只读节点 | 各自容器内 daemon（socket 命名空间互相隔离）；冒烟时经 `daemon fleet edge sync` 拉取中心投影到 `/data/view`，二次 sync 应答 `current`（零传输） |
+
+语义对齐：center/edge 是同一个 daemon 二进制对不同 repo 的 **mode**，不是不同程序；
+`remote-center` 写仲裁、A/B 同步、lease 等 M2 语义不在本台实现范围。
+
+## 一键命令
+
+```bash
+export GITLAB_TOKEN=$(cat ~/.harness-secrets-center-testbed-token)
+
+cd tools/center-testbed
+docker compose build            # 首次构建（npm ci + CLI build，几分钟）
+docker compose up -d --wait     # seed 跑完 → center healthy → edges 起来
+bash smoke-read.sh              # 读链路冒烟（edge 拉取 + GitLab 可见性 + 日志）
+```
+
+`docker compose down` 停止；`docker compose down -v` 连卷一起清（彻底重置）。
+
+冒烟通过标准：
+
+1. 两个 edge 各自打印 `SMOKE PASS: edge-N reads the center ledger projection through fleet TLS`；
+2. edge 视图里能读到 seed 写入的 task/decision/fact 文档内容（逐字断言）；
+3. 第二次 sync 返回 `fleet.replica.current/v1`（幂等，无传输）；
+4. GitLab 上 `root/plt-center-testbed` 可见，`main` HEAD 与 seed 推送的 canonical 一致。
+
+## 凭证与安全边界
+
+- `GITLAB_TOKEN` 只经环境变量注入 seed/center 两个服务；不进镜像层、不进 compose 文件、不进任何被 git 跟踪的文件。git 推拉用一次性 credential helper（`git -c credential.helper=...`），token 不落任何 `.git/config`。
+- fleet TLS 证书/私钥与 edge 机器凭证由 seed bootstrap 在运行时生成，落在 `testbed-shared` 卷里，同样不进 git。
+- 每个容器的 daemon socket 在容器自己的 tmp 命名空间（`/tmp/harness-anything/…`），与宿主机生产 daemon、本仓 `.harness/` 完全隔离；宿主机不跑任何测试用 daemon。
+- seed 复用 GitLab 上同名测试项目（不存在则经 API 创建；若路径被删除计划中的 tombstone 占用则先 restore 回收路径），复跑时对 `main` 与 `refs/ha/canonical` 做 force-push 覆盖；不要把真实项目放在 `root/plt-center-testbed` 路径下。
+
+## 如何把新构建的 dist 滚进容器重测
+
+完整重建（干净、可复现）：
+
+```bash
+npm run build -w @harness-anything/cli     # 或改完源码直接重建镜像（COPY 的是源码，镜像内自会 build）
+cd tools/center-testbed
+docker compose build center edge-1 edge-2
+docker compose up -d --force-recreate --wait
+bash smoke-read.sh
+```
+
+快速热替换（不动镜像，仅验证 dist 改动）：
+
+```bash
+npm run build -w @harness-anything/cli
+docker compose cp ../../packages/cli/dist center:/opt/harness-anything/packages/cli/dist
+docker compose cp ../../packages/cli/dist edge-1:/opt/harness-anything/packages/cli/dist
+docker compose cp ../../packages/cli/dist edge-2:/opt/harness-anything/packages/cli/dist
+docker compose up -d --force-recreate --wait
+bash smoke-read.sh
+```
+
+注意：center/edge 每次启动都清掉自己的 daemon-user 与工作区（确定性冷启动），所以
+restart 即等价于换 dist 后的全新一轮；edge 的 `/data/view` 跨 restart 保留，用于观察
+delta/current 路径。
+
+## 手动探针（可选）
+
+中心侧经 daemon 写一条 progress 并推回 GitLab，再让 edge sync 观察 delta（本台验收
+之外的能力自证，M2 写回测试将在这个原语上展开）：
+
+```bash
+docker compose exec center ha --root /data/workspace --json task progress append <task-id> --text "center-side probe"
+docker compose exec center sh -c 'git -C /data/workspace/harness -c "credential.helper=!f() { echo username=oauth2; echo password=$GITLAB_TOKEN; }; f" push origin refs/heads/main:refs/heads/main refs/ha/canonical:refs/ha/canonical'
+docker compose exec edge-1 ha --json daemon fleet edge sync --host center --port 7443 --ca /data/shared/fleet/fleet.crt --node-id edge-1 --credential edge-1-machine-secret --assignment assignment-edge-1 --view-root /data/view --quota-bytes 268435456
+```
+
+（task-id 等参数见共享卷里的 `/data/shared/testbed-state.json`。）
+
+## 文件
+
+| 文件 | 作用 |
+| --- | --- |
+| `Dockerfile` / `Dockerfile.dockerignore` | 基础镜像（node:24-bookworm-slim + 本仓源码 npm ci + CLI build，复用 coldstart 镜像配方） |
+| `docker-compose.yml` | seed → center(healthcheck) → edge-1/edge-2 拓扑与卷/网络 |
+| `bootstrap.mjs` | seed 入口：建项目、写台账、建/推 GitLab、铸 TLS+roster |
+| `entrypoint-center.mjs` | center 入口：clone、register、冷重建、fleet center start |
+| `entrypoint-edge.mjs` | edge 入口：常驻 daemon |
+| `smoke-edge.mjs` / `smoke-read.sh` | 容器内单边冒烟 / 宿主机一键冒烟 |
+| `lib/testbed.mjs` | 容器内共享 helper（ha 调用、receipt 解包、daemon 生命周期） |
+
+## 已知边界
+
+- 写回链路（edge → center → GitLab）是 M2 的面，本台只保证读链路与 GitLab 推/拉原语可用。
+- center 冷启动会做投影重建（分钟级属正常）；healthcheck 预算 10 分钟。
+- GitLab 侧只做建仓/删仓/推拉，不做任何服务器级配置变更。

--- a/tools/center-testbed/bootstrap.mjs
+++ b/tools/center-testbed/bootstrap.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+// Seed-container entrypoint: create the harness-ized test project, write real
+// ledger content (task, decision, fact, progress), push the canonical ledger to
+// GitLab, and mint the fleet TLS material + roster shared with center/edges.
+// The GitLab token arrives as GITLAB_TOKEN env only; it never lands in a file
+// tracked by this repo or in an image layer.
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { TESTBED, fail, fleetEnv, gitCredentialArgs, ha, harnessEnv, log, mustRun, startDaemon } from "./lib/testbed.mjs";
+
+const workspace = "/data/workspace";
+const userRoot = "/data/daemon-user";
+const sharedFleet = path.join(TESTBED.sharedRoot, "fleet");
+const edges = ["edge-1", "edge-2"];
+const taskTitle = "Prove the center ledger read chain";
+
+await main();
+
+async function main() {
+  const token = process.env.GITLAB_TOKEN;
+  if (!token) fail("env", "GITLAB_TOKEN is required (export GITLAB_TOKEN=$(cat ~/.harness-secrets-center-testbed-token)).");
+  resetState();
+  const daemon = startDaemon("seed", userRoot, "seed");
+  const seed = seedLedger();
+  const project = await ensureGitLabProject(token);
+  pushLedgerToGitLab(project, token);
+  const fleet = mintFleetMaterial(seed);
+  writeStateFile(seed, project, fleet);
+  log("seed", `bootstrap complete; shared state at ${TESTBED.stateFile}`);
+  await new Promise((resolve) => {
+    const timer = setTimeout(resolve, 10_000);
+    daemon.once("exit", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    daemon.kill("SIGTERM");
+  });
+}
+
+function resetState() {
+  // The workspace is a compose volume mount, so its contents are wiped
+  // entry-by-entry rather than removing the mountpoint itself. The shared
+  // volume is NOT wiped: center/edge containers may be reading it while a
+  // reseed runs, so every shared file is replaced atomically below instead.
+  if (existsSync(workspace)) for (const entry of readdirSync(workspace)) rmSync(path.join(workspace, entry), { recursive: true, force: true });
+  mkdirSync(workspace, { recursive: true });
+  rmSync(userRoot, { recursive: true, force: true });
+}
+
+function seedLedger() {
+  const env = fleetEnv(userRoot, "seed");
+  const root = ["--root", workspace];
+  const init = ha("init", env, [...root, "init", "--repo-id", TESTBED.repoId, "--person-id", TESTBED.personId, "--display-name", "PLT Center Testbed Owner", "--name", "plt-center-testbed"]);
+  log("init", `harness initialized, commit ${init.commit}`);
+
+  const task = ha("task-create", env, [...root, "task", "create", "--title", taskTitle, "--preset", "standard-task"]);
+  log("task-create", `task ${task.taskId} created (${task.packagePath})`);
+  const executionId = "exe-testbed-center-1";
+  ha("task-start", env, [...root, "task", "start", task.taskId, "--execution-id", executionId]);
+  log("task-start", `execution ${executionId} started`);
+
+  const packet = JSON.stringify({
+    title: "Testbed ledger authority sits on the center daemon",
+    question: "Where does the PLT-Center testbed ledger authority live?",
+    riskTier: "medium", urgency: "medium", vertical: "default", preset: "default", decisionClass: "ordinary",
+    appliesTo: { modules: [], productLines: [] },
+    chosen: [{ id: "CH1", text: "The center daemon is the single writer; edges consume replica cuts." }],
+    rejected: [{ id: "RJ1", text: "Edges write directly to the GitLab remote", whyNot: "M2 forbids edge direct writes to the canonical ledger." }],
+    claims: [], fulfillments: [], relations: []
+  });
+  const body = "# Testbed decision\n\nThe center daemon owns the canonical ledger. Edge nodes read replica cuts over fleet TLS and must not write the canonical ledger directly.";
+  const decision = ha("decision-propose", env, [...root, "decision", "propose", "--json-input", packet, "--body", body]);
+  log("decision-propose", `decision written at ${decision.path}`);
+
+  ha("fact-record", env, [...root, "fact", "record", "--task", task.taskId, "--statement", "The testbed bootstrap wrote a task, a decision, and a fact into the canonical center ledger before pushing it to GitLab.", "--source", "tools/center-testbed/bootstrap.mjs", "--confidence", "high"]);
+  ha("progress-append", env, [...root, "task", "progress", "append", task.taskId, "--text", "Seed bootstrap finished: ledger content ready for the center daemon to attach and republish."]);
+  log("writes", "task, execution, decision, fact, and progress entries committed to the ledger");
+
+  mustRun("wrapper", "git", ["-C", workspace, "add", "-A"], { env: harnessEnv() });
+  mustRun("wrapper", "git", ["-C", workspace, "-c", `user.name=${TESTBED.gitAuthor.name}`, "-c", `user.email=${TESTBED.gitAuthor.email}`, "commit", "-q", "-m", "Testbed project wrapper"], { env: harnessEnv() });
+  const ledger = path.join(workspace, "harness");
+  const canonicalHead = mustRun("revision", "git", ["-C", ledger, "rev-parse", "refs/ha/canonical"], { env: harnessEnv() }).trim();
+  const seedRevision = JSON.parse(readFileSync(path.join(ledger, "events/head.json"), "utf8")).revision;
+  return { taskId: task.taskId, executionId, packagePath: task.packagePath, title: taskTitle, decisionPath: decision.path, canonicalHead, seedRevision };
+}
+
+async function ensureGitLabProject(token) {
+  const headers = { "PRIVATE-TOKEN": token, "content-type": "application/json" };
+  const encoded = encodeURIComponent(`root/${TESTBED.gitlabProject}`);
+  let response = await gitlab(`projects/${encoded}`, { headers, redirect: "manual" });
+  if (response.status === 301) {
+    // A prior deletion attempt leaves a renamed tombstone that still owns the
+    // path (purge is adjourned server-side and not forceable through the API).
+    // Restoring reclaims the exact path; the force-push then replaces content.
+    const tombstone = await (await gitlab(`projects/${encoded}`, { headers })).json();
+    if (!tombstone?.marked_for_deletion_on) fail("gitlab", `path root/${TESTBED.gitlabProject} is taken by ${tombstone?.path_with_namespace ?? "an unknown project"} that is not a restorable tombstone.`);
+    const restored = await gitlab(`projects/${tombstone.id}/restore`, { method: "POST", headers });
+    if (restored.status >= 300) fail("gitlab", `restoring the tombstoned project failed: HTTP ${restored.status}`);
+    log("gitlab", `restored tombstoned project ${tombstone.path_with_namespace} back to root/${TESTBED.gitlabProject}`);
+    response = await gitlab(`projects/${encoded}`, { headers, redirect: "manual" });
+  }
+  if (response.status === 200) {
+    const project = await response.json();
+    log("gitlab", `reusing project ${project.path_with_namespace}; refs will be force-pushed for the reseed`);
+    await allowForcePush(project.id, headers);
+    return project;
+  }
+  if (response.status !== 404) fail("gitlab", `project lookup failed: HTTP ${response.status}`);
+  const created = await gitlab("projects", { method: "POST", headers, body: JSON.stringify({ name: TESTBED.gitlabProject, path: TESTBED.gitlabProject, visibility: "private", default_branch: "main" }) });
+  if (created.status !== 201) fail("gitlab", `project creation failed: HTTP ${created.status} ${(await created.text()).slice(0, 500)}`);
+  const project = await created.json();
+  await allowForcePush(project.id, headers);
+  log("gitlab", `project ready at ${project.web_url}`);
+  return project;
+}
+
+// Reseeding replaces ledger history, and GitLab protects the default branch
+// against force pushes out of the box; drop that protection on the test
+// project only (a project-level setting, not a server-level change).
+async function allowForcePush(projectId, headers) {
+  const removed = await gitlab(`projects/${projectId}/protected_branches/main`, { method: "DELETE", headers });
+  if (removed.status !== 204 && removed.status !== 404) fail("gitlab", `could not unprotect main for reseeding: HTTP ${removed.status}`);
+  log("gitlab", "branch main unprotected so reseeds can force-push");
+}
+
+function pushLedgerToGitLab(project, token) {
+  const ledger = path.join(workspace, "harness");
+  mustRun("push", "git", ["-C", ledger, ...gitCredentialArgs(), "push", "--force", project.http_url_to_repo, "refs/heads/main:refs/heads/main", "refs/ha/canonical:refs/ha/canonical"], { env: harnessEnv({ GITLAB_TOKEN: token }) });
+  log("push", `ledger pushed to ${project.http_url_to_repo}`);
+}
+
+function mintFleetMaterial(seed) {
+  mkdirSync(sharedFleet, { recursive: true });
+  const key = path.join(sharedFleet, "fleet.key"), cert = path.join(sharedFleet, "fleet.crt");
+  const keyStaging = `${key}.staging`, certStaging = `${cert}.staging`;
+  mustRun("tls", "openssl", ["req", "-x509", "-newkey", "rsa:2048", "-nodes", "-keyout", keyStaging, "-out", certStaging, "-subj", "/CN=center", "-days", "30", "-addext", "subjectAltName=DNS:center,DNS:localhost,IP:127.0.0.1"]);
+  renameSync(keyStaging, key);
+  renameSync(certStaging, cert);
+  const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+  const roster = {
+    schema: "fleet-roster/v1",
+    nodes: edges.map((nodeId) => ({ nodeId, credential: `${nodeId}-machine-secret` })),
+    assignments: edges.map((nodeId) => ({
+      assignmentId: `assignment-${nodeId}`, nodeId, repoId: TESTBED.repoId, taskId: seed.taskId, executionId: seed.executionId,
+      viewId: `${nodeId}-view`, personId: TESTBED.personId, executorId: "plt-center-testbed", expiresAt,
+      paths: [`${seed.packagePath}/task_plan.md`, seed.decisionPath]
+    }))
+  };
+  const rosterStaging = path.join(sharedFleet, "roster.json.staging");
+  writeFileSync(rosterStaging, `${JSON.stringify(roster, null, 2)}\n`);
+  renameSync(rosterStaging, path.join(sharedFleet, "roster.json"));
+  log("fleet", `TLS material + roster for ${roster.nodes.length} nodes written to ${sharedFleet}`);
+  return { roster, expiresAt };
+}
+
+function writeStateFile(seed, project, fleet) {
+  const state = {
+    schema: "center-testbed-state/v1",
+    repoId: TESTBED.repoId,
+    taskId: seed.taskId,
+    executionId: seed.executionId,
+    packagePath: seed.packagePath,
+    taskTitle: seed.title,
+    decisionPath: seed.decisionPath,
+    canonicalHead: seed.canonicalHead,
+    seedRevision: seed.seedRevision,
+    gitlab: { url: TESTBED.gitlabUrl, projectId: project.id, pathWithNamespace: project.path_with_namespace, webUrl: project.web_url, httpUrl: project.http_url_to_repo },
+    fleet: { port: TESTBED.fleetPort, quotaBytes: TESTBED.fleetQuotaBytes, rosterPath: path.join(sharedFleet, "roster.json"), certPath: path.join(sharedFleet, "fleet.crt"), nodes: fleet.roster.nodes.map(({ nodeId }) => nodeId), expiresAt: fleet.expiresAt }
+  };
+  const stateStaging = `${TESTBED.stateFile}.staging`;
+  writeFileSync(stateStaging, `${JSON.stringify(state, null, 2)}\n`);
+  renameSync(stateStaging, TESTBED.stateFile);
+}
+
+async function gitlab(pathname, init = {}) {
+  try {
+    return await fetch(new URL(pathname, `${TESTBED.gitlabUrl}/api/v4/`), { ...init, signal: AbortSignal.timeout(15_000) });
+  } catch (error) {
+    fail("gitlab", `request to ${pathname} failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}

--- a/tools/center-testbed/docker-compose.yml
+++ b/tools/center-testbed/docker-compose.yml
@@ -1,0 +1,97 @@
+# PLT-Center full-stack testbed. One-shot seed bootstraps the test project and
+# pushes the canonical ledger to GitLab; the center daemon attaches the cloned
+# ledger and serves fleet TLS; two edge daemons replicate read-only views.
+# Requires: export GITLAB_TOKEN=$(cat ~/.harness-secrets-center-testbed-token)
+
+name: plt-center-testbed
+
+x-testbed-image: &testbed-image
+  image: plt-center-testbed/source
+  build:
+    context: ../..
+    dockerfile: tools/center-testbed/Dockerfile
+
+services:
+  seed:
+    <<: *testbed-image
+    container_name: plt-center-seed
+    # people.yaml pins its unix-socket credential to host:<hostname>; the seed
+    # mints it and the center must resolve it, so both share one hostname.
+    hostname: testbed-host
+    command: ["node", "/opt/testbed/bootstrap.mjs"]
+    environment: &daemon-env
+      GITLAB_TOKEN: ${GITLAB_TOKEN:?export GITLAB_TOKEN=$(cat ~/.harness-secrets-center-testbed-token)}
+      # Exec'd `ha` commands must target the same daemon the entrypoint owns.
+      HARNESS_DAEMON_USER_ROOT: /data/daemon-user
+      HARNESS_DAEMON_ID: seed
+      HARNESS_ACTOR: agent:plt-center-testbed
+    volumes:
+      - testbed-shared:/data/shared
+      - testbed-workspace:/data/workspace
+    networks: [fleet]
+
+  center:
+    <<: *testbed-image
+    container_name: plt-center-center
+    hostname: testbed-host
+    command: ["node", "/opt/testbed/entrypoint-center.mjs"]
+    environment:
+      <<: *daemon-env
+      HARNESS_DAEMON_ID: center
+    volumes:
+      - testbed-shared:/data/shared:ro
+      - testbed-center:/data
+    depends_on:
+      seed:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "sh", "-c", "test -f /data/center-ready"]
+      interval: 5s
+      timeout: 3s
+      retries: 120
+      start_period: 20s
+    networks: [fleet]
+
+  edge-1:
+    <<: *testbed-image
+    container_name: plt-center-edge-1
+    hostname: testbed-edge-1
+    command: ["node", "/opt/testbed/entrypoint-edge.mjs"]
+    environment:
+      <<: *daemon-env
+      HARNESS_DAEMON_ID: edge-1
+      TESTBED_NODE_ID: edge-1
+    volumes:
+      - testbed-shared:/data/shared:ro
+      - testbed-edge-1:/data
+    depends_on:
+      center:
+        condition: service_healthy
+    networks: [fleet]
+
+  edge-2:
+    <<: *testbed-image
+    container_name: plt-center-edge-2
+    hostname: testbed-edge-2
+    command: ["node", "/opt/testbed/entrypoint-edge.mjs"]
+    environment:
+      <<: *daemon-env
+      HARNESS_DAEMON_ID: edge-2
+      TESTBED_NODE_ID: edge-2
+    volumes:
+      - testbed-shared:/data/shared:ro
+      - testbed-edge-2:/data
+    depends_on:
+      center:
+        condition: service_healthy
+    networks: [fleet]
+
+volumes:
+  testbed-shared:
+  testbed-workspace:
+  testbed-center:
+  testbed-edge-1:
+  testbed-edge-2:
+
+networks:
+  fleet:

--- a/tools/center-testbed/entrypoint-center.mjs
+++ b/tools/center-testbed/entrypoint-center.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Center-container entrypoint. Owns the resident daemon, clones the canonical
+// ledger from GitLab (the durable center authority), attaches it as the center
+// repo, drives the cold projection rebuild, then starts the fleet TLS center
+// the edge containers replicate from. A marker file flips the compose
+// healthcheck once the fleet center is listening.
+
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { TESTBED, cliEntry, daemonStatus, fail, fleetEnv, gitCredentialArgs, ha, harnessEnv, log, mustRun, run, sleepMs, startDaemon } from "./lib/testbed.mjs";
+
+const workspace = "/data/workspace";
+const userRoot = "/data/daemon-user";
+const readyMarker = "/data/center-ready";
+
+await main();
+
+async function main() {
+  if (!process.env.GITLAB_TOKEN) fail("env", "GITLAB_TOKEN is required for the center clone.");
+  if (!existsSync(TESTBED.stateFile)) fail("env", `${TESTBED.stateFile} is missing; the seed bootstrap must complete first.`);
+  // Deterministic cold start: the center always re-clones from GitLab and
+  // rebuilds its projection, so a reseeded upstream cannot leave stale state.
+  for (const target of [workspace, userRoot]) {
+    if (existsSync(target)) rmSync(target, { recursive: true, force: true });
+  }
+  mkdirSync(workspace, { recursive: true });
+
+  const daemon = startDaemon("center", userRoot, "center");
+  forwardSignals(daemon);
+
+  const state = JSON.parse(readFileSync(TESTBED.stateFile, "utf8"));
+  cloneLedger(state);
+  registerRepo();
+  await waitForProjection();
+  startFleetCenter(state);
+  writeFileSync(readyMarker, `${new Date().toISOString()}\n`);
+  log("center", `READY: fleet center listening on 0.0.0.0:${TESTBED.fleetPort}; marker ${readyMarker}`);
+
+  const exitCode = await new Promise((resolve) => daemon.once("exit", (code, signal) => resolve(signal ? 0 : code ?? 0)));
+  process.exit(exitCode);
+}
+
+function forwardSignals(daemon) {
+  for (const signal of ["SIGTERM", "SIGINT"]) {
+    process.on(signal, () => daemon.kill(signal));
+  }
+}
+
+function cloneLedger(state) {
+  const env = harnessEnv({ GITLAB_TOKEN: process.env.GITLAB_TOKEN }), ledger = path.join(workspace, "harness");
+  mustRun("clone", "git", [...gitCredentialArgs(), "clone", "--branch", "main", state.gitlab.httpUrl, ledger], { env });
+  // A branch checkout does not transfer non-branch refs; the canonical anchor
+  // rides its own ref and must be fetched explicitly.
+  mustRun("clone", "git", ["-C", ledger, ...gitCredentialArgs(), "fetch", "origin", "refs/ha/canonical:refs/ha/canonical"], { env });
+  const head = mustRun("clone", "git", ["-C", ledger, "rev-parse", "refs/ha/canonical"], { env: harnessEnv() }).trim();
+  if (head !== state.canonicalHead) fail("clone", `cloned canonical head ${head} does not match the seeded head ${state.canonicalHead}`);
+  log("clone", `ledger cloned from GitLab at canonical ${head.slice(0, 12)} (seed revision ${state.seedRevision})`);
+}
+
+function registerRepo() {
+  ha("register", fleetEnv(userRoot, "center"), ["daemon", "repo", "register", "--repo-id", TESTBED.repoId, "--root", workspace]);
+  log("register", `repo ${TESTBED.repoId} registered at ${workspace}`);
+}
+
+async function waitForProjection() {
+  const env = fleetEnv(userRoot, "center"), deadline = Date.now() + 300_000;
+  for (;;) {
+    const status = daemonStatus(userRoot, "center");
+    const repos = status?.repos ?? [];
+    const attached = repos.length === 1 && repos[0].repoId === TESTBED.repoId && repos[0].state === "attached";
+    if (attached) {
+      // The replica cut source only becomes exact once the projection has
+      // caught up; drive it with a read and require a non-zero revision.
+      const probe = run(process.execPath, [cliEntry(), "--json", "--root", workspace, "task", "list"], { env });
+      if (probe.status === 0) {
+        const receipt = JSON.parse(probe.stdout);
+        if (receipt.ok === true && Number(receipt.revision ?? 0) > 0) {
+          log("projection", `cold projection rebuild finished at revision ${receipt.revision}`);
+          return;
+        }
+      }
+    }
+    if (Date.now() > deadline) fail("projection", `projection did not become ready within 300s: ${JSON.stringify(repos).slice(0, 400)}`);
+    sleepMs(2_000);
+  }
+}
+
+
+function startFleetCenter(state) {
+  const fleet = path.join(TESTBED.sharedRoot, "fleet");
+  ha("fleet", fleetEnv(userRoot, "center"), [
+    "daemon", "fleet", "center", "start",
+    "--port", String(TESTBED.fleetPort), "--bind", "0.0.0.0",
+    "--key", path.join(fleet, "fleet.key"), "--cert", path.join(fleet, "fleet.crt"),
+    "--roster", state.fleet.rosterPath, "--quota-bytes", String(TESTBED.fleetQuotaBytes)
+  ]);
+  log("fleet", `fleet TLS center started for ${state.fleet.nodes.length} roster nodes`);
+}

--- a/tools/center-testbed/entrypoint-edge.mjs
+++ b/tools/center-testbed/entrypoint-edge.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+// Edge-container entrypoint. Each edge runs its own daemon in its own socket
+// namespace and stays resident; the read-path smoke (`smoke-edge.mjs`) then
+// drives `ha daemon fleet edge sync` through this daemon on demand. Edge views
+// under /data/view survive restarts so re-runs exercise the delta/current
+// replica paths instead of always resnapshotting.
+
+import { existsSync, rmSync } from "node:fs";
+import { fail, log, startDaemon } from "./lib/testbed.mjs";
+
+const userRoot = "/data/daemon-user";
+const nodeId = process.env.TESTBED_NODE_ID;
+
+if (!nodeId) fail("env", "TESTBED_NODE_ID is required (set per edge service in docker-compose.yml).");
+if (existsSync(userRoot)) rmSync(userRoot, { recursive: true, force: true });
+
+const daemon = startDaemon("edge", userRoot, nodeId);
+for (const signal of ["SIGTERM", "SIGINT"]) {
+  process.on(signal, () => daemon.kill(signal));
+}
+log("edge", `READY: edge ${nodeId} daemon resident; run the smoke to pull a replica view`);
+
+const exitCode = await new Promise((resolve) => daemon.once("exit", (code, signal) => resolve(signal ? 0 : code ?? 0)));
+process.exit(exitCode);

--- a/tools/center-testbed/lib/testbed.mjs
+++ b/tools/center-testbed/lib/testbed.mjs
@@ -1,0 +1,161 @@
+// Shared runtime helpers for the PLT-Center Docker testbed. Everything here runs
+// INSIDE a testbed container against the baked-in harness-anything source tree;
+// the host only ever drives `docker compose` and the smoke script.
+
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+export const TESTBED = Object.freeze({
+  sourceRoot: "/opt/harness-anything",
+  testbedRoot: "/opt/testbed",
+  sharedRoot: "/data/shared",
+  stateFile: "/data/shared/testbed-state.json",
+  fleetPort: 7443,
+  fleetQuotaBytes: 268_435_456,
+  repoId: "plt-center-testbed",
+  personId: "testbed-owner",
+  actor: "agent:plt-center-testbed",
+  gitAuthor: { name: "PLT Center Testbed", email: "plt-center-testbed@invalid" },
+  gitlabUrl: (process.env.GITLAB_URL ?? "http://43.142.81.196:8929").replace(/\/+$/u, ""),
+  gitlabProject: process.env.TESTBED_GITLAB_PROJECT ?? "plt-center-testbed"
+});
+
+export function log(step, message) {
+  console.log(`[testbed:${step}] ${message}`);
+}
+
+export function fail(step, message) {
+  console.error(`[testbed:${step}] FAILED: ${message}`);
+  process.exit(1);
+}
+
+// The CLI entry prefers the built dist (the same artifact CI and the coldstart
+// benchmark image run) and falls back to source when dist has not been built.
+export function cliEntry() {
+  const dist = path.join(TESTBED.sourceRoot, "packages/cli/dist/cli/src/index.js");
+  const source = path.join(TESTBED.sourceRoot, "packages/cli/src/index.ts");
+  if (existsSync(dist)) return dist;
+  if (existsSync(source)) return source;
+  throw new Error(`harness-anything CLI entry is missing at ${TESTBED.sourceRoot}`);
+}
+
+export function harnessEnv(extra = {}) {
+  const { name, email } = TESTBED.gitAuthor;
+  return {
+    ...process.env,
+    HARNESS_ACTOR: TESTBED.actor,
+    HARNESS_GIT_AUTHOR_NAME: name,
+    HARNESS_GIT_AUTHOR_EMAIL: email,
+    GIT_AUTHOR_NAME: name,
+    GIT_AUTHOR_EMAIL: email,
+    GIT_COMMITTER_NAME: name,
+    GIT_COMMITTER_EMAIL: email,
+    ...extra
+  };
+}
+
+export function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024, ...options });
+  return { status: result.status, stdout: result.stdout ?? "", stderr: result.stderr ?? "", error: result.error };
+}
+
+export function mustRun(step, command, args, options = {}) {
+  const result = run(command, args, options);
+  if (result.status !== 0) {
+    fail(step, `${command} ${args.join(" ")} exited ${result.status}: ${result.stderr.trim().slice(0, 2000)}`);
+  }
+  return result.stdout;
+}
+
+// `ha --json` emits command receipts whose payload lives under details.data plus
+// a paths map; flatten both so callers read receipt.taskId-style fields directly.
+// Path overrides only apply when the envelope actually carries a paths map —
+// receipts like task-create already expose packagePath at the top level.
+export function unwrapReceipt(value) {
+  const data = value?.details?.data && typeof value.details.data === "object" ? value.details.data : {};
+  const paths = Object.fromEntries(Array.isArray(value?.paths) ? value.paths.map((entry) => [entry.role, entry.path]) : []);
+  const flattened = { ...value, ...data };
+  if (paths.package) flattened.packagePath = paths.package;
+  if (paths.primary) flattened.primaryPath = paths.primary;
+  return flattened;
+}
+
+export function ha(step, env, args, options = {}) {
+  const argv = ["--json", ...args];
+  const result = run(process.execPath, [cliEntry(), ...argv], { ...options, env });
+  if (result.status !== 0) {
+    const hint = parseReceiptHint(result.stdout) ?? result.stderr.trim().slice(0, 2000);
+    fail(step, `ha ${args.join(" ")} exited ${result.status}: ${hint}`);
+  }
+  const receipt = unwrapReceipt(JSON.parse(result.stdout));
+  if (receipt.ok !== true) {
+    fail(step, `ha ${args.join(" ")} rejected: ${parseReceiptHint(result.stdout) ?? JSON.stringify(receipt).slice(0, 2000)}`);
+  }
+  return receipt;
+}
+
+function parseReceiptHint(stdout) {
+  try {
+    const parsed = JSON.parse(stdout);
+    return parsed?.error?.hint ?? parsed?.details?.data?.error?.hint ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// The resident daemon is the container's main long-running process; entrypoints
+// spawn it and own its lifecycle, so this helper only waits for the socket.
+export function startDaemon(step, userRoot, daemonId) {
+  const child = spawn(process.execPath, [cliEntry(), "daemon", "serve", "--user-root", userRoot, "--daemon-id", daemonId], {
+    env: harnessEnv({ HARNESS_DAEMON_USER_ROOT: userRoot, HARNESS_DAEMON_ID: daemonId }),
+    stdio: ["ignore", "inherit", "inherit"],
+    detached: false
+  });
+  child.on("error", (error) => fail(step, `daemon serve could not start: ${error.message}`));
+  waitForDaemon(step, userRoot, daemonId, 120_000);
+  log(step, `daemon serving (pid ${child.pid ?? "unknown"}, user-root ${userRoot})`);
+  return child;
+}
+
+export function waitForDaemon(step, userRoot, daemonId, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = run(process.execPath, [cliEntry(), "--json", "daemon", "status", "--user-root", userRoot, "--daemon-id", daemonId], {
+      env: harnessEnv({ HARNESS_DAEMON_USER_ROOT: userRoot, HARNESS_DAEMON_ID: daemonId })
+    });
+    if (result.status === 0) return;
+    if (Date.now() > deadline) fail(step, `daemon did not accept connections within ${timeoutMs}ms: ${result.stderr.trim().slice(0, 500)}`);
+    sleepMs(500);
+  }
+}
+
+export function daemonStatus(userRoot, daemonId) {
+  const result = run(process.execPath, [cliEntry(), "--json", "daemon", "status", "--user-root", userRoot, "--daemon-id", daemonId], {
+    env: harnessEnv({ HARNESS_DAEMON_USER_ROOT: userRoot, HARNESS_DAEMON_ID: daemonId })
+  });
+  if (result.status !== 0) return null;
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    return null;
+  }
+}
+
+export function sleepMs(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+export function readState() {
+  return JSON.parse(readFileSync(TESTBED.stateFile, "utf8"));
+}
+
+export function fleetEnv(userRoot, daemonId) {
+  return harnessEnv({ HARNESS_DAEMON_USER_ROOT: userRoot, HARNESS_DAEMON_ID: daemonId });
+}
+
+// One-shot git credential helper: hands the token to git without persisting it
+// into any .git/config (the config only ever records the clean http URL).
+export function gitCredentialArgs() {
+  return ["-c", `credential.helper=!f() { echo username=oauth2; echo password=$GITLAB_TOKEN; }; f`];
+}

--- a/tools/center-testbed/smoke-edge.mjs
+++ b/tools/center-testbed/smoke-edge.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Per-edge read-path smoke, run INSIDE an edge container:
+//   node /opt/testbed/smoke-edge.mjs edge-1
+// Pulls the center replica through this edge's daemon, asserts the seeded task,
+// decision, and fact documents are readable from the local view, then re-syncs
+// to prove idempotency (second pull answers "current", zero transfer).
+
+import { existsSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { TESTBED, fail, fleetEnv, ha, log } from "./lib/testbed.mjs";
+
+const nodeId = process.argv[2];
+if (!nodeId) fail("usage", "node smoke-edge.mjs <node-id> (e.g. edge-1)");
+
+const state = JSON.parse(readFileSync(TESTBED.stateFile, "utf8"));
+const roster = JSON.parse(readFileSync(state.fleet.rosterPath, "utf8"));
+const node = roster.nodes.find((entry) => entry.nodeId === nodeId);
+const assignment = roster.assignments.find((entry) => entry.nodeId === nodeId);
+if (!node || !assignment) fail("roster", `node ${nodeId} is not present in ${state.fleet.rosterPath}`);
+
+const userRoot = "/data/daemon-user";
+const viewRoot = "/data/view";
+const env = fleetEnv(userRoot, nodeId);
+
+// A reseed replaces ledger history; retained cuts from an older generation can
+// collide by revision number and fail the edge's atomic view verification. The
+// generation marker wipes the view only when the canonical head actually
+// changed, so re-runs within one generation still exercise delta/current.
+const generationFile = path.join(viewRoot, "generation.json");
+const generation = existsSync(generationFile) ? JSON.parse(readFileSync(generationFile, "utf8")) : null;
+if (generation?.canonicalHead !== state.canonicalHead) {
+  if (existsSync(viewRoot)) for (const entry of readdirSync(viewRoot)) rmSync(path.join(viewRoot, entry), { recursive: true, force: true });
+  writeFileSync(generationFile, `${JSON.stringify({ canonicalHead: state.canonicalHead }, null, 2)}\n`);
+  log("view", `ledger generation changed; view reset for canonical ${state.canonicalHead.slice(0, 12)}`);
+}
+const syncArgs = [
+  "daemon", "fleet", "edge", "sync",
+  "--host", "center", "--port", String(state.fleet.port), "--ca", state.fleet.certPath,
+  "--node-id", nodeId, "--credential", node.credential, "--assignment", assignment.assignmentId,
+  "--view-root", viewRoot, "--quota-bytes", String(state.fleet.quotaBytes)
+];
+
+const first = ha("sync", env, syncArgs);
+// A fresh center answers with a real transfer (fleet.ack.result/v1); a smoke
+// re-run against an already-current view legitimately answers "current". Both
+// must land on the seeded cut — the document assertions below catch a stale or
+// empty view either way.
+const firstStatuses = ["fleet.ack.result/v1", "fleet.replica.current/v1"];
+if (!firstStatuses.includes(first.status)) fail("sync", `pull #1 returned unexpected status ${first.status}`);
+log("sync", `pull #1 ok: status ${first.status} ackCut ${first.ackCut} (center cut revision ${first.cut.revision})`);
+
+const view = path.join(viewRoot, "repos", state.repoId, "views", assignment.viewId);
+const current = JSON.parse(readFileSync(path.join(view, "current.json"), "utf8"));
+if (current.cut.revision < state.seedRevision) fail("view", `view cut ${current.cut.revision} is behind the seed revision ${state.seedRevision}`);
+const cutFiles = path.join(view, "cuts", String(current.cut.revision), "files");
+
+const taskDoc = readText(path.join(cutFiles, `${state.packagePath}/task_plan.md`));
+assertContains("task doc", taskDoc, state.taskTitle);
+const decisionDoc = readText(path.join(cutFiles, state.decisionPath));
+assertContains("decision doc", decisionDoc, "The center daemon owns the canonical ledger");
+const factsDoc = readText(path.join(cutFiles, `${state.packagePath}/facts.md`));
+assertContains("facts doc", factsDoc, "The testbed bootstrap wrote a task, a decision, and a fact");
+log("view", `edge view serves cut ${current.cut.revision} with task, decision, and fact documents`);
+
+const second = ha("resync", env, syncArgs);
+if (second.status !== "fleet.replica.current/v1") fail("resync", `expected idempotent fleet.replica.current/v1, got ${second.status}`);
+log("resync", `pull #2 ok: center confirms the view is current at cut ${second.cut.revision} (no transfer)`);
+
+log("smoke", `SMOKE PASS: edge ${nodeId} reads the center ledger projection through fleet TLS`);
+
+function readText(file) {
+  if (!existsSync(file)) fail("view", `expected view file ${file} is missing`);
+  return readFileSync(file, "utf8");
+}
+
+function assertContains(label, body, marker) {
+  if (!body.includes(marker)) fail("view", `${label} does not contain the seeded marker "${marker}"`);
+}

--- a/tools/center-testbed/smoke-read.sh
+++ b/tools/center-testbed/smoke-read.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
-: "${GITLAB_TOKEN:?export GITLAB_TOKEN=$(cat ~/.harness-secrets-center-testbed-token)}"
+: "${GITLAB_TOKEN:?missing; run: export GITLAB_TOKEN=\$(cat ~/.harness-secrets-center-testbed-token)}"
 GITLAB_URL="${GITLAB_URL:-http://43.142.81.196:8929}"
 PROJECT_PATH="${TESTBED_GITLAB_PROJECT:-plt-center-testbed}"
 

--- a/tools/center-testbed/smoke-read.sh
+++ b/tools/center-testbed/smoke-read.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Host-side read-path smoke for the PLT-Center testbed. Assumes
+# `docker compose up -d --wait` succeeded. Verifies both edges can pull and read
+# the center ledger projection, that the canonical ledger is visible on GitLab,
+# and prints the center's key log lines.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+: "${GITLAB_TOKEN:?export GITLAB_TOKEN=$(cat ~/.harness-secrets-center-testbed-token)}"
+GITLAB_URL="${GITLAB_URL:-http://43.142.81.196:8929}"
+PROJECT_PATH="${TESTBED_GITLAB_PROJECT:-plt-center-testbed}"
+
+echo "== edge read-path smoke =="
+docker compose exec -T edge-1 node /opt/testbed/smoke-edge.mjs edge-1
+docker compose exec -T edge-2 node /opt/testbed/smoke-edge.mjs edge-2
+
+echo
+echo "== GitLab visibility =="
+PROJECT_JSON=$(curl -fsS -H "PRIVATE-TOKEN: $GITLAB_TOKEN" "$GITLAB_URL/api/v4/projects/root%2F$PROJECT_PATH")
+echo "$PROJECT_JSON" | python3 -c '
+import json, sys
+project = json.load(sys.stdin)
+print("web_url:", project["web_url"])
+print("path_with_namespace:", project["path_with_namespace"])
+print("default_branch:", project["default_branch"])
+print("last_activity_at:", project["last_activity_at"])
+'
+BRANCH_JSON=$(curl -fsS -H "PRIVATE-TOKEN: $GITLAB_TOKEN" "$GITLAB_URL/api/v4/projects/root%2F$PROJECT_PATH/repository/branches/main")
+echo "$BRANCH_JSON" | python3 -c '
+import json, sys
+branch = json.load(sys.stdin)
+print("main head:", branch["commit"]["short_id"], "-", branch["commit"]["title"][:60])
+'
+
+echo
+echo "== center log (key lines) =="
+docker compose logs --no-log-prefix center 2>/dev/null | grep "testbed:" | tail -12
+
+echo
+echo "SMOKE PASS: both edges read the center projection; the ledger is visible on GitLab."


### PR DESCRIPTION
# English

## Summary
PLT-Center Docker testbed (`tools/center-testbed/`, all-new, no production-package code): one-command full stack for M2 development — a center container (authority daemon + fleet TLS center), two edge containers (collaborator nodes), and a bootstrap that mints a real harnessed test project (tasks/decisions/facts via `ha`) and pushes it to the Tencent GitLab center repo (`root/plt-center-testbed`). Reuses the benchmark coldstart Dockerfile recipe. Isolation per dec_F974C3C33C6ACCA0E5CFB1011D/CH2: the production daemon and `.harness/` are never touched; container sockets live in their own namespace.

## Verification
- Four smoke paths exercised by the worker (fresh `up` with dual-edge `ackCut` transfer + view assertions; idempotent re-sync; center-side write at revision 6 delta-synced to both edges; dist hot-swap + re-smoke), plus full `down → up` rerun.
- CEO re-ran `smoke-read.sh` by hand: SMOKE PASS (both edges read the center projection; ledger visible on GitLab, head `d1a10875`).
- `npm run check:local` green (152.7s); `npx eslint tools/center-testbed` clean. New surface has no packages/ import chain.
- CEO fix included: the smoke script's missing-env hint used `$(cat …token)` inside `:?`, which bash executed — the actual token got rendered into the error text. Hint is now literal.

Production-Delta: +0/-0

## Review Evidence
- Worker (GLM) report: `harness/tasks/task_4255d9255e2f9f9cc354579aaf-plt-center-docker-testbed/artifacts/report-glm-testbed.md` (+ detailed report-20260818.md with topology, per-container log lines).
- Token scanned per-commit: no leak into git; credentials injected via env only.

## Residual Risk
- Worker surfaced an M1-E-class source observation (reseeding a reused revision number leaves a stale `cuts/<rev>` on edges; atomic verification fails then "self-heals" on retry). The testbed works around it with a generation marker; daemon/kernel source untouched — routed to the PLT-Center W1/W3 defect queue.
- GitLab project deletion is adjourned (restore+force-push reuse); image is 1.68GB; non-macOS/non-arm64 builds unverified.

## Governance Declaration
- Task: task_4255d9255e2f9f9cc354579aaf (derives from dec_F974C3C33C6ACCA0E5CFB1011D/CH2, refining dec_9E7AC30E811C0D18798DF60F76).
- No CI/gate authority surfaces touched; tools-only addition.

---

# 中文

## 摘要
PLT-Center Docker 测试台(`tools/center-testbed/`,全新增,不碰生产包代码):一键起全栈——center 容器(权威 daemon+fleet TLS center)、双 edge 容器(collaborator 节点),bootstrap 用 `ha` 真实写入铸一个 harness 化测试项目并推到腾讯 GitLab 中心仓(`root/plt-center-testbed`)。复用 benchmark coldstart 镜像配方。按 dec_F974C3C3/CH2 隔离:生产 daemon 与 `.harness/` 零接触,容器内 socket 自成命名空间。

## 验证
- worker 四路径冒烟(全新 up 双 edge ackCut 传输+视图断言;幂等重跑;center 写 revision 6 双 edge delta 同步;dist 热替换后复冒烟)+ down→up 全量重跑。
- CEO 亲手复跑 `smoke-read.sh`:SMOKE PASS(双 edge 读到中心投影,GitLab 可见,head d1a10875)。
- `npm run check:local` 全绿;eslint 干净;新面无 packages/ import 链。
- 含 CEO 一处修复:冒烟脚本缺 env 提示里的 `$(cat …token)` 被 bash 展开,把真 token 渲染进了报错文案;已改字面量。

生产增量(见上英文节):+0/-0

## 复核证据
- worker 报告在任务包 artifacts;token 逐 commit 扫描无泄漏,凭证只经 env 注入。

## 残留风险
- worker 发现 M1-E 级源码观察(reseed 复用 revision 号 → edge 留陈旧 cut,重试"自愈"),测试台用 generation 标记规避,未改 daemon/kernel 源——已路由进 PLT-Center W1/W3 缺陷队列。
- GitLab 删除走 restore+force-push 复用;镜像 1.68GB;非 macOS/arm64 未验。

## 治理声明
- 任务:task_4255d9255e2f9f9cc354579aaf(derives 自 dec_F974C3C3/CH2)。
- 未触碰 CI/gate 权威面;tools-only。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
