### PR TITLE
docs(skill): triage ledger generations from event bytes, drop the unshipped restamp branch

### DIFF
--- a/skills/harness-migration/SKILL.md
+++ b/skills/harness-migration/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: harness-migration
-description: Migrate a previous-generation Harness Anything repository into the current format, from a machine that does not have the current Harness installed. Use when a project's harness/ ledger predates the current generation, when ha commands fail against an existing repository because its layout is from an older release, or when a user asks to upgrade, migrate, or replay an old Harness ledger. Fetches the current source into a temporary location, so it works with no prior installation and does not disturb an existing Harness install.
+description: Diagnose and migrate a Harness Anything ledger from a machine that does not have the current Harness installed. Use when a project's harness/ ledger predates the current generation, when daemon attach fails because a current ledger has pre-S4 doc cuts, or when a user asks to upgrade, migrate, replay, or repair an old Harness ledger. The skill first distinguishes the narrow in-place restamp case from replay, then fetches the current source into a temporary location without disturbing an existing Harness install.
 ---
 
 # Harness Migration
 
-Replay a previous-generation `harness/` ledger into a freshly initialized
-current-format repository. The source is never written to.
+First decide whether a broken `harness/` ledger needs a fresh replay or the
+narrow in-place cut restamp. Replay a previous-generation ledger into a freshly
+initialized current-format repository; the source is never written to.
 
 **This skill assumes nothing is installed.** It fetches the current source into
 a throwaway directory and runs everything from there. A Harness installation
@@ -169,15 +170,94 @@ Two consequences worth knowing now rather than at step 8:
 absent. Running the TypeScript entry directly is the supported path here and
 needs no build step.
 
-## 2. Freeze and back up the source ledger
+## 1a. Decide: replay an older ledger, or restamp an S4-stale current ledger?
 
