### PR TITLE
perf(daemon): read GUI Agent/Squad from the entity projection instead of replaying the ledger

### DIFF
--- a/packages/daemon/src/agent-entities.ts
+++ b/packages/daemon/src/agent-entities.ts
@@ -1,6 +1,6 @@
 import { existsSync, lstatSync, readFileSync } from "node:fs";
 import path from "node:path";
-import { consumeKnownError, openEntityStore, type EntityStore } from "../../kernel/src/index.ts";
+import { consumeKnownError, openEntityStore, type EntityStore, type TaskProjection } from "../../kernel/src/index.ts";
 import {
   entitySlug,
   parseAgentDeclarationV1,
@@ -139,10 +139,9 @@ export function runAgentEntityAction(input: {
 export function readAgentEntityGuiProjection<
   const K extends "agent-list" | "squad-list" | "agent-inspect" | "squad-inspect",
 >(input: {
-  readonly rootDir: string;
   readonly kind: K;
   readonly entityId?: string;
-  readonly entityStore?: EntityStore;
+  readonly projection: Pick<TaskProjection, "listEntities" | "getEntity">;
 }): K extends "agent-list"
   ? Extract<AgentEntityGuiRead, { readonly schema: "agent-entity-catalog/v1" }>
   : K extends "squad-list"
@@ -150,46 +149,61 @@ export function readAgentEntityGuiProjection<
     : K extends "agent-inspect"
       ? Extract<AgentEntityGuiRead, { readonly schema: "agent-entity-detail/v1" }>
       : Extract<AgentEntityGuiRead, { readonly schema: "squad-entity-detail/v1" }> {
-  const action = input.kind.endsWith("-inspect")
-      ? {
-          kind: input.kind,
-          [input.kind === "agent-inspect" ? "agentId" : "squadId"]: requiredEntityText(input.entityId, "entityId"),
-        }
-      : { kind: input.kind },
-    evidence = agentEntityRecord(
-      runAgentEntityAction({ rootDir: input.rootDir, entityStore: input.entityStore, action }),
-    );
-  if (input.kind === "agent-list")
+  if (input.kind === "agent-list") {
+    const entities = readyEntityList(input.projection, "agent");
     return {
       schema: "agent-entity-catalog/v1",
       ok: true,
-      agents: Array.isArray(evidence.agents) ? evidence.agents.map(agentEntityRecord).map(agentEntityRow) : [],
+      agents: entities.map(({ value }) =>
+        agentEntityRow({ ...parseAgentDeclarationV1(value), layer: "user", validity: "valid", issues: [] }),
+      ),
     } as never;
-  if (input.kind === "squad-list")
+  }
+  if (input.kind === "squad-list") {
+    const entities = readyEntityList(input.projection, "squad");
     return {
       schema: "squad-entity-catalog/v1",
       ok: true,
-      squads: Array.isArray(evidence.squads) ? evidence.squads.map(agentEntityRecord).map(squadEntityRow) : [],
+      squads: entities.map(({ value }) =>
+        squadEntityRow({ ...parseSquadDeclarationV1(value), layer: "user", validity: "valid", issues: [] }),
+      ),
     } as never;
+  }
+  const entityId = requiredEntityText(input.entityId, "entityId");
   if (input.kind === "agent-inspect") {
-    const agent = agentEntityRecord(evidence.agent);
+    const agent = parseAgentDeclarationV1(readyEntityValue(input.projection, "agent", entityId));
     return {
       schema: "agent-entity-detail/v1",
       ok: true,
       agent: {
         id: entityText(agent.id),
         name: entityText(agent.name),
-        runtimeType: entityText(agent.runtime_type),
-        role: entityAgentRole(agent.role),
-        instructions: entityText(agent.instructions),
-        model: agent.model === undefined ? null : entityText(agent.model),
+        runtimeType: agent.runtime_type,
+        role: agent.role ?? "worker",
+        instructions: agent.instructions,
+        model: agent.model ?? null,
         skills: entitySkills(agent.skills),
-        prompts: entityStrings(agent.prompts),
-        preset: agent.preset === undefined ? null : entityText(agent.preset),
+        prompts: agent.prompts ?? [],
+        preset: agent.preset ?? null,
       },
     } as never;
   }
-  const squad = agentEntityRecord(evidence.squad);
+  const squad = parseSquadDeclarationV1(readyEntityValue(input.projection, "squad", entityId)),
+    missing = [squad.leader, ...squad.workers].filter((agentId) => {
+      try {
+        parseAgentDeclarationV1(readyEntityValue(input.projection, "agent", agentId));
+        return false;
+      } catch (error) {
+        if ((error as { code?: string }).code === "projection_pending") throw error;
+        consumeKnownError(error);
+        return true;
+      }
+    });
+  if (missing.length)
+    throw entityError(
+      "squad_agent_not_found",
+      `Squad ${squad.id} references unavailable agents: ${[...new Set(missing)].join(", ")}.`,
+    );
   return {
     schema: "squad-entity-detail/v1",
     ok: true,
@@ -201,6 +215,21 @@ export function readAgentEntityGuiProjection<
       roster: entityText(squad.roster),
     },
   } as never;
+}
+
+function readyEntityList(projection: Pick<TaskProjection, "listEntities">, kind: AgentEntityKind) {
+  return projection.listEntities(kind);
+}
+
+function readyEntityValue(
+  projection: Pick<TaskProjection, "getEntity">,
+  kind: AgentEntityKind,
+  id: string,
+): Readonly<Record<string, unknown>> {
+  if (!entitySlug(id)) throw entityError(`${kind}_not_found`, `${id} is not a valid ${kind} id.`);
+  const entity = projection.getEntity(kind, id);
+  if (entity === null) throw entityError(`${kind}_not_found`, `${id} is not an installed ${kind}.`);
+  return entity.value;
 }
 export function readAgentDeclaration(input: {
   readonly rootDir: string;

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -1,6 +1,5 @@
 import {
   assertCurrentWriter,
-  createEntityStore,
   projectDecisionReadiness,
   type TaskProjectionListQuery,
   type WriteReceipt,
@@ -210,16 +209,14 @@ export function createRepoCellApi(context: any): RepoCell {
       }),
     "repo.agent.entities.list": () =>
       readAgentEntityGuiProjection({
-        rootDir: context.rootDir,
         kind: "agent-list",
-        entityStore: createEntityStore(context.store),
+        projection: context.projection,
       }),
     "repo.agent.entity.read": (payload: Readonly<Record<string, unknown>>) =>
       readAgentEntityGuiProjection({
-        rootDir: context.rootDir,
         kind: "agent-inspect",
         entityId: context.requiredCellText(payload.agentId, "agentId"),
-        entityStore: createEntityStore(context.store),
+        projection: context.projection,
       }),
     "repo.agent.skills.list": () => ({
       schema: "agent-skill-catalog/v1" as const,
@@ -228,16 +225,14 @@ export function createRepoCellApi(context: any): RepoCell {
     }),
     "repo.squad.entities.list": () =>
       readAgentEntityGuiProjection({
-        rootDir: context.rootDir,
         kind: "squad-list",
-        entityStore: createEntityStore(context.store),
+        projection: context.projection,
       }),
     "repo.squad.entity.read": (payload: Readonly<Record<string, unknown>>) =>
       readAgentEntityGuiProjection({
-        rootDir: context.rootDir,
         kind: "squad-inspect",
         entityId: context.requiredCellText(payload.squadId, "squadId"),
-        entityStore: createEntityStore(context.store),
+        projection: context.projection,
       }),
     "repo.decisions.list": () => {
       const read = context.projection.listDecisions({}),

--- a/packages/daemon/test/agent-entities.test.ts
+++ b/packages/daemon/test/agent-entities.test.ts
@@ -14,7 +14,7 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { createEntityStore, makeTaskEventStore } from "../../kernel/src/index.ts";
+import { createEntityStore, makeTaskEventStore, makeTaskProjection } from "../../kernel/src/index.ts";
 import {
   prepareAgentEntityInstall,
   readAgentEntityGuiProjection,
@@ -428,13 +428,24 @@ test("entity validation names every malformed manifest and refuses squads that r
 test("the GUI entity projection lists closed rows and reads closed declarations", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-agent-entities-gui-")),
     source = path.join(rootDir, "source");
+  let projection: ReturnType<typeof makeTaskProjection> | undefined;
   try {
     writeEntity(source, "terra", "agent", agent);
     writeEntity(source, "core-squad", "squad", squad);
     await install({ rootDir, kind: "agent-install", packageSource: path.join(source, "terra") });
     await install({ rootDir, kind: "squad-install", packageSource: path.join(source, "core-squad") });
-    const agentRows = readAgentEntityGuiProjection({ rootDir, kind: "agent-list" }),
-      squadRows = readAgentEntityGuiProjection({ rootDir, kind: "squad-list" });
+    const eventStore = makeTaskEventStore({ repoId: "agent-entities-gui", rootDir });
+    let canonicalReads = 0;
+    const guardedEventStore = {
+      ...eventStore,
+      read: () => {
+        canonicalReads += 1;
+        return eventStore.read();
+      },
+    };
+    projection = makeTaskProjection({ rootDir, eventStore: guardedEventStore });
+    const agentRows = readAgentEntityGuiProjection({ kind: "agent-list", projection }),
+      squadRows = readAgentEntityGuiProjection({ kind: "squad-list", projection });
     assert.equal(agentRows.schema, "agent-entity-catalog/v1");
     assert.equal(agentRows.ok, true);
     assert.deepEqual(
@@ -462,8 +473,17 @@ test("the GUI entity projection lists closed rows and reads closed declarations"
       squadRows.squads.map(({ id, leader, workers }) => ({ id, leader, workers })),
       [{ id: "core-squad", leader: "terra", workers: ["terra"] }],
     );
-    const agentDetail = readAgentEntityGuiProjection({ rootDir, kind: "agent-inspect", entityId: "terra" }),
-      squadDetail = readAgentEntityGuiProjection({ rootDir, kind: "squad-inspect", entityId: "core-squad" });
+    const agentDetail = readAgentEntityGuiProjection({
+        kind: "agent-inspect",
+        entityId: "terra",
+        projection,
+      }),
+      squadDetail = readAgentEntityGuiProjection({
+        kind: "squad-inspect",
+        entityId: "core-squad",
+        projection,
+      });
+    assert.equal(canonicalReads, 0, "GUI projection reads must not replay the canonical event stream");
     assert.equal(agentDetail.ok, true);
     assert.equal(squadDetail.ok, true);
     assert.deepEqual(agentDetail.agent, {
@@ -485,10 +505,11 @@ test("the GUI entity projection lists closed rows and reads closed declarations"
       roster: squad.roster,
     });
     assert.throws(
-      () => readAgentEntityGuiProjection({ rootDir, kind: "agent-inspect", entityId: "unknown" }),
+      () => readAgentEntityGuiProjection({ kind: "agent-inspect", entityId: "unknown", projection: projection! }),
       (error: unknown) => (error as { code?: string }).code === "agent_not_found",
     );
   } finally {
+    projection?.close();
     rmSync(rootDir, { recursive: true, force: true });
   }
 });

--- a/packages/kernel/src/domain/entity-kind-projection.ts
+++ b/packages/kernel/src/domain/entity-kind-projection.ts
@@ -29,7 +29,7 @@ export interface InterpretedEntityRelation {
 }
 
 export interface InterpretedEntityProjection extends InterpretedEntityValue {
-  readonly ownerId: string;
+  readonly ownerId: string | null;
   readonly workspaceRevision: number;
   readonly relations: readonly InterpretedEntityRelation[];
 }
@@ -73,7 +73,10 @@ export function deriveEntityProjection(
   if (declaration === null) return null;
   if (entity.kind !== contract.kind) throw new Error(`${entity.kind} cannot be projected by ${contract.kind}`);
   const rowId = stringField(entity.value, declaration.row.idField, `${contract.kind} projection identity`),
-    ownerId = stringField(entity.value, declaration.row.ownerField, `${contract.kind} projection owner`);
+    ownerId =
+      declaration.row.ownerField === null
+        ? null
+        : stringField(entity.value, declaration.row.ownerField, `${contract.kind} projection owner`);
   if (rowId !== entity.id)
     throw new Error(`${contract.kind} projection identity does not match its EntityKindContract identity`);
   const relations = contract.relations.edges.flatMap((edge, recordIndex) => {

--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -441,7 +441,7 @@ export const entityKindContracts = Object.freeze([
     schema: AGENT_DECLARATION_V1_SCHEMA,
     id: { ...declarationId, refTemplate: "agent/{id}" },
     relations: { directions: [], edges: [] },
-    canonicalProjection: null,
+    canonicalProjection: { embeddedEvents: [], row: { idField: "id", ownerField: null } },
     statusVocabulary: [{ field: "state", words: agentStates }],
     actionCatalog: actionCatalog("kernel/agent-declaration/v1", "agent", "agent/{id}", [
       "configure",
@@ -457,7 +457,7 @@ export const entityKindContracts = Object.freeze([
     schema: SQUAD_DECLARATION_V1_SCHEMA,
     id: { ...declarationId, refTemplate: "squad/{id}" },
     relations: { directions: [], edges: [] },
-    canonicalProjection: null,
+    canonicalProjection: { embeddedEvents: [], row: { idField: "id", ownerField: null } },
     actionCatalog: null,
     entityStore: genericEntityStore("squads/{id}.json"),
     authoring: genericAuthoring,

--- a/packages/kernel/src/entity/registry-contract.ts
+++ b/packages/kernel/src/entity/registry-contract.ts
@@ -54,7 +54,7 @@ export interface EntityCanonicalProjectionDeclaration {
   readonly embeddedEvents: ReadonlyArray<EmbeddedCanonicalEventDeclaration>;
   readonly row: {
     readonly idField: string;
-    readonly ownerField: string;
+    readonly ownerField: string | null;
   };
 }
 export interface EntityRelationProjectionDeclaration {

--- a/packages/kernel/src/projection/projection-schema.ts
+++ b/packages/kernel/src/projection/projection-schema.ts
@@ -1,11 +1,12 @@
 import { DatabaseSync } from "node:sqlite";
 import { localRuntimeStateFileSystem } from "../local/local-layout-file-system.ts";
 
-// Version 9 derives execution/review relation edges while replaying their canonical events.
+// Version 10 projects generic Agent/Squad entity events, including the historical
+// agent-entity-event/v1 alias, into entity_projection with no task owner.
 // A version mismatch takes the
 // existing discard-and-replay path in rebuildable-task-projection.ts, so each
 // machine cold-rebuilds task.sqlite once on its first read.
-export const taskProjectionSchemaVersion = 9;
+export const taskProjectionSchemaVersion = 10;
 
 export function readTaskProjectionSchemaVersion(projectionPath: string): number | null {
   if (!localRuntimeStateFileSystem.exists(projectionPath)) return null;

--- a/packages/kernel/src/projection/rebuildable-task-projection-entities.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-entities.ts
@@ -8,7 +8,8 @@ import {
   type InterpretedEntityProjection,
 } from "../domain/entity-kind-projection.ts";
 import { entityKindContracts, type EntityKindContract } from "../domain/entity-kind-registry.ts";
-import { canonicalJson, runSql } from "./rebuildable-task-projection-sql.ts";
+import { canonicalJson, queryRows, runSql } from "./rebuildable-task-projection-sql.ts";
+import type { EntityProjectionRow } from "./task-projection-port.ts";
 
 const UPSERT_ENTITY_SQL = [
   "INSERT INTO entity_projection(entity_kind, entity_id, task_id, workspace_revision, value_json)",
@@ -23,6 +24,14 @@ const UPSERT_RELATION_SQL = [
   "relation_type=excluded.relation_type, state=excluded.state, owner_ref=excluded.owner_ref,",
   "workspace_revision=excluded.workspace_revision, row_json=excluded.row_json",
   "WHERE relation_edge.workspace_revision <= excluded.workspace_revision",
+].join(" ");
+const LIST_ENTITY_SQL = [
+  "SELECT entity_kind, entity_id, task_id, workspace_revision, value_json FROM entity_projection",
+  "WHERE entity_kind = ? ORDER BY entity_id",
+].join(" ");
+const GET_ENTITY_SQL = [
+  "SELECT entity_kind, entity_id, task_id, workspace_revision, value_json FROM entity_projection",
+  "WHERE entity_kind = ? AND entity_id = ? LIMIT 1",
 ].join(" ");
 
 export function projectEmbeddedCanonicalEntities(db: DatabaseSync, event: CanonicalEventV1): void {
@@ -65,4 +74,30 @@ function writeEntityProjection(db: DatabaseSync, projection: InterpretedEntityPr
       projection.workspaceRevision,
       canonicalJson(relation),
     );
+}
+
+export function listEntityProjectionRows(db: DatabaseSync, entityKind: string): readonly EntityProjectionRow[] {
+  return queryRows(db, LIST_ENTITY_SQL, entityKind).map(entityProjectionRow);
+}
+
+export function getEntityProjectionRow(
+  db: DatabaseSync,
+  entityKind: string,
+  entityId: string,
+): EntityProjectionRow | null {
+  const row = queryRows(db, GET_ENTITY_SQL, entityKind, entityId)[0];
+  return row === undefined ? null : entityProjectionRow(row);
+}
+
+function entityProjectionRow(row: Readonly<Record<string, unknown>>): EntityProjectionRow {
+  const value = JSON.parse(String(row.value_json)) as unknown;
+  if (typeof value !== "object" || value === null || Array.isArray(value))
+    throw new Error("entity projection value must be an object");
+  return {
+    kind: String(row.entity_kind),
+    id: String(row.entity_id),
+    ownerId: row.task_id === null ? null : String(row.task_id),
+    workspaceRevision: Number(row.workspace_revision),
+    value: value as Readonly<Record<string, unknown>>,
+  };
 }

--- a/packages/kernel/src/projection/rebuildable-task-projection-entity-api.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-entity-api.ts
@@ -1,0 +1,34 @@
+// @write-boundary-exemption rebuildable-projection
+import type { TaskProjection } from "./task-projection-port.ts";
+import type { ProjectionContext } from "./rebuildable-task-projection-types.ts";
+import { catchUpRound } from "./rebuildable-task-projection-catch-up.ts";
+import { withDatabase } from "./rebuildable-task-projection-database.ts";
+import { getEntityProjectionRow, listEntityProjectionRows } from "./rebuildable-task-projection-entities.ts";
+import { watermark } from "./rebuildable-task-projection-sql.ts";
+
+export function entityQueryApi(context: ProjectionContext): Pick<TaskProjection, "listEntities" | "getEntity"> {
+  const { eventStore, limit, projectionPath, readHead } = context;
+  return {
+    listEntities: (entityKind) =>
+      withDatabase(projectionPath, readHead, (db) => {
+        const round = catchUpRound(db, eventStore, limit),
+          current = watermark(db);
+        requireReadyEntityCut(current, round.sourceRevision);
+        return listEntityProjectionRows(db, entityKind);
+      }),
+    getEntity: (entityKind, entityId) =>
+      withDatabase(projectionPath, readHead, (db) => {
+        const round = catchUpRound(db, eventStore, limit),
+          current = watermark(db);
+        requireReadyEntityCut(current, round.sourceRevision);
+        return getEntityProjectionRow(db, entityKind, entityId);
+      }),
+  };
+}
+
+function requireReadyEntityCut(watermark: number, sourceRevision: number): void {
+  if (watermark === sourceRevision) return;
+  throw Object.assign(new Error(`Entity projection is catching up (${watermark}/${sourceRevision}); retry the read.`), {
+    code: "projection_pending" as const,
+  });
+}

--- a/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
@@ -39,6 +39,7 @@ import {
 import { reduceBatch } from "./rebuildable-task-projection-catch-up.ts";
 import { listProjection, readProjection, rebuildProjection } from "./rebuildable-task-projection-reads.ts";
 import { knowledgeQueryApi } from "./rebuildable-task-projection-knowledge-queries.ts";
+import { entityQueryApi } from "./rebuildable-task-projection-entity-api.ts";
 import { runtimeLeaseApi } from "./rebuildable-task-projection-runtime-api.ts";
 import { taskQueryApi } from "./rebuildable-task-projection-task-queries.ts";
 import { markRuntimeSessionsUnknown } from "./rebuildable-task-projection-runtime.ts";
@@ -137,6 +138,7 @@ export function makeTaskProjection(options: {
     readStateDigest: () => withDatabase(projectionPath, readHead, readStateDigest),
     read: (taskId) => readProjection(projectionPath, readHead, options.eventStore, taskId, limit, now),
     list: (query) => listProjection(projectionPath, readHead, options.eventStore, limit, now, query),
+    ...entityQueryApi(context),
     ...taskQueryApi(context),
     ...knowledgeQueryApi(context),
     ...runtimeLeaseApi(context),

--- a/packages/kernel/src/projection/task-projection-port.ts
+++ b/packages/kernel/src/projection/task-projection-port.ts
@@ -44,12 +44,21 @@ export interface RuntimeSessionPageRead {
   readonly remainingCount: number;
 }
 
+export interface EntityProjectionRow {
+  readonly kind: string;
+  readonly id: string;
+  readonly ownerId: string | null;
+  readonly workspaceRevision: number;
+  readonly value: Readonly<Record<string, unknown>>;
+}
 export interface TaskProjection {
   readonly path: string;
   readonly close: () => void;
   readonly apply: (event: CanonicalEventV1, plan?: FrozenWritePlan) => ProjectionApplyReceipt;
   readonly rebuild: () => ProjectionRebuildReceipt;
   readonly readStateDigest: () => `sha256:${string}` | null;
+  readonly listEntities: (entityKind: string) => readonly EntityProjectionRow[];
+  readonly getEntity: (entityKind: string, entityId: string) => EntityProjectionRow | null;
   readonly read: (taskId: string) => TaskProjectionRead;
   readonly list: (query?: TaskProjectionListQuery) => TaskProjectionListRead;
   readonly readWorkspaceSummary: () => WorkspaceSummaryProjectionRead;

--- a/packages/kernel/test/contracts/entity-store.test.ts
+++ b/packages/kernel/test/contracts/entity-store.test.ts
@@ -41,6 +41,10 @@ test("registered declaration Entity kinds explain the same contract shape from t
     ]);
     assert.equal(explanation.id.field, "id");
     assert.equal(explanation.relations.directions.length, 0);
+    assert.deepEqual(explanation.canonicalProjection, {
+      embeddedEvents: [],
+      row: { idField: "id", ownerField: null },
+    });
   }
   assert.deepEqual(
     { catalogRef: explanations[0]!.transitions.catalogRef, available: explanations[0]!.transitions.available },

--- a/packages/kernel/test/store/task-projection.test.ts
+++ b/packages/kernel/test/store/task-projection.test.ts
@@ -23,6 +23,7 @@ import {
   decideDocWrite,
   parseDocWriteIntent,
   serializeCanonicalEvent,
+  type CanonicalEventV1,
   type DocEventV1,
 } from "../../src/domain/doc-sync.contract.ts";
 import {
@@ -583,6 +584,28 @@ test("generic entity events project declaration documents without overriding lif
     eventStore.append(bundle);
     projection.apply(bundle.event, bundle.plan);
 
+    const listedAgents = projection.listEntities("agent");
+    assert.deepEqual(
+      listedAgents.map(({ kind, id, ownerId, workspaceRevision, value }) => ({
+        kind,
+        id,
+        ownerId,
+        workspaceRevision,
+        name: value.name,
+      })),
+      [
+        {
+          kind: "agent",
+          id: "projection-agent",
+          ownerId: null,
+          workspaceRevision: 3,
+          name: "Projection Agent",
+        },
+      ],
+    );
+    assert.deepEqual(projection.getEntity("agent", "projection-agent"), listedAgents[0]);
+    assert.equal(projection.getEntity("agent", "missing"), null);
+
     assert.equal(projection.read("task-1").snapshot.executions[0]?.state, "active");
     assert.deepEqual(
       projection
@@ -597,6 +620,72 @@ test("generic entity events project declaration documents without overriding lif
       { path: document.path, workspaceRevision: document.workspaceRevision, id: JSON.parse(document.body).id },
       { path: "agents/projection-agent.json", workspaceRevision: 3, id: "projection-agent" },
     );
+  });
+});
+
+test("historical agent entity envelopes replay into the generic entity projection", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    const actor = lifecycleFixture().events[0]!.actor,
+      bundle = compileEntityUpsert({
+        entityKind: "agent",
+        entity: {
+          schema: "agent-declaration/v1",
+          id: "historical-agent",
+          name: "Historical Agent",
+          instructions: "Remain readable after projection cutover.",
+          runtime_type: "codex",
+        },
+        eventId: "event-historical-agent",
+        opId: "op-historical-agent",
+        workspaceRevision: 1,
+        actor,
+        source: "local",
+        occurredAt: "2026-08-11T00:01:00.000Z",
+      }),
+      event = {
+        ...bundle.event,
+        schema: "agent-entity-event/v1",
+        type: "agent_entity_written",
+      } as unknown as CanonicalEventV1,
+      body = bundle.blobs[0].body,
+      bytes = new TextEncoder().encode(body),
+      eventDigest = `sha256:${sha256Text(serializeCanonicalEvent(event))}` as const,
+      eventStore = {
+        readHead: () => ({ revision: 1, eventDigest }),
+        readBatch: () => ({
+          sourceRevision: 1,
+          events: [event],
+          cursor: null,
+          done: true,
+          accessedItems: 1,
+          prefetchContent: () => new Map([[bundle.blobs[0].sha256, bytes]]),
+        }),
+        readContentBlob: (sha256: string) => (sha256 === bundle.blobs[0].sha256 ? bytes : null),
+      },
+      projection = makeTaskProjection({ rootDir, eventStore });
+    try {
+      const read = projection.getEntity("agent", "historical-agent");
+      assert.deepEqual(
+        read === null
+          ? null
+          : {
+              kind: read.kind,
+              id: read.id,
+              ownerId: read.ownerId,
+              workspaceRevision: read.workspaceRevision,
+              name: read.value.name,
+            },
+        {
+          kind: "agent",
+          id: "historical-agent",
+          ownerId: null,
+          workspaceRevision: 1,
+          name: "Historical Agent",
+        },
+      );
+    } finally {
+      projection.close();
+    }
   });
 });
 


### PR DESCRIPTION
# English

## Summary

The four GUI Agent/Squad list/show handlers each built a canonical `EntityStore` and replayed the whole Git event ledger on every call (16 s per Agent list, 15 s per Squad list on the reference ledger), which is why the runtime tabs took 20–30 s to open. Agent and Squad now project into the existing `entity_projection` table (ownerless rows); the kernel projection port exposes per-kind `listEntities`/`getEntity` with a bounded catch-up and fails closed with `projection_pending` instead of returning stale rows; the four handlers read that port and the four `createEntityStore(...)` calls are deleted. Cold read after the cutover: 0.4 ms / 0.1 ms with zero canonical stream reads.

## Architectural Justification

- Churn is above 200 lines because the read path moves from an ad-hoc ledger replay into the existing rebuildable SQLite projection: registry declares the Agent/Squad projection, the projection gains kind-scoped row queries, and the daemon handlers shrink to port calls. No cache, preload, timeout or second state store is added; the only new state is rows in the already-existing `entity_projection` table. Projection schema 9 → 10: table shape unchanged; old caches are discarded and replayed from canonical (`entity-event/v1` and the read-only `agent-entity-event/v1` alias both replay), so no data is lost (F38 discipline).

## What Changed

- kernel: `entity-kind-registry.ts` registers ownerless canonical projection for agent/squad; `entity-kind-projection.ts` / `entity/registry-contract.ts` accept `ownerField: null`; projection schema 10, entity-row list/get SQL, bounded catch-up API, port/factory wiring.
- daemon: `agent-entities.ts` builds GUI DTOs from projection rows (Squad→Agent reference check kept); `repo-cell-api.ts` `repo.agent.entities.list`, `repo.agent.entity.read`, `repo.squad.entities.list`, `repo.squad.entity.read` read the port; four `createEntityStore` calls deleted.
- tests: projection entity rows, generic-event projection without lifecycle override, GUI entity projection read.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +149/-41

### Optional Evidence Claims

## Task And Scope

- Harness task: task_d0327cfa92ff9e424b58ef8945
- Branch: codex/gui-runtime-tabs-perf
- Public scope: packages/kernel (registry + projection), packages/daemon (agent-entities, repo-cell-api), tests (15 files)
- Private planning/evidence updated: yes
- Out of scope: Provider page synchronous discovery/auth probe amplification and GUI polling cadence (separate tasks); GUI components untouched

## Version Impact

- Version: no version change because pre-release internal change (projection cache schema bump only)
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_d0327cfa92ff9e424b58ef8945
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: a228d89485f3377fa1a1df8f366efcab8d7e0e76
- Branch merge-base with `origin/main`: a228d89485f3377fa1a1df8f366efcab8d7e0e76
- Last `git fetch origin` time: 2026-08-25T18:45Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_d0327cfa92ff9e424b58ef8945 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] `npm run check:local` (worker run, green)
- [x] `tools/dispatch-isolated-test.mjs --target docker` for the projection/GUI-read integration tests (green)
- [x] cold-process read benchmark on the reference ledger: Agent 16,068 ms → 0.394 ms, Squad 14,934 ms → 0.117 ms, canonical full reads 0
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: nothing else; CI is the authority.

## Review Evidence

- Self-review: CEO accepted the root-cause checkpoint report (ledger replay per GUI read) and the deletion-first design before implementation; verified the four `createEntityStore` sites are gone.
- Reviewer subagent: Codex worker (sol) root-cause round + implementation round with red/green evidence.
- Human review: pending
- Blocking findings: none

## Residual Risk

- While the projection is still catching up after a restart, GUI Agent/Squad reads return `projection_pending` instead of data; the GUI already handles pending receipts for task reads.

## References

- Task: task_d0327cfa92ff9e424b58ef8945
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

GUI 的四个 Agent/Squad list/show handler 每次调用都新建 canonical `EntityStore` 并重放整个 Git 事件账本(参考账本上 Agent list 16 秒、Squad list 15 秒),这就是运行时 tab 要 20–30 秒才打开的原因。Agent/Squad 现在投影进既有 `entity_projection` 表(无 owner 行);kernel projection port 暴露按 kind 的 `listEntities`/`getEntity`,带 bounded catch-up,追不平时以 `projection_pending` fail-closed 而不返回陈旧行;四个 handler 改读该 port,四处 `createEntityStore(...)` 删除。切换后冷读 0.4 ms / 0.1 ms,canonical stream 读取为 0。

## 架构辩护

- churn 超过 200 行是因为读路径从临时账本重放迁到既有 rebuildable SQLite 投影:registry 声明 Agent/Squad 投影,投影增加按 kind 的行查询,daemon handler 收缩成 port 调用。不加缓存、预加载、超时或第二状态存储;唯一新增状态是既有 `entity_projection` 表里的行。投影 schema 9 → 10:表形状不变;旧缓存丢弃并从 canonical 重放(`entity-event/v1` 与只读 alias `agent-entity-event/v1` 都重放),数据不丢(F38 纪律)。

## 改动内容

- kernel:`entity-kind-registry.ts` 为 agent/squad 注册无 owner 的 canonical projection;`entity-kind-projection.ts` / `entity/registry-contract.ts` 接受 `ownerField: null`;投影 schema 10、entity 行 list/get SQL、bounded catch-up API、port/factory 接线。
- daemon:`agent-entities.ts` 由投影行构造 GUI DTO(保留 Squad→Agent 引用校验);`repo-cell-api.ts` 的四个 handler 改读 port;四处 `createEntityStore` 删除。
- 测试:投影 entity 行、generic 事件投影不覆盖 lifecycle、GUI entity 投影读。

## 门收割 / Gate Harvest

- 删除的生产路径:none(只删调用点,未删整文件)
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_d0327cfa92ff9e424b58ef8945
- 分支:codex/gui-runtime-tabs-perf
- 公开范围:packages/kernel(registry + projection)、packages/daemon(agent-entities、repo-cell-api)、测试(15 个文件)
- 私有计划 / 证据是否已更新:yes
- 范围外:Provider 页同步 discovery/auth probe 放大与 GUI 轮询节奏(另立任务);GUI 组件未动

## 版本影响

- 版本:不改版本,原因是预发布内部改动(仅投影缓存 schema 升版)
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_d0327cfa92ff9e424b58ef8945
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:a228d89485f3377fa1a1df8f366efcab8d7e0e76
- 当前分支与 `origin/main` 的 merge-base:a228d89485f3377fa1a1df8f366efcab8d7e0e76
- 最近一次 `git fetch origin` 时间:2026-08-25T18:45Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_d0327cfa92ff9e424b58ef8945
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] `npm run check:local`(worker 跑,绿)
- [x] `tools/dispatch-isolated-test.mjs --target docker` 跑投影/GUI 读 integration 测试(绿)
- [x] 参考账本冷进程读基准:Agent 16,068 ms → 0.394 ms,Squad 14,934 ms → 0.117 ms,canonical 全量读 0
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:无;以 CI 为权威。

## 审查证据

- 自查:CEO 在实现前验收根因 checkpoint 报告(每次 GUI 读都重放账本)与删除优先设计;复核四处 `createEntityStore` 已删除。
- Reviewer subagent:Codex worker(sol)根因轮 + 实现轮,带红/绿证据。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 重启后投影尚未追平时,GUI Agent/Squad 读返回 `projection_pending` 而不是数据;GUI 对 task 读已处理 pending 回执。

## 关联材料

- 任务:task_d0327cfa92ff9e424b58ef8945
- 证据:任务包 artifacts/reports
- 审查:本 PR
