### PR TITLE
fix(repo): pin the bytes that are the assertion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Some bytes in this repository are the assertion, not a rendering of it: preset asset bodies are
+# published to users verbatim, and test fixtures are hashed and compared against digests recorded
+# in production. A checkout that converts line endings rewrites them and every digest derived from
+# them changes -- the same mechanism as #1588 in the ledger, one layer up.
+#
+# Source stays convertible on purpose. A Windows contributor gets CRLF sources like any other, and
+# the crlf-checkout lane keeps the teeth it needs to find the next defect in this class.
+packages/preset/assets/** -text
+packages/*/test/fixtures/** -text


### PR DESCRIPTION
# English

## Summary

The `crlf-checkout` lane's first run found five failures. Four reproduce locally and share one root cause; this fixes those four.

Some bytes in this repository are the assertion, not a rendering of it:

- `packages/kernel/test/fixtures/review-consent/*.packet.json` is hashed and compared against a digest **recorded by a real production consent**. The test exists to prove the projection still reproduces that value.
- `packages/preset/assets/**` template bodies are published to users verbatim and are materialized into `task_plan.md`.

A checkout that converts line endings rewrites both, and every digest derived from them changes. Measured on a `core.autocrlf=true` clone of `main`:

| test | failure |
| --- | --- |
| `the projected ReviewV1 is complete and reproduces the production consent digests` | `sha256:8973a7…` against the recorded `sha256:5b0dcb…` |
| `F1: the fleet doc-submit channel cannot write task documents without the held execution` | `op_rejected` / `unresolved_touch` |
| `F2: a crash after the atomic bundle commit replays both the transition and carried document` | bundle did not replay with its document |
| `F8: the mirror gate fences on cut identity` | same |

The three F-tests are downstream of the same thing: their `task_plan.md` is materialized from CRLF template bodies, and doc-sync then refuses the touches it cannot resolve.

This is #1588's mechanism one layer up — the ledger's line-ending rule had to be committed to travel with a clone, and so does this one.

**Source stays convertible on purpose.** A blanket `* -text` would fix these four and simultaneously make the `crlf-checkout` lane a no-op, because nothing in the checkout would ever convert again. A Windows contributor gets CRLF sources like anyone else, and the lane keeps the teeth it needs to find the next defect in this class.

Production-Delta: +0/-0

## What Changed

- `.gitattributes`: new, at the repository root. `packages/preset/assets/** -text` and `packages/*/test/fixtures/** -text`, with the reason inline.

## Task And Scope

- Harness task: `task_0dab34ca03b28cf61d2a35d85c` — Windows P0-P2 repair wave #1565-#1589
- Branch: `fix/byte-pinned-paths-gitattributes`
- Public scope: repository root
- Private planning/evidence updated: yes
- Out of scope, and worth its own issue: **doc-sync refuses CRLF authored content with `unresolved_touch`.** Pinning our template bodies stops our tests from producing CRLF documents; it does nothing for a user who authors a document on Windows. That is a product limitation this lane surfaced, not a test defect, and it is not fixed here. The fifth CI failure (`integration shard declaration is non-overlapping and complete`) did not reproduce locally and is not addressed either.

## Version Impact

- Version: no version change because this adds a repository attribute file and changes no published contract.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none
- Authorizing task: `task_0dab34ca03b28cf61d2a35d85c`

## Verification

- Base `origin/main` SHA: `0742635e745d22388e18233bcd1793694fb170ce`
- Branch merge-base with `origin/main`: `0742635e745d22388e18233bcd1793694fb170ce`
- Last `git fetch origin` time: 2026-08-19, immediately before branching
- Sync method: branched from current `origin/main`
- Public diff command: `git diff 0742635e745d22388e18233bcd1793694fb170ce..HEAD`
- Private evidence commit/path: `harness/tasks/task_0dab34ca03b28cf61d2a35d85c-windows-p0-p2-repair-wave-1565-1589/`
- Reviewer evidence path: the before/after clone measurements below
- GitHub Actions `rewrite-ci` run URL: see this PR's checks
- [x] `npm run check:local` (fast tier, green)
- [x] `core.autocrlf=true` clone of this branch: the four tests are 9/9 green in their files
- [x] `node tools/gates/production-delta.mjs --base origin/main` (+0/-0)
- [x] `node tools/gates/line-budget.mjs --base origin/main` (pass)

## Review Evidence

- **The failures were reproduced locally before anything was changed.** A `core.autocrlf=true` clone of `main` fails exactly the four tests the CI lane reported, with the same messages. This is the same technique that turned #1588 from a Windows report into a local acceptance test.
- **Scope was measured, not assumed.** In a converting clone of this branch: the preset template body holds 0 carriage returns, the digest fixture holds 0, and `packages/kernel/src/index.ts` still holds 93. The pin covers the bytes that are load-bearing and nothing else.
- **Before/after on the same clone:** the four tests fail on `main`, pass on this branch, in a checkout configured the same way both times.
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none

## Residual Risk

- **The path patterns are a judgement about which bytes are load-bearing, and that judgement can go stale.** A future digest fixture placed outside `test/fixtures/`, or a published asset outside `packages/preset/assets/`, is not covered and will fail the same way. Nothing enforces the correspondence.
- `packages/*/test/fixtures/**` pins fixtures that are not hashed as well. That is harmless but broader than the evidence strictly requires.
- The doc-sync limitation above is real and unaddressed. This change makes our tests stop hitting it, which is exactly the shape of a fix that hides a defect — it is called out here for that reason.

## References

- Task: `task_0dab34ca03b28cf61d2a35d85c`
- Evidence: the clone measurements above
- Review: #1588, and the `crlf-checkout` lane in #1597

---

# 中文

## 摘要

`crlf-checkout` lane 第一次跑就报了五条红。其中四条本地可复现、同一根因；本 PR 修这四条。

这个仓里有些字节**本身就是断言**，不是断言的一种呈现：

- `packages/kernel/test/fixtures/review-consent/*.packet.json` 会被哈希，并与**一次真实生产 consent 记录下来的摘要**比对。这条测试存在的意义就是证明投影仍能复现那个值。
- `packages/preset/assets/**` 里的模板正文会原样发布给用户，并被物化成 `task_plan.md`。

转换行尾的检出把这两类都改写了，从它们派生的每一个摘要随之改变。在 `main` 的 `core.autocrlf=true` 克隆上实测：

| 测试 | 失败表现 |
| --- | --- |
| `the projected ReviewV1 is complete and reproduces the production consent digests` | 算出 `sha256:8973a7…`，记录值是 `sha256:5b0dcb…` |
| `F1: the fleet doc-submit channel cannot write task documents without the held execution` | `op_rejected` / `unresolved_touch` |
| `F2: a crash after the atomic bundle commit replays both the transition and carried document` | bundle 没有与其文档一起重放 |
| `F8: the mirror gate fences on cut identity` | 同上 |

三条 F 测试是同一件事的下游：它们的 `task_plan.md` 由 CRLF 模板正文物化而来，doc-sync 随后拒收它解析不了的 touch。

这就是 #1588 的机制上移一层 —— 台账的行尾规则必须被提交才能随 clone 走，这里同理。

**源码刻意保持可转换。** 一刀切的 `* -text` 能修好这四条，同时也会让 `crlf-checkout` lane 变成空转，因为检出里再没有任何东西会被转换。Windows 上的贡献者和其他人一样拿到 CRLF 源码，而这条 lane 保住了它下一次发现同类缺陷所需要的牙齿。

## 变更内容

- `.gitattributes`：新增，位于仓库根。`packages/preset/assets/** -text` 与 `packages/*/test/fixtures/** -text`，理由写在文件里。

## 任务与范围

- Harness 任务：`task_0dab34ca03b28cf61d2a35d85c` —— Windows P0-P2 修复波次 #1565-#1589
- 分支：`fix/byte-pinned-paths-gitattributes`
- 公开范围：仓库根
- 私有规划/证据已更新：是
- 不在范围内，且值得单独开 issue：**doc-sync 会以 `unresolved_touch` 拒收 CRLF 的 authored 内容。** 把我们的模板正文钉住，只是让我们的测试不再产出 CRLF 文档；对一个在 Windows 上撰写文档的用户毫无帮助。这是这条 lane 浮出来的**产品限制**，不是测试缺陷，本 PR 不修它。第五条 CI 失败（`integration shard declaration is non-overlapping and complete`）本地未复现，同样不在本 PR 内。

## 版本影响

- 版本：不变，因为这只新增一个仓库属性文件，没有改动任何已发布契约。
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权依据：不适用
- 机器检查边界：本 PR 只断言声明存在；声明是否属实、是否充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：无
- 授权任务：`task_0dab34ca03b28cf61d2a35d85c`

## 验证

- 基线 `origin/main` SHA：`0742635e745d22388e18233bcd1793694fb170ce`
- 分支与 `origin/main` 的 merge-base：`0742635e745d22388e18233bcd1793694fb170ce`
- 最近一次 `git fetch origin` 时间：2026-08-19，开分支前
- 同步方式：直接从当前 `origin/main` 开出
- 公开 diff 命令：`git diff 0742635e745d22388e18233bcd1793694fb170ce..HEAD`
- 私有证据路径：`harness/tasks/task_0dab34ca03b28cf61d2a35d85c-windows-p0-p2-repair-wave-1565-1589/`
- 评审证据路径：下方克隆前后实测
- GitHub Actions `rewrite-ci` run URL：见本 PR 的 checks
- [x] `npm run check:local`（fast tier，绿）
- [x] 本分支的 `core.autocrlf=true` 克隆：四条测试所在文件 9/9 全绿
- [x] `node tools/gates/production-delta.mjs --base origin/main`（+0/-0）
- [x] `node tools/gates/line-budget.mjs --base origin/main`（通过）

## 评审证据

- **动手改之前先在本地复现。** `main` 的 `core.autocrlf=true` 克隆恰好失败在 CI lane 报的那四条上，报错一致。这和把 #1588 从「Windows 报告」变成「本地验收测试」用的是同一手法。
- **覆盖范围是量出来的，不是假设的。** 在本分支的转换型克隆里：preset 模板正文 0 个回车，摘要 fixture 0 个，而 `packages/kernel/src/index.ts` 仍有 93 个。钉住的正好是承重字节，没有多余。
- **同一克隆条件下的前后对比：** 四条在 `main` 上红，在本分支上绿。
- Reviewer subagent：无
- 人工审查：待办
- 阻塞发现：无

## 残余风险

- **路径模式是一次「哪些字节承重」的判断，而判断会过期。** 未来放在 `test/fixtures/` 之外的摘要 fixture，或 `packages/preset/assets/` 之外的发布资产，都不在覆盖范围内，会以同样的方式失败。没有任何机制保证这个对应关系。
- `packages/*/test/fixtures/**` 也钉住了并不参与哈希的 fixture。无害，但比证据严格要求的范围更宽。
- 上面那条 doc-sync 限制是真的且未处理。本变更让我们的测试不再撞上它 —— 这正是「修复掩盖缺陷」的典型形状，所以在这里明确点名。

## 关联材料

- 任务：`task_0dab34ca03b28cf61d2a35d85c`
- 证据：上方克隆实测
- 审查：#1588，以及 #1597 里的 `crlf-checkout` lane
