### PR TITLE
feat(gui): turn the task detail page into a document reader

### DIFF
--- a/packages/gui/src/api/html-artifact-policy.ts
+++ b/packages/gui/src/api/html-artifact-policy.ts
@@ -1,0 +1,19 @@
+export const HTML_ARTIFACT_PARTITION = "html-artifact-preview";
+export const HTML_ARTIFACT_DATA_URL_PREFIX = "data:text/html;charset=utf-8,";
+
+export function buildHtmlArtifactDataUrl(content: string): string {
+  return `${HTML_ARTIFACT_DATA_URL_PREFIX}${encodeURIComponent(content)}`;
+}
+
+export function isAllowedHtmlArtifactAttachment(params: Readonly<Record<string, string>>): boolean {
+  return params.partition === HTML_ARTIFACT_PARTITION && params.src.startsWith(HTML_ARTIFACT_DATA_URL_PREFIX);
+}
+
+export function isAllowedHtmlArtifactRequest(url: string): boolean {
+  try {
+    const protocol = new URL(url).protocol;
+    return protocol === "data:" || protocol === "about:";
+  } catch {
+    return false;
+  }
+}

--- a/packages/gui/src/index.ts
+++ b/packages/gui/src/index.ts
@@ -6,6 +6,7 @@ export * from "./daemon/remote-tunnel.ts";
 export * from "./distribution/runtime-release-readiness.ts";
 export * from "./distribution/supply-chain-release-readiness.ts";
 export * from "./doc-renderer/sanitize.ts";
+export * from "./api/html-artifact-policy.ts";
 export * from "./main/ipc-handlers.ts";
 export * from "./main/local-composition-root.ts";
 export * from "./main/security-policy.ts";

--- a/packages/gui/src/main/electron-main.ts
+++ b/packages/gui/src/main/electron-main.ts
@@ -7,7 +7,14 @@ import { createLocalGuiServiceBridge } from "./local-composition-root.ts";
 import { addLocalMainControls } from "./local-main-controls.ts";
 import { resolveLocalDaemonTarget } from "../../../daemon/src/client/local-daemon-target.ts";
 import { daemonBuildStamp } from "../../../daemon/src/build-identity.ts";
-import { evaluateNavigationRequest, evaluatePermissionRequest, evaluateWindowOpenRequest } from "./security-policy.ts";
+import {
+  evaluateHtmlArtifactAttachment,
+  evaluateHtmlArtifactRequest,
+  evaluateNavigationRequest,
+  evaluatePermissionRequest,
+  evaluateWindowOpenRequest,
+  HTML_ARTIFACT_PARTITION,
+} from "./security-policy.ts";
 import { assertDevRendererUrl, createGuiContentSecurityPolicy } from "./window-config.ts";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -29,6 +36,7 @@ export function createMainWindow(): BrowserWindow {
       contextIsolation: true,
       sandbox: true,
       webSecurity: true,
+      webviewTag: true,
       preload: preloadPath
     }
   });
@@ -40,6 +48,7 @@ export function createMainWindow(): BrowserWindow {
       event.preventDefault();
     }
   });
+  installHtmlArtifactWebviewPolicy(mainWindow);
   if (rendererUrl) {
     assertDevRendererUrl(rendererUrl);
     void mainWindow.loadURL(rendererUrl);
@@ -62,6 +71,42 @@ export function installContentSecurityPolicy(): void {
         })]
       }
     });
+  });
+  const artifactSession = session.fromPartition(HTML_ARTIFACT_PARTITION);
+  artifactSession.setPermissionCheckHandler(() => false);
+  artifactSession.setPermissionRequestHandler((_webContents, _permission, callback) => callback(false));
+  artifactSession.webRequest.onBeforeRequest((details, callback) => {
+    callback({ cancel: evaluateHtmlArtifactRequest(details.url).action === "deny" });
+  });
+  artifactSession.on("will-download", (event) => event.preventDefault());
+}
+
+function installHtmlArtifactWebviewPolicy(mainWindow: BrowserWindow): void {
+  mainWindow.webContents.on("will-attach-webview", (event, webPreferences, params) => {
+    if (evaluateHtmlArtifactAttachment(params).action === "deny") {
+      event.preventDefault();
+      return;
+    }
+    delete webPreferences.preload;
+    webPreferences.nodeIntegration = false;
+    webPreferences.nodeIntegrationInWorker = false;
+    webPreferences.nodeIntegrationInSubFrames = false;
+    webPreferences.contextIsolation = true;
+    webPreferences.sandbox = true;
+    webPreferences.webSecurity = true;
+    webPreferences.javascript = false;
+    webPreferences.plugins = false;
+    webPreferences.devTools = false;
+    webPreferences.navigateOnDragDrop = false;
+    webPreferences.webviewTag = false;
+    webPreferences.partition = HTML_ARTIFACT_PARTITION;
+    delete params.preload;
+  });
+  mainWindow.webContents.on("did-attach-webview", (_event, guest) => {
+    guest.setWindowOpenHandler(() => ({ action: "deny" }));
+    guest.on("will-navigate", (event) => event.preventDefault());
+    guest.on("will-frame-navigate", (event) => event.preventDefault());
+    guest.on("will-redirect", (event) => event.preventDefault());
   });
 }
 

--- a/packages/gui/src/main/security-policy.ts
+++ b/packages/gui/src/main/security-policy.ts
@@ -1,4 +1,10 @@
 import { isTrustedRendererUrl, type TrustedRendererUrlOptions } from "./window-config.ts";
+import {
+  isAllowedHtmlArtifactAttachment,
+  isAllowedHtmlArtifactRequest,
+} from "../api/html-artifact-policy.ts";
+
+export { HTML_ARTIFACT_DATA_URL_PREFIX, HTML_ARTIFACT_PARTITION } from "../api/html-artifact-policy.ts";
 
 export type SecurityDecisionReason =
   | "trusted_renderer"
@@ -7,6 +13,10 @@ export type SecurityDecisionReason =
   | "permission_denied_by_default"
   | "navigation_denied"
   | "window_open_denied"
+  | "html_artifact_source_allowed"
+  | "html_artifact_source_denied"
+  | "html_artifact_request_allowed"
+  | "html_artifact_request_denied"
   | "missing_browser_preview_threat_model"
   | "browser_preview_not_shipped";
 
@@ -75,6 +85,24 @@ export function evaluateNavigationRequest(url: string, options: TrustedRendererU
 
 export function evaluateWindowOpenRequest(): SecurityDecision {
   return { action: "deny", reason: "window_open_denied" };
+}
+
+/**
+ * Task HTML previews receive bytes only from repo.tasks.document.read and turn
+ * them into one data:text/html guest navigation. Arbitrary URL and partition
+ * values never reach an attached guest WebContents.
+ */
+export function evaluateHtmlArtifactAttachment(params: Readonly<Record<string, string>>): SecurityDecision {
+  if (isAllowedHtmlArtifactAttachment(params)) {
+    return { action: "allow", reason: "html_artifact_source_allowed" };
+  }
+  return { action: "deny", reason: "html_artifact_source_denied", detail: params.src };
+}
+
+/** The isolated guest may load its own data resources and nothing else. */
+export function evaluateHtmlArtifactRequest(url: string): SecurityDecision {
+  if (isAllowedHtmlArtifactRequest(url)) return { action: "allow", reason: "html_artifact_request_allowed" };
+  return { action: "deny", reason: "html_artifact_request_denied", detail: url };
 }
 
 export function evaluateBrowserPreviewOpenRequest(request: BrowserPreviewOpenRequest): SecurityDecision {

--- a/packages/gui/src/main/window-config.ts
+++ b/packages/gui/src/main/window-config.ts
@@ -3,6 +3,7 @@ export interface GuiWebPreferences {
   readonly contextIsolation: true;
   readonly sandbox: true;
   readonly webSecurity: true;
+  readonly webviewTag: true;
   readonly preload: string;
 }
 
@@ -80,6 +81,7 @@ export function createGuiWindowOptions(preloadPath: string): GuiWindowOptions {
       contextIsolation: true,
       sandbox: true,
       webSecurity: true,
+      webviewTag: true,
       preload: preloadPath
     }
   };

--- a/packages/gui/src/renderer/components/DocReader.tsx
+++ b/packages/gui/src/renderer/components/DocReader.tsx
@@ -1,5 +1,5 @@
 import { isValidElement, useMemo, useState } from "react";
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import Markdown from "react-markdown";
 import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -28,19 +28,39 @@ const components: Components = {
   },
 };
 
