### PR TITLE
fix(gui): bound the overview ahead band and state the rows it defers

### DIFF
--- a/packages/gui/src/renderer/components/overview/TaskStream.tsx
+++ b/packages/gui/src/renderer/components/overview/TaskStream.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { SnapshotStatus, TaskRow } from "../../model/types";
 import type { WorkspaceSummaryRead } from "../../../api/renderer-dto.ts";
 import { BOARD_COLUMNS } from "../../model/types";
@@ -6,6 +6,16 @@ import { sortTasksByCreatedDesc, taskCreatedAt } from "../../model/ledger-timeli
 import { STATUS_META, StatusBadge } from "../badges.tsx";
 import { t } from "../../i18n/index.tsx";
 import { StreamBody, StreamEmpty, StreamExitButton, StreamTabs, streamTime } from "./streamParts.tsx";
+
+/**
+ * 「更新的」这一段一次渲染这么多行,剩下的靠批量按钮显形——照抄本仓 BoardView 与命令面板的做法。
+ *
+ * 这一段的组员是「比当前筛选里最新那行还新、且不属于该筛选状态」的任务,所以它的规模不是常数:
+ * 当前筛选一行都没有时阈值按设计退化为无阈值(那是为了让全新仓库刚建的第一条任务能浮现),
+ * 于是全部有已知创建时间的任务都合格。本仓 1538 个任务时,那一档实测会渲染 1475 行。
+ * 分批渲染把 DOM 节点数与任务总量脱钩,而标题仍然显示真实总数,所以被推迟渲染的行是显形的、不是被吞掉的。
+ */
+const AHEAD_BATCH_SIZE = 12;
 
 const ROW_CLASS =
   "flex w-full items-center gap-2 rounded-md border border-border bg-surface-raised px-2 py-1 text-left" +
