### PR TITLE
feat(ontology): Policy as a versioned entity with the default declaration mapped to the eight existing checks

### DIFF
--- a/packages/kernel/src/domain/default-policy.ts
+++ b/packages/kernel/src/domain/default-policy.ts
@@ -1,0 +1,62 @@
+import type { PolicyDeclarationV1 } from "./policy.ts";
+
+/** The single built-in policy package. Action rules mirror the eight object-level checks
+ * that currently live outside a shared AuthorizationPort; later slices consume this declaration. */
+const defaultPolicyDeclaration = {
+  schema: "policy/v1",
+  id: "default",
+  version: 1,
+  predicates: Object.freeze([
+    { predicate: "isOwner" },
+    { predicate: "isExecutorOfExecution" },
+    { predicate: "hasCommandClass", commandClass: "arbiter" },
+    { predicate: "reviewIndependence", level: "L1" },
+  ]),
+  actions: Object.freeze([
+    "task.consent",
+    "task.complete",
+    "execution.review",
+    "decision.accept",
+    "execution.release",
+    "runtime.dispatch",
+    "doc.submit",
+    "task.closeout",
+  ]),
+  rules: Object.freeze([
+    { action: "task.consent", mode: "all", predicates: [{ predicate: "isOwner" }] },
+    { action: "task.complete", mode: "all", predicates: [{ predicate: "isOwner" }] },
+    {
+      action: "execution.review",
+      mode: "all",
+      predicates: [{ predicate: "reviewIndependence", level: "L1" }],
+    },
+    {
+      action: "decision.accept",
+      mode: "all",
+      predicates: [
+        { predicate: "hasCommandClass", commandClass: "arbiter" },
+        { predicate: "reviewIndependence", level: "L1" },
+      ],
+    },
+    {
+      action: "execution.release",
+      mode: "any",
+      predicates: [{ predicate: "isExecutorOfExecution" }, { predicate: "isOwner" }],
+    },
+    {
+      action: "runtime.dispatch",
+      mode: "all",
+      predicates: [{ predicate: "isExecutorOfExecution" }],
+    },
+    {
+      action: "doc.submit",
+      mode: "any",
+      predicates: [{ predicate: "isExecutorOfExecution" }, { predicate: "isOwner" }],
+    },
+    { action: "task.closeout", mode: "all", predicates: [{ predicate: "isOwner" }] },
+  ]),
+} satisfies PolicyDeclarationV1;
+
+export const DEFAULT_POLICY: PolicyDeclarationV1 = Object.freeze(defaultPolicyDeclaration);
+
+export const defaultPolicy = DEFAULT_POLICY;

