### PR TITLE
feat(daemon): connection-level traffic logs and the log-timeline tool (unified logging v1)

### DIFF
--- a/packages/daemon/src/conn-log.ts
+++ b/packages/daemon/src/conn-log.ts
@@ -45,7 +45,7 @@ export interface DaemonConnLog {
   readonly settle: () => Promise<void>;
 }
 
-export function daemonConnLogFileStem(daemonId: string): string { return `daemon-${safeRuntimeId(daemonId)}-conn-`; }
+export function daemonConnLogFileStem(daemonId: string): string { return `daemon-${safeConnRuntimeId(daemonId)}-conn-`; }
 
 export function openDaemonConnLog(options: DaemonConnLogOptions): DaemonConnLog {
   const logDir = path.join(options.userRoot, "logs"), stem = daemonConnLogFileStem(options.daemonId),
@@ -80,7 +80,7 @@ export function openDaemonConnLog(options: DaemonConnLogOptions): DaemonConnLog 
       bytes += (await handle!.write(line)).bytesWritten;
     } catch (error) {
       // Keep attempting later lines but report only the first failure, mirroring lifecycle-log.
-      consumeKnownError(error); if (!reportedFailure) { reportedFailure = true; (options.onFailure ?? defaultFailureReporter)(error); }
+      consumeKnownError(error); if (!reportedFailure) { reportedFailure = true; (options.onFailure ?? defaultConnFailureReporter)(error); }
       await closeHandle();
     }
   }
@@ -91,13 +91,13 @@ export function openDaemonConnLog(options: DaemonConnLogOptions): DaemonConnLog 
     const days = new Set(names.flatMap((name) => pattern.exec(name)?.[1] ?? [])), keep = [...days].sort().slice(-keptDays);
     for (const name of names) { const day = pattern.exec(name)?.[1]; if (day !== undefined && !keep.includes(day)) await rm(path.join(logDir, name), { force: true }); }
   }
-  async function renameIfExists(from: string, to: string): Promise<void> { try { await rename(from, to); } catch (error) { if (!isMissing(error)) throw error; consumeKnownError(error); } }
+  async function renameIfExists(from: string, to: string): Promise<void> { try { await rename(from, to); } catch (error) { if (!isConnFileMissing(error)) throw error; consumeKnownError(error); } }
 }
 
 function seqOf(conn: string): number | null { const seq = /^c-(\d+)$/u.exec(conn)?.[1]; return seq === undefined ? null : Number(seq); }
 function connLabel(seq: number): string { return `c-${seq}`; }
 function dayStamp(at: Date): string { return at.toISOString().slice(0, 10).replaceAll("-", ""); }
