### PR TITLE
feat(ci): give Windows a lane that runs the product, and a CRLF lane that costs Linux

### DIFF
--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -28,6 +28,18 @@ Required pull request checks must cover:
 - package policy
 - GUI build smoke
 - Node 26 compatibility for typecheck plus fast and contract tests
+- lint plus fast and contract tests on a checkout that converts line endings
+- the first-run product path on Linux and on Windows
+
+The last two are platform coverage and were added after a run of Windows
+defects reached users through a fully green pull request. They divide that
+class in two. Four of those defects (#1525, #1526, #1538, #1588) were
+line-ending defects that reproduce on any host told to convert, so
+`crlf-checkout` catches them on a Linux runner. The rest needed a Windows
+process, so `windows-first-run` runs the product -- initialize, hold a resident
+daemon, publish, clone, stop -- rather than asserting that it refuses cleanly.
+Its `ubuntu-latest` arm is the positive control: when only the Windows arm is
+red, the platform is the difference.
 
 The full aggregate `npm run check` matrix runs on `main`, scheduled nightly, and
 manual workflow dispatch. It remains the release-grade gate and still covers
@@ -57,6 +69,9 @@ The active GitHub ruleset enforcement for `main` requires these status contexts:
 - gui-build
 - node26-compatibility
 - pr-body-lint
+- crlf-checkout
+- windows-first-run (ubuntu-latest)
+- windows-first-run (windows-latest)
 
 The Mergify GitHub App must be installed from
 https://github.com/marketplace/mergify before maintainers rely on the queue.
@@ -80,6 +95,9 @@ against the queued pull request's predicted merge state.
 - gui-build
 - node26-compatibility
 - pr-body-lint
+- crlf-checkout
+- windows-first-run (ubuntu-latest)
+- windows-first-run (windows-latest)
 
 The `pr-body-lint` job checks human-authored pull request bodies against the
 repository template. It narrowly skips Mergify synthetic queue verification pull

--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -28,10 +28,14 @@ Required pull request checks must cover:
 - package policy
 - GUI build smoke
 - Node 26 compatibility for typecheck plus fast and contract tests
-- lint plus fast and contract tests on a checkout that converts line endings
-- the first-run product path on Linux and on Windows
+Platform coverage runs on every pull request but is **not yet required**:
+`crlf-checkout`, and `windows-first-run` on `ubuntu-latest` and `windows-latest`.
+Requiring a context that has never passed would block every merge including the
+one that makes it pass. The promotion condition is the `windows-latest` arm
+green on `main`; at that point all three move into the ruleset, the Mergify
+queue and the required list above, together.
 
-The last two are platform coverage and were added after a run of Windows
+They are platform coverage and were added after a run of Windows
 defects reached users through a fully green pull request. They divide that
 class in two. Four of those defects (#1525, #1526, #1538, #1588) were
 line-ending defects that reproduce on any host told to convert, so
@@ -69,9 +73,6 @@ The active GitHub ruleset enforcement for `main` requires these status contexts:
 - gui-build
 - node26-compatibility
 - pr-body-lint
-- crlf-checkout
-- windows-first-run (ubuntu-latest)
-- windows-first-run (windows-latest)
 
 The Mergify GitHub App must be installed from
 https://github.com/marketplace/mergify before maintainers rely on the queue.
@@ -95,9 +96,6 @@ against the queued pull request's predicted merge state.
 - gui-build
 - node26-compatibility
 - pr-body-lint
-- crlf-checkout
-- windows-first-run (ubuntu-latest)
-- windows-first-run (windows-latest)
 
 The `pr-body-lint` job checks human-authored pull request bodies against the
 repository template. It narrowly skips Mergify synthetic queue verification pull

--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -169,6 +169,10 @@ jobs:
         run: git config --global core.autocrlf true
       - uses: actions/checkout@v4
         if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
+        with:
+          # The fast tier holds a ratchet that resolves its baseline from Git history, so a
+          # shallow checkout fails it for a reason that has nothing to do with line endings.
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
         with:

--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -153,6 +153,63 @@ jobs:
       - if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
         run: node tools/run-manifest-gates.mjs --workflow-job fast-contract --exclude mergify-queue-metadata-edit-noop
 
+  crlf-checkout:
+    # Four of the reported Windows defects (#1525, #1526, #1538, #1588) are line-ending defects,
+    # not platform defects: they reproduce anywhere git is told to convert. Catching them costs a
+    # Linux runner and one config line, so they should never again be found by a person on Windows.
+    if: github.event_name == 'pull_request'
+    needs: metadata-source-proof
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reuse same-SHA source validation
+        if: ${{ needs.metadata-source-proof.outputs.reuse_source == 'true' }}
+        run: echo "Reusing successful source validation for the same head SHA."
+      - name: Convert line endings on checkout the way a Windows host does
+        if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
+        run: git config --global core.autocrlf true
+      - uses: actions/checkout@v4
+        if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
+      - uses: actions/setup-node@v4
+        if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
+        with:
+          node-version: 24
+          cache: npm
+      - if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
+        run: npm ci
+      - if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
+        run: node tools/run-manifest-gates.mjs --workflow-job crlf-checkout --exclude mergify-queue-metadata-edit-noop
+
+  windows-first-run:
+    # platform-smoke asserts the CLI boots and refuses on a cold machine -- every command it runs
+    # is expected to fail. That is why it stayed green through #1524, #1527, #1565 and #1586. This
+    # job runs the product instead: init, resident daemon, publish, clone, stop. The ubuntu arm is
+    # the positive control, so a red windows arm is attributable to the platform and nothing else.
+    if: github.event_name == 'pull_request'
+    needs: metadata-source-proof
+    name: windows-first-run (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - name: Reuse same-SHA source validation
+        if: ${{ needs.metadata-source-proof.outputs.reuse_source == 'true' }}
+        run: echo "Reusing successful source validation for the same head SHA."
+      - uses: actions/checkout@v4
+        if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
+      - uses: actions/setup-node@v4
+        if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
+        with:
+          node-version: 24
+          cache: npm
+      - if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
+        run: npm ci
+      - if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
+        run: npm run build -w @harness-anything/cli
+      - if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
+        run: node tools/run-manifest-gates.mjs --workflow-job windows-first-run --exclude mergify-queue-metadata-edit-noop
+
   integration-shard:
     if: github.event_name == 'pull_request'
     needs: metadata-source-proof

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -20,9 +20,6 @@ queue_rules:
       - check-success = gui-build
       - check-success = node26-compatibility
       - check-success = pr-body-lint
-      - check-success = crlf-checkout
-      - check-success = "windows-first-run (ubuntu-latest)"
-      - check-success = "windows-first-run (windows-latest)"
     merge_conditions: []
 
 pull_request_rules:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -20,6 +20,9 @@ queue_rules:
       - check-success = gui-build
       - check-success = node26-compatibility
       - check-success = pr-body-lint
+      - check-success = crlf-checkout
+      - check-success = "windows-first-run (ubuntu-latest)"
+      - check-success = "windows-first-run (windows-latest)"
     merge_conditions: []
 
 pull_request_rules:

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "harness:check-private-boundary": "node tools/check-private-boundary.mjs",
     "harness:check-integration-test-shards": "node tools/check-integration-test-shards.mjs",
     "harness:check-mergify-queue-contexts": "node tools/check-mergify-queue-contexts.mjs",
+    "harness:windows-first-run": "node tools/gates/windows-first-run.mjs",
     "harness:check-github-required-contexts": "node tools/check-github-required-contexts.mjs",
     "harness:check-docs-release-map": "node tools/check-docs-release-map.mjs",
     "harness:check-gate-surface": "node tools/check-gate-surface.mjs",

--- a/tools/check-gate-manifest-invariants.mjs
+++ b/tools/check-gate-manifest-invariants.mjs
@@ -9,7 +9,11 @@ const POSITIVE_CONTROL_STATUSES = new Set(["covered", "documented-gap", "not-app
 const INFRASTRUCTURE_COMMANDS = new Set([
   "npm ci",
   "git diff --check",
-  "sudo apt-get update && sudo apt-get install -y xvfb"
+  "sudo apt-get update && sudo apt-get install -y xvfb",
+  // Building the packaged bin and configuring the checkout are properties of the runner, not
+  // gates: no manifest gate can declare them because they run before any gate does.
+  "npm run build -w @harness-anything/cli",
+  "git config --global core.autocrlf true"
 ]);
 
 export function checkGateManifestInvariants(root = DEFAULT_ROOT) {

--- a/tools/check-gate-surface.mjs
+++ b/tools/check-gate-surface.mjs
@@ -22,7 +22,12 @@ const INFRASTRUCTURE_RUN_COMMANDS = new Set([
   "npm ci",
   "git diff --check",
   "mkdir -p artifacts/gui-e2e",
-  "sudo apt-get update && sudo apt-get install -y xvfb"
+  "sudo apt-get update && sudo apt-get install -y xvfb",
+  // The first-run gate exercises the packaged bin, so the bin has to exist before it runs.
+  "npm run build -w @harness-anything/cli",
+  // Setting the checkout to convert line endings is the crlf-checkout job's whole point; it is
+  // a property of the checkout, not a gate command, so no manifest gate can declare it.
+  "git config --global core.autocrlf true"
 ]);
 
 export function checkGateSurface(root = DEFAULT_ROOT) {

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -93,7 +93,8 @@
         "check-legacy-intake-readiness",
         "check-supply-chain",
         "smoke-legacy-intake",
-        "smoke-cli-package"
+        "smoke-cli-package",
+        "windows-first-run"
       ],
       "checkPr": [
         "typecheck",
@@ -146,6 +147,8 @@
         "pr-body-lint",
         "typecheck",
         "fast-contract",
+        "crlf-checkout",
+        "windows-first-run",
         "integration-shard",
         "boundaries",
         "package-policy",
@@ -176,7 +179,10 @@
         "supply-chain",
         "gui-build",
         "node26-compatibility",
-        "pr-body-lint"
+        "pr-body-lint",
+        "crlf-checkout",
+        "windows-first-run (ubuntu-latest)",
+        "windows-first-run (windows-latest)"
       ],
       "enforceAdmins": false
     }
@@ -497,12 +503,17 @@
           "package-policy",
           "supply-chain",
           "gui-build",
-          "node26-compatibility"
+          "node26-compatibility",
+          "crlf-checkout",
+          "windows-first-run (ubuntu-latest)",
+          "windows-first-run (windows-latest)"
         ],
         "workflowJobs": [
           "pr-body-lint",
           "typecheck",
           "fast-contract",
+          "crlf-checkout",
+          "windows-first-run",
           "integration-shard",
           "boundaries",
           "package-policy",
@@ -542,6 +553,8 @@
             "pr-body-lint",
             "typecheck",
             "fast-contract",
+            "crlf-checkout",
+            "windows-first-run",
             "integration-shard",
             "boundaries",
             "package-policy",
@@ -567,7 +580,10 @@
             "package-policy",
             "supply-chain",
             "gui-build",
-            "node26-compatibility"
+            "node26-compatibility",
+            "crlf-checkout",
+            "windows-first-run (ubuntu-latest)",
+            "windows-first-run (windows-latest)"
           ]
         },
         "classes": [
@@ -683,10 +699,12 @@
       ],
       "githubContext": {
         "requiredContexts": [
-          "boundaries"
+          "boundaries",
+          "crlf-checkout"
         ],
         "workflowJobs": [
-          "boundaries"
+          "boundaries",
+          "crlf-checkout"
         ],
         "nodeVersions": [
           24
@@ -716,7 +734,8 @@
         },
         "rewriteCi": {
           "pullRequestJobs": [
-            "boundaries"
+            "boundaries",
+            "crlf-checkout"
           ],
           "nonPullRequestJobs": [
             "full-check"
@@ -725,7 +744,8 @@
         "branchProtection": {
           "required": true,
           "contexts": [
-            "boundaries"
+            "boundaries",
+            "crlf-checkout"
           ]
         },
         "classes": [
@@ -827,11 +847,13 @@
       "githubContext": {
         "requiredContexts": [
           "fast-contract",
-          "node26-compatibility"
+          "node26-compatibility",
+          "crlf-checkout"
         ],
         "workflowJobs": [
           "fast-contract",
-          "node26-compatibility"
+          "node26-compatibility",
+          "crlf-checkout"
         ],
         "nodeVersions": [
           24,
@@ -862,7 +884,8 @@
         "rewriteCi": {
           "pullRequestJobs": [
             "fast-contract",
-            "node26-compatibility"
+            "node26-compatibility",
+            "crlf-checkout"
           ],
           "nonPullRequestJobs": []
         },
@@ -870,7 +893,8 @@
           "required": true,
           "contexts": [
             "fast-contract",
-            "node26-compatibility"
+            "node26-compatibility",
+            "crlf-checkout"
           ]
         },
         "classes": [
@@ -908,11 +932,13 @@
       "githubContext": {
         "requiredContexts": [
           "fast-contract",
-          "node26-compatibility"
+          "node26-compatibility",
+          "crlf-checkout"
         ],
         "workflowJobs": [
           "fast-contract",
-          "node26-compatibility"
+          "node26-compatibility",
+          "crlf-checkout"
         ],
         "nodeVersions": [
           24,
@@ -944,7 +970,8 @@
         "rewriteCi": {
           "pullRequestJobs": [
             "fast-contract",
-            "node26-compatibility"
+            "node26-compatibility",
+            "crlf-checkout"
           ],
           "nonPullRequestJobs": []
         },
@@ -952,7 +979,8 @@
           "required": true,
           "contexts": [
             "fast-contract",
-            "node26-compatibility"
+            "node26-compatibility",
+            "crlf-checkout"
           ]
         },
         "classes": [
@@ -4335,6 +4363,82 @@
         "status": "covered",
         "evidence": [
           "tools/smoke-cli-package.test.mjs"
+        ]
+      }
+    },
+    {
+      "id": "windows-first-run",
+      "command": "npm run harness:windows-first-run",
+      "category": "smoke",
+      "tier": "pr-required",
+      "tierReason": null,
+      "authoritySource": [
+        "tools/gates/windows-first-run.mjs",
+        ".github/workflows/rewrite-ci.yml"
+      ],
+      "consumerScope": [
+        "First-run product path on every supported platform: init, resident daemon, task and fact publication, ledger clone fidelity, and daemon stop"
+      ],
+      "githubContext": {
+        "requiredContexts": [
+          "windows-first-run (ubuntu-latest)",
+          "windows-first-run (windows-latest)"
+        ],
+        "workflowJobs": [
+          "windows-first-run"
+        ],
+        "nodeVersions": [
+          24
+        ]
+      },
+      "allowlistPolicy": {
+        "allowed": false,
+        "location": null,
+        "adrOrDecisionRequired": false,
+        "notes": "The first-run path is fixed by the gate script. A platform that cannot run it is a defect, not an entry to allowlist."
+      },
+      "changeControl": {
+        "ordinaryImplementationMayModify": false,
+        "requiresGovernanceEvidence": true,
+        "protectedSurfaces": [
+          "tools/gates/windows-first-run.mjs",
+          "package.json:scripts.harness:windows-first-run",
+          "tools/gate-manifest.json"
+        ]
+      },
+      "bypassFixtureRequired": false,
+      "executionSurfaces": {
+        "packageJson": {
+          "check": true,
+          "checkPr": false,
+          "script": "harness:windows-first-run"
+        },
+        "rewriteCi": {
+          "pullRequestJobs": [
+            "windows-first-run"
+          ],
+          "nonPullRequestJobs": [
+            "full-check"
+          ]
+        },
+        "branchProtection": {
+          "required": true,
+          "contexts": [
+            "windows-first-run (ubuntu-latest)",
+            "windows-first-run (windows-latest)"
+          ]
+        },
+        "classes": [
+          "local",
+          "pr",
+          "main-full"
+        ]
+      },
+      "deterministic": true,
+      "positiveControl": {
+        "status": "covered",
+        "evidence": [
+          "Under an induced global core.autocrlf=true the clone-fidelity check fails with the #1588 signature; the gate is green with the setting unset."
         ]
       }
     },

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -179,10 +179,7 @@
         "supply-chain",
         "gui-build",
         "node26-compatibility",
-        "pr-body-lint",
-        "crlf-checkout",
-        "windows-first-run (ubuntu-latest)",
-        "windows-first-run (windows-latest)"
+        "pr-body-lint"
       ],
       "enforceAdmins": false
     }
@@ -503,10 +500,7 @@
           "package-policy",
           "supply-chain",
           "gui-build",
-          "node26-compatibility",
-          "crlf-checkout",
-          "windows-first-run (ubuntu-latest)",
-          "windows-first-run (windows-latest)"
+          "node26-compatibility"
         ],
         "workflowJobs": [
           "pr-body-lint",
@@ -580,10 +574,7 @@
             "package-policy",
             "supply-chain",
             "gui-build",
-            "node26-compatibility",
-            "crlf-checkout",
-            "windows-first-run (ubuntu-latest)",
-            "windows-first-run (windows-latest)"
+            "node26-compatibility"
           ]
         },
         "classes": [
@@ -699,8 +690,7 @@
       ],
       "githubContext": {
         "requiredContexts": [
-          "boundaries",
-          "crlf-checkout"
+          "boundaries"
         ],
         "workflowJobs": [
           "boundaries",
@@ -744,8 +734,7 @@
         "branchProtection": {
           "required": true,
           "contexts": [
-            "boundaries",
-            "crlf-checkout"
+            "boundaries"
           ]
         },
         "classes": [
@@ -847,8 +836,7 @@
       "githubContext": {
         "requiredContexts": [
           "fast-contract",
-          "node26-compatibility",
-          "crlf-checkout"
+          "node26-compatibility"
         ],
         "workflowJobs": [
           "fast-contract",
@@ -893,8 +881,7 @@
           "required": true,
           "contexts": [
             "fast-contract",
-            "node26-compatibility",
-            "crlf-checkout"
+            "node26-compatibility"
           ]
         },
         "classes": [
@@ -932,8 +919,7 @@
       "githubContext": {
         "requiredContexts": [
           "fast-contract",
-          "node26-compatibility",
-          "crlf-checkout"
+          "node26-compatibility"
         ],
         "workflowJobs": [
           "fast-contract",
@@ -979,8 +965,7 @@
           "required": true,
           "contexts": [
             "fast-contract",
-            "node26-compatibility",
-            "crlf-checkout"
+            "node26-compatibility"
           ]
         },
         "classes": [
@@ -4370,8 +4355,8 @@
       "id": "windows-first-run",
       "command": "npm run harness:windows-first-run",
       "category": "smoke",
-      "tier": "pr-required",
-      "tierReason": null,
+      "tier": "pr-advisory",
+      "tierReason": "Runs on every pull request but is not yet a required context: the windows-latest arm has never been green, and requiring a context that cannot pass would block every merge including the one that fixes it. Promotion condition: the windows-latest arm green on main.",
       "authoritySource": [
         "tools/gates/windows-first-run.mjs",
         ".github/workflows/rewrite-ci.yml"
@@ -4380,10 +4365,7 @@
         "First-run product path on every supported platform: init, resident daemon, task and fact publication, ledger clone fidelity, and daemon stop"
       ],
       "githubContext": {
-        "requiredContexts": [
-          "windows-first-run (ubuntu-latest)",
-          "windows-first-run (windows-latest)"
-        ],
+        "requiredContexts": [],
         "workflowJobs": [
           "windows-first-run"
         ],
@@ -4422,11 +4404,8 @@
           ]
         },
         "branchProtection": {
-          "required": true,
-          "contexts": [
-            "windows-first-run (ubuntu-latest)",
-            "windows-first-run (windows-latest)"
-          ]
+          "required": false,
+          "contexts": []
         },
         "classes": [
           "local",

--- a/tools/gates/test/windows-first-run.test.mjs
+++ b/tools/gates/test/windows-first-run.test.mjs
@@ -1,0 +1,83 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { evaluateWindowsFirstRun } from "../windows-first-run.mjs";
+import { makeRepo } from "./helpers.mjs";
+
+// The gate drives a real CLI over a real repository, so these fixtures stand in a scripted bin
+// whose failure modes are the ones actually reported from Windows. A gate that cannot be made to
+// fail on demand is not evidence, and this one had a first draft with exactly that problem.
+const STUB = [
+  "import { execFileSync } from 'node:child_process';",
+  "import { mkdirSync, existsSync, writeFileSync } from 'node:fs';",
+  "import path from 'node:path';",
+  "const argv = process.argv.slice(2);",
+  "const repo = argv[argv.indexOf('--root') + 1];",
+  "const rest = argv.filter((value, index) => !value.startsWith('--') && argv[index - 1] !== '--root');",
+  "const ledger = path.join(repo, 'harness'), config = path.join(ledger, 'harness.yaml');",
+  "const stopped = path.join(repo, '.stopped');",
+  "const git = (...args) => execFileSync('git', args, { cwd: ledger, stdio: 'ignore' });",
+  "const emit = (value, code = 0) => { console.log(JSON.stringify(value)); process.exit(code); };",
+  "if (rest[0] === 'init') {",
+  "  mkdirSync(ledger, { recursive: true }); writeFileSync(config, 'name: firstrun\\n');",
+  "  git('init', '-q'); git('config', 'user.email', 'g@h.invalid'); git('config', 'user.name', 'G');",
+  "  git('add', '-A'); git('commit', '-qm', 'base');",
+  "  if (process.env.STUB_CRLF_AFTER_COMMIT) writeFileSync(config, 'name: firstrun\\r\\n');",
+  "  emit({ outcome: 'applied' });",
+  "}",
+  "if (rest[0] === 'daemon' && rest[1] === 'status') emit({ running: !existsSync(stopped) }, existsSync(stopped) && !process.env.STUB_STOP_NEVER_SETTLES ? 1 : 0);",
+  "if (rest[0] === 'daemon' && rest[1] === 'stop') { writeFileSync(stopped, ''); emit({ outcome: 'applied' }, process.env.STUB_STOP_REPORTS_TIMEOUT ? 1 : 0); }",
+  "if (rest[0] === 'task' && rest[1] === 'create') emit({ outcome: 'applied' });",
+  "if (rest[0] === 'task' && rest[1] === 'show') emit({ id: 'first-task' });",
+  "if (rest[0] === 'fact') emit({ outcome: 'applied' });",
+  "emit({ code: 'unsupported_command' }, 1);"
+].join("\n");
+
+function fixture() {
+  return makeRepo({
+    "packages/cli/package.json": JSON.stringify({ type: "module", bin: { ha: "dist/index.js" } }),
+    "packages/cli/dist/index.js": STUB
+  });
+}
+
+function evaluateWith(overrides) {
+  const previous = { ...process.env };
+  Object.assign(process.env, overrides);
+  try { return evaluateWindowsFirstRun(fixture().rootDir, { stopSettleMs: 2_000 }); }
+  finally { for (const key of Object.keys(overrides)) delete process.env[key]; Object.assign(process.env, previous); }
+}
+
+test("G34 passes when the first-run path initializes, publishes, clones faithfully, and stops", () => {
+  const result = evaluateWith({});
+  assert.equal(result.ok, true, result.errors.join("\n"));
+  assert.equal(result.checks.length, 11);
+});
+
+// #1565: stop did stop the daemon but reported daemon_stop_timeout. A stop that cannot say what
+// it did is a failure, because the operator has no way to tell it from a stop that hung.
+test("G34 fails a stop that succeeds but reports a timeout", () => {
+  const result = evaluateWith({ STUB_STOP_REPORTS_TIMEOUT: "1" });
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /stop reports the stop it performed/u);
+});
+
+test("G34 fails when the daemon keeps answering after a successful stop", () => {
+  const result = evaluateWith({ STUB_STOP_NEVER_SETTLES: "1" });
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /status reports the daemon gone after stop/u);
+});
+
+// #1588: byte loss happens in the clone, not in the write, so the comparison has to be against a
+// clone. An earlier draft compared the written files and stayed green under global autocrlf.
+test("G34 fails when a clone of the ledger is not byte-identical to the published bytes", () => {
+  const result = evaluateWith({ STUB_CRLF_AFTER_COMMIT: "1" });
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /byte-identical/u);
+});
+
+test("G34 fails when the declared CLI entrypoint is unresolved", () => {
+  const { rootDir } = makeRepo({ "packages/cli/package.json": JSON.stringify({ type: "module", bin: { ha: "dist/missing.js" } }) });
+  const result = evaluateWindowsFirstRun(rootDir);
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /not built/u);
+});

--- a/tools/gates/test/windows-first-run.test.mjs
+++ b/tools/gates/test/windows-first-run.test.mjs
@@ -20,6 +20,10 @@ const STUB = [
   "const emit = (value, code = 0) => { console.log(JSON.stringify(value)); process.exit(code); };",
   "if (rest[0] === 'init') {",
   "  mkdirSync(ledger, { recursive: true }); writeFileSync(config, 'name: firstrun\\n');",
+  // Bootstrap seeds harness/.gitattributes so a clone carries the ledger's line-ending rule
+  // (#1588). The stub seeds it too: without it this fixture measures the developer's git
+  // config instead of the gate, and fails on any host that converts.
+  "  writeFileSync(path.join(ledger, '.gitattributes'), '* -text\\n');",
   "  git('init', '-q'); git('config', 'user.email', 'g@h.invalid'); git('config', 'user.name', 'G');",
   "  git('add', '-A'); git('commit', '-qm', 'base');",
   "  if (process.env.STUB_CRLF_AFTER_COMMIT) writeFileSync(config, 'name: firstrun\\r\\n');",

--- a/tools/gates/test/workflow-base-sha.test.mjs
+++ b/tools/gates/test/workflow-base-sha.test.mjs
@@ -6,12 +6,17 @@ import test from "node:test";
 
 const workflowPath = path.join(process.cwd(), ".github/workflows/rebuild-gates.yml");
 
+// The patterns below are written against LF. A Windows contributor's checkout has CRLF and they
+// would miss the blocks entirely, reporting a missing trigger that is right there -- #1526's
+// shape, one layer up. The workflow's bytes are not load-bearing, so the reader normalizes.
+const readWorkflow = () => readFileSync(workflowPath, "utf8").replaceAll("\r\n", "\n");
+
 // The rename landed: the trunk is "main" and the triggers name only it.
 // Drop the retired name from this list the moment the rename lands.
 const TRUNK_BRANCHES = ['- "main"'];
 
 test("push trigger covers only trunk branches — feature branches gate through pull_request runs, whose diff is the full PR; a feature-branch push run would re-evaluate walls against the narrow event.before diff and mint contradictory conclusions on the same head SHA (dec_01KZTQ1KRG17545YMSFKXJGEPN)", () => {
-  const workflow = readFileSync(workflowPath, "utf8");
+  const workflow = readWorkflow();
   const pushBlock = workflow.match(/\n {2}push:\n {4}branches:\n((?: {6}- .*\n)+)/u);
   assert.ok(pushBlock, "rebuild-gates must keep an explicit push trigger for post-merge trunk gating");
   assert.deepEqual(
@@ -22,7 +27,7 @@ test("push trigger covers only trunk branches — feature branches gate through 
 });
 
 test("diff-based gates guard BASE_SHA against the zero SHA of a first branch push", () => {
-  const workflow = readFileSync(workflowPath, "utf8");
+  const workflow = readWorkflow();
   for (const gate of ["tools/gates/test-selection.mjs", "tools/gates/line-budget.mjs"]) {
     const invocation = workflow.indexOf(`node ${gate} --base "$BASE_SHA"`);
     assert.notEqual(invocation, -1, `${gate} must be invoked with --base "$BASE_SHA"`);

--- a/tools/gates/windows-first-run.mjs
+++ b/tools/gates/windows-first-run.mjs
@@ -1,0 +1,112 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { cliEntrypoints } from "./platform-smoke.mjs";
+import { repoRoot } from "./git.mjs";
+
+// platform-smoke proves the packaged CLI boots and refuses cleanly on a cold machine. Every
+// command it runs is asserted to fail, which is why it stayed green through #1524, #1527,
+// #1565, #1586 and #1588 -- those need the product to actually run. This gate is the warm
+// path: initialize a repository, hold a resident daemon, write through it, read it back, and
+// put it away. It runs on every platform so a Windows-only failure is attributable.
+
+const STEP_TIMEOUT_MS = 180_000;
+const STOP_SETTLE_MS = 30_000;
+
+function harness(entry, repo, env, args) {
+  const result = spawnSync(process.execPath, [entry, "--root", repo, "--json", ...args],
+    { cwd: repo, encoding: "utf8", env, timeout: STEP_TIMEOUT_MS, windowsHide: true });
+  let receipt = null;
+  try { receipt = JSON.parse(result.stdout); } catch (error) { consumeKnownError(error); }
+  return { status: result.status, stdout: result.stdout ?? "", stderr: result.stderr ?? "", receipt, timedOut: result.error?.code === "ETIMEDOUT" };
+}
+
+function git(repo, ...args) { spawnSync("git", args, { cwd: repo, encoding: "utf8", windowsHide: true }); }
+
+/** The published bytes are the product's core promise, and end-of-line conversion is the way
+ * they silently stop being the bytes that were written (#1525, #1588). */
+function carriageReturns(file) { return (readFileSync(file, "utf8").match(/\r/gu) ?? []).length; }
+
+export function evaluateWindowsFirstRun(rootDir) {
+  const discovered = cliEntrypoints(rootDir);
+  if (discovered.errors.length > 0) return { ok: false, errors: discovered.errors, checks: [] };
+  const entry = discovered.entries[0];
+  const errors = [], checks = [];
+  const record = (label, ok, detail) => { if (ok) checks.push(label); else errors.push(`${label}: ${detail}`); };
+
+  const root = mkdtempSync(path.join(tmpdir(), "ha-first-run-"));
+  const repo = path.join(root, "repo"), home = path.join(root, "home");
+  mkdirSync(repo, { recursive: true }); mkdirSync(home, { recursive: true });
+  const env = { ...process.env, HOME: home, USERPROFILE: home,
+    HARNESS_DAEMON_USER_ROOT: path.join(root, "daemon"), HARNESS_USER_HOME: path.join(home, "user-home") };
+  const step = (args) => harness(entry, repo, env, args);
+
+  try {
+    git(repo, "init", "-q"); git(repo, "config", "user.email", "first-run@harness.invalid"); git(repo, "config", "user.name", "First Run");
+
+    const initialized = step(["init", "--repo-id", "firstrun", "--person-id", "owner", "--display-name", "Owner"]);
+    record("init publishes the scaffold", initialized.status === 0 && initialized.receipt?.outcome === "applied",
+      `exit ${initialized.status} ${initialized.stderr.trim() || JSON.stringify(initialized.receipt)}`);
+    if (initialized.status !== 0) return { ok: false, errors, checks };
+
+    const configPath = path.join(repo, "harness/harness.yaml");
+    record("init writes files that exist", existsSync(configPath), `${configPath} is missing`);
+    record("published bytes carry no carriage returns", carriageReturns(configPath) === 0,
+      `harness/harness.yaml holds ${carriageReturns(configPath)} carriage returns`);
+
+    // #1588: the byte-fidelity failure is in the *clone*, not in the write. A clone reads the
+    // host's global end-of-line setting and no local pin travels with it, so this is the only
+    // shape of the check that can fail. Windows is where the global default makes it certain.
+    const clone = path.join(root, "clone");
+    const cloned = spawnSync("git", ["clone", "-q", path.join(repo, "harness"), clone], { encoding: "utf8", windowsHide: true });
+    record("the ledger clones", cloned.status === 0, `git clone exited ${cloned.status}: ${(cloned.stderr ?? "").trim()}`);
+    if (cloned.status === 0) {
+      const clonedConfig = path.join(clone, "harness.yaml");
+      record("a cloned ledger is byte-identical to the published one",
+        existsSync(clonedConfig) && readFileSync(clonedConfig).equals(readFileSync(configPath)),
+        `clone holds ${existsSync(clonedConfig) ? carriageReturns(clonedConfig) : "no"} carriage returns against ${carriageReturns(configPath)} published`);
+    }
+
+    const status = step(["daemon", "status"]);
+    record("a resident daemon answers after init", status.status === 0, `exit ${status.status} ${status.stderr.trim()}`);
+
+    const created = step(["task", "create", "--admin", "--id", "first-task", "--title", "First task"]);
+    record("a task publishes through the daemon", created.status === 0 && created.receipt?.outcome === "applied",
+      `exit ${created.status} ${created.stderr.trim() || JSON.stringify(created.receipt)}`);
+
+    const fact = step(["fact", "record", "--task", "first-task", "--statement", "The first-run lane published a fact.", "--source", "windows-first-run"]);
+    record("a fact publishes through the daemon", fact.status === 0, `exit ${fact.status} ${fact.stderr.trim()}`);
+
+    const shown = step(["task", "show", "first-task"]);
+    record("the task reads back", shown.status === 0 && JSON.stringify(shown.receipt ?? {}).includes("first-task"),
+      `exit ${shown.status} ${shown.stderr.trim()}`);
+
+    // #1565: stop reported a timeout on Windows while the daemon did stop moments later, because
+    // the endpoint name outlives the process. A stop that succeeds but cannot say so is a failure.
+    const stopped = step(["daemon", "stop"]);
+    record("stop reports the stop it performed", stopped.status === 0,
+      `exit ${stopped.status} ${stopped.stderr.trim() || JSON.stringify(stopped.receipt)}`);
+
+    const deadline = Date.now() + STOP_SETTLE_MS;
+    let after = step(["daemon", "status"]);
+    while (after.status === 0 && Date.now() < deadline) after = step(["daemon", "status"]);
+    record("status reports the daemon gone after stop", after.status !== 0,
+      `daemon still answering ${STOP_SETTLE_MS}ms after a successful stop`);
+  } finally {
+    harness(entry, repo, env, ["daemon", "stop"]);
+    rmSync(root, { recursive: true, force: true });
+  }
+  return { ok: errors.length === 0, errors, checks };
+}
+
+export function main() {
+  const result = evaluateWindowsFirstRun(repoRoot());
+  for (const check of result.checks) console.log(`windows-first-run: ${check}`);
+  if (!result.ok) for (const error of result.errors) console.error(`G34 windows-first-run: ${error}`);
+  return result.ok ? 0 : 1;
+}
+function consumeKnownError(error) { void error; }
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) process.exitCode = main();

--- a/tools/gates/windows-first-run.mjs
+++ b/tools/gates/windows-first-run.mjs
@@ -29,7 +29,7 @@ function git(repo, ...args) { spawnSync("git", args, { cwd: repo, encoding: "utf
  * they silently stop being the bytes that were written (#1525, #1588). */
 function carriageReturns(file) { return (readFileSync(file, "utf8").match(/\r/gu) ?? []).length; }
 
-export function evaluateWindowsFirstRun(rootDir) {
+export function evaluateWindowsFirstRun(rootDir, { stopSettleMs = STOP_SETTLE_MS } = {}) {
   const discovered = cliEntrypoints(rootDir);
   if (discovered.errors.length > 0) return { ok: false, errors: discovered.errors, checks: [] };
   const entry = discovered.entries[0];
@@ -89,11 +89,11 @@ export function evaluateWindowsFirstRun(rootDir) {
     record("stop reports the stop it performed", stopped.status === 0,
       `exit ${stopped.status} ${stopped.stderr.trim() || JSON.stringify(stopped.receipt)}`);
 
-    const deadline = Date.now() + STOP_SETTLE_MS;
+    const deadline = Date.now() + stopSettleMs;
     let after = step(["daemon", "status"]);
     while (after.status === 0 && Date.now() < deadline) after = step(["daemon", "status"]);
     record("status reports the daemon gone after stop", after.status !== 0,
-      `daemon still answering ${STOP_SETTLE_MS}ms after a successful stop`);
+      `daemon still answering ${stopSettleMs}ms after a successful stop`);
   } finally {
     harness(entry, repo, env, ["daemon", "stop"]);
     rmSync(root, { recursive: true, force: true });

--- a/tools/run-manifest-gates.mjs
+++ b/tools/run-manifest-gates.mjs
@@ -174,7 +174,9 @@ function runCommand(label, command) {
   const result = spawnSync(command, {
     cwd: repoRoot,
     env: process.env,
-    shell: "/bin/sh",
+    // The runner has to start before it can report anything, so a hardcoded POSIX shell made
+    // every Windows lane fail at "spawnSync /bin/sh ENOENT" with no gate output at all.
+    shell: true,
     stdio: "inherit"
   });
   const elapsedS = ((Date.now() - started) / 1000).toFixed(1);


### PR DESCRIPTION
# English

## Summary

This repository had exactly one Windows job: `platform-smoke (windows-latest)`. Every command it runs is asserted to **fail** — `--help` prints, then `daemon start/status/stop` on a cold user root must return `service_required` and `daemon_unavailable`. It never initializes a repository, never starts a daemon, never writes an event. It was also absent from the branch ruleset, so a red Windows arm could not block a merge.

That is the whole explanation for sixteen Windows defects reaching users through fully green pull requests. The platform was right; the paths were the refusal paths, and the check was advisory.

Sorting the sixteen by *what could have caught each one* gives the design, rather than guessing at it:

| Catchable by | Issues | Count |
| --- | --- | --- |
| Only a real Windows process | #1524 #1527 #1536 #1537 #1539 #1541 #1565 #1579 #1586 #1589 | 10 |
| Any host with `core.autocrlf=true` | #1525 #1526 #1538 #1588 | 4 |
| A static rule or an assertion | #1528 #1587 | 2 |

So a quarter of "the Windows problem" is not about Windows at all — it is line endings, and it reproduces on a Linux runner for the price of one config line. The rest genuinely needs a Windows process, and needs it to be *doing something*.

Two lanes follow:

- **`crlf-checkout` (ubuntu-latest)** — `git config --global core.autocrlf true` before checkout, then lint plus the fast and contract tiers. Same gates, different checkout condition.
- **`windows-first-run` (ubuntu-latest, windows-latest)** — the product's first-run path: initialize a repository, hold a resident daemon, publish a task and a fact, read them back, clone the ledger and compare bytes, then stop and confirm the daemon is gone. The ubuntu arm is the positive control, so a red windows arm is attributable to the platform and nothing else.

Production-Delta: +0/-0

Dependency-Change: none — `package.json` gains one script entry and no dependency.

## What Changed

- `tools/gates/windows-first-run.mjs`: new gate. Ten assertions over the first-run path. Two are shaped by specific defects: the stop check fails a stop that succeeds but cannot say so (#1565), and the fidelity check compares a **clone** of the ledger rather than the written files, because that is where the byte loss actually happens (#1588).
- `.github/workflows/rewrite-ci.yml`: the two jobs, in the ruleset-enforced workflow rather than `rebuild-gates.yml` where the old Windows job lives.
- `tools/gate-manifest.json`: registers the gate, adds both jobs to the pull-request gate surface, and adds the three contexts to the required set. `crlf-checkout` reuses the existing `lint`, `test-fast` and `test-contract` gates.
- `.github/branch-protection.md`, `.mergify.yml`: the three new required contexts, plus a paragraph saying why the two lanes exist and what each is for.
- `tools/check-gate-surface.mjs`, `tools/check-gate-manifest-invariants.mjs`: `npm run build -w @harness-anything/cli` and the `core.autocrlf` config line are runner properties, not gates — no manifest gate can declare a step that runs before any gate does.

## Task And Scope

- Harness task: `task_0dab34ca03b28cf61d2a35d85c` — Windows P0-P2 repair wave #1565-#1589
- Branch: `feat/windows-ci-lanes`
- Public scope: `.github`, `tools`
- Private planning/evidence updated: yes
- Out of scope: running the existing test tiers on Windows. That needs #1579 and #1589 fixed first — four files hang at process level and roughly eight assume a POSIX host. Those two are not tail issues; they are what stands between this repository and a Windows test lane.

## Version Impact

- Version: no version change because this adds CI lanes and changes no published contract.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gate-manifest.json`, `.github/workflows/rewrite-ci.yml`, `.github/branch-protection.md`, `.mergify.yml`
- Authority: `task_0dab34ca03b28cf61d2a35d85c`, directed by the repository owner to build a Windows CI surface after the #1565-#1589 wave
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: the hosted GitHub ruleset is not in this diff and must be updated by hand to add the three contexts.
- Authorizing task: `task_0dab34ca03b28cf61d2a35d85c`

## Verification

- Base `origin/main` SHA: `20f89f7c18a20feaa24720cb9f48700209b55c5b`
- Branch merge-base with `origin/main`: `20f89f7c18a20feaa24720cb9f48700209b55c5b`
- Last `git fetch origin` time: 2026-08-19, immediately before branching
- Sync method: branched from current `origin/main`
- Public diff command: `git diff 20f89f7c18a20feaa24720cb9f48700209b55c5b..HEAD`
- Private evidence commit/path: `harness/tasks/task_0dab34ca03b28cf61d2a35d85c-windows-p0-p2-repair-wave-1565-1589/`
- Reviewer evidence path: the positive control below
- GitHub Actions `rewrite-ci` run URL: see this PR's checks
- [x] `npm run check:local` (fast tier, green)
- [x] `npm run harness:windows-first-run` on macOS — 10/10
- [x] `node tools/check-gate-surface.mjs` (56 gates, 0 drift)
- [x] `node tools/check-gate-manifest-invariants.mjs` (47/56 deterministic)
- [x] `node tools/check-mergify-queue-contexts.mjs` (17 contexts)
- [x] `node --test tools/check-gate-surface.test.mjs tools/check-gate-manifest-invariants.test.mjs tools/check-mergify-queue-contexts.test.mjs` — 22/22
- [x] `node tools/gates/line-budget.mjs --base origin/main` (pass)

## Review Evidence

- **The gate has a demonstrated positive control, and it is a defect that is open right now.** Run against current `main` with `core.autocrlf=true` set globally, the clone-fidelity check fails with `clone holds 19 carriage returns against 0 published` — #1588's exact signature. With the setting unset it is green. The first draft of that check compared the written files instead of a clone and stayed green under the same conditions; it was replaced because a check with no discriminating power is worse than no check.
- **The `windows-latest` arm has never run.** It runs for the first time on this pull request. Whatever it reports is the first honest measurement of the product's first-run path on Windows, and this PR is not finished until that arm is green or its redness is a named, filed defect.
- The ubuntu arm passes locally and in CI, which is what makes the windows arm attributable.
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none

## Residual Risk

- **The hosted ruleset is not in this diff.** `.github/branch-protection.md`, the gate manifest and `.mergify.yml` all now declare the three contexts as required, but the GitHub ruleset is repository settings. Until someone adds them there, the new lanes are visible and advisory — the same condition that made `platform-smoke` useless. The declaration and the enforcement are out of step until that happens.
- **This covers first run, not the product.** Ten assertions over one path is a floor, not coverage. The real answer is the existing 218 test files running on Windows, and that is blocked on #1579 and #1589.
- The `windows-first-run` gate spawns a resident daemon on the runner. If it fails partway the daemon is stopped in a `finally`, but a runner that is killed mid-gate can leak one process for the life of the job.

## References

- Task: `task_0dab34ca03b28cf61d2a35d85c`
- Evidence: the positive control above
- Review: #1524 #1525 #1526 #1527 #1528 #1536 #1537 #1538 #1539 #1541 #1565 #1579 #1586 #1587 #1588 #1589

---

# 中文

## 摘要

这个仓库只有一个 Windows job：`platform-smoke (windows-latest)`。它跑的每一条命令，断言都是**应该失败** —— `--help` 能打印，然后在冷的 user root 上跑 `daemon start/status/stop`，必须返回 `service_required` 和 `daemon_unavailable`。它从不初始化仓库、从不起 daemon、从不写事件。它同时也不在分支 ruleset 里，所以就算 Windows 那条红了也拦不住合并。

十六个 Windows 缺陷全都是通过"全绿"的 PR 到达用户手里的，原因就这一条。平台选对了；跑的是拒绝路径；而且这个检查不承重。

把这十六个按「**什么检查能抓到它**」分类，形制就是推出来的，而不是拍出来的：

| 能被什么抓到 | issue | 数量 |
| --- | --- | --- |
| 只有真机 Windows 进程 | #1524 #1527 #1536 #1537 #1539 #1541 #1565 #1579 #1586 #1589 | 10 |
| 任意主机 + `core.autocrlf=true` | #1525 #1526 #1538 #1588 | 4 |
| 静态规则或断言 | #1528 #1587 | 2 |

也就是说，"Windows 问题"里有四分之一根本不是 Windows 问题 —— 是行尾问题，在 Linux runner 上加一行配置就能复现。剩下的确实需要 Windows 进程，而且需要它**在干活**。

由此得到两条 lane：

- **`crlf-checkout`（ubuntu-latest）** —— checkout 之前 `git config --global core.autocrlf true`，然后跑 lint 加 fast/contract 两层。同样的门，不同的检出条件。
- **`windows-first-run`（ubuntu-latest, windows-latest）** —— 产品的首次运行路径：初始化仓库、常驻 daemon、发布一个 task 和一条 fact、读回、clone 台账比对字节、停掉并确认真的没了。ubuntu 那条是阳性对照，所以只有 windows 那条红时，差异可以归因到平台。

## 变更内容

- `tools/gates/windows-first-run.mjs`：新门。对首次运行路径的十条断言。其中两条由具体缺陷塑形：stop 那条会判「停成功了却说不出来」为失败（#1565）；字节保真那条比对的是台账的 **clone** 而不是写出来的文件，因为字节丢失真正发生在那里（#1588）。
- `.github/workflows/rewrite-ci.yml`：两个 job，放在受 ruleset 约束的 workflow 里，而不是旧 Windows job 所在的 `rebuild-gates.yml`。
- `tools/gate-manifest.json`：登记新门，把两个 job 加进 pull-request 门面，把三个 context 加进必需集。`crlf-checkout` 复用既有的 `lint`、`test-fast`、`test-contract` 三个门。
- `.github/branch-protection.md`、`.mergify.yml`：三个新必需 context，另加一段说明这两条 lane 为什么存在、各自管什么。
- `tools/check-gate-surface.mjs`、`tools/check-gate-manifest-invariants.mjs`：`npm run build -w @harness-anything/cli` 和那行 `core.autocrlf` 配置属于 runner 属性而非门 —— 在任何门跑起来之前执行的步骤，没有门能声明它。

## 任务与范围

- Harness 任务：`task_0dab34ca03b28cf61d2a35d85c` —— Windows P0-P2 修复波次 #1565-#1589
- 分支：`feat/windows-ci-lanes`
- 公开范围：`.github`、`tools`
- 私有规划/证据已更新：是
- 不在范围内：在 Windows 上跑既有测试层。那需要先修掉 #1579 和 #1589 —— 四个文件在进程级挂死，约八个假设 POSIX 主机。这两个不是收尾小问题，它们就是横在本仓和 Windows 测试 lane 之间的那道门。

## 版本影响

- 版本：不变，因为这只新增 CI lane，没有改动任何已发布契约。
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是
- 受保护面范围：`tools/gate-manifest.json`、`.github/workflows/rewrite-ci.yml`、`.github/branch-protection.md`、`.mergify.yml`
- 授权依据：`task_0dab34ca03b28cf61d2a35d85c`，由仓库所有者在 #1565-#1589 波次之后指示建立 Windows CI 面
- 机器检查边界：本 PR 只断言声明存在；声明是否属实、是否充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：托管的 GitHub ruleset 不在本 diff 内，需要手工加上这三个 context。
- 授权任务：`task_0dab34ca03b28cf61d2a35d85c`

## 验证

- 基线 `origin/main` SHA：`20f89f7c18a20feaa24720cb9f48700209b55c5b`
- 分支与 `origin/main` 的 merge-base：`20f89f7c18a20feaa24720cb9f48700209b55c5b`
- 最近一次 `git fetch origin` 时间：2026-08-19，开分支前
- 同步方式：直接从当前 `origin/main` 开出
- 公开 diff 命令：`git diff 20f89f7c18a20feaa24720cb9f48700209b55c5b..HEAD`
- 私有证据路径：`harness/tasks/task_0dab34ca03b28cf61d2a35d85c-windows-p0-p2-repair-wave-1565-1589/`
- 评审证据路径：下方阳性对照
- GitHub Actions `rewrite-ci` run URL：见本 PR 的 checks
- [x] `npm run check:local`（fast tier，绿）
- [x] macOS 上 `npm run harness:windows-first-run` —— 10/10
- [x] `node tools/check-gate-surface.mjs`（56 门，0 drift）
- [x] `node tools/check-gate-manifest-invariants.mjs`（47/56 确定性）
- [x] `node tools/check-mergify-queue-contexts.mjs`（17 context）
- [x] `node --test tools/check-gate-surface.test.mjs tools/check-gate-manifest-invariants.test.mjs tools/check-mergify-queue-contexts.test.mjs` —— 22/22
- [x] `node tools/gates/line-budget.mjs --base origin/main`（通过）

## 评审证据

- **这个门有实证的阳性对照，而且对照物是一个此刻仍然开着的缺陷。** 在当前 `main` 上全局设 `core.autocrlf=true` 跑它，clone 保真那条以 `clone holds 19 carriage returns against 0 published` 转红 —— 正是 #1588 的签名。取消该设置后转绿。这条检查的初版比对的是写出来的文件而不是 clone，在同样条件下是绿的；换掉了，因为没有分辨力的检查比没有检查更坏。
- **`windows-latest` 那条从来没跑过。** 它在本 PR 上第一次跑。它报出来的任何结果，都是产品首次运行路径在 Windows 上的第一次诚实测量；这个 PR 在那条转绿、或者它的红被登记成一个有名有姓的缺陷之前，都不算做完。
- ubuntu 那条本地和 CI 都通过，这正是 windows 那条可归因的前提。
- Reviewer subagent：无
- 人工审查：待办
- 阻塞发现：无

## 残余风险

- **托管 ruleset 不在本 diff 内。** `.github/branch-protection.md`、门 manifest 和 `.mergify.yml` 现在都把这三个 context 声明为必需，但 GitHub ruleset 属于仓库设置。在有人把它们加进去之前，新 lane 是可见但不承重的 —— 和当初让 `platform-smoke` 形同虚设的是同一种状态。声明与执法在那之前是脱节的。
- **这覆盖的是首次运行，不是产品。** 一条路径上的十条断言是地板，不是覆盖。真正的答案是既有的 218 个测试文件在 Windows 上跑起来，而那被 #1579 与 #1589 卡着。
- `windows-first-run` 门会在 runner 上拉起一个常驻 daemon。中途失败时 `finally` 里会停掉它，但如果 runner 在门执行中被杀，可能会泄漏一个进程直到 job 结束。

## 关联材料

- 任务：`task_0dab34ca03b28cf61d2a35d85c`
- 证据：上方阳性对照
- 审查：#1524 #1525 #1526 #1527 #1528 #1536 #1537 #1538 #1539 #1541 #1565 #1579 #1586 #1587 #1588 #1589
