### PR TITLE
fix(daemon): settle adopted runtime tails and inherit fleet runtime read waits (U18b/U19b)

### DIFF
--- a/packages/daemon/src/fleet-edge-runtime.ts
+++ b/packages/daemon/src/fleet-edge-runtime.ts
@@ -16,6 +16,7 @@ import { locateFleetMirrorView } from "./fleet-edge-mirror.ts";
 import { validateAgentRuntimeOverview, type AgentRuntimeOverviewResult } from "./agent-runtime-contract.ts";
 import { makeRuntimeSpawner, type RuntimeDaemonRoute, type RuntimeLauncher } from "./runtime-spawn.ts";
 import type { JsonObject } from "./protocol/json-rpc-types.ts";
+import { readFleetEdgeConfig } from "./client/fleet-edge-config.ts";
 
 export interface FleetEdgeRuntimeRequest {
   readonly payload: {
@@ -117,6 +118,11 @@ export function openFleetEdgeRuntime(input: {
       credential,
       assignmentId: request.assignmentId,
     },
+    runtimeReadTimeoutMs = readFleetEdgeConfig(request.workspaceRoot)?.waitTimeoutMs,
+    runtimeReadPeer: FleetPeerOptions = {
+      ...peer,
+      ...(runtimeReadTimeoutMs === undefined ? {} : { timeoutMs: runtimeReadTimeoutMs }),
+    },
     now = input.now ?? (() => new Date().toISOString()),
     stream = { publish: () => ({}) as never };
   let tail = Promise.resolve();
@@ -193,7 +199,7 @@ export function openFleetEdgeRuntime(input: {
       readRuntimeSessions: () =>
         readFleetRuntimeSessionsPaged((payload) =>
           runFleetRuntimeReadClient({
-            ...peer,
+            ...runtimeReadPeer,
             repoId: request.repoId,
             method: "repo.agentRuntime.overview",
             payload,
@@ -236,7 +242,7 @@ export function openFleetEdgeRuntime(input: {
         : method === "repo.agentRuntime.cancel"
           ? spawner.cancel(action, edgeBinding())
           : ((await runFleetRuntimeReadClient({
-              ...peer,
+              ...runtimeReadPeer,
               repoId: request.repoId,
               method,
               payload: action,

--- a/packages/daemon/src/runtime-spawn-settlement.ts
+++ b/packages/daemon/src/runtime-spawn-settlement.ts
@@ -3,6 +3,7 @@ import type { AgentRuntimeEventV1, CanonicalEventStore, RuntimeResultClaim } fro
 import { consumeKnownError } from "../../kernel/src/index.ts";
 import { scrubProviderValue } from "./dispatch-stream.ts";
 import { archiveRuntimeDispatch, type RuntimeDispatchArchive } from "./doc-sync-actions.ts";
+import { consumeDurableOutput } from "./runtime-spawn-provider-stream.ts";
 import type { ActiveRuntime } from "./runtime-spawn-types.ts";
 
 export async function publishExit(context: any, active: ActiveRuntime, code: number | null): Promise<void> {
@@ -15,6 +16,7 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
   const cancelled = active.cancelRequested,
     eventBinding = cancelled && active.cancelBinding ? active.cancelBinding : active.binding;
   try {
+    await consumeDurableOutput(context, active);
     if (!cancelled && code === null)
       context.input.stream.publish(active.runtimeSessionId, {
         type: "error",

--- a/packages/daemon/test/fleet-transport.integration.test.ts
+++ b/packages/daemon/test/fleet-transport.integration.test.ts
@@ -5,9 +5,12 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 import { connect, createServer, type TLSSocket } from "node:tls";
 import { makeTaskEventStore, registerDaemonRepo, sha256Bytes, type AgentDefinitionSnapshot, type LedgerCutIdentity } from "../../kernel/src/index.ts";
+import type { AgentRuntimeSessionDto } from "../src/agent-runtime-contract.ts";
 import { openDaemonHost } from "../src/daemon-host.ts";
+import { openFleetEdgeRuntime } from "../src/fleet-edge-runtime.ts";
 import { runFleetEdgeTask } from "../src/fleet-edge-task.ts";
 import { applyFleetMirrorCut, locateFleetMirrorView } from "../src/fleet-edge-mirror.ts";
 import { listenFleetTls, type FleetAssignmentRecord, type FleetTlsCenter } from "../src/fleet/center.ts";
@@ -110,6 +113,154 @@ test("remote-edge runtime launches locally while lifecycle and worker progress s
   await t.test("provider session resume keeps the center-observed runtime instance", async () => { const resumed = await edgeHost.fleet.edgeRuntime({ host: "127.0.0.1", port: center.port, caPath: fixture.certFile, nodeId: fixture.assignment.nodeId, rosterPath, assignmentId: fixture.assignment.assignmentId, repoId: fixture.assignment.repoId, viewRoot, quotaBytes: replicaQuota, workspaceRoot: edgeRoot, method: "repo.agentRuntime.spawn", action: { providerSessionId: "edge-provider-session", cwd: { scope: "repo-root" }, prompt: "Resume on the original runtime instance.", taskId: fixture.assignment.taskId, idempotencyKey: "remote-edge-runtime-resume" } }, localAuth); assert.equal(resumed.outcome, "applied", JSON.stringify(resumed)); assert.equal((await waitForOutcome(resumed.runtimeSessionId))?.session.activity.outcome, "succeeded"); assert.equal(launchedInstances.at(-1), runtimeDefinition.instanceId); });
   await t.test("another assignment cannot replay terminal events for this runtime session", async () => { const foreignAssignment = { ...fixture.assignment, nodeId: "node-two", assignmentId: "assignment-two", viewId: "node-two_task-fleet" }, events = makeTaskEventStore({ repoId: fixture.assignment.repoId, rootDir: fixture.repo }).read().events.filter((event) => (event.type === "runtime_session_exited" || event.type === "runtime_session_outcome_observed") && event.payload.runtimeSessionId === receipt.runtimeSessionId); assert.equal(events.length, 2); for (const event of events) await assert.rejects(fixture.host.runtimeIngress(fixture.assignment.repoId, { kind: "event", type: event.type, payload: event.payload, opId: event.opId }, { transportKind: "fleet-tls", assignmentBinding: foreignAssignment }), (error: unknown) => typeof error === "object" && error !== null && "code" in error && error.code === "assignment_scope_mismatch"); });
   await runFleetReplicaPullClient({ port: center.port, ca: fixture.cert, nodeId: fixture.assignment.nodeId, credential: "machine-secret", assignmentId: fixture.assignment.assignmentId, viewRoot, diskQuotaBytes: replicaQuota }); applyFleetMirrorCut(viewRoot, fixture.assignment.repoId, edgeRoot, "pull"); const mirrored = locateFleetMirrorView(viewRoot, fixture.assignment.repoId); assert.ok(mirrored); assert.equal((readFileSync(path.join(edgeRoot, "harness/tasks/task-fleet-fleet/progress.md"), "utf8").match(new RegExp(unique, "gu")) ?? []).length, 1); assert.equal(existsSync(path.join(edgeRoot, ".harness/runtime/dispatches", `${receipt.dispatchId}.jsonl`)), true); assert.equal(existsSync(path.join(fixture.repo, ".harness/runtime/dispatches", `${receipt.dispatchId}.jsonl`)), false);
+});
+
+test("fleet runtime waits over five seconds for every configured overview page", { timeout: 30_000 }, async (t) => {
+  const fixture = await fleetFixture();
+  t.after(() => fixture.close());
+  const definition: AgentDefinitionSnapshot = {
+      schema: "agent-definition-snapshot/v1",
+      configVersion: 1,
+      instanceId: "slow-page-codex",
+      installationId: "slow-page-installation",
+      kindId: "codex",
+      providerId: "openai",
+      model: "gpt-5.6-sol",
+      reasoningEffort: null,
+      baseUrl: null,
+      authMode: "subscription",
+    },
+    template: AgentRuntimeSessionDto = {
+      runtimeSessionId: "runtime-slow-00",
+      providerSessionId: null,
+      instanceId: definition.instanceId,
+      installationId: definition.installationId,
+      kindId: definition.kindId,
+      definitionSnapshotRef: "artifact:runtime-definition/slow-page",
+      definitionSnapshot: definition,
+      liveness: "live",
+      semanticState: "running",
+      attachCapability: "supported",
+      streamCursor: "stream:0",
+      associations: [],
+      activity: {
+        lastObservedAt: "2026-08-24T12:00:00.000Z",
+        outcome: null,
+        exitCode: null,
+        resultRef: null,
+      },
+    },
+    sessions = Array.from({ length: 17 }, (_, index) => ({
+      ...template,
+      runtimeSessionId: `runtime-slow-${String(index).padStart(2, "0")}`,
+    })),
+    pagePayloads: Array<Record<string, unknown>> = [],
+    responseWaits: number[] = [];
+  const slowHost = {
+    ...fixture.host,
+    read: async (...args: Parameters<typeof fixture.host.read>) => {
+      const [repoId, method, payload, auth] = args;
+      if (method !== "repo.agentRuntime.overview") return fixture.host.read(repoId, method, payload, auth);
+      const startedAt = performance.now();
+      await delay(5_100);
+      responseWaits.push(performance.now() - startedAt);
+      const query = payload as Record<string, unknown>,
+        limit = Number(query.limit),
+        cursor = typeof query.cursor === "string" ? query.cursor : null,
+        start = cursor === null ? 0 : Number(cursor.slice("slow-page:".length)),
+        selected = sessions.slice(start, start + limit),
+        next = start + selected.length;
+      pagePayloads.push(query);
+      return {
+        ok: true,
+        status: "ready",
+        installations: [],
+        instances: [],
+        sessions: selected,
+        page: {
+          limit,
+          cursor,
+          nextCursor: next < sessions.length ? `slow-page:${next}` : null,
+          remainingCount: Math.max(0, sessions.length - next),
+        },
+        watermark: 1,
+        sourceRevision: 1,
+      };
+    },
+  };
+  const center = await listenFleetTls({
+    host: slowHost,
+    stateRoot: path.join(fixture.root, "slow-runtime-center"),
+    key: fixture.key,
+    cert: fixture.cert,
+    replicaDiskQuotaBytes: replicaQuota,
+    authenticate: (nodeId, credential) =>
+      nodeId === fixture.assignment.nodeId && credential === "machine-secret",
+    resolveAssignment: (assignmentId) =>
+      assignmentId === fixture.assignment.assignmentId ? fixture.assignment : null,
+  });
+  t.after(() => center.close());
+  const workspaceRoot = path.join(fixture.root, "slow-runtime-edge"),
+    viewRoot = path.join(fixture.root, "slow-runtime-view");
+  mkdirSync(path.join(workspaceRoot, "harness"), { recursive: true });
+  writeFileSync(
+    path.join(workspaceRoot, "harness/harness.yaml"),
+    "schema: harness-anything/v1\nname: slow-runtime-edge\n" +
+      "layout:\n  authoredRoot: harness\n  localRoot: .harness\n",
+  );
+  writeFileSync(
+    path.join(workspaceRoot, "fleet-edge.json"),
+    `${JSON.stringify({
+      schema: "fleet-edge-config/v1",
+      repoId: fixture.assignment.repoId,
+      host: "127.0.0.1",
+      port: center.port,
+      caPath: fixture.certFile,
+      nodeId: fixture.assignment.nodeId,
+      credential: "machine-secret",
+      assignmentId: fixture.assignment.assignmentId,
+      viewRoot,
+      quotaBytes: replicaQuota,
+      waitTimeoutMs: 6_200,
+    })}\n`,
+  );
+  const runtime = openFleetEdgeRuntime({
+    request: {
+      host: "127.0.0.1",
+      port: center.port,
+      caPath: fixture.certFile,
+      nodeId: fixture.assignment.nodeId,
+      credential: "machine-secret",
+      assignmentId: fixture.assignment.assignmentId,
+      repoId: fixture.assignment.repoId,
+      viewRoot,
+      quotaBytes: replicaQuota,
+      workspaceRoot,
+      method: "repo.agentRuntime.overview",
+      action: { limit: 1 },
+    },
+    daemonGeneration: 1,
+    daemonRoute: {
+      userRoot: path.join(fixture.root, "slow-runtime-user"),
+      daemonId: "slow-runtime-edge",
+      endpoint: path.join(fixture.root, "slow-runtime.sock"),
+    },
+    ports: {
+      runtimeInstances: () => [],
+      prepareRuntimeLaunch: async () => {
+        throw new Error("runtime launch is not part of the read test");
+      },
+    },
+  });
+  t.after(() => runtime.close());
+  const overview = await runtime.run("repo.agentRuntime.overview", { limit: 1 });
+  assert.equal((overview.sessions as readonly unknown[]).length, 1);
+  assert.deepEqual(pagePayloads.slice(0, 2), [
+    { limit: 16 },
+    { limit: 16, cursor: "slow-page:16" },
+  ]);
+  assert.equal(responseWaits.length, 3);
+  assert.equal(responseWaits.every((elapsed) => elapsed >= 5_000), true);
 });
 
 test("production Fleet session rejects provenance, revocation, expiry, content mismatch, and ninth active upload before L1", { timeout: 30_000 }, async (t) => { const fixture = await fleetFixture(); t.after(() => fixture.close()); const center = await fixture.center(), before = fixture.commitCount(); let peer = await rawPeer(fixture.track, center.port, fixture.cert, fixture.assignment.nodeId, "machine-secret");

--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -12,6 +12,7 @@ import {
   type AgentDefinitionSnapshot,
 } from "../../kernel/src/index.ts";
 import { type RuntimeInstallationWitness } from "../src/agent-runtime-instances.ts";
+import { appendRuntimeWorkerRecord } from "../src/dispatch-stream.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { openRepoCell } from "../src/repo-cell.ts";
 import { launchExitNotification } from "../src/runtime-spawn.ts";
@@ -344,6 +345,130 @@ test("runtime spawn publishes a canonical session and makes it visible in overvi
           },
         ),
         (error: unknown) => error instanceof Error && "code" in error && error.code === "invalid_runtime_spawn",
+      );
+    } finally {
+      await cell.close();
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("attached runtime settlement includes provider records persisted after attach before exit", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-runtime-attached-tail-"));
+  let exit: ((code: number | null) => void) | null = null;
+  try {
+    initIngressRepo(root, 4310);
+    const cell = await openRepoCell({
+      repoId: workspaceId("runtime-attached-tail"),
+      rootDir: canonicalRoot(root),
+      ownerId: "attached-tail-test",
+      runtimeInstances: () => [
+        {
+          schemaVersion: 2,
+          instanceId: definition.instanceId,
+          name: "Codex Attached Tail",
+          kindId: definition.kindId,
+          installationId: definition.installationId,
+          providerId: definition.providerId,
+          models: [definition.model],
+          defaultModel: definition.model,
+          enabled: true,
+          permissionMode: "workspace-write",
+          codex: {},
+          authMode: definition.authMode,
+          authState: "configured",
+          authReadiness: { status: "ready", code: null, hint: null },
+          isolationState: "enforced",
+        },
+      ],
+      prepareRuntimeLaunch: async (_instanceId, request) => ({
+        definition,
+        installation,
+        executablePath: installation.executablePath,
+        args: ["exec", "--json", "-"],
+        env: process.env,
+        cwd: request.cwd,
+        prompt: request.prompt,
+      }),
+      runtimeLaunch: () => ({
+        pid: process.pid,
+        onOutput: () => undefined,
+        onErrorOutput: () => undefined,
+        onExit: (listener) => {
+          exit = listener;
+        },
+        terminate: () => undefined,
+      }),
+    });
+    try {
+      const receipt = await cell.spawnRuntime(
+        {
+          runtimeInstanceId: definition.instanceId,
+          cwd: { scope: "repo-root" },
+          prompt: "Settle the durable tail after attach",
+          taskId: null,
+          idempotencyKey: "attached-tail",
+        },
+        {
+          actor: { principal: { personId: "person-attached-tail" }, executor: null },
+          source: "local",
+        },
+      );
+      const records = [
+        { type: "thread.started", thread_id: "provider-attached-tail" },
+        {
+          type: "item.completed",
+          item: {
+            id: "write",
+            type: "file_change",
+            changes: [{ path: "result.txt", kind: "add" }],
+            status: "completed",
+          },
+        },
+        {
+          type: "item.completed",
+          item: { id: "message", type: "agent_message", text: "attached tail settled" },
+        },
+        { type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } },
+      ];
+      for (const event of records) {
+        appendRuntimeWorkerRecord(root, String(receipt.dispatchId), {
+          kind: "provider_event",
+          occurredAt: "2026-08-24T12:00:00.000Z",
+          event,
+        });
+      }
+      appendRuntimeWorkerRecord(root, String(receipt.dispatchId), {
+        kind: "process_exit",
+        occurredAt: "2026-08-24T12:00:01.000Z",
+        exitCode: 0,
+        signal: null,
+      });
+      assert.ok(exit, "runtime exit listener must be attached before the provider exits");
+      exit(0);
+      await eventually(() =>
+        makeTaskEventStore({ repoId: "runtime-attached-tail", rootDir: root })
+          .read()
+          .events.some(
+            (event) =>
+              event.type === "runtime_session_outcome_observed" &&
+              event.payload.runtimeSessionId === receipt.runtimeSessionId,
+          ),
+      );
+      const projection = makeTaskProjection({
+          rootDir: root,
+          eventStore: makeTaskEventStore({ repoId: "runtime-attached-tail", rootDir: root }),
+        }),
+        settled = projection.readRuntimeSession(String(receipt.runtimeSessionId))!;
+      projection.close();
+      assert.deepEqual(
+        {
+          liveness: settled.liveness,
+          outcome: settled.outcome,
+          exitCode: settled.exitCode,
+        },
+        { liveness: "exited", outcome: "succeeded", exitCode: 0 },
       );
     } finally {
       await cell.close();


### PR DESCRIPTION
Production-Delta: +10/-2

# English

## Summary

Close the last two remote-edge blockers left open by the W5-R round-4 re-verification (U18b/U19b):

- **U19b — adopted runtime settled `unknown` when the worker exited after re-attach**: terminal settlement read only in-memory state, so provider records persisted after attach (final text, `turn.completed`, `process_exit`) were never folded in before attribution. Fix: `publishExit()` now calls the existing `consumeDurableOutput()` first, so live, adopted, and exit-during-absence timelines share one settlement entry. Production +2/-0.
- **U18b — paged runtime overview reads timed out on cold pages**: `fleet-edge.json`'s validated `waitTimeoutMs` was never passed to the per-page peer calls, which fell back to `openPeer()`'s global 5000ms default; any cold page over 5s returned `bootstrap_failed: Fleet response timeout` (round-4 measured 17.7s/13s failures with a healthy center). Fix: adoption pagination and direct runtime reads now inherit the configured wait; `limit=16` and the frame ceiling are untouched. Production +8/-2.

## Verification

- U19b red/green: new integration case "attached runtime settlement includes provider records persisted after attach before exit" — before: `{liveness:"exited", outcome:"unknown", exitCode:0}` (4 pass / 1 fail); after: 5/5 green, and the existing exit-before-restart adoption case plus the U20 cancel-descendants case stay green (no regression).
- U18b red/green: new paginated-read tests with a slow cold page — red under the 5s default, green inheriting the configured wait; fleet transport suite 15/15, pagination/frame 10/10 on isolated Ubuntu.
- `npm run check:local`: all steps green after rebasing onto the U21 merge (c1321d96f).
- U21 overlap gate from the task plan was executed and documented: U21's production diff touches only the write materialization/CAS path, not `fleet-edge-runtime.ts`/`openPeer()` timeouts, so U18b proceeded.

## Residual Risk

- Real-machine confirmation (first successful production-scale worker spawn and a `succeeded` settlement after daemon restart) happens in the W5-R round-5 re-verification.

---

# 中文

## 摘要

关掉 W5-R 第四轮复验剩下的最后两个 remote-edge 阻塞(U18b/U19b):

- **U19b——worker 在重新接管之后退出被结算成 `unknown`**:终态结算只读内存状态,attach 后落盘的 provider 记录(最终文本、`turn.completed`、`process_exit`)没有在归因前被合入。修法:`publishExit()` 入口先调用既有 `consumeDurableOutput()`,live/adopted/缺席期退出三种时序共用同一结算入口,无第二套归因路径。production +2/-0。
- **U18b——分页 overview 冷读页超时**:`fleet-edge.json` 里已校验的 `waitTimeoutMs` 没有传给每页 peer 调用,落回 `openPeer()` 全局默认 5000ms;任一冷读页超 5 秒即 `bootstrap_failed: Fleet response timeout`(第四轮实测 17.7s/13s 失败而 center 正常)。修法:adoption 分页与直接 runtime 读继承配置等待值;`limit=16` 与帧上限不动。production +8/-2。

## 验证

- U19b 红绿成对:新增集成用例修前真实得到 `{outcome:"unknown", exitCode:0}`(4 过 1 红),修后同文件 5/5 绿;既有 exit-before-restart 用例与 U20 cancel 用例同轮绿(无回归)。
- U18b 红绿成对:新增「多页+慢冷页」测试,默认 5s 窗下红、继承配置值后绿;隔离 Ubuntu fleet 传输 15/15、分页/帧 10/10。
- rebase 到 U21 合并(c1321d96f)后 `npm run check:local` 全绿。
- 任务 plan 里的 U21 重叠闸门已执行并留痕:U21 的生产改动只在写侧物化/CAS 路径,未触 `fleet-edge-runtime.ts`/`openPeer()` 超时面,故 U18b 放行。

## 残余风险

- 真机确认(生产规模第一次成功派工 + daemon 重启后结算 `succeeded`)归 W5-R 第五轮复验。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
