### PR TITLE
fix(gates): compare overlong content by hunk

### DIFF
--- a/tools/gates/line-density.mjs
+++ b/tools/gates/line-density.mjs
@@ -8,8 +8,8 @@ const STANDARD_PATH = "harness/governance/standards/file-complexity-structural-d
 const REPORT_LIMIT = 20;
 
 /**
- * Parse `git diff -U0` output into the added lines it introduces, keeping each
- * line's destination path and line number so a violation can be pointed at.
+ * Parse `git diff -U0` output into changed hunks, keeping each hunk's
+ * destination path and starting line so a violation can be pointed at.
  */
 export function parseHunks(diffText) {
   const hunks = [];
@@ -45,25 +45,35 @@ export function parseHunks(diffText) {
   return hunks;
 }
 
+function measureOverlongCorpus(lines, limit) {
+  let characters = 0, maximum = 0;
+  for (const text of lines) {
+    if (text.length <= limit) continue;
+    characters += text.length;
+    maximum = Math.max(maximum, text.length);
+  }
+  return { characters, maximum };
+}
+
 export function findViolations(diffText, limit = MAX_LINE_LENGTH) {
   const violations = [];
 
   for (const hunk of parseHunks(diffText)) {
     if (!isProductionPath(hunk.filePath)) continue;
-    for (const [index, text] of hunk.added.entries()) {
-      if (text.length <= limit) continue;
-      // A modified line is paired positionally with the line it replaced. Editing an
-      // already-long line is allowed as long as it does not grow: the corpus can only
-      // shrink, and nobody is forced to refactor a line they did not write.
-      const replaced = hunk.removed[index];
-      if (replaced !== undefined && text.length <= replaced.length) continue;
-      violations.push({
-        filePath: hunk.filePath,
-        lineNumber: hunk.startLine + index,
-        length: text.length,
-        previousLength: replaced === undefined ? null : replaced.length
-      });
-    }
+    const added = measureOverlongCorpus(hunk.added, limit);
+    const removed = measureOverlongCorpus(hunk.removed, limit);
+    // Compare the overlong corpus within the whole hunk. Formatting can split one
+    // compressed source line into many lines without positionally pairing them, but
+    // neither the corpus size nor its longest line may grow.
+    if (added.characters <= removed.characters && added.maximum <= removed.maximum) continue;
+    violations.push({
+      filePath: hunk.filePath,
+      lineNumber: hunk.startLine,
+      addedLongCharacters: added.characters,
+      removedLongCharacters: removed.characters,
+      addedMaxLineLength: added.maximum,
+      removedMaxLineLength: removed.maximum
+    });
   }
 
   return violations;
@@ -71,24 +81,24 @@ export function findViolations(diffText, limit = MAX_LINE_LENGTH) {
 
 export function explain(violations, limit = MAX_LINE_LENGTH) {
   const shown = violations.slice(0, REPORT_LIMIT);
-  const found = shown.map((v) => v.previousLength === null
-    ? `  ${v.filePath}:${v.lineNumber}  new line, ${v.length} characters`
-    : `  ${v.filePath}:${v.lineNumber}  grew ${v.previousLength} -> ${v.length} characters`);
+  const found = shown.map((v) => `  ${v.filePath}:${v.lineNumber}  overlong characters ${v.removedLongCharacters} -> ${v.addedLongCharacters}; longest line ${v.removedMaxLineLength} -> ${v.addedMaxLineLength}`);
   if (violations.length > shown.length) {
     found.push(`  ... and ${violations.length - shown.length} more (${violations.length} total)`);
   }
 
   return [
     "=".repeat(78),
-    `G36 line-density FAILED — ${violations.length} added production line(s) over ${limit} characters`,
+    `G36 line-density FAILED — ${violations.length} production hunk(s) increased overlong content`,
     "=".repeat(78),
     "",
     "WHAT FAILED",
     ...found,
     "",
     "THE RULE",
-    `  A production line you create, or make longer, must be at most ${limit} characters.`,
-    "  Editing an existing long line is fine as long as you do not make it longer.",
+    `  In each production diff hunk, added lines longer than ${limit} characters may`,
+    "  increase neither their total characters nor their longest line. Total means the",
+    `  complete line length: a ${limit + 1}-character line contributes ${limit + 1}, not 1.`,
+    `  An all-new hunk starts from zero, so every added line must be at most ${limit} characters.`,
     "  You are never asked to refactor a line you did not write.",
     "",
     "IF YOU DID NOT COMPRESS ANYTHING, YOU ARE PROBABLY STILL RIGHT",
@@ -98,7 +108,7 @@ export function explain(violations, limit = MAX_LINE_LENGTH) {
     "  this repository, not a mistake you made, and this gate does not ask you to fix",
     "  it. Restoring the existing compressed code is its own tracked work (PLT-LineHonesty,",
     "  task_7fc88830d00f0b8157a498a85c); doing it opportunistically inside an unrelated",
-    "  change will collide with it. Your obligation is bounded to the lines listed above.",
+    "  change will collide with it. Your obligation is bounded to the hunks listed above.",
     "",
     "WHY THIS GATE EXISTS — read this before you try to satisfy it",
     "  G32 (line-budget) enforces a per-module ceiling on production lines. It counts",
@@ -156,7 +166,7 @@ export function explain(violations, limit = MAX_LINE_LENGTH) {
     "WHAT NOT TO DO",
     "  Do not lower the threshold, add an ignore entry, or skip this gate. Do not move",
     "  code into a non-production path to get it out of scope. Do not reformat unrelated",
-    "  lines to buy budget — this gate is a ratchet precisely so that never helps.",
+    "  lines in the same hunk to offset new overlong content; that is not a legitimate fix.",
     "",
     "AUTHORITY",
     "  dec_12BE7EB602461E84F6F0BA019B — establishes this gate (standing policy)",

--- a/tools/gates/test/line-density.test.mjs
+++ b/tools/gates/test/line-density.test.mjs
@@ -25,40 +25,76 @@ test("hunks carry their destination path and start line", () => {
   assert.deepEqual(parsed[0].added, ["one", "two"]);
 });
 
-test("a newly created long line is rejected and reported as new", () => {
+test("a purely added overlong line is rejected", () => {
   const violations = findViolations(hunk("packages/kernel/src/a.ts", 5, { added: [LONG] }));
   assert.deepEqual(violations, [{
     filePath: "packages/kernel/src/a.ts",
     lineNumber: 5,
-    length: LONG.length,
-    previousLength: null
+    addedLongCharacters: LONG.length,
+    removedLongCharacters: 0,
+    addedMaxLineLength: LONG.length,
+    removedMaxLineLength: 0
   }]);
-  assert.match(explain(violations), /new line, \d+ characters/u);
+  assert.match(explain(violations), /overlong characters 0 -> 121; longest line 0 -> 121/u);
 });
 
 test("a line exactly at the limit passes", () => {
   assert.deepEqual(findViolations(hunk("packages/kernel/src/a.ts", 5, { added: ["x".repeat(MAX_LINE_LENGTH)] })), []);
 });
 
-test("editing an existing long line without growing it is allowed", () => {
-  assert.deepEqual(findViolations(hunk("packages/kernel/src/a.ts", 5, { added: [LONG], removed: [LONG] })), []);
+test("a one-to-one edit that shortens an overlong line is allowed", () => {
   assert.deepEqual(findViolations(hunk("packages/kernel/src/a.ts", 5, { added: [LONG], removed: [LONGER] })), []);
 });
 
-test("growing an already-long line is rejected and names both lengths", () => {
+test("a one-to-one edit that lengthens an overlong line is rejected", () => {
   const violations = findViolations(hunk("packages/kernel/src/a.ts", 5, { added: [LONGER], removed: [LONG] }));
   assert.deepEqual(violations, [{
     filePath: "packages/kernel/src/a.ts",
     lineNumber: 5,
-    length: LONGER.length,
-    previousLength: LONG.length
+    addedLongCharacters: LONGER.length,
+    removedLongCharacters: LONG.length,
+    addedMaxLineLength: LONGER.length,
+    removedMaxLineLength: LONG.length
   }]);
-  assert.match(explain(violations), /grew \d+ -> \d+ characters/u);
 });
 
-test("an added line beyond the replaced ones is new, not a pairing", () => {
-  const violations = findViolations(hunk("packages/kernel/src/a.ts", 5, { added: [LONG, LONG], removed: [LONG] }));
-  assert.deepEqual(violations.map((v) => [v.lineNumber, v.previousLength]), [[6, null]]);
+test("a one-to-many restoration with less overlong content is allowed", () => {
+  assert.deepEqual(findViolations(hunk("packages/kernel/src/a.ts", 5, {
+    added: ["x".repeat(200), LONG],
+    removed: ["x".repeat(400)]
+  })), []);
+});
+
+test("a one-to-many change with more overlong content is rejected", () => {
+  const violations = findViolations(hunk("packages/kernel/src/a.ts", 5, {
+    added: [LONG, LONG],
+    removed: ["x".repeat(200)]
+  }));
+  assert.equal(violations.length, 1);
+  assert.deepEqual(violations[0], {
+    filePath: "packages/kernel/src/a.ts",
+    lineNumber: 5,
+    addedLongCharacters: LONG.length * 2,
+    removedLongCharacters: 200,
+    addedMaxLineLength: LONG.length,
+    removedMaxLineLength: 200
+  });
+});
+
+test("a many-to-one compression is rejected when the longest line grows even as the total shrinks", () => {
+  const violations = findViolations(hunk("packages/kernel/src/a.ts", 5, {
+    added: ["x".repeat(1200)],
+    removed: Array.from({ length: 10 }, () => "x".repeat(130))
+  }));
+  assert.equal(violations.length, 1);
+  assert.deepEqual(violations[0], {
+    filePath: "packages/kernel/src/a.ts",
+    lineNumber: 5,
+    addedLongCharacters: 1200,
+    removedLongCharacters: 1300,
+    addedMaxLineLength: 1200,
+    removedMaxLineLength: 130
+  });
 });
 
 test("non-production paths are out of scope", () => {
@@ -71,11 +107,19 @@ test("a pure deletion contributes no violations", () => {
 });
 
 test("the rejection carries the whole specification, not just a pointer", () => {
-  const message = explain([{ filePath: "packages/kernel/src/a.ts", lineNumber: 5, length: 400, previousLength: null }]);
+  const message = explain([{
+    filePath: "packages/kernel/src/a.ts",
+    lineNumber: 5,
+    addedLongCharacters: 400,
+    removedLongCharacters: 0,
+    addedMaxLineLength: 400,
+    removedMaxLineLength: 0
+  }]);
 
   // what failed, and the rule
   assert.match(message, /packages\/kernel\/src\/a\.ts:5/u);
   assert.match(message, /must be at most 120 characters/u);
+  assert.match(message, /complete line length: a 121-character line contributes 121, not 1/u);
   assert.match(message, /never asked to refactor a line you did not write/u);
 
   // the mechanism it closes, with the measurement that proves the pressure is real
@@ -101,7 +145,7 @@ test("the rejection carries the whole specification, not just a pointer", () => 
   assert.match(message, /writing new code in the style of the code already around it/u);
   assert.match(message, /not a mistake you made/u);
   assert.match(message, /task_7fc88830d00f0b8157a498a85c/u);
-  assert.match(message, /obligation is bounded to the lines listed above/u);
+  assert.match(message, /obligation is bounded to the hunks listed above/u);
 
   // preempt the reflex the gate is most likely to provoke
   assert.match(message, /ceiling and design limit was doubled/u);
@@ -117,10 +161,12 @@ test("a truncated report still states the true total", () => {
   const many = Array.from({ length: 25 }, (unused, index) => ({
     filePath: "packages/kernel/src/a.ts",
     lineNumber: index + 1,
-    length: 400,
-    previousLength: null
+    addedLongCharacters: 400,
+    removedLongCharacters: 0,
+    addedMaxLineLength: 400,
+    removedMaxLineLength: 0
   }));
   const message = explain(many);
-  assert.match(message, /25 added production line\(s\) over 120 characters/u);
+  assert.match(message, /25 production hunk\(s\) increased overlong content/u);
   assert.match(message, /and 5 more \(25 total\)/u);
 });


### PR DESCRIPTION
# English

## Summary

G36 line-density decides "is this a line you wrote?" by pairing each added line with the removed line at the same index inside its hunk. Index is a position, and position is not conserved under refactoring. When one compressed source line is restored into forty physical lines, every added line past the first pairs with nothing, so an **unchanged** long string literal that merely moved onto its own line is reported as a newly written overlong line.

The gate then blocks exactly the improvement it exists to encourage.

This PR replaces the positional proxy with the invariant the gate's own comment already states — "the corpus can only shrink, and nobody is forced to refactor a line they did not write" — measured across the whole hunk.

This is not a policy change. `dec_12BE7EB602461E84F6F0BA019B` already decided the policy; only the implementation lagged behind it.

## What Changed

- `tools/gates/line-density.mjs`: a hunk is rejected only when the added side's overlong corpus grows. Two numbers per hunk: the total characters of all lines over 120, and the longest such line. Both must not exceed the removed side's. The per-index `hunk.removed[index]` pairing is gone.
- `tools/gates/test/line-density.test.mjs`: six shapes — 1:1 edit shorter (pass), 1:1 edit longer (reject), 1:N restoration with a smaller corpus (pass), 1:N with a larger corpus (reject), a purely new overlong line (reject), and **N:1 compression whose total falls while its longest line grows** (reject).

The sixth shape is why the `max` constraint exists. Total characters alone would accept deleting ten 130-character lines and adding one 1200-character line — a ten-into-one compression, which is the precise behaviour this gate was built to stop.

## Machine-Readable Declarations

Production-Delta: +0/-0

## Task And Scope

- Harness task: task_08bb100a297b368759e5ea2995
- Branch: codex/g36-multiline-pairing
- Public scope: the G36 line-density decision rule and its tests.
- Private planning/evidence updated: yes
- Out of scope: the 120-character threshold, `isProductionPath` coverage, every other gate, and any per-file or per-path exemption. None were touched.

## Version Impact

- Version: no version change because this changes a repository gate, not a published package surface.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/gates/line-density.mjs` and its test fixture — the G36 gate decision rule.
- Authority: dec_12BE7EB602461E84F6F0BA019B (CH1 derives task_08bb100a297b368759e5ea2995)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 18c2aa4643281e37bb18da45034ccb9a4c0be890
- Branch merge-base with `origin/main`: 18c2aa4643281e37bb18da45034ccb9a4c0be890
- Last `git fetch origin` time: 2026-08-24T04:36Z
- Sync method: rebase
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: `harness/tasks/task_08bb100a297b368759e5ea2995-g36/`
- Reviewer evidence path: same task package, `artifacts/`
- GitHub Actions `rewrite-ci` run URL: pending — this PR opens the run.
- [x] `npm run check` (via `npm run check:local`: Node v24.16.0, 46 steps, fast 319/319, contract 574/574, 135.0s)
- [x] `npm run typecheck` (covered by `check:local`)
- [x] `git diff --check`
- Not run: full `npm test` matrix, integration and GUI tiers — this is a tools-only change that neither tier exercises; GitHub CI runs them on this PR.

**Evidence that matters more than the green gate:**

- The real 19-file W2-A daemon restoration diff: the old rule reported 9 violations, the new rule passes. That diff is the reason this task exists.
- Negative control for the sixth shape: total overlong characters fall 1300 → 1200 while the longest line grows 130 → 1200. Rejected, as it must be.
- Targeted gate tests: 12/12.

## Review Evidence

- Self-review: the load-bearing check is the sixth shape, not the first five. Anything that merely relaxes the rule would pass the restoration cases; only a case that must still be rejected proves the gate kept its teeth.
- Reviewer subagent: not run.
- Human review: pending.
- Blocking findings: none.

## Residual Risk

- Hunk-level aggregation does not track corpus identity. Inside one hunk, shortening an existing 1500-character line while compressing something else into a new 1400-character line lowers both the total and the maximum, so it would pass. This requires the same hunk to both improve and degrade, and the net movement of both metrics is still downward, so the ratchet still only turns one way — but the statement "no compression can hide here" would be false, and it is not being claimed.
- Compression that lands at or under 120 characters is outside this gate by design; that is the threshold, not a hole introduced here.

## References

- Task: task_08bb100a297b368759e5ea2995
- Decision: dec_12BE7EB602461E84F6F0BA019B
- Evidence: `harness/tasks/task_08bb100a297b368759e5ea2995-g36/artifacts/final-report.md`

---

# 中文

## 概要

G36 line-density 判断「这行是不是你写的」,用的是**在同一个 hunk 内按下标把加行配到删行**。下标是位置,而**位置在重构下不守恒**。一条压缩源码行被还原成四十条物理行时,第一条之后的每条加行都配不到任何删行,于是一条**一个字节都没改过**、只是被搬到自己行上的长字符串字面量,被判成新写的超长行。

**于是这道门拦住了它本来要鼓励的那个改进。**

本 PR 把位置代理换成门自己注释里早就写着的那个不变量——「语料只能单调变好,而没有任何人被索要他没写过的那行的重构」——并在整个 hunk 的尺度上度量它。

这不是政策变更。`dec_12BE7EB602461E84F6F0BA019B` 已经裁定了政策,只是实现没跟上。

## 改动内容

- `tools/gates/line-density.mjs`:只有当新增侧的超长语料**增长**时才拒绝该 hunk。每个 hunk 取两个数:全部超过 120 字符的行的字符总数,以及其中最长的那条。两个都不得超过删除侧。按下标的 `hunk.removed[index]` 配对被删除。
- `tools/gates/test/line-density.test.mjs`:六种形状——一对一改短(放行)、一对一改长(拦)、一对多还原且语料变小(放行)、一对多但语料变大(拦)、纯新增超长行(拦),以及**多对一压缩、总量下降但最长行变长**(拦)。

第六种形状就是那条最长行约束存在的理由。只看字符总数的话,「删掉十条 130 字符的行、加进一条 1200 字符的行」会被放行——那是把十行压成一行,正是这道门当初为之而立的行为。

## 机读声明

机读声明只在英文块出现一次,见上方 `Production-Delta`。生产行改动为零,因为 `tools/` 不在 `isProductionPath` 的覆盖面内。

## 任务与范围

- Harness 任务:task_08bb100a297b368759e5ea2995
- 分支:codex/g36-multiline-pairing
- 公开范围:G36 line-density 的判定规则及其测试。
- 私有规划/证据已更新:是
- 不在范围内:120 字符阈值、`isProductionPath` 覆盖面、其余任何门,以及任何按文件或按路径的豁免。全部未触碰。

## 版本影响

- 版本:不变,因为这改的是仓库的门,不是已发布的包面。
- 发布影响:不发布

## 治理声明

- 触碰受保护面:是
- 受保护面范围:`tools/gates/line-density.mjs` 及其测试 fixture,即 G36 的判定规则。
- 授权:dec_12BE7EB602461E84F6F0BA019B(CH1 derives task_08bb100a297b368759e5ea2995)
- 机器检查边界:本 PR 只断言声明存在;声明是否属实与充分由评审者判定。
- Break-glass:否

## 验证

- 基线 `origin/main` SHA:18c2aa4643281e37bb18da45034ccb9a4c0be890
- 与 `origin/main` 的 merge-base:18c2aa4643281e37bb18da45034ccb9a4c0be890
- 最近 `git fetch origin` 时间:2026-08-24T04:36Z
- 同步方式:rebase
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据路径:`harness/tasks/task_08bb100a297b368759e5ea2995-g36/`
- 评审者证据路径:同一任务包的 `artifacts/`
- GitHub Actions `rewrite-ci` run URL:待定,本 PR 开启该次运行。

已跑:`npm run check:local`,Node v24.16.0,46 步全过,fast 319/319、contract 574/574,135.0 秒;`git diff --check`。

未跑:完整 `npm test` 矩阵、integration 与 GUI tier。理由:本次是纯 tools 改动,那两个 tier 不会命中它;GitHub CI 在本 PR 上会跑。

**比绿灯更重要的证据:**

- 真实的 W2-A 19 文件 daemon 还原 diff:旧规则报 9 条违规,新规则通过。那个 diff 正是本任务存在的原因。
- 第六种形状的阴性对照:超长字符总量从 1300 降到 1200,而最长行从 130 涨到 1200。**被拒**,应当如此。
- 定向门测试:12/12。

## 评审证据

- 自评:承重的检查是第六种形状,不是前五种。任何单纯放宽规则的改动都能让还原用例通过;只有一个**必须仍被拒绝**的用例,才能证明这道门还有牙。
- 评审子代理:未跑。
- 人工评审:待定。
- 阻塞性发现:无。

## 残余风险

- hunk 级聚合不追踪语料身份。在同一个 hunk 内,把一条既有的 1500 字符行拆短、同时在别处新压出一条 1400 字符行,总量和最长行都下降,因此会被放行。这要求同一个 hunk 既改善又劣化,而且两个指标的净移动仍然向下,所以棘轮仍然只朝一个方向转——但「压缩不可能藏在这里」这句话是假的,本 PR 没有作此声称。
- 压缩后落在 120 字符以内的情况按设计不在本门范围内;那是阈值本身,不是本次引入的洞。

## 参考

- 任务:task_08bb100a297b368759e5ea2995
- 裁决:dec_12BE7EB602461E84F6F0BA019B
- 证据:`harness/tasks/task_08bb100a297b368759e5ea2995-g36/artifacts/final-report.md`
