### PR TITLE
feat(cli,daemon): single-flight autostart and lifecycle-aware startup progress (W1-E ⑤⑥)

### DIFF
--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -8,7 +8,7 @@ export { daemonIdFromEnv, daemonUserRoot, localUserDaemonEndpoint, resolveLocalD
   type LocalDaemonTarget } from "../../../daemon/src/client/local-daemon-target.ts";
 export type { DaemonLaunchSpec } from "../../../daemon/src/client/daemon-autostart.ts";
 
-const autostartFailureCodes = ["daemon_spawn_not_found", "daemon_spawn_permission", "daemon_start_failed", "daemon_bind_timeout"] as const;
+const autostartFailureCodes = ["daemon_spawn_not_found", "daemon_spawn_permission", "daemon_start_failed", "daemon_bind_timeout", "daemon_starting"] as const;
 export function daemonServeEntry(): string { return realpathSync(fileURLToPath(new URL(import.meta.url.endsWith(".js") ? "../index.js" : "../index.ts", import.meta.url))); }
 export function cliDaemonServeLaunch(userRoot: string, daemonId: string, execPath = process.execPath): DaemonLaunchSpec {
   return { command: execPath, args: [daemonServeEntry(), "daemon", "serve", "--user-root", userRoot, "--daemon-id", daemonId], env: process.env };
@@ -22,7 +22,7 @@ async function withAutostart(request: () => Promise<JsonObject>, launch: () => D
     if (!autostart) throw error;
     const { DaemonAutostartError, ensureLocalDaemonRunning, isDaemonUnreachable } = await import("../../../daemon/src/client/daemon-autostart.ts");
     if (!isDaemonUnreachable(error)) throw error;
-    const started = await ensureLocalDaemonRunning({ socketPath, launch });
+    const started = await ensureLocalDaemonRunning({ socketPath, launch, onProgress: (progress) => process.stderr.write(`${progress.message}\n`) });
     if (!started.ok) throw new DaemonAutostartError(started);
     return await request();
   }
@@ -37,10 +37,18 @@ export async function runCommandThroughDaemon(command: ThinCommand, onPhase: (re
   const target = resolveLocalDaemonTarget({ rootDir: command.rootDir, repoIdOverride: command.repoId });
   const { kind: _kind, ...actionPayload } = command.action, payload = command.method === "repo.script.run" ? Object.fromEntries(Object.entries(actionPayload).filter(([field, value]) => field !== "schema" && (field !== "taskId" || value !== null))) : actionPayload, executor = declaredExecutor();
   const requestPayload = command.method === "repo.task.run" ? { action: executor ? { ...command.action, executor } : command.action } : executor && !["repo.agentRuntime.cancel", "repo.agentRuntime.overview", "repo.agentRuntime.sessions.read", "repo.agentRuntime.events.read", "repo.runtimeInstance.auth.login", "repo.runtimeInstance.auth.reauth", "repo.runtimeInstance.auth.logout"].includes(command.method) ? { ...payload, executor } : payload;
-  let result = await withAutostart(() => requestLocalDaemonJsonRpcForTarget(target, command.method, { repo: { repoId: target.repoId }, payload: requestPayload as JsonObject }, 75, readResponseDeadlineMs(command.action.kind)), () => cliDaemonServeLaunch(target.userRoot, target.daemonId), target.socketPath, autostart);
+  const request = () => requestLocalDaemonJsonRpcForTarget(target, command.method, { repo: { repoId: target.repoId }, payload: requestPayload as JsonObject }, 75, readResponseDeadlineMs(command.action.kind));
+  let result = await withAutostart(request, () => cliDaemonServeLaunch(target.userRoot, target.daemonId), target.socketPath, autostart);
+  result = await settleRepoWarming(result, request, target.userRoot, target.daemonId);
   if (command.action.kind !== "preset-run-start") return result; let observed = 0;
   for (;;) { const phases = Array.isArray(result.phases) ? result.phases.filter((phase): phase is string => typeof phase === "string") : []; for (const phase of phases.slice(observed)) onPhase({ ...result, ok: !["op_rejected", "failed", "outcome_unknown"].includes(phase), command: "preset-run-start", summary: `preset-run-start: ${phase}` }); observed = phases.length; if (["applied", "op_rejected", "failed", "outcome_unknown"].includes(String(result.outcome))) { const ok = result.outcome === "applied"; return { ...result, ok, command: "preset-run-start", summary: `preset-run-start: ${String(result.phase)}`, ...(!ok ? { error: { code: result.code ?? "preset_run_failed", hint: result.nextAction ?? "Inspect the run receipt." } } : {}) }; } await new Promise((resolve) => setTimeout(resolve, 20)); try { result = await requestLocalDaemonJsonRpcForTarget(target, "repo.preset.run.status", { repo: { repoId: target.repoId }, payload: { runId: result.runId } }, 75); } catch (error) { consumeKnownError(error); result = { ...result, outcome: "outcome_unknown", phase: "outcome_unknown", phases: [...phases, "outcome_unknown"], code: "daemon_disconnect", nextAction: "Reconnect and inspect status; do not automatically retry." }; } }
 }
+async function settleRepoWarming(initial: JsonObject, request: () => Promise<JsonObject>, userRoot: string, daemonId: string): Promise<JsonObject> {
+  if (!isRepoWarming(initial)) return initial; const { readDaemonStartProgress } = await import("../../../daemon/src/client/daemon-autostart.ts"), launch = cliDaemonServeLaunch(userRoot, daemonId), startedAt = Date.now(), deadline = startedAt + 60_000; let result = initial, reported = "";
+  while (isRepoWarming(result) && Date.now() < deadline) { const progress = readDaemonStartProgress(launch, Date.now() - startedAt); if (progress) { const key = `${progress.fingerprint}:${Math.floor((Date.now() - startedAt) / 1_000)}`; if (key !== reported) { reported = key; process.stderr.write(`${progress.message}\n`); } } await new Promise((resolve) => setTimeout(resolve, 250)); result = await request(); }
+  return result;
+}
+function isRepoWarming(result: JsonObject): boolean { const error = result.error && typeof result.error === "object" && !Array.isArray(result.error) ? result.error as JsonObject : null; return result.code === "repo_warming" || error?.code === "repo_warming"; }
 export async function streamRuntimeThroughDaemon(command: ThinCommand, runtimeSessionId: string, onValue: (value: unknown) => void): Promise<() => void> { const target = resolveLocalDaemonTarget({ rootDir: command.rootDir, repoIdOverride: command.repoId }), { streamAgentRuntimeAt } = await import("../../../daemon/src/client/local-json-rpc-stream.ts"); return streamAgentRuntimeAt({ socketPath: target.socketPath, repoId: target.repoId, payload: { runtimeSessionId, afterCursor: "stream:0" }, onValue, timeoutMs: 2_000 }); }
 // The sign-in relay stays lazy for the same reason the autostart seam does: the thin dist static
 // import graph stays entry/parser/transport-only, and the tty bridge only loads for an

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -28,7 +28,7 @@ async function withAutostart(request: () => Promise<JsonObject>, launch: () => D
   }
 }
 export async function runCommandThroughDaemon(command: ThinCommand, onPhase: (receipt: JsonObject) => void = () => undefined, options: { readonly autostart?: boolean } = {}): Promise<JsonObject> {
-  const { requestLocalDaemonJsonRpcForTarget } = await import("../../../daemon/src/client/local-json-rpc-client.ts"), autostart = options.autostart !== false;
+  const { requestLocalDaemonJsonRpcForTarget } = await import("../../../daemon/src/client/local-json-rpc-client.ts"), autostart = options.autostart ?? command.action.kind !== "receipt-show";
   if (command.action.kind === "repo-bootstrap") { const userRoot = daemonUserRoot(), daemonId = daemonIdFromEnv(), { kind: _kind, ...params } = command.action, socketPath = localUserDaemonEndpoint(userRoot, daemonId); return withAutostart(() => requestLocalDaemonJsonRpcForTarget({ repoId: workspaceId("bootstrap"),
     canonicalRoot: canonicalRoot(command.rootDir, true), userRoot, daemonId, socketPath }, "daemon.repo.bootstrap", { rootDir: command.rootDir, ...params }, 75), () => cliDaemonServeLaunch(userRoot, daemonId), socketPath, autostart); }
   if (command.method.startsWith("daemon.runtimeInstance.")) { const userRoot = daemonUserRoot(), daemonId = daemonIdFromEnv(), { kind: _kind, ...payload } = command.action, socketPath = localUserDaemonEndpoint(userRoot, daemonId); return withAutostart(() => requestLocalDaemonJsonRpcForTarget({ userRoot, daemonId, socketPath }, command.method, { payload: payload as JsonObject }, 75), () => cliDaemonServeLaunch(userRoot, daemonId), socketPath, autostart); }

--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -29,7 +29,7 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
       const started = await ensureLocalDaemonRunning({ socketPath: localUserDaemonEndpoint(userRoot, daemonId), launch: () => cliDaemonServeLaunch(userRoot, daemonId), onProgress: (progress) => process.stderr.write(`${progress.message}\n`) });
       return started.ok ? finish(await status(userRoot, daemonId), 0) : finish(daemonFailure("daemon-start", started.code ?? "daemon_start_failed", started.hint), 1); }
     if (command === "status") { const receipt = await status(userRoot, daemonId); return finish(receipt, 0); }
-    if (command === "stop") { const pid = readDaemonPid(userRoot, daemonId); if (pid === null) return finish(daemonFailure("daemon-stop", "daemon_unavailable", "No daemon is running."), 1); terminateProcess(pid); return finish({ ok: true, command: "daemon-stop", pid }, 0); }
+    if (command === "stop") { const pid = readDaemonPid(userRoot, daemonId); if (pid === null) return finish(daemonFailure("daemon-stop", "daemon_unavailable", "No daemon is running."), 1); terminateProcess(pid); const stopped = await waitForDaemonStop(userRoot, daemonId); return stopped ? finish({ ok: true, command: "daemon-stop", pid }, 0) : finish(daemonFailure("daemon-stop", "daemon_stop_timeout", `Daemon pid ${pid} did not finish stopping within 5s; inspect its lifecycle log before sending another signal.`), 1); }
     return finish(daemonFailure("daemon", "unsupported_command", "Use daemon repo register|unregister, fleet center start, fleet edge sync, start --service, status, or stop."), 2);
   } catch (error) { return finish(daemonFailure(`daemon-${command ?? "unknown"}`, code(error), message(error)), 1); }
 }
