### PR TITLE
test: make POSIX integration fixtures Windows-safe

### DIFF
--- a/packages/application/test/task-lifecycle-transition-service.test.ts
+++ b/packages/application/test/task-lifecycle-transition-service.test.ts
@@ -94,7 +94,7 @@ test("transition service freezes targets and makes create/start idempotent by op
     assert.equal(started.snapshot.executions[0]?.state, "active");
     assert.equal(JSON.stringify(eventStore.read().events).includes("credential"), false);
   } finally {
-    rmSync(rootDir, { recursive: true, force: true });
+    rmSync(rootDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
   }
 });
 
@@ -118,7 +118,7 @@ test("transition service publishes aggregate-authored task status idempotently",
     assert.equal(unblocked.snapshot.task?.status, "active"); assert.equal(unblocked.event?.type, "task_transitioned"); assert.equal(unblocked.event?.payload.mutation.reason, "Explicit lifecycle transition to active"); assert.deepEqual(retried, unblocked);
     assert.equal(eventStore.read().events.filter((event) => event.schema === "task-event/v1").length, 3);
   } finally {
-    rmSync(rootDir, { recursive: true, force: true });
+    rmSync(rootDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
   }
 });
 
@@ -394,7 +394,7 @@ test("SQLite/response killpoints reconstruct the exact applied receipt by opId w
       assert.deepEqual(second, first, point);
       assert.equal(projection.readOperation(create.opId)?.event.opId, create.opId);
       assert.equal(git(rootDir, "rev-list", "--count", "refs/ha/canonical").trim(), commitCount);
-    } finally { rmSync(rootDir, { recursive: true, force: true }); }
+    } finally { rmSync(rootDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 }); }
   }
 });
 
@@ -413,7 +413,7 @@ test("lease broker capacity ceiling rejects concurrent exhaustion and release re
     projection.releaseLease(projection.currentLease("task-cap-0")!);
     assert.equal(projection.reserveLease(lease("recovered"), "2026-08-11T00:00:00.000Z").taskId, "task-recovered");
   } finally {
-    rmSync(rootDir, { recursive: true, force: true });
+    rmSync(rootDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
   }
 });
 

--- a/packages/daemon/test/migration-import.integration.test.ts
+++ b/packages/daemon/test/migration-import.integration.test.ts
@@ -44,7 +44,7 @@ test("non-UTF-8 attachments stay explicit in authored coverage as owner-excluded
   } finally { await cell?.close(); rmSync(scratch, { recursive: true, force: true }); }
 });
 
