### PR TITLE
test(daemon): add a nightly soak lane that proves it can go red

### DIFF
--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -272,6 +272,37 @@ jobs:
       - if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
         run: node tools/run-manifest-gates.mjs --workflow-job windows-integration-shard --shard ${{ matrix.shard }} --exclude mergify-queue-metadata-edit-noop
 
+  nightly-daemon-soak:
+    # Functional CI starts a small daemon, serves one client for seconds, and stops it. That shape
+    # cannot catch the connection/RSS growth and handshake starvation seen on 2026-08-20/21. This
+    # lane holds a 1,377-task / 26,650-event daemon under concurrent real-client load, then makes
+    # one attached stream lose the daemon and proves reconnects stay bounded. It runs only on the
+    # nightly schedule and manual dispatch, never on pull_request/push and never as a required context.
+    if: github.event_name != 'pull_request' && github.event_name != 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      # The runner imports the shared hermetic preflight and applies it to the exact temporary
+      # user-root and daemon id that it is about to use before it starts any daemon process.
+      - name: Run hermetic daemon scale, duration, concurrency, and reconnect invariants
+        env:
+          HARNESS_SOAK_RESULTS_DIR: tmp/soak-results
+        run: npm run test:soak
+      - name: Preserve readable soak evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: daemon-soak-${{ github.run_id }}-${{ github.run_attempt }}
+          path: tmp/soak-results/
+          if-no-files-found: error
+          retention-days: 14
+
   boundaries:
     if: github.event_name == 'pull_request'
     needs: metadata-source-proof

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:fast": "node tools/run-node-tests.mjs --tier fast",
     "test:contract": "node tools/run-node-tests.mjs --tier contract",
     "test:integration": "node tools/run-node-tests.mjs --tier integration",
+    "test:soak": "node tools/soak/daemon-soak.mjs",
     "test:list": "node tools/run-node-tests.mjs --list",
     "quickstart:demo": "npm -w @harness-anything/cli run build && node scripts/quickstart-demo.mjs",
     "quickstart:demo:fail-closed": "npm -w @harness-anything/cli run build && node scripts/quickstart-demo.mjs --break-step fact-record",

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -164,7 +164,8 @@
       ],
       "nonPullRequestGateJobs": [
         "full-check",
-        "windows-integration-shard"
+        "windows-integration-shard",
+        "nightly-daemon-soak"
       ]
     },
     "branchProtection": {
@@ -4372,6 +4373,79 @@
         "status": "covered",
         "evidence": [
           "tools/smoke-cli-package.test.mjs"
+        ]
+      }
+    },
+    {
+      "id": "nightly-daemon-soak",
+      "command": "npm run test:soak",
+      "category": "smoke",
+      "tier": "nightly-only",
+      "tierReason": "dec_E6E62653DA534ACDD1B7C0A388/CH3 requires a scheduled and manually dispatchable daemon soak without adding it to the pull-request merge path or required contexts.",
+      "authoritySource": [
+        "decision/dec_E6E62653DA534ACDD1B7C0A388#CH3",
+        "tools/soak/daemon-soak.mjs",
+        ".github/workflows/rewrite-ci.yml:jobs.nightly-daemon-soak"
+      ],
+      "consumerScope": [
+        "resident daemon behavior over a deterministic 1,377-task / 26,650-event ledger under concurrent real-client load",
+        "bounded attached-stream reconnects after daemon loss",
+        "protocol.hello P99 and daemon RSS trend during sustained load"
+      ],
+      "githubContext": {
+        "requiredContexts": [],
+        "workflowJobs": [
+          "nightly-daemon-soak"
+        ],
+        "nodeVersions": [
+          24
+        ]
+      },
+      "allowlistPolicy": {
+        "allowed": false,
+        "location": null,
+        "adrOrDecisionRequired": false,
+        "notes": "The invariant thresholds and scale fixture are fixed in the soak runner; failures remain failures and preserve readable artifacts."
+      },
+      "changeControl": {
+        "ordinaryImplementationMayModify": false,
+        "requiresGovernanceEvidence": true,
+        "protectedSurfaces": [
+          "tools/soak/daemon-soak.mjs",
+          "package.json:scripts.test:soak",
+          ".github/workflows/rewrite-ci.yml",
+          "tools/gate-manifest.json"
+        ]
+      },
+      "bypassFixtureRequired": false,
+      "executionSurfaces": {
+        "packageJson": {
+          "check": false,
+          "checkPr": false,
+          "script": "test:soak"
+        },
+        "rewriteCi": {
+          "pullRequestJobs": [],
+          "nonPullRequestJobs": [
+            "nightly-daemon-soak"
+          ],
+          "scheduleOnly": true
+        },
+        "branchProtection": {
+          "required": false,
+          "contexts": []
+        },
+        "classes": [
+          "local",
+          "nightly"
+        ]
+      },
+      "deterministic": false,
+      "positiveControl": {
+        "status": "covered",
+        "evidence": [
+          "tools/soak/daemon-soak.test.mjs rejects a 244-open reconnect storm while accepting the bounded 6-open control",
+          "Induced unlimited 40ms reconnect control produced 231 opens and failed the isolated Ubuntu soak; restored bounded reconnect produced 5 opens and passed."
         ]
       }
     },

--- a/tools/logs/log-timeline.mjs
+++ b/tools/logs/log-timeline.mjs
@@ -128,7 +128,7 @@ export function buildTimeline(records, options = {}) {
     minutes,
     growth: analyzeGrowth(minutes),
     cadence: analyzeCadence(minutes),
-    methods: [...methods.values()].sort((left, right) => sum(right.durations) - sum(left.durations) || right.count - left.count).slice(0, top).map((stats) => ({ ...stats, totalMs: sum(stats.durations), p50Ms: percentile(stats.durations, 0.5), p90Ms: percentile(stats.durations, 0.9), maxMs: Math.max(...stats.durations, 0) })),
+    methods: [...methods.values()].sort((left, right) => sum(right.durations) - sum(left.durations) || right.count - left.count).slice(0, top).map((stats) => ({ ...stats, totalMs: sum(stats.durations), p50Ms: percentile(stats.durations, 0.5), p90Ms: percentile(stats.durations, 0.9), p99Ms: percentile(stats.durations, 0.99), maxMs: Math.max(...stats.durations, 0) })),
     connections: summarizeConnections(conns)
   };
 }
@@ -185,9 +185,9 @@ export function renderTimeline(summary) {
   }
   lines.push("");
   lines.push(`top methods by total time (of ${summary.methods.length} shown):`);
