### PR TITLE
chore(ci): make the Windows and CRLF lanes required

### DIFF
--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -28,12 +28,9 @@ Required pull request checks must cover:
 - package policy
 - GUI build smoke
 - Node 26 compatibility for typecheck plus fast and contract tests
-Platform coverage runs on every pull request but is **not yet required**:
-`crlf-checkout`, and `windows-first-run` on `ubuntu-latest` and `windows-latest`.
-Requiring a context that has never passed would block every merge including the
-one that makes it pass. The promotion condition is the `windows-latest` arm
-green on `main`; at that point all three move into the ruleset, the Mergify
-queue and the required list above, together.
+Platform coverage is required: `crlf-checkout`, and `windows-first-run` on
+`ubuntu-latest` and `windows-latest`. They landed advisory in #1597 because the
+`windows-latest` arm had never passed, and were promoted once it did on `main`.
 
 They are platform coverage and were added after a run of Windows
 defects reached users through a fully green pull request. They divide that
@@ -73,6 +70,9 @@ The active GitHub ruleset enforcement for `main` requires these status contexts:
 - gui-build
 - node26-compatibility
 - pr-body-lint
+- crlf-checkout
+- windows-first-run (ubuntu-latest)
+- windows-first-run (windows-latest)
 
 The Mergify GitHub App must be installed from
 https://github.com/marketplace/mergify before maintainers rely on the queue.
@@ -96,6 +96,9 @@ against the queued pull request's predicted merge state.
 - gui-build
 - node26-compatibility
 - pr-body-lint
+- crlf-checkout
+- windows-first-run (ubuntu-latest)
+- windows-first-run (windows-latest)
 
 The `pr-body-lint` job checks human-authored pull request bodies against the
 repository template. It narrowly skips Mergify synthetic queue verification pull

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -20,6 +20,9 @@ queue_rules:
       - check-success = gui-build
       - check-success = node26-compatibility
       - check-success = pr-body-lint
+      - check-success = crlf-checkout
+      - check-success = "windows-first-run (ubuntu-latest)"
+      - check-success = "windows-first-run (windows-latest)"
     merge_conditions: []
 
 pull_request_rules:

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -179,7 +179,10 @@
         "supply-chain",
         "gui-build",
         "node26-compatibility",
-        "pr-body-lint"
+        "pr-body-lint",
+        "crlf-checkout",
+        "windows-first-run (ubuntu-latest)",
+        "windows-first-run (windows-latest)"
       ],
       "enforceAdmins": false
     }
@@ -500,7 +503,10 @@
           "package-policy",
           "supply-chain",
           "gui-build",
