### PR TITLE
feat(ontology): Action envelope, five-kind transition catalog, and receipt authorization/delta frame

### DIFF
--- a/packages/kernel/src/domain/action-envelope.ts
+++ b/packages/kernel/src/domain/action-envelope.ts
@@ -1,0 +1,43 @@
+import { stablePayloadHash } from "../integrity/stable-hash.ts";
+import type { ActorIdentity } from "./actor-identity.ts";
+import { validateActorIdentity } from "./actor-identity.ts";
+import { isNonEmptyString } from "./contract-validation.ts";
+import { parseEntityRef, type EntityRef } from "./entity-ref.ts";
+
+export interface ActionEnvelope<Kind extends string = string> {
+  readonly actionId: string;
+  readonly kind: Kind;
+  readonly target: EntityRef;
+  readonly actor: ActorIdentity;
+  readonly authorizationRef: string;
+  readonly idempotencyKey: string;
+}
+
+const actionEnvelopeFields = ["actionId", "kind", "target", "actor", "authorizationRef", "idempotencyKey"] as const;
+
+export function validateActionEnvelope(value: unknown): readonly string[] {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return ["Action envelope must be an object"];
+  const action = value as Readonly<Record<string, unknown>>,
+    errors = Object.keys(action)
+      .filter((field) => !actionEnvelopeFields.includes(field as (typeof actionEnvelopeFields)[number]))
+      .map((field) => `unexpected Action envelope field: ${field}`);
+  for (const field of ["actionId", "kind", "authorizationRef", "idempotencyKey"] as const)
+    if (!isNonEmptyString(action[field])) errors.push(`${field} is required`);
+  if (!isNonEmptyString(action.target) || parseEntityRef(action.target) === null)
+    errors.push("target must be an EntityRef");
+  errors.push(...validateActorIdentity(action.actor));
+  return errors;
+}
+
+/** Stable deduplication identity for retries; actionId identifies an attempt and is deliberately excluded. */
+export function actionReplayKey(action: ActionEnvelope): `sha256:${string}` {
+  const errors = validateActionEnvelope(action);
+  if (errors.length) throw new Error(`invalid Action envelope: ${errors.join("; ")}`);
+  return `sha256:${stablePayloadHash({
+    kind: action.kind,
+    target: action.target,
+    actor: action.actor,
+    authorizationRef: action.authorizationRef,
+    idempotencyKey: action.idempotencyKey,
+  })}`;
+}

--- a/packages/kernel/src/domain/actor-identity.ts
+++ b/packages/kernel/src/domain/actor-identity.ts
@@ -1,0 +1,36 @@
+import { isNonEmptyString } from "./contract-validation.ts";
+
+export interface ActorIdentity {
+  readonly principal: { readonly personId: string };
+  readonly executor: { readonly kind: "agent"; readonly id: string } | null;
+}
+
+export function validateActorIdentity(value: unknown, allowUnknownFields = false): readonly string[] {
+  if (
+    !record(value) ||
+    !fields(value, ["principal", "executor"], allowUnknownFields) ||
+    !record(value.principal) ||
+    !fields(value.principal, ["personId"], allowUnknownFields) ||
+    !isNonEmptyString(value.principal.personId)
+  )
+    return ["principal must be a person identity"];
+  if (
+    value.executor !== null &&
+    (!record(value.executor) ||
+      !fields(value.executor, ["kind", "id"], allowUnknownFields) ||
+      value.executor.kind !== "agent" ||
+      !isNonEmptyString(value.executor.id))
+  )
+    return ["executor must be an agent identity or null"];
+  return [];
+}
+
+function fields(value: Readonly<Record<string, unknown>>, required: readonly string[], allowUnknown: boolean): boolean {
+  return (
+    required.every((field) => Object.hasOwn(value, field)) &&
+    (allowUnknown || Object.keys(value).every((field) => required.includes(field)))
+  );
+}
+function record(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/kernel/src/domain/contract-validation.ts
+++ b/packages/kernel/src/domain/contract-validation.ts
@@ -1,0 +1,3 @@
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}

--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -1,6 +1,7 @@
 import type { VerticalDefinition } from "../schemas/registry.ts";
