### PR TITLE
fix(kernel): shadow failures must never alter the authoritative receipt — warn and reseed the WAL

### DIFF
--- a/packages/kernel/src/store/wal-event-log.ts
+++ b/packages/kernel/src/store/wal-event-log.ts
@@ -52,6 +52,7 @@ export interface WalEventLog {
   readonly readEvent: (opId: string) => CanonicalEventV1 | null;
   readonly readContentBlob: (sha256: string) => Uint8Array | null;
   readonly checkpoint: (throughRevision: number) => void;
+  readonly reseed: (events: readonly CanonicalEventV1[]) => void;
   readonly audit: (
     gitEvents: readonly CanonicalEventV1[],
     gitRevision: number,
@@ -228,6 +229,44 @@ export function openWalEventLog(rootDir: string): WalEventLog {
           },
     );
   };
+  const reseed = (events: readonly CanonicalEventV1[]): void => {
+    ensureRoot();
+    const records: WalEventRecord[] = [];
+    for (const event of events) {
+      const eventBytes = serializeCanonicalEvent(event);
+      const previous = records.at(-1);
+      records.push({
+        schema: WAL_SCHEMA,
+        revision: event.workspaceRevision,
+        opId: event.opId,
+        event,
+        blobs: [],
+        eventDigest: `sha256:${sha256Text(eventBytes)}`,
+        previousDigest: previous?.eventDigest ?? null,
+      });
+    }
+    const body = records.map((record) => `${stableStringify(record)}\n`).join("");
+    fileSystem.replace(segmentPath, body);
+    cached = records;
+    const last = records.at(-1);
+    writeHead(
+      last === undefined
+        ? {
+            schema: "harness-wal-head/v1",
+            revision: 0,
+            lastSegment: null,
+            lastOffset: 0,
+            headDigest: null,
+          }
+        : {
+            schema: "harness-wal-head/v1",
+            revision: last.revision,
+            lastSegment: WAL_SEGMENT,
+            lastOffset: Buffer.byteLength(body),
+            headDigest: last.eventDigest,
+          },
+    );
+  };
   return {
     rootDir: walRoot,
     head: readHead,
@@ -241,6 +280,7 @@ export function openWalEventLog(rootDir: string): WalEventLog {
       return null;
     },
     checkpoint,
+    reseed,
     audit: (gitEvents, gitRevision) =>
       auditRecords(readRecords(), gitEvents, gitRevision),
   };
@@ -303,7 +343,7 @@ function auditRecords(
       };
   }
   const lastRevision = records.at(-1)?.revision ?? 0;
-  const equivalent = lastRevision <= gitRevision;
+  const equivalent = lastRevision === 0 || lastRevision === gitRevision;
   return {
     status: equivalent ? "equivalent" : "diverged",
     walRevision: lastRevision,
@@ -311,6 +351,6 @@ function auditRecords(
     compared: records.length,
     divergence: equivalent
       ? null
-      : `WAL revision ${lastRevision} is ahead of Git revision ${gitRevision}`,
+      : `WAL revision ${lastRevision} does not reach Git revision ${gitRevision}`,
   };
 }

