### PR TITLE
feat(ontology): RuntimeSession as an entity; admit task-bound spawn through its handoff binding

### DIFF
--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -6,7 +6,7 @@ import type {
   SessionIdentity,
   TaskProjection,
 } from "../../kernel/src/index.ts";
-import { consumeKnownError } from "../../kernel/src/index.ts";
+import { consumeKnownError, runtimeSessionExecutesTask, runtimeSessionIdFromActor } from "../../kernel/src/index.ts";
 import { createRuntime } from "../../preset/src/preset-resolver.ts";
 import { presetRuntimeDefaults, presetUserRoot } from "../../preset/src/preset-system.ts";
 import type { SquadDispatchTarget } from "./agent-entities.ts";
@@ -213,8 +213,17 @@ export function makeRuntimeSpawner(input: {
         !input.remote &&
         (!lease ||
           lease.phase !== "held" ||
-          lease.actor.principal.personId !== binding.actor.principal.personId ||
-          lease.actor.executor?.id !== binding.actor.executor?.id)
+          !(
+            (lease.actor.principal.personId === binding.actor.principal.personId &&
+              (binding.actor.executor === null || lease.actor.executor?.id === binding.actor.executor?.id)) ||
+            runtimeSessionExecutesTask(
+              runtimeSessionIdFromActor(binding.actor)
+                ? projection!.readRuntimeSession(runtimeSessionIdFromActor(binding.actor)!)
+                : null,
+              taskId,
+              lease.executionId,
+            )
+          ))
       )
         throw runtimeSpawnError("runtime_task_lease_required", runtimeTaskLeaseRequiredMessage(taskId, lease));
       const daemonRoute = taskId ? input.runtimeDaemonRoute : undefined;

--- a/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
@@ -197,6 +197,57 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
         true,
       );
     });