@@ -65,6 +65,7 @@ function deferredServeReceipt(incumbent: { readonly pid: number | null; readonly
   return { ok: true, command: "daemon-serve", outcome: "deferred", incumbent: { pid: incumbent.pid, endpoint: incumbent.endpoint }, summary: `daemon serve deferred: ${witness}; this process did not bind the socket or take any workspace writer lock.`, nextAction: "Use the resident daemon (ha daemon status) or stop it first (ha daemon stop)." };
 }
 async function status(userRoot: string, daemonId: string): Promise<Record<string, unknown>> { return requestDaemonJsonRpcAt(localUserDaemonEndpoint(userRoot, daemonId), "daemon.status", {}, 75) as Promise<Record<string, unknown>>; }
+async function waitForDaemonStop(userRoot: string, daemonId: string): Promise<boolean> { const endpoint = localUserDaemonEndpoint(userRoot, daemonId); for (const deadline = Date.now() + 5_000; Date.now() < deadline;) { if (readDaemonPid(userRoot, daemonId) === null && !existsSync(endpoint)) return true; await new Promise((resolve) => setTimeout(resolve, 10)); } return false; }
 function daemonOption(argv: readonly string[], name: string): string | undefined { const at = argv.indexOf(name); return at < 0 ? undefined : argv[at + 1]; }
 function daemonFailure(command: string, errorCode: string, nextAction: string): Record<string, unknown> { return { schema: "command-receipt/v2", ok: false,
   command, outcome: "op_rejected", opId: "N/A", origin: "cli", code: errorCode, evidence: `rejection:${errorCode}`,

--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -26,7 +26,7 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
     if (command === "serve") return serve(userRoot, daemonId, finish);
     if (command === "start") { if (!argv.includes("--service")) return finish(daemonFailure("daemon-start", "service_required", "Use `ha daemon start --service` to start the resident daemon; other CLI commands start it on demand."), 2);
       const running = await status(userRoot, daemonId).catch(() => null); if (running?.ok === true) return finish(running, 0);
-      const started = await ensureLocalDaemonRunning({ socketPath: localUserDaemonEndpoint(userRoot, daemonId), launch: () => cliDaemonServeLaunch(userRoot, daemonId) });
+      const started = await ensureLocalDaemonRunning({ socketPath: localUserDaemonEndpoint(userRoot, daemonId), launch: () => cliDaemonServeLaunch(userRoot, daemonId), onProgress: (progress) => process.stderr.write(`${progress.message}\n`) });
       return started.ok ? finish(await status(userRoot, daemonId), 0) : finish(daemonFailure("daemon-start", started.code ?? "daemon_start_failed", started.hint), 1); }
     if (command === "status") { const receipt = await status(userRoot, daemonId); return finish(receipt, 0); }
     if (command === "stop") { const pid = readDaemonPid(userRoot, daemonId); if (pid === null) return finish(daemonFailure("daemon-stop", "daemon_unavailable", "No daemon is running."), 1); terminateProcess(pid); return finish({ ok: true, command: "daemon-stop", pid }, 0); }

--- a/packages/cli/test/daemon-autostart-cli.test.ts
+++ b/packages/cli/test/daemon-autostart-cli.test.ts
@@ -8,7 +8,7 @@ import test from "node:test";
 import { localUserDaemonEndpoint } from "../../daemon/src/client/local-daemon-target.ts";
 import { readDaemonLifecycleRecords } from "../../daemon/src/lifecycle-log.ts";
 import { readDaemonPid } from "../../daemon/src/runtime.ts";
-import { makeTaskEventStore, REPLAY_TASK_GRAPH, taskLifecycleWritePlan, type TaskEventV1 } from "../../kernel/src/index.ts";
+import { makeTaskEventStore, registerDaemonRepo, REPLAY_TASK_GRAPH, taskLifecycleWritePlan, type TaskEventV1 } from "../../kernel/src/index.ts";
 
 const cli = path.resolve("packages/cli/src/index.ts");
 
@@ -39,6 +39,16 @@ test("registered workspace CLI command auto-starts the daemon, retries, and succ
     assert.ok(generationStart >= 0 && bound > generationStart && attach > bound, "the resident socket must bind before the cold registry starts attaching");
     assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "stop"]).ok, true);
   } finally { rmSync(fixture.parent, { recursive: true, force: true }); }
+});
+
+test("receipt show diagnoses a missing daemon without starting one", () => {
+  const fixture = setup();
+  try {
+    registerDaemonRepo({ canonicalRoot: fixture.root, repoId: "diagnostic", userRoot: fixture.userRoot, createConvenienceLinks: false });
+    const result = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "receipt", "show", "op-missing"], { encoding: "utf8", env: cliEnv(fixture.root, fixture.userRoot) });
+    assert.notEqual(result.status, 0); const receipt = JSON.parse(result.stdout) as { error: { code: string } };
+    assert.equal(receipt.error.code, "daemon_unavailable"); assert.equal(readDaemonPid(fixture.userRoot, "default"), null, "a diagnostic read must not autostart the daemon");
+  } finally { stop(fixture.root, fixture.userRoot); rmSync(fixture.parent, { recursive: true, force: true }); }
 });
 
 test("semantic sources and agent execution cross the daemon before transport-bound human review completes", () => {
@@ -126,22 +136,22 @@ test("dry-run contract migration prints each manual task once", () => {
   }
 });
 
-test("autostart gives up after two attempts with a classified bind-timeout error", { skip: process.platform === "win32" || process.getuid?.() === 0 ? "requires POSIX non-root permission semantics" : false }, () => {
+test("autostart fails fast when its single-flight lock cannot be created", { skip: process.platform === "win32" || process.getuid?.() === 0 ? "requires POSIX non-root permission semantics" : false }, () => {
   const fixture = setup();
   try {
     assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
     register(fixture.root, fixture.userRoot, "autostart-fail");
     assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "stop"]).ok, true);
     waitForDaemonDown(fixture.userRoot);
-    // A read-only user root makes every spawned `daemon serve` die on its pid write,
-    // so the autostart loop exhausts its two attempts and reports why.
+    // The lock is the first mutating step. A read-only user root must fail there
+    // with the permission cause instead of spawning or waiting for a bind timeout.
     chmodSync(fixture.userRoot, 0o555);
     const result = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "task", "list"], { encoding: "utf8", env: cliEnv(fixture.root, fixture.userRoot) });
     assert.notEqual(result.status, 0);
     const receipt = JSON.parse(result.stdout) as { ok: boolean; error: { code: string; hint: string } };
     assert.equal(receipt.ok, false);
-    assert.equal(receipt.error.code, "daemon_bind_timeout");
-    assert.match(receipt.error.hint, /did not accept connections/u);
+    assert.equal(receipt.error.code, "daemon_spawn_permission");
+    assert.match(receipt.error.hint, /permission was denied/u);
     assert.match(receipt.error.hint, /daemon serve/u);
     assert.equal(readDaemonPid(fixture.userRoot, "default"), null, "no daemon may claim to be resident after failed starts");
   } finally { chmodSync(fixture.userRoot, 0o755); rmSync(fixture.parent, { recursive: true, force: true }); }

