### PR TITLE
feat(runtime): inject a task-bound GitHub credential so worker settlement can push its own codex/* branch

### DIFF
--- a/packages/cli/src/cli/thin-command-runtime-instance-create.ts
+++ b/packages/cli/src/cli/thin-command-runtime-instance-create.ts
@@ -12,41 +12,20 @@ export function parseRuntimeInstanceCreate(
 ): ThinParseResult {
   const authMode = flags.one.get("--auth"),
     credentialRef = flags.one.get("--credential-ref"),
+    githubCredentialRef = flags.one.get("--github-credential-ref"),
     kindId = flags.one.get("--kind"),
     header = runtimeHttpHeaderFlags(flags.many.get("--http-header") ?? []);
   if (authMode === "api-key" && !credentialRef)
-    return rejected(
-      "missing_field",
-      "API-key instances require --credential-ref <opaque-ref>.",
-      json,
-    );
+    return rejected("missing_field", "API-key instances require --credential-ref <opaque-ref>.", json);
   if (authMode === "subscription" && credentialRef)
-    return rejected(
-      "invalid_field",
-      "Subscription instances cannot accept a credential reference.",
-      json,
-    );
+    return rejected("invalid_field", "Subscription instances cannot accept a credential reference.", json);
   if (kindId === "agy" && authMode !== "subscription")
-    return rejected(
-      "invalid_field",
-      "agy runtime instances support subscription OAuth only.",
-      json,
-    );
+    return rejected("invalid_field", "agy runtime instances support subscription OAuth only.", json);
   if (!header.ok) return rejected("invalid_field", header.hint, json);
   if (hasForeignAdapterOptions(kindId, flags, header.value))
-    return rejected(
-      "invalid_field",
-      "This runtime kind does not accept options for another adapter.",
-      json,
-    );
+    return rejected("invalid_field", "This runtime kind does not accept options for another adapter.", json);
   const baseUrl = flags.one.get("--base-url"),
-    kindConfig = runtimeInstanceKindConfig(
-      kindId,
-      flags.one,
-      flags.booleans,
-      baseUrl,
-      header.value,
-    );
+    kindConfig = runtimeInstanceKindConfig(kindId, flags.one, flags.booleans, baseUrl, header.value);
   return accepted(
     rootDir,
     undefined,
@@ -56,23 +35,16 @@ export function parseRuntimeInstanceCreate(
       instanceId: flags.one.get("--id"),
       name: flags.one.get("--name"),
       kindId,
-      ...(flags.one.get("--installation")
-        ? { installationId: flags.one.get("--installation") }
-        : {}),
+      ...(flags.one.get("--installation") ? { installationId: flags.one.get("--installation") } : {}),
       providerId: flags.one.get("--provider"),
       models: flags.many.get("--model") ?? [],
-      ...(flags.one.get("--default-model")
-        ? { defaultModel: flags.one.get("--default-model") }
-        : {}),
-      ...(flags.one.get("--permission-mode")
-        ? { permissionMode: flags.one.get("--permission-mode") }
-        : {}),
-      ...(flags.one.get("--isolation")
-        ? { isolationState: flags.one.get("--isolation") }
-        : {}),
+      ...(flags.one.get("--default-model") ? { defaultModel: flags.one.get("--default-model") } : {}),
+      ...(flags.one.get("--permission-mode") ? { permissionMode: flags.one.get("--permission-mode") } : {}),
+      ...(flags.one.get("--isolation") ? { isolationState: flags.one.get("--isolation") } : {}),
       ...kindConfig,
       authMode,
       ...(credentialRef ? { credentialRef } : {}),
+      ...(githubCredentialRef ? { githubCredentialRef } : {}),
     },
     route.method,
   );
@@ -109,14 +81,10 @@ function runtimeInstanceKindConfig(
   return kindId === "codex"
     ? {
         codex: {
-          ...(one.get("--effort")
-            ? { reasoningEffort: one.get("--effort") }
-            : {}),
+          ...(one.get("--effort") ? { reasoningEffort: one.get("--effort") } : {}),
           ...(baseUrl ? { baseUrl } : {}),
           ...(one.get("--wire-api") ? { wireApi: one.get("--wire-api") } : {}),
-          ...(booleans.has("--requires-openai-auth")
-            ? { requiresOpenAiAuth: true }
-            : {}),
+          ...(booleans.has("--requires-openai-auth") ? { requiresOpenAiAuth: true } : {}),
           ...(headers ? { httpHeaders: headers } : {}),
         },
       }

--- a/packages/daemon/src/agent-runtime-contract.ts
+++ b/packages/daemon/src/agent-runtime-contract.ts
@@ -28,6 +28,7 @@ interface AgentRuntimeInstanceCommonDto {
     readonly code: string | null;
     readonly hint: string | null;
   };
+  readonly githubCredentialState?: "configured";
   readonly isolationState: "enforced" | "operator-environment";
 }
 export type AgentRuntimeInstanceDto = AgentRuntimeInstanceCommonDto &
@@ -209,23 +210,27 @@ function validInstance(value: unknown): value is AgentRuntimeInstanceDto {
   if (!isAgentRuntimeContractRecord(value)) return false;
   const field = value.kindId === "codex" ? "codex" : value.kindId === "agy" ? "agy" : "claude",
     common =
-      hasExactAgentRuntimeContractFields(value, [
-        "schemaVersion",
-        "instanceId",
-        "name",
-        "kindId",
-        "installationId",
-        "providerId",
-        "models",
-        "defaultModel",
-        "enabled",
-        "permissionMode",
-        field,
-        "authMode",
-        "authState",
-        "authReadiness",
-        "isolationState",
-      ]) &&
+      hasAgentRuntimeContractFields(
+        value,
+        [
+          "schemaVersion",
+          "instanceId",
+          "name",
+          "kindId",
+          "installationId",
+          "providerId",
+          "models",
+          "defaultModel",
+          "enabled",
+          "permissionMode",
+          field,
+          "authMode",
+          "authState",
+          "authReadiness",
+          "isolationState",
+        ],
+        ["githubCredentialState"],
+      ) &&
       value.schemaVersion === 2 &&
       Array.isArray(value.models) &&
       value.models.length > 0 &&
@@ -240,6 +245,7 @@ function validInstance(value: unknown): value is AgentRuntimeInstanceDto {
       ) &&
       ["subscription", "api-key"].includes(String(value.authMode)) &&
       ["configured", "authenticated", "unauthenticated", "unknown"].includes(String(value.authState)) &&
+      (value.githubCredentialState === undefined || value.githubCredentialState === "configured") &&
       ["enforced", "operator-environment"].includes(String(value.isolationState)) &&
       validReadiness(value.authReadiness);
   if (!common) return false;

--- a/packages/daemon/src/agent-runtime-instance-config.ts
+++ b/packages/daemon/src/agent-runtime-instance-config.ts
@@ -70,6 +70,7 @@ export function runtimeInstanceConfig(value: unknown): RuntimeInstanceConfig {
           "codex",
           "agy",
           "auth",
+          "githubCredentialRef",
         ];
   if (
     Object.keys(value).some((key) => !allowed.includes(key)) ||
@@ -151,6 +152,9 @@ export function runtimeInstanceConfig(value: unknown): RuntimeInstanceConfig {
     ...(permissionMode ? { permissionMode } : {}),
     isolationState,
     auth,
+    ...(value.githubCredentialRef === undefined
+      ? {}
+      : { githubCredentialRef: credentialReference(value.githubCredentialRef, "githubCredentialRef") }),
   };
   if (value.kindId === "claude")
     return {
@@ -347,12 +351,12 @@ export function identifier(value: unknown, field: string): string {
   return text;
 }
 
-export function credentialReference(value: unknown): string {
-  const text = requiredRuntimeInstanceText(value, "credentialRef");
+export function credentialReference(value: unknown, field = "credentialRef"): string {
+  const text = requiredRuntimeInstanceText(value, field);
   if (!isCredentialReferenceText(text))
     throw runtimeInstanceError(
       "invalid_credential_reference",
-      "credentialRef must be an opaque credential:v1 reference (legacy keychain: references resolve on macOS only).",
+      `${field} must be an opaque credential:v1 reference (legacy keychain: references resolve on macOS only).`,
     );
   return text;
 }

--- a/packages/daemon/src/agent-runtime-instance-storage.ts
+++ b/packages/daemon/src/agent-runtime-instance-storage.ts
@@ -140,6 +140,7 @@ export function publicConfig(
             ? ("unauthenticated" as const)
             : ("unknown" as const),
     authReadiness,
+    ...(config.githubCredentialRef === undefined ? {} : { githubCredentialState: "configured" as const }),
     isolationState: config.isolationState,
   };
   if (config.kindId === "claude")

--- a/packages/daemon/src/agent-runtime-instance-store.ts
+++ b/packages/daemon/src/agent-runtime-instance-store.ts
@@ -288,6 +288,26 @@ export function openRuntimeInstanceStore(input: {
       ...(request.providerSessionId ? { providerSessionId: request.providerSessionId } : {}),
     };
   }
+  async function prepareWorkerGitEnvironment(instanceId: string): Promise<NodeJS.ProcessEnv | null> {
+    const config = readOne(instanceId);
+    if (!config)
+      throw runtimeInstanceError("runtime_instance_not_found", `Runtime instance ${instanceId} does not exist.`);
+    if (config.githubCredentialRef === undefined) return null;
+    let secret: string;
+    try {
+      secret = await resolveCredential(config.githubCredentialRef);
+    } catch (error) {
+      consumeKnownError(error);
+      throw runtimeInstanceError("runtime_credential_unavailable", "The configured GitHub credential is unavailable.");
+    }
+    if (!secret)
+      throw runtimeInstanceError("runtime_credential_unavailable", "The configured GitHub credential is unavailable.");
+    return {
+      HARNESS_GITHUB_TOKEN: secret,
+      GIT_ASKPASS_REQUIRE: "force",
+      GIT_TERMINAL_PROMPT: "0",
+    };
+  }
   function command(
     action: Readonly<Record<string, unknown>>,
   ): Record<string, unknown> | Promise<Record<string, unknown>> {
@@ -350,6 +370,7 @@ export function openRuntimeInstanceStore(input: {
           ...(action.isolationState !== undefined ? { isolationState: action.isolationState } : {}),
           ...kindConfig,
           auth,
+          ...(action.githubCredentialRef === undefined ? {} : { githubCredentialRef: action.githubCredentialRef }),
         } as RuntimeInstanceConfig),
         instance = publicConfig(config, readiness.get(config.instanceId));
       return {
@@ -502,6 +523,7 @@ export function openRuntimeInstanceStore(input: {
     authStatus,
     prepareAuthCommand,
     prepareLaunch,
+    prepareWorkerGitEnvironment,
     command,
   };
   function read(): RuntimeInstanceConfig[] {
@@ -550,8 +572,7 @@ export function openRuntimeInstanceStore(input: {
     // workers; rewriting it here would expose an unauthenticated window.
     if (config.kindId === "codex") {
       const configPath = path.join(provider, "config.toml");
-      if (config.auth.mode === "subscription" || !existsSync(configPath))
-        writeCodexConfig(configPath, config);
+      if (config.auth.mode === "subscription" || !existsSync(configPath)) writeCodexConfig(configPath, config);
     }
     if (config.auth.mode === "subscription") {
       const authFile = providerAuthFile(config.kindId),

--- a/packages/daemon/src/agent-runtime-instance-types.ts
+++ b/packages/daemon/src/agent-runtime-instance-types.ts
@@ -21,6 +21,7 @@ export interface RuntimeInstanceCommon {
   readonly permissionMode?: RuntimePermissionMode;
   readonly isolationState: RuntimeIsolationState;
   readonly auth: RuntimeInstanceAuth;
+  readonly githubCredentialRef?: string;
 }
 
 export interface ClaudeRuntimeInstanceConfig {

--- a/packages/daemon/src/daemon-host-open.ts
+++ b/packages/daemon/src/daemon-host-open.ts
@@ -110,6 +110,7 @@ export async function openDaemonHost(input: {
     runtimePorts = {
       runtimeInstances: instances.listPublic,
       prepareRuntimeLaunch: instances.prepareLaunch,
+      prepareWorkerGitEnvironment: instances.prepareWorkerGitEnvironment,
     },
     startedAt = input.startedAt ?? new Date().toISOString(),
     now = input.now ?? (() => new Date().toISOString()),

--- a/packages/daemon/src/fleet-edge-runtime.ts
+++ b/packages/daemon/src/fleet-edge-runtime.ts
@@ -58,6 +58,7 @@ type RuntimePorts = {
       readonly permissionMode?: string;
     },
   ) => Promise<PreparedRuntimeLaunch>;
+  readonly prepareWorkerGitEnvironment: (instanceId: string) => Promise<NodeJS.ProcessEnv | null>;
 };
 const runtimeOverviewPageLimit = 16;
 
@@ -236,6 +237,7 @@ export function openFleetEdgeRuntime(input: {
     now,
     runtimeInstances: input.ports.runtimeInstances,
     prepareLaunch: input.ports.prepareRuntimeLaunch,
+    prepareWorkerGitEnvironment: input.ports.prepareWorkerGitEnvironment,
     resolveAgent: (agentId) =>
       readAgentDeclaration({ rootDir: request.workspaceRoot, agentId, entityStore: getEntityStore() }),
     resolveSquadDispatchTarget: (leaderId, workerId) =>

--- a/packages/daemon/src/protocol/daemon-protocol-commands-runtime-config.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-runtime-config.ts
@@ -196,6 +196,21 @@ export const runtimeConfigProtocolCommands = Object.freeze([
           regex: "^credential:v1:[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$|^keychain:[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$",
         },
       ),
+      cliInput(
+        "--github-credential-ref",
+        "single",
+        false,
+        {
+          code: "invalid_field",
+          nextAction: [
+            "Use an opaque credential:v1 reference (legacy keychain: references ",
+            "resolve on macOS only); never pass the GitHub token.",
+          ].join(""),
+        },
+        {
+          regex: "^credential:v1:[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$|^keychain:[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$",
+        },
+      ),
     ],
   }),
   defineCliCommand({

--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -126,6 +126,7 @@ export const runtimeInstanceMethods = Object.freeze([
         agy: "json?",
         authMode: "string",
         credentialRef: "string?",
+        githubCredentialRef: "string?",
       }),
     }),
     guiBridgeMethod: "createRuntimeInstance",

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -68,6 +68,7 @@ export async function openRepoCell(input: {
       readonly permissionMode?: string;
     },
   ) => Promise<PreparedRuntimeLaunch>;
+  readonly prepareWorkerGitEnvironment?: (instanceId: string) => Promise<NodeJS.ProcessEnv | null>;
   readonly bootstrap?: RepoBootstrapInput;
   readonly onBootstrap?: (receipt: RepoBootstrapReceipt) => void;
   readonly now?: () => string;
@@ -265,6 +266,7 @@ export async function openRepoCell(input: {
     schedule,
     runtimeInstances: input.runtimeInstances,
     prepareLaunch: input.prepareRuntimeLaunch ?? unavailableRuntimeInstanceStore,
+    ...(input.prepareWorkerGitEnvironment ? { prepareWorkerGitEnvironment: input.prepareWorkerGitEnvironment } : {}),
     resolveAgent: (agentId) => readAgentDeclaration({ rootDir, agentId, entityStore: createEntityStore(store) }),
     resolveSquadDispatchTarget: (leaderId, workerId) =>
       resolveSquadDispatchTarget({ rootDir, leaderId, workerId, entityStore: createEntityStore(store) }),

--- a/packages/daemon/src/runtime-spawn-settlement.ts
+++ b/packages/daemon/src/runtime-spawn-settlement.ts
@@ -43,8 +43,15 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
     let outcome = letOutcome;
     let body = context.runtimeResultText(active, code, outcome);
     if (active.task && outcome === "succeeded") {
-      const push = await pushWorkerBranch({ cwd: active.cwd, canonicalRoot: context.input.rootDir });
-      if (push.attempted && !push.ok) body = `${body}\n\nWorker branch push failed (no retry): ${push.detail}`;
+      try {
+        const env = await context.prepareWorkerGitEnvironment(active.instanceId),
+          push = await pushWorkerBranch({ cwd: active.cwd, canonicalRoot: context.input.rootDir, env });
+        if (push.attempted && !push.ok) body = `${body}\n\nWorker branch push failed (no retry): ${push.detail}`;
+      } catch (error) {
+        consumeKnownError(error);
+        const detail = String(scrubProviderValue(error instanceof Error ? error.message : String(error))).slice(0, 512);
+        body = `${body}\n\nWorker branch push failed (no retry): ${detail || "GitHub credential resolution failed."}`;
+      }
     }
     const sha256 = createHash("sha256").update(body).digest("hex"),
       result: RuntimeResultClaim = {

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -104,6 +104,7 @@ export function makeRuntimeSpawner(input: {
       readonly permissionMode?: string;
     },
   ) => Promise<PreparedRuntimeLaunch>;
+  readonly prepareWorkerGitEnvironment?: (instanceId: string) => Promise<NodeJS.ProcessEnv | null>;
   readonly resolveAgent?: (agentId: string) => RuntimeAgent;
   readonly resolveSquadDispatchTarget?: (leaderId: string, workerId: string) => SquadDispatchTarget;
   readonly launch?: RuntimeLauncher;
@@ -115,7 +116,17 @@ export function makeRuntimeSpawner(input: {
 }) {
   const processes = new Map<string, ActiveRuntime>(),
     exiting = new Set<string>(),
-    launch = input.launch ?? launchNative;
+    launch = input.launch ?? launchNative,
+    prepareWorkerGitEnvironment = async (instanceId: string): Promise<NodeJS.ProcessEnv | undefined> => {
+      const credentialEnvironment = await input.prepareWorkerGitEnvironment?.(instanceId);
+      return credentialEnvironment
+        ? {
+            ...credentialEnvironment,
+            GIT_ASKPASS: path.join(input.rootDir, "tools", "git-hooks", "git-askpass"),
+            HARNESS_TASK_BOUND: "1",
+          }
+        : undefined;
+    };
   const extracted = {
     input,
     requiredRuntimeStore,
@@ -137,6 +148,7 @@ export function makeRuntimeSpawner(input: {
     publishExit,
     controlReceipt,
     captureErrorOutput,
+    prepareWorkerGitEnvironment,
   };
 
   return {
@@ -363,7 +375,8 @@ export function makeRuntimeSpawner(input: {
           "",
         ].join(""),
         runtimeKind = runtimeKindForId(definition.kindId),
-        protocolFamily = runtimeKind.protocolFamily;
+        protocolFamily = runtimeKind.protocolFamily,
+        workerGitEnvironment = taskId ? await prepareWorkerGitEnvironment(runtimeInstanceId) : undefined;
       // Enforced runtimes replace HOME and TMPDIR, so a task worker needs the daemon's sealed callback
       // route as well as its own executor identity.
       const workerLaunch =
@@ -372,6 +385,7 @@ export function makeRuntimeSpawner(input: {
               ...prepared,
               env: {
                 ...prepared.env,
+                ...workerGitEnvironment,
                 HARNESS_CANONICAL_ROOT: input.rootDir,
                 PATH: [
                   path.join(input.rootDir, "tools", "git-hooks"),
@@ -384,6 +398,7 @@ export function makeRuntimeSpawner(input: {
                 HARNESS_DAEMON_ENDPOINT: daemonRoute.endpoint,
                 HARNESS_DAEMON_REPO_ID: input.repoId,
                 HARNESS_ACTOR: runtimeActor,
+                HARNESS_TASK_BOUND: "1",
               },
             }
           : prepared;

--- a/packages/daemon/test/runtime-worker-github-credential-binding.test.ts
+++ b/packages/daemon/test/runtime-worker-github-credential-binding.test.ts
@@ -1,0 +1,100 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { parseThinCommand } from "../../cli/src/cli/thin-command.ts";
+import { openRuntimeInstanceStore, type RuntimeInstallationWitness } from "../src/agent-runtime-instances.ts";
+
+const installation: RuntimeInstallationWitness = {
+  installationId: "codex-github-worker-installation",
+  kindId: "codex",
+  executablePath: "/opt/runtime-test/codex",
+  version: "1.0.0",
+  observedAt: "2026-08-25T00:00:00.000Z",
+};
+
+test("runtime instance create accepts a distinct GitHub credential reference", () => {
+  const parsed = parseThinCommand([
+    "runtime",
+    "instance",
+    "create",
+    "--id",
+    "codex-github-worker",
+    "--name",
+    "Codex GitHub Worker",
+    "--kind",
+    "codex",
+    "--installation",
+    installation.installationId,
+    "--provider",
+    "openai",
+    "--model",
+    "gpt-5.6-sol",
+    "--auth",
+    "subscription",
+    "--github-credential-ref",
+    "credential:v1:github-worker",
+  ]);
+
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+  assert.equal(parsed.command.method, "daemon.runtimeInstance.create");
+  assert.deepEqual(parsed.command.action, {
+    kind: "runtime-instance-create",
+    instanceId: "codex-github-worker",
+    name: "Codex GitHub Worker",
+    kindId: "codex",
+    installationId: installation.installationId,
+    providerId: "openai",
+    models: ["gpt-5.6-sol"],
+    codex: {},
+    authMode: "subscription",
+    githubCredentialRef: "credential:v1:github-worker",
+  });
+});
+
+test("GitHub credentials resolve only into the worker Git environment and stay out of public receipts", async () => {
+  const userRoot = mkdtempSync(path.join(tmpdir(), "ha-runtime-github-credential-")),
+    secret = randomUUID(),
+    reference = "credential:v1:github-worker";
+  try {
+    const store = openRuntimeInstanceStore({
+      userRoot,
+      discover: () => [installation],
+      resolveCredential: async (candidate) => {
+        assert.equal(candidate, reference);
+        return secret;
+      },
+    });
+    store.create({
+      schemaVersion: 2,
+      instanceId: "codex-github-worker",
+      name: "Codex GitHub Worker",
+      kindId: "codex",
+      installationId: installation.installationId,
+      providerId: "openai",
+      models: ["gpt-5.6-sol"],
+      defaultModel: "gpt-5.6-sol",
+      enabled: true,
+      codex: {},
+      auth: { mode: "subscription" },
+      githubCredentialRef: reference,
+    });
+
+    const environment = await store.prepareWorkerGitEnvironment("codex-github-worker"),
+      shown = store.command({ kind: "runtime-instance-show", instanceId: "codex-github-worker" });
+    assert.deepEqual(environment, {
+      HARNESS_GITHUB_TOKEN: secret,
+      GIT_ASKPASS_REQUIRE: "force",
+      GIT_TERMINAL_PROMPT: "0",
+    });
+    assert.equal((shown.instance as Record<string, unknown>).githubCredentialState, "configured");
+    assert.doesNotMatch(JSON.stringify(shown), new RegExp(secret, "u"));
+    assert.doesNotMatch(JSON.stringify(shown), /credential:v1:github-worker|githubCredentialRef/u);
+  } finally {
+    rmSync(userRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/daemon/test/runtime-worker-github-credentials.integration.test.ts
+++ b/packages/daemon/test/runtime-worker-github-credentials.integration.test.ts
@@ -1,0 +1,232 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { hostname, tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { makeTaskEventStore } from "../../kernel/src/index.ts";
+import { openRuntimeInstanceStore, type RuntimeInstallationWitness } from "../src/agent-runtime-instances.ts";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { openRepoCell } from "../src/repo-cell.ts";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "../../..");
+
+test("task-bound runtime settlement pushes only its own codex branch with the bound GitHub credential", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-worker-github-")),
+    root = path.join(parent, "repo"),
+    workerRoot = path.join(root, ".worktrees", "worker"),
+    remote = path.join(parent, "origin.git"),
+    userRoot = path.join(parent, "user"),
+    secret = randomUUID(),
+    credentialRef = "credential:v1:github-worker",
+    repoId = "runtime-worker-github",
+    instanceId = "codex-github-worker",
+    taskId = "task-github-worker",
+    executionId = "execution-github-worker";
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    initRepo(root, repoId);
+    installGitHelpers(root);
+    execFileSync("git", ["init", "--bare", remote]);
+    git(root, "remote", "add", "origin", remote);
+    git(root, "worktree", "add", "--quiet", workerRoot, "-b", "codex/github-worker");
+    writeFileSync(path.join(workerRoot, "worker-change.txt"), "task-bound worker change\n");
+    git(workerRoot, "add", "worker-change.txt");
+    git(workerRoot, "commit", "--quiet", "-m", "feat: add worker change");
+
+    const installation: RuntimeInstallationWitness = {
+        installationId: "codex-github-worker-installation",
+        kindId: "codex",
+        executablePath: "/opt/witnessed/codex-github-worker",
+        version: "1.0.0",
+        observedAt: "2026-08-25T00:00:00.000Z",
+      },
+      instances = openRuntimeInstanceStore({
+        userRoot,
+        discover: () => [installation],
+        resolveCredential: async (reference) => {
+          assert.equal(reference, credentialRef);
+          return secret;
+        },
+        subscriptionReady: () => ({ status: "ready", code: null, hint: null }),
+      });
+    instances.create({
+      schemaVersion: 2,
+      instanceId,
+      name: "Codex GitHub Worker",
+      kindId: "codex",
+      installationId: installation.installationId,
+      providerId: "openai",
+      models: ["gpt-5.6-sol"],
+      defaultModel: "gpt-5.6-sol",
+      enabled: true,
+      permissionMode: "read-only",
+      codex: {},
+      auth: { mode: "subscription" },
+      githubCredentialRef: credentialRef,
+    });
+
+    let taskBoundLaunches = 0;
+    let mainPush: ReturnType<typeof spawnSync> | null = null;
+    cell = await openRepoCell({
+      repoId: workspaceId(repoId),
+      rootDir: canonicalRoot(root),
+      ownerId: "runtime-worker-github-test",
+      runtimeDaemonRoute: {
+        userRoot: path.join(parent, "daemon-user"),
+        daemonId: "runtime-worker-github-test",
+        endpoint: path.join(parent, "daemon.sock"),
+      },
+      runtimeInstances: instances.listPublic,
+      prepareRuntimeLaunch: instances.prepareLaunch,
+      prepareWorkerGitEnvironment: instances.prepareWorkerGitEnvironment,
+      runtimeLaunch: (prepared) => {
+        const taskBound = prepared.env.HARNESS_TASK_BOUND === "1";
+        if (taskBound) {
+          taskBoundLaunches += 1;
+          assert.equal(prepared.env.HARNESS_GITHUB_TOKEN, secret);
+          assert.equal(prepared.env.GIT_ASKPASS, path.join(root, "tools", "git-hooks", "git-askpass"));
+          mainPush = spawnSync("git", ["-C", workerRoot, "push", "origin", "HEAD:main"], {
+            cwd: workerRoot,
+            encoding: "utf8",
+            env: prepared.env,
+          });
+        } else {
+          assert.equal(prepared.env.HARNESS_GITHUB_TOKEN, undefined);
+          assert.equal(prepared.env.GIT_ASKPASS, undefined);
+        }
+        return successfulRuntimeProcess();
+      },
+    });
+
+    const actor = { principal: { personId: "person-github-worker" }, executor: null },
+      binding = { actor, source: "local" as const },
+      unbound = await cell.spawnRuntime(
+        {
+          runtimeInstanceId: instanceId,
+          cwd: { scope: "repo-root" },
+          prompt: "Inspect without a task binding",
+          taskId: null,
+          idempotencyKey: "github-worker-unbound",
+        },
+        binding,
+      );
+    await runtimeOutcome(root, repoId, String(unbound.runtimeSessionId));
+
+    assert.equal(
+      (await cell.run({ kind: "task-create", taskId, title: "GitHub worker push" }, binding)).outcome,
+      "applied",
+    );
+    assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, binding)).outcome, "applied");
+    const spawned = await cell.spawnRuntime(
+      {
+        runtimeInstanceId: instanceId,
+        cwd: { scope: "repo-relative", path: ".worktrees/worker" },
+        prompt: "Publish the completed worker branch",
+        taskId,
+        idempotencyKey: "github-worker-task-bound",
+      },
+      binding,
+    );
+    await runtimeOutcome(root, repoId, String(spawned.runtimeSessionId));
+
+    assert.equal(taskBoundLaunches, 1);
+    assert.match(String(mainPush?.stderr), /outside refs\/heads\/codex/u);
+    assert.notEqual(mainPush?.status, 0, mainPush?.stderr);
+    assert.match(gitText(remote, "show-ref", "--verify", "refs/heads/codex/github-worker"), /codex\/github-worker/u);
+    assert.notEqual(spawnSync("git", ["-C", remote, "show-ref", "--verify", "refs/heads/main"]).status, 0);
+
+    const shown = instances.command({ kind: "runtime-instance-show", instanceId }),
+      events = makeTaskEventStore({ repoId, rootDir: root }).read().events,
+      stream = readFileSync(
+        path.join(root, ".harness", "runtime", "dispatches", `${String(spawned.dispatchId)}.jsonl`),
+        "utf8",
+      );
+    assert.equal((shown.instance as Record<string, unknown>).githubCredentialState, "configured");
+    for (const observed of [shown, events, stream]) {
+      assert.doesNotMatch(JSON.stringify(observed), new RegExp(secret, "u"));
+      assert.doesNotMatch(JSON.stringify(observed), /githubCredentialRef/u);
+    }
+  } finally {
+    await cell?.close();
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+function successfulRuntimeProcess() {
+  return {
+    pid: process.pid,
+    onOutput: (listener: (chunk: string) => void) => {
+      queueMicrotask(() =>
+        listener(
+          [
+            { type: "thread.started", thread_id: "github-worker-provider" },
+            {
+              type: "item.completed",
+              item: { id: "message", type: "agent_message", text: "worker push ready" },
+            },
+            { type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } },
+          ]
+            .map((frame) => JSON.stringify(frame))
+            .join("\n") + "\n",
+        ),
+      );
+    },
+    onErrorOutput: () => undefined,
+    onExit: (listener: (code: number | null) => void) => queueMicrotask(() => listener(0)),
+    terminate: () => undefined,
+  };
+}
+
+function initRepo(root: string, repoId: string): void {
+  mkdirSync(path.join(root, "harness"), { recursive: true });
+  git(root, "init", "-q");
+  git(root, "config", "user.name", "GitHub Worker Test");
+  git(root, "config", "user.email", "github-worker@example.invalid");
+  writeFileSync(
+    path.join(root, "harness", "harness.yaml"),
+    `schema: harness-anything/v1\nname: ${repoId}\nlayout:\n  authoredRoot: harness\n  localRoot: .harness\n`,
+  );
+  writeFileSync(
+    path.join(root, "harness", "people.yaml"),
+    `${JSON.stringify({ schema: "harness-people/v1", people: [{ personId: "owner", displayName: "Owner", roles: ["owner"], credentials: [{ kind: "unix-socket-owner-boundary", issuer: `host:${hostname()}`, subject: String(process.getuid?.() ?? 0) }] }], roles: [{ roleId: "owner", commandClasses: ["repo-read", "repo-write", "admin"] }] }, null, 2)}\n`,
+  );
+  git(root, "add", "harness");
+  git(root, "commit", "--quiet", "-m", "test: initialize fixture");
+}
+
+function installGitHelpers(root: string): void {
+  const target = path.join(root, "tools", "git-hooks");
+  mkdirSync(target, { recursive: true });
+  for (const name of ["git", "git-askpass"]) {
+    const destination = path.join(target, name);
+    copyFileSync(path.join(repositoryRoot, "tools", "git-hooks", name), destination);
+    chmodSync(destination, 0o755);
+  }
+}
+
+async function runtimeOutcome(root: string, repoId: string, runtimeSessionId: string): Promise<void> {
+  for (let attempt = 0; attempt < 300; attempt += 1) {
+    if (
+      makeTaskEventStore({ repoId, rootDir: root })
+        .read()
+        .events.some(
+          (event) =>
+            event.type === "runtime_session_outcome_observed" && event.payload.runtimeSessionId === runtimeSessionId,
+        )
+    )
+      return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`runtime ${runtimeSessionId} did not settle`);
+}
+
+function git(root: string, ...args: string[]): void {
+  execFileSync("git", ["-C", root, ...args]);
+}
+
+function gitText(root: string, ...args: string[]): string {
+  return execFileSync("git", ["-C", root, ...args], { encoding: "utf8" });
+}

--- a/tools/git-hooks/git
+++ b/tools/git-hooks/git
@@ -43,4 +43,100 @@ if [ -n "$repo_root" ] && [ -n "$canonical_root" ] && [ -d "$canonical_root" ]; 
   fi
 fi
 
+refuse_push() {
+  printf 'Refusing a task-bound git push outside refs/heads/codex/*.\n' >&2
+  exit 1
+}
+
+if [ "${HARNESS_TASK_BOUND:-}" = "1" ]; then
+  git_command=
+  global_value=
+  for argument in "$@"; do
+    if [ -n "$global_value" ]; then
+      global_value=
+      continue
+    fi
+    case "$argument" in
+      -C|-c|--git-dir|--work-tree|--namespace|--exec-path|--config-env)
+        global_value=1
+        ;;
+      --git-dir=*|--work-tree=*|--namespace=*|--exec-path=*|--config-env=*)
+        ;;
+      -*)
+        ;;
+      *)
+        git_command=$argument
+        break
+        ;;
+    esac
+  done
+
+  if [ "$git_command" = "push" ]; then
+    push_seen=
+    option_value=
+    remote_seen=
+    refspec_seen=
+    options_done=
+    for argument in "$@"; do
+      if [ -z "$push_seen" ]; then
+        [ "$argument" = "push" ] && push_seen=1
+        continue
+      fi
+      if [ -n "$option_value" ]; then
+        option_value=
+        continue
+      fi
+      if [ -z "$options_done" ]; then
+        case "$argument" in
+          --)
+            options_done=1
+            continue
+            ;;
+          --all|--mirror|--tags|--delete|--prune|--follow-tags)
+            refuse_push
+            ;;
+          --repo)
+            option_value=repo
+            remote_seen=1
+            continue
+            ;;
+          --receive-pack|--exec|-o|--push-option)
+            option_value=1
+            continue
+            ;;
+          --repo=*)
+            remote_seen=1
+            continue
+            ;;
+          --receive-pack=*|--exec=*|--push-option=*|--force-with-lease=*|--force-if-includes|--no-force-if-includes|--signed=*|--recurse-submodules=*)
+            continue
+            ;;
+          -n|--dry-run|-f|--force|-u|--set-upstream|-q|--quiet|-v|--verbose|--porcelain|--progress|--no-progress|--atomic|--no-atomic|--thin|--no-thin|-4|--ipv4|-6|--ipv6|--force-with-lease|--signed)
+            continue
+            ;;
+          -*)
+            refuse_push
+            ;;
+        esac
+      fi
+      if [ -z "$remote_seen" ]; then
+        remote_seen=1
+        continue
+      fi
+      refspec_seen=1
+      refspec=${argument#+}
+      case "$refspec" in
+        :*) refuse_push ;;
+        *:*) target=${refspec#*:} ;;
+        *) target=$refspec ;;
+      esac
+      case "$target" in
+        codex/?*|refs/heads/codex/?*) ;;
+        *) refuse_push ;;
+      esac
+    done
+    [ -n "$refspec_seen" ] || refuse_push
+  fi
+fi
+
 PATH=$filtered_path exec git "$@"

--- a/tools/git-hooks/git-askpass
+++ b/tools/git-hooks/git-askpass
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+set -eu
+
+prompt=${1:-}
+case "$prompt" in
+  *https://github.com/*|*https://github.com\'*|*https://*@github.com/*|*https://*@github.com\'*) ;;
+  *) exit 1 ;;
+esac
+
+case "$prompt" in
+  *Username*) printf '%s\n' x-access-token ;;
+  *Password*)
+    [ -n "${HARNESS_GITHUB_TOKEN:-}" ] || exit 1
+    printf '%s\n' "$HARNESS_GITHUB_TOKEN"
+    ;;
+  *) exit 1 ;;
+esac

--- a/tools/worker-discipline-hooks.test.mjs
+++ b/tools/worker-discipline-hooks.test.mjs
@@ -1,6 +1,7 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
 import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -58,6 +59,49 @@ test("canonical hooks reject worker commit and checkout", (context) => {
   assert.match(checkout.stderr, /Refusing a worker checkout in the canonical repository root/u);
 });
 
+test("task-bound git wrapper permits only explicit codex branch push targets", (context) => {
+  const root = makeRepo(context, "hook-push-guard-"),
+    bare = path.join(path.dirname(root), `${path.basename(root)}.git`);
+  context.after(() => rmSync(bare, { recursive: true, force: true }));
+  installHook(root, "git");
+  git(root, "init", "--bare", bare);
+  git(root, "checkout", "-b", "codex/push-guard");
+  git(root, "remote", "add", "origin", bare);
+  const env = {
+    ...process.env,
+    HARNESS_TASK_BOUND: "1",
+    PATH: `${path.join(root, "tools", "git-hooks")}${path.delimiter}${process.env.PATH ?? ""}`,
+  };
+  const refused = spawnSync("git", ["-C", root, "push", "origin", "HEAD:main"], {
+    cwd: root,
+    encoding: "utf8",
+    env,
+  });
+  assert.equal(refused.status, 1, refused.stderr);
+  assert.match(refused.stderr, /outside refs\/heads\/codex/u);
+  const allowed = spawnSync("git", ["-C", root, "push", "origin", "HEAD:refs/heads/codex/push-guard"], {
+    cwd: root,
+    encoding: "utf8",
+    env,
+  });
+  assert.equal(allowed.status, 0, allowed.stderr);
+  assert.match(git(bare, "show-ref", "--verify", "refs/heads/codex/push-guard"), /codex\/push-guard/u);
+});
+
+test("GitHub askpass answers only standard HTTPS GitHub prompts", (context) => {
+  const root = makeRepo(context, "hook-askpass-guard-"),
+    secret = randomUUID();
+  installHook(root, "git-askpass");
+  const helper = path.join(root, "tools", "git-hooks", "git-askpass"),
+    env = { ...process.env, HARNESS_GITHUB_TOKEN: secret },
+    username = spawnSync(helper, ["Username for 'https://github.com':"], { encoding: "utf8", env }),
+    password = spawnSync(helper, ["Password for 'https://x-access-token@github.com':"], { encoding: "utf8", env }),
+    hostile = spawnSync(helper, ["Password for 'https://github.com.example.invalid':"], { encoding: "utf8", env });
+  assert.deepEqual([username.status, username.stdout.trim()], [0, "x-access-token"]);
+  assert.deepEqual([password.status, digest(password.stdout.trim())], [0, digest(secret)]);
+  assert.deepEqual([hostile.status, hostile.stdout], [1, ""]);
+});
+
 test("worker handoff templates carry framework-owned publication rules", () => {
   const templatePaths = [
     "packages/preset/assets/software-coding/templates/task.worker.flow/en-US.md",
@@ -108,4 +152,8 @@ function runHook(root, name) {
 
 function git(root, ...args) {
   return execFileSync("git", ["-C", root, ...args], { encoding: "utf8" });
+}
+
+function digest(value) {
+  return createHash("sha256").update(value).digest("hex");
 }


### PR DESCRIPTION
# English

## Summary

Since 0.19 a worker's settlement tries to push its branch, but task-bound runtime sessions have no GitHub credential, so every push failed (`could not read Username for 'https://github.com'`) and the CEO pushed all eleven of today's branches by hand. This PR lets a runtime instance bind an independent GitHub credential reference (`--github-credential-ref`, reusing the existing credential port — not the provider API-key field, whose subscription/API-key exclusivity must stay intact), injects a Git askpass environment only into task-bound spawns and the settlement push, and restricts task-bound pushes to explicit `codex/*` branches (main, tags, deletes, mirror/all are refused). `ha runtime instance show` exposes only `githubCredentialState: "configured"`; the reference and value never enter DTOs, receipts, events or fixtures. PR creation and merge remain the CEO's.

## Architectural Justification

-

## What Changed

- CLI/protocol/config/storage: independent `githubCredentialRef` binding, validated and persisted; public projection shows configured state only.
- Daemon composition + runtime spawn: `prepareWorkerGitEnvironment` is the single resolver; non-task-bound spawns never call it.
- Settlement: the existing 0.19 `pushWorkerBranch` call receives the temporary Git environment; a resolution failure is a single scrubbed failure, no retry.
- `tools/git-hooks/git` and `git-askpass`: task-bound push target restriction and HTTPS askpass.
- Tests: contract (binding, resolution, no leak in receipts), integration (non-task no injection; task-bound main refused; settlement publishes its own codex/* branch; show/event/stream carry no credential), fast hook tests (main refused, codex allowed, look-alike hosts refused).

## Machine-Readable Declarations

Production-Delta: +115/-71

## Task And Scope

- Harness task: task_d3c5030e8c5271bc6f5e038266 (PLT-Ontology Phase 0.22)
- Branch: `codex/worker-gh-creds`
- Public scope: runtime instance credential binding, task-bound spawn environment, settlement push, git hooks, tests
- Private planning/evidence updated: yes (artifacts/reports/worker-gh-creds.md)
- Out of scope: PR creation/merge (CEO); real GitHub PAT + branch protection exercised end-to-end (CEO verifies after merge by binding a credential and watching the next worker push)

## Version Impact

- Version: no version change because this is a pre-release fix on the rebuild line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_d3c5030e8c5271bc6f5e038266 (PLT-Ontology Phase 0.22, Zeyu ruling 2026-08-25 ⑤)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 11ce436d3736c07b8fde702d54a20c1013708b79
- Branch merge-base with `origin/main`: 11ce436d3736c07b8fde702d54a20c1013708b79
- Last `git fetch origin` time: 2026-08-25T07:09Z
- Sync method: rebase
- Public diff command: `git diff 11ce436d3736c07b8fde702d54a20c1013708b79..8a107a5b6`
- Private evidence commit/path: harness task package task_d3c5030e8c5271bc6f5e038266 artifacts/reports
- Reviewer evidence path: worker report worker-gh-creds.md: Docker-isolated integration and contract runs, fast hook negatives; CEO verified G36 pass, control-character scan empty, gate delta +115/-71 (report counts +228/-71 including generated/config lines), and that the provider credentialRef exclusivity was not touched
- GitHub Actions `rewrite-ci` run URL: pending (filled after the run)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test` (contract + integration (Docker isolation) + fast hook tests per the report)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: a real GitHub push with a real PAT from a worker session (external verification after merge)

## Review Evidence

- Self-review: CEO: this is the missing half of 0.19 — the push path existed but no identity could use it; the design keeps provider identity and Git identity separate on purpose.
- Reviewer subagent: yes (read-only report audit with independent git verification)
- Human review: pending
- Blocking findings: none

## Residual Risk

- Until a credential is bound on the subscription instance the behaviour is unchanged (pushes still fail); the first bound run is the real test.

## References

- Task: task_d3c5030e8c5271bc6f5e038266
- Evidence: artifacts/reports/worker-gh-creds.md
- Review: pending

---

# 中文

## 概要

0.19 起 worker 的 settlement 会尝试 push 自己的分支,但 task-bound runtime 会话没有 GitHub 凭证,push 全部失败(`could not read Username for 'https://github.com'`),今天 11 条分支全由 CEO 手推。本 PR 让 runtime 实例绑定独立的 GitHub 凭证引用(`--github-credential-ref`,复用既有 credential port——不复用 provider API-key 字段,其 subscription/API-key 互斥语义保持不变),只对 task-bound spawn 与 settlement push 注入 Git askpass 环境,并把 task-bound push 限制为显式 `codex/*` 分支(main、tag、删除、mirror/all 一律拒绝)。`ha runtime instance show` 只暴露 `githubCredentialState: "configured"`;引用与值不进 DTO、receipt、事件或 fixture。PR 创建/合并仍归 CEO。

## 架构辩护

-

## 改动内容

- CLI/protocol/config/storage:独立 `githubCredentialRef` 绑定,校验并持久化;公开投影只显示 configured 状态。
- daemon composition + runtime spawn:`prepareWorkerGitEnvironment` 是唯一解析器;非 task-bound spawn 不调用。
- settlement:0.19 既有 `pushWorkerBranch` 调用获得临时 Git 环境;解析失败为单次、经 scrub、不重试。
- `tools/git-hooks/git` 与 `git-askpass`:task-bound push 目标限制与 HTTPS askpass。
- 测试:contract(绑定、解析、receipt 不泄露)、integration(非 task 不注入;task-bound push main 被拒;settlement 发布自己的 codex/* 分支;show/event/stream 无凭证)、fast hook(拒 main、允 codex、拒相似主机)。

## 机读声明说明

- 机读声明只在英文块出现一次。

## 任务与范围

- Harness 任务:task_d3c5030e8c5271bc6f5e038266(PLT-Ontology Phase 0.22)
- 分支:`codex/worker-gh-creds`
- 公开范围:runtime 实例凭证绑定、task-bound spawn 环境、settlement push、git hooks、测试
- 私有计划 / 证据是否已更新:yes(artifacts/reports/worker-gh-creds.md)
- 范围外:PR 创建/合并(CEO);真实 GitHub PAT + 分支保护的端到端(合入后 CEO 绑定凭证观察下一次 worker push)

## 版本影响

- 版本:不改版本,原因是 rebuild 线 pre-release 修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_d3c5030e8c5271bc6f5e038266 (PLT-Ontology Phase 0.22, Zeyu ruling 2026-08-25 ⑤)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:11ce436d3736c07b8fde702d54a20c1013708b79
- 当前分支与 `origin/main` 的 merge-base:11ce436d3736c07b8fde702d54a20c1013708b79
- 最近一次 `git fetch origin` 时间:2026-08-25T07:09Z
- 同步方式:rebase
- 公开 diff 命令:`git diff 11ce436d3736c07b8fde702d54a20c1013708b79..8a107a5b6`
- 私有证据 commit/path:任务包 artifacts/reports
- Reviewer 证据路径:worker 回执 worker-gh-creds.md:Docker 隔离 integration 与 contract、fast hook 阴性;CEO 核 G36 过、控制字符扫描为空、门口径 delta +115/-71(回执含生成/配置行计 +228/-71),且 provider credentialRef 互斥未动
- GitHub Actions `rewrite-ci` run URL:待 run 结束后补
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`(回执中的 contract + integration(Docker 隔离)+ fast hook 测试)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:worker 会话用真实 PAT 的真实 GitHub push(合入后外部验证)

## 审查证据

- 自查:CEO:这是 0.19 缺的另一半——push 路径在,但没有身份能用它;设计上刻意把 provider 身份与 Git 身份分开。
- Reviewer subagent:有(只读回执审计 + git 独立核实)
- 人工审查:待
- 阻塞发现:无

## 残余风险

- 订阅实例绑定凭证前行为不变(push 仍失败);第一次绑定后的运行才是真验证。

## 关联材料

- 任务:task_d3c5030e8c5271bc6f5e038266
- 证据:artifacts/reports/worker-gh-creds.md
- 审查:待

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPPk3TmbURWuxcFY3kFimA