-  lines.push(`  ${"method".padEnd(44)}  ${"count".padStart(7)}  ${"err".padStart(5)}  ${"p50".padStart(8)}  ${"p90".padStart(8)}  ${"max".padStart(8)}  ${"total".padStart(9)}`);
+  lines.push(`  ${"method".padEnd(44)}  ${"count".padStart(7)}  ${"err".padStart(5)}  ${"p50".padStart(8)}  ${"p90".padStart(8)}  ${"p99".padStart(8)}  ${"max".padStart(8)}  ${"total".padStart(9)}`);
   for (const stats of summary.methods) {
-    lines.push(`  ${stats.method.slice(0, 44).padEnd(44)}  ${String(stats.count).padStart(7)}  ${String(stats.errors).padStart(5)}  ${fmtMs(stats.p50Ms).padStart(8)}  ${fmtMs(stats.p90Ms).padStart(8)}  ${fmtMs(stats.maxMs).padStart(8)}  ${fmtMs(stats.totalMs).padStart(9)}`);
+    lines.push(`  ${stats.method.slice(0, 44).padEnd(44)}  ${String(stats.count).padStart(7)}  ${String(stats.errors).padStart(5)}  ${fmtMs(stats.p50Ms).padStart(8)}  ${fmtMs(stats.p90Ms).padStart(8)}  ${fmtMs(stats.p99Ms).padStart(8)}  ${fmtMs(stats.maxMs).padStart(8)}  ${fmtMs(stats.totalMs).padStart(9)}`);
   }
   const conns = summary.connections;
   lines.push("");

