### PR TITLE
fix(gui): make task detail fill wide viewports

### DIFF
--- a/packages/gui/src/renderer/components/DocReader.tsx
+++ b/packages/gui/src/renderer/components/DocReader.tsx
@@ -28,8 +28,14 @@ const components: Components = {
   },
 };
 
-type ReaderLayout = "single" | "double";
+type ReaderLayout = "auto" | "single" | "double";
 type ReaderFont = "sans" | "serif" | "mono";
+
+const readerLayouts: ReadonlyArray<{ readonly value: ReaderLayout; readonly label: string }> = [
+  { value: "auto", label: "自适应" },
+  { value: "single", label: "单栏" },
+  { value: "double", label: "双栏" },
+];
 
 const readerFonts: Record<ReaderFont, string> = {
   sans: "var(--font-sans)",
@@ -39,7 +45,7 @@ const readerFonts: Record<ReaderFont, string> = {
 
 export function DocReader({ content }: { content: string }) {
   const [query, setQuery] = useState("");
-  const [layout, setLayout] = useState<ReaderLayout>("single");
+  const [layout, setLayout] = useState<ReaderLayout>("auto");
   const [font, setFont] = useState<ReaderFont>("sans");
   const [fontSize, setFontSize] = useState(15);
 
@@ -84,8 +90,10 @@ export function DocReader({ content }: { content: string }) {
           ].join(" ")}
           data-testid="reader-floating-toolbar"
         >
+          {/* 栏数默认「自适应」:由 .doc-flow 容器查询按可用宽度自动分栏,无需点击;
+              单栏/双栏是显式覆盖,手动选择后仍可切回自适应。 */}
           <div className="flex items-center rounded-md border border-border bg-surface p-0.5" aria-label="阅读栏数">
-            {(["single", "double"] as const).map((value) => (
+            {readerLayouts.map(({ value, label }) => (
               <button
                 key={value}
                 type="button"
@@ -95,7 +103,7 @@ export function DocReader({ content }: { content: string }) {
                   layout === value ? "bg-accent text-accent-fg" : "text-text-muted hover:text-text"
                 }`}
               >
-                {value === "single" ? "单栏" : "双栏"}
+                {label}
               </button>
             ))}
           </div>
@@ -138,7 +146,7 @@ export function DocReader({ content }: { content: string }) {
           </button>
         </div>
       </div>
-      <div className="px-5 pb-6 pt-16 sm:px-6">
+      <div className="doc-flow px-5 pb-6 pt-16 sm:px-6">
         <div className="prose-harness" data-layout={layout} data-font={font}>
           <Markdown remarkPlugins={[remarkGfm]} components={components}>
             {content}

--- a/packages/gui/src/renderer/components/taskDetail/TaskDetailSections.tsx
+++ b/packages/gui/src/renderer/components/taskDetail/TaskDetailSections.tsx
@@ -54,7 +54,12 @@ export function TaskOverviewTab({ task }: { readonly task: TaskRow }) {
   const events = task.events ?? [];
 
   return (
-    <div className="grid min-h-full gap-8" data-testid="task-overview-tab">
+    // 时间线不独占整列:容器 <1600px 时间线作为正文下方分区随内容高度增长;
+    // ≥1600px 收窄为右侧 19rem inspector,正文占满剩余宽度(量尺是 TaskDetailView 的 main 容器)。
+    <div
+      className="grid min-h-full gap-8 @min-[1600px]:grid-cols-[minmax(0,1fr)_19rem]"
+      data-testid="task-overview-tab"
+    >
       <section className="min-w-0">
         <SectionHeading eyebrow="PLAN" title="任务计划" description="目标、验收与边界的完整原文" />
         <div className="mt-5">
@@ -75,7 +80,7 @@ export function TaskOverviewTab({ task }: { readonly task: TaskRow }) {
         </div>
       </section>
 
-      <aside className="border-t border-border pt-6">
+      <aside className="border-t border-border pt-6 @min-[1600px]:border-t-0 @min-[1600px]:border-l @min-[1600px]:pl-6 @min-[1600px]:pt-0">
         <SectionHeading eyebrow="TIMELINE" title="进展时间线" description={`${events.length} 条生命周期记录`} />
         {events.length === 0 ? (
           <div className="mt-5">
@@ -676,9 +681,7 @@ export function TaskCloseoutTab({
                 key={witness.schema === "code-doc-witness/v1" ? witness.witnessId : witness.recordId}
                 id={witness.schema === "code-doc-witness/v1" ? witness.witnessId : witness.recordId}
                 state={
-                  witness.schema === "code-doc-witness/v1" || witness.paths.length > 0
-                    ? "reconciled"
-                    : "known-invalid"
+                  witness.schema === "code-doc-witness/v1" || witness.paths.length > 0 ? "reconciled" : "known-invalid"
                 }
                 summary={witness.paths.join(", ")}
                 at={witness.schema === "code-doc-witness/v1" ? witness.reconciledAt : witness.repointedAt}

--- a/packages/gui/src/renderer/components/taskDetail/TaskFilesTab.tsx
+++ b/packages/gui/src/renderer/components/taskDetail/TaskFilesTab.tsx
@@ -14,17 +14,11 @@ interface TaskDocumentSidebarProps {
   readonly onOpenDoc: (path: string) => void;
 }
 
-export function TaskDocumentSidebar({
-  task,
-  activeDoc,
-  onActiveDocChange,
-  onOpenDoc,
-}: TaskDocumentSidebarProps) {
+export function TaskDocumentSidebar({ task, activeDoc, onActiveDocChange, onOpenDoc }: TaskDocumentSidebarProps) {
   const documentList = useTaskDocumentListQuery(task.projectId, task.taskId);
   const documents = useMemo(() => {
-    const projected = documentList.data?.status === "ready"
-      ? documentList.data.documents.map((document) => document.path)
-      : [];
+    const projected =
+      documentList.data?.status === "ready" ? documentList.data.documents.map((document) => document.path) : [];
     return projectedDocuments(projected);
   }, [documentList.data]);
   const tree = useMemo(() => buildDocTree(documents), [documents]);
@@ -41,7 +35,7 @@ export function TaskDocumentSidebar({
   return (
     <nav
       aria-label="任务包文件"
-      className="min-h-0 overflow-y-auto border-b border-border bg-surface p-3 md:border-r md:border-b-0"
+      className="min-h-0 overflow-y-auto border-b border-border bg-surface p-3 @max-[1100px]:max-h-72 @min-[1100px]:border-r @min-[1100px]:border-b-0"
       data-testid="task-document-tree"
     >
       <p className="mb-2 px-1 font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-text-faint">
@@ -88,15 +82,14 @@ function TaskFileBody({ repoId, taskId, path }: TaskFileBodyProps) {
   if (document.isError) return <p className="text-[12px] text-danger">文档读取失败：{document.error.message}</p>;
   if (document.data.status !== "ready") return <FileEmpty text="文档投影尚未追平。" />;
   if (document.data.blobSha256 === null) return <FileEmpty text="该文件尚未物化。" />;
-  const content = isHtmlDocument(path)
-    ? <HtmlArtifactPreview content={document.data.body} path={path} />
-    : <DocReader content={document.data.body} />;
+  const content = isHtmlDocument(path) ? (
+    <HtmlArtifactPreview content={document.data.body} path={path} />
+  ) : (
+    <DocReader content={document.data.body} />
+  );
   return (
     <>
-      <span
-        data-testid="task-document-status"
-        className="mb-3 block font-mono text-[10px] text-text-faint"
-      >
+      <span data-testid="task-document-status" className="mb-3 block font-mono text-[10px] text-text-faint">
         L2 · {document.data.status}
       </span>
       {content}

--- a/packages/gui/src/renderer/styles.css
+++ b/packages/gui/src/renderer/styles.css
@@ -160,7 +160,12 @@ html[data-theme="light"] ::selection {
   background: oklch(0.85 0.06 250);
 }
 
-/* 文档阅读区排版（react-markdown 输出） */
+/* 文档阅读区排版（react-markdown 输出）。
+   栏数三态:默认「自适应」(auto)——正文容器 .doc-flow 自己就是容器量尺,
+   容器 <50rem 时单栏 88ch 可读行宽;≥50rem 后按 26rem 理想栏宽自动分栏(2/3/4…
+   栏随可用宽度增长),正文填满可用宽度,不再留出大片空白列。
+   手动「单栏 / 双栏」覆盖自适应:对应属性值下容器查询不参与。 */
+.doc-flow { container-type: inline-size; }
 .prose-harness {
   width: 100%;
   max-width: none;
@@ -170,16 +175,30 @@ html[data-theme="light"] ::selection {
   color: var(--color-text);
   overflow-wrap: anywhere;
 }
-.prose-harness[data-layout="single"] > :where(h1, h2, h3, h4, p, ul, ol, blockquote) {
+.doc-flow .prose-harness[data-layout="single"] > :where(h1, h2, h3, h4, p, ul, ol, blockquote),
+.doc-flow .prose-harness[data-layout="auto"] > :where(h1, h2, h3, h4, p, ul, ol, blockquote) {
   max-width: 88ch;
 }
-.prose-harness[data-layout="double"] {
+.doc-flow .prose-harness[data-layout="double"] {
   columns: 2 24rem;
   column-gap: 2.5rem;
   column-rule: 1px solid var(--color-border);
 }
-.prose-harness[data-layout="double"] > * {
+.doc-flow .prose-harness[data-layout="double"] > * {
   break-inside: avoid;
+}
+@container (min-width: 50rem) {
+  .doc-flow .prose-harness[data-layout="auto"] {
+    columns: 26rem;
+    column-gap: 2.5rem;
+    column-rule: 1px solid var(--color-border);
+  }
+  .doc-flow .prose-harness[data-layout="auto"] > :where(h1, h2, h3, h4, p, ul, ol, blockquote) {
+    max-width: none;
+  }
+  .doc-flow .prose-harness[data-layout="auto"] > * {
+    break-inside: avoid;
+  }
 }
 .prose-harness h1 {
   font-size: var(--ui-font-heading);

--- a/packages/gui/src/renderer/views/TaskDetailView.tsx
+++ b/packages/gui/src/renderer/views/TaskDetailView.tsx
@@ -217,11 +217,15 @@ export function TaskDetailView({
         })}
       </nav>
 
-      <main className="min-h-0 flex-1 overflow-hidden px-3 py-3 sm:px-4">
+      {/* 宽屏自适应:main 是容器量尺(内容盒宽 = 卡片宽),卡片铺满可用宽度。
+          断带:容器 <1100px 单栏叠放(文件树横排在上,量高 18rem 内滚,不挤死正文);
+          ≥1100px 文件树收窄为 14rem 侧栏。 */}
+      <main className="@container min-h-0 flex-1 overflow-hidden px-3 py-3 sm:px-4">
         <div
           className={[
-            "mx-auto h-full w-full max-w-[96rem] overflow-hidden rounded-lg border border-border bg-bg",
-            "md:grid md:grid-cols-[14rem_minmax(0,1fr)]",
+            "h-full w-full overflow-hidden rounded-lg border border-border bg-bg",
+            "grid grid-cols-1 grid-rows-[auto_minmax(0,1fr)]",
+            "@min-[1100px]:grid-cols-[14rem_minmax(0,1fr)] @min-[1100px]:grid-rows-1",
           ].join(" ")}
         >
           <TaskDocumentSidebar

--- a/packages/gui/test/task-detail-expression.vitest.ts
+++ b/packages/gui/test/task-detail-expression.vitest.ts
@@ -9,31 +9,199 @@ import type { DecisionRow, RelationEdge, TaskRow } from "../src/renderer/model/t
 import { setActiveLocale } from "../src/renderer/i18n/core.ts";
 
 const mounted: { readonly root: Root; readonly client: QueryClient }[] = [];
-const definition = { schema: "agent-definition-snapshot/v1", configVersion: 1, instanceId: "codex-work", installationId: "codex-install", kindId: "codex", providerId: "openai", model: "gpt-5.6", reasoningEffort: "high", baseUrl: null, authMode: "subscription" } as const;
-const session = { runtimeSessionId: "runtime-w3", providerSessionId: "provider-w3", instanceId: "codex-work", installationId: "codex-install", kindId: "codex", definitionSnapshotRef: "artifact:definition/w3", definitionSnapshot: definition, liveness: "exited", attachCapability: "supported", streamCursor: "stream:4", associations: [{ taskId: "task-w3", executionId: "execution-w3", holder: { personId: "person-owner", executorId: "codex-worker" }, lease: null }], activity: { lastObservedAt: "2026-08-23T10:30:00.000Z", outcome: "succeeded", exitCode: 0, resultRef: "artifact:result/w3" } } as const;
-const dispatch = { dispatchId: "dispatch-w3", taskId: "task-w3", executionId: "execution-w3", runtimeSessionId: "runtime-w3", instanceId: "codex-work", agentId: "codex-worker", agentName: "Codex Worker", delegatedByAgentId: "claude-ceo", delegatedByAgentName: "Claude CEO", squadId: "squad-plt", providerSessionId: "provider-w3", eventStreamRef: "events/runtime-w3", startedAt: "2026-08-23T09:00:00.000Z", endedAt: "2026-08-23T10:30:00.000Z", outcome: "succeeded", status: "succeeded" } as const;
+const definition = {
+  schema: "agent-definition-snapshot/v1",
+  configVersion: 1,
+  instanceId: "codex-work",
+  installationId: "codex-install",
+  kindId: "codex",
+  providerId: "openai",
+  model: "gpt-5.6",
+  reasoningEffort: "high",
+  baseUrl: null,
+  authMode: "subscription",
+} as const;
+const session = {
+  runtimeSessionId: "runtime-w3",
+  providerSessionId: "provider-w3",
+  instanceId: "codex-work",
+  installationId: "codex-install",
+  kindId: "codex",
+  definitionSnapshotRef: "artifact:definition/w3",
+  definitionSnapshot: definition,
+  liveness: "exited",
+  attachCapability: "supported",
+  streamCursor: "stream:4",
+  associations: [
+    {
+      taskId: "task-w3",
+      executionId: "execution-w3",
+      holder: { personId: "person-owner", executorId: "codex-worker" },
+      lease: null,
+    },
+  ],
+  activity: {
+    lastObservedAt: "2026-08-23T10:30:00.000Z",
+    outcome: "succeeded",
+    exitCode: 0,
+    resultRef: "artifact:result/w3",
+  },
+} as const;
+const dispatch = {
+  dispatchId: "dispatch-w3",
+  taskId: "task-w3",
+  executionId: "execution-w3",
+  runtimeSessionId: "runtime-w3",
+  instanceId: "codex-work",
+  agentId: "codex-worker",
+  agentName: "Codex Worker",
+  delegatedByAgentId: "claude-ceo",
+  delegatedByAgentName: "Claude CEO",
+  squadId: "squad-plt",
+  providerSessionId: "provider-w3",
+  eventStreamRef: "events/runtime-w3",
+  startedAt: "2026-08-23T09:00:00.000Z",
+  endedAt: "2026-08-23T10:30:00.000Z",
+  outcome: "succeeded",
+  status: "succeeded",
+} as const;
 
 const task: TaskRow = {
-  taskId: "task-w3", title: "Task 表达重做", projectId: "repo-a", coordinationStatus: "in_review", canonicalStatus: "in_review",
-  rawStatus: "in_review/review", freshness: "fresh", packageDisposition: "active", closeoutReadiness: "ready", engine: "kernel/task-lifecycle/v1",
-  origin: "native", source: "local-document", module: "gui", moduleKeys: ["gui"], productLines: ["platform"], packagePath: "tasks/task-w3-expression",
-  taskClass: "standard", workKind: "feat", vertical: "software-coding", preset: "plt-gui", profile: "default", createdBy: "person-owner",
-  currentNode: "review", iteration: 0, riskTier: "high", urgency: "high", parentTaskId: "task-parent", rootTaskId: "task-parent", rootTitle: "PLT GUI UX",
-  createdAt: "2026-08-23T08:00:00.000Z", lastKnownAt: "2026-08-23T10:31:00.000Z", closeoutBlocker: undefined,
+  taskId: "task-w3",
+  title: "Task 表达重做",
+  projectId: "repo-a",
+  coordinationStatus: "in_review",
+  canonicalStatus: "in_review",
+  rawStatus: "in_review/review",
+  freshness: "fresh",
+  packageDisposition: "active",
+  closeoutReadiness: "ready",
+  engine: "kernel/task-lifecycle/v1",
+  origin: "native",
+  source: "local-document",
+  module: "gui",
+  moduleKeys: ["gui"],
+  productLines: ["platform"],
+  packagePath: "tasks/task-w3-expression",
+  taskClass: "standard",
+  workKind: "feat",
+  vertical: "software-coding",
+  preset: "plt-gui",
+  profile: "default",
+  createdBy: "person-owner",
+  currentNode: "review",
+  iteration: 0,
+  riskTier: "high",
+  urgency: "high",
+  parentTaskId: "task-parent",
+  rootTaskId: "task-parent",
+  rootTitle: "PLT GUI UX",
+  createdAt: "2026-08-23T08:00:00.000Z",
+  lastKnownAt: "2026-08-23T10:31:00.000Z",
+  closeoutBlocker: undefined,
   snapshotAvailability: { consents: "known", codeDocWitnesses: "known", gateWitnesses: "known" },
   // W5:执行证据页并入「收口」——execution 输出/回执经 task-adapter 原样透传。
-  executions: [{ schema: "execution/v1", executionId: "execution-w3", taskId: "task-w3", nodeId: "implementation", iteration: 0, state: "submitted", actor: { principal: { personId: "person-owner" }, executor: { kind: "agent", id: "codex-worker" } }, claimedAt: "2026-08-23T09:00:00.000Z", submittedAt: "2026-08-23T10:00:00.000Z", closedAt: null, submission: { completionClaim: "done", deliverables: ["report"], outputs: ["artifacts/report.md"], verificationNotes: [], knownGaps: [], residualRisks: [], commitSha: "a".repeat(40) } }],
-  executionEvidence: [{ executionId: "execution-w3", origin: "native", outputs: [{ evidenceId: `evidence_${"1".repeat(24)}`, locator: "artifacts/report.md", substrate: "repository-path", checkerReceiptRef: "receipt-dom", checkerResult: "pass" }] }],
-  gates: [{ name: "local-check", ok: true }], docs: [],
-  events: [{ projectId: "repo-a", taskId: "task-w3", at: "2026-08-23T10:20:00.000Z", summary: "Review review-w3: approved" }],
-  reviews: [{ schema: "review/v1", reviewId: "review-w3", taskId: "task-w3", executionId: "execution-w3", verdict: "approved", actor: { principal: { personId: "reviewer" }, executor: null }, capabilityRef: "review@v1", reason: "UI evidence is complete", evidenceChecked: ["task-detail DOM"], commitSha: "a".repeat(40), iteration: 0, contentDigest: `sha256:${"b".repeat(64)}`, reviewedAt: "2026-08-23T10:20:00.000Z" }],
-  consents: [{ schema: "review-consent/v1", consentId: "consent-w3", taskId: "task-w3", executionId: "execution-w3", reviewId: "review-w3", reviewDigest: `sha256:${"c".repeat(64)}`, contentDigest: `sha256:${"b".repeat(64)}`, actor: { principal: { personId: "person-owner" }, executor: null }, source: "local", consentedAt: "2026-08-23T10:22:00.000Z" }],
-  codeDocWitnesses: [], gateWitnesses: [],
+  executions: [
+    {
+      schema: "execution/v1",
+      executionId: "execution-w3",
+      taskId: "task-w3",
+      nodeId: "implementation",
+      iteration: 0,
+      state: "submitted",
+      actor: { principal: { personId: "person-owner" }, executor: { kind: "agent", id: "codex-worker" } },
+      claimedAt: "2026-08-23T09:00:00.000Z",
+      submittedAt: "2026-08-23T10:00:00.000Z",
+      closedAt: null,
+      submission: {
+        completionClaim: "done",
+        deliverables: ["report"],
+        outputs: ["artifacts/report.md"],
+        verificationNotes: [],
+        knownGaps: [],
+        residualRisks: [],
+        commitSha: "a".repeat(40),
+      },
+    },
+  ],
+  executionEvidence: [
+    {
+      executionId: "execution-w3",
+      origin: "native",
+      outputs: [
+        {
+          evidenceId: `evidence_${"1".repeat(24)}`,
+          locator: "artifacts/report.md",
+          substrate: "repository-path",
+          checkerReceiptRef: "receipt-dom",
+          checkerResult: "pass",
+        },
+      ],
+    },
+  ],
+  gates: [{ name: "local-check", ok: true }],
+  docs: [],
+  events: [
+    { projectId: "repo-a", taskId: "task-w3", at: "2026-08-23T10:20:00.000Z", summary: "Review review-w3: approved" },
+  ],
+  reviews: [
+    {
+      schema: "review/v1",
+      reviewId: "review-w3",
+      taskId: "task-w3",
+      executionId: "execution-w3",
+      verdict: "approved",
+      actor: { principal: { personId: "reviewer" }, executor: null },
+      capabilityRef: "review@v1",
+      reason: "UI evidence is complete",
+      evidenceChecked: ["task-detail DOM"],
+      commitSha: "a".repeat(40),
+      iteration: 0,
+      contentDigest: `sha256:${"b".repeat(64)}`,
+      reviewedAt: "2026-08-23T10:20:00.000Z",
+    },
+  ],
+  consents: [
+    {
+      schema: "review-consent/v1",
+      consentId: "consent-w3",
+      taskId: "task-w3",
+      executionId: "execution-w3",
+      reviewId: "review-w3",
+      reviewDigest: `sha256:${"c".repeat(64)}`,
+      contentDigest: `sha256:${"b".repeat(64)}`,
+      actor: { principal: { personId: "person-owner" }, executor: null },
+      source: "local",
+      consentedAt: "2026-08-23T10:22:00.000Z",
+    },
+  ],
+  codeDocWitnesses: [],
+  gateWitnesses: [],
 };
 const parent = { ...task, taskId: "task-parent", title: "PLT GUI UX", parentTaskId: undefined };
 const child = { ...task, taskId: "task-child", title: "下游可用性验证", parentTaskId: "task-w3" };
-const decision: DecisionRow = { decisionId: "dec-gui", title: "GUI 只展示后端结构化结果", state: "in_effect", question: "逻辑放在哪里？", chosen: [], rejected: [], claims: [], judgmentConsents: [] };
-const relations: RelationEdge[] = [{ relationId: "rel-gui", from: "decision/dec-gui", to: "task/task-w3", kind: "derives", direction: "directed", state: "active", provenance: "local-document", rationale: "UI boundary" }];
+const decision: DecisionRow = {
+  decisionId: "dec-gui",
+  title: "GUI 只展示后端结构化结果",
+  state: "in_effect",
+  question: "逻辑放在哪里？",
+  chosen: [],
+  rejected: [],
+  claims: [],
+  judgmentConsents: [],
+};
+const relations: RelationEdge[] = [
+  {
+    relationId: "rel-gui",
+    from: "decision/dec-gui",
+    to: "task/task-w3",
+    kind: "derives",
+    direction: "directed",
+    state: "active",
+    provenance: "local-document",
+    rationale: "UI boundary",
+  },
+];
 
 beforeAll(() => {
   globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -41,7 +209,12 @@ beforeAll(() => {
 });
 
 afterEach(async () => {
-  await act(async () => { for (const { root, client } of mounted.splice(0)) { root.unmount(); client.clear(); } });
+  await act(async () => {
+    for (const { root, client } of mounted.splice(0)) {
+      root.unmount();
+      client.clear();
+    }
+  });
   document.body.replaceChildren();
   vi.unstubAllGlobals();
 });
@@ -54,7 +227,14 @@ describe("Task detail expression", () => {
     expect(byTestId("task-identity-strip").textContent).toContain("person-owner · standard");
     expect(byTestId("task-identity-strip").textContent).toContain("plt-gui · software-coding");
     expect(byTestId("task-detail-view").textContent).toContain("Task 表达重做");
-    expect([...document.querySelectorAll('[role="tab"]')].map((tab) => tab.textContent?.trim())).toEqual(["概况", "派工", "证据", "关系", "收口", "文件"]);
+    expect([...document.querySelectorAll('[role="tab"]')].map((tab) => tab.textContent?.trim())).toEqual([
+      "概况",
+      "派工",
+      "证据",
+      "关系",
+      "收口",
+      "文件",
+    ]);
     expect(byTestId("task-document-tree").textContent).toContain("artifacts");
     expect(byTestId("task-overview-tab").textContent).toContain("Canonical plan body");
     expect(byTestId("task-progress-timeline").textContent).toContain("Review review-w3: approved");
@@ -105,15 +285,46 @@ describe("Task detail expression", () => {
     expect(byTestId("task-files-tab").textContent).toContain("Canonical plan body");
   });
 
-  it("switches reader layout and font in the floating toolbar and opens HTML in an isolated webview", async () => {
+  it("adapts the detail card and reader to container width; manual layout controls still override", async () => {
     installBridge();
     await mount();
 
+    // 详情卡铺满可用宽度:不再有 max-w 居中收口;main 是容器量尺,断带挂在卡片网格上。
+    const scrollPanel = byTestId("task-detail-panel-scroll");
+    const card = scrollPanel.parentElement!;
+    expect(card.className).not.toMatch(/max-w-|mx-auto/u);
+    expect(card.className).toContain("grid-cols-1");
+    expect(card.className).toContain("@min-[1100px]:grid-cols-[14rem_minmax(0,1fr)]");
+    expect(scrollPanel.closest("main")?.className).toContain("@container");
+    // 叠放带里文件树是 auto 行:量高 18rem 内部滚动,文件多的任务包不会挤死正文。
+    expect(byTestId("task-document-tree").className).toContain("@max-[1100px]:max-h-72");
+
+    // 概况:时间线并入分区/右侧 inspector,不再独占整列。
+    const overview = byTestId("task-overview-tab");
+    expect(overview.className).toContain("@min-[1600px]:grid-cols-[minmax(0,1fr)_19rem]");
+    expect(byTestId("task-progress-timeline").closest("aside")).toBe(overview.querySelector("aside"));
+
+    // 阅读栏数默认「自适应」:容器查询驱动(styles.css 的 .doc-flow),无需点击。
     const toolbar = byTestId("reader-floating-toolbar");
-    const double = [...toolbar.querySelectorAll("button")].find((button) => button.textContent === "双栏")!;
-    await act(async () => { double.click(); });
-    expect(double.getAttribute("aria-pressed")).toBe("true");
+    const layoutButton = (label: string) =>
+      [...toolbar.querySelectorAll("button")].find((button) => button.textContent === label)!;
+    expect(document.querySelector(".prose-harness")?.getAttribute("data-layout")).toBe("auto");
+    expect(document.querySelector(".doc-flow")?.contains(document.querySelector(".prose-harness"))).toBe(true);
+
+    // 单栏/双栏控件保留:手动选择覆盖自适应,并可切回。
+    await act(async () => {
+      layoutButton("双栏").click();
+    });
+    expect(layoutButton("双栏").getAttribute("aria-pressed")).toBe("true");
     expect(document.querySelector(".prose-harness")?.getAttribute("data-layout")).toBe("double");
+    await act(async () => {
+      layoutButton("单栏").click();
+    });
+    expect(document.querySelector(".prose-harness")?.getAttribute("data-layout")).toBe("single");
+    await act(async () => {
+      layoutButton("自适应").click();
+    });
+    expect(document.querySelector(".prose-harness")?.getAttribute("data-layout")).toBe("auto");
 
     const font = toolbar.querySelector("select")!;
     await act(async () => {
@@ -122,12 +333,20 @@ describe("Task detail expression", () => {
     });
     expect(document.querySelector(".prose-harness")?.getAttribute("data-font")).toBe("serif");
 
-    const reports = [...byTestId("task-document-tree").querySelectorAll("button")].find((button) => button.textContent?.includes("reports/"))!;
+    const reports = [...byTestId("task-document-tree").querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("reports/"),
+    )!;
     expect(reports).toBeInstanceOf(HTMLButtonElement);
-    await act(async () => { reports.click(); });
-    const html = [...byTestId("task-document-tree").querySelectorAll("button")].find((button) => button.textContent?.includes("night.html"))!;
+    await act(async () => {
+      reports.click();
+    });
+    const html = [...byTestId("task-document-tree").querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("night.html"),
+    )!;
     expect(html).toBeInstanceOf(HTMLButtonElement);
-    await act(async () => { html.click(); });
+    await act(async () => {
+      html.click();
+    });
     await flushEffects();
 
     expect(document.querySelector('[role="tab"][aria-selected="true"]')?.textContent).toContain("文件");
@@ -143,21 +362,111 @@ describe("Task detail expression", () => {
 
 function installBridge() {
   const bridge = {
-    getTaskDocument: vi.fn(async ({ taskId, path }: { taskId: string; path: string }) => ({ ok: true, status: "ready", taskId, path, body: path === "task_plan.md" ? "# Canonical plan body" : path.endsWith(".html") ? "<style>body{color:#123}</style><h1>Night report</h1><script>window.open(\"https://example.invalid\")</script>" : `# ${path}`, blobSha256: `sha256:${"d".repeat(64)}`, watermark: 7, sourceRevision: 7 })),
-    getTaskDocuments: vi.fn(async () => ({ ok: true, status: "ready", taskId: "task-w3", documents: [
-      { path: "task_plan.md", blobSha256: "d".repeat(64), size: 20, mediaType: "text/markdown" },
-      { path: "INDEX.md", blobSha256: "e".repeat(64), size: 20, mediaType: "text/markdown" },
-      { path: "artifacts/report.md", blobSha256: "f".repeat(64), size: 20, mediaType: "text/markdown" },
-      { path: "artifacts/reports/night.html", blobSha256: "a".repeat(64), size: 120, mediaType: "text/html" },
-    ], watermark: 7, sourceRevision: 7 })),
-    getTaskDispatches: vi.fn(async () => ({ ok: true, status: "ready", taskId: "task-w3", dispatches: [dispatch], watermark: 7, sourceRevision: 7 })),
-    getRelationGraph: vi.fn(async () => ({ ok: true, edges: [], coverageRows: [], factAnchors: [], facts: [
-      { schema: "task-fact-row/v1", ref: "fact/task-w3/F-DOM", taskId: "task-w3", factId: "F-DOM", statement: "Frontend consumes structured projections only", source: "review/dom", observedAt: "2026-08-23T10:10:00.000Z", confidence: "high", memoryClass: "episodic", memoryTags: ["gui"], provenance: [], liveness: "standing" },
-      { schema: "task-fact-row/v1", ref: "fact/task-w3/F-LOW", taskId: "task-w3", factId: "F-LOW", statement: "Confidence is low, needs a human recheck", source: "review/dom", observedAt: "2026-08-23T10:11:00.000Z", confidence: "low", memoryClass: "episodic", memoryTags: ["gui"], provenance: [], liveness: "standing" },
-    ], warnings: [] })),
-    getAgentRuntimeOverview: vi.fn(async () => ({ ok: true, status: "ready", installations: [], instances: [], sessions: [session], watermark: 7, sourceRevision: 7 })),
-    getAgentRuntimeSession: vi.fn(async () => ({ ok: true, status: "ready", session, result: { ref: "artifact:result/w3", text: "Rendered runtime report" }, watermark: 7, sourceRevision: 7 })),
-    getAgentRuntimeEvents: vi.fn(async () => ({ ok: true, runtimeSessionId: "runtime-w3", events: [{ cursor: "lifecycle:7", runtimeSessionId: "runtime-w3", type: "runtime_session_exited", occurredAt: "2026-08-23T10:30:00.000Z" }], cursor: "lifecycle:7", sourceCursor: "lifecycle:7", done: true })),
+    getTaskDocument: vi.fn(async ({ taskId, path }: { taskId: string; path: string }) => ({
+      ok: true,
+      status: "ready",
+      taskId,
+      path,
+      body:
+        path === "task_plan.md"
+          ? "# Canonical plan body"
+          : path.endsWith(".html")
+            ? '<style>body{color:#123}</style><h1>Night report</h1><script>window.open("https://example.invalid")</script>'
+            : `# ${path}`,
+      blobSha256: `sha256:${"d".repeat(64)}`,
+      watermark: 7,
+      sourceRevision: 7,
+    })),
+    getTaskDocuments: vi.fn(async () => ({
+      ok: true,
+      status: "ready",
+      taskId: "task-w3",
+      documents: [
+        { path: "task_plan.md", blobSha256: "d".repeat(64), size: 20, mediaType: "text/markdown" },
+        { path: "INDEX.md", blobSha256: "e".repeat(64), size: 20, mediaType: "text/markdown" },
+        { path: "artifacts/report.md", blobSha256: "f".repeat(64), size: 20, mediaType: "text/markdown" },
+        { path: "artifacts/reports/night.html", blobSha256: "a".repeat(64), size: 120, mediaType: "text/html" },
+      ],
+      watermark: 7,
+      sourceRevision: 7,
+    })),
+    getTaskDispatches: vi.fn(async () => ({
+      ok: true,
+      status: "ready",
+      taskId: "task-w3",
+      dispatches: [dispatch],
+      watermark: 7,
+      sourceRevision: 7,
+    })),
+    getRelationGraph: vi.fn(async () => ({
+      ok: true,
+      edges: [],
+      coverageRows: [],
+      factAnchors: [],
+      facts: [
+        {
+          schema: "task-fact-row/v1",
+          ref: "fact/task-w3/F-DOM",
+          taskId: "task-w3",
+          factId: "F-DOM",
+          statement: "Frontend consumes structured projections only",
+          source: "review/dom",
+          observedAt: "2026-08-23T10:10:00.000Z",
+          confidence: "high",
+          memoryClass: "episodic",
+          memoryTags: ["gui"],
+          provenance: [],
+          liveness: "standing",
+        },
+        {
+          schema: "task-fact-row/v1",
+          ref: "fact/task-w3/F-LOW",
+          taskId: "task-w3",
+          factId: "F-LOW",
+          statement: "Confidence is low, needs a human recheck",
+          source: "review/dom",
+          observedAt: "2026-08-23T10:11:00.000Z",
+          confidence: "low",
+          memoryClass: "episodic",
+          memoryTags: ["gui"],
+          provenance: [],
+          liveness: "standing",
+        },
+      ],
+      warnings: [],
+    })),
+    getAgentRuntimeOverview: vi.fn(async () => ({
+      ok: true,
+      status: "ready",
+      installations: [],
+      instances: [],
+      sessions: [session],
+      watermark: 7,
+      sourceRevision: 7,
+    })),
+    getAgentRuntimeSession: vi.fn(async () => ({
+      ok: true,
+      status: "ready",
+      session,
+      result: { ref: "artifact:result/w3", text: "Rendered runtime report" },
+      watermark: 7,
+      sourceRevision: 7,
+    })),
+    getAgentRuntimeEvents: vi.fn(async () => ({
+      ok: true,
+      runtimeSessionId: "runtime-w3",
+      events: [
+        {
+          cursor: "lifecycle:7",
+          runtimeSessionId: "runtime-w3",
+          type: "runtime_session_exited",
+          occurredAt: "2026-08-23T10:30:00.000Z",
+        },
+      ],
+      cursor: "lifecycle:7",
+      sourceCursor: "lifecycle:7",
+      done: true,
+    })),
     attachAgentRuntime: vi.fn(() => () => undefined),
   };
   vi.stubGlobal("window", { harness: bridge, addEventListener: () => undefined, removeEventListener: () => undefined });
@@ -166,17 +475,40 @@ function installBridge() {
 
 async function mount() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  const container = document.createElement("div"), root = createRoot(container);
+  const container = document.createElement("div"),
+    root = createRoot(container);
   document.body.append(container);
   mounted.push({ root, client });
-  await act(async () => { root.render(createElement(QueryClientProvider, { client }, createElement(TaskDetailView, { task, tasks: [parent, task, child], relations, decisions: [decision], onBack: () => undefined, onSelect: () => undefined, onNavigateDecision: () => undefined, onNavigateEntity: () => undefined, projectName: "Harness" }))); });
+  await act(async () => {
+    root.render(
+      createElement(
+        QueryClientProvider,
+        { client },
+        createElement(TaskDetailView, {
+          task,
+          tasks: [parent, task, child],
+          relations,
+          decisions: [decision],
+          onBack: () => undefined,
+          onSelect: () => undefined,
+          onNavigateDecision: () => undefined,
+          onNavigateEntity: () => undefined,
+          projectName: "Harness",
+        }),
+      ),
+    );
+  });
   await flushEffects();
 }
 
 async function clickTab(label: string) {
-  const tab = [...document.querySelectorAll<HTMLButtonElement>('[role="tab"]')].find((button) => button.textContent?.includes(label));
+  const tab = [...document.querySelectorAll<HTMLButtonElement>('[role="tab"]')].find((button) =>
+    button.textContent?.includes(label),
+  );
   expect(tab, `missing tab ${label}`).toBeInstanceOf(HTMLButtonElement);
-  await act(async () => { tab!.click(); });
+  await act(async () => {
+    tab!.click();
+  });
   await flushEffects();
 }
 


### PR DESCRIPTION
# English

## Summary

Task detail no longer wastes wide viewports: the card drops its `max-w-[96rem] mx-auto` cap, the file tree and body switch on container queries (stacked <1100px, 14rem sidebar ≥1100px), the timeline becomes a right-hand inspector at ≥1600px (below that it is a section under the body), and the document reader defaults to an automatic column count (ideal column 26rem, single column below 50rem) while the explicit single/double column toggles stay as overrides. Before/after screenshots at 1024/1440/1920 are in the task package.

## Architectural Justification

- Not required: Production-Delta churn is below 200 lines.

## What Changed

- `views/TaskDetailView.tsx`: `@container` on main; card fills available width; container breakpoints.
- `components/taskDetail/TaskFilesTab.tsx`: viewport `md:` breakpoint → container `@min-[1100px]`; stacked band capped at 18rem with internal scroll.
- `components/taskDetail/TaskDetailSections.tsx`: `@min-[1600px]` two-column grid with the timeline as aside.
- `components/DocReader.tsx` + `styles.css`: `.doc-flow` container with automatic columns; layout rules scoped to `.doc-flow`, unscoped `.prose-harness[data-layout=…]` rules removed.
- `test/task-detail-expression.vitest.ts`: asserts the three bands, the stacked cap, the timeline aside and the auto/override round trip.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +38/-30

### Optional Evidence Claims

## Task And Scope

- Harness task: task_79bc942e9ed76243c45774f906
- Branch: codex/gui-task-detail-widescreen
- Public scope: packages/gui (task detail view, files tab, sections, DocReader, styles, one vitest)
- Private planning/evidence updated: yes
- Out of scope: sessions page redesign (task_1994d52c) and progressive-expand removal (task_f5b74269)

## Version Impact

- Version: no version change because pre-release GUI layout change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_79bc942e9ed76243c45774f906
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: a82038c3a791684c522a1ab861e5db7204aa2caa
- Branch merge-base with `origin/main`: a82038c3a791684c522a1ab861e5db7204aa2caa
- Last `git fetch origin` time: 2026-08-25T19:56Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_79bc942e9ed76243c45774f906 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] `npm run check:local` (worker run, green)
- [x] Electron against the real canonical ledger at 1024/1440/1920: before/after screenshots and measurements in the task package
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: nothing else; CI is the authority.

## Review Evidence

- Self-review: CEO inspected the 1920px after-screenshot against the reported defect (empty side columns, timeline column) and accepted.
- Reviewer subagent: implemented by GLM worker (r1 partial, r2 completed via Codex runtime).
- Human review: pending
- Blocking findings: none

## Residual Risk

- Automatic column count depends on container-query support in the bundled Electron Chromium (present).

## References

- Task: task_79bc942e9ed76243c45774f906
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

任务详情页不再浪费宽屏:卡片去掉 `max-w-[96rem] mx-auto` 上限,文件树与正文改用容器查询(<1100px 叠放,≥1100px 14rem 侧栏),时间线在 ≥1600px 成为右侧 inspector(以下为正文下方分区),文档阅读器默认自动分栏(理想栏宽 26rem,<50rem 单栏),单/双栏切换保留为显式覆盖。1024/1440/1920 前后截图在任务包。

## 架构辩护

- 不需要:Production-Delta churn 低于 200 行。

## 改动内容

- `views/TaskDetailView.tsx`:main 挂 `@container`;卡片铺满可用宽度;容器断点。
- `components/taskDetail/TaskFilesTab.tsx`:视口 `md:` 断点 → 容器 `@min-[1100px]`;叠放带 18rem 内部滚动。
- `components/taskDetail/TaskDetailSections.tsx`:`@min-[1600px]` 双栏网格,时间线为 aside。
- `components/DocReader.tsx` + `styles.css`:`.doc-flow` 容器自动分栏;布局规则收窄到 `.doc-flow`,删除无作用域的 `.prose-harness[data-layout=…]` 规则。
- `test/task-detail-expression.vitest.ts`:断言三断带、叠放 cap、时间线 aside、自动/覆盖往返。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_79bc942e9ed76243c45774f906
- 分支:codex/gui-task-detail-widescreen
- 公开范围:packages/gui(任务详情视图、文件页签、分区、DocReader、样式、一个 vitest)
- 私有计划 / 证据是否已更新:yes
- 范围外:会话页重构(task_1994d52c)与渐进展开消灭(task_f5b74269)

## 版本影响

- 版本:不改版本,原因是预发布 GUI 布局改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_79bc942e9ed76243c45774f906
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:a82038c3a791684c522a1ab861e5db7204aa2caa
- 当前分支与 `origin/main` 的 merge-base:a82038c3a791684c522a1ab861e5db7204aa2caa
- 最近一次 `git fetch origin` 时间:2026-08-25T19:56Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_79bc942e9ed76243c45774f906
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] `npm run check:local`(worker 跑,绿)
- [x] Electron 对真实 canonical 在 1024/1440/1920 下前后截图与量尺在任务包
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:无;以 CI 为权威。

## 审查证据

- 自查:CEO 对照泽宇标出的缺陷(两侧空白列、时间线独占列)核看 1920px 修后截图,通过。
- Reviewer subagent:GLM worker 实现(r1 半成品,r2 经 Codex runtime 完成)。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 自动分栏依赖内置 Electron Chromium 的容器查询支持(已具备)。

## 关联材料

- 任务:task_79bc942e9ed76243c45774f906
- 证据:任务包 artifacts/reports
- 审查:本 PR
