### PR TITLE
fix(daemon): wait for the writer epoch lock instead of giving up after a guessed 400ms

### DIFF
--- a/packages/daemon/src/writer-epoch.ts
+++ b/packages/daemon/src/writer-epoch.ts
@@ -14,7 +14,7 @@ export interface PersistentWriterEpoch {
   readonly close: () => void;
 }
 export class WriterEpochError extends Error {
-  readonly code: "writer_epoch_stale" | "writer_epoch_busy" | "writer_epoch_invalid";
+  readonly code: "writer_epoch_stale" | "writer_epoch_invalid";
   constructor(code: WriterEpochError["code"], message: string) { super(message); this.name = "WriterEpochError"; this.code = code; }
 }
 type EpochState = { readonly schema: "fleet-writer-epoch/v1"; readonly repos: Record<string, WriterEpochLease> };
@@ -56,8 +56,8 @@ function readState(file: string): EpochState {
 function isEpochRecord(value: unknown): value is Record<string, unknown> { return value !== null && typeof value === "object" && !Array.isArray(value); }
 function withLock<T>(file: string, operation: () => T): T {
   mkdirSync(path.dirname(file), { recursive: true });
-  let fd: number | undefined;
-  for (let attempt = 0; attempt < 200 && fd === undefined; attempt += 1) {
+  let fd: number;
+  for (;;) {
     try { fd = openSync(file, "wx", 0o600); break; } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       let ownerText: string;
@@ -70,7 +70,6 @@ function withLock<T>(file: string, operation: () => T): T {
       Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2);
     }
   }
-  if (fd === undefined) throw new WriterEpochError("writer_epoch_busy", "another center is allocating a writer epoch");
   try { writeFileSync(fd, `${process.pid}\n`); fsyncSync(fd); return operation(); }
   finally { closeSync(fd); try { unlinkSync(file); } catch (error) { consumeKnownError(error); } }
 }

--- a/packages/daemon/test/fleet-writer-epoch.integration.test.ts
+++ b/packages/daemon/test/fleet-writer-epoch.integration.test.ts
@@ -13,9 +13,19 @@ function probeGit(repo: string, ...args: string[]): string { return execFileSync
 function probeRepo(root: string): string { const repo = path.join(root, "repo"); mkdirSync(path.join(repo, "harness"), { recursive: true }); probeGit(repo, "init", "-q"); probeGit(repo, "config", "user.name", "W3A Probe"); probeGit(repo, "config", "user.email", "w3a@example.invalid"); probeGit(repo, "commit", "--allow-empty", "-qm", "base"); writeFileSync(path.join(repo, "harness", "harness.yaml"), "schema: harness-anything/v1\nname: probe\nlayout:\n  authoredRoot: harness\n  localRoot: .harness\n"); probeGit(repo, "add", "harness"); probeGit(repo, "commit", "-qm", "harness"); return repo; }
 const probeBinding = (assertWriterEpoch: () => void) => ({ actor: { principal: { personId: "writer" }, executor: { kind: "agent" as const, id: "probe" } }, source: { kind: "assignment" as const, nodeId: "node", assignmentId: "assignment" }, assertWriterEpoch });
 
-function childEpoch(source: string, root: string, holderId: string): Promise<{ readonly code: number | null; readonly lease: { readonly epoch: number; readonly holderId: string } | null }> {
-  const code = `import { openPersistentWriterEpoch } from ${JSON.stringify(pathToFileURL(source).href)}; const [root, holder] = process.argv.slice(1); const authority = openPersistentWriterEpoch({ stateRoot: root, holderId: holder }); console.log(JSON.stringify(authority.acquire("repo")));`;
-  return new Promise((resolve, reject) => { const child = spawn(process.execPath, ["--input-type=module", "-e", code, root, holderId], { stdio: ["ignore", "pipe", "pipe"] }); let stdout = "", stderr = ""; child.stdout.on("data", (chunk) => { stdout += chunk; }); child.stderr.on("data", (chunk) => { stderr += chunk; }); child.on("error", reject); child.on("close", (exitCode) => { if (exitCode !== 0) return reject(new Error(stderr)); resolve({ code: exitCode, lease: JSON.parse(stdout.trim()) }); }); });
+function childEpoch(source: string, root: string, holderId: string, readyFile = ""): Promise<{ readonly code: number | null; readonly lease: { readonly epoch: number; readonly holderId: string } | null }> {
+  const code = `import { writeFileSync } from "node:fs"; import { openPersistentWriterEpoch } from ${JSON.stringify(pathToFileURL(source).href)}; const [root, holder, ready] = process.argv.slice(1); const authority = openPersistentWriterEpoch({ stateRoot: root, holderId: holder }); if (ready) writeFileSync(ready, "ready\\n"); console.log(JSON.stringify(authority.acquire("repo")));`;
+  return new Promise((resolve, reject) => { const child = spawn(process.execPath, ["--input-type=module", "-e", code, root, holderId, readyFile], { stdio: ["ignore", "pipe", "pipe"] }); let stdout = "", stderr = ""; child.stdout.on("data", (chunk) => { stdout += chunk; }); child.stderr.on("data", (chunk) => { stderr += chunk; }); child.on("error", reject); child.on("close", (exitCode) => { if (exitCode !== 0) return reject(new Error(stderr)); resolve({ code: exitCode, lease: JSON.parse(stdout.trim()) }); }); });
+}
+
+async function holdEpochLock(root: string, readyFile: string, holdMs: number): Promise<() => Promise<void>> {
+  const file = path.join(root, "writer-epochs.lock");
+  const code = `import { closeSync, existsSync, fsyncSync, openSync, unlinkSync, writeFileSync } from "node:fs"; const [file, ready, hold] = process.argv.slice(1); const fd = openSync(file, "wx", 0o600); writeFileSync(fd, process.pid + "\\n"); fsyncSync(fd); console.log("locked"); const deadline = Date.now() + 10_000; while (!existsSync(ready)) { if (Date.now() >= deadline) throw new Error("waiter did not become ready"); Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1); } Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Number(hold)); closeSync(fd); unlinkSync(file);`;
+  const child = spawn(process.execPath, ["--input-type=module", "-e", code, file, readyFile, String(holdMs)], { stdio: ["ignore", "pipe", "pipe"] }); let stderr = "";
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  const done = new Promise<void>((resolve, reject) => { child.once("error", reject); child.once("close", (exitCode) => exitCode === 0 ? resolve() : reject(new Error(stderr))); });
+  await new Promise<void>((resolve, reject) => { child.stdout.once("data", (chunk) => chunk.toString().includes("locked") ? resolve() : reject(new Error(`lock holder did not become ready: ${chunk.toString()}`))); child.once("error", reject); child.once("close", (exitCode) => { if (exitCode !== 0) reject(new Error(stderr)); }); });
+  return () => done;
 }
 
 test("persistent writer epochs allocate monotonically and fence a stale holder", () => {
@@ -45,6 +55,15 @@ test("concurrent processes allocate unique epochs through the same critical sect
     assert.deepEqual(epochs, Array.from({ length: 12 }, (_value, index) => index + 1));
     assert.equal(new Set(results.map((result) => result.lease!.holderId)).size, 12);
   } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("writer epoch acquisition waits for a live lock owner", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-writer-epoch-wait-")), readyFile = path.join(root, "waiter-ready");
+  const waitForHolder = await holdEpochLock(root, readyFile, 1_000);
+  try {
+    const source = path.resolve("packages/daemon/src/writer-epoch.ts"), result = await childEpoch(source, root, "waiting-worker", readyFile);
+    assert.equal(result.lease?.epoch, 1);
+  } finally { await waitForHolder(); rmSync(root, { recursive: true, force: true }); }
 });
 
 test("restoring an older state file cannot reuse a historical epoch", () => {


### PR DESCRIPTION
# English

## Summary

`withLock` in `writer-epoch.ts` bounded its cross-process lock acquisition at `attempt < 200` with a 2ms sleep between tries — a fixed ~400ms budget — and threw `writer_epoch_busy` when it ran out. The concurrent test drives 12 Node child processes through that critical section, each holding the lock across a `writeFileSync` + `fsyncSync`. On a loaded CI runner the queue does not clear inside 400ms, so a late waiter fails.

**No caller ever promised to release within 400ms.** All six call sites were enumerated (table below); none carries a timeout, a deadline parameter, or an upper-layer retry contract. The budget was introduced alongside writer-epoch fencing with no recorded rationale.

So the thing to delete is the budget, not the lock and not the test. `withLock` now waits for the lock to actually become free.

## What Changed

- `packages/daemon/src/writer-epoch.ts`: the bounded `for (let attempt = 0; attempt < 200 && fd === undefined; …)` becomes `for (;;)`; the exhaustion branch that threw `writer_epoch_busy` is gone; `writer_epoch_busy` is removed from the `WriterEpochError` code union, which no longer appears anywhere under `packages/`. PID liveness checking and stale-lock reclamation are untouched, as is the 2ms blocking sleep, the durable write shape, and every critical-section boundary.
- `packages/daemon/test/fleet-writer-epoch.integration.test.ts`: one new regression, "writer epoch acquisition waits for a live lock owner". A separate holder process takes the lock and writes its live PID; the contender writes a `waiter-ready` handshake **after** module cold start and then calls the real `acquire()`; the holder keeps the lock for 1000ms after seeing that handshake. The handshake is what makes it deterministic — cold start no longer eats the contention window, so the wait is strictly longer than the old budget.

**Why not a real blocking lock.** Node core has no cross-platform blocking inter-process lock, and this repository supports Linux, macOS, and Windows. `openSync(file, "wx")` is the atomic exclusive-create primitive available in core; the PID in the lock file is what lets a crashed holder's lock be reclaimed. Acquisition stays a poll, but `Atomics.wait(…, 2)` blocks the thread rather than spinning hot. Replacing this with `flock` or a native module would leave the file, break Windows support, and change the synchronization primitive — so it was rejected rather than attempted.

**Rejected alternatives**, each for a stated reason: raising 200 or converting it to a longer deadline (still guesses the hold time; just moves the red to a slower machine); lowering the test's concurrency, adding test retries, or marking it flaky (hides a production failure); `flock` (no cross-platform core API); an async watcher on file deletion (forces `acquire()` and the append fence async through the whole production call chain, plus lost-event and cancellation handling); removing the mutex (reopens lost updates and stale-holder passthrough between fence check and ref finalize); moving the `fsync` out (epoch history stops being a crash-durable fencing authority); sharding the lock per repo (the real contention is within one repo).

## Task And Scope

- Harness task: `task_5792940edeb74aebbe8395d0a4`
- Branch: `codex/writer-epoch-budget`
- Public scope: `packages/daemon/src/writer-epoch.ts`, `packages/daemon/test/fleet-writer-epoch.integration.test.ts`
- Private planning/evidence updated: yes
- Out of scope: the async-cancellable acquisition path and any native locking primitive; both are noted under Residual Risk as the correct future direction if cancellation is ever needed

## Version Impact

- Version: no version change because this is a bug fix inside an existing module with no package surface change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

No CI configuration, gate manifest entry, or timeout was modified, and no test was weakened: the 12-process uniqueness test keeps its concurrency and its assertions, and all five pre-existing epoch invariant tests still pass.

## Call sites and their timeout assumptions

| Call site | What the critical section protects | Timeout assumption |
| --- | --- | --- |
| `PersistentWriterEpoch.acquire()` | read state + history floor, allocate next epoch, append and `fsync` history, persist state | synchronous API; no timeout or deadline parameter, no upper-layer retry contract |
| `PersistentWriterEpoch.withAppendFence()` | re-read and verify epoch inside the same lock, then the canonical append's final ref CAS | synchronous API; no timeout parameter |
| `fleet/center.ts:25` — `listenFleetTls()` | eager `acquire()` per attached repo before the socket listens | none; failure fails center startup outright |
| `fleet/center.ts:29` — `ownedEpochFor()` | lazy `acquire()` on first assignment/auth request | none; the request layer does not pass a deadline into the epoch authority |
| `center.ts` → `daemon-host.ts` → `repo-cell.ts:65` → `task-event-store.ts:44` | `withWriterEpochFence()` around remote-center publish fence recheck and ref finalize | fleet edge socket timeout is `waitMs + 10_000ms`, but that bounds the **client's** wait and cannot cancel a server-side synchronous lock |
| `tools/center-testbed/smoke-epoch.mjs:28` | second center candidate allocating a successor epoch | none on acquire |

`current()`, `assert()`, `status()`, and `close()` do not take the lock. There are no other production callers of `openPersistentWriterEpoch()`.

## Verification

- Base `origin/main` SHA: `8e35e3834e73362e53fcafeb6f0a56f93bb85b7b`
- Branch merge-base with `origin/main`: `8e35e3834e73362e53fcafeb6f0a56f93bb85b7b`
- Last `git fetch origin` time: 2026-08-21, immediately before opening this PR
- Sync method: rebase
- Public diff command: `git diff origin/main...codex/writer-epoch-budget`
- Private evidence commit/path: `harness/tasks/task_5792940edeb74aebbe8395d0a4-writer-epoch-ci/artifacts/report-writer-epoch.md`
- Reviewer evidence path: same report, "阳性对照:两个方向" section
- GitHub Actions `rewrite-ci` run URL: pending on this PR

Production-Delta: +3/-4

- [x] `git diff --check`
- [x] `npm run check:local` (fast tier, 42 steps, 59.5s)
- [x] Isolated Ubuntu integration, **baseline red**: new regression fails with `writer_epoch_busy` (1275ms) while the 12-process test and all four other epoch guards pass in the same run — the failure is the contended lock, not a broken environment
- [x] Isolated Ubuntu integration, **fixed green**: 6/6
- [x] Isolated Ubuntu integration, **production rollback red**: reverting only `writer-epoch.ts` and keeping the identical test and runner reproduces the same single failure
- [x] Isolated Ubuntu integration, **final green after rebase**: 6/6, all five pre-existing invariants named individually
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full `npm run check` locally — the authoritative full gate surface is GitHub CI per the repository stop-point policy. Integration evidence above comes from `node tools/dispatch-isolated-test.mjs --target ubuntu`, not from the fast tier standing in for it. Windows integration was not run separately; the fix introduces no new platform API.

## Review Evidence

- Self-review: CEO independently read the production diff rather than trusting the report, and confirmed it is a pure deletion — bounded `for` becomes `for (;;)`, the exhaustion `throw` is gone, `writer_epoch_busy` leaves the error union — then grepped `packages/` to confirm that code no longer appears anywhere.
- Reviewer subagent: not used; the load-bearing evidence is the three-direction positive control, which is stronger than a code read.
- Human review: pending
- Blocking findings: none
- Worth recording: the delivered report corrected an error in the dispatch brief. The brief said "all four" pre-existing epoch tests; the baseline actually has five. The report said so explicitly rather than quietly matching the brief.

## Residual Risk

- **A holder that is alive but permanently wedged will block waiters indefinitely.** A real blocking OS lock behaves the same way. The previous 400ms budget was not protection against this — it was a random failure. The holder's critical section contains only synchronous durable filesystem and Git operations, and no caller has a cancellation contract to pass down. If cancellable waiting is ever needed, the answer is an async call chain or a cross-platform native lock, **not** reintroducing a guessed deadline.
- The pre-existing PID liveness check still carries PID-reuse risk, and treats a permission error as "not alive". This PR does not widen or narrow that existing semantic.
- `open(..., "wx")` depends on the state root's filesystem providing atomic exclusive create. This holds for local disks and the current testbed and CI; weakly consistent network filesystems are unverified.
- Polling has no fairness guarantee, so unbounded sustained contention could starve a waiter. Bounded holds no longer fail randomly, which is the traded-for property.
- Verified on isolated Ubuntu / Node 24.18.0 only.

## References

- Task: `task_5792940edeb74aebbe8395d0a4`
- Evidence: `harness/tasks/task_5792940edeb74aebbe8395d0a4-writer-epoch-ci/artifacts/report-writer-epoch.md`
- Facts: `F-6478F800` (the mechanism), `F-1348E49C` (baseline reproduction), `F-846B805A` (two-direction control and final verification)

---

# 中文

## 概要

`writer-epoch.ts` 的 `withLock` 用 `attempt < 200` 配 2ms 睡眠给跨进程锁的获取设了上界——约 400ms 的固定预算——耗尽即抛 `writer_epoch_busy`。而并发测试要 12 个 Node 子进程穿过这个临界区,每个持锁期间做 `writeFileSync` + `fsyncSync`。CI runner 有负载时队列排不完 400ms,后到的等待者就失败。

**没有任何调用方承诺过在 400ms 内释放。** 六个调用点全部枚举在下表:没有一个带 timeout、deadline 参数或上层重试合同。这个预算是随 writer epoch fencing 一起引入的,没有留下设计依据。

所以该删的是预算,不是锁,也不是测试。`withLock` 现在等锁真正空出来。

## 改动内容

- `packages/daemon/src/writer-epoch.ts`:有界的 `for (let attempt = 0; attempt < 200 && fd === undefined; …)` 改为 `for (;;)`;抛 `writer_epoch_busy` 的耗尽分支删除;`writer_epoch_busy` 从 `WriterEpochError` 的 code 联合类型中移除,该错误码在 `packages/` 下已不再出现。PID 存活检查与 stale lock 回收原样保留,2ms 阻塞睡眠、durable 写法与全部临界区边界均未改动。
- `packages/daemon/test/fleet-writer-epoch.integration.test.ts`:新增一个回归「writer epoch acquisition waits for a live lock owner」。独立 holder 进程取锁并写入自己的存活 PID;contender 在**模块冷启动之后**写 `waiter-ready` 握手再调真实的 `acquire()`;holder 看到握手后继续持锁 1000ms。**握手是它确定性的来源**——冷启动不再吃掉竞争窗口,等待时长严格超过旧预算。

**为什么不换成真正的阻塞锁。** Node core 没有跨平台的阻塞式进程间锁,而本仓支持 Linux、macOS 与 Windows。`openSync(file, "wx")` 是 core 内可用的原子排他创建原语;锁文件里的 PID 正是崩溃后回收锁的依据。获取过程仍是轮询,但 `Atomics.wait(…, 2)` 阻塞线程而非空转占 CPU。换成 `flock` 或原生模块会越出这个文件、破坏 Windows 支持并更换同步原语,因此是被否掉而不是没想到。

**被否掉的方案**及各自理由:把 200 调大或改成更长的 deadline(仍在猜持锁时长,只会把红移到更慢的机器);降低测试并发、给测试加重试、标记 flaky(掩盖生产失败);`flock`(core 无跨平台 API);用 async watcher 等文件删除(要把 `acquire()` 与 append fence 沿整条生产调用链改成 async,还要处理 watch 丢事件与取消);整体删除互斥(重新打开丢更新,以及 fence check 与 ref finalize 之间的 stale holder 穿透);把 `fsync` 移出临界区(epoch history 不再是崩溃可信的 fencing authority);按 repo 拆锁(真实竞争就发生在同一 repo 内)。

## 任务与范围

- Harness 任务:`task_5792940edeb74aebbe8395d0a4`
- 分支:`codex/writer-epoch-budget`
- 公开范围:`packages/daemon/src/writer-epoch.ts`、`packages/daemon/test/fleet-writer-epoch.integration.test.ts`
- 私有计划 / 证据是否已更新:yes
- 范围外:可取消的 async 获取路径与任何原生锁原语;两者都写在残余风险里,作为将来真需要取消能力时的正确方向

## 版本影响

- 版本:不改版本,原因是这是既有模块内的缺陷修复,不改包对外面
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:不适用
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无

未修改任何 CI 配置、gate manifest 条目或超时,也未削弱任何测试:12 进程唯一性测试的并发数与断言原样保留,五个既有 epoch 不变量测试全部继续通过。

## 调用方与各自的时限假设

完整枚举见英文段的表格(六个调用点,无一携带 timeout、deadline 或上层重试合同)。`current()`、`assert()`、`status()`、`close()` 不取锁;全仓没有其它 `openPersistentWriterEpoch()` 的生产调用方。

## 验证

- `origin/main` 基准 SHA:`8e35e3834e73362e53fcafeb6f0a56f93bb85b7b`
- 当前分支与 `origin/main` 的 merge-base:`8e35e3834e73362e53fcafeb6f0a56f93bb85b7b`
- 最近一次 `git fetch origin` 时间:2026-08-21,开 PR 前
- 同步方式:rebase
- 公开 diff 命令:`git diff origin/main...codex/writer-epoch-budget`
- 私有证据 commit/path:`harness/tasks/task_5792940edeb74aebbe8395d0a4-writer-epoch-ci/artifacts/report-writer-epoch.md`
- Reviewer 证据路径:同一报告的「阳性对照:两个方向」节
- GitHub Actions `rewrite-ci` run URL:本 PR 上待跑
- 生产净变化 +3/-4(机读声明见英文段的 `Production-Delta` 行)
- [x] `git diff --check`
- [x] `npm run check:local`(fast tier,42 步,59.5 秒)
- [x] 隔离 Ubuntu integration **基线红**:新回归以 `writer_epoch_busy` 失败(1275ms),而同一轮里 12 进程测试与其余四个 epoch 守卫全部通过——失败的是被争用的锁,不是坏掉的环境
- [x] 隔离 Ubuntu integration **修复后绿**:6/6
- [x] 隔离 Ubuntu integration **回退生产码后重新红**:只回退 `writer-epoch.ts`、保留完全相同的测试与 runner,复现同一条失败
- [x] 隔离 Ubuntu integration **rebase 后 fresh 绿**:6/6,五个既有不变量逐条列名
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:本地完整 `npm run check`——按本仓停止点政策,完整权威门面在 GitHub CI。上面的 integration 证据来自 `node tools/dispatch-isolated-test.mjs --target ubuntu`,不是拿 fast tier 顶替。Windows integration 未单独跑;本修复未引入新的平台 API。

## 审查证据

- 自查:CEO 独立读了生产 diff 而不是采信报告,确认它是纯删除——有界 `for` 变 `for (;;)`、耗尽分支的 `throw` 删除、`writer_epoch_busy` 退出错误码联合——然后 grep `packages/` 确认该错误码已不再出现于任何位置。
- Reviewer subagent:未使用;承重证据是三个方向的阳性对照,它比读代码更强。
- 人工审查:待做
- 阻塞发现:无
- 值得记一笔:交付报告纠正了派工书里的一处事实错误。派工书写「全部四个」既有 epoch 测试,基线实际有五个。报告明说了这一点,而不是默默迎合派工书。

## 残余风险

- **存活但永久卡死的持锁进程会让等待者持续阻塞。** 真正的阻塞式 OS 锁同样如此。此前那个 400ms 预算并不是对这种情况的保护——它是一次随机失败。持锁者的临界区里只有同步的 durable 文件系统与 Git 操作,调用方也没有可向下传递的取消合同。若将来确实需要可取消的等待,答案是 async 调用链或跨平台原生锁,**而不是**重新引入一个猜出来的 deadline。
- 既有的 PID 存活检查仍有 PID 重用风险,且把权限错误视作「不存活」。本 PR 未扩大也未收窄这一既有语义。
- `open(..., "wx")` 依赖 state root 所在文件系统提供原子排他创建。本地磁盘与当前 testbed/CI 成立;弱一致的网络文件系统未验证。
- 轮询没有公平性保证,持续无限竞争下可能饥饿。换来的性质是:有限持锁不再随机失败。
- 仅在隔离 Ubuntu / Node 24.18.0 上验证。

## 关联材料

- 任务:`task_5792940edeb74aebbe8395d0a4`
- 证据:`harness/tasks/task_5792940edeb74aebbe8395d0a4-writer-epoch-ci/artifacts/report-writer-epoch.md`
- Facts:`F-6478F800`(机制)、`F-1348E49C`(基线复现)、`F-846B805A`(双向对照与最终验证)
