### PR TITLE
test(gui): add interaction test capability and replace source-text wiring assertions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1608,6 +1608,23 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.63.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
@@ -2555,6 +2572,19 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/builder-util": {
       "version": "26.15.3",
@@ -3510,6 +3540,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
@@ -4294,6 +4337,25 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.11.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.6.tgz",
+      "integrity": "sha512-Hldbg8AdAa5a5oDcZpjqnGitp7JB0hqWmfv/8qr+kft4vzSD8BHsbdRfzYvL/0QcbKcURC/yyoygbeDQarPvYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -8530,6 +8592,16 @@
         "tslib": "^2.8.1"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8596,6 +8668,28 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
@@ -8775,6 +8869,7 @@
         "@vitejs/plugin-react": "6.0.5",
         "electron": "42.5.1",
         "electron-builder": "^26.15.3",
+        "happy-dom": "^20.11.6",
         "playwright-core": "1.62.1",
         "tailwindcss": "^4.3.2",
         "vite": "8.1.4",

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -42,6 +42,7 @@
     "@vitejs/plugin-react": "6.0.5",
     "electron": "42.5.1",
     "electron-builder": "^26.15.3",
+    "happy-dom": "^20.11.6",
     "playwright-core": "1.62.1",
     "tailwindcss": "^4.3.2",
     "vite": "8.1.4",

--- a/packages/gui/test/agent-runtime-sessions.vitest.ts
+++ b/packages/gui/test/agent-runtime-sessions.vitest.ts
@@ -3,8 +3,6 @@ import { beforeAll, describe, expect, it } from "vitest";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
 import { OrchestrationCard } from "../src/renderer/components/runtime/OrchestrationCard.tsx";
 import { RuntimeInspector } from "../src/renderer/components/runtime/RuntimeInspector.tsx";
 import { RuntimeRail } from "../src/renderer/components/runtime/RuntimeRail.tsx";
