### PR TITLE
fix(cli): keep runtime status --wait subscribed until dispatch terminal state (0.37)

### DIFF
--- a/packages/cli/src/cli-runtime-wait.ts
+++ b/packages/cli/src/cli-runtime-wait.ts
@@ -179,10 +179,11 @@ function recoverableSubscriptionFailure(error: unknown): boolean {
         : null,
     message = error instanceof Error ? error.message : String(error);
   return (
-    ["daemon_response_timeout", "ECONNREFUSED", "ECONNRESET", "ENOENT", "EPIPE", "ETIMEDOUT"].includes(String(code)) ||
+    ["daemon_response_timeout", "daemon_closed", "ECONNREFUSED", "ECONNRESET", "ENOENT", "EPIPE", "ETIMEDOUT"].includes(
+      String(code),
+    ) ||
     message === "daemon_unavailable" ||
-    message === "daemon_stream_unavailable" ||
-    message.startsWith("daemon closed before JSON-RPC response")
+    message === "daemon_stream_unavailable"
   );
 }
 
@@ -226,7 +227,9 @@ function runtimeDaemonGone(
         }
       : null,
     commandName = spawned ? "runtime-run" : "runtime-status",
-    hint = `The daemon process and socket are gone. Last known dispatch status: ${status}. Restart the daemon, then inspect the dispatch before deciding whether to run it again.`;
+    hint =
+      `The daemon process and socket are gone. Last known dispatch status: ${status}. ` +
+      "Restart the daemon, then inspect the dispatch before deciding whether to run it again.";
   return {
     schema: "command-receipt/v2",
     ok: false,
@@ -248,7 +251,10 @@ function runtimeDaemonGone(
 
 function taskDispatchDaemonGone(taskId: string, current: JsonObject | undefined, cause: string): JsonObject {
   const dispatches = Array.isArray(current?.dispatches) ? current.dispatches : [],
-    hint = `The daemon process and socket are gone. ${dispatches.length} last-known task dispatch status row${dispatches.length === 1 ? " is" : "s are"} attached. Restart the daemon, then inspect the task dispatches before deciding whether to run them again.`;
+    hint =
+      `The daemon process and socket are gone. ${dispatches.length} last-known task dispatch status ` +
+      `row${dispatches.length === 1 ? " is" : "s are"} attached. ` +
+      "Restart the daemon, then inspect the task dispatches before deciding whether to run them again.";
   return {
     schema: "command-receipt/v2",
     ok: false,
@@ -261,7 +267,9 @@ function taskDispatchDaemonGone(taskId: string, current: JsonObject | undefined,
     lastKnownDispatches: dispatches,
     error: { code: "daemon_gone", hint, cause },
     nextAction: hint,
-    summary: `runtime-status task ${taskId}: daemon_gone; ${dispatches.length} last-known dispatch status row${dispatches.length === 1 ? "" : "s"}`,
+    summary:
+      `runtime-status task ${taskId}: daemon_gone; ` +
+      `${dispatches.length} last-known dispatch status row${dispatches.length === 1 ? "" : "s"}`,
     exitCode: 1,
   };
 }

--- a/packages/cli/src/cli-runtime-wait.ts
+++ b/packages/cli/src/cli-runtime-wait.ts
@@ -4,9 +4,18 @@ import type { ThinCommand } from "./cli/thin-command.ts";
 import {
   consumeKnownError,
   openRuntimeStatusReader,
+  resolveLocalDaemonTarget,
   runCommandThroughDaemon,
   streamRuntimeThroughDaemon,
 } from "./daemon/client.ts";
+
+const reconnectBaseDelayMs = 250,
+  reconnectMaxDelayMs = 5_000;
+
+interface DaemonGone {
+  readonly kind: "daemon-gone";
+  readonly cause: string;
+}
 
 export async function waitForRuntime(
   command: ThinCommand,
@@ -16,50 +25,46 @@ export async function waitForRuntime(
   spawned?: JsonObject,
   target?: { readonly taskId: string; readonly dispatchId: string },
 ): Promise<JsonObject> {
-  const readCommand = {
-      ...command,
-      method: "repo.agentRuntime.sessions.read",
-      action: {
-        kind: "runtime-status",
-        ...(target ? target : { runtimeSessionId }),
-      },
-    },
-    read = () => runCommandThroughDaemon(readCommand);
-  let current = await read();
-  let detach: (() => void) | undefined;
-  if (current.ok !== true) return current;
-  if (stream)
-    try {
-      detach = await streamRuntimeThroughDaemon(command, runtimeSessionId, (value) =>
-        renderRuntimeFrames(value, writeActivity),
-      );
-    } catch (error) {
-      consumeKnownError(error);
-      writeActivity(`[stream] ${error instanceof Error ? error.message : String(error)}\n`);
-    }
   let statusReader: Awaited<ReturnType<typeof openRuntimeStatusReader>> | undefined;
-  if ((current as unknown as AgentRuntimeSessionResult).session.activity.outcome === null)
-    try {
-      statusReader = await openRuntimeStatusReader(command, runtimeSessionId);
-    } catch (error) {
-      consumeKnownError(error);
-    }
-  const readNext = async (): Promise<JsonObject> => {
-    if (!statusReader) return read();
-    try {
-      return await statusReader.read();
-    } catch (error) {
-      consumeKnownError(error);
-      statusReader.close();
-      statusReader = undefined;
-      return read();
-    }
-  };
+  let current: JsonObject | undefined,
+    detach: (() => void) | undefined,
+    streamStarted = false;
   try {
-    while ((current as unknown as AgentRuntimeSessionResult).session.activity.outcome === null) {
+    for (;;) {
+      const next = await readDaemonSubscription(
+        command,
+        async () => {
+          statusReader ??= await openRuntimeStatusReader(command, runtimeSessionId, target);
+          return statusReader.read();
+        },
+        () => {
+          statusReader?.close();
+          statusReader = undefined;
+        },
+      );
+      if (isDaemonGone(next))
+        return runtimeDaemonGone(
+          runtimeSessionId,
+          spawned,
+          target,
+          current as unknown as AgentRuntimeSessionResult | undefined,
+          next.cause,
+        );
+      if (next.ok !== true) return next;
+      current = next;
+      if (stream && !streamStarted) {
+        streamStarted = true;
+        try {
+          detach = await streamRuntimeThroughDaemon(command, runtimeSessionId, (value) =>
+            renderRuntimeFrames(value, writeActivity),
+          );
+        } catch (error) {
+          consumeKnownError(error);
+          writeActivity(`[stream] ${error instanceof Error ? error.message : String(error)}\n`);
+        }
+      }
+      if ((current as unknown as AgentRuntimeSessionResult).session.activity.outcome !== null) break;
       await new Promise((resolve) => setTimeout(resolve, 250));
-      current = await readNext();
-      if (current.ok !== true) return current;
     }
   } finally {
     statusReader?.close();
@@ -95,12 +100,16 @@ export async function waitForTaskDispatches(command: ThinCommand, taskId: string
     method: "repo.task.dispatches",
     action: { kind: "task-dispatches", taskId },
   };
-  let current = await runCommandThroughDaemon(readCommand);
-  if (current.ok !== true) return current;
-  while (current.status === "pending" || !taskDispatchesSettled(current)) {
-    await new Promise((resolve) => setTimeout(resolve, 250));
-    current = await runCommandThroughDaemon(readCommand);
+  let current: JsonObject | undefined;
+  for (;;) {
+    const next = await readDaemonSubscription(command, () =>
+      runCommandThroughDaemon(readCommand, () => undefined, { autostart: false }),
+    );
+    if (isDaemonGone(next)) return taskDispatchDaemonGone(taskId, current, next.cause);
+    current = next;
     if (current.ok !== true) return current;
+    if (current.status !== "pending" && taskDispatchesSettled(current)) break;
+    await new Promise((resolve) => setTimeout(resolve, 250));
   }
   const dispatches: readonly unknown[] = Array.isArray(current.dispatches) ? current.dispatches : [],
     finalDispatches = dispatches.filter(
@@ -136,6 +145,124 @@ export async function waitForTaskDispatches(command: ThinCommand, taskId: string
       outcome,
     ].join(" "),
     exitCode: outcome === "succeeded" ? 0 : 1,
+  };
+}
+
+async function readDaemonSubscription(
+  command: ThinCommand,
+  read: () => Promise<JsonObject>,
+  reset: () => void = () => undefined,
+): Promise<JsonObject | DaemonGone> {
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await read();
+    } catch (error) {
+      consumeKnownError(error);
+      reset();
+      if (!recoverableSubscriptionFailure(error)) throw error;
+      if (await daemonGone(command))
+        return { kind: "daemon-gone", cause: error instanceof Error ? error.message : String(error) };
+      await new Promise((resolve) => setTimeout(resolve, reconnectDelayMs(attempt++)));
+    }
+  }
+}
+
+function reconnectDelayMs(attempt: number): number {
+  return Math.min(reconnectBaseDelayMs * 2 ** attempt, reconnectMaxDelayMs);
+}
+
+function recoverableSubscriptionFailure(error: unknown): boolean {
+  const code =
+      error && typeof error === "object" && typeof (error as { readonly code?: unknown }).code === "string"
+        ? String((error as { readonly code: string }).code)
+        : null,
+    message = error instanceof Error ? error.message : String(error);
+  return (
+    ["daemon_response_timeout", "ECONNREFUSED", "ECONNRESET", "ENOENT", "EPIPE", "ETIMEDOUT"].includes(String(code)) ||
+    message === "daemon_unavailable" ||
+    message === "daemon_stream_unavailable" ||
+    message.startsWith("daemon closed before JSON-RPC response")
+  );
+}
+
+async function daemonGone(command: ThinCommand): Promise<boolean> {
+  const target = resolveLocalDaemonTarget({ rootDir: command.rootDir, repoIdOverride: command.repoId }),
+    { daemonProcessAlive, daemonSocketProbe, readDaemonPid } = await import("../../daemon/src/daemon-singleton.ts"),
+    pid = readDaemonPid(target.userRoot, target.daemonId),
+    livePid = pid !== null && daemonProcessAlive(pid),
+    liveSocket = await daemonSocketProbe(target.socketPath);
+  return !livePid && !liveSocket;
+}
+
+function isDaemonGone(value: JsonObject | DaemonGone): value is DaemonGone {
+  return "kind" in value && value.kind === "daemon-gone";
+}
+
+function runtimeDaemonGone(
+  runtimeSessionId: string,
+  spawned: JsonObject | undefined,
+  target: { readonly taskId: string; readonly dispatchId: string } | undefined,
+  current: AgentRuntimeSessionResult | undefined,
+  cause: string,
+): JsonObject {
+  const session = current?.session,
+    activity = session?.activity,
+    attempts = session?.attemptChain?.attempts ?? [],
+    attempt = attempts.find((candidate) => candidate.runtimeSessionId === runtimeSessionId),
+    association = session?.associations[0],
+    status = activity?.outcome ?? (session ? "running" : "unknown"),
+    lastKnownDispatch = session
+      ? {
+          taskId: target?.taskId ?? association?.taskId ?? null,
+          dispatchId: target?.dispatchId ?? attempt?.dispatchId ?? null,
+          runtimeSessionId,
+          status,
+          liveness: session.liveness,
+          outcome: activity?.outcome ?? null,
+          exitCode: activity?.exitCode ?? null,
+          classification: attempt?.classification ?? null,
+          fallbackState: attempt?.fallbackState ?? null,
+        }
+      : null,
+    commandName = spawned ? "runtime-run" : "runtime-status",
+    hint = `The daemon process and socket are gone. Last known dispatch status: ${status}. Restart the daemon, then inspect the dispatch before deciding whether to run it again.`;
+  return {
+    schema: "command-receipt/v2",
+    ok: false,
+    command: commandName,
+    outcome: "op_rejected",
+    origin: "cli",
+    code: "daemon_gone",
+    evidence: "rejection:daemon_gone",
+    runtimeSessionId,
+    ...(target ?? {}),
+    ...(spawned ? { spawn: spawned } : {}),
+    lastKnownDispatch,
+    error: { code: "daemon_gone", hint, cause },
+    nextAction: hint,
+    summary: `${commandName}: daemon_gone; last known dispatch status ${status}`,
+    exitCode: 1,
+  };
+}
+
+function taskDispatchDaemonGone(taskId: string, current: JsonObject | undefined, cause: string): JsonObject {
+  const dispatches = Array.isArray(current?.dispatches) ? current.dispatches : [],
+    hint = `The daemon process and socket are gone. ${dispatches.length} last-known task dispatch status row${dispatches.length === 1 ? " is" : "s are"} attached. Restart the daemon, then inspect the task dispatches before deciding whether to run them again.`;
+  return {
+    schema: "command-receipt/v2",
+    ok: false,
+    command: "runtime-status",
+    outcome: "op_rejected",
+    origin: "cli",
+    code: "daemon_gone",
+    evidence: "rejection:daemon_gone",
+    taskId,
+    lastKnownDispatches: dispatches,
+    error: { code: "daemon_gone", hint, cause },
+    nextAction: hint,
+    summary: `runtime-status task ${taskId}: daemon_gone; ${dispatches.length} last-known dispatch status row${dispatches.length === 1 ? "" : "s"}`,
+    exitCode: 1,
   };
 }
 

--- a/packages/cli/src/cli/thin-command.ts
+++ b/packages/cli/src/cli/thin-command.ts
@@ -1,5 +1,6 @@
 export const thinCliLocalErrorCodes = Object.freeze([
   "daemon_disconnect",
+  "daemon_gone",
   "daemon_target_conflict",
   "duplicate_field",
   "invalid_field",
@@ -30,27 +31,14 @@ import {
   thinCliCommands,
 } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
 import type { SafePath } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
-import {
-  accepted,
-  globalOption,
-  nonEmpty,
-  rejected,
-  stripGlobals,
-} from "./thin-command-flags.ts";
-import {
-  commandDomains,
-  unsupportedCommandHint,
-} from "./thin-command-help.ts";
+import { accepted, globalOption, nonEmpty, rejected, stripGlobals } from "./thin-command-flags.ts";
+import { commandDomains, unsupportedCommandHint } from "./thin-command-help.ts";
 import type { ThinHelpCatalogEntry } from "./thin-command-help.ts";
 import { deriveInputDirectory } from "./thin-command-inputs.ts";
 import { parseRouted } from "./thin-command-router.ts";
 import { parseResumeDispatch } from "./thin-command-runtime.ts";
 import { parseTask } from "./thin-command-task.ts";
-import type {
-  ProtocolCommand,
-  ThinCliInputDirectory,
-  ThinParseResult,
-} from "./thin-command-types.ts";
+import type { ProtocolCommand, ThinCliInputDirectory, ThinParseResult } from "./thin-command-types.ts";
 
 type LifecyclePublicationAction =
   | "task-create"
@@ -71,28 +59,15 @@ export function parseThinCommand(
     route =
       commands === daemonProtocolCommands
         ? resolveThinCliCommand(args)
-        : commands.find((entry) =>
-            entry.path.every((token, index) => args[index] === token),
-          ),
+        : commands.find((entry) => entry.path.every((token, index) => args[index] === token)),
     inputs = deriveInputDirectory(route);
-  if (
-    route?.id === "runtime-run" &&
-    args[2]?.startsWith("--") &&
-    args.includes("--resume-dispatch")
-  )
+  if (route?.id === "runtime-run" && args[2]?.startsWith("--") && args.includes("--resume-dispatch"))
     return parseResumeDispatch(rootDir, repoId, json, args, inputs);
   if (route?.id === "task-dispatches" && nonEmpty(args[2]) && args.length === 3)
-    return accepted(
-      rootDir,
-      repoId,
-      json,
-      { kind: "task-dispatches", taskId: args[2] },
-      "repo.task.dispatches",
-    );
+    return accepted(rootDir, repoId, json, { kind: "task-dispatches", taskId: args[2] }, "repo.task.dispatches");
   const routed = parseRouted(route, args, rootDir, repoId, json, inputs);
   if (routed) return routed;
-  if (!route || args[0] !== "task")
-    return rejected("unsupported_command", unsupportedCommandHint(args), json);
+  if (!route || args[0] !== "task") return rejected("unsupported_command", unsupportedCommandHint(args), json);
   return parseTaskRoute(route.id, args, rootDir, repoId, json, inputs);
 }
 
@@ -107,10 +82,7 @@ function parseTaskRoute(
   return parseTask(id, args, rootDir, repoId, json, inputs);
 }
 
-export function renderThinHelp(
-  catalog: readonly ThinHelpCatalogEntry[] = [],
-  domain?: string,
-): string {
+export function renderThinHelp(catalog: readonly ThinHelpCatalogEntry[] = [], domain?: string): string {
   const rows = [
       ...thinCliCommands.map(({ usage, summary, help }) => ({
         usage,
@@ -118,37 +90,25 @@ export function renderThinHelp(
         help,
       })),
     ],
-    visible = domain
-      ? rows.filter(({ usage }) => usage.split(" ")[1] === domain)
-      : rows,
+    visible = domain ? rows.filter(({ usage }) => usage.split(" ")[1] === domain) : rows,
     groups = commandDomains(),
     body = domain
       ? [
           `Commands for ${domain}:`,
-          ...visible.map(
-            ({ usage, summary, help }) =>
-              `  ${usage}\n    ${summary}${help ? `\n${help}` : ""}`,
-          ),
+          ...visible.map(({ usage, summary, help }) => `  ${usage}\n    ${summary}${help ? `\n${help}` : ""}`),
         ]
       : [
           "Commands:",
-          ...groups.map(
-            ({ name, count }) =>
-              `  ${name} (${count} command${count === 1 ? "" : "s"})`,
-          ),
+          ...groups.map(({ name, count }) => `  ${name} (${count} command${count === 1 ? "" : "s"})`),
           "",
           "Meta:",
           "  capabilities [--json] — Describe the contracted CLI command surface.",
           "  --version — Print the CLI package version.",
           "",
           "Use ha <domain> --help for the commands in a domain.",
-          ...rows
-            .filter(({ usage }) => usage.includes("--service"))
-            .map(({ usage }) => `  ${usage}`),
+          ...rows.filter(({ usage }) => usage.includes("--service")).map(({ usage }) => `  ${usage}`),
         ],
-    presetRows = catalog.length
-      ? ["", "Recommended presets:", ...catalog.map(renderPresetHelpEntry)]
-      : [];
+    presetRows = catalog.length ? ["", "Recommended presets:", ...catalog.map(renderPresetHelpEntry)] : [];
   return ["Harness Anything thin CLI", "", ...body, ...presetRows].join("\n");
 }
 

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -408,18 +408,22 @@ export async function streamRuntimeThroughDaemon(
 export async function openRuntimeStatusReader(
   command: ThinCommand,
   runtimeSessionId: string,
+  waitTarget?: { readonly taskId: string; readonly dispatchId: string },
 ): Promise<{ readonly read: () => Promise<JsonObject>; readonly close: () => void }> {
   const fleetCommand = {
     ...command,
     method: "repo.agentRuntime.sessions.read",
-    action: { kind: "runtime-status", runtimeSessionId },
+    action: { kind: "runtime-status", ...(waitTarget ?? { runtimeSessionId }) },
   } as ThinCommand;
   if (await fleetRuntimeRoute(fleetCommand))
-    return { read: () => runCommandThroughDaemon(fleetCommand), close: () => undefined };
-  const target = resolveLocalDaemonTarget({ rootDir: command.rootDir, repoIdOverride: command.repoId }),
+    return {
+      read: () => runCommandThroughDaemon(fleetCommand, () => undefined, { autostart: false }),
+      close: () => undefined,
+    };
+  const daemonTarget = resolveLocalDaemonTarget({ rootDir: command.rootDir, repoIdOverride: command.repoId }),
     { connectSocket, JsonRpcLineClient } = await import("../../../daemon/src/client/local-json-rpc-client.ts"),
     { currentDaemonProtocolVersion } = await import("../../../daemon/src/protocol/version.ts"),
-    socket = await connectSocket(target.socketPath, 2_000),
+    socket = await connectSocket(daemonTarget.socketPath, 2_000),
     client = new JsonRpcLineClient(socket, socket);
   try {
     await client.request("protocol.hello", { protocolVersion: currentDaemonProtocolVersion }, 30_000);
@@ -431,7 +435,7 @@ export async function openRuntimeStatusReader(
     read: () =>
       client.request(
         "repo.agentRuntime.sessions.read",
-        { repo: { repoId: target.repoId }, payload: { runtimeSessionId } },
+        { repo: { repoId: daemonTarget.repoId }, payload: waitTarget ?? { runtimeSessionId } },
         30_000,
       ),
     close: () => client.close(),

--- a/packages/cli/test/runtime-wait-reconnect.integration.test.ts
+++ b/packages/cli/test/runtime-wait-reconnect.integration.test.ts
@@ -1,0 +1,278 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { daemonPidPath } from "../../daemon/src/daemon-singleton.ts";
+import { localUserDaemonEndpoint } from "../../daemon/src/client/local-daemon-target.ts";
+
+const cli = path.resolve("packages/cli/src/index.ts"),
+  runtimeSessionId = "runtime-wait-reconnect";
+
+test("runtime status --wait reconnects after a protocol.hello deadline and returns the terminal dispatch", async () => {
+  const fixture = await openFixtureDaemon("slow-hello");
+  let allowHello = false,
+    terminal = false,
+    helloRequests = 0,
+    statusReads = 0;
+  fixture.onRequest = (socket, request) => {
+    if (request.method === "protocol.hello") {
+      helloRequests += 1;
+      if (allowHello) reply(socket, request.id, { ok: true });
+      return;
+    }
+    assert.equal(request.method, "repo.agentRuntime.sessions.read");
+    statusReads += 1;
+    reply(socket, request.id, runtimeStatus(terminal));
+    if (statusReads === 1) {
+      terminal = true;
+      socket.end();
+    }
+  };
+  const invocation = runWait(fixture);
+  try {
+    await delay(30_100);
+    assert.equal(invocation.closed, false, "--wait exited at the per-connection hello deadline");
+    allowHello = true;
+    const result = await invocation.result(10_000);
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.receipt.outcome, "succeeded");
+    assert.equal((result.receipt.result as Record<string, unknown>).text, "settled after reconnect");
+    assert.ok(helloRequests >= 3, `expected fresh hellos after timeout and stream loss, observed ${helloRequests}`);
+    assert.ok(
+      statusReads >= 2,
+      `expected the re-subscribed reader to observe running then terminal, observed ${statusReads}`,
+    );
+  } finally {
+    invocation.stop();
+    await fixture.close();
+  }
+});
+
+test("runtime status --wait returns daemon_gone with the last-known dispatch after pid and socket loss", async () => {
+  const fixture = await openFixtureDaemon("daemon-gone");
+  let statusReads = 0;
+  fixture.onRequest = (socket, request) => {
+    if (request.method === "protocol.hello") {
+      reply(socket, request.id, { ok: true });
+      return;
+    }
+    assert.equal(request.method, "repo.agentRuntime.sessions.read");
+    statusReads += 1;
+    if (statusReads === 1) {
+      reply(socket, request.id, runtimeStatus(false));
+      return;
+    }
+    fixture.die();
+  };
+  const invocation = runWait(fixture);
+  try {
+    const result = await invocation.result(10_000);
+    assert.equal(result.code, 1, result.stderr);
+    assert.equal(result.receipt.code, "daemon_gone");
+    assert.equal((result.receipt.error as Record<string, unknown>).code, "daemon_gone");
+    assert.deepEqual(result.receipt.lastKnownDispatch, {
+      taskId: "task-runtime-wait",
+      dispatchId: null,
+      runtimeSessionId,
+      status: "running",
+      liveness: "live",
+      outcome: null,
+      exitCode: null,
+      classification: null,
+      fallbackState: null,
+    });
+  } finally {
+    invocation.stop();
+    await fixture.close();
+  }
+});
+
+interface FixtureDaemon {
+  readonly root: string;
+  readonly userRoot: string;
+  readonly daemonId: string;
+  onRequest: (socket: net.Socket, request: RpcRequest) => void;
+  readonly die: () => void;
+  readonly close: () => Promise<void>;
+}
+
+interface RpcRequest {
+  readonly id: number;
+  readonly method: string;
+}
+
+async function openFixtureDaemon(daemonId: string): Promise<FixtureDaemon> {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-wait-")),
+    root = path.join(parent, "repo"),
+    userRoot = path.join(parent, "user"),
+    socketPath = localUserDaemonEndpoint(userRoot, daemonId),
+    sockets = new Set<net.Socket>();
+  mkdirSync(root, { recursive: true });
+  mkdirSync(userRoot, { recursive: true });
+  mkdirSync(path.dirname(socketPath), { recursive: true });
+  writeFileSync(
+    path.join(userRoot, "registry.json"),
+    JSON.stringify({
+      schema: "harness-daemon-registry/v1",
+      repos: [{ repoId: "runtime-wait", canonicalRoot: root, state: "enabled", mode: "local" }],
+    }),
+  );
+  writeFileSync(daemonPidPath(userRoot, daemonId), `${process.pid}\n`);
+  const fixture = {
+      root,
+      userRoot,
+      daemonId,
+      onRequest: () => undefined,
+      die: () => {
+        rmSync(daemonPidPath(userRoot, daemonId), { force: true });
+        if (server.listening) server.close();
+        for (const socket of sockets) socket.destroy();
+      },
+      close: async () => {
+        fixture.die();
+        await new Promise<void>((resolve) => {
+          if (!server.listening) resolve();
+          else server.close(() => resolve());
+        });
+        rmSync(parent, { recursive: true, force: true });
+      },
+    } satisfies FixtureDaemon,
+    server = net.createServer((socket) => {
+      sockets.add(socket);
+      socket.once("close", () => sockets.delete(socket));
+      socket.on("error", () => undefined);
+      let buffered = "";
+      socket.on("data", (chunk) => {
+        buffered += String(chunk);
+        for (;;) {
+          const newline = buffered.indexOf("\n");
+          if (newline < 0) break;
+          const line = buffered.slice(0, newline);
+          buffered = buffered.slice(newline + 1);
+          fixture.onRequest(socket, JSON.parse(line) as RpcRequest);
+        }
+      });
+    });
+  rmSync(socketPath, { force: true });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => resolve());
+  });
+  return fixture;
+}
+
+function runWait(fixture: FixtureDaemon): {
+  readonly closed: boolean;
+  readonly result: (timeoutMs: number) => Promise<InvocationResult>;
+  readonly stop: () => void;
+} {
+  const { HARNESS_DAEMON_ENDPOINT: _endpoint, HARNESS_DAEMON_REPO_ID: _repoId, ...baseEnv } = process.env,
+    child = spawn(
+      process.execPath,
+      [cli, "--root", fixture.root, "--json", "runtime", "status", runtimeSessionId, "--wait", "--no-stream"],
+      {
+        env: {
+          ...baseEnv,
+          HARNESS_DAEMON_USER_ROOT: fixture.userRoot,
+          HARNESS_DAEMON_ID: fixture.daemonId,
+          HARNESS_DAEMON_REPO_ID: "runtime-wait",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+  let closed = false,
+    stdout = "",
+    stderr = "";
+  child.stdout!.on("data", (chunk) => (stdout += String(chunk)));
+  child.stderr!.on("data", (chunk) => (stderr += String(chunk)));
+  const completion = new Promise<InvocationResult>((resolve) => {
+    child.once("close", (code) => {
+      closed = true;
+      resolve({ code, receipt: stdout.trim() ? (JSON.parse(stdout) as Record<string, unknown>) : {}, stderr });
+    });
+  });
+  return {
+    get closed() {
+      return closed;
+    },
+    result: (timeoutMs) => withTimeout(completion, child, timeoutMs),
+    stop: () => {
+      if (!closed) child.kill("SIGKILL");
+    },
+  };
+}
+
+interface InvocationResult {
+  readonly code: number | null;
+  readonly receipt: Record<string, unknown>;
+  readonly stderr: string;
+}
+
+async function withTimeout(
+  completion: Promise<InvocationResult>,
+  child: ChildProcess,
+  timeoutMs: number,
+): Promise<InvocationResult> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      completion,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          child.kill("SIGKILL");
+          reject(new Error(`runtime status --wait did not return within ${timeoutMs}ms`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function reply(socket: net.Socket, id: number, result: Record<string, unknown>): void {
+  socket.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
+}
+
+function runtimeStatus(terminal: boolean): Record<string, unknown> {
+  return {
+    ok: true,
+    status: "ready",
+    session: {
+      runtimeSessionId,
+      providerSessionId: "provider-wait",
+      instanceId: "fixture-runtime",
+      installationId: "fixture-installation",
+      kindId: "codex",
+      definitionSnapshotRef: "fixture-definition",
+      definitionSnapshot: {},
+      liveness: terminal ? "exited" : "live",
+      attachCapability: "supported",
+      streamCursor: "stream:0",
+      associations: [
+        {
+          taskId: "task-runtime-wait",
+          executionId: "execution-runtime-wait",
+          holder: null,
+          lease: null,
+        },
+      ],
+      activity: {
+        lastObservedAt: "2026-08-27T00:00:00.000Z",
+        outcome: terminal ? "succeeded" : null,
+        exitCode: terminal ? 0 : null,
+        resultRef: terminal ? "result:fixture" : null,
+      },
+    },
+    result: terminal ? { ref: "result:fixture", text: "settled after reconnect" } : null,
+    watermark: terminal ? 2 : 1,
+    sourceRevision: terminal ? 2 : 1,
+  };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/daemon/src/client/local-json-rpc-client.ts
+++ b/packages/daemon/src/client/local-json-rpc-client.ts
@@ -140,7 +140,7 @@ export class JsonRpcLineClient {
   }
   private readResponse(id: number): Promise<JsonRpcResponse> {
     return new Promise((resolve, reject) => {
-      if (this.closed) reject(new Error(`daemon closed before JSON-RPC response ${id}`));
+      if (this.closed) reject(daemonClosedError(id));
       else this.waiters.push({ id, resolve, reject });
     });
   }
@@ -165,7 +165,7 @@ export class JsonRpcLineClient {
   private onClosed(): void {
     this.closed = true;
     for (const waiter of this.waiters.splice(0))
-      waiter.reject(new Error(`daemon closed before JSON-RPC response ${waiter.id}`));
+      waiter.reject(daemonClosedError(waiter.id));
   }
 }
 
@@ -254,4 +254,8 @@ export function connectSocket(socketPath: string, timeoutMs: number): Promise<ne
 }
 export function jsonRpcRecord(value: unknown): value is JsonObject {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function daemonClosedError(id: number): Error & { readonly code: string } {
+  return Object.assign(new Error(`daemon closed before JSON-RPC response ${id}`), { code: "daemon_closed" });
 }


### PR DESCRIPTION
# English

## Summary

0.37: `ha runtime status <runtime> --wait` returned early with `daemon_response_timeout` whenever the daemon was too busy to answer `protocol.hello` within the per-connection 30s deadline, even though the worker was still running — five silent callback losses in one day. Ruling: the short per-connection hello deadline (dec_4F692A09D6A9E55411E5B49686 CH4) stays; `--wait` is a subscription and now treats hello timeouts and status-stream disconnects as recoverable: 250ms–5s backoff, reconnect, resubscribe, until the dispatch reaches a terminal state. Only when the daemon PID is dead and the socket unreachable does it return an explicit `daemon_gone` with the last known dispatch state. The exit-on-hello-timeout branch is deleted.

## Architectural Justification

- Not required: Production-Delta churn is below 200 lines.

## What Changed

- `packages/cli/src/daemon` wait path: reconnect/resubscribe loop with bounded backoff; `daemon_gone` requires PID dead + socket unreachable.
- Tests (+278): delayed-hello fixture daemon keeps `--wait` subscribed; dispatch settles → correct return; dead daemon → `daemon_gone`.

## Gate Harvest / 门收割

Deleted-Production-Paths: the `--wait` branch that exited on hello timeout / stream loss
Deleted-Gates-Fixtures: none (assertions for the old early exit replaced in the same commit; no gate or fixture file removed)
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +210/-107

### Optional Evidence Claims

## Task And Scope

- Harness task: task_90cd2677b166087c58faf85dc8
- Branch: codex/fix-wait
- Public scope: packages/cli/src/daemon (runtime status --wait), packages/cli/test
- Private planning/evidence updated: yes
- Out of scope: daemon-side dispatch stream durability (0.38); the 30s hello constant (unchanged by decision)

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_90cd2677b166087c58faf85dc8
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 233766f88af14a9cfc79a6a63aa5f2357dfc4968
- Branch merge-base with `origin/main`: 233766f88af14a9cfc79a6a63aa5f2357dfc4968
- Last `git fetch origin` time: 2026-08-26T16:49:25Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_90cd2677b166087c58faf85dc8 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] CLI wait tests green (worker run in `.worktrees/fix-wait`, worktree-local `node_modules`)
- [x] CEO ruling recorded in the task mission r2; CH4 of dec_4F692A09 untouched (constant and per-connection deadline unchanged)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; live confirmation comes from the next busy-daemon window (the CEO loop re-arms waits and observes no early return).

## Review Evidence

- Self-review: CEO hit the failure five times on 2026-08-26 and ground-truthed each against a live worker process.
- Reviewer subagent: Codex worker (gpt-5.6-sol), two rounds (r1 stopped at the decision checkpoint; r2 after ruling).
- Human review: pending
- Blocking findings: none

## Residual Risk

- A daemon that is alive but wedged keeps `--wait` subscribed indefinitely by design; the caller's own timeout bounds it.

## References

- Task: task_90cd2677b166087c58faf85dc8
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

0.37:`ha runtime status <runtime> --wait` 在 daemon 忙到 30s 内答不出 `protocol.hello` 时就带 `daemon_response_timeout` 提前返回,而 worker 仍在跑——一天五次回调静默失效。裁决:每连接的短 hello 死线(dec_4F692A09D6A9E55411E5B49686 CH4)保留;`--wait` 是订阅,现在把 hello 超时与 status 流断开当可恢复事件:250ms–5s 退避、重连、重订阅,直到 dispatch 终态;只有 daemon PID 不存活且 socket 不可达才返回明确 `daemon_gone` 并附最后已知 dispatch 状态。「hello 超时即退出」分支删除。

## 架构辩护

- 不需要:Production-Delta churn 低于 200 行。

## 改动内容

- `packages/cli/src/daemon` wait 路径:有界退避的重连/重订阅循环;`daemon_gone` 需 PID 死 + socket 不可达。
- 测试(+278):延迟 hello 的 fixture daemon 下 `--wait` 保持订阅;dispatch 落定后正确返回;daemon 真死返回 `daemon_gone`。

## 门收割 / Gate Harvest

- 删除的生产路径:`--wait` 里 hello 超时/流断即退出的分支
- 同 commit 删除的门 / fixture:none(旧提前退出的断言同 commit 替换;未删除门或 fixture 文件)
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_90cd2677b166087c58faf85dc8
- 分支:codex/fix-wait
- 公开范围:packages/cli/src/daemon(runtime status --wait)、packages/cli/test
- 私有计划 / 证据是否已更新:yes
- 范围外:daemon 侧 dispatch 流的 durable 性(0.38);30s hello 常量(按裁决不动)

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_90cd2677b166087c58faf85dc8
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:233766f88af14a9cfc79a6a63aa5f2357dfc4968
- 当前分支与 `origin/main` 的 merge-base:233766f88af14a9cfc79a6a63aa5f2357dfc4968
- 最近一次 `git fetch origin` 时间:2026-08-26T16:49:25Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_90cd2677b166087c58faf85dc8
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] CLI wait 测试绿(worker 在 `.worktrees/fix-wait` 跑,worktree 自有 `node_modules`)
- [x] CEO 裁决记录在任务 mission r2;dec_4F692A09 CH4 未动(常量与每连接死线不变)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;实机确认来自下一次 daemon 忙窗口(CEO loop 重挂 wait 观察不再提前返回)。

## 审查证据

- 自查:CEO 08-26 五次撞到该失效,每次都对照活 worker 进程核实。
- Reviewer subagent:Codex worker(gpt-5.6-sol),两轮(r1 在决策 checkpoint 停手;r2 裁决后)。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- daemon 活着但卡死时 `--wait` 按设计一直订阅;由调用方自己的超时兜底。

## 关联材料

- 任务:task_90cd2677b166087c58faf85dc8
- 证据:任务包 artifacts/reports
- 审查:本 PR

