### PR TITLE
feat(ontology): Relation vocabulary: Phase 1 endpoint kinds, five edges, owner immutability

### DIFF
--- a/packages/gui/src/renderer/components/taskDetail/constants.ts
+++ b/packages/gui/src/renderer/components/taskDetail/constants.ts
@@ -20,6 +20,11 @@ export const OUT_LABEL: Record<RelationKind, string> = {
   "refuted-by": "反驳",
   "invalidated-by": "失效于",
   "supersedes-fact": "取代事实",
+  executes: "执行",
+  reviews: "审查",
+  owns: "拥有",
+  dispatches: "派发",
+  authorizes: "授权",
 };
 
 export const IN_LABEL: Record<RelationKind, string> = {
@@ -38,4 +43,9 @@ export const IN_LABEL: Record<RelationKind, string> = {
   "refuted-by": "反驳来自",
   "invalidated-by": "令…失效",
   "supersedes-fact": "事实被取代",
+  executes: "执行→",
+  reviews: "被审查",
+  owns: "归属",
+  dispatches: "被派发",
+  authorizes: "获授权",
 };

--- a/packages/gui/src/renderer/graph/constants.ts
+++ b/packages/gui/src/renderer/graph/constants.ts
@@ -49,6 +49,11 @@ export const KIND_AXIS: Record<RelationKind, SemanticAxis> = {
   evidences: "evidence",
   "refuted-by": "evidence",
   "invalidated-by": "evidence",
+  executes: "execution",
+  reviews: "execution",
+  owns: "assoc",
+  dispatches: "execution",
+  authorizes: "authority",
 };
 
 export function axisForKind(kind: RelationKind): SemanticAxis {
@@ -94,6 +99,11 @@ export const KIND_LABEL: Record<RelationKind, string> = {
   "refuted-by": "反驳",
   "invalidated-by": "失效于",
   "supersedes-fact": "取代事实",
+  executes: "执行",
+  reviews: "审查",
+  owns: "拥有",
+  dispatches: "派发",
+  authorizes: "授权",
 };
 
 export const KIND_LABEL_IN: Record<string, string> = {

--- a/packages/gui/src/renderer/graph/relationVisual.ts
+++ b/packages/gui/src/renderer/graph/relationVisual.ts
@@ -34,6 +34,11 @@ export const RELATION_VISUAL: Record<RelationKind, RelationVisual> = {
   produces: { dasharray: undefined, strokeWidth: 1.5 },
   relates: { dasharray: "4 3", strokeWidth: 1.2 },
   implements: { dasharray: "1.5 2.5", strokeWidth: 1.4 },
+  executes: { dasharray: undefined, strokeWidth: 1.6 },
+  reviews: { dasharray: "4 3", strokeWidth: 1.5 },
+  owns: { dasharray: "2 3", strokeWidth: 1.2 },
+  dispatches: { dasharray: undefined, strokeWidth: 1.4 },
+  authorizes: { dasharray: "6 3", strokeWidth: 1.5 },
 };
 
 /** 稳定顺序:按语义轴分组,便于筛选 UI 与图例。 */
@@ -53,6 +58,11 @@ export const RELATION_KIND_ORDER: ReadonlyArray<RelationKind> = [
   "produces",
   "relates",
   "implements",
+  "executes",
+  "reviews",
+  "owns",
+  "dispatches",
+  "authorizes",
 ];
 
 export function visualForKind(kind: RelationKind): RelationVisual {
@@ -61,9 +71,7 @@ export function visualForKind(kind: RelationKind): RelationVisual {
 
 /** 默认关系类型筛选:assoc 轴(relates/implements)默认关,降噪。 */
 export function defaultKindFilter(): Set<RelationKind> {
-  return new Set(
-    RELATION_KIND_ORDER.filter((k) => KIND_AXIS[k] !== "assoc"),
-  );
+  return new Set(RELATION_KIND_ORDER.filter((k) => KIND_AXIS[k] !== "assoc"));
 }
 
 /** 默认语义轴筛选:assoc 默认关。 */
@@ -72,10 +80,7 @@ export function defaultAxisFilter(): Record<SemanticAxis, boolean> {
 }
 
 /** 边是否通过关系类型筛选。kinds 空集 = 全部隐藏。 */
-export function edgePassesKindFilter(
-  edge: Pick<RelationEdge, "kind">,
-  kinds: ReadonlySet<string>,
-): boolean {
+export function edgePassesKindFilter(edge: Pick<RelationEdge, "kind">, kinds: ReadonlySet<string>): boolean {
   return kinds.has(edge.kind);
 }
 

--- a/packages/kernel/src/domain/agent-squad-schema.ts
+++ b/packages/kernel/src/domain/agent-squad-schema.ts
@@ -12,6 +12,8 @@ export interface AgentSkillDeclarationV1 {
   readonly path: string;
 }
 export type AgentRole = "worker" | "commander";
+export const agentStates = ["configured", "active", "retired"] as const;
+export type AgentState = (typeof agentStates)[number];
 export interface AgentDeclarationV1 {
   readonly id: string;
   readonly name: string;

--- a/packages/kernel/src/domain/decision-event-types.ts
+++ b/packages/kernel/src/domain/decision-event-types.ts
@@ -1,10 +1,6 @@
 import { type SessionProvenanceV1 } from "./agent-runtime.ts";
 import { type EntityRelationRecord } from "./entity-relation.ts";
-import {
-  type ActorIdentity,
-  type EventEnvelope,
-  type FrozenWritePlan,
-} from "./write-chain.contract.ts";
+import { type ActorIdentity, type EventEnvelope, type FrozenWritePlan } from "./write-chain.contract.ts";
 
 export const decisionEventTypes = [
   "decision_proposed",
@@ -29,11 +25,9 @@ export const decisionStates = [
   "superseded",
   "outcome_retired",
 ] as const;
-export const decisionFulfillmentModes = [
-  "evidenced",
-  "delivered",
-  "standing_policy",
-] as const;
+export const policyStates = ["draft", "active", "retired"] as const;
+export type PolicyState = (typeof policyStates)[number];
+export const decisionFulfillmentModes = ["evidenced", "delivered", "standing_policy"] as const;
 export type DecisionState = (typeof decisionStates)[number];
 export type DecisionFulfillmentMode = (typeof decisionFulfillmentModes)[number];
 export interface DecisionProposalPayload {
@@ -93,8 +87,7 @@ export interface DecisionAmendmentV1 {
 export interface DecisionContentPinV1 {
   readonly schema: "decision-content-pin/v1";
   readonly pinId: string;
-  readonly action:
-    "accept" | "reject" | "defer" | "supersede" | "retire" | "amend" | "repin";
+  readonly action: "accept" | "reject" | "defer" | "supersede" | "retire" | "amend" | "repin";
   readonly state: DecisionState;
   readonly pinnedAt: string;
   readonly evidence: string;
@@ -155,8 +148,7 @@ export interface DecisionJudgmentConsentV1 {
   readonly source: DecisionEventDraftV1["source"];
   readonly consentedAt: string;
 }
-export const DECISION_DOCUMENT_POLICY_ID =
-  "markdown-body-replaceable/v1" as const;
+export const DECISION_DOCUMENT_POLICY_ID = "markdown-body-replaceable/v1" as const;
 export interface DecisionDocumentClaim {
   readonly path: string;
   readonly sha256: string;
@@ -169,38 +161,25 @@ export interface DecisionDocumentMutation {
   readonly decisionDocumentClaim: DecisionDocumentClaim;
 }
 export type DecisionEventDraftV1 = {
-  [T in keyof DecisionPayloads]: EventEnvelope<
-    "decision-event/v1",
-    T,
-    ActorIdentity,
-    DecisionPayloads[T]
-  > & { readonly decisionId: string };
+  [T in keyof DecisionPayloads]: EventEnvelope<"decision-event/v1", T, ActorIdentity, DecisionPayloads[T]> & {
+    readonly decisionId: string;
+  };
 }[keyof DecisionPayloads];
-export type DecisionOutcomeType =
-  "decision_accepted" | "decision_rejected" | "decision_deferred";
-export type DecisionTransitionType =
-  DecisionOutcomeType | "decision_superseded" | "decision_retired";
-type DecisionPublishedPayload<T extends keyof DecisionPayloads> =
-  DecisionPayloads[T] &
-    DecisionDocumentMutation &
-    (T extends DecisionOutcomeType
-      ? { readonly judgmentConsent: DecisionJudgmentConsentV1 }
+export type DecisionOutcomeType = "decision_accepted" | "decision_rejected" | "decision_deferred";
+export type DecisionTransitionType = DecisionOutcomeType | "decision_superseded" | "decision_retired";
+type DecisionPublishedPayload<T extends keyof DecisionPayloads> = DecisionPayloads[T] &
+  DecisionDocumentMutation &
+  (T extends DecisionOutcomeType ? { readonly judgmentConsent: DecisionJudgmentConsentV1 } : object) &
+  (T extends DecisionTransitionType | "decision_repinned"
+    ? { readonly contentPin?: DecisionContentPinV1 }
+    : T extends "decision_amended"
+      ? { readonly contentPin: DecisionContentPinV1 }
       : object) &
-    (T extends DecisionTransitionType | "decision_repinned"
-      ? { readonly contentPin?: DecisionContentPinV1 }
-      : T extends "decision_amended"
-        ? { readonly contentPin: DecisionContentPinV1 }
-        : object) &
-    (T extends "decision_amended"
-      ? { readonly amendment: DecisionAmendmentV1 }
-      : object);
+  (T extends "decision_amended" ? { readonly amendment: DecisionAmendmentV1 } : object);
 export type DecisionEventV1 = {
-  [T in keyof DecisionPayloads]: EventEnvelope<
-    "decision-event/v1",
-    T,
-    ActorIdentity,
-    DecisionPublishedPayload<T>
-  > & { readonly decisionId: string };
+  [T in keyof DecisionPayloads]: EventEnvelope<"decision-event/v1", T, ActorIdentity, DecisionPublishedPayload<T>> & {
+    readonly decisionId: string;
+  };
 }[keyof DecisionPayloads];
 export interface DecisionDocumentState {
   readonly decisionId: string;

--- a/packages/kernel/src/domain/entity-ref.ts
+++ b/packages/kernel/src/domain/entity-ref.ts
@@ -24,8 +24,12 @@ const taskOrDecisionRefPattern = /^(?<kind>task|decision)\/(?<id>[A-Za-z0-9_-]+)
 const phaseOneEntityRefPattern = /^(?<kind>execution|review|agent|runtime-session|policy)\/(?<id>[A-Za-z0-9_-]+)$/u;
 const factRefPattern = /^fact\/(?<ownerTaskId>[A-Za-z0-9_-]+)\/(?<factId>[A-Za-z0-9_-]+)$/u;
 const relationRefPattern = /^relation\/(?<relationId>rel_[a-f0-9]{16})$/u;
-const entityRefSearchPattern =
-  /(?<![A-Za-z0-9_/-])(?:[A-Za-z][A-Za-z0-9_-]*:)?(?:fact\/[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+|relation\/rel_[a-f0-9]{16}|(?:task|decision)\/[A-Za-z0-9_-]+(?:\/[A-Za-z0-9_-]+)?|(?:execution|review|agent|runtime-session|policy)\/[A-Za-z0-9_-]+)\b(?!\/)/gu;
+const entityRefSearchPattern = new RegExp(
+  String.raw`(?<![A-Za-z0-9_/-])(?:[A-Za-z][A-Za-z0-9_-]*:)?(?:fact\/[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+|` +
+    String.raw`relation\/rel_[a-f0-9]{16}|(?:task|decision)\/[A-Za-z0-9_-]+(?:\/[A-Za-z0-9_-]+)?|` +
+    String.raw`(?:execution|review|agent|runtime-session|policy)\/[A-Za-z0-9_-]+)\b(?!\/)`,
+  "gu",
+);
 
 function isPlausibleTaskRefId(id: string): boolean {
   return id.startsWith("task_") || id.includes("-");

--- a/packages/kernel/src/domain/entity-ref.ts
+++ b/packages/kernel/src/domain/entity-ref.ts
@@ -1,4 +1,13 @@
-export type EntityRefKind = "task" | "decision" | "fact" | "relation";
+export type EntityRefKind =
+  | "task"
+  | "decision"
+  | "fact"
+  | "execution"
+  | "review"
+  | "agent"
+  | "runtime-session"
+  | "policy"
+  | "relation";
 
 export interface ParsedEntityRef {
   readonly raw: string;
@@ -12,10 +21,11 @@ export interface ParsedEntityRef {
 
 const entityRefPrefixPattern = /^(?:(?<alias>[A-Za-z][A-Za-z0-9_-]*):)?(?<body>.+)$/u;
 const taskOrDecisionRefPattern = /^(?<kind>task|decision)\/(?<id>[A-Za-z0-9_-]+)(?:\/(?<anchor>[A-Za-z0-9_-]+))?$/u;
+const phaseOneEntityRefPattern = /^(?<kind>execution|review|agent|runtime-session|policy)\/(?<id>[A-Za-z0-9_-]+)$/u;
 const factRefPattern = /^fact\/(?<ownerTaskId>[A-Za-z0-9_-]+)\/(?<factId>[A-Za-z0-9_-]+)$/u;
 const relationRefPattern = /^relation\/(?<relationId>rel_[a-f0-9]{16})$/u;
 const entityRefSearchPattern =
-  /(?<![A-Za-z0-9_/-])(?:[A-Za-z][A-Za-z0-9_-]*:)?(?:fact\/[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+|relation\/rel_[a-f0-9]{16}|(?:task|decision)\/[A-Za-z0-9_-]+(?:\/[A-Za-z0-9_-]+)?)\b(?!\/)/gu;
+  /(?<![A-Za-z0-9_/-])(?:[A-Za-z][A-Za-z0-9_-]*:)?(?:fact\/[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+|relation\/rel_[a-f0-9]{16}|(?:task|decision)\/[A-Za-z0-9_-]+(?:\/[A-Za-z0-9_-]+)?|(?:execution|review|agent|runtime-session|policy)\/[A-Za-z0-9_-]+)\b(?!\/)/gu;
 
 function isPlausibleTaskRefId(id: string): boolean {
   return id.startsWith("task_") || id.includes("-");
@@ -59,6 +69,17 @@ export function parseEntityRef(value: string): ParsedEntityRef | null {
       raw: value,
       kind: "relation",
       id: relation.groups.relationId,
+      ...(harnessAlias ? { harnessAlias } : {}),
+      externalHarness: Boolean(harnessAlias),
+    };
+  }
+
+  const phaseOneEntity = body.match(phaseOneEntityRefPattern);
+  if (phaseOneEntity?.groups?.kind && phaseOneEntity.groups.id) {
+    return {
+      raw: value,
+      kind: phaseOneEntity.groups.kind as Exclude<EntityRefKind, "task" | "decision" | "fact" | "relation">,
+      id: phaseOneEntity.groups.id,
       ...(harnessAlias ? { harnessAlias } : {}),
       externalHarness: Boolean(harnessAlias),
     };

--- a/packages/kernel/src/domain/entity-relation.ts
+++ b/packages/kernel/src/domain/entity-relation.ts
@@ -19,6 +19,11 @@ export const relationTypes = [
   "refuted-by",
   "invalidated-by",
   "supersedes-fact",
+  "executes",
+  "reviews",
+  "owns",
+  "dispatches",
+  "authorizes",
 ] as const;
 
 export const relationStrengths = ["strong", "weak"] as const;
@@ -167,7 +172,10 @@ export function isAllowedRelationKindTriple(
   // `incomingRelations` in relation-direction.ts.
   return canonicalRelationDirections.some(
     (direction) =>
-      direction.sourceKind === sourceKind && direction.type === type && direction.targetKind === targetKind,
+      direction.registration !== "derived" &&
+      direction.sourceKind === sourceKind &&
+      direction.type === type &&
+      direction.targetKind === targetKind,
   );
 }
 

--- a/packages/kernel/src/domain/relation-direction.ts
+++ b/packages/kernel/src/domain/relation-direction.ts
@@ -2,10 +2,18 @@ import type { RelationType } from "./entity-relation.ts";
 
 /** Endpoint kinds that can host a canonical relation edge. Parsed refs may also be
  * "relation" or external-harness aliases; neither can host an edge. */
-export type RelationEndpointKind = "task" | "decision" | "fact";
+export type RelationEndpointKind =
+  | "task"
+  | "decision"
+  | "fact"
+  | "execution"
+  | "review"
+  | "agent"
+  | "runtime-session"
+  | "policy";
 
 /** Whether the reading of an allowed triple has a registered semantics. */
-export type RelationDirectionRegistration = "ratified" | "unregistered";
+export type RelationDirectionRegistration = "ratified" | "unregistered" | "derived";
 
 /**
  * The canonical direction registry (blueprint 铁律三): one row per writable
@@ -159,6 +167,51 @@ export const canonicalRelationDirections: readonly CanonicalRelationDirection[] 
     sourceKind: "fact",
     targetKind: "fact",
     reads: "the fact supersedes the target fact",
+    registration: "ratified",
+  },
+  // Phase 1 execution/review/runtime relations. `owns` is a read-only semantic
+  // projection of task.createdBy.principal, so it is registered for direction
+  // and reverse-query purposes but is not a writable relation edge.
+  {
+    type: "executes",
+    sourceKind: "execution",
+    targetKind: "task",
+    reads: "the execution executes the target task",
+    registration: "ratified",
+  },
+  {
+    type: "executes",
+    sourceKind: "runtime-session",
+    targetKind: "task",
+    reads: "the runtime session executes the target task",
+    registration: "ratified",
+  },
+  {
+    type: "reviews",
+    sourceKind: "review",
+    targetKind: "execution",
+    reads: "the review reviews the target execution",
+    registration: "ratified",
+  },
+  {
+    type: "owns",
+    sourceKind: "task",
+    targetKind: "agent",
+    reads: "the task is owned by the agent derived from createdBy.principal",
+    registration: "derived",
+  },
+  {
+    type: "dispatches",
+    sourceKind: "agent",
+    targetKind: "runtime-session",
+    reads: "the agent dispatches the target runtime session",
+    registration: "ratified",
+  },
+  {
+    type: "authorizes",
+    sourceKind: "policy",
+    targetKind: "execution",
+    reads: "the policy authorizes the target execution",
     registration: "ratified",
   },
 ];

--- a/packages/kernel/src/domain/status-vocabulary-catalog.ts
+++ b/packages/kernel/src/domain/status-vocabulary-catalog.ts
@@ -86,6 +86,22 @@ export const statusVocabularies: readonly StatusVocabulary[] = [
     words: ["active", "submitted", "accepted", "changes_requested", "abandoned"],
   },
   {
+    id: "agent.state",
+    entity: "Agent",
+    field: "state",
+    module: "packages/kernel/src/domain/agent-squad-schema.ts",
+    anchor: "agentStates",
+    words: ["configured", "active", "retired"],
+  },
+  {
+    id: "policy.state",
+    entity: "Policy",
+    field: "state",
+    module: "packages/kernel/src/domain/decision-event-types.ts",
+    anchor: "policyStates",
+    words: ["draft", "active", "retired"],
+  },
+  {
     id: "execution.state.v1",
     entity: "Execution",
     field: "state",

--- a/packages/kernel/src/domain/status-vocabulary-types.ts
+++ b/packages/kernel/src/domain/status-vocabulary-types.ts
@@ -2,6 +2,8 @@ export type StatusEntity =
   | "Task"
   | "Decision"
   | "Execution"
+  | "Agent"
+  | "Policy"
   | "Lease"
   | "RelationEdge"
   | "Package"

--- a/packages/kernel/src/domain/status-word-register-domain.ts
+++ b/packages/kernel/src/domain/status-word-register-domain.ts
@@ -1,6 +1,52 @@
 import type { StatusWordRegistration } from "./status-vocabulary-types.ts";
 
 export const domainStatusWords: readonly StatusWordRegistration[] = [
+  // ---- Agent.state (declaration lifecycle) ----
+  {
+    word: "configured",
+    entity: "Agent",
+    field: "state",
+    meaning: "Agent declaration is present and has passed schema validation.",
+    divergence: "entity-scoped",
+  },
+  {
+    word: "active",
+    entity: "Agent",
+    field: "state",
+    meaning: "Agent is eligible to receive dispatches.",
+    divergence: "divergent",
+    resolution: "Agent availability, not task execution occupancy; retained as an entity-scoped state.",
+  },
+  {
+    word: "retired",
+    entity: "Agent",
+    field: "state",
+    meaning: "Agent declaration is retained for history but no longer dispatchable.",
+    divergence: "entity-scoped",
+  },
+  // ---- Policy.state (policy lifecycle) ----
+  {
+    word: "draft",
+    entity: "Policy",
+    field: "state",
+    meaning: "Policy has been authored but is not in effect.",
+    divergence: "entity-scoped",
+  },
+  {
+    word: "active",
+    entity: "Policy",
+    field: "state",
+    meaning: "Policy is currently in effect for authorized executions.",
+    divergence: "divergent",
+    resolution: "Policy effect, not task or execution activity; retained as an entity-scoped state.",
+  },
+  {
+    word: "retired",
+    entity: "Policy",
+    field: "state",
+    meaning: "Policy is no longer in effect but remains auditable.",
+    divergence: "entity-scoped",
+  },
   // ---- Slice-3 domain judgments (registered here when the two slices met on main) ----
   {
     word: "blocked",

--- a/packages/kernel/src/domain/task-lifecycle-event.ts
+++ b/packages/kernel/src/domain/task-lifecycle-event.ts
@@ -1,9 +1,4 @@
-import {
-  isNativeCommitSha,
-  validateExecutionV1,
-  validateLeaseHolder,
-  validateLeaseV1,
-} from "./execution.ts";
+import { isNativeCommitSha, validateExecutionV1, validateLeaseHolder, validateLeaseV1 } from "./execution.ts";
 import type { ExecutionV1, LeaseHolder, LeaseV1 } from "./execution.ts";
 import { validateReviewConsentV1, validateReviewV1 } from "./review.ts";
 import type { ReviewConsentV1, ReviewV1 } from "./review.ts";
@@ -17,10 +12,7 @@ import {
   type CodeDocRepointV1,
   type CodeDocWitnessV1,
 } from "./code-doc-witness.ts";
-import {
-  validateCompletionGateWitnessV1,
-  type CompletionGateWitnessV1,
-} from "./completion-gate-witness.ts";
+import { validateCompletionGateWitnessV1, type CompletionGateWitnessV1 } from "./completion-gate-witness.ts";
 import {
   hasOnlyFields,
   hasRequiredFields,
@@ -33,10 +25,7 @@ import {
 } from "./write-chain.contract.ts";
 import type { EventEnvelope } from "./write-chain.contract.ts";
 import { normalizeRelativeDocumentPath } from "../layout/portable-path.ts";
-import {
-  isValidDocEventChange,
-  type DocEventChange,
-} from "./doc-sync.contract.ts";
+import { isValidDocEventChange, type DocEventChange } from "./doc-sync.contract.ts";
 export const taskEventTypes = [
   "task_created",
   "execution_started",
@@ -91,8 +80,7 @@ export type TaskCreatedEvent = EventEnvelope<
     readonly carriedDocumentClaims?: readonly TaskCarriedDocumentChange[];
   }
 > & { readonly taskId: string };
-export type LeaseChangeReason =
-  "initial_claim" | "same_principal_reconnect" | "ttl_expired_takeover";
+export type LeaseChangeReason = "initial_claim" | "same_principal_reconnect" | "ttl_expired_takeover";
 export type ExecutionStartedEvent = TaskEventEnvelope<
   "execution_started",
   {
@@ -244,10 +232,7 @@ export type TaskLifecycleErrorCode =
 export class TaskLifecycleContractError extends Error {
   readonly code: TaskLifecycleErrorCode;
   readonly issues: readonly ContractValidationIssue[];
-  constructor(
-    code: TaskLifecycleErrorCode,
-    issues: readonly ContractValidationIssue[],
-  ) {
+  constructor(code: TaskLifecycleErrorCode, issues: readonly ContractValidationIssue[]) {
     super(issues.map((issue) => issue.message).join("; "));
     this.name = "TaskLifecycleContractError";
     this.code = code;
@@ -270,32 +255,18 @@ export const TASK_EVENT_V1_SCHEMA = Object.freeze({
   ]),
   types: taskEventTypes,
 });
-export function validateTaskEvent(
-  value: unknown,
-): readonly ContractValidationIssue[] {
+export function validateTaskEvent(value: unknown): readonly ContractValidationIssue[] {
   return validateTaskEventFields(value, true);
 }
-export function validateCurrentTaskEvent(
-  value: unknown,
-): readonly ContractValidationIssue[] {
+export function validateCurrentTaskEvent(value: unknown): readonly ContractValidationIssue[] {
   return validateTaskEventFields(value, false);
 }
-function validateTaskEventFields(
-  value: unknown,
-  allowUnknownFields: boolean,
-): readonly ContractValidationIssue[] {
+function validateTaskEventFields(value: unknown, allowUnknownFields: boolean): readonly ContractValidationIssue[] {
   if (
     !isRecord(value) ||
-    !(allowUnknownFields ? hasRequiredFields : hasOnlyFields)(
-      value,
-      TASK_EVENT_V1_SCHEMA.required,
-    )
+    !(allowUnknownFields ? hasRequiredFields : hasOnlyFields)(value, TASK_EVENT_V1_SCHEMA.required)
   )
-    return [
-      invalidEventPayloadIssue(
-        "task-event/v1 fields are incomplete or unknown",
-      ),
-    ];
+    return [invalidEventPayloadIssue("task-event/v1 fields are incomplete or unknown")];
   const issues: ContractValidationIssue[] = [];
   if (value.schema !== "task-event/v1")
     issues.push({
@@ -311,25 +282,15 @@ function validateTaskEventFields(
     (value.workspaceRevision as number) < 1 ||
     !taskEventTypes.includes(value.type as TaskEventType)
   )
-    issues.push(
-      invalidEventPayloadIssue("event identity, revision, or type is invalid"),
-    );
+    issues.push(invalidEventPayloadIssue("event identity, revision, or type is invalid"));
   issues.push(...validateActorAxes(value.actor, allowUnknownFields));
   if (validateWriteSource(value.source, allowUnknownFields).length)
     issues.push(invalidEventPayloadIssue("event source is invalid"));
-  if (!isRecord(value.payload))
-    return [
-      ...issues,
-      invalidEventPayloadIssue("event payload must be an object"),
-    ];
+  if (!isRecord(value.payload)) return [...issues, invalidEventPayloadIssue("event payload must be an object")];
   const payload = value.payload,
     carried = payload.carriedDocumentClaims,
     payloadWithoutCarried = isRecord(payload)
-      ? Object.fromEntries(
-          Object.entries(payload).filter(
-            ([key]) => key !== "carriedDocumentClaims",
-          ),
-        )
+      ? Object.fromEntries(Object.entries(payload).filter(([key]) => key !== "carriedDocumentClaims"))
       : payload,
     fields = lifecyclePayloadFields(
       String(value.type),
@@ -339,39 +300,24 @@ function validateTaskEventFields(
   const claimlessFields =
     value.type === "task_created"
       ? ["task"]
-      : lifecyclePayloadFields(
-          String(value.type),
-          Object.hasOwn(payload, "edge"),
-        ).filter((field) => field !== "documentClaims");
+      : lifecyclePayloadFields(String(value.type), Object.hasOwn(payload, "edge")).filter(
+          (field) => field !== "documentClaims",
+        );
   const payloadFields = allowUnknownFields ? hasRequiredFields : hasOnlyFields;
   const validPayloadFields =
-    (value.type === "task_created" || value.type === "lease_renewed") &&
-    claims === undefined
-      ? payloadFields(
-          payloadWithoutCarried as Record<string, unknown>,
-          claimlessFields,
-        )
+    (value.type === "task_created" || value.type === "lease_renewed") && claims === undefined
+      ? payloadFields(payloadWithoutCarried as Record<string, unknown>, claimlessFields)
       : payloadFields(payloadWithoutCarried as Record<string, unknown>, fields);
   if (
     !validPayloadFields ||
     (claims !== undefined &&
-      (!Array.isArray(claims) ||
-        claims.some(
-          (claim) => !validLifecycleClaim(claim, allowUnknownFields),
-        ))) ||
+      (!Array.isArray(claims) || claims.some((claim) => !validLifecycleClaim(claim, allowUnknownFields)))) ||
     (carried !== undefined &&
       (!Array.isArray(carried) ||
         carried.length === 0 ||
-        carried.some(
-          (change) => !isValidDocEventChange(change, allowUnknownFields),
-        )))
+        carried.some((change) => !isValidDocEventChange(change, allowUnknownFields))))
   )
-    return [
-      ...issues,
-      invalidEventPayloadIssue(
-        `${String(value.type)} payload fields or document claims are invalid`,
-      ),
-    ];
+    return [...issues, invalidEventPayloadIssue(`${String(value.type)} payload fields or document claims are invalid`)];
   issues.push(...validateTaskV1(payload.task, allowUnknownFields));
   if (
     [
@@ -392,32 +338,21 @@ function validateTaskEventFields(
   if (value.type === "execution_started" || value.type === "lease_renewed") {
     issues.push(...validateLeaseV1(payload.lease, allowUnknownFields));
     if (payload.previousHolder !== null)
-      issues.push(
-        ...validateLeaseHolder(payload.previousHolder, allowUnknownFields),
-      );
+      issues.push(...validateLeaseHolder(payload.previousHolder, allowUnknownFields));
     if (
       !isNonEmptyString(payload.leaseExpiresAt) ||
-      ![
-        "initial_claim",
-        "same_principal_reconnect",
-        "ttl_expired_takeover",
-      ].includes(String(payload.reason)) ||
+      !["initial_claim", "same_principal_reconnect", "ttl_expired_takeover"].includes(String(payload.reason)) ||
       (value.type === "lease_renewed" &&
-        (payload.previousHolder === null ||
-          payload.reason !== "same_principal_reconnect"))
+        (payload.previousHolder === null || payload.reason !== "same_principal_reconnect"))
     )
       issues.push(invalidEventPayloadIssue("lease event history is invalid"));
   }
   if (value.type === "execution_executor_declared") {
-    issues.push(
-      ...validateActorAxes(payload.previousActor, allowUnknownFields),
-    );
+    issues.push(...validateActorAxes(payload.previousActor, allowUnknownFields));
     if (
       !isNonEmptyString(payload.reason) ||
-      (isRecord(payload.previousActor) &&
-        payload.previousActor.executor !== null) ||
-      (isRecord(payload.execution) &&
-        !sameActorIdentity(payload.execution.actor, value.actor))
+      (isRecord(payload.previousActor) && payload.previousActor.executor !== null) ||
+      (isRecord(payload.execution) && !sameActorIdentity(payload.execution.actor, value.actor))
     )
       issues.push(
         invalidEventPayloadIssue(
@@ -425,21 +360,15 @@ function validateTaskEventFields(
         ),
       );
   }
-  if (value.type === "review_recorded")
-    issues.push(...validateReviewV1(payload.review, allowUnknownFields));
+  if (value.type === "review_recorded") issues.push(...validateReviewV1(payload.review, allowUnknownFields));
   if (value.type === "review_consent_recorded")
     issues.push(
       ...validateReviewV1(payload.review, allowUnknownFields),
       ...validateReviewConsentV1(payload.consent, allowUnknownFields),
     );
   if (value.type === "code_doc_reconciled")
-    issues.push(
-      ...validateCodeDocWitnessV1(payload.witness, allowUnknownFields),
-    );
-  if (value.type === "code_doc_repointed")
-    issues.push(
-      ...validateCodeDocRepointV1(payload.record, allowUnknownFields),
-    );
+    issues.push(...validateCodeDocWitnessV1(payload.witness, allowUnknownFields));
+  if (value.type === "code_doc_repointed") issues.push(...validateCodeDocRepointV1(payload.record, allowUnknownFields));
   if (
     value.type === "code_doc_repointed" &&
     isRecord(payload.record) &&
@@ -450,13 +379,9 @@ function validateTaskEventFields(
       !sameWriteSource(payload.record.source, value.source) ||
       payload.record.repointedAt !== value.occurredAt)
   )
-    issues.push(
-      invalidEventPayloadIssue("code-doc repoint record must be pinned to its canonical event envelope"),
-    );
+    issues.push(invalidEventPayloadIssue("code-doc repoint record must be pinned to its canonical event envelope"));
   if (value.type === "completion_gate_verified") {
-    issues.push(
-      ...validateCompletionGateWitnessV1(payload.witness, allowUnknownFields),
-    );
+    issues.push(...validateCompletionGateWitnessV1(payload.witness, allowUnknownFields));
     if (
       isRecord(payload.witness) &&
       (payload.witness.receiptId !== value.opId ||
@@ -464,79 +389,49 @@ function validateTaskEventFields(
         !sameActorIdentity(payload.witness.actor, value.actor) ||
         !sameWriteSource(payload.witness.source, value.source))
     )
-      issues.push(
-        invalidEventPayloadIssue(
-          "completion gate witness must be pinned to its canonical event receipt",
-        ),
-      );
+      issues.push(invalidEventPayloadIssue("completion gate witness must be pinned to its canonical event receipt"));
   }
-  if ("edge" in payload)
-    issues.push(...validateEdge(payload.edge, allowUnknownFields));
+  if ("edge" in payload) issues.push(...validateEdge(payload.edge, allowUnknownFields));
   if (value.type === "lease_released") {
     issues.push(...validateLeaseV1(payload.releasedLease, allowUnknownFields));
     if (
       !validMutation(payload.mutation, allowUnknownFields) ||
-      (isRecord(payload.releasedLease) &&
-        payload.releasedLease.taskId !== value.taskId)
+      (isRecord(payload.releasedLease) && payload.releasedLease.taskId !== value.taskId)
     )
-      issues.push(
-        invalidEventPayloadIssue("lease release mutation is invalid"),
-      );
+      issues.push(invalidEventPayloadIssue("lease release mutation is invalid"));
   }
   if (
     String(value.type).startsWith("task_") &&
     !["task_created", "task_completed"].includes(String(value.type)) &&
     !validMutation(payload.mutation, allowUnknownFields)
   )
-    issues.push(
-      invalidEventPayloadIssue("task mutation audit fields are invalid"),
-    );
+    issues.push(invalidEventPayloadIssue("task mutation audit fields are invalid"));
   if (isRecord(payload.task) && "graph" in payload.task)
     issues.push(...validateTaskGraph(payload.task.graph, allowUnknownFields));
   if (isRecord(payload.task) && payload.task.taskId !== value.taskId)
-    issues.push(
-      invalidEventPayloadIssue("payload Task identity must match the envelope"),
-    );
+    issues.push(invalidEventPayloadIssue("payload Task identity must match the envelope"));
   return issues;
 }
-function lifecyclePayloadFields(
-  type: string,
-  edge: boolean,
-): readonly string[] {
+function lifecyclePayloadFields(type: string, edge: boolean): readonly string[] {
   const common = ["task", "execution", "documentClaims"];
   if (type === "task_created") return ["task", "documentClaims"];
   if (type === "execution_started" || type === "lease_renewed")
     return [...common, "lease", "previousHolder", "leaseExpiresAt", "reason"];
   if (type === "execution_submitted") return [...common, "edge"];
-  if (type === "execution_executor_declared")
-    return [...common, "previousActor", "reason"];
-  if (type === "review_recorded")
-    return [...common, "review", ...(edge ? ["edge"] : [])];
-  if (type === "review_consent_recorded")
-    return [...common, "review", "consent"];
-  if (type === "code_doc_reconciled" || type === "completion_gate_verified")
-    return [...common, "witness"];
+  if (type === "execution_executor_declared") return [...common, "previousActor", "reason"];
+  if (type === "review_recorded") return [...common, "review", ...(edge ? ["edge"] : [])];
+  if (type === "review_consent_recorded") return [...common, "review", "consent"];
+  if (type === "code_doc_reconciled" || type === "completion_gate_verified") return [...common, "witness"];
   if (type === "code_doc_repointed") return [...common, "record"];
-  if (type === "lease_released")
-    return [...common, "releasedLease", "mutation"];
-  if (
-    type.startsWith("task_") &&
-    !["task_created", "task_completed"].includes(type)
-  )
+  if (type === "lease_released") return [...common, "releasedLease", "mutation"];
+  if (type.startsWith("task_") && !["task_created", "task_completed"].includes(type))
     return ["task", "mutation", "documentClaims"];
   return common;
 }
-function validMutation(
-  value: unknown,
-  allowUnknownFields: boolean,
-): value is TaskMutationV1 {
+function validMutation(value: unknown, allowUnknownFields: boolean): value is TaskMutationV1 {
   return (
     isRecord(value) &&
-    (allowUnknownFields ? hasRequiredFields : hasOnlyFields)(value, [
-      "command",
-      "reason",
-      "fields",
-    ]) &&
+    (allowUnknownFields ? hasRequiredFields : hasOnlyFields)(value, ["command", "reason", "fields"]) &&
     [
       "release",
       "transition",
@@ -550,13 +445,13 @@ function validMutation(
     ].includes(String(value.command)) &&
     isNonEmptyString(value.reason) &&
     Array.isArray(value.fields) &&
-    value.fields.every(isNonEmptyString)
+    value.fields.every((field) => isNonEmptyString(field) && !isImmutableTaskField(field))
   );
 }
-function validLifecycleClaim(
-  value: unknown,
-  allowUnknownFields: boolean,
-): value is LifecycleDocumentClaim {
+function isImmutableTaskField(value: string): boolean {
+  return value.startsWith("owner") || value.startsWith("createdBy");
+}
+function validLifecycleClaim(value: unknown, allowUnknownFields: boolean): value is LifecycleDocumentClaim {
   if (
     !isRecord(value) ||
     !(allowUnknownFields ? hasRequiredFields : hasOnlyFields)(value, [
@@ -582,14 +477,10 @@ function validLifecycleClaim(
   if (!canonical) return false;
   const planClaim = path.endsWith("/task_plan.md");
   return planClaim
-    ? value.policyId === "markdown-body-replaceable/v1" &&
-        value.mediaType === "text/markdown"
+    ? value.policyId === "markdown-body-replaceable/v1" && value.mediaType === "text/markdown"
     : value.policyId === "typed-machine-writer/v1";
 }
-function validateEdge(
-  value: unknown,
-  allowUnknownFields: boolean,
-): readonly ContractValidationIssue[] {
+function validateEdge(value: unknown, allowUnknownFields: boolean): readonly ContractValidationIssue[] {
   return !isRecord(value) ||
     !(allowUnknownFields ? hasRequiredFields : hasOnlyFields)(value, [
       "edgeId",
@@ -624,7 +515,6 @@ function invalidEventPayloadIssue(message: string): ContractValidationIssue {
 }
 export function serializeTaskEvent(value: TaskEventV1): string {
   const issues = validateCurrentTaskEvent(value);
-  if (issues.length)
-    throw new TaskLifecycleContractError("invalid_schema", issues);
+  if (issues.length) throw new TaskLifecycleContractError("invalid_schema", issues);
   return serializeEventEnvelope(value);
 }

--- a/packages/kernel/src/entity/disposition.ts
+++ b/packages/kernel/src/entity/disposition.ts
@@ -242,10 +242,10 @@ function otherEndpointRefs(edge: RelationGraphEdgeRow, entityRef: string): Reado
 
 function entityKindFromRef(entityRef: string): KernelEntityKind {
   const parsed = parseEntityRef(entityRef);
-  if (!parsed || parsed.externalHarness) {
+  if (!parsed || parsed.externalHarness || !["task", "decision", "fact", "relation", "session"].includes(parsed.kind)) {
     throw new Error(`Unsupported entity ref for disposition: ${entityRef}`);
   }
-  return parsed.kind;
+  return parsed.kind as KernelEntityKind;
 }
 
 function nonDestructiveSupportedActions(entityKind: KernelEntityKind): ReadonlyArray<DispositionAction> {

--- a/packages/kernel/src/layout/entity-root-resolver.ts
+++ b/packages/kernel/src/layout/entity-root-resolver.ts
@@ -17,7 +17,7 @@ export interface EntityRootResolution {
 export function resolveEntityRootForLayout(
   layout: HarnessLayout,
   ref: string | ParsedEntityRef,
-  _intent: EntityRootIntent = "read"
+  _intent: EntityRootIntent = "read",
 ): EntityRootResolution {
   const entityRef = typeof ref === "string" ? parseEntityRef(ref) : ref;
   if (!entityRef) throw new Error(`invalid entity ref: ${String(ref)}`);
@@ -29,7 +29,7 @@ export function resolveEntityRootForLayout(
         entityRef,
         rootPath,
         documentPath: path.join(rootPath, "INDEX.md"),
-        ...(entityRef.anchor ? { anchor: entityRef.anchor } : {})
+        ...(entityRef.anchor ? { anchor: entityRef.anchor } : {}),
       };
     }
     case "decision": {
@@ -39,7 +39,7 @@ export function resolveEntityRootForLayout(
         entityRef,
         rootPath,
         documentPath: layout.decisionDocumentPath(decisionId),
-        ...(entityRef.anchor ? { anchor: entityRef.anchor } : {})
+        ...(entityRef.anchor ? { anchor: entityRef.anchor } : {}),
       };
     }
     case "fact": {
@@ -47,6 +47,12 @@ export function resolveEntityRootForLayout(
     }
     case "relation":
       throw new Error(`hosted relation refs cannot be resolved without their source host: ${entityRef.raw}`);
+    case "execution":
+    case "review":
+    case "agent":
+    case "runtime-session":
+    case "policy":
+      throw new Error(`Phase 1 relation endpoint has no authored layout root: ${entityRef.raw}`);
   }
 }
 

--- a/packages/kernel/test/contracts/task-event-owner-mutation.test.ts
+++ b/packages/kernel/test/contracts/task-event-owner-mutation.test.ts
@@ -1,0 +1,53 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { validateTaskEvent } from "../../src/domain/task-lifecycle-event.ts";
+import { REPLAY_TASK_GRAPH } from "../../src/domain/task-graph.ts";
+
+const actor = { principal: { personId: "person-owner" }, executor: null } as const;
+const task = {
+  schema: "task/v1" as const,
+  taskId: "task_owner_mutation",
+  title: "Owner mutation contract",
+  taskClass: "standard" as const,
+  status: "active" as const,
+  graph: REPLAY_TASK_GRAPH,
+  currentNode: "implementation" as const,
+  iteration: 0 as const,
+  createdBy: actor,
+  completionGateIds: [],
+  presetSnapshotDigest: null,
+};
+
+function event(fields: readonly string[]) {
+  return {
+    schema: "task-event/v1" as const,
+    eventId: "event-owner-mutation",
+    workspaceRevision: 2,
+    opId: "op-owner-mutation",
+    taskId: task.taskId,
+    type: "task_amended" as const,
+    actor,
+    source: "local" as const,
+    occurredAt: "2026-08-25T00:00:00.000Z",
+    payload: {
+      task,
+      mutation: { command: "amend" as const, reason: "contract probe", fields },
+      documentClaims: [],
+    },
+  };
+}
+
+test("task-event boundary rejects every owner or createdBy mutation field", () => {
+  for (const field of ["owner", "owner.principal", "createdBy", "createdBy.principal"]) {
+    const issues = validateTaskEvent(event([field]));
+    assert.ok(
+      issues.some((issue) => issue.message.includes("task mutation audit fields are invalid")),
+      `${field} must be rejected`,
+    );
+  }
+});
+
+test("task-event boundary keeps ordinary amend fields writable", () => {
+  assert.deepEqual(validateTaskEvent(event(["title", "pinned"])), []);
+});

--- a/packages/kernel/test/domain/entity-ref.test.ts
+++ b/packages/kernel/test/domain/entity-ref.test.ts
@@ -6,7 +6,7 @@ import {
   deriveRelationId,
   formatRelationFlowRecord,
   isAllowedRelationKindTriple,
-  validateRelationRecordsForHost
+  validateRelationRecordsForHost,
 } from "../../src/domain/entity-relation.ts";
 import type { EntityRelationRecord } from "../../src/domain/entity-relation.ts";
 
@@ -15,14 +15,14 @@ test("EntityRef parser accepts local and prefixed task references", () => {
     raw: "task/task_01JY1H4J1Y8Y9G7FZ6MZ4W0N8Q",
     kind: "task",
     id: "task_01JY1H4J1Y8Y9G7FZ6MZ4W0N8Q",
-    externalHarness: false
+    externalHarness: false,
   });
   assert.deepEqual(parseEntityRef("team-a:task/task_01JY1H4J1Y8Y9G7FZ6MZ4W0N8Q"), {
     raw: "team-a:task/task_01JY1H4J1Y8Y9G7FZ6MZ4W0N8Q",
     kind: "task",
     id: "task_01JY1H4J1Y8Y9G7FZ6MZ4W0N8Q",
     harnessAlias: "team-a",
-    externalHarness: true
+    externalHarness: true,
   });
   assert.equal(parseEntityRef("issue/123"), null);
   assert.equal(parseEntityRef("task/v1"), null);
@@ -35,14 +35,14 @@ test("EntityRef parser accepts M3 decision and fact endpoints", () => {
     kind: "decision",
     id: "dec_01K7Z",
     anchor: "C1",
-    externalHarness: false
+    externalHarness: false,
   });
   assert.deepEqual(parseEntityRef("fact/task_01JY1H4J1Y8Y9G7FZ6MZ4W0N8Q/F-a3f2"), {
     raw: "fact/task_01JY1H4J1Y8Y9G7FZ6MZ4W0N8Q/F-a3f2",
     kind: "fact",
     id: "F-a3f2",
     ownerTaskId: "task_01JY1H4J1Y8Y9G7FZ6MZ4W0N8Q",
-    externalHarness: false
+    externalHarness: false,
   });
   assert.equal(parseEntityRef("decision/doc"), null);
   assert.equal(parseEntityRef("fact/F-a3f2"), null);
@@ -54,29 +54,50 @@ test("EntityRef parser accepts hosted relation entity refs", () => {
     raw: "relation/rel_b75516c583945a52",
     kind: "relation",
     id: "rel_b75516c583945a52",
-    externalHarness: false
+    externalHarness: false,
   });
   assert.equal(parseEntityRef("relation/not-a-relation"), null);
+});
+
+test("EntityRef parser accepts Phase 1 relation endpoints", () => {
+  for (const [kind, ref] of [
+    ["execution", "execution/exe-1"],
+    ["review", "review/rev-1"],
+    ["agent", "agent/codex"],
+    ["runtime-session", "runtime-session/run-1"],
+    ["policy", "policy/policy-1"],
+  ] as const) {
+    assert.equal(parseEntityRef(ref)?.kind, kind);
+  }
+  assert.equal(parseEntityRef("squad/codex"), null);
 });
 
 test("EntityRef scanner preserves external harness prefixes without resolving them", () => {
   const refs = findEntityRefs("depends on task/local-task and other-harness:task/remote-task");
 
-  assert.deepEqual(refs.map((ref) => [ref.raw, ref.externalHarness]), [
-    ["task/local-task", false],
-    ["other-harness:task/remote-task", true]
-  ]);
+  assert.deepEqual(
+    refs.map((ref) => [ref.raw, ref.externalHarness]),
+    [
+      ["task/local-task", false],
+      ["other-harness:task/remote-task", true],
+    ],
+  );
 });
 
 test("EntityRef scanner ignores task-like prose, package markers, and paths", () => {
-  const refs = findEntityRefs([
-    "Task Contract: harness-task/v1",
-    "workspace has task/doc/terminal panes",
-    "path scripts/domain/task/task-subjects.mts",
-    "real refs task/local-task, decision/decision-local/C1, and fact/task_local/F-a3f2 remain"
-  ].join("\n"));
+  const refs = findEntityRefs(
+    [
+      "Task Contract: harness-task/v1",
+      "workspace has task/doc/terminal panes",
+      "path scripts/domain/task/task-subjects.mts",
+      "real refs task/local-task, decision/decision-local/C1, and fact/task_local/F-a3f2 remain",
+    ].join("\n"),
+  );
 
-  assert.deepEqual(refs.map((ref) => ref.raw), ["task/local-task", "decision/decision-local/C1", "fact/task_local/F-a3f2"]);
+  assert.deepEqual(
+    refs.map((ref) => ref.raw),
+    ["task/local-task", "decision/decision-local/C1", "fact/task_local/F-a3f2"],
+  );
 });
 
 test("relation ids are deterministic and ignore mutable relation attributes", () => {
@@ -85,7 +106,7 @@ test("relation ids are deterministic and ignore mutable relation attributes", ()
     ...base,
     strength: "weak",
     rationale: "Different rationale, same canonical edge.",
-    state: "retired"
+    state: "retired",
   } satisfies EntityRelationRecord;
 
   assert.equal(deriveRelationId(base), "rel_472c68c5d5dff1ed");
@@ -97,28 +118,30 @@ test("relation validator rejects host drift, duplicates, missing rationale, and 
   const duplicateWithDifferentAttributes = {
     ...base,
     strength: "weak",
-    rationale: "A different authored attribute set on the same canonical edge."
+    rationale: "A different authored attribute set on the same canonical edge.",
   } satisfies EntityRelationRecord;
 
   assert.deepEqual(
-    validateRelationRecordsForHost("decision/dec_01K7ZTRIADIC", [base, duplicateWithDifferentAttributes])
-      .map((issue) => issue.code),
-    ["duplicate_relation_id"]
+    validateRelationRecordsForHost("decision/dec_01K7ZTRIADIC", [base, duplicateWithDifferentAttributes]).map(
+      (issue) => issue.code,
+    ),
+    ["duplicate_relation_id"],
   );
   assert.deepEqual(
-    validateRelationRecordsForHost("decision/dec_OTHER", [base])
-      .map((issue) => issue.code),
-    ["relation_host_source_mismatch"]
+    validateRelationRecordsForHost("decision/dec_OTHER", [base]).map((issue) => issue.code),
+    ["relation_host_source_mismatch"],
   );
   assert.deepEqual(
-    validateRelationRecordsForHost("decision/dec_01K7ZTRIADIC", [{ ...base, rationale: "   " }])
-      .map((issue) => issue.code),
-    ["relation_rationale_missing"]
+    validateRelationRecordsForHost("decision/dec_01K7ZTRIADIC", [{ ...base, rationale: "   " }]).map(
+      (issue) => issue.code,
+    ),
+    ["relation_rationale_missing"],
   );
   assert.deepEqual(
-    validateRelationRecordsForHost("decision/dec_01K7ZTRIADIC", [{ ...base, target: "fact/F-a3f2" }])
-      .map((issue) => issue.code),
-    ["invalid_relation_endpoint"]
+    validateRelationRecordsForHost("decision/dec_01K7ZTRIADIC", [{ ...base, target: "fact/F-a3f2" }]).map(
+      (issue) => issue.code,
+    ),
+    ["invalid_relation_endpoint"],
   );
 });
 
@@ -149,7 +172,7 @@ test("type-subset whitelist only governs active relations", () => {
       source: "decision/dec_01K7ZTRIADIC/CH1",
       target: "task/task_01KV5TBASE",
       type: "implements",
-      direction: "directed"
+      direction: "directed",
     }),
     source: "decision/dec_01K7ZTRIADIC/CH1",
     target: "task/task_01KV5TBASE",
@@ -158,20 +181,17 @@ test("type-subset whitelist only governs active relations", () => {
     direction: "directed",
     origin: "declared",
     rationale: "Wrong-direction edge retired by the ledger migration.",
-    state: "retired"
+    state: "retired",
   } satisfies EntityRelationRecord;
 
   // Retired audit history does not re-trip the whitelist ...
-  assert.deepEqual(
-    validateRelationRecordsForHost("decision/dec_01K7ZTRIADIC", [retiredIllegal]),
-    []
-  );
+  assert.deepEqual(validateRelationRecordsForHost("decision/dec_01K7ZTRIADIC", [retiredIllegal]), []);
   // ... but the same edge in active state still does.
   assert.deepEqual(
-    validateRelationRecordsForHost("decision/dec_01K7ZTRIADIC", [
-      { ...retiredIllegal, state: "active" }
-    ]).map((issue) => issue.code),
-    ["invalid_relation_type_subset"]
+    validateRelationRecordsForHost("decision/dec_01K7ZTRIADIC", [{ ...retiredIllegal, state: "active" }]).map(
+      (issue) => issue.code,
+    ),
+    ["invalid_relation_type_subset"],
   );
 });
 
@@ -194,6 +214,6 @@ function relationRecord(): EntityRelationRecord {
     direction: "directed",
     origin: "declared",
     rationale: "C1 is supported by the measured finding F-a3f2.",
-    state: "active"
+    state: "active",
   };
 }

--- a/packages/kernel/test/domain/relation-direction.test.ts
+++ b/packages/kernel/test/domain/relation-direction.test.ts
@@ -6,13 +6,29 @@ import {
   canonicalRelationDirections,
   incomingRelations,
   type CanonicalRelationDirection,
-  type RelationEndpointKind
+  type RelationEndpointKind,
 } from "../../src/domain/relation-direction.ts";
 
-const kinds: readonly RelationEndpointKind[] = ["task", "decision", "fact"];
+const kinds: readonly RelationEndpointKind[] = [
+  "task",
+  "decision",
+  "fact",
+  "execution",
+  "review",
+  "agent",
+  "runtime-session",
+  "policy",
+];
 
-function row(sourceKind: RelationEndpointKind, type: (typeof relationTypes)[number], targetKind: RelationEndpointKind): CanonicalRelationDirection | undefined {
-  return canonicalRelationDirections.find((direction) => direction.sourceKind === sourceKind && direction.type === type && direction.targetKind === targetKind);
+function row(
+  sourceKind: RelationEndpointKind,
+  type: (typeof relationTypes)[number],
+  targetKind: RelationEndpointKind,
+): CanonicalRelationDirection | undefined {
+  return canonicalRelationDirections.find(
+    (direction) =>
+      direction.sourceKind === sourceKind && direction.type === type && direction.targetKind === targetKind,
+  );
 }
 
 test("the canonical direction registry is the allowlist: every triple agrees, cell for cell", () => {
@@ -21,8 +37,9 @@ test("the canonical direction registry is the allowlist: every triple agrees, ce
       for (const targetKind of kinds) {
         assert.equal(
           isAllowedRelationKindTriple(sourceKind, type, targetKind),
-          row(sourceKind, type, targetKind) !== undefined,
-          `${sourceKind} --${type}--> ${targetKind}: allowlist and registry disagree`
+          row(sourceKind, type, targetKind) !== undefined &&
+            row(sourceKind, type, targetKind)?.registration !== "derived",
+          `${sourceKind} --${type}--> ${targetKind}: allowlist and registry disagree`,
         );
       }
     }
@@ -48,7 +65,7 @@ test("every replaced reverse alias is refused on the mirrored endpoint pair", ()
     assert.equal(
       isAllowedRelationKindTriple(direction.targetKind, alias, direction.sourceKind),
       false,
-      `retired alias ${direction.targetKind} --${alias}--> ${direction.sourceKind} must stay unwritable (mirror of ${direction.sourceKind} --${direction.type}--> ${direction.targetKind})`
+      `retired alias ${direction.targetKind} --${alias}--> ${direction.sourceKind} must stay unwritable (mirror of ${direction.sourceKind} --${direction.type}--> ${direction.targetKind})`,
     );
   }
 });
@@ -63,12 +80,12 @@ test("the reverse query agrees with the canonical direction for every registry r
     assert.deepEqual(
       incomingRelations(target, direction.type, edges).map((hit) => hit.source),
       [source],
-      `reverse query at the target of ${direction.sourceKind} --${direction.type}--> ${direction.targetKind} must return the canonical source only`
+      `reverse query at the target of ${direction.sourceKind} --${direction.type}--> ${direction.targetKind} must return the canonical source only`,
     );
     assert.deepEqual(
       incomingRelations(source, direction.type, edges),
       [noise],
-      `asking at the source with the same verb returns only the literal target-side edges`
+      `asking at the source with the same verb returns only the literal target-side edges`,
     );
   }
 });
@@ -78,7 +95,7 @@ test("semantics with no registered reading are flagged, not silently ratified", 
   assert.deepEqual(
     unregistered.map(({ type }) => type).sort(),
     ["blocks"],
-    "only the decision->decision blocks cell lacks registered semantics"
+    "only the decision->decision blocks cell lacks registered semantics",
   );
   for (const direction of unregistered) {
     assert.equal(direction.sourceKind, "decision");
@@ -90,4 +107,14 @@ test("a non-canonical active edge is refused at the write boundary", () => {
   // The same validation the daemon and frontmatter ingest path apply to active edges.
   assert.equal(isAllowedRelationKindTriple("fact", "invalidated-by", "decision"), false);
   assert.equal(isAllowedRelationKindTriple("task", "blocks", "task"), false);
+});
+
+test("Phase 1 relation directions are registered and owns remains derived-only", () => {
+  assert.equal(isAllowedRelationKindTriple("execution", "executes", "task"), true);
+  assert.equal(isAllowedRelationKindTriple("runtime-session", "executes", "task"), true);
+  assert.equal(isAllowedRelationKindTriple("review", "reviews", "execution"), true);
+  assert.equal(isAllowedRelationKindTriple("task", "owns", "agent"), false);
+  assert.equal(isAllowedRelationKindTriple("agent", "dispatches", "runtime-session"), true);
+  assert.equal(isAllowedRelationKindTriple("policy", "authorizes", "execution"), true);
+  assert.equal(canonicalRelationDirections.find((row) => row.type === "owns")?.registration, "derived");
 });

--- a/tools/check-relation-canonical-direction.mjs
+++ b/tools/check-relation-canonical-direction.mjs
@@ -22,11 +22,11 @@ import { pathToFileURL } from "node:url";
 const KERNEL_ALLOWLIST = "../packages/kernel/src/domain/entity-relation.ts";
 const KERNEL_DIRECTION = "../packages/kernel/src/domain/relation-direction.ts";
 const GUI_MIRROR = "../packages/gui/src/renderer/model/relation-direction.ts";
-const ENDPOINT_KINDS = ["task", "decision", "fact"];
+const ENDPOINT_KINDS = ["task", "decision", "fact", "execution", "review", "agent", "runtime-session", "policy"];
 const RETIRED_REVERSE_TRIPLES = [
   { sourceKind: "fact", type: "supports", targetKind: "decision", mirrorOf: "decision --evidenced-by--> fact" },
   { sourceKind: "fact", type: "invalidated-by", targetKind: "decision", mirrorOf: "decision --refuted-by--> fact" },
-  { sourceKind: "task", type: "blocks", targetKind: "task", mirrorOf: "task --depends-on--> task" }
+  { sourceKind: "task", type: "blocks", targetKind: "task", mirrorOf: "task --depends-on--> task" },
 ];
 const RETIRED_ALIAS_COMPARISON = /(?:===|!==|==|!=)\s*["']invalidated-by["']|\bcase\s+["']invalidated-by["']/u;
 const SOURCE_FILE = /\.(?:ts|tsx|mts|js|jsx|mjs)$/u;
@@ -42,26 +42,37 @@ export function checkRegistryShape({ canonicalRelationDirections }, findings = [
         findings.push(`canonicalRelationDirections[${index}]: ${field} must be a non-empty string`);
       }
     }
-    if (direction.registration !== "ratified" && direction.registration !== "unregistered") {
-      findings.push(`${cell}: registration must be "ratified" or "unregistered", got ${JSON.stringify(direction.registration)}`);
+    if (!["ratified", "unregistered", "derived"].includes(direction.registration)) {
+      findings.push(
+        `${cell}: registration must be "ratified", "unregistered", or "derived", got ${JSON.stringify(direction.registration)}`,
+      );
     }
     if (!ENDPOINT_KINDS.includes(direction.sourceKind) || !ENDPOINT_KINDS.includes(direction.targetKind)) {
-      findings.push(`${cell}: endpoint kinds must be task/decision/fact`);
+      findings.push(`${cell}: endpoint kinds must be one of the closed Phase 1 relation kinds`);
     }
   }
   if (canonicalRelationDirections.length === 0) findings.push("canonicalRelationDirections: registry is empty");
   return findings;
 }
 
-export function checkDirectionBijection({ canonicalRelationDirections, isAllowedRelationKindTriple, relationTypes }, findings = []) {
-  const registered = new Set(canonicalRelationDirections.map((direction) => `${direction.sourceKind}|${direction.type}|${direction.targetKind}`));
+export function checkDirectionBijection(
+  { canonicalRelationDirections, isAllowedRelationKindTriple, relationTypes },
+  findings = [],
+) {
+  const registered = new Set(
+    canonicalRelationDirections
+      .filter((direction) => direction.registration !== "derived")
+      .map((direction) => `${direction.sourceKind}|${direction.type}|${direction.targetKind}`),
+  );
   for (const sourceKind of ENDPOINT_KINDS) {
     for (const type of relationTypes) {
       for (const targetKind of ENDPOINT_KINDS) {
         const cell = `${sourceKind}|${type}|${targetKind}`;
         const allowed = isAllowedRelationKindTriple(sourceKind, type, targetKind);
         if (allowed !== registered.has(cell)) {
-          findings.push(`${sourceKind} --${type}--> ${targetKind}: allowlist says ${allowed}, direction registry says ${registered.has(cell)}`);
+          findings.push(
+            `${sourceKind} --${type}--> ${targetKind}: allowlist says ${allowed}, direction registry says ${registered.has(cell)}`,
+          );
         }
       }
     }
@@ -69,17 +80,41 @@ export function checkDirectionBijection({ canonicalRelationDirections, isAllowed
   return findings;
 }
 
-export function checkRetiredReverseTriplesRefused({ canonicalRelationDirections, isAllowedRelationKindTriple }, findings = []) {
+export function checkDerivedDirectionsNotWritable(
+  { canonicalRelationDirections, isAllowedRelationKindTriple },
+  findings = [],
+) {
+  for (const direction of canonicalRelationDirections) {
+    if (
+      direction.registration === "derived" &&
+      isAllowedRelationKindTriple(direction.sourceKind, direction.type, direction.targetKind)
+    ) {
+      findings.push(
+        `${direction.sourceKind} --${direction.type}--> ${direction.targetKind} is derived-only and must stay unwritable`,
+      );
+    }
+  }
+  return findings;
+}
+
+export function checkRetiredReverseTriplesRefused(
+  { canonicalRelationDirections, isAllowedRelationKindTriple },
+  findings = [],
+) {
   for (const triple of RETIRED_REVERSE_TRIPLES) {
     if (isAllowedRelationKindTriple(triple.sourceKind, triple.type, triple.targetKind)) {
-      findings.push(`${triple.sourceKind} --${triple.type}--> ${triple.targetKind} must stay unwritable: it is the retired mirror of ${triple.mirrorOf} (one canonical direction per semantic relation)`);
+      findings.push(
+        `${triple.sourceKind} --${triple.type}--> ${triple.targetKind} must stay unwritable: it is the retired mirror of ${triple.mirrorOf} (one canonical direction per semantic relation)`,
+      );
     }
   }
   for (const direction of canonicalRelationDirections) {
     const alias = direction.replacedReverseAlias;
     if (!alias) continue;
     if (isAllowedRelationKindTriple(direction.targetKind, alias, direction.sourceKind)) {
-      findings.push(`${direction.targetKind} --${alias}--> ${direction.sourceKind} must stay unwritable: retired reverse alias of ${direction.sourceKind} --${direction.type}--> ${direction.targetKind}`);
+      findings.push(
+        `${direction.targetKind} --${alias}--> ${direction.sourceKind} must stay unwritable: retired reverse alias of ${direction.sourceKind} --${direction.type}--> ${direction.targetKind}`,
+      );
     }
   }
   return findings;
@@ -93,29 +128,45 @@ export function checkReverseQueryAgreement({ canonicalRelationDirections, incomi
     const reverse = { source: target, target: source, type: direction.type };
     const hits = incomingRelations(target, direction.type, [reverse, canonical]);
     if (hits.length !== 1 || hits[0] !== canonical) {
-      findings.push(`incomingRelations must answer the reverse question for ${direction.sourceKind} --${direction.type}--> ${direction.targetKind}: expected [${source}], got ${JSON.stringify(hits.map((edge) => edge.source))}`);
+      findings.push(
+        `incomingRelations must answer the reverse question for ${direction.sourceKind} --${direction.type}--> ${direction.targetKind}: expected [${source}], got ${JSON.stringify(hits.map((edge) => edge.source))}`,
+      );
     }
   }
   return findings;
 }
 
-export function checkGuiMirrorAgreement({ canonicalRelationDirections, incomingRelations }, guiIncomingRelations, findings = []) {
+export function checkGuiMirrorAgreement(
+  { canonicalRelationDirections, incomingRelations },
+  guiIncomingRelations,
+  findings = [],
+) {
   // The renderer may not import kernel runtime values (window.harness bridge only), so
   // the GUI carries a mirror of the reverse query. Both must answer identically for
   // every registry verb; this check makes the mirror drift a gate failure, not a silent
   // second orientation.
-  const kernelEdges = [], rendererEdges = [];
+  const kernelEdges = [],
+    rendererEdges = [];
   for (const direction of canonicalRelationDirections) {
-    const source = `${direction.sourceKind}/probe-source`, target = `${direction.targetKind}/probe-target`;
-    kernelEdges.push({ source, target, type: direction.type }, { source: target, target: source, type: direction.type });
-    rendererEdges.push({ from: source, to: target, kind: direction.type }, { from: target, to: source, kind: direction.type });
+    const source = `${direction.sourceKind}/probe-source`,
+      target = `${direction.targetKind}/probe-target`;
+    kernelEdges.push(
+      { source, target, type: direction.type },
+      { source: target, target: source, type: direction.type },
+    );
+    rendererEdges.push(
+      { from: source, to: target, kind: direction.type },
+      { from: target, to: source, kind: direction.type },
+    );
   }
   for (const direction of canonicalRelationDirections) {
     const target = `${direction.targetKind}/probe-target`;
     const kernelHits = incomingRelations(target, direction.type, kernelEdges).map((edge) => edge.source);
     const rendererHits = guiIncomingRelations(target, direction.type, rendererEdges).map((edge) => edge.from);
     if (JSON.stringify(kernelHits) !== JSON.stringify(rendererHits)) {
-      findings.push(`renderer reverse-query mirror disagrees with the kernel for ${direction.type} at ${target}: kernel [${kernelHits}] vs renderer [${rendererHits}]`);
+      findings.push(
+        `renderer reverse-query mirror disagrees with the kernel for ${direction.type} at ${target}: kernel [${kernelHits}] vs renderer [${rendererHits}]`,
+      );
     }
   }
   return findings;
@@ -126,7 +177,9 @@ export function checkNoRetiredAliasReads(root = process.cwd(), findings = []) {
     const rel = path.relative(root, file).split(path.sep).join("/");
     if (isTestOrFixturePath(rel)) continue;
     if (RETIRED_ALIAS_COMPARISON.test(readFileSync(file, "utf8"))) {
-      findings.push(`${rel}: reads or writes the retired invalidated-by alias; reverse questions must go through incomingRelations`);
+      findings.push(
+        `${rel}: reads or writes the retired invalidated-by alias; reverse questions must go through incomingRelations`,
+      );
     }
   }
   return findings;
@@ -141,16 +194,19 @@ async function main() {
     ...checkRegistryShape(modules),
     ...checkDirectionBijection(modules),
     ...checkRetiredReverseTriplesRefused(modules),
+    ...checkDerivedDirectionsNotWritable(modules),
     ...checkReverseQueryAgreement(modules),
     ...checkGuiMirrorAgreement(modules, guiMirror.incomingRelations),
-    ...checkNoRetiredAliasReads()
+    ...checkNoRetiredAliasReads(),
   ];
   if (findings.length > 0) {
     console.error("Canonical relation direction check failed:");
     for (const finding of findings) console.error(`- ${finding}`);
     process.exit(1);
   }
-  console.log("Canonical relation direction check passed (registry, allowlist, and reverse query agree; retired mirrors refused).");
+  console.log(
+    "Canonical relation direction check passed (registry, allowlist, and reverse query agree; retired mirrors refused).",
+  );
 }
 
 function walk(dir) {
@@ -175,10 +231,14 @@ function walk(dir) {
 }
 
 function isTestOrFixturePath(rel) {
-  return /(?:^|\/)(?:__fixtures__|fixtures|test|tests|e2e)\//u.test(rel) || /\.(?:test|spec|vitest)\.[cm]?[jt]sx?$/u.test(rel);
+  return (
+    /(?:^|\/)(?:__fixtures__|fixtures|test|tests|e2e)\//u.test(rel) ||
+    /\.(?:test|spec|vitest)\.[cm]?[jt]sx?$/u.test(rel)
+  );
 }
 
-const invokedDirectly = process.argv[1] !== undefined && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
 if (invokedDirectly) {
   await main();
 }


### PR DESCRIPTION
# English

## Summary

Phase 1 promotes Execution, Review, Agent, RuntimeSession and Policy to entities, but the relation-direction gate only knew task/decision/fact endpoints and the status register had no vocabulary for Agent or Policy. This PR extends the closed endpoint vocabulary to the eight Phase 1 kinds, registers the five Phase 1 edges (executes, reviews, owns, dispatches, authorizes) with direction, allowlist and reverse query in agreement, adds Agent/Policy state vocabularies to the existing status register, and rejects any owner*/createdBy* mutation at the task-event boundary so ownership stays derived from createdBy.principal.

## Architectural Justification

Why the existing modules cannot carry it: the relation-direction gate's endpoint vocabulary is a compile-time closed set; without extending it every Phase 1 edge is rejected, and there is no second place to register edges. Adding Agent/Policy state vocabularies goes into the existing status register rather than a new file.
What obsolete code was removed: nothing functional — the 225 deleted lines are formatter normalization of touched lines (pre-commit prettier), verified by diff.
Why the scope cannot be narrowed: the six rows, the endpoint set and the reverse-query table must change together or the gate's own consistency check (registry = allowlist = reverse) fails; owner immutability is included because `owns` is a derived-only edge and would otherwise be writable through the same registration.

## What Changed

- `tools/check-relation-canonical-direction.mjs` and the relation registry/allowlist: endpoint kinds become the closed set {task, decision, fact, execution, review, agent, runtime-session, policy}; six rows registered.
- Status register / kernel vocabularies: Agent and Policy state vocabularies added; Execution/Review/RuntimeSession keep their existing authoritative vocabularies.
- Task-event boundary: `owner*` and `createdBy*` mutation fields are rejected; contract test locks that any write path to owner fails.
- Deletions are formatter normalization of touched lines only.
- `packages/kernel/src/domain/entity-ref.ts`: the entity-reference scanner regex is split into `String.raw` segments (layout only, same alternatives and flags) so G36 line-density passes.

## Machine-Readable Declarations

Production-Delta: +278/-226

## Task And Scope

- Harness task: task_b054dbbb929b8f243feafc1de1 (PLT-Ontology Phase 1.5)
- Branch: `codex/relation-vocab`
- Public scope: relation direction gate vocabulary, relation registry, status register, task-event mutation guard, tests
- Private planning/evidence updated: yes (artifacts/reports/relation-vocab.md)
- Out of scope: wiring the new edges into Execution/RuntimeSession/Policy writers (Phase 1.2/1.3/1.4 PRs)

## Version Impact

- Version: no version change because this is a pre-release fix on the rebuild line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_b054dbbb929b8f243feafc1de1 (PLT-Ontology Phase 1.5); CEO ruling 2026-08-25 in the milestone task_plan explicitly authorizes extending the canonical-direction gate endpoint vocabulary (closed set, no weakening)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: aad7aa10919dc78920f0bfd0641c40354346f0c7
- Branch merge-base with `origin/main`: aad7aa10919dc78920f0bfd0641c40354346f0c7
- Last `git fetch origin` time: 2026-08-25T02:10Z
- Sync method: rebase
- Public diff command: `git diff aad7aa10919dc78920f0bfd0641c40354346f0c7..4aede19be`
- Private evidence commit/path: harness task package task_b054dbbb929b8f243feafc1de1 artifacts/reports
- Reviewer evidence path: worker report relation-vocab.md: canonical-direction gate passed with the six rows; status vocabulary gate passed; typecheck passed; CEO diffed the gate change and confirmed the set is still closed and no direction/reverse/retired-mirror logic was removed
- GitHub Actions `rewrite-ci` run URL: pending (filled after the run)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test` (relation direction gate, status vocabulary gate, contract tests for owner immutability (Node 22 strip-types loader in the worker worktree))
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full GitHub integration shard matrix locally (CI is the authority); Docker-isolated run of the new contract test was recorded by the worker

## Review Evidence

- Self-review: CEO: extending the gate is the core deliverable of the vocabulary task, not a bypass — the set stays closed and every new row is validated three ways. Owner immutability is enforced at the boundary rather than by convention.
- Reviewer subagent: yes (read-only report audit with independent git verification)
- Human review: pending
- Blocking findings: none

## Residual Risk

- 1.2 and 1.3 branches carry their own copies of `executes`/`reviews` rows; they must rebase onto this vocabulary before merge (CEO enforces).

## References

- Task: task_b054dbbb929b8f243feafc1de1
- Evidence: artifacts/reports/relation-vocab.md
- Review: pending

---

# 中文

## 概要

Phase 1 要把 Execution/Review/Agent/RuntimeSession/Policy 晋升为实体,但关系方向门只认 task/decision/fact 端点,状态登记表也没有 Agent/Policy 的词表。本 PR 把封闭端点集扩展为八类 Phase 1 kind,登记五条 Phase 1 边(executes/reviews/owns/dispatches/authorizes)并保证方向、allowlist、reverse query 三处一致,在既有状态登记表加 Agent/Policy 词表,并在 task-event 边界拒绝一切 owner*/createdBy* 变更,让 owner 始终派生自 createdBy.principal。

## 架构辩护

现有模块为何无法承载:关系方向门的端点词表是编译期封闭集,不扩展则每条 Phase 1 边都被拒,且没有第二个登记边的位置;Agent/Policy 状态词表加进既有状态登记表而不是新文件。
删除了哪些废弃代码:无功能性删除——225 行删除全部是触及行的格式化归一(pre-commit prettier),diff 已核。
为何不能收窄:六行、端点集、reverse-query 表必须同时改,否则门自身的一致性校验(registry = allowlist = reverse)不过;owner 不可变一并纳入,因为 `owns` 是只派生边,否则同一登记路径就能写它。

## 改动内容

- `tools/check-relation-canonical-direction.mjs` 与关系 registry/allowlist:端点 kind 变为封闭集 {task, decision, fact, execution, review, agent, runtime-session, policy};登记六行。
- 状态登记表/kernel 词表:新增 Agent 与 Policy 状态词表;Execution/Review/RuntimeSession 沿用既有权威词表。
- task-event 边界:拒绝 `owner*`/`createdBy*` 变更字段;contract 测试锁定任何写 owner 的路径必须失败。
- 删除行仅为触及行的格式化归一。
- `packages/kernel/src/domain/entity-ref.ts`:实体引用扫描正则拆成 `String.raw` 分段(仅布局,备选与 flag 不变),G36 通过。

## 机读声明说明

- 机读声明只在英文块出现一次。

## 任务与范围

- Harness 任务:task_b054dbbb929b8f243feafc1de1(PLT-Ontology Phase 1.5)
- 分支:`codex/relation-vocab`
- 公开范围:关系方向门词表、关系 registry、状态登记表、task-event 变更守卫、测试
- 私有计划 / 证据是否已更新:yes(artifacts/reports/relation-vocab.md)
- 范围外:把新边接到 Execution/RuntimeSession/Policy 的写路径(1.2/1.3/1.4 的 PR)

## 版本影响

- 版本:不改版本,原因是 rebuild 线 pre-release 修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_b054dbbb929b8f243feafc1de1 (PLT-Ontology Phase 1.5); CEO ruling 2026-08-25 in the milestone task_plan explicitly authorizes extending the canonical-direction gate endpoint vocabulary (closed set, no weakening)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:aad7aa10919dc78920f0bfd0641c40354346f0c7
- 当前分支与 `origin/main` 的 merge-base:aad7aa10919dc78920f0bfd0641c40354346f0c7
- 最近一次 `git fetch origin` 时间:2026-08-25T02:10Z
- 同步方式:rebase
- 公开 diff 命令:`git diff aad7aa10919dc78920f0bfd0641c40354346f0c7..4aede19be`
- 私有证据 commit/path:任务包 artifacts/reports
- Reviewer 证据路径:worker 回执 relation-vocab.md:方向门带六行通过;状态词表门通过;typecheck 通过;CEO 逐行看过门的改动,确认集合仍封闭、方向/reverse/retired-mirror 逻辑未删
- GitHub Actions `rewrite-ci` run URL:待 run 结束后补
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`(关系方向门、状态词表门、owner 不可变 contract 测试(worker worktree 内 Node 22 strip-types loader))
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:完整 GitHub integration shard 矩阵未在本地跑(CI 为权威);新 contract 测试的 Docker 隔离运行由 worker 记录

## 审查证据

- 自查:CEO:扩展该门是词表任务的核心交付,不是绕门——集合仍封闭,每条新行三处校验。owner 不可变在边界强制而非靠约定。
- Reviewer subagent:有(只读回执审计 + git 独立核实)
- 人工审查:待
- 阻塞发现:无

## 残余风险

- 1.2/1.3 分支各自带了 `executes`/`reviews` 行副本,合入前必须 rebase 到本词表(CEO 把关)。

## 关联材料

- 任务:task_b054dbbb929b8f243feafc1de1
- 证据:artifacts/reports/relation-vocab.md
- 审查:待

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPPk3TmbURWuxcFY3kFimA