--- a/tools/logs/log-timeline.test.mjs
+++ b/tools/logs/log-timeline.test.mjs
@@ -54,7 +54,8 @@ test("the timeline recovers growth start, climb rate, cadence, and leak counts f
   assert.equal(drainedMinute.closes, 33, "the 22:14 GUI stop drains 33 leaked sockets; the probe loop has ended by then");
   const hello = summary.methods.find((stats) => stats.method === "protocol.hello");
   const status = summary.methods.find((stats) => stats.method === "daemon.status");
-  assert.equal(hello.count, 5 + 55); assert.equal(status.count, 55); assert.equal(status.p50Ms, 1_200);
+  assert.equal(hello.count, 5 + 55); assert.equal(hello.p99Ms, 3);
+  assert.equal(status.count, 55); assert.equal(status.p50Ms, 1_200); assert.equal(status.p99Ms, 1_200);
   assert.equal(summary.methods[0].method, "daemon.status", "the slow probe method dominates total time");
   assert.equal(summary.connections.stillOpen, 27 * 30 - 33);
   assert.equal(summary.connections.zeroRequest, 27 * 30, "every leaked socket — drained or not — opened without a single request");

--- a/tools/soak/daemon-soak.mjs
+++ b/tools/soak/daemon-soak.mjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawn } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import net from "node:net";
+import { hostname, tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { randomUUID } from "node:crypto";
+import { REPLAY_TASK_GRAPH, eventObjectTarget, registerDaemonRepo, serializeCanonicalEvent, serializeEventHead, sha256Text } from "../../packages/kernel/src/index.ts";
+import { JsonRpcLineClient, connectSocket, requestDaemonJsonRpcAt } from "../../packages/daemon/src/client/local-json-rpc-client.ts";
+import { localUserDaemonEndpoint } from "../../packages/daemon/src/client/local-daemon-target.ts";
+import { streamAgentRuntimeAt } from "../../packages/daemon/src/client/local-json-rpc-stream.ts";
+import { openDaemonConnLog } from "../../packages/daemon/src/conn-log.ts";
+import { currentDaemonProtocolVersion } from "../../packages/daemon/src/protocol/version.ts";
+import { assessHermeticConfig } from "../test-hermetic-preflight.mjs";
+import { buildTimeline, discoverConnLogFiles, loadConnLogRecords, renderTimeline } from "../logs/log-timeline.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+const cliEntry = path.join(repoRoot, "packages/cli/src/index.ts");
+const MIB = 1024 * 1024;
+
+const soakActor = Object.freeze({ principal: { personId: "person-soak" }, executor: null });
+const runtimeDefinition = Object.freeze({ schema: "agent-definition-snapshot/v1", configVersion: 1, instanceId: "instance-soak", installationId: "installation-soak", kindId: "codex", providerId: "openai", model: "gpt-5.6-sol", reasoningEffort: "high", baseUrl: null, authMode: "subscription" });
+
+export function createSoakEvents({ taskCount, eventCount }) {
+  if (!Number.isInteger(taskCount) || taskCount < 1) throw new Error("taskCount must be a positive integer");
+  if (!Number.isInteger(eventCount) || eventCount < taskCount + 3) throw new Error("eventCount must leave room for every task and the runtime stream fixture");
+  const events = [], tasks = [];
+  const append = (schema, type, payload, taskId) => {
+    const revision = events.length + 1, suffix = String(revision).padStart(8, "0");
+    events.push({ schema, eventId: `event-soak-${suffix}`, workspaceRevision: revision, opId: `op-soak-${suffix}`, ...(taskId ? { taskId } : {}), type, actor: soakActor, source: "local", occurredAt: new Date(Date.UTC(2026, 0, 1) + revision * 1_000).toISOString(), payload });
+  };
+  for (let index = 0; index < taskCount; index += 1) {
+    const taskId = `task_soak_${String(index).padStart(6, "0")}`;
+    const task = { schema: "task/v1", taskId, title: `Nightly soak task ${String(index).padStart(6, "0")}`, taskClass: "standard", status: "planned", graph: REPLAY_TASK_GRAPH, currentNode: "implementation", iteration: 0, createdBy: soakActor, completionGateIds: [], presetSnapshotDigest: null,
+      metadata: { idempotencyKey: null, parentTaskId: index === 0 ? null : `task_soak_${String(index - 1).padStart(6, "0")}`, workKind: "test", riskTier: "medium", urgency: "medium", verticalId: "software/coding", presetId: "baseline", profileId: "baseline", moduleKey: "daemon", slug: `nightly-soak-${String(index).padStart(6, "0")}`, surfaces: ["packages/daemon"], fromLegacyId: null } };
+    tasks.push(task);
+    append("task-event/v1", "task_created", { task }, taskId);
+  }
+  append("agent-runtime-event/v1", "runtime_installation_observed", { installationId: "installation-soak", kindId: "codex", protocolFamily: "codex", hostRef: "host:soak", version: "1.0.0", discoverySource: "wrapper", capabilities: ["structured_witness", "attach"] });
+  append("agent-runtime-event/v1", "runtime_dispatch_requested", { dispatchId: "dispatch-soak", runtimeSessionId: "runtime-session-soak", instanceId: runtimeDefinition.instanceId, installationId: runtimeDefinition.installationId, kindId: runtimeDefinition.kindId, idempotencyKey: "nightly-soak", definitionSnapshotRef: "artifact:runtime-definition/nightly-soak", definitionSnapshot: runtimeDefinition });
+  append("agent-runtime-event/v1", "runtime_session_started", { runtimeSessionId: "runtime-session-soak", instanceId: runtimeDefinition.instanceId, installationId: runtimeDefinition.installationId, kindId: runtimeDefinition.kindId, definitionSnapshotRef: "artifact:runtime-definition/nightly-soak", launchGeneration: 1, attachable: true });
+  for (let index = 0; events.length < eventCount; index += 1) {
+    const task = tasks[index % tasks.length];
+    append("task-event/v1", "task_transitioned", { task, mutation: { command: "transition", reason: "nightly soak scale filler", fields: [] }, documentClaims: [] }, task.taskId);
+  }
+  return events;
+}
+
+export function assessConnections({ normal, fault, maxFaultConnections }) {
+  const failures = [];
+  if (normal.connections.stillOpen !== 0) failures.push(`${normal.connections.stillOpen} normal-load connection(s) remained open`);
+  if (normal.growth.startedMinute !== null) failures.push(`active connections entered a sustained climb at ${normal.growth.startedMinute}`);
+  if (fault.connections.stillOpen !== 0) failures.push(`${fault.connections.stillOpen} fault-window connection(s) remained open`);
+  if (fault.connections.opened > maxFaultConnections) failures.push(`fault window opened ${fault.connections.opened} > ${maxFaultConnections}`);
+  const prefix = failures.length === 0 ? "PASS" : "FAIL";
+  return {
+    ok: failures.length === 0,
+    message: `${prefix} bounded connections: ${failures.join("; ") || `${normal.connections.opened} normal opens drained; ${fault.connections.opened}/${maxFaultConnections} fault opens`}`
+  };
+}
+
+export function assessHelloLatency({ clientSamplesMs, daemon, maxP99Ms }) {
+  const clientP99Ms = percentile(clientSamplesMs, 0.99);
+  const daemonP99Ms = daemon.methods.find(({ method }) => method === "protocol.hello")?.p99Ms ?? Number.POSITIVE_INFINITY;
+  const failures = [];
+  if (clientP99Ms > maxP99Ms) failures.push(`client P99 ${formatMs(clientP99Ms)} > ${formatMs(maxP99Ms)}`);
+  if (daemonP99Ms > maxP99Ms) failures.push(`daemon dispatch P99 ${formatMs(daemonP99Ms)} > ${formatMs(maxP99Ms)}`);
+  const prefix = failures.length === 0 ? "PASS" : "FAIL";
+  return {
+    ok: failures.length === 0,
+    clientP99Ms,
+    daemonP99Ms,
+    message: `${prefix} protocol.hello latency: ${failures.join("; ") || `client P99 ${formatMs(clientP99Ms)}, daemon dispatch P99 ${formatMs(daemonP99Ms)} <= ${formatMs(maxP99Ms)}`}`
+  };
+}
+
+export function assessRssTrend({ samples, maxGrowthBytes, maxSlopeBytesPerMinute }) {
+  if (samples.length < 4) return { ok: false, message: `FAIL RSS trend: only ${samples.length} samples; need at least 4` };
+  const windowSize = Math.max(1, Math.floor(samples.length / 4));
+  const firstMedianBytes = median(samples.slice(0, windowSize).map(({ rssBytes }) => rssBytes));
+  const lastMedianBytes = median(samples.slice(-windowSize).map(({ rssBytes }) => rssBytes));
+  const growthBytes = lastMedianBytes - firstMedianBytes;
+  const slopeBytesPerMinute = linearSlope(samples.map(({ atMs, rssBytes }) => ({ x: atMs / 60_000, y: rssBytes })));
+  const failures = [];
+  if (growthBytes > maxGrowthBytes) failures.push(`last-window median grew ${formatBytes(growthBytes)} > ${formatBytes(maxGrowthBytes)}`);
+  if (slopeBytesPerMinute > maxSlopeBytesPerMinute) failures.push(`slope ${formatBytes(slopeBytesPerMinute)}/min > ${formatBytes(maxSlopeBytesPerMinute)}/min`);
+  const prefix = failures.length === 0 ? "PASS" : "FAIL";
+  return {
+    ok: failures.length === 0,
+    firstMedianBytes,
+    lastMedianBytes,
+    growthBytes,
+    slopeBytesPerMinute,
+    message: `${prefix} RSS trend: ${failures.join("; ") || `window growth ${formatBytes(growthBytes)}, slope ${formatBytes(slopeBytesPerMinute)}/min within bounds`}`
+  };
+}
+
+function percentile(values, fraction) {
+  if (values.length === 0) return Number.POSITIVE_INFINITY;
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.min(sorted.length - 1, Math.max(0, Math.ceil(fraction * sorted.length) - 1))];
+}
+
+function median(values) {
+  const sorted = [...values].sort((left, right) => left - right), middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+}
+
+function linearSlope(points) {
+  const meanX = points.reduce((sum, point) => sum + point.x, 0) / points.length;
+  const meanY = points.reduce((sum, point) => sum + point.y, 0) / points.length;
+  let numerator = 0, denominator = 0;
+  for (const point of points) { const dx = point.x - meanX; numerator += dx * (point.y - meanY); denominator += dx * dx; }
+  return denominator === 0 ? 0 : numerator / denominator;
+}
+
+function formatMs(value) { return `${Math.round(value)}ms`; }
+function formatBytes(value) { return `${(value / 1024 / 1024).toFixed(1)}MiB`; }
+
+async function runSoak(config = readConfig()) {
+  const resultsDir = path.resolve(config.resultsDir), parent = mkdtempSync(path.join(tmpdir(), "harness-nightly-soak-"));
+  const rootDir = path.join(parent, "repo"), userRoot = path.join(parent, "user"), home = path.join(parent, "home"), daemonId = `nightly-soak-${process.pid}`, repoId = "nightly-soak", endpoint = localUserDaemonEndpoint(userRoot, daemonId);
+  const hermetic = assessHermeticConfig({ userRoot, daemonId, userRootSource: "flag" });
+  if (!hermetic.ok) throw new Error(`soak fixture is not hermetic: ${hermetic.failures.join("; ")}`);
+  mkdirSync(resultsDir, { recursive: true });
+  let child, detach, rejectServer;
+  const daemonOutput = [];
+  try {
+    console.log(`[soak] hermetic user-root=${userRoot} daemon-id=${daemonId}`);
+    const fixtureStarted = performance.now(), events = createSoakEvents(config);
+    initializeFixture({ rootDir, userRoot, repoId, events });
+    console.log(`[soak] fixture tasks=${config.taskCount} events=${events.length} generated=${Math.round(performance.now() - fixtureStarted)}ms (deterministic canonical event snapshot)`);
+
+    child = spawn(process.execPath, [cliEntry, "daemon", "serve", "--user-root", userRoot, "--daemon-id", daemonId, "--json"], {
+      cwd: repoRoot,
+      env: { ...process.env, HOME: home, USERPROFILE: home, GIT_CONFIG_GLOBAL: "/dev/null", HARNESS_DAEMON_USER_ROOT: userRoot, HARNESS_DAEMON_ID: daemonId },
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    for (const stream of [child.stdout, child.stderr]) stream.on("data", (chunk) => daemonOutput.push(chunk.toString("utf8")));
+    const readyStarted = performance.now();
+    await waitForAttachedRepo({ child, endpoint, repoId, timeoutMs: config.startupTimeoutMs });
+    console.log(`[soak] daemon pid=${child.pid} attached scale ledger in ${Math.round(performance.now() - readyStarted)}ms`);
+
+    const taskIds = Array.from({ length: config.taskCount }, (_, index) => `task_soak_${String(index).padStart(6, "0")}`);
+    const warmup = await runLoadPhase({ endpoint, repoId, taskIds, durationMs: config.warmupMs, concurrency: config.concurrency, requestIntervalMs: config.requestIntervalMs, helloProbeIntervalMs: config.helloProbeIntervalMs, sampleRssPid: null });
+    console.log(`[soak] warmup ${config.warmupMs}ms requests=${warmup.requests} failures=${warmup.failures}`);
+    const load = await runLoadPhase({ endpoint, repoId, taskIds, durationMs: config.durationMs, concurrency: config.concurrency, requestIntervalMs: config.requestIntervalMs, helloProbeIntervalMs: config.helloProbeIntervalMs, sampleRssPid: child.pid });
+    console.log(`[soak] load ${config.durationMs}ms requests=${load.requests} failures=${load.failures} hello-probes=${load.helloSamplesMs.length} rss-samples=${load.rssSamples.length}`);
+
+    let streamAttached = false, streamLost = null;
+    detach = await streamAgentRuntimeAt({ socketPath: endpoint, repoId, payload: { runtimeSessionId: "runtime-session-soak", afterCursor: "stream:0" }, onValue: (value) => { if (value && typeof value === "object" && "ok" in value && value.ok === true) streamAttached = true; }, onClosed: (failure) => { streamLost = failure; } });
+    if (!streamAttached) throw new Error("fault-control stream did not complete its initial real daemon attach");
+    await requestDaemonJsonRpcAt(endpoint, "daemon.stop", {}, 1_000, 5_000);
+    await waitForChildExit(child, 30_000);
+    await waitForMissing(endpoint, 5_000);
+
+    const faultLog = openDaemonConnLog({ userRoot, daemonId: `${daemonId}-fault` });
+    rejectServer = net.createServer((socket) => {
+      const connectionId = randomUUID();
+      faultLog.connectionOpened(connectionId, "fault-injection");
+      socket.once("close", () => faultLog.connectionClosed(connectionId));
+      socket.destroy();
+    });
+    await listen(rejectServer, endpoint);
+    await delay(config.faultDurationMs);
+    detach(); detach = undefined;
+    await closeServer(rejectServer); rejectServer = undefined;
+    await faultLog.settle();
+    console.log(`[soak] fault window ${config.faultDurationMs}ms complete; terminal report=${streamLost ? JSON.stringify(streamLost) : "none"}`);
+
+    const normal = timelineFor({ userRoot, daemonId }), fault = timelineFor({ userRoot, daemonId: `${daemonId}-fault` });
+    const connections = assessConnections({ normal, fault, maxFaultConnections: config.maxFaultConnections });
+    const hello = assessHelloLatency({ clientSamplesMs: load.helloSamplesMs, daemon: normal, maxP99Ms: config.maxHelloP99Ms });
+    const rss = assessRssTrend({ samples: load.rssSamples, maxGrowthBytes: config.maxRssGrowthBytes, maxSlopeBytesPerMinute: config.maxRssSlopeBytesPerMinute });
+    const workload = { ...load, helloSamplesMs: undefined, rssSamples: undefined, warmupRequests: warmup.requests, warmupFailures: warmup.failures };
+    const assertions = [connections, hello, rss, { ok: load.failures === 0, message: `${load.failures === 0 ? "PASS" : "FAIL"} workload requests: ${load.requests} completed, ${load.failures} failed` }];
+    const report = { schema: "daemon-nightly-soak/v1", generatedAt: new Date().toISOString(), config, fixture: { tasks: config.taskCount, events: config.eventCount, method: "deterministic canonical event generator committed as the fixture's initial Git snapshot" }, workload, assertions, rssSamples: load.rssSamples, helloSamplesMs: load.helloSamplesMs, normalTimeline: normal, faultTimeline: fault, streamLost };
+    writeFileSync(path.join(resultsDir, "summary.json"), `${JSON.stringify(report, null, 2)}\n`, "utf8");
+    writeFileSync(path.join(resultsDir, "normal-timeline.txt"), `${renderTimeline(normal)}\n`, "utf8");
+    writeFileSync(path.join(resultsDir, "fault-timeline.txt"), `${renderTimeline(fault)}\n`, "utf8");
+    writeFileSync(path.join(resultsDir, "daemon-output.log"), daemonOutput.join(""), "utf8");
+    for (const assertion of assertions) console.log(assertion.message);
+    console.log(`[soak] artifacts=${resultsDir}`);
+    if (assertions.some(({ ok }) => !ok)) throw new Error("nightly soak invariants failed");
+    return report;
+  } finally {
+    detach?.();
+    if (rejectServer) await closeServer(rejectServer).catch(() => undefined);
+    await stopChild(child);
+    if (daemonOutput.length > 0 && !existsSync(path.join(resultsDir, "daemon-output.log"))) writeFileSync(path.join(resultsDir, "daemon-output.log"), daemonOutput.join(""), "utf8");
+    rmSync(parent, { recursive: true, force: true });
+  }
+}
+
+function initializeFixture({ rootDir, userRoot, repoId, events }) {
+  mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+  writeFileSync(path.join(rootDir, "README.md"), "# Nightly daemon soak fixture\n", "utf8");
+  writeFileSync(path.join(rootDir, "harness/harness.yaml"), `schema: harness-anything/v1\nname: ${repoId}\nlayout:\n  authoredRoot: harness\n  localRoot: .harness\n`, "utf8");
+  writeFileSync(path.join(rootDir, "harness/people.yaml"), `schema: harness-people/v1\npeople:\n  - personId: person-soak\n    displayName: Nightly Soak\n    primaryEmail: soak@example.test\n    roles: [owner]\n    credentials:\n      - kind: unix-socket-owner-boundary\n        issuer: host:${hostname()}\n        subject: ${process.getuid?.() ?? 0}\nroles:\n  - roleId: owner\n    commandClasses: [admin, repo-write, repo-read, arbiter]\n`, "utf8");
+  for (const event of events) { const target = path.join(rootDir, eventObjectTarget(event.opId)); mkdirSync(path.dirname(target), { recursive: true }); writeFileSync(target, serializeCanonicalEvent(event), "utf8"); }
+  const last = events.at(-1), eventBody = serializeCanonicalEvent(last);
+  writeFileSync(path.join(rootDir, "harness/events/head.json"), serializeEventHead({ revision: last.workspaceRevision, opId: last.opId, eventDigest: `sha256:${sha256Text(eventBody)}` }), "utf8");
+  git(rootDir, "init", "--quiet"); git(rootDir, "config", "user.name", "Nightly Soak"); git(rootDir, "config", "user.email", "soak@example.test"); git(rootDir, "add", "README.md", "harness"); git(rootDir, "commit", "--quiet", "-m", "nightly soak fixture");
+  registerDaemonRepo({ canonicalRoot: rootDir, repoId, userRoot, createConvenienceLinks: false });
+}
+
+async function runLoadPhase({ endpoint, repoId, taskIds, durationMs, concurrency, requestIntervalMs, helloProbeIntervalMs, sampleRssPid }) {
+  const stopAt = Date.now() + durationMs, counts = { requests: 0, failures: 0 }, methods = new Map(), helloSamplesMs = [], rssSamples = [];
+  const workers = Array.from({ length: concurrency }, (_, worker) => workloadClient({ endpoint, repoId, taskIds, stopAt, worker, counts, methods, requestIntervalMs }));
+  const probes = helloProbeLoop({ endpoint, stopAt, samples: helloSamplesMs, counts, helloProbeIntervalMs });
+  const rss = sampleRssPid ? rssLoop({ pid: sampleRssPid, stopAt, samples: rssSamples }) : Promise.resolve();
+  await Promise.all([...workers, probes, rss]);
+  await delay(250);
+  return { ...counts, methods: Object.fromEntries([...methods.entries()].sort()), helloSamplesMs, rssSamples };
+}
+
+async function workloadClient({ endpoint, repoId, taskIds, stopAt, worker, counts, methods, requestIntervalMs }) {
+  let iteration = 0;
+  while (Date.now() < stopAt) {
+    const batchStart = (worker * 53 + iteration * 17) % taskIds.length;
+    const taskBatch = Array.from({ length: Math.min(50, taskIds.length) }, (_, offset) => taskIds[(batchStart + offset) % taskIds.length]);
+    const options = [
+      ["repo.task.dispatches", { repo: { repoId }, payload: { taskIds: taskBatch, limit: taskBatch.length } }],
+      ["repo.task.dispatches", { repo: { repoId }, payload: { taskIds: taskBatch, limit: taskBatch.length } }],
+      ["repo.task.dispatches", { repo: { repoId }, payload: { taskIds: taskBatch, limit: taskBatch.length } }],
+      ["repo.task.dispatches", { repo: { repoId }, payload: { taskIds: taskBatch, limit: taskBatch.length } }],
+      ["repo.task.dispatches", { repo: { repoId }, payload: { taskIds: taskBatch, limit: taskBatch.length } }],
+      ["repo.tasks.list", { repo: { repoId }, payload: { limit: 50 } }],
+      ["repo.tasks.list", { repo: { repoId }, payload: { limit: 50 } }],
+      ["daemon.status", {}]
+    ];
+    const [method, params] = options[(worker + iteration) % options.length];
+    try {
+      const result = await requestDaemonJsonRpcAt(endpoint, method, params, 1_000, 5_000);
+      if (result.ok !== true) counts.failures += 1;
+    } catch { counts.failures += 1; }
+    counts.requests += 1; methods.set(method, (methods.get(method) ?? 0) + 1); iteration += 1;
+    await delay(requestIntervalMs);
+  }
+}
+
+async function helloProbeLoop({ endpoint, stopAt, samples, counts, helloProbeIntervalMs }) {
+  while (Date.now() < stopAt) {
+    let socket;
+    try {
+      socket = await connectSocket(endpoint, 1_000);
+      const client = new JsonRpcLineClient(socket, socket), started = performance.now();
+      const result = await client.request("protocol.hello", { protocolVersion: currentDaemonProtocolVersion }, 5_000);
+      samples.push(performance.now() - started);
+      if (result.ok !== true) counts.failures += 1;
+      client.close();
+    } catch { counts.failures += 1; socket?.destroy(); }
+    await delay(helloProbeIntervalMs);
+  }
+}
+
+async function rssLoop({ pid, stopAt, samples }) {
+  const started = performance.now();
+  while (Date.now() < stopAt) {
+    samples.push({ atMs: performance.now() - started, rssBytes: readRssBytes(pid) });
+    await delay(2_000);
+  }
+  samples.push({ atMs: performance.now() - started, rssBytes: readRssBytes(pid) });
+}
+
+function readRssBytes(pid) {
+  if (process.platform === "linux") {
+    const match = /^VmRSS:\s+(\d+)\s+kB$/mu.exec(readFileSync(`/proc/${pid}/status`, "utf8"));
+    if (!match) throw new Error(`VmRSS is missing for daemon pid ${pid}`);
+    return Number(match[1]) * 1024;
+  }
+  return Number(execFileSync("ps", ["-o", "rss=", "-p", String(pid)], { encoding: "utf8" }).trim()) * 1024;
+}
+
+function timelineFor({ userRoot, daemonId }) {
+  const files = discoverConnLogFiles({ userRoot, daemonId });
+  if (files.length === 0) throw new Error(`no connection log was written for daemon ${daemonId}`);
+  return buildTimeline(loadConnLogRecords(files));
+}
+
+async function waitForAttachedRepo({ child, endpoint, repoId, timeoutMs }) {
+  for (const deadline = Date.now() + timeoutMs; Date.now() < deadline;) {
+    if (child.exitCode !== null) throw new Error(`daemon exited during startup with code ${child.exitCode}`);
+    try {
+      const status = await requestDaemonJsonRpcAt(endpoint, "daemon.status", {}, 500, 2_000);
+      const repo = status.repos?.find?.((candidate) => candidate.repoId === repoId);
+      if (repo?.state === "attached") return;
+      if (repo?.state === "unavailable") throw new Error(`scale repo unavailable: ${repo.lastError}`);
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith("scale repo unavailable")) throw error;
+    }
+    await delay(100);
+  }
+  throw new Error(`daemon did not attach ${repoId} within ${timeoutMs}ms`);
+}
+
+function readConfig(env = process.env) {
+  return {
+    taskCount: positive(env.HARNESS_SOAK_TASKS, 1_377), eventCount: positive(env.HARNESS_SOAK_EVENTS, 26_650),
+    durationMs: positive(env.HARNESS_SOAK_DURATION_MS, 120_000), warmupMs: positive(env.HARNESS_SOAK_WARMUP_MS, 30_000), faultDurationMs: positive(env.HARNESS_SOAK_FAULT_MS, 10_000), startupTimeoutMs: positive(env.HARNESS_SOAK_STARTUP_TIMEOUT_MS, 300_000), concurrency: positive(env.HARNESS_SOAK_CONCURRENCY, 8), requestIntervalMs: positive(env.HARNESS_SOAK_REQUEST_INTERVAL_MS, 500), helloProbeIntervalMs: positive(env.HARNESS_SOAK_HELLO_INTERVAL_MS, 500),
+    maxFaultConnections: positive(env.HARNESS_SOAK_MAX_FAULT_CONNECTIONS, 6), maxHelloP99Ms: positive(env.HARNESS_SOAK_MAX_HELLO_P99_MS, 500), maxRssGrowthBytes: positive(env.HARNESS_SOAK_MAX_RSS_GROWTH_MIB, 32) * MIB, maxRssSlopeBytesPerMinute: positive(env.HARNESS_SOAK_MAX_RSS_SLOPE_MIB_PER_MIN, 12) * MIB,
+    resultsDir: env.HARNESS_SOAK_RESULTS_DIR || "tmp/soak-results"
+  };
+}
+
+function positive(value, fallback) { const parsed = value === undefined ? fallback : Number(value); if (!Number.isInteger(parsed) || parsed < 1) throw new Error(`soak configuration must be positive integers; received ${value}`); return parsed; }
+function git(rootDir, ...args) { execFileSync("git", ["-C", rootDir, ...args], { stdio: "ignore" }); }
+function delay(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
+function listen(server, endpoint) { return new Promise((resolve, reject) => { server.once("error", reject); server.listen(endpoint, () => { server.off("error", reject); resolve(); }); }); }
+function closeServer(server) { return new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve())); }
+function waitForChildExit(child, timeoutMs) { return Promise.race([new Promise((resolve) => child.exitCode !== null ? resolve() : child.once("close", resolve)), delay(timeoutMs).then(() => { throw new Error(`daemon did not exit within ${timeoutMs}ms`); })]); }
+async function waitForMissing(target, timeoutMs) { for (const deadline = Date.now() + timeoutMs; existsSync(target) && Date.now() < deadline;) await delay(25); if (existsSync(target)) throw new Error(`daemon endpoint remained after stop: ${target}`); }
+async function stopChild(child) { if (!child || child.exitCode !== null) return; child.kill("SIGTERM"); try { await waitForChildExit(child, 5_000); } catch { child.kill("SIGKILL"); await waitForChildExit(child, 2_000).catch(() => undefined); } }
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const config = readConfig();
+  try { await runSoak(config); } catch (error) {
+    const message = error instanceof Error ? error.stack ?? error.message : String(error), resultsDir = path.resolve(config.resultsDir);
+    mkdirSync(resultsDir, { recursive: true }); writeFileSync(path.join(resultsDir, "failure.txt"), `${message}\n`, "utf8");
+    console.error(`[soak] FAIL ${message}`); process.exitCode = 1;
+  }
+}

