### PR TITLE
fix: ignore private Harness directory families instead of enumerating members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,12 +8,11 @@
 /W2D-DISPOSAL.md
 /W2D-REPORT.md
 
-# Private self-hosted harness for this source repository.
-# This directory is versioned by its own local/private git repository and must not be
-# published with the open-source package.
-/.harness-private/
-/.harness/
+# Private self-hosted Harness state. Dot-prefixed Harness directories are runtime or
+# private data at any depth; the root workspace and old-generation copies are private.
+.harness*/
 /harness/
+/harness-old-generation-*/
 /.claude/
 /.agents/
 /.codex/
@@ -26,7 +25,6 @@ coverage/
 tmp/
 *.log
 *.tsbuildinfo
-.harness/
 .playwright-mcp/
 
 # release tarballs (npm pack output)


### PR DESCRIPTION
# English

## Summary

The ignore rules for the private Harness surface were a hand-maintained enumeration: `/.harness-private/` and `/.harness/` listed one directory each, plus one unanchored `.harness/` line. New members of the same families (`.harness-old-generation-20260818/`, `harness-old-generation-20260818/`, future dated copies) fell through and showed up as untracked noise at the repository root, one accidental `git add` away from publication. This replaces the enumeration with family patterns: dot-prefixed Harness directories are runtime or private data at any depth (`.harness*/`), and old-generation workspace copies are covered by a wildcard (`/harness-old-generation-*/`).

Production-Delta: +0/-0

## What Changed

- `.gitignore` only, +4/-6: `/.harness-private/`, `/.harness/`, and the unanchored `.harness/` line are replaced by `.harness*/` (any depth) and `/harness-old-generation-*/`; `/harness/` stays as-is.
- Removing the unanchored `.harness/` initially exposed `examples/minimal-project/.harness` — caught in review, fixed by making the family pattern `.harness*/` unanchored, and re-verified against the real nested directory.
- `.b5-baseline/` was adjudicated a one-off local worktree, not a repository family; it stays in `.git/info/exclude` rather than gaining a public ignore line.

## Task And Scope

- Harness task: `task_b81716cc0e05779bb41973ab50`
- Branch: `codex/private-boundary-ignore`
- Public scope: `.gitignore` only
- Out of scope: the 2026-08-11 publication incident found during the audit (commit `71d9a1fd` briefly tracked a sanitized engineering-discipline `AGENTS.md`, reverted 34 minutes later by `f4b85782e`). The published content carries no private paths or data; the incident is explicitly accepted, no history rewrite.

## Version Impact

- No version change; no publish.

## Governance Declaration

- Protected surface touched: no. `.gitignore` is not a CI/gate authority surface; no gate, workflow, or branch-protection change is included.
- Authority: task `task_b81716cc0e05779bb41973ab50` (private-boundary audit and ignore-family fix); incident fact `F-B830E9FB` recorded in the task ledger.
- Break-glass: no.

## Verification

- Base `origin/main` merge-base: `8e700a5ac94117435954bd2042544c0e4d5e8858`
- Positive controls, run by the CEO with real directories created on disk (the existence trap for trailing-slash patterns handled): `examples/minimal-project/.harness`, `.harness-probe`, `packages/kernel/.harness-cache`, `harness-old-generation-9999`, `harness`, `CLAUDE.md`, `AGENTS.md` — all 7 ignored with the expected rule line.
- Negative control: `git ls-files -ci --exclude-standard` returns 0 — no tracked file becomes ignored.
- Worker's `npm run check:local`: 43 steps green (fast 265/265, contract 507/507, 68.7s, Node 24.18.0).

## Review Evidence

- Self-review: worker's first iteration was sent back for the nested-`.harness` regression; the fix was re-measured by the CEO against the real directory.
- Human review: CEO re-ran every positive and negative control by hand rather than accepting the report.
- Blocking findings: none.

## Residual Risk

- `.harness*/` at any depth also covers future dot-prefixed Harness runtime directories nobody has created yet; that is the intent (the family, not a list). A legitimate future need to *track* such a directory would require an explicit negation line, which is the correct visible cost.
- The `71d9a1fd` content remains in git history on ~30 branches. Accepted: it is sanitized engineering discipline with no private surface, and a history rewrite would cost far more than it removes.

