### PR TITLE
fix(tools): stop task-bound git wrapper self-recursion under PATH aliases

### DIFF
--- a/tools/git-hooks/git
+++ b/tools/git-hooks/git
@@ -6,7 +6,8 @@ filtered_path=
 old_ifs=$IFS
 IFS=:
 for entry in ${PATH:-}; do
-  [ "$entry" = "$guard_dir" ] && continue
+  # PATH and $0 can spell the same directory differently through filesystem aliases.
+  [ "$entry" -ef "$guard_dir" ] && continue
   if [ -n "$filtered_path" ]; then filtered_path="$filtered_path:$entry"; else filtered_path=$entry; fi
 done
 IFS=$old_ifs

--- a/tools/worker-discipline-hooks.test.mjs
+++ b/tools/worker-discipline-hooks.test.mjs
@@ -1,8 +1,18 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -58,6 +68,31 @@ test("canonical hooks reject worker commit and checkout", (context) => {
   assert.equal(checkout.status, 1, checkout.stderr);
   assert.match(checkout.stderr, /Refusing a worker checkout in the canonical repository root/u);
 });
+
+test(
+  "git wrapper skips filesystem-identical PATH aliases",
+  { skip: process.platform === "win32" ? "requires POSIX file-symbolic-link semantics" : false },
+  async (context) => {
+    const root = makeRepo(context, "hook-path-alias-"),
+      hooks = path.join(root, "tools", "git-hooks"),
+      hooksAlias = path.join(path.dirname(root), `${path.basename(root)}-hooks-alias`);
+    installHook(root, "git");
+    symlinkSync(hooks, hooksAlias, "dir");
+    context.after(() => rmSync(hooksAlias, { force: true }));
+
+    const result = await spawnWithDeadline("git", ["-C", root, "rev-parse", "--show-toplevel"], {
+      cwd: root,
+      env: {
+        ...process.env,
+        PATH: `${hooksAlias}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
+
+    assert.equal(result.timedOut, false, `git wrapper recursively invoked itself\n${result.stderr}`);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(realpathSync(result.stdout.trim()), root);
+  },
+);
 
 test("task-bound git wrapper permits only explicit codex branch push targets", (context) => {
   const root = makeRepo(context, "hook-push-guard-"),
@@ -123,7 +158,7 @@ test("worker handoff templates carry framework-owned publication rules", () => {
 });
 
 function makeRepo(context, prefix) {
-  const root = mkdtempSync(path.join(os.tmpdir(), prefix));
+  const root = realpathSync(mkdtempSync(path.join(os.tmpdir(), prefix)));
   context.after(() => rmSync(root, { recursive: true, force: true }));
   git(root, "init", "-q");
   git(root, "config", "user.email", "hook-test@example.invalid");
@@ -156,4 +191,41 @@ function git(root, ...args) {
 
 function digest(value) {
   return createHash("sha256").update(value).digest("hex");
+}
+
+function spawnWithDeadline(command, args, options) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+        ...options,
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+      stdout = [],
+      stderr = [];
+    let timedOut = false;
+    child.stdout.on("data", (chunk) => stdout.push(chunk));
+    child.stderr.on("data", (chunk) => stderr.push(chunk));
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        process.kill(-child.pid, "SIGKILL");
+      } catch (error) {
+        if (error?.code !== "ESRCH") reject(error);
+      }
+    }, 2_000);
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("close", (status, signal) => {
+      clearTimeout(timer);
+      resolve({
+        status,
+        signal,
+        stderr: Buffer.concat(stderr).toString("utf8"),
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        timedOut,
+      });
+    });
+  });
 }


### PR DESCRIPTION
# English

## Summary

The task-bound `tools/git-hooks/git` wrapper stripped its own directory from PATH by string equality. When PATH spelled that directory through a filesystem alias (macOS `/var/folders` vs `/private/var/folders`, or a rewritten `TMPDIR` in worker environments), the filter missed, the wrapper resolved `git` to itself and forked without bound. On 2026-08-26 this produced ~9,700 `sh` processes on a developer machine within 8 minutes while workers ran `tools/worker-discipline-hooks.test.mjs` through `check:local`.

## Architectural Justification

- Not required: Production-Delta churn is below 200 lines.

## What Changed

- `tools/git-hooks/git`: PATH entries are compared to the wrapper directory with `-ef` (same inode) instead of string equality, so aliases of the wrapper directory are filtered too.
- `tools/worker-discipline-hooks.test.mjs`: fixture roots are realpath-resolved; new test invokes the wrapper through a symlinked alias of its directory under a 2-second process-group deadline and asserts it exits normally (red before the fix).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +0/-0

### Optional Evidence Claims

## Task And Scope

- Harness task: task_6e3a192b00db5f92c37127ba48
- Branch: codex/git-wrapper-self-recursion
- Public scope: tools/git-hooks/git, tools/worker-discipline-hooks.test.mjs
- Private planning/evidence updated: yes
- Out of scope: how `ha runtime run` composes worker PATH/TMPDIR (tracked in the harness task)

## Version Impact

- Version: no version change because tooling-only fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_6e3a192b00db5f92c37127ba48
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 3be977e6f325c5b10a8bbe288110b226571582a1
- Branch merge-base with `origin/main`: 3be977e6f325c5b10a8bbe288110b226571582a1
- Last `git fetch origin` time: 2026-08-25T16:32Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_6e3a192b00db5f92c37127ba48 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] `node --test tools/worker-discipline-hooks.test.mjs` (all tests pass, process count stays flat)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full `npm run check:local` locally, because the unfixed wrapper in other worktrees on the same machine was still fork-bombing during this fix; CI is the authority.

## Review Evidence

- Self-review: CEO read the wrapper end to end and reproduced the alias mismatch mechanism from a live process tree.
- Reviewer subagent: implementation drafted by a Codex worker (sol), completed and validated by CEO.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Windows keeps the string comparison semantics via `-ef` support in POSIX shells only; the new test is skipped on win32.

## References

- Task: task_6e3a192b00db5f92c37127ba48
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

task-bound 的 `tools/git-hooks/git` 包装器用字符串相等把自己的目录从 PATH 剔除。当 PATH 用文件系统别名拼写该目录(macOS `/var/folders` 与 `/private/var/folders`,或 worker 环境改写的 `TMPDIR`)时剔除失败,包装器把 `git` 解析成自己并无限 fork。2026-08-26 worker 经 `check:local` 跑 `tools/worker-discipline-hooks.test.mjs` 时在开发机 8 分钟内拉出约 9,700 个 `sh`。

## 架构辩护

- 不需要:Production-Delta churn 低于 200 行。

## 改动内容

- `tools/git-hooks/git`:PATH 条目与包装器目录用 `-ef`(同一 inode)比较,别名也被剔除。
- `tools/worker-discipline-hooks.test.mjs`:夹具根目录 realpath 解析;新测试通过目录符号链接别名调用包装器,带 2 秒进程组 deadline,断言正常退出(修前红)。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_6e3a192b00db5f92c37127ba48
- 分支:codex/git-wrapper-self-recursion
- 公开范围:tools/git-hooks/git、tools/worker-discipline-hooks.test.mjs
- 私有计划 / 证据是否已更新:yes
- 范围外:`ha runtime run` 如何组合 worker 的 PATH/TMPDIR(在 harness 任务里跟踪)

## 版本影响

- 版本:不改版本,原因是仅工具修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_6e3a192b00db5f92c37127ba48
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:3be977e6f325c5b10a8bbe288110b226571582a1
- 当前分支与 `origin/main` 的 merge-base:3be977e6f325c5b10a8bbe288110b226571582a1
- 最近一次 `git fetch origin` 时间:2026-08-25T16:32Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_6e3a192b00db5f92c37127ba48
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] `node --test tools/worker-discipline-hooks.test.mjs`(全部通过,进程数不增长)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:本机完整 `npm run check:local`,因为同机其它 worktree 未修的包装器仍在 fork bomb;以 CI 为权威。

## 审查证据

- 自查:CEO 通读包装器并从活进程树复现别名不匹配机制。
- Reviewer subagent:实现由 Codex worker(sol)起草,CEO 完成并验证。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 新测试在 win32 跳过;`-ef` 依赖 POSIX shell。

## 关联材料

- 任务:task_6e3a192b00db5f92c37127ba48
- 证据:任务包 artifacts/reports
- 审查:本 PR
