### PR TITLE
fix(kernel): stop gating task-bound runtime handoff authorization on projected liveness

### DIFF
--- a/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
@@ -627,21 +627,17 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
       },
     );
     await t.test(
-      "the live task-bound runtime publishes only its assigned artifacts while lifecycle authority stays holder-only",
+      "the task-bound runtime publishes only its assigned artifacts after projection reopen while lifecycle authority stays holder-only",
       async () => {
         const taskId = "task-runtime-artifact",
           executionId = "exec-runtime-artifact",
           otherTaskId = "task-runtime-artifact-other",
-          otherExecutionId = "exec-runtime-artifact-other",
-          holder = { kind: "agent", id: "dispatch-holder" } as const;
+          otherExecutionId = "exec-runtime-artifact-other";
         assert.equal(
           (await host.run(repoId, { kind: "task-create", taskId, title: "Runtime artifact" }, auth)).outcome,
           "applied",
         );
-        assert.equal(
-          (await host.run(repoId, { kind: "task-start", taskId, executionId, executor: holder }, auth)).outcome,
-          "applied",
-        );
+        assert.equal((await host.run(repoId, { kind: "task-start", taskId, executionId }, auth)).outcome, "applied");
         assert.equal(
           (
             await host.run(
@@ -664,7 +660,6 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
                 kind: "task-start",
                 taskId: otherTaskId,
                 executionId: otherExecutionId,
-                executor: holder,
               },
               auth,
             )
@@ -679,7 +674,6 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
             prompt: "Publish the report",
             taskId,
             idempotencyKey: "runtime-artifact",
-            executor: holder,
           },
         });
         await eventuallyValue(
@@ -712,11 +706,18 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
         );
         assert.equal(published.outcome, "applied", JSON.stringify(published));
         assert.equal(published.destination, `tasks/task-runtime-artifact-runtime-artifact/artifacts/${ownDestination}`);
+        const rebuilt = await host.run(repoId, { kind: "projection-rebuild" }, auth);
+        assert.equal(rebuilt.outcome, "applied", JSON.stringify(rebuilt));
+        const reopened = await host.read(repoId, "repo.agentRuntime.overview", {}, auth),
+          reopenedSession = reopened.sessions.find(
+            (candidate) => candidate.runtimeSessionId === spawned.runtimeSessionId,
+          );
+        assert.equal(reopenedSession?.liveness, "unknown");
         const syncedPath = "tasks/task-runtime-artifact-runtime-artifact/artifacts/reports/runtime-doc-sync.md",
           syncedTarget = path.join(root, "harness", syncedPath);
         mkdirSync(path.dirname(syncedTarget), { recursive: true });
         writeFileSync(syncedTarget, "# Runtime doc sync artifact\n");
-        const synced = await host.run(repoId, { kind: "doc-submit", paths: [], executor: worker }, auth);
+        const synced = await host.run(repoId, { kind: "doc-submit", paths: [syncedPath], executor: worker }, auth);
         assert.equal(synced.outcome, "applied", JSON.stringify(synced));
         assert.match(String(synced.summary), new RegExp(`applied:[\\s\\S]*${syncedPath}`, "u"));
 
@@ -792,7 +793,7 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
         assert.match(
           String(lifecycle.nextAction),
           new RegExp(
-            `authenticated holder \\(personId=owner, executor=agent:dispatch-holder\\) must run ha task submit ${taskId} --execution-id ${executionId} --from-file <submission.json>, or ha task release ${taskId}`,
+            `authenticated holder \\(personId=owner, executor=none\\) must run ha task submit ${taskId} --execution-id ${executionId} --from-file <submission.json>, or ha task release ${taskId}`,
             "u",
           ),
         );
@@ -806,7 +807,6 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
                 taskId,
                 executionId,
                 fromFile: "submission.json",
-                executor: holder,
               },
               auth,
             )

--- a/packages/kernel/src/domain/task-bound-runtime-authority.ts
+++ b/packages/kernel/src/domain/task-bound-runtime-authority.ts
@@ -16,28 +16,24 @@ export function runtimeSessionIdFromActor(actor: ActorIdentity): string | null {
   return id.startsWith(prefix) && id.length > prefix.length ? id.slice(prefix.length) : null;
 }
 
