### PR TITLE
fix(daemon): remove the fleet applied-write scale walls (U21, 32s -> 7.5s)

### DIFF
--- a/packages/daemon/src/fleet-edge-mirror.ts
+++ b/packages/daemon/src/fleet-edge-mirror.ts
@@ -654,7 +654,16 @@ function fleetMirrorCutEntries(viewDir: string, revision: number): ReadonlyMap<s
 }
 function fleetMirrorCutFile(viewDir: string, revision: number, logical: string): Buffer | null {
   const file = path.join(viewDir, "cuts", String(revision), "files", ...logical.split("/"));
-  return existsSync(file) && statSync(file).isFile() ? readFileSync(file) : null;
+  if (existsSync(file) && statSync(file).isFile()) return readFileSync(file);
+  const blob = fleetMirrorCutEntries(viewDir, revision)?.get(logical);
+  if (blob === undefined) return null;
+  const repoRoot = path.dirname(path.dirname(viewDir)),
+    cas = path.join(repoRoot, "cas", "sha256", blob.sha256.slice(0, 2), blob.sha256);
+  if (!existsSync(cas) || !statSync(cas).isFile()) return null;
+  const bytes = readFileSync(cas);
+  if (bytes.byteLength !== blob.size || sha256Bytes(bytes) !== blob.sha256)
+    throw new FleetMirrorError("replica_corrupt", `Replica CAS blob ${blob.sha256} is corrupt.`);
+  return bytes;
 }
 function fleetMirrorMaterializedPaths(materializedRoot: string): string[] {
   const found: string[] = [];

--- a/packages/daemon/src/fleet/center-listener.ts
+++ b/packages/daemon/src/fleet/center-listener.ts
@@ -180,8 +180,7 @@ export async function listenFleetTls(options: FleetCenterOptions): Promise<Fleet
   ): Promise<Delivery> => {
     if (frame.schema === "fleet.assignment.get/v1") {
       const a = await assignment(nodeId, frame.assignmentId),
-        status = await options.host.run(a.repoId, { kind: "doc-status", paths: a.paths }, auth(a)),
-        baseLedgerSha = status.detail?.kind === "doc_sync" ? status.detail.currentLedgerSha : null;
+        baseLedgerSha = options.host.replica(a.repoId).ledgerCut();
       if (!baseLedgerSha) throw new FleetFault("projection_pending", "Current ledger cut is unavailable.", true);
       return immediate({
         schema: "fleet.assignment.result/v1",
@@ -376,11 +375,14 @@ export async function listenFleetTls(options: FleetCenterOptions): Promise<Fleet
       const a = await assignment(nodeId, frame.assignmentId),
         replica = options.host.replica(a.repoId);
       replica.activate();
-      const exactRevision = replica.exactRevision();
-      if (exactRevision === null) throw new FleetFault("replica_pending", "No exact center cut is ready.", true);
-      const latest = await replica.waitForCut(exactRevision),
+      const ledgerCut = replica.ledgerCut();
+      if (!ledgerCut || ledgerCut.revision === 0)
+        throw new FleetFault("replica_pending", "No exact center cut is ready.", true);
+      const latest = await replica.waitForCut(ledgerCut.revision),
         key = { nodeId, viewId: a.viewId, repoId: a.repoId },
         id = keyId(key);
+      if (latest.headDigest !== ledgerCut.headDigest)
+        throw new FleetFault("replica_pending", "The exact center cut is not ready.", true);
       if (!window.keys.has(id) && window.keys.size >= 8)
         throw new FleetFault("busy", "Session already has eight active replica keys.", true);
       if (latest.manifest.totalBytes * 2 + FLEET_SESSION_SEND_WINDOW_BYTES > options.replicaDiskQuotaBytes!)

--- a/packages/daemon/src/fleet/edge.ts
+++ b/packages/daemon/src/fleet/edge.ts
@@ -98,7 +98,11 @@ export function openFleetEdgeView(
   killpoint?: (point: "after_page" | "after_chunk" | "before_current_rename") => void,
 ): FleetEdgeView {
   if (!Number.isSafeInteger(diskQuotaBytes) || diskQuotaBytes <= 0) throw new Error("replica disk quota is required");
+  // Reopening a view recomputes durable usage. Within one receive session,
+  // account appended staging bytes instead of walking the full mirror per chunk.
+  let knownDiskBytes: number | null = null;
   const active = new Map<string, string>(),
+    accountedDiskBytes = () => (knownDiskBytes ??= diskUsage(rootDir)),
     repoRoot = (repoId: string) => path.join(rootDir, "repos", repoId),
     viewRoot = (repoId: string, viewId: string) => path.join(repoRoot(repoId), "views", viewId),
     current = (repoId: string, viewId: string): Current | null =>
@@ -112,7 +116,7 @@ export function openFleetEdgeView(
           activeCut = current(frame.repoId, frame.viewId);
         if (
           frame.schema === "fleet.snapshot.begin/v1" &&
-          diskUsage(rootDir) + frame.manifest.totalBytes + FLEET_SESSION_SEND_WINDOW_BYTES > diskQuotaBytes
+          accountedDiskBytes() + frame.manifest.totalBytes + FLEET_SESSION_SEND_WINDOW_BYTES > diskQuotaBytes
         )
           throw new Error("replica_quota_exceeded: incoming snapshot exceeds persistent quota");
         mkdirSync(staging, { recursive: true });
@@ -154,7 +158,8 @@ export function openFleetEdgeView(
           )
             throw new Error("chunk replay mismatch");
         } else {
-          if (diskUsage(rootDir) + bytes.byteLength > diskQuotaBytes)
+          const usedBytes = accountedDiskBytes();
+          if (usedBytes + bytes.byteLength > diskQuotaBytes)
             throw new Error("replica_quota_exceeded: staging chunk exceeds persistent quota");
           const fd = openSync(target, "a");
           try {
@@ -163,6 +168,7 @@ export function openFleetEdgeView(
           } finally {
             closeSync(fd);
           }
+          knownDiskBytes = usedBytes + bytes.byteLength;
         }
         killpoint?.("after_chunk");
         return null;
@@ -229,7 +235,9 @@ function finish(
     entries = [...prior.entries];
     changes = pages.flatMap((page) => (page.schema === "fleet.delta.page/v1" ? page.changes : []));
     if (changes.length !== begin.changeCount) throw new Error("delta change count mismatch");
-    cpSync(path.join(viewRoot, "cuts", String(previous.cut.revision), "files"), files, { recursive: true });
+    // Delta cuts keep a complete manifest and materialize only changed files;
+    // unchanged bytes remain addressable through the verified edge CAS.
+    mkdirSync(files, { recursive: true });
     for (const change of changes) {
       entries = entries.filter((entry) => entry.path !== change.path);
       const target = path.join(files, change.path);
@@ -238,7 +246,11 @@ function finish(
     }
   }
   entries.sort((a, b) => a.path.localeCompare(b.path));
+  const changedPaths = new Set(changes.filter((change) => change.op === "put").map((change) => change.path));
   for (const entry of entries) {
+    // A delta base is an immutable cut whose bytes were verified before its
+    // current pointer was published. Only incoming puts need CAS revalidation.
+    if (begin.schema === "fleet.delta.begin/v1" && !changedPaths.has(entry.path)) continue;
     const cas = path.join(casRoot, entry.blob.sha256.slice(0, 2), entry.blob.sha256),
       incoming = path.join(staging, "blobs", entry.blob.sha256);
     if (!existsSync(cas)) {
@@ -258,14 +270,8 @@ function finish(
     if (bytes.byteLength !== entry.blob.size || sha256Bytes(bytes) !== entry.blob.sha256)
       throw new Error("edge CAS blob mismatch");
     const target = path.join(files, entry.path);
-    if (
-      !existsSync(target) ||
-      changes.some((change) => change.op === "put" && change.path === entry.path) ||
-      begin.schema === "fleet.snapshot.begin/v1"
-    ) {
-      mkdirSync(path.dirname(target), { recursive: true });
-      cpSync(cas, target);
-    }
+    mkdirSync(path.dirname(target), { recursive: true });
+    cpSync(cas, target);
   }
   const digest = fleetManifestDigest(entries);
   if (digest !== expected) throw new Error("result manifest mismatch");

--- a/packages/daemon/src/fleet/replica-cut-store.ts
+++ b/packages/daemon/src/fleet/replica-cut-store.ts
@@ -10,6 +10,7 @@ import {
   sha256Text,
   stableStringify,
   type CanonicalEventV1,
+  type LedgerCutIdentity,
   type ReplicaProjectionBasis,
 } from "../../../kernel/src/index.ts";
 import {
@@ -34,6 +35,7 @@ export interface ReplicaChangeLogEntry {
 }
 export interface ReplicaCutSource {
   readonly activate: () => SnapshotCut | null;
+  readonly ledgerCut: () => LedgerCutIdentity | null;
   readonly exactRevision: () => number | null;
   readonly kick: () => void;
   readonly waitForCut: (revision: number) => Promise<SnapshotCut>;
@@ -51,6 +53,7 @@ export interface ReplicaCutSourceOptions {
   readonly repoId: string;
   readonly localRoot: string;
   readonly readBasis: (afterRevision: number | null) => ReplicaProjectionBasis;
+  readonly readLedgerCut?: () => LedgerCutIdentity;
   readonly readContentBlob: (sha256: string) => Uint8Array | null;
   readonly readEvent?: (opId: string) => CanonicalEventV1 | null;
   readonly readApplied?: (opId: string) => { readonly event: CanonicalEventV1; readonly watermark: number } | null;
@@ -366,6 +369,7 @@ export function openReplicaCutSource(options: ReplicaCutSourceOptions): ReplicaC
   };
   return {
     activate,
+    ledgerCut: () => options.readLedgerCut?.() ?? null,
     exactRevision,
     kick,
     waitForCut,

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -68,6 +68,7 @@ export function initializeRepoCell(context: any): any {
       repoId: context.input.repoId,
       localRoot: path.dirname(path.dirname(projection.path)),
       readBasis: projection.readReplicaBasis,
+      readLedgerCut: store.currentCut,
       readContentBlob: store.readContentBlob,
       readEvent: store.readEvent,
       readApplied: projection.readOperation,

--- a/packages/daemon/test/fleet-doc-sync-ok-polarity.integration.test.ts
+++ b/packages/daemon/test/fleet-doc-sync-ok-polarity.integration.test.ts
@@ -53,11 +53,28 @@ async function pushRejectionFixture() {
   let center: FleetTlsCenter | null = null;
   let race: { readonly path: string; readonly base: string; readonly centerBody: string } | null = null;
   let raceInjected = false;
+  let raceAssignmentReads = 0;
+  let rejectCenterDocStatus = false;
   const centerHost: Pick<DaemonHost, "replica" | "run" | "status"> = {
     replica: (...args) => host.replica(...args),
     status: () => host.status(),
     run: async (repoId, action, auth) => {
-      if (race !== null && action.kind === "doc-status" && auth.assignmentBinding?.nodeId === "node-one") {
+      if (rejectCenterDocStatus && action.kind === "doc-status")
+        throw new Error("fleet assignment must not scan document status");
+      return host.run(repoId, action, auth);
+    }
+  };
+  center = await listenFleetTls({
+    host: centerHost,
+    stateRoot,
+    key,
+    cert,
+    replicaDiskQuotaBytes: replicaQuota,
+    authenticate: (nodeId, credential) => credential === `secret-${nodeId}`,
+    resolveAssignment: async (assignmentId) => {
+      if (race !== null && assignmentId === "assignment-node-one") {
+        raceAssignmentReads += 1;
+        if (raceAssignmentReads < 2) return assignments.get(assignmentId) ?? null;
         const pending = race;
         race = null;
         if (center === null) throw new Error("fleet center is not ready");
@@ -71,22 +88,19 @@ async function pushRejectionFixture() {
           assignmentId: "assignment-node-two",
           timeoutMs: 30_000,
           channel: "collaborator",
-          changes: [{ path: pending.path, body: pending.centerBody, baseBlobSha256: sha256Bytes(Buffer.from(pending.base)) }]
+          changes: [
+            {
+              path: pending.path,
+              body: pending.centerBody,
+              baseBlobSha256: sha256Bytes(Buffer.from(pending.base)),
+            },
+          ],
         });
         assert.equal(moved.center.outcome, "applied", JSON.stringify(moved.center));
         raceInjected = true;
       }
-      return host.run(repoId, action, auth);
+      return assignments.get(assignmentId) ?? null;
     }
-  };
-  center = await listenFleetTls({
-    host: centerHost,
-    stateRoot,
-    key,
-    cert,
-    replicaDiskQuotaBytes: replicaQuota,
-    authenticate: (nodeId, credential) => credential === `secret-${nodeId}`,
-    resolveAssignment: (assignmentId) => assignments.get(assignmentId) ?? null
   });
   const edgeRoot = (nodeId: NodeId): string => path.join(root, `${nodeId}-edge`);
   const workspaceRoot = (nodeId: NodeId): string => path.join(root, `${nodeId}-workspace`);
@@ -117,12 +131,30 @@ async function pushRejectionFixture() {
     rawWrite,
     edgeDocSync,
     writeWorktree,
-    armBaseBlobRace: (path: string, base: string, centerBody: string) => { race = { path, base, centerBody }; },
+    rejectDocumentStatusAtCenter: () => {
+      rejectCenterDocStatus = true;
+    },
+    armBaseBlobRace: (path: string, base: string, centerBody: string) => {
+      race = { path, base, centerBody };
+      raceAssignmentReads = 0;
+    },
     raceInjected: () => raceInjected,
     conflicts: () => readdirSync(path.join(workspaceRoot("node-one"), ".harness", "conflicts")).filter((entry) => entry.startsWith("cflt-")),
     close: async () => { await center!.close(); await host.close(); rmSync(root, { recursive: true, force: true }); }
   };
 }
+
+test("assignment admission uses the replica cut without a document-status scan", { timeout: 60_000 }, async (t) => {
+  const fixture = await pushRejectionFixture();
+  t.after(() => fixture.close());
+  fixture.rejectDocumentStatusAtCenter();
+
+  const result = await fixture.rawWrite("node-one", [
+    { path: "context/shared-notes.md", body: "# Exact replica admission\n" },
+  ]);
+
+  assert.equal(result.center.outcome, "applied", JSON.stringify(result.center));
+});
 
 test("push-rejected base_blob_changed staging is rejected instead of applied", { timeout: 60_000 }, async (t) => {
   const fixture = await pushRejectionFixture();

--- a/packages/daemon/test/fleet-lease-broker.integration.test.ts
+++ b/packages/daemon/test/fleet-lease-broker.integration.test.ts
@@ -38,7 +38,13 @@ async function leaseFixture(wrapRun?: (run: DaemonHost["run"]) => DaemonHost["ru
     try { const center = await listenFleetTls({ host, stateRoot, key, cert, ...(port === undefined ? {} : { port }), replicaDiskQuotaBytes: replicaQuota, authenticate: (nodeId, credential) => credential === `secret-${nodeId}`, resolveAssignment: (assignmentId) => byId.get(assignmentId) ?? null }); centers.push(center); return center; }
     finally { if (previousReap === undefined) delete process.env.HARNESS_LEASE_REAP_INTERVAL_MS; else process.env.HARNESS_LEASE_REAP_INTERVAL_MS = previousReap; }
   };
-  const openHost = (): Promise<DaemonHost> => openDaemonHost({ daemonId: "lease-center", userRoot }).then((host) => { const wrapped = wrapRun ? { ...host, run: wrapRun(host.run) } : host; hosts.push(wrapped); return wrapped; });
+  const openHost = async (): Promise<DaemonHost> => {
+    const host = await openDaemonHost({ daemonId: "lease-center", userRoot });
+    await host.attachmentsSettled();
+    const wrapped = wrapRun ? { ...host, run: wrapRun(host.run) } : host;
+    hosts.push(wrapped);
+    return wrapped;
+  };
   const closeHost = async (host: DaemonHost): Promise<void> => { const at = hosts.indexOf(host); if (at >= 0) hosts.splice(at, 1); await host.close(); };
   const host = await openHost(), center = await openCenter(host);
   const command = (nodeId: string, action: Record<string, unknown>, waitMs = 5_000, taskId: string | null = typeof action.taskId === "string" ? action.taskId : null) => runFleetTaskCommandClient({ port: center.port, ca: cert, servername: "localhost", nodeId, credential: `secret-${nodeId}`, assignmentId: `assignment-${nodeId}`, opId: randomUUID(), repoId: "lease-repo", taskId, action: action as never, waitMs });

--- a/packages/daemon/test/fleet-transport.integration.test.ts
+++ b/packages/daemon/test/fleet-transport.integration.test.ts
@@ -67,7 +67,12 @@ test("multi-path assignment produces a complete first snapshot and a scoped delt
   const firstSchemas: string[] = [], firstBodies = ["# A one\n", "# B one\n"], first = await runFleetRoundTrip({ port: center.port, ca: fixture.cert, nodeId: fixture.assignment.nodeId, credential: "machine-secret", assignmentId: fixture.assignment.assignmentId, viewRoot: edgeRoot, changes: paths.map((itemPath, index) => ({ path: itemPath, body: firstBodies[index]! })), onFrame: (frame) => firstSchemas.push(frame.schema) });
   assert.equal(first.replica.schema, "fleet.ack.result/v1"); assert.ok(firstSchemas.includes("fleet.delta.begin/v1")); for (const [index, itemPath] of paths.entries()) assert.equal(readFileSync(path.join(edgeRoot, "repos", fixture.assignment.repoId, "views", fixture.assignment.viewId, "cuts", String(first.center.revision), "files", itemPath), "utf8"), firstBodies[index]);
   const base = await ledgerBase(fixture), secondSchemas: string[] = [], nextBody = `${firstBodies[1]}Second.\n`, second = await runFleetRoundTrip({ port: center.port, ca: fixture.cert, nodeId: fixture.assignment.nodeId, credential: "machine-secret", assignmentId: fixture.assignment.assignmentId, viewRoot: edgeRoot, changes: [{ path: paths[1]!, body: nextBody, baseBlobSha256: sha256Bytes(Buffer.from(firstBodies[1]!)) }], baseLedgerSha: base.ledger, onFrame: (frame) => secondSchemas.push(frame.schema) });
-  assert.equal(second.replica.schema, "fleet.ack.result/v1"); assert.ok(secondSchemas.includes("fleet.delta.begin/v1")); assert.equal(readFileSync(path.join(edgeRoot, "repos", fixture.assignment.repoId, "views", fixture.assignment.viewId, "cuts", String(second.center.revision), "files", paths[0]!), "utf8"), firstBodies[0]); assert.equal(readFileSync(path.join(edgeRoot, "repos", fixture.assignment.repoId, "views", fixture.assignment.viewId, "cuts", String(second.center.revision), "files", paths[1]!), "utf8"), nextBody);
+  assert.equal(second.replica.schema, "fleet.ack.result/v1");
+  assert.ok(secondSchemas.includes("fleet.delta.begin/v1"));
+  const workspaceRoot = path.join(fixture.root, "multi-workspace");
+  assert.equal(applyFleetMirrorCut(edgeRoot, fixture.assignment.repoId, workspaceRoot, "pull").outcome, "applied");
+  assert.equal(readFileSync(path.join(workspaceRoot, "harness", paths[0]!), "utf8"), firstBodies[0]);
+  assert.equal(readFileSync(path.join(workspaceRoot, "harness", paths[1]!), "utf8"), nextBody);
 });
 
 test("more than 64 completed uploads remain bounded across center restart", { timeout: 120_000 }, async (t) => {


### PR DESCRIPTION
Production-Delta: +39/-17

# English

## Summary

Remove the per-write scale walls on the Fleet applied-write path (U21). On a remote edge, every applied write (task create/start/progress, doc submit) took a stable 32–43 seconds against the production-scale ledger, while local writes took ~3.3s and rejects returned in under a second. Paired large-fixture measurement (canonical cut at revision 31802, 26,412 replica-manifest documents) attributes the wall to corpus-sized work repeated on every write, not to a timer:

- **Admission (13.77s → 0.008s)**: the `fleet.assignment.get/v1` branch ran a corpus-wide `doc-status` scan on every write only to obtain the current ledger identity; it now reads the canonical ledger head directly.
- **Replica pull/ACK (11.66s → 1.57s)**: full delta cloning/rehashing and repeated disk-usage walks replaced by event-driven exact-cut waiting, CAS-backed sparse deltas, and session-level quota accounting.
- **Total dual-applied path: 32.38s → 7.52s** (76.8% lower, under the task's <8s target).

Receipt semantics are unchanged: canonical write → replica exact ACK → mirror materialization → command return, in that order; the command still returns only after both sides are applied.

## Verification

- Paired before/after segmented latency on the same fixture, same cut, same timing boundaries (see task_b8c057e9 artifacts/u21-write-latency-report.md).
- Isolated Ubuntu: Fleet transport 14/14, lease broker 16/16, replica cut store 9/9, plus dual-sync/contract/epoch/config suites green.
- `npm run check:local`: all 46 steps green (333 fast, 584 contract, all gates).
- The lease fixture now awaits daemon attachment explicitly — faster admission exposed its pre-existing startup race.

## Residual Risk

- Canonical write (2.1s) and mirror materialization (2.2s) are unchanged and remain the dominant post-fix segments; further reduction is possible but not required for the <8s gate.
- Real-machine confirmation of the post-fix latency happens in the W5-R round-5 re-verification.

---

# 中文

## 摘要

消除 Fleet applied 写路径上「每条写都付一次全仓开销」的规模墙(U21)。remote-edge 上每条 applied 写在生产规模台账下稳定耗时 32~43 秒,而本地写 ~3.3 秒、拒绝路径亚秒。成对大规模 fixture 测量(canonical revision 31802,26,412 个副本清单文档)归因:墙不是定时器,是每次写都重复的全仓工作——

- **准入(13.77s → 0.008s)**:`fleet.assignment.get/v1` 分支每条写都跑一次全仓 `doc-status` 扫描,只为取当前账本标识;改为直接读权威账本头。
- **副本拉取/ACK(11.66s → 1.57s)**:全量 delta 克隆+重哈希+反复磁盘用量遍历,改为事件驱动的精确 cut 等待、CAS 稀疏增量与会话级配额记账。
- **双侧 applied 全程:32.38s → 7.52s**(降 76.8%,低于任务 <8s 目标)。

回执语义未动:权威写入→副本精确 ACK→镜像物化→命令返回的顺序保持,仍是双侧 applied 才返回。

## 验证

- 同 fixture、同 cut、同计时边界的修前/修后分段延迟成对证据(见 task_b8c057e9 artifacts/u21-write-latency-report.md)。
- 隔离 Ubuntu:Fleet 传输 14/14、lease broker 16/16、replica cut store 9/9,dual-sync/contract/epoch/config 组全绿。
- `npm run check:local` 46 步全绿(fast 333、contract 584)。
- lease fixture 改为显式等待 daemon attach——准入变快暴露了它既有的启动竞态。

## 残余风险

- 权威写(2.1s)与镜像物化(2.2s)未动,是修后主要耗时段;可再降但不在 <8s 门要求内。
- 修后延迟的真机确认在 W5-R 第五轮复验中进行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