@@ -74,16 +72,6 @@ describe("sessions as a first-class view", () => {
     expect(markup).toMatch(/data-testid="orchestration-session-dispatch_aaa"(?![^>]*data-session=)/u);
     // The session the task points at is itself selectable in the rail — the reverse leg lands.
     expect(railView([boundRow], null)).toContain('data-testid="rail-session-runtime-bound"');
-  });
-
-  it("routes both jump directions through the rail selection in the workspace composition", async () => {
-    const source = await readFile(new URL("../src/renderer/views/RuntimeWorkspace.tsx", import.meta.url), "utf8");
-    expect(source).toMatch(/const focusSession = \(runtimeSessionId: string\) => setSelection\(\{ type: "session", id: runtimeSessionId \}\);/u);
-    expect(source).toMatch(/onFocusSession=\{focusSession\}/u);
-    expect(source).toMatch(/onSelectSession=\{focusSession\}/u);
-    expect(source).toMatch(/onOpenTask=\{\(taskId\) => setSelection\(\{ type: "orchestration", id: taskId \}\)\}/u);
-    expect(source).not.toMatch(/SessionsDock|sessions-dock/u);
-    expect(existsSync(new URL("../src/renderer/components/runtime/SessionsDock.tsx", import.meta.url))).toBe(false);
   });
 
   it("mirrors the selected session in the inspector with the same task jump", () => {

--- a/packages/gui/test/runtime-workspace-interactions.vitest.ts
+++ b/packages/gui/test/runtime-workspace-interactions.vitest.ts
@@ -1,0 +1,118 @@
+// harness-test-tier: integration
+// @vitest-environment happy-dom
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { RuntimeWorkspace } from "../src/renderer/views/RuntimeWorkspace.tsx";
+import { agentRuntimeClient } from "../src/renderer/agent-runtime-client.ts";
+import { setActiveLocale } from "../src/renderer/i18n/core.ts";
+
+const definition = { schema: "agent-definition-snapshot/v1", configVersion: 1, instanceId: "w4c-verify-codex", installationId: "codex-install", kindId: "codex", providerId: "openai", model: "gpt-5.6-terra", reasoningEffort: null, baseUrl: null, authMode: "subscription" } as const;
+const session = (runtimeSessionId: string, taskId: string) => ({ runtimeSessionId, providerSessionId: `provider-${runtimeSessionId}`, instanceId: "w4c-verify-codex", installationId: "codex-install", kindId: "codex", definitionSnapshotRef: "artifact:runtime-definition/test", definitionSnapshot: definition, liveness: "live", attachCapability: "supported", streamCursor: "stream:4", associations: [{ taskId, executionId: "execution-1", holder: { personId: "person-owner", executorId: null }, lease: { phase: "held", expiresAt: "2026-08-23T01:00:00.000Z" } }], activity: { lastObservedAt: "2026-08-23T00:00:00.000Z", outcome: null, exitCode: null, resultRef: null } } as const);
+const boundSession = session("runtime-bound", "task-bound"), siblingSession = session("runtime-sibling", "task-sibling");
+const boundDispatch = { dispatchId: "dispatch_bbb", taskId: "task-bound", executionId: "execution-1", runtimeSessionId: "runtime-bound", instanceId: "w4c-verify-codex", agentId: "terra", agentName: "terra", providerSessionId: null, eventStreamRef: null, startedAt: "2026-08-23T02:00:00.000Z", endedAt: null, outcome: null, status: "running" } as const;
+const siblingDispatch = { ...boundDispatch, dispatchId: "dispatch_sibling", taskId: "task-sibling", executionId: "execution-2", runtimeSessionId: "runtime-sibling", agentName: "terra sibling", startedAt: "2026-08-23T01:00:00.000Z" } as const;
+const tasks = [{ taskId: "task-bound", title: "Bound task title" }, { taskId: "task-sibling", title: "Sibling task title" }] as const;
+const mounted: { readonly root: Root; readonly client: QueryClient }[] = [];
+
+beforeAll(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  setActiveLocale("en-US");
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const { root, client } of mounted.splice(0)) { root.unmount(); client.clear(); }
+  });
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("runtime workspace interaction wiring", () => {
+  it("selects a rail session into the main workspace", async () => {
+    await mountWorkspace();
+
+    await click("rail-session-runtime-bound");
+
+    expect(byTestId("rail-session-runtime-bound").getAttribute("aria-current")).toBe("true");
+    expect(byTestId("session-detail").textContent).toContain("runtime-bound");
+  });
+
+  it("focuses a dispatch's live session from the task composition", async () => {
+    await mountWorkspace();
+    await click("rail-orchestration-task-bound");
+
+    await click("orchestration-session-dispatch_bbb");
+
+    expect(byTestId("rail-session-runtime-bound").getAttribute("aria-current")).toBe("true");
+    expect(byTestId("session-detail").textContent).toContain("runtime-bound");
+  });
+
+  it("opens the bound task from the selected session", async () => {
+    await mountWorkspace();
+    await click("rail-session-runtime-bound");
+
+    await click("session-open-task");
+
+    expect(byTestId("rail-orchestration-task-bound").getAttribute("aria-current")).toBe("true");
+    expect(byTestId("orchestration-panel").getAttribute("data-task")).toBe("task-bound");
+  });
+
+  it("focuses a related session from the workspace inspector", async () => {
+    await mountWorkspace();
+    await click("rail-session-runtime-bound");
+    const inspector = byTestId("runtime-inspector");
+    const sibling = [...inspector.querySelectorAll("button")].find((button) => button.textContent?.includes("Sibling task title"));
+    expect(sibling).toBeInstanceOf(HTMLButtonElement);
+
+    await act(async () => { sibling!.click(); });
+    await flushEffects();
+
+    expect(byTestId("rail-session-runtime-sibling").getAttribute("aria-current")).toBe("true");
+    expect(byTestId("session-detail").textContent).toContain("runtime-sibling");
+  });
+});
+
+async function mountWorkspace() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  client.setQueryData(["runtime-instances", "machine"], { installations: [], instances: [] });
+  client.setQueryData(["runtime-control", "repo-a", "overview"], { ok: true, status: "ready", installations: [], instances: [], sessions: [boundSession, siblingSession], watermark: 1, sourceRevision: 1 });
+  client.setQueryData(["agents", "repo-a"], []);
+  client.setQueryData(["squads", "repo-a"], []);
+  client.setQueryData(["runtime-panorama", "repo-a", "task-bound,task-sibling"], [
+    { ...boundDispatch, taskTitle: "Bound task title", squad: null },
+    { ...siblingDispatch, taskTitle: "Sibling task title", squad: null }
+  ]);
+  client.setQueryData(["catalog", "repo-a", "snapshot"], { presets: [] });
+  client.setQueryData(["agent-skills", "repo-a"], []);
+  client.setQueryData(["orchestration", "repo-a", "task-bound", "documents", 0], { documents: [
+    { path: "tasks/task-bound-verify/artifacts/missions/dispatch_bbb.md", blobSha256: "a".repeat(64), size: 10, mediaType: "text/markdown" },
+    { path: "tasks/task-bound-verify/artifacts/dispatches/dispatch_bbb.json", blobSha256: "b".repeat(64), size: 10, mediaType: "text/plain" }
+  ] });
+  client.setQueryData(["orchestration", "repo-a", "task-bound", "dispatches", 0], { dispatches: [boundDispatch] });
+  vi.spyOn(agentRuntimeClient, "session").mockImplementation(async (_repoId, runtimeSessionId) => ({ ok: true, status: "ready", session: runtimeSessionId === "runtime-sibling" ? siblingSession : boundSession, result: null, watermark: 1, sourceRevision: 1 }));
+  vi.spyOn(agentRuntimeClient, "attach").mockReturnValue(() => undefined);
+  const container = document.createElement("div"), root = createRoot(container);
+  document.body.append(container);
+  mounted.push({ root, client });
+  await act(async () => {
+    root.render(createElement(QueryClientProvider, { client }, createElement(RuntimeWorkspace, { repoId: "repo-a", tasks })));
+  });
+  return container;
+}
+
+async function click(testId: string) {
+  await act(async () => { byTestId(testId).click(); });
+  await flushEffects();
+}
+
+async function flushEffects() {
+  await act(async () => { await Promise.resolve(); });
+}
+
+function byTestId(testId: string): HTMLElement {
+  const element = document.querySelector(`[data-testid="${testId}"]`);
+  expect(element, `missing data-testid=${testId}`).toBeInstanceOf(HTMLElement);
+  return element as HTMLElement;
+}

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -1,6 +1,7 @@
 export const guiVitestManifest = [
   "packages/gui/test/agent-runtime-renderer.vitest.ts",
   "packages/gui/test/agent-runtime-sessions.vitest.ts",
+  "packages/gui/test/runtime-workspace-interactions.vitest.ts",
   "packages/gui/test/agent-dispatch.vitest.ts",
   "packages/gui/test/runtime-provider-planes.vitest.ts",
   "packages/gui/test/local-main-controls.vitest.ts",


### PR DESCRIPTION
# English

## Summary

This repository's GUI tests run in `environment: "node"` with no DOM, so components could only be rendered to static markup. That covers what a component renders, but nothing about what happens when you click it. Where a test needed to cover composition-layer wiring — which callback the workspace hands to which child — the only option left was matching source text:

```
expect(source).toMatch(/const focusSession = \(runtimeSessionId: string\) => setSelection\(\{ type: "session", id: runtimeSessionId \}\);/u);
```

That assertion is brittle against a harmless rename and does not actually establish that clicking does anything. The gap has cost this repository before: PR #1719 fixed a defect living in exactly that layer, where no test had ever rendered the overview page and a wrong count stayed green across 34 files.

Interaction tests are now possible, and the five source-text assertions covering session navigation are replaced by four tests that mount the real workspace, click, and assert what changed.

## What Changed

- `happy-dom` is the only new direct dependency, declared per file through `@vitest-environment happy-dom` rather than switched on globally. The other 59 static-render call sites keep running under `node` and are untouched.
- Interaction is driven by `react-dom/client` `createRoot` plus React's own `act`. No testing library was added — the goal was the capability, and `react-dom` was already a dependency.
- `packages/gui/test/runtime-workspace-interactions.vitest.ts` mounts `RuntimeWorkspace`, clicks a rail session, and asserts the selection and the detail region actually changed; the same for the inspector's related-session focus and both task-jump directions.
- The source-text test in `agent-runtime-sessions.vitest.ts` is deleted, not left beside the new one.
- Two `expect(source)` assertions remain elsewhere and are deliberately kept: they assert that renderer source contains no repository read, no private WebSocket, and no polling path. Those are static constraints about what must not exist, which is what source scanning is for.

## Task And Scope

- Harness task: task_14f34d1faeabb75a56f9e2ac03
- Branch: `codex/gui-interaction-tests`
- Public scope: `packages/gui` tests, `packages/gui/package.json`, `package-lock.json`, `tools/gui-test-manifest.mjs`
- Private planning/evidence updated: yes
- Out of scope: all production code, CI job structure, the 59 existing static-render call sites

## Version Impact

- Version: no version change because no production code changed
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `package-lock.json`, `packages/gui/package.json`, `tools/gui-test-manifest.mjs`
- Authority: task_14f34d1faeabb75a56f9e2ac03. The dependency addition is the substance of the task rather than an incidental edit, and the manifest registration is what `npm run test:gui` requires of every new GUI test file — without it the suite refuses to run. Licenses were reviewed per package: `happy-dom` 20.11.6 and its six transitive additions are all MIT or BSD-2-Clause, all on the allowed list, with `npm audit` reporting zero vulnerabilities. No gate was modified or waived.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 108fa3140969e373eea446c7861a6108c7e46275
- Branch merge-base with `origin/main`: 108fa3140969e373eea446c7861a6108c7e46275
- Last `git fetch origin` time: 2026-08-23, immediately before the branch was created
- Sync method: none needed
- Public diff command: `git diff origin/main...codex/gui-interaction-tests`
- Private evidence commit/path: task package `artifacts/worker-report.md`
- Reviewer evidence path: task package `artifacts/`
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `npm run check:local` (45 steps, fast tier, green in the branch worktree)
- [x] `npm run test:gui` (36 files, 322 tests)
- [x] `npm run harness:check-supply-chain` including the CycloneDX SBOM and license gates
- [x] `npm audit`: zero vulnerabilities
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: `npm run test:integration` — excluded from the fast local tier and covered by cloud CI.

Production-Delta: +0/-0
Dependency-Change: add happy-dom ^20.11.6 to packages/gui devDependencies, pinned by the lockfile, bringing seven transitive additions that are all MIT or BSD-2-Clause and already on the allowed-license list

The point of this change is that the new tests fail when the wiring breaks, so that is what was verified rather than the pass count. The implementer reports four mutations, each turning its test red. The reviewer ran a fifth independently: replacing `onSelectSession={focusSession}` with an empty function takes the GUI suite from 322 pass to 321, and the failure is the inspector's related-session focus test.

That mutation also shows why the replacement is worth making. Against the deleted source-text assertion, renaming `focusSession` while keeping the wiring correct would have gone red for the wrong reason, and breaking the wiring while keeping the text would not necessarily have gone red at all.

Flakiness observed on this PR, recorded rather than papered over: `windows-first-run (windows-latest)` ran three times on this same commit and failed once, on `daemon_stop_timeout` — the daemon accepted `daemon.stop` but did not finish draining inside five seconds. This change touches no production code, so it cannot reach the daemon stop path; the job is also not a required check per the Windows downgrade decision, which states the PR path runs smoke only and that per-surface Windows optimisation is out of scope. Noting the roughly one-in-three failure rate here so the next person who sees it red has a prior.

One honest note from the implementer's log: the supply-chain check failed on its first run because the worktree had installed only the GUI subtree and lacked root workspace links. It was resolved by installing from the lockfile in the same worktree and re-running. No gate was touched.

## Review Evidence

- Self-review: full diff read against the task plan's four invariants. The per-file environment override was checked specifically — the global vitest config is unchanged, so the existing static-render tests keep their `node` environment.
- Reviewer mutation as described above, run independently of the implementer's four.
- The two surviving `expect(source)` assertions were read to confirm they assert absence in source rather than behavior, which source scanning is the right tool for.
- Reviewer subagent: not used; reviewed directly.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Interaction tests are heavier than static rendering. The GUI suite grew from 314 to 322 tests with environment setup now appearing in the timings. Nothing was measured about how this scales if interaction coverage grows substantially.
- Only the composition wiring that previously relied on source text is covered. The rest of the GUI still has no interaction coverage, and this PR deliberately does not add any.
- `happy-dom` is not a browser. A behavior that depends on real layout or on APIs it approximates could pass here and fail in the app.
- The deleted test also asserted, via `existsSync`, that `SessionsDock.tsx` no longer exists. That specific regression guard is gone; the file's absence is now only implied by nothing importing it.

## References

- Task: task_14f34d1faeabb75a56f9e2ac03
- Evidence: task package `artifacts/worker-report.md`
- Review: task package `artifacts/`

---

# 中文

## 概要

本仓的 GUI 测试跑在 `environment: "node"` 下,没有 DOM,组件只能渲染成静态标记。这能覆盖「组件渲染出了什么」,但覆盖不了「点下去会发生什么」。当一条测试需要覆盖组合层接线——工作区把哪个回调交给了哪个子组件——剩下的唯一选项就是匹配源码文本:

```
expect(source).toMatch(/const focusSession = \(runtimeSessionId: string\) => setSelection\(\{ type: "session", id: runtimeSessionId \}\);/u);
```

这种断言对无害的重命名很脆,而且它并不能证明点击真的有反应。这个缺口在本仓有过实际代价:PR #1719 修的缺陷就住在这一层——从没有测试渲染过总览页面,于是一个算错的计数在 34 个文件里一路绿灯。

现在交互测试可行了,覆盖会话导航的那 5 条源码文本断言,被 4 条真正挂载工作区、点击、并断言变化的测试取代。

## 改动内容

- `happy-dom` 是唯一新增的直接依赖,而且是按文件用 `@vitest-environment happy-dom` 声明的,不是全局切换。其余 59 处静态渲染调用点继续跑在 `node` 环境下,未被触碰。
- 交互由 `react-dom/client` 的 `createRoot` 加 React 自带的 `act` 驱动。没有引入任何 testing library——要的是能力,而 `react-dom` 本来就是依赖。
- `packages/gui/test/runtime-workspace-interactions.vitest.ts` 挂载 `RuntimeWorkspace`、点击 rail 里的会话,并断言选中态与详情区确实变了;inspector 的相关会话聚焦与两个方向的任务跳转同理。
- `agent-runtime-sessions.vitest.ts` 里那条源码文本测试被删除,不是与新测试并存。
- 另有 2 处 `expect(source)` 保留在别处,这是刻意的:它们断言 renderer 源码中不存在仓库直读、不存在私有 WebSocket、不存在轮询路径。那是关于「什么必须不存在」的静态约束,正是源码扫描该干的事。

## 任务与范围

- Harness 任务：task_14f34d1faeabb75a56f9e2ac03
- 分支：`codex/gui-interaction-tests`
- 公开范围：`packages/gui` 测试、`packages/gui/package.json`、`package-lock.json`、`tools/gui-test-manifest.mjs`
- 私有计划 / 证据是否已更新：yes
- 范围外：全部生产代码、CI job 结构、现存 59 处静态渲染调用点

## 版本影响

- 版本：不改版本，原因是没有生产代码变更
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：yes
- protected surface 范围：`package-lock.json`、`packages/gui/package.json`、`tools/gui-test-manifest.mjs`
- 依据：task_14f34d1faeabb75a56f9e2ac03。新增依赖本身就是这条任务的实质内容，不是顺手改动；manifest 登记是 `npm run test:gui` 对每个新 GUI 测试文件的硬要求，缺了它整个套件拒绝运行。许可证已逐包审查：`happy-dom` 20.11.6 及其 6 个传递新增依赖全为 MIT 或 BSD-2-Clause，均在允许清单内，`npm audit` 报告零漏洞。没有修改或豁免任何 gate。
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：108fa3140969e373eea446c7861a6108c7e46275
- 当前分支与 `origin/main` 的 merge-base：108fa3140969e373eea446c7861a6108c7e46275
- 最近一次 `git fetch origin` 时间：2026-08-23，建分支前即刻
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...codex/gui-interaction-tests`
- 私有证据 commit/path：任务包 `artifacts/worker-report.md`
- Reviewer 证据路径：任务包 `artifacts/`
- GitHub Actions `rewrite-ci` run URL：本 PR 上待跑
- [x] `npm run check:local`（45 步，fast tier，在分支 worktree 内全绿）
- [x] `npm run test:gui`（36 文件，322 用例）
- [x] `npm run harness:check-supply-chain`，含 CycloneDX SBOM 与 license gates
- [x] `npm audit`：零漏洞
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：`npm run test:integration` —— 不在 fast 本地档位内，由云端 CI 覆盖。

这次改动的意义在于「接线断了测试会红」，所以验的是这个而不是通过数。实现方报告了 4 组变异，每组都让对应测试变红。复核方独立跑了第 5 组：把 `onSelectSession={focusSession}` 换成空函数，GUI 套件从 322 通过变为 321，失败的是 inspector 的相关会话聚焦那条。

这组变异同时说明了替换的价值。对着那条被删掉的源码文本断言：把 `focusSession` 改名而接线仍然正确，它会因为错误的理由变红；而把接线断掉但文本还在，它未必会红。

实现方日志里一条诚实的记录：供应链检查首次运行失败，因为该 worktree 只装了 GUI 子树、缺少根 workspace links。解决办法是在同一 worktree 内依 lockfile 安装后重跑。没有触碰任何 gate。

## 审查证据

- 自查：对照任务 plan 的四条不变量通读完整 diff。按文件的环境覆盖被专门核对过——全局 vitest 配置未变，因此既有静态渲染测试保持 `node` 环境。
- 复核方变异如上，独立于实现方那 4 组。
- 保留下来的 2 处 `expect(source)` 已读过，确认它们断言的是源码中的「不存在」而非行为，那正是源码扫描适用的场景。
- Reviewer subagent：未使用；直接复核。
- 人工审查：待进行
- 阻塞发现：无

## 残余风险

- 交互测试比静态渲染重。GUI 套件从 314 用例增至 322，计时里开始出现环境搭建耗时。交互覆盖若大幅增长会如何伸缩，未做任何测量。
- 只覆盖了此前依赖源码文本的那部分组合层接线。GUI 其余部分仍无交互覆盖，本 PR 刻意不增加。
- `happy-dom` 不是浏览器。依赖真实布局、或依赖它只做近似的 API 的行为，可能在这里通过而在应用里失败。
- 被删掉的那条测试还通过 `existsSync` 断言过 `SessionsDock.tsx` 已不存在。这一条具体的回归保护没有了；该文件的缺席现在只由「没有任何地方 import 它」隐含保证。

## 关联材料

- 任务：task_14f34d1faeabb75a56f9e2ac03
- 证据：任务包 `artifacts/worker-report.md`
- 审查：任务包 `artifacts/`

