### PR TITLE
fix(kernel): preserve batched projection prefetch in the WAL-shadow store

### DIFF
--- a/packages/kernel/src/store/wal-shadow-event-store.ts
+++ b/packages/kernel/src/store/wal-shadow-event-store.ts
@@ -192,12 +192,14 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
       cursor: walEvents.at(-1)?.opId ?? gitBatch?.cursor ?? cursor,
       done,
       accessedItems: (gitBatch?.accessedItems ?? 0) + walEvents.length,
-      prefetchContent: (replay) =>
-        new Map(
-          replay
-            .flatMap((event) => canonicalEventContentClaims(event))
-            .map((claim) => [claim.sha256, wal.readContentBlob(claim.sha256) ?? git.readContentBlob(claim.sha256)]),
-        ),
+      prefetchContent: records.length === 0 && gitBatch?.prefetchContent !== undefined
+        ? gitBatch.prefetchContent
+        : (replay) =>
+          new Map(
+            replay
+              .flatMap((event) => canonicalEventContentClaims(event))
+              .map((claim) => [claim.sha256, wal.readContentBlob(claim.sha256) ?? git.readContentBlob(claim.sha256)]),
+          ),
     };
   };
   const append = (bundle: CanonicalWriteBundle): CanonicalEventAppendReceipt => {

--- a/packages/kernel/test/store/task-projection.test.ts
+++ b/packages/kernel/test/store/task-projection.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import { DatabaseSync } from "node:sqlite";
 import { makeTaskProjection } from "../../src/projection/task-projection.ts";
 import { makeTaskEventStore, type CanonicalEventStore, type CanonicalWriteBundle } from "../../src/store/task-event-store.ts";
+import { makeWalShadowEventStore } from "../../src/store/wal-shadow-event-store.ts";
 import { localGitObjectRefStore } from "../../src/store/local-version-control-system.ts";
 import { taskLifecycleWritePlan } from "../../src/domain/task-lifecycle-publication.ts";
 import type { TaskEventV1 } from "../../src/domain/task-lifecycle.contract.ts";
@@ -76,6 +77,19 @@ test("cold projection reuses one batch tree scan and its verified blob prefetch"
     assert.equal(read.status, "ready"); assert.equal(read.document?.body, batchDocumentBody(count));
     const processes = localGitObjectRefStore.processCount() - before;
     assert.equal(processes <= 7, true, `cold projection opened ${processes} Git processes for ${count} claimed blobs across two batches`);
+  });
+});
+
+test("WAL-shadow cold projection preserves Git batch content prefetch", async (t) => {
+  await withTempStoreAsync(async (rootDir) => {
+    initRepo(rootDir); const writer = makeTaskEventStore({ repoId: "wal-shadow-batch-prefetch", rootDir }), count = 128;
+    for (let revision = 1; revision <= count; revision += 1) writer.append(batchDocumentBundle(writer, revision));
+    const reader = makeWalShadowEventStore({ repoId: "wal-shadow-batch-prefetch", rootDir, walFlushMs: 60_000 }), projection = makeTaskProjection({ rootDir, eventStore: reader, catchUpLimit: 64 }), before = localGitObjectRefStore.processCount();
+    const rebuilt = projection.rebuild(), processes = localGitObjectRefStore.processCount() - before;
+    t.diagnostic(JSON.stringify({ events: count, gitProcesses: processes, watermark: rebuilt.watermark }));
+    assert.equal(rebuilt.watermark, count);
+    assert.equal(processes <= 7, true, `WAL-shadow cold projection opened ${processes} Git processes for ${count} claimed blobs across two batches`);
+    projection.close();
   });
 });
 


### PR DESCRIPTION
# English

## Summary

Cold projection replay through the WAL-shadow event store opened roughly one synchronous Git process per event. Measured on a real 27,317-event ledger in an isolated root: **321.66 s and 30,358 Git processes**. The same ledger replayed through the direct Git store — which already has verified batch blob prefetch — took **38.66 s and 847 Git processes**. Same work, 8.3× the wall clock, 29,511 extra process spawns.

The cause is narrow: `task-event-store.ts` already hands each ≤64-event batch a hash- and size-verified `prefetchContent`. The WAL-shadow store threw that away and substituted its own per-claim implementation, which ends at one synchronous Git child per content claim.

The fix hands the existing batch prefetch straight through when there are no pending WAL records. **Nothing is added**: the diff deletes the duplicated per-claim fallback for that case and keeps it for mixed WAL/Git batches, where content-source and verification semantics genuinely differ.

## What Changed

- `packages/kernel/src/store/wal-shadow-event-store.ts`: when `records.length === 0` and the Git batch offers `prefetchContent`, forward it instead of rebuilding a per-claim map. Mixed batches keep the original WAL-first fallback unchanged.
- `packages/kernel/test/store/task-projection.test.ts`: a real WAL-shadow cold-rebuild regression that counts Git processes across two batches.

No change to rebuild triggers, watermark persistence, discard conditions, recovery semantics, protocol, or schema.

## Task And Scope

