### PR TITLE
fix(cli): report the stop that happened when the daemon never got to clean up

### DIFF
--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { daemonIdFromEnv, daemonUserRoot, localUserDaemonEndpoint } from "../../../daemon/src/client/local-daemon-target.ts"; import { requestDaemonJsonRpcAt } from "../../../daemon/src/client/local-json-rpc-client.ts"; import { detachedProcessOptions, terminateProcess } from "../../../daemon/src/process-port.ts"; import type { JsonObject } from "../../../daemon/src/protocol/json-rpc-types.ts";
 import { ensureLocalDaemonRunning } from "../../../daemon/src/client/daemon-autostart.ts";
 import { readDaemonPid, startDaemon } from "../../../daemon/src/runtime.ts";
+import { daemonProcessAlive, releaseDaemonPidFile } from "../../../daemon/src/daemon-singleton.ts";
 import { cliDaemonServeLaunch, consumeKnownError } from "./client.ts";
 import { daemonRepoModeWords } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
 import { firstCliCommandIndex } from "../cli/thin-command.ts";
@@ -29,7 +30,7 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
       const started = await ensureLocalDaemonRunning({ socketPath: localUserDaemonEndpoint(userRoot, daemonId), launch: () => cliDaemonServeLaunch(userRoot, daemonId), onProgress: (progress) => process.stderr.write(`${progress.message}\n`) });
       return started.ok ? finish(await status(userRoot, daemonId), 0) : finish(daemonFailure("daemon-start", started.code ?? "daemon_start_failed", started.hint), 1); }
     if (command === "status") { const receipt = await status(userRoot, daemonId); return finish(receipt, 0); }
-    if (command === "stop") { const pid = readDaemonPid(userRoot, daemonId); if (pid === null) return finish(daemonFailure("daemon-stop", "daemon_unavailable", "No daemon is running."), 1); terminateProcess(pid); const stopped = await waitForDaemonStop(userRoot, daemonId); return stopped ? finish({ ok: true, command: "daemon-stop", pid }, 0) : finish(daemonFailure("daemon-stop", "daemon_stop_timeout", `Daemon pid ${pid} did not finish stopping within 5s; inspect its lifecycle log before sending another signal.`), 1); }
+    if (command === "stop") { const pid = readDaemonPid(userRoot, daemonId); if (pid === null) return finish(daemonFailure("daemon-stop", "daemon_unavailable", "No daemon is running."), 1); signalStop(pid); const stopped = await waitForDaemonStop(userRoot, daemonId, pid); return stopped ? finish({ ok: true, command: "daemon-stop", pid }, 0) : finish(daemonFailure("daemon-stop", "daemon_stop_timeout", `Daemon pid ${pid} did not finish stopping within 5s; inspect its lifecycle log before sending another signal.`), 1); }
     return finish(daemonFailure("daemon", "unsupported_command", "Use daemon repo register|unregister, fleet center start, fleet edge sync, start --service, status, or stop."), 2);
   } catch (error) { return finish(daemonFailure(`daemon-${command ?? "unknown"}`, code(error), message(error)), 1); }
 }