--- a/packages/kernel/src/domain/entity-event.ts
+++ b/packages/kernel/src/domain/entity-event.ts
@@ -55,6 +55,8 @@ export function compileEntityUpsert(input: {
   const contract = requireEntityKindContract(input.entityKind),
     entity = parseEntityJsonSchema(contract.schema, input.entity, `${input.entityKind} declaration`),
     entityId = isRecord(entity) ? entity[contract.id.field] : undefined;
+  const contractErrors = contract.validate?.(entity) ?? [];
+  if (contractErrors.length) throw new Error(contractErrors.join("; "));
   if (typeof entityId !== "string") throw new Error(`${input.entityKind} declaration has no string identity`);
   const body = serializeEntityJsonSchema(contract.schema, entity, `${input.entityKind} declaration`),
     claim: EntityDeclarationClaim = {

--- a/packages/kernel/src/domain/entity-json-schema.ts
+++ b/packages/kernel/src/domain/entity-json-schema.ts
@@ -8,9 +8,16 @@ export type EntityJsonSchemaNode = (
       readonly description?: string;
     }
   | {
+      readonly type: "number";
+      readonly integer?: boolean;
+      readonly minimum?: number;
+      readonly description?: string;
+    }
+  | {
       readonly type: "array";
       readonly items: EntityJsonSchemaNode;
       readonly uniqueItems?: boolean;
+      readonly minItems?: number;
       readonly "x-unique-by"?: string;
       readonly description?: string;
     }
@@ -104,11 +111,23 @@ function validateNodeValue(schema: EntityJsonSchemaNode, value: unknown, path: s
       errors.push(`${path} does not match its declared pattern.`);
     return;
   }
+  if (schema.type === "number") {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      errors.push(`${path} must be a finite number.`);
+      return;
+    }
+    if (schema.integer && !Number.isSafeInteger(value)) errors.push(`${path} must be an integer.`);
+    if (schema.minimum !== undefined && value < schema.minimum)
+      errors.push(`${path} must be at least ${schema.minimum}.`);
+    return;
+  }
   if (schema.type === "array") {
     if (!Array.isArray(value)) {
       errors.push(`${path} must be an array.`);
       return;
     }
+    if (schema.minItems !== undefined && value.length < schema.minItems)
+      errors.push(`${path} must contain at least ${schema.minItems} item(s).`);
     value.forEach((item, index) => validateNode(schema.items, item, `${path}[${index}]`, errors));
     if (schema.uniqueItems && new Set(value.map(stableJson)).size !== value.length)
       errors.push(`${path} entries must be unique.`);

--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -1,6 +1,9 @@
 import type { VerticalDefinition } from "../schemas/registry.ts";
 import { AGENT_DECLARATION_V1_SCHEMA, SQUAD_DECLARATION_V1_SCHEMA } from "./agent-squad-schema.ts";
+import { DEFAULT_POLICY } from "./default-policy.ts";
 import { ENTITY_ID_PATTERN, explainEntityJsonSchema, type EntityDocumentJsonSchema } from "./entity-json-schema.ts";
+import { POLICY_DECLARATION_V1_SCHEMA, validatePolicyDeclarationV1 } from "./policy.ts";
+import type { PolicyPredicateName } from "./policy.ts";
 import type { RelationDirection } from "./entity-relation.ts";
 
 export type EntityKindDeclaration = VerticalDefinition["entityKinds"][number];
@@ -44,6 +47,11 @@ export interface EntityKindContract<T = unknown> {
     readonly mediaType: "application/json";
     readonly policyId: typeof ENTITY_DOCUMENT_POLICY_ID;
   };
+  readonly validate?: (value: unknown) => readonly string[];
+  readonly policy?: {
+    readonly predicates: readonly PolicyPredicateName[];
+    readonly actions: readonly string[];
+  };
 }
 
 export interface EntityKindExplanation {
@@ -58,6 +66,10 @@ export interface EntityKindExplanation {
   readonly transitions: {
     readonly catalogRef: string | null;
     readonly available: readonly string[];
+  };
+  readonly policy?: {
+    readonly predicates: readonly PolicyPredicateName[];
+    readonly actions: readonly string[];
   };
 }
 
@@ -84,6 +96,19 @@ export const entityKindContracts = Object.freeze([
     relations: { directions: [] },
     transitionCatalog: null,
     document: declarationDocument("squads/{id}.json"),
+  },
+  {
+    kind: "policy",
+    schema: POLICY_DECLARATION_V1_SCHEMA,
+    id: { ...declarationId, refTemplate: "policy/{id}" },
+    relations: { directions: [] },
+    transitionCatalog: null,
+    document: declarationDocument("policies/{id}.json"),
+    validate: validatePolicyDeclarationV1,
+    policy: {
+      predicates: Object.freeze(["isOwner", "isExecutorOfExecution", "hasCommandClass", "reviewIndependence"]),
+      actions: DEFAULT_POLICY.actions,
+    },
   },
 ] as const satisfies readonly EntityKindContract[]);
 
@@ -114,6 +139,7 @@ export function explainEntityKind(kind: string): EntityKindExplanation {
       catalogRef: contract.transitionCatalog?.ref ?? null,
       available: contract.transitionCatalog?.transitions ?? [],
     },
+    ...(contract.policy ? { policy: contract.policy } : {}),
   };
 }
 