--- a/packages/cli/test/daemon-autostart-cli.test.ts
+++ b/packages/cli/test/daemon-autostart-cli.test.ts
@@ -24,7 +24,7 @@ test("registered workspace CLI command auto-starts the daemon, retries, and succ
     assert.equal(run(fixture.root, fixture.userRoot, ["task", "list"]).outcome, "applied");
     assert.equal(readDaemonPid(fixture.userRoot, "default"), previousPid, "a reachable daemon must not be replaced by a second spawn");
     assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "stop"]).ok, true);
-    waitForDaemonDown(fixture.userRoot);
+    assert.equal(readDaemonPid(fixture.userRoot, "default"), null); assert.equal(existsSync(localUserDaemonEndpoint(fixture.userRoot, "default")), false, "stop receipt settles only after pid and socket are gone");
     const lifecycle = readDaemonLifecycleRecords(fixture.userRoot, "default");
     assert.equal(lifecycle.some((record) => record.event === "process_start"), true);
     assert.equal(lifecycle.some((record) => record.event === "socket_bound"), true);

--- a/packages/cli/test/daemon-autostart-cli.test.ts
+++ b/packages/cli/test/daemon-autostart-cli.test.ts
@@ -1,12 +1,13 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
 import { hostname, tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { localUserDaemonEndpoint } from "../../daemon/src/client/local-daemon-target.ts";
-import { readDaemonLifecycleRecords } from "../../daemon/src/lifecycle-log.ts";
+import { openDaemonLifecycleLog, readDaemonLifecycleRecords } from "../../daemon/src/lifecycle-log.ts";
 import { readDaemonPid } from "../../daemon/src/runtime.ts";
 import { makeTaskEventStore, registerDaemonRepo, REPLAY_TASK_GRAPH, taskLifecycleWritePlan, type TaskEventV1 } from "../../kernel/src/index.ts";
 
@@ -49,6 +50,19 @@ test("receipt show diagnoses a missing daemon without starting one", () => {
     assert.notEqual(result.status, 0); const receipt = JSON.parse(result.stdout) as { error: { code: string } };
     assert.equal(receipt.error.code, "daemon_unavailable"); assert.equal(readDaemonPid(fixture.userRoot, "default"), null, "a diagnostic read must not autostart the daemon");
   } finally { stop(fixture.root, fixture.userRoot); rmSync(fixture.parent, { recursive: true, force: true }); }
+});
+
+test("CLI reports lifecycle attach progress and waits through a slow warming repository", async () => {
+  const fixture = setup(), repoId = "slow-warming", socketPath = localUserDaemonEndpoint(fixture.userRoot, "default"), lifecycle = openDaemonLifecycleLog({ userRoot: fixture.userRoot, daemonId: "default" });
+  registerDaemonRepo({ canonicalRoot: fixture.root, repoId, userRoot: fixture.userRoot, createConvenienceLinks: false }); lifecycle.record({ event: "process_start", endpoint: socketPath }); lifecycle.record({ event: "socket_bound", endpoint: socketPath }); lifecycle.record({ event: "repo_attach_started", repoId, attachIndex: 2, attachTotal: 5 });
+  let attached = false, requests = 0; const server = createServer((socket) => { let buffered = ""; socket.on("data", (chunk) => { buffered += String(chunk); for (;;) { const newline = buffered.indexOf("\n"); if (newline < 0) break; const line = buffered.slice(0, newline); buffered = buffered.slice(newline + 1); const request = JSON.parse(line) as { id: number; method: string }; requests += request.method === "protocol.hello" ? 0 : 1; const result = request.method === "protocol.hello" ? { protocolVersion: 1 } : attached ? { schema: "command-receipt/v2", ok: true, command: "task-list", outcome: "applied", summary: "task list: 0" } : { schema: "command-receipt/v2", ok: false, command: "task-list", outcome: "op_rejected", code: "repo_warming", nextAction: "wait for attach" }; socket.write(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result })}\n`); } }); });
+  try {
+    await new Promise<void>((resolve, reject) => { server.once("error", reject); server.listen(socketPath, resolve); });
+    const completing = setTimeout(() => { attached = true; lifecycle.record({ event: "repo_attach_completed", repoId, attachIndex: 2, attachTotal: 5, durationMs: 1_000 }); }, 1_000);
+    const result = await spawnCli(fixture.root, fixture.userRoot, ["task", "list"]); clearTimeout(completing);
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`); assert.equal((JSON.parse(result.stdout) as { outcome: string }).outcome, "applied"); assert.ok(requests >= 2, "the original command must retry after the warming receipt");
+    assert.match(result.stderr, /daemon is starting; waited \d+s \(repo 2\/5: slow-warming\)/u);
+  } finally { await new Promise<void>((resolve) => server.close(() => resolve())); rmSync(fixture.parent, { recursive: true, force: true }); }
 });
 
 test("semantic sources and agent execution cross the daemon before transport-bound human review completes", () => {
@@ -179,3 +193,4 @@ function seedLegacyTask(root: string, repoId: string, taskId: string): void {
   const actor = { principal: { personId: "owner" }, executor: null } as const, event: TaskEventV1 = { schema: "task-event/v1", eventId: "event-contract-receipt", workspaceRevision: 1, opId: "op-contract-receipt", taskId, type: "task_created", actor, source: "local", occurredAt: "2026-08-18T00:00:00.000Z", payload: { task: { schema: "task/v1", taskId, title: "Legacy contract receipt", taskClass: "standard", status: "planned", graph: REPLAY_TASK_GRAPH, currentNode: "implementation", iteration: 0, createdBy: actor, completionGateIds: [], presetSnapshotDigest: null } } };
   makeTaskEventStore({ repoId, rootDir: root }).append({ event, plan: taskLifecycleWritePlan(event), blobs: [] });
 }
+function spawnCli(root: string, userRoot: string, args: readonly string[]): Promise<{ status: number | null; stdout: string; stderr: string }> { return new Promise((resolve) => { const child = spawn(process.execPath, [cli, "--root", root, "--json", ...args], { env: cliEnv(root, userRoot), stdio: ["ignore", "pipe", "pipe"] }); let stdout = "", stderr = ""; child.stdout.setEncoding("utf8").on("data", (chunk) => { stdout += chunk; }); child.stderr.setEncoding("utf8").on("data", (chunk) => { stderr += chunk; }); child.on("close", (status) => resolve({ status, stdout: stdout.trim(), stderr: stderr.trim() })); }); }

--- a/packages/daemon/src/client/daemon-autostart.ts
+++ b/packages/daemon/src/client/daemon-autostart.ts
@@ -2,11 +2,12 @@ import net from "node:net";
 import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { consumeKnownError } from "../../../kernel/src/index.ts";
-import { daemonLifecycleLogPath } from "../lifecycle-log.ts";
+import { daemonLifecycleLogPath, readDaemonLifecycleRecords } from "../lifecycle-log.ts";
 import { startDetachedProcessChecked } from "../process-port.ts";
 export interface DaemonLaunchSpec { readonly command: string; readonly args: readonly string[]; readonly env: NodeJS.ProcessEnv }
-export type DaemonAutostartFailureCode = "daemon_spawn_not_found" | "daemon_spawn_permission" | "daemon_start_failed" | "daemon_bind_timeout";
+export type DaemonAutostartFailureCode = "daemon_spawn_not_found" | "daemon_spawn_permission" | "daemon_start_failed" | "daemon_bind_timeout" | "daemon_starting";
 export interface DaemonAutostartResult { readonly ok: boolean; readonly code?: DaemonAutostartFailureCode; readonly hint: string; readonly attempts: number }
+export interface DaemonStartProgress { readonly fingerprint: string; readonly message: string }
 export class DaemonAutostartError extends Error { readonly code: DaemonAutostartFailureCode; readonly attempts: number;
   constructor(result: DaemonAutostartResult) { super(result.hint); this.name = "DaemonAutostartError"; this.code = result.code ?? "daemon_start_failed"; this.attempts = result.attempts; } }
 export function isDaemonUnreachable(error: unknown): boolean {
@@ -15,29 +16,35 @@ export function isDaemonUnreachable(error: unknown): boolean {
 }
 export async function ensureLocalDaemonRunning(input: { readonly socketPath: string; readonly launch: () => DaemonLaunchSpec;
   readonly readyTimeoutMs?: number; readonly probeIntervalMs?: number; readonly probe?: (socketPath: string) => Promise<boolean>;
-  readonly spawnDetached?: (launch: DaemonLaunchSpec) => Promise<void> }): Promise<DaemonAutostartResult> {
+  readonly spawnDetached?: (launch: DaemonLaunchSpec) => Promise<void>; readonly onProgress?: (progress: DaemonStartProgress) => void }): Promise<DaemonAutostartResult> {
   const readyTimeoutMs = input.readyTimeoutMs ?? 10_000, probeIntervalMs = input.probeIntervalMs ?? 50;
   const probe = input.probe ?? daemonSocketProbe, spawnDetached = input.spawnDetached ?? ((launch: DaemonLaunchSpec) => startDetachedProcessChecked(launch.command, launch.args, launch.env, daemonLaunchOutputPath(launch)));
   // A freshly started daemon can die between binding its socket and finishing
   // startup; confirm readiness with a second probe before declaring success.
   const ready = async () => { if (!await probe(input.socketPath)) return false; await delay(probeIntervalMs); return probe(input.socketPath); };
   if (await ready()) return { ok: true, hint: "daemon is reachable", attempts: 0 };
-  let launched: DaemonLaunchSpec | null = null, flight: Awaited<ReturnType<typeof claimAutostartFlight>> | null = null;
+  let launched: DaemonLaunchSpec | null = null, flight: Awaited<ReturnType<typeof claimAutostartFlight>> | null = null, latestProgress: DaemonStartProgress | null = null, reported = "";
   try {
     launched = input.launch(); flight = await claimAutostartFlight(autostartLockPath(launched));
     // The probe belongs inside the claim: another caller may have bound the
     // socket between this process's initial probe and atomic lock creation.
     if (flight.owner && await ready()) return { ok: true, hint: "daemon is reachable", attempts: 0 };
     if (flight.owner) await spawnDetached(launched);
-    for (const deadline = Date.now() + readyTimeoutMs; Date.now() < deadline;) { if (await ready()) return { ok: true, hint: "daemon is reachable", attempts: flight.owner ? 1 : 0 }; await delay(probeIntervalMs); }
+    const startedAt = Date.now(), quietDeadline = startedAt + readyTimeoutMs, progressDeadline = startedAt + readyTimeoutMs * 6;
+    for (;;) { if (await ready()) return { ok: true, hint: "daemon is reachable", attempts: flight.owner ? 1 : 0 }; const progress = readDaemonStartProgress(launched, Date.now() - startedAt); if (progress) { latestProgress = progress; const key = `${progress.fingerprint}:${Math.floor((Date.now() - startedAt) / 1_000)}`; if (key !== reported) { reported = key; input.onProgress?.(progress); } } const deadline = latestProgress ? progressDeadline : quietDeadline; if (Date.now() >= deadline) break; await delay(probeIntervalMs); }
   } catch (error) { return { ok: false, attempts: flight?.owner ? 1 : 0, ...classifySpawnFailure(error, launched) }; }
   finally { flight?.release(); }
-  return { ok: false, code: "daemon_bind_timeout", attempts: flight?.owner ? 1 : 0, hint: `The daemon did not accept connections at ${input.socketPath} within ${readyTimeoutMs}ms after one shared start attempt. Run this command directly to see the daemon's own error output: ${launched ? `${launched.command} ${launched.args.join(" ")}` : "the daemon launcher"}.` };
+  if (latestProgress) return { ok: false, code: "daemon_starting", attempts: flight?.owner ? 1 : 0, hint: `${latestProgress.message}; the daemon is still alive but has not bound ${input.socketPath}. Keep waiting or inspect ${launched ? daemonLaunchOutputPath(launched) : "the lifecycle log"}.` };
+  return { ok: false, code: "daemon_bind_timeout", attempts: flight?.owner ? 1 : 0, hint: `Daemon start failed: no socket appeared at ${input.socketPath} and no live lifecycle progress was observed within ${readyTimeoutMs}ms after one shared start attempt. Inspect ${launched ? daemonLaunchOutputPath(launched) : "the daemon lifecycle log"}.` };
 }
 export function daemonLaunchOutputPath(launch: DaemonLaunchSpec): string | undefined {
-  const daemon = launch.args.indexOf("daemon"), serve = daemon < 0 ? -1 : launch.args.indexOf("serve", daemon + 1), rootAt = launch.args.indexOf("--user-root", serve + 1), idAt = launch.args.indexOf("--daemon-id", serve + 1);
-  if (daemon < 0 || serve !== daemon + 1 || rootAt < 0 || idAt < 0 || !launch.args[rootAt + 1] || !launch.args[idAt + 1]) return undefined;
-  return daemonLifecycleLogPath(path.resolve(launch.args[rootAt + 1]!), launch.args[idAt + 1]!);
+  const target = daemonLaunchTarget(launch); return target ? daemonLifecycleLogPath(target.userRoot, target.daemonId) : undefined;
+}
+export function readDaemonStartProgress(launch: DaemonLaunchSpec, waitedMs: number): DaemonStartProgress | null {
+  const target = daemonLaunchTarget(launch); if (!target) return null; const records = readDaemonLifecycleRecords(target.userRoot, target.daemonId), start = records.findLastIndex((record) => record.event === "process_start"); if (start < 0) return null;
+  const generation = records.slice(start), processRecord = generation[0]!; if (!autostartOwnerAlive(processRecord.pid)) return null;
+  for (let index = generation.length - 1; index >= 0; index -= 1) { const record = generation[index]!; if (record.event !== "repo_attach_started") continue; const settled = generation.slice(index + 1).some((later) => later.repoId === record.repoId && (later.event === "repo_attach_completed" || later.event === "repo_attach_failed")); if (!settled && record.repoId && record.attachIndex && record.attachTotal) return { fingerprint: `${record.at}:${record.event}:${record.repoId}`, message: `daemon is starting; waited ${Math.floor(waitedMs / 1_000)}s (repo ${record.attachIndex}/${record.attachTotal}: ${record.repoId})` }; }
+  const latest = generation.at(-1)!, stage = latest.event === "socket_bound" ? "socket bound; preparing repositories" : latest.attachIndex && latest.attachTotal ? `repository ${latest.attachIndex}/${latest.attachTotal} settled; preparing the next repository` : "initializing before socket bind"; return { fingerprint: `${latest.at}:${latest.event}`, message: `daemon is starting; waited ${Math.floor(waitedMs / 1_000)}s (${stage})` };
 }
 export async function daemonSocketProbe(socketPath: string): Promise<boolean> {
   return new Promise((resolve) => { const socket = net.createConnection(socketPath), finish = (up: boolean) => { socket.destroy(); resolve(up); }; const timer = setTimeout(() => finish(false), 250);
@@ -51,10 +58,9 @@ function classifySpawnFailure(error: unknown, launch: DaemonLaunchSpec | null): 
   return { code: "daemon_start_failed", hint: `Starting the daemon failed: ${detail}. Command: ${command}.` };
 }
 function autostartLockPath(launch: DaemonLaunchSpec): string {
-  const daemon = launch.args.indexOf("daemon"), serve = daemon < 0 ? -1 : launch.args.indexOf("serve", daemon + 1), rootAt = launch.args.indexOf("--user-root", serve + 1), idAt = launch.args.indexOf("--daemon-id", serve + 1), userRoot = launch.args[rootAt + 1], daemonId = launch.args[idAt + 1];
-  if (daemon < 0 || serve !== daemon + 1 || rootAt < 0 || idAt < 0 || !userRoot || !daemonId) throw new Error("daemon launch spec does not declare its --user-root and --daemon-id");
-  return path.join(path.resolve(userRoot), `daemon-${daemonId.replace(/[^A-Za-z0-9_.-]/gu, "-")}.autostart.lock`);
+  const target = daemonLaunchTarget(launch); if (!target) throw new Error("daemon launch spec does not declare its --user-root and --daemon-id"); return path.join(target.userRoot, `daemon-${target.daemonId.replace(/[^A-Za-z0-9_.-]/gu, "-")}.autostart.lock`);
 }
+function daemonLaunchTarget(launch: DaemonLaunchSpec): { readonly userRoot: string; readonly daemonId: string } | null { const daemon = launch.args.indexOf("daemon"), serve = daemon < 0 ? -1 : launch.args.indexOf("serve", daemon + 1), rootAt = launch.args.indexOf("--user-root", serve + 1), idAt = launch.args.indexOf("--daemon-id", serve + 1), userRoot = launch.args[rootAt + 1], daemonId = launch.args[idAt + 1]; return daemon >= 0 && serve === daemon + 1 && rootAt >= 0 && idAt >= 0 && userRoot && daemonId ? { userRoot: path.resolve(userRoot), daemonId } : null; }
 async function claimAutostartFlight(lockPath: string): Promise<{ readonly owner: boolean; readonly release: () => void }> {
   mkdirSync(path.dirname(lockPath), { recursive: true }); const pid = process.pid;
   for (let attempt = 0; attempt < 8; attempt += 1) {

--- a/packages/daemon/src/client/daemon-autostart.ts
+++ b/packages/daemon/src/client/daemon-autostart.ts
@@ -1,5 +1,7 @@
 import net from "node:net";
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { consumeKnownError } from "../../../kernel/src/index.ts";
 import { daemonLifecycleLogPath } from "../lifecycle-log.ts";
 import { startDetachedProcessChecked } from "../process-port.ts";
 export interface DaemonLaunchSpec { readonly command: string; readonly args: readonly string[]; readonly env: NodeJS.ProcessEnv }
@@ -11,23 +13,26 @@ export function isDaemonUnreachable(error: unknown): boolean {
   if (typeof error === "object" && error !== null && "code" in error) { const code = (error as { readonly code?: unknown }).code; if (typeof code === "string") return code === "ECONNREFUSED" || code === "ENOENT" || code === "ETIMEDOUT"; }
   return error instanceof Error && error.message === "daemon_unavailable";
 }
-export async function ensureLocalDaemonRunning(input: { readonly socketPath: string; readonly launch: () => DaemonLaunchSpec; readonly maxAttempts?: number;
-  readonly readyTimeoutMs?: number; readonly retryDelayMs?: number; readonly probeIntervalMs?: number; readonly probe?: (socketPath: string) => Promise<boolean>;
+export async function ensureLocalDaemonRunning(input: { readonly socketPath: string; readonly launch: () => DaemonLaunchSpec;
+  readonly readyTimeoutMs?: number; readonly probeIntervalMs?: number; readonly probe?: (socketPath: string) => Promise<boolean>;
   readonly spawnDetached?: (launch: DaemonLaunchSpec) => Promise<void> }): Promise<DaemonAutostartResult> {
-  const maxAttempts = input.maxAttempts ?? 2, readyTimeoutMs = input.readyTimeoutMs ?? 10_000, retryDelayMs = input.retryDelayMs ?? 500, probeIntervalMs = input.probeIntervalMs ?? 50;
+  const readyTimeoutMs = input.readyTimeoutMs ?? 10_000, probeIntervalMs = input.probeIntervalMs ?? 50;
   const probe = input.probe ?? daemonSocketProbe, spawnDetached = input.spawnDetached ?? ((launch: DaemonLaunchSpec) => startDetachedProcessChecked(launch.command, launch.args, launch.env, daemonLaunchOutputPath(launch)));
   // A freshly started daemon can die between binding its socket and finishing
   // startup; confirm readiness with a second probe before declaring success.
   const ready = async () => { if (!await probe(input.socketPath)) return false; await delay(probeIntervalMs); return probe(input.socketPath); };
-  let launched: DaemonLaunchSpec | null = null;
-  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    if (await ready()) return { ok: true, hint: "daemon is reachable", attempts: attempt };
-    try { launched = input.launch(); await spawnDetached(launched); }
-    catch (error) { return { ok: false, attempts: attempt, ...classifySpawnFailure(error, launched) }; }
-    for (const deadline = Date.now() + readyTimeoutMs; Date.now() < deadline;) { if (await ready()) return { ok: true, hint: "daemon is reachable", attempts: attempt }; await delay(probeIntervalMs); }
-    if (attempt < maxAttempts) await delay(retryDelayMs);
-  }
-  return { ok: false, code: "daemon_bind_timeout", attempts: maxAttempts, hint: `The daemon did not accept connections at ${input.socketPath} within ${readyTimeoutMs}ms per attempt after ${maxAttempts} start attempts. Run this command directly to see the daemon's own error output: ${launched ? `${launched.command} ${launched.args.join(" ")}` : "the daemon launcher"}.` };
+  if (await ready()) return { ok: true, hint: "daemon is reachable", attempts: 0 };
+  let launched: DaemonLaunchSpec | null = null, flight: Awaited<ReturnType<typeof claimAutostartFlight>> | null = null;
+  try {
+    launched = input.launch(); flight = await claimAutostartFlight(autostartLockPath(launched));
+    // The probe belongs inside the claim: another caller may have bound the
+    // socket between this process's initial probe and atomic lock creation.
+    if (flight.owner && await ready()) return { ok: true, hint: "daemon is reachable", attempts: 0 };
+    if (flight.owner) await spawnDetached(launched);
+    for (const deadline = Date.now() + readyTimeoutMs; Date.now() < deadline;) { if (await ready()) return { ok: true, hint: "daemon is reachable", attempts: flight.owner ? 1 : 0 }; await delay(probeIntervalMs); }
+  } catch (error) { return { ok: false, attempts: flight?.owner ? 1 : 0, ...classifySpawnFailure(error, launched) }; }
+  finally { flight?.release(); }
+  return { ok: false, code: "daemon_bind_timeout", attempts: flight?.owner ? 1 : 0, hint: `The daemon did not accept connections at ${input.socketPath} within ${readyTimeoutMs}ms after one shared start attempt. Run this command directly to see the daemon's own error output: ${launched ? `${launched.command} ${launched.args.join(" ")}` : "the daemon launcher"}.` };
 }
 export function daemonLaunchOutputPath(launch: DaemonLaunchSpec): string | undefined {
   const daemon = launch.args.indexOf("daemon"), serve = daemon < 0 ? -1 : launch.args.indexOf("serve", daemon + 1), rootAt = launch.args.indexOf("--user-root", serve + 1), idAt = launch.args.indexOf("--daemon-id", serve + 1);
@@ -45,4 +50,27 @@ function classifySpawnFailure(error: unknown, launch: DaemonLaunchSpec | null): 
   if (code === "EACCES" || code === "EPERM") return { code: "daemon_spawn_permission", hint: `Starting the daemon failed because permission was denied (${code}): ${detail}. Command: ${command}.` };
   return { code: "daemon_start_failed", hint: `Starting the daemon failed: ${detail}. Command: ${command}.` };
 }
+function autostartLockPath(launch: DaemonLaunchSpec): string {
+  const daemon = launch.args.indexOf("daemon"), serve = daemon < 0 ? -1 : launch.args.indexOf("serve", daemon + 1), rootAt = launch.args.indexOf("--user-root", serve + 1), idAt = launch.args.indexOf("--daemon-id", serve + 1), userRoot = launch.args[rootAt + 1], daemonId = launch.args[idAt + 1];
+  if (daemon < 0 || serve !== daemon + 1 || rootAt < 0 || idAt < 0 || !userRoot || !daemonId) throw new Error("daemon launch spec does not declare its --user-root and --daemon-id");
+  return path.join(path.resolve(userRoot), `daemon-${daemonId.replace(/[^A-Za-z0-9_.-]/gu, "-")}.autostart.lock`);
+}
+async function claimAutostartFlight(lockPath: string): Promise<{ readonly owner: boolean; readonly release: () => void }> {
+  mkdirSync(path.dirname(lockPath), { recursive: true }); const pid = process.pid;
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    try { writeFileSync(lockPath, `${pid}\n`, { flag: "wx", mode: 0o600 }); return { owner: true, release: () => releaseAutostartFlight(lockPath, pid) }; }
+    catch (error) {
+      if (!autostartErrorCode(error, "EEXIST")) throw error;
+      consumeKnownError(error);
+      const owner = await settledAutostartOwner(lockPath); if (owner !== null && autostartOwnerAlive(owner)) return { owner: false, release: () => undefined };
+      try { unlinkSync(lockPath); } catch (cleanup) { if (!autostartErrorCode(cleanup, "ENOENT")) throw cleanup; consumeKnownError(cleanup); }
+    }
+  }
+  throw new Error(`daemon autostart lock at ${lockPath} could not be claimed after stale-owner cleanup`);
+}
+function readAutostartOwner(lockPath: string): number | null { try { const value = Number(readFileSync(lockPath, "utf8").trim()); return Number.isInteger(value) && value > 0 ? value : null; } catch (error) { consumeKnownError(error); return null; } }
+async function settledAutostartOwner(lockPath: string): Promise<number | null> { for (let attempt = 0; attempt < 4; attempt += 1) { const owner = readAutostartOwner(lockPath); if (owner !== null) return owner; await delay(5); } return readAutostartOwner(lockPath); }
+function autostartOwnerAlive(pid: number): boolean { try { process.kill(pid, 0); return true; } catch (error) { consumeKnownError(error); return autostartErrorCode(error, "EPERM"); } }
+function releaseAutostartFlight(lockPath: string, pid: number): void { if (readAutostartOwner(lockPath) !== pid) return; try { unlinkSync(lockPath); } catch (error) { if (!autostartErrorCode(error, "ENOENT")) throw error; consumeKnownError(error); } }
+function autostartErrorCode(error: unknown, expected: string): boolean { return typeof error === "object" && error !== null && "code" in error && error.code === expected; }
 function delay(ms: number): Promise<void> { return new Promise((resolve) => setTimeout(resolve, ms)); }

--- a/packages/daemon/src/client/daemon-autostart.ts
+++ b/packages/daemon/src/client/daemon-autostart.ts
@@ -1,7 +1,5 @@
-import net from "node:net";
-import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { consumeKnownError } from "../../../kernel/src/index.ts";
+import { acquireDaemonAutostartFlight, daemonProcessAlive, daemonSocketProbe } from "../daemon-singleton.ts";
 import { daemonLifecycleLogPath, readDaemonLifecycleRecords } from "../lifecycle-log.ts";
 import { startDetachedProcessChecked } from "../process-port.ts";
 export interface DaemonLaunchSpec { readonly command: string; readonly args: readonly string[]; readonly env: NodeJS.ProcessEnv }
@@ -23,9 +21,9 @@ export async function ensureLocalDaemonRunning(input: { readonly socketPath: str
   // startup; confirm readiness with a second probe before declaring success.
   const ready = async () => { if (!await probe(input.socketPath)) return false; await delay(probeIntervalMs); return probe(input.socketPath); };
   if (await ready()) return { ok: true, hint: "daemon is reachable", attempts: 0 };
-  let launched: DaemonLaunchSpec | null = null, flight: Awaited<ReturnType<typeof claimAutostartFlight>> | null = null, latestProgress: DaemonStartProgress | null = null, reported = "";
+  let launched: DaemonLaunchSpec | null = null, flight: Awaited<ReturnType<typeof acquireDaemonAutostartFlight>> | null = null, latestProgress: DaemonStartProgress | null = null, reported = "";
   try {
-    launched = input.launch(); flight = await claimAutostartFlight(autostartLockPath(launched));
+    launched = input.launch(); const target = daemonLaunchTarget(launched); if (!target) throw new Error("daemon launch spec does not declare its --user-root and --daemon-id"); flight = await acquireDaemonAutostartFlight(target);
     // The probe belongs inside the claim: another caller may have bound the
     // socket between this process's initial probe and atomic lock creation.
     if (flight.owner && await ready()) return { ok: true, hint: "daemon is reachable", attempts: 0 };
@@ -42,14 +40,11 @@ export function daemonLaunchOutputPath(launch: DaemonLaunchSpec): string | undef
 }
 export function readDaemonStartProgress(launch: DaemonLaunchSpec, waitedMs: number): DaemonStartProgress | null {
   const target = daemonLaunchTarget(launch); if (!target) return null; const records = readDaemonLifecycleRecords(target.userRoot, target.daemonId), start = records.findLastIndex((record) => record.event === "process_start"); if (start < 0) return null;
-  const generation = records.slice(start), processRecord = generation[0]!; if (!autostartOwnerAlive(processRecord.pid)) return null;
+  const generation = records.slice(start), processRecord = generation[0]!; if (!daemonProcessAlive(processRecord.pid)) return null;
   for (let index = generation.length - 1; index >= 0; index -= 1) { const record = generation[index]!; if (record.event !== "repo_attach_started") continue; const settled = generation.slice(index + 1).some((later) => later.repoId === record.repoId && (later.event === "repo_attach_completed" || later.event === "repo_attach_failed")); if (!settled && record.repoId && record.attachIndex && record.attachTotal) return { fingerprint: `${record.at}:${record.event}:${record.repoId}`, message: `daemon is starting; waited ${Math.floor(waitedMs / 1_000)}s (repo ${record.attachIndex}/${record.attachTotal}: ${record.repoId})` }; }
   const latest = generation.at(-1)!, stage = latest.event === "socket_bound" ? "socket bound; preparing repositories" : latest.attachIndex && latest.attachTotal ? `repository ${latest.attachIndex}/${latest.attachTotal} settled; preparing the next repository` : "initializing before socket bind"; return { fingerprint: `${latest.at}:${latest.event}`, message: `daemon is starting; waited ${Math.floor(waitedMs / 1_000)}s (${stage})` };
 }
-export async function daemonSocketProbe(socketPath: string): Promise<boolean> {
-  return new Promise((resolve) => { const socket = net.createConnection(socketPath), finish = (up: boolean) => { socket.destroy(); resolve(up); }; const timer = setTimeout(() => finish(false), 250);
-    socket.once("connect", () => { clearTimeout(timer); finish(true); }); socket.once("error", () => { clearTimeout(timer); finish(false); }); });
-}
+export { daemonSocketProbe };
 function classifySpawnFailure(error: unknown, launch: DaemonLaunchSpec | null): { readonly code: DaemonAutostartFailureCode; readonly hint: string } {
   const code = typeof error === "object" && error !== null && "code" in error && typeof (error as { readonly code?: unknown }).code === "string" ? (error as { readonly code: string }).code : null;
   const detail = error instanceof Error ? error.message : String(error), command = launch ? `${launch.command} ${launch.args.join(" ")}` : "the daemon launcher";
@@ -57,26 +52,5 @@ function classifySpawnFailure(error: unknown, launch: DaemonLaunchSpec | null): 
   if (code === "EACCES" || code === "EPERM") return { code: "daemon_spawn_permission", hint: `Starting the daemon failed because permission was denied (${code}): ${detail}. Command: ${command}.` };
   return { code: "daemon_start_failed", hint: `Starting the daemon failed: ${detail}. Command: ${command}.` };
 }
-function autostartLockPath(launch: DaemonLaunchSpec): string {
-  const target = daemonLaunchTarget(launch); if (!target) throw new Error("daemon launch spec does not declare its --user-root and --daemon-id"); return path.join(target.userRoot, `daemon-${target.daemonId.replace(/[^A-Za-z0-9_.-]/gu, "-")}.autostart.lock`);
-}
 function daemonLaunchTarget(launch: DaemonLaunchSpec): { readonly userRoot: string; readonly daemonId: string } | null { const daemon = launch.args.indexOf("daemon"), serve = daemon < 0 ? -1 : launch.args.indexOf("serve", daemon + 1), rootAt = launch.args.indexOf("--user-root", serve + 1), idAt = launch.args.indexOf("--daemon-id", serve + 1), userRoot = launch.args[rootAt + 1], daemonId = launch.args[idAt + 1]; return daemon >= 0 && serve === daemon + 1 && rootAt >= 0 && idAt >= 0 && userRoot && daemonId ? { userRoot: path.resolve(userRoot), daemonId } : null; }
-async function claimAutostartFlight(lockPath: string): Promise<{ readonly owner: boolean; readonly release: () => void }> {
-  mkdirSync(path.dirname(lockPath), { recursive: true }); const pid = process.pid;
-  for (let attempt = 0; attempt < 8; attempt += 1) {
-    try { writeFileSync(lockPath, `${pid}\n`, { flag: "wx", mode: 0o600 }); return { owner: true, release: () => releaseAutostartFlight(lockPath, pid) }; }
-    catch (error) {
-      if (!autostartErrorCode(error, "EEXIST")) throw error;
-      consumeKnownError(error);
-      const owner = await settledAutostartOwner(lockPath); if (owner !== null && autostartOwnerAlive(owner)) return { owner: false, release: () => undefined };
-      try { unlinkSync(lockPath); } catch (cleanup) { if (!autostartErrorCode(cleanup, "ENOENT")) throw cleanup; consumeKnownError(cleanup); }
-    }
-  }
-  throw new Error(`daemon autostart lock at ${lockPath} could not be claimed after stale-owner cleanup`);
-}
-function readAutostartOwner(lockPath: string): number | null { try { const value = Number(readFileSync(lockPath, "utf8").trim()); return Number.isInteger(value) && value > 0 ? value : null; } catch (error) { consumeKnownError(error); return null; } }
-async function settledAutostartOwner(lockPath: string): Promise<number | null> { for (let attempt = 0; attempt < 4; attempt += 1) { const owner = readAutostartOwner(lockPath); if (owner !== null) return owner; await delay(5); } return readAutostartOwner(lockPath); }
-function autostartOwnerAlive(pid: number): boolean { try { process.kill(pid, 0); return true; } catch (error) { consumeKnownError(error); return autostartErrorCode(error, "EPERM"); } }
-function releaseAutostartFlight(lockPath: string, pid: number): void { if (readAutostartOwner(lockPath) !== pid) return; try { unlinkSync(lockPath); } catch (error) { if (!autostartErrorCode(error, "ENOENT")) throw error; consumeKnownError(error); } }
-function autostartErrorCode(error: unknown, expected: string): boolean { return typeof error === "object" && error !== null && "code" in error && error.code === expected; }
 function delay(ms: number): Promise<void> { return new Promise((resolve) => setTimeout(resolve, ms)); }

--- a/packages/daemon/src/daemon-singleton.ts
+++ b/packages/daemon/src/daemon-singleton.ts
@@ -1,7 +1,7 @@
+import net from "node:net";
 import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { consumeKnownError } from "../../kernel/src/index.ts";
-import { daemonSocketProbe } from "./client/daemon-autostart.ts";
 
 // The daemon singleton is one process per (userRoot, daemonId). The claim is a
 // pidfile created with O_EXCL (atomic test-and-set): the second serve reads the
@@ -12,7 +12,16 @@ export interface DaemonSingletonIncumbent { readonly claim: "incumbent"; readonl
 export type DaemonSingletonOutcome = DaemonSingletonHeld | DaemonSingletonIncumbent;
 export function daemonPidPath(userRoot: string, daemonId: string): string { return path.join(userRoot, `daemon-${safeRuntimeId(daemonId)}.pid`); }
 export function daemonSingletonLockPath(userRoot: string, daemonId: string): string { return path.join(userRoot, `daemon-${safeRuntimeId(daemonId)}.singleton.lock`); }
+export function daemonAutostartLockPath(userRoot: string, daemonId: string): string { return path.join(userRoot, `daemon-${safeRuntimeId(daemonId)}.autostart.lock`); }
 export function readDaemonPid(userRoot: string, daemonId: string): number | null { return readPidFile(daemonPidPath(userRoot, daemonId)); }
+export async function acquireDaemonAutostartFlight(input: { readonly userRoot: string; readonly daemonId: string; readonly pid?: number }): Promise<{ readonly owner: boolean; readonly release: () => void }> {
+  const pid = input.pid ?? process.pid, lockPath = daemonAutostartLockPath(input.userRoot, input.daemonId); mkdirSync(input.userRoot, { recursive: true });
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    try { writeFileSync(lockPath, `${pid}\n`, { flag: "wx", mode: 0o600 }); return { owner: true, release: () => releaseIfHeld(lockPath, pid) }; }
+    catch (error) { if (!isCode(error, "EEXIST")) throw error; consumeKnownError(error); const owner = await readHolderPid(lockPath); if (owner !== null && processAlive(owner)) return { owner: false, release: () => undefined }; try { unlinkSync(lockPath); } catch (cleanup) { if (!isCode(cleanup, "ENOENT")) throw cleanup; consumeKnownError(cleanup); } }
+  }
+  throw singletonError(`The daemon autostart lock at ${lockPath} could not be claimed after repeated stale-holder replacement.`);
+}
 export async function acquireDaemonSingleton(input: { readonly userRoot: string; readonly daemonId: string; readonly endpoint: string; readonly pid?: number; readonly probe?: (socketPath: string) => Promise<boolean> }): Promise<DaemonSingletonOutcome> {
   const pid = input.pid ?? process.pid, probe = input.probe ?? daemonSocketProbe, lockPath = daemonSingletonLockPath(input.userRoot, input.daemonId);
   mkdirSync(input.userRoot, { recursive: true });
@@ -48,6 +57,11 @@ function readPidFile(target: string): number | null {
 }
 function releaseIfHeld(lockPath: string, pid: number): void { if (readPidFile(lockPath) === pid) try { unlinkSync(lockPath); } catch (error) { if (!isCode(error, "ENOENT")) throw error; consumeKnownError(error); } }
 function processAlive(pid: number): boolean { try { process.kill(pid, 0); return true; } catch (error) { if (!isCode(error, "EPERM")) consumeKnownError(error); return isCode(error, "EPERM"); } }
+export function daemonProcessAlive(pid: number): boolean { return processAlive(pid); }
+export async function daemonSocketProbe(socketPath: string): Promise<boolean> {
+  return new Promise((resolve) => { const socket = net.createConnection(socketPath), finish = (up: boolean) => { socket.destroy(); resolve(up); }; const timer = setTimeout(() => finish(false), 250);
+    socket.once("connect", () => { clearTimeout(timer); finish(true); }); socket.once("error", () => { clearTimeout(timer); finish(false); }); });
+}
 function isCode(error: unknown, code: string): boolean { return typeof error === "object" && error !== null && "code" in error && (error as { readonly code?: unknown }).code === code; }
 function singletonError(text: string): Error { const error = new Error(text) as Error & { code: string }; error.code = "daemon_singleton_lock_failed"; return error; }
 function safeRuntimeId(value: string): string { return value.replace(/[^A-Za-z0-9_.-]/gu, "-"); }

--- a/packages/daemon/test/daemon-autostart.test.ts
+++ b/packages/daemon/test/daemon-autostart.test.ts
@@ -12,17 +12,27 @@ function coded(code: string): Error & { code: string } { const error = Object.as
 const launch = (): DaemonLaunchSpec => ({ command: "node", args: ["index.ts", "daemon", "serve", "--user-root", "/tmp/ha-user", "--daemon-id", "default"], env: {} });
 
 test("unreachable daemon is started once and the ready socket is used without a second attempt", async () => {
-  const launches: DaemonLaunchSpec[] = [];
-  const result = await ensureLocalDaemonRunning({ socketPath: "/tmp/ha-autostart.sock", launch: () => { const spec = launch(); launches.push(spec); return spec; },
-    probe: async () => launches.length > 0, spawnDetached: async () => undefined, probeIntervalMs: 1, retryDelayMs: 1, readyTimeoutMs: 50 });
-  assert.equal(result.ok, true); assert.equal(result.attempts, 1); assert.equal(launches.length, 1);
+  let spawns = 0;
+  const result = await ensureLocalDaemonRunning({ socketPath: "/tmp/ha-autostart.sock", launch,
+    probe: async () => spawns > 0, spawnDetached: async () => { spawns += 1; }, probeIntervalMs: 1, readyTimeoutMs: 50 });
+  assert.equal(result.ok, true); assert.equal(result.attempts, 1); assert.equal(spawns, 1);
 });
 
-test("two failed start attempts stop retrying and classify the failure as a bind timeout", async () => {
+test("concurrent callers share one autostart flight and wait for the same socket", async () => {
+  const userRoot = mkdtempSync(path.join(tmpdir(), "ha-autostart-flight-")); let spawns = 0, reachable = false;
+  const sharedLaunch = (): DaemonLaunchSpec => ({ command: "node", args: ["index.ts", "daemon", "serve", "--user-root", userRoot, "--daemon-id", "default"], env: {} });
+  try {
+    const results = await Promise.all(Array.from({ length: 12 }, () => ensureLocalDaemonRunning({ socketPath: path.join(userRoot, "daemon.sock"), launch: sharedLaunch,
+      probe: async () => reachable, spawnDetached: async () => { spawns += 1; await new Promise((resolve) => setTimeout(resolve, 20)); reachable = true; }, probeIntervalMs: 1, readyTimeoutMs: 100 })));
+    assert.equal(results.every((result) => result.ok), true); assert.equal(spawns, 1, "one CLI owns the launch; every concurrent follower only waits");
+  } finally { rmSync(userRoot, { recursive: true, force: true }); }
+});
+
+test("one failed start attempt stops without spawning a second daemon", async () => {
   let spawns = 0;
   const result = await ensureLocalDaemonRunning({ socketPath: "/tmp/ha-autostart-timeout.sock", launch, probe: async () => false,
-    spawnDetached: async () => { spawns += 1; }, probeIntervalMs: 1, retryDelayMs: 1, readyTimeoutMs: 5 });
-  assert.equal(result.ok, false); assert.equal(result.code, "daemon_bind_timeout"); assert.equal(result.attempts, 2); assert.equal(spawns, 2);
+    spawnDetached: async () => { spawns += 1; }, probeIntervalMs: 1, readyTimeoutMs: 5 });
+  assert.equal(result.ok, false); assert.equal(result.code, "daemon_bind_timeout"); assert.equal(result.attempts, 1); assert.equal(spawns, 1);
   assert.match(result.hint, /did not accept connections/u); assert.match(result.hint, /\/tmp\/ha-autostart-timeout\.sock/u); assert.match(result.hint, /node index\.ts daemon serve/u);
 });
 

--- a/packages/daemon/test/daemon-autostart.test.ts
+++ b/packages/daemon/test/daemon-autostart.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { DaemonAutostartError, daemonLaunchOutputPath, ensureLocalDaemonRunning, isDaemonUnreachable, type DaemonAutostartResult, type DaemonLaunchSpec } from "../src/client/daemon-autostart.ts";
-import { daemonLifecycleLogPath } from "../src/lifecycle-log.ts";
+import { daemonLifecycleLogPath, openDaemonLifecycleLog } from "../src/lifecycle-log.ts";
 import { startDetachedProcessChecked } from "../src/process-port.ts";
 
 function coded(code: string): Error & { code: string } { const error = Object.assign(new Error(`connect ${code}`), { code }); return error; }
@@ -33,7 +33,16 @@ test("one failed start attempt stops without spawning a second daemon", async ()
   const result = await ensureLocalDaemonRunning({ socketPath: "/tmp/ha-autostart-timeout.sock", launch, probe: async () => false,
     spawnDetached: async () => { spawns += 1; }, probeIntervalMs: 1, readyTimeoutMs: 5 });
   assert.equal(result.ok, false); assert.equal(result.code, "daemon_bind_timeout"); assert.equal(result.attempts, 1); assert.equal(spawns, 1);
-  assert.match(result.hint, /did not accept connections/u); assert.match(result.hint, /\/tmp\/ha-autostart-timeout\.sock/u); assert.match(result.hint, /node index\.ts daemon serve/u);
+  assert.match(result.hint, /Daemon start failed/u); assert.match(result.hint, /\/tmp\/ha-autostart-timeout\.sock/u); assert.doesNotMatch(result.hint, /did not accept connections/u);
+});
+
+test("a live process with lifecycle attach progress reports starting instead of bind timeout", async () => {
+  const userRoot = mkdtempSync(path.join(tmpdir(), "ha-autostart-progress-")), progress: string[] = [], spec = (): DaemonLaunchSpec => ({ command: "node", args: ["index.ts", "daemon", "serve", "--user-root", userRoot, "--daemon-id", "progress"], env: {} });
+  try {
+    const result = await ensureLocalDaemonRunning({ socketPath: path.join(userRoot, "daemon.sock"), launch: spec, probe: async () => false, probeIntervalMs: 1, readyTimeoutMs: 5,
+      spawnDetached: async () => { const log = openDaemonLifecycleLog({ userRoot, daemonId: "progress" }); log.record({ event: "process_start" }); log.record({ event: "repo_attach_started", repoId: "repo-c", attachIndex: 3, attachTotal: 5 }); }, onProgress: (entry) => progress.push(entry.message) });
+    assert.equal(result.ok, false); assert.equal(result.code, "daemon_starting"); assert.match(result.hint, /repo 3\/5: repo-c/u); assert.doesNotMatch(result.hint, /bind_timeout|did not accept connections/u); assert.equal(progress.some((message) => /waited 0s \(repo 3\/5: repo-c\)/u.test(message)), true);
+  } finally { rmSync(userRoot, { recursive: true, force: true }); }
 });
 
 test("a launcher that is missing fails fast as daemon_spawn_not_found without a second attempt", async () => {

--- a/packages/gui/test/daemon-autostart-bridge.test.ts
+++ b/packages/gui/test/daemon-autostart-bridge.test.ts
@@ -47,7 +47,7 @@ test("GUI bridge auto-starts an unreachable daemon, retries the read, and reache
   }
 });
 
-test("GUI bridge reports a classified error after two failed autostart attempts", { skip: process.platform === "win32" || process.getuid?.() === 0 ? "requires POSIX non-root permission semantics" : false }, async () => {
+test("GUI bridge reports the single-flight lock permission failure without spawning", { skip: process.platform === "win32" || process.getuid?.() === 0 ? "requires POSIX non-root permission semantics" : false }, async () => {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-gui-autostart-fail-")), rootDir = path.join(parent, "repo"), userRoot = path.join(parent, "user"), daemonId = "gui-autostart-fail";
   const previous = process.env.HARNESS_DAEMON_USER_ROOT, previousId = process.env.HARNESS_DAEMON_ID;
   process.env.HARNESS_DAEMON_USER_ROOT = userRoot; process.env.HARNESS_DAEMON_ID = daemonId;
@@ -57,8 +57,9 @@ test("GUI bridge reports a classified error after two failed autostart attempts"
     await daemon.stop();
     chmodSync(userRoot, 0o555);
     const failure = await createLocalGuiServiceBridge(rootDir).invoke("getTasks", { repoId: "gui-autostart-fail" }) as Failure;
-    assert.equal(failure.ok, false); assert.equal(failure.error?.code, "daemon_bind_timeout");
-    assert.match(failure.error?.hint ?? "", /did not accept connections/u);
+    assert.equal(failure.ok, false); assert.equal(failure.error?.code, "daemon_spawn_permission");
+    assert.match(failure.error?.hint ?? "", /permission was denied/u);
+    assert.equal(readDaemonPid(userRoot, daemonId), null, "the permission failure must happen before any daemon spawn");
   } finally {
     process.env.HARNESS_DAEMON_USER_ROOT = previous; process.env.HARNESS_DAEMON_ID = previousId;
     chmodSync(userRoot, 0o755); await daemon.stop().catch(() => undefined); rmSync(parent, { recursive: true, force: true });


### PR DESCRIPTION
# English

## Summary

Completes the W1-E availability line (items ⑤⑥ after #1555's ①–④): the CLI side of daemon cold start.

- **Single-flight autostart**: concurrent CLI commands against one user-root spawn at most one daemon (atomic lock ownership); the rest wait on the socket. Diagnostic commands (`daemon status` / `stop`) no longer trigger autostart, so observing the daemon can no longer pollute the scene being observed (the incident night reached load 72 from stacked autostarts).
- **Lifecycle-aware wait window**: while the daemon is warming, the CLI reads the new lifecycle log and reports "starting, waited Ns (repo x/y)" instead of a fixed 2×10s window that misread slow starts as dead (`daemon_bind_timeout`). Starting and failed are now distinct outcomes; a slow cold rebuild is no longer killed by diagnosis.
- **Bonus closure**: `daemon stop` now settles — it returns success only after the PID and socket are both gone, fixing the stop/status disagreement recorded in the incident dossier.

## Verification

- Targeted tests 24/24; integration tier 513 tests (512 pass, 1 platform skip); `check:local` 41 steps green; duplicate-definitions and write-road green.
- Acceptance criterion from the incident dossier (evidence-coldstart-incident-20260818.md): the misdiagnosis chain "ENOENT/bind_timeout both say 'not up', nothing says 'coming up'" is broken by the progress line — covered by red/green tests in the report.

## Review Evidence

Worker implementation (Codex Sol), full evidence chain in ledger task `task_8c4fc791f95431ea7d616fb92d` (report-w1e-items56.md, report-w1e-sol.md). Small CLI-surface change reviewed under the bounded review budget (single lane + CI).

## Residual Risk

- Progress reporting reads the lifecycle log best-effort; if the log is absent (pre-#1555 daemon build), the CLI falls back to the previous wait semantics.

Production-Delta: +60/-29

---

# 中文

## 摘要

收口 W1-E 可用性线(#1555 的①–④之后的⑤⑥):daemon 冷启动的 CLI 侧。

- **autostart 单飞**:同 user-root 并发 CLI 至多 spawn 一个 daemon(原子锁属主),其余共等 socket;诊断命令(status/stop)不再触发 autostart——观测行为不再污染被观测现场(事故夜 autostart 堆积曾把 load 推到 72)。
- **lifecycle 感知等待窗**:daemon warming 期间 CLI 读生命周期日志,报「正在启动,已等 Ns(第 x/y 仓)」,替代把慢启动误读成坏死的固定 2×10s 窗;starting 与 failed 分流,慢冷重建不再被诊断误杀。
- **顺手收口**:`daemon stop` 等 PID 与 socket 都消失后才返回成功,修掉事故档记录的 stop/status 判定不一致缺陷。

## 验证

- 定向测试 24/24;integration 513(512 过,1 平台 skip);`check:local` 41 步绿;duplicate-definitions/write-road 绿。
- 事故档验收判据(「两个信号都说没起来,没有信号说正在起来」误判链)由进度行打断,red/green 覆盖见报告。

## 复核证据

Worker(Codex Sol)实现,证据链在台账任务 `task_8c4fc791f95431ea7d616fb92d`。CLI 小面改动按有界评审预算走单轨(CI+CEO 语义验收)。

## 残余风险

- 进度上报对 lifecycle 日志是 best-effort;日志缺失(旧 build daemon)时回退旧等待语义。

生产净变更:+60/-29(声明行见英文侧)