+type ReaderLayout = "single" | "double";
+type ReaderFont = "sans" | "serif" | "mono";
+
+const readerFonts: Record<ReaderFont, string> = {
+  sans: "var(--font-sans)",
+  serif: 'Iowan Old Style, Palatino Linotype, Noto Serif CJK SC, serif',
+  mono: "var(--font-mono)",
+};
+
 export function DocReader({ content }: { content: string }) {
   const [query, setQuery] = useState("");
+  const [layout, setLayout] = useState<ReaderLayout>("single");
+  const [font, setFont] = useState<ReaderFont>("sans");
+  const [fontSize, setFontSize] = useState(15);
 
   const matchCount = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return null;
     return content.toLowerCase().split(q).length - 1;
   }, [content, query]);
+  const readerStyle = {
+    "--reader-font-family": readerFonts[font],
+    "--reader-font-size": `${fontSize}px`,
+  } as CSSProperties;
 
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex items-center gap-2">
-        <div className="flex w-56 items-center gap-1.5 rounded-md border border-border bg-surface px-2 py-1">
+    <section
+      className="overflow-clip rounded-lg border border-border bg-surface shadow-sm"
+      data-testid="doc-reader"
+      style={readerStyle}
+    >
+      <div className="flex min-h-10 flex-wrap items-center gap-2 border-b border-border bg-surface-raised px-3 py-2">
+        <div className="flex w-56 max-w-full items-center gap-1.5 rounded-md border border-border bg-surface px-2 py-1">
           <MagnifyingGlass
             weight="bold"
             className="shrink-0 text-[12px] text-text-faint"
@@ -49,6 +69,7 @@ export function DocReader({ content }: { content: string }) {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="文档内搜索…"
+            aria-label="文档内搜索"
             className="w-full bg-transparent text-[12px] text-text outline-none placeholder:text-text-faint"
           />
         </div>
@@ -62,11 +83,78 @@ export function DocReader({ content }: { content: string }) {
           </span>
         )}
       </div>
-      <div className="prose-harness">
-        <Markdown remarkPlugins={[remarkGfm]} components={components}>
-          {content}
-        </Markdown>
+      <div className="pointer-events-none sticky top-3 z-20 -mb-11 flex justify-end px-3 pt-3">
+        <div
+          className={[
+            "pointer-events-auto flex items-center gap-1 rounded-lg border border-border-strong",
+            "bg-surface-raised/95 p-1 shadow-lg backdrop-blur",
+          ].join(" ")}
+          data-testid="reader-floating-toolbar"
+        >
+          <div className="flex items-center rounded-md border border-border bg-surface p-0.5" aria-label="阅读栏数">
+            {(["single", "double"] as const).map((value) => (
+              <button
+                key={value}
+                type="button"
+                aria-pressed={layout === value}
+                onClick={() => setLayout(value)}
+                className={`rounded px-2 py-1 text-[11px] ${
+                  layout === value ? "bg-accent text-accent-fg" : "text-text-muted hover:text-text"
+                }`}
+              >
+                {value === "single" ? "单栏" : "双栏"}
+              </button>
+            ))}
+          </div>
+          <select
+            aria-label="文档字体"
+            value={font}
+            onChange={(event) => setFont(event.target.value as ReaderFont)}
+            className="h-7 rounded-md border border-border bg-surface px-1.5 text-[11px] text-text"
+          >
+            <option value="sans">无衬线</option>
+            <option value="serif">衬线</option>
+            <option value="mono">等宽</option>
+          </select>
+          <button
+            type="button"
+            aria-label="缩小字号"
+            disabled={fontSize <= 13}
+            onClick={() => setFontSize((size) => Math.max(13, size - 1))}
+            className={[
+              "grid size-7 place-items-center rounded-md text-[15px] text-text-muted",
+              "hover:bg-surface hover:text-text disabled:opacity-35",
+            ].join(" ")}
+          >
+            −
+          </button>
+          <span
+            className="w-8 text-center font-mono text-[10px] text-text-faint"
+            aria-label={`字号 ${fontSize} 像素`}
+          >
+            {fontSize}
+          </span>
+          <button
+            type="button"
+            aria-label="放大字号"
+            disabled={fontSize >= 19}
+            onClick={() => setFontSize((size) => Math.min(19, size + 1))}
+            className={[
+              "grid size-7 place-items-center rounded-md text-[15px] text-text-muted",
+              "hover:bg-surface hover:text-text disabled:opacity-35",
+            ].join(" ")}
+          >
+            ＋
+          </button>
+        </div>
       </div>
-    </div>
+      <div className="px-5 pb-6 pt-16 sm:px-6">
+        <div className="prose-harness" data-layout={layout} data-font={font}>
+          <Markdown remarkPlugins={[remarkGfm]} components={components}>
+            {content}
+          </Markdown>
+        </div>
+      </div>
+    </section>
   );
 }

--- a/packages/gui/src/renderer/components/HtmlArtifactPreview.tsx
+++ b/packages/gui/src/renderer/components/HtmlArtifactPreview.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from "react";
+import { buildHtmlArtifactDataUrl, HTML_ARTIFACT_PARTITION } from "../../api/html-artifact-policy.ts";
+
+export function HtmlArtifactPreview({ content, path }: { readonly content: string; readonly path: string }) {
+  const hostRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    const preview = document.createElement("webview");
+    preview.dataset.testid = "html-artifact-webview";
+    preview.dataset.artifactPath = path;
+    preview.setAttribute("aria-label", `HTML artifact 预览：${path}`);
+    preview.setAttribute("partition", HTML_ARTIFACT_PARTITION);
+    preview.setAttribute(
+      "webpreferences",
+      [
+        "contextIsolation=yes",
+        "nodeIntegration=no",
+        "nodeIntegrationInWorker=no",
+        "nodeIntegrationInSubFrames=no",
+        "sandbox=yes",
+        "javascript=no",
+        "webSecurity=yes",
+        "plugins=no",
+        "webviewTag=no",
+      ].join(","),
+    );
+    preview.setAttribute("src", buildHtmlArtifactDataUrl(content));
+    preview.className = "html-artifact-webview";
+    host.replaceChildren(preview);
+    return () => preview.remove();
+  }, [content, path]);
+
+  return (
+    <section className="overflow-hidden rounded-lg border border-border bg-surface" data-testid="html-artifact-preview">
+      <header className="flex items-center justify-between gap-3 border-b border-border bg-surface-raised px-3 py-2">
+        <span className="min-w-0 truncate font-mono text-[11px] text-text-muted">{path}</span>
+        <span className="shrink-0 font-mono text-[10px] text-text-faint">
+          隔离本地预览 · 脚本 / 外联已禁用
+        </span>
+      </header>
+      <div ref={hostRef} className="min-h-[42rem] bg-white" />
+    </section>
+  );
+}

