### PR TITLE
fix(ci): execute non-PR manifest gates so the Windows nightly lane stops running empty

### DIFF
--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -249,7 +249,6 @@ jobs:
     # The full matrix runs on the nightly schedule (and manual dispatch) only; windows-first-run
     # remains the per-PR smoke. This lane is never promoted to a required context.
     if: github.event_name != 'pull_request' && github.event_name != 'push'
-    needs: metadata-source-proof
     name: windows-integration-shard (${{ matrix.shard }})
     runs-on: windows-latest
     strategy:
@@ -257,20 +256,13 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6]
     steps:
-      - name: Reuse same-SHA source validation
-        if: ${{ needs.metadata-source-proof.outputs.reuse_source == 'true' }}
-        run: echo "Reusing successful source validation for the same head SHA."
       - uses: actions/checkout@v4
-        if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
       - uses: actions/setup-node@v4
-        if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
         with:
           node-version: 24
           cache: npm
-      - if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
-        run: npm ci
-      - if: ${{ needs.metadata-source-proof.outputs.reuse_source != 'true' }}
-        run: node tools/run-manifest-gates.mjs --workflow-job windows-integration-shard --shard ${{ matrix.shard }} --exclude mergify-queue-metadata-edit-noop
+      - run: npm ci
+      - run: node tools/run-manifest-gates.mjs --workflow-job windows-integration-shard --shard ${{ matrix.shard }}
 
   nightly-daemon-soak:
     # Functional CI starts a small daemon, serves one client for seconds, and stops it. That shape

--- a/tools/check-gate-surface.mjs
+++ b/tools/check-gate-surface.mjs
@@ -15,6 +15,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { boundaryAllowlistAuthorityFindings } from "./gate-surface-boundary-policy.mjs";
+import { selectManifestGateIds } from "./run-manifest-gates.mjs";
 
 const DEFAULT_ROOT = process.cwd();
 const MANIFEST_GATE_RUNNER = "node tools/run-manifest-gates.mjs";
