### PR TITLE
test(doc-sync): fix F39 reconciliation flake in daemon-multi-repo-lifecycle

### DIFF
--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -259,9 +259,15 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
     mkdirSync(path.dirname(authored), { recursive: true });
     writeFileSync(authored, docBody);
     assert.equal(run(fixture.alpha, fixture.userRoot, ["doc", "status", "--path", docPath]).outcome, "applied");
-    assert.equal(
-      run(fixture.alpha, fixture.userRoot, ["doc", "sync", "--submit", "--task", "task-alpha"]).outcome,
-      "applied",
+    // The daemon's background local-repair reconciliation (repo-cell settleAuthoredCandidates, fired on
+    // every WAL flush) is the same idempotent doc-sync as this explicit submit; it may incorporate the
+    // freshly authored doc into canonical first. So this submit either applies it ("applied") or finds it
+    // already reconciled ("no_changes") — both mean the doc reached canonical, which the doc show below is
+    // the real proof of. Asserting a single outcome raced the background reconciliation (flake).
+    const notesSubmit = run(fixture.alpha, fixture.userRoot, ["doc", "sync", "--submit", "--task", "task-alpha"]);
+    assert.ok(
+      notesSubmit.outcome === "applied" || notesSubmit.outcome === "no_changes",
+      `submit must reconcile the authored doc (applied or no_changes), saw ${JSON.stringify(notesSubmit)}`,
     );
     assert.equal(run(fixture.alpha, fixture.userRoot, ["doc", "show", "--path", docPath]).evidence, docBody);
     const cleanSubmit = runMaybe(fixture.alpha, fixture.userRoot, ["doc", "sync", "--submit", "--path", docPath]);


### PR DESCRIPTION
# English

## Summary

Fixes flaky integration test `daemon-multi-repo-lifecycle-cli` (the recurring "F39" flake: `no_changes` vs `applied` at `daemon-multi-repo-lifecycle-cli.test.ts:262`) that intermittently reddens `integration-shard (2)` on unrelated PRs. Root-caused to a benign reconciliation race, fixed test-only. No production code changes.

## Architectural Justification

Not required (production net is +0/-0). The background reconciliation the test raced is load-bearing and correct, so nothing is removed.

## What Changed

- `packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts`: the test authored a doc then asserted its explicit `doc sync --submit --task` returned exactly `applied`. The daemon's background local-repair reconciliation (`repo-cell` `settleAuthoredCandidates`, fired on every WAL flush as the `daemon-local-repair` actor) is the **same idempotent doc-sync** and often incorporates the freshly authored doc into canonical first — so the explicit submit correctly sees it already reconciled and returns `no_changes`. In the reconciliation model a local commit is not the authoritative write; doc-sync into canonical is, and it converges regardless of which agent performs it, so *which* call is credited is not a meaningful distinction. The assertion now accepts the reconciled outcome (`applied` OR `no_changes`); the pre-existing `doc show` on the next line remains the real proof the content reached canonical. The other assertions are untouched.
- Root cause was established by instrumented reproduction (all instrumentation reverted): per-daemon traces showed a `doc-submit paths:[]` from actor `daemon-local-repair` publishing the doc's claim before the explicit `--task` submit scanned it. Not a client re-send, not multi-daemon.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +0/-0

## Task And Scope

- Harness task: PLT-Ontology milestone operational debt (F39 flake); no dedicated task — surfaced while unblocking PR #1825.
- Branch: `codex/f39-reconcile-flake`
- Public scope: one integration test file.
- Private planning/evidence updated: not applicable
- Out of scope: the background `settleAuthoredCandidates` reconciliation itself (load-bearing, unchanged); a separate `actual:1` exit that appears only under pathological 16-way local oversubscription (31s runtime; daemon response timeout under CPU starvation, not seen at CI-representative concurrency).

## Version Impact

- Version: no version change because this is a test-only correction.
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no

## Verification

- Base `origin/main` SHA: `7c942e94490c77b08aaf16001786936ecad95cec`
- Branch merge-base with `origin/main`: `7c942e94490c77b08aaf16001786936ecad95cec`
- Last `git fetch origin` time: 2026-08-25 (immediately before branch creation)
- Sync method: none needed (branch is at merge-base)
- Public diff command: `git diff origin/main...codex/f39-reconcile-flake`
- Targeted reproduction/fix evidence: baseline on clean `origin/main` reproduced `no_changes` at `:262` (~12% under 8-way local contention); after the change, `0/40` across five 8-way contended batches. A 16-way batch showed `0/40` for the F39 `no_changes` signature; the 2 failures there were a distinct `actual:1` daemon-timeout at 31s runtime from local CPU starvation, not this flake.
- Not run (worktree lacks `node_modules`): `npm ci`, `npm run check`, `npm run typecheck`, `npm test`, harness:* checks — GitHub Actions CI is the authority and runs the full matrix on this branch.

## Review Evidence

- Self-review: full instrumented root-cause (per-daemon ordered traces) established the mechanism before the fix; instrumentation reverted; working tree carries only the test assertion change; `prettier --check` clean.
- Reviewer subagent: none
- Human review: root cause and fix direction reviewed with the milestone owner (reconciliation-model framing; test over-specification, not a production defect).
- Blocking findings: none

## Residual Risk

- Very low. Test-only; the real invariant (doc reaches canonical) is still asserted by `doc show`. If the daemon-under-extreme-load `actual:1` exit ever appears on CI (not observed at CI concurrency), it is a separate daemon-robustness matter, not this change.

---

# 中文

## 摘要

修复偶发 integration 测试 `daemon-multi-repo-lifecycle-cli`(反复发作的「F39」flake:`daemon-multi-repo-lifecycle-cli.test.ts:262` 处 `no_changes` vs `applied`),它会随机把 `integration-shard (2)` 染红、拦住无关 PR。根因是一个良性的协调竞态,仅改测试,**无生产代码变更**。

## 架构理由

不需要(production 净 +0/-0)。测试抢跑的那个后台协调是 load-bearing 且正确的,不删任何东西。

## 变更内容

- `packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts`:测试 author 一个 doc 后,断言其显式 `doc sync --submit --task` 必须恰好回 `applied`。而 daemon 的**后台 local-repair 协调**(`repo-cell` 的 `settleAuthoredCandidates`,每次 WAL flush 后以 `daemon-local-repair` 身份触发)与显式 submit 是**同一个幂等 doc-sync**,常常先把刚 author 的 doc 并入 canonical——于是显式 submit 正确地看到「已协调」并回 `no_changes`。在协调模型里,本地提交不是权威写入,doc-sync 并入 canonical 才是,且无论哪个 agent 执行都收敛;因此「哪一次调用记功」没有意义。现在断言接受协调成功的结果(`applied` 或 `no_changes`);紧接着那行既有的 `doc show` 仍是「内容已到 canonical」的真实证据。其它断言不动。
- 根因由插桩复现坐实(插桩已全部还原):per-daemon trace 显示 actor `daemon-local-repair` 的 `doc-submit paths:[]` 在显式 `--task` submit 扫描前就 publish 了该 doc 的 claim。不是客户端重发,也与「多 daemon」无关。

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production 净行数:以下方唯一的 CI 背书 `Production-Delta` 为准,不再手填第二个指标。

## 机读声明

见上方英文块的 `Production-Delta: +0/-0`(全文仅声明一次)。

## 任务与范围

- Harness task:PLT-Ontology 里程碑运维债(F39 flake);无专门 task——在解锁 PR #1825 时顺手坐实。
- 分支:`codex/f39-reconcile-flake`
- 公开范围:一个 integration 测试文件。
- 私有计划/证据更新:不适用
- 范围外:后台 `settleAuthoredCandidates` 协调本身(load-bearing,不动);另有一个 `actual:1` 退出仅在本机病态 16 路超并发下出现(测试跑 31s;CPU 饥饿导致 daemon 响应超时,CI 级并发下未见)。

## 版本影响

- 版本:无变更,因为这是仅测试的修正。
- 发布影响:不发布

## 治理声明

- 触碰受保护面:否
- 受保护面范围:不适用
- 授权:不适用
- 机检边界:本 PR 只声明该声明存在;是否真实充分由 reviewer 判定。
- Break-glass:否

## 验证

- Base `origin/main` SHA:`7c942e94490c77b08aaf16001786936ecad95cec`
- 分支与 `origin/main` 的 merge-base:`7c942e94490c77b08aaf16001786936ecad95cec`
- 最近 `git fetch origin` 时间:2026-08-25(建分支前)
- 同步方式:无需(分支就在 merge-base)
- 公开 diff 命令:`git diff origin/main...codex/f39-reconcile-flake`
- 定向复现/修复证据:clean `origin/main` 上复现 `:262` 的 `no_changes`(8 路本机争抢约 12%);改后五批 8 路争抢 `0/40`。16 路一批对 F39 的 `no_changes` 签名 `0/40`;那批里 2 个失败是另一种 `actual:1` 的 daemon 超时(31s,本机 CPU 饥饿),非本 flake。
- 未运行(worktree 缺 `node_modules`):`npm ci`、`npm run check`、`npm run typecheck`、`npm test`、harness:* 检查——GitHub Actions CI 为权威,会在本分支跑完整矩阵。

## 复核证据

- 自审:改动前用完整插桩(per-daemon 有序 trace)坐实机制;插桩已还原;工作树只剩测试断言这一处改动;`prettier --check` 通过。
- Reviewer 子代理:无
- 人工复核:与里程碑 owner 一起复核了根因与修法方向(协调模型的定性;是测试过度断言,非生产缺陷)。
- 阻断性发现:无

## 残余风险

- 极低。仅测试;真正的不变量(doc 到达 canonical)仍由 `doc show` 断言。若那个「daemon 极端负载下 `actual:1`」退出将来在 CI 出现(CI 并发下未见),那是独立的 daemon 健壮性问题,与本变更无关。