--- a/packages/kernel/src/domain/policy.ts
+++ b/packages/kernel/src/domain/policy.ts
@@ -1,0 +1,177 @@
+import {
+  EntitySchemaContractError,
+  ENTITY_ID_PATTERN,
+  parseEntityJsonSchema,
+  serializeEntityJsonSchema,
+  validateEntityJsonSchema,
+  type EntityDocumentJsonSchema,
+} from "./entity-json-schema.ts";
+import { isRecord } from "./write-chain.contract.ts";
+
+export const policyPredicateNames = Object.freeze([
+  "isOwner",
+  "isExecutorOfExecution",
+  "hasCommandClass",
+  "reviewIndependence",
+] as const);
+export type PolicyPredicateName = (typeof policyPredicateNames)[number];
+
+export const reviewIndependenceLevels = Object.freeze(["L1", "L2"] as const);
+export type ReviewIndependenceLevel = (typeof reviewIndependenceLevels)[number];
+
+export type PolicyPredicateExpression =
+  | { readonly predicate: "isOwner" }
+  | { readonly predicate: "isExecutorOfExecution" }
+  | { readonly predicate: "hasCommandClass"; readonly commandClass: string }
+  | { readonly predicate: "reviewIndependence"; readonly level: ReviewIndependenceLevel };
+
+export interface PolicyActionRule {
+  readonly action: string;
+  readonly mode: "all" | "any";
+  readonly predicates: readonly PolicyPredicateExpression[];
+}
+
+export interface PolicyDeclarationV1 {
+  readonly schema: "policy/v1";
+  readonly id: string;
+  readonly version: number;
+  readonly predicates: readonly PolicyPredicateExpression[];
+  readonly actions: readonly string[];
+  readonly rules?: readonly PolicyActionRule[];
+}
+
+const nonEmpty = (description: string) => ({ type: "string" as const, minLength: 1, description });
+const slug = (description: string) => ({
+  type: "string" as const,
+  pattern: ENTITY_ID_PATTERN,
+  description,
+});
+const predicateSchema = {
+  type: "object" as const,
+  additionalProperties: false as const,
+  required: ["predicate"] as const,
+  properties: {
+    predicate: {
+      type: "string" as const,
+      enum: policyPredicateNames,
+      description: "One of the kernel authorization predicates.",
+    },
+    commandClass: nonEmpty("Command class required by hasCommandClass."),
+    level: {
+      type: "string" as const,
+      enum: reviewIndependenceLevels,
+      description: "Review independence level (L1 executor axis, L2 principal axis).",
+    },
+  },
+};
+
+export const POLICY_DECLARATION_V1_SCHEMA = Object.freeze({
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  $id: "policy/v1",
+  type: "object",
+  additionalProperties: false,
+  required: Object.freeze(["schema", "id", "version", "predicates", "actions"]),
+  properties: Object.freeze({
+    schema: { type: "string", const: "policy/v1", description: "Schema discriminator." },
+    id: { ...slug("Stable Policy identity."), "x-error": "must be a lowercase entity slug." },
+    version: {
+      type: "number",
+      integer: true,
+      minimum: 1,
+      description: "Monotonically increasing Policy version.",
+    },
+    predicates: {
+      type: "array",
+      minItems: 1,
+      uniqueItems: true,
+      description: "Kernel predicate expressions available to this Policy.",
+      items: predicateSchema,
+    },
+    actions: {
+      type: "array",
+      minItems: 1,
+      uniqueItems: true,
+      description: "Action identifiers to which this Policy applies.",
+      items: nonEmpty("Applicable Action identifier."),
+    },
+    rules: {
+      type: "array",
+      minItems: 1,
+      uniqueItems: true,
+      description: "Per-Action predicate expressions evaluated by the AuthorizationPort.",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["action", "mode", "predicates"],
+        properties: {
+          action: nonEmpty("Action identifier covered by this rule."),
+          mode: {
+            type: "string",
+            enum: ["all", "any"],
+            description: "Whether all or any rule predicates must hold.",
+          },
+          predicates: {
+            type: "array",
+            minItems: 1,
+            items: predicateSchema,
+            description: "Kernel predicate expressions for the Action.",
+          },
+        },
+      },
+    },
+  }),
+}) as EntityDocumentJsonSchema<PolicyDeclarationV1>;
+
+export class PolicyEntityContractError extends EntitySchemaContractError {
+  constructor(message: string) {
+    super(message);
+    this.name = "PolicyEntityContractError";
+  }
+}
+
+export function validatePolicyDeclarationV1(value: unknown): readonly string[] {
+  const errors = [...validateEntityJsonSchema(POLICY_DECLARATION_V1_SCHEMA, value, "policy declaration")];
+  if (errors.length || !isRecord(value)) return errors;
+  const policy = value as Partial<PolicyDeclarationV1>,
+    actions = Array.isArray(policy.actions) ? policy.actions : [],
+    rules = Array.isArray(policy.rules) ? policy.rules : [],
+    actionSet = new Set(actions);
+  if (rules.some((rule) => !isRecord(rule) || typeof rule.action !== "string" || !actionSet.has(rule.action)))
+    errors.push("every policy rule must target an applicable Action");
+  if (new Set(rules.map((rule) => (isRecord(rule) ? rule.action : undefined))).size !== rules.length)
+    errors.push("policy rules must contain one rule per Action");
+  for (const expression of [...(Array.isArray(policy.predicates) ? policy.predicates : []), ...rulePredicates(rules)])
+    errors.push(...validatePredicateExpression(expression));
+  return errors;
+}
+
+export function parsePolicyDeclarationV1(value: unknown): PolicyDeclarationV1 {
+  const errors = validatePolicyDeclarationV1(value);
+  if (errors.length) throw new PolicyEntityContractError(errors.join("; "));
+  return parseEntityJsonSchema(POLICY_DECLARATION_V1_SCHEMA, value, "policy declaration");
+}
+
+export function serializePolicyDeclarationV1(value: unknown): string {
+  return serializeEntityJsonSchema(POLICY_DECLARATION_V1_SCHEMA, parsePolicyDeclarationV1(value), "policy declaration");
+}
+
+function validatePredicateExpression(value: unknown): readonly string[] {
+  if (!isRecord(value) || typeof value.predicate !== "string") return ["policy predicate expression is invalid"];
+  if (!policyPredicateNames.includes(value.predicate as PolicyPredicateName))
+    return [`unknown policy predicate: ${value.predicate}`];
+  if (value.predicate === "hasCommandClass" && (typeof value.commandClass !== "string" || !value.commandClass.trim()))
+    return ["hasCommandClass requires a non-empty commandClass"];
+  if (
+    value.predicate === "reviewIndependence" &&
+    !reviewIndependenceLevels.includes(value.level as ReviewIndependenceLevel)
+  )
+    return ["reviewIndependence requires level L1 or L2"];
+  if (value.predicate === "isOwner" || value.predicate === "isExecutorOfExecution") {
+    if (Object.keys(value).length !== 1) return [`${value.predicate} does not accept arguments`];
+  }
+  return [];
+}
+
+function rulePredicates(rules: readonly unknown[]): readonly unknown[] {
+  return rules.flatMap((rule) => (isRecord(rule) && Array.isArray(rule.predicates) ? rule.predicates : []));
+}

