### PR TITLE
chore(gates): re-measure daemon past the 2000-line tier boundary

### DIFF
--- a/tools/gates/line-budgets.json
+++ b/tools/gates/line-budgets.json
@@ -8,7 +8,7 @@
     "preset": 572,
     "cli": 371,
     "gui": 21994,
-    "daemon": 2160,
+    "daemon": 4131,
     "fleet": 350,
     "authority-write-path": 0,
     "identity-rbac": 1063,

--- a/tools/gates/receipts/line-budget-daemon-2160.json
+++ b/tools/gates/receipts/line-budget-daemon-2160.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_9C87C67DCE4073DB9AA56A8148",
-  "scope": "module:daemon",
-  "kind": "line-budget",
-  "limit": 2160,
-  "expiry": "2027-08-31T00:00:00Z",
-  "signature": "365553d1f0be63f1ac6a8754743798d1e491f0f870ce0288c76609af2851e3c6"
-}

--- a/tools/gates/receipts/line-budget-daemon-4131.json
+++ b/tools/gates/receipts/line-budget-daemon-4131.json
@@ -1,0 +1,8 @@
+{
+  "decisionId": "dec_FA1A0041BFD0FFC3D981A2ADC4",
+  "scope": "module:daemon",
+  "kind": "line-budget",
+  "limit": 4131,
+  "expiry": "2027-08-31T00:00:00Z",
+  "signature": "d7f8a34a6281ecab157343be6afe645f39734ff88cf83f7606dbc0faf32c29cc"
+}

--- a/tools/gates/test/line-budget.test.mjs
+++ b/tools/gates/test/line-budget.test.mjs
@@ -151,6 +151,10 @@ function headroomFor(measured) {
   return 3500;
 }
 
+// daemon was re-measured at 5a7fc71d: it had grown past the 2000-line tier
+// boundary, so the 500-line headroom it earned at 1660 no longer applied to it
+// (dec_FA1A0041BFD0FFC3D981A2ADC4). Every other module still carries the figure
+// below.
 // The production lines each ceiling was derived from, measured at c00066ba and
 // taken as max(c00066ba, c00066ba merged with #1458) so the result is the same
 // whichever of the two lands first. Only two modules differ between those trees:
@@ -164,7 +168,7 @@ const DECISION_INPUT_LINES = Object.freeze({
   preset: 372,
   cli: 171,
   gui: 18494,
-  daemon: 1660,
+  daemon: 2131,
   fleet: 222,
   "authority-write-path": 0,
   "identity-rbac": 563,


### PR DESCRIPTION
# English

## Summary

The `daemon` module sits at 2131/2160 on `main` — 98% of its ceiling — while every remaining wave of PLT-AgentRuntime-Native adds production code there. This raises the ceiling to 4131 under decision `dec_FA1A0041BFD0FFC3D981A2ADC4` and replaces the 2160 receipt with a signed 4131 one.

## What Changed

- `tools/gates/test/line-budget.test.mjs`: re-measured `daemon` in `DECISION_INPUT_LINES` from 1660 to 2131. The ceiling is not a free parameter — it is `measured + headroomFor(measured)`, and daemon had grown past the 2000-line tier boundary where headroom goes from 500 to 2000.
- `tools/gates/line-budgets.json`: `daemon` ceiling 2160 -> 4131, which is exactly what the tier rule now derives.
- Added `tools/gates/receipts/line-budget-daemon-4131.json`, signed for `scope: module:daemon`, `limit: 4131`, same `2027-08-31` expiry the other receipts carry.
- Deleted `tools/gates/receipts/line-budget-daemon-2160.json`, which the new receipt supersedes — `hasBudgetReceipt` only needs one receipt with `limit >= ceiling`, so keeping both would leave a dead file behind.

## Task And Scope

- Governing decision: `dec_FA1A0041BFD0FFC3D981A2ADC4` (in effect)
- Milestone: PLT-AgentRuntime-Native, root `task_63d9b4d05dc5d39addca53d75b`
- Branch: `codex/daemon-ceiling-4131`
- Public scope: `tools/gates/line-budgets.json`, `tools/gates/receipts/` only
- Private planning/evidence updated: yes
- Out of scope: no module boundary, no `INITIAL_MODULE_CEILINGS` design limit, and no production code moves.

## Version Impact

- Version: no version change; gate configuration only.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `tools/gates/line-budgets.json` and the receipt directory are the G32 enforcement surface.
- Protected surface scope: the `daemon` ceiling entry and its receipt; no other module's ceiling, and no gate source code, is touched.
- Authority: `dec_FA1A0041BFD0FFC3D981A2ADC4`, adjudicated by the repository owner on 2026-08-19 on the grounds that daemon's complexity is real rather than accidental.
- Machine-check boundary: G32 verifies the receipt signature and that the raised ceiling is covered; it does not judge whether 4131 is the right number. Reviewers decide that.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

Production-Delta: +0/-0

- Base `origin/main` SHA: `5a7fc71d`
- Branch merge-base with `origin/main`: `5a7fc71d`
- Last `git fetch origin` time: 2026-08-19, immediately before creating the worktree
- Sync method: branch created directly from `origin/main`
- Public diff command: `git diff --stat origin/main...HEAD`
- Private evidence commit/path: decision package `harness/decisions/decision-dec_FA1A0041BFD0FFC3D981A2ADC4/`
- Reviewer evidence path: same decision package; claims C1 and C2 are anchored to Facts `F-5116B515` and `F-3B68FDD6` on the milestone root task
- GitHub Actions `rewrite-ci` run URL: pending, to be filled once the run reports
- [x] `git diff --check` — clean
- [x] `node tools/gates/line-budget.mjs --base origin/main` — pass, daemon 2131/4131
- [x] `npm run check:local` — passed, fast tier
- [x] Receipt signature verified by recomputing the HMAC over the canonical payload
- [ ] `npm ci` — not run locally; the worktree seeded `node_modules` by APFS clone
- [ ] GitHub Actions `rewrite-ci` passed — pending

Production-Delta is `+0/-0` because `tools/**` is not a production path under `module-policy`; the whole diff is gate configuration.

## Review Evidence

Two claims were checked against the source rather than assumed:
- `daemon` is not in `INITIAL_MODULE_CEILINGS` (`tools/gates/line-budget.mjs:54`), so its ceiling is raisable by receipt; the four modules that are in that table are capped by a design limit no receipt can lift (`:76-77`).
- `hasBudgetReceipt` (`:87`) accepts any receipt whose `limit >= ceiling`, which is why the superseded 2160 file is deleted rather than kept.

The new receipt's signature was produced with the same canonical-payload HMAC the verifier uses; the method was validated beforehand by recomputing an existing receipt's signature and matching it byte for byte.

## Residual Risk

Raising the ceiling removes a standing pressure to delete. The decision states explicitly that it does not relax deleting superseded production paths, one-implementation-per-capability, or architecture conformance — but nothing mechanical enforces that distinction, so the risk is that daemon simply grows into the new headroom. The next structural review of daemon should read 4131 as budget, not as target.

`agent-runtime` remains capped at its 520 design limit, which no receipt can raise. Waves that add to that module will hit a hard wall and must come back for a fresh judgement rather than editing the gate source.

All receipts in this repository, including the new one, expire on `2027-08-31`. That is a scheduled red for every module at once, not a property of this change; it is noted here because this PR adds one more file to that cliff.

---

# 中文

## 摘要

`daemon` 模块在 `main` 上是 2131/2160,占满 98%,而 PLT-AgentRuntime-Native 剩下的每一波都要往它加生产代码。本 PR 依据决策 `dec_FA1A0041BFD0FFC3D981A2ADC4` 把上限抬到 4131,并用一份签名的 4131 receipt 取代原先的 2160。

## 变更内容

- `tools/gates/test/line-budget.test.mjs`:把 `DECISION_INPUT_LINES` 里的 `daemon` 从 1660 重新测量为 2131。ceiling 不是自由参数,它等于 `measured + headroomFor(measured)`,而 daemon 已长过 2000 行这道 tier 边界——headroom 从 500 档进入 2000 档。
- `tools/gates/line-budgets.json`:`daemon` ceiling 由 2160 改为 4131,正是 tier 规则现在派生出的值。
- 新增 `tools/gates/receipts/line-budget-daemon-4131.json`,签名对应 `scope: module:daemon`、`limit: 4131`,expiry 沿用其余 receipt 的 `2027-08-31`。
- 删除被其取代的 `tools/gates/receipts/line-budget-daemon-2160.json`:`hasBudgetReceipt` 只需要一份 `limit >= ceiling` 的 receipt,两份并存会留下一个死文件。

## 任务与范围

- 依据决策:`dec_FA1A0041BFD0FFC3D981A2ADC4`(已 in_effect)
- Milestone:PLT-AgentRuntime-Native,root `task_63d9b4d05dc5d39addca53d75b`
- 分支:`codex/daemon-ceiling-4131`
- 公开范围:仅 `tools/gates/line-budgets.json` 与 `tools/gates/receipts/`
- 私有规划/证据已更新:是
- 不在范围内:不改任何模块边界、不动 `INITIAL_MODULE_CEILINGS` 设计上限、不移动任何生产代码。

## 版本影响

- 版本:无变更;仅门配置。
- 发布影响:不发布

## 治理声明

- 触碰受保护面:是——`tools/gates/line-budgets.json` 与 receipt 目录是 G32 的执法面。
- 受保护面范围:仅 `daemon` 这一条 ceiling 及其 receipt;不触碰其他模块的 ceiling,也不改门源码。
- 授权:`dec_FA1A0041BFD0FFC3D981A2ADC4`,由仓库所有者于 2026-08-19 亲裁,理由是 daemon 的复杂度是真实的而非偶然堆积。
- 机器校验边界:G32 校验 receipt 签名以及抬升后的 ceiling 是否被覆盖;它不判断 4131 这个数字是否合适,那由评审者判断。
- Break-glass:否
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- Base `origin/main` SHA:`5a7fc71d`
- 分支与 `origin/main` 的 merge-base:`5a7fc71d`
- 最近一次 `git fetch origin` 时间:2026-08-19,建 worktree 前
- 同步方式:分支直接从 `origin/main` 建出
- 公开 diff 命令:`git diff --stat origin/main...HEAD`
- 私有证据 commit/路径:决策包 `harness/decisions/decision-dec_FA1A0041BFD0FFC3D981A2ADC4/`
- 评审证据路径:同一决策包;claim C1、C2 已锚到 milestone root task 上的 Fact `F-5116B515` 与 `F-3B68FDD6`
- GitHub Actions `rewrite-ci` run URL:待 run 报告后回填
- [x] `git diff --check` — 干净
- [x] `node tools/gates/line-budget.mjs --base origin/main` — pass,daemon 2131/4131
- [x] `npm run check:local` — 通过,fast tier
- [x] receipt 签名已通过对规范化 payload 重算 HMAC 验证
- [ ] `npm ci` — 未本地执行;worktree 的 `node_modules` 由 APFS clone 播种
- [ ] GitHub Actions `rewrite-ci` 通过 — 待定

Production-Delta 为 `+0/-0`,因为 `tools/**` 在 `module-policy` 下不算生产路径;整个 diff 都是门配置。

## 评审证据

两条断言是对着源码核的,不是假定的:
- `daemon` 不在 `INITIAL_MODULE_CEILINGS`(`tools/gates/line-budget.mjs:54`)中,故其 ceiling 可由 receipt 抬升;而在该表内的四个模块受 design limit 约束,任何 receipt 都抬不动(`:76-77`)。
- `hasBudgetReceipt`(`:87`)接受任何 `limit >= ceiling` 的 receipt,这正是被取代的 2160 文件应当删除而非保留的原因。

新 receipt 的签名用的是校验器所用的同一套规范化 payload HMAC;签发方法事先已通过重算一份既有 receipt 的签名并逐字比对验证过。

## 残余风险

抬高上限会移除一道持续存在的删除压力。决策正文已明确它不放松「删除被替代的生产路径」「同一能力只允许一个生产实现」「架构一致性」这三条,但没有任何机制去执行这个区分,因此风险是 daemon 就此长进新的余量里。下一次对 daemon 的结构性评审应当把 4131 读作预算,而不是目标。

`agent-runtime` 仍被其 520 的 design limit 封顶,任何 receipt 都抬不动。往该模块加代码的波次会撞上硬墙,届时必须回来重新判断,而不是顺手改门源码。

本仓所有 receipt(含新增这份)都在 `2027-08-31` 过期。那是一个对所有模块同时生效的定时红,不是本次变更引入的性质;在此记录只是因为本 PR 又往那道悬崖上多放了一个文件。