-test("a migrated symbolic link preserves its target text and remains a link without dereferencing", async () => {
+test("a migrated symbolic link preserves its target text and remains a link without dereferencing", { skip: process.platform === "win32" ? "requires POSIX file-symbolic-link semantics" : false }, async () => {
   const scratch = mkdtempSync(path.join(tmpdir(), "ha-migrate-symbolic-link-")), source = path.join(scratch, "legacy"), destination = path.join(scratch, "new"), linkTarget = "../missing.md"; let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   try {
     symbolicLinkFixture(source, linkTarget); initRepo(destination); cell = await openRepoCell({ repoId: workspaceId("migration-symbolic-link-target"), rootDir: canonicalRoot(destination), ownerId: "migration-daemon", now: () => "2026-06-01T00:00:00.000Z" });
@@ -89,7 +89,7 @@ test("destination resolution keeps the visible target and explicitly accounts fo
   } finally { await cell?.close(); rmSync(scratch, { recursive: true, force: true }); }
 });
 
-test("source resolution replaces a committed symbolic link without dereferencing or hiding its preimage", async () => {
+test("source resolution replaces a committed symbolic link without dereferencing or hiding its preimage", { skip: process.platform === "win32" ? "requires POSIX file-symbolic-link semantics" : false }, async () => {
   const scratch = mkdtempSync(path.join(tmpdir(), "ha-migrate-link-resolution-")), source = path.join(scratch, "legacy"), destination = path.join(scratch, "new"), sourceTarget = "../legacy.md", destinationTarget = "../initialized.md"; let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   try { symbolicLinkFixture(source, sourceTarget); initRepo(destination); const directory = path.join(destination, "harness/field-notes"), target = path.join(directory, "latest.md"); mkdirSync(directory, { recursive: true }); symlinkSync(destinationTarget, target); git(destination, "add", "."); git(destination, "commit", "-qm", "initialized link"); cell = await openRepoCell({ repoId: workspaceId("migration-link-resolution"), rootDir: canonicalRoot(destination), ownerId: "migration-daemon", now: () => "2026-06-01T00:00:00.000Z" });
     const result = await cell.run({ kind: "migrate-import", sourceRoots: sources(source), resolutions: ["harness/field-notes/latest.md=source"] }, { actor, source: "local" }) as Record<string, unknown>; assert.equal(result.exitCode, 0, JSON.stringify(result)); assert.equal(readlinkSync(target), sourceTarget); assert.equal(readdirSync(directory).some((name) => name.includes(".conflict-")), false); assert.match(String(result.summary), /resolved: source; kept source kind=symbolic-link[\s\S]*source link target="\.\.\/legacy\.md"[\s\S]*destination link target="\.\.\/initialized\.md"/u);
@@ -97,7 +97,7 @@ test("source resolution replaces a committed symbolic link without dereferencing
   } finally { await cell?.close(); rmSync(scratch, { recursive: true, force: true }); }
 });
 
-test("source resolution can replace a committed destination link with a regular file", async () => {
+test("source resolution can replace a committed destination link with a regular file", { skip: process.platform === "win32" ? "requires POSIX file-symbolic-link semantics" : false }, async () => {
   const scratch = mkdtempSync(path.join(tmpdir(), "ha-migrate-file-over-link-")), source = path.join(scratch, "legacy"), destination = path.join(scratch, "new"), destinationTarget = "../initialized.md"; let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   try { unfamiliarDocumentFixture(source); initRepo(destination); const directory = path.join(destination, "harness/field-notes/2024"), target = path.join(directory, "xyz.md"); mkdirSync(directory, { recursive: true }); symlinkSync(destinationTarget, target); git(destination, "add", "."); git(destination, "commit", "-qm", "initialized link"); cell = await openRepoCell({ repoId: workspaceId("migration-file-over-link"), rootDir: canonicalRoot(destination), ownerId: "migration-daemon", now: () => "2026-06-01T00:00:00.000Z" });
     const result = await cell.run({ kind: "migrate-import", sourceRoots: sources(source), resolutions: ["harness/field-notes/2024/xyz.md=source"] }, { actor, source: "local" }) as Record<string, unknown>; assert.equal(result.exitCode, 0, JSON.stringify(result)); assert.equal(lstatSync(target).isFile(), true); assert.equal(readFileSync(target, "utf8"), "# Field observation\n\nUnknown directories are ordinary authored content.\n"); assert.equal(readdirSync(directory).some((name) => name.includes(".conflict-")), false);

--- a/packages/kernel/test/store/daemon-registry.test.ts
+++ b/packages/kernel/test/store/daemon-registry.test.ts
@@ -30,7 +30,7 @@ test("daemon registry register realpaths canonical roots and writes registry-onl
     const userRoot = path.join(root, "user-harness");
     const canonicalRoot = createHarnessRepo(path.join(root, "real-project"));
     const aliasRoot = path.join(root, "alias-project");
-    symlinkSync(canonicalRoot, aliasRoot, "dir");
+    symlinkSync(canonicalRoot, aliasRoot, process.platform === "win32" ? "junction" : "dir");
 
     const result = registerDaemonRepo({
       userRoot,

--- a/packages/kernel/test/store/helpers.ts
+++ b/packages/kernel/test/store/helpers.ts
@@ -11,7 +11,7 @@ export function withTempStore<T>(fn: (rootDir: string) => T): T {
   try {
     return fn(rootDir);
   } finally {
-    rmSync(rootDir, { recursive: true, force: true });
+    rmSync(rootDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
   }
 }
 
@@ -20,7 +20,7 @@ export async function withTempStoreAsync<T>(fn: (rootDir: string) => Promise<T>)
   try {
     return await fn(rootDir);
   } finally {
-    rmSync(rootDir, { recursive: true, force: true });
+    rmSync(rootDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
   }
 }
 

--- a/packages/kernel/test/store/ledger-maintenance.test.ts
+++ b/packages/kernel/test/store/ledger-maintenance.test.ts
@@ -20,12 +20,12 @@ function ledger(rootDir: string): string {
 
 /** Shadows `git version` with an older release while delegating every other subcommand to the real binary. */
 function withStubbedGitVersion<T>(rootDir: string, version: string, fn: () => T): T {
-  const binDir = path.join(rootDir, "stub-bin"), shim = path.join(binDir, "git"), real = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
+  const binDir = path.join(rootDir, "stub-bin"), windows = process.platform === "win32", shim = path.join(binDir, windows ? "git.cmd" : "git"), real = execFileSync(windows ? "where" : "which", ["git"], { encoding: "utf8" }).trim().split(/\r?\n/u)[0]!;
   mkdirSync(binDir, { recursive: true });
-  writeFileSync(shim, `#!/bin/sh\nfor a in "$@"; do if [ "$a" = "version" ]; then echo "git version ${version}"; exit 0; fi; done\nexec ${real} "$@"\n`, "utf8");
-  chmodSync(shim, 0o755);
+  writeFileSync(shim, windows ? `@echo off\r\nfor %%A in (%*) do if /I "%%~A"=="version" (echo git version ${version}& exit /b 0)\r\n"${real}" %*\r\n` : `#!/bin/sh\nfor a in "$@"; do if [ "$a" = "version" ]; then echo "git version ${version}"; exit 0; fi; done\nexec ${real} "$@"\n`, "utf8");
+  if (!windows) chmodSync(shim, 0o755);
   const previous = process.env.PATH;
-  process.env.PATH = `${binDir}:${previous ?? ""}`;
+  process.env.PATH = `${binDir}${path.delimiter}${previous ?? ""}`;
   try {
     return fn();
   } finally {

--- a/packages/kernel/test/store/task-event-store.test.ts
+++ b/packages/kernel/test/store/task-event-store.test.ts
@@ -169,7 +169,7 @@ for (const killpoint of ["before_event_write", "after_event_write", "after_head_
 }
 
 for (const killpoint of ["before_event_write", "after_event_write", "after_head_write", "after_git_commit", "before_worktree_rename", "after_worktree_rename"] as const) {
-  test(`SIGKILL recovery handles ${killpoint} without duplicate publication`, async () => {
+  test(`SIGKILL recovery handles ${killpoint} without duplicate publication`, { skip: process.platform === "win32" ? "requires POSIX SIGKILL kill-point semantics" : false }, async () => {
     await withTempStoreAsync(async (rootDir) => { initRepo(rootDir); const moduleUrl = new URL("../../src/store/task-event-store.ts", import.meta.url).href, child = spawnSync(process.execPath, ["--experimental-strip-types", "--input-type=module", "-e", [
         `import { makeTaskEventStore } from ${JSON.stringify(moduleUrl)};`,
         `import { taskLifecycleWritePlan } from ${JSON.stringify(new URL("../../src/domain/task-lifecycle-publication.ts", import.meta.url).href)};`,

--- a/packages/preset/test/preset-resolver.test.ts
+++ b/packages/preset/test/preset-resolver.test.ts
@@ -67,7 +67,7 @@ test("an invalid user package shadows the bundled package without fallback", asy
   } finally { fixture.cleanup(); }
 });
 
-test("a symbolic-link active pointer blocks the bundled package", async () => {
+test("a symbolic-link active pointer blocks the bundled package", { skip: process.platform === "win32" ? "requires POSIX file-symbolic-link semantics" : false }, async () => {
   const fixture = makeFixture();
   try {
     write(path.join(path.dirname(fixture.userRoot), "outside-pointer.json"), JSON.stringify({ schema: "preset-active-pointer/v1" })); mkdirSync(path.join(fixture.userRoot, "active"), { recursive: true }); symlinkSync(path.join(path.dirname(fixture.userRoot), "outside-pointer.json"), path.join(fixture.userRoot, "active/standard-task.json"));
@@ -75,7 +75,7 @@ test("a symbolic-link active pointer blocks the bundled package", async () => {
   } finally { fixture.cleanup(); }
 });
 
-test("a symbolic-link pointer blocks the same preset id in every vertical", async () => {
+test("a symbolic-link pointer blocks the same preset id in every vertical", { skip: process.platform === "win32" ? "requires POSIX file-symbolic-link semantics" : false }, async () => {
   const fixture = makeFixture();
   try {
     writePackage(fixture.bundledRoot, "other-task", { vertical: "other/vertical" }); write(path.join(path.dirname(fixture.userRoot), "outside-pointer.json"), "{}"); mkdirSync(path.join(fixture.userRoot, "active"), { recursive: true }); symlinkSync(path.join(path.dirname(fixture.userRoot), "outside-pointer.json"), path.join(fixture.userRoot, "active/other-task.json"));
@@ -87,7 +87,7 @@ test("a symbolic-link pointer blocks the same preset id in every vertical", asyn
 test("a symbolic-link active inventory root fails closed", async () => {
   const fixture = makeFixture(), outsideActive = path.join(path.dirname(fixture.userRoot), "outside-active");
   try {
-    mkdirSync(outsideActive, { recursive: true }); rmSync(path.join(fixture.userRoot, "active"), { recursive: true, force: true }); symlinkSync(outsideActive, path.join(fixture.userRoot, "active"));
+    mkdirSync(outsideActive, { recursive: true }); rmSync(path.join(fixture.userRoot, "active"), { recursive: true, force: true, maxRetries: 5, retryDelay: 20 }); symlinkSync(outsideActive, path.join(fixture.userRoot, "active"), process.platform === "win32" ? "junction" : "dir");
     const result = await createCanonicalPresetResolver({ bundledRoot: fixture.bundledRoot, userRoot: fixture.userRoot, assetsRoot: fixture.assetsRoot }).resolve({ presetId: "standard-task", verticalId: "software/coding", locale: "en-US", purpose: "inspect" });
     assert.equal(result.ok, false); if (!result.ok) assert.equal(result.error.code, "invalid_pointer_root");
     assert.throws(() => installPresetPackage({ source: path.join(fixture.bundledRoot, "standard-task"), userRoot: fixture.userRoot }), (error: unknown) => (error as { code?: string }).code === "invalid_install_root"); assert.equal(existsSync(path.join(outsideActive, "standard-task.json")), false);
@@ -104,7 +104,7 @@ test("an invalid pointer preserves its declared vertical and blocks that bundled
   } finally { fixture.cleanup(); }
 });
 
-test("package decoder rejects symlinks and missing PRESET or script files", () => {
+test("package decoder rejects symlinks and missing PRESET or script files", { skip: process.platform === "win32" ? "requires POSIX file-symbolic-link semantics" : false }, () => {
   const fixture = makeFixture();
   try {
     const complete = path.join(fixture.bundledRoot, "standard-task"), missingDocument = path.join(path.dirname(fixture.bundledRoot), "missing-document"), missingScript = path.join(path.dirname(fixture.bundledRoot), "missing-script");


### PR DESCRIPTION
# English

## Summary

Roughly eight integration files could not reach their own assertions on a stock Windows 11 host. None of the failures were product defects: the fixtures encoded a POSIX host — symlinks are free, open files are deletable, `which` and `#!/bin/sh` shims resolve, and `SIGKILL` has kill-point semantics.

Four families, each decided on evidence rather than uniformly:

| family | decision | why |
| --- | --- | --- |
| directory symlinks | **emulate** — `symlinkSync(..., "junction")` on win32 | a junction is what the fixture actually needed; the tests are about an alias root, not about link semantics |
| file symlinks | **skip**, `requires POSIX file-symbolic-link semantics` | here the POSIX semantic *is* the thing under test — dereferencing, preimage, link-vs-regular-file |
| locked-file cleanup | **emulate** — `rmSync(..., { maxRetries: 5, retryDelay: 20 })` | Node's own bounded retry. A hand-rolled unbounded loop would trade a visible failure for an invisible hang, which is the neighbouring defect #1579 |
| `SIGKILL` kill-points | **skip**, `requires POSIX SIGKILL kill-point semantics` | Windows termination does not produce the signal the assertion reads |
| git-version stub | **emulate** — `where` + a `.cmd` shim + `path.delimiter` | the assertion is about degradation on an old git, which is platform-neutral once the stub actually resolves |

Every skip is `process.platform === "win32" ? "<reason>" : false`. Nothing skips anywhere else, and no assertion was removed to reach green.

**The `expected null, got 'geometric'` failure was not a product defect.** On Windows the stub never resolved — `which` does not exist, and a `#!/bin/sh` shim is not executable — so the real git 2.55 answered instead of the stubbed old version, and the test read a real capability where it expected a degraded one. Making the stub resolve restores the assertion rather than relaxing it.

**One thing the issue did not name.** `withStubbedGitVersion` joined `PATH` with a literal `:`. On Windows the separator is `;`, so even a resolvable shim would never have been found. Now `path.delimiter`.

Production-Delta: +0/-0

## What Changed

- `packages/kernel/test/store/daemon-registry.test.ts`, `packages/preset/test/preset-resolver.test.ts`: directory alias fixtures use junctions on win32; three true file-symlink tests in `preset-resolver` skip with a reason.
- `packages/daemon/test/migration-import.integration.test.ts`: three symbolic-link semantic tests skip with a reason.
- `packages/kernel/test/store/helpers.ts`, `packages/application/test/task-lifecycle-transition-service.test.ts`: bounded `rmSync` retries.
- `packages/kernel/test/store/ledger-maintenance.test.ts`: `where`/`.cmd`/`path.delimiter`, assertion preserved.
- `packages/kernel/test/store/task-event-store.test.ts`: the `SIGKILL recovery` loop skips on win32.

## Task And Scope

- Harness task: `task_4ba780c4ded06c5e9b6d1966ef` (child of `task_0dab34ca03b28cf61d2a35d85c`)
- Branch: `fix/windows-posix-fixtures`
- Public scope: test fixtures only, no production source
- Private planning/evidence updated: yes
- Out of scope: #1579, the runner watchdog and the PTY round-trip, in flight on a separate branch with a non-overlapping file set.

## Version Impact

- Version: no version change because this touches test fixtures only.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none
- Authorizing task: `task_4ba780c4ded06c5e9b6d1966ef`

## Verification

- Base `origin/main` SHA: `32102b53`
- Public diff command: `git diff 32102b53..HEAD`
- Private evidence commit/path: `harness/tasks/task_4ba780c4ded06c5e9b6d1966ef-1589-integration-fixtures-must-run-or-skip-with-a-reason-on-a-stock-win/`
- Reviewer evidence path: the count reconciliation below
- GitHub Actions `rewrite-ci` run URL: see this PR's checks
- [x] `npm run check:local` (fast tier, green) — re-run by the reviewer, not only by the author
- [x] `node --test` over the four touched families — 94/94, **0 skipped on macOS**
- [x] `node tools/gates/line-budget.mjs --base origin/main` (pass)
- [x] `node tools/gates/production-delta.mjs --base origin/main` (+0/-0)

## Review Evidence

- **No test was removed.** `test(` counts compared against `origin/main`, per file: 12→12, 26→26, 9→9, 6→6, 26→26, 33→33. The diff is +19/-19 across seven files and every changed line is a platform branch or a retry option.
- **No skip leaks off Windows.** Every one of the seven skip sites is `process.platform === "win32" ? "<reason>" : false`, and the macOS run reports `skipped 0`. Coverage on POSIX is exactly what it was.
- **The junction/skip split was decided per test, not per file.** `preset-resolver.test.ts` both emulates (its alias root becomes a junction) and skips (its three link-semantics tests), which is the shape you get from deciding on what each test asserts rather than on which file it lives in.
- Reviewer subagent: none. Reviewed by the CEO against the worker's report: commit, diff, skip conditions, per-file test counts, and a local re-run.
- Human review: pending
- Blocking findings: none

## Residual Risk

- **Nothing here has run on Windows.** Every claim about win32 behaviour is a source-level argument plus the platform facts measured earlier in this wave. The `windows-first-run` lane does not run these tiers, so CI does not cover the new branches either. That instrument is the next piece of work, and until it exists these fixes are unverified where they matter.
- A junction is not a symlink. The directory fixtures now exercise a different object on Windows than on POSIX; they still test what they were written to test, but "the same test runs everywhere" is now false in a way the reader has to know.
- The author reported three or four integration-tier failures locally (fleet lease, fleet transport, a resident-CLI `ENOTEMPTY`) and judged them unrelated. That judgement was **not** accepted on the author's word: the machine had ten other agent workers running at the time, and this repository's fleet tests are known to fail under contention with a different test each round. CI's sharded run is the arbiter, and this PR is not merged until it is green.

## References

- Task: `task_4ba780c4ded06c5e9b6d1966ef`
- Evidence: the count reconciliation above
- Review: #1589

---

# 中文

## 摘要

约八个 integration 文件在一台没开 Developer Mode 的 Windows 11 上连自己的断言都跑不到。这些失败没有一个是产品缺陷：fixture 里编码了一台 POSIX 主机 —— 符号链接随便建、打开的文件可以删、`which` 与 `#!/bin/sh` shim 能解析、`SIGKILL` 有 kill-point 语义。

四族，逐族按证据裁决而不是一刀切：

| 族 | 裁决 | 理由 |
| --- | --- | --- |
| 目录符号链接 | **模拟** —— win32 上 `symlinkSync(..., "junction")` | junction 正是这些 fixture 真正需要的；测试考的是别名根，不是链接语义 |
| 文件符号链接 | **skip**，`requires POSIX file-symbolic-link semantics` | 这里 POSIX 语义**就是**被测对象 —— 解引用、preimage、链接与普通文件之别 |
| 锁定文件清理 | **模拟** —— `rmSync(..., { maxRetries: 5, retryDelay: 20 })` | 用 Node 自带的有界重试。手搓无界循环会把一次可见失败换成一次不可见挂死，那正是邻居缺陷 #1579 |
| `SIGKILL` kill-point | **skip**，`requires POSIX SIGKILL kill-point semantics` | Windows 的进程终止不会产生断言读取的那个信号 |
| git 版本 stub | **模拟** —— `where` + `.cmd` shim + `path.delimiter` | 断言考的是「旧版 git 上会降级」，只要 stub 真能被解析，这件事与平台无关 |

每一处 skip 都是 `process.platform === "win32" ? "<理由>" : false`。别处一律不跳，也没有为了转绿删掉任何断言。

**`expected null, got 'geometric'` 不是产品缺陷。** Windows 上 stub 从未被解析 —— `which` 不存在，`#!/bin/sh` shim 也不可执行 —— 于是回答问题的是真实的 git 2.55 而不是被打桩的旧版本，测试读到了真能力却期待一个降级值。让 stub 真正生效是**恢复**这条断言，不是放宽它。

**issue 没点到的一处。** `withStubbedGitVersion` 用字面量 `:` 拼 `PATH`。Windows 的分隔符是 `;`，所以即使 shim 可解析也永远找不到。现在改用 `path.delimiter`。

## 变更内容

- `packages/kernel/test/store/daemon-registry.test.ts`、`packages/preset/test/preset-resolver.test.ts`：目录别名 fixture 在 win32 上用 junction；`preset-resolver` 里三条真·文件链接测试带理由 skip。
- `packages/daemon/test/migration-import.integration.test.ts`：三条符号链接语义测试带理由 skip。
- `packages/kernel/test/store/helpers.ts`、`packages/application/test/task-lifecycle-transition-service.test.ts`：有界 `rmSync` 重试。
- `packages/kernel/test/store/ledger-maintenance.test.ts`：`where`/`.cmd`/`path.delimiter`，断言保留。
- `packages/kernel/test/store/task-event-store.test.ts`：`SIGKILL recovery` 那个循环在 win32 上 skip。

## 任务与范围

- Harness 任务：`task_4ba780c4ded06c5e9b6d1966ef`（`task_0dab34ca03b28cf61d2a35d85c` 的子任务）
- 分支：`fix/windows-posix-fixtures`
- 公开范围：仅测试 fixture，不含生产源码
- 私有规划/证据已更新：是
- 不在范围内：#1579 的运行器看门狗与 PTY 往返，在另一条分支上并行，文件面不重叠。

## 版本影响

- 版本：不变，因为只动了测试 fixture。
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权依据：不适用
- 机器检查边界：本 PR 只断言声明存在；声明是否属实、是否充分由评审者判断。
- Break-glass：否
- Break-glass 理由：不适用
- Break-glass 范围：不适用
- 后续治理任务：无
- 授权任务：`task_4ba780c4ded06c5e9b6d1966ef`

## 验证

- 基线 `origin/main` SHA：`32102b53`
- 公开 diff 命令：`git diff 32102b53..HEAD`
- 私有证据路径：`harness/tasks/task_4ba780c4ded06c5e9b6d1966ef-1589-integration-fixtures-must-run-or-skip-with-a-reason-on-a-stock-win/`
- 评审证据路径：下方数量对账
- GitHub Actions `rewrite-ci` run URL：见本 PR 的 checks
- [x] `npm run check:local`（fast tier，绿）—— 由评审者复跑，不只作者跑过
- [x] 四族被改文件的 `node --test` —— 94/94，**macOS 上 skipped 0**
- [x] `node tools/gates/line-budget.mjs --base origin/main`（通过）
- [x] `node tools/gates/production-delta.mjs --base origin/main`（+0/-0）

## 评审证据

- **没有删除任何测试。** 逐文件与 `origin/main` 对比 `test(` 数量：12→12、26→26、9→9、6→6、26→26、33→33。整个 diff 是七个文件 +19/-19，每一行改动要么是平台分支要么是重试选项。
- **没有 skip 泄漏到 Windows 之外。** 七处 skip 全是 `process.platform === "win32" ? "<理由>" : false`，macOS 跑出来 `skipped 0`。POSIX 侧覆盖与改动前完全一致。
- **junction 与 skip 的取舍是逐测试裁决的，不是逐文件。** `preset-resolver.test.ts` 既模拟（别名根改成 junction）又 skip（三条链接语义测试），这正是「按每条测试考什么来判」而不是「按文件归属来判」才会有的形状。
- Reviewer subagent：无。由 CEO 对着 worker 报告逐条核验：commit、diff、skip 条件、逐文件测试数、以及本地复跑。
- 人工审查：待办
- 阻塞发现：无

## 残余风险

- **这里没有任何东西在 Windows 上跑过。** 所有关于 win32 行为的论断都是源码层推理，加上本波次早先实测到的平台事实。`windows-first-run` lane 不跑这些测试层，所以 CI 也没有覆盖这些新分支。那个仪器是下一件事，在它存在之前，这些修复在真正要紧的地方是未验证的。
- junction 不是 symlink。目录 fixture 在 Windows 上现在操作的是另一种对象；它们仍然测的是当初要测的东西，但「同一条测试各平台都跑一样的路」这句话已经不成立，读者需要知道。
- 作者在本地报了三到四条 integration 失败（fleet lease、fleet transport、resident CLI `ENOTEMPTY`）并判为无关。这个判断**没有**按作者的说法采信：当时那台机器上还有十个 agent worker 在跑，而本仓 fleet 测试在争用下失败、且每轮红的测试不同，是已知现象。仲裁者是 CI 的分片跑，本 PR 在它转绿前不合并。

## 关联材料

- 任务：`task_4ba780c4ded06c5e9b6d1966ef`
- 证据：上方数量对账
- 审查：#1589
