### PR TITLE
fix(daemon): refuse shared-daemon start under runtime identity and reject auth self-links (0.40)

### DIFF
--- a/packages/cli/src/cli/thin-command.ts
+++ b/packages/cli/src/cli/thin-command.ts
@@ -1,4 +1,5 @@
 export const thinCliLocalErrorCodes = Object.freeze([
+  "daemon_start_runtime_forbidden",
   "daemon_disconnect",
   "daemon_gone",
   "daemon_target_conflict",

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -31,27 +31,6 @@ export {
 } from "../../../daemon/src/client/local-daemon-target.ts";
 export type { DaemonLaunchSpec } from "../../../daemon/src/client/daemon-autostart.ts";
 
-const autostartFailureCodes = [
-  "daemon_start_runtime_forbidden",
-  "daemon_spawn_not_found",
-  "daemon_spawn_permission",
-  "daemon_start_failed",
-  "daemon_bind_timeout",
-  "daemon_starting",
-] as const;
-export function runtimeDaemonStartRefusal(
-  env: NodeJS.ProcessEnv = process.env,
-): { readonly code: "daemon_start_runtime_forbidden"; readonly hint: string } | null {
-  const runtimeActor = env.HARNESS_ACTOR?.startsWith("agent:runtime-session:") === true;
-  if (env.HARNESS_TASK_BOUND !== "1" && !runtimeActor) return null;
-  return {
-    code: "daemon_start_runtime_forbidden",
-    hint: [
-      "A task-bound runtime cannot start the shared daemon because its HOME and PATH belong to the runtime instance.",
-      "Start the daemon from an operator shell with `ha daemon start --service`, then retry the worker command.",
-    ].join(" "),
-  };
-}
 // These values belong to the invoking runtime worker or its provider launch,
 // not to the resident daemon that owns the shared socket.
 const daemonRuntimeScopedEnvironmentKeys = [
@@ -88,14 +67,15 @@ export function cliDaemonServeLaunch(
     env,
   };
 }
-export function daemonAutostartFailureCode(error: unknown): string | null {
-  const code =
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    typeof (error as { readonly code?: unknown }).code === "string"
-      ? (error as { readonly code: string }).code
-      : null;
+export async function daemonAutostartFailureCode(error: unknown): Promise<string | null> {
+  const { autostartFailureCodes } = await import("../../../daemon/src/client/daemon-autostart.ts"),
+    code =
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      typeof (error as { readonly code?: unknown }).code === "string"
+        ? (error as { readonly code: string }).code
+        : null;
   return code !== null && (autostartFailureCodes as readonly string[]).includes(code) ? code : null;
 }
 // daemon_response_timeout proves one connection went unanswered within its deadline; the daemon being absent is a
@@ -128,30 +108,19 @@ async function withAutostart(
   request: () => Promise<JsonObject>,
   launch: () => DaemonLaunchSpec,
   socketPath: string,
-  autostart: boolean,
-  env: NodeJS.ProcessEnv,
+  options: { readonly autostart: boolean; readonly env: NodeJS.ProcessEnv },
 ): Promise<JsonObject> {
   try {
     return await request();
   } catch (error) {
-    if (!autostart) throw error;
-    const { DaemonAutostartError, ensureLocalDaemonRunning, isDaemonUnreachable } = await import(
-      "../../../daemon/src/client/daemon-autostart.ts"
-    );
-    const refusal = runtimeDaemonStartRefusal(env);
-    if (refusal && (isDaemonBuildStale(error) || isDaemonUnreachable(error)))
-      throw new DaemonAutostartError({ ok: false, ...refusal, attempts: 0 });
-    if (isDaemonBuildStale(error)) {
-      await waitForDaemonRestart(socketPath);
-      const restarted = await ensureLocalDaemonRunning({
-        socketPath,
-        launch,
-        onProgress: (progress) => process.stderr.write(`${progress.message}\n`),
-      });
-      if (!restarted.ok) throw new DaemonAutostartError(restarted);
-      return await request();
-    }
-    if (!isDaemonUnreachable(error)) throw error;
+    if (!options.autostart) throw error;
+    const { DaemonAutostartError, ensureLocalDaemonRunning, isDaemonUnreachable, runtimeDaemonStartRefusal } =
+      await import("../../../daemon/src/client/daemon-autostart.ts");
+    const buildStale = isDaemonBuildStale(error);
+    if (!buildStale && !isDaemonUnreachable(error)) throw error;
+    if (buildStale) await waitForDaemonRestart(socketPath);
+    const refusal = await runtimeDaemonStartRefusal(socketPath, options.env);
+    if (refusal) throw new DaemonAutostartError({ ok: false, ...refusal, attempts: 0 });
     const started = await ensureLocalDaemonRunning({
       socketPath,
       launch,
@@ -206,8 +175,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      autostart,
-      env,
+      { autostart, env },
     );
   }
   if (command.method.startsWith("daemon.runtimeInstance.")) {
@@ -231,8 +199,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      autostart,
-      env,
+      { autostart, env },
     );
   }
   const fleetSchedule = await fleetScheduleRoute(command, env);
@@ -250,7 +217,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      autostart,
+      { autostart, env },
     );
   }
   const fleetRuntime = await fleetRuntimeRoute(command, env);
@@ -268,8 +235,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      autostart,
-      env,
+      { autostart, env },
     );
   }
   const fleetTask = await fleetTaskRoute(command, env);
@@ -287,8 +253,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      autostart,
-      env,
+      { autostart, env },
     );
   }
   const fleetDoc = await fleetDocRoute(command, env);
