### PR TITLE
feat(tools): mechanics toolbox v2 — closeout driver fixes + dispatch driver

### DIFF
--- a/tools/closeout-task.mjs
+++ b/tools/closeout-task.mjs
@@ -10,6 +10,7 @@ const requiredSubmissionFields = Object.freeze(["completionClaim", "deliverables
 const requiredReviewFields = Object.freeze(["verdict", "reason", "evidenceChecked"]);
 const requiredConsentFields = Object.freeze(["approved"]);
 const requiredCompletionFields = Object.freeze(["ci", "codeDocPaths"]);
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 export class CloseoutCommandError extends Error {
   constructor(command, status, stdout, stderr) {
@@ -30,7 +31,7 @@ function usage() {
     "  submission: completionClaim, deliverables, outputs, verificationNotes, knownGaps, residualRisks, commitSha",
     "  review: verdict, reason, evidenceChecked",
     "  consent: approved=true",
-    "  completion: ci=passed, codeDocPaths[]",
+    "  completion: ci=passed, codeDocPaths[] (empty omits reconcile; an applicable code-doc gate may reject completion)",
     "",
     "The script derives the submitter and owner actor postures from the active task, binds Review to submission.commitSha,",
     "uses the transport human as independent reviewer, and invokes every existing lifecycle gate without bypasses.",
@@ -99,14 +100,18 @@ function parseReceiptText(text, command) {
   return receipt;
 }
 
+export function resolveCloseoutLauncher({ haBin = process.env.HA_BIN } = {}) {
+  return haBin
+    ? { executable: haBin, leadingArgs: [] }
+    : { executable: process.execPath, leadingArgs: [path.join(repositoryRoot, "packages/cli/src/index.ts")] };
+}
+
 function subprocessRunner({ haBin = process.env.HA_BIN, cwd = process.cwd() } = {}) {
   return ({ args, actor }) => {
     const environment = { ...process.env };
     if (actor === null) delete environment.HARNESS_ACTOR;
     else environment.HARNESS_ACTOR = actor;
-    const launcher = haBin
-      ? { executable: haBin, leadingArgs: [] }
-      : { executable: process.execPath, leadingArgs: [path.join(cwd, "packages/cli/src/index.ts")] };
+    const launcher = resolveCloseoutLauncher({ haBin });
     const command = [launcher.executable, ...launcher.leadingArgs, "--json", ...args];
     const result = spawnSync(launcher.executable, [...launcher.leadingArgs, "--json", ...args], { cwd, env: environment, encoding: "utf8" });
     const status = result.status ?? 1, stdout = result.stdout ?? "", stderr = result.stderr ?? "";
@@ -215,8 +220,11 @@ export function runCloseout(input, dependencies = {}) {
     const consentId = deterministicId("consent-closeout", input.taskId, input.executionId, judgment.submission.commitSha);
     invoke("task-review-consent", ["task", "review-consent", input.taskId, "--execution-id", input.executionId, "--review-id", reviewId, "--consent-id", consentId], ownerActor);
 
-    const completeArgs = ["task", "complete", input.taskId, "--execution-id", input.executionId, "--ci", judgment.completion.ci, "--commit-sha", judgment.submission.commitSha, "--iteration", String(execution.iteration)];
-    for (const codePath of judgment.completion.codeDocPaths) completeArgs.push("--path", codePath);
+    const completeArgs = ["task", "complete", input.taskId, "--execution-id", input.executionId, "--ci", judgment.completion.ci];
+    if (judgment.completion.codeDocPaths.length > 0) {
+      completeArgs.push("--commit-sha", judgment.submission.commitSha, "--iteration", String(execution.iteration));
+      for (const codePath of judgment.completion.codeDocPaths) completeArgs.push("--path", codePath);
+    }
     invoke("task-complete", completeArgs, ownerActor);
     return { schema: "closeout-task-receipt/v1", ok: true, taskId: input.taskId, executionId: input.executionId, reviewId, consentId, commitSha: judgment.submission.commitSha, docSyncMode, deferredForeignCandidates: foreign.map((row) => row.path), steps: receipts };
   } finally {

--- a/tools/closeout-task.test.mjs
+++ b/tools/closeout-task.test.mjs
@@ -5,7 +5,9 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { CloseoutCommandError, parseCloseoutArgs, runCloseout, validateCloseoutJudgment } from "./closeout-task.mjs";
+import * as closeout from "./closeout-task.mjs";
+
+const { CloseoutCommandError, parseCloseoutArgs, runCloseout, validateCloseoutJudgment } = closeout;
 
 const taskId = "task-closeout", executionId = "execution-closeout", packagePath = "tasks/task-closeout-fast-path", commitSha = "a".repeat(40);
 const owner = { principal: { personId: "owner" }, executor: { kind: "agent", id: "ceo" } };
@@ -77,6 +79,44 @@ test("closeout driver preserves all gates and derives actor/content-cut bindings
     assert.deepEqual(fixture.calls.map((call) => call.actor), [null, "agent:worker", "agent:worker", "agent:worker", null, "agent:ceo", "agent:ceo"]);
     const complete = fixture.calls.at(-1).args;
     assert.deepEqual(complete, ["task", "complete", taskId, "--execution-id", executionId, "--ci", "passed", "--commit-sha", commitSha, "--iteration", "0", "--path", "tools/closeout-task.mjs"]);
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("default CLI entry is anchored to the closeout script instead of the caller cwd", () => {
+  const callerCwd = path.join(import.meta.dirname, "fixtures", "nested-cwd");
+  assert.equal(typeof closeout.resolveCloseoutLauncher, "function");
+  assert.deepEqual(closeout.resolveCloseoutLauncher({ cwd: callerCwd }), {
+    executable: process.execPath,
+    leadingArgs: [path.join(import.meta.dirname, "..", "packages", "cli", "src", "index.ts")],
+  });
+});
+
+test("empty codeDocPaths omits the complete reconcile tuple", () => {
+  const temporaryDirectory = mkdtempSync(path.join(os.tmpdir(), "ha-closeout-empty-paths-"));
+  const fixture = successfulRunner();
+  const packet = judgment();
+  packet.completion.codeDocPaths = [];
+  try {
+    runCloseout({ taskId, executionId, judgment: packet }, { run: fixture.run, temporaryDirectory });
+    assert.deepEqual(fixture.calls.at(-1).args, ["task", "complete", taskId, "--execution-id", executionId, "--ci", "passed"]);
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("empty codeDocPaths preserves the code-doc completion gate rejection", () => {
+  const temporaryDirectory = mkdtempSync(path.join(os.tmpdir(), "ha-closeout-code-doc-gate-"));
+  const rejection = new CloseoutCommandError(["ha", "task", "complete"], 1, JSON.stringify({ ok: false, code: "code_doc_missing" }), "");
+  const fixture = successfulRunner({ "task-complete": () => { throw rejection; } });
+  const packet = judgment();
+  packet.completion.codeDocPaths = [];
+  try {
+    assert.throws(
+      () => runCloseout({ taskId, executionId, judgment: packet }, { run: fixture.run, temporaryDirectory }),
+      (error) => error === rejection && error.stdout.includes("code_doc_missing"),
+    );
   } finally {
     rmSync(temporaryDirectory, { recursive: true, force: true });
   }

--- a/tools/dispatch-task.mjs
+++ b/tools/dispatch-task.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const requiredFlags = Object.freeze(["--plan-file", "--preset", "--title", "--instance"]);
+const optionalFlags = Object.freeze(["--prompt-file"]);
+
+export class DispatchCommandError extends Error {
+  constructor(command, status, stdout, stderr) {
+    super(`${command.join(" ")} exited ${status}`);
+    this.name = "DispatchCommandError";
+    this.command = command;
+    this.status = status;
+    this.stdout = stdout;
+    this.stderr = stderr;
+  }
+}
+
+function usage() {
+  return [
+    "Usage: node tools/dispatch-task.mjs --plan-file <task_plan.md> --preset <preset-id> --title <title> --instance <runtime-instance-id> [--prompt-file <prompt-file>]",
+    "",
+    "Creates the Task, writes the caller-authored plan to the packagePath returned by task create, acquires the execution lease,",
+    "dispatches runtime run --detach, and returns the JSONL path plus a directly executable background sentinel command.",
+    "The script does not generate plan/title judgments and does not monitor, retry, or resume the dispatched runtime.",
+  ].join("\n");
+}
+
+export function parseDispatchArgs(argv) {
+  if (argv.length === 1 && (argv[0] === "--help" || argv[0] === "-h")) return { help: true };
+  const accepted = new Set([...requiredFlags, ...optionalFlags]);
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index], value = argv[index + 1];
+    if (!accepted.has(flag) || typeof value !== "string" || value.trim().length === 0) throw new Error(usage());
+    if (values.has(flag)) throw new Error(`${flag} may be supplied once.\n\n${usage()}`);
+    values.set(flag, value);
+  }
+  if (requiredFlags.some((flag) => !values.has(flag))) throw new Error(usage());
+  return {
+    help: false,
+    planFile: values.get("--plan-file"),
+    preset: values.get("--preset"),
+    title: values.get("--title"),
+    instance: values.get("--instance"),
+    promptFile: values.get("--prompt-file"),
+  };
+}
+
+function parseReceiptText(text, command) {
+  let receipt;
+  try {
+    receipt = JSON.parse(text);
+  } catch {
+    throw new Error(`${command.join(" ")} did not return one JSON receipt.`);
+  }
+  if (!receipt || typeof receipt !== "object" || Array.isArray(receipt)) throw new Error(`${command.join(" ")} returned an invalid receipt.`);
+  return receipt;
+}
+
+function subprocessRunner({ haBin = process.env.HA_BIN, cwd }) {
+  return ({ args }) => {
+    const launcher = haBin
+      ? { executable: haBin, leadingArgs: [] }
+      : { executable: process.execPath, leadingArgs: [path.join(repositoryRoot, "packages/cli/src/index.ts")] };
+    const command = [launcher.executable, ...launcher.leadingArgs, "--json", ...args];
+    const result = spawnSync(launcher.executable, [...launcher.leadingArgs, "--json", ...args], { cwd, env: process.env, encoding: "utf8" });
+    const status = result.status ?? 1, stdout = result.stdout ?? "", stderr = result.stderr ?? "";
+    if (status !== 0) throw new DispatchCommandError(command, status, stdout, stderr);
+    return { command, receipt: parseReceiptText(stdout, command) };
+  };
+}
+
+function findWorkspaceRoot(start = repositoryRoot) {
+  let current = path.resolve(start);
+  for (;;) {
+    if (existsSync(path.join(current, "harness", "harness.yaml"))) return current;
+    const parent = path.dirname(current);
+    if (parent === current) throw new Error(`Could not find harness/harness.yaml above ${start}.`);
+    current = parent;
+  }
+}
+
+function receiptText(receipt, field, step) {
+  const value = receipt?.[field];
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${step} receipt has no ${field}; refusing to infer it.`);
+  return value;
+}
+
+function shellQuote(value) {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+export function turnCompletedCountCommand(jsonlPath) {
+  const target = shellQuote(jsonlPath);
+  return `if [ -f ${target} ]; then grep -c '"type":"turn.completed"' ${target} || true; else printf '0\\n'; fi`;
+}
+
+export function dispatchSentinelCommand(jsonlPath) {
+  const target = shellQuote(jsonlPath), count = turnCompletedCountCommand(jsonlPath);
+  return `(while :; do completed=$(${count}); if [ "$completed" -gt 0 ]; then printf '%s\\n' ${target}; break; fi; sleep 5; done) &`;
+}
+
+export function runDispatch(input, dependencies = {}) {
+  const callerCwd = dependencies.cwd ?? process.cwd();
+  const workspaceRoot = dependencies.workspaceRoot ?? findWorkspaceRoot();
+  const planSource = path.resolve(callerCwd, input.planFile);
+  const planBody = readFileSync(planSource, "utf8");
+  if (planBody.trim().length === 0) throw new Error("--plan-file must contain the caller-authored task plan.");
+  const promptFile = input.promptFile === undefined ? undefined : path.resolve(callerCwd, input.promptFile);
+  if (promptFile !== undefined) readFileSync(promptFile, "utf8");
+
+  const run = dependencies.run ?? subprocessRunner({ cwd: workspaceRoot });
+  const steps = [];
+  const invoke = (step, args) => {
+    const result = run({ step, args });
+    steps.push({ step, command: result.command, receipt: result.receipt });
+    return result.receipt;
+  };
+
+  const created = invoke("task-create", ["task", "create", "--title", input.title, "--preset", input.preset]);
+  const taskId = receiptText(created, "taskId", "task create");
+  const packagePath = receiptText(created, "packagePath", "task create");
+  const planPath = path.join(workspaceRoot, "harness", ...packagePath.split("/"), "task_plan.md");
+  writeFileSync(planPath, planBody, "utf8");
+  steps.push({ step: "plan-write", source: planSource, path: planPath });
+
+  const started = invoke("task-start", ["task", "start", taskId]);
+  const executionId = receiptText(started, "executionId", "task start");
+  const runtimeArgs = ["runtime", "run", input.instance, "--task", taskId, "--detach"];
+  if (promptFile !== undefined) runtimeArgs.push("--prompt-file", promptFile);
+  const dispatched = invoke("runtime-run", runtimeArgs);
+  const dispatchId = receiptText(dispatched, "dispatchId", "runtime run");
+  const runtimeSessionId = receiptText(dispatched, "runtimeSessionId", "runtime run");
+  const dispatchJsonlPath = path.join(workspaceRoot, ".harness", "runtime", "dispatches", `${dispatchId}.jsonl`);
+  const sentinelCommand = dispatchSentinelCommand(dispatchJsonlPath);
+  steps.push({ step: "sentinel", path: dispatchJsonlPath, command: sentinelCommand });
+
+  return { schema: "dispatch-task-receipt/v1", ok: true, taskId, executionId, packagePath, planPath, dispatchId, runtimeSessionId, dispatchJsonlPath, sentinelCommand, steps };
+}
+
+function main() {
+  try {
+    const parsed = parseDispatchArgs(process.argv.slice(2));
+    if (parsed.help) {
+      process.stdout.write(`${usage()}\n`);
+      return;
+    }
+    process.stdout.write(`${JSON.stringify(runDispatch(parsed), null, 2)}\n`);
+  } catch (error) {
+    if (error instanceof DispatchCommandError) {
+      process.stdout.write(error.stdout);
+      process.stderr.write(error.stderr);
+      process.exitCode = error.status;
+      return;
+    }
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 2;
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/tools/dispatch-task.test.mjs
+++ b/tools/dispatch-task.test.mjs
@@ -1,0 +1,129 @@
+// harness-test-tier: fast
+
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { DispatchCommandError, dispatchSentinelCommand, parseDispatchArgs, runDispatch, turnCompletedCountCommand } from "./dispatch-task.mjs";
+
+const taskId = "task_receipt_truth", executionId = "exe_receipt_truth";
+const packagePath = "tasks/server-returned-path-no-guessed-slug";
+const dispatchId = `dispatch_${"a".repeat(24)}`, runtimeSessionId = "runtime_receipt_truth";
+
+function successfulRunner(workspaceRoot, overrides = {}) {
+  const calls = [];
+  const run = ({ step, args }) => {
+    calls.push({ step, args });
+    if (overrides[step]) return overrides[step]({ step, args, calls });
+    if (step === "task-create") {
+      mkdirSync(path.join(workspaceRoot, "harness", ...packagePath.split("/")), { recursive: true });
+      return { command: ["ha", ...args], receipt: { ok: true, taskId, packagePath } };
+    }
+    if (step === "task-start") return { command: ["ha", ...args], receipt: { ok: true, taskId, executionId } };
+    return { command: ["ha", ...args], receipt: { ok: true, dispatchId, runtimeSessionId } };
+  };
+  return { calls, run };
+}
+
+test("dispatch driver walks create, returned package path, start, detach, and sentinel", () => {
+  const workspaceRoot = mkdtempSync(path.join(os.tmpdir(), "ha-dispatch-dry-"));
+  const planFile = path.join(workspaceRoot, "caller-plan.md");
+  writeFileSync(planFile, "# Caller-authored plan\n\nDo the bounded work.\n", "utf8");
+  const fixture = successfulRunner(workspaceRoot);
+  try {
+    const receipt = runDispatch({ planFile, preset: "standard-task", title: "A title whose slug must not be guessed", instance: "codex-worker" }, { workspaceRoot, run: fixture.run });
+    assert.equal(readFileSync(receipt.planPath, "utf8"), readFileSync(planFile, "utf8"));
+    assert.equal(receipt.packagePath, packagePath);
+    assert.equal(receipt.planPath, path.join(workspaceRoot, "harness", ...packagePath.split("/"), "task_plan.md"));
+    assert.equal(existsSync(path.join(workspaceRoot, "harness", "tasks", "a-title-whose-slug-must-not-be-guessed")), false);
+    assert.deepEqual(fixture.calls, [
+      { step: "task-create", args: ["task", "create", "--title", "A title whose slug must not be guessed", "--preset", "standard-task"] },
+      { step: "task-start", args: ["task", "start", taskId] },
+      { step: "runtime-run", args: ["runtime", "run", "codex-worker", "--task", taskId, "--detach"] },
+    ]);
+    assert.deepEqual(receipt.steps.map((step) => step.step), ["task-create", "plan-write", "task-start", "runtime-run", "sentinel"]);
+    assert.equal(receipt.dispatchJsonlPath, path.join(workspaceRoot, ".harness", "runtime", "dispatches", `${dispatchId}.jsonl`));
+    assert.equal(receipt.sentinelCommand, dispatchSentinelCommand(receipt.dispatchJsonlPath));
+    assert.match(receipt.sentinelCommand, /turn\.completed/u);
+    assert.match(receipt.sentinelCommand, /\) &$/u);
+  } finally {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("task create receipt without packagePath stops instead of guessing a package directory", () => {
+  const workspaceRoot = mkdtempSync(path.join(os.tmpdir(), "ha-dispatch-no-path-"));
+  const planFile = path.join(workspaceRoot, "plan.md");
+  writeFileSync(planFile, "# Plan\n", "utf8");
+  const fixture = successfulRunner(workspaceRoot, {
+    "task-create": ({ args }) => ({ command: ["ha", ...args], receipt: { ok: true, taskId } }),
+  });
+  try {
+    assert.throws(
+      () => runDispatch({ planFile, preset: "standard-task", title: "Never guess me", instance: "codex-worker" }, { workspaceRoot, run: fixture.run }),
+      /receipt has no packagePath; refusing to infer/u,
+    );
+    assert.deepEqual(fixture.calls.map((call) => call.step), ["task-create"]);
+  } finally {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("optional prompt file is validated before create and forwarded to runtime", () => {
+  const workspaceRoot = mkdtempSync(path.join(os.tmpdir(), "ha-dispatch-prompt-"));
+  const planFile = path.join(workspaceRoot, "plan.md"), promptFile = path.join(workspaceRoot, "prompt.md");
+  writeFileSync(planFile, "# Plan\n", "utf8");
+  writeFileSync(promptFile, "Use the supplied worker posture.\n", "utf8");
+  const fixture = successfulRunner(workspaceRoot);
+  try {
+    runDispatch({ planFile, promptFile, preset: "standard-task", title: "Prompt dispatch", instance: "codex-worker" }, { workspaceRoot, run: fixture.run });
+    assert.deepEqual(fixture.calls.at(-1).args, ["runtime", "run", "codex-worker", "--task", taskId, "--detach", "--prompt-file", promptFile]);
+  } finally {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("lifecycle rejection is rethrown unchanged and runtime is not dispatched", () => {
+  const workspaceRoot = mkdtempSync(path.join(os.tmpdir(), "ha-dispatch-gate-"));
+  const planFile = path.join(workspaceRoot, "plan.md");
+  writeFileSync(planFile, "# Plan\n", "utf8");
+  const rejection = new DispatchCommandError(["ha", "task", "start"], 1, JSON.stringify({ ok: false, code: "task_wip_limit_reached" }), "");
+  const fixture = successfulRunner(workspaceRoot, { "task-start": () => { throw rejection; } });
+  try {
+    assert.throws(
+      () => runDispatch({ planFile, preset: "standard-task", title: "Rejected dispatch", instance: "codex-worker" }, { workspaceRoot, run: fixture.run }),
+      (error) => error === rejection && error.stdout.includes("task_wip_limit_reached"),
+    );
+    assert.deepEqual(fixture.calls.map((call) => call.step), ["task-create", "task-start"]);
+  } finally {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("turn.completed count is one clean integer for zero matches and a missing file", { skip: process.platform === "win32" ? "requires POSIX shell command semantics emitted by the sentinel" : false }, () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "ha-dispatch-sentinel-"));
+  const emptyPath = path.join(directory, "empty.jsonl"), missingPath = path.join(directory, "missing.jsonl");
+  writeFileSync(emptyPath, `${JSON.stringify({ type: "thread.started" })}\n`, "utf8");
+  try {
+    for (const target of [emptyPath, missingPath]) {
+      const result = spawnSync("sh", ["-c", turnCompletedCountCommand(target)], { encoding: "utf8" });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout, "0\n");
+    }
+    writeFileSync(emptyPath, `${JSON.stringify({ event: { type: "turn.completed" } })}\n`, "utf8");
+    assert.equal(spawnSync("sh", ["-c", turnCompletedCountCommand(emptyPath)], { encoding: "utf8" }).stdout, "1\n");
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("CLI arguments and help expose exactly the supported judgment inputs", () => {
+  assert.deepEqual(parseDispatchArgs(["--plan-file", "plan.md", "--preset", "standard-task", "--title", "Dispatch", "--instance", "codex-worker"]), {
+    help: false, planFile: "plan.md", preset: "standard-task", title: "Dispatch", instance: "codex-worker", promptFile: undefined,
+  });
+  assert.equal(parseDispatchArgs(["--help"]).help, true);
+  assert.throws(() => parseDispatchArgs(["--plan-file", "plan.md", "--preset", "standard-task", "--title", "Dispatch"]), /Usage:/u);
+  assert.throws(() => parseDispatchArgs(["--plan-file", "plan.md", "--preset", "standard-task", "--title", "Dispatch", "--instance", "one", "--instance", "two"]), /may be supplied once/u);
+});


### PR DESCRIPTION
# English

## Summary

Second slice of the CEO mechanics-downgrade line: fix the two defects the deterministic closeout driver (`tools/closeout-task.mjs`, #1698) exposed in its first real-world closeout, and add `tools/dispatch-task.mjs`, which collapses the five mechanical dispatch steps (task create → write plan into the receipt-reported package path → start lease → detached runtime run → emit a clean file-level sentinel command) into one deterministic entry. Judgment content (the plan itself, titles, verdicts) still comes from the caller. Both fixes were proven in production during this very task's closeout, executed from a subdirectory with a non-empty codeDocPaths packet.

Production-Delta: +0/-0

## What Changed

- `tools/closeout-task.mjs`: CLI entrypoint now resolves from the script's own location instead of caller cwd (was: MODULE_NOT_FOUND when run from a subdirectory); an empty `codeDocPaths` no longer emits an orphan `--commit-sha` to `ha task complete` (was: invalid_field), and the `code_doc_missing` gate semantics pass through verbatim.
- New `tools/dispatch-task.mjs`: deterministic dispatch driver; takes packagePath only from the create receipt (refuses to guess slugs), writes the caller-authored plan byte-for-byte, and emits a sentinel command whose zero-match and missing-file outputs are a single clean integer (the hand-rolled `0\n0` sentinel bug is encoded as a negative test).
- Tests for both drivers (tier: fast, marker-registered): 15 pass / 0 fail; pre-fix red frames recorded in the task closeout.

## Task And Scope

- Harness task: task_c14f184f44178c39ba991e66f2
- Branch: codex/mechanical-toolbox-v2
- Public scope: tools/ only; no packages/ or CI changes
- Private planning/evidence updated: yes
- Out of scope: runtime spawn surfaces; lifecycle gate semantics; architecture-check tooling

## Version Impact

- Version: no version change because this changes repo-local tools, not a published package surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task_c14f184f44178c39ba991e66f2 (derived from CEO-side cost measurement, task_b077112f30c5f4086bb2fbc1b5)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: none

## Verification

- Base `origin/main` SHA: 8ea68968a
- Branch merge-base with `origin/main`: 8ea68968a (branch based on latest main)
- Last `git fetch origin` time: 2026-08-22 (immediately before PR)
- Sync method: none needed
- Public diff command: git diff origin/main...codex/mechanical-toolbox-v2
- Private evidence commit/path: harness ledger, task package task_c14f184f44178c39ba991e66f2 (closeout with pre-fix red frames, Fact F-4E28DCFB, dogfood-failures artifact)
- Reviewer evidence path: task package reviews/ (review-closeout-53d5b1ce37083390)
- GitHub Actions `rewrite-ci` run URL: pending first run on this PR
- [x] `npm test` (targeted: run-node-tests --tier fast on both driver test files, 15/15, re-run by CEO in the worktree; walls preflight 12 PASS / 0 RED)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: unchecked commands are covered by rewrite-ci on this PR; diff is tools/-only with no packages/ source changes, so the targeted test files plus CI are the honest stop point.

## Review Evidence

- Self-review: implementing worker (Codex Sol) recorded pre-fix red frames for both defects and a five-step dry receipt chain for the dispatch driver
- Reviewer subagent: ledger review review-closeout-53d5b1ce37083390 (approved) driven by the fixed closeout driver itself
- Human review: pending (this PR)
- Blocking findings: none; production proof — this task's own ledger closeout was executed with the fixed driver from a subdirectory cwd with non-empty codeDocPaths, exercising both fixes end-to-end (submit → review → consent → code-doc reconcile → complete, final state accepted)

## Residual Risk

- Both drivers encode current `ha` CLI contracts; contract changes fail loudly (verbatim gate errors) but require driver updates.
- `dispatch-task.mjs` was verified against a dry receipt chain, not a paid provider dispatch; its first real dispatch is the next CEO dispatch after merge.

## References

- Task: task_c14f184f44178c39ba991e66f2
- Evidence: task closeout.md, artifacts/dogfood-failures.md, Fact F-4E28DCFB
- Review: review-closeout-53d5b1ce37083390

---

# 中文

## 概要

CEO 机械活降档线第二刀:修复确定性销账驱动器(`tools/closeout-task.mjs`,#1698)首次实战暴露的两个缺陷,并新增 `tools/dispatch-task.mjs`,把派工的五步机械动作(task create → 按回执 packagePath 写入 plan → start 持锁 → detach runtime run → 输出干净的文件级哨兵命令)收窄为一条确定性入口。判断性内容(plan 本身、标题、裁决)仍由调用者提供。两个修复已在本任务自身的台账销账中实战验证:站在子目录 cwd、带非空 codeDocPaths 的判断包,整条链一次走通。

## 改动内容

- `tools/closeout-task.mjs`:CLI 入口改为按脚本自身位置解析,不再依赖调用方 cwd(原缺陷:子目录下 MODULE_NOT_FOUND);空 `codeDocPaths` 不再向 `ha task complete` 传孤立 `--commit-sha`(原缺陷:invalid_field),`code_doc_missing` 门语义原样透传。
- 新增 `tools/dispatch-task.mjs`:确定性派工驱动;packagePath 只从 create 回执获取(拒绝猜 slug),逐字节写入调用者提供的 plan,输出的哨兵命令对零命中/文件缺失两态均为单个干净整数(手搓哨兵的 `0\n0` bug 已固化为负例测试)。
- 两驱动器的测试(tier: fast,marker 登记):15 pass / 0 fail;修前红帧记录于任务 closeout。

## 任务与范围

- Harness 任务:task_c14f184f44178c39ba991e66f2
- 分支:codex/mechanical-toolbox-v2
- 公开范围:仅 tools/;不涉及 packages/ 与 CI
- 私有计划 / 证据是否已更新:yes
- 范围外:runtime spawn 面;生命周期门语义;architecture-check 工具链

## 版本影响

- 版本:不改版本,原因是仅变更仓库内工具,不触及发布包面
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:task_c14f184f44178c39ba991e66f2(由 CEO 侧成本测量任务 task_b077112f30c5f4086bb2fbc1b5 派生)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:无

## 验证

- `origin/main` 基准 SHA:8ea68968a
- 当前分支与 `origin/main` 的 merge-base:8ea68968a(基于最新 main)
- 最近一次 `git fetch origin` 时间:2026-08-22(开 PR 前即刻)
- 同步方式:不需要
- 公开 diff 命令:git diff origin/main...codex/mechanical-toolbox-v2
- 私有证据 commit/path:harness 台账,任务包 task_c14f184f44178c39ba991e66f2(closeout 含修前红帧、Fact F-4E28DCFB、dogfood-failures artifact)
- Reviewer 证据路径:任务包 reviews/(review-closeout-53d5b1ce37083390)
- GitHub Actions `rewrite-ci` run URL:本 PR 首个 run 待触发
- [x] `npm test`(定向:run-node-tests --tier fast 两驱动器测试文件 15/15,CEO 在 worktree 复跑;walls 预检 12 PASS / 0 RED)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:未勾选命令由本 PR 的 rewrite-ci 覆盖;diff 仅 tools/、无 packages/ 源码变更,定向测试 + CI 是诚实停止点。

## 审查证据

- 自查:实现 worker(Codex Sol)记录两缺陷修前红帧与派工驱动五步干跑回执链
- Reviewer subagent:台账复核 review-closeout-53d5b1ce37083390(approved),由修复版销账驱动器本身驱动
- 人工审查:待本 PR
- 阻塞发现:无;生产实证——本任务自己的台账销账即用修复版驱动器在子目录 cwd、非空 codeDocPaths 下端到端走通(submit → review → consent → code-doc reconcile → complete,终态 accepted)

## 残余风险

- 两驱动器编码当前 `ha` CLI 契约;契约变更时大声失败(门错误原样透传)但需随之更新。
- `dispatch-task.mjs` 以干跑回执链验证,未做真实付费 provider 派工;合并后 CEO 的下一次真实派工即其首次实战。

## 关联材料

- 任务:task_c14f184f44178c39ba991e66f2
- 证据:任务 closeout.md、artifacts/dogfood-failures.md、Fact F-4E28DCFB
- 审查:review-closeout-53d5b1ce37083390

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文:`# English` 在上,`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] If the PR touches a manifest-derived protected surface, Governance Declaration is filled with ADR/decision/task evidence or break-glass fields. / 若 PR 触碰 manifest 派生的 protected surface,Governance Declaration 已填写 ADR/decision/task 依据或 break-glass 字段。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No ignored local agent entry files are included. / 不包含被忽略的本地 agent 入口文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
- [x] Private planning/evidence updates are recorded when applicable. / 适用时已记录私有计划 / 证据更新。
- [x] Version and publish impact are stated. / 已说明版本与发布影响。
- [x] Local verification commands are recorded honestly. / 已如实记录本地验证命令。
- [x] CI results are linked or explained. / CI 结果已链接或说明。
- [x] Review evidence is recorded. / 已记录审查证据。
- [x] Open P0/P1/P2 findings are closed, deferred with owner, or explicitly blocked. / open P0/P1/P2 findings 已关闭、带 owner 延后,或明确阻塞。
- [x] Merge method and post-merge branch cleanup plan are clear. / 合并方式和合并后分支清理计划清楚。
- [x] No admin bypass is planned unless explicitly approved and recorded. / 除非明确批准并记录,否则不计划 admin bypass。
