### PR TITLE
fix(daemon): reject task-bound runtime self-review

### DIFF
--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -181,7 +181,7 @@ export async function openRepoCell(input: { readonly repoId: WorkspaceId; readon
   async function lifecycleAction(action: RepoTaskAction, binding: RepoCellBinding): Promise<WriteReceipt> { const taskId = requiredCellText(action.taskId, "taskId"), current = await service.read(taskId), expectedRevision = current.snapshot.revision;
     const normalized = buildCommand(action, taskId, binding, input.repoId, expectedRevision, rootDir, current.snapshot);
     const command = withServerMeta(normalized, store.readTaskEvent(normalized.opId), store.readHead()?.revision ?? 0, now());
-    const result = await service.execute(command, await proofFor(command, current.snapshot, binding));
+    const result = await service.execute(command, await proofFor(command, current.snapshot, binding, projection));
     if (result.outcome === "applied" && result.event && result.proof) return lifecycleReceipt(result.event, result.snapshot, publicPublication(store.publication(result.event)), result.proof);
     if (result.outcome === "pending") return { outcome: "pending", opId: command.opId, revision: result.revision, evidence: result.evidence, visibility: result.visibility, proof: result.proof, nextAction: result.nextAction ?? "Retry receipt show." };
     return rejected(command.opId, result.code ?? "publication_unknown", result.nextAction ?? "Retry receipt show before resubmitting.");
@@ -209,7 +209,7 @@ export async function openRepoCell(input: { readonly repoId: WorkspaceId; readon
     // The lifecycle service publishes one task event whose carried-document
     // claims and machine lifecycle claims share the same canonical commit.
     // Projection replay therefore restores both sides after any crash.
-    const current = await service.read(taskId), normalized = buildCommand(taskAction as RepoTaskAction, taskId, binding, input.repoId, current.snapshot.revision, rootDir, current.snapshot), command = withServerMeta(normalized, store.readTaskEvent(normalized.opId), store.readHead()?.revision ?? 0, now()), proof = await proofFor(command, current.snapshot, binding);
+    const current = await service.read(taskId), normalized = buildCommand(taskAction as RepoTaskAction, taskId, binding, input.repoId, current.snapshot.revision, rootDir, current.snapshot), command = withServerMeta(normalized, store.readTaskEvent(normalized.opId), store.readHead()?.revision ?? 0, now()), proof = await proofFor(command, current.snapshot, binding, projection);
     let transition: Awaited<ReturnType<typeof service.executeWithDocuments>>;
     try { transition = await service.executeWithDocuments(command, proof, { changes: carriedChanges, blobs: adjudication.decision.blobs }); }
     finally { recycleClaims(rootDir, intent); }
@@ -324,14 +324,14 @@ function buildCommand(action: RepoTaskAction, taskId: string, binding: RepoCellB
 }
 function withServerMeta(command: Omit<TaskLifecycleCommand, "eventId" | "workspaceRevision" | "occurredAt">, existing: ReturnType<ReturnType<typeof makeTaskEventStore>["readTaskEvent"]>, revision: number, occurredAt: string): TaskLifecycleCommand {
   return { ...command, eventId: existing?.eventId ?? `event-${createHash("sha256").update(command.opId).digest("hex")}`, workspaceRevision: existing?.workspaceRevision ?? revision + 1, occurredAt: existing?.occurredAt ?? occurredAt } as TaskLifecycleCommand; }
-async function proofFor(command: TaskLifecycleCommand, snapshot: Snapshot, binding: RepoCellBinding): Promise<TaskLifecycleServiceProof<typeof command>> {
+async function proofFor(command: TaskLifecycleCommand, snapshot: Snapshot, binding: RepoCellBinding, projection: Pick<ReturnType<typeof makeTaskProjection>, "readRuntimeSession">): Promise<TaskLifecycleServiceProof<typeof command>> {
   if (command.type === "CreateReplayTask") return { taskIdUnique: true, actorBinding: command.actor };
   if (command.type === "StartExecution") { const ttlMs = command.ttlMs ?? leaseTtlMs; return { actorBinding: command.actor, reservation: { taskId: command.taskId, executionId: command.executionId, expiresAt: new Date(Date.parse(command.occurredAt) + ttlMs).toISOString(), ttlMs, previousHolder: null, reason: "initial_claim", version: 0 } }; }
   if (command.type === "TransitionTask") return {};
   if (command.type === "SubmitExecution") { const lease = snapshot.lease; if (!lease || lease.phase !== "held" || lease.executionId !== command.executionId || !isSameExecution(lease.actor, command.actor)) throw cellCodedError("lease_required", "Submit requires the active execution lease bound to this actor.");
     return { actorBinding: command.actor, leaseVersion: lease.version, sessionDisposition: "unavailable" };
   }
-  if (command.type === "RecordReview") { if (!binding.roles?.includes("$arbiter")) throw cellCodedError("actor_unauthorized", "Execution Review requires the arbiter command class; give the reviewing person a role that carries it in harness/people.yaml."); const blocked = reviewerDependence(command.actor, snapshot); if (blocked) throw cellCodedError("actor_unauthorized", blocked); return { actorBinding: command.actor, capability: "execution-review@v1", capabilityRef: `transport-reviewer:${command.actor.principal.personId}` }; }
+  if (command.type === "RecordReview") { if (!binding.roles?.includes("$arbiter")) throw cellCodedError("actor_unauthorized", "Execution Review requires the arbiter command class; give the reviewing person a role that carries it in harness/people.yaml."); const runtimeSessionId = runtimeSessionIdFromActor(command.actor), runtimeSession = runtimeSessionId === null ? null : projection.readRuntimeSession(runtimeSessionId); if (runtimeSession?.taskBindings.some((taskBinding) => taskBinding.taskId === command.taskId && taskBinding.executionId === command.executionId)) throw cellCodedError("runtime_task_self_review_forbidden", "This runtime is bound to the task and execution under review and cannot review its own work."); const blocked = reviewerDependence(command.actor, snapshot); if (blocked) throw cellCodedError("actor_unauthorized", blocked); return { actorBinding: command.actor, capability: "execution-review@v1", capabilityRef: `transport-reviewer:${command.actor.principal.personId}` }; }
   if (command.type === "RecordReviewConsent") { if (!snapshot.task || !isSameExecution(snapshot.task.createdBy, command.actor)) throw cellCodedError("actor_unauthorized", "Review consent requires the Task owner."); return { actorBinding: command.actor, capability: "execution-consent@v1", capabilityRef: `task-owner:${command.actor.principal.personId}` }; }
   if (command.type === "ReconcileCodeDoc") return { actorBinding: command.actor, capability: "code-doc-reconcile@v1", capabilityRef: `transport-writer:${command.actor.principal.personId}` };
   return completeProof(command, snapshot) as TaskLifecycleServiceProof<typeof command>;

--- a/packages/daemon/test/review-independence-diagnostics.integration.test.ts
+++ b/packages/daemon/test/review-independence-diagnostics.integration.test.ts
@@ -125,3 +125,78 @@ test("a bare-invocation execution has a visible warning and an audited recovery 
     rmSync(rootDir, { recursive: true, force: true });
   }
 });
+
+test("task-bound runtime sessions cannot review their own execution across exit and resume", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-review-runtime-bound-"));
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    initRepo(rootDir);
+    const processes: { exit: ((code: number | null) => void) | null }[] = [];
+    let providerSequence = 0;
+    cell = await openRepoCell({
+      repoId: workspaceId("review-runtime-bound"), rootDir: canonicalRoot(rootDir), ownerId: "daemon-test",
+      runtimeDaemonRoute: { userRoot: rootDir, daemonId: "daemon-test", endpoint: path.join(rootDir, "daemon.sock") },
+      prepareRuntimeLaunch: (_instanceId, request) => {
+        const providerSessionId = request.providerSessionId ?? `provider-${++providerSequence}`;
+        return { definition: { schema: "agent-definition-snapshot/v1", configVersion: 1, instanceId: "review-runtime", installationId: "review-runtime-installation", kindId: "codex", providerId: "openai", model: "review-model", reasoningEffort: "medium", baseUrl: null, authMode: "subscription" }, installation: { installationId: "review-runtime-installation", kindId: "codex", executablePath: "/test/review-runtime", version: "1.0.0", observedAt: "2026-08-22T00:00:00.000Z" }, executablePath: "/test/review-runtime", args: [providerSessionId], env: {}, cwd: request.cwd, prompt: request.prompt };
+      },
+      runtimeLaunch: (prepared) => {
+        const process = { exit: null as ((code: number | null) => void) | null }, providerSessionId = prepared.args[0]!;
+        processes.push(process);
+        return { pid: 1_001 + processes.length, onOutput: (listener) => { queueMicrotask(() => listener(`${JSON.stringify({ type: "thread.started", thread_id: providerSessionId })}\n`)); }, onErrorOutput: () => undefined, onExit: (listener) => { process.exit = listener; }, terminate: () => process.exit?.(0) };
+      }
+    });
+    const principal = { personId: "person-worker" } as const, implementer = { actor: { principal, executor: { kind: "agent" as const, id: "implementer" } }, source: "local" as const }, arbiter = (id: string) => ({ actor: { principal, executor: { kind: "agent" as const, id } }, source: "local" as const, roles: ["$arbiter"] });
+    const taskId = "task-runtime-bound", executionId = "execution-runtime-bound";
+    assert.equal((await cell.run({ kind: "task-create", taskId, title: "Runtime-bound review" }, implementer)).outcome, "applied");
+    assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, implementer)).outcome, "applied");
+
+    const original = await cell.spawnRuntime({ runtimeInstanceId: "review-runtime", cwd: { scope: "repo-root" }, prompt: "Implement the task.", taskId, idempotencyKey: "original-runtime" }, implementer);
+    await runtimeEvent(rootDir, "review-runtime-bound", (event) => event.type === "runtime_session_task_bound" && event.payload.runtimeSessionId === original.runtimeSessionId);
+    processes[0]!.exit?.(0);
+    await runtimeEvent(rootDir, "review-runtime-bound", (event) => event.type === "runtime_session_exited" && event.payload.runtimeSessionId === original.runtimeSessionId);
+
+    const resumed = await cell.spawnRuntime({ runtimeInstanceId: "review-runtime", cwd: { scope: "repo-root" }, prompt: "Resume the task.", taskId, providerSessionId: "provider-1", idempotencyKey: "resumed-runtime" }, implementer);
+    await runtimeEvent(rootDir, "review-runtime-bound", (event) => event.type === "runtime_session_task_bound" && event.payload.runtimeSessionId === resumed.runtimeSessionId);
+
+    const commitSha = git(rootDir, "rev-parse", "HEAD");
+    writeFileSync(path.join(rootDir, "submission.json"), JSON.stringify({ completionClaim: "Ready.", deliverables: ["d"], outputs: ["o"], verificationNotes: ["v"], knownGaps: [], residualRisks: [], commitSha }));
+    assert.equal((await cell.run({ kind: "task-submit", taskId, executionId, fromFile: "submission.json" }, implementer)).outcome, "applied");
+    writeFileSync(path.join(rootDir, "review.json"), JSON.stringify({ verdict: "approved", reason: "Reviewed.", evidenceChecked: ["tests"], commitSha, iteration: 0 }));
+
+    for (const [reviewId, runtimeSessionId] of [["review-exited", original.runtimeSessionId], ["review-resumed", resumed.runtimeSessionId]] as const) {
+      const denied = await cell.run({ kind: "task-review-execution", taskId, executionId, reviewId, fromFile: "review.json" }, arbiter(`runtime-session:${runtimeSessionId}`));
+      assert.equal(denied.code, "runtime_task_self_review_forbidden");
+      assert.match(String(denied.nextAction), /runtime is bound to the task and execution under review and cannot review its own work/u);
+      assert.doesNotMatch(String(denied.nextAction), /(?:retry|resume|run ha)/iu);
+    }
+
+    // A dedicated reviewer runtime has no binding to this task/execution, so the new gate stays narrow.
+    const unbound = await cell.spawnRuntime({ runtimeInstanceId: "review-runtime", cwd: { scope: "repo-root" }, prompt: "Review only.", taskId: null, idempotencyKey: "unbound-reviewer" }, implementer);
+    await runtimeEvent(rootDir, "review-runtime-bound", (event) => event.type === "runtime_session_provider_bound" && event.payload.runtimeSessionId === unbound.runtimeSessionId);
+    const reviewedByRuntime = await cell.run({ kind: "task-review-execution", taskId, executionId, reviewId: "review-unbound", fromFile: "review.json" }, arbiter(`runtime-session:${unbound.runtimeSessionId}`));
+    assert.equal(reviewedByRuntime.outcome, "applied", JSON.stringify(reviewedByRuntime));
+
+    const directTaskId = "task-direct-review", directExecutionId = "execution-direct-review";
+    assert.equal((await cell.run({ kind: "task-create", taskId: directTaskId, title: "Direct review" }, implementer)).outcome, "applied");
+    assert.equal((await cell.run({ kind: "task-start", taskId: directTaskId, executionId: directExecutionId }, implementer)).outcome, "applied");
+    const directCommitSha = git(rootDir, "rev-parse", "HEAD");
+    writeFileSync(path.join(rootDir, "submission.json"), JSON.stringify({ completionClaim: "Ready.", deliverables: ["d"], outputs: ["o"], verificationNotes: ["v"], knownGaps: [], residualRisks: [], commitSha: directCommitSha }));
+    assert.equal((await cell.run({ kind: "task-submit", taskId: directTaskId, executionId: directExecutionId, fromFile: "submission.json" }, implementer)).outcome, "applied");
+    writeFileSync(path.join(rootDir, "review.json"), JSON.stringify({ verdict: "approved", reason: "Reviewed by another agent.", evidenceChecked: ["tests"], commitSha: directCommitSha, iteration: 0 }));
+    // A child/non-runtime agent has no runtime-session identity; existing executor independence decides it.
+    const reviewedByAgent = await cell.run({ kind: "task-review-execution", taskId: directTaskId, executionId: directExecutionId, reviewId: "review-child-agent", fromFile: "review.json" }, arbiter("child-reviewer"));
+    assert.equal(reviewedByAgent.outcome, "applied", JSON.stringify(reviewedByAgent));
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+async function runtimeEvent(rootDir: string, repoId: string, matches: (event: ReturnType<ReturnType<typeof makeTaskEventStore>["read"]>["events"][number]) => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (makeTaskEventStore({ repoId, rootDir }).read().events.some(matches)) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("runtime event did not arrive");
+}


### PR DESCRIPTION
# English

## Summary

Native dispatch injects `HARNESS_ACTOR=agent:runtime-session:<id>` into the worker process, and review independence compared only executor ids — so the same process could approve its own execution under a "different" identity, defeating the independence rationale of dec_0302A1FB/CH3 (owner consent still blocked self-completion; the exposure was a fabricated green review). Per dec_89737215986F7C19BBB7813A45/CH1 (owner-adjudicated 2026-08-22, option B): the RecordReview authorization now also consults the system-owned runtime session task binding — a runtime session bound to the exact task and execution under review is refused with `runtime_task_self_review_forbidden`. The check anchors on the binding relation, which cannot be freely minted, instead of the identity label, which can. Other people, other agents, and reviewer runtimes not bound to the task still review as before. `independentReviewer` is not relaxed, no `--self-review` is added, and executor self-description is untouched.

Production-Delta: +4/-4

## What Changed

- `packages/daemon/src/repo-cell.ts`: the `RecordReview` proof branch reads the caller's runtime session (same `runtimeSessionIdFromActor` + `readRuntimeSession` reads the progress write path already uses) and rejects when its task bindings contain the reviewed task/execution pair. `proofFor` gains the projection parameter to make that read possible. The refusal message states the cause plainly and points at no unreachable recovery.
- `packages/daemon/test/review-independence-diagnostics.integration.test.ts`: a task-bound runtime cannot review its own execution — across process exit and resume — while an unbound runtime and a direct agent identity still can (positive controls). Removing the guard wiring re-reds exactly this test (2 pass / 1 fail).
- The guard deliberately ignores session liveness: a dead-but-still-bound session is also refused (fail-closed).

## Task And Scope

- Harness task: `task_e7b976693e49743b36c95d0792` (derives from `dec_89737215986F7C19BBB7813A45` CH1)
- Branch: `codex/review-selfreview-ban`, rebased onto `a093fdcac` (after PR #1706)
- Public scope: `packages/daemon` authorization, tests
- Out of scope: restoring append-only multi-review (CH2) — separate task `task_f54ae54beb7236762729701553`, dispatched after this lands because both touch the review write path.

## Version Impact

- No version change; no publish.

## Governance Declaration

- Protected surface touched: no gate/CI change, no new command surface. An authorization check is tightened under an in-effect decision.
- Authority: `dec_89737215986F7C19BBB7813A45` CH1; task `task_e7b976693e49743b36c95d0792`; investigation `task_0ccbb860fcb241a152d033976e` with fact `F-5D3DEE2F`.
- Break-glass: no.

## Verification

- Base `origin/main` merge-base: `a093fdcacd3bad6e6538e279a1e3219b33f268f4`
- Worker: focused baseline 2/2 before the guard; pre-fix regression 2 pass / 1 fail; post-fix 3/3; guard-removal mutation 2 pass / 1 fail; restored 3/3; `check:local` 45/45.
- CEO: read the full production diff (guard reuses the progress path's session reads — no second enumeration); reran the guard-removal mutation independently (re-reds exactly the new test); after rebasing onto the newer main, repaired the test fixture for PR #1705's sealed-daemon-route precondition (`runtimeDaemonRoute` added to the fixture's `openRepoCell`) and reran: focused 3/3, `check:local` 45/45 in 92.1s; production delta measured with the gate's own script.

## Review Evidence

- Self-review: worker report with red-green-mutation counts recorded in the task progress ledger.
- Human review: CEO verified the diff shape, the anchor choice (binding relation, not identity label), and the fail-closed liveness stance; independently reran the mutation control.
- Blocking findings: none. One landing repair: the fixture predates PR #1705 and needed the sealed daemon route.

## Residual Risk

- A runtime session that was never task-bound (spawned with `taskId: null`) can still review any execution its actor is otherwise authorized for — that is the intended reviewer-runtime path, now the only runtime path.

## References

- Decision: `dec_89737215986F7C19BBB7813A45`
- Task: `task_e7b976693e49743b36c95d0792`
- Investigation: `task_0ccbb860fcb241a152d033976e` (PR #1703 landed its segment-3 fix)

---

# 中文

## 概要

原生派工会把 `HARNESS_ACTOR=agent:runtime-session:<id>` 注入 worker 进程,而复核独立性只比对 executor id——同一进程可以用"另一个身份"给自己的 execution 写 approved Review,dec_0302A1FB/CH3 的独立性理由被架空(owner consent 仍拦住自我完成;暴露面是伪造绿色复核)。按 `dec_89737215986F7C19BBB7813A45`/CH1(泽宇 2026-08-22 亲裁,B 方案):RecordReview 授权现在还要查 system-owned 的 runtime session task binding——绑定着待审 task 与 execution 的 runtime session 被以 `runtime_task_self_review_forbidden` 拒绝。检查锚定不可自由铸造的绑定关系,而不是可自由铸造的身份标签。其他人、其他 agent、未绑定该任务的 reviewer runtime 照常可审。不放宽 `independentReviewer`、不加 `--self-review`、不动 executor 自述机制。

## 改动内容

- `packages/daemon/src/repo-cell.ts`:`RecordReview` 的 proof 分支读取调用方的 runtime session(与 progress 写路同一套 `runtimeSessionIdFromActor` + `readRuntimeSession` 读法),其 task bindings 含被审 task/execution 对时拒绝。`proofFor` 增加 projection 参数以支撑这次读取。拒绝报文直说原因,不指向不可达的恢复路径。
- `packages/daemon/test/review-independence-diagnostics.integration.test.ts`:task-bound runtime 不能审自己的 execution——跨进程退出与 resume 均成立——而未绑定 runtime 与直接 agent 身份仍可审(阳性对照)。删掉 guard 接线恰好重新红这条测试(2 pass / 1 fail)。
- guard 有意不看 session 活性:已死但仍绑定的 session 同样拒绝(fail-closed)。

## 任务与范围

- Harness 任务:`task_e7b976693e49743b36c95d0792`(derives 自 `dec_89737215986F7C19BBB7813A45` CH1)
- 分支:`codex/review-selfreview-ban`,rebase 到 `a093fdcac`(PR #1706 之后)
- 公开范围:`packages/daemon` 授权与测试
- 范围外:恢复 append-only 多 Review(CH2)——独立任务 `task_f54ae54beb7236762729701553`,因两者都碰 review 写路,等本 PR 落地后派发。

## 版本影响

- 无版本变更;不发布。

## 治理声明

- 是否触碰受保护面:无门/CI 变更、无新增命令面。在 in_effect 决策授权下收紧一处授权检查。
- 授权来源:`dec_89737215986F7C19BBB7813A45` CH1;任务 `task_e7b976693e49743b36c95d0792`;调查 `task_0ccbb860fcb241a152d033976e` 与 fact `F-5D3DEE2F`。
- Break-glass:否。

## 验证

- 与 `origin/main` 的 merge-base:`a093fdcacd3bad6e6538e279a1e3219b33f268f4`
- worker:guard 前基线 2/2;修前回归 2 pass / 1 fail;修后 3/3;删 guard 变异 2 pass / 1 fail;还原 3/3;`check:local` 45/45。
- CEO:通读生产 diff(guard 复用 progress 写路的 session 读法,无第二份枚举);独立复跑删 guard 变异(恰好重新红那条新测试);rebase 到新 main 后,为 PR #1705 的 sealed-daemon-route 前置修补测试 fixture(`openRepoCell` 补 `runtimeDaemonRoute`)并复跑:焦点 3/3、`check:local` 45/45(92.1s);生产行数用门同款脚本实测。

## 复核证据

- 自审:worker 报告,红-绿-变异计数落任务 progress 台账。
- 人工复核:CEO 核验 diff 形状、锚定选择(绑定关系而非身份标签)与 fail-closed 活性立场;独立复跑变异对照。
- 阻塞性发现:无。落地修补一处:fixture 早于 PR #1705,需补 sealed daemon route。

## 残余风险

- 从未绑定任务的 runtime session(`taskId: null` 起的)仍可审其 actor 本就有权审的 execution——这正是预期中的 reviewer-runtime 路径,现在是唯一的 runtime 审路。

## 参考

- 决策:`dec_89737215986F7C19BBB7813A45`
- 任务:`task_e7b976693e49743b36c95d0792`
- 调查:`task_0ccbb860fcb241a152d033976e`(其第三段修复经 PR #1703 落地)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