- Harness task: `task_dff249e10fb1bf17d8374ece57`
- Branch: `codex/projection-catchup`
- Public scope: one kernel store file plus its projection regression
- Private planning/evidence updated: yes
- Out of scope: the per-claim fallback for batches with a pending WAL suffix — it touches WAL/Git content-override and verification semantics, and it is not the source of the incident's Git-only replay. Also out of scope: structured observability for projection discard reason and startup watermark, tracked separately.

## Version Impact

- Version: no version change because this is a performance fix inside an existing package with no published surface change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: `task_dff249e10fb1bf17d8374ece57`, fact `F-FEDB860F`
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: `37dc7e5687a4e8f0df04af8ccd19287f700847f6`
- Branch merge-base with `origin/main`: `37dc7e5687a4e8f0df04af8ccd19287f700847f6`
- Last `git fetch origin` time: 2026-08-21, immediately before opening this PR
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/projection-catchup`
- Private evidence commit/path: task package `artifacts/report-projection-catchup.md`
- Reviewer evidence path: same report
- GitHub Actions `rewrite-ci` run URL: see the checks on this PR
- [x] `npm run check:local` — `Local check passed (fast tier) in 73.3s.`, 43 steps, `G32 line-budget-ratchet: pass`
- [x] Targeted: `node --test packages/kernel/test/store/wal-shadow-event-store.test.ts` — 7/7; `node --test packages/kernel/test/store/task-projection.test.ts` — 15/15
- [x] `git diff --check` — exit 0, no output
- [x] GitHub Actions runs on this PR
- Not run: `npm run check:local -- --full` locally — the authoritative full matrix is GitHub CI, per the repository stop-point policy. The two integration files on the changed surface were run in full.

**Negative control, both sides**, same fixture and same command, counting Git processes only around the reader/rebuild (fixture construction is excluded from the counter):

- Before: `{"events":128,"gitProcesses":132,"watermark":128}` — the assertion fails with `opened 132 Git processes for 128 claimed blobs across two batches`
- After: `{"events":128,"gitProcesses":6,"watermark":128}`

**Full-scale measurement**, isolated `/tmp` roots, default daemon never touched:

- WAL-shadow, 27,317 events: `321660.407 ms`, `30358` Git processes, `11.775 ms/event`
- direct Git, 27,316 events: `38655.504 ms`, `847` Git processes, `1.415 ms/event`

## Review Evidence

- Self-review: read the diff and the report against three questions. (1) Does the 128-event sample extrapolate? The per-event process ratios agree — 132/128 = 1.03 against 30358/27317 = 1.11 — and the report does not rely on the extrapolation anyway, because it measured the full 27k ledger on both sides. (2) The 128-event test wall clock barely moved (21.6 s → 20.8 s), which looked like the fix not working; the report already answers it — that total includes constructing 128 commits with a direct Git writer, and the counter is read only around the rebuild. (3) Is anything added? No: production is +8/-6 and what is deleted is the duplicated per-claim selection.
- Reviewer subagent: not used; production change is one branch in one function with a full-scale two-sided measurement.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Batches with a pending WAL suffix still use the per-claim fallback. Deliberate: it involves WAL/Git content override and verification semantics, and the suffix is bounded by the materializer batch limit.
- **The reason the projection was discarded in the first place is still unknown and now unknowable for that incident.** The watermark went from 2477 to 0 between two log lines; there is no reset-reason record, and the original meta was later overwritten by an explicit rebuild. This fix makes recovery ~8× cheaper; it does not explain why recovery was needed.
- Observability gaps remain — no reset reason, no startup watermark, no batch progress. They are why the incident was read as "stuck for 40 minutes" when the process was in fact working. Deliberately not bundled here: adding progress logging to a path that spawns 30k processes would have made the slow path more articulate instead of removing the slowness.

## References

- Task: `task_dff249e10fb1bf17d8374ece57`
- Evidence: fact `F-FEDB860F`; task package `artifacts/report-projection-catchup.md`
- Review: this PR

Production-Delta: +8/-6

---

# 中文

## 概要

冷投影重放经过 WAL-shadow event store 时，**每个事件大约开一个同步 Git 进程**。在隔离 root 上用真实的 27,317 事件台账实测：**321.66 秒、30,358 个 Git 进程**。同一份台账走 direct Git store（它本来就有经过校验的批量 blob 预取）：**38.66 秒、847 个 Git 进程**。同样的工作，墙钟慢 8.3 倍，多出 29,511 次进程创建。

病因很窄：`task-event-store.ts` 已经为每个 ≤64 事件的批次提供了经 hash 与 size 校验的 `prefetchContent`，而 WAL-shadow store 把它丢掉，换成自己实现的逐 claim 版本——那个版本最终对每个 content claim 起一个同步 Git 子进程。

修法是在没有待物化 WAL records 时把已有的批量预取**直接转交**。**没有新增任何东西**：diff 删掉的正是那种情形下重复实现的逐 claim fallback，而混合 WAL/Git 批次保留原路径——那里的内容来源与校验语义确实不同。

## 改动内容

- `packages/kernel/src/store/wal-shadow-event-store.ts`：`records.length === 0` 且 Git 批次提供了 `prefetchContent` 时直接转交，不再重建逐 claim 的 map。混合批次保持原有 WAL-first fallback 不变。
- `packages/kernel/test/store/task-projection.test.ts`：一条真实的 WAL-shadow 冷重建回归，跨两个批次统计 Git 进程数。

未改动重建触发条件、watermark 持久化、discard 条件、恢复语义、协议或 schema。

## 任务与范围

- Harness 任务：`task_dff249e10fb1bf17d8374ece57`
- 分支：`codex/projection-catchup`
- 公开范围：一个 kernel store 文件及其投影回归
- 私有计划 / 证据是否已更新：yes
- 范围外：带待物化 WAL 后缀的批次的逐 claim fallback——它涉及 WAL/Git 内容覆盖与校验语义，且不是本次事故那条纯 Git 重放的来源。同样在范围外：投影 discard 原因与启动 watermark 的结构化可观测性，单独立线。

## 版本影响

- 版本：不改版本，原因是这是既有 package 内部的性能修复，发布面无变化。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：`task_dff249e10fb1bf17d8374ece57`，fact `F-FEDB860F`
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：无

## 验证

- `origin/main` 基准 SHA：`37dc7e5687a4e8f0df04af8ccd19287f700847f6`
- 当前分支与 `origin/main` 的 merge-base：`37dc7e5687a4e8f0df04af8ccd19287f700847f6`
- 最近一次 `git fetch origin` 时间：2026-08-21，开 PR 前紧邻执行
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...codex/projection-catchup`
- 私有证据 commit/path：任务包 `artifacts/report-projection-catchup.md`
- Reviewer 证据路径：同上
- GitHub Actions `rewrite-ci` run URL：见本 PR 的 checks
- [x] `npm run check:local` —— `Local check passed (fast tier) in 73.3s.`，43 步，`G32 line-budget-ratchet: pass`
- [x] 定向：`node --test packages/kernel/test/store/wal-shadow-event-store.test.ts` —— 7/7；`node --test packages/kernel/test/store/task-projection.test.ts` —— 15/15
- [x] `git diff --check` —— 退出 0，无输出
- [x] 本 PR 上的 GitHub Actions
- 未运行：本地 `npm run check:local -- --full` —— 按本仓停止点政策，完整门矩阵的权威面是 GitHub CI。改动面上的两个 integration 文件已定向全跑。

