### PR TITLE
refactor(kernel): close the nine-kind entity authority

### DIFF
--- a/packages/daemon/src/doc-sync-adjudication.ts
+++ b/packages/daemon/src/doc-sync-adjudication.ts
@@ -3,7 +3,7 @@ import {
   decideDocWrite,
   docSyncWritePlan,
   parseDocWriteIntent,
-  resolveLiveTaskBoundRuntimeBinding,
+  resolveTaskBoundRuntimeBinding,
   resolveRetirableDocument,
   runtimeSessionIdFromActor,
   sha256Bytes,
@@ -91,7 +91,7 @@ export function adjudicateDocIntent(
     runtimeSessionId = runtimeSessionIdFromActor(input.binding.actor),
     runtimeSession = runtimeSessionId === null ? null : input.projection.readRuntimeSession(runtimeSessionId),
     runtimeBinding =
-      lease === null ? null : resolveLiveTaskBoundRuntimeBinding(runtimeSession, lease.taskId, lease.executionId),
+      lease === null ? null : resolveTaskBoundRuntimeBinding(runtimeSession, lease.taskId, lease.executionId),
     authorizationDecision =
       intent.executionId === null
         ? null

--- a/packages/daemon/src/doc-sync-candidate-scanner.ts
+++ b/packages/daemon/src/doc-sync-candidate-scanner.ts
@@ -14,7 +14,7 @@ import {
   resolveDocRoute,
   resolveHarnessLayout,
   resolveLedgerGitLayout,
-  resolveLiveTaskBoundRuntimeBinding,
+  resolveTaskBoundRuntimeBinding,
   resolveRetirableDocument,
   runtimeSessionIdFromActor,
   sha256Bytes,
@@ -110,7 +110,7 @@ export function scanDocCandidates(input: {
     runtimeBinding =
       execution.lease === null
         ? null
-        : resolveLiveTaskBoundRuntimeBinding(runtimeSession, execution.lease.taskId, execution.lease.executionId),
+        : resolveTaskBoundRuntimeBinding(runtimeSession, execution.lease.taskId, execution.lease.executionId),
     authorizationDecision =
       execution.id === null
         ? null
@@ -407,11 +407,11 @@ function executionBinding(
         session?.taskBindings.flatMap((binding) => {
           if (!tasks.has(binding.taskId)) return [];
           const lease = projection.currentLeaseForExecution(binding.executionId, now),
-            live = resolveLiveTaskBoundRuntimeBinding(session, binding.taskId, binding.executionId);
-          if (lease === null || live === null) return [];
+            runtimeBinding = resolveTaskBoundRuntimeBinding(session, binding.taskId, binding.executionId);
+          if (lease === null || runtimeBinding === null) return [];
           const decision = authorizeAction("doc.submit", `execution/${binding.executionId}`, actor, "doc-scan", {
             writeSource: source,
-            target: { lease, runtimeBinding: live },
+            target: { lease, runtimeBinding },
             evaluatedAtCut,
           });
           return decision.outcome === "allowed" ? [{ id: binding.executionId, lease }] : [];

--- a/packages/daemon/src/repo-cell-task-progress.ts
+++ b/packages/daemon/src/repo-cell-task-progress.ts
@@ -5,7 +5,7 @@ import {
   completionBlockers,
   consumeKnownError,
   isTaskProgressEvent,
-  resolveLiveTaskBoundRuntimeBinding,
+  resolveTaskBoundRuntimeBinding,
   runtimeSessionIdFromActor,
   stableStringify,
   taskProgressWritePlan,
@@ -58,7 +58,7 @@ export function appendProgress(
     recoverySnapshot = lease?.phase === "orphaned" ? { ...task.snapshot, lease: null } : task.snapshot,
     runtimeSessionId = runtimeSessionIdFromActor(binding.actor),
     runtimeSession = runtimeSessionId === null ? null : cell.projection.readRuntimeSession(runtimeSessionId),
-    runtimeBinding = resolveLiveTaskBoundRuntimeBinding(runtimeSession, taskId, executionId),
+    runtimeBinding = resolveTaskBoundRuntimeBinding(runtimeSession, taskId, executionId),
     progressPath = `${task.packagePath}/progress.md`,
     document = cell.projection.readDocument(progressPath);
   if (document.watermark < document.sourceRevision)

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -8,7 +8,7 @@ import type {
 } from "../../kernel/src/index.ts";
 import {
   consumeKnownError,
-  resolveLiveTaskBoundRuntimeBinding,
+  resolveTaskBoundRuntimeBinding,
   runtimeSessionIdFromActor,
   type AuthorizationDecision,
 } from "../../kernel/src/index.ts";
@@ -236,7 +236,7 @@ export function makeRuntimeSpawner(input: {
           runtimeBinding =
             callerRuntimeSessionId === null || lease === null
               ? null
-              : resolveLiveTaskBoundRuntimeBinding(
+              : resolveTaskBoundRuntimeBinding(
                   projection!.readRuntimeSession(callerRuntimeSessionId),
                   taskId,
                   lease.executionId,

--- a/packages/kernel/src/domain/doc-sync-canonical-events.ts
+++ b/packages/kernel/src/domain/doc-sync-canonical-events.ts
@@ -18,7 +18,13 @@ import { validateCurrentTaskEvent, validateTaskEvent, type TaskEventV1 } from ".
 import { validateCurrentTaskProgressEvent, validateTaskProgressEvent } from "./task-progress-event.ts";
 import { canonicalizeWriteValue, isRecord } from "./write-chain.contract.ts";
 
-export const canonicalEventSchemas = Object.freeze([
+interface CanonicalEventSchemaRegistration {
+  readonly schema: string;
+  readonly validate: (value: unknown) => readonly string[];
+  readonly validateCurrent?: (value: unknown) => readonly string[];
+}
+
+export const canonicalEventSchemas: readonly CanonicalEventSchemaRegistration[] = Object.freeze([
   {
     schema: "task-event/v1",
     validate: (value: unknown) => validateTaskEvent(value).map((issue) => issue.message),
@@ -57,7 +63,6 @@ export const canonicalEventSchemas = Object.freeze([
   {
     schema: "agent-entity-event/v1",
     validate: validateEntityEvent,
-    validateCurrent: validateCurrentEntityEvent,
   },
   {
     schema: "fact-event/v1",
@@ -86,7 +91,7 @@ import { validateDocEvent } from "./doc-sync-validation.ts";
 export function validateCurrentCanonicalEvent(value: unknown): readonly string[] {
   if (!isRecord(value)) return ["canonical event is not an object"];
   const entry = canonicalEventSchemas.find((candidate) => candidate.schema === value.schema);
-  return entry?.validateCurrent(value) ?? ["canonical event schema is unknown"];
+  return entry?.validateCurrent?.(value) ?? ["canonical event schema is unknown or not current"];
 }
 
 export function serializeCanonicalEvent(event: CanonicalEventV1): string {

--- a/packages/kernel/src/domain/doc-sync-types.ts
+++ b/packages/kernel/src/domain/doc-sync-types.ts
@@ -15,7 +15,7 @@ import type {
   LedgerIdentity,
 } from "./receipt-domain-registry.ts";
 import type { TaskBootstrapEventV1 } from "./task-bootstrap-event.ts";
-import type { LiveTaskBoundRuntimeBinding } from "./task-bound-runtime-authority.ts";
+import type { TaskBoundRuntimeBinding } from "./task-bound-runtime-authority.ts";
 import type { TaskEventV1 } from "./task-lifecycle.contract.ts";
 import type { TaskProgressEventV1 } from "./task-progress-event.ts";
 import type { ActorIdentity, EventEnvelope, FrozenWritePlan, WriteSource } from "./write-chain.contract.ts";
@@ -205,7 +205,7 @@ export interface DocWriteDecisionInput {
   readonly lease: LeaseV1 | null;
   /** Decision evaluated by the daemon AuthorizationPort for execution-bound writes. */
   readonly authorizationDecision: AuthorizationDecision | null;
-  readonly runtimeBinding?: LiveTaskBoundRuntimeBinding;
+  readonly runtimeBinding?: TaskBoundRuntimeBinding;
   readonly documents: readonly (DocumentState | null)[];
   readonly claims: readonly (Uint8Array | null)[];
   readonly resolvedTaskIds?: readonly (string | null)[];

--- a/packages/kernel/src/domain/entity-event.ts
+++ b/packages/kernel/src/domain/entity-event.ts
@@ -75,12 +75,6 @@ export function compileEntityUpsert(input: {
   readonly occurredAt: string;
 }): EntityUpsertBundle {
   const contract = requireEntityStoreKindContract(input.entityKind);
-  if (contract.authoring.kind !== "generic-entity-store") {
-    const message =
-      `Entity kind ${contract.kind} must be authored via lifecycle/runtime events, ` +
-      `not generic upsert (${contract.authoring.contractRef}).`;
-    throw new Error(message);
-  }
   const entity = parseEntityJsonSchema(contract.schema, input.entity, `${input.entityKind} declaration`),
     entityId = isRecord(entity) ? entity[contract.id.field] : undefined;
   const contractErrors = contract.entityStore.validate?.(entity) ?? [];
@@ -135,7 +129,9 @@ function validateEntityEventFields(value: unknown, allowUnknownFields: boolean):
       "occurredAt",
       "payload",
     ]) ||
-    !isEntityEventEnvelope(value.schema, value.type) ||
+    (!allowUnknownFields
+      ? value.schema !== "entity-event/v1" || value.type !== "entity_upserted"
+      : !isEntityEventEnvelope(value.schema, value.type)) ||
     !isRecord(value.payload) ||
     !hasFields(value.payload, ["entityKind", "entityId", "declarationDocumentClaim"])
   )

--- a/packages/kernel/src/domain/entity-json-schema.ts
+++ b/packages/kernel/src/domain/entity-json-schema.ts
@@ -25,8 +25,6 @@ export type EntityJsonSchemaNode = (
   | EntityJsonObjectSchema
 ) & { readonly "x-error"?: string; readonly "x-nullable"?: boolean };
 
-export const ENTITY_ID_PATTERN = "^[a-z0-9][a-z0-9-]{0,63}$";
-
 export interface EntityJsonObjectSchema {
   readonly type: "object";
   readonly properties: Readonly<Record<string, EntityJsonSchemaNode>>;
@@ -180,3 +178,4 @@ function stableJson(value: unknown): string {
   );
 }
 import { isRecord } from "./write-chain.contract.ts";
+export { ENTITY_ID_PATTERN } from "./entity-ref.ts";

--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -8,16 +8,16 @@ import { decisionEventTypes, decisionStates, policyStates } from "./decision-eve
 import { CONTRACT_VERSION_1_0, type ContractVersion } from "./contract-version.ts";
 import { DEFAULT_POLICY } from "./default-policy.ts";
 import {
-  ENTITY_ID_PATTERN,
   explainEntityJsonSchema,
   type EntityDocumentJsonSchema,
   type EntityJsonObjectSchema,
   type EntityJsonSchemaNode,
 } from "./entity-json-schema.ts";
+import { deriveEntityKindIdentity } from "./entity-ref.ts";
 import type { RelationDirection, RelationType } from "./entity-relation.ts";
 import { executionStates } from "./execution.ts";
 import { domainStatuses } from "./lifecycle-status.ts";
-import { policyPredicateNames, POLICY_DECLARATION_V1_SCHEMA, validatePolicyDeclarationV1 } from "./policy.ts";
+import { policyPredicateNames, POLICY_DECLARATION_V1_SCHEMA } from "./policy.ts";
 import type { PolicyActionRule, PolicyPredicateName } from "./policy.ts";
 import { canonicalRelationDirections } from "./relation-direction.ts";
 import { reviewVerdicts } from "./review.ts";
@@ -88,11 +88,11 @@ export interface EntityKindContract<T = unknown> {
   readonly authoring: {
     readonly kind: "generic-entity-store" | "task-lifecycle" | "fact-event" | "decision-event" | "agent-runtime-event";
     readonly contractRef: string;
-  };
+  } | null;
   readonly sdkExposure: EntitySdkExposure;
   readonly framework?: {
     readonly schemaId: string;
-    readonly mutabilityContractRef: string;
+    readonly mutabilityContract: "entityFieldContracts";
     readonly anchors: EntityAnchorDeclaration;
     readonly dispositionMatrix: EntityDispositionMatrix;
     readonly storageForm: EntityStorageForm;
@@ -145,10 +145,6 @@ export interface EntityKindExplanation {
   } | null;
 }
 
-const declarationId = Object.freeze({
-  field: "id",
-  pattern: ENTITY_ID_PATTERN,
-});
 const declarationDocument = (pathTemplate: string) =>
   Object.freeze({ pathTemplate, mediaType: "application/json" as const, policyId: ENTITY_DOCUMENT_POLICY_ID });
 const noSdkExposure: EntitySdkExposure = Object.freeze({ sdk: null, agentCapability: null });
@@ -159,23 +155,23 @@ const capabilityExposure = (target: string, schemaId: string): EntitySdkExposure
   });
 const entityAction = (
   kind: string,
-  refTemplate: string,
+  identity: EntityKindContract["id"],
   id: string,
   sdkExposure: EntitySdkExposure = noSdkExposure,
 ): EntityActionContract =>
   Object.freeze({
     id,
     version: CONTRACT_VERSION_1_0,
-    target: Object.freeze({ kind, refTemplate }),
+    target: Object.freeze({ kind, refTemplate: identity.refTemplate }),
     sdkExposure,
   });
 const actionCatalog = (
   ref: string,
   kind: string,
-  refTemplate: string,
+  identity: EntityKindContract["id"],
   ids: readonly string[],
   sdkExposure: EntitySdkExposure = noSdkExposure,
-) => Object.freeze({ ref, actions: Object.freeze(ids.map((id) => entityAction(kind, refTemplate, id, sdkExposure))) });
+) => Object.freeze({ ref, actions: Object.freeze(ids.map((id) => entityAction(kind, identity, id, sdkExposure))) });
 const genericAuthoring = Object.freeze({ kind: "generic-entity-store" as const, contractRef: "entity-event/v1" });
 const genericEntityStore = (pathTemplate: string, validate?: (value: unknown) => readonly string[]) =>
   Object.freeze({ document: declarationDocument(pathTemplate), ...(validate ? { validate } : {}) });
@@ -184,9 +180,18 @@ const taskExposure = capabilityExposure("task", "task-frontmatter");
 const factExposure = capabilityExposure("fact", "fact-event");
 const decisionExposure = capabilityExposure("decision", "decision-package");
 
-const executionIdPattern = "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$";
-const reviewIdPattern = "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$";
-const lifecycleTaskIdPattern = "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$";
+const taskIdentity = deriveEntityKindIdentity("task");
+const factIdentity = deriveEntityKindIdentity("fact");
+const decisionIdentity = deriveEntityKindIdentity("decision");
+const agentIdentity = deriveEntityKindIdentity("agent");
+const squadIdentity = deriveEntityKindIdentity("squad");
+const policyIdentity = deriveEntityKindIdentity("policy");
+const executionIdentity = deriveEntityKindIdentity("execution");
+const reviewIdentity = deriveEntityKindIdentity("review");
+const runtimeSessionIdentity = deriveEntityKindIdentity("runtime-session");
+const executionIdPattern = executionIdentity.pattern;
+const reviewIdPattern = reviewIdentity.pattern;
+const lifecycleTaskIdPattern = taskIdentity.pattern;
 const opaqueObject = (): EntityJsonObjectSchema => ({
   type: "object",
   properties: {},
@@ -243,8 +248,8 @@ const factSchema = explainableSchema("fact-event", factEventJsonSchema);
 const decisionSchema = explainableSchema("decision-package", decisionPackageJsonSchema);
 
 const decisionFramework = Object.freeze({
-  schemaId: "DecisionEventSchema",
-  mutabilityContractRef: "decisionFieldContracts",
+  schemaId: "decision-package",
+  mutabilityContract: "entityFieldContracts" as const,
   anchors: {
     entityRef: "decision/{decisionId}",
     anchors: [
@@ -264,8 +269,8 @@ const decisionFramework = Object.freeze({
   storageForm: "lifecycle" as const,
 });
 const taskFramework = Object.freeze({
-  schemaId: "TaskFrontmatterSchema",
-  mutabilityContractRef: "taskFieldContracts",
+  schemaId: "task-frontmatter",
+  mutabilityContract: "entityFieldContracts" as const,
   anchors: { entityRef: "task/{task_id}", anchors: [] },
   dispositionMatrix: dispositionMatrix([
     unsupported("D1", "supersede", "replay/v1 does not expose authored task package disposition writes"),
@@ -278,8 +283,8 @@ const taskFramework = Object.freeze({
   storageForm: "lifecycle" as const,
 });
 const factFramework = Object.freeze({
-  schemaId: "FactEventSchema",
-  mutabilityContractRef: "factFieldContracts",
+  schemaId: "fact-event",
+  mutabilityContract: "entityFieldContracts" as const,
   anchors: { entityRef: "fact/{task_id}/{fact_id}", anchors: [] },
   dispositionMatrix: dispositionMatrix([
     supported("D1", "invalidate", ["fact_recorded"], "fact invalidation is a superseding append-only Fact event"),
@@ -388,14 +393,14 @@ export const entityKindContracts = Object.freeze([
   {
     kind: "task",
     schema: taskSchema,
-    id: { field: "task_id", pattern: lifecycleTaskIdPattern, refTemplate: "task/{id}" },
+    id: taskIdentity,
     relations: relationsFor("task"),
     canonicalProjection: null,
     statusVocabulary: [{ field: "lifecycle.status", words: domainStatuses }],
     actionCatalog: actionCatalog(
       "kernel/task-lifecycle/v1",
       "task",
-      "task/{id}",
+      taskIdentity,
       TASK_LIFECYCLE_TRANSITIONS.map(({ id }) => id),
       taskExposure,
     ),
@@ -407,11 +412,11 @@ export const entityKindContracts = Object.freeze([
   {
     kind: "fact",
     schema: factSchema,
-    id: { field: "factId", pattern: "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$", refTemplate: "fact/{id}" },
+    id: factIdentity,
     relations: relationsFor("fact"),
     canonicalProjection: null,
     statusVocabulary: [{ field: "state", words: ["standing", "superseded_fact"] }],
-    actionCatalog: actionCatalog("kernel/fact-event/v1", "fact", "fact/{id}", ["record"], factExposure),
+    actionCatalog: actionCatalog("kernel/fact-event/v1", "fact", factIdentity, ["record"], factExposure),
     entityStore: null,
     authoring: { kind: "fact-event", contractRef: "fact-event/v1" },
     sdkExposure: factExposure,
@@ -420,14 +425,14 @@ export const entityKindContracts = Object.freeze([
   {
     kind: "decision",
     schema: decisionSchema,
-    id: { field: "decisionId", pattern: "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$", refTemplate: "decision/{id}" },
+    id: decisionIdentity,
     relations: relationsFor("decision"),
     canonicalProjection: null,
     statusVocabulary: [{ field: "state", words: decisionStates }],
     actionCatalog: actionCatalog(
       "kernel/decision-event/v1",
       "decision",
-      "decision/{id}",
+      decisionIdentity,
       decisionActionIds,
       decisionExposure,
     ),
@@ -439,11 +444,11 @@ export const entityKindContracts = Object.freeze([
   {
     kind: "agent",
     schema: AGENT_DECLARATION_V1_SCHEMA,
-    id: { ...declarationId, refTemplate: "agent/{id}" },
+    id: agentIdentity,
     relations: { directions: [], edges: [] },
     canonicalProjection: { embeddedEvents: [], row: { idField: "id", ownerField: null } },
     statusVocabulary: [{ field: "state", words: agentStates }],
-    actionCatalog: actionCatalog("kernel/agent-declaration/v1", "agent", "agent/{id}", [
+    actionCatalog: actionCatalog("kernel/agent-declaration/v1", "agent", agentIdentity, [
       "configure",
       "activate",
       "retire",
@@ -455,7 +460,7 @@ export const entityKindContracts = Object.freeze([
   {
     kind: "squad",
     schema: SQUAD_DECLARATION_V1_SCHEMA,
-    id: { ...declarationId, refTemplate: "squad/{id}" },
+    id: squadIdentity,
     relations: { directions: [], edges: [] },
     canonicalProjection: { embeddedEvents: [], row: { idField: "id", ownerField: null } },
     actionCatalog: null,
@@ -466,13 +471,13 @@ export const entityKindContracts = Object.freeze([
   {
     kind: "policy",
     schema: POLICY_DECLARATION_V1_SCHEMA,
-    id: { ...declarationId, refTemplate: "policy/{id}" },
+    id: policyIdentity,
     relations: { directions: [], edges: [] },
     canonicalProjection: null,
     statusVocabulary: [{ field: "state", words: policyStates }],
-    actionCatalog: actionCatalog("kernel/policy/v1", "policy", "policy/{id}", ["draft", "activate", "retire"]),
-    entityStore: genericEntityStore("policies/{id}.json", validatePolicyDeclarationV1),
-    authoring: genericAuthoring,
+    actionCatalog: actionCatalog("kernel/policy/v1", "policy", policyIdentity, ["draft", "activate", "retire"]),
+    entityStore: null,
+    authoring: null,
     sdkExposure: noSdkExposure,
     policy: {
       predicates: policyPredicateNames,
@@ -483,7 +488,7 @@ export const entityKindContracts = Object.freeze([
   {
     kind: "execution",
     schema: executionSchema,
-    id: { field: "executionId", pattern: executionIdPattern, refTemplate: "execution/{id}" },
+    id: executionIdentity,
     relations: {
       directions: ["directed"],
       edges: [
@@ -492,8 +497,8 @@ export const entityKindContracts = Object.freeze([
           sourceKind: "execution",
           targetKind: "task",
           projection: {
-            source: { field: "executionId", refTemplate: "execution/{id}" },
-            target: { field: "taskId", refTemplate: "task/{id}" },
+            source: { field: "executionId", refTemplate: executionIdentity.refTemplate },
+            target: { field: "taskId", refTemplate: taskIdentity.refTemplate },
             direction: "directed",
             strength: "strong",
             origin: "generated",
@@ -525,21 +530,21 @@ export const entityKindContracts = Object.freeze([
       row: { idField: "executionId", ownerField: "taskId" },
     },
     statusVocabulary: [{ field: "state", words: executionStates }],
-    actionCatalog: actionCatalog("kernel/task-lifecycle/v1", "execution", "execution/{id}", [
+    actionCatalog: actionCatalog("kernel/task-lifecycle/v1", "execution", executionIdentity, [
       "start",
       "renew",
       "submit",
       "complete",
       "release",
     ]),
-    entityStore: genericEntityStore("executions/{id}.json"),
+    entityStore: null,
     authoring: { kind: "task-lifecycle", contractRef: "task-event/v1" },
     sdkExposure: noSdkExposure,
   },
   {
     kind: "review",
     schema: reviewSchema,
-    id: { field: "reviewId", pattern: reviewIdPattern, refTemplate: "review/{id}" },
+    id: reviewIdentity,
     relations: {
       directions: ["directed"],
       edges: [
@@ -548,8 +553,8 @@ export const entityKindContracts = Object.freeze([
           sourceKind: "review",
           targetKind: "execution",
           projection: {
-            source: { field: "reviewId", refTemplate: "review/{id}" },
-            target: { field: "executionId", refTemplate: "execution/{id}" },
+            source: { field: "reviewId", refTemplate: reviewIdentity.refTemplate },
+            target: { field: "executionId", refTemplate: executionIdentity.refTemplate },
             direction: "directed",
             strength: "strong",
             origin: "generated",
@@ -569,15 +574,15 @@ export const entityKindContracts = Object.freeze([
       row: { idField: "reviewId", ownerField: "taskId" },
     },
     statusVocabulary: [{ field: "verdict", words: reviewVerdicts }],
-    actionCatalog: actionCatalog("kernel/task-lifecycle/v1", "review", "review/{id}", ["record"]),
-    entityStore: genericEntityStore("reviews/{id}.json"),
+    actionCatalog: actionCatalog("kernel/task-lifecycle/v1", "review", reviewIdentity, ["record"]),
+    entityStore: null,
     authoring: { kind: "task-lifecycle", contractRef: "task-event/v1" },
     sdkExposure: noSdkExposure,
   },
   {
     kind: "runtime-session",
     schema: runtimeSessionEntityV1Schema,
-    id: { field: "runtimeSessionId", pattern: "^runtime_[a-z0-9]+$", refTemplate: "runtime-session/{id}" },
+    id: runtimeSessionIdentity,
     relations: {
       directions: ["directed"],
       edges: [{ type: "executes", sourceKind: "runtime-session", targetKind: "task" }],
@@ -594,10 +599,10 @@ export const entityKindContracts = Object.freeze([
     actionCatalog: actionCatalog(
       "kernel/agent-runtime-event/v1",
       "runtime-session",
-      "runtime-session/{id}",
+      runtimeSessionIdentity,
       agentRuntimeEventTypes.filter((type) => type.startsWith("runtime_session_")),
     ),
-    entityStore: genericEntityStore("runtime-sessions/{id}.json"),
+    entityStore: null,
     authoring: { kind: "agent-runtime-event", contractRef: "agent-runtime-event/v1" },
     sdkExposure: noSdkExposure,
   },
@@ -620,12 +625,13 @@ export function requireEntityKindContract(kind: string): EntityKindContract {
 
 export type EntityStoreKindContract = EntityKindContract & {
   readonly entityStore: NonNullable<EntityKindContract["entityStore"]>;
+  readonly authoring: { readonly kind: "generic-entity-store"; readonly contractRef: string };
 };
 
 export function requireEntityStoreKindContract(kind: string): EntityStoreKindContract {
   const contract = requireEntityKindContract(kind);
-  if (contract.entityStore === null)
-    throw Object.assign(new Error(`Entity kind ${kind} is authored through ${contract.authoring.contractRef}.`), {
+  if (contract.entityStore === null || contract.authoring?.kind !== "generic-entity-store")
+    throw Object.assign(new Error(`Entity kind ${kind} has no generic entity-store surface.`), {
       code: "entity_kind_has_dedicated_authoring",
     });
   return contract as EntityStoreKindContract;

--- a/packages/kernel/src/domain/entity-ref.ts
+++ b/packages/kernel/src/domain/entity-ref.ts
@@ -1,13 +1,61 @@
-export type EntityRefKind =
-  | "task"
-  | "decision"
-  | "fact"
-  | "execution"
-  | "review"
-  | "agent"
-  | "runtime-session"
-  | "policy"
-  | "relation";
+export const ENTITY_ID_PATTERN = "^[a-z0-9][a-z0-9-]{0,63}$";
+
+export interface EntityKindRefAuthority {
+  readonly kind: string;
+  readonly field: string;
+  readonly pattern: string;
+  readonly refTemplate: string;
+  readonly refPattern?: string;
+  readonly anchorPattern?: string;
+}
+
+export const entityKindRefAuthorities = Object.freeze([
+  {
+    kind: "task",
+    field: "task_id",
+    pattern: "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$",
+    refTemplate: "task/{id}",
+    refPattern: "^(?:task_[A-Za-z0-9_-]+|[A-Za-z0-9][A-Za-z0-9_-]*-[A-Za-z0-9_-]+)$",
+  },
+  {
+    kind: "fact",
+    field: "factId",
+    pattern: "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$",
+    refTemplate: "fact/{task}/{id}",
+    refPattern: "^F-[A-Za-z0-9][A-Za-z0-9_-]{0,127}$",
+  },
+  {
+    kind: "decision",
+    field: "decisionId",
+    pattern: "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$",
+    refTemplate: "decision/{id}",
+    refPattern: "^(?:dec_[A-Za-z0-9_-]+|[A-Za-z0-9][A-Za-z0-9_-]*-[A-Za-z0-9_-]+)$",
+    anchorPattern: "^[A-Za-z0-9][A-Za-z0-9_-]*$",
+  },
+  { kind: "agent", field: "id", pattern: ENTITY_ID_PATTERN, refTemplate: "agent/{id}" },
+  { kind: "squad", field: "id", pattern: ENTITY_ID_PATTERN, refTemplate: "squad/{id}" },
+  { kind: "policy", field: "id", pattern: ENTITY_ID_PATTERN, refTemplate: "policy/{id}" },
+  {
+    kind: "execution",
+    field: "executionId",
+    pattern: "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$",
+    refTemplate: "execution/{id}",
+  },
+  {
+    kind: "review",
+    field: "reviewId",
+    pattern: "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$",
+    refTemplate: "review/{id}",
+  },
+  {
+    kind: "runtime-session",
+    field: "runtimeSessionId",
+    pattern: "^runtime_[a-z0-9]+$",
+    refTemplate: "runtime-session/{id}",
+  },
+] as const satisfies readonly EntityKindRefAuthority[]);
+
+export type EntityRefKind = (typeof entityKindRefAuthorities)[number]["kind"] | "relation";
 
 export interface ParsedEntityRef {
   readonly raw: string;
@@ -15,128 +63,98 @@ export interface ParsedEntityRef {
   readonly id: string;
   readonly anchor?: string;
   readonly ownerTaskId?: string;
+  readonly ownerExecutionId?: string;
   readonly harnessAlias?: string;
   readonly externalHarness: boolean;
 }
 export type EntityRef = ParsedEntityRef["raw"];
 
 const entityRefPrefixPattern = /^(?:(?<alias>[A-Za-z][A-Za-z0-9_-]*):)?(?<body>.+)$/u;
-const taskOrDecisionRefPattern = /^(?<kind>task|decision)\/(?<id>[A-Za-z0-9_-]+)(?:\/(?<anchor>[A-Za-z0-9_-]+))?$/u;
-const executionRefPattern = /^execution\/(?<ownerTaskId>[A-Za-z0-9_-]+)\/(?<executionId>[A-Za-z0-9_-]+)$/u;
-const reviewRefPattern = /^review\/(?<ownerExecutionId>[A-Za-z0-9_-]+)\/(?<reviewId>[A-Za-z0-9_-]+)$/u;
-const phaseOneEntityRefPattern = /^(?<kind>execution|review|agent|runtime-session|policy)\/(?<id>[A-Za-z0-9_-]+)$/u;
-const factRefPattern = /^fact\/(?<ownerTaskId>[A-Za-z0-9_-]+)\/(?<factId>[A-Za-z0-9_-]+)$/u;
-const relationRefPattern = /^relation\/(?<relationId>rel_[a-f0-9]{16})$/u;
+const relationRefPattern = /^relation\/(?<id>rel_[a-f0-9]{16})$/u;
+const templateTokenPattern = /^\{(?<kind>[a-z-]+)\}$/u;
+const kindRefPatterns = entityKindRefAuthorities.map((contract) => ({
+  contract,
+  parse: new RegExp(`^${compileRefBodyPattern(contract, true)}$`, "u"),
+}));
 const entityRefSearchPattern = new RegExp(
-  String.raw`(?<![A-Za-z0-9_/-])(?:[A-Za-z][A-Za-z0-9_-]*:)?(?:fact\/[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+|` +
-    String.raw`relation\/rel_[a-f0-9]{16}|(?:execution|review)\/[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+|` +
-    String.raw`(?:task|decision)\/[A-Za-z0-9_-]+(?:\/[A-Za-z0-9_-]+)?|` +
-    String.raw`(?:execution|review|agent|runtime-session|policy)\/[A-Za-z0-9_-]+)\b(?!\/)`,
+  String.raw`(?<![A-Za-z0-9_/-])(?:[A-Za-z][A-Za-z0-9_-]*:)?(?:relation\/rel_[a-f0-9]{16}|${entityKindRefAuthorities
+    .map((contract) => compileRefBodyPattern(contract, false))
+    .join("|")})\b(?!\/)`,
   "gu",
 );
 
-function isPlausibleTaskRefId(id: string): boolean {
-  return id.startsWith("task_") || id.includes("-");
-}
-
-function isPlausibleDecisionRefId(id: string): boolean {
-  return id.startsWith("dec_") || id.includes("-");
-}
-
-function isPlausibleFactRefId(id: string): boolean {
-  return id.startsWith("F-");
-}
-
-function isPlausibleRelationRefId(id: string): boolean {
-  return /^rel_[a-f0-9]{16}$/u.test(id);
-}
-
 export function parseEntityRef(value: string): ParsedEntityRef | null {
-  const prefix = value.match(entityRefPrefixPattern);
-  const body = prefix?.groups?.body;
+  const prefix = value.match(entityRefPrefixPattern),
+    body = prefix?.groups?.body;
   if (!body) return null;
-  const harnessAlias = prefix.groups?.alias;
-
-  const fact = body.match(factRefPattern);
-  if (fact?.groups?.ownerTaskId && fact.groups.factId) {
-    if (!isPlausibleTaskRefId(fact.groups.ownerTaskId) || !isPlausibleFactRefId(fact.groups.factId)) return null;
-    return {
-      raw: value,
-      kind: "fact",
-      id: fact.groups.factId,
-      ownerTaskId: fact.groups.ownerTaskId,
-      ...(harnessAlias ? { harnessAlias } : {}),
-      externalHarness: Boolean(harnessAlias),
-    };
-  }
-
-  const relation = body.match(relationRefPattern);
-  if (relation?.groups?.relationId) {
-    if (!isPlausibleRelationRefId(relation.groups.relationId)) return null;
+  const harnessAlias = prefix.groups?.alias,
+    relation = body.match(relationRefPattern);
+  if (relation?.groups?.id)
     return {
       raw: value,
       kind: "relation",
-      id: relation.groups.relationId,
+      id: relation.groups.id,
       ...(harnessAlias ? { harnessAlias } : {}),
       externalHarness: Boolean(harnessAlias),
     };
-  }
 
-  const execution = body.match(executionRefPattern);
-  if (execution?.groups?.ownerTaskId && execution.groups.executionId) {
-    if (!isPlausibleTaskRefId(execution.groups.ownerTaskId)) return null;
+  for (const { contract, parse } of kindRefPatterns) {
+    const match = body.match(parse),
+      id = match?.groups?.id;
+    if (!id) continue;
     return {
       raw: value,
-      kind: "execution",
-      id: execution.groups.executionId,
-      ownerTaskId: execution.groups.ownerTaskId,
+      kind: contract.kind as Exclude<EntityRefKind, "relation">,
+      id,
+      ...(match.groups?.anchor ? { anchor: match.groups.anchor } : {}),
+      ...(match.groups?.task ? { ownerTaskId: match.groups.task } : {}),
+      ...(match.groups?.execution ? { ownerExecutionId: match.groups.execution } : {}),
       ...(harnessAlias ? { harnessAlias } : {}),
       externalHarness: Boolean(harnessAlias),
     };
   }
-
-  const review = body.match(reviewRefPattern);
-  if (review?.groups?.ownerExecutionId && review.groups.reviewId) {
-    return {
-      raw: value,
-      kind: "review",
-      id: review.groups.reviewId,
-      ownerTaskId: review.groups.ownerExecutionId,
-      ...(harnessAlias ? { harnessAlias } : {}),
-      externalHarness: Boolean(harnessAlias),
-    };
-  }
-
-  const phaseOneEntity = body.match(phaseOneEntityRefPattern);
-  if (phaseOneEntity?.groups?.kind && phaseOneEntity.groups.id) {
-    return {
-      raw: value,
-      kind: phaseOneEntity.groups.kind as Exclude<EntityRefKind, "task" | "decision" | "fact" | "relation">,
-      id: phaseOneEntity.groups.id,
-      ...(harnessAlias ? { harnessAlias } : {}),
-      externalHarness: Boolean(harnessAlias),
-    };
-  }
-
-  const entity = body.match(taskOrDecisionRefPattern);
-  const kind = entity?.groups?.kind;
-  const id = entity?.groups?.id;
-  if ((kind !== "task" && kind !== "decision") || !id) return null;
-  if (kind === "task" && !isPlausibleTaskRefId(id)) return null;
-  if (kind === "decision" && !isPlausibleDecisionRefId(id)) return null;
-  const anchor = entity.groups?.anchor;
-  return {
-    raw: value,
-    kind,
-    id,
-    ...(anchor ? { anchor } : {}),
-    ...(harnessAlias ? { harnessAlias } : {}),
-    externalHarness: Boolean(harnessAlias),
-  };
+  return null;
 }
 
 export function findEntityRefs(body: string): ReadonlyArray<ParsedEntityRef> {
   return [...body.matchAll(entityRefSearchPattern)]
     .map((match) => parseEntityRef(match[0]))
     .filter((ref): ref is ParsedEntityRef => ref !== null);
+}
+
+export function requireEntityKindRefAuthority(kind: string): EntityKindRefAuthority {
+  const authority = entityKindRefAuthorities.find((candidate) => candidate.kind === kind);
+  if (!authority) throw new Error(`Entity kind ${kind} has no ref authority.`);
+  return authority;
+}
+
+export function deriveEntityKindIdentity(
+  kind: string,
+): Pick<EntityKindRefAuthority, "field" | "pattern" | "refTemplate"> {
+  const { field, pattern, refTemplate } = requireEntityKindRefAuthority(kind);
+  return Object.freeze({ field, pattern, refTemplate });
+}
+
+function compileRefBodyPattern(contract: EntityKindRefAuthority, capture: boolean): string {
+  const segments = contract.refTemplate.split("/").map((segment) => {
+    const token = segment.match(templateTokenPattern)?.groups?.kind;
+    if (!token) return escapeRegExp(segment);
+    const source: EntityKindRefAuthority | undefined =
+      token === "id" ? contract : entityKindRefAuthorities.find(({ kind }) => kind === token);
+    if (!source) throw new Error(`Entity ref template ${contract.refTemplate} names unknown kind ${token}.`);
+    const pattern = unanchored(source.refPattern ?? source.pattern);
+    return capture ? `(?<${token}>${pattern})` : `(?:${pattern})`;
+  });
+  const anchor = contract.anchorPattern
+    ? `(?:/${capture ? `(?<anchor>${unanchored(contract.anchorPattern)})` : `(?:${unanchored(contract.anchorPattern)})`})?`
+    : "";
+  return `${segments.join("/")}${anchor}`;
+}
+
+function unanchored(pattern: string): string {
+  return pattern.replace(/^\^/u, "").replace(/\$$/u, "");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }

--- a/packages/kernel/src/domain/entity-ref.ts
+++ b/packages/kernel/src/domain/entity-ref.ts
@@ -145,9 +145,8 @@ function compileRefBodyPattern(contract: EntityKindRefAuthority, capture: boolea
     const pattern = unanchored(source.refPattern ?? source.pattern);
     return capture ? `(?<${token}>${pattern})` : `(?:${pattern})`;
   });
-  const anchor = contract.anchorPattern
-    ? `(?:/${capture ? `(?<anchor>${unanchored(contract.anchorPattern)})` : `(?:${unanchored(contract.anchorPattern)})`})?`
-    : "";
+  const anchorPattern = contract.anchorPattern ? unanchored(contract.anchorPattern) : "",
+    anchor = contract.anchorPattern ? `(?:/${capture ? `(?<anchor>${anchorPattern})` : `(?:${anchorPattern})`})?` : "";
   return `${segments.join("/")}${anchor}`;
 }
 

--- a/packages/kernel/src/domain/task-bound-runtime-authority.ts
+++ b/packages/kernel/src/domain/task-bound-runtime-authority.ts
@@ -4,7 +4,7 @@ import { isSamePerson } from "./actor-domain-services.ts";
 import type { LeaseV1 } from "./execution.ts";
 import type { ActorIdentity, WriteSource } from "./write-chain.contract.ts";
 
-export interface LiveTaskBoundRuntimeBinding {
+export interface TaskBoundRuntimeBinding {
   readonly runtimeSessionId: string;
   readonly taskId: string;
   readonly executionId: string;
@@ -28,11 +28,11 @@ export function runtimeSessionExecutesTask(
 }
 
 /** Resolves the canonical runtime-session handoff; callers pair it with the current execution lease. */
-export function resolveLiveTaskBoundRuntimeBinding(
+export function resolveTaskBoundRuntimeBinding(
   session: RuntimeSession | null,
   taskId: string,
   executionId: string,
-): LiveTaskBoundRuntimeBinding | null {
+): TaskBoundRuntimeBinding | null {
   if (!session?.taskBindings.some((binding) => binding.taskId === taskId && binding.executionId === executionId))
     return null;
   return { runtimeSessionId: session.runtimeSessionId, taskId, executionId };
@@ -42,7 +42,7 @@ export function isTaskBoundRuntimeWriter(
   lease: LeaseV1,
   actor: ActorIdentity,
   source: WriteSource,
-  binding: LiveTaskBoundRuntimeBinding,
+  binding: TaskBoundRuntimeBinding,
 ): boolean {
   return (
     lease.taskId === binding.taskId &&

--- a/packages/kernel/src/domain/task-progress-event.ts
+++ b/packages/kernel/src/domain/task-progress-event.ts
@@ -17,7 +17,7 @@ import {
 } from "./write-chain.contract.ts";
 import type { LeaseV1 } from "./execution.ts";
 import { isSameExecution } from "./actor-domain-services.ts";
-import { isTaskBoundRuntimeWriter, type LiveTaskBoundRuntimeBinding } from "./task-bound-runtime-authority.ts";
+import { isTaskBoundRuntimeWriter, type TaskBoundRuntimeBinding } from "./task-bound-runtime-authority.ts";
 import { isValidDocEventChange, type DocEventChange } from "./doc-sync.contract.ts";
 
 export const TASK_PROGRESS_POLICY_ID = "typed-machine-writer/v1" as const;
@@ -100,7 +100,7 @@ export function compileTaskProgress(input: {
   readonly currentDocument: ProgressDocumentState | null;
   readonly activeLease: LeaseV1 | null;
   readonly startRecoveryAvailable: boolean;
-  readonly runtimeBinding?: LiveTaskBoundRuntimeBinding;
+  readonly runtimeBinding?: TaskBoundRuntimeBinding;
   readonly actor: ActorIdentity;
   readonly source: WriteSource;
   readonly eventId: string;

--- a/packages/kernel/src/entity/registry.ts
+++ b/packages/kernel/src/entity/registry.ts
@@ -1,11 +1,8 @@
 import { getEntityKindContract } from "../domain/entity-kind-registry.ts";
-import { EntityRelationRecordSchema, FactEventSchema, TaskFrontmatterSchema } from "../schemas/registry.ts";
-import { DecisionEventSchema } from "../schemas/decision-event.ts";
+import { EntityRelationRecordSchema, schemaRegistry } from "../schemas/registry.ts";
 import {
-  decisionFieldContracts,
-  factFieldContracts,
+  entityFieldContracts,
   relationFieldContracts,
-  taskFieldContracts,
   type DecisionFieldKey,
   type FactFieldKey,
   type RelationFieldKey,
@@ -49,26 +46,23 @@ export type EntityRegistryShape = {
 
 function derivedFrameworkRegistration<FieldKey extends string>(
   kind: "decision" | "task" | "fact",
-  schema: unknown,
-  mutabilityContract: EntityRegistration<FieldKey>["mutabilityContract"],
 ): EntityRegistration<FieldKey> {
   const framework = getEntityKindContract(kind)?.framework;
   if (!framework) throw new Error(`Entity kind ${kind} has no framework registration contract.`);
+  const schema = schemaRegistry.find(({ id }) => id === framework.schemaId)?.schema;
+  if (!schema) throw new Error(`Entity kind ${kind} names unknown schema ${framework.schemaId}.`);
   return {
     kind,
     schema,
-    mutabilityContract,
+    mutabilityContract: entityFieldContracts[kind] as EntityRegistration<FieldKey>["mutabilityContract"],
     anchors: framework.anchors,
     dispositionMatrix: framework.dispositionMatrix,
     storageForm: framework.storageForm,
   };
 }
 
-/** Compatibility projection. task/fact/decision metadata is derived from entityKindContracts. */
-export const entityRegistry = {
-  decision: derivedFrameworkRegistration("decision", DecisionEventSchema, decisionFieldContracts),
-  task: derivedFrameworkRegistration("task", TaskFrontmatterSchema, taskFieldContracts),
-  fact: derivedFrameworkRegistration("fact", FactEventSchema, factFieldContracts),
+/** relation/session are framework-only hosted boundaries, not members of the nine-kind authoring authority. */
+const frameworkBoundaryRegistrations = {
   relation: {
     kind: "relation",
     schema: EntityRelationRecordSchema,
@@ -90,6 +84,14 @@ export const entityRegistry = {
     storageForm: "host_frontmatter",
   },
   session: sessionEntityRegistration,
+} as const;
+
+/** Compatibility projection. Nine-kind members derive schema, mutability, and metadata from kind authority. */
+export const entityRegistry = {
+  decision: derivedFrameworkRegistration<DecisionFieldKey>("decision"),
+  task: derivedFrameworkRegistration<TaskFieldKey>("task"),
+  fact: derivedFrameworkRegistration<FactFieldKey>("fact"),
+  ...frameworkBoundaryRegistrations,
 } satisfies EntityRegistryShape;
 
 export const entityRegistryKinds = Object.keys(entityRegistry) as ReadonlyArray<KernelEntityKind>;

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -34,10 +34,7 @@ export {
   validateTaskLifecycleCommandEnvelope,
 } from "./domain/task-lifecycle.contract.ts";
 export { isSameExecution, isSamePerson } from "./domain/actor-domain-services.ts";
-export {
-  resolveLiveTaskBoundRuntimeBinding,
-  runtimeSessionIdFromActor,
-} from "./domain/task-bound-runtime-authority.ts";
+export { resolveTaskBoundRuntimeBinding, runtimeSessionIdFromActor } from "./domain/task-bound-runtime-authority.ts";
 export {
   compileTaskLifecycleWrite,
   lifecycleDocumentFetchPaths,

--- a/packages/kernel/src/layout/entity-root-resolver.ts
+++ b/packages/kernel/src/layout/entity-root-resolver.ts
@@ -50,6 +50,7 @@ export function resolveEntityRootForLayout(
     case "execution":
     case "review":
     case "agent":
+    case "squad":
     case "runtime-session":
     case "policy":
       throw new Error(`Phase 1 relation endpoint has no authored layout root: ${entityRef.raw}`);

--- a/packages/kernel/src/ports/authorization-port.ts
+++ b/packages/kernel/src/ports/authorization-port.ts
@@ -10,7 +10,7 @@ import {
   type PolicyPredicateExpression,
 } from "../domain/policy.ts";
 import type { AuthorizationDecision, ReceiptJsonValue } from "../domain/receipt-frame.ts";
-import { runtimeSessionIdFromActor, type LiveTaskBoundRuntimeBinding } from "../domain/task-bound-runtime-authority.ts";
+import { runtimeSessionIdFromActor, type TaskBoundRuntimeBinding } from "../domain/task-bound-runtime-authority.ts";
 import { sameWriteSource, type WriteSource } from "../domain/write-chain.contract.ts";
 
 export interface AuthorizationTargetSnapshot {
@@ -19,7 +19,7 @@ export interface AuthorizationTargetSnapshot {
   readonly canonicalExecutionExists?: boolean;
   readonly executionActor?: ActorIdentity | null;
   readonly proposalActor?: ActorIdentity | null;
-  readonly runtimeBinding?: LiveTaskBoundRuntimeBinding | null;
+  readonly runtimeBinding?: TaskBoundRuntimeBinding | null;
 }
 
 /** Volatile bindings are inputs to evaluation, not fields added to ActionEnvelope. */

--- a/packages/kernel/src/projection/rebuildable-task-projection-migration.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-migration.ts
@@ -2,7 +2,7 @@
 import { DatabaseSync } from "node:sqlite";
 import { emptyTaskLifecycleSnapshot } from "../domain/task-lifecycle.contract.ts";
 import { docByteLength, type DocumentState } from "../domain/doc-sync.contract.ts";
-import { requireEntityStoreKindContract } from "../domain/entity-kind-registry.ts";
+import { requireEntityKindContract } from "../domain/entity-kind-registry.ts";
 import { type MigrationDocumentClaim, type MigrationImportEventV1 } from "../domain/migration-import-event.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
 import { refreshDecisionDocumentSearch } from "./decision-event-projection.ts";
@@ -208,7 +208,7 @@ export function projectMigration(
       event.occurredAt,
     );
     refreshTaskRelationProjection(db, value.taskId, next.task, event.workspaceRevision, event.occurredAt);
-    const contract = requireEntityStoreKindContract(entity.kind);
+    const contract = requireEntityKindContract(entity.kind);
     projectInterpretedEntityValue(
       db,
       contract,

--- a/packages/kernel/src/projection/rebuildable-task-projection-write-model.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-write-model.ts
@@ -2,10 +2,7 @@
 import { DatabaseSync } from "node:sqlite";
 import { docByteLength, verifyDocEventChange, type DocumentState } from "../domain/doc-sync.contract.ts";
 import { type TaskProgressEventV1 } from "../domain/task-progress-event.ts";
-import {
-  isTaskBoundRuntimeWriter,
-  resolveLiveTaskBoundRuntimeBinding,
-} from "../domain/task-bound-runtime-authority.ts";
+import { isTaskBoundRuntimeWriter, resolveTaskBoundRuntimeBinding } from "../domain/task-bound-runtime-authority.ts";
 import { type DecisionEventV1 } from "../domain/decision-event.ts";
 import { type FactEventV1 } from "../domain/fact-event.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
@@ -45,7 +42,7 @@ export function projectProgress(
     runtimeSessionIdValue = event.payload.runtimeSessionId,
     runtime = runtimeSessionIdValue ? readRuntimeSession(db, runtimeSessionIdValue) : null;
   const runtimeBinding =
-      runtime === null ? null : resolveLiveTaskBoundRuntimeBinding(runtime, taskId, event.payload.executionId),
+      runtime === null ? null : resolveTaskBoundRuntimeBinding(runtime, taskId, event.payload.executionId),
     directHolder =
       lease !== null &&
       runtimeSessionIdValue === undefined &&

--- a/packages/kernel/src/store/entity-store.ts
+++ b/packages/kernel/src/store/entity-store.ts
@@ -5,12 +5,8 @@ import {
   type EntityUpsertBundle,
   type StoredEntityEventV1,
 } from "../domain/entity-event.ts";
-import {
-  interpretEmbeddedEntityProjections,
-  interpretEntityValue,
-  type InterpretedEntityProjection,
-} from "../domain/entity-kind-projection.ts";
-import { entityDocumentPath, requireEntityStoreKindContract } from "../domain/entity-kind-registry.ts";
+import { interpretEntityValue } from "../domain/entity-kind-projection.ts";
+import { requireEntityStoreKindContract } from "../domain/entity-kind-registry.ts";
 import { sha256Text } from "../integrity/stable-hash.ts";
 import { resolveLedgerGitLayout } from "./ledger-git-layout.ts";
 import { publicationRefs } from "./task-event-store-git-refs.ts";
@@ -37,15 +33,9 @@ export function createEntityStore(source: EntityEventSource): EntityStore {
   const records = (kind: string): readonly StoredEntity[] => {
     const contract = requireEntityStoreKindContract(kind),
       latest = new Map<string, ReturnType<typeof entityEventRecord>>();
-    const keepLatest = (record: StoredEntity): void => {
-      const current = latest.get(record.id);
-      if (current === undefined || current.workspaceRevision <= record.workspaceRevision) latest.set(record.id, record);
-    };
     for (const event of source.read().events) {
       if (isEntityEvent(event) && event.payload.entityKind === contract.kind)
-        keepLatest(entityEventRecord(event, source, contract));
-      for (const projection of interpretEmbeddedEntityProjections(contract, event))
-        keepLatest(embeddedEventRecord(projection, contract));
+        latest.set(event.payload.entityId, entityEventRecord(event, source, contract));
     }
     return [...latest.values()].sort((left, right) => left.id.localeCompare(right.id));
   };
@@ -54,19 +44,6 @@ export function createEntityStore(source: EntityEventSource): EntityStore {
     get: <T>(kind: string, id: string) =>
       (records(kind).find((record) => record.id === id) as StoredEntity<T> | undefined) ?? null,
     list: <T>(kind: string) => records(kind) as readonly StoredEntity<T>[],
-  };
-}
-
-function embeddedEventRecord(
-  projection: InterpretedEntityProjection,
-  contract: ReturnType<typeof requireEntityStoreKindContract>,
-): StoredEntity {
-  return {
-    kind: contract.kind,
-    id: projection.id,
-    value: projection.value,
-    documentPath: entityDocumentPath(contract, projection.id),
-    workspaceRevision: projection.workspaceRevision,
   };
 }
 

--- a/packages/kernel/test/contracts/canonical-event-forward-compat.test.ts
+++ b/packages/kernel/test/contracts/canonical-event-forward-compat.test.ts
@@ -4,7 +4,11 @@ import { readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { REPLAY_TASK_GRAPH } from "../../src/domain/task-graph.ts";
-import { canonicalEventSchemas, parseCanonicalEvent, validateCurrentCanonicalEvent } from "../../src/domain/doc-sync.contract.ts";
+import {
+  canonicalEventSchemas,
+  parseCanonicalEvent,
+  validateCurrentCanonicalEvent,
+} from "../../src/domain/doc-sync.contract.ts";
 import { sameActorIdentity, sameWriteSource, serializeEventEnvelope } from "../../src/domain/write-chain.contract.ts";
 
 const actor = { principal: { personId: "person-fixture" }, executor: { kind: "agent" as const, id: "codex" } };
@@ -30,15 +34,15 @@ const taskCreated = {
       iteration: 0 as const,
       createdBy: actor,
       completionGateIds: ["ci"],
-      presetSnapshotDigest: null
-    }
-  }
+      presetSnapshotDigest: null,
+    },
+  },
 };
 
 test("Task/v1 readers ignore a field that current writers do not know", () => {
   const future = {
     ...taskCreated,
-    payload: { task: { ...taskCreated.payload.task, futureOptionalField: true } }
+    payload: { task: { ...taskCreated.payload.task, futureOptionalField: true } },
   };
   const bytes = serializeEventEnvelope(future);
 
@@ -51,9 +55,29 @@ test("semantic actor and source equality ignores additions but not known-axis ch
   assert.equal(sameActorIdentity({ ...actor, principal: { personId: "someone-else" } }, actor), false);
   // watch_session remains readable only as immutable historical event identity;
   // current command normalization rejects it after automatic ingestion retired.
-  const source = { kind: "watch_session" as const, sessionId: "session-1", path: "context/input.md", fingerprint: "a".repeat(64) };
+  const source = {
+    kind: "watch_session" as const,
+    sessionId: "session-1",
+    path: "context/input.md",
+    fingerprint: "a".repeat(64),
+  };
   assert.equal(sameWriteSource({ ...source, futureOptionalField: true }, source), true);
   assert.equal(sameWriteSource({ ...source, path: "context/other.md" }, source), false);
+});
+
+test("the retired agent entity envelope is parse-only", () => {
+  const pathName = path.resolve(
+      import.meta.dirname,
+      "../../fixtures/canonical-events/agent-entity-event-v1/accepted.json",
+    ),
+    body = readFileSync(pathName, "utf8"),
+    event = JSON.parse(body) as unknown;
+  assert.deepEqual(parseCanonicalEvent(body), event);
+  assert.match(validateCurrentCanonicalEvent(event).join("\n"), /not current/u);
+  assert.equal(
+    Object.hasOwn(canonicalEventSchemas.find(({ schema }) => schema === "agent-entity-event/v1")!, "validateCurrent"),
+    false,
+  );
 });
 
 test("every canonical reader ignores an unknown field at every frozen object boundary", () => {
@@ -89,9 +113,11 @@ function objectAt(value: unknown, objectPath: ObjectPath): Record<string, unknow
   let current = value;
   for (const segment of objectPath) {
     if (Array.isArray(current) && typeof segment === "number") current = current[segment];
-    else if (current !== null && typeof current === "object" && typeof segment === "string") current = (current as Record<string, unknown>)[segment];
+    else if (current !== null && typeof current === "object" && typeof segment === "string")
+      current = (current as Record<string, unknown>)[segment];
     else throw new Error(`fixture path does not resolve to an object: ${objectPath.join(".")}`);
   }
-  if (current === null || typeof current !== "object" || Array.isArray(current)) throw new Error(`fixture path is not an object: ${objectPath.join(".")}`);
+  if (current === null || typeof current !== "object" || Array.isArray(current))
+    throw new Error(`fixture path is not an object: ${objectPath.join(".")}`);
   return current as Record<string, unknown>;
 }

--- a/packages/kernel/test/contracts/doc-sync-runtime-artifacts.test.ts
+++ b/packages/kernel/test/contracts/doc-sync-runtime-artifacts.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { OPAQUE_TEXTUAL_POLICY_ID } from "../../src/domain/artifact-text-classification.ts";
 import { DOC_POLICY_ID, decideDocWrite, documentPath, type DocumentState } from "../../src/domain/doc-sync.contract.ts";
-import { resolveLiveTaskBoundRuntimeBinding } from "../../src/domain/task-bound-runtime-authority.ts";
+import { resolveTaskBoundRuntimeBinding } from "../../src/domain/task-bound-runtime-authority.ts";
 import { validateWriteReceipt } from "../../src/domain/write-chain.contract.ts";
 import { sha256Text } from "../../src/integrity/stable-hash.ts";
 
@@ -102,12 +102,12 @@ test("a task-bound runtime may write only its assigned task artifacts subtree wh
     resultRef: null,
     lastObservedAt: "2026-08-12T10:00:00.000Z",
   } as const;
-  assert.deepEqual(resolveLiveTaskBoundRuntimeBinding(session, lease.taskId, lease.executionId), runtimeBinding);
+  assert.deepEqual(resolveTaskBoundRuntimeBinding(session, lease.taskId, lease.executionId), runtimeBinding);
   assert.deepEqual(
-    resolveLiveTaskBoundRuntimeBinding({ ...session, liveness: "unknown" }, lease.taskId, lease.executionId),
+    resolveTaskBoundRuntimeBinding({ ...session, liveness: "unknown" }, lease.taskId, lease.executionId),
     runtimeBinding,
   );
-  assert.equal(resolveLiveTaskBoundRuntimeBinding(session, lease.taskId, "another-execution"), null);
+  assert.equal(resolveTaskBoundRuntimeBinding(session, lease.taskId, "another-execution"), null);
 });
 
 test("an opaque artifact write reclassifies an existing prose record without a policy upgrade", () => {

--- a/packages/kernel/test/contracts/doc-sync.fixtures.ts
+++ b/packages/kernel/test/contracts/doc-sync.fixtures.ts
@@ -11,7 +11,7 @@ import {
 import { sha256Text } from "../../src/integrity/stable-hash.ts";
 import { authorizationPort } from "../../src/ports/authorization-port.ts";
 import type { ActorIdentity, WriteSource } from "../../src/domain/write-chain.contract.ts";
-import type { LiveTaskBoundRuntimeBinding } from "../../src/domain/task-bound-runtime-authority.ts";
+import type { TaskBoundRuntimeBinding } from "../../src/domain/task-bound-runtime-authority.ts";
 import { currentActionEnvelopeVersion } from "../../src/index.ts";
 
 export const actor = {
@@ -41,7 +41,7 @@ export const lease = {
 } as const;
 export function authorizeDocWrite(
   actionActor: ActorIdentity = actor,
-  runtimeBinding: LiveTaskBoundRuntimeBinding | null = null,
+  runtimeBinding: TaskBoundRuntimeBinding | null = null,
   writeSource: WriteSource = "local",
 ) {
   return authorizationPort.authorize(

--- a/packages/kernel/test/contracts/entity-store.test.ts
+++ b/packages/kernel/test/contracts/entity-store.test.ts
@@ -3,14 +3,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { createEntityStore, explainEntityKind } from "../../src/index.ts";
 import { validateAgentDeclarationV1 } from "../../src/domain/agent-squad-schema.ts";
-import type { CanonicalEventV1 } from "../../src/domain/doc-sync.contract.ts";
 import {
   assertEntityUpsertInputs,
   type EntityEventV1,
   type EntityUpsertBundle,
 } from "../../src/domain/entity-event.ts";
 import { validateWriteReceipt } from "../../src/domain/write-chain.contract.ts";
-import { lifecycleFixture } from "../store/task-lifecycle-fixture.ts";
 
 const actor = { principal: { personId: "person-entity-store" }, executor: null } as const;
 const agent = {
@@ -143,47 +141,6 @@ test("Entity upsert rejects schema-invalid declarations and tampered declaration
   const bundle = upsert(store, "agent", agent, 1),
     tampered = [{ ...bundle.blobs[0], body: `${bundle.blobs[0].body} ` }];
   assert.throws(() => assertEntityUpsertInputs(bundle.event, bundle.plan, tampered), /declaration blob must be exact/u);
-});
-
-test("EntityStore keeps lifecycle entities on embedded events and applies generic revision precedence independently", () => {
-  const fixture = lifecycleFixture(),
-    events: CanonicalEventV1[] = [...fixture.events],
-    blobs = new Map<string, Uint8Array>(),
-    store = createEntityStore({
-      read: () => ({ schema: "canonical-event-stream/v1", revision: events.length, events }),
-      readContentBlob: (sha256) => blobs.get(sha256) ?? null,
-    });
-  assert.deepEqual(
-    store.list<{ readonly state: string }>("execution").map(({ id, value, workspaceRevision }) => ({
-      id,
-      state: value.state,
-      workspaceRevision,
-    })),
-    [{ id: "execution-1", state: "accepted", workspaceRevision: 6 }],
-  );
-  assert.deepEqual(
-    store.list<{ readonly verdict: string }>("review").map(({ id, value, workspaceRevision }) => ({
-      id,
-      verdict: value.verdict,
-      workspaceRevision,
-    })),
-    [{ id: "review-execution", verdict: "approved", workspaceRevision: 5 }],
-  );
-
-  const installed = upsert(store, "agent", agent, 7),
-    updated = upsert(store, "agent", { ...agent, name: "Terra Updated" }, 8);
-  for (const bundle of [installed, updated]) {
-    events.push(bundle.event);
-    for (const blob of bundle.blobs) blobs.set(blob.sha256, Buffer.from(blob.body));
-  }
-  assert.deepEqual(
-    store.get<{ readonly name: string }>("agent", "terra") && {
-      name: store.get<{ readonly name: string }>("agent", "terra")?.value.name,
-      workspaceRevision: store.get("agent", "terra")?.workspaceRevision,
-    },
-    { name: "Terra Updated", workspaceRevision: 8 },
-  );
-  assert.equal(store.get<{ readonly state: string }>("execution", "execution-1")?.value.state, "accepted");
 });
 
 test("entity_upsert receipt detail is closed and registered", () => {

--- a/packages/kernel/test/contracts/execution-review-entity.test.ts
+++ b/packages/kernel/test/contracts/execution-review-entity.test.ts
@@ -157,15 +157,15 @@ test("execution and review are dependency-free EntityKindContracts with lifecycl
   });
   assert.throws(
     () => compileEntityUpsert({ ...base, entityKind: "execution", entity: execution }),
-    /execution.*must be authored via lifecycle\/runtime events, not generic upsert/u,
+    /execution.*no generic entity-store surface/u,
   );
   assert.throws(
     () => compileEntityUpsert({ ...base, entityKind: "review", entity: review }),
-    /review.*must be authored via lifecycle\/runtime events, not generic upsert/u,
+    /review.*no generic entity-store surface/u,
   );
   assert.throws(
     () => compileEntityUpsert({ ...base, entityKind: "runtime-session", entity: runtimeSession }),
-    /runtime-session.*must be authored via lifecycle\/runtime events, not generic upsert/u,
+    /runtime-session.*no generic entity-store surface/u,
   );
   assert.doesNotThrow(() => compileEntityUpsert({ ...base, entityKind: "agent", entity: agent }));
   assert.doesNotThrow(() => compileEntityUpsert({ ...base, entityKind: "squad", entity: squad }));
@@ -189,8 +189,10 @@ test("execution and review are dependency-free EntityKindContracts with lifecycl
   assert.equal(isAllowedRelationKindTriple("execution", "executes", "task"), true);
   assert.equal(isAllowedRelationKindTriple("review", "reviews", "execution"), true);
   assert.equal(isAllowedRelationKindTriple("task", "executes", "execution"), false);
-  assert.deepEqual(parseEntityRef(`execution/${execution.taskId}/${execution.executionId}`)?.kind, "execution");
-  assert.deepEqual(parseEntityRef(`review/${execution.executionId}/${review.reviewId}`)?.kind, "review");
+  assert.deepEqual(parseEntityRef(`execution/${execution.executionId}`)?.kind, "execution");
+  assert.deepEqual(parseEntityRef(`review/${review.reviewId}`)?.kind, "review");
+  assert.equal(parseEntityRef(`execution/${execution.taskId}/${execution.executionId}`), null);
+  assert.equal(parseEntityRef(`review/${execution.executionId}/${review.reviewId}`), null);
 });
 
 test("a synthetic third contract drives the same embedded projection interpreter", () => {

--- a/packages/kernel/test/contracts/kind-authority-version.test.ts
+++ b/packages/kernel/test/contracts/kind-authority-version.test.ts
@@ -3,12 +3,16 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { contractVersion } from "../../src/domain/contract-version.ts";
 import { entityKindContracts } from "../../src/domain/entity-kind-registry.ts";
+import { entityKindRefAuthorities } from "../../src/domain/entity-ref.ts";
 import {
   explainEntityKind,
+  getEntityKindContract,
   isContractVersionCompatible,
   requireEntityStoreKindContract,
 } from "../../src/domain/index.ts";
-import { entityRegistry } from "../../src/entity/registry.ts";
+import { entityFieldContracts } from "../../src/entity/field-contracts.ts";
+import { entityRegistry, entityRegistryKinds } from "../../src/entity/registry.ts";
+import { schemaRegistry } from "../../src/schemas/registry.ts";
 
 const expectedKinds = [
   "agent",
@@ -39,22 +43,47 @@ test("every Action declares version, target, and SDK exposure metadata", () => {
   const actions = entityKindContracts.flatMap(({ actionCatalog }) => actionCatalog?.actions ?? []);
   assert.ok(actions.length > 0);
   for (const action of actions) {
+    const authority = entityKindContracts.find(({ kind }) => kind === action.target.kind);
+    assert.ok(authority);
     assert.deepEqual(action.version, { major: 1, minor: 0 }, action.id);
-    assert.match(action.target.refTemplate, new RegExp(`^${action.target.kind}/`, "u"), action.id);
+    assert.equal(action.target.refTemplate, authority.id.refTemplate, action.id);
     assert.deepEqual(Object.keys(action.sdkExposure).sort(), ["agentCapability", "sdk"], action.id);
   }
 });
 
-test("framework registry is derived while dedicated kinds cannot enter generic entity writes", () => {
+test("kind identity views are derived from the ref grammar authority without leaking parser metadata", () => {
+  for (const authority of entityKindRefAuthorities) {
+    const contract = getEntityKindContract(authority.kind);
+    assert.ok(contract);
+    assert.deepEqual(contract.id, {
+      field: authority.field,
+      pattern: authority.pattern,
+      refTemplate: authority.refTemplate,
+    });
+  }
+});
+
+test("framework registry derives schema and mutability while relation/session stay explicit boundaries", () => {
   for (const kind of ["task", "fact", "decision"] as const) {
-    const framework = entityKindContracts.find((contract) => contract.kind === kind)?.framework;
+    const contract = entityKindContracts.find((candidate) => candidate.kind === kind),
+      framework = contract?.framework,
+      schema = schemaRegistry.find(({ id }) => id === framework?.schemaId)?.schema;
     assert.ok(framework);
+    assert.equal(entityRegistry[kind].schema, schema);
+    assert.equal(entityRegistry[kind].mutabilityContract, entityFieldContracts[kind]);
     assert.deepEqual(entityRegistry[kind].anchors, framework.anchors);
     assert.deepEqual(entityRegistry[kind].dispositionMatrix, framework.dispositionMatrix);
     assert.equal(entityRegistry[kind].storageForm, framework.storageForm);
-    assert.throws(() => requireEntityStoreKindContract(kind), /authored through/u);
+    assert.throws(() => requireEntityStoreKindContract(kind), /no generic entity-store surface/u);
   }
+  assert.deepEqual([...entityRegistryKinds].sort(), ["decision", "fact", "relation", "session", "task"]);
+  assert.equal(getEntityKindContract("relation"), undefined);
+  assert.equal(getEntityKindContract("session"), undefined);
   assert.equal(requireEntityStoreKindContract("agent").kind, "agent");
+  assert.equal(requireEntityStoreKindContract("squad").kind, "squad");
+  for (const kind of ["execution", "review", "runtime-session", "policy"])
+    assert.throws(() => requireEntityStoreKindContract(kind), /no generic entity-store surface/u);
+  assert.equal(explainEntityKind("policy").authoring, null);
 });
 
 test("Action, projection, and protocol consumers share structured compatibility semantics", () => {

--- a/packages/kernel/test/contracts/policy-entity.test.ts
+++ b/packages/kernel/test/contracts/policy-entity.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { DEFAULT_POLICY } from "../../src/domain/default-policy.ts";
 import { parsePolicyDeclarationV1, validatePolicyDeclarationV1 } from "../../src/domain/policy.ts";
-import { createEntityStore, explainEntityKind } from "../../src/index.ts";
+import { explainEntityKind } from "../../src/index.ts";
 
 test("the built-in v2 policy registers its binding predicates and applicable Actions", () => {
   assert.deepEqual(validatePolicyDeclarationV1(DEFAULT_POLICY), []);
@@ -121,41 +121,5 @@ test("policy schema rejects missing Action coverage and undeclared or unused rul
       predicates: [...DEFAULT_POLICY.predicates, { predicate: "reviewIndependence", level: "L2" }],
     }).join("\n"),
     /must be used/u,
-  );
-});
-
-test("the shared EntityStore accepts policy declarations without a policy-specific store", () => {
-  const events: any[] = [];
-  const blobs = new Map<string, Uint8Array>();
-  const store = createEntityStore({
-    read: () => ({ schema: "canonical-event-stream/v1", revision: events.length, events }),
-    readContentBlob: (sha256) => blobs.get(sha256) ?? null,
-  });
-  const bundle = store.upsert({
-    entityKind: "policy",
-    entity: DEFAULT_POLICY,
-    eventId: "event-policy-default",
-    opId: "op-policy-default",
-    workspaceRevision: 1,
-    actor: { principal: { personId: "policy-test" }, executor: null },
-    source: "local",
-    occurredAt: "2026-08-25T00:00:00.000Z",
-  });
-  events.push(bundle.event);
-  for (const blob of bundle.blobs) blobs.set(blob.sha256, Buffer.from(blob.body));
-  assert.deepEqual(store.get("policy", "default")?.value, DEFAULT_POLICY);
-  assert.throws(
-    () =>
-      store.upsert({
-        entityKind: "policy",
-        entity: { ...DEFAULT_POLICY, actions: [] },
-        eventId: "event-policy-invalid",
-        opId: "op-policy-invalid",
-        workspaceRevision: 2,
-        actor: { principal: { personId: "policy-test" }, executor: null },
-        source: "local",
-        occurredAt: "2026-08-25T00:00:00.000Z",
-      }),
-    /at least 1 item/u,
   );
 });

--- a/packages/kernel/test/domain/entity-ref.test.ts
+++ b/packages/kernel/test/domain/entity-ref.test.ts
@@ -59,17 +59,19 @@ test("EntityRef parser accepts hosted relation entity refs", () => {
   assert.equal(parseEntityRef("relation/not-a-relation"), null);
 });
 
-test("EntityRef parser accepts Phase 1 relation endpoints", () => {
+test("EntityRef parser derives the nine canonical kind grammars from authority", () => {
   for (const [kind, ref] of [
     ["execution", "execution/exe-1"],
     ["review", "review/rev-1"],
     ["agent", "agent/codex"],
-    ["runtime-session", "runtime-session/run-1"],
+    ["squad", "squad/codex"],
+    ["runtime-session", "runtime-session/runtime_session1"],
     ["policy", "policy/policy-1"],
   ] as const) {
     assert.equal(parseEntityRef(ref)?.kind, kind);
   }
-  assert.equal(parseEntityRef("squad/codex"), null);
+  assert.equal(parseEntityRef("execution/task-1/exe-1"), null);
+  assert.equal(parseEntityRef("review/exe-1/rev-1"), null);
 });
 
 test("EntityRef scanner preserves external harness prefixes without resolving them", () => {


### PR DESCRIPTION
# English

## Summary

Ontology 1.10 (dec_57A9D27BA446C23759A08B1C13, anti-entropy review #2 P1-1/P1-3): close the nine-kind entity authority. EntityRef grammar, schema, mutability and authoring declarations are derived from one kind-authority table instead of three drifting sources. Fixes `fact/{task}/{id}` parser vs authority mismatch and unparseable `squad/{id}`; the `agent-entity-event/v1` alias becomes parse-only (no `validateCurrent` registration); Execution/Review/RuntimeSession lose their false `genericEntityStore` surface (only Agent/Squad keep one); Policy becomes built-in configuration with no authored declaration; `LiveTaskBoundRuntimeBinding`/`resolveLiveTaskBoundRuntimeBinding` renamed to liveness-free names with no alias.

## Architectural Justification

- Production-Delta churn is +232/-235 (above 200): every line is a derivation replacing a hand-copied table or a rename; the diff adds no new mechanism, no alias, no fallback. Net production lines are -3. Follow-up commit 153a3760c fixes the legacy execution migration projector that wrongly went through the generic-authoring guard (CI shard 4).

## What Changed

- `packages/kernel/src/domain/entity-kind-registry.ts` and ref/scanner: single nine-kind authority table feeds parser, scanner and derived identity views.
- `packages/kernel/src/domain/doc-sync-canonical-events.ts`: `agent-entity-event/v1` keeps `validate` (historical readability) and drops `validateCurrent`.
- `packages/kernel/src/entity/registry.ts`, `disposition.ts`: legacy `entityRegistry` is now derived from kind authority (kernel-internal, single consumer).
- `packages/kernel/src/domain/task-bound-runtime-authority.ts` and all call sites: rename away from `Live*`.
- Tests updated to the derived shapes.

## Gate Harvest / 门收割

Deleted-Production-Paths: hand-maintained schema/mutability tables in entityRegistry; genericEntityStore declarations for Execution/Review/RuntimeSession; authored Policy declaration; validateCurrent registration for agent-entity-event/v1
Deleted-Gates-Fixtures: packages/kernel/test/contracts/entity-store.test.ts generic-store cases for Execution/Review/RuntimeSession (-43 lines); packages/kernel/test/contracts/policy-entity.test.ts authored-Policy cases (-38 lines)
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +232/-235

### Optional Evidence Claims

## Task And Scope

- Harness task: task_2e30a777b6a28502404e404135
- Branch: codex/kind-authority-closure
- Public scope: packages/kernel (domain, entity, layout, store, projection, ports, barrel) and tests
- Private planning/evidence updated: yes
- Out of scope: ingress task-start special case (2.4); runtime/daemon process decoupling (0.24)

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_2e30a777b6a28502404e404135
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 5d066b6e7025af392cbb359e29d4b1b4586668b2
- Branch merge-base with `origin/main`: 5d066b6e7025af392cbb359e29d4b1b4586668b2
- Last `git fetch origin` time: 2026-08-26T01:44Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_2e30a777b6a28502404e404135 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] `npm run check:local` (worker run: fast 357/357, contract 658/658, 46 steps green, 126.9s)
- [x] isolated integration for touched kernel/daemon surfaces (worker report `sol-r3-2026-08-26.md`)
- [x] CEO rg: `genericEntityStore(` only Agent/Squad; `Live*Binding` symbols = 0; alias has no `validateCurrent`
- [x] CI round 1 red: line-density (regex template line) and shard 4 (migration projector) fixed in 153a3760c; shard 6 = known flake F27 (cold-restart p95), file green locally
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: nothing else; CI is the authority.

## Review Evidence

- Self-review: CEO re-read review #2 P1-1/P1-3 and grep-verified each of the five closure items in the worktree.
- Reviewer subagent: Codex worker (sol); design-side items named by anti-entropy review #2.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Old ledgers containing `agent-entity-event/v1` remain readable but can no longer be written; any producer still emitting the alias would now be rejected by current validation.

## References

- Task: task_2e30a777b6a28502404e404135
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

本体 1.10(dec_57A9D27BA446C23759A08B1C13,反熵审查 #2 P1-1/P1-3):九 kind 权威闭合。EntityRef grammar、schema、mutability、authoring 声明从唯一 kind authority 表派生,不再三处各说各话。修 `fact/{task}/{id}` parser 与 authority 不一致、`squad/{id}` 不可解析;`agent-entity-event/v1` alias 收成 parse-only(不再注册 `validateCurrent`);Execution/Review/RuntimeSession 删掉假 `genericEntityStore` 面(只剩 Agent/Squad);Policy 收成内建配置、无 authored 声明;`LiveTaskBoundRuntimeBinding`/`resolveLiveTaskBoundRuntimeBinding` 改为不含 liveness 承诺的名字,不留 alias。

## 架构辩护

- Production-Delta 变动 +232/-235(超 200):每一行都是「派生替换手抄表」或改名;不新增机制、alias、兜底。净生产行 -3。追加 commit 153a3760c 修 legacy execution migration projector 误走 generic-authoring guard(CI shard 4)。

## 改动内容

- `packages/kernel/src/domain/entity-kind-registry.ts` 与 ref/scanner:单一九 kind 权威表喂 parser、scanner 与派生 identity 视图。
- `packages/kernel/src/domain/doc-sync-canonical-events.ts`:`agent-entity-event/v1` 保留 `validate`(历史可读)、删 `validateCurrent`。
- `packages/kernel/src/entity/registry.ts`、`disposition.ts`:旧 `entityRegistry` 改为从 kind authority 派生(kernel 内部、单消费者)。
- `packages/kernel/src/domain/task-bound-runtime-authority.ts` 及全部调用点:去掉 `Live*` 命名。
- 测试改到派生形状。

## 门收割 / Gate Harvest

- 删除的生产路径:见英文块
- 同 commit 删除的门 / fixture:packages/kernel/test/contracts/entity-store.test.ts 里 Execution/Review/RuntimeSession 的 generic-store 用例(-43 行);policy-entity.test.ts 里 authored Policy 用例(-38 行)
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_2e30a777b6a28502404e404135
- 分支:codex/kind-authority-closure
- 公开范围:packages/kernel(domain、entity、layout、store、projection、ports、barrel)与测试
- 私有计划 / 证据是否已更新:yes
- 范围外:ingress task-start 特判(2.4);runtime/daemon 进程解耦(0.24)

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_2e30a777b6a28502404e404135
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:5d066b6e7025af392cbb359e29d4b1b4586668b2
- 当前分支与 `origin/main` 的 merge-base:5d066b6e7025af392cbb359e29d4b1b4586668b2
- 最近一次 `git fetch origin` 时间:2026-08-26T01:44Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_2e30a777b6a28502404e404135
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] `npm run check:local`(worker 跑:fast 357/357、contract 658/658,46 步绿,126.9s)
- [x] 触及 kernel/daemon 面的隔离 integration(worker 报告 `sol-r3-2026-08-26.md`)
- [x] CEO rg:`genericEntityStore(` 只剩 Agent/Squad;`Live*Binding` 符号 = 0;alias 无 `validateCurrent`
- [x] CI 首轮红:line-density(regex 模板行)与 shard 4(migration projector)在 153a3760c 修;shard 6 = 已知 flake F27,本地该文件绿
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:无;以 CI 为权威。

## 审查证据

- 自查:CEO 回读审查 #2 P1-1/P1-3,逐条 grep 复核五项收口。
- Reviewer subagent:Codex worker(sol);设计项来自反熵审查 #2。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 含 `agent-entity-event/v1` 的旧台账仍可读但不可再写;若还有生产者在发该 alias,现在会被当前校验拒绝。

## 关联材料

- 任务:task_2e30a777b6a28502404e404135
- 证据:任务包 artifacts/reports
- 审查:本 PR