## References

- Task: `task_b81716cc0e05779bb41973ab50`
- Evidence: `harness/tasks/task_b81716cc0e05779bb41973ab50-2-2gb/artifacts/private-boundary-verification.md`

---

# 中文

## 概要

私有 Harness 面的 ignore 规则原本是手工枚举:`/.harness-private/` 与 `/.harness/` 各列一条,外加一条非锚定 `.harness/`。同族新成员(`.harness-old-generation-20260818/`、`harness-old-generation-20260818/` 及未来带日期的副本)全部漏网,在仓库根显示为未跟踪噪音,离一次误 `git add` 只差一步。本 PR 把枚举换成族模式:点前缀 Harness 目录在任意深度都是运行时或私有数据(`.harness*/`),老一代工作区副本用通配符覆盖(`/harness-old-generation-*/`)。

## 改动内容

- 仅 `.gitignore`,+4/-6:`/.harness-private/`、`/.harness/` 与非锚定 `.harness/` 三行被 `.harness*/`(任意深度)与 `/harness-old-generation-*/` 取代;`/harness/` 原样保留。
- 第一版删掉非锚定 `.harness/` 时曾暴露 `examples/minimal-project/.harness`——评审中打回,改为非锚定族模式 `.harness*/` 修复,并对真实嵌套目录复测。
- `.b5-baseline/` 裁定为一次性本机 worktree,不属于仓库级家族;留在 `.git/info/exclude`,不进公开 ignore。

## 任务与范围

- Harness 任务:`task_b81716cc0e05779bb41973ab50`
- 分支:`codex/private-boundary-ignore`
- 公开范围:仅 `.gitignore`
- 范围外:审计中发现的 2026-08-11 发布事故(commit `71d9a1fd` 短暂跟踪过一份净化版工程纪律 `AGENTS.md`,34 分钟后被 `f4b58` revert)。被发布内容不含任何私有路径或数据,事故明示接受,不做历史重写。

## 版本影响

- 无版本变更;不发布。

## 治理声明

- 是否触碰受保护面:否。`.gitignore` 不是 CI/gate 权威面;不含任何门、workflow 或分支保护变更。
- 授权来源:任务 `task_b81716cc0e05779bb41973ab50`(私有边界审计与 ignore 族修复);事故已记 fact `F-B830E9FB`。
- Break-glass:否。

## 验证

- 与 `origin/main` 的 merge-base:`8e700a5ac94117435954bd2042544c0e4d5e8858`
- 阳性对照由 CEO 在磁盘上造出真实目录后亲手复跑(已处理「目录型 pattern 对不存在路径假报」的坑):`examples/minimal-project/.harness`、`.harness-probe`、`packages/kernel/.harness-cache`、`harness-old-generation-9999`、`harness`、`CLAUDE.md`、`AGENTS.md`——7 项全部按预期规则行命中。
- 阴性对照:`git ls-files -ci --exclude-standard` 返回 0——无被跟踪文件被误伤。
- worker 的 `npm run check:local`:43 步全绿(fast 265/265,contract 507/507,68.7s,Node 24.18.0)。

## 复核证据

- 自审:worker 第一版因嵌套 `.harness` 回归被打回;修复由 CEO 对真实目录重新测量。
- 人工复核:CEO 亲手复跑全部正反对照,不采信报告。
- 阻塞性发现:无。

## 残余风险

- `.harness*/` 在任意深度也会覆盖将来才出现的点前缀 Harness 运行时目录——这正是意图(管的是族,不是清单)。未来若真要*跟踪*这样的目录,需显式加否定行,那是正确的可见成本。
- `71d9a1fd` 的内容仍留在约 30 条分支的历史里。已接受:内容是净化版工程纪律、无私有面,历史重写的代价远大于收益。

## 参考

- 任务:`task_b81716cc0e05779bb41973ab50`
- 证据:`harness/tasks/task_b81716cc0e05779bb41973ab50-2-2gb/artifacts/private-boundary-verification.md`