-          "node26-compatibility"
+          "node26-compatibility",
+          "crlf-checkout",
+          "windows-first-run (ubuntu-latest)",
+          "windows-first-run (windows-latest)"
         ],
         "workflowJobs": [
           "pr-body-lint",
@@ -574,7 +580,10 @@
             "package-policy",
             "supply-chain",
             "gui-build",
-            "node26-compatibility"
+            "node26-compatibility",
+            "crlf-checkout",
+            "windows-first-run (ubuntu-latest)",
+            "windows-first-run (windows-latest)"
           ]
         },
         "classes": [
@@ -690,7 +699,8 @@
       ],
       "githubContext": {
         "requiredContexts": [
-          "boundaries"
+          "boundaries",
+          "crlf-checkout"
         ],
         "workflowJobs": [
           "boundaries",
@@ -734,7 +744,8 @@
         "branchProtection": {
           "required": true,
           "contexts": [
-            "boundaries"
+            "boundaries",
+            "crlf-checkout"
           ]
         },
         "classes": [
@@ -836,7 +847,8 @@
       "githubContext": {
         "requiredContexts": [
           "fast-contract",
-          "node26-compatibility"
+          "node26-compatibility",
+          "crlf-checkout"
         ],
         "workflowJobs": [
           "fast-contract",
@@ -881,7 +893,8 @@
           "required": true,
           "contexts": [
             "fast-contract",
-            "node26-compatibility"
+            "node26-compatibility",
+            "crlf-checkout"
           ]
         },
         "classes": [
@@ -919,7 +932,8 @@
       "githubContext": {
         "requiredContexts": [
           "fast-contract",
-          "node26-compatibility"
+          "node26-compatibility",
+          "crlf-checkout"
         ],
         "workflowJobs": [
           "fast-contract",
@@ -965,7 +979,8 @@
           "required": true,
           "contexts": [
             "fast-contract",
-            "node26-compatibility"
+            "node26-compatibility",
+            "crlf-checkout"
           ]
         },
         "classes": [
@@ -4355,8 +4370,8 @@
       "id": "windows-first-run",
       "command": "npm run harness:windows-first-run",
       "category": "smoke",
-      "tier": "pr-advisory",
-      "tierReason": "Runs on every pull request but is not yet a required context: the windows-latest arm has never been green, and requiring a context that cannot pass would block every merge including the one that fixes it. Promotion condition: the windows-latest arm green on main.",
+      "tier": "pr-required",
+      "tierReason": null,
       "authoritySource": [
         "tools/gates/windows-first-run.mjs",
         ".github/workflows/rewrite-ci.yml"
@@ -4365,7 +4380,10 @@
         "First-run product path on every supported platform: init, resident daemon, task and fact publication, ledger clone fidelity, and daemon stop"
       ],
       "githubContext": {
-        "requiredContexts": [],
+        "requiredContexts": [
+          "windows-first-run (ubuntu-latest)",
+          "windows-first-run (windows-latest)"
+        ],
         "workflowJobs": [
           "windows-first-run"
         ],
@@ -4404,8 +4422,11 @@
           ]
         },
         "branchProtection": {
-          "required": false,
-          "contexts": []
+          "required": true,
+          "contexts": [
+            "windows-first-run (ubuntu-latest)",
+            "windows-first-run (windows-latest)"
+          ]
         },
         "classes": [
           "local",


### PR DESCRIPTION
# English

## Summary

`crlf-checkout` and both arms of `windows-first-run` landed advisory in #1597, because the `windows-latest` arm had never passed and a required context that cannot pass blocks every merge including the one that fixes it. It passes now, on `main`, so the declaration catches up.

What the lanes found between landing and this promotion, all on `main`:

| finding | fixed in |
| --- | --- |
| the gate runner hardcoded `shell: "/bin/sh"` — the Windows lane died before any gate ran | #1597 |
| `daemon stop` reported `daemon_stop_timeout` for a daemon that had already stopped | #1600 |
| preset asset bodies and digest fixtures were rewritten by a converting checkout | #1601 |
| `workflow-base-sha` matched an LF-only pattern and reported a trigger missing that was there | #1597 |
| doc-sync refuses CRLF authored content with `unresolved_touch` | filed as #1602 |

The hosted ruleset now enforces 17 contexts; `check-github-required-contexts` verifies it against the manifest and passes.

Production-Delta: +0/-0

## What Changed

- `tools/gate-manifest.json`: `windows-first-run` returns to `pr-required` with its two contexts; `lint`, `test-fast` and `test-contract` declare `crlf-checkout`; the three contexts join `surfaces.branchProtection.requiredContexts` and the Mergify no-op gate.
- `.mergify.yml`: the three contexts join `queue_conditions`.
- `.github/branch-protection.md`: both required lists, and the paragraph that said "not yet required" now records that they were promoted and why they were not required on arrival.

## Task And Scope

- Harness task: `task_0dab34ca03b28cf61d2a35d85c` — Windows P0-P2 repair wave #1565-#1589
- Branch: `chore/promote-windows-lanes-required`
- Public scope: `.github`, `tools`, `.mergify.yml`
- Private planning/evidence updated: yes
- Out of scope: #1579, #1589 and #1602 remain open. Running the existing test tiers on Windows is still blocked on the first two.

## Version Impact

- Version: no version change because this changes required-check declarations and no published contract.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gate-manifest.json`, `.github/branch-protection.md`, `.mergify.yml`
- Authority: `task_0dab34ca03b28cf61d2a35d85c`. The repository owner authorized promotion conditional on the `windows-latest` arm going green; it did, on `main`, in #1597.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none
- Authorizing task: `task_0dab34ca03b28cf61d2a35d85c`

## Verification

- Base `origin/main` SHA: `9ae3eb9f428a7a81a49cfa1bfa4ca1e288276669`
- Branch merge-base with `origin/main`: `9ae3eb9f428a7a81a49cfa1bfa4ca1e288276669`
- Last `git fetch origin` time: 2026-08-19, immediately before branching
- Sync method: branched from current `origin/main`
- Public diff command: `git diff 9ae3eb9f428a7a81a49cfa1bfa4ca1e288276669..HEAD`
- Private evidence commit/path: `harness/tasks/task_0dab34ca03b28cf61d2a35d85c-windows-p0-p2-repair-wave-1565-1589/`
- Reviewer evidence path: the hosted-ruleset reconciliation below
- GitHub Actions `rewrite-ci` run URL: see this PR's checks
- [x] `npm run check:local` (fast tier, green)
- [x] `node tools/check-gate-surface.mjs` (56 gates, 0 drift)
- [x] `node tools/check-mergify-queue-contexts.mjs` (17 contexts)
- [x] `node tools/check-gate-manifest-invariants.mjs` (47/56 deterministic)
- [x] `GITHUB_REPOSITORY=… node tools/check-github-required-contexts.mjs` — **17 contexts, passed against the live ruleset**
- [x] `node tools/gates/production-delta.mjs --base origin/main` (+0/-0)

## Review Evidence

- **The hosted ruleset was changed first and reconciled against the manifest.** Before: 14 contexts. After: 17. The other three rules (`deletion`, `non_fast_forward`, `pull_request`), the conditions and the empty bypass-actor list are unchanged — compared field by field against a snapshot taken before the edit.
- **The promotion condition was met on `main`, not on a branch.** #1597 merged with `crlf-checkout`, `windows-first-run (ubuntu-latest)` and `windows-first-run (windows-latest)` all green, 33/33.
- The ordering was chosen so no window exists where the manifest requires a context the ruleset does not: the hosted change went first, and `check-github-required-contexts` only fails on manifest-ahead-of-hosted.
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none

## Residual Risk

- **A required Windows context means a Windows runner outage blocks merges.** That is the point of requiring it, and it is also a new dependency on GitHub's Windows fleet that this repository did not have before.
- `windows-first-run` covers one path with eleven assertions. Making it required states that the first-run path must work on Windows; it does not state that the product works on Windows. The honest version of that is the test tiers running there, still blocked on #1579 and #1589.
- The hosted ruleset is edited outside this diff. Nothing prevents it from drifting again; `check-github-required-contexts` detects drift in one direction only — a context required by the ruleset but absent from the manifest would not be reported.

## References

- Task: `task_0dab34ca03b28cf61d2a35d85c`
- Evidence: the reconciliation above
- Review: #1597, #1600, #1601, #1602

---

# 中文

## 摘要

`crlf-checkout` 与 `windows-first-run` 的两条臂在 #1597 里是以「运行但不承重」的姿态合入的，因为当时 `windows-latest` 那条从未通过过，而把一个不可能通过的 context 设为必需，会连"修好它的那个 PR"一起拦死。它现在在 `main` 上通过了，所以声明追上来。

从合入到本次提升之间，这两条 lane 在 `main` 上找到的东西：

| 发现 | 修复于 |
| --- | --- |
| 门运行器硬编码 `shell: "/bin/sh"` —— Windows lane 在任何门跑起来之前就死了 | #1597 |
| `daemon stop` 对一个早已停止的 daemon 报 `daemon_stop_timeout` | #1600 |
| preset 资产正文与摘要 fixture 被转换型检出改写 | #1601 |
| `workflow-base-sha` 用只认 LF 的模式匹配，把明明在那儿的 trigger 报成缺失 | #1597 |
| doc-sync 以 `unresolved_touch` 拒收 CRLF 的 authored 内容 | 已登记为 #1602 |

托管 ruleset 现在执行 17 个 context；`check-github-required-contexts` 对着 manifest 核过，通过。

## 变更内容

- `tools/gate-manifest.json`：`windows-first-run` 回到 `pr-required` 并带上它的两个 context；`lint`、`test-fast`、`test-contract` 声明 `crlf-checkout`；三个 context 进入 `surfaces.branchProtection.requiredContexts` 和 Mergify no-op 门。
- `.mergify.yml`：三个 context 进入 `queue_conditions`。
- `.github/branch-protection.md`：两份必需清单，以及那段原本写着「尚未必需」的说明，现在记录它们已被提升、以及当初为什么不是一上来就必需。

## 任务与范围

- Harness 任务：`task_0dab34ca03b28cf61d2a35d85c` —— Windows P0-P2 修复波次 #1565-#1589
- 分支：`chore/promote-windows-lanes-required`
- 公开范围：`.github`、`tools`、`.mergify.yml`
- 私有规划/证据已更新：是
- 不在范围内：#1579、#1589、#1602 仍然开着。在 Windows 上跑既有测试层依旧被前两个卡着。

## 版本影响

- 版本：不变，因为这只改必需检查的声明，没有改动任何已发布契约。
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是
- 受保护面范围：`tools/gate-manifest.json`、`.github/branch-protection.md`、`.mergify.yml`
- 授权依据：`task_0dab34ca03b28cf61d2a35d85c`。仓库所有者授权在 `windows-latest` 臂转绿后提升；它在 #1597 里于 `main` 上转绿了。
- 机器检查边界：本 PR 只断言声明存在；声明是否属实、是否充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：无
- 授权任务：`task_0dab34ca03b28cf61d2a35d85c`

## 验证

- 基线 `origin/main` SHA：`9ae3eb9f428a7a81a49cfa1bfa4ca1e288276669`
- 分支与 `origin/main` 的 merge-base：`9ae3eb9f428a7a81a49cfa1bfa4ca1e288276669`
- 最近一次 `git fetch origin` 时间：2026-08-19，开分支前
- 同步方式：直接从当前 `origin/main` 开出
- 公开 diff 命令：`git diff 9ae3eb9f428a7a81a49cfa1bfa4ca1e288276669..HEAD`
- 私有证据路径：`harness/tasks/task_0dab34ca03b28cf61d2a35d85c-windows-p0-p2-repair-wave-1565-1589/`
- 评审证据路径：下方托管 ruleset 对账
- GitHub Actions `rewrite-ci` run URL：见本 PR 的 checks
- [x] `npm run check:local`（fast tier，绿）
- [x] `node tools/check-gate-surface.mjs`（56 门，0 drift）
- [x] `node tools/check-mergify-queue-contexts.mjs`（17 context）
- [x] `node tools/check-gate-manifest-invariants.mjs`（47/56 确定性）
- [x] `GITHUB_REPOSITORY=… node tools/check-github-required-contexts.mjs` —— **17 context，对着线上 ruleset 通过**
- [x] `node tools/gates/production-delta.mjs --base origin/main`（+0/-0）

## 评审证据

- **先改托管 ruleset，再与 manifest 对账。** 改前 14 个 context，改后 17 个。另外三条规则（`deletion`、`non_fast_forward`、`pull_request`）、conditions 以及空的 bypass actor 列表均未变 —— 对着改动前的快照逐字段比过。
- **提升条件是在 `main` 上满足的，不是在分支上。** #1597 合入时 `crlf-checkout`、`windows-first-run (ubuntu-latest)`、`windows-first-run (windows-latest)` 全绿，33/33。
- 顺序是刻意选的，避免出现「manifest 要求而 ruleset 没有」的窗口：先改托管侧，而 `check-github-required-contexts` 只在 manifest 领先于托管时报错。
- Reviewer subagent：无
- 人工审查：待办
- 阻塞发现：无

## 残余风险

- **Windows context 成为必需，意味着 GitHub Windows 机群故障会拦下合并。** 这正是「必需」的含义，但它也是本仓此前没有的一项新依赖。
- `windows-first-run` 覆盖的是一条路径上的十一条断言。把它设为必需，断言的是「首次运行路径在 Windows 上必须能用」，不是「产品在 Windows 上能用」。后者的诚实版本是测试层在那里跑起来，而那仍被 #1579 与 #1589 卡着。
- 托管 ruleset 是在本 diff 之外编辑的。没有任何东西阻止它再次漂移；`check-github-required-contexts` 只检测单向漂移 —— ruleset 里有而 manifest 里没有的 context 不会被报出来。

## 关联材料

- 任务：`task_0dab34ca03b28cf61d2a35d85c`
- 证据：上方对账
- 审查：#1597、#1600、#1601、#1602
