### PR TITLE
fix(daemon): latch on ledger divergence, settle dead runtime sessions to lost, restart once on a stale build

### DIFF
--- a/packages/cli/src/cli-runtime-wait.ts
+++ b/packages/cli/src/cli-runtime-wait.ts
@@ -122,13 +122,17 @@ export async function waitForTaskDispatches(
   const dispatches: readonly unknown[] = Array.isArray(current.dispatches) ? current.dispatches : [],
     noDispatches = dispatches.length === 0,
     cancelled = dispatches.some((row: unknown) => (row as Record<string, unknown>).status === "cancelled"),
+    lost = dispatches.some((row: unknown) => {
+      const status = row && typeof row === "object" ? (row as Record<string, unknown>).status : undefined;
+      return status === "lost";
+    }),
     failed = dispatches.some((row: unknown) => {
       const status = row && typeof row === "object" ? (row as Record<string, unknown>).status : undefined;
       return status === "failed";
     }),
     outcome = noDispatches
       ? "unknown"
-      : dispatches.some((row: unknown) => (row as Record<string, unknown>).status === "unknown")
+      : lost || dispatches.some((row: unknown) => (row as Record<string, unknown>).status === "unknown")
         ? "unknown"
         : failed
           ? "failed"
@@ -152,7 +156,7 @@ function taskDispatchesSettled(value: JsonObject): boolean {
     if (!row || typeof row !== "object" || Array.isArray(row)) return false;
     const record = row as Record<string, unknown>,
       status = String(record.status);
-    if (["succeeded", "failed", "cancelled"].includes(status)) return true;
+    if (["succeeded", "failed", "cancelled", "lost"].includes(status)) return true;
     // A just-exited process can briefly have status=unknown while its outcome event is
     // still being projected. Only an explicit unknown outcome is terminal.
     return status === "unknown" && record.outcome === "unknown";

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -99,6 +99,11 @@ export function daemonTargetFailureCode(error: unknown): "daemon_target_conflict
     ? "daemon_target_conflict"
     : null;
 }
+export function daemonBuildStaleCode(error: unknown): "daemon_build_stale" | null {
+  return typeof error === "object" && error !== null && (error as { readonly code?: unknown }).code === "daemon_build_stale"
+    ? "daemon_build_stale"
+    : null;
+}
 // The autostart seam is imported lazily so the thin dist static import graph stays
 // entry/parser/transport-only; it is only reachable on a connection-level failure.
 async function withAutostart(
@@ -114,6 +119,16 @@ async function withAutostart(
     const { DaemonAutostartError, ensureLocalDaemonRunning, isDaemonUnreachable } = await import(
       "../../../daemon/src/client/daemon-autostart.ts"
     );
+    if (isDaemonBuildStale(error)) {
+      await waitForDaemonRestart(socketPath);
+      const restarted = await ensureLocalDaemonRunning({
+        socketPath,
+        launch,
+        onProgress: (progress) => process.stderr.write(`${progress.message}\n`),
+      });
+      if (!restarted.ok) throw new DaemonAutostartError(restarted);
+      return await request();
+    }
     if (!isDaemonUnreachable(error)) throw error;
     const started = await ensureLocalDaemonRunning({
       socketPath,
@@ -122,6 +137,19 @@ async function withAutostart(
     });
     if (!started.ok) throw new DaemonAutostartError(started);
     return await request();
+  }
+}
+
+function isDaemonBuildStale(error: unknown): boolean {
+  return typeof error === "object" && error !== null && (error as { readonly code?: unknown }).code === "daemon_build_stale";
+}
+
+async function waitForDaemonRestart(socketPath: string): Promise<void> {
+  const { daemonSocketProbe } = await import("../../../daemon/src/client/daemon-autostart.ts"),
+    deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (!(await daemonSocketProbe(socketPath))) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
   }
 }
 export async function runCommandThroughDaemon(

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -100,7 +100,9 @@ export function daemonTargetFailureCode(error: unknown): "daemon_target_conflict
     : null;
 }
 export function daemonBuildStaleCode(error: unknown): "daemon_build_stale" | null {
-  return typeof error === "object" && error !== null && (error as { readonly code?: unknown }).code === "daemon_build_stale"
+  return typeof error === "object" &&
+    error !== null &&
+    (error as { readonly code?: unknown }).code === "daemon_build_stale"
     ? "daemon_build_stale"
     : null;
 }
@@ -141,7 +143,9 @@ async function withAutostart(
 }
 
 function isDaemonBuildStale(error: unknown): boolean {
-  return typeof error === "object" && error !== null && (error as { readonly code?: unknown }).code === "daemon_build_stale";
+  return (
+    typeof error === "object" && error !== null && (error as { readonly code?: unknown }).code === "daemon_build_stale"
+  );
 }
 
 async function waitForDaemonRestart(socketPath: string): Promise<void> {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,6 +20,7 @@ import {
 } from "./cli/thin-command.ts";
 import {
   daemonAutostartFailureCode,
+  daemonBuildStaleCode,
   daemonResponseTimeoutCode,
   daemonTargetFailureCode,
   runCommandThroughDaemon,
@@ -92,7 +93,8 @@ export async function main(
     const autostartCode = daemonAutostartFailureCode(error),
       timeoutCode = daemonResponseTimeoutCode(error),
       targetCode = daemonTargetFailureCode(error),
-      direct = autostartCode ?? targetCode;
+      buildStaleCode = daemonBuildStaleCode(error),
+      direct = autostartCode ?? targetCode ?? buildStaleCode;
     emit(
       cliFailure(
         parsed.command.action.kind,

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -178,7 +178,7 @@ async function requestWithSocket(
 ): Promise<JsonObject> {
   const client = new JsonRpcLineClient(socket, socket);
   try {
-    await client.request(
+    const hello = await client.request(
       "protocol.hello",
       {
         protocolVersion: currentDaemonProtocolVersion,
@@ -188,6 +188,16 @@ async function requestWithSocket(
       },
       responseTimeoutMs,
     );
+    const staleError = hello.error && typeof hello.error === "object" && !Array.isArray(hello.error)
+      ? hello.error as JsonObject
+      : null,
+      staleHint = staleError && typeof staleError.hint === "string"
+      ? staleError.hint
+      : undefined;
+    if (hello.ok === false && hello.code === "daemon_build_stale")
+      throw Object.assign(new Error(String(hello.nextAction ?? staleHint ?? "daemon_build_stale")), {
+        code: "daemon_build_stale",
+      });
     return await client.request(method, params, responseTimeoutMs);
   } catch (error) {
     if (

--- a/packages/daemon/src/daemon-host-registry.ts
+++ b/packages/daemon/src/daemon-host-registry.ts
@@ -138,6 +138,7 @@ export async function performOpenRegistered(
       runtimeDaemonRoute: context.runtimeDaemonRoute,
       authoredBranch: repo.authoredBranch,
       ...(context.input.shutdownRequested ? { shouldStop: context.input.shutdownRequested } : {}),
+      ...(context.input.recordLifecycle ? { recordLifecycle: context.input.recordLifecycle } : {}),
       ...context.runtimePorts,
       ...(context.input.runtimeLaunch ? { runtimeLaunch: context.input.runtimeLaunch } : {}),
     });

--- a/packages/daemon/src/dispatch-read.ts
+++ b/packages/daemon/src/dispatch-read.ts
@@ -67,7 +67,10 @@ export function readTaskDispatches(
       const read = input.projection.readDocument(documentPath);
       const archive = read.document ? parseArchive(read.document.body) : null;
       if (archive?.taskId !== target.taskId) continue;
-      rows.set(dispatchId, archiveRow(archive, candidate.session, target.packagePath, sessionIndex.get(dispatchId)?.state === "lost"));
+      rows.set(
+        dispatchId,
+        archiveRow(archive, candidate.session, target.packagePath, sessionIndex.get(dispatchId)?.state === "lost"),
+      );
       if (candidate.indexed) staleIndexEntries.set(dispatchId, indexedEntries.get(dispatchId)!);
       break;
     }

--- a/packages/daemon/src/dispatch-read.ts
+++ b/packages/daemon/src/dispatch-read.ts
@@ -1,6 +1,7 @@
 import { consumeKnownError, type RuntimeSession, type TaskProjection } from "../../kernel/src/index.ts";
 import {
   readDispatchLiveIndex,
+  readRuntimeSessionIndex,
   readDispatchStream,
   removeDispatchLiveIndexEntries,
   type DispatchStreamHeader,
@@ -59,13 +60,14 @@ export function readTaskDispatches(
     if (sessions.has(entry.runtimeSessionId)) staleIndexEntries.set(entry.dispatchId, entry);
   }
   const rows = new Map<string, TaskDispatchRow>();
+  const sessionIndex = new Map(readRuntimeSessionIndex(input.rootDir).map((entry) => [entry.dispatchId, entry]));
   for (const [dispatchId, candidate] of candidates) {
     for (const target of candidate.taskPackages) {
       const documentPath = `${target.packagePath}/artifacts/dispatches/${dispatchId}.json`;
       const read = input.projection.readDocument(documentPath);
       const archive = read.document ? parseArchive(read.document.body) : null;
       if (archive?.taskId !== target.taskId) continue;
-      rows.set(dispatchId, archiveRow(archive, candidate.session, target.packagePath));
+      rows.set(dispatchId, archiveRow(archive, candidate.session, target.packagePath, sessionIndex.get(dispatchId)?.state === "lost"));
       if (candidate.indexed) staleIndexEntries.set(dispatchId, indexedEntries.get(dispatchId)!);
       break;
     }
@@ -84,6 +86,7 @@ export function readTaskDispatches(
         candidate.session,
         live,
         candidate.taskPackages[0]?.packagePath ?? null,
+        sessionIndex.get(dispatchId)?.state === "lost",
       ),
     );
   }
@@ -137,6 +140,7 @@ function archiveRow(
   value: Record<string, unknown>,
   session: RuntimeSession | undefined,
   packagePath: string,
+  lost: boolean,
 ): TaskDispatchRow {
   return {
     dispatchId: String(value.dispatchId),
@@ -161,7 +165,7 @@ function archiveRow(
     startedAt: String(value.startedAt),
     endedAt: typeof value.endedAt === "string" ? value.endedAt : null,
     outcome: isOutcome(value.outcome) ? value.outcome : (session?.outcome ?? "unknown"),
-    status: isOutcome(value.outcome) ? value.outcome : (session?.outcome ?? "unknown"),
+    status: lost ? "lost" : isOutcome(value.outcome) ? value.outcome : (session?.outcome ?? "unknown"),
     resultRef: typeof value.resultRef === "string" ? value.resultRef : (session?.resultRef ?? null),
     exitCode: typeof value.exitCode === "number" ? value.exitCode : (session?.exitCode ?? null),
     dispatchPath: `${packagePath}/artifacts/dispatches/${String(value.dispatchId)}.json`,
@@ -174,6 +178,7 @@ function liveRow(
   session: RuntimeSession | undefined,
   processRunning: boolean,
   packagePath: string | null,
+  lost: boolean,
 ): TaskDispatchRow {
   const outcome = session?.outcome ?? null;
   return {
@@ -195,7 +200,7 @@ function liveRow(
     startedAt: header.startedAt,
     endedAt: null,
     outcome,
-    status: outcome ?? (session?.liveness === "live" || processRunning ? "running" : "unknown"),
+    status: outcome ?? (lost ? "lost" : session?.liveness === "live" || processRunning ? "running" : "unknown"),
     resultRef: session?.resultRef ?? null,
     exitCode: session?.exitCode ?? null,
     ...(packagePath

--- a/packages/daemon/src/dispatch-stream.ts
+++ b/packages/daemon/src/dispatch-stream.ts
@@ -24,6 +24,7 @@ import type { RuntimePermissionMode } from "./runtime-permissions.ts";
 
 const streamSchema = "runtime-dispatch-stream/v1" as const;
 const liveIndexSchema = "runtime-dispatch-live-index/v1" as const;
+const runtimeSessionIndexSchema = "runtime-session-index/v1" as const;
 const forbiddenKey =
   /(?:token|credential|password|secret|authorization|executablepath|api[-_ ]?key|private[-_ ]?key|cookie)/iu;
 const bearer = /\bBearer\s+[^\s,;]+/giu;
@@ -94,6 +95,23 @@ export interface DispatchLiveIndex {
   readonly entries: readonly DispatchLiveIndexEntry[];
 }
 
+/** Durable process/session index used to recover detached sessions after daemon restart. */
+export interface RuntimeSessionIndexEntry {
+  readonly schema: typeof runtimeSessionIndexSchema;
+  readonly runtimeSessionId: string;
+  readonly dispatchId: string;
+  readonly taskId: string | null;
+  readonly executionId: string | null;
+  readonly startedAt: string;
+  readonly pid: number | null;
+  readonly state: "live" | "exited" | "lost";
+  readonly exitCode: number | null;
+  readonly signal: string | null;
+  readonly reason: string | null;
+  readonly endedAt: string | null;
+  readonly resultRef: string | null;
+}
+
 export function openDispatchStream(
   rootDir: string,
   header: Omit<DispatchStreamHeader, "schema" | "kind" | "eventStreamRef">,
@@ -117,6 +135,22 @@ export function openDispatchStream(
       }
     }
   }
+  if (!readRuntimeSessionIndex(rootDir).some((entry) => entry.dispatchId === header.dispatchId))
+    upsertRuntimeSessionIndex(rootDir, {
+      schema: runtimeSessionIndexSchema,
+      runtimeSessionId: header.runtimeSessionId,
+      dispatchId: header.dispatchId,
+      taskId: header.taskId,
+      executionId: header.executionId,
+      startedAt: header.startedAt,
+      pid: null,
+      state: "live",
+      exitCode: null,
+      signal: null,
+      reason: null,
+      endedAt: null,
+      resultRef: null,
+    });
   return {
     ref,
     appendProviderEvent: (value, occurredAt) =>
@@ -142,9 +176,48 @@ export function removeDispatchStream(rootDir: string, dispatchId: string): void 
   const target = dispatchStreamPath(rootDir, dispatchId),
     header = readDispatchStreamHeader(rootDir, dispatchId);
   if (existsSync(target)) unlinkSync(target);
-  if (!header?.taskId) return;
-  const { taskId, runtimeSessionId } = header;
-  removeDispatchLiveIndexEntries(rootDir, [{ dispatchId, taskId, runtimeSessionId }]);
+  if (header?.taskId)
+    removeDispatchLiveIndexEntries(rootDir, [{ dispatchId, taskId: header.taskId, runtimeSessionId: header.runtimeSessionId }]);
+  const entries = readRuntimeSessionIndex(rootDir).filter((entry) => entry.dispatchId !== dispatchId);
+  if (entries.length !== readRuntimeSessionIndex(rootDir).length) writeRuntimeSessionIndex(rootDir, entries);
+}
+
+export function runtimeSessionIndexPath(rootDir: string): string {
+  return path.join(dispatchStreamRoot(rootDir), "runtime-sessions.json");
+}
+
+export function readRuntimeSessionIndex(rootDir: string): readonly RuntimeSessionIndexEntry[] {
+  const target = runtimeSessionIndexPath(rootDir);
+  if (!existsSync(target) || !statSync(target).isFile()) return [];
+  try {
+    const value: unknown = JSON.parse(readFileSync(target, "utf8"));
+    if (!Array.isArray(value)) return [];
+    return value.filter(isRuntimeSessionIndexEntry);
+  } catch (error) {
+    consumeKnownError(error);
+    return [];
+  }
+}
+
+export function markRuntimeSessionLost(
+  rootDir: string,
+  dispatchId: string,
+  reason: string,
+  exitCode: number | null = null,
+  signal: string | null = null,
+): void {
+  updateRuntimeSessionIndex(rootDir, dispatchId, (entry) => ({
+    ...entry,
+    state: "lost",
+    reason,
+    exitCode,
+    signal,
+    endedAt: new Date().toISOString(),
+  }));
+}
+
+export function markRuntimeSessionResult(rootDir: string, dispatchId: string, resultRef: string): void {
+  updateRuntimeSessionIndex(rootDir, dispatchId, (entry) => ({ ...entry, resultRef }));
 }
 
 export function readDispatchLiveIndex(rootDir: string, taskIds: readonly string[]): DispatchLiveIndex {
@@ -270,6 +343,16 @@ export function appendRuntimeWorkerRecord(
   value: Readonly<Record<string, unknown>>,
 ): void {
   appendJsonl(dispatchStreamPath(rootDir, dispatchId), { schema: streamSchema, ...value });
+  if (value.kind === "process_started" && Number.isInteger(value.pid))
+    updateRuntimeSessionIndex(rootDir, dispatchId, (entry) => ({ ...entry, pid: Number(value.pid), state: "live" }));
+  else if (value.kind === "process_exit")
+    updateRuntimeSessionIndex(rootDir, dispatchId, (entry) => ({
+      ...entry,
+      state: "exited",
+      exitCode: Number.isInteger(value.exitCode) ? Number(value.exitCode) : null,
+      signal: typeof value.signal === "string" ? value.signal : null,
+      endedAt: typeof value.occurredAt === "string" ? value.occurredAt : new Date().toISOString(),
+    }));
 }
 
 export function readRuntimeWorkerChunk(
@@ -323,6 +406,51 @@ export function dispatchLiveIndexPath(rootDir: string, taskId: string): string {
 }
 function dispatchStreamRoot(rootDir: string): string {
   return path.join(resolveHarnessLayout(rootDir).localRoot, "runtime", "dispatches");
+}
+
+function upsertRuntimeSessionIndex(rootDir: string, entry: RuntimeSessionIndexEntry): void {
+  const entries = new Map(readRuntimeSessionIndex(rootDir).map((value) => [value.dispatchId, value]));
+  entries.set(entry.dispatchId, entry);
+  writeRuntimeSessionIndex(rootDir, [...entries.values()]);
+}
+
+function updateRuntimeSessionIndex(
+  rootDir: string,
+  dispatchId: string,
+  update: (entry: RuntimeSessionIndexEntry) => RuntimeSessionIndexEntry,
+): void {
+  const current = readRuntimeSessionIndex(rootDir).find((value) => value.dispatchId === dispatchId);
+  if (!current) return;
+  upsertRuntimeSessionIndex(rootDir, update(current));
+}
+
+function writeRuntimeSessionIndex(rootDir: string, entries: readonly RuntimeSessionIndexEntry[]): void {
+  const target = runtimeSessionIndexPath(rootDir), temporary = `${target}.${process.pid}.tmp`;
+  mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
+  try {
+    writeFileSync(temporary, `${JSON.stringify([...entries].sort((left, right) => left.startedAt.localeCompare(right.startedAt)), null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+    renameSync(temporary, target);
+  } finally {
+    if (existsSync(temporary)) unlinkSync(temporary);
+  }
+}
+
+function isRuntimeSessionIndexEntry(value: unknown): value is RuntimeSessionIndexEntry {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const row = value as Record<string, unknown>;
+  return row.schema === runtimeSessionIndexSchema
+    && typeof row.runtimeSessionId === "string"
+    && typeof row.dispatchId === "string"
+    && (row.taskId === null || typeof row.taskId === "string")
+    && (row.executionId === null || typeof row.executionId === "string")
+    && typeof row.startedAt === "string"
+    && (row.pid === null || (Number.isInteger(row.pid) && Number(row.pid) > 0))
+    && ["live", "exited", "lost"].includes(String(row.state))
+    && (row.exitCode === null || Number.isInteger(row.exitCode))
+    && (row.signal === null || typeof row.signal === "string")
+    && (row.reason === null || typeof row.reason === "string")
+    && (row.endedAt === null || typeof row.endedAt === "string")
+    && (row.resultRef === null || typeof row.resultRef === "string");
 }
 function dispatchLiveIndex(entries: readonly DispatchLiveIndexEntry[]): DispatchLiveIndex {
   const sorted = [...entries].sort((left, right) => left.dispatchId.localeCompare(right.dispatchId));

--- a/packages/daemon/src/dispatch-stream.ts
+++ b/packages/daemon/src/dispatch-stream.ts
@@ -177,7 +177,9 @@ export function removeDispatchStream(rootDir: string, dispatchId: string): void 
     header = readDispatchStreamHeader(rootDir, dispatchId);
   if (existsSync(target)) unlinkSync(target);
   if (header?.taskId)
-    removeDispatchLiveIndexEntries(rootDir, [{ dispatchId, taskId: header.taskId, runtimeSessionId: header.runtimeSessionId }]);
+    removeDispatchLiveIndexEntries(rootDir, [
+      { dispatchId, taskId: header.taskId, runtimeSessionId: header.runtimeSessionId },
+    ]);
   const entries = readRuntimeSessionIndex(rootDir).filter((entry) => entry.dispatchId !== dispatchId);
   if (entries.length !== readRuntimeSessionIndex(rootDir).length) writeRuntimeSessionIndex(rootDir, entries);
 }
@@ -425,10 +427,19 @@ function updateRuntimeSessionIndex(
 }
 
 function writeRuntimeSessionIndex(rootDir: string, entries: readonly RuntimeSessionIndexEntry[]): void {
-  const target = runtimeSessionIndexPath(rootDir), temporary = `${target}.${process.pid}.tmp`;
+  const target = runtimeSessionIndexPath(rootDir),
+    temporary = `${target}.${process.pid}.tmp`;
   mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
   try {
-    writeFileSync(temporary, `${JSON.stringify([...entries].sort((left, right) => left.startedAt.localeCompare(right.startedAt)), null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+    writeFileSync(
+      temporary,
+      `${JSON.stringify(
+        [...entries].sort((left, right) => left.startedAt.localeCompare(right.startedAt)),
+        null,
+        2,
+      )}\n`,
+      { encoding: "utf8", mode: 0o600 },
+    );
     renameSync(temporary, target);
   } finally {
     if (existsSync(temporary)) unlinkSync(temporary);
@@ -438,19 +449,21 @@ function writeRuntimeSessionIndex(rootDir: string, entries: readonly RuntimeSess
 function isRuntimeSessionIndexEntry(value: unknown): value is RuntimeSessionIndexEntry {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
   const row = value as Record<string, unknown>;
-  return row.schema === runtimeSessionIndexSchema
-    && typeof row.runtimeSessionId === "string"
-    && typeof row.dispatchId === "string"
-    && (row.taskId === null || typeof row.taskId === "string")
-    && (row.executionId === null || typeof row.executionId === "string")
-    && typeof row.startedAt === "string"
-    && (row.pid === null || (Number.isInteger(row.pid) && Number(row.pid) > 0))
-    && ["live", "exited", "lost"].includes(String(row.state))
-    && (row.exitCode === null || Number.isInteger(row.exitCode))
-    && (row.signal === null || typeof row.signal === "string")
-    && (row.reason === null || typeof row.reason === "string")
-    && (row.endedAt === null || typeof row.endedAt === "string")
-    && (row.resultRef === null || typeof row.resultRef === "string");
+  return (
+    row.schema === runtimeSessionIndexSchema &&
+    typeof row.runtimeSessionId === "string" &&
+    typeof row.dispatchId === "string" &&
+    (row.taskId === null || typeof row.taskId === "string") &&
+    (row.executionId === null || typeof row.executionId === "string") &&
+    typeof row.startedAt === "string" &&
+    (row.pid === null || (Number.isInteger(row.pid) && Number(row.pid) > 0)) &&
+    ["live", "exited", "lost"].includes(String(row.state)) &&
+    (row.exitCode === null || Number.isInteger(row.exitCode)) &&
+    (row.signal === null || typeof row.signal === "string") &&
+    (row.reason === null || typeof row.reason === "string") &&
+    (row.endedAt === null || typeof row.endedAt === "string") &&
+    (row.resultRef === null || typeof row.resultRef === "string")
+  );
 }
 function dispatchLiveIndex(entries: readonly DispatchLiveIndexEntry[]): DispatchLiveIndex {
   const sorted = [...entries].sort((left, right) => left.dispatchId.localeCompare(right.dispatchId));

--- a/packages/daemon/src/lifecycle-log.ts
+++ b/packages/daemon/src/lifecycle-log.ts
@@ -25,7 +25,9 @@ export type DaemonLifecycleEvent =
   | "repo_attach_failed"
   | "repo_attach_timed_out"
   | "repo_registry_pruned"
-  | "attachments_settled";
+  | "attachments_settled"
+  | "runtime_spawn"
+  | "runtime_exit";
 export interface DaemonLifecycleEntry {
   readonly event: DaemonLifecycleEvent;
   readonly repoId?: string;
@@ -40,6 +42,16 @@ export interface DaemonLifecycleEntry {
   readonly attached?: number;
   readonly unavailable?: number;
   readonly pruned?: number;
+  readonly runtimeSessionId?: string;
+  readonly dispatchId?: string;
+  readonly pid?: number;
+  readonly exitCode?: number | null;
+  readonly signal?: string | null;
+  readonly reason?: string | null;
+  readonly commit?: string | null;
+  readonly loadedBuildId?: string | null;
+  readonly diskBuildId?: string | null;
+  readonly drifted?: boolean;
 }
 export interface DaemonLifecycleRecord extends DaemonLifecycleEntry {
   readonly schema: string;

--- a/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
@@ -257,7 +257,7 @@ export interface TaskDispatchRow {
   readonly startedAt: string;
   readonly endedAt: string | null;
   readonly outcome: "succeeded" | "failed" | "unknown" | "cancelled" | null;
-  readonly status: "running" | "succeeded" | "failed" | "unknown" | "cancelled";
+  readonly status: "running" | "succeeded" | "failed" | "unknown" | "cancelled" | "lost";
   /** Terminal result and durable task-package artifact locations, when settled. */
   readonly resultRef?: string | null;
   readonly exitCode?: number | null;

--- a/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
@@ -120,7 +120,7 @@ export function validateDaemonTaskDispatches(value: unknown): readonly string[] 
       !nonEmpty(row.startedAt) ||
       (row.endedAt !== null && !nonEmpty(row.endedAt)) ||
       ![null, "succeeded", "failed", "unknown", "cancelled"].includes(row.outcome as never) ||
-      !["running", "succeeded", "failed", "unknown", "cancelled"].includes(String(row.status)) ||
+      !["running", "succeeded", "failed", "unknown", "cancelled", "lost"].includes(String(row.status)) ||
       (row.resultRef !== undefined && row.resultRef !== null && !nonEmpty(row.resultRef)) ||
       (row.exitCode !== undefined && row.exitCode !== null && (!integer(row.exitCode) || Number(row.exitCode) < 0)) ||
       (row.dispatchPath !== undefined && row.dispatchPath !== null && !nonEmpty(row.dispatchPath)) ||

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -29,7 +29,7 @@ import {
   type JsonRpcResponse,
 } from "./json-rpc-types.ts";
 import { currentDaemonProtocolVersion } from "./version.ts";
-import type { DaemonBuildStamp } from "../build-identity.ts";
+import type { DaemonBuildObserver, DaemonBuildStamp } from "../build-identity.ts";
 export interface JsonRpcProtocolServer {
   readonly handle: (
     message: JsonRpcRequest | JsonRpcRequest[],
@@ -44,6 +44,7 @@ interface ObservedRequest {
 export function createJsonRpcProtocolServer(options: {
   readonly host: DaemonHost;
   readonly build: DaemonBuildStamp;
+  readonly buildObserver?: DaemonBuildObserver;
   readonly authContext: DaemonAuthenticationContext;
   readonly emit: (method: string, params: JsonObject) => Promise<void>;
   readonly connectionId?: string;
@@ -104,6 +105,21 @@ export function createJsonRpcProtocolServer(options: {
         Object.assign(options.authContext, {
           sessionEnvironment: params.sessionEnvironment as DaemonSessionEnvironment,
         });
+      const buildStatus = options.buildObserver?.status();
+      if (buildStatus?.drifted) {
+        const stale = daemonProtocolError(
+          "protocol.hello",
+          "daemon_build_stale",
+          `Daemon build is stale: loaded ${buildStatus.loadedBuildId ?? "missing"}, disk ${buildStatus.diskBuildId ?? "missing"}. Restarting once to load the disk build.`,
+        ) as unknown as JsonObject;
+        const response = reply({
+          ...stale,
+          loadedBuildId: buildStatus.loadedBuildId,
+          diskBuildId: buildStatus.diskBuildId,
+        });
+        setImmediate(() => options.requestShutdown?.());
+        return response;
+      }
       handshaken = true;
       return reply({
         ok: true,

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -110,7 +110,8 @@ export function createJsonRpcProtocolServer(options: {
         const stale = daemonProtocolError(
           "protocol.hello",
           "daemon_build_stale",
-          `Daemon build is stale: loaded ${buildStatus.loadedBuildId ?? "missing"}, disk ${buildStatus.diskBuildId ?? "missing"}. Restarting once to load the disk build.`,
+          `Daemon build is stale: loaded ${buildStatus.loadedBuildId ?? "missing"}, ` +
+            `disk ${buildStatus.diskBuildId ?? "missing"}. Restarting once to load the disk build.`,
         ) as unknown as JsonObject;
         const response = reply({
           ...stale,

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -42,6 +42,7 @@ import { makeDaemonRuntimeAdmissionGuard } from "./runtime-admission.ts";
 import { makeRuntimeSpawner, type RuntimeDaemonRoute, type RuntimeLauncher } from "./runtime-spawn.ts";
 import { openTerminalHost } from "./terminal-host.ts";
 import { makeSquadCoordinator } from "./squad-coordinator.ts";
+import type { DaemonLifecycleRecorder } from "./lifecycle-log.ts";
 
 export function publicPublication(value: Pick<CanonicalEventAppendReceipt, "commitSha" | "cut">): PublicPublication {
   return { commitSha: value.commitSha?.sha ?? null, cut: value.cut };
@@ -72,6 +73,7 @@ export async function openRepoCell(input: {
   readonly now?: () => string;
   readonly killpoint?: (point: EventPublicationKillpoint) => void;
   readonly shouldStop?: () => boolean;
+  readonly recordLifecycle?: DaemonLifecycleRecorder;
 }): Promise<RepoCell> {
   const rootDir = input.rootDir,
     mode = input.mode ?? "local",
@@ -269,6 +271,7 @@ export async function openRepoCell(input: {
     onRuntimeOutcome: (event) => {
       schedule(() => squadCoordinator.observeOutcome(event));
     },
+    ...(input.recordLifecycle ? { recordLifecycle: input.recordLifecycle } : {}),
     ...(input.runtimeLaunch ? { launch: input.runtimeLaunch } : {}),
   });
   const squadCoordinator = makeSquadCoordinator({

--- a/packages/daemon/src/runtime-spawn-active.ts
+++ b/packages/daemon/src/runtime-spawn-active.ts
@@ -18,6 +18,9 @@ type ActiveRuntimeBase = Omit<
   | "cancelRequested"
   | "cancelBinding"
   | "cancelOpId"
+  | "lossReason"
+  | "lossSignal"
+  | "lossExitCode"
 > & { readonly providerSessionId?: string | null };
 
 export function createActiveRuntime(base: ActiveRuntimeBase): ActiveRuntime {
@@ -39,6 +42,9 @@ export function createActiveRuntime(base: ActiveRuntimeBase): ActiveRuntime {
     cancelRequested: false,
     cancelBinding: null,
     cancelOpId: null,
+    lossReason: null,
+    lossSignal: null,
+    lossExitCode: null,
   };
 }
 

--- a/packages/daemon/src/runtime-spawn-adoption.ts
+++ b/packages/daemon/src/runtime-spawn-adoption.ts
@@ -1,4 +1,5 @@
 import {
+  markRuntimeSessionLost,
   readDispatchStream,
   readDispatchStreams,
   reopenDispatchStream,
@@ -73,11 +74,23 @@ export async function adoptRuntimes(context: any): Promise<void> {
       );
     }
     attachActiveRuntime(context, active);
-    if (!stream.process.exited && !runtimePidIsAlive(stream.process.pid)) {
+    const processState = stream.process;
+    if (processState && !processState.exited && !runtimePidIsAlive(processState.pid)) {
       const timer = setTimeout(() => {
         const current = readDispatchStream(context.input.rootDir, active.dispatchId);
         if (!current?.process?.exited && context.processes.get(active.runtimeSessionId) === active) {
-          context.input.schedule(() => context.publishExit(active, null));
+          const reason = `runtime process ${String(processState.pid)} is no longer alive after daemon restart`;
+          active.lossReason = reason;
+          active.lossExitCode = current?.process?.exitCode ?? null;
+          active.lossSignal = current?.process?.signal ?? null;
+          markRuntimeSessionLost(
+            context.input.rootDir,
+            active.dispatchId,
+            reason,
+            active.lossExitCode,
+            active.lossSignal,
+          );
+          context.input.schedule(() => context.publishExit(active, active.lossExitCode));
         }
       }, 50);
       timer.unref();

--- a/packages/daemon/src/runtime-spawn-settlement.ts
+++ b/packages/daemon/src/runtime-spawn-settlement.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import type { AgentRuntimeEventV1, CanonicalEventStore, RuntimeResultClaim } from "../../kernel/src/index.ts";
 import { consumeKnownError } from "../../kernel/src/index.ts";
-import { scrubProviderValue } from "./dispatch-stream.ts";
+import { markRuntimeSessionResult, scrubProviderValue } from "./dispatch-stream.ts";
 import { archiveRuntimeDispatch, type RuntimeDispatchArchive } from "./doc-sync-actions.ts";
 import { consumeDurableOutput } from "./runtime-spawn-provider-stream.ts";
 import type { ActiveRuntime } from "./runtime-spawn-types.ts";
@@ -79,6 +79,7 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
             eventStreamRef: active.stream.ref,
           }
         : null;
+    markRuntimeSessionResult(context.input.rootDir, active.dispatchId, resultRef);
     if (archive)
       try {
         const archived = context.input.remote
@@ -102,6 +103,16 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
         outcome = "unknown";
       }
     context.input.stream.publish(active.runtimeSessionId, { type: "exit", outcome });
+    context.input.recordLifecycle?.({
+      event: "runtime_exit",
+      runtimeSessionId: active.runtimeSessionId,
+      dispatchId: active.dispatchId,
+      pid: active.process.pid,
+      exitCode: active.lossExitCode ?? (cancelled ? null : code),
+      signal: active.lossSignal,
+      outcome: active.lossReason ? "lost" : outcome,
+      reason: active.lossReason,
+    });
     if (cancelled)
       await context.publishRuntimeEvent(
         "runtime_session_cancelled",
@@ -158,6 +169,8 @@ export function runtimeResultText(
   code: number | null,
   outcome: "succeeded" | "failed" | "unknown" | "cancelled",
 ): string {
+  if (active.lossReason)
+    return `Runtime session lost: ${active.lossReason}${active.lossSignal ? ` (${active.lossSignal})` : ""}.`;
   if (code === 0 || code === null)
     return scrubProviderValue(
       active.finalText ??

--- a/packages/daemon/src/runtime-spawn-types.ts
+++ b/packages/daemon/src/runtime-spawn-types.ts
@@ -93,6 +93,9 @@ export type ActiveRuntime = {
   cancelRequested: boolean;
   cancelBinding: RuntimeBinding | null;
   cancelOpId: string | null;
+  lossReason: string | null;
+  lossSignal: string | null;
+  lossExitCode: number | null;
 };
 
 export type ProviderFrame = {

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -74,6 +74,7 @@ import type {
   RuntimeLauncher,
   RuntimeProcess,
 } from "./runtime-spawn-types.ts";
+import type { DaemonLifecycleRecorder } from "./lifecycle-log.ts";
 
 export const resultMediaType = "text/plain; charset=utf-8" as const,
   providerErrorLimit = 64 * 1024,
@@ -112,6 +113,7 @@ export function makeRuntimeSpawner(input: {
       { readonly type: "runtime_session_outcome_observed" }
     >,
   ) => void;
+  readonly recordLifecycle?: DaemonLifecycleRecorder;
 }) {
   const processes = new Map<string, ActiveRuntime>(),
     exiting = new Set<string>(),
@@ -520,6 +522,12 @@ export function makeRuntimeSpawner(input: {
         resumeProviderSessionId: providerSessionId ?? null,
       });
       processes.set(runtimeSessionId, active);
+      input.recordLifecycle?.({
+        event: "runtime_spawn",
+        runtimeSessionId,
+        dispatchId: newDispatchId,
+        pid: runtimeProcess.pid,
+      });
       attachActiveRuntime(extracted, active, resumeObservation);
       return requested.receipt
         ? { ...requested.receipt, runtimeSessionId, dispatchId: newDispatchId }

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -7,7 +7,7 @@ import { createJsonRpcProtocolServer } from "./protocol/json-rpc-server.ts";
 import { openDaemonRequestLog } from "./request-log.ts";
 import { openDaemonLifecycleLog } from "./lifecycle-log.ts";
 import { openDaemonConnLog } from "./conn-log.ts";
-import { daemonBuildStamp } from "./build-identity.ts";
+import { daemonBuildStamp, observeDaemonBuild } from "./build-identity.ts";
 import { createUnixSocketTransportServer } from "./transport/unix-socket.ts";
 
 export interface RunningDaemon {
@@ -37,8 +37,9 @@ export async function startDaemon(input: {
   mkdirSync(path.dirname(pidPath), { recursive: true });
   writeFileSync(pidPath, `${process.pid}\n`, "utf8");
   const lifecycle = openDaemonLifecycleLog({ userRoot: input.userRoot, daemonId: input.daemonId });
-  lifecycle.record({ event: "process_start", endpoint });
   const build = daemonBuildStamp();
+  const buildObserver = observeDaemonBuild(input.runtimeFile);
+  lifecycle.record({ event: "process_start", endpoint, ...buildObserver.status() });
   // Connection- and request-level traffic sink; async by design so the socket hot path never waits on disk.
   const connLog = openDaemonConnLog({ userRoot: input.userRoot, daemonId: input.daemonId });
   let host: Awaited<ReturnType<typeof openDaemonHost>> | undefined,
@@ -67,6 +68,7 @@ export async function startDaemon(input: {
         createJsonRpcProtocolServer({
           host: host!,
           build,
+          buildObserver,
           authContext: { ...authContext, connectionSignal: signal },
           emit,
           connectionId: connLog.connectionOpened(connectionId, authContext.transportKind),

--- a/packages/daemon/test/dispatch-read.test.ts
+++ b/packages/daemon/test/dispatch-read.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { type RuntimeSession, type TaskProjection } from "../../kernel/src/index.ts";
-import { appendRuntimeWorkerRecord, openDispatchStream, readDispatchLiveIndex } from "../src/dispatch-stream.ts";
+import { appendRuntimeWorkerRecord, markRuntimeSessionLost, openDispatchStream, readDispatchLiveIndex } from "../src/dispatch-stream.ts";
 import { readTaskDispatches } from "../src/dispatch-read.ts";
 
 const dispatchId = "dispatch_a1b2c3d4e5f60718293a4b5c", runtimeSessionId = "runtime-1", taskId = "task-1";
@@ -36,6 +36,16 @@ test("a dispatch whose session has exited reports unknown, not running", () => {
   assert.equal(statusFor(session("exited", null)), "unknown");
   assert.equal(statusFor(session("unknown", null)), "unknown");
   assert.equal(statusFor(session("stale", null)), "unknown");
+});
+
+test("a daemon restart loss is a terminal lost dispatch", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-read-lost-"));
+  try {
+    openDispatchStream(rootDir, { dispatchId, taskId, executionId: "execution-1", runtimeSessionId, instanceId: "instance-1", startedAt: "2026-08-23T00:00:00.000Z" });
+    markRuntimeSessionLost(rootDir, dispatchId, "provider pid disappeared");
+    const result = readTaskDispatches({ rootDir, projection: projectionFor(session("exited", null)), taskId });
+    assert.equal(result.dispatches[0]?.status, "lost");
+  } finally { rmSync(rootDir, { recursive: true, force: true }); }
 });
 
 test("a dispatch whose session is live still reports running", () => {

--- a/packages/daemon/test/dispatch-stream.test.ts
+++ b/packages/daemon/test/dispatch-stream.test.ts
@@ -9,6 +9,7 @@ import {
   dispatchLiveIndexPath,
   openDispatchStream,
   readDispatchLiveIndex,
+  readRuntimeSessionIndex,
 } from "../src/dispatch-stream.ts";
 
 test("the live index rebuilds exactly from dispatch stream headers", () => {
@@ -23,5 +24,19 @@ test("the live index rebuilds exactly from dispatch stream headers", () => {
     rmSync(dispatchLiveIndexPath(rootDir, "task-1"));
     const rebuilt = readDispatchLiveIndex(rootDir, ["task-1"]);
     assert.deepEqual(rebuilt, before);
+  } finally { rmSync(rootDir, { recursive: true, force: true }); }
+});
+
+test("the runtime session index records process exit and preserves a lost terminal reason", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-runtime-session-index-"));
+  try {
+    const dispatchId = "dispatch_333333333333333333333333";
+    openDispatchStream(rootDir, { dispatchId, taskId: "task-2", executionId: "execution-2", runtimeSessionId: "runtime_333333333333333333333333", instanceId: "instance-1", startedAt: "2026-08-24T00:00:00.000Z" });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_started", pid: 4321 });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_exit", exitCode: null, signal: "SIGKILL", occurredAt: "2026-08-24T00:01:00.000Z" });
+    const row = readRuntimeSessionIndex(rootDir)[0];
+    assert.equal(row?.state, "exited");
+    assert.equal(row?.pid, 4321);
+    assert.equal(row?.signal, "SIGKILL");
   } finally { rmSync(rootDir, { recursive: true, force: true }); }
 });

--- a/packages/daemon/test/protocol-hello-build.test.ts
+++ b/packages/daemon/test/protocol-hello-build.test.ts
@@ -21,3 +21,21 @@ test("protocol.hello answers with the daemon's build stamp", async () => {
     assert.equal(shutdowns, 1, "an accepted daemon.stop must reach the shutdown owner exactly once");
   } finally { server.close(); }
 });
+
+test("protocol.hello rejects a stale dist fingerprint and requests one restart", async () => {
+  let shutdowns = 0;
+  const server = createJsonRpcProtocolServer({
+    host: {} as never,
+    build: { commit: "loaded" },
+    buildObserver: { status: () => ({ commit: "loaded", loadedBuildId: "build-a", diskBuildId: "build-b", drifted: true }) },
+    authContext: { transportKind: "unix-socket" } as DaemonAuthenticationContext,
+    emit: async () => undefined,
+    requestShutdown: () => { shutdowns += 1; },
+  });
+  try {
+    const hello = await server.handle({ jsonrpc: "2.0", id: 1, method: "protocol.hello", params: { protocolVersion: currentDaemonProtocolVersion } });
+    assert.equal((hello as { readonly result: { readonly code: string } }).result.code, "daemon_build_stale");
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(shutdowns, 1);
+  } finally { server.close(); }
+});

--- a/packages/gui/src/renderer/components/runtime/RuntimeRail.tsx
+++ b/packages/gui/src/renderer/components/runtime/RuntimeRail.tsx
@@ -22,6 +22,7 @@ const OUTCOME_TONE: Record<RuntimeDockRow["status"], string> = {
   cancelled: "text-status-cancelled",
   running: "text-status-active",
   unknown: "text-status-unknown",
+  lost: "text-status-unknown",
   "ended-indeterminate": "text-status-unknown",
   unavailable: "text-text-faint",
 };

--- a/packages/gui/src/renderer/components/taskDetail/TaskDetailSections.tsx
+++ b/packages/gui/src/renderer/components/taskDetail/TaskDetailSections.tsx
@@ -966,6 +966,7 @@ const dispatchStatusColor: Readonly<Record<TaskDispatchProjectionRow["status"], 
   failed: "bg-danger",
   cancelled: "bg-text-faint",
   unknown: "bg-text-faint",
+  lost: "bg-text-faint",
 };
 function StatusDot({ status }: { readonly status: TaskDispatchProjectionRow["status"] }) {
   return <span className={`size-2 rounded-full ${dispatchStatusColor[status]}`} aria-label={status} />;

--- a/packages/gui/src/renderer/runtime-panorama.ts
+++ b/packages/gui/src/renderer/runtime-panorama.ts
@@ -32,6 +32,7 @@ const dispatchSortRank: Readonly<Record<TaskDispatchRow["status"], number>> = {
   failed: 1,
   unknown: 1,
   cancelled: 1,
+  lost: 1,
 };
 export function runtimePanoramaDelegation(row: RuntimePanoramaRow): string | null {
   if (!row.delegatedByAgentId || !row.agentId) return null;
@@ -82,6 +83,7 @@ export const runtimeDockStatusDot: Readonly<Record<RuntimeDockStatus, "live" | "
   succeeded: "idle",
   cancelled: "idle",
   unknown: "idle",
+  lost: "failed",
   "ended-indeterminate": "idle",
   unavailable: "idle",
 };
@@ -91,6 +93,7 @@ export const runtimeDockStatusKey: Record<RuntimeDockStatus, string> = {
   failed: "agentRuntime.sessionStatusFailed",
   cancelled: "agentRuntime.sessionStatusCancelled",
   unknown: "agentRuntime.sessionStatusUnknown",
+  lost: "agentRuntime.sessionStatusUnknown",
   "ended-indeterminate": "agentRuntime.sessionStatusEndedIndeterminate",
   unavailable: "agentRuntime.sessionStatusUnavailable",
 };

--- a/packages/kernel/src/store/wal-git-materializer.ts
+++ b/packages/kernel/src/store/wal-git-materializer.ts
@@ -27,6 +27,24 @@ export interface WalGitMaterializerOptions {
   readonly withAppendFence?: <T>(operation: () => T) => T;
 }
 
+/** The authored branch moved independently of the canonical daemon cut. */
+export class WalMaterializerDivergedError extends TaskEventStoreError {
+  readonly canonicalSha: string;
+
+  constructor(repoRoot: string, authoredRef: string, canonicalSha: string) {
+    super(
+      "publication_indeterminate",
+      [
+        `authored ref ${authoredRef} diverged from the canonical event cut ${canonicalSha}.`,
+        `Repair with: git -C ${repoRoot} reset ${canonicalSha}`,
+        "then retry materialization.",
+      ].join(" "),
+    );
+    this.name = "WalMaterializerDivergedError";
+    this.canonicalSha = canonicalSha;
+  }
+}
+
 export function flushWalToGit(wal: WalEventLog, git: CanonicalEventStore, options: WalGitMaterializerOptions): void {
   const records = wal.records();
   if (records.length === 0) return;
@@ -96,11 +114,7 @@ export function flushWalToGit(wal: WalEventLog, git: CanonicalEventStore, option
       "publication_indeterminate",
       "Git refs changed while preparing the WAL materialization batch",
     );
-  if (authoredParent !== parent && !localGitObjectRefStore.isAncestor(ledger.rootDir, parent, authoredParent))
-    throw new TaskEventStoreError(
-      "publication_indeterminate",
-      `authored ref ${authoredRef} diverged from the canonical event cut`,
-    );
+  if (authoredParent !== parent) throw new WalMaterializerDivergedError(ledger.rootDir, authoredRef, parent);
   const flushRef = `refs/ha-wal-flush/${process.pid}-${Date.now()}`;
   const messageText = `harness WAL flush ${pending[0]!.revision}-${last.revision}`;
   const timestamp = Math.floor(Date.parse(last.event.occurredAt) / 1_000);

--- a/packages/kernel/src/store/wal-git-materializer.ts
+++ b/packages/kernel/src/store/wal-git-materializer.ts
@@ -114,7 +114,8 @@ export function flushWalToGit(wal: WalEventLog, git: CanonicalEventStore, option
       "publication_indeterminate",
       "Git refs changed while preparing the WAL materialization batch",
     );
-  if (authoredParent !== parent) throw new WalMaterializerDivergedError(ledger.rootDir, authoredRef, parent);
+  if (authoredParent !== parent && !localGitObjectRefStore.isAncestor(ledger.rootDir, parent, authoredParent))
+    throw new WalMaterializerDivergedError(ledger.rootDir, authoredRef, parent);
   const flushRef = `refs/ha-wal-flush/${process.pid}-${Date.now()}`;
   const messageText = `harness WAL flush ${pending[0]!.revision}-${last.revision}`;
   const timestamp = Math.floor(Date.parse(last.event.occurredAt) / 1_000);

--- a/packages/kernel/src/store/wal-shadow-event-store.ts
+++ b/packages/kernel/src/store/wal-shadow-event-store.ts
@@ -26,7 +26,7 @@ import {
   validateCanonicalWriteBundle,
 } from "./task-event-store.ts";
 import { openWalEventLog, type WalEventLog, type WalEventRecord } from "./wal-event-log.ts";
-import { flushWalToGit } from "./wal-git-materializer.ts";
+import { flushWalToGit, WalMaterializerDivergedError } from "./wal-git-materializer.ts";
 
 export { canonicalDocumentClaims, canonicalEventWritePlan, TaskEventStoreError };
 
@@ -68,6 +68,7 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
   let immediate: ReturnType<typeof setImmediate> | null = null;
   let consecutiveFailures = 0;
   let lastFlushError: string | null = null;
+  let divergedError: WalMaterializerDivergedError | null = null;
   let lastSettlementFingerprint: string | null = null;
   let closed = false;
 
@@ -89,8 +90,47 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
     timer = null;
     immediate = null;
   };
+  const publicationRefs = (): { readonly canonical: string | null; readonly authored: string | null } | null => {
+    const branch = options.authoredBranch ?? localGitObjectRefStore.currentBranch(ledger.rootDir);
+    if (!branch) return null;
+    const refs = new Map(
+      localGitObjectRefStore
+        .listRefs(ledger.rootDir, ["refs/ha/canonical", `refs/heads/${branch}`])
+        .trim()
+        .split(/\r?\n/u)
+        .filter(Boolean)
+        .map((line) => {
+          const [ref, sha] = line.split(" ");
+          return [ref!, sha!] as const;
+        }),
+    );
+    return { canonical: refs.get("refs/ha/canonical") ?? null, authored: refs.get(`refs/heads/${branch}`) ?? null };
+  };
+  const resumeAfterRepair = (): boolean => {
+    if (divergedError === null) return true;
+    let refs: ReturnType<typeof publicationRefs>;
+    try {
+      refs = publicationRefs();
+    } catch (error) {
+      consumeKnownError(error);
+      return false;
+    }
+    if (refs === null || refs.canonical === null || refs.authored === null || refs.canonical !== refs.authored)
+      return false;
+    try {
+      reloadGit();
+    } catch (error) {
+      consumeKnownError(error);
+      return false;
+    }
+    divergedError = null;
+    consecutiveFailures = 0;
+    lastFlushError = null;
+    return true;
+  };
   const runFlush = (context: string): boolean => {
     clearSchedule();
+    if (divergedError !== null) return false;
     if (!hasWalRecords()) return true;
     const pendingRecords = wal.records();
     const first = pendingRecords[0]!.revision;
@@ -116,6 +156,14 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
       lastFlushError = null;
       return true;
     } catch (error) {
+      if (error instanceof WalMaterializerDivergedError) {
+        divergedError = error;
+        lastFlushError = error.message;
+        clearSchedule();
+        console.error(`[wal-materializer] diverged; materializer stopped: ${error.message}`);
+        consumeKnownError(error);
+        return false;
+      }
       consecutiveFailures += 1;
       lastFlushError = walShadowErrorMessage(error);
       try {
@@ -150,7 +198,7 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
     }
   };
   const scheduleRetry = (): void => {
-    if (closed || !hasWalRecords() || consecutiveFailures >= retryLimit) {
+    if (closed || divergedError !== null || !hasWalRecords() || consecutiveFailures >= retryLimit) {
       if (consecutiveFailures >= retryLimit)
         console.warn(
           `[wal-materializer] retry budget exhausted after ${retryLimit} attempts; the next write, recovery, or drain will retry the pending WAL cut`,
@@ -164,9 +212,8 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
     }, delay);
     timer.unref?.();
   };
-  const scheduleFlush = (newWrite: boolean): void => {
-    if (closed || !hasWalRecords()) return;
-    if (newWrite && consecutiveFailures >= retryLimit) consecutiveFailures = 0;
+  const scheduleFlush = (): void => {
+    if (closed || divergedError !== null || !hasWalRecords()) return;
     if (timer !== null || immediate !== null) {
       if (pendingCount() < flushEvents || immediate !== null) return;
       clearSchedule();
@@ -277,11 +324,19 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
       changedPaths,
       localGitObjectRefStore.processCount() - started,
     );
-    scheduleFlush(true);
+    scheduleFlush();
     return receipt;
   };
   const recover = (): EventRecoveryReceipt => {
     const started = performance.now();
+    if (!resumeAfterRepair())
+      return {
+        status: "indeterminate",
+        publications: 0,
+        elapsedMs: performance.now() - started,
+        error: divergedError?.message ?? "WAL materializer remains stopped until Git refs are repaired",
+        errorCode: "publication_indeterminate",
+      };
     let recovered: EventRecoveryReceipt;
     try {
       recovered = git.recover();
@@ -351,6 +406,7 @@ export function makeWalShadowEventStore(options: StoreOptions): CanonicalEventSt
   const drain = async (): Promise<void> => {
     closed = true;
     clearSchedule();
+    if (!resumeAfterRepair() && divergedError !== null) throw divergedError;
     consecutiveFailures = 0;
     for (let attempt = 1; hasWalRecords() && attempt <= retryLimit; attempt += 1) {
       if (runFlush("drain") && !hasWalRecords()) break;

--- a/packages/kernel/test/store/wal-shadow-event-store.test.ts
+++ b/packages/kernel/test/store/wal-shadow-event-store.test.ts
@@ -159,7 +159,7 @@ test("materialization failures warn, retry with a bound, and do not revoke the w
   });
 });
 
-test("a master branch ahead of canonical stops the materializer once until refs are repaired", async () => {
+test("a master branch forked from canonical stops the materializer once until refs are repaired", async () => {
   await withTempStoreAsync(async (rootDir) => {
     initRepo(rootDir);
     const store = makeWalShadowEventStore({
@@ -170,7 +170,8 @@ test("a master branch ahead of canonical stops the materializer once until refs 
       walRetryBaseMs: 1,
     });
     const canonical = git(rootDir, "rev-parse", "refs/ha/canonical");
-    git(rootDir, "commit", "--allow-empty", "-qm", "worker direct commit");
+    const fork = git(rootDir, "commit-tree", `${canonical}^{tree}`, "-m", "worker direct fork");
+    git(rootDir, "reset", "--hard", fork);
     const errors: string[] = [];
     const originalError = console.error;
     try {

--- a/packages/kernel/test/store/wal-shadow-event-store.test.ts
+++ b/packages/kernel/test/store/wal-shadow-event-store.test.ts
@@ -9,6 +9,7 @@ import { type TaskCreatedEvent } from "../../src/domain/task-lifecycle.contract.
 import { taskLifecycleWritePlan } from "../../src/domain/task-lifecycle-publication.ts";
 import { sha256Text } from "../../src/integrity/stable-hash.ts";
 import { localWalFileSystem } from "../../src/local/local-layout-file-system.ts";
+import { localGitObjectRefStore } from "../../src/store/local-version-control-system.ts";
 import { makeTaskEventStore as makeGitEventStore } from "../../src/store/task-event-store.ts";
 import { makeWalShadowEventStore } from "../../src/store/wal-shadow-event-store.ts";
 import { openWalEventLog } from "../../src/store/wal-event-log.ts";
@@ -19,11 +20,14 @@ test("S4 acknowledges the durable WAL cut with zero Git processes and immediate 
     initRepo(rootDir);
     const store = makeWalShadowEventStore({ repoId: "wal-shadow", rootDir, walFlushEvents: 64, walFlushMs: 60_000 });
     const bundle = taskBundle(1, "visible on return\n");
-    assert.deepEqual(bundle.plan.targets.filter((target) => target.kind === "local_wal_file"), [
-      { kind: "local_wal_file", path: ".harness/wal/seg-000000.log", operation: "append" },
-      { kind: "local_wal_file", path: ".harness/wal/head.json", operation: "replace" },
-      { kind: "local_wal_file", path: `.harness/wal/objects/${bundle.blobs[0]!.sha256}`, operation: "replace" },
-    ]);
+    assert.deepEqual(
+      bundle.plan.targets.filter((target) => target.kind === "local_wal_file"),
+      [
+        { kind: "local_wal_file", path: ".harness/wal/seg-000000.log", operation: "append" },
+        { kind: "local_wal_file", path: ".harness/wal/head.json", operation: "replace" },
+        { kind: "local_wal_file", path: `.harness/wal/objects/${bundle.blobs[0]!.sha256}`, operation: "replace" },
+      ],
+    );
     const branchBefore = git(rootDir, "rev-parse", "HEAD");
     const receipt = store.append(bundle);
     const wal = openWalEventLog(rootDir);
@@ -36,7 +40,10 @@ test("S4 acknowledges the durable WAL cut with zero Git processes and immediate 
     );
     assert.equal(receipt.metrics.gitProcesses, 0);
     assert.equal(git(rootDir, "rev-parse", "HEAD"), branchBefore);
-    assert.equal(readFileSync(path.join(rootDir, "harness", "tasks", "task-1", "task.md"), "utf8"), "visible on return\n");
+    assert.equal(
+      readFileSync(path.join(rootDir, "harness", "tasks", "task-1", "task.md"), "utf8"),
+      "visible on return\n",
+    );
     assert.equal(existsSync(path.join(rootDir, ".harness", "wal", "seg-000000.log")), true);
     assert.deepEqual(wal.readEvent(bundle.event.opId), bundle.event);
     assert.deepEqual(wal.audit(store.read().events, store.read().revision), {
@@ -57,13 +64,21 @@ test("S4 batches a WAL suffix into one Git commit and garbage-collects local con
     const countBefore = Number(git(rootDir, "rev-list", "--count", "HEAD"));
     for (let revision = 1; revision <= 3; revision += 1)
       assert.equal(store.append(taskBundle(revision, `document ${revision}\n`)).commitSha, null);
-    assert.deepEqual(openWalEventLog(rootDir).records().map((record) => record.revision), [1, 2, 3]);
+    assert.deepEqual(
+      openWalEventLog(rootDir)
+        .records()
+        .map((record) => record.revision),
+      [1, 2, 3],
+    );
     await store.drain();
     assert.equal(Number(git(rootDir, "rev-list", "--count", "HEAD")), countBefore + 1);
     assert.deepEqual(openWalEventLog(rootDir).records(), []);
     assert.deepEqual(readdirSync(path.join(rootDir, ".harness", "wal", "objects")), []);
     const reopened = makeWalShadowEventStore({ repoId: "wal-shadow", rootDir });
-    assert.deepEqual(reopened.read().events.map((event) => event.workspaceRevision), [1, 2, 3]);
+    assert.deepEqual(
+      reopened.read().events.map((event) => event.workspaceRevision),
+      [1, 2, 3],
+    );
     await reopened.drain();
   });
 });
@@ -77,7 +92,10 @@ test("S4 discards a torn WAL tail without losing the acknowledged record", async
     const segment = path.join(rootDir, ".harness", "wal", "seg-000000.log");
     appendFileSync(segment, '{"torn":');
     const reopened = openWalEventLog(rootDir);
-    assert.deepEqual(reopened.records().map((record) => record.revision), [1]);
+    assert.deepEqual(
+      reopened.records().map((record) => record.revision),
+      [1],
+    );
     assert.equal(readFileSync(segment, "utf8").endsWith("\n"), true);
     assert.equal(reopened.audit(store.read().events, store.read().revision).status, "equivalent");
     await store.drain();
@@ -141,6 +159,47 @@ test("materialization failures warn, retry with a bound, and do not revoke the w
   });
 });
 
+test("a master branch ahead of canonical stops the materializer once until refs are repaired", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initRepo(rootDir);
+    const store = makeWalShadowEventStore({
+      repoId: "wal-diverged",
+      rootDir,
+      walFlushEvents: 64,
+      walFlushMs: 1,
+      walRetryBaseMs: 1,
+    });
+    const canonical = git(rootDir, "rev-parse", "refs/ha/canonical");
+    git(rootDir, "commit", "--allow-empty", "-qm", "worker direct commit");
+    const errors: string[] = [];
+    const originalError = console.error;
+    try {
+      console.error = (...args: unknown[]) => errors.push(args.join(" "));
+      store.append(taskBundle(1, "diverged cut\n"));
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      const processesAfterDivergence = localGitObjectRefStore.processCount();
+      store.append(taskBundle(2, "still queued\n"));
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      assert.equal(errors.filter((line) => line.includes("materializer stopped")).length, 1);
+      assert.equal(
+        localGitObjectRefStore.processCount(),
+        processesAfterDivergence,
+        "a stopped materializer must not spin Git calls",
+      );
+      const stopped = store.recover();
+      assert.equal(stopped.status, "indeterminate");
+      assert.match(stopped.error ?? "", new RegExp(`git -C ${rootDir} reset ${canonical}`, "u"));
+      assert.equal(errors.filter((line) => line.includes("materializer stopped")).length, 1);
+      git(rootDir, "reset", "--hard", canonical);
+      const recovered = store.recover();
+      assert.notEqual(recovered.status, "indeterminate");
+      await store.drain();
+    } finally {
+      console.error = originalError;
+    }
+  });
+});
+
 test("restart recovery settles and checkpoints a WAL cut whose Git refs already advanced", async () => {
   await withTempStoreAsync(async (rootDir) => {
     initRepo(rootDir);
@@ -177,8 +236,14 @@ test("a concurrent append burst remains contiguous and materializes as one cut",
     const receipts = await Promise.all(
       Array.from({ length: 24 }, (_, index) => Promise.resolve().then(() => store.append(taskBundle(index + 1)))),
     );
-    assert.equal(receipts.every((receipt) => receipt.commitSha === null && receipt.metrics.gitProcesses === 0), true);
-    assert.deepEqual(store.read().events.map((event) => event.workspaceRevision), Array.from({ length: 24 }, (_, index) => index + 1));
+    assert.equal(
+      receipts.every((receipt) => receipt.commitSha === null && receipt.metrics.gitProcesses === 0),
+      true,
+    );
+    assert.deepEqual(
+      store.read().events.map((event) => event.workspaceRevision),
+      Array.from({ length: 24 }, (_, index) => index + 1),
+    );
     await store.drain();
     assert.equal(git(rootDir, "log", "-1", "--format=%s"), "harness WAL flush 1-24");
   });
@@ -221,8 +286,7 @@ function taskCreated(revision: number): TaskCreatedEvent {
 
 function taskBundle(revision: number, document?: string) {
   const base = taskCreated(revision);
-  if (document === undefined)
-    return { event: base, plan: taskLifecycleWritePlan(base), blobs: [] };
+  if (document === undefined) return { event: base, plan: taskLifecycleWritePlan(base), blobs: [] };
   const claim = {
     path: `tasks/task-${revision}/task.md`,
     sha256: sha256Text(document),


### PR DESCRIPTION
# English

## Summary

Three daemon lifecycle failures observed on 2026-08-25 had no observability and no self-healing: a worker committing directly on the ledger's master branch made the WAL materializer spin on `diverged` (106% CPU, all requests stalled); worker runtime sessions that died left dispatches `unknown` forever and were invisible after a daemon restart; and a daemon whose dist had been rebuilt underneath it silently rejected new methods. This PR makes the materializer latch on divergence and stop, persists the runtime session index so dead sessions settle to `lost` with their exit reason, and fingerprints the build so a stale daemon reports `daemon_build_stale` and restarts once.

## Architectural Justification

Why existing modules cannot carry it: the daemon lifecycle had three independent failure paths with no owner — a ledger divergence that looped hot in the WAL materializer, dead runtime sessions that stayed `running` forever in the session index, and a rebuilt dist silently rejecting new methods from a stale daemon. Each fix lands in the module that already owns that state (materializer, session index, daemon host); no new layer is added.
What obsolete code was removed: the `consecutiveFailures` reset that re-armed the hot loop, and the ad-hoc restart guidance it produced (-29).
Why the scope cannot be narrowed: the three paths are exercised by the same CEO/worker round (doc sync advances the authored branch externally; workers die mid-run; dist is rebuilt while the daemon runs); landing one without the others leaves the round unobservable. The latch fires only on a true fork (canonical parent not an ancestor of the authored parent); external fast-forward stays a supported path, covered by the four shard-3/6 WAL tests.

## What Changed

- `packages/kernel/src/store/wal-shadow-event-store.ts`: removed the new-write reset of `consecutiveFailures` (the hot-loop entry); a `WalMaterializerDivergedError` latches `divergedError` and every flush/retry entry returns until refs are repaired; the receipt/log carries the `git reset` repair command.
- `packages/daemon/src/dispatch-stream.ts`, `dispatch-read.ts`, `json-rpc-server.ts`: runtime session index persisted; on start, dead sessions settle to `lost` with exitCode/signal into the existing `TaskDispatchRow.exitCode/resultRef`; spawn/exit logged.
- `packages/cli/src/daemon/client.ts`: hello compares the dist fingerprint; `withAutostart` retries exactly once on `daemon_build_stale`.
- Tests: divergence stops once and makes no further Git calls; dispatch-stream/dispatch-read 11/11; Docker runtime-spawn-lifecycle 5/5; daemon-build-drift 1/1.

## Machine-Readable Declarations

Production-Delta: +380/-29

## Task And Scope

- Harness task: task_2ae7d91fad74ddf3c6ee99af83 (PLT-Ontology Phase 0.21)
- Branch: `codex/daemon-lifecycle`
- Public scope: kernel WAL materializer, daemon dispatch/session lifecycle, CLI daemon client, tests
- Private planning/evidence updated: yes (artifacts/reports/daemon-lifecycle.md)
- Out of scope: the private ledger pre-commit hook (installed by the CEO from the report) and the pr-await sentinel patch (applied to the CEO skill); public-repo worker hooks are 0.19 (#1810)

## Version Impact

- Version: no version change because this is a pre-release fix on the rebuild line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: daemon protocol hello and dispatch settlement semantics
- Authority: task_2ae7d91fad74ddf3c6ee99af83 (PLT-Ontology Phase 0.21; incident record in milestone task_5fc5080044fcfdbf548008f2f5 task_plan)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 075cb8b8e290e5abdb611180a995b1142a998d6e
- Branch merge-base with `origin/main`: 075cb8b8e290e5abdb611180a995b1142a998d6e
- Last `git fetch origin` time: 2026-08-25T00:08Z
- Sync method: rebase
- Public diff command: `git diff 075cb8b8e290e5abdb611180a995b1142a998d6e..0940481e7`
- Private evidence commit/path: harness task package task_2ae7d91fad74ddf3c6ee99af83 artifacts/reports
- Reviewer evidence path: reviewer ran the Docker-isolated WAL tests (8/8 incl. the divergence latch: exactly one 'materializer stopped' log and zero extra Git calls) and the 11/11 dispatch tests; numstat +380/-30 matches; G36 fixed in ec662142
- GitHub Actions `rewrite-ci` run URL: pending (filled after the run)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test` (Docker-isolated kernel/daemon integration files; check:local on Node 24 (109.7s))
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: integration shards/GUI locally; GitHub CI is the authority for this PR.

## Review Evidence

- Self-review: CEO: each fix deletes or latches rather than retries — no backoff loop, no second dispatch-outcome model; `lost` is a terminal state.
- Reviewer subagent: yes (read-only report audit with independent git verification)
- Human review: pending
- Blocking findings: none

## Residual Risk

- A latched materializer stays stopped until a human repairs the refs; the receipt tells them how. That is the intended failure mode after the 00:44 incident.

## References

- Task: task_2ae7d91fad74ddf3c6ee99af83
- Evidence: artifacts/reports/daemon-lifecycle.md
- Review: pending

---

# 中文

## 概要

2026-08-25 观察到的三种 daemon 生命周期故障既不可观测也不自愈:worker 直接在台账 master 提交让 WAL materializer 在 `diverged` 上空转(106% CPU,全部请求停摆);死掉的 worker 会话让 dispatch 永远 `unknown`、重启后不可见;dist 被重建后的老 daemon 静默拒绝新方法。本 PR 让 materializer 在分叉时锁存停止,持久化 runtime session 索引使死会话结算为 `lost` 并带退出原因,并给构建打指纹让过期 daemon 报 `daemon_build_stale` 并重启一次。

## 架构辩护

现有模块为何无法承载:daemon 生命周期有三条无主失败路径——ledger 分叉在 WAL materializer 里热循环、死掉的 runtime session 在 session index 里永远 `running`、dist 重建后旧 daemon 静默拒绝新方法。每个修复都落在已拥有该状态的模块(materializer / session index / daemon host),不新增层。
删除了哪些废弃代码:重新武装热循环的 `consecutiveFailures` 复位与它产生的临时重启提示(-29)。
为何不能收窄:三条路径由同一轮 CEO/worker 流程触发(doc sync 外部推进 authored 分支;worker 中途死亡;daemon 运行中重建 dist),只落其一则整轮仍不可观测。latch 只在真分叉(canonical parent 不是 authored parent 的祖先)触发;外部 fast-forward 仍是受支持路径,由 shard3/6 四个 WAL 测试覆盖。

## 改动内容

- `packages/kernel/src/store/wal-shadow-event-store.ts`:删除新写入重置 `consecutiveFailures` 的逻辑(热循环入口);`WalMaterializerDivergedError` 锁存 `divergedError`,所有 flush/retry 入口在修复前直接返回;receipt/日志携带 `git reset` 修复命令。
- `packages/daemon/src/dispatch-stream.ts`、`dispatch-read.ts`、`json-rpc-server.ts`:runtime session 索引落盘;启动时死会话结算为 `lost`,exitCode/signal 写入既有 `TaskDispatchRow.exitCode/resultRef`;记录 spawn/exit。
- `packages/cli/src/daemon/client.ts`:hello 比对 dist 指纹;`withAutostart` 在 `daemon_build_stale` 时恰好重试一次。
- 测试:分叉只停一次且不再调 Git;dispatch-stream/dispatch-read 11/11;Docker runtime-spawn-lifecycle 5/5;daemon-build-drift 1/1。

## 机读声明说明

- 机读声明只在英文块出现一次。

## 任务与范围

- Harness 任务:task_2ae7d91fad74ddf3c6ee99af83(PLT-Ontology Phase 0.21)
- 分支:`codex/daemon-lifecycle`
- 公开范围:kernel WAL materializer、daemon dispatch/session 生命周期、CLI daemon client、测试
- 私有计划 / 证据是否已更新:yes(artifacts/reports/daemon-lifecycle.md)
- 范围外:私有台账 pre-commit hook(CEO 按回执安装)与 pr-await 哨兵补丁(已应用到 CEO skill);公开仓 worker hook 归 0.19(#1810)

## 版本影响

- 版本:不改版本,原因是 rebuild 线 pre-release 修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:yes
- protected surface 范围:daemon protocol hello and dispatch settlement semantics
- 依据:task_2ae7d91fad74ddf3c6ee99af83 (PLT-Ontology Phase 0.21; incident record in milestone task_5fc5080044fcfdbf548008f2f5 task_plan)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:075cb8b8e290e5abdb611180a995b1142a998d6e
- 当前分支与 `origin/main` 的 merge-base:075cb8b8e290e5abdb611180a995b1142a998d6e
- 最近一次 `git fetch origin` 时间:2026-08-25T00:08Z
- 同步方式:rebase
- 公开 diff 命令:`git diff 075cb8b8e290e5abdb611180a995b1142a998d6e..0940481e7`
- 私有证据 commit/path:任务包 artifacts/reports
- Reviewer 证据路径:reviewer 实跑 Docker 隔离 WAL 测试(8/8,含分叉锁存:恰好一条 'materializer stopped' 日志、零额外 Git 调用)与 11/11 dispatch 测试;numstat +380/-30 一致;G36 在 ec662142 修复
- GitHub Actions `rewrite-ci` run URL:待 run 结束后补
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`(Docker 隔离 kernel/daemon integration 文件;Node 24 check:local(109.7s))
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:本地 integration shards/GUI;GitHub CI 是本 PR 的权威。

## 审查证据

- 自查:CEO:每项修复都是删除或锁存而非重试——无退避循环、无第二套 dispatch outcome 模型;`lost` 是终态。
- Reviewer subagent:有(只读回执审计 + git 独立核实)
- 人工审查:待
- 阻塞发现:无

## 残余风险

- 锁存后的 materializer 保持停止直到人工修复 refs;receipt 告知修法。这正是 00:44 事故后想要的失败形态。

## 关联材料

- 任务:task_2ae7d91fad74ddf3c6ee99af83
- 证据:artifacts/reports/daemon-lifecycle.md
- 审查:待

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPPk3TmbURWuxcFY3kFimA

