### PR TITLE
fix(tools): restrict isolated test sync to a fail-closed allowlist

### DIFF
--- a/tools/dispatch-isolated-test.mjs
+++ b/tools/dispatch-isolated-test.mjs
@@ -1,13 +1,28 @@
 #!/usr/bin/env node
 
 import { randomUUID } from "node:crypto";
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
+import { lstatSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { dispatchIsolatedTestCommand, parseToolOptions, renderToolHelp, toolOption, toolValue } from "./tool-command-contract.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-const sourceExcludes = [".git", "node_modules", ".harness", "coverage", "dist", "out"];
+export const sourceRootAllowlist = Object.freeze([
+  ".github",
+  ".gitignore",
+  ".mergify.yml",
+  "README.md",
+  "docs-release",
+  "eslint.config.mjs",
+  "package-lock.json",
+  "package.json",
+  "packages",
+  "scripts",
+  "skills",
+  "tools",
+  "tsconfig.json"
+]);
 
 export function parseDispatchArgs(argv) {
   const parsed = parseToolOptions(dispatchIsolatedTestCommand, argv);
@@ -20,12 +35,24 @@ export function testRunnerArgs(options) {
   return ["node", "tools/run-node-tests.mjs", ...(options.tier === undefined ? ["--file", options.file] : ["--tier", options.tier])];
 }
 
-export function sourceArchiveArgs(platform = process.platform) {
+export function sourceArchiveArgs(platform = process.platform, sourceRoot = repoRoot) {
   return [
     ...(platform === "darwin" ? ["--no-xattrs"] : []),
-    ...sourceExcludes.map((entry) => `--exclude=${entry}`),
-    "-cf", "-", "-C", repoRoot, "."
+    "-cf", "-", "-C", sourceRoot,
+    "--null", "-T", "-"
   ];
+}
+
+export function sourceRsyncArgs(sourceRoot, destination) {
+  return ["-a", "--delete", "--from0", "--files-from=-", `${sourceRoot}/`, destination];
+}
+
+export function sourceFileList(sourceRoot = repoRoot, allowedRoots = sourceRootAllowlist, candidates = gitWorktreeFiles(sourceRoot)) {
+  const allowed = new Set(allowedRoots);
+  return candidates
+    .filter((entry) => entry !== "" && !path.isAbsolute(entry) && entry.split("/")[0] !== ".." && allowed.has(entry.split("/")[0]))
+    .filter((entry) => pathExists(path.join(sourceRoot, entry)))
+    .sort();
 }
 
 export function posixTestScript(workspaceRoot, stateRoot, options) {
@@ -82,11 +109,12 @@ export async function main(argv = process.argv.slice(2)) {
 async function runUbuntu(options, runId) {
   const workspaceRoot = `/tmp/${runId}`;
   const stateRoot = `${workspaceRoot}/.test-isolation-state`;
+  const files = sourceFileList();
   let exitCode = 1;
   try {
     console.log(`[test-isolation] sync=rsync destination=ubuntu:${workspaceRoot}`);
     if (await run("ssh", ["ubuntu", `mkdir -p -- ${shellQuote(workspaceRoot)}`]) === 0
-      && await run("rsync", ["-a", "--delete", ...sourceExcludes.map((entry) => `--exclude=${entry}`), `${repoRoot}/`, `ubuntu:${workspaceRoot}/`]) === 0) {
+      && await runWithInput("rsync", sourceRsyncArgs(repoRoot, `ubuntu:${workspaceRoot}/`), encodeFileList(files)) === 0) {
       exitCode = await run("ssh", ["ubuntu", posixTestScript(workspaceRoot, stateRoot, options)]);
     }
   } finally {
@@ -151,8 +179,10 @@ function powerShellArgs(script) {
 }
 
 async function copyArchive(destinationArgs) {
-  const archive = spawn("tar", sourceArchiveArgs(), { stdio: ["ignore", "pipe", "pipe"], env: { ...process.env, COPYFILE_DISABLE: "1" } });
+  const input = encodeFileList(sourceFileList());
+  const archive = spawn("tar", sourceArchiveArgs(), { stdio: ["pipe", "pipe", "pipe"], env: { ...process.env, COPYFILE_DISABLE: "1" } });
   const destination = spawn(destinationArgs[0], destinationArgs.slice(1), { stdio: ["pipe", "pipe", "pipe"] });
+  archive.stdin.end(input);
   archive.stdout.pipe(destination.stdin);
   archive.stderr.pipe(process.stderr);
   destination.stdout.pipe(process.stdout);
@@ -165,6 +195,13 @@ async function copyArchive(destinationArgs) {
 async function run(command, args, options = {}) {
   if (!options.quiet) console.log(`[test-isolation] exec=${formatCommand(command, args)}`);
   const child = spawn(command, args, { stdio: "inherit" });
+  return waitFor(child);
+}
+
+async function runWithInput(command, args, input) {
+  console.log(`[test-isolation] exec=${formatCommand(command, args)}`);
+  const child = spawn(command, args, { stdio: ["pipe", "inherit", "inherit"] });
+  child.stdin.end(input);
   return waitFor(child);
 }
 
@@ -195,6 +232,24 @@ function formatCommand(command, args) {
   const encodedAt = args.indexOf("-EncodedCommand");
   const visible = encodedAt === -1 ? args : [...args.slice(0, encodedAt + 1), "<encoded>"];
   return [command, ...visible].map(shellQuote).join(" ");
+}
+
+function gitWorktreeFiles(sourceRoot) {
+  return execFileSync("git", ["-C", sourceRoot, "ls-files", "--cached", "--others", "--exclude-standard", "-z"])
+    .toString("utf8")
+    .split("\0")
+    .filter(Boolean);
+}
+
+function pathExists(target) {
+  try { lstatSync(target); return true; } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function encodeFileList(files) {
+  return Buffer.from(files.length === 0 ? "" : `${files.join("\0")}\0`);
 }
 
 if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) process.exitCode = await main();

--- a/tools/dispatch-isolated-test.test.mjs
+++ b/tools/dispatch-isolated-test.test.mjs
@@ -1,7 +1,11 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
-import { parseDispatchArgs, posixTestScript, powerShellTestScript, sourceArchiveArgs, testRunnerArgs } from "./dispatch-isolated-test.mjs";
+import { parseDispatchArgs, posixTestScript, powerShellTestScript, sourceArchiveArgs, sourceFileList, sourceRootAllowlist, sourceRsyncArgs, testRunnerArgs } from "./dispatch-isolated-test.mjs";
 
 test("dispatcher defaults to Ubuntu and requires exactly one test selector", () => {
   assert.deepEqual(parseDispatchArgs(["--tier", "integration"]), { target: "ubuntu", tier: "integration", file: undefined });
@@ -26,9 +30,77 @@ test("dispatcher builds runner commands for either supported selector", () => {
   assert.deepEqual(testRunnerArgs({ tier: undefined, file: "tools/a.test.mjs" }), ["node", "tools/run-node-tests.mjs", "--file", "tools/a.test.mjs"]);
 });
 
+test("source root allowlist contains only current test inputs", () => {
+  assert.deepEqual(sourceRootAllowlist, [
+    ".github", ".gitignore", ".mergify.yml", "README.md", "docs-release", "eslint.config.mjs",
+    "package-lock.json", "package.json", "packages", "scripts", "skills", "tools", "tsconfig.json"
+  ]);
+});
+
 test("macOS source archives omit extended attributes while other hosts keep portable tar arguments", () => {
-  assert.deepEqual(sourceArchiveArgs("darwin").slice(0, 2), ["--no-xattrs", "--exclude=.git"]);
+  assert.deepEqual(sourceArchiveArgs("darwin").slice(0, 2), ["--no-xattrs", "-cf"]);
   assert.equal(sourceArchiveArgs("linux").includes("--no-xattrs"), false);
+});
+
+test("source archives consume a structural NUL file list without exclusion patterns", () => {
+  withFixture(({ source }) => {
+    write(source, "packages/kept.txt");
+    write(source, "tools/kept.txt");
+    const args = sourceArchiveArgs("linux", source);
+    assert.deepEqual(args, ["-cf", "-", "-C", source, "--null", "-T", "-"]);
+    assert.equal(args.some((arg) => arg.startsWith("--exclude=")), false);
+  });
+});
+
+test("source file discovery keeps worktree changes but drops ignored output and unknown roots", () => {
+  withFixture(({ source }) => {
+    execFileSync("git", ["-C", source, "init", "--quiet"]);
+    writeFileSync(path.join(source, ".gitignore"), "dist/\n");
+    write(source, "packages/tracked.ts");
+    write(source, "packages/untracked.ts");
+    write(source, "packages/gui/dist/ignored.js");
+    write(source, "future-private/untracked.txt");
+    execFileSync("git", ["-C", source, "add", ".gitignore", "packages/tracked.ts"]);
+    assert.deepEqual(sourceFileList(source), [".gitignore", "packages/tracked.ts", "packages/untracked.ts"]);
+  });
+});
+
+test("tar copies the complete allowlist and rejects every other repository root", () => {
+  withFixture(({ source, destination }) => {
+    seedCompletePolicyFixture(source);
+    extractArchive(source, destination, sourceRootAllowlist);
+    assert.deepEqual(rootEntries(destination), ["packages", "tools"]);
+    console.log(`[archive-implementation] ${toolVersion("tar")}`);
+  });
+});
+
+test("tar file lists preserve a nested harness directory", () => {
+  withFixture(({ source, destination }) => {
+    write(source, "harness/root.txt");
+    write(source, "tmp/benchmarks/codex-hostnet-patch/harness/nested.txt");
+    extractArchive(source, destination, ["tmp"]);
+    assert.equal(existsSync(path.join(destination, "harness")), false);
+    assert.equal(existsSync(path.join(destination, "tmp/benchmarks/codex-hostnet-patch/harness/nested.txt")), true);
+  });
+});
+
+test("rsync copies the complete allowlist and rejects every other repository root", () => {
+  withFixture(({ source, destination }) => {
+    seedCompletePolicyFixture(source);
+    syncWithRsync(source, destination, sourceRootAllowlist);
+    assert.deepEqual(rootEntries(destination), ["packages", "tools"]);
+    console.log(`[rsync-implementation] ${toolVersion("rsync")}`);
+  });
+});
+
+test("rsync file lists preserve a nested harness directory", () => {
+  withFixture(({ source, destination }) => {
+    write(source, "harness/root.txt");
+    write(source, "tmp/benchmarks/codex-hostnet-patch/harness/nested.txt");
+    syncWithRsync(source, destination, ["tmp"]);
+    assert.equal(existsSync(path.join(destination, "harness")), false);
+    assert.equal(existsSync(path.join(destination, "tmp/benchmarks/codex-hostnet-patch/harness/nested.txt")), true);
+  });
 });
 
 test("remote scripts preflight before executing tests with a dedicated root and id", () => {
@@ -43,3 +115,61 @@ test("remote scripts preflight before executing tests with a dedicated root and 
   assert.match(powerShell, /test-hermetic-preflight\.mjs --user-root 'C:\\Temp\\run\\\.test-isolation-state'/u);
   assert.match(powerShell, /\$env:HARNESS_DAEMON_USER_ROOT = 'C:\\Temp\\run\\\.test-isolation-state'/u);
 });
+
+function withFixture(run) {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-dispatch-sync-"));
+  const source = path.join(root, "source"), destination = path.join(root, "destination");
+  mkdirSync(source); mkdirSync(destination);
+  try { run({ source, destination }); } finally { rmSync(root, { recursive: true, force: true }); }
+}
+
+function write(root, relativePath) {
+  const target = path.join(root, relativePath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, `${relativePath}\n`);
+}
+
+function seedCompletePolicyFixture(root) {
+  for (const entry of [
+    "harness", ".harness", ".harness-private", ".worktrees", "tmp",
+    ".harness-old-generation-20260818", "harness-old-generation-20260818", "future-private"
+  ]) write(root, `${entry}/excluded.txt`);
+  write(root, "packages/kept.txt");
+  write(root, "tools/kept.txt");
+}
+
+function extractArchive(source, destination, allowedRoots) {
+  const files = sourceFileList(source, allowedRoots, fixtureFiles(source));
+  const archive = spawnSync("tar", sourceArchiveArgs(process.platform, source), { input: encodeFileList(files), maxBuffer: 10 * 1024 * 1024 });
+  assert.equal(archive.status, 0, archive.stderr.toString());
+  const extracted = spawnSync("tar", ["-xf", "-", "-C", destination], { input: archive.stdout });
+  assert.equal(extracted.status, 0, extracted.stderr.toString());
+}
+
+function syncWithRsync(source, destination, allowedRoots) {
+  const files = sourceFileList(source, allowedRoots, fixtureFiles(source));
+  const result = spawnSync("rsync", sourceRsyncArgs(source, `${destination}/`), { input: encodeFileList(files), encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+}
+
+function fixtureFiles(root, directory = root) {
+  const files = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const target = path.join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...fixtureFiles(root, target));
+    else files.push(path.relative(root, target).split(path.sep).join("/"));
+  }
+  return files;
+}
+
+function encodeFileList(files) {
+  return Buffer.from(files.length === 0 ? "" : `${files.join("\0")}\0`);
+}
+
+function rootEntries(root) {
+  return readdirSync(root).sort((left, right) => left.localeCompare(right));
+}
+
+function toolVersion(command) {
+  return execFileSync(command, ["--version"], { encoding: "utf8" }).split(/\r?\n/u)[0];
+}


### PR DESCRIPTION
# English

## Summary

`tools/dispatch-isolated-test.mjs` is the one sanctioned way to run a test on an isolated remote target. It synchronized the repository by copying everything except a short blacklist of six names (`.git`, `node_modules`, `.harness`, `coverage`, `dist`, `out`). Every other repository root was copied, including the private planning workspace and the drained legacy history, and including any new private root a future change might add. A blacklist fails open: a directory nobody thought to list is silently shipped.

This replaces the blacklist with a fail-closed root allowlist, and derives the actual file list from Git rather than from directory recursion. Both archivers and rsync are handed the same NUL-delimited list, so no tar exclusion patterns are involved and the three tools cannot drift apart.

The allowlist is `packages` and `tools` (the only test-discovery roots), `package.json` and `package-lock.json` (needed by the target-side install), `.github`, `.gitignore`, `.mergify.yml`, `README.md`, `docs-release` (read by registered repository and gate tests), `scripts` and `skills` (read by quickstart and skill-contract tests), and `eslint.config.mjs` and `tsconfig.json` (needed by lint and build-oriented tests).

Deriving the list from Git's tracked plus non-ignored-untracked files also fixes a subtler problem an allowlist of directory roots alone would not: recursing into the allowed `packages/` root re-admits ignored build output such as `packages/gui/dist/`. Using Git's own file list keeps uncommitted source under allowed roots while omitting ignored build products.

## What Changed

- `tools/dispatch-isolated-test.mjs`: the six-name exclusion list is replaced by a root allowlist plus a Git-derived, NUL-delimited file list. That single list is fed to bsdtar, GNU tar, and rsync alike; deleted tracked paths are dropped before encoding, and NUL framing handles paths containing whitespace or newlines without shell parsing.
- `tools/dispatch-isolated-test.test.mjs`: adds a complete-policy fixture containing every forbidden root, both historical-generation directory forms, an unknown `future-private/`, plus `packages/` and `tools/`, and asserts only the last two reach the destination. A second fixture proves a nested directory literally named `harness` beneath an allowed path is preserved, so the rule anchors at the repository root rather than matching the name anywhere in the path.

## Machine-Readable Declarations

Production-Delta: +0/-0

<!-- The diff is +194/-9 across two files, but `tools/gates/module-policy.mjs` counts only `packages/*/src/**` and `src/<module>/**` as production source. `tools/` is neither, so the computed production delta is zero. -->

## Task And Scope

- Harness task: task_658c848779e60fe652bd682035
- Branch: codex/isolated-test-sync-scope
- Public scope: `tools/dispatch-isolated-test.mjs` and `tools/dispatch-isolated-test.test.mjs`. The raw diff is +194/-9; the declared production delta is zero because the gate's production definition covers only package and top-level `src` trees.
- Private planning/evidence updated: yes
- Out of scope: no CI workflow, no gate manifest, no test tier assignment, and no change to which tests run or to the isolation state directory.

## Version Impact

- Version: no version change because this is developer test tooling with no published surface.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: `tools/dispatch-isolated-test.mjs` is not listed in any `protectedSurfaces` entry of `tools/gate-manifest.json`. It is, however, the entry point named by the standing test-isolation policy, so that decision is cited below as the governing authority even though no machine check binds it.
- Authority: dec_E6E62653DA534ACDD1B7C0A388
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: 18c2aa4643281e37bb18da45034ccb9a4c0be890
- Branch merge-base with `origin/main`: 18c2aa4643281e37bb18da45034ccb9a4c0be890
- Last `git fetch origin` time: 2026-08-24, immediately before opening this PR.
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: the implementation closeout in the harness task package, not part of this public diff.
- Reviewer evidence path: same task package.
- GitHub Actions `rewrite-ci` run URL: see the checks on this PR.
- [x] `npm run check:local` (fast tier, green, using Node 24 as the repository requires)
- [x] The changed test file was run through the isolated dispatcher against Ubuntu: 12 tests, 12 pass.
- Not run: full GitHub CI, the GUI job, other integration shards, and Windows lanes were not run locally; cloud CI on this PR is the authority for those.

## Review Evidence

- Self-review: a positive control was run before the fix. Six non-sensitive sentinel files were placed under the ignored roots, and the old implementation shipped `harness`, `.harness-private`, `.worktrees`, `tmp`, and both historical-generation roots to the destination under both bsdtar and rsync, with both destinations measuring identically. A test-first mutation also produced a real red on the old archiver, which distinguishes this from a test that was already green. The sentinels were removed before the public commit.
- An intermediate implementation was rejected during the work: an allowlist of directory roots alone still recursed into `packages/gui/dist/`, and both destinations measured larger than the positive-control copy. The implementation was tightened to the Git-derived file list, which keeps the no-exclusion-pattern property without re-admitting build products.
- Reviewer subagent: not used.
- Human review: pending.
- Blocking findings: none open.

## Residual Risk

- An allowlist requires maintenance. If a future test needs a repository root that is not on the list, the failure is loud and immediate: the target-side install fails on a missing workspace or lock input, or the selected test fails with a missing import or fixture. That is the intended failure direction — the blacklist it replaces failed the other way, by silently copying private directories.
- The second fixture allows `tmp/` solely so that a nested `harness` directory can be shown to survive; that fixture is not production configuration, because the production allowlist excludes root `tmp/` outright.
- Behavior was proven under local bsdtar with openrsync and under Ubuntu GNU tar with GNU rsync. Other platform tool combinations were not exercised.

## References

- Task: task_658c848779e60fe652bd682035
- Evidence: implementation closeout in the task package
- Review: CEO checkpoint ruling in the same task package

---

# 中文

## 概要

`tools/dispatch-isolated-test.mjs` 是把测试发到隔离远端跑的唯一合规入口。它此前同步仓库的方式是「除了六个名字之外全部拷过去」（`.git`、`node_modules`、`.harness`、`coverage`、`dist`、`out`）。其余每一个仓库根目录都被拷贝，包括私有规划工作区和已抽干的历史遗留目录，也包括未来任何新增的私有根。黑名单是 fail-open 的：没人想到要写进名单的目录会被静默送出去。

本 PR 把黑名单换成 fail-closed 的根白名单，并且用 Git 而不是目录递归来产生真正的文件清单。两种打包器和 rsync 拿到的是同一份以 NUL 分隔的清单，因此完全不依赖 tar 的排除模式，三个工具也不可能各走各的。

白名单是：`packages` 与 `tools`（唯二的测试发现根）、`package.json` 与 `package-lock.json`（远端安装需要）、`.github`、`.gitignore`、`.mergify.yml`、`README.md`、`docs-release`（已登记的仓库类与门类测试会读）、`scripts` 与 `skills`（quickstart 与 skill 契约测试会读）、`eslint.config.mjs` 与 `tsconfig.json`（lint 与构建类测试需要）。

用 Git 的「已跟踪 + 未被忽略的未跟踪」文件清单，还顺带解决了「只列目录根的白名单」解决不了的一个更隐蔽的问题：递归进被允许的 `packages/` 根，会把被忽略的构建产物（例如 `packages/gui/dist/`）重新放进来。改用 Git 自己的文件清单，既保留了被允许根下未提交的源码，又排除了被忽略的构建产物。

## 改动内容

- `tools/dispatch-isolated-test.mjs`：六个名字的排除清单换成根白名单加 Git 派生的 NUL 分隔文件清单。这一份清单同时喂给 bsdtar、GNU tar 和 rsync；编码前先剔除已删除的跟踪路径；NUL 分帧使含空白或换行的路径无需 shell 解析即可正确处理。
- `tools/dispatch-isolated-test.test.mjs`：新增一个完整策略夹具，内含每一个禁止根、两种历史代目录形态、一个未知的 `future-private/`，外加 `packages/` 与 `tools/`，断言只有后两者到达目标端。第二个夹具证明被允许路径下方一个字面名为 `harness` 的嵌套目录会被保留，说明规则锚定在仓库根，而不是在路径任意位置匹配这个名字。

## 任务与范围

- Harness 任务：task_658c848779e60fe652bd682035
- 分支：codex/isolated-test-sync-scope
- 公开范围：`tools/dispatch-isolated-test.mjs` 与 `tools/dispatch-isolated-test.test.mjs`。原始 diff 是 +194/-9；声明的生产增删为零，是因为门对「生产源码」的定义只覆盖 package 与顶层 `src` 目录树。
- 私有计划 / 证据是否已更新：yes
- 范围外：不改 CI workflow、不改 gate manifest、不改测试分层归属，也不改变「跑哪些测试」以及隔离状态目录。

## 版本影响

- 版本：不改版本，原因是这是开发者测试工具，没有对外发布面。
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：`tools/dispatch-isolated-test.mjs` 不在 `tools/gate-manifest.json` 的任何 `protectedSurfaces` 条目里。但它是常设测试隔离政策点名的唯一入口，所以下面仍把该决策列为治理依据，尽管没有任何机器检查把它绑住。
- 依据：dec_E6E62653DA534ACDD1B7C0A388
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no

## 验证

- `origin/main` 基准 SHA：18c2aa4643281e37bb18da45034ccb9a4c0be890
- 当前分支与 `origin/main` 的 merge-base：18c2aa4643281e37bb18da45034ccb9a4c0be890
- 最近一次 `git fetch origin` 时间：2026-08-24，开 PR 前刚取。
- 同步方式：不需要
- 公开 diff 命令：`git diff origin/main...HEAD`
- 私有证据 commit/path：任务包内的实现结案文档，不在本公开 diff 内。
- Reviewer 证据路径：同一任务包。
- GitHub Actions `rewrite-ci` run URL：见本 PR 的 checks。
- [x] `npm run check:local`（fast tier 全绿，按仓库要求用 Node 24）
- [x] 被改的测试文件已通过隔离派测器在 Ubuntu 上跑过：12 个测试，12 个通过。
- 未运行：完整 GitHub CI、GUI job、其余 integration shard 与 Windows lane 本地都没跑；这些以本 PR 的云端 CI 为权威。

## 审查证据

- 自查：修复前做了阳性对照。在被忽略的各个根下放了六个非敏感哨兵文件，旧实现在 bsdtar 与 rsync 两条路径下都把 `harness`、`.harness-private`、`.worktrees`、`tmp` 以及两种历史代根送到了目标端，且两个目标端体积完全一致。测试先行的变异也让旧打包器真的变红，这把本次修复与「行为改动前就已经绿的测试」区分开。哨兵在公开提交前已删除。
- 工作过程中否掉了一版中间实现：只列目录根的白名单仍会递归进 `packages/gui/dist/`，两个目标端体积都大于阳性对照。实现因此收紧为 Git 派生文件清单，既保住了「不依赖排除模式」这一性质，又不会把构建产物放回来。
- Reviewer subagent：未使用。
- 人工审查：待进行。
- 阻塞发现：无。

## 残余风险

- 白名单需要维护。未来某个测试若需要一个不在名单上的仓库根，失败是响亮且即时的：远端安装因缺少 workspace 或 lock 输入而失败，或者被选中的测试因缺少 import 或夹具而失败。这正是我们要的失败方向——它替换掉的黑名单是朝另一个方向失败的，也就是静默拷贝私有目录。
- 第二个夹具允许 `tmp/`，唯一目的是能演示嵌套的 `harness` 目录会被保留；该夹具不是生产配置，因为生产白名单直接排除了根 `tmp/`。
- 行为在「本机 bsdtar + openrsync」与「Ubuntu GNU tar + GNU rsync」两组下分别验证过。其他平台的工具组合没有实测。

## 关联材料

- 任务：task_658c848779e60fe652bd682035
- 证据：任务包内实现结案文档
- 审查：同一任务包内的 CEO checkpoint 裁决书