--- a/tools/soak/daemon-soak.test.mjs
+++ b/tools/soak/daemon-soak.test.mjs
@@ -1,0 +1,49 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseCanonicalEvent, serializeCanonicalEvent } from "../../packages/kernel/src/index.ts";
+import { assessConnections, assessHelloLatency, assessRssTrend, createSoakEvents } from "./daemon-soak.mjs";
+
+test("scale ledger generator emits the requested valid event and task counts", () => {
+  const events = createSoakEvents({ taskCount: 3, eventCount: 12 });
+  assert.equal(events.length, 12);
+  assert.equal(events.filter(({ type }) => type === "task_created").length, 3);
+  assert.equal(events.filter(({ type }) => type === "runtime_session_started").length, 1);
+  for (const event of events) assert.deepEqual(parseCanonicalEvent(serializeCanonicalEvent(event)), event);
+});
+
+test("bounded connection assessment rejects the historical reconnect storm", () => {
+  const stable = assessConnections({
+    normal: { growth: { startedMinute: null }, connections: { opened: 120, closed: 120, stillOpen: 0 } },
+    fault: { connections: { opened: 5, closed: 5, stillOpen: 0 } },
+    maxFaultConnections: 6
+  });
+  assert.equal(stable.ok, true, stable.message);
+
+  const storm = assessConnections({
+    normal: { growth: { startedMinute: null }, connections: { opened: 120, closed: 120, stillOpen: 0 } },
+    fault: { connections: { opened: 244, closed: 244, stillOpen: 0 } },
+    maxFaultConnections: 6
+  });
+  assert.equal(storm.ok, false);
+  assert.match(storm.message, /bounded connections.*244 > 6/u);
+});
+
+test("hello assessment uses client end-to-end P99 as well as daemon dispatch P99", () => {
+  const daemon = { methods: [{ method: "protocol.hello", p99Ms: 8 }] };
+  assert.equal(assessHelloLatency({ clientSamplesMs: [8, 9, 10, 11, 12], daemon, maxP99Ms: 250 }).ok, true);
+  const blocked = assessHelloLatency({ clientSamplesMs: [8, 9, 10, 11, 900], daemon, maxP99Ms: 250 });
+  assert.equal(blocked.ok, false);
+  assert.match(blocked.message, /client P99 900ms > 250ms/u);
+});
+
+test("RSS assessment accepts a plateau and rejects sustained monotonic growth", () => {
+  const mib = 1024 * 1024;
+  const plateau = [100, 102, 101, 103, 102, 101, 102, 102].map((rss, index) => ({ atMs: index * 10_000, rssBytes: rss * mib }));
+  assert.equal(assessRssTrend({ samples: plateau, maxGrowthBytes: 16 * mib, maxSlopeBytesPerMinute: 8 * mib }).ok, true);
+
+  const climb = [100, 110, 120, 130, 140, 150, 160, 170].map((rss, index) => ({ atMs: index * 10_000, rssBytes: rss * mib }));
+  const result = assessRssTrend({ samples: climb, maxGrowthBytes: 16 * mib, maxSlopeBytesPerMinute: 8 * mib });
+  assert.equal(result.ok, false);
+  assert.match(result.message, /RSS trend/u);
+});


