### PR TITLE
perf(gui): bound scale-heavy views and narrow runtime reads

### DIFF
--- a/packages/gui/src/renderer/components/runtime/SessionsPanel.tsx
+++ b/packages/gui/src/renderer/components/runtime/SessionsPanel.tsx
@@ -29,8 +29,8 @@ export function SessionsPanel({ repoId, runtimeSessionId, row, busy, onCancel, o
       if (snapshot.session.attachCapability !== "supported") return;
       detach = openAgentRuntimePane(repoId, runtimeSessionId, snapshot.session.streamCursor, (value) => {
         if (!active) return;
-        if ("ok" in value) { setAttach(value.ok ? value.status : value.code); if (value.ok) { const caught = value.events.filter((event) => event.type !== "gap"); if (caught.length) setFrames((current) => [...current, ...caught].slice(-32)); if (value.status === "gap" || value.events.some((event) => event.type === "exit")) void reread(); } return; }
-        if (value.type === "gap") void reread(); else { setFrames((current) => [...current.slice(-31), value]); if (value.type === "exit") void reread(); }
+        if ("ok" in value) { setAttach(value.ok ? value.status : value.code); if (value.ok) { const caught = value.events.filter((event) => event.type !== "gap"); if (caught.length) setFrames((current) => [...current, ...caught]); if (value.status === "gap" || value.events.some((event) => event.type === "exit")) void reread(); } return; }
+        if (value.type === "gap") void reread(); else { setFrames((current) => [...current, value]); if (value.type === "exit") void reread(); }
       }).close;
     }, (cause) => { if (active) setError(cause instanceof Error ? cause.message : String(cause)); });
     return () => { active = false; detach?.(); };
