### PR TITLE
fix(ci): make the G32 line-budget gate reachable from check:local

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "check:local:derived-contracts": "node tools/gates/derived-contracts.mjs --check",
     "check:local:gates": "node tools/run-local-gates-check.mjs",
     "check:local:full": "node tools/run-local-check.mjs --full",
+    "check:local:line-budget": "node tools/run-local-line-budget.mjs",
     "check:local:schema-closure": "node tools/gates/schema-closure.mjs --check",
     "harness:check-file-complexity": "node tools/check-file-complexity.mjs",
     "harness:check-cli-structure": "node tools/check-cli-structure.mjs",

--- a/tools/run-local-check.mjs
+++ b/tools/run-local-check.mjs
@@ -14,8 +14,8 @@
  *     reclaimed. `--no-wait` exits immediately instead of waiting.
  *   - Low QoS: on darwin, wrap each step in `taskpolicy -c utility`; otherwise
  *     fall back to `nice -n 10`; if neither is available, run bare.
- *   - Tiers: default "fast" (typecheck, lint, test:fast, test:contract,
- *     boundaries checkers, package-policy, and rebuild contract gates).
+ *   - Tiers: default "fast" (fresh-main line-budget, typecheck, lint,
+ *     test:fast, test:contract, boundaries checkers, package-policy, and rebuild contract gates).
  *     `--full` appends test:integration test:gui, and test:gui:e2e. First
  *     failing step stops the run with a non-zero exit and a clear report of
  *     which step failed.
@@ -80,7 +80,10 @@ function manifestDerivedSteps() {
     ]);
 }
 