--- a/packages/kernel/src/store/entity-store.ts
+++ b/packages/kernel/src/store/entity-store.ts
@@ -78,6 +78,8 @@ function entityEventRecord(
     throw new Error(`entity declaration blob ${claim.sha256} is not JSON`);
   }
   const value = parseEntityJsonSchema(contract.schema, decoded, `${contract.kind} declaration`);
+  const contractErrors = contract.validate?.(value) ?? [];
+  if (contractErrors.length) throw new Error(contractErrors.join("; "));
   if (
     value === null ||
     typeof value !== "object" ||

--- a/packages/kernel/test/contracts/policy-entity.test.ts
+++ b/packages/kernel/test/contracts/policy-entity.test.ts
@@ -1,0 +1,84 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DEFAULT_POLICY } from "../../src/domain/default-policy.ts";
+import { parsePolicyDeclarationV1, validatePolicyDeclarationV1 } from "../../src/domain/policy.ts";
+import { createEntityStore, explainEntityKind } from "../../src/index.ts";
+
+test("the built-in policy registers its four kernel predicates and eight applicable Actions", () => {
+  assert.deepEqual(validatePolicyDeclarationV1(DEFAULT_POLICY), []);
+  assert.deepEqual(DEFAULT_POLICY.actions, [
+    "task.consent",
+    "task.complete",
+    "execution.review",
+    "decision.accept",
+    "execution.release",
+    "runtime.dispatch",
+    "doc.submit",
+    "task.closeout",
+  ]);
+  assert.deepEqual(
+    [
+      ...new Set(
+        (DEFAULT_POLICY.rules ?? []).flatMap((rule) => rule.predicates.map((predicate) => predicate.predicate)),
+      ),
+    ],
+    ["isOwner", "reviewIndependence", "hasCommandClass", "isExecutorOfExecution"],
+  );
+});
+
+test("ha entity explain policy exposes the registered predicate vocabulary and Action set", () => {
+  const explanation = explainEntityKind("policy");
+  assert.deepEqual(explanation.policy, {
+    predicates: ["isOwner", "isExecutorOfExecution", "hasCommandClass", "reviewIndependence"],
+    actions: DEFAULT_POLICY.actions,
+  });
+  assert.equal(explanation.documentSchema.id, "policy/v1");
+  assert.equal(explanation.id.refTemplate, "policy/{id}");
+  assert.equal(explanation.documentSchema.fields.find(({ name }) => name === "version")?.type, "number");
+});
+
+test("policy schema rejects a missing version and invalid predicate arguments", () => {
+  const withoutVersion = { ...DEFAULT_POLICY, version: undefined };
+  assert.match(validatePolicyDeclarationV1(withoutVersion).join("\n"), /missing required field "version"/u);
+  assert.throws(
+    () => parsePolicyDeclarationV1({ ...DEFAULT_POLICY, predicates: [{ predicate: "isOwner", level: "L1" }] }),
+    /isOwner does not accept arguments/u,
+  );
+});
+
+test("the shared EntityStore accepts policy declarations without a policy-specific store", () => {
+  const events: any[] = [];
+  const blobs = new Map<string, Uint8Array>();
+  const store = createEntityStore({
+    read: () => ({ schema: "canonical-event-stream/v1", revision: events.length, events }),
+    readContentBlob: (sha256) => blobs.get(sha256) ?? null,
+  });
+  const bundle = store.upsert({
+    entityKind: "policy",
+    entity: DEFAULT_POLICY,
+    eventId: "event-policy-default",
+    opId: "op-policy-default",
+    workspaceRevision: 1,
+    actor: { principal: { personId: "policy-test" }, executor: null },
+    source: "local",
+    occurredAt: "2026-08-25T00:00:00.000Z",
+  });
+  events.push(bundle.event);
+  for (const blob of bundle.blobs) blobs.set(blob.sha256, Buffer.from(blob.body));
+  assert.deepEqual(store.get("policy", "default")?.value, DEFAULT_POLICY);
+  assert.throws(
+    () =>
+      store.upsert({
+        entityKind: "policy",
+        entity: { ...DEFAULT_POLICY, actions: [] },
+        eventId: "event-policy-invalid",
+        opId: "op-policy-invalid",
+        workspaceRevision: 2,
+        actor: { principal: { personId: "policy-test" }, executor: null },
+        source: "local",
+        occurredAt: "2026-08-25T00:00:00.000Z",
+      }),
+    /at least 1 item/u,
+  );
+});


