### PR TITLE
fix(runtime): make provider fallback durable across daemon restarts (0.38)

### DIFF
--- a/packages/cli/src/cli/thin-command-runtime.ts
+++ b/packages/cli/src/cli/thin-command-runtime.ts
@@ -1,18 +1,7 @@
 import type { SafePath } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
-import {
-  accepted,
-  nonEmpty,
-  promptInput,
-  readFlags,
-  rejectInput,
-  rejected,
-} from "./thin-command-flags.ts";
+import { accepted, nonEmpty, promptInput, readFlags, rejectInput, rejected } from "./thin-command-flags.ts";
 import { parseRuntimeStatus } from "./thin-command-runtime-status.ts";
-import type {
-  ProtocolCommand,
-  ThinCliInputDirectory,
-  ThinParseResult,
-} from "./thin-command-types.ts";
+import type { ProtocolCommand, ThinCliInputDirectory, ThinParseResult } from "./thin-command-types.ts";
 
 export function parseRuntime(
   route: ProtocolCommand,
@@ -28,52 +17,26 @@ export function parseRuntime(
     f = readFlags(kind, args.slice(id ? 3 : 2), inputs);
   if (!f.ok) return rejected(f.code, f.nextAction, json);
   if (!optional && !nonEmpty(id))
-    return rejected(
-      "missing_field",
-      `Run ha runtime ${kind.slice(8)} <${runtimeTarget(kind)}>.`,
-      json,
-    );
-  if (kind === "runtime-batch")
-    return accepted(
-      rootDir,
-      repoId,
-      json,
-      { kind, batchFile: id },
-      route.method,
-    );
-  if (kind === "runtime-status")
-    return parseRuntimeStatus(route, rootDir, repoId, json, id, f, inputs);
-  if (kind === "runtime-cancel")
-    return accepted(
-      rootDir,
-      repoId,
-      json,
-      { kind, runtimeSessionId: id },
-      route.method,
-    );
+    return rejected("missing_field", `Run ha runtime ${kind.slice(8)} <${runtimeTarget(kind)}>.`, json);
+  if (kind === "runtime-batch") return accepted(rootDir, repoId, json, { kind, batchFile: id }, route.method);
+  if (kind === "runtime-status") return parseRuntimeStatus(route, rootDir, repoId, json, id, f, inputs);
+  if (kind === "runtime-cancel") return accepted(rootDir, repoId, json, { kind, runtimeSessionId: id }, route.method);
   const prompt = promptInput(f.one),
     taskId = f.one.get("--task"),
     promptFlagPresent = f.one.has("--prompt") || f.one.has("--prompt-file"),
     detach = f.booleans.has("--detach"),
     onExitCommand = f.one.get("--on-exit");
   if (!prompt && (promptFlagPresent || !taskId))
-    return rejectInput(
-      inputs,
-      kind,
-      f.one.has("--prompt") ? "--prompt-file" : "--prompt",
-      json,
-    );
-  if (onExitCommand && !detach)
-    return rejectInput(inputs, kind, "--on-exit", json);
+    return rejectInput(inputs, kind, f.one.has("--prompt") ? "--prompt-file" : "--prompt", json);
+  if (onExitCommand && !detach) return rejectInput(inputs, kind, "--on-exit", json);
   const cwd = f.one.get("--cwd"),
     agentId = f.one.get("--agent"),
-    targetAgentId = f.one.get("--to");
+    targetAgentId = f.one.get("--to"),
+    squadId = f.one.get("--squad");
   if (targetAgentId && !agentId)
-    return rejected(
-      "invalid_field",
-      "Use --to <worker-agent-id> only with --agent <leader-agent-id>.",
-      json,
-    );
+    return rejected("invalid_field", "Use --to <worker-agent-id> only with --agent <leader-agent-id>.", json);
+  if (squadId && !agentId)
+    return rejected("invalid_field", "Use --squad <squad-id> only with --agent <leader-agent-id>.", json);
   return accepted(
     rootDir,
     repoId,
@@ -83,26 +46,16 @@ export function parseRuntime(
       runtimeInstanceId: id,
       ...(agentId ? { agentId } : {}),
       ...(targetAgentId ? { targetAgentId } : {}),
+      ...(squadId ? { squadId } : {}),
       ...(f.one.get("--model") ? { model: f.one.get("--model") } : {}),
       ...(f.one.get("--effort") ? { effort: f.one.get("--effort") } : {}),
-      ...(f.one.get("--permission-mode")
-        ? { permissionMode: f.one.get("--permission-mode") }
-        : {}),
+      ...(f.one.get("--permission-mode") ? { permissionMode: f.one.get("--permission-mode") } : {}),
       ...(prompt ?? {}),
-      cwd:
-        cwd && cwd !== "."
-          ? { scope: "repo-relative", path: cwd }
-          : { scope: "repo-root" },
+      cwd: cwd && cwd !== "." ? { scope: "repo-relative", path: cwd } : { scope: "repo-root" },
       taskId: taskId ?? null,
-      ...(f.one.get("--resume")
-        ? { providerSessionId: f.one.get("--resume") }
-        : {}),
-      ...(f.one.get("--resume-dispatch")
-        ? { dispatchId: f.one.get("--resume-dispatch") }
-        : {}),
-      ...(f.one.get("--idempotency-key")
-        ? { idempotencyKey: f.one.get("--idempotency-key") }
-        : {}),
+      ...(f.one.get("--resume") ? { providerSessionId: f.one.get("--resume") } : {}),
+      ...(f.one.get("--resume-dispatch") ? { dispatchId: f.one.get("--resume-dispatch") } : {}),
+      ...(f.one.get("--idempotency-key") ? { idempotencyKey: f.one.get("--idempotency-key") } : {}),
       ...(detach ? { detach: true } : {}),
       ...(onExitCommand ? { onExitCommand } : {}),
       ...(f.booleans.has("--no-stream") ? { noStream: true } : {}),
@@ -112,11 +65,7 @@ export function parseRuntime(
 }
 
 function runtimeTarget(kind: string): string {
-  return kind === "runtime-run"
-    ? "instance-id"
-    : kind === "runtime-batch"
-      ? "batch-file"
-      : "runtime-session-id";
+  return kind === "runtime-run" ? "instance-id" : kind === "runtime-batch" ? "batch-file" : "runtime-session-id";
 }
 
 export function parseResumeDispatch(
@@ -131,24 +80,16 @@ export function parseResumeDispatch(
   const prompt = promptInput(f.one),
     detach = f.booleans.has("--detach"),
     onExitCommand = f.one.get("--on-exit");
-  if (!prompt)
-    return rejectInput(
-      inputs,
-      "runtime-run",
-      f.one.has("--prompt") ? "--prompt-file" : "--prompt",
-      json,
-    );
-  if (onExitCommand && !detach)
-    return rejectInput(inputs, "runtime-run", "--on-exit", json);
+  if (!prompt) return rejectInput(inputs, "runtime-run", f.one.has("--prompt") ? "--prompt-file" : "--prompt", json);
+  if (onExitCommand && !detach) return rejectInput(inputs, "runtime-run", "--on-exit", json);
   const cwd = f.one.get("--cwd"),
     agentId = f.one.get("--agent"),
-    targetAgentId = f.one.get("--to");
+    targetAgentId = f.one.get("--to"),
+    squadId = f.one.get("--squad");
   if (targetAgentId && !agentId)
-    return rejected(
-      "invalid_field",
-      "Use --to <worker-agent-id> only with --agent <leader-agent-id>.",
-      json,
-    );
+    return rejected("invalid_field", "Use --to <worker-agent-id> only with --agent <leader-agent-id>.", json);
+  if (squadId && !agentId)
+    return rejected("invalid_field", "Use --squad <squad-id> only with --agent <leader-agent-id>.", json);
   return accepted(
     rootDir,
     repoId,
@@ -157,20 +98,14 @@ export function parseResumeDispatch(
       kind: "runtime-run",
       dispatchId: f.one.get("--resume-dispatch"),
       ...(f.one.get("--effort") ? { effort: f.one.get("--effort") } : {}),
-      ...(f.one.get("--permission-mode")
-        ? { permissionMode: f.one.get("--permission-mode") }
-        : {}),
+      ...(f.one.get("--permission-mode") ? { permissionMode: f.one.get("--permission-mode") } : {}),
       ...prompt,
-      cwd:
-        cwd && cwd !== "."
-          ? { scope: "repo-relative", path: cwd }
-          : { scope: "repo-root" },
+      cwd: cwd && cwd !== "." ? { scope: "repo-relative", path: cwd } : { scope: "repo-root" },
       taskId: f.one.get("--task") ?? null,
       ...(agentId ? { agentId } : {}),
       ...(targetAgentId ? { targetAgentId } : {}),
-      ...(f.one.get("--idempotency-key")
-        ? { idempotencyKey: f.one.get("--idempotency-key") }
-        : {}),
+      ...(squadId ? { squadId } : {}),
+      ...(f.one.get("--idempotency-key") ? { idempotencyKey: f.one.get("--idempotency-key") } : {}),
       ...(detach ? { detach: true } : {}),
       ...(onExitCommand ? { onExitCommand } : {}),
       ...(f.booleans.has("--no-stream") ? { noStream: true } : {}),

--- a/packages/cli/test/runtime-cli.integration.test.ts
+++ b/packages/cli/test/runtime-cli.integration.test.ts
@@ -745,7 +745,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     assert.equal(unknownDispatch.status, 1);
     assert.equal(
       rejectionHint(unknownDispatch.receipt),
-      'Batch dispatch 0 contains an unknown field "permissionMode"; allowed fields: "instance", "agent", "to", "model", "effort", "permission-mode", "prompt", "prompt-file", "cwd", "task".',
+      'Batch dispatch 0 contains an unknown field "permissionMode"; allowed fields: "instance", "agent", "to", "squad", "model", "effort", "permission-mode", "prompt", "prompt-file", "cwd", "task".',
     );
     const unknownSpawn = await runCommandThroughDaemon(
       {

--- a/packages/cli/test/thin-command-script-doc-runtime.test.ts
+++ b/packages/cli/test/thin-command-script-doc-runtime.test.ts
@@ -31,68 +31,22 @@ test("thin parser converts the sole preset script target into closed typed start
         inputs: { title: "Canary" },
       },
     });
+  assert.equal(parseThinCommand(["script", "run", "user-canary/check", "--idempotency-key", "once"]).ok, false);
   assert.equal(
-    parseThinCommand([
-      "script",
-      "run",
-      "user-canary/check",
-      "--idempotency-key",
-      "once",
-    ]).ok,
-    false,
-  );
-  assert.equal(
-    parseThinCommand([
-      "script",
-      "run",
-      "preset:user-canary/check",
-      "--idempotency-key",
-      "once",
-      "--inputs",
-      "not-json",
-    ]).ok,
+    parseThinCommand(["script", "run", "preset:user-canary/check", "--idempotency-key", "once", "--inputs", "not-json"])
+      .ok,
     false,
   );
 });
 
 test("thin doc commands derive descriptor-only actions from the protocol directory", () => {
   const status = parseThinCommand(["doc", "status"]),
-    selectedStatus = parseThinCommand([
-      "doc",
-      "status",
-      "--path",
-      "context/a.md",
-      "--path",
-      "context/b.md",
-    ]),
-    dryRun = parseThinCommand([
-      "doc",
-      "sync",
-      "--dry-run",
-      "--path",
-      "context/a.md",
-      "--path",
-      "context/b.md",
-    ]),
+    selectedStatus = parseThinCommand(["doc", "status", "--path", "context/a.md", "--path", "context/b.md"]),
+    dryRun = parseThinCommand(["doc", "sync", "--dry-run", "--path", "context/a.md", "--path", "context/b.md"]),
     materialize = parseThinCommand(["doc", "materialize"]),
     show = parseThinCommand(["doc", "show", "--path", "tasks/task-1/INDEX.md"]),
-    retire = parseThinCommand([
-      "doc",
-      "retire",
-      "--path",
-      "context/old.md",
-      "--reason",
-      "superseded scratch",
-    ]),
-    submit = parseThinCommand([
-      "doc",
-      "sync",
-      "--submit",
-      "--path",
-      "context/a.md",
-      "--path",
-      "context/b.md",
-    ]),
+    retire = parseThinCommand(["doc", "retire", "--path", "context/old.md", "--reason", "superseded scratch"]),
+    submit = parseThinCommand(["doc", "sync", "--submit", "--path", "context/a.md", "--path", "context/b.md"]),
     taskSubmit = parseThinCommand(["doc", "sync", "--submit", "--task", "task-1"]);
   assert.equal(status.ok, true);
   assert.equal(selectedStatus.ok, true);
@@ -102,8 +56,7 @@ test("thin doc commands derive descriptor-only actions from the protocol directo
   assert.equal(retire.ok, true);
   assert.equal(submit.ok, true);
   assert.equal(taskSubmit.ok, true);
-  if (status.ok)
-    assert.deepEqual(status.command.action, { kind: "doc-status", paths: [] });
+  if (status.ok) assert.deepEqual(status.command.action, { kind: "doc-status", paths: [] });
   if (selectedStatus.ok)
     assert.deepEqual(selectedStatus.command.action, {
       kind: "doc-status",
@@ -114,8 +67,7 @@ test("thin doc commands derive descriptor-only actions from the protocol directo
       kind: "doc-dry-run",
       paths: ["context/a.md", "context/b.md"],
     });
-  if (materialize.ok)
-    assert.deepEqual(materialize.command.action, { kind: "doc-materialize" });
+  if (materialize.ok) assert.deepEqual(materialize.command.action, { kind: "doc-materialize" });
   if (show.ok)
     assert.deepEqual(show.command.action, {
       kind: "doc-show",
@@ -143,19 +95,9 @@ test("thin doc commands derive descriptor-only actions from the protocol directo
     parseThinCommand(["doc", "sync", "--submit", "--task", "task-1", "--path", "tasks/task-1/task_plan.md"]).ok,
     false,
   );
-  assert.equal(
-    parseThinCommand(["doc", "sync", "--submit", "--execution-id", "exec-1"]).ok,
-    false,
-  );
-  assert.equal(
-    parseThinCommand(["doc", "show", "--path", "INDEX.md", "--body", "inline"])
-      .ok,
-    false,
-  );
-  assert.equal(
-    parseThinCommand(["doc", "retire", "--path", "context/old.md"]).ok,
-    false,
-  );
+  assert.equal(parseThinCommand(["doc", "sync", "--submit", "--execution-id", "exec-1"]).ok, false);
+  assert.equal(parseThinCommand(["doc", "show", "--path", "INDEX.md", "--body", "inline"]).ok, false);
+  assert.equal(parseThinCommand(["doc", "retire", "--path", "context/old.md"]).ok, false);
 });
 
 test("doc CLI and GUI delivery surfaces do not import store, Git, or semantic compiler code", () => {
@@ -196,10 +138,7 @@ test("thin parser exposes daemon-backed workspace bootstrap", () => {
       name: "Alpha Project",
       addNpmScripts: true,
     });
-  assert.equal(
-    parseThinCommand(["init", "--repo-id", "alpha", "--person-id", "owner"]).ok,
-    false,
-  );
+  assert.equal(parseThinCommand(["init", "--repo-id", "alpha", "--person-id", "owner"]).ok, false);
   const configureOnly = parseThinCommand([
     "init",
     "--repo-id",
@@ -230,6 +169,8 @@ test("runtime work commands parse into closed daemon facade actions", () => {
       "fable",
       "--to",
       "terra",
+      "--squad",
+      "runtime-squad",
       "--prompt",
       "Inspect",
       "--cwd",
@@ -242,24 +183,8 @@ test("runtime work commands parse into closed daemon facade actions", () => {
       "once",
       "--no-stream",
     ]),
-    taskOnly = parseThinCommand([
-      "runtime",
-      "run",
-      "worker",
-      "--agent",
-      "terra",
-      "--task",
-      "task-1",
-      "--cwd",
-      ".",
-    ]),
-    file = parseThinCommand([
-      "runtime",
-      "run",
-      "worker",
-      "--prompt-file",
-      "prompt.txt",
-    ]),
+    taskOnly = parseThinCommand(["runtime", "run", "worker", "--agent", "terra", "--task", "task-1", "--cwd", "."]),
+    file = parseThinCommand(["runtime", "run", "worker", "--prompt-file", "prompt.txt"]),
     batch = parseThinCommand(["runtime", "batch", "dispatches.json"]),
     detached = parseThinCommand([
       "runtime",
@@ -282,27 +207,9 @@ test("runtime work commands parse into closed daemon facade actions", () => {
     dispatches = parseThinCommand(["task", "dispatches", "task-1"]),
     list = parseThinCommand(["runtime", "status", "--task", "task-1"]),
     show = parseThinCommand(["runtime", "status", "runtime-1"]),
-    wait = parseThinCommand([
-      "runtime",
-      "status",
-      "runtime-1",
-      "--wait",
-      "--no-stream",
-    ]),
+    wait = parseThinCommand(["runtime", "status", "runtime-1", "--wait", "--no-stream"]),
     cancel = parseThinCommand(["runtime", "cancel", "runtime-1"]);
-  for (const parsed of [
-    run,
-    taskOnly,
-    file,
-    batch,
-    detached,
-    resumed,
-    dispatches,
-    list,
-    show,
-    wait,
-    cancel,
-  ])
+  for (const parsed of [run, taskOnly, file, batch, detached, resumed, dispatches, list, show, wait, cancel])
     assert.equal(parsed.ok, true, JSON.stringify(parsed));
   if (run.ok)
     assert.deepEqual(run.command.action, {
@@ -310,6 +217,7 @@ test("runtime work commands parse into closed daemon facade actions", () => {
       runtimeInstanceId: "worker",
       agentId: "fable",
       targetAgentId: "terra",
+      squadId: "runtime-squad",
       prompt: "Inspect",
       cwd: { scope: "repo-relative", path: "packages/cli" },
       taskId: "task-1",
@@ -394,64 +302,22 @@ test("runtime work commands parse into closed daemon facade actions", () => {
     });
   assert.equal(parseThinCommand(["runtime", "run", "worker"]).ok, false);
   assert.equal(parseThinCommand(["runtime", "batch"]).ok, false);
+  assert.equal(parseThinCommand(["runtime", "batch", "dispatches.json", "--detach"]).ok, false);
   assert.equal(
-    parseThinCommand(["runtime", "batch", "dispatches.json", "--detach"]).ok,
+    parseThinCommand(["runtime", "run", "worker", "--prompt", "Inspect", "--on-exit", "./notify.sh"]).ok,
     false,
   );
   assert.equal(
-    parseThinCommand([
-      "runtime",
-      "run",
-      "worker",
-      "--prompt",
-      "Inspect",
-      "--on-exit",
-      "./notify.sh",
-    ]).ok,
+    parseThinCommand(["runtime", "run", "worker", "--squad", "runtime-squad", "--prompt", "Inspect"]).ok,
     false,
   );
+  assert.equal(parseThinCommand(["runtime", "run", "worker", "--prompt", "one", "--prompt-file", "two"]).ok, false);
   assert.equal(
-    parseThinCommand([
-      "runtime",
-      "run",
-      "worker",
-      "--prompt",
-      "one",
-      "--prompt-file",
-      "two",
-    ]).ok,
+    parseThinCommand(["runtime", "run", "worker", "--task", "task-1", "--prompt", "one", "--prompt-file", "two"]).ok,
     false,
   );
-  assert.equal(
-    parseThinCommand([
-      "runtime",
-      "run",
-      "worker",
-      "--task",
-      "task-1",
-      "--prompt",
-      "one",
-      "--prompt-file",
-      "two",
-    ]).ok,
-    false,
-  );
-  assert.equal(
-    parseThinCommand([
-      "runtime",
-      "run",
-      "worker",
-      "--to",
-      "terra",
-      "--prompt",
-      "Inspect",
-    ]).ok,
-    false,
-  );
-  assert.equal(
-    parseThinCommand(["runtime", "status", "runtime-1", "--task", "task-1"]).ok,
-    false,
-  );
+  assert.equal(parseThinCommand(["runtime", "run", "worker", "--to", "terra", "--prompt", "Inspect"]).ok, false);
+  assert.equal(parseThinCommand(["runtime", "status", "runtime-1", "--task", "task-1"]).ok, false);
   const taskWait = parseThinCommand(["runtime", "status", "--task", "task-1", "--wait", "--no-stream"]);
   assert.equal(taskWait.ok, true);
   if (taskWait.ok)
@@ -462,9 +328,6 @@ test("runtime work commands parse into closed daemon facade actions", () => {
       noStream: true,
     });
   assert.equal(parseThinCommand(["runtime", "status", "--wait"]).ok, false);
-  assert.equal(
-    parseThinCommand(["runtime", "status", "runtime-1", "--no-stream"]).ok,
-    false,
-  );
+  assert.equal(parseThinCommand(["runtime", "status", "runtime-1", "--no-stream"]).ok, false);
   assert.equal(parseThinCommand(["runtime", "wait", "runtime-1"]).ok, false);
 });

--- a/packages/daemon/src/agent-entities.contract.ts
+++ b/packages/daemon/src/agent-entities.contract.ts
@@ -6,9 +6,8 @@ export interface AgentSkillDeclarationV1 {
   readonly path: string;
 }
 export interface AgentFallbackDeclarationV1 {
-  readonly enabled: boolean;
   readonly chain: readonly { readonly instance: string; readonly model?: string }[];
-  readonly backoff: { readonly baseMs: number; readonly maxMs: number; readonly maxAttempts: number };
+  readonly backoff: { readonly baseMs: number; readonly maxMs: number };
 }
 export type AgentRole = "worker" | "commander";
 export interface AgentDeclarationV1 {
@@ -184,10 +183,9 @@ function agentSkills(value: unknown): value is readonly AgentSkillDeclarationV1[
 function agentFallbackErrors(value: unknown): readonly string[] {
   if (!isEntityRecord(value)) return ['agent declaration field "fallback" must be an object.'];
   const errors: string[] = [],
-    fields = ["enabled", "chain", "backoff"];
+    fields = ["chain", "backoff"];
   if (Object.keys(value).some((key) => !fields.includes(key)) || fields.some((key) => !Object.hasOwn(value, key)))
-    errors.push('agent declaration field "fallback" must contain exactly enabled, chain, and backoff.');
-  if (typeof value.enabled !== "boolean") errors.push('agent declaration field "fallback.enabled" must be boolean.');
+    errors.push('agent declaration field "fallback" must contain exactly chain and backoff.');
   if (
     !Array.isArray(value.chain) ||
     value.chain.length === 0 ||
@@ -208,28 +206,17 @@ function agentFallbackErrors(value: unknown): readonly string[] {
     return errors;
   }
   const backoff = value.backoff;
-  const backoffFields = ["baseMs", "maxMs", "maxAttempts"];
+  const backoffFields = ["baseMs", "maxMs"];
   if (
     Object.keys(backoff).some((key) => !backoffFields.includes(key)) ||
     backoffFields.some((key) => !Object.hasOwn(backoff, key))
   )
-    errors.push('agent declaration field "fallback.backoff" must contain exactly baseMs, maxMs, and maxAttempts.');
-  const { baseMs, maxMs, maxAttempts } = backoff;
+    errors.push('agent declaration field "fallback.backoff" must contain exactly baseMs and maxMs.');
+  const { baseMs, maxMs } = backoff;
   if (!Number.isSafeInteger(baseMs) || Number(baseMs) < 0)
     errors.push('agent declaration field "fallback.backoff.baseMs" must be a non-negative integer.');
   if (!Number.isSafeInteger(maxMs) || Number(maxMs) < Number(baseMs))
     errors.push('agent declaration field "fallback.backoff.maxMs" must be an integer greater than or equal to baseMs.');
-  if (
-    !Number.isSafeInteger(maxAttempts) ||
-    Number(maxAttempts) < 1 ||
-    (Array.isArray(value.chain) && Number(maxAttempts) > value.chain.length)
-  )
-    errors.push(
-      [
-        'agent declaration field "fallback.backoff.maxAttempts" must be positive and ',
-        "cannot exceed fallback.chain length.",
-      ].join(""),
-    );
   return errors;
 }
 // GUI read envelopes for the identity layers. These validators live in this pure contract

--- a/packages/daemon/src/agent-entities.ts
+++ b/packages/daemon/src/agent-entities.ts
@@ -263,19 +263,36 @@ export function readSquadDeclaration(input: {
     );
   return squad;
 }
-export interface SquadDispatchTarget {
+export interface SquadDispatchSelection {
   readonly squadId: string;
   readonly leader: AgentDeclarationV1;
-  readonly worker: AgentDeclarationV1;
+  readonly worker: AgentDeclarationV1 | null;
 }
-export function resolveSquadDispatchTarget(input: {
+export function resolveSquadDispatch(input: {
   readonly rootDir: string;
+  readonly squadId?: string;
   readonly leaderId: string;
-  readonly workerId: string;
+  readonly workerId?: string;
   readonly entityStore?: EntityStore;
-}): SquadDispatchTarget {
-  const entityStore = input.entityStore ?? openEntityStore(input.rootDir),
-    matches: SquadDispatchTarget[] = [];
+}): SquadDispatchSelection {
+  const entityStore = input.entityStore ?? openEntityStore(input.rootDir);
+  if (input.squadId) {
+    const squad = readSquadDeclaration({ rootDir: input.rootDir, squadId: input.squadId, entityStore });
+    if (squad.leader !== input.leaderId)
+      throw entityError("squad_leader_mismatch", `Agent ${input.leaderId} is not the leader of squad ${squad.id}.`);
+    if (input.workerId && !squad.workers.includes(input.workerId))
+      throw entityError("squad_member_not_found", `Agent ${input.workerId} is not a worker in squad ${squad.id}.`);
+    return {
+      squadId: squad.id,
+      leader: readAgentDeclaration({ rootDir: input.rootDir, agentId: squad.leader, entityStore }),
+      worker: input.workerId
+        ? readAgentDeclaration({ rootDir: input.rootDir, agentId: input.workerId, entityStore })
+        : null,
+    };
+  }
+  if (!input.workerId)
+    throw entityError("squad_not_found", `A squad id is required to dispatch leader ${input.leaderId}.`);
+  const matches: SquadDispatchSelection[] = [];
   for (const { id: squadId, value } of entityStore.list<SquadDeclarationV1>("squad")) {
     const squad = parseSquadDeclarationV1(value);
     if (squad.leader !== input.leaderId || !squad.workers.includes(input.workerId)) continue;

--- a/packages/daemon/src/daemon-host-registry.ts
+++ b/packages/daemon/src/daemon-host-registry.ts
@@ -3,10 +3,10 @@ import {
   consumeKnownError,
   readDaemonRegistry,
   unregisterDaemonRepo,
-  type AgentRuntimeEventV1,
   type DaemonRepoMode,
 } from "../../kernel/src/index.ts";
 import { canonicalRoot, workspaceId } from "./protocol/daemon-protocol.contract.ts";
+import type { RuntimeAttemptTerminal } from "./runtime-spawn.ts";
 
 export async function closeCell(context: any, repoId: string): Promise<void> {
   const cell = context.cells.get(repoId),
@@ -140,8 +140,8 @@ export async function performOpenRegistered(
       authoredBranch: repo.authoredBranch,
       ...(context.input.shutdownRequested ? { shouldStop: context.input.shutdownRequested } : {}),
       ...(context.input.recordLifecycle ? { recordLifecycle: context.input.recordLifecycle } : {}),
-      onRuntimeOutcome: (event: Extract<AgentRuntimeEventV1, { readonly type: "runtime_session_outcome_observed" }>) =>
-        void context.e2eProbeScheduler.onRuntimeOutcome(repo.repoId, event),
+      onAttemptTerminal: (terminal: RuntimeAttemptTerminal) =>
+        void context.e2eProbeScheduler.onAttemptTerminal(repo.repoId, terminal.runtimeSessionId),
       ...context.runtimePorts,
       ...(context.input.runtimeLaunch ? { runtimeLaunch: context.input.runtimeLaunch } : {}),
     });

--- a/packages/daemon/src/dispatch-read.ts
+++ b/packages/daemon/src/dispatch-read.ts
@@ -222,7 +222,8 @@ function archiveRow(
     classification = isClassification(value.classification)
       ? value.classification
       : (attemptOutcome?.classification ?? null),
-    reason = typeof value.reason === "string" ? value.reason : (attemptOutcome?.reason ?? null);
+    reason = typeof value.reason === "string" ? value.reason : (attemptOutcome?.reason ?? null),
+    outcome = isOutcome(value.outcome) ? value.outcome : (session?.outcome ?? "unknown");
   return {
     dispatchId: String(value.dispatchId),
     taskId: String(value.taskId),
@@ -258,16 +259,16 @@ function archiveRow(
           delegatedByAgentId: value.delegatedByAgentId,
           delegatedByAgentName:
             typeof value.delegatedByAgentName === "string" ? value.delegatedByAgentName : value.delegatedByAgentId,
-          squadId: String(value.squadId),
         }
       : {}),
+    ...(typeof value.squadId === "string" ? { squadId: value.squadId } : {}),
     providerSessionId:
       typeof value.providerSessionId === "string" ? value.providerSessionId : (session?.providerSessionId ?? null),
     eventStreamRef: typeof value.eventStreamRef === "string" ? value.eventStreamRef : null,
     startedAt: String(value.startedAt),
     endedAt: typeof value.endedAt === "string" ? value.endedAt : null,
-    outcome: isOutcome(value.outcome) ? value.outcome : (session?.outcome ?? "unknown"),
-    status: lost ? "lost" : isOutcome(value.outcome) ? value.outcome : (session?.outcome ?? "unknown"),
+    outcome,
+    status: lost ? "lost" : outcome,
     resultRef: typeof value.resultRef === "string" ? value.resultRef : (session?.resultRef ?? null),
     exitCode: typeof value.exitCode === "number" ? value.exitCode : (session?.exitCode ?? null),
     dispatchPath: `${packagePath}/artifacts/dispatches/${String(value.dispatchId)}.json`,
@@ -306,9 +307,9 @@ function liveRow(
       ? {
           delegatedByAgentId: header.delegatedByAgentId,
           delegatedByAgentName: header.delegatedByAgentName ?? header.delegatedByAgentId,
-          squadId: header.squadId!,
         }
       : {}),
+    ...(header.squadId ? { squadId: header.squadId } : {}),
     providerSessionId: providerSessionId ?? session?.providerSessionId ?? null,
     eventStreamRef: header.eventStreamRef,
     startedAt: header.startedAt,

--- a/packages/daemon/src/dispatch-stream.ts
+++ b/packages/daemon/src/dispatch-stream.ts
@@ -91,6 +91,7 @@ export interface DispatchStreamWriter {
       | {
           readonly state: "scheduled";
           readonly delayMs: number;
+          readonly notBeforeAt: string;
           readonly nextProvider: { readonly instance: string; readonly model?: string };
         }
       | { readonly state: "dispatched"; readonly nextDispatchId: string; readonly nextRuntimeSessionId: string }
@@ -246,6 +247,10 @@ export function readDispatchStream(
   readonly process: DispatchProcessState | null;
   readonly attemptOutcome: RuntimeAttemptOutcome | null;
   readonly fallbackState: "scheduled" | "dispatched" | "exhausted" | null;
+  readonly fallbackSchedule: {
+    readonly notBeforeAt: string;
+    readonly nextProvider: { readonly instance: string; readonly model?: string };
+  } | null;
   readonly nextDispatchId: string | null;
   readonly records: readonly DispatchStreamRecord[];
 } | null {
@@ -258,6 +263,10 @@ export function readDispatchStream(
     processState: DispatchProcessState | null = null,
     attemptOutcome: RuntimeAttemptOutcome | null = null,
     fallbackState: "scheduled" | "dispatched" | "exhausted" | null = null,
+    fallbackSchedule: {
+      readonly notBeforeAt: string;
+      readonly nextProvider: { readonly instance: string; readonly model?: string };
+    } | null = null,
     nextDispatchId: string | null = null;
   const records = lines
     .slice(1)
@@ -281,6 +290,12 @@ export function readDispatchStream(
     if (record.kind === "attempt_outcome" && isRuntimeAttemptOutcome(record)) attemptOutcome = record;
     if (record.kind === "fallback_state" && ["scheduled", "dispatched", "exhausted"].includes(String(record.state))) {
       fallbackState = record.state as typeof fallbackState;
+      fallbackSchedule =
+        record.state === "scheduled" &&
+        typeof record.notBeforeAt === "string" &&
+        isFallbackProvider(record.nextProvider)
+          ? { notBeforeAt: record.notBeforeAt, nextProvider: record.nextProvider }
+          : null;
       nextDispatchId = typeof record.nextDispatchId === "string" ? record.nextDispatchId : nextDispatchId;
     }
   }
@@ -290,9 +305,21 @@ export function readDispatchStream(
     process: processState,
     attemptOutcome,
     fallbackState,
+    fallbackSchedule,
     nextDispatchId,
     records,
   };
+}
+
+function isFallbackProvider(value: unknown): value is { readonly instance: string; readonly model?: string } {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof (value as { readonly instance?: unknown }).instance === "string" &&
+    ((value as { readonly model?: unknown }).model === undefined ||
+      typeof (value as { readonly model?: unknown }).model === "string")
+  );
 }
 
 export function readDispatchStreams(rootDir: string): readonly NonNullable<ReturnType<typeof readDispatchStream>>[] {

--- a/packages/daemon/src/e2e-probe-scheduler.ts
+++ b/packages/daemon/src/e2e-probe-scheduler.ts
@@ -1,11 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
-import {
-  consumeKnownError,
-  resolveHarnessLayout,
-  settingBlockValue,
-  type AgentRuntimeEventV1,
-} from "../../kernel/src/index.ts";
+import { consumeKnownError, resolveHarnessLayout, settingBlockValue } from "../../kernel/src/index.ts";
 import { readDispatchStreams } from "./dispatch-stream.ts";
 import type { RepoCell, RepoCellBinding } from "./repo-cell.ts";
 import type { RuntimeDaemonRoute } from "./runtime-spawn.ts";
@@ -190,19 +185,16 @@ export function makeE2EProbeScheduler(input: {
     timer = null;
   };
 
-  const onRuntimeOutcome = async (
-    repoId: string,
-    event: Extract<AgentRuntimeEventV1, { readonly type: "runtime_session_outcome_observed" }>,
-  ): Promise<void> => {
+  const onAttemptTerminal = async (repoId: string, runtimeSessionId: string): Promise<void> => {
     const current = active;
     if (
       !current ||
       current.repoId !== repoId ||
-      (current.runtimeSessionId !== null && current.runtimeSessionId !== event.payload.runtimeSessionId)
+      (current.runtimeSessionId !== null && current.runtimeSessionId !== runtimeSessionId)
     )
       return;
-    current.runtimeSessionId = event.payload.runtimeSessionId;
-    await settle(schedules.get(repoId)!, event.payload.runtimeSessionId, now(), current.token);
+    current.runtimeSessionId = runtimeSessionId;
+    await settle(schedules.get(repoId)!, runtimeSessionId, now(), current.token);
   };
 
   async function hydrate(schedule: E2EProbeSchedule): Promise<void> {
@@ -347,7 +339,7 @@ export function makeE2EProbeScheduler(input: {
     ].join("\n");
   }
 
-  return { start, close, status, onRuntimeOutcome };
+  return { start, close, status, onAttemptTerminal };
 }
 
 function disabledSchedule(source: string): E2EProbeScheduleConfig {

--- a/packages/daemon/src/fleet-edge-runtime.ts
+++ b/packages/daemon/src/fleet-edge-runtime.ts
@@ -7,7 +7,7 @@ import {
   type AgentRuntimeEventV1,
   type EntityStore,
 } from "../../kernel/src/index.ts";
-import { readAgentDeclaration, resolveSquadDispatchTarget } from "./agent-entities.ts";
+import { readAgentDeclaration, resolveSquadDispatch } from "./agent-entities.ts";
 import { parseAgentDeclarationV1 } from "./agent-entities.contract.ts";
 import type { PreparedRuntimeLaunch, RuntimeInstanceSummary } from "./agent-runtime-instances.ts";
 import {
@@ -249,58 +249,54 @@ export function openFleetEdgeRuntime(input: {
     resolveAgent: (agentId) =>
       trustedScheduleAgents.get(agentId) ??
       readAgentDeclaration({ rootDir: request.workspaceRoot, agentId, entityStore: getEntityStore() }),
-    resolveSquadDispatchTarget: (leaderId, workerId) =>
-      resolveSquadDispatchTarget({
+    resolveSquadDispatch: (squadId, leaderId, workerId) =>
+      resolveSquadDispatch({
         rootDir: request.workspaceRoot,
+        ...(squadId ? { squadId } : {}),
         leaderId,
-        workerId,
+        ...(workerId ? { workerId } : {}),
         entityStore: getEntityStore(),
       }),
-    onFallbackExhausted: async ({ taskId, executionId, reason }) => {
-      const waitMs = runtimeReadTimeoutMs ?? 30_000,
-        release = await runFleetTaskCommandClient({
-          ...peer,
-          repoId: request.repoId,
-          taskId,
-          opId: `provider-fallback-release-${executionId}`,
-          waitMs,
-          action: { kind: "task-release", taskId, reason: `Provider fallback exhausted: ${reason}` },
-        });
-      if (release.outcome !== "applied")
-        throw edgeRuntimeError(
-          "fallback_block_failed",
-          `Center rejected provider fallback lease release: ${String(release.code ?? release.outcome)}.`,
-        );
-      const blocked = await runFleetTaskCommandClient({
-        ...peer,
-        repoId: request.repoId,
-        taskId,
-        opId: `provider-fallback-block-${executionId}`,
-        waitMs,
-        action: { kind: "task-transition", taskId, status: "blocked", reason },
-      });
-      if (blocked.outcome !== "applied")
-        throw edgeRuntimeError(
-          "fallback_block_failed",
-          `Center rejected provider fallback blocked transition: ${String(blocked.code ?? blocked.outcome)}.`,
-        );
-    },
-    onRuntimeOutcome: (event, scheduled) => {
+    onAttemptTerminal: async (terminal) => {
+      if (terminal.fallbackExhausted && terminal.task) {
+        const waitMs = runtimeReadTimeoutMs ?? 30_000,
+          { taskId, executionId } = terminal.task,
+          settled = await runFleetTaskCommandClient({
+            ...peer,
+            repoId: request.repoId,
+            taskId,
+            opId: `provider-fallback-exhausted-${executionId}`,
+            waitMs,
+            action: {
+              kind: "task-fallback-exhausted",
+              taskId,
+              executionId,
+              reason: terminal.reason ?? "Provider fallback exhausted.",
+            },
+          });
+        if (settled.outcome !== "applied")
+          throw edgeRuntimeError(
+            "fallback_block_failed",
+            `Center rejected provider fallback exhaustion settlement: ${String(settled.code ?? settled.outcome)}.`,
+          );
+      }
+      const scheduled = terminal.schedule,
+        detail = terminal.resultRef ?? terminal.reason;
       if (!scheduled) return;
       schedule(async () => {
         const response = await runFleetScheduleCommandClient({
           ...peer,
           repoId: request.repoId,
           scheduleId: scheduled.scheduleId,
-          opId: `${event.payload.runtimeSessionId}-schedule-outcome`,
+          opId: `${terminal.runtimeSessionId}-schedule-attempt-terminal`,
           action: {
             kind: "schedule-settle",
             phase: "outcome",
             scheduleId: scheduled.scheduleId,
             claimFence: scheduled.claimFence,
-            outcome: event.payload.outcome,
-            endedAt: event.occurredAt,
-            detail: event.payload.resultRef,
+            outcome: terminal.outcome,
+            endedAt: terminal.endedAt,
+            ...(detail ? { detail } : {}),
           },
         });
         if (response.outcome !== "applied")

--- a/packages/daemon/src/fleet/contract.ts
+++ b/packages/daemon/src/fleet/contract.ts
@@ -29,6 +29,7 @@ export const FLEET_TASK_COMMAND_KINDS = Object.freeze([
   "task-progress-append",
   "task-submit",
   "task-release",
+  "task-fallback-exhausted",
   "task-transition",
   "task-show",
 ] as const);
@@ -390,6 +391,10 @@ const taskActionShapes: Readonly<Record<FleetTaskCommandKind, Check>> = {
   ),
   "task-submit": optionalShape({ kind: one("task-submit"), taskId: id, executionId: id, submission: record }, ["kind"]),
   "task-release": optionalShape({ kind: one("task-release"), taskId: id, reason: text }, ["kind"]),
+  "task-fallback-exhausted": optionalShape(
+    { kind: one("task-fallback-exhausted"), taskId: id, executionId: id, reason: text },
+    ["kind", "taskId", "executionId", "reason"],
+  ),
   "task-transition": optionalShape({ kind: one("task-transition"), taskId: id, status: one("blocked"), reason: text }, [
     "kind",
     "taskId",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-runtime-fleet.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-runtime-fleet.ts
@@ -29,6 +29,10 @@ export const runtimeFleetProtocolCommands = Object.freeze([
         code: "invalid_field",
         nextAction: "Use --to <worker-agent-id> only with --agent <leader-agent-id>.",
       }),
+      cliInput("--squad", "single", false, {
+        code: "invalid_field",
+        nextAction: "Use --squad <squad-id> only with --agent <leader-agent-id>.",
+      }),
       cliInput("--model", "single", false, {
         code: "invalid_field",
         nextAction: "Use one model supported by the runtime instance.",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
@@ -27,6 +27,16 @@ export const taskSurfaceProtocolCommands = Object.freeze([
       }),
     ],
   }),
+  defineCenterForwardWriteCommand({
+    id: "task-fallback-exhausted",
+    actionKind: "task-fallback-exhausted",
+    internal: true,
+    phase: "Runtime-B",
+    path: ["task", "_fallback-exhausted", "<task-id>"],
+    summary: "Atomically release a fallback attempt lease and move its Task to blocked.",
+    method: "repo.task.run",
+    inputs: [],
+  }),
   defineLedgerWriteCommand({
     id: "task-declare-executor",
     phase: "W3",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task-surface.ts
@@ -16,6 +16,7 @@ export const taskSurfaceProtocolCommands = Object.freeze([
   }),
   defineCenterForwardWriteCommand({
     id: "task-release",
+    actionAliases: ["task-fallback-exhausted"],
     phase: "W3",
     path: ["task", "release", "<task-id>"],
     summary: "Release the authenticated holder lease and preserve the Execution audit trail.",
@@ -26,16 +27,6 @@ export const taskSurfaceProtocolCommands = Object.freeze([
         nextAction: "Use one non-empty --reason, or omit it for the standard release audit.",
       }),
     ],
-  }),
-  defineCenterForwardWriteCommand({
-    id: "task-fallback-exhausted",
-    actionKind: "task-fallback-exhausted",
-    internal: true,
-    phase: "Runtime-B",
-    path: ["task", "_fallback-exhausted", "<task-id>"],
-    summary: "Atomically release a fallback attempt lease and move its Task to blocked.",
-    method: "repo.task.run",
-    inputs: [],
   }),
   defineLedgerWriteCommand({
     id: "task-declare-executor",

--- a/packages/daemon/src/protocol/daemon-protocol-commands.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands.ts
@@ -213,7 +213,7 @@ export function resolveThinCliCommand(args: readonly string[]): (typeof daemonPr
 
 export function commandDescriptorForAction(kind: string) {
   const descriptor =
-    daemonProtocolCommands.find((entry) => ("actionKind" in entry ? entry.actionKind : entry.id) === kind) ??
+    daemonProtocolCommands.find((entry) => commandAcceptsAction(entry, kind)) ??
     presetMethods.find((entry) => entry.actionKind === kind);
   if (!descriptor)
     throw new DaemonProtocolContractError("unsupported_command", `No command descriptor exists for ${kind}.`);
@@ -227,9 +227,7 @@ export function commandClassForAction(kind: string): "repo-read" | "repo-write" 
 export function actionForDaemonMethod(method: string, payload: JsonObject): JsonObject & { readonly kind: string } {
   if (method === "repo.task.run") {
     const action = payload.action as JsonObject & { readonly kind: string },
-      descriptor = daemonProtocolCommands.find(
-        (entry) => ("actionKind" in entry ? entry.actionKind : entry.id) === action.kind,
-      );
+      descriptor = daemonProtocolCommands.find((entry) => commandAcceptsAction(entry, action.kind));
     if (descriptor?.method !== method)
       throw new DaemonProtocolContractError(
         "unsupported_command",
@@ -243,4 +241,11 @@ export function actionForDaemonMethod(method: string, payload: JsonObject): Json
   const command = presetCommands.find((entry) => entry.method === method),
     defaults = command && "actionDefaults" in command ? command.actionDefaults : {};
   return { ...defaults, kind: descriptor.actionKind, ...payload };
+}
+
+function commandAcceptsAction(entry: (typeof daemonProtocolCommands)[number], kind: string): boolean {
+  return (
+    ("actionKind" in entry ? entry.actionKind : entry.id) === kind ||
+    ("actionAliases" in entry && entry.actionAliases.some((alias) => alias === kind))
+  );
 }

--- a/packages/daemon/src/protocol/daemon-protocol-gui-actions.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-gui-actions.ts
@@ -242,6 +242,7 @@ export const daemonGuiActionMethods = Object.freeze([
       dispatchId: "string?",
       agentId: "string?",
       targetAgentId: "string?",
+      squadId: "string?",
       model: "string?",
       effort: "string?",
       permissionMode: "string?",

--- a/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
@@ -348,6 +348,7 @@ export function validateGuiActionPayload(method: DaemonGuiActionMethod, value: u
       (value.dispatchId !== undefined && !nonEmpty(value.dispatchId)) ||
       (value.agentId !== undefined && !nonEmpty(value.agentId)) ||
       (value.targetAgentId !== undefined && !nonEmpty(value.targetAgentId)) ||
+      (value.squadId !== undefined && !nonEmpty(value.squadId)) ||
       (value.model !== undefined && !nonEmpty(value.model)) ||
       (value.effort !== undefined && !nonEmpty(value.effort)) ||
       (value.permissionMode !== undefined && !nonEmpty(value.permissionMode)) ||

--- a/packages/daemon/src/repo-cell-evidence.ts
+++ b/packages/daemon/src/repo-cell-evidence.ts
@@ -56,6 +56,7 @@ export function renderEvidenceRows(rows: readonly unknown[], named = false): str
 export function taskSurfaceWriteKind(kind: string): boolean {
   return [
     "task-release",
+    "task-fallback-exhausted",
     "task-amend",
     "task-archive",
     "task-supersede",

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -9,7 +9,7 @@ import {
 } from "../../kernel/src/index.ts";
 import { createPresetProcessService, presetUserRoot } from "../../preset/src/index.ts";
 import { ledgerWriteCommandTopology } from "../../preset/src/preset-command-contract.ts";
-import { readAgentDeclaration, resolveSquadDispatchTarget } from "./agent-entities.ts";
+import { readAgentDeclaration, resolveSquadDispatch } from "./agent-entities.ts";
 import type { PreparedRuntimeLaunch, RuntimeInstanceSummary } from "./agent-runtime-instances.ts";
 import { makeAgentRuntimeStreamHub } from "./agent-runtime-stream.ts";
 import { openGuiCatalog } from "./gui-catalog.ts";
@@ -41,7 +41,12 @@ import type {
 } from "./repo-cell-types.ts";
 import { admitRepoMode } from "./repo-mode.ts";
 import { makeDaemonRuntimeAdmissionGuard } from "./runtime-admission.ts";
-import { makeRuntimeSpawner, type RuntimeDaemonRoute, type RuntimeLauncher } from "./runtime-spawn.ts";
+import {
+  makeRuntimeSpawner,
+  type RuntimeAttemptTerminal,
+  type RuntimeDaemonRoute,
+  type RuntimeLauncher,
+} from "./runtime-spawn.ts";
 import { openTerminalHost } from "./terminal-host.ts";
 import { makeSquadCoordinator } from "./squad-coordinator.ts";
 import type { DaemonLifecycleRecorder } from "./lifecycle-log.ts";
@@ -79,6 +84,7 @@ export async function openRepoCell(input: {
       { readonly type: "runtime_session_outcome_observed" }
     >,
   ) => void;
+  readonly onAttemptTerminal?: (terminal: RuntimeAttemptTerminal) => void;
   readonly now?: () => string;
   readonly killpoint?: (point: EventPublicationKillpoint) => void;
   readonly shouldStop?: () => boolean;
@@ -270,13 +276,7 @@ export async function openRepoCell(input: {
   }) => Promise<void> = async () => {
     throw cellCodedError("runtime_preconditions_unavailable", "RepoCell fallback settlement is not ready.");
   };
-  let settleScheduledOutcome: (
-    event: Extract<
-      import("../../kernel/src/index.ts").AgentRuntimeEventV1,
-      { readonly type: "runtime_session_outcome_observed" }
-    >,
-    scheduled: { readonly scheduleId: string; readonly claimFence: string },
-  ) => Promise<void> = async () => {
+  let settleScheduledOutcome: (terminal: RuntimeAttemptTerminal) => Promise<void> = async () => {
     throw cellCodedError("runtime_preconditions_unavailable", "RepoCell Schedule settlement is not ready.");
   };
   const runtimeSpawner = makeRuntimeSpawner({
@@ -293,14 +293,28 @@ export async function openRepoCell(input: {
     prepareLaunch: input.prepareRuntimeLaunch ?? unavailableRuntimeInstanceStore,
     ...(input.prepareWorkerGitEnvironment ? { prepareWorkerGitEnvironment: input.prepareWorkerGitEnvironment } : {}),
     resolveAgent: (agentId) => readAgentDeclaration({ rootDir, agentId, entityStore: createEntityStore(store) }),
-    resolveSquadDispatchTarget: (leaderId, workerId) =>
-      resolveSquadDispatchTarget({ rootDir, leaderId, workerId, entityStore: createEntityStore(store) }),
-    onRuntimeOutcome: (event, scheduled) => {
+    resolveSquadDispatch: (squadId, leaderId, workerId) =>
+      resolveSquadDispatch({
+        rootDir,
+        ...(squadId ? { squadId } : {}),
+        leaderId,
+        ...(workerId ? { workerId } : {}),
+        entityStore: createEntityStore(store),
+      }),
+    onRuntimeOutcome: (event) => {
       schedule(() => squadCoordinator.observeOutcome(event));
-      if (scheduled) schedule(() => settleScheduledOutcome(event, scheduled));
       input.onRuntimeOutcome?.(event);
     },
-    onFallbackExhausted: (value) => settleFallbackExhaustion(value as Parameters<typeof settleFallbackExhaustion>[0]),
+    onAttemptTerminal: async (terminal) => {
+      if (terminal.fallbackExhausted && terminal.task)
+        await settleFallbackExhaustion({
+          ...terminal.task,
+          reason: terminal.reason ?? "Provider fallback exhausted.",
+          binding: terminal.binding,
+        });
+      if (terminal.schedule) schedule(() => settleScheduledOutcome(terminal));
+      input.onAttemptTerminal?.(terminal);
+    },
     ...(input.recordLifecycle ? { recordLifecycle: input.recordLifecycle } : {}),
     ...(input.runtimeLaunch ? { launch: input.runtimeLaunch } : {}),
   });
@@ -376,17 +390,20 @@ export async function openRepoCell(input: {
   });
   const scheduleActions = makeRepoCellScheduleActions(extracted);
   Object.assign(extracted, { mode, runtimeSpawner, scheduleActions });
-  settleScheduledOutcome = async (event, scheduled) => {
+  settleScheduledOutcome = async (terminal) => {
+    const scheduled = terminal.schedule,
+      detail = terminal.resultRef ?? terminal.reason;
+    if (!scheduled) return;
     const receipt = scheduleActions.settle(
       {
         scheduleId: scheduled.scheduleId,
         claimFence: scheduled.claimFence,
-        outcome: event.payload.outcome,
-        endedAt: event.occurredAt,
-        detail: event.payload.resultRef,
-        idempotencyKey: `${event.payload.runtimeSessionId}:outcome`,
+        outcome: terminal.outcome,
+        endedAt: terminal.endedAt,
+        ...(detail ? { detail } : {}),
+        idempotencyKey: `${terminal.runtimeSessionId}:attempt-terminal`,
       },
-      { actor: event.actor, source: "local" },
+      terminal.binding,
     );
     if (receipt.outcome !== "applied")
       throw cellCodedError(
@@ -395,29 +412,12 @@ export async function openRepoCell(input: {
       );
   };
   settleFallbackExhaustion = async ({ taskId, executionId, reason, binding }) => {
-    const before = await service.read(taskId);
-    if (before.snapshot.lease) {
-      if (before.snapshot.lease.executionId !== executionId)
-        throw cellCodedError(
-          "lease_conflict",
-          [
-            `Fallback exhaustion belongs to ${executionId}, but `,
-            `${before.snapshot.lease.executionId} holds the task lease.`,
-          ].join(""),
-        );
-      const released = await extracted.taskSurfaceWrite(
-        { kind: "task-release", taskId, reason: `Release after provider fallback exhaustion: ${reason}` },
-        binding,
-      );
-      if (released.outcome !== "applied")
-        throw cellCodedError("fallback_block_failed", `Fallback lease release was ${released.outcome}.`);
-    }
-    const blocked = await extracted.lifecycleAction(
-      { kind: "task-transition", taskId, status: "blocked", reason },
+    const settled = await extracted.taskSurfaceWrite(
+      { kind: "task-fallback-exhausted", taskId, executionId, reason },
       binding,
     );
-    if (blocked.outcome !== "applied")
-      throw cellCodedError("fallback_block_failed", `Fallback task transition was ${blocked.outcome}.`);
+    if (settled.outcome !== "applied")
+      throw cellCodedError("fallback_block_failed", `Fallback exhaustion settlement was ${settled.outcome}.`);
   };
   await runtimeSpawner.adopt();
   schedule(() => squadCoordinator.reconcile());

--- a/packages/daemon/src/repo-cell-task-mutation.ts
+++ b/packages/daemon/src/repo-cell-task-mutation.ts
@@ -1,5 +1,6 @@
 import {
   deriveRelationId,
+  explainStatusTransition,
   isTerminalStatus,
   taskClasses,
   validateRelationRecordsForHost,
@@ -48,9 +49,19 @@ export function taskMutation(
       amendPatches.every(
         (raw) => raw !== null && typeof raw === "object" && (raw as Record<string, unknown>).field === "pinned",
       );
-  if (action.kind === "task-release") {
+  if (action.kind === "task-release" || action.kind === "task-fallback-exhausted") {
     if (!activeLease)
       throw cell.cellCodedError("lease_not_found", `Start task ${task.taskId} before releasing its lease.`);
+    if (action.kind === "task-fallback-exhausted" && action.executionId !== activeLease.executionId)
+      throw cell.cellCodedError(
+        "lease_conflict",
+        `Fallback exhaustion belongs to ${String(action.executionId)}, but ${activeLease.executionId} holds the lease.`,
+      );
+    if (action.kind === "task-fallback-exhausted" && !explainStatusTransition(task.status, "blocked").allowed)
+      throw cell.cellCodedError(
+        "invalid_transition",
+        `Task ${task.taskId} cannot move from ${task.status} to blocked.`,
+      );
     const execution = snapshot.executions.find((value) => value.executionId === activeLease.executionId),
       actionId = `task-release:${task.taskId}:${activeLease.executionId}:${snapshot.revision}`,
       authorizationDecision = authorizeAction(
@@ -75,11 +86,15 @@ export function taskMutation(
       );
     return {
       type: "lease_released",
-      task,
+      task: action.kind === "task-fallback-exhausted" ? { ...task, status: "blocked" } : task,
       ...(execution === undefined ? {} : { execution }),
       releasedLease: activeLease,
       authorizationDecision,
-      audit: { command: "release", reason, fields: ["lease"] },
+      audit: {
+        command: "release",
+        reason,
+        fields: action.kind === "task-fallback-exhausted" ? ["lease", "status"] : ["lease"],
+      },
     };
   }
   if (activeLease && !pinOnlyAmend)

--- a/packages/daemon/src/runtime-fallback-contract.ts
+++ b/packages/daemon/src/runtime-fallback-contract.ts
@@ -22,7 +22,7 @@ export type RuntimeFallbackAttempt = {
   readonly rootIdempotencyKey: string;
   readonly originalMission: string;
   readonly candidates: readonly RuntimeFallbackCandidate[];
-  readonly backoff: { readonly baseMs: number; readonly maxMs: number; readonly maxAttempts: number };
+  readonly backoff: { readonly baseMs: number; readonly maxMs: number };
 };
 
 export type RuntimeAttemptOutcome = {

--- a/packages/daemon/src/runtime-spawn-adoption.ts
+++ b/packages/daemon/src/runtime-spawn-adoption.ts
@@ -19,6 +19,7 @@ export async function adoptRuntimes(context: any): Promise<void> {
     sessions.map((session: { readonly runtimeSessionId: string }) => [session.runtimeSessionId, session]),
   );
   for (const stream of readDispatchStreams(context.input.rootDir)) {
+    context.reconcileFallback(stream);
     const session = byId.get(stream.header.runtimeSessionId) as
       | { readonly liveness: string; readonly outcome: string | null }
       | undefined;

--- a/packages/daemon/src/runtime-spawn-settlement.ts
+++ b/packages/daemon/src/runtime-spawn-settlement.ts
@@ -30,19 +30,8 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
         (code === 0 && (active.finalText === null || active.providerOutcome === null)))
     )
       context.markProtocolError(active);
-    const writeEvidenceRequired = active.kindId !== "agy" && active.permissionMode !== "read-only",
-      letOutcome = cancelled
-        ? ("cancelled" as const)
-        : code === null || active.protocolError
-          ? ("unknown" as const)
-          : code !== 0
-            ? ("failed" as const)
-            : active.providerOutcome === "succeeded" &&
-                (active.planIncomplete || (writeEvidenceRequired && !active.writeItemObserved && !active.planObserved))
-              ? ("unknown" as const)
-              : (active.providerOutcome ?? ("unknown" as const));
-    let outcome = letOutcome;
-    const classifiedAttempt = classifyRuntimeExit(active, code),
+    const outcome = deriveRuntimeSpawnOutcome(active, code),
+      classifiedAttempt = classifyRuntimeExit(active, code),
       attemptOutcome = {
         ...classifiedAttempt,
         reason: String(scrubProviderValue(classifiedAttempt.reason)).slice(0, 1024),
@@ -73,11 +62,11 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
             dispatchId: active.dispatchId,
             ...active.task,
             ...(active.agent ? { agentId: active.agent.id, agentName: active.agent.name } : {}),
+            ...(active.squadId ? { squadId: active.squadId } : {}),
             ...(active.delegatedBy
               ? {
                   delegatedByAgentId: active.delegatedBy.id,
                   delegatedByAgentName: active.delegatedBy.name,
-                  squadId: active.squadId!,
                 }
               : {}),
             instanceId: active.instanceId,
@@ -123,7 +112,8 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
           );
       } catch (error) {
         consumeKnownError(error);
-        outcome = "unknown";
+        const detail = String(scrubProviderValue(error instanceof Error ? error.message : String(error))).slice(0, 512);
+        console.warn(`[runtime-archive] ${active.dispatchId} could not be archived: ${detail}`);
       }
     context.input.stream.publish(active.runtimeSessionId, { type: "exit", outcome });
     context.input.recordLifecycle?.({
@@ -180,11 +170,48 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
           };
     context.processes.delete(active.runtimeSessionId);
     active.process.release?.();
-    await context.settleFallback(active, attemptOutcome);
+    await context.settleFallback(active, attemptOutcome, {
+      runtimeSessionId: active.runtimeSessionId,
+      dispatchId: active.dispatchId,
+      task: active.task,
+      schedule: active.schedule,
+      outcome: outcome === "succeeded" ? "succeeded" : "failed",
+      fallbackExhausted: false,
+      reason: outcome === "succeeded" ? null : attemptOutcome.reason,
+      endedAt,
+      resultRef,
+      binding: active.binding,
+    });
     if (notification) setImmediate(() => context.launchExitNotification({ ...notification, now: context.input.now }));
   } finally {
     context.exiting.delete(active.runtimeSessionId);
   }
+}
+
+export function deriveRuntimeSpawnOutcome(
+  active: Pick<
+    ActiveRuntime,
+    | "cancelRequested"
+    | "kindId"
+    | "permissionMode"
+    | "planIncomplete"
+    | "planObserved"
+    | "protocolError"
+    | "providerOutcome"
+    | "writeItemObserved"
+  >,
+  code: number | null,
+): "succeeded" | "failed" | "unknown" | "cancelled" {
+  if (active.cancelRequested) return "cancelled";
+  if (code === null || active.protocolError) return "unknown";
+  if (code !== 0) return "failed";
+  const writeEvidenceRequired = active.kindId !== "agy" && active.permissionMode !== "read-only";
+  if (
+    active.providerOutcome === "succeeded" &&
+    (active.planIncomplete || (writeEvidenceRequired && !active.writeItemObserved && !active.planObserved))
+  )
+    return "unknown";
+  return active.providerOutcome ?? "unknown";
 }
 
 export function runtimeResultText(

--- a/packages/daemon/src/runtime-spawn-types.ts
+++ b/packages/daemon/src/runtime-spawn-types.ts
@@ -55,6 +55,19 @@ export interface TrustedScheduleSpawn extends TrustedScheduleRuntime {
   readonly cwd?: string;
 }
 
+export interface RuntimeAttemptTerminal {
+  readonly runtimeSessionId: string;
+  readonly dispatchId: string;
+  readonly task: { readonly taskId: string; readonly executionId: string } | null;
+  readonly schedule: TrustedScheduleRuntime | null;
+  readonly outcome: "succeeded" | "failed";
+  readonly fallbackExhausted: boolean;
+  readonly reason: string | null;
+  readonly endedAt: string;
+  readonly resultRef: string | null;
+  readonly binding: RuntimeBinding;
+}
+
 export type RuntimeAgent = {
   readonly id: string;
   readonly name: string;

--- a/packages/daemon/src/runtime-spawn.ts
+++ b/packages/daemon/src/runtime-spawn.ts
@@ -2,6 +2,7 @@ export { launchExitNotification } from "./runtime-spawn-process.ts";
 export type {
   RemoteRuntimePersistence,
   RuntimeDaemonRoute,
+  RuntimeAttemptTerminal,
   RuntimeLauncher,
   RuntimeProcess,
   TrustedScheduleRuntime,

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -14,7 +14,7 @@ import {
 } from "../../kernel/src/index.ts";
 import { createRuntime } from "../../preset/src/preset-resolver.ts";
 import { presetRuntimeDefaults, presetUserRoot } from "../../preset/src/preset-system.ts";
-import type { SquadDispatchTarget } from "./agent-entities.ts";
+import type { SquadDispatchSelection } from "./agent-entities.ts";
 import { runtimeTypeMatchesKind } from "./agent-runtime-contract.ts";
 import type { PreparedRuntimeLaunch, RuntimeInstanceSummary } from "./agent-runtime-instances.ts";
 import type { AgentRuntimeStreamHub } from "./agent-runtime-stream.ts";
@@ -22,6 +22,7 @@ import { resolveAgentSkills } from "./agent-skills.ts";
 import {
   openDispatchStream,
   readDispatchStream,
+  reopenDispatchStream,
   removeDispatchStream,
   scrubProviderValue,
   type DispatchStreamWriter,
@@ -78,6 +79,7 @@ import type {
   RuntimeAgent,
   RuntimeBinding,
   RuntimeDaemonRoute,
+  RuntimeAttemptTerminal,
   RuntimeLauncher,
   RuntimeProcess,
   TrustedScheduleRuntime,
@@ -116,24 +118,22 @@ export function makeRuntimeSpawner(input: {
   ) => Promise<PreparedRuntimeLaunch>;
   readonly prepareWorkerGitEnvironment?: (instanceId: string) => Promise<NodeJS.ProcessEnv | null>;
   readonly resolveAgent?: (agentId: string) => RuntimeAgent;
-  readonly resolveSquadDispatchTarget?: (leaderId: string, workerId: string) => SquadDispatchTarget;
+  readonly resolveSquadDispatch?: (
+    squadId: string | undefined,
+    leaderId: string,
+    workerId?: string,
+  ) => SquadDispatchSelection;
   readonly launch?: RuntimeLauncher;
   readonly schedule: (work: () => void | Promise<void>) => void;
   readonly onRuntimeOutcome?: (
     event: Extract<AgentRuntimeEventV1, { readonly type: "runtime_session_outcome_observed" }>,
     schedule: TrustedScheduleRuntime | null,
   ) => void;
-  readonly onFallbackExhausted?: (input: {
-    readonly taskId: string;
-    readonly executionId: string;
-    readonly reason: string;
-    readonly binding: RuntimeBinding;
-  }) => void | Promise<void>;
+  readonly onAttemptTerminal?: (terminal: RuntimeAttemptTerminal) => void | Promise<void>;
   readonly recordLifecycle?: DaemonLifecycleRecorder;
 }) {
   const processes = new Map<string, ActiveRuntime>(),
     exiting = new Set<string>(),
-    fallbackTimers = new Set<ReturnType<typeof setTimeout>>(),
     launch = input.launch ?? launchNative,
     prepareWorkerGitEnvironment = async (instanceId: string): Promise<NodeJS.ProcessEnv | undefined> => {
       const credentialEnvironment = await input.prepareWorkerGitEnvironment?.(instanceId);
@@ -145,6 +145,7 @@ export function makeRuntimeSpawner(input: {
           }
         : undefined;
     };
+  let fallbackClosed = false;
   const extracted = {
     input,
     requiredRuntimeStore,
@@ -168,6 +169,7 @@ export function makeRuntimeSpawner(input: {
     captureErrorOutput,
     prepareWorkerGitEnvironment,
     settleFallback,
+    reconcileFallback,
   };
 
   const spawnAttempt = async (
@@ -181,6 +183,7 @@ export function makeRuntimeSpawner(input: {
         "dispatchId",
         "agentId",
         "targetAgentId",
+        "squadId",
         "model",
         "effort",
         "permissionMode",
@@ -213,6 +216,7 @@ export function makeRuntimeSpawner(input: {
         payload.targetAgentId === undefined
           ? undefined
           : requiredRuntimeSpawnText(payload.targetAgentId, "targetAgentId"),
+      squadId = payload.squadId === undefined ? undefined : requiredRuntimeSpawnText(payload.squadId, "squadId"),
       model = payload.model === undefined ? undefined : requiredRuntimeSpawnText(payload.model, "model"),
       effort = payload.effort === undefined ? undefined : requiredRuntimeSpawnText(payload.effort, "effort"),
       permissionMode =
@@ -236,6 +240,8 @@ export function makeRuntimeSpawner(input: {
           : resumed?.providerSessionId;
     if (targetAgentId !== undefined && agentId === undefined)
       throw runtimeSpawnError("squad_leader_required", "Targeted squad dispatch requires --agent <leader-id>.");
+    if (squadId !== undefined && agentId === undefined)
+      throw runtimeSpawnError("squad_leader_required", "Squad attribution requires --agent <leader-id>.");
     const cwd = resolveRuntimeCwd(input.rootDir, payload.cwd),
       store = input.remote ? null : requiredRuntimeStore(input),
       projection = input.remote ? null : requiredRuntimeProjection(input),
@@ -317,18 +323,21 @@ export function makeRuntimeSpawner(input: {
                 runtimeActor,
               })
             : mission,
-      target = targetAgentId
-        ? (input.resolveSquadDispatchTarget?.(agentId!, targetAgentId) ??
-          (() => {
-            throw runtimeSpawnError(
-              "squad_member_not_found",
-              `Agent ${targetAgentId} is not available in a squad led by ${agentId}.`,
-            );
-          })())
-        : null,
-      delegatedBy = target?.leader ?? null,
+      squad =
+        squadId || targetAgentId
+          ? (input.resolveSquadDispatch?.(squadId, agentId!, targetAgentId) ??
+            (() => {
+              if (squadId) throw runtimeSpawnError("squad_not_found", `Squad ${squadId} is unavailable.`);
+              throw runtimeSpawnError(
+                "squad_member_not_found",
+                `Agent ${targetAgentId} is not available in a squad led by ${agentId}.`,
+              );
+            })())
+          : null,
+      delegatedBy = squad?.worker ? squad.leader : null,
       agent =
-        target?.worker ??
+        squad?.worker ??
+        squad?.leader ??
         (agentId
           ? (input.resolveAgent?.(agentId) ??
             (() => {
@@ -352,15 +361,7 @@ export function makeRuntimeSpawner(input: {
         : undefined,
       fallbackAttempt =
         inheritedFallback ??
-        initialFallbackAttempt(
-          agent,
-          explicitRuntimeInstanceId,
-          model,
-          providerSessionId,
-          taskId,
-          idempotencyKey,
-          mission,
-        ),
+        initialFallbackAttempt(agent, explicitRuntimeInstanceId, model, providerSessionId, idempotencyKey, mission),
       fallbackCandidate = fallbackAttempt?.candidates[fallbackAttempt.attemptIndex],
       prompt = agent
         ? assembleAgentPrompt(agent, selfContainedMission ?? mission, preset, resolvedSkills)
@@ -488,11 +489,11 @@ export function makeRuntimeSpawner(input: {
         resumeProviderSessionId: providerSessionId ?? null,
         ...(onExitCommand ? { onExitCommand } : {}),
         ...(agent ? { agentId: agent.id, agentName: agent.name } : {}),
+        ...(squad ? { squadId: squad.squadId } : {}),
         ...(delegatedBy
           ? {
               delegatedByAgentId: delegatedBy.id,
               delegatedByAgentName: delegatedBy.name,
-              squadId: target!.squadId,
             }
           : {}),
       }));
@@ -599,7 +600,7 @@ export function makeRuntimeSpawner(input: {
       permissionMode: launchedPermissionMode ?? null,
       agent,
       delegatedBy,
-      squadId: target?.squadId ?? null,
+      squadId: squad?.squadId ?? null,
       binding,
       task: taskBinding,
       schedule: trustedSchedule ?? null,
@@ -654,8 +655,7 @@ export function makeRuntimeSpawner(input: {
     adopt: () => adoptRuntimes(extracted),
     cancel: (payload: JsonObject, binding: RuntimeBinding) => cancelRuntime(extracted, payload, binding),
     close: () => {
-      for (const timer of fallbackTimers) clearTimeout(timer);
-      fallbackTimers.clear();
+      fallbackClosed = true;
       closeRuntimes(extracted);
     },
   };
@@ -713,22 +713,28 @@ export function makeRuntimeSpawner(input: {
   function controlReceipt(opId: string, runtimeSessionId: string, detail?: string) {
     return controlReceiptImpl(extracted, opId, runtimeSessionId, detail);
   }
-  async function settleFallback(active: ActiveRuntime, outcome: RuntimeAttemptOutcome): Promise<void> {
+  async function settleFallback(
+    active: ActiveRuntime,
+    outcome: RuntimeAttemptOutcome,
+    terminal: RuntimeAttemptTerminal,
+  ): Promise<void> {
     const fallback = active.fallbackAttempt;
-    if (outcome.classification !== "provider_fault" || !fallback || !active.task) return;
+    if (outcome.classification !== "provider_fault" || !fallback) {
+      await input.onAttemptTerminal?.(terminal);
+      return;
+    }
     const nextAttemptIndex = fallback.attemptIndex + 1,
-      exhausted = nextAttemptIndex >= fallback.backoff.maxAttempts || nextAttemptIndex >= fallback.candidates.length;
+      exhausted = nextAttemptIndex >= fallback.candidates.length;
     if (exhausted) {
       const reason = `Provider fallback exhausted after ${String(nextAttemptIndex)} attempt(s): ${outcome.reason}`;
       active.stream.appendFallbackState({ state: "exhausted", reason }, input.now());
       try {
-        await input.onFallbackExhausted?.({
-          ...active.task,
-          reason,
-          binding: active.binding,
-        });
+        await input.onAttemptTerminal?.({ ...terminal, outcome: "failed", fallbackExhausted: true, reason });
       } catch (error) {
-        const settlementReason = `Provider fallback exhaustion could not block the Task: ${runtimeErrorMessage(error)}`;
+        const settlementReason = [
+          "Provider fallback exhaustion could not settle terminal state: ",
+          runtimeErrorMessage(error),
+        ].join("");
         active.stream.appendFallbackState({ state: "exhausted", reason: settlementReason }, input.now());
         console.warn(`[runtime-fallback] ${settlementReason}`);
         throw error;
@@ -737,38 +743,85 @@ export function makeRuntimeSpawner(input: {
     }
     const next = fallback.candidates[nextAttemptIndex]!,
       delayMs = Math.min(fallback.backoff.maxMs, fallback.backoff.baseMs * 2 ** fallback.attemptIndex),
-      nextFallback = { ...fallback, attemptIndex: nextAttemptIndex },
-      continuation = continuationMission(outcome, fallback.originalMission);
-    active.stream.appendFallbackState({ state: "scheduled", delayMs, nextProvider: next }, input.now());
+      notBeforeAt = new Date(Date.parse(input.now()) + delayMs).toISOString();
+    active.stream.appendFallbackState({ state: "scheduled", delayMs, notBeforeAt, nextProvider: next }, input.now());
+    reconcileFallback(readDispatchStream(input.rootDir, active.dispatchId));
+  }
+
+  function reconcileFallback(stream: ReturnType<typeof readDispatchStream>): void {
+    if (
+      fallbackClosed ||
+      !stream ||
+      stream.fallbackState !== "scheduled" ||
+      !stream.fallbackSchedule ||
+      !stream.attemptOutcome ||
+      !stream.header.fallbackAttempt ||
+      !stream.header.binding ||
+      typeof stream.header.cwd !== "string"
+    )
+      return;
+    const notBeforeMs = Date.parse(stream.fallbackSchedule.notBeforeAt),
+      observedNowMs = Date.parse(input.now());
+    if (!Number.isFinite(notBeforeMs) || !Number.isFinite(observedNowMs)) return;
+    const remainingMs = Math.max(0, notBeforeMs - observedNowMs);
     const timer = setTimeout(() => {
-      fallbackTimers.delete(timer);
+      if (fallbackClosed) return;
       input.schedule(async () => {
+        const current = readDispatchStream(input.rootDir, stream.header.dispatchId);
+        if (
+          !current ||
+          current.fallbackState !== "scheduled" ||
+          current.fallbackSchedule?.notBeforeAt !== stream.fallbackSchedule!.notBeforeAt ||
+          !current.attemptOutcome ||
+          !current.header.fallbackAttempt ||
+          !current.header.binding ||
+          typeof current.header.cwd !== "string"
+        )
+          return;
+        const header = current.header,
+          binding = header.binding,
+          dispatchCwd = header.cwd;
+        if (!binding || typeof dispatchCwd !== "string") return;
+        const fallback = header.fallbackAttempt!,
+          nextAttemptIndex = fallback.attemptIndex + 1,
+          nextFallback = { ...fallback, attemptIndex: nextAttemptIndex },
+          next = fallback.candidates[nextAttemptIndex],
+          writer = reopenDispatchStream(input.rootDir, header),
+          continuation = continuationMission(current.attemptOutcome, fallback.originalMission);
+        if (
+          !next ||
+          next.instance !== current.fallbackSchedule.nextProvider.instance ||
+          next.model !== current.fallbackSchedule.nextProvider.model
+        )
+          return;
         try {
           const receipt = await spawnAttempt(
             {
               runtimeInstanceId: next.instance,
-              ...(active.delegatedBy
-                ? { agentId: active.delegatedBy.id, targetAgentId: active.agent!.id }
-                : active.agent
-                  ? { agentId: active.agent.id }
+              ...(header.delegatedByAgentId && header.agentId
+                ? { agentId: header.delegatedByAgentId, targetAgentId: header.agentId }
+                : header.agentId
+                  ? { agentId: header.agentId }
                   : {}),
+              ...(header.squadId ? { squadId: header.squadId } : {}),
               ...(next.model ? { model: next.model } : {}),
-              ...(active.reasoningEffort ? { effort: active.reasoningEffort } : {}),
-              ...(active.permissionMode ? { permissionMode: active.permissionMode } : {}),
+              ...(header.reasoningEffort ? { effort: header.reasoningEffort } : {}),
+              ...(header.permissionMode ? { permissionMode: header.permissionMode } : {}),
               cwd:
-                active.cwd === input.rootDir
+                dispatchCwd === input.rootDir
                   ? { scope: "repo-root" }
-                  : { scope: "repo-relative", path: path.relative(input.rootDir, active.cwd) },
+                  : { scope: "repo-relative", path: path.relative(input.rootDir, dispatchCwd) },
               prompt: continuation,
-              ...(active.promptSource ? { promptSource: active.promptSource } : {}),
-              ...(active.onExitCommand ? { onExitCommand: active.onExitCommand } : {}),
-              taskId: active.task!.taskId,
+              ...(header.promptSource ? { promptSource: header.promptSource } : {}),
+              ...(header.onExitCommand ? { onExitCommand: header.onExitCommand } : {}),
+              ...(header.taskId ? { taskId: header.taskId } : {}),
               idempotencyKey: `${fallback.rootIdempotencyKey}:fallback:${String(nextAttemptIndex)}`,
             },
-            active.binding,
+            binding,
             nextFallback,
+            header.schedule,
           );
-          active.stream.appendFallbackState(
+          writer.appendFallbackState(
             {
               state: "dispatched",
               nextDispatchId: String(receipt.dispatchId),
@@ -779,13 +832,24 @@ export function makeRuntimeSpawner(input: {
         } catch (error) {
           consumeKnownError(error);
           const reason = `Provider fallback could not launch ${next.instance}: ${runtimeErrorMessage(error)}`;
-          active.stream.appendFallbackState({ state: "exhausted", reason }, input.now());
-          await input.onFallbackExhausted?.({ ...active.task!, reason, binding: active.binding });
+          writer.appendFallbackState({ state: "exhausted", reason }, input.now());
+          await input.onAttemptTerminal?.({
+            runtimeSessionId: header.runtimeSessionId,
+            dispatchId: header.dispatchId,
+            task:
+              header.taskId && header.executionId ? { taskId: header.taskId, executionId: header.executionId } : null,
+            schedule: header.schedule ?? null,
+            outcome: "failed",
+            fallbackExhausted: true,
+            reason,
+            endedAt: input.now(),
+            resultRef: null,
+            binding,
+          });
         }
       });
-    }, delayMs);
+    }, remainingMs);
     timer.unref();
-    fallbackTimers.add(timer);
   }
 }
 
@@ -794,12 +858,11 @@ function initialFallbackAttempt(
   requestedInstance: string | undefined,
   requestedModel: string | undefined,
   providerSessionId: string | null | undefined,
-  taskId: string | null,
   idempotencyKey: string,
   mission: string,
 ): RuntimeFallbackAttempt | undefined {
   const declared = agent?.fallback;
-  if (!declared?.enabled || providerSessionId || !taskId) return undefined;
+  if (!declared || providerSessionId) return undefined;
   const requestedIndex =
     requestedInstance === undefined
       ? 0
@@ -810,7 +873,6 @@ function initialFallbackAttempt(
         );
   if (requestedIndex < 0) return undefined;
   const candidates = declared.chain.slice(requestedIndex),
-    maxAttempts = Math.min(declared.backoff.maxAttempts, candidates.length),
     digest = createHash("sha256").update(`${agent!.id}\0${idempotencyKey}`).digest("hex");
   return {
     attemptGroupId: `attempt_${digest.slice(0, 24)}`,
@@ -818,7 +880,7 @@ function initialFallbackAttempt(
     rootIdempotencyKey: idempotencyKey,
     originalMission: mission,
     candidates,
-    backoff: { ...declared.backoff, maxAttempts },
+    backoff: declared.backoff,
   };
 }
 

--- a/packages/daemon/test/agent-entities.test.ts
+++ b/packages/daemon/test/agent-entities.test.ts
@@ -18,7 +18,7 @@ import { createEntityStore, makeTaskEventStore, makeTaskProjection } from "../..
 import {
   prepareAgentEntityInstall,
   readAgentEntityGuiProjection,
-  resolveSquadDispatchTarget,
+  resolveSquadDispatch,
   runAgentEntityAction,
 } from "../src/agent-entities.ts";
 import { discoverAgentSkills, resolveAgentSkills } from "../src/agent-skills.ts";
@@ -165,9 +165,8 @@ test("agent model is optional but must be non-empty when declared", () => {
 
 test("daemon Agent fallback validation mirrors the kernel authority", () => {
   const fallback = {
-    enabled: true,
     chain: [{ instance: "provider-a" }, { instance: "provider-b", model: "model-b" }],
-    backoff: { baseMs: 25, maxMs: 100, maxAttempts: 2 },
+    backoff: { baseMs: 25, maxMs: 100 },
   };
   assert.deepEqual(validateAgentDeclarationV1({ ...agent, fallback }), []);
   assert.match(
@@ -544,13 +543,13 @@ test("Squad dispatch resolution selects one declared worker and rejects outsider
     }
     writeEntity(source, "core-squad", "squad", { ...squad, leader: "fable", workers: ["luna"] });
     await install({ rootDir, kind: "squad-install", packageSource: path.join(source, "core-squad") });
-    assert.deepEqual(resolveSquadDispatchTarget({ rootDir, leaderId: "fable", workerId: "luna" }), {
+    assert.deepEqual(resolveSquadDispatch({ rootDir, leaderId: "fable", workerId: "luna" }), {
       squadId: "core-squad",
       leader: fable,
       worker: luna,
     });
     assert.throws(
-      () => resolveSquadDispatchTarget({ rootDir, leaderId: "fable", workerId: "outsider" }),
+      () => resolveSquadDispatch({ rootDir, leaderId: "fable", workerId: "outsider" }),
       (error: unknown) => (error as { code?: string }).code === "squad_member_not_found",
     );
     writeEntity(source, "other-squad", "squad", {
@@ -562,12 +561,12 @@ test("Squad dispatch resolution selects one declared worker and rejects outsider
     });
     await install({ rootDir, kind: "squad-install", packageSource: path.join(source, "other-squad") });
     assert.throws(
-      () => resolveSquadDispatchTarget({ rootDir, leaderId: "fable", workerId: "luna" }),
+      () => resolveSquadDispatch({ rootDir, leaderId: "fable", workerId: "luna" }),
       (error: unknown) => (error as { code?: string }).code === "squad_member_ambiguous",
     );
     writeFileSync(path.join(rootDir, "harness/squads/broken.json"), "{not-json\n");
     assert.throws(
-      () => resolveSquadDispatchTarget({ rootDir, leaderId: "fable", workerId: "luna" }),
+      () => resolveSquadDispatch({ rootDir, leaderId: "fable", workerId: "luna" }),
       (error: unknown) => (error as { code?: string }).code === "squad_member_ambiguous",
     );
   } finally {

--- a/packages/daemon/test/e2e-probe-scheduler.test.ts
+++ b/packages/daemon/test/e2e-probe-scheduler.test.ts
@@ -97,10 +97,7 @@ test("daemon probe scheduler owns one timer, one in-flight run, and readable set
     });
 
     observedAt = "2026-08-26T00:10:00.000Z";
-    await scheduler.onRuntimeOutcome("alpha", {
-      type: "runtime_session_outcome_observed",
-      payload: { runtimeSessionId: "runtime-probe-one" },
-    } as never);
+    await scheduler.onAttemptTerminal("alpha", "runtime-probe-one");
     const status = scheduler.status();
     assert.equal(status.running, null);
     assert.equal(status.repos[0]?.lastRun?.probeOutcome, "failed");

--- a/packages/daemon/test/fleet-lease-broker.integration.test.ts
+++ b/packages/daemon/test/fleet-lease-broker.integration.test.ts
@@ -214,25 +214,22 @@ test(
 );
 
 test(
-  "fleet fallback settlement can only transition its released assignment Task to blocked",
+  "fleet fallback settlement atomically releases its assignment Task and moves it to blocked",
   { timeout: 30_000 },
   async (t) => {
     const fixture = await leaseFixture();
     t.after(() => fixture.close());
     const created = await fixture.command("node-one", { kind: "task-create", title: "Fallback exhausted" }),
       taskId = String((created.receipt as Record<string, unknown>).taskId);
-    assert.equal((await fixture.command("node-one", { kind: "task-start", taskId })).outcome, "applied");
-    assert.equal(
-      (await fixture.command("node-one", { kind: "task-release", taskId, reason: "provider fallback exhausted" }))
-        .outcome,
-      "applied",
-    );
+    const started = await fixture.command("node-one", { kind: "task-start", taskId });
+    assert.equal(started.outcome, "applied");
+    const executionId = String(started.lease?.executionId);
     assert.equal(
       (
         await fixture.command("node-one", {
-          kind: "task-transition",
+          kind: "task-fallback-exhausted",
           taskId,
-          status: "blocked",
+          executionId,
           reason: "provider chain exhausted",
         })
       ).outcome,

--- a/packages/daemon/test/fleet-transport.contract.test.ts
+++ b/packages/daemon/test/fleet-transport.contract.test.ts
@@ -263,6 +263,12 @@ test("Fleet transport union round-trips every closed wire variant", () => {
       submission: { completionClaim: "complete", deliverables: [] },
     },
     { kind: "task-release", taskId: "task_abc", reason: "handoff" },
+    {
+      kind: "task-fallback-exhausted",
+      taskId: "task_abc",
+      executionId: "exe_abc",
+      reason: "provider fallback exhausted",
+    },
     { kind: "task-transition", taskId: "task_abc", status: "blocked", reason: "provider fallback exhausted" },
   ])
     assert.deepEqual(parseFleetFrame({ ...taskCommand, taskId: "task_abc", action }).action, action);
@@ -300,6 +306,7 @@ test("Fleet codec rejects unknown provenance, nested fields, malformed values, a
     { ...taskCommand, action: { kind: "host-run", command: "anything" } },
     { ...taskCommand, action: { kind: "task-create", title: "t", createMode: "admin" } },
     { ...taskCommand, action: { kind: "task-release", taskId: "task_abc", ttlMs: 1 } },
+    { ...taskCommand, action: { kind: "task-fallback-exhausted", taskId: "task_abc", reason: "missing execution" } },
     { ...taskCommand, action: { kind: "task-transition", taskId: "task_abc", status: "cancelled", reason: "no" } },
     { ...taskCommand, action: { kind: "task-start", taskId: "task_abc", ttlMs: "forever" } },
     { ...taskCommand, action: { kind: "task-create", title: "t", riskTier: "critical" } },

--- a/packages/daemon/test/provider-fallback.integration.test.ts
+++ b/packages/daemon/test/provider-fallback.integration.test.ts
@@ -5,11 +5,13 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import type { AgentDefinitionSnapshot } from "../../kernel/src/index.ts";
+import { makeTaskEventStore, type AgentDefinitionSnapshot, type AgentRuntimeEventV1 } from "../../kernel/src/index.ts";
 import type { RuntimeInstanceSummary, RuntimeInstallationWitness } from "../src/agent-runtime-instances.ts";
+import { readDispatchStreams } from "../src/dispatch-stream.ts";
 import type { TaskDispatchRow } from "../src/protocol/daemon-protocol.contract.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { openRepoCell } from "../src/repo-cell.ts";
+import { makeRuntimeSpawner } from "../src/runtime-spawn.ts";
 import type { RuntimeProcess } from "../src/runtime-spawn-types.ts";
 
 const binding = {
@@ -23,13 +25,17 @@ const installation: RuntimeInstallationWitness = {
   version: "1.0.0",
   observedAt: "2026-08-26T00:00:00.000Z",
 };
-const behaviors = new Map<string, "429" | "success" | "worker_stop">([
+type Behavior = "429" | "success" | "worker_stop" | "empty_success";
+const behaviors = new Map<string, Behavior>([
   ["provider-rate-first", "429"],
   ["provider-success-second", "success"],
   ["provider-rate-a", "429"],
   ["provider-rate-b", "429"],
   ["provider-stop-first", "worker_stop"],
   ["provider-unused-second", "success"],
+  ["provider-restart-first", "429"],
+  ["provider-restart-second", "success"],
+  ["provider-empty-success", "empty_success"],
 ]);
 
 test("provider fallback switches attempts, exhausts to blocked, and never switches on worker_stop", async () => {
@@ -44,33 +50,35 @@ test("provider fallback switches attempts, exhausts to blocked, and never switch
   git(root, "config", "user.name", "Provider Fallback Test");
   git(root, "config", "user.email", "provider-fallback@example.invalid");
   git(root, "commit", "--allow-empty", "-qm", "base");
-  const cell = await openRepoCell({
-    repoId: workspaceId("provider-fallback"),
-    rootDir: canonicalRoot(root),
-    ownerId: "provider-fallback",
-    runtimeDaemonRoute: {
-      userRoot,
-      daemonId: "provider-fallback",
-      endpoint: path.join(userRoot, "provider-fallback.sock"),
-    },
-    runtimeInstances: () => instances,
-    prepareRuntimeLaunch: async (instanceId, request) => ({
-      definition: definition(instanceId, request.model ?? `${instanceId}-model`),
-      installation,
-      executablePath: installation.executablePath,
-      args: ["exec", "--json", "-"],
-      env: {},
-      cwd: request.cwd,
-      prompt: request.prompt,
-    }),
-    runtimeLaunch: (prepared) => {
-      const instanceId = prepared.definition.instanceId,
-        behavior = behaviors.get(instanceId);
-      assert.ok(behavior, `missing fake behavior for ${instanceId}`);
-      prompts.set(instanceId, [...(prompts.get(instanceId) ?? []), prepared.prompt]);
-      return fakeProcess(++pid, behavior);
-    },
-  });
+  const open = () =>
+    openRepoCell({
+      repoId: workspaceId("provider-fallback"),
+      rootDir: canonicalRoot(root),
+      ownerId: "provider-fallback",
+      runtimeDaemonRoute: {
+        userRoot,
+        daemonId: "provider-fallback",
+        endpoint: path.join(userRoot, "provider-fallback.sock"),
+      },
+      runtimeInstances: () => instances,
+      prepareRuntimeLaunch: async (instanceId, request) => ({
+        definition: definition(instanceId, request.model ?? `${instanceId}-model`),
+        installation,
+        executablePath: installation.executablePath,
+        args: ["exec", "--json", "-"],
+        env: {},
+        cwd: request.cwd,
+        prompt: request.prompt,
+      }),
+      runtimeLaunch: (prepared) => {
+        const instanceId = prepared.definition.instanceId,
+          behavior = behaviors.get(instanceId);
+        assert.ok(behavior, `missing fake behavior for ${instanceId}`);
+        prompts.set(instanceId, [...(prompts.get(instanceId) ?? []), prepared.prompt]);
+        return fakeProcess(++pid, behavior);
+      },
+    });
+  let cell = await open();
   try {
     await installAgent(cell, "fallback-success", [
       { instance: "provider-rate-first" },
@@ -149,6 +157,14 @@ test("provider fallback switches attempts, exhausts to blocked, and never switch
       ["provider_fault", "provider_fault"],
     );
     assert.equal(exhausted.rows[1]?.fallbackState, "exhausted");
+    const exhaustionEvents = makeTaskEventStore({ repoId: "provider-fallback", rootDir: root })
+      .read()
+      .events.filter((event) => event.taskId === "task_provider_fallback_exhausted");
+    assert.equal(exhaustionEvents.filter((event) => event.type === "lease_released").length, 1);
+    assert.equal(exhaustionEvents.filter((event) => event.type === "task_transitioned").length, 0);
+    const exhaustion = exhaustionEvents.find((event) => event.type === "lease_released");
+    assert.deepEqual(exhaustion?.payload.mutation.fields, ["lease", "status"]);
+    assert.equal(exhaustion?.payload.task.status, "blocked");
 
     await installAgent(cell, "fallback-worker-stop", [
       { instance: "provider-stop-first" },
@@ -176,9 +192,178 @@ test("provider fallback switches attempts, exhausts to blocked, and never switch
     );
     assert.equal(stopped[0]?.classification, "worker_stop");
     assert.equal(prompts.has("provider-unused-second"), false);
+
+    await installAgent(cell, "fallback-empty-success", [{ instance: "provider-empty-success" }]);
+    await startTask(cell, "task_provider_empty_success", "execution-provider-empty-success");
+    await cell.spawnRuntime(
+      {
+        agentId: "fallback-empty-success",
+        cwd: { scope: "repo-root" },
+        prompt: "Exit zero without structured provider output.",
+        taskId: "task_provider_empty_success",
+        idempotencyKey: "provider-empty-success",
+      },
+      binding,
+    );
+    const emptyUnknown = await eventually(async () => {
+      const rows = (await cell.read("repo.task.dispatches", { taskId: "task_provider_empty_success" })).dispatches;
+      return rows.length === 1 && rows[0]?.outcome === "unknown" ? rows[0] : null;
+    });
+    assert.equal(emptyUnknown.outcome, "unknown");
+    assert.equal(emptyUnknown.exitCode, 0);
+
+    await installAgent(
+      cell,
+      "fallback-restart",
+      [{ instance: "provider-restart-first" }, { instance: "provider-restart-second" }],
+      { baseMs: 500, maxMs: 500 },
+    );
+    await startTask(cell, "task_provider_fallback_restart", "execution-provider-fallback-restart");
+    await cell.spawnRuntime(
+      {
+        agentId: "fallback-restart",
+        cwd: { scope: "repo-root" },
+        prompt: "Resume fallback after daemon restart.",
+        taskId: "task_provider_fallback_restart",
+        idempotencyKey: "provider-fallback-restart",
+      },
+      binding,
+    );
+    await eventually(async () => {
+      const rows = (await cell.read("repo.task.dispatches", { taskId: "task_provider_fallback_restart" })).dispatches;
+      return rows.length === 1 && rows[0]?.fallbackState === "scheduled" ? rows : null;
+    });
+    await cell.close();
+    cell = await open();
+    const restarted = await eventually(async () => {
+      const rows = (await cell.read("repo.task.dispatches", { taskId: "task_provider_fallback_restart" })).dispatches;
+      return rows.length === 2 && rows[1]?.status === "succeeded" ? rows : null;
+    });
+    assertAttemptChain(restarted, ["provider-restart-first", "provider-restart-second"]);
   } finally {
     await cell.close();
     rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("repeated adoption dispatches one durable fallback continuation", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-provider-fallback-adopt-twice-")),
+    now = () => new Date().toISOString(),
+    receipts = new Map<string, Record<string, unknown>>(),
+    published: AgentRuntimeEventV1[] = [];
+  let pid = 10_000,
+    revision = 0,
+    nextLaunches = 0,
+    scheduled = Promise.resolve();
+  const remote = {
+      existing: async (opId: string) => receipts.get(opId) ?? null,
+      taskContext: async () => {
+        throw new Error("task context is not used by this taskless fallback test");
+      },
+      readRuntimeSessions: async () => [],
+      publish: async (draft: {
+        readonly type: AgentRuntimeEventV1["type"];
+        readonly payload: Readonly<Record<string, unknown>>;
+        readonly opId: string;
+        readonly resultBody?: string;
+      }) => {
+        const event = {
+            schema: "agent-runtime-event/v1",
+            eventId: `event-${String(++revision)}`,
+            workspaceRevision: revision,
+            opId: draft.opId,
+            type: draft.type,
+            actor: binding.actor,
+            source: binding.source,
+            occurredAt: now(),
+            payload: draft.payload,
+          } as unknown as AgentRuntimeEventV1,
+          receipt = { outcome: "applied", opId: draft.opId };
+        published.push(event);
+        receipts.set(draft.opId, receipt);
+        return { event, receipt };
+      },
+      archive: async () => ({ outcome: "applied" }),
+    },
+    agent = {
+      id: "fallback-adopt-twice",
+      name: "Fallback Adopt Twice",
+      instructions: "Exercise durable fallback adoption.",
+      runtime_type: "codex",
+      fallback: {
+        chain: [{ instance: "provider-adopt-first" }, { instance: "provider-adopt-next" }],
+        backoff: { baseMs: 500, maxMs: 500 },
+      },
+    },
+    instances = [runtimeInstance("provider-adopt-first"), runtimeInstance("provider-adopt-next")],
+    schedule = (work: () => void | Promise<void>) => {
+      scheduled = scheduled.then(async () => {
+        await work();
+      });
+    },
+    open = () =>
+      makeRuntimeSpawner({
+        repoId: "provider-fallback-adopt-twice",
+        rootDir: root,
+        daemonGeneration: 1,
+        remote,
+        stream: { publish: () => ({}) as never },
+        now,
+        runtimeInstances: () => instances,
+        prepareLaunch: async (instanceId, request) => ({
+          definition: definition(instanceId, request.model ?? `${instanceId}-model`),
+          installation,
+          executablePath: installation.executablePath,
+          args: ["exec", "--json", "-"],
+          env: {},
+          cwd: request.cwd,
+          prompt: request.prompt,
+        }),
+        resolveAgent: () => agent,
+        launch: (prepared) => {
+          const isNext = prepared.definition.instanceId === "provider-adopt-next";
+          if (isNext) nextLaunches += 1;
+          return fakeProcess(++pid, isNext ? "success" : "429");
+        },
+        schedule,
+      });
+  let spawner = open();
+  try {
+    await spawner.spawn(
+      {
+        agentId: agent.id,
+        cwd: { scope: "repo-root" },
+        prompt: "Schedule one durable fallback.",
+        taskId: null,
+        idempotencyKey: "adopt-twice",
+      },
+      binding,
+    );
+    const first = await eventually(async () => {
+      const stream = readDispatchStreams(root)[0];
+      return stream?.fallbackState === "scheduled" ? stream : null;
+    });
+    spawner.close();
+    spawner = open();
+    await spawner.adopt();
+    await spawner.adopt();
+    const streams = await eventually(async () => {
+      const values = readDispatchStreams(root),
+        original = values.find((stream) => stream.header.dispatchId === first.header.dispatchId);
+      return values.length === 2 && original?.fallbackState === "dispatched" ? values : null;
+    });
+    await scheduled;
+    const original = streams.find((stream) => stream.header.dispatchId === first.header.dispatchId),
+      continuation = streams.find((stream) => stream.header.dispatchId !== first.header.dispatchId),
+      continuations = published.filter(
+        (event) => event.type === "runtime_dispatch_requested" && event.payload.instanceId === "provider-adopt-next",
+      );
+    assert.equal(nextLaunches, 1);
+    assert.equal(continuations.length, 1);
+    assert.equal(original?.nextDispatchId, continuation?.header.dispatchId);
+  } finally {
+    spawner.close();
+    rmSync(root, { recursive: true, force: true });
   }
 });
 
@@ -186,6 +371,7 @@ async function installAgent(
   cell: Awaited<ReturnType<typeof openRepoCell>>,
   agentId: string,
   chain: readonly { readonly instance: string; readonly model?: string }[],
+  backoff = { baseMs: 1, maxMs: 2 },
 ): Promise<void> {
   const receipt = await cell.run(
     {
@@ -196,7 +382,7 @@ async function installAgent(
         name: agentId,
         instructions: "Execute the assigned mission.",
         runtime_type: "codex",
-        fallback: { enabled: true, chain, backoff: { baseMs: 1, maxMs: 2, maxAttempts: chain.length } },
+        fallback: { chain, backoff },
       },
     },
     binding,
@@ -269,7 +455,7 @@ function definition(instanceId: string, model: string): AgentDefinitionSnapshot 
   };
 }
 
-function fakeProcess(pid: number, behavior: "429" | "success" | "worker_stop"): RuntimeProcess {
+function fakeProcess(pid: number, behavior: Behavior): RuntimeProcess {
   let output: ((chunk: string) => void) | null = null,
     exit: ((code: number | null) => void) | null = null,
     terminated = false;
@@ -284,27 +470,29 @@ function fakeProcess(pid: number, behavior: "429" | "success" | "worker_stop"): 
       setImmediate(() => {
         if (terminated) return;
         const frames =
-          behavior === "429"
-            ? [
-                { type: "thread.started", thread_id: `provider-${pid}` },
-                {
-                  type: "turn.failed",
-                  error: {
-                    http_status: 429,
-                    code: "rate_limit",
-                    message: "quota exhausted OPENAI_API_KEY=sk-provider-fallback-secret",
+          behavior === "empty_success"
+            ? []
+            : behavior === "429"
+              ? [
+                  { type: "thread.started", thread_id: `provider-${pid}` },
+                  {
+                    type: "turn.failed",
+                    error: {
+                      http_status: 429,
+                      code: "rate_limit",
+                      message: "quota exhausted OPENAI_API_KEY=sk-provider-fallback-secret",
+                    },
                   },
-                },
-              ]
-            : [
-                { type: "thread.started", thread_id: `provider-${pid}` },
-                ...(behavior === "success"
-                  ? [{ type: "item.completed", item: { id: "write", type: "file_change", status: "completed" } }]
-                  : []),
-                { type: "item.completed", item: { id: "message", type: "agent_message", text: "done" } },
-                { type: "turn.completed" },
-              ];
-        output?.(`${frames.map((frame) => JSON.stringify(frame)).join("\n")}\n`);
+                ]
+              : [
+                  { type: "thread.started", thread_id: `provider-${pid}` },
+                  ...(behavior === "success"
+                    ? [{ type: "item.completed", item: { id: "write", type: "file_change", status: "completed" } }]
+                    : []),
+                  { type: "item.completed", item: { id: "message", type: "agent_message", text: "done" } },
+                  { type: "turn.completed" },
+                ];
+        if (frames.length) output?.(`${frames.map((frame) => JSON.stringify(frame)).join("\n")}\n`);
         exit?.(behavior === "429" ? 1 : 0);
       });
     },

--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -140,7 +140,9 @@ test("runtime spawn publishes a canonical session and makes it visible in overvi
           "code" in error &&
           error.code === "invalid_runtime_spawn" &&
           error.message ===
-            'Runtime spawn payload contains an unknown field "permission_mode"; allowed fields: "runtimeInstanceId", "dispatchId", "agentId", "targetAgentId", "model", "effort", "permissionMode", "cwd", "prompt", "promptSource", "onExitCommand", "taskId", "idempotencyKey", "providerSessionId".',
+            'Runtime spawn payload contains an unknown field "permission_mode"; allowed fields: "runtimeInstanceId", ' +
+              '"dispatchId", "agentId", "targetAgentId", "squadId", "model", "effort", "permissionMode", "cwd", ' +
+              '"prompt", "promptSource", "onExitCommand", "taskId", "idempotencyKey", "providerSessionId".',
       );
       await assert.rejects(
         cell.cancelRuntime({ runtimeSessionId: "missing", force: true }, binding),
@@ -895,6 +897,11 @@ test(
         ).detail,
         "cancelled",
       );
+      const cancelledSession = await eventuallyValue(async () => {
+        const read = await cell!.read("repo.agentRuntime.sessions.read", { runtimeSessionId });
+        return read.session.activity.outcome === "cancelled" ? read.session : null;
+      });
+      assert.equal(cancelledSession.activity.outcome, "cancelled");
       const streamPath = path.join(root, ".harness", "runtime", "dispatches", `${String(spawned.dispatchId)}.jsonl`),
         descendants = await eventuallyValue(() => {
           const records = readFileSync(streamPath, "utf8")

--- a/packages/daemon/test/runtime-spawn-settlement.test.ts
+++ b/packages/daemon/test/runtime-spawn-settlement.test.ts
@@ -1,0 +1,34 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { deriveRuntimeSpawnOutcome } from "../src/runtime-spawn-settlement.ts";
+import type { ActiveRuntime } from "../src/runtime-spawn-types.ts";
+
+test("an exit-zero protocol error settles as unknown", () => {
+  assert.equal(deriveRuntimeSpawnOutcome(active({ protocolError: true }), 0), "unknown");
+});
+
+test("an exit-zero write-capable attempt without write or plan evidence settles as unknown", () => {
+  assert.equal(deriveRuntimeSpawnOutcome(active({ writeItemObserved: false, planObserved: false }), 0), "unknown");
+});
+
+test("an exit-zero attempt with an incomplete plan settles as unknown", () => {
+  assert.equal(
+    deriveRuntimeSpawnOutcome(active({ writeItemObserved: true, planObserved: true, planIncomplete: true }), 0),
+    "unknown",
+  );
+});
+
+function active(overrides: Partial<ActiveRuntime>): ActiveRuntime {
+  return {
+    cancelRequested: false,
+    kindId: "codex",
+    permissionMode: "bypass",
+    planIncomplete: false,
+    planObserved: true,
+    protocolError: false,
+    providerOutcome: "succeeded",
+    writeItemObserved: true,
+    ...overrides,
+  } as ActiveRuntime;
+}

--- a/packages/daemon/test/runtime-spawn.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn.integration.test.ts
@@ -689,6 +689,27 @@ test("a squad-delegated worker injects selected absolute skill paths into every 
       assert.equal(Object.hasOwn(launch.request, "skillRoot"), false);
       assert.equal(Object.hasOwn(launch.request, "skills"), false);
     }
+    const leaderReceipt = await cell.spawnRuntime(
+      {
+        runtimeInstanceId: "codex-squad",
+        agentId: "squad-leader",
+        squadId: "runtime-squad",
+        cwd: { scope: "repo-root" },
+        prompt: "Run as the attributed squad leader.",
+        taskId: null,
+        idempotencyKey: "squad-leader-codex",
+      },
+      binding,
+    );
+    const header = JSON.parse(
+      readFileSync(
+        path.join(root, ".harness/runtime/dispatches", `${String(leaderReceipt.dispatchId)}.jsonl`),
+        "utf8",
+      ).split(/\r?\n/u)[0]!,
+    ) as Record<string, unknown>;
+    assert.equal(header.squadId, "runtime-squad");
+    assert.equal(header.agentId, "squad-leader");
+    assert.equal(Object.hasOwn(header, "delegatedByAgentId"), false);
   } finally {
     await cell.close();
     rmSync(parent, { recursive: true, force: true });

--- a/packages/daemon/test/schedule-actions.integration.test.ts
+++ b/packages/daemon/test/schedule-actions.integration.test.ts
@@ -110,6 +110,10 @@ test("run-now launches only after an applied claim, stays single-flight, and set
                 name: "Probe Agent",
                 instructions: "Run the exact probe mission.",
                 runtime_type: "codex",
+                fallback: {
+                  chain: [{ instance: definition.instanceId }, { instance: definition.instanceId }],
+                  backoff: { baseMs: 1, maxMs: 1 },
+                },
               },
             },
             actor,
@@ -175,6 +179,17 @@ test("run-now launches only after an applied claim, stays single-flight, and set
         },
       );
       output?.(
+        `${JSON.stringify({ type: "thread.started", thread_id: "provider-schedule-first" })}\n` +
+          `${JSON.stringify({ type: "turn.failed", error: { http_status: 429, message: "rate limited" } })}\n`,
+      );
+      exit?.(1);
+      assert.equal(await eventually(async () => launchCount === 2), true);
+      const continuing = (await cell.run({ kind: "schedule-list" }, actor)) as unknown as {
+        readonly schedules: readonly { readonly status: { readonly activeRun: unknown; readonly lastRun: unknown } }[];
+      };
+      assert.notEqual(continuing.schedules[0]?.status.activeRun, null);
+      assert.equal(continuing.schedules[0]?.status.lastRun, null);
+      output?.(
         `${JSON.stringify({ type: "thread.started", thread_id: "provider-schedule" })}\n` +
           `${JSON.stringify({ type: "item.completed", item: { id: "write", type: "file_change", status: "completed" } })}\n` +
           `${JSON.stringify({ type: "item.completed", item: { id: "message", type: "agent_message", text: "done" } })}\n` +
@@ -192,7 +207,7 @@ test("run-now launches only after an applied claim, stays single-flight, and set
         );
       });
       assert.equal(settled, true);
-      assert.equal(launchCount, 1);
+      assert.equal(launchCount, 2);
     } finally {
       await cell.close();
     }

--- a/packages/kernel/src/domain/agent-squad-schema.ts
+++ b/packages/kernel/src/domain/agent-squad-schema.ts
@@ -12,9 +12,8 @@ export interface AgentSkillDeclarationV1 {
   readonly path: string;
 }
 export interface AgentFallbackDeclarationV1 {
-  readonly enabled: boolean;
   readonly chain: readonly { readonly instance: string; readonly model?: string }[];
-  readonly backoff: { readonly baseMs: number; readonly maxMs: number; readonly maxAttempts: number };
+  readonly backoff: { readonly baseMs: number; readonly maxMs: number };
 }
 export type AgentRole = "worker" | "commander";
 export const agentStates = ["configured", "active", "retired"] as const;
@@ -82,10 +81,9 @@ export const AGENT_DECLARATION_V1_SCHEMA = Object.freeze({
     fallback: {
       type: "object",
       additionalProperties: false,
-      required: ["enabled", "chain", "backoff"],
+      required: ["chain", "backoff"],
       description: "Attempt-bound provider fallback policy.",
       properties: {
-        enabled: { type: "boolean", description: "Whether provider-fault exits advance the chain." },
         chain: {
           type: "array",
           minItems: 1,
@@ -103,7 +101,7 @@ export const AGENT_DECLARATION_V1_SCHEMA = Object.freeze({
         backoff: {
           type: "object",
           additionalProperties: false,
-          required: ["baseMs", "maxMs", "maxAttempts"],
+          required: ["baseMs", "maxMs"],
           properties: {
             baseMs: {
               type: "integer",
@@ -116,12 +114,6 @@ export const AGENT_DECLARATION_V1_SCHEMA = Object.freeze({
               minimum: 0,
               maximum: Number.MAX_SAFE_INTEGER,
               description: "Maximum attempt backoff in milliseconds.",
-            },
-            maxAttempts: {
-              type: "integer",
-              minimum: 1,
-              maximum: Number.MAX_SAFE_INTEGER,
-              description: "Maximum attempts including the first.",
             },
           },
         },
@@ -162,14 +154,10 @@ export class AgentEntityContractError extends EntitySchemaContractError {
 export function validateAgentDeclarationV1(value: unknown): readonly string[] {
   const issues = [...validateEntityJsonSchema(AGENT_DECLARATION_V1_SCHEMA, value, "agent declaration")];
   if (entityRecord(value) && entityRecord(value.fallback) && entityRecord(value.fallback.backoff)) {
-    const chain = value.fallback.chain,
-      baseMs = value.fallback.backoff.baseMs,
-      maxMs = value.fallback.backoff.maxMs,
-      maxAttempts = value.fallback.backoff.maxAttempts;
+    const baseMs = value.fallback.backoff.baseMs,
+      maxMs = value.fallback.backoff.maxMs;
     if (Number.isInteger(baseMs) && Number.isInteger(maxMs) && Number(maxMs) < Number(baseMs))
       issues.push('agent declaration field "fallback.backoff.maxMs" must be greater than or equal to baseMs.');
-    if (Array.isArray(chain) && Number.isInteger(maxAttempts) && Number(maxAttempts) > chain.length)
-      issues.push('agent declaration field "fallback.backoff.maxAttempts" cannot exceed fallback.chain length.');
   }
   return issues;
 }

--- a/packages/kernel/src/domain/task-lifecycle-replay.ts
+++ b/packages/kernel/src/domain/task-lifecycle-replay.ts
@@ -1,4 +1,4 @@
-import type { ExecutionV1 } from "./execution.ts";
+import type { ExecutionV1, LeaseV1 } from "./execution.ts";
 import { reviewDigest } from "./review.ts";
 import type { ActorAxes, ContractValidationIssue } from "./task.ts";
 import { validateTaskGraph } from "./task-graph.ts";
@@ -26,6 +26,7 @@ import {
 } from "./task-lifecycle-contract-support.ts";
 import { isReadyToComplete } from "./task-lifecycle-review-transitions.ts";
 import { TASK_LIFECYCLE_TRANSITIONS } from "./task-lifecycle-transitions.ts";
+import { explainStatusTransition } from "./lifecycle-status.ts";
 
 // Transition application plus event replay and executor-declaration repair.
 export function validateTransition<C extends TaskLifecycleCommand>(
@@ -280,6 +281,17 @@ export function reduceTaskEvent(snapshot: TaskLifecycleSnapshot, event: TaskEven
   assertReplay(snapshot, event, next);
   return next;
 }
+function sameReleasedLease(current: LeaseV1, released: LeaseV1): boolean {
+  if (stableStringify(released) === stableStringify(current)) return true;
+  // `orphaned` is derived from the wall clock by the live projection; canonical
+  // replay still sees the same stored lease as `held`. Normalize only that
+  // derived phase while preserving every field that identifies the lease CAS.
+  return (
+    current.phase === "held" &&
+    released.phase === "orphaned" &&
+    stableStringify({ ...released, phase: "held" }) === stableStringify(current)
+  );
+}
 function assertReplay(snapshot: TaskLifecycleSnapshot, event: TaskEventV1, next: TaskLifecycleSnapshot): void {
   if (event.type === "code_doc_repointed") {
     const target = snapshot.codeDocWitnesses.find(
@@ -312,6 +324,21 @@ function assertReplay(snapshot: TaskLifecycleSnapshot, event: TaskEventV1, next:
     throw new TaskLifecycleContractError("invalid_transition", [
       lifecycleContractIssue("invalid_submit_atomicity", "replayed submit is incomplete"),
     ]);
+  if (event.type === "lease_released") {
+    const changesStatus = event.payload.mutation.fields.includes("status"),
+      expectedTask = changesStatus && snapshot.task ? { ...snapshot.task, status: "blocked" as const } : snapshot.task;
+    if (
+      !snapshot.lease ||
+      !sameReleasedLease(snapshot.lease, event.payload.releasedLease) ||
+      event.payload.execution.executionId !== snapshot.lease.executionId ||
+      stableStringify(event.payload.task) !== stableStringify(expectedTask) ||
+      (changesStatus && (!snapshot.task || !explainStatusTransition(snapshot.task.status, "blocked").allowed)) ||
+      next.lease !== null
+    )
+      throw new TaskLifecycleContractError("invalid_transition", [
+        lifecycleContractIssue("invalid_release_atomicity", "replayed lease release is incomplete"),
+      ]);
+  }
   if (event.type === "execution_executor_declared") {
     const current = execution(snapshot, event.payload.execution.executionId),
       expected = current ? { ...current, actor: event.actor } : null,

--- a/packages/kernel/test/contracts/entity-store.test.ts
+++ b/packages/kernel/test/contracts/entity-store.test.ts
@@ -73,11 +73,10 @@ test("registered declaration Entity kinds explain the same contract shape from t
   );
 });
 
-test("Agent fallback is an exact bounded attempt declaration", () => {
+test("Agent fallback is an exact chain-bounded attempt declaration", () => {
   const fallback = {
-    enabled: true,
     chain: [{ instance: "provider-a" }, { instance: "provider-b", model: "model-b" }],
-    backoff: { baseMs: 25, maxMs: 100, maxAttempts: 2 },
+    backoff: { baseMs: 25, maxMs: 100 },
   };
   assert.deepEqual(validateAgentDeclarationV1({ ...agent, fallback }), []);
   assert.match(
@@ -85,11 +84,15 @@ test("Agent fallback is an exact bounded attempt declaration", () => {
     /fallback.*unknown/u,
   );
   assert.match(
+    validateAgentDeclarationV1({ ...agent, fallback: { ...fallback, enabled: true } }).join("\n"),
+    /enabled.*unknown/u,
+  );
+  assert.match(
     validateAgentDeclarationV1({
       ...agent,
       fallback: { ...fallback, backoff: { ...fallback.backoff, maxAttempts: 3 } },
     }).join("\n"),
-    /cannot exceed fallback\.chain length/u,
+    /maxAttempts.*unknown/u,
   );
 });
 


### PR DESCRIPTION
# English

## Summary

0.38 (anti-entropy review #4 NO-GO on #1842 → rebuilt): provider fallback becomes durable. The fallback schedule and `notBeforeAt` are persisted in the dispatch stream and rebuilt on daemon restart (`reconcileFallback` on adopt) instead of living in in-memory `setTimeout`s that died with the daemon; exhaustion settles in one canonical event (`lease_released` carrying `status=blocked`) instead of two writes; the terminal-attempt API no longer requires a taskId; the fallback schema drops `enabled/maxAttempts`; `--squad` attribution flows through runtime run. Review rulings applied in r2/r3: cancelled runtimes keep outcome `cancelled` (not `failed`); the `writeEvidenceRequired/planIncomplete → unknown` write-evidence gate and the protocolError / null-exit → `unknown` path are restored in r4 (verified by grep at runtime-spawn-settlement.ts:206-214, three new tests); the duplicate `resolveSquadDispatchTarget` and the parallel `onFallbackExhausted` callback are deleted; a replay bug surfaced by the fleet-lease-broker orphan-reaper tests (strict comparison of canonical `held` vs projection-derived `orphaned` lease) is fixed in `task-lifecycle-replay.ts`, broker 17/17. Two CLI files carry a prettier-driven whole-file reflow enforced by pre-commit (not shaved).

## Architectural Justification

- Not required: Production-Delta churn is below 200 lines.

## What Changed

- `packages/daemon/src`: dispatch-stream persistence of fallback schedule; runtime-spawner `reconcileFallback`/adoption; single-event exhaustion in repo-cell-task-mutation/repo-cell-open/fleet-edge-runtime; settlement outcome rules; fleet contract `task-fallback-exhausted` descriptor.
- `packages/kernel/src/domain/task-lifecycle-replay.ts`: replay atomicity assertion; lease phase normalisation for orphaned-vs-held.
- `packages/cli`: `--squad` attribution; prettier reflow of thin-command-runtime.ts and its doc-runtime test.
- Tests: provider fallback, runtime-spawn lifecycle (double-adopt idempotency), broker settlement.

## Gate Harvest / 门收割

Deleted-Production-Paths: in-memory `fallbackTimers` set and its close sweep; the second local write and the edge double-RPC on exhaustion; Schedule settlement from `onRuntimeOutcome`; `resolveSquadDispatchTarget`; `onFallbackExhausted`; fallback schema `enabled/maxAttempts`
Deleted-Gates-Fixtures: packages/daemon/test/provider-fallback.integration.test.ts (timer-based fallback assertions replaced by stream-rebuild assertions in the same commit)
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +439/-332

### Optional Evidence Claims

## Task And Scope

- Harness task: task_277fad7546dc2e4a7edaa4e5f3
- Branch: codex/fallback-durable
- Public scope: packages/daemon/src (runtime-spawn*, dispatch-stream, repo-cell*, fleet-edge-runtime, fleet/contract), packages/kernel/src/domain/task-lifecycle-replay.ts, packages/cli/src/cli/thin-command-runtime.ts, tests
- Private planning/evidence updated: yes
- Out of scope: the scheduler host/timer for Schedule (S2, stacked next); provider quota exhaustion turning tasks blocked without a return path (0.41)

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_277fad7546dc2e4a7edaa4e5f3
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: b5952bce18c714d12d711b5f1b4533f9c99fdc0b
- Branch merge-base with `origin/main`: b5952bce18c714d12d711b5f1b4533f9c99fdc0b
- Last `git fetch origin` time: 2026-08-26T19:15:38Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_277fad7546dc2e4a7edaa4e5f3 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Broker 17/17 (was 14/17 before the replay fix; pure-S3 control 17/17); unit/contract 44/44; provider 2/2; schedule 2/2; runtime-spawn 5/5; lifecycle 5/5; typecheck
- [x] Gates in worktree: line-density, derived-contracts, schema-closure, production-delta
- [x] Opus read-only review of r1 (six questions) → rulings applied in r2/r3; CEO verified the two must-fix items in the diff
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; live durable-restart proof comes from the next daemon restart with a scheduled fallback in flight.

## Review Evidence

- Self-review: CEO applied review #4's NO-GO, ruled on the two semantic regressions and the formatter question, and read the replay fix.
- Reviewer subagent: Codex worker (gpt-5.6-sol) r1–r3; Opus read-only functional review of r1; Opus verify of r2/r3 rulings pending before merge.
- Human review: pending
- Blocking findings: none

## Residual Risk

- The lease-phase normalisation in replay narrows one CAS comparison (held vs orphaned); all other CAS fields stay strict. Formatter reflow inflates the CLI diff without semantic change.

## References

- Task: task_277fad7546dc2e4a7edaa4e5f3
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

0.38(反熵审查#4 对 #1842 判 NO-GO → 重做):provider fallback 变 durable。fallback 计划与 `notBeforeAt` 持久化在 dispatch 流里,daemon 重启时(adopt 时 `reconcileFallback`)重建,不再是随 daemon 一起死掉的内存 `setTimeout`;耗尽用一条 canonical 事件结算(带 `status=blocked` 的 `lease_released`)而非两次写;terminal-attempt API 不再要求 taskId;fallback schema 删 `enabled/maxAttempts`;`--squad` 归属贯通 runtime run。复核裁决在 r2/r3 落地:取消的 runtime 保持 outcome `cancelled`(不记 `failed`);`writeEvidenceRequired/planIncomplete → unknown` 写入证据门与 protocolError / null-exit → `unknown` 路径已在 r4 恢复(CEO grep 核实 runtime-spawn-settlement.ts:206-214,新增三条测试);删除并存的 `resolveSquadDispatchTarget` 与平行的 `onFallbackExhausted` 回调;fleet-lease-broker orphan-reaper 测试暴露的 replay bug(canonical `held` 与投影派生 `orphaned` lease 的严格比较)在 `task-lifecycle-replay.ts` 修掉,broker 17/17。两个 CLI 文件带 pre-commit 强制的 prettier 整文件重排(不是压行)。

## 架构辩护

- 不需要:Production-Delta churn 低于 200 行。

## 改动内容

- `packages/daemon/src`:dispatch 流持久化 fallback 计划;runtime-spawner `reconcileFallback`/adoption;repo-cell-task-mutation/repo-cell-open/fleet-edge-runtime 单事件耗尽;结算 outcome 规则;fleet contract `task-fallback-exhausted` 描述符。
- `packages/kernel/src/domain/task-lifecycle-replay.ts`:replay 原子性断言;orphaned-vs-held 的 lease phase 归一。
- `packages/cli`:`--squad` 归属;thin-command-runtime.ts 及其 doc-runtime 测试的 prettier 重排。
- 测试:provider fallback、runtime-spawn lifecycle(二次 adopt 幂等)、broker 结算。

## 门收割 / Gate Harvest

- 删除的生产路径:内存 `fallbackTimers` 集合及其 close 遍历;耗尽时的第二次本地写与 edge 双 RPC;`onRuntimeOutcome` 里的 Schedule 结算;`resolveSquadDispatchTarget`;`onFallbackExhausted`;fallback schema `enabled/maxAttempts`
- 同 commit 删除的门 / fixture:packages/daemon/test/provider-fallback.integration.test.ts(定时器型 fallback 断言同 commit 换成流重建断言)
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_277fad7546dc2e4a7edaa4e5f3
- 分支:codex/fallback-durable
- 公开范围:packages/daemon/src(runtime-spawn*、dispatch-stream、repo-cell*、fleet-edge-runtime、fleet/contract)、packages/kernel/src/domain/task-lifecycle-replay.ts、packages/cli/src/cli/thin-command-runtime.ts、测试
- 私有计划 / 证据是否已更新:yes
- 范围外:Schedule 的调度宿主/定时器(S2,下一栈);provider 额度耗尽把 task 转 blocked 且无回路(0.41)

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_277fad7546dc2e4a7edaa4e5f3
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:b5952bce18c714d12d711b5f1b4533f9c99fdc0b
- 当前分支与 `origin/main` 的 merge-base:b5952bce18c714d12d711b5f1b4533f9c99fdc0b
- 最近一次 `git fetch origin` 时间:2026-08-26T19:15:38Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_277fad7546dc2e4a7edaa4e5f3
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] Broker 17/17(replay 修复前 14/17;纯 S3 对照 17/17);单元/合同 44/44;provider 2/2;schedule 2/2;runtime-spawn 5/5;lifecycle 5/5;typecheck
- [x] worktree 内门:line-density、derived-contracts、schema-closure、production-delta
- [x] Opus 只读复核 r1(六问)→ 裁决在 r2/r3 落地;CEO 在 diff 里核对两处必修项
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;实机 durable 重启证明来自下一次 daemon 重启时有 fallback 在排程。

## 审查证据

- 自查:CEO 执行审查#4 的 NO-GO,对两处语义回归与 formatter 问题裁决,并读了 replay 修复。
- Reviewer subagent:Codex worker(gpt-5.6-sol)r1–r3;Opus 只读复核 r1;合并前 Opus 复核 r2/r3 裁决落地。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- replay 的 lease phase 归一收窄了一处 CAS 比较(held vs orphaned);其余 CAS 字段仍严格。formatter 重排让 CLI diff 变大但无语义变化。

## 关联材料

- 任务:task_277fad7546dc2e4a7edaa4e5f3
- 证据:任务包 artifacts/reports
- 审查:本 PR



