### PR TITLE
fix(daemon): keep the shutdown pipe open for delayed replies (0.45)

### DIFF
--- a/packages/daemon/src/client/local-json-rpc-shutdown.ts
+++ b/packages/daemon/src/client/local-json-rpc-shutdown.ts
@@ -72,7 +72,12 @@ export async function requestDaemonShutdownAt(
         }
       }
     });
-    socket.end(payload);
+    // Keep the writable side open until the reply exchange settles. Ending it here lets a named
+    // pipe deliver EOF before a loaded daemon gets its next turn to write the acknowledgements;
+    // the server then closes this connection as part of shutdown and the caller misclassifies an
+    // accepted stop as a silent one. finish() owns the one close path after a reply, error, close,
+    // or the existing response deadline.
+    socket.write(payload);
   });
 }
 

--- a/packages/daemon/test/transport-shutdown.integration.test.ts
+++ b/packages/daemon/test/transport-shutdown.integration.test.ts
@@ -102,6 +102,42 @@ test("a cooperative shutdown queues stop without waiting for the hello response"
   }
 });
 
+test("the shutdown client keeps the pipe open until a delayed stop reply arrives", async () => {
+  const { endpoint, cleanup } = probeEndpoint("ha-shutdown-reply-");
+  const server = net.createServer((socket) => {
+    let input = "",
+      replyScheduled = false;
+    socket.on("data", (chunk: Buffer) => {
+      input += chunk.toString("utf8");
+      const requests = input
+        .split("\n")
+        .filter((line) => line.startsWith("{"))
+        .map((line) => JSON.parse(line) as JsonRpcRequest);
+      if (requests.length < 2 || replyScheduled) return;
+      replyScheduled = true;
+      // The complete request exchange is the trigger. Yielding one event-loop turn models a
+      // loaded daemon without using a wall-clock delay to arrange the intermediate state.
+      setImmediate(() =>
+        setImmediate(() => {
+          socket.write(
+            `${JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true, build: { commit: null } } })}\n` +
+              `${JSON.stringify({ jsonrpc: "2.0", id: 2, result: { ok: true } })}\n`,
+          );
+        }),
+      );
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(endpoint, resolve));
+  try {
+    const exchange = await requestDaemonShutdownAt(endpoint, 2_000);
+    assert.equal(exchange.helloAnswered, true, JSON.stringify(exchange));
+    assert.deepEqual(exchange.stopReply, { ok: true, code: null, message: null });
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    cleanup();
+  }
+});
+
 test("transport stop stays bounded when an in-flight request never completes", async () => {
   const { endpoint, cleanup } = probeEndpoint("ha-transport-hang-");
   let handlerEntered: () => void = () => {};


### PR DESCRIPTION
# English

## Summary

0.45: `windows-first-run`'s G34 'stop reports the stop it performed' intermittently returned `daemon_stop_timeout` on windows-latest (2026-08-27 #1856 and #1869, green on rerun). Root cause is a race in the shutdown client, not a slow daemon: `requestDaemonShutdownAt` half-closed the pipe right after writing the request, so a delayed acknowledgement from the daemon was lost and the CLI reported a timeout it had caused itself. The client now keeps the pipe open until the reply (or the real deadline). No timeout, retry, Windows skip, gate or CI change. A regression reproduces `helloAnswered=false` before the fix (3/4) and passes after (4/4).

## Architectural Justification

- Not required: Production-Delta churn is below 200 lines.

## What Changed

- `packages/daemon/src/client/local-json-rpc-shutdown.ts`: no premature half-close after writing the shutdown request.
- `packages/daemon/test/transport-shutdown.integration.test.ts`: delayed-acknowledgement regression.

## Gate Harvest / 门收割

Deleted-Production-Paths: the premature `end()` after the shutdown request write
Deleted-Gates-Fixtures: none (assertion for the half-close behaviour replaced in the same commit)
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +6/-1

### Optional Evidence Claims

## Task And Scope

- Harness task: task_3078df7b5c749e08ace01ec5a8
- Branch: codex/windows-stop-flake
- Public scope: packages/daemon/src/client/local-json-rpc-shutdown.ts, packages/daemon/test/transport-shutdown.integration.test.ts
- Private planning/evidence updated: yes
- Out of scope: the 5s stop deadline in `control.ts` (unchanged; it was never the cause); Windows lane policy (dec_9B75595F)

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_3078df7b5c749e08ace01ec5a8
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 8b3bbb3e207a2442e53c96e8cba92e75632a13f2
- Branch merge-base with `origin/main`: 8b3bbb3e207a2442e53c96e8cba92e75632a13f2
- Last `git fetch origin` time: 2026-08-26T20:46:08Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_3078df7b5c749e08ace01ec5a8 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Regression: 3/4 before (reproduces `helloAnswered=false`), 4/4 after; related daemon suites 3/3 and 4/4
- [x] No timeout/retry/skip/gate/CI change (diff read by CEO)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: a live windows-latest run before merge; CI's windows-first-run job on this PR is the authority.

## Review Evidence

- Self-review: CEO filed the task from two dequeues and read the fix diff.
- Reviewer subagent: Codex worker (gpt-5.6-sol); CEO diff read.
- Human review: pending
- Blocking findings: none

## Residual Risk

- A daemon that never answers now waits for the real deadline instead of failing instantly — that is the intended semantics.

## References

- Task: task_3078df7b5c749e08ace01ec5a8
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

0.45:`windows-first-run` 的 G34「stop reports the stop it performed」在 windows-latest 上间歇返回 `daemon_stop_timeout`(08-27 #1856、#1869,重跑绿)。根因是关停客户端的竞态而非 daemon 慢:`requestDaemonShutdownAt` 写完请求就半关管道,daemon 稍晚的应答被丢,CLI 报了一个自己造成的超时。客户端现在保持管道打开直到回包(或真实死线)。没有调超时、重试、跳过 Windows、改门或 CI。回归测试修前复现 `helloAnswered=false`(3/4),修后 4/4。

## 架构辩护

- 不需要:Production-Delta churn 低于 200 行。

## 改动内容

- `packages/daemon/src/client/local-json-rpc-shutdown.ts`:写完 shutdown 请求后不再提前半关。
- `packages/daemon/test/transport-shutdown.integration.test.ts`:延迟应答回归。

## 门收割 / Gate Harvest

- 删除的生产路径:shutdown 请求写入后的提前 `end()`
- 同 commit 删除的门 / fixture:none(半关行为的断言同 commit 替换)
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_3078df7b5c749e08ace01ec5a8
- 分支:codex/windows-stop-flake
- 公开范围:packages/daemon/src/client/local-json-rpc-shutdown.ts、packages/daemon/test/transport-shutdown.integration.test.ts
- 私有计划 / 证据是否已更新:yes
- 范围外:`control.ts` 的 5s stop 死线(不动;从来不是原因);Windows lane 政策(dec_9B75595F)

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_3078df7b5c749e08ace01ec5a8
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:8b3bbb3e207a2442e53c96e8cba92e75632a13f2
- 当前分支与 `origin/main` 的 merge-base:8b3bbb3e207a2442e53c96e8cba92e75632a13f2
- 最近一次 `git fetch origin` 时间:2026-08-26T20:46:08Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_3078df7b5c749e08ace01ec5a8
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] 回归:修前 3/4(复现 `helloAnswered=false`),修后 4/4;相关 daemon 套件 3/3、4/4
- [x] 未调超时/重试/skip/门/CI(CEO 读 diff)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:合并前的实机 windows-latest;本 PR 的 windows-first-run job 为权威。

## 审查证据

- 自查:CEO 从两次 dequeue 立任务并读修复 diff。
- Reviewer subagent:Codex worker(gpt-5.6-sol);CEO 读 diff。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 永不应答的 daemon 现在等真实死线而不是立即失败——这正是预期语义。

## 关联材料

- 任务:task_3078df7b5c749e08ace01ec5a8
- 证据:任务包 artifacts/reports
- 审查:本 PR
