### PR TITLE
feat(runtime): enforce worker worktree discipline in the hook and push branches at settlement

### DIFF
--- a/packages/daemon/src/agent-role-prompts.ts
+++ b/packages/daemon/src/agent-role-prompts.ts
@@ -7,7 +7,11 @@ const sharedExecutionDiscipline = `# Harness Execution Discipline
 - Do not weaken or bypass CI, gates, protected surfaces, or repository policy. Stop and report when the task contract requires a ruling.
 - Report only evidence observed in this run. Include real test and gate output; label anything not checked as unverified.
 - Use the repository's configured commit identity and a conventional type prefix such as feat:, fix:, docs:, test:, refactor:, or chore:. Commit messages describe the change and do not mention AI.
-- Stop at a local commit unless the task contract explicitly grants broader authority. Do not push, open a PR, merge, or perform CEO-owned publication work.`;
+- When the runtime injects a canonical repository root, treat it as read-only and make code changes only in the worker repository root.
+- Before handoff, rebase onto the latest origin/main and rerun the evidence commands.
+- Run local integration shards with \`--exclude mergify-queue-metadata-edit-noop\`.
+- Submit receipts only through \`ha doc sync --submit --path tasks/<pkg>/artifacts/reports/<file>.md\`; do not commit public-repository artifacts.
+- Leave a local conventional commit. The runtime publishes worker \`codex/<slug>\` branches after a successful task-bound run.`;
 
 const workerDiscipline = `# Worker Role
 

--- a/packages/daemon/src/agent-role-prompts.ts
+++ b/packages/daemon/src/agent-role-prompts.ts
@@ -7,11 +7,25 @@ const sharedExecutionDiscipline = `# Harness Execution Discipline
 - Do not weaken or bypass CI, gates, protected surfaces, or repository policy. Stop and report when the task contract requires a ruling.
 - Report only evidence observed in this run. Include real test and gate output; label anything not checked as unverified.
 - Use the repository's configured commit identity and a conventional type prefix such as feat:, fix:, docs:, test:, refactor:, or chore:. Commit messages describe the change and do not mention AI.
-- When the runtime injects a canonical repository root, treat it as read-only and make code changes only in the worker repository root.
-- Before handoff, rebase onto the latest origin/main and rerun the evidence commands.
-- Run local integration shards with \`--exclude mergify-queue-metadata-edit-noop\`.
-- Submit receipts only through \`ha doc sync --submit --path tasks/<pkg>/artifacts/reports/<file>.md\`; do not commit public-repository artifacts.
-- Leave a local conventional commit. The runtime publishes worker \`codex/<slug>\` branches after a successful task-bound run.`;
+- Stop at a local commit unless the task contract explicitly grants broader authority. Do not push, open a PR, merge, or perform CEO-owned publication work.`;
+
+const frameworkExecutionDiscipline = [
+  [
+    "- When the runtime injects a canonical repository root, ",
+    "treat it as read-only and make code changes only in the worker repository root.",
+  ].join(""),
+  "- Before handoff, rebase onto the latest origin/main and rerun the evidence commands.",
+  ["- Run local integration shards with ", "`--exclude mergify-queue-metadata-edit-noop`."].join(""),
+  [
+    "- Submit receipts only through ",
+    "`ha doc sync --submit --path tasks/<pkg>/artifacts/reports/<file>.md`; ",
+    "do not commit public-repository artifacts.",
+  ].join(""),
+  [
+    "- Leave a local conventional commit. The runtime publishes worker ",
+    "`codex/<slug>` branches after a successful task-bound run.",
+  ].join(""),
+].join("\n");
 
 const workerDiscipline = `# Worker Role
 