--- a/packages/gui/src/renderer/components/taskDetail/DocTree.tsx
+++ b/packages/gui/src/renderer/components/taskDetail/DocTree.tsx
@@ -83,7 +83,9 @@ function TreeNodeView({
     return (
       <>
         <button
+          type="button"
           onClick={() => onToggle(node.path)}
+          aria-expanded={isExpanded}
           className="flex w-full items-center gap-1 rounded-md py-1 pr-2 text-left text-[12px] font-medium text-text-muted hover:text-text"
           style={{ paddingLeft: indent }}
         >
@@ -118,7 +120,9 @@ function TreeNodeView({
 
   return (
     <button
+      type="button"
       onClick={() => onSelectDoc(doc.path)}
+      aria-current={activeDoc === doc.path ? "page" : undefined}
       className={`flex w-full items-center gap-1.5 rounded-md py-1 pr-2 text-left text-[13px] ${
         activeDoc === doc.path
           ? "bg-surface-raised text-text"

--- a/packages/gui/src/renderer/components/taskDetail/TaskDetailSections.tsx
+++ b/packages/gui/src/renderer/components/taskDetail/TaskDetailSections.tsx
@@ -43,14 +43,14 @@ interface TaskActionProps {
 }
 
 export function TaskOverviewTab({ task }: { readonly task: TaskRow }) {
-  const plan = useTaskDocumentQuery(task.projectId, task.taskId, typeof task.packagePath === "string" ? "task_plan.md" : null);
+  const plan = useTaskDocumentQuery(task.projectId, task.taskId, "task_plan.md");
   const events = task.events ?? [];
 
   return (
-    <div className="grid min-h-full gap-8 xl:grid-cols-[minmax(0,1fr)_19rem]" data-testid="task-overview-tab">
+    <div className="grid min-h-full gap-8" data-testid="task-overview-tab">
       <section className="min-w-0">
         <SectionHeading eyebrow="PLAN" title="任务计划" description="目标、验收与边界的完整原文" />
-        <div className="mt-5 max-w-[78ch]">
+        <div className="mt-5">
           {/* TODO(read-model): repo.tasks.document.read only exposes body:string today.
               Keep the plan intact; do not parse markdown/frontmatter in the renderer.
               Replace this whole-body rendering when the backend projects plan sections. */}
@@ -62,7 +62,7 @@ export function TaskOverviewTab({ task }: { readonly task: TaskRow }) {
         </div>
       </section>
 
-      <aside className="border-t border-border pt-6 xl:border-t-0 xl:border-l xl:pt-0 xl:pl-6">
+      <aside className="border-t border-border pt-6">
         <SectionHeading eyebrow="TIMELINE" title="进展时间线" description={`${events.length} 条生命周期记录`} />
         {events.length === 0 ? <div className="mt-5"><Empty text="还没有 execution、review、consent 或 gate witness 记录。" /></div> : (
           <ol className="mt-5 grid gap-0" data-testid="task-progress-timeline">

--- a/packages/gui/src/renderer/components/taskDetail/TaskFilesTab.tsx
+++ b/packages/gui/src/renderer/components/taskDetail/TaskFilesTab.tsx
@@ -1,61 +1,123 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 import { CaretRight, FileText } from "@phosphor-icons/react";
 import { DocReader } from "../DocReader.tsx";
+import { HtmlArtifactPreview } from "../HtmlArtifactPreview.tsx";
 import { buildDocTree, mergeProjectedDocuments } from "../../model/docTree.ts";
 import type { TaskRow } from "../../model/types.ts";
 import { useTaskDocumentListQuery, useTaskDocumentQuery } from "../../task-data.ts";
 import { DocTree } from "./DocTree.tsx";
 
-export function TaskFilesTab({ task }: { readonly task: TaskRow }) {
-  const canonicalPackage = typeof task.packagePath === "string";
-  const documentList = useTaskDocumentListQuery(task.projectId, canonicalPackage ? task.taskId : null);
+interface TaskDocumentSidebarProps {
+  readonly task: TaskRow;
+  readonly activeDoc: string;
+  readonly onActiveDocChange: (path: string) => void;
+  readonly onOpenDoc: (path: string) => void;
+}
+
+export function TaskDocumentSidebar({
+  task,
+  activeDoc,
+  onActiveDocChange,
+  onOpenDoc,
+}: TaskDocumentSidebarProps) {
+  const documentList = useTaskDocumentListQuery(task.projectId, task.taskId);
   const documents = useMemo(() => {
-    const projected = documentList.data?.status === "ready" ? documentList.data.documents.map((document) => document.path) : [];
-    return mergeProjectedDocuments(canonicalPackage ? [] : task.docs, projected);
-  }, [canonicalPackage, documentList.data, task.docs]);
+    const projected = documentList.data?.status === "ready"
+      ? documentList.data.documents.map((document) => document.path)
+      : [];
+    return mergeProjectedDocuments([], projected);
+  }, [documentList.data]);
   const tree = useMemo(() => buildDocTree(documents), [documents]);
-  const [activeDoc, setActiveDoc] = useState(() => documents[0]?.path ?? task.docs[0]?.path ?? "");
 
   useEffect(() => {
+    if (documentList.data?.status !== "ready") return;
     if (documents.length === 0) {
-      if (activeDoc !== "") setActiveDoc("");
+      if (activeDoc !== "") onActiveDocChange("");
       return;
     }
-    if (!documents.some((document) => document.path === activeDoc)) setActiveDoc(documents[0]!.path);
-  }, [activeDoc, documents]);
+    if (!documents.some((document) => document.path === activeDoc)) onActiveDocChange(documents[0]!.path);
+  }, [activeDoc, documentList.data?.status, documents, onActiveDocChange]);
 
-  const document = documents.find((entry) => entry.path === activeDoc) ?? documents[0];
   return (
-    <section className="grid min-h-[32rem] overflow-hidden border border-border md:grid-cols-[15rem_minmax(0,1fr)]" data-testid="task-files-tab">
-      <nav aria-label="任务包文件" className="max-h-72 overflow-y-auto border-b border-border bg-surface p-3 md:max-h-none md:border-r md:border-b-0">
-        {tree.length === 0 ? <p className="border border-dashed border-border px-2 py-3 text-[12px] leading-5 text-text-faint">
-          {canonicalPackage && documentList.isPending ? "正在读取任务包文件清单…" : documentList.isError ? `文件清单读取失败：${documentList.error.message}` : "投影没有返回任务包文件。"}
-        </p> : <DocTree nodes={tree} activeDoc={activeDoc} onSelectDoc={setActiveDoc} />}
-      </nav>
-      <article className="min-w-0 overflow-y-auto px-5 py-5 lg:px-8 lg:py-6">
-        <div className="mx-auto max-w-[78ch]">
-          <div className="mb-5 flex flex-wrap items-center gap-1.5 border-b border-border pb-3">
-            <span className="font-mono text-[11px] text-text-faint">{task.taskId}</span>
-            <CaretRight weight="bold" className="text-[10px] text-text-faint" />
-            <span className="font-mono text-[11px] text-text-muted">{document?.path ?? "未选择文件"}</span>
-          </div>
-          <TaskFileBody repoId={task.projectId} taskId={task.taskId} path={document?.path ?? null} />
-        </div>
-      </article>
+    <nav
+      aria-label="任务包文件"
+      className="min-h-0 overflow-y-auto border-b border-border bg-surface p-3 md:border-r md:border-b-0"
+      data-testid="task-document-tree"
+    >
+      <p className="mb-2 px-1 font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-text-faint">
+        Task 文件
+      </p>
+      {tree.length === 0 ? (
+        <p className="border border-dashed border-border px-2 py-3 text-[12px] leading-5 text-text-faint">
+          {documentList.isPending
+            ? "正在读取任务包文件清单…"
+            : documentList.isError
+              ? `文件清单读取失败：${documentList.error.message}`
+              : "投影没有返回任务包文件。"}
+        </p>
+      ) : (
+        <DocTree nodes={tree} activeDoc={activeDoc} onSelectDoc={onOpenDoc} />
+      )}
+    </nav>
+  );
+}
+
+export function TaskFilesTab({ task, activeDoc }: { readonly task: TaskRow; readonly activeDoc: string }) {
+  return (
+    <section className="min-w-0" data-testid="task-files-tab">
+      <div className="mb-4 flex flex-wrap items-center gap-1.5 border-b border-border pb-3">
+        <span className="font-mono text-[11px] text-text-faint">{task.taskId}</span>
+        <CaretRight weight="bold" className="text-[10px] text-text-faint" />
+        <span className="font-mono text-[11px] text-text-muted">{activeDoc || "未选择文件"}</span>
+      </div>
+      <TaskFileBody repoId={task.projectId} taskId={task.taskId} path={activeDoc || null} />
     </section>
   );
 }
 
-function TaskFileBody({ repoId, taskId, path }: { readonly repoId: string; readonly taskId: string; readonly path: string | null }) {
+interface TaskFileBodyProps {
+  readonly repoId: string;
+  readonly taskId: string;
+  readonly path: string | null;
+}
+
+function TaskFileBody({ repoId, taskId, path }: TaskFileBodyProps) {
   const document = useTaskDocumentQuery(repoId, taskId, path);
   if (!path) return <FileEmpty text="先从左侧选择一个任务包文件。" />;
   if (document.isPending) return <FileEmpty text="正在读取文档投影…" />;
   if (document.isError) return <p className="text-[12px] text-danger">文档读取失败：{document.error.message}</p>;
   if (document.data.status !== "ready") return <FileEmpty text="文档投影尚未追平。" />;
   if (document.data.blobSha256 === null) return <FileEmpty text="该文件尚未物化。" />;
-  return <><span data-testid="task-document-status" className="mb-3 block font-mono text-[10px] text-text-faint">L2 · {document.data.status}</span><DocReader content={document.data.body} /></>;
+  const content = isHtmlDocument(path)
+    ? <HtmlArtifactPreview content={document.data.body} path={path} />
+    : <DocReader content={document.data.body} />;
+  return (
+    <>
+      <span
+        data-testid="task-document-status"
+        className="mb-3 block font-mono text-[10px] text-text-faint"
+      >
+        L2 · {document.data.status}
+      </span>
+      {content}
+    </>
+  );
+}
+
+export function isHtmlDocument(path: string): boolean {
+  return /\.html?$/iu.test(path);
 }
 
 function FileEmpty({ text }: { readonly text: string }) {
-  return <div className="flex min-h-56 flex-col items-center justify-center gap-2 border border-dashed border-border-strong px-6 text-center"><FileText weight="duotone" className="text-2xl text-text-faint" /><p className="text-[12px] text-text-faint">{text}</p></div>;
+  return (
+    <div
+      className={[
+        "flex min-h-56 flex-col items-center justify-center gap-2",
+        "border border-dashed border-border-strong px-6 text-center",
+      ].join(" ")}
+    >
+      <FileText weight="duotone" className="text-2xl text-text-faint" />
+      <p className="text-[12px] text-text-faint">{text}</p>
+    </div>
+  );
 }

--- a/packages/gui/src/renderer/styles.css
+++ b/packages/gui/src/renderer/styles.css
@@ -162,14 +162,30 @@ html[data-theme="light"] ::selection {
 
 /* 文档阅读区排版（react-markdown 输出） */
 .prose-harness {
-  font-size: var(--ui-font-prose);
+  width: 100%;
+  max-width: none;
+  font-family: var(--reader-font-family, var(--font-sans));
+  font-size: var(--reader-font-size, var(--ui-font-prose));
   line-height: 1.75;
   color: var(--color-text);
-  max-width: 42rem;
+  overflow-wrap: anywhere;
+}
+.prose-harness[data-layout="single"] > :where(h1, h2, h3, h4, p, ul, ol, blockquote) {
+  max-width: 88ch;
+}
+.prose-harness[data-layout="double"] {
+  columns: 2 24rem;
+  column-gap: 2.5rem;
+  column-rule: 1px solid var(--color-border);
+}
+.prose-harness[data-layout="double"] > * {
+  break-inside: avoid;
 }
 .prose-harness h1 {
   font-size: var(--ui-font-heading);
   font-weight: 650;
+  line-height: 1.3;
+  margin-top: 0;
   margin-bottom: 1rem;
 }
 .prose-harness h2 {
@@ -178,15 +194,30 @@ html[data-theme="light"] ::selection {
   margin-top: 1.75rem;
   margin-bottom: 0.5rem;
 }
+.prose-harness h3 {
+  margin-top: 1.35rem;
+  margin-bottom: 0.4rem;
+  font-size: 1.08em;
+  font-weight: 620;
+}
+.prose-harness h4 {
+  margin-top: 1.1rem;
+  margin-bottom: 0.35rem;
+  font-size: 1em;
+  font-weight: 620;
+  color: var(--color-text-muted);
+}
 .prose-harness p {
   margin: 0.6rem 0;
   color: var(--color-text);
 }
-.prose-harness ul {
+.prose-harness ul,
+.prose-harness ol {
   padding-left: 1.25rem;
-  list-style: disc;
   color: var(--color-text);
 }
+.prose-harness ul { list-style: disc; }
+.prose-harness ol { list-style: decimal; }
 .prose-harness li {
   margin: 0.25rem 0;
 }
@@ -238,9 +269,34 @@ html[data-theme="light"] ::selection {
   margin: 0.75rem 0;
   color: var(--color-text-faint);
 }
+.prose-harness a {
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in oklch, var(--color-accent) 45%, transparent);
+  text-underline-offset: 0.16em;
+}
+.prose-harness hr {
+  margin: 1.5rem 0;
+  border: 0;
+  border-top: 1px solid var(--color-border-strong);
+}
+.prose-harness img {
+  max-width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+}
 .prose-harness input[type="checkbox"] {
   accent-color: var(--color-accent);
   margin-right: 0.4rem;
+}
+
+/* Electron guest surface sizing; class-based so the strict host CSP remains unchanged. */
+.html-artifact-webview {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  min-height: 42rem;
+  background: white;
 }
 
 /*

--- a/packages/gui/src/renderer/views/TaskDetailView.tsx
+++ b/packages/gui/src/renderer/views/TaskDetailView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type KeyboardEvent } from "react";
+import { useCallback, useEffect, useState, type KeyboardEvent } from "react";
 import {
   ArrowLeft,
   CaretRight,
@@ -18,7 +18,7 @@ import {
   TaskOverviewTab,
   TaskRelationsTab,
 } from "../components/taskDetail/TaskDetailSections.tsx";
-import { TaskFilesTab } from "../components/taskDetail/TaskFilesTab.tsx";
+import { TaskDocumentSidebar, TaskFilesTab } from "../components/taskDetail/TaskFilesTab.tsx";
 import { PhaseSteps } from "../components/taskDetail/PhaseSteps.tsx";
 import type { DecisionRow, RelationEdge, TaskRow } from "../model/types.ts";
 import { isExternal } from "../model/types.ts";
@@ -66,11 +66,13 @@ export function TaskDetailView({
   onSubmit?: (submission: GuiSubmissionV1) => Promise<unknown>;
 }) {
   const [activeTab, setActiveTab] = useState<TaskDetailTab>("overview");
+  const [activeDoc, setActiveDoc] = useState("task_plan.md");
   const [focusedSessionId, setFocusedSessionId] = useState<string | null>(null);
   const external = isExternal(task);
 
   useEffect(() => {
     setActiveTab("overview");
+    setActiveDoc("task_plan.md");
     setFocusedSessionId(null);
   }, [task.taskId]);
 
@@ -82,45 +84,93 @@ export function TaskDetailView({
     setFocusedSessionId(runtimeSessionId);
     setActiveTab("dispatch");
   };
+  const openDocument = useCallback((path: string) => {
+    setActiveDoc(path);
+    setFocusedSessionId(null);
+    setActiveTab("files");
+  }, []);
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-bg" data-testid="task-detail-view">
-      <header className="shrink-0 border-b border-border bg-surface/80">
-        <div className="flex items-start gap-3 px-4 py-3 lg:px-6">
-          <button type="button" onClick={onBack} aria-label={t("views.taskDetailView.returnPreviousLevel")} className="mt-0.5 grid size-8 shrink-0 place-items-center rounded-md border border-border text-text-muted hover:border-border-strong hover:bg-surface-raised hover:text-text focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent">
+      <header className="relative z-20 shrink-0 border-b border-border bg-surface/80" data-testid="task-detail-header">
+        <div className="flex min-h-14 items-center gap-2.5 px-3 py-2 lg:px-4">
+          <button
+            type="button"
+            onClick={onBack}
+            aria-label={t("views.taskDetailView.returnPreviousLevel")}
+            className={[
+              "grid size-7 shrink-0 place-items-center rounded-md border border-border text-text-muted",
+              "hover:border-border-strong hover:bg-surface-raised hover:text-text",
+              "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+            ].join(" ")}
+          >
             <ArrowLeft weight="bold" />
           </button>
           <div className="min-w-0 flex-1">
-            <div className="mb-1 flex min-w-0 items-center gap-1.5 font-mono text-[10px] text-text-faint">
+            <div className="flex min-w-0 items-center gap-1 font-mono text-[9px] leading-3 text-text-faint">
               <button type="button" onClick={onBack} className="truncate hover:text-text-muted">{projectName}</button>
               <CaretRight weight="bold" className="shrink-0" />
               <button type="button" onClick={onBack} className="truncate hover:text-text-muted">{fromViewLabel}</button>
               <CaretRight weight="bold" className="shrink-0" />
-              <span className="shrink-0 text-text-muted">{task.taskId}</span>
+              <span className="truncate text-text-muted">{task.taskId}</span>
             </div>
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-              <h1 className="text-[18px] font-semibold leading-6 tracking-[-0.01em] text-text">{task.title}</h1>
+            <div className="mt-0.5 flex min-w-0 items-center gap-2">
+              <h1 className="truncate text-[16px] font-semibold leading-5 tracking-[-0.01em] text-text">
+                {task.title}
+              </h1>
               <StatusBadge status={task.coordinationStatus} />
               <FreshnessTag freshness={task.freshness} lastKnownAt={task.lastKnownAt} />
             </div>
           </div>
           <EngineBadge engine={task.engine} locked={external} />
+          <details className="group relative shrink-0">
+            <summary
+              className={[
+                "list-none rounded-md border border-border px-2 py-1.5 font-mono text-[10px] text-text-muted",
+                "hover:border-border-strong hover:bg-surface-raised hover:text-text",
+                "[&::-webkit-details-marker]:hidden",
+              ].join(" ")}
+            >
+              身份信息
+            </summary>
+            <dl
+              className={[
+                "absolute right-0 top-[calc(100%+0.5rem)] z-40 grid w-[min(56rem,calc(100vw-2rem))]",
+                "overflow-hidden rounded-lg border border-border-strong bg-surface shadow-2xl",
+                "sm:grid-cols-2 lg:grid-cols-3",
+              ].join(" ")}
+              data-testid="task-identity-strip"
+            >
+              <IdentityItem label="TASK ID" value={task.taskId} />
+              <IdentityItem
+                label="PARENT"
+                value={task.parentTaskId ?? "root"}
+                onClick={task.parentTaskId && onSelect ? () => onSelect(task.parentTaskId!) : undefined}
+              />
+              <IdentityItem
+                label="LIFECYCLE / STATUS"
+                value={`${task.engine} · ${task.canonicalStatus ?? task.coordinationStatus}`}
+              />
+              <IdentityItem
+                label="阶段"
+                value={`${task.currentNode ?? "—"} · iteration ${task.iteration ?? "—"}`}
+                detail={<PhaseSteps status={task.canonicalStatus ?? task.coordinationStatus} />}
+              />
+              <IdentityItem label="PRESET / VERTICAL" value={`${task.preset ?? "—"} · ${task.vertical ?? "—"}`} />
+              <IdentityItem label="RISK / URGENCY" value={`${task.riskTier ?? "—"} · ${task.urgency ?? "—"}`} />
+              <IdentityItem label="OWNER / CLASS" value={`${task.createdBy ?? "—"} · ${task.taskClass ?? "—"}`} />
+              <IdentityItem label="WORK KIND" value={task.workKind ?? "—"} />
+              <IdentityItem label="PACKAGE PATH" value={task.packagePath ?? "未物化"} wide />
+            </dl>
+          </details>
         </div>
-
-        <dl className="grid border-t border-border/80 sm:grid-cols-2 lg:grid-cols-4 2xl:grid-cols-6" data-testid="task-identity-strip">
-          <IdentityItem label="TASK ID" value={task.taskId} />
-          <IdentityItem label="PARENT" value={task.parentTaskId ?? "root"} onClick={task.parentTaskId && onSelect ? () => onSelect(task.parentTaskId!) : undefined} />
-          <IdentityItem label="LIFECYCLE / STATUS" value={`${task.engine} · ${task.canonicalStatus ?? task.coordinationStatus}`} />
-          <IdentityItem label="阶段" value={`${task.currentNode ?? "—"} · iteration ${task.iteration ?? "—"}`} detail={<PhaseSteps status={task.canonicalStatus ?? task.coordinationStatus} />} />
-          <IdentityItem label="PRESET / VERTICAL" value={`${task.preset ?? "—"} · ${task.vertical ?? "—"}`} />
-          <IdentityItem label="RISK / URGENCY" value={`${task.riskTier ?? "—"} · ${task.urgency ?? "—"}`} />
-          <IdentityItem label="OWNER / CLASS" value={`${task.createdBy ?? "—"} · ${task.taskClass ?? "—"}`} />
-          <IdentityItem label="WORK KIND" value={task.workKind ?? "—"} />
-          <IdentityItem label="PACKAGE PATH" value={task.packagePath ?? "未物化"} wide />
-        </dl>
       </header>
 
-      <nav role="tablist" aria-label="Task 详情分区" className="flex shrink-0 overflow-x-auto border-b border-border bg-surface px-3 sm:px-5">
+      <nav
+        role="tablist"
+        aria-label="Task 详情分区"
+        className="relative z-10 flex h-8 shrink-0 overflow-x-auto border-b border-border bg-surface px-2 sm:px-3"
+      >
         {tabs.map((tab, index) => {
           const Icon = tab.icon, active = activeTab === tab.id;
           return <button
@@ -133,35 +183,94 @@ export function TaskDetailView({
             tabIndex={active ? 0 : -1}
             onClick={() => selectTab(tab.id)}
             onKeyDown={(event) => navigateTabs(event, index, selectTab)}
-            className={`relative flex min-h-11 shrink-0 items-center gap-1.5 px-3 text-[12px] font-medium focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent ${active ? "text-text" : "text-text-faint hover:text-text-muted"}`}
+            className={[
+              "relative flex h-8 shrink-0 items-center gap-1 px-2 text-[11px] font-medium",
+              "focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent",
+              active ? "text-text" : "text-text-faint hover:text-text-muted",
+            ].join(" ")}
           >
-            <Icon weight={active ? "bold" : "regular"} className="text-[14px]" />
+            <Icon weight={active ? "bold" : "regular"} className="text-[12px]" />
             {tab.label}
             {active ? <span className="absolute inset-x-2 bottom-0 h-0.5 bg-accent" /> : null}
           </button>;
         })}
       </nav>
 
-      <main id={`task-panel-${activeTab}`} role="tabpanel" aria-labelledby={`task-tab-${activeTab}`} className="min-h-0 flex-1 overflow-y-auto px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
-        <div className="mx-auto w-full max-w-[96rem]">
-          {activeTab === "overview" ? <TaskOverviewTab task={task} />
-            : activeTab === "dispatch" ? <TaskDispatchTab task={task} focusedSessionId={focusedSessionId} />
-              : activeTab === "evidence" ? <TaskEvidenceTab task={task} tasks={tasks} relations={relations} decisions={decisions} onNavigateEntity={onNavigateEntity} />
-                : activeTab === "relations" ? <TaskRelationsTab task={task} tasks={tasks} relations={relations} decisions={decisions} onSelect={onSelect} onNavigateDecision={onNavigateDecision} onNavigateEntity={onNavigateEntity} onOpenSession={openSession} />
-                  : activeTab === "closeout" ? <TaskCloseoutTab task={task} mutationFeedback={mutationFeedback} onProgress={onProgress} onSubmit={onSubmit} />
-                    : <TaskFilesTab task={task} />}
+      <main className="min-h-0 flex-1 overflow-hidden px-3 py-3 sm:px-4">
+        <div
+          className={[
+            "mx-auto h-full w-full max-w-[96rem] overflow-hidden rounded-lg border border-border bg-bg",
+            "md:grid md:grid-cols-[14rem_minmax(0,1fr)]",
+          ].join(" ")}
+        >
+          <TaskDocumentSidebar
+            task={task}
+            activeDoc={activeDoc}
+            onActiveDocChange={setActiveDoc}
+            onOpenDoc={openDocument}
+          />
+          <section
+            id={`task-panel-${activeTab}`}
+            role="tabpanel"
+            aria-labelledby={`task-tab-${activeTab}`}
+            className="min-h-0 min-w-0 overflow-y-auto px-4 py-5 lg:px-6"
+            data-testid="task-detail-panel-scroll"
+          >
+            {activeTab === "overview" ? <TaskOverviewTab task={task} />
+              : activeTab === "dispatch" ? <TaskDispatchTab task={task} focusedSessionId={focusedSessionId} />
+                : activeTab === "evidence" ? (
+                    <TaskEvidenceTab
+                      task={task}
+                      tasks={tasks}
+                      relations={relations}
+                      decisions={decisions}
+                      onNavigateEntity={onNavigateEntity}
+                    />
+                  ) : activeTab === "relations" ? (
+                      <TaskRelationsTab
+                        task={task}
+                        tasks={tasks}
+                        relations={relations}
+                        decisions={decisions}
+                        onSelect={onSelect}
+                        onNavigateDecision={onNavigateDecision}
+                        onNavigateEntity={onNavigateEntity}
+                        onOpenSession={openSession}
+                      />
+                    ) : activeTab === "closeout" ? (
+                        <TaskCloseoutTab
+                          task={task}
+                          mutationFeedback={mutationFeedback}
+                          onProgress={onProgress}
+                          onSubmit={onSubmit}
+                        />
+                      )
+                      : <TaskFilesTab task={task} activeDoc={activeDoc} />}
+          </section>
         </div>
       </main>
     </div>
   );
 }
 
-function IdentityItem({ label, value, detail, wide = false, onClick }: { readonly label: string; readonly value: string; readonly detail?: React.ReactNode; readonly wide?: boolean; readonly onClick?: () => void }) {
+interface IdentityItemProps {
+  readonly label: string;
+  readonly value: string;
+  readonly detail?: React.ReactNode;
+  readonly wide?: boolean;
+  readonly onClick?: () => void;
+}
+
+function IdentityItem({ label, value, detail, wide = false, onClick }: IdentityItemProps) {
   return (
-    <div className={`min-w-0 border-r border-b border-border/70 px-4 py-3 2xl:border-b-0 ${wide ? "sm:col-span-2" : ""}`}>
+    <div className={`min-w-0 border-r border-b border-border/70 px-3 py-2 ${wide ? "sm:col-span-2" : ""}`}>
       <dt className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-text-faint">{label}</dt>
       <dd title={value} className="mt-1 min-w-0 truncate font-mono text-[11px] text-text-muted">
-        {onClick ? <button type="button" onClick={onClick} className="text-accent hover:underline">{value}</button> : value}
+        {onClick ? (
+          <button type="button" onClick={onClick} className="text-accent hover:underline">
+            {value}
+          </button>
+        ) : value}
       </dd>
       {detail ? <div className="mt-2 min-w-0">{detail}</div> : null}
     </div>

--- a/packages/gui/test/electron-security-policy.test.ts
+++ b/packages/gui/test/electron-security-policy.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   createStaticWebContentsTrustPolicy,
+  evaluateHtmlArtifactAttachment,
+  evaluateHtmlArtifactRequest,
   evaluateBrowserPreviewOpenRequest,
   evaluateIpcSender,
   evaluateNavigationRequest,
@@ -45,6 +47,25 @@ test("IPC sender trust requires both renderer URL and owned webContents id", () 
     evaluateIpcSender({ sender: { id: 7 }, senderFrame: { url: "file:///app/.harness-private/task.md" } }, trustPolicy),
     { action: "deny", reason: "untrusted_renderer_url" }
   );
+});
+
+test("HTML artifact guests accept only the isolated data document and no external subresources", () => {
+  assert.deepEqual(
+    evaluateHtmlArtifactAttachment({ partition: "html-artifact-preview", src: "data:text/html;charset=utf-8,%3Ch1%3Ereport%3C%2Fh1%3E" }),
+    { action: "allow", reason: "html_artifact_source_allowed" }
+  );
+  for (const params of [
+    { partition: "persist:html-artifact-preview", src: "data:text/html;charset=utf-8,report" },
+    { partition: "html-artifact-preview", src: "file:///tmp/report.html" },
+    { partition: "html-artifact-preview", src: "https://example.invalid/report.html" }
+  ]) {
+    assert.equal(evaluateHtmlArtifactAttachment(params).action, "deny");
+  }
+  assert.equal(evaluateHtmlArtifactRequest("data:image/png;base64,AAAA").action, "allow");
+  assert.equal(evaluateHtmlArtifactRequest("about:blank").action, "allow");
+  for (const url of ["https://example.invalid/a.png", "http://127.0.0.1:3000", "file:///tmp/private", "blob:https://example.invalid/id", "not a url"]) {
+    assert.equal(evaluateHtmlArtifactRequest(url).action, "deny");
+  }
 });
 
 test("permission navigation and window-open policies are deny-by-default", () => {

--- a/packages/gui/test/task-detail-expression.vitest.ts
+++ b/packages/gui/test/task-detail-expression.vitest.ts
@@ -47,7 +47,7 @@ afterEach(async () => {
 });
 
 describe("Task detail expression", () => {
-  it("renders task identity and six task-first tabs before the file browser", async () => {
+  it("renders compact task identity, six task-first tabs and a permanent document tree", async () => {
     const bridge = installBridge();
     await mount();
 
@@ -55,6 +55,7 @@ describe("Task detail expression", () => {
     expect(byTestId("task-identity-strip").textContent).toContain("plt-gui · software-coding");
     expect(byTestId("task-detail-view").textContent).toContain("Task 表达重做");
     expect([...document.querySelectorAll('[role="tab"]')].map((tab) => tab.textContent?.trim())).toEqual(["概况", "派工", "证据", "关系", "收口", "文件"]);
+    expect(byTestId("task-document-tree").textContent).toContain("artifacts");
     expect(byTestId("task-overview-tab").textContent).toContain("Canonical plan body");
     expect(byTestId("task-progress-timeline").textContent).toContain("Review review-w3: approved");
     expect(bridge.getTaskDocument).toHaveBeenCalledWith({ repoId: "repo-a", taskId: "task-w3", path: "task_plan.md" });
@@ -99,18 +100,55 @@ describe("Task detail expression", () => {
     expect(byTestId("task-execution-execution-w3").textContent).toContain("1 passing");
 
     await clickTab("文件");
-    expect(byTestId("task-files-tab").textContent).toContain("INDEX.md");
-    expect(byTestId("task-files-tab").textContent).toContain("artifacts");
+    expect(byTestId("task-document-tree").textContent).toContain("INDEX.md");
+    expect(byTestId("task-document-tree").textContent).toContain("artifacts");
+    expect(byTestId("task-files-tab").textContent).toContain("Canonical plan body");
+  });
+
+  it("switches reader layout and font in the floating toolbar and opens HTML in an isolated webview", async () => {
+    installBridge();
+    await mount();
+
+    const toolbar = byTestId("reader-floating-toolbar");
+    const double = [...toolbar.querySelectorAll("button")].find((button) => button.textContent === "双栏")!;
+    await act(async () => { double.click(); });
+    expect(double.getAttribute("aria-pressed")).toBe("true");
+    expect(document.querySelector(".prose-harness")?.getAttribute("data-layout")).toBe("double");
+
+    const font = toolbar.querySelector("select")!;
+    await act(async () => {
+      font.value = "serif";
+      font.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(document.querySelector(".prose-harness")?.getAttribute("data-font")).toBe("serif");
+
+    const reports = [...byTestId("task-document-tree").querySelectorAll("button")].find((button) => button.textContent?.includes("reports/"))!;
+    expect(reports).toBeInstanceOf(HTMLButtonElement);
+    await act(async () => { reports.click(); });
+    const html = [...byTestId("task-document-tree").querySelectorAll("button")].find((button) => button.textContent?.includes("night.html"))!;
+    expect(html).toBeInstanceOf(HTMLButtonElement);
+    await act(async () => { html.click(); });
+    await flushEffects();
+
+    expect(document.querySelector('[role="tab"][aria-selected="true"]')?.textContent).toContain("文件");
+    expect(reports.getAttribute("aria-expanded")).toBe("true");
+    const preview = byTestId("html-artifact-preview");
+    expect(preview.textContent).toContain("脚本 / 外联已禁用");
+    const webview = byTestId("html-artifact-webview");
+    expect(webview.getAttribute("partition")).toBe("html-artifact-preview");
+    expect(webview.getAttribute("preload")).toBeNull();
+    expect(webview.getAttribute("src")).toMatch(/^data:text\/html;charset=utf-8,/u);
   });
 });
 
 function installBridge() {
   const bridge = {
-    getTaskDocument: vi.fn(async ({ taskId, path }: { taskId: string; path: string }) => ({ ok: true, status: "ready", taskId, path, body: path === "task_plan.md" ? "# Canonical plan body" : `# ${path}`, blobSha256: `sha256:${"d".repeat(64)}`, watermark: 7, sourceRevision: 7 })),
+    getTaskDocument: vi.fn(async ({ taskId, path }: { taskId: string; path: string }) => ({ ok: true, status: "ready", taskId, path, body: path === "task_plan.md" ? "# Canonical plan body" : path.endsWith(".html") ? "<style>body{color:#123}</style><h1>Night report</h1><script>window.open(\"https://example.invalid\")</script>" : `# ${path}`, blobSha256: `sha256:${"d".repeat(64)}`, watermark: 7, sourceRevision: 7 })),
     getTaskDocuments: vi.fn(async () => ({ ok: true, status: "ready", taskId: "task-w3", documents: [
       { path: "task_plan.md", blobSha256: "d".repeat(64), size: 20, mediaType: "text/markdown" },
       { path: "INDEX.md", blobSha256: "e".repeat(64), size: 20, mediaType: "text/markdown" },
       { path: "artifacts/report.md", blobSha256: "f".repeat(64), size: 20, mediaType: "text/markdown" },
+      { path: "artifacts/reports/night.html", blobSha256: "a".repeat(64), size: 120, mediaType: "text/html" },
     ], watermark: 7, sourceRevision: 7 })),
     getTaskDispatches: vi.fn(async () => ({ ok: true, status: "ready", taskId: "task-w3", dispatches: [dispatch], watermark: 7, sourceRevision: 7 })),
     getRelationGraph: vi.fn(async () => ({ ok: true, edges: [], coverageRows: [], factAnchors: [], facts: [

--- a/packages/gui/test/window-config.test.ts
+++ b/packages/gui/test/window-config.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
 import test from "node:test";
-import { assertDevRendererUrl, createGuiContentSecurityPolicy, guiContentSecurityPolicy, isTrustedRendererUrl } from "../src/index.ts";
+import { assertDevRendererUrl, createGuiContentSecurityPolicy, createGuiWindowOptions, guiContentSecurityPolicy, isTrustedRendererUrl } from "../src/index.ts";
 
 test("dev renderer override accepts only the local Vite server", () => {
   assert.equal(assertDevRendererUrl("http://127.0.0.1:5173"), true);
@@ -34,4 +34,13 @@ test("trusted renderer URL accepts only explicit dev server or packaged renderer
   assert.equal(isTrustedRendererUrl("file:///tmp/renderer/index.html", { packagedRendererUrl }), false);
   assert.equal(isTrustedRendererUrl("file:///app/.harness-private/task.md", { packagedRendererUrl }), false);
   assert.equal(isTrustedRendererUrl("https://example.invalid", { packagedRendererUrl }), false);
+});
+
+test("the main window enables only the policy-guarded HTML artifact webview surface", () => {
+  const options = createGuiWindowOptions("/app/preload.cjs");
+  assert.equal(options.webPreferences.webviewTag, true);
+  assert.equal(options.webPreferences.nodeIntegration, false);
+  assert.equal(options.webPreferences.contextIsolation, true);
+  assert.equal(options.webPreferences.sandbox, true);
+  assert.equal(options.webPreferences.webSecurity, true);
 });

--- a/packages/gui/tsconfig.renderer.json
+++ b/packages/gui/tsconfig.renderer.json
@@ -26,6 +26,7 @@
     "src/renderer/**/*.json",
     "src/api/entity-payload-hygiene.ts",
     "src/api/error-consumption.ts",
+    "src/api/html-artifact-policy.ts",
     "src/api/renderer-dto.ts"
   ],
   "exclude": [


### PR DESCRIPTION
# English

## Summary

Turns the Task detail page into a document reader. The page previously spent most of its vertical space on chrome — a nine-field identity grid plus a tall tab row — and rendered Markdown into a 42rem column inside a much wider container, so tables and code blocks wrapped while the surrounding page stayed empty. HTML artifacts could not be opened at all.

Top chrome drops from 258px to 50.25px, the reading column widens from 588px to 932px, and the six tabs keep every function while shrinking from 39.5px to 28px. The projected document tree becomes a permanent left column instead of hiding inside the sixth tab. A floating toolbar carries single/double column, font family, and font size. HTML artifacts render inside an isolated Electron guest with scripting disabled.

## What Changed

- `TaskDetailView.tsx`: the nine-field identity grid becomes an expandable panel behind one button, so the identity data is preserved rather than deleted; the tab row shrinks to `h-8 px-2 text-[11px]` with all six tabs intact; the document tree becomes a permanent left column that does not unmount when the active document changes, so expansion state survives navigation.
- `DocReader.tsx` + `styles.css`: `.prose-harness` drops its `max-width: 42rem` container cap; instead only prose blocks (`h1..h4, p, ul, ol, blockquote`) are capped at `88ch`, so running text keeps a readable line length while tables, code blocks, and diagrams use the full width. Adds a `double` layout using CSS columns, and reader-controlled font family and size.
- `TaskFilesTab.tsx`: removes the branch that treated tasks without a `packagePath` differently, and removes the renderer-side `task.docs` legacy index it fell back to. Old and new task packages now go through the same `repo.tasks.documents.list` projection with no compatibility layer.
- `HtmlArtifactPreview.tsx` + `html-artifact-policy.ts` + `main/electron-main.ts` + `main/security-policy.ts` + `main/window-config.ts`: HTML artifact rendering, per `dec_01KXTS73HANF1JHBKS95P9EDX7`. The host page CSP is unchanged. Bytes come only from the existing `repo.tasks.document.read` read face and become a single `data:text/html` navigation in a guest with its own session partition.

Nothing was added to the daemon read surface, the CLI command surface, or the preload allowlist, and no Task tab was removed or merged.

### Why the HTML preview is safe

The renderer cannot point a guest anywhere it likes. `will-attach-webview` denies attachment unless the partition is exactly `html-artifact-preview` and the source starts with `data:text/html;charset=utf-8,`; on the allowed path the main process then overrides the guest's preferences rather than trusting the tag, forcing `javascript=false`, `sandbox=true`, `contextIsolation=true`, all three `nodeIntegration*` flags off, and no preload.

Script execution being off removes the active exfiltration vectors, and the passive ones are cut at the session rather than per tag: the guest partition cancels every request whose protocol is not `data:` or `about:`, denies all permission requests, and prevents downloads. Navigation is blocked in all four forms (`will-navigate`, `will-frame-navigate`, `will-redirect`, and window open).

## Machine-Readable Declarations

Production-Delta: +484/-80

## Task And Scope

- Harness task: task_ca3f4f00dc414ac324ab35f782
- Branch: codex/task-reader
- Public scope: `packages/gui/src/renderer/**`, `packages/gui/src/main/**`, `packages/gui/src/api/html-artifact-policy.ts`, `packages/gui/src/index.ts`, `packages/gui/test/**`, `packages/gui/tsconfig.renderer.json`
- Private planning/evidence updated: yes
- Out of scope: Monaco file/diff viewing, and wiring these as first-class ADR-0003 pane types. See Residual Risk.

## Version Impact

- Version: no version change because this is renderer and Electron main behavior inside an unpublished package
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 049517f45c14456e352d5e5f174ef98405c8303d
- Branch merge-base with `origin/main`: 049517f45c14456e352d5e5f174ef98405c8303d
- Last `git fetch origin` time: 2026-08-23T19:25:53Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: task package `artifacts/` holds `before.png`, `after.png`, `html-night-report.png`, `before-after-measurements.md`, and `worker-report.md`
- Reviewer evidence path: same task package `artifacts/`
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `npm run check:local` — passed, 46 steps, re-run independently by the reviewer at `aea375662`
- [x] `npm run test:gui` — passed, 42 files / 349 tests
- [x] `git diff --check`
- Not run: `npm ci` (no dependency change; `package.json` and `package-lock.json` are untouched). The individual `harness:check-*` commands were not invoked one by one because `check:local` runs them as its own steps; `npm run test:integration` and the GUI e2e job are left to CI, which is the authority for both.

### Measurements

Measured in a hermetic fixture at a fixed 1440x920 viewport, before and after on the same document:

| Item | Before | After | Change |
| --- | --- | --- | --- |
| Top chrome height | 258px | 50.25px | -80.5% |
| Reading column width | 588px | 932px | +58.5% |
| Tab row height | 39.5px | 28px | -29.1% |

## Review Evidence

- Self-review: the reviewer re-ran both gates on this exact commit in a clean worktree rather than trusting the implementer's report, and read the full `packages/gui/src/main/**` diff against `dec_01KXTS73HANF1JHBKS95P9EDX7`.
- Reviewer subagent: none; the security surface was reviewed by the reviewer directly.
- Human review: pending.
- Blocking findings: none.

The requirement this change is measured against is "old Task documents must open too". The implementer argued it structurally — same code path for old and new — which is a claim about shape, not about behavior, so it was checked directly against the projection the GUI reads:

- All 1534 tasks in the projection carry a `packagePath`; none is null. This matters because `listProjectedTaskDocuments` throws `task_not_found` on a null `packagePath`, so deleting the `task.docs` fallback would have turned a stale index into a hard failure if even one task lacked it.
- Because `packagePath` is always present, the deleted fallback was already unreachable for every task in the projection. It was dead code, not a live compatibility path.
- All 1538 task packages have projected documents, 21220 rows in total. The oldest package, created 2026-06-14, has all six of its documents in the projection, so the tree and the reader have real content to show for old tasks.

## Residual Risk

- `dec_01KXTS73HANF1JHBKS95P9EDX7` says these viewers should arrive as new pane types in the ADR-0003 pane tree, depending on the W-C1 tab infrastructure. That infrastructure does not exist in the codebase yet, so this lands as a component inside the Task detail page instead. This is a placement gap against the decision, not a contradiction of it: nothing here creates a pane descriptor, a tab store, or a second HTML engine, and when the pane tree arrives this thin view should be retired rather than kept alongside it.
- The Monaco half of the same decision is untouched and remains unimplemented.
- `webviewTag` is now enabled on the main window. It was previously off, so this widens what a compromised renderer could attempt. The mitigation is that attachment is gated on an exact partition and source-prefix match and the main process overwrites the guest's preferences, so a renderer compromise cannot choose the guest's capabilities — but the attack surface is larger than it was.
- The single/double column requirement came from a voice transcript with a known transcription ambiguity. It is implemented as the most conservative reading — one document reflowed into one or two columns — rather than a two-document comparison view. If the original intent was comparison, that is a follow-up, not a defect in this change.

## References

- Task: task_ca3f4f00dc414ac324ab35f782
- Evidence: task package `artifacts/before-after-measurements.md` and `worker-report.md`
- Review: this PR body

---

# 中文

## 概要

把 Task 详情页做成文档阅读器。此前这个页面把大部分纵向空间花在外壳上——九项身份信息栅格加一行很高的 tab；正文则被渲染进一个 42rem 的窄栏里，而外面的容器要宽得多，于是表格和代码块折行，周围的页面却空着。HTML 产物则完全打不开。

顶部外壳从 258px 降到 50.25px，正文栏从 588px 加宽到 932px，六个 tab 一个不少但高度从 39.5px 收到 28px。投影出来的文档树从第六个 tab 里挪出来，成为常驻左栏。单栏/双栏、字体族、字号三个控制放在悬浮工具条上。HTML 产物在一个禁用脚本的隔离 Electron guest 里渲染。

## 改动内容

- `TaskDetailView.tsx`：九项身份栅格收进一个按钮后的可展开面板——身份数据是被收起来，不是被删掉；tab 行收到 `h-8 px-2 text-[11px]`，六个 tab 全部保留；文档树成为常驻左栏，切换文档时不卸载，所以目录展开态不会丢。
- `DocReader.tsx` + `styles.css`：`.prose-harness` 去掉容器级的 `max-width: 42rem`，改为只给正文块（`h1..h4, p, ul, ol, blockquote`）设 `88ch` 上限。这样连续文字仍有可读行长，而表格、代码块、图表能吃满宽度。新增基于 CSS columns 的 `double` 布局，以及读者可控的字体族与字号。
- `TaskFilesTab.tsx`：删掉「按有没有 `packagePath` 区别对待新旧任务」的分支，以及它回退用的 renderer 侧 `task.docs` 老索引。新旧任务包现在走同一条 `repo.tasks.documents.list` 投影，没有兼容层。
- `HtmlArtifactPreview.tsx` + `html-artifact-policy.ts` + `main/electron-main.ts` + `main/security-policy.ts` + `main/window-config.ts`：按 `dec_01KXTS73HANF1JHBKS95P9EDX7` 落地 HTML 产物渲染。宿主页 CSP 未改。内容只来自既有的 `repo.tasks.document.read` 读面，变成 guest 里的一次 `data:text/html` 导航，guest 有自己的 session 分区。

没有新增任何 daemon 读面、CLI 命令面或 preload allowlist 条目，也没有删除或合并任何一个 Task tab。

### 这个 HTML 预览为什么是安全的

renderer 没法让 guest 指向任意地方。`will-attach-webview` 只在分区恰好是 `html-artifact-preview`、且源以 `data:text/html;charset=utf-8,` 开头时才允许挂载；即便走到允许分支，主进程也不信任标签上写的偏好，而是覆盖它——强制 `javascript=false`、`sandbox=true`、`contextIsolation=true`、三个 `nodeIntegration*` 全关、不注入 preload。

脚本关掉之后主动外传的路子就没了；被动的那些则堵在 session 而不是逐个标签上：guest 分区会取消任何协议不是 `data:` 或 `about:` 的请求，拒绝全部权限申请，并阻止下载。导航四种形态（`will-navigate`、`will-frame-navigate`、`will-redirect`、window open）全部拦下。

## 机读声明说明

生产增删已在英文块顶格声明一次；本 PR 未改动任何 `package.json` 或 `package-lock.json`，因此删除依赖变化行；未保留旧路径，未做 evidence claim。

## 任务与范围

- Harness 任务：task_ca3f4f00dc414ac324ab35f782
- 分支：codex/task-reader
- 公开范围：`packages/gui/src/renderer/**`、`packages/gui/src/main/**`、`packages/gui/src/api/html-artifact-policy.ts`、`packages/gui/src/index.ts`、`packages/gui/test/**`、`packages/gui/tsconfig.renderer.json`
- 私有计划 / 证据是否已更新：yes
- 范围外：Monaco 文件/diff 查看，以及把这两者接成 ADR-0003 的一等 pane 类型。见残余风险。

## 版本影响

- 版本：不改版本，原因是这是未发布包内的 renderer 与 Electron main 行为
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no

## 验证

- `origin/main` 基准 SHA：049517f45c14456e352d5e5f174ef98405c8303d
- 当前分支与 `origin/main` 的 merge-base：049517f45c14456e352d5e5f174ef98405c8303d
- 最近一次 `git fetch origin` 时间：2026-08-23T19:25:53Z
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...HEAD`
- 私有证据 commit/path：任务包 `artifacts/` 下的 `before.png`、`after.png`、`html-night-report.png`、`before-after-measurements.md`、`worker-report.md`
- Reviewer 证据路径：同一任务包 `artifacts/`
- GitHub Actions `rewrite-ci` run URL：本 PR 上待出
- [x] `npm run check:local` —— 通过，46 步，由复核方在 `aea375662` 上独立重跑
- [x] `npm run test:gui` —— 通过，42 个文件 / 349 个用例
- [x] `git diff --check`
- 未运行：`npm ci`（无依赖变化，`package.json` 与 `package-lock.json` 均未动）。那些 `harness:check-*` 命令没有逐条单独调用，因为 `check:local` 已把它们作为自己的步骤跑完；`npm run test:integration` 与 GUI e2e job 留给 CI，CI 是这两者的权威。

### 实测数据

在固定 1440x920 视口的 hermetic fixture 里，对同一份文档改前改后各测一次：

| 项目 | 改前 | 改后 | 变化 |
| --- | --- | --- | --- |
| 顶部外壳高度 | 258px | 50.25px | -80.5% |
| 正文栏宽度 | 588px | 932px | +58.5% |
| tab 行高度 | 39.5px | 28px | -29.1% |

## 审查证据

- 自查：复核方没有采信实现方的报告，而是在干净 worktree 里对着这个 commit 独立重跑了两个门，并对照 `dec_01KXTS73HANF1JHBKS95P9EDX7` 通读了 `packages/gui/src/main/**` 的完整 diff。
- Reviewer subagent：无；安全面由复核方亲自审。
- 人工审查：待做。
- 阻塞发现：无。

本次改动要对齐的需求里有一条是「老 Task 文档也必须能打开」。实现方给的是结构论证——新旧走同一条代码路径——那是关于形状的断言，不是关于行为的断言，所以直接对着 GUI 实际读的那份投影验了一遍：

- 投影里 1534 个 task 全部带 `packagePath`，没有一个为空。这一点是承重的：`listProjectedTaskDocuments` 在 `packagePath` 为空时会抛 `task_not_found`，所以只要有一个 task 缺它，删掉 `task.docs` 回退就会把「索引陈旧」变成「直接打不开」。
- 正因为 `packagePath` 恒在，被删掉的那条回退对投影里的每一个 task 本来就不可达。它是死代码，不是活着的兼容路径。
- 1538 个任务包在投影里都有文档行，合计 21220 条。最老的那个包（2026-06-14 建）六份文档全在投影里，所以老任务的树和阅读器确实有真实内容可显示。

## 残余风险

- `dec_01KXTS73HANF1JHBKS95P9EDX7` 写的是这两个查看器应当作为 ADR-0003 pane tree 的新 pane 类型落地，依赖 W-C1 的 tab 基建。那套基建目前在代码里还不存在，所以本次落在 Task 详情页内部的一个组件里。这是相对该决策的**落点差距**，不是与它相悖：这里没有创建任何 pane descriptor、tab store，也没有第二套 HTML 引擎；等 pane tree 建起来，应当退役这个薄视图，而不是让两者并存。
- 同一个决策里 Monaco 那一半没有动，仍未实现。
- 主窗口现在开了 `webviewTag`，之前是关的，所以一个被攻陷的 renderer 能尝试的动作变多了。缓解在于挂载要同时匹配精确分区与源前缀，且主进程会覆盖 guest 的偏好，renderer 被攻陷也选不了 guest 的能力——但攻击面确实比以前大。
- 单栏/双栏这条需求来自一段语音转写，且已知转写有歧义。这里按最保守的读法实现——同一份文档重排成一栏或两栏——而不是双文档对比视图。如果原意是对比，那是后续任务，不是本次改动的缺陷。

## 关联材料

- 任务：task_ca3f4f00dc414ac324ab35f782
- 证据：任务包 `artifacts/before-after-measurements.md` 与 `worker-report.md`
- 审查：本 PR 正文
