### PR TITLE
fix(cli): replace the CLI startup gate's undefined ratio with cli/bare

### DIFF
--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -245,7 +245,7 @@ test("resident daemon CLI write p50 includes process startup through parsed rece
     // for the Node binary, so the denominator was systematically the most favourable
     // number in the run. That is how this gate reported 6.450x and 1.650x for the same
     // commit with no diff (runs 32002647956 and its rerun).
-    const daemonSamples: number[] = [], cliSamples: number[] = [], bareSamples: number[] = [], overheadSamples: number[] = [], ratios: number[] = [];
+    const daemonSamples: number[] = [], cliSamples: number[] = [], bareSamples: number[] = [], ratios: number[] = [];
     for (let index = 0; index < 11; index += 1) {
       const daemonStarted = performance.now();
       const response = await requestLocalDaemonJsonRpc(fixture.alpha, "repo.task.create", { repo: { repoId: "alpha" },
@@ -262,39 +262,57 @@ test("resident daemon CLI write p50 includes process startup through parsed rece
       spawnSync(process.execPath, ["-e", ""], { stdio: "ignore" });
       const bareElapsed = performance.now() - bareStarted;
       daemonSamples.push(daemonElapsed); cliSamples.push(cliElapsed); bareSamples.push(bareElapsed);
-      overheadSamples.push(cliElapsed - daemonElapsed); ratios.push((cliElapsed - daemonElapsed) / bareElapsed);
+      ratios.push(cliElapsed / bareElapsed);
     }
-    const p50 = median(cliSamples), daemonP50 = median(daemonSamples), bareP50 = median(bareSamples), overheadRatio = median(ratios);
+    const p50 = median(cliSamples), daemonP50 = median(daemonSamples), bareP50 = median(bareSamples), startupRatio = median(ratios);
     const orderedRatios = [...ratios].sort((left, right) => left - right);
     context.diagnostic(`latency-window=before-cli-process-spawn-through-exit-and-parsed-receipt daemon=resident samples=${cliSamples.length} p50=${p50.toFixed(3)}ms min=${Math.min(...cliSamples).toFixed(3)}ms max=${Math.max(...cliSamples).toFixed(3)}ms`);
     context.diagnostic(`latency-segment=resident-daemon-socket-through-parsed-receipt samples=${daemonSamples.length} p50=${daemonP50.toFixed(3)}ms min=${Math.min(...daemonSamples).toFixed(3)}ms max=${Math.max(...daemonSamples).toFixed(3)}ms`);
-    context.diagnostic(`latency-segment=paired-cli-minus-daemon samples=${overheadSamples.length} p50=${median(overheadSamples).toFixed(3)}ms min=${Math.min(...overheadSamples).toFixed(3)}ms max=${Math.max(...overheadSamples).toFixed(3)}ms`);
     context.diagnostic(`latency-baseline=bare-node-process-spawn samples=${bareSamples.length} p50=${bareP50.toFixed(3)}ms min=${Math.min(...bareSamples).toFixed(3)}ms max=${Math.max(...bareSamples).toFixed(3)}ms`);
-    context.diagnostic(`latency-ratio=paired-cli-overhead-over-bare-spawn samples=${ratios.length} p50=${overheadRatio.toFixed(3)}x min=${orderedRatios[0]!.toFixed(3)}x max=${orderedRatios.at(-1)!.toFixed(3)}x`);
-    // The thin CLI's own cost is everything outside the daemon round-trip: spawning a
-    // process, loading its modules, parsing, rendering. Measured against a bare Node
-    // spawn taken immediately after it, so machine speed and load cancel within each
-    // pair — an absolute millisecond bound here would only assert how fast the runner
-    // is, and dec_01KY6X4J486MZ35RW1QN51V2V1 restricts performance gates to relative
-    // overhead. It fails if the CLI grows eager module loading, or stops delegating to
-    // the resident daemon and starts doing the write in its own process.
+    context.diagnostic(`latency-ratio=paired-cli-over-bare-spawn samples=${ratios.length} p50=${startupRatio.toFixed(3)}x min=${orderedRatios[0]!.toFixed(3)}x max=${orderedRatios.at(-1)!.toFixed(3)}x`);
+    // A CLI invocation costs a bare Node spawn plus the CLI's own work: loading its
+    // modules, parsing, one daemon round trip, rendering. Measured against a bare spawn
+    // taken immediately after it, so machine speed and load cancel within each pair — an
+    // absolute millisecond bound would only assert how fast the runner is, and
+    // dec_01KY6X4J486MZ35RW1QN51V2V1 restricts performance gates to relative overhead. It
+    // fails if the CLI grows eager module loading, or stops delegating to the resident
+    // daemon and starts doing the write in its own process.
     //
-    // The bound is 4, derived rather than chosen. The old bound of 3 was calibrated
-    // against a measurement that systematically under-read: the bare-spawn batch ran
-    // last, after ~22 spawns had warmed the page cache, so the denominator was too
-    // small and the reading too low. With the denominator fixed, the enforcement lane
-    // (full-check) reads 3.086 / 3.106 / 3.072 / 3.071 — stable to ±0.6%, and above the
-    // old bound. Keeping 3 would have failed every run; the bound was never calibrated
-    // against a correct instrument in the first place.
+    // This used to subtract daemonElapsed first, on the reading that the daemon round trip
+    // is not the CLI's own cost. That subtraction was never valid: daemonElapsed times a
+    // round trip THIS TEST PROCESS makes, not the one the CLI subprocess makes. Subtracting
+    // one operation's duration from an unrelated operation's duration is not a decomposition,
+    // and when the test process's own call ran slow it exceeded the entire CLI run — every
+    // observed run reported negative per-sample ratios, on passing runs as well as failing
+    // ones. Neither raising the bound nor re-running could help: the asserted quantity was
+    // not defined. Governance task task_182bb1c6068a1c36ca11c68185.
     //
-    // 4 preserves the original design's sensitivity in absolute terms, which is what
-    // the gate actually protects. Old: (3 - 2.028) x 37.9ms bare = 36.8ms of added CLI
-    // startup before it fires. New: (4 - 3.08) x 33.7ms bare = 31.0ms. The gate gets
-    // slightly stricter in milliseconds while gaining 1.29x headroom over the worst
-    // observed reading. 3.5 leaves only 1.13x headroom; 4.5 relaxes sensitivity to
-    // 47.9ms, looser than the design it replaces.
-    assert.equal(overheadRatio <= 4, true,
-      `thin CLI overhead was ${overheadRatio.toFixed(3)}x a bare Node spawn (paired p50; spread ${orderedRatios[0]!.toFixed(3)}x-${orderedRatios.at(-1)!.toFixed(3)}x, cli=${p50.toFixed(3)}ms, bare=${bareP50.toFixed(3)}ms, daemon=${daemonP50.toFixed(3)}ms)`);
+    // Both terms here are real: a bare spawn is a cost every CLI run pays, so the ratio
+    // cannot go negative and cannot fall below 1. Five calibration runs on this lane, emitted
+    // from codex/gate-calibration alongside the old metric, show why this one and not
+    // cli/(bare+daemon) — which keeps the same bogus term and inherits its noise:
+    //
+    //   metric              run1   run2   run3   run4   run5   cross-run spread
+    //   (cli-daemon)/bare   4.111  3.169  4.404  4.627  4.371  46.0%
+    //   cli/bare            6.730  6.858  7.016  7.442  7.150  10.6%
+    //   cli/(bare+daemon)   1.860  1.460  1.942  1.937  1.892  33.0%
+    //
+    // Run 2 was the noisiest internally — incoherent samples where cli <= daemon went 1/11 to
+    // 2/11 and the old metric's per-sample range widened to -23.781x..11.631x — and cli/bare
+    // barely moved while the old metric crossed its own bound: same branch, same content,
+    // 3.169 passed and 4.627 failed. cli/(bare+daemon) bottomed out at 0.231x on that run.
+    //
+    // The bound is 8.6, derived rather than chosen, preserving the old design's stated intent.
+    // The old comment protected absolute added startup: (4 - 3.08) x 33.7ms bare = 31.0ms.
+    // Added cost X moves this ratio by X/bare; at the observed bare median of 26.285ms,
+    // 31.0ms of sensitivity needs 31.0/26.285 = 1.179 of headroom above the worst observed
+    // reading, so 7.442 + 1.179 = 8.6. That leaves (8.6 - 7.442) x 26.285ms = 30.4ms of added
+    // startup before it fires — the same order as the 31.0ms it replaces — and 1.156x headroom
+    // over the worst reading, tighter than the old 1.29x. The tighter headroom is affordable
+    // because this metric moves 10.6% between runs where the old one moved 46.0%; measured
+    // against its own noise it is the safer of the two.
+    assert.equal(startupRatio <= 8.6, true,
+      `thin CLI startup was ${startupRatio.toFixed(3)}x a bare Node spawn (paired p50; spread ${orderedRatios[0]!.toFixed(3)}x-${orderedRatios.at(-1)!.toFixed(3)}x, cli=${p50.toFixed(3)}ms, bare=${bareP50.toFixed(3)}ms, daemon=${daemonP50.toFixed(3)}ms)`);
   } finally { stop(fixture.alpha, fixture.userRoot, builtCli); rmSync(fixture.root, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
# English

## Summary

The CLI startup gate asserted a quantity that was not defined. It now asserts one that is.

`overhead = cliElapsed - daemonElapsed` looked like a whole minus one of its parts. It is not:
`daemonElapsed` is a JSON-RPC round trip **this test process** makes, while `cliElapsed` times
a **separate CLI subprocess**. Subtracting one operation's duration from an unrelated
operation's duration is not a decomposition, and when the test process's own call ran slow it
exceeded the entire CLI run — every observed run reported negative per-sample ratios, on
passing runs as well as failing ones.

That is why neither raising the bound nor re-running ever helped. Seven pull requests rebased
onto current main and re-run all failed on this one check.

The gate now asserts `cliElapsed / bareElapsed`. Both terms are real: a bare Node spawn is a
cost every CLI invocation pays. The ratio cannot go negative and cannot fall below 1.

## Not a threshold change

This replaces the metric under governance task `task_182bb1c6068a1c36ca11c68185`. The old
bound is not being raised — the old metric is being removed because it measured nothing. The
gate still protects what it always claimed to: it fails if the CLI grows eager module loading,
or stops delegating to the resident daemon and does the write in its own process.
`dec_01KY6X4J486MZ35RW1QN51V2V1` is honoured — the replacement is still relative overhead, not
an absolute millisecond bound.

## How the metric was chosen

Choosing from four log lines scraped off failed jobs would have been guesswork, and this
machine was not idle enough to calibrate locally. So CI itself became the measurement rig:
`codex/gate-calibration` (#1632) emits the candidates on every run without changing any
verdict. Readings from that lane:

| metric | run 1 | run 2 | run 3 | run 4 | run 5 | cross-run spread |
| --- | --- | --- | --- | --- | --- | --- |
| `(cli-daemon)/bare` (old) | 4.111 FAIL | 3.169 PASS | 4.404 FAIL | 4.627 FAIL | 4.371 FAIL | 46.0% |
| **`cli/bare` (this PR)** | 6.730 | 6.858 | 7.016 | 7.442 | 7.150 | **10.6%** |
| `cli/(bare+daemon)` | 1.860 | 1.460 | 1.942 | 1.937 | 1.892 | 33.0% |

Run 2 was far noisier internally than the others — its incoherent-sample count (where
`cli <= daemon`) went 1/11 to 2/11 and the old metric's per-sample range widened to
−23.781x…11.631x — and `cli/bare` barely moved while the old metric swung across its own
bound. Same branch, same content: 3.169 passed and 4.627 failed.

`cli/(bare+daemon)` was rejected: it keeps the same bogus term and inherits its noise, with a
per-sample floor of 0.231x on run 2.

## How the bound was derived

The derivation was written into the governance task **before** the readings were in, so the
number could not be picked to fit.

The old comment states what the gate actually protects: absolute added startup, `(4 - 3.08) x
33.7ms = 31.0ms`. Under `cli/bare`, added cost X moves the ratio by `X / bare`. At the observed
bare median of 26.285 ms, preserving 31ms of sensitivity needs `31 / 26.285 = 1.179` of
headroom above the worst observed reading:

- bound = 7.442 + 1.179 = **8.6**
- absolute sensitivity: `(8.6 - 7.442) x 26.285` = **30.4 ms** — the same order as the 31.0ms it replaces
- headroom over the worst observed reading: **1.156 x**, tighter than the old 1.29x

The tighter headroom is affordable because this metric's cross-run spread is 10.6% rather
than the old metric's 46.0%. Proportionally it is the safer of the two: the old design's
1.29x headroom sat against a metric that swung 46.0% between runs.

## Verification

- `npx tsc -b` — pass
- `npm run check:local` — pass
- `node tools/gates/line-budget.mjs --base <main>` — pass
**Sensitivity, measured rather than argued.** `codex/gate-mutation` (#1633, draft, not for
merge) injects the regression this gate claims to protect against — an eager
`import "../../daemon/src/repo-cell.ts"` at the top of the thin CLI, pulling the daemon's
implementation graph into CLI startup instead of delegating over the socket. On the same
lane it reads:

| metric | healthy (5 runs) | with the regression |
| --- | --- | --- |
| `cli/bare` | 6.730 – 7.442 | **21.794** |
| bound | 8.6 | **fires** |

The mutation adds roughly `(21.794 - 7.442) x 29.539ms = 424ms` of startup, so this proves
the gate catches a real regression with a large margin — it does not prove the exact 30.4ms
sensitivity, which is derived arithmetically above rather than measured.

One detail worth recording: under the mutation the old metric's incoherent-sample count fell
to **0 of 11**. Its negative samples disappear once the CLI is slow enough to always exceed
the test process's own daemon call. The metric being replaced was incoherent precisely in the
healthy regime and coherent only when something was badly broken.

## Follow-up

`#1632`'s calibration diagnostics are removed once this lands — the same capability may have
only one production implementation.

## Governance Declaration

Derived from task `task_182bb1c6068a1c36ca11c68185` (CLI 启动比值门), under milestone
`task_63d9b4d05dc5d39addca53d75b`.

Production-Delta: +0/-0

---

# 中文

## 摘要

CLI 启动门断言的是一个**没有定义的量**,现在换成有定义的。

`overhead = cliElapsed - daemonElapsed` 看着像「整体减去它的一部分」,其实不是:
`daemonElapsed` 是**测试进程自己**发的一次 JSON-RPC 往返,而 `cliElapsed` 计的是**另一个 CLI
子进程**。拿一个操作的耗时去减另一个不相干操作的耗时,不构成分解;当测试进程那次调用慢时,
它会超过整趟 CLI 运行 —— **每一次观测到的跑动都报出了负的每样本比值,通过的跑次也一样**。

这就是抬限值和重跑从来没用的原因。七条 PR rebase 到当前 main 重跑后全部只红在这一个检查上。

现在断言 `cliElapsed / bareElapsed`。两个项都是真实的:裸 Node spawn 是每次 CLI 调用都要付的
成本。该比值不可能为负,也不可能低于 1。

## 这不是抬限值

这是在治理任务 `task_182bb1c6068a1c36ca11c68185` 下的**度量更换**。旧限值没有被抬高 ——
旧度量被删除,因为它什么都没量。门仍然守着它一直声称守的东西:CLI 若开始 eager 加载模块、
或不再委托常驻 daemon 而自己做写入,它就会红。`dec_01KY6X4J486MZ35RW1QN51V2V1` 得到遵守 ——
替代度量仍是相对开销,不是绝对毫秒边界。

## 度量是怎么选的

从四条捞来的失败日志里挑数字等于猜,而本机负载不足以本地标定。于是**把 CI 本身变成测量装置**:
`codex/gate-calibration`(#1632)在不改变任何判决的前提下,每次跑动输出候选度量。读数见英文段表格。

样本 2 内部噪声远大于其它样本(`cli <= daemon` 的自相矛盾样本从 1/11 升到 2/11,旧度量每样本
区间宽到 −23.781x 到 11.631x),**而 `cli/bare` 几乎纹丝不动,旧度量却在自己的限值两侧穿越** ——
同一分支、同样内容,3.169 通过、4.627 失败。

`cli/(bare+daemon)` 被否决:它留着同一个伪造项并继承其噪声,样本 2 上每样本下界 0.231x。

## 阈值是怎么推出来的

**推导方法在读数到齐之前就写进治理任务了**,所以数字无法事后挑选。见英文段。

余量比旧设计更紧是可以承受的,因为本度量的跨跑次极差是 10.6% 而旧度量是 46.0%。
按比例算,新的反而更安全:旧设计 1.29x 的余量,面对的是一个跑次间摆动 46.0% 的度量。

## 后续

`#1632` 的标定诊断在本 PR 合入后一并删除 —— 同一能力只允许一个生产实现。