-import { AGENT_DECLARATION_V1_SCHEMA, SQUAD_DECLARATION_V1_SCHEMA } from "./agent-squad-schema.ts";
-import { runtimeSessionEntityV1Schema } from "./agent-runtime.ts";
+import { AGENT_DECLARATION_V1_SCHEMA, agentStates, SQUAD_DECLARATION_V1_SCHEMA } from "./agent-squad-schema.ts";
+import { agentRuntimeEventTypes, runtimeSessionEntityV1Schema } from "./agent-runtime.ts";
+import { policyStates } from "./decision-event-types.ts";
 import { DEFAULT_POLICY } from "./default-policy.ts";
 import {
   ENTITY_ID_PATTERN,
@@ -10,8 +11,10 @@ import {
   type EntityJsonSchemaNode,
 } from "./entity-json-schema.ts";
 import type { RelationDirection } from "./entity-relation.ts";
+import { executionStates } from "./execution.ts";
 import { POLICY_DECLARATION_V1_SCHEMA, validatePolicyDeclarationV1 } from "./policy.ts";
 import type { PolicyPredicateName } from "./policy.ts";
+import { reviewVerdicts } from "./review.ts";
 
 export type EntityKindDeclaration = VerticalDefinition["entityKinds"][number];
 export type EntityPackageScaffold = VerticalDefinition["packageScaffolds"][number];
@@ -185,7 +188,11 @@ export const entityKindContracts = Object.freeze([
     schema: AGENT_DECLARATION_V1_SCHEMA,
     id: { ...declarationId, refTemplate: "agent/{id}" },
     relations: { directions: [], edges: [] },
-    transitionCatalog: null,
+    statusVocabulary: [{ field: "state", words: agentStates }],
+    transitionCatalog: {
+      ref: "kernel/agent-declaration/v1",
+      transitions: ["configure", "activate", "retire"],
+    },
     document: declarationDocument("agents/{id}.json"),
   },
   {
@@ -201,7 +208,11 @@ export const entityKindContracts = Object.freeze([
     schema: POLICY_DECLARATION_V1_SCHEMA,
     id: { ...declarationId, refTemplate: "policy/{id}" },
     relations: { directions: [], edges: [] },
-    transitionCatalog: null,
+    statusVocabulary: [{ field: "state", words: policyStates }],
+    transitionCatalog: {
+      ref: "kernel/policy/v1",
+      transitions: ["draft", "activate", "retire"],
+    },
     document: declarationDocument("policies/{id}.json"),
     validate: validatePolicyDeclarationV1,
     policy: {
@@ -217,6 +228,7 @@ export const entityKindContracts = Object.freeze([
       directions: ["directed"],
       edges: [{ type: "executes", sourceKind: "execution", targetKind: "task" }],
     },
+    statusVocabulary: [{ field: "state", words: executionStates }],
     transitionCatalog: {
       ref: "kernel/task-lifecycle/v1",
       transitions: ["start", "renew", "submit", "complete", "release"],
@@ -231,6 +243,7 @@ export const entityKindContracts = Object.freeze([
       directions: ["directed"],
       edges: [{ type: "reviews", sourceKind: "review", targetKind: "execution" }],
     },
+    statusVocabulary: [{ field: "verdict", words: reviewVerdicts }],
     transitionCatalog: {
       ref: "kernel/task-lifecycle/v1",
       transitions: ["record"],
@@ -253,7 +266,10 @@ export const entityKindContracts = Object.freeze([
         words: ["running", "succeeded", "failed", "cancelled", "ended-indeterminate", "unavailable"],
       },
     ],
-    transitionCatalog: null,
+    transitionCatalog: {
+      ref: "kernel/agent-runtime-event/v1",
+      transitions: agentRuntimeEventTypes.filter((type) => type.startsWith("runtime_session_")),
+    },
     document: declarationDocument("runtime-sessions/{id}.json"),
   },
 ] as const satisfies readonly EntityKindContract[]);

--- a/packages/kernel/src/domain/entity-ref.ts
+++ b/packages/kernel/src/domain/entity-ref.ts
@@ -18,6 +18,7 @@ export interface ParsedEntityRef {
   readonly harnessAlias?: string;
   readonly externalHarness: boolean;
 }
+export type EntityRef = ParsedEntityRef["raw"];
 
 const entityRefPrefixPattern = /^(?:(?<alias>[A-Za-z][A-Za-z0-9_-]*):)?(?<body>.+)$/u;
 const taskOrDecisionRefPattern = /^(?<kind>task|decision)\/(?<id>[A-Za-z0-9_-]+)(?:\/(?<anchor>[A-Za-z0-9_-]+))?$/u;

--- a/packages/kernel/src/domain/receipt-domain-registry.ts
+++ b/packages/kernel/src/domain/receipt-domain-registry.ts
@@ -1,3 +1,10 @@
+import { validateActorIdentity } from "./actor-identity.ts";
+import { isNonEmptyString } from "./contract-validation.ts";
+import { parseEntityRef } from "./entity-ref.ts";
+import { type AuthorizationDecision, type TriadicDelta, type TriadicDeltaEntry } from "./receipt-frame.ts";
+export { EMPTY_TRIADIC_DELTA } from "./receipt-frame.ts";
+export type { AuthorizationDecision, ReceiptJsonValue, TriadicDelta, TriadicDeltaEntry } from "./receipt-frame.ts";
+
 export type ReceiptVisibility = "center" | { readonly kind: "replica"; readonly viewId: string };
 export interface ReceiptProof {
   readonly committedRevision: number;
@@ -89,6 +96,8 @@ export interface WriteReceipt {
   readonly proof?: ReceiptProof;
   readonly detail?: WriteReceiptDetail;
   readonly commitSha?: string | null;
+  readonly authorizationDecision?: AuthorizationDecision | null;
+  readonly delta?: TriadicDelta;
   readonly cut?: {
     readonly repoId: string;
     readonly revision: number;
@@ -110,6 +119,8 @@ export const WRITE_RECEIPT_SCHEMA = Object.freeze({
     "proof",
     "detail",
     "commitSha",
+    "authorizationDecision",
+    "delta",
     "cut",
   ]),
 });
@@ -120,16 +131,16 @@ export function validateWriteReceipt(value: unknown): readonly string[] {
     .map((key) => `unexpected field: ${key}`);
   if (!(WRITE_RECEIPT_SCHEMA.outcomes as readonly unknown[]).includes(value.outcome))
     errors.push("receipt outcome is invalid");
-  if (!text(value.opId)) errors.push("opId is required");
+  if (!isNonEmptyString(value.opId)) errors.push("opId is required");
   if ("revision" in value && !cut(value.revision)) errors.push("revision must be a non-negative integer");
   for (const field of ["code", "origin", "nextAction", "evidence"] as const)
-    if (field in value && !text(value[field])) errors.push(`${field} must be a non-empty string`);
+    if (field in value && !isNonEmptyString(value[field])) errors.push(`${field} must be a non-empty string`);
   const visibility = value.visibility,
     replica =
       isReceiptDomainRecord(visibility) &&
       exact(visibility, ["kind", "viewId"]) &&
       visibility.kind === "replica" &&
-      text(visibility.viewId);
+      isNonEmptyString(visibility.viewId);
   if ("visibility" in value && visibility !== "center" && !replica)
     errors.push("visibility must be center or replica(viewId)");
   const proof = value.proof,
@@ -160,13 +171,21 @@ export function validateWriteReceipt(value: unknown): readonly string[] {
     validPublicationCut =
       isReceiptDomainRecord(publicationCut) &&
       exact(publicationCut, ["repoId", "revision", "opId", "headDigest"]) &&
-      text(publicationCut.repoId) &&
+      isNonEmptyString(publicationCut.repoId) &&
       cut(publicationCut.revision) &&
-      text(publicationCut.opId) &&
+      isNonEmptyString(publicationCut.opId) &&
       typeof publicationCut.headDigest === "string" &&
       /^sha256:[0-9a-f]{64}$/u.test(publicationCut.headDigest);
   if ("commitSha" in value && value.commitSha !== null && !sha(value.commitSha))
     errors.push("commitSha must be a Git SHA or null while materialization is pending");
+  if (
+    "authorizationDecision" in value &&
+    value.authorizationDecision !== null &&
+    !validAuthorizationDecision(value.authorizationDecision)
+  )
+    errors.push("authorizationDecision must match AuthorizationDecision or be null before authorization wiring");
+  if ("delta" in value && !validTriadicDelta(value.delta))
+    errors.push("delta must contain closed fact, decision, and task change arrays");
   if ("cut" in value && !validPublicationCut) errors.push("cut must identify repoId, revision, opId, and headDigest");
   if (
     ("cut" in value && !("commitSha" in value)) ||
@@ -193,19 +212,77 @@ export function validateWriteReceipt(value: unknown): readonly string[] {
     errors.push("replica applied requires worktree visibility and ackCut at the same cut");
   if (
     (value.outcome === "applied" || value.outcome === "no_changes") &&
-    (!cut(value.revision) || !text(value.evidence))
+    (!cut(value.revision) || !isNonEmptyString(value.evidence))
   )
     errors.push(`${String(value.outcome)} requires revision and evidence`);
-  if (value.outcome === "no_changes" && (value.code !== "no_changes" || !text(value.origin) || !text(value.nextAction)))
+  if (
+    value.outcome === "no_changes" &&
+    (value.code !== "no_changes" || !isNonEmptyString(value.origin) || !isNonEmptyString(value.nextAction))
+  )
     errors.push("no_changes requires code, origin, and nextAction");
-  if (value.outcome === "pending" && (!cut(value.revision) || !text(value.evidence) || !text(value.nextAction)))
+  if (
+    value.outcome === "pending" &&
+    (!cut(value.revision) || !isNonEmptyString(value.evidence) || !isNonEmptyString(value.nextAction))
+  )
     errors.push("pending requires committed evidence, revision, and nextAction");
   if (value.outcome === "indeterminate" || value.outcome === "op_rejected")
     for (const field of ["code", "origin", "nextAction"] as const)
-      if (!text(value[field])) errors.push(`${field} is required for ${value.outcome}`);
-  if (!text(value.evidence) && (value.outcome !== "indeterminate" || value.origin !== "N/A"))
+      if (!isNonEmptyString(value[field])) errors.push(`${field} is required for ${value.outcome}`);
+  if (!isNonEmptyString(value.evidence) && (value.outcome !== "indeterminate" || value.origin !== "N/A"))
     errors.push("evidence-free receipt must be N/A indeterminate");
   return errors;
+}
+function validAuthorizationDecision(value: unknown): value is AuthorizationDecision {
+  if (
+    !isReceiptDomainRecord(value) ||
+    !exact(value, [
+      "policyRef",
+      "actor",
+      "subject",
+      "bindingsUsed",
+      "outcome",
+      "reasonCodes",
+      "nextActions",
+      "evaluatedAtCut",
+    ])
+  )
+    return false;
+  const denied = value.outcome === "denied";
+  return (
+    /^\S+@[1-9][0-9]*$/u.test(String(value.policyRef)) &&
+    validateActorIdentity(value.actor).length === 0 &&
+    typeof value.subject === "string" &&
+    parseEntityRef(value.subject) !== null &&
+    Array.isArray(value.bindingsUsed) &&
+    value.bindingsUsed.every((binding) => isReceiptDomainRecord(binding) && jsonValue(binding)) &&
+    (value.outcome === "allowed" || denied) &&
+    Array.isArray(value.reasonCodes) &&
+    value.reasonCodes.every(isNonEmptyString) &&
+    Array.isArray(value.nextActions) &&
+    value.nextActions.every(isNonEmptyString) &&
+    (!denied || (value.reasonCodes.length > 0 && value.nextActions.length > 0)) &&
+    isNonEmptyString(value.evaluatedAtCut)
+  );
+}
+function validTriadicDelta(value: unknown): value is TriadicDelta {
+  return (
+    isReceiptDomainRecord(value) &&
+    exact(value, ["fact", "decision", "task"]) &&
+    (["fact", "decision", "task"] as const).every(
+      (kind) => Array.isArray(value[kind]) && value[kind].every((entry) => validDeltaEntry(entry, kind)),
+    )
+  );
+}
+function validDeltaEntry(value: unknown, kind: "fact" | "decision" | "task"): value is TriadicDeltaEntry {
+  if (!isReceiptDomainRecord(value) || !exact(value, ["ref", "before", "after"]) || typeof value.ref !== "string")
+    return false;
+  const ref = parseEntityRef(value.ref);
+  return (
+    ref?.kind === kind &&
+    jsonValue(value.before) &&
+    jsonValue(value.after) &&
+    !(value.before === null && value.after === null)
+  );
 }
 function validateDocSyncDetail(value: Readonly<Record<string, unknown>>): boolean {
   return (
@@ -222,31 +299,33 @@ function validateDocSyncDetail(value: Readonly<Record<string, unknown>>): boolea
       "nextAction",
     ]) &&
     value.kind === "doc_sync" &&
-    text(value.code) &&
+    isNonEmptyString(value.code) &&
     receiptLedgerIdentity(value.baseLedgerSha) &&
     ledgerCut(value.currentLedgerSha) &&
-    text(value.nextAction) &&
+    isNonEmptyString(value.nextAction) &&
     Array.isArray(value.paths) &&
     value.paths.every(
       (row) =>
         isReceiptDomainRecord(row) &&
         exact(row, ["path", "baseBlobSha256", "currentBlobSha256", "candidateBlobSha256"]) &&
-        text(row.path) &&
+        isNonEmptyString(row.path) &&
         [row.baseBlobSha256, row.currentBlobSha256, row.candidateBlobSha256].every(nullableSha),
     ) &&
     (value.holder === null ||
       (isReceiptDomainRecord(value.holder) &&
         exact(value.holder, ["taskId", "executionId", "personId", "executorId", "source", "expiresAt", "version"]) &&
-        [value.holder.taskId, value.holder.executionId, value.holder.personId, value.holder.expiresAt].every(text) &&
-        (value.holder.executorId === null || text(value.holder.executorId)) &&
+        [value.holder.taskId, value.holder.executionId, value.holder.personId, value.holder.expiresAt].every(
+          isNonEmptyString,
+        ) &&
+        (value.holder.executorId === null || isNonEmptyString(value.holder.executorId)) &&
         cut(value.holder.version))) &&
     Array.isArray(value.differences) &&
     value.differences.every(
       (row) =>
         isReceiptDomainRecord(row) &&
         exact(row, ["path", "regionId", "insertBytes", "deleteBytes", "replaceBytes", "firstChange"]) &&
-        text(row.path) &&
-        text(row.regionId) &&
+        isNonEmptyString(row.path) &&
+        isNonEmptyString(row.regionId) &&
         [row.insertBytes, row.deleteBytes, row.replaceBytes].every(cut) &&
         (row.firstChange === null ||
           (isReceiptDomainRecord(row.firstChange) &&
@@ -259,16 +338,16 @@ function validateDocSyncDetail(value: Readonly<Record<string, unknown>>): boolea
       (row) =>
         isReceiptDomainRecord(row) &&
         exact(row, ["path", "regionId", "anchor", "reason", "requiredRoute", "policy"]) &&
-        [row.path, row.reason, row.requiredRoute, row.policy].every(text) &&
-        (row.regionId === null || text(row.regionId)) &&
-        (row.anchor === null || text(row.anchor)),
+        [row.path, row.reason, row.requiredRoute, row.policy].every(isNonEmptyString) &&
+        (row.regionId === null || isNonEmptyString(row.regionId)) &&
+        (row.anchor === null || isNonEmptyString(row.anchor)),
     ) &&
     Array.isArray(value.deletions) &&
     value.deletions.every(
       (row) =>
         isReceiptDomainRecord(row) &&
         exact(row, ["path", "baseBlobSha256", "source"]) &&
-        text(row.path) &&
+        isNonEmptyString(row.path) &&
         nullableSha(row.baseBlobSha256) &&
         row.baseBlobSha256 !== null &&
         row.source === "intent",
@@ -280,10 +359,10 @@ function validateEntityUpsertDetail(value: Readonly<Record<string, unknown>>): b
   return (
     exact(value, ["kind", "entityKind", "entityId", "schemaId", "path"]) &&
     value.kind === "entity_upsert" &&
-    text(value.entityKind) &&
-    text(value.entityId) &&
-    text(value.schemaId) &&
-    text(value.path)
+    isNonEmptyString(value.entityKind) &&
+    isNonEmptyString(value.entityId) &&
+    isNonEmptyString(value.schemaId) &&
+    isNonEmptyString(value.path)
   );
 }
 function isReceiptDomainRecord(value: unknown): value is Readonly<Record<string, unknown>> {
@@ -292,8 +371,11 @@ function isReceiptDomainRecord(value: unknown): value is Readonly<Record<string,
 function exact(value: Readonly<Record<string, unknown>>, fields: readonly string[]): boolean {
   return Object.keys(value).length === fields.length && fields.every((field) => field in value);
 }
-function text(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
+function jsonValue(value: unknown): boolean {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return true;
+  if (typeof value === "number") return Number.isFinite(value);
+  if (Array.isArray(value)) return value.every(jsonValue);
+  return isReceiptDomainRecord(value) && Object.values(value).every(jsonValue);
 }
 function cut(value: unknown): value is number {
   return Number.isInteger(value) && (value as number) >= 0;
@@ -307,14 +389,17 @@ function nullableSha(value: unknown): boolean {
 function receiptLedgerIdentity(value: unknown): value is LedgerIdentity {
   return (
     ledgerCut(value) ||
-    (isReceiptDomainRecord(value) && exact(value, ["repoId", "sha"]) && text(value.repoId) && sha(value.sha))
+    (isReceiptDomainRecord(value) &&
+      exact(value, ["repoId", "sha"]) &&
+      isNonEmptyString(value.repoId) &&
+      sha(value.sha))
   );
 }
 function ledgerCut(value: unknown): value is LedgerCutIdentity {
   return (
     isReceiptDomainRecord(value) &&
     exact(value, ["repoId", "revision", "headDigest"]) &&
-    text(value.repoId) &&
+    isNonEmptyString(value.repoId) &&
     cut(value.revision) &&
     typeof value.headDigest === "string" &&
     /^sha256:[0-9a-f]{64}$/u.test(value.headDigest)

--- a/packages/kernel/src/domain/receipt-frame.ts
+++ b/packages/kernel/src/domain/receipt-frame.ts
@@ -1,0 +1,35 @@
+import type { ActorIdentity } from "./actor-identity.ts";
+import type { EntityRef } from "./entity-ref.ts";
+
+export type ReceiptJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly ReceiptJsonValue[]
+  | { readonly [field: string]: ReceiptJsonValue };
+export interface AuthorizationDecision {
+  readonly policyRef: string;
+  readonly actor: ActorIdentity;
+  readonly subject: EntityRef;
+  readonly bindingsUsed: readonly Readonly<Record<string, ReceiptJsonValue>>[];
+  readonly outcome: "allowed" | "denied";
+  readonly reasonCodes: readonly string[];
+  readonly nextActions: readonly string[];
+  readonly evaluatedAtCut: string;
+}
+export interface TriadicDeltaEntry {
+  readonly ref: EntityRef;
+  readonly before: ReceiptJsonValue;
+  readonly after: ReceiptJsonValue;
+}
+export interface TriadicDelta {
+  readonly fact: readonly TriadicDeltaEntry[];
+  readonly decision: readonly TriadicDeltaEntry[];
+  readonly task: readonly TriadicDeltaEntry[];
+}
+export const EMPTY_TRIADIC_DELTA: TriadicDelta = Object.freeze({
+  fact: Object.freeze([]),
+  decision: Object.freeze([]),
+  task: Object.freeze([]),
+});

--- a/packages/kernel/src/domain/status-vocabulary-catalog.ts
+++ b/packages/kernel/src/domain/status-vocabulary-catalog.ts
@@ -284,6 +284,15 @@ export const statusVocabularies: readonly StatusVocabulary[] = [
     note: "The WriteReceipt interface repeats the outcome vocabulary; must stay equal to writeReceiptOutcomes.",
   },
   {
+    id: "authorization-decision.outcome",
+    entity: "AuthorizationDecision",
+    field: "outcome",
+    module: "packages/kernel/src/domain/receipt-frame.ts",
+    anchor: "#outcome",
+    words: ["allowed", "denied"],
+    note: "Append-only policy evaluation result carried by a write receipt.",
+  },
+  {
     id: "recovery.state",
     entity: "Recovery",
     field: "state",

--- a/packages/kernel/src/domain/status-vocabulary-types.ts
+++ b/packages/kernel/src/domain/status-vocabulary-types.ts
@@ -11,6 +11,7 @@ export type StatusEntity =
   | "Review"
   | "RuntimeSession"
   | "WriteReceipt"
+  | "AuthorizationDecision"
   | "Recovery"
   | "PresetRun"
   | "TaskCloseout"

--- a/packages/kernel/src/domain/status-word-register-runtime.ts
+++ b/packages/kernel/src/domain/status-word-register-runtime.ts
@@ -169,6 +169,22 @@ export const runtimeAndRecoveryStatusWords: readonly StatusWordRegistration[] = 
       "one-shot operation result no longer collides with Decision.rejected.",
   },
 
+  // ---- AuthorizationDecision.outcome (policy evaluation carried by a receipt) ----
+  {
+    word: "allowed",
+    entity: "AuthorizationDecision",
+    field: "outcome",
+    meaning: "The evaluated policy permits the Action for the recorded actor and subject.",
+    divergence: "entity-scoped",
+  },
+  {
+    word: "denied",
+    entity: "AuthorizationDecision",
+    field: "outcome",
+    meaning: "The evaluated policy refuses the Action and records reasons and next Actions.",
+    divergence: "entity-scoped",
+  },
+
   // ---- Recovery.state (write-chain recovery batches; runtime-only) ----
   {
     word: "queued",

--- a/packages/kernel/src/domain/write-chain.contract.ts
+++ b/packages/kernel/src/domain/write-chain.contract.ts
@@ -1,19 +1,28 @@
 import { stablePayloadHash, stableStringify } from "../integrity/stable-hash.ts";
-import { validateWriteReceipt, type WriteReceipt } from "./receipt-domain-registry.ts";
-export { receiptDetailRegistry, validateWriteReceipt, WRITE_RECEIPT_SCHEMA } from "./receipt-domain-registry.ts";
+import { validateActorIdentity, type ActorIdentity } from "./actor-identity.ts";
+import { isNonEmptyString } from "./contract-validation.ts";
+import { EMPTY_TRIADIC_DELTA, validateWriteReceipt, type WriteReceipt } from "./receipt-domain-registry.ts";
+export { validateActorIdentity } from "./actor-identity.ts";
+export type { ActorIdentity } from "./actor-identity.ts";
+export { isNonEmptyString } from "./contract-validation.ts";
+export {
+  EMPTY_TRIADIC_DELTA,
+  receiptDetailRegistry,
+  validateWriteReceipt,
+  WRITE_RECEIPT_SCHEMA,
+} from "./receipt-domain-registry.ts";
 export type {
+  AuthorizationDecision,
   DocSyncReceiptDetail,
   LedgerCutIdentity,
   ReceiptProof,
+  ReceiptJsonValue,
   ReceiptVisibility,
   WriteReceipt,
   WriteReceiptDetail,
+  TriadicDelta,
+  TriadicDeltaEntry,
 } from "./receipt-domain-registry.ts";
-
-export interface ActorIdentity {
-  readonly principal: { readonly personId: string };
-  readonly executor: { readonly kind: "agent"; readonly id: string } | null;
-}
 
 export type WriteSource =
   | "local"
@@ -177,10 +186,6 @@ export class WriteChainContractError extends Error {
   }
 }
 
-export function isNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
-}
-
 export function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -200,26 +205,6 @@ export function hasContractFields(
   allowUnknownFields: boolean,
 ): boolean {
   return allowUnknownFields ? hasRequiredFields(value, fields) : hasOnlyFields(value, fields);
-}
-
-export function validateActorIdentity(value: unknown, allowUnknownFields = false): readonly string[] {
-  if (
-    !isRecord(value) ||
-    !hasContractFields(value, ["principal", "executor"], allowUnknownFields) ||
-    !isRecord(value.principal) ||
-    !hasContractFields(value.principal, ["personId"], allowUnknownFields) ||
-    !isNonEmptyString(value.principal.personId)
-  )
-    return ["principal must be a person identity"];
-  if (
-    value.executor !== null &&
-    (!isRecord(value.executor) ||
-      !hasContractFields(value.executor, ["kind", "id"], allowUnknownFields) ||
-      value.executor.kind !== "agent" ||
-      !isNonEmptyString(value.executor.id))
-  )
-    return ["executor must be an agent identity or null"];
-  return [];
 }
 
 export function validateWriteSource(value: unknown, allowUnknownFields = false): readonly string[] {
@@ -268,10 +253,13 @@ export function sameWriteSource(left: unknown, right: unknown): boolean {
   return shape !== null && stableStringify(shape) === stableStringify(writeSourceShape(right));
 }
 
-export function createWriteReceipt<R extends WriteReceipt>(receipt: R): Readonly<R> {
-  const errors = validateWriteReceipt(receipt);
+export function createWriteReceipt<R extends WriteReceipt>(
+  receipt: R,
+): Readonly<R & Pick<WriteReceipt, "authorizationDecision" | "delta">> {
+  const framed = { authorizationDecision: null, delta: EMPTY_TRIADIC_DELTA, ...receipt },
+    errors = validateWriteReceipt(framed);
   if (errors.length > 0) throw new WriteChainContractError("invalid_contract", `invalid receipt: ${errors.join("; ")}`);
-  return Object.freeze({ ...receipt });
+  return Object.freeze(framed);
 }
 
 export function serializeWriteReceipt(receipt: WriteReceipt): string {

--- a/packages/kernel/test/contracts/action-envelope.test.ts
+++ b/packages/kernel/test/contracts/action-envelope.test.ts
@@ -1,0 +1,102 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { actionReplayKey, validateActionEnvelope } from "../../src/domain/action-envelope.ts";
+import { validateWriteReceipt } from "../../src/domain/receipt-domain-registry.ts";
+import { createWriteReceipt, explainEntityKind } from "../../src/index.ts";
+
+const actor = { principal: { personId: "person-action" }, executor: { kind: "agent" as const, id: "sol" } };
+const action = {
+  actionId: "action-start-1",
+  kind: "start",
+  target: "execution/exe_action",
+  actor,
+  authorizationRef: "task.start@1",
+  idempotencyKey: "start-once",
+};
+
+test("Action envelope is one closed kernel contract with a stable replay identity", () => {
+  assert.deepEqual(validateActionEnvelope(action), []);
+  assert.equal(actionReplayKey(action), actionReplayKey({ ...action, actionId: "action-retry-2" }));
+  assert.notEqual(actionReplayKey(action), actionReplayKey({ ...action, idempotencyKey: "start-twice" }));
+  assert.match(validateActionEnvelope({ ...action, method: "repo.task.run" }).join("\n"), /unexpected.*method/u);
+  assert.match(validateActionEnvelope({ ...action, idempotencyKey: "" }).join("\n"), /idempotencyKey is required/u);
+});
+
+test("the five promoted Entity explanations expose status-aligned transition Actions", () => {
+  const catalogs = Object.fromEntries(
+    ["execution", "review", "agent", "runtime-session", "policy"].map((kind) => [kind, explainEntityKind(kind)]),
+  );
+  assert.deepEqual(catalogs.execution?.statusVocabulary, [
+    { field: "state", words: ["active", "submitted", "accepted", "changes_requested", "abandoned"] },
+  ]);
+  assert.deepEqual(catalogs.execution?.transitions.available, ["start", "renew", "submit", "complete", "release"]);
+  assert.deepEqual(catalogs.review?.statusVocabulary, [
+    { field: "verdict", words: ["approved", "changes_requested", "dismissed"] },
+  ]);
+  assert.deepEqual(catalogs.review?.transitions.available, ["record"]);
+  assert.deepEqual(catalogs.agent?.statusVocabulary, [{ field: "state", words: ["configured", "active", "retired"] }]);
+  assert.deepEqual(catalogs.agent?.transitions.available, ["configure", "activate", "retire"]);
+  assert.deepEqual(catalogs.policy?.statusVocabulary, [{ field: "state", words: ["draft", "active", "retired"] }]);
+  assert.deepEqual(catalogs.policy?.transitions.available, ["draft", "activate", "retire"]);
+  assert.deepEqual(catalogs["runtime-session"]?.transitions.available, [
+    "runtime_session_started",
+    "runtime_session_provider_bound",
+    "runtime_session_task_bound",
+    "runtime_session_liveness_changed",
+    "runtime_session_cancelled",
+    "runtime_session_exited",
+    "runtime_session_outcome_observed",
+  ]);
+});
+
+test("new receipts default to an unwired AuthorizationDecision and an empty triadic delta", () => {
+  const receipt = createWriteReceipt({
+    outcome: "applied",
+    opId: "op-action",
+    revision: 1,
+    evidence: "event:op-action",
+    visibility: "center",
+    proof: {
+      committedRevision: 1,
+      appliedCut: 1,
+      durable: true,
+      canonicalVisible: true,
+      worktreeVisible: null,
+    },
+  });
+  assert.equal(receipt.authorizationDecision, null);
+  assert.deepEqual(receipt.delta, { fact: [], decision: [], task: [] });
+  assert.deepEqual(validateWriteReceipt(receipt), []);
+
+  const authorized = {
+    ...receipt,
+    authorizationDecision: {
+      policyRef: "task.start@1",
+      actor,
+      subject: "task/task-action",
+      bindingsUsed: [],
+      outcome: "allowed" as const,
+      reasonCodes: [],
+      nextActions: [],
+      evaluatedAtCut: "canonical:1",
+    },
+    delta: {
+      fact: [{ ref: "fact/task-action/F-action", before: null, after: { statement: "observed" } }],
+      decision: [],
+      task: [{ ref: "task/task-action", before: { status: "planned" }, after: { status: "active" } }],
+    },
+  };
+  assert.deepEqual(validateWriteReceipt(authorized), []);
+  assert.match(
+    validateWriteReceipt({
+      ...authorized,
+      authorizationDecision: { ...authorized.authorizationDecision, evaluatedAtCut: "" },
+    }).join("\n"),
+    /AuthorizationDecision/u,
+  );
+  assert.match(
+    validateWriteReceipt({ ...authorized, delta: { ...authorized.delta, decision: undefined } }).join("\n"),
+    /closed fact, decision, and task/u,
+  );
+});

--- a/packages/kernel/test/contracts/entity-store.test.ts
+++ b/packages/kernel/test/contracts/entity-store.test.ts
@@ -27,7 +27,7 @@ const squad = {
   roster: "# Core Squad",
 };
 
-test("registered Entity kinds explain the same contract shape from their JSON schemas", () => {
+test("registered declaration Entity kinds explain the same contract shape from their JSON schemas", () => {
   const explanations = [explainEntityKind("agent"), explainEntityKind("squad")];
   assert.deepEqual(Object.keys(explanations[0]!).sort(), Object.keys(explanations[1]!).sort());
   for (const explanation of explanations) {
@@ -39,8 +39,12 @@ test("registered Entity kinds explain the same contract shape from their JSON sc
     ]);
     assert.equal(explanation.id.field, "id");
     assert.equal(explanation.relations.directions.length, 0);
-    assert.deepEqual(explanation.transitions, { catalogRef: null, available: [] });
   }
+  assert.deepEqual(explanations[0]!.transitions, {
+    catalogRef: "kernel/agent-declaration/v1",
+    available: ["configure", "activate", "retire"],
+  });
+  assert.deepEqual(explanations[1]!.transitions, { catalogRef: null, available: [] });
   assert.equal(explanations[0]!.documentSchema.fields.find(({ name }) => name === "runtime_type")?.required, true);
   assert.match(
     validateAgentDeclarationV1({
@@ -74,9 +78,9 @@ test("RuntimeSession explains its identity, task handoff, status vocabulary, and
     },
   ]);
   assert.deepEqual(
-    explanation.documentSchema.fields.filter(({ name }) =>
-      ["runtimeSessionId", "taskBindings", "liveness", "outcome", "semanticState"].includes(name),
-    ).map(({ name, required }) => ({ name, required })),
+    explanation.documentSchema.fields
+      .filter(({ name }) => ["runtimeSessionId", "taskBindings", "liveness", "outcome", "semanticState"].includes(name))
+      .map(({ name, required }) => ({ name, required })),
     [
       { name: "runtimeSessionId", required: true },
       { name: "taskBindings", required: true },

--- a/tools/gates/test/write-chain-contract.test.mjs
+++ b/tools/gates/test/write-chain-contract.test.mjs
@@ -207,6 +207,8 @@ test("G02/G07 expose one four-state receipt and bounded recovery contract", asyn
       proof: { committedRevision: 1, appliedCut: 1, durable: true, canonicalVisible: true, worktreeVisible: null },
     }),
     {
+      authorizationDecision: null,
+      delta: { fact: [], decision: [], task: [] },
       outcome: "applied",
       opId: "op_1",
       revision: 1,


### PR DESCRIPTION
# English

## Summary

Phase 2 needs one request contract that every Action goes through and one receipt frame that can carry the authorization decision and the write delta. This PR defines the Action envelope in the kernel domain (actionId, kind, target EntityRef, actor, authorizationRef, idempotencyKey; replay identity excludes actionId so retries dedupe on the five semantic fields), projects the transition catalog for all five Phase 1 entity kinds from their existing state/event vocabularies so `ha entity explain <kind>` lists available Actions from the single contract table, and adds `AuthorizationDecision` and a closed triadic `delta` to the receipt frame with defaults so old receipts still replay. Nothing is wired to decision points yet — that is 2.2.

## Architectural Justification

Why the existing modules cannot carry it: `command-receipt/v2` only has a result-side `action`/`entity` and no request envelope (no actor, authorization ref or idempotency key), so there was nothing to merge into; `write-chain.contract.ts` owned ActorIdentity and consumed the receipt registry, so adding AuthorizationDecision there would create a cycle.
What obsolete code was removed: the ActorIdentity interface and `validateActorIdentity` implementation inside `write-chain.contract.ts` and the scattered ad-hoc string validators (-68); write-chain now re-exports the single definition.
Why the scope cannot be narrowed: the closed six-field envelope, replay identity, five-kind catalog, AuthorizationDecision, closed delta and old-receipt defaults must hold together — dropping any one leaves a TypeScript-only schema with no runtime rejection, a duplicated actor validator, or a second Action table in the CLI.

## What Changed

- `packages/kernel/src/domain/action-envelope.ts`: the envelope type and runtime validator; replay identity hash over the five semantic fields.
- `actor-identity.ts`: `ActorIdentity` and its validator moved out of `write-chain.contract.ts` into a neutral domain seam (write-chain re-exports; no duplicate validator).
- `entity-kind-registry.ts` / `entity-ref.ts`: Action catalog for execution/review (task-lifecycle/v1), agent, policy, runtime-session (`runtime_session_*` events only).
- `receipt-frame.ts` / `receipt-domain-registry.ts`: `authorizationDecision: null` and `delta: {fact:[],decision:[],task:[]}` defaults; `allowed|denied` registered in the status vocabulary.
- Tests: contract tests for the envelope and store; write-chain gate test updated.

## Machine-Readable Declarations

Production-Delta: +301/-68

## Task And Scope

- Harness task: task_f43c77a13ddbadd9a8a49e18bc (PLT-Ontology Phase 2.1)
- Branch: `codex/action-envelope`
- Public scope: kernel domain contracts (envelope, actor identity, receipt frame, entity action catalog), status vocabulary, contract tests
- Private planning/evidence updated: yes (artifacts/reports/action-envelope.md)
- Out of scope: wiring the envelope/decision into AuthorizationPort call sites (2.2) and StartExecution (2.3); no daemon or CLI write path changed

## Version Impact

- Version: no version change because this is a pre-release fix on the rebuild line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_f43c77a13ddbadd9a8a49e18bc (PLT-Ontology Phase 2.1)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 84cc1223dcfb9b3ef65a47c0ab58952278505101
- Branch merge-base with `origin/main`: 84cc1223dcfb9b3ef65a47c0ab58952278505101
- Last `git fetch origin` time: 2026-08-25T04:38Z
- Sync method: rebase
- Public diff command: `git diff 84cc1223dcfb9b3ef65a47c0ab58952278505101..3c248f8a7`
- Private evidence commit/path: harness task package task_f43c77a13ddbadd9a8a49e18bc artifacts/reports
- Reviewer evidence path: worker report action-envelope.md: typecheck, contract tests, Docker-isolated contract run, `ha entity explain` output for the five kinds; CEO verified G36 pass, control-character scan empty, production delta +301/-68 matches the report
- GitHub Actions `rewrite-ci` run URL: pending (filled after the run)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test` (kernel contract tests (envelope, entity-store), write-chain gate test, Docker-isolated contract run)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: GitHub integration shard matrix locally (CI is the authority)

## Review Evidence

- Self-review: CEO: the single-definition moves (actor identity out of write-chain) are what keep this from becoming a second validator; the receipt defaults are the compatibility point for replay, not a fallback for new writes.
- Reviewer subagent: yes (read-only report audit with independent git verification)
- Human review: pending
- Blocking findings: none

## Residual Risk

- Churn 369 > 200 — justification section provided; the catalog is a projection of existing vocabularies, so it must be re-checked when 1.5's status vocabularies change.

## References

- Task: task_f43c77a13ddbadd9a8a49e18bc
- Evidence: artifacts/reports/action-envelope.md
- Review: pending

---

# 中文

## 概要

Phase 2 需要一份所有 Action 都经过的 request 契约,以及一个能装下授权决定与写入 delta 的 receipt 框架。本 PR 在 kernel domain 定义 Action envelope(actionId、kind、target EntityRef、actor、authorizationRef、idempotencyKey;replay identity 排除 actionId,重试按五个语义字段去重),把五类 Phase 1 实体的 transition catalog 从既有状态/事件词表投影出来,让 `ha entity explain <kind>` 从唯一契约表列出可用 Action,并给 receipt 框架加 `AuthorizationDecision` 与封闭三元 `delta`(带默认值,旧 receipt 可冷重放)。尚未接判定点——那是 2.2。

## 架构辩护

现有模块为何无法承载:`command-receipt/v2` 只有 result 侧 `action`/`entity`,没有 request envelope(无 actor、authorization ref、idempotency key),无处并入;`write-chain.contract.ts` 既拥有 ActorIdentity 又消费 receipt registry,在那里加 AuthorizationDecision 会成环。
删除了哪些废弃代码:`write-chain.contract.ts` 内的 ActorIdentity 接口与 `validateActorIdentity` 实现,以及散落的临时字符串校验器(-68);write-chain 只 re-export 唯一定义。
为何不能收窄:封闭六字段 envelope、replay identity、五类 catalog、AuthorizationDecision、封闭 delta、旧 receipt 默认值必须同时成立——少任一项就会出现只有 TS 类型无运行时拒绝、actor 校验器被复制、或 CLI 再维护一份 Action 表。

## 改动内容

- `packages/kernel/src/domain/action-envelope.ts`:envelope 类型与运行时校验;五个语义字段的 replay identity 哈希。
- `actor-identity.ts`:`ActorIdentity` 与校验器从 `write-chain.contract.ts` 移到中性 domain seam(write-chain re-export;不复制校验器)。
- `entity-kind-registry.ts` / `entity-ref.ts`:execution/review(task-lifecycle/v1)、agent、policy、runtime-session(仅 `runtime_session_*` 事件)的 Action catalog。
- `receipt-frame.ts` / `receipt-domain-registry.ts`:默认 `authorizationDecision: null`、`delta: {fact:[],decision:[],task:[]}`;`allowed|denied` 登记进状态词表。
- 测试:envelope 与 store 的 contract 测试;write-chain 门测试更新。

## 机读声明说明

- 机读声明只在英文块出现一次。

## 任务与范围

- Harness 任务:task_f43c77a13ddbadd9a8a49e18bc(PLT-Ontology Phase 2.1)
- 分支:`codex/action-envelope`
- 公开范围:kernel domain 契约(envelope、actor identity、receipt 框架、实体 Action catalog)、状态词表、contract 测试
- 私有计划 / 证据是否已更新:yes(artifacts/reports/action-envelope.md)
- 范围外:把 envelope/决定接到 AuthorizationPort 调用点(2.2)与 StartExecution(2.3);daemon/CLI 写路径未动

## 版本影响

- 版本:不改版本,原因是 rebuild 线 pre-release 修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_f43c77a13ddbadd9a8a49e18bc (PLT-Ontology Phase 2.1)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:84cc1223dcfb9b3ef65a47c0ab58952278505101
- 当前分支与 `origin/main` 的 merge-base:84cc1223dcfb9b3ef65a47c0ab58952278505101
- 最近一次 `git fetch origin` 时间:2026-08-25T04:38Z
- 同步方式:rebase
- 公开 diff 命令:`git diff 84cc1223dcfb9b3ef65a47c0ab58952278505101..3c248f8a7`
- 私有证据 commit/path:任务包 artifacts/reports
- Reviewer 证据路径:worker 回执 action-envelope.md:typecheck、contract 测试、Docker 隔离 contract 运行、五类 `ha entity explain` 输出;CEO 核 G36 过、控制字符扫描为空、production delta +301/-68 与回执一致
- GitHub Actions `rewrite-ci` run URL:待 run 结束后补
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`(kernel contract 测试(envelope、entity-store)、write-chain 门测试、Docker 隔离 contract 运行)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:GitHub integration shard 矩阵未在本地跑(CI 为权威)

## 审查证据

- 自查:CEO:把 actor identity 从 write-chain 移出的单定义处理,是它没变成第二个校验器的关键;receipt 默认值是重放兼容点,不是新写入的回退。
- Reviewer subagent:有(只读回执审计 + git 独立核实)
- 人工审查:待
- 阻塞发现:无

## 残余风险

- churn 369 > 200——已附辩护段;catalog 是既有词表的投影,1.5 状态词表变动时须复核。

## 关联材料

- 任务:task_f43c77a13ddbadd9a8a49e18bc
- 证据:artifacts/reports/action-envelope.md
- 审查:待

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPPk3TmbURWuxcFY3kFimA