### PR DESCRIPTION
# English

## Summary

Authorization today lives in eight scattered if-checks across daemon, kernel and application code. This PR registers Policy as a versioned Entity kind (policy/v1) on the generic EntityStore with the four kernel predicate names (isOwner, isExecutorOfExecution, hasCommandClass, reviewIndependence) and per-Action predicate rules, ships one built-in DEFAULT_POLICY whose eight Action rules map one-to-one onto those existing checks, and makes `ha entity explain policy` list the predicates. No decision point is wired yet — that is Phase 2.2.

## Architectural Justification

Why the existing modules cannot carry it: there is no declaration of authorization anywhere — the eight checks are inline conditionals with no shared vocabulary; the generic EntityStore from 1.1 is the only registration seam and a Policy kind must be declared there to be explainable.
What obsolete code was removed: none in this slice by design — the task explicitly forbids touching decision points; removal of the eight inline checks is 2.2's deliverable.
Why the scope cannot be narrowed: a policy without the default declaration and the correspondence table would be an unverifiable schema; the table is what lets 2.2 replace each check safely.

## What Changed

- Kernel: `policy` EntityKindContract (`policy/v1`): id + integer version, predicate names, applicable Action set, per-Action rules.
- `DEFAULT_POLICY` (id `default`, version 1) with eight Action rules; the report carries the correspondence table to the eight existing checks (file:line each).
- `ha entity explain policy` resolves through the generic explain route.
- No AuthorizationPort call site changed.

