### PR TITLE
feat(daemon): give the Commander role a real context block

### DIFF
--- a/packages/daemon/src/agent-role-prompts.ts
+++ b/packages/daemon/src/agent-role-prompts.ts
@@ -15,12 +15,36 @@ const workerDiscipline = `# Worker Role
 - Follow task-specific stop conditions and raise one evidence-backed objection when the proposed route conflicts with code or established decisions.
 - Complete proportionate verification, leave a local commit when code changes are requested, and hand back changed paths, evidence, residual risks, and unverified items.`;
 
-const commanderDiscipline = `# Commander Role
+const commanderDiscipline = `<very_important>
+# Commander Context
 
-- Decompose the task into bounded missions with explicit ownership, inputs, outputs, and acceptance evidence. Tell workers they share the codebase and must preserve one another's edits.
-- Keep your own context focused on coordination, but independently inspect the final diff, affected tests, and gate evidence; worker reports are leads, not proof.
-- Resolve overlaps and objections against the task contract, escalate load-bearing choices at checkpoints, and return an integrated result to the CEO.
-- Do not take over CEO-owned push, PR, merge, or publication work.`;
+Your default context already tells you how this repository works. This tells you what changes because you are the Commander, and it outranks your habit of doing the work yourself.
+
+${[
+  "You exist so that whoever assigned this area can stop tracking what happens inside it, which makes " +
+  "your own attention — not compute, not the number of workers — the resource you are spending, so " +
+  "settle inside your area whatever you can settle and send upward only what genuinely needs a ruling. " +
+  "Delegate the work you cannot specify precisely, the work that needs long trial and error, and the " +
+  "work whose context would crowd out yours; when you can already write the change yourself, write it, " +
+  "because authoring a packet, waiting, reading the log and integrating the result usually costs more " +
+  "than the edit. Before you dispatch anything, read the code rather than the description of it, " +
+  "because a task can rest on a single stale measurement or be half-finished already, and a worker will " +
+  "faithfully execute a wrong model all the way to green. Give each worker a map rather than a fence — " +
+  "where to look, why this matters, who will judge it, and what done means in evidence — and name only " +
+  "the paths it must not touch, since the files it should change are precisely what you sent it to " +
+  "discover and a whitelist turns it into someone who stops to ask permission; never let two workers " +
+  "hold the same file. Treat every report as a lead and never as proof: a passing gate quoted back to " +
+  "you is a claim about a gate, so run the gate yourself against the final commit, where the most " +
+  "common failure you will meet is a report that says everything passed because everything did pass, " +
+  "one commit ago. State the stopping condition separately from the success condition, or a worker that " +
+  "has to stop early will read them as one chain and commit nothing. Hold the mission fixed; if you " +
+  "come to believe the mission itself is wrong, say so upward with evidence and a proposed alternative " +
+  "instead of quietly redefining it, and grant your workers that same right downward, because a worker " +
+  "that pushes back with evidence is doing its job. Then own the integration: inspect the final diff, " +
+  "the tests it touches and the gate output yourself, and report only what you actually observed, " +
+  "marking everything else unverified."
+].join("")}
+</very_important>`;
 
 export function agentRolePrompt(role: AgentRole | undefined): string {
   return [sharedExecutionDiscipline, role === "commander" ? commanderDiscipline : workerDiscipline].join("\n\n");

--- a/packages/daemon/test/runtime-spawn.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn.integration.test.ts
@@ -451,7 +451,7 @@ test("runtime spawn resolves command model, Agent model, then instance default w
     assert.equal(launched?.definition.model, "instance-default");
     assert.match(
       launched?.prompt ?? "",
-      /# Harness Execution Discipline.*# Commander Role.*bounded missions.*independently inspect.*CEO-owned/su,
+      /# Harness Execution Discipline.*<very_important>.*# Commander Context.*attention.*run the gate yourself.*<\/very_important>/su,
     );
     for (const kindId of ["claude", "codex", "agy"] as const) {
       await cell.spawnRuntime(


### PR DESCRIPTION
# English

## Summary

A Commander agent already receives a role-specific prompt: `runtime-spawn-mission.ts:38` calls `agentRolePrompt(agent.role)`, and `agent-role-prompts.ts` appends a commander block whenever the declared role is `commander`. That trigger works for every provider, because the block is assembled into the prompt text rather than passed through any provider-specific mechanism.

What the block said was four bullets in a 27-line file. They state conclusions — decompose into bounded missions, inspect independently, do not take over CEO-owned publication — without the method behind any of them. A Commander reading them learned that it should delegate, but not when it should *not*; that worker reports are leads, but not what to do about that; nothing at all about how to write a packet a worker will not have to guess at.

This replaces them with one continuous paragraph inside a `<very_important>` tag. It opens by naming itself as the delta over the agent's existing context — AGENTS.md and repository standards already tell it how the repository works — rather than repeating that. It carries causes alongside rules, so a Commander can act correctly in a situation the text does not enumerate: why delegating work you could already specify usually costs more than doing it, why handing a worker a whitelist of files turns it into someone who stops to ask permission, why a passing gate quoted back at you is a claim about a gate and most often true one commit ago.

## What Changed

- `packages/daemon/src/agent-role-prompts.ts`: `commanderDiscipline` is rewritten from four bullets into one tagged paragraph. Nothing else in the file changes; `sharedExecutionDiscipline` and `workerDiscipline` are untouched, and the `role === "commander"` selection at line 26 is unchanged.
- `packages/daemon/test/runtime-spawn.integration.test.ts`: the assertion that the commander block reaches the final prompt now anchors on the tag, the `# Commander Context` heading, and two phrases from the new text, instead of three phrases from the old text.

## Machine-Readable Declarations

Production-Delta: +29/-5

<!-- 29 added lines for one paragraph: the text is wrapped into 22 concatenated source segments so no source line exceeds 120 characters. The emitted prompt is one paragraph and is byte-identical to the unwrapped version. -->

## Task And Scope

- Harness task: task_61d6ac34f0d946d86ba54b4e2a
- Branch: codex/commander-context
- Public scope: `packages/daemon/src/agent-role-prompts.ts` and one assertion in `packages/daemon/test/runtime-spawn.integration.test.ts`. The production delta is +29/-5 rather than +6/-5 because the paragraph is wrapped into 22 concatenated source segments to satisfy `line-density`; the emitted text is one paragraph either way.
- Private planning/evidence updated: yes
- Out of scope: no new skill directory, no new loading path, no change to how roles are declared or selected, and no change to the worker block.

## Version Impact

- Version: no version change because this is prompt content behind an existing role selection.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: `packages/daemon/src/agent-role-prompts.ts` is not listed in any `protectedSurfaces` entry of `tools/gate-manifest.json`.
- Authority: dec_B17094CA8B26A5BE7804F9C767
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: b525f0009
- Branch merge-base with `origin/main`: b525f0009
- Last `git fetch origin` time: 2026-08-24, immediately before opening this PR.
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: the governing decision package, not part of this public diff.
- Reviewer evidence path: task package for task_61d6ac34f0d946d86ba54b4e2a.
- GitHub Actions `rewrite-ci` run URL: see the checks on this PR.
- [x] `npm run check:local` (fast tier, green in 106.3s) — run against commit `7e881e39d`, after the final amend. An earlier run of the same command reported green while the edit was still uncommitted, which measured `origin/main` rather than this change; that receipt was worthless and cloud CI correctly failed `line-density` on the pushed commit. See the self-review below.
- [x] `node --test packages/daemon/test/runtime-spawn.integration.test.ts` — 12 tests, 12 pass, including the one that asserts the commander block reaches the final prompt.
- Not run: full GitHub CI, the GUI job, the remaining integration shards, and Windows lanes were not run locally; cloud CI on this PR is the authority for those.

## Review Evidence

- The paragraph was first written as a single 2100-character source line, which made the `line-density` gate's hunk exceed its prior overlong total (497 to 2279 characters). It is now wrapped into 22 concatenated source segments, none over 120 characters. The emitted prompt was captured before and after the rewrite and compared byte for byte: both are 3334 characters and identical, so the wrapping changed the source layout and not the text any Commander receives.
- That gate had also changed under this branch: PR #1783 replaced the per-line rule with a per-hunk one, so the rule is now that a hunk may increase neither its total overlong characters nor its longest line.
- Self-review: the first bare run of the integration file failed one unrelated test (`repo-cell restart re-adopts a live native runtime`) with `runtime provider event did not arrive`. Re-running the same file unchanged passed all twelve, so that red was an intermittent timing race and not caused by this change. The assertion this PR edits passed in both runs of the file that reached it.
- Reviewer subagent: not used.
- Human review: the prompt text was written to a direction given in conversation and shown before this PR was opened.
- Blocking findings: none open.

## Residual Risk

- This is prompt content, so its effect is not mechanically verifiable. The test proves the block reaches the final prompt for every provider; whether Commanders actually behave differently can only be judged from how dispatched Commanders behave over time.
- The paragraph is longer than what it replaces and competes with the mission for attention in the same prompt. It is deliberately one block rather than a list, on the reasoning that a list gets skimmed for conclusions while the causes are the part that generalizes; that reasoning is a judgment, not a measurement.
- The text is English, matching the surrounding blocks. Whether a Chinese-first Commander reads it as well was not tested.

## References

- Task: task_61d6ac34f0d946d86ba54b4e2a
- Evidence: fact F-1C35DC9A
- Review: dec_B17094CA8B26A5BE7804F9C767, which supersedes dec_AB0672F220EE630C0A06C575B8/CH5

---

# 中文

## 概要

Commander 本来就会收到一段按角色定制的提示词:`runtime-spawn-mission.ts:38` 调用 `agentRolePrompt(agent.role)`,`agent-role-prompts.ts` 在声明的 role 为 `commander` 时拼上 commander 段落。这条触发对所有 provider 都成立,因为它是把文本拼进提示词,不经过任何 provider 专有机制。

问题在于这段内容:27 行文件里的 4 条要点。它们说的是结论——拆解成有边界的任务、独立核查、不接管 CEO 的发布权——但没有任何一条给出方法。Commander 读完知道自己应该派工,却不知道什么时候**不该**派;知道 worker 的汇报只是线索,却不知道据此该做什么;至于怎么写一个 worker 不用猜的派工包,一个字都没有。

本 PR 把它换成包在 `<very_important>` 标签内的一整段连续文字。开篇先点明这段是相对 agent 既有上下文的增量——AGENTS.md 与仓库标准已经告诉过它这个仓库怎么运作——而不是重复那些内容。正文把因果和规则一起给出,好让 Commander 在文本没有枚举到的情形里也能做对:为什么派出一件你已经能说清楚的活通常比自己做更贵、为什么给 worker 一份文件白名单反而让它变成一个停下来问许可的人、为什么它报回来的绿灯是关于门的一句断言而且多半在上一个 commit 才为真。

## 改动内容

- `packages/daemon/src/agent-role-prompts.ts`:`commanderDiscipline` 从 4 条要点改写为一段带标签的连续文字。文件其余部分不变,`sharedExecutionDiscipline` 与 `workerDiscipline` 未动,第 26 行 `role === "commander"` 的选择逻辑也未动。
- `packages/daemon/test/runtime-spawn.integration.test.ts`:断言 commander 段落进入最终提示词的那一条,锚点从旧文本的三个短语改为标签、`# Commander Context` 标题与新文本的两个短语。

## 任务与范围

- Harness 任务:task_61d6ac34f0d946d86ba54b4e2a
- 分支:codex/commander-context
- 公开范围:`packages/daemon/src/agent-role-prompts.ts` 与 `packages/daemon/test/runtime-spawn.integration.test.ts` 里的一条断言。生产增删是 +29/-5 而不是 +6/-5,因为那段文字为满足 `line-density` 被拆成了 22 段拼接;两种写法下实际注入的文本都是同一段。
- 私有计划 / 证据是否已更新:yes
- 范围外:不新建 skill 目录、不新增加载路径、不改 role 的声明与选择方式、不动 worker 段落。

## 版本影响

- 版本:不改版本,原因是这是既有角色选择背后的提示词内容。
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:`packages/daemon/src/agent-role-prompts.ts` 不在 `tools/gate-manifest.json` 的任何 `protectedSurfaces` 条目里。
- 依据:dec_B17094CA8B26A5BE7804F9C767
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no

## 验证

- `origin/main` 基准 SHA:b525f0009
- 当前分支与 `origin/main` 的 merge-base:b525f0009
- 最近一次 `git fetch origin` 时间:2026-08-24,开 PR 前刚取。
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:治理该改动的 decision 包,不在本公开 diff 内。
- Reviewer 证据路径:task_61d6ac34f0d946d86ba54b4e2a 的任务包。
- GitHub Actions `rewrite-ci` run URL:见本 PR 的 checks。
- [x] `npm run check:local`(fast tier,106.3 秒全绿)——跑在 commit `7e881e39d` 上,在最后一次 amend 之后。此前同一条命令曾在改动尚未提交时报绿,那次量的是 `origin/main` 而不是本改动,该回执是无效的,云端 CI 在推上去的提交上正确地让 `line-density` 变红。详见下方自查。
- [x] `node --test packages/daemon/test/runtime-spawn.integration.test.ts`——12 条测试 12 条通过,含断言 commander 段落进入最终提示词的那一条。
- 未运行:完整 GitHub CI、GUI job、其余 integration shard 与 Windows lane 本地都没跑;这些以本 PR 的云端 CI 为权威。

## 审查证据

- 这段文字最初写成源码里的单行 2100 字符,使 `line-density` 门所在 hunk 的超长内容总量从 497 涨到 2279。现已拆成 22 段拼接,单行均不超过 120 字符。改写前后各捕获一次实际注入的提示词逐字节比对:两边都是 3334 字符且完全相同,因此拆行只改了源码排版,没有改变任何 Commander 收到的文本。
- 该门在本分支期间也换过判据:PR #1783 把逐行规则换成了逐 hunk 规则,现在的规则是一个 hunk 内超长内容的总字符数与最长行都不得增加。
- 自查:第一次裸跑该集成测试文件时,有一条**无关**测试失败(`repo-cell restart re-adopts a live native runtime`,报 `runtime provider event did not arrive`)。原封不动重跑同一文件,12 条全过,因此那次红是间歇性时序竞态,不是本改动造成的。本 PR 改的那条断言在两次跑到它的运行里都通过。
- Reviewer subagent:未使用。
- 人工审查:提示词文本按对话中给定的方向撰写,并在开 PR 前已展示。
- 阻塞发现:无。

## 残余风险

- 这是提示词内容,效果无法机械验证。测试证明的是这段确实进入了所有 provider 的最终提示词;Commander 是否真的因此变得不同,只能从此后被派出的 Commander 的实际行为里判断。
- 这段比它替换掉的更长,会在同一个提示词里与任务本身争夺注意力。刻意做成一整段而不是列表,依据是列表会被扫读取结论,而能泛化的恰恰是因果部分;这个依据是判断,不是测量。
- 文本是英文,与前后两段一致。中文优先的 Commander 读起来是否同样有效,没有测过。

## 关联材料

- 任务:task_61d6ac34f0d946d86ba54b4e2a
- 证据:fact F-1C35DC9A
- 审查:dec_B17094CA8B26A5BE7804F9C767,它取代 dec_AB0672F220EE630C0A06C575B8/CH5
