### PR TITLE
fix(daemon): stop re-reading the task projection on every provider output line

### DIFF
--- a/packages/daemon/src/agent-runtime-stream.ts
+++ b/packages/daemon/src/agent-runtime-stream.ts
@@ -116,9 +116,6 @@ export function makeAgentRuntimeStreamHub(input: {
       };
     },
     publish: (runtimeSessionId, signal) => {
-      const session = input.readSession(runtimeSessionId);
-      if (session === null || !input.canAttach(session))
-        throw runtimeStreamError("unsupported", `Runtime session ${runtimeSessionId} has no live attach capability.`);
       const state = stateFor(runtimeSessionId),
         event = signalEvent(runtimeSessionId, ++state.sequence, now(), signal);
       if (validateAgentRuntimeAttachEvent(event).length) {

--- a/packages/daemon/test/agent-runtime-publish-projection.integration.test.ts
+++ b/packages/daemon/test/agent-runtime-publish-projection.integration.test.ts
@@ -1,0 +1,99 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { makeTaskEventStore, makeTaskProjection, type RuntimeSession } from "../../kernel/src/index.ts";
+import { makeAgentRuntimeStreamHub } from "../src/agent-runtime-stream.ts";
+import { parseProviderFrame } from "../src/runtime-spawn-provider-frames.ts";
+import { consumeProviderLine } from "../src/runtime-spawn-provider-stream.ts";
+
+test("provider output publication does not scale full projection reads with line count", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-runtime-publish-projection-"));
+  git(rootDir, "init", "-q");
+  git(rootDir, "config", "user.name", "Runtime Projection Test");
+  git(rootDir, "config", "user.email", "runtime-projection@example.invalid");
+  git(rootDir, "commit", "--allow-empty", "-qm", "base");
+
+  const store = makeTaskEventStore({ repoId: "runtime-projection", rootDir });
+  const projection = makeTaskProjection({ rootDir, eventStore: store });
+  const session: RuntimeSession = {
+    runtimeSessionId: "runtime-session",
+    instanceId: "instance-runtime",
+    installationId: "installation-runtime",
+    kindId: "codex",
+    definitionSnapshotRef: "artifact:runtime-definition/test",
+    providerSessionId: null,
+    transcriptRef: null,
+    launchGeneration: 1,
+    liveness: "live",
+    attachable: true,
+    taskBindings: [],
+    outcome: null,
+    exitCode: null,
+    resultRef: null,
+    lastObservedAt: "2026-08-13T00:00:00.000Z",
+  };
+  let fullProjectionReads = 0;
+  const stream = makeAgentRuntimeStreamHub({
+    readSession: (runtimeSessionId) => {
+      fullProjectionReads += 1;
+      projection.list();
+      return runtimeSessionId === session.runtimeSessionId ? session : null;
+    },
+    canAttach: ({ attachable }) => attachable,
+    now: () => new Date("2026-08-13T00:00:00.000Z"),
+  });
+  const active = {
+    runtimeSessionId: session.runtimeSessionId,
+    kindId: "codex",
+    stream: { appendProviderEvent: () => undefined },
+    durableOutputCount: 0,
+    finalText: null,
+    failureText: null,
+    providerOutcome: null,
+    writeItemObserved: false,
+    planObserved: false,
+    planIncomplete: false,
+    protocolError: false,
+  } as never;
+  const context = {
+    input: { stream, now: () => "2026-08-13T00:00:00.000Z" },
+    parseProviderFrame,
+    bindProvider: async () => undefined,
+    markProtocolError: () => assert.fail("valid provider output was rejected"),
+    isStructuredSuccessResult: () => false,
+  };
+
+  try {
+    for (let index = 0; index < 1_000; index += 1)
+      await consumeProviderLine(
+        context,
+        active,
+        JSON.stringify({
+          type: "item.completed",
+          item: { type: "agent_message", text: `line-${index}` },
+        }),
+      );
+
+    assert.equal(fullProjectionReads, 0);
+    const attached = stream.attach(session.runtimeSessionId, "stream:1000");
+    assert.equal(attached.initial.ok, true);
+    attached.detach();
+    stream.issueWitnessToken(session.runtimeSessionId, {
+      principalId: "person-owner",
+      source: "local",
+    });
+    assert.equal(fullProjectionReads, 2);
+  } finally {
+    stream.close();
+    projection.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+function git(rootDir: string, ...args: readonly string[]): string {
+  return execFileSync("git", ["-C", rootDir, ...args], { encoding: "utf8" }).trim();
+}


### PR DESCRIPTION
# English

## Summary

`AgentRuntimeStreamHub.publish` re-validated the runtime session on every provider output line; that `readSession` callback calls `projection.list()` first, i.e. a full task-projection read (1,360 tasks on the reference ledger) per line. With six concurrent workers the daemon pinned at 100% CPU and every `ha` command timed out (CPU profile: 43% self-time in `readSnapshot` under `publish`). The per-frame check is deleted; session validation stays at the attach and witness-token issuance boundaries, which are the real producer/consumer boundaries.

## Architectural Justification

- Not required: Production-Delta churn is below 200 lines.

## What Changed

- `packages/daemon/src/agent-runtime-stream.ts`: `publish` no longer calls `readSession`/`canAttach` per frame (-3 production lines). No cache, flag, throttle or timer added.
- `packages/daemon/test/agent-runtime-publish-projection.integration.test.ts`: 1,000 provider lines must not scale projection reads (red before the fix: `1000 !== 0`), plus attach/token boundary assertions.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +0/-3

### Optional Evidence Claims

## Task And Scope

- Harness task: task_66392d934c20eb70db6ff4144f
- Branch: codex/daemon-publish-projection
- Public scope: packages/daemon/src/agent-runtime-stream.ts and one new integration test
- Private planning/evidence updated: yes
- Out of scope: GUI polling of `repo.agentRuntime.sessions.read` and Agent/Squad ledger-replay reads (task_d0327cfa92ff9e424b58ef8945)

## Version Impact

- Version: no version change because pre-release internal fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_66392d934c20eb70db6ff4144f
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 11a8312a7980d3131e4626cba42c2e667c7c2358
- Branch merge-base with `origin/main`: 11a8312a7980d3131e4626cba42c2e667c7c2358
- Last `git fetch origin` time: 2026-08-25T18:12Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_66392d934c20eb70db6ff4144f (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] `npm run check:local` (worker run, green)
- [x] `tools/dispatch-isolated-test.mjs --target docker --file packages/daemon/test/agent-runtime-publish-projection.integration.test.ts` (red with the three lines restored, green after)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local macOS integration shard (one unrelated CLI daemon-lifecycle test red on the host, documented in the task report); CI is the authority.

## Review Evidence

- Self-review: CEO captured the CPU profile that located the hot path and accepted the deletion-only fix against dec_57A9D27BA446C23759A08B1C13.
- Reviewer subagent: implemented by Codex worker (sol) with red/green negative control.
- Human review: pending
- Blocking findings: none

## Residual Risk

- A provider that publishes after its session stopped being attachable is no longer rejected at publish time; consumers still gate on attachability at attach.

## References

- Task: task_66392d934c20eb70db6ff4144f
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

`AgentRuntimeStreamHub.publish` 对 worker 每一行 provider 输出都重新校验 runtime session;该 `readSession` 回调先调 `projection.list()`,即每行一次全量任务投影读(参考账本 1,360 任务)。6 个 worker 并发时 daemon 100% CPU、所有 `ha` 命令超时(CPU profile:`publish` 下 `readSnapshot` 占 43% self-time)。删除每帧校验;session 校验保留在 attach 与 witness token 签发边界,那才是真正的生产者/消费者边界。

## 架构辩护

- 不需要:Production-Delta churn 低于 200 行。

## 改动内容

- `packages/daemon/src/agent-runtime-stream.ts`:`publish` 不再每帧调 `readSession`/`canAttach`(-3 行生产代码)。不加缓存、标志、节流或定时器。
- `packages/daemon/test/agent-runtime-publish-projection.integration.test.ts`:1,000 行 provider 输出不得放大投影读(修前红:`1000 !== 0`),并断言 attach/token 边界仍校验。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_66392d934c20eb70db6ff4144f
- 分支:codex/daemon-publish-projection
- 公开范围:packages/daemon/src/agent-runtime-stream.ts 与一个新 integration 测试
- 私有计划 / 证据是否已更新:yes
- 范围外:GUI 对 `repo.agentRuntime.sessions.read` 的轮询与 Agent/Squad 账本重放读(task_d0327cfa92ff9e424b58ef8945)

## 版本影响

- 版本:不改版本,原因是预发布内部修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_66392d934c20eb70db6ff4144f
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:11a8312a7980d3131e4626cba42c2e667c7c2358
- 当前分支与 `origin/main` 的 merge-base:11a8312a7980d3131e4626cba42c2e667c7c2358
- 最近一次 `git fetch origin` 时间:2026-08-25T18:12Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_66392d934c20eb70db6ff4144f
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] `npm run check:local`(worker 跑,绿)
- [x] `tools/dispatch-isolated-test.mjs --target docker --file packages/daemon/test/agent-runtime-publish-projection.integration.test.ts`(还原三行为红,修后绿)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:本机完整 macOS integration shard(一个无关 CLI daemon-lifecycle 测试在宿主机红,任务报告有记录);以 CI 为权威。

## 审查证据

- 自查:CEO 抓取定位热路径的 CPU profile,并按 dec_57A9D27BA446C23759A08B1C13 验收纯删除修法。
- Reviewer subagent:Codex worker(sol)实现,带红/绿阴性对照。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- session 不再可 attach 后 provider 继续发布不再在 publish 时被拒;消费者仍在 attach 时按可 attach 性把关。

## 关联材料

- 任务:task_66392d934c20eb70db6ff4144f
- 证据:任务包 artifacts/reports
- 审查:本 PR
