### PR TITLE
feat(daemon): settle authored docs on WAL flush

### DIFF
--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -1,27 +1,13 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { requestLocalDaemonJsonRpc } from "../../daemon/src/client/local-json-rpc-client.ts";
 import { makeTaskEventStore } from "../../kernel/src/index.ts";
 
-import {
-  cli,
-  git,
-  register,
-  run,
-  runMaybe,
-  setup,
-  stop,
-} from "./daemon-multi-repo-lifecycle-cli.fixtures.ts";
+import { cli, git, register, run, runMaybe, setup, stop } from "./daemon-multi-repo-lifecycle-cli.fixtures.ts";
 test("real CLI reaches one resident multi-workspace daemon and publishes Git event -> SQLite -> receipt", async () => {
   const fixture = setup();
   try {
@@ -36,18 +22,9 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
       "--no-link",
     ]);
     assert.notEqual(noDaemon.status, 0);
-    assert.equal(
-      (noDaemon.receipt.error as { code?: string }).code,
-      "daemon_unavailable",
-    );
-    assert.equal(
-      existsSync(path.join(fixture.userRoot, "registry.json")),
-      false,
-    );
-    assert.equal(
-      run(fixture.alpha, fixture.userRoot, ["daemon", "start", "--service"]).ok,
-      true,
-    );
+    assert.equal((noDaemon.receipt.error as { code?: string }).code, "daemon_unavailable");
+    assert.equal(existsSync(path.join(fixture.userRoot, "registry.json")), false);
+    assert.equal(run(fixture.alpha, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
     register(fixture.alpha, fixture.userRoot, "alpha");
     register(fixture.beta, fixture.userRoot, "beta");
     const alphaPreview = run(fixture.alpha, fixture.userRoot, [
@@ -62,10 +39,7 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
     ]);
     assert.equal(alphaPreview.dryRun, true);
     assert.equal(alphaPreview.packagePath, "tasks/task-alpha-alpha");
-    assert.equal(
-      existsSync(path.join(fixture.alpha, "harness/tasks/task-alpha-alpha")),
-      false,
-    );
+    assert.equal(existsSync(path.join(fixture.alpha, "harness/tasks/task-alpha-alpha")), false);
     const textPreview = spawnSync(
       process.execPath,
       [
@@ -144,15 +118,7 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
     };
     assert.equal(fact.state, "standing");
     const factSearch = JSON.parse(
-      String(
-        run(fixture.alpha, fixture.userRoot, [
-          "fact",
-          "search",
-          "Canonical",
-          "--task",
-          "task-alpha",
-        ]).evidence,
-      ),
+      String(run(fixture.alpha, fixture.userRoot, ["fact", "search", "Canonical", "--task", "task-alpha"]).evidence),
     ) as { facts: readonly { factId: string }[] };
     assert.deepEqual(
       factSearch.facts.map((row) => row.factId),
@@ -160,14 +126,7 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
     );
     const factShow = JSON.parse(
       String(
-        run(fixture.alpha, fixture.userRoot, [
-          "fact",
-          "show",
-          "--task",
-          "task-alpha",
-          "--id",
-          fact.factId,
-        ]).evidence,
+        run(fixture.alpha, fixture.userRoot, ["fact", "show", "--task", "task-alpha", "--id", fact.factId]).evidence,
       ),
     ) as { fact: { statement: string } };
     assert.equal(factShow.fact.statement, "Canonical Fact from CLI");
@@ -186,17 +145,8 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
         fulfillments: [],
         relations: [],
       }),
-      decisionPropose = run(fixture.alpha, fixture.userRoot, [
-        "decision",
-        "propose",
-        "--json-input",
-        decisionPacket,
-      ]);
-    assert.equal(
-      decisionPropose.outcome,
-      "applied",
-      JSON.stringify(decisionPropose),
-    );
+      decisionPropose = run(fixture.alpha, fixture.userRoot, ["decision", "propose", "--json-input", decisionPacket]);
+    assert.equal(decisionPropose.outcome, "applied", JSON.stringify(decisionPropose));
     const decision = JSON.parse(String(decisionPropose.evidence)) as {
         decisionId: string;
         state: string;
@@ -228,19 +178,11 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
     assert.equal(acceptedDecision.outcome, "applied");
     assert.match(String(acceptedDecision.consentId), /^djc_[0-9a-f]{26}$/u);
     assert.equal(
-      makeTaskEventStore({ rootDir: fixture.alpha, repoId: "alpha" }).readHead()
-        ?.revision,
+      makeTaskEventStore({ rootDir: fixture.alpha, repoId: "alpha" }).readHead()?.revision,
       beforeAccepted + 1,
     );
     const decisionList = JSON.parse(
-      String(
-        run(fixture.alpha, fixture.userRoot, [
-          "decision",
-          "list",
-          "--search",
-          "Canonical Decision",
-        ]).evidence,
-      ),
+      String(run(fixture.alpha, fixture.userRoot, ["decision", "list", "--search", "Canonical Decision"]).evidence),
     ) as { decisions: readonly { decisionId: string }[] };
     assert.deepEqual(
       decisionList.decisions.map((row) => row.decisionId),
@@ -249,26 +191,13 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
     assert.deepEqual(
       (
         JSON.parse(
-          String(
-            run(fixture.alpha, fixture.userRoot, [
-              "decision",
-              "list",
-              "--search",
-              "Uncanonical",
-            ]).evidence,
-          ),
+          String(run(fixture.alpha, fixture.userRoot, ["decision", "list", "--search", "Uncanonical"]).evidence),
         ) as { decisions: readonly { decisionId: string }[] }
       ).decisions,
       [],
     );
     const decisionShow = JSON.parse(
-      String(
-        run(fixture.alpha, fixture.userRoot, [
-          "decision",
-          "show",
-          decision.decisionId,
-        ]).evidence,
-      ),
+      String(run(fixture.alpha, fixture.userRoot, ["decision", "show", decision.decisionId]).evidence),
     ) as { decision: { decisionId: string; body: unknown } };
     assert.equal(decisionShow.decision.decisionId, decision.decisionId);
     assert.equal(decisionShow.decision.body, null);
@@ -284,46 +213,25 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
       evidenceSource: string;
       statement: string;
     };
-    assert.match(
-      reckonFact.evidenceSource,
-      new RegExp(`^decision/${decision.decisionId}@\\d+$`, "u"),
-    );
+    assert.match(reckonFact.evidenceSource, new RegExp(`^decision/${decision.decisionId}@\\d+$`, "u"));
     assert.match(reckonFact.statement, /no load-bearing claims/u);
     const canonicalEvents = makeTaskEventStore({
       rootDir: fixture.alpha,
       repoId: "alpha",
     }).read().events;
     assert.equal(
-      canonicalEvents.some(
-        (event) =>
-          event.schema === "decision-event/v1" &&
-          event.decisionId === decision.decisionId,
-      ),
+      canonicalEvents.some((event) => event.schema === "decision-event/v1" && event.decisionId === decision.decisionId),
       true,
     );
     assert.equal(
       canonicalEvents.some(
-        (event) =>
-          event.schema === "fact-event/v1" &&
-          event.payload.evidenceSource === reckonFact.evidenceSource,
+        (event) => event.schema === "fact-event/v1" && event.payload.evidenceSource === reckonFact.evidenceSource,
       ),
       true,
     );
-    assert.match(
-      String(
-        run(fixture.alpha, fixture.userRoot, ["task", "show", "task-alpha"])
-          .evidence,
-      ),
-      /Alpha/u,
-    );
+    assert.match(String(run(fixture.alpha, fixture.userRoot, ["task", "show", "task-alpha"]).evidence), /Alpha/u);
     assert.equal(
-      run(fixture.alpha, fixture.userRoot, [
-        "task",
-        "start",
-        "task-alpha",
-        "--execution-id",
-        "exec-doc",
-      ]).outcome,
+      run(fixture.alpha, fixture.userRoot, ["task", "start", "task-alpha", "--execution-id", "exec-doc"]).outcome,
       "applied",
     );
     const progress = run(fixture.alpha, fixture.userRoot, [
@@ -340,15 +248,9 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
     assert.equal(progress.commitSha, null);
     assert.ok(progress.cut);
     assert.equal(progress.worktreeVisible, true);
+    assert.match(String(progress.evidence), /file:tasks\/task-alpha-alpha\/progress\.md/u);
     assert.match(
-      String(progress.evidence),
-      /file:tasks\/task-alpha-alpha\/progress\.md/u,
-    );
-    assert.match(
-      readFileSync(
-        path.join(fixture.alpha, "harness/tasks/task-alpha-alpha/progress.md"),
-        "utf8",
-      ),
+      readFileSync(path.join(fixture.alpha, "harness/tasks/task-alpha-alpha/progress.md"), "utf8"),
       /CLI progress is canonical\..*Evidence: test:reports\/cli\.txt:passed/su,
     );
     const docPath = "tasks/task-alpha-alpha/notes.md",
@@ -356,63 +258,47 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
       authored = path.join(fixture.alpha, "harness", docPath);
     mkdirSync(path.dirname(authored), { recursive: true });
     writeFileSync(authored, docBody);
+    assert.equal(run(fixture.alpha, fixture.userRoot, ["doc", "status", "--path", docPath]).outcome, "applied");
     assert.equal(
-      run(fixture.alpha, fixture.userRoot, ["doc", "status", "--path", docPath])
-        .outcome,
+      run(fixture.alpha, fixture.userRoot, ["doc", "sync", "--submit", "--task", "task-alpha"]).outcome,
       "applied",
     );
-    assert.equal(
-      run(fixture.alpha, fixture.userRoot, [
-        "doc",
-        "sync",
-        "--submit",
-        "--task",
-        "task-alpha",
-      ]).outcome,
-      "applied",
-    );
-    assert.equal(
-      run(fixture.alpha, fixture.userRoot, ["doc", "show", "--path", docPath])
-        .evidence,
-      docBody,
-    );
+    assert.equal(run(fixture.alpha, fixture.userRoot, ["doc", "show", "--path", docPath]).evidence, docBody);
+    const cleanSubmit = runMaybe(fixture.alpha, fixture.userRoot, ["doc", "sync", "--submit", "--path", docPath]);
+    assert.equal(cleanSubmit.status, 0, cleanSubmit.stderr);
+    assert.equal(cleanSubmit.receipt.ok, true, JSON.stringify(cleanSubmit.receipt));
+    assert.equal(cleanSubmit.receipt.outcome, "no_changes", JSON.stringify(cleanSubmit.receipt));
+    assert.equal(cleanSubmit.receipt.code, "no_changes");
+    const invalidSubmit = runMaybe(fixture.alpha, fixture.userRoot, [
+      "doc",
+      "sync",
+      "--submit",
+      "--path",
+      "context/missing.md",
+    ]);
+    assert.equal(invalidSubmit.status, 1, JSON.stringify(invalidSubmit.receipt));
+    assert.equal(invalidSubmit.receipt.ok, false, JSON.stringify(invalidSubmit.receipt));
+    assert.equal(invalidSubmit.receipt.outcome, "op_rejected");
+    assert.equal(invalidSubmit.receipt.code, "document_not_found");
     const blockedPath = "context/other-session.md",
       eligiblePath = "context/this-session.md",
       blockedFile = path.join(fixture.alpha, "harness", blockedPath);
     mkdirSync(path.dirname(blockedFile), { recursive: true });
     writeFileSync(blockedFile, "# Stable\n");
     assert.equal(
-      run(fixture.alpha, fixture.userRoot, [
-        "doc",
-        "sync",
-        "--submit",
-        "--path",
-        blockedPath,
-      ]).outcome,
+      run(fixture.alpha, fixture.userRoot, ["doc", "sync", "--submit", "--path", blockedPath]).outcome,
       "applied",
     );
     writeFileSync(blockedFile, "# Renamed\n");
-    writeFileSync(
-      path.join(fixture.alpha, "harness", eligiblePath),
-      "# Eligible\n",
-    );
-    const partial = run(fixture.alpha, fixture.userRoot, [
-      "doc",
-      "sync",
-      "--submit",
-    ]);
+    writeFileSync(path.join(fixture.alpha, "harness", eligiblePath), "# Eligible\n");
+    const partial = run(fixture.alpha, fixture.userRoot, ["doc", "sync", "--submit"]);
     assert.equal(partial.outcome, "applied", JSON.stringify(partial));
     assert.match(
       String(partial.summary),
       /doc-submit: applied[\s\S]*skipped:[\s\S]*context\/other-session\.md\tblocked\tbase region is missing: "# Stable"/u,
     );
     assert.equal(
-      run(fixture.alpha, fixture.userRoot, [
-        "doc",
-        "show",
-        "--path",
-        eligiblePath,
-      ]).evidence,
+      run(fixture.alpha, fixture.userRoot, ["doc", "show", "--path", eligiblePath]).evidence,
       "# Eligible\n",
     );
     const spoof = await requestLocalDaemonJsonRpc(
@@ -432,52 +318,26 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
     assert.equal(spoof.ok, false);
     assert.equal((spoof.error as { code?: string }).code, "invalid_request");
     const logicalRevisions = new Map([
-      [
-        fixture.alpha,
-        makeTaskEventStore({ rootDir: fixture.alpha, repoId: "alpha" }).read()
-          .revision,
-      ],
-      [
-        fixture.beta,
-        makeTaskEventStore({ rootDir: fixture.beta, repoId: "beta" }).read()
-          .revision,
-      ],
+      [fixture.alpha, makeTaskEventStore({ rootDir: fixture.alpha, repoId: "alpha" }).read().revision],
+      [fixture.beta, makeTaskEventStore({ rootDir: fixture.beta, repoId: "beta" }).read().revision],
     ]);
     stop(fixture.alpha, fixture.userRoot); // explicit drain: Git/fresh readers catch up after acknowledged visibility
     for (const root of [fixture.alpha, fixture.beta]) {
-      const gitHead = JSON.parse(
-        git(root, "show", "refs/ha/canonical:harness/events/head.json"),
-      ) as { revision: number };
+      const gitHead = JSON.parse(git(root, "show", "refs/ha/canonical:harness/events/head.json")) as {
+        revision: number;
+      };
       assert.equal(gitHead.revision, logicalRevisions.get(root));
       assert.equal(
-        git(
-          root,
-          "ls-tree",
-          "--name-only",
-          "refs/ha/canonical",
-          "harness/events",
-        ).includes("harness/events"),
+        git(root, "ls-tree", "--name-only", "refs/ha/canonical", "harness/events").includes("harness/events"),
         true,
       );
-      assert.equal(
-        existsSync(path.join(root, ".harness/cache/task.sqlite")),
-        true,
-      );
-      assert.equal(
-        existsSync(path.join(root, ".harness/write-journal")),
-        false,
-      );
+      assert.equal(existsSync(path.join(root, ".harness/cache/task.sqlite")), true);
+      assert.equal(existsSync(path.join(root, ".harness/write-journal")), false);
     }
     assert.equal(
-      git(
-        fixture.alpha,
-        "grep",
-        "-l",
-        "fact-event/v1",
-        "refs/ha/canonical",
-        "--",
+      git(fixture.alpha, "grep", "-l", "fact-event/v1", "refs/ha/canonical", "--", "harness/events").includes(
         "harness/events",
-      ).includes("harness/events"),
+      ),
       true,
     );
   } finally {
@@ -489,14 +349,12 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
 test("real CLI creates module and subtask-expansion packages through their declared providers", () => {
   const fixture = setup();
   try {
-    assert.equal(
-      run(fixture.alpha, fixture.userRoot, ["daemon", "start", "--service"]).ok,
-      true,
-    );
+    assert.equal(run(fixture.alpha, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
     register(fixture.alpha, fixture.userRoot, "alpha");
-    const catalog = JSON.parse(
-      String(run(fixture.alpha, fixture.userRoot, ["preset", "list"]).evidence),
-    ) as Array<{ id: string; validity: string }>;
+    const catalog = JSON.parse(String(run(fixture.alpha, fixture.userRoot, ["preset", "list"]).evidence)) as Array<{
+      id: string;
+      validity: string;
+    }>;
     assert.deepEqual(
       catalog
         .filter(({ id }) => ["module", "subtask-expansion"].includes(id))
@@ -507,15 +365,8 @@ test("real CLI creates module and subtask-expansion packages through their decla
       ],
     );
     assert.equal(
-      run(fixture.alpha, fixture.userRoot, [
-        "task",
-        "create",
-        "--id",
-        "task-parent",
-        "--admin",
-        "--title",
-        "Parent",
-      ]).outcome,
+      run(fixture.alpha, fixture.userRoot, ["task", "create", "--id", "task-parent", "--admin", "--title", "Parent"])
+        .outcome,
       "applied",
     );
     const moduleTask = run(fixture.alpha, fixture.userRoot, [
@@ -542,28 +393,13 @@ test("real CLI creates module and subtask-expansion packages through their decla
     assert.equal(moduleTask.outcome, "applied", JSON.stringify(moduleTask));
     assert.deepEqual(
       (moduleTask.generatedPaths as string[])
-        .filter((target) =>
-          /(?:module\.md|module_(?:plan|brief|session_prompt)\.md)$/u.test(
-            target,
-          ),
-        )
+        .filter((target) => /(?:module\.md|module_(?:plan|brief|session_prompt)\.md)$/u.test(target))
         .map((target) => path.basename(target))
         .sort(),
-      [
-        "module.md",
-        "module_brief.md",
-        "module_plan.md",
-        "module_session_prompt.md",
-      ],
+      ["module.md", "module_brief.md", "module_plan.md", "module_session_prompt.md"],
     );
     assert.match(
-      readFileSync(
-        path.join(
-          fixture.alpha,
-          "harness/tasks/task-module-module-task/module.md",
-        ),
-        "utf8",
-      ),
+      readFileSync(path.join(fixture.alpha, "harness/tasks/task-module-module-task/module.md"), "utf8"),
       /Module key: kernel[\s\S]*Module title: Kernel[\s\S]*Module prefix: KER[\s\S]*Module scope: packages\/kernel\/\*\*/u,
     );
     const child = run(fixture.alpha, fixture.userRoot, [
@@ -585,26 +421,13 @@ test("real CLI creates module and subtask-expansion packages through their decla
       repoId: "alpha",
     })
       .read()
-      .events.find(
-        (event) =>
-          event.schema === "task-bootstrap-event/v1" &&
-          event.taskId === "task-child",
-      );
+      .events.find((event) => event.schema === "task-bootstrap-event/v1" && event.taskId === "task-child");
     assert.equal(
-      childEvent?.schema === "task-bootstrap-event/v1"
-        ? childEvent.payload.task.metadata.parentTaskId
-        : null,
+      childEvent?.schema === "task-bootstrap-event/v1" ? childEvent.payload.task.metadata.parentTaskId : null,
       "task-parent",
     );
     const children = JSON.parse(
-      String(
-        run(fixture.alpha, fixture.userRoot, [
-          "task",
-          "list",
-          "--parent",
-          "task-parent",
-        ]).evidence,
-      ),
+      String(run(fixture.alpha, fixture.userRoot, ["task", "list", "--parent", "task-parent"]).evidence),
     ) as { rows: Array<{ taskId: string }> };
     assert.deepEqual(
       children.rows.map(({ taskId }) => taskId),

--- a/packages/daemon/src/doc-sync-candidate-scanner.ts
+++ b/packages/daemon/src/doc-sync-candidate-scanner.ts
@@ -431,7 +431,12 @@ function dirtyPaths(repoRoot: string, authoredPrefix: string): string[] {
   return [
     ...new Set(
       [...changed, ...untracked]
-        .filter((value) => (!prefix || value.startsWith(prefix)) && !value.includes(".conflict-"))
+        .filter(
+          (value) =>
+            (!prefix || value.startsWith(prefix)) &&
+            !value.includes(".conflict-") &&
+            !/\/\.ha-(?:visible|settle)-/u.test(`/${value}`),
+        )
         .map((value) => value.slice(prefix.length))
         .concat(conflictLogicalPaths(path.join(repoRoot, authoredPrefix))),
     ),

--- a/packages/daemon/src/doc-sync-settlement.ts
+++ b/packages/daemon/src/doc-sync-settlement.ts
@@ -232,15 +232,17 @@ export function noOp(input: Input, scan: DocCandidateScan): DocSettlementReceipt
   const revision = input.store.readHead()?.revision ?? 0,
     nextAction = "no eligible document changes to submit";
   return {
-    outcome: "op_rejected",
+    outcome: "no_changes",
     opId: `noop:${scan.baseLedgerSha.headDigest}`,
     revision,
     code: "no_changes",
     origin: "doc-sync",
     evidence: "doc-sync:no-op",
+    visibility: "center",
+    proof: proof(revision, revision, true, true),
     nextAction,
     detail: { ...scanDetail(input, scan, "no_changes"), nextAction },
-    summary: submitSummary("op_rejected", [], scan),
+    summary: submitSummary("no_changes", [], scan),
   };
 }
 

--- a/packages/daemon/src/doc-sync-settlement.ts
+++ b/packages/daemon/src/doc-sync-settlement.ts
@@ -15,7 +15,7 @@ import type { DocSettlementReceipt, Input } from "./doc-sync-command-actions.ts"
 import { detail, holder, isTaskPackagePath, touch } from "./doc-sync-details.ts";
 import { localProseSource, proof } from "./doc-sync-files.ts";
 
-export function scanReceipt(input: Input, scan: DocCandidateScan): WriteReceipt {
+export function scanReceipt(input: Input, scan: DocCandidateScan): DocSettlementReceipt {
   const revision = input.store.readHead()?.revision ?? 0,
     report = publicScan(scan),
     opId = `scan:${input.action.kind}:${scan.baseLedgerSha.headDigest}`,
@@ -50,7 +50,24 @@ export function scanReceipt(input: Input, scan: DocCandidateScan): WriteReceipt 
           scan.rows.every((row) => row.state === "clean"),
         ),
         detail,
+        ...(input.action.kind === "doc-status" ? { summary: statusSummary(scan) } : {}),
       };
+}
+
+function statusSummary(scan: DocCandidateScan): string {
+  const blocked = scan.rows.filter(
+      (row) => row.state === "blocked" || row.state === "deletion" || row.state === "conflict",
+    ),
+    eligible = scan.rows.filter((row) => row.state === "eligible").length,
+    inapplicable = scan.rows.filter((row) => row.state === "inapplicable").length;
+  return [
+    blocked.length ? `doc-status: BLOCKED (${blocked.length})` : "doc-status: clean",
+    ...(blocked.length
+      ? ["blocked:", ...blocked.map((row) => `${row.path}\t${row.state}\t${row.reason ?? "candidate is blocked"}`)]
+      : []),
+    `eligible: ${eligible}`,
+    `inapplicable: ${inapplicable}`,
+  ].join("\n");
 }
 
 export function scanDetail(input: Input, scan: DocCandidateScan, code: string): DocSyncReceiptDetail {

--- a/packages/daemon/src/fleet-edge-doc-sync.ts
+++ b/packages/daemon/src/fleet-edge-doc-sync.ts
@@ -202,7 +202,7 @@ export async function runFleetEdgeDocSync(input: FleetEdgeDocSyncRequest): Promi
         mediaType: change.mediaType,
       })),
     });
-    if (pushed.center.outcome === "applied") {
+    if (pushed.center.outcome === "applied" || pushed.center.outcome === "no_changes") {
       // PULLING — land this node's own effect in the mirror. A pull that finds
       // another divergence reports pull_blocked and ok:false; canonical
       // success is never presented as locally synced (§8).
@@ -450,7 +450,7 @@ export async function runFleetEdgeConflictExit(input: FleetEdgeConflictExitReque
         baseBlobSha256: row.centerBlobSha256,
       })),
     });
-    if (pushed.center.outcome !== "applied")
+    if (pushed.center.outcome !== "applied" && pushed.center.outcome !== "no_changes")
       return {
         schema: "command-receipt/v2",
         ok: false,

--- a/packages/daemon/src/fleet/contract.ts
+++ b/packages/daemon/src/fleet/contract.ts
@@ -88,7 +88,7 @@ export type FleetFrameV1 =
       "fleet.doc.result/v1",
       {
         inReplyTo: string;
-        outcome: "applied" | "pending" | "op_rejected" | "indeterminate";
+        outcome: "applied" | "pending" | "no_changes" | "op_rejected" | "indeterminate";
         opId: string;
         revision: number | null;
         code: string | null;
@@ -426,7 +426,7 @@ const schemas: Readonly<Record<string, Check>> = {
   }),
   "fleet.doc.result/v1": shape({
     ...reply,
-    outcome: one("applied", "pending", "op_rejected", "indeterminate"),
+    outcome: one("applied", "pending", "no_changes", "op_rejected", "indeterminate"),
     opId: text,
     revision: nullable(uint),
     code: nullable(text),

--- a/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
@@ -66,12 +66,12 @@ export type DaemonGuiReadResultMap = {
     ReturnType<typeof import("../../../kernel/src/projection/sqlite-task-projection.ts").readRelationGraphProjection>,
     "taskRows" | "coverageRows"
   > & {
-    /** Coverage rows as served: the kernel row plus the optional uncovered-cause
-     * classification (kernel `freshnessReasonOf`), attached only to uncovered rows.
-     * Optional so older daemons and every persisted record shape stay valid. */
-    readonly coverageRows: readonly (RelationCoverageRow & { readonly freshnessReason?: FreshnessReason })[];
-    readonly page?: ProjectionPage;
-  };
+      /** Coverage rows as served: the kernel row plus the optional uncovered-cause
+       * classification (kernel `freshnessReasonOf`), attached only to uncovered rows.
+       * Optional so older daemons and every persisted record shape stay valid. */
+      readonly coverageRows: readonly (RelationCoverageRow & { readonly freshnessReason?: FreshnessReason })[];
+      readonly page?: ProjectionPage;
+    };
   readonly "repo.decisions.list": {
     readonly ok: true;
     readonly decisions: readonly DecisionProjectionRow[];
@@ -125,7 +125,7 @@ export type DaemonGuiReadPayloadMap = {
   readonly "repo.agentRuntime.overview": {
     readonly taskId?: string;
     readonly limit?: number;
-    readonly cursor?: string
+    readonly cursor?: string;
   };
   readonly "repo.agentRuntime.sessions.read": {
     readonly runtimeSessionId: string;
@@ -369,7 +369,7 @@ export type DaemonGuiActionResult = JsonObject & {
   readonly schema: "command-receipt/v2";
   readonly ok: boolean;
   readonly command: string;
-  readonly outcome: "applied" | "pending" | "indeterminate" | "op_rejected";
+  readonly outcome: "applied" | "pending" | "no_changes" | "indeterminate" | "op_rejected";
   readonly opId: string;
 };
 

--- a/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
@@ -201,6 +201,7 @@ export function writeReceipt(value: JsonObject): string[] {
     proof = isJsonObject(value.proof) ? value.proof : {},
     applied = outcome === "applied",
     pending = outcome === "pending",
+    noChanges = outcome === "no_changes",
     failed = outcome === "op_rejected" || outcome === "indeterminate",
     validProof =
       exactRecord(proof, ["committedRevision", "appliedCut", "durable", "canonicalVisible", "worktreeVisible"]) &&
@@ -212,10 +213,11 @@ export function writeReceipt(value: JsonObject): string[] {
   return !statusWord(receiptOutcomeWords, outcome) ||
     !nonEmpty(value.opId) ||
     (value.revision !== undefined && (!integer(value.revision) || Number(value.revision) < 0)) ||
-    ((applied || pending) &&
+    ((applied || pending || noChanges) &&
       (!validProof || value.visibility !== "center" || !integer(value.revision) || !nonEmpty(value.evidence))) ||
     (applied && (!proof.durable || !proof.canonicalVisible || proof.committedRevision !== proof.appliedCut)) ||
     (pending && !nonEmpty(value.nextAction)) ||
+    (noChanges && (![value.code, value.origin, value.nextAction].every(nonEmpty) || value.code !== "no_changes")) ||
     (failed &&
       (![value.code, value.origin, value.nextAction].every(nonEmpty) ||
         (value.evidence !== undefined && !nonEmpty(value.evidence))))
@@ -229,7 +231,7 @@ export function validateDaemonGuiCommandReceipt(value: unknown): readonly string
     receipt = Object.fromEntries(
       writeReceiptFields.filter((field) => Object.hasOwn(value, field)).map((field) => [field, value[field]]),
     ) as JsonObject,
-    ok = value.outcome === "applied" || value.outcome === "pending",
+    ok = value.outcome === "applied" || value.outcome === "pending" || value.outcome === "no_changes",
     errors =
       Object.keys(value).some((field) => !allowed.includes(field)) ||
       value.schema !== "command-receipt/v2" ||

--- a/packages/daemon/src/protocol/daemon-protocol-vocabulary.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-vocabulary.ts
@@ -23,7 +23,7 @@ export const decisionStateWords = [
   "outcome_retired",
 ] as const;
 
-export const receiptOutcomeWords = ["applied", "pending", "indeterminate", "op_rejected"] as const;
+export const receiptOutcomeWords = ["applied", "pending", "no_changes", "indeterminate", "op_rejected"] as const;
 
 export const daemonRepoModeWords = Object.freeze([
   "local",

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -492,7 +492,7 @@ export function createJsonRpcProtocolServer(options: {
     if (action.kind === "preset-run-start" || action.kind === "preset-run-status")
       return reply((await options.host.presetRun(repo, action, options.authContext)) as unknown as JsonObject);
     const receipt = await options.host.run(repo, action, options.authContext);
-    const ok = receipt.outcome === "applied" || receipt.outcome === "pending";
+    const ok = receipt.outcome === "applied" || receipt.outcome === "pending" || receipt.outcome === "no_changes";
     const result = {
       schema: "command-receipt/v2",
       ok,

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -30,9 +30,13 @@ export const repoCellTaskQueryJudgments: TaskQueryJudgments = {
 
 export function initializeRepoCell(context: any): any {
   let projection: ReturnType<typeof makeTaskProjection> | null = null;
+  let settlementPending = false;
   const settleAuthoredCandidates = (): void => {
     const currentProjection = projection;
-    if (currentProjection === null) return;
+    if (currentProjection === null) {
+      settlementPending = true;
+      return;
+    }
     void runDocAction({
       action: { kind: "doc-submit", paths: [] },
       binding: localRepairBinding,
@@ -74,7 +78,7 @@ export function initializeRepoCell(context: any): any {
     }),
     recovery = store.recover();
   projection = makeTaskProjection({ rootDir: context.rootDir, eventStore: store, now: context.now });
-  if (recovery.status === "committed" || recovery.status === "already_committed") settleAuthoredCandidates();
+  if (settlementPending) settleAuthoredCandidates();
   const currentSessionIdentity = (binding: RepoCellBinding) => resolveWriteSessionIdentity(binding, projection!);
   const factActions = makeFactActions({
       store,

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -3,7 +3,9 @@ import { makeTaskLifecycleService } from "../../application/src/task-lifecycle-s
 import { blockingOf, closeoutReadiness, makeTaskEventStore, makeTaskProjection } from "../../kernel/src/index.ts";
 import { makeAgentRuntimeReadModel } from "./agent-runtime-read.ts";
 import { readTaskDispatches } from "./dispatch-read.ts";
+import { localRepairBinding } from "./daemon-host-binding.ts";
 import { makeDecisionActions } from "./decision-actions.ts";
+import { runDocAction } from "./doc-sync-actions.ts";
 import { makeFactActions } from "./fact-actions.ts";
 import { openReplicaCutSource } from "./fleet/replica-cut-store.ts";
 import type { RepoCellBinding } from "./repo-cell-types.ts";
@@ -27,19 +29,53 @@ export const repoCellTaskQueryJudgments: TaskQueryJudgments = {
 };
 
 export function initializeRepoCell(context: any): any {
+  let projection: ReturnType<typeof makeTaskProjection> | null = null;
+  const settleAuthoredCandidates = (): void => {
+    const currentProjection = projection;
+    if (currentProjection === null) return;
+    void runDocAction({
+      action: { kind: "doc-submit", paths: [] },
+      binding: localRepairBinding,
+      workspaceId: context.input.repoId,
+      rootDir: context.rootDir,
+      store,
+      projection: currentProjection,
+      now: context.now,
+      killpoint: context.input.killpoint,
+    })
+      .then((receipt) => {
+        const blocked = [
+          ...(receipt.detail?.unresolvedTouches ?? []).map(
+            (touch) => `${touch.path} (${touch.requiredRoute})`,
+          ),
+          ...(receipt.detail?.deletions ?? []).map((deletion) => `${deletion.path} (deletion)`),
+        ];
+        if (blocked.length)
+          console.warn(
+            `[wal-materializer] authored doc candidates blocked; run ha doc status: ${blocked.join(", ")}`,
+          );
+      })
+      .catch((error) => {
+        console.warn(
+          `[wal-materializer] authored doc scan failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      });
+  };
   const store = makeTaskEventStore({
       repoId: context.input.repoId,
       rootDir: context.rootDir,
       authoredBranch: context.authoredBranch,
       killpoint: context.input.killpoint,
+      afterFlush: settleAuthoredCandidates,
       beforeAppend: () => context.activeWriterEpochGuard?.(),
       withAppendFence: (operation) =>
         context.activeWriterEpochFence ? context.activeWriterEpochFence(operation) : operation(),
       rejectPreparedRecovery: context.mode === "remote-center",
     }),
-    recovery = store.recover(),
-    projection = makeTaskProjection({ rootDir: context.rootDir, eventStore: store, now: context.now }),
-    currentSessionIdentity = (binding: RepoCellBinding) => resolveWriteSessionIdentity(binding, projection);
+    recovery = store.recover();
+  projection = makeTaskProjection({ rootDir: context.rootDir, eventStore: store, now: context.now });
+  if (recovery.status === "committed" || recovery.status === "already_committed") settleAuthoredCandidates();
+  const currentSessionIdentity = (binding: RepoCellBinding) => resolveWriteSessionIdentity(binding, projection!);
   const factActions = makeFactActions({
       store,
       projection,

--- a/packages/daemon/test/authored-wal-doc-sync.integration.test.ts
+++ b/packages/daemon/test/authored-wal-doc-sync.integration.test.ts
@@ -1,0 +1,56 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { openRepoCell } from "../src/repo-cell.ts";
+import { actor, git, initRepo, write } from "./doc-sync-slice-a.fixtures.ts";
+
+test("WAL flush settles an eligible authored edit and status highlights blocked candidates", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-authored-wal-doc-sync-"));
+  initRepo(rootDir);
+  const cell = await openRepoCell({
+    repoId: workspaceId("authored-wal-doc-sync"),
+    rootDir: canonicalRoot(rootDir),
+    ownerId: "authored-wal-doc-sync-daemon",
+  });
+  const binding = { actor, source: "local" as const };
+  try {
+    assert.equal(
+      (await cell.run({ kind: "task-create", taskId: "task-authored-wal", title: "Authored WAL" }, binding)).outcome,
+      "applied",
+    );
+    write(rootDir, "context/auto.md", "# Settled by WAL\n");
+
+    const tracked = path.join(rootDir, "harness/context/auto.md"),
+      deadline = Date.now() + 10_000;
+    while (!gitHasPath(rootDir, "harness/context/auto.md") && Date.now() < deadline)
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    assert.equal(gitHasPath(rootDir, "harness/context/auto.md"), true, "eligible edit did not reach HEAD in time");
+    assert.equal(readFileSync(tracked, "utf8"), "# Settled by WAL\n");
+
+    write(rootDir, "harness.yaml", "schema: hand-edited\n");
+    const status = await cell.run({ kind: "doc-status", paths: ["harness.yaml"] }, binding);
+    assert.match(status.summary ?? "", /doc-status: BLOCKED \(1\)/u);
+    assert.match(status.summary ?? "", /harness\.yaml\tblocked/u);
+  } finally {
+    await cell.close();
+    assert.equal(git(rootDir, "diff", "--name-only"), "");
+    assert.match(git(rootDir, "status", "--porcelain", "-uall"), /\?\? harness\/harness\.yaml/u);
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+function gitHasPath(rootDir: string, target: string): boolean {
+  try {
+    execFileSync("git", ["-C", rootDir, "ls-files", "--error-unmatch", "--", target], {
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/daemon/test/authored-wal-doc-sync.integration.test.ts
+++ b/packages/daemon/test/authored-wal-doc-sync.integration.test.ts
@@ -5,6 +5,7 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { makeTaskEventStore, sha256Text } from "../../kernel/src/index.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { openRepoCell } from "../src/repo-cell.ts";
 import { actor, git, initRepo, write } from "./doc-sync-slice-a.fixtures.ts";
@@ -44,6 +45,123 @@ test("WAL flush settles an eligible authored edit and status highlights blocked 
   }
 });
 
+test("WAL flush keeps forbidden and unresolved candidates out of an eligible batch", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-authored-wal-mixed-"));
+  initRepo(rootDir);
+  const repoId = workspaceId("authored-wal-mixed"),
+    cell = await openRepoCell({
+      repoId,
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "authored-wal-mixed-daemon",
+    }),
+    binding = { actor, source: "local" as const };
+  try {
+    assert.equal(
+      (await cell.run({ kind: "task-create", taskId: "task-mixed", title: "Mixed WAL" }, binding)).outcome,
+      "applied",
+    );
+    const unresolved = "context/unresolved.md";
+    write(rootDir, unresolved, "---\nowner: canonical\n---\n# Unresolved\n\nbase\n");
+    assert.equal((await cell.run({ kind: "doc-submit", paths: [unresolved] }, binding)).outcome, "applied");
+    await waitForHeadBody(rootDir, unresolved, "---\nowner: canonical\n---\n# Unresolved\n\nbase\n");
+
+    write(rootDir, unresolved, "---\nowner: hand-edit\n---\n# Unresolved\n\nbase\n");
+    write(rootDir, "context/eligible.md", "# Eligible\n\nsettled in the same WAL cut\n");
+    write(rootDir, "harness.yaml", "schema: hand-edited\n");
+    const transition = await cell.run(
+      { kind: "task-start", taskId: "task-mixed", executionId: "execution-mixed" },
+      binding,
+    );
+    assert.equal(transition.outcome, "applied", JSON.stringify(transition));
+    await waitForHeadBody(rootDir, "context/eligible.md", "# Eligible\n\nsettled in the same WAL cut\n");
+
+    const status = await cell.run(
+        { kind: "doc-status", paths: ["context/eligible.md", unresolved, "harness.yaml"] },
+        binding,
+      ),
+      statusRows = JSON.parse((status.evidence ?? "").slice("doc-scan:".length)) as {
+        rows: readonly { readonly path: string; readonly state: string }[];
+      };
+    assert.equal(statusRows.rows.find((row) => row.path === "context/eligible.md")?.state, "clean");
+    assert.equal(statusRows.rows.find((row) => row.path === unresolved)?.state, "blocked");
+    assert.equal(statusRows.rows.find((row) => row.path === "harness.yaml")?.state, "blocked");
+    assert.match(status.summary ?? "", /doc-status: BLOCKED \(2\)/u);
+    assert.equal(
+      readFileSync(path.join(rootDir, "harness", unresolved), "utf8"),
+      "---\nowner: hand-edit\n---\n# Unresolved\n\nbase\n",
+    );
+    assert.equal(readFileSync(path.join(rootDir, "harness", "harness.yaml"), "utf8"), "schema: hand-edited\n");
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("a repeated authored write target settles to the latest WAL claim", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-authored-wal-repeat-"));
+  initRepo(rootDir);
+  const repoId = workspaceId("authored-wal-repeat"),
+    cell = await openRepoCell({
+      repoId,
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "authored-wal-repeat-daemon",
+    }),
+    binding = { actor, source: "local" as const },
+    logical = "context/repeated.md",
+    firstBody = "# Repeated\n\nfirst claim\n",
+    latestBody = "# Repeated\n\nlatest claim\n";
+  try {
+    write(rootDir, logical, firstBody);
+    const first = await cell.run({ kind: "doc-submit", paths: [logical] }, binding);
+    assert.equal(first.outcome, "applied", JSON.stringify(first));
+    write(rootDir, logical, latestBody);
+    const second = await cell.run({ kind: "doc-submit", paths: [logical] }, binding);
+    assert.equal(second.outcome, "applied", JSON.stringify(second));
+    await waitForHeadBody(rootDir, logical, latestBody);
+    assert.equal(git(rootDir, "show", `HEAD:harness/${logical}`), latestBody.trim());
+    const events = makeTaskEventStore({ repoId, rootDir })
+      .read()
+      .events.filter((event) => event.schema === "doc-event/v1");
+    assert.equal(events.length, 2);
+    assert.equal(events.at(-1)?.schema, "doc-event/v1");
+    if (events.at(-1)?.schema === "doc-event/v1")
+      assert.equal(events.at(-1).payload.changes[0]?.candidate?.sha256, sha256Text(latestBody));
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("closing after a state transition drains a settlement event created by the same flush", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-authored-wal-close-"));
+  initRepo(rootDir);
+  const repoId = workspaceId("authored-wal-close"),
+    cell = await openRepoCell({
+      repoId,
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "authored-wal-close-daemon",
+    }),
+    binding = { actor, source: "local" as const },
+    logical = "context/close-settlement.md",
+    body = "# Close settlement\n\nflush before close\n";
+  try {
+    assert.equal(
+      (await cell.run({ kind: "task-create", taskId: "task-close", title: "Close settlement" }, binding)).outcome,
+      "applied",
+    );
+    write(rootDir, logical, body);
+    assert.equal(
+      (await cell.run({ kind: "task-start", taskId: "task-close", executionId: "execution-close" }, binding)).outcome,
+      "applied",
+    );
+    await cell.close();
+    assert.equal(git(rootDir, "show", `HEAD:harness/${logical}`), body.trim());
+    assert.equal(git(rootDir, "diff", "--name-only"), "");
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 function gitHasPath(rootDir: string, target: string): boolean {
   try {
     execFileSync("git", ["-C", rootDir, "ls-files", "--error-unmatch", "--", target], {
@@ -53,4 +171,17 @@ function gitHasPath(rootDir: string, target: string): boolean {
   } catch {
     return false;
   }
+}
+
+async function waitForHeadBody(rootDir: string, logical: string, expected: string): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (
+      gitHasPath(rootDir, `harness/${logical}`) &&
+      git(rootDir, "show", `HEAD:harness/${logical}`) === expected.trim()
+    )
+      return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert.equal(git(rootDir, "show", `HEAD:harness/${logical}`), expected.trim());
 }

--- a/packages/daemon/test/doc-sync-slice-a-task-plan-titles.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a-task-plan-titles.test.ts
@@ -1,12 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import {
-  mkdtempSync,
-  readFileSync,
-  readdirSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -19,19 +13,10 @@ import {
   reduceTaskEvent,
   sha256Text,
 } from "../../kernel/src/index.ts";
-import {
-  canonicalRoot,
-  workspaceId,
-} from "../src/protocol/daemon-protocol.contract.ts";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { openRepoCell } from "../src/repo-cell.ts";
 
-import {
-  actor,
-  blockedReason,
-  initRepo,
-  rows,
-  write,
-} from "./doc-sync-slice-a.fixtures.ts";
+import { actor, blockedReason, initRepo, rows, write } from "./doc-sync-slice-a.fixtures.ts";
 // F-42D28979/F-F4814511: a task plan whose H1 no longer matches the ledger
 // title is the highest-frequency doc-sync block; the receipt must name the
 // mechanical fix, and following it verbatim must leave the healed task idempotent.
@@ -48,10 +33,7 @@ test("a renamed task plan H1 receipt names the exact title restore and the heal 
     taskId = "task_H1REST0RE000000000000AAAAA",
     title = "很长的自解释标题:带括号与路径的完整 create title";
   try {
-    const created = (await cell.run(
-        { kind: "task-create", taskId, title },
-        binding,
-      )) as { packagePath?: string },
+    const created = (await cell.run({ kind: "task-create", taskId, title }, binding)) as { packagePath?: string },
       plan = `${created.packagePath}/task_plan.md`,
       target = path.join(rootDir, "harness", plan);
     const scaffold = readFileSync(target, "utf8");
@@ -64,31 +46,22 @@ test("a renamed task plan H1 receipt names the exact title restore and the heal 
       `restore the H1 of ${plan.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")} to the task title verbatim \\("# ${title.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")}"\\), then rerun ha doc sync --submit --path ${plan.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")}`,
       "u",
     );
-    const status = (await cell.run(
-      { kind: "doc-status", paths: [plan] },
-      binding,
-    )) as { detail?: { nextAction?: string } };
-    assert.equal(
-      rows(
-        (await cell.run({ kind: "doc-status", paths: [plan] }, binding))
-          .evidence,
-      )[0]?.state,
-      "blocked",
-    );
+    const status = (await cell.run({ kind: "doc-status", paths: [plan] }, binding)) as {
+      detail?: { nextAction?: string };
+    };
+    assert.equal(rows((await cell.run({ kind: "doc-status", paths: [plan] }, binding)).evidence)[0]?.state, "blocked");
     assert.match(status.detail?.nextAction ?? "", restore);
-    const rejected = (await cell.run(
-      { kind: "doc-submit", paths: [plan] },
-      binding,
-    )) as { outcome?: string; code?: string; nextAction?: string };
+    const rejected = (await cell.run({ kind: "doc-submit", paths: [plan] }, binding)) as {
+      outcome?: string;
+      code?: string;
+      nextAction?: string;
+    };
     assert.equal(rejected.outcome, "op_rejected");
     assert.equal(rejected.code, "preview_blocked");
     assert.match(rejected.nextAction ?? "", restore);
-    writeFileSync(
-      target,
-      readFileSync(target, "utf8").replace("# 好读的短标题", `# ${title}`),
-    );
+    writeFileSync(target, readFileSync(target, "utf8").replace("# 好读的短标题", `# ${title}`));
     const healed = await cell.run({ kind: "doc-submit", taskId }, binding);
-    assert.equal(healed.outcome, "op_rejected", JSON.stringify(healed));
+    assert.equal(healed.outcome, "no_changes", JSON.stringify(healed));
     assert.equal(healed.code, "no_changes", JSON.stringify(healed));
   } finally {
     await cell.close();
@@ -110,27 +83,18 @@ test("amending the title retitles the published plan through the typed route and
     firstTitle = "amend retitle first title",
     secondTitle = "amend retitle second title";
   try {
-    const created = (await cell.run(
-        { kind: "task-create", taskId, title: firstTitle },
-        binding,
-      )) as { packagePath?: string },
+    const created = (await cell.run({ kind: "task-create", taskId, title: firstTitle }, binding)) as {
+        packagePath?: string;
+      },
       plan = `${created.packagePath}/task_plan.md`,
       target = path.join(rootDir, "harness", plan);
     const scaffold = readFileSync(target, "utf8");
-    assert.match(
-      scaffold.split("\n")[0] ?? "",
-      /^# amend retitle first title$/u,
-    );
-    writeFileSync(
-      target,
-      `${scaffold}\n## Worker Notes\n\nfirst round of worker prose\n`,
-    );
+    assert.match(scaffold.split("\n")[0] ?? "", /^# amend retitle first title$/u);
+    writeFileSync(target, `${scaffold}\n## Worker Notes\n\nfirst round of worker prose\n`);
     assert.equal(
       (await cell.run({ kind: "doc-submit", paths: [plan] }, binding)).outcome,
       "applied",
-      JSON.stringify(
-        await cell.run({ kind: "doc-status", paths: [plan] }, binding),
-      ),
+      JSON.stringify(await cell.run({ kind: "doc-status", paths: [plan] }, binding)),
     );
     const amended = (await cell.run(
       {
@@ -146,51 +110,22 @@ test("amending the title retitles the published plan through the typed route and
       `amend changedPaths must retitle the plan: ${JSON.stringify(amended.changedPaths)}`,
     );
     const retitled = readFileSync(target, "utf8");
-    assert.match(
-      retitled.split("\n")[0] ?? "",
-      /^# amend retitle second title$/u,
-    );
+    assert.match(retitled.split("\n")[0] ?? "", /^# amend retitle second title$/u);
     assert.match(retitled, /## Worker Notes\n\nfirst round of worker prose/u);
-    const amendEvent = makeTaskEventStore({ repoId, rootDir }).readEvent(
-      amended.opId!,
-    );
+    const amendEvent = makeTaskEventStore({ repoId, rootDir }).readEvent(amended.opId!);
     assert.equal(amendEvent?.type, "task_amended");
     if (amendEvent?.type === "task_amended") {
-      const planClaim = amendEvent.payload.documentClaims.find(
-        (claim) => claim.path === plan,
-      );
+      const planClaim = amendEvent.payload.documentClaims.find((claim) => claim.path === plan);
       assert.ok(planClaim, "amend event must claim the retitled plan");
       assert.equal(planClaim.policyId, "markdown-body-replaceable/v1");
     }
     rebuildTaskProjection({ rootDir });
-    const projected = (await cell.run(
-      { kind: "doc-show", path: plan },
-      binding,
-    )) as { evidence?: string };
-    assert.match(
-      (projected.evidence ?? "").split("\n")[0] ?? "",
-      /^# amend retitle second title$/u,
-    );
-    writeFileSync(
-      target,
-      retitled.replace(
-        "first round of worker prose",
-        "second round of worker prose",
-      ),
-    );
-    const status = await cell.run(
-      { kind: "doc-status", paths: [plan] },
-      binding,
-    );
-    assert.equal(
-      rows(status.evidence)[0]?.state,
-      "eligible",
-      JSON.stringify(status),
-    );
-    const resubmitted = await cell.run(
-      { kind: "doc-submit", paths: [plan] },
-      binding,
-    );
+    const projected = (await cell.run({ kind: "doc-show", path: plan }, binding)) as { evidence?: string };
+    assert.match((projected.evidence ?? "").split("\n")[0] ?? "", /^# amend retitle second title$/u);
+    writeFileSync(target, retitled.replace("first round of worker prose", "second round of worker prose"));
+    const status = await cell.run({ kind: "doc-status", paths: [plan] }, binding);
+    assert.equal(rows(status.evidence)[0]?.state, "eligible", JSON.stringify(status));
+    const resubmitted = await cell.run({ kind: "doc-submit", paths: [plan] }, binding);
     assert.equal(resubmitted.outcome, "applied", JSON.stringify(resubmitted));
   } finally {
     await cell.close();
@@ -213,15 +148,14 @@ test("a no-op title amend heals a plan whose canonical base still holds the pre-
       ownerId: "amend-noop-daemon",
     });
     const binding = { actor, source: "local" as const };
-    const created = (await cell.run(
-        { kind: "task-create", taskId, title: firstTitle },
-        binding,
-      )) as { packagePath?: string },
+    const created = (await cell.run({ kind: "task-create", taskId, title: firstTitle }, binding)) as {
+        packagePath?: string;
+      },
       packagePath = created.packagePath!,
       plan = `${packagePath}/task_plan.md`,
       target = path.join(rootDir, "harness", plan);
     const initialSync = await cell.run({ kind: "doc-submit", taskId }, binding);
-    assert.equal(initialSync.outcome, "op_rejected", JSON.stringify(initialSync));
+    assert.equal(initialSync.outcome, "no_changes", JSON.stringify(initialSync));
     assert.equal(initialSync.code, "no_changes", JSON.stringify(initialSync));
     // Seed the stock shape directly: a title amend whose ledger was written before the typed
     // retitle existed (claims INDEX + contract only), so canonical keeps the old-H1 plan base
@@ -257,9 +191,7 @@ test("a no-op title amend heals a plan whose canonical base still holds the pre-
       snapshot: reduceTaskEvent(read.snapshot, seedEvent),
       packagePath,
       currentDocuments: ["INDEX.md", "task-contract.json"].map((leaf) => {
-        const document = projection.readDocument(
-          `${packagePath}/${leaf}`,
-        ).document!;
+        const document = projection.readDocument(`${packagePath}/${leaf}`).document!;
         return {
           path: document.path,
           body: document.body,
@@ -277,23 +209,11 @@ test("a no-op title amend heals a plan whose canonical base still holds the pre-
     });
     const workerBody = readFileSync(target, "utf8")
       .replace(`# ${firstTitle}`, `# ${secondTitle}`)
-      .concat(
-        "\n## Drift\n\nworker prose written under the already-renamed H1\n",
-      );
+      .concat("\n## Drift\n\nworker prose written under the already-renamed H1\n");
     writeFileSync(target, workerBody);
-    const blocked = await cell.run(
-      { kind: "doc-status", paths: [plan] },
-      binding,
-    );
-    assert.equal(
-      rows(blocked.evidence)[0]?.state,
-      "blocked",
-      JSON.stringify(blocked),
-    );
-    assert.match(
-      blockedReason(blocked.evidence),
-      /base region is missing: "# no-op amend first title"/u,
-    );
+    const blocked = await cell.run({ kind: "doc-status", paths: [plan] }, binding);
+    assert.equal(rows(blocked.evidence)[0]?.state, "blocked", JSON.stringify(blocked));
+    assert.match(blockedReason(blocked.evidence), /base region is missing: "# no-op amend first title"/u);
     const noop = (await cell.run(
       {
         kind: "task-amend",
@@ -312,26 +232,12 @@ test("a no-op title amend heals a plan whose canonical base still holds the pre-
     const scratches = readdirSync(path.dirname(target)).filter((name) =>
       /^task_plan\.conflict-[0-9a-f]{8}\.md$/u.test(name),
     );
-    assert.equal(
-      scratches.length,
-      1,
-      `expected one conflict scratch, found ${JSON.stringify(scratches)}`,
-    );
+    assert.equal(scratches.length, 1, `expected one conflict scratch, found ${JSON.stringify(scratches)}`);
     writeFileSync(target, workerBody);
     rmSync(path.join(path.dirname(target), scratches[0]!));
-    const healed = await cell.run(
-      { kind: "doc-status", paths: [plan] },
-      binding,
-    );
-    assert.equal(
-      rows(healed.evidence)[0]?.state,
-      "eligible",
-      JSON.stringify(healed),
-    );
-    assert.equal(
-      (await cell.run({ kind: "doc-submit", paths: [plan] }, binding)).outcome,
-      "applied",
-    );
+    const healed = await cell.run({ kind: "doc-status", paths: [plan] }, binding);
+    assert.equal(rows(healed.evidence)[0]?.state, "eligible", JSON.stringify(healed));
+    assert.equal((await cell.run({ kind: "doc-submit", paths: [plan] }, binding)).outcome, "applied");
   } finally {
     await cell?.close();
     rmSync(rootDir, { recursive: true, force: true });
@@ -352,29 +258,15 @@ test("authored CRLF prose is canonicalized on scanner read and submitted as LF",
     canonical = "# CRLF\n\naccepted\n";
   try {
     write(rootDir, logical, canonical.replace(/\n/gu, "\r\n"));
-    const submitted = await cell.run(
-      { kind: "doc-submit", paths: [logical] },
-      binding,
-    );
+    const submitted = await cell.run({ kind: "doc-submit", paths: [logical] }, binding);
     assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
-    const event = makeTaskEventStore({ repoId, rootDir }).readEvent(
-      submitted.opId,
-    );
+    const event = makeTaskEventStore({ repoId, rootDir }).readEvent(submitted.opId);
     assert.equal(event?.schema, "doc-event/v1");
     if (event?.schema === "doc-event/v1") {
-      assert.equal(
-        event.payload.changes[0]?.candidate.sha256,
-        sha256Text(canonical),
-      );
-      assert.equal(
-        event.payload.changes[0]?.candidate.size,
-        Buffer.byteLength(canonical),
-      );
+      assert.equal(event.payload.changes[0]?.candidate.sha256, sha256Text(canonical));
+      assert.equal(event.payload.changes[0]?.candidate.size, Buffer.byteLength(canonical));
     }
-    assert.equal(
-      readFileSync(path.join(rootDir, "harness", logical), "utf8"),
-      canonical,
-    );
+    assert.equal(readFileSync(path.join(rootDir, "harness", logical), "utf8"), canonical);
   } finally {
     await cell.close();
     rmSync(rootDir, { recursive: true, force: true });

--- a/packages/daemon/test/doc-sync-slice-a.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a.test.ts
@@ -5,20 +5,10 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { makeTaskEventStore, sha256Text } from "../../kernel/src/index.ts";
-import {
-  canonicalRoot,
-  workspaceId,
-} from "../src/protocol/daemon-protocol.contract.ts";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { openRepoCell } from "../src/repo-cell.ts";
 
-import {
-  actor,
-  git,
-  initRepo,
-  opaqueTextualMediaType,
-  rows,
-  write,
-} from "./doc-sync-slice-a.fixtures.ts";
+import { actor, git, initRepo, opaqueTextualMediaType, rows, write } from "./doc-sync-slice-a.fixtures.ts";
 test("status, dry-run, and submit share the repeatable-path scanner and automatic base", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-scanner-"));
   initRepo(rootDir);
@@ -46,29 +36,17 @@ test("status, dry-run, and submit share the repeatable-path scanner and automati
         ["tasks/task-one/progress.md", "blocked"],
       ],
     );
-    assert.equal(
-      statusRows.find((row) => row.path.endsWith("artifacts/data.json"))
-        ?.mediaType,
-      opaqueTextualMediaType,
-    );
+    assert.equal(statusRows.find((row) => row.path.endsWith("artifacts/data.json"))?.mediaType, opaqueTextualMediaType);
     assert.equal(git(rootDir, "rev-parse", "HEAD"), before);
-    const dry = await cell.run(
-      { kind: "doc-dry-run", paths: ["context/a.md", "context/b.md"] },
-      binding,
-    );
+    const dry = await cell.run({ kind: "doc-dry-run", paths: ["context/a.md", "context/b.md"] }, binding);
     assert.equal(dry.outcome, "pending");
     assert.equal(dry.proof?.canonicalVisible, false);
     assert.deepEqual(rows(dry.evidence), statusRows.slice(0, 2));
     assert.equal(git(rootDir, "rev-parse", "HEAD"), before);
-    const submitted = await cell.run(
-      { kind: "doc-submit", paths: ["context/a.md"] },
-      binding,
-    );
+    const submitted = await cell.run({ kind: "doc-submit", paths: ["context/a.md"] }, binding);
     assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
     assert.equal(submitted.commitSha, null);
-    const event = makeTaskEventStore({ repoId: "scanner", rootDir }).readEvent(
-      submitted.opId,
-    );
+    const event = makeTaskEventStore({ repoId: "scanner", rootDir }).readEvent(submitted.opId);
     assert.equal(event?.schema, "doc-event/v1");
     if (event?.schema === "doc-event/v1") {
       assert.deepEqual(
@@ -100,23 +78,11 @@ test("status, dry-run, and submit share the repeatable-path scanner and automati
     );
     write(rootDir, "context/a.md", "# Renamed\n\nfirst\n");
     const acceptedCut = git(rootDir, "rev-parse", "HEAD"),
-      blocked = await cell.run(
-        { kind: "doc-dry-run", paths: ["context/a.md"] },
-        binding,
-      );
+      blocked = await cell.run({ kind: "doc-dry-run", paths: ["context/a.md"] }, binding);
     assert.equal(rows(blocked.evidence)[0]?.state, "blocked");
-    assert.match(
-      blocked.detail?.nextAction ?? "",
-      /listed blocked candidates/u,
-    );
-    assert.doesNotMatch(
-      blocked.detail?.nextAction ?? "",
-      /doc retire|conflict scratch/iu,
-    );
-    const rejected = await cell.run(
-      { kind: "doc-submit", paths: ["context/a.md"] },
-      binding,
-    );
+    assert.match(blocked.detail?.nextAction ?? "", /listed blocked candidates/u);
+    assert.doesNotMatch(blocked.detail?.nextAction ?? "", /doc retire|conflict scratch/iu);
+    const rejected = await cell.run({ kind: "doc-submit", paths: ["context/a.md"] }, binding);
     assert.equal(rejected.outcome, "op_rejected");
     assert.equal(rejected.code, "preview_blocked");
     assert.equal(git(rootDir, "rev-parse", "HEAD"), acceptedCut);
@@ -126,7 +92,7 @@ test("status, dry-run, and submit share the repeatable-path scanner and automati
   }
 });
 
-test("selected doc-sync paths are authored-relative candidates and zero-write submit is rejected", async () => {
+test("selected doc-sync paths are authored-relative candidates and zero-write submit succeeds", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-selection-"));
   initRepo(rootDir);
   const repoId = workspaceId("selection"),
@@ -148,7 +114,7 @@ test("selected doc-sync paths are authored-relative candidates and zero-write su
     assert.equal(missing.code, "document_not_found");
 
     const clean = await cell.run({ kind: "doc-submit", paths: ["context/selected.md"] }, binding);
-    assert.equal(clean.outcome, "op_rejected", JSON.stringify(clean));
+    assert.equal(clean.outcome, "no_changes", JSON.stringify(clean));
     assert.equal(clean.code, "no_changes");
     assert.match(String((clean as Record<string, unknown>).summary), /applied count: 0/u);
   } finally {
@@ -172,32 +138,26 @@ test("task-scoped doc sync derives every dirty candidate from the task id", asyn
     const packagePath = String(created.packagePath);
     write(rootDir, `${packagePath}/notes.md`, "# Task note\n");
     write(rootDir, "context/unrelated.md", "# Unrelated\n");
-    const status = await cell.run(
-      { kind: "doc-status", taskId: "task-scope" },
-      binding,
-    );
+    const status = await cell.run({ kind: "doc-status", taskId: "task-scope" }, binding);
     assert.equal(status.outcome, "applied", JSON.stringify(status));
     const scanned = rows(status.evidence);
     assert.equal(scanned.length > 0, true);
-    assert.equal(scanned.every((row) => row.path.startsWith(`${packagePath}/`)), true);
-    assert.equal(scanned.some((row) => row.path === `${packagePath}/notes.md`), true);
-    const submitted = await cell.run(
-      { kind: "doc-submit", taskId: "task-scope" },
-      binding,
+    assert.equal(
+      scanned.every((row) => row.path.startsWith(`${packagePath}/`)),
+      true,
     );
+    assert.equal(
+      scanned.some((row) => row.path === `${packagePath}/notes.md`),
+      true,
+    );
+    const submitted = await cell.run({ kind: "doc-submit", taskId: "task-scope" }, binding);
     assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
     assert.match(submitted.summary ?? "", new RegExp(`${packagePath}/notes\\.md`, "u"));
-    const clean = await cell.run(
-      { kind: "doc-submit", taskId: "task-scope" },
-      binding,
-    );
-    assert.equal(clean.outcome, "op_rejected", JSON.stringify(clean));
+    const clean = await cell.run({ kind: "doc-submit", taskId: "task-scope" }, binding);
+    assert.equal(clean.outcome, "no_changes", JSON.stringify(clean));
     assert.equal(clean.code, "no_changes");
     assert.match(clean.summary ?? "", /applied count: 0/u);
-    const mixed = await cell.run(
-      { kind: "doc-submit", taskId: "task-scope", paths: [] },
-      binding,
-    );
+    const mixed = await cell.run({ kind: "doc-submit", taskId: "task-scope", paths: [] }, binding);
     assert.equal(mixed.outcome, "op_rejected");
     assert.equal(mixed.code, "invalid_command");
   } finally {
@@ -219,33 +179,19 @@ test("doc retire deletes one projected document and returns an auditable retirem
     reason = "superseded temporary evidence";
   try {
     write(rootDir, logical, "# Temporary\n\nRetire me.\n");
-    const submitted = await cell.run(
-      { kind: "doc-submit", paths: [logical] },
-      binding,
-    );
+    const submitted = await cell.run({ kind: "doc-submit", paths: [logical] }, binding);
     assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
     rmSync(path.join(rootDir, "harness", logical));
-    const mutation = await cell.run(
-      { kind: "doc-status", paths: [logical] },
-      binding,
-    );
+    const mutation = await cell.run({ kind: "doc-status", paths: [logical] }, binding);
     assert.equal(rows(mutation.evidence)[0]?.state, "deletion");
-    assert.match(
-      mutation.detail?.nextAction ?? "",
-      new RegExp(`ha doc retire --path ${logical}`, "u"),
-    );
+    assert.match(mutation.detail?.nextAction ?? "", new RegExp(`ha doc retire --path ${logical}`, "u"));
     assert.doesNotMatch(mutation.detail?.nextAction ?? "", /resolve blocked/iu);
-    const retired = await cell.run(
-      { kind: "doc-retire", path: logical, reason },
-      binding,
-    );
+    const retired = await cell.run({ kind: "doc-retire", path: logical, reason }, binding);
     assert.equal(retired.outcome, "applied", JSON.stringify(retired));
     assert.equal(retired.proof?.canonicalVisible, true);
     assert.equal(retired.proof?.worktreeVisible, true);
     assert.match(retired.evidence ?? "", /^doc-retirement:/u);
-    const receipt = JSON.parse(
-      (retired.evidence ?? "").slice("doc-retirement:".length),
-    ) as {
+    const receipt = JSON.parse((retired.evidence ?? "").slice("doc-retirement:".length)) as {
       readonly schema: string;
       readonly path: string;
       readonly reason: string;
@@ -256,9 +202,7 @@ test("doc retire deletes one projected document and returns an auditable retirem
       baseBlobSha256: sha256Text("# Temporary\n\nRetire me.\n"),
       reason,
     });
-    const event = makeTaskEventStore({ repoId: "retire", rootDir }).readEvent(
-      retired.opId,
-    );
+    const event = makeTaskEventStore({ repoId: "retire", rootDir }).readEvent(retired.opId);
     assert.equal(event?.schema, "doc-event/v1");
     if (event?.schema === "doc-event/v1") {
       assert.equal(event.payload.retirementReason, reason);
@@ -266,14 +210,11 @@ test("doc retire deletes one projected document and returns an auditable retirem
     }
     const shown = await cell.run({ kind: "doc-show", path: logical }, binding);
     assert.equal(shown.code, "document_not_found");
+    assert.equal(git(rootDir, "ls-tree", "--name-only", "HEAD", `harness/${logical}`), "");
     assert.equal(
-      git(rootDir, "ls-tree", "--name-only", "HEAD", `harness/${logical}`),
-      "",
-    );
-    assert.equal(
-      rows(
-        (await cell.run({ kind: "doc-status", paths: [] }, binding)).evidence,
-      ).some((row) => row.state === "deletion"),
+      rows((await cell.run({ kind: "doc-status", paths: [] }, binding)).evidence).some(
+        (row) => row.state === "deletion",
+      ),
       false,
     );
   } finally {
@@ -291,12 +232,11 @@ test("doc retire follows status for a Git-tracked document that was never projec
   write(rootDir, logical, body);
   git(rootDir, "add", `harness/${logical}`);
   git(rootDir, "commit", "-qm", "track legacy document");
-  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined =
-    await openRepoCell({
-      repoId: workspaceId("retire-tracked"),
-      rootDir: canonicalRoot(rootDir),
-      ownerId: "retire-tracked-daemon",
-    });
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined = await openRepoCell({
+    repoId: workspaceId("retire-tracked"),
+    rootDir: canonicalRoot(rootDir),
+    ownerId: "retire-tracked-daemon",
+  });
   const binding = { actor, source: "local" as const };
   try {
     rmSync(path.join(rootDir, "harness", logical));
@@ -305,52 +245,32 @@ test("doc retire follows status for a Git-tracked document that was never projec
       rows(status.evidence).map((row) => [row.path, row.state]),
       [[logical, "deletion"]],
     );
-    assert.match(
-      status.detail?.nextAction ?? "",
-      new RegExp(`ha doc retire --path ${logical}`, "u"),
-    );
+    assert.match(status.detail?.nextAction ?? "", new RegExp(`ha doc retire --path ${logical}`, "u"));
 
-    const retired = await cell.run(
-      { kind: "doc-retire", path: logical, reason },
-      binding,
-    );
+    const retired = await cell.run({ kind: "doc-retire", path: logical, reason }, binding);
     assert.equal(retired.outcome, "applied", JSON.stringify(retired));
     assert.match(retired.evidence ?? "", /^doc-retirement:/u);
     assert.equal(
-      makeTaskEventStore({ repoId: "retire-tracked", rootDir }).readEvent(
-        retired.opId,
-      )?.schema,
+      makeTaskEventStore({ repoId: "retire-tracked", rootDir }).readEvent(retired.opId)?.schema,
       "doc-event/v1",
     );
     assert.equal(
-      rows(
-        (await cell.run({ kind: "doc-status", paths: [] }, binding)).evidence,
-      ).some((row) => row.state === "deletion"),
+      rows((await cell.run({ kind: "doc-status", paths: [] }, binding)).evidence).some(
+        (row) => row.state === "deletion",
+      ),
       false,
     );
     await cell.close();
     cell = undefined;
-    assert.equal(
-      git(rootDir, "ls-tree", "--name-only", "HEAD", `harness/${logical}`),
-      "",
-    );
-    assert.equal(
-      git(rootDir, "status", "--porcelain", "--untracked-files=no"),
-      "",
-    );
+    assert.equal(git(rootDir, "ls-tree", "--name-only", "HEAD", `harness/${logical}`), "");
+    assert.equal(git(rootDir, "status", "--porcelain", "--untracked-files=no"), "");
     const reopened = await openRepoCell({
       repoId: workspaceId("retire-tracked"),
       rootDir: canonicalRoot(rootDir),
       ownerId: "retire-tracked-reopened",
     });
     try {
-      assert.deepEqual(
-        rows(
-          (await reopened.run({ kind: "doc-status", paths: [] }, binding))
-            .evidence,
-        ),
-        [],
-      );
+      assert.deepEqual(rows((await reopened.run({ kind: "doc-status", paths: [] }, binding)).evidence), []);
     } finally {
       await reopened.close();
     }
@@ -374,53 +294,24 @@ test("new non-textual artifacts are inapplicable while binary replacement of can
   try {
     const freshTarget = path.join(rootDir, "harness", fresh);
     mkdirSync(path.dirname(freshTarget), { recursive: true });
-    writeFileSync(
-      freshTarget,
-      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0xff, 0x00]),
-    );
-    const status = await cell.run(
-        { kind: "doc-status", paths: [fresh] },
-        binding,
-      ),
-      row = rows(status.evidence)[0] as
-        { readonly state: string; readonly reason?: string } | undefined;
-    assert.deepEqual(
-      [row?.state, row?.reason],
-      ["inapplicable", "non-textual artifact is outside doc sync"],
-    );
+    writeFileSync(freshTarget, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0xff, 0x00]));
+    const status = await cell.run({ kind: "doc-status", paths: [fresh] }, binding),
+      row = rows(status.evidence)[0] as { readonly state: string; readonly reason?: string } | undefined;
+    assert.deepEqual([row?.state, row?.reason], ["inapplicable", "non-textual artifact is outside doc sync"]);
     assert.deepEqual(status.detail?.unresolvedTouches, []);
-    assert.equal(
-      status.detail?.nextAction,
-      "no action required; inapplicable candidates are outside doc sync",
-    );
-    const noOp = (await cell.run(
-      { kind: "doc-submit", paths: [fresh] },
-      binding,
-    )) as Record<string, unknown>;
-    assert.equal(noOp.outcome, "op_rejected");
+    assert.equal(status.detail?.nextAction, "no action required; inapplicable candidates are outside doc sync");
+    const noOp = (await cell.run({ kind: "doc-submit", paths: [fresh] }, binding)) as Record<string, unknown>;
+    assert.equal(noOp.outcome, "no_changes");
     assert.equal(noOp.code, "no_changes");
     assert.match(String(noOp.summary), /applied count: 0/u);
     assert.match(String(noOp.opId), /^noop:/u);
 
     write(rootDir, tracked, "textual baseline\n");
-    assert.equal(
-      (await cell.run({ kind: "doc-submit", paths: [tracked] }, binding))
-        .outcome,
-      "applied",
-    );
-    writeFileSync(
-      path.join(rootDir, "harness", tracked),
-      Buffer.from([0xff, 0x00]),
-    );
-    const blocked = await cell.run(
-      { kind: "doc-status", paths: [tracked] },
-      binding,
-    );
+    assert.equal((await cell.run({ kind: "doc-submit", paths: [tracked] }, binding)).outcome, "applied");
+    writeFileSync(path.join(rootDir, "harness", tracked), Buffer.from([0xff, 0x00]));
+    const blocked = await cell.run({ kind: "doc-status", paths: [tracked] }, binding);
     assert.equal(rows(blocked.evidence)[0]?.state, "blocked");
-    assert.equal(
-      blocked.detail?.unresolvedTouches[0]?.requiredRoute,
-      "typed-binary-content",
-    );
+    assert.equal(blocked.detail?.unresolvedTouches[0]?.requiredRoute, "typed-binary-content");
   } finally {
     await cell.close();
     rmSync(rootDir, { recursive: true, force: true });
@@ -437,57 +328,26 @@ test("people-registry ownership is inapplicable while typed writable routes rema
     }),
     binding = { actor, source: "local" as const };
   try {
-    write(
-      rootDir,
-      "people.yaml",
-      "schema: harness-people/v1\npeople: []\nroles: []\n",
-    );
-    write(
-      rootDir,
-      "harness.yaml",
-      "schema: harness-anything/v1\nname: hand-edited\n",
-    );
-    const people = await cell.run(
-        { kind: "doc-status", paths: ["people.yaml"] },
-        binding,
-      ),
-      peopleRow = rows(people.evidence)[0] as
-        { readonly state: string; readonly reason?: string } | undefined;
+    write(rootDir, "people.yaml", "schema: harness-people/v1\npeople: []\nroles: []\n");
+    write(rootDir, "harness.yaml", "schema: harness-anything/v1\nname: hand-edited\n");
+    const people = await cell.run({ kind: "doc-status", paths: ["people.yaml"] }, binding),
+      peopleRow = rows(people.evidence)[0] as { readonly state: string; readonly reason?: string } | undefined;
     assert.deepEqual(
       [peopleRow?.state, peopleRow?.reason],
-      [
-        "inapplicable",
-        "path is owned by people-registry and is outside doc sync",
-      ],
+      ["inapplicable", "path is owned by people-registry and is outside doc sync"],
     );
     assert.deepEqual(people.detail?.unresolvedTouches, []);
-    assert.equal(
-      people.detail?.nextAction,
-      "no action required; inapplicable candidates are outside doc sync",
-    );
-    const noOp = await cell.run(
-      { kind: "doc-submit", paths: ["people.yaml"] },
-      binding,
-    );
-    assert.equal(noOp.outcome, "op_rejected");
+    assert.equal(people.detail?.nextAction, "no action required; inapplicable candidates are outside doc sync");
+    const noOp = await cell.run({ kind: "doc-submit", paths: ["people.yaml"] }, binding);
+    assert.equal(noOp.outcome, "no_changes");
     assert.equal(noOp.code, "no_changes");
     assert.match(String(noOp.summary), /applied count: 0/u);
     assert.match(noOp.opId, /^noop:/u);
 
-    const workspace = await cell.run(
-        { kind: "doc-status", paths: ["harness.yaml"] },
-        binding,
-      ),
-      workspaceRow = rows(workspace.evidence)[0] as
-        { readonly state: string; readonly reason?: string } | undefined;
-    assert.deepEqual(
-      [workspaceRow?.state, workspaceRow?.reason],
-      ["blocked", "path is owned by workspace-config"],
-    );
-    assert.equal(
-      workspace.detail?.unresolvedTouches[0]?.requiredRoute,
-      "workspace-config",
-    );
+    const workspace = await cell.run({ kind: "doc-status", paths: ["harness.yaml"] }, binding),
+      workspaceRow = rows(workspace.evidence)[0] as { readonly state: string; readonly reason?: string } | undefined;
+    assert.deepEqual([workspaceRow?.state, workspaceRow?.reason], ["blocked", "path is owned by workspace-config"]);
+    assert.equal(workspace.detail?.unresolvedTouches[0]?.requiredRoute, "workspace-config");
   } finally {
     await cell.close();
     rmSync(rootDir, { recursive: true, force: true });

--- a/packages/daemon/test/doc-sync-slice-b.test.ts
+++ b/packages/daemon/test/doc-sync-slice-b.test.ts
@@ -22,146 +22,490 @@ test("local doc submit rejects the retired selection assembler", async () => {
     const cut = await startLease(fixture.cell, "local");
     const relativePath = "tasks/task-doc-docs/notes.md";
     writeAuthored(fixture.rootDir, relativePath, "# Notes\n");
-    const result = await fixture.cell.run({ kind: "doc-submit", executionId: "execution-doc", baseLedgerSha: cut,
-      selections: [{ path: relativePath, baseBlobSha256: null }] }, { actor, source: "local" });
+    const result = await fixture.cell.run(
+      {
+        kind: "doc-submit",
+        executionId: "execution-doc",
+        baseLedgerSha: cut,
+        selections: [{ path: relativePath, baseBlobSha256: null }],
+      },
+      { actor, source: "local" },
+    );
     assert.equal(result.outcome, "op_rejected");
     assert.equal(result.code, "invalid_command");
-  } finally { await fixture.close(); }
+  } finally {
+    await fixture.close();
+  }
 });
 
 test("local selection and assignment claim normalize to the same doc event through RepoCell.run", async () => {
-  const local = await docCell("local"), remote = await docCell("remote");
+  const local = await docCell("local"),
+    remote = await docCell("remote");
   try {
-    await startLease(local.cell, "local"); const remoteCut = await startLease(remote.cell, assignmentSource);
-    const body = "# Notes\n\nShared candidate.\n", hash = sha(body), relativePath = "tasks/task-doc-docs/notes.md";
-    writeAuthored(local.rootDir, relativePath, body); writeClaim(remote.rootDir, "remote", body);
-    const localResult = await local.cell.run({ kind: "doc-submit", executionId: "execution-doc", paths: [relativePath] }, { actor, source: "local" });
+    await startLease(local.cell, "local");
+    const remoteCut = await startLease(remote.cell, assignmentSource);
+    const body = "# Notes\n\nShared candidate.\n",
+      hash = sha(body),
+      relativePath = "tasks/task-doc-docs/notes.md";
+    writeAuthored(local.rootDir, relativePath, body);
+    writeClaim(remote.rootDir, "remote", body);
+    const localResult = await local.cell.run(
+      { kind: "doc-submit", executionId: "execution-doc", paths: [relativePath] },
+      { actor, source: "local" },
+    );
     const remoteBinding = assignmentBinding("remote", [relativePath]);
-    const remoteResult = await remote.cell.run({ kind: "doc-submit", executionId: "execution-doc", baseLedgerSha: remoteCut, changes: [{ path: relativePath,
-      baseBlobSha256: null, policyId, candidate: { ref: "doc-sync-claims/remote", sha256: hash, size: Buffer.byteLength(body), mediaType: "text/markdown" } }] }, remoteBinding);
-    assert.equal(localResult.outcome, "applied", JSON.stringify(localResult)); assert.equal(remoteResult.outcome, "applied", JSON.stringify(remoteResult));
+    const remoteResult = await remote.cell.run(
+      {
+        kind: "doc-submit",
+        executionId: "execution-doc",
+        baseLedgerSha: remoteCut,
+        changes: [
+          {
+            path: relativePath,
+            baseBlobSha256: null,
+            policyId,
+            candidate: {
+              ref: "doc-sync-claims/remote",
+              sha256: hash,
+              size: Buffer.byteLength(body),
+              mediaType: "text/markdown",
+            },
+          },
+        ],
+      },
+      remoteBinding,
+    );
+    assert.equal(localResult.outcome, "applied", JSON.stringify(localResult));
+    assert.equal(remoteResult.outcome, "applied", JSON.stringify(remoteResult));
     const localEvent = makeTaskEventStore({ repoId: "local", rootDir: local.rootDir }).readEvent(localResult.opId);
     const remoteEvent = makeTaskEventStore({ repoId: "remote", rootDir: remote.rootDir }).readEvent(remoteResult.opId);
-    assert.equal(localEvent?.schema, "doc-event/v1"); assert.equal(remoteEvent?.schema, "doc-event/v1");
-    if (localEvent?.schema === "doc-event/v1" && remoteEvent?.schema === "doc-event/v1") assert.deepEqual(localEvent.payload.changes, remoteEvent.payload.changes);
-    assert.deepEqual(remoteResult.proof?.worktreeVisible, null); assert.equal("gitCredential" in remoteBinding, false);
-  } finally { await local.close(); await remote.close(); }
+    assert.equal(localEvent?.schema, "doc-event/v1");
+    assert.equal(remoteEvent?.schema, "doc-event/v1");
+    if (localEvent?.schema === "doc-event/v1" && remoteEvent?.schema === "doc-event/v1")
+      assert.deepEqual(localEvent.payload.changes, remoteEvent.payload.changes);
+    assert.deepEqual(remoteResult.proof?.worktreeVisible, null);
+    assert.equal("gitCredential" in remoteBinding, false);
+  } finally {
+    await local.close();
+    await remote.close();
+  }
 });
 
 test("Decision prose is an explicit idempotent doc-sync region in the canonical authored document", async () => {
   const fixture = await docCell("decision-prose");
   try {
-    await startLease(fixture.cell, "local"); const binding = { actor, source: "local" as const };
-    const proposed = await fixture.cell.run({ kind: "decision-propose", jsonInput: JSON.stringify({ title: "Body join", question: "Should the body remain doc-sync owned?", riskTier: "medium", urgency: "medium", vertical: "default", preset: "default", decisionClass: "ordinary", appliesTo: { modules: ["daemon"], productLines: [] }, chosen: [{ id: "CH1", text: "Use doc-sync" }], rejected: [{ id: "RJ1", text: "Inline body", whyNot: "It duplicates content storage" }], claims: [], fulfillments: [], relations: [] }) }, binding);
-    assert.equal(proposed.outcome, "applied", JSON.stringify(proposed)); const decisionId = (JSON.parse(proposed.evidence) as { decisionId: string }).decisionId;
-    const relativePath = `decisions/decision-${decisionId}/decision.md`, initial = JSON.parse((await fixture.cell.run({ kind: "decision-show", decisionId, includeBody: true }, binding)).evidence) as { decision: { body: { body: string } } }; assert.equal(initial.decision.body.body, "\n# Body join\n");
-    const machine = readFileSync(path.join(fixture.rootDir, "harness", relativePath), "utf8").replace(/\n# Body join\n$/u, ""), firstProse = "\n# Body join\n\nFirst paragraph.\n", firstBody = `${machine}${firstProse}`, firstHash = sha(firstBody); writeAuthored(fixture.rootDir, relativePath, firstBody);
+    await startLease(fixture.cell, "local");
+    const binding = { actor, source: "local" as const };
+    const proposed = await fixture.cell.run(
+      {
+        kind: "decision-propose",
+        jsonInput: JSON.stringify({
+          title: "Body join",
+          question: "Should the body remain doc-sync owned?",
+          riskTier: "medium",
+          urgency: "medium",
+          vertical: "default",
+          preset: "default",
+          decisionClass: "ordinary",
+          appliesTo: { modules: ["daemon"], productLines: [] },
+          chosen: [{ id: "CH1", text: "Use doc-sync" }],
+          rejected: [{ id: "RJ1", text: "Inline body", whyNot: "It duplicates content storage" }],
+          claims: [],
+          fulfillments: [],
+          relations: [],
+        }),
+      },
+      binding,
+    );
+    assert.equal(proposed.outcome, "applied", JSON.stringify(proposed));
+    const decisionId = (JSON.parse(proposed.evidence) as { decisionId: string }).decisionId;
+    const relativePath = `decisions/decision-${decisionId}/decision.md`,
+      initial = JSON.parse(
+        (await fixture.cell.run({ kind: "decision-show", decisionId, includeBody: true }, binding)).evidence,
+      ) as { decision: { body: { body: string } } };
+    assert.equal(initial.decision.body.body, "\n# Body join\n");
+    const machine = readFileSync(path.join(fixture.rootDir, "harness", relativePath), "utf8").replace(
+        /\n# Body join\n$/u,
+        "",
+      ),
+      firstProse = "\n# Body join\n\nFirst paragraph.\n",
+      firstBody = `${machine}${firstProse}`,
+      firstHash = sha(firstBody);
+    writeAuthored(fixture.rootDir, relativePath, firstBody);
     const firstAction = { kind: "doc-submit", executionId: "execution-doc", paths: [relativePath] } as const;
-    const first = await fixture.cell.run(firstAction, binding); assert.equal(first.outcome, "applied", JSON.stringify(first));
-    const retried = await fixture.cell.run(firstAction, binding); assert.equal(retried.outcome, "op_rejected"); assert.equal(retried.code, "no_changes"); assert.match(retried.opId, /^noop:/u); assert.equal(retried.revision, first.revision);
-    const joined = JSON.parse((await fixture.cell.run({ kind: "decision-show", decisionId, includeBody: true }, binding)).evidence) as { decision: { body: { body: string; blobSha256: string; size: number; path: string } } };
-    assert.deepEqual(joined.decision.body, { body: firstProse, blobSha256: firstHash, size: Buffer.byteLength(firstBody), path: relativePath, mediaType: "text/markdown", workspaceRevision: first.revision });
-    const store = makeTaskEventStore({ repoId: "decision-prose", rootDir: fixture.rootDir }), event = store.readEvent(first.opId); assert.equal(event?.schema, "doc-event/v1"); if (event?.schema === "doc-event/v1") { const claim = event.payload.changes[0]!.candidate, blob = store.readContentBlob(claim.sha256); assert.equal(blob?.byteLength, claim.size); assert.equal(sha(Buffer.from(blob!).toString("utf8")), claim.sha256); }
-    const firstList = JSON.parse((await fixture.cell.run({ kind: "decision-list", search: "paragraph" }, binding)).evidence) as { decisions: readonly Record<string, unknown>[] }; assert.deepEqual(firstList.decisions.map(({ decisionId: id }) => id), [decisionId]); assert.equal(Object.hasOwn(firstList.decisions[0]!, "body"), false); const gui = await fixture.cell.read("repo.decisions.list"); assert.deepEqual(gui.decisions.map(({ decisionId: id }) => id), firstList.decisions.map(({ decisionId: id }) => id));
-    const secondProse = "\n# Body join\n\nReplacement needle.\n", secondBody = `${machine}${secondProse}`; writeAuthored(fixture.rootDir, relativePath, secondBody); const second = await fixture.cell.run({ kind: "doc-submit", executionId: "execution-doc", paths: [relativePath] }, binding); assert.equal(second.outcome, "applied", JSON.stringify(second));
-    const updated = JSON.parse((await fixture.cell.run({ kind: "decision-show", decisionId, includeBody: true }, binding)).evidence) as { decision: { body: { body: string; blobSha256: string } } }; assert.equal(updated.decision.body.body, secondProse); assert.equal(updated.decision.body.blobSha256, sha(secondBody));
-    assert.equal((JSON.parse((await fixture.cell.run({ kind: "decision-list", search: "paragraph" }, binding)).evidence) as { decisions: readonly unknown[] }).decisions.length, 0); assert.deepEqual((JSON.parse((await fixture.cell.run({ kind: "decision-list", search: "Replacement" }, binding)).evidence) as { decisions: readonly { decisionId: string }[] }).decisions.map(({ decisionId: id }) => id), [decisionId]);
-    writeAuthored(fixture.rootDir, relativePath, `${secondBody}Unsynced.\n`); const redacted = JSON.parse((await fixture.cell.run({ kind: "decision-show", decisionId, includeBody: false }, binding)).evidence) as { decision: { body: unknown } }; assert.equal(redacted.decision.body, null); assert.equal((JSON.parse((await fixture.cell.run({ kind: "decision-show", decisionId, includeBody: true }, binding)).evidence) as { decision: { body: { body: string } } }).decision.body.body, secondProse);
-  } finally { await fixture.close(); }
+    const first = await fixture.cell.run(firstAction, binding);
+    assert.equal(first.outcome, "applied", JSON.stringify(first));
+    const retried = await fixture.cell.run(firstAction, binding);
+    assert.equal(retried.outcome, "no_changes");
+    assert.equal(retried.code, "no_changes");
+    assert.match(retried.opId, /^noop:/u);
+    assert.equal(retried.revision, first.revision);
+    const joined = JSON.parse(
+      (await fixture.cell.run({ kind: "decision-show", decisionId, includeBody: true }, binding)).evidence,
+    ) as { decision: { body: { body: string; blobSha256: string; size: number; path: string } } };
+    assert.deepEqual(joined.decision.body, {
+      body: firstProse,
+      blobSha256: firstHash,
+      size: Buffer.byteLength(firstBody),
+      path: relativePath,
+      mediaType: "text/markdown",
+      workspaceRevision: first.revision,
+    });
+    const store = makeTaskEventStore({ repoId: "decision-prose", rootDir: fixture.rootDir }),
+      event = store.readEvent(first.opId);
+    assert.equal(event?.schema, "doc-event/v1");
+    if (event?.schema === "doc-event/v1") {
+      const claim = event.payload.changes[0]!.candidate,
+        blob = store.readContentBlob(claim.sha256);
+      assert.equal(blob?.byteLength, claim.size);
+      assert.equal(sha(Buffer.from(blob!).toString("utf8")), claim.sha256);
+    }
+    const firstList = JSON.parse(
+      (await fixture.cell.run({ kind: "decision-list", search: "paragraph" }, binding)).evidence,
+    ) as { decisions: readonly Record<string, unknown>[] };
+    assert.deepEqual(
+      firstList.decisions.map(({ decisionId: id }) => id),
+      [decisionId],
+    );
+    assert.equal(Object.hasOwn(firstList.decisions[0]!, "body"), false);
+    const gui = await fixture.cell.read("repo.decisions.list");
+    assert.deepEqual(
+      gui.decisions.map(({ decisionId: id }) => id),
+      firstList.decisions.map(({ decisionId: id }) => id),
+    );
+    const secondProse = "\n# Body join\n\nReplacement needle.\n",
+      secondBody = `${machine}${secondProse}`;
+    writeAuthored(fixture.rootDir, relativePath, secondBody);
+    const second = await fixture.cell.run(
+      { kind: "doc-submit", executionId: "execution-doc", paths: [relativePath] },
+      binding,
+    );
+    assert.equal(second.outcome, "applied", JSON.stringify(second));
+    const updated = JSON.parse(
+      (await fixture.cell.run({ kind: "decision-show", decisionId, includeBody: true }, binding)).evidence,
+    ) as { decision: { body: { body: string; blobSha256: string } } };
+    assert.equal(updated.decision.body.body, secondProse);
+    assert.equal(updated.decision.body.blobSha256, sha(secondBody));
+    assert.equal(
+      (
+        JSON.parse((await fixture.cell.run({ kind: "decision-list", search: "paragraph" }, binding)).evidence) as {
+          decisions: readonly unknown[];
+        }
+      ).decisions.length,
+      0,
+    );
+    assert.deepEqual(
+      (
+        JSON.parse((await fixture.cell.run({ kind: "decision-list", search: "Replacement" }, binding)).evidence) as {
+          decisions: readonly { decisionId: string }[];
+        }
+      ).decisions.map(({ decisionId: id }) => id),
+      [decisionId],
+    );
+    writeAuthored(fixture.rootDir, relativePath, `${secondBody}Unsynced.\n`);
+    const redacted = JSON.parse(
+      (await fixture.cell.run({ kind: "decision-show", decisionId, includeBody: false }, binding)).evidence,
+    ) as { decision: { body: unknown } };
+    assert.equal(redacted.decision.body, null);
+    assert.equal(
+      (
+        JSON.parse(
+          (await fixture.cell.run({ kind: "decision-show", decisionId, includeBody: true }, binding)).evidence,
+        ) as { decision: { body: { body: string } } }
+      ).decision.body.body,
+      secondProse,
+    );
+  } finally {
+    await fixture.close();
+  }
 });
 
 test("doc submit returns holder and scope detail for wrong role, another holder, expiry, and assignment scope", async () => {
-  const fixture = rbacFixture(); const host = await openDaemonHost({ daemonId: "doc-rbac", userRoot: fixture.userRoot }); await host.attachmentsSettled();
-  const auth = (ownerUid: number) => ({ transportKind: "unix-socket", unixSocketOwnerBoundary: { ownerUid, source: "unix-socket-filesystem-owner-boundary" } } as const);
+  const fixture = rbacFixture();
+  const host = await openDaemonHost({ daemonId: "doc-rbac", userRoot: fixture.userRoot });
+  await host.attachmentsSettled();
+  const auth = (ownerUid: number) =>
+    ({
+      transportKind: "unix-socket",
+      unixSocketOwnerBoundary: { ownerUid, source: "unix-socket-filesystem-owner-boundary" },
+    }) as const;
   try {
     await host.admin({ kind: "register", rootDir: fixture.rootDir, repoId: "rbac" }, auth(fixture.ids.admin));
-    assert.equal((await host.run("rbac", { kind: "task-create", taskId: "task-doc", title: "Docs" }, auth(fixture.ids.writer))).outcome, "applied");
-    const started = await host.run("rbac", { kind: "task-start", taskId: "task-doc", executionId: "execution-doc" }, auth(fixture.ids.writer)); assert.equal(started.outcome, "applied");
-    const relativePath = "tasks/task-doc-docs/notes.md", body = "# Notes\n", action = { kind: "doc-submit", executionId: "execution-doc", paths: [relativePath] } as const;
-    writeAuthored(fixture.rootDir, relativePath, body); const before = ledgerCut(started.cut);
+    assert.equal(
+      (await host.run("rbac", { kind: "task-create", taskId: "task-doc", title: "Docs" }, auth(fixture.ids.writer)))
+        .outcome,
+      "applied",
+    );
+    const started = await host.run(
+      "rbac",
+      { kind: "task-start", taskId: "task-doc", executionId: "execution-doc" },
+      auth(fixture.ids.writer),
+    );
+    assert.equal(started.outcome, "applied");
+    const relativePath = "tasks/task-doc-docs/notes.md",
+      body = "# Notes\n",
+      action = { kind: "doc-submit", executionId: "execution-doc", paths: [relativePath] } as const;
+    writeAuthored(fixture.rootDir, relativePath, body);
+    const before = ledgerCut(started.cut);
     const denied = await host.run("rbac", action, auth(fixture.ids.reader));
-    assert.equal(denied.code, "rbac_forbidden"); assert.equal(denied.detail?.holder?.personId, "writer");
-    assert.equal(denied.detail?.unresolvedTouches[0]?.requiredRoute, "repo-write"); assert.deepEqual(denied.detail?.currentLedgerSha, before);
+    assert.equal(denied.code, "rbac_forbidden");
+    assert.equal(denied.detail?.holder?.personId, "writer");
+    assert.equal(denied.detail?.unresolvedTouches[0]?.requiredRoute, "repo-write");
+    assert.deepEqual(denied.detail?.currentLedgerSha, before);
     assert.equal(existsSync(claimPath(fixture.rootDir, sha(body))), false);
     const other = await host.run("rbac", action, auth(fixture.ids.otherWriter));
-    assert.equal(other.code, "lease_conflict"); assert.equal(other.detail?.holder?.personId, "writer"); assert.deepEqual(other.detail?.currentLedgerSha, before);
+    assert.equal(other.code, "lease_conflict");
+    assert.equal(other.detail?.holder?.personId, "writer");
+    assert.deepEqual(other.detail?.currentLedgerSha, before);
     assert.equal((await host.run("rbac", action, auth(fixture.ids.writer))).outcome, "applied");
-    const shown = await host.run("rbac", { kind: "doc-show", path: relativePath }, auth(fixture.ids.reader)); assert.equal(shown.outcome, "applied"); assert.equal(shown.evidence, body);
-  } finally { await host.close(); fixture.close(); }
+    const shown = await host.run("rbac", { kind: "doc-show", path: relativePath }, auth(fixture.ids.reader));
+    assert.equal(shown.outcome, "applied");
+    assert.equal(shown.evidence, body);
+  } finally {
+    await host.close();
+    fixture.close();
+  }
 
-  let now = "2026-08-12T00:00:00.000Z"; const expired = await docCell("expired", () => now);
-  try { const before = await startLease(expired.cell, "local", 30 * 60 * 1_000); const relativePath = "tasks/task-doc-docs/expired.md", body = "# Expired\n"; writeAuthored(expired.rootDir, relativePath, body);
-    now = "2026-08-12T01:00:00.000Z"; const result = await expired.cell.run({ kind: "doc-submit", executionId: "execution-doc", paths: [relativePath] }, { actor, source: "local" });
-    assert.equal(result.code, "lease_conflict"); assert.equal(result.detail?.holder?.executionId, "execution-doc"); assert.equal(result.detail?.holder?.expiresAt, "2026-08-12T00:30:00.000Z"); assert.deepEqual(result.detail?.currentLedgerSha, before);
-  } finally { await expired.close(); }
+  let now = "2026-08-12T00:00:00.000Z";
+  const expired = await docCell("expired", () => now);
+  try {
+    const before = await startLease(expired.cell, "local", 30 * 60 * 1_000);
+    const relativePath = "tasks/task-doc-docs/expired.md",
+      body = "# Expired\n";
+    writeAuthored(expired.rootDir, relativePath, body);
+    now = "2026-08-12T01:00:00.000Z";
+    const result = await expired.cell.run(
+      { kind: "doc-submit", executionId: "execution-doc", paths: [relativePath] },
+      { actor, source: "local" },
+    );
+    assert.equal(result.code, "lease_conflict");
+    assert.equal(result.detail?.holder?.executionId, "execution-doc");
+    assert.equal(result.detail?.holder?.expiresAt, "2026-08-12T00:30:00.000Z");
+    assert.deepEqual(result.detail?.currentLedgerSha, before);
+  } finally {
+    await expired.close();
+  }
 
   const scoped = await docCell("scoped");
-  try { const before = await startLease(scoped.cell, assignmentSource); const body = "# Scoped\n", relativePath = "tasks/task-doc-docs/outside.md"; writeClaim(scoped.rootDir, "scoped", body);
-    const result = await scoped.cell.run(remoteAction(before, relativePath, "scoped", body), assignmentBinding("scoped", ["tasks/task-doc-docs/inside.md"]));
-    assert.equal(result.code, "assignment_scope_mismatch"); assert.equal(result.detail?.holder?.personId, "person-owner");
-    assert.match(result.detail?.unresolvedTouches[0]?.requiredRoute ?? "", /assignment-one.*inside\.md/u); assert.deepEqual(result.detail?.currentLedgerSha, before);
+  try {
+    const before = await startLease(scoped.cell, assignmentSource);
+    const body = "# Scoped\n",
+      relativePath = "tasks/task-doc-docs/outside.md";
+    writeClaim(scoped.rootDir, "scoped", body);
+    const result = await scoped.cell.run(
+      remoteAction(before, relativePath, "scoped", body),
+      assignmentBinding("scoped", ["tasks/task-doc-docs/inside.md"]),
+    );
+    assert.equal(result.code, "assignment_scope_mismatch");
+    assert.equal(result.detail?.holder?.personId, "person-owner");
+    assert.match(result.detail?.unresolvedTouches[0]?.requiredRoute ?? "", /assignment-one.*inside\.md/u);
+    assert.deepEqual(result.detail?.currentLedgerSha, before);
     assert.equal(existsSync(path.join(scoped.rootDir, ".harness/doc-sync-claims/scoped")), false);
-    writeClaim(scoped.rootDir, "identity", body); const identityBinding = assignmentBinding("scoped", [relativePath]);
+    writeClaim(scoped.rootDir, "identity", body);
+    const identityBinding = assignmentBinding("scoped", [relativePath]);
     // W3-C: the assignment's static taskId/executionId labels no longer veto a
     // task-document write — design-v2 §3 makes the dynamically acquired lease
     // the task-context authority (decideDocWrite arbitrates holder, execution,
     // and write channel), and a node-level roster cannot name every task a
     // W3-B automatic lease will grant. Path scope plus lease arbitration fully
     // bind this write, so the mislabeled scope no longer rejects it.
-    const identity = await scoped.cell.run(remoteAction(before, relativePath, "identity", body), { ...identityBinding, assignmentScope: { ...identityBinding.assignmentScope!, taskId: "task-other" } });
+    const identity = await scoped.cell.run(remoteAction(before, relativePath, "identity", body), {
+      ...identityBinding,
+      assignmentScope: { ...identityBinding.assignmentScope!, taskId: "task-other" },
+    });
     assert.equal(identity.outcome, "applied", JSON.stringify(identity).slice(0, 400));
     assert.equal(existsSync(path.join(scoped.rootDir, ".harness/doc-sync-claims/identity")), false);
-  } finally { await scoped.close(); }
+  } finally {
+    await scoped.close();
+  }
 });
 
 test("claim-check keeps large bodies out of commands and recycles missing, hash, size, and rejected claims", async () => {
   const local = await docCell("large");
-  try { await startLease(local.cell, "local"); const relativePath = "tasks/task-doc-docs/large.md", body = `# Large\n${"x".repeat(DOC_COMMAND_FRAME_MAX_BYTES + 1)}\n`;
-    writeAuthored(local.rootDir, relativePath, body); const action = { kind: "doc-submit", executionId: "execution-doc", paths: [relativePath] } as const;
-    assert.equal(Buffer.byteLength(JSON.stringify(action)) < DOC_COMMAND_FRAME_MAX_BYTES, true); assert.equal(JSON.stringify(action).includes(body), false);
-    const result = await local.cell.run(action, { actor, source: "local" }); assert.equal(result.outcome, "applied", JSON.stringify(result));
-    const event = makeTaskEventStore({ repoId: "large", rootDir: local.rootDir }).readEvent(result.opId); assert.equal(JSON.stringify(event).includes(body), false);
-    if (event?.schema === "doc-event/v1") assert.deepEqual(event.payload.changes[0]?.candidate, { sha256: sha(body), size: Buffer.byteLength(body), mediaType: "text/markdown" });
+  try {
+    await startLease(local.cell, "local");
+    const relativePath = "tasks/task-doc-docs/large.md",
+      body = `# Large\n${"x".repeat(DOC_COMMAND_FRAME_MAX_BYTES + 1)}\n`;
+    writeAuthored(local.rootDir, relativePath, body);
+    const action = { kind: "doc-submit", executionId: "execution-doc", paths: [relativePath] } as const;
+    assert.equal(Buffer.byteLength(JSON.stringify(action)) < DOC_COMMAND_FRAME_MAX_BYTES, true);
+    assert.equal(JSON.stringify(action).includes(body), false);
+    const result = await local.cell.run(action, { actor, source: "local" });
+    assert.equal(result.outcome, "applied", JSON.stringify(result));
+    const event = makeTaskEventStore({ repoId: "large", rootDir: local.rootDir }).readEvent(result.opId);
+    assert.equal(JSON.stringify(event).includes(body), false);
+    if (event?.schema === "doc-event/v1")
+      assert.deepEqual(event.payload.changes[0]?.candidate, {
+        sha256: sha(body),
+        size: Buffer.byteLength(body),
+        mediaType: "text/markdown",
+      });
     assert.equal(existsSync(claimPath(local.rootDir, sha(body))), false);
-  } finally { await local.close(); }
+  } finally {
+    await local.close();
+  }
 
   const remote = await docCell("claims");
-  try { const before = await startLease(remote.cell, assignmentSource); const relativePath = "tasks/task-doc-docs/claim.md", body = "# Claim\n";
-    const missing = await remote.cell.run(remoteAction(before, relativePath, "missing", body), assignmentBinding("claims", [relativePath]));
-    assert.equal(missing.code, "content_claim_mismatch"); assert.deepEqual(missing.detail?.currentLedgerSha, before);
-    writeClaim(remote.rootDir, "bad-hash", body); const badHash = remoteAction(before, relativePath, "bad-hash", body);
-    const hashResult = await remote.cell.run({ ...badHash, changes: [{ ...badHash.changes[0]!, candidate: { ...badHash.changes[0]!.candidate!, sha256: "f".repeat(64) } }] }, assignmentBinding("claims", [relativePath]));
-    assert.equal(hashResult.code, "content_claim_mismatch"); assert.equal(existsSync(path.join(remote.rootDir, ".harness/doc-sync-claims/bad-hash")), false);
-    writeClaim(remote.rootDir, "bad-size", body); const badSize = remoteAction(before, relativePath, "bad-size", body);
-    const sizeResult = await remote.cell.run({ ...badSize, changes: [{ ...badSize.changes[0]!, candidate: { ...badSize.changes[0]!.candidate!, size: Buffer.byteLength(body) + 1 } }] }, assignmentBinding("claims", [relativePath]));
-    assert.equal(sizeResult.code, "content_claim_mismatch"); assert.equal(existsSync(path.join(remote.rootDir, ".harness/doc-sync-claims/bad-size")), false); assert.deepEqual(sizeResult.detail?.currentLedgerSha, before);
-  } finally { await remote.close(); }
+  try {
+    const before = await startLease(remote.cell, assignmentSource);
+    const relativePath = "tasks/task-doc-docs/claim.md",
+      body = "# Claim\n";
+    const missing = await remote.cell.run(
+      remoteAction(before, relativePath, "missing", body),
+      assignmentBinding("claims", [relativePath]),
+    );
+    assert.equal(missing.code, "content_claim_mismatch");
+    assert.deepEqual(missing.detail?.currentLedgerSha, before);
+    writeClaim(remote.rootDir, "bad-hash", body);
+    const badHash = remoteAction(before, relativePath, "bad-hash", body);
+    const hashResult = await remote.cell.run(
+      {
+        ...badHash,
+        changes: [{ ...badHash.changes[0]!, candidate: { ...badHash.changes[0]!.candidate!, sha256: "f".repeat(64) } }],
+      },
+      assignmentBinding("claims", [relativePath]),
+    );
+    assert.equal(hashResult.code, "content_claim_mismatch");
+    assert.equal(existsSync(path.join(remote.rootDir, ".harness/doc-sync-claims/bad-hash")), false);
+    writeClaim(remote.rootDir, "bad-size", body);
+    const badSize = remoteAction(before, relativePath, "bad-size", body);
+    const sizeResult = await remote.cell.run(
+      {
+        ...badSize,
+        changes: [
+          {
+            ...badSize.changes[0]!,
+            candidate: { ...badSize.changes[0]!.candidate!, size: Buffer.byteLength(body) + 1 },
+          },
+        ],
+      },
+      assignmentBinding("claims", [relativePath]),
+    );
+    assert.equal(sizeResult.code, "content_claim_mismatch");
+    assert.equal(existsSync(path.join(remote.rootDir, ".harness/doc-sync-claims/bad-size")), false);
+    assert.deepEqual(sizeResult.detail?.currentLedgerSha, before);
+  } finally {
+    await remote.close();
+  }
 });
 
-async function docCell(repoId: string, now?: () => string) { const rootDir = mkdtempSync(path.join(tmpdir(), `ha-doc-b-${repoId}-`)); initRepo(rootDir);
-  const cell = await openRepoCell({ repoId: workspaceId(repoId), rootDir: canonicalRoot(rootDir), ownerId: `daemon-${repoId}`, ...(now ? { now } : {}) });
-  return { rootDir, cell, close: async () => { await cell.close(); rmSync(rootDir, { recursive: true, force: true }); } }; }
-async function startLease(cell: Awaited<ReturnType<typeof openRepoCell>>, source: RepoCellBinding["source"], ttlMs?: number): Promise<unknown> {
-  assert.equal((await cell.run({ kind: "task-create", taskId: "task-doc", title: "Docs" }, { actor, source })).outcome, "applied");
-  const started = await cell.run({ kind: "task-start", taskId: "task-doc", executionId: "execution-doc", ...(ttlMs === undefined ? {} : { ttlMs }) }, { actor, source });
+async function docCell(repoId: string, now?: () => string) {
+  const rootDir = mkdtempSync(path.join(tmpdir(), `ha-doc-b-${repoId}-`));
+  initRepo(rootDir);
+  const cell = await openRepoCell({
+    repoId: workspaceId(repoId),
+    rootDir: canonicalRoot(rootDir),
+    ownerId: `daemon-${repoId}`,
+    ...(now ? { now } : {}),
+  });
+  return {
+    rootDir,
+    cell,
+    close: async () => {
+      await cell.close();
+      rmSync(rootDir, { recursive: true, force: true });
+    },
+  };
+}
+async function startLease(
+  cell: Awaited<ReturnType<typeof openRepoCell>>,
+  source: RepoCellBinding["source"],
+  ttlMs?: number,
+): Promise<unknown> {
+  assert.equal(
+    (await cell.run({ kind: "task-create", taskId: "task-doc", title: "Docs" }, { actor, source })).outcome,
+    "applied",
+  );
+  const started = await cell.run(
+    { kind: "task-start", taskId: "task-doc", executionId: "execution-doc", ...(ttlMs === undefined ? {} : { ttlMs }) },
+    { actor, source },
+  );
   assert.equal(started.outcome, "applied");
   return ledgerCut(started.cut);
 }
-function assignmentBinding(repoId: string, paths: readonly string[]): RepoCellBinding { return { actor, source: assignmentSource,
-  assignmentScope: { repoId, taskId: "task-doc", executionId: "execution-doc", paths } }; }
-function remoteAction(baseLedgerSha: unknown, relativePath: string, ref: string, body: string) { return { kind: "doc-submit", executionId: "execution-doc", baseLedgerSha, changes: [{ path: relativePath,
-  baseBlobSha256: null, policyId, candidate: { ref: `doc-sync-claims/${ref}`, sha256: sha(body), size: Buffer.byteLength(body), mediaType: "text/markdown" } }] } as const; }
-function writeAuthored(rootDir: string, relativePath: string, body: string): void { const target = path.join(rootDir, "harness", relativePath); mkdirSync(path.dirname(target), { recursive: true }); writeFileSync(target, body); }
-function writeClaim(rootDir: string, ref: string, body: string): void { const target = path.join(rootDir, ".harness/doc-sync-claims", ref); mkdirSync(path.dirname(target), { recursive: true }); writeFileSync(target, body); }
-function claimPath(rootDir: string, hash: string): string { return path.join(rootDir, ".harness/doc-sync-claims", hash); }
-function sha(body: string): string { return createHash("sha256").update(body).digest("hex"); }
-function ledgerCut(value: unknown) { const cut = value as { repoId: string; revision: number; headDigest: string }; return { repoId: cut.repoId, revision: cut.revision, headDigest: cut.headDigest }; }
-function initRepo(rootDir: string): void { git(rootDir, "init", "--quiet"); git(rootDir, "config", "user.name", "Doc B Test"); git(rootDir, "config", "user.email", "doc-b@example.invalid"); git(rootDir, "commit", "--allow-empty", "--quiet", "-m", "base"); }
-function git(rootDir: string, ...args: string[]): string { return execFileSync("git", ["-C", rootDir, ...args], { encoding: "utf8" }).trim(); }
-function rbacFixture() { const parent = mkdtempSync(path.join(tmpdir(), "ha-doc-b-rbac-")), rootDir = path.join(parent, "repo"), userRoot = path.join(parent, "user");
-  const ids = { reader: 5101, writer: 5102, otherWriter: 5103, admin: 5104 }; mkdirSync(path.join(rootDir, "harness"), { recursive: true }); initRepo(rootDir);
-  writeFileSync(path.join(rootDir, "harness/harness.yaml"), "schema: harness-anything/v1\nname: rbac\nlayout:\n  authoredRoot: harness\n  localRoot: .harness\n");
-  const people = Object.entries(ids).map(([role, uid]) => ({ personId: role, displayName: role, roles: [role === "otherWriter" ? "writer" : role], credentials: [{ kind: "unix-socket-owner-boundary", issuer: `host:${hostname()}`, subject: String(uid) }] }));
-  const roles = [{ roleId: "reader", commandClasses: ["repo-read"] }, { roleId: "writer", commandClasses: ["repo-write", "repo-read"] }, { roleId: "admin", commandClasses: ["admin"] }];
-  writeFileSync(path.join(rootDir, "harness/people.yaml"), `${JSON.stringify({ schema: "harness-people/v1", people, roles }, null, 2)}\n`); git(rootDir, "add", "harness"); git(rootDir, "commit", "--quiet", "-m", "rbac");
-  return { rootDir, userRoot, ids, close: () => rmSync(parent, { recursive: true, force: true }) }; }
+function assignmentBinding(repoId: string, paths: readonly string[]): RepoCellBinding {
+  return {
+    actor,
+    source: assignmentSource,
+    assignmentScope: { repoId, taskId: "task-doc", executionId: "execution-doc", paths },
+  };
+}
+function remoteAction(baseLedgerSha: unknown, relativePath: string, ref: string, body: string) {
+  return {
+    kind: "doc-submit",
+    executionId: "execution-doc",
+    baseLedgerSha,
+    changes: [
+      {
+        path: relativePath,
+        baseBlobSha256: null,
+        policyId,
+        candidate: {
+          ref: `doc-sync-claims/${ref}`,
+          sha256: sha(body),
+          size: Buffer.byteLength(body),
+          mediaType: "text/markdown",
+        },
+      },
+    ],
+  } as const;
+}
+function writeAuthored(rootDir: string, relativePath: string, body: string): void {
+  const target = path.join(rootDir, "harness", relativePath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, body);
+}
+function writeClaim(rootDir: string, ref: string, body: string): void {
+  const target = path.join(rootDir, ".harness/doc-sync-claims", ref);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, body);
+}
+function claimPath(rootDir: string, hash: string): string {
+  return path.join(rootDir, ".harness/doc-sync-claims", hash);
+}
+function sha(body: string): string {
+  return createHash("sha256").update(body).digest("hex");
+}
+function ledgerCut(value: unknown) {
+  const cut = value as { repoId: string; revision: number; headDigest: string };
+  return { repoId: cut.repoId, revision: cut.revision, headDigest: cut.headDigest };
+}
+function initRepo(rootDir: string): void {
+  git(rootDir, "init", "--quiet");
+  git(rootDir, "config", "user.name", "Doc B Test");
+  git(rootDir, "config", "user.email", "doc-b@example.invalid");
+  git(rootDir, "commit", "--allow-empty", "--quiet", "-m", "base");
+}
+function git(rootDir: string, ...args: string[]): string {
+  return execFileSync("git", ["-C", rootDir, ...args], { encoding: "utf8" }).trim();
+}
+function rbacFixture() {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-doc-b-rbac-")),
+    rootDir = path.join(parent, "repo"),
+    userRoot = path.join(parent, "user");
+  const ids = { reader: 5101, writer: 5102, otherWriter: 5103, admin: 5104 };
+  mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+  initRepo(rootDir);
+  writeFileSync(
+    path.join(rootDir, "harness/harness.yaml"),
+    "schema: harness-anything/v1\nname: rbac\nlayout:\n  authoredRoot: harness\n  localRoot: .harness\n",
+  );
+  const people = Object.entries(ids).map(([role, uid]) => ({
+    personId: role,
+    displayName: role,
+    roles: [role === "otherWriter" ? "writer" : role],
+    credentials: [{ kind: "unix-socket-owner-boundary", issuer: `host:${hostname()}`, subject: String(uid) }],
+  }));
+  const roles = [
+    { roleId: "reader", commandClasses: ["repo-read"] },
+    { roleId: "writer", commandClasses: ["repo-write", "repo-read"] },
+    { roleId: "admin", commandClasses: ["admin"] },
+  ];
+  writeFileSync(
+    path.join(rootDir, "harness/people.yaml"),
+    `${JSON.stringify({ schema: "harness-people/v1", people, roles }, null, 2)}\n`,
+  );
+  git(rootDir, "add", "harness");
+  git(rootDir, "commit", "--quiet", "-m", "rbac");
+  return { rootDir, userRoot, ids, close: () => rmSync(parent, { recursive: true, force: true }) };
+}

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -7,15 +7,41 @@ import { hostname, tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { openDaemonHost } from "../src/daemon-host.ts";
-import { eventObjectTarget, makeTaskEventStore, makeTaskProjection, readDaemonRegistry, REPLAY_TASK_GRAPH, serializeCanonicalEvent, serializeEventHead, sha256Text, type AgentRuntimeEventV1, type FrozenWritePlan, type TaskEventV1 } from "../../kernel/src/index.ts";
+import {
+  eventObjectTarget,
+  makeTaskEventStore,
+  makeTaskProjection,
+  readDaemonRegistry,
+  REPLAY_TASK_GRAPH,
+  serializeCanonicalEvent,
+  serializeEventHead,
+  sha256Text,
+  type AgentRuntimeEventV1,
+  type FrozenWritePlan,
+  type TaskEventV1,
+} from "../../kernel/src/index.ts";
 import { projectDecisionReadiness, reviewDigest } from "../../kernel/src/index.ts";
-import { actionForDaemonMethod, canonicalRoot, commandClassForAction, daemonGuiActionMethods, daemonProtocolCommands, parseDaemonRpcParams, validateDaemonDecisionList, validateDaemonGuiCommandReceipt, validateDaemonRelationGraph, validateDaemonTaskSnapshotList, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import {
+  actionForDaemonMethod,
+  canonicalRoot,
+  commandClassForAction,
+  daemonGuiActionMethods,
+  daemonProtocolCommands,
+  parseDaemonRpcParams,
+  validateDaemonDecisionList,
+  validateDaemonGuiCommandReceipt,
+  validateDaemonRelationGraph,
+  validateDaemonTaskSnapshotList,
+  workspaceId,
+} from "../src/protocol/daemon-protocol.contract.ts";
 import { createJsonRpcProtocolServer } from "../src/protocol/json-rpc-server.ts";
 import { currentDaemonProtocolVersion } from "../src/protocol/version.ts";
 import { openRepoCell } from "../src/repo-cell.ts";
 const DOC_POLICY_ID = "markdown-body-replaceable/v1";
 
 const actor = { principal: { personId: "person-owner" }, executor: { kind: "agent", id: "codex" } } as const;
+
+// prettier-ignore
 
 test("descriptor-derived RBAC preserves every preset, runtime, doc-sync, Fact, and Decision action class", () => {
   const expected = {
@@ -79,6 +105,8 @@ test("descriptor-derived RBAC preserves every preset, runtime, doc-sync, Fact, a
   assert.deepEqual(Object.fromEntries(Object.keys(expected).map((kind) => [kind, commandClassForAction(kind)])), expected);
 });
 
+// prettier-ignore
+
 test("task-create and preset RPC descriptors enforce closed payloads and retire the open route", () => {
   const params = { repo: { repoId: "alpha" }, payload: { title: "Closed", presetId: "standard-task" } };
   assert.equal(parseDaemonRpcParams("repo.task.create", params).ok, true); assert.equal(parseDaemonRpcParams("repo.task.create", { ...params, payload: { ...params.payload, dryRun: true } }).ok, true); assert.equal(parseDaemonRpcParams("repo.task.create", { ...params, payload: { ...params.payload, dryRun: "true" } }).ok, false); assert.equal(parseDaemonRpcParams("repo.task.create", { ...params, payload: { ...params.payload, completionGateIds: [] } }).ok, false); assert.deepEqual(actionForDaemonMethod("repo.task.create", params.payload), { kind: "task-create", ...params.payload }); assert.throws(() => actionForDaemonMethod("repo.task.run", { action: { kind: "task-create", title: "Open" } }), /closed method/u);
@@ -90,11 +118,15 @@ test("task-create and preset RPC descriptors enforce closed payloads and retire 
   assert.equal(parseDaemonRpcParams("repo.task.create", { repo: { repoId: "alpha" }, payload: { ...fullPayload, taskClass: "long_running" } }).ok, true);
 });
 
+// prettier-ignore
+
 test("daemon repo registration derives its closed mode enum at the wire boundary", () => {
   const base = { rootDir: "/tmp/workspace", repoId: "alpha" };
   for (const mode of [undefined, "local", "remote-center", "remote-edge"]) assert.equal(parseDaemonRpcParams("daemon.repo.register", { ...base, ...(mode ? { mode } : {}) }).ok, true, String(mode));
   const invalid = parseDaemonRpcParams("daemon.repo.register", { ...base, mode: "invalid" }); assert.equal(invalid.ok, false); if (!invalid.ok) assert.deepEqual(invalid.errors, ["params.mode must be one of local, remote-center, remote-edge"]);
 });
+
+// prettier-ignore
 
 test("local Fleet runtime envelope admits the paged overview read", async () => {
   let observed: Record<string, unknown> | null = null;
@@ -109,6 +141,8 @@ test("local Fleet runtime envelope admits the paged overview read", async () => 
   } finally { server.close(); }
 });
 
+// prettier-ignore
+
 test("protocol hello accepts only the session variables owned by runtime resolvers", () => {
   const hello = (sessionEnvironment?: Record<string, unknown>) => parseDaemonRpcParams("protocol.hello", { protocolVersion: currentDaemonProtocolVersion, ...(sessionEnvironment ? { sessionEnvironment } : {}) });
   assert.equal(hello().ok, true);
@@ -116,6 +150,8 @@ test("protocol hello accepts only the session variables owned by runtime resolve
   assert.deepEqual(hello({ CLAUDE_CODE_HOST_SESSION_ID: "local-wrong" }), { ok: false, errors: ["session environment contains an unknown field \"CLAUDE_CODE_HOST_SESSION_ID\"; allowed fields: \"CLAUDE_CODE_SESSION_ID\", \"CODEX_THREAD_ID\", \"CODEX_SESSION_ID\"."] });
   assert.deepEqual(hello({ CODEX_THREAD_ID: " " }), { ok: false, errors: ["session environment values must be non-empty strings"] });
 });
+
+// prettier-ignore
 
 test("ledger migrate runs through the RepoCell write queue and reports its bounded projection catch-up", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-ledger-layout-migrate-")); let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
@@ -125,6 +161,8 @@ test("ledger migrate runs through the RepoCell write queue and reports its bound
     const repeated = await cell.run({ kind: "ledger-migrate" }, { actor, source: "local" }) as Record<string, unknown>; assert.equal(repeated.commitSha, receipt.commitSha); assert.equal(git(rootDir, "rev-list", "--count", "HEAD"), "3");
   } finally { await cell?.close(); rmSync(rootDir, { recursive: true, force: true }); }
 });
+
+// prettier-ignore
 
 test("explicit projection rebuild is a local repair action with a source-complete digest", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-projection-rebuild-")); let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
@@ -138,11 +176,15 @@ test("explicit projection rebuild is a local repair action with a source-complet
   } finally { await cell?.close(); rmSync(rootDir, { recursive: true, force: true }); }
 });
 
+// prettier-ignore
+
 test("replay receipts retain their event cut and upgrade pending commit identity after drain", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-replay-current-cut-")); let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   try { initRepo(rootDir); cell = await openRepoCell({ repoId: workspaceId("replay-current-cut"), rootDir: canonicalRoot(rootDir), ownerId: "replay-current-cut" }); const binding = { actor, source: "local" as const }; await cell.run({ kind: "task-create", taskId: "task_replay_first", title: "First" }, binding); const first = await cell.run({ kind: "task-start", taskId: "task_replay_first", executionId: "execution_replay_first" }, binding) as Record<string, unknown>, second = await cell.run({ kind: "task-create", taskId: "task_replay_second", title: "Second" }, binding) as Record<string, unknown>, replay = await cell.run({ kind: "receipt-show", opId: first.opId }, binding) as Record<string, unknown>; assert.equal(first.commitSha, null); assert.equal(second.commitSha, null); assert.notDeepEqual(first.cut, second.cut); assert.equal(replay.commitSha, null); assert.deepEqual(replay.cut, first.cut); await cell.close(); cell = await openRepoCell({ repoId: workspaceId("replay-current-cut"), rootDir: canonicalRoot(rootDir), ownerId: "replay-current-cut-reopened" }); const materialized = await cell.run({ kind: "receipt-show", opId: first.opId }, binding) as Record<string, unknown>; assert.equal(materialized.commitSha, git(rootDir, "rev-parse", "HEAD")); assert.deepEqual(materialized.cut, first.cut); }
   finally { await cell?.close(); rmSync(rootDir, { recursive: true, force: true }); }
 });
+
+// prettier-ignore
 
 test("relation graph contract accepts the materialized ledger row schema and rejects malformed rows", () => {
   const payload = { ok: true, edges: [{ relationId: "rel_real", sourceRef: "decision/dec_REAL/C1", targetRef: "fact/task_REAL/F-REAL", relationType: "evidenced-by", direction: "directed", strength: "strong", origin: "declared", state: "active", rationale: "Observed.", ownerRef: "decision/dec_REAL", sourcePath: "harness/decisions/decision-dec_REAL/decision.md", recordIndex: 0 }], coverageRows: [{ decisionRef: "decision/dec_REAL", claimRef: "decision/dec_REAL/C1", status: "covered", fulfillment: "standing-policy", relationPath: ["rel_real"] }], factAnchors: [{ factRef: "fact/task_REAL/F-REAL", taskId: "task_REAL", factId: "F-REAL", sourcePath: "harness/tasks/task_REAL/facts.md" }], facts: [{ schema: "task-fact-row/v1", ref: "fact/task_REAL/F-REAL", taskId: "task_REAL", factId: "F-REAL", statement: "Real observation.", source: "harness/tasks/task_REAL/facts.md", observedAt: "2026-08-14T00:00:00.000Z", confidence: "high", memoryClass: "semantic", memoryTags: [], provenance: [], liveness: "standing" }], warnings: [] };
@@ -159,6 +201,8 @@ test("relation graph contract accepts the materialized ledger row schema and rej
   const { observedAt: _observedAt, ...missingObservedAt } = payload.facts[0]; assert.deepEqual(validateDaemonRelationGraph({ ...payload, facts: [missingObservedAt] }), ["daemon relation graph is invalid"]);
 });
 
+// prettier-ignore
+
 test("wide GUI read contracts accept only their explicit narrow and page facets", () => {
   const task = (payload: Record<string, unknown>) => parseDaemonRpcParams("repo.tasks.list", { repo: { repoId: "alpha" }, payload });
   const graph = (payload: Record<string, unknown>) => parseDaemonRpcParams("repo.triadic.relationGraph", { repo: { repoId: "alpha" }, payload });
@@ -171,10 +215,14 @@ test("wide GUI read contracts accept only their explicit narrow and page facets"
   assert.equal(task({ unexpected: true }).ok, false);
 });
 
+// prettier-ignore
+
 test("preset process RPC enforces object inputs and keeps status closed", () => {
   const start = { repo: { repoId: "alpha" }, payload: { presetId: "user-canary", entrypoint: "check", inputs: { title: "Canary" }, idempotencyKey: "once" } }, status = { repo: { repoId: "alpha" }, payload: { runId: "run_1" } };
   assert.equal(parseDaemonRpcParams("repo.preset.run.start", start).ok, true); assert.equal(parseDaemonRpcParams("repo.preset.run.start", { ...start, payload: { ...start.payload, allowScripts: true } }).ok, false); assert.equal(parseDaemonRpcParams("repo.preset.run.start", { ...start, payload: { ...start.payload, inputs: "open" } }).ok, false); assert.equal(parseDaemonRpcParams("repo.preset.run.status", status).ok, true); assert.equal(parseDaemonRpcParams("repo.preset.run.status", { ...status, payload: { ...status.payload, retry: true } }).ok, false);
 });
+
+// prettier-ignore
 
 test("GUI action facets are exact, typed, and exclude the generic runner", () => {
   const submission = { completionClaim: "Ready.", deliverables: ["code"], outputs: ["packages/daemon/src/repo-cell.ts"], verificationNotes: ["tests"], knownGaps: [], residualRisks: [], commitSha: "a".repeat(40) }, proposal = { title: "Typed actions", question: "Ship?", riskTier: "medium", urgency: "high", vertical: "software/coding", preset: "standard-task", appliesTo: { modules: ["daemon"], productLines: ["gui"] }, decisionClass: "ordinary", chosen: [{ id: "CH1", text: "Ship" }], rejected: [{ id: "RJ1", text: "Wait", whyNot: "No need" }], body: "# Typed actions\n", claims: [], fulfillments: [], relations: [] };
@@ -211,6 +259,8 @@ test("GUI action facets are exact, typed, and exclude the generic runner", () =>
   assert.deepEqual(actionForDaemonMethod("repo.task.submit", cases.get("repo.task.submit")!), { kind: "task-submit", ...cases.get("repo.task.submit")! });
 });
 
+// prettier-ignore
+
 test("GUI command receipts and task supplements reject unknown, missing, and mistyped fields", () => {
   const proof = { committedRevision: 0, appliedCut: 0, durable: true, canonicalVisible: true, worktreeVisible: null }, receipt = { schema: "command-receipt/v2", ok: true, command: "decision-list", outcome: "applied", opId: "read:decision-list", revision: 0, evidence: "{}", visibility: "center", proof };
   assert.deepEqual(validateDaemonGuiCommandReceipt(receipt), []); assert.notDeepEqual(validateDaemonGuiCommandReceipt({ ...receipt, extra: true }), []); const { schema: _schema, ...missing } = receipt; assert.notDeepEqual(validateDaemonGuiCommandReceipt(missing), []); assert.notDeepEqual(validateDaemonGuiCommandReceipt({ ...receipt, revision: "0" }), []);
@@ -225,6 +275,8 @@ test("GUI command receipts and task supplements reject unknown, missing, and mis
   assert.notDeepEqual(validateDaemonTaskSnapshotList({ ...current, rows: [{ ...current.rows[0]!, snapshot: { ...current.rows[0]!.snapshot, task: { ...currentTask, pinned: "true" } } }] }), []);
 });
 
+// prettier-ignore
+
 test("repo-bound ledger commit rejects cross-repo SHA", () => {
   const roots = ["a", "b"].map((name) => mkdtempSync(path.join(tmpdir(), `ha-ledger-${name}-`)));
   try { roots.forEach(initRepo); const left = makeTaskEventStore({ rootDir: roots[0]!, repoId: "repo-a" }), right = makeTaskEventStore({ rootDir: roots[1]!, repoId: "repo-b" });
@@ -232,12 +284,16 @@ test("repo-bound ledger commit rejects cross-repo SHA", () => {
   } finally { roots.forEach((root) => rmSync(root, { recursive: true, force: true })); }
 });
 
+// prettier-ignore
+
 test("task create dry-run validates the exact package without event, revision, commit, or authored writes", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-task-create-preview-")); let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   try { initRepo(rootDir); mkdirSync(path.join(rootDir, "harness/custom"), { recursive: true }); mkdirSync(path.join(rootDir, "harness/templates"), { recursive: true }); writeFileSync(path.join(rootDir, "harness/harness.yaml"), "settings:\n  scaffolds:\n    task: custom/task-scaffold.json\n"); writeFileSync(path.join(rootDir, "harness/templates/notes.md"), "# Notes\n\n## Project Notes\n\nCustom.\n"); writeFileSync(path.join(rootDir, "harness/custom/task-scaffold.json"), `${JSON.stringify({ schema: "task-scaffold/v1", replaceTemplate: [], addDocument: [{ slot: "project.notes", path: "notes.md", template: "templates/notes.md", requiredAnchors: ["## Project Notes"] }] })}\n`); cell = await openRepoCell({ repoId: workspaceId("preview"), rootDir: canonicalRoot(rootDir), ownerId: "preview-daemon" }); const action = { kind: "task-create", taskId: "task-preview", title: "Preview Package" } as const, before = git(rootDir, "rev-parse", "HEAD"), preview = await cell.run({ ...action, dryRun: true }, { actor, source: "local" }) as Record<string, unknown>; assert.equal(preview.outcome, "pending"); assert.equal((preview.proof as { canonicalVisible: boolean }).canonicalVisible, false); assert.equal(preview.packagePath, "tasks/task-preview-preview-package"); assert.equal(preview.commitSha, null); assert.equal(preview.dryRun, true); assert.equal((preview.generatedPaths as string[]).length, 7); assert.equal((preview.generatedPaths as string[]).includes("tasks/task-preview-preview-package/notes.md"), true); assert.equal(makeTaskEventStore({ repoId: "preview", rootDir }).read().revision, 0); assert.equal(git(rootDir, "rev-parse", "HEAD"), before); assert.equal(existsSync(path.join(rootDir, "harness/tasks/task-preview-preview-package")), false);
     const created = await cell.run(action, { actor, source: "local" }) as Record<string, unknown>; assert.equal(created.packagePath, preview.packagePath); assert.equal(created.presetDigest, preview.presetDigest); assert.equal(created.scaffoldDigest, preview.scaffoldDigest); assert.equal(created.commitSha, null); assert.equal(typeof created.cut, "object"); assert.match(String(created.nextAction), /task_plan\.md.*task start/u); assert.equal(readFileSync(path.join(rootDir, "harness/tasks/task-preview-preview-package/notes.md"), "utf8"), "# Notes\n\n## Project Notes\n\nCustom.\n"); assert.equal(makeTaskEventStore({ repoId: "preview", rootDir }).read().revision, 1); const duplicate = await cell.run({ ...action, title: "Different title" }, { actor, source: "local" }); assert.equal(duplicate.outcome, "op_rejected"); assert.equal(duplicate.code, "task_exists"); assert.equal(makeTaskEventStore({ repoId: "preview", rootDir }).read().revision, 1); writeFileSync(path.join(rootDir, "harness/tasks/task-preview-preview-package/INDEX.md"), "corrupt markdown\n"); const shown = await cell.run({ kind: "task-show", taskId: "task-preview" }, { actor, source: "local" }); const evidence = JSON.parse(String(shown.evidence)) as { packagePath: string; task: { title: string } }; assert.equal(evidence.packagePath, preview.packagePath); assert.equal(evidence.task.title, "Preview Package");
   } finally { await cell?.close(); rmSync(rootDir, { recursive: true, force: true }); }
 });
+
+// prettier-ignore
 
 test("RepoCell rejects completion on snapshot drift and preset upgrade publishes one canonical replacement", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-preset-upgrade-cell-")), source = path.join(rootDir, "source/upgrade-task"), taskId = "task-upgrade-cell", binding = { actor, source: "local" as const }; let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
@@ -247,6 +303,8 @@ test("RepoCell rejects completion on snapshot drift and preset upgrade publishes
     const blocked = await cell.run({ kind: "task-complete", taskId, executionId: "execution-missing" }, binding); assert.equal(blocked.code, "preset_snapshot_mismatch"); const upgraded = await cell.run({ kind: "preset-upgrade", taskId }, binding) as Record<string, unknown>; assert.equal(upgraded.outcome, "applied"); const evidence = JSON.parse(String(upgraded.evidence)) as { previousDigest: string; digest: string }; assert.equal(evidence.previousDigest, previousDigest); assert.notEqual(evidence.digest, previousDigest); const event = makeTaskEventStore({ repoId: "preset-upgrade-cell", rootDir }).readEvent(String(upgraded.opId)); assert.equal(event?.schema, "preset-snapshot-upgrade-event/v1"); assert.equal((await cell.run({ kind: "task-complete", taskId, executionId: "execution-missing" }, binding)).code, "not_in_review");
   } finally { await cell?.close(); rmSync(rootDir, { recursive: true, force: true }); }
 });
+
+// prettier-ignore
 
 test("RepoCell serializes identical lifecycle intents into one WAL event and one drained Git publication", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-repo-cell-"));
@@ -279,6 +337,8 @@ test("RepoCell serializes identical lifecycle intents into one WAL event and one
   }
 });
 
+// prettier-ignore
+
 test("structured GUI submit and CLI packet submit publish the same canonical event", async () => {
   const roots = ["packet", "structured"].map((name) => mkdtempSync(path.join(tmpdir(), `ha-submit-ab-${name}-`)));
   const cells: Awaited<ReturnType<typeof openRepoCell>>[] = [];
@@ -297,6 +357,8 @@ test("structured GUI submit and CLI packet submit publish the same canonical eve
     const projected = await cells[1]!.read("repo.tasks.list"), row = projected.rows[0]!, output = row.executionEvidence[0]!.outputs[0]!; assert.deepEqual(row.snapshotAvailability, { consents: "known", codeDocWitnesses: "known", gateWitnesses: "known" }); assert.deepEqual({ parentTaskId: row.placement.parentTaskId, origin: row.placement.origin, packageDisposition: row.placement.packageDisposition }, { parentTaskId: null, origin: "native", packageDisposition: "active" }); assert.equal(row.placement.provenance.length > 0, true); assert.deepEqual({ executionId: row.executionEvidence[0]!.executionId, origin: row.executionEvidence[0]!.origin, locator: output.locator, substrate: output.substrate, checkerReceiptRef: output.checkerReceiptRef, checkerResult: output.checkerResult }, { executionId, origin: "native", locator: submission.outputs[0], substrate: "repository-path", checkerReceiptRef: null, checkerResult: "unknown" }); assert.match(output.evidenceId, /^evidence_[0-9a-f]{24}$/u); assert.deepEqual(validateDaemonTaskSnapshotList(projected), []);
   } finally { await Promise.all(cells.map((cell) => cell.close())); roots.forEach((root) => rmSync(root, { recursive: true, force: true })); }
 });
+
+// prettier-ignore
 
 test("lifecycle commands publish typed events, machine files, rebuildable L2, and complete receipts in one cut", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-lifecycle-files-")); let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
@@ -320,6 +382,7 @@ test("lifecycle commands publish typed events, machine files, rebuildable L2, an
   } finally { await cell?.close(); rmSync(rootDir, { recursive: true, force: true }); }
 });
 
+// prettier-ignore
 
 test("code-doc repoint appends a replacement witness and rejects stale or unknown records", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-code-doc-repoint-")),
@@ -423,6 +486,8 @@ test("code-doc repoint appends a replacement witness and rejects stale or unknow
   }
 });
 
+// prettier-ignore
+
 test("milestone-closeout uses the normal completion facade, review, and gates exactly once", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-completion-facade-")); let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   const taskId = "task-complete", executionId = "execution-complete", packagePath = "tasks/task-complete-completion-facade", binding = { actor, source: "local" as const };
@@ -453,6 +518,8 @@ test("milestone-closeout uses the normal completion facade, review, and gates ex
   } finally { await cell?.close(); rmSync(rootDir, { recursive: true, force: true }); }
 });
 
+// prettier-ignore
+
 test("CompleteTask response loss settles by stable receipt and never publishes a second completion", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-complete-unknown-")), taskId = "task-unknown-complete", executionId = "execution-unknown-complete", repoId = workspaceId("complete-unknown"); let armed = false, cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   try {
@@ -461,6 +528,8 @@ test("CompleteTask response loss settles by stable receipt and never publishes a
     cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "complete-unknown-two" }); const settled = await cell.run({ kind: "receipt-show", opId: String(unknown.opId) }, { actor, source: "local" }), retried = await cell.run({ kind: "task-complete", taskId, executionId }, { actor, source: "local" }); assert.equal(settled.outcome, "applied", JSON.stringify(settled)); assert.equal(retried.outcome, "applied", JSON.stringify(retried)); assert.equal(retried.opId, unknown.opId); assert.equal(store().read().revision, before + 1); assert.equal(store().read().events.filter((event) => event.type === "task_completed").length, 1);
   } finally { await cell?.close(); rmSync(rootDir, { recursive: true, force: true }); }
 });
+
+// prettier-ignore
 
 test("Fact record publishes one event, L2 row, authored facts document, and supersession history", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-repo-cell-invalid-fact-")); let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
@@ -475,6 +544,8 @@ test("Fact record publishes one event, L2 row, authored facts document, and supe
     const second = await cell.run({ kind: "fact-record", taskId: "task-fact", statement: "Canonical facts also backwrite Markdown.", evidenceSource: "test:second", confidence: "high", memoryClass: "semantic", memoryTags: ["pattern"], supersedes: { factRef: `fact/task-fact/${firstId}`, rationale: "The stronger observation supersedes the first." } }, binding) as Record<string, unknown>; assert.equal(second.outcome, "applied", JSON.stringify(second)); const body = readFileSync(factsFile, "utf8"); assert.match(body, new RegExp(`### ${firstId}[\\s\\S]*State: superseded_fact`, "u")); assert.match(body, new RegExp(`### ${String(second.factId)}[\\s\\S]*State: standing`, "u")); const shown = await cell.run({ kind: "fact-show", taskId: "task-fact", factId: firstId }, binding); assert.equal((JSON.parse(String(shown.evidence)) as { fact: { state: string } }).fact.state, "superseded_fact"); assert.equal(makeTaskEventStore({ repoId: "invalid-fact", rootDir }).readHead()?.revision, 3);
   } finally { await cell?.close(); rmSync(rootDir, { recursive: true, force: true }); }
 });
+
+// prettier-ignore
 
 test("invalid Decision payload stays invalid_command and reckon records exact projected basis", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-repo-cell-decision-")); let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
@@ -497,6 +568,8 @@ test("invalid Decision payload stays invalid_command and reckon records exact pr
   } finally { await cell?.close(); rmSync(rootDir, { recursive: true, force: true }); }
 });
 
+// prettier-ignore
+
 test("Decision proposal packet is closed, UTF-8, atomic, and leaves the related Task INDEX untouched", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-decision-packet-")); let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   try { initRepo(rootDir); cell = await openRepoCell({ repoId: workspaceId("decision-packet"), rootDir: canonicalRoot(rootDir), ownerId: "daemon-test" }); const binding = { actor, source: "local" as const }, created = await cell.run({ kind: "task-create", taskId: "task-related", title: "Related Task" }, binding) as Record<string, unknown>, index = path.join(rootDir, "harness", String(created.packagePath), "INDEX.md"), indexBefore = readFileSync(index); const packet = { title: "Atomic proposal", question: "Can one event publish the whole proposal?", riskTier: "medium", urgency: "high", vertical: "default", preset: "default", decisionClass: "ordinary", appliesTo: { modules: ["daemon"], productLines: [] }, chosen: [{ id: "CH1", text: "Publish once" }], rejected: [{ id: "RJ1", text: "Patch later", whyNot: "It exposes partial state" }], claims: [{ id: "C1", text: "The packet is atomic.", loadBearing: true }], fulfillments: [{ claimId: "C1", mode: "delivered" }], relations: [{ anchor: "C1", type: "derives", target: "task/task-related", rationale: "The Decision creates this delivery." }] }, missingPacket = (({ relations: _relations, ...missing }) => missing)(packet), before = makeTaskEventStore({ repoId: "decision-packet", rootDir }).readHead()!.revision;
@@ -507,6 +580,8 @@ test("Decision proposal packet is closed, UTF-8, atomic, and leaves the related 
   } finally { await cell?.close(); rmSync(rootDir, { recursive: true, force: true }); }
 });
 
+// prettier-ignore
+
 test("Decision judgment keeps the transport arbiter gate and returns the embedded consent identity", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-repo-cell-decision-consent-")); let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   try { initRepo(rootDir); cell = await openRepoCell({ repoId: workspaceId("decision-consent"), rootDir: canonicalRoot(rootDir), ownerId: "daemon-test" }); const human = { principal: { personId: "person-ceo" }, executor: null } as const, binding = { actor: human, source: "local" as const }, proposed = await cell.run(decisionProposal("Consent", "May the CEO judge this proposal?"), binding), decisionId = (JSON.parse(proposed.evidence) as { decisionId: string }).decisionId, before = makeTaskEventStore({ repoId: "decision-consent", rootDir }).readHead()!.revision;
@@ -514,6 +589,8 @@ test("Decision judgment keeps the transport arbiter gate and returns the embedde
     const accepted = await cell.run({ kind: "decision-accept", decisionId, rationale: "CEO approval", judgmentOnlyRationale: "Explicit CEO judgment." }, { ...binding, roles: ["$arbiter"] }); assert.equal(accepted.outcome, "applied", JSON.stringify(accepted)); assert.match(String((accepted as Record<string, unknown>).consentId), /^djc_[0-9a-f]{26}$/u); const event = makeTaskEventStore({ repoId: "decision-consent", rootDir }).readEvent(accepted.opId); assert.equal(event?.schema, "decision-event/v1"); if (event?.schema === "decision-event/v1" && event.type === "decision_accepted") assert.equal(event.payload.judgmentConsent.consentId, (accepted as Record<string, unknown>).consentId);
   } finally { await cell?.close(); rmSync(rootDir, { recursive: true, force: true }); }
 });
+
+// prettier-ignore
 
 test("Decision full vertical golden rebuilds proposal, prose, claim, relation, consent, list, and show", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-decision-vertical-")); let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
@@ -529,6 +606,8 @@ test("Decision full vertical golden rebuilds proposal, prose, claim, relation, c
   } finally { await cell?.close(); rmSync(rootDir, { recursive: true, force: true }); }
 });
 
+// prettier-ignore
+
 test("a pending WAL receipt remains readable when the Git object store is unavailable", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-repo-cell-corrupt-")); let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   try { initRepo(rootDir); cell = await openRepoCell({ repoId: workspaceId("corrupt"), rootDir: canonicalRoot(rootDir), ownerId: "daemon-test" });
@@ -541,8 +620,17 @@ test("a pending WAL receipt remains readable when the Git object store is unavai
   } finally { if (cell) await cell.close(); rmSync(rootDir, { recursive: true, force: true }); }
 });
 
-for (const killpoint of ["before_event_write", "after_event_write", "after_head_write", "before_worktree_rename", "after_worktree_rename",
-  "after_sqlite_commit", "before_response_write", "after_response_write"] as const) {
+for (const killpoint of [
+  "before_event_write",
+  "after_event_write",
+  "after_head_write",
+  "before_worktree_rename",
+  "after_worktree_rename",
+  "after_sqlite_commit",
+  "before_response_write",
+  "after_response_write",
+] as const) {
+  // prettier-ignore
   test(`RepoCell new generation recovers ${killpoint} without a duplicate publication`, async () => {
     const rootDir = mkdtempSync(path.join(tmpdir(), "ha-repo-cell-crash-"));
     const action = { kind: "task-create", taskId: `task-${killpoint}`, title: killpoint } as const;
@@ -568,6 +656,8 @@ for (const killpoint of ["before_event_write", "after_event_write", "after_head_
   });
 }
 
+// prettier-ignore
+
 test("RepoCell preserves an acknowledged receipt when Git materialization stops after ref update", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-repo-cell-git-cut-crash-"));
   const action = { kind: "task-create", taskId: "task-after-git-commit", title: "after_git_commit" } as const;
@@ -588,6 +678,7 @@ test("RepoCell preserves an acknowledged receipt when Git materialization stops 
 });
 
 for (const killpoint of ["after_sqlite_commit", "before_response_write", "after_response_write"] as const) {
+  // prettier-ignore
   test(`Decision response recovery handles ${killpoint} without a duplicate authored event`, async () => {
     const rootDir = mkdtempSync(path.join(tmpdir(), "ha-decision-response-crash-")), action = decisionProposal("Recover Decision", "Does the receipt settle once?"), binding = { actor, source: "local" as const };
     let crashed: Awaited<ReturnType<typeof openRepoCell>> | undefined, recovered: Awaited<ReturnType<typeof openRepoCell>> | undefined;
@@ -596,6 +687,8 @@ for (const killpoint of ["after_sqlite_commit", "before_response_write", "after_
     } finally { await crashed?.close(); await recovered?.close(); rmSync(rootDir, { recursive: true, force: true }); }
   });
 }
+
+// prettier-ignore
 
 test("RepoCell doc mapping enforces strict dual CAS, holder receipts, deletion rejection, and worktree preservation", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-cell-")); let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
@@ -609,12 +702,14 @@ test("RepoCell doc mapping enforces strict dual CAS, holder receipts, deletion r
     const before = { head: git(rootDir, "rev-parse", "HEAD"), bytes: readFileSync(authored).toString("hex") }, applied = await cell.run(action, { actor, source: "local" });
     assert.equal(applied.outcome, "applied", JSON.stringify(applied)); assert.equal(applied.detail?.kind, "doc_sync"); assert.equal(applied.proof?.worktreeVisible, true); assert.equal(applied.commitSha, null); assert.ok(applied.cut); assert.equal(git(rootDir, "rev-parse", "HEAD"), before.head); assert.equal(git(rootDir, "rev-parse", "refs/ha/canonical"), before.head); assert.equal(readFileSync(authored).toString("hex"), before.bytes);
     const shown = await cell.run({ kind: "receipt-show", opId: applied.opId }, { actor, source: "local" }); assert.equal(shown.outcome, "applied"); assert.equal(shown.detail?.kind, "doc_sync"); assert.equal(shown.proof?.canonicalVisible, true);
-    const commits = git(rootDir, "rev-list", "--count", "refs/ha/canonical"), retried = await cell.run(action, { actor, source: "local" }); assert.equal(retried.outcome, "op_rejected"); assert.equal(retried.code, "no_changes"); assert.match(retried.opId, /^noop:/u); assert.equal(git(rootDir, "rev-list", "--count", "refs/ha/canonical"), commits);
+    const commits = git(rootDir, "rev-list", "--count", "refs/ha/canonical"), retried = await cell.run(action, { actor, source: "local" }); assert.equal(retried.outcome, "no_changes"); assert.equal(retried.code, "no_changes"); assert.match(retried.opId, /^noop:/u); assert.equal(git(rootDir, "rev-list", "--count", "refs/ha/canonical"), commits);
     const next = `${body}B\n`; writeFileSync(authored, next);
     const updated = await cell.run(action, { actor, source: "local" }); assert.equal(updated.outcome, "applied", JSON.stringify(updated)); body = next;
     rmSync(authored); const deletion = await cell.run(action, { actor, source: "local" }); assert.equal(deletion.code, "deletion_forbidden"); writeFileSync(authored, body);
   } finally { await cell?.close(); rmSync(rootDir, { recursive: true, force: true }); }
 });
+
+// prettier-ignore
 
 test("doc ingress rejects symbolic links in claim and authored path chains", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-claim-link-")); let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
@@ -629,6 +724,8 @@ test("doc ingress rejects symbolic links in claim and authored path chains", asy
   } finally { await cell?.close(); rmSync(rootDir, { recursive: true, force: true }); }
 });
 
+// prettier-ignore
+
 test("bootstrap concurrent writer admission commits one complete workspace", async () => {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-bootstrap-writer-")), rootDir = path.join(parent, "repo");
   const auth = { transportKind: "unix-socket", unixSocketOwnerBoundary: { ownerUid: process.getuid?.() ?? 0,
@@ -639,6 +736,8 @@ test("bootstrap concurrent writer admission commits one complete workspace", asy
     const ledgerRoot = path.join(rootDir, "harness"); assert.equal(git(ledgerRoot, "rev-list", "--count", "HEAD"), "1"); assert.equal(git(rootDir, "check-ignore", "harness"), "harness"); assert.equal(git(rootDir, "check-ignore", ".harness"), ".harness"); }
   finally { await Promise.all(hosts.map((host) => host.close())); rmSync(parent, { recursive: true, force: true }); }
 });
+
+// prettier-ignore
 
 test("bootstrap binds the ledger repository branch independently of the project branch", async () => {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-bootstrap-branch-")), rootDir = path.join(parent, "repo"), userRoot = path.join(parent, "user");
@@ -657,11 +756,15 @@ test("bootstrap binds the ledger repository branch independently of the project 
   } finally { await host.close(); rmSync(parent, { recursive: true, force: true }); }
 });
 
+// prettier-ignore
+
 test("bootstrap validates local identity before repository initialization", async () => {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-bootstrap-identity-")), rootDir = path.join(parent, "repo"), host = await openDaemonHost({ daemonId: "bootstrap-identity", userRoot: path.join(parent, "user") });
   try { await assert.rejects(host.bootstrap({ rootDir, repoId: "identity", personId: "owner", displayName: "Owner" }, { transportKind: "unix-socket" }), hasCode("bootstrap_identity_unavailable")); assert.equal(existsSync(path.join(rootDir, ".git")), false); }
   finally { await host.close(); rmSync(parent, { recursive: true, force: true }); }
 });
+
+// prettier-ignore
 
 test("unrelated workspace lock collision does not block either workspace", async () => {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-lock-collision-")), owners = new Map<number, string>(); let roots: string[] | undefined;
@@ -673,6 +776,8 @@ test("unrelated workspace lock collision does not block either workspace", async
   try { assert.deepEqual(cells.map((cell) => cell.status().state), ["attached", "attached"]); }
   finally { await Promise.all(cells.map((cell) => cell.close())); rmSync(parent, { recursive: true, force: true }); }
 });
+
+// prettier-ignore
 
 test("JSON-RPC failure receipt carries formal operation identity and origin", async () => {
   const host = { run: async () => { throw new Error("unused"); }, read: async () => { throw new Error("unused"); }, attach: async () => { throw new Error("unused"); }, issueRuntimeWitness: async () => { throw new Error("unused"); }, bindRuntimeWitness: () => { throw new Error("unused"); }, publishRuntimeWitness: () => { throw new Error("unused"); }, bootstrap: async () => ({}), admin: async () => ({}),
@@ -686,6 +791,8 @@ test("JSON-RPC failure receipt carries formal operation identity and origin", as
   assert.ok(malformed && !Array.isArray(malformed) && "result" in malformed); if (malformed && !Array.isArray(malformed) && "result" in malformed) assert.equal((malformed.result as Record<string, unknown>).code, "invalid_request");
 });
 
+// prettier-ignore
+
 test("local daemon stop acknowledges the control request and triggers shutdown", async () => {
   let shutdowns = 0;
   const host = { status: () => ({ daemonId: "stop-test", pid: process.pid, repos: [] }) } as never;
@@ -695,6 +802,8 @@ test("local daemon stop acknowledges the control request and triggers shutdown",
   assert.ok(response && !Array.isArray(response) && "result" in response); if (response && !Array.isArray(response) && "result" in response) assert.deepEqual(response.result, { ok: true, command: "daemon-stop", pid: process.pid });
   assert.equal(shutdowns, 1);
 });
+
+// prettier-ignore
 
 test("read-only principal cannot write or admin while semantic capabilities pass", async () => {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-rbac-surfaces-")), root = path.join(parent, "repo"), second = path.join(parent, "second"), userRoot = path.join(parent, "user");
@@ -727,6 +836,8 @@ test("read-only principal cannot write or admin while semantic capabilities pass
   } finally { await host.close(); rmSync(parent, { recursive: true, force: true }); }
 });
 
+// prettier-ignore
+
 test("runtime witness issuance uses the server principal and rejects admin or arbiter authority", async () => {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-witness-rbac-")), root = path.join(parent, "repo"), userRoot = path.join(parent, "user"), ids = { writer: 4201, admin: 4202, dualAdmin: 4203, dualArbiter: 4204 }; rbacRepo(root, ids); const auth = (ownerUid: number) => ({ transportKind: "unix-socket", unixSocketOwnerBoundary: { ownerUid, source: "unix-socket-filesystem-owner-boundary" } } as const);
   const runtimeActor = { principal: { personId: "fixture" }, executor: null } as const, definition = { schema: "agent-definition-snapshot/v1", configVersion: 1, instanceId: "instance-runtime", installationId: "installation-runtime", kindId: "codex", providerId: "openai", model: "gpt-5.6-sol", reasoningEffort: "high", baseUrl: null, authMode: "subscription" } as const, store = makeTaskEventStore({ repoId: "runtime-witness", rootDir: root }), events = [{ schema: "agent-runtime-event/v1", eventId: "runtime-installation", workspaceRevision: 1, opId: "runtime-installation", actor: runtimeActor, source: "local", occurredAt: "2026-08-13T00:00:00.000Z", type: "runtime_installation_observed", payload: { installationId: "installation-runtime", kindId: "codex", protocolFamily: "codex", hostRef: "host:local", version: "1.0.0", discoverySource: "wrapper", capabilities: ["structured_witness", "attach"] } }, { schema: "agent-runtime-event/v1", eventId: "runtime-dispatch", workspaceRevision: 2, opId: "runtime-dispatch", actor: runtimeActor, source: "local", occurredAt: "2026-08-13T00:00:01.000Z", type: "runtime_dispatch_requested", payload: { dispatchId: "dispatch-runtime", runtimeSessionId: "session-runtime", instanceId: definition.instanceId, installationId: definition.installationId, kindId: definition.kindId, idempotencyKey: "runtime-witness", definitionSnapshotRef: "artifact:runtime-definition/test", definitionSnapshot: definition } }, { schema: "agent-runtime-event/v1", eventId: "runtime-session", workspaceRevision: 3, opId: "runtime-session", actor: runtimeActor, source: "local", occurredAt: "2026-08-13T00:00:02.000Z", type: "runtime_session_started", payload: { runtimeSessionId: "session-runtime", instanceId: definition.instanceId, installationId: definition.installationId, kindId: definition.kindId, definitionSnapshotRef: "artifact:runtime-definition/test", launchGeneration: 1, attachable: true } }] as const satisfies readonly AgentRuntimeEventV1[]; for (const event of events) store.append({ event, plan: runtimeWritePlan(event), blobs: [] });
@@ -739,26 +850,154 @@ function initRepo(rootDir: string): void {
   git(rootDir, "config", "user.email", "repo-cell@example.invalid");
   git(rootDir, "config", "gc.auto", "0");
   git(rootDir, "config", "maintenance.auto", "false");
-  writeFileSync(path.join(rootDir, "README.md"), "# Fixture\n"); git(rootDir, "add", "README.md"); git(rootDir, "commit", "--quiet", "-m", "fixture base");
+  writeFileSync(path.join(rootDir, "README.md"), "# Fixture\n");
+  git(rootDir, "add", "README.md");
+  git(rootDir, "commit", "--quiet", "-m", "fixture base");
 }
 function initDeterministicRepo(rootDir: string): void {
-  git(rootDir, "init", "--quiet"); git(rootDir, "config", "user.name", "RepoCell Test"); git(rootDir, "config", "user.email", "repo-cell@example.invalid"); git(rootDir, "config", "gc.auto", "0"); git(rootDir, "config", "maintenance.auto", "false");
-  execFileSync("git", ["-C", rootDir, "commit", "--allow-empty", "--quiet", "-m", "fixture base"], { env: { ...process.env, GIT_AUTHOR_DATE: "2026-08-14T00:00:00Z", GIT_COMMITTER_DATE: "2026-08-14T00:00:00Z" }, stdio: ["ignore", "pipe", "pipe"] });
+  git(rootDir, "init", "--quiet");
+  git(rootDir, "config", "user.name", "RepoCell Test");
+  git(rootDir, "config", "user.email", "repo-cell@example.invalid");
+  git(rootDir, "config", "gc.auto", "0");
+  git(rootDir, "config", "maintenance.auto", "false");
+  execFileSync("git", ["-C", rootDir, "commit", "--allow-empty", "--quiet", "-m", "fixture base"], {
+    env: { ...process.env, GIT_AUTHOR_DATE: "2026-08-14T00:00:00Z", GIT_COMMITTER_DATE: "2026-08-14T00:00:00Z" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
 }
-function decisionProposal(title: string, question: string) { return { kind: "decision-propose", jsonInput: JSON.stringify({ title, question, riskTier: "medium", urgency: "medium", vertical: "default", preset: "default", decisionClass: "ordinary", appliesTo: { modules: ["daemon"], productLines: [] }, chosen: [{ id: "CH1", text: "Use events" }], rejected: [{ id: "RJ1", text: "Use files", whyNot: "They are not canonical" }], claims: [], fulfillments: [], relations: [] }) } as const; }
-async function prepareReadyCompletion(cell: Awaited<ReturnType<typeof openRepoCell>>, rootDir: string, taskId: string, executionId: string, title: string): Promise<void> { const binding = { actor, source: "local" as const }; await cell.run({ kind: "task-create", taskId, title }, binding); await cell.run({ kind: "task-start", taskId, executionId }, binding); const packagePath = `tasks/${taskId}-${title.toLocaleLowerCase("en-US").replace(/[^a-z0-9]+/gu, "-").replace(/^-|-$/gu, "")}`, closeoutPath = `${packagePath}/closeout.md`; writeFileSync(path.join(rootDir, "harness", closeoutPath), "# Closeout\n\n## Summary\n\nDone.\n\n## Verification\n\nVerified.\n\n## Residual Risk\n\nNone.\n\n## Same Mechanism Elsewhere\n\nNot applicable to this fixture.\n"); assert.equal((await cell.run({ kind: "doc-submit", paths: [closeoutPath] }, binding)).outcome, "applied"); const commitSha = git(rootDir, "rev-parse", "HEAD"); writeFileSync(path.join(rootDir, "submission.json"), JSON.stringify({ completionClaim: "Ready.", deliverables: ["completion"], outputs: [closeoutPath], verificationNotes: ["verified"], knownGaps: [], residualRisks: [], commitSha })); await cell.run({ kind: "task-submit", taskId, executionId, fromFile: "submission.json" }, binding); writeFileSync(path.join(rootDir, "review.json"), JSON.stringify({ verdict: "approved", reason: "Approved.", evidenceChecked: ["verified"] })); await cell.run({ kind: "task-review-execution", taskId, executionId, reviewId: "review-ready", fromFile: "review.json" }, { actor: { principal: { personId: "person-reviewer" }, executor: { kind: "agent", id: "arbiter" } }, source: "local", roles: ["$arbiter"] }); await cell.run({ kind: "task-review-consent", taskId, executionId, reviewId: "review-ready", consentId: "consent-ready" }, binding); await cell.run({ kind: "task-complete", taskId, executionId, ci: "passed" }, binding); await cell.run({ kind: "task-code-doc-reconcile", taskId, executionId, commitSha, iteration: 0, paths: ["README.md"] }, binding); }
-function rbacRepo(rootDir: string, ids: Readonly<Record<string, number>>): void { mkdirSync(rootDir, { recursive: true }); initRepo(rootDir); mkdirSync(path.join(rootDir, "harness"));
-  writeFileSync(path.join(rootDir, "harness/harness.yaml"), "schema: harness-anything/v1\nname: rbac\nlayout:\n  authoredRoot: harness\n  localRoot: .harness\n");
-  const people = Object.entries(ids).map(([role, uid]) => ({ personId: role, displayName: role, roles: [role], credentials: [{ kind: "unix-socket-owner-boundary", issuer: `host:${hostname()}`, subject: String(uid) }] }));
-  const commands: Readonly<Record<string, readonly string[]>> = { reader: ["repo-read"], writer: ["repo-write"], arbiter: ["arbiter"], admin: ["admin"], dualAdmin: ["repo-write", "admin"], dualArbiter: ["repo-write", "arbiter"] }, roles = Object.keys(ids).map((roleId) => ({ roleId, commandClasses: commands[roleId] }));
-  writeFileSync(path.join(rootDir, "harness/people.yaml"), `${JSON.stringify({ schema: "harness-people/v1", people, roles }, null, 2)}\n`); git(rootDir, "add", "harness"); git(rootDir, "commit", "--quiet", "-m", "add RBAC fixture"); }
-async function rpc(host: Awaited<ReturnType<typeof openDaemonHost>>, auth: Parameters<Awaited<ReturnType<typeof openDaemonHost>>["run"]>[2], method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
-  const server = createJsonRpcProtocolServer({ host, build: { commit: null }, authContext: auth, emit: async () => undefined }); await server.handle({ jsonrpc: "2.0", id: 1, method: "protocol.hello", params: { protocolVersion: currentDaemonProtocolVersion } });
-  const response = await server.handle({ jsonrpc: "2.0", id: 2, method, params }); assert.ok(response && !Array.isArray(response) && "result" in response); return (response as { result: Record<string, unknown> }).result; }
+function decisionProposal(title: string, question: string) {
+  return {
+    kind: "decision-propose",
+    jsonInput: JSON.stringify({
+      title,
+      question,
+      riskTier: "medium",
+      urgency: "medium",
+      vertical: "default",
+      preset: "default",
+      decisionClass: "ordinary",
+      appliesTo: { modules: ["daemon"], productLines: [] },
+      chosen: [{ id: "CH1", text: "Use events" }],
+      rejected: [{ id: "RJ1", text: "Use files", whyNot: "They are not canonical" }],
+      claims: [],
+      fulfillments: [],
+      relations: [],
+    }),
+  } as const;
+}
+async function prepareReadyCompletion(
+  cell: Awaited<ReturnType<typeof openRepoCell>>,
+  rootDir: string,
+  taskId: string,
+  executionId: string,
+  title: string,
+): Promise<void> {
+  const binding = { actor, source: "local" as const };
+  await cell.run({ kind: "task-create", taskId, title }, binding);
+  await cell.run({ kind: "task-start", taskId, executionId }, binding);
+  const packagePath = `tasks/${taskId}-${title
+      .toLocaleLowerCase("en-US")
+      .replace(/[^a-z0-9]+/gu, "-")
+      .replace(/^-|-$/gu, "")}`,
+    closeoutPath = `${packagePath}/closeout.md`;
+  writeFileSync(
+    path.join(rootDir, "harness", closeoutPath),
+    "# Closeout\n\n## Summary\n\nDone.\n\n## Verification\n\nVerified.\n\n## Residual Risk\n\nNone.\n\n## Same Mechanism Elsewhere\n\nNot applicable to this fixture.\n",
+  );
+  assert.equal((await cell.run({ kind: "doc-submit", paths: [closeoutPath] }, binding)).outcome, "applied");
+  const commitSha = git(rootDir, "rev-parse", "HEAD");
+  writeFileSync(
+    path.join(rootDir, "submission.json"),
+    JSON.stringify({
+      completionClaim: "Ready.",
+      deliverables: ["completion"],
+      outputs: [closeoutPath],
+      verificationNotes: ["verified"],
+      knownGaps: [],
+      residualRisks: [],
+      commitSha,
+    }),
+  );
+  await cell.run({ kind: "task-submit", taskId, executionId, fromFile: "submission.json" }, binding);
+  writeFileSync(
+    path.join(rootDir, "review.json"),
+    JSON.stringify({ verdict: "approved", reason: "Approved.", evidenceChecked: ["verified"] }),
+  );
+  await cell.run(
+    { kind: "task-review-execution", taskId, executionId, reviewId: "review-ready", fromFile: "review.json" },
+    {
+      actor: { principal: { personId: "person-reviewer" }, executor: { kind: "agent", id: "arbiter" } },
+      source: "local",
+      roles: ["$arbiter"],
+    },
+  );
+  await cell.run(
+    { kind: "task-review-consent", taskId, executionId, reviewId: "review-ready", consentId: "consent-ready" },
+    binding,
+  );
+  await cell.run({ kind: "task-complete", taskId, executionId, ci: "passed" }, binding);
+  await cell.run(
+    { kind: "task-code-doc-reconcile", taskId, executionId, commitSha, iteration: 0, paths: ["README.md"] },
+    binding,
+  );
+}
+function rbacRepo(rootDir: string, ids: Readonly<Record<string, number>>): void {
+  mkdirSync(rootDir, { recursive: true });
+  initRepo(rootDir);
+  mkdirSync(path.join(rootDir, "harness"));
+  writeFileSync(
+    path.join(rootDir, "harness/harness.yaml"),
+    "schema: harness-anything/v1\nname: rbac\nlayout:\n  authoredRoot: harness\n  localRoot: .harness\n",
+  );
+  const people = Object.entries(ids).map(([role, uid]) => ({
+    personId: role,
+    displayName: role,
+    roles: [role],
+    credentials: [{ kind: "unix-socket-owner-boundary", issuer: `host:${hostname()}`, subject: String(uid) }],
+  }));
+  const commands: Readonly<Record<string, readonly string[]>> = {
+      reader: ["repo-read"],
+      writer: ["repo-write"],
+      arbiter: ["arbiter"],
+      admin: ["admin"],
+      dualAdmin: ["repo-write", "admin"],
+      dualArbiter: ["repo-write", "arbiter"],
+    },
+    roles = Object.keys(ids).map((roleId) => ({ roleId, commandClasses: commands[roleId] }));
+  writeFileSync(
+    path.join(rootDir, "harness/people.yaml"),
+    `${JSON.stringify({ schema: "harness-people/v1", people, roles }, null, 2)}\n`,
+  );
+  git(rootDir, "add", "harness");
+  git(rootDir, "commit", "--quiet", "-m", "add RBAC fixture");
+}
+async function rpc(
+  host: Awaited<ReturnType<typeof openDaemonHost>>,
+  auth: Parameters<Awaited<ReturnType<typeof openDaemonHost>>["run"]>[2],
+  method: string,
+  params: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const server = createJsonRpcProtocolServer({
+    host,
+    build: { commit: null },
+    authContext: auth,
+    emit: async () => undefined,
+  });
+  await server.handle({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "protocol.hello",
+    params: { protocolVersion: currentDaemonProtocolVersion },
+  });
+  const response = await server.handle({ jsonrpc: "2.0", id: 2, method, params });
+  assert.ok(response && !Array.isArray(response) && "result" in response);
+  return (response as { result: Record<string, unknown> }).result;
+}
 // The readiness projection reports an unavailable canonical Git cut with no basis commit. Before the
 // ledger owned its own repository the outer repository always had a HEAD, so that branch was
 // unreachable and the wire validator was free to demand a sha; once it became reachable the producer
 // was emitting a value its own validator rejected. This pins producer and validator to each other.
+// prettier-ignore
 test("decision readiness survives the wire when the canonical Git cut is unavailable", () => {
   const decision = { decisionId: "dec_1", proposedAt: "2026-01-01T00:00:00Z", appliesTo: { modules: ["packages/kernel"], productLines: [] } };
   const noCut = projectDecisionReadiness({ rootDir: "/nonexistent", commitSha: "", decisions: [decision] }, { run: () => ({ ok: false, stdout: "" }) });
@@ -774,6 +1013,7 @@ test("decision readiness survives the wire when the canonical Git cut is unavail
 // implementation while the wire shape still rejects it — the CLI and the RPC params are two
 // separate declarations of the same request. This walks the declared flags so the next one added
 // to init cannot repeat that.
+// prettier-ignore
 test("every declared ha init flag survives the daemon.repo.bootstrap wire params", () => {
   const command = daemonProtocolCommands.find((candidate) => candidate.id === "repo-bootstrap");
   assert.ok(command, "the init command must stay declared as repo-bootstrap");
@@ -784,16 +1024,63 @@ test("every declared ha init flag survives the daemon.repo.bootstrap wire params
     assert.equal(parsed.ok, true, `${input.name} reaches the daemon as params.${field}, which the wire shape rejects`);
   }
 });
-
 function decisionList(readiness: unknown): Record<string, unknown> {
-  return { ok: true, warnings: [], decisions: [{ schema: "decision-row/v1", decisionId: "dec_1", path: "harness/decisions/decision-dec_1/decision.md", state: "in_effect",
-    title: "t", question: "q", riskTier: "low", urgency: "low", vertical: "v", preset: "p", decisionClass: "c", proposedAt: "2026-01-01T00:00:00Z", decidedAt: null,
-    workspaceRevision: 1, appliesTo: {}, proposer: {}, arbiter: null, body: null, chosen: [], rejected: [], claims: [], provenance: [{ runtime: "unavailable", sessionId: null, transcriptReachability: "unavailable", boundAt: "2026-01-01T00:00:00Z" }], judgmentConsents: [], readiness }] };
+  return {
+    ok: true,
+    warnings: [],
+    decisions: [
+      {
+        schema: "decision-row/v1",
+        decisionId: "dec_1",
+        path: "harness/decisions/decision-dec_1/decision.md",
+        state: "in_effect",
+        title: "t",
+        question: "q",
+        riskTier: "low",
+        urgency: "low",
+        vertical: "v",
+        preset: "p",
+        decisionClass: "c",
+        proposedAt: "2026-01-01T00:00:00Z",
+        decidedAt: null,
+        workspaceRevision: 1,
+        appliesTo: {},
+        proposer: {},
+        arbiter: null,
+        body: null,
+        chosen: [],
+        rejected: [],
+        claims: [],
+        provenance: [
+          {
+            runtime: "unavailable",
+            sessionId: null,
+            transcriptReachability: "unavailable",
+            boundAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+        judgmentConsents: [],
+        readiness,
+      },
+    ],
+  };
 }
-
 
 function git(rootDir: string, ...args: readonly string[]): string {
   return execFileSync("git", ["-C", rootDir, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
 }
-function hasCode(expected: string): (error: unknown) => boolean { return (error) => typeof error === "object" && error !== null && "code" in error && error.code === expected; }
-function runtimeWritePlan(event: AgentRuntimeEventV1): FrozenWritePlan { return Object.freeze({ commandType: event.type, targets: Object.freeze([{ kind: "event_file", path: eventObjectTarget(event.opId), operation: "create" }, { kind: "event_head", path: "harness/events/head.json", operation: "replace" }, { kind: "projection_invalidation", projection: "agent-runtime/v1", key: event.opId }].map((target) => Object.freeze(target))) }) as FrozenWritePlan; }
+function hasCode(expected: string): (error: unknown) => boolean {
+  return (error) => typeof error === "object" && error !== null && "code" in error && error.code === expected;
+}
+function runtimeWritePlan(event: AgentRuntimeEventV1): FrozenWritePlan {
+  return Object.freeze({
+    commandType: event.type,
+    targets: Object.freeze(
+      [
+        { kind: "event_file", path: eventObjectTarget(event.opId), operation: "create" },
+        { kind: "event_head", path: "harness/events/head.json", operation: "replace" },
+        { kind: "projection_invalidation", projection: "agent-runtime/v1", key: event.opId },
+      ].map((target) => Object.freeze(target)),
+    ),
+  }) as FrozenWritePlan;
+}

--- a/packages/gui/src/renderer/api-client.ts
+++ b/packages/gui/src/renderer/api-client.ts
@@ -573,7 +573,7 @@ function readGuiActionResult(value: unknown): GuiActionResult {
     result.schema !== "command-receipt/v2" ||
     typeof result.ok !== "boolean" ||
     typeof result.command !== "string" ||
-    !["applied", "pending", "indeterminate", "op_rejected"].includes(String(result.outcome)) ||
+    !["applied", "pending", "no_changes", "indeterminate", "op_rejected"].includes(String(result.outcome)) ||
     typeof result.opId !== "string"
   ) {
     throw new Error(localErrorHint(value, "GUI action bridge returned an invalid receipt."));

--- a/packages/gui/src/renderer/runtime-control.ts
+++ b/packages/gui/src/renderer/runtime-control.ts
@@ -106,7 +106,7 @@ function receipt(value: unknown): RuntimeReceipt {
     !isRendererRecord(value) ||
     value.schema !== "command-receipt/v2" ||
     typeof value.opId !== "string" ||
-    !["applied", "pending", "indeterminate", "op_rejected"].includes(String(value.outcome))
+    !["applied", "pending", "no_changes", "indeterminate", "op_rejected"].includes(String(value.outcome))
   )
     throw new Error(rendererErrorHint(value, "Runtime spawn returned an invalid receipt."));
   return value as RuntimeReceipt;

--- a/packages/kernel/src/domain/receipt-domain-registry.ts
+++ b/packages/kernel/src/domain/receipt-domain-registry.ts
@@ -68,7 +68,7 @@ export interface DocSyncReceiptDetail {
 export const receiptDetailRegistry = Object.freeze([{ kind: "doc_sync", validate: validateDocSyncDetail }] as const);
 export type WriteReceiptDetail = DocSyncReceiptDetail;
 export interface WriteReceipt {
-  readonly outcome: "applied" | "pending" | "indeterminate" | "op_rejected";
+  readonly outcome: "applied" | "pending" | "no_changes" | "indeterminate" | "op_rejected";
   readonly opId: string;
   readonly revision?: number;
   readonly code?: string;
@@ -88,7 +88,7 @@ export interface WriteReceipt {
 }
 export const WRITE_RECEIPT_SCHEMA = Object.freeze({
   id: "write-receipt/v1",
-  outcomes: Object.freeze(["applied", "pending", "indeterminate", "op_rejected"] as const),
+  outcomes: Object.freeze(["applied", "pending", "no_changes", "indeterminate", "op_rejected"] as const),
   required: Object.freeze(["outcome", "opId"]),
   optional: Object.freeze([
     "revision",
@@ -163,7 +163,10 @@ export function validateWriteReceipt(value: unknown): readonly string[] {
     ("commitSha" in value && value.commitSha !== null && !("cut" in value))
   )
     errors.push("materialized commitSha and cut must be reported together");
-  if ((value.outcome === "applied" || value.outcome === "pending") && (visibility === undefined || !validProof))
+  if (
+    (value.outcome === "applied" || value.outcome === "pending" || value.outcome === "no_changes") &&
+    (visibility === undefined || !validProof)
+  )
     errors.push(`${String(value.outcome)} requires visibility and proof`);
   if (
     value.outcome === "applied" &&
@@ -178,8 +181,13 @@ export function validateWriteReceipt(value: unknown): readonly string[] {
     (proof.ackCut !== proof.appliedCut || proof.worktreeVisible !== true)
   )
     errors.push("replica applied requires worktree visibility and ackCut at the same cut");
-  if (value.outcome === "applied" && (!cut(value.revision) || !text(value.evidence)))
-    errors.push("applied requires revision and evidence");
+  if (
+    (value.outcome === "applied" || value.outcome === "no_changes") &&
+    (!cut(value.revision) || !text(value.evidence))
+  )
+    errors.push(`${String(value.outcome)} requires revision and evidence`);
+  if (value.outcome === "no_changes" && (value.code !== "no_changes" || !text(value.origin) || !text(value.nextAction)))
+    errors.push("no_changes requires code, origin, and nextAction");
   if (value.outcome === "pending" && (!cut(value.revision) || !text(value.evidence) || !text(value.nextAction)))
     errors.push("pending requires committed evidence, revision, and nextAction");
   if (value.outcome === "indeterminate" || value.outcome === "op_rejected")

--- a/packages/kernel/src/domain/status-vocabulary-catalog.ts
+++ b/packages/kernel/src/domain/status-vocabulary-catalog.ts
@@ -239,7 +239,7 @@ export const statusVocabularies: readonly StatusVocabulary[] = [
     words: ["running", "succeeded", "failed", "unknown", "cancelled"],
     mirrorOf: "runtime.outcome",
     plusWords: ["running"],
-    note: "TaskDispatchRow.status is the session outcome plus \"running\" while a dispatch is in flight.",
+    note: 'TaskDispatchRow.status is the session outcome plus "running" while a dispatch is in flight.',
   },
   {
     id: "runtime.transcript-reachability",
@@ -255,7 +255,7 @@ export const statusVocabularies: readonly StatusVocabulary[] = [
     field: "outcome",
     module: "packages/kernel/src/domain/write-chain.contract.ts",
     anchor: "writeReceiptOutcomes",
-    words: ["applied", "pending", "indeterminate", "op_rejected"],
+    words: ["applied", "pending", "no_changes", "indeterminate", "op_rejected"],
   },
   {
     id: "receipt.detail.outcome",
@@ -263,7 +263,7 @@ export const statusVocabularies: readonly StatusVocabulary[] = [
     field: "outcome",
     module: "packages/kernel/src/domain/receipt-domain-registry.ts",
     anchor: "#outcome",
-    words: ["applied", "pending", "indeterminate", "op_rejected"],
+    words: ["applied", "pending", "no_changes", "indeterminate", "op_rejected"],
     subsetOf: "receipt.outcome",
     note: "The WriteReceipt interface repeats the outcome vocabulary; must stay equal to writeReceiptOutcomes.",
   },
@@ -433,7 +433,7 @@ export const statusVocabularies: readonly StatusVocabulary[] = [
     field: "outcome",
     module: "packages/daemon/src/protocol/daemon-protocol-vocabulary.ts",
     anchor: "receiptOutcomeWords",
-    words: ["applied", "pending", "indeterminate", "op_rejected"],
+    words: ["applied", "pending", "no_changes", "indeterminate", "op_rejected"],
     mirrorOf: "receipt.outcome",
   },
 ];

--- a/packages/kernel/src/domain/status-word-register-runtime.ts
+++ b/packages/kernel/src/domain/status-word-register-runtime.ts
@@ -119,7 +119,7 @@ export const runtimeAndRecoveryStatusWords: readonly StatusWordRegistration[] = 
       "Collides with the same entity's transcript reachability word, which is " +
       "about reaching the transcript rather than about how the session ended. " +
       "Both stand for now; a rename would go to this semantic state word " +
-      "(candidate: \"ended-unobserved\").",
+      '(candidate: "ended-unobserved").',
   },
   {
     word: "unavailable",
@@ -142,6 +142,13 @@ export const runtimeAndRecoveryStatusWords: readonly StatusWordRegistration[] = 
     entity: "WriteReceipt",
     field: "outcome",
     meaning: "Write not yet settled at the canonical cut.",
+    divergence: "entity-scoped",
+  },
+  {
+    word: "no_changes",
+    entity: "WriteReceipt",
+    field: "outcome",
+    meaning: "The requested valid document selection is already clean; no write was needed.",
     divergence: "entity-scoped",
   },
   {

--- a/packages/kernel/src/domain/write-chain.contract.ts
+++ b/packages/kernel/src/domain/write-chain.contract.ts
@@ -38,7 +38,13 @@ export interface WriterGeneration {
   readonly ownerId: string;
 }
 
-export const writeReceiptOutcomes = Object.freeze(["applied", "pending", "indeterminate", "op_rejected"] as const);
+export const writeReceiptOutcomes = Object.freeze([
+  "applied",
+  "pending",
+  "no_changes",
+  "indeterminate",
+  "op_rejected",
+] as const);
 export type WriteReceiptOutcome = (typeof writeReceiptOutcomes)[number];
 
 export interface RecoveryBudget {

--- a/packages/kernel/src/store/local-version-control-system.ts
+++ b/packages/kernel/src/store/local-version-control-system.ts
@@ -317,6 +317,27 @@ export const localGitObjectRefStore = Object.freeze({
 });
 export const localGitWorktreeSettlement = Object.freeze({
   readNode,
+  changesFingerprint: (repoRoot: string, scope: string, ignored: ReadonlySet<string> = new Set()): string | null => {
+    const entries = runGit(repoRoot, "status", "--porcelain=v1", "--untracked-files=all", "-z", "--", scope)
+      .split("\0")
+      .filter(Boolean)
+      .map((entry) => {
+        const target = entry.slice(3);
+        if (ignored.has(target) || /(?:^|\/)\.ha-(?:visible|settle)-/u.test(target)) return null;
+        const absolute = path.join(repoRoot, ...target.split("/"));
+        try {
+          const stat = statSync(absolute);
+          return `${entry}:${stat.size}:${stat.mtimeMs}:${stat.mode}`;
+        } catch {
+          return `${entry}:missing`;
+        }
+      })
+      .filter((entry): entry is string => entry !== null)
+      .sort();
+    return entries.length === 0 ? null : entries.join("\0");
+  },
+  hasChanges: (repoRoot: string, scope: string, ignored: ReadonlySet<string> = new Set()): boolean =>
+    localGitWorktreeSettlement.changesFingerprint(repoRoot, scope, ignored) !== null,
   visible: (
     repoRoot: string,
     files: readonly {

--- a/packages/kernel/src/store/wal-shadow-event-store.ts
+++ b/packages/kernel/src/store/wal-shadow-event-store.ts
@@ -40,6 +40,8 @@ type StoreOptions = Parameters<typeof makeGitEventStore>[0] & {
   readonly walFlushMs?: number;
   readonly walRetryLimit?: number;
   readonly walRetryBaseMs?: number;
+  /** Runs after a WAL cut is durable and Git state has been reloaded. */
+  readonly afterFlush?: () => void;
 };
 
 export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventStore {
@@ -95,6 +97,15 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
     try {
       flushWalToGit(wal, git, options);
       reloadGit();
+      // Authored settlement observes the durable cut. It is intentionally outside the
+      // materialization transaction: an ineligible edit must remain visible for doc status,
+      // but can never make an already durable WAL cut fail.
+      try {
+        options.afterFlush?.();
+      } catch (error) {
+        console.warn(`[wal-materializer] authored settlement failed: ${walShadowErrorMessage(error)}`);
+        consumeKnownError(error);
+      }
       console.info(
         `[wal-materializer] materialized revisions ${first}-${last} (${context}, attempt ${consecutiveFailures + 1})`,
       );

--- a/packages/kernel/src/store/wal-shadow-event-store.ts
+++ b/packages/kernel/src/store/wal-shadow-event-store.ts
@@ -313,7 +313,7 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
     clearSchedule();
     consecutiveFailures = 0;
     for (let attempt = 1; hasWalRecords() && attempt <= retryLimit; attempt += 1) {
-      if (runFlush("drain")) break;
+      if (runFlush("drain") && !hasWalRecords()) break;
       if (attempt < retryLimit) await wait(retryBaseMs * 2 ** (attempt - 1));
     }
     if (hasWalRecords())

--- a/packages/kernel/src/store/wal-shadow-event-store.ts
+++ b/packages/kernel/src/store/wal-shadow-event-store.ts
@@ -68,6 +68,7 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
   let immediate: ReturnType<typeof setImmediate> | null = null;
   let consecutiveFailures = 0;
   let lastFlushError: string | null = null;
+  let lastSettlementFingerprint: string | null = null;
   let closed = false;
 
   const reloadGit = (): void => {
@@ -100,12 +101,14 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
       // Authored settlement observes the durable cut. It is intentionally outside the
       // materialization transaction: an ineligible edit must remain visible for doc status,
       // but can never make an already durable WAL cut fail.
-      try {
-        options.afterFlush?.();
-      } catch (error) {
-        console.warn(`[wal-materializer] authored settlement failed: ${walShadowErrorMessage(error)}`);
-        consumeKnownError(error);
-      }
+      notifyAfterFlush(
+        new Set(
+          pendingRecords.flatMap((record) => [
+            ...canonicalDocumentClaims(record.event).map((claim) => ledgerGitPath(ledger, claim.path)),
+            ...canonicalDocumentRetirements(record.event).map((retirement) => ledgerGitPath(ledger, retirement.path)),
+          ]),
+        ),
+      );
       console.info(
         `[wal-materializer] materialized revisions ${first}-${last} (${context}, attempt ${consecutiveFailures + 1})`,
       );
@@ -128,6 +131,22 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
       );
       consumeKnownError(error);
       return false;
+    }
+  };
+  const notifyAfterFlush = (ignored: ReadonlySet<string> = new Set()): void => {
+    const fingerprint = localGitWorktreeSettlement.changesFingerprint(
+      ledger.rootDir,
+      ledger.authoredPrefix || ".",
+      ignored,
+    );
+    if (fingerprint === lastSettlementFingerprint) return;
+    lastSettlementFingerprint = fingerprint;
+    if (fingerprint === null) return;
+    try {
+      options.afterFlush?.();
+    } catch (error) {
+      console.warn(`[wal-materializer] authored settlement failed: ${walShadowErrorMessage(error)}`);
+      consumeKnownError(error);
     }
   };
   const scheduleRetry = (): void => {
@@ -301,12 +320,33 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
         errorCode: "publication_indeterminate",
       };
     }
-    if (recovered.status !== "none" || !hadWalRecords) return recovered;
-    return {
+    if (recovered.status !== "none" || !hadWalRecords) {
+      if (recovered.status === "committed" || recovered.status === "already_committed")
+        notifyAfterFlush(
+          new Set(
+            records.flatMap((record) => [
+              ...canonicalDocumentClaims(record.event).map((claim) => ledgerGitPath(ledger, claim.path)),
+              ...canonicalDocumentRetirements(record.event).map((retirement) => ledgerGitPath(ledger, retirement.path)),
+            ]),
+          ),
+        );
+      return recovered;
+    }
+    const result = {
       status: hadPendingPublication ? "committed" : "already_committed",
       publications: hadPendingPublication ? 1 : 0,
       elapsedMs: performance.now() - started,
-    };
+    } as const;
+    if (result.status === "committed" || result.status === "already_committed")
+      notifyAfterFlush(
+        new Set(
+          records.flatMap((record) => [
+            ...canonicalDocumentClaims(record.event).map((claim) => ledgerGitPath(ledger, claim.path)),
+            ...canonicalDocumentRetirements(record.event).map((retirement) => ledgerGitPath(ledger, retirement.path)),
+          ]),
+        ),
+      );
+    return result;
   };
   const drain = async (): Promise<void> => {
     closed = true;

--- a/tools/gates/test/write-chain-contract.test.mjs
+++ b/tools/gates/test/write-chain-contract.test.mjs
@@ -11,9 +11,13 @@ import {
   serializeEventEnvelope,
   serializeEventHead,
   validateNormalizedCommandEnvelope,
-  WriteChainContractError
+  WriteChainContractError,
 } from "../../../packages/kernel/src/domain/write-chain.contract.ts";
-import { emptyTaskLifecycleSnapshot, normalizeTaskLifecycleCommand, serializeTaskEvent } from "../../../packages/kernel/src/domain/task-lifecycle.contract.ts";
+import {
+  emptyTaskLifecycleSnapshot,
+  normalizeTaskLifecycleCommand,
+  serializeTaskEvent,
+} from "../../../packages/kernel/src/domain/task-lifecycle.contract.ts";
 import { decideTaskLifecycleWrite } from "../../../packages/kernel/src/domain/task-write-decision.ts";
 import { REPLAY_TASK_GRAPH } from "../../../packages/kernel/src/domain/task-graph.ts";
 
@@ -25,67 +29,111 @@ test("G02 derives a stable opId and digest from one normalized command envelope"
     actor,
     source: "local",
     expectedRevision: 0,
-    command: { type: "CreateReplayTask", taskId: "task-1", title: "Replay task" }
+    command: { type: "CreateReplayTask", taskId: "task-1", title: "Replay task" },
   };
   const first = normalizeCommandEnvelope(input);
   const reordered = normalizeCommandEnvelope({
     ...input,
-    command: { title: "Replay task", taskId: "task-1", type: "CreateReplayTask" }
+    command: { title: "Replay task", taskId: "task-1", type: "CreateReplayTask" },
   });
 
   assert.equal(first.opId, reordered.opId);
   assert.equal(first.commandDigest, reordered.commandDigest);
   assert.match(first.opId, /^op_[0-9a-f]{64}$/u);
   assert.match(first.commandDigest, /^sha256:[0-9a-f]{64}$/u);
-  assert.deepEqual({ source: first.source, expectedRevision: first.expectedRevision }, { source: "local", expectedRevision: 0 });
+  assert.deepEqual(
+    { source: first.source, expectedRevision: first.expectedRevision },
+    { source: "local", expectedRevision: 0 },
+  );
   assert.notEqual(first.commandDigest, normalizeCommandEnvelope({ ...input, source: "remote_direct" }).commandDigest);
   const revisionInput = { ...input, command: { type: "SubmitExecution", taskId: "task-1" } };
-  assert.notEqual(normalizeCommandEnvelope(revisionInput).commandDigest,
-    normalizeCommandEnvelope({ ...revisionInput, expectedRevision: 1 }).commandDigest);
+  assert.notEqual(
+    normalizeCommandEnvelope(revisionInput).commandDigest,
+    normalizeCommandEnvelope({ ...revisionInput, expectedRevision: 1 }).commandDigest,
+  );
   assert.equal(Object.isFrozen(first), true);
-  assert.match(validateNormalizedCommandEnvelope(first, {
-    ...input, command: { ...input.command, title: "different" }
-  }).join("\n"), /digest/u);
+  assert.match(
+    validateNormalizedCommandEnvelope(first, {
+      ...input,
+      command: { ...input.command, title: "different" },
+    }).join("\n"),
+    /digest/u,
+  );
 });
 
 test("G03 rejects an unsafe target before freezing the write plan", () => {
-  assert.throws(() => freezeDeclaredWritePlan({
-    commandType: "CreateReplayTask",
-    targets: [
-      { kind: "event_file", path: "../events/op-1.json", operation: "create" },
-      { kind: "event_head", path: "harness/events/head.json", operation: "replace" },
-      { kind: "projection_invalidation", projection: "task-lifecycle/v1", key: "task-1" }
-    ]
-  }, ["CreateReplayTask"]), (error) => error instanceof WriteChainContractError && error.code === "invalid_write_plan");
+  assert.throws(
+    () =>
+      freezeDeclaredWritePlan(
+        {
+          commandType: "CreateReplayTask",
+          targets: [
+            { kind: "event_file", path: "../events/op-1.json", operation: "create" },
+            { kind: "event_head", path: "harness/events/head.json", operation: "replace" },
+            { kind: "projection_invalidation", projection: "task-lifecycle/v1", key: "task-1" },
+          ],
+        },
+        ["CreateReplayTask"],
+      ),
+    (error) => error instanceof WriteChainContractError && error.code === "invalid_write_plan",
+  );
 });
 
 test("G03 derives exact local WAL declarations from canonical targets", () => {
-  const plan = freezeDeclaredWritePlan({
-    commandType: "CreateReplayTask",
-    targets: [
-      { kind: "event_file", path: "harness/events/op-1.json", operation: "create" },
-      { kind: "event_head", path: "harness/events/head.json", operation: "replace" },
-      { kind: "projection_invalidation", projection: "task-lifecycle/v1", key: "task-1" },
-      { kind: "content_blob", sha256: "a".repeat(64), size: 4, mediaType: "text/plain" }
-    ]
-  }, ["CreateReplayTask"]);
-  assert.deepEqual(plan.targets.filter((target) => target.kind === "local_wal_file"), [
-    { kind: "local_wal_file", path: ".harness/wal/seg-000000.log", operation: "append" },
-    { kind: "local_wal_file", path: ".harness/wal/head.json", operation: "replace" },
-    { kind: "local_wal_file", path: `.harness/wal/objects/${"a".repeat(64)}`, operation: "replace" }
-  ]);
-  assert.throws(() => freezeDeclaredWritePlan({
-    commandType: "CreateReplayTask",
-    targets: [...plan.targets, { kind: "local_wal_file", path: `.harness/wal/objects/${"b".repeat(64)}`, operation: "replace" }]
-  }, ["CreateReplayTask"]), /local WAL targets must exactly derive/u);
+  const plan = freezeDeclaredWritePlan(
+    {
+      commandType: "CreateReplayTask",
+      targets: [
+        { kind: "event_file", path: "harness/events/op-1.json", operation: "create" },
+        { kind: "event_head", path: "harness/events/head.json", operation: "replace" },
+        { kind: "projection_invalidation", projection: "task-lifecycle/v1", key: "task-1" },
+        { kind: "content_blob", sha256: "a".repeat(64), size: 4, mediaType: "text/plain" },
+      ],
+    },
+    ["CreateReplayTask"],
+  );
+  assert.deepEqual(
+    plan.targets.filter((target) => target.kind === "local_wal_file"),
+    [
+      { kind: "local_wal_file", path: ".harness/wal/seg-000000.log", operation: "append" },
+      { kind: "local_wal_file", path: ".harness/wal/head.json", operation: "replace" },
+      { kind: "local_wal_file", path: `.harness/wal/objects/${"a".repeat(64)}`, operation: "replace" },
+    ],
+  );
+  assert.throws(
+    () =>
+      freezeDeclaredWritePlan(
+        {
+          commandType: "CreateReplayTask",
+          targets: [
+            ...plan.targets,
+            { kind: "local_wal_file", path: `.harness/wal/objects/${"b".repeat(64)}`, operation: "replace" },
+          ],
+        },
+        ["CreateReplayTask"],
+      ),
+    /local WAL targets must exactly derive/u,
+  );
 });
 
 test("G02 rejects invalid or payload-reported command sources", () => {
   const binding = { workspaceId: "workspace-1", actor, expectedRevision: 0 };
-  assert.throws(() => normalizeCommandEnvelope({ ...binding, source: "peer_env", command: { type: "CreateReplayTask" } }), WriteChainContractError);
-  assert.throws(() => normalizeCommandEnvelope({ ...binding, source: "local", command: {
-    type: "CreateReplayTask", source: "remote_direct"
-  } }), WriteChainContractError);
+  assert.throws(
+    () => normalizeCommandEnvelope({ ...binding, source: "peer_env", command: { type: "CreateReplayTask" } }),
+    WriteChainContractError,
+  );
+  assert.throws(
+    () =>
+      normalizeCommandEnvelope({
+        ...binding,
+        source: "local",
+        command: {
+          type: "CreateReplayTask",
+          source: "remote_direct",
+        },
+      }),
+    WriteChainContractError,
+  );
 });
 
 test("G02 freezes deterministic event bytes and a committed head shape", () => {
@@ -99,45 +147,96 @@ test("G02 freezes deterministic event bytes and a committed head shape", () => {
     actor,
     source: "local",
     occurredAt: "2026-08-11T00:00:00.000Z",
-    payload: { task: { title: "Replay task", taskId: "task-1" } }
+    payload: { task: { title: "Replay task", taskId: "task-1" } },
   };
   const bytes = serializeEventEnvelope(event);
-  const reorderedBytes = serializeEventEnvelope({ payload: event.payload, occurredAt: event.occurredAt,
-    actor, source: event.source, type: event.type, taskId: event.taskId, opId: event.opId, workspaceRevision: 1,
-    eventId: event.eventId, schema: event.schema });
+  const reorderedBytes = serializeEventEnvelope({
+    payload: event.payload,
+    occurredAt: event.occurredAt,
+    actor,
+    source: event.source,
+    type: event.type,
+    taskId: event.taskId,
+    opId: event.opId,
+    workspaceRevision: 1,
+    eventId: event.eventId,
+    schema: event.schema,
+  });
   assert.equal(bytes, reorderedBytes);
   assert.match(bytes, /"source":"local"/u);
   assert.throws(() => serializeEventEnvelope({ ...event, source: "peer_env" }), WriteChainContractError);
-  assert.throws(() => serializeEventEnvelope({ ...event, actor: {
-    principal: { kind: "agent", personId: "person-owner" }, executor: null
-  } }), WriteChainContractError);
-  assert.equal(serializeEventHead({ revision: 1, opId: "op_1", eventDigest: "sha256:" + "a".repeat(64) }),
-    '{"eventDigest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","opId":"op_1","revision":1}\n');
+  assert.throws(
+    () =>
+      serializeEventEnvelope({
+        ...event,
+        actor: {
+          principal: { kind: "agent", personId: "person-owner" },
+          executor: null,
+        },
+      }),
+    WriteChainContractError,
+  );
+  assert.equal(
+    serializeEventHead({ revision: 1, opId: "op_1", eventDigest: "sha256:" + "a".repeat(64) }),
+    '{"eventDigest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","opId":"op_1","revision":1}\n',
+  );
 });
 
 test("G02/G07 expose one four-state receipt and bounded recovery contract", async () => {
   const contract = await import("../../../packages/kernel/src/domain/write-chain.contract.ts");
-  assert.deepEqual(contract.writeReceiptOutcomes, ["applied", "pending", "indeterminate", "op_rejected"]);
+  assert.deepEqual(contract.writeReceiptOutcomes, ["applied", "pending", "no_changes", "indeterminate", "op_rejected"]);
   assert.deepEqual(contract.RECOVERY_BUDGET, { deadline: 100, maxItems: 64, retry: 1 });
   assert.equal(Object.isFrozen(contract.RECOVERY_BUDGET), true);
   const recovery = nextRecoveryBatch(Array.from({ length: 10_000 }, (_, index) => index));
   assert.equal(recovery.items.length, 64);
-  assert.deepEqual(recovery.items, Array.from({ length: 64 }, (_, index) => index));
-  assert.deepEqual({ deferred: recovery.deferred, nextCursor: recovery.nextCursor }, { deferred: 9_936, nextCursor: 64 });
-  assert.deepEqual(createWriteReceipt({
-    outcome: "applied", opId: "op_1", revision: 1, evidence: "event:op_1", visibility: "center",
-    proof: { committedRevision: 1, appliedCut: 1, durable: true, canonicalVisible: true, worktreeVisible: null }
-  }), { outcome: "applied", opId: "op_1", revision: 1, evidence: "event:op_1", visibility: "center",
-    proof: { committedRevision: 1, appliedCut: 1, durable: true, canonicalVisible: true, worktreeVisible: null } });
-  assert.throws(() => createWriteReceipt({
-    outcome: "applied", opId: "op_1", revision: 1, evidence: "event:op_1", visibility: "center",
-    proof: { committedRevision: 1, appliedCut: 1, durable: true, canonicalVisible: true, worktreeVisible: null }, leaseCredential: "removed"
-  }), WriteChainContractError);
+  assert.deepEqual(
+    recovery.items,
+    Array.from({ length: 64 }, (_, index) => index),
+  );
+  assert.deepEqual(
+    { deferred: recovery.deferred, nextCursor: recovery.nextCursor },
+    { deferred: 9_936, nextCursor: 64 },
+  );
+  assert.deepEqual(
+    createWriteReceipt({
+      outcome: "applied",
+      opId: "op_1",
+      revision: 1,
+      evidence: "event:op_1",
+      visibility: "center",
+      proof: { committedRevision: 1, appliedCut: 1, durable: true, canonicalVisible: true, worktreeVisible: null },
+    }),
+    {
+      outcome: "applied",
+      opId: "op_1",
+      revision: 1,
+      evidence: "event:op_1",
+      visibility: "center",
+      proof: { committedRevision: 1, appliedCut: 1, durable: true, canonicalVisible: true, worktreeVisible: null },
+    },
+  );
+  assert.throws(
+    () =>
+      createWriteReceipt({
+        outcome: "applied",
+        opId: "op_1",
+        revision: 1,
+        evidence: "event:op_1",
+        visibility: "center",
+        proof: { committedRevision: 1, appliedCut: 1, durable: true, canonicalVisible: true, worktreeVisible: null },
+        leaseCredential: "removed",
+      }),
+    WriteChainContractError,
+  );
 });
 
 test("G08 recovery cursor is monotonic, visits once, reports exhausted budgets, drains, and escalates exhausted retry", () => {
   const budget = { deadline: 100, maxItems: 2, retry: 1 };
-  for (const invalid of [{ ...budget, deadline: -1 }, { ...budget, maxItems: -1 }, { ...budget, retry: -1 }]) {
+  for (const invalid of [
+    { ...budget, deadline: -1 },
+    { ...budget, maxItems: -1 },
+    { ...budget, retry: -1 },
+  ]) {
     assert.throws(() => nextRecoveryBatch([0, 1], 0, invalid), WriteChainContractError);
   }
   const first = nextRecoveryBatch([0, 1, 2, 3, 4], 0, budget);
@@ -146,22 +245,50 @@ test("G08 recovery cursor is monotonic, visits once, reports exhausted budgets, 
   assert.deepEqual([first.nextCursor, second.nextCursor, third.nextCursor], [2, 4, 5]);
   assert.deepEqual([...first.items, ...second.items, ...third.items], [0, 1, 2, 3, 4]);
   assert.deepEqual([first.deferred, first.state, third.deferred, third.state], [3, "exhausted", 0, "drained"]);
-  assert.deepEqual(nextRecoveryBatch([0, 1], 0, budget, { elapsed: 100, attempt: 0 }),
-    { items: [], deferred: 2, nextCursor: 0, state: "exhausted" });
-  assert.deepEqual(nextRecoveryBatch([0, 1], 0, budget, { elapsed: 0, attempt: 2 }),
-    { items: [], deferred: 2, nextCursor: 0, state: "failed" });
+  assert.deepEqual(nextRecoveryBatch([0, 1], 0, budget, { elapsed: 100, attempt: 0 }), {
+    items: [],
+    deferred: 2,
+    nextCursor: 0,
+    state: "exhausted",
+  });
+  assert.deepEqual(nextRecoveryBatch([0, 1], 0, budget, { elapsed: 0, attempt: 2 }), {
+    items: [],
+    deferred: 2,
+    nextCursor: 0,
+    state: "failed",
+  });
 });
 
 test("G02/G03 task decision rejects stale writers, conflicting opIds, and unsafe targets before publication", () => {
   const activeWriter = { workspaceId: "workspace-1", generation: 2, ownerId: "daemon-a" };
   const writerToken = issueWriterGenerationToken(activeWriter);
-  const command = { ...normalizeTaskLifecycleCommand({ workspaceId: "workspace-1", actor, source: "local", expectedRevision: 0 }, {
-    type: "CreateReplayTask", taskId: "task-1", title: "Replay task", taskClass: "standard", graph: REPLAY_TASK_GRAPH, completionGateIds: [], presetSnapshotDigest: null
-  }), eventId: "event-1", workspaceRevision: 1, occurredAt: "2026-08-11T00:00:00.000Z" };
+  const command = {
+    ...normalizeTaskLifecycleCommand(
+      { workspaceId: "workspace-1", actor, source: "local", expectedRevision: 0 },
+      {
+        type: "CreateReplayTask",
+        taskId: "task-1",
+        title: "Replay task",
+        taskClass: "standard",
+        graph: REPLAY_TASK_GRAPH,
+        completionGateIds: [],
+        presetSnapshotDigest: null,
+      },
+    ),
+    eventId: "event-1",
+    workspaceRevision: 1,
+    occurredAt: "2026-08-11T00:00:00.000Z",
+  };
   const proof = { taskIdUnique: true, actorBinding: actor };
-  const decide = (overrides = {}) => decideTaskLifecycleWrite({
-    snapshot: emptyTaskLifecycleSnapshot(), command, proof, activeWriter, writerToken, ...overrides
-  });
+  const decide = (overrides = {}) =>
+    decideTaskLifecycleWrite({
+      snapshot: emptyTaskLifecycleSnapshot(),
+      command,
+      proof,
+      activeWriter,
+      writerToken,
+      ...overrides,
+    });
 
   const legal = decide();
   assert.equal(legal.accepted, true);
@@ -169,37 +296,97 @@ test("G02/G03 task decision rejects stale writers, conflicting opIds, and unsafe
   assert.equal(legal.accepted && serializeTaskEvent(legal.event), legal.accepted && serializeTaskEvent(decide().event));
 
   const stale = decide({ writerToken: issueWriterGenerationToken({ ...activeWriter, generation: 1 }) });
-  assert.deepEqual([stale.accepted, stale.receipt.outcome, stale.receipt.code], [false, "op_rejected", "writer_rejected"]);
+  assert.deepEqual(
+    [stale.accepted, stale.receipt.outcome, stale.receipt.code],
+    [false, "op_rejected", "writer_rejected"],
+  );
 
-  const conflict = decide({ existingOperation: { opId: command.opId, commandDigest: `sha256:${"0".repeat(64)}`,
-    event: legal.event, receipt: legal.receipt } });
-  assert.deepEqual([conflict.accepted, conflict.receipt.outcome, conflict.receipt.code], [false, "op_rejected", "operation_conflict"]);
+  const conflict = decide({
+    existingOperation: {
+      opId: command.opId,
+      commandDigest: `sha256:${"0".repeat(64)}`,
+      event: legal.event,
+      receipt: legal.receipt,
+    },
+  });
+  assert.deepEqual(
+    [conflict.accepted, conflict.receipt.outcome, conflict.receipt.code],
+    [false, "op_rejected", "operation_conflict"],
+  );
 
-  const sourceDrift = decide({ command: { ...command, source: "remote_direct" }, existingOperation: {
-    opId: command.opId, commandDigest: command.commandDigest, event: legal.event, receipt: legal.receipt } });
-  assert.deepEqual([sourceDrift.accepted, sourceDrift.receipt.outcome, sourceDrift.receipt.code], [false, "op_rejected", "invalid_schema"]);
+  const sourceDrift = decide({
+    command: { ...command, source: "remote_direct" },
+    existingOperation: {
+      opId: command.opId,
+      commandDigest: command.commandDigest,
+      event: legal.event,
+      receipt: legal.receipt,
+    },
+  });
+  assert.deepEqual(
+    [sourceDrift.accepted, sourceDrift.receipt.outcome, sourceDrift.receipt.code],
+    [false, "op_rejected", "invalid_schema"],
+  );
 
-  const unsafe = { ...normalizeTaskLifecycleCommand({ workspaceId: "workspace-1", actor, source: "local", expectedRevision: 0 }, {
-    type: "CreateReplayTask", taskId: "../escape", title: "Unsafe", taskClass: "standard", graph: REPLAY_TASK_GRAPH, completionGateIds: [], presetSnapshotDigest: null
-  }), eventId: "event-unsafe", workspaceRevision: 1, occurredAt: "2026-08-11T00:00:00.000Z" };
+  const unsafe = {
+    ...normalizeTaskLifecycleCommand(
+      { workspaceId: "workspace-1", actor, source: "local", expectedRevision: 0 },
+      {
+        type: "CreateReplayTask",
+        taskId: "../escape",
+        title: "Unsafe",
+        taskClass: "standard",
+        graph: REPLAY_TASK_GRAPH,
+        completionGateIds: [],
+        presetSnapshotDigest: null,
+      },
+    ),
+    eventId: "event-unsafe",
+    workspaceRevision: 1,
+    occurredAt: "2026-08-11T00:00:00.000Z",
+  };
   const invalidTarget = decide({ command: unsafe });
-  assert.deepEqual([invalidTarget.accepted, invalidTarget.receipt.outcome, invalidTarget.receipt.code], [false, "op_rejected", "invalid_write_plan"]);
+  assert.deepEqual(
+    [invalidTarget.accepted, invalidTarget.receipt.outcome, invalidTarget.receipt.code],
+    [false, "op_rejected", "invalid_write_plan"],
+  );
 });
 
 test("G03 returns an immutable event with stable canonical bytes", () => {
   const activeWriter = { workspaceId: "workspace-1", generation: 2, ownerId: "daemon-a" };
-  const command = { ...normalizeTaskLifecycleCommand({ workspaceId: "workspace-1", actor, source: "local", expectedRevision: 0 }, {
-    type: "CreateReplayTask", taskId: "task-1", title: "Replay task", taskClass: "standard", graph: REPLAY_TASK_GRAPH, completionGateIds: [], presetSnapshotDigest: null
-  }), eventId: "event-1", workspaceRevision: 1, occurredAt: "2026-08-11T00:00:00.000Z" };
-  const decision = decideTaskLifecycleWrite({ snapshot: emptyTaskLifecycleSnapshot(), command,
-    proof: { taskIdUnique: true, actorBinding: actor }, activeWriter, writerToken: issueWriterGenerationToken(activeWriter) });
+  const command = {
+    ...normalizeTaskLifecycleCommand(
+      { workspaceId: "workspace-1", actor, source: "local", expectedRevision: 0 },
+      {
+        type: "CreateReplayTask",
+        taskId: "task-1",
+        title: "Replay task",
+        taskClass: "standard",
+        graph: REPLAY_TASK_GRAPH,
+        completionGateIds: [],
+        presetSnapshotDigest: null,
+      },
+    ),
+    eventId: "event-1",
+    workspaceRevision: 1,
+    occurredAt: "2026-08-11T00:00:00.000Z",
+  };
+  const decision = decideTaskLifecycleWrite({
+    snapshot: emptyTaskLifecycleSnapshot(),
+    command,
+    proof: { taskIdUnique: true, actorBinding: actor },
+    activeWriter,
+    writerToken: issueWriterGenerationToken(activeWriter),
+  });
   assert.equal(decision.accepted, true);
   if (!decision.accepted) return;
   const before = serializeTaskEvent(decision.event);
   assert.equal(Object.isFrozen(decision.event), true);
   assert.equal(Object.isFrozen(decision.event.payload), true);
   assert.equal(Object.isFrozen(decision.event.payload.task), true);
-  assert.throws(() => { decision.event.payload.task.title = "mutated"; }, TypeError);
+  assert.throws(() => {
+    decision.event.payload.task.title = "mutated";
+  }, TypeError);
   assert.equal(serializeTaskEvent(decision.event), before);
 });
 
@@ -210,11 +397,11 @@ test("G03 rejects a second writer and a token from an old generation", () => {
 
   for (const token of [
     issueWriterGenerationToken({ ...active, generation: 1 }),
-    issueWriterGenerationToken({ ...active, ownerId: "daemon-b" })
+    issueWriterGenerationToken({ ...active, ownerId: "daemon-b" }),
   ]) {
     assert.throws(
       () => assertCurrentWriter(active, token, "workspace-1"),
-      (error) => error instanceof WriteChainContractError && error.code === "writer_rejected"
+      (error) => error instanceof WriteChainContractError && error.code === "writer_rejected",
     );
   }
 });


### PR DESCRIPTION
# English

## Summary

Authored harness documents (task plans, reports) were only committed by lifecycle transitions, so the private ledger accumulated 100+ uncommitted files between transitions. This PR makes the WAL materializer flush also settle the authored eligible doc-sync candidates, and fixes drain() so that records appended by the settlement callback are drained in the same pass instead of being left for the next flush.

## What Changed

- `packages/daemon/src/doc-sync-settlement.ts`, `packages/daemon/src/repo-cell.ts`: WAL flush sweeps authored eligible candidates through the existing doc-sync settlement (no watcher, no new write path).
- `packages/kernel/src/store/wal-shadow-event-store.ts`: drain() re-checks for records appended during settlement.
- `packages/daemon/test/authored-wal-doc-sync.integration.test.ts`: settlement after flush, forbidden/unresolved candidates do not fail the batch, callback-appended records drained.

## Machine-Readable Declarations

Production-Delta: +199/-40

## Task And Scope

- Harness task: task_963656e5641ba6ef8033b3e665 (PLT-Ontology Phase 0.12)
- Branch: `codex/authored-continuous-commit`
- Public scope: daemon WAL flush settlement + kernel WAL drain + one integration test file
- Private planning/evidence updated: yes (artifacts/reports/dispatch_20260825_wal_flush_continued.md)
- Out of scope: task-id scoped doc sync (0.15, #1799)

## Version Impact

- Version: no version change because this is a pre-release fix on the rebuild line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 0e365f163024cdba439cb24bcfa12e9abfc773cf
- Branch merge-base with `origin/main`: 0e365f163024cdba439cb24bcfa12e9abfc773cf
- Last `git fetch origin` time: 2026-08-24T18:21Z
- Sync method: rebase
- Public diff command: `git diff 0e365f163024cdba439cb24bcfa12e9abfc773cf..220ea43cc21986b33dc93fc13a8a1050a95a2126`
- Private evidence commit/path: harness task package task_963656e5641ba6ef8033b3e665 artifacts/reports
- Reviewer evidence path: worker report with isolated integration output 4/4 pass; reviewer verified numstat +69/-5 exactly matches the declaration
- GitHub Actions `rewrite-ci` run URL: pending (filled after the run)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test` (isolated integration 4/4 via tools/dispatch-isolated-test.mjs)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full `npm run check:local` fast tier in the worker environment (host Node 22, tier requires ≥24); GitHub CI is the authority for this PR.

## Review Evidence

- Self-review: CEO ruled to reuse the materializer flush instead of a watcher (watcher deleted in b96bb6e08); the drain fix is a correctness fix for an early-exit loop, not a retry layer.
- Reviewer subagent: yes (read-only report audit with independent git verification)
- Human review: pending
- Blocking findings: none

## Residual Risk

- Flush now performs doc-sync settlement work; if a candidate set is large the flush takes longer, bounded by the same settlement cost paid today at transitions.

## References

- Task: task_963656e5641ba6ef8033b3e665
- Evidence: artifacts/reports/dispatch_20260825_wal_flush_continued.md
- Review: pending

---

# 中文

## 概要

harness 台账里的 authored 文档(task plan、回执)只在生命周期转换时被提交,转换之间会堆积 100+ 未提交文件。本 PR 让 WAL materializer 的 flush 顺带结算 authored eligible doc-sync 候选,并修 drain():结算回调期间追加的记录在同一趟被 drain,而不是留到下次 flush。

## 改动内容

- `packages/daemon/src/doc-sync-settlement.ts`、`packages/daemon/src/repo-cell.ts`:WAL flush 通过既有 doc-sync settlement 扫 authored eligible 候选(无 watcher、无新写路径)。
- `packages/kernel/src/store/wal-shadow-event-store.ts`:drain() 重查结算期间追加的记录。
- `packages/daemon/test/authored-wal-doc-sync.integration.test.ts`:flush 后结算、forbidden/unresolved 候选不拖垮整批、回调追加记录被 drain。

## 机读声明说明

- 机读声明只在英文块出现一次。

## 任务与范围

- Harness 任务:task_963656e5641ba6ef8033b3e665(PLT-Ontology Phase 0.12)
- 分支:`codex/authored-continuous-commit`
- 公开范围:daemon WAL flush 结算 + kernel WAL drain + 一个 integration 测试文件
- 私有计划 / 证据是否已更新:yes(artifacts/reports/dispatch_20260825_wal_flush_continued.md)
- 范围外:按 task id 作用域的 doc sync(0.15,#1799)

## 版本影响

- 版本:不改版本,原因是 rebuild 线 pre-release 修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:not applicable
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:0e365f163024cdba439cb24bcfa12e9abfc773cf
- 当前分支与 `origin/main` 的 merge-base:0e365f163024cdba439cb24bcfa12e9abfc773cf
- 最近一次 `git fetch origin` 时间:2026-08-24T18:21Z
- 同步方式:rebase
- 公开 diff 命令:`git diff 0e365f163024cdba439cb24bcfa12e9abfc773cf..220ea43cc21986b33dc93fc13a8a1050a95a2126`
- 私有证据 commit/path:任务包 artifacts/reports
- Reviewer 证据路径:worker 回执含隔离 integration 输出 4/4 通过;reviewer 核实 numstat +69/-5 与声明精确相符
- GitHub Actions `rewrite-ci` run URL:待 run 结束后补
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`(经 tools/dispatch-isolated-test.mjs 的隔离 integration 4/4)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:worker 环境的完整 `npm run check:local` fast tier(主机 Node 22,tier 需 ≥24);GitHub CI 是本 PR 的权威。

## 审查证据

- 自查:CEO 裁定复用 materializer flush 而非 watcher(watcher 已在 b96bb6e08 删除);drain 修复是循环提前退出的正确性修复,不是重试层。
- Reviewer subagent:有(只读回执审计 + git 独立核实)
- 人工审查:待
- 阻塞发现:无

## 残余风险

- flush 现在承担 doc-sync 结算;候选集大时 flush 变长,上限等于今天在转换时付出的同一结算成本。

## 关联材料

- 任务:task_963656e5641ba6ef8033b3e665
- 证据:artifacts/reports/dispatch_20260825_wal_flush_continued.md
- 审查:待

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPPk3TmbURWuxcFY3kFimA



