### PR TITLE
fix(cli): isolate daemon autostart environment from runtime workers

### DIFF
--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -36,6 +36,24 @@ const autostartFailureCodes = [
   "daemon_bind_timeout",
   "daemon_starting",
 ] as const;
+// These values belong to the invoking runtime worker or its provider launch,
+// not to the resident daemon that owns the shared socket.
+const daemonRuntimeScopedEnvironmentKeys = [
+  "CODEX_HOME",
+  "CLAUDE_CONFIG_DIR",
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_BASE_URL",
+  "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
+  "CLAUDE_CODE_SESSION_ID",
+  "CODEX_THREAD_ID",
+  "CODEX_SESSION_ID",
+  "HARNESS_ACTOR",
+  "HARNESS_DAEMON_ENDPOINT",
+  "HARNESS_DAEMON_ID",
+  "HARNESS_DAEMON_REPO_ID",
+  "HARNESS_DAEMON_USER_ROOT",
+] as const;
 export function daemonServeEntry(): string {
   return realpathSync(
     fileURLToPath(new URL(import.meta.url.endsWith(".js") ? "../index.js" : "../index.ts", import.meta.url)),
@@ -46,10 +64,12 @@ export function cliDaemonServeLaunch(
   daemonId: string,
   execPath = process.execPath,
 ): DaemonLaunchSpec {
+  const env = { ...process.env };
+  for (const key of daemonRuntimeScopedEnvironmentKeys) delete env[key];
   return {
     command: execPath,
     args: [daemonServeEntry(), "daemon", "serve", "--user-root", userRoot, "--daemon-id", daemonId],
-    env: process.env,
+    env,
   };
 }
 export function daemonAutostartFailureCode(error: unknown): string | null {

--- a/packages/cli/test/daemon-autostart-cli.test.ts
+++ b/packages/cli/test/daemon-autostart-cli.test.ts
@@ -48,6 +48,62 @@ test("registered workspace CLI command auto-starts the daemon, retries, and succ
   } finally { rmSync(fixture.parent, { recursive: true, force: true }); }
 });
 
+test("autostart daemon does not inherit runtime worker environment", (context) => {
+  const fixture = setup(),
+    repoId = "clean-autostart",
+    endpoint = localUserDaemonEndpoint(fixture.userRoot, "default"),
+    workerEnv = {
+      ...cliEnv(fixture.root, fixture.userRoot),
+      CODEX_HOME: path.join(fixture.parent, "worker", ".codex"),
+      CLAUDE_CONFIG_DIR: path.join(fixture.parent, "worker", ".claude"),
+      ANTHROPIC_API_KEY: "worker-anthropic-secret",
+      ANTHROPIC_BASE_URL: "https://anthropic.worker.invalid",
+      OPENAI_API_KEY: "worker-openai-secret",
+      OPENAI_BASE_URL: "https://openai.worker.invalid",
+      CLAUDE_CODE_SESSION_ID: "claude-worker-session",
+      CODEX_THREAD_ID: "codex-worker-thread",
+      CODEX_SESSION_ID: "codex-worker-session",
+      HARNESS_ACTOR: "agent:runtime-session:worker-env",
+      HARNESS_DAEMON_ENDPOINT: endpoint,
+      HARNESS_DAEMON_ID: "default",
+      HARNESS_DAEMON_REPO_ID: repoId,
+    };
+  try {
+    registerDaemonRepo({ canonicalRoot: fixture.root, repoId, userRoot: fixture.userRoot, createConvenienceLinks: false });
+    const result = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "task", "list"], {
+      encoding: "utf8",
+      env: workerEnv,
+    });
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+    assert.equal((JSON.parse(result.stdout) as { readonly outcome?: string }).outcome, "applied");
+    const pid = readDaemonPid(fixture.userRoot, "default");
+    assert.ok(pid, "autostart must leave a resident daemon pid file");
+    const processEnvironment = execFileSync("ps", ["eww", "-p", String(pid)], { encoding: "utf8" });
+    const forbidden = [
+      "CODEX_HOME",
+      "CLAUDE_CONFIG_DIR",
+      "ANTHROPIC_API_KEY",
+      "ANTHROPIC_BASE_URL",
+      "OPENAI_API_KEY",
+      "OPENAI_BASE_URL",
+      "CLAUDE_CODE_SESSION_ID",
+      "CODEX_THREAD_ID",
+      "CODEX_SESSION_ID",
+      "HARNESS_ACTOR",
+      "HARNESS_DAEMON_ENDPOINT",
+      "HARNESS_DAEMON_ID",
+      "HARNESS_DAEMON_REPO_ID",
+      "HARNESS_DAEMON_USER_ROOT",
+    ],
+      leaked = forbidden.filter((name) => new RegExp(`(?:^|\\s)${name}=`, "u").test(processEnvironment));
+    context.diagnostic(`ps eww -p ${pid} runtime-scoped env matches: ${JSON.stringify(leaked)}`);
+    assert.deepEqual(leaked, []);
+  } finally {
+    stop(fixture.root, fixture.userRoot);
+    rmSync(fixture.parent, { recursive: true, force: true });
+  }
+});
+
 test("a blocked vertical script keeps handshakes, snapshots, and same-repo writes live", async (context) => {
   const fixture = setup(), repoId = "vertical-wedge", taskId = "task-vertical-wedge", blocker = path.join(fixture.parent, "vertical-script.block"), started = `${blocker}.started`, endpoint = localUserDaemonEndpoint(fixture.userRoot, "default");
   let client: JsonRpcLineClient | undefined, readClient: JsonRpcLineClient | undefined, queuedClient: JsonRpcLineClient | undefined, scriptRequest: Promise<Record<string, unknown>> | undefined, queuedWrite: Promise<Record<string, unknown>> | undefined;


### PR DESCRIPTION
# English

## Summary

The shared daemon could be auto-started by a sandboxed runtime worker and inherit that worker's environment (`CODEX_HOME` pointing into a runtime-instance home, `HARNESS_ACTOR` of the worker session, provider secrets). Every runtime instance on the machine then failed credential resolution. This PR makes `cliDaemonServeLaunch()` strip runtime-scoped variables before spawning the daemon, so autostart no longer depends on who wins the race.

## What Changed

- `packages/cli/src/daemon/client.ts`: the daemon launch spec now copies `process.env` minus an explicit list of runtime-scoped keys (provider homes, API keys/base URLs, session ids, `HARNESS_ACTOR`, daemon routing vars). No detection, restart, or retry layer was added.
- `packages/cli/test/daemon-autostart-cli.test.ts`: integration regression that triggers autostart from a process carrying all of those variables and asserts via `ps eww -p <pid>` that none leaked into the resident daemon.

## Machine-Readable Declarations

Production-Delta: +21/-1

## Task And Scope

- Harness task: task_2acb88e9cd7603fb57cdb05fa1 (PLT-Ontology Phase 0.6, supersedes task_f543b867d85785a785eadeaee0)
- Branch: `codex/daemon-autostart-env`
- Public scope: CLI daemon autostart launch environment + one integration test
- Private planning/evidence updated: yes (task package report `artifacts/reports/dispatch_7f0b7f089e6914a68e9d3d4c.md`)
- Out of scope: squad batch fan-out credential injection (task_bc455a9d45f7518a8397ac7216)

## Version Impact

- Version: no version change because this is a pre-release fix on the rebuild line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 2bc2ee42b213ae6a6211154d1815b03adb4fb465
- Branch merge-base with `origin/main`: 2bc2ee42b213ae6a6211154d1815b03adb4fb465
- Last `git fetch origin` time: 2026-08-24T15:40Z
- Sync method: none needed
- Public diff command: `git diff 2bc2ee42b213ae6a6211154d1815b03adb4fb465..6952b5690d252910030683e3ebbc28549e831b5c`
- Private evidence commit/path: harness task package task_2acb88e9cd7603fb57cdb05fa1 artifacts/reports
- Reviewer evidence path: same report; pre-fix isolated run 10 pass / 1 fail with leaked vars visible in `ps eww`, post-fix 11 pass / 0 fail with `runtime-scoped env matches: []`
- GitHub Actions `rewrite-ci` run URL: pending (filled after the run)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test` (fast + isolated integration via `tools/dispatch-isolated-test.mjs`)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full `npm run check:local` in the worker environment (worker host had Node 22, `.ts` fast tier fails to load there); GitHub CI is the authority for this PR.

## Review Evidence

- Self-review: CEO read the full diff; the fix is an explicit deny-list at the single launch site, no new mechanism.
- Reviewer subagent: none
- Human review: pending
- Blocking findings: none

## Residual Risk

- The deny-list is explicit; a new runtime-scoped variable introduced later must be added here. The regression test asserts the current list.

## References

- Task: task_2acb88e9cd7603fb57cdb05fa1
- Evidence: fact F-09234340 (original pollution incident)
- Review: pending

---

# 中文

## 概要

共享 daemon 可能被沙箱内的 runtime worker 抢先 autostart,并继承该 worker 的环境(`CODEX_HOME` 指进 runtime-instance home、`HARNESS_ACTOR` 是 worker 会话、provider 密钥),导致全机所有实例凭证解析失效。本 PR 让 `cliDaemonServeLaunch()` 在 spawn daemon 前剔除 runtime 作用域变量,autostart 不再取决于谁赢竞争。

## 改动内容

- `packages/cli/src/daemon/client.ts`:daemon 启动规格改为复制 `process.env` 并删除一份显式的 runtime 作用域键清单(provider home、API key/base URL、会话 id、`HARNESS_ACTOR`、daemon 路由变量)。不加检测、重启或重试层。
- `packages/cli/test/daemon-autostart-cli.test.ts`:integration 回归,在携带全部这些变量的进程里触发 autostart,用 `ps eww -p <pid>` 断言没有任何一个泄漏进常驻 daemon。

## 机读声明说明

- 机读声明只在英文块出现一次。

## 任务与范围

- Harness 任务:task_2acb88e9cd7603fb57cdb05fa1(PLT-Ontology Phase 0.6,接管 task_f543b867d85785a785eadeaee0)
- 分支:`codex/daemon-autostart-env`
- 公开范围:CLI daemon autostart 启动环境 + 一个 integration 测试
- 私有计划 / 证据是否已更新:yes(任务包 `artifacts/reports/dispatch_7f0b7f089e6914a68e9d3d4c.md`)
- 范围外:squad 批量扇出的凭证注入(task_bc455a9d45f7518a8397ac7216)

## 版本影响

- 版本:不改版本,原因是 rebuild 线 pre-release 修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:无
- 依据:不适用
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:2bc2ee42b213ae6a6211154d1815b03adb4fb465
- 当前分支与 `origin/main` 的 merge-base:2bc2ee42b213ae6a6211154d1815b03adb4fb465
- 最近一次 `git fetch origin` 时间:2026-08-24T15:40Z
- 同步方式:不需要
- 公开 diff 命令:`git diff 2bc2ee42b213ae6a6211154d1815b03adb4fb465..6952b5690d252910030683e3ebbc28549e831b5c`
- 私有证据 commit/path:任务包 artifacts/reports
- Reviewer 证据路径:同上;修复前隔离跑 10 pass / 1 fail 且 `ps eww` 可见泄漏变量,修复后 11 pass / 0 fail,`runtime-scoped env matches: []`
- GitHub Actions `rewrite-ci` run URL:待 run 结束后补
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`(fast + 经 `tools/dispatch-isolated-test.mjs` 的隔离 integration)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:worker 环境里的完整 `npm run check:local`(worker 主机是 Node 22,`.ts` fast tier 加载失败);GitHub CI 是本 PR 的权威。

## 审查证据

- 自查:CEO 读完整 diff;修复是单一启动点上的显式 deny-list,无新机制。
- Reviewer subagent:无
- 人工审查:待
- 阻塞发现:无

## 残余风险

- deny-list 是显式的;将来新增的 runtime 作用域变量需要补进来。回归测试锁定当前清单。

## 关联材料

- 任务:task_2acb88e9cd7603fb57cdb05fa1
- 证据:fact F-09234340(原始污染事故)
- 审查:待

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPPk3TmbURWuxcFY3kFimA
