### PR TITLE
refactor(gui): narrow projected document mapping to its live half

### DIFF
--- a/packages/gui/src/renderer/components/taskDetail/TaskFilesTab.tsx
+++ b/packages/gui/src/renderer/components/taskDetail/TaskFilesTab.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from "react";
 import { CaretRight, FileText } from "@phosphor-icons/react";
 import { DocReader } from "../DocReader.tsx";
 import { HtmlArtifactPreview } from "../HtmlArtifactPreview.tsx";
-import { buildDocTree, mergeProjectedDocuments } from "../../model/docTree.ts";
+import { buildDocTree, projectedDocuments } from "../../model/docTree.ts";
 import type { TaskRow } from "../../model/types.ts";
 import { useTaskDocumentListQuery, useTaskDocumentQuery } from "../../task-data.ts";
 import { DocTree } from "./DocTree.tsx";
@@ -25,7 +25,7 @@ export function TaskDocumentSidebar({
     const projected = documentList.data?.status === "ready"
       ? documentList.data.documents.map((document) => document.path)
       : [];
-    return mergeProjectedDocuments([], projected);
+    return projectedDocuments(projected);
   }, [documentList.data]);
   const tree = useMemo(() => buildDocTree(documents), [documents]);
 

--- a/packages/gui/src/renderer/model/docTree.ts
+++ b/packages/gui/src/renderer/model/docTree.ts
@@ -29,19 +29,16 @@ interface TrieNode {
   children: Map<string, TrieNode>;
 }
 
-/**
- * 合同槽位文档 + 投影清单:同一 path 以合同条目为准(保留 required/分组语义),
- * 只在投影里出现的文件(artifacts/ 等)补为已存在的文档条目。
- */
-export function mergeProjectedDocuments(
-  contractDocs: ReadonlyArray<DocEntry>,
-  projectedPaths: ReadonlyArray<string>,
-): DocEntry[] {
-  const known = new Set(contractDocs.map((doc) => doc.path));
-  const extras = projectedPaths
-    .filter((path) => !known.has(path))
-    .map((path) => ({ path, title: path.split("/").at(-1) ?? path, group: inferDocGroup(path), required: false, present: true, presence: "present" as const }));
-  return [...contractDocs, ...extras];
+/** 投影清单 → 文档条目。投影列出的文件都在磁盘上,所以恒为 present 且非 required。 */
+export function projectedDocuments(projectedPaths: ReadonlyArray<string>): DocEntry[] {
+  return projectedPaths.map((path) => ({
+    path,
+    title: path.split("/").at(-1) ?? path,
+    group: inferDocGroup(path),
+    required: false,
+    present: true,
+    presence: "present" as const,
+  }));
 }
 
 /** 投影补充文件的分组:artifacts/ 归证据,其余归进度(仅作面包屑标签,导航已改用目录树)。 */

--- a/packages/gui/test/docTree.vitest.ts
+++ b/packages/gui/test/docTree.vitest.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildDocTree,
   collectDirectoryPaths,
-  mergeProjectedDocuments,
+  projectedDocuments,
 } from "../src/renderer/model/docTree.ts";
 import type { DocEntry } from "../src/renderer/model/types.ts";
 
@@ -205,23 +205,15 @@ describe("collectDirectoryPaths", () => {
 });
 
 