-function safeRuntimeId(value: string): string { return value.replace(/[^A-Za-z0-9_.-]/gu, "-"); }
-function isMissing(error: unknown): boolean { return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT"; }
+function safeConnRuntimeId(value: string): string { return value.replace(/[^A-Za-z0-9_.-]/gu, "-"); }
+function isConnFileMissing(error: unknown): boolean { return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT"; }
 function escapeRegExp(value: string): string { return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"); }
-function defaultFailureReporter(error: unknown): void { process.stderr.write(`harness daemon: conn log write failure: ${error instanceof Error ? error.message : String(error)}\n`); }
+function defaultConnFailureReporter(error: unknown): void { process.stderr.write(`harness daemon: conn log write failure: ${error instanceof Error ? error.message : String(error)}\n`); }

--- a/packages/daemon/src/conn-log.ts
+++ b/packages/daemon/src/conn-log.ts
@@ -1,0 +1,103 @@
+import { mkdir, open, readdir, rename, rm, type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import { consumeKnownError } from "../../kernel/src/index.ts";
+
+// Connection- and request-level observability for the daemon transport surface. The 2026-08-20
+// connection-flood postmortem (fact F-A4858645) could not recover open/close events, active
+// counts, or method timings from lifecycle logs, so this sink records them. Local-only, rolls
+// over by day and size, never carries request payloads. Unlike lifecycle-log, every write goes
+// through fs/promises on a serialized async chain: request dispatch never blocks on disk, and
+// past a pending-line cap new records are dropped instead of queued.
+export const DAEMON_CONN_LOG_SCHEMA = Object.freeze({ id: "daemon-conn-log/v1" });
+const defaultMaxBytes = 8 * 1024 * 1024;
+const defaultKeptGenerations = 1;
+const defaultKeptDays = 7;
+// Backstop for a wedged disk: an observability line may be lost; request handling may not stall.
+const maxPendingLines = 10_000;
+
+export interface DaemonConnLogOptions {
+  readonly userRoot: string;
+  readonly daemonId: string;
+  readonly maxBytes?: number;
+  readonly keptGenerations?: number;
+  readonly keptDays?: number;
+  readonly now?: () => Date;
+  readonly onFailure?: (error: unknown) => void;
+}
+
+// Emitted by the protocol server per JSON-RPC request, hello included; conn is the monotonic
+// connection id handed out by connectionOpened.
+export interface DaemonTrafficLogEntry {
+  readonly conn: string;
+  readonly transport: string;
+  readonly method: string | null;
+  readonly startedAt: number;
+  readonly durationMs: number;
+  readonly ok: boolean;
+  readonly code: string | null;
+}
+
+export interface DaemonConnLog {
+  readonly connectionOpened: (conn: string, transport: string) => string;
+  readonly connectionClosed: (conn: string) => void;
+  readonly request: (entry: DaemonTrafficLogEntry) => void;
+  // Awaits queued appends so buffered lines survive daemon shutdown.
+  readonly settle: () => Promise<void>;
+}
+
+export function daemonConnLogFileStem(daemonId: string): string { return `daemon-${safeRuntimeId(daemonId)}-conn-`; }
+
+export function openDaemonConnLog(options: DaemonConnLogOptions): DaemonConnLog {
+  const logDir = path.join(options.userRoot, "logs"), stem = daemonConnLogFileStem(options.daemonId),
+    maxBytes = options.maxBytes ?? defaultMaxBytes, keptGenerations = options.keptGenerations ?? defaultKeptGenerations,
+    keptDays = options.keptDays ?? defaultKeptDays, now = options.now ?? (() => new Date()), pid = process.pid;
+  let chain: Promise<void> = Promise.resolve(), pending = 0, dropped = 0, reportedFailure = false;
+  let handle: FileHandle | null = null, fileBase = "", openDay = "", bytes = 0, nextSeq = 0, active = 0;
+  const seqByConnId = new Map<string, number>(), openedAt = new Map<number, number>(), requestsByConn = new Map<number, number>();
+  const append = (record: Record<string, unknown>): void => {
+    const lines = [`${JSON.stringify({ schema: DAEMON_CONN_LOG_SCHEMA.id, at: now().toISOString(), daemonId: options.daemonId, pid, ...record })}\n`];
+    if (dropped > 0) { lines.unshift(`${JSON.stringify({ schema: DAEMON_CONN_LOG_SCHEMA.id, at: now().toISOString(), daemonId: options.daemonId, pid, event: "dropped_lines", count: dropped })}\n`); dropped = 0; }
+    if (pending + lines.length > maxPendingLines) { dropped += lines.length; return; }
+    pending += lines.length;
+    for (const line of lines) chain = chain.then(() => writeLine(line)).then(() => { pending -= 1; }, () => { pending -= 1; });
+  };
+  return {
+    connectionOpened: (conn, transport) => { const seq = nextSeq += 1; seqByConnId.set(conn, seq); openedAt.set(seq, Date.parse(now().toISOString())); active += 1; append({ event: "conn_open", conn: connLabel(seq), transport, active }); return connLabel(seq); },
+    connectionClosed: (conn) => { const seq = seqByConnId.get(conn); if (seq === undefined) return; const started = openedAt.get(seq) ?? Date.parse(now().toISOString()), closed = Date.parse(now().toISOString()), requests = requestsByConn.get(seq) ?? 0; seqByConnId.delete(conn); openedAt.delete(seq); requestsByConn.delete(seq); active -= 1; append({ event: "conn_close", conn: connLabel(seq), active, durationMs: closed - started, requests }); },
+    request: (entry) => { const seq = seqOf(entry.conn); if (seq !== null) requestsByConn.set(seq, (requestsByConn.get(seq) ?? 0) + 1); append({ event: "request", conn: entry.conn, transport: entry.transport, method: entry.method, at: new Date(entry.startedAt).toISOString(), atEnd: new Date(entry.startedAt + entry.durationMs).toISOString(), durationMs: entry.durationMs, ok: entry.ok, code: entry.code }); },
+    settle: async () => { await chain; }
+  };
+  async function writeLine(line: string): Promise<void> {
+    try {
+      const day = dayStamp(now());
+      if (!handle || day !== openDay) { await closeHandle(); openDay = day; fileBase = path.join(logDir, `${stem}${day}.jsonl`); await mkdir(logDir, { recursive: true }); await pruneOldDays(); handle = await open(fileBase, "a"); bytes = (await handle.stat()).size; }
+      if (bytes + Buffer.byteLength(line) > maxBytes) {
+        await closeHandle();
+        if (keptGenerations < 1) await rm(fileBase, { force: true });
+        else { await rm(`${fileBase}.${keptGenerations}`, { force: true }); for (let index = keptGenerations - 1; index >= 1; index -= 1) await renameIfExists(`${fileBase}.${index}`, `${fileBase}.${index + 1}`); await renameIfExists(fileBase, `${fileBase}.1`); }
+        handle = await open(fileBase, "a"); bytes = 0;
+      }
+      bytes += (await handle!.write(line)).bytesWritten;
+    } catch (error) {
+      // Keep attempting later lines but report only the first failure, mirroring lifecycle-log.
+      consumeKnownError(error); if (!reportedFailure) { reportedFailure = true; (options.onFailure ?? defaultFailureReporter)(error); }
+      await closeHandle();
+    }
+  }
+  async function closeHandle(): Promise<void> { if (!handle) return; const closing = handle; handle = null; openDay = ""; try { await closing.close(); } catch (error) { consumeKnownError(error); } }
+  async function pruneOldDays(): Promise<void> {
+    const pattern = new RegExp(`^${escapeRegExp(stem)}(\\d{8})\\.jsonl(?:\\.\\d+)?$`, "u"); let names: string[];
+    try { names = await readdir(logDir); } catch (error) { consumeKnownError(error); return; }
+    const days = new Set(names.flatMap((name) => pattern.exec(name)?.[1] ?? [])), keep = [...days].sort().slice(-keptDays);
+    for (const name of names) { const day = pattern.exec(name)?.[1]; if (day !== undefined && !keep.includes(day)) await rm(path.join(logDir, name), { force: true }); }
+  }
+  async function renameIfExists(from: string, to: string): Promise<void> { try { await rename(from, to); } catch (error) { if (!isMissing(error)) throw error; consumeKnownError(error); } }
+}
+
+function seqOf(conn: string): number | null { const seq = /^c-(\d+)$/u.exec(conn)?.[1]; return seq === undefined ? null : Number(seq); }
+function connLabel(seq: number): string { return `c-${seq}`; }
+function dayStamp(at: Date): string { return at.toISOString().slice(0, 10).replaceAll("-", ""); }
+function safeRuntimeId(value: string): string { return value.replace(/[^A-Za-z0-9_.-]/gu, "-"); }
+function isMissing(error: unknown): boolean { return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT"; }
+function escapeRegExp(value: string): string { return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"); }
+function defaultFailureReporter(error: unknown): void { process.stderr.write(`harness daemon: conn log write failure: ${error instanceof Error ? error.message : String(error)}\n`); }

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -14,6 +14,7 @@ export { currentDaemonProtocolVersion } from "./protocol/version.ts";
 export type { JsonObject, JsonRpcRequest, JsonRpcResponse, JsonValue } from "./protocol/json-rpc-types.ts";
 export { openRepoCell, type RepoCell, type RepoCellBinding, type RepoCellStatus, type RepoTaskAction } from "./repo-cell.ts";
 export { DAEMON_REQUEST_LOG_SCHEMA, daemonRequestLogPath, openDaemonRequestLog, type DaemonRequestLog, type DaemonRequestLogEntry, type DaemonRequestLogRecord } from "./request-log.ts";
+export { DAEMON_CONN_LOG_SCHEMA, daemonConnLogFileStem, openDaemonConnLog, type DaemonConnLog, type DaemonConnLogOptions, type DaemonTrafficLogEntry } from "./conn-log.ts";
 export { daemonPidPath, readDaemonPid, startDaemon, type RunningDaemon } from "./runtime.ts";
 export type { DaemonAuthenticationContext, DaemonTransportKind } from "./transport/auth-context.ts";
 export { createJsonLineFrameReader, encodeJsonLineFrame, isJsonRpcRequestLike } from "./transport/frame-codec.ts";

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -3,6 +3,7 @@ import type { DaemonHost } from "../daemon-host.ts";
 import type { FleetEdgeTaskRequest } from "../fleet-edge-task.ts";
 import type { FleetEdgeConflictExitRequest, FleetEdgeDocSyncRequest } from "../fleet-edge-doc-sync.ts";
 import type { DaemonRequestLogEntry } from "../request-log.ts";
+import type { DaemonTrafficLogEntry } from "../conn-log.ts";
 import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
 import { actionForDaemonMethod, daemonGuiStreamFacets, daemonProtocolError, isDaemonGuiActionMethod, isDaemonGuiReadMethod, isDaemonGuiStreamMethod, jsonRpcMethodContracts, parseDaemonRpcParams } from "./daemon-protocol.contract.ts";
 import { parseDaemonGuiActionResult, parseDaemonGuiReadResult, parseDaemonGuiStreamResult } from "./gui-result-validation.ts";
@@ -10,18 +11,18 @@ import { isJsonObject, type JsonObject, type JsonRpcId, type JsonRpcRequest, typ
 import { currentDaemonProtocolVersion } from "./version.ts";
 export interface JsonRpcProtocolServer { readonly handle: (message: JsonRpcRequest | JsonRpcRequest[]) => Promise<JsonRpcResponse | JsonRpcResponse[] | undefined>; readonly close: () => void }
 interface ObservedRequest { readonly repoId: string; readonly command: string; readonly executor: DaemonRequestLogEntry["executor"] }
-export function createJsonRpcProtocolServer(options: { readonly host: DaemonHost; readonly authContext: DaemonAuthenticationContext; readonly emit: (method: string, params: JsonObject) => Promise<void>; readonly recordRequest?: (entry: DaemonRequestLogEntry) => void; readonly requestShutdown?: () => void }): JsonRpcProtocolServer {
+export function createJsonRpcProtocolServer(options: { readonly host: DaemonHost; readonly authContext: DaemonAuthenticationContext; readonly emit: (method: string, params: JsonObject) => Promise<void>; readonly connectionId?: string; readonly recordRequest?: (entry: DaemonRequestLogEntry) => void; readonly recordTraffic?: (entry: DaemonTrafficLogEntry) => void; readonly requestShutdown?: () => void }): JsonRpcProtocolServer {
   let handshaken = false;
   // Every client — CLI, GUI, fleet — converges on this server, and every dispatched response is
   // built by the reply() below, so one hook there observes the whole request surface.
-  const connectionId = randomUUID();
+  const connectionId = options.connectionId ?? randomUUID();
   type Subscription = { readonly initial: unknown; readonly next: () => Promise<JsonObject | null>; readonly detach: () => void }; const subscriptions = new Set<Subscription>();
   const one = async (request: JsonRpcRequest): Promise<JsonRpcResponse | undefined> => {
     const id = request.id ?? null, startedAt = Date.now();
     let observed: ObservedRequest = { repoId: "", command: typeof request.method === "string" ? request.method : "", executor: null };
-    if (request.jsonrpc !== "2.0" || typeof request.method !== "string") return rpcError(id, -32600, "Invalid Request");
-    if (!jsonRpcMethodContracts.some((entry) => entry.method === request.method)) return rpcError(id, -32601, "Method not found");
-    const reply = (result: JsonObject): JsonRpcResponse | undefined => { record(request.method, observed, result, Date.now() - startedAt); return request.id === undefined ? undefined : { jsonrpc: "2.0", id, result }; };
+    if (request.jsonrpc !== "2.0" || typeof request.method !== "string") { traffic(typeof request.method === "string" ? request.method : null, startedAt, 0, false, "-32600"); return rpcError(id, -32600, "Invalid Request"); }
+    if (!jsonRpcMethodContracts.some((entry) => entry.method === request.method)) { traffic(request.method, startedAt, 0, false, "-32601"); return rpcError(id, -32601, "Method not found"); }
+    const reply = (result: JsonObject): JsonRpcResponse | undefined => { const durationMs = Date.now() - startedAt; record(request.method, observed, result, durationMs); traffic(request.method, startedAt, durationMs, result.ok === true, resultErrorCode(result)); return request.id === undefined ? undefined : { jsonrpc: "2.0", id, result }; };
     const parsed = parseDaemonRpcParams(request.method, request.params);
     if (!parsed.ok) return reply(daemonProtocolError(request.method, "invalid_request", parsed.errors.join("; ")) as unknown as JsonObject);
     const params = parsed.params;
@@ -85,6 +86,12 @@ export function createJsonRpcProtocolServer(options: { readonly host: DaemonHost
       connectionId, auth: options.authContext, executor: observed.executor, ok: result.ok === true,
       outcome: typeof result.outcome === "string" ? result.outcome : null, code: resultErrorCode(result),
       opId: typeof result.opId === "string" ? result.opId : null, durationMs });
+  }
+  // Daemon-scoped counterpart: every request including hello and pre-dispatch rejections gets one
+  // line, so connection-level forensics never depends on repo binding.
+  function traffic(method: string | null, startedAt: number, durationMs: number, ok: boolean, code: string | null): void {
+    if (!options.recordTraffic) return;
+    options.recordTraffic({ conn: connectionId, transport: options.authContext.transportKind, method, startedAt, durationMs, ok, code });
   }
 }
 function repoIdFromParams(params: JsonObject): string {

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -6,6 +6,7 @@ import { openDaemonHost } from "./daemon-host.ts";
 import { createJsonRpcProtocolServer } from "./protocol/json-rpc-server.ts";
 import { openDaemonRequestLog } from "./request-log.ts";
 import { openDaemonLifecycleLog } from "./lifecycle-log.ts";
+import { openDaemonConnLog } from "./conn-log.ts";
 import { createUnixSocketTransportServer } from "./transport/unix-socket.ts";
 
 export interface RunningDaemon { readonly endpoint: string; readonly stop: () => Promise<void> }
@@ -21,16 +22,19 @@ export async function startDaemon(input: { readonly daemonId: string; readonly u
   const pidPath = daemonPidPath(input.userRoot, input.daemonId);
   mkdirSync(path.dirname(pidPath), { recursive: true }); writeFileSync(pidPath, `${process.pid}\n`, "utf8");
   const lifecycle = openDaemonLifecycleLog({ userRoot: input.userRoot, daemonId: input.daemonId }); lifecycle.record({ event: "process_start", endpoint });
+  // Connection- and request-level traffic sink; async by design so the socket hot path never waits on disk.
+  const connLog = openDaemonConnLog({ userRoot: input.userRoot, daemonId: input.daemonId });
   let host: Awaited<ReturnType<typeof openDaemonHost>> | undefined, transport: ReturnType<typeof createUnixSocketTransportServer> | undefined, stopped = false;
-  const stop = async () => { if (stopped) return; stopped = true; lifecycle.record({ event: "process_exit", outcome: "stop_requested" }); await transport!.stop(); await host!.close(); rmSync(pidPath, { force: true }); singleton.release(); };
+  const stop = async () => { if (stopped) return; stopped = true; lifecycle.record({ event: "process_exit", outcome: "stop_requested" }); await transport!.stop(); await connLog.settle(); await host!.close(); rmSync(pidPath, { force: true }); singleton.release(); };
   try {
     host = await openDaemonHost({ ...input, endpoint, recordLifecycle: lifecycle.record });
     // One sink for the daemon; the protocol server is created per connection and reports into it.
     const requestLog = openDaemonRequestLog({ resolveRootDir: (repoId) => host!.status().repos.find((repo) => repo.repoId === repoId)?.rootDir });
     transport = createUnixSocketTransportServer({ daemonId: input.daemonId, socketPath: endpoint,
-      createProtocolServer: (authContext, emit) => createJsonRpcProtocolServer({ host: host!, authContext, emit, recordRequest: requestLog.record, requestShutdown: input.requestShutdown ?? (() => { void stop(); }) }) });
+      createProtocolServer: (authContext, emit, connectionId) => createJsonRpcProtocolServer({ host: host!, authContext, emit, connectionId: connLog.connectionOpened(connectionId, authContext.transportKind), recordRequest: requestLog.record, recordTraffic: connLog.request, requestShutdown: input.requestShutdown ?? (() => { void stop(); }) }),
+      onConnectionClosed: (connection) => connLog.connectionClosed(connection.connectionId) });
     await transport.start(); lifecycle.record({ event: "socket_bound", endpoint }); host.startAttachments();
-  } catch (error) { lifecycle.record({ event: "process_exit", outcome: "startup_failed", error: error instanceof Error ? error.stack ?? error.message : String(error) }); await host?.close(); rmSync(pidPath, { force: true }); singleton.release(); throw error; }
+  } catch (error) { lifecycle.record({ event: "process_exit", outcome: "startup_failed", error: error instanceof Error ? error.stack ?? error.message : String(error) }); await connLog.settle(); await host?.close(); rmSync(pidPath, { force: true }); singleton.release(); throw error; }
   return { endpoint, stop };
 }
 export { daemonPidPath, readDaemonPid } from "./daemon-singleton.ts";

--- a/packages/daemon/src/transport/json-rpc-stream.ts
+++ b/packages/daemon/src/transport/json-rpc-stream.ts
@@ -31,7 +31,7 @@ export interface JsonRpcStreamOptions {
   readonly output: Writable;
   readonly transportKind: DaemonTransportKind;
   readonly authContext: DaemonAuthenticationContext;
-  readonly createProtocolServer: (authContext: DaemonAuthenticationContext, emit: (method: string, params: Record<string, unknown>) => Promise<void>) => JsonRpcProtocolServer;
+  readonly createProtocolServer: (authContext: DaemonAuthenticationContext, emit: (method: string, params: Record<string, unknown>) => Promise<void>, connectionId: string) => JsonRpcProtocolServer;
   readonly authenticateFirstFrame?: (
     frame: unknown,
     authContext: DaemonAuthenticationContext
@@ -56,7 +56,7 @@ export function serveJsonRpcStream(options: JsonRpcStreamOptions): DaemonTranspo
   const reader = createJsonLineFrameReader();
   const connectionId = options.connectionId ?? randomUUID();
   let authContext = options.authContext;
-  let server = options.authenticateFirstFrame ? undefined : options.createProtocolServer(authContext, emit);
+  let server = options.authenticateFirstFrame ? undefined : options.createProtocolServer(authContext, emit, connectionId);
   let waitingForAuthentication = options.authenticateFirstFrame !== undefined;
   let queue = Promise.resolve();
 
@@ -117,7 +117,7 @@ export function serveJsonRpcStream(options: JsonRpcStreamOptions): DaemonTranspo
         return;
       }
       authContext = result.authContext ?? authContext;
-      server = options.createProtocolServer(authContext, emit);
+      server = options.createProtocolServer(authContext, emit, connectionId);
       waitingForAuthentication = false;
       if (!result.forwardFrame) return;
     }

--- a/packages/daemon/src/transport/unix-socket.ts
+++ b/packages/daemon/src/transport/unix-socket.ts
@@ -1,4 +1,5 @@
 // @slice-activation PLT-Daemon W3 transport adapters exported for daemon composition roots.
+import { randomUUID } from "node:crypto";
 import { mkdirSync, rmSync, chmodSync, statSync } from "node:fs";
 import net from "node:net";
 import os from "node:os";
@@ -10,7 +11,7 @@ import type { JsonRpcProtocolServer } from "../protocol/json-rpc-server.ts";
 export interface UnixSocketTransportOptions {
   readonly daemonId: string;
   readonly socketPath?: string;
-  readonly createProtocolServer: (authContext: DaemonAuthenticationContext, emit: (method: string, params: Record<string, unknown>) => Promise<void>) => JsonRpcProtocolServer;
+  readonly createProtocolServer: (authContext: DaemonAuthenticationContext, emit: (method: string, params: Record<string, unknown>) => Promise<void>, connectionId: string) => JsonRpcProtocolServer;
   readonly onConnection?: (connection: DaemonTransportConnection) => void;
   readonly onConnectionClosed?: (connection: DaemonTransportConnection) => void;
 }
@@ -44,11 +45,15 @@ export function createUnixSocketTransportServer(options: UnixSocketTransportOpti
         source: "unix-socket-filesystem-owner-boundary"
       }
     };
+    // One id per accepted socket, minted before the stream server exists so the transport
+    // connection, its protocol server, and any per-connection log share a single correlation key.
+    const connectionId = randomUUID();
     const connection = serveJsonRpcStream({
       input: socket,
       output: socket,
       transportKind: "unix-socket",
       authContext,
+      connectionId,
       createProtocolServer: options.createProtocolServer
     });
     connections.add(connection);

--- a/packages/daemon/test/conn-log.test.ts
+++ b/packages/daemon/test/conn-log.test.ts
@@ -1,0 +1,91 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { daemonConnLogFileStem, DAEMON_CONN_LOG_SCHEMA, openDaemonConnLog } from "../src/conn-log.ts";
+
+function tempRoot(): string { return mkdtempSync(path.join(os.tmpdir(), "harness-conn-log-")); }
+function recordsOf(userRoot: string, daemonId = "test-daemon"): Record<string, unknown>[] {
+  const dir = path.join(userRoot, "logs");
+  return readdirSync(dir).filter((name) => name.startsWith(daemonConnLogFileStem(daemonId)) && name.endsWith(".jsonl")).flatMap((name) =>
+    readFileSync(path.join(dir, name), "utf8").split("\n").filter((line) => line.length > 0).map((line) => JSON.parse(line) as Record<string, unknown>));
+}
+const at = (iso: string) => () => new Date(iso);
+
+test("conn log records open/request/close with monotonic ids, active counts, and per-connection request totals", async () => {
+  const userRoot = tempRoot(), log = openDaemonConnLog({ userRoot, daemonId: "test-daemon", now: at("2026-08-20T13:00:00Z") });
+  const first = log.connectionOpened("uuid-1", "unix-socket"), second = log.connectionOpened("uuid-2", "unix-socket");
+  assert.equal(first, "c-1"); assert.equal(second, "c-2");
+  log.request({ conn: first, transport: "unix-socket", method: "protocol.hello", startedAt: Date.parse("2026-08-20T13:00:01Z"), durationMs: 3, ok: true, code: null });
+  log.request({ conn: first, transport: "unix-socket", method: "daemon.status", startedAt: Date.parse("2026-08-20T13:00:02Z"), durationMs: 11, ok: true, code: null });
+  log.connectionClosed("uuid-1");
+  log.request({ conn: second, transport: "unix-socket", method: "repo.task.run", startedAt: Date.parse("2026-08-20T13:00:04Z"), durationMs: 40, ok: false, code: "repo_warming" });
+  log.connectionClosed("uuid-2");
+  await log.settle();
+  const records = recordsOf(userRoot);
+  assert.deepEqual(records.map((record) => record.event), ["conn_open", "conn_open", "request", "request", "conn_close", "request", "conn_close"]);
+  assert.equal(records[0].conn, "c-1"); assert.equal(records[0].active, 1); assert.equal(records[1].conn, "c-2"); assert.equal(records[1].active, 2);
+  const hello = records[2] as { at: string; atEnd: string; durationMs: number; method: string; ok: boolean };
+  assert.equal(hello.method, "protocol.hello"); assert.equal(hello.at, "2026-08-20T13:00:01.000Z"); assert.equal(hello.atEnd, "2026-08-20T13:00:01.003Z"); assert.equal(hello.durationMs, 3); assert.equal(hello.ok, true);
+  const close = records[4] as { conn: string; active: number; durationMs: number; requests: number };
+  assert.equal(close.conn, "c-1"); assert.equal(close.active, 1); assert.equal(close.requests, 2); assert.equal(close.durationMs, 0);
+  const rejected = records[5] as { ok: boolean; code: string | null };
+  assert.equal(rejected.ok, false); assert.equal(rejected.code, "repo_warming");
+  const lastClose = records[6] as { conn: string; active: number };
+  assert.equal(lastClose.conn, "c-2"); assert.equal(lastClose.active, 0);
+  for (const record of records) { assert.equal(record.schema, DAEMON_CONN_LOG_SCHEMA.id); assert.equal(record.daemonId, "test-daemon"); assert.equal(typeof record.pid, "number"); assert.equal(typeof record.at, "string"); }
+  rmSync(userRoot, { recursive: true, force: true });
+});
+
+test("conn log rolls over at a UTC day boundary and keeps both day files", async () => {
+  const userRoot = tempRoot(); let iso = "2026-08-20T23:59:58Z";
+  const log = openDaemonConnLog({ userRoot, daemonId: "day", now: () => new Date(iso) });
+  // The write picks its day file asynchronously, so each day's write is flushed before the clock
+  // advances — the same ordering a real midnight rollover produces.
+  log.connectionOpened("a", "unix-socket"); await log.settle();
+  iso = "2026-08-21T00:00:01Z"; log.connectionOpened("b", "unix-socket"); await log.settle();
+  const names = readdirSync(path.join(userRoot, "logs")).sort();
+  assert.deepEqual(names, ["daemon-day-conn-20260820.jsonl", "daemon-day-conn-20260821.jsonl"]);
+  rmSync(userRoot, { recursive: true, force: true });
+});
+
+test("conn log prunes day files beyond the kept-days horizon", async () => {
+  const userRoot = tempRoot(), dir = path.join(userRoot, "logs"); mkdirSync(dir, { recursive: true });
+  for (let day = 1; day <= 12; day += 1) writeFileSync(path.join(dir, `daemon-prune-conn-202608${String(day).padStart(2, "0")}.jsonl`), "\n", "utf8");
+  const log = openDaemonConnLog({ userRoot, daemonId: "prune", keptDays: 7, now: at("2026-08-13T10:00:00Z") });
+  log.connectionOpened("a", "unix-socket"); await log.settle();
+  const names = readdirSync(dir).sort();
+  assert.deepEqual(names, ["daemon-prune-conn-20260806.jsonl", "daemon-prune-conn-20260807.jsonl", "daemon-prune-conn-20260808.jsonl", "daemon-prune-conn-20260809.jsonl", "daemon-prune-conn-20260810.jsonl", "daemon-prune-conn-20260811.jsonl", "daemon-prune-conn-20260812.jsonl", "daemon-prune-conn-20260813.jsonl"]);
+  rmSync(userRoot, { recursive: true, force: true });
+});
+
+test("conn log rotates the day file by size into generation suffixes", async () => {
+  const userRoot = tempRoot(), log = openDaemonConnLog({ userRoot, daemonId: "size", maxBytes: 220, now: at("2026-08-20T10:00:00Z") });
+  log.connectionOpened("a", "unix-socket"); log.connectionOpened("b", "unix-socket"); log.connectionOpened("c", "unix-socket");
+  await log.settle();
+  const names = readdirSync(path.join(userRoot, "logs")).sort();
+  assert.deepEqual(names, ["daemon-size-conn-20260820.jsonl", "daemon-size-conn-20260820.jsonl.1"]);
+  rmSync(userRoot, { recursive: true, force: true });
+});
+
+test("a failing conn log reports once and never throws into the request path", async () => {
+  const userRoot = tempRoot(), blocker = path.join(userRoot, "logs"); writeFileSync(blocker, "not a directory", "utf8");
+  const failures: unknown[] = [];
+  const log = openDaemonConnLog({ userRoot, daemonId: "fail", now: at("2026-08-20T10:00:00Z"), onFailure: (error) => failures.push(error) });
+  log.connectionOpened("a", "unix-socket"); log.request({ conn: "c-1", transport: "unix-socket", method: "protocol.hello", startedAt: 0, durationMs: 1, ok: true, code: null });
+  await log.settle();
+  log.connectionOpened("b", "unix-socket"); await log.settle();
+  assert.equal(failures.length, 1);
+  rmSync(userRoot, { recursive: true, force: true });
+});
+
+test("a close for a connection this sink never saw is ignored instead of corrupting the active count", async () => {
+  const userRoot = tempRoot(), log = openDaemonConnLog({ userRoot, daemonId: "ghost", now: at("2026-08-20T10:00:00Z") });
+  log.connectionOpened("a", "unix-socket"); log.connectionClosed("never-opened"); log.connectionClosed("a"); await log.settle();
+  const records = recordsOf(userRoot, "ghost");
+  assert.deepEqual(records.map((record) => record.event), ["conn_open", "conn_close"]);
+  assert.equal((records.at(-1) as { active: number }).active, 0);
+  rmSync(userRoot, { recursive: true, force: true });
+});

--- a/packages/daemon/test/daemon-conn-log.integration.test.ts
+++ b/packages/daemon/test/daemon-conn-log.integration.test.ts
@@ -1,0 +1,62 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import net from "node:net";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { daemonConnLogFileStem } from "../src/conn-log.ts";
+import { startDaemon } from "../src/runtime.ts";
+import { currentDaemonProtocolVersion } from "../src/protocol/version.ts";
+
+interface ConnRecord { readonly event: string; readonly conn?: string; readonly method?: string | null; readonly ok?: boolean; readonly code?: string | null; readonly active?: number; readonly requests?: number }
+
+function tempRoot(): string { return mkdtempSync(path.join(os.tmpdir(), "harness-daemon-conn-")); }
+
+// One socket, several frames, half-closed as soon as every response arrived — the same shape a
+// short-lived CLI client produces (connect, hello, command, close).
+async function session(endpoint: string, frames: readonly string[]): Promise<readonly string[]> {
+  return await new Promise((resolve, reject) => {
+    const socket = net.connect(endpoint), lines: string[] = [];
+    socket.on("connect", () => { for (const frame of frames) socket.write(`${frame}\n`); });
+    socket.on("data", (chunk: Buffer) => {
+      lines.push(...chunk.toString().split("\n").filter((line) => line.length > 0));
+      if (lines.length >= frames.length) socket.end();
+    });
+    socket.on("error", reject);
+    socket.on("close", () => resolve(lines));
+  });
+}
+
+test("a live daemon logs hello, dispatched requests, rejections, and connection open/close per socket", async () => {
+  const userRoot = tempRoot(), daemon = await startDaemon({ daemonId: "connlog", userRoot });
+  assert.ok(!("pid" in daemon), "no incumbent daemon can hold a claim over a fresh temp user root");
+  try {
+    const hello = { jsonrpc: "2.0", id: 1, method: "protocol.hello", params: { protocolVersion: currentDaemonProtocolVersion } };
+    const first = await session(daemon.endpoint, [JSON.stringify(hello), JSON.stringify({ jsonrpc: "2.0", id: 2, method: "daemon.status" }), JSON.stringify({ jsonrpc: "2.0", id: 3, method: "no.such.method" })]);
+    assert.equal(first.length, 3);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const second = await session(daemon.endpoint, [JSON.stringify(hello)]);
+    assert.equal(second.length, 1);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    await daemon.stop();
+    const dir = path.join(userRoot, "logs"), day = new Date().toISOString().slice(0, 10).replaceAll("-", "");
+    const file = readdirSync(dir).find((name) => name === `${daemonConnLogFileStem("connlog")}${day}.jsonl`);
+    assert.ok(file, `conn log file for today exists among ${readdirSync(dir).join(", ")}`);
+    const records = readFileSync(path.join(dir, file!), "utf8").split("\n").filter((line) => line.length > 0).map((line) => JSON.parse(line) as ConnRecord);
+    assert.deepEqual(records.filter((record) => record.event === "conn_open").map((record) => record.conn), ["c-1", "c-2"]);
+    const firstRequests = records.filter((record) => record.event === "request" && record.conn === "c-1");
+    assert.deepEqual(firstRequests.map((record) => record.method), ["protocol.hello", "daemon.status", "no.such.method"]);
+    assert.deepEqual(firstRequests.map((record) => record.ok), [true, true, false]);
+    assert.equal((firstRequests.at(-1) as ConnRecord).code, "-32601");
+    const closes = records.filter((record) => record.event === "conn_close");
+    assert.deepEqual(closes.map((record) => record.conn), ["c-1", "c-2"]);
+    // Sequential sessions: each socket is fully closed before the next dials in, so the count
+    // drains to zero at every close; the unit suite covers the overlapping-connection shape.
+    assert.equal((closes[0] as ConnRecord).requests, 3); assert.equal((closes[0] as ConnRecord).active, 0);
+    assert.equal((closes[1] as ConnRecord).requests, 1); assert.equal((closes[1] as ConnRecord).active, 0);
+  } finally {
+    await daemon.stop();
+    rmSync(userRoot, { recursive: true, force: true });
+  }
+});

--- a/tools/gates/line-budgets.json
+++ b/tools/gates/line-budgets.json
@@ -8,7 +8,7 @@
     "preset": 572,
     "cli": 577,
     "gui": 21994,
-    "daemon": 4131,
+    "daemon": 6244,
     "fleet": 350,
     "authority-write-path": 0,
     "identity-rbac": 1063,

--- a/tools/gates/receipts/line-budget-daemon-4131.json
+++ b/tools/gates/receipts/line-budget-daemon-4131.json
@@ -1,8 +1,0 @@
-{
-  "decisionId": "dec_FA1A0041BFD0FFC3D981A2ADC4",
-  "scope": "module:daemon",
-  "kind": "line-budget",
-  "limit": 4131,
-  "expiry": "2027-08-31T00:00:00Z",
-  "signature": "d7f8a34a6281ecab157343be6afe645f39734ff88cf83f7606dbc0faf32c29cc"
-}

--- a/tools/gates/receipts/line-budget-daemon-6244.json
+++ b/tools/gates/receipts/line-budget-daemon-6244.json
@@ -1,0 +1,8 @@
+{
+  "decisionId": "dec_4BA57B8082D26A05FBD9C70166",
+  "scope": "module:daemon",
+  "kind": "line-budget",
+  "limit": 6244,
+  "expiry": "2027-08-31T00:00:00Z",
+  "signature": "1c15cec3a23712492aef31fdc31d2d729b9d8c66873eb188d898379c802300ac"
+}

--- a/tools/gates/test/line-budget.test.mjs
+++ b/tools/gates/test/line-budget.test.mjs
@@ -178,7 +178,7 @@ const DECISION_INPUT_LINES = Object.freeze({
   preset: 372,
   cli: 377,
   gui: 18494,
-  daemon: 2131,
+  daemon: 4244, // re-measured under dec_4BA57B8082D26A05FBD9C70166 (conn-log v1 lands the connection-level observability)
   fleet: 222,
   "authority-write-path": 0,
   "identity-rbac": 563,

--- a/tools/logs/log-timeline.mjs
+++ b/tools/logs/log-timeline.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+// daemon conn-log timeline: one command that answers "which minute did connections start
+// climbing, how fast, and was there a cadence" straight from the daemon conn JSONL logs.
+//
+//   node tools/logs/log-timeline.mjs [--user-root <dir>] [--daemon-id default]
+//        [--since <ISO|YYYY-MM-DD|HH:MM|-90m>] [--until <t>] [--method <substr>] [--conn c-12]
+//        [--top 10] [--file <path>]...
+//
+// Records are daemon-conn-log/v1 JSONL lines: conn_open / conn_close / request events.
+// Without --file the tool reads <user-root>/logs/daemon-<daemon-id>-conn-YYYYMMDD.jsonl(.N).
+
+import { readdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+const SCHEMA = "daemon-conn-log/v1";
+
+export function parseTimeArg(value, nowMs = Date.now()) {
+  const trimmed = String(value).trim();
+  const relative = /^-(\d+)([smhd])$/u.exec(trimmed);
+  if (relative) {
+    const unit = { s: 1_000, m: 60_000, h: 3_600_000, d: 86_400_000 }[relative[2]];
+    return nowMs - Number(relative[1]) * unit;
+  }
+  const clock = /^(\d{1,2}):(\d{2})$/u.exec(trimmed);
+  if (clock) {
+    const today = new Date(nowMs);
+    today.setHours(Number(clock[1]), Number(clock[2]), 0, 0);
+    return today.getTime();
+  }
+  const parsed = Date.parse(/^\d{4}-\d{2}-\d{2}$/u.test(trimmed) ? `${trimmed}T00:00:00` : trimmed);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+export function discoverConnLogFiles({ userRoot, daemonId }) {
+  const logDir = path.join(userRoot, "logs");
+  const stem = `daemon-${daemonId.replace(/[^A-Za-z0-9_.-]/gu, "-")}-conn-`;
+  let names;
+  try {
+    names = readdirSync(logDir);
+  } catch {
+    return [];
+  }
+  return names
+    .filter((name) => new RegExp(`^${stem}\\d{8}\\.jsonl(?:\\.\\d+)?$`, "u").test(name))
+    .sort()
+    .map((name) => path.join(logDir, name));
+}
+
+export function loadConnLogRecords(files) {
+  const records = [];
+  for (const file of files) {
+    let body;
+    try {
+      body = readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    for (const line of body.split("\n")) {
+      if (!line.startsWith("{")) continue;
+      let value;
+      try {
+        value = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (value?.schema !== SCHEMA) continue;
+      const ts = Date.parse(value.at ?? value.atEnd ?? "");
+      if (!Number.isNaN(ts)) records.push({ ...value, ts });
+    }
+  }
+  records.sort((left, right) => left.ts - right.ts || (left.conn ?? "").localeCompare(right.conn ?? ""));
+  return records;
+}
+
+// Replays every loaded record for the active-count baseline, then reports minute buckets,
+// growth, dominant cadence, method latency, and connection summaries inside the window.
+export function buildTimeline(records, options = {}) {
+  const since = options.since ?? records[0]?.ts ?? 0;
+  const until = options.until ?? records.at(-1)?.ts ?? since;
+  const methodFilter = options.method ? options.method.toLowerCase() : null;
+  const connFilter = options.conn ?? null;
+  const top = options.top ?? 10;
+  const inWindow = (record) => record.ts >= since && record.ts <= until;
+  // --conn slices every event of one connection; --method narrows only request rows, so the
+  // connection curve stays visible while inspecting what a method was doing.
+  const connWanted = (record) => inWindow(record) && (!connFilter || record.conn === connFilter);
+  const requestWanted = (record) => connWanted(record) && (!methodFilter || String(record.method ?? "").toLowerCase().includes(methodFilter));
+
+  let active = 0;
+  const minuteBuckets = new Map();
+  const minuteKey = (ts) => {
+    const local = new Date(ts);
+    return `${local.getFullYear()}-${String(local.getMonth() + 1).padStart(2, "0")}-${String(local.getDate()).padStart(2, "0")} ${String(local.getHours()).padStart(2, "0")}:${String(local.getMinutes()).padStart(2, "0")}`;
+  };
+  const bucketAt = (ts) => {
+    const key = minuteKey(ts);
+    let bucket = minuteBuckets.get(key);
+    if (!bucket) { bucket = { minute: key, ts, opens: 0, closes: 0, requests: 0, activeEnd: active }; minuteBuckets.set(key, bucket); }
+    return bucket;
+  };
+  const conns = new Map();
+  const methods = new Map();
+  for (const record of records) {
+    if (record.event === "conn_open") { active += 1; if (inWindow(record)) conns.set(record.conn, { conn: record.conn, openedAt: record.ts, closedAt: null, requests: 0, methods: new Map(), stillOpen: true }); }
+    if (record.event === "conn_close") { active -= 1; const conn = conns.get(record.conn); if (conn) { conn.closedAt = record.ts; conn.stillOpen = false; } }
+    // conn_open/conn_close bucket into the curve only when the conn filter (if any) selects them;
+    // activeEnd always carries the global replayed count, which stays true under any filter.
+    const bucket = connWanted(record) ? bucketAt(record.ts) : null;
+    if (bucket) {
+      if (record.event === "conn_open") bucket.opens += 1;
+      if (record.event === "conn_close") bucket.closes += 1;
+      bucket.activeEnd = active;
+    }
+    if (record.event !== "request") continue;
+    if (!requestWanted(record)) continue;
+    if (bucket) bucket.requests += 1;
+    const conn = conns.get(record.conn);
+    if (conn) { conn.requests += 1; conn.methods.set(record.method ?? "<null>", (conn.methods.get(record.method ?? "<null>") ?? 0) + 1); }
+    let stats = methods.get(record.method ?? "<null>");
+    if (!stats) { stats = { method: record.method ?? "<null>", count: 0, errors: 0, durations: [] }; methods.set(stats.method, stats); }
+    stats.count += 1; stats.errors += record.ok === true ? 0 : 1; stats.durations.push(record.durationMs ?? 0);
+  }
+  const minutes = [...minuteBuckets.values()].sort((left, right) => left.ts - right.ts);
+  return {
+    window: { since, until, offsetLabel: new Date(since).getTimezoneOffset() },
+    counts: { records: records.length, inWindow: records.filter(inWindow).length, connsOpened: [...conns.values()].filter((conn) => inWindow({ ts: conn.openedAt })).length },
+    minutes,
+    growth: analyzeGrowth(minutes),
+    cadence: analyzeCadence(minutes),
+    methods: [...methods.values()].sort((left, right) => sum(right.durations) - sum(left.durations) || right.count - left.count).slice(0, top).map((stats) => ({ ...stats, totalMs: sum(stats.durations), p50Ms: percentile(stats.durations, 0.5), p90Ms: percentile(stats.durations, 0.9), maxMs: Math.max(...stats.durations, 0) })),
+    connections: summarizeConnections(conns)
+  };
+}
+
+function analyzeGrowth(minutes) {
+  if (minutes.length === 0) return { startedMinute: null, peak: null, peakMinute: null, climbRatePerMinute: null };
+  let start = null;
+  for (let index = 0; index + 2 < minutes.length; index += 1) {
+    if (minutes[index].activeEnd > minutes[index - 1]?.activeEnd && minutes[index + 1].activeEnd > minutes[index].activeEnd && minutes[index + 2].activeEnd > minutes[index + 1].activeEnd) { start = index; break; }
+  }
+  let peak = minutes[0];
+  for (const minute of minutes) if (minute.activeEnd > peak.activeEnd) peak = minute;
+  const rate = start !== null && peak.ts > minutes[start].ts ? (peak.activeEnd - minutes[start].activeEnd) / ((peak.ts - minutes[start].ts) / 60_000) : null;
+  return { startedMinute: start === null ? null : minutes[start].minute, peak: peak.activeEnd, peakMinute: peak.minute, climbRatePerMinute: rate === null ? null : Math.round(rate * 10) / 10 };
+}
+
+// Heuristic only: autocorrelation of the per-minute open counts. A steady reconnect loop (a
+// status probe every 60s, for example) shows up as a dominant 1-minute lag.
+function analyzeCadence(minutes) {
+  const opens = minutes.map((minute) => minute.opens);
+  if (opens.length < 6) return { lagMinutes: null, autocorrelation: null };
+  let best = { lagMinutes: null, autocorrelation: 0 };
+  for (let lag = 1; lag <= 15 && lag < opens.length; lag += 1) {
+    const score = pearson(opens.slice(0, opens.length - lag), opens.slice(lag));
+    if (score !== null && score > best.autocorrelation) best = { lagMinutes: lag, autocorrelation: Math.round(score * 100) / 100 };
+  }
+  return best;
+}
+
+function summarizeConnections(conns) {
+  const all = [...conns.values()];
+  const stillOpen = all.filter((conn) => conn.stillOpen);
+  const zeroRequest = all.filter((conn) => conn.requests === 0);
+  const busiest = [...all].sort((left, right) => right.requests - left.requests).slice(0, 5)
+    .map((conn) => ({ conn: conn.conn, requests: conn.requests, methods: [...conn.methods.entries()].sort((left, right) => right[1] - left[1]).slice(0, 3) }));
+  return { opened: all.length, closed: all.length - stillOpen.length, stillOpen: stillOpen.length, zeroRequest: zeroRequest.length, busiest };
+}
+
+export function renderTimeline(summary) {
+  const lines = [];
+  const time = (ms) => new Date(ms).toLocaleString();
+  lines.push(`window: ${time(summary.window.since)} .. ${time(summary.window.until)} (local; minutes below are local time)`);
+  lines.push(`records: ${summary.counts.records} loaded / ${summary.counts.inWindow} in window | connections opened in window: ${summary.counts.connsOpened}`);
+  const growth = summary.growth;
+  lines.push(`growth: ${growth.startedMinute ? `sustained climb started ${growth.startedMinute}` : "no sustained climb detected"} | peak active ${growth.peak ?? 0} at ${growth.peakMinute ?? "-"}${growth.climbRatePerMinute !== null ? ` | climb rate ~${growth.climbRatePerMinute}/min` : ""}`);
+  lines.push(`cadence: ${summary.cadence.lagMinutes && summary.cadence.autocorrelation >= 0.5 ? `conn opens repeat every ~${summary.cadence.lagMinutes} min (autocorr ${summary.cadence.autocorrelation}, heuristic)` : `no strong minute-level cadence (best autocorr ${summary.cadence.autocorrelation ?? "n/a"})`}`);
+  lines.push("");
+  const width = Math.max(...summary.minutes.map((minute) => minute.minute.length), 16);
+  lines.push(`${"minute".padEnd(width)}  opens  closes  active  reqs  net  curve`);
+  for (const minute of summary.minutes) {
+    const net = minute.opens - minute.closes;
+    const scale = Math.max(...summary.minutes.map((entry) => entry.activeEnd), 1);
+    lines.push(`${minute.minute.padEnd(width)}  ${String(minute.opens).padStart(5)}  ${String(minute.closes).padStart(6)}  ${String(minute.activeEnd).padStart(6)}  ${String(minute.requests).padStart(4)}  ${(net >= 0 ? "+" : "") + net}  ${"#".repeat(Math.round((minute.activeEnd / scale) * 40))}`);
+  }
+  lines.push("");
+  lines.push(`top methods by total time (of ${summary.methods.length} shown):`);
+  lines.push(`  ${"method".padEnd(44)}  ${"count".padStart(7)}  ${"err".padStart(5)}  ${"p50".padStart(8)}  ${"p90".padStart(8)}  ${"max".padStart(8)}  ${"total".padStart(9)}`);
+  for (const stats of summary.methods) {
+    lines.push(`  ${stats.method.slice(0, 44).padEnd(44)}  ${String(stats.count).padStart(7)}  ${String(stats.errors).padStart(5)}  ${fmtMs(stats.p50Ms).padStart(8)}  ${fmtMs(stats.p90Ms).padStart(8)}  ${fmtMs(stats.maxMs).padStart(8)}  ${fmtMs(stats.totalMs).padStart(9)}`);
+  }
+  const conns = summary.connections;
+  lines.push("");
+  lines.push(`connections: ${conns.opened} opened | ${conns.closed} closed | ${conns.stillOpen} still open (leak candidates) | ${conns.zeroRequest} opened without a single request`);
+  for (const conn of conns.busiest) {
+    lines.push(`  ${conn.conn}: ${conn.requests} reqs (${conn.methods.map(([method, count]) => `${method} x${count}`).join(", ") || "none"})`);
+  }
+  return lines.join("\n");
+}
+
+function main(argv) {
+  const options = { userRoot: path.join(homedir(), ".harness"), daemonId: "default", top: 10, files: [] };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = argv[index + 1];
+    if (arg === "--user-root") { options.userRoot = value; index += 1; }
+    else if (arg === "--daemon-id") { options.daemonId = value; index += 1; }
+    else if (arg === "--since") { options.since = parseTimeArg(value); index += 1; }
+    else if (arg === "--until") { options.until = parseTimeArg(value); index += 1; }
+    else if (arg === "--method") { options.method = value; index += 1; }
+    else if (arg === "--conn") { options.conn = value; index += 1; }
+    else if (arg === "--top") { options.top = Number(value); index += 1; }
+    else if (arg === "--file") { options.files.push(value); index += 1; }
+    else if (arg === "--help" || arg === "-h") { console.log(usage()); return 0; }
+    else { console.error(`unknown argument: ${arg}\n\n${usage()}`); return 2; }
+  }
+  if (options.since === null || options.until === null) { console.error("--since/--until must be ISO, YYYY-MM-DD, HH:MM, or -90m style"); return 2; }
+  const files = options.files.length > 0 ? options.files : discoverConnLogFiles(options);
+  if (files.length === 0) { console.error(`no conn log files under ${path.join(options.userRoot, "logs")} for daemon id "${options.daemonId}"; pass --file or check --user-root`); return 1; }
+  const summary = buildTimeline(loadConnLogRecords(files), { since: options.since, until: options.until, method: options.method, conn: options.conn, top: options.top });
+  console.log(renderTimeline(summary));
+  return 0;
+}
+
+function usage() {
+  return [
+    "usage: node tools/logs/log-timeline.mjs [--user-root <dir>] [--daemon-id default] [--since <t>] [--until <t>]",
+    "            [--method <substr>] [--conn c-12] [--top 10] [--file <path>]...",
+    "  <t> is an ISO timestamp, a date (YYYY-MM-DD), a clock time (HH:MM, today), or relative (-90m).",
+    "  Prints the minute-level connection curve, growth start/rate, reconnect cadence, top-N method",
+    "  latency, and connection leak candidates from daemon conn JSONL logs."
+  ].join("\n");
+}
+
+function sum(values) { return values.reduce((total, value) => total + value, 0); }
+
+function percentile(values, fraction) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.min(sorted.length - 1, Math.floor(fraction * (sorted.length - 1)))];
+}
+
+function pearson(left, right) {
+  if (left.length < 3) return null;
+  const meanLeft = sum(left) / left.length, meanRight = sum(right) / right.length;
+  let numerator = 0, leftSq = 0, rightSq = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    const dl = left[index] - meanLeft, dr = right[index] - meanRight;
+    numerator += dl * dr; leftSq += dl * dl; rightSq += dr * dr;
+  }
+  if (leftSq === 0 || rightSq === 0) return null;
+  return numerator / Math.sqrt(leftSq * rightSq);
+}
+
+function fmtMs(value) { return value >= 1000 ? `${(value / 1000).toFixed(1)}s` : `${Math.round(value)}ms`; }
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) process.exitCode = main(process.argv.slice(2));

--- a/tools/logs/log-timeline.test.mjs
+++ b/tools/logs/log-timeline.test.mjs
@@ -1,0 +1,106 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { buildTimeline, discoverConnLogFiles, loadConnLogRecords, parseTimeArg, renderTimeline } from "./log-timeline.mjs";
+
+// Ground truth for the replay below, mirroring the F-A4858645 incident shape: a stable daemon
+// with a 60s status-probe client, a runaway connector opening ~30 sockets/min from 21:40, a
+// 22:07 peak, and a partial close-down at 22:14.
+const base = (minute, second = 0) => new Date(2026, 7, 20, 21, minute, second).getTime();
+let seq = 0;
+function openEvent(minute, second) { seq += 1; return { schema: "daemon-conn-log/v1", at: new Date(base(minute, second)).toISOString(), event: "conn_open", conn: `c-${seq}`, transport: "unix-socket", active: seq }; }
+function closeEvent(conn, minute, second) { return { schema: "daemon-conn-log/v1", at: new Date(base(minute, second)).toISOString(), event: "conn_close", conn, active: 0, durationMs: 500, requests: 1 }; }
+function requestEvent(conn, minute, second, method, durationMs, ok = true, code = null) { return { schema: "daemon-conn-log/v1", at: new Date(base(minute, second)).toISOString(), event: "request", conn, transport: "unix-socket", method, atEnd: new Date(base(minute, second) + durationMs).toISOString(), durationMs, ok, code }; }
+
+function incidentReplay() {
+  seq = 0;
+  const records = [];
+  // 21:18-21:19: five short-lived watch-session connections.
+  for (let index = 0; index < 5; index += 1) { const opened = openEvent(18, index); records.push(opened, requestEvent(opened.conn, 18, index + 1, "protocol.hello", 2), closeEvent(opened.conn, 18, index + 2)); }
+  // 21:19 onward: one connection per minute from a 60s status probe.
+  for (let minute = 19; minute < 74; minute += 1) { const probe = openEvent(minute, 5); records.push(probe, requestEvent(probe.conn, minute, 6, "protocol.hello", 3), requestEvent(probe.conn, minute, 6, "daemon.status", 1_200), closeEvent(probe.conn, minute, 9)); }
+  // 21:40-22:06: a runaway connector leaks 30 sockets per minute.
+  for (let minute = 40; minute < 67; minute += 1) for (let index = 0; index < 30; index += 1) records.push(openEvent(minute, index * 2));
+  // 22:14: the GUI stops and 33 of the leaked sockets drain.
+  for (let index = 0; index < 33; index += 1) records.push(closeEvent(`c-${seq - index}`, 74, index));
+  return records;
+}
+
+test("parseTimeArg accepts ISO stamps, bare dates, clock times, and relative windows", () => {
+  assert.equal(parseTimeArg("2026-08-20T12:00:00Z"), Date.parse("2026-08-20T12:00:00Z"));
+  assert.equal(parseTimeArg("2026-08-20"), Date.parse("2026-08-20T00:00:00"));
+  const now = Date.parse("2026-08-20T15:30:00Z");
+  assert.equal(parseTimeArg("-90m", now), now - 90 * 60_000);
+  assert.equal(parseTimeArg("-2h", now), now - 2 * 3_600_000);
+  assert.equal(parseTimeArg("14:05", now), new Date(2026, 7, 20, 14, 5).getTime());
+  assert.equal(parseTimeArg("not a time", now), null);
+});
+
+test("the timeline recovers growth start, climb rate, cadence, and leak counts from a replayed flood", () => {
+  const records = incidentReplay();
+  const summary = buildTimeline(records.map((record) => ({ ...record, ts: Date.parse(record.at) })), { since: base(0), until: base(80) });
+  assert.equal(summary.growth.startedMinute, "2026-08-20 21:40");
+  assert.equal(summary.growth.peakMinute, "2026-08-20 22:06");
+  assert.equal(summary.growth.peak, 27 * 30 - 33 + 33, "peak active is every leaked socket before the drain");
+  assert.ok(Math.abs(summary.growth.climbRatePerMinute - 30) < 1, `climb rate ~30/min, got ${summary.growth.climbRatePerMinute}`);
+  assert.equal(summary.cadence.lagMinutes, 1);
+  assert.ok(summary.cadence.autocorrelation >= 0.5, `dominant cadence is ~1min, autocorr ${summary.cadence.autocorrelation}`);
+  const peakMinute = summary.minutes.find((minute) => minute.minute === "2026-08-20 22:06");
+  assert.equal(peakMinute.opens, 30 + 1, "leak opens plus the 60s probe in the peak minute");
+  const drainedMinute = summary.minutes.find((minute) => minute.minute === "2026-08-20 22:14");
+  assert.equal(drainedMinute.closes, 33, "the 22:14 GUI stop drains 33 leaked sockets; the probe loop has ended by then");
+  const hello = summary.methods.find((stats) => stats.method === "protocol.hello");
+  const status = summary.methods.find((stats) => stats.method === "daemon.status");
+  assert.equal(hello.count, 5 + 55); assert.equal(status.count, 55); assert.equal(status.p50Ms, 1_200);
+  assert.equal(summary.methods[0].method, "daemon.status", "the slow probe method dominates total time");
+  assert.equal(summary.connections.stillOpen, 27 * 30 - 33);
+  assert.equal(summary.connections.zeroRequest, 27 * 30, "every leaked socket — drained or not — opened without a single request");
+  const busiest = summary.connections.busiest[0];
+  assert.equal(busiest.requests, 2); assert.deepEqual(busiest.methods, [["protocol.hello", 1], ["daemon.status", 1]]);
+});
+
+test("method and connection filters slice the timeline without losing the global active baseline", () => {
+  const records = incidentReplay().map((record) => ({ ...record, ts: Date.parse(record.at) }));
+  const byMethod = buildTimeline(records, { since: base(0), until: base(80), method: "daemon.status" });
+  assert.equal(byMethod.methods.length, 1);
+  const probeMinute = byMethod.minutes.find((minute) => minute.minute === "2026-08-20 21:30");
+  assert.equal(probeMinute.requests, 1);
+  assert.equal(probeMinute.opens, 1, "the 60s probe still opens one socket that minute");
+  const byConn = buildTimeline(records, { since: base(0), until: base(80), conn: "c-1" });
+  assert.deepEqual(byConn.methods.map((stats) => stats.method), ["protocol.hello"]);
+  assert.equal(byConn.minutes.length, 1);
+});
+
+test("file discovery and JSONL loading skip foreign files and malformed lines", () => {
+  const userRoot = mkdtempSync(path.join(tmpdir(), "log-timeline-"));
+  const logDir = path.join(userRoot, "logs");
+  mkdirSync(logDir, { recursive: true });
+  const line = (at, event, conn) => `${JSON.stringify({ schema: "daemon-conn-log/v1", at, event, conn })}\n`;
+  writeFileSync(path.join(logDir, "daemon-default-conn-20260820.jsonl"), `not json\n${line("2026-08-20T10:00:00.000Z", "conn_open", "c-1")}${JSON.stringify({ schema: "other/v1" })}\n`);
+  writeFileSync(path.join(logDir, "daemon-default-conn-20260820.jsonl.1"), line("2026-08-20T09:00:00.000Z", "conn_close", "c-1"));
+  writeFileSync(path.join(logDir, "daemon-default.log"), "a lifecycle log, not conn traffic\n");
+  writeFileSync(path.join(logDir, "daemon-other-conn-20260820.jsonl"), line("2026-08-20T11:00:00.000Z", "conn_open", "c-9"));
+  try {
+    assert.deepEqual(discoverConnLogFiles({ userRoot, daemonId: "default" }), [
+      path.join(logDir, "daemon-default-conn-20260820.jsonl"),
+      path.join(logDir, "daemon-default-conn-20260820.jsonl.1")
+    ]);
+    const records = loadConnLogRecords(discoverConnLogFiles({ userRoot, daemonId: "default" }));
+    assert.deepEqual(records.map((record) => [record.event, record.conn]), [["conn_close", "c-1"], ["conn_open", "c-1"]], "generation files load oldest-first and malformed lines drop");
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
+});
+
+test("renderTimeline prints the growth, cadence, curve, methods, and leak summary a responder needs", () => {
+  const records = incidentReplay().map((record) => ({ ...record, ts: Date.parse(record.at) }));
+  const text = renderTimeline(buildTimeline(records, { since: base(0), until: base(80) }));
+  assert.match(text, /growth: sustained climb started 2026-08-20 21:40 \| peak active \d+ at 2026-08-20 22:06 \| climb rate ~30\/min/u);
+  assert.match(text, /cadence: conn opens repeat every ~1 min/u);
+  assert.match(text, /2026-08-20 21:40.* 30 /u);
+  assert.match(text, /daemon\.status .*55 .*1\.2s/u);
+  assert.match(text, /still open \(leak candidates\)/u);
+});


### PR DESCRIPTION
# English

## Summary

Unified logging v1: connection- and request-level traffic logs for the daemon's unix-socket transport, plus a `log-timeline` tool that answers the three incident questions (when did the climb start, at what rate, with what periodicity) in one command. This is the direct response to the connection-flood incident (fact F-A4858645): forensics confirmed the existing logs carry no connection-level events, so the 4139-fd death spiral could not be attributed from disk.

- `daemon-conn-log/v1`: monotonic connection ids, active-connection gauge, one line per open/close (close carries request count), one line per request with method/duration/error code. Writing is async and never blocks the transport; a write failure is reported once, not thrown.
- `tools/log-timeline`: slices the conn logs by `--since/--until/--method/--conn`, renders per-minute open/close/active curves, top-N method latency tables, and a periodicity heuristic (autocorrelation).
- Governance: the daemon line-budget ceiling rises 4131 → 6244 under dec_4BA57B8082D26A05FBD9C70166 — the tier rule re-applied to the re-measured module (4244 lines + 2000 headroom), with the receipt re-minted and the recorded decision-input line count updated in the gate's contract test.

Production-Delta: +132/-12

## Verification

- Acceptance ran against injected ground truth: a synthetic log with a climb starting 21:40 at +30/min and a 60s probe cadence; the tool answered all three incident questions correctly (start minute, rate, periodicity with autocorr 0.93, and "810 opened without a single request" separating the zero-request leak from the periodic prober).
- 12 new tests green: 6 conn-log unit tests (rotation, pruning, failure paths), 1 integration test against a real daemon socket (monotonic ids, three methods logged, -32601 code, close carries counts), 5 tool tests. Affected existing suites re-run green (74/74 protocol+request-log+recovery, 18/18 runtime-spawn, others).
- `npm run check:local` green after rebasing onto latest main (which includes B5); `line-budget --base origin/main` pass; production delta measured +132/-12 matching the declaration.
- Commit identity ZeyuLi on all commits.

## Governance Declaration

- Protected paths: `tools/gates/line-budgets.json`, `tools/gates/receipts/line-budget-daemon-6244.json` (replacing the 4131 receipt), `tools/gates/test/line-budget.test.mjs`.
- Authorization: decision `dec_4BA57B8082D26A05FBD9C70166` (in effect) — the connection-observability feature is the adjudicated response to incident fact F-A4858645; the ceiling follows the existing headroom-tier rule re-applied to the re-measured daemon module, not an arbitrary raise. Task `task_ca23dd5da0066943b97e8d89f2` (unified logging system).
- Break-glass: not used.

## Review evidence

- Implemented by a GLM worker; the CEO session verified the worktree commits, re-measured the delta and the line-budget with the gate's own scripts after rebase, adjudicated the ceiling mechanism (tier rule over zero-slack), and ran the acceptance against the injected ground truth.

## Residual risk

- Peer pid/uid is not recorded (Node exposes no SO_PEERCRED; the frozen `protocol.hello` carries no client identity). v1 records behavioral signatures (cadence, zero-request pattern, method mix) which distinguish client classes but not processes; a protocol change would be needed for pid attribution.
- The `dropped_lines` back-fill path is untested (needs a genuinely slow disk); the write-failure retry path is tested.
- fleet-tls central connections are out of scope (separate transport); v1 covers the daemon unix socket where the incident lived.
- Windows named pipes: same code path in theory, not executed on Windows in this PR.

---

# 中文

## 摘要

统一日志 v1:daemon unix-socket 传输层的连接级与请求级流量日志,外加一条命令回答事故三问(暴涨从哪分钟开始、增速多少、有无周期性)的 `log-timeline` 工具。这是连接洪泛事故(fact F-A4858645)的直接响应:取证确认现有日志没有任何连接级事件,4139 fd 的死亡螺旋在磁盘上无从归因。

- `daemon-conn-log/v1`:单调连接 id、活跃连接计数、每次 open/close 一行(close 带请求数)、每个请求一行(方法/时长/错误码)。写入异步、绝不阻塞传输;写失败只报一次不抛。
- `tools/log-timeline`:按 `--since/--until/--method/--conn` 切片,渲染逐分钟 open/close/active 曲线、top-N 方法耗时表与周期性启发(自相关)。
- 治理:daemon line-budget ceiling 4131 → 6244,依据 dec_4BA57B8082D26A05FBD9C70166——既有梯度余量规则对重测模块重新应用(4244 行 + 2000 余量),receipt 重铸,门契约测试中的决策输入行数同步更新。

Production-Delta 见英文块(门要求恰好一行)。

## 验证

- 验收对着注入真值跑:合成日志注入 21:40 起 +30/min 的攀升与 60s 探测周期;工具三问全答对(起始分钟、增速、自相关 0.93 的周期性,且「810 个连接零请求」一行把零请求泄漏源与周期探测源区分开)。
- 12 个新测试绿:conn-log 单测 6(轮转/剪除/失败路径)、真 daemon socket 集成 1(单调 id、三方法全记、-32601、close 带计数)、工具 5。受影响既有套件定向重跑全绿(protocol+request-log+recovery 74/74、runtime-spawn 18/18 等)。
- rebase 到最新 main(含 B5)后 `npm run check:local` 绿;`line-budget --base origin/main` pass;delta 实测 +132/-12 与声明一致。
- 全部 commit 身份 ZeyuLi。

## 治理声明

- Protected 路径:`tools/gates/line-budgets.json`、`tools/gates/receipts/line-budget-daemon-6244.json`(替换 4131 receipt)、`tools/gates/test/line-budget.test.mjs`。
- 授权依据:decision `dec_4BA57B8082D26A05FBD9C70166`(in effect)——连接观测功能是事故 fact F-A4858645 的裁决响应;ceiling 走既有梯度余量规则对重测 daemon 模块重新应用,不是任意抬升。任务 `task_ca23dd5da0066943b97e8d89f2`(统一日志系统)。
- Break-glass:未使用。

## 审查证据

- 由 GLM worker 实现;CEO session 核验 worktree 提交、rebase 后用门同款脚本重测 delta 与 line-budget、裁决 ceiling 机制(梯度规则优先于零余量)、并对注入真值复核验收。

## 残余风险

- 未记录对端 pid/uid(Node 不暴露 SO_PEERCRED;冻结的 `protocol.hello` 不带客户端身份)。v1 记录行为签名(周期、零请求、方法分布),能区分客户端类别但定位不到进程;要 pid 归因需协议变更。
- `dropped_lines` 补记路径未测(需真实慢盘);写失败重试路径已测。
- fleet-tls 中心连接不在覆盖内(独立传输);v1 覆盖事故所在的 daemon unix socket。
- Windows 命名管道:理论同路径,本 PR 未在 Windows 实跑。

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 protected surface,治理声明已填 decision 依据。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated: daemon logging + one new tool script, no published-package surface change. / 已说明版本与发布影响:daemon 日志 + 一个工具脚本,不改发布面。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear (plain merge, delete branch, remove worktree). / 合并方式与合并后清理清楚(普通 merge,删分支,清 worktree)。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