-/** The handoff edge is the authenticated executor relation for a live runtime. */
+/** The handoff edge is the authenticated executor relation; the execution lease controls write lifetime. */
 export function runtimeSessionExecutesTask(
   session: RuntimeSession | null,
   taskId: string,
   executionId: string,
 ): boolean {
   return (
-    session?.liveness === "live" &&
-    session.taskBindings.some((binding) => binding.taskId === taskId && binding.executionId === executionId)
+    session?.taskBindings.some((binding) => binding.taskId === taskId && binding.executionId === executionId) ?? false
   );
 }
 
-/** Resolves authority only from a canonical live runtime-session projection. */
+/** Resolves the canonical runtime-session handoff; callers pair it with the current execution lease. */
 export function resolveLiveTaskBoundRuntimeBinding(
   session: RuntimeSession | null,
   taskId: string,
   executionId: string,
 ): LiveTaskBoundRuntimeBinding | null {
-  if (
-    session?.liveness !== "live" ||
-    !session.taskBindings.some((binding) => binding.taskId === taskId && binding.executionId === executionId)
-  )
+  if (!session?.taskBindings.some((binding) => binding.taskId === taskId && binding.executionId === executionId))
     return null;
   return { runtimeSessionId: session.runtimeSessionId, taskId, executionId };
 }

--- a/packages/kernel/test/contracts/doc-sync-runtime-artifacts.test.ts
+++ b/packages/kernel/test/contracts/doc-sync-runtime-artifacts.test.ts
@@ -18,7 +18,7 @@ import {
   opaqueClaim,
   state,
 } from "./doc-sync.fixtures.ts";
