### PR TITLE
test(cli): emit candidate startup-cost metrics alongside the asserted one

### DIFF
--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -266,6 +266,18 @@ test("resident daemon CLI write p50 includes process startup through parsed rece
     }
     const p50 = median(cliSamples), daemonP50 = median(daemonSamples), bareP50 = median(bareSamples), overheadRatio = median(ratios);
     const orderedRatios = [...ratios].sort((left, right) => left - right);
+    // Calibration only: these diagnostics do not change the verdict. The asserted metric
+    // subtracts a daemon round trip the CLI subprocess never made — the test process made
+    // its own — so cli-minus-daemon is not a decomposition and goes negative. These lines
+    // emit the candidate replacements on every run so a metric can be chosen from real
+    // readings rather than from four scraped log lines. Governance task task_182bb1c6068a1c36ca11c68185.
+    const spawnRatios = cliSamples.map((value, sample) => value / bareSamples[sample]!),
+      unavoidableRatios = cliSamples.map((value, sample) => value / (bareSamples[sample]! + daemonSamples[sample]!)),
+      incoherent = cliSamples.filter((value, sample) => value <= daemonSamples[sample]!).length;
+    const spread = (values: readonly number[]) => { const ordered = [...values].sort((left, right) => left - right); return `p50=${median(values).toFixed(3)}x min=${ordered[0]!.toFixed(3)}x max=${ordered.at(-1)!.toFixed(3)}x`; };
+    context.diagnostic(`calibration-candidate=cli-over-bare-spawn samples=${spawnRatios.length} ${spread(spawnRatios)}`);
+    context.diagnostic(`calibration-candidate=cli-over-bare-plus-daemon samples=${unavoidableRatios.length} ${spread(unavoidableRatios)}`);
+    context.diagnostic(`calibration-incoherent-samples=cli-not-greater-than-daemon count=${incoherent} of=${cliSamples.length}`);
     context.diagnostic(`latency-window=before-cli-process-spawn-through-exit-and-parsed-receipt daemon=resident samples=${cliSamples.length} p50=${p50.toFixed(3)}ms min=${Math.min(...cliSamples).toFixed(3)}ms max=${Math.max(...cliSamples).toFixed(3)}ms`);
     context.diagnostic(`latency-segment=resident-daemon-socket-through-parsed-receipt samples=${daemonSamples.length} p50=${daemonP50.toFixed(3)}ms min=${Math.min(...daemonSamples).toFixed(3)}ms max=${Math.max(...daemonSamples).toFixed(3)}ms`);
     context.diagnostic(`latency-segment=paired-cli-minus-daemon samples=${overheadSamples.length} p50=${median(overheadSamples).toFixed(3)}ms min=${Math.min(...overheadSamples).toFixed(3)}ms max=${Math.max(...overheadSamples).toFixed(3)}ms`);


### PR DESCRIPTION
# English

## Summary

Instrumentation only. The verdict of the CLI startup gate is unchanged; this adds
diagnostics so a replacement metric can be chosen from readings taken on the lane that
actually enforces it.

## Why

`packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts` asserts
`overheadRatio <= 4`, where `overhead = cliElapsed - daemonElapsed`. Those two terms measure
different operations: `daemonElapsed` is a JSON-RPC round trip the **test process** makes,
not the round trip the **CLI subprocess** makes. So the subtraction is not a decomposition of
one request into its parts, and when the test process's own call is slow it exceeds the whole
CLI run — every observed run reports negative per-sample ratios, on passing runs as well as
failing ones (#1629 passed at 3.835x with a per-sample floor of −8.185x).

The comment above the assertion defends per-iteration pairing, which fixed an earlier defect
where three separate batches were divided p50-by-p50. The validity of the subtraction itself
was never checked.

This is why neither raising the bound nor re-running helps: the quantity being asserted is
not defined. Seven pull requests rebased onto current main and re-run all failed on this one
check, with readings spanning 3.725x to 4.662x against a bound of 4.

## What this does not do

It does not change the assertion, the bound, or the metric. `production +0/-0`.

Choosing the replacement is a real tradeoff and needs data this repository does not yet have:

- `cli / bare` is well defined and always positive, but a globally slow daemon inflates it —
  on the four scraped runs it reads 6.8x, 7.2x, 8.3x and 16.1x.
- `cli / (bare + daemon)` normalises by both unavoidable components and reads 1.66x, 1.90x,
  1.96x and 2.90x on the same runs.
- Subtracting the CLI's *own* server-side duration would be the faithful decomposition, but
  no receipt carries that field today, and adding one to every receipt to serve one test is
  the kind of speculative surface this repository avoids.

Four numbers scraped from job logs are not enough to set a bound on a load-bearing gate, and
this machine is not idle enough to calibrate locally. So this change makes CI itself the
measurement rig: every run now prints both candidates with their per-sample spread, plus a
count of samples where `cli <= daemon` — the incoherent ones.

## Verification

- `npx tsc -b` — pass
- `node tools/gates/production-delta.mjs` — `production +0/-0`
- The assertion is untouched: `git diff` contains no change to the `assert.equal(overheadRatio ...)` line.

## Residual risk

This branch is expected to fail `integration-shard (2)` exactly like every other open branch,
for the reason it documents. That does not affect the diagnostics, which are emitted before
the assertion runs.

## Governance Declaration

Derived from task `task_182bb1c6068a1c36ca11c68185` (CLI 启动比值门:标定 lane 与执法 lane
不一致,且样本含负比值), under milestone `task_63d9b4d05dc5d39addca53d75b`.

Production-Delta: +0/-0

---

# 中文

## 摘要

只加仪表。CLI 启动门的判决**不变**;本改动加诊断,好让替代度量能从**真正执法的那条 lane** 上
取到的读数里选,而不是从四条捞来的日志里猜。

## 为什么

`packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts` 断言 `overheadRatio <= 4`,
其中 `overhead = cliElapsed - daemonElapsed`。这两项测的是**两个不同的操作**:
`daemonElapsed` 是**测试进程**自己发的一次 JSON-RPC 往返,不是 **CLI 子进程**内部那一次。
所以这个减法不是「把一次请求拆成它的组成部分」,当测试进程那次调用慢时它会超过整个 CLI 运行 ——
**每一次观测到的跑动都报出了负的每样本比值,通过的跑次也一样**(#1629 以 3.835x 通过,
每样本下界 −8.185x)。

断言上方那段注释捍卫的是「逐次配对」,那修的是更早的一个缺陷(三批分别采样再拿 p50 除 p50)。
**减法本身的有效性从未被检查过。**

这解释了为什么抬限值和重跑都不解决问题:**被断言的那个量本身没有定义。**七条 PR rebase 到
当前 main 重跑后全部只红在这一个检查上,读数从 3.725x 到 4.662x,而限值是 4。

## 本改动不做什么

不改断言、不改限值、不改度量。`production +0/-0`。

选替代度量是有真实取舍的,而这个仓库目前没有做这个选择所需的数据:

- `cli / bare` 定义良好且恒为正,但 daemon 整体变慢会抬高它 —— 四个跑次读到 6.8x、7.2x、8.3x、16.1x。
- `cli / (bare + daemon)` 用两个不可避免的组成部分归一,同样四个跑次读到 1.66x、1.90x、1.96x、2.90x。
- 减去 CLI **自己**的服务端耗时才是忠实的分解,但今天没有任何回执带这个字段,
  而为一个测试给每条回执加字段,正是本仓明令避免的猜测性面。

四个从 job 日志里捞出来的数字不足以给一道承重门定阈,而本机负载不足以本地标定。
所以本改动**把 CI 本身变成测量装置**:每次跑动都打印两个候选度量及其每样本区间,
外加一个 `cli <= daemon` 的样本计数 —— 那些自相矛盾的样本。

## 残余风险

本分支预计会和其它每条开着的分支一样红在 `integration-shard (2)`,原因正是它所记录的这一条。
这不影响诊断,诊断在断言之前就已输出。
