### PR TITLE
fix(daemon): drain racing conn log appends and close the handle on the write chain

### DIFF
--- a/packages/daemon/src/conn-log.ts
+++ b/packages/daemon/src/conn-log.ts
@@ -41,7 +41,8 @@ export interface DaemonConnLog {
   readonly connectionOpened: (conn: string, transport: string) => string;
   readonly connectionClosed: (conn: string) => void;
   readonly request: (entry: DaemonTrafficLogEntry) => void;
-  // Awaits queued appends and closes the file handle so shutdown leaks no descriptor; a later append reopens.
+  // Drains queued appends (looping until no racing line extends the chain) and closes the handle on
+  // the write chain itself, so shutdown leaks no descriptor; a later append transparently reopens.
   readonly settle: () => Promise<void>;
 }
 
@@ -65,7 +66,7 @@ export function openDaemonConnLog(options: DaemonConnLogOptions): DaemonConnLog 
     connectionOpened: (conn, transport) => { const seq = nextSeq += 1; seqByConnId.set(conn, seq); openedAt.set(seq, Date.parse(now().toISOString())); active += 1; append({ event: "conn_open", conn: connLabel(seq), transport, active }); return connLabel(seq); },
     connectionClosed: (conn) => { const seq = seqByConnId.get(conn); if (seq === undefined) return; const started = openedAt.get(seq) ?? Date.parse(now().toISOString()), closed = Date.parse(now().toISOString()), requests = requestsByConn.get(seq) ?? 0; seqByConnId.delete(conn); openedAt.delete(seq); requestsByConn.delete(seq); active -= 1; append({ event: "conn_close", conn: connLabel(seq), active, durationMs: closed - started, requests }); },
     request: (entry) => { const seq = seqOf(entry.conn); if (seq !== null) requestsByConn.set(seq, (requestsByConn.get(seq) ?? 0) + 1); append({ event: "request", conn: entry.conn, transport: entry.transport, method: entry.method, at: new Date(entry.startedAt).toISOString(), atEnd: new Date(entry.startedAt + entry.durationMs).toISOString(), durationMs: entry.durationMs, ok: entry.ok, code: entry.code }); },
-    settle: async () => { await chain; await closeHandle(); }
+    settle: async () => { let tail: Promise<void>; do { tail = chain; await tail; } while (tail !== chain); chain = chain.then(() => closeHandle()); await chain; }
   };
   async function writeLine(line: string): Promise<void> {
     try {


### PR DESCRIPTION
# English

## Summary

Second half of the conn-log descriptor-leak fix: #1649 closed the handle after awaiting the write chain, but `settle` captured the chain reference once — a `connectionClosed` append racing in after transport stop (its callback still in the microtask queue) extended the chain, reopened the file, and leaked the new handle, so the post-merge `main` full-check stayed red in `daemon-host-recovery.test.ts` with the same GC-closed-FileHandle error across multiple descriptors (one per daemon restart in the budget benchmark). `settle` now loops until no racing line extends the chain, then enqueues the close on the write chain itself, so every append either lands before the close or transparently reopens for a later settle.

Production-Delta: +3/-2

## Verification

- `packages/daemon/test/daemon-host-recovery.test.ts`: 16/16 green (the suite red on `main` runs 32396813714 and 32398946461); `conn-log.test.ts` 6/6 green three consecutive runs (the suite settles then keeps appending, exercising reopen-after-close).
- `packages/daemon/test/conn-log.test.ts`: 6/6 green — the rotation and failure-path tests exercise reopen-after-close.
- `npm run check:local` passed (fast tier).

## Review evidence

- Two-line fix authored by the CEO session directly (below delegation threshold); the red `main` run is the negative control — the failing GC error names the conn log file explicitly.

## Residual risk

- None beyond the change surface: the settle contract gains "closes the handle", documented at the interface.

---

# 中文

## 摘要

conn-log 句柄泄漏修复的后半:#1649 在 await 写链后关句柄,但 `settle` 只取了一次链引用——transport 停止后仍在微任务队列里的 `connectionClosed` 回调赶进来的 append 会延长写链、重开文件并泄漏新句柄,所以合入后 `main` 的 full-check 依旧红在 `daemon-host-recovery.test.ts`(预算基准每次重启 daemon 泄一个 fd,同一 GC 报错多个描述符)。现在 `settle` 循环等到没有竞态行再延长链,然后把 close 排进写链本身:任何 append 要么在 close 前落盘,要么透明重开等下次 settle。

Production-Delta 见英文块(门要求恰好一行)。

## 验证

- `packages/daemon/test/daemon-host-recovery.test.ts`:16/16 绿(main run 32396813714 与 32398946461 红掉的那套);`conn-log.test.ts` 连续三轮 6/6 绿(该套件 settle 后继续 append,覆盖 close 后重开)。
- `packages/daemon/test/conn-log.test.ts`:6/6 绿——轮转与失败路径测试覆盖了 close 后重开。
- `npm run check:local` 通过(fast tier)。

## 审查证据

- 两行修复,低于委托阈值,由 CEO session 直接完成;红掉的 `main` run 即阴性对照——GC 报错里明确点名 conn log 文件。

## 残余风险

- 改动面之外无:settle 契约新增「关闭句柄」语义,已在接口注释写明。

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 protected surface,治理声明已填 decision 依据。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated: daemon-internal fix, no publish impact. / 已说明版本与发布影响:daemon 内部修复,无发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear (plain merge, delete branch, remove worktree). / 合并方式与合并后清理清楚(普通 merge,删分支,清 worktree)。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