-test("a live task-bound runtime may write only its assigned task artifacts subtree", () => {
+test("a task-bound runtime may write only its assigned task artifacts subtree while its execution lease is held", () => {
   const runtimeActor = {
       principal: actor.principal,
       executor: { kind: "agent", id: "runtime-session:runtime-doc" },
@@ -63,7 +63,7 @@ test("a live task-bound runtime may write only its assigned task artifacts subtr
   assert.equal(accepted.accepted, true, JSON.stringify(accepted));
   for (const [name, result, code] of [
     [
-      "canonical live binding required",
+      "canonical binding required",
       run("tasks/task-owner-docs/artifacts/unbound.md", lease.taskId, {
         runtimeBinding: undefined,
         authorizationDecision: authorizeDocWrite(runtimeActor),
@@ -103,10 +103,11 @@ test("a live task-bound runtime may write only its assigned task artifacts subtr
     lastObservedAt: "2026-08-12T10:00:00.000Z",
   } as const;
   assert.deepEqual(resolveLiveTaskBoundRuntimeBinding(session, lease.taskId, lease.executionId), runtimeBinding);
-  assert.equal(
-    resolveLiveTaskBoundRuntimeBinding({ ...session, liveness: "stale" }, lease.taskId, lease.executionId),
-    null,
+  assert.deepEqual(
+    resolveLiveTaskBoundRuntimeBinding({ ...session, liveness: "unknown" }, lease.taskId, lease.executionId),
+    runtimeBinding,
   );
+  assert.equal(resolveLiveTaskBoundRuntimeBinding(session, lease.taskId, "another-execution"), null);
 });
 
 test("an opaque artifact write reclassifies an existing prose record without a policy upgrade", () => {


### PR DESCRIPTION
# English

## Summary

Task-bound runtime authority required the runtime session's projected liveness to be `live` before honouring the canonical `runtime_session_task_bound` handoff. The projection marks every runtime session `unknown` on reopen/rebuild, so after any daemon restart every worker's `doc.submit`/`progress` was rejected with `lease_conflict` although its execution lease was still held and its binding still canonical. Liveness is volatile process state, not authorization; the two liveness predicates are deleted. AuthorizationPort still requires a held lease on the same task/execution, an exact runtime-session/binding/person match and `sameWriteSource`, so release/expiry and every wrong-identity case still reject.

## Architectural Justification

- Not required: Production-Delta churn is below 200 lines.

## What Changed

- `packages/kernel/src/domain/task-bound-runtime-authority.ts`: `runtimeSessionExecutesTask` and `resolveLiveTaskBoundRuntimeBinding` no longer gate on `liveness === "live"`.
- `packages/daemon/test/contracts/doc-sync-runtime-artifacts.test.ts`: fixture now covers the production flow (person starts the task, executor null, runtime dispatched, projection reopened) and submits one explicit artifact path.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +4/-8

### Optional Evidence Claims

## Task And Scope

- Harness task: task_a4c4f60fcd52a7b6266ed1be15
- Branch: codex/dispatch-executor-handoff
- Public scope: packages/kernel/src/domain/task-bound-runtime-authority.ts and one daemon contract test
- Private planning/evidence updated: yes
- Out of scope: projection liveness marking on reopen (0.24 runtime/daemon decoupling) and the `runtime-sessions.json` mutable index (1.8)

## Version Impact

- Version: no version change because pre-release internal fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_a4c4f60fcd52a7b6266ed1be15
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 48f1baaffb6922ee08013f53789071925985edf5
- Branch merge-base with `origin/main`: 48f1baaffb6922ee08013f53789071925985edf5
- Last `git fetch origin` time: 2026-08-25T20:25Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_a4c4f60fcd52a7b6266ed1be15 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] `npm run check:local` (worker run, green)
- [x] daemon contract test red before / green after the deletion
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: nothing else; CI is the authority.

## Review Evidence

- Self-review: CEO's premise (#1830 deleted the delegation carrier) was refuted by the worker with diff evidence; CEO accepted the liveness-coupling root cause and the deletion-only fix.
- Reviewer subagent: Codex worker (sol) with challenge report and red/green evidence.
- Human review: pending
- Blocking findings: none

## Residual Risk

- A runtime session whose process died keeps its handoff authorization until the execution lease is released or expires (bounded by lease TTL).

## References

- Task: task_a4c4f60fcd52a7b6266ed1be15
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

task-bound runtime authority 在承认 canonical `runtime_session_task_bound` handoff 之前,要求 runtime session 的投影 liveness 为 `live`。投影在 reopen/rebuild 时把所有 runtime session 标成 `unknown`,于是 daemon 每次重启后所有 worker 的 `doc.submit`/`progress` 都被 `lease_conflict` 拒绝,尽管其 execution lease 仍持有、binding 仍 canonical。liveness 是易失的进程状态,不是授权;删除这两处 liveness 判定。AuthorizationPort 仍要求同 task/execution 的 held lease、runtime-session/binding/person 精确相等与 `sameWriteSource`,release/过期与所有错身份场景照旧拒绝。

## 架构辩护

- 不需要:Production-Delta churn 低于 200 行。

## 改动内容

- `packages/kernel/src/domain/task-bound-runtime-authority.ts`:`runtimeSessionExecutesTask` 与 `resolveLiveTaskBoundRuntimeBinding` 不再以 `liveness === "live"` 把关。
- `packages/daemon/test/contracts/doc-sync-runtime-artifacts.test.ts`:fixture 覆盖生产流程(person 启动任务、executor 为空、派出 runtime、投影 reopen),显式提交单一 artifact 路径。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_a4c4f60fcd52a7b6266ed1be15
- 分支:codex/dispatch-executor-handoff
- 公开范围:packages/kernel/src/domain/task-bound-runtime-authority.ts 与一个 daemon contract 测试
- 私有计划 / 证据是否已更新:yes
- 范围外:投影 reopen 时的 liveness 标记(0.24 runtime/daemon 解耦)与 `runtime-sessions.json` mutable index(1.8)

## 版本影响

- 版本:不改版本,原因是预发布内部修复
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_a4c4f60fcd52a7b6266ed1be15
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:48f1baaffb6922ee08013f53789071925985edf5
- 当前分支与 `origin/main` 的 merge-base:48f1baaffb6922ee08013f53789071925985edf5
- 最近一次 `git fetch origin` 时间:2026-08-25T20:25Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_a4c4f60fcd52a7b6266ed1be15
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] `npm run check:local`(worker 跑,绿)
- [x] daemon contract 测试删除前红 / 删除后绿
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:无;以 CI 为权威。

## 审查证据

- 自查:CEO 的前提(#1830 删了 delegation 载体)被 worker 用 diff 证据驳回;CEO 采纳 liveness 耦合根因与纯删除修法。
- Reviewer subagent:Codex worker(sol),带 challenge 报告与红/绿证据。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 进程已死的 runtime session 在 execution lease release/过期前仍保有 handoff 授权(受 lease TTL 约束)。

## 关联材料

- 任务:task_a4c4f60fcd52a7b6266ed1be15
- 证据:任务包 artifacts/reports
- 审查:本 PR
