### PR TITLE
fix(gui): bound the two-second task poll to a page walk and an indexed delta

### DIFF
--- a/packages/gui/src/renderer/task-actions.ts
+++ b/packages/gui/src/renderer/task-actions.ts
@@ -4,7 +4,7 @@ import type { GuiActionResult } from "../api/renderer-dto.ts";
 import type { GuiSubmissionV1 } from "../api/renderer-dto.ts";
 import { harnessClient, type TaskListSuccess } from "./api-client.ts";
 import type { TaskRow } from "./model/types.ts";
-import { taskQueryKeys } from "./task-data.ts";
+import { readTaskList, taskQueryKeys } from "./task-data.ts";
 
 type ReceiptRecord = GuiActionResult & {
   readonly revision?: number;
@@ -78,7 +78,8 @@ export function useTaskActions(repoId: string) {
   };
   const reread = async (taskId: string, kind: TaskMutationFeedback["kind"], settlement: TaskSettlement, visible: (data: TaskListSuccess) => boolean): Promise<TaskMutationFeedback> => {
     if (settlement.state !== "applied") return publish(taskId, { state: settlement.state === "op_rejected" ? "error" : "pending", kind, opId: settlement.opId, code: settlement.code, hint: settlement.hint ?? "canonical receipt 尚未 settled；不要重放 mutation。" });
-    const data = await queryClient.fetchQuery({ queryKey: taskQueryKeys.list(repoId), queryFn: () => harnessClient.getTasks({ repoId }), staleTime: 0 });
+    const queryKey = taskQueryKeys.list(repoId), previous = queryClient.getQueryData<TaskListSuccess>(queryKey);
+    const data = await queryClient.fetchQuery({ queryKey, queryFn: () => readTaskList(repoId, previous), staleTime: 0 });
     const revisionVisible = settlement.revision === undefined || data.watermark >= settlement.revision;
     return revisionVisible && visible(data)
       ? publish(taskId, { state: "success", kind, opId: settlement.opId, hint: "canonical projection 已重读并确认。" })

--- a/packages/gui/src/renderer/task-data.ts
+++ b/packages/gui/src/renderer/task-data.ts
@@ -1,9 +1,10 @@
-import { useQuery, type QueryClient } from "@tanstack/react-query";
-import { harnessClient } from "./api-client.ts";
+import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
+import { harnessClient, type TaskListSuccess, type TaskQueryFacets } from "./api-client.ts";
 import type { DocEntry, DocGroup } from "./model/types.ts";
 import { isRendererRecord } from "./result-validation.ts";
 
 export const LEDGER_REFRESH_INTERVAL_MS = 2_000;
+export const TASK_LIST_PAGE_LIMIT = 500;
 
 export const taskQueryKeys = {
   all: (repoId: string) => ["tasks", repoId] as const,
@@ -15,16 +16,47 @@ export const taskQueryKeys = {
 export function taskListQuery(repoId: string) {
   return {
     queryKey: taskQueryKeys.list(repoId),
-    queryFn: () => harnessClient.getTasks({ repoId }),
+    queryFn: () => readCompleteTaskList(repoId),
     staleTime: 10_000,
     refetchInterval: LEDGER_REFRESH_INTERVAL_MS,
     refetchOnWindowFocus: "always" as const
   };
 }
 
+export async function readCompleteTaskList(repoId: string): Promise<TaskListSuccess> {
+  return readTaskPages(repoId, {});
+}
+
+export async function readTaskList(repoId: string, previous?: TaskListSuccess): Promise<TaskListSuccess> {
+  if (!previous || previous.status !== "ready" || previous.rows.length === 0) return readCompleteTaskList(repoId);
+  const updatedAfter = previous.rows.reduce((latest, row) => row.updatedAt > latest ? row.updatedAt : latest, "");
+  const delta = await readTaskPages(repoId, { updatedAfter });
+  if (delta.status !== "ready" || delta.watermark < previous.watermark || delta.sourceRevision < previous.sourceRevision) return readCompleteTaskList(repoId);
+  const rows = new Map(previous.rows.map((row) => [row.taskId, row]));
+  for (const row of delta.rows) rows.set(row.taskId, row);
+  return { ...delta, rows: [...rows.values()].sort((left, right) => left.taskId < right.taskId ? -1 : left.taskId > right.taskId ? 1 : 0) };
+}
+
+async function readTaskPages(repoId: string, facets: Pick<TaskQueryFacets, "updatedAfter">): Promise<TaskListSuccess> {
+  const first = await harnessClient.getTasks({ repoId, ...facets, limit: TASK_LIST_PAGE_LIMIT });
+  let current = first;
+  const rows = [...first.rows];
+  while (current.page?.nextCursor) {
+    current = await harnessClient.getTasks({ repoId, ...facets, limit: TASK_LIST_PAGE_LIMIT, cursor: current.page.nextCursor });
+    if (current.watermark !== first.watermark || current.sourceRevision !== first.sourceRevision) {
+      throw new Error("Task projection changed while the complete list was being read.");
+    }
+    rows.push(...current.rows);
+  }
+  const { page: _page, ...complete } = first;
+  return { ...complete, rows };
+}
+
 export function useTasksQuery(repoId: string | null) {
+  const queryClient = useQueryClient(), selectedRepoId = repoId ?? "unselected", queryKey = taskQueryKeys.list(selectedRepoId);
   return useQuery({
-    ...taskListQuery(repoId ?? "unselected"),
+    ...taskListQuery(selectedRepoId),
+    queryFn: () => readTaskList(selectedRepoId, queryClient.getQueryData<TaskListSuccess>(queryKey)),
     enabled: repoId !== null
   });
 }

--- a/packages/gui/test/gui-s3-r1-repo-isolation.vitest.ts
+++ b/packages/gui/test/gui-s3-r1-repo-isolation.vitest.ts
@@ -7,8 +7,8 @@ vi.hoisted(() => {
 });
 import { catalogQueryKeys } from "../src/renderer/catalog-data.ts";
 import { controlSucceeded, selectActiveRepoId, settleDaemonControl, systemQueryKeys } from "../src/renderer/system-data.ts";
-import type { DaemonControlReceipt, SystemRepoRow } from "../src/renderer/api-client.ts";
-import { invalidateLedgerDependents, LEDGER_REFRESH_INTERVAL_MS, taskDocumentQuery, taskListQuery, taskQueryKeys } from "../src/renderer/task-data.ts";
+import type { DaemonControlReceipt, SystemRepoRow, TaskListSuccess } from "../src/renderer/api-client.ts";
+import { invalidateLedgerDependents, LEDGER_REFRESH_INTERVAL_MS, readTaskList, TASK_LIST_PAGE_LIMIT, taskDocumentQuery, taskListQuery, taskQueryKeys } from "../src/renderer/task-data.ts";
 import { triadicQueryKeys } from "../src/renderer/triadic-data.ts";
 import { favoritesStorageKey } from "../src/renderer/model/favorites.ts";
 
@@ -51,6 +51,49 @@ describe("GUI S3 R1 repository isolation", () => {
       client.clear();
       vi.useRealTimers();
     }
+  });
+
+  it("walks bounded task pages and returns one complete projection cut", async () => {
+    const getTasks = vi.fn(async (payload: { readonly repoId: string; readonly limit: number; readonly cursor?: string }) => ({
+      ok: true as const,
+      status: "ready" as const,
+      rows: [],
+      watermark: 42,
+      sourceRevision: 42,
+      warnings: [],
+      page: { limit: TASK_LIST_PAGE_LIMIT, cursor: payload.cursor ?? null, nextCursor: payload.cursor ? null : "task-page-2" }
+    }));
+    Object.defineProperty(window, "harness", { configurable: true, value: { getTasks } });
+    const result = await taskListQuery("repo-a").queryFn();
+    expect(getTasks).toHaveBeenNthCalledWith(1, { repoId: "repo-a", limit: TASK_LIST_PAGE_LIMIT });
+    expect(getTasks).toHaveBeenNthCalledWith(2, { repoId: "repo-a", limit: TASK_LIST_PAGE_LIMIT, cursor: "task-page-2" });
+    expect(result).toEqual({ ok: true, status: "ready", rows: [], watermark: 42, sourceRevision: 42, warnings: [] });
+  });
+
+  it("rejects task pages from different projection cuts", async () => {
+    const getTasks = vi.fn(async (payload: { readonly cursor?: string }) => ({
+      ok: true as const,
+      status: "ready" as const,
+      rows: [],
+      watermark: payload.cursor ? 43 : 42,
+      sourceRevision: payload.cursor ? 43 : 42,
+      warnings: [],
+      page: { limit: TASK_LIST_PAGE_LIMIT, cursor: payload.cursor ?? null, nextCursor: payload.cursor ? null : "task-page-2" }
+    }));
+    Object.defineProperty(window, "harness", { configurable: true, value: { getTasks } });
+    await expect(taskListQuery("repo-a").queryFn()).rejects.toThrow("Task projection changed while the complete list was being read.");
+  });
+
+  it("polls only rows updated since the cached complete task list", async () => {
+    const getTasks = vi.fn(async () => ({ ok: true as const, status: "ready" as const, rows: [], watermark: 43, sourceRevision: 43, warnings: [], page: { limit: TASK_LIST_PAGE_LIMIT, cursor: null, nextCursor: null } }));
+    Object.defineProperty(window, "harness", { configurable: true, value: { getTasks } });
+    const cachedRows = [
+      { taskId: "task-cached", updatedAt: "2026-08-21T23:58:00.000Z" },
+      { taskId: "task_cached", updatedAt: "2026-08-21T23:59:00.000Z" }
+    ] as TaskListSuccess["rows"];
+    const result = await readTaskList("repo-a", { ok: true, status: "ready", rows: cachedRows, watermark: 42, sourceRevision: 42, warnings: [] });
+    expect(getTasks).toHaveBeenCalledWith({ repoId: "repo-a", updatedAfter: cachedRows[1]!.updatedAt, limit: TASK_LIST_PAGE_LIMIT });
+    expect(result.rows).toEqual(cachedRows);
   });
 
   it("refreshes an open task document when the ledger cut advances", async () => {


### PR DESCRIPTION
# English

## What

The GUI re-read the entire task list every two seconds with no bound on it. `taskListQuery` called `getTasks({ repoId })` with neither `limit` nor `cursor`, and the projection only appends a `LIMIT` clause when one of those is present (`packages/kernel/src/projection/task-query-projection.ts:147`). Every poll therefore ran a full scan and shipped the whole list to the renderer.

On the real 1,433-row ledger that steady poll measured 405.41 ms p95 and 6,731,532 bytes.

## How

- The initial load walks `limit`-500 pages and refuses to stitch pages from different projection cuts: if `watermark` or `sourceRevision` moves between pages, the read throws rather than returning a torn list.
- Subsequent polls request only rows changed since the newest `updatedAt` already held, and merge that delta into the cached React Query value by `taskId`. The projection's `updated_at >= ?` filter is served by an existing index.
- Mutation rereads go through the same bounded reader.
- A complete re-read still happens whenever there is no usable cache, or when `watermark`/`sourceRevision` moves backwards.

Steady p95 fell from 405.41 ms to 2.23 ms, and the polled payload from 6,731,532 bytes to 2,553 bytes, while the merged row digest stayed identical to the old wide read.

Production-Delta: +39/-6

## Verification

`npm run test:gui`: 34 files, 304 tests passed. `npm run check:local`: fast tier passed in 78.9s.

The three added tests are additions only; no existing assertion was removed or relaxed.

Mutation check on the load-bearing guard. Baseline for `packages/gui/test/gui-s3-r1-repo-isolation.vitest.ts` is 9 passed / 0 failed. Deleting the cut-consistency `throw` in `readTaskPages` produces 8 passed / 1 failed, and the single failure is `rejects task pages from different projection cuts`. Restoring the line returns 9/9 with a clean worktree. The guard is on the path it claims to guard.

Correctness of the delta path was checked against the projection rather than assumed. No code path deletes rows from `task_snapshot` — removal is modelled as a state or disposition change — and every task-affecting event upserts the row with `updated_at = event.occurredAt` (`packages/kernel/src/projection/rebuildable-task-projection.ts:407`). A change to a task therefore always surfaces in the delta, so the merge cannot retain a stale row for a task that is still being written to.

## Residual risk

**The delta boundary is a wall-clock timestamp, not a monotonic revision, so an event carrying an `occurredAt` older than the newest one already held will be missed.** The watermark still advances, so the existing "watermark moved backwards" fallback does not fire, and the polling client silently never sees those rows.

This is reachable, not theoretical. Migration import events carry the source's original timestamps rather than the import moment: sampling `entity_migrated` events in this ledger gives `occurredAt` values spread from 2026-06-14 to 2026-08-15. Running a migration import while the GUI is open would therefore leave the imported tasks invisible until the client does a complete read again. Out-of-order arrival from remote replication has the same shape.

The correct fix is for the delta boundary to be the projection revision rather than `updatedAt`, which needs a query facet the read surface does not currently expose. That is deliberately out of scope here: this pull request does not widen the read contract. A follow-up task carries it.

Cold startup is untouched and remains dominated by an independent path: 52.26 s and 871 Git subprocesses for the projection rebuild in the isolated real-ledger measurement. That has its own task.

---

# 中文

## What

GUI 每两秒把整份任务列表重读一遍,而这个读法不带任何边界。`taskListQuery` 调 `getTasks({ repoId })`,既不给 `limit` 也不给 `cursor`,而投影层只在两者之一存在时才拼 `LIMIT` 子句(`packages/kernel/src/projection/task-query-projection.ts:147`)。**于是每一次轮询都是一次全表扫描,并把整份列表送进渲染层。**

真实的 1,433 行台账上,这次稳态轮询实测 405.41 毫秒(p95),载荷 6,731,532 字节。

## How

- **首次加载按 500 一页走,并且拒绝把不同投影切面的页拼在一起**:换页时 `watermark` 或 `sourceRevision` 变了就抛错,而不是返回一份撕裂的列表。
- **后续轮询只要「比手上最新的 `updatedAt` 更新的行」**,再按 `taskId` 合并进 React Query 已有的值。投影的 `updated_at >= ?` 过滤走的是现成索引。
- 变更后的重读走同一条有边界的读法。
- **完整重读仍会发生**:没有可用缓存时,或 `watermark`/`sourceRevision` 倒退时。

稳态 p95 从 405.41 毫秒降到 2.23 毫秒,轮询载荷从 6,731,532 字节降到 2,553 字节,**而合并后的行摘要与旧的全量读逐字节相同**。

## Verification

`npm run test:gui`:34 个文件、304 个测试通过。`npm run check:local`:fast tier 78.9 秒通过。

新增的三个测试**全是增量,没有删除或放宽任何既有断言**。

**对承重护栏做了变异检查。** `packages/gui/test/gui-s3-r1-repo-isolation.vitest.ts` 干净基线是 9 通过 / 0 失败;删掉 `readTaskPages` 里那句切面一致性的 `throw` 后是 8 通过 / 1 失败,而唯一那条失败正是「rejects task pages from different projection cuts」;恢复后回到 9/9 且工作树干净。**护栏确实在它声称把守的那条路径上。**

增量路径的正确性是**对着投影核过的,不是假定的**:没有任何代码路径从 `task_snapshot` 删行——移除在这个模型里表现为状态或 disposition 变化——而每一个触及任务的事件都会 upsert 该行并把 `updated_at` 设为 `event.occurredAt`(`packages/kernel/src/projection/rebuildable-task-projection.ts:407`)。所以一个任务发生变化就一定会出现在增量里,合并不会为仍在被写入的任务留下陈旧行。

## Residual risk

**增量的边界是墙钟时间戳而不是单调递增的 revision,所以一个 `occurredAt` 早于手上最新值的事件会被漏掉。** 此时 watermark 仍然前进,于是现有的「watermark 倒退就全量重读」那道兜底不会触发,**轮询中的客户端会静默地永远看不到那些行**。

**这是可达的,不是理论风险。** 迁移导入事件携带的是源的原始时间戳而非导入时刻:在本台账里抽样 `entity_migrated` 事件,`occurredAt` 分布在 2026-06-14 到 2026-08-15 之间。**因此 GUI 开着时跑一次迁移导入,那批任务会一直不可见,直到客户端再做一次完整读。** 远程复制的乱序到达是同一个形状。

正确的修法是把增量边界改成投影 revision 而不是 `updatedAt`,而那需要一个当前读法面没有暴露的查询 facet。**本 PR 有意不做**——它不扩宽读取契约。已由后续任务承接。

冷启动未动,仍由另一条独立路径主导:隔离环境实测投影重建 52.26 秒、871 个 Git 子进程。那条另有任务。