@@ -83,6 +93,11 @@ export function TaskStream({
     [tasks, status],
   );
   const ahead = useMemo(() => tasksAheadOfStatus(tasks, status), [tasks, status]);
+  const [aheadVisible, setAheadVisible] = useState(AHEAD_BATCH_SIZE);
+  // 切换筛选会换掉这一段的全部组员,展开状态不能跟着过去。
+  useEffect(() => { setAheadVisible(AHEAD_BATCH_SIZE); }, [status]);
+  const aheadShown = useMemo(() => ahead.slice(0, aheadVisible), [ahead, aheadVisible]);
+  const aheadHidden = ahead.length - aheadShown.length;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-2">
@@ -112,9 +127,22 @@ export function TaskStream({
             {t("views.overviewView.taskAhead", { count: ahead.length })}
           </p>
           <div className="max-h-[6rem] space-y-0.5 overflow-y-auto pr-1" data-testid="task-stream-ahead-rows">
-            {ahead.map((task) => (
+            {aheadShown.map((task) => (
               <TaskStreamRow key={task.taskId} task={task} onOpenPreview={onOpenPreview} />
             ))}
+            {aheadHidden > 0 && (
+              <button
+                type="button"
+                data-testid="task-stream-ahead-more"
+                onClick={() => setAheadVisible((count) => Math.min(count + AHEAD_BATCH_SIZE, ahead.length))}
+                className="w-full px-1 py-1 text-center font-mono text-[11px] text-text-muted hover:text-text"
+              >
+                {t("views.overviewView.taskAheadShowMore", {
+                  count: Math.min(AHEAD_BATCH_SIZE, aheadHidden),
+                  remaining: aheadHidden,
+                })}
+              </button>
+            )}
           </div>
         </div>
       )}

--- a/packages/gui/src/renderer/i18n/locales/en-US/views.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/views.json
@@ -227,6 +227,7 @@
   "views.overviewView.decisionEmpty": "No decisions in this state.",
   "views.overviewView.taskEmpty": "No tasks in this status.",
   "views.overviewView.taskAhead": "{count} newer · outside this status filter",
+  "views.overviewView.taskAheadShowMore": "Show {count} more · {remaining} remaining",
   "views.overviewView.pinnedEmpty": "No pinned tasks right now.",
   "views.overviewView.pinnedHint": "Mark what you are working on with ha task pin <task-id>.",
   "views.overviewView.goInbox": "Judge queue",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/views.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/views.json
@@ -227,6 +227,7 @@
   "views.overviewView.decisionEmpty": "该状态下暂无决策。",
   "views.overviewView.taskEmpty": "该状态下暂无任务。",
   "views.overviewView.taskAhead": "更新的 {count} 条 · 不在当前状态筛选内",
+  "views.overviewView.taskAheadShowMore": "再显示 {count} 条 · 还有 {remaining} 条",
   "views.overviewView.pinnedEmpty": "当前没有 pin 的任务。",
   "views.overviewView.pinnedHint": "用 ha task pin <task-id> 标记你正在做的任务。",
   "views.overviewView.goInbox": "去批准",

--- a/packages/gui/test/overview-streams.vitest.ts
+++ b/packages/gui/test/overview-streams.vitest.ts
@@ -312,6 +312,56 @@ describe("overview task stream: freshly created tasks are visible with zero inte
     expect(markup).not.toContain("Older done");
   });
 
+  // 这一段的规模不是常数:当前筛选一行都没有时阈值退化为无阈值,于是全部有已知创建时间的
+  // 任务都合格。本仓 1538 个任务时那一档实测 1475 行(fact F-EDD4483A)。分批渲染让 DOM
+  // 节点数与任务总量脱钩,而标题仍报真实总数,所以推迟渲染的行是显形的、不是被吞掉的。
+  it("bounds the ahead band DOM and states how many rows it deferred", () => {
+    const rows = Array.from({ length: 45 }, (_, index) => task({
+      taskId: `task_ahead_${index}`, title: `Ahead ${index}`, coordinationStatus: "planned",
+      createdAt: `2026-08-22T09:${String(index).padStart(2, "0")}:00.000Z`,
+    }));
+    const markup = renderToStaticMarkup(createElement(TaskStream, {
+      tasks: [task({ taskId: "task_old_active", title: "Older active task", coordinationStatus: "active", createdAt: "2026-08-20T10:00:00.000Z" }), ...rows],
+      summary: taskSummary({ active: 1, planned: 45 }), onOpenPreview: noop, onGoBoard: noop,
+    }));
+    const ahead = section(markup, "task-stream-ahead-rows");
+    expect(ahead).not.toBeNull();
+    expect(ahead!.match(/title="task_ahead_/gu)).toHaveLength(12);
+    expect(ahead).toContain('data-testid="task-stream-ahead-more"');
+    expect(ahead).toContain("还有 33 条");
+    // 标题报的是真实总数,不是渲染出来的行数——被推迟的行在界面上有交代。
+    expect(markup).toContain("更新的 45 条");
+  });
+
+  // 负向断言:没超出一批时不许出现批量按钮。没有它,「无脑常显按钮」也能让上面那条变绿。
+  it("shows no batch button when the ahead band fits in one batch", () => {
+    const rows = Array.from({ length: 5 }, (_, index) => task({
+      taskId: `task_ahead_${index}`, title: `Ahead ${index}`, coordinationStatus: "planned",
+      createdAt: `2026-08-22T09:0${index}:00.000Z`,
+    }));
+    const markup = renderToStaticMarkup(createElement(TaskStream, {
+      tasks: [task({ taskId: "task_old_active", title: "Older active task", coordinationStatus: "active", createdAt: "2026-08-20T10:00:00.000Z" }), ...rows],
+      summary: taskSummary({ active: 1, planned: 5 }), onOpenPreview: noop, onGoBoard: noop,
+    }));
+    expect(section(markup, "task-stream-ahead-rows")!.match(/title="task_ahead_/gu)).toHaveLength(5);
+    expect(markup).not.toContain('data-testid="task-stream-ahead-more"');
+  });
+
+  // 最坏一档:active 筛选为空,阈值退化为无阈值,全部任务合格。DOM 仍须与总量脱钩。
+  it("stays bounded when the active filter is empty and every task qualifies", () => {
+    const rows = Array.from({ length: 60 }, (_, index) => task({
+      taskId: `task_done_${index}`, title: `Done ${index}`, coordinationStatus: "done",
+      createdAt: `2026-08-22T09:${String(index).padStart(2, "0")}:00.000Z`,
+    }));
+    const markup = renderToStaticMarkup(createElement(TaskStream, {
+      tasks: rows, summary: taskSummary({ done: 60 }), onOpenPreview: noop, onGoBoard: noop,
+    }));
+    const ahead = section(markup, "task-stream-ahead-rows");
+    expect(ahead!.match(/title="task_done_/gu)).toHaveLength(12);
+    expect(markup).toContain("更新的 60 条");
+    expect(ahead).toContain("还有 48 条");
+  });
+
   it("derives the ahead rows purely from the selected status (unit-level invariant)", () => {
     const rows = freshWorkspace();
     expect(tasksAheadOfStatus(rows, "active").map((row) => row.taskId)).toEqual(["task_new_planned"]);


### PR DESCRIPTION
# English

## Summary

The overview's "ahead" band — the strip that surfaces tasks newer than the newest row of the current filter, added yesterday in PR #1764 so a freshly created task is visible with zero interaction — renders every qualifying row with no upper bound. Its size is not a constant: when the current filter matches nothing, the threshold degrades to no threshold **by design** (that is what lets the very first task of a brand-new workspace surface), and every task with a known creation time qualifies. Measured on this repository's real ledger of 1538 tasks, that case renders **1475 rows**.

This was measured by the reviewer while accepting #1764, not reported by its author, and recorded as fact `F-EDD4483A`.

## What Changed

- `packages/gui/src/renderer/components/overview/TaskStream.tsx` renders the band one batch of 12 at a time, with the batch button this repository already uses in `BoardView`, the command palette, and — as of PR #1765 — five other places. Nothing was invented for this fix.
- The band's heading still reports the **true total** (`更新的 {count} 条`), so deferred rows are stated rather than swallowed. This matters because the whole point of #1764 was that a new task must not silently vanish, and the whole point of W6 was that no list may silently truncate. Bounding this band by cutting rows and saying nothing would have violated both.
- Switching the status tab resets the batch, because a tab switch replaces every member of this band; an expanded state must not carry over into a different set.

## Machine-Readable Declarations

Production-Delta: +30/-2

## Task And Scope

- Harness task: task_c4126ada741eddfe523e1e8bbd
- Branch: codex/ahead-band
- Public scope: `packages/gui/src/renderer/components/overview/TaskStream.tsx`, its two locale files, and `packages/gui/test/overview-streams.vitest.ts`
- Private planning/evidence updated: yes
- Out of scope: the ahead band's membership rule itself. Narrowing *which* tasks qualify would change the visibility guarantee PR #1764 established; this PR only bounds how many are painted at once.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no — the governance checker was run against this branch's changed-file list and reported no protected path among its 89 manifest-derived rules. No new test *file* was added, only assertions inside an already-registered one, so no test manifest changes.
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: bb60bfb550c4dad273810da57727e1b850c9692b
- Branch merge-base with `origin/main`: bb60bfb550c4dad273810da57727e1b850c9692b
- Last `git fetch origin` time: 2026-08-24, immediately before opening this PR
- Sync method: rebase
- Public diff command: `git diff origin/main...codex/ahead-band`
- Private evidence commit/path: `harness/tasks/task_c4126ada741eddfe523e1e8bbd-*/`
- GitHub Actions `rewrite-ci` run URL: pending; this PR is opened to obtain it
- [x] `npm run check:local` — pass, exit 0, zero failing steps
- [x] `npm run test:gui` — 46 files / 399 tests pass (396 before this change)
- [x] Three assertions added: the bounded worst case with the batch button and its stated remainder, the empty-filter case where every task qualifies, and **a negative case** — a band that fits in one batch must show no button. Without the negative one, "always render the button" would pass the other two.
- [x] Positive control run: rendering `ahead` instead of the batched slice turns exactly the two bounding assertions red and correctly leaves the negative one green.

## Review Evidence

- This change was implemented by the CEO rather than delegated. The machine was at load average 136 on 16 cores at the time — consumed entirely by macOS iCloud sync daemons (`fileproviderd` 101%, `cloudd` 55%, `bird` 52%), unrelated to this repository, which is not under an iCloud-synced path. Dispatching a worker onto that would have been slower than writing a known, single-file diff whose pattern had landed hours earlier. Recorded as fact `F-84756517`.
- Blocking findings: none.

## Residual Risk

- The batch size of 12 is a judgement, not a measurement. The band's container is `max-h-[6rem]` and scrolls internally, so roughly four rows are visible at rest; 12 gives a scroll's worth of depth without paying for the tail. If it reads as too few in practice it is a one-constant change.
- The band's membership rule is unchanged, so the empty-filter case still *qualifies* every task — it just paints twelve of them. The count in the heading will still read `更新的 1475 条` on such a workspace, which is honest but visually loud. Whether that heading should itself be phrased differently is a design question left open.

---

# 中文

## 概要

总览的「更新的」那一段 —— 昨天 PR #1764 加的、用来让刚建好的任务零交互可见的那条带 —— 会把所有合格的行一次渲染完,没有上界。它的规模不是常数:当前筛选一行都没有时,阈值**按设计**退化为无阈值(那正是让全新工作区的第一条任务能浮现的机制),于是全部有已知创建时间的任务都合格。在本仓 1538 个任务的真实台账上实测,那一档会渲染 **1475 行**。

这个数是复核者在验收 #1764 时自己量出来的,不是实现方报的,已记为 fact `F-EDD4483A`。

## 改动内容

- `packages/gui/src/renderer/components/overview/TaskStream.tsx` 改为一次渲染 12 行一批,用的是本仓 `BoardView`、命令面板、以及 PR #1765 刚落地的另外五处都在用的批量按钮。这次修复没有发明任何新东西。
- 这一段的标题仍然报**真实总数**(`更新的 {count} 条`),所以被推迟的行是交代过的,不是被吞掉的。这一点承重:#1764 的全部意义就是新任务不许无声消失,W6 的全部意义就是列表不许静默截断 —— 用「砍掉行然后不告诉用户」来给这条带封顶,会同时违反这两条。
- 切换状态页签会重置批次,因为切页签会换掉这一段的全部组员;展开状态不该带进一组完全不同的内容里。

## 机读声明说明

Production-Delta 的口径与 G33 门一致,数值由门脚本实测得出,非手工估算。

## 任务与范围

- Harness 任务:task_c4126ada741eddfe523e1e8bbd
- 分支:codex/ahead-band
- 公开范围:`packages/gui/src/renderer/components/overview/TaskStream.tsx`、两份语言文件、`packages/gui/test/overview-streams.vitest.ts`
- 私有计划/证据已更新:是
- 范围外:这条带的**成员判定规则**本身。收窄「哪些任务合格」会改变 PR #1764 建立的可见性保证;本 PR 只限制一次画多少行。

## 版本影响

- 版本:不变更
- 发布影响:不发布

## 治理声明

- 触碰 protected surface:否 —— 治理 checker 已用本分支的变更文件清单跑过,89 条 manifest 派生规则下无一命中。没有新增测试**文件**,只是在一个已登记的文件里加断言,所以不涉及任何测试 manifest 改动。
- Protected surface 范围:不适用
- 权威依据:不适用
- 机检边界:本 PR 只断言声明存在;是否为真、是否充分由复核者判断。
- Break-glass:否

## 验证

- 基线 `origin/main` SHA:bb60bfb550c4dad273810da57727e1b850c9692b
- 分支与 `origin/main` 的 merge-base:bb60bfb550c4dad273810da57727e1b850c9692b
- 最近一次 `git fetch origin`:2026-08-24,开 PR 前
- 同步方式:rebase
- 公开 diff 命令:`git diff origin/main...codex/ahead-band`
- 私有证据路径:`harness/tasks/task_c4126ada741eddfe523e1e8bbd-*/`
- GitHub Actions `rewrite-ci` run URL:待补;本 PR 正是为取得它而开
- [x] `npm run check:local` —— 通过,退出码 0,零失败步骤
- [x] `npm run test:gui` —— 46 个文件 / 399 个测试通过(改动前是 396)
- [x] 新增三条断言:有界的最坏一档(带批量按钮与它报的剩余数)、筛选为空时全部任务合格的一档、以及**一条负向断言** —— 一批装得下时不许出现按钮。没有那条负向的,「无脑常显按钮」也能让前两条变绿。
- [x] 已跑阳性对照:把批量切片换回整个 `ahead`,恰好两条「有界」断言变红,负向那条正确保持绿。

## 审查证据

- 本改动由 CEO 亲自实现而非派工。当时本机 load average 是 16 核上的 136,消耗全部来自 macOS 的 iCloud 同步守护进程(`fileproviderd` 101%、`cloudd` 55%、`bird` 52%),与本仓无关 —— 仓库路径不在 iCloud 同步区。往那个负载上派 worker,比自己写一个确切的、单文件的、模式在几小时前刚落地的 diff 更慢。已记为 fact `F-84756517`。
- 阻塞性发现:无。

## 残余风险

- 每批 12 行是判断,不是测量。这条带的容器是 `max-h-[6rem]` 且内部滚动,静止时大约露出四行;12 给出一屏滚动的纵深,又不为长尾买单。如果实际用起来觉得少了,那是改一个常数的事。
- 成员判定规则没有变,所以筛选为空那一档仍然让全部任务**合格**,只是只画其中十二行。那种工作区里标题仍会读作「更新的 1475 条」,这是诚实的,但视觉上很吵。这个标题本身该不该换个说法,是一个留待回答的设计问题。
