### PR TITLE
refactor(daemon): declare command admission and kind residency; delete admitRepoMode branches

### DIFF
--- a/packages/daemon/src/daemon-host-admission.ts
+++ b/packages/daemon/src/daemon-host-admission.ts
@@ -1,14 +1,14 @@
 /** @daemon-transport-authority Transport-bound repository-mode admission. */
 import { readDaemonRegistry, type WriteSource } from "../../kernel/src/index.ts";
+import type { CommandTopology } from "../../preset/src/preset-command-contract.ts";
 import type { DaemonControlReceipt } from "./gui-s3-control.ts";
-import type { DaemonCommandClass } from "./identity/types.ts";
 import { admitRepoMode, type RepoModeAdmission } from "./repo-mode.ts";
 import type { DaemonAuthenticationContext } from "./transport/auth-context.ts";
 
 export function admitHostMode(
   context: any,
   repoId: string,
-  commandClass: DaemonCommandClass,
+  command: CommandTopology,
   auth: DaemonAuthenticationContext,
 ): RepoModeAdmission {
   const persisted = readDaemonRegistry({
@@ -28,7 +28,7 @@ export function admitHostMode(
         assignmentId: auth.assignmentBinding.assignmentId,
       }
     : "local";
-  return admitRepoMode(persisted?.mode ?? fallback!.mode!, commandClass, source);
+  return admitRepoMode(persisted?.mode ?? fallback!.mode!, command, source);
 }
 
 export function localCenterProjectionRepair(
@@ -49,10 +49,10 @@ export function localCenterProjectionRepair(
 export function requireHostMode(
   context: any,
   repoId: string,
-  commandClass: DaemonCommandClass,
+  command: CommandTopology,
   auth: DaemonAuthenticationContext,
 ): void {
-  const admission = context.admitHostMode(repoId, commandClass, auth);
+  const admission = context.admitHostMode(repoId, command, auth);
   if (!admission.ok) throw context.hostCodedError(admission.code, admission.nextAction);
 }
 

--- a/packages/daemon/src/daemon-host-control-api.ts
+++ b/packages/daemon/src/daemon-host-control-api.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { readDaemonRegistry } from "../../kernel/src/index.ts";
+import { ledgerWriteCommandTopology } from "../../preset/src/preset-command-contract.ts";
 import type { DaemonHost } from "./daemon-host.ts";
 import type { DaemonControlReceipt } from "./gui-s3-control.ts";
 
@@ -117,7 +118,7 @@ export function createDaemonHostControlApi(
       };
     },
     issueRuntimeWitness: async (repoId, runtimeSessionId, auth) => {
-      context.requireHostMode(repoId, "repo-write", auth);
+      context.requireHostMode(repoId, ledgerWriteCommandTopology, auth);
       await context.attemptHostRecovery(repoId);
       const cell = context.requiredCell(context.cells, context.warming, context.unavailable, repoId),
         serverBinding = await context.binding(cell.status().rootDir, auth, "repo-write");

--- a/packages/daemon/src/daemon-host-open.ts
+++ b/packages/daemon/src/daemon-host-open.ts
@@ -5,6 +5,7 @@ import {
   registerDaemonRepo,
   type DaemonRepoMode,
 } from "../../kernel/src/index.ts";
+import type { CommandTopology } from "../../preset/src/preset-command-contract.ts";
 import {
   discoverRuntimeInstallations,
   openRuntimeInstanceStore,
@@ -62,7 +63,6 @@ import type { DaemonHost } from "./daemon-host-types.ts";
 import { openFleetEdgeRuntime } from "./fleet-edge-runtime.ts";
 import type { FleetTlsCenter } from "./fleet/center.ts";
 import type { DaemonControlReceipt } from "./gui-s3-control.ts";
-import type { DaemonCommandClass } from "./identity/types.ts";
 import type { DaemonLifecycleRecorder } from "./lifecycle-log.ts";
 import { canonicalRoot, workspaceId } from "./protocol/daemon-protocol.contract.ts";
 import type { JsonObject } from "./protocol/json-rpc-types.ts";
@@ -462,16 +462,16 @@ export async function openDaemonHost(input: {
   }
   function admitHostMode(
     repoId: string,
-    commandClass: DaemonCommandClass,
+    command: CommandTopology,
     auth: DaemonAuthenticationContext,
   ): RepoModeAdmission {
-    return admitHostModeImpl(extracted, repoId, commandClass, auth);
+    return admitHostModeImpl(extracted, repoId, command, auth);
   }
   function localCenterProjectionRepair(repoId: string, actionKind: string, auth: DaemonAuthenticationContext): boolean {
     return localCenterProjectionRepairImpl(extracted, repoId, actionKind, auth);
   }
-  function requireHostMode(repoId: string, commandClass: DaemonCommandClass, auth: DaemonAuthenticationContext): void {
-    return requireHostModeImpl(extracted, repoId, commandClass, auth);
+  function requireHostMode(repoId: string, command: CommandTopology, auth: DaemonAuthenticationContext): void {
+    return requireHostModeImpl(extracted, repoId, command, auth);
   }
   function settleControl(pending: DaemonControlReceipt, ok: boolean, error?: unknown): void {
     return settleControlImpl(extracted, pending, ok, error);

--- a/packages/daemon/src/daemon-host-repository-api.ts
+++ b/packages/daemon/src/daemon-host-repository-api.ts
@@ -11,8 +11,13 @@ import {
   presetUserRoot,
   recoverPresetRunStatus,
 } from "../../preset/src/index.ts";
+import { repoReadCommandTopology } from "../../preset/src/preset-command-contract.ts";
 import type { DaemonHost } from "./daemon-host.ts";
-import { commandClassForAction, type DaemonGuiReadResultMap } from "./protocol/daemon-protocol.contract.ts";
+import {
+  commandClassForAction,
+  commandDescriptorForAction,
+  type DaemonGuiReadResultMap,
+} from "./protocol/daemon-protocol.contract.ts";
 import type { JsonObject } from "./protocol/json-rpc-types.ts";
 import { resolveRepoBootstrap, type RepoBootstrapReceipt } from "./repo-bootstrap.ts";
 import { openRepoCell, type RepoCell, type RepoTaskAction } from "./repo-cell.ts";
@@ -197,11 +202,10 @@ export function createDaemonHostRepositoryApi(
       };
     },
     run: async (repoId, action, auth) => {
-      const commandClass = commandClassForAction(action.kind),
+      const command = commandDescriptorForAction(action.kind),
+        commandClass = command.commandClass,
         projectionRepair = context.localCenterProjectionRepair(repoId, action.kind, auth),
-        modeAdmission = projectionRepair
-          ? { ok: true, code: "repo_mode_admitted", nextAction: "Continue." }
-          : context.admitHostMode(repoId, commandClass, auth);
+        modeAdmission = context.admitHostMode(repoId, command, auth);
       if (!modeAdmission.ok) return context.rejectHostAction(action, modeAdmission.code, modeAdmission.nextAction);
       await context.attemptHostRecovery(repoId);
       const cell = context.cells.get(repoId);
@@ -251,11 +255,8 @@ export function createDaemonHostRepositoryApi(
     },
     replica: (repoId) => context.requiredCell(context.cells, context.warming, context.unavailable, repoId).replica,
     presetRun: async (repoId, action, auth) => {
-      const hostAdmission = context.admitHostMode(
-        repoId,
-        action.kind === "preset-run-status" ? "repo-read" : "repo-write",
-        auth,
-      );
+      const command = commandDescriptorForAction(action.kind),
+        hostAdmission = context.admitHostMode(repoId, command, auth);
       if (!hostAdmission.ok)
         return context.rejectPresetRun(
           typeof action.runId === "string" ? action.runId : "run_invalid",
@@ -310,7 +311,7 @@ export function createDaemonHostRepositoryApi(
       }
     },
     read: async (repoId, method, payload, auth) => {
-      context.requireHostMode(repoId, "repo-read", auth);
+      context.requireHostMode(repoId, repoReadCommandTopology, auth);
       await context.attemptHostRecovery(repoId);
       const cell = context.cells.get(repoId);
       if (!cell)

--- a/packages/daemon/src/daemon-host-runtime-api.ts
+++ b/packages/daemon/src/daemon-host-runtime-api.ts
@@ -1,4 +1,5 @@
 import { readDaemonRegistry } from "../../kernel/src/index.ts";
+import { ledgerWriteCommandTopology, repoReadCommandTopology } from "../../preset/src/preset-command-contract.ts";
 import type { DaemonHost } from "./daemon-host.ts";
 import {
   startFleetCenterAdmission,
@@ -7,7 +8,7 @@ import {
   type FleetEdgeSyncRequest,
 } from "./fleet-center-admission.ts";
 import { openFleetEdgeRuntime, type FleetEdgeRuntimeRequest } from "./fleet-edge-runtime.ts";
-import { canonicalRoot } from "./protocol/daemon-protocol.contract.ts";
+import { canonicalRoot, commandDescriptorForAction } from "./protocol/daemon-protocol.contract.ts";
 import type { JsonObject } from "./protocol/json-rpc-types.ts";
 
 export function createDaemonHostRuntimeApi(
@@ -27,14 +28,14 @@ export function createDaemonHostRuntimeApi(
 > {
   return {
     attach: async (repoId, runtimeSessionId, afterCursor, auth) => {
-      context.requireHostMode(repoId, "repo-read", auth);
+      context.requireHostMode(repoId, repoReadCommandTopology, auth);
       await context.attemptHostRecovery(repoId);
       const cell = context.requiredCell(context.cells, context.warming, context.unavailable, repoId);
       await context.binding(cell.status().rootDir, auth, "repo-read");
       return cell.attach(runtimeSessionId, afterCursor);
     },
     spawnRuntime: async (repoId, payload, auth) => {
-      context.requireHostMode(repoId, "repo-write", auth);
+      context.requireHostMode(repoId, commandDescriptorForAction("runtime-run"), auth);
       await context.attemptHostRecovery(repoId);
       const cell = context.requiredCell(context.cells, context.warming, context.unavailable, repoId),
         { executor: declared, ...intent } = payload,
@@ -45,7 +46,7 @@ export function createDaemonHostRuntimeApi(
       );
     },
     cancelRuntime: async (repoId, payload, auth) => {
-      context.requireHostMode(repoId, "repo-write", auth);
+      context.requireHostMode(repoId, commandDescriptorForAction("runtime-cancel"), auth);
       await context.attemptHostRecovery(repoId);
       const cell = context.requiredCell(context.cells, context.warming, context.unavailable, repoId),
         { executor: declared, ...intent } = payload,
@@ -56,13 +57,13 @@ export function createDaemonHostRuntimeApi(
       );
     },
     runtimeIngress: async (repoId, action, auth) => {
-      context.requireHostMode(repoId, "repo-write", auth);
+      context.requireHostMode(repoId, commandDescriptorForAction("runtime-run"), auth);
       await context.attemptHostRecovery(repoId);
       const cell = context.requiredCell(context.cells, context.warming, context.unavailable, repoId);
       return cell.runtimeIngress(action, await context.binding(cell.status().rootDir, auth, "repo-write"));
     },
     terminalAttach: async (repoId, sessionId, afterSeq, auth) => {
-      context.requireHostMode(repoId, "repo-read", auth);
+      context.requireHostMode(repoId, repoReadCommandTopology, auth);
       await context.attemptHostRecovery(repoId);
       const cell = context.requiredCell(context.cells, context.warming, context.unavailable, repoId);
       await context.binding(cell.status().rootDir, auth, "repo-read");
@@ -70,8 +71,9 @@ export function createDaemonHostRuntimeApi(
     },
     terminalAction: async (repoId, method, payload, auth) => {
       const commandClass =
-        method === "repo.gui.catalog.reread" || method === "repo.terminal.detach" ? "repo-read" : "repo-write";
-      context.requireHostMode(repoId, commandClass, auth);
+          method === "repo.gui.catalog.reread" || method === "repo.terminal.detach" ? "repo-read" : "repo-write",
+        commandTopology = commandClass === "repo-read" ? repoReadCommandTopology : ledgerWriteCommandTopology;
+      context.requireHostMode(repoId, commandTopology, auth);
       await context.attemptHostRecovery(repoId);
       const cell = context.requiredCell(context.cells, context.warming, context.unavailable, repoId),
         serverBinding = await context.binding(cell.status().rootDir, auth, commandClass);
@@ -181,7 +183,7 @@ export function createDaemonHostRuntimeApi(
       })) as JsonObject;
     },
     runtimeInstanceAuth: async (repoId, method, payload, auth) => {
-      context.requireHostMode(repoId, "repo-write", auth);
+      context.requireHostMode(repoId, ledgerWriteCommandTopology, auth);
       await context.attemptHostRecovery(repoId);
       const cell = context.requiredCell(context.cells, context.warming, context.unavailable, repoId),
         serverBinding = await context.binding(cell.status().rootDir, auth, "repo-write");

--- a/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-agent.ts
@@ -1,13 +1,18 @@
-import { cliInput, defineCliCommand } from "../../../preset/src/preset-command-contract.ts";
+import {
+  cliInput,
+  defineHostAdminCommand,
+  defineLedgerWriteCommand,
+  defineRepoReadCommand,
+  defineRuntimeLocalWriteCommand,
+} from "../../../preset/src/preset-command-contract.ts";
 
 export const agentProtocolCommands = Object.freeze([
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "agenda",
     phase: "W3",
     path: ["agenda"],
     summary: "Project the current supervisory agenda from tasks, decisions, executions, and relations.",
     method: "repo.agenda.read",
-    commandClass: "repo-read",
     inputs: [
       cliInput(
         "--limit",
@@ -25,7 +30,7 @@ export const agentProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "migrate-import",
     phase: "Migration-A",
     path: ["migrate", "import"],
@@ -34,7 +39,6 @@ export const agentProtocolCommands = Object.freeze([
       "id collisions are deterministically remapped and recorded.",
     ].join(""),
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput(
         "--source",
@@ -65,7 +69,7 @@ export const agentProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineRuntimeLocalWriteCommand({
     id: "agent-create",
     phase: "Runtime-B",
     path: ["agent", "create", "<instance-id>"],
@@ -74,7 +78,6 @@ export const agentProtocolCommands = Object.freeze([
       "validate it, and install it without overwriting an existing Agent.",
     ].join(""),
     method: "repo.agentRuntime.spawn",
-    commandClass: "repo-write",
     positional: "runtimeInstanceId",
     inputs: [
       cliInput(
@@ -142,42 +145,38 @@ export const agentProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "squad-status",
     phase: "Runtime-B",
     path: ["squad", "status", "<squad-run-id>"],
     summary: "Read a durable Squad run and its leader and worker dispatches.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     positional: "squadRunId",
     inputs: [],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "ledger-migrate",
     phase: "Migration-A",
     path: ["migrate", "ledger"],
     summary: "Migrate the canonical ledger from flat/v1 to sharded-sha256-2/v1.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "entity-explain",
     phase: "Runtime-B",
     path: ["entity", "explain", "<kind>"],
     summary: "Explain one registered Entity kind contract.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     positional: "entityKind",
     inputs: [],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "entity-get",
     phase: "Runtime-B",
     path: ["entity", "get", "<kind>"],
     summary: "Read one canonical Entity declaration.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     positional: "entityKind",
     inputs: [
       cliInput("--id", "single", true, {
@@ -186,42 +185,38 @@ export const agentProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "entity-list",
     phase: "Runtime-B",
     path: ["entity", "list", "<kind>"],
     summary: "List canonical declarations for one registered Entity kind.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     positional: "entityKind",
     inputs: [],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "agent-list",
     phase: "Runtime-B",
     path: ["agent", "list"],
     summary: "List installed Agent identity declarations.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     inputs: [],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "agent-inspect",
     phase: "Runtime-B",
     path: ["agent", "inspect", "<id>"],
     summary: "Inspect one Agent identity including its instructions and runtime type.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     positional: "agentId",
     inputs: [],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "agent-validate",
     phase: "Runtime-B",
     path: ["agent", "validate"],
     summary: "Validate one Agent declaration package before installing it.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     inputs: [
       cliInput(
         "--source",
@@ -232,13 +227,12 @@ export const agentProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "agent-install",
     phase: "Runtime-B",
     path: ["agent", "install"],
     summary: "Install an Agent declaration into the repository entity store.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput(
         "--source",
@@ -256,32 +250,29 @@ export const agentProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "squad-list",
     phase: "Runtime-B",
     path: ["squad", "list"],
     summary: "List installed Squad identity declarations.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     inputs: [],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "squad-inspect",
     phase: "Runtime-B",
     path: ["squad", "inspect", "<id>"],
     summary: "Inspect one Squad and its human-editable roster text.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     positional: "squadId",
     inputs: [],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "squad-run",
     phase: "Runtime-B",
     path: ["squad", "run", "<id>"],
     summary: "Start a durable Squad run supervised by callback-driven leader turns.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     positional: "squadId",
     inputs: [
       cliInput("--instance", "single", true, {
@@ -316,13 +307,12 @@ export const agentProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "squad-validate",
     phase: "Runtime-B",
     path: ["squad", "validate"],
     summary: "Validate one Squad declaration package before installing it.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     inputs: [
       cliInput(
         "--source",
@@ -333,13 +323,12 @@ export const agentProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "squad-install",
     phase: "Runtime-B",
     path: ["squad", "install"],
     summary: "Install a Squad declaration into the repository entity store.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput(
         "--source",
@@ -357,7 +346,7 @@ export const agentProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineHostAdminCommand({
     id: "repo-bootstrap",
     phase: "W3",
     path: ["init"],
@@ -367,7 +356,6 @@ export const agentProtocolCommands = Object.freeze([
       "already-initialized workspace without writing documents.",
     ].join(""),
     method: "daemon.repo.bootstrap",
-    commandClass: "admin",
     inputs: [
       cliInput("--repo-id", "single", true, {
         code: "missing_field",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-decision-lifecycle.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-decision-lifecycle.ts
@@ -1,14 +1,19 @@
-import { cliInput, decisionProposalJsonFields, defineCliCommand } from "../../../preset/src/preset-command-contract.ts";
+import {
+  cliInput,
+  decisionProposalJsonFields,
+  defineLedgerWriteCommand,
+  defineLocalArbiterCommand,
+  defineRepoReadCommand,
+} from "../../../preset/src/preset-command-contract.ts";
 
 export const decisionLifecycleProtocolCommands = Object.freeze([
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "decision-validate",
     actionKind: "decision-validate",
     phase: "DecisionFact-B",
     path: ["decision", "validate", "[id]"],
     summary: "Read-only validation of one or all Decision packages, pins, and amend history.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     inputs: [
       cliInput("--all", "boolean", false, {
         code: "invalid_field",
@@ -16,14 +21,13 @@ export const decisionLifecycleProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "decision-verify",
     actionKind: "decision-validate",
     phase: "DecisionFact-B",
     path: ["decision", "verify", "[id]"],
     summary: "Read-only content-pin verification alias; reports every warning without rewriting.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     inputs: [
       cliInput("--all", "boolean", false, {
         code: "invalid_field",
@@ -31,13 +35,12 @@ export const decisionLifecycleProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "decision-repin",
     phase: "DecisionFact-B",
     path: ["decision", "repin", "[id]"],
     summary: "Append current v1 content pins to one Decision or every Decision in a migration batch.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--all", "boolean", false, {
         code: "invalid_field",
@@ -55,13 +58,12 @@ export const decisionLifecycleProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "decision-propose",
     phase: "DecisionFact-B",
     path: ["decision", "propose"],
     summary: "Propose an immutable Decision from one structured packet.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput(
         "--from-file",
@@ -117,13 +119,12 @@ export const decisionLifecycleProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "decision-transition",
     phase: "DecisionFact-B",
     path: ["decision", "transition", "<in_effect|rejected|deferred|superseded|outcome_retired>", "<id>"],
     summary: "Canonical lifecycle transition; terminal states cannot transition again.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--decided-at", "single", false, {
         code: "invalid_field",
@@ -159,13 +160,12 @@ export const decisionLifecycleProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLocalArbiterCommand({
     id: "decision-accept",
     phase: "DecisionFact-B",
     path: ["decision", "accept", "<id>"],
     summary: "Deprecated alias for decision transition in_effect.",
     method: "repo.task.run",
-    commandClass: "arbiter",
     inputs: [
       cliInput(
         "--rationale",
@@ -192,13 +192,12 @@ export const decisionLifecycleProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLocalArbiterCommand({
     id: "decision-reject",
     phase: "DecisionFact-B",
     path: ["decision", "reject", "<id>"],
     summary: "Deprecated alias for decision transition rejected.",
     method: "repo.task.run",
-    commandClass: "arbiter",
     inputs: [
       cliInput(
         "--rationale",
@@ -212,13 +211,12 @@ export const decisionLifecycleProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLocalArbiterCommand({
     id: "decision-defer",
     phase: "DecisionFact-B",
     path: ["decision", "defer", "<id>"],
     summary: "Deprecated alias for decision transition deferred.",
     method: "repo.task.run",
-    commandClass: "arbiter",
     inputs: [
       cliInput(
         "--rationale",
@@ -232,13 +230,12 @@ export const decisionLifecycleProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "decision-supersede",
     phase: "DecisionFact-B",
     path: ["decision", "supersede", "<id>"],
     summary: "Deprecated alias for decision transition superseded.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput(
         "--reason",
@@ -252,13 +249,12 @@ export const decisionLifecycleProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "decision-retire",
     phase: "DecisionFact-B",
     path: ["decision", "retire", "<id>"],
     summary: "Deprecated alias for decision transition outcome_retired.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput(
         "--reason",
@@ -272,13 +268,12 @@ export const decisionLifecycleProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "decision-amend",
     phase: "DecisionFact-B",
     path: ["decision", "amend", "<id>"],
     summary: "Amend declared machine fields or replace Markdown prose without changing lifecycle state.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--title", "single", false, {
         code: "invalid_field",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-decision-relations.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-decision-relations.ts
@@ -1,13 +1,16 @@
-import { cliInput, defineCliCommand } from "../../../preset/src/preset-command-contract.ts";
+import {
+  cliInput,
+  defineLedgerWriteCommand,
+  defineRepoReadCommand,
+} from "../../../preset/src/preset-command-contract.ts";
 
 export const decisionRelationProtocolCommands = Object.freeze([
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "decision-claim-add",
     phase: "DecisionFact-B",
     path: ["decision", "claim", "add", "<id>"],
     summary: "Append a Decision claim.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput(
         "--id",
@@ -29,13 +32,12 @@ export const decisionRelationProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "decision-claim-fulfill",
     phase: "DecisionFact-B",
     path: ["decision", "claim", "fulfill", "<id>"],
     summary: "Declare a claim fulfillment mode.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput(
         "--id",
@@ -59,13 +61,12 @@ export const decisionRelationProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "decision-relate",
     phase: "DecisionFact-B",
     path: ["decision", "relate", "<id>"],
     summary: "Append a Decision-owned relation.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--anchor", "single", true, {
         code: "invalid_field",
@@ -91,13 +92,12 @@ export const decisionRelationProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "decision-relation-retire",
     phase: "DecisionFact-B",
     path: ["decision", "relation", "retire", "<id>"],
     summary: "Retire a Decision-owned relation while preserving the old edge.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput(
         "--relation",
@@ -121,13 +121,12 @@ export const decisionRelationProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "decision-relation-replace",
     phase: "DecisionFact-B",
     path: ["decision", "relation", "replace", "<id>"],
     summary: "Atomically retire one hosted relation and append its deterministic replacement.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput(
         "--relation",
@@ -171,13 +170,12 @@ export const decisionRelationProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "decision-reckon",
     phase: "DecisionFact-B",
     path: ["decision", "reckon", "<id>"],
     summary: "Record coverage at the exact projected basis revision.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--task", "single", true, {
         code: "missing_field",
@@ -185,13 +183,12 @@ export const decisionRelationProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "decision-list",
     phase: "DecisionFact-B",
     path: ["decision", "list"],
     summary: "List the canonical Decision projection without authored prose.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     inputs: [
       cliInput("--search", "single", false, {
         code: "invalid_field",
@@ -236,13 +233,12 @@ export const decisionRelationProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "decision-show",
     phase: "DecisionFact-B",
     path: ["decision", "show", "<id>"],
     summary: "Show one canonical Decision by id or E-number.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     inputs: [
       cliInput("--include-body", "boolean", false, {
         code: "invalid_field",
@@ -250,13 +246,12 @@ export const decisionRelationProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "distill-candidate",
     phase: "DecisionFact-B",
     path: ["distill", "candidate"],
     summary: "Create a generated, non-canonical candidate artifact from a task evidence file; no Fact is written.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--task", "single", true, {
         code: "missing_field",
@@ -268,13 +263,12 @@ export const decisionRelationProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "distill-promote",
     phase: "DecisionFact-B",
     path: ["distill", "promote"],
     summary: "Promote one validated candidate claim through the canonical immutable Fact write path.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--task", "single", true, {
         code: "missing_field",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-doc-fact.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-doc-fact.ts
@@ -1,13 +1,18 @@
-import { cliInput, defineCliCommand } from "../../../preset/src/preset-command-contract.ts";
+import {
+  defineCenterForwardReadCommand,
+  defineCenterForwardWriteCommand,
+  cliInput,
+  defineLedgerWriteCommand,
+  defineRepoReadCommand,
+} from "../../../preset/src/preset-command-contract.ts";
 
 export const docFactProtocolCommands = Object.freeze([
-  defineCliCommand({
+  defineCenterForwardReadCommand({
     id: "doc-status",
     phase: "DocSync-B",
     path: ["doc", "status"],
     summary: "Scan the authored root for document candidates.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     inputs: [
       cliInput("--task", "single", false, {
         code: "invalid_field",
@@ -19,14 +24,13 @@ export const docFactProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineCenterForwardReadCommand({
     id: "doc-sync-dry-run",
     actionKind: "doc-dry-run",
     phase: "DocSync-B",
     path: ["doc", "sync", "--dry-run"],
     summary: "Preview the scanner selection without writing.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     inputs: [
       cliInput("--task", "single", false, {
         code: "invalid_field",
@@ -38,14 +42,13 @@ export const docFactProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineCenterForwardWriteCommand({
     id: "doc-sync-submit",
     actionKind: "doc-submit",
     phase: "DocSync-B",
     path: ["doc", "sync", "--submit"],
     summary: "Submit eligible scanner candidates through the resident daemon.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--task", "single", false, {
         code: "invalid_field",
@@ -57,22 +60,20 @@ export const docFactProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "doc-materialize",
     phase: "DocSync-B",
     path: ["doc", "materialize"],
     summary: "Restore the current canonical document cut to the worktree.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "doc-show",
     phase: "DocSync-B",
     path: ["doc", "show"],
     summary: "Show a canonical projected document.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     inputs: [
       cliInput("--path", "single", true, {
         code: "missing_field",
@@ -80,13 +81,12 @@ export const docFactProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "doc-retire",
     phase: "DocSync-B",
     path: ["doc", "retire"],
     summary: "Retire one canonical document with an audited reason.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--path", "single", true, {
         code: "missing_field",
@@ -98,26 +98,24 @@ export const docFactProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineCenterForwardWriteCommand({
     id: "doc-conflict-resolve",
     phase: "Fleet-Wiring",
     path: ["doc", "conflict", "resolve", "<conflict-id>"],
     summary:
       "Close a staged sync conflict by hand after merging base/local/center; the next sync submits on the fresh base.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [],
   }),
-  defineCliCommand({
+  defineCenterForwardWriteCommand({
     id: "doc-conflict-discard-local",
     phase: "Fleet-Wiring",
     path: ["doc", "conflict", "discard-local", "<conflict-id>"],
     summary: "Resolve a staged sync conflict by discarding the local changes and restoring the recorded center bytes.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [],
   }),
-  defineCliCommand({
+  defineCenterForwardWriteCommand({
     id: "doc-conflict-overwrite-center",
     phase: "Fleet-Wiring",
     path: ["doc", "conflict", "overwrite-center", "<conflict-id>"],
@@ -126,16 +124,14 @@ export const docFactProtocolCommands = Object.freeze([
       "the recorded center digest as the expected base.",
     ].join(""),
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "fact-record",
     phase: "DecisionFact-A",
     path: ["fact", "record"],
     summary: "Record an immutable Fact event.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--task", "single", true, {
         code: "missing_field",
@@ -201,13 +197,12 @@ export const docFactProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "fact-search",
     phase: "DecisionFact-A",
     path: ["fact", "search", "[query]"],
     summary: "Search the Fact FTS projection.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     inputs: [
       cliInput("--task", "single", false, {
         code: "invalid_field",
@@ -235,13 +230,12 @@ export const docFactProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "fact-show",
     phase: "DecisionFact-A",
     path: ["fact", "show"],
     summary: "Show one projected Fact.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     inputs: [
       cliInput("--task", "single", true, {
         code: "missing_field",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-runtime-config.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-runtime-config.ts
@@ -1,27 +1,31 @@
-import { cliInput, defineCliCommand } from "../../../preset/src/preset-command-contract.ts";
+import {
+  defineCenterRepairWriteCommand,
+  cliInput,
+  defineHostAdminCommand,
+  defineLedgerWriteCommand,
+  defineRepoReadCommand,
+} from "../../../preset/src/preset-command-contract.ts";
 import { daemonRepoModeWords } from "./daemon-protocol-vocabulary.ts";
 
 const credentialReferenceRegex =
   "^credential:v1:[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$|^keychain:[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$";
 
 export const runtimeConfigProtocolCommands = Object.freeze([
-  defineCliCommand({
+  defineCenterRepairWriteCommand({
     id: "daemon-projection-rebuild",
     phase: "B2-S1",
     path: ["daemon", "projection", "rebuild"],
     summary: "Rebuild the local task projection in place from the canonical ledger.",
     method: "repo.task.run",
     actionKind: "projection-rebuild",
-    commandClass: "repo-write",
     inputs: [],
   }),
-  defineCliCommand({
+  defineHostAdminCommand({
     id: "daemon-repo-register",
     phase: "W3",
     path: ["daemon", "repo", "register"],
     summary: "Register an initialized workspace with an explicit service mode.",
     method: "daemon.repo.register",
-    commandClass: "admin",
     inputs: [
       cliInput("--repo-id", "single", true, {
         code: "missing_field",
@@ -43,13 +47,12 @@ export const runtimeConfigProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineHostAdminCommand({
     id: "daemon-repo-unregister",
     phase: "W3",
     path: ["daemon", "repo", "unregister"],
     summary: "Disable a registered workspace.",
     method: "daemon.repo.unregister",
-    commandClass: "admin",
     inputs: [
       cliInput("--repo-id", "single", true, {
         code: "missing_field",
@@ -57,31 +60,28 @@ export const runtimeConfigProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineHostAdminCommand({
     id: "daemon-start",
     phase: "W3",
     path: ["daemon", "start", "--service"],
     summary: "Explicitly start the resident daemon.",
     method: "protocol.hello",
-    commandClass: "admin",
     inputs: [],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "daemon-status",
     phase: "W3",
     path: ["daemon", "status"],
     summary: "Show daemon and RepoCell status.",
     method: "daemon.status",
-    commandClass: "repo-read",
     inputs: [],
   }),
-  defineCliCommand({
+  defineHostAdminCommand({
     id: "runtime-instance-create",
     phase: "Runtime-Instances-S1",
     path: ["runtime", "instance", "create"],
     summary: "Create one machine-local runtime instance bound to a witnessed installation.",
     method: "daemon.runtimeInstance.create",
-    commandClass: "admin",
     inputs: [
       cliInput(
         "--id",
@@ -199,14 +199,13 @@ export const runtimeConfigProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineHostAdminCommand({
     id: "runtime-instance-github-credential-set",
     phase: "Runtime-Instances-S1",
     path: ["runtime", "instance", "github-credential", "set", "<instance-id>"],
     positional: "instanceId",
     summary: "Bind a GitHub credential reference to an existing runtime instance.",
     method: "daemon.runtimeInstance.githubCredential.set",
-    commandClass: "admin",
     inputs: [
       cliInput(
         "--ref",
@@ -223,17 +222,16 @@ export const runtimeConfigProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineHostAdminCommand({
     id: "runtime-instance-github-credential-unset",
     phase: "Runtime-Instances-S1",
     path: ["runtime", "instance", "github-credential", "unset", "<instance-id>"],
     positional: "instanceId",
     summary: "Unbind the GitHub credential reference from an existing runtime instance.",
     method: "daemon.runtimeInstance.githubCredential.unset",
-    commandClass: "admin",
     inputs: [],
   }),
-  defineCliCommand({
+  defineHostAdminCommand({
     id: "runtime-instance-list",
     phase: "Runtime-Instances-S1",
     path: ["runtime", "instance", "list"],
@@ -242,7 +240,6 @@ export const runtimeConfigProtocolCommands = Object.freeze([
       "without secrets or host paths; use --all to include disabled instances.",
     ].join(""),
     method: "daemon.runtimeInstance.list",
-    commandClass: "admin",
     inputs: [
       cliInput("--all", "boolean", false, {
         code: "invalid_field",
@@ -250,14 +247,13 @@ export const runtimeConfigProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineHostAdminCommand({
     id: "runtime-instance-show",
     phase: "Runtime-Instances-S1",
     path: ["runtime", "instance", "show", "<instance-id>"],
     positional: "instanceId",
     summary: "Show one redacted machine-local runtime instance; use --probe to verify provider authentication.",
     method: "daemon.runtimeInstance.show",
-    commandClass: "admin",
     inputs: [
       cliInput("--probe", "boolean", false, {
         code: "invalid_field",
@@ -265,17 +261,16 @@ export const runtimeConfigProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineHostAdminCommand({
     id: "runtime-instance-delete",
     phase: "Runtime-Instances-S1",
     path: ["runtime", "instance", "delete", "<instance-id>"],
     positional: "instanceId",
     summary: "Delete one runtime instance and any instance-managed state.",
     method: "daemon.runtimeInstance.delete",
-    commandClass: "admin",
     inputs: [],
   }),
-  defineCliCommand({
+  defineHostAdminCommand({
     id: "runtime-instance-update",
     phase: "Runtime-Instances-S1",
     path: ["runtime", "instance", "update", "<instance-id>"],
@@ -285,7 +280,6 @@ export const runtimeConfigProtocolCommands = Object.freeze([
       "isolation, or enabled state without touching credentials.",
     ].join(""),
     method: "daemon.runtimeInstance.update",
-    commandClass: "admin",
     inputs: [
       cliInput("--name", "single", false, {
         code: "invalid_field",
@@ -337,14 +331,13 @@ export const runtimeConfigProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "runtime-instance-login",
     phase: "Runtime-Instances-S3",
     path: ["runtime", "instance", "login", "<instance-id>"],
     positional: "instanceId",
     summary: "Bridge your terminal to provider-native sign-in when supported by the runtime kind.",
     method: "repo.runtimeInstance.auth.login",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--idempotency-key", "single", false, {
         code: "invalid_field",
@@ -352,14 +345,13 @@ export const runtimeConfigProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "runtime-instance-logout",
     phase: "Runtime-Instances-S3",
     path: ["runtime", "instance", "logout", "<instance-id>"],
     positional: "instanceId",
     summary: "Remove provider credentials through provider-native sign-out when supported by the runtime kind.",
     method: "repo.runtimeInstance.auth.logout",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--idempotency-key", "single", false, {
         code: "invalid_field",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-runtime-fleet.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-runtime-fleet.ts
@@ -1,7 +1,12 @@
-import { cliInput, defineCliCommand } from "../../../preset/src/preset-command-contract.ts";
+import {
+  cliInput,
+  defineHostAdminCommand,
+  defineRepoReadCommand,
+  defineRuntimeLocalWriteCommand,
+} from "../../../preset/src/preset-command-contract.ts";
 
 export const runtimeFleetProtocolCommands = Object.freeze([
-  defineCliCommand({
+  defineRuntimeLocalWriteCommand({
     id: "runtime-run",
     phase: "Runtime-B",
     path: ["runtime", "run", "<instance-id>"],
@@ -13,7 +18,6 @@ export const runtimeFleetProtocolCommands = Object.freeze([
       "ha runtime status --task <task-id> --wait.",
     ].join(""),
     method: "repo.agentRuntime.spawn",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--agent", "single", false, {
         code: "invalid_field",
@@ -100,7 +104,7 @@ export const runtimeFleetProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineRuntimeLocalWriteCommand({
     id: "runtime-batch",
     phase: "Runtime-B",
     path: ["runtime", "batch", "<batch-file>"],
@@ -109,16 +113,14 @@ export const runtimeFleetProtocolCommands = Object.freeze([
       "dispatches and wait for every entry to settle.",
     ].join(""),
     method: "repo.agentRuntime.spawn",
-    commandClass: "repo-write",
     inputs: [],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "runtime-status",
     phase: "Runtime-B",
     path: ["runtime", "status", "[<runtime-session-id>]"],
     summary: "List runtime sessions, show one session, or use --wait to stream and wait for its final result.",
     method: "repo.agentRuntime.overview",
-    commandClass: "repo-read",
     inputs: [
       cliInput("--task", "single", false, {
         code: "invalid_field",
@@ -134,22 +136,20 @@ export const runtimeFleetProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineRuntimeLocalWriteCommand({
     id: "runtime-cancel",
     phase: "Runtime-B",
     path: ["runtime", "cancel", "<runtime-session-id>"],
     summary: "Idempotently cancel a runtime session.",
     method: "repo.agentRuntime.cancel",
-    commandClass: "repo-write",
     inputs: [],
   }),
-  defineCliCommand({
+  defineHostAdminCommand({
     id: "daemon-stop",
     phase: "W3",
     path: ["daemon", "stop"],
     summary: "Stop the resident daemon.",
     method: "protocol.hello",
-    commandClass: "admin",
     inputs: [
       cliInput("--force", "boolean", false, {
         code: "invalid_field",
@@ -160,13 +160,12 @@ export const runtimeFleetProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineHostAdminCommand({
     id: "daemon-fleet-center-start",
     phase: "Fleet-Wiring",
     path: ["daemon", "fleet", "center", "start"],
     summary: "Start the daemon-owned fleet TLS center serving the authoritative ledger to admitted edge nodes.",
     method: "daemon.fleet.center.start",
-    commandClass: "admin",
     inputs: [
       cliInput(
         "--port",
@@ -214,13 +213,12 @@ export const runtimeFleetProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineHostAdminCommand({
     id: "daemon-fleet-edge-sync",
     phase: "Fleet-Wiring",
     path: ["daemon", "fleet", "edge", "sync"],
     summary: "Mirror the fleet center ledger into the registered workspace harness over verified TLS.",
     method: "daemon.fleet.edge.sync",
-    commandClass: "admin",
     inputs: [
       cliInput("--host", "single", true, {
         code: "missing_field",
@@ -276,8 +274,9 @@ export const runtimeFleetProtocolCommands = Object.freeze([
       ),
       cliInput("--view-root", "single", true, {
         code: "missing_field",
-        nextAction: "Edge sync requires --view-root for transport state;"
-          + " ledger files materialize in the registered workspace harness.",
+        nextAction:
+          "Edge sync requires --view-root for transport state;" +
+          " ledger files materialize in the registered workspace harness.",
       }),
       cliInput(
         "--quota-bytes",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
@@ -1,22 +1,25 @@
-import { cliInput, defineCliCommand } from "../../../preset/src/preset-command-contract.ts";
+import {
+  defineCenterForwardWriteCommand,
+  cliInput,
+  defineLedgerWriteCommand,
+  defineRepoReadCommand,
+} from "../../../preset/src/preset-command-contract.ts";
 
 export const taskSurfaceProtocolCommands = Object.freeze([
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "task-dispatches",
     phase: "Runtime-B",
     path: ["task", "dispatches", "<task-id>"],
     summary: "List current and historical runtime dispatches associated with a Task.",
     method: "repo.task.dispatches",
-    commandClass: "repo-read",
     inputs: [],
   }),
-  defineCliCommand({
+  defineCenterForwardWriteCommand({
     id: "task-release",
     phase: "W3",
     path: ["task", "release", "<task-id>"],
     summary: "Release the authenticated holder lease and preserve the Execution audit trail.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--reason", "single", false, {
         code: "invalid_field",
@@ -24,13 +27,12 @@ export const taskSurfaceProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "task-declare-executor",
     phase: "W3",
     path: ["task", "declare-executor", "<task-id>"],
     summary: "Auditably declare the agent executor omitted from a submitted Execution at the review node.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--execution-id", "single", false, {
         code: "invalid_field",
@@ -42,13 +44,12 @@ export const taskSurfaceProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "task-transition",
     phase: "W3",
     path: ["task", "transition", "<task-id>", "<planned|active|blocked|in_review|done|cancelled>"],
     summary: "Move lifecycle status; done and in_review remain reserved for complete and submit.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--force", "boolean", false, {
         code: "invalid_field",
@@ -61,13 +62,12 @@ export const taskSurfaceProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "task-amend",
     phase: "W3",
     path: ["task", "amend", "<task-id>"],
     summary: "Amend declared task prose or metadata without changing lifecycle authority.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput(
         "--set",
@@ -81,31 +81,28 @@ export const taskSurfaceProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "task-pin",
     phase: "W3",
     path: ["task", "pin", "<task-id>"],
     summary: "Pin a task to the front of its agenda group.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "task-unpin",
     phase: "W3",
     path: ["task", "unpin", "<task-id>"],
     summary: "Remove a task pin so its agenda group uses the standard order.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "task-contract-migrate",
     phase: "W3",
     path: ["task", "contract", "migrate"],
     summary: "Plan or apply deterministic Task contract backfills; ambiguous Tasks remain manual.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--dry-run", "boolean", false, {
         code: "invalid_field",
@@ -121,13 +118,12 @@ export const taskSurfaceProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "task-archive",
     phase: "W3",
     path: ["task", "archive", "[<task-id>]"],
     summary: "Archive selected Task packages while retaining their evidence and lifecycle history.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--ids", "single", false, {
         code: "invalid_field",
@@ -160,13 +156,12 @@ export const taskSurfaceProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "task-supersede",
     phase: "W3",
     path: ["task", "supersede", "<old-task-id>"],
     summary: "Archive old work and preserve an explicit replacement lineage.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--title", "single", false, {
         code: "invalid_field",
@@ -204,13 +199,12 @@ export const taskSurfaceProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "task-delete",
     phase: "W3",
     path: ["task", "delete"],
     summary: "Soft-delete through production authority; hard delete remains rejected with a repair path.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--soft", "single", false, {
         code: "invalid_field",
@@ -234,13 +228,12 @@ export const taskSurfaceProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "task-reopen",
     phase: "W3",
     path: ["task", "reopen", "<task-id>"],
     summary: "Reopen a nonterminal archived or tombstoned Task package.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--reason", "single", true, {
         code: "missing_field",
@@ -248,13 +241,12 @@ export const taskSurfaceProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "task-review",
     phase: "W3",
     path: ["task", "review", "<task-id>"],
     summary: "Lint the legacy review contract without approving completion.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     inputs: [
       cliInput("--reviewer", "single", false, {
         code: "invalid_field",
@@ -262,13 +254,12 @@ export const taskSurfaceProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "task-list",
     phase: "W3",
     path: ["task", "list"],
     summary: "List Task projection rows with canonical lifecycle and metadata filters.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     inputs: [
       cliInput(
         "--status",
@@ -320,13 +311,12 @@ export const taskSurfaceProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "relation-list",
     phase: "W3",
     path: ["relation", "list"],
     summary: "Query Task, Decision, and Fact relation edges from the converged projection.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     inputs: [
       cliInput("--entity", "single", false, {
         code: "invalid_field",
@@ -356,13 +346,12 @@ export const taskSurfaceProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "task-relate",
     phase: "W3",
     path: ["task", "relate", "<source-task-id>", "depends-on", "<target-task-id>"],
     summary: "Declare a cycle-checked depends-on edge owned by the source Task.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--rationale", "single", true, {
         code: "missing_field",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task.ts
@@ -1,33 +1,49 @@
 import {
+  defineCenterForwardReadCommand,
+  defineCenterForwardWriteCommand,
   cliInput,
   consentJsonFields,
-  defineCliCommand,
+  defineLedgerWriteCommand,
+  defineLocalArbiterCommand,
+  defineRepoReadCommand,
   reviewJsonFields,
   taskSubmissionJsonFields,
 } from "../../../preset/src/preset-command-contract.ts";
 
 export const taskExecutionProtocolCommands = Object.freeze([
-  defineCliCommand({
+  defineCenterForwardWriteCommand({
     id: "task-start",
     phase: "W3",
     path: ["task", "start", "<task-id>"],
     summary: "Acquire the task execution lease.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
-      cliInput("--execution-id", "single", true, {
-        code: "missing_field",
-        nextAction: "Add --execution-id <execution-id>.",
+      cliInput("--execution-id", "single", false, {
+        code: "invalid_field",
+        nextAction: "Use one execution id, or omit it for deterministic allocation.",
+      }),
+      cliInput(
+        "--ttl-ms",
+        "single",
+        false,
+        {
+          code: "invalid_field",
+          nextAction: "Use a positive lease duration in milliseconds.",
+        },
+        { regex: "^[1-9][0-9]*$" },
+      ),
+      cliInput("--dry-run", "boolean", false, {
+        code: "invalid_field",
+        nextAction: "Use --dry-run once to preview lease admission.",
       }),
     ],
   }),
-  defineCliCommand({
+  defineCenterForwardWriteCommand({
     id: "task-progress-append",
     phase: "W3",
     path: ["task", "progress", "append", "<task-id>"],
     summary: "Append typed progress through the active task lease.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--text", "single", true, {
         code: "missing_field",
@@ -48,13 +64,12 @@ export const taskExecutionProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "task-artifact-add",
     phase: "W3",
     path: ["task", "artifact", "add", "<task-id>"],
     summary: "Publish an untracked UTF-8 artifact through canonical doc sync.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--source", "single", true, {
         code: "missing_field",
@@ -66,13 +81,12 @@ export const taskExecutionProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineCenterForwardWriteCommand({
     id: "task-submit",
     phase: "W3",
     path: ["task", "submit", "<task-id>"],
     summary: "Atomically finalize an Execution and enter review.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--execution-id", "single", false, {
         code: "invalid_field",
@@ -90,7 +104,7 @@ export const taskExecutionProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "task-closeout",
     phase: "W3",
     path: ["task", "closeout", "<task-id>"],
@@ -99,7 +113,6 @@ export const taskExecutionProtocolCommands = Object.freeze([
       "canonical order, resuming from the current closeout stage.",
     ].join(""),
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--execution-id", "single", false, {
         code: "invalid_field",
@@ -117,13 +130,12 @@ export const taskExecutionProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLocalArbiterCommand({
     id: "task-review-execution",
     phase: "W3",
     path: ["task", "review-execution", "<task-id>"],
     summary: "Append a canonical Execution Review.",
     method: "repo.task.run",
-    commandClass: "arbiter",
     inputs: [
       cliInput("--execution-id", "single", false, {
         code: "invalid_field",
@@ -145,13 +157,12 @@ export const taskExecutionProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "task-review-consent",
     phase: "W3",
     path: ["task", "review-consent", "<task-id>"],
     summary: "Select a recorded Review with content-pinned owner consent.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--execution-id", "single", false, {
         code: "invalid_field",
@@ -180,13 +191,12 @@ export const taskExecutionProtocolCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "task-code-doc-reconcile",
     phase: "W3",
     path: ["task", "code-doc", "reconcile", "<task-id>"],
     summary: "Publish a typed code-doc witness.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--execution-id", "single", true, {
         code: "invalid_field",
@@ -215,13 +225,12 @@ export const taskExecutionProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "task-code-doc-repoint",
     phase: "W3",
     path: ["task", "code-doc", "repoint", "<task-id>"],
     summary: "Append an audited code-doc witness correction for a completed task.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--record", "single", true, {
         code: "missing_field",
@@ -247,13 +256,12 @@ export const taskExecutionProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "task-complete",
     phase: "W3",
     path: ["task", "complete", "<task-id>"],
     summary: "Complete a reviewed and consented task after canonical gate checks.",
     method: "repo.task.run",
-    commandClass: "repo-write",
     inputs: [
       cliInput("--execution-id", "single", false, {
         code: "invalid_field",
@@ -276,22 +284,20 @@ export const taskExecutionProtocolCommands = Object.freeze([
       }),
     ],
   }),
-  defineCliCommand({
+  defineCenterForwardReadCommand({
     id: "task-show",
     phase: "W3",
     path: ["task", "show", "<task-id>"],
     summary: "Read the task projection.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     inputs: [],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "receipt-show",
     phase: "W3",
     path: ["receipt", "show", "<op-id>"],
     summary: "Read a write receipt.",
     method: "repo.task.run",
-    commandClass: "repo-read",
     inputs: [],
   }),
 ] as const);

--- a/packages/daemon/src/protocol/daemon-protocol-commands.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands.ts
@@ -54,31 +54,7 @@ export const effectiveDaemonOwnedProtocolCommands = Object.freeze(
             }),
           ],
         })
-      : command.id === "task-start"
-        ? defineCliCommand({
-            ...command,
-            inputs: [
-              cliInput("--execution-id", "single", false, {
-                code: "invalid_field",
-                nextAction: "Use one execution id, or omit it for deterministic allocation.",
-              }),
-              cliInput(
-                "--ttl-ms",
-                "single",
-                false,
-                {
-                  code: "invalid_field",
-                  nextAction: "Use a positive lease duration in milliseconds.",
-                },
-                { regex: "^[1-9][0-9]*$" },
-              ),
-              cliInput("--dry-run", "boolean", false, {
-                code: "invalid_field",
-                nextAction: "Use --dry-run once to preview lease admission.",
-              }),
-            ],
-          })
-        : command,
+      : command,
   ),
 );
 
@@ -230,13 +206,17 @@ export function resolveThinCliCommand(args: readonly string[]): (typeof daemonPr
   );
 }
 
-export function commandClassForAction(kind: string): "repo-read" | "repo-write" | "arbiter" | "admin" {
+export function commandDescriptorForAction(kind: string) {
   const descriptor =
     daemonProtocolCommands.find((entry) => ("actionKind" in entry ? entry.actionKind : entry.id) === kind) ??
     presetMethods.find((entry) => entry.actionKind === kind);
   if (!descriptor)
     throw new DaemonProtocolContractError("unsupported_command", `No command descriptor exists for ${kind}.`);
-  return descriptor.commandClass;
+  return descriptor;
+}
+
+export function commandClassForAction(kind: string): "repo-read" | "repo-write" | "arbiter" | "admin" {
+  return commandDescriptorForAction(kind).commandClass;
 }
 
 export function actionForDaemonMethod(method: string, payload: JsonObject): JsonObject & { readonly kind: string } {

--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -415,6 +415,7 @@ export default Object.freeze({
 export {
   actionForDaemonMethod,
   commandClassForAction,
+  commandDescriptorForAction,
   daemonProtocolCommands,
   resolveThinCliCommand,
   thinCliCommands,

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -12,6 +12,7 @@ import { listProjectedTaskDocuments, readProjectedDocument } from "./doc-sync-ac
 import { makeGitReadinessSource } from "./process-port.ts";
 import {
   commandClassForAction,
+  commandDescriptorForAction,
   type DaemonGuiReadResultMap,
   type DaemonTaskDispatchesPayload,
 } from "./protocol/daemon-protocol.contract.ts";
@@ -26,15 +27,9 @@ import { workspaceSummaryFromProjection } from "./workspace-summary-read.ts";
 
 export function createRepoCellApi(context: any): RepoCell {
   const run = (action: RepoTaskAction, binding: RepoCellBinding, signal?: AbortSignal): Promise<WriteReceipt> => {
-    const commandClass = commandClassForAction(action.kind),
-      admitsLocalCenterRepair =
-        action.kind === "projection-rebuild" &&
-        context.mode === "remote-center" &&
-        binding.source === "local" &&
-        binding.roles?.includes("$admin"),
-      modeAdmission = admitsLocalCenterRepair
-        ? { ok: true, code: "repo_mode_admitted", nextAction: "Continue." }
-        : admitRepoMode(context.mode, commandClass, binding.source);
+    const command = commandDescriptorForAction(action.kind),
+      commandClass = command.commandClass,
+      modeAdmission = admitRepoMode(context.mode, command, binding.source);
     if (!modeAdmission.ok)
       return Promise.resolve(
         context.rejected(
@@ -73,9 +68,7 @@ export function createRepoCellApi(context: any): RepoCell {
       context.queueDepth += 1;
       const pending = chainRepoCellWrite(context.tail, async () => {
         context.queueDepth -= 1;
-        const queuedAdmission = admitsLocalCenterRepair
-          ? { ok: true, code: "repo_mode_admitted", nextAction: "Continue." }
-          : admitRepoMode(context.mode, commandClass, binding.source);
+        const queuedAdmission = admitRepoMode(context.mode, command, binding.source);
         if (!queuedAdmission.ok) throw context.cellCodedError(queuedAdmission.code, queuedAdmission.nextAction);
         if (context.state === "closed" || (context.state !== "attached" && !recoveryCommandAllowed))
           throw context.cellCodedError(
@@ -147,7 +140,8 @@ export function createRepoCellApi(context: any): RepoCell {
     return enqueuePublication(() => context.executeAction(action, { ...binding, commandClasses: [commandClass] }));
   };
   const presetRun: RepoCell["presetRun"] = async (action, binding) => {
-    const commandClass = action.kind === "preset-run-status" ? "repo-read" : "repo-write",
+    const command = commandDescriptorForAction(action.kind),
+      commandClass = command.commandClass,
       reject = (code: string, nextAction: string): PresetRunReceiptV1 => ({
         schema: "preset-run-receipt/v1",
         runId: typeof action.runId === "string" ? action.runId : "run_invalid",
@@ -157,7 +151,7 @@ export function createRepoCellApi(context: any): RepoCell {
         code,
         nextAction,
       }),
-      admission = admitRepoMode(context.mode, commandClass, binding.source);
+      admission = admitRepoMode(context.mode, command, binding.source);
     if (!admission.ok) return reject(admission.code, admission.nextAction);
     if (context.state !== "attached") context.attemptRecovery();
     if (context.state !== "attached") return reject("repo_unavailable", context.latched());
@@ -167,7 +161,7 @@ export function createRepoCellApi(context: any): RepoCell {
       } catch (error) {
         return reject(context.cellErrorCode(error), context.cellErrorMessage(error));
       }
-    const queuedAdmission = admitRepoMode(context.mode, commandClass, binding.source);
+    const queuedAdmission = admitRepoMode(context.mode, command, binding.source);
     if (!queuedAdmission.ok) return reject(queuedAdmission.code, queuedAdmission.nextAction);
     return action.kind === "preset-run-status"
       ? context.presetProcess.status(context.requiredCellText(action.runId, "runId"))
@@ -414,13 +408,14 @@ export function createRepoCellApi(context: any): RepoCell {
   });
   Object.assign(context.extracted, { taskListQueryFromAction, queryRead, relationQueryFromAction });
   const spawnRuntime: RepoCell["spawnRuntime"] = (payload, binding) => {
-    const admission = admitRepoMode(context.mode, "repo-write", binding.source);
+    const command = commandDescriptorForAction("runtime-run"),
+      admission = admitRepoMode(context.mode, command, binding.source);
     if (!admission.ok) return Promise.reject(context.cellCodedError(admission.code, admission.nextAction));
     context.queueDepth += 1;
     const pending = chainRepoCellWrite(context.tail, () => {
       context.queueDepth -= 1;
       if (context.state !== "attached") context.attemptRecovery();
-      const queuedAdmission = admitRepoMode(context.mode, "repo-write", binding.source);
+      const queuedAdmission = admitRepoMode(context.mode, command, binding.source);
       if (!queuedAdmission.ok) throw context.cellCodedError(queuedAdmission.code, queuedAdmission.nextAction);
       if (context.state !== "attached") throw context.cellCodedError("repo_unavailable", context.latched());
       context.recheckRuntime();
@@ -438,13 +433,14 @@ export function createRepoCellApi(context: any): RepoCell {
     return pending;
   };
   const cancelRuntime: RepoCell["cancelRuntime"] = (payload, binding) => {
-    const admission = admitRepoMode(context.mode, "repo-write", binding.source);
+    const command = commandDescriptorForAction("runtime-cancel"),
+      admission = admitRepoMode(context.mode, command, binding.source);
     if (!admission.ok) return Promise.reject(context.cellCodedError(admission.code, admission.nextAction));
     context.queueDepth += 1;
     const pending = chainRepoCellWrite(context.tail, () => {
       context.queueDepth -= 1;
       if (context.state !== "attached") context.attemptRecovery();
-      const queuedAdmission = admitRepoMode(context.mode, "repo-write", binding.source);
+      const queuedAdmission = admitRepoMode(context.mode, command, binding.source);
       if (!queuedAdmission.ok) throw context.cellCodedError(queuedAdmission.code, queuedAdmission.nextAction);
       if (context.state !== "attached") throw context.cellCodedError("repo_unavailable", context.latched());
       context.recheckRuntime();
@@ -462,7 +458,8 @@ export function createRepoCellApi(context: any): RepoCell {
     return pending;
   };
   const runtimeIngress: RepoCell["runtimeIngress"] = (action, binding) => {
-    const admission = admitRepoMode(context.mode, "repo-write", binding.source);
+    const command = commandDescriptorForAction("runtime-run"),
+      admission = admitRepoMode(context.mode, command, binding.source);
     if (!admission.ok) return Promise.reject(context.cellCodedError(admission.code, admission.nextAction));
     context.queueDepth += 1;
     const pending = chainRepoCellWrite(context.tail, () => {

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -8,6 +8,7 @@ import {
   type WriterGeneration,
 } from "../../kernel/src/index.ts";
 import { createPresetProcessService, presetUserRoot } from "../../preset/src/index.ts";
+import { ledgerWriteCommandTopology } from "../../preset/src/preset-command-contract.ts";
 import { readAgentDeclaration, resolveSquadDispatchTarget } from "./agent-entities.ts";
 import type { PreparedRuntimeLaunch, RuntimeInstanceSummary } from "./agent-runtime-instances.ts";
 import { makeAgentRuntimeStreamHub } from "./agent-runtime-stream.ts";
@@ -302,7 +303,7 @@ export async function openRepoCell(input: {
       now,
     });
   const admitTerminalWrite = (binding: RepoCellBinding): void => {
-    const admission = admitRepoMode(mode, "repo-write", binding.source);
+    const admission = admitRepoMode(mode, ledgerWriteCommandTopology, binding.source);
     if (!admission.ok) throw cellCodedError(admission.code, admission.nextAction);
     if (state !== "attached") attemptRecovery();
     if (state !== "attached") throw cellCodedError("repo_unavailable", latched());

--- a/packages/daemon/src/repo-mode.ts
+++ b/packages/daemon/src/repo-mode.ts
@@ -1,43 +1,47 @@
 import type { DaemonRepoMode, WriteSource } from "../../kernel/src/index.ts";
-import type { DaemonCommandClass } from "./identity/types.ts";
+import type { CommandTopology } from "../../preset/src/preset-command-contract.ts";
 
 export interface RepoModeAdmission {
   readonly ok: boolean;
   readonly code: string;
   readonly nextAction: string;
 }
+const rejection = (code: string, nextAction: string): RepoModeAdmission => ({
+  ok: false,
+  code,
+  nextAction,
+});
 
 export function admitRepoMode(
   mode: DaemonRepoMode,
-  commandClass: DaemonCommandClass,
+  command: Pick<CommandTopology, "admission">,
   source: WriteSource,
 ): RepoModeAdmission {
-  const assignment = typeof source === "object" && source.kind === "assignment";
-  const directRemote = source === "remote_direct";
-  const allowed =
-    mode === "local"
-      ? !directRemote
-      : mode === "remote-center"
-        ? commandClass === "repo-read" || (assignment && commandClass === "repo-write")
-        : commandClass === "repo-read" && !assignment;
-  if (allowed) return { ok: true, code: "repo_mode_admitted", nextAction: "Continue." };
-  if (mode === "remote-center")
-    return {
-      ok: false,
-      code: "repo_mode_requires_center_ingress",
-      nextAction:
-        "Send write commands through the authenticated Fleet assignment ingress; local direct writes are disabled for remote-center repositories.",
-    };
+  const route = command.admission[mode],
+    assignment = typeof source === "object" && source.kind === "assignment";
+  if (mode === "local" && source === "remote_direct")
+    return rejection(
+      "repo_mode_rejects_direct_remote",
+      "Use authenticated assignment ingress for remote commands; direct remote writes are not admitted.",
+    );
+  if (route === "direct" && !(mode === "remote-edge" && assignment))
+    return { ok: true, code: "repo_mode_admitted", nextAction: "Continue." };
+  if (route === "via-assignment" && assignment)
+    return { ok: true, code: "repo_mode_admitted", nextAction: "Continue." };
+  if (route === "via-assignment")
+    return rejection(
+      "repo_mode_requires_center_ingress",
+      "Send write commands through the authenticated Fleet assignment ingress; local direct writes are disabled for remote-center repositories.",
+    );
+  if (route === "via-center-forward")
+    return rejection(
+      "repo_mode_read_only",
+      "Forward this command to the remote center; the remote-edge repository does not author ledger state.",
+    );
   if (mode === "remote-edge")
-    return {
-      ok: false,
-      code: "repo_mode_read_only",
-      nextAction:
-        "Send writes to the remote center; this remote-edge repository only serves local reads and receipt queries.",
-    };
-  return {
-    ok: false,
-    code: "repo_mode_rejects_direct_remote",
-    nextAction: "Use authenticated assignment ingress for remote commands; direct remote writes are not admitted.",
-  };
+    return rejection("repo_mode_read_only", "This command has no remote-edge route in its daemon command descriptor.");
+  return rejection(
+    "repo_mode_command_rejected",
+    `The daemon command descriptor explicitly rejects this command in ${mode} mode.`,
+  );
 }

--- a/packages/daemon/test/command-admission.test.ts
+++ b/packages/daemon/test/command-admission.test.ts
@@ -1,0 +1,38 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { daemonProtocolCommands } from "../src/protocol/daemon-protocol-commands.ts";
+import { daemonRepoModeWords } from "../src/protocol/daemon-protocol-vocabulary.ts";
+import { admitRepoMode } from "../src/repo-mode.ts";
+
+const localSource = "local" as const;
+const assignmentSource = { kind: "assignment", nodeId: "edge-one", assignmentId: "assignment-one" } as const;
+const admissionRoutes = new Set(["direct", "via-assignment", "via-center-forward", "rejected"]);
+
+test("all 117 daemon commands close every repo-mode admission cell", () => {
+  assert.equal(daemonProtocolCommands.length, 117);
+  let cells = 0;
+  for (const command of daemonProtocolCommands) {
+    assert.deepEqual(Object.keys(command.admission).sort(), [...daemonRepoModeWords].sort(), command.id);
+    for (const mode of daemonRepoModeWords) {
+      cells += 1;
+      const route = command.admission[mode];
+      assert.equal(admissionRoutes.has(route), true, `${command.id} ${mode} ${route}`);
+      const direct = admitRepoMode(mode, command, localSource),
+        assigned = admitRepoMode(mode, command, assignmentSource);
+      if (route === "direct") {
+        assert.equal(direct.ok, true, `${command.id} ${mode} direct fixture`);
+      } else if (route === "via-assignment") {
+        assert.equal(direct.ok, false, `${command.id} ${mode} requires assignment`);
+        assert.equal(assigned.ok, true, `${command.id} ${mode} assignment fixture`);
+      } else if (route === "via-center-forward") {
+        assert.equal(direct.ok, false, `${command.id} ${mode} forwards instead of executing locally`);
+        assert.match(direct.nextAction, /forward/iu, command.id);
+      } else {
+        assert.equal(direct.ok, false, `${command.id} ${mode} explicitly rejected`);
+        assert.equal(assigned.ok, false, `${command.id} ${mode} explicitly rejected for assignments`);
+      }
+    }
+  }
+  assert.equal(cells, 117 * 3);
+});

--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -54,8 +54,12 @@ export interface EntityKindRegistry {
   readonly byId: ReadonlyMap<string, EntityKindRegistration>;
 }
 
+export type EntityResidency = "ledger" | "runtime-local" | "projection";
+export type EntityResidencyFacets = Readonly<Record<string, EntityResidency>>;
+
 export interface EntityKindContract<T = unknown> {
   readonly kind: string;
+  readonly residency: EntityResidencyFacets;
   readonly schema: EntityDocumentJsonSchema<T>;
   readonly id: {
     readonly field: string;
@@ -122,6 +126,7 @@ export interface EntityActionContract {
 export interface EntityKindExplanation {
   readonly schema: "entity-kind-explanation/v1";
   readonly kind: string;
+  readonly residency: EntityResidencyFacets;
   readonly documentSchema: {
     readonly id: string;
     readonly fields: ReturnType<typeof explainEntityJsonSchema>;
@@ -173,6 +178,8 @@ const actionCatalog = (
   sdkExposure: EntitySdkExposure = noSdkExposure,
 ) => Object.freeze({ ref, actions: Object.freeze(ids.map((id) => entityAction(kind, identity, id, sdkExposure))) });
 const genericAuthoring = Object.freeze({ kind: "generic-entity-store" as const, contractRef: "entity-event/v1" });
+const authoredResidency = Object.freeze({ authored: "ledger" as const });
+const authoredLiveResidency = Object.freeze({ authored: "ledger" as const, live: "runtime-local" as const });
 const genericEntityStore = (pathTemplate: string, validate?: (value: unknown) => readonly string[]) =>
   Object.freeze({ document: declarationDocument(pathTemplate), ...(validate ? { validate } : {}) });
 
@@ -392,6 +399,7 @@ const decisionActionIds = decisionEventTypes.map((type) => decisionActionByEvent
 export const entityKindContracts = Object.freeze([
   {
     kind: "task",
+    residency: authoredResidency,
     schema: taskSchema,
     id: taskIdentity,
     relations: relationsFor("task"),
@@ -411,6 +419,7 @@ export const entityKindContracts = Object.freeze([
   },
   {
     kind: "fact",
+    residency: authoredResidency,
     schema: factSchema,
     id: factIdentity,
     relations: relationsFor("fact"),
@@ -424,6 +433,7 @@ export const entityKindContracts = Object.freeze([
   },
   {
     kind: "decision",
+    residency: authoredResidency,
     schema: decisionSchema,
     id: decisionIdentity,
     relations: relationsFor("decision"),
@@ -443,6 +453,7 @@ export const entityKindContracts = Object.freeze([
   },
   {
     kind: "agent",
+    residency: authoredResidency,
     schema: AGENT_DECLARATION_V1_SCHEMA,
     id: agentIdentity,
     relations: { directions: [], edges: [] },
@@ -459,6 +470,7 @@ export const entityKindContracts = Object.freeze([
   },
   {
     kind: "squad",
+    residency: authoredResidency,
     schema: SQUAD_DECLARATION_V1_SCHEMA,
     id: squadIdentity,
     relations: { directions: [], edges: [] },
@@ -470,6 +482,7 @@ export const entityKindContracts = Object.freeze([
   },
   {
     kind: "policy",
+    residency: authoredResidency,
     schema: POLICY_DECLARATION_V1_SCHEMA,
     id: policyIdentity,
     relations: { directions: [], edges: [] },
@@ -487,6 +500,7 @@ export const entityKindContracts = Object.freeze([
   },
   {
     kind: "execution",
+    residency: authoredLiveResidency,
     schema: executionSchema,
     id: executionIdentity,
     relations: {
@@ -543,6 +557,7 @@ export const entityKindContracts = Object.freeze([
   },
   {
     kind: "review",
+    residency: authoredResidency,
     schema: reviewSchema,
     id: reviewIdentity,
     relations: {
@@ -581,6 +596,7 @@ export const entityKindContracts = Object.freeze([
   },
   {
     kind: "runtime-session",
+    residency: authoredLiveResidency,
     schema: runtimeSessionEntityV1Schema,
     id: runtimeSessionIdentity,
     relations: {
@@ -642,6 +658,7 @@ export function explainEntityKind(kind: string): EntityKindExplanation {
   return {
     schema: "entity-kind-explanation/v1",
     kind: contract.kind,
+    residency: contract.residency,
     documentSchema: { id: contract.schema.$id, fields: explainEntityJsonSchema(contract.schema) },
     id: contract.id,
     relations: contract.relations,

--- a/packages/kernel/test/contracts/kind-authority-version.test.ts
+++ b/packages/kernel/test/contracts/kind-authority-version.test.ts
@@ -25,9 +25,22 @@ const expectedKinds = [
   "squad",
   "task",
 ] as const;
+const expectedResidency = {
+  agent: { authored: "ledger" },
+  decision: { authored: "ledger" },
+  execution: { authored: "ledger", live: "runtime-local" },
+  fact: { authored: "ledger" },
+  policy: { authored: "ledger" },
+  review: { authored: "ledger" },
+  "runtime-session": { authored: "ledger", live: "runtime-local" },
+  squad: { authored: "ledger" },
+  task: { authored: "ledger" },
+} as const;
 
 test("one named kind-contract authority explains all nine entity kinds with one shape", () => {
   assert.deepEqual(entityKindContracts.map(({ kind }) => kind).sort(), [...expectedKinds]);
+  for (const contract of entityKindContracts)
+    assert.deepEqual(contract.residency, expectedResidency[contract.kind], `${contract.kind} residency`);
   const explanations = expectedKinds.map(explainEntityKind);
   const shape = Object.keys(explanations[0]!).sort();
   for (const explanation of explanations) assert.deepEqual(Object.keys(explanation).sort(), shape, explanation.kind);

--- a/packages/preset/src/preset-command-contract.ts
+++ b/packages/preset/src/preset-command-contract.ts
@@ -2,6 +2,29 @@ export interface CliInputError {
   readonly code: string;
   readonly nextAction: string;
 }
+export type CommandAdmissionRoute = "direct" | "via-assignment" | "via-center-forward" | "rejected";
+export type CommandAdmission = Readonly<Record<"local" | "remote-center" | "remote-edge", CommandAdmissionRoute>>;
+export interface CommandTopology {
+  readonly commandClass: "admin" | "repo-write" | "repo-read" | "arbiter";
+  readonly admission: CommandAdmission;
+}
+const commandTopology = (
+  commandClass: CommandTopology["commandClass"],
+  center: CommandAdmissionRoute,
+  edge: CommandAdmissionRoute,
+): CommandTopology =>
+  Object.freeze({
+    commandClass,
+    admission: Object.freeze({ local: "direct", "remote-center": center, "remote-edge": edge }),
+  });
+export const repoReadCommandTopology = commandTopology("repo-read", "direct", "direct"),
+  ledgerWriteCommandTopology = commandTopology("repo-write", "via-assignment", "rejected"),
+  centerForwardReadCommandTopology = commandTopology("repo-read", "direct", "via-center-forward"),
+  centerForwardWriteCommandTopology = commandTopology("repo-write", "via-assignment", "via-center-forward"),
+  runtimeLocalWriteCommandTopology = commandTopology("repo-write", "via-assignment", "direct"),
+  centerRepairWriteCommandTopology = commandTopology("repo-write", "direct", "rejected"),
+  localArbiterCommandTopology = commandTopology("arbiter", "rejected", "rejected"),
+  hostAdminCommandTopology = commandTopology("admin", "direct", "direct");
 export interface CliInputFacet {
   readonly name: string;
   readonly kind: "single" | "repeated" | "boolean";
@@ -134,6 +157,8 @@ export function defineCliCommand<
     readonly path: readonly string[];
     readonly syntaxPath?: readonly string[];
     readonly inputs: readonly CliInputFacet[];
+    readonly commandClass: CommandTopology["commandClass"];
+    readonly admission: CommandAdmission;
   },
 >(declaration: Command) {
   const rawPath = declaration.syntaxPath ?? declaration.path,
@@ -156,14 +181,30 @@ export function defineCliCommand<
   // is the source of truth, so a positional like <task-id> survives every rebuild automatically.
   return Object.freeze({ ...declaration, path, syntaxPath, inputs, flags: inputs, usage, help });
 }
+type CliCommandDeclaration = {
+  readonly path: readonly string[];
+  readonly syntaxPath?: readonly string[];
+  readonly inputs: readonly CliInputFacet[];
+};
+const defineTopologyCommand =
+  (topology: CommandTopology) =>
+  <const Command extends CliCommandDeclaration>(declaration: Command) =>
+    defineCliCommand({ ...declaration, ...topology });
+export const defineRepoReadCommand = defineTopologyCommand(repoReadCommandTopology),
+  defineLedgerWriteCommand = defineTopologyCommand(ledgerWriteCommandTopology),
+  defineCenterForwardReadCommand = defineTopologyCommand(centerForwardReadCommandTopology),
+  defineCenterForwardWriteCommand = defineTopologyCommand(centerForwardWriteCommandTopology),
+  defineRuntimeLocalWriteCommand = defineTopologyCommand(runtimeLocalWriteCommandTopology),
+  defineCenterRepairWriteCommand = defineTopologyCommand(centerRepairWriteCommandTopology),
+  defineLocalArbiterCommand = defineTopologyCommand(localArbiterCommandTopology),
+  defineHostAdminCommand = defineTopologyCommand(hostAdminCommandTopology);
 export const presetCommands = Object.freeze([
-  defineCliCommand({
+  defineCenterForwardWriteCommand({
     id: "task-create",
     phase: "Preset-A",
     path: ["task", "create"],
     summary: "Create a task package with its complete metadata and initial relations.",
     method: "repo.task.create",
-    commandClass: "repo-write",
     inputs: [
       cliInput(
         "--title",
@@ -387,13 +428,12 @@ export const presetCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "preset-list",
     phase: "Preset-A",
     path: ["preset", "list"],
     summary: "List effective preset packages and blocked shadows.",
     method: "repo.preset.list",
-    commandClass: "repo-read",
     inputs: [
       cliInput(
         "--vertical",
@@ -404,13 +444,12 @@ export const presetCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "preset-inspect",
     phase: "Preset-A",
     path: ["preset", "inspect", "<id>"],
     summary: "Inspect one resolved preset snapshot.",
     method: "repo.preset.inspect",
-    commandClass: "repo-read",
     positional: "presetId",
     inputs: [
       cliInput(
@@ -436,13 +475,12 @@ export const presetCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "preset-check",
     phase: "Preset-A",
     path: ["preset", "check", "<id>"],
     summary: "Preflight one effective preset package or compare a frozen snapshot.",
     method: "repo.preset.check",
-    commandClass: "repo-read",
     positional: "presetId",
     inputs: [
       cliInput(
@@ -461,13 +499,12 @@ export const presetCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "preset-validate",
     phase: "Preset-A",
     path: ["preset", "validate"],
     summary: "Validate one self-contained preset package.",
     method: "repo.preset.validate",
-    commandClass: "repo-read",
     inputs: [
       cliInput(
         "--source",
@@ -478,13 +515,12 @@ export const presetCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "preset-install",
     phase: "Preset-A",
     path: ["preset", "install"],
     summary: "Install a whole package behind an atomic active pointer.",
     method: "repo.preset.install",
-    commandClass: "repo-write",
     inputs: [
       cliInput(
         "--source",
@@ -502,13 +538,12 @@ export const presetCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "preset-seed",
     phase: "Preset-A",
     path: ["preset", "seed"],
     summary: "Seed bundled packages into user active pointers.",
     method: "repo.preset.seed",
-    commandClass: "repo-write",
     inputs: [
       cliInput(
         "--dry-run",
@@ -519,13 +554,12 @@ export const presetCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "preset-audit",
     phase: "Preset-A",
     path: ["preset", "audit"],
     summary: "Audit the effective preset inventory and its issues.",
     method: "repo.preset.audit",
-    commandClass: "repo-read",
     inputs: [
       cliInput(
         "--vertical",
@@ -536,13 +570,12 @@ export const presetCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "preset-uninstall",
     phase: "Preset-A",
     path: ["preset", "uninstall", "<id>"],
     summary: "Remove only the user active pointer.",
     method: "repo.preset.uninstall",
-    commandClass: "repo-write",
     positional: "presetId",
     inputs: [
       cliInput(
@@ -554,23 +587,21 @@ export const presetCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "preset-upgrade",
     phase: "Preset-A",
     path: ["preset", "upgrade", "<task-id>"],
     summary: "Canonically upgrade one task to the current complete preset snapshot.",
     method: "repo.preset.upgrade",
-    commandClass: "repo-write",
     positional: "taskId",
     inputs: [],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "vertical-validate",
     phase: "Preset-A",
     path: ["vertical", "validate"],
     summary: "Validate the builtin software/coding declaration and its catalog closure.",
     method: "repo.vertical.validate",
-    commandClass: "repo-read",
     inputs: [
       cliInput(
         "--source",
@@ -581,22 +612,20 @@ export const presetCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "template-list",
     phase: "Preset-A",
     path: ["template", "list"],
     summary: "List builtin software/coding template declarations.",
     method: "repo.template.list",
-    commandClass: "repo-read",
     inputs: [],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "template-render",
     phase: "Preset-A",
     path: ["template", "render", "<ref>"],
     summary: "Render one builtin template without writing it.",
     method: "repo.template.render",
-    commandClass: "repo-read",
     positional: "templateRef",
     inputs: [
       cliInput(
@@ -608,32 +637,29 @@ export const presetCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "script-list",
     phase: "Preset-A",
     path: ["script", "list"],
     summary: "List executable builtin vertical script declarations.",
     method: "repo.script.list",
-    commandClass: "repo-read",
     inputs: [],
   }),
-  defineCliCommand({
+  defineRepoReadCommand({
     id: "script-inspect",
     phase: "Preset-A",
     path: ["script", "inspect", "<id>"],
     summary: "Inspect one builtin vertical script declaration and execution availability.",
     method: "repo.script.inspect",
-    commandClass: "repo-read",
     positional: "scriptId",
     inputs: [],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "script-run",
     phase: "Preset-A",
     path: ["script", "run", "<id>"],
     summary: "Run one declared builtin vertical script through its typed RepoCell host.",
     method: "repo.script.run",
-    commandClass: "repo-write",
     positional: "scriptId",
     positionalRegex: "^vertical:[a-z0-9][a-z0-9-]*:[a-z0-9][a-z0-9-]*$",
     actionDefaults: { schema: "vertical-script-action/v1", taskId: null, inputs: {}, dryRun: false },
@@ -661,13 +687,12 @@ export const presetCommands = Object.freeze([
       ),
     ],
   }),
-  defineCliCommand({
+  defineLedgerWriteCommand({
     id: "preset-run-start",
     phase: "Preset-B",
     path: ["script", "run", "preset:<id>/<entrypoint>"],
     summary: "Run one declared user preset entrypoint through the resident daemon.",
     method: "repo.preset.run.start",
-    commandClass: "repo-write",
     positional: "presetTarget",
     positionalFields: ["presetId", "entrypoint"],
     inputs: [
@@ -746,6 +771,7 @@ export const presetMethods = Object.freeze([
       requiresRepo: true,
       actionKind: command.id,
       commandClass: command.commandClass,
+      admission: command.admission,
       params: shape({ repo, payload: shape(fields) }),
     };
   }),
@@ -755,7 +781,7 @@ export const presetMethods = Object.freeze([
     method: "repo.preset.run.status",
     requiresRepo: true,
     actionKind: "preset-run-status",
-    commandClass: "repo-read",
+    ...repoReadCommandTopology,
     params: shape({ repo, payload: shape({ runId: "string", executor: "json?" }) }),
   },
 ] as const);


### PR DESCRIPTION
# English

## Summary

2.4 topology slice (dec_9C393CDA95B725A4BB178B2CC9, accepted by the user): topology becomes a declared axis instead of hand-written enforcement. All 117 daemon command descriptors declare `commandClass + admission {local, remote-center, remote-edge}` through named topology constructors; `admitRepoMode` no longer derives behavior from `mode × commandClass` but reads the descriptor route and checks the actual ingress source — its hand-written allowed branches, the `command.id === "task-start"` effective-descriptor overlay, and RepoCell's private `projection-rebuild` admission bypass are deleted. All nine entity kinds declare named residency facets (`{authored: ledger, live: runtime-local, ...}`) in kind authority. A new contract-tier test enumerates 117 × 3 = 351 cells (every cell admitted with a fixture or explicitly rejected) and a kind-authority test pins the exact residency shape of all nine kinds.

## Architectural Justification

- Production-Delta +343/-356 (net -13): every added line is a declaration replacing a hand-written branch or overlay; three bypasses are deleted. Census: commands=117, cells=351, `classMismatches: []`, `duplicates: []`.

## What Changed

- `packages/daemon/src/protocol/daemon-protocol-commands*.ts`: 117 descriptors via named topology constructors; task-start overlay removed.
- `packages/daemon/src/repo-mode.ts`: `admitRepoMode` reads descriptor admission; hand-written branches deleted.
- `packages/daemon/src/repo-cell*.ts`: projection-rebuild bypass deleted.
- `packages/kernel/src/domain/entity-kind-registry.ts`: residency facets on nine kinds; `explainEntityKind` projects it.
- Tests: `packages/daemon/test/command-admission.test.ts` (117×3 exhaustive, contract tier); `kind-authority-version.test.ts` extended.

## Gate Harvest / 门收割

Deleted-Production-Paths: admitRepoMode mode×commandClass hand-written branches; task-start effective-descriptor overlay; RepoCell projection-rebuild admission bypass; 117 scattered commandClass fields
Deleted-Gates-Fixtures: repo-mode tests asserting the hand-written allowed table replaced by descriptor-derived assertions
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +343/-356

### Optional Evidence Claims

## Task And Scope

- Harness task: task_1a28d3e3065d0811705c0c2b6e
- Branch: codex/catalog-topology
- Public scope: packages/daemon (protocol commands, repo-mode, repo-cell), packages/kernel (kind authority), tests
- Private planning/evidence updated: yes
- Out of scope: schema-sdk generator and `context` SDK surface (2.4 r3, removed from this slice); read-RPC facet declarations beyond observe.tail

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_1a28d3e3065d0811705c0c2b6e
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 2d301f17e1665423056a933cba48b01bd13b55d9
- Branch merge-base with `origin/main`: 2d301f17e1665423056a933cba48b01bd13b55d9
- Last `git fetch origin` time: 2026-08-26T05:03Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_1a28d3e3065d0811705c0c2b6e (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] `npm run check:local` green (worker run)
- [x] two affected integration files via `tools/dispatch-isolated-test.mjs --target docker` green
- [x] census output `{"commands":117,"originalClasses":117,"classMismatches":[],"duplicates":[]}`
- [x] CEO ruled the three authority gaps (context removed; admission owned by the daemon command directory; named residency facets) before this slice
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: nothing else; CI is the authority.

## Review Evidence

- Self-review: CEO wrote the decision with the user, ruled the ownership question (command directory, not entity Action catalog) and accepted the net-negative result.
- Reviewer subagent: Codex worker (sol) r1 audit + r2 implementation.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Admission is now only as correct as each descriptor's declaration; the exhaustive test guarantees coverage, not semantics — a wrong declaration is caught by the per-cell fixture, not by the census.

## References

- Task: task_1a28d3e3065d0811705c0c2b6e
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

2.4 拓扑切片(dec_9C393CDA95B725A4BB178B2CC9,泽宇认可):拓扑从手写执法变成声明轴。117 条 daemon command descriptor 全部经命名 topology constructor 声明 `commandClass + admission {local, remote-center, remote-edge}`;`admitRepoMode` 不再从 `mode × commandClass` 推导,只读 descriptor route 并核对实际 ingress source——其手写 allowed 分支、`command.id === "task-start"` effective-descriptor overlay、RepoCell 私有的 `projection-rebuild` admission 旁路全部删除。九个 entity kind 在 kind authority 声明命名 residency facet(`{authored: ledger, live: runtime-local, …}`)。新增 contract 级穷举测试覆盖 117 × 3 = 351 格(每格要么有夹具 admitted 要么显式 rejected),kind-authority 测试固定九 kind 的精确 residency 形状。

## 架构辩护

- Production-Delta +343/-356(净 -13):新增每一行都是替换手写分支/overlay 的声明;删掉三处旁路。普查:commands=117,cells=351,`classMismatches: []`,`duplicates: []`。

## 改动内容

- `packages/daemon/src/protocol/daemon-protocol-commands*.ts`:117 条 descriptor 经命名 topology constructor;删 task-start overlay。
- `packages/daemon/src/repo-mode.ts`:`admitRepoMode` 读 descriptor admission;手写分支删除。
- `packages/daemon/src/repo-cell*.ts`:删 projection-rebuild 旁路。
- `packages/kernel/src/domain/entity-kind-registry.ts`:九 kind residency facet;`explainEntityKind` 投影该字段。
- 测试:`packages/daemon/test/command-admission.test.ts`(117×3 穷举,contract 层);`kind-authority-version.test.ts` 扩充。

## 门收割 / Gate Harvest

- 删除的生产路径:见英文块
- 同 commit 删除的门 / fixture:断言手写 allowed 表的 repo-mode 测试改为 descriptor 派生断言
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_1a28d3e3065d0811705c0c2b6e
- 分支:codex/catalog-topology
- 公开范围:packages/daemon(protocol commands、repo-mode、repo-cell)、packages/kernel(kind authority)、测试
- 私有计划 / 证据是否已更新:yes
- 范围外:schema-sdk 生成器与 `context` SDK 面(2.4 r3,本切片移除);observe.tail 之外的读 RPC facet 声明

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_1a28d3e3065d0811705c0c2b6e
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:2d301f17e1665423056a933cba48b01bd13b55d9
- 当前分支与 `origin/main` 的 merge-base:2d301f17e1665423056a933cba48b01bd13b55d9
- 最近一次 `git fetch origin` 时间:2026-08-26T05:03Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_1a28d3e3065d0811705c0c2b6e
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] `npm run check:local` 绿(worker 跑)
- [x] 两个受影响 integration 文件经 `tools/dispatch-isolated-test.mjs --target docker` 绿
- [x] 普查输出 `{"commands":117,"originalClasses":117,"classMismatches":[],"duplicates":[]}`
- [x] CEO 在本切片前裁决了三个 authority gap(移除 context;admission 归 daemon command directory;命名 residency facet)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:无;以 CI 为权威。

## 审查证据

- 自查:CEO 与用户共同定了决策,裁决了归属问题(command directory 而非 entity Action catalog),验收净负结果。
- Reviewer subagent:Codex worker(sol)r1 审计 + r2 实现。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- admission 的正确性现在取决于每条 descriptor 的声明;穷举测试保证覆盖不保证语义——错误声明由每格夹具而非普查抓住。

## 关联材料

- 任务:task_1a28d3e3065d0811705c0c2b6e
- 证据:任务包 artifacts/reports
- 审查:本 PR
