### PR TITLE
fix(soak): record what failed instead of only how many

### DIFF
--- a/tools/soak/daemon-soak.mjs
+++ b/tools/soak/daemon-soak.mjs
@@ -19,6 +19,7 @@ import { buildTimeline, discoverConnLogFiles, loadConnLogRecords, renderTimeline
 const repoRoot = path.resolve(import.meta.dirname, "../..");
 const cliEntry = path.join(repoRoot, "packages/cli/src/index.ts");
 const MIB = 1024 * 1024;
+const workloadFailureEvidenceLimit = 20;
 
 const soakActor = Object.freeze({ principal: { personId: "person-soak" }, executor: null });
 const runtimeDefinition = Object.freeze({ schema: "agent-definition-snapshot/v1", configVersion: 1, instanceId: "instance-soak", installationId: "installation-soak", kindId: "codex", providerId: "openai", model: "gpt-5.6-sol", reasoningEffort: "high", baseUrl: null, authMode: "subscription" });
@@ -97,6 +98,12 @@ export function assessRssTrend({ samples, maxGrowthBytes, maxSlopeBytesPerMinute
   };
 }
 
+export function assessWorkload({ requests, failures, failureEvidence, failureEvidenceDropped, failureEvidenceLimit }) {
+  const prefix = failures === 0 ? "PASS" : "FAIL";
+  const evidence = failures === 0 ? "" : `; ${failureEvidence.join("; ")}${failureEvidenceDropped === 0 ? "" : `${failureEvidence.length > 0 ? "; " : ""}failure evidence truncated: ${failureEvidenceDropped} additional failure(s) omitted after ${failureEvidenceLimit} record(s)`}`;
+  return { ok: failures === 0, message: `${prefix} workload requests: ${requests} completed, ${failures} failed${evidence}` };
+}
+
 function percentile(values, fraction) {
   if (values.length === 0) return Number.POSITIVE_INFINITY;
   const sorted = [...values].sort((left, right) => left - right);
@@ -146,7 +153,7 @@ async function runSoak(config = readConfig()) {
     const taskIds = Array.from({ length: config.taskCount }, (_, index) => `task_soak_${String(index).padStart(6, "0")}`);
     const warmup = await runLoadPhase({ endpoint, repoId, taskIds, durationMs: config.warmupMs, concurrency: config.concurrency, requestIntervalMs: config.requestIntervalMs, helloProbeIntervalMs: config.helloProbeIntervalMs, sampleRssPid: null });
     console.log(`[soak] warmup ${config.warmupMs}ms requests=${warmup.requests} failures=${warmup.failures}`);
-    const load = await runLoadPhase({ endpoint, repoId, taskIds, durationMs: config.durationMs, concurrency: config.concurrency, requestIntervalMs: config.requestIntervalMs, helloProbeIntervalMs: config.helloProbeIntervalMs, sampleRssPid: child.pid });
+    const load = await runLoadPhase({ endpoint, repoId, taskIds, durationMs: config.durationMs, concurrency: config.concurrency, requestIntervalMs: config.requestIntervalMs, helloProbeIntervalMs: config.helloProbeIntervalMs, sampleRssPid: child.pid, workloadMethodOverride: config.workloadMethodOverride });
     console.log(`[soak] load ${config.durationMs}ms requests=${load.requests} failures=${load.failures} hello-probes=${load.helloSamplesMs.length} rss-samples=${load.rssSamples.length}`);
 
     let streamAttached = false, streamLost = null;
@@ -175,12 +182,12 @@ async function runSoak(config = readConfig()) {
     const hello = assessHelloLatency({ clientSamplesMs: load.helloSamplesMs, daemon: normal, maxP99Ms: config.maxHelloP99Ms });
     const rss = assessRssTrend({ samples: load.rssSamples, maxGrowthBytes: config.maxRssGrowthBytes, maxSlopeBytesPerMinute: config.maxRssSlopeBytesPerMinute });
     const workload = { ...load, helloSamplesMs: undefined, rssSamples: undefined, warmupRequests: warmup.requests, warmupFailures: warmup.failures };
-    const assertions = [connections, hello, rss, { ok: load.failures === 0, message: `${load.failures === 0 ? "PASS" : "FAIL"} workload requests: ${load.requests} completed, ${load.failures} failed` }];
+    const assertions = [connections, hello, rss, assessWorkload(load)];
     const report = { schema: "daemon-nightly-soak/v1", generatedAt: new Date().toISOString(), config, fixture: { tasks: config.taskCount, events: config.eventCount, method: "deterministic canonical event generator committed as the fixture's initial Git snapshot" }, workload, assertions, rssSamples: load.rssSamples, helloSamplesMs: load.helloSamplesMs, normalTimeline: normal, faultTimeline: fault, streamLost };
     writeFileSync(path.join(resultsDir, "summary.json"), `${JSON.stringify(report, null, 2)}\n`, "utf8");
     writeFileSync(path.join(resultsDir, "normal-timeline.txt"), `${renderTimeline(normal)}\n`, "utf8");
     writeFileSync(path.join(resultsDir, "fault-timeline.txt"), `${renderTimeline(fault)}\n`, "utf8");
-    writeFileSync(path.join(resultsDir, "daemon-output.log"), daemonOutput.join(""), "utf8");
+    writeFileSync(path.join(resultsDir, "daemon-output.log"), renderDaemonOutput(daemonOutput), "utf8");
     for (const assertion of assertions) console.log(assertion.message);
     console.log(`[soak] artifacts=${resultsDir}`);
     if (assertions.some(({ ok }) => !ok)) throw new Error("nightly soak invariants failed");
@@ -189,7 +196,7 @@ async function runSoak(config = readConfig()) {
     detach?.();
     if (rejectServer) await closeServer(rejectServer).catch(() => undefined);
     await stopChild(child);
-    if (daemonOutput.length > 0 && !existsSync(path.join(resultsDir, "daemon-output.log"))) writeFileSync(path.join(resultsDir, "daemon-output.log"), daemonOutput.join(""), "utf8");
+    if (!existsSync(path.join(resultsDir, "daemon-output.log"))) writeFileSync(path.join(resultsDir, "daemon-output.log"), renderDaemonOutput(daemonOutput), "utf8");
     rmSync(parent, { recursive: true, force: true });
   }
 }
@@ -206,17 +213,17 @@ function initializeFixture({ rootDir, userRoot, repoId, events }) {
   registerDaemonRepo({ canonicalRoot: rootDir, repoId, userRoot, createConvenienceLinks: false });
 }
 
-async function runLoadPhase({ endpoint, repoId, taskIds, durationMs, concurrency, requestIntervalMs, helloProbeIntervalMs, sampleRssPid }) {
-  const stopAt = Date.now() + durationMs, counts = { requests: 0, failures: 0 }, methods = new Map(), helloSamplesMs = [], rssSamples = [];
-  const workers = Array.from({ length: concurrency }, (_, worker) => workloadClient({ endpoint, repoId, taskIds, stopAt, worker, counts, methods, requestIntervalMs }));
-  const probes = helloProbeLoop({ endpoint, stopAt, samples: helloSamplesMs, counts, helloProbeIntervalMs });
+async function runLoadPhase({ endpoint, repoId, taskIds, durationMs, concurrency, requestIntervalMs, helloProbeIntervalMs, sampleRssPid, workloadMethodOverride = null }) {
+  const startedAt = performance.now(), stopAt = Date.now() + durationMs, counts = { requests: 0, failures: 0, failureEvidence: [], failureEvidenceDropped: 0, failureEvidenceLimit: workloadFailureEvidenceLimit }, methods = new Map(), helloSamplesMs = [], rssSamples = [];
+  const workers = Array.from({ length: concurrency }, (_, worker) => workloadClient({ endpoint, repoId, taskIds, stopAt, startedAt, worker, counts, methods, requestIntervalMs, workloadMethodOverride }));
+  const probes = helloProbeLoop({ endpoint, stopAt, startedAt, samples: helloSamplesMs, counts, helloProbeIntervalMs });
   const rss = sampleRssPid ? rssLoop({ pid: sampleRssPid, stopAt, samples: rssSamples }) : Promise.resolve();
   await Promise.all([...workers, probes, rss]);
   await delay(250);
   return { ...counts, methods: Object.fromEntries([...methods.entries()].sort()), helloSamplesMs, rssSamples };
 }
 
-async function workloadClient({ endpoint, repoId, taskIds, stopAt, worker, counts, methods, requestIntervalMs }) {
+async function workloadClient({ endpoint, repoId, taskIds, stopAt, startedAt, worker, counts, methods, requestIntervalMs, workloadMethodOverride }) {
   let iteration = 0;
   while (Date.now() < stopAt) {
     const batchStart = (worker * 53 + iteration * 17) % taskIds.length;
@@ -231,17 +238,17 @@ async function workloadClient({ endpoint, repoId, taskIds, stopAt, worker, count
       ["repo.tasks.list", { repo: { repoId }, payload: { limit: 50 } }],
       ["daemon.status", {}]
     ];
-    const [method, params] = options[(worker + iteration) % options.length];
+    const [method, params] = workloadMethodOverride === null ? options[(worker + iteration) % options.length] : [workloadMethodOverride, {}];
     try {
       const result = await requestDaemonJsonRpcAt(endpoint, method, params, 1_000, 5_000);
-      if (result.ok !== true) counts.failures += 1;
-    } catch { counts.failures += 1; }
+      if (result.ok !== true) { counts.failures += 1; recordLoadFailure({ counts, method, startedAt, failure: result }); }
+    } catch (error) { counts.failures += 1; recordLoadFailure({ counts, method, startedAt, failure: error }); }
     counts.requests += 1; methods.set(method, (methods.get(method) ?? 0) + 1); iteration += 1;
     await delay(requestIntervalMs);
   }
 }
 
-async function helloProbeLoop({ endpoint, stopAt, samples, counts, helloProbeIntervalMs }) {
+async function helloProbeLoop({ endpoint, stopAt, startedAt, samples, counts, helloProbeIntervalMs }) {
   while (Date.now() < stopAt) {
     let socket;
     try {
@@ -249,11 +256,30 @@ async function helloProbeLoop({ endpoint, stopAt, samples, counts, helloProbeInt
       const client = new JsonRpcLineClient(socket, socket), started = performance.now();
       const result = await client.request("protocol.hello", { protocolVersion: currentDaemonProtocolVersion }, 5_000);
       samples.push(performance.now() - started);
-      if (result.ok !== true) counts.failures += 1;
+      if (result.ok !== true) { counts.failures += 1; recordLoadFailure({ counts, method: "protocol.hello", startedAt, failure: result }); }
       client.close();
-    } catch { counts.failures += 1; socket?.destroy(); }
+    } catch (error) { counts.failures += 1; recordLoadFailure({ counts, method: "protocol.hello", startedAt, failure: error }); socket?.destroy(); }
     await delay(helloProbeIntervalMs);
   }
+}
+
+export function recordLoadFailure({ counts, method, startedAt, failure }) {
+  if (counts.failureEvidence.length >= counts.failureEvidenceLimit) { counts.failureEvidenceDropped += 1; return; }
+  counts.failureEvidence.push(`t+${Math.round(performance.now() - startedAt)}ms ${method} failed: ${describeFailure(failure)}`);
+}
+
+function describeFailure(failure) {
+  const record = failure !== null && typeof failure === "object" ? failure : null;
+  const nested = record?.error !== null && typeof record?.error === "object" ? record.error : null;
+  const code = typeof nested?.code === "string" ? nested.code : typeof record?.code === "string" ? record.code : null;
+  const detail = failure instanceof Error ? failure.message : typeof nested?.hint === "string" ? nested.hint : typeof record?.message === "string" ? record.message : typeof record?.summary === "string" ? record.summary : null;
+  return `${code === null ? "error" : `code=${code}`}${detail === null ? " (no diagnostic text returned)" : `; ${detail}`}`;
+}
+
+export function renderDaemonOutput(chunks) {
+  const output = chunks.join(""), bytes = Buffer.byteLength(output);
+  if (bytes > 0) return `[soak] captured daemon stdout/stderr: ${bytes} byte(s)\n${output}`;
+  return "[soak] captured daemon stdout/stderr: 0 byte(s)\n[soak] no daemon stdout/stderr was emitted. This is expected: normal `ha daemon serve` startup, service, and cooperative shutdown intentionally write no stdio. This capture is working; persistent daemon diagnostics use lifecycle, connection, and request log sinks.\n";
 }
 
 async function rssLoop({ pid, stopAt, samples }) {
@@ -296,16 +322,17 @@ async function waitForAttachedRepo({ child, endpoint, repoId, timeoutMs }) {
   throw new Error(`daemon did not attach ${repoId} within ${timeoutMs}ms`);
 }
 
-function readConfig(env = process.env) {
+export function readConfig(env = process.env) {
   return {
     taskCount: positive(env.HARNESS_SOAK_TASKS, 1_377), eventCount: positive(env.HARNESS_SOAK_EVENTS, 26_650),
     durationMs: positive(env.HARNESS_SOAK_DURATION_MS, 120_000), warmupMs: positive(env.HARNESS_SOAK_WARMUP_MS, 30_000), faultDurationMs: positive(env.HARNESS_SOAK_FAULT_MS, 10_000), startupTimeoutMs: positive(env.HARNESS_SOAK_STARTUP_TIMEOUT_MS, 300_000), concurrency: positive(env.HARNESS_SOAK_CONCURRENCY, 8), requestIntervalMs: positive(env.HARNESS_SOAK_REQUEST_INTERVAL_MS, 500), helloProbeIntervalMs: positive(env.HARNESS_SOAK_HELLO_INTERVAL_MS, 500),
-    maxFaultConnections: positive(env.HARNESS_SOAK_MAX_FAULT_CONNECTIONS, 6), maxHelloP99Ms: positive(env.HARNESS_SOAK_MAX_HELLO_P99_MS, 500), maxRssGrowthBytes: positive(env.HARNESS_SOAK_MAX_RSS_GROWTH_MIB, 32) * MIB, maxRssSlopeBytesPerMinute: positive(env.HARNESS_SOAK_MAX_RSS_SLOPE_MIB_PER_MIN, 12) * MIB,
+    maxFaultConnections: positive(env.HARNESS_SOAK_MAX_FAULT_CONNECTIONS, 6), maxHelloP99Ms: positive(env.HARNESS_SOAK_MAX_HELLO_P99_MS, 500), maxRssGrowthBytes: positive(env.HARNESS_SOAK_MAX_RSS_GROWTH_MIB, 32) * MIB, maxRssSlopeBytesPerMinute: positive(env.HARNESS_SOAK_MAX_RSS_SLOPE_MIB_PER_MIN, 12) * MIB, workloadMethodOverride: optionalText(env.HARNESS_SOAK_WORKLOAD_METHOD_OVERRIDE),
     resultsDir: env.HARNESS_SOAK_RESULTS_DIR || "tmp/soak-results"
   };
 }
 
 function positive(value, fallback) { const parsed = value === undefined ? fallback : Number(value); if (!Number.isInteger(parsed) || parsed < 1) throw new Error(`soak configuration must be positive integers; received ${value}`); return parsed; }
+function optionalText(value) { if (value === undefined) return null; if (typeof value !== "string" || value.length === 0) throw new Error("HARNESS_SOAK_WORKLOAD_METHOD_OVERRIDE must be a non-empty method name"); return value; }
 function git(rootDir, ...args) { execFileSync("git", ["-C", rootDir, ...args], { stdio: "ignore" }); }
 function delay(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
 function listen(server, endpoint) { return new Promise((resolve, reject) => { server.once("error", reject); server.listen(endpoint, () => { server.off("error", reject); resolve(); }); }); }

--- a/tools/soak/daemon-soak.test.mjs
+++ b/tools/soak/daemon-soak.test.mjs
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { parseCanonicalEvent, serializeCanonicalEvent } from "../../packages/kernel/src/index.ts";
-import { assessConnections, assessHelloLatency, assessRssTrend, createSoakEvents } from "./daemon-soak.mjs";
+import { assessConnections, assessHelloLatency, assessRssTrend, assessWorkload, createSoakEvents, recordLoadFailure, renderDaemonOutput } from "./daemon-soak.mjs";
 
 test("scale ledger generator emits the requested valid event and task counts", () => {
   const events = createSoakEvents({ taskCount: 3, eventCount: 12 });
@@ -46,4 +46,22 @@ test("RSS assessment accepts a plateau and rejects sustained monotonic growth", 
   const result = assessRssTrend({ samples: climb, maxGrowthBytes: 16 * mib, maxSlopeBytesPerMinute: 8 * mib });
   assert.equal(result.ok, false);
   assert.match(result.message, /RSS trend/u);
+});
+
+test("workload failures retain bounded, self-explanatory evidence", () => {
+  const counts = { requests: 3, failures: 3, failureEvidence: [], failureEvidenceDropped: 0, failureEvidenceLimit: 2 }, startedAt = performance.now();
+  for (const method of ["repo.tasks.list", "protocol.hello", "daemon.status"]) recordLoadFailure({ counts, method, startedAt, failure: Object.assign(new Error("the daemon did not answer within 5s"), { code: "daemon_response_timeout" }) });
+  assert.equal(counts.failureEvidence.length, 2);
+  assert.equal(counts.failureEvidenceDropped, 1);
+  assert.match(counts.failureEvidence[0], /^t\+\d+ms repo\.tasks\.list failed: code=daemon_response_timeout; the daemon did not answer within 5s$/u);
+  const assessment = assessWorkload(counts);
+  assert.equal(assessment.ok, false);
+  assert.match(assessment.message, /protocol\.hello failed/u);
+  assert.match(assessment.message, /failure evidence truncated: 1 additional failure\(s\) omitted after 2 record\(s\)/u);
+});
+
+test("daemon output artifact declares that a normal empty stdio capture is expected", () => {
+  const output = renderDaemonOutput([]);
+  assert.match(output, /captured daemon stdout\/stderr: 0 byte\(s\)/u);
+  assert.match(output, /This capture is working/u);
 });


### PR DESCRIPTION
# English

## Summary

The nightly soak lane reported `FAIL workload requests: 1747 completed, 8 failed` and nothing else. What those eight failures were was not recoverable from the artifacts: `summary.json` carried the count and no error type, timestamp, or method attribution, and `daemon-output.log` was zero bytes. Locating the real cause took four rounds of manual cross-referencing between the timeline's method table and the RSS samples.

The evidence was thrown away at a specific line. In `workloadClient`:

```js
} catch { counts.failures += 1; }
```

An empty catch — the error variable was never even bound. The adjacent `result.ok !== true` branch discarded the response's error content the same way. **And `method` was already in scope**, so attributing the failure cost nothing there.

**The same file already contained the correct pattern.** The three core invariants each build a `failures` array of complete sentences (`` `${normal.connections.stillOpen} normal-load connection(s) remained open` ``). Only the workload assertion was an inline object reading a bare counter.

## What Changed

- **`assessWorkload` is now an exported function** shaped like the other three assessors, instead of an inline object literal.
- **Four discard sites now record evidence**, not two. The mission named the two in `workloadClient`; the worker also found and fixed the two in `helloProbeLoop`, which are the same family.
- **Each record carries elapsed time, method, and error**: `t+13ms repo.task.dispatches failed: code=invalid_request; params.repo must be an object; params.payload must be an object`
- **Truncation is bounded and self-declaring.** The first 20 records are kept; beyond that the assertion message states how many were omitted and after what limit, rather than dropping them silently.
- **`daemon-output.log` explains itself when empty.** The zero bytes were not a broken collector — the daemon is simply silent under normal operation. The artifact now says so, instead of leaving the next reader to suspect the capture.

## Evidence

**Negative control, not a field-exists check.** A field that is added but never populated is indistinguishable from the current state. The worker drove a run to **1,896 real failures**, and the artifact kept 20 records while stating that **1,876 were omitted**. Both halves matter: the records prove evidence is captured, the stated count proves truncation does not lie.

**Load timing was measured, not assumed.** This is a soak lane, so recording evidence on the hot path could change what it measures. Before and after: 1,871 versus 1,851 requests, client P50 ~0.254ms unchanged, P99 377ms versus 419ms. No meaningful slowdown.

**The empty log was diagnosed before being treated.** The mission asked for this to be answered first and separately, because it was the more likely place for a surprise. The answer is benign, and the fix is to say so in the artifact rather than to change the capture.

The failure-injection path is an environment variable (`HARNESS_SOAK_WORKLOAD_METHOD_OVERRIDE`) defaulting to null, so the negative control is reproducible in CI rather than a one-off manual demonstration.

## Task And Scope

- Harness task: `task_720e324f195e13109a080d5b49` (second slice; the first slice shipped in #1663)
- Evidence: fact `F-D065E109`
- Branch: `codex/soak-selfevidence`
- Public scope: `tools/soak/daemon-soak.mjs` and its test
- Private planning/evidence updated: yes
- Out of scope: the three forbidden files listed below; the assertions themselves, whose strictness is unchanged

## Version Impact

- Version: no version change; this touches a CI soak harness only, with no package surface or wire-contract change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/soak/daemon-soak.mjs`, which the gate manifest lists as a protected surface. Its test file is not listed and is changed alongside it.
- Authority: `task_720e324f195e13109a080d5b49`, whose plan authorizes `tools/soak/**` as this task's write scope and states the judging criterion (a failure record that reads on its own). No gate threshold, required check, or assertion strictness is changed — only what a failing assertion prints. Separately, `.github/workflows/rewrite-ci.yml`, `tools/gate-manifest.json`, and `tools/run-manifest-gates.mjs` were declared off-limits in the mission because another line was editing them concurrently; the worker confirms it did not touch them.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: `4713a393d1acc3a7e9876acad194c13b1235573f`
- Branch merge-base with `origin/main`: `4713a393d1acc3a7e9876acad194c13b1235573f`
- Last `git fetch origin` time: 2026-08-21, before this PR
- Sync method: branch base already equals current `origin/main`
- Public diff command: `git diff origin/main...codex/soak-selfevidence`
- Private evidence commit/path: `harness/tasks/task_720e324f195e13109a080d5b49-soak-lane-daemon-output-log/artifacts/report-soak-selfevidence.md`
- Reviewer evidence path: same report, the negative-control and load-timing sections
- GitHub Actions `rewrite-ci` run URL: pending on this PR

Production-Delta: +0/-0

- [x] `git diff --check`
- [x] `npm run check:local` (exit 0)
- [x] Targeted tests 6/6
- [x] `node tools/gates/line-budget.mjs` — run by the worker because the mission named it alongside `check:local`
- [x] **Negative control with 1,896 injected failures**, 20 records kept, 1,876 declared omitted
- [x] Load-timing comparison before and after, on the full default lane
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: the historical GitHub artifacts were not re-downloaded; all new evidence comes from full local lane runs. Not run: full `npm run check` locally — the authoritative full gate surface is GitHub CI per the repository stop-point policy.

## Review Evidence

- CEO located the discard site and the in-file positive pattern before dispatch, and put both in the mission with line numbers, so the worker was not asked to rediscover them.
- CEO read the diff rather than accepting the report: the four discard sites now bind their error, `recordLoadFailure` checks its limit before pushing, and the test hook is an env var defaulting to null so it cannot affect a normal run.
- The worker widened the fix beyond what the mission named, to the two `helloProbeLoop` sites. That is the sibling scan working as intended.
- **A CEO declaration error was caught and corrected before merge.** The governance section first said no protected surface was touched. The gate accepted that body once a task reference was added, but its output ("1 protected path declared") contradicted the claim, and `tools/soak/daemon-soak.mjs` is in fact listed as a protected surface. The gate checks that a reference exists, not that the yes/no answer is true — so passing it is not evidence the declaration is correct. The section now says yes and names the file.
- Reviewer subagent: not used; the diff is two files and the load-bearing evidence is a negative control with stated counts.
- Human review: pending
- Blocking findings: none

## Residual Risk

- The 20-record limit is a fixed constant. A run whose failures are diverse beyond the first 20 records will have its variety truncated, and the message reports how many were dropped but not what they were.
- Records are kept in memory for the duration of the run. Bounded at 20, so the footprint is small, but it is a bound rather than a stream.
- The evidence proves failures are now attributable; it does not prove the eight failures from run 32454215119 would have been diagnosable, because that run cannot be replayed.
- Timing was compared on one machine over one pair of runs. The absence of a slowdown is evidence, not a guarantee across runner classes.

## References

- Task: `task_720e324f195e13109a080d5b49`
- Evidence: fact `F-D065E109`, report `report-soak-selfevidence.md`
- Review: pending

---

# 中文

## 概要

夜间压力测试跑道报出 `FAIL workload requests: 1747 completed, 8 failed`,然后就没有了。那 8 个失败是什么,从产物里根本恢复不出来:`summary.json` 只有计数,没有错误类型、时刻或方法归属,`daemon-output.log` 是 0 字节。定位真凶用了**四轮**人工交叉比对——在时间线的方法表和内存采样之间来回对照。

证据是在一个具体的位置被丢掉的。`workloadClient` 里:

```js
} catch { counts.failures += 1; }
```

一个空的捕获块,**连错误变量都没绑定**。相邻的 `result.ok !== true` 分支同样扔掉了响应里的错误内容。**而 `method` 就在作用域里**,在那个位置记录方法归属是零成本的。

**同一个文件里本来就有正确的样板。** 三条核心不变量各自维护一个 `failures` 数组,每条都是完整的句子(`` `${normal.connections.stillOpen} normal-load connection(s) remained open` ``)。只有 workload 那条是一个读裸计数器的内联对象。

## 改动内容

- **`assessWorkload` 现在是一个导出函数**,形状与另外三个评估函数一致,不再是内联对象字面量。
- **四处丢弃点现在都记录证据,而不是两处。** 派工书点名的是 `workloadClient` 里的两处;worker 自己找到并修了 `helloProbeLoop` 里的另外两处,它们是同族。
- **每条记录带经过时间、方法与错误**:`t+13ms repo.task.dispatches failed: code=invalid_request; params.repo must be an object; params.payload must be an object`
- **截断有界且自证。** 保留前 20 条,超出部分由断言消息说明省略了多少条、在什么上限之后,而不是悄悄丢掉。
- **`daemon-output.log` 为空时会自己解释。** 那 0 字节不是采集坏了——daemon 在正常运行下本来就是静默的。产物现在会这么说,而不是留给下一个读者去怀疑采集。

## 证据

**阴性对照,不是"字段存在"检查。** 一个加上了但永远不被填充的字段,与现状无法区分。worker 驱动出**1,896 次真实失败**,产物保留 20 条,同时声明**1,876 条被省略**。两半都重要:记录证明证据被抓到了,声明的数字证明截断没有撒谎。

**负载时序是被测量的,不是假设的。** 这是压力测试跑道,在热路径上记录证据可能改变它测量的东西。改动前后:1,871 与 1,851 次请求,客户端 P50 均约 0.254 毫秒,P99 分别为 377 与 419 毫秒。没有显著拖慢。

**空日志是先诊断后处置的。** 派工书要求先单独回答这个问题,因为它是更可能出现意外的那个。答案是良性的,处置方式是在产物里说清楚,而不是去改采集。

失败注入路径是一个环境变量(`HARNESS_SOAK_WORKLOAD_METHOD_OVERRIDE`),默认为 null,因此阴性对照在 CI 里可复现,而不是一次性的手工演示。

## 任务与范围

- Harness 任务:`task_720e324f195e13109a080d5b49`(第二片;第一片随 #1663 合入)
- 证据:fact `F-D065E109`
- 分支:`codex/soak-selfevidence`
- 公开范围:`tools/soak/daemon-soak.mjs` 及其测试
- 私有计划 / 证据是否已更新:yes
- 范围外:下方列出的三个禁区文件;以及断言本身,其严格程度未变

## 版本影响

- 版本:不改版本;本次只触碰一个 CI 压力测试装置,不改包对外面也不改 wire 契约
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:yes
- protected surface 范围:`tools/soak/daemon-soak.mjs`,它被 gate manifest 列为 protected surface。其测试文件不在清单内,随它一同改动。
- 依据:`task_720e324f195e13109a080d5b49`,其计划把 `tools/soak/**` 授权为本任务的写入范围,并写明了判据(失败记录要能独立读懂)。没有改变任何门的阈值、required check 或断言严格程度——只改变了断言失败时打印什么。另外,`.github/workflows/rewrite-ci.yml`、`tools/gate-manifest.json` 与 `tools/run-manifest-gates.mjs` 在派工书里被划为禁区,因为另一条线正在并发编辑它们;worker 确认未触碰。
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无

## 验证

- `origin/main` 基准 SHA:`4713a393d1acc3a7e9876acad194c13b1235573f`
- 当前分支与 `origin/main` 的 merge-base:`4713a393d1acc3a7e9876acad194c13b1235573f`
- 最近一次 `git fetch origin` 时间:2026-08-21,开 PR 前
- 同步方式:分支 base 已等于当前 `origin/main`
- 公开 diff 命令:`git diff origin/main...codex/soak-selfevidence`
- 私有证据 commit/path:`harness/tasks/task_720e324f195e13109a080d5b49-soak-lane-daemon-output-log/artifacts/report-soak-selfevidence.md`
- Reviewer 证据路径:同一报告的阴性对照与负载时序两节
- GitHub Actions `rewrite-ci` run URL:本 PR 上待跑
- 生产净变化 +0/-0(机读声明见英文段的 `Production-Delta` 行;改动全在 `tools/`,不计入生产行)
- [x] `git diff --check`
- [x] `npm run check:local`(exit 0)
- [x] 定向测试 6/6
- [x] `node tools/gates/line-budget.mjs` —— worker 主动跑了,因为派工书把它与 `check:local` 并列点名
- [x] **1,896 次注入失败的阴性对照**,保留 20 条,声明 1,876 条被省略
- [x] 改动前后的负载时序对照,跑的是默认完整跑道
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:历史 GitHub 产物未重新下载,新增证据全部来自本机完整跑道实际产物。未运行:本地完整 `npm run check`——按本仓停止点政策,完整权威门面在 GitHub CI。

## 审查证据

- CEO 在派工前就定位了丢弃点与文件内的正面样板,并带行号写进派工书,因此没有让 worker 重新发现一遍。
- CEO 读了 diff 而不是采信报告:四处丢弃点现在都绑定了错误变量,`recordLoadFailure` 在 push 前检查上限,测试钩子是默认为 null 的环境变量因而不会影响正常运行。
- worker 把修复扩大到了派工书没点名的两处 `helloProbeLoop`。这正是兄弟扫描应有的作用。
- **CEO 的一处声明错误在合并前被发现并更正。** 治理声明段起初写的是未触碰 protected surface。加上任务引用之后门放行了那份 body,但它的输出(「declared 1 protected path」)与该断言矛盾,而 `tools/soak/daemon-soak.mjs` 确实在 protected surface 清单里。**这道门检查的是"有没有引用",不是"是与否答得对不对"——所以它放行不构成声明正确的证据。** 该段现已改为 yes 并点名文件。
- Reviewer subagent:未使用;diff 只有两个文件,承重证据是一次带确切计数的阴性对照。
- 人工复核:待进行
- 阻塞性 findings:无

## 残余风险

- 20 条的上限是一个固定常量。如果某次运行的失败种类多样、超出前 20 条,它的多样性会被截断,而消息只报省略了多少条、不报它们是什么。
- 记录在运行期间保存在内存里。上限 20 条所以占用很小,但那是一个上界而不是流式处理。
- 证据证明的是失败现在可归因,**不能**证明 run 32454215119 的那 8 个失败当时就能被诊断出来,因为那次运行无法重放。
- 时序只在一台机器、一对运行上对照过。没有拖慢是证据,不是跨 runner 等级的保证。

## 参考

- 任务:`task_720e324f195e13109a080d5b49`
- 证据:fact `F-D065E109`、报告 `report-soak-selfevidence.md`
- 复核:待进行
