### PR TITLE
fix(gui): wrap the over-length lines PR #1755 added

### DIFF
--- a/packages/gui/src/renderer/App.tsx
+++ b/packages/gui/src/renderer/App.tsx
@@ -506,7 +506,8 @@ function AppShell() {
             ) : view === "agentSquad" ? (
               <AgentSquadView
                 repoId={projectId}
-                tasks={projectTasks.map(({ taskId, title, activeExecutionId }) => ({ taskId, title, heldLease: activeExecutionId !== undefined }))}
+                tasks={projectTasks.map(({ taskId, title, activeExecutionId }) => ({ taskId, title,
+                  heldLease: activeExecutionId !== undefined }))}
                 focusedEntityRef={focusedEntityRef}
                 onSelectEntity={selectRuntimeEntity}
               />

--- a/packages/gui/src/renderer/components/runtime/RuntimeInspector.tsx
+++ b/packages/gui/src/renderer/components/runtime/RuntimeInspector.tsx
@@ -20,22 +20,39 @@ type OpenSession = (runtimeSessionId: string) => void;
 // liveness word decides the dot through a table lookup alone.
 const LIVENESS_DOT: Record<string, "live" | "idle"> = { live: "live" };
 
-export function ProviderInspector({ instance, probeError, sessions, onOpenSession }: { readonly instance: RuntimeInstanceSummary | null; readonly probeError: string | null; readonly sessions: readonly AgentRuntimeSessionDto[]; readonly onOpenSession: OpenSession }) {
-  return <aside data-testid="runtime-inspector" aria-label={t("agentRuntime.inspectorRuntime")} className="w-[300px] shrink-0 overflow-y-auto border-l border-border bg-surface">
-    <h2 className="sticky top-0 border-b border-border bg-surface px-3 py-2 text-[10.5px] font-bold uppercase tracking-[0.09em] text-text-faint">{t("agentRuntime.inspectorRuntime")}</h2>
+export function ProviderInspector({ instance, probeError, sessions, onOpenSession }: {
+  readonly instance: RuntimeInstanceSummary | null; readonly probeError: string | null; readonly sessions:
+  readonly AgentRuntimeSessionDto[]; readonly onOpenSession: OpenSession }) {
+  return <aside data-testid="runtime-inspector" aria-label={t("agentRuntime.inspectorRuntime")}
+    className="w-[300px] shrink-0 overflow-y-auto border-l border-border bg-surface">
+    <h2
+      className="sticky top-0 border-b border-border bg-surface px-3 py-2 text-[10.5px] font-bold uppercase
+        tracking-[0.09em] text-text-faint">{t("agentRuntime.inspectorRuntime")}</h2>
     <RuntimeFacts instance={instance} probeError={probeError} />
     <Section title={t("agentRuntime.inspectorSessions", { count: sessions.length })}>
-      {sessions.length === 0 ? <Empty>{t("agentRuntime.noSessions")}</Empty> : sessions.slice(0, 8).map((session) => <LiveSessionRow key={session.runtimeSessionId} session={session} onOpenSession={onOpenSession} />)}
+      {sessions.length === 0 ? <Empty>{t("agentRuntime.noSessions")}</Empty> : sessions.slice(0,
+        8).map((session) => <LiveSessionRow key={session.runtimeSessionId} session={session}
+        onOpenSession={onOpenSession} />)}
     </Section>
   </aside>;
 }
 
-export function IdentityInspector({ selection, agents, squads, rows, onSelect, onOpenSession }: { readonly selection: RuntimeSelection; readonly agents: readonly AgentEntityRow[]; readonly squads: readonly SquadEntityRow[]; readonly rows: readonly RuntimeDockRow[]; readonly onSelect: (selection: RuntimeSelection) => void; readonly onOpenSession: OpenSession }) {
-  const related = rows.filter((row) => selection.type === "agent" ? row.agentId === selection.id : row.squadId === selection.id);
-  return <aside data-testid="runtime-inspector" aria-label={t(selection.type === "agent" ? "agentRuntime.inspectorAgent" : "agentRuntime.inspectorSquad")} className="w-[300px] shrink-0 overflow-y-auto border-l border-border bg-surface">
-    <h2 className="sticky top-0 border-b border-border bg-surface px-3 py-2 text-[10.5px] font-bold uppercase tracking-[0.09em] text-text-faint">{t(selection.type === "agent" ? "agentRuntime.inspectorAgent" : "agentRuntime.inspectorSquad")}</h2>
+export function IdentityInspector({ selection, agents, squads, rows, onSelect, onOpenSession }: {
+  readonly selection: RuntimeSelection; readonly agents: readonly AgentEntityRow[]; readonly squads:
+  readonly SquadEntityRow[]; readonly rows: readonly RuntimeDockRow[]; readonly onSelect: (selection:
+  RuntimeSelection) => void; readonly onOpenSession: OpenSession }) {
+  const related = rows.filter((row) => selection.type === "agent" ? row.agentId === selection.id :
+    row.squadId === selection.id);
+  return <aside data-testid="runtime-inspector" aria-label={t(selection.type === "agent" ?
+    "agentRuntime.inspectorAgent" : "agentRuntime.inspectorSquad")}
+    className="w-[300px] shrink-0 overflow-y-auto border-l border-border bg-surface">
+    <h2
+      className="sticky top-0 border-b border-border bg-surface px-3 py-2 text-[10.5px] font-bold uppercase
+        tracking-[0.09em] text-text-faint">{t(selection.type === "agent" ? "agentRuntime.inspectorAgent" :
+          "agentRuntime.inspectorSquad")}</h2>
     {selection.type === "agent"
-      ? <AgentFacts agent={agents.find((agent) => agent.id === selection.id) ?? null} squads={squads} onSelect={onSelect} />
+      ? <AgentFacts agent={agents.find((agent) => agent.id === selection.id) ?? null} squads={squads}
+        onSelect={onSelect} />
       : <SquadFacts squad={squads.find((squad) => squad.id === selection.id) ?? null} onSelect={onSelect} />}
     <Section title={t("agentRuntime.inspectorSessions", { count: related.length })}>
       {related.length === 0 ? <Empty>{t("agentRuntime.noSessions")}</Empty> : related.slice(0, 8).map((row) => <DispatchSessionRow key={row.runtimeSessionId} row={row} onOpenSession={onOpenSession} />)}
@@ -43,29 +60,46 @@ export function IdentityInspector({ selection, agents, squads, rows, onSelect, o
   </aside>;
 }
 
-export function SessionInspector({ row, rows, onSelectSession, onOpenTask }: { readonly row: RuntimeDockRow | null; readonly rows: readonly RuntimeDockRow[]; readonly onSelectSession: OpenSession; readonly onOpenTask: (taskId: string) => void }) {
+export function SessionInspector({ row, rows, onSelectSession, onOpenTask }: { readonly row:
+  RuntimeDockRow | null; readonly rows: readonly RuntimeDockRow[]; readonly onSelectSession:
+  OpenSession; readonly onOpenTask: (taskId: string) => void }) {
   const siblings = sessionSiblingRows(rows, row?.runtimeSessionId ?? "");
-  return <aside data-testid="runtime-inspector" aria-label={t("agentRuntime.inspectorSession")} className="w-[300px] shrink-0 overflow-y-auto border-l border-border bg-surface">
-    <h2 className="sticky top-0 border-b border-border bg-surface px-3 py-2 text-[10.5px] font-bold uppercase tracking-[0.09em] text-text-faint">{t("agentRuntime.inspectorSession")}</h2>
+  return <aside data-testid="runtime-inspector" aria-label={t("agentRuntime.inspectorSession")}
+    className="w-[300px] shrink-0 overflow-y-auto border-l border-border bg-surface">
+    <h2
+      className="sticky top-0 border-b border-border bg-surface px-3 py-2 text-[10.5px] font-bold uppercase
+        tracking-[0.09em] text-text-faint">{t("agentRuntime.inspectorSession")}</h2>
     <SessionFacts row={row} onOpenTask={onOpenTask} />
     <Section title={t("agentRuntime.inspectorSessions", { count: siblings.length })}>
-      {siblings.length === 0 ? <Empty>{t("agentRuntime.noSessions")}</Empty> : siblings.slice(0, 8).map((sibling) => <DispatchSessionRow key={sibling.runtimeSessionId} row={sibling} onOpenSession={onSelectSession} />)}
+      {siblings.length === 0 ? <Empty>{t("agentRuntime.noSessions")}</Empty> : siblings.slice(0,
+        8).map((sibling) => <DispatchSessionRow key={sibling.runtimeSessionId} row={sibling}
+        onOpenSession={onSelectSession} />)}
     </Section>
   </aside>;
 }
 
 function Section({ title, children }: { readonly title: string; readonly children: ReactNode }) { return <section className="border-b border-border px-3 py-2 last:border-b-0"><h3 className="mb-1.5 font-mono text-[10px] uppercase tracking-[0.07em] text-text-faint">{title}</h3>{children}</section>; }
-function LiveSessionRow({ session, onOpenSession }: { readonly session: AgentRuntimeSessionDto; readonly onOpenSession: OpenSession }) {
-  return <button type="button" onClick={() => onOpenSession(session.runtimeSessionId)} className="flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-left hover:bg-surface-raised">
+function LiveSessionRow({ session, onOpenSession }: { readonly session: AgentRuntimeSessionDto;
+  readonly onOpenSession: OpenSession }) {
+  return <button type="button" onClick={() => onOpenSession(session.runtimeSessionId)}
+    className="flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-left hover:bg-surface-raised">
     <LiveDot state={LIVENESS_DOT[session.liveness] ?? "idle"} tip={session.liveness} />
-    <span className="min-w-0 flex-1"><span className="block truncate text-[11.5px]">{session.instanceId}</span><span className="block truncate font-mono text-[10px] text-text-faint">{session.runtimeSessionId}</span></span>
-    <span className="shrink-0 font-mono text-[9.5px] text-text-faint">{session.activity.lastObservedAt.slice(11, 16)}</span>
+    <span className="min-w-0 flex-1"><span
+      className="block truncate text-[11.5px]">{session.instanceId}</span><span
+      className="block truncate font-mono text-[10px] text-text-faint">{session.runtimeSessionId}</span></span>
+    <span className="shrink-0 font-mono text-[9.5px] text-text-faint">{session.activity.lastObservedAt.slice(11,
+      16)}</span>
   </button>;
 }
-function DispatchSessionRow({ row, onOpenSession }: { readonly row: RuntimeDockRow; readonly onOpenSession: OpenSession }) {
-  return <button type="button" onClick={() => onOpenSession(row.runtimeSessionId)} className="flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-left hover:bg-surface-raised">
+function DispatchSessionRow({ row, onOpenSession }: { readonly row: RuntimeDockRow;
+  readonly onOpenSession: OpenSession }) {
+  return <button type="button" onClick={() => onOpenSession(row.runtimeSessionId)}
+    className="flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-left hover:bg-surface-raised">
     <LiveDot state={row.status === "running" ? "live" : row.status === "failed" ? "failed" : "idle"} tip={row.status} />
-    <span className="min-w-0 flex-1"><span className="block truncate text-[11.5px]">{row.agentName ?? row.instanceId}</span><span className="block truncate font-mono text-[10px] text-text-faint">{row.taskTitle ?? row.runtimeSessionId}</span></span>
+    <span className="min-w-0 flex-1"><span className="block truncate text-[11.5px]">{row.agentName ??
+      row.instanceId}</span><span
+      className="block truncate font-mono text-[10px] text-text-faint">{row.taskTitle ??
+      row.runtimeSessionId}</span></span>
     <span className="shrink-0 font-mono text-[9.5px] text-text-faint">{row.startedAt.slice(11, 16)}</span>
   </button>;
 }

--- a/packages/gui/src/renderer/components/runtime/RuntimeRail.tsx
+++ b/packages/gui/src/renderer/components/runtime/RuntimeRail.tsx
@@ -14,7 +14,10 @@ const OUTCOME_TONE: Record<RuntimeDockRow["status"], string> = { succeeded: "tex
 // SessionRail(执行)。行渲染与 testid(rail-runtime-*/rail-agent-*/rail-squad-*/
 // rail-session-*/runtime-new-*)原样保留,只是各回各页;跨页不再共享选中态,
 // 互跳走可寻址路由。
-export function ProviderRail({ instances, authProbeErrors, selectedId, liveByInstance, onSelect, onNew }: { readonly instances: readonly RuntimeInstanceSummary[]; readonly authProbeErrors?: ReadonlyMap<string, string>; readonly selectedId: string | null; readonly liveByInstance: ReadonlyMap<string, number>; readonly onSelect: (instanceId: string) => void; readonly onNew: () => void }) {
+export function ProviderRail({ instances, authProbeErrors, selectedId, liveByInstance, onSelect, onNew
+  }: { readonly instances: readonly RuntimeInstanceSummary[]; readonly authProbeErrors?:
+  ReadonlyMap<string, string>; readonly selectedId: string | null; readonly liveByInstance:
+  ReadonlyMap<string, number>; readonly onSelect: (instanceId: string) => void; readonly onNew: () => void }) {
   const [open, setOpen] = useState(true);
   return <nav data-testid="runtime-rail" aria-label={t("agentRuntime.railLabel")} className="flex w-[240px] shrink-0 flex-col overflow-y-auto border-r border-border bg-surface">
     <Segment segment="runtimes" title={t("agentRuntime.segRuntimes")} sub={t("agentRuntime.segRuntimesSub")} count={instances.length} open={open} onToggle={() => setOpen(!open)} onNew={onNew}>
@@ -32,19 +35,27 @@ export function ProviderRail({ instances, authProbeErrors, selectedId, liveByIns
 // fourth entry. The design-thesis note stays at this rail's foot: dispatch is authored
 // from this page, and the formula it explains (Agent × Runtime × Task → Session) is the
 // one this page starts.
-export function IdentityRail({ agents, squads, selection, onSelect, onNew }: { readonly agents: readonly AgentEntityRow[]; readonly squads: readonly SquadEntityRow[]; readonly selection: RuntimeSelection | null; readonly onSelect: (selection: RuntimeSelection) => void; readonly onNew: (segment: "agents" | "squads") => void }) {
+export function IdentityRail({ agents, squads, selection, onSelect, onNew }: { readonly agents: readonly
+  AgentEntityRow[]; readonly squads: readonly SquadEntityRow[]; readonly selection: RuntimeSelection |
+  null; readonly onSelect: (selection: RuntimeSelection) => void; readonly onNew: (segment: "agents" |
+  "squads") => void }) {
   const [segments, setSegments] = useState<Readonly<Record<string, boolean>>>({ agents: true, squads: true });
   const onToggle = (segment: string) => setSegments((value) => ({ ...value, [segment]: !(value[segment] ?? true) }));
   const picked = (type: "agent" | "squad", id: string) => selection?.type === type && selection.id === id;
-  return <nav data-testid="runtime-rail" aria-label={t("agentRuntime.railLabel")} className="flex w-[240px] shrink-0 flex-col overflow-y-auto border-r border-border bg-surface">
-    <Segment segment="agents" title={t("agentRuntime.segAgents")} sub={t("agentRuntime.segAgentsSub")} count={agents.length} open={segments.agents ?? true} onToggle={() => onToggle("agents")} onNew={() => onNew("agents")}>
+  return <nav data-testid="runtime-rail" aria-label={t("agentRuntime.railLabel")}
+    className="flex w-[240px] shrink-0 flex-col overflow-y-auto border-r border-border bg-surface">
+    <Segment segment="agents" title={t("agentRuntime.segAgents")} sub={t("agentRuntime.segAgentsSub")}
+      count={agents.length} open={segments.agents ?? true} onToggle={() => onToggle("agents")} onNew={() =>
+      onNew("agents")}>
       {agents.map((agent) => <Row key={agent.id} tip={agent.id} testId={`rail-agent-${agent.id}`} selected={picked("agent", agent.id)} onSelect={() => onSelect({ type: "agent", id: agent.id })}>
         <Avatar id={agent.id} /><span className="min-w-0 flex-1 truncate text-[12px]">{agent.name}</span>
         <span data-tip={t("agentRuntime.layerTip", { layer: agent.layer })} className="shrink-0 rounded-[3px] border border-border-strong px-1 font-mono text-[9px] tracking-[0.04em] text-text-faint">{agent.layer}</span>
         {agent.validity === "blocked" && <LiveDot state="failed" tip={t("agentRuntime.declarationBlocked")} />}
       </Row>)}
     </Segment>
-    <Segment segment="squads" title={t("agentRuntime.segSquads")} sub={t("agentRuntime.segSquadsSub")} count={squads.length} open={segments.squads ?? true} onToggle={() => onToggle("squads")} onNew={() => onNew("squads")}>
+    <Segment segment="squads" title={t("agentRuntime.segSquads")} sub={t("agentRuntime.segSquadsSub")}
+      count={squads.length} open={segments.squads ?? true} onToggle={() => onToggle("squads")} onNew={() =>
+      onNew("squads")}>
       {squads.map((squad) => <Row key={squad.id} tip={squad.id} testId={`rail-squad-${squad.id}`} selected={picked("squad", squad.id)} onSelect={() => onSelect({ type: "squad", id: squad.id })}>
         <KindDot kind="any" /><span className="min-w-0 flex-1 truncate text-[12px]">{squad.name}</span>
         <span className="shrink-0 rounded-[3px] border border-border-strong px-1 font-mono text-[9px] text-text-faint">{t("agentRuntime.memberCount", { count: squad.workers.length + 1 })}</span>
@@ -58,16 +69,20 @@ export function IdentityRail({ agents, squads, selection, onSelect, onNew }: { r
 // the carrier is only where a session happens to run. A runtime session the dispatch ledger
 // does not know about still belongs here, under its unattributed group. W5:「编排」段撤销
 // ——task 派工链归 Task 详情「派工」页签,运行侧只保留 session 行与其绑定的 task 标题。
-export function SessionRail({ sessions, selectedId, onSelect }: { readonly sessions: readonly RuntimeDockRow[]; readonly selectedId: string | null; readonly onSelect: (runtimeSessionId: string) => void }) {
+export function SessionRail({ sessions, selectedId, onSelect }: { readonly sessions: readonly
+  RuntimeDockRow[]; readonly selectedId: string | null; readonly onSelect: (runtimeSessionId: string) => void }) {
   const [open, setOpen] = useState(true);
-  return <nav data-testid="runtime-rail" aria-label={t("agentRuntime.railLabel")} className="flex w-[240px] shrink-0 flex-col overflow-y-auto border-r border-border bg-surface">
-    <Segment segment="sessions" title={t("agentRuntime.segSessions")} sub={t("agentRuntime.segSessionsSub")} count={sessions.length} open={open} onToggle={() => setOpen(!open)}>
+  return <nav data-testid="runtime-rail" aria-label={t("agentRuntime.railLabel")}
+    className="flex w-[240px] shrink-0 flex-col overflow-y-auto border-r border-border bg-surface">
+    <Segment segment="sessions" title={t("agentRuntime.segSessions")}
+      sub={t("agentRuntime.segSessionsSub")} count={sessions.length} open={open} onToggle={() => setOpen(!open)}>
       <SessionGroupRows sessions={sessions} selectedId={selectedId} onSelect={onSelect} />
     </Segment>
   </nav>;
 }
 
-function SessionGroupRows({ sessions, selectedId, onSelect }: { readonly sessions: readonly RuntimeDockRow[]; readonly selectedId: string | null; readonly onSelect: (runtimeSessionId: string) => void }) {
+function SessionGroupRows({ sessions, selectedId, onSelect }: { readonly sessions: readonly
+  RuntimeDockRow[]; readonly selectedId: string | null; readonly onSelect: (runtimeSessionId: string) => void }) {
   const [collapsed, setCollapsed] = useState<Readonly<Record<string, boolean>>>({});
   return <>{runtimeDockGroups(sessions).map((group) => <div key={group.key}>
     <button type="button" aria-expanded={!collapsed[group.key]} onClick={() => setCollapsed((current) => ({ ...current, [group.key]: !current[group.key] }))} className="flex w-full items-center gap-1.5 px-1.5 pt-1 pb-0.5 text-left text-[10.5px] text-text-muted">

--- a/packages/gui/src/renderer/components/runtime/useRuntimeWorkspace.ts
+++ b/packages/gui/src/renderer/components/runtime/useRuntimeWorkspace.ts
@@ -19,7 +19,8 @@ const message = (value: unknown): string => value instanceof Error ? value.messa
 
 // 可寻址选择(W4 路由的运行时段):agent/squad/session 用本名,Runtime 实例在导航
 // 引用里叫 provider/<id>(与一级入口「Provider」同名),选择类型仍是 "runtime"。
-export function runtimeSelectionRef(selection: RuntimeSelection): string { return selection.type === "runtime" ? `provider/${selection.id}` : `${selection.type}/${selection.id}`; }
+export function runtimeSelectionRef(selection: RuntimeSelection): string { return selection.type ===
+  "runtime" ? `provider/${selection.id}` : `${selection.type}/${selection.id}`; }
 export function runtimeSelectionFromRef(ref: string | null): RuntimeSelection | null {
   if (ref === null) return null;
   const separator = ref.indexOf("/"); if (separator < 0) return null;
@@ -42,7 +43,9 @@ const LIVENESS_LIVE: Record<string, boolean> = { live: true };
 // feedback line, the same error line, and (for spawn-shaped actions) the same receipt
 // settlement footer. The channel owns no reads; the page hook passes its own refresh.
 function useRuntimeChannel(repoId: string, refresh: () => Promise<unknown>) {
-  const [busy, setBusy] = useState(false), [feedback, setFeedback] = useState<string | null>(null), [error, setError] = useState<string | null>(null), [settlement, setSettlement] = useState<RuntimeSpawnSettlement | null>(null);
+  const [busy, setBusy] = useState(false), [feedback, setFeedback] = useState<string | null>(null),
+    [error, setError] = useState<string | null>(null), [settlement, setSettlement] =
+    useState<RuntimeSpawnSettlement | null>(null);
   const run = async (label: string, action: () => Promise<unknown>, reread = true): Promise<unknown> => {
     if (busy) return null; setBusy(true); setError(null);
     try { const result = await action(); const record = result as Record<string, unknown> | null, id = String(record?.sessionId ?? record?.opId ?? "applied"); setFeedback(t("agentRuntime.feedbackApplied", { label, id })); if (reread) await refresh(); return result; }
@@ -55,28 +58,39 @@ function useRuntimeChannel(repoId: string, refresh: () => Promise<unknown>) {
     catch (cause) { consumeKnownError(cause); setError(message(cause)); return null; }
     finally { setBusy(false); }
   };
-  return { busy, feedback, error, settlement, clearFeedback: () => { setFeedback(null); setError(null); }, reportError: setError, run, spawn };
+  return { busy, feedback, error, settlement, clearFeedback: () => { setFeedback(null); setError(null);
+    }, reportError: setError, run, spawn };
 }
 
 // The dispatch-ledger panorama, narrowed to the task ids the overview already associates
 // with runtime sessions (W6) and shared verbatim between the sessions and agent entries —
 // one cache key, one batched task-dispatches read.
-function useRuntimePanorama(repoId: string, tasks: readonly RuntimePanoramaTask[], sessions: readonly AgentRuntimeSessionDto[]) {
+function useRuntimePanorama(repoId: string, tasks: readonly RuntimePanoramaTask[], sessions: readonly
+  AgentRuntimeSessionDto[]) {
   const client = useQueryClient(), panoramaTasks = runtimePanoramaTasks(tasks, sessions);
-  const squadQuery = { queryKey: ["squads", repoId], queryFn: () => agentEntityClient.listSquads(repoId), staleTime: 4_000 } as const;
-  return useQuery({ queryKey: ["runtime-panorama", repoId, panoramaTasks.map((task) => task.taskId).join(",")], queryFn: () => readPanorama(repoId, panoramaTasks, { listSquads: () => client.fetchQuery(squadQuery), getTaskDispatches: (taskIds) => harnessClient.getTaskDispatches({ repoId, taskIds }) }), staleTime: 4_000 });
+  const squadQuery = { queryKey: ["squads", repoId], queryFn: () =>
+    agentEntityClient.listSquads(repoId), staleTime: 4_000 } as const;
+  return useQuery({ queryKey: ["runtime-panorama", repoId, panoramaTasks.map((task) =>
+    task.taskId).join(",")], queryFn: () => readPanorama(repoId, panoramaTasks, { listSquads: () =>
+    client.fetchQuery(squadQuery), getTaskDispatches: (taskIds) => harnessClient.getTaskDispatches({
+    repoId, taskIds }) }), staleTime: 4_000 });
 }
 
 // 会话入口:overview + 收窄 panorama → dock rows。rail 分组、主区会话详情、inspector
 // 兄弟会话全部从这两面派生;唯一的写是 cancel。
 export function useSessionsWorkspace(repoId: string, tasks: readonly RuntimePanoramaTask[]) {
   const client = useQueryClient();
-  const overview = useQuery({ queryKey: ["runtime-control", repoId, "overview"], queryFn: () => agentRuntimeClient.overview(repoId), staleTime: 3_000 });
+  const overview = useQuery({ queryKey: ["runtime-control", repoId, "overview"], queryFn: () =>
+    agentRuntimeClient.overview(repoId), staleTime: 3_000 });
   const sessions = () => overview.data?.sessions ?? [];
   const panorama = useRuntimePanorama(repoId, tasks, sessions());
-  const channel = useRuntimeChannel(repoId, async () => { await Promise.all([client.invalidateQueries({ queryKey: ["runtime-control", repoId] }), client.invalidateQueries({ queryKey: ["runtime-panorama", repoId] })]); });
-  return { overview, panorama, dockRows: runtimeDockRows(panorama.data ?? [], sessions()), busy: channel.busy, feedback: channel.feedback, error: channel.error, clearFeedback: channel.clearFeedback,
-    cancelSession: (runtimeSessionId: string) => channel.run(t("agentRuntime.opSessionCancelled"), () => runtimeCommandClient.cancel(repoId, runtimeSessionId)) };
+  const channel = useRuntimeChannel(repoId, async () => { await Promise.all([client.invalidateQueries({
+    queryKey: ["runtime-control", repoId] }), client.invalidateQueries({ queryKey: ["runtime-panorama",
+    repoId] })]); });
+  return { overview, panorama, dockRows: runtimeDockRows(panorama.data ?? [], sessions()), busy:
+    channel.busy, feedback: channel.feedback, error: channel.error, clearFeedback: channel.clearFeedback,
+    cancelSession: (runtimeSessionId: string) => channel.run(t("agentRuntime.opSessionCancelled"), () =>
+      runtimeCommandClient.cancel(repoId, runtimeSessionId)) };
 }
 
 // Agent 入口(含 Squad 面):身份层读写 + 派工。兼容 Runtime 实例列表来自 machine
@@ -84,17 +98,32 @@ export function useSessionsWorkspace(repoId: string, tasks: readonly RuntimePano
 // panorama 行(收窄读,与会话入口共享缓存键)。
 export function useAgentSquadWorkspace(repoId: string, tasks: readonly RuntimePanoramaTask[]) {
   const client = useQueryClient();
-  const overview = useQuery({ queryKey: ["runtime-control", repoId, "overview"], queryFn: () => agentRuntimeClient.overview(repoId), staleTime: 3_000 });
-  const agents = useQuery({ queryKey: ["agents", repoId], queryFn: () => agentEntityClient.listAgents(repoId), staleTime: 4_000 });
-  const squads = useQuery({ queryKey: ["squads", repoId], queryFn: () => agentEntityClient.listSquads(repoId), staleTime: 4_000 });
-  const machine = useQuery({ queryKey: ["runtime-instances", "machine"], queryFn: runtimeInstanceClient.list, staleTime: 2_000 });
+  const overview = useQuery({ queryKey: ["runtime-control", repoId, "overview"], queryFn: () =>
+    agentRuntimeClient.overview(repoId), staleTime: 3_000 });
+  const agents = useQuery({ queryKey: ["agents", repoId], queryFn: () =>
+    agentEntityClient.listAgents(repoId), staleTime: 4_000 });
+  const squads = useQuery({ queryKey: ["squads", repoId], queryFn: () =>
+    agentEntityClient.listSquads(repoId), staleTime: 4_000 });
+  const machine = useQuery({ queryKey: ["runtime-instances", "machine"], queryFn:
+    runtimeInstanceClient.list, staleTime: 2_000 });
   const sessions = () => overview.data?.sessions ?? [];
   const panorama = useRuntimePanorama(repoId, tasks, sessions());
-  const channel = useRuntimeChannel(repoId, async () => { await Promise.all([client.invalidateQueries({ queryKey: ["runtime-control", repoId] }), client.invalidateQueries({ queryKey: ["runtime-panorama", repoId] })]); });
-  return { overview, agents, squads, machine, instances: machine.data?.instances ?? [], dockRows: runtimeDockRows(panorama.data ?? [], sessions()), busy: channel.busy, feedback: channel.feedback, error: channel.error, settlement: channel.settlement, clearFeedback: channel.clearFeedback,
-    saveAgent: async (declaration: AgentDeclarationV1) => { const saved = await channel.run(t("agentRuntime.opAgentSaved"), () => agentEntityClient.saveAgent(repoId, declaration), false); if (saved === null) return null; await client.invalidateQueries({ queryKey: ["agents", repoId] }); await client.invalidateQueries({ queryKey: ["agent-detail", repoId] }); return saved; },
-    saveSquad: async (declaration: SquadDeclarationV1) => { const saved = await channel.run(t("agentRuntime.opSquadSaved"), () => agentEntityClient.saveSquad(repoId, declaration), false); if (saved === null) return null; await client.invalidateQueries({ queryKey: ["squads", repoId] }); await client.invalidateQueries({ queryKey: ["squad-detail", repoId] }); return saved; },
-    dispatch: (request: DispatchRequest) => channel.spawn(buildDispatchSpawnInput(request, overview.data?.instances ?? [])) };
+  const channel = useRuntimeChannel(repoId, async () => { await Promise.all([client.invalidateQueries({
+    queryKey: ["runtime-control", repoId] }), client.invalidateQueries({ queryKey: ["runtime-panorama",
+    repoId] })]); });
+  return { overview, agents, squads, machine, instances: machine.data?.instances ?? [], dockRows:
+    runtimeDockRows(panorama.data ?? [], sessions()), busy: channel.busy, feedback: channel.feedback,
+    error: channel.error, settlement: channel.settlement, clearFeedback: channel.clearFeedback,
+    saveAgent: async (declaration: AgentDeclarationV1) => { const saved = await
+      channel.run(t("agentRuntime.opAgentSaved"), () => agentEntityClient.saveAgent(repoId,
+      declaration), false); if (saved === null) return null; await client.invalidateQueries({ queryKey:
+      ["agents", repoId] }); await client.invalidateQueries({ queryKey: ["agent-detail", repoId] }); return saved; },
+    saveSquad: async (declaration: SquadDeclarationV1) => { const saved = await
+      channel.run(t("agentRuntime.opSquadSaved"), () => agentEntityClient.saveSquad(repoId,
+      declaration), false); if (saved === null) return null; await client.invalidateQueries({ queryKey:
+      ["squads", repoId] }); await client.invalidateQueries({ queryKey: ["squad-detail", repoId] }); return saved; },
+    dispatch: (request: DispatchRequest) => channel.spawn(buildDispatchSpawnInput(request,
+      overview.data?.instances ?? [])) };
 }
 
 // Provider 入口:实例目录 + auth 探测 + 实例读写。live 计数取 overview 的 session
@@ -103,18 +132,31 @@ export function useAgentSquadWorkspace(repoId: string, tasks: readonly RuntimePa
 // 数据面),与 Agent 入口共享缓存键。
 export function useProviderWorkspace(repoId: string) {
   const client = useQueryClient();
-  const machine = useQuery({ queryKey: ["runtime-instances", "machine"], queryFn: runtimeInstanceClient.list, staleTime: 2_000 });
-  const agents = useQuery({ queryKey: ["agents", repoId], queryFn: () => agentEntityClient.listAgents(repoId), staleTime: 4_000 });
+  const machine = useQuery({ queryKey: ["runtime-instances", "machine"], queryFn:
+    runtimeInstanceClient.list, staleTime: 2_000 });
+  const agents = useQuery({ queryKey: ["agents", repoId], queryFn: () =>
+    agentEntityClient.listAgents(repoId), staleTime: 4_000 });
   const listedInstances = machine.data?.instances ?? [];
-  const authProbes = useQueries({ queries: listedInstances.map((instance) => { const needsProbe = instance.authReadiness.code === "runtime_auth_not_checked"; return { queryKey: ["runtime-instance-auth", instance.instanceId, machine.dataUpdatedAt], queryFn: () => runtimeInstanceClient.probe(instance.instanceId), enabled: needsProbe, retry: false, staleTime: 2_000, ...(needsProbe ? {} : { initialData: instance }) }; }) });
+  const authProbes = useQueries({ queries: listedInstances.map((instance) => { const needsProbe =
+    instance.authReadiness.code === "runtime_auth_not_checked"; return { queryKey:
+    ["runtime-instance-auth", instance.instanceId, machine.dataUpdatedAt], queryFn: () =>
+    runtimeInstanceClient.probe(instance.instanceId), enabled: needsProbe, retry: false, staleTime:
+    2_000, ...(needsProbe ? {} : { initialData: instance }) }; }) });
   const instances = listedInstances.map((instance, index) => authProbes[index]?.data ?? instance);
-  const authProbeErrors = new Map<string, string>(listedInstances.flatMap((instance, index) => { const error = authProbes[index]?.error; return error === null || error === undefined ? [] : [[instance.instanceId, message(error)] as const]; }));
-  const overview = useQuery({ queryKey: ["runtime-control", repoId, "overview"], queryFn: () => agentRuntimeClient.overview(repoId), staleTime: 3_000 });
+  const authProbeErrors = new Map<string, string>(listedInstances.flatMap((instance, index) => { const
+    error = authProbes[index]?.error; return error === null || error === undefined ? [] :
+    [[instance.instanceId, message(error)] as const]; }));
+  const overview = useQuery({ queryKey: ["runtime-control", repoId, "overview"], queryFn: () =>
+    agentRuntimeClient.overview(repoId), staleTime: 3_000 });
   const liveByInstance = new Map<string, number>();
-  for (const session of overview.data?.sessions ?? []) if (LIVENESS_LIVE[session.liveness]) liveByInstance.set(session.instanceId, (liveByInstance.get(session.instanceId) ?? 0) + 1);
-  const channel = useRuntimeChannel(repoId, async () => { await Promise.all([client.invalidateQueries({ queryKey: ["runtime-instances", "machine"] }), client.invalidateQueries({ queryKey: ["runtime-control", repoId] })]); });
+  for (const session of overview.data?.sessions ?? []) if (LIVENESS_LIVE[session.liveness])
+    liveByInstance.set(session.instanceId, (liveByInstance.get(session.instanceId) ?? 0) + 1);
+  const channel = useRuntimeChannel(repoId, async () => { await Promise.all([client.invalidateQueries({
+    queryKey: ["runtime-instances", "machine"] }), client.invalidateQueries({ queryKey:
+    ["runtime-control", repoId] })]); });
   const selfTest = async (instanceId: string, model: string): Promise<string | null> => {
-    const result = await channel.spawn(runtimeSelfTestSpawnInput(instanceId, model, `gui-runtime-self-test-${instanceId}-${crypto.randomUUID()}`));
+    const result = await channel.spawn(runtimeSelfTestSpawnInput(instanceId, model,
+      `gui-runtime-self-test-${instanceId}-${crypto.randomUUID()}`));
     if (!result?.runtimeSessionId) return null;
     try {
       for (let attempt = 0; attempt < 80; attempt += 1) {
@@ -126,16 +168,33 @@ export function useProviderWorkspace(repoId: string) {
       }
       throw new Error(t("agentRuntime.selfTestTimeout"));
     } catch (cause) {
-      consumeKnownError(cause); channel.reportError(t("agentRuntime.feedbackFailed", { label: t("agentRuntime.selfTestTitle"), error: message(cause) })); return null;
+      consumeKnownError(cause); channel.reportError(t("agentRuntime.feedbackFailed", { label:
+        t("agentRuntime.selfTestTitle"), error: message(cause) })); return null;
     }
   };
-  return { machine, agents, instances, authProbeErrors, overview, liveByInstance, busy: channel.busy, feedback: channel.feedback, error: channel.error, settlement: channel.settlement, clearFeedback: channel.clearFeedback,
-    createInstance: async (input: RuntimeInstanceCreateInput) => { const created = await channel.run(t("agentRuntime.opInstanceCreated"), () => runtimeInstanceClient.create(input), false); if (!created) return null; if (input.authMode === "subscription") { const probed = await channel.run(t("agentRuntime.opAuthChecked"), () => runtimeInstanceClient.probe(input.instanceId), false); if (subscriptionCreationNeedsLogin(input, probed)) await channel.run(t("agentRuntime.opSignIn"), () => runtimeInstanceClient.auth(repoId, input.instanceId, "login"), false); } await client.invalidateQueries({ queryKey: ["runtime-instances", "machine"] }); await client.invalidateQueries({ queryKey: ["runtime-control", repoId] }); return created; },
-    updateInstance: (input: RuntimeInstanceUpdateInput) => channel.run(t("agentRuntime.opInstanceUpdated"), () => runtimeInstanceClient.update(input)),
-    setInstanceEnabled: (instanceId: string, enabled: boolean) => channel.run(t(enabled ? "agentRuntime.opInstanceEnabled" : "agentRuntime.opInstanceDisabled"), () => runtimeInstanceClient.setEnabled(instanceId, enabled)),
-    deleteInstance: (instanceId: string) => channel.run(t("agentRuntime.opInstanceDeleted"), () => runtimeInstanceClient.delete(instanceId)),
-    validateInstance: (instanceId: string) => channel.run(t("agentRuntime.opAuthChecked"), () => runtimeInstanceClient.probe(instanceId)),
-    authInstance: (instanceId: string, action: "login" | "logout") => channel.run(t(action === "logout" ? "agentRuntime.opSignOut" : "agentRuntime.opSignIn"), () => runtimeInstanceClient.auth(repoId, instanceId, action), false),
+  return { machine, agents, instances, authProbeErrors, overview, liveByInstance, busy: channel.busy,
+    feedback: channel.feedback, error: channel.error, settlement: channel.settlement, clearFeedback:
+    channel.clearFeedback,
+    createInstance: async (input: RuntimeInstanceCreateInput) => { const created = await
+      channel.run(t("agentRuntime.opInstanceCreated"), () => runtimeInstanceClient.create(input),
+      false); if (!created) return null; if (input.authMode === "subscription") { const probed = await
+      channel.run(t("agentRuntime.opAuthChecked"), () => runtimeInstanceClient.probe(input.instanceId),
+      false); if (subscriptionCreationNeedsLogin(input, probed)) await
+      channel.run(t("agentRuntime.opSignIn"), () => runtimeInstanceClient.auth(repoId, input.instanceId,
+      "login"), false); } await client.invalidateQueries({ queryKey: ["runtime-instances", "machine"]
+      }); await client.invalidateQueries({ queryKey: ["runtime-control", repoId] }); return created; },
+    updateInstance: (input: RuntimeInstanceUpdateInput) =>
+      channel.run(t("agentRuntime.opInstanceUpdated"), () => runtimeInstanceClient.update(input)),
+    setInstanceEnabled: (instanceId: string, enabled: boolean) => channel.run(t(enabled ?
+      "agentRuntime.opInstanceEnabled" : "agentRuntime.opInstanceDisabled"), () =>
+      runtimeInstanceClient.setEnabled(instanceId, enabled)),
+    deleteInstance: (instanceId: string) => channel.run(t("agentRuntime.opInstanceDeleted"), () =>
+      runtimeInstanceClient.delete(instanceId)),
+    validateInstance: (instanceId: string) => channel.run(t("agentRuntime.opAuthChecked"), () =>
+      runtimeInstanceClient.probe(instanceId)),
+    authInstance: (instanceId: string, action: "login" | "logout") => channel.run(t(action === "logout"
+      ? "agentRuntime.opSignOut" : "agentRuntime.opSignIn"), () => runtimeInstanceClient.auth(repoId,
+      instanceId, action), false),
     selfTest };
 }
 export function runtimeSelfTestSpawnInput(instanceId: string, model: string, idempotencyKey: string) { return { runtimeInstanceId: instanceId, model, permissionMode: "read-only" as const, cwd: { scope: "repo-root" as const }, prompt: "Reply with exactly: runtime connectivity ok", taskId: null, idempotencyKey }; }

--- a/packages/gui/src/renderer/navigation/navConfig.tsx
+++ b/packages/gui/src/renderer/navigation/navConfig.tsx
@@ -1,4 +1,5 @@
-import { Kanban, SquaresFour, Graph, Scales, Stack, PlugsConnected, GearSix, GitBranch, Users, Waveform } from "@phosphor-icons/react";
+import { Kanban, SquaresFour, Graph, Scales, Stack, PlugsConnected, GearSix, GitBranch, Users, Waveform
+  } from "@phosphor-icons/react";
 import { t, type MessageKey } from "../i18n/index.tsx";
 import type { ViewId } from "./viewHistory.ts";
 

--- a/packages/gui/src/renderer/views/AgentSquadView.tsx
+++ b/packages/gui/src/renderer/views/AgentSquadView.tsx
@@ -11,50 +11,69 @@ import { Badge, Btn, Empty, Hint } from "../components/runtime/parts.tsx";
 import { IdentityRail } from "../components/runtime/RuntimeRail.tsx";
 import { IdentityInspector } from "../components/runtime/RuntimeInspector.tsx";
 import { SquadCard, squadDeclarationFrom, squadDraftFrom } from "../components/runtime/SquadCard.tsx";
-import { runtimeSelectionFromRef, runtimeSelectionRef, useAgentDetail, useAgentSquadWorkspace, useSquadDetail, type RuntimeSelection } from "../components/runtime/useRuntimeWorkspace.ts";
+import { runtimeSelectionFromRef, runtimeSelectionRef, useAgentDetail, useAgentSquadWorkspace,
+  useSquadDetail, type RuntimeSelection } from "../components/runtime/useRuntimeWorkspace.ts";
 
-type Dialog = { readonly kind: "new-entity"; readonly entity: "agent" | "squad" } | { readonly kind: "dispatch"; readonly subject: DispatchSubject; readonly prompts: readonly string[]; readonly mission: string };
+type Dialog = { readonly kind: "new-entity"; readonly entity: "agent" | "squad" } | { readonly kind:
+  "dispatch"; readonly subject: DispatchSubject; readonly prompts: readonly string[]; readonly mission: string };
 
 // Agent 入口 · 含 Squad(W6 IA 拆分):身份层(Agent 声明)与组织层(Squad)共享一页,
 // 依据方案 P2——Squad 没有独立于 Agent 的生命周期,所以它是本页的一个面而非第四个
 // 入口。派工(agent dispatch / squad launch)从这页发起;settle 后跳会话入口看它跑
 // (session/<id>,可寻址,回撤原路返回)。跨页出口:兼容 Runtime 实例 → Provider,
 // 相关会话 → 会话;页内 Agent↔Squad 互跳同样走可寻址选择,推导航栈。
-export function AgentSquadView({ repoId, tasks, focusedEntityRef, onSelectEntity }: { readonly repoId: string; readonly tasks: readonly DispatchDialogTaskOption[]; readonly focusedEntityRef: string | null; readonly onSelectEntity: (ref: string) => void }) {
-  const workspace = useAgentSquadWorkspace(repoId, tasks), catalog = useCatalogSnapshot(repoId), skills = useQuery({ queryKey: ["agent-skills", repoId], queryFn: () => agentEntityClient.listAgentSkills(repoId), staleTime: 10_000 });
+export function AgentSquadView({ repoId, tasks, focusedEntityRef, onSelectEntity }: { readonly repoId:
+  string; readonly tasks: readonly DispatchDialogTaskOption[]; readonly focusedEntityRef: string | null;
+  readonly onSelectEntity: (ref: string) => void }) {
+  const workspace = useAgentSquadWorkspace(repoId, tasks), catalog = useCatalogSnapshot(repoId), skills
+    = useQuery({ queryKey: ["agent-skills", repoId], queryFn: () =>
+    agentEntityClient.listAgentSkills(repoId), staleTime: 10_000 });
   const [dialog, setDialog] = useState<Dialog | null>(null), [inspector, setInspector] = useState(true);
   const agents = workspace.agents.data ?? [], squads = workspace.squads.data ?? [];
   const refSelection = runtimeSelectionFromRef(focusedEntityRef);
   // 深链指向的实体可能已被删除(或仍在读取):存在才采用,否则回落首项 Agent、再
   // 回落首项 Squad——派生选择,不写回导航栈。
-  const current: RuntimeSelection | null = refSelection?.type === "agent" && agents.some((agent) => agent.id === refSelection.id) ? refSelection
+  const current: RuntimeSelection | null = refSelection?.type === "agent" && agents.some((agent) =>
+    agent.id === refSelection.id) ? refSelection
     : refSelection?.type === "squad" && squads.some((squad) => squad.id === refSelection.id) ? refSelection
       : agents[0] ? { type: "agent", id: agents[0].id } : squads[0] ? { type: "squad", id: squads[0].id } : null;
-  const agentDetail = useAgentDetail(repoId, current?.type === "agent" ? current.id : null), squadDetail = useSquadDetail(repoId, current?.type === "squad" ? current.id : null);
+  const agentDetail = useAgentDetail(repoId, current?.type === "agent" ? current.id : null), squadDetail
+    = useSquadDetail(repoId, current?.type === "squad" ? current.id : null);
 
   const openAgentDispatch = async (agentId: string, mission: string) => {
     const row = agents.find((agent) => agent.id === agentId); if (!row) return;
-    setDialog({ kind: "dispatch", subject: { kind: "agent", agent: { agentId: row.id, agentName: row.name, runtimeType: row.runtimeType } }, prompts: [], mission });
+    setDialog({ kind: "dispatch", subject: { kind: "agent", agent: { agentId: row.id, agentName:
+      row.name, runtimeType: row.runtimeType } }, prompts: [], mission });
     const detail = await agentEntityClient.showAgent(repoId, agentId);
-    setDialog((value) => value?.kind === "dispatch" && value.subject.kind === "agent" && value.subject.agent.agentId === agentId ? { ...value, prompts: detail.prompts } : value);
+    setDialog((value) => value?.kind === "dispatch" && value.subject.kind === "agent" &&
+      value.subject.agent.agentId === agentId ? { ...value, prompts: detail.prompts } : value);
   };
   const openSquadDispatch = async (squadId: string) => {
-    const detail = await agentEntityClient.showSquad(repoId, squadId), byId = new Map(agents.map((agent) => [agent.id, agent]));
-    const ref = (id: string) => ({ agentId: id, agentName: byId.get(id)?.name ?? id, runtimeType: byId.get(id)?.runtimeType ?? "" });
-    setDialog({ kind: "dispatch", subject: { kind: "squad", squadId, squadName: detail.name, leader: ref(detail.leader), workers: detail.workers.map(ref) }, prompts: [], mission: "" });
+    const detail = await agentEntityClient.showSquad(repoId, squadId), byId = new Map(agents.map((agent) =>
+      [agent.id, agent]));
+    const ref = (id: string) => ({ agentId: id, agentName: byId.get(id)?.name ?? id, runtimeType:
+      byId.get(id)?.runtimeType ?? "" });
+    setDialog({ kind: "dispatch", subject: { kind: "squad", squadId, squadName: detail.name, leader:
+      ref(detail.leader), workers: detail.workers.map(ref) }, prompts: [], mission: "" });
   };
   const createEntity = async (request: NewEntityRequest) => {
     if (request.kind === "agent") {
-      const draft = request.templateId ? agentDraftFrom(await agentEntityClient.showAgent(repoId, request.templateId)) : { name: request.name, role: "worker" as const, runtimeType: "any", model: "", preset: "", skills: [], instructions: t("agentRuntime.blankInstructions"), prompts: [] };
+      const draft = request.templateId ? agentDraftFrom(await agentEntityClient.showAgent(repoId,
+        request.templateId)) : { name: request.name, role: "worker" as const, runtimeType: "any", model:
+        "", preset: "", skills: [], instructions: t("agentRuntime.blankInstructions"), prompts: [] };
       await workspace.saveAgent(agentDeclarationFrom(request.id, { ...draft, name: request.name }));
     } else {
-      const draft = request.templateId ? squadDraftFrom(await agentEntityClient.showSquad(repoId, request.templateId)) : { name: request.name, leader: agents.find((agent) => agent.role === "commander")?.id ?? agents[0]?.id ?? "", workers: [], roster: t("agentRuntime.blankRoster") };
+      const draft = request.templateId ? squadDraftFrom(await agentEntityClient.showSquad(repoId,
+        request.templateId)) : { name: request.name, leader: agents.find((agent) => agent.role ===
+        "commander")?.id ?? agents[0]?.id ?? "", workers: [], roster: t("agentRuntime.blankRoster") };
       await workspace.saveSquad(squadDeclarationFrom(request.id, { ...draft, name: request.name }));
     }
     onSelectEntity(`${request.kind}/${request.id}`);
     setDialog(null);
   };
-  const dispatch = async (request: DispatchRequest) => { const settled = await workspace.dispatch(request); setDialog(null); if (settled?.runtimeSessionId) onSelectEntity(`session/${settled.runtimeSessionId}`); };
+  const dispatch = async (request: DispatchRequest) => { const settled = await
+    workspace.dispatch(request); setDialog(null); if (settled?.runtimeSessionId)
+    onSelectEntity(`session/${settled.runtimeSessionId}`); };
 
   // The page reads only its own sources: one failing read degrades its region (rail, card,
   // inspector) and nothing else — the machine instance catalogue going down must not take
@@ -63,31 +82,60 @@ export function AgentSquadView({ repoId, tasks, focusedEntityRef, onSelectEntity
   const catalogsPending = workspace.agents.isPending && workspace.squads.isPending;
   return <section data-testid="agent-squad-view" className="flex min-h-0 flex-1 flex-col overflow-hidden">
     <header className="flex h-[42px] shrink-0 items-center gap-3 border-b border-border bg-surface-raised px-3.5">
-      <b className="text-[13px] tracking-[0.02em]">{t("agentRuntime.agentsTitle")}</b><span className="truncate font-mono text-[10.5px] text-text-faint">{t("agentRuntime.agentsSubtitle")}</span>
+      <b className="text-[13px] tracking-[0.02em]">{t("agentRuntime.agentsTitle")}</b><span
+        className="truncate font-mono text-[10.5px] text-text-faint">{t("agentRuntime.agentsSubtitle")}</span>
       <span className="flex-1" />
-      <Badge>{t("agentRuntime.agentCount", { count: agents.length })}</Badge><Badge>{t("agentRuntime.squadCount", { count: squads.length })}</Badge>
-      <Btn size="sm" variant="ghost" onClick={() => setInspector(!inspector)} tip={t("agentRuntime.toggleInspector")}>▐</Btn>
+      <Badge>{t("agentRuntime.agentCount", { count: agents.length
+        })}</Badge><Badge>{t("agentRuntime.squadCount", { count: squads.length })}</Badge>
+      <Btn size="sm" variant="ghost" onClick={() => setInspector(!inspector)}
+        tip={t("agentRuntime.toggleInspector")}>▐</Btn>
     </header>
-    {readError !== undefined && <p role="alert" data-testid="runtime-read-error" className="shrink-0 border-b border-border bg-status-blocked/10 px-3.5 py-1.5 font-mono text-[11px] text-status-blocked">{t("agentRuntime.readFailed", { error: readError instanceof Error ? readError.message : String(readError) })}</p>}
-    {(workspace.error ?? workspace.feedback) && <p role="status" onClick={workspace.clearFeedback} className={`shrink-0 border-b border-border px-3.5 py-1.5 font-mono text-[11px] ${workspace.error ? "bg-status-blocked/10 text-status-blocked" : "text-text-muted"}`}>{workspace.error ?? workspace.feedback}</p>}
+    {readError !== undefined && <p role="alert" data-testid="runtime-read-error"
+      className="shrink-0 border-b border-border bg-status-blocked/10 px-3.5 py-1.5 font-mono text-[11px]
+        text-status-blocked">{t("agentRuntime.readFailed", { error: readError instanceof Error ?
+          readError.message : String(readError) })}</p>}
+    {(workspace.error ?? workspace.feedback) && <p role="status" onClick={workspace.clearFeedback}
+      className={`shrink-0 border-b border-border px-3.5 py-1.5 font-mono text-[11px] ${workspace.error ?
+        "bg-status-blocked/10 text-status-blocked" : "text-text-muted"}`}>{workspace.error ?? workspace.feedback}</p>}
     <div className="flex min-h-0 flex-1">
-      <IdentityRail agents={agents} squads={squads} selection={current} onSelect={(selection) => onSelectEntity(runtimeSelectionRef(selection))} onNew={(segment) => setDialog({ kind: "new-entity", entity: segment === "agents" ? "agent" : "squad" })} />
+      <IdentityRail agents={agents} squads={squads} selection={current} onSelect={(selection) =>
+        onSelectEntity(runtimeSelectionRef(selection))} onNew={(segment) => setDialog({ kind:
+        "new-entity", entity: segment === "agents" ? "agent" : "squad" })} />
       <main className="min-w-0 flex-1 overflow-y-auto px-4 pt-3.5 pb-6">
         {current === null ? <Empty>{t(catalogsPending ? "agentRuntime.loading" : "agentRuntime.emptyAgents")}</Empty>
           : current.type === "agent" ? (agentDetail.data
-            ? <AgentCard detail={agentDetail.data} row={agents.find((agent) => agent.id === current.id) ?? null} squads={squads} instances={workspace.instances} availableSkills={skills.data ?? []} presets={catalog.data?.presets ?? []} busy={workspace.busy}
-                onSave={(declaration) => void workspace.saveAgent(declaration)} onDispatch={(mission) => void openAgentDispatch(current.id, mission)}
-                onSelectSquad={(squadId) => onSelectEntity(`squad/${squadId}`)} onSelectRuntime={(instanceId) => onSelectEntity(`provider/${instanceId}`)} />
+            ? <AgentCard detail={agentDetail.data} row={agents.find((agent) => agent.id === current.id)
+              ?? null} squads={squads} instances={workspace.instances} availableSkills={skills.data ??
+              []} presets={catalog.data?.presets ?? []} busy={workspace.busy}
+                onSave={(declaration) => void workspace.saveAgent(declaration)} onDispatch={(mission) =>
+                  void openAgentDispatch(current.id, mission)}
+                onSelectSquad={(squadId) => onSelectEntity(`squad/${squadId}`)}
+                  onSelectRuntime={(instanceId) => onSelectEntity(`provider/${instanceId}`)} />
             : <Empty>{t("agentRuntime.loading")}</Empty>)
           : squadDetail.data
-            ? <SquadCard detail={squadDetail.data} row={squads.find((squad) => squad.id === current.id) ?? null} agents={agents} busy={workspace.busy}
-                onSave={(declaration) => void workspace.saveSquad(declaration)} onLaunch={() => void openSquadDispatch(current.id)} onSelectAgent={(agentId) => onSelectEntity(`agent/${agentId}`)} />
+            ? <SquadCard detail={squadDetail.data} row={squads.find((squad) => squad.id === current.id)
+              ?? null} agents={agents} busy={workspace.busy}
+                onSave={(declaration) => void workspace.saveSquad(declaration)} onLaunch={() => void
+                  openSquadDispatch(current.id)} onSelectAgent={(agentId) => onSelectEntity(`agent/${agentId}`)} />
             : <Empty>{t("agentRuntime.loading")}</Empty>}
       </main>
-      {inspector && current !== null && <IdentityInspector selection={current} agents={agents} squads={squads} rows={workspace.dockRows} onSelect={(selection) => onSelectEntity(runtimeSelectionRef(selection))} onOpenSession={(runtimeSessionId) => onSelectEntity(`session/${runtimeSessionId}`)} />}
+      {inspector && current !== null && <IdentityInspector selection={current} agents={agents}
+        squads={squads} rows={workspace.dockRows} onSelect={(selection) =>
+        onSelectEntity(runtimeSelectionRef(selection))} onOpenSession={(runtimeSessionId) =>
+        onSelectEntity(`session/${runtimeSessionId}`)} />}
     </div>
-    {dialog?.kind === "new-entity" && <NewEntityDialog kind={dialog.entity} agents={agents} squads={squads} busy={workspace.busy} taken={dialog.entity === "agent" ? agents.map((agent) => agent.id) : squads.map((squad) => squad.id)} onCancel={() => setDialog(null)} onCreate={(request) => void createEntity(request)} />}
-    {dialog?.kind === "dispatch" && <DispatchDialog subject={dialog.subject} instances={workspace.overview.data?.instances ?? []} tasks={tasks} prompts={dialog.prompts} initialMission={dialog.mission} busy={workspace.busy} notice={workspace.settlement?.state === "pending" ? workspace.settlement.hint : null} onCancel={() => setDialog(null)} onSubmit={(request) => void dispatch(request)} />}
-    {workspace.settlement && <p role="status" className="shrink-0 border-t border-border px-3.5 py-1 font-mono text-[10.5px] text-text-faint"><Hint>{workspace.settlement.state} · {workspace.settlement.opId} · {workspace.settlement.hint}</Hint></p>}
+    {dialog?.kind === "new-entity" && <NewEntityDialog kind={dialog.entity} agents={agents}
+      squads={squads} busy={workspace.busy} taken={dialog.entity === "agent" ? agents.map((agent) =>
+      agent.id) : squads.map((squad) => squad.id)} onCancel={() => setDialog(null)} onCreate={(request) =>
+      void createEntity(request)} />}
+    {dialog?.kind === "dispatch" && <DispatchDialog subject={dialog.subject}
+      instances={workspace.overview.data?.instances ?? []} tasks={tasks} prompts={dialog.prompts}
+      initialMission={dialog.mission} busy={workspace.busy} notice={workspace.settlement?.state ===
+      "pending" ? workspace.settlement.hint : null} onCancel={() => setDialog(null)} onSubmit={(request) =>
+      void dispatch(request)} />}
+    {workspace.settlement && <p role="status"
+      className="shrink-0 border-t border-border px-3.5 py-1 font-mono text-[10.5px]
+        text-text-faint"><Hint>{workspace.settlement.state} · {workspace.settlement.opId} ·
+          {workspace.settlement.hint}</Hint></p>}
   </section>;
 }

--- a/packages/gui/src/renderer/views/ProvidersView.tsx
+++ b/packages/gui/src/renderer/views/ProvidersView.tsx
@@ -11,7 +11,8 @@ import { runtimeSelectionFromRef, useProviderWorkspace } from "../components/run
 // 实例卡片(编辑/auth/self-test/权限/删除)与右栏 health。live 计数取 overview 的
 // session liveness(daemon 自己的在跑投影),这一页不读 dispatch 台账。跨页出口:
 // 兼容 Agent chips → Agent 入口,相关会话 → 会话入口;均为可寻址路由。
-export function ProvidersView({ repoId, focusedEntityRef, onSelectEntity }: { readonly repoId: string; readonly focusedEntityRef: string | null; readonly onSelectEntity: (ref: string) => void }) {
+export function ProvidersView({ repoId, focusedEntityRef, onSelectEntity }: { readonly repoId: string;
+  readonly focusedEntityRef: string | null; readonly onSelectEntity: (ref: string) => void }) {
   const workspace = useProviderWorkspace(repoId);
   const [dialog, setDialog] = useState(false), [inspector, setInspector] = useState(true);
   const installations = workspace.machine.data?.installations ?? [];
@@ -20,30 +21,64 @@ export function ProvidersView({ repoId, focusedEntityRef, onSelectEntity }: { re
   const refId = refSelection?.type === "runtime" ? refSelection.id : null;
   // 深链指向的实例可能已被删除(或仍在读取):存在才采用,否则回落首项——派生选择,
   // 不写回导航栈。
-  const selectedId = refId !== null && instances.some((candidate) => candidate.instanceId === refId) ? refId : instances[0]?.instanceId ?? null;
-  const instance = selectedId === null ? null : instances.find((candidate) => candidate.instanceId === selectedId) ?? null;
+  const selectedId = refId !== null && instances.some((candidate) => candidate.instanceId === refId) ?
+    refId : instances[0]?.instanceId ?? null;
+  const instance = selectedId === null ? null : instances.find((candidate) => candidate.instanceId ===
+    selectedId) ?? null;
   const liveSessions = selectedId === null ? 0 : workspace.liveByInstance.get(selectedId) ?? 0;
-  const carrierSessions = workspace.overview.data?.sessions.filter((session) => session.instanceId === selectedId) ?? [];
+  const carrierSessions = workspace.overview.data?.sessions.filter((session) => session.instanceId ===
+    selectedId) ?? [];
   return <section data-testid="providers-view" className="flex min-h-0 flex-1 flex-col overflow-hidden">
     <header className="flex h-[42px] shrink-0 items-center gap-3 border-b border-border bg-surface-raised px-3.5">
-      <b className="text-[13px] tracking-[0.02em]">{t("agentRuntime.providersTitle")}</b><span className="truncate font-mono text-[10.5px] text-text-faint">{t("agentRuntime.providersSubtitle")}</span>
+      <b className="text-[13px] tracking-[0.02em]">{t("agentRuntime.providersTitle")}</b><span
+        className="truncate font-mono text-[10.5px] text-text-faint">{t("agentRuntime.providersSubtitle")}</span>
       <span className="flex-1" />
-      <span className="flex items-center gap-2.5 whitespace-nowrap text-[11px] text-text-muted"><span className="flex items-center gap-1"><CapDot size={10} state="full" tip={t("agentRuntime.legendReadyTip")} />{t("agentRuntime.legendReady")}</span><span className="flex items-center gap-1"><CapDot size={10} state="part" tip={t("agentRuntime.legendPartialTip")} />{t("agentRuntime.legendPartial")}</span><span className="flex items-center gap-1"><CapDot size={10} state="none" tip={t("agentRuntime.legendBlockedTip")} />{t("agentRuntime.legendBlocked")}</span></span>
-      <Btn size="sm" variant="ghost" onClick={() => setInspector(!inspector)} tip={t("agentRuntime.toggleInspector")}>▐</Btn>
+      <span className="flex items-center gap-2.5 whitespace-nowrap text-[11px] text-text-muted"><span
+        className="flex items-center gap-1"><CapDot size={10} state="full"
+        tip={t("agentRuntime.legendReadyTip")} />{t("agentRuntime.legendReady")}</span><span
+        className="flex items-center gap-1"><CapDot size={10} state="part"
+        tip={t("agentRuntime.legendPartialTip")} />{t("agentRuntime.legendPartial")}</span><span
+        className="flex items-center gap-1"><CapDot size={10} state="none"
+        tip={t("agentRuntime.legendBlockedTip")} />{t("agentRuntime.legendBlocked")}</span></span>
+      <Btn size="sm" variant="ghost" onClick={() => setInspector(!inspector)}
+        tip={t("agentRuntime.toggleInspector")}>▐</Btn>
     </header>
-    {workspace.machine.error && <p role="alert" data-testid="runtime-read-error" className="shrink-0 border-b border-border bg-status-blocked/10 px-3.5 py-1.5 font-mono text-[11px] text-status-blocked">{t("agentRuntime.readFailed", { error: workspace.machine.error instanceof Error ? workspace.machine.error.message : String(workspace.machine.error) })}</p>}
-    {(workspace.error ?? workspace.feedback) && <p role="status" onClick={workspace.clearFeedback} className={`shrink-0 border-b border-border px-3.5 py-1.5 font-mono text-[11px] ${workspace.error ? "bg-status-blocked/10 text-status-blocked" : "text-text-muted"}`}>{workspace.error ?? workspace.feedback}</p>}
+    {workspace.machine.error && <p role="alert" data-testid="runtime-read-error"
+      className="shrink-0 border-b border-border bg-status-blocked/10 px-3.5 py-1.5 font-mono text-[11px]
+        text-status-blocked">{t("agentRuntime.readFailed", { error: workspace.machine.error instanceof Error ?
+          workspace.machine.error.message : String(workspace.machine.error) })}</p>}
+    {(workspace.error ?? workspace.feedback) && <p role="status" onClick={workspace.clearFeedback}
+      className={`shrink-0 border-b border-border px-3.5 py-1.5 font-mono text-[11px] ${workspace.error ?
+        "bg-status-blocked/10 text-status-blocked" : "text-text-muted"}`}>{workspace.error ?? workspace.feedback}</p>}
     <div className="flex min-h-0 flex-1">
-      <ProviderRail instances={instances} authProbeErrors={workspace.authProbeErrors} selectedId={selectedId} liveByInstance={workspace.liveByInstance} onSelect={(instanceId) => onSelectEntity(`provider/${instanceId}`)} onNew={() => setDialog(true)} />
+      <ProviderRail instances={instances} authProbeErrors={workspace.authProbeErrors}
+        selectedId={selectedId} liveByInstance={workspace.liveByInstance} onSelect={(instanceId) =>
+        onSelectEntity(`provider/${instanceId}`)} onNew={() => setDialog(true)} />
       <main className="min-w-0 flex-1 overflow-y-auto px-4 pt-3.5 pb-6">
-        {instance === null ? <Empty>{t(workspace.machine.isPending ? "agentRuntime.loading" : "agentRuntime.emptyProviders")}</Empty>
-          : <RuntimeCard instance={instance} installations={installations} authProbeError={workspace.authProbeErrors.get(instance.instanceId)} agents={workspace.agents.data ?? []} liveSessions={liveSessions} busy={workspace.busy}
-              onSelectAgent={(agentId) => onSelectEntity(`agent/${agentId}`)} onAuth={(action) => void workspace.authInstance(instance.instanceId, action)} onValidate={() => void workspace.validateInstance(instance.instanceId)}
-              onSetEnabled={(enabled) => void workspace.setInstanceEnabled(instance.instanceId, enabled)} onUpdate={(input) => void workspace.updateInstance(input)} onDelete={() => { void workspace.deleteInstance(instance.instanceId); }} onSelfTest={(model) => workspace.selfTest(instance.instanceId, model)} />}
+        {instance === null ? <Empty>{t(workspace.machine.isPending ? "agentRuntime.loading" :
+          "agentRuntime.emptyProviders")}</Empty>
+          : <RuntimeCard instance={instance} installations={installations}
+            authProbeError={workspace.authProbeErrors.get(instance.instanceId)}
+            agents={workspace.agents.data ?? []} liveSessions={liveSessions} busy={workspace.busy}
+              onSelectAgent={(agentId) => onSelectEntity(`agent/${agentId}`)} onAuth={(action) => void
+                workspace.authInstance(instance.instanceId, action)} onValidate={() => void
+                workspace.validateInstance(instance.instanceId)}
+              onSetEnabled={(enabled) => void workspace.setInstanceEnabled(instance.instanceId,
+                enabled)} onUpdate={(input) => void workspace.updateInstance(input)} onDelete={() => {
+                void workspace.deleteInstance(instance.instanceId); }} onSelfTest={(model) =>
+                workspace.selfTest(instance.instanceId, model)} />}
       </main>
-      {inspector && <ProviderInspector instance={instance} probeError={selectedId === null ? null : workspace.authProbeErrors.get(selectedId) ?? null} sessions={carrierSessions} onOpenSession={(runtimeSessionId) => onSelectEntity(`session/${runtimeSessionId}`)} />}
+      {inspector && <ProviderInspector instance={instance} probeError={selectedId === null ? null :
+        workspace.authProbeErrors.get(selectedId) ?? null} sessions={carrierSessions}
+        onOpenSession={(runtimeSessionId) => onSelectEntity(`session/${runtimeSessionId}`)} />}
     </div>
-    {dialog && <NewRuntimeDialog installations={installations} existingInstanceIds={instances.map((row) => row.instanceId)} busy={workspace.busy} onCancel={() => setDialog(false)} onCreate={(input) => { void workspace.createInstance(input).then((created) => { if (created) { setDialog(false); onSelectEntity(`provider/${input.instanceId}`); } }); }} />}
-    {workspace.settlement && <p role="status" className="shrink-0 border-t border-border px-3.5 py-1 font-mono text-[10.5px] text-text-faint"><Hint>{workspace.settlement.state} · {workspace.settlement.opId} · {workspace.settlement.hint}</Hint></p>}
+    {dialog && <NewRuntimeDialog installations={installations} existingInstanceIds={instances.map((row) =>
+      row.instanceId)} busy={workspace.busy} onCancel={() => setDialog(false)} onCreate={(input) => {
+      void workspace.createInstance(input).then((created) => { if (created) { setDialog(false);
+      onSelectEntity(`provider/${input.instanceId}`); } }); }} />}
+    {workspace.settlement && <p role="status"
+      className="shrink-0 border-t border-border px-3.5 py-1 font-mono text-[10.5px]
+        text-text-faint"><Hint>{workspace.settlement.state} · {workspace.settlement.opId} ·
+          {workspace.settlement.hint}</Hint></p>}
   </section>;
 }

--- a/packages/gui/src/renderer/views/SessionsView.tsx
+++ b/packages/gui/src/renderer/views/SessionsView.tsx
@@ -12,33 +12,46 @@ import { runtimeSelectionFromRef, useSessionsWorkspace } from "../components/run
 // 与 task 出口。选择是可寻址的(session/<id>,经 entityRoutes 推栈,导航回撤原路返回),
 // 进入页面未指定时落在最新一条(panorama 已把 running 排前)。数据只有 overview 与
 // 收窄后的 dispatch 全景(W6:runtimePanoramaTasks 不退回全量查询)。
-export function SessionsView({ repoId, tasks, focusedEntityRef, onSelectEntity, onOpenTask }: { readonly repoId: string; readonly tasks: readonly RuntimePanoramaTask[]; readonly focusedEntityRef: string | null; readonly onSelectEntity: (ref: string) => void; readonly onOpenTask: (taskId: string) => void }) {
+export function SessionsView({ repoId, tasks, focusedEntityRef, onSelectEntity, onOpenTask }: {
+  readonly repoId: string; readonly tasks: readonly RuntimePanoramaTask[]; readonly focusedEntityRef: string |
+  null; readonly onSelectEntity: (ref: string) => void; readonly onOpenTask: (taskId: string) => void }) {
   const workspace = useSessionsWorkspace(repoId, tasks);
   const [inspector, setInspector] = useState(true);
   const rows = workspace.dockRows;
   const refSelection = runtimeSelectionFromRef(focusedEntityRef);
   // 深链指向的会话可能已不在投影里:存在才采用,否则回落最新一条(panorama 已把
   // running 排前)——派生选择,不写回导航栈。
-  const selectedId = refSelection?.type === "session" && rows.some((row) => row.runtimeSessionId === refSelection.id) ? refSelection.id : rows[0]?.runtimeSessionId ?? null;
+  const selectedId = refSelection?.type === "session" && rows.some((row) => row.runtimeSessionId ===
+    refSelection.id) ? refSelection.id : rows[0]?.runtimeSessionId ?? null;
   const row = selectedId === null ? null : rows.find((candidate) => candidate.runtimeSessionId === selectedId) ?? null;
   const live = runtimeDockLiveCount(rows);
   return <section data-testid="sessions-view" className="flex min-h-0 flex-1 flex-col overflow-hidden">
     <header className="flex h-[42px] shrink-0 items-center gap-3 border-b border-border bg-surface-raised px-3.5">
-      <b className="text-[13px] tracking-[0.02em]">{t("agentRuntime.sessionsTitle")}</b><span className="truncate font-mono text-[10.5px] text-text-faint">{t("agentRuntime.sessionsSubtitle")}</span>
+      <b className="text-[13px] tracking-[0.02em]">{t("agentRuntime.sessionsTitle")}</b><span
+        className="truncate font-mono text-[10.5px] text-text-faint">{t("agentRuntime.sessionsSubtitle")}</span>
       <span className="flex-1" />
       <Badge status={live > 0 ? "active" : "planned"}>{t("agentRuntime.liveSessions", { count: live })}</Badge>
-      <Btn size="sm" variant="ghost" onClick={() => setInspector(!inspector)} tip={t("agentRuntime.toggleInspector")}>▐</Btn>
+      <Btn size="sm" variant="ghost" onClick={() => setInspector(!inspector)}
+        tip={t("agentRuntime.toggleInspector")}>▐</Btn>
     </header>
-    {workspace.overview.error && <p role="alert" data-testid="runtime-read-error" className="shrink-0 border-b border-border bg-status-blocked/10 px-3.5 py-1.5 font-mono text-[11px] text-status-blocked">{t("agentRuntime.readFailed", { error: workspace.overview.error instanceof Error ? workspace.overview.error.message : String(workspace.overview.error) })}</p>}
-    {(workspace.error ?? workspace.feedback) && <p role="status" onClick={workspace.clearFeedback} className={`shrink-0 border-b border-border px-3.5 py-1.5 font-mono text-[11px] ${workspace.error ? "bg-status-blocked/10 text-status-blocked" : "text-text-muted"}`}>{workspace.error ?? workspace.feedback}</p>}
+    {workspace.overview.error && <p role="alert" data-testid="runtime-read-error"
+      className="shrink-0 border-b border-border bg-status-blocked/10 px-3.5 py-1.5 font-mono text-[11px]
+        text-status-blocked">{t("agentRuntime.readFailed", { error: workspace.overview.error instanceof Error ?
+          workspace.overview.error.message : String(workspace.overview.error) })}</p>}
+    {(workspace.error ?? workspace.feedback) && <p role="status" onClick={workspace.clearFeedback}
+      className={`shrink-0 border-b border-border px-3.5 py-1.5 font-mono text-[11px] ${workspace.error ?
+        "bg-status-blocked/10 text-status-blocked" : "text-text-muted"}`}>{workspace.error ?? workspace.feedback}</p>}
     <div className="flex min-h-0 flex-1">
-      <SessionRail sessions={rows} selectedId={selectedId} onSelect={(runtimeSessionId) => onSelectEntity(`session/${runtimeSessionId}`)} />
+      <SessionRail sessions={rows} selectedId={selectedId} onSelect={(runtimeSessionId) =>
+        onSelectEntity(`session/${runtimeSessionId}`)} />
       <main className="min-w-0 flex-1 overflow-y-auto px-4 pt-3.5 pb-6">
         {selectedId === null
           ? <Empty>{t(workspace.overview.isPending ? "agentRuntime.loading" : "agentRuntime.noSessions")}</Empty>
-          : <SessionsPanel repoId={repoId} runtimeSessionId={selectedId} row={row} busy={workspace.busy} onCancel={(runtimeSessionId) => void workspace.cancelSession(runtimeSessionId)} onOpenTask={onOpenTask} />}
+          : <SessionsPanel repoId={repoId} runtimeSessionId={selectedId} row={row} busy={workspace.busy}
+            onCancel={(runtimeSessionId) => void workspace.cancelSession(runtimeSessionId)} onOpenTask={onOpenTask} />}
       </main>
-      {inspector && <SessionInspector row={row} rows={rows} onSelectSession={(runtimeSessionId) => onSelectEntity(`session/${runtimeSessionId}`)} onOpenTask={onOpenTask} />}
+      {inspector && <SessionInspector row={row} rows={rows} onSelectSession={(runtimeSessionId) =>
+        onSelectEntity(`session/${runtimeSessionId}`)} onOpenTask={onOpenTask} />}
     </div>
   </section>;
 }

--- a/packages/gui/src/renderer/views/SwimlaneBoard.tsx
+++ b/packages/gui/src/renderer/views/SwimlaneBoard.tsx
@@ -388,7 +388,8 @@ export function SwimlaneBoard({
               onClick={() => setVisibleLaneCount((count) => Math.min(count + LANE_BATCH_SIZE, lanes.length))}
               className="mt-3 w-full rounded-lg border border-dashed border-border px-3 py-2 font-mono text-[12px] text-text-muted hover:border-border-strong hover:text-text"
             >
-              {t("views.swimlaneBoard.showMore", { count: Math.min(LANE_BATCH_SIZE, hiddenLaneCount), remaining: hiddenLaneCount })}
+              {t("views.swimlaneBoard.showMore", { count: Math.min(LANE_BATCH_SIZE, hiddenLaneCount),
+                remaining: hiddenLaneCount })}
             </button>
           )}
           {lanes.length === 0 && (


### PR DESCRIPTION
# English

## Summary

Wraps the 129 production lines that PR #1755 added over 120 characters, so the runtime IA split's code stops carrying long single lines forward. This is a whitespace-only change: stripping all whitespace from every touched file yields a byte-identical result before and after, on all nine files.

Worth stating plainly: **main is already green.** G36 is a ratchet on newly added lines, so those 129 lines were grandfathered the moment the next commit landed, and `43e0d6d70` passes. This PR is not a repair of a broken main — it is the cleanup of lines this line should not have left behind, landed now because the LineHonesty line is waiting on it before its repo-wide pass.

## What Changed

- Nine renderer files from PR #1755 have their over-length lines broken into ordinary multi-line statements. No identifier was renamed, no function extracted, no code removed, no logic altered.
- Nothing else. The gate configuration, the thresholds, the ignore lists, and `tools/gates/**` are untouched.

## Machine-Readable Declarations

Production-Delta: +329/-122

## Task And Scope

- Harness task: task_92fed3577e8daac4fdf849da77
- Branch: codex/line-density-fix
- Public scope: `packages/gui/src/renderer/**` — the nine files PR #1755 introduced long lines into
- Private planning/evidence updated: yes
- Out of scope: the pre-existing long lines everywhere else in the repository. Those belong to the LineHonesty line's own restoration waves, not to any PR that happens to pass nearby.

## Version Impact

- Version: no version change because this is a formatting change with no behavioural surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 43e0d6d7092402f1016c2c2e64c933953e97d1dd
- Branch merge-base with `origin/main`: 43e0d6d7092402f1016c2c2e64c933953e97d1dd
- Last `git fetch origin` time: 2026-08-24, immediately before opening this PR
- Sync method: rebase
- Public diff command: `git diff origin/main...codex/line-density-fix`
- Private evidence commit/path: `harness/tasks/task_92fed3577e8daac4fdf849da77-*/`
- Reviewer evidence path: same directory
- GitHub Actions `rewrite-ci` run URL: pending; this PR is opened to obtain it
- [x] **Whitespace-identity proof** — for each of the nine files, the SHA-1 of its contents with every whitespace character removed is identical at `origin/main` and at this branch's HEAD. This is the primary correctness evidence: it makes "did this change any code?" a mechanical question rather than a review judgement.
- [x] `npm run check:local:line-density` — G36 pass
- [x] `npm run test:gui` — 42 files / 348 tests pass, the same counts as before the change
- Not run: the rest of `check:local`, because the whitespace-identity proof above already bounds what this change can affect; GitHub CI is the complete authority and runs it.

## Review Evidence

- Self-review: the reviewer did not rely on the worker's report. The whitespace-identity check was run independently over all nine changed files, the gate was run independently, and the GUI suite was run independently with the same result.
- Reviewer subagent: not used; the correctness question here is mechanical and was answered mechanically.
- Human review: pending.
- Blocking findings: none.

## Residual Risk

- Wrapping long lines can make a file read as several responsibilities stacked together where the single line hid that. That is information, not a regression, and it is what the ceiling was designed to surface. Any such observation is recorded in the task package rather than acted on here.
- This PR does not change how much of the repository is still written as long single lines. That is the LineHonesty line's scope.

## References

- Task: task_92fed3577e8daac4fdf849da77
- Evidence: task package `artifacts/`
- Review: recorded in the task package review ledger

---

# 中文

## 概要

把 PR #1755 引入的 129 行超过 120 字符的生产行拆成正常的多行语句。**这是一次纯空白改动**:九个受影响文件,把全部空白字符去掉之后,改前改后逐字节相同。

有一句要说清楚:**main 现在已经是绿的。** G36 是只咬新增行的棘轮门,那 129 行在下一个提交落地的瞬间就被祖父豁免了,`43e0d6d70` 通过。**本 PR 不是在抢修一个坏掉的 main**,而是把这条线本不该留下的东西收拾掉;现在落是因为 LineHonesty 那条线在等它,之后才好派全仓 pass。

## 改动内容

- PR #1755 涉及的九个渲染层文件,超长行拆成多行。没有重命名任何标识符、没有提取函数、没有删除代码、没有改动任何逻辑。
- 没有别的。门的配置、阈值、ignore 清单、`tools/gates/**` 一概未碰。

## 机读声明说明

生产增删已在英文块顶格声明一次,此处不重复。

## 任务与范围

- Harness 任务:task_92fed3577e8daac4fdf849da77
- 分支:codex/line-density-fix
- 公开范围:`packages/gui/src/renderer/**` 中被 PR #1755 引入超长行的九个文件
- 私有计划 / 证据是否已更新:yes
- 范围外:仓库其他地方既有的超长行。那些属于 LineHonesty 那条线自己的还原波次,不该摊派给任何路过的 PR。

## 版本影响

- 版本:不改版本,原因是本次只是排版改动,没有任何行为面
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:不适用
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no

## 验证

- `origin/main` 基准 SHA:43e0d6d7092402f1016c2c2e64c933953e97d1dd
- 当前分支与 `origin/main` 的 merge-base:43e0d6d7092402f1016c2c2e64c933953e97d1dd
- 最近一次 `git fetch origin` 时间:2026-08-24,开 PR 前即刻
- 同步方式:rebase
- 公开 diff 命令:`git diff origin/main...codex/line-density-fix`
- 私有证据 commit/path:`harness/tasks/task_92fed3577e8daac4fdf849da77-*/`
- Reviewer 证据路径:同上目录
- GitHub Actions `rewrite-ci` run URL:待补;开这个 PR 就是为了拿到它
- [x] **空白恒等证明** —— 九个文件各自把全部空白字符去掉后取 SHA-1,`origin/main` 与本分支 HEAD 完全相同。**这是本 PR 的首要正确性证据**:它把「这次改动到底动没动代码」变成一个机械可判的问题,而不是一次需要人眼评审的判断。
- [x] `npm run check:local:line-density` —— G36 pass
- [x] `npm run test:gui` —— 42 files / 348 tests 全绿,与改动前的数字相同
- 未运行:`check:local` 的其余部分。理由是上面那条空白恒等证明已经把这次改动可能影响的范围锁死了;GitHub CI 是完整权威,它会跑。

## 审查证据

- 自查:复核者没有采信 worker 的报告。空白恒等检查由复核者独立跑遍九个文件、门独立跑、GUI 测试独立跑,结果一致。
- Reviewer subagent:未使用;本次的正确性问题是机械的,已用机械方式回答。
- 人工审查:待泽宇。
- 阻塞发现:无。

## 残余风险

- 拆开长行之后,某些文件可能读起来像「几个职责摞在一起」——原来那一行把这件事藏住了。**那是信息不是回归**,也正是行数上限想暴露的东西。这类观察记在任务包里,本 PR 不据此动手。
- 本 PR 不改变仓库里还有多少地方写成长单行。那是 LineHonesty 那条线的范围。

## 关联材料

- 任务:task_92fed3577e8daac4fdf849da77
- 证据:任务包 `artifacts/`
- 审查:记录在任务包的 review 台账
