### PR TITLE
fix(daemon,cli): admission compares process build id vs dist, never source mtimes

### DIFF
--- a/packages/cli/scripts/copy-assets.mjs
+++ b/packages/cli/scripts/copy-assets.mjs
@@ -1,4 +1,5 @@
-import { cpSync, existsSync, rmSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { cpSync, existsSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -8,3 +9,4 @@ if (existsSync(staleAssets)) rmSync(staleAssets, { recursive: true, force: true 
 const bundledPresetAssets = path.resolve(packageRoot, "../preset/assets"), publishedPresetAssets = path.join(packageRoot, "dist/preset/assets");
 if (existsSync(publishedPresetAssets)) rmSync(publishedPresetAssets, { recursive: true, force: true });
 cpSync(bundledPresetAssets, publishedPresetAssets, { recursive: true });
+writeFileSync(path.join(packageRoot, "dist/build-id.txt"), `${randomUUID()}\n`, "utf8");

--- a/packages/daemon/src/runtime-admission.ts
+++ b/packages/daemon/src/runtime-admission.ts
@@ -1,48 +1,44 @@
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defaultLifecycleTaskProjectionPath, readTaskProjectionSchemaVersion, taskProjectionSchemaVersion } from "../../kernel/src/index.ts";
 
-export const runtimeAdmissionRecheckMs = 5_000;
 export interface DaemonRuntimeAdmissionGuard { readonly assert: (rootDir: string, force?: boolean) => void }
+interface RuntimeBuildBaseline { readonly markerPath: string; readonly loadedBuildId: string | null }
+const runtimeBuildIdFilename = "build-id.txt", schemaAdmissionRecheckMs = 5_000, defaultRuntimeFile = fileURLToPath(import.meta.url), processBuildBaseline = runtimeBuildBaseline(defaultRuntimeFile);
 
 export class DaemonAdmissionError extends Error {
   readonly code: "daemon_build_stale" | "kernel_schema_mismatch";
   constructor(code: "daemon_build_stale" | "kernel_schema_mismatch", message: string) { super(message); this.name = "DaemonAdmissionError"; this.code = code; }
 }
 
-export function assertDaemonRuntimeAdmitted(rootDir: string, runtimeFile = fileURLToPath(import.meta.url)): void {
-  const stale = staleDistFiles(runtimeFile);
-  if (stale.length > 0) throw new DaemonAdmissionError("daemon_build_stale", `daemon build is behind source for ${stale.slice(0, 3).join(", ")}${stale.length > 3 ? ` and ${stale.length - 3} more files` : ""}; stop the resident daemon, run npm run build -w @harness-anything/cli, then restart.`);
+export function makeDaemonRuntimeAdmissionGuard(options: { readonly runtimeFile?: string; readonly nowMs?: () => number; readonly schemaRecheckMs?: number } = {}): DaemonRuntimeAdmissionGuard {
+  const build = options.runtimeFile ? runtimeBuildBaseline(options.runtimeFile) : processBuildBaseline, nowMs = options.nowMs ?? Date.now, recheckMs = options.schemaRecheckMs ?? schemaAdmissionRecheckMs;
+  let schemaAdmittedAt = Number.NEGATIVE_INFINITY;
+  return { assert: (rootDir, force = false) => { assertCurrentProcessBuild(build); const observedAt = nowMs(); if (!force && observedAt >= schemaAdmittedAt && observedAt - schemaAdmittedAt < recheckMs) return; assertProjectionSchema(rootDir); schemaAdmittedAt = observedAt; } };
+}
+
+function runtimeBuildBaseline(runtimeFile: string): RuntimeBuildBaseline | null {
+  if (path.extname(runtimeFile) !== ".js") return null;
+  const distRoot = path.resolve(path.dirname(runtimeFile), "../..");
+  if (path.basename(distRoot) !== "dist") return null;
+  const markerPath = path.join(distRoot, runtimeBuildIdFilename);
+  return { markerPath, loadedBuildId: readBuildId(markerPath) };
+}
+
+function assertCurrentProcessBuild(baseline: RuntimeBuildBaseline | null): void {
+  if (baseline === null) return;
+  const currentBuildId = readBuildId(baseline.markerPath);
+  if (baseline.loadedBuildId === null || currentBuildId !== baseline.loadedBuildId) throw new DaemonAdmissionError("daemon_build_stale", `daemon process loaded dist build ${baseline.loadedBuildId ?? "without a build id"}, but current dist build is ${currentBuildId ?? "missing"}; finish npm run build -w @harness-anything/cli, then stop and restart the resident daemon before retrying.`);
+}
+
+function assertProjectionSchema(rootDir: string): void {
   const projectionPath = defaultLifecycleTaskProjectionPath(rootDir), observed = readTaskProjectionSchemaVersion(projectionPath);
   if (observed !== null && observed !== taskProjectionSchemaVersion) throw new DaemonAdmissionError("kernel_schema_mismatch", `kernel projection schema ${observed} does not match daemon schema ${taskProjectionSchemaVersion}; stop the daemon, remove ${projectionPath}, then restart so the projection is rebuilt.`);
 }
 
-export function makeDaemonRuntimeAdmissionGuard(options: { readonly runtimeFile?: string; readonly nowMs?: () => number; readonly recheckMs?: number } = {}): DaemonRuntimeAdmissionGuard {
-  const runtimeFile = options.runtimeFile ?? fileURLToPath(import.meta.url), nowMs = options.nowMs ?? Date.now, recheckMs = options.recheckMs ?? runtimeAdmissionRecheckMs;
-  let admittedAt = Number.NEGATIVE_INFINITY;
-  return { assert: (rootDir, force = false) => { const observedAt = nowMs(); if (!force && observedAt >= admittedAt && observedAt - admittedAt < recheckMs) return; assertDaemonRuntimeAdmitted(rootDir, runtimeFile); admittedAt = observedAt; } };
-}
-
-export function staleDistFiles(runtimeFile: string): readonly string[] {
-  const marker = `${path.sep}packages${path.sep}cli${path.sep}dist${path.sep}`;
-  const markerAt = runtimeFile.indexOf(marker);
-  if (markerAt < 0) return [];
-  const workspaceRoot = runtimeFile.slice(0, markerAt), distRoot = path.join(workspaceRoot, "packages", "cli", "dist"), stale: string[] = [];
-  for (const output of walkJs(distRoot)) {
-    const source = path.join(workspaceRoot, "packages", path.relative(distRoot, output).replace(/\.js$/u, ".ts"));
-    if (existsSync(source) && statSync(source).mtimeMs > statSync(output).mtimeMs) stale.push(path.relative(workspaceRoot, source));
-  }
-  return stale.sort();
-}
-
-function walkJs(directory: string): readonly string[] {
-  if (!existsSync(directory)) return [];
-  const files: string[] = [];
-  for (const entry of readdirSync(directory, { withFileTypes: true }).sort((left, right) => left.name.localeCompare(right.name))) {
-    const target = path.join(directory, entry.name);
-    if (entry.isDirectory()) files.push(...walkJs(target));
-    else if (entry.isFile() && entry.name.endsWith(".js")) files.push(target);
-  }
-  return files;
+function readBuildId(markerPath: string): string | null {
+  if (!existsSync(markerPath)) return null;
+  const value = readFileSync(markerPath, "utf8").trim();
+  return value || null;
 }

--- a/packages/daemon/test/daemon-host-recovery.test.ts
+++ b/packages/daemon/test/daemon-host-recovery.test.ts
@@ -10,7 +10,6 @@ import { makeTaskProjection, registerDaemonRepo } from "../../kernel/src/index.t
 import { openDaemonHost } from "../src/daemon-host.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { openRepoCell } from "../src/repo-cell.ts";
-import { staleDistFiles } from "../src/runtime-admission.ts";
 
 const auth = { transportKind: "unix-socket", unixSocketOwnerBoundary: { ownerUid: process.getuid?.() ?? 0, source: "unix-socket-filesystem-owner-boundary" } } as const;
 
@@ -84,33 +83,36 @@ test("repository modes close local, center-assignment, and edge command families
   } finally { await host.close(); rmSync(parent, { recursive: true, force: true }); }
 });
 
-test("resident admission rechecks emitted preset output and projection schema before later writes", async () => {
-  const parent = mkdtempSync(path.join(tmpdir(), "ha-resident-admission-")), rootDir = path.join(parent, "repo"), runtimeRoot = path.join(parent, "runtime");
-  const source = path.join(runtimeRoot, "packages/preset/src/example.ts"), output = path.join(runtimeRoot, "packages/cli/dist/preset/src/example.js"), runtimeFile = path.join(runtimeRoot, "packages/cli/dist/daemon/src/runtime-admission.js");
-  let clock = "2026-08-18T00:00:00.000Z", cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+test("a dist orphan from an old build graph does not reject the resident daemon", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-dist-orphan-admission-")), rootDir = path.join(parent, "repo"), runtimeRoot = path.join(parent, "runtime"), runtimeFile = builtRuntime(runtimeRoot, "build-a");
+  const source = path.join(runtimeRoot, "packages/application/src/record.ts"), orphan = path.join(runtimeRoot, "packages/cli/dist/application/src/record.js"); let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   try {
-    rosterRepo(rootDir, "resident-admission");
-    for (const file of [source, output, runtimeFile]) { mkdirSync(path.dirname(file), { recursive: true }); writeFileSync(file, `${path.basename(file)}\n`); }
-    const initial = Date.parse(clock) / 1_000; utimesSync(source, initial, initial); utimesSync(output, initial, initial);
-    cell = await openRepoCell({ repoId: workspaceId("resident-admission"), rootDir: canonicalRoot(rootDir), ownerId: "resident-admission", now: () => clock, runtimeFile });
-    clock = "2026-08-18T00:00:06.000Z"; const stale = Date.parse(clock) / 1_000; utimesSync(source, stale, stale);
-    const buildBlocked = await cell.run({ kind: "task-create", taskId: "task_build_blocked", title: "Blocked by build" }, { actor: { principal: { personId: "writer" }, executor: null }, source: "local" });
-    assert.equal(buildBlocked.outcome, "op_rejected"); assert.equal(buildBlocked.code, "daemon_build_stale"); assert.equal(cell.status().state, "unavailable");
-    clock = "2026-08-18T00:00:12.000Z"; const rebuilt = Date.parse(clock) / 1_000; utimesSync(output, rebuilt, rebuilt);
-    assert.equal((await cell.run({ kind: "task-create", taskId: "task_after_build", title: "After build" }, { actor: { principal: { personId: "writer" }, executor: null }, source: "local" })).outcome, "applied");
-    clock = "2026-08-18T00:00:18.000Z"; const presetStale = Date.parse(clock) / 1_000; utimesSync(source, presetStale, presetStale);
-    const presetBlocked = await cell.presetRun({ kind: "preset-run-start" }, { actor: { principal: { personId: "writer" }, executor: null }, source: "local" }); assert.equal(presetBlocked.outcome, "op_rejected"); assert.equal(presetBlocked.code, "daemon_build_stale");
-    clock = "2026-08-18T00:00:24.000Z"; const presetRebuilt = Date.parse(clock) / 1_000; utimesSync(output, presetRebuilt, presetRebuilt);
-    assert.equal((await cell.run({ kind: "task-create", taskId: "task_after_preset_build", title: "After preset build" }, { actor: { principal: { personId: "writer" }, executor: null }, source: "local" })).outcome, "applied");
-    clock = "2026-08-18T00:00:30.000Z"; const spawnStale = Date.parse(clock) / 1_000; utimesSync(source, spawnStale, spawnStale);
-    await assert.rejects(cell.spawnRuntime({}, { actor: { principal: { personId: "writer" }, executor: null }, source: "local" }), (error: unknown) => typeof error === "object" && error !== null && "code" in error && error.code === "daemon_build_stale");
-    clock = "2026-08-18T00:00:36.000Z"; const spawnRebuilt = Date.parse(clock) / 1_000; utimesSync(output, spawnRebuilt, spawnRebuilt);
-    assert.equal((await cell.run({ kind: "task-create", taskId: "task_after_spawn_build", title: "After spawn build" }, { actor: { principal: { personId: "writer" }, executor: null }, source: "local" })).outcome, "applied");
-    const cache = path.join(rootDir, ".harness/cache/task.sqlite"), db = new DatabaseSync(cache); db.exec("UPDATE projection_meta SET schema_version = 999 WHERE singleton = 1;"); db.close(); clock = "2026-08-18T00:00:42.000Z";
-    const schemaBlocked = await cell.run({ kind: "task-create", taskId: "task_schema_blocked", title: "Blocked by schema" }, { actor: { principal: { personId: "writer" }, executor: null }, source: "local" });
-    assert.equal(schemaBlocked.outcome, "op_rejected"); assert.equal(schemaBlocked.code, "kernel_schema_mismatch"); assert.equal(cell.status().state, "unavailable");
-    const repaired = new DatabaseSync(cache); repaired.exec("UPDATE projection_meta SET schema_version = 2 WHERE singleton = 1;"); repaired.close(); clock = "2026-08-18T00:00:48.000Z";
-    assert.equal((await cell.run({ kind: "task-create", taskId: "task_after_schema", title: "After schema" }, { actor: { principal: { personId: "writer" }, executor: null }, source: "local" })).outcome, "applied");
+    rosterRepo(rootDir, "dist-orphan-admission"); for (const file of [source, orphan]) { mkdirSync(path.dirname(file), { recursive: true }); writeFileSync(file, `${path.basename(file)}\n`); }
+    const old = Date.now() / 1_000 - 10, current = old + 5; utimesSync(orphan, old, old); utimesSync(source, current, current);
+    cell = await openRepoCell({ repoId: workspaceId("dist-orphan-admission"), rootDir: canonicalRoot(rootDir), ownerId: "dist-orphan-admission", runtimeFile });
+    assert.equal((await cell.run({ kind: "task-create", taskId: "task_dist_orphan", title: "Dist orphan" }, writerBinding)).outcome, "applied");
+  } finally { await cell?.close(); rmSync(parent, { recursive: true, force: true }); }
+});
+
+test("an uncommitted canonical source edit does not reject the unchanged daemon process", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-dirty-source-admission-")), rootDir = path.join(parent, "repo"), runtimeRoot = path.join(parent, "runtime"), runtimeFile = builtRuntime(runtimeRoot, "build-a");
+  const source = path.join(runtimeRoot, "packages/cli/src/cli/thin-command.ts"), output = path.join(runtimeRoot, "packages/cli/dist/cli/src/cli/thin-command.js"); let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    rosterRepo(rootDir, "dirty-source-admission"); for (const file of [source, output]) { mkdirSync(path.dirname(file), { recursive: true }); writeFileSync(file, `${path.basename(file)}\n`); }
+    const old = Date.now() / 1_000 - 10, current = old + 5; utimesSync(output, old, old); utimesSync(source, current, current);
+    cell = await openRepoCell({ repoId: workspaceId("dirty-source-admission"), rootDir: canonicalRoot(rootDir), ownerId: "dirty-source-admission", runtimeFile });
+    assert.equal((await cell.run({ kind: "task-create", taskId: "task_dirty_source", title: "Dirty source" }, writerBinding)).outcome, "applied");
+  } finally { await cell?.close(); rmSync(parent, { recursive: true, force: true }); }
+});
+
+test("a dist rebuild after process start rejects writes until the daemon restarts", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-rebuilt-dist-admission-")), rootDir = path.join(parent, "repo"), runtimeRoot = path.join(parent, "runtime"), runtimeFile = builtRuntime(runtimeRoot, "build-a"), buildId = path.join(runtimeRoot, "packages/cli/dist/build-id.txt"); let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    rosterRepo(rootDir, "rebuilt-dist-admission"); cell = await openRepoCell({ repoId: workspaceId("rebuilt-dist-admission"), rootDir: canonicalRoot(rootDir), ownerId: "rebuilt-dist-admission", runtimeFile });
+    assert.equal((await cell.run({ kind: "task-create", taskId: "task_before_rebuild", title: "Before rebuild" }, writerBinding)).outcome, "applied");
+    writeFileSync(buildId, "build-b\n");
+    const rejected = await cell.run({ kind: "task-create", taskId: "task_after_rebuild", title: "After rebuild" }, writerBinding);
+    assert.equal(rejected.outcome, "op_rejected"); assert.equal(rejected.code, "daemon_build_stale"); assert.equal(cell.status().state, "unavailable");
   } finally { await cell?.close(); rmSync(parent, { recursive: true, force: true }); }
 });
 
