### PR TITLE
fix(daemon): close the four remote-edge usability gaps (U17-U20)

### DIFF
--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -568,6 +568,7 @@ async function fleetEdgeRegistration(
 // compare→push/pull fleet round, and the three conflict exits become fleet
 // conflict-exit rounds. Everything else keeps its local receipt path.
 const fleetDocSyncKinds = new Map([
+  ["doc-status", { method: "daemon.fleet.doc.sync", dryRun: true }],
   ["doc-dry-run", { method: "daemon.fleet.doc.sync", dryRun: true }],
   ["doc-submit", { method: "daemon.fleet.doc.sync", dryRun: false }],
   ["doc-conflict-resolve", { method: "daemon.fleet.conflict.exit", action: "resolve" }],

--- a/packages/cli/test/daemon-fleet-cli.test.ts
+++ b/packages/cli/test/daemon-fleet-cli.test.ts
@@ -27,6 +27,7 @@ test("fleet center start and edge sync mirror the authoritative ledger through t
     const center = run(fixture, "center", ["daemon", "fleet", "center", "start", "--port", "0", "--key", fixture.key, "--cert", fixture.cert, "--roster", fixture.roster, "--quota-bytes", String(quotaBytes)]);
     assert.equal(center.ok, true); assert.equal(center.bind, "127.0.0.1"); assert.equal(center.stateRoot, path.join(fixture.centerUser, "fleet")); assert.equal(center.nodes, 1); assert.equal(center.assignments, 1);
     const port = center.port as number;
+    writeFileSync(path.join(fixture.edgeRepo, "fleet-edge.json"), JSON.stringify({ schema: "fleet-edge-config/v1", repoId: "fleet-demo", host: "127.0.0.1", port, caPath: fixture.ca, nodeId: "edge-one", rosterPath: fixture.roster, assignmentId: "assignment-edge-one", viewRoot: fixture.viewRoot, quotaBytes }));
     assert.equal(run(fixture, "edge", ["daemon", "start", "--service"]).ok, true);
     assert.equal(run(fixture, "edge", ["daemon", "repo", "register", "--repo-id", "fleet-demo", "--root", fixture.edgeRepo, "--mode", "remote-edge"]).ok, true);
     const syncArgs = ["daemon", "fleet", "edge", "sync", "--host", "127.0.0.1", "--port", String(port), "--ca", fixture.ca, "--node-id", "edge-one", "--roster", fixture.roster, "--assignment", "assignment-edge-one", "--view-root", fixture.viewRoot, "--quota-bytes", String(quotaBytes)] as const;
@@ -42,6 +43,10 @@ test("fleet center start and edge sync mirror the authoritative ledger through t
     assert.equal(readFileSync(path.join(fixture.edgeRepo, "harness", docPath), "utf8"), docBody, "sync materializes the registered workspace path");
     assert.equal(existsSync(path.join(viewRoot, "worktree")), false, "the daemon-internal view worktree no longer exists");
     assert.equal(readFileSync(path.join(fixture.edgeRepo, ".git", "HEAD"), "utf8"), edgeGitHead, "materialization leaves workspace Git metadata untouched");
+    const shown = run(fixture, "edge", ["task", "show", "task-fleet"]);
+    assert.equal(shown.revision, pulled.ackCut); assert.doesNotMatch(String(shown.summary), /task=null/u);
+    const status = run(fixture, "edge", ["doc", "status", "--path", docPath]);
+    assert.equal((status.cut as { revision: number }).revision, pulled.ackCut); assert.deepEqual(status.rows, []);
     const current = JSON.parse(readFileSync(path.join(viewRoot, "current.json"), "utf8")) as { cut: { revision: number } };
     assert.equal(current.cut.revision, pulled.ackCut);
     stop(fixture, "edge"); assert.equal(run(fixture, "edge", ["daemon", "start", "--service"]).ok, true);

--- a/packages/cli/test/fleet-task-route.test.ts
+++ b/packages/cli/test/fleet-task-route.test.ts
@@ -4,7 +4,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { fleetRuntimeRoute, fleetTaskRoute } from "../src/daemon/client.ts";
+import { fleetDocRoute, fleetRuntimeRoute, fleetTaskRoute } from "../src/daemon/client.ts";
 
 test("fleet task routing requires both edge config and remote-edge registry mode", async (t) => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-fleet-task-route-")), userRoot = path.join(root, "user");
@@ -22,6 +22,9 @@ test("fleet task routing requires both edge config and remote-edge registry mode
   registry("remote-edge");
   const routed = await fleetTaskRoute(command("repo.task.run", { kind: "task-start", verb: "start", commandType: "StartExecution", taskId: "task_one" }), env);
   assert.deepEqual(routed?.action, { kind: "task-start", taskId: "task_one" });
+  assert.deepEqual((await fleetTaskRoute(command("repo.task.run", { kind: "task-show", taskId: "task_one" }), env))?.action, { kind: "task-show", taskId: "task_one" });
+  const docStatus = await fleetDocRoute(command("repo.task.run", { kind: "doc-status", paths: ["context/notes.md"] }), env);
+  assert.equal(docStatus?.method, "daemon.fleet.doc.sync"); assert.equal(docStatus?.payload.dryRun, true); assert.deepEqual(docStatus?.payload.paths, ["context/notes.md"]);
   const child = path.join(root, "worktrees", "nested"); mkdirSync(child, { recursive: true });
   const childRouted = await fleetTaskRoute(command("repo.task.run", { kind: "task-progress-append", taskId: "task_one", executionId: "execution_one", text: "nested cwd", evidence: [] }, child), env);
   assert.equal(childRouted?.workspaceRoot, root, "commands from descendants still materialize the registered workspace"); assert.deepEqual(childRouted?.action, { kind: "task-progress-append", taskId: "task_one", executionId: "execution_one", text: "nested cwd", evidence: [] });

--- a/packages/daemon/src/fleet-edge-runtime.ts
+++ b/packages/daemon/src/fleet-edge-runtime.ts
@@ -53,6 +53,47 @@ type RuntimePorts = {
     },
   ) => Promise<PreparedRuntimeLaunch>;
 };
+const runtimeOverviewPageLimit = 16;
+
+export async function readFleetRuntimeSessionsPaged(
+  readPage: (payload: JsonObject) => Promise<unknown>,
+): Promise<readonly {
+  readonly runtimeSessionId: string;
+  readonly providerSessionId: string | null;
+  readonly instanceId: string;
+  readonly liveness: "live" | "stale" | "unknown" | "exited";
+  readonly outcome: "succeeded" | "failed" | "unknown" | "cancelled" | null;
+}[]> {
+  const sessions: Array<{
+    readonly runtimeSessionId: string;
+    readonly providerSessionId: string | null;
+    readonly instanceId: string;
+    readonly liveness: "live" | "stale" | "unknown" | "exited";
+    readonly outcome: "succeeded" | "failed" | "unknown" | "cancelled" | null;
+  }> = [];
+  const seen = new Set<string>();
+  let cursor: string | null = null;
+  do {
+    const result = await readPage({ limit: runtimeOverviewPageLimit, ...(cursor === null ? {} : { cursor }) });
+    const issues = validateAgentRuntimeOverview(result);
+    if (issues.length) throw edgeRuntimeError("runtime_read_invalid", issues.join("; "));
+    const overview = result as AgentRuntimeOverviewResult;
+    if (!overview.page)
+      throw edgeRuntimeError("runtime_read_invalid", "A paged runtime overview omitted its page receipt.");
+    sessions.push(...overview.sessions.map(({
+      runtimeSessionId,
+      providerSessionId,
+      instanceId,
+      liveness,
+      activity,
+    }) => ({ runtimeSessionId, providerSessionId, instanceId, liveness, outcome: activity.outcome })));
+    cursor = overview.page.nextCursor;
+    if (cursor !== null && seen.has(cursor))
+      throw edgeRuntimeError("runtime_read_invalid", `Runtime overview repeated cursor ${cursor}.`);
+    if (cursor !== null) seen.add(cursor);
+  } while (cursor !== null);
+  return sessions;
+}
 
 export function openFleetEdgeRuntime(input: {
   readonly request: FleetEdgeRuntimeRequest["payload"];
@@ -149,25 +190,15 @@ export function openFleetEdgeRuntime(input: {
           mission: `Your task package is ${packageRoot}.\nRead task_plan.md in that package and complete the task.`,
         };
       },
-      readRuntimeSessions: async () => {
-        const result = await runFleetRuntimeReadClient({
-          ...peer,
-          repoId: request.repoId,
-          method: "repo.agentRuntime.overview",
-          payload: {},
-        });
-        const issues = validateAgentRuntimeOverview(result);
-        if (issues.length) throw edgeRuntimeError("runtime_read_invalid", issues.join("; "));
-        return (result as AgentRuntimeOverviewResult).sessions.map(
-          ({ runtimeSessionId, providerSessionId, instanceId, liveness, activity }) => ({
-            runtimeSessionId,
-            providerSessionId,
-            instanceId,
-            liveness,
-            outcome: activity.outcome,
+      readRuntimeSessions: () =>
+        readFleetRuntimeSessionsPaged((payload) =>
+          runFleetRuntimeReadClient({
+            ...peer,
+            repoId: request.repoId,
+            method: "repo.agentRuntime.overview",
+            payload,
           }),
-        );
-      },
+        ),
       publish: async (draft) => {
         const response = await runFleetRuntimeEventClient({
           ...peer,

--- a/packages/daemon/src/fleet-edge-task.ts
+++ b/packages/daemon/src/fleet-edge-task.ts
@@ -126,6 +126,7 @@ export async function runFleetEdgeTask(input: FleetEdgeTaskRequest): Promise<Rec
   const payload = input.payload,
     action = payload.action,
     timers = fleetLeaseTimers();
+  const readOnly = action.kind === "task-show";
   const credential = fleetEdgeCredential(payload.nodeId, payload.credential, payload.rosterPath);
   const taskId = typeof action.taskId === "string" ? action.taskId : null;
   const waitMs =
@@ -151,7 +152,7 @@ export async function runFleetEdgeTask(input: FleetEdgeTaskRequest): Promise<Rec
     // The unresolved-conflict gate (design §4): while this task's package has a
     // staged, unhandled divergence, its transitions stay blocked — the edge
     // refuses before any upload or center round-trip.
-    if (workspaceRoot !== null && taskId !== null && action.kind !== "task-create") {
+    if (!readOnly && workspaceRoot !== null && taskId !== null && action.kind !== "task-create") {
       const view = locateFleetMirrorView(payload.viewRoot, payload.repoId);
       const exactPackage = view === null ? null : fleetExactTaskPackagePath(view, workspaceRoot, taskId);
       const belongs = (conflictPath: string): boolean =>
@@ -178,7 +179,7 @@ export async function runFleetEdgeTask(input: FleetEdgeTaskRequest): Promise<Rec
           },
         } as Record<string, unknown>;
     }
-    const bundle = await attachTaskDocs();
+    const bundle = readOnly ? null : await attachTaskDocs();
     const deadline = Date.now() + waitMs + 30_000 + (bundle === null ? 0 : 60_000);
     let result: Awaited<ReturnType<typeof runFleetTaskCommandClient>> | null = null,
       attempt = 0;
@@ -217,7 +218,7 @@ export async function runFleetEdgeTask(input: FleetEdgeTaskRequest): Promise<Rec
     // Any center effect (applied) and any content conflict both end in a pull:
     // applied commands must land in the mirror, and a rejected bundle needs the
     // center bytes staged beside the local ones for the explicit exits.
-    if (applied || conflictCode !== null) {
+    if (!readOnly && (applied || conflictCode !== null)) {
       try {
         const pulled = await runFleetReplicaPullClient({
           ...peer,

--- a/packages/daemon/src/fleet/contract.ts
+++ b/packages/daemon/src/fleet/contract.ts
@@ -20,6 +20,7 @@ export const FLEET_TASK_COMMAND_KINDS = Object.freeze([
   "task-progress-append",
   "task-submit",
   "task-release",
+  "task-show",
 ] as const);
 export type FleetTaskCommandKind = (typeof FLEET_TASK_COMMAND_KINDS)[number];
 export type FleetTaskAction = Readonly<Record<string, unknown>> & { readonly kind: FleetTaskCommandKind };
@@ -349,6 +350,7 @@ const taskActionShapes: Readonly<Record<FleetTaskCommandKind, Check>> = {
   ),
   "task-submit": optionalShape({ kind: one("task-submit"), taskId: id, executionId: id, submission: record }, ["kind"]),
   "task-release": optionalShape({ kind: one("task-release"), taskId: id, reason: text }, ["kind"]),
+  "task-show": optionalShape({ kind: one("task-show"), taskId: id }, ["kind", "taskId"]),
 };
 const taskAction: Check = (value) =>
   record(value) &&

--- a/packages/daemon/src/lease-broker.ts
+++ b/packages/daemon/src/lease-broker.ts
@@ -539,7 +539,7 @@ export function openFleetLeaseBroker(options: {
         ...failure(
           "op_rejected",
           "task_command_rejected",
-          "The fleet task channel accepts task-create, task-start, task-progress-append, task-submit, and task-release only.",
+          "The fleet task channel accepts its closed task command set only.",
         ),
         opId: frame.opId,
       };
@@ -554,6 +554,28 @@ export function openFleetLeaseBroker(options: {
         ),
         opId: frame.opId,
       };
+    if (kind === "task-show") {
+      if (taskId !== assignment.taskId || frame.docChanges !== null || frame.mirrorBaseCut !== null)
+        return {
+          ...failure(
+            "op_rejected",
+            "assignment_scope_mismatch",
+            "Fleet task reads must select the authenticated assignment task without document writes.",
+          ),
+          opId: frame.opId,
+        };
+      const receipt = await options.host.run(assignment.repoId, action, auth(assignment));
+      const record = receipt as unknown as Record<string, unknown>;
+      return {
+        outcome: receipt.outcome === "applied" ? "applied" : "op_rejected",
+        opId: frame.opId,
+        code: receipt.code ?? null,
+        revision: receipt.revision ?? null,
+        receipt: receiptPayload(record),
+        lease: null,
+        queuePosition: null,
+      };
+    }
     const docs =
       frame.docChanges !== null || frame.mirrorBaseCut !== null
         ? { docChanges: frame.docChanges, mirrorBaseCut: frame.mirrorBaseCut }

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -250,9 +250,12 @@ export function createJsonRpcProtocolServer(options: {
           fleetAction = fleetPayload.action;
         if (isJsonObject(fleetAction) && fleetAction.kind === "fleet-runtime") {
           if (
-            !["repo.agentRuntime.spawn", "repo.agentRuntime.cancel", "repo.agentRuntime.sessions.read"].includes(
-              String(fleetAction.method),
-            ) ||
+            ![
+              "repo.agentRuntime.spawn",
+              "repo.agentRuntime.cancel",
+              "repo.agentRuntime.overview",
+              "repo.agentRuntime.sessions.read",
+            ].includes(String(fleetAction.method)) ||
             !isJsonObject(fleetAction.payload)
           )
             throw Object.assign(new Error("Fleet runtime envelope must carry one closed runtime method and payload."), {

--- a/packages/daemon/src/runtime-spawn-adoption.ts
+++ b/packages/daemon/src/runtime-spawn-adoption.ts
@@ -6,6 +6,7 @@ import {
 } from "./dispatch-stream.ts";
 import { createActiveRuntime, attachActiveRuntime } from "./runtime-spawn-active.ts";
 import { adoptNativeProcess, runtimePidIsAlive } from "./runtime-spawn-process.ts";
+import { durableOutputRecordCount, restoreDurableOutputRecords } from "./runtime-spawn-provider-stream.ts";
 import type { RuntimeBinding } from "./runtime-spawn-types.ts";
 import type { RuntimePermissionMode } from "./runtime-permissions.ts";
 
@@ -26,6 +27,7 @@ export async function adoptRuntimes(context: any): Promise<void> {
       context.input.rootDir,
       stream.header.dispatchId,
       stream.process.pid,
+      durableOutputRecordCount(stream.records),
     );
     const active = createActiveRuntime({
       process: runtimeProcess,
@@ -61,6 +63,7 @@ export async function adoptRuntimes(context: any): Promise<void> {
       providerSessionId: stream.providerSessionId,
     });
     context.processes.set(active.runtimeSessionId, active);
+    await restoreDurableOutputRecords(context, active, stream.records);
     if (session.liveness !== "live") {
       await context.publishRuntimeEvent(
         "runtime_session_liveness_changed",

--- a/packages/daemon/src/runtime-spawn-control.ts
+++ b/packages/daemon/src/runtime-spawn-control.ts
@@ -20,7 +20,8 @@ export async function cancelRuntime(context: any, payload: JsonObject, binding: 
     active.cancelOpId = opId;
     active.cancelRequested = true;
     await consumeDurableOutput(context, active, cancelDurableDrainTimeoutMs);
-    active.process.terminate();
+    if (active.process.terminateTree) await active.process.terminateTree();
+    else active.process.terminate();
     await context.publishExit(active, null);
     return context.controlReceipt(opId, runtimeSessionId);
   }

--- a/packages/daemon/src/runtime-spawn-process.ts
+++ b/packages/daemon/src/runtime-spawn-process.ts
@@ -2,6 +2,7 @@ import { spawn,
   /* @gate-identity check-sync-subprocess/sync-subprocess-010 */
   spawnSync } from "node:child_process";
 import { StringDecoder } from "node:string_decoder";
+import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import type { CanonicalEventStore, TaskProjection } from "../../kernel/src/index.ts";
 import { consumeKnownError } from "../../kernel/src/index.ts";
@@ -16,6 +17,7 @@ import { runtimeSpawnError } from "./runtime-spawn-errors.ts";
 import { parseProviderFrame } from "./runtime-spawn-provider-frames.ts";
 import type { ResumeProcessEvent, ResumeProcessObservation, RuntimeProcess } from "./runtime-spawn-types.ts";
 import { exitNotificationTimeoutMs, providerErrorLimit, resumeAdmissionTimeoutMs } from "./runtime-spawner.ts";
+import { runProcessTextAsync } from "./process-port.ts";
 
 export function requiredRuntimeStore(input: { readonly store?: () => CanonicalEventStore }): CanonicalEventStore {
   if (!input.store)
@@ -160,6 +162,108 @@ export function terminateRuntimePid(pid: number): void {
     if (childProcessErrorCode(error) !== "ESRCH") throw error;
     consumeKnownError(error);
   }
+}
+
+type PosixProcessRow = {
+  readonly pid: number;
+  readonly parentPid: number;
+  readonly processGroupId: number;
+  readonly state: string;
+};
+
+async function readPosixProcessRows(): Promise<readonly PosixProcessRow[]> {
+  const output = await runProcessTextAsync("ps", ["-axo", "pid=,ppid=,pgid=,stat="]);
+  return output.split(/\r?\n/u).flatMap((line) => {
+    const match = /^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\S+)/u.exec(line);
+    if (!match) return [];
+    return [{ pid: Number(match[1]), parentPid: Number(match[2]), processGroupId: Number(match[3]), state: match[4]! }];
+  });
+}
+
+function descendantProcessRows(rows: readonly PosixProcessRow[], rootPid: number): readonly PosixProcessRow[] {
+  const selected = new Set([rootPid]);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const row of rows) if (!selected.has(row.pid) && selected.has(row.parentPid)) {
+      selected.add(row.pid);
+      changed = true;
+    }
+  }
+  return rows.filter((row) => selected.has(row.pid));
+}
+
+function signalRuntimeTargets(
+  rows: readonly PosixProcessRow[],
+  rootPid: number,
+  ownProcessGroupId: number | null,
+  signal: NodeJS.Signals,
+): void {
+  const groups = [...new Set(rows.map(({ processGroupId }) => processGroupId).filter((group) => group > 0))]
+    .sort((left, right) => Number(left === rootPid) - Number(right === rootPid));
+  for (const processGroupId of groups) {
+    if (processGroupId === ownProcessGroupId) continue;
+    try { process.kill(-processGroupId, signal); }
+    catch (error) { if (childProcessErrorCode(error) !== "ESRCH") throw error; consumeKnownError(error); }
+  }
+  if (groups.includes(ownProcessGroupId ?? -1)) for (const { pid } of rows) {
+    if (pid === process.pid) continue;
+    try { process.kill(pid, signal); }
+    catch (error) { if (childProcessErrorCode(error) !== "ESRCH") throw error; consumeKnownError(error); }
+  }
+}
+
+async function survivingRuntimePids(pids: readonly number[]): Promise<readonly number[]> {
+  const wanted = new Set(pids), rows = await readPosixProcessRows();
+  return rows.filter(({ pid, state }) => wanted.has(pid) && !state.startsWith("Z")).map(({ pid }) => pid);
+}
+
+async function awaitRuntimeProcessExit(pids: readonly number[], timeoutMs: number): Promise<readonly number[]> {
+  const deadline = Date.now() + timeoutMs;
+  let survivors = await survivingRuntimePids(pids);
+  while (survivors.length > 0 && Date.now() < deadline) {
+    await delay(Math.min(25, Math.max(1, deadline - Date.now())));
+    survivors = await survivingRuntimePids(pids);
+  }
+  return survivors;
+}
+
+export async function terminateRuntimeTree(rootDir: string, dispatchId: string, rootPid: number): Promise<void> {
+  if (!Number.isInteger(rootPid) || rootPid < 1) return;
+  if (process.platform === "win32") {
+    terminateRuntimePid(rootPid);
+    return;
+  }
+  let allRows: readonly PosixProcessRow[];
+  try { allRows = await readPosixProcessRows(); }
+  catch (error) { consumeKnownError(error); terminateRuntimePid(rootPid); return; }
+  const rows = descendantProcessRows(allRows, rootPid), pids = rows.map(({ pid }) => pid),
+    processGroupIds = [...new Set(rows.map(({ processGroupId }) => processGroupId))]
+      .sort((left, right) => left - right),
+    ownProcessGroupId = allRows.find(({ pid }) => pid === process.pid)?.processGroupId ?? null;
+  appendRuntimeWorkerRecord(rootDir, dispatchId, {
+    kind: "process_descendants",
+    occurredAt: new Date().toISOString(),
+    rootPid,
+    pids,
+    processGroupIds,
+  });
+  signalRuntimeTargets(rows, rootPid, ownProcessGroupId, "SIGTERM");
+  let survivors = await awaitRuntimeProcessExit(pids, 500);
+  if (survivors.length > 0) {
+    signalRuntimeTargets(rows.filter(({ pid }) => survivors.includes(pid)), rootPid, ownProcessGroupId, "SIGKILL");
+    survivors = await awaitRuntimeProcessExit(pids, 500);
+  }
+  appendRuntimeWorkerRecord(rootDir, dispatchId, {
+    kind: "process_descendants_terminated",
+    occurredAt: new Date().toISOString(),
+    rootPid,
+    survivorPids: survivors,
+  });
+  if (survivors.length > 0) throw runtimeSpawnError(
+    "runtime_cancel_failed",
+    `Runtime cancel left descendant processes alive: ${survivors.join(", ")}.`,
+  );
 }
 
 export function runtimePidIsAlive(pid: number): boolean {
@@ -323,15 +427,26 @@ export function launchNative(
   return observed;
 }
 
-export function adoptNativeProcess(rootDir: string, dispatchId: string, pid: number): RuntimeProcess {
-  return observeDispatchProcess(rootDir, dispatchId, pid);
+export function adoptNativeProcess(
+  rootDir: string,
+  dispatchId: string,
+  pid: number,
+  skipPersistedOutputRecords = 0,
+): RuntimeProcess {
+  return observeDispatchProcess(rootDir, dispatchId, pid, skipPersistedOutputRecords);
 }
 
-function observeDispatchProcess(rootDir: string, dispatchId: string, pid: number): RuntimeProcess {
+function observeDispatchProcess(
+  rootDir: string,
+  dispatchId: string,
+  pid: number,
+  skipPersistedOutputRecords = 0,
+): RuntimeProcess {
   const outputs: Array<{ readonly chunk: string; readonly persisted: boolean }> = [];
   const errors: string[] = [];
   const decoder = new StringDecoder("utf8");
   let offset = 0;
+  let skippedOutputRecords = 0;
   let buffer = "";
   let outputListener: ((chunk: string, persisted?: boolean) => void) | null = null;
   let errorListener: ((chunk: string) => void) | null = null;
@@ -364,8 +479,14 @@ function observeDispatchProcess(rootDir: string, dispatchId: string, pid: number
       buffer = lines.pop() ?? "";
       for (const line of lines) {
         const record = parseDispatchProcessRecord(line);
-        if (record?.kind === "provider_event") emitOutput(`${JSON.stringify(record.event)}\n`);
-        else if (record?.kind === "provider_output_invalid") emitOutput(`${String(record.output)}\n`);
+        if (record?.kind === "provider_event") {
+          if (skippedOutputRecords < skipPersistedOutputRecords) skippedOutputRecords += 1;
+          else emitOutput(`${JSON.stringify(record.event)}\n`);
+        }
+        else if (record?.kind === "provider_output_invalid") {
+          if (skippedOutputRecords < skipPersistedOutputRecords) skippedOutputRecords += 1;
+          else emitOutput(`${String(record.output)}\n`);
+        }
         else if (record?.kind === "provider_stderr") emitError(String(record.chunk));
         else if (record?.kind === "process_exit") {
           emitExit(Number.isInteger(record.exitCode) ? Number(record.exitCode) : null);
@@ -393,6 +514,7 @@ function observeDispatchProcess(rootDir: string, dispatchId: string, pid: number
       if (exited) queueMicrotask(() => listener(exitCode));
     },
     terminate: () => terminateRuntimePid(pid),
+    terminateTree: () => terminateRuntimeTree(rootDir, dispatchId, pid),
     release: () => {
       released = true;
       clearInterval(timer);

--- a/packages/daemon/src/runtime-spawn-provider-stream.ts
+++ b/packages/daemon/src/runtime-spawn-provider-stream.ts
@@ -79,6 +79,7 @@ export async function consumeProviderLine(
   active: ActiveRuntime,
   line: string,
   persisted = false,
+  publishSignals = true,
 ): Promise<void> {
   let value: unknown;
   try {
@@ -100,7 +101,8 @@ export async function consumeProviderLine(
     return;
   }
   if (parsed.sessionIdentity?.sessionId) await context.bindProvider(active, parsed.sessionIdentity);
-  for (const signal of parsed.signals ?? []) context.input.stream.publish(active.runtimeSessionId, signal);
+  if (publishSignals)
+    for (const signal of parsed.signals ?? []) context.input.stream.publish(active.runtimeSessionId, signal);
   if (parsed.finalText !== undefined) active.finalText = parsed.finalText;
   if (parsed.failureText !== undefined) active.failureText = parsed.failureText;
   if (parsed.outcome) active.providerOutcome = parsed.outcome;
@@ -131,6 +133,27 @@ export async function consumeDurableOutput(
       true,
     );
   }
+}
+
+export async function restoreDurableOutputRecords(
+  context: any,
+  active: ActiveRuntime,
+  records: readonly Record<string, unknown>[],
+): Promise<number> {
+  const durable = durableOutputRecords(records);
+  for (const record of durable) {
+    await context.consumeLine(
+      active,
+      record.kind === "provider_event" ? JSON.stringify(record.event) : String(record.output),
+      true,
+      false,
+    );
+  }
+  return durable.length;
+}
+
+export function durableOutputRecordCount(records: readonly Record<string, unknown>[]): number {
+  return durableOutputRecords(records).length;
 }
 
 function durableOutputRecords(

--- a/packages/daemon/src/runtime-spawn-types.ts
+++ b/packages/daemon/src/runtime-spawn-types.ts
@@ -20,6 +20,7 @@ export interface RuntimeProcess {
   readonly onErrorOutput: (listener: (chunk: string) => void) => void;
   readonly onExit: (listener: (code: number | null) => void) => void;
   readonly terminate: () => void;
+  readonly terminateTree?: () => Promise<void>;
   readonly release?: () => void;
 }
 

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -536,8 +536,13 @@ export function makeRuntimeSpawner(input: {
   async function consumeChunk(active: ActiveRuntime, chunk: string, flush: boolean, persisted = false): Promise<void> {
     return consumeProviderChunk(extracted, active, chunk, flush, persisted);
   }
-  async function consumeLine(active: ActiveRuntime, line: string, persisted = false): Promise<void> {
-    return consumeProviderLine(extracted, active, line, persisted);
+  async function consumeLine(
+    active: ActiveRuntime,
+    line: string,
+    persisted = false,
+    publishSignals = true,
+  ): Promise<void> {
+    return consumeProviderLine(extracted, active, line, persisted, publishSignals);
   }
   function captureErrorOutput(active: ActiveRuntime, chunk: string): void {
     return captureErrorOutputImpl(extracted, active, chunk);

--- a/packages/daemon/test/agent-runtime-slice-b.test.ts
+++ b/packages/daemon/test/agent-runtime-slice-b.test.ts
@@ -8,6 +8,7 @@ import test from "node:test";
 import { eventObjectTarget, makeTaskEventStore, makeTaskProjection, type AgentDefinitionSnapshot, type AgentRuntimeEventV1, type FrozenWritePlan, type RuntimeSession } from "../../kernel/src/index.ts";
 import { makeAgentRuntimeReadModel } from "../src/agent-runtime-read.ts"; import { validateAgentRuntimeOverview } from "../src/agent-runtime-contract.ts";
 import { makeAgentRuntimeStreamHub } from "../src/agent-runtime-stream.ts";
+import { readFleetRuntimeSessionsPaged } from "../src/fleet-edge-runtime.ts";
 import { daemonGuiReadMethods, daemonGuiStreamFacets, jsonRpcMethodContracts, validateDaemonRpcCall, validateDaemonTaskDispatches } from "../src/protocol/daemon-protocol.contract.ts";
 import { parseDaemonGuiReadResult } from "../src/protocol/gui-result-validation.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts"; import { openRepoCell } from "../src/repo-cell.ts";
@@ -35,6 +36,24 @@ test("runtime overview pages at the server before DTO and dispatch expansion", (
   const rows = Array.from({ length: 12 }, (_, index) => ({ ...session, runtimeSessionId: `runtime-${String(index).padStart(2, "0")}` })); let unboundedReads = 0, exactDispatchReads = 0, pageQuery: unknown;
   const measured = new Proxy(projection, { get: (target, property, receiver) => { if (property === "readRuntimeSessions") return () => { unboundedReads += 1; return [...rows, ...rows]; }; if (property === "readRuntimeSessionPage") return (query: unknown) => { pageQuery = query; return { rows, nextRuntimeSessionId: "runtime-11", remainingCount: 13 }; }; if (property === "readRuntimeDispatch") return (runtimeSessionId: string) => { exactDispatchReads += 1; return { ...dispatch(), payload: { ...dispatch().payload, runtimeSessionId } }; }; const value = Reflect.get(target, property, receiver); return typeof value === "function" ? value.bind(target) : value; } });
   const overview = makeAgentRuntimeReadModel({ store, projection: measured, stream }).overview({ limit: 12 }); assert.equal(overview.sessions.length, 12); assert.equal(unboundedReads, 0); assert.equal(exactDispatchReads, 12); assert.deepEqual(pageQuery, { limit: 12 }); assert.deepEqual(overview.page, { limit: 12, cursor: null, nextCursor: "runtime-session:runtime-11", remainingCount: 13 });
+}));
+
+test("fleet runtime adoption keeps every overview response below the negotiated frame ceiling", async (t) => withRuntime(async ({ store, projection, stream }) => {
+  const base = makeAgentRuntimeReadModel({ store, projection, stream }).overview({}), sessions = Array.from({ length: 192 }, (_, index) => ({ ...base.sessions[0]!, runtimeSessionId: `runtime-${String(index).padStart(4, "0")}-${"x".repeat(256)}` })),
+    unboundedBytes = Buffer.byteLength(JSON.stringify({ ...base, sessions })), payloads: Record<string, unknown>[] = [], responseBytes: number[] = [];
+  const selected = await readFleetRuntimeSessionsPaged(async (payload) => {
+    payloads.push(payload);
+    const cursor = typeof payload.cursor === "string" ? Number(payload.cursor.slice("page:".length)) : 0,
+      limit = Number(payload.limit), pageSessions = sessions.slice(cursor, cursor + limit), next = cursor + pageSessions.length,
+      response = { ...base, sessions: pageSessions, page: { limit, cursor: typeof payload.cursor === "string" ? payload.cursor : null, nextCursor: next < sessions.length ? `page:${next}` : null, remainingCount: Math.max(0, sessions.length - next) } };
+    responseBytes.push(Buffer.byteLength(JSON.stringify(response)));
+    return response;
+  });
+  assert.ok(unboundedBytes > 98_304, `unbounded overview measured ${unboundedBytes} bytes`);
+  assert.ok(Math.max(...responseBytes) < 98_304, `largest page measured ${Math.max(...responseBytes)} bytes`);
+  assert.equal(selected.length, sessions.length);
+  assert.deepEqual(payloads.slice(0, 2), [{ limit: 16 }, { limit: 16, cursor: "page:16" }]);
+  t.diagnostic(`overview bytes: unbounded=${unboundedBytes} maxPage=${Math.max(...responseBytes)} pages=${responseBytes.length}`);
 }));
 
 test("attach catches up from cursor, gaps require snapshot, and unsupported is typed", async () => withRuntime(async ({ stream, session }) => {

--- a/packages/daemon/test/fleet-dual-sync.integration.test.ts
+++ b/packages/daemon/test/fleet-dual-sync.integration.test.ts
@@ -57,6 +57,19 @@ async function dualSyncFixture() {
 }
 type Fixture = Awaited<ReturnType<typeof dualSyncFixture>>;
 
+test("remote-edge task and document reads use the authoritative cut after materialization", { timeout: 60_000 }, async (t) => {
+  const fixture: Fixture = await dualSyncFixture(); t.after(() => fixture.close());
+  const created = await fixture.createTask("node-one", "task-seeded", "Authoritative edge read");
+  const shown = await fixture.edgeTask("node-one", { kind: "task-show", taskId: created.taskId });
+  assert.equal(shown.ok, true, JSON.stringify(shown)); assert.ok(Number(shown.revision) > 0); assert.doesNotMatch(String(shown.summary), /task=null/u);
+  const logical = "context/shared-notes.md"; fixture.writeWorktree("node-one", logical, "# Submitted once\n");
+  const submitted = await fixture.edgeDocSync("node-one", { paths: [logical] });
+  assert.equal(submitted.ok, true, JSON.stringify(submitted));
+  const status = await fixture.edgeDocSync("node-one", { dryRun: true, paths: [logical] });
+  assert.equal(status.cut && (status.cut as { revision: number }).revision, submitted.cut && (submitted.cut as { revision: number }).revision);
+  assert.deepEqual(status.rows, [], `already-submitted document was re-eligible: ${JSON.stringify(status.rows)}`);
+});
+
 test("class A: a task command carries local task documents, and the effect lands in both mirrors", { timeout: 60_000 }, async (t) => {
   const fixture: Fixture = await dualSyncFixture(); t.after(() => fixture.close());
   const created = await fixture.createTask("node-one", "task_AAAA000000000000000000000A", "Class A carry");

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -95,6 +95,19 @@ test("daemon repo registration derives its closed mode enum at the wire boundary
   const invalid = parseDaemonRpcParams("daemon.repo.register", { ...base, mode: "invalid" }); assert.equal(invalid.ok, false); if (!invalid.ok) assert.deepEqual(invalid.errors, ["params.mode must be one of local, remote-center, remote-edge"]);
 });
 
+test("local Fleet runtime envelope admits the paged overview read", async () => {
+  let observed: Record<string, unknown> | null = null;
+  const host = { fleet: { edgeRuntime: async (payload: Record<string, unknown>) => { observed = payload; return { ok: true, command: "fleet-runtime-overview" }; } }, status: () => ({ daemonId: "fleet-overview", pid: process.pid, repos: [] }) } as never,
+    server = createJsonRpcProtocolServer({ host, build: { commit: null }, authContext: { transportKind: "unix-socket" }, emit: async () => undefined });
+  try {
+    await server.handle({ jsonrpc: "2.0", id: 1, method: "protocol.hello", params: { protocolVersion: currentDaemonProtocolVersion } });
+    const payload = { host: "center", port: 7443, caPath: "/fleet/ca.pem", nodeId: "edge-one", credential: "secret", assignmentId: "assignment-one", repoId: "repo", viewRoot: "/view", quotaBytes: 1_048_576, workspaceRoot: "/workspace", action: { kind: "fleet-runtime", method: "repo.agentRuntime.overview", payload: { limit: 16 } } },
+      response = await server.handle({ jsonrpc: "2.0", id: 2, method: "daemon.fleet.task.run", params: { payload } });
+    assert.ok(response && !Array.isArray(response) && "result" in response); assert.equal(response && !Array.isArray(response) && "result" in response && (response.result as Record<string, unknown>).ok, true);
+    assert.deepEqual(observed, { ...payload, method: "repo.agentRuntime.overview", action: { limit: 16 } });
+  } finally { server.close(); }
+});
+
 test("protocol hello accepts only the session variables owned by runtime resolvers", () => {
   const hello = (sessionEnvironment?: Record<string, unknown>) => parseDaemonRpcParams("protocol.hello", { protocolVersion: currentDaemonProtocolVersion, ...(sessionEnvironment ? { sessionEnvironment } : {}) });
   assert.equal(hello().ok, true);

--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -361,7 +361,7 @@ test("repo-cell restart re-adopts a live native runtime and settles an exit reco
     repoId = "runtime-re-adopt",
     executablePath = writeProviderExecutable(
       path.join(parent, "re-adopt-provider.mjs"),
-      `import fs from "node:fs";\nfs.readFileSync(0, "utf8");\nfs.writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));\nconsole.log(JSON.stringify({ type: "thread.started", thread_id: "provider-re-adopt-session" }));\nconst timer = setInterval(() => { if (!fs.existsSync(${JSON.stringify(release)})) return; clearInterval(timer); console.log(JSON.stringify({ type: "item.completed", item: { id: "message", type: "agent_message", text: "survived daemon restart" } })); console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } })); }, 10);\n`,
+      `import fs from "node:fs";\nfs.readFileSync(0, "utf8");\nfs.writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));\nconsole.log(JSON.stringify({ type: "thread.started", thread_id: "provider-re-adopt-session" }));\nconst timer = setInterval(() => { if (!fs.existsSync(${JSON.stringify(release)})) return; clearInterval(timer); console.log(JSON.stringify({ type: "item.completed", item: { id: "write", type: "file_change", changes: [{ path: "result.txt", kind: "add" }], status: "completed" } })); console.log(JSON.stringify({ type: "item.completed", item: { id: "message", type: "agent_message", text: "survived daemon restart" } })); console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } })); }, 10);\n`,
     ),
     installation = installationFixture("codex", executablePath),
     definition = {
@@ -373,7 +373,7 @@ test("repo-cell restart re-adopts a live native runtime and settles an exit reco
       models: ["codex-model"],
       defaultModel: "codex-model",
       enabled: true,
-      permissionMode: "read-only" as const,
+      permissionMode: "workspace-write" as const,
       codex: {},
       authMode: "subscription" as const,
       authState: "configured" as const,
@@ -548,14 +548,14 @@ test("repo-cell restart re-adopts a live native runtime and settles an exit reco
   }
 });
 
-test("explicit runtime cancel terminates a detached native provider process tree", async () => {
+test("explicit runtime cancel terminates every detached native provider descendant group", { skip: process.platform === "win32" ? "requires POSIX process-group semantics" : false }, async (t) => {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-detached-cancel-")),
     root = path.join(parent, "repo"),
     pidFile = path.join(parent, "provider-pids.json"),
     repoId = "runtime-detached-cancel",
     executablePath = writeProviderExecutable(
       path.join(parent, "cancel-tree-provider.mjs"),
-      `import fs from "node:fs"; import { spawn } from "node:child_process";\nfs.readFileSync(0, "utf8"); const child = spawn(process.execPath, ["-e", "setInterval(() => undefined, 1000)"], { stdio: "ignore" }); fs.writeFileSync(${JSON.stringify(pidFile)}, JSON.stringify([process.pid, child.pid])); console.log(JSON.stringify({ type: "thread.started", thread_id: "provider-cancel-tree" })); setInterval(() => undefined, 1000);\n`,
+      `import fs from "node:fs"; import { spawn } from "node:child_process";\nfs.readFileSync(0, "utf8"); const child = spawn(process.execPath, ["-e", "setInterval(() => undefined, 1000)"], { stdio: "ignore", detached: true }); child.unref(); fs.writeFileSync(${JSON.stringify(pidFile)}, JSON.stringify([process.pid, child.pid])); console.log(JSON.stringify({ type: "thread.started", thread_id: "provider-cancel-tree" })); setInterval(() => undefined, 1000);\n`,
     ),
     installation = installationFixture("codex", executablePath),
     instance = {
@@ -663,16 +663,18 @@ test("explicit runtime cancel terminates a detached native provider process tree
       ).detail,
       "cancelled",
     );
-    await eventually(() =>
-      pids.every((pid) => {
-        try {
-          process.kill(pid, 0);
-          return false;
-        } catch {
-          return true;
-        }
-      }),
-    );
+    const streamPath = path.join(root, ".harness", "runtime", "dispatches", `${String(spawned.dispatchId)}.jsonl`),
+      descendants = await eventuallyValue(() => {
+        const records = readFileSync(streamPath, "utf8").trim().split(/\r?\n/u).map((line) => JSON.parse(line) as Record<string, unknown>);
+        return records.find((record) => record.kind === "process_descendants") ?? null;
+      });
+    assert.deepEqual((descendants.pids as number[]).slice().sort((left, right) => left - right), pids.slice().sort((left, right) => left - right));
+    const survivors = pids.filter((pid) => {
+      try { process.kill(pid, 0); return true; }
+      catch { return false; }
+    });
+    assert.deepEqual(survivors, [], `cancel survivors: ${JSON.stringify(survivors)}`);
+    t.diagnostic(`cancel descendants=${JSON.stringify(pids)} survivors=${JSON.stringify(survivors)}`);
   } finally {
     if (runtimeSessionId)
       try {
@@ -764,7 +766,7 @@ async function eventually(check: () => boolean | Promise<boolean>): Promise<void
   await eventuallyValue(async () => ((await check()) ? true : null));
 }
 async function eventuallyValue<T>(read: () => T | null | Promise<T | null>): Promise<T> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+  for (let attempt = 0; attempt < 500; attempt += 1) {
     const value = await read();
     if (value !== null) return value;
     await new Promise((resolve) => setTimeout(resolve, 10));


### PR DESCRIPTION
Production-Delta: +249/-34

# English

## Summary

Fix the four remote-edge usability defects (U17–U20) found by the W5-R round-3 cutover rehearsal on locked baseline `18c2aa46`, so a remote edge is fully usable against a production-scale ledger:

- **U17** — after materialization, `task show` / `doc status` on the edge now reach the authoritative center cut through the assignment identity instead of returning `revision=0, task=null`; already-pushed documents are no longer re-listed as eligible. The read surface is strictly limited to the authenticated assignment's task, with document writes rejected.
- **U18** — runtime adoption/spawn reads the overview in pages of `limit=16`, keeping every response below the 98,304-byte fleet frame ceiling (the ceiling itself is untouched). Repeated cursors and missing page receipts are rejected.
- **U19** — before attaching, adoption replays provider output persisted while the daemon was absent, restoring the settlement context; a worker that finished during the absence now settles `succeeded` instead of `unknown`, and the tail observer skips exactly the restored records without republishing native signals.
- **U20** — POSIX cancel enumerates and books every descendant PID/PGID, TERMs each safe process group, KILLs survivors after a timeout, and re-enumerates; a remaining non-zombie survivor returns `runtime_cancel_failed`. Windows keeps the existing `taskkill /T` path.

## Verification

- `npm run check:local`: pass, 46 steps (fast 331/331, contract 576/576, G32/G33/G36 and all boundary gates green); re-run green after rebasing onto `857814da1`.
- Isolated Ubuntu targeted integration (`node tools/dispatch-isolated-test.mjs --file …`):
  - `packages/daemon/test/fleet-dual-sync.integration.test.ts` exit=0 (21.1s, includes the new U17 case "remote-edge task and document reads use the authoritative cut after materialization")
  - `packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts` exit=0 (11.4s, includes the U19 case "repo-cell restart re-adopts a live native runtime and settles an exit recorded while absent" and the U20 case "explicit runtime cancel terminates every detached native provider descendant group", the latter asserting an empty descendant set after cancel with real detached grandchildren)
- U18 scale case: 192 large sessions read in 12 pages, largest page 17,792 bytes < 98,304; the unbounded response measured 209,372 bytes before the fix (red).
- Every defect carries a paired red (rehearsal receipt / reproducing test) and green (same test after the fix); see task_c8dad240 artifacts/report-u17-u20-fixes.md.

## Review Evidence

- U17 read surface: lease-broker validates `assignment.taskId` for task-show and rejects any docChanges/mirrorBaseCut.
- U18 does not raise the frame ceiling; it wires callers onto the pagination added in #1782.
- The rebase conflict with the #1791 formatting-restoration line (4 overlapping files) was resolved by hand as "main's expanded formatting + this branch's semantic delta"; targeted integration and check:local re-run green on the merged tree.

## Residual Risk

- POSIX descendant discovery depends on `ps -axo pid,ppid,pgid,stat` output; macOS real processes tested, Linux covered by the CI integration shards.
- The production-scale route-B / U10 / stop→adopt / cancel checks must be re-run on real machines by the W5-R re-verification round after merge; fixture evidence does not substitute (already planned).

---

# 中文

## 摘要

修复 W5-R 第三轮切换彩排(锁定基线 `18c2aa46`)发现的四个 remote-edge 可用性缺陷(U17–U20),使 edge 在生产规模台账下完整可用:

- **U17**——物化后 `task show`/`doc status` 经 assignment 身份读 center 权威投影,不再返回 `revision=0, task=null`;已提交文档不再重复列 eligible。只读面严格限于 authenticated assignment 的 task,禁带文档写。
- **U18**——runtime adoption/spawn 以 `limit=16` 分页读 overview,每页帧不超 98,304 字节上限(帧上限本身未动);重复 cursor 与缺页回执一律拒绝。
- **U19**——adoption 前同步重放缺席期间持久化的 provider 输出,恢复结算上下文;缺席期完成的 worker 结算 `succeeded` 而非 `unknown`,tail observer 精确跳过已恢复记录、不重复发布 native signals。
- **U20**——POSIX cancel 枚举并记账全部后代 PID/PGID,先 TERM 每个安全进程组、超时后 KILL 存活项并复枚举;残留非僵尸进程返回 `runtime_cancel_failed`。Windows 保留原 `taskkill /T` 路径。

## 验证

- `npm run check:local`:pass,46 steps(fast 331/331、contract 576/576、G32/G33/G36 与全部 boundary gates 绿);rebase 到 `857814da1` 后复跑仍绿。
- 隔离 Ubuntu 定向集成(`node tools/dispatch-isolated-test.mjs --file …`):
  - `packages/daemon/test/fleet-dual-sync.integration.test.ts` exit=0(21.1s,含 U17 新用例)
  - `packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts` exit=0(11.4s,含 U19 adoption 结算用例与 U20 cancel 后代全灭用例,后者用真实 detached 子孙进程断言 cancel 后枚举为空集)
- U18 规模用例:192 个大 session 分 12 页读取,最大页 17,792 bytes < 98,304;修前无界响应实测 209,372 bytes(红)。
- 每缺陷均有修前红(彩排原始回执/复现测试)+ 修后绿成对证据,详见 task_c8dad240 的 artifacts/report-u17-u20-fixes.md。

## 评审证据

- U17 只读面:lease-broker 对 task-show 校验 assignment.taskId 且拒绝任何 docChanges/mirrorBaseCut。
- U18 未调帧上限,只把调用方接到 #1782 的分页。
- 与 #1791 排版还原线的 rebase 冲突(4 个文件交叠)由 CEO 手工按「main 展开排版 + 本分支语义增量」合成,合成后定向集成与 check:local 复跑全绿。

## 残余风险

- POSIX 后代进程发现依赖 `ps -axo pid,ppid,pgid,stat` 输出格式;macOS 真进程已测,Linux 由 CI 集成 shard 覆盖。
- 真实规模的路线 B/U10/stop→adopt/cancel 四项须在合入后由 W5-R 复验轮真机重跑,fixture 证据不替代真机(已列入下一轮计划)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
