### PR TITLE
fix(daemon): defer fs watcher close out of its own FSEvents error callback (production outage hotfix)

### DIFF
--- a/packages/daemon/src/doc-sync-watcher.ts
+++ b/packages/daemon/src/doc-sync-watcher.ts
@@ -50,7 +50,10 @@ export function openDocSyncWatcher(input: { readonly rootDir: string; readonly p
     if (directories.has(directory) || state === "closed" || path.basename(directory) === ".git") return; let watcher: FSWatcher;
     try { watcher = watch(directory, (_event, filename) => { if (filename === null) { wake(); return; } const child = path.join(directory, String(filename));
       try { if (lstatSync(child).isDirectory()) watchDirectory(child); } catch (error) { consumeKnownError(error); } wake(path.relative(authoredRoot, child)); }); } catch (error) { consumeKnownError(error); degradeToPolling(); return; }
-    watcher.on("error", () => { watcher.close(); directories.delete(directory); degradeToPolling(); wake(); }); directories.set(directory, watcher);
+    // The error event is delivered from inside the FSEvents callback (FSEventWrap::OnEvent);
+    // closing the watcher synchronously there deadlocks libuv on macOS (uv__fsevents_close
+    // waits on a semaphore the in-flight callback prevents from ever being signaled).
+    watcher.on("error", () => { setImmediate(() => watcher.close()); directories.delete(directory); degradeToPolling(); wake(); }); directories.set(directory, watcher);
     try { for (const entry of readdirSync(directory, { withFileTypes: true })) if (entry.isDirectory()) watchDirectory(path.join(directory, entry.name)); } catch (error) { consumeKnownError(error); } };
   if (input.watchFilesystem !== false) { watchDirectory(authoredRoot); if (directories.size === 0) state = "blocked"; }
   if (input.startupScan !== false) wake();


### PR DESCRIPTION
# English

## Summary
Production daemon outage hotfix. Tonight the resident daemon entered a crash/hang loop and never bound its socket, blocking every `ha` write on this machine. Root cause (sampled stack, reproduced deterministically on a probe user-root): `doc-sync-watcher.ts` closed an `fs.watch` watcher **synchronously inside its own error handler**. On macOS the error event is delivered from within `FSEventWrap::OnEvent`; `watcher.close()` there reaches `uv__fsevents_close`, which waits on a semaphore the in-flight callback prevents from ever being signaled — the daemon main thread deadlocks (`uv_close → uv_fs_event_stop → uv__fsevents_close → uv_sem_wait`, 1608/1610 samples). Repos with thousands of authored directories (one watcher per directory; kqueue/EMFILE exhaustion) hit the error path on every cold start. Fix: defer the close with `setImmediate` so it runs outside the callback; polling degradation and wake stay immediate.

## Verification
- Deterministic repro before fix: register the canonical repo into a fresh probe user-root → serve process dies/hangs without binding (empty stdout/stderr; sampled deadlock stack above).
- After fix: same poisoned probe root binds in 76s, `daemon status` reports canonical `state=attached`; status polled repeatedly, stays responsive.
- `npm run check:local` green (46.2s).

Production-Delta: +4/-1

## Review Evidence
- Incident evidence (multi-session, timelines, samples, registry census): `harness/tasks/task_856697c1a1b98d751bbe09034f-plt-center/artifacts/evidence-coldstart-incident-20260818.md`. Diagnosis cross-verified with two peer sessions (uds:19277 sampled the stack; uds:8298 established crash-loop shape and no-log finding).

## Residual Risk
- Cold start with a large repo is still slow (~76s on the probe): serial per-directory watcher registration and cold projection rebuild before bind. The structural fixes (bind before attach; watcher capacity; crash logging for detached daemons) are chartered as PLT-Center W1/W5 work (dec_9E7AC30E), not in this hotfix.
- The deferred close releases the FSEvents stream one tick later; no user-visible semantics change.

## Governance Declaration
- Task: task_f72d54e99610e0e851ef7b1acb (PLT-Center W1 line; incident absorbed as evidence). Decisions: dec_9E7AC30E811C0D18798DF60F76 / dec_F974C3C33C6ACCA0E5CFB1011D.
- No CI/gate authority surfaces touched.

---

# 中文

## 摘要
生产 daemon 停摆热修。今晚常驻 daemon 进入崩溃/挂死循环、始终不 bind socket,本机所有 `ha` 写入被堵。根因(采样栈+probe user-root 确定性复现):`doc-sync-watcher.ts` 在 watcher 的 error 处理器里**同步 close 它自己**。macOS 上 error 事件从 `FSEventWrap::OnEvent` 回调内派发,此处 `watcher.close()` 走到 `uv__fsevents_close`,等一个被在飞回调堵死的信号量——主线程死锁(`uv_close → uv_fs_event_stop → uv__fsevents_close → uv_sem_wait`,1608/1610 采样)。authored 目录数千的仓(每目录一个 watcher,kqueue/EMFILE 耗尽)每次冷启动必踩 error 路径。修法:close 用 `setImmediate` 挪出回调;降级轮询与 wake 保持立即。

## 验证
- 修前确定性复现:全新 probe user-root 注册 canonical 仓 → serve 不 bind 即死/挂(stdout/stderr 零字节;采样栈如上)。
- 修后:同一毒 root 76s bind,`daemon status` 报 canonical `state=attached`,持续轮询保持响应。
- `npm run check:local` 全绿。

生产增量(见上英文节):+4/-1

## 复核证据
- 事故证据(多会话时间线/采样/registry 普查)在 PLT-Center milestone artifacts;诊断与两个邻会话交叉验证。

## 残留风险
- 大仓冷启动仍慢(probe ~76s):bind 前的逐目录 watcher 注册与投影冷重建——结构修复(bind 前置/watcher 容量/detached 崩溃留痕)已立进 PLT-Center W1/W5,不在本热修。

## 治理声明
- 任务:task_f72d54e99610e0e851ef7b1acb;决策:dec_9E7AC30E / dec_F974C3C3。未触碰 CI/gate 权威面。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