**阴性对照，两侧真实输出**，同一 fixture 同一命令，Git 进程计数只取 reader/rebuild 前后（构造 fixture 的部分不计入）：

- 修复前：`{"events":128,"gitProcesses":132,"watermark":128}` —— 断言失败原文是 `opened 132 Git processes for 128 claimed blobs across two batches`
- 修复后：`{"events":128,"gitProcesses":6,"watermark":128}`

**全规模实测**，隔离 `/tmp` root，全程未碰 default daemon：

- WAL-shadow，27,317 事件：`321660.407 ms`、`30358` 个 Git 进程、`11.775 ms/事件`
- direct Git，27,316 事件：`38655.504 ms`、`847` 个 Git 进程、`1.415 ms/事件`

## 审查证据

- 自查：带着三个问题读 diff 与报告。(1) 128 事件的样本能外推吗？每事件进程比对得上——132/128 = 1.03 对 30358/27317 = 1.11——而且结论本来就不依赖外推，两侧都做了完整 27k 台账的实测。(2) 128 事件测试的总耗时几乎没变（21.6 秒 → 20.8 秒），看起来像修复没生效；报告已经回答了——那个总耗时包含用 direct Git writer 构造 128 个 commit，而计数器只在 rebuild 前后读。(3) 有没有新增东西？没有：生产面 +8/-6，删掉的正是重复实现的逐 claim 选择。
- Reviewer subagent：未使用；生产改动是一个函数里的一个分支，且带全规模两侧实测。
- 人工审查：待做
- 阻塞发现：无

## 残余风险

- 带待物化 WAL 后缀的批次仍走逐 claim fallback。刻意保留：它涉及 WAL/Git 内容覆盖与校验语义，且该后缀受 materializer 批次上限约束。
- **投影当初为什么被丢弃，仍然不知道，而且对那次事故已经永远无法知道。** watermark 在两条日志之间从 2477 变成 0；没有 reset reason 记录，原 meta 后来又被一次显式 rebuild 覆盖。本修复让恢复便宜了约 8 倍，但它不解释为什么需要恢复。
- 可观测性缺口仍在——没有 reset reason、没有启动 watermark、没有批次进度。正是它们让这次事故被读成「卡了 40 分钟」，而实际上进程一直在工作。刻意不与本修复一起合并：给一条会创建 3 万个进程的路径补进度日志，只会让慢路径更会说话，而不是让它不慢。

## 关联材料

- 任务：`task_dff249e10fb1bf17d8374ece57`
- 证据：fact `F-FEDB860F`；任务包 `artifacts/report-projection-catchup.md`
- 审查：本 PR
