### PR TITLE
refactor(kernel): drive embedded entity projection from kind contracts, forbid generic authoring of lifecycle entities

### DIFF
--- a/packages/daemon/test/task-surface-pages-facts.integration.test.ts
+++ b/packages/daemon/test/task-surface-pages-facts.integration.test.ts
@@ -4,10 +4,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import {
-  canonicalRoot,
-  workspaceId,
-} from "../src/protocol/daemon-protocol.contract.ts";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { openRepoCell } from "../src/repo-cell.ts";
 
 import { actor, evidence, initRepo } from "./task-surface.fixtures.ts";
@@ -31,11 +28,7 @@ test("wide task reads keep byte-identical unparameterized results and serve narr
       ["Epsilon", "Epsilon"],
     ] as const) {
       const taskId = `task_real_${index}`;
-      assert.equal(
-        (await cell.run({ kind: "task-create", taskId, title }, binding))
-          .outcome,
-        "applied",
-      );
+      assert.equal((await cell.run({ kind: "task-create", taskId, title }, binding)).outcome, "applied");
     }
     assert.equal(
       (
@@ -142,9 +135,7 @@ test("wide task reads keep byte-identical unparameterized results and serve narr
     assert.equal(factReceipt.outcome, "applied", JSON.stringify(factReceipt));
 
     const taskBytes = JSON.stringify(await cell.read("repo.tasks.list", {})),
-      graphBytes = JSON.stringify(
-        await cell.read("repo.triadic.relationGraph", {}),
-      );
+      graphBytes = JSON.stringify(await cell.read("repo.triadic.relationGraph", {}));
     const unparameterized = JSON.parse(taskBytes) as {
       page?: unknown;
       rows: {
@@ -152,11 +143,7 @@ test("wide task reads keep byte-identical unparameterized results and serve narr
         blockingAssessment: { blockers: { targetTaskId: string }[] };
       }[];
     };
-    assert.equal(
-      unparameterized.page,
-      undefined,
-      "unparameterized task list must not carry a page facet",
-    );
+    assert.equal(unparameterized.page, undefined, "unparameterized task list must not carry a page facet");
     assert.deepEqual(
       unparameterized.rows
         .find(({ taskId }) => taskId === "task_real_Alpha")
@@ -165,9 +152,9 @@ test("wide task reads keep byte-identical unparameterized results and serve narr
       "unparameterized guiTasks must judge blockers from the complete relation graph",
     );
     const alphaPlacement = (
-      unparameterized.rows.find(
-        ({ taskId }) => taskId === "task_real_Alpha",
-      ) as { placement: { moduleKeys: string[]; productLines: string[] } }
+      unparameterized.rows.find(({ taskId }) => taskId === "task_real_Alpha") as {
+        placement: { moduleKeys: string[]; productLines: string[] };
+      }
     ).placement;
     assert.deepEqual(
       {
@@ -207,10 +194,7 @@ test("wide task reads keep byte-identical unparameterized results and serve narr
     assert.deepEqual(
       windowed.rows.map((row) => row.taskId),
       JSON.parse(taskBytes)
-        .rows.filter(
-          (row: { updatedAt: string }) =>
-            row.updatedAt >= "2026-08-15T00:00:00.000Z",
-        )
+        .rows.filter((row: { updatedAt: string }) => row.updatedAt >= "2026-08-15T00:00:00.000Z")
         .map((row: { taskId: string }) => row.taskId),
     );
     const changed = await cell.read("repo.tasks.list", {
@@ -219,9 +203,7 @@ test("wide task reads keep byte-identical unparameterized results and serve narr
     assert.deepEqual(
       changed.rows.map((row) => row.taskId),
       JSON.parse(taskBytes)
-        .rows.filter(
-          (row: { workspaceRevision: number }) => row.workspaceRevision > 7,
-        )
+        .rows.filter((row: { workspaceRevision: number }) => row.workspaceRevision > 7)
         .map((row: { taskId: string }) => row.taskId),
     );
     let page = await cell.read("repo.tasks.list", { limit: 2 }),
@@ -244,18 +226,15 @@ test("wide task reads keep byte-identical unparameterized results and serve narr
     const graphPage = await cell.read("repo.triadic.relationGraph", {
       limit: 1,
     });
-    const graphEdges = JSON.parse(graphBytes).edges as { relationId: string }[];
-    assert.equal(
-      graphEdges.length,
-      3,
-      `fixture should carry two task edges and one Decision edge, saw ${graphEdges.length}`,
+    const graphEdges = JSON.parse(graphBytes).edges as { relationId: string; relationType: string }[];
+    assert.deepEqual(
+      graphEdges.map((edge) => edge.relationType).sort(),
+      ["depends-on", "depends-on", "derives", "executes", "executes"],
+      "fixture carries two depends-on task edges, one Decision derives edge, and two execution→task executes edges",
     );
     assert.equal(graphPage.edges.length, 1);
     assert.equal(graphPage.page?.limit, 1);
-    assert.ok(
-      graphPage.page?.nextCursor,
-      "one edge per page must leave a next cursor when more edges remain",
-    );
+    assert.ok(graphPage.page?.nextCursor, "one edge per page must leave a next cursor when more edges remain");
     let graphWalk = await cell.read("repo.triadic.relationGraph", { limit: 1 }),
       walked: typeof graphWalk.edges = [];
     while (true) {
@@ -271,9 +250,7 @@ test("wide task reads keep byte-identical unparameterized results and serve narr
       graphEdges.map((edge) => edge.relationId),
       "relation graph pages must concatenate to the unparameterized edges",
     );
-    let taskActionPage = evidence(
-        await cell.run({ kind: "task-list", limit: 2 }, binding),
-      ),
+    let taskActionPage = evidence(await cell.run({ kind: "task-list", limit: 2 }, binding)),
       taskActionRows = [...(taskActionPage.rows as { taskId: string }[])];
     while ((taskActionPage.page as { nextCursor: string | null }).nextCursor) {
       taskActionPage = evidence(
@@ -286,61 +263,38 @@ test("wide task reads keep byte-identical unparameterized results and serve narr
           binding,
         ),
       );
-      taskActionRows = [
-        ...taskActionRows,
-        ...(taskActionPage.rows as { taskId: string }[]),
-      ];
+      taskActionRows = [...taskActionRows, ...(taskActionPage.rows as { taskId: string }[])];
     }
     assert.deepEqual(
       taskActionRows.map(({ taskId }) => taskId),
       unparameterizedRows.map((row: { taskId: string }) => row.taskId),
     );
-    const relationActionFull = evidence(
-      await cell.run({ kind: "relation-list" }, binding),
-    );
-    let relationActionPage = evidence(
-        await cell.run({ kind: "relation-list", limit: 1 }, binding),
-      ),
-      relationActionRows = [
-        ...(relationActionPage.rows as { relationId: string }[]),
-      ];
-    while (
-      (relationActionPage.page as { nextCursor: string | null }).nextCursor
-    ) {
+    const relationActionFull = evidence(await cell.run({ kind: "relation-list" }, binding));
+    let relationActionPage = evidence(await cell.run({ kind: "relation-list", limit: 1 }, binding)),
+      relationActionRows = [...(relationActionPage.rows as { relationId: string }[])];
+    while ((relationActionPage.page as { nextCursor: string | null }).nextCursor) {
       relationActionPage = evidence(
         await cell.run(
           {
             kind: "relation-list",
             limit: 1,
-            cursor: (relationActionPage.page as { nextCursor: string })
-              .nextCursor,
+            cursor: (relationActionPage.page as { nextCursor: string }).nextCursor,
           },
           binding,
         ),
       );
-      relationActionRows = [
-        ...relationActionRows,
-        ...(relationActionPage.rows as { relationId: string }[]),
-      ];
+      relationActionRows = [...relationActionRows, ...(relationActionPage.rows as { relationId: string }[])];
     }
     assert.deepEqual(
       relationActionRows.map(({ relationId }) => relationId),
-      (relationActionFull.rows as { relationId: string }[]).map(
-        ({ relationId }) => relationId,
-      ),
+      (relationActionFull.rows as { relationId: string }[]).map(({ relationId }) => relationId),
     );
     const graphState = await cell.read("repo.triadic.relationGraph", {
       status: "active",
     });
     assert.ok(graphState.edges.every((edge) => edge.state === "active"));
-    await assert.rejects(
-      cell.read("repo.tasks.list", { status: "not-a-status" }),
-      /status is invalid/u,
-    );
-    await assert.rejects(
-      cell.read("repo.triadic.relationGraph", { limit: 0 }),
-      /limit must be an integer/u,
-    );
+    await assert.rejects(cell.read("repo.tasks.list", { status: "not-a-status" }), /status is invalid/u);
+    await assert.rejects(cell.read("repo.triadic.relationGraph", { limit: 0 }), /limit must be an integer/u);
   } finally {
     await cell?.close();
     rmSync(rootDir, { recursive: true, force: true });
@@ -391,18 +345,8 @@ test("fact search action forwards observed-time windows and preserves keyset pag
         ).outcome,
         "applied",
       );
-    const full = evidence(
-        await cell.run(
-          { kind: "fact-search", taskId: "task_fact_query" },
-          binding,
-        ),
-      ),
-      first = evidence(
-        await cell.run(
-          { kind: "fact-search", taskId: "task_fact_query", limit: 2 },
-          binding,
-        ),
-      );
+    const full = evidence(await cell.run({ kind: "fact-search", taskId: "task_fact_query" }, binding)),
+      first = evidence(await cell.run({ kind: "fact-search", taskId: "task_fact_query", limit: 2 }, binding));
     assert.deepEqual(
       (full.facts as { factId: string }[]).map(({ factId }) => factId),
       ["F-00000005", "F-00000004", "F-00000003", "F-00000002", "F-00000001"],
@@ -412,10 +356,7 @@ test("fact search action forwards observed-time windows and preserves keyset pag
       rows = [...(first.facts as { factId: string }[])];
     while (cursor) {
       const next = evidence(
-        await cell.run(
-          { kind: "fact-search", taskId: "task_fact_query", limit: 2, cursor },
-          binding,
-        ),
+        await cell.run({ kind: "fact-search", taskId: "task_fact_query", limit: 2, cursor }, binding),
       );
       rows = [...rows, ...(next.facts as { factId: string }[])];
       cursor = (next.page as { nextCursor: string | null }).nextCursor;
@@ -453,10 +394,7 @@ test("fact search action forwards observed-time windows and preserves keyset pag
         },
         binding,
       ),
-      invalidLimit = await cell.run(
-        { kind: "fact-search", taskId: "task_fact_query", limit: 0 },
-        binding,
-      );
+      invalidLimit = await cell.run({ kind: "fact-search", taskId: "task_fact_query", limit: 0 }, binding);
     const unknownField = await cell.run(
       {
         kind: "fact-search",

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -204,11 +204,24 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
     assert.deepEqual(tasks.rows[0]?.placement.moduleKeys, ["gui"]);
     assert.equal(tasks.rows[0]?.placement.origin, "native");
     const graph = parseDaemonGuiReadResult("repo.triadic.relationGraph", results.get("repo.triadic.relationGraph"));
-    assert.deepEqual(graph.edges.map(({ relationType }) => relationType).sort(), [
-      "derives",
-      "evidenced-by",
-      "executes",
-    ]);
+    assert.deepEqual(
+      graph.edges
+        .map(({ sourceRef, targetRef, relationType }) => ({ sourceRef, targetRef, relationType }))
+        .sort((left, right) =>
+          `${left.relationType}|${left.sourceRef}`.localeCompare(`${right.relationType}|${right.sourceRef}`),
+        ),
+      [
+        { sourceRef: "decision/dec_gui_smoke", targetRef: "task/task-gui-smoke", relationType: "derives" },
+        {
+          sourceRef: "decision/dec_gui_smoke/C1",
+          targetRef: "fact/task-gui-smoke/F-ABCDEFGH",
+          relationType: "evidenced-by",
+        },
+        { sourceRef: "execution/execution-gui-bridge", targetRef: "task/task-gui-smoke", relationType: "executes" },
+        { sourceRef: "runtime-session/runtime-gui", targetRef: "task/task-gui", relationType: "executes" },
+      ],
+      "the execution and the runtime session each carry a distinct executes edge to their task",
+    );
     assert.equal(graph.factAnchors.length, 1);
     assert.equal(graph.facts.length, 1);
     assert.equal(graph.facts[0]?.statement, "The GUI renderer received event-backed triadic rows.");

--- a/packages/kernel/src/domain/entity-event.ts
+++ b/packages/kernel/src/domain/entity-event.ts
@@ -75,10 +75,12 @@ export function compileEntityUpsert(input: {
   readonly occurredAt: string;
 }): EntityUpsertBundle {
   const contract = requireEntityStoreKindContract(input.entityKind);
-  if (contract.authoring.kind !== "generic-entity-store")
-    throw new Error(
-      `Entity kind ${contract.kind} must be authored via lifecycle/runtime events, not generic upsert (${contract.authoring.contractRef}).`,
-    );
+  if (contract.authoring.kind !== "generic-entity-store") {
+    const message =
+      `Entity kind ${contract.kind} must be authored via lifecycle/runtime events, ` +
+      `not generic upsert (${contract.authoring.contractRef}).`;
+    throw new Error(message);
+  }
   const entity = parseEntityJsonSchema(contract.schema, input.entity, `${input.entityKind} declaration`),
     entityId = isRecord(entity) ? entity[contract.id.field] : undefined;
   const contractErrors = contract.entityStore.validate?.(entity) ?? [];

--- a/packages/kernel/src/domain/entity-event.ts
+++ b/packages/kernel/src/domain/entity-event.ts
@@ -74,8 +74,12 @@ export function compileEntityUpsert(input: {
   readonly source: WriteSource;
   readonly occurredAt: string;
 }): EntityUpsertBundle {
-  const contract = requireEntityStoreKindContract(input.entityKind),
-    entity = parseEntityJsonSchema(contract.schema, input.entity, `${input.entityKind} declaration`),
+  const contract = requireEntityStoreKindContract(input.entityKind);
+  if (contract.authoring.kind !== "generic-entity-store")
+    throw new Error(
+      `Entity kind ${contract.kind} must be authored via lifecycle/runtime events, not generic upsert (${contract.authoring.contractRef}).`,
+    );
+  const entity = parseEntityJsonSchema(contract.schema, input.entity, `${input.entityKind} declaration`),
     entityId = isRecord(entity) ? entity[contract.id.field] : undefined;
   const contractErrors = contract.entityStore.validate?.(entity) ?? [];
   if (contractErrors.length) throw new Error(contractErrors.join("; "));

--- a/packages/kernel/src/domain/entity-kind-projection.ts
+++ b/packages/kernel/src/domain/entity-kind-projection.ts
@@ -1,0 +1,148 @@
+import { deriveRelationId } from "./entity-relation.ts";
+import { parseEntityJsonSchema } from "./entity-json-schema.ts";
+import type { EntityKindContract } from "./entity-kind-registry.ts";
+
+export type EntityProjectionContract = Pick<
+  EntityKindContract,
+  "kind" | "schema" | "id" | "relations" | "canonicalProjection"
+>;
+
+export interface InterpretedEntityValue {
+  readonly kind: string;
+  readonly id: string;
+  readonly value: Readonly<Record<string, unknown>>;
+}
+
+export interface InterpretedEntityRelation {
+  readonly relationId: string;
+  readonly sourceRef: string;
+  readonly targetRef: string;
+  readonly relationType: string;
+  readonly direction: "directed";
+  readonly strength: "strong" | "weak";
+  readonly origin: "generated" | "inferred";
+  readonly state: "active";
+  readonly rationale: string;
+  readonly ownerRef: string;
+  readonly sourcePath: string;
+  readonly recordIndex: number;
+}
+
+export interface InterpretedEntityProjection extends InterpretedEntityValue {
+  readonly ownerId: string;
+  readonly workspaceRevision: number;
+  readonly relations: readonly InterpretedEntityRelation[];
+}
+
+interface CanonicalEventShape {
+  readonly schema: string;
+  readonly type: string;
+  readonly opId: string;
+  readonly workspaceRevision: number;
+  readonly payload: unknown;
+}
+
+export function interpretEntityValue(
+  contract: Pick<EntityKindContract, "kind" | "schema" | "id">,
+  value: unknown,
+  label = `${contract.kind} declaration`,
+): InterpretedEntityValue {
+  const parsed = parseEntityJsonSchema(contract.schema, value, label);
+  if (!isEntityRecord(parsed)) throw new Error(`${label} must be an object`);
+  const id = parsed[contract.id.field];
+  if (typeof id !== "string") throw new Error(`${label} has no string identity`);
+  return { kind: contract.kind, id, value: parsed };
+}
+
+export function interpretEntityProjection(
+  contract: EntityProjectionContract,
+  value: unknown,
+  workspaceRevision: number,
+  sourcePath: string,
+): InterpretedEntityProjection | null {
+  return deriveEntityProjection(contract, interpretEntityValue(contract, value), workspaceRevision, sourcePath);
+}
+
+export function deriveEntityProjection(
+  contract: EntityProjectionContract,
+  entity: InterpretedEntityValue,
+  workspaceRevision: number,
+  sourcePath: string,
+): InterpretedEntityProjection | null {
+  const declaration = contract.canonicalProjection;
+  if (declaration === null) return null;
+  if (entity.kind !== contract.kind) throw new Error(`${entity.kind} cannot be projected by ${contract.kind}`);
+  const rowId = stringField(entity.value, declaration.row.idField, `${contract.kind} projection identity`),
+    ownerId = stringField(entity.value, declaration.row.ownerField, `${contract.kind} projection owner`);
+  if (rowId !== entity.id)
+    throw new Error(`${contract.kind} projection identity does not match its EntityKindContract identity`);
+  const relations = contract.relations.edges.flatMap((edge, recordIndex) => {
+    const projection = edge.projection;
+    if (projection === undefined) return [];
+    const sourceId = stringField(entity.value, projection.source.field, `${contract.kind} relation source`),
+      targetId = stringField(entity.value, projection.target.field, `${contract.kind} relation target`),
+      sourceRef = applyRefTemplate(projection.source.refTemplate, sourceId),
+      targetRef = applyRefTemplate(projection.target.refTemplate, targetId),
+      relationId = deriveRelationId({ source: sourceRef, target: targetRef, type: edge.type, direction: "directed" });
+    if (sourceId !== entity.id)
+      throw new Error(`${contract.kind} relation source does not match its projected entity identity`);
+    return [
+      {
+        relationId,
+        sourceRef,
+        targetRef,
+        relationType: edge.type,
+        direction: projection.direction,
+        strength: projection.strength,
+        origin: projection.origin,
+        state: "active" as const,
+        rationale: projection.rationale,
+        ownerRef: sourceRef,
+        sourcePath,
+        recordIndex,
+      },
+    ];
+  });
+  return {
+    ...entity,
+    ownerId,
+    workspaceRevision,
+    relations,
+  };
+}
+
+export function interpretEmbeddedEntityProjections(
+  contract: EntityProjectionContract,
+  event: CanonicalEventShape,
+): readonly InterpretedEntityProjection[] {
+  const declaration = contract.canonicalProjection;
+  if (declaration === null) return [];
+  if (!isEntityRecord(event.payload)) throw new Error(`${event.schema}/${event.type} payload must be an object`);
+  const payload = event.payload;
+  return declaration.embeddedEvents
+    .filter((source) => source.schema === event.schema && source.types.includes(event.type))
+    .map((source) => {
+      const value = payload[source.payloadField];
+      const projected = interpretEntityProjection(contract, value, event.workspaceRevision, `event:${event.opId}`);
+      if (projected === null) throw new Error(`${contract.kind} embedded projection declaration is unavailable`);
+      return projected;
+    });
+}
+
+function stringField(value: Readonly<Record<string, unknown>>, field: string, label: string): string {
+  const selected = value[field];
+  if (typeof selected !== "string" || selected.length === 0)
+    throw new Error(`${label} field ${field} must be a string`);
+  return selected;
+}
+
+function applyRefTemplate(template: string, id: string): string {
+  if (!template.includes("{id}")) throw new Error(`Entity relation ref template ${template} has no {id} slot`);
+  const ref = template.replace("{id}", id);
+  if (ref.includes("{id}")) throw new Error(`Entity relation ref template ${template} has more than one {id} slot`);
+  return ref;
+}
+
+function isEntityRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -184,8 +184,8 @@ const taskExposure = capabilityExposure("task", "task-frontmatter");
 const factExposure = capabilityExposure("fact", "fact-event");
 const decisionExposure = capabilityExposure("decision", "decision-package");
 
-const executionIdPattern = "^[a-z0-9][a-z0-9_-]{0,127}$";
-const reviewIdPattern = "^[a-z0-9][a-z0-9_-]{0,127}$";
+const executionIdPattern = "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$";
+const reviewIdPattern = "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$";
 const lifecycleTaskIdPattern = "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$";
 const opaqueObject = (): EntityJsonObjectSchema => ({
   type: "object",

--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -14,7 +14,7 @@ import {
   type EntityJsonObjectSchema,
   type EntityJsonSchemaNode,
 } from "./entity-json-schema.ts";
-import type { RelationDirection } from "./entity-relation.ts";
+import type { RelationDirection, RelationType } from "./entity-relation.ts";
 import { executionStates } from "./execution.ts";
 import { domainStatuses } from "./lifecycle-status.ts";
 import { policyPredicateNames, POLICY_DECLARATION_V1_SCHEMA, validatePolicyDeclarationV1 } from "./policy.ts";
@@ -27,7 +27,9 @@ import {
   supported,
   unsupported,
   type EntityAnchorDeclaration,
+  type EntityCanonicalProjectionDeclaration,
   type EntityDispositionMatrix,
+  type EntityRelationProjectionDeclaration,
   type EntityStorageForm,
 } from "../entity/registry-contract.ts";
 
@@ -63,11 +65,13 @@ export interface EntityKindContract<T = unknown> {
   readonly relations: {
     readonly directions: readonly RelationDirection[];
     readonly edges: readonly {
-      readonly type: string;
+      readonly type: RelationType;
       readonly sourceKind: string;
       readonly targetKind: string;
+      readonly projection?: EntityRelationProjectionDeclaration;
     }[];
   };
+  readonly canonicalProjection: EntityCanonicalProjectionDeclaration | null;
   readonly statusVocabulary?: readonly { readonly field: string; readonly words: readonly string[] }[];
   readonly actionCatalog: {
     readonly ref: string;
@@ -124,6 +128,7 @@ export interface EntityKindExplanation {
   };
   readonly id: EntityKindContract["id"];
   readonly relations: EntityKindContract["relations"];
+  readonly canonicalProjection: EntityKindContract["canonicalProjection"];
   readonly statusVocabulary: NonNullable<EntityKindContract["statusVocabulary"]>;
   readonly transitions: {
     readonly catalogRef: string | null;
@@ -385,6 +390,7 @@ export const entityKindContracts = Object.freeze([
     schema: taskSchema,
     id: { field: "task_id", pattern: lifecycleTaskIdPattern, refTemplate: "task/{id}" },
     relations: relationsFor("task"),
+    canonicalProjection: null,
     statusVocabulary: [{ field: "lifecycle.status", words: domainStatuses }],
     actionCatalog: actionCatalog(
       "kernel/task-lifecycle/v1",
@@ -403,6 +409,7 @@ export const entityKindContracts = Object.freeze([
     schema: factSchema,
     id: { field: "factId", pattern: "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$", refTemplate: "fact/{id}" },
     relations: relationsFor("fact"),
+    canonicalProjection: null,
     statusVocabulary: [{ field: "state", words: ["standing", "superseded_fact"] }],
     actionCatalog: actionCatalog("kernel/fact-event/v1", "fact", "fact/{id}", ["record"], factExposure),
     entityStore: null,
@@ -415,6 +422,7 @@ export const entityKindContracts = Object.freeze([
     schema: decisionSchema,
     id: { field: "decisionId", pattern: "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$", refTemplate: "decision/{id}" },
     relations: relationsFor("decision"),
+    canonicalProjection: null,
     statusVocabulary: [{ field: "state", words: decisionStates }],
     actionCatalog: actionCatalog(
       "kernel/decision-event/v1",
@@ -433,6 +441,7 @@ export const entityKindContracts = Object.freeze([
     schema: AGENT_DECLARATION_V1_SCHEMA,
     id: { ...declarationId, refTemplate: "agent/{id}" },
     relations: { directions: [], edges: [] },
+    canonicalProjection: null,
     statusVocabulary: [{ field: "state", words: agentStates }],
     actionCatalog: actionCatalog("kernel/agent-declaration/v1", "agent", "agent/{id}", [
       "configure",
@@ -448,6 +457,7 @@ export const entityKindContracts = Object.freeze([
     schema: SQUAD_DECLARATION_V1_SCHEMA,
     id: { ...declarationId, refTemplate: "squad/{id}" },
     relations: { directions: [], edges: [] },
+    canonicalProjection: null,
     actionCatalog: null,
     entityStore: genericEntityStore("squads/{id}.json"),
     authoring: genericAuthoring,
@@ -458,6 +468,7 @@ export const entityKindContracts = Object.freeze([
     schema: POLICY_DECLARATION_V1_SCHEMA,
     id: { ...declarationId, refTemplate: "policy/{id}" },
     relations: { directions: [], edges: [] },
+    canonicalProjection: null,
     statusVocabulary: [{ field: "state", words: policyStates }],
     actionCatalog: actionCatalog("kernel/policy/v1", "policy", "policy/{id}", ["draft", "activate", "retire"]),
     entityStore: genericEntityStore("policies/{id}.json", validatePolicyDeclarationV1),
@@ -475,7 +486,43 @@ export const entityKindContracts = Object.freeze([
     id: { field: "executionId", pattern: executionIdPattern, refTemplate: "execution/{id}" },
     relations: {
       directions: ["directed"],
-      edges: [{ type: "executes", sourceKind: "execution", targetKind: "task" }],
+      edges: [
+        {
+          type: "executes",
+          sourceKind: "execution",
+          targetKind: "task",
+          projection: {
+            source: { field: "executionId", refTemplate: "execution/{id}" },
+            target: { field: "taskId", refTemplate: "task/{id}" },
+            direction: "directed",
+            strength: "strong",
+            origin: "generated",
+            rationale: "Execution belongs to its task lifecycle.",
+          },
+        },
+      ],
+    },
+    canonicalProjection: {
+      embeddedEvents: [
+        {
+          schema: "task-event/v1",
+          types: [
+            "execution_started",
+            "lease_renewed",
+            "execution_submitted",
+            "execution_executor_declared",
+            "review_recorded",
+            "review_consent_recorded",
+            "code_doc_reconciled",
+            "code_doc_repointed",
+            "completion_gate_verified",
+            "task_completed",
+            "lease_released",
+          ],
+          payloadField: "execution",
+        },
+      ],
+      row: { idField: "executionId", ownerField: "taskId" },
     },
     statusVocabulary: [{ field: "state", words: executionStates }],
     actionCatalog: actionCatalog("kernel/task-lifecycle/v1", "execution", "execution/{id}", [
@@ -495,7 +542,31 @@ export const entityKindContracts = Object.freeze([
     id: { field: "reviewId", pattern: reviewIdPattern, refTemplate: "review/{id}" },
     relations: {
       directions: ["directed"],
-      edges: [{ type: "reviews", sourceKind: "review", targetKind: "execution" }],
+      edges: [
+        {
+          type: "reviews",
+          sourceKind: "review",
+          targetKind: "execution",
+          projection: {
+            source: { field: "reviewId", refTemplate: "review/{id}" },
+            target: { field: "executionId", refTemplate: "execution/{id}" },
+            direction: "directed",
+            strength: "strong",
+            origin: "generated",
+            rationale: "Review records judgment for its execution.",
+          },
+        },
+      ],
+    },
+    canonicalProjection: {
+      embeddedEvents: [
+        {
+          schema: "task-event/v1",
+          types: ["review_recorded", "review_consent_recorded"],
+          payloadField: "review",
+        },
+      ],
+      row: { idField: "reviewId", ownerField: "taskId" },
     },
     statusVocabulary: [{ field: "verdict", words: reviewVerdicts }],
     actionCatalog: actionCatalog("kernel/task-lifecycle/v1", "review", "review/{id}", ["record"]),
@@ -511,6 +582,7 @@ export const entityKindContracts = Object.freeze([
       directions: ["directed"],
       edges: [{ type: "executes", sourceKind: "runtime-session", targetKind: "task" }],
     },
+    canonicalProjection: null,
     statusVocabulary: [
       { field: "liveness", words: ["live", "stale", "unknown", "exited"] },
       { field: "outcome", words: ["succeeded", "failed", "unknown", "cancelled"] },
@@ -567,6 +639,7 @@ export function explainEntityKind(kind: string): EntityKindExplanation {
     documentSchema: { id: contract.schema.$id, fields: explainEntityJsonSchema(contract.schema) },
     id: contract.id,
     relations: contract.relations,
+    canonicalProjection: contract.canonicalProjection,
     statusVocabulary: contract.statusVocabulary ?? [],
     transitions: {
       catalogRef: contract.actionCatalog?.ref ?? null,

--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -86,7 +86,7 @@ export interface EntityKindContract<T = unknown> {
     readonly validate?: (value: unknown) => readonly string[];
   } | null;
   readonly authoring: {
-    readonly kind: "generic-entity-store" | "task-lifecycle" | "fact-event" | "decision-event";
+    readonly kind: "generic-entity-store" | "task-lifecycle" | "fact-event" | "decision-event" | "agent-runtime-event";
     readonly contractRef: string;
   };
   readonly sdkExposure: EntitySdkExposure;
@@ -533,7 +533,7 @@ export const entityKindContracts = Object.freeze([
       "release",
     ]),
     entityStore: genericEntityStore("executions/{id}.json"),
-    authoring: genericAuthoring,
+    authoring: { kind: "task-lifecycle", contractRef: "task-event/v1" },
     sdkExposure: noSdkExposure,
   },
   {
@@ -571,7 +571,7 @@ export const entityKindContracts = Object.freeze([
     statusVocabulary: [{ field: "verdict", words: reviewVerdicts }],
     actionCatalog: actionCatalog("kernel/task-lifecycle/v1", "review", "review/{id}", ["record"]),
     entityStore: genericEntityStore("reviews/{id}.json"),
-    authoring: genericAuthoring,
+    authoring: { kind: "task-lifecycle", contractRef: "task-event/v1" },
     sdkExposure: noSdkExposure,
   },
   {
@@ -598,7 +598,7 @@ export const entityKindContracts = Object.freeze([
       agentRuntimeEventTypes.filter((type) => type.startsWith("runtime_session_")),
     ),
     entityStore: genericEntityStore("runtime-sessions/{id}.json"),
-    authoring: genericAuthoring,
+    authoring: { kind: "agent-runtime-event", contractRef: "agent-runtime-event/v1" },
     sdkExposure: noSdkExposure,
   },
 ] as const satisfies readonly EntityKindContract[]);

--- a/packages/kernel/src/entity/registry-contract.ts
+++ b/packages/kernel/src/entity/registry-contract.ts
@@ -45,6 +45,32 @@ export interface EntityAnchorDeclaration {
   readonly entityRef: string;
   readonly anchors: ReadonlyArray<{ readonly field: string; readonly idField: string; readonly ref: string }>;
 }
+export interface EmbeddedCanonicalEventDeclaration {
+  readonly schema: string;
+  readonly types: ReadonlyArray<string>;
+  readonly payloadField: string;
+}
+export interface EntityCanonicalProjectionDeclaration {
+  readonly embeddedEvents: ReadonlyArray<EmbeddedCanonicalEventDeclaration>;
+  readonly row: {
+    readonly idField: string;
+    readonly ownerField: string;
+  };
+}
+export interface EntityRelationProjectionDeclaration {
+  readonly source: {
+    readonly field: string;
+    readonly refTemplate: string;
+  };
+  readonly target: {
+    readonly field: string;
+    readonly refTemplate: string;
+  };
+  readonly direction: "directed";
+  readonly strength: "strong" | "weak";
+  readonly origin: "generated" | "inferred";
+  readonly rationale: string;
+}
 export interface DispositionMatrixEntry {
   readonly level: DispositionLevel;
   readonly action: DispositionAction;

--- a/packages/kernel/src/projection/projection-schema.ts
+++ b/packages/kernel/src/projection/projection-schema.ts
@@ -1,11 +1,11 @@
 import { DatabaseSync } from "node:sqlite";
 import { localRuntimeStateFileSystem } from "../local/local-layout-file-system.ts";
 
-// Version 8 replaces the legacy execution/review tables with entity_projection.
+// Version 9 derives execution/review relation edges while replaying their canonical events.
 // A version mismatch takes the
 // existing discard-and-replay path in rebuildable-task-projection.ts, so each
 // machine cold-rebuilds task.sqlite once on its first read.
-export const taskProjectionSchemaVersion = 8;
+export const taskProjectionSchemaVersion = 9;
 
 export function readTaskProjectionSchemaVersion(projectionPath: string): number | null {
   if (!localRuntimeStateFileSystem.exists(projectionPath)) return null;

--- a/packages/kernel/src/projection/rebuildable-task-projection-entities.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-entities.ts
@@ -1,0 +1,68 @@
+// @write-boundary-exemption rebuildable-projection
+import type { DatabaseSync } from "node:sqlite";
+import type { CanonicalEventV1 } from "../domain/doc-sync.contract.ts";
+import {
+  deriveEntityProjection,
+  interpretEmbeddedEntityProjections,
+  type InterpretedEntityValue,
+  type InterpretedEntityProjection,
+} from "../domain/entity-kind-projection.ts";
+import { entityKindContracts, type EntityKindContract } from "../domain/entity-kind-registry.ts";
+import { canonicalJson, runSql } from "./rebuildable-task-projection-sql.ts";
+
+const UPSERT_ENTITY_SQL = [
+  "INSERT INTO entity_projection(entity_kind, entity_id, task_id, workspace_revision, value_json)",
+  "VALUES (?, ?, ?, ?, ?) ON CONFLICT(entity_kind, entity_id) DO UPDATE SET",
+  "task_id=excluded.task_id, workspace_revision=excluded.workspace_revision, value_json=excluded.value_json",
+  "WHERE entity_projection.workspace_revision <= excluded.workspace_revision",
+].join(" ");
+const UPSERT_RELATION_SQL = [
+  "INSERT INTO relation_edge(relation_id, source_ref, target_ref, relation_type, state, owner_ref,",
+  "workspace_revision, row_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+  "ON CONFLICT(relation_id) DO UPDATE SET source_ref=excluded.source_ref, target_ref=excluded.target_ref,",
+  "relation_type=excluded.relation_type, state=excluded.state, owner_ref=excluded.owner_ref,",
+  "workspace_revision=excluded.workspace_revision, row_json=excluded.row_json",
+  "WHERE relation_edge.workspace_revision <= excluded.workspace_revision",
+].join(" ");
+
+export function projectEmbeddedCanonicalEntities(db: DatabaseSync, event: CanonicalEventV1): void {
+  for (const contract of entityKindContracts)
+    for (const projection of interpretEmbeddedEntityProjections(contract, event)) writeEntityProjection(db, projection);
+}
+
+export function projectInterpretedEntityValue(
+  db: DatabaseSync,
+  contract: EntityKindContract,
+  entity: InterpretedEntityValue,
+  workspaceRevision: number,
+  sourcePath: string,
+): InterpretedEntityProjection | null {
+  const projection = deriveEntityProjection(contract, entity, workspaceRevision, sourcePath);
+  if (projection !== null) writeEntityProjection(db, projection);
+  return projection;
+}
+
+function writeEntityProjection(db: DatabaseSync, projection: InterpretedEntityProjection): void {
+  runSql(
+    db,
+    UPSERT_ENTITY_SQL,
+    projection.kind,
+    projection.id,
+    projection.ownerId,
+    projection.workspaceRevision,
+    canonicalJson(projection.value),
+  );
+  for (const relation of projection.relations)
+    runSql(
+      db,
+      UPSERT_RELATION_SQL,
+      relation.relationId,
+      relation.sourceRef,
+      relation.targetRef,
+      relation.relationType,
+      relation.state,
+      relation.ownerRef,
+      projection.workspaceRevision,
+      canonicalJson(relation),
+    );
+}

--- a/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
@@ -20,6 +20,8 @@ import {
   runtimeSessionId,
 } from "../domain/agent-runtime.ts";
 import { isEntityEvent } from "../domain/entity-event.ts";
+import { interpretEntityValue } from "../domain/entity-kind-projection.ts";
+import { requireEntityStoreKindContract } from "../domain/entity-kind-registry.ts";
 import { isTaskBootstrapEvent, taskBootstrapPackagePath } from "../domain/task-bootstrap-event.ts";
 import { isTaskProgressEvent } from "../domain/task-progress-event.ts";
 import { isPresetSnapshotUpgradeEvent } from "../domain/preset-snapshot-upgrade-event.ts";
@@ -30,6 +32,7 @@ import type { EventStreamPort } from "./rebuildable-task-projection-types.ts";
 import { projectMigration } from "./rebuildable-task-projection-migration.ts";
 import { projectDecision, projectFact, projectProgress } from "./rebuildable-task-projection-write-model.ts";
 import { applyTaskEvent } from "./rebuildable-task-projection-task-events.ts";
+import { projectInterpretedEntityValue } from "./rebuildable-task-projection-entities.ts";
 import {
   readRuntimeInstallation,
   readRuntimeSession,
@@ -111,6 +114,12 @@ export function applyEvent(
     } catch {
       throw new Error(`entity declaration blob ${claim.sha256} is not JSON`);
     }
+    const contract = requireEntityStoreKindContract(event.payload.entityKind),
+      entity = interpretEntityValue(contract, value),
+      contractErrors = contract.entityStore.validate?.(entity.value) ?? [];
+    if (contractErrors.length) throw new Error(contractErrors.join("; "));
+    if (entity.id !== event.payload.entityId)
+      throw new Error(`entity declaration blob ${claim.sha256} identity mismatch`);
     const document: DocumentState = {
       path: claim.path as DocumentState["path"],
       blobSha256: claim.sha256,
@@ -128,21 +137,7 @@ export function applyEvent(
       eventJson,
     );
     runSql(db, UPSERT_DOCUMENT_SQL, claim.path, event.workspaceRevision, canonicalJson(document));
-    const record = value && typeof value === "object" ? (value as Record<string, unknown>) : {};
-    if (event.payload.entityKind === "execution" || event.payload.entityKind === "review")
-      runSql(
-        db,
-        [
-          "INSERT INTO entity_projection(entity_kind, entity_id, task_id, workspace_revision, value_json)",
-          "VALUES (?, ?, ?, ?, ?) ON CONFLICT(entity_kind, entity_id) DO UPDATE SET",
-          "task_id=excluded.task_id, workspace_revision=excluded.workspace_revision, value_json=excluded.value_json",
-        ].join(" "),
-        event.payload.entityKind,
-        event.payload.entityId,
-        typeof record.taskId === "string" ? record.taskId : null,
-        event.workspaceRevision,
-        body,
-      );
+    projectInterpretedEntityValue(db, contract, entity, event.workspaceRevision, `event:${event.opId}`);
     return;
   }
   if (isFactEvent(event)) {

--- a/packages/kernel/src/projection/rebuildable-task-projection-migration.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-migration.ts
@@ -2,12 +2,14 @@
 import { DatabaseSync } from "node:sqlite";
 import { emptyTaskLifecycleSnapshot } from "../domain/task-lifecycle.contract.ts";
 import { docByteLength, type DocumentState } from "../domain/doc-sync.contract.ts";
+import { requireEntityStoreKindContract } from "../domain/entity-kind-registry.ts";
 import { type MigrationDocumentClaim, type MigrationImportEventV1 } from "../domain/migration-import-event.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
 import { refreshDecisionDocumentSearch } from "./decision-event-projection.ts";
 import { refreshTaskRelationProjection } from "./task-query-projection.ts";
 import type { EventStreamPort } from "./rebuildable-task-projection-types.ts";
 import { canonicalJson, queryRows, runSql } from "./rebuildable-task-projection-sql.ts";
+import { projectInterpretedEntityValue } from "./rebuildable-task-projection-entities.ts";
 import { readSnapshot } from "./rebuildable-task-projection-runtime.ts";
 export type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
 export type { TaskProjection } from "./task-projection-port.ts";
@@ -32,12 +34,6 @@ const UPSERT_DOCUMENT_SQL = [
   "ON CONFLICT(path) DO UPDATE SET workspace_revision=excluded.workspace_revision,",
   "value_json=excluded.value_json",
 ].join(" ");
-const UPSERT_ENTITY_SQL = [
-  "INSERT INTO entity_projection(entity_kind, entity_id, task_id, workspace_revision, value_json)",
-  "VALUES (?, ?, ?, ?, ?) ON CONFLICT(entity_kind, entity_id) DO UPDATE SET",
-  "task_id=excluded.task_id, workspace_revision=excluded.workspace_revision, value_json=excluded.value_json",
-].join(" ");
-
 // Legacy migration-import replay and its document materialization.
 export function projectMigration(
   db: DatabaseSync,
@@ -212,14 +208,13 @@ export function projectMigration(
       event.occurredAt,
     );
     refreshTaskRelationProjection(db, value.taskId, next.task, event.workspaceRevision, event.occurredAt);
-    runSql(
+    const contract = requireEntityStoreKindContract(entity.kind);
+    projectInterpretedEntityValue(
       db,
-      UPSERT_ENTITY_SQL,
-      "execution",
-      value.executionId,
-      value.taskId,
+      contract,
+      { kind: contract.kind, id: value.executionId, value: { ...value } },
       event.workspaceRevision,
-      canonicalJson(value),
+      `event:${event.opId}`,
     );
     storeMigrationDocument(db, event, entity.documentClaim, readBlob);
     return;

--- a/packages/kernel/src/projection/rebuildable-task-projection-task-events.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-task-events.ts
@@ -6,6 +6,7 @@ import { lifecycleDocumentPaths } from "../domain/task-lifecycle-publication.ts"
 import { slugifyTaskTitle } from "../layout/index.ts";
 import { refreshDecisionDocumentSearch } from "./decision-event-projection.ts";
 import { refreshTaskRelationProjection } from "./task-query-projection.ts";
+import { projectEmbeddedCanonicalEntities } from "./rebuildable-task-projection-entities.ts";
 import type { EventStreamPort } from "./rebuildable-task-projection-types.ts";
 import { readSnapshot, replayClaim, replayRelease, replayRenew } from "./rebuildable-task-projection-runtime.ts";
 import { canonicalJson, queryRows, runSql } from "./rebuildable-task-projection-sql.ts";
@@ -23,12 +24,6 @@ const UPSERT_DOCUMENT_SQL = [
   "ON CONFLICT(path) DO UPDATE SET workspace_revision=excluded.workspace_revision,",
   "value_json=excluded.value_json",
 ].join(" ");
-const UPSERT_ENTITY_SQL = [
-  "INSERT INTO entity_projection(entity_kind, entity_id, task_id, workspace_revision, value_json)",
-  "VALUES (?, ?, ?, ?, ?) ON CONFLICT(entity_kind, entity_id) DO UPDATE SET",
-  "task_id=excluded.task_id, workspace_revision=excluded.workspace_revision, value_json=excluded.value_json",
-].join(" ");
-
 // Lifecycle task-event reduction, document claims, and materialized task rows.
 export function applyTaskEvent(
   db: DatabaseSync,
@@ -137,36 +132,7 @@ export function applyTaskEvent(
     runSql(db, UPSERT_DOCUMENT_SQL, change.path, event.workspaceRevision, canonicalJson(document));
     refreshDecisionDocumentSearch(db, document);
   }
-  if ("execution" in event.payload)
-    runSql(
-      db,
-      UPSERT_ENTITY_SQL,
-      "execution",
-      event.payload.execution.executionId,
-      event.taskId,
-      event.workspaceRevision,
-      canonicalJson(event.payload.execution),
-    );
-  if (event.type === "review_recorded")
-    runSql(
-      db,
-      UPSERT_ENTITY_SQL,
-      "review",
-      event.payload.review.reviewId,
-      event.taskId,
-      event.workspaceRevision,
-      canonicalJson(event.payload.review),
-    );
-  if (event.type === "review_consent_recorded")
-    runSql(
-      db,
-      UPSERT_ENTITY_SQL,
-      "review",
-      event.payload.review.reviewId,
-      event.taskId,
-      event.workspaceRevision,
-      canonicalJson(event.payload.review),
-    );
+  projectEmbeddedCanonicalEntities(db, event);
   const edge =
     event.type === "execution_submitted"
       ? event.payload.edge

--- a/packages/kernel/src/store/entity-store.ts
+++ b/packages/kernel/src/store/entity-store.ts
@@ -1,12 +1,15 @@
 import type { HarnessLayoutInput } from "../layout/index.ts";
-import { parseEntityJsonSchema } from "../domain/entity-json-schema.ts";
 import {
   compileEntityUpsert,
   isEntityEvent,
   type EntityUpsertBundle,
   type StoredEntityEventV1,
 } from "../domain/entity-event.ts";
-import { isTaskEvent } from "../domain/doc-sync.contract.ts";
+import {
+  interpretEmbeddedEntityProjections,
+  interpretEntityValue,
+  type InterpretedEntityProjection,
+} from "../domain/entity-kind-projection.ts";
 import { entityDocumentPath, requireEntityStoreKindContract } from "../domain/entity-kind-registry.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
 import { resolveLedgerGitLayout } from "./ledger-git-layout.ts";
@@ -34,23 +37,15 @@ export function createEntityStore(source: EntityEventSource): EntityStore {
   const records = (kind: string): readonly StoredEntity[] => {
     const contract = requireEntityStoreKindContract(kind),
       latest = new Map<string, ReturnType<typeof entityEventRecord>>();
+    const keepLatest = (record: StoredEntity): void => {
+      const current = latest.get(record.id);
+      if (current === undefined || current.workspaceRevision <= record.workspaceRevision) latest.set(record.id, record);
+    };
     for (const event of source.read().events) {
       if (isEntityEvent(event) && event.payload.entityKind === contract.kind)
-        latest.set(event.payload.entityId, entityEventRecord(event, source, contract));
-      if (contract.kind === "execution" && isTaskEvent(event) && "execution" in event.payload)
-        latest.set(
-          event.payload.execution.executionId,
-          taskEventRecord(event.payload.execution, event.workspaceRevision, contract),
-        );
-      if (
-        contract.kind === "review" &&
-        isTaskEvent(event) &&
-        (event.type === "review_recorded" || event.type === "review_consent_recorded")
-      )
-        latest.set(
-          event.payload.review.reviewId,
-          taskEventRecord(event.payload.review, event.workspaceRevision, contract),
-        );
+        keepLatest(entityEventRecord(event, source, contract));
+      for (const projection of interpretEmbeddedEntityProjections(contract, event))
+        keepLatest(embeddedEventRecord(projection, contract));
     }
     return [...latest.values()].sort((left, right) => left.id.localeCompare(right.id));
   };
@@ -62,20 +57,16 @@ export function createEntityStore(source: EntityEventSource): EntityStore {
   };
 }
 
-function taskEventRecord(
-  value: unknown,
-  workspaceRevision: number,
+function embeddedEventRecord(
+  projection: InterpretedEntityProjection,
   contract: ReturnType<typeof requireEntityStoreKindContract>,
 ): StoredEntity {
-  const parsed = parseEntityJsonSchema(contract.schema, value, `${contract.kind} declaration`),
-    id = (parsed as Record<string, unknown>)[contract.id.field];
-  if (typeof id !== "string") throw new Error(`${contract.kind} lifecycle event has no string identity`);
   return {
     kind: contract.kind,
-    id,
-    value: parsed,
-    documentPath: entityDocumentPath(contract, id),
-    workspaceRevision,
+    id: projection.id,
+    value: projection.value,
+    documentPath: entityDocumentPath(contract, projection.id),
+    workspaceRevision: projection.workspaceRevision,
   };
 }
 
@@ -115,20 +106,15 @@ function entityEventRecord(
   } catch {
     throw new Error(`entity declaration blob ${claim.sha256} is not JSON`);
   }
-  const value = parseEntityJsonSchema(contract.schema, decoded, `${contract.kind} declaration`);
-  const contractErrors = contract.entityStore.validate?.(value) ?? [];
+  const entity = interpretEntityValue(contract, decoded),
+    contractErrors = contract.entityStore.validate?.(entity.value) ?? [];
   if (contractErrors.length) throw new Error(contractErrors.join("; "));
-  if (
-    value === null ||
-    typeof value !== "object" ||
-    Array.isArray(value) ||
-    (value as Readonly<Record<string, unknown>>)[contract.id.field] !== event.payload.entityId
-  )
+  if (entity.id !== event.payload.entityId)
     throw new Error(`entity declaration blob ${claim.sha256} identity mismatch`);
   return {
     kind: contract.kind,
     id: event.payload.entityId,
-    value,
+    value: entity.value,
     documentPath: claim.path,
     workspaceRevision: event.workspaceRevision,
   };

--- a/packages/kernel/test/contracts/entity-store.test.ts
+++ b/packages/kernel/test/contracts/entity-store.test.ts
@@ -3,12 +3,14 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { createEntityStore, explainEntityKind } from "../../src/index.ts";
 import { validateAgentDeclarationV1 } from "../../src/domain/agent-squad-schema.ts";
+import type { CanonicalEventV1 } from "../../src/domain/doc-sync.contract.ts";
 import {
   assertEntityUpsertInputs,
   type EntityEventV1,
   type EntityUpsertBundle,
 } from "../../src/domain/entity-event.ts";
 import { validateWriteReceipt } from "../../src/domain/write-chain.contract.ts";
+import { lifecycleFixture } from "../store/task-lifecycle-fixture.ts";
 
 const actor = { principal: { personId: "person-entity-store" }, executor: null } as const;
 const agent = {
@@ -137,6 +139,48 @@ test("Entity upsert rejects schema-invalid declarations and tampered declaration
   const bundle = upsert(store, "agent", agent, 1),
     tampered = [{ ...bundle.blobs[0], body: `${bundle.blobs[0].body} ` }];
   assert.throws(() => assertEntityUpsertInputs(bundle.event, bundle.plan, tampered), /declaration blob must be exact/u);
+});
+
+test("EntityStore interprets embedded lifecycle values and generic upserts with revision-latest precedence", () => {
+  const fixture = lifecycleFixture(),
+    events: CanonicalEventV1[] = [...fixture.events],
+    blobs = new Map<string, Uint8Array>(),
+    store = createEntityStore({
+      read: () => ({ schema: "canonical-event-stream/v1", revision: events.length, events }),
+      readContentBlob: (sha256) => blobs.get(sha256) ?? null,
+    });
+  assert.deepEqual(
+    store.list<{ readonly state: string }>("execution").map(({ id, value, workspaceRevision }) => ({
+      id,
+      state: value.state,
+      workspaceRevision,
+    })),
+    [{ id: "execution-1", state: "accepted", workspaceRevision: 6 }],
+  );
+  assert.deepEqual(
+    store.list<{ readonly verdict: string }>("review").map(({ id, value, workspaceRevision }) => ({
+      id,
+      verdict: value.verdict,
+      workspaceRevision,
+    })),
+    [{ id: "review-execution", verdict: "approved", workspaceRevision: 5 }],
+  );
+
+  const latestExecution = {
+      ...fixture.snapshot.executions[0]!,
+      state: "abandoned",
+      closedAt: "2026-08-25T01:00:00.000Z",
+    },
+    bundle = upsert(store, "execution", latestExecution, 7);
+  events.push(bundle.event);
+  for (const blob of bundle.blobs) blobs.set(blob.sha256, Buffer.from(blob.body));
+  assert.deepEqual(
+    store.get<{ readonly state: string }>("execution", "execution-1") && {
+      state: store.get<{ readonly state: string }>("execution", "execution-1")?.value.state,
+      workspaceRevision: store.get("execution", "execution-1")?.workspaceRevision,
+    },
+    { state: "abandoned", workspaceRevision: 7 },
+  );
 });
 
 test("entity_upsert receipt detail is closed and registered", () => {

--- a/packages/kernel/test/contracts/entity-store.test.ts
+++ b/packages/kernel/test/contracts/entity-store.test.ts
@@ -141,7 +141,7 @@ test("Entity upsert rejects schema-invalid declarations and tampered declaration
   assert.throws(() => assertEntityUpsertInputs(bundle.event, bundle.plan, tampered), /declaration blob must be exact/u);
 });
 
-test("EntityStore interprets embedded lifecycle values and generic upserts with revision-latest precedence", () => {
+test("EntityStore keeps lifecycle entities on embedded events and applies generic revision precedence independently", () => {
   const fixture = lifecycleFixture(),
     events: CanonicalEventV1[] = [...fixture.events],
     blobs = new Map<string, Uint8Array>(),
@@ -166,21 +166,20 @@ test("EntityStore interprets embedded lifecycle values and generic upserts with 
     [{ id: "review-execution", verdict: "approved", workspaceRevision: 5 }],
   );
 
-  const latestExecution = {
-      ...fixture.snapshot.executions[0]!,
-      state: "abandoned",
-      closedAt: "2026-08-25T01:00:00.000Z",
-    },
-    bundle = upsert(store, "execution", latestExecution, 7);
-  events.push(bundle.event);
-  for (const blob of bundle.blobs) blobs.set(blob.sha256, Buffer.from(blob.body));
+  const installed = upsert(store, "agent", agent, 7),
+    updated = upsert(store, "agent", { ...agent, name: "Terra Updated" }, 8);
+  for (const bundle of [installed, updated]) {
+    events.push(bundle.event);
+    for (const blob of bundle.blobs) blobs.set(blob.sha256, Buffer.from(blob.body));
+  }
   assert.deepEqual(
-    store.get<{ readonly state: string }>("execution", "execution-1") && {
-      state: store.get<{ readonly state: string }>("execution", "execution-1")?.value.state,
-      workspaceRevision: store.get("execution", "execution-1")?.workspaceRevision,
+    store.get<{ readonly name: string }>("agent", "terra") && {
+      name: store.get<{ readonly name: string }>("agent", "terra")?.value.name,
+      workspaceRevision: store.get("agent", "terra")?.workspaceRevision,
     },
-    { state: "abandoned", workspaceRevision: 7 },
+    { name: "Terra Updated", workspaceRevision: 8 },
   );
+  assert.equal(store.get<{ readonly state: string }>("execution", "execution-1")?.value.state, "accepted");
 });
 
 test("entity_upsert receipt detail is closed and registered", () => {

--- a/packages/kernel/test/contracts/execution-review-entity.test.ts
+++ b/packages/kernel/test/contracts/execution-review-entity.test.ts
@@ -41,6 +41,29 @@ test("execution and review are dependency-free EntityKindContracts with lifecycl
       contentDigest: `sha256:${"b".repeat(64)}`,
       reviewedAt: execution.claimedAt,
     },
+    runtimeSession = {
+      schema: "runtime-session/v1",
+      runtimeSessionId: "runtime_session1",
+      taskBindings: [],
+      liveness: "live",
+      outcome: null,
+      semanticState: "running",
+    },
+    agent = {
+      schema: "agent-declaration/v1",
+      id: "agent-valid",
+      name: "Valid Agent",
+      instructions: "Work precisely.",
+      runtime_type: "codex",
+    },
+    squad = {
+      schema: "squad-declaration/v1",
+      id: "squad-valid",
+      name: "Valid Squad",
+      leader: agent.id,
+      workers: [agent.id],
+      roster: "# Valid Squad",
+    },
     base = {
       eventId: "event-1",
       opId: "op-1",
@@ -52,6 +75,18 @@ test("execution and review are dependency-free EntityKindContracts with lifecycl
 
   assert.equal(getEntityKindContract("execution")?.id.field, "executionId");
   assert.equal(getEntityKindContract("review")?.id.field, "reviewId");
+  assert.deepEqual(getEntityKindContract("execution")?.authoring, {
+    kind: "task-lifecycle",
+    contractRef: "task-event/v1",
+  });
+  assert.deepEqual(getEntityKindContract("review")?.authoring, {
+    kind: "task-lifecycle",
+    contractRef: "task-event/v1",
+  });
+  assert.deepEqual(getEntityKindContract("runtime-session")?.authoring, {
+    kind: "agent-runtime-event",
+    contractRef: "agent-runtime-event/v1",
+  });
   assert.deepEqual(getEntityKindContract("execution")?.canonicalProjection, {
     embeddedEvents: [
       {
@@ -120,23 +155,35 @@ test("execution and review are dependency-free EntityKindContracts with lifecycl
       },
     ],
   });
-  assert.doesNotThrow(() => compileEntityUpsert({ ...base, entityKind: "execution", entity: execution }));
-  assert.doesNotThrow(() => compileEntityUpsert({ ...base, entityKind: "review", entity: review }));
   assert.throws(
-    () => compileEntityUpsert({ ...base, entityKind: "execution", entity: { ...execution, executionId: "" } }),
-    /invalid|pattern|non-empty/u,
+    () => compileEntityUpsert({ ...base, entityKind: "execution", entity: execution }),
+    /execution.*must be authored via lifecycle\/runtime events, not generic upsert/u,
   );
   assert.throws(
-    () => compileEntityUpsert({ ...base, entityKind: "execution", entity: { ...execution, executionId: "exe/bad" } }),
-    /invalid|pattern/u,
+    () => compileEntityUpsert({ ...base, entityKind: "review", entity: review }),
+    /review.*must be authored via lifecycle\/runtime events, not generic upsert/u,
   );
   assert.throws(
-    () => compileEntityUpsert({ ...base, entityKind: "review", entity: { ...review, reviewId: "" } }),
-    /invalid|pattern|non-empty/u,
+    () => compileEntityUpsert({ ...base, entityKind: "runtime-session", entity: runtimeSession }),
+    /runtime-session.*must be authored via lifecycle\/runtime events, not generic upsert/u,
+  );
+  assert.doesNotThrow(() => compileEntityUpsert({ ...base, entityKind: "agent", entity: agent }));
+  assert.doesNotThrow(() => compileEntityUpsert({ ...base, entityKind: "squad", entity: squad }));
+  assert.throws(
+    () => compileEntityUpsert({ ...base, entityKind: "agent", entity: { ...agent, id: "" } }),
+    /lowercase entity slug|invalid|pattern|non-empty/u,
   );
   assert.throws(
-    () => compileEntityUpsert({ ...base, entityKind: "review", entity: { ...review, reviewId: "rev.bad" } }),
-    /invalid|pattern/u,
+    () => compileEntityUpsert({ ...base, entityKind: "agent", entity: { ...agent, id: "agent/bad" } }),
+    /lowercase entity slug|invalid|pattern/u,
+  );
+  assert.throws(
+    () => compileEntityUpsert({ ...base, entityKind: "squad", entity: { ...squad, id: "" } }),
+    /lowercase entity slug|invalid|pattern|non-empty/u,
+  );
+  assert.throws(
+    () => compileEntityUpsert({ ...base, entityKind: "squad", entity: { ...squad, id: "squad.bad" } }),
+    /lowercase entity slug|invalid|pattern/u,
   );
 
   assert.equal(isAllowedRelationKindTriple("execution", "executes", "task"), true);

--- a/packages/kernel/test/contracts/execution-review-entity.test.ts
+++ b/packages/kernel/test/contracts/execution-review-entity.test.ts
@@ -15,7 +15,7 @@ const actor = { principal: { personId: "person-1" }, executor: { kind: "agent" a
 test("execution and review are dependency-free EntityKindContracts with lifecycle relations", () => {
   const execution = {
       schema: "execution/v1",
-      executionId: "exe_01j00000000000000000000000",
+      executionId: "exe_01KXZ6PY19GBXMBRHBXQT3Q0DH",
       taskId: "task_01j00000000000000000000000",
       nodeId: "implementation",
       iteration: 0,
@@ -28,7 +28,7 @@ test("execution and review are dependency-free EntityKindContracts with lifecycl
     },
     review = {
       schema: "review/v1",
-      reviewId: "rev_01j00000000000000000000000",
+      reviewId: "rev_88E36DD4172ECC8AC1C0FF318A",
       taskId: execution.taskId,
       executionId: execution.executionId,
       verdict: "approved",
@@ -125,6 +125,18 @@ test("execution and review are dependency-free EntityKindContracts with lifecycl
   assert.throws(
     () => compileEntityUpsert({ ...base, entityKind: "execution", entity: { ...execution, executionId: "" } }),
     /invalid|pattern|non-empty/u,
+  );
+  assert.throws(
+    () => compileEntityUpsert({ ...base, entityKind: "execution", entity: { ...execution, executionId: "exe/bad" } }),
+    /invalid|pattern/u,
+  );
+  assert.throws(
+    () => compileEntityUpsert({ ...base, entityKind: "review", entity: { ...review, reviewId: "" } }),
+    /invalid|pattern|non-empty/u,
+  );
+  assert.throws(
+    () => compileEntityUpsert({ ...base, entityKind: "review", entity: { ...review, reviewId: "rev.bad" } }),
+    /invalid|pattern/u,
   );
 
   assert.equal(isAllowedRelationKindTriple("execution", "executes", "task"), true);

--- a/packages/kernel/test/contracts/execution-review-entity.test.ts
+++ b/packages/kernel/test/contracts/execution-review-entity.test.ts
@@ -2,6 +2,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { compileEntityUpsert } from "../../src/domain/entity-event.ts";
+import {
+  interpretEmbeddedEntityProjections,
+  type EntityProjectionContract,
+} from "../../src/domain/entity-kind-projection.ts";
 import { explainEntityKind, getEntityKindContract } from "../../src/domain/entity-kind-registry.ts";
 import { isAllowedRelationKindTriple } from "../../src/domain/entity-relation.ts";
 import { parseEntityRef } from "../../src/domain/entity-ref.ts";
@@ -48,13 +52,73 @@ test("execution and review are dependency-free EntityKindContracts with lifecycl
 
   assert.equal(getEntityKindContract("execution")?.id.field, "executionId");
   assert.equal(getEntityKindContract("review")?.id.field, "reviewId");
+  assert.deepEqual(getEntityKindContract("execution")?.canonicalProjection, {
+    embeddedEvents: [
+      {
+        schema: "task-event/v1",
+        types: [
+          "execution_started",
+          "lease_renewed",
+          "execution_submitted",
+          "execution_executor_declared",
+          "review_recorded",
+          "review_consent_recorded",
+          "code_doc_reconciled",
+          "code_doc_repointed",
+          "completion_gate_verified",
+          "task_completed",
+          "lease_released",
+        ],
+        payloadField: "execution",
+      },
+    ],
+    row: { idField: "executionId", ownerField: "taskId" },
+  });
+  assert.deepEqual(getEntityKindContract("review")?.canonicalProjection, {
+    embeddedEvents: [
+      {
+        schema: "task-event/v1",
+        types: ["review_recorded", "review_consent_recorded"],
+        payloadField: "review",
+      },
+    ],
+    row: { idField: "reviewId", ownerField: "taskId" },
+  });
   assert.deepEqual(explainEntityKind("execution").relations, {
     directions: ["directed"],
-    edges: [{ type: "executes", sourceKind: "execution", targetKind: "task" }],
+    edges: [
+      {
+        type: "executes",
+        sourceKind: "execution",
+        targetKind: "task",
+        projection: {
+          source: { field: "executionId", refTemplate: "execution/{id}" },
+          target: { field: "taskId", refTemplate: "task/{id}" },
+          direction: "directed",
+          strength: "strong",
+          origin: "generated",
+          rationale: "Execution belongs to its task lifecycle.",
+        },
+      },
+    ],
   });
   assert.deepEqual(explainEntityKind("review").relations, {
     directions: ["directed"],
-    edges: [{ type: "reviews", sourceKind: "review", targetKind: "execution" }],
+    edges: [
+      {
+        type: "reviews",
+        sourceKind: "review",
+        targetKind: "execution",
+        projection: {
+          source: { field: "reviewId", refTemplate: "review/{id}" },
+          target: { field: "executionId", refTemplate: "execution/{id}" },
+          direction: "directed",
+          strength: "strong",
+          origin: "generated",
+          rationale: "Review records judgment for its execution.",
+        },
+      },
+    ],
   });
   assert.doesNotThrow(() => compileEntityUpsert({ ...base, entityKind: "execution", entity: execution }));
   assert.doesNotThrow(() => compileEntityUpsert({ ...base, entityKind: "review", entity: review }));
@@ -69,3 +133,78 @@ test("execution and review are dependency-free EntityKindContracts with lifecycl
   assert.deepEqual(parseEntityRef(`execution/${execution.taskId}/${execution.executionId}`)?.kind, "execution");
   assert.deepEqual(parseEntityRef(`review/${execution.executionId}/${review.reviewId}`)?.kind, "review");
 });
+
+test("a synthetic third contract drives the same embedded projection interpreter", () => {
+  const contract = {
+    kind: "artifact",
+    schema: {
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      $id: "Artifact/v1",
+      type: "object",
+      properties: {
+        artifactId: { type: "string", minLength: 1 },
+        taskId: { type: "string", minLength: 1 },
+      },
+      required: ["artifactId", "taskId"],
+      additionalProperties: false,
+    },
+    id: { field: "artifactId", pattern: "^artifact-", refTemplate: "artifact/{id}" },
+    canonicalProjection: {
+      embeddedEvents: [{ schema: "fixture-event/v1", types: ["artifact_written"], payloadField: "artifact" }],
+      row: { idField: "artifactId", ownerField: "taskId" },
+    },
+    relations: {
+      directions: ["directed"],
+      edges: [
+        {
+          type: "produces",
+          sourceKind: "artifact",
+          targetKind: "task",
+          projection: {
+            source: { field: "artifactId", refTemplate: "artifact/{id}" },
+            target: { field: "taskId", refTemplate: "task/{id}" },
+            direction: "directed",
+            strength: "strong",
+            origin: "generated",
+            rationale: "Fixture artifact belongs to its task.",
+          },
+        },
+      ],
+    },
+  } as const satisfies EntityProjectionContract;
+  const [projection] = interpretEmbeddedEntityProjections(contract, {
+    schema: "fixture-event/v1",
+    type: "artifact_written",
+    opId: "op-artifact",
+    workspaceRevision: 17,
+    payload: { artifact: { artifactId: "artifact-1", taskId: "task-1" } },
+  });
+  assert.deepEqual(
+    {
+      kind: projection?.kind,
+      id: projection?.id,
+      ownerId: projection?.ownerId,
+      sourceRef: projection?.relations[0]?.sourceRef,
+      targetRef: projection?.relations[0]?.targetRef,
+      relationType: projection?.relations[0]?.relationType,
+    },
+    {
+      kind: "artifact",
+      id: "artifact-1",
+      ownerId: "task-1",
+      sourceRef: "artifact/artifact-1",
+      targetRef: "task/task-1",
+      relationType: "produces",
+    },
+  );
+  assert.equal(containsFunction(contract.canonicalProjection), false);
+  assert.equal(getEntityKindContract("runtime-session")?.canonicalProjection, null);
+  assert.equal(getEntityKindContract("runtime-session")?.relations.edges[0]?.projection, undefined);
+});
+
+function containsFunction(value: unknown): boolean {
+  if (typeof value === "function") return true;
+  if (Array.isArray(value)) return value.some(containsFunction);
+  if (typeof value !== "object" || value === null) return false;
+  return Object.values(value).some(containsFunction);
+}

--- a/packages/kernel/test/store/task-projection.test.ts
+++ b/packages/kernel/test/store/task-projection.test.ts
@@ -14,6 +14,7 @@ import {
 import { makeWalShadowEventStore } from "../../src/store/wal-shadow-event-store.ts";
 import { localGitObjectRefStore } from "../../src/store/local-version-control-system.ts";
 import { taskLifecycleWritePlan } from "../../src/domain/task-lifecycle-publication.ts";
+import { compileEntityUpsert } from "../../src/domain/entity-event.ts";
 import type { TaskEventV1 } from "../../src/domain/task-lifecycle.contract.ts";
 import {
   DOC_CODEC_ID,
@@ -511,6 +512,15 @@ test("steady apply and rebuild use the same reducer and reproduce watermark, op 
       })),
       [{ executionId: "execution-1", acquiredRevision: 2, releasedRevision: 3, reason: "initial_claim" }],
     );
+    const firstDerivedRelations = projection
+      .readRelationQuery()
+      .rows.filter(({ relationType }) => relationType === "executes" || relationType === "reviews")
+      .map(({ sourceRef, targetRef, relationType }) => ({ sourceRef, targetRef, relationType }))
+      .sort((left, right) => left.relationType.localeCompare(right.relationType));
+    assert.deepEqual(firstDerivedRelations, [
+      { sourceRef: "execution/execution-1", targetRef: "task/task-1", relationType: "executes" },
+      { sourceRef: "review/review-execution", targetRef: "execution/execution-1", relationType: "reviews" },
+    ]);
     const incrementalStateDigest = projection.readStateDigest();
     if (incrementalStateDigest === null)
       assert.fail("a source-complete incremental projection must persist its state digest");
@@ -524,6 +534,14 @@ test("steady apply and rebuild use the same reducer and reproduce watermark, op 
     assert.equal(rebuilt.metrics.reducedItems, 6);
     assert.equal(rebuilt.metrics.maxBatchItems <= 64, true);
     assert.deepEqual(projection.read("task-1").snapshot, first.snapshot);
+    assert.deepEqual(
+      projection
+        .readRelationQuery()
+        .rows.filter(({ relationType }) => relationType === "executes" || relationType === "reviews")
+        .map(({ sourceRef, targetRef, relationType }) => ({ sourceRef, targetRef, relationType }))
+        .sort((left, right) => left.relationType.localeCompare(right.relationType)),
+      firstDerivedRelations,
+    );
     assert.equal(projection.readOperation(startOpId)?.event.type, "execution_started");
 
     const db = new DatabaseSync(projection.path);
@@ -532,6 +550,51 @@ test("steady apply and rebuild use the same reducer and reproduce watermark, op 
     assert.throws(() => projection.read("task-1"), /projection.*mismatch/u);
     projection.rebuild();
     assert.equal(projection.read("task-1").snapshot.executions[0]?.state, "accepted");
+  });
+});
+
+test("generic entity events use the canonical projection writer for rows and declared relations", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    initRepo(rootDir);
+    const eventStore = makeTaskEventStore({ repoId: "generic-entity-projection", rootDir }),
+      projection = makeTaskProjection({ rootDir, eventStore }),
+      [created, started] = lifecycleFixture().events;
+    if (created === undefined || started?.type !== "execution_started") throw new Error("fixture requires start event");
+    eventStore.append(taskBundle(created));
+    projection.apply(created);
+    eventStore.append(taskBundle(started));
+    projection.apply(started);
+    const bundle = compileEntityUpsert({
+      entityKind: "execution",
+      entity: {
+        ...started.payload.execution,
+        state: "abandoned",
+        closedAt: "2026-08-11T00:03:00.000Z",
+      },
+      eventId: "event-generic-execution",
+      opId: "op-generic-execution",
+      workspaceRevision: 3,
+      actor: started.actor,
+      source: started.source,
+      occurredAt: "2026-08-11T00:03:00.000Z",
+    });
+    eventStore.append(bundle);
+    projection.apply(bundle.event, bundle.plan);
+
+    assert.equal(projection.read("task-1").snapshot.executions[0]?.state, "abandoned");
+    assert.deepEqual(
+      projection
+        .readRelationQuery()
+        .rows.filter(({ relationType }) => relationType === "executes")
+        .map(({ sourceRef, targetRef }) => ({ sourceRef, targetRef })),
+      [{ sourceRef: "execution/execution-1", targetRef: "task/task-1" }],
+    );
+    const db = new DatabaseSync(projection.path),
+      row = db
+        .prepare("SELECT task_id, workspace_revision FROM entity_projection WHERE entity_kind=? AND entity_id=?")
+        .get("execution", "execution-1") as { readonly task_id: string; readonly workspace_revision: number };
+    db.close();
+    assert.deepEqual({ ...row }, { task_id: "task-1", workspace_revision: 3 });
   });
 });
 

--- a/packages/kernel/test/store/task-projection.test.ts
+++ b/packages/kernel/test/store/task-projection.test.ts
@@ -553,7 +553,7 @@ test("steady apply and rebuild use the same reducer and reproduce watermark, op 
   });
 });
 
-test("generic entity events use the canonical projection writer for rows and declared relations", async () => {
+test("generic entity events project declaration documents without overriding lifecycle entities", async () => {
   await withTempStoreAsync(async (rootDir) => {
     initRepo(rootDir);
     const eventStore = makeTaskEventStore({ repoId: "generic-entity-projection", rootDir }),
@@ -565,14 +565,16 @@ test("generic entity events use the canonical projection writer for rows and dec
     eventStore.append(taskBundle(started));
     projection.apply(started);
     const bundle = compileEntityUpsert({
-      entityKind: "execution",
+      entityKind: "agent",
       entity: {
-        ...started.payload.execution,
-        state: "abandoned",
-        closedAt: "2026-08-11T00:03:00.000Z",
+        schema: "agent-declaration/v1",
+        id: "projection-agent",
+        name: "Projection Agent",
+        instructions: "Exercise the generic projection writer.",
+        runtime_type: "codex",
       },
-      eventId: "event-generic-execution",
-      opId: "op-generic-execution",
+      eventId: "event-generic-agent",
+      opId: "op-generic-agent",
       workspaceRevision: 3,
       actor: started.actor,
       source: started.source,
@@ -581,7 +583,7 @@ test("generic entity events use the canonical projection writer for rows and dec
     eventStore.append(bundle);
     projection.apply(bundle.event, bundle.plan);
 
-    assert.equal(projection.read("task-1").snapshot.executions[0]?.state, "abandoned");
+    assert.equal(projection.read("task-1").snapshot.executions[0]?.state, "active");
     assert.deepEqual(
       projection
         .readRelationQuery()
@@ -589,12 +591,12 @@ test("generic entity events use the canonical projection writer for rows and dec
         .map(({ sourceRef, targetRef }) => ({ sourceRef, targetRef })),
       [{ sourceRef: "execution/execution-1", targetRef: "task/task-1" }],
     );
-    const db = new DatabaseSync(projection.path),
-      row = db
-        .prepare("SELECT task_id, workspace_revision FROM entity_projection WHERE entity_kind=? AND entity_id=?")
-        .get("execution", "execution-1") as { readonly task_id: string; readonly workspace_revision: number };
-    db.close();
-    assert.deepEqual({ ...row }, { task_id: "task-1", workspace_revision: 3 });
+    const document = projection.readDocument("agents/projection-agent.json").document;
+    assert.ok(document);
+    assert.deepEqual(
+      { path: document.path, workspaceRevision: document.workspaceRevision, id: JSON.parse(document.body).id },
+      { path: "agents/projection-agent.json", workspaceRevision: 3, id: "projection-agent" },
+    );
   });
 });
 


### PR DESCRIPTION
# English

## Summary

Phase 1.7 (a 2.3 T-poc prerequisite) makes the nine-kind contract's pure data drive the embedded canonical-event read projection, so Execution/Review/RuntimeSession no longer need per-kind branches in entity-store or the task-event projector. `rg 'contract.kind === "' packages/kernel/src` is now zero. compileEntityUpsert generically rejects any authoring whose contract is not `generic-entity-store`, so Execution/Review (authored via task-event/v1 lifecycle) and RuntimeSession (via agent-runtime-event/v1 handoff) can no longer be written through the generic path; only Agent/Squad remain generic-authorable. An adversarial verification worker found a real bug — a lowercase-only ID pattern made the schema-9 rebuild fail on real history at revision 26959 — fixed by unifying the pattern to `[A-Za-z0-9_-]`, not by adding an alias. Projection schema 8->9 discards the disposable cache and replays canonical; no event envelope or canonical data changed.

## Architectural Justification

Why existing modules cannot carry it: entity-store.ts hardcoded a `contract.kind === "execution"/"review"` branch and the task-event projector hand-wrote payload/id/SQL, so there were two projection authorities for the embedded lifecycle entities. The only way to one authority is to drive the read projection from the kind contract's pure data and delete the kind switches. Why scope cannot be narrowed: the read interpreter, the entity-store kind-if removal and the generic-authoring rejection must land together, or a generic entity-event could still overwrite a lifecycle Execution. What obsolete code was removed: execution/review EntityStore kind ifs, three hand-coded task-event payload/id/SQL blocks, the generic entity-event kind filter, and the test that locked the generic-overwrite ability; schema 8->9 discards the stale cache and replays canonical.

## What Changed

- `packages/kernel/src/domain/entity-kind-projection.ts` (new): pure-data interpreter for embedded canonical-event read projection driven by the kind contract's `canonicalProjection`.
- `packages/kernel/src/domain/entity-kind-registry.ts`: Execution/Review declared `task-lifecycle`+`task-event/v1` authoring, RuntimeSession `agent-runtime-event`+`agent-runtime-event/v1`; id pattern unified to `[A-Za-z0-9_-]`.
- `packages/kernel/src/domain/entity-event.ts`: compileEntityUpsert rejects any non-`generic-entity-store` authoring with a readable message.
- `packages/kernel/src/store/entity-store.ts`: execution/review kind ifs deleted; reads via the shared interpreter.
- `packages/kernel/src/projection/*`: task-event hand-coded payload/id/SQL removed; schema 8->9 with discard-and-replay.
- Tests: execution/review now assert.throws through compileEntityUpsert, agent/squad still doesNotThrow; a synthetic third contract proves the interpreter is contract-driven.

## Machine-Readable Declarations

Production-Delta: +376/-113

## Task And Scope

- Harness task: task_bfcef3a36106109cd228b7162a (PLT-Ontology Phase 1.7)
- Branch: `codex/kind-projection-compat`
- Public scope: kernel entity kind contract projection + authoring gate, entity-store, rebuildable projection, tests
- Private planning/evidence updated: yes (artifacts/reports/kind-projection-squad.md, kind-projection-narrow.md)
- Out of scope: the remaining nine-kind authority overlaps (EntityRef grammar, entityRegistry schema/mutability) tracked as P1 deletion debt; 2.3 StartExecution itself

## Version Impact

- Version: no version change because this is a pre-release fix on the rebuild line
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_bfcef3a36106109cd228b7162a (PLT-Ontology Phase 1.7); 2.3 T-poc NO-GO prerequisite; antientropy review 2026-08-25 (narrow-then-keep: declarative read projection, delete generic dual-write) adopted by CEO
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 7c942e944
- Branch merge-base with `origin/main`: 7c942e944
- Last `git fetch origin` time: 2026-08-26T03:15Z
- Sync method: rebase
- Public diff command: `git diff 7c942e944..8f28fa0ec`
- Private evidence commit/path: harness task package task_bfcef3a36106109cd228b7162a artifacts/reports
- Reviewer evidence path: squad report + narrow report: production +376/-113 net +263 (of which the authoring narrowing is +12/-6); `rg 'contract.kind === "' packages/kernel/src`=0; compileEntityUpsert now throws for execution/review/runtime-session and passes for agent/squad (contract test); adversarial worker's schema-9 rebuild red at revision 26959 -> green after id-pattern unification; check:local green; schema-closure/derived-contracts pass with effect physically removed; control-char scan clean; CEO read the throws assertions, the zero kind-switch, and the generic rejection `if (contract.authoring.kind !== 'generic-entity-store') throw`
- GitHub Actions `rewrite-ci` run URL: pending (filled after the run)
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test` (execution-review-entity contract test, entity-store contract test, task-projection store test (isolated Ubuntu npm ci))
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full GitHub integration shard matrix locally (CI authority)

## Review Evidence

- Self-review: CEO: this closes a real dual-write latent path using the existing authoring field declaratively — no hardcoded blocklist, no schema churn; the adversarial worker turning a rebuild failure into a pattern-unification fix is the anti-entropy pattern working.
- Reviewer subagent: yes (read-only report audit with independent git verification)
- Human review: pending
- Blocking findings: none

## Residual Risk

- Nine-kind authority still has EntityRef-grammar and schema/mutability overlaps (P1); those are read/parse authorities, not write paths, so this PR's single-write-face claim holds for authoring.

## References

- Task: task_bfcef3a36106109cd228b7162a
- Evidence: artifacts/reports/kind-projection-squad.md, kind-projection-narrow.md
- Review: pending

---

# 中文

## 概要

Phase 1.7(2.3 T-poc 前置)让九类 kind contract 的纯数据驱动 embedded canonical-event 读投影,Execution/Review/RuntimeSession 不再需要 entity-store 或 task-event projector 里的按 kind 分支。`rg 'contract.kind === "' packages/kernel/src` 现为 0。compileEntityUpsert 通用拒绝一切非 `generic-entity-store` authoring,于是 Execution/Review(经 task-event/v1 lifecycle)与 RuntimeSession(经 agent-runtime-event/v1 handoff)不能再走 generic 写入口,只剩 Agent/Squad 可 generic authoring。对抗验证 worker 发现真 bug——lowercase-only ID 正则令 schema-9 rebuild 在真实历史 revision 26959 失败——修法是统一正则 `[A-Za-z0-9_-]` 而非加 alias。投影 schema 8→9 丢弃可重建 cache 并 replay canonical;事件 envelope 与 canonical 数据未变。

## 架构辩护

现有模块为何无法承载:entity-store.ts 硬编码 `contract.kind === "execution"/"review"` 分支、task-event projector 手写 payload/id/SQL,embedded lifecycle 实体有两个投影权威。要单一权威只能让读投影由 kind contract 纯数据驱动并删 kind switch。为何不能收窄:读解释器、entity-store kind-if 删除、generic authoring 拒绝必须同时落地,否则 generic entity-event 仍能覆盖 lifecycle Execution。删除了哪些废弃代码:execution/review EntityStore kind if、三段手写 task-event payload/id/SQL、generic entity-event kind filter、以及锁住 generic 覆盖能力的测试;schema 8→9 丢弃旧 cache 并 replay canonical。

## 改动内容

- `entity-kind-projection.ts`(新):由 contract `canonicalProjection` 驱动的纯数据 embedded 读投影解释器。
- `entity-kind-registry.ts`:Execution/Review 声明 `task-lifecycle`+`task-event/v1`,RuntimeSession `agent-runtime-event`+`agent-runtime-event/v1`;id 正则统一 `[A-Za-z0-9_-]`。
- `entity-event.ts`:compileEntityUpsert 对非 `generic-entity-store` authoring 通用拒绝并给可读消息。
- `entity-store.ts`:删 execution/review kind if,经共享解释器读。
- `projection/*`:删 task-event 手写 payload/id/SQL;schema 8→9 discard-and-replay。
- 测试:execution/review 改 assert.throws,agent/squad 仍 doesNotThrow;合成第三 contract 证解释器由声明驱动。

## 机读声明说明

- 机读声明只在英文块出现一次。

## 任务与范围

- Harness 任务:task_bfcef3a36106109cd228b7162a(PLT-Ontology Phase 1.7)
- 分支:`codex/kind-projection-compat`
- 公开范围:kernel kind contract 投影+authoring 门、entity-store、可重建投影、测试
- 私有计划 / 证据是否已更新:yes(artifacts/reports/kind-projection-squad.md, kind-projection-narrow.md)
- 范围外:九 kind 权威其余重叠(EntityRef grammar、entityRegistry schema/mutability)列 P1 删除债;2.3 StartExecution 本体

## 版本影响

- 版本:不改版本,原因是 rebuild 线 pre-release 修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_bfcef3a36106109cd228b7162a (PLT-Ontology Phase 1.7); 2.3 T-poc NO-GO prerequisite; antientropy review 2026-08-25 (narrow-then-keep: declarative read projection, delete generic dual-write) adopted by CEO
- 机器检查边界:本 PR 只声明该段存在;声明是否真实、充分,由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:7c942e944
- 当前分支与 `origin/main` 的 merge-base:7c942e944
- 最近一次 `git fetch origin` 时间:2026-08-26T03:15Z
- 同步方式:rebase
- 公开 diff 命令:`git diff 7c942e944..8f28fa0ec`
- 私有证据 commit/path:任务包 artifacts/reports
- Reviewer 证据路径:squad+收窄回执:production +376/-113 net +263(收窄部分 +12/-6);`rg 'contract.kind === "' packages/kernel/src`=0;compileEntityUpsert 对 execution/review/runtime-session throws、对 agent/squad 通过(contract 测试);对抗 worker 的 schema-9 rebuild 在 revision 26959 由红转绿(正则统一后);check:local 绿;effect 物理移除下两门过;控制字符扫描空;CEO 核过 throws 断言、零 kind-switch、通用拒绝 `if (contract.authoring.kind !== 'generic-entity-store') throw`
- GitHub Actions `rewrite-ci` run URL:待 run 结束后补
- [x] `npm ci`
- [x] `git diff --check`
- [ ] `npm run check`
- [x] `npm run typecheck`
- [x] `npm test`(execution-review-entity、entity-store contract、task-projection store 测试(Ubuntu 隔离 npm ci))
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:完整 GitHub integration shard 矩阵未本地跑(CI 权威)

## 审查证据

- 自查:CEO:用既有 authoring 字段声明式关掉一个真实双写 latent 路径——无硬编码 blocklist、无 schema churn;对抗 worker 把 rebuild 失败变成正则统一修复,是反熵纪律生效。
- Reviewer subagent:有(只读回执审计 + git 独立核实)
- 人工审查:待
- 阻塞发现:无

## 残余风险

- 九 kind 权威仍有 EntityRef grammar 与 schema/mutability 重叠(P1);那些是读/解析权威非写路,故本 PR 的 authoring 单写面结论成立。

## 关联材料

- 任务:task_bfcef3a36106109cd228b7162a
- 证据:artifacts/reports/kind-projection-squad.md, kind-projection-narrow.md
- 审查:待

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPPk3TmbURWuxcFY3kFimA

