### PR TITLE
fix(gates): keep a PR body value on its own line

### DIFF
--- a/tools/check-pr-governance.mjs
+++ b/tools/check-pr-governance.mjs
@@ -173,7 +173,7 @@ function hasLabeledValue(text, labels) {
 function readLabeledValue(text, labels) {
   for (const label of labels) {
     const escaped = escapeRegex(label);
-    const match = new RegExp(`^\\s*-?\\s*${escaped}\\s*[:：]\\s*(.+?)\\s*$`, "imu").exec(text);
+    const match = new RegExp(`^\\s*-?\\s*${escaped}\\s*[:：][ \\t]*(.+?)\\s*$`, "imu").exec(text);
     const value = match?.[1]?.trim();
     if (value && !FIELD_PLACEHOLDER.test(value)) {
       return value;

--- a/tools/check-pr-governance.test.mjs
+++ b/tools/check-pr-governance.test.mjs
@@ -167,6 +167,20 @@ test("break-glass declaration passes with required exception fields", () => {
   assert.equal(result.ok, true);
 });
 
+test("break-glass declaration rejects an empty reason before the scope line", () => {
+  const result = checkPrGovernance({
+    body: bodyWithGovernance({ breakGlass: true }).replace(
+      "- Break-glass reason: restore main after an urgent CI outage",
+      "- Break-glass reason:"
+    ),
+    changedFiles: ["tools/gate-allowlists/check-import-boundaries.json"],
+    manifest: makeManifest()
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.issues.join("\n"), /non-empty break-glass reason/u);
+});
+
 test("classifies wildcard package surfaces", () => {
   const rules = deriveProtectedSurfaceRules(makeManifest());
   const matches = classifyProtectedChanges(["packages/cli/package.json"], rules);

--- a/tools/gates/dependency-policy.mjs
+++ b/tools/gates/dependency-policy.mjs
@@ -4,7 +4,7 @@ import { pathToFileURL } from "node:url";
 import { changedFiles, repoRoot } from "./git.mjs";
 
 const DEPENDENCY_SECTIONS = Object.freeze(["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"]);
-const DECLARATION = /^Dependency-Change:\s*(.*?)\s*$/gmu;
+const DECLARATION = /^Dependency-Change:[ \t]*(.*?)\s*$/gmu;
 
 function packageManifestPaths(rootDir) {
   const result = ["package.json"];

--- a/tools/gates/production-delta.mjs
+++ b/tools/gates/production-delta.mjs
@@ -5,8 +5,8 @@ import { git, pathExistsAt, repoRoot } from "./git.mjs";
 import { classifyModule, isProductionPath, normalizeRepoPath } from "./module-policy.mjs";
 import { loadReceipts, verifyReceipt } from "./receipt-verify.mjs";
 
-const DELTA_LINE = /^Production-Delta:\s*\+(\d+)\s*\/\s*-(\d+)\s*$/gmu;
-const RETAINED_LINE = /^Retained-Path:\s*(\S+)\s+until\s+(\d{4}-\d{2}-\d{2})\s+per\s+(dec_[0-9A-Za-z]+)\s*$/gmu;
+const DELTA_LINE = /^Production-Delta:[ \t]*\+(\d+)\s*\/\s*-(\d+)\s*$/gmu;
+const RETAINED_LINE = /^Retained-Path:[ \t]*(\S+)\s+until\s+(\d{4}-\d{2}-\d{2})\s+per\s+(dec_[0-9A-Za-z]+)\s*$/gmu;
 
 export function computeProductionDelta({ rootDir, base }) {
   const output = git(rootDir, ["diff", "--no-renames", "--numstat", "-z", base, "--"]);

--- a/tools/gates/test/dependency-policy.test.mjs
+++ b/tools/gates/test/dependency-policy.test.mjs
@@ -34,3 +34,12 @@ test("G31 rejects lock drift and undeclared dependency changes", () => {
   assert.deepEqual(validateDependencyDeclaration(["package.json"], "Dependency-Change: pin effect to 2.0.0"), []);
   assert.deepEqual(validateDependencyDeclaration(["package.json"], "", false), []);
 });
+
+test("G31 rejects an empty Dependency-Change before another line", () => {
+  const errors = validateDependencyDeclaration(
+    ["package.json"],
+    "Dependency-Change:\n## Task And Scope"
+  );
+
+  assert.match(errors.join("\n"), /must describe the deterministic dependency change/u);
+});

--- a/tools/gates/test/production-delta.test.mjs
+++ b/tools/gates/test/production-delta.test.mjs
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import path from "node:path";
 import test from "node:test";
-import { evaluateProductionDelta } from "../production-delta.mjs";
+import { evaluateProductionDelta, parseProductionDeclaration, parseRetainedPaths } from "../production-delta.mjs";
 import { signReceipt } from "../receipt-verify.mjs";
 import { makeRepo, writeRepoFile } from "./helpers.mjs";
 
@@ -23,6 +23,23 @@ test("G33 rejects a missing or inaccurate declaration", () => {
   assert.match(missing.errors.join("\n"), /exactly one Production-Delta/u);
   assert.equal(inaccurate.ok, false);
   assert.match(inaccurate.errors.join("\n"), /does not match computed \+1\/-0/u);
+});
+
+test("G33 does not read a Production-Delta value from the next line", () => {
+  const result = parseProductionDeclaration("Production-Delta:\n+2/-1");
+
+  assert.equal(result.declaration, null);
+  assert.match(result.errors.join("\n"), /exactly one Production-Delta/u);
+});
+
+test("G33 does not read a Retained-Path value from the next line", () => {
+  const result = parseRetainedPaths([
+    "Retained-Path:",
+    "packages/kernel/src/legacy.ts until 2099-12-30 per dec_01KZQ92VEPTDRS2HS8CKDBKW2Q"
+  ].join("\n"));
+
+  assert.deepEqual(result.declarations, []);
+  assert.match(result.errors.join("\n"), /each Retained-Path line must use/u);
 });
 
 test("G33 verifies retained production paths against an expiring decision receipt", () => {


### PR DESCRIPTION
# English

## Summary

Four parsers that read a PR body separate a label from its value with a whitespace class that spans newlines in JavaScript. An empty value therefore does not read as empty — the capture group crosses the line break and takes the next line instead. The worst case lets an empty `Break-glass reason:` consume the following line, so the non-empty check passes and that protection is hollowed out. This narrows the label-to-value separator to `[ \t]*` in all four places, so a line-oriented parser matches within its line.

## What Changed

- `tools/check-pr-governance.mjs`, `tools/gates/dependency-policy.mjs`, and `tools/gates/production-delta.mjs` (two regexes): the separator between the label and the start of the value becomes `[ \t]*`.
- Four regression tests, one per site. Not one test for the worst case — a family where only one member has regression evidence gets partially reintroduced later, and the three silent members look identical to fixed ones.
- No new validation layer was added. The root cause is a character class, and a character class is what changed.

## Machine-Readable Declarations

Production-Delta: +0/-0

## Task And Scope

- Harness task: task_5a7b4e3de711840695ba5e578d
- Scope: the four label-to-value separators and their tests. `tools/gates/evidence-contract.mjs` is deliberately untouched — it already splits per line before matching, which is why it is immune, and it served as the positive control proving this fix direction is already validated in this repository.

## Version Impact

- Version: no version change.
- Publish impact: no publish.

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/check-pr-governance.mjs` and `tools/check-pr-governance.test.mjs`, matched by the `tools/check-*.mjs` rule.
- Authority: dec_2EFBD23067BFFBAF0319902514 (in_effect, standing_policy), implemented by task_5a7b4e3de711840695ba5e578d.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not used
- Break-glass scope: not used
- Follow-up governance task: task_77fb142a04eca9b3aa7d09274c covers why `tools/gates/*.mjs` is not itself a protected surface.

## Verification

- Base `origin/main` SHA: `8c6a50db1`
- Public diff command: `git diff origin/main...HEAD`
- [x] Positive controls before the change: each of the four sites was shown to mis-capture. `Dependency-Change:` followed by the next template line captured `## Task And Scope`; `- Authority:` captured the following `- Break-glass: no`.
- [x] After the change all four capture nothing from the next line.
- [x] Mutation, all four sites reverted at once: 17 passing became 13 passing and 4 failing — every test fires.
- [x] Mutation, one site reverted: 16 passing and 1 failing — the tests discriminate, they are not one assertion firing four times.
- [x] `npm run check:local` — fast tier, green.

## Review Evidence

- Self-review: the diff was read before the report. Each remaining `\s*` was checked individually rather than accepting "only the necessary ones were changed" as a claim.
- Reviewer subagent: none — verification was done directly.
- Human review: pending.
- Blocking findings: none.

## Residual Risk

- Whitespace **inside** a value can still span lines: `Production-Delta: +10` followed by a line starting `/-5` still matches, and `Retained-Path:` still tolerates a line break before `until`. This was left deliberately. Those separators sit inside a value that has already started parsing, so they cannot pull unrelated content in as the value — the failure mode this PR fixes. Narrowing them would widen the diff without changing any outcome.
- `tools/gates/*.mjs` is not a protected surface, while `tools/check-*.mjs` is, so two equally load-bearing gate scripts in this one change get different governance treatment. That asymmetry is a symptom of `tools/gate-manifest.json` covering only `rewrite-ci.yml`; tracked as task_77fb142a04eca9b3aa7d09274c.

## References

- Task: task_5a7b4e3de711840695ba5e578d
- Evidence: `fact/task_5a7b4e3de711840695ba5e578d/F-7B130F88`
- Review: `harness/tasks/task_5a7b4e3de711840695ba5e578d-pr-body/`

---

# 中文

## 概要

四个解析 PR body 的正则,用会跨换行的空白类分隔标签与值。于是一个空值读起来并不空——捕获组越过换行,取走了下一行。最坏的一个让空的 `Break-glass reason:` 吞掉下一行,于是「非空」检查通过,那层保护被架空。本 PR 把四处的标签—值分隔符收窄为 `[ \t]*`:按行设计的解析器,就在行内匹配。

## 改动内容

- `tools/check-pr-governance.mjs`、`tools/gates/dependency-policy.mjs`、`tools/gates/production-delta.mjs`(两条正则):标签与值起点之间的分隔符改为 `[ \t]*`。
- 四条回归测试,每处一条。**不是只给最严重的那处写一条** —— 一个族里若只有一个成员有回归证据,日后同样的改动只会修回来一个,另外三个沉默的成员看起来和修好了一样。
- **没有新增任何校验层。** 根因是一个字符类,改的就是那个字符类。

## 机读声明说明

- 机读行只在英文块出现一次并顶格;生产面净变化 +0/-0(`tools/` 不属生产路径)。
- 未改任何 `package.json` / `package-lock.json`,故删除 `Dependency-Change` 行。
- 未保留旧生产路径,未声明 evidence claim,相应样例保持注释。

## 任务与范围

- Harness 任务:task_5a7b4e3de711840695ba5e578d
- 范围:四处标签—值分隔符及其测试。**`tools/gates/evidence-contract.mjs` 刻意不动** —— 它先按行 split 再匹配,因而免疫;它同时是本次的阳性对照,证明这个修法方向在本仓已被验证过,不是新引入的抽象。

## 版本影响

- 版本:无变化。
- 发布影响:不发布。

## 治理声明

- 是否触碰 protected surface:yes
- protected surface 范围:`tools/check-pr-governance.mjs` 与 `tools/check-pr-governance.test.mjs`,命中 `tools/check-*.mjs` 规则。
- 依据:dec_2EFBD23067BFFBAF0319902514(in_effect,standing_policy),由 task_5a7b4e3de711840695ba5e578d 实现。
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:未使用
- Break-glass 范围:未使用
- 后续治理任务:task_77fb142a04eca9b3aa7d09274c,跟进 `tools/gates/*.mjs` 为何本身不是 protected surface。

## 验证

- Base `origin/main` SHA:`8c6a50db1`
- 公开 diff 命令:`git diff origin/main...HEAD`
- [x] **改之前先跑阳性对照**:四处各自证明当前会误捕获。`Dependency-Change:` 后跟模板下一行捕获到 `## Task And Scope`;`- Authority:` 捕获到下一行的 `- Break-glass: no`。
- [x] 改之后四处都不再从下一行取值。
- [x] **变异一(四处一起改回 `\s*`)**:17 绿变成 13 绿 4 红 —— 四条测试全部点火。
- [x] **变异二(只改回一处)**:16 绿 1 红 —— 测试有区分度,不是同一条断言响了四次。
- [x] `npm run check:local` fast tier 全绿。

## 审查证据

- 自审:先读 diff 再读报告。**每一处保留下来的 `\s*` 都逐个查过**,而不是接受「只改了必要的那些」这句断言。
- 评审子代理:无,直接验证。
- 人工评审:待。
- 阻塞性 findings:无。

## 残余风险

- **值内部**的空白仍可跨行:`Production-Delta: +10` 后跟一行 `/-5` 仍能匹配,`Retained-Path:` 也仍容忍 `until` 前的换行。这是刻意保留的。那些分隔符位于**已经开始解析的值内部**,拉不进无关内容当作值——而那正是本 PR 修掉的失败形态。收窄它们只会放大 diff,不改变任何结果。
- `tools/gates/*.mjs` 不是 protected surface,而 `tools/check-*.mjs` 是,于是本次改动里两个同等承重的门脚本得到了不同的治理待遇。这个不对称是 `tools/gate-manifest.json` 只覆盖 `rewrite-ci.yml` 的症状,已立 task_77fb142a04eca9b3aa7d09274c。

## 关联材料

- 任务:task_5a7b4e3de711840695ba5e578d
- 证据:`fact/task_5a7b4e3de711840695ba5e578d/F-7B130F88`
- 评审:`harness/tasks/task_5a7b4e3de711840695ba5e578d-pr-body/`