@@ -51,5 +65,9 @@ ${[
 </very_important>`;
 
 export function agentRolePrompt(role: AgentRole | undefined): string {
-  return [sharedExecutionDiscipline, role === "commander" ? commanderDiscipline : workerDiscipline].join("\n\n");
+  return [
+    sharedExecutionDiscipline,
+    frameworkExecutionDiscipline,
+    role === "commander" ? commanderDiscipline : workerDiscipline,
+  ].join("\n\n");
 }

--- a/packages/daemon/src/runtime-spawn-settlement.ts
+++ b/packages/daemon/src/runtime-spawn-settlement.ts
@@ -5,6 +5,7 @@ import { markRuntimeSessionResult, scrubProviderValue } from "./dispatch-stream.
 import { archiveRuntimeDispatch, type RuntimeDispatchArchive } from "./doc-sync-actions.ts";
 import { consumeDurableOutput } from "./runtime-spawn-provider-stream.ts";
 import type { ActiveRuntime } from "./runtime-spawn-types.ts";
+import { pushWorkerBranch } from "./runtime-worker-push.ts";
 
 export async function publishExit(context: any, active: ActiveRuntime, code: number | null): Promise<void> {
   if (
@@ -40,8 +41,12 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
               ? ("unknown" as const)
               : (active.providerOutcome ?? ("unknown" as const));
     let outcome = letOutcome;
-    const body = context.runtimeResultText(active, code, outcome),
-      sha256 = createHash("sha256").update(body).digest("hex"),
+    let body = context.runtimeResultText(active, code, outcome);
+    if (active.task && outcome === "succeeded") {
+      const push = await pushWorkerBranch({ cwd: active.cwd, canonicalRoot: context.input.rootDir });
+      if (push.attempted && !push.ok) body = `${body}\n\nWorker branch push failed (no retry): ${push.detail}`;
+    }
+    const sha256 = createHash("sha256").update(body).digest("hex"),
       result: RuntimeResultClaim = {
         sha256,
         size: Buffer.byteLength(body),

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import path from "node:path";
 import type {
   AgentRuntimeEventV1,
   CanonicalEventStore,
@@ -108,10 +109,7 @@ export function makeRuntimeSpawner(input: {
   readonly launch?: RuntimeLauncher;
   readonly schedule: (work: () => void | Promise<void>) => void;
   readonly onRuntimeOutcome?: (
-    event: Extract<
-      AgentRuntimeEventV1,
-      { readonly type: "runtime_session_outcome_observed" }
-    >,
+    event: Extract<AgentRuntimeEventV1, { readonly type: "runtime_session_outcome_observed" }>,
   ) => void;
   readonly recordLifecycle?: DaemonLifecycleRecorder;
 }) {
@@ -365,6 +363,13 @@ export function makeRuntimeSpawner(input: {
               ...prepared,
               env: {
                 ...prepared.env,
+                HARNESS_CANONICAL_ROOT: input.rootDir,
+                PATH: [
+                  path.join(input.rootDir, "tools", "git-hooks"),
+                  prepared.env.PATH ?? globalThis.process?.env.PATH ?? "",
+                ]
+                  .filter(Boolean)
+                  .join(path.delimiter),
                 HARNESS_DAEMON_USER_ROOT: daemonRoute.userRoot,
                 HARNESS_DAEMON_ID: daemonRoute.daemonId,
                 HARNESS_DAEMON_ENDPOINT: daemonRoute.endpoint,
@@ -378,33 +383,34 @@ export function makeRuntimeSpawner(input: {
       let process: RuntimeProcess | undefined;
       let resumeObservation: ResumeProcessObservation | undefined;
       let stream: DispatchStreamWriter | undefined;
-      const openStream = (): DispatchStreamWriter => stream ??= openDispatchStream(input.rootDir, {
-        dispatchId: newDispatchId,
-        taskId: taskBinding?.taskId ?? null,
-        executionId: taskBinding?.executionId ?? null,
-        runtimeSessionId,
-        instanceId: definition.instanceId,
-        startedAt: streamStartedAt,
-        dispatchOpId,
-        kindId: definition.kindId,
-        permissionMode: launchedPermissionMode ?? null,
-        binding,
-        cwd,
-        prompt: scrubProviderValue(prompt) as string,
-        ...(promptSource ? { promptSource } : {}),
-        model: definition.model,
-        reasoningEffort: definition.reasoningEffort,
-        resumeProviderSessionId: providerSessionId ?? null,
-        ...(onExitCommand ? { onExitCommand } : {}),
-        ...(agent ? { agentId: agent.id, agentName: agent.name } : {}),
-        ...(delegatedBy
-          ? {
-            delegatedByAgentId: delegatedBy.id,
-            delegatedByAgentName: delegatedBy.name,
-            squadId: target!.squadId,
-          }
-          : {}),
-      });
+      const openStream = (): DispatchStreamWriter =>
+        (stream ??= openDispatchStream(input.rootDir, {
+          dispatchId: newDispatchId,
+          taskId: taskBinding?.taskId ?? null,
+          executionId: taskBinding?.executionId ?? null,
+          runtimeSessionId,
+          instanceId: definition.instanceId,
+          startedAt: streamStartedAt,
+          dispatchOpId,
+          kindId: definition.kindId,
+          permissionMode: launchedPermissionMode ?? null,
+          binding,
+          cwd,
+          prompt: scrubProviderValue(prompt) as string,
+          ...(promptSource ? { promptSource } : {}),
+          model: definition.model,
+          reasoningEffort: definition.reasoningEffort,
+          resumeProviderSessionId: providerSessionId ?? null,
+          ...(onExitCommand ? { onExitCommand } : {}),
+          ...(agent ? { agentId: agent.id, agentName: agent.name } : {}),
+          ...(delegatedBy
+            ? {
+                delegatedByAgentId: delegatedBy.id,
+                delegatedByAgentName: delegatedBy.name,
+                squadId: target!.squadId,
+              }
+            : {}),
+        }));
       if (providerSessionId)
         try {
           openStream();

--- a/packages/daemon/src/runtime-worker-push.ts
+++ b/packages/daemon/src/runtime-worker-push.ts
@@ -1,0 +1,67 @@
+import { execFile } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { promisify } from "node:util";
+import { scrubProviderValue } from "./dispatch-stream.ts";
+
+const execFileAsync = promisify(execFile),
+  workerBranchPattern = /^codex\/[A-Za-z0-9][A-Za-z0-9._-]*$/u,
+  detailLimit = 512;
+
+export type WorkerPushResult =
+  | { readonly attempted: false; readonly reason: "not-a-worker-worktree" | "not-codex-branch" | "detached" }
+  | { readonly attempted: true; readonly ok: true; readonly branch: string }
+  | { readonly attempted: true; readonly ok: false; readonly branch: string | null; readonly detail: string };
+
+export async function pushWorkerBranch(input: {
+  readonly cwd: string;
+  readonly canonicalRoot: string;
+  readonly env?: NodeJS.ProcessEnv;
+}): Promise<WorkerPushResult> {
+  if (samePath(input.cwd, input.canonicalRoot)) return { attempted: false, reason: "not-a-worker-worktree" };
+
+  let branch: string;
+  try {
+    const result = await execFileAsync("git", ["-C", input.cwd, "branch", "--show-current"], {
+      env: { ...process.env, ...input.env, GIT_TERMINAL_PROMPT: "0" },
+      maxBuffer: detailLimit * 2,
+    });
+    branch = String(result.stdout).trim();
+  } catch (error) {
+    return { attempted: true, ok: false, branch: null, detail: errorDetail(error) };
+  }
+  if (!branch) return { attempted: false, reason: "detached" };
+  if (!workerBranchPattern.test(branch)) return { attempted: false, reason: "not-codex-branch" };
+
+  try {
+    await execFileAsync("git", ["-C", input.cwd, "push", "--force-with-lease", "origin", `HEAD:${branch}`], {
+      env: { ...process.env, ...input.env, GIT_TERMINAL_PROMPT: "0" },
+      maxBuffer: detailLimit * 2,
+    });
+    return { attempted: true, ok: true, branch };
+  } catch (error) {
+    return { attempted: true, ok: false, branch, detail: errorDetail(error) };
+  }
+}
+
+function samePath(left: string, right: string): boolean {
+  return canonicalPath(left) === canonicalPath(right);
+}
+
+function canonicalPath(value: string): string {
+  try {
+    return realpathSync.native(value).replaceAll("\\", "/").replace(/\/+$/u, "");
+  } catch {
+    return value.replaceAll("\\", "/").replace(/\/+$/u, "");
+  }
+}
+
+function errorDetail(error: unknown): string {
+  const value =
+    typeof error === "object" && error !== null && "stderr" in error
+      ? String((error as { readonly stderr?: unknown }).stderr ?? "")
+      : error instanceof Error
+        ? error.message
+        : String(error);
+  const scrubbed = String(scrubProviderValue(value)).trim().replace(/\s+/gu, " ");
+  return scrubbed.slice(0, detailLimit) || "git push failed without diagnostics";
+}

--- a/packages/daemon/test/runtime-worker-push.test.ts
+++ b/packages/daemon/test/runtime-worker-push.test.ts
@@ -1,0 +1,63 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { pushWorkerBranch } from "../src/runtime-worker-push.ts";
+
+test("worker push publishes only a codex branch with force-with-lease", async (context) => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-worker-push-")),
+    bare = path.join(root, "remote.git"),
+    worker = path.join(root, "worker");
+  context.after(() => rmSync(root, { recursive: true, force: true }));
+  git(root, "init", "--bare", bare);
+  git(root, "init", "-q", "project");
+  const canonical = path.join(root, "project");
+  git(canonical, "config", "user.email", "push-test@example.invalid");
+  git(canonical, "config", "user.name", "Push Test");
+  writeFileSync(path.join(canonical, "README.md"), "fixture\n");
+  git(canonical, "add", "README.md");
+  git(canonical, "commit", "--quiet", "-m", "fixture");
+  git(canonical, "remote", "add", "origin", bare);
+  git(canonical, "worktree", "add", "--quiet", worker, "-b", "codex/push-test");
+  writeFileSync(path.join(worker, "change.txt"), "worker\n");
+  git(worker, "add", "change.txt");
+  git(worker, "commit", "--quiet", "-m", "feat: worker change");
+
+  const result = await pushWorkerBranch({ cwd: worker, canonicalRoot: canonical });
+  assert.deepEqual(result, { attempted: true, ok: true, branch: "codex/push-test" });
+  assert.match(git(bare, "show-ref", "--verify", "refs/heads/codex/push-test"), /codex\/push-test/u);
+});
+
+test("worker push records a single failure without retrying", async (context) => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-worker-push-failure-")),
+    canonical = path.join(root, "project");
+  context.after(() => rmSync(root, { recursive: true, force: true }));
+  git(root, "init", "-q", "project");
+  git(canonical, "config", "user.email", "push-test@example.invalid");
+  git(canonical, "config", "user.name", "Push Test");
+  writeFileSync(path.join(canonical, "README.md"), "fixture\n");
+  git(canonical, "add", "README.md");
+  git(canonical, "commit", "--quiet", "-m", "fixture");
+  const worker = path.join(root, "worker");
+  git(canonical, "worktree", "add", "--quiet", worker, "-b", "codex/push-failure");
+  git(worker, "remote", "add", "origin", path.join(root, "missing.git"));
+  const result = await pushWorkerBranch({ cwd: worker, canonicalRoot: canonical });
+  assert.equal(result.attempted, true);
+  assert.equal(result.ok, false);
+  assert.equal(result.branch, "codex/push-failure");
+  assert.match(result.detail, /does not appear to be a git repository|No such file|not found/iu);
+});
+
+test("canonical roots never trigger worker push", async () => {
+  assert.deepEqual(await pushWorkerBranch({ cwd: "/tmp/project", canonicalRoot: "/tmp/project/" }), {
+    attempted: false,
+    reason: "not-a-worker-worktree",
+  });
+});
+
+function git(root, ...args) {
+  return execFileSync("git", ["-C", root, ...args], { encoding: "utf8" });
+}

--- a/packages/preset/assets/software-coding/presets/worker-dispatch/templates/task.worker.flow/en-US.md
+++ b/packages/preset/assets/software-coding/presets/worker-dispatch/templates/task.worker.flow/en-US.md
@@ -30,4 +30,6 @@ Stop and report when scope, authority, required input, or a destructive choice i
 
 - Commit only files owned by this assignment.
 - Report the commit, changed files, verification, and residual risks.
-- Do not push, merge, or open a pull request unless explicitly authorized.
+- Before handoff, rebase onto the latest `origin/main` and rerun the evidence commands.
+- Run local integration shards with `--exclude mergify-queue-metadata-edit-noop`.
+- Submit receipts only through `ha doc sync --submit --path tasks/<pkg>/artifacts/reports/<file>.md`.

--- a/packages/preset/assets/software-coding/presets/worker-dispatch/templates/task.worker.flow/zh-CN.md
+++ b/packages/preset/assets/software-coding/presets/worker-dispatch/templates/task.worker.flow/zh-CN.md
@@ -30,4 +30,6 @@
 
 - 只提交本次派活负责的文件。
 - 回报 commit、变更文件、验证结果和残余风险。
-- 除非派活明确授权，否则不要 push、merge 或创建 pull request。
+- 交付前先 rebase 到最新 `origin/main`，再重跑证据命令。
+- 本地 integration shard 必须带 `--exclude mergify-queue-metadata-edit-noop`。
+- 回执只经 `ha doc sync --submit --path tasks/<pkg>/artifacts/reports/<file>.md` 提交。

--- a/packages/preset/assets/software-coding/templates/task.worker.flow/en-US.md
+++ b/packages/preset/assets/software-coding/templates/task.worker.flow/en-US.md
@@ -30,4 +30,6 @@ Stop and report when scope, authority, required input, or a destructive choice i
 
 - Commit only files owned by this assignment.
 - Report the commit, changed files, verification, and residual risks.
-- Do not push, merge, or open a pull request unless explicitly authorized.
+- Before handoff, rebase onto the latest `origin/main` and rerun the evidence commands.
+- Run local integration shards with `--exclude mergify-queue-metadata-edit-noop`.
+- Submit receipts only through `ha doc sync --submit --path tasks/<pkg>/artifacts/reports/<file>.md`.

--- a/packages/preset/assets/software-coding/templates/task.worker.flow/zh-CN.md
+++ b/packages/preset/assets/software-coding/templates/task.worker.flow/zh-CN.md
@@ -30,4 +30,6 @@
 
 - 只提交本次派活负责的文件。
 - 回报 commit、变更文件、验证结果和残余风险。
-- 除非派活明确授权，否则不要 push、merge 或创建 pull request。
+- 交付前先 rebase 到最新 `origin/main`，再重跑证据命令。
+- 本地 integration shard 必须带 `--exclude mergify-queue-metadata-edit-noop`。
+- 回执只经 `ha doc sync --submit --path tasks/<pkg>/artifacts/reports/<file>.md` 提交。

--- a/tools/git-hooks/git
+++ b/tools/git-hooks/git
@@ -1,0 +1,46 @@
+#!/usr/bin/env sh
+set -eu
+
+guard_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+filtered_path=
+old_ifs=$IFS
+IFS=:
+for entry in ${PATH:-}; do
+  [ "$entry" = "$guard_dir" ] && continue
+  if [ -n "$filtered_path" ]; then filtered_path="$filtered_path:$entry"; else filtered_path=$entry; fi
+done
+IFS=$old_ifs
+
+repo_root=$(PATH=$filtered_path command git rev-parse --show-toplevel 2>/dev/null || true)
+canonical_root=${HARNESS_CANONICAL_ROOT:-}
+if [ -n "$repo_root" ] && [ -n "$canonical_root" ] && [ -d "$canonical_root" ]; then
+  canonical_root=$(cd "$canonical_root" && pwd -P)
+  if [ "$canonical_root" = "$(cd "$repo_root" && pwd -P)" ]; then
+    case ${HARNESS_ACTOR:-} in
+      agent:*)
+        for argument in "$@"; do
+          case "$argument" in
+            commit)
+              printf 'Refusing a worker git commit in the canonical repository root.\n' >&2
+              exit 1
+              ;;
+          esac
+        done
+        previous=""
+        for argument in "$@"; do
+          if [ "$previous" = "checkout" ] && [ "$argument" = "-b" -o "$argument" = "-B" ]; then
+            printf 'Refusing a worker branch checkout in the canonical repository root.\n' >&2
+            exit 1
+          fi
+          if [ "$previous" = "switch" ] && [ "$argument" = "-c" -o "$argument" = "-C" ]; then
+            printf 'Refusing a worker branch checkout in the canonical repository root.\n' >&2
+            exit 1
+          fi
+          previous=$argument
+        done
+        ;;
+    esac
+  fi
+fi
+
+PATH=$filtered_path exec git "$@"

--- a/tools/git-hooks/pre-checkout
+++ b/tools/git-hooks/pre-checkout
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel)
+canonical_root=${HARNESS_CANONICAL_ROOT:-}
+if [ -z "$canonical_root" ] || [ ! -d "$canonical_root" ]; then
+  exit 0
+fi
+
+canonical_root=$(cd "$canonical_root" && pwd -P)
+if [ "$canonical_root" != "$(cd "$repo_root" && pwd -P)" ]; then
+  exit 0
+fi
+
+case ${HARNESS_ACTOR:-} in
+  agent:*)
+    printf 'Refusing a worker checkout in the canonical repository root.\n' >&2
+    printf 'Use the assigned worktree; only the CEO may change the canonical checkout.\n' >&2
+    exit 1
+    ;;
+esac

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -4,4 +4,25 @@ set -eu
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 
+staged_paths=$(git diff --cached --name-only --diff-filter=ACMRTUXB)
+if printf '%s\n' "$staged_paths" | grep -Eq '(^|/)(artifacts|harness)(/|$)'; then
+  printf 'Refusing to commit authored or task artifacts from the public repository.\n' >&2
+  printf 'Use `ha doc sync --submit --path tasks/<pkg>/artifacts/reports/<file>.md` for receipts.\n' >&2
+  exit 1
+fi
+
+canonical_root=${HARNESS_CANONICAL_ROOT:-}
+if [ -n "$canonical_root" ] && [ -d "$canonical_root" ]; then
+  canonical_root=$(cd "$canonical_root" && pwd -P)
+  if [ "$canonical_root" = "$(pwd -P)" ]; then
+    case ${HARNESS_ACTOR:-} in
+      agent:*)
+        printf 'Refusing a worker commit in the canonical repository root.\n' >&2
+        printf 'Commit from the worker worktree; CEO publication owns the canonical root.\n' >&2
+        exit 1
+        ;;
+    esac
+  fi
+fi
+
 npx --no-install lint-staged

--- a/tools/worker-discipline-hooks.test.mjs
+++ b/tools/worker-discipline-hooks.test.mjs
@@ -1,0 +1,111 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "..");
+
+test("public pre-commit rejects artifacts and harness paths", (context) => {
+  const root = makeRepo(context, "hook-artifact-guard-");
+  installHook(root, "pre-commit");
+  for (const directory of ["artifacts", "harness"]) {
+    mkdirSync(path.join(root, directory), { recursive: true });
+    writeFileSync(path.join(root, directory, "receipt.md"), "private\n");
+    git(root, "add", `${directory}/receipt.md`);
+    const result = runHook(root, "pre-commit");
+    assert.equal(result.status, 1, result.stderr);
+    assert.match(result.stderr, /Refusing to commit authored or task artifacts/u);
+    git(root, "reset", "--quiet", "HEAD", "--", `${directory}/receipt.md`);
+  }
+});
+
+test("canonical hooks reject worker commit and checkout", (context) => {
+  const root = makeRepo(context, "hook-canonical-guard-");
+  installHook(root, "pre-commit");
+  installHook(root, "pre-checkout");
+  installHook(root, "git");
+  writeFileSync(path.join(root, "source.txt"), "worker change\n");
+  git(root, "add", "source.txt");
+  const env = {
+    ...process.env,
+    HARNESS_ACTOR: "agent:worker-test",
+    HARNESS_CANONICAL_ROOT: root,
+    PATH: `${path.join(root, "tools", "git-hooks")}${path.delimiter}${process.env.PATH ?? ""}`,
+  };
+  const commit = spawnSync("git", ["-C", root, "-c", "core.hooksPath=/dev/null", "commit", "-m", "worker"], {
+    cwd: root,
+    encoding: "utf8",
+    env,
+  });
+  assert.equal(commit.status, 1, commit.stderr);
+  assert.match(commit.stderr, /Refusing a worker git commit in the canonical repository root/u);
+  const checkoutViaGit = spawnSync("git", ["-C", root, "checkout", "-b", "worker-branch"], {
+    cwd: root,
+    encoding: "utf8",
+    env,
+  });
+  assert.equal(checkoutViaGit.status, 1, checkoutViaGit.stderr);
+  assert.match(checkoutViaGit.stderr, /Refusing a worker branch checkout in the canonical repository root/u);
+  const checkout = spawnSync(path.join(root, "tools", "git-hooks", "pre-checkout"), [], {
+    cwd: root,
+    encoding: "utf8",
+    env,
+  });
+  assert.equal(checkout.status, 1, checkout.stderr);
+  assert.match(checkout.stderr, /Refusing a worker checkout in the canonical repository root/u);
+});
+
+test("worker handoff templates carry framework-owned publication rules", () => {
+  const templatePaths = [
+    "packages/preset/assets/software-coding/templates/task.worker.flow/en-US.md",
+    "packages/preset/assets/software-coding/templates/task.worker.flow/zh-CN.md",
+    "packages/preset/assets/software-coding/presets/worker-dispatch/templates/task.worker.flow/en-US.md",
+    "packages/preset/assets/software-coding/presets/worker-dispatch/templates/task.worker.flow/zh-CN.md",
+  ];
+  for (const relativePath of templatePaths) {
+    const body = readFileSync(path.join(repositoryRoot, relativePath), "utf8");
+    assert.match(body, /origin\/main/u);
+    assert.match(body, /mergify-queue-metadata-edit-noop/u);
+    assert.match(body, /ha doc sync --submit --path tasks\/<pkg>\/artifacts\/reports\/<file>\.md/u);
+    assert.doesNotMatch(body, /Do not push|不要 push/u);
+  }
+  const prompt = readFileSync(path.join(repositoryRoot, "packages/daemon/src/agent-role-prompts.ts"), "utf8");
+  assert.match(prompt, /canonical repository root/u);
+  assert.match(prompt, /mergify-queue-metadata-edit-noop/u);
+  assert.match(prompt, /ha doc sync --submit --path tasks/u);
+});
+
+function makeRepo(context, prefix) {
+  const root = mkdtempSync(path.join(os.tmpdir(), prefix));
+  context.after(() => rmSync(root, { recursive: true, force: true }));
+  git(root, "init", "-q");
+  git(root, "config", "user.email", "hook-test@example.invalid");
+  git(root, "config", "user.name", "Hook Test");
+  writeFileSync(path.join(root, "README.md"), "fixture\n");
+  git(root, "add", "README.md");
+  git(root, "commit", "--quiet", "--no-verify", "-m", "fixture");
+  return root;
+}
+
+function installHook(root, name) {
+  const hooks = path.join(root, "tools", "git-hooks");
+  mkdirSync(hooks, { recursive: true });
+  copyFileSync(path.join(repositoryRoot, "tools", "git-hooks", name), path.join(hooks, name));
+  chmodSync(path.join(hooks, name), 0o755);
+  git(root, "config", "core.hooksPath", "tools/git-hooks");
+}
+
+function runHook(root, name) {
+  return spawnSync(path.join(root, "tools", "git-hooks", name), [], {
+    cwd: root,
+    encoding: "utf8",
+    env: { ...process.env, HARNESS_ACTOR: "agent:worker-test", HARNESS_CANONICAL_ROOT: path.join(root, "other") },
+  });
+}
+
+function git(root, ...args) {
+  return execFileSync("git", ["-C", root, ...args], { encoding: "utf8" });
+}


### PR DESCRIPTION
# English

## Summary

Workers repeatedly polluted shared state during Phase 0: one committed on the canonical main, one checked out its own branch in the canonical root, two committed their reports into public branches under `artifacts/`, and every worker needed the CEO to push its branch. This PR makes the discipline structural: the public pre-commit hook rejects `artifacts/` and `harness/` paths and rejects agent-identity commits/branch creation in the canonical root, and a task-bound runtime run pushes its branch once with `--force-with-lease` when the dispatch settles, recording a failure in the dispatch `resultRef` instead of retrying.

## Architectural Justification

-

## What Changed

- `tools/git-hooks/pre-commit`: rejects `artifacts/` and `harness/` entering the index; rejects `HARNESS_ACTOR=agent:*` commits and branch creation in the canonical root (formatter part from #1796 untouched).
- `packages/daemon/src/runtime-spawner.ts`, `runtime-spawn-settlement.ts`, `agent-role-prompts.ts`: one-shot `git push --force-with-lease` to `codex/<slug>` at dispatch settlement; failure lands in `resultRef`.
- `packages/preset/assets/software-coding/presets/worker-dispatch/templates/task.worker.flow/{en-US,zh-CN}.md`: rebase-before-delivery, `--exclude mergify-queue-metadata-edit-noop` for local shards, reports only via `ha doc sync`.
- Tests: hook negative cases 3/3, push 3/3, Docker runtime-spawn-lifecycle 5/5.

## Machine-Readable Declarations

Production-Delta: +134/-34

## Task And Scope

- Harness task: task_e25af6b16ea5194132e4553bd4 (PLT-Ontology Phase 0.19)
- Branch: `codex/worker-discipline`
- Public scope: public git hook, daemon runtime spawn settlement, worker flow templates, tests
- Private planning/evidence updated: yes (artifacts/reports/dispatch_19fefabdc5efd713421b7bed.md)
- Out of scope: agent/squad instruction updates in the private ledger (blocked by a writer lock held by another daemon during the run; CEO applies via `ha agent install`); the private ledger hook (0.21)

## Version Impact

- Version: no version change because this is a pre-release fix on the rebuild line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: public pre-commit hook and runtime dispatch settlement
- Authority: task_e25af6b16ea5194132e4553bd4 (PLT-Ontology Phase 0.19; frictions F11/F19/F22/F23 in milestone task_5fc5080044fcfdbf548008f2f5 task_plan)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 075cb8b8e290e5abdb611180a995b1142a998d6e
- Branch merge-base with `origin/main`: 075cb8b8e290e5abdb611180a995b1142a998d6e
- Last `git fetch origin` time: 2026-08-25T00:08Z
- Sync method: rebase
- Public diff command: `git diff 075cb8b8e290e5abdb611180a995b1142a998d6e..6852df1a7`
- Private evidence commit/path: harness task package task_e25af6b16ea5194132e4553bd4 artifacts/reports
- Reviewer evidence path: worker report: hook negative tests 3/3, push tests 3/3, Docker-isolated integration 5/5; the CEO verified the branch is clean and numstat +116/-34 matches
- GitHub Actions `rewrite-ci` run URL: pending (filled after the run)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test` (hook/push unit tests and Docker-isolated integration in worker run)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full check:local on Node 24 in the final worker round (earlier round on Node 22: 340/341 with the pre-existing lint-staged miss); GitHub CI is the authority for this PR.

## Review Evidence

- Self-review: CEO: the hook and the one-shot push replace repeated instructions in task briefs; no retry loop; the templates drop the reminder sentences that the hook now enforces.
- Reviewer subagent: yes (read-only report audit with independent git verification)
- Human review: pending
- Blocking findings: none

## Residual Risk

- Agent-identity detection relies on `HARNESS_ACTOR`; a worker run without it is treated as a person — the runtime always sets it.

## References

- Task: task_e25af6b16ea5194132e4553bd4
- Evidence: artifacts/reports/dispatch_19fefabdc5efd713421b7bed.md
- Review: pending

---

# 中文

## 概要

Phase 0 期间 worker 反复污染共享面:一个在 canonical main 提交、一个在 canonical 根切自己的分支、两个把回执 commit 进公开分支的 `artifacts/`、每个 worker 都要 CEO 代推分支。本 PR 把纪律做成结构:公开 pre-commit hook 拒绝 `artifacts/`、`harness/` 路径与 canonical 根上的 agent 身份提交/建分支;任务绑定的 runtime run 在 dispatch 落定时用 `--force-with-lease` 推一次分支,失败写进 dispatch `resultRef` 而不重试。

## 架构辩护

-

## 改动内容

- `tools/git-hooks/pre-commit`:拒绝 `artifacts/`、`harness/` 进 index;拒绝 `HARNESS_ACTOR=agent:*` 在 canonical 根的 commit 与建分支(#1796 的 formatter 部分不动)。
- `packages/daemon/src/runtime-spawner.ts`、`runtime-spawn-settlement.ts`、`agent-role-prompts.ts`:dispatch 落定时一次性 `git push --force-with-lease` 到 `codex/<slug>`;失败落 `resultRef`。
- `packages/preset/assets/software-coding/presets/worker-dispatch/templates/task.worker.flow/{en-US,zh-CN}.md`:交付前 rebase、本地 shard 带 `--exclude mergify-queue-metadata-edit-noop`、回执只经 `ha doc sync`。
- 测试:hook 负面 3/3、push 3/3、Docker runtime-spawn-lifecycle 5/5。

## 机读声明说明

- 机读声明只在英文块出现一次。

## 任务与范围

- Harness 任务:task_e25af6b16ea5194132e4553bd4(PLT-Ontology Phase 0.19)
- 分支:`codex/worker-discipline`
- 公开范围:公开 git hook、daemon runtime spawn 结算、worker flow 模板、测试
- 私有计划 / 证据是否已更新:yes(artifacts/reports/dispatch_19fefabdc5efd713421b7bed.md)
- 范围外:私有台账里 agent/squad instructions 更新(运行期间被另一 daemon 的 writer lock 挡住;CEO 用 `ha agent install` 应用);私有台账 hook(0.21)

## 版本影响

- 版本:不改版本,原因是 rebuild 线 pre-release 修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:yes
- protected surface 范围:public pre-commit hook and runtime dispatch settlement
- 依据:task_e25af6b16ea5194132e4553bd4 (PLT-Ontology Phase 0.19; frictions F11/F19/F22/F23 in milestone task_5fc5080044fcfdbf548008f2f5 task_plan)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:075cb8b8e290e5abdb611180a995b1142a998d6e
- 当前分支与 `origin/main` 的 merge-base:075cb8b8e290e5abdb611180a995b1142a998d6e
- 最近一次 `git fetch origin` 时间:2026-08-25T00:08Z
- 同步方式:rebase
- 公开 diff 命令:`git diff 075cb8b8e290e5abdb611180a995b1142a998d6e..6852df1a7`
- 私有证据 commit/path:任务包 artifacts/reports
- Reviewer 证据路径:worker 回执:hook 负面 3/3、push 3/3、Docker 隔离 integration 5/5;CEO 核实分支干净、numstat +116/-34 一致
- GitHub Actions `rewrite-ci` run URL:待 run 结束后补
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`(worker 运行 hook/push 单测与 Docker 隔离 integration)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:最后一轮未在 Node 24 跑完整 check:local(前一轮 Node 22:340/341,唯一失败是既有 lint-staged 缺失);GitHub CI 是本 PR 的权威。

## 审查证据

- 自查:CEO:hook 与一次性 push 替换任务书里反复的叮嘱;无重试循环;模板删掉 hook 已强制的提醒句。
- Reviewer subagent:有(只读回执审计 + git 独立核实)
- 人工审查:待
- 阻塞发现:无

## 残余风险

- agent 身份判定依赖 `HARNESS_ACTOR`;没带它的 worker 会被当作人——runtime 总会设置它。

## 关联材料

- 任务:task_e25af6b16ea5194132e4553bd4
- 证据:artifacts/reports/dispatch_19fefabdc5efd713421b7bed.md
- 审查:待

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPPk3TmbURWuxcFY3kFimA