@@ -306,8 +271,7 @@ export async function runCommandThroughDaemon(
         ),
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
-      autostart,
-      env,
+      { autostart, env },
     );
   }
   const target = {
@@ -345,8 +309,7 @@ export async function runCommandThroughDaemon(
     request,
     () => cliDaemonServeLaunch(target.userRoot, target.daemonId),
     target.socketPath,
-    autostart,
-    env,
+    { autostart, env },
   );
   result = await settleRepoWarming(result, request, target.userRoot, target.daemonId);
   if (command.action.kind !== "preset-run-start") return result;

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -32,12 +32,26 @@ export {
 export type { DaemonLaunchSpec } from "../../../daemon/src/client/daemon-autostart.ts";
 
 const autostartFailureCodes = [
+  "daemon_start_runtime_forbidden",
   "daemon_spawn_not_found",
   "daemon_spawn_permission",
   "daemon_start_failed",
   "daemon_bind_timeout",
   "daemon_starting",
 ] as const;
+export function runtimeDaemonStartRefusal(
+  env: NodeJS.ProcessEnv = process.env,
+): { readonly code: "daemon_start_runtime_forbidden"; readonly hint: string } | null {
+  const runtimeActor = env.HARNESS_ACTOR?.startsWith("agent:runtime-session:") === true;
+  if (env.HARNESS_TASK_BOUND !== "1" && !runtimeActor) return null;
+  return {
+    code: "daemon_start_runtime_forbidden",
+    hint: [
+      "A task-bound runtime cannot start the shared daemon because its HOME and PATH belong to the runtime instance.",
+      "Start the daemon from an operator shell with `ha daemon start --service`, then retry the worker command.",
+    ].join(" "),
+  };
+}
 // These values belong to the invoking runtime worker or its provider launch,
 // not to the resident daemon that owns the shared socket.
 const daemonRuntimeScopedEnvironmentKeys = [
@@ -115,6 +129,7 @@ async function withAutostart(
   launch: () => DaemonLaunchSpec,
   socketPath: string,
   autostart: boolean,
+  env: NodeJS.ProcessEnv,
 ): Promise<JsonObject> {
   try {
     return await request();
@@ -123,6 +138,9 @@ async function withAutostart(
     const { DaemonAutostartError, ensureLocalDaemonRunning, isDaemonUnreachable } = await import(
       "../../../daemon/src/client/daemon-autostart.ts"
     );
+    const refusal = runtimeDaemonStartRefusal(env);
+    if (refusal && (isDaemonBuildStale(error) || isDaemonUnreachable(error)))
+      throw new DaemonAutostartError({ ok: false, ...refusal, attempts: 0 });
     if (isDaemonBuildStale(error)) {
       await waitForDaemonRestart(socketPath);
       const restarted = await ensureLocalDaemonRunning({
@@ -189,6 +207,7 @@ export async function runCommandThroughDaemon(
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
       autostart,
+      env,
     );
   }
   if (command.method.startsWith("daemon.runtimeInstance.")) {
@@ -213,6 +232,7 @@ export async function runCommandThroughDaemon(
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
       autostart,
+      env,
     );
   }
   const fleetSchedule = await fleetScheduleRoute(command, env);
@@ -249,6 +269,7 @@ export async function runCommandThroughDaemon(
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
       autostart,
+      env,
     );
   }
   const fleetTask = await fleetTaskRoute(command, env);
@@ -267,6 +288,7 @@ export async function runCommandThroughDaemon(
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
       autostart,
+      env,
     );
   }
   const fleetDoc = await fleetDocRoute(command, env);
@@ -285,6 +307,7 @@ export async function runCommandThroughDaemon(
       () => cliDaemonServeLaunch(userRoot, daemonId),
       socketPath,
       autostart,
+      env,
     );
   }
   const target = {
@@ -323,6 +346,7 @@ export async function runCommandThroughDaemon(
     () => cliDaemonServeLaunch(target.userRoot, target.daemonId),
     target.socketPath,
     autostart,
+    env,
   );
   result = await settleRepoWarming(result, request, target.userRoot, target.daemonId);
   if (command.action.kind !== "preset-run-start") return result;

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -67,16 +67,14 @@ export function cliDaemonServeLaunch(
     env,
   };
 }
-export async function daemonAutostartFailureCode(error: unknown): Promise<string | null> {
-  const { autostartFailureCodes } = await import("../../../daemon/src/client/daemon-autostart.ts"),
-    code =
-      typeof error === "object" &&
-      error !== null &&
-      "code" in error &&
-      typeof (error as { readonly code?: unknown }).code === "string"
-        ? (error as { readonly code: string }).code
-        : null;
-  return code !== null && (autostartFailureCodes as readonly string[]).includes(code) ? code : null;
+export function daemonAutostartFailureCode(error: unknown): string | null {
+  const code =
+    error instanceof Error &&
+    error.name === "DaemonAutostartError" &&
+    typeof (error as Error & { readonly code?: unknown }).code === "string"
+      ? (error as Error & { readonly code: string }).code
+      : null;
+  return code;
 }
 // daemon_response_timeout proves one connection went unanswered within its deadline; the daemon being absent is a
 // different, checkable claim. Flattening the deadline into daemon_unavailable once sent a degraded waiting client
@@ -114,12 +112,18 @@ async function withAutostart(
     return await request();
   } catch (error) {
     if (!options.autostart) throw error;
-    const { DaemonAutostartError, ensureLocalDaemonRunning, isDaemonUnreachable, runtimeDaemonStartRefusal } =
-      await import("../../../daemon/src/client/daemon-autostart.ts");
+    const {
+      DaemonAutostartError,
+      ensureLocalDaemonRunning,
+      isDaemonUnreachable,
+      runtimeDaemonStartRefusalForUnavailable,
+    } = await import("../../../daemon/src/client/daemon-autostart.ts");
     const buildStale = isDaemonBuildStale(error);
     if (!buildStale && !isDaemonUnreachable(error)) throw error;
     if (buildStale) await waitForDaemonRestart(socketPath);
-    const refusal = await runtimeDaemonStartRefusal(socketPath, options.env);
+    // The failed connection (or the completed stale-daemon shutdown wait) already proves this
+    // socket unavailable. A second socket probe can consume its full timeout without adding evidence.
+    const refusal = runtimeDaemonStartRefusalForUnavailable(options.env);
     if (refusal) throw new DaemonAutostartError({ ok: false, ...refusal, attempts: 0 });
     const started = await ensureLocalDaemonRunning({
       socketPath,

--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -13,7 +13,12 @@ import { requestDaemonJsonRpcAt } from "../../../daemon/src/client/local-json-rp
 import type { DaemonShutdownExchange } from "../../../daemon/src/client/local-json-rpc-shutdown.ts";
 import { detachedProcessOptions, terminateProcess } from "../../../daemon/src/process-port.ts";
 import type { JsonObject } from "../../../daemon/src/protocol/json-rpc-types.ts";
-import { ensureLocalDaemonRunning, runtimeDaemonStartRefusal } from "../../../daemon/src/client/daemon-autostart.ts";
+import {
+  ensureLocalDaemonRunning,
+  isDaemonUnreachable,
+  runtimeDaemonStartRefusal,
+  runtimeDaemonStartRefusalForUnavailable,
+} from "../../../daemon/src/client/daemon-autostart.ts";
 import { readDaemonPid, startDaemon } from "../../../daemon/src/runtime.ts";
 import {
   daemonProcessAlive,
@@ -106,9 +111,18 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
           ),
           2,
         );
-      const running = await status(userRoot, daemonId).catch(() => null);
+      let running: Record<string, unknown> | null = null,
+        unavailable = false;
+      try {
+        running = await status(userRoot, daemonId);
+      } catch (error) {
+        unavailable = isDaemonUnreachable(error);
+        consumeKnownError(error);
+      }
       if (running?.ok === true) return finish(running, 0);
-      const refusal = await runtimeDaemonStartRefusal(localUserDaemonEndpoint(userRoot, daemonId));
+      const refusal = unavailable
+        ? runtimeDaemonStartRefusalForUnavailable()
+        : await runtimeDaemonStartRefusal(localUserDaemonEndpoint(userRoot, daemonId));
       if (refusal) return finish(daemonFailure("daemon-start", "daemon_start_runtime_forbidden", refusal.hint), 1);
       const started = await ensureLocalDaemonRunning({
         socketPath: localUserDaemonEndpoint(userRoot, daemonId),

--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -13,7 +13,7 @@ import { requestDaemonJsonRpcAt } from "../../../daemon/src/client/local-json-rp
 import type { DaemonShutdownExchange } from "../../../daemon/src/client/local-json-rpc-shutdown.ts";
 import { detachedProcessOptions, terminateProcess } from "../../../daemon/src/process-port.ts";
 import type { JsonObject } from "../../../daemon/src/protocol/json-rpc-types.ts";
-import { ensureLocalDaemonRunning } from "../../../daemon/src/client/daemon-autostart.ts";
+import { ensureLocalDaemonRunning, runtimeDaemonStartRefusal } from "../../../daemon/src/client/daemon-autostart.ts";
 import { readDaemonPid, startDaemon } from "../../../daemon/src/runtime.ts";
 import {
   daemonProcessAlive,
@@ -23,7 +23,7 @@ import {
   releaseDaemonSingletonLock,
 } from "../../../daemon/src/daemon-singleton.ts";
 import { daemonBuildStamp } from "../../../daemon/src/build-identity.ts";
-import { cliDaemonServeLaunch, consumeKnownError, runtimeDaemonStartRefusal } from "./client.ts";
+import { cliDaemonServeLaunch, consumeKnownError } from "./client.ts";
 import { daemonRepoModeWords } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
 import { firstCliCommandIndex } from "../cli/thin-command.ts";
 const fleetNumber = { port: /^(?:0|[1-9][0-9]{0,4})$/u, quota: /^[1-9][0-9]{0,15}$/u };
@@ -92,8 +92,9 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
       return finish(result, result.ok === true ? 0 : 1);
     }
     if (command === "serve") {
-      const refusal = runtimeDaemonStartRefusal();
-      return refusal ? finish(daemonFailure("daemon-serve", refusal.code, refusal.hint), 1) : serve(userRoot, daemonId, finish);
+      const refusal = await runtimeDaemonStartRefusal(localUserDaemonEndpoint(userRoot, daemonId));
+      if (refusal) return finish(daemonFailure("daemon-serve", "daemon_start_runtime_forbidden", refusal.hint), 1);
+      return serve(userRoot, daemonId, finish);
     }
     if (command === "start") {
       if (!argv.includes("--service"))
@@ -105,10 +106,10 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
           ),
           2,
         );
-      const refusal = runtimeDaemonStartRefusal();
-      if (refusal) return finish(daemonFailure("daemon-start", refusal.code, refusal.hint), 1);
       const running = await status(userRoot, daemonId).catch(() => null);
       if (running?.ok === true) return finish(running, 0);
+      const refusal = await runtimeDaemonStartRefusal(localUserDaemonEndpoint(userRoot, daemonId));
+      if (refusal) return finish(daemonFailure("daemon-start", "daemon_start_runtime_forbidden", refusal.hint), 1);
       const started = await ensureLocalDaemonRunning({
         socketPath: localUserDaemonEndpoint(userRoot, daemonId),
         launch: () => cliDaemonServeLaunch(userRoot, daemonId),

--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -23,7 +23,7 @@ import {
   releaseDaemonSingletonLock,
 } from "../../../daemon/src/daemon-singleton.ts";
 import { daemonBuildStamp } from "../../../daemon/src/build-identity.ts";
-import { cliDaemonServeLaunch, consumeKnownError } from "./client.ts";
+import { cliDaemonServeLaunch, consumeKnownError, runtimeDaemonStartRefusal } from "./client.ts";
 import { daemonRepoModeWords } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
 import { firstCliCommandIndex } from "../cli/thin-command.ts";
 const fleetNumber = { port: /^(?:0|[1-9][0-9]{0,4})$/u, quota: /^[1-9][0-9]{0,15}$/u };
@@ -91,7 +91,10 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
       );
       return finish(result, result.ok === true ? 0 : 1);
     }
-    if (command === "serve") return serve(userRoot, daemonId, finish);
+    if (command === "serve") {
+      const refusal = runtimeDaemonStartRefusal();
+      return refusal ? finish(daemonFailure("daemon-serve", refusal.code, refusal.hint), 1) : serve(userRoot, daemonId, finish);
+    }
     if (command === "start") {
       if (!argv.includes("--service"))
         return finish(
@@ -102,6 +105,8 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
           ),
           2,
         );
+      const refusal = runtimeDaemonStartRefusal();
+      if (refusal) return finish(daemonFailure("daemon-start", refusal.code, refusal.hint), 1);
       const running = await status(userRoot, daemonId).catch(() => null);
       if (running?.ok === true) return finish(running, 0);
       const started = await ensureLocalDaemonRunning({

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -59,7 +59,7 @@ export async function main(argv: readonly string[] = process.argv.slice(2)): Pro
     emit(receipt, parsed.command.json);
     return Number.isInteger(receipt.exitCode) ? Number(receipt.exitCode) : receipt.ok === true ? 0 : 1;
   } catch (error) {
-    const autostartCode = daemonAutostartFailureCode(error),
+    const autostartCode = await daemonAutostartFailureCode(error),
       timeoutCode = daemonResponseTimeoutCode(error),
       targetCode = daemonTargetFailureCode(error),
       buildStaleCode = daemonBuildStaleCode(error),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -59,7 +59,7 @@ export async function main(argv: readonly string[] = process.argv.slice(2)): Pro
     emit(receipt, parsed.command.json);
     return Number.isInteger(receipt.exitCode) ? Number(receipt.exitCode) : receipt.ok === true ? 0 : 1;
   } catch (error) {
-    const autostartCode = await daemonAutostartFailureCode(error),
+    const autostartCode = daemonAutostartFailureCode(error),
       timeoutCode = daemonResponseTimeoutCode(error),
       targetCode = daemonTargetFailureCode(error),
       buildStaleCode = daemonBuildStaleCode(error),

--- a/packages/cli/test/daemon-autostart-cli.test.ts
+++ b/packages/cli/test/daemon-autostart-cli.test.ts
@@ -48,14 +48,17 @@ test("registered workspace CLI command auto-starts the daemon, retries, and succ
   } finally { rmSync(fixture.parent, { recursive: true, force: true }); }
 });
 
-test("autostart daemon does not inherit runtime worker environment", (context) => {
+test("task-bound runtime identity cannot autostart the shared daemon", (context) => {
   const fixture = setup(),
     repoId = "clean-autostart",
     endpoint = localUserDaemonEndpoint(fixture.userRoot, "default"),
+    workerHome = path.join(fixture.parent, "worker", "home"),
     workerEnv = {
       ...cliEnv(fixture.root, fixture.userRoot),
-      CODEX_HOME: path.join(fixture.parent, "worker", ".codex"),
-      CLAUDE_CONFIG_DIR: path.join(fixture.parent, "worker", ".claude"),
+      HOME: workerHome,
+      PATH: [path.join(fixture.parent, "worker", "arg0"), process.env.PATH ?? ""].join(path.delimiter),
+      CODEX_HOME: path.join(workerHome, ".codex"),
+      CLAUDE_CONFIG_DIR: path.join(workerHome, ".claude"),
       ANTHROPIC_API_KEY: "worker-anthropic-secret",
       ANTHROPIC_BASE_URL: "https://anthropic.worker.invalid",
       OPENAI_API_KEY: "worker-openai-secret",
@@ -67,37 +70,38 @@ test("autostart daemon does not inherit runtime worker environment", (context) =
       HARNESS_DAEMON_ENDPOINT: endpoint,
       HARNESS_DAEMON_ID: "default",
       HARNESS_DAEMON_REPO_ID: repoId,
+      HARNESS_TASK_BOUND: "1",
     };
   try {
     registerDaemonRepo({ canonicalRoot: fixture.root, repoId, userRoot: fixture.userRoot, createConvenienceLinks: false });
-    const result = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "task", "list"], {
+    const denied = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "task", "list"], {
       encoding: "utf8",
       env: workerEnv,
     });
-    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
-    assert.equal((JSON.parse(result.stdout) as { readonly outcome?: string }).outcome, "applied");
-    const pid = readDaemonPid(fixture.userRoot, "default");
-    assert.ok(pid, "autostart must leave a resident daemon pid file");
-    const processEnvironment = execFileSync("ps", ["eww", "-p", String(pid)], { encoding: "utf8" });
-    const forbidden = [
-      "CODEX_HOME",
-      "CLAUDE_CONFIG_DIR",
-      "ANTHROPIC_API_KEY",
-      "ANTHROPIC_BASE_URL",
-      "OPENAI_API_KEY",
-      "OPENAI_BASE_URL",
-      "CLAUDE_CODE_SESSION_ID",
-      "CODEX_THREAD_ID",
-      "CODEX_SESSION_ID",
-      "HARNESS_ACTOR",
-      "HARNESS_DAEMON_ENDPOINT",
-      "HARNESS_DAEMON_ID",
-      "HARNESS_DAEMON_REPO_ID",
-      "HARNESS_DAEMON_USER_ROOT",
-    ],
-      leaked = forbidden.filter((name) => new RegExp(`(?:^|\\s)${name}=`, "u").test(processEnvironment));
-    context.diagnostic(`ps eww -p ${pid} runtime-scoped env matches: ${JSON.stringify(leaked)}`);
-    assert.deepEqual(leaked, []);
+    assert.notEqual(denied.status, 0, `${denied.stderr}\n${denied.stdout}`);
+    const refusal = JSON.parse(denied.stdout) as { readonly error?: { readonly code?: string; readonly hint?: string } };
+    assert.equal(refusal.error?.code, "daemon_start_runtime_forbidden");
+    assert.match(String(refusal.error?.hint), /operator shell/u);
+    assert.equal(readDaemonPid(fixture.userRoot, "default"), null, "a runtime caller must not claim the daemon slot");
+
+    const explicitStart = spawnSync(
+      process.execPath,
+      [cli, "--root", fixture.root, "--json", "daemon", "start", "--service"],
+      { encoding: "utf8", env: workerEnv },
+    );
+    assert.notEqual(explicitStart.status, 0);
+    assert.equal(
+      (JSON.parse(explicitStart.stdout) as { readonly error?: { readonly code?: string } }).error?.code,
+      "daemon_start_runtime_forbidden",
+    );
+    assert.equal(run(fixture.root, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
+    const available = spawnSync(process.execPath, [cli, "--root", fixture.root, "--json", "task", "list"], {
+      encoding: "utf8",
+      env: workerEnv,
+    });
+    assert.equal(available.status, 0, `${available.stderr}\n${available.stdout}`);
+    assert.equal((JSON.parse(available.stdout) as { readonly outcome?: string }).outcome, "applied");
+    context.diagnostic(`task-bound refusal=${refusal.error?.code}; existing daemon request=applied`);
   } finally {
     stop(fixture.root, fixture.userRoot);
     rmSync(fixture.parent, { recursive: true, force: true });

--- a/packages/cli/test/daemon-stop-identity.test.ts
+++ b/packages/cli/test/daemon-stop-identity.test.ts
@@ -26,8 +26,14 @@ test("a daemon that rejects daemon.stop still stops through the signal fallback"
     assert.equal(stopped.ok, true, JSON.stringify(stopped));
     assert.notEqual(stopped.code, "daemon_stop_timeout");
     await waitForExit(fixture.daemonPid);
-    assert.equal(existsSync(daemonPidPath(fixture.userRoot, fixture.daemonId)), false, "the fallback stop must still clear the pid file");
-  } finally { await cleanup(fixture); }
+    assert.equal(
+      existsSync(daemonPidPath(fixture.userRoot, fixture.daemonId)),
+      false,
+      "the fallback stop must still clear the pid file",
+    );
+  } finally {
+    await cleanup(fixture);
+  }
 });
 
 test("a wedged daemon reports observed state in the timeout and stops through --force", async () => {
@@ -41,19 +47,29 @@ test("a wedged daemon reports observed state in the timeout and stops through --
     assert.match(hint, /process alive/u, hint);
     assert.match(hint, /never answered the handshake/u, hint);
     assert.match(hint, /ha daemon stop --force/u, "the hint must name the supported escalation");
-    assert.ok(existsSync(daemonPidPath(fixture.userRoot, fixture.daemonId)), "a timeout must not clear bookkeeping the process still holds");
+    assert.ok(
+      existsSync(daemonPidPath(fixture.userRoot, fixture.daemonId)),
+      "a timeout must not clear bookkeeping the process still holds",
+    );
 
     const forced = run(fixture, ["daemon", "stop", "--force", "--json"]);
     assert.equal(forced.ok, true, JSON.stringify(forced));
     assert.equal(forced.forced, true);
     await waitForExit(fixture.daemonPid);
-    assert.equal(existsSync(daemonPidPath(fixture.userRoot, fixture.daemonId)), false, "force must release the pid file");
-  } finally { await cleanup(fixture); }
+    assert.equal(
+      existsSync(daemonPidPath(fixture.userRoot, fixture.daemonId)),
+      false,
+      "force must release the pid file",
+    );
+  } finally {
+    await cleanup(fixture);
+  }
 });
 
 test("force refuses to signal a pid the daemon slot no longer claims", async () => {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-stop-replaced-"));
-  const userRoot = path.join(parent, "user"), daemonId = "replaced";
+  const userRoot = path.join(parent, "user"),
+    daemonId = "replaced";
   try {
     const innocent = spawn(process.execPath, ["-e", "setInterval(() => {}, 60000)"]);
     assert.ok(innocent.pid, "the innocent stand-in must have a pid");
@@ -66,33 +82,63 @@ test("force refuses to signal a pid the daemon slot no longer claims", async () 
     assert.equal(receipt.code, "daemon_replaced");
     assert.equal(await alive(innocent.pid), true, "a pid the slot no longer claims must not be signalled");
     innocent.kill("SIGKILL");
-  } finally { rmSync(parent, { recursive: true, force: true }); }
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
 });
 
+// Codex uses stdin EOF to delimit its `-` prompt, so the provider stand-in starts emitting only
+// after EOF. A second child deliberately keeps daemon-owned stdio open and must exit when those
+// pipes close; that positive control proves the fixture can distinguish process-group survival
+// from the worker-host's durable output path.
 test(
   "force stopping the daemon leaves its detached runtime worker alive",
   { skip: process.platform === "win32" ? "requires POSIX detached process-group semantics" : false },
   async () => {
     const fixture = await spawnRuntimeOwningDaemon();
     try {
+      await waitForTextCount(fixture.streamPath, '"kind":"provider_event"', 1);
       assert.equal(await alive(fixture.workerPid), true, "the runtime worker must be live before daemon stop");
+      assert.equal(await alive(fixture.coupledPid), true, "the stdio-coupled control must be live before daemon stop");
       const forced = run(fixture, ["daemon", "stop", "--force", "--json"]);
       assert.equal(forced.ok, true, JSON.stringify(forced));
+      assert.match(String(forced.summary), /SIGKILL/u, "the fixture must exercise forceStopDaemon's SIGKILL path");
       await waitForExit(fixture.daemonPid);
-      assert.equal(await alive(fixture.workerPid), true, "daemon stop must not signal the runtime worker process group");
+      await waitForExit(fixture.coupledPid);
+      const providerEventsAfterDaemonExit = textCount(fixture.streamPath, '"kind":"provider_event"');
+      assert.equal(
+        await alive(fixture.workerPid),
+        true,
+        "the detached runtime worker must keep persisting provider output after daemon SIGKILL",
+      );
+      await waitForTextCount(fixture.streamPath, '"kind":"provider_event"', providerEventsAfterDaemonExit + 1);
     } finally {
       try {
         process.kill(-fixture.workerPid, "SIGTERM");
       } catch {
         // The worker may have exited between the assertion and cleanup.
       }
+      try {
+        process.kill(fixture.coupledPid, "SIGKILL");
+      } catch {
+        /* the positive control already exited */
+      }
       await cleanup(fixture);
     }
   },
 );
 
-interface Fixture { readonly parent: string; readonly userRoot: string; readonly daemonId: string; readonly daemonPid: number }
-interface RuntimeFixture extends Fixture { readonly workerPid: number }
+interface Fixture {
+  readonly parent: string;
+  readonly userRoot: string;
+  readonly daemonId: string;
+  readonly daemonPid: number;
+}
+interface RuntimeFixture extends Fixture {
+  readonly workerPid: number;
+  readonly coupledPid: number;
+  readonly streamPath: string;
+}
 
 async function spawnRuntimeOwningDaemon(): Promise<RuntimeFixture> {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-stop-runtime-worker-")),
@@ -100,30 +146,38 @@ async function spawnRuntimeOwningDaemon(): Promise<RuntimeFixture> {
     daemonId = "runtime-worker",
     rootDir = path.join(parent, "repo"),
     workerPidPath = path.join(parent, "worker.pid"),
+    coupledPidPath = path.join(parent, "coupled.pid"),
     script = path.join(parent, "runtime-daemon.mjs"),
     launcher = path.join(parent, "launcher.mjs"),
     socketPath = localUserDaemonEndpoint(userRoot, daemonId),
     pidPath = daemonPidPath(userRoot, daemonId),
+    streamPath = path.join(rootDir, ".harness", "runtime", "dispatches", "dispatch_111111111111111111111111.jsonl"),
     runtimeModule = pathToFileURL(path.resolve("packages/daemon/src/runtime-spawn-process.ts")).href;
   mkdirSync(userRoot, { recursive: true });
   mkdirSync(path.dirname(socketPath), { recursive: true });
   writeFileSync(
     script,
     `import net from "node:net";
-import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { launchNative } from ${JSON.stringify(runtimeModule)};
-const [socketPath, pidPath, rootDir, workerPidPath] = process.argv.slice(2);
+const [socketPath, pidPath, rootDir, workerPidPath, coupledPidPath] = process.argv.slice(2);
 const dispatchId = "dispatch_111111111111111111111111";
 const streamRoot = path.join(rootDir, ".harness", "runtime", "dispatches");
 mkdirSync(streamRoot, { recursive: true });
 writeFileSync(path.join(streamRoot, dispatchId + ".jsonl"), "{}\\n");
-const runtime = launchNative({ executablePath: process.execPath, args: ["-e", "setInterval(() => undefined, 60000)"], env: process.env, cwd: rootDir, prompt: "hold" }, { rootDir, dispatchId });
+const providerScript = 'process.stdin.resume(); process.stdin.once("end", () => { let sequence = 0; setInterval(() => process.stdout.write(JSON.stringify({ type: "item.updated", sequence: sequence += 1 }) + "\\\\n"), 20); }); process.stdout.on("error", () => process.exit(3));';
+const runtime = launchNative({ executablePath: process.execPath, args: ["-e", providerScript], env: process.env, cwd: rootDir, prompt: "hold" }, { rootDir, dispatchId });
+runtime.onOutput((_chunk, persisted) => { if (!persisted) appendFileSync(path.join(streamRoot, dispatchId + ".jsonl"), '{"kind":"provider_event"}\\n'); });
+const coupled = spawn(process.execPath, ["-e", 'process.stdin.resume(); process.stdin.once("end", () => process.exit(3)); setInterval(() => process.stdout.write("control\\\\n"), 20); process.stdout.on("error", () => process.exit(3));'], { stdio: ["pipe", "pipe", "ignore"] });
+coupled.stdout.resume();
 writeFileSync(workerPidPath, String(runtime.pid));
+writeFileSync(coupledPidPath, String(coupled.pid));
 writeFileSync(pidPath, process.pid + "\\n");
 const server = net.createServer(() => undefined);
 server.listen(socketPath);
-process.on("SIGTERM", () => { server.close(); try { unlinkSync(socketPath); } catch {} try { unlinkSync(pidPath); } catch {} process.exit(0); });
+process.on("SIGTERM", () => undefined);
 `,
     "utf8",
   );
@@ -136,34 +190,53 @@ child.unref();
     "utf8",
   );
   const nodeOptions = [process.env.NODE_OPTIONS, "--experimental-strip-types"].filter(Boolean).join(" "),
-    launched = spawnSync(process.execPath, [launcher, socketPath, pidPath, rootDir, workerPidPath], {
+    launched = spawnSync(process.execPath, [launcher, socketPath, pidPath, rootDir, workerPidPath, coupledPidPath], {
       encoding: "utf8",
       env: { ...process.env, NODE_OPTIONS: nodeOptions },
       timeout: 10_000,
     });
   assert.equal(launched.status, 0, launched.stderr);
   const daemonPid = await waitForPidFile(pidPath, socketPath),
-    workerPid = await waitForPidFile(workerPidPath);
-  return { parent, userRoot, daemonId, daemonPid, workerPid };
+    workerPid = await waitForPidFile(workerPidPath),
+    coupledPid = await waitForPidFile(coupledPidPath);
+  return { parent, userRoot, daemonId, daemonPid, workerPid, coupledPid, streamPath };
 }
 
 async function spawnLegacyDaemon(daemonId: string): Promise<Fixture> {
-  const parent = mkdtempSync(path.join(tmpdir(), `ha-stop-${daemonId}-`)), userRoot = path.join(parent, "user");
+  const parent = mkdtempSync(path.join(tmpdir(), `ha-stop-${daemonId}-`)),
+    userRoot = path.join(parent, "user");
   mkdirSync(userRoot, { recursive: true });
-  const script = path.join(parent, "legacy-daemon.mjs"), launcher = path.join(parent, "launcher.mjs");
+  const script = path.join(parent, "legacy-daemon.mjs"),
+    launcher = path.join(parent, "launcher.mjs");
   writeFileSync(script, LEGACY_DAEMON, "utf8");
   // A real resident daemon is started by a launcher that exits (daemon start --service, GUI
   // restart): the daemon is orphaned, parented by init, and reaped the moment it dies. Spawning
   // the stub the same way keeps an exited stub from lingering as a zombie of this test process
   // while it is blocked inside a synchronous CLI call.
-  writeFileSync(launcher, `import { spawn } from "node:child_process";\nconst child = spawn(process.execPath, [${JSON.stringify(script)}, ...process.argv.slice(2)], { stdio: "ignore", detached: true });\nchild.unref();\n`, "utf8");
+  writeFileSync(
+    launcher,
+    `import { spawn } from "node:child_process";\nconst child = spawn(process.execPath, [${JSON.stringify(script)}, ...process.argv.slice(2)], { stdio: "ignore", detached: true });\nchild.unref();\n`,
+    "utf8",
+  );
   const socketPath = localUserDaemonEndpoint(userRoot, daemonId);
   mkdirSync(path.dirname(socketPath), { recursive: true });
-  const launched = spawnSync(process.execPath, [launcher, daemonId === "wedge" ? "wedge" : "legacy", socketPath, daemonPidPath(userRoot, daemonId)], { encoding: "utf8", timeout: 10_000 });
+  const launched = spawnSync(
+    process.execPath,
+    [launcher, daemonId === "wedge" ? "wedge" : "legacy", socketPath, daemonPidPath(userRoot, daemonId)],
+    { encoding: "utf8", timeout: 10_000 },
+  );
   assert.equal(launched.status, 0, launched.stderr);
   const daemonPid = await new Promise<number>((resolve, reject) => {
     const deadline = Date.now() + 10_000;
-    const poll = async () => { const pid = readDaemonPid(userRoot, daemonId); if (pid !== null && await socketAccepting(socketPath)) resolve(pid); else if (Date.now() > deadline) reject(new Error("legacy daemon never became socket-ready")); else setTimeout(() => { void poll(); }, 20); };
+    const poll = async () => {
+      const pid = readDaemonPid(userRoot, daemonId);
+      if (pid !== null && (await socketAccepting(socketPath))) resolve(pid);
+      else if (Date.now() > deadline) reject(new Error("legacy daemon never became socket-ready"));
+      else
+        setTimeout(() => {
+          void poll();
+        }, 20);
+    };
     void poll();
   });
   return { parent, userRoot, daemonId, daemonPid };
@@ -198,16 +271,53 @@ setTimeout(() => server.listen(socketPath), 2_000);
 process.on("SIGTERM", () => { if (mode === "wedge") return; server.close(); try { unlinkSync(socketPath); } catch {} try { unlinkSync(pidPath); } catch {} process.exit(0); });
 `;
 type Target = { readonly userRoot: string; readonly daemonId: string };
-function cliEnv(): NodeJS.ProcessEnv { const env = { ...process.env }; delete env.HARNESS_DAEMON_USER_ROOT; delete env.HARNESS_DAEMON_ID; return env; }
-function runRaw(target: Target, args: readonly string[]) { return spawnSync(process.execPath, [cli, ...args, "--user-root", target.userRoot, "--daemon-id", target.daemonId], { encoding: "utf8", timeout: 60_000, env: cliEnv() }); }
+function cliEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.HARNESS_DAEMON_USER_ROOT;
+  delete env.HARNESS_DAEMON_ID;
+  return env;
+}
+function runRaw(target: Target, args: readonly string[]) {
+  return spawnSync(process.execPath, [cli, ...args, "--user-root", target.userRoot, "--daemon-id", target.daemonId], {
+    encoding: "utf8",
+    timeout: 60_000,
+    env: cliEnv(),
+  });
+}
 function run(target: Target, args: readonly string[]): Record<string, unknown> {
   const result = runRaw(target, args);
   assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
   return JSON.parse(result.stdout) as Record<string, unknown>;
 }
-function socketAccepting(socketPath: string): Promise<boolean> { return new Promise((resolve) => { const socket = connect(socketPath); const settle = (ready: boolean) => { socket.removeAllListeners(); socket.destroy(); resolve(ready); }; socket.once("connect", () => settle(true)); socket.once("error", () => settle(false)); }); }
-async function alive(pid: number): Promise<boolean> { return new Promise((resolve) => { try { process.kill(pid, 0); resolve(true); } catch { resolve(false); } }); }
-async function waitForExit(pid: number): Promise<void> { for (let attempt = 0; attempt < 600; attempt += 1) { if (!(await alive(pid))) return; await new Promise((resolve) => setTimeout(resolve, 20)); } throw new Error(`process ${pid} did not exit`); }
+function socketAccepting(socketPath: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = connect(socketPath);
+    const settle = (ready: boolean) => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(ready);
+    };
+    socket.once("connect", () => settle(true));
+    socket.once("error", () => settle(false));
+  });
+}
+async function alive(pid: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    try {
+      process.kill(pid, 0);
+      resolve(true);
+    } catch {
+      resolve(false);
+    }
+  });
+}
+async function waitForExit(pid: number): Promise<void> {
+  for (let attempt = 0; attempt < 600; attempt += 1) {
+    if (!(await alive(pid))) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`process ${pid} did not exit`);
+}
 async function waitForPidFile(target: string, socketPath?: string): Promise<number> {
   const deadline = Date.now() + 10_000;
   for (;;) {
@@ -217,8 +327,22 @@ async function waitForPidFile(target: string, socketPath?: string): Promise<numb
     await new Promise((resolve) => setTimeout(resolve, 20));
   }
 }
+function textCount(target: string, pattern: string): number {
+  return readFileSync(target, "utf8").split(pattern).length - 1;
+}
+async function waitForTextCount(target: string, pattern: string, count: number): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (textCount(target, pattern) < count) {
+    if (Date.now() >= deadline) throw new Error(`${target} never contained ${count} occurrences of ${pattern}`);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
 async function cleanup(fixture: Fixture): Promise<void> {
-  try { process.kill(fixture.daemonPid, "SIGKILL"); } catch { /* already gone */ }
+  try {
+    process.kill(fixture.daemonPid, "SIGKILL");
+  } catch {
+    /* already gone */
+  }
   rmSync(daemonPidPath(fixture.userRoot, fixture.daemonId), { force: true });
   rmSync(localUserDaemonEndpoint(fixture.userRoot, fixture.daemonId), { force: true });
   rmSync(fixture.parent, { recursive: true, force: true });

--- a/packages/cli/test/daemon-stop-identity.test.ts
+++ b/packages/cli/test/daemon-stop-identity.test.ts
@@ -1,11 +1,12 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { connect } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { pathToFileURL } from "node:url";
 import { localUserDaemonEndpoint } from "../../daemon/src/client/local-daemon-target.ts";
 import { daemonPidPath, readDaemonPid } from "../../daemon/src/runtime.ts";
 
@@ -68,7 +69,84 @@ test("force refuses to signal a pid the daemon slot no longer claims", async () 
   } finally { rmSync(parent, { recursive: true, force: true }); }
 });
 
+test(
+  "force stopping the daemon leaves its detached runtime worker alive",
+  { skip: process.platform === "win32" ? "requires POSIX detached process-group semantics" : false },
+  async () => {
+    const fixture = await spawnRuntimeOwningDaemon();
+    try {
+      assert.equal(await alive(fixture.workerPid), true, "the runtime worker must be live before daemon stop");
+      const forced = run(fixture, ["daemon", "stop", "--force", "--json"]);
+      assert.equal(forced.ok, true, JSON.stringify(forced));
+      await waitForExit(fixture.daemonPid);
+      assert.equal(await alive(fixture.workerPid), true, "daemon stop must not signal the runtime worker process group");
+    } finally {
+      try {
+        process.kill(-fixture.workerPid, "SIGTERM");
+      } catch {
+        // The worker may have exited between the assertion and cleanup.
+      }
+      await cleanup(fixture);
+    }
+  },
+);
+
 interface Fixture { readonly parent: string; readonly userRoot: string; readonly daemonId: string; readonly daemonPid: number }
+interface RuntimeFixture extends Fixture { readonly workerPid: number }
+
+async function spawnRuntimeOwningDaemon(): Promise<RuntimeFixture> {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-stop-runtime-worker-")),
+    userRoot = path.join(parent, "user"),
+    daemonId = "runtime-worker",
+    rootDir = path.join(parent, "repo"),
+    workerPidPath = path.join(parent, "worker.pid"),
+    script = path.join(parent, "runtime-daemon.mjs"),
+    launcher = path.join(parent, "launcher.mjs"),
+    socketPath = localUserDaemonEndpoint(userRoot, daemonId),
+    pidPath = daemonPidPath(userRoot, daemonId),
+    runtimeModule = pathToFileURL(path.resolve("packages/daemon/src/runtime-spawn-process.ts")).href;
+  mkdirSync(userRoot, { recursive: true });
+  mkdirSync(path.dirname(socketPath), { recursive: true });
+  writeFileSync(
+    script,
+    `import net from "node:net";
+import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { launchNative } from ${JSON.stringify(runtimeModule)};
+const [socketPath, pidPath, rootDir, workerPidPath] = process.argv.slice(2);
+const dispatchId = "dispatch_111111111111111111111111";
+const streamRoot = path.join(rootDir, ".harness", "runtime", "dispatches");
+mkdirSync(streamRoot, { recursive: true });
+writeFileSync(path.join(streamRoot, dispatchId + ".jsonl"), "{}\\n");
+const runtime = launchNative({ executablePath: process.execPath, args: ["-e", "setInterval(() => undefined, 60000)"], env: process.env, cwd: rootDir, prompt: "hold" }, { rootDir, dispatchId });
+writeFileSync(workerPidPath, String(runtime.pid));
+writeFileSync(pidPath, process.pid + "\\n");
+const server = net.createServer(() => undefined);
+server.listen(socketPath);
+process.on("SIGTERM", () => { server.close(); try { unlinkSync(socketPath); } catch {} try { unlinkSync(pidPath); } catch {} process.exit(0); });
+`,
+    "utf8",
+  );
+  writeFileSync(
+    launcher,
+    `import { spawn } from "node:child_process";
+const child = spawn(process.execPath, [${JSON.stringify(script)}, ...process.argv.slice(2)], { stdio: "ignore", detached: true, env: process.env });
+child.unref();
+`,
+    "utf8",
+  );
+  const nodeOptions = [process.env.NODE_OPTIONS, "--experimental-strip-types"].filter(Boolean).join(" "),
+    launched = spawnSync(process.execPath, [launcher, socketPath, pidPath, rootDir, workerPidPath], {
+      encoding: "utf8",
+      env: { ...process.env, NODE_OPTIONS: nodeOptions },
+      timeout: 10_000,
+    });
+  assert.equal(launched.status, 0, launched.stderr);
+  const daemonPid = await waitForPidFile(pidPath, socketPath),
+    workerPid = await waitForPidFile(workerPidPath);
+  return { parent, userRoot, daemonId, daemonPid, workerPid };
+}
+
 async function spawnLegacyDaemon(daemonId: string): Promise<Fixture> {
   const parent = mkdtempSync(path.join(tmpdir(), `ha-stop-${daemonId}-`)), userRoot = path.join(parent, "user");
   mkdirSync(userRoot, { recursive: true });
@@ -80,6 +158,7 @@ async function spawnLegacyDaemon(daemonId: string): Promise<Fixture> {
   // while it is blocked inside a synchronous CLI call.
   writeFileSync(launcher, `import { spawn } from "node:child_process";\nconst child = spawn(process.execPath, [${JSON.stringify(script)}, ...process.argv.slice(2)], { stdio: "ignore", detached: true });\nchild.unref();\n`, "utf8");
   const socketPath = localUserDaemonEndpoint(userRoot, daemonId);
+  mkdirSync(path.dirname(socketPath), { recursive: true });
   const launched = spawnSync(process.execPath, [launcher, daemonId === "wedge" ? "wedge" : "legacy", socketPath, daemonPidPath(userRoot, daemonId)], { encoding: "utf8", timeout: 10_000 });
   assert.equal(launched.status, 0, launched.stderr);
   const daemonPid = await new Promise<number>((resolve, reject) => {
@@ -129,6 +208,15 @@ function run(target: Target, args: readonly string[]): Record<string, unknown> {
 function socketAccepting(socketPath: string): Promise<boolean> { return new Promise((resolve) => { const socket = connect(socketPath); const settle = (ready: boolean) => { socket.removeAllListeners(); socket.destroy(); resolve(ready); }; socket.once("connect", () => settle(true)); socket.once("error", () => settle(false)); }); }
 async function alive(pid: number): Promise<boolean> { return new Promise((resolve) => { try { process.kill(pid, 0); resolve(true); } catch { resolve(false); } }); }
 async function waitForExit(pid: number): Promise<void> { for (let attempt = 0; attempt < 600; attempt += 1) { if (!(await alive(pid))) return; await new Promise((resolve) => setTimeout(resolve, 20)); } throw new Error(`process ${pid} did not exit`); }
+async function waitForPidFile(target: string, socketPath?: string): Promise<number> {
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    const pid = existsSync(target) ? Number(readFileSync(target, "utf8")) : 0;
+    if (Number.isInteger(pid) && pid > 0 && (!socketPath || (await socketAccepting(socketPath)))) return pid;
+    if (Date.now() >= deadline) throw new Error(`process pid never appeared in ${target}`);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
 async function cleanup(fixture: Fixture): Promise<void> {
   try { process.kill(fixture.daemonPid, "SIGKILL"); } catch { /* already gone */ }
   rmSync(daemonPidPath(fixture.userRoot, fixture.daemonId), { force: true });

--- a/packages/daemon/src/agent-runtime-instance-storage.ts
+++ b/packages/daemon/src/agent-runtime-instance-storage.ts
@@ -230,6 +230,11 @@ export function sharedProviderDirectory(
 // Mode); if even that fails, sharing is best-effort skipped and the provider's own
 // subscription probe reports the consequence instead of failing the launch.
 export function ensureSharedAuthFile(src: string, dst: string): void {
+  if (path.resolve(src) === path.resolve(dst))
+    throw runtimeInstanceError(
+      "runtime_auth_share_self_reference",
+      `Runtime auth sharing source and destination resolve to the same path: ${path.resolve(src)}.`,
+    );
   if (!existsSync(src)) return;
   const existing = lstatSync(dst, { throwIfNoEntry: false });
   if (existing?.isSymbolicLink() && readlinkSync(dst) === src) return;

--- a/packages/daemon/src/client/daemon-autostart.ts
+++ b/packages/daemon/src/client/daemon-autostart.ts
@@ -13,6 +13,7 @@ export interface DaemonLaunchSpec {
   readonly env: NodeJS.ProcessEnv;
 }
 export type DaemonAutostartFailureCode =
+  | "daemon_start_runtime_forbidden"
   | "daemon_spawn_not_found"
   | "daemon_spawn_permission"
   | "daemon_start_failed"

--- a/packages/daemon/src/client/daemon-autostart.ts
+++ b/packages/daemon/src/client/daemon-autostart.ts
@@ -12,13 +12,15 @@ export interface DaemonLaunchSpec {
   readonly args: readonly string[];
   readonly env: NodeJS.ProcessEnv;
 }
-export type DaemonAutostartFailureCode =
-  | "daemon_start_runtime_forbidden"
-  | "daemon_spawn_not_found"
-  | "daemon_spawn_permission"
-  | "daemon_start_failed"
-  | "daemon_bind_timeout"
-  | "daemon_starting";
+export const autostartFailureCodes = [
+  "daemon_start_runtime_forbidden",
+  "daemon_spawn_not_found",
+  "daemon_spawn_permission",
+  "daemon_start_failed",
+  "daemon_bind_timeout",
+  "daemon_starting",
+] as const;
+export type DaemonAutostartFailureCode = (typeof autostartFailureCodes)[number];
 export interface DaemonAutostartResult {
   readonly ok: boolean;
   readonly code?: DaemonAutostartFailureCode;
@@ -45,6 +47,20 @@ export function isDaemonUnreachable(error: unknown): boolean {
     if (typeof code === "string") return code === "ECONNREFUSED" || code === "ENOENT" || code === "ETIMEDOUT";
   }
   return error instanceof Error && error.message === "daemon_unavailable";
+}
+export async function runtimeDaemonStartRefusal(
+  socketPath: string,
+  env: NodeJS.ProcessEnv = process.env,
+  probe: (socketPath: string) => Promise<boolean> = daemonSocketProbe,
+): Promise<{ readonly code: "daemon_start_runtime_forbidden"; readonly hint: string } | null> {
+  if (env.HARNESS_ACTOR?.startsWith("agent:runtime-session:") !== true || (await probe(socketPath))) return null;
+  return {
+    code: "daemon_start_runtime_forbidden",
+    hint: [
+      "A task-bound runtime cannot start the shared daemon because its HOME and PATH belong to the runtime instance.",
+      "Start the daemon from an operator shell with `ha daemon start --service`, then retry the worker command.",
+    ].join(" "),
+  };
 }
 export async function ensureLocalDaemonRunning(input: {
   readonly socketPath: string;

--- a/packages/daemon/src/client/daemon-autostart.ts
+++ b/packages/daemon/src/client/daemon-autostart.ts
@@ -48,12 +48,10 @@ export function isDaemonUnreachable(error: unknown): boolean {
   }
   return error instanceof Error && error.message === "daemon_unavailable";
 }
-export async function runtimeDaemonStartRefusal(
-  socketPath: string,
+export function runtimeDaemonStartRefusalForUnavailable(
   env: NodeJS.ProcessEnv = process.env,
-  probe: (socketPath: string) => Promise<boolean> = daemonSocketProbe,
-): Promise<{ readonly code: "daemon_start_runtime_forbidden"; readonly hint: string } | null> {
-  if (env.HARNESS_ACTOR?.startsWith("agent:runtime-session:") !== true || (await probe(socketPath))) return null;
+): { readonly code: "daemon_start_runtime_forbidden"; readonly hint: string } | null {
+  if (env.HARNESS_ACTOR?.startsWith("agent:runtime-session:") !== true) return null;
   return {
     code: "daemon_start_runtime_forbidden",
     hint: [
@@ -61,6 +59,14 @@ export async function runtimeDaemonStartRefusal(
       "Start the daemon from an operator shell with `ha daemon start --service`, then retry the worker command.",
     ].join(" "),
   };
+}
+export async function runtimeDaemonStartRefusal(
+  socketPath: string,
+  env: NodeJS.ProcessEnv = process.env,
+  probe: (socketPath: string) => Promise<boolean> = daemonSocketProbe,
+): Promise<{ readonly code: "daemon_start_runtime_forbidden"; readonly hint: string } | null> {
+  const refusal = runtimeDaemonStartRefusalForUnavailable(env);
+  return refusal === null || (await probe(socketPath)) ? null : refusal;
 }
 export async function ensureLocalDaemonRunning(input: {
   readonly socketPath: string;

--- a/packages/daemon/test/agent-runtime-instances.test.ts
+++ b/packages/daemon/test/agent-runtime-instances.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import { parseThinCommand } from "../../cli/src/cli/thin-command.ts";
 import { credentialPort, runCredentialCommand } from "../src/agent-runtime-credential-port.ts";
 import { discoverRuntimeInstallations, openRuntimeInstanceStore, type RuntimeAuthReadiness, type RuntimeInstallationWitness } from "../src/agent-runtime-instances.ts";
+import { ensureSharedAuthFile } from "../src/agent-runtime-instance-storage.ts";
 import { daemonProtocolCommands, validateDaemonRpcCall } from "../src/protocol/daemon-protocol.contract.ts";
 import { writeProviderExecutable } from "./fixtures/runtime-stub.ts";
 
@@ -485,6 +486,27 @@ test("enforced instances link the operator's shared provider auth while generate
     assert.equal(lstatSync(claudeCredentials).isSymbolicLink(), true); assert.equal(readlinkSync(claudeCredentials), path.join(operatorHome, ".claude", ".credentials.json"));
     for (const receipt of [launch, login]) assert.doesNotMatch(JSON.stringify(receipt), /operator-login/u);
   } finally { rmSync(parent, { recursive: true, force: true }); }
+});
+
+test("auth sharing rejects a source that is also its destination without replacing the credential", () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-auth-self-reference-")),
+    authFile = path.join(parent, "home", ".codex", "auth.json"),
+    contents = `{"tokens":"operator-login"}`;
+  try {
+    mkdirSync(path.dirname(authFile), { recursive: true });
+    writeFileSync(authFile, contents, { mode: 0o600 });
+    assert.throws(
+      () => ensureSharedAuthFile(authFile, path.join(parent, "home", ".codex", ".", "auth.json")),
+      (error: unknown) =>
+        error instanceof Error &&
+        (error as Error & { readonly code?: string }).code === "runtime_auth_share_self_reference" &&
+        /same path/u.test(error.message),
+    );
+    assert.equal(lstatSync(authFile).isSymbolicLink(), false, "the credential must remain a regular file");
+    assert.equal(readFileSync(authFile, "utf8"), contents, "the rejected link must not mutate the credential");
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
 });
 
 test("api-key instances never receive the operator's shared provider credentials", async () => {

--- a/packages/daemon/test/daemon-autostart.test.ts
+++ b/packages/daemon/test/daemon-autostart.test.ts
@@ -10,6 +10,7 @@ import {
   ensureLocalDaemonRunning,
   isDaemonUnreachable,
   readDaemonStartProgress,
+  runtimeDaemonStartRefusal,
   type DaemonAutostartResult,
   type DaemonLaunchSpec,
 } from "../src/client/daemon-autostart.ts";
@@ -25,6 +26,34 @@ const launch = (): DaemonLaunchSpec => ({
   command: "node",
   args: ["index.ts", "daemon", "serve", "--user-root", "/tmp/ha-user", "--daemon-id", "default"],
   env: {},
+});
+
+test("runtime start refusal requires a runtime actor and an unavailable daemon", async () => {
+  let probes = 0;
+  const taskBoundOnly = await runtimeDaemonStartRefusal(
+    "/tmp/ha-autostart.sock",
+    { HARNESS_TASK_BOUND: "1" },
+    async () => {
+      probes += 1;
+      return false;
+    },
+  );
+  assert.equal(taskBoundOnly, null);
+  assert.equal(probes, 0, "a task-bound marker alone is not runtime identity");
+
+  const resident = await runtimeDaemonStartRefusal(
+    "/tmp/ha-autostart.sock",
+    { HARNESS_ACTOR: "agent:runtime-session:worker" },
+    async () => true,
+  );
+  assert.equal(resident, null, "a runtime actor may use a resident daemon");
+
+  const absent = await runtimeDaemonStartRefusal(
+    "/tmp/ha-autostart.sock",
+    { HARNESS_ACTOR: "agent:runtime-session:worker" },
+    async () => false,
+  );
+  assert.equal(absent?.code, "daemon_start_runtime_forbidden");
 });
 
 test("unreachable daemon is started once and the ready socket is used without a second attempt", async () => {

--- a/packages/daemon/test/daemon-autostart.test.ts
+++ b/packages/daemon/test/daemon-autostart.test.ts
@@ -11,6 +11,7 @@ import {
   isDaemonUnreachable,
   readDaemonStartProgress,
   runtimeDaemonStartRefusal,
+  runtimeDaemonStartRefusalForUnavailable,
   type DaemonAutostartResult,
   type DaemonLaunchSpec,
 } from "../src/client/daemon-autostart.ts";
@@ -48,11 +49,7 @@ test("runtime start refusal requires a runtime actor and an unavailable daemon",
   );
   assert.equal(resident, null, "a runtime actor may use a resident daemon");
 
-  const absent = await runtimeDaemonStartRefusal(
-    "/tmp/ha-autostart.sock",
-    { HARNESS_ACTOR: "agent:runtime-session:worker" },
-    async () => false,
-  );
+  const absent = runtimeDaemonStartRefusalForUnavailable({ HARNESS_ACTOR: "agent:runtime-session:worker" });
   assert.equal(absent?.code, "daemon_start_runtime_forbidden");
 });
 


### PR DESCRIPTION
# English

## Summary

0.40: a daemon that self-healed after a crash inherited the *triggering worker's* environment (`HOME=~/.harness/runtime-instances/<instance>/home`), so every later provider launch shared auth into itself (a self-referential `auth.json` symlink) and every worker failed with `runtime_subscription_required`; `ha runtime instance login` could not repair it because the daemon kept writing the loop. Ruling (task goal option ②): a task-bound or runtime-session identity may use an existing daemon but may not start the shared one — autostart and `ha daemon start/serve` refuse with `daemon_start_runtime_forbidden` and tell the operator shell to start it. Auth sharing now fails closed before touching credentials when source and destination resolve to the same path. `ha daemon stop --force` gets a regression asserting the detached runtime worker survives.

## Architectural Justification

- Not required: Production-Delta churn is below 200 lines.

## What Changed

- `packages/cli/src/daemon/client.ts`: `runtimeDaemonStartRefusal(env)` (HARNESS_TASK_BOUND=1 or `agent:runtime-session:*` actor) consulted before autostart; new failure code `daemon_start_runtime_forbidden`.
- `packages/cli/src/daemon/control.ts`: `daemon serve` / `daemon start --service` refuse under a runtime identity.
- `packages/daemon/src/agent-runtime-instance-storage.ts`: `ensureSharedAuthFile` throws `runtime_auth_share_self_reference` when src == dst.
- Tests: autostart refusal, self-link rejection, force-stop worker survival.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +199/-86

### Optional Evidence Claims

## Task And Scope

- Harness task: task_9a996767520ac0b3489e014295
- Branch: codex/daemon-env-0-40
- Public scope: packages/cli/src/daemon/{client,control}.ts, packages/daemon/src/agent-runtime-instance-storage.ts, packages/daemon/src/client/daemon-autostart.ts, tests
- Private planning/evidence updated: yes
- Out of scope: why the observed `daemon stop --force` on 2026-08-26 reaped four live Sol workers — the new regression covers the detached process-group contract only; the real-daemon shutdown sequence is followed up in the task closeout

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_9a996767520ac0b3489e014295
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 79e192949fc1105a71a849ac3c11ad84da4f20ec
- Branch merge-base with `origin/main`: 79e192949fc1105a71a849ac3c11ad84da4f20ec
- Last `git fetch origin` time: 2026-08-26T17:45:15Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_9a996767520ac0b3489e014295 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Isolated suites 47/47, 10/10 (one pre-existing skip), 4/4; fast tests 13/13; TypeScript, targeted ESLint, line-budget pass
- [x] CEO read the full production diff (+37/-2): refusal keyed on `HARNESS_TASK_BOUND` / runtime-session actor only; `ensureSharedAuthFile` guard precedes any fs write
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: live reproduction of the self-healing restart under a worker HOME (the failing daemon was already replaced from the operator shell on 2026-08-26); CI is the authority.

## Review Evidence

- Self-review: CEO hit the self-link loop live on 2026-08-26 (`runtime_subscription_required` on every worker) and traced it to the inherited HOME before filing the task.
- Reviewer subagent: Codex worker (gpt-5.6-sol); CEO full-diff read.
- Human review: pending
- Blocking findings: none

## Residual Risk

- A worker that finds no daemon now fails fast instead of starting one; the operator must keep `ha daemon start --service` running (launchd/GUI already do).

## References

- Task: task_9a996767520ac0b3489e014295
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

0.40:daemon 崩溃后自愈重启时继承了*触发它的 worker* 的环境(`HOME=~/.harness/runtime-instances/<instance>/home`),此后每次 provider 启动都把 auth 共享到自己身上(`auth.json` 自环符号链接),所有 worker 报 `runtime_subscription_required`;`ha runtime instance login` 修不了,因为 daemon 一直在重写这个环。裁决(任务目标选项②):task-bound / runtime-session 身份可以用已有 daemon,但不得启动共享 daemon——autostart 与 `ha daemon start/serve` 以 `daemon_start_runtime_forbidden` 拒绝并提示从操作者 shell 启动。auth 共享在源与目标解析为同一路径时在改动凭证前 fail-closed。`ha daemon stop --force` 增加回归:detached 的 runtime worker 存活。

## 架构辩护

- 不需要:Production-Delta churn 低于 200 行。

## 改动内容

- `packages/cli/src/daemon/client.ts`:autostart 前先问 `runtimeDaemonStartRefusal(env)`(HARNESS_TASK_BOUND=1 或 `agent:runtime-session:*` actor);新失败码 `daemon_start_runtime_forbidden`。
- `packages/cli/src/daemon/control.ts`:runtime 身份下 `daemon serve` / `daemon start --service` 拒绝。
- `packages/daemon/src/agent-runtime-instance-storage.ts`:`ensureSharedAuthFile` 在 src == dst 时抛 `runtime_auth_share_self_reference`。
- 测试:autostart 拒绝、自环拒绝、force-stop 下 worker 存活。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_9a996767520ac0b3489e014295
- 分支:codex/daemon-env-0-40
- 公开范围:packages/cli/src/daemon/{client,control}.ts、packages/daemon/src/agent-runtime-instance-storage.ts、packages/daemon/src/client/daemon-autostart.ts、测试
- 私有计划 / 证据是否已更新:yes
- 范围外:08-26 实测 `daemon stop --force` 收割四个活 Sol worker 的真实原因——新回归只覆盖 detached 进程组契约;真 daemon 的关停序列在任务 closeout 里另行跟进

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_9a996767520ac0b3489e014295
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:79e192949fc1105a71a849ac3c11ad84da4f20ec
- 当前分支与 `origin/main` 的 merge-base:79e192949fc1105a71a849ac3c11ad84da4f20ec
- 最近一次 `git fetch origin` 时间:2026-08-26T17:45:15Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_9a996767520ac0b3489e014295
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] 隔离套件 47/47、10/10(一个既有 skip)、4/4;快速测试 13/13;TypeScript、定向 ESLint、line-budget 通过
- [x] CEO 通读全部生产 diff(+37/-2):拒绝仅按 `HARNESS_TASK_BOUND` / runtime-session actor 判定;`ensureSharedAuthFile` 守卫先于任何 fs 写入
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:worker HOME 下自愈重启的实机复现(08-26 已从操作者 shell 换掉故障 daemon);以 CI 为权威。

## 审查证据

- 自查:CEO 08-26 实机撞到自环(所有 worker `runtime_subscription_required`),立任务前已追到继承的 HOME。
- Reviewer subagent:Codex worker(gpt-5.6-sol);CEO 通读 diff。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 找不到 daemon 的 worker 现在快速失败而不是自己起一个;操作者需保持 `ha daemon start --service`(launchd/GUI 已负责)。

## 关联材料

- 任务:task_9a996767520ac0b3489e014295
- 证据:任务包 artifacts/reports
- 审查:本 PR



