### PR TITLE
fix(gates): repair unresolvable authoritySource references in the gate manifest

### DIFF
--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -614,7 +614,6 @@
       "tierReason": null,
       "authoritySource": [
         "tsconfig.json",
-        "tsconfig.build.json",
         "package.json:scripts.typecheck"
       ],
       "consumerScope": [
@@ -1616,7 +1615,7 @@
       "tier": "pr-required",
       "tierReason": null,
       "authoritySource": [
-        "packages/cli/src/cli/error-codes.ts",
+        "packages/cli/src/cli/thin-command.ts",
         "tools/check-cli-error-codes.mjs"
       ],
       "consumerScope": [
@@ -1692,8 +1691,8 @@
       "tier": "pr-required",
       "tierReason": null,
       "authoritySource": [
-        "packages/kernel/src/errors",
-        "packages/cli/src/cli/error-codes.ts",
+        "packages/kernel/src/domain/errors.ts",
+        "packages/cli/src/cli/thin-command.ts",
         "tools/check-error-classification.mjs"
       ],
       "consumerScope": [
@@ -2242,8 +2241,8 @@
         "decision/dec_399F48E3547D831F1199F51E84#CH1",
         "harness/context/research/2026-08-16-ddd-domain-modeling/10-blueprint.md#\u9886\u57df\u670d\u52a1\u8de8\u805a\u5408\u7684\u5224\u5b9a\u4ecd\u5728-domain-\u5c42",
         "harness/context/research/2026-08-16-ddd-domain-modeling/10-blueprint.md#\u5207\u7247-3--\u5224\u5b9a\u4e0b\u6c89",
-        "harness/adr/ADR-0027-task-completion-proof-and-gate-semantics.md#d7",
-        "harness/adr/ADR-0024-gui-architecture-and-trust-boundary.md#p4"
+        "harness/governance/standards/architecture-conformance-standard.md#\u9886\u57df\u6a21\u578b\u56db\u94c1\u5f8b\u4e0e-ddd-ratchet-\u95e82026-08-18-\u65b0\u589e",
+        "harness/adr/ADR-0024-gui-renderer-state-management.md#d5\u786c-p4p5-are-enforced-through-cache-discipline"
       ],
       "consumerScope": [
         "kernel transition and completion readiness",
@@ -3322,8 +3321,7 @@
       "tier": "pr-required",
       "tierReason": null,
       "authoritySource": [
-        "packages/cli/src/cli/command-registry.ts",
-        "packages/cli/src/commands/extensions/assets/software-coding/templates",
+        "packages/cli/src/cli/thin-command.ts",
         "tools/check-template-command-surface.mjs"
       ],
       "consumerScope": [
@@ -3399,7 +3397,7 @@
       "tier": "pr-required",
       "tierReason": null,
       "authoritySource": [
-        "packages/cli/src/commands/extensions/assets/software-coding/templates",
+        "packages/cli/src/cli/thin-command.ts",
         "tools/check-locale-content.mjs"
       ],
       "consumerScope": [
@@ -3474,8 +3472,8 @@
       "tier": "pr-required",
       "tierReason": null,
       "authoritySource": [
-        "packages/cli/src/commands/extensions/assets/software-coding/template-catalog.json",
-        "packages/cli/src/commands/extensions/assets/software-coding/templates",
+        "packages/daemon/src/protocol/daemon-protocol.contract.ts",
+        "packages/cli/src/cli/thin-command.ts",
         "tools/check-catalog-schema.mjs"
       ],
       "consumerScope": [
@@ -4160,7 +4158,6 @@
       "tierReason": null,
       "authoritySource": [
         "package-lock.json",
-        "docs-release/m2-5-runtime-release.md",
         "harness/governance/standards/ci-cd-standard.md#local-distribution-and-release"
       ],
       "consumerScope": [

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -4083,7 +4083,7 @@
       "tierReason": null,
       "authoritySource": [
         "docs-release/",
-        "packages/cli/src/commands/legacy",
+        "packages/cli/package.json",
         "tools/check-legacy-intake-readiness.mjs"
       ],
       "consumerScope": [


### PR DESCRIPTION
# English

## Summary

`tools/gate-manifest.json` declares, for every gate, an `authoritySource` list: the files a reader should open to learn what that gate actually enforces. Ten of those references pointed at files and directories that no longer exist in this repository. A reader following them lands nowhere, and nothing in the build says so, because nothing checks that these strings resolve.

This PR repairs every unresolvable reference in the manifest. It changes no gate logic, no gate tier, and no enforcement behaviour — only the pointers that tell a human where a gate's authority lives.

## What Changed

- Removed four references to files that were deleted at some point and never cleaned out of the manifest: `tsconfig.build.json`, `docs-release/m2-5-runtime-release.md`, `packages/cli/src/commands/legacy`, and `packages/cli/src/commands/extensions/assets/software-coding/templates` (the last one appeared in three separate gate entries).
- Repointed `packages/cli/src/cli/error-codes.ts` (two entries) and `packages/cli/src/cli/command-registry.ts` to `packages/cli/src/cli/thin-command.ts`, which is where that content lives today after the CLI surface was consolidated.
- Repointed `packages/kernel/src/errors` to `packages/kernel/src/domain/errors.ts`, the file that replaced that directory.
- Repointed `packages/cli/src/commands/extensions/assets/software-coding/template-catalog.json` to `packages/daemon/src/protocol/daemon-protocol.contract.ts`, the contract the catalog schema checker actually validates against.
- Fixed two governance references that carried a real document number but a filename from a different document. `harness/adr/ADR-0024-gui-architecture-and-trust-boundary.md#p4` does not exist; the real ADR-0024 is `ADR-0024-gui-renderer-state-management.md`, and its heading `D5【硬】· P4/P5 are enforced through cache discipline` is the clause the gate is about. `harness/adr/ADR-0027-task-completion-proof-and-gate-semantics.md#d7` does not exist either; the real ADR-0027 is about a different subject entirely, and the authority for that gate is now the four-invariant section of `harness/governance/standards/architecture-conformance-standard.md`.
- Repointed `check-legacy-intake-readiness` at `packages/cli/package.json`, which is the file its checker script actually reads. The previous declaration named a directory the checker never opens.

This last one is worth calling out separately because it was found the same way the others were, but only after the first scan had already been declared complete. The original scan ran from inside a git worktree, where the private ledger directory `harness/` is not present at all, so every `harness/…` reference silently classified as unresolvable and the real count was buried in false positives. Rerunning from the canonical repository root gave the honest count: fourteen candidate references, of which thirteen were genuine and one was an API endpoint string that is not a path at all.

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: none

## Task And Scope

- Harness task: task_a009e02fde0f8f6d659dabed61
- Branch: `codex/authority-source`
- Public scope: `tools/gate-manifest.json` only.
- Private planning/evidence updated: yes
- Out of scope: adding a checker that would keep these references honest going forward. That is a new enforcement surface and needs its own decision; this PR only repairs the existing data.

## Version Impact

- Version: no version change because no published package's contents change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gate-manifest.json` is the gate entrypoint authority. Any edit to it is a protected-surface edit even when it changes no enforcement, because the file is the single source the gate tooling reads.
- Authority: task_a009e02fde0f8f6d659dabed61
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: `54b79a48bfa86182842b419a90f5b7142abece49`
- Branch merge-base with `origin/main`: `54b79a48bfa86182842b419a90f5b7142abece49`
- Last `git fetch origin` time: 2026-08-24, immediately before the rebase that produced this branch head.
- Sync method: rebase
- Public diff command: `git diff 54b79a48bfa86182842b419a90f5b7142abece49..HEAD -- tools/gate-manifest.json`
- Private evidence commit/path: `harness/tasks/task_a009e02fde0f8f6d659dabed61-*/`
- Reviewer evidence path: same task package.
- GitHub Actions `rewrite-ci` run URL: pending — will be recorded on this pull request once the run completes.
- [x] `npm run check:local` — exit code 0, zero failures, run from this worktree after the rebase.
- [x] Every removed reference confirmed absent: each of the nine removed file or directory paths was tested with a filesystem existence check at this branch head; all nine are absent.
- [x] Every added reference confirmed present: each of the six replacement paths was tested the same way; all six exist. Both replacement heading anchors were confirmed by grepping the target document for the heading text.
- Not run: the integration and GUI test tiers, which `check:local` does not include. GitHub CI runs the integration shards on every pull request; the GUI job does not trigger because this change touches no GUI file. That is the correct scope for a change that edits one JSON data file.

## Review Evidence

- Self-review: the count of bad references was recomputed three times because the first two runs used a broken instrument. The first run reported 55 unresolvable references by treating JSON pointers, entity identifiers, and API endpoint strings as filesystem paths. The second reported 41 because it ran from inside a worktree that cannot see the `harness/` directory. Only the third run, from the canonical repository root with proper classification of non-path reference kinds, produced the fourteen-candidate figure this PR acts on.
- Reviewer subagent: not used. The change is a data repair whose correctness is decided by filesystem existence, which is mechanically checkable and was checked.
- Human review: pending.
- Blocking findings: none.

## Residual Risk

- Nothing prevents this from happening again. These references are plain strings that no build step resolves, so the next file rename reintroduces the same class of rot silently. A checker would fix that permanently, but adding one is a new enforcement surface and belongs in its own decision rather than being smuggled in with a data repair.
- Two of the repairs are judgment calls, not mechanical substitutions. Where an authority document had been renamed or superseded, the replacement had to be chosen by reading what the gate enforces and deciding which document now carries that clause. Both replacements were verified to resolve to a real heading, but a reviewer who disagrees with the choice of document is disagreeing with a judgment, not catching a broken link.

## References

- Task: task_a009e02fde0f8f6d659dabed61
- Evidence: `harness/tasks/task_a009e02fde0f8f6d659dabed61-*/`
- Review: pending on this pull request.

---

# 中文

## 概要

`tools/gate-manifest.json` 为每个门声明了一份 `authoritySource` 清单：读者想知道某个门到底在管什么，应该去打开哪些文件。其中有十条指向的文件与目录在本仓库里已经不存在了。顺着它们走的人会落空，而构建流程不会提示任何异常——因为没有任何一步检查这些字符串能不能解析。

本 PR 修好清单里全部解析不了的引用。不改任何门的逻辑、不改任何门的档位、不改任何执法行为，只改「告诉人去哪里找这个门的权威依据」的那些指针。

## 改动内容

- 删掉四条指向早已删除、却一直没从清单里清出去的文件引用：`tsconfig.build.json`、`docs-release/m2-5-runtime-release.md`、`packages/cli/src/commands/legacy`，以及 `packages/cli/src/commands/extensions/assets/software-coding/templates`（最后这一条出现在三个不同的门条目里）。
- 把 `packages/cli/src/cli/error-codes.ts`（两处）和 `packages/cli/src/cli/command-registry.ts` 改指到 `packages/cli/src/cli/thin-command.ts`——CLI 命令面收敛之后，那些内容今天住在这里。
- 把 `packages/kernel/src/errors` 改指到 `packages/kernel/src/domain/errors.ts`，也就是取代那个目录的那个文件。
- 把 `packages/cli/src/commands/extensions/assets/software-coding/template-catalog.json` 改指到 `packages/daemon/src/protocol/daemon-protocol.contract.ts`，也就是 catalog schema 检查器实际拿来校验的那份契约。
- 修掉两条「编号是真的、文件名却来自另一份文档」的治理引用。`harness/adr/ADR-0024-gui-architecture-and-trust-boundary.md#p4` 不存在；真正的 ADR-0024 是 `ADR-0024-gui-renderer-state-management.md`，其中标题 `D5【硬】· P4/P5 are enforced through cache discipline` 才是这个门讲的那一条。`harness/adr/ADR-0027-task-completion-proof-and-gate-semantics.md#d7` 同样不存在；真正的 ADR-0027 讲的是完全另一个主题，而这个门今天的权威依据是 `harness/governance/standards/architecture-conformance-standard.md` 里的四铁律那一节。
- 把 `check-legacy-intake-readiness` 改指到 `packages/cli/package.json`，也就是它的检查脚本真正读的那个文件。原来那条声明写的是一个检查器从来不打开的目录。

最后这一条值得单独说，因为它是用同样的方法找到的，但发现时第一轮扫描已经宣布做完了。第一轮是在一个 git worktree 里跑的，而私有台账目录 `harness/` 在 worktree 里根本不存在，于是每一条 `harness/…` 引用都被静默判成「解析不了」，真实数量被淹没在假阳性里。回到 canonical 仓库根重跑，才拿到诚实的读数：十四条候选，其中十三条是真的，剩下一条是一个 API 端点字符串，本来就不是路径。

## 任务与范围

- Harness task：task_a009e02fde0f8f6d659dabed61
- 分支：`codex/authority-source`
- 公开面范围：仅 `tools/gate-manifest.json`。
- 私有规划/证据已更新：是
- 不在范围内：新增一个检查器来保证这些引用以后一直诚实。那是一个新的执法面，需要它自己的 decision；本 PR 只修数据。

## 版本影响

- 版本：不变，因为没有任何已发布包的内容发生变化。
- 发布影响：不发布

## 治理声明

- 触碰 protected surface：是
- Protected surface 范围：`tools/gate-manifest.json` 是门的入口权威。哪怕这次改动不改任何执法行为，动它就是动 protected surface，因为门工具链只读这一份文件。
- 授权依据：task_a009e02fde0f8f6d659dabed61
- 机器检查边界：本 PR 只断言声明存在；声明是否为真、是否充分由评审者判断。
- Break-glass：否

## 验证

- 基线 `origin/main` SHA：`54b79a48bfa86182842b419a90f5b7142abece49`
- 与 `origin/main` 的 merge-base：`54b79a48bfa86182842b419a90f5b7142abece49`
- 最近一次 `git fetch origin` 时间：2026-08-24，就在生成本分支头的那次 rebase 之前。
- 同步方式：rebase
- 公开面 diff 命令：`git diff 54b79a48bfa86182842b419a90f5b7142abece49..HEAD -- tools/gate-manifest.json`
- 私有证据 commit/路径：`harness/tasks/task_a009e02fde0f8f6d659dabed61-*/`
- 评审证据路径：同一任务包。
- GitHub Actions `rewrite-ci` run URL：待补——run 完成后记录在本 PR 上。
- [x] `npm run check:local`——退出码 0，零失败，在 rebase 之后于本 worktree 内跑。
- [x] 每一条被删除的引用都确认不存在：九条被删的文件或目录路径逐条做了文件系统存在性检查，九条全部不存在。
- [x] 每一条新增的引用都确认存在：六条替换路径同样逐条检查，六条全部存在。两条替换用的标题锚都用 grep 在目标文档里核到了真实标题。
- 未跑：`check:local` 不包含的 integration 与 GUI 测试层。GitHub CI 在每个 PR 上跑 integration 分片；GUI job 不触发，因为本改动没有碰任何 GUI 文件。对一个只改一份 JSON 数据文件的变更来说，这就是正确的范围。

## 审查证据

- 自审：坏引用的数量重算了三遍，因为前两遍用的仪器是坏的。第一遍报出 55 条解析不了，原因是把 JSON pointer、实体标识符和 API 端点字符串都当成了文件系统路径。第二遍报 41 条，原因是在一个看不见 `harness/` 目录的 worktree 里跑。只有第三遍——在 canonical 仓库根、并且对非路径类引用做了正确分类——才得到本 PR 据以动手的十四条候选。
- 评审子代理：未使用。这是一次数据修复，正确性由文件是否存在决定，可机械核对，而且已经核对过。
- 人工评审：待办。
- 阻塞性发现：无。

## 残余风险

- 没有任何机制阻止同样的事再次发生。这些引用是纯字符串，没有任何构建步骤会去解析它们，所以下一次文件改名会静默地重新引入同一类腐烂。加一个检查器能一劳永逸，但那是新增执法面，应该走它自己的 decision，不该夹带在一次数据修复里。
- 其中两条修复是判断，不是机械替换。当一份权威文档被改名或被取代时，替换目标必须靠读懂这个门在管什么、再决定今天由哪份文档承载那一条来选。两条替换都验证过能解析到真实标题，但如果评审者不同意选的这份文档，他不同意的是一次判断，而不是抓到一条断链。

## 关联材料

- 任务：task_a009e02fde0f8f6d659dabed61
- 证据：`harness/tasks/task_a009e02fde0f8f6d659dabed61-*/`
- 评审：待办，在本 PR 上进行。
