### PR TITLE
fix(gui): bind the dispatch end-to-end test to its fake Codex installation

### DIFF
--- a/packages/gui/e2e/electron-smoke.e2e.mjs
+++ b/packages/gui/e2e/electron-smoke.e2e.mjs
@@ -108,7 +108,7 @@ test("Electron shell opens its first BrowserWindow", { timeout: 90_000 }, async 
   await page.locator('[data-entity="decision"]').first().click();
   await page.locator("aside").getByText("decision/dec_gui_smoke", { exact: true }).waitFor();
   await page.locator('[data-entity="task"]').first().click();
-  await page.locator("aside").getByText("task-gui-smoke", { exact: true }).waitFor();
+  await page.locator("aside").getByText("task/task-gui-smoke", { exact: true }).waitFor();
   await page.getByRole("button", { name: "打开", exact: true }).click();
   // W3 起 Task 详情是分页签的:上游 decision 归「关系」页签,默认页签是「概况」;
   // 同一次重构把关系类型拆成了独立的 label badge,链接按钮上只剩 peer 引用。
@@ -176,6 +176,9 @@ test("GUI creates a Runtime and Agent from zero, invokes its selected Skill, and
   const runtimeDialog = page.getByTestId("new-runtime-dialog");
   await runtimeDialog.waitFor();
   await runtimeDialog.getByRole("button", { name: "Codex", exact: true }).click();
+  const fakeInstallationChoice = runtimeDialog.locator("button", { hasText: codexInstallation.installationId });
+  await fakeInstallationChoice.waitFor();
+  await fakeInstallationChoice.click();
   await runtimeDialog.getByTestId("new-runtime-id").fill("gui-from-zero");
   await runtimeDialog.getByLabel(/^(?:名称|Name)$/u).fill("GUI From Zero");
   // model 面自 bd7d9422e 起是多选 checkbox 列表,不再是单选 select。原断言
@@ -195,6 +198,14 @@ test("GUI creates a Runtime and Agent from zero, invokes its selected Skill, and
   assert.equal(await createRuntime.isEnabled(), true, "blank-model Runtime form did not become creatable from the detected default");
   await createRuntime.click();
   await page.getByTestId("rail-runtime-gui-from-zero").waitFor({ timeout: 20_000 });
+  const savedRuntime = JSON.parse(
+    readFileSync(resolve(daemonFixture.userRoot, "runtime-instances.json"), "utf8"),
+  ).instances.find((instance) => instance.instanceId === "gui-from-zero");
+  assert.equal(
+    savedRuntime?.installationId,
+    codexInstallation.installationId,
+    "e2e Runtime did not bind the witnessed fake Codex installation",
+  );
 
   await page.getByRole("button", { name: /^(?:Agents · Squads|Agent · 含 Squad)$/u }).click();
   await page.getByTestId("runtime-new-agents").click();
@@ -260,26 +271,29 @@ test("GUI creates a Runtime and Agent from zero, invokes its selected Skill, and
   await page.getByTestId("task-detail-view").waitFor({ timeout: 10_000 });
   await page.getByRole("tab", { name: "派工" }).click();
   const dispatchTab = page.getByTestId("task-dispatch-tab");
-  await dispatchTab.locator("article").first().waitFor({ timeout: 20_000 });
+  const dispatchChain = dispatchTab.locator('[data-testid^="dispatch-chain-"]').first();
+  await dispatchChain.waitFor({ timeout: 20_000 });
   assert.match(await dispatchTab.textContent(), new RegExp(runtimeSessionId, "u"), "dispatch chain lost the runtime session id");
-  const dispatchId = (await dispatchTab.textContent()).match(/dispatch_[a-z0-9]+/u)?.[0];
+  const dispatchId = (await dispatchChain.getAttribute("data-testid"))?.slice("dispatch-chain-".length);
   assert.ok(dispatchId, "GUI did not display a dispatch id in the dispatch chain");
   const reportText = dispatchTab.locator("pre").first();
   await reportText.waitFor({ timeout: 20_000 });
   assert.match((await reportText.textContent()) ?? "", /GUI_REAL_DISPATCH_PROOF=/u, "dispatch chain did not render the settled report");
   for (const [kind, dirName] of [["mission", "missions/"], ["report", "reports/"]]) {
     await page.getByRole("tab", { name: "文件" }).click();
-    const filesTab = page.getByTestId("task-files-tab");
+    const documentTree = page.getByTestId("task-document-tree");
     // 文档树默认只展开根级目录:先展开 missions//reports/ 目录,再点 dispatch 工件叶节点。
-    const dirToggle = filesTab.locator("button", { hasText: dirName }).first();
+    const dirToggle = documentTree.locator("button", { hasText: dirName }).first();
     await dirToggle.waitFor({ timeout: 20_000 });
     await dirToggle.click();
-    const docLeaf = filesTab.locator("button", { hasText: dispatchId }).first();
+    const docLeaf = documentTree.locator("button", { hasText: dispatchId }).first();
     await docLeaf.waitFor({ timeout: 10_000 });
     await docLeaf.click();
     const bodyHandle = await page.waitForFunction(
       (pattern) => {
-        const text = globalThis.document.querySelector('[data-testid="task-files-tab"] article')?.textContent ?? "";
+        const text = globalThis.document.querySelector(
+          '[data-testid="task-files-tab"] [data-testid="doc-reader"]',
+        )?.textContent ?? "";
         return new RegExp(pattern, "u").test(text) ? text : null;
       },
       /GUI_REAL_DISPATCH_PROOF=/u.source,


### PR DESCRIPTION
# English

## Summary

The GUI end-to-end test that exercises "create a Runtime, dispatch it, and read the resulting documents" was failing intermittently at a 150-second wait for the dispatch outcome. The cause is in the test fixture, not in the product.

The fixture writes a fake Codex executable into a temporary directory and prepends that directory to `PATH`, intending the Runtime it creates to use the fake. But the create-Runtime dialog defaults to the first entry of the witnessed-installations list, which is sorted by a hashed installation id. On a machine that also has a real Codex installed, the fake is often not first, so the test created a Runtime bound to the operator's real Codex and then waited for a mission that a real provider may take arbitrarily long to finish — or never finish in the way the test expects.

The fix makes the fixture click the installation whose id is the fake one, and adds an assertion that the created Runtime is actually bound to it. The test is now deterministic on any machine, whether or not a real Codex is installed.

## What Changed

- `packages/gui/e2e/electron-smoke.e2e.mjs`: select the fake Codex installation explicitly before creating the Runtime, and assert that the persisted Runtime record carries that installation id. This is the substantive fix; everything below is a locator repair the fix exposed.
- Repoint three stale DOM locators in the same test, which only became reachable once the test stopped hanging earlier: the document tree is now a sibling with test id `task-document-tree` rather than a descendant of `task-files-tab`; the dispatch id is now read from the exact `dispatch-chain-*` test id instead of a greedy text regular expression over the whole tab; and the document reader is now a `doc-reader` section rather than an `article` element.
- Repoint one stale locator in the first smoke test, which asserts on a graph drawer that now renders the typed entity reference `task/task-gui-smoke` where it previously rendered the bare id.

No timeout was widened. Every artifact-content assertion is preserved.

## Machine-Readable Declarations

Production-Delta: +0/-0
Dependency-Change: none

## Task And Scope

- Harness task: task_385ec0eb99fa74e0df7004fbfe
- Branch: `codex/e2e-outcome`
- Public scope: `packages/gui/e2e/electron-smoke.e2e.mjs` only.
- Private planning/evidence updated: yes
- Out of scope: the production observation that motivated this task. See Residual Risk.

## Version Impact

- Version: no version change because no published package's contents change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `packages/gui/e2e/**`. The whole end-to-end directory is protected, so editing a test file inside it is a protected-surface edit even when the edit only repairs the test's own fixture and changes no product code. I initially declared this "no"; the governance checker proved that wrong, and the checker is right — the boundary is the directory, not the nature of the edit.
- Authority: task_385ec0eb99fa74e0df7004fbfe
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: `a31496b48ed4f66775a937cecb3ffb75ef00a810`
- Branch merge-base with `origin/main`: `a31496b48ed4f66775a937cecb3ffb75ef00a810`
- Last `git fetch origin` time: 2026-08-24, immediately before the rebase that produced this branch head.
- Sync method: rebase
- Public diff command: `git diff origin/main..HEAD -- packages/gui/e2e/electron-smoke.e2e.mjs`
- Private evidence commit/path: `harness/tasks/task_385ec0eb99fa74e0df7004fbfe-gui-e2e-runtime-dispatch-outcome-150s/artifacts/investigation-report.md`
- Reviewer evidence path: same task package.
- GitHub Actions `rewrite-ci` run URL: pending — will be recorded on this pull request once the run completes.
- [x] `npm run check:local` — exit code 0, 106.7 seconds, rerun by the reviewer from this worktree after the rebase onto current `origin/main`.
- [x] `npm run test:gui:e2e` — exit code 0, all three tests pass in 32.8 seconds, including the repaired dispatch test in 16.8 seconds.
- [x] Negative control: with the fix in place, deleting only the three lines that select the fake installation makes the test exit 1 after 17.8 seconds at the new binding assertion, reporting the operator's real Codex installation id where the fake was expected. The lines were then restored. This is what makes the assertion load-bearing rather than decorative.
- [x] Reviewer rerun of the end-to-end suite: I ran `npm run test:gui:e2e` myself from this worktree at the branch head, with `HARNESS_DAEMON_ENDPOINT`, `HARNESS_DAEMON_ID`, `HARNESS_REPO_ID`, and `HARNESS_USER_ROOT` unset and `TMPDIR=/tmp`. Result: 3 tests, 3 pass, 0 fail, exit 0, 28.0 seconds, with the repaired dispatch test at 17.7 seconds.
- Not run in cloud CI, and this is not an oversight: `test:gui:e2e` is declared `manual-only` in `tools/gate-manifest.json` under decision `dec_mrat10bn`, because headed GUI end-to-end tests have low signal in headless GitHub runners and previously hung the merge queue. The `gui-build` job that does run on this pull request executes `npm run test:gui` and the GUI package build — neither of which touches this file. The authority for this change is therefore the local run recorded on the line above, which is exactly what that gate declaration asks a GUI task closeout to attach.
  I first wrote here that cloud CI would re-prove this result independently. That was wrong, and I only found it by opening the workflow and the manifest instead of assuming. Recording the correction rather than quietly deleting it, because the false version is the one a reader would have believed.

## Review Evidence

- Self-review: the investigation falsified its own starting hypothesis and said so. The task was opened on the premise that a fake-provider session which exits normally never reaches the code that writes its outcome. Instrumenting the real exit path disproved that: the callback fires while the session is still active and the outcome is persisted as `succeeded`. The real cause turned out to be that the session under test was not the fake provider at all.
- Reviewer subagent: not used. The correctness claim is decided by a negative control that was run and recorded.
- Human review: pending.
- Blocking findings: none.

## Residual Risk

- This fixture repair does not explain the production observation that motivated the task. Roughly 180 production runtime sessions have a null outcome. The instrumented run proves that a normal local exit does persist its outcome on this checkout, so this end-to-end test is not a reproduction of that population. Investigating it remains open under task_06cc8bd50da7e60179d0941969, and this PR should not be read as closing it.
- Four DOM locators in this file were stale, three of them hidden behind a test that hung before reaching them. A test that fails early hides the staleness of everything after it, so other end-to-end files may carry the same kind of rot without anyone knowing.

## References

- Task: task_385ec0eb99fa74e0df7004fbfe
- Evidence: `harness/tasks/task_385ec0eb99fa74e0df7004fbfe-gui-e2e-runtime-dispatch-outcome-150s/artifacts/investigation-report.md`
- Review: pending on this pull request.

---

# 中文

## 概要

那条端到端测试——「建一个 Runtime、派它干活、再读回它产出的文档」——一直会间歇性地卡在等待派工结果的 150 秒超时上。病根在测试夹具里,不在产品里。

夹具会往一个临时目录写一个假的 Codex 可执行文件,再把那个目录前置进 `PATH`,本意是让它建出来的 Runtime 用这个假的。但创建 Runtime 的对话框默认选中「已探测到的安装」列表的第一项,而那个列表按安装 id 的哈希排序。在一台同时装了真 Codex 的机器上,假的往往不排第一,于是测试建出来的 Runtime 绑的是操作者的真 Codex,然后去等一个真 provider 可能要跑很久、甚至根本不会按测试预期完成的任务。

修法是让夹具显式点中 id 等于假安装的那一项,并加一条断言确认建出来的 Runtime 真的绑上了它。现在这条测试在任何机器上都是确定性的,不管本机装没装真 Codex。

## 改动内容

- `packages/gui/e2e/electron-smoke.e2e.mjs`:在创建 Runtime 之前显式选中假的 Codex 安装,并断言落盘的 Runtime 记录带的就是那个安装 id。这是实质修复;下面几条都是这次修复才暴露出来的定位器修补。
- 修正同一条测试里三个过期的 DOM 定位器——它们只有在测试不再提前卡住之后才够得着:文档树现在是带 test id `task-document-tree` 的兄弟节点,不再是 `task-files-tab` 的后代;派工 id 现在从精确的 `dispatch-chain-*` test id 上读,不再用贪婪正则在整个页签文本里捞;文档阅读器现在是 `doc-reader` 区块,不再是 `article` 元素。
- 修正第一条冒烟测试里一个过期定位器:它断言的图谱抽屉现在渲染的是带类型的实体引用 `task/task-gui-smoke`,而以前渲染的是裸 id。

没有放宽任何超时。所有关于工件内容的断言全部保留。

## 任务与范围

- Harness task:task_385ec0eb99fa74e0df7004fbfe
- 分支:`codex/e2e-outcome`
- 公开面范围:仅 `packages/gui/e2e/electron-smoke.e2e.mjs`。
- 私有规划/证据已更新:是
- 不在范围内:引出这个任务的那条生产观察。见残余风险。

## 版本影响

- 版本:不变,因为没有任何已发布包的内容发生变化。
- 发布影响:不发布

## 治理声明

- 触碰 protected surface:是
- Protected surface 范围:`packages/gui/e2e/**`。整个端到端目录是受保护面,所以哪怕这次编辑只是修这条测试自己的夹具、不动任何产品代码,动它仍然是动 protected surface。我最初填的是「否」,治理 checker 证明那是错的——它是对的:边界是这个目录,不是这次编辑的性质。
- 授权依据:task_385ec0eb99fa74e0df7004fbfe
- 机器检查边界:本 PR 只断言声明存在;声明是否为真、是否充分由评审者判断。
- Break-glass:否

## 验证

- 基线 `origin/main` SHA:`a31496b48ed4f66775a937cecb3ffb75ef00a810`
- 与 `origin/main` 的 merge-base:`a31496b48ed4f66775a937cecb3ffb75ef00a810`
- 最近一次 `git fetch origin` 时间:2026-08-24,就在生成本分支头的那次 rebase 之前。
- 同步方式:rebase
- 公开面 diff 命令:`git diff origin/main..HEAD -- packages/gui/e2e/electron-smoke.e2e.mjs`
- 私有证据 commit/路径:`harness/tasks/task_385ec0eb99fa74e0df7004fbfe-gui-e2e-runtime-dispatch-outcome-150s/artifacts/investigation-report.md`
- 评审证据路径:同一任务包。
- GitHub Actions `rewrite-ci` run URL:待补——run 完成后记录在本 PR 上。
- [x] `npm run check:local`——退出码 0,106.7 秒,由评审者在 rebase 到当前 `origin/main` 之后于本 worktree 内重跑。
- [x] `npm run test:gui:e2e`——退出码 0,三条测试全绿,32.8 秒,其中被修的那条派工测试 16.8 秒。
- [x] 阴性对照:在修复就位的前提下,只删掉选中假安装的那三行,同一条测试 17.8 秒后退出码 1,红在新加的绑定断言上,报出的是操作者的真 Codex 安装 id、期望的是假的。随后把那三行恢复。这就是这条断言承重、而不是装饰的依据。
- [x] 评审者重跑端到端套件:我在分支头上、于本 worktree 亲自跑了 `npm run test:gui:e2e`,并去掉 `HARNESS_DAEMON_ENDPOINT`、`HARNESS_DAEMON_ID`、`HARNESS_REPO_ID`、`HARNESS_USER_ROOT` 四个环境变量、设 `TMPDIR=/tmp`。结果:3 条测试、3 条通过、0 条失败,退出码 0,28.0 秒,其中被修的那条派工测试 17.7 秒。
- 云端 CI 不跑它,而这不是疏漏:`test:gui:e2e` 在 `tools/gate-manifest.json` 里被声明为 `manual-only`,依据是决策 `dec_mrat10bn`——有头的 GUI 端到端测试在无头 GitHub runner 里信号很弱,而且曾经把合并队列挂死。本 PR 上确实会跑的 `gui-build` job 执行的是 `npm run test:gui` 与 GUI 包构建,两者都不碰这个文件。所以本变更的权威证据就是上面那条本地运行记录——而那正是这条门声明要求 GUI 任务收口时附上的东西。
  我最初在这里写的是「云端 CI 会独立再证一遍」。那是错的,而我发现它靠的是去打开 workflow 与 manifest 读一遍,不是靠推断。把这条更正记下来而不是悄悄删掉,因为错的那一版才是读者本来会相信的那一版。

## 审查证据

- 自审:这次调查证伪了它自己的出发假设,并且写明了。任务立案时的前提是「假 provider 的会话正常退出时,根本走不到写结果的那段代码」。给真实退出路径加插桩之后这个前提被推翻了:回调在会话仍然 active 时就触发,结果被持久化成 `succeeded`。真正的病根是——被测的那个会话根本就不是假 provider。
- 评审子代理:未使用。正确性主张由一次真的跑过并记录在案的阴性对照裁定。
- 人工评审:待办。
- 阻塞性发现:无。

## 残余风险

- 这次夹具修复**不解释**引出该任务的那条生产观察。大约 180 条生产 runtime 会话的结果字段是 null。插桩实测证明在当前 checkout 上正常本地退出确实会把结果落盘,所以这条端到端测试并不是那一批的复现。那件事仍然挂在 task_06cc8bd50da7e60179d0941969 下面,本 PR 不应被读成把它结掉了。
- 这个文件里有四个 DOM 定位器是过期的,其中三个藏在一条走不到它们就先挂住的测试后面。**一条提前失败的测试会把它后面所有东西的过期状态一并藏起来**,所以其他端到端文件里可能带着同一类腐烂而无人知晓。

## 关联材料

- 任务:task_385ec0eb99fa74e0df7004fbfe
- 证据:`harness/tasks/task_385ec0eb99fa74e0df7004fbfe-gui-e2e-runtime-dispatch-outcome-150s/artifacts/investigation-report.md`
- 评审:待办,在本 PR 上进行。