-describe("mergeProjectedDocuments (contract ∪ projection)", () => {
-  it("adds projection-only files (artifacts/) as present docs, contract entries win on collision", () => {
-    const merged = mergeProjectedDocuments(
-      [doc("task_plan.md", { required: true, present: false, group: "计划" })],
-      ["task_plan.md", "artifacts/report.md", "artifacts/orchestration/notes.md"],
-    );
-    expect(merged).toHaveLength(3);
-    const contract = merged.find((entry) => entry.path === "task_plan.md");
-    expect(contract?.required).toBe(true);
-    expect(contract?.present).toBe(false);
-    const artifacts = merged.filter((entry) => entry.path.startsWith("artifacts/"));
-    expect(artifacts.every((entry) => entry.present && !entry.required && entry.group === "证据")).toBe(true);
-    expect(artifacts.map((entry) => entry.title)).toEqual(["report.md", "notes.md"]);
+describe("projectedDocuments", () => {
+  it("titles each entry by basename and groups artifacts/ apart from the rest", () => {
+    const entries = projectedDocuments(["task_plan.md", "artifacts/report.md", "artifacts/orchestration/notes.md"]);
+    expect(entries.map((entry) => entry.title)).toEqual(["task_plan.md", "report.md", "notes.md"]);
+    expect(entries.map((entry) => entry.group)).toEqual(["进度", "证据", "证据"]);
+    expect(entries.every((entry) => entry.present && !entry.required)).toBe(true);
   });
 
-  it("empty projection keeps contract docs untouched", () => {
-    const contract = [doc("INDEX.md", { required: true })];
-    expect(mergeProjectedDocuments(contract, [])).toEqual(contract);
+  it("returns nothing for an empty projection", () => {
+    expect(projectedDocuments([])).toEqual([]);
   });
 });


### PR DESCRIPTION
# English

## Summary

Removes a dead compatibility path that the gates could not see, because two tests were keeping it alive.

`mergeProjectedDocuments(contractDocs, projectedPaths)` existed to merge a renderer-side contract document list with the projected document list. PR #1759 deleted the branch that supplied `contractDocs`, so its only production caller began passing `[]` unconditionally. With an empty contract list the function degenerates: `known` stays empty, `extras` always equals every projected path, and the return value always equals `extras`. The merge half — the entire reason the function took two arguments — became unreachable.

It still looked alive under the gates because `packages/gui/test/docTree.vitest.ts` kept two tests that called it with a non-empty contract list. A test that reaches a production-unreachable code path does not just fail to catch the dead code; it actively certifies it.

## What Changed

- `packages/gui/src/renderer/model/docTree.ts`: `mergeProjectedDocuments(contractDocs, projectedPaths)` becomes `projectedDocuments(projectedPaths)`, which is what the single production caller was already asking for — map each projected path to a document entry, title it by basename, group `artifacts/` apart from the rest, and mark it present and not required.
- `packages/gui/src/renderer/components/taskDetail/TaskFilesTab.tsx`: calls the narrowed function; the `[]` argument that carried no information is gone.
- `packages/gui/test/docTree.vitest.ts`: the two tests that exercised the unreachable merge behaviour are replaced by two that assert what the production caller actually depends on.

No behaviour changes for any user of the file tree. The rendered document list is identical, because `[...[], ...extras]` and `extras` are the same list.

### How this was found

This came out of answering the "Same Mechanism Elsewhere" question in the closeout of `task_ca3f4f00dc414ac324ab35f782`, rather than from a gate or a review comment. The mechanism sentence written there was: a compatibility branch whose predicate is constant across all real data, so its other side has never executed. Searching the repository for that shape rather than for the symptom found this one sibling, one layer below the branch that had just been deleted and in the same file that had just been changed — the branch was removed but the function that existed to serve it was left behind.

## Machine-Readable Declarations

Production-Delta: +12/-15

## Task And Scope

- Harness task: task_ca3f4f00dc414ac324ab35f782 (found while closing out; recorded in that task's `closeout.md`)
- Branch: codex/dead-merge-param
- Public scope: `packages/gui/src/renderer/model/docTree.ts`, `packages/gui/src/renderer/components/taskDetail/TaskFilesTab.tsx`, `packages/gui/test/docTree.vitest.ts`
- Private planning/evidence updated: yes
- Out of scope: any other renderer fallback. The same search surfaced `packages/gui/src/renderer/runtime-panorama.ts:26`, whose comment mentions an association fallback; it was checked and is a live presentation fallback with a non-constant predicate, so it is not the same mechanism and is deliberately untouched.

## Version Impact

- Version: no version change because this is an internal rename and narrowing inside an unpublished package
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 2455632fd0e2a0aa3949c0579896ad1987931289
- Branch merge-base with `origin/main`: 2455632fd0e2a0aa3949c0579896ad1987931289
- Last `git fetch origin` time: 2026-08-23T19:36:00Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: `closeout.md` of `task_ca3f4f00dc414ac324ab35f782`, section "Same Mechanism Elsewhere"
- Reviewer evidence path: same
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [x] `npm run check:local` — passed, fast tier, 90.3s
- [x] `npm run test:gui` — passed, 42 files / 349 tests
- [x] `git diff --check`
- Not run: `npm ci` (no dependency change). `npm run test:integration` and the GUI e2e job are left to CI, which is the authority for both.

## Review Evidence

- Self-review: the claim that the merge half is unreachable was checked against every caller in the repository, not inferred. `grep -rn "mergeProjectedDocuments("` returns exactly three sites before this change: the definition, one production caller passing `[]`, and the test file. After the change the test suite still passes at the same count, 349, which is expected — the two deleted tests are replaced by two new ones.
- Reviewer subagent: none.
- Human review: pending.
- Blocking findings: none.

## Residual Risk

- If a future feature reintroduces a contract-side document list, this function will need a second argument again. That is the correct order of events: the merge belongs to the change that has a second list to merge, not kept warm by tests in the meantime.

## References

- Task: task_ca3f4f00dc414ac324ab35f782
- Evidence: that task's `closeout.md`, section "Same Mechanism Elsewhere"
- Review: this PR body

---

# 中文

## 概要

删掉一条门看不见的死兼容路径——门看不见,是因为有两个测试在替它作证。

`mergeProjectedDocuments(contractDocs, projectedPaths)` 的存在意义是把 renderer 侧的合同文档清单和投影文档清单并到一起。PR #1759 删掉了提供 `contractDocs` 的那条分支,于是它唯一的生产调用方开始无条件传 `[]`。合同清单为空之后这个函数就退化了:`known` 恒空,`extras` 恒等于全部投影路径,返回值恒等于 `extras`。**「合并」那一半——也就是这个函数需要两个参数的全部理由——变得不可达。**

它在门下看起来还活着,是因为 `packages/gui/test/docTree.vitest.ts` 留着两个用非空合同清单调用它的用例。**一个够得到生产不可达路径的测试,不只是没抓住死代码,它是在主动为死代码作证。**

## 改动内容

- `packages/gui/src/renderer/model/docTree.ts`:`mergeProjectedDocuments(contractDocs, projectedPaths)` 收窄成 `projectedDocuments(projectedPaths)` —— 这正是那个唯一的生产调用方本来要的:把每条投影路径映射成一个文档条目,标题取文件名,`artifacts/` 与其余分组,恒为 present 且非 required。
- `packages/gui/src/renderer/components/taskDetail/TaskFilesTab.tsx`:改调收窄后的函数;那个不携带任何信息的 `[]` 实参没了。
- `packages/gui/test/docTree.vitest.ts`:两个走不可达合并行为的用例,换成两个断言生产调用方真正依赖的行为的用例。

对文件树的任何使用者都没有行为变化。渲染出来的文档清单一模一样,因为 `[...[], ...extras]` 和 `extras` 是同一个列表。

### 这是怎么找到的

它不是门报出来的,也不是评审提的,而是**认真回答 `task_ca3f4f00dc414ac324ab35f782` 销账文档里那道「Same Mechanism Elsewhere」问题的产物**。当时写下的机制句是:一条兼容分支的判据在全部真实数据上恒为同一值,所以它的另一支从来没有被执行过。按这个形状而不是按症状去搜仓库,捞到了这一个兄弟——就在刚被删掉的那条分支下面一层,而且在刚被改过的同一个文件里:**分支删了,但这条分支存在的理由被留下来了。**

## 机读声明说明

生产增删已在英文块顶格声明一次;本 PR 未改动任何 `package.json` 或 `package-lock.json`,因此删除依赖变化行;未保留旧路径,未做 evidence claim。

## 任务与范围

- Harness 任务:task_ca3f4f00dc414ac324ab35f782(销账时发现,记在该任务的 `closeout.md` 里)
- 分支:codex/dead-merge-param
- 公开范围:`packages/gui/src/renderer/model/docTree.ts`、`packages/gui/src/renderer/components/taskDetail/TaskFilesTab.tsx`、`packages/gui/test/docTree.vitest.ts`
- 私有计划 / 证据是否已更新:yes
- 范围外:renderer 里其它回退。同一次搜索还捞到 `packages/gui/src/renderer/runtime-panorama.ts:26` 那条注释里提到的 association fallback;核过了,那是活的展示层回退、判据不恒定,**不是**同一个机制,故意不动。

## 版本影响

- 版本:不改版本,原因是这是未发布包内的内部重命名与收窄
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:不适用
- 依据:不适用
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no

## 验证

- `origin/main` 基准 SHA:2455632fd0e2a0aa3949c0579896ad1987931289
- 当前分支与 `origin/main` 的 merge-base:2455632fd0e2a0aa3949c0579896ad1987931289
- 最近一次 `git fetch origin` 时间:2026-08-23T19:36:00Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:`task_ca3f4f00dc414ac324ab35f782` 的 `closeout.md`「Same Mechanism Elsewhere」一节
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:本 PR 上待出
- [x] `npm run check:local` —— 通过,fast tier,90.3s
- [x] `npm run test:gui` —— 通过,42 个文件 / 349 个用例
- [x] `git diff --check`
- 未运行:`npm ci`(无依赖变化)。`npm run test:integration` 与 GUI e2e job 留给 CI,CI 是这两者的权威。

## 审查证据

- 自查:「合并那一半不可达」这个断言是**查过全仓每一个调用方**得出的,不是推理出来的。改动前 `grep -rn "mergeProjectedDocuments("` 恰好返回三处:定义、一个传 `[]` 的生产调用方、以及测试文件。改动后测试总数仍是 349,这符合预期——删掉的两个用例由两个新用例替上。
- Reviewer subagent:无。
- 人工审查:待做。
- 阻塞发现:无。

## 残余风险

- 如果将来有功能重新引入合同侧文档清单,这个函数会需要第二个参数。**这才是正确的先后:合并属于那个真的有第二份清单要合的改动,而不是靠测试在这期间替它保温。**

## 关联材料

- 任务:task_ca3f4f00dc414ac324ab35f782
- 证据:该任务 `closeout.md` 的「Same Mechanism Elsewhere」一节
- 审查:本 PR 正文