@@ -153,26 +155,17 @@ test("daemon admission rejects a mismatched kernel projection schema and recover
   } finally { await host.close(); rmSync(parent, { recursive: true, force: true }); }
 });
 
-test("built-daemon admission compares only sources represented by emitted dist files", () => {
-  const parent = mkdtempSync(path.join(tmpdir(), "ha-dist-admission-")), runtime = path.join(parent, "packages/cli/dist/daemon/src/runtime-admission.js");
-  const staleSource = path.join(parent, "packages/kernel/src/stale.ts"), staleOutput = path.join(parent, "packages/cli/dist/kernel/src/stale.js");
-  const equalSource = path.join(parent, "packages/daemon/src/equal.ts"), equalOutput = path.join(parent, "packages/cli/dist/daemon/src/equal.js");
-  const missingOutputSource = path.join(parent, "packages/kernel/src/not-emitted.ts"), outsideBuildSource = path.join(parent, "packages/application/src/record.ts");
-  try {
-    for (const file of [runtime, staleSource, staleOutput, equalSource, equalOutput, missingOutputSource, outsideBuildSource]) { mkdirSync(path.dirname(file), { recursive: true }); writeFileSync(file, `${path.basename(file)}\n`); }
-    const old = Date.now() / 1_000 - 10, current = old + 5;
-    utimesSync(staleOutput, old, old); utimesSync(staleSource, current, current);
-    utimesSync(equalOutput, current, current); utimesSync(equalSource, current, current);
-    assert.deepEqual(staleDistFiles(runtime), ["packages/kernel/src/stale.ts"]);
-  }
-  finally { rmSync(parent, { recursive: true, force: true }); }
-});
-
 function systemRow(host: Awaited<ReturnType<typeof openDaemonHost>>, repoId: string): Record<string, unknown> {
   const system = host.system(auth) as { readonly repos: readonly Record<string, unknown>[] };
   const row = system.repos.find((repo) => repo.repoId === repoId);
   assert.ok(row, `gui-system-status must list ${repoId}`);
   return row;
+}
+const writerBinding = { actor: { principal: { personId: "writer" }, executor: null }, source: "local" as const };
+function builtRuntime(runtimeRoot: string, buildId: string): string {
+  const runtimeFile = path.join(runtimeRoot, "packages/cli/dist/daemon/src/runtime-admission.js"), marker = path.join(runtimeRoot, "packages/cli/dist/build-id.txt");
+  for (const [file, body] of [[runtimeFile, "runtime\n"], [marker, `${buildId}\n`]] as const) { mkdirSync(path.dirname(file), { recursive: true }); writeFileSync(file, body); }
+  return runtimeFile;
 }
 function rosterRepo(rootDir: string, repoId: string): void {
   mkdirSync(rootDir, { recursive: true });


### PR DESCRIPTION
# English

## Summary
Redesigns the M1-B version-admission axis after two production misfires tonight proved "source mtime vs dist mtime" is the wrong comparison:
1. Orphaned dist files (emitted by older builds, no longer in the tsc graph) made the reverse-map judge repos permanently stale — a clean rebuild removed the files and proved them orphans.
2. Any session editing a source file uncommitted in the canonical root instantly bricked all 5 repos, although the running daemon's code had not changed at all.

The real drift to prevent is "dist rebuilt while an old daemon keeps serving" (silent stale-process drift). New axis: the CLI build stamps a build id into dist; the daemon snapshots it at startup and refuses writes only when the current dist build id no longer matches its own — i.e. exactly when a restart is actually due. Source files are never consulted; the mtime scanner and emitted-map machinery are deleted outright (net -9 lines including tests).

## Verification
- Regression proof: the two misfire classes are covered by tests that were red before the fix (shard 6: 164/167 pre, 167/167 post).
- Two consecutive CLI builds generate distinct 36-char build ids (restart demand fires on rebuild).
- `npm run check:local` green (95.9s; fast 179/179, contract 421/421).

Production-Delta: +26/-30

## Review Evidence
- Worker (Codex Sol) report with red/green outputs and full deletion ledger: `harness/tasks/task_f72d54e99610e0e851ef7b1acb-plt-center-w1-local-hardening/artifacts/report-w1-sol.md` (r5 section). Incident evidence for both misfires lives in the same task's artifacts and tonight's daemon status logs.

## Residual Risk
- A rebuild that produces byte-identical output still mints a new build id and demands a restart; harmless (restart is the safe direction) and disappears once W1-E lands fast restarts.

## Governance Declaration
- Task: task_f72d54e99610e0e851ef7b1acb (PLT-Center W1 line, r5). Decisions: dec_9E7AC30E811C0D18798DF60F76/CH4.
- No CI/gate authority surfaces touched.

---

# 中文

## 摘要
重设计 M1-B 版本准入的轴——今晚两类生产误伤证明「source mtime vs dist mtime」是错的比较:①dist 孤儿产物让反向映射把仓判成永远 stale(全量重建后文件消失,坐实孤儿);②任何会话在 canonical 根未提交地改一个源文件,5 仓瞬间全拒服务,而运行中 daemon 的代码根本没变。

真正要防的漂移是「dist 被重建而旧 daemon 继续服务」。新轴:构建时把 build id 打进 dist;daemon 启动时快照,仅当当前 dist build id 与自身不一致(=确实该重启)时拒写。source 一概不看;mtime 扫描与 emitted-map 机制整体删除(含测试净删 9 行)。

## 验证
- 回归证据:两类误伤各有修前红、修后绿的测试(shard 6:修前 164/167,修后 167/167)。
- 连续两次构建生成不同 build id(重建即触发重启要求)。
- `npm run check:local` 全绿。

生产增量(见上英文节):+26/-30

## 复核证据
- worker 报告(r5 节)含 red/green 输出与完整删除清单;两类误伤的事故证据在同任务包与今晚 daemon 状态日志。

## 残留风险
- 字节级相同的重复构建也会铸新 build id 并要求重启;方向安全,W1-E 落地快速重启后代价趋零。

## 治理声明
- 任务:task_f72d54e9(W1 线 r5);决策:dec_9E7AC30E/CH4。未触碰 CI/gate 权威面。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
