### PR TITLE
feat(runtime): bind GitHub credentials to existing runtime instances

### DIFF
--- a/packages/cli/src/cli/thin-command-runtime-instance.ts
+++ b/packages/cli/src/cli/thin-command-runtime-instance.ts
@@ -1,17 +1,8 @@
 import type { SafePath } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
-import {
-  accepted,
-  nonEmpty,
-  readFlags,
-  rejected,
-} from "./thin-command-flags.ts";
+import { accepted, nonEmpty, readFlags, rejected } from "./thin-command-flags.ts";
 import { parseRuntimeInstanceCreate } from "./thin-command-runtime-instance-create.ts";
 import { parseRuntimeInstanceUpdate } from "./thin-command-runtime-instance-update.ts";
-import type {
-  ProtocolCommand,
-  ThinCliInputDirectory,
-  ThinParseResult,
-} from "./thin-command-types.ts";
+import type { ProtocolCommand, ThinCliInputDirectory, ThinParseResult } from "./thin-command-types.ts";
 
 export function parseRuntimeInstance(
   route: ProtocolCommand,
@@ -22,30 +13,15 @@ export function parseRuntimeInstance(
   inputs: ThinCliInputDirectory,
 ): ThinParseResult {
   const kind = route.id,
-    positional = [
-      "runtime-instance-show",
-      "runtime-instance-delete",
-      "runtime-instance-login",
-      "runtime-instance-logout",
-      "runtime-instance-update",
-    ].includes(kind),
+    positional = "positional" in route && route.positional === "instanceId",
     auth = ["runtime-instance-login", "runtime-instance-logout"].includes(kind),
-    instanceId = positional ? args[3] : undefined,
-    flags = readFlags(kind, args.slice(positional ? 4 : 3), inputs);
+    instanceId = positional ? args[route.path.length] : undefined,
+    flags = readFlags(kind, args.slice(route.path.length + (positional ? 1 : 0)), inputs);
   if (!flags.ok) return rejected(flags.code, flags.nextAction, json);
-  if (positional && !nonEmpty(instanceId))
-    return rejected("missing_field", "Runtime instance id is required.", json);
+  if (positional && !nonEmpty(instanceId)) return rejected("missing_field", "Runtime instance id is required.", json);
   if (kind === "runtime-instance-update")
-    return parseRuntimeInstanceUpdate(
-      route,
-      rootDir,
-      instanceId,
-      json,
-      inputs,
-      flags,
-    );
-  if (kind === "runtime-instance-create")
-    return parseRuntimeInstanceCreate(route, rootDir, json, flags);
+    return parseRuntimeInstanceUpdate(route, rootDir, instanceId, json, inputs, flags);
+  if (kind === "runtime-instance-create") return parseRuntimeInstanceCreate(route, rootDir, json, flags);
   return accepted(
     rootDir,
     auth ? repoId : undefined,
@@ -53,15 +29,10 @@ export function parseRuntimeInstance(
     {
       kind,
       ...(instanceId ? { instanceId } : {}),
-      ...(kind === "runtime-instance-list" && flags.booleans.has("--all")
-        ? { all: true }
-        : {}),
-      ...(kind === "runtime-instance-show" && flags.booleans.has("--probe")
-        ? { probe: true }
-        : {}),
-      ...(auth && flags.one.get("--idempotency-key")
-        ? { idempotencyKey: flags.one.get("--idempotency-key") }
-        : {}),
+      ...(kind === "runtime-instance-list" && flags.booleans.has("--all") ? { all: true } : {}),
+      ...(kind === "runtime-instance-show" && flags.booleans.has("--probe") ? { probe: true } : {}),
+      ...(kind === "runtime-instance-github-credential-set" ? { githubCredentialRef: flags.one.get("--ref") } : {}),
+      ...(auth && flags.one.get("--idempotency-key") ? { idempotencyKey: flags.one.get("--idempotency-key") } : {}),
     },
     route.method,
   );

--- a/packages/cli/test/thin-command-contract-parity.test.ts
+++ b/packages/cli/test/thin-command-contract-parity.test.ts
@@ -1,7 +1,12 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
-import { DAEMON_RPC_SCHEMA, daemonMethodAcceptsPayloadExecutor, daemonProtocolCommands, validateDaemonRpcCall } from "../../daemon/src/protocol/daemon-protocol.contract.ts";
+import {
+  DAEMON_RPC_SCHEMA,
+  daemonMethodAcceptsPayloadExecutor,
+  daemonProtocolCommands,
+  validateDaemonRpcCall,
+} from "../../daemon/src/protocol/daemon-protocol.contract.ts";
 import { unknownFieldViolation } from "../../daemon/src/protocol/json-rpc-types.ts";
 import { deriveThinCliInputs, parseThinCommand } from "../src/cli/thin-command.ts";
 
@@ -10,24 +15,64 @@ const frozenMutations = Object.freeze([
   { commandId: "task-submit", inputName: "--execution-id", facet: "kind", argv: ["task", "submit", "task-1"] },
   { commandId: "task-create", inputName: "--title", facet: "name", argv: ["task", "create"] },
   { commandId: "task-create", inputName: "--title", facet: "error", argv: ["task", "create"] },
-  { commandId: "fact-search", inputName: "--confidence", facet: "enum", argv: ["fact", "search", "--confidence", "impossible"] },
-  { commandId: "fact-show", inputName: "--id", facet: "regex", argv: ["fact", "show", "--task", "task-1", "--id", "bad"] },
-  { commandId: "fact-record", inputName: "--memory-tag", facet: "repeated", argv: ["fact", "record", "--task", "task-1", "--statement", "s", "--source", "src", "--memory-tag", "a"] },
-  { commandId: "decision-show", inputName: "--include-body", facet: "boolean", argv: ["decision", "show", "dec_1", "--include-body"] }
+  {
+    commandId: "fact-search",
+    inputName: "--confidence",
+    facet: "enum",
+    argv: ["fact", "search", "--confidence", "impossible"],
+  },
+  {
+    commandId: "fact-show",
+    inputName: "--id",
+    facet: "regex",
+    argv: ["fact", "show", "--task", "task-1", "--id", "bad"],
+  },
+  {
+    commandId: "fact-record",
+    inputName: "--memory-tag",
+    facet: "repeated",
+    argv: ["fact", "record", "--task", "task-1", "--statement", "s", "--source", "src", "--memory-tag", "a"],
+  },
+  {
+    commandId: "decision-show",
+    inputName: "--include-body",
+    facet: "boolean",
+    argv: ["decision", "show", "dec_1", "--include-body"],
+  },
 ] as const);
 
 test("all public commands expose the canonical structured input facet", () => {
-  assert.equal(daemonProtocolCommands.length, 115);
+  assert.equal(daemonProtocolCommands.length, 117);
   for (const command of daemonProtocolCommands) {
     assert.equal(Object.hasOwn(command, "inputs"), true, `${command.id}: explicit inputs`);
     assert.deepEqual(deriveThinCliInputs(command), command.inputs, command.id);
-    assert.equal(command.inputs.every((input) => input.name.startsWith("--") && Object.hasOwn(input, "required") && Object.hasOwn(input, "error")), true, command.id);
+    assert.equal(
+      command.inputs.every(
+        (input) => input.name.startsWith("--") && Object.hasOwn(input, "required") && Object.hasOwn(input, "error"),
+      ),
+      true,
+      command.id,
+    );
   }
-  for (const id of ["task-show", "receipt-show", "doc-materialize", "preset-upgrade", "ledger-migrate", "daemon-projection-rebuild", "daemon-start", "daemon-status"]) assert.deepEqual(daemonProtocolCommands.find((command) => command.id === id)?.inputs, [], id);
+  for (const id of [
+    "task-show",
+    "receipt-show",
+    "doc-materialize",
+    "preset-upgrade",
+    "ledger-migrate",
+    "daemon-projection-rebuild",
+    "daemon-start",
+    "daemon-status",
+  ])
+    assert.deepEqual(daemonProtocolCommands.find((command) => command.id === id)?.inputs, [], id);
   // daemon-stop is the one daemon control with a flag: --force is the supported escalation when
   // a cooperative stop times out, and the usage line is derived from this declaration.
   const daemonStop = daemonProtocolCommands.find((command) => command.id === "daemon-stop");
-  assert.deepEqual(daemonStop?.inputs.map((input) => [input.name, input.kind]), [["--force", "boolean"]], "daemon-stop");
+  assert.deepEqual(
+    daemonStop?.inputs.map((input) => [input.name, input.kind]),
+    [["--force", "boolean"]],
+    "daemon-stop",
+  );
   assert.match(daemonStop?.usage ?? "", /daemon stop \[--force\]/u, "daemon-stop");
 });
 
@@ -36,13 +81,18 @@ test("daemon-effective rebuilds keep their declared positional in usage", () => 
   // already-built command into a second defineCliCommand call. Both declare a required positional
   // (<task-id> / --repo-id etc.), and the rebuild must not silently drop it from the rendered usage.
   const taskStart = daemonProtocolCommands.find((command) => command.id === "task-start");
-  assert.ok(taskStart); assert.match(taskStart.usage, /task start <task-id>/u);
+  assert.ok(taskStart);
+  assert.match(taskStart.usage, /task start <task-id>/u);
   const repoBootstrap = daemonProtocolCommands.find((command) => command.id === "repo-bootstrap");
-  assert.ok(repoBootstrap); assert.match(repoBootstrap.usage, /--repo-id <repo-id>/u);
+  assert.ok(repoBootstrap);
+  assert.match(repoBootstrap.usage, /--repo-id <repo-id>/u);
 });
 
 test("closed-field violations bind the rejected name to the legal field table", () => {
-  assert.equal(unknownFieldViolation({ schema: "probe", permissionMode: "bypass" }, ["schema", "permission-mode"]), 'unknown field "permissionMode"; allowed fields: "schema", "permission-mode".');
+  assert.equal(
+    unknownFieldViolation({ schema: "probe", permissionMode: "bypass" }, ["schema", "permission-mode"]),
+    'unknown field "permissionMode"; allowed fields: "schema", "permission-mode".',
+  );
   assert.equal(unknownFieldViolation({ schema: "probe" }, ["schema", "permission-mode"]), null);
 });
 
@@ -52,32 +102,107 @@ test("closed-field violations bind the rejected name to the legal field table", 
 // a payload envelope exists without the declaration, the validator must reject the field. A newly contracted
 // command therefore needs no CLI edit to stay un-injected, and removing a declaration from an injected method
 // fails here instead of silently dropping attribution.
-const reviewedExecutorSurface = Object.freeze(["repo.task.create", "repo.preset.list", "repo.preset.inspect", "repo.preset.check", "repo.preset.validate", "repo.preset.install", "repo.preset.seed", "repo.preset.audit", "repo.preset.uninstall", "repo.preset.upgrade", "repo.vertical.validate", "repo.template.list", "repo.template.render", "repo.script.list", "repo.script.inspect", "repo.script.run", "repo.preset.run.start", "repo.preset.run.status", "repo.agentRuntime.spawn"] as const);
+const reviewedExecutorSurface = Object.freeze([
+  "repo.task.create",
+  "repo.preset.list",
+  "repo.preset.inspect",
+  "repo.preset.check",
+  "repo.preset.validate",
+  "repo.preset.install",
+  "repo.preset.seed",
+  "repo.preset.audit",
+  "repo.preset.uninstall",
+  "repo.preset.upgrade",
+  "repo.vertical.validate",
+  "repo.template.list",
+  "repo.template.render",
+  "repo.script.list",
+  "repo.script.inspect",
+  "repo.script.run",
+  "repo.preset.run.start",
+  "repo.preset.run.status",
+  "repo.agentRuntime.spawn",
+] as const);
 const agent = Object.freeze({ kind: "agent", id: "parity-probe" });
-const payloadShapeOf = (params: (typeof DAEMON_RPC_SCHEMA.methods)[number]["params"]) => { const payload = params.fields.payload; return typeof payload === "object" && payload !== null && "fields" in payload ? payload : null; };
+const payloadShapeOf = (params: (typeof DAEMON_RPC_SCHEMA.methods)[number]["params"]) => {
+  const payload = params.fields.payload;
+  return typeof payload === "object" && payload !== null && "fields" in payload ? payload : null;
+};
 
 test("executor injection follows the daemon-declared surface exactly", () => {
   for (const { method, params } of DAEMON_RPC_SCHEMA.methods) {
-    const accepts = daemonMethodAcceptsPayloadExecutor(method), payload = payloadShapeOf(params);
-    const errors = validateDaemonRpcCall({ method, params: { repo: { repoId: "parity" }, payload: { executor: agent } } });
-    const executorRejected = errors.some((error) => error.includes('params.payload contains an unknown field "executor"'));
-    assert.equal(accepts, reviewedExecutorSurface.includes(method), `${method}: derived surface matches the reviewed register`);
-    if (accepts) assert.equal(executorRejected, false, `${method}: the validator must accept a declared payload executor`);
-    else if (payload && !payload.open) assert.equal(executorRejected, true, `${method}: an undeclared payload executor must be rejected`);
-    else if (!payload) assert.equal(errors.some((error) => error.includes('params contains an unknown field "payload"')), true, `${method}: carries no payload envelope at all`);
+    const accepts = daemonMethodAcceptsPayloadExecutor(method),
+      payload = payloadShapeOf(params);
+    const errors = validateDaemonRpcCall({
+      method,
+      params: { repo: { repoId: "parity" }, payload: { executor: agent } },
+    });
+    const executorRejected = errors.some((error) =>
+      error.includes('params.payload contains an unknown field "executor"'),
+    );
+    assert.equal(
+      accepts,
+      reviewedExecutorSurface.includes(method),
+      `${method}: derived surface matches the reviewed register`,
+    );
+    if (accepts)
+      assert.equal(executorRejected, false, `${method}: the validator must accept a declared payload executor`);
+    else if (payload && !payload.open)
+      assert.equal(executorRejected, true, `${method}: an undeclared payload executor must be rejected`);
+    else if (!payload)
+      assert.equal(
+        errors.some((error) => error.includes('params contains an unknown field "payload"')),
+        true,
+        `${method}: carries no payload envelope at all`,
+      );
   }
   // repo.task.run is the one structural exception: the executor rides inside the open action envelope.
-  assert.deepEqual(validateDaemonRpcCall({ method: "repo.task.run", params: { repo: { repoId: "parity" }, payload: { action: { kind: "task-list", executor: agent } } } }), []);
+  assert.deepEqual(
+    validateDaemonRpcCall({
+      method: "repo.task.run",
+      params: { repo: { repoId: "parity" }, payload: { action: { kind: "task-list", executor: agent } } },
+    }),
+    [],
+  );
   assert.equal(daemonMethodAcceptsPayloadExecutor("repo.task.run"), false);
   assert.equal(daemonMethodAcceptsPayloadExecutor("repo.not.contracted"), false);
 });
 
 test("frozen public-parser mutations kill every canonical input facet", () => {
   for (const mutation of frozenMutations) {
-    const command = daemonProtocolCommands.find((candidate) => candidate.id === mutation.commandId); assert.ok(command, mutation.commandId);
-    const input = command.inputs.find((candidate) => candidate.name === mutation.inputName); assert.ok(input, `${mutation.commandId}:${mutation.inputName}`);
-    if (["required", "kind", "name", "error", "enum", "regex"].includes(mutation.facet)) assert.equal(Object.hasOwn(input, mutation.facet), true, `${mutation.commandId}:${mutation.facet}`);
-    const removeInput = mutation.facet === "repeated" || mutation.facet === "boolean", inputs = removeInput ? command.inputs.filter((candidate) => candidate.name !== mutation.inputName) : command.inputs.map((candidate) => candidate.name === mutation.inputName ? Object.fromEntries(Object.entries(candidate).filter(([key]) => key !== mutation.facet)) : candidate), mutatedCommand = { ...command, inputs, flags: inputs }, catalog = daemonProtocolCommands.map((candidate) => candidate.id === command.id ? mutatedCommand : candidate) as unknown as typeof daemonProtocolCommands;
-    const baseline = parseThinCommand(mutation.argv); if (["required", "kind", "name", "error"].includes(mutation.facet)) assert.throws(() => parseThinCommand(mutation.argv, process.cwd(), catalog), undefined, `${mutation.commandId}:${mutation.facet}`); else { const mutant = parseThinCommand(mutation.argv, process.cwd(), catalog); assert.notDeepEqual(mutant, baseline, `${mutation.commandId}:${mutation.facet}`); assert.equal(removeInput ? baseline.ok && !mutant.ok : !baseline.ok && mutant.ok, true, `${mutation.commandId}:${mutation.facet}`); }
+    const command = daemonProtocolCommands.find((candidate) => candidate.id === mutation.commandId);
+    assert.ok(command, mutation.commandId);
+    const input = command.inputs.find((candidate) => candidate.name === mutation.inputName);
+    assert.ok(input, `${mutation.commandId}:${mutation.inputName}`);
+    if (["required", "kind", "name", "error", "enum", "regex"].includes(mutation.facet))
+      assert.equal(Object.hasOwn(input, mutation.facet), true, `${mutation.commandId}:${mutation.facet}`);
+    const removeInput = mutation.facet === "repeated" || mutation.facet === "boolean",
+      inputs = removeInput
+        ? command.inputs.filter((candidate) => candidate.name !== mutation.inputName)
+        : command.inputs.map((candidate) =>
+            candidate.name === mutation.inputName
+              ? Object.fromEntries(Object.entries(candidate).filter(([key]) => key !== mutation.facet))
+              : candidate,
+          ),
+      mutatedCommand = { ...command, inputs, flags: inputs },
+      catalog = daemonProtocolCommands.map((candidate) =>
+        candidate.id === command.id ? mutatedCommand : candidate,
+      ) as unknown as typeof daemonProtocolCommands;
+    const baseline = parseThinCommand(mutation.argv);
+    if (["required", "kind", "name", "error"].includes(mutation.facet))
+      assert.throws(
+        () => parseThinCommand(mutation.argv, process.cwd(), catalog),
+        undefined,
+        `${mutation.commandId}:${mutation.facet}`,
+      );
+    else {
+      const mutant = parseThinCommand(mutation.argv, process.cwd(), catalog);
+      assert.notDeepEqual(mutant, baseline, `${mutation.commandId}:${mutation.facet}`);
+      assert.equal(
+        removeInput ? baseline.ok && !mutant.ok : !baseline.ok && mutant.ok,
+        true,
+        `${mutation.commandId}:${mutation.facet}`,
+      );
+    }
   }
 });

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -2,50 +2,28 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
-import {
-  daemonProtocolCommands,
-  thinCliCommands,
-} from "../../daemon/src/protocol/daemon-protocol.contract.ts";
-import {
-  deriveCliCapabilities,
-  parseThinCommand,
-  renderThinHelp,
-} from "../src/cli/thin-command.ts";
+import { daemonProtocolCommands, thinCliCommands } from "../../daemon/src/protocol/daemon-protocol.contract.ts";
+import { deriveCliCapabilities, parseThinCommand, renderThinHelp } from "../src/cli/thin-command.ts";
 import { emit, main, resolveCliVersion } from "../src/index.ts";
 
 test("top-level help renders a derived domain directory and domain help filters commands", () => {
   const help = renderThinHelp();
-  assert.equal(thinCliCommands.length, 115);
-  for (const domain of [
-    ...new Set(daemonProtocolCommands.map((command) => command.path[0])),
-  ]
+  assert.equal(thinCliCommands.length, 117);
+  for (const domain of [...new Set(daemonProtocolCommands.map((command) => command.path[0]))]
     .filter((value): value is string => value !== undefined)
     .sort())
     assert.match(help, new RegExp(`^  ${domain} \\(`, "mu"));
   assert.doesNotMatch(help, /ha task start <task-id>/u);
   const taskHelp = renderThinHelp([], "task");
-  for (const command of thinCliCommands.filter(
-    ({ usage }) => usage.split(" ")[1] === "task",
-  ))
-    assert.match(
-      taskHelp,
-      new RegExp(command.usage.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"),
-    );
+  for (const command of thinCliCommands.filter(({ usage }) => usage.split(" ")[1] === "task"))
+    assert.match(taskHelp, new RegExp(command.usage.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
   assert.doesNotMatch(taskHelp, /ha decision propose|ha preset list/u);
   for (const domain of ["decision", "distill"]) {
     const domainHelp = renderThinHelp([], domain);
-    for (const command of thinCliCommands.filter(
-      ({ usage }) => usage.split(" ")[1] === domain,
-    ))
-      assert.match(
-        domainHelp,
-        new RegExp(command.usage.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"),
-      );
+    for (const command of thinCliCommands.filter(({ usage }) => usage.split(" ")[1] === domain))
+      assert.match(domainHelp, new RegExp(command.usage.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
   }
-  assert.match(
-    help,
-    /capabilities \[--json\].*--version.*ha daemon start --service/su,
-  );
+  assert.match(help, /capabilities \[--json\].*--version.*ha daemon start --service/su);
 });
 
 test("an unknown command domain reports unknown with the available set instead of an empty help page", async () => {
@@ -61,11 +39,7 @@ test("an unknown command domain reports unknown with the available set instead o
   };
   const exits: number[] = [];
   try {
-    exits.push(
-      await main(["bananas", "--help"]),
-      await main(["bananas"]),
-      await main(["migrate", "--help"]),
-    );
+    exits.push(await main(["bananas", "--help"]), await main(["bananas"]), await main(["migrate", "--help"]));
   } finally {
     console.log = log;
     console.error = error;
@@ -76,8 +50,7 @@ test("an unknown command domain reports unknown with the available set instead o
   for (const line of errors) {
     assert.match(line, /code=unsupported_command/u);
     assert.match(line, /bananas is not a command domain/u);
-    for (const domain of Object.keys(deriveCliCapabilities()))
-      assert.match(line, new RegExp(`\\b${domain}\\b`, "u"));
+    for (const domain of Object.keys(deriveCliCapabilities())) assert.match(line, new RegExp(`\\b${domain}\\b`, "u"));
   }
   assert.equal(logs.length, 1);
   assert.match(logs[0] ?? "", /Commands for migrate:\n {2}ha migrate import/u);
@@ -86,13 +59,7 @@ test("an unknown command domain reports unknown with the available set instead o
 test("capabilities is an exact-set projection of the command contract", () => {
   assert.deepEqual(deriveCliCapabilities(), {
     agenda: ["agenda"],
-    agent: [
-      "agent-create",
-      "agent-inspect",
-      "agent-install",
-      "agent-list",
-      "agent-validate",
-    ],
+    agent: ["agent-create", "agent-inspect", "agent-install", "agent-list", "agent-validate"],
     daemon: [
       "daemon-fleet-center-start",
       "daemon-fleet-edge-sync",
@@ -158,6 +125,8 @@ test("capabilities is an exact-set projection of the command contract", () => {
       "runtime-cancel",
       "runtime-instance-create",
       "runtime-instance-delete",
+      "runtime-instance-github-credential-set",
+      "runtime-instance-github-credential-unset",
       "runtime-instance-list",
       "runtime-instance-login",
       "runtime-instance-logout",
@@ -167,14 +136,7 @@ test("capabilities is an exact-set projection of the command contract", () => {
       "runtime-status",
     ],
     script: ["preset-run-start", "script-inspect", "script-list", "script-run"],
-    squad: [
-      "squad-inspect",
-      "squad-install",
-      "squad-list",
-      "squad-run",
-      "squad-status",
-      "squad-validate",
-    ],
+    squad: ["squad-inspect", "squad-install", "squad-list", "squad-run", "squad-status", "squad-validate"],
     task: [
       "task-amend",
       "task-archive",
@@ -210,9 +172,7 @@ test("capabilities is an exact-set projection of the command contract", () => {
 });
 
 test("CLI version is read from the CLI package metadata", () => {
-  const packageJson = JSON.parse(
-    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
-  );
+  const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
   assert.equal(resolveCliVersion(), packageJson.version);
 });
 
@@ -318,25 +278,12 @@ test("human preset and task receipts print resolved completion contracts byte-fo
       false,
     ),
   );
-  assert.equal(
-    replayOutput,
-    "reused task task-one for the supplied idempotency key",
-  );
+  assert.equal(replayOutput, "reused task task-one for the supplied idempotency key");
 });
 
 test("thin parser derives closed preset and task-create payloads from descriptors", () => {
   assert.equal(parseThinCommand(["doc", "sync"]).ok, false);
-  assert.equal(
-    parseThinCommand([
-      "task",
-      "create",
-      "--title",
-      "Bound",
-      "--completion-gate",
-      "G32",
-    ]).ok,
-    false,
-  );
+  assert.equal(parseThinCommand(["task", "create", "--title", "Bound", "--completion-gate", "G32"]).ok, false);
   const create = parseThinCommand([
       "task",
       "create",
@@ -348,54 +295,16 @@ test("thin parser derives closed preset and task-create payloads from descriptor
       "milestone",
       "--dry-run",
     ]),
-    inspect = parseThinCommand([
-      "preset",
-      "inspect",
-      "standard-task",
-      "--locale",
-      "en-US",
-    ]),
-    check = parseThinCommand([
-      "preset",
-      "check",
-      "standard-task",
-      "--snapshot-digest",
-      `sha256:${"a".repeat(64)}`,
-    ]),
+    inspect = parseThinCommand(["preset", "inspect", "standard-task", "--locale", "en-US"]),
+    check = parseThinCommand(["preset", "check", "standard-task", "--snapshot-digest", `sha256:${"a".repeat(64)}`]),
     validate = parseThinCommand(["preset", "validate", "--source", "package"]),
-    install = parseThinCommand([
-      "preset",
-      "install",
-      "--source",
-      "package",
-      "--dry-run",
-    ]),
+    install = parseThinCommand(["preset", "install", "--source", "package", "--dry-run"]),
     seed = parseThinCommand(["preset", "seed", "--dry-run"]),
-    audit = parseThinCommand([
-      "preset",
-      "audit",
-      "--vertical",
-      "software/coding",
-    ]),
-    uninstall = parseThinCommand([
-      "preset",
-      "uninstall",
-      "standard-task",
-      "--dry-run",
-    ]),
+    audit = parseThinCommand(["preset", "audit", "--vertical", "software/coding"]),
+    uninstall = parseThinCommand(["preset", "uninstall", "standard-task", "--dry-run"]),
     upgrade = parseThinCommand(["preset", "upgrade", "task-1"]);
   assert.equal(
-    [
-      create,
-      inspect,
-      check,
-      validate,
-      install,
-      seed,
-      audit,
-      uninstall,
-      upgrade,
-    ].every((result) => result.ok),
+    [create, inspect, check, validate, install, seed, audit, uninstall, upgrade].every((result) => result.ok),
     true,
   );
   if (create.ok) {
@@ -416,11 +325,7 @@ test("thin parser derives closed preset and task-create payloads from descriptor
       locale: "en-US",
     });
   }
-  if (check.ok)
-    assert.equal(
-      check.command.action.snapshotDigest,
-      `sha256:${"a".repeat(64)}`,
-    );
+  if (check.ok) assert.equal(check.command.action.snapshotDigest, `sha256:${"a".repeat(64)}`);
   if (validate.ok)
     assert.deepEqual(validate.command.action, {
       kind: "preset-validate",
@@ -456,9 +361,7 @@ test("thin parser derives closed preset and task-create payloads from descriptor
 });
 
 test("thin parser validates only the selected command descriptor", () => {
-  const selected = daemonProtocolCommands.find(
-    (command) => command.id === "task-show",
-  );
+  const selected = daemonProtocolCommands.find((command) => command.id === "task-show");
   assert.ok(selected);
   const unrelatedInvalid = {
       ...selected,
@@ -475,39 +378,24 @@ test("thin parser validates only the selected command descriptor", () => {
 });
 
 test("shared CLI option rejections point to descriptor-derived leaf help", () => {
-  assert.deepEqual(
-    parseThinCommand(["task", "create", "--policy-conformance-probe"]),
-    {
-      ok: false,
-      code: "unknown_field",
-      nextAction:
-        "Unknown option --policy-conformance-probe. Run ha task create --help.",
-      json: false,
-    },
-  );
-  assert.deepEqual(
-    parseThinCommand([
-      "task",
-      "dispatches",
-      "task-1",
-      "--policy-conformance-probe",
-    ]),
-    {
-      ok: false,
-      code: "unsupported_command",
-      nextAction: "Run ha task dispatches --help.",
-      json: false,
-    },
-  );
-  assert.deepEqual(
-    parseThinCommand(["task", "show", "task-1", "--policy-conformance-probe"]),
-    {
-      ok: false,
-      code: "unsupported_command",
-      nextAction: "Run ha task show --help.",
-      json: false,
-    },
-  );
+  assert.deepEqual(parseThinCommand(["task", "create", "--policy-conformance-probe"]), {
+    ok: false,
+    code: "unknown_field",
+    nextAction: "Unknown option --policy-conformance-probe. Run ha task create --help.",
+    json: false,
+  });
+  assert.deepEqual(parseThinCommand(["task", "dispatches", "task-1", "--policy-conformance-probe"]), {
+    ok: false,
+    code: "unsupported_command",
+    nextAction: "Run ha task dispatches --help.",
+    json: false,
+  });
+  assert.deepEqual(parseThinCommand(["task", "show", "task-1", "--policy-conformance-probe"]), {
+    ok: false,
+    code: "unsupported_command",
+    nextAction: "Run ha task show --help.",
+    json: false,
+  });
 });
 
 function captureStdout(run: () => void): string {

--- a/packages/daemon/src/agent-runtime-instance-store.ts
+++ b/packages/daemon/src/agent-runtime-instance-store.ts
@@ -425,6 +425,25 @@ export function openRuntimeInstanceStore(input: {
       };
     }
     const instanceId = requiredRuntimeInstanceText(action.instanceId, "instanceId");
+    if (kind === "runtime-instance-github-credential-set" || kind === "runtime-instance-github-credential-unset") {
+      const current = readOne(instanceId);
+      if (!current)
+        throw runtimeInstanceError("runtime_instance_not_found", `Runtime instance ${instanceId} does not exist.`);
+      const { githubCredentialRef: _githubCredentialRef, ...withoutGithubCredential } = current,
+        updated = runtimeInstanceConfig(
+          kind === "runtime-instance-github-credential-set"
+            ? { ...current, githubCredentialRef: action.githubCredentialRef }
+            : withoutGithubCredential,
+        ),
+        instance = publicConfig(updated, readiness.get(updated.instanceId));
+      persist(read().map((entry) => (entry.instanceId === current.instanceId ? updated : entry)));
+      return {
+        ...base,
+        instance,
+        evidence: JSON.stringify(instance),
+        summary: `${kind}: ${instanceId}`,
+      };
+    }
     if (kind === "runtime-instance-update") {
       const current = readOne(instanceId);
       if (!current)

--- a/packages/daemon/src/daemon-host-runtime-api.ts
+++ b/packages/daemon/src/daemon-host-runtime-api.ts
@@ -115,11 +115,13 @@ export function createDaemonHostRuntimeApi(
       edgeSync: async (payload, auth) => {
         context.localOnly(auth);
         const request = payload as unknown as FleetEdgeSyncRequest["payload"],
-          registered = readDaemonRegistry({ userRoot: context.input.userRoot }).repos
-            .find((repo) => repo.repoId === request.repoId && repo.state === "enabled");
-        const modeMatches = registered !== undefined
-          && registered.mode === "remote-edge"
-          && canonicalRoot(request.workspaceRoot) === canonicalRoot(registered.canonicalRoot);
+          registered = readDaemonRegistry({ userRoot: context.input.userRoot }).repos.find(
+            (repo) => repo.repoId === request.repoId && repo.state === "enabled",
+          );
+        const modeMatches =
+          registered !== undefined &&
+          registered.mode === "remote-edge" &&
+          canonicalRoot(request.workspaceRoot) === canonicalRoot(registered.canonicalRoot);
         if (!modeMatches)
           throw context.hostCodedError(
             "repo_mode_read_only",
@@ -162,12 +164,20 @@ export function createDaemonHostRuntimeApi(
     system: context.system,
     runtimeInstance: async (method, payload, auth) => {
       context.localOnly(auth);
-      const operation = method.replace("daemon.runtimeInstance.", "");
-      if (!["create", "list", "show", "update", "delete"].includes(operation))
+      const operation = method.replace("daemon.runtimeInstance.", ""),
+        actionKind =
+          operation === "githubCredential.set"
+            ? "runtime-instance-github-credential-set"
+            : operation === "githubCredential.unset"
+              ? "runtime-instance-github-credential-unset"
+              : ["create", "list", "show", "update", "delete"].includes(operation)
+                ? `runtime-instance-${operation}`
+                : null;
+      if (!actionKind)
         throw context.hostCodedError("unsupported_command", `Unsupported runtime instance method: ${method}.`);
       return (await context.instances.command({
         ...payload,
-        kind: `runtime-instance-${operation}`,
+        kind: actionKind,
       })) as JsonObject;
     },
     runtimeInstanceAuth: async (repoId, method, payload, auth) => {

--- a/packages/daemon/src/protocol/daemon-protocol-commands-runtime-config.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-runtime-config.ts
@@ -1,6 +1,9 @@
 import { cliInput, defineCliCommand } from "../../../preset/src/preset-command-contract.ts";
 import { daemonRepoModeWords } from "./daemon-protocol-vocabulary.ts";
 
+const credentialReferenceRegex =
+  "^credential:v1:[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$|^keychain:[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$";
+
 export const runtimeConfigProtocolCommands = Object.freeze([
   defineCliCommand({
     id: "daemon-projection-rebuild",
@@ -192,9 +195,7 @@ export const runtimeConfigProtocolCommands = Object.freeze([
             "resolve on macOS only); never pass the API key.",
           ].join(""),
         },
-        {
-          regex: "^credential:v1:[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$|^keychain:[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$",
-        },
+        { regex: credentialReferenceRegex },
       ),
       cliInput(
         "--github-credential-ref",
@@ -207,11 +208,43 @@ export const runtimeConfigProtocolCommands = Object.freeze([
             "resolve on macOS only); never pass the GitHub token.",
           ].join(""),
         },
-        {
-          regex: "^credential:v1:[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$|^keychain:[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$",
-        },
+        { regex: credentialReferenceRegex },
       ),
     ],
+  }),
+  defineCliCommand({
+    id: "runtime-instance-github-credential-set",
+    phase: "Runtime-Instances-S1",
+    path: ["runtime", "instance", "github-credential", "set", "<instance-id>"],
+    positional: "instanceId",
+    summary: "Bind a GitHub credential reference to an existing runtime instance.",
+    method: "daemon.runtimeInstance.githubCredential.set",
+    commandClass: "admin",
+    inputs: [
+      cliInput(
+        "--ref",
+        "single",
+        true,
+        {
+          code: "invalid_field",
+          nextAction: [
+            "Use an opaque credential:v1 reference (legacy keychain: references ",
+            "resolve on macOS only); never pass the GitHub token.",
+          ].join(""),
+        },
+        { regex: credentialReferenceRegex },
+      ),
+    ],
+  }),
+  defineCliCommand({
+    id: "runtime-instance-github-credential-unset",
+    phase: "Runtime-Instances-S1",
+    path: ["runtime", "instance", "github-credential", "unset", "<instance-id>"],
+    positional: "instanceId",
+    summary: "Unbind the GitHub credential reference from an existing runtime instance.",
+    method: "daemon.runtimeInstance.githubCredential.unset",
+    commandClass: "admin",
+    inputs: [],
   }),
   defineCliCommand({
     id: "runtime-instance-list",

--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -181,6 +181,27 @@ export const runtimeInstanceMethods = Object.freeze([
   },
 ] as const);
 
+export const runtimeInstanceCredentialMethods = Object.freeze([
+  {
+    id: "daemon.runtimeInstance.githubCredential.set",
+    phase: "Runtime-Instances-S1",
+    method: "daemon.runtimeInstance.githubCredential.set",
+    requiresRepo: false,
+    params: shape({
+      payload: shape({ instanceId: "string", githubCredentialRef: "string" }),
+    }),
+  },
+  {
+    id: "daemon.runtimeInstance.githubCredential.unset",
+    phase: "Runtime-Instances-S1",
+    method: "daemon.runtimeInstance.githubCredential.unset",
+    requiresRepo: false,
+    params: shape({
+      payload: shape({ instanceId: "string" }),
+    }),
+  },
+] as const);
+
 export const runtimeInstanceAuthMethods = Object.freeze([
   {
     id: "repo.runtimeInstance.auth.login",
@@ -328,6 +349,7 @@ export const fleetProtocolMethods = Object.freeze([
 export const allDaemonProtocolMethods = Object.freeze([
   ...daemonProtocolMethods,
   ...runtimeInstanceMethods,
+  ...runtimeInstanceCredentialMethods,
   ...runtimeInstanceAuthMethods,
   ...fleetProtocolMethods,
   ...presetMethods,
@@ -378,6 +400,7 @@ export default Object.freeze({
   methods: Object.freeze([
     ...daemonProtocolMethods,
     ...runtimeInstanceMethods,
+    ...runtimeInstanceCredentialMethods,
     ...runtimeInstanceAuthMethods,
     ...fleetProtocolMethods,
     ...daemonGuiReadMethods,

--- a/packages/daemon/test/runtime-worker-github-credential-binding.test.ts
+++ b/packages/daemon/test/runtime-worker-github-credential-binding.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -16,47 +16,47 @@ const installation: RuntimeInstallationWitness = {
   observedAt: "2026-08-25T00:00:00.000Z",
 };
 
-test("runtime instance create accepts a distinct GitHub credential reference", () => {
-  const parsed = parseThinCommand([
-    "runtime",
-    "instance",
-    "create",
-    "--id",
-    "codex-github-worker",
-    "--name",
-    "Codex GitHub Worker",
-    "--kind",
-    "codex",
-    "--installation",
-    installation.installationId,
-    "--provider",
-    "openai",
-    "--model",
-    "gpt-5.6-sol",
-    "--auth",
-    "subscription",
-    "--github-credential-ref",
-    "credential:v1:github-worker",
-  ]);
+test("runtime instance GitHub credential set and unset parse as instance-scoped commands", () => {
+  const set = parseThinCommand([
+      "runtime",
+      "instance",
+      "github-credential",
+      "set",
+      "codex-github-worker",
+      "--ref",
+      "keychain:harness/github-worker",
+    ]),
+    unset = parseThinCommand(["runtime", "instance", "github-credential", "unset", "codex-github-worker"]);
 
-  assert.equal(parsed.ok, true);
-  if (!parsed.ok) return;
-  assert.equal(parsed.command.method, "daemon.runtimeInstance.create");
-  assert.deepEqual(parsed.command.action, {
-    kind: "runtime-instance-create",
+  assert.equal(set.ok, true, JSON.stringify(set));
+  assert.equal(unset.ok, true, JSON.stringify(unset));
+  if (!set.ok || !unset.ok) return;
+  assert.equal(set.command.method, "daemon.runtimeInstance.githubCredential.set");
+  assert.deepEqual(set.command.action, {
+    kind: "runtime-instance-github-credential-set",
     instanceId: "codex-github-worker",
-    name: "Codex GitHub Worker",
-    kindId: "codex",
-    installationId: installation.installationId,
-    providerId: "openai",
-    models: ["gpt-5.6-sol"],
-    codex: {},
-    authMode: "subscription",
-    githubCredentialRef: "credential:v1:github-worker",
+    githubCredentialRef: "keychain:harness/github-worker",
   });
+  assert.equal(unset.command.method, "daemon.runtimeInstance.githubCredential.unset");
+  assert.deepEqual(unset.command.action, {
+    kind: "runtime-instance-github-credential-unset",
+    instanceId: "codex-github-worker",
+  });
+  assert.equal(
+    parseThinCommand([
+      "runtime",
+      "instance",
+      "github-credential",
+      "set",
+      "codex-github-worker",
+      "--ref",
+      "plaintext-token",
+    ]).ok,
+    false,
+  );
 });
 
-test("GitHub credentials resolve only into the worker Git environment and stay out of public receipts", async () => {
+test("set, unset, and show project only GitHub credential state without rebuilding the instance", async () => {
   const userRoot = mkdtempSync(path.join(tmpdir(), "ha-runtime-github-credential-")),
     secret = randomUUID(),
     reference = "credential:v1:github-worker";
@@ -81,10 +81,17 @@ test("GitHub credentials resolve only into the worker Git environment and stay o
       enabled: true,
       codex: {},
       auth: { mode: "subscription" },
-      githubCredentialRef: reference,
     });
+    const providerAuth = store.read("codex-github-worker")!.auth,
+      stateMarker = path.join(userRoot, "runtime-instances", "codex-github-worker", "binding-marker");
+    writeFileSync(stateMarker, "preserved");
 
-    const environment = await store.prepareWorkerGitEnvironment("codex-github-worker"),
+    const bound = store.command({
+        kind: "runtime-instance-github-credential-set",
+        instanceId: "codex-github-worker",
+        githubCredentialRef: reference,
+      }),
+      environment = await store.prepareWorkerGitEnvironment("codex-github-worker"),
       shown = store.command({ kind: "runtime-instance-show", instanceId: "codex-github-worker" });
     assert.deepEqual(environment, {
       HARNESS_GITHUB_TOKEN: secret,
@@ -92,8 +99,23 @@ test("GitHub credentials resolve only into the worker Git environment and stay o
       GIT_TERMINAL_PROMPT: "0",
     });
     assert.equal((shown.instance as Record<string, unknown>).githubCredentialState, "configured");
-    assert.doesNotMatch(JSON.stringify(shown), new RegExp(secret, "u"));
-    assert.doesNotMatch(JSON.stringify(shown), /credential:v1:github-worker|githubCredentialRef/u);
+    for (const receipt of [bound, shown]) {
+      assert.doesNotMatch(JSON.stringify(receipt), new RegExp(secret, "u"));
+      assert.doesNotMatch(JSON.stringify(receipt), /credential:v1:github-worker|githubCredentialRef/u);
+    }
+
+    const unbound = store.command({
+        kind: "runtime-instance-github-credential-unset",
+        instanceId: "codex-github-worker",
+      }),
+      shownAfterUnset = store.command({ kind: "runtime-instance-show", instanceId: "codex-github-worker" });
+    assert.equal("githubCredentialState" in (unbound.instance as Record<string, unknown>), false);
+    assert.equal("githubCredentialState" in (shownAfterUnset.instance as Record<string, unknown>), false);
+    assert.equal(await store.prepareWorkerGitEnvironment("codex-github-worker"), null);
+    assert.deepEqual(store.read("codex-github-worker")!.auth, providerAuth);
+    assert.equal(readFileSync(stateMarker, "utf8"), "preserved");
+    for (const receipt of [unbound, shownAfterUnset])
+      assert.doesNotMatch(JSON.stringify(receipt), /credential:v1:github-worker|githubCredentialRef/u);
   } finally {
     rmSync(userRoot, { recursive: true, force: true });
   }

--- a/packages/daemon/test/runtime-worker-github-credentials.integration.test.ts
+++ b/packages/daemon/test/runtime-worker-github-credentials.integration.test.ts
@@ -65,6 +65,10 @@ test("task-bound runtime settlement pushes only its own codex branch with the bo
       permissionMode: "read-only",
       codex: {},
       auth: { mode: "subscription" },
+    });
+    const bound = instances.command({
+      kind: "runtime-instance-github-credential-set",
+      instanceId,
       githubCredentialRef: credentialRef,
     });
 
@@ -145,9 +149,12 @@ test("task-bound runtime settlement pushes only its own codex branch with the bo
         "utf8",
       );
     assert.equal((shown.instance as Record<string, unknown>).githubCredentialState, "configured");
-    for (const observed of [shown, events, stream]) {
+    const unsetReceipt = instances.command({ kind: "runtime-instance-github-credential-unset", instanceId });
+    assert.equal("githubCredentialState" in (unsetReceipt.instance as Record<string, unknown>), false);
+    assert.equal(await instances.prepareWorkerGitEnvironment(instanceId), null);
+    for (const observed of [bound, shown, unsetReceipt, events, stream]) {
       assert.doesNotMatch(JSON.stringify(observed), new RegExp(secret, "u"));
-      assert.doesNotMatch(JSON.stringify(observed), /githubCredentialRef/u);
+      assert.doesNotMatch(JSON.stringify(observed), /githubCredentialRef|credential:v1:github-worker/u);
     }
   } finally {
     await cell?.close();


### PR DESCRIPTION
# English

## Summary

PR #1820 added `--github-credential-ref`, but only on `ha runtime instance create`, and `instance update` is contractually credential-free, so an existing subscription instance (`test-codex-sol`, logged in) could not be bound to a GitHub credential without being deleted and recreated. This PR adds `ha runtime instance github-credential set <instance> --ref <credential:v1:…|keychain:svc/acct>` and `… unset <instance>`: instance-level, no recreate, provider credential untouched, same credential port and secure storage; `instance show` still exposes only `githubCredentialState`.

## Architectural Justification

-

## What Changed

- `packages/cli` + `packages/daemon`: new `github-credential set/unset` subcommands on the runtime instance surface; `update` keeps its 'does not touch credentials' contract.
- Reuses the existing credential port and `credential:v1` / `keychain:` reference syntax (macOS keychain resolution already covered by contract tests); no new store or persisted schema.
- Tests: contract coverage for set/unset/show projection; a bare-remote integration test proves a task-bound worker can push after binding.

## Machine-Readable Declarations

Production-Delta: +109/-53

## Task And Scope

- Harness task: task_535b62405ce635aa54b0773edd (PLT-Ontology Phase 0.23)
- Branch: `codex/gh-cred-bind`
- Public scope: runtime instance CLI/daemon surface for GitHub credential binding, tests
- Private planning/evidence updated: yes (artifacts/reports/gh-cred-bind.md)
- Out of scope: binding a real credential to test-codex-sol and a real GitHub push (CEO action after merge)

## Version Impact

- Version: no version change because this is a pre-release fix on the rebuild line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_535b62405ce635aa54b0773edd (PLT-Ontology Phase 0.23); Zeyu ruling 2026-08-25 #5 (inject GitHub credentials so workers can push); CEO finding that --github-credential-ref existed only on instance create
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 7c942e944
- Branch merge-base with `origin/main`: 7c942e944
- Last `git fetch origin` time: 2026-08-25T22:00Z
- Sync method: rebase
- Public diff command: `git diff 7c942e944..3ac7ea0e9`
- Private evidence commit/path: harness task package task_535b62405ce635aa54b0773edd artifacts/reports
- Reviewer evidence path: worker report gh-cred-bind.md: fresh clone + fresh npm ci `npm run check:local` fast 352/352 contract 646/646; both schema gates ok with effect physically removed; Ubuntu isolated bare-remote integration 1/1; control-character scan (rg --pcre2) empty; CEO read the command surface diff and the show projection
- GitHub Actions `rewrite-ci` run URL: pending (filled after the run)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test` (contract tests for set/unset/show, bare-remote integration via tools/dispatch-isolated-test.mjs)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: real keychain item on test-codex-sol and real GitHub HTTPS push (needs CEO-provided credential); full GitHub shard matrix locally

## Review Evidence

- Self-review: CEO: this is the missing half of #1820 — the binding command an operator actually needs; it adds no second credential store and keeps the subscription/API-key exclusion intact.
- Reviewer subagent: yes (read-only report audit with independent git verification)
- Human review: pending
- Blocking findings: none

## Residual Risk

- Real GitHub push through a keychain reference remains unverified until the CEO binds one; if keychain resolution differs on Linux the bare-remote test would not catch it.

## References

- Task: task_535b62405ce635aa54b0773edd
- Evidence: artifacts/reports/gh-cred-bind.md
- Review: pending

---

# 中文

## 概要

PR #1820 加了 `--github-credential-ref`,但只在 `ha runtime instance create` 上,而 `instance update` 的契约是不碰凭证——已登录的订阅实例(`test-codex-sol`)要绑 GitHub 凭证只能删了重建。本 PR 新增 `ha runtime instance github-credential set <instance> --ref <credential:v1:…|keychain:svc/acct>` 与 `… unset <instance>`:实例级、不重建、不碰 provider 凭证、复用同一 credential port 与安全存储;`instance show` 仍只暴露 `githubCredentialState`。

## 架构辩护

-

## 改动内容

- `packages/cli` + `packages/daemon`:runtime instance 面新增 `github-credential set/unset` 子命令;`update` 保持「不碰凭证」契约。
- 复用既有 credential port 与 `credential:v1` / `keychain:` 引用语法(macOS keychain 解析已有 contract 覆盖);不新增存储或持久化 schema。
- 测试:set/unset/show 投影的 contract 覆盖;bare-remote integration 证明绑定后 task-bound worker 可 push。

## 机读声明说明

- 机读声明只在英文块出现一次。

## 任务与范围

- Harness 任务:task_535b62405ce635aa54b0773edd(PLT-Ontology Phase 0.23)
- 分支:`codex/gh-cred-bind`
- 公开范围:runtime instance 的 GitHub 凭证绑定 CLI/daemon 面、测试
- 私有计划 / 证据是否已更新:yes(artifacts/reports/gh-cred-bind.md)
- 范围外:给 test-codex-sol 绑真实凭证并真实 push(合入后 CEO 动作)

## 版本影响

- 版本:不改版本,原因是 rebuild 线 pre-release 修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_535b62405ce635aa54b0773edd (PLT-Ontology Phase 0.23); Zeyu ruling 2026-08-25 #5 (inject GitHub credentials so workers can push); CEO finding that --github-credential-ref existed only on instance create
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:7c942e944
- 当前分支与 `origin/main` 的 merge-base:7c942e944
- 最近一次 `git fetch origin` 时间:2026-08-25T22:00Z
- 同步方式:rebase
- 公开 diff 命令:`git diff 7c942e944..3ac7ea0e9`
- 私有证据 commit/path:任务包 artifacts/reports
- Reviewer 证据路径:worker 回执 gh-cred-bind.md:fresh clone + fresh npm ci 下 `npm run check:local` fast 352/352、contract 646/646;effect 物理移除后两门 ok;Ubuntu 隔离 bare-remote integration 1/1;控制字符扫描(rg --pcre2)为空;CEO 看过命令面 diff 与 show 投影
- GitHub Actions `rewrite-ci` run URL:待 run 结束后补
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`(set/unset/show contract 测试、经 tools/dispatch-isolated-test.mjs 的 bare-remote integration)
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:test-codex-sol 上的真实 keychain 项与真实 GitHub HTTPS push(需 CEO 提供凭证);完整 GitHub shard 矩阵未在本地跑

## 审查证据

- 自查:CEO:这是 #1820 缺的另一半——操作者真正需要的绑定命令;不加第二个凭证存储,订阅/API-key 互斥不变。
- Reviewer subagent:有(只读回执审计 + git 独立核实)
- 人工审查:待
- 阻塞发现:无

## 残余风险

- keychain 引用的真实 GitHub push 在 CEO 绑定前未验证;若 Linux 上 keychain 解析行为不同,bare-remote 测试抓不到。

## 关联材料

- 任务:task_535b62405ce635aa54b0773edd
- 证据:artifacts/reports/gh-cred-bind.md
- 审查:待

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPPk3TmbURWuxcFY3kFimA

