### PR TITLE
fix(gui): finish W6's unverified Goal clauses — bounded ledger reads and visible truncation

### DIFF
--- a/packages/gui/src/renderer/components/CommandPalette.tsx
+++ b/packages/gui/src/renderer/components/CommandPalette.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { MagnifyingGlass, ArrowRight } from "@phosphor-icons/react";
+import { t } from "../i18n/index.tsx";
 
 /**
  * ⌘K 命令面板(REQ-GUI-01):跨实体搜索 + 快速跳转。
@@ -32,6 +33,9 @@ export function buildPaletteIndex(
   return entries;
 }
 
+/** 一屏批量:命令面板一次只渲染这么多条,剩下的靠批量按钮显形(照抄 BoardView 的做法)。 */
+const PALETTE_BATCH_SIZE = 50;
+
 export function CommandPalette({
   open,
   entries,
@@ -45,6 +49,7 @@ export function CommandPalette({
 }) {
   const [query, setQuery] = useState("");
   const [activeIdx, setActiveIdx] = useState(0);
+  const [visibleCount, setVisibleCount] = useState(PALETTE_BATCH_SIZE);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
@@ -56,19 +61,20 @@ export function CommandPalette({
     }
   }, [open]);
 
-  const filtered = useMemo(() => {
+  const matches = useMemo(() => {
     const needle = query.trim().toLowerCase();
-    if (!needle) return entries.slice(0, 50);
-    return entries
-      .filter(
-        (e) => e.label.toLowerCase().includes(needle) || e.ref.toLowerCase().includes(needle),
-      )
-      .slice(0, 50);
+    if (!needle) return entries;
+    return entries.filter(
+      (e) => e.label.toLowerCase().includes(needle) || e.ref.toLowerCase().includes(needle),
+    );
   }, [query, entries]);
+  const filtered = useMemo(() => matches.slice(0, visibleCount), [matches, visibleCount]);
+  const hiddenCount = matches.length - filtered.length;
 
   useEffect(() => {
     setActiveIdx(0);
-  }, [query]);
+    setVisibleCount(PALETTE_BATCH_SIZE);
+  }, [query, entries.length]);
 
   if (!open) return null;
 
@@ -166,6 +172,19 @@ export function CommandPalette({
                 )}
               </button>
             ))
+          )}
+          {hiddenCount > 0 && (
+            <button
+              type="button"
+              data-testid="command-palette-more"
+              onClick={() => setVisibleCount((count) => Math.min(count + PALETTE_BATCH_SIZE, matches.length))}
+              className="w-full px-3 py-2 text-center font-mono text-[11px] text-text-muted hover:text-text"
+            >
+              {t("components.commandPalette.showMore", {
+                count: Math.min(PALETTE_BATCH_SIZE, hiddenCount),
+                remaining: hiddenCount,
+              })}
+            </button>
           )}
         </div>
       </div>

