### PR TITLE
fix(daemon): teach the GUI task-snapshot validator the code-doc repoint shape

### DIFF
--- a/packages/daemon/src/protocol/daemon-protocol-validate-entities.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-entities.ts
@@ -380,6 +380,39 @@ export function codeDoc(value: unknown): boolean {
   );
 }
 
+export function codeDocRepoint(value: unknown): boolean {
+  return (
+    exactRecord(value, [
+      "schema",
+      "recordId",
+      "supersedes",
+      "taskId",
+      "executionId",
+      "commitSha",
+      "iteration",
+      "paths",
+      "disposition",
+      "reason",
+      "actor",
+      "source",
+      "repointedAt",
+    ]) &&
+    value.schema === "code-doc-witness-repoint/v1" &&
+    [value.recordId, value.supersedes, value.taskId, value.executionId, value.reason, value.repointedAt].every(
+      nonEmpty,
+    ) &&
+    sha(value.commitSha) &&
+    iteration(value.iteration) &&
+    stringArray(value.paths) &&
+    ((value.disposition === "repointed" && value.paths.length > 0) ||
+      (value.disposition === "known-invalid" && value.paths.length === 0)) &&
+    actor(value.actor) &&
+    source(value.source)
+  );
+}
+
+export const codeDocRecord = (value: unknown): boolean => codeDoc(value) || codeDocRepoint(value);
+
 export function gate(value: unknown): boolean {
   return (
     exactRecord(value, [

--- a/packages/daemon/src/protocol/daemon-protocol-validate-task.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-task.ts
@@ -1,6 +1,6 @@
 import { DAEMON_TASK_SNAPSHOT_LIST_SCHEMA, DAEMON_WORKSPACE_SUMMARY_SCHEMA } from "./daemon-protocol-schema-ids.ts";
 import {
-  codeDoc,
+  codeDocRecord,
   consent,
   exactRecord,
   execution,
@@ -74,7 +74,7 @@ export function snapshot(value: unknown, availability: unknown): boolean {
     return false;
   const validators = {
     consents: consent,
-    codeDocWitnesses: codeDoc,
+    codeDocWitnesses: codeDocRecord,
     gateWitnesses: gate,
   };
   return known.every((field) => Array.isArray(value[field]) && value[field].every(validators[field]));
@@ -195,37 +195,97 @@ export function validateDaemonTaskSnapshotList(value: unknown): readonly string[
     "placement",
     "executionEvidence",
   ];
+  if (!recordWith(value, DAEMON_TASK_SNAPSHOT_LIST_SCHEMA.required)) return ["daemon task snapshot list is invalid"];
   if (
-    !recordWith(value, DAEMON_TASK_SNAPSHOT_LIST_SCHEMA.required) ||
-    (isJsonObject(value) &&
-      Object.keys(value).some((field) => ![...DAEMON_TASK_SNAPSHOT_LIST_SCHEMA.required, "page"].includes(field))) ||
+    Object.keys(value).some((field) => ![...DAEMON_TASK_SNAPSHOT_LIST_SCHEMA.required, "page"].includes(field)) ||
     value.ok !== true ||
     (value.status !== "ready" && value.status !== "pending") ||
     !integer(value.watermark) ||
     !integer(value.sourceRevision) ||
     !warningArray(value.warnings) ||
     (value.page !== undefined && !queryPageRow(value.page)) ||
-    !Array.isArray(value.rows) ||
-    value.rows.some(
-      (row) =>
-        !exactRecord(row, rowFields) ||
-        !nonEmpty(row.taskId) ||
-        (row.packagePath !== null && !nonEmpty(row.packagePath)) ||
-        (row.generation !== "v0" && row.generation !== "v1") ||
-        !integer(row.workspaceRevision) ||
-        (row.createdAt !== null && !nonEmpty(row.createdAt)) ||
-        !nonEmpty(row.updatedAt) ||
-        !statusWord([...taskStatusWords, "unknown"], row.coordinationStatus) ||
-        !snapshot(row.snapshot, row.snapshotAvailability) ||
-        !closeoutAssessment(row.closeoutAssessment) ||
-        !blockingAssessment(row.blockingAssessment) ||
-        !placement(row.placement) ||
-        !Array.isArray(row.executionEvidence) ||
-        row.executionEvidence.some((item) => !executionEvidence(item)),
-    )
+    !Array.isArray(value.rows)
   )
     return ["daemon task snapshot list is invalid"];
-  return [];
+  return value.rows.flatMap((row, index) => taskSnapshotRowErrors(row, index, rowFields));
+}
+
+function taskSnapshotRowErrors(value: unknown, index: number, rowFields: readonly string[]): readonly string[] {
+  const taskId = isJsonObject(value) && nonEmpty(value.taskId) ? value.taskId : "<unknown>",
+    error = (field: string) =>
+      `daemon task snapshot taskId=${taskId} field=rows[${index}]${field ? `.${field}` : ""} is invalid`;
+  if (!exactRecord(value, rowFields)) return [error("")];
+  const errors: string[] = [];
+  if (!nonEmpty(value.taskId)) errors.push(error("taskId"));
+  if (value.packagePath !== null && !nonEmpty(value.packagePath)) errors.push(error("packagePath"));
+  if (value.generation !== "v0" && value.generation !== "v1") errors.push(error("generation"));
+  if (!integer(value.workspaceRevision)) errors.push(error("workspaceRevision"));
+  if (value.createdAt !== null && !nonEmpty(value.createdAt)) errors.push(error("createdAt"));
+  if (!nonEmpty(value.updatedAt)) errors.push(error("updatedAt"));
+  if (!statusWord([...taskStatusWords, "unknown"], value.coordinationStatus)) errors.push(error("coordinationStatus"));
+  if (!snapshot(value.snapshot, value.snapshotAvailability))
+    errors.push(...snapshotFailurePaths(value.snapshot, value.snapshotAvailability).map(error));
+  if (!closeoutAssessment(value.closeoutAssessment)) errors.push(error("closeoutAssessment"));
+  if (!blockingAssessment(value.blockingAssessment)) errors.push(error("blockingAssessment"));
+  if (!placement(value.placement)) errors.push(error("placement"));
+  if (!Array.isArray(value.executionEvidence)) errors.push(error("executionEvidence"));
+  else
+    value.executionEvidence.forEach((item, evidenceIndex) => {
+      if (!executionEvidence(item)) errors.push(error(`executionEvidence[${evidenceIndex}]`));
+    });
+  return errors;
+}
+
+function snapshotFailurePaths(value: unknown, availability: unknown): readonly string[] {
+  if (
+    !exactRecord(availability, availabilityFields) ||
+    availabilityFields.some((field) => availability[field] !== "known" && availability[field] !== "unknown")
+  )
+    return ["snapshotAvailability"];
+  if (!isJsonObject(value)) return ["snapshot"];
+  const known = availabilityFields.filter((field) => availability[field] === "known"),
+    paths: string[] = [];
+  if (!exactRecord(value, [...snapshotBaseFields, ...known])) paths.push("snapshot");
+  if (!integer(value.revision)) paths.push("snapshot.revision");
+  if (value.task !== null && !task(value.task)) paths.push("snapshot.task");
+  for (const [field, validate] of [
+    ["executions", execution],
+    ["reviews", review],
+  ] as const) {
+    const rows = value[field];
+    if (!Array.isArray(rows)) paths.push(`snapshot.${field}`);
+    else rows.forEach((row, index) => !validate(row) && paths.push(`snapshot.${field}[${index}]`));
+  }
+  if (
+    !Array.isArray(value.edgesTaken) ||
+    value.edgesTaken.some(
+      (edge) =>
+        !exactRecord(edge, ["edgeId", "from", "to", "on", "actorRole", "reason", "commitSha", "iteration"]) ||
+        !nonEmpty(edge.edgeId) ||
+        !nonEmpty(edge.reason) ||
+        !sha(edge.commitSha) ||
+        !iteration(edge.iteration),
+    )
+  )
+    paths.push("snapshot.edgesTaken");
+  if (value.lease !== null && !lease(value.lease)) paths.push("snapshot.lease");
+  if (
+    !Array.isArray(value.decisionRelations) ||
+    value.decisionRelations.some(
+      (relation) =>
+        !exactRecord(relation, ["relationId", "sourceRef", "targetRef", "relationType", "state"]) ||
+        ![relation.relationId, relation.sourceRef, relation.targetRef, relation.relationType].every(nonEmpty) ||
+        !statusWord(relationStateWords, relation.state),
+    )
+  )
+    paths.push("snapshot.decisionRelations");
+  const validators = { consents: consent, codeDocWitnesses: codeDocRecord, gateWitnesses: gate };
+  for (const field of known) {
+    const rows = value[field];
+    if (!Array.isArray(rows)) paths.push(`snapshot.${field}`);
+    else rows.forEach((row, index) => !validators[field](row) && paths.push(`snapshot.${field}[${index}]`));
+  }
+  return paths.length ? [...new Set(paths)] : ["snapshot"];
 }
 
 export function validateDaemonWorkspaceSummary(value: unknown): readonly string[] {

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -446,6 +446,7 @@ test("code-doc repoint appends a replacement witness and rejects stale or unknow
     assert.equal(lines[1]!.disposition, "repointed");
     const projection = await cell.read("repo.tasks.list"),
       row = projection.rows.find((value) => value.taskId === taskId)!;
+    assert.deepEqual(validateDaemonTaskSnapshotList(projection), []);
     assert.equal(
       row.closeoutAssessment.gates.find((gate) => gate.gateId === "code-doc-reconciliation")?.status,
       "passed",
@@ -480,6 +481,7 @@ test("code-doc repoint appends a replacement witness and rejects stale or unknow
     assert.equal(invalidLines[2]!.disposition, "known-invalid");
     const invalidProjection = await cell.read("repo.tasks.list"),
       invalidRow = invalidProjection.rows.find((value) => value.taskId === taskId)!;
+    assert.deepEqual(validateDaemonTaskSnapshotList(invalidProjection), []);
     assert.equal(
       invalidRow.closeoutAssessment.gates.find((gate) => gate.gateId === "code-doc-reconciliation")?.status,
       "missing",

--- a/packages/daemon/test/task-snapshot-protocol.contract.test.ts
+++ b/packages/daemon/test/task-snapshot-protocol.contract.test.ts
@@ -1,0 +1,75 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { validateDaemonTaskSnapshotList } from "../src/protocol/daemon-protocol.contract.ts";
+
+const actor = { principal: { personId: "person-owner" }, executor: null } as const;
+const repoint = {
+  schema: "code-doc-witness-repoint/v1",
+  recordId: "code-doc-repoint-0123456789abcdef",
+  supersedes: "code-doc-0123456789abcdef",
+  taskId: "task-repoint",
+  executionId: "execution-repoint",
+  commitSha: "a".repeat(40),
+  iteration: 0,
+  paths: ["tasks/task-repoint/report.md"],
+  disposition: "repointed",
+  reason: "Correct the ledger-root path.",
+  actor,
+  source: "local",
+  repointedAt: "2026-08-25T00:00:00.000Z",
+} as const;
+const row = {
+  taskId: "task-repoint",
+  packagePath: null,
+  generation: "v1",
+  workspaceRevision: 1,
+  createdAt: null,
+  updatedAt: "2026-08-25T00:00:00.000Z",
+  snapshot: {
+    revision: 1,
+    task: null,
+    executions: [],
+    reviews: [],
+    edgesTaken: [],
+    lease: null,
+    decisionRelations: [],
+    consents: [],
+    codeDocWitnesses: [repoint],
+    gateWitnesses: [],
+  },
+  coordinationStatus: "unknown",
+  snapshotAvailability: { consents: "known", codeDocWitnesses: "known", gateWitnesses: "known" },
+  closeoutAssessment: { readiness: "missing", blocker: "execution", gates: [] },
+  blockingAssessment: { taskId: "task-repoint", state: "clear", blockers: [], warnings: [] },
+  placement: {
+    moduleKeys: [],
+    productLines: [],
+    parentTaskId: null,
+    origin: "native",
+    engine: "kernel/task-lifecycle/v1",
+    packageDisposition: "active",
+    provenance: [{ kind: "canonical-event", ref: "task/task-repoint" }],
+  },
+  executionEvidence: [],
+} as const;
+const list = { ok: true, status: "ready", watermark: 1, sourceRevision: 1, warnings: [], rows: [row] } as const;
+
+test("task snapshot protocol accepts audited code-doc repoints", () => {
+  assert.deepEqual(validateDaemonTaskSnapshotList(list), []);
+});
+
+test("task snapshot protocol identifies the task and malformed field", () => {
+  const invalid = {
+    ...list,
+    rows: [
+      {
+        ...row,
+        snapshot: { ...row.snapshot, codeDocWitnesses: [{ ...repoint, reason: "" }] },
+      },
+    ],
+  };
+  assert.deepEqual(validateDaemonTaskSnapshotList(invalid), [
+    "daemon task snapshot taskId=task-repoint field=rows[0].snapshot.codeDocWitnesses[0] is invalid",
+  ]);
+});


### PR DESCRIPTION
# English

## Summary

The GUI task board showed refresh-failed for 13 hours: daemon returned invalid_result for repo.tasks.list on 7546/7557 calls, while the CLI write path stayed green. Root cause: seven tasks carry a legitimate append-only code-doc-witness-repoint/v1 audit event in snapshot.codeDocWitnesses[1], a union member the wire result validator did not know, so it rejected the whole list with the single string 'daemon task snapshot list is invalid'. This PR teaches the validator the repoint shape and makes every task-snapshot validation error carry the taskId, field path and array index. It does not hide or rewrite the audit events.

## Architectural Justification

-

## What Changed

- packages/daemon/src/protocol/daemon-protocol-validate-entities.ts: accept the legit code-doc-witness-repoint/v1 shape.
- packages/daemon/src/protocol/daemon-protocol-validate-task.ts: failure strings now include taskId + field path + array index (e.g. snapshot.codeDocWitnesses[1]).
- New contract test for the repoint snapshot and a real repoint integration assertion.

## Machine-Readable Declarations

Production-Delta: +117/-24

## Task And Scope

- Harness task: task_444d80767ade3dcfc3f6a5dbbb (PLT-Ontology Phase 0.25)
- Branch: `codex/gui-tasks-list`
- Public scope: daemon GUI-read wire validators for task snapshots, tests
- Private planning/evidence updated: yes (artifacts/reports/gui-tasks-list.md)
- Out of scope: the broader validator-detail sweep across every validate* (Phase 0.28) and the live read-path probe (Phase 0.26)

## Version Impact

- Version: no version change because this is a pre-release fix on the rebuild line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_444d80767ade3dcfc3f6a5dbbb (PLT-Ontology Phase 0.25); CEO 2026-08-25 (GUI board refresh failed 13h; fix the validator's missing legit shape, not by relaxing it)
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 9d3a31d4
- Branch merge-base with `origin/main`: 9d3a31d4
- Last `git fetch origin` time: 2026-08-25T22:55Z
- Sync method: rebase
- Public diff command: `git diff 9d3a31d4..7be5fef70`
- Private evidence commit/path: harness task package task_444d80767ade3dcfc3f6a5dbbb artifacts/reports
- Reviewer evidence path: worker report gui-tasks-list.md: before fix canonical 1643 rows badRowCount=7 generic invalid_result; after rebase 1644 rows listErrors=[] badRowCount=0; check:local 46/46 fast 355/355 contract 654/654; Ubuntu isolated contract 2/2 integration 52/52; both schema gates ok with effect removed; control-char scan empty; CEO read the seven bad taskIds all failing at snapshot.codeDocWitnesses[1] and confirmed the fix teaches a legit union rather than relaxing the schema
- GitHub Actions `rewrite-ci` run URL: pending (filled after the run)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test` (task-snapshot protocol contract test, repoint integration assertion (Ubuntu fresh npm ci))
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: production daemon not yet on this commit, so 'GUI conn log 20 consecutive ok' awaits CEO deploy+restart; GUI e2e

## Review Evidence

- Self-review: CEO: the board being dark for 13h with the CLI green is exactly the read-path blind spot this fixes; the error now names the row so the next occurrence is diagnosable in seconds. Deploy = restart daemon after merge.
- Reviewer subagent: yes (read-only report audit with independent git verification)
- Human review: pending
- Blocking findings: none

## Residual Risk

- Any other legit union member still missing from a GUI-read validator would fail the same way until 0.28 sweeps them; the improved error message makes each one a 1-line find.

## References

- Task: task_444d80767ade3dcfc3f6a5dbbb
- Evidence: artifacts/reports/gui-tasks-list.md
- Review: pending

---

# 中文

## 概要

GUI 看板「刷新失败」13 小时:daemon 对 repo.tasks.list 在 7546/7557 次返回 invalid_result,而 CLI 写路径全绿。根因:7 个任务的 snapshot.codeDocWitnesses[1] 带一个合法的 append-only code-doc-witness-repoint/v1 审计事件,wire 结果校验器不认这个联合成员,于是把整张列表用一句「daemon task snapshot list is invalid」拒掉。本 PR 教会校验器这个 repoint 形状,并让每条 task-snapshot 校验错误带 taskId、字段路径、数组索引;不隐藏也不改写审计事件。

## 架构辩护

-

## 改动内容

- daemon-protocol-validate-entities.ts:接受合法 code-doc-witness-repoint/v1 形状。
- daemon-protocol-validate-task.ts:失败信息含 taskId + 字段路径 + 数组索引(如 snapshot.codeDocWitnesses[1])。
- 新增 repoint snapshot contract 测试与真实 repoint integration 断言。

## 机读声明说明

- 机读声明只在英文块出现一次。

## 任务与范围

- Harness 任务:task_444d80767ade3dcfc3f6a5dbbb(PLT-Ontology Phase 0.25)
- 分支:`codex/gui-tasks-list`
- 公开范围:daemon GUI 读的 task snapshot wire 校验器、测试
- 私有计划 / 证据是否已更新:yes(artifacts/reports/gui-tasks-list.md)
- 范围外:覆盖所有 validate* 的校验器纪律普查(0.28)与活读路径探针(0.26)

## 版本影响

- 版本:不改版本,原因是 rebuild 线 pre-release 修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_444d80767ade3dcfc3f6a5dbbb (PLT-Ontology Phase 0.25); CEO 2026-08-25 (GUI board refresh failed 13h; fix the validator's missing legit shape, not by relaxing it)
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:9d3a31d4
- 当前分支与 `origin/main` 的 merge-base:9d3a31d4
- 最近一次 `git fetch origin` 时间:2026-08-25T22:55Z
- 同步方式:rebase
- 公开 diff 命令:`git diff 9d3a31d4..7be5fef70`
- 私有证据 commit/path:任务包 artifacts/reports
- Reviewer 证据路径:worker 回执:修前 canonical 1643 行 badRowCount=7 generic invalid_result;rebase 后 1644 行 listErrors=[] badRowCount=0;check:local 46/46 fast 355/355 contract 654/654;Ubuntu 隔离 contract 2/2 integration 52/52;effect 移除后两门 ok;控制字符扫描空;CEO 核对 7 个坏 taskId 都失败在 snapshot.codeDocWitnesses[1],确认修法是教会合法联合而非放宽 schema
- GitHub Actions `rewrite-ci` run URL:待 run 结束后补
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`(task-snapshot 协议 contract 测试、repoint integration 断言(Ubuntu fresh npm ci))
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:生产 daemon 尚未部署此 commit,「GUI conn log 连续 20 次 ok」待 CEO 部署+重启验收;GUI e2e

## 审查证据

- 自查:CEO:CLI 绿而看板黑 13 小时正是本 PR 修的读路径盲区;错误现在点名坏行,下次同类几秒定位。部署=合并后重启 daemon。
- Reviewer subagent:有(只读回执审计 + git 独立核实)
- 人工审查:待
- 阻塞发现:无

## 残余风险

- 其它 GUI 读校验器若还漏合法联合成员会同样失败,待 0.28 普查;改进后的错误信息让每处都是一行定位。

## 关联材料

- 任务:task_444d80767ade3dcfc3f6a5dbbb
- 证据:artifacts/reports/gui-tasks-list.md
- 审查:待

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPPk3TmbURWuxcFY3kFimA

