### PR TITLE
feat(ontology): Execution and Review as entities on the generic EntityStore

### DIFF
--- a/packages/kernel/src/domain/entity-json-schema.ts
+++ b/packages/kernel/src/domain/entity-json-schema.ts
@@ -8,9 +8,10 @@ export type EntityJsonSchemaNode = (
       readonly description?: string;
     }
   | {
-      readonly type: "number";
+      readonly type: "number" | "integer" | "boolean" | "null";
       readonly integer?: boolean;
       readonly minimum?: number;
+      readonly enum?: readonly (string | number | boolean | null)[];
       readonly description?: string;
     }
   | {
@@ -22,7 +23,7 @@ export type EntityJsonSchemaNode = (
       readonly description?: string;
     }
   | EntityJsonObjectSchema
-) & { readonly "x-error"?: string };
+) & { readonly "x-error"?: string; readonly "x-nullable"?: boolean };
 
 export const ENTITY_ID_PATTERN = "^[a-z0-9][a-z0-9-]{0,63}$";
 
@@ -30,7 +31,7 @@ export interface EntityJsonObjectSchema {
   readonly type: "object";
   readonly properties: Readonly<Record<string, EntityJsonSchemaNode>>;
   readonly required: readonly string[];
-  readonly additionalProperties: false;
+  readonly additionalProperties: boolean;
   readonly description?: string;
 }
 
