### PR TITLE
fix(daemon): bump the task projection schema after the entity migration and let the holder reclaim a canonical-free reservation

### DIFF
--- a/packages/daemon/src/repo-cell-task-command-docs.ts
+++ b/packages/daemon/src/repo-cell-task-command-docs.ts
@@ -244,6 +244,52 @@ export function taskSurfaceWrite(cell: any, action: RepoTaskAction, binding: Rep
       snapshot.revision,
       `Remove --dry-run to publish this validated ${action.kind} event.`,
     );
+  if (mutation.type === "lease_released" && mutation.execution === undefined) {
+    const reservation = mutation.releasedLease;
+    if (!reservation) throw cell.cellCodedError("invalid_command", "A reservation release requires the current lease.");
+    const published = cell.store
+      .read()
+      .events.some(
+        (event: TaskEventV1) =>
+          event.type === "execution_started" &&
+          event.taskId === taskId &&
+          event.payload.execution.executionId === reservation.executionId,
+      );
+    if (published)
+      throw cell.cellCodedError(
+        "projection_pending",
+        [
+          `Execution ${reservation.executionId} is canonical but missing from the projection; `,
+          "retry after projection rebuild.",
+        ].join(""),
+      );
+    cell.projection.releaseLease(reservation);
+    const revision = cell.store.readHead()?.revision ?? snapshot.revision;
+    return {
+      outcome: "no_changes",
+      opId: canonicalOpId,
+      revision,
+      code: "no_changes",
+      origin: "task-release",
+      evidence: `projection-reservation-released:${reservation.executionId}`,
+      visibility: "center",
+      proof: {
+        committedRevision: revision,
+        appliedCut: revision,
+        durable: true,
+        canonicalVisible: true,
+        worktreeVisible: true,
+      },
+      nextAction: `Reservation released; run ha task start ${taskId} to claim a new execution.`,
+      taskId,
+      executionId: reservation.executionId,
+      report: {
+        command: action.kind,
+        reason: mutation.audit.reason,
+        fields: mutation.audit.fields,
+      },
+    } as WriteReceipt;
+  }
   const opId = canonicalOpId,
     existing = cell.store.readEvent(opId);
   if (existing) return cell.receiptForOperation(opId, binding);