### PR DESCRIPTION
# English

## Summary

Functional CI starts a small daemon, serves one client for a few seconds, and stops it. That shape structurally cannot observe the three dimensions where production actually failed — **scale, duration, concurrency**. Three incidents on 2026-08-20/21 (fd climbing to 4139; 1797 connections in two minutes with 439 left unclosed; 1944 opened / 801 closed / 1143 still open) were all invisible to a fully green CI.

This adds one nightly-only lane that holds a real daemon under real client load at real scale and asserts three invariants that the incidents violated.

**The lane is proven to fail, not just proven to pass.** Temporarily restoring the pre-#1656 unbounded reconnect (40ms fixed interval, no cap, silent failure) turns it red on exactly one assertion — bounded connections — and restoring the bounded reconnect turns it green. Both directions were run end-to-end on an isolated Ubuntu host.

## What Changed

- New `nightly-daemon-soak` job in `rewrite-ci.yml`: `ubuntu-latest`, Node 24, 15-minute timeout, gated on `github.event_name != 'pull_request' && github.event_name != 'push'` so it only rides the existing nightly schedule and manual dispatch.
- New `tools/soak/daemon-soak.mjs` runner plus `tools/soak/daemon-soak.test.mjs` unit positive controls; `npm run test:soak` entrypoint.
- `tools/logs/log-timeline.mjs` gains a P99 summary; the lane reuses its existing `buildTimeline` / growth / opened / closed / still-open logic rather than inventing a second metrics path.
- `tools/gate-manifest.json` registers the job as a non-deterministic `nightly-only` smoke with empty `requiredContexts` and empty `pullRequestJobs`.
- Evidence (`summary.json`, timelines, daemon output or `failure.txt`) uploads on `always()`, retained 14 days.