--- a/packages/kernel/src/store/wal-shadow-event-store.ts
+++ b/packages/kernel/src/store/wal-shadow-event-store.ts
@@ -20,27 +20,75 @@ export function makeWalShadowEventStore(
     throw new Error("canonical event store requires rootInput or rootDir");
   const wal = openWalEventLog(resolveHarnessLayout(input).rootDir);
   let auditScheduled = false;
-  let auditFailure: Error | null = null;
-  const checkAudit = (): void => {
-    if (auditFailure !== null) throw auditFailure;
+  const warn = (context: string, error: unknown): void => {
+    console.warn(
+      `[wal-shadow] ${context}; Git remains authoritative: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  };
+  const reseed = (
+    stream: ReturnType<CanonicalEventStore["read"]>,
+    context: string,
+    cause: unknown,
+  ): void => {
+    warn(`${context}; reseeding WAL from Git`, cause);
+    try {
+      wal.reseed(stream.events);
+      console.warn(
+        `[wal-shadow] reseed complete at Git revision ${stream.revision}`,
+      );
+    } catch (error) {
+      consumeKnownError(error);
+      warn("WAL shadow reseed failed", error);
+    }
+  };
+  const align = (context: string): void => {
+    let stream: ReturnType<CanonicalEventStore["read"]>;
+    try {
+      stream = git.read();
+      const audit = wal.audit(stream.events, stream.revision);
+      if (audit.status === "equivalent") return;
+      reseed(stream, `${context}: ${audit.divergence ?? "WAL differs"}`, new TaskEventStoreError(
+        "invalid_store",
+        audit.divergence ?? "WAL shadow differs from Git",
+      ));
+    } catch (error) {
+      consumeKnownError(error);
+      try {
+        stream = git.read();
+        reseed(stream, context, error);
+      } catch (readError) {
+        consumeKnownError(readError);
+        warn(`${context}; Git stream could not be read for reseed`, readError);
+      }
+    }
+  };
+  const appendShadow = (
+    bundle: Parameters<CanonicalEventStore["append"]>[0],
+  ): void => {
+    try {
+      wal.append({ event: bundle.event, blobs: bundle.blobs });
+    } catch (error) {
+      consumeKnownError(error);
+      let stream: ReturnType<CanonicalEventStore["read"]>;
+      try {
+        stream = git.read();
+        reseed(stream, "WAL append failed", error);
+      } catch (readError) {
+        consumeKnownError(readError);
+        warn("WAL append failed and Git stream could not be read", readError);
+      }
+    }
   };
   const scheduleAudit = (): void => {
     if (auditScheduled) return;
     auditScheduled = true;
     const pending = setImmediate(() => {
-      auditScheduled = false;
       try {
-        const stream = git.read();
-        const audit = wal.audit(stream.events, stream.revision);
-        if (audit.status !== "equivalent")
-          throw new TaskEventStoreError(
-            "invalid_store",
-            `WAL shadow diverged from Git: ${audit.divergence ?? "unknown difference"}`,
-          );
-      } catch (error) {
-        consumeKnownError(error);
-        auditFailure =
-          error instanceof Error ? error : new Error(String(error));
+        align("WAL audit failed");
+      } finally {
+        auditScheduled = false;
       }
     });
     pending.unref();
@@ -48,10 +96,19 @@ export function makeWalShadowEventStore(
   return {
     ...git,
     append: (bundle) => {
-      checkAudit();
       const receipt = git.append(bundle);
-      wal.append({ event: bundle.event, blobs: bundle.blobs });
+      appendShadow(bundle);
       scheduleAudit();
+      return receipt;
+    },
+    migrateLayout: (migration) => {
+      const receipt = git.migrateLayout(migration);
+      align("WAL layout migration alignment");
+      return receipt;
+    },
+    recover: () => {
+      const receipt = git.recover();
+      align("WAL recovery alignment");
       return receipt;
     },
   };

--- a/packages/kernel/test/store/wal-shadow-event-store.test.ts
+++ b/packages/kernel/test/store/wal-shadow-event-store.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import { REPLAY_TASK_GRAPH } from "../../src/domain/task-graph.ts";
 import { type TaskCreatedEvent } from "../../src/domain/task-lifecycle.contract.ts";
 import { taskLifecycleWritePlan } from "../../src/domain/task-lifecycle-publication.ts";
+import { localWalFileSystem } from "../../src/local/local-layout-file-system.ts";
 import { makeTaskEventStore as makeGitEventStore } from "../../src/store/task-event-store.ts";
 import { makeWalShadowEventStore } from "../../src/store/wal-shadow-event-store.ts";
 import { openWalEventLog } from "../../src/store/wal-event-log.ts";
@@ -77,6 +78,34 @@ test("S3 discards a torn WAL tail and keeps the Git-equivalence audit", async ()
     assert.deepEqual(reopened.records().map((record) => record.revision), [1]);
     assert.equal(readFileSync(segment, "utf8").endsWith("\n"), true);
     assert.equal(reopened.audit(store.read().events, store.read().revision).status, "equivalent");
+  });
+});
+
+test("WAL shadow failure never changes the authoritative Git receipt", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initRepo(rootDir);
+    const store = makeWalShadowEventStore({ repoId: "wal-shadow-failure", rootDir });
+    const first = taskCreated(1);
+    store.append({ event: first, plan: taskLifecycleWritePlan(first), blobs: [] });
+    const originalAppend = localWalFileSystem.append;
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    localWalFileSystem.append = () => {
+      throw new Error("simulated WAL I/O failure");
+    };
+    console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+    try {
+      const event = taskCreated(2);
+      const receipt = store.append({ event, plan: taskLifecycleWritePlan(event), blobs: [] });
+      assert.equal(receipt.status, "applied");
+      assert.equal(receipt.revision, 2);
+      assert.deepEqual(store.read().events.map((candidate) => candidate.workspaceRevision), [1, 2]);
+    } finally {
+      localWalFileSystem.append = originalAppend;
+      console.warn = originalWarn;
+    }
+    assert.equal(warnings.some((warning) => warning.includes("WAL append failed")), true);
+    assert.deepEqual(openWalEventLog(rootDir).records().map((record) => record.revision), [1, 2]);
   });
 });
 


### PR DESCRIPTION
# English

## Summary

Fix the three same-root BLOCKING findings from anti-entropy review R5 against #1616 (WAL shadow, which sits on the authoritative publication path via the composition root): the shadow could take the authoritative write path down with it.

- **F1 — bare throw after authoritative commit**: `wal.append` failure after a successful `git.append` returned a failure receipt for an already-committed event (retries never converge). Now every shadow operation is caught: the authoritative receipt is unaffected, the failure is warned observably (`[wal-shadow] … Git remains authoritative`).
- **F2 — recover/migrateLayout bypassed the shadow**: a crash-recovery or layout migration advanced git without the WAL, wedging every subsequent write on `WAL revision N must follow M` with no built-in recovery, while the equivalence audit was blind to missing records. Now the WAL gains a full **`reseed`** (rebuild from the current git stream) and the shadow re-aligns on those paths; the audit also detects a truncated WAL tail.
- **F3 — audit latch blocked authoritative writes**: a detected divergence threw before `git.append` (write path permanently latched, `void error` silent, checkpoint could not clear it). Now divergence → warn + reseed, never a block.
- F4 (torn non-final line beyond the tail-tolerance assumption) is covered by the same align/reseed path. F5 (full-stream audit per append) remains a follow-up task.

Unifying invariant, pinned by a new regression: **no shadow failure may alter the authoritative receipt** (dec_41D2645085 shadow semantics: git is the sole authority; the WAL is a trial shadow).

## Verification

- All R5 reproduction scripts (R1–R7, R3b) re-run green: EACCES, crash-recovery gap, divergence, torn line — git write succeeds, shadow warns and reseeds.
- WAL shadow targeted suite 4/4 including the new "WAL failure does not change the authoritative receipt" regression.
- `npm run check:local` green (41 steps) on base `264338e1`.

## Review Evidence

R5 findings and reproduction scripts archived in ledger task `task_6ea79ccc6ab9aaaaee44b7eda1` artifacts (r5-findings.md, repro/); worker report (report-walfix-sol.md). CEO reviewed the failure-path diff: every shadow operation wrapped, authority path untouched.

## Governance Declaration

- No gates, CI lanes, or protected surfaces modified. Derived from `dec_41D2645085` via ledger task `task_6ea79ccc6ab9aaaaee44b7eda1` (findings provenance: anti-entropy review R5 on #1616).

## Residual Risk

- F5 (per-append full-stream audit cost, unbounded WAL growth between reseeds) tracked as follow-up; reseed provides the natural checkpoint hook.
- Shadow warnings go to the daemon log (`console.warn`); no structured alert channel yet — acceptable for a trial shadow.

Production-Delta: +116/-19

---

# 中文

## 摘要

修复反熵审查 R5 对 #1616(WAL shadow,经 composition 根实际位于权威发布路径上)抓出的三项同根 BLOCKING:影子可能把权威写路径一起拖垮。

- **F1 权威提交后裸抛**:`git.append` 成功后 `wal.append` 失败,给已提交事件返回失败回执(重试永不收敛)。现在影子全部操作被捕获:权威回执不受影响,失败走可观测告警(`[wal-shadow] … Git remains authoritative`)。
- **F2 recover/migrateLayout 绕过影子**:崩溃恢复或布局迁移只推进 git 不落 WAL,后续每笔写卡死在「WAL revision N must follow M」且无内置恢复,等价审计对缺记录失明。现在 WAL 新增全量 **`reseed`**(从当前 git 流重建),这些路径自动重对齐;审计还能识别 WAL 尾部断档。
- **F3 审计闩锁封死权威写**:检出分叉在 `git.append` 之前抛(写路永久闩死,`void error` 零告警,checkpoint 清不掉)。现在分叉 → 告警+reseed,绝不阻塞。
- F4(非尾部撕裂行超出断尾容忍假设)由同一 align/reseed 路径覆盖;F5(每 append 全量审计成本)留后续任务。

统一不变量并用新回归钉住:**影子的任何失败不得改变权威回执**(dec_41D2645085 shadow 语义:git 唯一权威,WAL 只是试运行影子)。

## 验证

- R5 全部复现脚本(R1–R7、R3b)重跑翻绿:EACCES/崩溃恢复断档/分叉/撕裂行下 git 写成功、影子告警并 reseed。
- WAL shadow 定向套件 4/4,含新增「WAL 失败不改变权威回执」回归。
- 基线 `264338e1` 上 `npm run check:local` 绿(41 步)。

## 复核证据

R5 findings 与复现脚本归档于台账任务 `task_6ea79ccc6ab9aaaaee44b7eda1` artifacts;worker 报告 report-walfix-sol.md。CEO 亲验失败路径 diff:影子操作全包裹,权威路径未触碰。

## 治理声明

- 未改任何 gate/CI lane/protected surface。派生自 `dec_41D2645085`,台账任务 `task_6ea79ccc6ab9aaaaee44b7eda1`(findings 出处:反熵审查 R5 对 #1616)。

## 残余风险

- F5(每 append 全量审计、reseed 间 WAL 无界增长)留后续任务;reseed 给 checkpoint 提供了天然挂点。
- 影子告警走 daemon 日志(console.warn),暂无结构化告警通道——试运行影子可接受。

生产净变更见英文侧声明行。