+    await t.test("dispatcher can hand off a task held by another executor", async () => {
+      const taskId = "task-runtime-dispatcher-handoff",
+        executionId = "exec-runtime-dispatcher-handoff",
+        leaseExecutor = { kind: "agent", id: "codex-sol" } as const;
+      assert.equal(
+        (await host.run(repoId, { kind: "task-create", taskId, title: "Dispatcher handoff" }, auth)).outcome,
+        "applied",
+      );
+      assert.equal(
+        (await host.run(repoId, { kind: "task-start", taskId, executionId, executor: leaseExecutor }, auth)).outcome,
+        "applied",
+      );
+      const receipt = await rpc(host, auth, "repo.agentRuntime.spawn", {
+        repo: { repoId },
+        payload: {
+          runtimeInstanceId: ingressDefinition.instanceId,
+          cwd: { scope: "repo-root" },
+          prompt: "Dispatcher hands off to the runtime session.",
+          taskId,
+          idempotencyKey: "dispatcher-handoff",
+        },
+      });
+      assert.equal(receipt.outcome, "applied", JSON.stringify(receipt));
+      const bound = await eventuallyValue(
+        async () =>
+          makeTaskEventStore({ repoId, rootDir: root })
+            .read()
+            .events.find(
+              (event) =>
+                event.type === "runtime_session_task_bound" &&
+                event.payload.runtimeSessionId === receipt.runtimeSessionId,
+            ) ?? null,
+      );
+      assert.equal(bound?.type, "runtime_session_task_bound");
+      assert.equal(bound?.actor.executor, null);
+      const projection = makeTaskProjection({ rootDir: root, eventStore: makeTaskEventStore({ repoId, rootDir: root }) });
+      try {
+        assert.equal(
+          projection.read(taskId).snapshot.decisionRelations.some(
+            (relation) =>
+              relation.sourceRef === `runtime-session/${receipt.runtimeSessionId}` &&
+              relation.targetRef === `task/${taskId}` &&
+              relation.relationType === "executes" &&
+              relation.state === "active",
+          ),
+          true,
+        );
+      } finally {
+        projection.close();
+      }
+    });
     await t.test("a worker that changes its user root is rejected before it can reach the parent daemon", async () => {
       const scratchUserRoot = path.join(parent, "isolated-user");
       registerDaemonRepo({

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -204,7 +204,11 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
     assert.deepEqual(tasks.rows[0]?.placement.moduleKeys, ["gui"]);
     assert.equal(tasks.rows[0]?.placement.origin, "native");
     const graph = parseDaemonGuiReadResult("repo.triadic.relationGraph", results.get("repo.triadic.relationGraph"));
-    assert.deepEqual(graph.edges.map(({ relationType }) => relationType).sort(), ["derives", "evidenced-by"]);
+    assert.deepEqual(graph.edges.map(({ relationType }) => relationType).sort(), [
+      "derives",
+      "evidenced-by",
+      "executes",
+    ]);
     assert.equal(graph.factAnchors.length, 1);
     assert.equal(graph.facts.length, 1);
     assert.equal(graph.facts[0]?.statement, "The GUI renderer received event-backed triadic rows.");

--- a/packages/kernel/src/domain/agent-runtime.ts
+++ b/packages/kernel/src/domain/agent-runtime.ts
@@ -7,6 +7,7 @@ import {
   type ActorIdentity,
   type EventEnvelope,
 } from "./write-chain.contract.ts";
+import type { EntityDocumentJsonSchema } from "./entity-json-schema.ts";
 
 export const runtimeProtocolFamilies = ["claude-compatible", "codex", "agy"] as const;
 export const runtimeCapabilities = ["structured_witness", "resume", "attach", "session_identity"] as const;
@@ -109,6 +110,64 @@ export type RuntimeSessionSemanticState =
   | "cancelled"
   | "ended-indeterminate"
   | "unavailable";
+
+const runtimeSessionSemanticStates = [
+  "running",
+  "succeeded",
+  "failed",
+  "cancelled",
+  "ended-indeterminate",
+  "unavailable",
+] as const;
+
+const runtimeSessionTaskLinkSchema = {
+  type: "object" as const,
+  additionalProperties: false as const,
+  required: ["taskId", "executionId"] as const,
+  properties: {
+    taskId: { type: "string" as const, minLength: 1, description: "Task bound during runtime handoff." },
+    executionId: { type: "string" as const, minLength: 1, description: "Execution opened by the task lease." },
+  },
+  description: "Task handoffs represented by the runtime-session executes edge.",
+};
+
+export const runtimeSessionEntityV1Schema = Object.freeze({
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  $id: "runtime-session/v1",
+  type: "object",
+  additionalProperties: false,
+  required: ["schema", "runtimeSessionId", "taskBindings", "liveness", "outcome", "semanticState"],
+  properties: {
+    schema: { type: "string", const: "runtime-session/v1", description: "Schema discriminator." },
+    runtimeSessionId: {
+      type: "string",
+      pattern: "^runtime_[a-z0-9]+$",
+      minLength: 1,
+      description: "Stable runtime session identity.",
+    },
+    taskBindings: {
+      type: "array",
+      items: runtimeSessionTaskLinkSchema,
+      description: "Tasks this session executes after authenticated handoff.",
+    },
+    liveness: {
+      type: "string",
+      enum: runtimeLivenessStates,
+      description: "Provider/process liveness vocabulary.",
+    },
+    outcome: {
+      type: "string",
+      enum: ["succeeded", "failed", "unknown", "cancelled"],
+      "x-nullable": true,
+      description: "Provider outcome, null before settlement.",
+    },
+    semanticState: {
+      type: "string",
+      enum: runtimeSessionSemanticStates,
+      description: "Derived semantic state from liveness and outcome.",
+    },
+  },
+}) as EntityDocumentJsonSchema;
 /** A domain judgment over independent liveness and outcome facts. */
 export function runtimeSessionSemanticState(
   session: Pick<RuntimeSession, "liveness" | "outcome">,
@@ -118,6 +177,7 @@ export function runtimeSessionSemanticState(
   if (session.outcome === "unknown") return "ended-indeterminate";
   return session.liveness === "live" ? "running" : "unavailable";
 }
+
 interface RuntimePayloads {
   readonly runtime_installation_observed: {
     readonly installationId: string;

--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -1,5 +1,6 @@
 import type { VerticalDefinition } from "../schemas/registry.ts";
 import { AGENT_DECLARATION_V1_SCHEMA, SQUAD_DECLARATION_V1_SCHEMA } from "./agent-squad-schema.ts";
+import { runtimeSessionEntityV1Schema } from "./agent-runtime.ts";
 import { DEFAULT_POLICY } from "./default-policy.ts";
 import {
   ENTITY_ID_PATTERN,
@@ -43,7 +44,13 @@ export interface EntityKindContract<T = unknown> {
   };
   readonly relations: {
     readonly directions: readonly RelationDirection[];
+    readonly edges: readonly {
+      readonly type: string;
+      readonly sourceKind: string;
+      readonly targetKind: string;
+    }[];
   };
+  readonly statusVocabulary?: readonly { readonly field: string; readonly words: readonly string[] }[];
   readonly transitionCatalog: {
     readonly ref: string;
     readonly transitions: readonly string[];
@@ -69,6 +76,7 @@ export interface EntityKindExplanation {
   };
   readonly id: EntityKindContract["id"];
   readonly relations: EntityKindContract["relations"];
+  readonly statusVocabulary: NonNullable<EntityKindContract["statusVocabulary"]>;
   readonly transitions: {
     readonly catalogRef: string | null;
     readonly available: readonly string[];
@@ -176,7 +184,7 @@ export const entityKindContracts = Object.freeze([
     kind: "agent",
     schema: AGENT_DECLARATION_V1_SCHEMA,
     id: { ...declarationId, refTemplate: "agent/{id}" },
-    relations: { directions: [] },
+    relations: { directions: [], edges: [] },
     transitionCatalog: null,
     document: declarationDocument("agents/{id}.json"),
   },
@@ -184,7 +192,7 @@ export const entityKindContracts = Object.freeze([
     kind: "squad",
     schema: SQUAD_DECLARATION_V1_SCHEMA,
     id: { ...declarationId, refTemplate: "squad/{id}" },
-    relations: { directions: [] },
+    relations: { directions: [], edges: [] },
     transitionCatalog: null,
     document: declarationDocument("squads/{id}.json"),
   },
@@ -192,7 +200,7 @@ export const entityKindContracts = Object.freeze([
     kind: "policy",
     schema: POLICY_DECLARATION_V1_SCHEMA,
     id: { ...declarationId, refTemplate: "policy/{id}" },
-    relations: { directions: [] },
+    relations: { directions: [], edges: [] },
     transitionCatalog: null,
     document: declarationDocument("policies/{id}.json"),
     validate: validatePolicyDeclarationV1,
@@ -205,7 +213,10 @@ export const entityKindContracts = Object.freeze([
     kind: "execution",
     schema: executionSchema,
     id: { field: "executionId", pattern: executionIdPattern, refTemplate: "execution/{id}" },
-    relations: { directions: ["directed"] },
+    relations: {
+      directions: ["directed"],
+      edges: [{ type: "executes", sourceKind: "execution", targetKind: "task" }],
+    },
     transitionCatalog: {
       ref: "kernel/task-lifecycle/v1",
       transitions: ["start", "renew", "submit", "complete", "release"],
@@ -216,12 +227,34 @@ export const entityKindContracts = Object.freeze([
     kind: "review",
     schema: reviewSchema,
     id: { field: "reviewId", pattern: reviewIdPattern, refTemplate: "review/{id}" },
-    relations: { directions: ["directed"] },
+    relations: {
+      directions: ["directed"],
+      edges: [{ type: "reviews", sourceKind: "review", targetKind: "execution" }],
+    },
     transitionCatalog: {
       ref: "kernel/task-lifecycle/v1",
       transitions: ["record"],
     },
     document: declarationDocument("reviews/{id}.json"),
+  },
+  {
+    kind: "runtime-session",
+    schema: runtimeSessionEntityV1Schema,
+    id: { field: "runtimeSessionId", pattern: "^runtime_[a-z0-9]+$", refTemplate: "runtime-session/{id}" },
+    relations: {
+      directions: ["directed"],
+      edges: [{ type: "executes", sourceKind: "runtime-session", targetKind: "task" }],
+    },
+    statusVocabulary: [
+      { field: "liveness", words: ["live", "stale", "unknown", "exited"] },
+      { field: "outcome", words: ["succeeded", "failed", "unknown", "cancelled"] },
+      {
+        field: "semanticState",
+        words: ["running", "succeeded", "failed", "cancelled", "ended-indeterminate", "unavailable"],
+      },
+    ],
+    transitionCatalog: null,
+    document: declarationDocument("runtime-sessions/{id}.json"),
   },
 ] as const satisfies readonly EntityKindContract[]);
 
@@ -248,6 +281,7 @@ export function explainEntityKind(kind: string): EntityKindExplanation {
     documentSchema: { id: contract.schema.$id, fields: explainEntityJsonSchema(contract.schema) },
     id: contract.id,
     relations: contract.relations,
+    statusVocabulary: contract.statusVocabulary ?? [],
     transitions: {
       catalogRef: contract.transitionCatalog?.ref ?? null,
       available: contract.transitionCatalog?.transitions ?? [],

--- a/packages/kernel/src/domain/task-bound-runtime-authority.ts
+++ b/packages/kernel/src/domain/task-bound-runtime-authority.ts
@@ -16,6 +16,18 @@ export function runtimeSessionIdFromActor(actor: ActorIdentity): string | null {
   return id.startsWith(prefix) && id.length > prefix.length ? id.slice(prefix.length) : null;
 }
 
+/** The handoff edge is the authenticated executor relation for a live runtime. */
+export function runtimeSessionExecutesTask(
+  session: RuntimeSession | null,
+  taskId: string,
+  executionId: string,
+): boolean {
+  return (
+    session?.liveness === "live" &&
+    session.taskBindings.some((binding) => binding.taskId === taskId && binding.executionId === executionId)
+  );
+}
+
 /** Resolves authority only from a canonical live runtime-session projection. */
 export function resolveLiveTaskBoundRuntimeBinding(
   session: RuntimeSession | null,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -37,6 +37,7 @@ export { canReclaim, isIndependentFrom, isSameExecution, isSamePerson } from "./
 export {
   isTaskBoundRuntimeWriter,
   resolveLiveTaskBoundRuntimeBinding,
+  runtimeSessionExecutesTask,
   runtimeSessionIdFromActor,
 } from "./domain/task-bound-runtime-authority.ts";
 export {

--- a/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
@@ -37,6 +37,7 @@ import {
   refreshRuntimeSessionAssociations,
 } from "./rebuildable-task-projection-runtime.ts";
 import { canonicalJson, runSql } from "./rebuildable-task-projection-sql.ts";
+import { deriveRelationId } from "../domain/entity-relation.ts";
 export type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
 export type { TaskProjection } from "./task-projection-port.ts";
 
@@ -187,6 +188,37 @@ export function applyEvent(
         );
         refreshRuntimeSessionAssociations(db, session);
       }
+    }
+    if (event.type === "runtime_session_task_bound") {
+      const source = `runtime-session/${event.payload.runtimeSessionId}`,
+        target = `task/${event.payload.taskId}`,
+        relationId = deriveRelationId({ source, target, type: "executes", direction: "directed" }),
+        row = {
+          relationId,
+          sourceRef: source,
+          targetRef: target,
+          relationType: "executes",
+          direction: "directed",
+          strength: "strong",
+          origin: "generated",
+          state: "active",
+          rationale: "Authenticated runtime handoff.",
+          ownerRef: source,
+          sourcePath: `event:${event.opId}`,
+          recordIndex: 0,
+        };
+      runSql(
+        db,
+        "INSERT OR REPLACE INTO relation_edge VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        relationId,
+        source,
+        target,
+        "executes",
+        "active",
+        source,
+        event.workspaceRevision,
+        JSON.stringify(row),
+      );
     }
     return;
   }

--- a/packages/kernel/src/schemas/entity-relations.ts
+++ b/packages/kernel/src/schemas/entity-relations.ts
@@ -13,7 +13,16 @@ const NonBlankStringSchema = Schema.String.pipe(Schema.pattern(/\S/u));
 const RelationIdSchema = Schema.String.pipe(Schema.pattern(/^rel_[a-f0-9]{16}$/u));
 const EntityRelationRefSchema = Schema.String.pipe(
   Schema.pattern(
-    /^(?:(?:task|decision)\/[A-Za-z0-9_-]+(?:\/[A-Za-z][A-Za-z0-9_-]*)?|fact\/[A-Za-z0-9_-]+\/F-[A-Za-z0-9_-]+|runtime-session\/runtime_[a-z0-9]+)$/u,
+    new RegExp(
+      [
+        "^(?:",
+        "(?:task|decision)/[A-Za-z0-9_-]+(?:/[A-Za-z][A-Za-z0-9_-]*)?",
+        "|fact/[A-Za-z0-9_-]+/F-[A-Za-z0-9_-]+",
+        "|runtime-session/runtime_[a-z0-9]+",
+        ")$",
+      ].join(""),
+      "u",
+    ),
   ),
 );
 

--- a/packages/kernel/src/schemas/entity-relations.ts
+++ b/packages/kernel/src/schemas/entity-relations.ts
@@ -13,7 +13,7 @@ const NonBlankStringSchema = Schema.String.pipe(Schema.pattern(/\S/u));
 const RelationIdSchema = Schema.String.pipe(Schema.pattern(/^rel_[a-f0-9]{16}$/u));
 const EntityRelationRefSchema = Schema.String.pipe(
   Schema.pattern(
-    /^(?:(?:task|decision)\/[A-Za-z0-9_-]+(?:\/[A-Za-z][A-Za-z0-9_-]*)?|fact\/[A-Za-z0-9_-]+\/F-[A-Za-z0-9_-]+)$/u,
+    /^(?:(?:task|decision)\/[A-Za-z0-9_-]+(?:\/[A-Za-z][A-Za-z0-9_-]*)?|fact\/[A-Za-z0-9_-]+\/F-[A-Za-z0-9_-]+|runtime-session\/runtime_[a-z0-9]+)$/u,
   ),
 );
 

--- a/packages/kernel/test/contracts/entity-store.test.ts
+++ b/packages/kernel/test/contracts/entity-store.test.ts
@@ -59,6 +59,34 @@ test("registered Entity kinds explain the same contract shape from their JSON sc
   );
 });
 
+test("RuntimeSession explains its identity, task handoff, status vocabulary, and executes edge", () => {
+  const explanation = explainEntityKind("runtime-session");
+  assert.equal(explanation.id.field, "runtimeSessionId");
+  assert.deepEqual(explanation.relations.edges, [
+    { type: "executes", sourceKind: "runtime-session", targetKind: "task" },
+  ]);
+  assert.deepEqual(explanation.statusVocabulary, [
+    { field: "liveness", words: ["live", "stale", "unknown", "exited"] },
+    { field: "outcome", words: ["succeeded", "failed", "unknown", "cancelled"] },
+    {
+      field: "semanticState",
+      words: ["running", "succeeded", "failed", "cancelled", "ended-indeterminate", "unavailable"],
+    },
+  ]);
+  assert.deepEqual(
+    explanation.documentSchema.fields.filter(({ name }) =>
+      ["runtimeSessionId", "taskBindings", "liveness", "outcome", "semanticState"].includes(name),
+    ).map(({ name, required }) => ({ name, required })),
+    [
+      { name: "runtimeSessionId", required: true },
+      { name: "taskBindings", required: true },
+      { name: "liveness", required: true },
+      { name: "outcome", required: true },
+      { name: "semanticState", required: true },
+    ],
+  );
+});
+
 test("one EntityStore implementation upserts, gets, and lists every registered declaration kind", () => {
   const events: EntityEventV1[] = [],
     blobs = new Map<string, Uint8Array>(),

--- a/packages/kernel/test/contracts/execution-review-entity.test.ts
+++ b/packages/kernel/test/contracts/execution-review-entity.test.ts
@@ -48,8 +48,14 @@ test("execution and review are dependency-free EntityKindContracts with lifecycl
 
   assert.equal(getEntityKindContract("execution")?.id.field, "executionId");
   assert.equal(getEntityKindContract("review")?.id.field, "reviewId");
-  assert.deepEqual(explainEntityKind("execution").relations, { directions: ["directed"] });
-  assert.deepEqual(explainEntityKind("review").relations, { directions: ["directed"] });
+  assert.deepEqual(explainEntityKind("execution").relations, {
+    directions: ["directed"],
+    edges: [{ type: "executes", sourceKind: "execution", targetKind: "task" }],
+  });
+  assert.deepEqual(explainEntityKind("review").relations, {
+    directions: ["directed"],
+    edges: [{ type: "reviews", sourceKind: "review", targetKind: "execution" }],
+  });
   assert.doesNotThrow(() => compileEntityUpsert({ ...base, entityKind: "execution", entity: execution }));
   assert.doesNotThrow(() => compileEntityUpsert({ ...base, entityKind: "review", entity: review }));
   assert.throws(


### PR DESCRIPTION
# English

## Summary

Task-bound runtime dispatch was coupled to the caller's lease: a dispatcher that did not hold the task's execution lease was rejected with `runtime_task_lease_required`, even when a same-principal handoff was legitimate. This PR registers RuntimeSession as an EntityKindContract (runtime session id, task handoff binding, liveness/outcome/semantic-state vocabularies, the directed `runtime-session executes task` edge) and admits a task-bound spawn through the projected handoff binding, so a dispatcher with the same principal may hand off a task held by another executor and an authenticated live session is admitted via its binding. The machine-local runtime-instance and terminal-session stores are deliberately untouched.

## Architectural Justification

-

## What Changed

- Kernel: `runtime-session` EntityKindContract with status vocabularies and the `executes` edge; `EntityKindContract.relations` now carries `edges` (policy entry updated with an empty list).
- Daemon `runtime-spawner.ts`: `runtime_task_lease_required` decided from the handoff binding; same-principal handoff allowed; regression added to `runtime-spawn-ingress.integration.test.ts` (codex-sol lease + dispatcher spawn).
- GUI relation constants: none — the 1.5 merge already carries them; the worker's duplicates were dropped on rebase.

## Machine-Readable Declarations

Production-Delta: +166/-9

## Task And Scope

- Harness task: task_95206d5d4731d28a54f36d59fe (PLT-Ontology Phase 1.3)
- Branch: `codex/agent-runtime-session`
- Public scope: kernel runtime-session contract, daemon spawn admission, integration test
- Private planning/evidence updated: yes (artifacts/reports/agent-runtime-session.md)
- Out of scope: agent-runtime-instance-store and terminal-session-store (user-root machine state, kept by CEO ruling); Agent contract (already landed in 1.1)

## Version Impact

- Version: no version change because this is a pre-release fix on the rebuild line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_95206d5d4731d28a54f36d59fe (PLT-Ontology Phase 1.3, scope narrowed by CEO ruling 2026-08-25: the two machine-local runtime stores stay)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: eb68191d08785d5b78f4e0978f91874122223306
- Branch merge-base with `origin/main`: eb68191d08785d5b78f4e0978f91874122223306
- Last `git fetch origin` time: 2026-08-25T02:22Z
- Sync method: rebase
- Public diff command: `git diff eb68191d08785d5b78f4e0978f91874122223306..9808c903a`
- Private evidence commit/path: harness task package task_95206d5d4731d28a54f36d59fe artifacts/reports
- Reviewer evidence path: worker report agent-runtime-session.md (typecheck pass; fast 345/345, contract 594/594; blocked only by the relation gate that #1811 has since unblocked); CEO finished the rebase after the worker session died, resolved conflicts by taking main for the vocabulary files and adding `edges: []` to the policy entry, and re-ran typecheck, the relation-direction gate, schema-closure, derived-contracts and kernel contract tests (107/107)
- GitHub Actions `rewrite-ci` run URL: pending (filled after the run)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test` (kernel contract tests 107/107 (CEO, worktree); worker fast/contract tiers; relation-direction, schema-closure, derived-contracts, G36 gates)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: the new runtime-spawn-ingress integration case was not re-run locally after the CEO rebase (worker ran it before the rebase); GitHub CI is the authority

## Review Evidence

- Self-review: CEO: the ontology change is that RuntimeSession is now an entity with an explicit executes edge, and admission reads that edge instead of inferring executor identity from the caller's lease.
- Reviewer subagent: yes (read-only report audit with independent git verification)
- Human review: pending
- Blocking findings: none

## Residual Risk

- The CEO-completed rebase touched `entity-kind-registry.ts` by hand; CI shard results are the check on that.

## References

- Task: task_95206d5d4731d28a54f36d59fe
- Evidence: artifacts/reports/agent-runtime-session.md
- Review: pending

---

# 中文

## 概要

task-bound runtime 派发一直耦合在调用者的 lease 上:不持有该任务 execution lease 的 dispatcher 会被 `runtime_task_lease_required` 拒绝,即便同 principal 的 handoff 是合法的。本 PR 把 RuntimeSession 登记为 EntityKindContract(session id、task handoff 绑定、liveness/outcome/semanticState 词表、有向 `runtime-session executes task` 边),并让 task-bound spawn 经投影的 handoff 绑定准入:同 principal 的 dispatcher 可以 handoff 另一执行者持有的任务,已认证的活 session 经其绑定准入。机器本地的 runtime-instance 与 terminal-session 两个 store 有意不动。

## 架构辩护

-

## 改动内容

- Kernel:`runtime-session` EntityKindContract,含状态词表与 `executes` 边;`EntityKindContract.relations` 增加 `edges`(policy 条目补空列表)。
- Daemon `runtime-spawner.ts`:`runtime_task_lease_required` 改由 handoff 绑定判定;允许同 principal handoff;`runtime-spawn-ingress.integration.test.ts` 增回归(codex-sol lease + dispatcher spawn)。
- GUI 关系常量:无——1.5 合入已带;worker 的重复项在 rebase 时删除。

## 机读声明说明

- 机读声明只在英文块出现一次。

## 任务与范围

- Harness 任务:task_95206d5d4731d28a54f36d59fe(PLT-Ontology Phase 1.3)
- 分支:`codex/agent-runtime-session`
- 公开范围:kernel runtime-session 契约、daemon spawn 准入、integration 测试
- 私有计划 / 证据是否已更新:yes(artifacts/reports/agent-runtime-session.md)
- 范围外:agent-runtime-instance-store 与 terminal-session-store(user-root 机器状态,CEO 裁决保留);Agent 契约(1.1 已落)

## 版本影响

- 版本:不改版本,原因是 rebuild 线 pre-release 修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_95206d5d4731d28a54f36d59fe (PLT-Ontology Phase 1.3, scope narrowed by CEO ruling 2026-08-25: the two machine-local runtime stores stay)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:eb68191d08785d5b78f4e0978f91874122223306
- 当前分支与 `origin/main` 的 merge-base:eb68191d08785d5b78f4e0978f91874122223306
- 最近一次 `git fetch origin` 时间:2026-08-25T02:22Z
- 同步方式:rebase
- 公开 diff 命令:`git diff eb68191d08785d5b78f4e0978f91874122223306..9808c903a`
- 私有证据 commit/path:任务包 artifacts/reports
- Reviewer 证据路径:worker 回执 agent-runtime-session.md(typecheck 过;fast 345/345、contract 594/594;仅被关系门挡,#1811 合入后解除);worker 会话死亡后 CEO 完成 rebase,词表文件取 main、policy 条目补 `edges: []`,重跑 typecheck、关系方向门、schema-closure、derived-contracts 与 kernel contract 测试(107/107)
- GitHub Actions `rewrite-ci` run URL:待 run 结束后补
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`(kernel contract 测试 107/107(CEO,worktree);worker 的 fast/contract tier;关系方向、schema-closure、derived-contracts、G36 门)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:CEO rebase 后未本地重跑新的 runtime-spawn-ingress integration 用例(worker 在 rebase 前跑过);GitHub CI 为权威

## 审查证据

- 自查:CEO:本体论变化在于 RuntimeSession 成为带显式 executes 边的实体,准入读这条边而不是从调用者 lease 推断执行者身份。
- Reviewer subagent:有(只读回执审计 + git 独立核实)
- 人工审查:待
- 阻塞发现:无

## 残余风险

- CEO 手工完成的 rebase 动了 `entity-kind-registry.ts`;以 CI shard 结果为准。

## 关联材料

- 任务:task_95206d5d4731d28a54f36d59fe
- 证据:artifacts/reports/agent-runtime-session.md
- 审查:待

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPPk3TmbURWuxcFY3kFimA


