### PR TITLE
fix(daemon): decouple runtime worker lifetime from the daemon process

### DIFF
--- a/packages/daemon/src/dispatch-read.ts
+++ b/packages/daemon/src/dispatch-read.ts
@@ -17,7 +17,10 @@ export function readTaskDispatches(input: { readonly rootDir: string; readonly p
   const streamRoot = path.join(resolveHarnessLayout(input.rootDir).localRoot, "runtime", "dispatches");
   if (existsSync(streamRoot) && statSync(streamRoot).isDirectory()) for (const name of readdirSync(streamRoot).filter((value) => /^dispatch_[a-f0-9]{24}\.jsonl$/u.test(value))) {
     const dispatchId = name.slice(0, -6), stream = readDispatchStream(input.rootDir, dispatchId); if (!stream?.header?.taskId || !tasks.has(stream.header.taskId)) continue;
-    const current = sessions.get(stream.header.runtimeSessionId); if (!rows.has(dispatchId)) rows.set(dispatchId, liveRow(stream.header, stream.providerSessionId, current));
+    const current = sessions.get(stream.header.runtimeSessionId);
+    if (!rows.has(dispatchId)) {
+      rows.set(dispatchId, liveRow(stream.header, stream.providerSessionId, current, stream.process?.exited === false));
+    }
   }
   const dispatches = [...rows.values()].sort((left, right) => left.startedAt.localeCompare(right.startedAt));
   return singleTaskId === undefined
@@ -26,7 +29,35 @@ export function readTaskDispatches(input: { readonly rootDir: string; readonly p
 }
 
 function archiveRow(value: Record<string, unknown>, session: RuntimeSession | undefined): TaskDispatchRow { return { dispatchId: String(value.dispatchId), taskId: String(value.taskId), executionId: String(value.executionId), runtimeSessionId: String(value.runtimeSessionId), instanceId: String(value.instanceId), ...(typeof value.agentId === "string" ? { agentId: value.agentId, agentName: typeof value.agentName === "string" ? value.agentName : value.agentId } : {}), ...(typeof value.delegatedByAgentId === "string" ? { delegatedByAgentId: value.delegatedByAgentId, delegatedByAgentName: typeof value.delegatedByAgentName === "string" ? value.delegatedByAgentName : value.delegatedByAgentId, squadId: String(value.squadId) } : {}), providerSessionId: typeof value.providerSessionId === "string" ? value.providerSessionId : session?.providerSessionId ?? null, eventStreamRef: typeof value.eventStreamRef === "string" ? value.eventStreamRef : null, startedAt: String(value.startedAt), endedAt: typeof value.endedAt === "string" ? value.endedAt : null, outcome: isOutcome(value.outcome) ? value.outcome : session?.outcome ?? "unknown", status: isOutcome(value.outcome) ? value.outcome : session?.outcome ?? "unknown" }; }
-function liveRow(header: DispatchStreamHeader, providerSessionId: string | null, session: RuntimeSession | undefined): TaskDispatchRow { const outcome = session?.outcome ?? null; return { dispatchId: header.dispatchId, taskId: header.taskId!, executionId: header.executionId!, runtimeSessionId: header.runtimeSessionId, instanceId: header.instanceId, ...(header.agentId ? { agentId: header.agentId, agentName: header.agentName ?? header.agentId } : {}), ...(header.delegatedByAgentId ? { delegatedByAgentId: header.delegatedByAgentId, delegatedByAgentName: header.delegatedByAgentName ?? header.delegatedByAgentId, squadId: header.squadId! } : {}), providerSessionId: providerSessionId ?? session?.providerSessionId ?? null, eventStreamRef: header.eventStreamRef, startedAt: header.startedAt, endedAt: null, outcome, status: outcome ?? (session?.liveness === "live" ? "running" : "unknown") }; }
+function liveRow(
+  header: DispatchStreamHeader,
+  providerSessionId: string | null,
+  session: RuntimeSession | undefined,
+  processRunning: boolean,
+): TaskDispatchRow {
+  const outcome = session?.outcome ?? null;
+  return {
+    dispatchId: header.dispatchId,
+    taskId: header.taskId!,
+    executionId: header.executionId!,
+    runtimeSessionId: header.runtimeSessionId,
+    instanceId: header.instanceId,
+    ...(header.agentId ? { agentId: header.agentId, agentName: header.agentName ?? header.agentId } : {}),
+    ...(header.delegatedByAgentId
+      ? {
+        delegatedByAgentId: header.delegatedByAgentId,
+        delegatedByAgentName: header.delegatedByAgentName ?? header.delegatedByAgentId,
+        squadId: header.squadId!,
+      }
+      : {}),
+    providerSessionId: providerSessionId ?? session?.providerSessionId ?? null,
+    eventStreamRef: header.eventStreamRef,
+    startedAt: header.startedAt,
+    endedAt: null,
+    outcome,
+    status: outcome ?? (session?.liveness === "live" || processRunning ? "running" : "unknown"),
+  };
+}
 function parseArchive(body: string): Record<string, unknown> | null { try { const value: unknown = JSON.parse(body); return isRecord(value) && value.schema === "runtime-dispatch/v1" ? value : null; } catch (error) { consumeKnownError(error); return null; } }
 function isRecord(value: unknown): value is Record<string, unknown> { return value !== null && typeof value === "object" && !Array.isArray(value); }
 function isOutcome(value: unknown): value is NonNullable<TaskDispatchRow["outcome"]> { return value === "succeeded" || value === "failed" || value === "unknown" || value === "cancelled"; }

--- a/packages/daemon/src/dispatch-stream.ts
+++ b/packages/daemon/src/dispatch-stream.ts
@@ -1,6 +1,25 @@
-import { appendFileSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  constants as fsConstants,
+  existsSync,
+  fstatSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
-import { consumeKnownError, resolveHarnessLayout } from "../../kernel/src/index.ts";
+import {
+  consumeKnownError,
+  resolveHarnessLayout,
+  type ActorIdentity,
+  type WriteSource,
+} from "../../kernel/src/index.ts";
+import type { RuntimePermissionMode } from "./runtime-permissions.ts";
 
 const streamSchema = "runtime-dispatch-stream/v1" as const;
 const forbiddenKey = /(?:token|credential|password|secret|authorization|executablepath|api[-_ ]?key|private[-_ ]?key|cookie)/iu;
@@ -24,7 +43,25 @@ export interface DispatchStreamHeader {
   readonly delegatedByAgentName?: string;
   readonly squadId?: string;
   readonly onExitCommand?: string;
+  readonly dispatchOpId?: string;
+  readonly kindId?: "claude" | "codex" | "agy";
+  readonly permissionMode?: RuntimePermissionMode | null;
+  readonly binding?: { readonly actor: ActorIdentity; readonly source: WriteSource };
+  readonly cwd?: string;
+  readonly prompt?: string;
+  readonly promptSource?: string;
+  readonly model?: string;
+  readonly reasoningEffort?: string | null;
+  readonly resumeProviderSessionId?: string | null;
 }
+
+export type DispatchStreamRecord = Record<string, unknown>;
+export type DispatchProcessState = {
+  readonly pid: number;
+  readonly exitCode: number | null;
+  readonly signal: string | null;
+  readonly exited: boolean;
+};
 
 export interface DispatchStreamWriter {
   readonly ref: string;
@@ -40,14 +77,82 @@ export function openDispatchStream(rootDir: string, header: Omit<DispatchStreamH
   return { ref, appendProviderEvent: (value, occurredAt) => appendJsonl(target, { schema: streamSchema, kind: "provider_event", occurredAt, event: scrubProviderValue(value) }), appendProviderBinding: (providerSessionId, occurredAt) => appendJsonl(target, { schema: streamSchema, kind: "provider_binding", occurredAt, providerSessionId }), appendExitNotification: (value, occurredAt) => appendJsonl(target, { schema: streamSchema, kind: "exit_notification", occurredAt, ...value }) };
 }
 
-export function readDispatchStream(rootDir: string, dispatchId: string): { readonly header: DispatchStreamHeader; readonly providerSessionId: string | null } | null {
+export function reopenDispatchStream(rootDir: string, header: DispatchStreamHeader): DispatchStreamWriter {
+  const { schema: _schema, kind: _kind, eventStreamRef: _eventStreamRef, ...stored } = header;
+  return openDispatchStream(rootDir, stored);
+}
+
+export function removeDispatchStream(rootDir: string, dispatchId: string): void {
+  const target = dispatchStreamPath(rootDir, dispatchId);
+  if (existsSync(target)) unlinkSync(target);
+}
+
+export function readDispatchStream(
+  rootDir: string,
+  dispatchId: string,
+): {
+  readonly header: DispatchStreamHeader;
+  readonly providerSessionId: string | null;
+  readonly process: DispatchProcessState | null;
+  readonly records: readonly DispatchStreamRecord[];
+} | null {
   const target = dispatchStreamPath(rootDir, dispatchId);
   if (!existsSync(target) || !statSync(target).isFile()) return null;
   const lines = readFileSync(target, "utf8").split(/\r?\n/u).filter(Boolean), first = parseRecord(lines[0]);
   if (!isHeader(first) || first.dispatchId !== dispatchId) return null;
-  let providerSessionId: string | null = null;
-  for (const line of lines.slice(1)) { const record = parseRecord(line); if (record?.kind === "provider_binding" && typeof record.providerSessionId === "string") providerSessionId = record.providerSessionId; }
-  return { header: first, providerSessionId };
+  let providerSessionId: string | null = null, processState: DispatchProcessState | null = null;
+  const records = lines.slice(1).map(parseRecord).filter((record): record is DispatchStreamRecord => record !== null);
+  for (const record of records) {
+    if (record.kind === "provider_binding" && typeof record.providerSessionId === "string") {
+      providerSessionId = record.providerSessionId;
+    }
+    if (record.kind === "process_started" && Number.isInteger(record.pid) && Number(record.pid) > 0) {
+      processState = { pid: Number(record.pid), exitCode: null, signal: null, exited: false };
+    }
+    if (record.kind === "process_exit" && processState) {
+      processState = {
+        ...processState,
+        exitCode: Number.isInteger(record.exitCode) ? Number(record.exitCode) : null,
+        signal: typeof record.signal === "string" ? record.signal : null,
+        exited: true,
+      };
+    }
+  }
+  return { header: first, providerSessionId, process: processState, records };
+}
+
+export function readDispatchStreams(rootDir: string): readonly NonNullable<ReturnType<typeof readDispatchStream>>[] {
+  const root = path.join(resolveHarnessLayout(rootDir).localRoot, "runtime", "dispatches");
+  if (!existsSync(root) || !statSync(root).isDirectory()) return [];
+  return readdirSync(root)
+    .filter((name) => /^dispatch_[a-f0-9]{24}\.jsonl$/u.test(name))
+    .map((name) => readDispatchStream(rootDir, name.slice(0, -6)))
+    .filter((stream): stream is NonNullable<ReturnType<typeof readDispatchStream>> => stream !== null);
+}
+
+export function appendRuntimeWorkerRecord(
+  rootDir: string,
+  dispatchId: string,
+  value: Readonly<Record<string, unknown>>,
+): void {
+  appendJsonl(dispatchStreamPath(rootDir, dispatchId), { schema: streamSchema, ...value });
+}
+
+export function readRuntimeWorkerChunk(
+  rootDir: string,
+  dispatchId: string,
+  offset: number,
+  limit = 1024 * 1024,
+): Buffer {
+  const descriptor = openSync(dispatchStreamPath(rootDir, dispatchId), fsConstants.O_RDONLY);
+  try {
+    const size = fstatSync(descriptor).size;
+    if (size <= offset) return Buffer.alloc(0);
+    const bytes = Buffer.alloc(Math.min(size - offset, limit));
+    const read = readSync(descriptor, bytes, 0, bytes.length, offset);
+    return bytes.subarray(0, read);
+  }
+  finally { closeSync(descriptor); }
 }
 
 export function dispatchStreamRef(rootDir: string, dispatchId: string): string { const relative = path.relative(resolveHarnessLayout(rootDir).rootDir, dispatchStreamPath(rootDir, dispatchId)).split(path.sep).join("/"); return `file:${relative}`; }
@@ -59,7 +164,17 @@ export function scrubProviderValue(value: unknown): unknown {
   return value.replace(bearer, "Bearer [REDACTED]").replace(knownToken, "[REDACTED]").replace(sensitiveAssignment, "[REDACTED]");
 }
 
-function dispatchStreamPath(rootDir: string, dispatchId: string): string { if (!/^dispatch_[a-f0-9]{24}$/u.test(dispatchId)) throw new Error("dispatch id is invalid"); return path.join(resolveHarnessLayout(rootDir).localRoot, "runtime", "dispatches", `${dispatchId}.jsonl`); }
-function appendJsonl(target: string, value: unknown): void { appendFileSync(target, `${JSON.stringify(scrubProviderValue(value))}\n`, { encoding: "utf8" }); }
+export function dispatchStreamPath(rootDir: string, dispatchId: string): string {
+  if (!/^dispatch_[a-f0-9]{24}$/u.test(dispatchId)) throw new Error("dispatch id is invalid");
+  return path.join(resolveHarnessLayout(rootDir).localRoot, "runtime", "dispatches", `${dispatchId}.jsonl`);
+}
+function appendJsonl(target: string, value: unknown): void {
+  const descriptor = openSync(target, fsConstants.O_APPEND | fsConstants.O_WRONLY);
+  try {
+    writeFileSync(descriptor, `${JSON.stringify(scrubProviderValue(value))}\n`, "utf8");
+  } finally {
+    closeSync(descriptor);
+  }
+}
 function parseRecord(value: string | undefined): Record<string, unknown> | null { if (!value) return null; try { const parsed: unknown = JSON.parse(value); return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : null; } catch (error) { consumeKnownError(error); return null; } }
 function isHeader(value: Record<string, unknown> | null): value is Record<string, unknown> & DispatchStreamHeader { return value?.schema === streamSchema && value.kind === "dispatch" && typeof value.dispatchId === "string" && (value.taskId === null || typeof value.taskId === "string") && (value.executionId === null || typeof value.executionId === "string") && typeof value.runtimeSessionId === "string" && typeof value.instanceId === "string" && typeof value.startedAt === "string" && typeof value.eventStreamRef === "string"; }

--- a/packages/daemon/src/fleet-edge-runtime.ts
+++ b/packages/daemon/src/fleet-edge-runtime.ts
@@ -72,12 +72,39 @@ export function openFleetEdgeRuntime(input: { readonly request: FleetEdgeRuntime
         mission: `Your task package is ${packageRoot}.\nRead task_plan.md in that package and complete the task.`,
       };
     },
-    readRuntimeSessions: async () => { const result = await runFleetRuntimeReadClient({ ...peer, repoId: request.repoId, method: "repo.agentRuntime.overview", payload: {} }); const issues = validateAgentRuntimeOverview(result); if (issues.length) throw edgeRuntimeError("runtime_read_invalid", issues.join("; ")); return (result as AgentRuntimeOverviewResult).sessions.map(({ providerSessionId, instanceId, liveness }) => ({ providerSessionId, instanceId, liveness })); },
+    readRuntimeSessions: async () => {
+      const result = await runFleetRuntimeReadClient({
+        ...peer,
+        repoId: request.repoId,
+        method: "repo.agentRuntime.overview",
+        payload: {},
+      });
+      const issues = validateAgentRuntimeOverview(result);
+      if (issues.length) throw edgeRuntimeError("runtime_read_invalid", issues.join("; "));
+      return (result as AgentRuntimeOverviewResult).sessions.map(({
+        runtimeSessionId,
+        providerSessionId,
+        instanceId,
+        liveness,
+        activity,
+      }) => ({ runtimeSessionId, providerSessionId, instanceId, liveness, outcome: activity.outcome }));
+    },
     publish: async (draft) => { const response = await runFleetRuntimeEventClient({ ...peer, repoId: request.repoId, opId: draft.opId, eventType: draft.type, payload: draft.payload, ...(draft.resultBody === undefined ? {} : { resultBody: draft.resultBody }) }); return { event: response.event as unknown as AgentRuntimeEventV1, receipt: response.receipt as JsonObject }; },
     archive: async (archive) => await runFleetRuntimeArchiveClient({ ...peer, repoId: request.repoId, archive: archive as unknown as Readonly<Record<string, unknown>> }) as { readonly outcome: string; readonly nextAction?: string }
   }, stream, now, runtimeInstances: input.ports.runtimeInstances, prepareLaunch: input.ports.prepareRuntimeLaunch, resolveAgent: (agentId) => readAgentDeclaration({ rootDir: request.workspaceRoot, agentId }), resolveSquadDispatchTarget: (leaderId, workerId) => resolveSquadDispatchTarget({ rootDir: request.workspaceRoot, leaderId, workerId }), ...(input.launch ? { launch: input.launch } : {}), schedule });
+  const ready = spawner.adopt();
   return {
-    run: async (method: FleetEdgeRuntimeRequest["payload"]["method"], action: JsonObject): Promise<JsonObject> => method === "repo.agentRuntime.spawn" ? spawner.spawn(action, edgeBinding()) : method === "repo.agentRuntime.cancel" ? spawner.cancel(action, edgeBinding()) : await runFleetRuntimeReadClient({ ...peer, repoId: request.repoId, method, payload: action }) as JsonObject,
+    run: async (
+      method: FleetEdgeRuntimeRequest["payload"]["method"],
+      action: JsonObject,
+    ): Promise<JsonObject> => {
+      await ready;
+      return method === "repo.agentRuntime.spawn"
+        ? spawner.spawn(action, edgeBinding())
+        : method === "repo.agentRuntime.cancel"
+          ? spawner.cancel(action, edgeBinding())
+          : await runFleetRuntimeReadClient({ ...peer, repoId: request.repoId, method, payload: action }) as JsonObject;
+    },
     close: () => { spawner.close(); }
   };
 }

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -329,6 +329,7 @@ export async function openRepoCell(input: {
       resolveSquadDispatchTarget({ rootDir, leaderId, workerId }),
     ...(input.runtimeLaunch ? { launch: input.runtimeLaunch } : {}),
   });
+  await runtimeSpawner.adopt();
   function assertRuntimeAdmission(force = false): void {
     runtimeAdmission.assert(rootDir, force);
   }

--- a/packages/daemon/src/runtime-spawn-active.ts
+++ b/packages/daemon/src/runtime-spawn-active.ts
@@ -1,0 +1,77 @@
+import type { ActiveRuntime, ResumeProcessObservation } from "./runtime-spawn-types.ts";
+
+type ActiveRuntimeBase = Omit<
+  ActiveRuntime,
+  | "buffer"
+  | "durableOutputCount"
+  | "stdoutObserved"
+  | "errorBuffer"
+  | "errorOverflowed"
+  | "providerSessionId"
+  | "finalText"
+  | "failureText"
+  | "providerOutcome"
+  | "writeItemObserved"
+  | "planObserved"
+  | "planIncomplete"
+  | "protocolError"
+  | "cancelRequested"
+  | "cancelBinding"
+  | "cancelOpId"
+> & { readonly providerSessionId?: string | null };
+
+export function createActiveRuntime(base: ActiveRuntimeBase): ActiveRuntime {
+  return {
+    ...base,
+    buffer: "",
+    durableOutputCount: 0,
+    stdoutObserved: false,
+    errorBuffer: "",
+    errorOverflowed: false,
+    providerSessionId: base.providerSessionId ?? null,
+    finalText: null,
+    failureText: null,
+    providerOutcome: null,
+    writeItemObserved: false,
+    planObserved: false,
+    planIncomplete: false,
+    protocolError: false,
+    cancelRequested: false,
+    cancelBinding: null,
+    cancelOpId: null,
+  };
+}
+
+export function attachActiveRuntime(
+  context: any,
+  active: ActiveRuntime,
+  resumeObservation?: ResumeProcessObservation,
+): void {
+  const runtimeSessionId = active.runtimeSessionId, handlers = {
+    output: (chunk: string, persisted = false) => {
+      if (context.processes.get(runtimeSessionId) === active) context.input.schedule(async () => {
+        if (context.processes.get(runtimeSessionId) === active) {
+          active.stdoutObserved ||= chunk.length > 0;
+          await context.consumeChunk(active, chunk, false, persisted);
+        }
+      });
+    },
+    error: (chunk: string) => {
+      if (context.processes.get(runtimeSessionId) === active) {
+        context.input.schedule(() => context.captureErrorOutput(active, chunk));
+      }
+    },
+    exit: (code: number | null) => {
+      if (context.processes.get(runtimeSessionId) === active) context.input.schedule(async () => {
+        if (context.processes.get(runtimeSessionId) !== active) return;
+        await context.consumeChunk(active, "", true); await context.publishExit(active, code);
+      });
+    },
+  };
+  if (resumeObservation) resumeObservation.activate(handlers);
+  else {
+    active.process.onOutput(handlers.output);
+    active.process.onErrorOutput(handlers.error);
+    active.process.onExit(handlers.exit);
+  }
+}

--- a/packages/daemon/src/runtime-spawn-adoption.ts
+++ b/packages/daemon/src/runtime-spawn-adoption.ts
@@ -1,0 +1,126 @@
+import {
+  readDispatchStream,
+  readDispatchStreams,
+  reopenDispatchStream,
+  type DispatchStreamHeader,
+} from "./dispatch-stream.ts";
+import { createActiveRuntime, attachActiveRuntime } from "./runtime-spawn-active.ts";
+import { adoptNativeProcess, runtimePidIsAlive } from "./runtime-spawn-process.ts";
+import type { RuntimeBinding } from "./runtime-spawn-types.ts";
+import type { RuntimePermissionMode } from "./runtime-permissions.ts";
+
+export async function adoptRuntimes(context: any): Promise<void> {
+  const sessions = context.input.remote
+    ? await context.input.remote.readRuntimeSessions()
+    : context.requiredRuntimeProjection(context.input).readRuntimeSessions();
+  const byId = new Map(sessions.map(
+    (session: { readonly runtimeSessionId: string }) => [session.runtimeSessionId, session],
+  ));
+  for (const stream of readDispatchStreams(context.input.rootDir)) {
+    const session = byId.get(stream.header.runtimeSessionId) as
+      | { readonly liveness: string; readonly outcome: string | null }
+      | undefined;
+    const metadata = adoptableMetadata(stream.header);
+    if (!session || session.liveness === "exited" || session.outcome !== null || !stream.process || !metadata) continue;
+    const runtimeProcess = adoptNativeProcess(
+      context.input.rootDir,
+      stream.header.dispatchId,
+      stream.process.pid,
+    );
+    const active = createActiveRuntime({
+      process: runtimeProcess,
+      dispatchId: stream.header.dispatchId,
+      runtimeSessionId: stream.header.runtimeSessionId,
+      dispatchOpId: metadata.dispatchOpId,
+      instanceId: stream.header.instanceId,
+      kindId: metadata.kindId,
+      permissionMode: metadata.permissionMode,
+      agent: stream.header.agentId
+        ? { id: stream.header.agentId, name: stream.header.agentName ?? stream.header.agentId }
+        : null,
+      delegatedBy: stream.header.delegatedByAgentId
+        ? {
+          id: stream.header.delegatedByAgentId,
+          name: stream.header.delegatedByAgentName ?? stream.header.delegatedByAgentId,
+        }
+        : null,
+      squadId: stream.header.squadId ?? null,
+      binding: metadata.binding,
+      task: stream.header.taskId && stream.header.executionId
+        ? { taskId: stream.header.taskId, executionId: stream.header.executionId }
+        : null,
+      cwd: metadata.cwd,
+      prompt: metadata.prompt,
+      ...(stream.header.promptSource ? { promptSource: stream.header.promptSource } : {}),
+      onExitCommand: stream.header.onExitCommand ?? null,
+      model: metadata.model,
+      reasoningEffort: metadata.reasoningEffort,
+      startedAt: stream.header.startedAt,
+      stream: reopenDispatchStream(context.input.rootDir, stream.header),
+      resumeProviderSessionId: stream.header.resumeProviderSessionId ?? null,
+      providerSessionId: stream.providerSessionId,
+    });
+    context.processes.set(active.runtimeSessionId, active);
+    if (session.liveness !== "live") {
+      await context.publishRuntimeEvent(
+        "runtime_session_liveness_changed",
+        { runtimeSessionId: active.runtimeSessionId, liveness: "live" },
+        `${active.dispatchOpId}-adopt-${String(context.input.daemonGeneration)}`,
+        active.binding,
+      );
+    }
+    attachActiveRuntime(context, active);
+    if (!stream.process.exited && !runtimePidIsAlive(stream.process.pid)) {
+      const timer = setTimeout(() => {
+        const current = readDispatchStream(context.input.rootDir, active.dispatchId);
+        if (!current?.process?.exited && context.processes.get(active.runtimeSessionId) === active) {
+          context.input.schedule(() => context.publishExit(active, null));
+        }
+      }, 50);
+      timer.unref();
+    }
+  }
+}
+
+function adoptableMetadata(header: DispatchStreamHeader): {
+  readonly dispatchOpId: string;
+  readonly kindId: "claude" | "codex" | "agy";
+  readonly permissionMode: RuntimePermissionMode | null;
+  readonly binding: RuntimeBinding;
+  readonly cwd: string;
+  readonly prompt: string;
+  readonly model: string;
+  readonly reasoningEffort: string | null;
+} | null {
+  if (
+    typeof header.dispatchOpId !== "string"
+    || !["claude", "codex", "agy"].includes(String(header.kindId))
+    || header.permissionMode !== null
+      && !["bypass", "workspace-write", "read-only"].includes(String(header.permissionMode))
+    || !isBinding(header.binding)
+    || typeof header.cwd !== "string"
+    || typeof header.prompt !== "string"
+    || typeof header.model !== "string"
+    || header.reasoningEffort !== null && typeof header.reasoningEffort !== "string"
+  ) return null;
+  return {
+    dispatchOpId: header.dispatchOpId,
+    kindId: header.kindId as "claude" | "codex" | "agy",
+    permissionMode: header.permissionMode as RuntimePermissionMode | null,
+    binding: header.binding,
+    cwd: header.cwd,
+    prompt: header.prompt,
+    model: header.model,
+    reasoningEffort: header.reasoningEffort,
+  };
+}
+function isBinding(value: unknown): value is RuntimeBinding {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const binding = value as Record<string, unknown>;
+  const actor = binding.actor;
+  return actor !== null
+    && typeof actor === "object"
+    && !Array.isArray(actor)
+    && typeof (actor as { principal?: { personId?: unknown } }).principal?.personId === "string"
+    && binding.source !== undefined;
+}

--- a/packages/daemon/src/runtime-spawn-control.ts
+++ b/packages/daemon/src/runtime-spawn-control.ts
@@ -1,7 +1,10 @@
 import { createHash } from "node:crypto";
 import { unknownFieldViolation, type JsonObject } from "./protocol/json-rpc-types.ts";
 import { requiredRuntimeSpawnText, runtimeSpawnError } from "./runtime-spawn-errors.ts";
+import { consumeDurableOutput } from "./runtime-spawn-provider-stream.ts";
 import type { RuntimeBinding } from "./runtime-spawn-types.ts";
+
+const cancelDurableDrainTimeoutMs = 1_000;
 
 export async function cancelRuntime(context: any, payload: JsonObject, binding: RuntimeBinding): Promise<JsonObject> {
   const allowed = ["runtimeSessionId"],
@@ -16,6 +19,7 @@ export async function cancelRuntime(context: any, payload: JsonObject, binding: 
     active.cancelBinding = binding;
     active.cancelOpId = opId;
     active.cancelRequested = true;
+    await consumeDurableOutput(context, active, cancelDurableDrainTimeoutMs);
     active.process.terminate();
     await context.publishExit(active, null);
     return context.controlReceipt(opId, runtimeSessionId);
@@ -26,5 +30,5 @@ export async function cancelRuntime(context: any, payload: JsonObject, binding: 
 export function closeRuntimes(context: any): void {
   const active = [...context.processes.values()];
   context.processes.clear();
-  for (const entry of active) context.terminateActive(entry, false);
+  for (const entry of active) entry.process.release?.();
 }

--- a/packages/daemon/src/runtime-spawn-process.ts
+++ b/packages/daemon/src/runtime-spawn-process.ts
@@ -1,10 +1,17 @@
 import { spawn,
   /* @gate-identity check-sync-subprocess/sync-subprocess-010 */
   spawnSync } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
+import { fileURLToPath } from "node:url";
 import type { CanonicalEventStore, TaskProjection } from "../../kernel/src/index.ts";
 import { consumeKnownError } from "../../kernel/src/index.ts";
 import type { PreparedRuntimeLaunch, RuntimeInstanceKind } from "./agent-runtime-instances.ts";
-import { scrubProviderValue, type DispatchStreamWriter } from "./dispatch-stream.ts";
+import {
+  appendRuntimeWorkerRecord,
+  readRuntimeWorkerChunk,
+  scrubProviderValue,
+  type DispatchStreamWriter,
+} from "./dispatch-stream.ts";
 import { runtimeSpawnError } from "./runtime-spawn-errors.ts";
 import { parseProviderFrame } from "./runtime-spawn-provider-frames.ts";
 import type { ResumeProcessEvent, ResumeProcessObservation, RuntimeProcess } from "./runtime-spawn-types.ts";
@@ -129,7 +136,7 @@ export function observeResumeProcess(
 // cmd.exe, and the surviving grandchild holds the inherited stdio pipes open, which keeps the
 // daemon -- or a test process -- alive with a runtime it believes it stopped. taskkill /T ends the
 // tree. Windows has no graceful signal to lose here: SIGTERM already terminates unconditionally.
-export function terminateRuntimeProcess(child: ReturnType<typeof spawn>): void {
+export function terminateRuntimeProcess(child: Pick<ReturnType<typeof spawn>, "killed" | "pid" | "kill">): void {
   if (child.killed || child.pid === undefined) return;
   if (process.platform === "win32") {
     /* @gate-identity check-sync-subprocess/sync-subprocess-011 */
@@ -139,6 +146,24 @@ export function terminateRuntimeProcess(child: ReturnType<typeof spawn>): void {
     return;
   }
   child.kill("SIGTERM");
+}
+
+export function terminateRuntimePid(pid: number): void {
+  if (!Number.isInteger(pid) || pid < 1) return;
+  if (process.platform === "win32") {
+    terminateRuntimeProcess({ killed: false, pid, kill: () => false });
+    return;
+  }
+  try {
+    process.kill(-pid, "SIGTERM");
+  } catch (error) {
+    if (childProcessErrorCode(error) !== "ESRCH") throw error;
+    consumeKnownError(error);
+  }
+}
+
+export function runtimePidIsAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; } catch (error) { return childProcessErrorCode(error) === "EPERM"; }
 }
 
 export function launchExitNotification(input: {
@@ -261,36 +286,130 @@ export function childProcessErrorCode(error: unknown): string {
     : "spawn_failed";
 }
 
-export function launchNative(input: PreparedRuntimeLaunch): RuntimeProcess {
-  const command = nativeCommand(input),
-    child = spawn(command.executablePath, command.args, {
-      cwd: input.cwd,
-      stdio: ["pipe", "pipe", "pipe"],
-      windowsHide: true,
-      env: input.env,
-      ...(process.platform === "win32" && command.executablePath.toLowerCase().endsWith("cmd.exe")
-        ? { windowsVerbatimArguments: true }
-        : {}),
-    });
-  child.stdout.setEncoding("utf8");
-  child.stderr.setEncoding("utf8");
-  child.stdin.end(input.prompt);
+export function launchNative(
+  input: PreparedRuntimeLaunch,
+  persistence: { readonly rootDir: string; readonly dispatchId: string },
+): RuntimeProcess {
+  const command = nativeCommand(input);
+  const workerHost = import.meta.url.endsWith(".js")
+    ? "./runtime-worker-host.js"
+    : "./runtime-worker-host.ts";
+  const entry = fileURLToPath(new URL(workerHost, import.meta.url));
+  const child = spawn(process.execPath, [entry, "--runtime-worker-host"], {
+    detached: true,
+    stdio: ["pipe", "ignore", "ignore"],
+    windowsHide: true,
+    env: process.env,
+  });
+  const pid = child.pid ?? 0;
+  const observed = observeDispatchProcess(persistence.rootDir, persistence.dispatchId, pid);
+  appendRuntimeWorkerRecord(persistence.rootDir, persistence.dispatchId, {
+    kind: "process_started",
+    occurredAt: new Date().toISOString(),
+    pid,
+  });
+  child.stdin?.on("error", consumeKnownError);
+  child.stdin?.end(JSON.stringify({
+    ...persistence,
+    executablePath: command.executablePath,
+    args: command.args,
+    cwd: input.cwd,
+    env: input.env,
+    prompt: input.prompt,
+    windowsVerbatimArguments:
+      process.platform === "win32" && command.executablePath.toLowerCase().endsWith("cmd.exe"),
+  }));
+  child.unref();
+  return observed;
+}
+
+export function adoptNativeProcess(rootDir: string, dispatchId: string, pid: number): RuntimeProcess {
+  return observeDispatchProcess(rootDir, dispatchId, pid);
+}
+
+function observeDispatchProcess(rootDir: string, dispatchId: string, pid: number): RuntimeProcess {
+  const outputs: Array<{ readonly chunk: string; readonly persisted: boolean }> = [];
+  const errors: string[] = [];
+  const decoder = new StringDecoder("utf8");
+  let offset = 0;
+  let buffer = "";
+  let outputListener: ((chunk: string, persisted?: boolean) => void) | null = null;
+  let errorListener: ((chunk: string) => void) | null = null;
+  let exitListener: ((code: number | null) => void) | null = null;
+  let exitCode: number | null = null;
+  let exited = false;
+  let released = false;
+  const emitOutput = (chunk: string): void => {
+    if (outputListener) outputListener(chunk, true);
+    else outputs.push({ chunk, persisted: true });
+  };
+  const emitError = (chunk: string): void => {
+    if (errorListener) errorListener(chunk);
+    else errors.push(chunk);
+  };
+  const emitExit = (code: number | null): void => {
+    if (exited) return;
+    exited = true;
+    exitCode = code;
+    if (exitListener) exitListener(code);
+  };
+  const drain = (): void => {
+    if (released) return;
+    try {
+      const bytes = readRuntimeWorkerChunk(rootDir, dispatchId, offset);
+      if (bytes.length === 0) return;
+      offset += bytes.length;
+      buffer += decoder.write(bytes);
+      const lines = buffer.split(/\r?\n/u);
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        const record = parseDispatchProcessRecord(line);
+        if (record?.kind === "provider_event") emitOutput(`${JSON.stringify(record.event)}\n`);
+        else if (record?.kind === "provider_output_invalid") emitOutput(`${String(record.output)}\n`);
+        else if (record?.kind === "provider_stderr") emitError(String(record.chunk));
+        else if (record?.kind === "process_exit") {
+          emitExit(Number.isInteger(record.exitCode) ? Number(record.exitCode) : null);
+        }
+      }
+    } catch (error) {
+      consumeKnownError(error);
+    }
+  };
+  const timer = setInterval(drain, 20);
+  timer.unref();
+  queueMicrotask(drain);
   return {
-    pid: child.pid ?? 0,
+    pid,
     onOutput: (listener) => {
-      child.stdout.on("data", listener);
+      outputListener = listener;
+      for (const value of outputs.splice(0)) listener(value.chunk, value.persisted);
     },
     onErrorOutput: (listener) => {
-      child.stderr.on("data", listener);
+      errorListener = listener;
+      for (const value of errors.splice(0)) listener(value);
     },
     onExit: (listener) => {
-      child.once("close", listener);
-      child.once("error", () => listener(null));
+      exitListener = listener;
+      if (exited) queueMicrotask(() => listener(exitCode));
     },
-    terminate: () => {
-      terminateRuntimeProcess(child);
+    terminate: () => terminateRuntimePid(pid),
+    release: () => {
+      released = true;
+      clearInterval(timer);
     },
   };
+}
+
+function parseDispatchProcessRecord(line: string): Record<string, unknown> | null {
+  try {
+    const value: unknown = JSON.parse(line);
+    return value !== null && typeof value === "object" && !Array.isArray(value)
+      ? value as Record<string, unknown>
+      : null;
+  } catch (error) {
+    consumeKnownError(error);
+    return null;
+  }
 }
 
 export function nativeCommand(input: PreparedRuntimeLaunch): {

--- a/packages/daemon/src/runtime-spawn-provider-stream.ts
+++ b/packages/daemon/src/runtime-spawn-provider-stream.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
 import type {
   AgentRuntimeEventV1,
   CanonicalContentBlob,
@@ -6,7 +7,7 @@ import type {
   SessionIdentity,
 } from "../../kernel/src/index.ts";
 import { canonicalEventWritePlan, consumeKnownError } from "../../kernel/src/index.ts";
-import { scrubProviderValue } from "./dispatch-stream.ts";
+import { readDispatchStream, scrubProviderValue } from "./dispatch-stream.ts";
 import { type JsonObject } from "./protocol/json-rpc-types.ts";
 import type { ActiveRuntime, ProviderFrame, RuntimeBinding } from "./runtime-spawn-types.ts";
 import { transcriptRefForSessionIdentity } from "./session-identity/index.ts";
@@ -58,20 +59,34 @@ export async function publishRuntimeEvent<T extends AgentRuntimeEventV1["type"]>
   return { event: value, publication: appended };
 }
 
-export async function consumeChunk(context: any, active: ActiveRuntime, chunk: string, flush: boolean): Promise<void> {
+export async function consumeProviderChunk(
+  context: any,
+  active: ActiveRuntime,
+  chunk: string,
+  flush: boolean,
+  persisted = false,
+): Promise<void> {
   active.buffer += chunk;
   const lines = active.buffer.split(/\r?\n/u);
-  active.buffer = flush ? "" : (lines.pop() ?? "");
-  for (const line of lines) if (line.trim()) await context.consumeLine(active, line);
-  if (flush && active.buffer.trim()) await context.consumeLine(active, active.buffer);
+  const trailing = lines.pop() ?? "";
+  active.buffer = flush ? "" : trailing;
+  for (const line of lines) if (line.trim()) await context.consumeLine(active, line, persisted);
+  if (flush && trailing.trim()) await context.consumeLine(active, trailing, persisted);
 }
 
-export async function consumeLine(context: any, active: ActiveRuntime, line: string): Promise<void> {
+export async function consumeProviderLine(
+  context: any,
+  active: ActiveRuntime,
+  line: string,
+  persisted = false,
+): Promise<void> {
   let value: unknown;
   try {
     value = JSON.parse(line);
-    active.stream.appendProviderEvent(value, context.input.now());
+    if (!persisted) active.stream.appendProviderEvent(value, context.input.now());
+    active.durableOutputCount += 1;
   } catch (error) {
+    if (persisted) active.durableOutputCount += 1;
     consumeKnownError(error);
     context.markProtocolError(active);
     return;
@@ -94,6 +109,36 @@ export async function consumeLine(context: any, active: ActiveRuntime, line: str
     parsed.planObserved === true ||
     (parsed.finalText !== undefined && context.isStructuredSuccessResult(parsed.finalText));
   if (parsed.planIncomplete !== undefined) active.planIncomplete = parsed.planIncomplete;
+}
+
+export async function consumeDurableOutput(
+  context: any,
+  active: ActiveRuntime,
+  waitForFirstRecordMs = 0,
+): Promise<void> {
+  let stream = readDispatchStream(context.input.rootDir, active.dispatchId);
+  let records = durableOutputRecords(stream?.records ?? []);
+  const deadline = Date.now() + waitForFirstRecordMs;
+  while (records.length === 0 && stream?.process?.exited === false && Date.now() < deadline) {
+    await delay(Math.min(10, Math.max(1, deadline - Date.now())));
+    stream = readDispatchStream(context.input.rootDir, active.dispatchId);
+    records = durableOutputRecords(stream?.records ?? []);
+  }
+  for (const record of records.slice(active.durableOutputCount)) {
+    await context.consumeLine(
+      active,
+      record.kind === "provider_event" ? JSON.stringify(record.event) : String(record.output),
+      true,
+    );
+  }
+}
+
+function durableOutputRecords(
+  records: readonly Record<string, unknown>[],
+): readonly Record<string, unknown>[] {
+  return records.filter(
+    (record) => record.kind === "provider_event" || record.kind === "provider_output_invalid",
+  );
 }
 
 export function captureErrorOutput(context: any, active: ActiveRuntime, chunk: string): void {
@@ -157,9 +202,4 @@ export function markProtocolError(context: any, active: ActiveRuntime): void {
     type: "error",
     code: "provider_protocol_error",
   });
-}
-
-export function terminateActive(context: any, active: ActiveRuntime, cancelled: boolean): void {
-  if (cancelled) active.cancelRequested = true;
-  active.process.terminate();
 }

--- a/packages/daemon/src/runtime-spawn-settlement.ts
+++ b/packages/daemon/src/runtime-spawn-settlement.ts
@@ -142,6 +142,7 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
             },
           };
     context.processes.delete(active.runtimeSessionId);
+    active.process.release?.();
     if (notification) setImmediate(() => context.launchExitNotification({ ...notification, now: context.input.now }));
   } finally {
     context.exiting.delete(active.runtimeSessionId);

--- a/packages/daemon/src/runtime-spawn-types.ts
+++ b/packages/daemon/src/runtime-spawn-types.ts
@@ -16,13 +16,17 @@ import { type RuntimePermissionMode } from "./runtime-permissions.ts";
 
 export interface RuntimeProcess {
   readonly pid: number;
-  readonly onOutput: (listener: (chunk: string) => void) => void;
+  readonly onOutput: (listener: (chunk: string, persisted?: boolean) => void) => void;
   readonly onErrorOutput: (listener: (chunk: string) => void) => void;
   readonly onExit: (listener: (code: number | null) => void) => void;
   readonly terminate: () => void;
+  readonly release?: () => void;
 }
 
-export type RuntimeLauncher = (input: PreparedRuntimeLaunch) => RuntimeProcess;
+export type RuntimeLauncher = (
+  input: PreparedRuntimeLaunch,
+  persistence: { readonly rootDir: string; readonly dispatchId: string },
+) => RuntimeProcess;
 
 export interface RuntimeDaemonRoute {
   readonly userRoot: string;
@@ -55,8 +59,8 @@ export type ActiveRuntime = {
   readonly instanceId: string;
   readonly kindId: RuntimeInstanceKind;
   readonly permissionMode: RuntimePermissionMode | null;
-  readonly agent: RuntimeAgent | null;
-  readonly delegatedBy: RuntimeAgent | null;
+  readonly agent: Pick<RuntimeAgent, "id" | "name"> | null;
+  readonly delegatedBy: Pick<RuntimeAgent, "id" | "name"> | null;
   readonly squadId: string | null;
   readonly binding: RuntimeBinding;
   readonly task: {
@@ -72,6 +76,7 @@ export type ActiveRuntime = {
   readonly startedAt: string;
   readonly stream: DispatchStreamWriter;
   buffer: string;
+  durableOutputCount: number;
   stdoutObserved: boolean;
   errorBuffer: string;
   errorOverflowed: boolean;
@@ -114,7 +119,10 @@ export type ResumeProcessObservation = {
   }) => void;
 };
 
-export type RuntimeSessionSelection = Pick<RuntimeSession, "providerSessionId" | "instanceId" | "liveness">;
+export type RuntimeSessionSelection = Pick<
+  RuntimeSession,
+  "runtimeSessionId" | "providerSessionId" | "instanceId" | "liveness" | "outcome"
+>;
 
 export interface RemoteRuntimePersistence {
   readonly existing: (opId: string) => Promise<JsonObject | null>;

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -13,11 +13,19 @@ import { runtimeTypeMatchesKind } from "./agent-runtime-contract.ts";
 import type { PreparedRuntimeLaunch, RuntimeInstanceSummary } from "./agent-runtime-instances.ts";
 import type { AgentRuntimeStreamHub } from "./agent-runtime-stream.ts";
 import { resolveAgentSkills } from "./agent-skills.ts";
-import { openDispatchStream, readDispatchStream } from "./dispatch-stream.ts";
+import {
+  openDispatchStream,
+  readDispatchStream,
+  removeDispatchStream,
+  scrubProviderValue,
+  type DispatchStreamWriter,
+} from "./dispatch-stream.ts";
 import { unknownFieldViolation, type JsonObject } from "./protocol/json-rpc-types.ts";
 import { runtimeKindForId } from "./runtime-inventory.ts";
 import { runtimePermissionMode } from "./runtime-permissions.ts";
 import { cancelRuntime, closeRuntimes } from "./runtime-spawn-control.ts";
+import { createActiveRuntime, attachActiveRuntime } from "./runtime-spawn-active.ts";
+import { adoptRuntimes } from "./runtime-spawn-adoption.ts";
 import {
   isRuntimeEvent,
   requiredRuntimeSpawnText,
@@ -45,11 +53,10 @@ import { isStructuredSuccessResult, parseProviderFrame } from "./runtime-spawn-p
 import {
   bindProvider as bindProviderImpl,
   captureErrorOutput as captureErrorOutputImpl,
-  consumeChunk as consumeChunkImpl,
-  consumeLine as consumeLineImpl,
+  consumeProviderChunk,
+  consumeProviderLine,
   markProtocolError as markProtocolErrorImpl,
   publishRuntimeEvent as publishRuntimeEventImpl,
-  terminateActive as terminateActiveImpl,
 } from "./runtime-spawn-provider-stream.ts";
 import {
   applied as appliedImpl,
@@ -108,6 +115,7 @@ export function makeRuntimeSpawner(input: {
     requiredRuntimeStore,
     requiredRuntimeProjection,
     runtimeSpawnError,
+    consumeChunk,
     consumeLine,
     markProtocolError,
     parseProviderFrame,
@@ -122,7 +130,7 @@ export function makeRuntimeSpawner(input: {
     launchExitNotification,
     publishExit,
     controlReceipt,
-    terminateActive,
+    captureErrorOutput,
   };
 
   return {
@@ -357,14 +365,48 @@ export function makeRuntimeSpawner(input: {
               },
             }
           : prepared;
-      let process: RuntimeProcess | undefined, resumeObservation: ResumeProcessObservation | undefined;
+      const taskBinding = taskId ? { taskId, executionId: remoteTask?.executionId ?? lease!.executionId } : null,
+        streamStartedAt = input.now();
+      let process: RuntimeProcess | undefined;
+      let resumeObservation: ResumeProcessObservation | undefined;
+      let stream: DispatchStreamWriter | undefined;
+      const openStream = (): DispatchStreamWriter => stream ??= openDispatchStream(input.rootDir, {
+        dispatchId: newDispatchId,
+        taskId: taskBinding?.taskId ?? null,
+        executionId: taskBinding?.executionId ?? null,
+        runtimeSessionId,
+        instanceId: definition.instanceId,
+        startedAt: streamStartedAt,
+        dispatchOpId,
+        kindId: definition.kindId,
+        permissionMode: launchedPermissionMode ?? null,
+        binding,
+        cwd,
+        prompt: scrubProviderValue(prompt) as string,
+        ...(promptSource ? { promptSource } : {}),
+        model: definition.model,
+        reasoningEffort: definition.reasoningEffort,
+        resumeProviderSessionId: providerSessionId ?? null,
+        ...(onExitCommand ? { onExitCommand } : {}),
+        ...(agent ? { agentId: agent.id, agentName: agent.name } : {}),
+        ...(delegatedBy
+          ? {
+            delegatedByAgentId: delegatedBy.id,
+            delegatedByAgentName: delegatedBy.name,
+            squadId: target!.squadId,
+          }
+          : {}),
+      });
       if (providerSessionId)
         try {
-          process = launch(workerLaunch);
+          openStream();
+          process = launch(workerLaunch, { rootDir: input.rootDir, dispatchId: newDispatchId });
           resumeObservation = observeResumeProcess(process, definition.kindId, providerSessionId);
           await resumeObservation.ready;
         } catch (error) {
           process?.terminate();
+          process?.release?.();
+          removeDispatchStream(input.rootDir, newDispatchId);
           if (runtimeErrorCode(error) === "runtime_resume_failed") throw error;
           consumeKnownError(error);
           throw runtimeSpawnError(
@@ -405,12 +447,16 @@ export function makeRuntimeSpawner(input: {
         );
       } catch (error) {
         process?.terminate();
+        process?.release?.();
+        if (stream) removeDispatchStream(input.rootDir, newDispatchId);
         throw error;
       }
       if (!process)
         try {
-          process = launch(workerLaunch);
+          openStream();
+          process = launch(workerLaunch, { rootDir: input.rootDir, dispatchId: newDispatchId });
         } catch (error) {
+          removeDispatchStream(input.rootDir, newDispatchId);
           await publishRuntimeEvent(
             "runtime_dispatch_outcome_unknown",
             { dispatchId: newDispatchId, runtimeSessionId },
@@ -420,47 +466,28 @@ export function makeRuntimeSpawner(input: {
           throw error;
         }
       const runtimeProcess = process;
-      let started!: AgentRuntimeEventV1;
       try {
-        started = (
-          await publishRuntimeEvent(
-            "runtime_session_started",
-            {
-              runtimeSessionId,
-              instanceId: definition.instanceId,
-              installationId: definition.installationId,
-              kindId: definition.kindId,
-              definitionSnapshotRef,
-              launchGeneration: input.daemonGeneration,
-              attachable: true,
-            },
-            `${dispatchOpId}-started`,
-            binding,
-          )
-        ).event;
+        await publishRuntimeEvent(
+          "runtime_session_started",
+          {
+            runtimeSessionId,
+            instanceId: definition.instanceId,
+            installationId: definition.installationId,
+            kindId: definition.kindId,
+            definitionSnapshotRef,
+            launchGeneration: input.daemonGeneration,
+            attachable: true,
+          },
+          `${dispatchOpId}-started`,
+          binding,
+        );
       } catch (error) {
         runtimeProcess.terminate();
+        runtimeProcess.release?.();
+        removeDispatchStream(input.rootDir, newDispatchId);
         throw error;
       }
-      const taskBinding = taskId ? { taskId, executionId: remoteTask?.executionId ?? lease!.executionId } : null;
-      const stream = openDispatchStream(input.rootDir, {
-        dispatchId: newDispatchId,
-        taskId: taskBinding?.taskId ?? null,
-        executionId: taskBinding?.executionId ?? null,
-        runtimeSessionId,
-        instanceId: definition.instanceId,
-        startedAt: started.occurredAt,
-        ...(onExitCommand ? { onExitCommand } : {}),
-        ...(agent ? { agentId: agent.id, agentName: agent.name } : {}),
-        ...(delegatedBy
-          ? {
-              delegatedByAgentId: delegatedBy.id,
-              delegatedByAgentName: delegatedBy.name,
-              squadId: target!.squadId,
-            }
-          : {}),
-      });
-      const active: ActiveRuntime = {
+      const active = createActiveRuntime({
         process: runtimeProcess,
         dispatchId: newDispatchId,
         runtimeSessionId,
@@ -479,58 +506,17 @@ export function makeRuntimeSpawner(input: {
         onExitCommand: onExitCommand ?? null,
         model: definition.model,
         reasoningEffort: definition.reasoningEffort,
-        startedAt: started.occurredAt,
-        stream,
-        buffer: "",
-        stdoutObserved: false,
-        errorBuffer: "",
-        errorOverflowed: false,
-        providerSessionId: null,
+        startedAt: streamStartedAt,
+        stream: openStream(),
         resumeProviderSessionId: providerSessionId ?? null,
-        finalText: null,
-        failureText: null,
-        providerOutcome: null,
-        writeItemObserved: false,
-        planObserved: false,
-        planIncomplete: false,
-        protocolError: false,
-        cancelRequested: false,
-        cancelBinding: null,
-        cancelOpId: null,
-      };
+      });
       processes.set(runtimeSessionId, active);
-      const handlers = {
-        output: (chunk: string) => {
-          if (processes.get(runtimeSessionId) === active)
-            input.schedule(async () => {
-              if (processes.get(runtimeSessionId) === active) {
-                active.stdoutObserved ||= chunk.length > 0;
-                await consumeChunk(active, chunk, false);
-              }
-            });
-        },
-        error: (chunk: string) => {
-          if (processes.get(runtimeSessionId) === active) input.schedule(() => captureErrorOutput(active, chunk));
-        },
-        exit: (code: number | null) => {
-          if (processes.get(runtimeSessionId) === active)
-            input.schedule(async () => {
-              if (processes.get(runtimeSessionId) !== active) return;
-              await consumeChunk(active, "", true);
-              await publishExit(active, code);
-            });
-        },
-      };
-      if (resumeObservation) resumeObservation.activate(handlers);
-      else {
-        runtimeProcess.onOutput(handlers.output);
-        runtimeProcess.onErrorOutput(handlers.error);
-        runtimeProcess.onExit(handlers.exit);
-      }
+      attachActiveRuntime(extracted, active, resumeObservation);
       return requested.receipt
         ? { ...requested.receipt, runtimeSessionId, dispatchId: newDispatchId }
         : applied(requested.event, requested.publication!, runtimeSessionId, newDispatchId);
     },
+    adopt: () => adoptRuntimes(extracted),
     cancel: (payload: JsonObject, binding: RuntimeBinding) => cancelRuntime(extracted, payload, binding),
     close: () => closeRuntimes(extracted),
   };
@@ -547,11 +533,11 @@ export function makeRuntimeSpawner(input: {
   }> {
     return publishRuntimeEventImpl<T>(extracted, type, payload, opId, binding, resultBody);
   }
-  async function consumeChunk(active: ActiveRuntime, chunk: string, flush: boolean): Promise<void> {
-    return consumeChunkImpl(extracted, active, chunk, flush);
+  async function consumeChunk(active: ActiveRuntime, chunk: string, flush: boolean, persisted = false): Promise<void> {
+    return consumeProviderChunk(extracted, active, chunk, flush, persisted);
   }
-  async function consumeLine(active: ActiveRuntime, line: string): Promise<void> {
-    return consumeLineImpl(extracted, active, line);
+  async function consumeLine(active: ActiveRuntime, line: string, persisted = false): Promise<void> {
+    return consumeProviderLine(extracted, active, line, persisted);
   }
   function captureErrorOutput(active: ActiveRuntime, chunk: string): void {
     return captureErrorOutputImpl(extracted, active, chunk);
@@ -561,9 +547,6 @@ export function makeRuntimeSpawner(input: {
   }
   function markProtocolError(active: ActiveRuntime): void {
     return markProtocolErrorImpl(extracted, active);
-  }
-  function terminateActive(active: ActiveRuntime, cancelled: boolean): void {
-    return terminateActiveImpl(extracted, active, cancelled);
   }
   async function publishExit(active: ActiveRuntime, code: number | null): Promise<void> {
     return publishExitImpl(extracted, active, code);

--- a/packages/daemon/src/runtime-worker-host.ts
+++ b/packages/daemon/src/runtime-worker-host.ts
@@ -1,0 +1,105 @@
+import { spawn } from "node:child_process";
+import { consumeKnownError } from "../../kernel/src/index.ts";
+import { appendRuntimeWorkerRecord, scrubProviderValue } from "./dispatch-stream.ts";
+
+type RuntimeWorkerManifest = {
+  readonly rootDir: string;
+  readonly dispatchId: string;
+  readonly executablePath: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly prompt: string;
+  readonly windowsVerbatimArguments: boolean;
+};
+
+async function runRuntimeWorkerHost(): Promise<void> {
+  const manifest = parseManifest(await readStandardInput());
+  const append = (value: Readonly<Record<string, unknown>>): void => appendRuntimeWorkerRecord(
+    manifest.rootDir,
+    manifest.dispatchId,
+    { occurredAt: new Date().toISOString(), ...value },
+  );
+  const child = spawn(manifest.executablePath, [...manifest.args], {
+    cwd: manifest.cwd,
+    env: manifest.env,
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+    ...(manifest.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
+  });
+  let outputBuffer = "";
+  let settled = false;
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  const consumeOutput = (chunk: string, flush = false): void => {
+    outputBuffer += chunk;
+    const lines = outputBuffer.split(/\r?\n/u);
+    const trailing = lines.pop() ?? "";
+    outputBuffer = flush ? "" : trailing;
+    for (const line of lines) if (line.trim()) appendProviderLine(append, line);
+    if (flush && trailing.trim()) appendProviderLine(append, trailing);
+  };
+  child.stdout.on("data", (chunk: string) => consumeOutput(chunk));
+  child.stderr.on("data", (chunk: string) => append({
+    kind: "provider_stderr",
+    chunk: scrubProviderValue(chunk) as string,
+  }));
+  const finish = (exitCode: number | null, signal: NodeJS.Signals | null): void => {
+    if (settled) return;
+    settled = true;
+    consumeOutput("", true);
+    append({ kind: "process_exit", exitCode, signal });
+  };
+  child.once("error", (error) => {
+    append({ kind: "provider_stderr", chunk: scrubProviderValue(error.message) as string });
+    finish(null, null);
+  });
+  child.once("close", finish);
+  process.once("SIGTERM", () => { if (!settled) child.kill("SIGTERM"); });
+  child.stdin.end(manifest.prompt);
+  await new Promise<void>((resolve) => child.once("close", () => resolve()));
+}
+
+function appendProviderLine(
+  append: (value: Readonly<Record<string, unknown>>) => void,
+  line: string,
+): void {
+  try {
+    append({ kind: "provider_event", event: scrubProviderValue(JSON.parse(line)) });
+  } catch (error) {
+    consumeKnownError(error);
+    append({ kind: "provider_output_invalid", output: scrubProviderValue(line) });
+  }
+}
+
+async function readStandardInput(): Promise<string> {
+  let value = "";
+  for await (const chunk of process.stdin) value += String(chunk);
+  return value;
+}
+function parseManifest(value: string): RuntimeWorkerManifest {
+  const parsed: unknown = JSON.parse(value);
+  if (
+    !isRuntimeWorkerRecord(parsed)
+    || typeof parsed.rootDir !== "string"
+    || typeof parsed.dispatchId !== "string"
+    || typeof parsed.executablePath !== "string"
+    || !Array.isArray(parsed.args)
+    || !parsed.args.every((arg) => typeof arg === "string")
+    || typeof parsed.cwd !== "string"
+    || !isRuntimeWorkerRecord(parsed.env)
+    || typeof parsed.prompt !== "string"
+    || typeof parsed.windowsVerbatimArguments !== "boolean"
+  ) throw new Error("runtime worker manifest is invalid");
+  return parsed as RuntimeWorkerManifest;
+}
+function isRuntimeWorkerRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+if (process.argv[2] === "--runtime-worker-host") {
+  void runRuntimeWorkerHost().catch((error: unknown) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/packages/daemon/test/runtime-spawn.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn.integration.test.ts
@@ -5,7 +5,7 @@ import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSy
 import { hostname, tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { makeTaskEventStore, makeTaskProjection, registerDaemonRepo, type AgentDefinitionSnapshot } from "../../kernel/src/index.ts";
+import { consumeKnownError, makeTaskEventStore, makeTaskProjection, registerDaemonRepo, type AgentDefinitionSnapshot } from "../../kernel/src/index.ts";
 import { openRuntimeInstanceStore, type RuntimeInstallationWitness } from "../src/agent-runtime-instances.ts";
 import { localUserDaemonEndpoint } from "../src/client/local-daemon-target.ts";
 import { openDaemonHost } from "../src/daemon-host.ts";
@@ -51,6 +51,54 @@ test("runtime spawn publishes a canonical session and makes it visible in overvi
         await assert.rejects(cell.spawnRuntime({ kindId: "codex", installationId: "installation-codex", profileId: "default", cwd: { scope: "repo-root" }, prompt: "Legacy", taskId: null, idempotencyKey: "legacy" }, { actor: { principal: { personId: "person-spawn" }, executor: null }, source: "local" }), (error: unknown) => error instanceof Error && "code" in error && error.code === "invalid_runtime_spawn");
       } finally { await cell.close(); }
     } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("repo-cell restart re-adopts a live native runtime and settles an exit recorded while absent", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-re-adopt-")), root = path.join(parent, "repo"), release = path.join(parent, "release"), pidFile = path.join(parent, "provider.pid"), repoId = "runtime-re-adopt", executablePath = writeProviderExecutable(path.join(parent, "re-adopt-provider.mjs"), `import fs from "node:fs";\nfs.readFileSync(0, "utf8");\nfs.writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));\nconsole.log(JSON.stringify({ type: "thread.started", thread_id: "provider-re-adopt-session" }));\nconst timer = setInterval(() => { if (!fs.existsSync(${JSON.stringify(release)})) return; clearInterval(timer); console.log(JSON.stringify({ type: "item.completed", item: { id: "message", type: "agent_message", text: "survived daemon restart" } })); console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } })); }, 10);\n`), installation = installationFixture("codex", executablePath), definition = { instanceId: "codex-re-adopt", name: "Codex Re-adopt", kindId: "codex" as const, installationId: installation.installationId, providerId: "openai", models: ["codex-model"], defaultModel: "codex-model", enabled: true, permissionMode: "read-only" as const, codex: {}, authMode: "subscription" as const, authState: "configured" as const, authReadiness: { status: "ready" as const, code: null, hint: null }, isolationState: "enforced" as const, schemaVersion: 2 as const }, preparedDefinition: AgentDefinitionSnapshot = { schema: "agent-definition-snapshot/v1", configVersion: 1, instanceId: definition.instanceId, installationId: installation.installationId, kindId: "codex", providerId: "openai", model: "codex-model", reasoningEffort: null, baseUrl: null, authMode: "subscription" };
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined, providerPid = 0;
+  try {
+    initIngressRepo(root, 4309);
+    const open = (ownerId: string) => openRepoCell({ repoId: workspaceId(repoId), rootDir: canonicalRoot(root), ownerId, runtimeInstances: () => [definition], prepareRuntimeLaunch: async (_instanceId, request) => ({ definition: preparedDefinition, installation, executablePath, args: ["exec", "--json", "--model", "codex-model", "-"], env: process.env, cwd: request.cwd, prompt: request.prompt }) });
+    cell = await open("re-adopt-before");
+    const receipt = await cell.spawnRuntime({ runtimeInstanceId: definition.instanceId, cwd: { scope: "repo-root" }, prompt: "Stay alive across restart", taskId: null, idempotencyKey: "re-adopt" }, { actor: { principal: { personId: "person-re-adopt" }, executor: null }, source: "local" });
+    providerPid = await eventuallyValue(() => { try { const value = Number(readFileSync(pidFile, "utf8")); return Number.isInteger(value) && value > 0 ? value : null; } catch { return null; } });
+    await eventually(() => readFileSync(path.join(root, ".harness", "runtime", "dispatches", `${String(receipt.dispatchId)}.jsonl`), "utf8").includes("provider-re-adopt-session"));
+    await cell.close(); cell = undefined;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    assert.doesNotThrow(() => process.kill(providerPid, 0), "repo-cell close must not terminate its runtime worker");
+    cell = await open("re-adopt-after");
+    writeFileSync(release, "release");
+    await eventually(() => makeTaskEventStore({ repoId, rootDir: root }).read().events.some((event) => event.type === "runtime_session_outcome_observed" && event.payload.runtimeSessionId === receipt.runtimeSessionId));
+    const projection = makeTaskProjection({ rootDir: root, eventStore: makeTaskEventStore({ repoId, rootDir: root }) }), settled = projection.readRuntimeSession(String(receipt.runtimeSessionId))!; projection.close();
+    assert.deepEqual({ liveness: settled.liveness, outcome: settled.outcome, exitCode: settled.exitCode }, { liveness: "exited", outcome: "succeeded", exitCode: 0 });
+    assert.match(readFileSync(path.join(root, ".harness", "runtime", "dispatches", `${String(receipt.dispatchId)}.jsonl`), "utf8"), /survived daemon restart/u);
+    rmSync(release, { force: true }); const absentReceipt = await cell.spawnRuntime({ runtimeInstanceId: definition.instanceId, cwd: { scope: "repo-root" }, prompt: "Exit while daemon is absent", taskId: null, idempotencyKey: "re-adopt-absent-exit" }, { actor: { principal: { personId: "person-re-adopt" }, executor: null }, source: "local" });
+    providerPid = await eventuallyValue(() => { try { const value = Number(readFileSync(pidFile, "utf8")); return Number.isInteger(value) && value > 0 && value !== providerPid ? value : null; } catch { return null; } }); await eventually(() => readFileSync(path.join(root, ".harness", "runtime", "dispatches", `${String(absentReceipt.dispatchId)}.jsonl`), "utf8").includes("provider-re-adopt-session"));
+    await cell.close(); cell = undefined; writeFileSync(release, "release"); await eventually(() => readFileSync(path.join(root, ".harness", "runtime", "dispatches", `${String(absentReceipt.dispatchId)}.jsonl`), "utf8").includes('"kind":"process_exit"'));
+    cell = await open("re-adopt-dead"); await eventually(() => makeTaskEventStore({ repoId, rootDir: root }).read().events.some((event) => event.type === "runtime_session_outcome_observed" && event.payload.runtimeSessionId === absentReceipt.runtimeSessionId));
+    const reopenedProjection = makeTaskProjection({ rootDir: root, eventStore: makeTaskEventStore({ repoId, rootDir: root }) }), daemonlessSettlement = reopenedProjection.readRuntimeSession(String(absentReceipt.runtimeSessionId))!; reopenedProjection.close(); assert.deepEqual({ liveness: daemonlessSettlement.liveness, outcome: daemonlessSettlement.outcome, exitCode: daemonlessSettlement.exitCode }, { liveness: "exited", outcome: "succeeded", exitCode: 0 });
+  } finally {
+    writeFileSync(release, "release");
+    await cell?.close();
+    if (providerPid > 0) try { process.kill(providerPid, "SIGTERM"); } catch (error) { consumeKnownError(error); }
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("explicit runtime cancel terminates a detached native provider process tree", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-detached-cancel-")), root = path.join(parent, "repo"), pidFile = path.join(parent, "provider-pids.json"), repoId = "runtime-detached-cancel", executablePath = writeProviderExecutable(path.join(parent, "cancel-tree-provider.mjs"), `import fs from "node:fs"; import { spawn } from "node:child_process";\nfs.readFileSync(0, "utf8"); const child = spawn(process.execPath, ["-e", "setInterval(() => undefined, 1000)"], { stdio: "ignore" }); fs.writeFileSync(${JSON.stringify(pidFile)}, JSON.stringify([process.pid, child.pid])); console.log(JSON.stringify({ type: "thread.started", thread_id: "provider-cancel-tree" })); setInterval(() => undefined, 1000);\n`), installation = installationFixture("codex", executablePath), instance = { schemaVersion: 2 as const, instanceId: "codex-cancel-tree", name: "Codex Cancel Tree", kindId: "codex" as const, installationId: installation.installationId, providerId: "openai", models: ["codex-model"], defaultModel: "codex-model", enabled: true, permissionMode: "read-only" as const, codex: {}, authMode: "subscription" as const, authState: "configured" as const, authReadiness: { status: "ready" as const, code: null, hint: null }, isolationState: "enforced" as const }, preparedDefinition: AgentDefinitionSnapshot = { schema: "agent-definition-snapshot/v1", configVersion: 1, instanceId: "codex-cancel-tree", installationId: installation.installationId, kindId: "codex", providerId: "openai", model: "codex-model", reasoningEffort: null, baseUrl: null, authMode: "subscription" };
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined, runtimeSessionId = "", pids: number[] = [];
+  try {
+    initIngressRepo(root, 4310); cell = await openRepoCell({ repoId: workspaceId(repoId), rootDir: canonicalRoot(root), ownerId: "cancel-tree", runtimeInstances: () => [instance], prepareRuntimeLaunch: async (_instanceId, request) => ({ definition: preparedDefinition, installation, executablePath, args: ["exec", "--json", "--model", "codex-model", "-"], env: process.env, cwd: request.cwd, prompt: request.prompt }) });
+    const spawned = await cell.spawnRuntime({ runtimeInstanceId: instance.instanceId, cwd: { scope: "repo-root" }, prompt: "Wait for cancellation", taskId: null, idempotencyKey: "cancel-tree" }, { actor: { principal: { personId: "person-cancel-tree" }, executor: null }, source: "local" }); runtimeSessionId = String(spawned.runtimeSessionId);
+    pids = await eventuallyValue(() => { try { const values = JSON.parse(readFileSync(pidFile, "utf8")) as number[]; return values.length === 2 && values.every((pid) => Number.isInteger(pid) && pid > 0) ? values : null; } catch { return null; } });
+    const hostPid = await eventuallyValue(() => { try { const records = readFileSync(path.join(root, ".harness", "runtime", "dispatches", `${String(spawned.dispatchId)}.jsonl`), "utf8").trim().split(/\r?\n/u).map((line) => JSON.parse(line) as Record<string, unknown>), pid = records.find((record) => record.kind === "process_started")?.pid; return Number.isInteger(pid) && Number(pid) > 0 ? Number(pid) : null; } catch { return null; } }); pids = [hostPid, ...pids];
+    assert.equal((await cell.cancelRuntime({ runtimeSessionId }, { actor: { principal: { personId: "person-cancel-tree" }, executor: null }, source: "local" })).detail, "cancelled");
+    await eventually(() => pids.every((pid) => { try { process.kill(pid, 0); return false; } catch { return true; } }));
+  } finally {
+    if (runtimeSessionId) try { await cell?.cancelRuntime({ runtimeSessionId }, { actor: { principal: { personId: "person-cancel-tree" }, executor: null }, source: "local" }); } catch (error) { consumeKnownError(error); }
+    await cell?.close(); for (const pid of pids) try { process.kill(pid, "SIGTERM"); } catch (error) { consumeKnownError(error); } rmSync(parent, { recursive: true, force: true });
+  }
 });
 
 test("runtime exit notification records a bounded timeout", async () => {

--- a/packages/kernel/src/domain/agent-runtime.ts
+++ b/packages/kernel/src/domain/agent-runtime.ts
@@ -69,7 +69,15 @@ export function reduceRuntimeSession(current: RuntimeSession | null, event: Agen
   const sessionId = runtimeSessionId(event); if (sessionId === null) return current; if (current === null || current.runtimeSessionId !== sessionId) throw new Error(`runtime session ${sessionId} has not started`);
   if (event.type === "runtime_session_provider_bound") { if (current.providerSessionId !== null && current.providerSessionId !== event.payload.providerSessionId) throw new Error(`runtime session ${sessionId} provider binding changed`); return { ...current, providerSessionId: event.payload.providerSessionId, transcriptRef: event.payload.transcriptRef, lastObservedAt: event.occurredAt }; }
   if (event.type === "runtime_session_task_bound") { if (current.providerSessionId !== null && current.providerSessionId !== event.payload.providerSessionId) throw new Error(`runtime session ${sessionId} task binding changed provider session`); const binding = { taskId: event.payload.taskId, executionId: event.payload.executionId, providerSessionId: event.payload.providerSessionId, transcriptRef: event.payload.transcriptRef, boundAt: event.occurredAt }, taskBindings = [...current.taskBindings.filter((value) => value.taskId !== binding.taskId || value.executionId !== binding.executionId), binding]; return { ...current, providerSessionId: binding.providerSessionId, transcriptRef: binding.transcriptRef, taskBindings, lastObservedAt: event.occurredAt }; }
-  if (event.type === "runtime_session_liveness_changed") { if (current.liveness === "exited") throw new Error(`runtime session ${sessionId} already exited`); return { ...current, liveness: event.payload.liveness, lastObservedAt: event.occurredAt }; }
+  if (event.type === "runtime_session_liveness_changed") {
+    if (current.liveness === "exited") throw new Error(`runtime session ${sessionId} already exited`);
+    return {
+      ...current,
+      liveness: event.payload.liveness,
+      attachable: event.payload.liveness === "live" ? true : current.attachable,
+      lastObservedAt: event.occurredAt,
+    };
+  }
   if (event.type === "runtime_session_cancelled") return { ...current, liveness: "exited", attachable: false, outcome: "cancelled", exitCode: null, lastObservedAt: event.occurredAt };
   if (event.type === "runtime_session_exited") return { ...current, liveness: "exited", attachable: false, lastObservedAt: event.occurredAt };
   if (event.type === "runtime_session_outcome_observed") return { ...current, outcome: event.payload.outcome, exitCode: event.payload.exitCode, resultRef: event.payload.resultRef, lastObservedAt: event.occurredAt };

--- a/packages/kernel/test/store/agent-runtime.test.ts
+++ b/packages/kernel/test/store/agent-runtime.test.ts
@@ -82,6 +82,7 @@ test("projection reopen and rebuild project nonterminal sessions unknown before 
     const reopened = makeTaskProjection({ rootDir, eventStore: store });
     assert.deepEqual(runtimeState(reopened, "runtime-session-claude"), { liveness: "unknown", attachable: false }); assert.deepEqual(runtimeState(reopened, "runtime-session-exited"), { liveness: "exited", attachable: false }); assert.equal(store.read().revision, before);
     const rebuilt = reopened.rebuild(); assert.equal(rebuilt.metrics.sqliteTransactions, 2); assert.deepEqual(runtimeState(reopened, "runtime-session-claude"), { liveness: "unknown", attachable: false }); assert.deepEqual(runtimeState(reopened, "runtime-session-exited"), { liveness: "exited", attachable: false }); assert.equal(store.read().revision, before);
+    const adopted = eventFromProviderWitness({ ...witness("heartbeat"), type: "runtime_session_liveness_changed", payload: { runtimeSessionId: "runtime-session-claude", liveness: "live" } }, envelope(4))!; store.append(bundle(adopted)); reopened.apply(adopted); assert.deepEqual(runtimeState(reopened, "runtime-session-claude"), { liveness: "live", attachable: true });
     assert.equal(reopened.read("task-runtime").snapshot.task, null);
   });
 });


### PR DESCRIPTION
Production-Delta: +796/-151

# English

## Summary

Runtime workers no longer die when the daemon restarts. Previously every native runtime worker was a child of the daemon process, and the daemon's close path (`closeRuntimes`) SIGTERM-ed all of them — so any daemon restart (explicit stop, GUI supervisor restart, build refresh) reaped the whole in-flight fleet, and the reaped workers left no death record. This change decouples worker lifetime from daemon lifetime: workers run behind a detached per-runtime host process, the daemon tails a durable event stream, and a restarted daemon re-adopts live workers and settles exits that happened while it was away.

## What Changed

- **Detached per-runtime host** (`runtime-worker-host.ts`, `runtime-spawn-process.ts`): the host — not the daemon — owns provider stdin/stdout/stderr and appends scrubbed provider events, stderr, and the exact exit code/signal to `.harness/runtime/dispatches/<dispatch>.jsonl`. It is a per-worker shim (containerd-shim pattern), not a second daemon: it never relaunches work and dies with its worker.
- **Adoption on startup** (`runtime-spawn-adoption.ts`, `repo-cell-open.ts`): repo-cell/fleet-edge startup scans nonterminal sessions plus dispatch streams, reattaches to a live host PID, and republishes live/attachable state. A provider that exited while the daemon was absent has its recorded output and `process_exit` replayed through the normal settlement path (same session/archive/result/outcome effects). A missing process without a durable exit settles honestly as unknown instead of staying permanently live.
- **`closeRuntimes` now releases only local tailers** — the terminate-everything loop and the daemon-owned pipe listeners are deleted.
- **Explicit cancellation stays lethal**: POSIX targets the detached process group (`kill(-pid)`), Windows keeps the frozen `taskkill /T /F`; the Ubuntu integration test proves host, provider, and provider grandchild all die on explicit cancel.
- `runtime-spawner.ts` sheds its large inline active-runtime block into shared `runtime-spawn-active.ts`; `agent-runtime.ts` reducer restores attachability on re-adoption; `dispatch-read.ts` reports truthful running state during the reopen/adoption window.
- All compressed-style lines flagged by the G36 line-density gate in this diff were restored to normal multi-line formatting (no semantic change).

## Verification

- RED→GREEN: before the change, `process.kill(providerPid, 0)` after `cell.close()` raised ESRCH (old close path killed the provider) — 25/1. After: isolated Ubuntu `runtime-spawn.integration.test.ts` 27/27, including: live provider survives repo-cell close, is re-adopted, keeps streaming, settles `succeeded`/exit 0; a provider that exits with no repo cell open settles after reopen as `liveness=exited`, `outcome=succeeded`; explicit cancel kills the whole tree.
- Conflict-resolution check after rebasing over #1776 (Route B): `fleet-transport.integration.test.ts` "remote-edge runtime launches locally" 3/3 — the merged `fleet-edge-runtime.ts` carries Route B's registered-workspace task context and this PR's session-ID/outcome projection.
- `npm run check:local` fast tier green on `ff461e2f0` (46 steps; contract tests, typecheck, lint, boundaries, G36 line-density, G32 line-budget, write-road checks).
- CEO review: closeRuntimes release-only semantics, adoption identity late-lookup (`context.processes.get()` on every event), and detached spawn/process-group kill verified by direct code inspection; sibling audit found `terminal-host.ts` still owns PTY children (separate terminal workstream, unchanged here).
- Fact F-2F5A1A45 records the integration evidence.

## Residual Risk

- Windows branch not executed locally (keeps the frozen taskkill implementation and passes the 17-site subprocess inventory); GitHub CI is the integration authority.
- The production daemon serves the old dist until its next natural restart; the new no-reap behavior applies from the first restart onto this build.

# 中文

## 摘要

daemon 重启不再收割在飞 worker。此前 worker 是 daemon 子进程,daemon 关门时 `closeRuntimes` 无差别 SIGTERM 全部 worker——任何 daemon 重启都会屠掉全机在飞舰队,且被收割者一条死亡记录都不写。本 PR 把 worker 生命周期从 daemon 解耦:worker 挂在 detached 的逐 worker host 进程后面,daemon 只尾随落盘事件流,重启后 re-adopt 活着的 worker,缺席窗口内的退出按流补结算。

## 变更

- detached 逐 worker host(containerd-shim 同构):host 而非 daemon 持有 provider 管道,把脱敏事件与精确退出码落盘到派工流;不重拉、随 worker 死。
- 启动 adoption:扫描非终态 session+派工流,活 pid 重接续流,缺席退出按正常结算路径重放;无落盘退出的消失进程如实结 unknown,不留永久 live。
- `closeRuntimes` 只释放本地 tailer;显式 cancel 仍杀整个进程组(POSIX `kill(-pid)`,Windows taskkill /T /F,集成测试证明孙进程也死)。
- G36 点名的压缩行全部恢复正常排版(无语义变化)。

## 验证

- RED→GREEN 与 27/27 见英文节;跨 #1776 冲突合成后 remote-edge runtime 3/3;check:local 46 步全绿;fact F-2F5A1A45。

## 复核证据

- CEO 亲验 close 语义、adoption 晚查身份、detached+进程组杀;机制兄弟审计发现 terminal-host 仍屠 PTY 子进程(归 terminal 线,本 PR 不动)。

## 残留风险

- Windows 分支未本地执行(保留冻结 taskkill 实现);生产 daemon 在下次自然重启后才获得不收割行为。