## Machine-Readable Declarations

Production-Delta: +288/-0

## Task And Scope

- Harness task: task_322466c36c8a3acf086d7183f4 (PLT-Ontology Phase 1.4)
- Branch: `codex/policy-entity`
- Public scope: kernel policy contract and default declaration, explain route, tests
- Private planning/evidence updated: yes (artifacts/reports/policy-entity-contract.md)
- Out of scope: wiring predicates into the eight decision points (2.2); transition-state, digest, lease-freshness and path-eligibility checks stay outside the predicate vocabulary

## Version Impact

- Version: no version change because this is a pre-release fix on the rebuild line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_322466c36c8a3acf086d7183f4 (PLT-Ontology Phase 1.4)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: aad7aa10919dc78920f0bfd0641c40354346f0c7
- Branch merge-base with `origin/main`: aad7aa10919dc78920f0bfd0641c40354346f0c7
- Last `git fetch origin` time: 2026-08-25T02:10Z
- Sync method: rebase
- Public diff command: `git diff aad7aa10919dc78920f0bfd0641c40354346f0c7..2e1d0d12a`
- Private evidence commit/path: harness task package task_322466c36c8a3acf086d7183f4 artifacts/reports
- Reviewer evidence path: worker report policy-entity-contract.md with the eight-position correspondence table; CEO cross-checked that the table cites the actual current sources and that no call site was modified (+288/-0)
- GitHub Actions `rewrite-ci` run URL: pending (filled after the run)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test` (kernel contract tests for the policy kind and default declaration; derived-contracts/schema-closure gates)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: GitHub integration shard matrix locally (CI is the authority)

## Review Evidence

- Self-review: CEO: registering the policy before wiring it is the right order — 2.2 can then replace each if-check with a predicate lookup one at a time against a known declaration.
- Reviewer subagent: yes (read-only report audit with independent git verification)
- Human review: pending
- Blocking findings: none

## Residual Risk

- Purely additive (+288/-0); the eight if-checks remain the enforcing implementation until 2.2 lands, so the declaration could drift from them in the meantime.

## References

- Task: task_322466c36c8a3acf086d7183f4
- Evidence: artifacts/reports/policy-entity-contract.md
- Review: pending

---

# 中文

## 概要

授权判定今天散落在 daemon/kernel/application 的 8 处 if 里。本 PR 把 Policy 登记为通用 EntityStore 上的版本化实体(policy/v1),带四个 kernel 谓词名(isOwner/isExecutorOfExecution/hasCommandClass/reviewIndependence)与按 Action 的谓词规则;内置一份 DEFAULT_POLICY,其 8 条 Action 规则与现有 8 处检查一一对应;`ha entity explain policy` 可列谓词。不接任何判定点——那是 Phase 2.2。

## 架构辩护

现有模块为何无法承载:授权在任何地方都没有声明——8 处检查是内联条件,无共享词表;1.1 的通用 EntityStore 是唯一登记接缝,Policy 必须在那里声明才可解释。
删除了哪些废弃代码:本切片按设计不删——任务明令不碰判定点,删 8 处内联检查是 2.2 的交付。
为何不能收窄:没有默认声明与对照表的 Policy 只是不可验证的 schema;对照表正是让 2.2 能逐条安全替换的依据。

## 改动内容

- Kernel:`policy` EntityKindContract(`policy/v1`):id + 整数 version、谓词名、适用 Action 集、按 Action 规则。
- `DEFAULT_POLICY`(id `default`,version 1)8 条 Action 规则;回执含与现有 8 处检查的对照表(逐条 file:line)。
- `ha entity explain policy` 走通用 explain 路由。
- 未改任何 AuthorizationPort 调用点。

## 机读声明说明

- 机读声明只在英文块出现一次。

## 任务与范围

- Harness 任务:task_322466c36c8a3acf086d7183f4(PLT-Ontology Phase 1.4)
- 分支:`codex/policy-entity`
- 公开范围:kernel policy 契约与默认声明、explain 路由、测试
- 私有计划 / 证据是否已更新:yes(artifacts/reports/policy-entity-contract.md)
- 范围外:把谓词接到 8 个判定点(2.2);转换态、digest、lease 新鲜度、路径资格检查不进谓词词表

## 版本影响

- 版本:不改版本,原因是 rebuild 线 pre-release 修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_322466c36c8a3acf086d7183f4 (PLT-Ontology Phase 1.4)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:aad7aa10919dc78920f0bfd0641c40354346f0c7
- 当前分支与 `origin/main` 的 merge-base:aad7aa10919dc78920f0bfd0641c40354346f0c7
- 最近一次 `git fetch origin` 时间:2026-08-25T02:10Z
- 同步方式:rebase
- 公开 diff 命令:`git diff aad7aa10919dc78920f0bfd0641c40354346f0c7..2e1d0d12a`
- 私有证据 commit/path:任务包 artifacts/reports
- Reviewer 证据路径:worker 回执 policy-entity-contract.md 含 8 处对照表;CEO 核过表里引用的是当前真实源码位置且未改任何调用点(+288/-0)
- GitHub Actions `rewrite-ci` run URL:待 run 结束后补
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`(policy kind 与默认声明的 kernel contract 测试;derived-contracts/schema-closure 门)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:GitHub integration shard 矩阵未在本地跑(CI 为权威)

## 审查证据

- 自查:CEO:先登记再接线是正确顺序——2.2 可以对着已知声明逐个把 if 换成谓词查询。
- Reviewer subagent:有(只读回执审计 + git 独立核实)
- 人工审查:待
- 阻塞发现:无

## 残余风险

- 纯新增(+288/-0);2.2 落地前 8 处 if 仍是生效实现,期间声明可能与之漂移。

## 关联材料

- 任务:task_322466c36c8a3acf086d7183f4
- 证据:artifacts/reports/policy-entity-contract.md
- 审查:待

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPPk3TmbURWuxcFY3kFimA

