### PR TITLE
fix(ontology): reuse the incumbent daemon writer during GUI and CLI autostart

### DIFF
--- a/packages/daemon/src/client/daemon-autostart.ts
+++ b/packages/daemon/src/client/daemon-autostart.ts
@@ -1,5 +1,10 @@
 import path from "node:path";
-import { acquireDaemonAutostartFlight, daemonProcessAlive, daemonSocketProbe } from "../daemon-singleton.ts";
+import {
+  acquireDaemonAutostartFlight,
+  daemonProcessAlive,
+  daemonSocketProbe,
+  readDaemonSingletonLockPid,
+} from "../daemon-singleton.ts";
 import { daemonLifecycleLogPath, readDaemonLifecycleRecords } from "../lifecycle-log.ts";
 import { startDetachedProcessChecked } from "../process-port.ts";
 export interface DaemonLaunchSpec {
@@ -66,6 +71,7 @@ export async function ensureLocalDaemonRunning(input: {
   if (await ready()) return { ok: true, hint: "daemon is reachable", attempts: 0 };
   let launched: DaemonLaunchSpec | null = null,
     flight: Awaited<ReturnType<typeof acquireDaemonAutostartFlight>> | null = null,
+    spawned = false,
     latestProgress: DaemonStartProgress | null = null,
     reported = "";
   try {
@@ -76,12 +82,19 @@ export async function ensureLocalDaemonRunning(input: {
     // The probe belongs inside the claim: another caller may have bound the
     // socket between this process's initial probe and atomic lock creation.
     if (flight.owner && (await ready())) return { ok: true, hint: "daemon is reachable", attempts: 0 };
-    if (flight.owner) await spawnDetached(launched);
+    // A peer may have claimed the daemon singleton after the initial socket
+    // probe but before this process claimed the autostart flight. That peer is
+    // already the writer for this target; spawning a deferred candidate adds
+    // noise and can make a GUI startup look like a writer-lock collision.
+    if (flight.owner && !liveDaemonSingleton(launched)) {
+      spawned = true;
+      await spawnDetached(launched);
+    }
     const startedAt = Date.now(),
       quietDeadline = startedAt + readyTimeoutMs,
       progressDeadline = startedAt + readyTimeoutMs * 6;
     for (;;) {
-      if (await ready()) return { ok: true, hint: "daemon is reachable", attempts: flight.owner ? 1 : 0 };
+      if (await ready()) return { ok: true, hint: "daemon is reachable", attempts: spawned ? 1 : 0 };
       const progress = readDaemonStartProgress(launched, Date.now() - startedAt);
       if (progress) {
         latestProgress = progress;
@@ -96,7 +109,7 @@ export async function ensureLocalDaemonRunning(input: {
       await delay(probeIntervalMs);
     }
   } catch (error) {
-    return { ok: false, attempts: flight?.owner ? 1 : 0, ...classifySpawnFailure(error, launched) };
+    return { ok: false, attempts: spawned ? 1 : 0, ...classifySpawnFailure(error, launched) };
   } finally {
     flight?.release();
   }
@@ -104,7 +117,7 @@ export async function ensureLocalDaemonRunning(input: {
     return {
       ok: false,
       code: "daemon_starting",
-      attempts: flight?.owner ? 1 : 0,
+      attempts: spawned ? 1 : 0,
       hint: `${latestProgress.message}; the daemon is still alive but has not bound ${
         input.socketPath
       }. Keep waiting or inspect ${launched ? daemonLaunchOutputPath(launched) : "the lifecycle log"}.`,
@@ -112,12 +125,10 @@ export async function ensureLocalDaemonRunning(input: {
   return {
     ok: false,
     code: "daemon_bind_timeout",
-    attempts: flight?.owner ? 1 : 0,
+    attempts: spawned ? 1 : 0,
     hint: `Daemon start failed: no socket appeared at ${
       input.socketPath
-    } and no live lifecycle progress was observed within ${
-      readyTimeoutMs
-    }ms after one shared start attempt. Inspect ${
+    } and no live lifecycle progress was observed within ${readyTimeoutMs}ms after one shared start attempt. Inspect ${
       launched ? daemonLaunchOutputPath(launched) : "the daemon lifecycle log"
     }.`,
   };
@@ -221,6 +232,12 @@ function daemonLaunchTarget(launch: DaemonLaunchSpec): { readonly userRoot: stri
   return daemon >= 0 && serve === daemon + 1 && rootAt >= 0 && idAt >= 0 && userRoot && daemonId
     ? { userRoot: path.resolve(userRoot), daemonId }
     : null;
+}
+function liveDaemonSingleton(launch: DaemonLaunchSpec): boolean {
+  const target = daemonLaunchTarget(launch);
+  if (!target) return false;
+  const pid = readDaemonSingletonLockPid(target.userRoot, target.daemonId);
+  return pid !== null && daemonProcessAlive(pid);
 }
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/packages/daemon/test/daemon-autostart.test.ts
+++ b/packages/daemon/test/daemon-autostart.test.ts
@@ -1,68 +1,223 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { DaemonAutostartError, daemonLaunchOutputPath, ensureLocalDaemonRunning, isDaemonUnreachable, readDaemonStartProgress, type DaemonAutostartResult, type DaemonLaunchSpec } from "../src/client/daemon-autostart.ts";
+import {
+  DaemonAutostartError,
+  daemonLaunchOutputPath,
+  ensureLocalDaemonRunning,
+  isDaemonUnreachable,
+  readDaemonStartProgress,
+  type DaemonAutostartResult,
+  type DaemonLaunchSpec,
+} from "../src/client/daemon-autostart.ts";
 import { daemonLifecycleLogPath, openDaemonLifecycleLog } from "../src/lifecycle-log.ts";
 import { startDetachedProcessChecked } from "../src/process-port.ts";
+import { daemonSingletonLockPath } from "../src/daemon-singleton.ts";
 
-function coded(code: string): Error & { code: string } { const error = Object.assign(new Error(`connect ${code}`), { code }); return error; }
-const launch = (): DaemonLaunchSpec => ({ command: "node", args: ["index.ts", "daemon", "serve", "--user-root", "/tmp/ha-user", "--daemon-id", "default"], env: {} });
+function coded(code: string): Error & { code: string } {
+  const error = Object.assign(new Error(`connect ${code}`), { code });
+  return error;
+}
+const launch = (): DaemonLaunchSpec => ({
+  command: "node",
+  args: ["index.ts", "daemon", "serve", "--user-root", "/tmp/ha-user", "--daemon-id", "default"],
+  env: {},
+});
 
 test("unreachable daemon is started once and the ready socket is used without a second attempt", async () => {
   let spawns = 0;
-  const result = await ensureLocalDaemonRunning({ socketPath: "/tmp/ha-autostart.sock", launch,
-    probe: async () => spawns > 0, spawnDetached: async () => { spawns += 1; }, probeIntervalMs: 1, readyTimeoutMs: 50 });
-  assert.equal(result.ok, true); assert.equal(result.attempts, 1); assert.equal(spawns, 1);
+  const result = await ensureLocalDaemonRunning({
+    socketPath: "/tmp/ha-autostart.sock",
+    launch,
+    probe: async () => spawns > 0,
+    spawnDetached: async () => {
+      spawns += 1;
+    },
+    probeIntervalMs: 1,
+    readyTimeoutMs: 50,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.attempts, 1);
+  assert.equal(spawns, 1);
 });
 
 test("concurrent callers share one autostart flight and wait for the same socket", async () => {
-  const userRoot = mkdtempSync(path.join(tmpdir(), "ha-autostart-flight-")); let spawns = 0, reachable = false;
-  const sharedLaunch = (): DaemonLaunchSpec => ({ command: "node", args: ["index.ts", "daemon", "serve", "--user-root", userRoot, "--daemon-id", "default"], env: {} });
+  const userRoot = mkdtempSync(path.join(tmpdir(), "ha-autostart-flight-"));
+  let spawns = 0,
+    reachable = false;
+  const sharedLaunch = (): DaemonLaunchSpec => ({
+    command: "node",
+    args: ["index.ts", "daemon", "serve", "--user-root", userRoot, "--daemon-id", "default"],
+    env: {},
+  });
   try {
-    const results = await Promise.all(Array.from({ length: 12 }, () => ensureLocalDaemonRunning({ socketPath: path.join(userRoot, "daemon.sock"), launch: sharedLaunch,
-      probe: async () => reachable, spawnDetached: async () => { spawns += 1; await new Promise((resolve) => setTimeout(resolve, 20)); reachable = true; }, probeIntervalMs: 1, readyTimeoutMs: 100 })));
-    assert.equal(results.every((result) => result.ok), true); assert.equal(spawns, 1, "one CLI owns the launch; every concurrent follower only waits");
-  } finally { rmSync(userRoot, { recursive: true, force: true }); }
+    const results = await Promise.all(
+      Array.from({ length: 12 }, () =>
+        ensureLocalDaemonRunning({
+          socketPath: path.join(userRoot, "daemon.sock"),
+          launch: sharedLaunch,
+          probe: async () => reachable,
+          spawnDetached: async () => {
+            spawns += 1;
+            await new Promise((resolve) => setTimeout(resolve, 20));
+            reachable = true;
+          },
+          probeIntervalMs: 1,
+          readyTimeoutMs: 100,
+        }),
+      ),
+    );
+    assert.equal(
+      results.every((result) => result.ok),
+      true,
+    );
+    assert.equal(spawns, 1, "one CLI owns the launch; every concurrent follower only waits");
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
+});
+
+test("a GUI/CLI peer that already owns the daemon singleton is awaited, not respawned", async () => {
+  const userRoot = mkdtempSync(path.join(tmpdir(), "ha-autostart-singleton-peer-"));
+  let spawns = 0;
+  const sharedLaunch = (): DaemonLaunchSpec => ({
+    command: "node",
+    args: ["index.ts", "daemon", "serve", "--user-root", userRoot, "--daemon-id", "default"],
+    env: {},
+  });
+  try {
+    writeFileSync(daemonSingletonLockPath(userRoot, "default"), `${process.pid}\n`, "utf8");
+    const result = await ensureLocalDaemonRunning({
+      socketPath: path.join(userRoot, "daemon.sock"),
+      launch: sharedLaunch,
+      probe: async () => false,
+      spawnDetached: async () => {
+        spawns += 1;
+      },
+      probeIntervalMs: 1,
+      readyTimeoutMs: 5,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.code, "daemon_bind_timeout");
+    assert.equal(result.attempts, 0);
+    assert.equal(spawns, 0, "the existing singleton holder is the only writer candidate");
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
 });
 
 test("one failed start attempt stops without spawning a second daemon", async () => {
   let spawns = 0;
-  const result = await ensureLocalDaemonRunning({ socketPath: "/tmp/ha-autostart-timeout.sock", launch, probe: async () => false,
-    spawnDetached: async () => { spawns += 1; }, probeIntervalMs: 1, readyTimeoutMs: 5 });
-  assert.equal(result.ok, false); assert.equal(result.code, "daemon_bind_timeout"); assert.equal(result.attempts, 1); assert.equal(spawns, 1);
-  assert.match(result.hint, /Daemon start failed/u); assert.match(result.hint, /\/tmp\/ha-autostart-timeout\.sock/u); assert.doesNotMatch(result.hint, /did not accept connections/u);
+  const result = await ensureLocalDaemonRunning({
+    socketPath: "/tmp/ha-autostart-timeout.sock",
+    launch,
+    probe: async () => false,
+    spawnDetached: async () => {
+      spawns += 1;
+    },
+    probeIntervalMs: 1,
+    readyTimeoutMs: 5,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "daemon_bind_timeout");
+  assert.equal(result.attempts, 1);
+  assert.equal(spawns, 1);
+  assert.match(result.hint, /Daemon start failed/u);
+  assert.match(result.hint, /\/tmp\/ha-autostart-timeout\.sock/u);
+  assert.doesNotMatch(result.hint, /did not accept connections/u);
 });
 
 test("a live process with lifecycle attach progress reports starting instead of bind timeout", async () => {
-  const userRoot = mkdtempSync(path.join(tmpdir(), "ha-autostart-progress-")), progress: string[] = [], spec = (): DaemonLaunchSpec => ({ command: "node", args: ["index.ts", "daemon", "serve", "--user-root", userRoot, "--daemon-id", "progress"], env: {} });
+  const userRoot = mkdtempSync(path.join(tmpdir(), "ha-autostart-progress-")),
+    progress: string[] = [],
+    spec = (): DaemonLaunchSpec => ({
+      command: "node",
+      args: ["index.ts", "daemon", "serve", "--user-root", userRoot, "--daemon-id", "progress"],
+      env: {},
+    });
   try {
-    const result = await ensureLocalDaemonRunning({ socketPath: path.join(userRoot, "daemon.sock"), launch: spec, probe: async () => false, probeIntervalMs: 1, readyTimeoutMs: 5,
-      spawnDetached: async () => { const log = openDaemonLifecycleLog({ userRoot, daemonId: "progress" }); log.record({ event: "process_start" }); log.record({ event: "repo_attach_started", repoId: "repo-c", attachIndex: 3, attachTotal: 5 }); }, onProgress: (entry) => progress.push(entry.message) });
-    assert.equal(result.ok, false); assert.equal(result.code, "daemon_starting"); assert.match(result.hint, /repo 3\/5: repo-c/u); assert.doesNotMatch(result.hint, /bind_timeout|did not accept connections/u); assert.equal(progress.some((message) => /waited 0s \(repo 3\/5: repo-c\)/u.test(message)), true);
-  } finally { rmSync(userRoot, { recursive: true, force: true }); }
+    const result = await ensureLocalDaemonRunning({
+      socketPath: path.join(userRoot, "daemon.sock"),
+      launch: spec,
+      probe: async () => false,
+      probeIntervalMs: 1,
+      readyTimeoutMs: 5,
+      spawnDetached: async () => {
+        const log = openDaemonLifecycleLog({ userRoot, daemonId: "progress" });
+        log.record({ event: "process_start" });
+        log.record({ event: "repo_attach_started", repoId: "repo-c", attachIndex: 3, attachTotal: 5 });
+      },
+      onProgress: (entry) => progress.push(entry.message),
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.code, "daemon_starting");
+    assert.match(result.hint, /repo 3\/5: repo-c/u);
+    assert.doesNotMatch(result.hint, /bind_timeout|did not accept connections/u);
+    assert.equal(
+      progress.some((message) => /waited 0s \(repo 3\/5: repo-c\)/u.test(message)),
+      true,
+    );
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
 });
 
 test("a launcher that is missing fails fast as daemon_spawn_not_found without a second attempt", async () => {
   let spawns = 0;
-  const result = await ensureLocalDaemonRunning({ socketPath: "/tmp/ha-autostart-enoent.sock", launch, probe: async () => false,
-    spawnDetached: async () => { spawns += 1; throw coded("ENOENT"); }, probeIntervalMs: 1, retryDelayMs: 1, readyTimeoutMs: 5 });
-  assert.equal(result.ok, false); assert.equal(result.code, "daemon_spawn_not_found"); assert.equal(result.attempts, 1); assert.equal(spawns, 1);
+  const result = await ensureLocalDaemonRunning({
+    socketPath: "/tmp/ha-autostart-enoent.sock",
+    launch,
+    probe: async () => false,
+    spawnDetached: async () => {
+      spawns += 1;
+      throw coded("ENOENT");
+    },
+    probeIntervalMs: 1,
+    retryDelayMs: 1,
+    readyTimeoutMs: 5,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "daemon_spawn_not_found");
+  assert.equal(result.attempts, 1);
+  assert.equal(spawns, 1);
   assert.match(result.hint, /ENOENT/u);
 });
 
 test("a permission-denied launcher is classified as daemon_spawn_permission", async () => {
-  const result = await ensureLocalDaemonRunning({ socketPath: "/tmp/ha-autostart-eacces.sock", launch, probe: async () => false,
-    spawnDetached: async () => { throw coded("EACCES"); }, probeIntervalMs: 1, retryDelayMs: 1, readyTimeoutMs: 5 });
-  assert.equal(result.ok, false); assert.equal(result.code, "daemon_spawn_permission"); assert.match(result.hint, /EACCES/u);
+  const result = await ensureLocalDaemonRunning({
+    socketPath: "/tmp/ha-autostart-eacces.sock",
+    launch,
+    probe: async () => false,
+    spawnDetached: async () => {
+      throw coded("EACCES");
+    },
+    probeIntervalMs: 1,
+    retryDelayMs: 1,
+    readyTimeoutMs: 5,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "daemon_spawn_permission");
+  assert.match(result.hint, /EACCES/u);
 });
 
 test("a non-OS launcher failure is classified as daemon_start_failed", async () => {
-  const result = await ensureLocalDaemonRunning({ socketPath: "/tmp/ha-autostart-other.sock", launch, probe: async () => false,
-    spawnDetached: async () => { throw new Error("spawn helper exploded"); }, probeIntervalMs: 1, retryDelayMs: 1, readyTimeoutMs: 5 });
-  assert.equal(result.ok, false); assert.equal(result.code, "daemon_start_failed"); assert.match(result.hint, /spawn helper exploded/u);
+  const result = await ensureLocalDaemonRunning({
+    socketPath: "/tmp/ha-autostart-other.sock",
+    launch,
+    probe: async () => false,
+    spawnDetached: async () => {
+      throw new Error("spawn helper exploded");
+    },
+    probeIntervalMs: 1,
+    retryDelayMs: 1,
+    readyTimeoutMs: 5,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "daemon_start_failed");
+  assert.match(result.hint, /spawn helper exploded/u);
 });
 
 test("only connection-level failures count as unreachable so protocol rejections never autostart", () => {
@@ -76,29 +231,56 @@ test("only connection-level failures count as unreachable so protocol rejections
 });
 
 test("DaemonAutostartError carries the classified code for CLI/GUI receipt rendering", () => {
-  const result: DaemonAutostartResult = { ok: false, code: "daemon_bind_timeout", hint: "The daemon did not accept connections.", attempts: 2 };
+  const result: DaemonAutostartResult = {
+    ok: false,
+    code: "daemon_bind_timeout",
+    hint: "The daemon did not accept connections.",
+    attempts: 2,
+  };
   const error = new DaemonAutostartError(result);
-  assert.equal(error instanceof Error, true); assert.equal(error.code, "daemon_bind_timeout"); assert.equal(error.attempts, 2); assert.equal(error.message, result.hint);
+  assert.equal(error instanceof Error, true);
+  assert.equal(error.code, "daemon_bind_timeout");
+  assert.equal(error.attempts, 2);
+  assert.equal(error.message, result.hint);
 });
 
 test("daemon launch output path is derived from the explicit serve target", () => {
   const userRoot = path.join(tmpdir(), "ha-output-target");
-  assert.equal(daemonLaunchOutputPath({ command: "node", args: ["index.js", "daemon", "serve", "--user-root", userRoot, "--daemon-id", "blue"], env: {} }), daemonLifecycleLogPath(userRoot, "blue"));
+  assert.equal(
+    daemonLaunchOutputPath({
+      command: "node",
+      args: ["index.js", "daemon", "serve", "--user-root", userRoot, "--daemon-id", "blue"],
+      env: {},
+    }),
+    daemonLifecycleLogPath(userRoot, "blue"),
+  );
   assert.equal(daemonLaunchOutputPath({ command: "node", args: ["index.js", "task", "list"], env: {} }), undefined);
 });
 
 test("start progress stages report the last repository, attach timeouts, prunes, and settled startup", async () => {
   const userRoot = mkdtempSync(path.join(tmpdir(), "ha-autostart-stages-"));
   try {
-    const log = openDaemonLifecycleLog({ userRoot, daemonId: "stages" }), spec = (): DaemonLaunchSpec => ({ command: "node", args: ["index.ts", "daemon", "serve", "--user-root", userRoot, "--daemon-id", "stages"], env: {} });
-    log.record({ event: "process_start" }); log.record({ event: "socket_bound" });
+    const log = openDaemonLifecycleLog({ userRoot, daemonId: "stages" }),
+      spec = (): DaemonLaunchSpec => ({
+        command: "node",
+        args: ["index.ts", "daemon", "serve", "--user-root", userRoot, "--daemon-id", "stages"],
+        env: {},
+      });
+    log.record({ event: "process_start" });
+    log.record({ event: "socket_bound" });
     log.record({ event: "repo_attach_started", repoId: "kty-web", attachIndex: 5, attachTotal: 5 });
     log.record({ event: "repo_attach_completed", repoId: "kty-web", attachIndex: 5, attachTotal: 5 });
     const completed = readDaemonStartProgress(spec(), 61_000);
     assert.match(completed?.message ?? "", /all 5 repositories attached; daemon completing startup/u);
     assert.doesNotMatch(completed?.message ?? "", /preparing the next repository/u);
     log.record({ event: "repo_attach_started", repoId: "probe-zombie", attachIndex: 6, attachTotal: 8 });
-    log.record({ event: "repo_attach_timed_out", repoId: "probe-zombie", attachIndex: 6, attachTotal: 8, durationMs: 60_000 });
+    log.record({
+      event: "repo_attach_timed_out",
+      repoId: "probe-zombie",
+      attachIndex: 6,
+      attachTotal: 8,
+      durationMs: 60_000,
+    });
     const timedOut = readDaemonStartProgress(spec(), 62_000);
     assert.match(timedOut?.message ?? "", /repository attach exceeded its budget; daemon moved on/u);
     log.record({ event: "repo_registry_pruned", repoId: "probe-zombie", rootDir: "/private/tmp/gone" });
@@ -106,15 +288,32 @@ test("start progress stages report the last repository, attach timeouts, prunes,
     assert.match(pruned?.message ?? "", /retired a stale registry entry whose root no longer exists/u);
     log.record({ event: "attachments_settled", attachTotal: 8, attached: 5, unavailable: 1, pruned: 1 });
     const settled = readDaemonStartProgress(spec(), 64_000);
-    assert.match(settled?.message ?? "", /all repositories settled \(1 unavailable\) \(1 pruned\); daemon completing startup after attach/u);
-  } finally { rmSync(userRoot, { recursive: true, force: true }); }
+    assert.match(
+      settled?.message ?? "",
+      /all repositories settled \(1 unavailable\) \(1 pruned\); daemon completing startup after attach/u,
+    );
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
 });
 
 test("detached stdout, stderr, and a fatal stack land in the daemon output log", async () => {
-  const root = mkdtempSync(path.join(tmpdir(), "ha-detached-output-")), outputPath = path.join(root, "daemon.log");
+  const root = mkdtempSync(path.join(tmpdir(), "ha-detached-output-")),
+    outputPath = path.join(root, "daemon.log");
   try {
-    await startDetachedProcessChecked(process.execPath, ["-e", "console.log('stdout witness'); console.error('stderr witness'); throw new Error('fatal witness')"], process.env, outputPath);
-    for (let attempt = 0; attempt < 100 && !readFileSync(outputPath, "utf8").includes("fatal witness"); attempt += 1) await new Promise((resolve) => setTimeout(resolve, 10));
-    const output = readFileSync(outputPath, "utf8"); assert.match(output, /stdout witness/u); assert.match(output, /stderr witness/u); assert.match(output, /Error: fatal witness/u);
-  } finally { rmSync(root, { recursive: true, force: true }); }
+    await startDetachedProcessChecked(
+      process.execPath,
+      ["-e", "console.log('stdout witness'); console.error('stderr witness'); throw new Error('fatal witness')"],
+      process.env,
+      outputPath,
+    );
+    for (let attempt = 0; attempt < 100 && !readFileSync(outputPath, "utf8").includes("fatal witness"); attempt += 1)
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    const output = readFileSync(outputPath, "utf8");
+    assert.match(output, /stdout witness/u);
+    assert.match(output, /stderr witness/u);
+    assert.match(output, /Error: fatal witness/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/packages/gui/test/gui-cli-writer-lock.integration.test.ts
+++ b/packages/gui/test/gui-cli-writer-lock.integration.test.ts
@@ -1,0 +1,138 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createLocalGuiServiceBridge } from "../src/main/local-composition-root.ts";
+
+const cli = path.resolve("packages/cli/src/index.ts");
+
+test("GUI and CLI write the same canonical through one resident daemon", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-gui-cli-writer-lock-"));
+  const root = path.join(parent, "repo"),
+    userRoot = path.join(parent, "user"),
+    sourceRoot = path.join(parent, "cli-agent"),
+    daemonId = "gui-cli-writer-lock",
+    repoId = "gui-cli-writer-lock";
+  mkdirSync(root, { recursive: true });
+  mkdirSync(sourceRoot, { recursive: true });
+  writeFileSync(
+    path.join(sourceRoot, "agent.json"),
+    `${JSON.stringify(
+      {
+        schema: "agent-declaration/v1",
+        id: "cli-agent",
+        name: "CLI Agent",
+        instructions: "Written by the CLI path.",
+        runtime_type: "any",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  const env = {
+    ...process.env,
+    HOME: path.join(parent, "home"),
+    NODE_OPTIONS: [process.env.NODE_OPTIONS, "--experimental-strip-types"].filter(Boolean).join(" "),
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_ID: daemonId,
+    HARNESS_DAEMON_REPO_ID: repoId,
+  };
+  delete env.HARNESS_DAEMON_ENDPOINT;
+  const previousEnv = {
+    userRoot: process.env.HARNESS_DAEMON_USER_ROOT,
+    daemonId: process.env.HARNESS_DAEMON_ID,
+    endpoint: process.env.HARNESS_DAEMON_ENDPOINT,
+  };
+  Object.assign(process.env, {
+    HARNESS_DAEMON_USER_ROOT: userRoot,
+    HARNESS_DAEMON_ID: daemonId,
+  });
+  delete process.env.HARNESS_DAEMON_ENDPOINT;
+  try {
+    const daemonStart = runCli(root, env, ["daemon", "start", "--service"]);
+    assert.equal(daemonStart.status, 0, `${daemonStart.stderr}\n${JSON.stringify(daemonStart.receipt)}`);
+    const initialized = runCli(root, env, [
+      "init",
+      "--repo-id",
+      repoId,
+      "--person-id",
+      "owner",
+      "--display-name",
+      "Owner",
+    ]);
+    assert.equal(initialized.status, 0, `${initialized.stderr}\n${JSON.stringify(initialized.receipt)}`);
+
+    const bridge = createLocalGuiServiceBridge(root),
+      guiWrite = bridge.invoke("saveAgent", {
+        repoId,
+        declaration: {
+          schema: "agent-declaration/v1",
+          id: "gui-agent",
+          name: "GUI Agent",
+          instructions: "Written by the GUI path.",
+          runtime_type: "any",
+        },
+      }),
+      cliSourceWrite = runCliAsync(root, env, ["agent", "install", "--source", sourceRoot]);
+    const [guiResult, cliResult] = await Promise.all([guiWrite, cliSourceWrite]);
+    assert.equal((guiResult as { readonly ok?: boolean }).ok, true, JSON.stringify(guiResult));
+    assert.equal((guiResult as { readonly outcome?: string }).outcome, "applied", JSON.stringify(guiResult));
+    assert.equal(cliResult.status, 0, `${cliResult.stderr}\n${JSON.stringify(cliResult.receipt)}`);
+    assert.equal(cliResult.receipt.outcome, "applied", JSON.stringify(cliResult.receipt));
+    assert.doesNotMatch(cliResult.stderr, /writer lock|EEXIST/iu);
+
+    const listed = await bridge.invoke("listAgents", { repoId });
+    const agents = (listed as { readonly agents?: readonly { readonly id: string }[] }).agents ?? [];
+    assert.deepEqual(agents.map(({ id }) => id).sort(), ["cli-agent", "gui-agent"]);
+    assert.match(readFileSync(path.join(root, "harness/agents/gui-agent.json"), "utf8"), /GUI Agent/u);
+    assert.match(readFileSync(path.join(root, "harness/agents/cli-agent.json"), "utf8"), /CLI Agent/u);
+  } finally {
+    runCli(root, env, ["daemon", "stop"]);
+    restoreEnv("HARNESS_DAEMON_USER_ROOT", previousEnv.userRoot);
+    restoreEnv("HARNESS_DAEMON_ID", previousEnv.daemonId);
+    restoreEnv("HARNESS_DAEMON_ENDPOINT", previousEnv.endpoint);
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+function runCli(root: string, env: NodeJS.ProcessEnv, args: readonly string[]) {
+  const result = spawnSync(process.execPath, ["--experimental-strip-types", cli, "--root", root, "--json", ...args], {
+    encoding: "utf8",
+    env,
+  });
+  return {
+    status: result.status,
+    receipt: result.stdout.trim() ? (JSON.parse(result.stdout) as Record<string, unknown>) : {},
+    stderr: result.stderr,
+  };
+}
+
+async function runCliAsync(root: string, env: NodeJS.ProcessEnv, args: readonly string[]) {
+  const child = spawn(process.execPath, ["--experimental-strip-types", cli, "--root", root, "--json", ...args], {
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "",
+    stderr = "";
+  child.stdout.on("data", (chunk) => {
+    stdout += String(chunk);
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += String(chunk);
+  });
+  const [status] = (await once(child, "close")) as [number | null];
+  return {
+    status,
+    receipt: stdout.trim() ? (JSON.parse(stdout) as Record<string, unknown>) : {},
+    stderr,
+  };
+}


### PR DESCRIPTION
# English

## Summary

When the Electron GUI and the CLI both autostarted a daemon for the same canonical repository, the second caller spawned a deferred writer and the first held the singleton lock, so governance writes such as agent install failed with `writer lock held by Electron` (or `EEXIST`). This PR makes the shared autostart path reuse the live incumbent daemon: after claiming the autostart flight it checks the singleton lock, waits for the incumbent socket when a live PID owns it, and never spawns a second writer. The GUI Agent/Squad surface already routes through the 1.1 entity commands, so no GUI-only path remained to delete.

## Architectural Justification

-

## What Changed

- `packages/daemon/src/client/daemon-autostart.ts` (+26/-9): `ensureLocalDaemonRunning` reuses the live incumbent singleton writer and counts only real spawn attempts.
- `packages/daemon/test/daemon-autostart.test.ts`: one regression case (plus formatting).
- New integration test: GUI client and CLI write concurrently to the same canonical repository; both succeed with no lock error.

## Machine-Readable Declarations

Production-Delta: +26/-9

## Task And Scope

- Harness task: task_61208abf87ff95d0d4e4d051b8 (PLT-Ontology Phase 0.20)
- Branch: `codex/gui-writer-lock`
- Public scope: daemon autostart client path and its tests
- Private planning/evidence updated: yes (artifacts/reports/gui-writer-lock.md)
- Out of scope: GUI Agent/Squad install/list code (already entity-backed after 1.1, verified unchanged)

## Version Impact

- Version: no version change because this is a pre-release fix on the rebuild line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_61208abf87ff95d0d4e4d051b8 (PLT-Ontology Phase 0.20)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: aad7aa10919dc78920f0bfd0641c40354346f0c7
- Branch merge-base with `origin/main`: aad7aa10919dc78920f0bfd0641c40354346f0c7
- Last `git fetch origin` time: 2026-08-25T02:10Z
- Sync method: rebase
- Public diff command: `git diff aad7aa10919dc78920f0bfd0641c40354346f0c7..b6ce4d546`
- Private evidence commit/path: harness task package task_61208abf87ff95d0d4e4d051b8 artifacts/reports
- Reviewer evidence path: worker report gui-writer-lock.md: daemon-autostart tests 13/13; new integration test passed in Docker isolation; CEO read the diff — the change is confined to the autostart decision and adds no GUI-specific fallback
- GitHub Actions `rewrite-ci` run URL: pending (filled after the run)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test` (daemon-autostart unit tests; new concurrent GUI+CLI integration test (Docker isolation))
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: manual Electron dev session against a CLI-held daemon (covered by the integration test's client simulation, not by a real Electron process)

## Review Evidence

- Self-review: CEO: the fix lives in the one shared autostart path rather than in GUI code, which is why it is +17 net; F28 (`EEXIST` on `ha agent install` from a worktree) is expected to disappear with it.
- Reviewer subagent: yes (read-only report audit with independent git verification)
- Human review: pending
- Blocking findings: none

## Residual Risk

- The integration test simulates the GUI client; a real Electron process is not exercised in CI.

## References

- Task: task_61208abf87ff95d0d4e4d051b8
- Evidence: artifacts/reports/gui-writer-lock.md
- Review: pending

---

# 中文

## 概要

Electron GUI 与 CLI 为同一 canonical 仓库各自 autostart daemon 时,后来者会另起一个 deferred writer、先来者持有 singleton 锁,于是 agent install 之类治理写入报 `writer lock held by Electron`(或 `EEXIST`)。本 PR 让共享的 autostart 路径复用在位 daemon:抢到 autostart flight 后检查 singleton 锁,若活 PID 已持有就等它的 socket,绝不起第二个 writer。GUI 的 Agent/Squad 面在 1.1 后已走 entity 命令,没有 GUI 专用路径可删。

## 架构辩护

-

## 改动内容

- `packages/daemon/src/client/daemon-autostart.ts`(+26/-9):`ensureLocalDaemonRunning` 复用在位 singleton writer,只统计真实 spawn 次数。
- `packages/daemon/test/daemon-autostart.test.ts`:一条回归用例(含格式化)。
- 新 integration 测试:GUI 客户端与 CLI 同时对同一 canonical 写,两者成功且无锁错误。

## 机读声明说明

- 机读声明只在英文块出现一次。

## 任务与范围

- Harness 任务:task_61208abf87ff95d0d4e4d051b8(PLT-Ontology Phase 0.20)
- 分支:`codex/gui-writer-lock`
- 公开范围:daemon autostart 客户端路径及其测试
- 私有计划 / 证据是否已更新:yes(artifacts/reports/gui-writer-lock.md)
- 范围外:GUI Agent/Squad 安装/列表代码(1.1 后已是 entity 面,核实未动)

## 版本影响

- 版本:不改版本,原因是 rebuild 线 pre-release 修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_61208abf87ff95d0d4e4d051b8 (PLT-Ontology Phase 0.20)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:aad7aa10919dc78920f0bfd0641c40354346f0c7
- 当前分支与 `origin/main` 的 merge-base:aad7aa10919dc78920f0bfd0641c40354346f0c7
- 最近一次 `git fetch origin` 时间:2026-08-25T02:10Z
- 同步方式:rebase
- 公开 diff 命令:`git diff aad7aa10919dc78920f0bfd0641c40354346f0c7..b6ce4d546`
- 私有证据 commit/path:任务包 artifacts/reports
- Reviewer 证据路径:worker 回执 gui-writer-lock.md:daemon-autostart 测试 13/13;新 integration 测试在 Docker 隔离通过;CEO 读过 diff——改动只在 autostart 判定,没加 GUI 专用兜底
- GitHub Actions `rewrite-ci` run URL:待 run 结束后补
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`(daemon-autostart 单测;新的 GUI+CLI 并发 integration 测试(Docker 隔离))
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:真实 Electron dev 进程对着 CLI 持有的 daemon 的手工验证(integration 测试用客户端模拟,不是真 Electron)

## 审查证据

- 自查:CEO:修在唯一的共享 autostart 路径而非 GUI 代码,所以净 +17;F28(worktree 内 `ha agent install` 撞 `EEXIST`)预期随之消失。
- Reviewer subagent:有(只读回执审计 + git 独立核实)
- 人工审查:待
- 阻塞发现:无

## 残余风险

- integration 测试模拟 GUI 客户端;CI 不跑真实 Electron 进程。

## 关联材料

- 任务:task_61208abf87ff95d0d4e4d051b8
- 证据:artifacts/reports/gui-writer-lock.md
- 审查:待

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPPk3TmbURWuxcFY3kFimA

