### PR TITLE
refactor(daemon): delete the runtime-session mutable index and derive session state from the dispatch stream

### DIFF
--- a/packages/daemon/src/dispatch-read.ts
+++ b/packages/daemon/src/dispatch-read.ts
@@ -1,7 +1,6 @@
 import { consumeKnownError, type RuntimeSession, type TaskProjection } from "../../kernel/src/index.ts";
 import {
   readDispatchLiveIndex,
-  readRuntimeSessionIndex,
   readDispatchStream,
   removeDispatchLiveIndexEntries,
   type DispatchStreamHeader,
@@ -60,22 +59,23 @@ export function readTaskDispatches(
     if (sessions.has(entry.runtimeSessionId)) staleIndexEntries.set(entry.dispatchId, entry);
   }
   const rows = new Map<string, TaskDispatchRow>();
-  const sessionIndex = new Map(readRuntimeSessionIndex(input.rootDir).map((entry) => [entry.dispatchId, entry]));
   for (const [dispatchId, candidate] of candidates) {
+    const stream = /^dispatch_[a-f0-9]{24}$/u.test(dispatchId) ? readDispatchStream(input.rootDir, dispatchId) : null,
+      lost =
+        stream?.records.some((record) => record.kind === "process_lost") === true ||
+        (stream?.process?.exited === false &&
+          candidate.session?.liveness === "exited" &&
+          candidate.session.outcome === "unknown");
     for (const target of candidate.taskPackages) {
       const documentPath = `${target.packagePath}/artifacts/dispatches/${dispatchId}.json`;
       const read = input.projection.readDocument(documentPath);
       const archive = read.document ? parseArchive(read.document.body) : null;
       if (archive?.taskId !== target.taskId) continue;
-      rows.set(
-        dispatchId,
-        archiveRow(archive, candidate.session, target.packagePath, sessionIndex.get(dispatchId)?.state === "lost"),
-      );
+      rows.set(dispatchId, archiveRow(archive, candidate.session, target.packagePath, lost));
       if (candidate.indexed) staleIndexEntries.set(dispatchId, indexedEntries.get(dispatchId)!);
       break;
     }
-    if (rows.has(dispatchId) || !/^dispatch_[a-f0-9]{24}$/u.test(dispatchId)) continue;
-    const stream = readDispatchStream(input.rootDir, dispatchId);
+    if (rows.has(dispatchId)) continue;
     if (!stream?.header.taskId || !tasks.has(stream.header.taskId)) {
       if (candidate.indexed) staleIndexEntries.set(dispatchId, indexedEntries.get(dispatchId)!);
       continue;
@@ -89,7 +89,7 @@ export function readTaskDispatches(
         candidate.session,
         live,
         candidate.taskPackages[0]?.packagePath ?? null,
-        sessionIndex.get(dispatchId)?.state === "lost",
+        lost,
       ),
     );
   }
@@ -203,7 +203,7 @@ function liveRow(
     startedAt: header.startedAt,
     endedAt: null,
     outcome,
-    status: outcome ?? (lost ? "lost" : session?.liveness === "live" || processRunning ? "running" : "unknown"),
+    status: lost ? "lost" : (outcome ?? (session?.liveness === "live" || processRunning ? "running" : "unknown")),
     resultRef: session?.resultRef ?? null,
     exitCode: session?.exitCode ?? null,
     ...(packagePath

--- a/packages/daemon/src/dispatch-stream.ts
+++ b/packages/daemon/src/dispatch-stream.ts
@@ -24,7 +24,6 @@ import type { RuntimePermissionMode } from "./runtime-permissions.ts";
 
 const streamSchema = "runtime-dispatch-stream/v1" as const;
 const liveIndexSchema = "runtime-dispatch-live-index/v1" as const;
-const runtimeSessionIndexSchema = "runtime-session-index/v1" as const;
 const forbiddenKey =
   /(?:token|credential|password|secret|authorization|executablepath|api[-_ ]?key|private[-_ ]?key|cookie)/iu;
 const bearer = /\bBearer\s+[^\s,;]+/giu;
@@ -95,23 +94,6 @@ export interface DispatchLiveIndex {
   readonly entries: readonly DispatchLiveIndexEntry[];
 }
 
-/** Durable process/session index used to recover detached sessions after daemon restart. */
-export interface RuntimeSessionIndexEntry {
-  readonly schema: typeof runtimeSessionIndexSchema;
-  readonly runtimeSessionId: string;
-  readonly dispatchId: string;
-  readonly taskId: string | null;
-  readonly executionId: string | null;
-  readonly startedAt: string;
-  readonly pid: number | null;
-  readonly state: "live" | "exited" | "lost";
-  readonly exitCode: number | null;
-  readonly signal: string | null;
-  readonly reason: string | null;
-  readonly endedAt: string | null;
-  readonly resultRef: string | null;
-}
-
 export function openDispatchStream(
   rootDir: string,
   header: Omit<DispatchStreamHeader, "schema" | "kind" | "eventStreamRef">,
@@ -135,22 +117,6 @@ export function openDispatchStream(
       }
     }
   }
-  if (!readRuntimeSessionIndex(rootDir).some((entry) => entry.dispatchId === header.dispatchId))
-    upsertRuntimeSessionIndex(rootDir, {
-      schema: runtimeSessionIndexSchema,
-      runtimeSessionId: header.runtimeSessionId,
-      dispatchId: header.dispatchId,
-      taskId: header.taskId,
-      executionId: header.executionId,
-      startedAt: header.startedAt,
-      pid: null,
-      state: "live",
-      exitCode: null,
-      signal: null,
-      reason: null,
-      endedAt: null,
-      resultRef: null,
-    });
   return {
     ref,
     appendProviderEvent: (value, occurredAt) =>
@@ -180,46 +146,6 @@ export function removeDispatchStream(rootDir: string, dispatchId: string): void 
     removeDispatchLiveIndexEntries(rootDir, [
       { dispatchId, taskId: header.taskId, runtimeSessionId: header.runtimeSessionId },
     ]);
-  const entries = readRuntimeSessionIndex(rootDir).filter((entry) => entry.dispatchId !== dispatchId);
-  if (entries.length !== readRuntimeSessionIndex(rootDir).length) writeRuntimeSessionIndex(rootDir, entries);
-}
-
-export function runtimeSessionIndexPath(rootDir: string): string {
-  return path.join(dispatchStreamRoot(rootDir), "runtime-sessions.json");
-}
-
-export function readRuntimeSessionIndex(rootDir: string): readonly RuntimeSessionIndexEntry[] {
-  const target = runtimeSessionIndexPath(rootDir);
-  if (!existsSync(target) || !statSync(target).isFile()) return [];
-  try {
-    const value: unknown = JSON.parse(readFileSync(target, "utf8"));
-    if (!Array.isArray(value)) return [];
-    return value.filter(isRuntimeSessionIndexEntry);
-  } catch (error) {
-    consumeKnownError(error);
-    return [];
-  }
-}
-
-export function markRuntimeSessionLost(
-  rootDir: string,
-  dispatchId: string,
-  reason: string,
-  exitCode: number | null = null,
-  signal: string | null = null,
-): void {
-  updateRuntimeSessionIndex(rootDir, dispatchId, (entry) => ({
-    ...entry,
-    state: "lost",
-    reason,
-    exitCode,
-    signal,
-    endedAt: new Date().toISOString(),
-  }));
-}
-
-export function markRuntimeSessionResult(rootDir: string, dispatchId: string, resultRef: string): void {
-  updateRuntimeSessionIndex(rootDir, dispatchId, (entry) => ({ ...entry, resultRef }));
 }
 
 export function readDispatchLiveIndex(rootDir: string, taskIds: readonly string[]): DispatchLiveIndex {
@@ -345,16 +271,6 @@ export function appendRuntimeWorkerRecord(
   value: Readonly<Record<string, unknown>>,
 ): void {
   appendJsonl(dispatchStreamPath(rootDir, dispatchId), { schema: streamSchema, ...value });
-  if (value.kind === "process_started" && Number.isInteger(value.pid))
-    updateRuntimeSessionIndex(rootDir, dispatchId, (entry) => ({ ...entry, pid: Number(value.pid), state: "live" }));
-  else if (value.kind === "process_exit")
-    updateRuntimeSessionIndex(rootDir, dispatchId, (entry) => ({
-      ...entry,
-      state: "exited",
-      exitCode: Number.isInteger(value.exitCode) ? Number(value.exitCode) : null,
-      signal: typeof value.signal === "string" ? value.signal : null,
-      endedAt: typeof value.occurredAt === "string" ? value.occurredAt : new Date().toISOString(),
-    }));
 }
 
 export function readRuntimeWorkerChunk(
@@ -410,61 +326,6 @@ function dispatchStreamRoot(rootDir: string): string {
   return path.join(resolveHarnessLayout(rootDir).localRoot, "runtime", "dispatches");
 }
 
-function upsertRuntimeSessionIndex(rootDir: string, entry: RuntimeSessionIndexEntry): void {
-  const entries = new Map(readRuntimeSessionIndex(rootDir).map((value) => [value.dispatchId, value]));
-  entries.set(entry.dispatchId, entry);
-  writeRuntimeSessionIndex(rootDir, [...entries.values()]);
-}
-
-function updateRuntimeSessionIndex(
-  rootDir: string,
-  dispatchId: string,
-  update: (entry: RuntimeSessionIndexEntry) => RuntimeSessionIndexEntry,
-): void {
-  const current = readRuntimeSessionIndex(rootDir).find((value) => value.dispatchId === dispatchId);
-  if (!current) return;
-  upsertRuntimeSessionIndex(rootDir, update(current));
-}
-
-function writeRuntimeSessionIndex(rootDir: string, entries: readonly RuntimeSessionIndexEntry[]): void {
-  const target = runtimeSessionIndexPath(rootDir),
-    temporary = `${target}.${process.pid}.tmp`;
-  mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
-  try {
-    writeFileSync(
-      temporary,
-      `${JSON.stringify(
-        [...entries].sort((left, right) => left.startedAt.localeCompare(right.startedAt)),
-        null,
-        2,
-      )}\n`,
-      { encoding: "utf8", mode: 0o600 },
-    );
-    renameSync(temporary, target);
-  } finally {
-    if (existsSync(temporary)) unlinkSync(temporary);
-  }
-}
-
-function isRuntimeSessionIndexEntry(value: unknown): value is RuntimeSessionIndexEntry {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
-  const row = value as Record<string, unknown>;
-  return (
-    row.schema === runtimeSessionIndexSchema &&
-    typeof row.runtimeSessionId === "string" &&
-    typeof row.dispatchId === "string" &&
-    (row.taskId === null || typeof row.taskId === "string") &&
-    (row.executionId === null || typeof row.executionId === "string") &&
-    typeof row.startedAt === "string" &&
-    (row.pid === null || (Number.isInteger(row.pid) && Number(row.pid) > 0)) &&
-    ["live", "exited", "lost"].includes(String(row.state)) &&
-    (row.exitCode === null || Number.isInteger(row.exitCode)) &&
-    (row.signal === null || typeof row.signal === "string") &&
-    (row.reason === null || typeof row.reason === "string") &&
-    (row.endedAt === null || typeof row.endedAt === "string") &&
-    (row.resultRef === null || typeof row.resultRef === "string")
-  );
-}
 function dispatchLiveIndex(entries: readonly DispatchLiveIndexEntry[]): DispatchLiveIndex {
   const sorted = [...entries].sort((left, right) => left.dispatchId.localeCompare(right.dispatchId));
   return { schema: liveIndexSchema, entries: sorted };

--- a/packages/daemon/src/runtime-spawn-adoption.ts
+++ b/packages/daemon/src/runtime-spawn-adoption.ts
@@ -1,5 +1,5 @@
 import {
-  markRuntimeSessionLost,
+  appendRuntimeWorkerRecord,
   readDispatchStream,
   readDispatchStreams,
   reopenDispatchStream,
@@ -15,9 +15,9 @@ export async function adoptRuntimes(context: any): Promise<void> {
   const sessions = context.input.remote
     ? await context.input.remote.readRuntimeSessions()
     : context.requiredRuntimeProjection(context.input).readRuntimeSessions();
-  const byId = new Map(sessions.map(
-    (session: { readonly runtimeSessionId: string }) => [session.runtimeSessionId, session],
-  ));
+  const byId = new Map(
+    sessions.map((session: { readonly runtimeSessionId: string }) => [session.runtimeSessionId, session]),
+  );
   for (const stream of readDispatchStreams(context.input.rootDir)) {
     const session = byId.get(stream.header.runtimeSessionId) as
       | { readonly liveness: string; readonly outcome: string | null }
@@ -43,15 +43,16 @@ export async function adoptRuntimes(context: any): Promise<void> {
         : null,
       delegatedBy: stream.header.delegatedByAgentId
         ? {
-          id: stream.header.delegatedByAgentId,
-          name: stream.header.delegatedByAgentName ?? stream.header.delegatedByAgentId,
-        }
+            id: stream.header.delegatedByAgentId,
+            name: stream.header.delegatedByAgentName ?? stream.header.delegatedByAgentId,
+          }
         : null,
       squadId: stream.header.squadId ?? null,
       binding: metadata.binding,
-      task: stream.header.taskId && stream.header.executionId
-        ? { taskId: stream.header.taskId, executionId: stream.header.executionId }
-        : null,
+      task:
+        stream.header.taskId && stream.header.executionId
+          ? { taskId: stream.header.taskId, executionId: stream.header.executionId }
+          : null,
       cwd: metadata.cwd,
       prompt: metadata.prompt,
       ...(stream.header.promptSource ? { promptSource: stream.header.promptSource } : {}),
@@ -83,13 +84,13 @@ export async function adoptRuntimes(context: any): Promise<void> {
           active.lossReason = reason;
           active.lossExitCode = current?.process?.exitCode ?? null;
           active.lossSignal = current?.process?.signal ?? null;
-          markRuntimeSessionLost(
-            context.input.rootDir,
-            active.dispatchId,
+          appendRuntimeWorkerRecord(context.input.rootDir, active.dispatchId, {
+            kind: "process_lost",
+            occurredAt: context.input.now(),
             reason,
-            active.lossExitCode,
-            active.lossSignal,
-          );
+            exitCode: active.lossExitCode,
+            signal: active.lossSignal,
+          });
           context.input.schedule(() => context.publishExit(active, active.lossExitCode));
         }
       }, 50);
@@ -109,16 +110,17 @@ function adoptableMetadata(header: DispatchStreamHeader): {
   readonly reasoningEffort: string | null;
 } | null {
   if (
-    typeof header.dispatchOpId !== "string"
-    || !["claude", "codex", "agy"].includes(String(header.kindId))
-    || header.permissionMode !== null
-      && !["bypass", "workspace-write", "read-only"].includes(String(header.permissionMode))
-    || !isBinding(header.binding)
-    || typeof header.cwd !== "string"
-    || typeof header.prompt !== "string"
-    || typeof header.model !== "string"
-    || header.reasoningEffort !== null && typeof header.reasoningEffort !== "string"
-  ) return null;
+    typeof header.dispatchOpId !== "string" ||
+    !["claude", "codex", "agy"].includes(String(header.kindId)) ||
+    (header.permissionMode !== null &&
+      !["bypass", "workspace-write", "read-only"].includes(String(header.permissionMode))) ||
+    !isBinding(header.binding) ||
+    typeof header.cwd !== "string" ||
+    typeof header.prompt !== "string" ||
+    typeof header.model !== "string" ||
+    (header.reasoningEffort !== null && typeof header.reasoningEffort !== "string")
+  )
+    return null;
   return {
     dispatchOpId: header.dispatchOpId,
     kindId: header.kindId as "claude" | "codex" | "agy",
@@ -134,9 +136,11 @@ function isBinding(value: unknown): value is RuntimeBinding {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
   const binding = value as Record<string, unknown>;
   const actor = binding.actor;
-  return actor !== null
-    && typeof actor === "object"
-    && !Array.isArray(actor)
-    && typeof (actor as { principal?: { personId?: unknown } }).principal?.personId === "string"
-    && binding.source !== undefined;
+  return (
+    actor !== null &&
+    typeof actor === "object" &&
+    !Array.isArray(actor) &&
+    typeof (actor as { principal?: { personId?: unknown } }).principal?.personId === "string" &&
+    binding.source !== undefined
+  );
 }

--- a/packages/daemon/src/runtime-spawn-settlement.ts
+++ b/packages/daemon/src/runtime-spawn-settlement.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import type { AgentRuntimeEventV1, CanonicalEventStore, RuntimeResultClaim } from "../../kernel/src/index.ts";
 import { consumeKnownError } from "../../kernel/src/index.ts";
-import { markRuntimeSessionResult, scrubProviderValue } from "./dispatch-stream.ts";
+import { scrubProviderValue } from "./dispatch-stream.ts";
 import { archiveRuntimeDispatch, type RuntimeDispatchArchive } from "./doc-sync-actions.ts";
 import { consumeDurableOutput } from "./runtime-spawn-provider-stream.ts";
 import type { ActiveRuntime } from "./runtime-spawn-types.ts";
@@ -91,7 +91,6 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
             eventStreamRef: active.stream.ref,
           }
         : null;
-    markRuntimeSessionResult(context.input.rootDir, active.dispatchId, resultRef);
     if (archive)
       try {
         const archived = context.input.remote

--- a/packages/daemon/test/dispatch-read.test.ts
+++ b/packages/daemon/test/dispatch-read.test.ts
@@ -5,28 +5,68 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { type RuntimeSession, type TaskProjection } from "../../kernel/src/index.ts";
-import { appendRuntimeWorkerRecord, markRuntimeSessionLost, openDispatchStream, readDispatchLiveIndex } from "../src/dispatch-stream.ts";
+import { appendRuntimeWorkerRecord, openDispatchStream, readDispatchLiveIndex } from "../src/dispatch-stream.ts";
 import { readTaskDispatches } from "../src/dispatch-read.ts";
 
-const dispatchId = "dispatch_a1b2c3d4e5f60718293a4b5c", runtimeSessionId = "runtime-1", taskId = "task-1";
+const dispatchId = "dispatch_a1b2c3d4e5f60718293a4b5c",
+  runtimeSessionId = "runtime-1",
+  taskId = "task-1";
 
 function session(liveness: RuntimeSession["liveness"], outcome: RuntimeSession["outcome"]): RuntimeSession {
-  return { runtimeSessionId, instanceId: "instance-1", installationId: "installation-1", kindId: "codex", definitionSnapshotRef: "artifact:runtime-definition/test", providerSessionId: null, transcriptRef: null, launchGeneration: 1, liveness, attachable: false, taskBindings: [], outcome, exitCode: null, resultRef: null, lastObservedAt: "2026-08-23T00:00:00.000Z" };
+  return {
+    runtimeSessionId,
+    instanceId: "instance-1",
+    installationId: "installation-1",
+    kindId: "codex",
+    definitionSnapshotRef: "artifact:runtime-definition/test",
+    providerSessionId: null,
+    transcriptRef: null,
+    launchGeneration: 1,
+    liveness,
+    attachable: false,
+    taskBindings: [],
+    outcome,
+    exitCode: null,
+    resultRef: null,
+    lastObservedAt: "2026-08-23T00:00:00.000Z",
+  };
 }
 
 function projectionFor(current: RuntimeSession): TaskProjection {
-  return { readTaskRuntimeBatch: () => ({ status: "ready", taskIds: [taskId], rows: [{ taskId, packagePath: "tasks/task-1", sessions: [current] }], watermark: 1, sourceRevision: 1 }), readRuntimeDispatch: () => ({ payload: { dispatchId } }), readReplicaBasis: () => { throw new Error("dispatch reads must not enumerate the replica document basis"); }, readDocument: () => ({ document: null }) } as unknown as TaskProjection;
+  return {
+    readTaskRuntimeBatch: () => ({
+      status: "ready",
+      taskIds: [taskId],
+      rows: [{ taskId, packagePath: "tasks/task-1", sessions: [current] }],
+      watermark: 1,
+      sourceRevision: 1,
+    }),
+    readRuntimeDispatch: () => ({ payload: { dispatchId } }),
+    readReplicaBasis: () => {
+      throw new Error("dispatch reads must not enumerate the replica document basis");
+    },
+    readDocument: () => ({ document: null }),
+  } as unknown as TaskProjection;
 }
 
 function statusFor(current: RuntimeSession): string {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-read-"));
   try {
-    openDispatchStream(rootDir, { dispatchId, taskId, executionId: "execution-1", runtimeSessionId, instanceId: "instance-1", startedAt: "2026-08-23T00:00:00.000Z" });
+    openDispatchStream(rootDir, {
+      dispatchId,
+      taskId,
+      executionId: "execution-1",
+      runtimeSessionId,
+      instanceId: "instance-1",
+      startedAt: "2026-08-23T00:00:00.000Z",
+    });
     const result = readTaskDispatches({ rootDir, projection: projectionFor(current), taskId });
     const row = result.dispatches.find((candidate) => candidate.dispatchId === dispatchId);
     assert.ok(row, "dispatch row missing");
     return row.status;
-  } finally { rmSync(rootDir, { recursive: true, force: true }); }
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
 }
 
 // A dispatch stream with no archived record reports status from the session field that is
@@ -41,11 +81,20 @@ test("a dispatch whose session has exited reports unknown, not running", () => {
 test("a daemon restart loss is a terminal lost dispatch", () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-read-lost-"));
   try {
-    openDispatchStream(rootDir, { dispatchId, taskId, executionId: "execution-1", runtimeSessionId, instanceId: "instance-1", startedAt: "2026-08-23T00:00:00.000Z" });
-    markRuntimeSessionLost(rootDir, dispatchId, "provider pid disappeared");
-    const result = readTaskDispatches({ rootDir, projection: projectionFor(session("exited", null)), taskId });
+    openDispatchStream(rootDir, {
+      dispatchId,
+      taskId,
+      executionId: "execution-1",
+      runtimeSessionId,
+      instanceId: "instance-1",
+      startedAt: "2026-08-23T00:00:00.000Z",
+    });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_started", pid: 12345 });
+    const result = readTaskDispatches({ rootDir, projection: projectionFor(session("exited", "unknown")), taskId });
     assert.equal(result.dispatches[0]?.status, "lost");
-  } finally { rmSync(rootDir, { recursive: true, force: true }); }
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
 });
 
 test("a dispatch whose session is live still reports running", () => {
@@ -60,23 +109,53 @@ test("an observed outcome outranks liveness", () => {
 test("an unbound detached dispatch is read from the live index", () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-read-unbound-"));
   try {
-    openDispatchStream(rootDir, { dispatchId, taskId, executionId: "execution-1", runtimeSessionId, instanceId: "instance-1", startedAt: "2026-08-23T00:00:00.000Z" });
+    openDispatchStream(rootDir, {
+      dispatchId,
+      taskId,
+      executionId: "execution-1",
+      runtimeSessionId,
+      instanceId: "instance-1",
+      startedAt: "2026-08-23T00:00:00.000Z",
+    });
     appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_started", pid: 12345 });
-    const projection = { readTaskRuntimeBatch: () => ({ status: "ready", taskIds: [taskId], rows: [{ taskId, packagePath: "tasks/task-1", sessions: [] }], watermark: 1, sourceRevision: 1 }), readReplicaBasis: () => { throw new Error("dispatch reads must not enumerate the replica document basis"); }, readDocument: () => ({ document: null }) } as unknown as TaskProjection;
+    const projection = {
+      readTaskRuntimeBatch: () => ({
+        status: "ready",
+        taskIds: [taskId],
+        rows: [{ taskId, packagePath: "tasks/task-1", sessions: [] }],
+        watermark: 1,
+        sourceRevision: 1,
+      }),
+      readReplicaBasis: () => {
+        throw new Error("dispatch reads must not enumerate the replica document basis");
+      },
+      readDocument: () => ({ document: null }),
+    } as unknown as TaskProjection;
     const result = readTaskDispatches({ rootDir, projection, taskId });
     assert.equal(result.dispatches.find((row) => row.dispatchId === dispatchId)?.status, "running");
     assert.equal(readDispatchLiveIndex(rootDir, [taskId]).entries.length, 1, "unbound dispatch must remain indexed");
-  } finally { rmSync(rootDir, { recursive: true, force: true }); }
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
 });
 
 test("a projected task binding removes the live index entry", () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-read-bound-"));
   try {
-    openDispatchStream(rootDir, { dispatchId, taskId, executionId: "execution-1", runtimeSessionId, instanceId: "instance-1", startedAt: "2026-08-23T00:00:00.000Z" });
+    openDispatchStream(rootDir, {
+      dispatchId,
+      taskId,
+      executionId: "execution-1",
+      runtimeSessionId,
+      instanceId: "instance-1",
+      startedAt: "2026-08-23T00:00:00.000Z",
+    });
     const result = readTaskDispatches({ rootDir, projection: projectionFor(session("live", null)), taskId });
     assert.equal(result.dispatches.find((row) => row.dispatchId === dispatchId)?.status, "running");
     assert.deepEqual(readDispatchLiveIndex(rootDir, [taskId]).entries, []);
-  } finally { rmSync(rootDir, { recursive: true, force: true }); }
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
 });
 
 test("archived dispatch rows expose terminal result and task artifact references", () => {
@@ -106,7 +185,9 @@ test("archived dispatch rows expose terminal result and task artifact references
       }),
       readRuntimeDispatch: () => ({ payload: { dispatchId } }),
       readDocument: () => ({ document: { body: JSON.stringify(archived) } }),
-      readReplicaBasis: () => { throw new Error("dispatch reads must not enumerate the replica document basis"); },
+      readReplicaBasis: () => {
+        throw new Error("dispatch reads must not enumerate the replica document basis");
+      },
     } as unknown as TaskProjection;
     const result = readTaskDispatches({ rootDir, projection, taskId });
     assert.deepEqual(result.dispatches[0], {
@@ -126,5 +207,7 @@ test("archived dispatch rows expose terminal result and task artifact references
       dispatchPath: "tasks/task-1/artifacts/dispatches/dispatch_a1b2c3d4e5f60718293a4b5c.json",
       reportPath: "tasks/task-1/artifacts/reports/dispatch_a1b2c3d4e5f60718293a4b5c.md",
     });
-  } finally { rmSync(rootDir, { recursive: true, force: true }); }
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
 });

--- a/packages/daemon/test/dispatch-stream.test.ts
+++ b/packages/daemon/test/dispatch-stream.test.ts
@@ -9,7 +9,7 @@ import {
   dispatchLiveIndexPath,
   openDispatchStream,
   readDispatchLiveIndex,
-  readRuntimeSessionIndex,
+  readDispatchStream,
 } from "../src/dispatch-stream.ts";
 
 test("the live index rebuilds exactly from dispatch stream headers", () => {
@@ -17,26 +17,54 @@ test("the live index rebuilds exactly from dispatch stream headers", () => {
   try {
     for (const suffix of ["111111111111111111111111", "222222222222222222222222"] as const) {
       const dispatchId = `dispatch_${suffix}`;
-      openDispatchStream(rootDir, { dispatchId, taskId: "task-1", executionId: "execution-1", runtimeSessionId: `runtime_${suffix}`, instanceId: "instance-1", startedAt: "2026-08-24T00:00:00.000Z" });
-      appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "provider_event", event: { text: "tail records are not needed to rebuild the header index" } });
+      openDispatchStream(rootDir, {
+        dispatchId,
+        taskId: "task-1",
+        executionId: "execution-1",
+        runtimeSessionId: `runtime_${suffix}`,
+        instanceId: "instance-1",
+        startedAt: "2026-08-24T00:00:00.000Z",
+      });
+      appendRuntimeWorkerRecord(rootDir, dispatchId, {
+        kind: "provider_event",
+        event: { text: "tail records are not needed to rebuild the header index" },
+      });
     }
     const before = readDispatchLiveIndex(rootDir, ["task-1"]);
     rmSync(dispatchLiveIndexPath(rootDir, "task-1"));
     const rebuilt = readDispatchLiveIndex(rootDir, ["task-1"]);
     assert.deepEqual(rebuilt, before);
-  } finally { rmSync(rootDir, { recursive: true, force: true }); }
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
 });
 
-test("the runtime session index records process exit and preserves a lost terminal reason", () => {
-  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-runtime-session-index-"));
+test("process lifecycle observations remain in the append-only dispatch stream", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-process-stream-"));
   try {
     const dispatchId = "dispatch_333333333333333333333333";
-    openDispatchStream(rootDir, { dispatchId, taskId: "task-2", executionId: "execution-2", runtimeSessionId: "runtime_333333333333333333333333", instanceId: "instance-1", startedAt: "2026-08-24T00:00:00.000Z" });
+    openDispatchStream(rootDir, {
+      dispatchId,
+      taskId: "task-2",
+      executionId: "execution-2",
+      runtimeSessionId: "runtime_333333333333333333333333",
+      instanceId: "instance-1",
+      startedAt: "2026-08-24T00:00:00.000Z",
+    });
     appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_started", pid: 4321 });
-    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_exit", exitCode: null, signal: "SIGKILL", occurredAt: "2026-08-24T00:01:00.000Z" });
-    const row = readRuntimeSessionIndex(rootDir)[0];
-    assert.equal(row?.state, "exited");
-    assert.equal(row?.pid, 4321);
-    assert.equal(row?.signal, "SIGKILL");
-  } finally { rmSync(rootDir, { recursive: true, force: true }); }
+    appendRuntimeWorkerRecord(rootDir, dispatchId, {
+      kind: "process_exit",
+      exitCode: null,
+      signal: "SIGKILL",
+      occurredAt: "2026-08-24T00:01:00.000Z",
+    });
+    const stream = readDispatchStream(rootDir, dispatchId);
+    assert.deepEqual(stream?.process, { pid: 4321, exitCode: null, signal: "SIGKILL", exited: true });
+    assert.deepEqual(
+      stream?.records.map((record) => record.kind),
+      ["process_started", "process_exit"],
+    );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
 });

--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -527,6 +527,11 @@ test("repo-cell restart re-adopts a live native runtime and settles an exit reco
         repoId: workspaceId(repoId),
         rootDir: canonicalRoot(root),
         ownerId,
+        runtimeDaemonRoute: {
+          userRoot: path.join(parent, "daemon-user"),
+          daemonId: "runtime-re-adopt-test",
+          endpoint: path.join(parent, "daemon.sock"),
+        },
         runtimeInstances: () => [definition],
         prepareRuntimeLaunch: async (_instanceId, request) => ({
           definition: preparedDefinition,
@@ -660,6 +665,105 @@ test("repo-cell restart re-adopts a live native runtime and settles an exit reco
       },
       { liveness: "exited", outcome: "succeeded", exitCode: 0 },
     );
+
+    const taskId = "task-runtime-lost",
+      executionId = "execution-runtime-lost",
+      binding = {
+        actor: { principal: { personId: "owner" }, executor: null },
+        source: "local" as const,
+      };
+    assert.equal((await cell.run({ kind: "task-create", taskId, title: "Runtime Lost" }, binding)).outcome, "applied");
+    assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, binding)).outcome, "applied");
+    rmSync(release, { force: true });
+    const lostReceipt = await cell.spawnRuntime(
+      {
+        runtimeInstanceId: definition.instanceId,
+        cwd: { scope: "repo-root" },
+        prompt: "Lose the worker host while the daemon is absent",
+        taskId,
+        idempotencyKey: "re-adopt-lost",
+      },
+      binding,
+    );
+    providerPid = await eventuallyValue(() => {
+      try {
+        const value = Number(readFileSync(pidFile, "utf8"));
+        return Number.isInteger(value) && value > 0 ? value : null;
+      } catch {
+        return null;
+      }
+    });
+    const lostDispatchId = String(lostReceipt.dispatchId),
+      hostPid = await eventuallyValue(() => {
+        const started = readFileSync(
+          path.join(root, ".harness", "runtime", "dispatches", `${lostDispatchId}.jsonl`),
+          "utf8",
+        )
+          .trim()
+          .split(/\r?\n/u)
+          .map((line) => JSON.parse(line) as Record<string, unknown>)
+          .find((record) => record.kind === "process_started");
+        return Number.isInteger(started?.pid) && Number(started?.pid) > 0 ? Number(started?.pid) : null;
+      });
+    await cell.close();
+    cell = undefined;
+    process.kill(hostPid, "SIGKILL");
+    try {
+      process.kill(providerPid, "SIGKILL");
+    } catch (error) {
+      consumeKnownError(error);
+    }
+    await eventuallyValue(() => {
+      try {
+        process.kill(hostPid, 0);
+        return null;
+      } catch {
+        return true;
+      }
+    });
+    cell = await open("re-adopt-lost");
+    await eventually(() =>
+      makeTaskEventStore({ repoId, rootDir: root })
+        .read()
+        .events.some(
+          (event) =>
+            event.type === "runtime_session_outcome_observed" &&
+            event.payload.runtimeSessionId === lostReceipt.runtimeSessionId,
+        ),
+    );
+    rmSync(path.join(root, ".harness", "runtime", "dispatches", "runtime-sessions.json"), { force: true });
+    const lostDispatches = await cell.read("repo.task.dispatches", { taskId }),
+      lostRow = lostDispatches.dispatches.find((row) => row.dispatchId === lostDispatchId),
+      lostProjection = makeTaskProjection({
+        rootDir: root,
+        eventStore: makeTaskEventStore({ repoId, rootDir: root }),
+      }),
+      lostSession = lostProjection.readRuntimeSession(String(lostReceipt.runtimeSessionId))!;
+    lostProjection.close();
+    assert.ok(lostRow, "lost dispatch row missing after daemon restart");
+    assert.equal(
+      readFileSync(path.join(root, ".harness", "runtime", "dispatches", `${lostDispatchId}.jsonl`), "utf8")
+        .split(/\r?\n/u)
+        .some((line) => line.includes('"kind":"process_lost"')),
+      true,
+      "daemon restart loss must be durable in the dispatch stream",
+    );
+    assert.deepEqual(
+      {
+        status: lostRow.status,
+        outcome: lostRow.outcome,
+        exitCode: lostRow.exitCode,
+        resultRef: lostRow.resultRef,
+        liveness: lostSession.liveness,
+      },
+      {
+        status: "lost",
+        outcome: "unknown",
+        exitCode: null,
+        resultRef: lostSession.resultRef,
+        liveness: "exited",
+      },
+    );
   } finally {
     writeFileSync(release, "release");
     await cell?.close();
@@ -673,159 +777,173 @@ test("repo-cell restart re-adopts a live native runtime and settles an exit reco
   }
 });
 
-test("explicit runtime cancel terminates every detached native provider descendant group", { skip: process.platform === "win32" ? "requires POSIX process-group semantics" : false }, async (t) => {
-  const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-detached-cancel-")),
-    root = path.join(parent, "repo"),
-    pidFile = path.join(parent, "provider-pids.json"),
-    repoId = "runtime-detached-cancel",
-    executablePath = writeProviderExecutable(
-      path.join(parent, "cancel-tree-provider.mjs"),
-      `import fs from "node:fs"; import { spawn } from "node:child_process";\nfs.readFileSync(0, "utf8"); const child = spawn(process.execPath, ["-e", "setInterval(() => undefined, 1000)"], { stdio: "ignore", detached: true }); child.unref(); fs.writeFileSync(${JSON.stringify(pidFile)}, JSON.stringify([process.pid, child.pid])); console.log(JSON.stringify({ type: "thread.started", thread_id: "provider-cancel-tree" })); setInterval(() => undefined, 1000);\n`,
-    ),
-    installation = installationFixture("codex", executablePath),
-    instance = {
-      schemaVersion: 2 as const,
-      instanceId: "codex-cancel-tree",
-      name: "Codex Cancel Tree",
-      kindId: "codex" as const,
-      installationId: installation.installationId,
-      providerId: "openai",
-      models: ["codex-model"],
-      defaultModel: "codex-model",
-      enabled: true,
-      permissionMode: "read-only" as const,
-      codex: {},
-      authMode: "subscription" as const,
-      authState: "configured" as const,
-      authReadiness: { status: "ready" as const, code: null, hint: null },
-      isolationState: "enforced" as const,
-    },
-    preparedDefinition: AgentDefinitionSnapshot = {
-      schema: "agent-definition-snapshot/v1",
-      configVersion: 1,
-      instanceId: "codex-cancel-tree",
-      installationId: installation.installationId,
-      kindId: "codex",
-      providerId: "openai",
-      model: "codex-model",
-      reasoningEffort: null,
-      baseUrl: null,
-      authMode: "subscription",
-    };
-  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined,
-    runtimeSessionId = "",
-    pids: number[] = [];
-  try {
-    initIngressRepo(root, 4310);
-    cell = await openRepoCell({
-      repoId: workspaceId(repoId),
-      rootDir: canonicalRoot(root),
-      ownerId: "cancel-tree",
-      runtimeInstances: () => [instance],
-      prepareRuntimeLaunch: async (_instanceId, request) => ({
-        definition: preparedDefinition,
-        installation,
-        executablePath,
-        args: ["exec", "--json", "--model", "codex-model", "-"],
-        env: process.env,
-        cwd: request.cwd,
-        prompt: request.prompt,
-      }),
-    });
-    const spawned = await cell.spawnRuntime(
-      {
-        runtimeInstanceId: instance.instanceId,
-        cwd: { scope: "repo-root" },
-        prompt: "Wait for cancellation",
-        taskId: null,
-        idempotencyKey: "cancel-tree",
+test(
+  "explicit runtime cancel terminates every detached native provider descendant group",
+  { skip: process.platform === "win32" ? "requires POSIX process-group semantics" : false },
+  async (t) => {
+    const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-detached-cancel-")),
+      root = path.join(parent, "repo"),
+      pidFile = path.join(parent, "provider-pids.json"),
+      repoId = "runtime-detached-cancel",
+      executablePath = writeProviderExecutable(
+        path.join(parent, "cancel-tree-provider.mjs"),
+        `import fs from "node:fs"; import { spawn } from "node:child_process";\nfs.readFileSync(0, "utf8"); const child = spawn(process.execPath, ["-e", "setInterval(() => undefined, 1000)"], { stdio: "ignore", detached: true }); child.unref(); fs.writeFileSync(${JSON.stringify(pidFile)}, JSON.stringify([process.pid, child.pid])); console.log(JSON.stringify({ type: "thread.started", thread_id: "provider-cancel-tree" })); setInterval(() => undefined, 1000);\n`,
+      ),
+      installation = installationFixture("codex", executablePath),
+      instance = {
+        schemaVersion: 2 as const,
+        instanceId: "codex-cancel-tree",
+        name: "Codex Cancel Tree",
+        kindId: "codex" as const,
+        installationId: installation.installationId,
+        providerId: "openai",
+        models: ["codex-model"],
+        defaultModel: "codex-model",
+        enabled: true,
+        permissionMode: "read-only" as const,
+        codex: {},
+        authMode: "subscription" as const,
+        authState: "configured" as const,
+        authReadiness: { status: "ready" as const, code: null, hint: null },
+        isolationState: "enforced" as const,
       },
-      {
-        actor: {
-          principal: { personId: "person-cancel-tree" },
-          executor: null,
+      preparedDefinition: AgentDefinitionSnapshot = {
+        schema: "agent-definition-snapshot/v1",
+        configVersion: 1,
+        instanceId: "codex-cancel-tree",
+        installationId: installation.installationId,
+        kindId: "codex",
+        providerId: "openai",
+        model: "codex-model",
+        reasoningEffort: null,
+        baseUrl: null,
+        authMode: "subscription",
+      };
+    let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined,
+      runtimeSessionId = "",
+      pids: number[] = [];
+    try {
+      initIngressRepo(root, 4310);
+      cell = await openRepoCell({
+        repoId: workspaceId(repoId),
+        rootDir: canonicalRoot(root),
+        ownerId: "cancel-tree",
+        runtimeInstances: () => [instance],
+        prepareRuntimeLaunch: async (_instanceId, request) => ({
+          definition: preparedDefinition,
+          installation,
+          executablePath,
+          args: ["exec", "--json", "--model", "codex-model", "-"],
+          env: process.env,
+          cwd: request.cwd,
+          prompt: request.prompt,
+        }),
+      });
+      const spawned = await cell.spawnRuntime(
+        {
+          runtimeInstanceId: instance.instanceId,
+          cwd: { scope: "repo-root" },
+          prompt: "Wait for cancellation",
+          taskId: null,
+          idempotencyKey: "cancel-tree",
         },
-        source: "local",
-      },
-    );
-    runtimeSessionId = String(spawned.runtimeSessionId);
-    pids = await eventuallyValue(() => {
-      try {
-        const values = JSON.parse(readFileSync(pidFile, "utf8")) as number[];
-        return values.length === 2 && values.every((pid) => Number.isInteger(pid) && pid > 0) ? values : null;
-      } catch {
-        return null;
-      }
-    });
-    const hostPid = await eventuallyValue(() => {
-      try {
-        const records = readFileSync(
-            path.join(root, ".harness", "runtime", "dispatches", `${String(spawned.dispatchId)}.jsonl`),
-            "utf8",
+        {
+          actor: {
+            principal: { personId: "person-cancel-tree" },
+            executor: null,
+          },
+          source: "local",
+        },
+      );
+      runtimeSessionId = String(spawned.runtimeSessionId);
+      pids = await eventuallyValue(() => {
+        try {
+          const values = JSON.parse(readFileSync(pidFile, "utf8")) as number[];
+          return values.length === 2 && values.every((pid) => Number.isInteger(pid) && pid > 0) ? values : null;
+        } catch {
+          return null;
+        }
+      });
+      const hostPid = await eventuallyValue(() => {
+        try {
+          const records = readFileSync(
+              path.join(root, ".harness", "runtime", "dispatches", `${String(spawned.dispatchId)}.jsonl`),
+              "utf8",
+            )
+              .trim()
+              .split(/\r?\n/u)
+              .map((line) => JSON.parse(line) as Record<string, unknown>),
+            pid = records.find((record) => record.kind === "process_started")?.pid;
+          return Number.isInteger(pid) && Number(pid) > 0 ? Number(pid) : null;
+        } catch {
+          return null;
+        }
+      });
+      pids = [hostPid, ...pids];
+      assert.equal(
+        (
+          await cell.cancelRuntime(
+            { runtimeSessionId },
+            {
+              actor: {
+                principal: { personId: "person-cancel-tree" },
+                executor: null,
+              },
+              source: "local",
+            },
           )
+        ).detail,
+        "cancelled",
+      );
+      const streamPath = path.join(root, ".harness", "runtime", "dispatches", `${String(spawned.dispatchId)}.jsonl`),
+        descendants = await eventuallyValue(() => {
+          const records = readFileSync(streamPath, "utf8")
             .trim()
             .split(/\r?\n/u)
-            .map((line) => JSON.parse(line) as Record<string, unknown>),
-          pid = records.find((record) => record.kind === "process_started")?.pid;
-        return Number.isInteger(pid) && Number(pid) > 0 ? Number(pid) : null;
-      } catch {
-        return null;
-      }
-    });
-    pids = [hostPid, ...pids];
-    assert.equal(
-      (
-        await cell.cancelRuntime(
-          { runtimeSessionId },
-          {
-            actor: {
-              principal: { personId: "person-cancel-tree" },
-              executor: null,
-            },
-            source: "local",
-          },
-        )
-      ).detail,
-      "cancelled",
-    );
-    const streamPath = path.join(root, ".harness", "runtime", "dispatches", `${String(spawned.dispatchId)}.jsonl`),
-      descendants = await eventuallyValue(() => {
-        const records = readFileSync(streamPath, "utf8").trim().split(/\r?\n/u).map((line) => JSON.parse(line) as Record<string, unknown>);
-        return records.find((record) => record.kind === "process_descendants") ?? null;
+            .map((line) => JSON.parse(line) as Record<string, unknown>);
+          return records.find((record) => record.kind === "process_descendants") ?? null;
+        });
+      assert.deepEqual(
+        (descendants.pids as number[]).slice().sort((left, right) => left - right),
+        pids.slice().sort((left, right) => left - right),
+      );
+      const survivors = pids.filter((pid) => {
+        try {
+          process.kill(pid, 0);
+          return true;
+        } catch {
+          return false;
+        }
       });
-    assert.deepEqual((descendants.pids as number[]).slice().sort((left, right) => left - right), pids.slice().sort((left, right) => left - right));
-    const survivors = pids.filter((pid) => {
-      try { process.kill(pid, 0); return true; }
-      catch { return false; }
-    });
-    assert.deepEqual(survivors, [], `cancel survivors: ${JSON.stringify(survivors)}`);
-    t.diagnostic(`cancel descendants=${JSON.stringify(pids)} survivors=${JSON.stringify(survivors)}`);
-  } finally {
-    if (runtimeSessionId)
-      try {
-        await cell?.cancelRuntime(
-          { runtimeSessionId },
-          {
-            actor: {
-              principal: { personId: "person-cancel-tree" },
-              executor: null,
+      assert.deepEqual(survivors, [], `cancel survivors: ${JSON.stringify(survivors)}`);
+      t.diagnostic(`cancel descendants=${JSON.stringify(pids)} survivors=${JSON.stringify(survivors)}`);
+    } finally {
+      if (runtimeSessionId)
+        try {
+          await cell?.cancelRuntime(
+            { runtimeSessionId },
+            {
+              actor: {
+                principal: { personId: "person-cancel-tree" },
+                executor: null,
+              },
+              source: "local",
             },
-            source: "local",
-          },
-        );
-      } catch (error) {
-        consumeKnownError(error);
-      }
-    await cell?.close();
-    for (const pid of pids)
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch (error) {
-        consumeKnownError(error);
-      }
-    rmSync(parent, { recursive: true, force: true });
-  }
-});
+          );
+        } catch (error) {
+          consumeKnownError(error);
+        }
+      await cell?.close();
+      for (const pid of pids)
+        try {
+          process.kill(pid, "SIGTERM");
+        } catch (error) {
+          consumeKnownError(error);
+        }
+      rmSync(parent, { recursive: true, force: true });
+    }
+  },
+);
 
 test("runtime exit notification records a bounded timeout", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-runtime-exit-notification-")),


### PR DESCRIPTION
# English

## Summary

Anti-entropy P0-2 (dec_57A9D27BA446C23759A08B1C13, review #1 and #2): the `runtime-session-index/v1` / `runtime-sessions.json` mutable index added by #1809 is deleted. It was a second, user-visible state authority for runtime sessions (dispatch-read overwrote outcomes to `lost` from it) parallel to the canonical `agent-runtime-event/v1` stream and the rebuildable SQLite runtime projection. `lost`/`liveness`/`outcome`/`resultRef` are now derived from the append-only dispatch stream plus the canonical projection; CLI and GUI observations are unchanged on the real ledger.

## Architectural Justification

- Not required: Production-Delta churn is below 200 lines.

## What Changed

- `packages/daemon/src/dispatch-stream.ts`: index schema, file path, read/write/upsert helpers and the open/process/exit/lost/result rewrite paths deleted.
- `packages/daemon/src/dispatch-read.ts`: no longer overlays `lost` from the index; derives state from the stream and projection.
- tests: regression asserting dispatch terminal state and lost detection survive a daemon restart without the index.

## Gate Harvest / 门收割

Deleted-Production-Paths: packages/daemon/src/dispatch-stream.ts (runtime-session-index/v1 helpers), .harness/runtime/dispatches/runtime-sessions.json (runtime file, no longer written)
Deleted-Gates-Fixtures: index-shaped fixtures in the dispatch-stream tests replaced by stream-derived assertions
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +46/-182

### Optional Evidence Claims

## Task And Scope

- Harness task: task_a1cee558e37000cddfad14278a
- Branch: codex/delete-runtime-session-index
- Public scope: packages/daemon (dispatch-stream, dispatch-read) and tests
- Private planning/evidence updated: yes
- Out of scope: runtime/daemon process decoupling (0.24); kind-authority closure (1.10)

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_a1cee558e37000cddfad14278a
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: a006d5dad1d568333593b2b0d43ba34a53663a5a
- Branch merge-base with `origin/main`: a006d5dad1d568333593b2b0d43ba34a53663a5a
- Last `git fetch origin` time: 2026-08-25T22:22Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_a1cee558e37000cddfad14278a (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] `npm run check:local` (worker run, green)
- [x] affected daemon integration files via `tools/dispatch-isolated-test.mjs --target docker` (green)
- [x] `rg 'runtime-session-index|runtime-sessions\.json' packages/*/src` → 0; real-ledger `ha runtime status` / `ha task dispatches` before/after identical
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: nothing else; CI is the authority.

## Review Evidence

- Self-review: CEO grep-verified the index symbols are gone and accepted the derivation argument against the P0-2 protected assumption.
- Reviewer subagent: Codex worker (sol); anti-entropy review #2 named this the first P0 item.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Process-level liveness (pid alive) is no longer persisted; it is observed from the stream and the running spawner only.

## References

- Task: task_a1cee558e37000cddfad14278a
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

反熵 P0-2(dec_57A9D27BA446C23759A08B1C13,审查 #1/#2):删除 #1809 加的 `runtime-session-index/v1` / `runtime-sessions.json` mutable 索引。它是 runtime session 的第二个用户可见状态权威(dispatch-read 用它把结果覆写成 `lost`),与 canonical `agent-runtime-event/v1` 流和可重建 SQLite runtime 投影并行。`lost`/`liveness`/`outcome`/`resultRef` 现在由 append-only dispatch stream + canonical 投影派生;真实账本上 CLI 与 GUI 观察不变。

## 架构辩护

- 不需要:Production-Delta churn 低于 200 行。

## 改动内容

- `packages/daemon/src/dispatch-stream.ts`:索引 schema、文件路径、read/write/upsert helper 与 open/process/exit/lost/result 重写路径删除。
- `packages/daemon/src/dispatch-read.ts`:不再用索引覆盖 `lost`;从流与投影派生状态。
- 测试:回归测试断言 daemon 重启后 dispatch 终态与 lost 判定在无索引下仍成立。

## 门收割 / Gate Harvest

- 删除的生产路径:见英文块
- 同 commit 删除的门 / fixture:dispatch-stream 测试中的索引形 fixture 改为流派生断言
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_a1cee558e37000cddfad14278a
- 分支:codex/delete-runtime-session-index
- 公开范围:packages/daemon(dispatch-stream、dispatch-read)与测试
- 私有计划 / 证据是否已更新:yes
- 范围外:runtime/daemon 进程解耦(0.24);kind 权威收口(1.10)

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_a1cee558e37000cddfad14278a
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:a006d5dad1d568333593b2b0d43ba34a53663a5a
- 当前分支与 `origin/main` 的 merge-base:a006d5dad1d568333593b2b0d43ba34a53663a5a
- 最近一次 `git fetch origin` 时间:2026-08-25T22:22Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_a1cee558e37000cddfad14278a
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] `npm run check:local`(worker 跑,绿)
- [x] 受影响 daemon integration 文件经 `tools/dispatch-isolated-test.mjs --target docker`(绿)
- [x] `rg 'runtime-session-index|runtime-sessions\.json' packages/*/src` → 0;真实账本 `ha runtime status` / `ha task dispatches` 前后一致
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:无;以 CI 为权威。

## 审查证据

- 自查:CEO grep 复核索引符号归零,采纳对 P0-2「保护的假设」的派生论证。
- Reviewer subagent:Codex worker(sol);反熵审查 #2 将其列为 P0 首项。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 进程级 liveness(pid 存活)不再持久化;只从流与在跑的 spawner 观察。

## 关联材料

- 任务:task_a1cee558e37000cddfad14278a
- 证据:任务包 artifacts/reports
- 审查:本 PR
