### PR TITLE
test(gui): assert the overview census through the page that renders it

### DIFF
--- a/packages/gui/test/overview-streams.vitest.ts
+++ b/packages/gui/test/overview-streams.vitest.ts
@@ -6,6 +6,7 @@ import type { DecisionRow, TaskRow } from "../src/renderer/model/types.ts";
 import { DecisionStream } from "../src/renderer/components/overview/DecisionStream.tsx";
 import { TaskStream } from "../src/renderer/components/overview/TaskStream.tsx";
 import { BoardView } from "../src/renderer/views/BoardView.tsx";
+import { OverviewView } from "../src/renderer/views/OverviewView.tsx";
 import { PinnedStream } from "../src/renderer/components/overview/PinnedStream.tsx";
 import { RuntimeHealthCard } from "../src/renderer/components/overview/RuntimeHealthCard.tsx";
 import { DecisionPreviewDrawer } from "../src/renderer/components/DecisionPreviewDrawer.tsx";
@@ -35,6 +36,12 @@ function decision(patch: Partial<DecisionRow>): DecisionRow {
 }
 
 const noop = () => {};
+// Read one status tab's rendered text exactly. A loose `testid … label … count` regex
+// matches any later digit in the document, so it stays green when the count is wrong.
+const tabText = (markup: string, testId: string): string | null => {
+  const found = markup.match(new RegExp(`data-testid="${testId}"[^>]*>([\\s\\S]*?)</button>`, "u"));
+  return found === null ? null : found[1]!.replace(/<!--[\s\S]*?-->/gu, "").replace(/\s+/gu, " ").trim();
+};
 const taskSummary = (patch: Partial<WorkspaceSummaryRead["tasks"]["byStatus"]> = {}): WorkspaceSummaryRead["tasks"] => {
   const byStatus = { planned: 0, active: 0, blocked: 0, in_review: 0, done: 0, cancelled: 0, unknown: 0, ...patch };
   return { total: Object.values(byStatus).reduce((sum, count) => sum + count, 0), byStatus };
@@ -120,8 +127,34 @@ describe("overview task stream", () => {
       expect(board).toContain(`data-testid="board-status-${status}-count">${drawn}</span>`);
     }
     expect(summary.total).toBe(visible.length);
-    expect(overview).toMatch(/data-testid="overview-status-active"[\s\S]*?进行中[\s\S]*?2/);
-    expect(overview).toMatch(/data-testid="overview-status-blocked"[\s\S]*?已阻塞[\s\S]*?1/);
+    expect(tabText(overview, "overview-status-active")).toBe("进行中 2");
+    expect(tabText(overview, "overview-status-blocked")).toBe("已阻塞 1");
+  });
+
+  // The test above renders TaskStream directly, so it proves the leaf agrees with the
+  // census but says nothing about the page that feeds it. Render the overview page so
+  // breaking the census on its way to the leaf has somewhere to go red.
+  it("carries the daemon census through the overview page into the task stream", () => {
+    const rows = [
+      task({ taskId: "task_a1", title: "Active one", coordinationStatus: "active" }),
+      task({ taskId: "task_a2", title: "Active two", coordinationStatus: "active" }),
+      task({ taskId: "task_b1", title: "Blocked one", coordinationStatus: "blocked" }),
+    ];
+    const page = renderToStaticMarkup(createElement(OverviewView, {
+      project: { id: "proj", name: "Harness", path: "/repo", preset: "software/coding", engines: [], watermarkAt: "2026-08-01T00:00:00.000Z" },
+      tasks: rows,
+      decisions: [],
+      workspaceSummary: {
+        schema: "daemon.workspace-summary/v1", ok: true, status: "ready", warnings: [], watermark: 1, sourceRevision: 1,
+        tasks: taskSummary({ active: 2, blocked: 1 }), decisions: decisionSummary({ proposed: 1 }),
+      },
+      relations: [],
+      systemHealth: { daemon: null, repo: null, projection: null },
+      onSelect: noop, onDrill: noop, onOpenInbox: noop, onOpenDecision: noop, onOpenSystem: noop,
+    }));
+
+    expect(tabText(page, "overview-status-active")).toBe("进行中 2");
+    expect(tabText(page, "overview-status-blocked")).toBe("已阻塞 1");
   });
 
   it("filters to the selected status in place with census counts on every tab (sidebar parity)", () => {


### PR DESCRIPTION
# English

## Summary

An anti-entropy audit of the day's merged pull requests found that the census equality test shipped in #1716 does not cover the wiring it claims to protect. Zeroing the summary where `OverviewView` hands it to `TaskStream` leaves the whole GUI suite green, because the test renders `TaskStream` directly. The same test also matched its expected count with a pattern loose enough that any later digit in the document satisfied it. This adds a test that renders the overview page and reads each status tab exactly.

Production-Delta: +0/-0

## What Changed

- `packages/gui/test/overview-streams.vitest.ts`: a new case renders `OverviewView` with a full workspace summary and asserts the census reaches the task stream through the production wiring.
- The same file gains a `tabText` helper that extracts one status tab's rendered text and compares it exactly; the pre-existing leaf assertions move onto it, because they had the same loose-match defect.

## Task And Scope

- Harness task: task_b6a9dac33ddc9325b9aa799a8f
- Branch: codex/overview-wiring-test
- Public scope: GUI overview census tests only; no production code changes
- Private planning/evidence updated: yes
- Out of scope: the two other audit findings (a sibling error exit in `progress_lease_mismatch`, and precondition messages in a closeout tool that a separate line already deletes), both routed to existing tasks

## Version Impact

- Version: no version change because this changes only tests
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: task_b6a9dac33ddc9325b9aa799a8f (anti-entropy audit of 2026-08-22 merges), finding on #1716
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: a780e0798
- Branch merge-base with `origin/main`: a780e0798
- Last `git fetch origin` time: 2026-08-23 Asia/Taipei
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/overview-wiring-test`
- Private evidence commit/path: task package artifacts
- Reviewer evidence path: task package audit report
- GitHub Actions `rewrite-ci` run URL: pending on this pull request
- [x] `npm run check:local` (fast tier)
- [x] `npm run test:gui` (34 files, 308 tests)
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: the full local gate set is retired in favour of GitHub CI, which is the complete authority for this repository.

## Review Evidence

- Self-review: the first version of this test used the same loose pattern as the one it was fixing and did NOT catch the mutation — the audit's mutation left 308 tests passing. The assertion was rewritten to read the tab text exactly, and the mutation then failed exactly one test with `expected '进行中 0' to be '进行中 2'`. Restoring the mutation returns the suite to 34 files and 308 tests passing.
- Reviewer subagent: the finding itself came from an independent audit worker that supplied its own positive control and targeted mutation.
- Human review: pending
- Blocking findings: none

## Residual Risk

- The overview page is now covered at the census seam only. Other props it passes down remain unasserted at the page level.

## References

- Task: task_b6a9dac33ddc9325b9aa799a8f
- Evidence: task package audit report
- Review: this pull request

---

# 中文

## 概要

对当日已合入 PR 的反熵审计发现:#1716 交付的普查等式测试并没有覆盖它声称守住的接线。把 `OverviewView` 交给 `TaskStream` 的那份汇总变异为 0,整个 GUI 套件仍然全绿——因为测试直接渲染的是 `TaskStream`。同一条测试断言计数用的模式还足够松,文档里任何一个后续数字都能满足它。本 PR 补一条渲染总览页面的测试,并按精确文本读取每个状态页签。

## 改动内容

- `packages/gui/test/overview-streams.vitest.ts`:新增用例渲染 `OverviewView`(带完整 workspace summary),断言普查经生产接线到达任务流。
- 同文件新增 `tabText` 辅助函数,提取某个状态页签渲染出的文本并精确比较;原有的叶子断言一并改用它——它们有同样的松散匹配缺陷。

## 任务与范围

- Harness 任务:task_b6a9dac33ddc9325b9aa799a8f
- 分支:codex/overview-wiring-test
- 公开范围:仅 GUI 总览普查测试;不改生产代码
- 私有计划 / 证据是否已更新:yes
- 范围外:审计的另两条 finding(`progress_lease_mismatch` 的兄弟出口,以及某销账工具的前置检查文案——该工具正被另一条线整体删除),均已路由到既有任务

## 版本影响

- 版本:不改版本,原因是本次只改测试
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:task_b6a9dac33ddc9325b9aa799a8f(2026-08-22 合入批次的反熵审计)对 #1716 的 finding
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:a780e0798
- 当前分支与 `origin/main` 的 merge-base:a780e0798
- 最近一次 `git fetch origin` 时间:2026-08-23 Asia/Taipei
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...codex/overview-wiring-test`
- 私有证据 commit/path:任务包 artifacts
- Reviewer 证据路径:任务包审计报告
- GitHub Actions `rewrite-ci` run URL:本 PR 上待跑
- [x] `npm run check:local`(fast tier)
- [x] `npm run test:gui`(34 文件 / 308 测试)
- [x] `git diff --check`
- [ ] `npm run check`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:本地全量门集已退役,GitHub CI 是本仓完整权威。

## 审查证据

- 自查:这条测试的第一版沿用了它要修的那条测试的松散模式,**没有**抓住变异——审计那条变异下仍是 308 条全绿。断言改写为精确读取页签文本后,同一变异恰好只让一条测试红,报错为 `expected '进行中 0' to be '进行中 2'`;恢复变异后回到 34 文件 / 308 测试全绿。
- Reviewer subagent:该 finding 由独立审计 worker 提出,并自带阳性对照与针对性变异。
- 人工审查:待办
- 阻塞发现:无

## 残余风险

- 总览页面目前只在普查这个接缝上被覆盖;它向下传递的其他 props 在页面层仍无断言。

## 关联材料

- 任务:task_b6a9dac33ddc9325b9aa799a8f
- 证据:任务包审计报告
- 审查:本 PR