--- a/packages/daemon/src/repo-cell-task-mutation.ts
+++ b/packages/daemon/src/repo-cell-task-mutation.ts
@@ -50,27 +50,14 @@ export function taskMutation(
   if (action.kind === "task-release") {
     if (!activeLease)
       throw cell.cellCodedError("lease_not_found", `Start task ${task.taskId} before releasing its lease.`);
-    if (!isSameExecution(activeLease.actor, binding.actor) && !canReclaim(activeLease, binding.actor, cell.now()))
+    const execution = snapshot.executions.find((value) => value.executionId === activeLease.executionId),
+      reclaimableLease = execution === undefined ? { ...activeLease, phase: "orphaned" as const } : activeLease;
+    if (!isSameExecution(activeLease.actor, binding.actor) && !canReclaim(reclaimableLease, binding.actor, cell.now()))
       throw cell.cellCodedError(
         "lease_conflict",
         [
-          "The current holder, or the same principal after the lease becomes ",
-          "orphaned, must run ha task release ",
-          `${task.taskId}`,
-          ".",
-        ].join(""),
-      );
-    const execution = snapshot.executions.find((value) => value.executionId === activeLease.executionId);
-    if (!execution)
-      throw cell.cellCodedError(
-        "orphaned_reservation",
-        [
-          "Lease ",
-          `${activeLease.executionId}`,
-          " is an in-flight reservation with no published execution behind it; wait ",
-          "for the holder to publish it or for the reservation to lapse at ",
-          `${activeLease.expiresAt}`,
-          ", then rerun ha task release ",
+          "The current holder, or the same principal reclaiming an orphaned lease or reservation, must run ",
+          "ha task release ",
           `${task.taskId}`,
           ".",
         ].join(""),
@@ -78,7 +65,7 @@ export function taskMutation(
     return {
       type: "lease_released",
       task,
-      execution,
+      ...(execution === undefined ? {} : { execution }),
       releasedLease: activeLease,
       audit: { command: "release", reason, fields: ["lease"] },
     };

--- a/packages/daemon/test/lease-reservation-reclaim.contract.test.ts
+++ b/packages/daemon/test/lease-reservation-reclaim.contract.test.ts
@@ -1,0 +1,116 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { type ActorIdentity, type LeaseV1, type TaskLifecycleSnapshot, type TaskV1 } from "../../kernel/src/index.ts";
+import { taskSurfaceWrite } from "../src/repo-cell-task-command-docs.ts";
+import { taskMutation } from "../src/repo-cell-task-command.ts";
+
+const now = "2026-08-25T03:15:20.000Z";
+const owner = (executorId: string): ActorIdentity => ({
+  principal: { personId: "person-owner" },
+  executor: { kind: "agent", id: executorId },
+});
+const task: TaskV1 = {
+  schema: "task/v1",
+  taskId: "task-orphaned-reservation",
+  title: "Orphaned reservation",
+  taskClass: "standard",
+  status: "active",
+  graph: { maxIterations: 1, nodes: [], edges: [] },
+  currentNode: "implementation",
+  iteration: 0,
+  createdBy: owner("creator"),
+  completionGateIds: [],
+  presetSnapshotDigest: null,
+};
+const lease: LeaseV1 = {
+  schema: "lease/v1",
+  taskId: task.taskId,
+  executionId: "exec-orphaned-reservation",
+  actor: owner("original-worker"),
+  source: "local",
+  phase: "held",
+  expiresAt: "2026-08-26T03:15:20.000Z",
+  ttlMs: 86_400_000,
+  version: 7,
+};
+const cell = {
+  now: () => now,
+  cellCodedError: (code: string, message: string) => Object.assign(new Error(message), { code }),
+};
+const snapshot = (): TaskLifecycleSnapshot => ({
+  revision: 8,
+  task,
+  executions: [],
+  reviews: [],
+  consents: [],
+  codeDocWitnesses: [],
+  gateWitnesses: [],
+  edgesTaken: [],
+  lease,
+});
+
+test("same principal can reclaim a live reservation with no published execution", () => {
+  const mutation = taskMutation(
+    cell,
+    { kind: "task-release", taskId: task.taskId, reason: "Recover my interrupted reservation." },
+    task,
+    snapshot(),
+    { actor: owner("replacement-worker"), source: "local" },
+  );
+
+  assert.equal(mutation.type, "lease_released");
+  assert.equal(mutation.execution, undefined);
+  assert.equal(mutation.releasedLease, lease);
+});
+
+test("same principal release settles a canonical-free reservation in the local CAS", () => {
+  let released: LeaseV1 | null = null;
+  const surfaceCell = {
+      ...cell,
+      input: { repoId: "lease-reservation-contract" },
+      requiredCellText: (value: unknown) => String(value),
+      projection: {
+        read: () => ({ status: "ready", snapshot: snapshot(), packagePath: "tasks/task-orphaned-reservation" }),
+        releaseLease: (value: LeaseV1) => {
+          released = value;
+        },
+      },
+      projectionReady: () => true,
+      taskMutation: (
+        action: Parameters<typeof taskMutation>[1],
+        currentTask: Parameters<typeof taskMutation>[2],
+        currentSnapshot: Parameters<typeof taskMutation>[3],
+        binding: Parameters<typeof taskMutation>[4],
+      ) => taskMutation(cell, action, currentTask, currentSnapshot, binding),
+      withoutDryRun: (action: unknown) => action,
+      operationId: () => "op-release-orphaned-reservation",
+      store: {
+        read: () => ({ events: [] }),
+        readHead: () => ({ revision: 8 }),
+      },
+    },
+    receipt = taskSurfaceWrite(
+      surfaceCell,
+      { kind: "task-release", taskId: task.taskId },
+      { actor: owner("replacement-worker"), source: "local" },
+    );
+
+  assert.equal(receipt.outcome, "no_changes");
+  assert.equal(receipt.code, "no_changes");
+  assert.equal(released, lease);
+});
+
+test("a different principal cannot reclaim the reservation before TTL", () => {
+  assert.throws(
+    () =>
+      taskMutation(cell, { kind: "task-release", taskId: task.taskId }, task, snapshot(), {
+        actor: {
+          principal: { personId: "person-outsider" },
+          executor: { kind: "agent", id: "outsider-worker" },
+        },
+        source: "local",
+      }),
+    (error: unknown) => error instanceof Error && "code" in error && error.code === "lease_conflict",
+  );
+});

--- a/packages/daemon/test/lease-reservation.integration.test.ts
+++ b/packages/daemon/test/lease-reservation.integration.test.ts
@@ -1,0 +1,210 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { hostname, tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import {
+  makeTaskEventStore,
+  registerDaemonRepo,
+  taskProjectionSchemaVersion,
+  type AgentDefinitionSnapshot,
+} from "../../kernel/src/index.ts";
+import type { RuntimeInstallationWitness } from "../src/agent-runtime-instances.ts";
+import { openDaemonHost } from "../src/daemon-host.ts";
+import { writeProviderExecutable } from "./fixtures/runtime-stub.ts";
+
+const definition: AgentDefinitionSnapshot = {
+  schema: "agent-definition-snapshot/v1",
+  configVersion: 1,
+  instanceId: "codex-lease-worker",
+  installationId: "installation-codex-lease-worker",
+  kindId: "codex",
+  providerId: "openai",
+  model: "gpt-5.6-sol",
+  reasoningEffort: "high",
+  baseUrl: "https://api.example.test/",
+  authMode: "subscription",
+};
+test("task-bound spawn exit keeps its published execution releasable after a v7 cache restart", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-lease-reservation-")),
+    root = path.join(parent, "repo"),
+    userRoot = path.join(parent, "user"),
+    repoId = "lease-reservation",
+    taskId = "task-lease-reservation",
+    executionId = "exec-lease-reservation",
+    uid = process.getuid?.() ?? 0,
+    installation: RuntimeInstallationWitness = {
+      installationId: definition.installationId,
+      kindId: definition.kindId,
+      executablePath: writeProviderExecutable(path.join(parent, "codex-stub.mjs"), "process.exit(0);\n"),
+      version: "1.0.0",
+      observedAt: "2026-08-25T00:00:00.000Z",
+    },
+    auth = {
+      transportKind: "unix-socket",
+      unixSocketOwnerBoundary: {
+        ownerUid: uid,
+        source: "unix-socket-filesystem-owner-boundary",
+      },
+    } as const;
+  initRepo(root, uid);
+  registerDaemonRepo({ canonicalRoot: root, repoId, userRoot, createConvenienceLinks: false });
+
+  const open = async (daemonId: string) => {
+    const host = await openDaemonHost({
+      daemonId,
+      userRoot,
+      runtimeDiscover: () => [installation],
+      runtimeLaunch: () => ({
+        pid: 9538,
+        onOutput: (listener) => {
+          queueMicrotask(() =>
+            listener(
+              [
+                { type: "thread.started", thread_id: "provider-lease-reservation" },
+                { type: "item.completed", item: { id: "done", type: "agent_message", text: "done" } },
+                { type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } },
+              ]
+                .map((event) => JSON.stringify(event))
+                .join("\n") + "\n",
+            ),
+          );
+        },
+        onErrorOutput: () => undefined,
+        onExit: (listener) => {
+          queueMicrotask(() => listener(0));
+        },
+        terminate: () => undefined,
+      }),
+    });
+    await host.attachmentsSettled();
+    return host;
+  };
+
+  let host = await open("lease-reservation-before");
+  try {
+    await host.runtimeInstance(
+      "daemon.runtimeInstance.create",
+      {
+        instanceId: definition.instanceId,
+        name: "Codex Lease Worker",
+        kindId: definition.kindId,
+        installationId: definition.installationId,
+        providerId: definition.providerId,
+        models: [definition.model],
+        codex: { reasoningEffort: definition.reasoningEffort },
+        authMode: definition.authMode,
+      },
+      auth,
+    );
+    assert.equal(
+      (await host.run(repoId, { kind: "task-create", taskId, title: "Lease reservation" }, auth)).outcome,
+      "applied",
+    );
+    assert.equal((await host.run(repoId, { kind: "task-start", taskId, executionId }, auth)).outcome, "applied");
+    const spawned = await host.spawnRuntime(
+      repoId,
+      {
+        runtimeInstanceId: definition.instanceId,
+        cwd: { scope: "repo-root" },
+        prompt: "Finish the task-bound runtime session.",
+        taskId,
+        idempotencyKey: "lease-reservation-spawn",
+      },
+      auth,
+    );
+    assert.equal(spawned.outcome, "applied", JSON.stringify(spawned));
+    await eventually(() =>
+      makeTaskEventStore({ repoId, rootDir: root })
+        .read()
+        .events.some(
+          (event) =>
+            event.type === "runtime_session_outcome_observed" &&
+            event.payload.runtimeSessionId === spawned.runtimeSessionId,
+        ),
+    );
+  } finally {
+    await host.close();
+  }
+
+  const cache = path.join(root, ".harness/cache/task.sqlite"),
+    stale = new DatabaseSync(cache);
+  stale.exec("UPDATE projection_meta SET schema_version = 7 WHERE singleton = 1");
+  stale.prepare("DELETE FROM entity_projection WHERE entity_kind = 'execution' AND task_id = ?").run(taskId);
+  stale.close();
+
+  host = await open("lease-reservation-after");
+  try {
+    const released = await host.run(repoId, { kind: "task-release", taskId }, auth);
+    assert.equal(released.outcome, "applied", JSON.stringify(released));
+    const events = makeTaskEventStore({ repoId, rootDir: root }).read().events,
+      sequence = events.map((event) => event.type),
+      started = sequence.indexOf("execution_started"),
+      bound = sequence.indexOf("runtime_session_task_bound"),
+      exited = sequence.indexOf("runtime_session_outcome_observed"),
+      release = sequence.indexOf("lease_released");
+    assert.ok(started >= 0 && started < bound, sequence.join(" -> "));
+    assert.ok(bound < exited && exited < release, sequence.join(" -> "));
+
+    const rebuilt = new DatabaseSync(cache, { readOnly: true }),
+      version = rebuilt.prepare("SELECT schema_version FROM projection_meta WHERE singleton = 1").get() as {
+        readonly schema_version: number;
+      },
+      execution = rebuilt
+        .prepare("SELECT entity_id FROM entity_projection WHERE entity_kind = 'execution' AND task_id = ?")
+        .get(taskId) as { readonly entity_id: string } | undefined;
+    rebuilt.close();
+    assert.equal(version.schema_version, taskProjectionSchemaVersion);
+    assert.equal(execution?.entity_id, executionId);
+  } finally {
+    await host.close();
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+function initRepo(root: string, uid: number): void {
+  mkdirSync(path.join(root, "harness"), { recursive: true });
+  git(root, "init", "-q");
+  git(root, "config", "user.name", "Lease Test");
+  git(root, "config", "user.email", "lease@example.invalid");
+  writeFileSync(
+    path.join(root, "harness/harness.yaml"),
+    "schema: harness-anything/v1\nname: lease-reservation\nlayout:\n  authoredRoot: harness\n  localRoot: .harness\n",
+  );
+  writeFileSync(
+    path.join(root, "harness/people.yaml"),
+    `${JSON.stringify(
+      {
+        schema: "harness-people/v1",
+        people: [
+          {
+            personId: "owner",
+            displayName: "Owner",
+            roles: ["owner"],
+            credentials: [{ kind: "unix-socket-owner-boundary", issuer: `host:${hostname()}`, subject: String(uid) }],
+          },
+        ],
+        roles: [{ roleId: "owner", commandClasses: ["repo-read", "repo-write"] }],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  git(root, "add", "harness");
+  git(root, "commit", "-qm", "fixture");
+}
+
+async function eventually(check: () => boolean | Promise<boolean>): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (await check()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("runtime session did not settle");
+}
+
+function git(root: string, ...args: string[]): void {
+  execFileSync("git", ["-C", root, ...args]);
+}

--- a/packages/kernel/src/projection/projection-schema.ts
+++ b/packages/kernel/src/projection/projection-schema.ts
@@ -1,11 +1,11 @@
 import { DatabaseSync } from "node:sqlite";
 import { localRuntimeStateFileSystem } from "../local/local-layout-file-system.ts";
 
-// Version 7 adds Decision session provenance to the disposable projection.
+// Version 8 replaces the legacy execution/review tables with entity_projection.
 // A version mismatch takes the
 // existing discard-and-replay path in rebuildable-task-projection.ts, so each
 // machine cold-rebuilds task.sqlite once on its first read.
-export const taskProjectionSchemaVersion = 7;
+export const taskProjectionSchemaVersion = 8;
 
 export function readTaskProjectionSchemaVersion(projectionPath: string): number | null {
   if (!localRuntimeStateFileSystem.exists(projectionPath)) return null;


### PR DESCRIPTION
# English

## Summary

After #1812 moved execution/review reads into the generic `entity_projection`, an existing v7 `task.sqlite` cache was never discarded because the projection schema version stayed at 7. Executions that were correctly published to the ledger (`execution_started` at revision 33068/33230/33280) were invisible to the new reader, so `ha task release` misreported a live lease as an `orphaned_reservation` and locked the task until the 24h TTL. This PR bumps the disposable projection schema to 8 (forcing a cold rebuild), lets the same principal reclaim a genuinely canonical-free reservation immediately via `canReclaim`, and returns `projection_pending` when the canonical event exists but the projection has not caught up — never mistaking a projection gap for a missing event. It deliberately does not release leases on runtime-session exit: an execution lease legitimately outlives one provider session.

## Architectural Justification

-

## What Changed

- `packages/kernel/src/projection/projection-schema.ts`: task projection schema 7 → 8 so existing caches discard and replay into `entity_projection`.
- `packages/daemon/src/repo-cell-task-mutation.ts`: release distinguishes (a) execution present → release, (b) canonical event present but projection behind → `projection_pending`, (c) truly canonical-free reservation → same-principal reclaim now, other principals still conflict.
- Tests: contract case for same-principal reclaim; integration case start → task-bound spawn → session exit → release succeeds.

## Machine-Readable Declarations

Production-Delta: +54/-21

## Task And Scope

- Harness task: task_e8dca9b58bd8300e71df0dcd73 (PLT-Ontology Phase 0.18 (framework defect F38, found while closing out Phase 1))
- Branch: `codex/lease-reservation`
- Public scope: projection schema version, daemon lease release decision, tests
- Private planning/evidence updated: yes (artifacts/reports/lease-reservation.md)
- Out of scope: auto-release on runtime-session exit (rejected by design); StartExecution publish path (already correct at task-lifecycle-service.ts:174-202)

## Version Impact

- Version: no version change because this is a pre-release fix on the rebuild line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: PLT-Ontology milestone; F38 recorded in the milestone task_plan 2026-08-25; hosted under the standing closeout task task_e8dca9b58bd8300e71df0dcd73
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 84cc1223dcfb9b3ef65a47c0ab58952278505101
- Branch merge-base with `origin/main`: 84cc1223dcfb9b3ef65a47c0ab58952278505101
- Last `git fetch origin` time: 2026-08-25T04:47Z
- Sync method: rebase
- Public diff command: `git diff 84cc1223dcfb9b3ef65a47c0ab58952278505101..65e01d8e7`
- Private evidence commit/path: harness task package task_e8dca9b58bd8300e71df0dcd73 artifacts/reports
- Reviewer evidence path: worker report lease-reservation.md with the read-only `event_index` table proving `execution_started` exists for exe_8d4d2fe9 and `entity_projection` has 0 rows under schema 7; CEO confirms this refutes the earlier 'spawn never published' hypothesis recorded in the milestone plan; G36 pass; control-character scan empty; delta +54/-21
- GitHub Actions `rewrite-ci` run URL: pending (filled after the run)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test` (contract + integration tests added by the worker; typecheck; Docker-isolated runs per the report)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: the live canonical repository recovery itself (will be the first verification after merge and daemon restart: `ha task release task_95206d5d…` must succeed)

## Review Evidence

- Self-review: CEO: the worker refused the tempting fix (release on session exit) with a correct lifecycle argument; the schema bump is the actual missing piece from #1812 and should have been part of it.
- Reviewer subagent: yes (read-only report audit with independent git verification)
- Human review: pending
- Blocking findings: none

## Residual Risk

- The cold rebuild on first start after merge blocks task.create briefly (known 0.13 behaviour).

## References

- Task: task_e8dca9b58bd8300e71df0dcd73
- Evidence: artifacts/reports/lease-reservation.md
- Review: pending

---

# 中文

## 概要

#1812 把 execution/review 的读迁到通用 `entity_projection` 后,既有 v7 `task.sqlite` 缓存从未被丢弃,因为投影 schema 版本仍是 7。已正确发布到台账的 execution(`execution_started` 在 33068/33230/33280)对新读取器不可见,于是 `ha task release` 把活 lease 误报为 `orphaned_reservation`,任务被锁到 24h TTL。本 PR 把一次性投影 schema 升到 8(强制冷重建),让同 principal 对真正无 canonical 事件的 reservation 经 `canReclaim` 立即回收,并在 canonical 事件存在但投影未追上时返回 `projection_pending`——绝不把投影缺口当成事件缺失。刻意不在 runtime session 退出时释放 lease:execution lease 本就可跨越单个 provider session。

## 架构辩护

-

## 改动内容

- `packages/kernel/src/projection/projection-schema.ts`:task 投影 schema 7 → 8,既有缓存丢弃并 replay 进 `entity_projection`。
- `packages/daemon/src/repo-cell-task-mutation.ts`:release 区分 (a) execution 在 → 释放;(b) canonical 事件在但投影落后 → `projection_pending`;(c) 真无 canonical 的 reservation → 同 principal 立即回收,其他 principal 仍冲突。
- 测试:同 principal 回收的 contract 用例;start → task-bound spawn → 会话退出 → release 成功的 integration 用例。

## 机读声明说明

- 机读声明只在英文块出现一次。

## 任务与范围

- Harness 任务:task_e8dca9b58bd8300e71df0dcd73(PLT-Ontology Phase 0.18 (framework defect F38, found while closing out Phase 1))
- 分支:`codex/lease-reservation`
- 公开范围:投影 schema 版本、daemon lease release 判定、测试
- 私有计划 / 证据是否已更新:yes(artifacts/reports/lease-reservation.md)
- 范围外:runtime session 退出自动释放(按设计拒绝);StartExecution 发布路径(task-lifecycle-service.ts:174-202 本就正确)

## 版本影响

- 版本:不改版本,原因是 rebuild 线 pre-release 修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:PLT-Ontology milestone; F38 recorded in the milestone task_plan 2026-08-25; hosted under the standing closeout task task_e8dca9b58bd8300e71df0dcd73
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:84cc1223dcfb9b3ef65a47c0ab58952278505101
- 当前分支与 `origin/main` 的 merge-base:84cc1223dcfb9b3ef65a47c0ab58952278505101
- 最近一次 `git fetch origin` 时间:2026-08-25T04:47Z
- 同步方式:rebase
- 公开 diff 命令:`git diff 84cc1223dcfb9b3ef65a47c0ab58952278505101..65e01d8e7`
- 私有证据 commit/path:任务包 artifacts/reports
- Reviewer 证据路径:worker 回执 lease-reservation.md 用只读 `event_index` 表证明 exe_8d4d2fe9 的 `execution_started` 存在、schema 7 下 `entity_projection` 为 0 行;CEO 确认这反证了里程碑 plan 里先前「spawn 未发布」的假设;G36 过;控制字符扫描为空;delta +54/-21
- GitHub Actions `rewrite-ci` run URL:待 run 结束后补
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`(worker 新增 contract + integration 测试;typecheck;回执中的 Docker 隔离运行)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:真实 canonical 仓库的恢复本身(合入并重启 daemon 后第一件验证:`ha task release task_95206d5d…` 必须成功)

## 审查证据

- 自查:CEO:worker 用正确的生命周期论证拒绝了「会话退出即释放」这个诱人修法;schema 升版才是 #1812 真正缺的那块,本应随它一起落。
- Reviewer subagent:有(只读回执审计 + git 独立核实)
- 人工审查:待
- 阻塞发现:无

## 残余风险

- 合入后首次启动的冷重建会短暂挡住 task.create(0.13 已知行为)。

## 关联材料

- 任务:task_e8dca9b58bd8300e71df0dcd73
- 证据:artifacts/reports/lease-reservation.md
- 审查:待

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPPk3TmbURWuxcFY3kFimA