@@ -70,7 +71,6 @@ function checkPackageScripts({ findings, manifest, gates, gatesById, commandToGa
     aggregateName: "check",
     commands: splitShellAndList(packageScripts.check ?? ""),
     manifest,
-    gates,
     commandToGateIds
   });
   const actualCheckPrIds = mapAggregateCommands({
@@ -78,7 +78,6 @@ function checkPackageScripts({ findings, manifest, gates, gatesById, commandToGa
     aggregateName: "check:pr",
     commands: splitShellAndList(packageScripts["check:pr"] ?? ""),
     manifest,
-    gates,
     commandToGateIds
   });
 
@@ -267,12 +266,12 @@ function checkBoundaryFields({ findings, gates, packageScripts }) {
   }
 }
 
-function mapAggregateCommands({ findings, aggregateName, commands, manifest, gates, commandToGateIds }) {
+function mapAggregateCommands({ findings, aggregateName, commands, manifest, commandToGateIds }) {
   const ids = [];
   for (const command of commands) {
     const runnerInvocation = parseManifestRunnerCommand(command);
     if (runnerInvocation) {
-      const expandedIds = expandManifestRunnerIds({ invocation: runnerInvocation, manifest, gates });
+      const expandedIds = expandManifestRunnerIds({ invocation: runnerInvocation, manifest });
       if (runnerInvocation.packageSurface === null) {
         findings.push(formatFinding("package-json", `package.json scripts.${aggregateName} uses manifest gate runner without --package-surface.`));
       }
@@ -317,19 +316,19 @@ function jobRunsGateCommand({ job, gate, manifest, gates }) {
   if (job.runCommands.includes(gate.command)) {
     return true;
   }
-  if (job.runCommands.some((command) => manifestRunnerCoversGate({ command, gateId: gate.id, workflowJob: job.id, manifest, gates }))) {
+  if (job.runCommands.some((command) => manifestRunnerCoversGate({ command, gateId: gate.id, workflowJob: job.id, manifest }))) {
     return true;
   }
   const parts = splitShellAndList(gate.command);
   return parts.length > 1 && parts.every((part) => jobRunsCommandPart({ job, part, manifest, gates }));
 }
 
-function manifestRunnerCoversGate({ command, gateId, workflowJob, manifest, gates }) {
+function manifestRunnerCoversGate({ command, gateId, workflowJob, manifest }) {
   const invocation = parseManifestRunnerCommand(command);
   if (!invocation || invocation.workflowJob !== workflowJob) {
     return false;
   }
-  return expandManifestRunnerIds({ invocation, manifest, gates }).includes(gateId);
+  return expandManifestRunnerIds({ invocation, manifest }).includes(gateId);
 }
 
 function jobRunsCommandPart({ job, part, manifest, gates }) {
@@ -342,7 +341,7 @@ function jobRunsCommandPart({ job, part, manifest, gates }) {
     if (!invocation || invocation.workflowJob !== job.id) {
       continue;
     }
-    const expandedGates = expandManifestRunnerIds({ invocation, manifest, gates })
+    const expandedGates = expandManifestRunnerIds({ invocation, manifest })
       .map((id) => gatesById.get(id))
       .filter(Boolean);
     if (expandedGates.some((gate) => gate.command === part)) {
@@ -525,21 +524,8 @@ function parseManifestRunnerCommand(command) {
   return invocation;
 }
 
-function expandManifestRunnerIds({ invocation, manifest, gates }) {
-  if (invocation.packageSurface) {
-    return (manifest.surfaces?.packageJson?.[invocation.packageSurface] ?? [])
-      .filter((id) => !invocation.exclude.has(id));
-  }
-
-  if (invocation.workflowJob) {
-    return gates
-      .filter((gate) => !gate.aggregate)
-      .filter((gate) => gate.executionSurfaces?.rewriteCi?.pullRequestJobs?.includes(invocation.workflowJob))
-      .map((gate) => gate.id)
-      .filter((id) => !invocation.exclude.has(id));
-  }
-
-  return [];
+function expandManifestRunnerIds({ invocation, manifest }) {
+  return selectManifestGateIds(manifest, invocation);
 }
 
 function compareIdSets({ findings, label, expected, actual }) {

--- a/tools/check-runtime-release-readiness.mjs
+++ b/tools/check-runtime-release-readiness.mjs
@@ -5,6 +5,7 @@ import {
   harnessRuntimeReleaseReadiness,
   validateRuntimeReleaseReadiness
 } from "../packages/gui/src/distribution/runtime-release-readiness.ts";
+import { selectManifestGateIds } from "./run-manifest-gates.mjs";
 
 const root = process.cwd();
 const errors = [];
@@ -225,18 +226,7 @@ function parseManifestRunnerCommand(command) {
 }
 
 function expandManifestRunnerIds(invocation) {
-  if (invocation.packageSurface) {
-    return (gateManifest.surfaces?.packageJson?.[invocation.packageSurface] ?? [])
-      .filter((id) => !invocation.exclude.has(id));
-  }
-  if (invocation.workflowJob) {
-    return (gateManifest.gates ?? [])
-      .filter((gate) => !gate.aggregate)
-      .filter((gate) => gate.executionSurfaces?.rewriteCi?.pullRequestJobs?.includes(invocation.workflowJob))
-      .map((gate) => gate.id)
-      .filter((id) => !invocation.exclude.has(id));
-  }
-  return [];
+  return selectManifestGateIds(gateManifest, invocation);
 }
 
 function splitShellAndList(script) {

--- a/tools/check-supply-chain.mjs
+++ b/tools/check-supply-chain.mjs
@@ -5,6 +5,7 @@ import {
   harnessSupplyChainReleaseReadiness,
   validateSupplyChainReleaseReadiness
 } from "../packages/gui/src/distribution/supply-chain-release-readiness.ts";
+import { selectManifestGateIds } from "./run-manifest-gates.mjs";
 
 const root = process.cwd();
 const errors = [];
@@ -291,18 +292,7 @@ function parseManifestRunnerCommand(command) {
 }
 
 function expandManifestRunnerIds(invocation) {
-  if (invocation.packageSurface) {
-    return (gateManifest.surfaces?.packageJson?.[invocation.packageSurface] ?? [])
-      .filter((id) => !invocation.exclude.has(id));
-  }
-  if (invocation.workflowJob) {
-    return (gateManifest.gates ?? [])
-      .filter((gate) => !gate.aggregate)
-      .filter((gate) => gate.executionSurfaces?.rewriteCi?.pullRequestJobs?.includes(invocation.workflowJob))
-      .map((gate) => gate.id)
-      .filter((id) => !invocation.exclude.has(id));
-  }
-  return [];
+  return selectManifestGateIds(gateManifest, invocation);
 }
 
 function splitShellAndList(script) {

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -566,9 +566,7 @@
             "gui-build",
             "node26-compatibility"
           ],
-          "nonPullRequestJobs": [
-            "windows-integration-shard"
-          ]
+          "nonPullRequestJobs": []
         },
         "branchProtection": {
           "required": true,

--- a/tools/run-manifest-gates.mjs
+++ b/tools/run-manifest-gates.mjs
@@ -76,7 +76,10 @@ export function selectManifestGateIds(manifest, options) {
 
   return manifest.gates
     .filter((gate) => !gate.aggregate)
-    .filter((gate) => gate.executionSurfaces?.rewriteCi?.pullRequestJobs?.includes(options.workflowJob))
+    .filter((gate) => [
+      ...(gate.executionSurfaces?.rewriteCi?.pullRequestJobs ?? []),
+      ...(gate.executionSurfaces?.rewriteCi?.nonPullRequestJobs ?? [])
+    ].includes(options.workflowJob))
     .map((gate) => gate.id)
     .filter((id) => !options.exclude.has(id));
 }

--- a/tools/run-manifest-gates.test.mjs
+++ b/tools/run-manifest-gates.test.mjs
@@ -21,6 +21,24 @@ test("manifest gate runner appends shard args only to shardable gates", () => {
   ]);
 });
 
+test("manifest gate runner executes gates declared for non-pull-request workflow jobs", () => {
+  const manifest = {
+    gates: [
+      {
+        id: "test-integration",
+        command: "npm run test:integration",
+        shardable: true,
+        executionSurfaces: { rewriteCi: { pullRequestJobs: [], nonPullRequestJobs: ["windows-integration-shard"] } }
+      }
+    ]
+  };
+  const options = parseManifestGateArgs(["--workflow-job", "windows-integration-shard", "--shard", "4"]);
+
+  assert.deepEqual(buildManifestGatePlan(manifest, options), [
+    { id: "test-integration", command: "npm run test:integration -- --shard 4" }
+  ]);
+});
+
 test("manifest gate runner rejects --shard for non-shardable gates", () => {
   const manifest = {
     gates: [


### PR DESCRIPTION
# English

## Summary

`windows-integration-shard` claimed to run the full Windows matrix on the nightly schedule. It ran on no event at all: its condition said "not `pull_request` and not `push`", while the job it declared in `needs` runs only on `pull_request`. Two mutually exclusive conditions. Schedule and dispatch runs on 2026-08-20 and 2026-08-21 both show it `skipped`.

**Fixing the trigger alone would have made things worse.** With the condition repaired the job would check out, install, run **zero gates**, and go green. A green `windows-integration-shard (1..6)` reads as "Windows integration passed". A dead job is a visible absence; a green no-op is an invisible one.

The reason it would run nothing is the real defect. `selectManifestGateIds` filtered on `executionSurfaces.rewriteCi.pullRequestJobs` only and never read `nonPullRequestJobs` — while `test-integration` (`npm run test:integration`) declares exactly that field to say it belongs on the Windows nightly. **The manifest stated an intent the runner could not see.**

And that filter existed in **four separate copies**: the runner plus three check scripts, each with its own verbatim duplicate reading only the first field. Repairing one would have left the checkers disagreeing with the executor about the same job.

Net effect on the tree is **-23 lines**: the three duplicates are deleted and now call the single implementation.

## What Changed

- **`tools/run-manifest-gates.mjs`** — the selector now reads both `pullRequestJobs` and `nonPullRequestJobs`. One filter expression.
- **`tools/check-gate-surface.mjs`, `tools/check-runtime-release-readiness.mjs`, `tools/check-supply-chain.mjs`** — each carried a verbatim copy of the selection logic; all three now call `selectManifestGateIds`. This is the deletion that made the fix complete rather than local.
- **`.github/workflows/rewrite-ci.yml`** — drops the `needs: metadata-source-proof` dependency and the `reuse_source` step conditions that dangled from it. Required contexts, the matrix, and timeouts are untouched, and the lane is still never promoted to a required context.
- **`tools/gate-manifest.json`** — removes the mapping that assigned the PR-only Mergify no-op gate to this non-PR job.

**On that last item, a CEO judgement was corrected by the worker.** Reviewing the first commit, CEO measured that removing the Mergify mapping and the matching `--exclude` flag changed nothing — both selected zero gates before and after — and asked the worker to double-check a claim of "harmless but pointless". The worker's answer: they were no-ops *under the old selector*, and stop being no-ops once the selector honours `nonPullRequestJobs`. Keeping the old mapping would make the Windows shard select a **non-shardable** Mergify no-op, and `--shard` then fails closed; keeping the `--exclude` to mask it would leave the manifest claiming Windows consumes a PR-only gate. The declaration cleanup is a required precondition, not tidying.

## Evidence

**The selector was measured, not reasoned about.** Calling `selectManifestGateIds` directly, before the fix:

```
  2 windows-first-run
  2 integration-shard
  2 typecheck
 39 boundaries
  0 windows-integration-shard   <-- zero
```

Every other job returns non-zero, so the zero is a property of that job and not of the call. After the fix it selects `test-integration => npm run test:integration -- --shard 1`.

**A full before/after comparison across every job in the manifest** shows exactly three gate sets changed, **all additions, nothing lost**: `windows-integration-shard` (+`test-integration`), `nightly-daemon-soak` (+`nightly-daemon-soak`), and `full-check` (+45). The last two do not execute through the manifest runner — `nightly-daemon-soak` runs `npm run test:soak` and `full-check` runs its own script — so their declarations are documentation and their change does not alter execution. **One job's behaviour changes, and it is the intended one.**

**Exhaustive scan by field rather than by job name**, because a dead job's defining feature is that its name looks fine: three jobs declare gates through `nonPullRequestJobs`, and only `windows-integration-shard` consumes the manifest runner. The idle-job count is therefore exactly one.

## Task And Scope

- Harness task: `task_cfd765534c533898fe0cf357c6`
- Evidence: facts `F-D4CB196D` (the dead job) and `F-BCB21959` (the empty gate set)
- Branch: `codex/ci-deadjob`
- Public scope: `tools/run-manifest-gates.mjs` and its test, `tools/check-{gate-surface,runtime-release-readiness,supply-chain}.mjs`, `tools/gate-manifest.json`, `.github/workflows/rewrite-ci.yml`
- Private planning/evidence updated: yes
- Out of scope: a governance gate that would fail a manifest job selecting zero gates — deliberately **not** minted here, see below

## Version Impact

- Version: no version change; this touches CI orchestration only, with no package surface or wire-contract change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `.github/workflows/rewrite-ci.yml` (removal of a `needs` edge and its dependent step conditions), `tools/gate-manifest.json` (one declaration mapping), `tools/run-manifest-gates.mjs` (gate selection), and the three check scripts that duplicated that selection
- Authority: this is a CI/gate governance task; the task plan authorizes exactly these files. **No required check was added or removed**, no existing job's pass condition was changed, and no `continue-on-error`, timeout relaxation, or skip condition was introduced. `dec_630DB4EB94D3CB0B2459C8ABE2` keeps the Windows integration matrix off the required set and this PR does not disturb that.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none yet. The worker recommends, and does **not** mint, a gate that fails when a manifest-runner job selects zero gates — the defect class this PR fixes would then be impossible to reintroduce silently. That is a governance decision for the CEO, and minting it inside an implementation PR would be exactly the kind of quiet scope growth this repository forbids.

## Verification

- Base `origin/main` SHA: `77be9f45ffe3da2c47423bbaf4cd0ae8d8231a88`
- Branch merge-base with `origin/main`: `77be9f45ffe3da2c47423bbaf4cd0ae8d8231a88`
- Last `git fetch origin` time: 2026-08-21, immediately before the rebase
- Sync method: rebased onto `77be9f45f` after #1665 landed
- Public diff command: `git diff origin/main...codex/ci-deadjob`
- Private evidence commit/path: `harness/tasks/task_cfd765534c533898fe0cf357c6-windows-integration-shard-job-nightly-pr-only/artifacts/report-ci-deadjob.md`
- Reviewer evidence path: same report, sections 6.2 through 6.5
- GitHub Actions `rewrite-ci` run URL: pending on this PR

Production-Delta: +0/-0

- [x] `git diff --check`
- [x] `npm run check:local`
- [x] `node --test tools/run-manifest-gates.test.mjs` including a new case covering the second field
- [x] Selector measured directly before and after, with a positive control across other jobs
- [x] Full before/after gate-set comparison across every job: three sets changed, all additions, none lost
- [x] Exhaustive scan by field name rather than by job name
- [ ] GitHub Actions `rewrite-ci` passed
- [ ] **Windows nightly actually firing — explicitly `unverified`.** Scheduled and dispatched workflows resolve against the default branch, so this cannot be proven before merge. A verifier script is kept in the task package that distinguishes `PASS`, `NOT_FIRED`, and `FIRED_NOT_GREEN`; the third is the one that would otherwise be mistaken for the first.
- Not run: full `npm run check` locally — the authoritative full gate surface is GitHub CI per the repository stop-point policy.

## Review Evidence

- The empty-gate-set finding came from CEO review of the worker's first commit, not from the original task framing. The task was opened as "a job with mutually exclusive conditions"; measuring the selector turned it into "a declaration the runner cannot read, duplicated four times".
- CEO re-ran the selector independently rather than accepting the report's numbers, including the positive control that rules out a broken call, and the full-job comparison that rules out collateral damage from the refactor.
- The worker corrected a CEO judgement (the Mergify cleanup being pointless) with a concrete failure mode. That correction is reflected above.
- The worker declined to mint the follow-up gate on its own initiative and wrote it up as a recommendation instead.
- Reviewer subagent: not used; the load-bearing evidence is a measured selector and a 7-file diff that is net negative.
- Human review: pending
- Blocking findings: none

## Residual Risk

- **Whether the Windows integration suite actually passes on Windows is unknown.** This job has never executed. If it starts failing after merge, those failures are pre-existing breakage that the dead job was hiding, not regressions from this PR. The task plan instructs stopping and reporting rather than making them green.
- The nightly lane will now take longer and consume Windows runner minutes it previously never used.
- Nothing prevents the fourth copy of this selection logic from reappearing. The recommended zero-gate governance gate would address the symptom's cause; until it is decided, this stays a convention.
- `full-check` and `nightly-daemon-soak` still declare gates in the manifest that they do not execute through the runner. That is documentation drift rather than a live defect, and it was left alone deliberately to keep this change scoped.

## References

- Task: `task_cfd765534c533898fe0cf357c6`
- Facts: `F-D4CB196D`, `F-BCB21959`
- Decision context: `dec_630DB4EB94D3CB0B2459C8ABE2` (Windows downgraded; integration matrix never required)
- Review: pending

---

# 中文

## 概要

`windows-integration-shard` 声称在每晚的定时任务里跑完整的 Windows 矩阵。它在**任何事件下都不执行**:它的条件写着"不是 `pull_request` 且不是 `push`",而它在 `needs` 里声明的前置 job 只在 `pull_request` 下跑。两个条件互斥。2026-08-20 的定时运行与 2026-08-21 的手动运行都显示它 `skipped`。

**只修触发条件会让情况更糟。** 条件修好之后,这个 job 会 checkout、装依赖、跑**零个门**,然后变绿。一个绿色的 `windows-integration-shard (1..6)` 读起来正是"Windows 集成测试通过了"。**死 job 是可见的空,绿色空转是不可见的空。**

它为什么会跑零个门,才是真正的缺陷。`selectManifestGateIds` 只按 `executionSurfaces.rewriteCi.pullRequestJobs` 过滤,从不读 `nonPullRequestJobs`;而 `test-integration`(`npm run test:integration`)正是用后一个字段声明"我属于 Windows nightly"。**manifest 表达了一个执行器看不见的意图。**

而这个过滤器存在**四份各自独立的副本**:执行器加三个检查脚本,每一份都逐字重复且只读第一个字段。只修一处,会让检查脚本与执行器对同一个 job 给出不同答案。

对代码树的净效果是**减少 23 行**:三份副本被删除,改为调用唯一实现。

## 改动内容

- **`tools/run-manifest-gates.mjs`** —— 选择器现在同时读 `pullRequestJobs` 与 `nonPullRequestJobs`。一处 filter 表达式。
- **`tools/check-gate-surface.mjs`、`tools/check-runtime-release-readiness.mjs`、`tools/check-supply-chain.mjs`** —— 每个都带着一份逐字复制的选择逻辑,现在三者都调用 `selectManifestGateIds`。**正是这次删除让修复从局部变成完整。**
- **`.github/workflows/rewrite-ci.yml`** —— 删除 `needs: metadata-source-proof` 依赖,以及悬空于它的那串 `reuse_source` 步骤条件。required contexts、矩阵与超时均未触碰,这条跑道仍然永不晋升为 required。
- **`tools/gate-manifest.json`** —— 移除把 PR-only 的 Mergify no-op 门映射到这个 non-PR job 的声明。

**关于最后一项,CEO 的一处判断被 worker 纠正了。** 复核第一个提交时,CEO 实测发现移除 Mergify 映射与对应的 `--exclude` 参数什么都没改变——改前改后都选出零个门——于是把"无害但也无效果"这个说法退回去让它复核。worker 的回答是:它们**在旧选择器下**确实是 no-op,而一旦选择器开始兑现 `nonPullRequestJobs`,它们就不再是 no-op 了。保留旧映射会让 Windows shard 同时选中**不可分片的** Mergify no-op,`--shard` 随即 fail closed;靠保留 `--exclude` 去遮蔽它,则 manifest 会继续谎称 Windows 消费了一个 PR-only 门。**这次声明清理是必需的前置,不是顺手整理。**

## 证据

**选择器是被测量的,不是被推理的。** 直接调用 `selectManifestGateIds`,修复前:

```
  2 windows-first-run
  2 integration-shard
  2 typecheck
 39 boundaries
  0 windows-integration-shard   <-- 零
```

其它 job 全部返回非零,所以这个零是那个 job 的性质,不是调用写错了。修复后它选出 `test-integration => npm run test:integration -- --shard 1`。

**对 manifest 里每一个 job 做改前改后全量对照**,结果是恰好三个门集发生变化,**全部是新增,没有任何丢失**:`windows-integration-shard`(+`test-integration`)、`nightly-daemon-soak`(+`nightly-daemon-soak`)、`full-check`(+45)。后两个并不通过 manifest runner 执行——`nightly-daemon-soak` 跑 `npm run test:soak`,`full-check` 跑自己的脚本——所以它们的声明是文档性质的,变化不改变执行。**只有一个 job 的行为改变,而它正是目标。**

**按字段而不是按 job 名做穷尽扫描**,因为死 job 的特征恰恰是名字看起来正常:三个 job 通过 `nonPullRequestJobs` 声明门,其中只有 `windows-integration-shard` 消费 manifest runner。因此空转 job 的数量恰好是一个。

## 任务与范围

- Harness 任务:`task_cfd765534c533898fe0cf357c6`
- 证据:fact `F-D4CB196D`(死 job)与 `F-BCB21959`(空门集)
- 分支:`codex/ci-deadjob`
- 公开范围:`tools/run-manifest-gates.mjs` 及其测试、`tools/check-{gate-surface,runtime-release-readiness,supply-chain}.mjs`、`tools/gate-manifest.json`、`.github/workflows/rewrite-ci.yml`
- 私有计划 / 证据是否已更新:yes
- 范围外:一道"manifest job 选出零个门即失败"的治理门——**刻意不在本 PR 铸造**,见下

## 版本影响

- 版本:不改版本;本次只触碰 CI 编排,不改包对外面也不改 wire 契约
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:yes
- protected surface 范围:`.github/workflows/rewrite-ci.yml`(删除一条 `needs` 边及依赖它的步骤条件)、`tools/gate-manifest.json`(一处声明映射)、`tools/run-manifest-gates.mjs`(门选择),以及三个复制了该选择逻辑的检查脚本
- 依据:本任务是 CI/gate 治理任务,任务计划明确授权上述文件。**没有增删任何 required check**,没有改变任何既有 job 的通过条件,也没有引入 `continue-on-error`、放宽超时或跳过条件。`dec_630DB4EB94D3CB0B2459C8ABE2` 规定 Windows 集成矩阵永不进 required 集合,本 PR 未触动这一点。
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:暂无。worker **建议**而没有铸造一道"manifest runner job 选出零个门即失败"的门——有了它,本 PR 修的这一类缺陷就无法再静默复现。那是 CEO 的治理裁决,在一个实现 PR 里顺手铸门,正是本仓禁止的那种悄悄扩张。

## 验证

- `origin/main` 基准 SHA:`77be9f45ffe3da2c47423bbaf4cd0ae8d8231a88`
- 当前分支与 `origin/main` 的 merge-base:`77be9f45ffe3da2c47423bbaf4cd0ae8d8231a88`
- 最近一次 `git fetch origin` 时间:2026-08-21,rebase 前
- 同步方式:在 #1665 合入后 rebase 到 `77be9f45f`
- 公开 diff 命令:`git diff origin/main...codex/ci-deadjob`
- 私有证据 commit/path:`harness/tasks/task_cfd765534c533898fe0cf357c6-windows-integration-shard-job-nightly-pr-only/artifacts/report-ci-deadjob.md`
- Reviewer 证据路径:同一报告的 6.2 至 6.5 节
- GitHub Actions `rewrite-ci` run URL:本 PR 上待跑
- 生产净变化 +0/-0(机读声明见英文段的 `Production-Delta` 行;本次改动全在 `tools/` 与 `.github/`,不计入生产行)
- [x] `git diff --check`
- [x] `npm run check:local`
- [x] `node --test tools/run-manifest-gates.test.mjs`,含一条覆盖第二个字段的新用例
- [x] 选择器改前改后直接实测,并用其它 job 做阳性对照
- [x] 对每一个 job 做全量门集改前改后对照:三个门集变化,全部新增,无一丢失
- [x] 按字段名而不是按 job 名做穷尽扫描
- [ ] GitHub Actions `rewrite-ci` passed
- [ ] **Windows nightly 真实点火——明确标记为 `unverified`。** 定时与手动触发的 workflow 取默认分支的定义,因此合入前无法证明。任务包里保留了一个验证器脚本,它区分 `PASS`、`NOT_FIRED` 与 `FIRED_NOT_GREEN`——第三种正是最容易被误当成第一种的那个。
- 未运行:本地完整 `npm run check`——按本仓停止点政策,完整权威门面在 GitHub CI。

## 审查证据

- 空门集这个发现来自 CEO 对 worker 第一个提交的复核,不来自任务最初的框定。这个任务立案时是"一个条件互斥的 job",实测选择器之后变成了"一个执行器读不到的声明,而且被复制了四份"。
- CEO 独立重跑了选择器而不是采信报告里的数字,包括排除"调用写错了"的阳性对照,以及排除"重构误伤"的全量 job 对照。
- worker 用一个具体的失效路径纠正了 CEO 的一处判断(Mergify 清理无意义),该纠正已反映在上文。
- worker 没有擅自铸造后续那道门,而是写成了建议。
- Reviewer subagent:未使用;承重证据是一次实测的选择器与一份净删除的 7 文件 diff。
- 人工复核:待进行
- 阻塞性 findings:无

## 残余风险

- **Windows 集成测试在 Windows 上到底能不能通过,现在是未知的。** 这个 job 从未执行过。如果合入后它开始报红,那些失败是死 job 一直掩盖着的既有破损,而不是本 PR 引入的回归。任务计划要求那时停下报告,而不是把它弄绿。
- nightly 跑道会因此变长,并开始消耗此前从未用过的 Windows runner 时间。
- 没有任何机制阻止这份选择逻辑被复制出第四份。建议中的那道零门集治理门能治住症状的成因;在它被裁决之前,这里只是一条约定。
- `full-check` 与 `nightly-daemon-soak` 仍然在 manifest 里声明了它们并不通过 runner 执行的门。那是文档漂移而非活缺陷,刻意留着以保持本次改动的范围。

## 参考

- 任务:`task_cfd765534c533898fe0cf357c6`
- 证据:`F-D4CB196D`、`F-BCB21959`
- 决策背景:`dec_630DB4EB94D3CB0B2459C8ABE2`(Windows 降级;集成矩阵永不 required)
- 复核:待进行