@@ -65,7 +66,26 @@ function deferredServeReceipt(incumbent: { readonly pid: number | null; readonly
   return { ok: true, command: "daemon-serve", outcome: "deferred", incumbent: { pid: incumbent.pid, endpoint: incumbent.endpoint }, summary: `daemon serve deferred: ${witness}; this process did not bind the socket or take any workspace writer lock.`, nextAction: "Use the resident daemon (ha daemon status) or stop it first (ha daemon stop)." };
 }
 async function status(userRoot: string, daemonId: string): Promise<Record<string, unknown>> { return requestDaemonJsonRpcAt(localUserDaemonEndpoint(userRoot, daemonId), "daemon.status", {}, 75) as Promise<Record<string, unknown>>; }
-async function waitForDaemonStop(userRoot: string, daemonId: string): Promise<boolean> { const endpoint = localUserDaemonEndpoint(userRoot, daemonId); for (const deadline = Date.now() + 5_000; Date.now() < deadline;) { if (readDaemonPid(userRoot, daemonId) === null && !existsSync(endpoint)) return true; await new Promise((resolve) => setTimeout(resolve, 10)); } return false; }
+// A daemon that exited between reading its pid file and being signalled is stopped, which is what
+// the caller asked for. Reporting the failed signal instead would answer a question nobody asked.
+function signalStop(pid: number): void {
+  try { terminateProcess(pid); } catch (error) { if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error; consumeKnownError(error); }
+}
+// Stop is done when nothing is held any more, and there are two ways to get there. Shutdown
+// releases the pid file and the endpoint as its last acts, which is the fast path and the only
+// one the original predicate knew. But Windows has no signals: process.kill terminates
+// unconditionally, shutdown never runs, and those two never go -- so a stop that had already
+// succeeded reported daemon_stop_timeout for the full five seconds (#1565). A dead process holds
+// nothing, so its exit is the second way, and whoever killed it clears the bookkeeping it left.
+async function waitForDaemonStop(userRoot: string, daemonId: string, pid: number): Promise<boolean> {
+  const endpoint = localUserDaemonEndpoint(userRoot, daemonId);
+  for (const deadline = Date.now() + 5_000; Date.now() < deadline;) {
+    if (readDaemonPid(userRoot, daemonId) === null && !existsSync(endpoint)) return true;
+    if (!daemonProcessAlive(pid)) { releaseDaemonPidFile(userRoot, daemonId, pid); return true; }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return false;
+}
 function daemonOption(argv: readonly string[], name: string): string | undefined { const at = argv.indexOf(name); return at < 0 ? undefined : argv[at + 1]; }
 function daemonFailure(command: string, errorCode: string, nextAction: string): Record<string, unknown> { return { schema: "command-receipt/v2", ok: false,
   command, outcome: "op_rejected", opId: "N/A", origin: "cli", code: errorCode, evidence: `rejection:${errorCode}`,

--- a/packages/cli/test/daemon-singleton-cli.test.ts
+++ b/packages/cli/test/daemon-singleton-cli.test.ts
@@ -11,6 +11,27 @@ import { daemonPidPath, readDaemonPid } from "../../daemon/src/runtime.ts";
 
 const cli = path.resolve("packages/cli/src/index.ts");
 
+// #1565: on Windows nothing delivers SIGTERM -- process.kill terminates unconditionally and the
+// daemon's shutdown never runs, so its pid file outlives it. `daemon stop` waited on that file and
+// reported daemon_stop_timeout for a daemon that had already stopped. SIGKILL reproduces the same
+// condition here: the handler does not run, and the file is left behind exactly as on Windows.
+test("#1565: a daemon whose shutdown never ran still yields a successful stop receipt", async () => {
+  const fixture = setup();
+  try {
+    assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
+    const pid = readDaemonPid(fixture.userRoot, "default");
+    assert.ok(pid, "the resident daemon must have published a pid");
+    process.kill(pid as number, "SIGKILL");
+    await waitForProcessExit(pid as number, 5_000);
+    assert.equal(existsSync(daemonPidPath(fixture.userRoot, "default")), true, "an ungraceful exit leaves the pid file behind");
+
+    const stopped = run(fixture.root, fixture.userRoot, ["daemon", "stop"]);
+    assert.equal(stopped.ok, true, JSON.stringify(stopped));
+    assert.notEqual(stopped.code, "daemon_stop_timeout");
+    assert.equal(existsSync(daemonPidPath(fixture.userRoot, "default")), false, "stop must clear the bookkeeping it outlived");
+  } finally { rmSync(fixture.parent, { recursive: true, force: true }); }
+});
+
 test("two concurrent daemon serves yield exactly one resident daemon and one deferral receipt", async () => {
   const fixture = setup();
   try {

--- a/packages/daemon/src/daemon-singleton.ts
+++ b/packages/daemon/src/daemon-singleton.ts
@@ -58,6 +58,12 @@ function readPidFile(target: string): number | null {
 function releaseIfHeld(lockPath: string, pid: number): void { if (readPidFile(lockPath) === pid) try { unlinkSync(lockPath); } catch (error) { if (!isCode(error, "ENOENT")) throw error; consumeKnownError(error); } }
 function processAlive(pid: number): boolean { try { process.kill(pid, 0); return true; } catch (error) { if (!isCode(error, "EPERM")) consumeKnownError(error); return isCode(error, "EPERM"); } }
 export function daemonProcessAlive(pid: number): boolean { return processAlive(pid); }
+/** A daemon removes its own pid file on the way out, but only when it gets to run shutdown.
+ * Windows has no signals: process.kill terminates unconditionally and no handler runs, so the
+ * file outlives the process and whoever killed it has to clear the bookkeeping (#1565). */
+export function releaseDaemonPidFile(userRoot: string, daemonId: string, pid: number): void {
+  releaseIfHeld(daemonPidPath(userRoot, daemonId), pid);
+}
 export async function daemonSocketProbe(socketPath: string): Promise<boolean> {
   return new Promise((resolve) => { const socket = net.createConnection(socketPath), finish = (up: boolean) => { socket.destroy(); resolve(up); }; const timer = setTimeout(() => finish(false), 250);
     socket.once("connect", () => { clearTimeout(timer); finish(true); }); socket.once("error", () => { clearTimeout(timer); finish(false); }); });


### PR DESCRIPTION
# English

## Summary

`ha daemon stop` waited for the pid file and the endpoint to disappear. Shutdown removes both as its last acts, so on POSIX that is a sound "nothing is held any more" test.

Windows has no signals. `process.kill(pid, "SIGTERM")` terminates the process unconditionally, the `SIGTERM` handler never runs, `daemon.stop()` never runs, and neither the pid file nor the endpoint is ever removed. The daemon was already dead within milliseconds; `stop` reported `daemon_stop_timeout` for the full five seconds, every time.

**The filed hypothesis was wrong and was falsified by measurement.** #1565 says the 5s poll "requires the named-pipe name to clear". A probe on the Windows 11 VM says otherwise:

```
listening exists: true
after 0ms exists: false     after 50ms: false     after 3000ms: false
```

The pipe name clears immediately. The half that lags is the pid file, and it lags forever, because the only code that removes it lives in a handler that Windows never invokes.

A dead process holds nothing, so its exit is a second way to be stopped, and whoever killed it clears the bookkeeping it left behind. **Both paths stay.** Replacing the resource test with process liveness looked cleaner and broke the concurrent-singleton test: on POSIX shutdown releases the pid file and endpoint well before the process finishes exiting, so waiting for the exit exceeded 5s. That is the measurement that turned this from a replacement into a union.

Production-Delta: +28/-2

## What Changed

- `packages/cli/src/daemon/control.ts`: `waitForDaemonStop` accepts either "resources released" or "the process is gone", and clears a pid file that still names the dead pid. `signalStop` treats `ESRCH` as already-stopped — a daemon that exited between the pid read and the signal is stopped, which is what was asked for.
- `packages/daemon/src/daemon-singleton.ts`: `releaseDaemonPidFile` exposes the existing hold-check so the stopper does not hand-roll it.
- `packages/cli/test/daemon-singleton-cli.test.ts`: `SIGKILL` reproduces the Windows condition — no handler runs, the pid file survives — so the regression test has teeth without Windows.

## Task And Scope

- Harness task: `task_0dab34ca03b28cf61d2a35d85c` — Windows P0-P2 repair wave #1565-#1589
- Branch: `fix/windows-daemon-stop-receipt`
- Public scope: `packages/cli`, `packages/daemon`
- Private planning/evidence updated: yes
- Out of scope: **Windows stop is not graceful.** The daemon is hard-killed and never drains. That is a real gap this investigation uncovered and it needs a `daemon.stop` request over the existing JSON-RPC surface, which does not exist today. It is a separate defect, not a bigger version of this one.

## Version Impact

- Version: no version change because this corrects a receipt and changes no published contract.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none
- Authorizing task: `task_0dab34ca03b28cf61d2a35d85c`

## Verification

- Base `origin/main` SHA: `3dd39300b79ca7dff3c73ed7213de4f057392437`
- Branch merge-base with `origin/main`: `3dd39300b79ca7dff3c73ed7213de4f057392437`
- Last `git fetch origin` time: 2026-08-19, immediately before branching
- Sync method: branched from current `origin/main`
- Public diff command: `git diff 3dd39300b79ca7dff3c73ed7213de4f057392437..HEAD`
- Private evidence commit/path: `harness/tasks/task_0dab34ca03b28cf61d2a35d85c-windows-p0-p2-repair-wave-1565-1589/`
- Reviewer evidence path: the VM probe and mutation results below
- GitHub Actions `rewrite-ci` run URL: see this PR's checks
- [x] `npm run check:local` (fast tier, green)
- [x] `npm run typecheck`, `npm run lint`
- [x] `node --test packages/cli/test/daemon-singleton-cli.test.ts` — 3/3
- [x] `node --test packages/cli/test/daemon-autostart-cli.test.ts packages/cli/test/daemon-receipt-cli.test.ts packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts` — 26/26
- [x] `node tools/gates/line-budget.mjs --base origin/main` (pass)

## Review Evidence

- **The reported mechanism was falsified on real hardware before anything was changed.** A named-pipe probe on the Windows 11 arm64 VM shows the name clearing at 0ms after `close()`, which rules out the filed explanation and points at the pid file.
- **A first fix was built, tested and rejected.** Switching the predicate to process liveness alone passed the new test and turned `two concurrent daemon serves yield exactly one resident daemon and one deferral receipt` red with `daemon_stop_timeout`. That failure is what established that the resource test is correct on POSIX and the fix is a union, not a replacement.
- **Mutation:** removing the dead-process branch turns the #1565 test red and leaves the other two green. The test measures the repair, not the neighbourhood.
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none

## Residual Risk

- **This corrects the receipt, not the shutdown.** On Windows the daemon is still terminated without draining. Anything shutdown would have flushed is still not flushed; the difference is that `stop` now says what happened instead of describing a timeout that did not occur.
- The dead-process branch makes `stop` succeed for a daemon somebody else killed. That is the honest answer to "is it stopped", but it means a successful stop receipt no longer implies this command is what stopped it.
- Verified on macOS via `SIGKILL`, which reproduces "no handler runs" faithfully. The Windows path itself is verified by the `windows-first-run` lane once it is in place, not by this PR.

## References

- Task: `task_0dab34ca03b28cf61d2a35d85c`
- Evidence: the VM probe and mutation results above
- Review: #1565

---

# 中文

## 摘要

`ha daemon stop` 等的是 pid 文件和 endpoint 消失。停机流程把这两样作为最后动作删掉，所以在 POSIX 上这是一个成立的「已经不再持有任何东西」判据。

Windows 没有信号。`process.kill(pid, "SIGTERM")` 无条件终止进程，`SIGTERM` handler 从不运行，`daemon.stop()` 从不运行，pid 文件和 endpoint 一个都不会被删。daemon 其实几毫秒内就死了；`stop` 每一次都要把五秒等满，然后报 `daemon_stop_timeout`。

**issue 里写的机制是错的，并且是被实测推翻的。** #1565 说 5s 轮询「要等命名管道名清掉」。Windows 11 虚拟机上的探针给出相反答案：

```
listening exists: true
after 0ms exists: false     after 50ms: false     after 3000ms: false
```

管道名是立刻消失的。滞后的那一半是 pid 文件，而且它会永远滞后，因为唯一会删它的代码在一个 Windows 从不触发的 handler 里。

死进程不持有任何东西，所以它的退出是第二条「已停止」的路径；而杀掉它的人负责清理它留下的簿记。**两条路径都保留。** 把资源判据整个换成进程存活看着更干净，结果打红了并发单例那条测试：POSIX 上停机流程释放 pid 文件与 endpoint 的时间点，远早于进程真正退完，等退出会超过 5s。正是这次失败把这个修法从「替换」变成了「并集」。

## 变更内容

- `packages/cli/src/daemon/control.ts`：`waitForDaemonStop` 接受「资源已释放」**或**「进程已消失」两者之一，并清掉仍然指向那个死 pid 的 pid 文件。`signalStop` 把 `ESRCH` 当作已停止 —— 在读 pid 与发信号之间自己退掉的 daemon 就是停了，而这正是调用者要的。
- `packages/daemon/src/daemon-singleton.ts`：`releaseDaemonPidFile` 把已有的「持有校验」暴露出来，免得停止方自己再手写一遍。
- `packages/cli/test/daemon-singleton-cli.test.ts`：`SIGKILL` 在本地忠实复现 Windows 条件 —— handler 不运行、pid 文件留下 —— 所以这条回归测试不需要 Windows 也有牙齿。

## 任务与范围

- Harness 任务：`task_0dab34ca03b28cf61d2a35d85c` —— Windows P0-P2 修复波次 #1565-#1589
- 分支：`fix/windows-daemon-stop-receipt`
- 公开范围：`packages/cli`、`packages/daemon`
- 私有规划/证据已更新：是
- 不在范围内：**Windows 上的停机不是优雅停机。** daemon 是被硬杀的，从不 drain。这是本次调查挖出来的真实缺口，需要在既有 JSON-RPC 面上加一个 `daemon.stop` 请求，而这个方法今天不存在。它是另一个缺陷，不是本缺陷的放大版。

## 版本影响

- 版本：不变，因为这只修正一份回执，没有改动任何已发布契约。
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权依据：不适用
- 机器检查边界：本 PR 只断言声明存在；声明是否属实、是否充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：无
- 授权任务：`task_0dab34ca03b28cf61d2a35d85c`

## 验证

- 基线 `origin/main` SHA：`3dd39300b79ca7dff3c73ed7213de4f057392437`
- 分支与 `origin/main` 的 merge-base：`3dd39300b79ca7dff3c73ed7213de4f057392437`
- 最近一次 `git fetch origin` 时间：2026-08-19，开分支前
- 同步方式：直接从当前 `origin/main` 开出
- 公开 diff 命令：`git diff 3dd39300b79ca7dff3c73ed7213de4f057392437..HEAD`
- 私有证据路径：`harness/tasks/task_0dab34ca03b28cf61d2a35d85c-windows-p0-p2-repair-wave-1565-1589/`
- 评审证据路径：下方真机探针与 mutation 结果
- GitHub Actions `rewrite-ci` run URL：见本 PR 的 checks
- [x] `npm run check:local`（fast tier，绿）
- [x] `npm run typecheck`、`npm run lint`
- [x] `node --test packages/cli/test/daemon-singleton-cli.test.ts` —— 3/3
- [x] `node --test packages/cli/test/daemon-autostart-cli.test.ts packages/cli/test/daemon-receipt-cli.test.ts packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts` —— 26/26
- [x] `node tools/gates/line-budget.mjs --base origin/main`（通过）

## 评审证据

- **报告里的机制在动手改之前就已在真机上被证伪。** Windows 11 arm64 虚拟机上的命名管道探针显示，`close()` 后 0ms 名字就没了，排除了 issue 给出的解释，指向 pid 文件。
- **第一版修法做完、测完、被否掉了。** 把判据整个换成进程存活能让新测试通过，却把 `two concurrent daemon serves yield exactly one resident daemon and one deferral receipt` 打成 `daemon_stop_timeout`。正是这次失败确立了「资源判据在 POSIX 上是对的、修法应是并集而非替换」。
- **Mutation：** 去掉死进程那条分支，#1565 测试转红，另外两条保持绿。这条测试量的是修复本身，不是它的邻居。
- Reviewer subagent：无
- 人工审查：待办
- 阻塞发现：无

## 残余风险

- **这修的是回执，不是停机。** Windows 上 daemon 仍然是不 drain 就被终止。停机流程本该刷盘的东西照样没刷；差别只在于 `stop` 现在说的是实际发生的事，而不是一个并未发生的超时。
- 死进程分支会让「别人杀掉的 daemon」也返回成功。这是对「它停了吗」这个问题的诚实回答，但也意味着一份成功的 stop 回执不再蕴含「是这条命令把它停掉的」。
- 在 macOS 上用 `SIGKILL` 验证，它忠实复现了「handler 不运行」。Windows 路径本身由 `windows-first-run` lane 落地后验证，不由本 PR 验证。

## 关联材料

- 任务：`task_0dab34ca03b28cf61d2a35d85c`
- 证据：上方真机探针与 mutation 结果
- 审查：#1565
