### PR TITLE
fix(daemon): index live task dispatches instead of scanning all history

### DIFF
--- a/packages/daemon/src/dispatch-read.ts
+++ b/packages/daemon/src/dispatch-read.ts
@@ -1,6 +1,13 @@
 import { consumeKnownError, type RuntimeSession, type TaskProjection } from "../../kernel/src/index.ts";
-import { readDispatchLiveIndex, readDispatchStream, removeDispatchLiveIndexEntries, type DispatchStreamHeader } from "./dispatch-stream.ts";
+import {
+  readDispatchLiveIndex,
+  readDispatchStream,
+  removeDispatchLiveIndexEntries,
+  type DispatchStreamHeader,
+} from "./dispatch-stream.ts";
 import type { DaemonTaskDispatchesPayload, DaemonTaskDispatchesResult, TaskDispatchRow } from "./protocol/daemon-protocol.contract.ts";
+
+type DispatchLiveIndexRow = ReturnType<typeof readDispatchLiveIndex>["entries"][number];
 
 type DispatchCandidate = {
   readonly session: RuntimeSession | undefined;
@@ -18,17 +25,21 @@ export function readTaskDispatches(input: { readonly rootDir: string; readonly p
     if (!event) continue;
     addCandidate(candidates, event.payload.dispatchId, session, task.taskId, task.packagePath, false);
   }
-  const staleIndexEntries = new Map<string, ReturnType<typeof readDispatchLiveIndex>["entries"][number]>(), indexedEntries = new Map<string, ReturnType<typeof readDispatchLiveIndex>["entries"][number]>();
+  const staleIndexEntries = new Map<string, DispatchLiveIndexRow>();
+  const indexedEntries = new Map<string, DispatchLiveIndexRow>();
   for (const entry of readDispatchLiveIndex(input.rootDir, batch.rows.map((row) => row.taskId)).entries) {
     const task = tasks.get(entry.taskId); if (!task) continue;
     indexedEntries.set(entry.dispatchId, entry);
-    addCandidate(candidates, entry.dispatchId, sessions.get(entry.runtimeSessionId), entry.taskId, task.packagePath, true);
+    const session = sessions.get(entry.runtimeSessionId);
+    addCandidate(candidates, entry.dispatchId, session, entry.taskId, task.packagePath, true);
     if (sessions.has(entry.runtimeSessionId)) staleIndexEntries.set(entry.dispatchId, entry);
   }
   const rows = new Map<string, TaskDispatchRow>();
   for (const [dispatchId, candidate] of candidates) {
     for (const target of candidate.taskPackages) {
-      const read = input.projection.readDocument(`${target.packagePath}/artifacts/dispatches/${dispatchId}.json`), archive = read.document ? parseArchive(read.document.body) : null;
+      const documentPath = `${target.packagePath}/artifacts/dispatches/${dispatchId}.json`;
+      const read = input.projection.readDocument(documentPath);
+      const archive = read.document ? parseArchive(read.document.body) : null;
       if (archive?.taskId !== target.taskId) continue;
       rows.set(dispatchId, archiveRow(archive, candidate.session));
       if (candidate.indexed) staleIndexEntries.set(dispatchId, indexedEntries.get(dispatchId)!);
@@ -40,7 +51,8 @@ export function readTaskDispatches(input: { readonly rootDir: string; readonly p
       if (candidate.indexed) staleIndexEntries.set(dispatchId, indexedEntries.get(dispatchId)!);
       continue;
     }
-    rows.set(dispatchId, liveRow(stream.header, stream.providerSessionId, candidate.session, stream.process?.exited === false));
+    const live = stream.process?.exited === false;
+    rows.set(dispatchId, liveRow(stream.header, stream.providerSessionId, candidate.session, live));
   }
   removeDispatchLiveIndexEntries(input.rootDir, [...staleIndexEntries.values()]);
   const dispatches = [...rows.values()].sort((left, right) => left.startedAt.localeCompare(right.startedAt));
@@ -49,11 +61,22 @@ export function readTaskDispatches(input: { readonly rootDir: string; readonly p
     : { ok: true, status: batch.status, taskId: singleTaskId, dispatches, watermark: batch.watermark, sourceRevision: batch.sourceRevision };
 }
 
-function addCandidate(candidates: Map<string, DispatchCandidate>, dispatchId: string, session: RuntimeSession | undefined, taskId: string, packagePath: string | null, indexed: boolean): void {
-  const known = candidates.get(dispatchId), taskPackages = packagePath === null ? [] : [{ taskId, packagePath }], merged = [...(known?.taskPackages ?? []), ...taskPackages];
+function addCandidate(
+  candidates: Map<string, DispatchCandidate>,
+  dispatchId: string,
+  session: RuntimeSession | undefined,
+  taskId: string,
+  packagePath: string | null,
+  indexed: boolean,
+): void {
+  const known = candidates.get(dispatchId);
+  const taskPackages = packagePath === null ? [] : [{ taskId, packagePath }];
+  const merged = [...(known?.taskPackages ?? []), ...taskPackages];
   candidates.set(dispatchId, {
     session: known?.session ?? session,
-    taskPackages: merged.filter((value, index) => merged.findIndex((candidate) => candidate.taskId === value.taskId && candidate.packagePath === value.packagePath) === index),
+    taskPackages: merged.filter((value, index) => merged.findIndex(
+      (candidate) => candidate.taskId === value.taskId && candidate.packagePath === value.packagePath,
+    ) === index),
     indexed: known?.indexed === true || indexed,
   });
 }

--- a/packages/daemon/src/dispatch-read.ts
+++ b/packages/daemon/src/dispatch-read.ts
@@ -1,31 +1,61 @@
-import { existsSync, readdirSync, statSync } from "node:fs";
-import path from "node:path";
-import { consumeKnownError, resolveHarnessLayout, type RuntimeSession, type TaskProjection } from "../../kernel/src/index.ts";
-import { readDispatchStream, type DispatchStreamHeader } from "./dispatch-stream.ts";
+import { consumeKnownError, type RuntimeSession, type TaskProjection } from "../../kernel/src/index.ts";
+import { readDispatchLiveIndex, readDispatchStream, removeDispatchLiveIndexEntries, type DispatchStreamHeader } from "./dispatch-stream.ts";
 import type { DaemonTaskDispatchesPayload, DaemonTaskDispatchesResult, TaskDispatchRow } from "./protocol/daemon-protocol.contract.ts";
 
+type DispatchCandidate = {
+  readonly session: RuntimeSession | undefined;
+  readonly taskPackages: readonly { readonly taskId: string; readonly packagePath: string }[];
+  readonly indexed: boolean;
+};
+
 export function readTaskDispatches(input: { readonly rootDir: string; readonly projection: TaskProjection } & DaemonTaskDispatchesPayload): DaemonTaskDispatchesResult {
-  const singleTaskId = input.taskId, query = singleTaskId === undefined ? { taskIds: input.taskIds, ...(input.limit === undefined ? {} : { limit: input.limit }), ...(input.cursor === undefined ? {} : { cursor: input.cursor }) } : { taskIds: [singleTaskId] }, batch = input.projection.readTaskRuntimeBatch(query), tasks = new Map(batch.rows.map((row) => [row.taskId, row])), packageTasks = new Map(batch.rows.flatMap((row) => row.packagePath ? [[row.packagePath, row.taskId] as const] : []));
+  const singleTaskId = input.taskId, query = singleTaskId === undefined ? { taskIds: input.taskIds, ...(input.limit === undefined ? {} : { limit: input.limit }), ...(input.cursor === undefined ? {} : { cursor: input.cursor }) } : { taskIds: [singleTaskId] }, batch = input.projection.readTaskRuntimeBatch(query), tasks = new Map(batch.rows.map((row) => [row.taskId, row]));
   if (singleTaskId !== undefined && !batch.rows[0]?.packagePath) throw new Error(`Task ${singleTaskId} has no projected package path.`);
   const sessions = new Map(batch.rows.flatMap((task) => task.sessions.map((session) => [session.runtimeSessionId, session] as const)));
+  const candidates = new Map<string, DispatchCandidate>();
+  for (const task of batch.rows) for (const session of task.sessions) {
+    const event = input.projection.readRuntimeDispatch(session.runtimeSessionId, session.definitionSnapshotRef);
+    if (!event) continue;
+    addCandidate(candidates, event.payload.dispatchId, session, task.taskId, task.packagePath, false);
+  }
+  const staleIndexEntries = new Map<string, ReturnType<typeof readDispatchLiveIndex>["entries"][number]>(), indexedEntries = new Map<string, ReturnType<typeof readDispatchLiveIndex>["entries"][number]>();
+  for (const entry of readDispatchLiveIndex(input.rootDir, batch.rows.map((row) => row.taskId)).entries) {
+    const task = tasks.get(entry.taskId); if (!task) continue;
+    indexedEntries.set(entry.dispatchId, entry);
+    addCandidate(candidates, entry.dispatchId, sessions.get(entry.runtimeSessionId), entry.taskId, task.packagePath, true);
+    if (sessions.has(entry.runtimeSessionId)) staleIndexEntries.set(entry.dispatchId, entry);
+  }
   const rows = new Map<string, TaskDispatchRow>();
-  for (const document of input.projection.readReplicaBasis(null).documents) {
-    const target = String(document.path), marker = "/artifacts/dispatches/"; if (!target.endsWith(".json") || !target.includes(marker)) continue;
-    const taskId = packageTasks.get(target.slice(0, target.indexOf(marker))); if (!taskId) continue;
-    const read = input.projection.readDocument(target), archive = read.document ? parseArchive(read.document.body) : null; if (archive?.taskId === taskId) rows.set(String(archive.dispatchId), archiveRow(archive, sessions.get(String(archive.runtimeSessionId))));
-  }
-  const streamRoot = path.join(resolveHarnessLayout(input.rootDir).localRoot, "runtime", "dispatches");
-  if (existsSync(streamRoot) && statSync(streamRoot).isDirectory()) for (const name of readdirSync(streamRoot).filter((value) => /^dispatch_[a-f0-9]{24}\.jsonl$/u.test(value))) {
-    const dispatchId = name.slice(0, -6), stream = readDispatchStream(input.rootDir, dispatchId); if (!stream?.header?.taskId || !tasks.has(stream.header.taskId)) continue;
-    const current = sessions.get(stream.header.runtimeSessionId);
-    if (!rows.has(dispatchId)) {
-      rows.set(dispatchId, liveRow(stream.header, stream.providerSessionId, current, stream.process?.exited === false));
+  for (const [dispatchId, candidate] of candidates) {
+    for (const target of candidate.taskPackages) {
+      const read = input.projection.readDocument(`${target.packagePath}/artifacts/dispatches/${dispatchId}.json`), archive = read.document ? parseArchive(read.document.body) : null;
+      if (archive?.taskId !== target.taskId) continue;
+      rows.set(dispatchId, archiveRow(archive, candidate.session));
+      if (candidate.indexed) staleIndexEntries.set(dispatchId, indexedEntries.get(dispatchId)!);
+      break;
     }
+    if (rows.has(dispatchId) || !/^dispatch_[a-f0-9]{24}$/u.test(dispatchId)) continue;
+    const stream = readDispatchStream(input.rootDir, dispatchId);
+    if (!stream?.header.taskId || !tasks.has(stream.header.taskId)) {
+      if (candidate.indexed) staleIndexEntries.set(dispatchId, indexedEntries.get(dispatchId)!);
+      continue;
+    }
+    rows.set(dispatchId, liveRow(stream.header, stream.providerSessionId, candidate.session, stream.process?.exited === false));
   }
+  removeDispatchLiveIndexEntries(input.rootDir, [...staleIndexEntries.values()]);
   const dispatches = [...rows.values()].sort((left, right) => left.startedAt.localeCompare(right.startedAt));
   return singleTaskId === undefined
     ? { ok: true, status: batch.status, taskIds: batch.taskIds, unavailableTaskIds: batch.taskIds.filter((taskId) => !tasks.get(taskId)?.packagePath), dispatches, page: batch.page, watermark: batch.watermark, sourceRevision: batch.sourceRevision }
     : { ok: true, status: batch.status, taskId: singleTaskId, dispatches, watermark: batch.watermark, sourceRevision: batch.sourceRevision };
+}
+
+function addCandidate(candidates: Map<string, DispatchCandidate>, dispatchId: string, session: RuntimeSession | undefined, taskId: string, packagePath: string | null, indexed: boolean): void {
+  const known = candidates.get(dispatchId), taskPackages = packagePath === null ? [] : [{ taskId, packagePath }], merged = [...(known?.taskPackages ?? []), ...taskPackages];
+  candidates.set(dispatchId, {
+    session: known?.session ?? session,
+    taskPackages: merged.filter((value, index) => merged.findIndex((candidate) => candidate.taskId === value.taskId && candidate.packagePath === value.packagePath) === index),
+    indexed: known?.indexed === true || indexed,
+  });
 }
 
 function archiveRow(value: Record<string, unknown>, session: RuntimeSession | undefined): TaskDispatchRow { return { dispatchId: String(value.dispatchId), taskId: String(value.taskId), executionId: String(value.executionId), runtimeSessionId: String(value.runtimeSessionId), instanceId: String(value.instanceId), ...(typeof value.agentId === "string" ? { agentId: value.agentId, agentName: typeof value.agentName === "string" ? value.agentName : value.agentId } : {}), ...(typeof value.delegatedByAgentId === "string" ? { delegatedByAgentId: value.delegatedByAgentId, delegatedByAgentName: typeof value.delegatedByAgentName === "string" ? value.delegatedByAgentName : value.delegatedByAgentId, squadId: String(value.squadId) } : {}), providerSessionId: typeof value.providerSessionId === "string" ? value.providerSessionId : session?.providerSessionId ?? null, eventStreamRef: typeof value.eventStreamRef === "string" ? value.eventStreamRef : null, startedAt: String(value.startedAt), endedAt: typeof value.endedAt === "string" ? value.endedAt : null, outcome: isOutcome(value.outcome) ? value.outcome : session?.outcome ?? "unknown", status: isOutcome(value.outcome) ? value.outcome : session?.outcome ?? "unknown" }; }

--- a/packages/daemon/src/dispatch-stream.ts
+++ b/packages/daemon/src/dispatch-stream.ts
@@ -9,6 +9,7 @@ import {
   readdirSync,
   readFileSync,
   statSync,
+  renameSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -22,6 +23,7 @@ import {
 import type { RuntimePermissionMode } from "./runtime-permissions.ts";
 
 const streamSchema = "runtime-dispatch-stream/v1" as const;
+const liveIndexSchema = "runtime-dispatch-live-index/v1" as const;
 const forbiddenKey = /(?:token|credential|password|secret|authorization|executablepath|api[-_ ]?key|private[-_ ]?key|cookie)/iu;
 const bearer = /\bBearer\s+[^\s,;]+/giu;
 const knownToken = /\b(?:sk|rk|ghp|github_pat|xox[baprs])[-_A-Za-z0-9]{8,}\b/giu;
@@ -70,10 +72,35 @@ export interface DispatchStreamWriter {
   readonly appendExitNotification: (value: { readonly phase: "started" | "finished"; readonly started: boolean; readonly exitCode: number | null; readonly timedOut: boolean; readonly errorCode?: string }, occurredAt: string) => void;
 }
 
+export interface DispatchLiveIndexEntry {
+  readonly dispatchId: string;
+  readonly taskId: string;
+  readonly runtimeSessionId: string;
+}
+
+export interface DispatchLiveIndex {
+  readonly schema: typeof liveIndexSchema;
+  readonly entries: readonly DispatchLiveIndexEntry[];
+}
+
 export function openDispatchStream(rootDir: string, header: Omit<DispatchStreamHeader, "schema" | "kind" | "eventStreamRef">): DispatchStreamWriter {
   const ref = dispatchStreamRef(rootDir, header.dispatchId), target = dispatchStreamPath(rootDir, header.dispatchId);
   mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
-  if (!existsSync(target)) writeFileSync(target, `${JSON.stringify({ schema: streamSchema, kind: "dispatch", ...header, eventStreamRef: ref })}\n`, { encoding: "utf8", mode: 0o600 });
+  if (!existsSync(target)) {
+    writeFileSync(target, `${JSON.stringify({ schema: streamSchema, kind: "dispatch", ...header, eventStreamRef: ref })}\n`, { encoding: "utf8", mode: 0o600 });
+    if (header.taskId) {
+      try {
+        upsertDispatchLiveIndex(rootDir, {
+          dispatchId: header.dispatchId,
+          taskId: header.taskId,
+          runtimeSessionId: header.runtimeSessionId,
+        });
+      } catch (error) {
+        unlinkSync(target);
+        throw error;
+      }
+    }
+  }
   return { ref, appendProviderEvent: (value, occurredAt) => appendJsonl(target, { schema: streamSchema, kind: "provider_event", occurredAt, event: scrubProviderValue(value) }), appendProviderBinding: (providerSessionId, occurredAt) => appendJsonl(target, { schema: streamSchema, kind: "provider_binding", occurredAt, providerSessionId }), appendExitNotification: (value, occurredAt) => appendJsonl(target, { schema: streamSchema, kind: "exit_notification", occurredAt, ...value }) };
 }
 
@@ -83,8 +110,65 @@ export function reopenDispatchStream(rootDir: string, header: DispatchStreamHead
 }
 
 export function removeDispatchStream(rootDir: string, dispatchId: string): void {
-  const target = dispatchStreamPath(rootDir, dispatchId);
+  const target = dispatchStreamPath(rootDir, dispatchId), header = readDispatchStreamHeader(rootDir, dispatchId);
   if (existsSync(target)) unlinkSync(target);
+  if (header?.taskId) removeDispatchLiveIndexEntries(rootDir, [{ dispatchId, taskId: header.taskId, runtimeSessionId: header.runtimeSessionId }]);
+}
+
+export function readDispatchLiveIndex(rootDir: string, taskIds: readonly string[]): DispatchLiveIndex {
+  const entries: DispatchLiveIndexEntry[] = [], missing: string[] = [];
+  for (const taskId of new Set(taskIds)) {
+    const stored = readStoredDispatchLiveIndex(dispatchLiveIndexPath(rootDir, taskId), taskId);
+    if (stored) entries.push(...stored.entries); else missing.push(taskId);
+  }
+  if (missing.length > 0) entries.push(...rebuildDispatchLiveIndex(rootDir, missing).entries);
+  return dispatchLiveIndex(entries);
+}
+
+export function rebuildDispatchLiveIndex(rootDir: string, taskIds: readonly string[]): DispatchLiveIndex {
+  const root = dispatchStreamRoot(rootDir), selected = new Set(taskIds), entries = new Map<string, DispatchLiveIndexEntry>();
+  if (existsSync(root) && statSync(root).isDirectory()) {
+    for (const name of readdirSync(root).filter((value) => /^dispatch_[a-f0-9]{24}\.jsonl$/u.test(value))) {
+      const header = readDispatchStreamHeader(rootDir, name.slice(0, -6));
+      if (!header?.taskId || !selected.has(header.taskId)) continue;
+      entries.set(header.dispatchId, {
+        dispatchId: header.dispatchId,
+        taskId: header.taskId,
+        runtimeSessionId: header.runtimeSessionId,
+      });
+    }
+  }
+  const rebuilt = dispatchLiveIndex([...entries.values()]);
+  for (const taskId of selected) writeDispatchLiveIndex(rootDir, taskId, dispatchLiveIndex(rebuilt.entries.filter((entry) => entry.taskId === taskId)));
+  return rebuilt;
+}
+
+export function removeDispatchLiveIndexEntries(rootDir: string, removals: readonly DispatchLiveIndexEntry[]): void {
+  const byTask = new Map<string, Set<string>>();
+  for (const removal of removals) byTask.set(removal.taskId, (byTask.get(removal.taskId) ?? new Set()).add(removal.dispatchId));
+  for (const [taskId, dispatchIds] of byTask) {
+    const stored = readStoredDispatchLiveIndex(dispatchLiveIndexPath(rootDir, taskId), taskId);
+    if (!stored) continue;
+    const entries = stored.entries.filter((entry) => !dispatchIds.has(entry.dispatchId));
+    if (entries.length !== stored.entries.length) writeDispatchLiveIndex(rootDir, taskId, dispatchLiveIndex(entries));
+  }
+}
+
+export function readDispatchStreamHeader(rootDir: string, dispatchId: string): DispatchStreamHeader | null {
+  const target = dispatchStreamPath(rootDir, dispatchId);
+  if (!existsSync(target) || !statSync(target).isFile()) return null;
+  const descriptor = openSync(target, fsConstants.O_RDONLY), chunks: Buffer[] = [];
+  try {
+    while (true) {
+      const chunk = Buffer.alloc(4096), read = readSync(descriptor, chunk, 0, chunk.length, null);
+      if (read === 0) break;
+      const newline = chunk.subarray(0, read).indexOf(10);
+      chunks.push(chunk.subarray(0, newline === -1 ? read : newline));
+      if (newline !== -1) break;
+    }
+  } finally { closeSync(descriptor); }
+  const first = parseRecord(Buffer.concat(chunks).toString("utf8").replace(/\r$/u, ""));
+  return isHeader(first) && first.dispatchId === dispatchId ? first : null;
 }
 
 export function readDispatchStream(
@@ -122,7 +206,7 @@ export function readDispatchStream(
 }
 
 export function readDispatchStreams(rootDir: string): readonly NonNullable<ReturnType<typeof readDispatchStream>>[] {
-  const root = path.join(resolveHarnessLayout(rootDir).localRoot, "runtime", "dispatches");
+  const root = dispatchStreamRoot(rootDir);
   if (!existsSync(root) || !statSync(root).isDirectory()) return [];
   return readdirSync(root)
     .filter((name) => /^dispatch_[a-f0-9]{24}\.jsonl$/u.test(name))
@@ -166,7 +250,36 @@ export function scrubProviderValue(value: unknown): unknown {
 
 export function dispatchStreamPath(rootDir: string, dispatchId: string): string {
   if (!/^dispatch_[a-f0-9]{24}$/u.test(dispatchId)) throw new Error("dispatch id is invalid");
-  return path.join(resolveHarnessLayout(rootDir).localRoot, "runtime", "dispatches", `${dispatchId}.jsonl`);
+  return path.join(dispatchStreamRoot(rootDir), `${dispatchId}.jsonl`);
+}
+export function dispatchLiveIndexPath(rootDir: string, taskId: string): string { return path.join(dispatchStreamRoot(rootDir), "live-index", `task-${Buffer.from(taskId).toString("base64url")}.json`); }
+function dispatchStreamRoot(rootDir: string): string { return path.join(resolveHarnessLayout(rootDir).localRoot, "runtime", "dispatches"); }
+function dispatchLiveIndex(entries: readonly DispatchLiveIndexEntry[]): DispatchLiveIndex { return { schema: liveIndexSchema, entries: [...entries].sort((left, right) => left.dispatchId.localeCompare(right.dispatchId)) }; }
+function upsertDispatchLiveIndex(rootDir: string, entry: DispatchLiveIndexEntry): void {
+  const current = readDispatchLiveIndex(rootDir, [entry.taskId]), entries = new Map(current.entries.map((value) => [value.dispatchId, value]));
+  entries.set(entry.dispatchId, entry);
+  writeDispatchLiveIndex(rootDir, entry.taskId, dispatchLiveIndex([...entries.values()]));
+}
+function writeDispatchLiveIndex(rootDir: string, taskId: string, index: DispatchLiveIndex): void {
+  const target = dispatchLiveIndexPath(rootDir, taskId), temporary = `${target}.${process.pid}.tmp`;
+  mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
+  try {
+    writeFileSync(temporary, `${JSON.stringify(index, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+    renameSync(temporary, target);
+  } finally { if (existsSync(temporary)) unlinkSync(temporary); }
+}
+function readStoredDispatchLiveIndex(target: string, taskId: string): DispatchLiveIndex | null {
+  if (!existsSync(target) || !statSync(target).isFile()) return null;
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(target, "utf8"));
+    if (!isDispatchIndexRecord(parsed) || parsed.schema !== liveIndexSchema || !Array.isArray(parsed.entries)) return null;
+    const entries: DispatchLiveIndexEntry[] = [];
+    for (const value of parsed.entries) {
+      if (!isDispatchIndexRecord(value) || !/^dispatch_[a-f0-9]{24}$/u.test(String(value.dispatchId)) || value.taskId !== taskId || typeof value.runtimeSessionId !== "string") return null;
+      entries.push({ dispatchId: String(value.dispatchId), taskId: value.taskId, runtimeSessionId: value.runtimeSessionId });
+    }
+    return dispatchLiveIndex(entries);
+  } catch (error) { consumeKnownError(error); return null; }
 }
 function appendJsonl(target: string, value: unknown): void {
   const descriptor = openSync(target, fsConstants.O_APPEND | fsConstants.O_WRONLY);
@@ -177,4 +290,5 @@ function appendJsonl(target: string, value: unknown): void {
   }
 }
 function parseRecord(value: string | undefined): Record<string, unknown> | null { if (!value) return null; try { const parsed: unknown = JSON.parse(value); return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : null; } catch (error) { consumeKnownError(error); return null; } }
+function isDispatchIndexRecord(value: unknown): value is Record<string, unknown> { return value !== null && typeof value === "object" && !Array.isArray(value); }
 function isHeader(value: Record<string, unknown> | null): value is Record<string, unknown> & DispatchStreamHeader { return value?.schema === streamSchema && value.kind === "dispatch" && typeof value.dispatchId === "string" && (value.taskId === null || typeof value.taskId === "string") && (value.executionId === null || typeof value.executionId === "string") && typeof value.runtimeSessionId === "string" && typeof value.instanceId === "string" && typeof value.startedAt === "string" && typeof value.eventStreamRef === "string"; }

--- a/packages/daemon/src/dispatch-stream.ts
+++ b/packages/daemon/src/dispatch-stream.ts
@@ -87,7 +87,8 @@ export function openDispatchStream(rootDir: string, header: Omit<DispatchStreamH
   const ref = dispatchStreamRef(rootDir, header.dispatchId), target = dispatchStreamPath(rootDir, header.dispatchId);
   mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
   if (!existsSync(target)) {
-    writeFileSync(target, `${JSON.stringify({ schema: streamSchema, kind: "dispatch", ...header, eventStreamRef: ref })}\n`, { encoding: "utf8", mode: 0o600 });
+    const record = { schema: streamSchema, kind: "dispatch", ...header, eventStreamRef: ref };
+    writeFileSync(target, `${JSON.stringify(record)}\n`, { encoding: "utf8", mode: 0o600 });
     if (header.taskId) {
       try {
         upsertDispatchLiveIndex(rootDir, {
@@ -112,7 +113,9 @@ export function reopenDispatchStream(rootDir: string, header: DispatchStreamHead
 export function removeDispatchStream(rootDir: string, dispatchId: string): void {
   const target = dispatchStreamPath(rootDir, dispatchId), header = readDispatchStreamHeader(rootDir, dispatchId);
   if (existsSync(target)) unlinkSync(target);
-  if (header?.taskId) removeDispatchLiveIndexEntries(rootDir, [{ dispatchId, taskId: header.taskId, runtimeSessionId: header.runtimeSessionId }]);
+  if (!header?.taskId) return;
+  const { taskId, runtimeSessionId } = header;
+  removeDispatchLiveIndexEntries(rootDir, [{ dispatchId, taskId, runtimeSessionId }]);
 }
 
 export function readDispatchLiveIndex(rootDir: string, taskIds: readonly string[]): DispatchLiveIndex {
@@ -126,7 +129,8 @@ export function readDispatchLiveIndex(rootDir: string, taskIds: readonly string[
 }
 
 export function rebuildDispatchLiveIndex(rootDir: string, taskIds: readonly string[]): DispatchLiveIndex {
-  const root = dispatchStreamRoot(rootDir), selected = new Set(taskIds), entries = new Map<string, DispatchLiveIndexEntry>();
+  const root = dispatchStreamRoot(rootDir), selected = new Set(taskIds);
+  const entries = new Map<string, DispatchLiveIndexEntry>();
   if (existsSync(root) && statSync(root).isDirectory()) {
     for (const name of readdirSync(root).filter((value) => /^dispatch_[a-f0-9]{24}\.jsonl$/u.test(value))) {
       const header = readDispatchStreamHeader(rootDir, name.slice(0, -6));
@@ -139,13 +143,18 @@ export function rebuildDispatchLiveIndex(rootDir: string, taskIds: readonly stri
     }
   }
   const rebuilt = dispatchLiveIndex([...entries.values()]);
-  for (const taskId of selected) writeDispatchLiveIndex(rootDir, taskId, dispatchLiveIndex(rebuilt.entries.filter((entry) => entry.taskId === taskId)));
+  for (const taskId of selected) {
+    const owned = rebuilt.entries.filter((entry) => entry.taskId === taskId);
+    writeDispatchLiveIndex(rootDir, taskId, dispatchLiveIndex(owned));
+  }
   return rebuilt;
 }
 
 export function removeDispatchLiveIndexEntries(rootDir: string, removals: readonly DispatchLiveIndexEntry[]): void {
   const byTask = new Map<string, Set<string>>();
-  for (const removal of removals) byTask.set(removal.taskId, (byTask.get(removal.taskId) ?? new Set()).add(removal.dispatchId));
+  for (const removal of removals) {
+    byTask.set(removal.taskId, (byTask.get(removal.taskId) ?? new Set()).add(removal.dispatchId));
+  }
   for (const [taskId, dispatchIds] of byTask) {
     const stored = readStoredDispatchLiveIndex(dispatchLiveIndexPath(rootDir, taskId), taskId);
     if (!stored) continue;
@@ -252,11 +261,20 @@ export function dispatchStreamPath(rootDir: string, dispatchId: string): string 
   if (!/^dispatch_[a-f0-9]{24}$/u.test(dispatchId)) throw new Error("dispatch id is invalid");
   return path.join(dispatchStreamRoot(rootDir), `${dispatchId}.jsonl`);
 }
-export function dispatchLiveIndexPath(rootDir: string, taskId: string): string { return path.join(dispatchStreamRoot(rootDir), "live-index", `task-${Buffer.from(taskId).toString("base64url")}.json`); }
-function dispatchStreamRoot(rootDir: string): string { return path.join(resolveHarnessLayout(rootDir).localRoot, "runtime", "dispatches"); }
-function dispatchLiveIndex(entries: readonly DispatchLiveIndexEntry[]): DispatchLiveIndex { return { schema: liveIndexSchema, entries: [...entries].sort((left, right) => left.dispatchId.localeCompare(right.dispatchId)) }; }
+export function dispatchLiveIndexPath(rootDir: string, taskId: string): string {
+  const shard = `task-${Buffer.from(taskId).toString("base64url")}.json`;
+  return path.join(dispatchStreamRoot(rootDir), "live-index", shard);
+}
+function dispatchStreamRoot(rootDir: string): string {
+  return path.join(resolveHarnessLayout(rootDir).localRoot, "runtime", "dispatches");
+}
+function dispatchLiveIndex(entries: readonly DispatchLiveIndexEntry[]): DispatchLiveIndex {
+  const sorted = [...entries].sort((left, right) => left.dispatchId.localeCompare(right.dispatchId));
+  return { schema: liveIndexSchema, entries: sorted };
+}
 function upsertDispatchLiveIndex(rootDir: string, entry: DispatchLiveIndexEntry): void {
-  const current = readDispatchLiveIndex(rootDir, [entry.taskId]), entries = new Map(current.entries.map((value) => [value.dispatchId, value]));
+  const current = readDispatchLiveIndex(rootDir, [entry.taskId]);
+  const entries = new Map(current.entries.map((value) => [value.dispatchId, value]));
   entries.set(entry.dispatchId, entry);
   writeDispatchLiveIndex(rootDir, entry.taskId, dispatchLiveIndex([...entries.values()]));
 }
@@ -272,11 +290,15 @@ function readStoredDispatchLiveIndex(target: string, taskId: string): DispatchLi
   if (!existsSync(target) || !statSync(target).isFile()) return null;
   try {
     const parsed: unknown = JSON.parse(readFileSync(target, "utf8"));
-    if (!isDispatchIndexRecord(parsed) || parsed.schema !== liveIndexSchema || !Array.isArray(parsed.entries)) return null;
+    if (!isDispatchIndexRecord(parsed) || parsed.schema !== liveIndexSchema) return null;
+    if (!Array.isArray(parsed.entries)) return null;
     const entries: DispatchLiveIndexEntry[] = [];
     for (const value of parsed.entries) {
-      if (!isDispatchIndexRecord(value) || !/^dispatch_[a-f0-9]{24}$/u.test(String(value.dispatchId)) || value.taskId !== taskId || typeof value.runtimeSessionId !== "string") return null;
-      entries.push({ dispatchId: String(value.dispatchId), taskId: value.taskId, runtimeSessionId: value.runtimeSessionId });
+      if (!isDispatchIndexRecord(value) || value.taskId !== taskId) return null;
+      const dispatchId = String(value.dispatchId), runtimeSessionId = value.runtimeSessionId;
+      if (!/^dispatch_[a-f0-9]{24}$/u.test(dispatchId)) return null;
+      if (typeof runtimeSessionId !== "string") return null;
+      entries.push({ dispatchId, taskId: value.taskId, runtimeSessionId });
     }
     return dispatchLiveIndex(entries);
   } catch (error) { consumeKnownError(error); return null; }
@@ -290,5 +312,7 @@ function appendJsonl(target: string, value: unknown): void {
   }
 }
 function parseRecord(value: string | undefined): Record<string, unknown> | null { if (!value) return null; try { const parsed: unknown = JSON.parse(value); return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : null; } catch (error) { consumeKnownError(error); return null; } }
-function isDispatchIndexRecord(value: unknown): value is Record<string, unknown> { return value !== null && typeof value === "object" && !Array.isArray(value); }
+function isDispatchIndexRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
 function isHeader(value: Record<string, unknown> | null): value is Record<string, unknown> & DispatchStreamHeader { return value?.schema === streamSchema && value.kind === "dispatch" && typeof value.dispatchId === "string" && (value.taskId === null || typeof value.taskId === "string") && (value.executionId === null || typeof value.executionId === "string") && typeof value.runtimeSessionId === "string" && typeof value.instanceId === "string" && typeof value.startedAt === "string" && typeof value.eventStreamRef === "string"; }

--- a/packages/daemon/test/dispatch-read.test.ts
+++ b/packages/daemon/test/dispatch-read.test.ts
@@ -1,10 +1,11 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { resolveHarnessLayout, type RuntimeSession, type TaskProjection } from "../../kernel/src/index.ts";
+import { type RuntimeSession, type TaskProjection } from "../../kernel/src/index.ts";
+import { appendRuntimeWorkerRecord, openDispatchStream, readDispatchLiveIndex } from "../src/dispatch-stream.ts";
 import { readTaskDispatches } from "../src/dispatch-read.ts";
 
 const dispatchId = "dispatch_a1b2c3d4e5f60718293a4b5c", runtimeSessionId = "runtime-1", taskId = "task-1";
@@ -14,15 +15,13 @@ function session(liveness: RuntimeSession["liveness"], outcome: RuntimeSession["
 }
 
 function projectionFor(current: RuntimeSession): TaskProjection {
-  return { readTaskRuntimeBatch: () => ({ status: "ready", taskIds: [taskId], rows: [{ taskId, packagePath: "tasks/task-1", sessions: [current] }], watermark: 1, sourceRevision: 1 }), readReplicaBasis: () => ({ documents: [] }), readDocument: () => ({ document: null }) } as unknown as TaskProjection;
+  return { readTaskRuntimeBatch: () => ({ status: "ready", taskIds: [taskId], rows: [{ taskId, packagePath: "tasks/task-1", sessions: [current] }], watermark: 1, sourceRevision: 1 }), readRuntimeDispatch: () => ({ payload: { dispatchId } }), readReplicaBasis: () => { throw new Error("dispatch reads must not enumerate the replica document basis"); }, readDocument: () => ({ document: null }) } as unknown as TaskProjection;
 }
 
 function statusFor(current: RuntimeSession): string {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-read-"));
   try {
-    const streamRoot = path.join(resolveHarnessLayout(rootDir).localRoot, "runtime", "dispatches");
-    mkdirSync(streamRoot, { recursive: true });
-    writeFileSync(path.join(streamRoot, `${dispatchId}.jsonl`), `${JSON.stringify({ schema: "runtime-dispatch-stream/v1", kind: "dispatch", dispatchId, taskId, executionId: "execution-1", runtimeSessionId, instanceId: "instance-1", startedAt: "2026-08-23T00:00:00.000Z", eventStreamRef: `artifact:dispatch-stream/${dispatchId}` })}\n`, "utf8");
+    openDispatchStream(rootDir, { dispatchId, taskId, executionId: "execution-1", runtimeSessionId, instanceId: "instance-1", startedAt: "2026-08-23T00:00:00.000Z" });
     const result = readTaskDispatches({ rootDir, projection: projectionFor(current), taskId });
     const row = result.dispatches.find((candidate) => candidate.dispatchId === dispatchId);
     assert.ok(row, "dispatch row missing");
@@ -46,4 +45,26 @@ test("a dispatch whose session is live still reports running", () => {
 test("an observed outcome outranks liveness", () => {
   assert.equal(statusFor(session("exited", "succeeded")), "succeeded");
   assert.equal(statusFor(session("live", "cancelled")), "cancelled");
+});
+
+test("an unbound detached dispatch is read from the live index", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-read-unbound-"));
+  try {
+    openDispatchStream(rootDir, { dispatchId, taskId, executionId: "execution-1", runtimeSessionId, instanceId: "instance-1", startedAt: "2026-08-23T00:00:00.000Z" });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_started", pid: 12345 });
+    const projection = { readTaskRuntimeBatch: () => ({ status: "ready", taskIds: [taskId], rows: [{ taskId, packagePath: "tasks/task-1", sessions: [] }], watermark: 1, sourceRevision: 1 }), readReplicaBasis: () => { throw new Error("dispatch reads must not enumerate the replica document basis"); }, readDocument: () => ({ document: null }) } as unknown as TaskProjection;
+    const result = readTaskDispatches({ rootDir, projection, taskId });
+    assert.equal(result.dispatches.find((row) => row.dispatchId === dispatchId)?.status, "running");
+    assert.equal(readDispatchLiveIndex(rootDir, [taskId]).entries.length, 1, "unbound dispatch must remain indexed");
+  } finally { rmSync(rootDir, { recursive: true, force: true }); }
+});
+
+test("a projected task binding removes the live index entry", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-read-bound-"));
+  try {
+    openDispatchStream(rootDir, { dispatchId, taskId, executionId: "execution-1", runtimeSessionId, instanceId: "instance-1", startedAt: "2026-08-23T00:00:00.000Z" });
+    const result = readTaskDispatches({ rootDir, projection: projectionFor(session("live", null)), taskId });
+    assert.equal(result.dispatches.find((row) => row.dispatchId === dispatchId)?.status, "running");
+    assert.deepEqual(readDispatchLiveIndex(rootDir, [taskId]).entries, []);
+  } finally { rmSync(rootDir, { recursive: true, force: true }); }
 });

--- a/packages/daemon/test/dispatch-stream.test.ts
+++ b/packages/daemon/test/dispatch-stream.test.ts
@@ -1,0 +1,27 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  appendRuntimeWorkerRecord,
+  dispatchLiveIndexPath,
+  openDispatchStream,
+  readDispatchLiveIndex,
+} from "../src/dispatch-stream.ts";
+
+test("the live index rebuilds exactly from dispatch stream headers", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-live-index-"));
+  try {
+    for (const suffix of ["111111111111111111111111", "222222222222222222222222"] as const) {
+      const dispatchId = `dispatch_${suffix}`;
+      openDispatchStream(rootDir, { dispatchId, taskId: "task-1", executionId: "execution-1", runtimeSessionId: `runtime_${suffix}`, instanceId: "instance-1", startedAt: "2026-08-24T00:00:00.000Z" });
+      appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "provider_event", event: { text: "tail records are not needed to rebuild the header index" } });
+    }
+    const before = readDispatchLiveIndex(rootDir, ["task-1"]);
+    rmSync(dispatchLiveIndexPath(rootDir, "task-1"));
+    const rebuilt = readDispatchLiveIndex(rootDir, ["task-1"]);
+    assert.deepEqual(rebuilt, before);
+  } finally { rmSync(rootDir, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
# English

## Summary

Reading a task's dispatches used to enumerate every dispatch stream on disk and every replica-basis document, so the cost grew with total local history rather than with the task being asked about. PR #1782 attempted to fix that by deriving candidates from the task's already-projected sessions, but that changed what the read enumerates over: a detached dispatch has a stream file before the projection binds it to a task, so its row simply did not exist during the startup window. That regression was carved back out of #1782 before merge; this PR is the correct fix.

Each task now owns a small local sidecar file mapping its task id to the dispatch ids and runtime session ids currently in flight. The sidecar is written synchronously when a dispatch stream is created, before the runtime process launches, so the live row is visible from the first read. Once the projection binds a session, the reader drops that entry, and the steady-state read touches only the requested task's shard. A missing or malformed shard is rebuilt deterministically from stream headers alone.

The sidecar is a derived cache, not a second source of truth: it stores only identifiers already present in the stream header, and both previous production enumerations are deleted in this same commit.

## What Changed

- `packages/daemon/src/dispatch-stream.ts`: added the per-task live index — creation writes the entry inside `openDispatchStream` (rolling back the stream file if the index write throws), reads are point lookups by task id, deletion removes bound entries, and a rebuild path reconstructs a shard by reading only the first line of each stream file. Added `readDispatchStreamHeader`, which reads a single header line instead of parsing a whole stream.
- `packages/daemon/src/dispatch-read.ts`: replaced both full enumerations. The `readReplicaBasis(null).documents` scan over every replica document is gone; the directory-wide `readDispatchStream` scan over every stream file is gone. Candidates now come from the task's projected sessions plus its live-index shard, and each candidate's archive document is fetched by direct path instead of by scanning.
- A second commit breaks the new statements onto separate lines. The `line-density` gate rejects added production lines over 120 characters, and the worker's first pass wrote 21 of them in the file's existing single-line style. Splitting them required one small extraction (a `DispatchLiveIndexRow` type alias for a repeated `ReturnType<...>` expression) and one destructuring of an already-narrowed header; everything else is pure line breaking.
- Tests: `dispatch-read.test.ts` gains cases for an unbound detached dispatch being read from the live index and for a projected binding evicting that entry; `dispatch-stream.test.ts` asserts that deleting a shard and rebuilding it reproduces the pre-delete value exactly.

## Machine-Readable Declarations

Production-Delta: +211/-20

## Task And Scope

- Harness task: task_6a1dc045241dd24f68789a0fae
- Branch: codex/dispatch-live-index
- Public scope: `packages/daemon/src/dispatch-read.ts`, `packages/daemon/src/dispatch-stream.ts`, and their two test files.
- Private planning/evidence updated: yes
- Out of scope: no runtime event contract change (no `taskId` was added to `runtime_dispatch_requested`), no CLI command, no wire method, no GUI file, no CI or gate surface.

## Version Impact

- Version: no version change because this is an internal daemon read path with no published surface.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 18c2aa4643281e37bb18da45034ccb9a4c0be890
- Branch merge-base with `origin/main`: 18c2aa4643281e37bb18da45034ccb9a4c0be890
- Last `git fetch origin` time: 2026-08-24, immediately before opening this PR.
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: the implementation report in the harness task package, not part of this public diff.
- Reviewer evidence path: same task package.
- GitHub Actions `rewrite-ci` run URL: see the checks on this PR.
- [x] `npm run check:local` (fast tier, green in 103.5s) — re-run by the reviewer after the line-splitting commit, not taken from the worker's report. The worker's report claimed all 46 steps were green; that claim did not hold, because both cloud CI and the same local command failed `line-density` with 21 violations. The gate reads the committed tree, so the fix had to be committed before it could be re-measured.
- [x] `npm run typecheck` and the six targeted daemon tests, re-run after the line-splitting commit.
- [x] The affected integration test was run through the repository's isolated dispatcher against Ubuntu, green.
- Not run: full GitHub CI, the GUI job, the remaining integration shards, Windows, and soak lanes were not run locally; cloud CI on this PR is the authority for those.

## Review Evidence

- Self-review: a positive control reproduced the exact production failure before the fix — restoring the reverted #1782 implementation made the isolated acceptance test fail with `actual: undefined` against `expected: 'running'`, confirming the symptom is an absent row rather than a mis-computed status. The mutation was fully reverted before implementing.
- Reviewer subagent: not used.
- Human review: pending.
- Blocking findings: none open.

## Residual Risk

- Cache-miss recovery still enumerates stream filenames, but it reads only each file's first line and is exceptional rather than steady-state.
- Eviction happens on the first task-dispatch read after the projection binds the session, not at the earlier provider-binding marker. A task that is never queried after binding keeps its stale entry until its next query, which then prunes it.
- Measured on a disposable 290-stream, 434 MiB fixture: the hot read went from 508.850 ms to 1.766 ms, and an exceptional cold rebuild measured 31.166 ms. These are local fixture measurements, not a production daemon measurement.

## References

- Task: task_6a1dc045241dd24f68789a0fae
- Evidence: implementation report in the task package
- Review: CEO checkpoint ruling in the same task package

---

# 中文

## 概要

读取某个任务的派工记录，过去要把磁盘上所有派工流文件、以及所有 replica-basis 文档全部枚举一遍，所以耗时随本机历史总量增长，而不是随被查询的那个任务增长。#1782 曾试图改成「从任务已投影的会话派生候选集」，但那改变了这次读取所枚举的对象：一个 detached 派工在被投影绑定到任务之前就已经有流文件了，于是在启动窗口内它那一行根本不存在。该回归在合并前已从 #1782 中切出，本 PR 是正确的修法。

现在每个任务拥有一个小的本地边车文件，把任务 id 映射到当前在飞的派工 id 与运行时会话 id。边车在派工流创建时同步写入，早于运行时进程启动，因此活动行从第一次读取就可见。一旦投影绑定了会话，读取方就删掉该条目，稳态读取只碰被请求任务自己的分片。分片缺失或损坏时，仅凭流文件头即可确定性重建。

边车是派生缓存，不是第二个真源：它只存流文件头里已有的标识符，而且此前两条生产枚举路径都在同一个提交里删除了。

## 改动内容

- `packages/daemon/src/dispatch-stream.ts`：新增按任务分片的活动索引。创建时在 `openDispatchStream` 内写入条目（索引写入抛错则回滚已写的流文件）；读取是按任务 id 的点查；绑定后删除条目；重建路径只读每个流文件的第一行来重构分片。新增 `readDispatchStreamHeader`，只读一行文件头，不再解析整条流。
- `packages/daemon/src/dispatch-read.ts`：替换掉两条全量枚举。遍历全部 replica 文档的 `readReplicaBasis(null).documents` 扫描已删除；遍历全部流文件的目录级 `readDispatchStream` 扫描已删除。候选集现在来自任务已投影的会话加上它自己的活动索引分片，每个候选的归档文档按确定路径直接取，不再靠扫描。
- 第二个提交把新写的语句拆成多行。`line-density` 门拒绝超过 120 字符的新增生产行，而 worker 第一版按该文件既有的单行风格写了 21 条这样的行。拆分过程中做了一次小提取（把重复的 `ReturnType<...>` 表达式提成 `DispatchLiveIndexRow` 类型别名）和一次对已收窄 header 的解构；其余全是纯换行。
- 测试：`dispatch-read.test.ts` 增加了「未绑定的 detached 派工从活动索引读出」和「投影绑定后该条目被驱逐」两个用例；`dispatch-stream.test.ts` 断言删除分片后重建的结果与删除前逐字段相等。

## 任务与范围

- Harness 任务：task_6a1dc045241dd24f68789a0fae
- 分支：codex/dispatch-live-index
- 公开范围：`packages/daemon/src/dispatch-read.ts`、`packages/daemon/src/dispatch-stream.ts` 及其两个测试文件。
- 私有计划 / 证据是否已更新：yes
- 范围外：不改运行时事件契约（没有往 `runtime_dispatch_requested` 里加 `taskId`）、不改 CLI 命令、不改 wire 方法、不动 GUI 文件、不动 CI 与 gate 面。

## 版本影响

- 版本：不改版本，原因是这是 daemon 内部读路径，没有对外发布面。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：不适用
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no

## 验证

- `origin/main` 基准 SHA：18c2aa4643281e37bb18da45034ccb9a4c0be890
- 当前分支与 `origin/main` 的 merge-base：18c2aa4643281e37bb18da45034ccb9a4c0be890
- 最近一次 `git fetch origin` 时间：2026-08-24，开 PR 前刚取。
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...HEAD`
- 私有证据 commit/path：任务包内的实现报告，不在本公开 diff 内。
- Reviewer 证据路径：同一任务包。
- GitHub Actions `rewrite-ci` run URL：见本 PR 的 checks。
- [x] `npm run check:local`（fast tier，103.5 秒全绿）——这是复核方在拆行提交之后自己重跑的，不是取自 worker 的报告。worker 报告声称 46 步全绿；该断言不成立，云端 CI 与本地同一条命令都在 `line-density` 上报了 21 处违规。该门读的是已提交的树，所以必须先提交才能重新测量。
- [x] `npm run typecheck` 与六个定向 daemon 测试，均在拆行提交后重跑。
- [x] 受影响的集成测试已通过仓库的隔离派测器在 Ubuntu 上跑过，绿。
- 未运行：完整 GitHub CI、GUI job、其余 integration shard、Windows 与 soak lane 本地都没跑；这些以本 PR 的云端 CI 为权威。

## 审查证据

- 自查：修复前先做了阳性对照——把 #1782 中被回退的那版实现临时装回去，隔离验收测试当场失败，`actual: undefined` 对 `expected: 'running'`，证实症状是「行不存在」而不是「状态算错了」。该变异在实现前已完全回退。
- Reviewer subagent：未使用。
- 人工审查：待进行。
- 阻塞发现：无。

## 残余风险

- 缓存未命中时仍需枚举流文件名，但只读每个文件的第一行，且属于例外路径而非稳态路径。
- 驱逐发生在「投影绑定会话之后的第一次派工读取」，而不是更早的 provider 绑定标记处。一个绑定后再也没被查询过的任务会一直保留陈旧条目，直到下次查询时被清掉。
- 在一次性构造的 290 个流文件、434 MiB 的夹具上实测：热读从 508.850 ms 降到 1.766 ms，例外的冷重建实测 31.166 ms。这些是本地夹具读数，不是生产 daemon 的读数。

## 关联材料

- 任务：task_6a1dc045241dd24f68789a0fae
- 证据：任务包内实现报告
- 审查：同一任务包内的 CEO checkpoint 裁决书
