### PR TITLE
fix(daemon): watch the authored root as one recursive stream on macOS

### DIFF
--- a/packages/daemon/src/doc-sync-watcher.ts
+++ b/packages/daemon/src/doc-sync-watcher.ts
@@ -55,7 +55,20 @@ export function openDocSyncWatcher(input: { readonly rootDir: string; readonly p
     // waits on a semaphore the in-flight callback prevents from ever being signaled).
     watcher.on("error", () => { setImmediate(() => watcher.close()); directories.delete(directory); degradeToPolling(); wake(); }); directories.set(directory, watcher);
     try { for (const entry of readdirSync(directory, { withFileTypes: true })) if (entry.isDirectory()) watchDirectory(path.join(directory, entry.name)); } catch (error) { consumeKnownError(error); } };
-  if (input.watchFilesystem !== false) { watchDirectory(authoredRoot); if (directories.size === 0) state = "blocked"; }
+  // macOS gives every fs.watch handle its own FSEvents stream, and every stream's start and stop is
+  // serialized through one CoreFoundation run loop thread. At authored-root scale — thousands of
+  // directories — an error status on any single handle wedges the whole event loop: Node's own
+  // onchange closes that handle synchronously *before* it emits "error", from inside the in-flight
+  // FSEvents callback, and uv__fsevents_close then waits on a semaphore only that callback can
+  // signal. Deferring the close in a user-level error handler cannot help, because the close Node
+  // already made is the one that blocks. One recursive stream removes the per-directory handles
+  // instead of guarding them. The rename-over blindness documented above is an inotify property;
+  // FSEvents resolves paths, not inodes, so it does not apply here.
+  const watchTree = (): void => { let watcher: FSWatcher;
+    try { watcher = watch(authoredRoot, { recursive: true }, (_event, filename) => { if (filename === null) { wake(); return; } const relative = String(filename); if (relative.split(path.sep).includes(".git")) return; wake(relative); }); }
+    catch (error) { consumeKnownError(error); degradeToPolling(); return; }
+    watcher.on("error", () => { setImmediate(() => watcher.close()); directories.delete(authoredRoot); degradeToPolling(); wake(); }); directories.set(authoredRoot, watcher); };
+  if (input.watchFilesystem !== false) { if (process.platform === "darwin") watchTree(); else watchDirectory(authoredRoot); if (directories.size === 0) state = "blocked"; }
   if (input.startupScan !== false) wake();
   return { wake, overflow: () => wake(), flush: async () => { if (timer) { clearTimeout(timer); timer = null; } enqueue(true); await tail; }, status: () => ({ sessionId, personId: input.personId, state, pendingPaths: [...pending].sort(), lastReceipt, metrics: { ...metrics } }),
     close: async () => { if (state === "closed") return; state = "closed"; if (timer) clearTimeout(timer); timer = null; if (pollTimer) clearInterval(pollTimer); pollTimer = null; for (const watcher of directories.values()) watcher.close(); directories.clear(); await tail; } };


### PR DESCRIPTION
# English

## Summary

Every daemon start on this machine wedged. Four consecutive starts hung with the identical main-thread stack:

```
uv__fsevents_cb -> FSEventWrap::OnEvent -> AsyncWrap::MakeCallback -> <JS>
  -> HandleWrap::Close -> uv_close -> uv_fs_event_stop -> uv__fsevents_close -> uv_sem_wait
```

macOS gives every `fs.watch` handle its own FSEvents stream and serializes every start and stop through a single CoreFoundation run loop thread. Watching each authored directory separately meant **~10,400 handles** across five registered repositories (7,417 of them in this repository alone). An error status on any one of them wedges the entire event loop.

The repair in #1540 cannot prevent this, and that is the part worth stating plainly: Node's own `onchange` calls `this._handle.close()` **synchronously, before** it emits `"error"`. By the time the user-level error handler could defer a close, the close that blocks has already happened. The `setImmediate` there defers a second, harmless close — the deadlock is upstream of it.

One recursive stream removes the per-directory handles instead of guarding them. The rename-over blindness that motivated per-directory watching is an inotify property — FSEvents resolves paths rather than inodes — so Linux keeps the existing walk unchanged.

Production-Delta: +14/-1

## What Changed

- `packages/daemon/src/doc-sync-watcher.ts`: on `darwin`, one `watch(authoredRoot, { recursive: true })` stream replaces the recursive per-directory registration. `.git` paths are filtered in the callback, which is what the per-directory walk did by skipping those directories. Every other platform takes the existing path, untouched.

## Task And Scope

- Harness task: `task_b31b5f0c5e6d5cb9eae9514a89` — Windows follow-up issue wave #1536-#1546 (found while running that wave's own closeout)
- Branch: `fix/macos-recursive-watch`
- Public scope: `packages/daemon`
- Private planning/evidence updated: yes (fact `F-6A858ED8` records the mechanism)
- Out of scope: the Linux watch strategy; the `setImmediate` in the error handler is left in place rather than removed, since it is harmless and this PR is not the place to relitigate #1540.

## Version Impact

- Version: no version change because this changes how an existing watcher registers, not any published contract.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: `c5a003583bd3502b014567e9d8aa647e17c33e14`
- Branch merge-base with `origin/main`: `c5a003583bd3502b014567e9d8aa647e17c33e14`
- Last `git fetch origin` time: 2026-08-19, immediately before branching
- Sync method: none needed (branched from current `origin/main`)
- Public diff command: `git diff c5a003583bd3502b014567e9d8aa647e17c33e14..HEAD`
- Private evidence commit/path: fact `F-6A858ED8` on `task_b31b5f0c5e6d5cb9eae9514a89`
- Reviewer evidence path: the before/after end-to-end result below
- GitHub Actions `rewrite-ci` run URL: see this PR's checks
- [x] `npm run check:local` (fast tier, green)
- [x] `npm run typecheck`
- [x] `node --test packages/daemon/test/doc-sync-watcher.test.ts` (12/12, including the convergence and soak cases)
- [x] `node tools/gates/line-budget.mjs --base origin/main` (pass)
- [x] `node tools/gates/production-delta.mjs --base origin/main` (+14/-1)
- Not run: `npm run check:local -- --full` — the integration tier is authoritative in cloud CI.

## Review Evidence

- **End-to-end, on the affected platform.** Before: four consecutive `ha daemon start --service` attempts, each ending in `daemon_bind_timeout`, each sampled to the identical `uv_sem_wait` stack, with the wedged process holding the singleton lock so the next start could not bind either. After: the daemon bound within 15 seconds, `ha daemon status` reports `pid=89834 repos=5`, and a sample 58 seconds later shows 0% CPU and **zero** `uv__fsevents_close` frames. This is the real evidence for this PR; the unit tests only show nothing else broke.
- Isolated probes that did **not** reproduce, and therefore rule out simpler explanations: deleting a watched directory; calling `fs.watch()` on a nonexistent path from inside a change callback (Node closes that fresh handle synchronously, and it does not deadlock); closing a sibling watcher from inside a callback; closing the watcher itself from inside its own callback. The deadlock needs FSEvents to deliver an error *status*, which is what scale makes likely.
- A first attempt — deferring the recursive `watchDirectory` call out of the change callback — was written, built, and tested end-to-end, did **not** fix the wedge, and was reverted rather than kept.
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none

## Residual Risk

- **CI cannot cover this branch.** `platform-smoke` runs ubuntu and windows; the changed code path only executes on darwin. The evidence above is local and cannot be reproduced by any job in this repository.
- Recursive FSEvents coalesces events differently from per-directory watches. The watcher treats every notification as a hint and reconciles through `wake()`, and the 30s full-scan poll remains the backstop, so a coalesced or missed event costs latency rather than data — but the observed event *volume* under doc-sync will differ from before.
- This does not fix the underlying Node behaviour, only this repository's exposure to it. Any other component that opens many `fs.watch` handles on macOS carries the same deadlock.
- The trigger is scale-dependent, so a smaller workspace would not have shown it.

## References

- Task: `task_b31b5f0c5e6d5cb9eae9514a89`
- Evidence: fact `F-6A858ED8`; the before/after above
- Review: #1540 (the earlier repair this supersedes in effect)

---

# 中文

## 概要

本机每次启动 daemon 都会卡死。连续四次启动，主线程栈完全一致：

```
uv__fsevents_cb -> FSEventWrap::OnEvent -> AsyncWrap::MakeCallback -> <JS>
  -> HandleWrap::Close -> uv_close -> uv_fs_event_stop -> uv__fsevents_close -> uv_sem_wait
```

macOS 上每个 `fs.watch` 句柄各占一条 FSEvents 流，而所有流的启停都被串行到单个 CoreFoundation run loop 线程。按目录逐个监视，意味着五个已注册仓库合计约 **10,400 个句柄**（仅本仓就有 7,417 个）。其中任意一个收到 error 状态，整个事件循环就卡死。

#1540 的修法挡不住这个，这点值得直说：Node 自己的 `onchange` 在 status 为负时会**先同步**调用 `this._handle.close()`，**然后**才 emit `"error"`。等用户层的 error 处理器有机会去 defer 时，真正阻塞的那次 close 早就发生了。那里的 `setImmediate` 推迟的是第二次、无害的 close——死锁在它上游。

改成一条递归流，是把逐目录句柄**删掉**而不是给它加防护。当初促成逐目录监视的 rename-over 失明是 inotify 的性质（FSEvents 解析路径而非 inode），所以 Linux 分支原样保留。

## 改动内容

- `packages/daemon/src/doc-sync-watcher.ts`：`darwin` 上用一条 `watch(authoredRoot, { recursive: true })` 取代递归逐目录注册。`.git` 路径在回调里过滤——这正是原来逐目录走法通过跳过那些目录做到的事。其他平台走原路径，不变。

## 任务与范围

- Harness 任务：`task_b31b5f0c5e6d5cb9eae9514a89` —— Windows follow-up issue wave #1536-#1546（在给这一波收口时撞见）
- 分支：`fix/macos-recursive-watch`
- 公开范围：`packages/daemon`
- 私有计划 / 证据是否已更新：yes（fact `F-6A858ED8` 记录了机制）
- 范围外：Linux 的监视策略；error 处理器里那个 `setImmediate` 保留不删——它无害，本 PR 也不是重新审判 #1540 的地方。

## 版本影响

- 版本：不改版本，原因是本 PR 只改既有 watcher 的注册方式，不动任何已发布契约。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无

## 验证

- `origin/main` 基准 SHA：`c5a003583bd3502b014567e9d8aa647e17c33e14`
- 当前分支与 `origin/main` 的 merge-base：`c5a003583bd3502b014567e9d8aa647e17c33e14`
- 最近一次 `git fetch origin` 时间：2026-08-19，建分支前刚拉
- 同步方式：不需要（直接从当前 `origin/main` 建分支）
- 公开 diff 命令：`git diff c5a003583bd3502b014567e9d8aa647e17c33e14..HEAD`
- 私有证据 commit/path：`task_b31b5f0c5e6d5cb9eae9514a89` 上的 fact `F-6A858ED8`
- Reviewer 证据路径：下方的前后对比
- GitHub Actions `rewrite-ci` run URL：见本 PR 的 checks
- [x] `npm run check:local`（fast tier，全绿）
- [x] `npm run typecheck`
- [x] `node --test packages/daemon/test/doc-sync-watcher.test.ts`（12/12，含收敛与并发 soak）
- [x] `node tools/gates/line-budget.mjs --base origin/main`（pass）
- [x] `node tools/gates/production-delta.mjs --base origin/main`（+14/-1）
- 未运行：`npm run check:local -- --full` —— integration tier 以云端 CI 为权威。

## 审查证据

- **端到端，就在受影响的平台上。** 修复前：连续四次 `ha daemon start --service` 全部 `daemon_bind_timeout`，每次采样都是同一条 `uv_sem_wait` 栈，且卡死进程占着单例锁，导致下一次启动同样绑不上。修复后：daemon 15 秒内绑定，`ha daemon status` 报 `pid=89834 repos=5`，58 秒后再采样为 0% CPU、`uv__fsevents_close` 帧数为 **0**。这才是本 PR 的实证；单测只说明别的没被弄坏。
- 未能复现、因而排除掉的更简单解释：删除被监视目录；在 change 回调里对不存在路径调用 `fs.watch()`（Node 会同步关掉那个新句柄，但不死锁）；在回调里关闭兄弟 watcher；在回调里关闭自己。死锁需要 FSEvents 真的投递一个 error **状态**，而规模正是让它变得大概率的原因。
- 第一版尝试——把递归 `watchDirectory` 调用移出 change 回调——已写好、构建并端到端验证，**没能**解卡，于是撤回而不是留着。
- Reviewer subagent：无
- 人工审查：待办
- 阻塞发现：无

## 残余风险

- **CI 覆盖不到这个分支。** `platform-smoke` 只跑 ubuntu 和 windows，而改动的代码路径只在 darwin 执行。上面的证据是本地的，本仓任何 job 都复现不了。
- 递归 FSEvents 的事件合并方式与逐目录监视不同。watcher 把每个通知都当作提示、经 `wake()` 对账，30 秒全量扫描兜底仍在，所以合并或漏掉一个事件代价是延迟而非数据——但 doc-sync 观察到的事件**量级**会与此前不同。
- 这不修 Node 本身的行为，只是消掉本仓对它的暴露。任何在 macOS 上开大量 `fs.watch` 句柄的组件都带着同一个死锁。
- 触发条件与规模相关，小工作区不会暴露它。

## 关联材料

- 任务：`task_b31b5f0c5e6d5cb9eae9514a89`
- 证据：fact `F-6A858ED8`；上方前后对比
- 审查：#1540（本 PR 在效果上取代的那次修复）