**Three invariants.** *Bounded connections*: under sustained load, active connections must not climb; still-open must drain to 0; after the daemon is killed, the reconnect window must open at most 6. *`protocol.hello` P99*: measured at two layers — an independent client probe (catches queuing and event-loop starvation, which is what failed first on 11:21) and the daemon handler itself; missing samples fail rather than silently reading as 0. *RSS not monotonically growing*: sampled post-warmup, judged by first/last-quartile medians plus an OLS slope over the window.

**Scale ledger is generated, not copied from any user ledger.** 1,377 tasks / 26,650 canonical events, written deterministically through the production kernel serializer and committed as the fixture's initial Git snapshot, so the production parser, replay, SQLite projection, and daemon read path all carry full scale.

**Auto-filing on red is deliberately not implemented this round.** The issue intake bot hard-requires 12 fixed `###` headings; a naive `gh issue create` would produce issues silently closed as `not_planned`, and duplicating the intake body protocol here would create a second copy that drifts. The lane preserves readable artifacts instead, and auto-filing is left as a separate governance integration once intake exposes a stable machine entrypoint.

## Task And Scope

- Harness task: `task_9dae72581603ced28d96973a95`
- Branch: `codex/soak-lane`
- Public scope: `.github/workflows/rewrite-ci.yml`, `tools/soak/**`, `tools/logs/log-timeline*.mjs`, `tools/gate-manifest.json`, `package.json` (one script entry)
- Private planning/evidence updated: yes
- Out of scope: the Windows matrix (already landed under `dec_630DB4EB94D3CB0B2459C8ABE2` and untouched here); auto-filing red runs as issues

