### PR TITLE
feat(preset): show the completion contract before work starts

### DIFF
--- a/packages/cli/src/cli/thin-command.ts
+++ b/packages/cli/src/cli/thin-command.ts
@@ -153,9 +153,19 @@ export function renderThinHelp(
 }
 
 function renderPresetHelpEntry(entry: ThinHelpCatalogEntry): string {
+  const contract = entry as ThinHelpCatalogEntry & {
+    readonly defaultProfile?: string;
+    readonly outputShape?: string;
+    readonly completionGates?: readonly string[];
+  };
   const description =
     entry.validity === "valid"
-      ? entry.description
+      ? [
+          entry.description,
+          `profile=${String(contract.defaultProfile)}`,
+          `outputShape=${String(contract.outputShape)}`,
+          `completionGates=${JSON.stringify(contract.completionGates)}`,
+        ].join(" — ")
       : `${entry.validity}${entry.errorCode ? ` (${entry.errorCode})` : ""}`;
   return `  ${entry.id} — ${entry.title} — ${description}`;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,6 +29,12 @@ import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 export { resolveCliVersion } from "./cli-meta.ts";
 
+const repositoryDiffContract = [
+  "contract: repository-diff requires a committable public-repository diff, ",
+  "real CI, and a code-doc reconciliation witness. ",
+  "For a task-package-only report or decision, use the task-package-artifact preset docs-task.",
+].join("");
+
 export async function main(
   argv: readonly string[] = process.argv.slice(2),
 ): Promise<number> {
@@ -123,7 +129,18 @@ export function emit(receipt: Record<string, unknown>, json: boolean): void {
       typeof receipt.summary === "string")
   ) {
     const summary = contractMigrationDryRunSummary(receipt);
-    if (Array.isArray(receipt.dispatches))
+    if (
+      receipt.command === "task-create" &&
+      typeof receipt.presetId === "string" &&
+      typeof receipt.profileId === "string" &&
+      typeof receipt.outputShape === "string" &&
+      Array.isArray(receipt.completionGates) &&
+      typeof receipt.nextAction === "string"
+    )
+      console.log(renderTaskCreateReceipt(receipt));
+    else if (receipt.command === "preset-list")
+      console.log(renderPresetListReceipt(receipt));
+    else if (Array.isArray(receipt.dispatches))
       console.log(
         receipt.dispatches.length
           ? receipt.dispatches.map(renderDispatchRow).join("\n")
@@ -153,6 +170,41 @@ export function emit(receipt: Record<string, unknown>, json: boolean): void {
     const error = humanError(receipt);
     console.error(`error code=${error.code} hint=${error.hint}`);
   }
+}
+
+function renderTaskCreateReceipt(receipt: Record<string, unknown>): string {
+  const contract =
+    receipt.outputShape === "repository-diff"
+      ? [repositoryDiffContract]
+      : [];
+  return [
+    String(receipt.summary),
+    `preset: ${String(receipt.presetId)}/${String(receipt.profileId)}`,
+    `outputShape: ${String(receipt.outputShape)}`,
+    `completionGates: ${JSON.stringify(receipt.completionGates)}`,
+    ...contract,
+    `next: ${String(receipt.nextAction)}`,
+  ].join("\n");
+}
+
+function renderPresetListReceipt(receipt: Record<string, unknown>): string {
+  const rows = JSON.parse(String(receipt.evidence)) as Array<
+    Record<string, unknown>
+  >;
+  return rows
+    .map((row) => {
+      const gates = Array.isArray(row.completionGates)
+        ? JSON.stringify(row.completionGates)
+        : "unavailable";
+      return [
+        `${String(row.id)} — ${String(row.title)} — ${String(row.description)}`,
+        `  validity: ${String(row.validity)}`,
+        `  defaultProfile: ${String(row.defaultProfile ?? "unavailable")}`,
+        `  outputShape: ${String(row.outputShape ?? "unavailable")}`,
+        `  completionGates: ${gates}`,
+      ].join("\n");
+    })
+    .join("\n");
 }
 
 function emitSquadRun(

--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -94,7 +94,16 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
     assert.equal(textPreview.status, 0, textPreview.stderr);
     assert.equal(
       textPreview.stdout.trim(),
-      "would create task task-alpha at tasks/task-alpha-alpha",
+      [
+        "would create task task-alpha at tasks/task-alpha-alpha",
+        "preset: standard-task/baseline",
+        "outputShape: repository-diff",
+        'completionGates: ["ci","code-doc-reconciliation"]',
+        "contract: repository-diff requires a committable public-repository diff, " +
+          "real CI, and a code-doc reconciliation witness. For a task-package-only " +
+          "report or decision, use the task-package-artifact preset docs-task.",
+        "next: remove --dry-run to publish this exact resolved scaffold",
+      ].join("\n"),
     );
     const alpha = run(fixture.alpha, fixture.userRoot, [
       "task",

--- a/packages/cli/test/task-closeout-docs-ci.integration.test.ts
+++ b/packages/cli/test/task-closeout-docs-ci.integration.test.ts
@@ -75,6 +75,49 @@ test("a real docs task with no declared ci gate closes out on not_applicable and
         taskClass: "standard",
       }),
     );
+    const presetList = runHumanMaybe(root, userRoot, ["preset", "list"]),
+      standardPreview = runHumanMaybe(root, userRoot, [
+        "task",
+        "create",
+        "--title",
+        "Standard Completion Contract",
+        "--preset",
+        "standard-task",
+        "--dry-run",
+      ]);
+    context.diagnostic(`preset-list-human=${presetList.stdout}`);
+    context.diagnostic(`standard-task-create-human=${standardPreview.stdout}`);
+    assert.equal(presetList.status, 0, presetList.stderr || presetList.stdout);
+    assert.match(
+      presetList.stdout,
+      /standard-task[\s\S]*outputShape: repository-diff[\s\S]*completionGates: \["ci","code-doc-reconciliation"\]/u,
+    );
+    assert.equal(
+      standardPreview.status,
+      0,
+      standardPreview.stderr || standardPreview.stdout,
+    );
+    assert.match(
+      standardPreview.stdout,
+      new RegExp(
+        [
+          "preset: standard-task/baseline\\n",
+          "outputShape: repository-diff\\n",
+          'completionGates: \\["ci","code-doc-reconciliation"\\]',
+        ].join(""),
+        "u",
+      ),
+    );
+    assert.match(
+      standardPreview.stdout,
+      new RegExp(
+        [
+          "contract: repository-diff requires a committable public-repository diff,",
+          "[\\s\\S]*preset docs-task\\.\\nnext: remove --dry-run",
+        ].join(""),
+        "u",
+      ),
+    );
     const created = run(root, userRoot, [
         "task",
         "create",
@@ -92,6 +135,9 @@ test("a real docs task with no declared ci gate closes out on not_applicable and
       [],
       "the docs-task preset must declare no completion gates for this fixture to mean anything",
     );
+    assert.equal(created.presetId, "docs-task");
+    assert.equal(created.profileId, "baseline");
+    assert.equal(created.outputShape, "task-package-artifact");
 
     run(
       root,
@@ -310,6 +356,25 @@ function runMaybe(
       env: environment(root, userRoot, actor),
     },
   );
+  return {
+    status: result.status,
+    stdout: result.stdout.trim(),
+    stderr: result.stderr.trim(),
+  };
+}
+function runHumanMaybe(
+  root: string,
+  userRoot: string,
+  args: readonly string[],
+): {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+} {
+  const result = spawnSync(process.execPath, [cli, "--root", root, ...args], {
+    encoding: "utf8",
+    env: environment(root, userRoot),
+  });
   return {
     status: result.status,
     stdout: result.stdout.trim(),

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -11,7 +11,7 @@ import {
   parseThinCommand,
   renderThinHelp,
 } from "../src/cli/thin-command.ts";
-import { main, resolveCliVersion } from "../src/index.ts";
+import { emit, main, resolveCliVersion } from "../src/index.ts";
 
 test("top-level help renders a derived domain directory and domain help filters commands", () => {
   const help = renderThinHelp();
@@ -220,6 +220,11 @@ test("task-create help renders recommended presets only from effective catalog r
       title: "Standard Task",
       description: "General work.",
       validity: "valid",
+      ...{
+        defaultProfile: "baseline",
+        outputShape: "repository-diff",
+        completionGates: ["ci", "code-doc-reconciliation"],
+      },
     },
     {
       id: "module",
@@ -233,7 +238,87 @@ test("task-create help renders recommended presets only from effective catalog r
     help,
     /Recommended presets:.*standard-task — Standard Task — General work\..*module — Module — unavailable \(missing_provider\)/su,
   );
+  assert.match(
+    help,
+    /profile=baseline.*outputShape=repository-diff.*completionGates=\["ci","code-doc-reconciliation"\]/su,
+  );
   assert.doesNotMatch(help, /reference-task|long-running-task/u);
+});
+
+test("human preset and task receipts print resolved completion contracts byte-for-byte", () => {
+  const presetOutput = captureStdout(() =>
+      emit(
+        {
+          ok: true,
+          command: "preset-list",
+          evidence: JSON.stringify([
+            {
+              id: "standard-task",
+              title: "Standard Task",
+              description: "General work.",
+              validity: "valid",
+              defaultProfile: "baseline",
+              outputShape: "repository-diff",
+              completionGates: ["ci", "code-doc-reconciliation"],
+            },
+          ]),
+        },
+        false,
+      ),
+    ),
+    expectedPreset = [
+      "standard-task — Standard Task — General work.",
+      "  validity: valid",
+      "  defaultProfile: baseline",
+      "  outputShape: repository-diff",
+      '  completionGates: ["ci","code-doc-reconciliation"]',
+    ].join("\n");
+  assert.deepEqual(Buffer.from(presetOutput), Buffer.from(expectedPreset));
+
+  const taskOutput = captureStdout(() =>
+      emit(
+        {
+          ok: true,
+          command: "task-create",
+          summary: "created task task-one at tasks/task-one",
+          presetId: "standard-task",
+          profileId: "baseline",
+          outputShape: "repository-diff",
+          completionGates: ["ci", "code-doc-reconciliation"],
+          nextAction: "edit tasks/task-one/task_plan.md, then run ha task start task-one --execution-id <id>",
+        },
+        false,
+      ),
+    ),
+    expectedContract = [
+      "contract: repository-diff requires a committable public-repository diff, ",
+      "real CI, and a code-doc reconciliation witness. ",
+      "For a task-package-only report or decision, use the task-package-artifact preset docs-task.",
+    ].join(""),
+    expectedTask = [
+      "created task task-one at tasks/task-one",
+      "preset: standard-task/baseline",
+      "outputShape: repository-diff",
+      'completionGates: ["ci","code-doc-reconciliation"]',
+      expectedContract,
+      "next: edit tasks/task-one/task_plan.md, then run ha task start task-one --execution-id <id>",
+    ].join("\n");
+  assert.deepEqual(Buffer.from(taskOutput), Buffer.from(expectedTask));
+
+  const replayOutput = captureStdout(() =>
+    emit(
+      {
+        ok: true,
+        command: "task-create",
+        summary: "reused task task-one for the supplied idempotency key",
+      },
+      false,
+    ),
+  );
+  assert.equal(
+    replayOutput,
+    "reused task task-one for the supplied idempotency key",
+  );
 });
 
 test("thin parser derives closed preset and task-create payloads from descriptors", () => {
@@ -421,3 +506,15 @@ test("shared CLI option rejections point to descriptor-derived leaf help", () =>
     },
   );
 });
+
+function captureStdout(run: () => void): string {
+  const lines: string[] = [],
+    log = console.log;
+  console.log = (...values: unknown[]) => lines.push(values.join(" "));
+  try {
+    run();
+    return lines.join("\n");
+  } finally {
+    console.log = log;
+  }
+}

--- a/packages/daemon/src/repo-cell-task-create.ts
+++ b/packages/daemon/src/repo-cell-task-create.ts
@@ -240,6 +240,9 @@ export function createTask(cell: any, action: RepoTaskAction, binding: RepoCellB
       generatedPaths: compiled.documents.map((document) => document.path),
       presetDigest: compiled.snapshot.digest,
       scaffoldDigest: compiled.scaffoldDigest,
+      presetId: compiled.snapshot.identity.id,
+      profileId: compiled.snapshot.profile.id,
+      outputShape: compiled.snapshot.profile.outputShape,
       completionGates: compiled.snapshot.profile.completionGateIds,
       dryRun,
     };

--- a/packages/daemon/src/repo-cell-types.ts
+++ b/packages/daemon/src/repo-cell-types.ts
@@ -52,6 +52,9 @@ export type TaskCreateReceipt = WriteReceipt & {
   readonly generatedPaths: readonly string[];
   readonly presetDigest: string;
   readonly scaffoldDigest: string;
+  readonly presetId: string;
+  readonly profileId: string;
+  readonly outputShape: string;
   readonly completionGates: readonly string[];
   readonly commitSha: string | null;
   readonly dryRun: boolean;

--- a/packages/preset/src/preset-discovery.ts
+++ b/packages/preset/src/preset-discovery.ts
@@ -11,6 +11,11 @@ import type { Candidate, PresetFailure } from "./preset-resolver-types.ts";
 import type { PresetCatalogEntryV1 } from "./preset.contract.ts";
 import path from "node:path";
 
+type PresetCatalogDisplayEntry = PresetCatalogEntryV1 & {
+  readonly outputShape?: string;
+  readonly completionGates?: readonly string[];
+};
+
 export function runBuiltinDiscoveryAction(
   action: Readonly<Record<string, unknown>> & { readonly kind: string },
   assetsRoot = defaultAssets,
@@ -105,11 +110,11 @@ export function runBuiltinDiscoveryAction(
 export function listCatalog(
   catalog: Map<string, Candidate>,
   verticalId: string,
-): PresetCatalogEntryV1[] {
+): PresetCatalogDisplayEntry[] {
   return [...catalog.values()]
     .filter((item) => item.verticalId === verticalId)
     .map(
-      (item): PresetCatalogEntryV1 =>
+      (item): PresetCatalogDisplayEntry =>
         item.decoded
           ? {
               id: item.id,
@@ -122,6 +127,10 @@ export function listCatalog(
               version: item.decoded.manifest.version,
               kind: item.decoded.manifest.kind,
               defaultProfile: item.decoded.manifest.defaultProfile,
+              outputShape: item.decoded.manifest.outputShape,
+              completionGates: item.decoded.manifest.profiles.find(
+                ({ id }) => id === item.decoded?.manifest.defaultProfile,
+              )!.completionGates,
               entrypoints: Object.keys(
                 item.decoded.manifest.entrypoints ?? {},
               ).sort(),

--- a/packages/preset/test/preset-resolver-vertical-scripts.test.ts
+++ b/packages/preset/test/preset-resolver-vertical-scripts.test.ts
@@ -50,6 +50,8 @@ test("generic list, inspect, check, install, and uninstall actions share the can
         version: "3.0.0",
         kind: "template-content",
         defaultProfile: "baseline",
+        outputShape: "repository-diff",
+        completionGates: ["ci", "code-doc-reconciliation"],
         entrypoints: [],
         issues: [],
         issueCount: 0,


### PR DESCRIPTION
# English

## Summary

A read-only investigation task was archived without ever reaching `done`, because it was created from the `standard-task` preset. That preset declares `outputShape: repository-diff` and therefore carries the completion gates `ci` and `code-doc-reconciliation`. The task produced a report and no code, so `ci` was structurally unsatisfiable, and `completionGates` is not an amendable field. The archive event records the root cause plainly: `docs-task` should have been chosen instead.

The mismatch was only discoverable at closeout. Everything needed to avoid it already existed at creation: the resolved preset snapshot carries `profile.outputShape` and `completionGateIds`, and the create receipt already returned the gates. They were simply never printed anywhere a person passes through. `preset list` showed neither, and the CLI's human output for a successful command prints only its summary line.

This makes the completion contract visible before work starts. `preset list` now shows each valid preset's default profile, output shape, and completion gates. `task create` shows the resolved preset and profile, the output shape, and the gates, in both JSON and human output, and for a `repository-diff` preset it prints one contract sentence naming the `task-package-artifact` alternative.

The keying is on `outputShape`, not on work kind. The incident task's `workKind` was `fix`, so a rule conditioned on `docs` or `chore` would have missed the very case that motivated this work.

## What Changed

- `packages/preset/src/preset-discovery.ts`: valid catalog entries carry the manifest's `outputShape` and the default profile's declared `completionGates`. Invalid entries keep their existing error shape.
- `packages/daemon/src/repo-cell-types.ts` and `repo-cell-task-create.ts`: `TaskCreateReceipt` gains `presetId`, `profileId`, and `outputShape`, copied directly from the compiled snapshot. No derivation function and no conditional tree.
- `packages/cli/src/index.ts`: JSON output serializes the receipt unchanged; human output shows preset/profile, output shape, and gates, and prints the contract sentence only when the receipt already resolved to `repository-diff`.
- `packages/cli/src/cli/thin-command.ts`: `renderPresetHelpEntry` shows default profile, output shape, and gates for valid recommendations. No other production path in that file changes.
- Tests: `thin-command.test.ts` covers help, `preset list`, and create-receipt output byte for byte, and proves a replayed receipt missing the resolved fields still takes the old summary path. `task-closeout-docs-ci.integration.test.ts` adds real-CLI assertions through the isolated dispatcher.

Nothing is deleted, and that is stated deliberately rather than papered over: this change projects an existing truth onto a path people already walk. It replaces no creation or closeout mechanism, so there is no superseded production path to remove.

## Machine-Readable Declarations

Production-Delta: +81/-4

## Task And Scope

- Harness task: task_a18b1331199806c5e14c6760fb
- Branch: codex/preset-completion-gate
- Public scope: `packages/preset/src/preset-discovery.ts`, `packages/daemon/src/repo-cell-types.ts`, `packages/daemon/src/repo-cell-task-create.ts`, `packages/cli/src/index.ts`, `packages/cli/src/cli/thin-command.ts`, and two test files.
- Private planning/evidence updated: yes
- Out of scope: `completionGates` remains unamendable; `ciJudgmentIssue` is unchanged; closeout gains no diff-based applicability; no new CLI command, daemon action, or wire method.

## Version Impact

- Version: no version change because this adds display fields to existing command output.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none of the changed paths appear in any `protectedSurfaces` entry of `tools/gate-manifest.json`. The three gates that define the CLI command surface were read and run directly; none treats added result fields on existing commands as a new command surface.
- Authority: task_a18b1331199806c5e14c6760fb
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: cf2b15e54514c9a5fd115b10ce1404f369b985c8
- Branch merge-base with `origin/main`: cf2b15e54514c9a5fd115b10ce1404f369b985c8
- Last `git fetch origin` time: 2026-08-24, immediately before opening this PR.
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: the implementation report in the harness task package, not part of this public diff.
- Reviewer evidence path: same task package.
- GitHub Actions `rewrite-ci` run URL: see the checks on this PR.
- [x] `npm run check:local` (fast tier, green in 109.0s) — run by the reviewer against commit `4805e8c27` after the final commit, not taken from the implementer's report. The implementer ran individual steps rather than the full chain, so this receipt is the reviewer's.
- [x] `node tools/check-cli-help-contract.mjs`, `node tools/check-cli-structure.mjs`, `node tools/check-template-command-surface.mjs` — all exit 0.
- [x] The changed integration test was run through the isolated Ubuntu dispatcher: 1 test, 1 pass.
- Not run: full GitHub CI, the GUI job, the remaining integration shards, and Windows lanes were not run locally; cloud CI on this PR is the authority for those.

## Review Evidence

- Positive control: before accepting the integration evidence, the expected `outputShape` in the docs-task assertion was mutated to `mutation-must-fail`; the isolated Ubuntu run went red at that assertion reporting the real value `task-package-artifact`, and passed again after the mutation was reverted. The assertion is therefore load-bearing rather than vacuously green.
- Both falsifications required before implementation were carried out against real reads, not assumptions. `TaskCreateReceipt` crosses JSON-RPC, but `repo.task.create` is not in `daemonGuiActionMethods`, so the closed GUI receipt validator never sees it and no fixture freezes its field set; adding fields needs no protocol version change. The three CLI-surface gates were read line by line and none defines added result fields on an existing command as a new command surface.
- Reviewer check on the one non-null assertion introduced: `listCatalog` uses `profiles.find(...)!.completionGates`, which would throw on a manifest whose `defaultProfile` names no profile. `packages/preset/src/preset.contract.ts:310` rejects exactly that manifest, and the branch only runs on decoded manifests, so the invariant is guaranteed by contract rather than by coincidence. No finding.
- Reviewer subagent: not used.
- Human review: pending.
- Blocking findings: none open.

## Residual Risk

- This is a soft prompt. An operator can still read the gates and pick the wrong preset anyway. The task's invariant was visibility before work starts, not mechanical prevention; a fail-closed deliverable-shape reconciliation at create time was considered and deferred, because it would add a public `task create` input and should not be escalated before a second real incident shows the prompt is insufficient.
- Receipts replayed from history without the resolved fields keep their original summary rather than recomputing from the current catalog. That is deliberate: recomputing would present today's catalog as the frozen preset the task was actually created from.
- The advisory architecture check was not run. It resolves public code from the canonical root and cannot observe a worker worktree, and the canonical tree currently holds unrelated uncommitted content. Marked unverified rather than substituted with a run against the wrong tree.

## References

- Task: task_a18b1331199806c5e14c6760fb
- Evidence: implementation report and options comparison in the task package
- Review: CEO checkpoint ruling in the same task package

---

# 中文

## 概要

一个只读调查任务被归档,却从未到达 `done`,原因是它用 `standard-task` preset 创建。该 preset 声明 `outputShape: repository-diff`,因而携带 `ci` 与 `code-doc-reconciliation` 两个完成门。这个任务产出的是一份报告、没有代码,所以 `ci` 在结构上不可能满足,而 `completionGates` 不是可修改字段。归档事件把根因写得很清楚:本该选 `docs-task`。

这个错配只在收口时才暴露。而避免它所需的一切在创建时就已存在:解析出来的 preset snapshot 带着 `profile.outputShape` 与 `completionGateIds`,create receipt 里也早就有 gates。它们只是从未被打印到任何人必经的地方——`preset list` 两样都不显示,而 CLI 对成功命令的人类输出只打印一行 summary。

本 PR 让完成契约在开工前显形。`preset list` 现在展示每个有效 preset 的 default profile、output shape 与完成门。`task create` 在 JSON 与人类输出里都展示解析出的 preset/profile、output shape 与 gates,并且当 preset 是 `repository-diff` 时打印一句契约说明,点名 `task-package-artifact` 的替代项。

判据是 `outputShape`,不是 work kind。那个事故任务的 `workKind` 是 `fix`,所以按 `docs`/`chore` 设条件的规则,恰好会漏掉催生这项工作的那个案例本身。

## 改动内容

- `packages/preset/src/preset-discovery.ts`:有效 catalog 项携带 manifest 的 `outputShape` 与 default profile 已声明的 `completionGates`;无效项保持原有错误形状。
- `packages/daemon/src/repo-cell-types.ts` 与 `repo-cell-task-create.ts`:`TaskCreateReceipt` 增加 `presetId`、`profileId`、`outputShape`,直接从已编译的 snapshot 复制。没有推导函数,也没有条件树。
- `packages/cli/src/index.ts`:JSON 输出原样序列化 receipt;人类输出展示 preset/profile、output shape 与 gates,并且只在 receipt 已解析为 `repository-diff` 时打印那句契约说明。
- `packages/cli/src/cli/thin-command.ts`:`renderPresetHelpEntry` 为有效推荐项显示 default profile、output shape 与 gates。该文件其他生产路径未改。
- 测试:`thin-command.test.ts` 逐字节覆盖 help、`preset list` 与 create receipt 输出,并证明缺少解析字段的历史回放回执仍走旧 summary 路径。`task-closeout-docs-ci.integration.test.ts` 通过隔离派测器增加真实 CLI 断言。

**没有任何删除,而且这一点是刻意写明而不是掩饰过去的**:本改动是把一个已经存在的真相投影到人已经走过的路径上。它没有替换任何创建或收口机制,因此不存在被取代的旧生产路径需要移除。

## 任务与范围

- Harness 任务:task_a18b1331199806c5e14c6760fb
- 分支:codex/preset-completion-gate
- 公开范围:`packages/preset/src/preset-discovery.ts`、`packages/daemon/src/repo-cell-types.ts`、`packages/daemon/src/repo-cell-task-create.ts`、`packages/cli/src/index.ts`、`packages/cli/src/cli/thin-command.ts` 与两个测试文件。
- 私有计划 / 证据是否已更新:yes
- 范围外:`completionGates` 仍不可修改;`ciJudgmentIssue` 未改;closeout 不增加基于 diff 的适用性判断;不新增 CLI 命令、daemon 动作或 wire 方法。

## 版本影响

- 版本:不改版本,原因是这是给既有命令输出增加展示字段。
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:改动路径没有一个出现在 `tools/gate-manifest.json` 的任何 `protectedSurfaces` 条目里。定义 CLI 命令面的三个门都被逐行读过并实跑,没有一个把「给既有命令的结果增加字段」定义为新增命令面。
- 依据:task_a18b1331199806c5e14c6760fb
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no

## 验证

- `origin/main` 基准 SHA:cf2b15e54514c9a5fd115b10ce1404f369b985c8
- 当前分支与 `origin/main` 的 merge-base:cf2b15e54514c9a5fd115b10ce1404f369b985c8
- 最近一次 `git fetch origin` 时间:2026-08-24,开 PR 前刚取。
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:任务包内的实现报告,不在本公开 diff 内。
- Reviewer 证据路径:同一任务包。
- GitHub Actions `rewrite-ci` run URL:见本 PR 的 checks。
- [x] `npm run check:local`(fast tier,109.0 秒全绿)——由复核方在最终提交之后针对 commit `4805e8c27` 自己跑的,不是取自实现方的报告。实现方跑的是其中几个单步而非完整链条,所以这条回执归复核方。
- [x] `node tools/check-cli-help-contract.mjs`、`node tools/check-cli-structure.mjs`、`node tools/check-template-command-surface.mjs`——均 exit 0。
- [x] 被改的集成测试通过隔离 Ubuntu 派测器跑过:1 条测试,1 条通过。
- 未运行:完整 GitHub CI、GUI job、其余 integration shard 与 Windows lane 本地都没跑;这些以本 PR 的云端 CI 为权威。

## 审查证据

- 阳性对照:在采信集成证据之前,把 docs-task 断言里预期的 `outputShape` 变异成 `mutation-must-fail`;隔离 Ubuntu 运行在该断言处变红并报出真实值 `task-package-artifact`,恢复变异后再次通过。因此该断言是承重的,不是空绿。
- 实现前要求的两项证伪都是用实读完成的,不是假设。`TaskCreateReceipt` 确实跨 JSON-RPC,但 `repo.task.create` 不在 `daemonGuiActionMethods` 里,闭合的 GUI receipt 校验器根本看不到它,也没有任何 fixture 冻结它的字段集;加字段不需要改协议版本。三个 CLI 命令面的门逐行读过,没有一个把「给既有命令的结果加字段」定义为新增命令面。
- 复核方对新引入的那个非空断言做了独立核查:`listCatalog` 用了 `profiles.find(...)!.completionGates`,若某个 manifest 的 `defaultProfile` 指向不存在的 profile 就会抛异常。`packages/preset/src/preset.contract.ts:310` 恰好拒绝这种 manifest,且该分支只对已解码的 manifest 执行,所以这个不变量由契约保证而非巧合。不构成 finding。
- Reviewer subagent:未使用。
- 人工审查:待进行。
- 阻塞发现:无。

## 残余风险

- 这是软提示。操作者仍然可以看完门之后照样选错 preset。本任务的不变量是「开工前显形」,不是机械阻止;创建期显式声明交付形状并 fail-closed 对账的方案已被考虑并延后,因为它会给 `task create` 增加一个公共输入,不该在第二个真实事故证明软提示不足之前升格。
- 从历史回放、缺少解析字段的回执保留原 summary,不从当前 catalog 重算。这是刻意的:重算会把今天的 catalog 冒充成该任务当初实际使用的那个冻结 preset。
- advisory 架构检查未运行。它从 canonical root 解析公开代码,看不到 worker worktree,而 canonical 树当前有大量无关的未提交内容。此项标为未验证,而不是拿一次跑在错误树上的结果冒充。

## 关联材料

- 任务:task_a18b1331199806c5e14c6760fb
- 证据:任务包内的实现报告与方案对比
- 审查:同一任务包内的 CEO checkpoint 裁决书
