### PR TITLE
fix(gui): show freshly created tasks in the overview without touching a status tab

### DIFF
--- a/packages/gui/src/renderer/components/overview/TaskStream.tsx
+++ b/packages/gui/src/renderer/components/overview/TaskStream.tsx
@@ -7,12 +7,64 @@ import { STATUS_META, StatusBadge } from "../badges.tsx";
 import { t } from "../../i18n/index.tsx";
 import { StreamBody, StreamEmpty, StreamExitButton, StreamTabs, streamTime } from "./streamParts.tsx";
 
+const ROW_CLASS =
+  "flex w-full items-center gap-2 rounded-md border border-border bg-surface-raised px-2 py-1 text-left" +
+  " transition-colors duration-100 [contain-intrinsic-size:auto_1.75rem] [content-visibility:auto]" +
+  " hover:border-accent/60";
+
+/** 流里的一行:主行集与「更新的」行集共用,两处的状态表达必须逐字一致。 */
+function TaskStreamRow({ task, onOpenPreview }: { task: TaskRow; onOpenPreview: (taskId: string) => void }) {
+  return (
+    <button
+      type="button"
+      onClick={() => onOpenPreview(task.taskId)}
+      title={`${task.taskId} · ${task.title}`}
+      className={ROW_CLASS}
+    >
+      <span className="shrink-0 text-[13px]" style={{ color: STATUS_META[task.coordinationStatus].color }}>
+        {STATUS_META[task.coordinationStatus].icon}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-text">{task.title}</span>
+      <StatusBadge status={task.coordinationStatus} />
+      <span className="shrink-0 font-mono text-[11px] tabular-nums text-text-faint">
+        {streamTime(taskCreatedAt(task))}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * 「比当前筛选里最新那行更新」的任务 —— 状态筛选之外、但时间上排在你看得见的
+ * 东西之前的那些行。刚 `ha task create` 出来的任务恒为 `planned`,默认筛选恒为
+ * `active`,两者不相交(fact F-266F2F09);这一组就是让它不必先点标签也能被看见的行集。
+ *
+ * 判定只认**已知创建时间**:`createdAt` 为 null 的任务(没有可靠 task_bootstrapped
+ * 的导入任务)无法被证明更新,按 ledger-timeline 的约定排尾部、不得从 ID 推时间,
+ * 所以永不进这一组。当前筛选没有任何一行带已知创建时间(含筛选为空)时阈值退化为
+ * 无阈值——那正是「全新仓库刚建第一条任务、active 为空」的场景。
+ */
+export function tasksAheadOfStatus(tasks: ReadonlyArray<TaskRow>, status: SnapshotStatus): TaskRow[] {
+  const newestVisible = tasks.reduce<string | null>((newest, task) => {
+    if (task.coordinationStatus !== status) return newest;
+    const at = taskCreatedAt(task);
+    return at !== null && (newest === null || at > newest) ? at : newest;
+  }, null);
+  return sortTasksByCreatedDesc(tasks.filter((task) => {
+    if (task.coordinationStatus === status) return false;
+    const at = taskCreatedAt(task);
+    return at !== null && (newestVisible === null || at > newestVisible);
+  }));
+}
+
 /**
  * 总览「任务流」:合并原「现在在跑什么」与「任务流」两格。
  * 状态切换是**就地筛选**——点哪个状态,本格数据源换成该状态的任务瀑布流,
  * 路由不动;「去看板」是唯一的显式路由出口,带当前状态预置。
  * Tab counts are rendered verbatim from the daemon workspace summary.
  * 排序 = task_bootstrapped 创建时间倒序;内部滚动,不截断。
+ * 流首那一组是 `tasksAheadOfStatus` 派生的「更新的」行:没有独立筛选/排序/状态,
+ * 不可能显示当前标签本来就会显示的行,当前标签已含最新行时它为空 —— 所以它不是
+ * 第二条任务流(O-02),而是同一条流对「你还没看见更新的东西」的诚实交代。
  */
 export function TaskStream({
   tasks,
@@ -30,6 +82,7 @@ export function TaskStream({
     () => sortTasksByCreatedDesc(tasks.filter((task) => task.coordinationStatus === status)),
     [tasks, status],
   );
+  const ahead = useMemo(() => tasksAheadOfStatus(tasks, status), [tasks, status]);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-2">
@@ -50,25 +103,27 @@ export function TaskStream({
           onClick={() => onGoBoard(status)}
         />
       </div>
+      {ahead.length > 0 && (
+        <div
+          data-testid="task-stream-ahead"
+          className="shrink-0 rounded-md border border-dashed border-accent/50 bg-surface/40 p-1"
+        >
+          <p className="px-1 pb-1 font-mono text-[11px] text-text-muted" data-testid="task-stream-ahead-label">
+            {t("views.overviewView.taskAhead", { count: ahead.length })}
+          </p>
+          <div className="max-h-[6rem] space-y-0.5 overflow-y-auto pr-1" data-testid="task-stream-ahead-rows">
+            {ahead.map((task) => (
+              <TaskStreamRow key={task.taskId} task={task} onOpenPreview={onOpenPreview} />
+            ))}
+          </div>
+        </div>
+      )}
       {rows.length === 0 ? (
         <StreamEmpty>{t("views.overviewView.taskEmpty")}</StreamEmpty>
       ) : (
         <StreamBody testId="task-stream-rows">
           {rows.map((task) => (
-            <button
-              key={task.taskId}
-              type="button"
-              onClick={() => onOpenPreview(task.taskId)}
-              title={`${task.taskId} · ${task.title}`}
-              className="flex w-full items-center gap-2 rounded-md border border-border bg-surface-raised px-2 py-1 text-left transition-colors duration-100 [contain-intrinsic-size:auto_1.75rem] [content-visibility:auto] hover:border-accent/60"
-            >
-              <span className="shrink-0 text-[13px]" style={{ color: STATUS_META[task.coordinationStatus].color }}>
-                {STATUS_META[task.coordinationStatus].icon}
-              </span>
-              <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-text">{task.title}</span>
-              <StatusBadge status={task.coordinationStatus} />
-              <span className="shrink-0 font-mono text-[11px] tabular-nums text-text-faint">{streamTime(taskCreatedAt(task))}</span>
-            </button>
+            <TaskStreamRow key={task.taskId} task={task} onOpenPreview={onOpenPreview} />
           ))}
         </StreamBody>
       )}

--- a/packages/gui/src/renderer/i18n/locales/en-US/views.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/views.json
@@ -225,6 +225,7 @@
   "views.overviewView.runtimeHealthTitle": "Runtime health",
   "views.overviewView.decisionEmpty": "No decisions in this state.",
   "views.overviewView.taskEmpty": "No tasks in this status.",
+  "views.overviewView.taskAhead": "{count} newer · outside this status filter",
   "views.overviewView.pinnedEmpty": "No pinned tasks right now.",
   "views.overviewView.pinnedHint": "Mark what you are working on with ha task pin <task-id>.",
   "views.overviewView.goInbox": "Judge queue",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/views.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/views.json
@@ -225,6 +225,7 @@
   "views.overviewView.runtimeHealthTitle": "运行时健康",
   "views.overviewView.decisionEmpty": "该状态下暂无决策。",
   "views.overviewView.taskEmpty": "该状态下暂无任务。",
+  "views.overviewView.taskAhead": "更新的 {count} 条 · 不在当前状态筛选内",
   "views.overviewView.pinnedEmpty": "当前没有 pin 的任务。",
   "views.overviewView.pinnedHint": "用 ha task pin <task-id> 标记你正在做的任务。",
   "views.overviewView.goInbox": "去批准",

--- a/packages/gui/test/overview-streams.vitest.ts
+++ b/packages/gui/test/overview-streams.vitest.ts
@@ -4,7 +4,7 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { DecisionRow, TaskRow } from "../src/renderer/model/types.ts";
 import { DecisionStream } from "../src/renderer/components/overview/DecisionStream.tsx";
-import { TaskStream } from "../src/renderer/components/overview/TaskStream.tsx";
+import { TaskStream, tasksAheadOfStatus } from "../src/renderer/components/overview/TaskStream.tsx";
 import { BoardView } from "../src/renderer/views/BoardView.tsx";
 import { SwimlaneBoard } from "../src/renderer/views/SwimlaneBoard.tsx";
 import { OverviewView } from "../src/renderer/views/OverviewView.tsx";
@@ -224,6 +224,118 @@ describe("overview task stream", () => {
       onGoBoard: noop,
     }));
     expect(markup).toContain("该状态下暂无任务");
+  });
+});
+
+// O-01(乙)/ 不变量 1:`ha task create` 建出来的任务恒为 planned(kernel create transition),
+// 总览任务流默认标签恒为 active,两者不相交(fact F-266F2F09)——于是新任务必须先点标签才看得见。
+// 这一组把「零动作可见」钉住:把 TaskStream 的行集改回「只显示当前标签的状态」(删掉流首那组
+// 更新的行)会让 "surfaces the freshly created planned task" 立刻红。
+describe("overview task stream: freshly created tasks are visible with zero interaction", () => {
+  // 只保留 button/span 的区块可以用非贪婪到第一个 </div> 截断:行本身不含 div。
+  const section = (markup: string, testId: string): string | null => {
+    const found = markup.match(new RegExp(`data-testid="${testId}"[^>]*>([\\s\\S]*?)</div>`, "u"));
+    return found === null ? null : found[1]!;
+  };
+  const freshWorkspace = () => [
+    task({ taskId: "task_old_active", title: "Older active task", coordinationStatus: "active", createdAt: "2026-08-20T10:00:00.000Z" }),
+    task({ taskId: "task_new_planned", title: "Just created task", coordinationStatus: "planned", createdAt: "2026-08-22T09:30:00.000Z" }),
+  ];
+
+  it("surfaces the freshly created planned task in the default view without touching a status tab", () => {
+    const markup = renderToStaticMarkup(createElement(TaskStream, {
+      tasks: freshWorkspace(), summary: taskSummary({ active: 1, planned: 1 }), onOpenPreview: noop, onGoBoard: noop,
+    }));
+    // 不变量 1:零交互的默认渲染里就有它,而且在可视区域顶部(流首,主行集之前),不在折叠区。
+    expect(markup).toContain("Just created task");
+    expect(markup.indexOf('data-testid="task-stream-ahead"')).toBeLessThan(markup.indexOf('data-testid="task-stream-rows"'));
+    const ahead = section(markup, "task-stream-ahead-rows");
+    expect(ahead).not.toBeNull();
+    expect(ahead).toContain("Just created task");
+    // 可点开:与主行集同一个 button 行,带 taskId 的 title,不是纯文本。
+    expect(ahead).toMatch(/<button[^>]*title="task_new_planned · Just created task"/u);
+    expect(markup).toContain("更新的 1 条");
+  });
+
+  it("keeps the active default and the active-only main rows (invariant 3: 看在做的任务仍是 0 动作)", () => {
+    const markup = renderToStaticMarkup(createElement(TaskStream, {
+      tasks: freshWorkspace(), summary: taskSummary({ active: 1, planned: 1 }), onOpenPreview: noop, onGoBoard: noop,
+    }));
+    expect(markup).toMatch(/aria-selected="true" data-testid="overview-status-active"/u);
+    expect(markup).toMatch(/aria-selected="false" data-testid="overview-status-planned"/u);
+    const rows = section(markup, "task-stream-rows");
+    expect(rows).toContain("Older active task");
+    expect(rows).not.toContain("Just created task");
+  });
+
+  it("shows the new task under its real status word, not disguised as active (invariant 4)", () => {
+    const markup = renderToStaticMarkup(createElement(TaskStream, {
+      tasks: freshWorkspace(), summary: taskSummary({ active: 1, planned: 1 }), onOpenPreview: noop, onGoBoard: noop,
+    }));
+    expect(section(markup, "task-stream-ahead-rows")).toContain("计划中");
+    // census 逐字照抄 daemon,不因为「让它可见」而被改写。
+    expect(tabText(markup, "overview-status-active")).toBe("进行中 1");
+    expect(tabText(markup, "overview-status-planned")).toBe("计划中 1");
+  });
+
+  it("surfaces the first task of a brand-new workspace where the active filter is empty", () => {
+    const markup = renderToStaticMarkup(createElement(TaskStream, {
+      tasks: [task({ taskId: "task_first", title: "First ever task", coordinationStatus: "planned", createdAt: "2026-08-22T09:30:00.000Z" })],
+      summary: taskSummary({ planned: 1 }), onOpenPreview: noop, onGoBoard: noop,
+    }));
+    expect(section(markup, "task-stream-ahead-rows")).toContain("First ever task");
+    // 空态照旧诚实:当前状态确实没有任务。
+    expect(markup).toContain("该状态下暂无任务");
+  });
+
+  it("never promotes rows whose creation time is unknown (ledger-timeline: 不从 ID 推时间)", () => {
+    const markup = renderToStaticMarkup(createElement(TaskStream, {
+      tasks: [
+        task({ taskId: "task_a1", title: "Active one", coordinationStatus: "active", createdAt: null }),
+        task({ taskId: "task_b1", title: "Blocked unknown time", coordinationStatus: "blocked", createdAt: null }),
+      ],
+      summary: taskSummary({ active: 1, blocked: 1 }), onOpenPreview: noop, onGoBoard: noop,
+    }));
+    expect(markup).not.toContain('data-testid="task-stream-ahead"');
+    expect(markup).not.toContain("Blocked unknown time");
+  });
+
+  it("stays silent when the newest task already sits in the selected status", () => {
+    const markup = renderToStaticMarkup(createElement(TaskStream, {
+      tasks: [
+        task({ taskId: "task_new_active", title: "Newest active", coordinationStatus: "active", createdAt: "2026-08-22T09:30:00.000Z" }),
+        task({ taskId: "task_old_done", title: "Older done", coordinationStatus: "done", createdAt: "2026-08-19T09:30:00.000Z" }),
+      ],
+      summary: taskSummary({ active: 1, done: 1 }), onOpenPreview: noop, onGoBoard: noop,
+    }));
+    expect(markup).not.toContain('data-testid="task-stream-ahead"');
+    expect(markup).not.toContain("Older done");
+  });
+
+  it("derives the ahead rows purely from the selected status (unit-level invariant)", () => {
+    const rows = freshWorkspace();
+    expect(tasksAheadOfStatus(rows, "active").map((row) => row.taskId)).toEqual(["task_new_planned"]);
+    // 选中 planned 时那条新任务已在主行集里,不重复出现在流首。
+    expect(tasksAheadOfStatus(rows, "planned")).toEqual([]);
+  });
+
+  // 组件级证据说明 leaf 会渲染,页面级证据说明总览页真的把这条流接上了。
+  it("carries the zero-interaction visibility through the overview page", () => {
+    const page = renderToStaticMarkup(createElement(OverviewView, {
+      project: { id: "proj", name: "Harness", path: "/repo", preset: "software/coding", engines: [], watermarkAt: "2026-08-22T00:00:00.000Z" },
+      tasks: freshWorkspace(),
+      decisions: [],
+      workspaceSummary: {
+        schema: "daemon.workspace-summary/v1", ok: true, status: "ready", warnings: [], watermark: 1, sourceRevision: 1,
+        tasks: taskSummary({ active: 1, planned: 1 }), decisions: decisionSummary({ proposed: 0 }),
+      },
+      relations: [],
+      systemHealth: { daemon: null, repo: null, projection: null },
+      onSelect: noop, onDrill: noop, onOpenInbox: noop, onOpenDecision: noop, onOpenSystem: noop,
+      onNavigateEntity: noop,
+    }));
+    expect(page).toContain("Just created task");
+    expect(page).toMatch(/aria-selected="true" data-testid="overview-status-active"/u);
   });
 });
 


### PR DESCRIPTION
# English

## Summary

A task created with `ha task create` did not appear in the overview until the reader clicked a status tab. Three correct-in-isolation pieces produced it: the kernel writes every new task as `planned`; `workspaceTaskStatus` only rewrites the status word when the task is blocked, otherwise returning it unchanged; and the overview task stream defaults to `active` and filters rows strictly on `coordinationStatus === status`. The three sets do not intersect.

The fix adds a derived "ahead" group at the head of the same stream: tasks outside the current filter whose creation time is strictly later than the newest row inside it, newest first, rendered by the same row function and carrying their real status badge. No new state, no new read face, no change to the default tab.

## What Changed

- `tasksAheadOfStatus(tasks, status)` derives the ahead rows purely from the selected status. It never emits a row the current tab would already show, so when the newest task already sits in the selected status the group is empty and nothing extra renders.
- Only tasks with a known creation time can be promoted. `ledger-timeline.ts` states that a task id carries no time semantics and time must not be inferred from it, so a task whose `createdAt` is null can never be proven newer and stays out.
- When nothing in the current filter has a known creation time — including the empty filter, which is exactly a brand-new workspace right after its first `ha task create` — the threshold degrades to "no threshold" and every known-time task outside the filter qualifies.
- The group scrolls internally and is not sliced, following the convention the overview streams already use (`streamParts.tsx`), which differs from the board's batch-button convention on purpose.
- One new i18n key in each of the two locales for the group heading.

## Machine-Readable Declarations

Production-Delta: +69/-14

## Task And Scope

- Harness task: `task_84448afefef35b2a4191864e05`
- Branch: `codex/overview-new-task-visible`
- Public scope: `packages/gui/src/renderer/components/overview/TaskStream.tsx`, both locale files, `packages/gui/test/overview-streams.vitest.ts`
- Private planning/evidence updated: yes
- Out of scope: the four unannounced "first N only" truncations (`task_be076d3ac25b87b79be09b02dd`), whose file surface is disjoint from this one.

## Version Impact

- Version: no version change because this is a renderer-only behavioural fix with no published package API change.
- Publish impact: no publish

## Verification

- Base `origin/main` SHA: `f433ac12d80ff2249e9b1c77cf04ecb517032eb9`
- Branch merge-base with `origin/main`: `f433ac12d80ff2249e9b1c77cf04ecb517032eb9`
- Last `git fetch origin` time: 2026-08-24 06:17 CST
- Sync method: none needed
- Public diff command: `git diff f433ac12d80ff2249e9b1c77cf04ecb517032eb9...fb7de0c0fc874e45f7911d428ec1619ea54c40bb`
- Private evidence commit/path: `harness/tasks/task_84448afefef35b2a4191864e05-.../artifacts/` — `fix-choice-and-exclusions.md`, `invariants-verification.md`, `local-gates.md`, `report.md`
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending on this PR

CEO-run verification, independent of the implementer's report:

- [x] Invariant 4 (status vocabulary untouched): the diff contains zero changes under `packages/kernel` and zero to `model/types.ts`; `TaskStream.tsx` still declares `useState<SnapshotStatus>("active")`.
- [x] The implementer's claim that the Decision stream does not have the same defect: `DecisionStream.tsx:39` defaults to `"proposed"` and `decision-event.ts:35` writes `state: "proposed"` on creation, so a new decision is visible by default. The defect is specifically a misalignment between the task's initial status word and the task stream's default tab.
- [x] Positive control: neutering `tasksAheadOfStatus` to return `[]` turns 5 of the 23 tests red. The 3 invariance tests that stay green are exactly the ones asserting "do not break what already worked" (default tab unchanged, silent when the newest row is already in the selected status, unknown creation time never promoted) — they correctly should not fire on this break. Restored, 23/23 green.
- [x] `npx vitest run packages/gui/test/overview-streams.vitest.ts` — 23 passed.
- [x] `node tools/gates/entity-id-links.mjs` (G37, landed in #1763) — pass; this change touches renderer rendering.
- [x] `node tools/gates/line-density.mjs --base <base>` and `line-budget.mjs --base <base>` — pass.
- [x] `node tools/check-pr-governance.mjs` — no protected surfaces touched (89 manifest-derived rules).

**On the local `check:local --full` red the implementer reported.** It reported `quickstart demo fails closed when a middle step is deliberately broken` failing, reproduced the same failure on the canonical main worktree at `f433ac12d` with a clean tree, and correctly declined to touch it under the stop rule. **That negative control was correctly performed but structurally could not discriminate**, because both arms ran in the same session environment. The discriminating evidence is CI: PR #1763, whose merge commit *is* `f433ac12d`, ran `integration-shard` 1–6 and all six were SUCCESS. So the local red is an environment artifact of the worker session, not a red on main. Separately, `tools/quickstart-demo.test.mjs` imports only Node builtins and spawns child processes, and no file under `packages/cli`, `packages/daemon`, `packages/kernel`, or `tools` imports anything from `packages/gui/src/renderer` — this change is not reachable from that test at all.

## Review Evidence

- Self-review: CEO ran the positive control and the invariant checks above rather than accepting the implementer's report, and independently re-derived why the reported integration red is not attributable to this change.
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none

## Residual Risk

- The ahead group is derived from `createdAt`, which the projection sources from the `task_bootstrapped` event and which can be null for imported tasks. Those tasks are never promoted. That is the intended trade — inferring time from a task id is explicitly forbidden — but it means an imported task created "now" would still not surface.
- **The group's row count is unbounded, and in the degenerate case grows linearly with the total.** Measured on this workspace (1538 tasks: 1102 done, 282 planned, 74 cancelled, 63 active, 12 blocked, 5 in_review): with the current data the newest active row was created at `2026-08-23T20:45:01.936Z` and exactly one non-active task is newer, so **the group renders 1 row** — the common path is right. But if the active filter is empty the threshold degrades to "no threshold" by design and the group would render **1475 rows**; and if the newest active row is old, the group's size equals every non-active task created since. The container is `max-h-[6rem] overflow-y-auto` with no slice and an honest count in the heading, so this is not a silent truncation — but the DOM node count is linear in the total in those two cases, which is the shape W6's first goal sentence exists to eliminate. Recorded as fact `F-EDD4483A`; follow-up task filed. Not blocking: the measured common case is one row.
- The group's threshold is the newest known creation time *inside the current filter*. If the current filter is large and its newest row is itself recent, a task created slightly earlier but still after the reader last looked will not be promoted. The invariant this PR is accountable for is "a freshly created task is visible with zero interaction", which holds; "everything the reader has not seen yet" is a stronger property and is not claimed.

## References

- Task: `task_84448afefef35b2a4191864e05`
- Requirement: ledger entry O-01, second conjunct (the first conjunct — a mixed Task/Decision timeline — was superseded by O-02 and that supersession is recorded in the ledger)
- Evidence: `F-266F2F09` (the three-part code trace establishing the defect)

---

# 中文

## 摘要

用 `ha task create` 建出来的任务,在总览上看不见,除非先去点一下状态标签。造成它的是三段**单独看都没错**的代码:kernel 把每个新任务写成 `planned`;`workspaceTaskStatus` 只在任务被判定阻塞时改写状态词,其余原样返回;而总览的 Task 流默认 `active`,行集严格按 `coordinationStatus === status` 过滤。三者的交集是空的。

修法是在**同一条流**的流首加一个派生行组(ahead 带):当前筛选之外、且创建时间严格晚于筛选内最新那行的任务,按创建时间倒序,用同一个行渲染函数,每行照旧带真实状态徽标。**零新状态、零新读面、默认 tab 一个字节没动。**

## 改了什么

- `tasksAheadOfStatus(tasks, status)` 完全由当前选中状态派生 ahead 行。它**永不产出当前 tab 本来就会显示的行**,所以当最新任务已经在选中状态里时这一组为空,一个像素都不多渲染。
- 只有**已知创建时间**的任务才可能被上提。`ledger-timeline.ts` 明确写着任务 ID 不带时间语义、不得从 ID 推导时间,所以 `createdAt` 为 null 的任务无法被证明更新,一律不进。
- 当前筛选里没有任何一行带已知创建时间时(**包括筛选为空,那正是全新仓库刚建第一条任务的场景**),阈值退化为「无阈值」,筛选外所有已知时间的任务都算更新的。
- 这一组自己内部滚动、**不 slice**,遵的是总览四条流已有的约定(`streamParts.tsx`),它与看板的批次按钮约定**不是同一套**,这一点是有意区分的。
- 两个语言各加一条 i18n 键,用于这一组的标题。

## Task 与范围

- Harness 任务:`task_84448afefef35b2a4191864e05`
- 分支:`codex/overview-new-task-visible`
- 公开范围:`components/overview/TaskStream.tsx`、两份 locale 文件、`packages/gui/test/overview-streams.vitest.ts`
- 私有规划/证据已更新:是
- 不在范围内:四处无提示的静默截断(`task_be076d3ac25b87b79be09b02dd`),文件面与本 PR 不重叠。

## 版本影响

- 版本:不变。纯渲染层行为修复,不改任何已发布包的 API。
- 发布影响:不发布

## 验证

- 基线 `origin/main` SHA:`f433ac12d80ff2249e9b1c77cf04ecb517032eb9`
- merge-base:同上
- 最近 `git fetch origin` 时间:2026-08-24 06:17 CST
- 同步方式:无需同步
- 公开 diff 命令:`git diff f433ac12d80ff2249e9b1c77cf04ecb517032eb9...fb7de0c0fc874e45f7911d428ec1619ea54c40bb`
- 私有证据路径:`harness/tasks/task_84448afefef35b2a4191864e05-.../artifacts/` 的四份文档
- GitHub Actions `rewrite-ci` run URL:本 PR 上待跑

CEO 亲跑的验证,独立于实现者自述:

- [x] 不变量 4(状态词表未动):diff 里 `packages/kernel` 与 `model/types.ts` 零改动;`TaskStream.tsx` 仍是 `useState<SnapshotStatus>("active")`。
- [x] 复核实现者「Decision 侧没有同病」这条断言:`DecisionStream.tsx:39` 默认 `"proposed"`,而 `decision-event.ts:35` 建决策时写的正是 `state: "proposed"`,所以新决策默认可见。**缺陷是「任务初态词与任务流默认 tab 不对齐」这个特定问题,不是流式设计本身的错。**
- [x] 阳性对照:把 `tasksAheadOfStatus` 掐成 `return []`,23 个测试里 **5 个变红**。保持绿的 3 个恰好是断言「不许破坏既有行为」的那几条(默认 tab 未变、最新已在选中状态时保持沉默、未知创建时间永不上提)——它们本就不该因这个破坏而红。还原后 23/23 绿。
- [x] `npx vitest run packages/gui/test/overview-streams.vitest.ts` —— 23 通过。
- [x] `node tools/gates/entity-id-links.mjs`(G37,#1763 刚合入)—— 通过;本改动动了渲染层。
- [x] `line-density.mjs --base <base>` 与 `line-budget.mjs --base <base>` —— 通过。
- [x] `node tools/check-pr-governance.mjs` —— 未触碰受保护面(89 条派生规则)。

**关于实现者报的那个本地 `check:local --full` 红。** 它报告 `quickstart demo fails closed when a middle step is deliberately broken` 失败,并去 canonical 主工作树(树干净、HEAD = `f433ac12d`)复现了同一个红,然后按停手规则没有去动它。**那个阴性对照做法正确,但结构上无法判别**——两侧跑在同一个会话环境里。能判别的证据是 CI:PR #1763 的合并点**正是** `f433ac12d`,它跑了 `integration-shard` 1–6,**六个全部 SUCCESS**。所以本地那个红是 worker 会话的环境假红,不是 main 上的红。另外,`tools/quickstart-demo.test.mjs` 只 import Node 内置并 spawn 子进程,而 `packages/cli`、`packages/daemon`、`packages/kernel`、`tools` 下**没有任何文件** import `packages/gui/src/renderer` 的东西——本改动对那个测试根本不可达。

## 评审证据

- 自审:CEO 亲跑了上面的阳性对照与不变量检查,而不是采信实现者报告,并独立重新推导了「那个 integration 红不归本改动」的判据。
- 评审子代理:无
- 人工评审:待
- 阻塞发现:无

## 残余风险

- ahead 带靠 `createdAt` 派生,而该字段由投影从 `task_bootstrapped` 事件取,导入类任务可能为 null。这类任务永不被上提。这是有意的取舍(从任务 ID 推时间是被明令禁止的),但**它意味着一个"刚刚"导入的任务仍然不会浮现**。
- **这一组的行数没有上界,在退化情形下随总量线性增长。** 在本仓实测(1538 个任务:done 1102 / planned 282 / cancelled 74 / active 63 / blocked 12 / in_review 5):当前数据下 active 里最新那行的创建时间是 `2026-08-23T20:45:01.936Z`,比它更新的非 active 任务恰好 1 个,所以**这一组实际渲染 1 行**——常见路径是对的。但若 active 筛选为空,阈值按设计退化为「无阈值」,这一组要渲染 **1475 行**;若 active 非空而其中最新那行很旧,这一组的规模等于此后创建的全部非 active 任务数。容器是 `max-h-[6rem] overflow-y-auto`、无 slice、标题显示真实条数,**所以它不是静默截断**——但在上述两种情形下 DOM 节点数随总量线性增长,正是 W6 第一句目标要消除的形态。已记事实 `F-EDD4483A`,已立后续任务。**不阻塞合并**:实测常见情形是一行。
- 这一组的阈值是**当前筛选内**最新的已知创建时间。若当前筛选很大且其最新行本身就很新,那么一个创建得稍早、但仍晚于读者上次查看的任务不会被上提。本 PR 负责的不变量是「刚创建的任务零动作可见」,这条成立;「读者还没看过的一切」是更强的性质,本 PR 不声称满足它。

## 参考

- 任务:`task_84448afefef35b2a4191864e05`
- 需求:清册 O-01 的第二个合取项(第一个合取项「Task 与 Decision 混排在同一条时间线」已被 O-02 取代,取代关系已写进清册)
- 证据:`F-266F2F09`(确立该缺陷的三段代码追踪)