## Version Impact

- Version: no version change because this adds a CI lane and test tooling only, with no package surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `.github/workflows/rewrite-ci.yml`, `tools/gate-manifest.json`
- Authority: `dec_E6E62653DA534ACDD1B7C0A388` CH3 defines this lane; claim C2 ("the soak lane catches the same defect family as the 2026-08-20/21 incidents") is this task's acceptance criterion
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: auto-filing integration, to be opened once issue intake exposes a stable machine entrypoint

No existing gate was weakened: no `continue-on-error` added, no existing timeout changed, no required context added or removed. The `windows-integration-shard` line in the gate-manifest diff is a trailing-comma artifact, not a removal.

## Verification

- Base `origin/main` SHA: `a9cd12f38d6ed45ab81d29fe327d3814bdec2539`
- Branch merge-base with `origin/main`: `a9cd12f38d6ed45ab81d29fe327d3814bdec2539`
- Last `git fetch origin` time: 2026-08-21, immediately before opening this PR
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/soak-lane`
- Private evidence commit/path: `harness/tasks/task_9dae72581603ced28d96973a95-test-isolation-sop/artifacts/report-soak-lane.md`
- Reviewer evidence path: same report, "阳性对照真实输出" section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
Production-Delta: +0/-0

Dependency-Change: package.json gains only the test:soak script entry; no dependency was added, removed, or version-changed
- [x] `git diff --check`
- [x] `npm run check:local` (41 steps; 252 fast tests, 487 contract tests; 57 gates / 0 drift)
- [x] `node tools/check-gate-manifest-invariants.mjs` (47/57 deterministic gates)
- [x] Isolated Ubuntu soak, red direction: `exit=1`, ~192s, failing on `bounded connections: fault window opened 231 > 6` while the other three assertions passed
- [x] Isolated Ubuntu soak, green direction: `exit=0`, ~192s, `bounded connections: 2514 normal opens drained; 5/6 fault opens`, terminal report `{"code":"daemon_stream_lost","attempts":5,"lastError":"write EPIPE"}`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full `npm run check` locally — the authoritative full gate surface is GitHub CI per the repository stop-point policy. The nightly lane itself cannot run on this PR by design (it is excluded from `pull_request`), so its first real scheduled execution is post-merge.

## Review Evidence

- Self-review: CEO independently verified the gate-manifest deletion line is a comma artifact rather than a removed job, confirmed the workflow diff touches no existing job, and confirmed the final commit contains neither the temporary dispatch wrapper nor the temporarily reverted reconnect file.
- Reviewer subagent: not used; acceptance rested on the two-direction positive control, which is stronger evidence than a code read.
- Human review: pending
- Blocking findings: none

## Residual Risk

- ~3 minutes per night covers scale, sustained load, concurrency, and one explicit reconnect fault, but is not a multi-hour endurance test; a very slow leak can still sit below the signal window.
- The RSS criterion is a single-process, single-run trend threshold with no cross-night historical baseline yet. Thresholds may need per-runner-class stratification after several nights of artifacts.
- Fault injection covers daemon loss and attach reconnect only; slow disks, long-held SQLite locks, and OS fd hard limits are not injected, so diagnosing those root causes still depends on reading the timeline and daemon output.
- The workflow YAML and governance mapping passed local static gates, but the real GitHub nightly schedule and artifact upload are only exercised by the first scheduled or manual run after merge.
- The delivered report cites commit `d3e119f48`, which was amended before final commit; the authoritative commit is `3eb529527`. Content is unchanged.

## References

- Task: `task_9dae72581603ced28d96973a95`
- Evidence: `harness/tasks/task_9dae72581603ced28d96973a95-test-isolation-sop/artifacts/report-soak-lane.md`
- Review: `dec_E6E62653DA534ACDD1B7C0A388` CH3, claim C2

---

# 中文

## 概要

现有 CI 全部在测**功能正确性**：小 fixture 台账、单客户端、起 daemon 跑几秒就杀。生产事故真正暴露的三个维度——**规模、时长、并发**——结构性地不在任何测试的选择面里。2026-08-20/21 的三次事故（fd 涨到 4139；两分钟 1797 条连接、结束时 439 条不关；1944 opened / 801 closed / 1143 still open）对全绿的 CI 完全不可见。

本 PR 加一条只在 nightly 跑的 lane：让真实 daemon 在真实规模下承受真实客户端负载，断言事故违反的三条不变量。

**这条 lane 被证明会红，而不只是被证明会绿。** 把 #1656 之前的无界重连（40ms 固定间隔、无上限、失败静默吞掉）临时恢复，lane 精确红在**一条**断言上——连接数有界；恢复有界重连后转绿。两个方向都在隔离 Ubuntu 主机上完整跑过。

## 改动内容

- `rewrite-ci.yml` 新增 `nightly-daemon-soak` job：`ubuntu-latest`、Node 24、15 分钟超时，条件为 `github.event_name != 'pull_request' && github.event_name != 'push'`，因此只承接既有 nightly schedule 与手动 dispatch。
- 新增 `tools/soak/daemon-soak.mjs` runner 与 `tools/soak/daemon-soak.test.mjs` 单元阳性对照；入口为 `npm run test:soak`。
- `tools/logs/log-timeline.mjs` 增加 P99 汇总；lane 复用它已有的 `buildTimeline` / growth / opened / closed / still-open 判据，不另造一套指标。
- `tools/gate-manifest.json` 将该 job 登记为非确定性的 `nightly-only` smoke，`requiredContexts` 与 `pullRequestJobs` 均为空。
- 证据（`summary.json`、timeline、daemon 输出或 `failure.txt`）在 `always()` 上传，保留 14 天。

**三条不变量。** *连接数有界*：持续负载下活跃连接不得爬升，结束时 still-open 必须归 0；daemon 被杀后的重连窗口最多开 6 条。*`protocol.hello` P99*：两层测量——独立客户端探针（抓排队与 event-loop starvation，即 11:21 那次最先失效的东西）与 daemon handler 自身；缺样本判失败而不是静默读成 0。*RSS 不单调增长*：warmup 后采样，用首尾四分位中位数加全窗口 OLS 斜率双判据。

**规模台账是生成的，不是拷用户台账。** 1,377 个任务 / 26,650 个 canonical events，通过生产 kernel serializer 确定性写出并作为 fixture 的初始 Git snapshot 提交，使生产 parser、replay、SQLite projection 与 daemon read path 都承受完整规模。

**「红了自动立件」本轮刻意不做。** issue intake 机器人硬性要求 12 个固定 `###` heading；盲接 `gh issue create` 会产出被静默标记 `not_planned` 关掉的 issue，而在此复制一份 intake body 协议则会造出第二套会漂移的副本。lane 改为保留可读产物，自动立件留作独立治理集成，等 intake 暴露稳定机器入口后再接。