-Ask the user for the absolute path of the repository holding the old `harness/`
-directory.
+Do this **after step 1 fetches the current source, before creating a destination
+or running `migrate import`**. The symptoms below are an entry point, not a
+decision: both kinds of ledger can produce them.
+
+| What you see | What it means | Next action |
+| --- | --- | --- |
+| `doc event envelope or payload is invalid` | Could be either an older ledger or a current ledger with pre-S4 doc cuts. | Run the read-only event scan below. |
+| daemon receipt `repo_attach_failed` or `repo_unavailable` while attaching the repository | The daemon could not build its projection; it does not identify the ledger generation. | Run the read-only event scan below; do not retry attach as a probe. |
+
+Set the source path once. The scan only reads its event files; it does not need
+the daemon and does not alter the source.
+
+```bash
+export ARCHIVE_SOURCE="$(cd /absolute/path/to/repository-with-harness && pwd -P)"
+export CANONICAL_EVENT_CONTRACT="file://$HARNESS_MIGRATION_WORK/ha-src/packages/kernel/src/domain/doc-sync.contract.ts"
+node --input-type=module - "$ARCHIVE_SOURCE/harness/events" "$CANONICAL_EVENT_CONTRACT" <<'NODE'
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const [eventsRoot, contractUrl] = process.argv.slice(2);
+const { parseCanonicalEvent } = await import(contractUrl);
+const counts = { files: 0, parsed: 0, unknown_schema: 0, legacy_cut_shape: 0, other: 0 };
+async function* eventFiles(dir) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const file = join(dir, entry.name);
+    if (entry.isDirectory()) yield* eventFiles(file);
+    else if (entry.isFile() && entry.name.endsWith('.json') && entry.name !== 'head.json') yield file;
+  }
+}
+function hasLegacyCut(value) {
+  if (!value || typeof value !== 'object') return false;
+  if (Array.isArray(value)) return value.some(hasLegacyCut);
+  const cut = value.baseLedgerSha;
+  if (cut && typeof cut === 'object' && !Array.isArray(cut)) {
+    const keys = Object.keys(cut).sort();
+    if (keys.length === 2 && keys[0] === 'repoId' && keys[1] === 'sha') return true;
+  }
+  return Object.values(value).some(hasLegacyCut);
+}
+for await (const file of eventFiles(eventsRoot)) {
+  counts.files++;
+  let text, event;
+  try {
+    text = await readFile(file, 'utf8');
+    event = JSON.parse(text);
+    parseCanonicalEvent(text);
+    counts.parsed++;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message === 'canonical event schema is unknown') counts.unknown_schema++;
+    else if (message === 'doc event envelope or payload is invalid' && event?.schema === 'doc-event/v1' && hasLegacyCut(event)) counts.legacy_cut_shape++;
+    else counts.other++;
+  }
+}
+console.log(JSON.stringify(counts, null, 2));
+NODE
+```
+
+Interpret the counts conservatively:
+
+- If `unknown_schema > 0` **or** `other > 0`, this is not the narrow S4-only
+  cut mismatch. **Do not restamp it.** Continue with the replay steps in this
+  skill. The replay importer constructs current migration events rather than
+  copying source event bytes.
+- If `legacy_cut_shape > 0`, `unknown_schema = 0`, and `other = 0`, the ledger
+  is the current-generation pre-S4-cut case. **Do not use replay:** it would
+  remap IDs and rewrite the ledger when only its cut identity needs restamping.
+
+  **RESTAMP COMMAND PLACEHOLDER — do not invent or substitute a command here.**
+  When the in-place restamp migration is released, replace this paragraph with
+  its exact documented invocation. It must run against this source ledger,
+  preserve `opId`, make one migration commit, be idempotent, and work without a
+  successful daemon attach.
+- If all three failure counts are zero, the stream already parses under the
+  current code. Neither replay nor restamp is indicated by this issue; stop and
+  investigate the reported symptom separately.
+
+If the scan itself cannot read the events directory or run the current parser,
+stop and report that failure. Do not infer the generation from `harness.yaml`:
+both generations can carry `schema: harness-anything/v1`.
+
+## 2. Freeze and back up the source ledger
 
 Back up and digest **`harness/` only** — never the repository root.
 
 ```bash
-export ARCHIVE_SOURCE="$(cd /absolute/path/to/legacy-repository && pwd -P)"
 export WORK_SOURCE="$HARNESS_MIGRATION_WORK/legacy-copy"
 mkdir -p "$HARNESS_MIGRATION_WORK/backups" "$WORK_SOURCE"
 export LEDGER_ARCHIVE="$HARNESS_MIGRATION_WORK/backups/legacy-harness.tar"

--- a/skills/harness-migration/SKILL.md
+++ b/skills/harness-migration/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: harness-migration
-description: Diagnose and migrate a Harness Anything ledger from a machine that does not have the current Harness installed. Use when a project's harness/ ledger predates the current generation, when daemon attach fails because a current ledger has pre-S4 doc cuts, or when a user asks to upgrade, migrate, replay, or repair an old Harness ledger. The skill first distinguishes the narrow in-place restamp case from replay, then fetches the current source into a temporary location without disturbing an existing Harness install.
+description: Diagnose and migrate a Harness Anything ledger from a machine that does not have the current Harness installed. Use when a project's harness/ ledger predates the current generation, when daemon attach fails because a current ledger has pre-S4 doc cuts, or when a user asks to upgrade, migrate, replay, or repair an old Harness ledger. The skill first confirms the symptom really is a ledger-generation mismatch, then fetches the current source into a temporary location without disturbing an existing Harness install.
 ---
 
 # Harness Migration
 
-First decide whether a broken `harness/` ledger needs a fresh replay or the
-narrow in-place cut restamp. Replay a previous-generation ledger into a freshly
-initialized current-format repository; the source is never written to.
+First confirm a broken `harness/` ledger actually has a generation mismatch
+rather than some other fault. If it does, replay it into a freshly initialized
+current-format repository; the source is never written to. Replay is the only
+supported migration path — there is no in-place repair tool.
 
 **This skill assumes nothing is installed.** It fetches the current source into
 a throwaway directory and runs everything from there. A Harness installation
@@ -170,7 +171,7 @@ Two consequences worth knowing now rather than at step 8:
 absent. Running the TypeScript entry directly is the supported path here and
 needs no build step.
 
-## 1a. Decide: replay an older ledger, or restamp an S4-stale current ledger?
+## 1a. Confirm the symptom is a ledger-generation mismatch before importing
 
 Do this **after step 1 fetches the current source, before creating a destination
 or running `migrate import`**. The symptoms below are an entry point, not a
@@ -232,22 +233,28 @@ NODE
 
 Interpret the counts conservatively:
 
-- If `unknown_schema > 0` **or** `other > 0`, this is not the narrow S4-only
-  cut mismatch. **Do not restamp it.** Continue with the replay steps in this
-  skill. The replay importer constructs current migration events rather than
-  copying source event bytes.
+- If `unknown_schema > 0` **or** `other > 0`, this is a previous-generation
+  ledger rather than the narrow S4-only cut mismatch. Continue with the replay
+  steps in this skill. The replay importer constructs current migration events
+  rather than copying source event bytes.
 - If `legacy_cut_shape > 0`, `unknown_schema = 0`, and `other = 0`, the ledger
-  is the current-generation pre-S4-cut case. **Do not use replay:** it would
-  remap IDs and rewrite the ledger when only its cut identity needs restamping.
+  is a current-generation ledger whose doc cuts predate S4. Replay handles it,
+  and replay is the only supported path: **there is no in-place restamp
+  migration, and none is planned.** An in-place restamp was built and evaluated;
+  it was deliberately not shipped, because a tool that rewrites cut identity in
+  place has to be trusted on a ledger nobody can re-derive, while replay
+  reconstructs the destination from source events and leaves the source
+  untouched.
 
-  **RESTAMP COMMAND PLACEHOLDER — do not invent or substitute a command here.**
-  When the in-place restamp migration is released, replace this paragraph with
-  its exact documented invocation. It must run against this source ledger,
-  preserve `opId`, make one migration commit, be idempotent, and work without a
-  successful daemon attach.
+  Know what replay costs you here: it remaps entity IDs and writes a new
+  ledger, which is more than this ledger strictly needs — only its cut identity
+  is stale. Budget for the ID remapping (see the ID mapping steps below) rather
+  than looking for a narrower tool. If remapped IDs are genuinely unacceptable
+  for your ledger, stop and report that; do not improvise a hand-edit of event
+  bytes.
 - If all three failure counts are zero, the stream already parses under the
-  current code. Neither replay nor restamp is indicated by this issue; stop and
-  investigate the reported symptom separately.
+  current code. This is not a generation mismatch, so migration will not fix it;
+  stop and investigate the reported symptom separately.
 
 If the scan itself cannot read the events directory or run the current parser,
 stop and report that failure. Do not infer the generation from `harness.yaml`:


### PR DESCRIPTION
# English

## Summary

The `harness-migration` skill had no way to tell a previous-generation ledger from a current-generation ledger whose doc cuts predate S4. Both present identically — `doc event envelope or payload is invalid`, or a daemon receipt of `repo_attach_failed` — and the skill's advice was to infer the generation from `harness.yaml`, which cannot distinguish them because both carry `schema: harness-anything/v1`.

This adds a read-only event scan that answers the question from the event bytes themselves, and states plainly what to do with each answer.

It also removes a branch that pointed at nothing. The skill routed the pre-S4-cut case to an in-place restamp command and left a `RESTAMP COMMAND PLACEHOLDER` where the invocation would go. That restamp was built, evaluated, and **deliberately not shipped** — so the placeholder could never be filled, and a reader following that branch reached a dead end with instructions not to improvise.

## What Changed

- Section 1a is retitled from "Decide: replay an older ledger, or restamp an S4-stale current ledger?" to "Confirm the symptom is a ledger-generation mismatch before importing". The scan's job changed: it no longer picks between two paths, it confirms whether migration is the right answer at all.
- A read-only Node scan classifies every event file in the source against the current canonical parser, counting `parsed` / `unknown_schema` / `legacy_cut_shape` / `other`. It touches only the source's event files, needs no daemon, and does not alter the source.
- Each count combination now routes to something real: previous-generation → replay; pre-S4 cuts → also replay, with its cost stated; all-zero → not a generation mismatch, so migration will not fix it, investigate the symptom separately.
- The restamp placeholder is replaced with the actual state of the world: there is no in-place restamp migration and none is planned, with the reason — a tool that rewrites cut identity in place must be trusted against a ledger nobody can re-derive, while replay reconstructs the destination from source events and leaves the source untouched.
- The stale framing is removed everywhere it landmarked the old two-path structure: the front-matter `description`, the opening paragraph, and the two other bullets that said "do not restamp it" / "neither replay nor restamp".

**On honesty about cost.** Replay is heavier than this ledger strictly needs — it remaps entity IDs and writes a new ledger when only the cut identity is stale. The skill says so and tells the reader to budget for the ID remapping rather than go looking for a narrower tool that does not exist. If remapped IDs are genuinely unacceptable, the instruction is to stop and report, explicitly not to hand-edit event bytes.

## Task And Scope

- Harness task: `task_dede5b2125d9d3f029debf6206` (rename/migration design line)
- Branch: `codex/migration-skill-w4`
- Public scope: `skills/harness-migration/SKILL.md` only
- Private planning/evidence updated: yes
- Out of scope: the in-place restamp implementation itself, which is archived and not merged

## Version Impact

- Version: no version change because this is documentation only, with no package surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: `f1630935299e05d693fa0705fc9c06c06c6a2f07`
- Branch merge-base with `origin/main`: `f1630935299e05d693fa0705fc9c06c06c6a2f07`
- Last `git fetch origin` time: 2026-08-21, immediately before opening this PR
- Sync method: rebase
- Public diff command: `git diff origin/main...codex/migration-skill-w4`
- Private evidence commit/path: `harness/tasks/task_dede5b2125d9d3f029debf6206-rename-migration-design/`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending on this PR

Production-Delta: +0/-0

- [x] `git diff --check`
- [x] `npm run check:local` (fast tier, 70.5s, all steps green)
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full `npm run check` locally — the authoritative full gate surface is GitHub CI per the repository stop-point policy. The scan snippet's runtime behavior is not exercised by any gate; see Residual Risk.

## Review Evidence

- Self-review: CEO grepped the file for every surviving `restamp` mention after rewriting the branch, and confirmed the only remaining ones are the sentence explaining that no such tool exists. This matters because changing a conclusion silently invalidates the prose that landmarked it, and the front-matter `description` in particular is read by agents selecting the skill, not by humans reading the body.
- Reviewer subagent: not used; this is a documentation change whose correctness rests on facts the CEO verified directly.
- Human review: pending
- Blocking findings: none

## Residual Risk

- The scan snippet is prose, not a tested tool. No gate executes it, so a future change to `parseCanonicalEvent`'s error messages would silently break its classification — it matches on the exact strings `canonical event schema is unknown` and `doc event envelope or payload is invalid`. This is the same class of coupling the skill warns readers about elsewhere.
- The `legacy_cut_shape` detector recognizes one specific pre-S4 cut shape (a `baseLedgerSha` object with exactly the keys `repoId` and `sha`). An older cut shape that does not match would fall into `other` and route to replay, which is the safe direction but reports a misleading reason.
- The claim that replay handles the pre-S4-cut case is carried over from the original triage work and was not re-executed against a real pre-S4 ledger in this PR.

## References

- Task: `task_dede5b2125d9d3f029debf6206`
- Evidence: `harness/tasks/task_dede5b2125d9d3f029debf6206-rename-migration-design/`
- Review: pending

---

# 中文

## 概要

`harness-migration` skill 此前无法区分「上一代台账」与「当代台账但 doc cut 早于 S4」。两者症状完全一样——`doc event envelope or payload is invalid`,或者 daemon 回执 `repo_attach_failed`——而 skill 给的判法是从 `harness.yaml` 推断代次,那恰恰区分不了:两代都写着 `schema: harness-anything/v1`。

本 PR 加一段只读事件扫描,从事件字节本身回答这个问题,并对每种答案给出明确处置。

同时删掉一条指向空处的分支。skill 原本把 pre-S4-cut 情形路由到一个 in-place restamp 命令,并在调用处留了 `RESTAMP COMMAND PLACEHOLDER`。那个 restamp 已经被造出来、评估过,并**刻意不合入**——所以这个占位符永远填不上,顺着这条分支走的读者会走到死路,而且还被告知不许自行发挥。

## 改动内容

- 1a 节标题从「决定:replay 旧台账,还是 restamp S4-stale 的当代台账?」改为「导入前先确认症状确实是台账代次不匹配」。扫描的职责变了:它不再在两条路之间选,而是确认迁移到底是不是对症的答案。
- 一段只读 Node 扫描用当代 canonical parser 分类源台账的每个事件文件,计数 `parsed` / `unknown_schema` / `legacy_cut_shape` / `other`。它只读源的事件文件,不需要 daemon,不改动源。
- 每种计数组合现在都路由到真实存在的东西:上一代台账 → replay;pre-S4 cut → 也走 replay,并说清代价;三项全零 → 不是代次问题,迁移修不了它,另查症状。
- restamp 占位符替换为世界的实际状态:不存在 in-place restamp 迁移,也不计划做,并给出理由——一个在原地重写 cut 身份的工具,必须在一份没人能重新推导的台账上被信任;而 replay 是从源事件重建目标,源全程不被写。
- 旧的两路结构在别处留下的路标一并清除:front-matter 的 `description`、开篇段落,以及另外两条写着「不要 restamp 它」/「replay 和 restamp 都不指示」的条目。

**关于诚实交代代价。** 对这种台账来说 replay 比严格必要的更重——它会重映射实体 ID 并写出新台账,而实际上只有 cut 身份是陈旧的。skill 直说这一点,并让读者为 ID 重映射做预算,而不是去找一个不存在的更窄的工具。如果重映射后的 ID 确实不可接受,指令是停下并报告,**明确不许**手改事件字节。

## 任务与范围

- Harness 任务:`task_dede5b2125d9d3f029debf6206`(rename/migration 设计线)
- 分支:`codex/migration-skill-w4`
- 公开范围:仅 `skills/harness-migration/SKILL.md`
- 私有计划 / 证据是否已更新:yes
- 范围外:in-place restamp 的实现本身,它已归档且不合入

## 版本影响

- 版本:不改版本,原因是本 PR 只改文档,不改包对外面
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:不适用
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无

## 验证

- `origin/main` 基准 SHA:`f1630935299e05d693fa0705fc9c06c06c6a2f07`
- 当前分支与 `origin/main` 的 merge-base:`f1630935299e05d693fa0705fc9c06c06c6a2f07`
- 最近一次 `git fetch origin` 时间:2026-08-21,开 PR 前
- 同步方式:rebase
- 公开 diff 命令:`git diff origin/main...codex/migration-skill-w4`
- 私有证据 commit/path:`harness/tasks/task_dede5b2125d9d3f029debf6206-rename-migration-design/`
- Reviewer 证据路径:同一任务包
- GitHub Actions `rewrite-ci` run URL:本 PR 上待跑
- [x] `git diff --check`
- [x] `npm run check:local`(fast tier,70.5 秒,全部步骤绿)
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:本地完整 `npm run check`——按本仓停止点政策,完整权威门面在 GitHub CI。扫描片段的运行时行为不被任何门覆盖,见残余风险。

## 审查证据

- 自查:CEO 在改写分支后 grep 了全文每一处残留的 `restamp`,确认只剩下「说明它不存在」那一句。这一步重要,因为改掉结论会悄悄作废那些拿它当路标的正文;尤其 front-matter 的 `description` 是被选择 skill 的 agent 读的,不是被读正文的人读的。
- Reviewer subagent:未使用;这是文档改动,正确性依赖的事实由 CEO 直接核实。
- 人工审查:待做
- 阻塞发现:无

## 残余风险

- 扫描片段是正文而不是被测试的工具。没有门执行它,因此 `parseCanonicalEvent` 的错误文案一旦变化,它的分类会静默失效——它匹配的是字面串 `canonical event schema is unknown` 与 `doc event envelope or payload is invalid`。这正是 skill 在别处提醒读者提防的那类耦合。
- `legacy_cut_shape` 探测器只认一种特定的 pre-S4 cut 形状(`baseLedgerSha` 对象恰好只有 `repoId` 与 `sha` 两个键)。不匹配的更老形状会落进 `other` 并路由到 replay——方向是安全的,但报出的理由会误导。
- 「replay 能处理 pre-S4-cut 情形」这一断言承自原始分诊工作,本 PR 未针对真实的 pre-S4 台账重新执行验证。

## 关联材料

- 任务:`task_dede5b2125d9d3f029debf6206`
- 证据:`harness/tasks/task_dede5b2125d9d3f029debf6206-rename-migration-design/`
- 审查:待做
