### PR TITLE
fix(daemon): close the conn log file handle when settle drains the queue

### DIFF
--- a/packages/daemon/src/conn-log.ts
+++ b/packages/daemon/src/conn-log.ts
@@ -41,7 +41,7 @@ export interface DaemonConnLog {
   readonly connectionOpened: (conn: string, transport: string) => string;
   readonly connectionClosed: (conn: string) => void;
   readonly request: (entry: DaemonTrafficLogEntry) => void;
-  // Awaits queued appends so buffered lines survive daemon shutdown.
+  // Awaits queued appends and closes the file handle so shutdown leaks no descriptor; a later append reopens.
   readonly settle: () => Promise<void>;
 }
 
@@ -65,7 +65,7 @@ export function openDaemonConnLog(options: DaemonConnLogOptions): DaemonConnLog 
     connectionOpened: (conn, transport) => { const seq = nextSeq += 1; seqByConnId.set(conn, seq); openedAt.set(seq, Date.parse(now().toISOString())); active += 1; append({ event: "conn_open", conn: connLabel(seq), transport, active }); return connLabel(seq); },
     connectionClosed: (conn) => { const seq = seqByConnId.get(conn); if (seq === undefined) return; const started = openedAt.get(seq) ?? Date.parse(now().toISOString()), closed = Date.parse(now().toISOString()), requests = requestsByConn.get(seq) ?? 0; seqByConnId.delete(conn); openedAt.delete(seq); requestsByConn.delete(seq); active -= 1; append({ event: "conn_close", conn: connLabel(seq), active, durationMs: closed - started, requests }); },
     request: (entry) => { const seq = seqOf(entry.conn); if (seq !== null) requestsByConn.set(seq, (requestsByConn.get(seq) ?? 0) + 1); append({ event: "request", conn: entry.conn, transport: entry.transport, method: entry.method, at: new Date(entry.startedAt).toISOString(), atEnd: new Date(entry.startedAt + entry.durationMs).toISOString(), durationMs: entry.durationMs, ok: entry.ok, code: entry.code }); },
-    settle: async () => { await chain; }
+    settle: async () => { await chain; await closeHandle(); }
   };
   async function writeLine(line: string): Promise<void> {
     try {


### PR DESCRIPTION
# English

## Summary

Fix a descriptor leak introduced by unified logging v1 (#1648): `DaemonConnLog.settle` drained the queued appends but never closed the file handle, so the post-merge `main` full-check run went red in `daemon-host-recovery.test.ts` with "A FileHandle object was closed during garbage collection" once the daemon under test stopped. `settle` now closes the handle after draining; a later append transparently reopens the file (the write path already handles a null handle), so mid-life settles remain safe.

Production-Delta: +2/-2

## Verification

- `packages/daemon/test/daemon-host-recovery.test.ts`: 16/16 green (the exact suite that failed on `main` run 32396813714).
- `packages/daemon/test/conn-log.test.ts`: 6/6 green — the rotation and failure-path tests exercise reopen-after-close.
- `npm run check:local` passed (fast tier).

## Review evidence

- Two-line fix authored by the CEO session directly (below delegation threshold); the red `main` run is the negative control — the failing GC error names the conn log file explicitly.

## Residual risk

- None beyond the change surface: the settle contract gains "closes the handle", documented at the interface.

---

# 中文

## 摘要

修复统一日志 v1(#1648)引入的句柄泄漏:`DaemonConnLog.settle` 只排干了待写队列,从不关闭文件句柄,导致合入后 `main` 的 full-check run 在 `daemon-host-recovery.test.ts` 红——被测 daemon 停止后 FileHandle 被垃圾回收时报 "A FileHandle object was closed during garbage collection"。现在 `settle` 排干后关闭句柄;后续 append 会透明地重新打开文件(写路径本就处理空句柄),中途 settle 依旧安全。

Production-Delta 见英文块(门要求恰好一行)。

## 验证

- `packages/daemon/test/daemon-host-recovery.test.ts`:16/16 绿(正是 `main` run 32396813714 红掉的那套)。
- `packages/daemon/test/conn-log.test.ts`:6/6 绿——轮转与失败路径测试覆盖了 close 后重开。
- `npm run check:local` 通过(fast tier)。

## 审查证据

- 两行修复,低于委托阈值,由 CEO session 直接完成;红掉的 `main` run 即阴性对照——GC 报错里明确点名 conn log 文件。

## 残余风险

- 改动面之外无:settle 契约新增「关闭句柄」语义,已在接口注释写明。

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 protected surface,治理声明已填 decision 依据。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated: daemon-internal fix, no publish impact. / 已说明版本与发布影响:daemon 内部修复,无发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear (plain merge, delete branch, remove worktree). / 合并方式与合并后清理清楚(普通 merge,删分支,清 worktree)。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