## 任务与范围

- Harness 任务：`task_9dae72581603ced28d96973a95`
- 分支：`codex/soak-lane`
- 公开范围：`.github/workflows/rewrite-ci.yml`、`tools/soak/**`、`tools/logs/log-timeline*.mjs`、`tools/gate-manifest.json`、`package.json`（一条 script 条目）
- 私有计划 / 证据是否已更新：yes
- 范围外：Windows 矩阵（已在 `dec_630DB4EB94D3CB0B2459C8ABE2` 下落地，本 PR 未触碰）；红灯自动立 issue

## 版本影响

- 版本：不改版本，原因是本 PR 只新增 CI lane 与测试工具，不改包对外面
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`.github/workflows/rewrite-ci.yml`、`tools/gate-manifest.json`
- 依据：`dec_E6E62653DA534ACDD1B7C0A388` CH3 定义了本 lane；其 claim C2（「soak lane 能抓到 2026-08-20/21 那几次事故的同族缺陷」）即本任务验收标准
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：自动立件集成，待 issue intake 暴露稳定机器入口后立项

未削任何既有门：未加 `continue-on-error`、未改既有超时、未增删 required context。gate-manifest diff 里的 `windows-integration-shard` 那行是数组尾逗号造成的 diff 假象，不是删除。

## 验证

- `origin/main` 基准 SHA：`a9cd12f38d6ed45ab81d29fe327d3814bdec2539`
- 当前分支与 `origin/main` 的 merge-base：`a9cd12f38d6ed45ab81d29fe327d3814bdec2539`
- 最近一次 `git fetch origin` 时间：2026-08-21，开 PR 前
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...codex/soak-lane`
- 私有证据 commit/path：`harness/tasks/task_9dae72581603ced28d96973a95-test-isolation-sop/artifacts/report-soak-lane.md`
- Reviewer 证据路径：同一报告的「阳性对照真实输出」节
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑
- [x] `git diff --check`
- [x] `npm run check:local`（41 步；252 fast tests、487 contract tests；57 gates / 0 drift）
- [x] `node tools/check-gate-manifest-invariants.mjs`（47/57 deterministic gates）
- [x] 隔离 Ubuntu soak 红方向：`exit=1`，约 192 秒，红在 `bounded connections: fault window opened 231 > 6`，其余三条断言均 PASS
- [x] 隔离 Ubuntu soak 绿方向：`exit=0`，约 192 秒，`bounded connections: 2514 normal opens drained; 5/6 fault opens`，终态上报 `{"code":"daemon_stream_lost","attempts":5,"lastError":"write EPIPE"}`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：本地完整 `npm run check`——按本仓停止点政策，完整权威门面在 GitHub CI。nightly lane 本身按设计无法在本 PR 上运行（它被排除在 `pull_request` 之外），首次真实 scheduled 执行在合并之后。

## 审查证据

- 自查：CEO 独立核实 gate-manifest 的删除行是逗号假象而非删 job，核实 workflow diff 未触碰任何既有 job，核实最终 commit 既不含临时派测 wrapper 也不含被临时回退的 reconnect 文件。
- Reviewer subagent：未使用；验收依据是两个方向的阳性对照，它比读代码更强。
- 人工审查：待做
- 阻塞发现：无

## 残余风险

- 每夜约三分钟能覆盖规模、持续负载、并发与一次明确的 reconnect fault，但不是多小时耐久测试；非常缓慢的泄漏仍可能低于信号窗。
- RSS 判据是单进程、单次运行的趋势阈值，尚无跨 nightly 的历史基线。观察若干晚产物后可能需要按 runner 类型分层阈值。
- 故障注入只覆盖 daemon 丢失与 attach 重连；慢磁盘、SQLite 长时间持锁、OS fd 硬上限均未注入，这些根因的独立诊断仍依赖 timeline 与 daemon 输出。
- workflow YAML 与治理映射已过本地静态门，但真实 GitHub nightly schedule 与 artifact upload 只能由合并后首次 scheduled 或手动 run 验证。
- 交付报告里写的 commit 是 `d3e119f48`，该 commit 在最终提交前被 amend；权威 commit 是 `3eb529527`，内容未变。

## 关联材料

- 任务：`task_9dae72581603ced28d96973a95`
- 证据：`harness/tasks/task_9dae72581603ced28d96973a95-test-isolation-sop/artifacts/report-soak-lane.md`
- 审查：`dec_E6E62653DA534ACDD1B7C0A388` CH3, claim C2