@@ -73,8 +73,8 @@ export function SessionDetailView({ session, row, result, frames, attach, busy, 
     <Card>
       <CardHead><CardTitle>{t("agentRuntime.liveStream")}</CardTitle></CardHead>
       <CardBody>
-        <div className="rounded border border-border">
-          {frames.length === 0 ? <p className="px-2.5 py-2 text-[10.5px] text-text-faint">{t("agentRuntime.noFrames")}</p> : frames.map((frame) => <div key={frame.cursor} className="grid grid-cols-[64px_minmax(0,1fr)] gap-2 border-b border-border px-2.5 py-1.5 last:border-b-0 text-[11px]"><span className="font-mono text-[9px] text-text-faint">{frame.cursor}</span><span className="min-w-0 [overflow-wrap:anywhere]">{frame.type === "activity" ? frame.activity : frame.type}</span></div>)}
+        <div data-testid="session-event-stream" className="max-h-64 overflow-y-auto rounded border border-border">
+          {frames.length === 0 ? <p className="px-2.5 py-2 text-[10.5px] text-text-faint">{t("agentRuntime.noFrames")}</p> : frames.map((frame) => <div key={frame.cursor} data-testid="session-event-frame" className="grid grid-cols-[64px_minmax(0,1fr)] gap-2 border-b border-border px-2.5 py-1.5 last:border-b-0 text-[11px]"><span className="font-mono text-[9px] text-text-faint">{frame.cursor}</span><span className="min-w-0 [overflow-wrap:anywhere]">{frame.type === "activity" ? frame.activity : frame.type}</span></div>)}
           <div className="flex items-center gap-1.5 border-t border-border px-2.5 py-1.5 font-mono text-[10px] text-text-faint">{LIVENESS_LIVE[session.liveness] ? <><span className="rt-pulse" />{t("agentRuntime.waitingNextEvent")}</> : <><LiveDot state={OUTCOME_DOT[session.activity.outcome ?? ""] ?? "idle"} />{t("agentRuntime.exitCode", { code: session.activity.exitCode ?? "—" })}</>}</div>
         </div>
       </CardBody>

--- a/packages/gui/src/renderer/components/runtime/useRuntimeWorkspace.ts
+++ b/packages/gui/src/renderer/components/runtime/useRuntimeWorkspace.ts
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { consumeKnownError } from "../../../api/error-consumption.ts";
 import type { AgentDeclarationV1, SquadDeclarationV1 } from "../../../../../daemon/src/agent-entities.contract.ts";
-import { successfulAgentRuntimeResult } from "../../../../../daemon/src/agent-runtime-contract.ts";
+import { successfulAgentRuntimeResult, type AgentRuntimeSessionDto } from "../../../../../daemon/src/agent-runtime-contract.ts";
 import { agentEntityClient, type SquadEntityRow } from "../../agent-entity-client.ts";
 import { agentRuntimeClient } from "../../agent-runtime-client.ts";
 import { harnessClient } from "../../api-client.ts";
@@ -28,7 +28,8 @@ export function useRuntimeWorkspace(repoId: string, tasks: readonly RuntimePanor
   const agents = useQuery({ queryKey: ["agents", repoId], queryFn: () => agentEntityClient.listAgents(repoId), staleTime: 4_000 });
   const squadQuery = { queryKey: ["squads", repoId], queryFn: () => agentEntityClient.listSquads(repoId), staleTime: 4_000 } as const;
   const squads = useQuery(squadQuery);
-  const panorama = useQuery({ queryKey: ["runtime-panorama", repoId, tasks.map((task) => task.taskId).join(",")], queryFn: () => readPanorama(repoId, tasks, { listSquads: () => client.fetchQuery(squadQuery), getTaskDispatches: (taskIds) => harnessClient.getTaskDispatches({ repoId, taskIds }) }), staleTime: 4_000 });
+  const panoramaTasks = runtimePanoramaTasks(tasks, overview.data?.sessions ?? []);
+  const panorama = useQuery({ queryKey: ["runtime-panorama", repoId, panoramaTasks.map((task) => task.taskId).join(",")], queryFn: () => readPanorama(repoId, panoramaTasks, { listSquads: () => client.fetchQuery(squadQuery), getTaskDispatches: (taskIds) => harnessClient.getTaskDispatches({ repoId, taskIds }) }), staleTime: 4_000 });
   const [busy, setBusy] = useState(false), [feedback, setFeedback] = useState<string | null>(null), [error, setError] = useState<string | null>(null), [settlement, setSettlement] = useState<RuntimeSpawnSettlement | null>(null);
 
   const refresh = async () => { await Promise.all([client.invalidateQueries({ queryKey: ["runtime-instances", "machine"] }), client.invalidateQueries({ queryKey: ["runtime-control", repoId] }), client.invalidateQueries({ queryKey: ["runtime-panorama", repoId] })]); };
@@ -80,6 +81,11 @@ export function useRuntimeWorkspace(repoId: string, tasks: readonly RuntimePanor
 export function runtimeSelfTestSpawnInput(instanceId: string, model: string, idempotencyKey: string) { return { runtimeInstanceId: instanceId, model, permissionMode: "read-only" as const, cwd: { scope: "repo-root" as const }, prompt: "Reply with exactly: runtime connectivity ok", taskId: null, idempotencyKey }; }
 
 export function subscriptionCreationNeedsLogin(input: Pick<RuntimeInstanceCreateInput, "authMode">, probed: unknown): boolean { return input.authMode === "subscription" && typeof probed === "object" && probed !== null && "authState" in probed && probed.authState === "unauthenticated"; }
+
+export function runtimePanoramaTasks(tasks: readonly RuntimePanoramaTask[], sessions: readonly AgentRuntimeSessionDto[]): readonly RuntimePanoramaTask[] {
+  const tasksById = new Map(tasks.map((task) => [task.taskId, task])), taskIds = new Set(sessions.flatMap((session) => session.associations.map((association) => association.taskId)));
+  return [...taskIds].sort().map((taskId) => tasksById.get(taskId) ?? { taskId, title: taskId });
+}
 
 export function useAgentDetail(repoId: string, agentId: string | null) { return useQuery({ queryKey: ["agent-detail", repoId, agentId], queryFn: () => agentEntityClient.showAgent(repoId, agentId ?? ""), enabled: agentId !== null, staleTime: 4_000 }); }
 export function useSquadDetail(repoId: string, squadId: string | null) { return useQuery({ queryKey: ["squad-detail", repoId, squadId], queryFn: () => agentEntityClient.showSquad(repoId, squadId ?? ""), enabled: squadId !== null, staleTime: 4_000 }); }

--- a/packages/gui/src/renderer/i18n/locales/en-US/views.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/views.json
@@ -163,6 +163,7 @@
   "views.decisionPoolView.allGroup": "all",
   "views.decisionPoolView.emptyFilter": "There are no decisions under the current filter.",
   "views.decisionPoolView.groupCount": "· {count} rows",
+  "views.decisionPoolView.showMore": "Show {count} more · {remaining} remaining",
   "views.decisionPropose.packetTitle": "New complete proposal packet",
   "views.decisionPropose.columnsRequired": "{label} needs {count} columns per line, separated by |.",
   "views.decisionPropose.packetRequired": "title/question/vertical/preset and all three body sections are required.",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/views.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/views.json
@@ -163,6 +163,7 @@
   "views.decisionPoolView.allGroup": "全部",
   "views.decisionPoolView.emptyFilter": "当前过滤条件下没有 decision。",
   "views.decisionPoolView.groupCount": "· {count} 条",
+  "views.decisionPoolView.showMore": "再显示 {count} 条 · 还有 {remaining} 条",
   "views.decisionPropose.packetTitle": "新建完整 proposal packet",
   "views.decisionPropose.columnsRequired": "{label} 每行需要 {count} 列，以 | 分隔。",
   "views.decisionPropose.packetRequired": "title、question、vertical、preset 与正文三段均必填。",

--- a/packages/gui/src/renderer/views/BoardView.tsx
+++ b/packages/gui/src/renderer/views/BoardView.tsx
@@ -34,6 +34,7 @@ const ENGINE_HINT: Record<string, string> = {
   github: "由 GitHub Issues 管理，去 GitHub 改状态",
   linear: "由 Linear 管理，去 Linear 改状态",
 };
+const COLUMN_BATCH_SIZE = 30;
 
 function taskControlHint(task: TaskRow): string {
   if (isExternal(task)) return ENGINE_HINT[task.engine] ?? `由外部引擎 ${task.engine} 管理，GUI 只读`;
@@ -64,6 +65,7 @@ function Card({
   const spawningDecision = spawningDecisionOf(task, relations);
   return (
     <div
+      data-testid="board-task-card"
       onClick={() => onSelect?.(task.taskId)}
       title={taskControlHint(task)}
       className={`group relative cursor-pointer rounded-lg bg-surface-raised p-2.5 ${freshnessBorder(
@@ -164,6 +166,9 @@ function Column({
   const { setNodeRef, isOver } = useDroppable({ id: status });
   const meta = STATUS_META[status];
   const ordered = sortByFavoritesFirst(tasks, (t) => t.taskId, favorites);
+  const [visibleCount, setVisibleCount] = useState(COLUMN_BATCH_SIZE);
+  useEffect(() => { setVisibleCount(COLUMN_BATCH_SIZE); }, [tasks.length]);
+  const visible = ordered.slice(0, visibleCount), hiddenCount = ordered.length - visible.length;
   return (
     <div
       ref={setNodeRef}
@@ -190,7 +195,7 @@ function Column({
       </div>
       <div className="flex flex-col gap-2 overflow-y-auto pb-1">
         {ordered.length > 0 ? (
-          ordered.map((t) => (
+          visible.map((t) => (
             <DraggableCard
               key={t.taskId}
               task={t}
@@ -204,6 +209,16 @@ function Column({
           <div className="rounded-lg border border-dashed border-border px-3 py-5 text-[14px] text-text-faint">
             当前筛选下无 {meta.label} 任务
           </div>
+        )}
+        {hiddenCount > 0 && (
+          <button
+            type="button"
+            data-testid={`board-column-more-${status}`}
+            onClick={() => setVisibleCount((count) => Math.min(count + COLUMN_BATCH_SIZE, ordered.length))}
+            className="rounded-lg border border-dashed border-border px-3 py-2 text-center font-mono text-[12px] text-text-muted hover:border-border-strong hover:text-text"
+          >
+            再显示 {Math.min(COLUMN_BATCH_SIZE, hiddenCount)} 条 · 还有 {hiddenCount} 条
+          </button>
         )}
       </div>
     </div>

--- a/packages/gui/src/renderer/views/DecisionPoolView.tsx
+++ b/packages/gui/src/renderer/views/DecisionPoolView.tsx
@@ -19,6 +19,7 @@ type PoolTab = WorkspaceSummaryRead["decisions"]["groups"][number]["id"];
 type TimeRange = "all" | "14d" | "30d";
 type RelationState = "ready" | "loading" | "error";
 const selectClass = "rounded-md border border-border bg-surface px-2 py-1 font-mono text-[12px] text-text-muted outline-none transition-colors duration-100 hover:border-border-strong focus-visible:border-border-strong";
+const DECISION_BATCH_SIZE = 30;
 
 function withinRange(decision: DecisionRow, range: TimeRange) {
   if (range === "all") return true;
@@ -58,6 +59,7 @@ export function DecisionPoolView({ repoId, decisions, summary, facts, relations,
   const [verticalFilter, setVerticalFilter] = useState("all"), [presetFilter, setPresetFilter] = useState("all"), [proposedByFilter, setProposedByFilter] = useState<NonNullable<DecisionRow["proposedBy"]>["kind"] | "unknown" | "all">("all"), [timeRange, setTimeRange] = useState<TimeRange>("all");
   const [search, setSearch] = useState(""), [moduleFilter, setModuleFilter] = useState("all"), [productLineFilter, setProductLineFilter] = useState("all"), [proposalOpen, setProposalOpen] = useState(false);
   const [groupBy, setGroupBy] = useState<PoolGroupBy>("none");
+  const [page, setPage] = useState({ scope: "", count: DECISION_BATCH_SIZE });
   const handledFocusRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -92,6 +94,15 @@ export function DecisionPoolView({ repoId, decisions, summary, facts, relations,
       .filter((decision) => verticalFilter === "all" || decision.vertical === verticalFilter).filter((decision) => presetFilter === "all" || decision.preset === presetFilter)
       .filter((decision) => proposedByFilter === "all" || (proposedByFilter === "unknown" ? !decision.proposedBy : decision.proposedBy?.kind === proposedByFilter)).filter((decision) => withinRange(decision, timeRange));
   }, [currentGroup.decisionIds, decisions, presetFilter, proposedByFilter, remoteEnabled, remoteIds, riskFilter, stateFilter, timeRange, urgencyFilter, verticalFilter]);
+  const pageScope = [tab, stateFilter, riskFilter, urgencyFilter, verticalFilter, presetFilter, proposedByFilter, timeRange, search.trim(), moduleFilter, productLineFilter, groupBy].join("\0");
+  const visibleLimit = page.scope === pageScope ? page.count : DECISION_BATCH_SIZE;
+  const visibleIds = useMemo(() => {
+    const ids = new Set(rows.slice(0, visibleLimit).map((decision) => decision.decisionId));
+    if (focusedDecisionId && rows.some((decision) => decision.decisionId === focusedDecisionId)) ids.add(focusedDecisionId);
+    return ids;
+  }, [focusedDecisionId, rows, visibleLimit]);
+  const groups = useMemo(() => groupDecisions(rows, groupBy).map((group) => ({ ...group, total: group.rows.length, rows: group.rows.filter((decision) => visibleIds.has(decision.decisionId)) })).filter((group) => group.rows.length > 0), [groupBy, rows, visibleIds]);
+  const hiddenCount = rows.length - visibleIds.size;
 
   return <div className="flex h-full flex-col">
     <header className="flex items-center gap-3 border-b border-border px-4 py-3"><div><h1 className="ui-title font-semibold">{t("renderer.shellConfig.decisionPool")}</h1><span className="font-mono text-[12px] text-text-faint">{t("views.decisionPoolView.subtitle")}</span></div>{onPropose && <button onClick={() => setProposalOpen((value) => !value)} className={`ml-auto inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-[12px] font-semibold text-accent-fg transition-colors duration-100 ${proposalOpen ? "bg-accent/85 hover:bg-accent" : "bg-accent hover:bg-accent/85"}`}><Plus weight="bold" />{t("views.decisionPoolView.proposal")}</button>}</header>
@@ -110,8 +121,8 @@ export function DecisionPoolView({ repoId, decisions, summary, facts, relations,
     </div>
     {remoteEnabled && (remote.isPending || remote.isError || remote.data?.status !== "ready") && <div className="border-b border-border bg-stale/10 px-4 py-2 font-mono text-[11px] text-stale">{t("views.decisionPoolView.projectionUnknown", { detail: remote.error instanceof Error ? remote.error.message : remote.data?.hint ?? remote.data?.opId ?? "loading" })}</div>}
     <div className="min-h-0 flex-1 overflow-auto p-4"><div className="space-y-2">
-      {groupDecisions(rows, groupBy).map((group) => <section key={group.key} aria-label={group.title || t("views.decisionPoolView.allGroup")} className="space-y-2">
-      {groupBy !== "none" && <div className="sticky top-0 z-10 flex items-center gap-2 rounded-md border border-border bg-surface/95 px-2.5 py-1.5 font-mono text-[12px] text-text-muted backdrop-blur" data-testid={`decision-pool-group-${group.key}`}><span className="font-semibold text-text">{group.title}</span><span className="text-text-faint">{t("views.decisionPoolView.groupCount", { count: group.rows.length })}</span></div>}
+      {groups.map((group) => <section key={group.key} aria-label={group.title || t("views.decisionPoolView.allGroup")} className="space-y-2">
+      {groupBy !== "none" && <div className="sticky top-0 z-10 flex items-center gap-2 rounded-md border border-border bg-surface/95 px-2.5 py-1.5 font-mono text-[12px] text-text-muted backdrop-blur" data-testid={`decision-pool-group-${group.key}`}><span className="font-semibold text-text">{group.title}</span><span className="text-text-faint">{t("views.decisionPoolView.groupCount", { count: group.total })}</span></div>}
       {group.rows.map((decision) => <article key={decision.decisionId} id={`decision-card-${decision.decisionId}`} data-focused={decision.decisionId === focusedDecisionId || undefined} className={`rounded-lg border bg-surface px-3.5 py-3 transition-colors duration-100 ${decision.decisionId === focusedDecisionId ? "border-accent ring-1 ring-accent/30" : "border-border hover:border-border-strong"}`}>
         <div className="flex items-start gap-3"><div className="min-w-0 flex-1"><div className="flex flex-wrap items-center gap-1.5"><span className="font-mono text-[12px] text-text-faint">{decision.decisionId}{decision.legacyId ? ` · ${decision.legacyId}` : ""}</span><DecisionStateBadge state={decision.state} /><RiskTierBadge tier={decision.riskTier} /><UrgencyBadge urgency={decision.urgency} /><ReadinessBadge decision={decision} facts={facts} rows={coverageRows} graphState={relationState} /></div>
           <h2 className="mt-1 text-[15px] font-semibold leading-snug text-text">{decision.title}</h2><p className="mt-0.5 text-[12px] text-text-muted">Q: {decision.question}</p>
@@ -122,6 +133,7 @@ export function DecisionPoolView({ repoId, decisions, summary, facts, relations,
         {decision.state === "proposed" && onJudge && <DecisionJudgmentPanel decision={decision} relations={relations} feedback={mutationFeedback?.(decision.decisionId)} onSubmit={onJudge} onCheckReceipt={() => onCheckReceipt?.(decision.decisionId)} />}
       </article>)}
       </section>)}
+      {hiddenCount > 0 && <button type="button" data-testid="decision-pool-more" onClick={() => setPage({ scope: pageScope, count: Math.min(visibleLimit + DECISION_BATCH_SIZE, rows.length) })} className="w-full rounded-lg border border-dashed border-border px-3 py-2 font-mono text-[12px] text-text-muted hover:border-border-strong hover:text-text">{t("views.decisionPoolView.showMore", { count: Math.min(DECISION_BATCH_SIZE, hiddenCount), remaining: hiddenCount })}</button>}
       {rows.length === 0 && (!remoteEnabled || remote.data?.status === "ready") && <div className="rounded-lg border border-dashed border-border px-4 py-8 text-center text-[14px] text-text-faint">{t("views.decisionPoolView.emptyFilter")}</div>}
     </div></div>
   </div>;

--- a/packages/gui/src/renderer/views/SwimlaneBoard.tsx
+++ b/packages/gui/src/renderer/views/SwimlaneBoard.tsx
@@ -15,6 +15,7 @@ import { sortByFavoritesFirst } from "../model/taskFilters";
 export type LaneGroupBy = "module" | "engine" | "root" | "productLine";
 
 const PAGE_SIZE = 5;
+const LANE_BATCH_SIZE = 20;
 const GRID_COLS = "grid-cols-[180px_repeat(7,230px)]";
 
 const cellKey = (lane: string, status: SnapshotStatus) => `${lane}::${status}`;
@@ -286,10 +287,25 @@ export function SwimlaneBoard({
     }
   }, [drillMatches, drillLane, drillStatus]);
 
-  const lanes = useMemo(
-    () => [...new Set(tasks.map((t) => groupKeyOf(t, groupBy)))],
-    [groupBy, tasks],
-  );
+  const tasksByLane = useMemo(() => {
+    const grouped = new Map<string, TaskRow[]>();
+    for (const task of tasks) {
+      const key = groupKeyOf(task, groupBy);
+      const group = grouped.get(key);
+      if (group) group.push(task);
+      else grouped.set(key, [task]);
+    }
+    return grouped;
+  }, [groupBy, tasks]);
+  const lanes = useMemo(() => [...tasksByLane.keys()], [tasksByLane]);
+  const [visibleLaneCount, setVisibleLaneCount] = useState(LANE_BATCH_SIZE);
+  useEffect(() => { setVisibleLaneCount(LANE_BATCH_SIZE); }, [groupBy, tasks]);
+  const visibleLanes = useMemo(() => {
+    const visible = lanes.slice(0, visibleLaneCount);
+    if (drillMatches && drillLane && lanes.includes(drillLane) && !visible.includes(drillLane)) visible.push(drillLane);
+    return visible;
+  }, [drillLane, drillMatches, lanes, visibleLaneCount]);
+  const hiddenLaneCount = lanes.length - visibleLanes.length;
 
   useEffect(() => {
     if (activeCell && !lanes.includes(activeCell.lane)) setActiveCell(null);
@@ -299,12 +315,8 @@ export function SwimlaneBoard({
 
   const activeTasks = useMemo(() => {
     if (!activeCell) return [];
-    return tasks.filter(
-      (t) =>
-        groupKeyOf(t, groupBy) === activeCell.lane &&
-        t.coordinationStatus === activeCell.status,
-    );
-  }, [activeCell, groupBy, tasks]);
+    return (tasksByLane.get(activeCell.lane) ?? []).filter((task) => task.coordinationStatus === activeCell.status);
+  }, [activeCell, tasksByLane]);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -330,12 +342,13 @@ export function SwimlaneBoard({
               );
             })}
           </div>
-          {lanes.map((lane) => {
-            const laneTasks = tasks.filter((t) => groupKeyOf(t, groupBy) === lane);
+          {visibleLanes.map((lane) => {
+            const laneTasks = tasksByLane.get(lane) ?? [];
             const laneLabel = groupLabelOf(lane, groupBy, tasks);
             return (
               <div
                 key={lane}
+                data-testid="swimlane-row"
                 className={`grid ${GRID_COLS} gap-2 border-b border-border py-2.5`}
               >
                 <div className="flex items-baseline gap-2 self-start px-1.5 pt-1.5">
@@ -367,6 +380,16 @@ export function SwimlaneBoard({
               </div>
             );
           })}
+          {hiddenLaneCount > 0 && (
+            <button
+              type="button"
+              data-testid="swimlane-more"
+              onClick={() => setVisibleLaneCount((count) => Math.min(count + LANE_BATCH_SIZE, lanes.length))}
+              className="mt-3 w-full rounded-lg border border-dashed border-border px-3 py-2 font-mono text-[12px] text-text-muted hover:border-border-strong hover:text-text"
+            >
+              再显示 {Math.min(LANE_BATCH_SIZE, hiddenLaneCount)} 个泳道 · 还有 {hiddenLaneCount} 个
+            </button>
+          )}
           {lanes.length === 0 && (
             <div className="rounded-lg border border-dashed border-border px-4 py-8 text-[15px] text-text-faint">
               当前筛选下没有可展示的泳道任务。

--- a/packages/gui/test/agent-runtime-renderer.vitest.ts
+++ b/packages/gui/test/agent-runtime-renderer.vitest.ts
@@ -16,7 +16,7 @@ import { assertPreloadPayload } from "../src/preload/allowlist.ts";
 import { setActiveLocale } from "../src/renderer/i18n/core.ts";
 import { openAgentRuntimePane } from "../src/renderer/agent-runtime-client.ts";
 import { submitRuntimeSpawn } from "../src/renderer/runtime-control.ts";
-import { readPanorama, runtimeSelfTestSpawnInput } from "../src/renderer/components/runtime/useRuntimeWorkspace.ts";
+import { readPanorama, runtimePanoramaTasks, runtimeSelfTestSpawnInput } from "../src/renderer/components/runtime/useRuntimeWorkspace.ts";
 
 beforeAll(() => setActiveLocale("en-US"));
 
@@ -181,5 +181,13 @@ describe("agent runtime renderer", () => {
     const tasks = Array.from({ length: 402 }, (_, index) => ({ taskId: `task-${String(index).padStart(3, "0")}`, title: `Task ${index}` })), dispatch = { dispatchId: "dispatch-batch", taskId: tasks[0]!.taskId, executionId: "execution-batch", runtimeSessionId: "runtime-batch", instanceId: "codex-review", squadId: "missing-squad", providerSessionId: null, eventStreamRef: null, startedAt: "2026-08-21T00:00:00.000Z", endedAt: null, outcome: null, status: "running" } as const, getTaskDispatches = vi.fn(async (taskIds: readonly string[]) => ({ ok: true, status: "ready", taskIds, unavailableTaskIds: [], dispatches: [dispatch], page: { limit: 500, cursor: null, nextCursor: null }, watermark: 1, sourceRevision: 1 } as const)), listSquads = vi.fn(async (): Promise<readonly (typeof squadRows)[number][]> => { throw new Error("one catalog row is unavailable"); });
     const panorama = await readPanorama("repo-a", tasks, { getTaskDispatches, listSquads });
     expect(getTaskDispatches).toHaveBeenCalledOnce(); expect(getTaskDispatches).toHaveBeenCalledWith(tasks.map(({ taskId }) => taskId)); expect(listSquads).toHaveBeenCalledOnce(); expect(panorama).toHaveLength(1); expect(panorama[0]).toMatchObject({ taskTitle: "Task 0", squad: null });
+  });
+  it("queries dispatches only for task ids already associated with runtime sessions", () => {
+    const tasks = Array.from({ length: 1_000 }, (_, index) => ({ taskId: `task-${index}`, title: `Task ${index}` }));
+    const sessions = [
+      { ...session, associations: [{ ...session.associations[0]!, taskId: "task-8" }, { ...session.associations[0]!, taskId: "task-8" }] },
+      { ...session, runtimeSessionId: "runtime-missing-task", associations: [{ ...session.associations[0]!, taskId: "task-not-listed" }] },
+    ];
+    expect(runtimePanoramaTasks(tasks, sessions)).toEqual([{ taskId: "task-8", title: "Task 8" }, { taskId: "task-not-listed", title: "task-not-listed" }]);
   });
 });

--- a/packages/gui/test/agent-runtime-sessions.vitest.ts
+++ b/packages/gui/test/agent-runtime-sessions.vitest.ts
@@ -42,6 +42,15 @@ describe("sessions as a first-class view", () => {
     expect(markup).toContain(">live</span>");
   });
 
+  it("keeps every received frame in a fixed-height inline scroller", () => {
+    const frames = Array.from({ length: 40 }, (_, index) => ({ ...frame, cursor: `stream:${index}`, activity: "tool" as const }));
+    const markup = detailView({ frames });
+    expect(markup).toContain('data-testid="session-event-stream"');
+    expect(markup).toContain("max-h-64 overflow-y-auto");
+    expect(markup).toContain("stream:0");
+    expect(markup).toContain("stream:39");
+  });
+
   it("jumps from a session to exactly the task it is bound to, and offers no jump when unbound", () => {
     expect(sessionTaskTarget(boundRow, sessionDto.associations)).toEqual({ taskId: "task-bound", taskTitle: "Bound task title" });
     expect(sessionTaskTarget(null, sessionDto.associations)).toEqual({ taskId: "task-assoc", taskTitle: null });

--- a/packages/gui/test/overview-streams.vitest.ts
+++ b/packages/gui/test/overview-streams.vitest.ts
@@ -6,6 +6,7 @@ import type { DecisionRow, TaskRow } from "../src/renderer/model/types.ts";
 import { DecisionStream } from "../src/renderer/components/overview/DecisionStream.tsx";
 import { TaskStream } from "../src/renderer/components/overview/TaskStream.tsx";
 import { BoardView } from "../src/renderer/views/BoardView.tsx";
+import { SwimlaneBoard } from "../src/renderer/views/SwimlaneBoard.tsx";
 import { OverviewView } from "../src/renderer/views/OverviewView.tsx";
 import { PinnedStream } from "../src/renderer/components/overview/PinnedStream.tsx";
 import { RuntimeHealthCard } from "../src/renderer/components/overview/RuntimeHealthCard.tsx";
@@ -129,6 +130,19 @@ describe("overview task stream", () => {
     expect(summary.total).toBe(visible.length);
     expect(tabText(overview, "overview-status-active")).toBe("进行中 2");
     expect(tabText(overview, "overview-status-blocked")).toBe("已阻塞 1");
+  });
+
+  it("bounds the initial board and swimlane DOM while making every deferred row explicit", () => {
+    const rows = Array.from({ length: 45 }, (_, index) => task({ taskId: `task_${index}`, title: `Task ${index}`, rootTaskId: `root_${index}`, coordinationStatus: "active" }));
+    const board = renderToStaticMarkup(createElement(BoardView, { tasks: rows, allTasks: rows, filters: DEFAULT_TASK_FILTERS, onFiltersChange: noop, onSelect: noop, relations: [], favorites: new Set<string>(), onToggleFavorite: noop }));
+    expect(board.match(/data-testid="board-task-card"/gu)).toHaveLength(30);
+    expect(board).toContain('data-testid="board-column-more-active"');
+    expect(board).toContain("还有 15 条");
+
+    const swimlane = renderToStaticMarkup(createElement(SwimlaneBoard, { tasks: rows, groupBy: "root", onSelect: noop, drill: null, relations: [], favorites: new Set<string>(), onToggleFavorite: noop }));
+    expect(swimlane.match(/data-testid="swimlane-row"/gu)).toHaveLength(20);
+    expect(swimlane).toContain('data-testid="swimlane-more"');
+    expect(swimlane).toContain("还有 25 个");
   });
 
   // The test above renders TaskStream directly, so it proves the leaf agrees with the

--- a/packages/gui/test/renderer-app-model.vitest.ts
+++ b/packages/gui/test/renderer-app-model.vitest.ts
@@ -289,13 +289,15 @@ describe("renderer app model", () => {
       claims: [],
       judgmentConsents: [],
     };
+    const decisions = Array.from({ length: 35 }, (_, index) => ({ ...decision, decisionId: `dec_${String(index).padStart(2, "0")}`, title: `Decision ${index}` }));
+    const focused = decisions.at(-1)!;
     const markup = renderToStaticMarkup(createElement(QueryClientProvider, { client: new QueryClient() }, createElement(DecisionPoolView, {
-      repoId: "repo-a", decisions: [decision], facts: [], relations: [], focusedDecisionId: decision.decisionId,
+      repoId: "repo-a", decisions, facts: [], relations: [], focusedDecisionId: focused.decisionId,
       summary: {
-        total: 7, inboxCount: 7,
-        byState: { proposed: 7, in_effect: 0, rejected: 0, deferred: 0, superseded: 0, outcome_retired: 0 },
+        total: decisions.length, inboxCount: decisions.length,
+        byState: { proposed: decisions.length, in_effect: 0, rejected: 0, deferred: 0, superseded: 0, outcome_retired: 0 },
         groups: [
-          { id: "proposed", states: ["proposed"], count: 7, decisionIds: [decision.decisionId, "dec_missing_1", "dec_missing_2", "dec_missing_3", "dec_missing_4", "dec_missing_5", "dec_missing_6"] },
+          { id: "proposed", states: ["proposed"], count: decisions.length, decisionIds: decisions.map((row) => row.decisionId) },
           { id: "in_effect", states: ["in_effect"], count: 0, decisionIds: [] },
           { id: "rejected", states: ["rejected"], count: 0, decisionIds: [] },
           { id: "deferred", states: ["deferred"], count: 0, decisionIds: [] },
@@ -304,9 +306,11 @@ describe("renderer app model", () => {
       }
     })));
 
-    expect(markup).toContain('id="decision-card-dec_gui_smoke"');
+    expect(markup.match(/id="decision-card-/gu)).toHaveLength(31);
+    expect(markup).toContain(`id="decision-card-${focused.decisionId}"`);
     expect(markup).toContain('data-focused="true"');
-    expect(markup).toMatch(/proposed\s*·\s*7/);
+    expect(markup).toContain('data-testid="decision-pool-more"');
+    expect(markup).toMatch(/proposed\s*·\s*35/);
   });
 
   it("renders the exact proposal surface with human-selected risk and urgency", () => {

--- a/packages/gui/test/runtime-workspace-interactions.vitest.ts
+++ b/packages/gui/test/runtime-workspace-interactions.vitest.ts
@@ -54,6 +54,20 @@ describe("runtime workspace interaction wiring", () => {
     expect(document.querySelector('[data-testid^="rail-orchestration-"]')).toBeNull();
   });
 
+  it("keeps more than 32 streamed frames in the inline session scroller", async () => {
+    await mountWorkspace();
+    vi.mocked(agentRuntimeClient.attach).mockImplementation((_repoId, runtimeSessionId, _cursor, onValue) => {
+      for (let index = 0; index < 40; index += 1) onValue({ schema: "agent-runtime-attach-event/v1", runtimeSessionId, cursor: `stream:${index + 5}`, occurredAt: `2026-08-23T00:00:${String(index).padStart(2, "0")}.000Z`, type: "heartbeat" });
+      return () => undefined;
+    });
+
+    await click("rail-session-runtime-bound");
+
+    expect(document.querySelectorAll('[data-testid="session-event-frame"]')).toHaveLength(40);
+    expect(byTestId("session-event-stream").className).toContain("max-h-64");
+    expect(byTestId("session-event-stream").className).toContain("overflow-y-auto");
+  });
+
   it("focuses a related session from the workspace inspector", async () => {
     await mountWorkspace();
     await click("rail-session-runtime-bound");


### PR DESCRIPTION
# English

## Task And Scope

Scale handling for the GUI, the last implementation wave of PLT-GUI-UX. The rule this wave was given was **measure first, change second**: a list being long is not evidence that it is slow, and virtualising a list that is not slow buys complexity while spending scroll anchoring, keyboard navigation and drag.

So the deliverable includes a **measured-but-unchanged** list, and that list is as much a part of the result as the changes are.

### Changed, with the measurement that justified it

| Surface | Before | After |
| --- | --- | --- |
| Board column mode | 1,254 cards · 18,780 DOM · 464.8ms | 122 cards · 2,121 DOM · 136.7ms |
| Board swimlanes (root) | ~815 root lanes · 12,290 DOM · 348.5ms | 20 lanes · 604 DOM · 62.7ms |
| Decision pool (in_effect) | 586 cards · 18,082 DOM · 431.1ms | 30 cards · 1,233 DOM · 97.0ms |
| Runtime rail | 188 rows · 1,433 DOM · **5,515.0ms** | 188 rows · 1,398 DOM · **2,064.1ms** |

The runtime rail was never a rendering problem. It fetched dispatches for all 1,498 taskIds; the runtime overview's session associations name only 69 distinct ones. Querying those 69 returns the **identical 131 dispatches**, with `dispatchSessionsMissingFromOverview=0`. This is a narrowed read, not a cache.

### Measured and deliberately left alone

| Surface | Measurement | Why unchanged |
| --- | --- | --- |
| Board list mode | 15 rows · 727 DOM · 148.2ms | already paginated |
| Decision approval | 28-item queue · 311 DOM · 148.8ms | main pane renders the current card only |
| Presets | 13 rows · 256 DOM · 65.3ms | no real problem |
| Templates | 33 rows · 283 DOM · 63.8ms | no real problem |
| Adapters | 2 rows · 158 DOM · 58.3ms | within noise |

Task's own full cursor read is 250.9ms, so `task-data.ts` is untouched.

### Silent truncation removed, and none introduced

`SessionsPanel` rendered at most 32 event frames via `.slice(-32)` / `.slice(-31)`. That is not pagination — the reader cannot tell anything is missing. Both are deleted; the stream is now an inline fixed-height scroll container, verified to retain 40 frames.

The batching this PR introduces is held to the same standard: every batched surface shows the remaining count and offers a keyboard-reachable control to continue. A deep-linked target outside the first batch is force-retained and stays addressable.

## Verification

- Root `npm run check:local`: exit 0, 45 steps, 95.0s.
- `npm run test:gui:e2e`: 2 pass, 1 pre-existing failure (`settled artifact chain`), red on `main` before this branch and untouched here — tracked as task_385ec0eb99fa74e0df7004fbfe.
- Targeted GUI tests: 5 files / 72 tests.
- Measurement conditions: one Mac, one production build, one canonical resident daemon, 1440×920 window, no other test/worker/Electron measurement process; CPU idle 76–80% before and 75% after. Interaction time is click → target node present → two `requestAnimationFrame`.
- Keyboard, in production Electron: Board 122→152 (45.2ms), Swimlane 20→40 (29.8ms), Decision pool 30→60 (62.6ms).
- Reviewer independently confirmed in the diff that both `.slice(-32)` / `.slice(-31)` are gone, that `runtimePanoramaTasks` narrows by session associations, and that each batched surface exposes a remaining count.

## Review Evidence

Author and reviewer are different agents. The first sampling run was discarded rather than reported: the decision pool grew from 585 to 586 rows mid-measurement, so a fixed-count wait never satisfied. The script was changed to read the live count. Worth stating plainly — the row that appeared was written by the reviewer's own ledger activity during the run.

## Residual Risk

A checkpoint was hit and **not worked around**. `useTriadicProjectionQuery` calls `repo.triadic.relationGraph` with no facets: 1,371 edges / 1,190 facts / 810 coverage in **29,706.2ms**. Following `nextCursor` with `limit=500` takes 91.6ms for the same 1,371 edges — but yields only 235 facts and 412 coverage, silently dropping **955 facts and 398 coverage**, because the narrow relation page returns only the fact refs its own edges touch (`packages/daemon/src/task-query-read.ts:60-69`).

The obvious change here would have replaced a 29.7-second query with a fast one that silently loses the data W5 just moved into Task detail. Fixing it properly requires widening a daemon read face, which this wave is not authorised to do. Tracked as task_8d3b7b7ba7de40281b8fff16a4.

This is worth naming because the task plan asserted the opposite — it called following `nextCursor` a *certain* win. The worker's measurement falsified its own instructions.

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not used
- Break-glass scope: not used

## Machine-Readable Declarations

Production-Delta: +77/-21
Dependency-Change: none

---

# 中文

## 任务与范围

GUI 的规模处理,PLT-GUI-UX 的最后一个实现 wave。这一 wave 的规矩是**先量再改**:列表长不等于渲染慢,而给一个不慢的列表加虚拟化,买到的是复杂度,赔进去的是滚动定位、键盘导航和拖拽。

所以交付物里包含一份**测了但没改**的清单,它与改动清单同等重要。

### 改了的,以及支撑它的实测

| 面 | 改前 | 改后 |
| --- | --- | --- |
| 看板列模式 | 1,254 卡 · 18,780 DOM · 464.8ms | 122 卡 · 2,121 DOM · 136.7ms |
| 看板泳道(root) | 约 815 lanes · 12,290 DOM · 348.5ms | 20 lanes · 604 DOM · 62.7ms |
| 决策池(in_effect) | 586 卡 · 18,082 DOM · 431.1ms | 30 卡 · 1,233 DOM · 97.0ms |
| Runtime rail | 188 行 · 1,433 DOM · **5,515.0ms** | 188 行 · 1,398 DOM · **2,064.1ms** |

Runtime rail 从来不是渲染问题。它拿全部 1,498 个 taskId 去查 dispatch,而 runtime overview 的 session 关联里只有 69 个不同的 taskId。用这 69 个查,返回**完全相同的 131 条 dispatch**,`dispatchSessionsMissingFromOverview=0`。这是把读收窄,不是加缓存。

### 测了但刻意没改

| 面 | 实测 | 为什么不改 |
| --- | --- | --- |
| 看板列表模式 | 15 行 · 727 DOM · 148.2ms | 已有分页 |
| 决策批准 | 28 条队列 · 311 DOM · 148.8ms | 主区只渲染当前卡 |
| 预设 | 13 行 · 256 DOM · 65.3ms | 无真实问题 |
| 模板 | 33 行 · 283 DOM · 63.8ms | 无真实问题 |
| 适配器 | 2 行 · 158 DOM · 58.3ms | 在噪声范围内 |

Task 自身的全量 cursor 读只有 250.9ms,因此 `task-data.ts` 未动。

### 删掉了静默截断,也没有引入新的

`SessionsPanel` 原先用 `.slice(-32)` / `.slice(-31)` 最多渲染 32 帧事件。**那不是分页——读的人无从知道自己少看了什么。** 两处都已删除,事件流改为内联定高滚动容器,实测保留 40 帧。

本 PR 引入的分批被按同一标准要求:每个分批面都显示剩余条数,并提供键盘可达的继续控件;首批之外的深链目标强制保留且仍可寻址。

## 验证

- 根 `npm run check:local`:exit 0,45 steps,95.0s。
- `npm run test:gui:e2e`:2 通过,1 例存量失败(`settled artifact chain`),该例在本分支之前的 `main` 上就是红的,本次未动——由 task_385ec0eb99fa74e0df7004fbfe 跟进。
- 定向 GUI 测试:5 文件 / 72 用例。
- 测量条件:同一台 Mac、同一 production build、同一 canonical resident daemon、1440×920 窗口,测量期间无其它 test/worker/Electron 测量进程;CPU idle 改前 76–80%、改后 75%。交互耗时定义为点击到目标节点出现并经过两个 `requestAnimationFrame`。
- 键盘(production Electron):看板 122→152(45.2ms)、泳道 20→40(29.8ms)、决策池 30→60(62.6ms)。
- 复核者在 diff 中独立确认:两处 `.slice(-32)` / `.slice(-31)` 确已删除;`runtimePanoramaTasks` 确实按 session 关联收窄;每个分批面确实暴露了剩余条数。

## 复核证据

作者与复核者是不同的 agent。第一轮采样被作废而不是拿来报告:测量期间决策池从 585 条变成 586 条,固定计数的等待条件永远不满足。脚本改为动态读当下计数。这里如实说明——**多出来的那一条是复核者自己在同时段写台账造成的**。

## 残留风险

命中了一个 checkpoint,并且**没有绕过它**。`useTriadicProjectionQuery` 调用无 facets 的 `repo.triadic.relationGraph`:1,371 edges / 1,190 facts / 810 coverage,耗时 **29,706.2ms**。用 `limit=500` 跟随 `nextCursor` 读同样的 1,371 edges 只要 91.6ms——但只得到 235 facts 与 412 coverage,**静默丢失 955 facts 与 398 coverage**,因为窄 relation page 只返回它自己那页 edge 触达的 fact refs(`packages/daemon/src/task-query-read.ts:60-69`)。

在这里做那个「显而易见」的改动,会把一个 29.7 秒的慢查询换成一个静默丢数据的快查询,而丢的正是 W5 刚迁进 Task 详情的那批。正确修法要扩宽 daemon 读面,本 wave 无权限。由 task_8d3b7b7ba7de40281b8fff16a4 跟进。

这一条值得点名,因为**任务计划里写的正好相反**——它把「跟随 `nextCursor`」称为收益**确定**的改动。worker 的实测证伪了它自己收到的指令。

## 治理声明

- 触碰受保护面:否
- 受保护面范围:不适用
- 授权依据:不适用
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:未使用
- Break-glass 范围:未使用