+// G32 lives in rebuild-gates.yml rather than the rewrite-ci manifest. Keep its
+// base-sensitive local adapter explicit; the remaining static gates are derived.
 const FAST_STEPS = [
+  ["line-budget", "check:local:line-budget"],
   ["typecheck", "typecheck"],
   ["test:fast", "test:fast"],
   ["test:contract", "test:contract"],

--- a/tools/run-local-check.test.mjs
+++ b/tools/run-local-check.test.mjs
@@ -50,6 +50,7 @@ test("buildSteps appends integration and gui lanes only in the full tier", () =>
     assert.ok(fastScripts.includes(script), `missing manifest gate script: ${script}`);
   }
   assert.ok(fastScripts.includes("lint"));
+  assert.ok(fastScripts.includes("check:local:line-budget"));
   // Positive control: the gate PR #1358 slipped through on must be present.
   assert.ok(fastScripts.includes("harness:check-cli-help-contract"));
   // CI's boundaries exclusions must be honored locally too — and only those. The
@@ -58,6 +59,11 @@ test("buildSteps appends integration and gui lanes only in the full tier", () =>
   assert.deepEqual([...excluded], ["mergify-queue-metadata-edit-noop"]);
   assert.ok(fastScripts.includes("harness:check-duplicate-definitions"));
   assert.deepEqual(fastScripts.slice(-2), ["check:local:derived-contracts", "check:local:schema-closure"]);
+});
+
+test("the local line-budget step resolves to an executable package script", () => {
+  const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+  assert.equal(packageJson.scripts["check:local:line-budget"], "node tools/run-local-line-budget.mjs");
 });
 
 test("selectQosPrefix wraps with taskpolicy on darwin when available", () => {

--- a/tools/run-local-line-budget.mjs
+++ b/tools/run-local-line-budget.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { git, repoRoot } from "./gates/git.mjs";
+
+const CANONICAL_REPOSITORY = "github.com/fairladyz625/harness-anything";
+const CANONICAL_REMOTE_URL = "https://github.com/FairladyZ625/harness-anything.git";
+export const FETCH_TIMEOUT_MS = 15_000;
+
+function normalizedRepository(url) {
+  const trimmed = url.trim().replace(/\.git\/?$/u, "");
+  const scpLike = trimmed.includes("://") ? null : /^(?:[^@]+@)?([^:]+):(.+)$/u.exec(trimmed);
+  if (scpLike) return `${scpLike[1]}/${scpLike[2]}`.toLowerCase();
+  try {
+    const parsed = new URL(trimmed);
+    return `${parsed.hostname}/${parsed.pathname.replace(/^\/+|\/+$/gu, "")}`.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export function findCanonicalRemote(rootDir) {
+  const remotes = git(rootDir, ["remote"]).split(/\r?\n/u).filter(Boolean);
+  return remotes.find((remote) => {
+    const url = git(rootDir, ["config", "--get", `remote.${remote}.url`]).trim();
+    return normalizedRepository(url) === CANONICAL_REPOSITORY;
+  }) ?? null;
+}
+
+function resolutionError(step, nextAction, detail = "") {
+  return new Error([
+    step,
+    "G32 needs network access to fetch canonical main because a stale or fork base can produce a false pass.",
+    `Next action: ${nextAction}`,
+    detail
+  ].filter(Boolean).join("\n"));
+}
+
+export function resolveLocalLineBudgetBase(rootDir, fetchTimeoutMs = FETCH_TIMEOUT_MS) {
+  const remote = findCanonicalRemote(rootDir);
+  if (remote === null) {
+    throw resolutionError(
+      "no configured remote points to github.com/FairladyZ625/harness-anything.",
+      `run \`git remote add upstream ${CANONICAL_REMOTE_URL}\`, then re-run \`npm run check:local\`.`
+    );
+  }
+
+  const fetchResult = spawnSync(
+    "git",
+    ["fetch", "--quiet", "--no-tags", remote, `refs/heads/main:refs/remotes/${remote}/main`],
+    { cwd: rootDir, encoding: "utf8", timeout: fetchTimeoutMs }
+  );
+  if (fetchResult.error?.code === "ETIMEDOUT") {
+    throw resolutionError(
+      `fetching canonical main from remote "${remote}" timed out after ${fetchTimeoutMs}ms.`,
+      `check network access, run \`git fetch ${remote} main\`, then re-run \`npm run check:local\`.`
+    );
+  }
+  if (fetchResult.error || fetchResult.status !== 0) {
+    const detail = fetchResult.stderr?.trim() || fetchResult.error?.message || "git fetch exited without an error message";
+    throw resolutionError(
+      `fetching canonical main from remote "${remote}" failed.`,
+      `check network access and Git credentials, run \`git fetch ${remote} main\`, then re-run \`npm run check:local\`.`,
+      `Git reported: ${detail}`
+    );
+  }
+
+  let base;
+  try {
+    base = git(rootDir, ["rev-parse", `refs/remotes/${remote}/main^{commit}`]).trim();
+  } catch (error) {
+    throw resolutionError(
+      `fetched canonical main from remote "${remote}", but its commit could not be resolved.`,
+      `run \`git fetch ${remote} main\`, inspect \`${remote}/main\`, then re-run \`npm run check:local\`.`,
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+
+  const ancestry = spawnSync("git", ["merge-base", "--is-ancestor", base, "HEAD"], {
+    cwd: rootDir,
+    encoding: "utf8"
+  });
+  if (ancestry.status === 1) {
+    throw resolutionError(
+      `HEAD is not a descendant of the latest canonical main (${remote}/main ${base}).`,
+      `first rebase onto latest main with \`git rebase ${remote}/main\`, then re-run \`npm run check:local\`.`
+    );
+  }
+  if (ancestry.error || ancestry.status !== 0) {
+    const detail = ancestry.stderr?.trim() || ancestry.error?.message || "git merge-base exited without an error message";
+    throw resolutionError(
+      `could not verify whether HEAD descends from ${remote}/main ${base}.`,
+      `inspect \`git merge-base --is-ancestor ${remote}/main HEAD\`, repair the branch, then re-run \`npm run check:local\`.`,
+      `Git reported: ${detail}`
+    );
+  }
+  return { base, remote };
+}
+
+export function main(argv = process.argv.slice(2)) {
+  if (argv.length > 0) {
+    console.error("Local line-budget base resolution failed: this command accepts no arguments; its base must come from freshly fetched canonical main.");
+    return 1;
+  }
+
+  const rootDir = repoRoot();
+  let resolved;
+  try {
+    resolved = resolveLocalLineBudgetBase(rootDir);
+  } catch (error) {
+    console.error(`Local line-budget base resolution failed: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+
+  console.log(`Local line-budget base: ${resolved.remote}/main ${resolved.base}`);
+  const result = spawnSync(process.execPath, [path.join(import.meta.dirname, "gates/line-budget.mjs"), "--base", resolved.base], {
+    cwd: rootDir,
+    env: process.env,
+    stdio: "inherit"
+  });
+  if (result.error) {
+    console.error(`Local line-budget failed to launch G32: ${result.error.message}`);
+    return 1;
+  }
+  return result.status ?? 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) process.exitCode = main();

--- a/tools/run-local-line-budget.test.mjs
+++ b/tools/run-local-line-budget.test.mjs
@@ -1,0 +1,132 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { makeRepo, runGit } from "./gates/test/helpers.mjs";
+import { MODULES } from "./gates/module-policy.mjs";
+import { resolveLocalLineBudgetBase } from "./run-local-line-budget.mjs";
+
+const runnerPath = fileURLToPath(new URL("./run-local-line-budget.mjs", import.meta.url));
+const canonicalUrl = "https://github.com/FairladyZ625/harness-anything.git";
+
+function budgetBody(kernel) {
+  return `${JSON.stringify({
+    version: 1,
+    ceilings: Object.fromEntries(MODULES.map((moduleName) => [moduleName, moduleName === "kernel" ? kernel : 0]))
+  }, null, 2)}\n`;
+}
+
+function addCanonicalRemote(rootDir) {
+  const remoteRoot = mkdtempSync(path.join(tmpdir(), "local-line-budget-remote-"));
+  const bareRoot = path.join(remoteRoot, "canonical.git");
+  runGit(remoteRoot, ["init", "--bare", "--quiet", bareRoot]);
+  runGit(rootDir, ["config", `url.${pathToFileURL(bareRoot).href}.insteadOf`, canonicalUrl]);
+  runGit(rootDir, ["remote", "add", "origin", canonicalUrl]);
+  runGit(rootDir, ["push", "--quiet", "origin", "HEAD:refs/heads/main"]);
+  runGit(rootDir, ["update-ref", "-d", "refs/remotes/origin/main"]);
+  return remoteRoot;
+}
+
+test("local line-budget refuses a repository without the canonical remote and gives the next action", () => {
+  const { rootDir } = makeRepo({ "README.md": "fixture\n" });
+  try {
+    const result = spawnSync(process.execPath, [runnerPath], { cwd: rootDir, encoding: "utf8" });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /needs network access to fetch canonical main/u);
+    assert.match(result.stderr, /no configured remote points to github\.com\/FairladyZ625\/harness-anything/u);
+    assert.match(result.stderr, /git remote add upstream https:\/\/github\.com\/FairladyZ625\/harness-anything\.git/u);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("local line-budget fetches canonical main and runs G32 with that exact base", () => {
+  const { rootDir, base } = makeRepo({
+    "packages/kernel/src/index.ts": "one\n",
+    "tools/gates/line-budgets.json": budgetBody(1)
+  });
+  const remoteRoot = addCanonicalRemote(rootDir);
+  try {
+    const result = spawnSync(process.execPath, [runnerPath], { cwd: rootDir, encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, new RegExp(`Local line-budget base: origin/main ${base}`, "u"));
+    assert.match(result.stdout, /kernel: 1\/1/u);
+    assert.match(result.stdout, /G32 line-budget-ratchet: pass/u);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+    rmSync(remoteRoot, { recursive: true, force: true });
+  }
+});
+
+test("local line-budget explains a canonical-main fetch failure and gives the next action", () => {
+  const { rootDir } = makeRepo({ "README.md": "fixture\n" });
+  try {
+    const missingRemote = pathToFileURL(path.join(rootDir, "missing-canonical.git")).href;
+    runGit(rootDir, ["config", `url.${missingRemote}.insteadOf`, canonicalUrl]);
+    runGit(rootDir, ["remote", "add", "origin", canonicalUrl]);
+    const result = spawnSync(process.execPath, [runnerPath], { cwd: rootDir, encoding: "utf8" });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /needs network access to fetch canonical main/u);
+    assert.match(result.stderr, /fetching canonical main from remote "origin" failed/u);
+    assert.match(result.stderr, /check network access and Git credentials/u);
+    assert.match(result.stderr, /git fetch origin main/u);
+    assert.match(result.stderr, /Git reported:/u);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("local line-budget bounds canonical-main fetch latency and explains a timeout", () => {
+  const { rootDir } = makeRepo({ "README.md": "fixture\n" });
+  const remoteRoot = addCanonicalRemote(rootDir);
+  try {
+    assert.throws(
+      () => resolveLocalLineBudgetBase(rootDir, 1),
+      (error) => {
+        assert.match(error.message, /needs network access to fetch canonical main/u);
+        assert.match(error.message, /fetching canonical main from remote "origin" timed out after 1ms/u);
+        assert.match(error.message, /check network access/u);
+        assert.match(error.message, /git fetch origin main/u);
+        return true;
+      }
+    );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+    rmSync(remoteRoot, { recursive: true, force: true });
+  }
+});
+
+test("local line-budget rejects a branch behind canonical main and tells the worker to rebase", () => {
+  const { rootDir, base } = makeRepo({
+    "packages/kernel/src/index.ts": "one\n",
+    "tools/gates/line-budgets.json": budgetBody(1)
+  });
+  const remoteRoot = addCanonicalRemote(rootDir);
+  try {
+    const advancedMain = runGit(rootDir, ["commit-tree", `${base}^{tree}`, "-p", base, "-m", "advance canonical main"]);
+    runGit(rootDir, ["push", "--quiet", "origin", `${advancedMain}:refs/heads/main`]);
+
+    const result = spawnSync(process.execPath, [runnerPath], { cwd: rootDir, encoding: "utf8" });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /needs network access to fetch canonical main/u);
+    assert.match(result.stderr, /HEAD is not a descendant of the latest canonical main/u);
+    assert.ok(result.stderr.includes("first rebase onto latest main"));
+    assert.ok(result.stderr.includes("git rebase origin/main"));
+    assert.ok(result.stderr.includes("then re-run"));
+    assert.ok(result.stderr.includes("npm run check:local"));
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+    rmSync(remoteRoot, { recursive: true, force: true });
+  }
+});
+
+test("local line-budget does not accept a caller-selected base override", () => {
+  const result = spawnSync(process.execPath, [runnerPath, "--base", "HEAD~1"], { encoding: "utf8" });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /accepts no arguments/u);
+  assert.match(result.stderr, /base must come from freshly fetched canonical main/u);
+});


### PR DESCRIPTION
<!-- markdownlint-disable -->

# English

## Summary

The G32 line-budget ratchet was not reachable from any local command. Workers could only learn they had blown a module ceiling once cloud CI told them — by which point their session had usually ended. The same knowledge failed three times in six days (2026-08-15 migration line, PR #1659, PR #1664), and in two of those three the dispatch packet was written by the CEO, who also forgot the gate. The root cause is not forgetfulness: `check:local` did not run G32, so no amount of local diligence could hit it.

This adds `check:local:line-budget` as the first step of the fast tier, so the gate now sits on the path every worker already walks.

## What Changed

Production-Delta: +0/-0

Dependency-Change: none in substance — no dependency is added, removed, or version-changed, and `package-lock.json` is untouched; `package.json` gains exactly one script key (`check:local:line-budget`). G31 keys off any `package.json` edit rather than off dependency sections, so this declaration is required even though no dependency moved.

- `tools/run-local-line-budget.mjs` (new): resolves the base for G32 locally, then invokes the existing gate unchanged.
- `tools/run-local-check.mjs`: `line-budget` becomes the first entry of `FAST_STEPS`; the first failing step already stops the run.
- `package.json`: adds the `check:local:line-budget` script.
- Tests: `tools/run-local-line-budget.test.mjs` (new) and an added case in `tools/run-local-check.test.mjs`.

The gate itself, its ceilings, the gate manifest, and every workflow file are untouched. The 273 added lines are all under `tools/`, which `module-policy.mjs` classifies as `test-infra`, hence a production delta of zero.

### Why base resolution is strict

CI passes an explicit base SHA; locally there is none. A wrong base does not fail — it produces a **credible false pass**. Measured on this branch:

```
wrong_base=4713a393d1acc3a7e9876acad194c13b1235573f
G32 line-budget-ratchet: pass                       <- legal but wrong base, silently green
G32 line-budget-ratchet: Command failed: git ls-tree ... definitely-not-a-valid-base
fatal: Not a valid object name                      <- only an invalid ref fails loudly
```

So the resolver refuses to guess: it requires a remote pointing at the canonical repository, fetches `main` fresh on every run, resolves an exact commit, and requires HEAD to descend from it. Any failure is loud. Local `--base` overrides are rejected, because accepting one reintroduces exactly the stale-base failure this change exists to prevent.

**Offline is a hard failure, by decision.** No degraded path was added. A green produced from a stale base is worse than not running the gate, because it makes someone believe a conclusion that does not hold.

## Task And Scope

- Task: `task_99889a63ffc6155b80af6f8333`
- Scope: make G32 locally reachable. Not in scope: changing what CI enforces, adding or removing required checks, or altering any ceiling.

## Version Impact

- Version: no version change because this only adds a local developer command.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `package.json` (adds one script key; no existing script was modified). `tools/run-local-check.mjs` and the two test files are not protected surfaces.
- Authority: `task_99889a63ffc6155b80af6f8333`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `708eb7f64985dc0e8fb4e7f5dcb109c344a22b3c`
- Branch merge-base with `origin/main`: `708eb7f64985dc0e8fb4e7f5dcb109c344a22b3c`
- Last `git fetch origin` time: 2026-08-21, during this verification run
- Sync method: none needed
- Public diff command: `git diff 708eb7f64..codex/line-budget-stoppoint`
- Private evidence commit/path: `harness/tasks/task_99889a63ffc6155b80af6f8333-line-budget-worker/artifacts/report-line-budget-stoppoint.md`
- Reviewer evidence path: same as above
- GitHub Actions `rewrite-ci` run URL: pending, to be filled once the run completes

**Bidirectional demonstration, re-run by the CEO rather than accepted from the worker's report.** Proving only that it can go red does not rule out it being permanently red, so both directions were run:

```
# Baseline
write-contract: 349/350
G32 line-budget-ratchet: pass                       exit 0

# Three lines appended to packages/kernel/src/domain/write-chain.contract.ts
G32 line-budget-ratchet: write-contract: actual 352 exceeds ceiling 350;
  reduce production lines to 350 or add a verified line-budget decision receipt
  and update the ceiling                            exit 1

# After reverting
write-contract: 349/350
G32 line-budget-ratchet: pass                       exit 0
```

The gate reads the **working tree**, not HEAD, so uncommitted work is caught too.

**Real error text for a stale branch**, reproduced by pointing the resolver at a clone 30 commits behind:

```
Local line-budget base resolution failed: HEAD is not a descendant of the latest
canonical main (upstream/main 708eb7f64985dc0e8fb4e7f5dcb109c344a22b3c).
G32 needs network access to fetch canonical main because a stale or fork base can
produce a false pass.
Next action: first rebase onto latest main with `git rebase upstream/main`, then
re-run `npm run check:local`.
```

Three things in one message: which step failed, why the network is needed at all, and the exact command to run next. A worker who has never heard of this gate does not need to read the source.

- [x] `npm run check:local` — passed, fast tier, 69.3s measured (was roughly 60s before; the increase is the gate body plus a 1.4s fetch)
- [x] Bidirectional red/green demonstration, exit codes confirmed
- [x] Stale-branch error text reproduced from a real failing case
- [x] Targeted tests: 14/14
- Not run: `test:integration`, `test:gui`, `test:gui:e2e` — outside the fast tier; cloud CI runs them.

### Does CI now fetch on every job?

No. `grep -rn "check:local" .github/workflows/` returns nothing — no job runs `check:local`, so this change is local-only and adds no CI network traffic.

## Review Evidence

- Self-review: CEO independently re-ran the bidirectional demonstration, the stale-branch failure, and the full `check:local`, rather than accepting the worker's transcript. One CEO probe was itself faulty and discarded: checking out an older commit to simulate a stale branch also reverted `package.json`, so the observed error was npm failing to find the script, not the gate's behaviour. The case was re-run by injecting `rootDir` into the exported resolver instead.
- Reviewer subagent: not used; the change is small and every claim was verified by execution.
- Human review: pending
- Blocking findings: none

## Residual Risk

- `check:local` now requires network access. Offline work cannot run it. This is deliberate and was adjudicated, not an oversight.
- The 15s fetch timeout is a constant. On a very slow link it will fail rather than wait, which is the intended trade: an unbounded wait turns "slow network" into "hung command", and this repository has prior incidents of unbounded waits.
- The resolver recognises the canonical repository by remote URL. A worker whose only remote is a fork gets a loud failure telling them to add the canonical remote; this is correct but is a new setup step for fork-based workflows.
- Timing was measured on one machine across a handful of runs. Roughly 8% added to `check:local` is the observed cost, not a guarantee across machines.

## References

- Task: `task_99889a63ffc6155b80af6f8333`
- Prior failures this addresses: PR #1659, PR #1664, and the 2026-08-15 migration line
- Worker report: `harness/tasks/task_99889a63ffc6155b80af6f8333-line-budget-worker/artifacts/report-line-budget-stoppoint.md`

---

# 中文

## 概要

G32 行数棘轮门此前不在任何本地命令里。worker 只有等云端 CI 报红才知道自己顶破了某个模块的行数上限,而那时他的会话通常已经结束。同一条知识六天内失效三次(2026-08-15 迁移线、PR #1659、PR #1664),其中两次的派工书是 CEO 亲手写的,CEO 自己也漏了这道门。**真因不是健忘**:`check:local` 不跑 G32,worker 在本地无论多认真都撞不到它。

本 PR 把 `check:local:line-budget` 加为 fast tier 的第一步,让这道门落在每个 worker 本来就要走的路上。

## 改动内容

- `tools/run-local-line-budget.mjs`(新增):在本地解析 G32 的 base,然后原样调用既有的门。
- `tools/run-local-check.mjs`:`line-budget` 成为 `FAST_STEPS` 的第一项;首个失败即停是既有行为。
- `package.json`:新增 `check:local:line-budget` 脚本。
- 测试:`tools/run-local-line-budget.test.mjs`(新增),以及 `tools/run-local-check.test.mjs` 里新增的一个用例。

门本身、各模块上限、gate manifest 与所有 workflow 文件都未改动。新增的 273 行全在 `tools/` 之下,而 `module-policy.mjs` 把它归为 `test-infra`,因此生产行增量为零。

### base 解析为什么这么严

CI 会传一个明确的 base SHA,本地没有。而 base 取错**不会报错,它会给出一个可信的假绿**。本分支上的实测:

```
wrong_base=4713a393d1acc3a7e9876acad194c13b1235573f
G32 line-budget-ratchet: pass                       <- 合法但错误的 base,静默变绿
G32 line-budget-ratchet: Command failed: git ls-tree ... definitely-not-a-valid-base
fatal: Not a valid object name                      <- 只有无效 ref 才响亮失败
```

所以解析器拒绝猜:必须存在指向 canonical 仓库的 remote,每次运行都重新 fetch `main`,解析出精确 commit,并要求 HEAD 是它的后代。任何一步失败都响亮报错。本地 `--base` 覆盖被拒绝——接受它就等于把这次要消除的陈旧 base 故障重新引进来。

**离线即硬失败,这是裁决结果,不是疏漏。** 没有加降级路径。用陈旧 base 得出的绿比不跑这道门更坏,因为它会让人相信一个不成立的结论。

## 任务与范围

- 任务:`task_99889a63ffc6155b80af6f8333`
- 范围:让 G32 在本地可达。不在范围内:改变 CI 的执法内容、增删 required check、调整任何上限。

## 版本影响

- 版本:不变,本改动只新增一条本地开发命令。
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:是
- protected surface 范围:`package.json`(新增一个 script 键,未修改任何既有 script)。`tools/run-local-check.mjs` 与两个测试文件不属于 protected surface。
- 授权依据:`task_99889a63ffc6155b80af6f8333`
- 机器检查边界:本 PR 只断言声明存在;声明是否为真、是否充分由复核者判断。
- Break-glass:否
- Break-glass 理由:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- Base `origin/main` SHA:`708eb7f64985dc0e8fb4e7f5dcb109c344a22b3c`
- 与 `origin/main` 的 merge-base:`708eb7f64985dc0e8fb4e7f5dcb109c344a22b3c`
- 最后一次 `git fetch origin`:2026-08-21,本次验证过程中
- 同步方式:无需同步
- 公开 diff 命令:`git diff 708eb7f64..codex/line-budget-stoppoint`
- 私有证据路径:`harness/tasks/task_99889a63ffc6155b80af6f8333-line-budget-worker/artifacts/report-line-budget-stoppoint.md`
- 复核者证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待运行完成后补充

**双向演示由 CEO 重跑,不采信 worker 的报告。** 只证明它会红,不能排除它永远红,所以两侧都跑了:

```
# 基线
write-contract: 349/350
G32 line-budget-ratchet: pass                       exit 0

# 向 packages/kernel/src/domain/write-chain.contract.ts 追加三行
G32 line-budget-ratchet: write-contract: actual 352 exceeds ceiling 350;
  reduce production lines to 350 or add a verified line-budget decision receipt
  and update the ceiling                            exit 1

# 撤销后
write-contract: 349/350
G32 line-budget-ratchet: pass                       exit 0
```

这道门读的是**工作树**而不是 HEAD,所以未提交的改动同样会被抓到。

**分支陈旧时的真实错误文案**,把解析器指向一个落后 30 个提交的克隆复现:

```
Local line-budget base resolution failed: HEAD is not a descendant of the latest
canonical main (upstream/main 708eb7f64985dc0e8fb4e7f5dcb109c344a22b3c).
G32 needs network access to fetch canonical main because a stale or fork base can
produce a false pass.
Next action: first rebase onto latest main with `git rebase upstream/main`, then
re-run `npm run check:local`.
```

一条消息说清三件事:哪一步失败了、为什么这道门需要网络、下一步该跑什么命令。一个从没听说过这道门的 worker 不需要读源码。

- [x] `npm run check:local` —— 通过,fast tier,实测 69.3 秒(改动前约 60 秒;增量是门体加上 1.4 秒 fetch)
- [x] 双向红绿演示,退出码已确认
- [x] 分支陈旧的错误文案由真实失败场景复现
- [x] 定向测试:14/14
- 未运行:`test:integration`、`test:gui`、`test:gui:e2e` —— 不属于 fast tier,由云端 CI 运行。

### CI 会不会因此每个 job 都 fetch?

不会。`grep -rn "check:local" .github/workflows/` 无匹配,没有任何 job 跑 `check:local`,因此本改动只影响本地,不增加 CI 的网络往返。

## 审查证据

- 自审:CEO 独立重跑了双向演示、分支陈旧失败与完整 `check:local`,而不是采信 worker 的记录。**CEO 自己有一个探针是坏的并已作废**:为模拟陈旧分支而 checkout 到旧提交,同时把 `package.json` 也退回去了,于是观察到的错误是 npm 找不到脚本,而不是这道门的行为。该用例改用向导出的解析器注入 `rootDir` 重跑。
- 复核 subagent:未使用;改动很小,每条断言都由执行验证。
- 人工复核:待办
- 阻塞性发现:无

## 残余风险

- `check:local` 现在需要网络。离线时跑不了。这是有意为之并经过裁决,不是疏漏。
- 15 秒的 fetch 超时是一个常量。网络很慢时它会失败而不是继续等——这是刻意的取舍:无界等待会把「网络慢」变成「命令挂死」,而本仓有过无界等待的先例。
- 解析器靠 remote URL 识别 canonical 仓库。只配了 fork remote 的 worker 会得到一条响亮的错误,告诉他加上 canonical remote;这是正确行为,但对基于 fork 的工作流是一个新增的配置步骤。
- 耗时只在一台机器上跑了有限几轮。`check:local` 增加约 8% 是观察值,不是跨机器的保证。

## 关联材料

- 任务:`task_99889a63ffc6155b80af6f8333`
- 本 PR 针对的历史失败:PR #1659、PR #1664,以及 2026-08-15 迁移线
- worker 报告:`harness/tasks/task_99889a63ffc6155b80af6f8333-line-budget-worker/artifacts/report-line-budget-stoppoint.md`