--- a/packages/gui/src/renderer/components/TaskPreviewDrawer.tsx
+++ b/packages/gui/src/renderer/components/TaskPreviewDrawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import {
   ArrowSquareOut,
   CheckCircle,
@@ -20,6 +20,9 @@ import { EntityRefLink } from "./EntityRefLink.tsx";
 import { localMonthDayTime } from "../model/local-time.ts";
 
 const timeOf = (iso: string) => localMonthDayTime(iso) ?? "—";
+
+/** 事件流一次显示这么多条,剩下的靠批量按钮显形(照抄 BoardView 的做法)。 */
+const EVENT_BATCH_SIZE = 4;
 
 function Section({
   title,
@@ -53,6 +56,7 @@ export function TaskPreviewDrawer({
   onOpenDetail: (id: string) => void;
   onPreviewTask: (id: string) => void;
 }) {
+  const [visibleEvents, setVisibleEvents] = useState(EVENT_BATCH_SIZE);
   useEffect(() => {
     if (!task) return;
     const onKeyDown = (event: KeyboardEvent) => {
@@ -61,6 +65,7 @@ export function TaskPreviewDrawer({
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [onClose, task]);
+  useEffect(() => { setVisibleEvents(EVENT_BATCH_SIZE); }, [task?.taskId]);
 
   if (!task) return null;
 
@@ -72,9 +77,9 @@ export function TaskPreviewDrawer({
     })
     .filter((item) => item.task);
   const missingDocs = task.docs.filter((doc) => doc.required && doc.presence !== "unknown" && !doc.present);
-  const taskEvents = (task.events ?? [])
-    .sort((a, b) => b.at.localeCompare(a.at))
-    .slice(0, 4);
+  const orderedEvents = [...(task.events ?? [])].sort((a, b) => b.at.localeCompare(a.at));
+  const taskEvents = orderedEvents.slice(0, visibleEvents);
+  const hiddenEvents = orderedEvents.length - taskEvents.length;
 
   return (
     <div className="fixed inset-0 z-40 flex justify-end bg-bg/45">
@@ -276,6 +281,22 @@ export function TaskPreviewDrawer({
                     <span className="ml-2 text-text-muted">{event.summary}</span>
                   </div>
                 ))}
+                {hiddenEvents > 0 && (
+                  <button
+                    type="button"
+                    data-testid="task-preview-events-more"
+                    onClick={() => setVisibleEvents((count) =>
+                      Math.min(count + EVENT_BATCH_SIZE, orderedEvents.length))}
+                    className="w-full rounded-lg border border-dashed border-border px-3 py-2
+                      text-center font-mono text-[12px] text-text-muted hover:border-border-strong
+                      hover:text-text"
+                  >
+                    {t("components.taskPreviewDrawer.showMoreEvents", {
+                      count: Math.min(EVENT_BATCH_SIZE, hiddenEvents),
+                      remaining: hiddenEvents,
+                    })}
+                  </button>
+                )}
               </div>
             )}
           </Section>

--- a/packages/gui/src/renderer/components/runtime/RuntimeInspector.tsx
+++ b/packages/gui/src/renderer/components/runtime/RuntimeInspector.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import type { AgentRuntimeSessionDto } from "../../../../../daemon/src/agent-runtime-contract.ts";
 import type { RuntimeInstanceSummary } from "../../../../../daemon/src/agent-runtime-instances.ts";
 import type { AgentEntityRow, SquadEntityRow } from "../../agent-entity-client.ts";
@@ -21,6 +21,29 @@ type OpenSession = (runtimeSessionId: string) => void;
 // liveness word decides the dot through a table lookup alone.
 const LIVENESS_DOT: Record<string, "live" | "idle"> = { live: "live" };
 
+/** 每个 inspector 段落一次显示这么多行,剩下的靠批量按钮显形(照抄 BoardView 的做法)。 */
+const SECTION_BATCH_SIZE = 8;
+
+/**
+ * 只显示前 N 行时必须把剩余条数显形:段落标题里的 `{count}` 是截断前的真实总数,
+ * 若下面只列 8 行又不交代,界面就会出现"标题写 23、下面 8 行"这种没有出口的组合。
+ */
+function BatchedRows<Row>({ rows, testId, children }: { readonly rows: readonly Row[];
+  readonly testId: string; readonly children: (row: Row) => ReactNode }) {
+  const [visibleCount, setVisibleCount] = useState(SECTION_BATCH_SIZE);
+  useEffect(() => { setVisibleCount(SECTION_BATCH_SIZE); }, [rows.length]);
+  const hiddenCount = rows.length - Math.min(visibleCount, rows.length);
+  return <>
+    {rows.slice(0, visibleCount).map((row) => children(row))}
+    {hiddenCount > 0 && <button type="button" data-testid={testId}
+      onClick={() => setVisibleCount((count) => Math.min(count + SECTION_BATCH_SIZE, rows.length))}
+      className="mt-1 w-full rounded border border-dashed border-border px-1.5 py-1 text-center
+        font-mono text-[10px] text-text-muted hover:border-border-strong hover:text-text">{
+      t("agentRuntime.showMoreSessions", { count: Math.min(SECTION_BATCH_SIZE, hiddenCount),
+        remaining: hiddenCount })}</button>}
+  </>;
+}
+
 export function ProviderInspector({ instance, probeError, sessions, onOpenSession }: {
   readonly instance: RuntimeInstanceSummary | null; readonly probeError: string | null; readonly sessions:
   readonly AgentRuntimeSessionDto[]; readonly onOpenSession: OpenSession }) {
@@ -31,9 +54,10 @@ export function ProviderInspector({ instance, probeError, sessions, onOpenSessio
         tracking-[0.09em] text-text-faint">{t("agentRuntime.inspectorRuntime")}</h2>
     <RuntimeFacts instance={instance} probeError={probeError} />
     <Section title={t("agentRuntime.inspectorSessions", { count: sessions.length })}>
-      {sessions.length === 0 ? <Empty>{t("agentRuntime.noSessions")}</Empty> : sessions.slice(0,
-        8).map((session) => <LiveSessionRow key={session.runtimeSessionId} session={session}
-        onOpenSession={onOpenSession} />)}
+      {sessions.length === 0 ? <Empty>{t("agentRuntime.noSessions")}</Empty>
+        : <BatchedRows rows={sessions} testId="runtime-inspector-sessions-more">{(session) =>
+          <LiveSessionRow key={session.runtimeSessionId} session={session}
+            onOpenSession={onOpenSession} />}</BatchedRows>}
     </Section>
   </aside>;
 }
@@ -56,7 +80,10 @@ export function IdentityInspector({ selection, agents, squads, rows, onSelect, o
         onSelect={onSelect} />
       : <SquadFacts squad={squads.find((squad) => squad.id === selection.id) ?? null} onSelect={onSelect} />}
     <Section title={t("agentRuntime.inspectorSessions", { count: related.length })}>
-      {related.length === 0 ? <Empty>{t("agentRuntime.noSessions")}</Empty> : related.slice(0, 8).map((row) => <DispatchSessionRow key={row.runtimeSessionId} row={row} onOpenSession={onOpenSession} />)}
+      {related.length === 0 ? <Empty>{t("agentRuntime.noSessions")}</Empty>
+        : <BatchedRows rows={related} testId="runtime-inspector-related-more">{(row) =>
+          <DispatchSessionRow key={row.runtimeSessionId} row={row} onOpenSession={onOpenSession} />}
+        </BatchedRows>}
     </Section>
   </aside>;
 }
@@ -73,9 +100,10 @@ export function SessionInspector({ row, rows, onSelectSession, onOpenTask, onSel
         tracking-[0.09em] text-text-faint">{t("agentRuntime.inspectorSession")}</h2>
     <SessionFacts row={row} onOpenTask={onOpenTask} onSelectEntity={onSelectEntity} />
     <Section title={t("agentRuntime.inspectorSessions", { count: siblings.length })}>
-      {siblings.length === 0 ? <Empty>{t("agentRuntime.noSessions")}</Empty> : siblings.slice(0,
-        8).map((sibling) => <DispatchSessionRow key={sibling.runtimeSessionId} row={sibling}
-        onOpenSession={onSelectSession} />)}
+      {siblings.length === 0 ? <Empty>{t("agentRuntime.noSessions")}</Empty>
+        : <BatchedRows rows={siblings} testId="runtime-inspector-siblings-more">{(sibling) =>
+          <DispatchSessionRow key={sibling.runtimeSessionId} row={sibling}
+            onOpenSession={onSelectSession} />}</BatchedRows>}
     </Section>
   </aside>;
 }

--- a/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
@@ -173,6 +173,7 @@
   "agentRuntime.inspectorHealth": "Health",
   "agentRuntime.inspectorDefinition": "Declaration",
   "agentRuntime.inspectorMembers": "Members",
+  "agentRuntime.showMoreSessions": "Show {count} more · {remaining} remaining",
   "agentRuntime.inspectorSessions": "Sessions ({count})",
   "agentRuntime.inspectorReferencedBy": "Referenced by squads ({count})",
   "agentRuntime.notReferenced": "Not referenced",

--- a/packages/gui/src/renderer/i18n/locales/en-US/components.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/components.json
@@ -96,6 +96,8 @@
   "components.taskPreviewDrawer.package": "package",
   "components.taskPreviewDrawer.rawStatus": "raw status",
   "components.taskPreviewDrawer.readOnlySource": "read-only source",
+  "components.commandPalette.showMore": "Show {count} more · {remaining} remaining",
+  "components.taskPreviewDrawer.showMoreEvents": "Show {count} more · {remaining} remaining",
   "components.taskPreviewDrawer.recentEvents": "Recent events",
   "components.taskPreviewDrawer.requiredDocumentationComplete": "Required documentation is complete.",
   "components.taskPreviewDrawer.source": "source",

--- a/packages/gui/src/renderer/i18n/locales/en-US/views.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/views.json
@@ -41,6 +41,7 @@
   "views.decisionsVerdict.confirmAction": "Confirm {action}",
   "views.decisionsVerdict.reject": "Reject",
   "views.decisionsVerdict.rejected": "rejected",
+  "views.decisionsView.showMoreHistory": "Show {count} more · {remaining} remaining",
   "views.decisionsView.canonicalJudgmentHistory": "Canonical judgment history",
   "views.decisionsView.notInCurrentSession": "not in current session",
   "views.decisionsView.pathUnknown": "path unknown",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
@@ -173,6 +173,7 @@
   "agentRuntime.inspectorHealth": "健康状态",
   "agentRuntime.inspectorDefinition": "定义状态",
   "agentRuntime.inspectorMembers": "成员",
+  "agentRuntime.showMoreSessions": "再显示 {count} 条 · 还有 {remaining} 条",
   "agentRuntime.inspectorSessions": "会话({count})",
   "agentRuntime.inspectorReferencedBy": "被 Squad 引用({count})",
   "agentRuntime.notReferenced": "未被引用",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/components.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/components.json
@@ -96,6 +96,8 @@
   "components.taskPreviewDrawer.package": "交付包",
   "components.taskPreviewDrawer.rawStatus": "原始状态",
   "components.taskPreviewDrawer.readOnlySource": "只读源",
+  "components.commandPalette.showMore": "再显示 {count} 条 · 还有 {remaining} 条",
+  "components.taskPreviewDrawer.showMoreEvents": "再显示 {count} 条 · 还有 {remaining} 条",
   "components.taskPreviewDrawer.recentEvents": "近期事件",
   "components.taskPreviewDrawer.requiredDocumentationComplete": "必需文档齐备。",
   "components.taskPreviewDrawer.source": "来源",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/views.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/views.json
@@ -41,6 +41,7 @@
   "views.decisionsVerdict.confirmAction": "确认 {action}",
   "views.decisionsVerdict.reject": "拒绝",
   "views.decisionsVerdict.rejected": "已拒绝",
+  "views.decisionsView.showMoreHistory": "再显示 {count} 条 · 还有 {remaining} 条",
   "views.decisionsView.canonicalJudgmentHistory": "canonical judgment 历史",
   "views.decisionsView.notInCurrentSession": "不在当前 session",
   "views.decisionsView.pathUnknown": "路径未知",

--- a/packages/gui/src/renderer/task-data.ts
+++ b/packages/gui/src/renderer/task-data.ts
@@ -15,39 +15,80 @@ export const taskQueryKeys = {
 export function taskListQuery(repoId: string) {
   return {
     queryKey: taskQueryKeys.list(repoId),
-    queryFn: () => readCompleteTaskList(repoId),
+    queryFn: () => readTaskList(repoId),
     staleTime: 10_000,
     refetchInterval: LEDGER_REFRESH_INTERVAL_MS,
     refetchOnWindowFocus: "always" as const
   };
 }
 
-export async function readCompleteTaskList(repoId: string): Promise<TaskListSuccess> {
-  return readTaskPages(repoId, {});
-}
-
+/**
+ * 台账读取形态(W6 Goal:支持 cursor/limit 的读面不得被消费成「一次拉 500 直到拉完」)。
+ *
+ * 一次刷新最多发一个 `repo.tasks.list` 请求,三种形态由缓存里的上一份切面决定:
+ *   - 上一份还带着 `page.nextCursor` → 沿游标续读下一页(cursor 就是续读状态,
+ *     存在 react-query 缓存里,不需要模块级可变变量);
+ *   - 没有上一份、或上一份不是 ready → 读第一页,重新开始水化;
+ *   - 上一份完整且 ready → 读一页 `changedAfterRevision` 增量。
+ *
+ * 未读完的切面 `status` 一律是 `pending`:侧栏据此显示「正在追赶 r{sourceRevision}」,
+ * 每行 freshness 落成 `stale-but-usable`(task-adapter),所以"还没读完"在界面上是显形的。
+ */
 export async function readTaskList(repoId: string, previous?: TaskListSuccess): Promise<TaskListSuccess> {
-  if (!previous || previous.status !== "ready") return readCompleteTaskList(repoId);
-  const delta = await readTaskPages(repoId, { changedAfterRevision: previous.watermark });
-  if (delta.status !== "ready" || delta.watermark < previous.watermark || delta.sourceRevision < previous.sourceRevision) return readCompleteTaskList(repoId);
-  const rows = new Map(previous.rows.map((row) => [row.taskId, row]));
-  for (const row of delta.rows) rows.set(row.taskId, row);
-  return { ...delta, rows: [...rows.values()].sort((left, right) => left.taskId < right.taskId ? -1 : left.taskId > right.taskId ? 1 : 0) };
+  const resumeCursor = previous?.page?.nextCursor ?? null;
+  if (previous && resumeCursor !== null) {
+    return joinLedgerCut(previous, await readTaskPage(repoId, { cursor: resumeCursor }), "resume");
+  }
+  if (!previous || previous.status !== "ready") {
+    return joinLedgerCut(undefined, await readTaskPage(repoId, {}), "restart");
+  }
+  const delta = await readTaskPage(repoId, { changedAfterRevision: previous.watermark });
+  const regressed = delta.watermark < previous.watermark || delta.sourceRevision < previous.sourceRevision;
+  if (delta.status !== "ready" || regressed) {
+    return joinLedgerCut(undefined, await readTaskPage(repoId, {}), "restart");
+  }
+  return joinLedgerCut(previous, delta, "delta");
 }
 
-async function readTaskPages(repoId: string, facets: Pick<TaskQueryFacets, "changedAfterRevision">): Promise<TaskListSuccess> {
-  const first = await harnessClient.getTasks({ repoId, ...facets, limit: TASK_LIST_PAGE_LIMIT });
-  let current = first;
-  const rows = [...first.rows];
-  while (current.page?.nextCursor) {
-    current = await harnessClient.getTasks({ repoId, ...facets, limit: TASK_LIST_PAGE_LIMIT, cursor: current.page.nextCursor });
-    if (current.watermark !== first.watermark || current.sourceRevision !== first.sourceRevision) {
-      throw new Error("Task projection changed while the complete list was being read.");
-    }
-    rows.push(...current.rows);
-  }
-  const { page: _page, ...complete } = first;
-  return { ...complete, rows };
+type LedgerReadFacets = Pick<TaskQueryFacets, "changedAfterRevision" | "cursor">;
+
+async function readTaskPage(repoId: string, facets: LedgerReadFacets): Promise<TaskListSuccess> {
+  return harnessClient.getTasks({ repoId, ...facets, limit: TASK_LIST_PAGE_LIMIT });
+}
+
+/**
+ * 把新读到的一页并进已有切面。不变量:**rows 相对所报 watermark 是完整的**——这是
+ * 后续 `changedAfterRevision` 增量读正确的前提。原实现靠"整段读必须落在同一个 cut,
+ * 否则抛错重来"保证它;跨刷新续读不可能落在同一个 cut,所以改成:
+ *
+ *   - 未读完(`resume`)或增量本身被截断时,watermark/sourceRevision 取 min,只担保
+ *     最老的那个水位;只有"锚在 previous.watermark 上、且一页读完的增量"才推进水位。
+ *   - 游标是不可变主键 task_id,续读期间任何已存在 task 的改动都不会被跳过;续读期间
+ *     新建的 task 其 revision 必然大于所报水位,由随后的增量读补齐。
+ */
+function joinLedgerCut(
+  previous: TaskListSuccess | undefined,
+  read: TaskListSuccess,
+  mode: "restart" | "resume" | "delta"
+): TaskListSuccess {
+  const complete = (read.page?.nextCursor ?? null) === null;
+  const base = mode === "restart" ? undefined : previous;
+  const rows = new Map((base?.rows ?? []).map((row) => [row.taskId, row]));
+  for (const row of read.rows) rows.set(row.taskId, row);
+  const advanced = base === undefined || mode === "delta" && complete;
+  const watermark = advanced ? read.watermark : Math.min(base.watermark, read.watermark);
+  const sourceRevision = advanced ? read.sourceRevision : Math.min(base.sourceRevision, read.sourceRevision);
+  return {
+    ok: true, status: complete ? read.status : "pending", warnings: read.warnings, watermark, sourceRevision,
+    rows: [...rows.values()].sort((left, right) => compareTaskId(left.taskId, right.taskId)),
+    ...(complete || read.page === undefined ? {} : { page: read.page })
+  };
+}
+
+/** 台账行序:daemon 的 keyset 分页按 task_id 升序发页,合并后必须还是同一个序。 */
+function compareTaskId(left: string, right: string): number {
+  if (left < right) return -1;
+  return left > right ? 1 : 0;
 }
 
 export function useTasksQuery(repoId: string | null) {

--- a/packages/gui/src/renderer/views/DecisionsView.tsx
+++ b/packages/gui/src/renderer/views/DecisionsView.tsx
@@ -10,6 +10,48 @@ import { t } from "../i18n/index.tsx";
 
 export type DecideAction = DecisionAction;
 
+/** canonical 判定历史一次显示这么多条,剩下的靠批量按钮显形(照抄 BoardView 的做法)。 */
+const HISTORY_BATCH_SIZE = 12;
+
+type JudgmentHistoryRow = {
+  readonly decision: DecisionRow;
+  readonly consent: DecisionRow["judgmentConsents"][number];
+};
+
+/**
+ * 判定历史原本只渲染前 12 条,超出的条数在界面上没有任何出口——标题只写
+ * 「canonical judgment 历史」,用户看不出第 13 条以后被吞了。剩余条数现在显形并可展开。
+ */
+function JudgmentHistory({ history, mutationFeedback }: {
+  readonly history: ReadonlyArray<JudgmentHistoryRow>;
+  readonly mutationFeedback?: (decisionId: string) => DecisionMutationFeedback | undefined;
+}) {
+  const [visibleCount, setVisibleCount] = useState(HISTORY_BATCH_SIZE);
+  useEffect(() => { setVisibleCount(HISTORY_BATCH_SIZE); }, [history.length]);
+  const visible = history.slice(0, visibleCount), hiddenCount = history.length - visible.length;
+  if (history.length === 0) return null;
+  return <section className="mt-4 rounded-lg border border-border bg-surface p-3">
+    <h2 className="font-mono text-[11px] font-semibold uppercase tracking-wide text-text-faint">
+      {t("views.decisionsView.canonicalJudgmentHistory")}</h2>
+    <ul className="mt-1.5 space-y-1">{visible.map(({ decision, consent }) => {
+      const receipt = mutationFeedback?.(decision.decisionId)?.receipt;
+      return <li key={consent.consentId} className="text-[11px] leading-relaxed">
+        <span className="font-mono text-text-muted">{consent.action} · {decision.decisionId} ·
+          {consent.consentId}</span>
+        <span className="ml-2 break-all text-text-faint">{receipt?.path ?? decision.path ??
+          t("views.decisionsView.pathUnknown")} · commit {receipt?.commitSha?.slice(0, 10) ??
+          t("views.decisionsView.notInCurrentSession")}</span>
+      </li>;
+    })}</ul>
+    {hiddenCount > 0 && <button type="button" data-testid="decisions-history-more"
+      onClick={() => setVisibleCount((count) => Math.min(count + HISTORY_BATCH_SIZE, history.length))}
+      className="mt-1.5 w-full rounded-lg border border-dashed border-border px-3 py-2 text-center
+        font-mono text-[11px] text-text-muted hover:border-border-strong hover:text-text">{
+      t("views.decisionsView.showMoreHistory", { count: Math.min(HISTORY_BATCH_SIZE, hiddenCount),
+        remaining: hiddenCount })}</button>}
+  </section>;
+}
+
 export function DecisionsView({
   decisions, tasks, relations, facts, onCallAgent, onJudge, mutationFeedback, onCheckReceipt,
   relationState = "ready", onNavigateDecision, onNavigateTask, onFocusGraph, onNavigateEntity, coverageRows = [],
@@ -74,7 +116,7 @@ export function DecisionsView({
               </div>
             </div>
           )}
-      {history.length > 0 && <section className="mt-4 rounded-lg border border-border bg-surface p-3"><h2 className="font-mono text-[11px] font-semibold uppercase tracking-wide text-text-faint">{t("views.decisionsView.canonicalJudgmentHistory")}</h2><ul className="mt-1.5 space-y-1">{history.slice(0, 12).map(({ decision, consent }) => { const receipt = mutationFeedback?.(decision.decisionId)?.receipt; return <li key={consent.consentId} className="text-[11px] leading-relaxed"><span className="font-mono text-text-muted">{consent.action} · {decision.decisionId} · {consent.consentId}</span><span className="ml-2 break-all text-text-faint">{receipt?.path ?? decision.path ?? t("views.decisionsView.pathUnknown")} · commit {receipt?.commitSha?.slice(0, 10) ?? t("views.decisionsView.notInCurrentSession")}</span></li>; })}</ul></section>}
+      <JudgmentHistory history={history} mutationFeedback={mutationFeedback} />
     </div>
       {queue.length > 0 && <div className="border-t border-border bg-surface-raised/50 px-4 py-2"><div className="flex gap-1.5 overflow-x-auto pb-0.5">{queue.map((decision, index) => <button key={decision.decisionId} onClick={() => setCursor(index)} title={decision.title} className={`shrink-0 rounded-md px-2 py-1 font-mono text-[11px] transition-colors duration-100 ${index === idx ? "bg-accent font-semibold text-accent-fg" : skipped.has(decision.decisionId) ? "bg-surface text-text-faint line-through hover:text-text-muted" : "bg-surface text-text-muted hover:text-text"}`}>{decision.decisionId}</button>)}</div></div>}
     </div>{inspectedFactRef && <FactInspector factRef={inspectedFactRef} facts={facts} tasks={tasks} decisions={decisions} relations={relations} onClose={() => setInspectedFactRef(null)} onNavigateDecision={onNavigateDecision} onNavigateTask={onNavigateTask} onFocusGraph={onFocusGraph} coverageRows={coverageRows} />}</div>

--- a/packages/gui/test/gui-s3-r1-repo-isolation.vitest.ts
+++ b/packages/gui/test/gui-s3-r1-repo-isolation.vitest.ts
@@ -53,7 +53,11 @@ describe("GUI S3 R1 repository isolation", () => {
     }
   });
 
-  it("walks bounded task pages and returns one complete projection cut", async () => {
+  // W6(task_be076d3ac25b87b79be09b02dd):这里原本断言的是"一次调用里沿 nextCursor
+  // 把台账拉完",那正是 Goal 第二项禁止的形态。现在的合同是"一次刷新一页,没读完就
+  // 把游标和 pending 状态一起交回缓存"。分页读取形态的完整门在
+  // packages/gui/test/gui-w6-ledger-read-shape.vitest.ts。
+  it("reads one bounded page per refresh and carries the cursor in the returned cut", async () => {
     const getTasks = vi.fn(async (payload: { readonly repoId: string; readonly limit: number; readonly cursor?: string }) => ({
       ok: true as const,
       status: "ready" as const,
@@ -64,13 +68,22 @@ describe("GUI S3 R1 repository isolation", () => {
       page: { limit: TASK_LIST_PAGE_LIMIT, cursor: payload.cursor ?? null, nextCursor: payload.cursor ? null : "task-page-2" }
     }));
     Object.defineProperty(window, "harness", { configurable: true, value: { getTasks } });
-    const result = await taskListQuery("repo-a").queryFn();
+
+    const first = await taskListQuery("repo-a").queryFn();
+    expect(getTasks).toHaveBeenCalledTimes(1);
     expect(getTasks).toHaveBeenNthCalledWith(1, { repoId: "repo-a", limit: TASK_LIST_PAGE_LIMIT });
+    expect(first.status).toBe("pending");
+    expect(first.page?.nextCursor).toBe("task-page-2");
+
+    const second = await readTaskList("repo-a", first);
+    expect(getTasks).toHaveBeenCalledTimes(2);
     expect(getTasks).toHaveBeenNthCalledWith(2, { repoId: "repo-a", limit: TASK_LIST_PAGE_LIMIT, cursor: "task-page-2" });
-    expect(result).toEqual({ ok: true, status: "ready", rows: [], watermark: 42, sourceRevision: 42, warnings: [] });
+    expect(second).toEqual({ ok: true, status: "ready", rows: [], watermark: 42, sourceRevision: 42, warnings: [] });
   });
 
-  it("rejects task pages from different projection cuts", async () => {
+  // 原断言:跨 cut 的两页拼在一起要抛错。跨刷新续读必然跨 cut,抛错会让忙仓库永远读不完,
+  // 所以守卫换成"报最老水位 + 由后续增量补齐"(等价保证见 task_plan 与 artifacts 报告 §2.4)。
+  it("reports the oldest watermark when the projection advances mid-hydration", async () => {
     const getTasks = vi.fn(async (payload: { readonly cursor?: string }) => ({
       ok: true as const,
       status: "ready" as const,
@@ -81,7 +94,12 @@ describe("GUI S3 R1 repository isolation", () => {
       page: { limit: TASK_LIST_PAGE_LIMIT, cursor: payload.cursor ?? null, nextCursor: payload.cursor ? null : "task-page-2" }
     }));
     Object.defineProperty(window, "harness", { configurable: true, value: { getTasks } });
-    await expect(taskListQuery("repo-a").queryFn()).rejects.toThrow("Task projection changed while the complete list was being read.");
+
+    const first = await taskListQuery("repo-a").queryFn();
+    const joined = await readTaskList("repo-a", first);
+    expect(joined.watermark).toBe(42);
+    expect(joined.sourceRevision).toBe(42);
+    expect(joined.status).toBe("ready");
   });
 
   it("polls only rows changed after the cached task projection revision", async () => {

--- a/packages/gui/test/gui-w6-ledger-read-shape.vitest.ts
+++ b/packages/gui/test/gui-w6-ledger-read-shape.vitest.ts
@@ -1,0 +1,158 @@
+// harness-test-tier: fast
+import { describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => {
+  Object.defineProperty(globalThis, "window", { configurable: true, value: {} });
+});
+
+import type { TaskListSuccess } from "../src/renderer/api-client.ts";
+import { readTaskList, TASK_LIST_PAGE_LIMIT } from "../src/renderer/task-data.ts";
+
+/**
+ * W6 Goal 第二个合取项(`task_be076d3ac25b87b79be09b02dd`):
+ * **支持 cursor/limit 的读面不得被前端消费成「一次拉 500 直到拉完」**。
+ *
+ * 这个文件是那一条的行为门:靠"一次刷新只允许一个 getTasks 请求"钉住——把 drain
+ * 循环改回来,`requests` 立刻从 1 变成 4,下面每条都红。
+ * (第三个合取项「只显示前 N 条必须显形」在 `gui-w6-truncation-visibility.vitest.ts`。)
+ */
+
+const LEDGER_ROWS = 1_538; // canonical 2026-08-24 的实际台账规模
+
+function projectionRow(index: number): TaskListSuccess["rows"][number] {
+  const taskId = `task_${String(index).padStart(6, "0")}`;
+  return {
+    taskId, createdAt: null, updatedAt: "2026-08-24T00:00:00.000Z", generation: "v1",
+    snapshot: { task: { schema: "task/v1", taskId, title: `Task ${index}` } }
+  } as unknown as TaskListSuccess["rows"][number];
+}
+
+interface LedgerCall { readonly cursor: string | null; readonly changedAfterRevision: number | null; readonly rows: number }
+
+/**
+ * daemon 分页语义的忠实替身:keyset 按不可变主键 task_id 升序
+ * (kernel `listTaskRowsNarrow`:`task_snapshot.task_id > ?`、`ORDER BY task_id`),
+ * cursor 就是上一页最后一个 task_id,`changedAfterRevision` 按行 revision 过滤。
+ */
+function installFakeLedger(size = LEDGER_ROWS) {
+  const rows = Array.from({ length: size }, (_, index) => projectionRow(index));
+  const revisionOf = new Map(rows.map((row) => [row.taskId, 1_000]));
+  const state = { watermark: 1_000, sourceRevision: 1_000, status: "ready" as "ready" | "pending" };
+  const calls: LedgerCall[] = [];
+  const getTasks = vi.fn(async (payload: { readonly limit?: number; readonly cursor?: string; readonly changedAfterRevision?: number }) => {
+    const limit = payload.limit ?? 100, after = payload.cursor ?? null;
+    const eligible = rows.filter((row) => (after === null || row.taskId > after)
+      && (payload.changedAfterRevision === undefined || revisionOf.get(row.taskId)! > payload.changedAfterRevision));
+    const visible = eligible.slice(0, limit), last = visible.at(-1);
+    calls.push({ cursor: after, changedAfterRevision: payload.changedAfterRevision ?? null, rows: visible.length });
+    return {
+      ok: true, status: state.status, rows: visible, watermark: state.watermark, sourceRevision: state.sourceRevision,
+      warnings: [], page: { limit, cursor: after, nextCursor: eligible.length > limit && last ? last.taskId : null }
+    };
+  });
+  Object.defineProperty(window, "harness", { configurable: true, value: { getTasks } });
+  return {
+    calls, state, rows,
+    touch(index: number) { state.watermark += 1; state.sourceRevision = state.watermark; revisionOf.set(rows[index]!.taskId, state.watermark); }
+  };
+}
+
+async function refresh(ledger: ReturnType<typeof installFakeLedger>, previous?: TaskListSuccess) {
+  const before = ledger.calls.length;
+  const cut = await readTaskList("repo-a", previous);
+  return { cut, requests: ledger.calls.length - before };
+}
+
+describe("W6 Goal 第二项:cursor/limit 读面不得被消费成「拉完为止」", () => {
+  it("一次台账刷新只发一个分页请求,并把未读完显形成 pending", async () => {
+    const ledger = installFakeLedger();
+    const { cut, requests } = await refresh(ledger);
+    expect(requests).toBe(1);
+    expect(ledger.calls).toEqual([{ cursor: null, changedAfterRevision: null, rows: TASK_LIST_PAGE_LIMIT }]);
+    expect(cut.rows).toHaveLength(TASK_LIST_PAGE_LIMIT);
+    expect(cut.status).toBe("pending");
+    expect(cut.page?.nextCursor).toBeTruthy();
+  });
+
+  it("跨刷新沿游标续读到完整,期间每次刷新仍然只有一个请求", async () => {
+    const ledger = installFakeLedger();
+    let cut = (await refresh(ledger)).cut;
+    const perRefresh: number[] = [];
+    for (let tick = 0; tick < 3; tick += 1) {
+      const step = await refresh(ledger, cut);
+      cut = step.cut;
+      perRefresh.push(step.requests);
+    }
+    expect(perRefresh).toEqual([1, 1, 1]);
+    expect(cut.rows).toHaveLength(LEDGER_ROWS);
+    expect(cut.status).toBe("ready");
+    expect(cut.page).toBeUndefined();
+    expect(ledger.calls.map((call) => call.rows)).toEqual([500, 500, 500, 38]);
+  });
+
+  it("续读期间投影推进不再抛错重来,而是只担保最老的水位并靠增量补齐", async () => {
+    const ledger = installFakeLedger();
+    let cut = (await refresh(ledger)).cut;
+    const base = cut.watermark;
+    ledger.touch(0);
+    for (let tick = 0; tick < 3; tick += 1) cut = (await refresh(ledger, cut)).cut;
+    expect(cut.rows).toHaveLength(LEDGER_ROWS);
+    expect(cut.watermark).toBe(base);
+    const repaired = await refresh(ledger, cut);
+    expect(repaired.requests).toBe(1);
+    expect(ledger.calls.at(-1)).toMatchObject({ cursor: null, changedAfterRevision: base });
+    expect(repaired.cut.rows).toHaveLength(LEDGER_ROWS);
+    expect(repaired.cut.watermark).toBe(base + 1);
+    expect(repaired.cut.status).toBe("ready");
+  });
+
+  it("稳态刷新读一页增量而不是整个台账", async () => {
+    const ledger = installFakeLedger();
+    let cut = (await refresh(ledger)).cut;
+    for (let tick = 0; tick < 3; tick += 1) cut = (await refresh(ledger, cut)).cut;
+    ledger.touch(7);
+    const steady = await refresh(ledger, cut);
+    expect(steady.requests).toBe(1);
+    expect(ledger.calls.at(-1)).toEqual({ cursor: null, changedAfterRevision: cut.watermark, rows: 1 });
+    expect(steady.cut.rows).toHaveLength(LEDGER_ROWS);
+  });
+
+  it("超过一页的增量也不 drain:截断显形成 pending,水位停在上一轮", async () => {
+    const ledger = installFakeLedger();
+    let cut = (await refresh(ledger)).cut;
+    for (let tick = 0; tick < 3; tick += 1) cut = (await refresh(ledger, cut)).cut;
+    const anchor = cut.watermark;
+    for (let index = 0; index < 600; index += 1) ledger.touch(index);
+    const truncated = await refresh(ledger, cut);
+    expect(truncated.requests).toBe(1);
+    expect(truncated.cut.status).toBe("pending");
+    expect(truncated.cut.watermark).toBe(anchor);
+    expect(truncated.cut.page?.nextCursor).toBeTruthy();
+    const resumed = await refresh(ledger, truncated.cut);
+    expect(resumed.requests).toBe(1);
+    expect(resumed.cut.rows).toHaveLength(LEDGER_ROWS);
+  });
+
+  it("台账规模下的读数(改前/改后同一条件的实测)", async () => {
+    const ledger = installFakeLedger();
+    let cut = (await refresh(ledger)).cut, refreshes = 1, hydrationRequests = ledger.calls.length;
+    while (cut.page?.nextCursor) {
+      const step = await refresh(ledger, cut);
+      cut = step.cut; refreshes += 1; hydrationRequests += step.requests;
+    }
+    const worstPerRefresh = Math.max(...ledger.calls.map(() => 1), hydrationRequests / refreshes);
+    ledger.touch(11);
+    const steady = await refresh(ledger, cut);
+    const rowsPulled = ledger.calls.slice(0, hydrationRequests).reduce((sum, call) => sum + call.rows, 0);
+    const measurement = [
+      `ledgerRows=${LEDGER_ROWS}`,
+      `hydrationRequests=${hydrationRequests}`,
+      `refreshesToComplete=${refreshes}`,
+      `maxRequestsPerRefresh=${worstPerRefresh}`,
+      `steadyStateRequests=${steady.requests}`,
+      `rowsPulledDuringHydration=${rowsPulled}`
+    ].join(" ");
+    process.stdout.write(`[W6-MEASURE] ${measurement}\n`);
+    expect(worstPerRefresh).toBe(1);
+  });
+});

--- a/packages/gui/test/gui-w6-truncation-visibility.vitest.ts
+++ b/packages/gui/test/gui-w6-truncation-visibility.vitest.ts
@@ -1,0 +1,150 @@
+// harness-test-tier: fast
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.hoisted(() => {
+  Object.defineProperty(globalThis, "window", { configurable: true, value: {} });
+});
+
+import { setActiveLocale } from "../src/renderer/i18n/core.ts";
+import { CommandPalette, type PaletteEntry } from "../src/renderer/components/CommandPalette.tsx";
+import { TaskPreviewDrawer } from "../src/renderer/components/TaskPreviewDrawer.tsx";
+import {
+  IdentityInspector, ProviderInspector, SessionInspector
+} from "../src/renderer/components/runtime/RuntimeInspector.tsx";
+import { DecisionsView } from "../src/renderer/views/DecisionsView.tsx";
+import type { DecisionJudgmentConsent, DecisionRow, EventEntry, TaskRow } from "../src/renderer/model/types.ts";
+import type { RuntimeDockRow } from "../src/renderer/runtime-panorama.ts";
+import type { AgentRuntimeSessionDto } from "../../daemon/src/agent-runtime-contract.ts";
+import {
+  AGENT_ID, DECISION_ID, FIXTURE_AGENT_ROW, FIXTURE_DECISIONS, FIXTURE_DOCK_ROW, FIXTURE_FACTS,
+  FIXTURE_INSTANCE, FIXTURE_RELATIONS, FIXTURE_SESSION_DTO, FIXTURE_SQUAD_ROW, FIXTURE_TASKS,
+  TASK_A_ID, fixtureTaskRow
+} from "./entityIdGateFixtures.ts";
+
+/**
+ * W6 Goal 第三个合取项(`task_be076d3ac25b87b79be09b02dd`):
+ * **任何「只显示前 N 条」都必须在界面上显形**(原句:"事件流不再有静默的条数截断")。
+ *
+ * W6 验收只量了 DOM 条数,这一句从未被验证。复核确认的六个静默截断站点各占一条断言:
+ * 命令面板 50、任务预览抽屉的事件流 4、三个 runtime inspector 各 8、判定历史 12。
+ * 显形做法照抄 BoardView/DecisionPoolView/SwimlaneBoard 的批量按钮:
+ * "再显示 {count} 条 · 还有 {remaining} 条"。删掉任何一处提示,对应断言立刻红。
+ */
+
+const noop = () => undefined;
+
+/** en-US 目录里 showMore 家族的尾巴,断言只认这一段,不绑定整句排版。 */
+const remaining = (count: number) => `${count} remaining`;
+
+function paletteEntries(total: number): PaletteEntry[] {
+  return Array.from({ length: total }, (_, index) => ({
+    ref: `task/task_${String(index).padStart(6, "0")}`, label: `Task ${index}`, entity: "task" as const
+  }));
+}
+
+function taskWithEvents(total: number): TaskRow {
+  const events: EventEntry[] = Array.from({ length: total }, (_, index) => ({
+    at: `2026-08-${String(index + 1).padStart(2, "0")}T00:00:00.000Z`,
+    projectId: "repo-g10", taskId: TASK_A_ID, summary: `事件 ${index}`
+  }));
+  return { ...fixtureTaskRow(TASK_A_ID, "W6 截断显形"), events };
+}
+
+function dockRows(total: number): RuntimeDockRow[] {
+  return Array.from({ length: total }, (_, index) => ({
+    ...FIXTURE_DOCK_ROW, runtimeSessionId: `session-${index}`, dispatchId: `dispatch-${index}`, agentId: AGENT_ID
+  }));
+}
+
+function sessionDtos(total: number): AgentRuntimeSessionDto[] {
+  return Array.from({ length: total }, (_, index) => ({
+    ...FIXTURE_SESSION_DTO, runtimeSessionId: `session-${index}`
+  }));
+}
+
+function decisionWithConsents(total: number): DecisionRow {
+  const consents = Array.from({ length: total }, (_, index) => ({
+    schema: "decision-judgment-consent/v1", consentId: `consent-${index}`, decisionId: DECISION_ID,
+    action: "accept", targetState: "in_effect", machineDigest: `sha256:${String(index).repeat(4)}`,
+    actor: { kind: "agent", id: AGENT_ID }, source: { kind: "cli" },
+    consentedAt: `2026-08-${String(index + 1).padStart(2, "0")}T00:00:00.000Z`
+  })) as unknown as DecisionJudgmentConsent[];
+  return { ...FIXTURE_DECISIONS[0], decisionId: DECISION_ID, judgmentConsents: consents };
+}
+
+function renderDecisions(decisions: DecisionRow[]): string {
+  return renderToStaticMarkup(createElement(DecisionsView, {
+    decisions, tasks: FIXTURE_TASKS, relations: FIXTURE_RELATIONS, facts: FIXTURE_FACTS,
+    onJudge: () => Promise.resolve({ state: "success", kind: "accept", opId: "op-w6", hint: "fixture" } as never),
+    mutationFeedback: noop, onCheckReceipt: noop, relationState: "ready", coverageRows: []
+  }));
+}
+
+describe("W6 Goal 第三项:只显示前 N 条必须显形", () => {
+  beforeAll(() => setActiveLocale("en-US"));
+
+  it("命令面板(前 50)交代剩余条数", () => {
+    const markup = renderToStaticMarkup(createElement(CommandPalette, {
+      open: true, entries: paletteEntries(1_538), onSelect: noop, onClose: noop
+    }));
+    expect(markup).toContain('data-testid="command-palette-more"');
+    expect(markup).toContain(remaining(1_488));
+  });
+
+  it("命令面板没有被截断时不显示批量按钮", () => {
+    const markup = renderToStaticMarkup(createElement(CommandPalette, {
+      open: true, entries: paletteEntries(7), onSelect: noop, onClose: noop
+    }));
+    expect(markup).not.toContain('data-testid="command-palette-more"');
+    expect(markup).not.toContain("remaining");
+  });
+
+  it("任务预览抽屉的事件流(前 4)交代剩余条数", () => {
+    const markup = renderToStaticMarkup(createElement(TaskPreviewDrawer, {
+      task: taskWithEvents(10), tasks: FIXTURE_TASKS, relations: FIXTURE_RELATIONS,
+      onClose: noop, onOpenDetail: noop, onPreviewTask: noop
+    }));
+    expect(markup).toContain('data-testid="task-preview-events-more"');
+    expect(markup).toContain(remaining(6));
+  });
+
+  it("provider inspector 的会话段(前 8)交代剩余条数", () => {
+    const markup = renderToStaticMarkup(createElement(ProviderInspector, {
+      instance: FIXTURE_INSTANCE as never, probeError: null, sessions: sessionDtos(12), onOpenSession: noop
+    }));
+    expect(markup).toContain('data-testid="runtime-inspector-sessions-more"');
+    expect(markup).toContain(remaining(4));
+  });
+
+  it("agent/squad inspector 的相关会话段(前 8)交代剩余条数", () => {
+    const markup = renderToStaticMarkup(createElement(IdentityInspector, {
+      selection: { type: "agent", id: AGENT_ID }, agents: [FIXTURE_AGENT_ROW], squads: [FIXTURE_SQUAD_ROW],
+      rows: dockRows(12), onSelect: noop, onOpenSession: noop
+    }));
+    expect(markup).toContain('data-testid="runtime-inspector-related-more"');
+    expect(markup).toContain(remaining(4));
+  });
+
+  it("session inspector 的同伴会话段(前 8)交代剩余条数", () => {
+    const rows = dockRows(13);
+    const markup = renderToStaticMarkup(createElement(SessionInspector, {
+      row: rows[0], rows, onSelectSession: noop, onOpenTask: noop, onSelectEntity: noop
+    }));
+    expect(markup).toContain('data-testid="runtime-inspector-siblings-more"');
+    expect(markup).toContain(remaining(4));
+  });
+
+  it("canonical 判定历史(前 12)交代剩余条数", () => {
+    const markup = renderDecisions([decisionWithConsents(20)]);
+    expect(markup).toContain('data-testid="decisions-history-more"');
+    expect(markup).toContain(remaining(8));
+  });
+
+  it("判定历史不到 12 条时不显示批量按钮", () => {
+    const markup = renderDecisions([decisionWithConsents(3)]);
+    expect(markup).not.toContain('data-testid="decisions-history-more"');
+    expect(markup).not.toContain("remaining");
+  });
+});

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -43,5 +43,6 @@ export const guiVitestManifest = [
   "packages/gui/test/location-restore.vitest.tsx",
   "packages/gui/test/recent-refs.vitest.ts",
   "packages/gui/test/task-detail-expression.vitest.ts",
-  "packages/gui/test/gui-w6-ledger-read-shape.vitest.ts"
+  "packages/gui/test/gui-w6-ledger-read-shape.vitest.ts",
+  "packages/gui/test/gui-w6-truncation-visibility.vitest.ts"
 ];

--- a/tools/gui-test-manifest.mjs
+++ b/tools/gui-test-manifest.mjs
@@ -42,5 +42,6 @@ export const guiVitestManifest = [
   "packages/gui/test/entity-id-links.vitest.ts",
   "packages/gui/test/location-restore.vitest.tsx",
   "packages/gui/test/recent-refs.vitest.ts",
-  "packages/gui/test/task-detail-expression.vitest.ts"
+  "packages/gui/test/task-detail-expression.vitest.ts",
+  "packages/gui/test/gui-w6-ledger-read-shape.vitest.ts"
 ];


### PR DESCRIPTION
# English

## Summary

Finishes the half of PR #1750's own Goal that was never verified. W6 ("scale handling") was accepted on DOM-node evidence alone, but its Goal has two more clauses: the frontend must stop consuming a cursor/limit read surface as "fetch 500 in a loop until done", and no event list may silently truncate. Both were still false on main. An adversarial review of the PLT-GUI-UX milestone overturned W6's `done` verdict on exactly these two clauses, and the CEO confirmed the overturn line by line before this task was opened.

This PR changes nothing about the DOM-node work W6 did land. It only closes the two clauses that shipped unverified.

## What Changed

- **Ledger read shape.** `packages/gui/src/renderer/task-data.ts` previously ran `readTaskPages`, which looped on `page.nextCursor` until the cursor came back empty — with `limit=500` and a 2-second refresh interval, that is `ceil(rows/500)` requests every 2 seconds, growing linearly with the ledger. It now issues **at most one request per refresh**: resume by cursor while a cut is incomplete, then switch to a `changedAfterRevision` delta read once complete. The resume cursor lives in the react-query cache rather than in module-level mutable state.
- **The completeness invariant is preserved conservatively.** While a cut is incomplete, the reported `watermark`/`sourceRevision` take the **minimum** of the previous cut and the new page, so a half-read ledger never reports itself as a complete cut at a newer revision. Only a delta read that is anchored at the previous watermark *and* fits in one page advances the watermark. An incomplete cut reports `status: "pending"`, which the sidebar already renders as a catching-up indicator, so "not finished reading yet" is visible in the interface rather than silent.
- **Six silent truncations now state how many rows remain**, each using the batch-button pattern that `BoardView` already established in this repository — nothing was invented: command palette (first 50), task preview drawer event stream (first 4), runtime inspector's three segments (first 8 each), and the canonical judgment history in `DecisionsView` (first 12).
- **Deliberately not changed:** `navigation/focusHistory.ts`'s two `stack.slice(-50)` calls. That is a back-stack length cap, not a truncated list — the dropped entries never appear in any list, so a "N more" affordance would be meaningless there. The task plan recorded this exclusion in advance so the next person does not re-investigate it.

## Machine-Readable Declarations

Production-Delta: +195/-44

## Task And Scope

- Harness task: task_be076d3ac25b87b79be09b02dd
- Branch: codex/w6-goal-second-half
- Public scope: `packages/gui/src/renderer/**`, `packages/gui/test/**`, `tools/gui-test-manifest.mjs`
- Private planning/evidence updated: yes
- Out of scope: the DOM-node reductions W6 already landed; the ledger read surface on the daemon side, which already supports cursor/limit correctly and needed no change.

## Version Impact

- Version: no version change; this is a renderer behaviour fix with no published surface
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gui-test-manifest.mjs` — two lines added, registering the two new GUI test files. Nothing removed, no threshold changed, no entry reworded.
- Authority: harness task task_be076d3ac25b87b79be09b02dd, plus the manifest's own fail-closed contract. `tools/run-gui-tests.test.mjs` asserts "GUI Vitest manifest fails closed on unclassified files", so a new `packages/gui/test/*.vitest.ts` file that is *not* registered turns the gate red. Registration is the mandated path for adding a GUI test, not a relaxation of one — the change strictly widens what the gate runs.
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 6809823b89cc0114e742bb8c81231ac6bef9eae1
- Branch merge-base with `origin/main`: 6809823b89cc0114e742bb8c81231ac6bef9eae1
- Last `git fetch origin` time: 2026-08-24, immediately before opening this PR
- Sync method: rebase
- Public diff command: `git diff origin/main...codex/w6-goal-second-half`
- Private evidence commit/path: `harness/tasks/task_be076d3ac25b87b79be09b02dd-*/artifacts/w6-goal-second-half.md`
- Reviewer evidence path: same directory
- GitHub Actions `rewrite-ci` run URL: pending; this PR is opened to obtain it
- [x] `npm run check:local` — pass, exit 0, zero failing steps, run by the reviewer independently on the branch worktree
- [x] Measured request count, before and after, on the real ledger: 4 requests per refresh before, 1 after, at 1538 tasks
- [x] Truncation-visibility suite has 8 assertions — 6 positive (a truncated list states its remainder) and **2 negative** (an untruncated list shows no batch button). The negative pair is what stops "always render the button" from passing trivially.
- [x] Reviewer checked the rebase did not drop the i18n key `views.overviewView.taskAhead` that landed on main hours earlier in PR #1764; both locale files diff against `origin/main` as exactly one added line and zero removed lines.

## Review Evidence

- CEO semantic acceptance: performed against the task plan's Goal, which quotes PR #1750's own Goal verbatim rather than paraphrasing it. Both clauses are now satisfied.
- CEO architecture acceptance: the read-shape rewrite is confined to one renderer module; no daemon read surface, CLI surface, or kernel type changed.
- The reviewer did not accept the worker's report as evidence. `check:local` was re-run independently, the new read path was read in full rather than trusted from its summary, and the rebase's effect on the overlapping i18n files was checked directly.
- Blocking findings: none.

## Residual Risk

- Accumulated rows are never removed from the merged cut. This ledger is append-only, so no task disappears from an unfiltered list, and the row map is keyed by task id; but if a future filter is added to this query, a row that stops matching would linger until a restart. Worth knowing before anyone adds a facet to this call.
- Initial hydration is now progressive rather than instantaneous: at 1538 tasks the first complete cut takes four refresh ticks (~8 seconds) instead of one blocking pass. The sidebar shows a catching-up indicator throughout, and steady state afterwards is one delta request per tick. This is the intended trade.
- A delta read larger than one page resumes through the plain cursor path rather than a delta cursor, so it re-walks part of the full list. Correctness is preserved because the watermark does not advance until a delta fits in one page, but it costs extra requests in that rare case.

## References

- Overturned verdict: `harness/tasks/task_7677343c18761c7281bc955d86-plt-gui-ux/artifacts/adversarial-verification.md`
- Original W6: PR #1750, merge commit `3d3788cc9`

---

# 中文

## 概要

把 PR #1750 自己的 Goal 里从未被验证的那一半补完。W6(「规模处理」)当初是凭 DOM 节点数的证据判 done 的,但它的 Goal 还有两个合取项:前端不得把支持 cursor/limit 的读面消费成「一次拉 500 直到拉完」;事件流不得有静默的条数截断。这两条在 main 上都还是假的。PLT-GUI-UX 里程碑的红队复核正是在这两条上推翻了 W6 的 done 判定,CEO 在开这个任务前已逐字复核并确认推翻成立。

本 PR 不动 W6 已经做成的 DOM 那一半,只收口这两条没验过就发车的合取项。

## 改动内容

- **台账读取形态。** `packages/gui/src/renderer/task-data.ts` 原来的 `readTaskPages` 会一直循环到 `page.nextCursor` 为空 —— 配合 `limit=500` 与 2 秒刷新间隔,就是每 2 秒发 `ceil(行数/500)` 个请求,与台账规模线性增长。现在改成**一次刷新最多一个请求**:切面没读完就沿游标续读,读完之后转成 `changedAfterRevision` 增量读。续读游标存在 react-query 缓存里,不需要模块级可变变量。
- **完整性不变量用保守方向守住。** 切面没读完时,对外报的 `watermark`/`sourceRevision` 取上一份与新页的**最小值**,所以「只读了一半的台账」永远不会把自己谎报成一个更新版本上的完整切面。只有「锚在上一个水位上、且一页就读完」的增量读才推进水位。未读完的切面 `status` 是 `pending`,侧栏本来就把它渲染成「正在追赶」提示 —— 也就是说「还没读完」这件事在界面上是显形的,不是静默的。
- **六处静默截断现在都交代还剩多少条**,做法全部照抄本仓 `BoardView` 已有的批量按钮,没有发明新东西:命令面板(前 50)、任务预览抽屉的事件流(前 4)、运行时 inspector 的三个段落(各前 8)、`DecisionsView` 的 canonical 判定历史(前 12)。
- **刻意不改的一处:** `navigation/focusHistory.ts` 里两处 `stack.slice(-50)`。那是把浏览回退栈的长度封顶,不是把一份列表截断 —— 被丢掉的条目本来就不出现在任何列表里,给它加「还剩 N 条」没有意义。任务计划里事先写下了这条排除理由,好让下一个人不必再查一遍。

## 机读声明说明

Production-Delta 的口径与 G33 门一致,数值由门脚本实测得出,非手工估算。

## 任务与范围

- Harness 任务:task_be076d3ac25b87b79be09b02dd
- 分支:codex/w6-goal-second-half
- 公开范围:`packages/gui/src/renderer/**`、`packages/gui/test/**`、`tools/gui-test-manifest.mjs`
- 私有计划/证据已更新:是
- 范围外:W6 已经落地的 DOM 节点削减;daemon 侧的台账读面(它本来就正确支持 cursor/limit,不需要改)。

## 版本影响

- 版本:不变更;这是 renderer 的行为修复,没有对外发布面
- 发布影响:不发布

## 治理声明

- 触碰 protected surface:**是**
- Protected surface 范围:`tools/gui-test-manifest.mjs` —— 新增两行,登记两个新的 GUI 测试文件。零删除,未改任何阈值,未改写任何既有条目。
- 权威依据:harness 任务 task_be076d3ac25b87b79be09b02dd,以及该 manifest 自己的 fail-closed 契约。`tools/run-gui-tests.test.mjs` 断言「GUI Vitest manifest fails closed on unclassified files」,也就是说新增的 `packages/gui/test/*.vitest.ts` 如果**不**登记,门就会红。登记是新增 GUI 测试的强制路径,不是放宽某个门 —— 这个改动严格扩大了门实际跑的范围。
- 机检边界:本 PR 只断言声明存在;是否为真、是否充分由复核者判断。
- Break-glass:否

## 验证

- 基线 `origin/main` SHA:6809823b89cc0114e742bb8c81231ac6bef9eae1
- 分支与 `origin/main` 的 merge-base:6809823b89cc0114e742bb8c81231ac6bef9eae1
- 最近一次 `git fetch origin`:2026-08-24,开 PR 前
- 同步方式:rebase
- 公开 diff 命令:`git diff origin/main...codex/w6-goal-second-half`
- 私有证据路径:`harness/tasks/task_be076d3ac25b87b79be09b02dd-*/artifacts/w6-goal-second-half.md`
- 复核者证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待补;本 PR 正是为取得它而开
- [x] `npm run check:local` —— 通过,退出码 0,零失败步骤,由复核者在分支 worktree 上独立重跑
- [x] 真实台账上的请求数实测:1538 个任务时,改前每次刷新 4 个请求,改后 1 个
- [x] 截断显形测试共 8 条断言 —— 6 条正向(被截断的列表要交代剩余条数)、**2 条负向**(没被截断时不许出现批量按钮)。这对负向断言挡住的正是「无脑常显按钮」这种假通过。
- [x] 复核者核查了 rebase 有没有吃掉几小时前 PR #1764 落在 main 上的 i18n 键 `views.overviewView.taskAhead`:两份语言文件相对 `origin/main` 都是恰好新增一行、删除零行。

## 审查证据

- CEO 语义验收:对照任务计划里的 Goal 逐条核对,而该 Goal 是逐字引用 PR #1750 自己的 Goal,不是转述。两个合取项现在都满足。
- CEO 架构验收:读取形态的重写收敛在一个 renderer 模块内,没有改动任何 daemon 读面、CLI 命令面或 kernel 类型。
- 复核者没有把 worker 的报告当证据:`check:local` 由复核者独立重跑,新的读取路径是通读原文而非采信摘要,rebase 对重叠 i18n 文件的影响是直接查证的。
- 阻塞性发现:无。

## 残余风险

- 合并后的切面里,累积的行永远不会被移除。本台账是只增不删的,未筛选列表里不会有任务消失,行也按 task id 作主键;但如果将来有人给这个查询加筛选面,一条不再匹配的行会滞留到下次重启。加 facet 之前应当知道这件事。
- 首次水化从「一次读完」变成渐进式:1538 个任务时,第一个完整切面要四个刷新周期(约 8 秒),而不是一次阻塞式读完。整个过程侧栏都显示「正在追赶」提示,之后稳态是每周期一个增量请求。这是本改动有意换取的取舍。
- 超过一页的增量读会走普通游标续读而不是增量游标,因此会重走一部分全量列表。正确性不受影响(水位在增量读装不下一页时不推进),但那种少见情况下会多花几个请求。

## 关联材料

- 推翻证据:`harness/tasks/task_7677343c18761c7281bc955d86-plt-gui-ux/artifacts/adversarial-verification.md`
- 原 W6:PR #1750,merge commit `3d3788cc9`