@@ -89,6 +90,7 @@ export function explainEntityJsonSchema(schema: EntityDocumentJsonSchema): reado
 }
 
 function validateNode(schema: EntityJsonSchemaNode, value: unknown, path: string, errors: string[]): void {
+  if (value === null && schema["x-nullable"] === true) return;
   const errorStart = errors.length;
   validateNodeValue(schema, value, path, errors);
   if (errors.length > errorStart && schema["x-error"] !== undefined)
@@ -111,14 +113,29 @@ function validateNodeValue(schema: EntityJsonSchemaNode, value: unknown, path: s
       errors.push(`${path} does not match its declared pattern.`);
     return;
   }
-  if (schema.type === "number") {
+  if (schema.type === "number" || schema.type === "integer") {
     if (typeof value !== "number" || !Number.isFinite(value)) {
       errors.push(`${path} must be a finite number.`);
       return;
     }
     if (schema.integer && !Number.isSafeInteger(value)) errors.push(`${path} must be an integer.`);
+    if (schema.type === "integer" && !Number.isInteger(value)) errors.push(`${path} must be an integer.`);
     if (schema.minimum !== undefined && value < schema.minimum)
       errors.push(`${path} must be at least ${schema.minimum}.`);
+    if (schema.enum !== undefined && !schema.enum.includes(value)) errors.push(`${path} has an invalid value.`);
+    return;
+  }
+  if (schema.type === "boolean") {
+    if (typeof value !== "boolean") {
+      errors.push(`${path} must be a boolean.`);
+      return;
+    }
+    if (schema.enum !== undefined && !schema.enum.includes(value)) errors.push(`${path} has an invalid value.`);
+    return;
+  }
+  if (schema.type === "null") {
+    if (value !== null) errors.push(`${path} must be null.`);
+    else if (schema.enum !== undefined && !schema.enum.includes(value)) errors.push(`${path} has an invalid value.`);
     return;
   }
   if (schema.type === "array") {
@@ -138,6 +155,7 @@ function validateNodeValue(schema: EntityJsonSchemaNode, value: unknown, path: s
     }
     return;
   }
+  if (schema.type !== "object") return;
   if (!isRecord(value)) {
     errors.push(`${path} must be a JSON object.`);
     return;
@@ -145,9 +163,10 @@ function validateNodeValue(schema: EntityJsonSchemaNode, value: unknown, path: s
   for (const field of schema.required)
     if (!Object.hasOwn(value, field) || value[field] === undefined)
       errors.push(`${path} is missing required field ${JSON.stringify(field)}.`);
-  for (const field of Object.keys(value))
-    if (!Object.hasOwn(schema.properties, field))
-      errors.push(`${path} field ${JSON.stringify(field)} is unknown; remove it.`);
+  if (!schema.additionalProperties)
+    for (const field of Object.keys(value))
+      if (!Object.hasOwn(schema.properties, field))
+        errors.push(`${path} field ${JSON.stringify(field)} is unknown; remove it.`);
   for (const [field, fieldSchema] of Object.entries(schema.properties))
     if (Object.hasOwn(value, field) && value[field] !== undefined)
       validateNode(fieldSchema, value[field], `${path} field ${JSON.stringify(field)}`, errors);

--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -1,10 +1,16 @@
 import type { VerticalDefinition } from "../schemas/registry.ts";
 import { AGENT_DECLARATION_V1_SCHEMA, SQUAD_DECLARATION_V1_SCHEMA } from "./agent-squad-schema.ts";
 import { DEFAULT_POLICY } from "./default-policy.ts";
-import { ENTITY_ID_PATTERN, explainEntityJsonSchema, type EntityDocumentJsonSchema } from "./entity-json-schema.ts";
+import {
+  ENTITY_ID_PATTERN,
+  explainEntityJsonSchema,
+  type EntityDocumentJsonSchema,
+  type EntityJsonObjectSchema,
+  type EntityJsonSchemaNode,
+} from "./entity-json-schema.ts";
+import type { RelationDirection } from "./entity-relation.ts";
 import { POLICY_DECLARATION_V1_SCHEMA, validatePolicyDeclarationV1 } from "./policy.ts";
 import type { PolicyPredicateName } from "./policy.ts";
-import type { RelationDirection } from "./entity-relation.ts";
 
 export type EntityKindDeclaration = VerticalDefinition["entityKinds"][number];
 export type EntityPackageScaffold = VerticalDefinition["packageScaffolds"][number];
@@ -80,6 +86,91 @@ const declarationId = Object.freeze({
 const declarationDocument = (pathTemplate: string) =>
   Object.freeze({ pathTemplate, mediaType: "application/json" as const, policyId: ENTITY_DOCUMENT_POLICY_ID });
 
+const executionIdPattern = "^[a-z0-9][a-z0-9_-]{0,127}$";
+const reviewIdPattern = "^[a-z0-9][a-z0-9_-]{0,127}$";
+const lifecycleTaskIdPattern = "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$";
+const opaqueObject = (): EntityJsonObjectSchema => ({
+  type: "object",
+  properties: {},
+  required: [],
+  additionalProperties: true,
+});
+const nullableOpaqueObject = (): EntityJsonSchemaNode => ({
+  type: "object",
+  properties: {},
+  required: [],
+  additionalProperties: true,
+  "x-nullable": true,
+});
+const executionSchema: EntityDocumentJsonSchema = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  $id: "Execution/v1",
+  type: "object",
+  properties: {
+    schema: { type: "string", const: "execution/v1" },
+    executionId: { type: "string", pattern: executionIdPattern, minLength: 1 },
+    taskId: { type: "string", pattern: lifecycleTaskIdPattern, minLength: 1 },
+    nodeId: { type: "string", const: "implementation" },
+    iteration: { type: "integer" },
+    state: { type: "string", enum: ["active", "submitted", "accepted", "changes_requested", "abandoned"] },
+    actor: opaqueObject(),
+    claimedAt: { type: "string", minLength: 1 },
+    submittedAt: { type: "string", minLength: 1, "x-nullable": true },
+    closedAt: { type: "string", minLength: 1, "x-nullable": true },
+    submission: nullableOpaqueObject(),
+  },
+  required: [
+    "schema",
+    "executionId",
+    "taskId",
+    "nodeId",
+    "iteration",
+    "state",
+    "actor",
+    "claimedAt",
+    "submittedAt",
+    "closedAt",
+    "submission",
+  ],
+  additionalProperties: false,
+};
+const reviewSchema: EntityDocumentJsonSchema = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  $id: "Review/v1",
+  type: "object",
+  properties: {
+    schema: { type: "string", const: "review/v1" },
+    reviewId: { type: "string", pattern: reviewIdPattern, minLength: 1 },
+    taskId: { type: "string", pattern: lifecycleTaskIdPattern, minLength: 1 },
+    executionId: { type: "string", pattern: executionIdPattern, minLength: 1 },
+    verdict: { type: "string", enum: ["approved", "changes_requested", "dismissed"] },
+    actor: opaqueObject(),
+    capabilityRef: { type: "string", minLength: 1 },
+    reason: { type: "string", minLength: 1 },
+    evidenceChecked: { type: "array", items: { type: "string", minLength: 1 } },
+    commitSha: { type: "string", pattern: "^[0-9a-f]{40}$" },
+    iteration: { type: "integer" },
+    contentDigest: { type: "string", pattern: "^sha256:[0-9a-f]{64}$" },
+    reviewedAt: { type: "string", minLength: 1 },
+  },
+  required: [
+    "schema",
+    "reviewId",
+    "taskId",
+    "executionId",
+    "verdict",
+    "actor",
+    "capabilityRef",
+    "reason",
+    "evidenceChecked",
+    "commitSha",
+    "iteration",
+    "contentDigest",
+    "reviewedAt",
+  ],
+  additionalProperties: false,
+};
+
 export const entityKindContracts = Object.freeze([
   {
     kind: "agent",
@@ -109,6 +200,28 @@ export const entityKindContracts = Object.freeze([
       predicates: Object.freeze(["isOwner", "isExecutorOfExecution", "hasCommandClass", "reviewIndependence"]),
       actions: DEFAULT_POLICY.actions,
     },
+  },
+  {
+    kind: "execution",
+    schema: executionSchema,
+    id: { field: "executionId", pattern: executionIdPattern, refTemplate: "execution/{id}" },
+    relations: { directions: ["directed"] },
+    transitionCatalog: {
+      ref: "kernel/task-lifecycle/v1",
+      transitions: ["start", "renew", "submit", "complete", "release"],
+    },
+    document: declarationDocument("executions/{id}.json"),
+  },
+  {
+    kind: "review",
+    schema: reviewSchema,
+    id: { field: "reviewId", pattern: reviewIdPattern, refTemplate: "review/{id}" },
+    relations: { directions: ["directed"] },
+    transitionCatalog: {
+      ref: "kernel/task-lifecycle/v1",
+      transitions: ["record"],
+    },
+    document: declarationDocument("reviews/{id}.json"),
   },
 ] as const satisfies readonly EntityKindContract[]);
 

--- a/packages/kernel/src/domain/entity-ref.ts
+++ b/packages/kernel/src/domain/entity-ref.ts
@@ -21,12 +21,15 @@ export interface ParsedEntityRef {
 
 const entityRefPrefixPattern = /^(?:(?<alias>[A-Za-z][A-Za-z0-9_-]*):)?(?<body>.+)$/u;
 const taskOrDecisionRefPattern = /^(?<kind>task|decision)\/(?<id>[A-Za-z0-9_-]+)(?:\/(?<anchor>[A-Za-z0-9_-]+))?$/u;
+const executionRefPattern = /^execution\/(?<ownerTaskId>[A-Za-z0-9_-]+)\/(?<executionId>[A-Za-z0-9_-]+)$/u;
+const reviewRefPattern = /^review\/(?<ownerExecutionId>[A-Za-z0-9_-]+)\/(?<reviewId>[A-Za-z0-9_-]+)$/u;
 const phaseOneEntityRefPattern = /^(?<kind>execution|review|agent|runtime-session|policy)\/(?<id>[A-Za-z0-9_-]+)$/u;
 const factRefPattern = /^fact\/(?<ownerTaskId>[A-Za-z0-9_-]+)\/(?<factId>[A-Za-z0-9_-]+)$/u;
 const relationRefPattern = /^relation\/(?<relationId>rel_[a-f0-9]{16})$/u;
 const entityRefSearchPattern = new RegExp(
   String.raw`(?<![A-Za-z0-9_/-])(?:[A-Za-z][A-Za-z0-9_-]*:)?(?:fact\/[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+|` +
-    String.raw`relation\/rel_[a-f0-9]{16}|(?:task|decision)\/[A-Za-z0-9_-]+(?:\/[A-Za-z0-9_-]+)?|` +
+    String.raw`relation\/rel_[a-f0-9]{16}|(?:execution|review)\/[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+|` +
+    String.raw`(?:task|decision)\/[A-Za-z0-9_-]+(?:\/[A-Za-z0-9_-]+)?|` +
     String.raw`(?:execution|review|agent|runtime-session|policy)\/[A-Za-z0-9_-]+)\b(?!\/)`,
   "gu",
 );
@@ -73,6 +76,31 @@ export function parseEntityRef(value: string): ParsedEntityRef | null {
       raw: value,
       kind: "relation",
       id: relation.groups.relationId,
+      ...(harnessAlias ? { harnessAlias } : {}),
+      externalHarness: Boolean(harnessAlias),
+    };
+  }
+
+  const execution = body.match(executionRefPattern);
+  if (execution?.groups?.ownerTaskId && execution.groups.executionId) {
+    if (!isPlausibleTaskRefId(execution.groups.ownerTaskId)) return null;
+    return {
+      raw: value,
+      kind: "execution",
+      id: execution.groups.executionId,
+      ownerTaskId: execution.groups.ownerTaskId,
+      ...(harnessAlias ? { harnessAlias } : {}),
+      externalHarness: Boolean(harnessAlias),
+    };
+  }
+
+  const review = body.match(reviewRefPattern);
+  if (review?.groups?.ownerExecutionId && review.groups.reviewId) {
+    return {
+      raw: value,
+      kind: "review",
+      id: review.groups.reviewId,
+      ownerTaskId: review.groups.ownerExecutionId,
       ...(harnessAlias ? { harnessAlias } : {}),
       externalHarness: Boolean(harnessAlias),
     };

--- a/packages/kernel/src/projection/rebuildable-task-projection-database.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-database.ts
@@ -8,11 +8,7 @@ import { createRelationGraphProjectionTables } from "./relation-graph-projection
 import { taskProjectionSchemaVersion } from "./projection-schema.ts";
 import { createTaskRelationProjectionTable } from "./task-query-projection.ts";
 import type { EventStreamPort } from "./rebuildable-task-projection-types.ts";
-import {
-  queryRows,
-  runSql,
-  transaction,
-} from "./rebuildable-task-projection-sql.ts";
+import { queryRows, runSql, transaction } from "./rebuildable-task-projection-sql.ts";
 export type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
 export type { TaskProjection } from "./task-projection-port.ts";
 
@@ -186,13 +182,11 @@ function projectionFileFingerprint(projectionPath: string): string | null {
 function matchesLedgerIdentity(db: DatabaseSync, head: ReturnType<EventStreamPort["readHead"]>): boolean {
   const row =
     /* @gate-identity check-bypass-write-boundary/bypass-write-010 */
-    db
-    .prepare("SELECT watermark, scanned_revision, head_digest FROM projection_meta WHERE singleton = 1")
-    .get() as {
-    readonly watermark: number;
-    readonly scanned_revision: number;
-    readonly head_digest: string | null;
-  };
+    db.prepare("SELECT watermark, scanned_revision, head_digest FROM projection_meta WHERE singleton = 1").get() as {
+      readonly watermark: number;
+      readonly scanned_revision: number;
+      readonly head_digest: string | null;
+    };
   const sourceRevision = head?.revision ?? 0;
   if (Number(row.watermark) > sourceRevision || Number(row.scanned_revision) > sourceRevision) return false;
   return Number(row.scanned_revision) !== sourceRevision || row.head_digest === (head?.eventDigest ?? null);
@@ -297,19 +291,16 @@ function createTables(db: DatabaseSync): void {
       execution_id TEXT NOT NULL,
       event_json TEXT NOT NULL
     );
-    CREATE TABLE IF NOT EXISTS execution (
-      execution_id TEXT PRIMARY KEY,
-      task_id TEXT NOT NULL,
+    CREATE TABLE IF NOT EXISTS entity_projection (
+      entity_kind TEXT NOT NULL,
+      entity_id TEXT NOT NULL,
+      task_id TEXT,
       workspace_revision INTEGER NOT NULL,
-      value_json TEXT NOT NULL
+      value_json TEXT NOT NULL,
+      PRIMARY KEY(entity_kind, entity_id)
     );
-    CREATE TABLE IF NOT EXISTS review (
-      review_id TEXT PRIMARY KEY,
-      task_id TEXT NOT NULL,
-      execution_id TEXT NOT NULL,
-      workspace_revision INTEGER NOT NULL,
-      value_json TEXT NOT NULL
-    );
+    CREATE INDEX IF NOT EXISTS entity_projection_task
+      ON entity_projection(entity_kind, task_id, workspace_revision, entity_id);
     CREATE TABLE IF NOT EXISTS edge (
       task_id TEXT NOT NULL,
       edge_id TEXT NOT NULL,
@@ -334,7 +325,9 @@ function createTables(db: DatabaseSync): void {
   // This table is a disposable lookup over runtime_session.value_json, so adding it must not
   // invalidate the self-contained projection database (event_source lives in the same file).
   // Backfill once in place; steady-state runtime events maintain the rows transactionally.
-  runSql(db, `
+  runSql(
+    db,
+    `
     INSERT OR IGNORE INTO runtime_session_task_binding(task_id, runtime_session_id, execution_id, bound_at)
     SELECT
       json_extract(binding.value, '$.taskId'),
@@ -346,7 +339,8 @@ function createTables(db: DatabaseSync): void {
     WHERE json_type(binding.value, '$.taskId') = 'text'
       AND json_type(binding.value, '$.executionId') = 'text'
       AND json_type(binding.value, '$.boundAt') = 'text';
-  `);
+  `,
+  );
   createTaskRelationProjectionTable(db);
   createRelationGraphProjectionTables(db);
   createFactProjectionTables(db);

--- a/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
@@ -104,6 +104,12 @@ export function applyEvent(
       throw new Error(`entity declaration blob ${claim.sha256} is not UTF-8`);
     }
     if (sha256Text(body) !== claim.sha256) throw new Error(`entity declaration blob ${claim.sha256} hash mismatch`);
+    let value: unknown;
+    try {
+      value = JSON.parse(body);
+    } catch {
+      throw new Error(`entity declaration blob ${claim.sha256} is not JSON`);
+    }
     const document: DocumentState = {
       path: claim.path as DocumentState["path"],
       blobSha256: claim.sha256,
@@ -121,6 +127,21 @@ export function applyEvent(
       eventJson,
     );
     runSql(db, UPSERT_DOCUMENT_SQL, claim.path, event.workspaceRevision, canonicalJson(document));
+    const record = value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+    if (event.payload.entityKind === "execution" || event.payload.entityKind === "review")
+      runSql(
+        db,
+        [
+          "INSERT INTO entity_projection(entity_kind, entity_id, task_id, workspace_revision, value_json)",
+          "VALUES (?, ?, ?, ?, ?) ON CONFLICT(entity_kind, entity_id) DO UPDATE SET",
+          "task_id=excluded.task_id, workspace_revision=excluded.workspace_revision, value_json=excluded.value_json",
+        ].join(" "),
+        event.payload.entityKind,
+        event.payload.entityId,
+        typeof record.taskId === "string" ? record.taskId : null,
+        event.workspaceRevision,
+        body,
+      );
     return;
   }
   if (isFactEvent(event)) {
@@ -181,7 +202,8 @@ export function applyEvent(
       const previous =
           /* @gate-identity check-bypass-write-boundary/bypass-write-011 */
           db.prepare("SELECT value_json FROM document WHERE path = ?").get(change.path) as
-            { readonly value_json: string } | undefined,
+            | { readonly value_json: string }
+            | undefined,
         base = previous ? (JSON.parse(previous.value_json) as DocumentState) : null;
       if (change.candidate === null) {
         if (

--- a/packages/kernel/src/projection/rebuildable-task-projection-migration.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-migration.ts
@@ -32,6 +32,11 @@ const UPSERT_DOCUMENT_SQL = [
   "ON CONFLICT(path) DO UPDATE SET workspace_revision=excluded.workspace_revision,",
   "value_json=excluded.value_json",
 ].join(" ");
+const UPSERT_ENTITY_SQL = [
+  "INSERT INTO entity_projection(entity_kind, entity_id, task_id, workspace_revision, value_json)",
+  "VALUES (?, ?, ?, ?, ?) ON CONFLICT(entity_kind, entity_id) DO UPDATE SET",
+  "task_id=excluded.task_id, workspace_revision=excluded.workspace_revision, value_json=excluded.value_json",
+].join(" ");
 
 // Legacy migration-import replay and its document materialization.
 export function projectMigration(
@@ -202,14 +207,15 @@ export function projectMigration(
       UPSERT_TASK_SNAPSHOT_SQL,
       value.taskId,
       event.workspaceRevision,
-      canonicalJson(next),
+      canonicalJson({ ...next, executions: [], reviews: [] }),
       next.task?.status ?? null,
       event.occurredAt,
     );
     refreshTaskRelationProjection(db, value.taskId, next.task, event.workspaceRevision, event.occurredAt);
     runSql(
       db,
-      "INSERT INTO execution(execution_id, task_id, workspace_revision, value_json) VALUES (?, ?, ?, ?)",
+      UPSERT_ENTITY_SQL,
+      "execution",
       value.executionId,
       value.taskId,
       event.workspaceRevision,

--- a/packages/kernel/src/projection/rebuildable-task-projection-runtime.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-runtime.ts
@@ -101,8 +101,8 @@ export function readSnapshot(db: DatabaseSync, taskId: string, now?: string): Ta
   const row =
     /* @gate-identity check-bypass-write-boundary/bypass-write-024 */
     db.prepare("SELECT snapshot_json FROM task_snapshot WHERE task_id = ?").get(taskId) as
-    | { readonly snapshot_json: string }
-    | undefined;
+      | { readonly snapshot_json: string }
+      | undefined;
   if (row === undefined) return emptyTaskLifecycleSnapshot();
   let snapshot: TaskLifecycleSnapshot;
   try {
@@ -110,6 +110,16 @@ export function readSnapshot(db: DatabaseSync, taskId: string, now?: string): Ta
   } catch {
     throw new Error(`projection snapshot mismatch for task ${taskId}`);
   }
+  const executions = queryRows(
+      db,
+      "SELECT value_json FROM entity_projection WHERE entity_kind = 'execution' AND task_id = ? ORDER BY entity_id",
+      taskId,
+    ).map((value) => JSON.parse(String(value.value_json)) as TaskLifecycleSnapshot["executions"][number]),
+    reviews = queryRows(
+      db,
+      "SELECT value_json FROM entity_projection WHERE entity_kind = 'review' AND task_id = ? ORDER BY entity_id",
+      taskId,
+    ).map((value) => JSON.parse(String(value.value_json)) as TaskLifecycleSnapshot["reviews"][number]);
   const lease = now === undefined ? storedLease(db, taskId) : effectiveLease(db, taskId, now);
   // The stored snapshot is pure task-aggregate state; the decision relations this task is a
   // target of are stamped at read time as-of the applied cut, the same join the live lease uses.
@@ -135,6 +145,8 @@ export function readSnapshot(db: DatabaseSync, taskId: string, now?: string): Ta
   });
   return {
     ...snapshot,
+    executions,
+    reviews,
     lease: lease?.phase === "released" ? null : lease,
     decisionRelations,
   };
@@ -144,8 +156,8 @@ export function readIntervals(db: DatabaseSync, taskId: string): readonly LeaseI
   const rows =
     /* @gate-identity check-bypass-write-boundary/bypass-write-025 */
     db
-    .prepare("SELECT * FROM lease_interval WHERE task_id = ? ORDER BY acquired_revision")
-    .all(taskId) as unknown as readonly Record<string, unknown>[];
+      .prepare("SELECT * FROM lease_interval WHERE task_id = ? ORDER BY acquired_revision")
+      .all(taskId) as unknown as readonly Record<string, unknown>[];
   return rows.map((row) => ({
     taskId: String(row.task_id),
     executionId: String(row.execution_id),
@@ -249,30 +261,50 @@ export function readRuntimeSessionsForTask(db: DatabaseSync, taskId: string): Ru
     taskId,
   ).map((row) => JSON.parse(String(row.value_json)) as RuntimeSession);
 }
-export function readRuntimeSessionPage(db: DatabaseSync,
-  query: RuntimeSessionPageQuery): RuntimeSessionPageRead {
+export function readRuntimeSessionPage(db: DatabaseSync, query: RuntimeSessionPageQuery): RuntimeSessionPageRead {
   if (!Number.isInteger(query.limit) || query.limit < 1 || query.limit > 64)
     throw new Error("runtime session page limit must be between 1 and 64");
-  const after = query.afterRuntimeSessionId, taskId = query.taskId;
-  const rows = taskId ? queryRows(db,
-    ["SELECT runtime_session.value_json FROM runtime_session_task_binding",
-      "JOIN runtime_session USING(runtime_session_id)",
-      "WHERE runtime_session_task_binding.task_id = ?",
-      ...(after === undefined ? [] : ["AND runtime_session.runtime_session_id > ?"]),
-      "GROUP BY runtime_session.runtime_session_id ORDER BY runtime_session.runtime_session_id LIMIT ?"
-    ].join(" "), taskId, ...(after === undefined ? [] : [after]), query.limit) : queryRows(db,
-    ["SELECT value_json FROM runtime_session", ...(after === undefined ? [] :
-      ["WHERE runtime_session_id > ?"]), "ORDER BY runtime_session_id LIMIT ?"].join(" "),
-    ...(after === undefined ? [] : [after]), query.limit);
+  const after = query.afterRuntimeSessionId,
+    taskId = query.taskId;
+  const rows = taskId
+    ? queryRows(
+        db,
+        [
+          "SELECT runtime_session.value_json FROM runtime_session_task_binding",
+          "JOIN runtime_session USING(runtime_session_id)",
+          "WHERE runtime_session_task_binding.task_id = ?",
+          ...(after === undefined ? [] : ["AND runtime_session.runtime_session_id > ?"]),
+          "GROUP BY runtime_session.runtime_session_id ORDER BY runtime_session.runtime_session_id LIMIT ?",
+        ].join(" "),
+        taskId,
+        ...(after === undefined ? [] : [after]),
+        query.limit,
+      )
+    : queryRows(
+        db,
+        [
+          "SELECT value_json FROM runtime_session",
+          ...(after === undefined ? [] : ["WHERE runtime_session_id > ?"]),
+          "ORDER BY runtime_session_id LIMIT ?",
+        ].join(" "),
+        ...(after === undefined ? [] : [after]),
+        query.limit,
+      );
   const sessions = rows.map((row) => JSON.parse(String(row.value_json)) as RuntimeSession),
     lastId = sessions.at(-1)?.runtimeSessionId;
   if (lastId === undefined) return { rows: sessions, nextRuntimeSessionId: null, remainingCount: 0 };
-  const countRow = taskId ? queryRows(db,
-    ["SELECT COUNT(DISTINCT runtime_session.runtime_session_id) AS count",
-      "FROM runtime_session_task_binding JOIN runtime_session USING(runtime_session_id)",
-      "WHERE runtime_session_task_binding.task_id = ? AND runtime_session.runtime_session_id > ?"
-    ].join(" "), taskId, lastId)[0] : queryRows(db,
-    "SELECT COUNT(*) AS count FROM runtime_session WHERE runtime_session_id > ?", lastId)[0];
+  const countRow = taskId
+    ? queryRows(
+        db,
+        [
+          "SELECT COUNT(DISTINCT runtime_session.runtime_session_id) AS count",
+          "FROM runtime_session_task_binding JOIN runtime_session USING(runtime_session_id)",
+          "WHERE runtime_session_task_binding.task_id = ? AND runtime_session.runtime_session_id > ?",
+        ].join(" "),
+        taskId,
+        lastId,
+      )[0]
+    : queryRows(db, "SELECT COUNT(*) AS count FROM runtime_session WHERE runtime_session_id > ?", lastId)[0];
   const remainingCount = Number(countRow?.count ?? 0);
   return { rows: sessions, nextRuntimeSessionId: remainingCount > 0 ? lastId : null, remainingCount };
 }

--- a/packages/kernel/src/projection/rebuildable-task-projection-sql.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-sql.ts
@@ -17,8 +17,7 @@ const stateDigestTables = [
   ["task_generation", "task_id"],
   ["task_relation", "relation_id"],
   ["task_progress", "workspace_revision"],
-  ["execution", "execution_id"],
-  ["review", "review_id"],
+  ["entity_projection", "entity_kind, entity_id"],
   ["edge", "task_id, edge_id, iteration"],
   ["lease_cas", "task_id"],
   ["lease_interval", "task_id, execution_id, acquired_revision"],
@@ -36,8 +35,8 @@ export function watermark(db: DatabaseSync): number {
   const row =
     /* @gate-identity check-bypass-write-boundary/bypass-write-031 */
     db.prepare("SELECT watermark FROM projection_meta WHERE singleton = 1").get() as {
-    readonly watermark: number;
-  };
+      readonly watermark: number;
+    };
   return Number(row.watermark);
 }
 
@@ -45,21 +44,19 @@ export function readStateDigest(db: DatabaseSync): `sha256:${string}` | null {
   const row =
     /* @gate-identity check-bypass-write-boundary/bypass-write-032 */
     db.prepare("SELECT state_digest FROM projection_meta WHERE singleton = 1").get() as {
-    readonly state_digest: string | null;
-  };
+      readonly state_digest: string | null;
+    };
   return row.state_digest === null ? null : (row.state_digest as `sha256:${string}`);
 }
 
 export function isAtSourceCut(db: DatabaseSync, sourceRevision: number): boolean {
   const state =
     /* @gate-identity check-bypass-write-boundary/bypass-write-033 */
-    db
-    .prepare("SELECT watermark, scan_cursor, scanned_revision FROM projection_meta WHERE singleton = 1")
-    .get() as {
-    readonly watermark: number;
-    readonly scan_cursor: string | null;
-    readonly scanned_revision: number;
-  };
+    db.prepare("SELECT watermark, scan_cursor, scanned_revision FROM projection_meta WHERE singleton = 1").get() as {
+      readonly watermark: number;
+      readonly scan_cursor: string | null;
+      readonly scanned_revision: number;
+    };
   return (
     Number(state.watermark) === sourceRevision &&
     state.scan_cursor === null &&

--- a/packages/kernel/src/projection/rebuildable-task-projection-task-events.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-task-events.ts
@@ -23,6 +23,11 @@ const UPSERT_DOCUMENT_SQL = [
   "ON CONFLICT(path) DO UPDATE SET workspace_revision=excluded.workspace_revision,",
   "value_json=excluded.value_json",
 ].join(" ");
+const UPSERT_ENTITY_SQL = [
+  "INSERT INTO entity_projection(entity_kind, entity_id, task_id, workspace_revision, value_json)",
+  "VALUES (?, ?, ?, ?, ?) ON CONFLICT(entity_kind, entity_id) DO UPDATE SET",
+  "task_id=excluded.task_id, workspace_revision=excluded.workspace_revision, value_json=excluded.value_json",
+].join(" ");
 
 // Lifecycle task-event reduction, document claims, and materialized task rows.
 export function applyTaskEvent(
@@ -45,7 +50,7 @@ export function applyTaskEvent(
     UPSERT_TASK_SNAPSHOT_SQL,
     event.taskId,
     event.workspaceRevision,
-    canonicalJson(snapshot),
+    canonicalJson({ ...snapshot, executions: [], reviews: [] }),
     snapshot.task?.status ?? null,
     event.occurredAt,
   );
@@ -135,7 +140,8 @@ export function applyTaskEvent(
   if ("execution" in event.payload)
     runSql(
       db,
-      "INSERT OR REPLACE INTO execution(execution_id, task_id, workspace_revision, value_json) VALUES (?, ?, ?, ?)",
+      UPSERT_ENTITY_SQL,
+      "execution",
       event.payload.execution.executionId,
       event.taskId,
       event.workspaceRevision,
@@ -144,10 +150,20 @@ export function applyTaskEvent(
   if (event.type === "review_recorded")
     runSql(
       db,
-      "INSERT INTO review(review_id, task_id, execution_id, workspace_revision, value_json) VALUES (?, ?, ?, ?, ?)",
+      UPSERT_ENTITY_SQL,
+      "review",
       event.payload.review.reviewId,
       event.taskId,
-      event.payload.review.executionId,
+      event.workspaceRevision,
+      canonicalJson(event.payload.review),
+    );
+  if (event.type === "review_consent_recorded")
+    runSql(
+      db,
+      UPSERT_ENTITY_SQL,
+      "review",
+      event.payload.review.reviewId,
+      event.taskId,
       event.workspaceRevision,
       canonicalJson(event.payload.review),
     );

--- a/packages/kernel/src/store/entity-store.ts
+++ b/packages/kernel/src/store/entity-store.ts
@@ -6,7 +6,8 @@ import {
   type EntityUpsertBundle,
   type StoredEntityEventV1,
 } from "../domain/entity-event.ts";
-import { requireEntityKindContract } from "../domain/entity-kind-registry.ts";
+import { isTaskEvent } from "../domain/doc-sync.contract.ts";
+import { entityDocumentPath, requireEntityKindContract } from "../domain/entity-kind-registry.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
 import { resolveLedgerGitLayout } from "./ledger-git-layout.ts";
 import { publicationRefs } from "./task-event-store-git-refs.ts";
@@ -33,9 +34,24 @@ export function createEntityStore(source: EntityEventSource): EntityStore {
   const records = (kind: string): readonly StoredEntity[] => {
     const contract = requireEntityKindContract(kind),
       latest = new Map<string, ReturnType<typeof entityEventRecord>>();
-    for (const event of source.read().events)
+    for (const event of source.read().events) {
       if (isEntityEvent(event) && event.payload.entityKind === contract.kind)
         latest.set(event.payload.entityId, entityEventRecord(event, source, contract));
+      if (contract.kind === "execution" && isTaskEvent(event) && "execution" in event.payload)
+        latest.set(
+          event.payload.execution.executionId,
+          taskEventRecord(event.payload.execution, event.workspaceRevision, contract),
+        );
+      if (
+        contract.kind === "review" &&
+        isTaskEvent(event) &&
+        (event.type === "review_recorded" || event.type === "review_consent_recorded")
+      )
+        latest.set(
+          event.payload.review.reviewId,
+          taskEventRecord(event.payload.review, event.workspaceRevision, contract),
+        );
+    }
     return [...latest.values()].sort((left, right) => left.id.localeCompare(right.id));
   };
   return {
@@ -43,6 +59,23 @@ export function createEntityStore(source: EntityEventSource): EntityStore {
     get: <T>(kind: string, id: string) =>
       (records(kind).find((record) => record.id === id) as StoredEntity<T> | undefined) ?? null,
     list: <T>(kind: string) => records(kind) as readonly StoredEntity<T>[],
+  };
+}
+
+function taskEventRecord(
+  value: unknown,
+  workspaceRevision: number,
+  contract: ReturnType<typeof requireEntityKindContract>,
+): StoredEntity {
+  const parsed = parseEntityJsonSchema(contract.schema, value, `${contract.kind} declaration`),
+    id = (parsed as Record<string, unknown>)[contract.id.field];
+  if (typeof id !== "string") throw new Error(`${contract.kind} lifecycle event has no string identity`);
+  return {
+    kind: contract.kind,
+    id,
+    value: parsed,
+    documentPath: entityDocumentPath(contract, id),
+    workspaceRevision,
   };
 }
 

--- a/packages/kernel/test/contracts/execution-review-entity.test.ts
+++ b/packages/kernel/test/contracts/execution-review-entity.test.ts
@@ -1,0 +1,65 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { compileEntityUpsert } from "../../src/domain/entity-event.ts";
+import { explainEntityKind, getEntityKindContract } from "../../src/domain/entity-kind-registry.ts";
+import { isAllowedRelationKindTriple } from "../../src/domain/entity-relation.ts";
+import { parseEntityRef } from "../../src/domain/entity-ref.ts";
+
+const actor = { principal: { personId: "person-1" }, executor: { kind: "agent" as const, id: "agent-1" } };
+
+test("execution and review are dependency-free EntityKindContracts with lifecycle relations", () => {
+  const execution = {
+      schema: "execution/v1",
+      executionId: "exe_01j00000000000000000000000",
+      taskId: "task_01j00000000000000000000000",
+      nodeId: "implementation",
+      iteration: 0,
+      state: "active",
+      actor,
+      claimedAt: "2026-08-25T00:00:00.000Z",
+      submittedAt: null,
+      closedAt: null,
+      submission: null,
+    },
+    review = {
+      schema: "review/v1",
+      reviewId: "rev_01j00000000000000000000000",
+      taskId: execution.taskId,
+      executionId: execution.executionId,
+      verdict: "approved",
+      actor,
+      capabilityRef: "execution-review@v1",
+      reason: "checked",
+      evidenceChecked: ["test"],
+      commitSha: "a".repeat(40),
+      iteration: 0,
+      contentDigest: `sha256:${"b".repeat(64)}`,
+      reviewedAt: execution.claimedAt,
+    },
+    base = {
+      eventId: "event-1",
+      opId: "op-1",
+      workspaceRevision: 1,
+      actor: { principal: { personId: "person-1" }, executor: null },
+      source: "local" as const,
+      occurredAt: execution.claimedAt,
+    };
+
+  assert.equal(getEntityKindContract("execution")?.id.field, "executionId");
+  assert.equal(getEntityKindContract("review")?.id.field, "reviewId");
+  assert.deepEqual(explainEntityKind("execution").relations, { directions: ["directed"] });
+  assert.deepEqual(explainEntityKind("review").relations, { directions: ["directed"] });
+  assert.doesNotThrow(() => compileEntityUpsert({ ...base, entityKind: "execution", entity: execution }));
+  assert.doesNotThrow(() => compileEntityUpsert({ ...base, entityKind: "review", entity: review }));
+  assert.throws(
+    () => compileEntityUpsert({ ...base, entityKind: "execution", entity: { ...execution, executionId: "" } }),
+    /invalid|pattern|non-empty/u,
+  );
+
+  assert.equal(isAllowedRelationKindTriple("execution", "executes", "task"), true);
+  assert.equal(isAllowedRelationKindTriple("review", "reviews", "execution"), true);
+  assert.equal(isAllowedRelationKindTriple("task", "executes", "execution"), false);
+  assert.deepEqual(parseEntityRef(`execution/${execution.taskId}/${execution.executionId}`)?.kind, "execution");
+  assert.deepEqual(parseEntityRef(`review/${execution.executionId}/${review.reviewId}`)?.kind, "review");
+});


### PR DESCRIPTION
# English

## Summary

Execution and Review were read models derived ad hoc from the task event stream, each with its own SQLite projection table and INSERT path. This PR registers both as EntityKindContracts on the generic EntityStore introduced by 1.1, expresses their links as canonical relations (execution executes task, review reviews execution), replaces the two dedicated projection tables with one generic entity_projection, and deletes the dedicated table definitions, state-digest entries and INSERT branches so there is a single read model.

## Architectural Justification

Why the existing modules cannot carry it: `EntityKindRegistry` only accepted dependency-free schema nodes and `EntityStore` only consumed entity-event/v1, while lifecycle replay stored execution/review in dedicated tables read directly by snapshots — no existing seam could expose lifecycle records as entities.
What obsolete code was removed: the `execution` and `review` projection tables, their SQL state-digest entries and task-event INSERT branches (-91).
Why the scope cannot be narrowed: relation validation, entity refs, GUI relation maps, projection schema, replay hydration and the generic store all have compile-time closed vocabularies; leaving any one unchanged keeps `entity explain`, relation direction or replay on a second implementation.

## What Changed

- Kernel: dependency-free `EntityKindContract` registrations for `execution` and `review`; `ha entity explain execution|review` resolves through the generic explain route.
- Relations: canonical `execution -> task` (executes) and `review -> execution` (reviews) rows and endpoint parsing (rebased onto the merged 1.5 vocabulary; the branch's own copies were dropped).
- Projection: `execution`/`review` SQLite tables replaced by one `entity_projection`; lifecycle replay writes it, snapshot reads hydrate from it.
- Deleted: the two table definitions, their state-digest entries and dedicated INSERT paths.

## Machine-Readable Declarations

Production-Delta: +340/-80
+0/-0
+340/-80

## Task And Scope

- Harness task: task_1316d58707c6c078b91855459b (PLT-Ontology Phase 1.2)
- Branch: `codex/execution-review-entity`
- Public scope: kernel entity contracts, relation vocabulary rows, task projection schema and replay, generic EntityStore lifecycle records
- Private planning/evidence updated: yes (artifacts/reports/execution-review-entity.md)
- Out of scope: review consent semantics (unchanged, still a lifecycle event with content-pinned digest); archived migration executions (still replayed, not accepted by execution/v1)

## Version Impact

- Version: no version change because this is a pre-release fix on the rebuild line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_1316d58707c6c078b91855459b (PLT-Ontology Phase 1.2)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: aad7aa10919dc78920f0bfd0641c40354346f0c7
- Branch merge-base with `origin/main`: aad7aa10919dc78920f0bfd0641c40354346f0c7
- Last `git fetch origin` time: 2026-08-25T01:39Z
- Sync method: rebase
- Public diff command: `git diff aad7aa10919dc78920f0bfd0641c40354346f0c7..dfd8f0aea`
- Private evidence commit/path: harness task package task_1316d58707c6c078b91855459b artifacts/reports
- Reviewer evidence path: worker report: typecheck passed; contract tests 5/5; lifecycle regression 17/17; negative mutation (executes target kind → decision) turned the contract test red; derived-contracts ok (7), schema-closure ok, implementation-contracts delta 0; Docker-isolated contract test passed
- GitHub Actions `rewrite-ci` run URL: pending (filled after the run)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test` (kernel contract tests, application lifecycle tests, gate checks, Docker-isolated contract test)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: fast tier in the worker worktree (Node 22 loader `ERR_UNKNOWN_FILE_EXTENSION` environment issue, not a code failure); GitHub CI is the authority

## Review Evidence

- Self-review: CEO: the deletion of the two dedicated tables is what makes this a real promotion rather than a parallel model; the relation rows must rebase onto 1.5's vocabulary before merge.
- Reviewer subagent: yes (read-only report audit with independent git verification)
- Human review: pending
- Blocking findings: none

## Residual Risk

- None from vocabulary now that #1811 is merged; the -356 includes formatter normalization of touched files.

## References

- Task: task_1316d58707c6c078b91855459b
- Evidence: artifacts/reports/execution-review-entity.md
- Review: pending

---

# 中文

## 概要

Execution 与 Review 一直是从 task 事件流临时派生的读模型,各有自己的 SQLite 投影表与 INSERT 路径。本 PR 把两者登记为 1.1 通用 EntityStore 上的 EntityKindContract,用规范关系表达其链接(execution executes task,review reviews execution),用一张通用 entity_projection 替换两张专用投影表,并删除专用表定义、state-digest 项与 INSERT 分支,只留一个读模型。

## 架构辩护

现有模块为何无法承载:`EntityKindRegistry` 只接受无依赖 schema 节点、`EntityStore` 只消费 entity-event/v1,而 lifecycle replay 把 execution/review 存在专用表里由 snapshot 直接读——没有任何现成接缝能把 lifecycle 记录暴露为实体。
删除了哪些废弃代码:`execution`/`review` 投影表、其 SQL state-digest 项与 task-event INSERT 分支(-91)。
为何不能收窄:关系校验、entity ref、GUI 关系图、投影 schema、replay 水合、通用 store 都是编译期封闭词表;任一不改,`entity explain`、关系方向或 replay 就仍留在第二套实现上。

## 改动内容

- Kernel:`execution`/`review` 的无依赖 EntityKindContract 登记;`ha entity explain execution|review` 走通用 explain 路由。
- 关系:`execution -> task`(executes)与 `review -> execution`(reviews)规范行与端点解析(已 rebase 到合入的 1.5 词表,分支自带副本已删)。
- 投影:`execution`/`review` SQLite 表替换为一张 `entity_projection`;lifecycle replay 写它,snapshot 读从它水合。
- 删除:两张表定义、其 state-digest 项与专用 INSERT 路径。

## 机读声明说明

- 机读声明只在英文块出现一次。

## 任务与范围

- Harness 任务:task_1316d58707c6c078b91855459b(PLT-Ontology Phase 1.2)
- 分支:`codex/execution-review-entity`
- 公开范围:kernel 实体契约、关系词表行、task 投影 schema 与 replay、通用 EntityStore 的 lifecycle 记录
- 私有计划 / 证据是否已更新:yes(artifacts/reports/execution-review-entity.md)
- 范围外:review consent 语义(不变,仍是 lifecycle 事件,内容锁定 digest);归档迁移 execution(仍 replay,不被 execution/v1 接受)

## 版本影响

- 版本:不改版本,原因是 rebuild 线 pre-release 修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_1316d58707c6c078b91855459b (PLT-Ontology Phase 1.2)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:aad7aa10919dc78920f0bfd0641c40354346f0c7
- 当前分支与 `origin/main` 的 merge-base:aad7aa10919dc78920f0bfd0641c40354346f0c7
- 最近一次 `git fetch origin` 时间:2026-08-25T01:39Z
- 同步方式:rebase
- 公开 diff 命令:`git diff aad7aa10919dc78920f0bfd0641c40354346f0c7..dfd8f0aea`
- 私有证据 commit/path:任务包 artifacts/reports
- Reviewer 证据路径:worker 回执:typecheck 通过;contract 测试 5/5;lifecycle 回归 17/17;负向变异(executes 目标 kind 改 decision)让 contract 测试变红;derived-contracts ok(7)、schema-closure ok、implementation-contracts delta 0;Docker 隔离 contract 测试通过
- GitHub Actions `rewrite-ci` run URL:待 run 结束后补
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`(kernel contract 测试、application lifecycle 测试、门检查、Docker 隔离 contract 测试)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:worker worktree 内 fast tier(Node 22 loader `ERR_UNKNOWN_FILE_EXTENSION` 环境问题,非代码失败);GitHub CI 为权威

## 审查证据

- 自查:CEO:删掉两张专用表才使这是真正的实体晋升而非并行模型;关系行合入前必须 rebase 到 1.5 词表。
- Reviewer subagent:有(只读回执审计 + git 独立核实)
- 人工审查:待
- 阻塞发现:无

## 残余风险

- #1811 已合入,词表风险消除;-356 中含触及文件的格式化归一。

## 关联材料

- 任务:task_1316d58707c6c078b91855459b
- 证据:artifacts/reports/execution-review-entity.md
- 审查:待

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPPk3TmbURWuxcFY3kFimA

