### PR TITLE
fix(gui): bound the genealogy participants sidebar row set

### DIFF
--- a/packages/gui/src/renderer/views/genealogy/ParticipantsSidebar.tsx
+++ b/packages/gui/src/renderer/views/genealogy/ParticipantsSidebar.tsx
@@ -93,7 +93,10 @@ export function ParticipantsSidebar({
             type="button"
             data-testid="genealogy-participants-more"
             onClick={() => setRowsVisible((count) => Math.min(count + ROW_BATCH_SIZE, filtered.length))}
-            className="w-full rounded px-2 py-1 text-center font-mono text-[11px] text-text-muted hover:bg-surface-raised hover:text-text"
+            className={
+              "w-full rounded px-2 py-1 text-center font-mono text-[11px] text-text-muted "
+              + "hover:bg-surface-raised hover:text-text"
+            }
           >
             再显示 {Math.min(ROW_BATCH_SIZE, hidden)} 条 · 还有 {hidden} 条
           </button>

--- a/packages/gui/src/renderer/views/genealogy/ParticipantsSidebar.tsx
+++ b/packages/gui/src/renderer/views/genealogy/ParticipantsSidebar.tsx
@@ -1,8 +1,17 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ListChecks, MagnifyingGlass } from "@phosphor-icons/react";
 import type { DecisionRow } from "../../model/types";
 import { DecisionStateBadge } from "../../components/badges";
 import { dayKeyOf } from "../../graph/genealogy";
+
+/**
+ * 侧栏一次渲染这么多行,剩下的靠批量按钮显形——照抄本仓 TaskStream / DecisionStream 的
+ * ROW_BATCH_SIZE 做法。规模不是常数:participants 是「出现在任意谱系边端点上的决策」去重,
+ * 本仓实测 252 行(2026-08-24),随台账谱系边被动累积。分批把 DOM 节点数与决策总量脱钩;
+ * 标题计数报真实总数,按钮报出剩余条数,被推迟的行是显形的、不是被吞掉的。
+ * 搜索始终在**全量** participants 上过滤,再对过滤结果分批——不是在已渲染的那一批里搜。
+ */
+const ROW_BATCH_SIZE = 12;
 
 /**
  * 谱系参与者侧栏(REQ-GUI-05):列焦点谱系内所有 decision,可搜索换焦点。
@@ -19,12 +28,17 @@ export function ParticipantsSidebar({
   onFocus: (id: string) => void;
 }) {
   const [query, setQuery] = useState("");
+  const [rowsVisible, setRowsVisible] = useState(ROW_BATCH_SIZE);
   const needle = query.trim().toLowerCase();
   const filtered = needle
     ? participants.filter(
         (d) => d.title.toLowerCase().includes(needle) || d.decisionId.toLowerCase().includes(needle),
       )
     : participants;
+  // 搜索词换了行集的全部组员,展开状态不能跟着过去。
+  useEffect(() => { setRowsVisible(ROW_BATCH_SIZE); }, [needle]);
+  const shown = filtered.slice(0, rowsVisible);
+  const hidden = filtered.length - shown.length;
 
   return (
     <aside className="flex w-[240px] shrink-0 flex-col border-r border-border bg-surface">
@@ -46,8 +60,11 @@ export function ParticipantsSidebar({
           />
         </div>
       </div>
-      <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-1.5 py-1.5">
-        {filtered.map((d) => {
+      <div
+        data-testid="genealogy-participants-rows"
+        className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-1.5 py-1.5"
+      >
+        {shown.map((d) => {
           const active = d.decisionId === focusId;
           const size = lineageSize.get(d.decisionId) ?? 0;
           return (
@@ -71,6 +88,16 @@ export function ParticipantsSidebar({
             </button>
           );
         })}
+        {hidden > 0 && (
+          <button
+            type="button"
+            data-testid="genealogy-participants-more"
+            onClick={() => setRowsVisible((count) => Math.min(count + ROW_BATCH_SIZE, filtered.length))}
+            className="w-full rounded px-2 py-1 text-center font-mono text-[11px] text-text-muted hover:bg-surface-raised hover:text-text"
+          >
+            再显示 {Math.min(ROW_BATCH_SIZE, hidden)} 条 · 还有 {hidden} 条
+          </button>
+        )}
         {filtered.length === 0 && (
           <span className="px-2 py-4 text-center text-[11px] text-text-faint">无匹配</span>
         )}

--- a/packages/gui/test/genealogy.vitest.ts
+++ b/packages/gui/test/genealogy.vitest.ts
@@ -1,5 +1,8 @@
 // harness-test-tier: integration
-import { describe, expect, it } from "vitest";
+// @vitest-environment happy-dom
+import { beforeAll, describe, expect, it } from "vitest";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import type { DecisionRow, RelationEdge } from "../src/renderer/model/types.ts";
 import {
   buildGenealogyEdges,
@@ -10,6 +13,7 @@ import {
   findGenealogyCycles,
   timeMsOf,
 } from "../src/renderer/graph/genealogy.ts";
+import { ParticipantsSidebar } from "../src/renderer/views/genealogy/ParticipantsSidebar.tsx";
 
 function dec(overrides: Partial<DecisionRow> = {}): DecisionRow {
   return {
@@ -187,5 +191,134 @@ describe("genealogy time helpers", () => {
   it("dayKeyOf slices the date portion", () => {
     expect(dayKeyOf(dec({ proposedAt: "2026-08-13T10:00:00Z" }))).toBe("2026-08-13");
     expect(dayKeyOf(dec({ proposedAt: undefined } as any))).toBe("NO_TIME");
+  });
+});
+
+// 参与者侧栏 = 「出现在任意谱系边端点上的决策」去重,规模随台账谱系边被动累积
+// (本仓实测 252 行,见 ParticipantsSidebar 的 ROW_BATCH_SIZE 注释)。分批让 DOM 节点数
+// 与决策总量脱钩;标题计数报真实总数,按钮报出剩余条数,搜索仍在全量上过滤。
+describe("genealogy participants sidebar: row set is bounded", () => {
+  const noop = () => {};
+  beforeAll(() => { globalThis.IS_REACT_ACT_ENVIRONMENT = true; });
+
+  function sidebarRow(patch: Partial<DecisionRow>): DecisionRow {
+    // state 必须是 DecisionStateBadge 认识的词(单元夹具里的 "active" 不进 DOM 渲染路径)。
+    return { ...dec({ state: "in_effect" as DecisionRow["state"], ...patch }) } as DecisionRow;
+  }
+
+  async function renderSidebar(participants: ReadonlyArray<DecisionRow>) {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root: Root = createRoot(container);
+    await act(async () => {
+      root.render(createElement(ParticipantsSidebar, {
+        participants, focusId: null, lineageSize: new Map(), onFocus: noop,
+      }));
+    });
+    const scope = () => container.querySelector('[data-testid="genealogy-participants-rows"]')!;
+    return {
+      container,
+      // 批量按钮也是容器的直接子 button,行数要把它排除掉。
+      rows: () => [...scope().querySelectorAll<HTMLButtonElement>(":scope > button")]
+        .filter((button) => button.dataset.testid !== "genealogy-participants-more"),
+      more: () => container.querySelector<HTMLButtonElement>('[data-testid="genealogy-participants-more"]'),
+      header: () => container.querySelector("aside > div")!.textContent ?? "",
+      input: () => container.querySelector<HTMLInputElement>("input")!,
+      async type(text: string) {
+        const input = container.querySelector<HTMLInputElement>("input")!;
+        await act(async () => {
+          const set = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+          set.call(input, text);
+          input.dispatchEvent(new Event("input", { bubbles: true }));
+        });
+      },
+      async clickMore() {
+        await act(async () => { more(container)!.click(); });
+      },
+      unmount() {
+        act(() => { root.unmount(); });
+        container.remove();
+      },
+    };
+  }
+  function more(container: HTMLElement) {
+    return container.querySelector<HTMLButtonElement>('[data-testid="genealogy-participants-more"]');
+  }
+
+  it("bounds the initial row DOM and states how many rows it deferred", async () => {
+    const participants = Array.from({ length: 45 }, (_, index) =>
+      sidebarRow({ decisionId: `dec_${index}`, title: `Decision ${index}` }));
+    const view = await renderSidebar(participants);
+    try {
+      expect(view.rows()).toHaveLength(12);
+      expect(view.more()?.textContent?.trim()).toBe("再显示 12 条 · 还有 33 条");
+      // 标题计数报真实总数,不是渲染出来的行数——被推迟的行在界面上有交代。
+      expect(view.header()).toMatch(/参与者\s*45/u);
+    } finally { view.unmount(); }
+  });
+
+  // 负向断言:没超出一批时不许出现批量按钮。没有它,「无脑常显按钮」也能让上面那条变绿。
+  it("shows no batch button when the participants fit in one batch", async () => {
+    const participants = Array.from({ length: 5 }, (_, index) =>
+      sidebarRow({ decisionId: `dec_${index}`, title: `Decision ${index}` }));
+    const view = await renderSidebar(participants);
+    try {
+      expect(view.rows()).toHaveLength(5);
+      expect(view.more()).toBeNull();
+    } finally { view.unmount(); }
+  });
+
+  // 搜索语义不许变:needle 过滤发生在**全量** participants 上,再对过滤结果分批。
+  // 做成「先分批后搜索」的话,这里会渲染成「无匹配」——用户会以为搜不到。
+  it("filters the full participant list before batching", async () => {
+    const participants = [
+      ...Array.from({ length: 12 }, (_, index) =>
+        sidebarRow({ decisionId: `dec_alpha_${index}`, title: `Alpha ${index}` })),
+      ...Array.from({ length: 18 }, (_, index) =>
+        sidebarRow({ decisionId: `dec_probe_${index}`, title: `Probe ${index}` })),
+    ];
+    const view = await renderSidebar(participants);
+    try {
+      await view.type("probe");
+      // 命中的 18 行全部来自第一批之外,只有全量过滤才看得见它们。
+      const rows = view.rows().map((row) => row.textContent ?? "");
+      expect(rows).toHaveLength(12);
+      for (const text of rows) expect(text).toContain("Probe");
+      expect(view.more()?.textContent?.trim()).toBe("再显示 6 条 · 还有 6 条");
+      // 标题计数仍是全量参与者总数,不随搜索收窄。
+      expect(view.header()).toMatch(/参与者\s*30/u);
+    } finally { view.unmount(); }
+  });
+
+  it("reveals the next batch on click until the list is exhausted", async () => {
+    const participants = Array.from({ length: 30 }, (_, index) =>
+      sidebarRow({ decisionId: `dec_${index}`, title: `Decision ${index}` }));
+    const view = await renderSidebar(participants);
+    try {
+      await view.clickMore();
+      expect(view.rows()).toHaveLength(24);
+      expect(view.more()?.textContent?.trim()).toBe("再显示 6 条 · 还有 6 条");
+      await view.clickMore();
+      expect(view.rows()).toHaveLength(30);
+      expect(view.more()).toBeNull();
+    } finally { view.unmount(); }
+  });
+
+  // 展开状态不能跟着搜索词过去:换词 = 换掉行集全部组员,回到第一批。
+  it("resets the visible batch when the search query changes", async () => {
+    const participants = [
+      ...Array.from({ length: 12 }, (_, index) =>
+        sidebarRow({ decisionId: `dec_alpha_${index}`, title: `Alpha ${index}` })),
+      ...Array.from({ length: 18 }, (_, index) =>
+        sidebarRow({ decisionId: `dec_probe_${index}`, title: `Probe ${index}` })),
+    ];
+    const view = await renderSidebar(participants);
+    try {
+      await view.clickMore();
+      expect(view.rows()).toHaveLength(24);
+      await view.type("probe");
+      expect(view.rows()).toHaveLength(12);
+      expect(view.more()?.textContent?.trim()).toBe("再显示 6 条 · 还有 6 条");
+    } finally { view.unmount(); }
   });
 });


### PR DESCRIPTION
# English

## Summary

The genealogy view's left sidebar lists every decision that appears at either end of a genealogy relation, and it rendered all of them in a single pass. On today's ledger that is 252 rows, and the number grows on its own as genealogy edges accumulate — nothing in the read path bounds it. This PR gives that list the same batching the overview streams already use: twelve rows at a time, with a button that says how many rows are still hidden.

Nothing is silently dropped. The sidebar header keeps reporting the true total, the button reports the remaining count, and search still filters the complete participant list before batching — so typing a term finds matches that were never rendered.

## What Changed

- `packages/gui/src/renderer/views/genealogy/ParticipantsSidebar.tsx`: render `filtered.slice(0, rowsVisible)` instead of the whole list, add a batch button when rows remain, and reset the visible count when the search term changes (a new search replaces every member of the row set, so a stale expanded count would be meaningless). The mechanism is copied verbatim from `components/overview/TaskStream.tsx`; no new pattern was invented.
- `packages/gui/test/genealogy.vitest.ts`: five new tests. Four are positive — initial row set is bounded and states the deferred count, clicking reveals the next batch until exhausted, changing the search resets the expansion, and search filters the full list rather than the rendered batch. One is negative: with five participants, no batch button appears at all. The negative one is what stops "always render the button" from passing the other four trivially.
- A follow-up commit wraps the batch button's class list across two lines. It was 138 characters, and the G36 line-density gate rejects a newly added production line over 120. No behaviour change.

## A correction to the task plan this branch was dispatched with

The task plan stated the sidebar renders 389 rows, derived from `SELECT source_ref, target_ref FROM relation_edge WHERE state='active'` with both endpoints being decisions. That query has no relation-kind filter, so it counts `derives`, `relates`, `evidenced-by` and everything else.

The sidebar's actual input is `buildGenealogyEdges`, which admits only four kinds — `refines`, `narrows`, `supersedes`, `supports` — and requires both endpoints to exist in the decision table. Following that pipeline through gives 214 genealogy edges and **252** participants, reproduced two independent ways: by calling the running daemon's `repo.triadic.relationGraph` and `repo.decisions.list` (the same pair the GUI itself calls) and by equivalent SQL against `.harness/cache/task.sqlite`.

The mechanism claim is unaffected — 252 rows in one pass is still an unbounded row set — but the number in the plan was wrong and is corrected here rather than carried forward.

## Machine-Readable Declarations

Production-Delta: +33/-3
Dependency-Change: none

## Task And Scope

- Harness task: task_55b926b6118f9491e23824bdcb
- Branch: `codex/genealogy-sidebar-bounds`
- Public scope: the participants sidebar component and its test file.
- Private planning/evidence updated: yes
- Out of scope: the daemon's `relationGraph` read, which returns all 1420 edges with no pagination. That is a separate surface with its own tradeoffs; bounding the rendering does not make the read bounded.

## Version Impact

- Version: no version change because no published package's public contents change.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable. I first assumed `packages/gui/test/**` was protected by analogy with `packages/gui/e2e/**`, which is. Running `tools/check-pr-governance.mjs` against this diff showed it is not: the checker's 89 manifest-derived rules match nothing here. The declaration follows the checker, not the analogy.
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: `409eb95590e98a504e2a20f42788e21433205b66`
- Branch merge-base with `origin/main`: `409eb95590e98a504e2a20f42788e21433205b66`
- Last `git fetch origin` time: 2026-08-24, immediately before the rebase that produced this branch head.
- Sync method: rebase
- Public diff command: `git diff 409eb95590e98a504e2a20f42788e21433205b66..HEAD`
- Private evidence commit/path: `harness/tasks/task_55b926b6118f9491e23824bdcb-389-overview/artifacts/report.md`
- Reviewer evidence path: same task package.
- GitHub Actions `rewrite-ci` run URL: pending — will be recorded on this pull request once the run completes.
- [x] `npm run check:local` — exit code 0, 102.3 seconds, rerun by the reviewer after the line-density fix.
- [x] `npm run test:gui` — 46 files, 409 tests, all pass. The baseline before this branch was 404, so the five new tests are the whole difference.
- [x] Positive control, run by the reviewer rather than taken from the worker's report: replacing `filtered.slice(0, rowsVisible)` with `filtered` — that is, restoring the single-pass render this PR removes — turns exactly four of the new tests red and leaves 405 green. The four that go red are the four positive ones. The negative one stays green, correctly, because five rows fit in one batch either way.
- Not run: `npm run test:gui:e2e`. It is declared `manual-only` in `tools/gate-manifest.json` under decision `dec_mrat10bn` and is not part of cloud CI. The genealogy sidebar has zero references in `packages/gui/e2e/electron-smoke.e2e.mjs`, so that suite exercises none of this change.

## Review Evidence

- Self-review: the worker corrected the number in its own dispatch packet and said so with two independent reproductions, instead of reporting against a figure it could not verify. That correction is in the "What Changed" section above.
- Reviewer subagent: not used. The load-bearing claim is that the new assertions can fail, and the reviewer established that by running the mutation directly.
- Human review: pending.
- Blocking findings: none.

## Residual Risk

- The daemon read behind this view is still unbounded: `repo.triadic.relationGraph` returns all 1420 edges with no pagination. This PR bounds what the browser renders, not what the process holds. A ledger large enough to make that read expensive will show it somewhere else first.
- The header count reports the total participant list even while a search is active. That is pre-existing behaviour and unchanged here, but it means the header and the visible row count disagree during a search.

## References

- Task: task_55b926b6118f9491e23824bdcb
- Evidence: `harness/tasks/task_55b926b6118f9491e23824bdcb-389-overview/artifacts/report.md`
- Review: pending on this pull request.

---

# 中文

## 概要

谱系视图的左侧栏列出所有出现在谱系关系任一端的决策,而它一次性把全部渲染出来。按今天的台账那是 252 行,并且这个数字会自己长——谱系边不断累积,读路径上没有任何东西给它设界。本 PR 给这份列表加上总览三条流已经在用的同款分批:一次 12 行,配一个按钮说明还有多少行没显示。

**没有任何东西被静默丢掉。** 侧栏标题继续报真实总数,按钮报剩余条数,搜索仍然在**全量** participants 上过滤再分批——所以输入关键词能搜到那些从没被渲染过的行。

## 改动内容

- `packages/gui/src/renderer/views/genealogy/ParticipantsSidebar.tsx`:渲染 `filtered.slice(0, rowsVisible)` 而不是整份列表;还有剩余行时渲染批量按钮;搜索词变化时把可见行数重置(换了搜索词等于换掉行集的全部组员,沿用旧的展开数没有意义)。机制照抄 `components/overview/TaskStream.tsx`,没有发明新模式。
- `packages/gui/test/genealogy.vitest.ts`:新增五条测试。四条正向——首屏行集有界并报出被推迟的条数、点击逐批显形直到取尽、换搜索词重置展开、搜索在全量而非已渲染的那一批上过滤。一条负向——只有五个 participants 时根本不出现批量按钮。**负向那条是拦住「无论如何都渲染按钮」这种实现轻松通过另外四条的东西。**
- 随后一个提交把批量按钮的 class 列表折成两行。它原本 138 字符,而 G36 line-density 门拒收新增的超过 120 字符的生产行。行为无变化。

## 对本分支派工计划里一个数字的更正

任务计划写侧栏渲染 389 行,依据是 `SELECT source_ref, target_ref FROM relation_edge WHERE state='active'` 且两端都是决策。**那条 SQL 没有按关系类型过滤**,把 `derives`、`relates`、`evidenced-by` 等全部计入了。

侧栏真正的输入是 `buildGenealogyEdges`,它只认四类——`refines`、`narrows`、`supersedes`、`supports`——并要求两端都在决策表里。按这条管线走下来是 214 条谱系边、**252** 个 participants,并且用两条独立路径复现:一条是调正在运行的 daemon 的 `repo.triadic.relationGraph` 与 `repo.decisions.list`(GUI 自己调的就是这一对),另一条是对 `.harness/cache/task.sqlite` 跑等价 SQL。

机制结论不受影响——252 行一次渲染仍然是一个无界行集——但计划里那个数字是错的,在这里更正掉,而不是让它继续往下传。

## 任务与范围

- Harness task:task_55b926b6118f9491e23824bdcb
- 分支:`codex/genealogy-sidebar-bounds`
- 公开面范围:参与者侧栏组件与它的测试文件。
- 私有规划/证据已更新:是
- 不在范围内:daemon 的 `relationGraph` 读——它默认返回全部 1420 条边、无分页。那是另一个面、有它自己的权衡;把渲染设界并不等于把读设界。

## 版本影响

- 版本:不变,因为没有任何已发布包的公开内容发生变化。
- 发布影响:不发布

## 治理声明

- 触碰 protected surface:否
- Protected surface 范围:不适用。我最初按 `packages/gui/e2e/**` 的类比假定 `packages/gui/test/**` 也是受保护面——前者确实是。把 `tools/check-pr-governance.mjs` 跑在本 diff 上表明它不是:checker 的 89 条 manifest 派生规则在这里一条都不命中。声明按 checker 填,不按类比填。
- 授权依据:不适用
- 机器检查边界:本 PR 只断言声明存在;声明是否为真、是否充分由评审者判断。
- Break-glass:否

## 验证

- 基线 `origin/main` SHA:`409eb95590e98a504e2a20f42788e21433205b66`
- 与 `origin/main` 的 merge-base:`409eb95590e98a504e2a20f42788e21433205b66`
- 最近一次 `git fetch origin` 时间:2026-08-24,就在生成本分支头的那次 rebase 之前。
- 同步方式:rebase
- 公开面 diff 命令:`git diff 409eb95590e98a504e2a20f42788e21433205b66..HEAD`
- 私有证据 commit/路径:`harness/tasks/task_55b926b6118f9491e23824bdcb-389-overview/artifacts/report.md`
- 评审证据路径:同一任务包。
- GitHub Actions `rewrite-ci` run URL:待补——run 完成后记录在本 PR 上。
- [x] `npm run check:local`——退出码 0,102.3 秒,由评审者在 line-density 修复之后重跑。
- [x] `npm run test:gui`——46 个文件、409 条测试全绿。本分支之前的基线是 404,五条新测试就是全部差额。
- [x] 阳性对照,由评审者亲自跑,不是抄 worker 的报告:把 `filtered.slice(0, rowsVisible)` 换回 `filtered`——也就是复原本 PR 要移除的那种整段渲染——**精确地让四条新测试变红、405 条保持绿**。变红的正是那四条正向测试;负向那条正确地保持绿,因为五行本来就装得下一批,两种实现在那种规模下等价。
- 未跑:`npm run test:gui:e2e`。它在 `tools/gate-manifest.json` 里被声明为 `manual-only`(依据决策 `dec_mrat10bn`),不属于云端 CI。谱系侧栏在 `packages/gui/e2e/electron-smoke.e2e.mjs` 里引用数为 0,那套端到端不碰本改动的任何一行。

## 审查证据

- 自审:worker 更正了它自己派工包里的数字,并给了两条独立复现,而不是照着一个它无法核实的数字交差。那条更正写在上面的「对本分支派工计划里一个数字的更正」一节。
- 评审子代理:未使用。承重的主张是「这些新断言真的会失败」,评审者用直接跑变异的方式确立了它。
- 人工评审:待办。
- 阻塞性发现:无。

## 残余风险

- 这个视图背后的 daemon 读仍然无界:`repo.triadic.relationGraph` 返回全部 1420 条边、没有分页。本 PR 给浏览器渲染的东西设了界,没有给进程持有的东西设界。台账大到让那次读变贵时,症状会先从别处冒出来。
- 搜索进行中时,标题计数报的仍是全量 participants 总数。这是既有行为、本次未改,但它意味着搜索状态下标题与可见行数对不上。

## 关联材料

- 任务:task_55b926b6118f9491e23824bdcb
- 证据:`harness/tasks/task_55b926b6118f9491e23824bdcb-389-overview/artifacts/report.md`
- 评审:待办,在本 PR 上进行。
