### PR TITLE
fix(gui): admit detected runtime model defaults through the preload bridge

### DIFF
--- a/packages/gui/e2e/electron-smoke.e2e.mjs
+++ b/packages/gui/e2e/electron-smoke.e2e.mjs
@@ -118,8 +118,8 @@ test("Electron shell opens its first BrowserWindow", { timeout: 90_000 }, async 
   assert.deepEqual(consoleFailures, [], "renderer emitted console errors");
 });
 
-test("GUI dispatches a real daemon-mediated codex provider mission and exposes its settled artifact chain", { timeout: 90_000 }, async (t) => {
-  const proofValue = `gui-real-dispatch-${Date.now()}`;
+test("GUI creates a Runtime and Agent from zero, invokes its selected Skill, and exposes the settled artifact chain", { timeout: 90_000 }, async (t) => {
+  const proofValue = `gui-real-dispatch-${Date.now()}`, skillProofValue = `manifest-observed-${Date.now()}`;
   const fakeProviderRoot = mkdtempSync(resolve(tmpdir(), "ha-gui-codex-provider-")), fakeProviderBin = resolve(fakeProviderRoot, "bin"), fakeProviderPath = resolve(fakeProviderBin, "codex"), originalPath = process.env.PATH ?? "";
   mkdirSync(fakeProviderBin);
   writeFakeCodex(fakeProviderPath);
@@ -133,22 +133,65 @@ test("GUI dispatches a real daemon-mediated codex provider mission and exposes i
     rmSync(fakeProviderRoot, { recursive: true, force: true });
     throw error;
   }
-  const ledgerRoot = daemonFixture.rootDir, proofPath = resolve(ledgerRoot, "artifacts/gui-real-dispatch-proof.txt");
+  const ledgerRoot = daemonFixture.rootDir, proofPath = resolve(ledgerRoot, "artifacts/gui-real-dispatch-proof.txt"), skillCandidate = resolve(ledgerRoot, ".agents/skills/gui-proof-skill");
   let electronApp;
   t.after(async () => { try { if (electronApp) await closeElectronApp(electronApp); await daemonFixture.stop(); } finally { process.env.PATH = originalPath; rmSync(fakeProviderRoot, { recursive: true, force: true }); } });
   const codexInstallation = discoverRuntimeInstallations().find((installation) => installation.kindId === "codex" && installation.executablePath === realpathSync.native(fakeProviderPath));
   if (!codexInstallation) throw new Error("fake codex installation was not witnessed by the daemon runtime inventory");
-  seedRealDispatchFixture(daemonFixture.userRoot, ledgerRoot, codexInstallation.installationId);
+  assert.deepEqual(codexInstallation.models, ["gpt-5.6-sol", "gpt-5.6-terra"]);
+  assert.equal(codexInstallation.defaultModel, "gpt-5.6-sol");
+  mkdirSync(skillCandidate, { recursive: true });
+  const skillPath = realpathSync.native(skillCandidate);
+  writeFileSync(resolve(skillPath, "SKILL.md"), `# GUI proof skill\n\nWhen selected, read this file and report GUI_MANIFEST_MARKER:${skillProofValue}.\n`);
 
   electronApp = await electron.launch({ executablePath: electronPath, args: [resolve(guiRoot, "src/main/electron-main.ts")], cwd: repoRoot, env: { ...process.env, ...daemonFixture.env, HARNESS_GUI_ROOT: ledgerRoot } });
   const page = await electronApp.firstWindow();
   page.setDefaultTimeout(20_000);
   await page.waitForLoadState("domcontentloaded");
-  await page.getByRole("button", { name: "Agent 会话", exact: true }).click();
-  await page.getByTestId("rail-agent-codex-sidecar").waitFor({ timeout: 20_000 });
-  await page.getByTestId("rail-agent-codex-sidecar").click();
-  await page.getByTestId("dispatch-entry-codex-sidecar").waitFor({ timeout: 20_000 });
-  await page.getByTestId("dispatch-entry-codex-sidecar").click();
+  await page.getByRole("button", { name: /^Agent (?:运行时|Runtime)$/u }).click();
+
+  await page.getByTestId("runtime-new-runtimes").click();
+  const runtimeDialog = page.getByTestId("new-runtime-dialog");
+  await runtimeDialog.waitFor();
+  await runtimeDialog.getByRole("button", { name: "Codex", exact: true }).click();
+  await runtimeDialog.getByTestId("new-runtime-id").fill("gui-from-zero");
+  await runtimeDialog.getByLabel(/^(?:名称|Name)$/u).fill("GUI From Zero");
+  const modelSelect = runtimeDialog.getByTestId("new-runtime-model");
+  await modelSelect.locator('option[value="gpt-5.6-sol"]').waitFor({ state: "attached" });
+  assert.equal(await modelSelect.inputValue(), "", "detected default must not require a typed model override");
+  assert.equal(await runtimeDialog.getByTestId("new-runtime-model-custom").count(), 0, "custom model input must stay opt-in");
+  const createRuntime = runtimeDialog.getByTestId("new-runtime-create");
+  assert.equal(await createRuntime.isEnabled(), true, "blank-model Runtime form did not become creatable from the detected default");
+  await createRuntime.click();
+  await page.getByTestId("rail-runtime-gui-from-zero").waitFor({ timeout: 20_000 });
+
+  await page.getByTestId("runtime-new-agents").click();
+  const agentDialog = page.getByTestId("new-agent-dialog");
+  await agentDialog.waitFor();
+  await agentDialog.getByRole("button", { name: /(?:空白创建|Blank)/u }).click();
+  await agentDialog.getByTestId("new-agent-id").fill("gui-from-zero-agent");
+  await agentDialog.getByLabel(/^(?:名称|Name)$/u).fill("GUI From Zero Agent");
+  await agentDialog.getByTestId("new-agent-create").click();
+  const agentCard = page.getByTestId("agent-card-gui-from-zero-agent");
+  await agentCard.waitFor({ timeout: 20_000 });
+  await agentCard.getByTestId("agent-instructions").fill("Use every selected Skill before completing the mission, then report the exact proof values.");
+  await agentCard.getByTestId("agent-skill-search").fill("gui-proof-skill");
+  const skillChoice = agentCard.locator("button", { hasText: "gui-proof-skill" });
+  await skillChoice.waitFor();
+  assert.ok((await skillChoice.innerText()).includes(skillPath), "Skill selector did not expose the absolute .agents path");
+  await skillChoice.click();
+  await agentCard.getByTestId("agent-preset").fill("standard-task");
+  const presetChoice = agentCard.locator("button", { hasText: "standard-task" });
+  await presetChoice.waitFor();
+  await presetChoice.click();
+  assert.equal(await agentCard.getByTestId("agent-model-select").inputValue(), "", "Agent must retain the Runtime provider default unless the user chooses an override");
+  await agentCard.getByTestId("agent-save").click();
+  await page.waitForFunction(() => globalThis.document.querySelector('[data-testid="agent-save"]')?.hasAttribute("disabled"));
+  const savedAgent = JSON.parse(readFileSync(resolve(ledgerRoot, "harness/agents/gui-from-zero-agent.json"), "utf8"));
+  assert.deepEqual(savedAgent.skills, [{ id: "gui-proof-skill", path: skillPath }]);
+  assert.equal(savedAgent.preset, "standard-task");
+
+  await page.getByTestId("dispatch-entry-gui-from-zero-agent").click();
   const dialog = page.getByTestId("dispatch-dialog");
   await dialog.waitFor();
   await dialog.getByTestId("dispatch-task-task-gui-dispatch").click();
@@ -160,9 +203,9 @@ test("GUI dispatches a real daemon-mediated codex provider mission and exposes i
 
   const dock = page.getByTestId("sessions-dock");
   await dock.waitFor({ timeout: 30_000 });
-  const settledOutcome = page.locator('[data-testid^="runtime-outcome-"]').first();
+  const settledOutcome = dock.locator("button", { hasText: "Run a real GUI dispatch" }).locator('[data-testid^="runtime-outcome-"]');
   await settledOutcome.waitFor({ timeout: 20_000 });
-  await page.waitForFunction(() => [...globalThis.document.querySelectorAll('[data-testid^="runtime-outcome-"]')].some((element) => ["succeeded", "failed", "unknown", "cancelled"].includes(element.textContent?.trim() ?? "")), undefined, { timeout: 150_000 });
+  await page.waitForFunction(() => [...globalThis.document.querySelectorAll('[data-testid^="runtime-outcome-"]')].some((element) => element.closest("button")?.textContent?.includes("Run a real GUI dispatch") && ["succeeded", "failed", "cancelled"].includes(element.textContent?.trim() ?? "")), undefined, { timeout: 150_000 });
   assert.equal((await settledOutcome.textContent())?.trim(), "succeeded", `real provider dispatch did not settle successfully: ${await settledOutcome.textContent()}`);
   const detail = page.getByTestId("session-detail");
   await detail.waitFor();
@@ -170,6 +213,8 @@ test("GUI dispatches a real daemon-mediated codex provider mission and exposes i
   const providerResult = await detail.locator("pre").textContent();
   assert.ok((providerResult ?? "").trim().length > 0, "daemon did not expose a provider result in the GUI");
   assert.match(providerResult ?? "", /GUI_REAL_DISPATCH_PROOF=/u, "provider result did not report the requested proof line");
+  assert.ok((providerResult ?? "").includes(`GUI_MANIFEST_OBSERVED:${skillProofValue}`), `provider did not read the selected Skill manifest:\n${providerResult}`);
+  assert.ok((providerResult ?? "").includes(`GUI_SKILL_PATH=${resolve(skillPath, "SKILL.md")}`), "provider prompt did not contain the selected Skill manifest's absolute path");
   assert.equal(readFileSync(proofPath, "utf8"), `GUI_REAL_DISPATCH_PROOF=${proofValue}\n`, "provider did not create the requested proof file");
 
   await page.getByTestId("rail-orchestration-task-gui-dispatch").waitFor({ timeout: 20_000 });
@@ -189,14 +234,7 @@ test("GUI dispatches a real daemon-mediated codex provider mission and exposes i
   }
 });
 
-function seedRealDispatchFixture(userRoot, rootDir, installationId) {
-  if (!installationId) throw new Error("codex installation is not witnessed by the daemon runtime inventory");
-  mkdirSync(resolve(rootDir, "harness/agents"), { recursive: true });
-  writeFileSync(resolve(rootDir, "harness/agents/codex-sidecar.json"), `${JSON.stringify({ schema: "agent-declaration/v1", id: "codex-sidecar", name: "Codex Sidecar", instructions: "Use the shell to complete the mission exactly and report the resulting file contents.", runtime_type: "codex" }, null, 2)}\n`);
-  writeFileSync(resolve(userRoot, "runtime-instances.json"), `${JSON.stringify({ schema: "runtime-instances/v1", instances: [{ schemaVersion: 2, instanceId: "codex-sidecar", name: "Codex Sidecar", installationId, providerId: "codex_local_access", models: ["gpt-5.6-terra"], defaultModel: "gpt-5.6-terra", enabled: true, auth: { mode: "api-key", credentialRef: "credential:v1:codex-sidecar" }, kindId: "codex", codex: { reasoningEffort: "low", baseUrl: "http://localhost:50818/v1", wireApi: "responses", requiresOpenAiAuth: true } }] }, null, 2)}\n`);
-}
-
-function writeFakeCodex(target) { const source = ["#!/usr/bin/env node", "import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';", "import path from 'node:path';", "if (process.argv.includes('--version')) { console.log('codex-cli e2e-fake'); process.exit(0); }", "const prompt = readFileSync(0, 'utf8');", "const proof = /GUI_REAL_DISPATCH_PROOF=([A-Za-z0-9-]+)/u.exec(prompt)?.[1] ?? 'missing';", "const line = `GUI_REAL_DISPATCH_PROOF=${proof}`;", "mkdirSync(path.resolve(process.cwd(), 'artifacts'), { recursive: true });", "writeFileSync(path.resolve(process.cwd(), 'artifacts/gui-real-dispatch-proof.txt'), `${line}\\n`);", "console.log(JSON.stringify({ type: 'thread.started', thread_id: 'thread-gui-e2e-fake' }));", "console.log(JSON.stringify({ type: 'item.completed', item: { type: 'file_change', status: 'completed', path: 'artifacts/gui-real-dispatch-proof.txt' } }));", "console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: line } }));", "console.log(JSON.stringify({ type: 'turn.completed' }));"].join("\n"); writeFileSync(target, `${source}\n`, { mode: 0o755 }); chmodSync(target, 0o755); }
+function writeFakeCodex(target) { const source = ["#!/usr/bin/env node", "import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';", "import path from 'node:path';", "const args = process.argv.slice(2);", "if (args.includes('--version')) { console.log('codex-cli e2e-fake'); process.exit(0); }", "if (args.join(' ') === 'debug models --bundled') { console.log(JSON.stringify({ models: [{ slug: 'gpt-5.6-sol' }, { slug: 'gpt-5.6-terra' }] })); process.exit(0); }", "if (args[0] === 'login' && args[1] === 'status') process.exit(0);", "if (args[0] === 'login') process.exit(0);", "const prompt = readFileSync(0, 'utf8');", "const proof = /GUI_REAL_DISPATCH_PROOF=([A-Za-z0-9-]+)/u.exec(prompt)?.[1] ?? 'missing';", "const skillFile = /^- gui-proof-skill: (.+)$/mu.exec(prompt)?.[1]?.trim() ?? '';", "const skillText = skillFile ? readFileSync(skillFile, 'utf8') : '';", "const skillProof = /GUI_MANIFEST_MARKER:([A-Za-z0-9-]+)/u.exec(skillText)?.[1] ?? 'missing';", "const line = `GUI_REAL_DISPATCH_PROOF=${proof}`;", "const result = `${line}\\nGUI_MANIFEST_OBSERVED:${skillProof}\\nGUI_SKILL_PATH=${skillFile}`;", "mkdirSync(path.resolve(process.cwd(), 'artifacts'), { recursive: true });", "writeFileSync(path.resolve(process.cwd(), 'artifacts/gui-real-dispatch-proof.txt'), `${line}\\n`);", "console.log(JSON.stringify({ type: 'thread.started', thread_id: 'thread-gui-e2e-fake' }));", "console.log(JSON.stringify({ type: 'item.completed', item: { type: 'file_change', status: 'completed', path: 'artifacts/gui-real-dispatch-proof.txt' } }));", "console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: result } }));", "console.log(JSON.stringify({ type: 'turn.completed' }));"].join("\n"); writeFileSync(target, `${source}\n`, { mode: 0o755 }); chmodSync(target, 0o755); }
 
 async function closeElectronApp(electronApp) {
   const child = electronApp.process();

--- a/packages/gui/src/preload/allowlist.ts
+++ b/packages/gui/src/preload/allowlist.ts
@@ -5,7 +5,7 @@ export const localMainPreloadMethods = ["listRuntimeInstances", "showRuntimeInst
 export type PreloadApiMethod = (typeof daemonGuiReadMethods)[number]["guiBridgeMethod"] | (typeof daemonGuiActionMethods)[number]["guiBridgeMethod"] | (typeof daemonGuiStreamFacets)[number]["guiBridgeMethod"] | (typeof localMainPreloadMethods)[number];
 const daemonGuiFacets: ReadonlyArray<{ readonly guiBridgeMethod: PreloadApiMethod }> = [...daemonGuiReadMethods, ...daemonGuiActionMethods, ...daemonGuiStreamFacets];
 const localMainFacets: ReadonlyArray<{ readonly guiBridgeMethod: PreloadApiMethod }> = localMainPreloadMethods.map((guiBridgeMethod) => ({ guiBridgeMethod }));
-const runtimeInstanceCreateFields = ["instanceId", "name", "kindId", "installationId", "providerId", "models", "permissionMode", "isolationState", "claude", "codex", "agy", "authMode", "apiKey"] as const;
+const runtimeInstanceCreateFields = ["instanceId", "name", "kindId", "installationId", "providerId", "models", "defaultModel", "permissionMode", "isolationState", "claude", "codex", "agy", "authMode", "apiKey"] as const;
 type PreloadFacet = { readonly guiBridgeMethod: string; readonly requiresRepo?: boolean; readonly inputSchemaId: string };
 export function deriveRepoScopedMethods(facets: readonly PreloadFacet[]): ReadonlySet<string> { return new Set(facets.filter(({ requiresRepo }) => requiresRepo).map(({ guiBridgeMethod }) => guiBridgeMethod)); }
 export function deriveEmptyRepoMethods(facets: readonly PreloadFacet[]): ReadonlySet<string> { return new Set(facets.filter(({ requiresRepo, inputSchemaId }) => requiresRepo && inputSchemaId === "gui.empty/v1").map(({ guiBridgeMethod }) => guiBridgeMethod)); }
@@ -75,6 +75,7 @@ function runtimeInstanceCreateProblem(value: unknown): string | undefined {
   for (const field of ["instanceId", "name", "installationId", "providerId"]) if (typeof value[field] !== "string" || value[field].trim().length === 0) return `field "${field}" must be a non-blank string.`;
   if (!["claude", "codex", "agy"].includes(String(value.kindId))) return 'field "kindId" must be claude, codex, or agy.';
   if (!Array.isArray(value.models) || value.models.length === 0 || value.models.some((model) => typeof model !== "string" || model.trim().length === 0) || new Set(value.models).size !== value.models.length) return 'field "models" must be a non-empty array of non-blank strings with no duplicates.';
+  if (value.defaultModel !== undefined && (typeof value.defaultModel !== "string" || !value.models.includes(value.defaultModel))) return 'field "defaultModel" must be one of the listed models.';
   if (!["subscription", "api-key"].includes(String(value.authMode))) return 'field "authMode" must be subscription or api-key.';
   if (value.kindId === "agy" && value.authMode !== "subscription") return 'field "authMode" must be subscription for agy.';
   if (value.permissionMode !== undefined && !["bypass", "workspace-write", "read-only"].includes(String(value.permissionMode))) return 'field "permissionMode" must be bypass, workspace-write, or read-only.';

--- a/packages/gui/test/preload-allowlist.test.ts
+++ b/packages/gui/test/preload-allowlist.test.ts
@@ -88,6 +88,13 @@ test("preload accepts the renderer's codex create payload", () => {
   assert.equal(assertPreloadPayload("createRuntimeInstance", payload), true);
 });
 
+test("preload accepts the renderer's detected model default", () => {
+  const payload = buildRuntimeInstanceCreatePayload({ ...runtimeCreateForm, instanceId: "codex-detected", name: "Codex detected", kindId: "codex", providerId: "openai", model: "", permissionMode: "workspace-write", isolation: "enforced" }, "codex-install", { models: ["gpt-5.6-sol", "gpt-5.6-terra"], defaultModel: "gpt-5.6-sol" });
+  assert.equal(payload.defaultModel, "gpt-5.6-sol");
+  assert.equal(assertPreloadPayload("createRuntimeInstance", payload), true);
+  assert.throws(() => assertPreloadPayload("createRuntimeInstance", { ...payload, defaultModel: "typed-by-hand" }), /defaultModel.*listed models/u);
+});
+
 test("preload accepts the renderer's claude create payload", () => {
   const payload = buildRuntimeInstanceCreatePayload(runtimeCreateForm, "claude-install");
   assert.deepEqual(Object.keys(payload).sort(), ["authMode", "claude", "installationId", "instanceId", "isolationState", "kindId", "models", "name", "permissionMode", "providerId"]);


### PR DESCRIPTION
# English

## What

Creating a runtime instance from the GUI failed whenever the user did not type a model name by hand. The renderer builds the create payload with `defaultModel` taken from installation detection (`runtime-instance-form.ts:9`, the `!overrideModels.length && detected.defaultModel` branch), but the preload bridge's `runtimeInstanceCreateFields` allowlist did not list `defaultModel`. The payload was therefore rejected at the IPC boundary before it ever reached the daemon.

This makes the two reported symptoms one defect: instance creation "always failing", and the user being forced to type a model every time. Typing a model takes the override branch, which omits `defaultModel` and therefore passes.

Model detection itself was never broken. All three witnessed installations report a populated model list and a default (`agy` 14 models, `claude` 3, `codex` 8).

## How

- `packages/gui/src/preload/allowlist.ts`: add `defaultModel` to `runtimeInstanceCreateFields`, and validate it as an optional string that must be one of the listed `models`.
- `packages/gui/test/preload-allowlist.test.ts`: add a regression that sends the renderer's detected-default payload through the bridge.
- `packages/gui/e2e/electron-smoke.e2e.mjs`: cover the detected-default create path.

Production-Delta: +2/-1

## Verification

`npm run check:local` passed in the worktree (fast tier, 73.9s). Targeted file: `packages/gui/test/preload-allowlist.test.ts` 13/13.

Mutation check, both directions. Clean baseline is 13 pass / 0 fail. Removing `defaultModel` from the allowlist again produces 12 pass / 1 fail, and the single failure is the new regression at `preload-allowlist.test.ts:94`. Restoring the line returns 13/13 with a clean worktree. The guard is therefore on the path it claims to guard.

Note that `check:local` does not run `test:gui`; the cloud GUI job runs on this pull request because it touches `packages/gui`.

## Review evidence

A sibling sweep was run against the mechanism rather than the symptom: every closed literal field set in `preload/allowlist.ts` was enumerated by schema, not by grepping for `defaultModel`. That is 6 code sites covering 9 independent payload schemas, plus 2 zero-field guards. Daemon-backed read shapes were enumerated at runtime from `daemonGuiReadMethods`; renderer local-main shapes were expanded with the TypeScript compiler API over `RuntimeInstanceCreateInput`, `RuntimeInstanceUpdateInput`, `AuthInput` and the bridge union; each pair was compared with a bidirectional set difference. Current omissions: zero. `defaultModel` was the only one.

## Governance Declaration

Protected surface: `packages/gui/src/preload/allowlist.ts`, the renderer-to-main IPC field allowlist.

Authorizing task: `task_877d5e84575c4469e7849fe02b` ("GUI 端到端:Agent/Squad/Runtime 的定义、挂载、派发、看结果全部在 GUI 里可操作"), which carries the owner's direct report that runtime instance creation always fails.

Nature of the change: the allowlist is widened by exactly one optional field, `defaultModel`. The field is not free-form. It is accepted only when it is a string that already appears in the same payload's `models` array, which the allowlist admits today and validates as a non-empty array of unique non-blank strings. The widening therefore admits no value that could not already cross this boundary inside `models`, and it adds no new value domain, no new type, and no new nesting.

No break-glass was used. No CI gate, required check, branch protection, or authority manifest was touched.

## Residual risk

There is no family-level field-parity gate. The existing tests exercise hand-picked payloads and unknown-field rejection; they do not derive full-field samples from the type declarations, and they do not mutate the declarations to check the allowlist follows. That is exactly why adding `defaultModel` on the renderer side left typecheck and tests green while the field was silently dropped. This pull request adds a targeted regression that kills this one root cause; the sibling optional fields can still drift by the same mechanism in future. No gate is added here — that decision is deliberately left to the owner rather than taken inside a defect fix.

---

# 中文

## What

从 GUI 创建 runtime 实例,只要用户不手打模型名就必然失败。渲染层构造创建请求时会带上从安装探测得到的 `defaultModel`(`runtime-instance-form.ts:9`,`!overrideModels.length && detected.defaultModel` 那一支),而 preload 桥的 `runtimeInstanceCreateFields` 白名单里没有 `defaultModel`。请求因此在 IPC 边界就被拒,根本到不了 daemon。

这让两个被分别报告的症状合并成一个缺陷:「创建实例总是失败」,以及「每次都被迫手打模型」。手打模型走的是 override 分支,那条路不带 `defaultModel`,所以能过。

模型探测本身从来没坏过。三个被见证的安装全部报出了非空模型清单与默认模型(`agy` 14 个、`claude` 3 个、`codex` 8 个)。

## How

- `packages/gui/src/preload/allowlist.ts`:把 `defaultModel` 加进 `runtimeInstanceCreateFields`,并校验它是可选字符串且必须是已列出 `models` 之一。
- `packages/gui/test/preload-allowlist.test.ts`:新增回归,把渲染层的 detected-default 请求真的送过桥。
- `packages/gui/e2e/electron-smoke.e2e.mjs`:覆盖 detected-default 的创建路径。

## Verification

worktree 内 `npm run check:local` 通过(fast tier,73.9 秒)。定向文件 `packages/gui/test/preload-allowlist.test.ts` 13/13。

**变异检查双向做完。** 干净基线是 13 通过 / 0 失败;把 `defaultModel` 从白名单里去掉后是 12 通过 / 1 失败,而且唯一那条失败正是新增回归(`preload-allowlist.test.ts:94`);恢复该行后回到 13/13 且工作树干净。**所以这道守卫确实在它声称把守的那条路径上。**

注意 `check:local` 不跑 `test:gui`;本 PR 触碰 `packages/gui`,云端 GUI job 会跑。

## Review evidence

**按机制而不是按症状扫了一遍兄弟**:`preload/allowlist.ts` 里每一份封闭的字面量字段集合都按 schema 枚举,而不是 grep `defaultModel`。共 6 个代码点、9 个独立 payload schema,另有 2 个零字段 guard。daemon 侧读形状从 `daemonGuiReadMethods` 在运行时枚举;渲染层 local-main 形状用 TypeScript 编译器 API 展开 `RuntimeInstanceCreateInput`、`RuntimeInstanceUpdateInput`、`AuthInput` 与 bridge 的 union;每组再与白名单做双向集合差。**当前漏项为零,`defaultModel` 是唯一一处。**

## 治理声明

受保护面:`packages/gui/src/preload/allowlist.ts`,渲染进程到主进程的 IPC 字段白名单。

授权任务:`task_877d5e84575c4469e7849fe02b`(「GUI 端到端:Agent/Squad/Runtime 的定义、挂载、派发、看结果全部在 GUI 里可操作」),该任务承载 owner 亲自报告的「创建 runtime 实例总是失败」。

**变更性质:白名单只放宽一个可选字段 `defaultModel`,而且它不是自由取值。** 它只有在是字符串、且已经出现在同一请求的 `models` 数组里时才被接受;而 `models` 本来就允许通过,并已被校验为非空、无重复、无空串的字符串数组。**因此这次放宽不会让任何原本无法跨越该边界的值通过**——它没有引入新的取值域、新的类型、也没有新的嵌套层。

未使用 break-glass。未触碰任何 CI gate、required check、分支保护或 authority manifest。

## Residual risk

**这一族没有字段同构门。** 现有测试只覆盖人工挑选的 payload 与未知字段拒绝,既不从类型声明自动生成全字段样本,也不对声明做字段增量变异来检查白名单是否跟上。这正是为什么渲染层新增 `defaultModel` 之后,typecheck 与测试仍然全绿而字段被静默丢弃。本 PR 新增的定向回归能杀死这一个根因,但兄弟可选字段将来仍可能以同一机制漂移。**本 PR 不新增门**——那个选择被有意留给 owner,而不是在一次缺陷修复里顺手做掉。
