### PR TITLE
fix(daemon): release execution leases when runtime sessions terminate (0.35)

### DIFF
--- a/packages/cli/src/cli-runtime-batch.ts
+++ b/packages/cli/src/cli-runtime-batch.ts
@@ -2,13 +2,9 @@ import type { JsonObject } from "../../daemon/src/protocol/json-rpc-types.ts";
 import { runtimeRejected } from "./cli-runtime-auth.ts";
 import { readRuntimeBatch } from "./cli-runtime-batch-input.ts";
 import { runRuntimeFacadeCommand } from "./cli-runtime-command.ts";
-import type {
-  RuntimeBatchDeclaration,
-  RuntimeBatchEntry,
-  RuntimeBatchResult,
-} from "./cli-types.ts";
+import type { RuntimeBatchDeclaration, RuntimeBatchEntry, RuntimeBatchResult } from "./cli-types.ts";
 import type { ThinCommand } from "./cli/thin-command.ts";
-import { consumeKnownError } from "./daemon/client.ts";
+import { consumeKnownError, runCommandThroughDaemon } from "./daemon/client.ts";
 
 export async function runRuntimeBatch(
   command: ThinCommand,
@@ -34,52 +30,58 @@ export async function runRuntimeBatchDeclaration(
   writeActivity: (text: string) => void,
 ): Promise<JsonObject> {
   const results: RuntimeBatchResult[] = [];
-  let next = 0;
-  const worker = async (): Promise<void> => {
-    while (true) {
-      const index = next++;
-      if (index >= declaration.dispatches.length) return;
-      const entry = declaration.dispatches[index]!;
-      let receipt: JsonObject;
-      try {
-        receipt = await runRuntimeFacadeCommand(
-          {
-            ...command,
-            method: "repo.agentRuntime.spawn",
-            action: runtimeBatchSpawnAction(entry),
-          },
-          writeActivity,
-        );
-      } catch (error) {
-        consumeKnownError(error);
-        receipt = runtimeRejected(
-          "runtime-run",
-          "batch_dispatch_failed",
-          error instanceof Error ? error.message : String(error),
-        );
-      }
-      results[index] = runtimeBatchResult(index, entry, receipt);
+  const releasedTaskIds = new Set<string>();
+  for (let offset = 0; offset < declaration.dispatches.length; offset += declaration.maxConcurrency) {
+    const wave = declaration.dispatches.slice(offset, offset + declaration.maxConcurrency),
+      reacquireFailures = new Map<string, JsonObject>(),
+      reacquireTaskIds = wave
+        .flatMap((entry) => (entry.task && releasedTaskIds.has(entry.task) ? [entry.task] : []))
+        .filter((taskId, index, taskIds) => taskIds.indexOf(taskId) === index);
+    for (const taskId of reacquireTaskIds) {
+      const receipt = await runCommandThroughDaemon({
+        ...command,
+        method: "repo.task.run",
+        action: { kind: "task-start", taskId },
+      });
+      if (receipt.ok === true && receipt.outcome === "applied") releasedTaskIds.delete(taskId);
+      else reacquireFailures.set(taskId, receipt);
     }
-  };
-  await Promise.all(
-    Array.from(
-      {
-        length: Math.min(
-          declaration.maxConcurrency,
-          declaration.dispatches.length,
-        ),
-      },
-      () => worker(),
-    ),
-  );
+    const settled = await Promise.all(
+      wave.map(async (entry, waveIndex) => {
+        const index = offset + waveIndex;
+        let receipt: JsonObject;
+        try {
+          receipt =
+            entry.task && reacquireFailures.has(entry.task)
+              ? reacquireFailures.get(entry.task)!
+              : await runRuntimeFacadeCommand(
+                  {
+                    ...command,
+                    method: "repo.agentRuntime.spawn",
+                    action: runtimeBatchSpawnAction(entry),
+                  },
+                  writeActivity,
+                );
+        } catch (error) {
+          consumeKnownError(error);
+          receipt = runtimeRejected(
+            "runtime-run",
+            "batch_dispatch_failed",
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+        return runtimeBatchResult(index, entry, receipt);
+      }),
+    );
+    for (const result of settled) results[result.index] = result;
+    for (const result of settled) {
+      const taskId = declaration.dispatches[result.index]?.task;
+      if (taskId && result.runtimeSessionId) releasedTaskIds.add(taskId);
+    }
+  }
   const failed = results.filter((result) => result.status !== "succeeded"),
     unknown = results.some((result) => result.status === "unknown"),
-    outcome =
-      failed.length === 0
-        ? "succeeded"
-        : unknown
-          ? "unknown"
-          : "partial_failure";
+    outcome = failed.length === 0 ? "succeeded" : unknown ? "unknown" : "partial_failure";
   return {
     schema: "command-receipt/v2",
     ok: true,
@@ -92,9 +94,7 @@ export async function runRuntimeBatchDeclaration(
   };
 }
 
-export function runtimeBatchSpawnAction(
-  entry: RuntimeBatchEntry,
-): ThinCommand["action"] {
+export function runtimeBatchSpawnAction(entry: RuntimeBatchEntry): ThinCommand["action"] {
   return {
     kind: "runtime-run",
     runtimeInstanceId: entry.instance,
@@ -103,9 +103,7 @@ export function runtimeBatchSpawnAction(
     ...(entry.model ? { model: entry.model } : {}),
     ...(entry.effort ? { effort: entry.effort } : {}),
     ...(entry.permissionMode ? { permissionMode: entry.permissionMode } : {}),
-    ...(entry.prompt
-      ? { prompt: entry.prompt }
-      : { promptFile: entry.promptFile }),
+    ...(entry.prompt ? { prompt: entry.prompt } : { promptFile: entry.promptFile }),
     cwd:
       typeof entry.cwd === "object"
         ? entry.cwd
@@ -117,23 +115,12 @@ export function runtimeBatchSpawnAction(
   };
 }
 
-export function runtimeBatchResult(
-  index: number,
-  entry: RuntimeBatchEntry,
-  receipt: JsonObject,
-): RuntimeBatchResult {
+export function runtimeBatchResult(index: number, entry: RuntimeBatchEntry, receipt: JsonObject): RuntimeBatchResult {
   const spawn =
-      receipt.spawn && typeof receipt.spawn === "object"
-        ? (receipt.spawn as Record<string, unknown>)
-        : receipt,
-    error =
-      receipt.error && typeof receipt.error === "object"
-        ? (receipt.error as Record<string, unknown>)
-        : undefined,
+      receipt.spawn && typeof receipt.spawn === "object" ? (receipt.spawn as Record<string, unknown>) : receipt,
+    error = receipt.error && typeof receipt.error === "object" ? (receipt.error as Record<string, unknown>) : undefined,
     result =
-      receipt.result && typeof receipt.result === "object"
-        ? (receipt.result as Record<string, unknown>)
-        : undefined,
+      receipt.result && typeof receipt.result === "object" ? (receipt.result as Record<string, unknown>) : undefined,
     outcome = typeof receipt.outcome === "string" ? receipt.outcome : null,
     status =
       receipt.ok !== true

--- a/packages/cli/src/cli-runtime-batch.ts
+++ b/packages/cli/src/cli-runtime-batch.ts
@@ -30,55 +30,61 @@ export async function runRuntimeBatchDeclaration(
   writeActivity: (text: string) => void,
 ): Promise<JsonObject> {
   const results: RuntimeBatchResult[] = [];
+  let next = 0;
   const releasedTaskIds = new Set<string>();
-  for (let offset = 0; offset < declaration.dispatches.length; offset += declaration.maxConcurrency) {
-    const wave = declaration.dispatches.slice(offset, offset + declaration.maxConcurrency),
-      reacquireFailures = new Map<string, JsonObject>(),
-      reacquireTaskIds = wave
-        .flatMap((entry) => (entry.task && releasedTaskIds.has(entry.task) ? [entry.task] : []))
-        .filter((taskId, index, taskIds) => taskIds.indexOf(taskId) === index);
-    for (const taskId of reacquireTaskIds) {
-      const receipt = await runCommandThroughDaemon({
+  const reacquisitions = new Map<string, Promise<JsonObject>>();
+  const reacquireReleasedTask = async (taskId: string): Promise<JsonObject | null> => {
+    if (!releasedTaskIds.has(taskId)) return null;
+    let pending = reacquisitions.get(taskId);
+    if (!pending) {
+      pending = runCommandThroughDaemon({
         ...command,
         method: "repo.task.run",
         action: { kind: "task-start", taskId },
       });
-      if (receipt.ok === true && receipt.outcome === "applied") releasedTaskIds.delete(taskId);
-      else reacquireFailures.set(taskId, receipt);
+      reacquisitions.set(taskId, pending);
     }
-    const settled = await Promise.all(
-      wave.map(async (entry, waveIndex) => {
-        const index = offset + waveIndex;
-        let receipt: JsonObject;
-        try {
-          receipt =
-            entry.task && reacquireFailures.has(entry.task)
-              ? reacquireFailures.get(entry.task)!
-              : await runRuntimeFacadeCommand(
-                  {
-                    ...command,
-                    method: "repo.agentRuntime.spawn",
-                    action: runtimeBatchSpawnAction(entry),
-                  },
-                  writeActivity,
-                );
-        } catch (error) {
-          consumeKnownError(error);
-          receipt = runtimeRejected(
-            "runtime-run",
-            "batch_dispatch_failed",
-            error instanceof Error ? error.message : String(error),
-          );
-        }
-        return runtimeBatchResult(index, entry, receipt);
-      }),
-    );
-    for (const result of settled) results[result.index] = result;
-    for (const result of settled) {
-      const taskId = declaration.dispatches[result.index]?.task;
-      if (taskId && result.runtimeSessionId) releasedTaskIds.add(taskId);
+    const receipt = await pending;
+    if (reacquisitions.get(taskId) === pending) reacquisitions.delete(taskId);
+    if (receipt.ok === true && receipt.outcome === "applied") {
+      releasedTaskIds.delete(taskId);
+      return null;
     }
-  }
+    return receipt;
+  };
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const index = next++;
+      if (index >= declaration.dispatches.length) return;
+      const entry = declaration.dispatches[index]!;
+      let receipt: JsonObject;
+      try {
+        const reacquireFailure = entry.task ? await reacquireReleasedTask(entry.task) : null;
+        receipt =
+          reacquireFailure ??
+          (await runRuntimeFacadeCommand(
+            {
+              ...command,
+              method: "repo.agentRuntime.spawn",
+              action: runtimeBatchSpawnAction(entry),
+            },
+            writeActivity,
+          ));
+      } catch (error) {
+        consumeKnownError(error);
+        receipt = runtimeRejected(
+          "runtime-run",
+          "batch_dispatch_failed",
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      results[index] = runtimeBatchResult(index, entry, receipt);
+      if (entry.task && runtimeBatchTaskDispatchSettled(receipt)) releasedTaskIds.add(entry.task);
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(declaration.maxConcurrency, declaration.dispatches.length) }, () => worker()),
+  );
   const failed = results.filter((result) => result.status !== "succeeded"),
     unknown = results.some((result) => result.status === "unknown"),
     outcome = failed.length === 0 ? "succeeded" : unknown ? "unknown" : "partial_failure";
@@ -92,6 +98,29 @@ export async function runRuntimeBatchDeclaration(
     summary: `runtime-batch: ${results.length - failed.length} succeeded, ${failed.length} failed`,
     exitCode: failed.length ? 1 : 0,
   };
+}
+
+export function runtimeBatchTaskDispatchSettled(receipt: JsonObject): boolean {
+  if (
+    receipt.ok !== true ||
+    !["succeeded", "failed", "unknown", "cancelled"].includes(String(receipt.outcome)) ||
+    typeof receipt.runtimeSessionId !== "string"
+  )
+    return false;
+  const session = receipt.session;
+  if (!session || typeof session !== "object" || Array.isArray(session)) return true;
+  const attemptChain = (session as Record<string, unknown>).attemptChain;
+  if (!attemptChain || typeof attemptChain !== "object" || Array.isArray(attemptChain)) return true;
+  const attempts = (attemptChain as Record<string, unknown>).attempts;
+  if (!Array.isArray(attempts)) return true;
+  const attempt = attempts.find(
+    (candidate) =>
+      candidate !== null &&
+      typeof candidate === "object" &&
+      !Array.isArray(candidate) &&
+      (candidate as Record<string, unknown>).runtimeSessionId === receipt.runtimeSessionId,
+  ) as Record<string, unknown> | undefined;
+  return attempt?.fallbackState !== "scheduled" && attempt?.fallbackState !== "dispatched";
 }
 
 export function runtimeBatchSpawnAction(entry: RuntimeBatchEntry): ThinCommand["action"] {

--- a/packages/cli/test/agent-create.integration.test.ts
+++ b/packages/cli/test/agent-create.integration.test.ts
@@ -196,6 +196,7 @@ test("agent create runs and ontology-squad reinstall stays on the canonical Enti
       unknown
     >;
     assert.deepEqual((inspected.agent as Record<string, unknown>).instructions, generated.instructions);
+    run(root, env, ["task", "start", "agent-create-task", "--execution-id", "agent-create-execution"]);
     const duplicate = runMaybe(root, env, [
       "agent",
       "create",
@@ -210,6 +211,7 @@ test("agent create runs and ontology-squad reinstall stays on the canonical Enti
     assert.equal(duplicate.status, 1);
     assert.equal(duplicate.receipt.code, "agent_id_conflict");
     assert.match(String(duplicate.receipt.nextAction), /ha agent inspect mechanic-agent.*ha agent create/u);
+    run(root, env, ["task", "start", "agent-create-task", "--execution-id", "agent-create-execution"]);
     const unavailable = runMaybe(root, env, [
       "agent",
       "create",
@@ -224,6 +226,7 @@ test("agent create runs and ontology-squad reinstall stays on the canonical Enti
     assert.equal(unavailable.status, 1);
     assert.equal(unavailable.receipt.code, "agent_runtime_type_unavailable");
     assert.match(String(unavailable.receipt.nextAction), /ha runtime instance list.*retry ha agent create/u);
+    run(root, env, ["task", "start", "agent-create-task", "--execution-id", "agent-create-execution"]);
     const child = run(root, env, [
       "runtime",
       "run",

--- a/packages/cli/test/cli-runtime-batch.test.ts
+++ b/packages/cli/test/cli-runtime-batch.test.ts
@@ -1,0 +1,41 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { runtimeBatchTaskDispatchSettled } from "../src/cli-runtime-batch.ts";
+
+test("runtime batch records a released task only after the dispatch reaches its final terminal attempt", () => {
+  assert.equal(
+    runtimeBatchTaskDispatchSettled({
+      ok: false,
+      outcome: "op_rejected",
+      code: "daemon_gone",
+      runtimeSessionId: "runtime-still-running",
+      lastKnownDispatch: { status: "running" },
+    }),
+    false,
+  );
+  assert.equal(
+    runtimeBatchTaskDispatchSettled({
+      ok: true,
+      outcome: "failed",
+      runtimeSessionId: "runtime-fallback-scheduled",
+      session: {
+        attemptChain: {
+          attempts: [{ runtimeSessionId: "runtime-fallback-scheduled", fallbackState: "scheduled" }],
+        },
+      },
+    }),
+    false,
+  );
+  assert.equal(
+    runtimeBatchTaskDispatchSettled({
+      ok: true,
+      outcome: "succeeded",
+      runtimeSessionId: "runtime-terminal",
+      session: {
+        attemptChain: { attempts: [{ runtimeSessionId: "runtime-terminal", fallbackState: null }] },
+      },
+    }),
+    true,
+  );
+});

--- a/packages/cli/test/runtime-cli.integration.test.ts
+++ b/packages/cli/test/runtime-cli.integration.test.ts
@@ -866,12 +866,10 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
       true,
       JSON.stringify(batchDispatches),
     );
+    const slowBatchArchive = path.join(artifactRoot, "dispatches", `${String(batchRows[1]?.dispatchId)}.json`);
+    await eventuallyFile(slowBatchArchive);
     assert.equal(
-      (
-        JSON.parse(
-          readFileSync(path.join(artifactRoot, "dispatches", `${String(batchRows[1]?.dispatchId)}.json`), "utf8"),
-        ) as Record<string, unknown>
-      ).reasoningEffort,
+      (JSON.parse(readFileSync(slowBatchArchive, "utf8")) as Record<string, unknown>).reasoningEffort,
       "high",
     );
     const emptyFailure = runMaybe(root, env, [

--- a/packages/cli/test/runtime-cli.integration.test.ts
+++ b/packages/cli/test/runtime-cli.integration.test.ts
@@ -304,7 +304,8 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
       "test:reports/runtime-progress.txt:unrelated",
     ]);
     assert.equal(unrelatedProgress.status, 1);
-    assert.equal(unrelatedProgress.receipt.code, "progress_lease_mismatch");
+    assert.equal(unrelatedProgress.receipt.code, "progress_lease_required");
+    run(root, env, ["task", "start", taskId, "--execution-id", executionId]);
     const assembledPromptPrefix =
         "# Agent Identity: Terra (terra)\n\nReview precisely.\n\n# Harness Execution Discipline",
       bound = run(root, env, [
@@ -382,6 +383,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     assert.match(String(boundDispatch.endedAt), /^\d{4}-\d{2}-\d{2}T/u);
     assert.doesNotMatch(JSON.stringify(boundDispatch), /(?:api.?key|credential|environment|token)/iu);
     assert.equal(existsSync(path.join(root, ".harness", "runtime", "dispatches", `${boundDispatchId}.jsonl`)), true);
+    run(root, env, ["task", "start", taskId, "--execution-id", executionId]);
     const dispatchRow = (
       run(root, env, ["task", "dispatches", taskId]).dispatches as Array<Record<string, unknown>>
     ).find((row) => row.dispatchId === boundDispatchId);
@@ -470,6 +472,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
       runtimeSessionId: String(reused.runtimeSessionId),
       mission: "existing mission",
     });
+    run(root, env, ["task", "start", taskId, "--execution-id", executionId]);
     const taskPackage = path.join(realpathSync(root), "harness", packagePath),
       derivedMission = `Your task package is ${taskPackage}.\nRead task_plan.md in that package and complete the task.`,
       derived = run(root, env, [
@@ -557,6 +560,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     ]);
     assert.equal(invalidOnExit.status, 2);
     assert.match(rejectionHint(invalidOnExit.receipt), /only with --detach/u);
+    run(root, env, ["task", "start", taskId, "--execution-id", executionId]);
     const controlNotification = run(root, env, [
         "runtime",
         "run",
@@ -575,6 +579,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
         "--no-stream",
       ]),
       controlInvariant = runtimeInvariantEvidence(root, artifactRoot, controlNotification, controlNotificationWait);
+    run(root, env, ["task", "start", taskId, "--execution-id", executionId]);
     const missingNotifier = path.join(parent, "missing-notifier"),
       missingNotification = run(root, env, [
         "runtime",
@@ -597,6 +602,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
       ]),
       missingTrace = await eventuallyNotification(root, String(missingNotification.dispatchId)),
       missingInvariant = runtimeInvariantEvidence(root, artifactRoot, missingNotification, missingNotificationWait);
+    run(root, env, ["task", "start", taskId, "--execution-id", executionId]);
     const nonzeroNotification = run(root, env, [
         "runtime",
         "run",
@@ -662,6 +668,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     context.diagnostic(
       `failed notification trace: ${JSON.stringify({ missing: missingTrace.finished, nonzero: nonzeroNotificationTrace.finished, invariant: nonzeroInvariant })}`,
     );
+    run(root, env, ["task", "start", taskId, "--execution-id", executionId]);
     const queueNotification = run(root, env, [
       "runtime",
       "run",
@@ -676,6 +683,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     ]);
     run(root, env, ["runtime", "status", String(queueNotification.runtimeSessionId), "--wait", "--no-stream"]);
     await eventuallyFile(notificationStarted);
+    run(root, env, ["task", "start", taskId, "--execution-id", executionId]);
     const revisionBefore = makeTaskEventStore({ repoId: "runtime-cli", rootDir: root }).readHead()?.revision ?? 0,
       writeStartedAt = performance.now(),
       queueWrite = run(root, env, [
@@ -822,6 +830,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
             },
             { instance: "cli-worker", agent: "fable", to: "terra", prompt: "batch hold two", cwd: ".", task: taskId },
             { instance: "cli-worker", agent: "fable", to: "terra", "prompt-file": "batch-prompt.txt", task: taskId },
+            { instance: "cli-worker", agent: "fable", to: "terra", prompt: "batch hold three", task: taskId },
           ],
         },
         null,
@@ -833,10 +842,10 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     assert.equal(batch.receipt.command, "runtime-batch");
     assert.equal(batch.receipt.outcome, "partial_failure");
     const batchRows = batch.receipt.dispatches as Array<Record<string, unknown>>;
-    assert.equal(batchRows.length, 4);
+    assert.equal(batchRows.length, 5);
     assert.deepEqual(
       batchRows.map((row) => row.status),
-      ["rejected", "succeeded", "succeeded", "succeeded"],
+      ["rejected", "succeeded", "succeeded", "succeeded", "succeeded"],
       JSON.stringify(batch.receipt),
     );
     assert.equal(batchRows[0]?.code, "squad_member_not_found");
@@ -849,7 +858,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
       batchDispatches = (
         run(root, env, ["task", "dispatches", taskId]).dispatches as Array<Record<string, unknown>>
       ).filter((row) => batchDispatchIds.has(String(row.dispatchId)));
-    assert.equal(batchDispatches.length, 3);
+    assert.equal(batchDispatches.length, 4);
     assert.equal(
       batchDispatches.every(
         (row) => row.agentId === "terra" && row.delegatedByAgentId === "fable" && row.squadId === "core-squad",
@@ -926,6 +935,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     assert.equal(waitedRow?.exitCode, 0);
     assert.equal(waitedRow?.dispatchPath, `${packagePath}/artifacts/dispatches/${progressDispatchId}.json`);
     assert.equal(waitedRow?.reportPath, `${packagePath}/artifacts/reports/${progressDispatchId}.md`);
+    run(root, env, ["task", "start", taskId, "--execution-id", executionId]);
     const detachedFailure = run(root, env, [
       "runtime",
       "run",
@@ -961,9 +971,10 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
       active += event === "start" ? 1 : -1;
       peak = Math.max(peak, active);
     }
-    assert.equal(events.filter((event) => event === "start").length, 3);
-    assert.equal(events.filter((event) => event === "end").length, 3);
+    assert.equal(events.filter((event) => event === "start").length, 4);
+    assert.equal(events.filter((event) => event === "end").length, 4);
     assert.ok(peak <= 2, `batch exceeded declared concurrency: ${events.join(",")}`);
+    run(root, env, ["task", "start", taskId, "--execution-id", executionId]);
     const detached = run(root, env, [
         "runtime",
         "run",
@@ -1029,6 +1040,7 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
     context.diagnostic(
       `notification at-most-once: ${JSON.stringify({ executions: onceLines.length, records: cancelledRecords })}`,
     );
+    run(root, env, ["task", "start", taskId, "--execution-id", executionId]);
     const streamRoot = path.join(root, ".harness", "runtime", "dispatches"),
       streamsBeforeRejectedResume = readdirSync(streamRoot).sort(),
       sessionsBeforeRejectedResume = (run(root, env, ["runtime", "status"]).sessions as Array<Record<string, unknown>>)

--- a/packages/daemon/src/fleet-edge-runtime.ts
+++ b/packages/daemon/src/fleet-edge-runtime.ts
@@ -258,7 +258,7 @@ export function openFleetEdgeRuntime(input: {
         entityStore: getEntityStore(),
       }),
     onAttemptTerminal: async (terminal) => {
-      if (terminal.task && !terminal.fallbackExhausted) {
+      if (terminal.task) {
         const waitMs = runtimeReadTimeoutMs ?? 30_000,
           { taskId, executionId } = terminal.task,
           settled = await runFleetTaskCommandClient({
@@ -283,27 +283,6 @@ export function openFleetEdgeRuntime(input: {
           throw edgeRuntimeError(
             "runtime_lease_release_failed",
             `Center rejected Runtime terminal lease settlement: ${String(settled.code ?? settled.outcome)}.`,
-          );
-      } else if (terminal.fallbackExhausted && terminal.task) {
-        const waitMs = runtimeReadTimeoutMs ?? 30_000,
-          { taskId, executionId } = terminal.task,
-          settled = await runFleetTaskCommandClient({
-            ...peer,
-            repoId: request.repoId,
-            taskId,
-            opId: `provider-fallback-exhausted-${executionId}`,
-            waitMs,
-            action: {
-              kind: "task-fallback-exhausted",
-              taskId,
-              executionId,
-              reason: terminal.reason ?? "Provider fallback exhausted.",
-            },
-          });
-        if (settled.outcome !== "applied")
-          throw edgeRuntimeError(
-            "fallback_exhaustion_failed",
-            `Center rejected provider fallback exhaustion settlement: ${String(settled.code ?? settled.outcome)}.`,
           );
       }
       const scheduled = terminal.schedule,

--- a/packages/daemon/src/fleet-edge-runtime.ts
+++ b/packages/daemon/src/fleet-edge-runtime.ts
@@ -258,7 +258,33 @@ export function openFleetEdgeRuntime(input: {
         entityStore: getEntityStore(),
       }),
     onAttemptTerminal: async (terminal) => {
-      if (terminal.fallbackExhausted && terminal.task) {
+      if (terminal.task && !terminal.fallbackExhausted) {
+        const waitMs = runtimeReadTimeoutMs ?? 30_000,
+          { taskId, executionId } = terminal.task,
+          settled = await runFleetTaskCommandClient({
+            ...peer,
+            repoId: request.repoId,
+            taskId,
+            opId: `runtime-terminal-${terminal.runtimeSessionId}`,
+            waitMs,
+            action: {
+              kind: "task-release",
+              taskId,
+              terminalExecutionId: executionId,
+              terminalRuntimeSessionId: terminal.runtimeSessionId,
+              reason: `Runtime session ${terminal.runtimeSessionId} reached a terminal dispatch state.`,
+            },
+          });
+        if (
+          settled.outcome !== "applied" &&
+          settled.code !== "lease_not_found" &&
+          settled.code !== "runtime_terminal_superseded"
+        )
+          throw edgeRuntimeError(
+            "runtime_lease_release_failed",
+            `Center rejected Runtime terminal lease settlement: ${String(settled.code ?? settled.outcome)}.`,
+          );
+      } else if (terminal.fallbackExhausted && terminal.task) {
         const waitMs = runtimeReadTimeoutMs ?? 30_000,
           { taskId, executionId } = terminal.task,
           settled = await runFleetTaskCommandClient({

--- a/packages/daemon/src/fleet/contract.ts
+++ b/packages/daemon/src/fleet/contract.ts
@@ -390,7 +390,16 @@ const taskActionShapes: Readonly<Record<FleetTaskCommandKind, Check>> = {
     ["kind"],
   ),
   "task-submit": optionalShape({ kind: one("task-submit"), taskId: id, executionId: id, submission: record }, ["kind"]),
-  "task-release": optionalShape({ kind: one("task-release"), taskId: id, reason: text }, ["kind"]),
+  "task-release": optionalShape(
+    {
+      kind: one("task-release"),
+      taskId: id,
+      reason: text,
+      terminalExecutionId: id,
+      terminalRuntimeSessionId: id,
+    },
+    ["kind"],
+  ),
   "task-fallback-exhausted": optionalShape(
     { kind: one("task-fallback-exhausted"), taskId: id, executionId: id, reason: text },
     ["kind", "taskId", "executionId", "reason"],

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -14,7 +14,7 @@ import { readAgentDeclaration, resolveSquadDispatch } from "./agent-entities.ts"
 import type { PreparedRuntimeLaunch, RuntimeInstanceSummary } from "./agent-runtime-instances.ts";
 import { makeAgentRuntimeStreamHub } from "./agent-runtime-stream.ts";
 import { openGuiCatalog } from "./gui-catalog.ts";
-import { type CanonicalRoot, type WorkspaceId } from "./protocol/daemon-protocol.contract.ts";
+import { commandClassForAction, type CanonicalRoot, type WorkspaceId } from "./protocol/daemon-protocol.contract.ts";
 import { makeRecoveryProbe } from "./recovery-state.ts";
 import { bootstrapRepo, type RepoBootstrapInput, type RepoBootstrapReceipt } from "./repo-bootstrap.ts";
 import { createRepoCellActionContext } from "./repo-cell-action-context.ts";
@@ -40,6 +40,7 @@ import type {
   RepoCellBinding,
   RepoCellStatus,
   RepoCellTerminal,
+  Snapshot,
 } from "./repo-cell-types.ts";
 import { admitRepoMode } from "./repo-mode.ts";
 import { makeDaemonRuntimeAdmissionGuard } from "./runtime-admission.ts";
@@ -335,6 +336,27 @@ export async function openRepoCell(input: {
     rootDir,
     projection: () => projection,
     store: () => store,
+    reacquireTaskLease: async (taskId, binding) => {
+      const snapshot = projection.read(taskId).snapshot as Snapshot;
+      if (snapshot.lease) return;
+      const execution = snapshot.executions.find(
+        (candidate) => candidate.iteration === snapshot.task?.iteration && candidate.state === "active",
+      );
+      if (!execution)
+        throw cellCodedError(
+          "runtime_task_lease_required",
+          `Task ${taskId} has no active execution for the squad continuation to reacquire.`,
+        );
+      const started = await extracted.lifecycleAction(
+        { kind: "task-start", taskId, executionId: execution.executionId },
+        { ...binding, commandClasses: [commandClassForAction("task-start")] },
+      );
+      if (started.outcome !== "applied")
+        throw cellCodedError(
+          "runtime_task_lease_required",
+          `Squad continuation could not reacquire execution ${execution.executionId} for task ${taskId}.`,
+        );
+    },
     runtimeSpawner: () => runtimeSpawner,
   });
   function assertRuntimeAdmission(force = false): void {

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -282,6 +282,9 @@ export async function openRepoCell(input: {
   }) => Promise<void> = async () => {
     throw cellCodedError("runtime_preconditions_unavailable", "RepoCell fallback settlement is not ready.");
   };
+  let settleExecutionLease: (terminal: RuntimeAttemptTerminal) => Promise<void> = async () => {
+    throw cellCodedError("runtime_preconditions_unavailable", "RepoCell execution settlement is not ready.");
+  };
   let settleScheduledOutcome: (terminal: RuntimeAttemptTerminal) => Promise<void> = async () => {
     throw cellCodedError("runtime_preconditions_unavailable", "RepoCell Schedule settlement is not ready.");
   };
@@ -313,12 +316,15 @@ export async function openRepoCell(input: {
       input.onRuntimeOutcome?.(event);
     },
     onAttemptTerminal: async (terminal) => {
-      if (terminal.fallbackExhausted && terminal.task)
-        await settleFallbackExhaustion({
-          ...terminal.task,
-          reason: terminal.reason ?? "Provider fallback exhausted.",
-          binding: terminal.binding,
-        });
+      if (terminal.task) {
+        if (terminal.fallbackExhausted)
+          await settleFallbackExhaustion({
+            ...terminal.task,
+            reason: terminal.reason ?? "Provider fallback exhausted.",
+            binding: terminal.binding,
+          });
+        else await settleExecutionLease(terminal);
+      }
       if (terminal.schedule) schedule(() => settleScheduledOutcome(terminal));
       input.onAttemptTerminal?.(terminal);
     },
@@ -427,6 +433,24 @@ export async function openRepoCell(input: {
     );
     if (settled.outcome !== "applied")
       throw cellCodedError("fallback_exhaustion_failed", `Fallback exhaustion settlement was ${settled.outcome}.`);
+  };
+  settleExecutionLease = async (terminal) => {
+    const task = terminal.task;
+    if (!task) return;
+    const lease = extracted.projection.currentLease(task.taskId, terminal.endedAt);
+    if (!lease || lease.phase === "released" || lease.executionId !== task.executionId) return;
+    const settled = await extracted.taskSurfaceWrite(
+      {
+        kind: "task-release",
+        taskId: task.taskId,
+        terminalExecutionId: task.executionId,
+        terminalRuntimeSessionId: terminal.runtimeSessionId,
+        reason: `Runtime session ${terminal.runtimeSessionId} reached a terminal dispatch state.`,
+      },
+      terminal.binding,
+    );
+    if (settled.outcome !== "applied")
+      throw cellCodedError("runtime_lease_release_failed", `Runtime terminal lease settlement was ${settled.outcome}.`);
   };
   await runtimeSpawner.adopt();
   schedule(() => squadCoordinator.reconcile());

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -2,6 +2,7 @@ import {
   bindWriterGenerationToken,
   consumeKnownError,
   createEntityStore,
+  isSameExecution,
   type CanonicalEventAppendReceipt,
   type DaemonRepoMode,
   type EventPublicationKillpoint,
@@ -56,6 +57,36 @@ import type { DaemonLifecycleRecorder } from "./lifecycle-log.ts";
 
 export function publicPublication(value: Pick<CanonicalEventAppendReceipt, "commitSha" | "cut">): PublicPublication {
   return { commitSha: value.commitSha?.sha ?? null, cut: value.cut };
+}
+
+export async function reacquireSquadTaskLease(input: {
+  readonly taskId: string;
+  readonly binding: RepoCellBinding;
+  readonly snapshot: Snapshot;
+  readonly start: (executionId: string) => Promise<{ readonly outcome: string }>;
+}): Promise<void> {
+  const execution = input.snapshot.executions.find(
+    (candidate) => candidate.iteration === input.snapshot.task?.iteration && candidate.state === "active",
+  );
+  if (!execution)
+    throw cellCodedError(
+      "runtime_task_lease_required",
+      `Task ${input.taskId} has no active execution for the squad continuation to reacquire.`,
+    );
+  const lease = input.snapshot.lease;
+  if (lease) {
+    if (lease.executionId === execution.executionId && isSameExecution(lease.actor, input.binding.actor)) return;
+    throw cellCodedError(
+      "lease_conflict",
+      `Task ${input.taskId} is leased by another execution or actor; the squad continuation stopped.`,
+    );
+  }
+  const started = await input.start(execution.executionId);
+  if (started.outcome !== "applied")
+    throw cellCodedError(
+      "runtime_task_lease_required",
+      `Squad continuation could not reacquire execution ${execution.executionId} for task ${input.taskId}.`,
+    );
 }
 
 export async function openRepoCell(input: {
@@ -275,14 +306,6 @@ export async function openRepoCell(input: {
       () => replica.kick(),
     );
   };
-  let settleFallbackExhaustion: (value: {
-    readonly taskId: string;
-    readonly executionId: string;
-    readonly reason: string;
-    readonly binding: RepoCellBinding;
-  }) => Promise<void> = async () => {
-    throw cellCodedError("runtime_preconditions_unavailable", "RepoCell fallback settlement is not ready.");
-  };
   let settleExecutionLease: (terminal: RuntimeAttemptTerminal) => Promise<void> = async () => {
     throw cellCodedError("runtime_preconditions_unavailable", "RepoCell execution settlement is not ready.");
   };
@@ -317,15 +340,7 @@ export async function openRepoCell(input: {
       input.onRuntimeOutcome?.(event);
     },
     onAttemptTerminal: async (terminal) => {
-      if (terminal.task) {
-        if (terminal.fallbackExhausted)
-          await settleFallbackExhaustion({
-            ...terminal.task,
-            reason: terminal.reason ?? "Provider fallback exhausted.",
-            binding: terminal.binding,
-          });
-        else await settleExecutionLease(terminal);
-      }
+      if (terminal.task) await settleExecutionLease(terminal);
       if (terminal.schedule) schedule(() => settleScheduledOutcome(terminal));
       input.onAttemptTerminal?.(terminal);
     },
@@ -337,25 +352,16 @@ export async function openRepoCell(input: {
     projection: () => projection,
     store: () => store,
     reacquireTaskLease: async (taskId, binding) => {
-      const snapshot = projection.read(taskId).snapshot as Snapshot;
-      if (snapshot.lease) return;
-      const execution = snapshot.executions.find(
-        (candidate) => candidate.iteration === snapshot.task?.iteration && candidate.state === "active",
-      );
-      if (!execution)
-        throw cellCodedError(
-          "runtime_task_lease_required",
-          `Task ${taskId} has no active execution for the squad continuation to reacquire.`,
-        );
-      const started = await extracted.lifecycleAction(
-        { kind: "task-start", taskId, executionId: execution.executionId },
-        { ...binding, commandClasses: [commandClassForAction("task-start")] },
-      );
-      if (started.outcome !== "applied")
-        throw cellCodedError(
-          "runtime_task_lease_required",
-          `Squad continuation could not reacquire execution ${execution.executionId} for task ${taskId}.`,
-        );
+      await reacquireSquadTaskLease({
+        taskId,
+        binding,
+        snapshot: projection.read(taskId).snapshot as Snapshot,
+        start: (executionId) =>
+          extracted.lifecycleAction(
+            { kind: "task-start", taskId, executionId },
+            { ...binding, commandClasses: [commandClassForAction("task-start")] },
+          ),
+      });
     },
     runtimeSpawner: () => runtimeSpawner,
   });
@@ -447,14 +453,6 @@ export async function openRepoCell(input: {
         "schedule_settlement_pending",
         `Schedule ${scheduled.scheduleId} settlement was ${receipt.outcome}.`,
       );
-  };
-  settleFallbackExhaustion = async ({ taskId, executionId, reason, binding }) => {
-    const settled = await extracted.taskSurfaceWrite(
-      { kind: "task-fallback-exhausted", taskId, executionId, reason },
-      binding,
-    );
-    if (settled.outcome !== "applied")
-      throw cellCodedError("fallback_exhaustion_failed", `Fallback exhaustion settlement was ${settled.outcome}.`);
   };
   settleExecutionLease = async (terminal) => {
     const task = terminal.task;

--- a/packages/daemon/src/repo-cell-task-mutation.ts
+++ b/packages/daemon/src/repo-cell-task-mutation.ts
@@ -58,8 +58,8 @@ export function taskMutation(
   if (action.kind === "task-release" || action.kind === "task-fallback-exhausted") {
     if (!activeLease)
       throw cell.cellCodedError("lease_not_found", `Start task ${task.taskId} before releasing its lease.`);
-    const terminalExecutionId = optionalText(action.terminalExecutionId),
-      terminalRuntimeSessionId = optionalText(action.terminalRuntimeSessionId);
+    const terminalExecutionId = optionalReleaseText(action.terminalExecutionId),
+      terminalRuntimeSessionId = optionalReleaseText(action.terminalRuntimeSessionId);
     if ((terminalExecutionId === null) !== (terminalRuntimeSessionId === null))
       throw cell.cellCodedError(
         "invalid_command",
@@ -366,7 +366,7 @@ export function taskMutation(
   throw cell.cellCodedError("unsupported_command", `No task mutation contract exists for ${action.kind}.`);
 }
 
-function optionalText(value: unknown): string | null {
+function optionalReleaseText(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 

--- a/packages/daemon/src/repo-cell-task-mutation.ts
+++ b/packages/daemon/src/repo-cell-task-mutation.ts
@@ -1,14 +1,21 @@
 import {
   deriveRelationId,
+  isSameExecution,
   isTerminalStatus,
+  resolveTaskBoundRuntimeBinding,
+  runtimeSessionSemanticState,
   taskClasses,
   validateRelationRecordsForHost,
   type EntityRelationRecord,
   type AuthorizationDecision,
+  type LeaseV1,
+  type RuntimeSession,
+  type TaskBoundRuntimeBinding,
   type TaskEventV1,
   type TaskV1,
 } from "../../kernel/src/index.ts";
 import { authorizeAction } from "./authorization.ts";
+import { readDispatchStreams } from "./dispatch-stream.ts";
 import type { RepoCellBinding, RepoTaskAction, Snapshot } from "./repo-cell-types.ts";
 
 export function taskMutation(
@@ -51,12 +58,28 @@ export function taskMutation(
   if (action.kind === "task-release" || action.kind === "task-fallback-exhausted") {
     if (!activeLease)
       throw cell.cellCodedError("lease_not_found", `Start task ${task.taskId} before releasing its lease.`);
+    const terminalExecutionId = optionalText(action.terminalExecutionId),
+      terminalRuntimeSessionId = optionalText(action.terminalRuntimeSessionId);
+    if ((terminalExecutionId === null) !== (terminalRuntimeSessionId === null))
+      throw cell.cellCodedError(
+        "invalid_command",
+        "Runtime terminal lease settlement requires both terminal execution and RuntimeSession identities.",
+      );
+    if (terminalExecutionId !== null && terminalExecutionId !== activeLease.executionId)
+      throw cell.cellCodedError(
+        "runtime_terminal_superseded",
+        `Runtime terminal settlement belongs to ${terminalExecutionId}; ${activeLease.executionId} now holds the lease.`,
+      );
     if (action.kind === "task-fallback-exhausted" && action.executionId !== activeLease.executionId)
       throw cell.cellCodedError(
         "lease_conflict",
         `Fallback exhaustion belongs to ${String(action.executionId)}, but ${activeLease.executionId} holds the lease.`,
       );
     const execution = snapshot.executions.find((value) => value.executionId === activeLease.executionId),
+      terminalRuntimeBinding =
+        terminalRuntimeSessionId !== null || !isSameExecution(activeLease.actor, binding.actor)
+          ? terminalExecutionRuntimeBinding(cell, activeLease, terminalRuntimeSessionId)
+          : null,
       actionId = `task-release:${task.taskId}:${activeLease.executionId}:${snapshot.revision}`,
       authorizationDecision = authorizeAction(
         "execution.release",
@@ -64,7 +87,12 @@ export function taskMutation(
         binding.actor,
         actionId,
         {
-          target: { lease: activeLease, canonicalExecutionExists: execution !== undefined },
+          target: {
+            owner: task.createdBy,
+            lease: activeLease,
+            canonicalExecutionExists: execution !== undefined,
+            terminalRuntimeBinding,
+          },
           evaluatedAtCut: `canonical:${snapshot.revision}`,
         },
       );
@@ -334,4 +362,43 @@ export function taskMutation(
     };
   }
   throw cell.cellCodedError("unsupported_command", `No task mutation contract exists for ${action.kind}.`);
+}
+
+function optionalText(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function terminalExecutionRuntimeBinding(
+  cell: any,
+  lease: LeaseV1,
+  runtimeSessionId: string | null,
+): TaskBoundRuntimeBinding | null {
+  if (typeof cell.projection?.readRuntimeSessionsForTask !== "function") return null;
+  const inferredTerminalSessionIds =
+    runtimeSessionId === null
+      ? new Set(
+          readDispatchStreams(cell.rootDir)
+            .filter(
+              (stream) =>
+                stream.header.taskId === lease.taskId &&
+                stream.header.executionId === lease.executionId &&
+                stream.attemptOutcome !== null &&
+                (stream.attemptOutcome.classification !== "provider_fault" ||
+                  stream.header.fallbackAttempt === undefined ||
+                  stream.fallbackState === "exhausted"),
+            )
+            .map((stream) => stream.header.runtimeSessionId),
+        )
+      : null;
+  const sessions = [...(cell.projection.readRuntimeSessionsForTask(lease.taskId) as readonly RuntimeSession[])].sort(
+    (left, right) => right.lastObservedAt.localeCompare(left.lastObservedAt),
+  );
+  for (const session of sessions) {
+    if (runtimeSessionId !== null && session.runtimeSessionId !== runtimeSessionId) continue;
+    if (inferredTerminalSessionIds !== null && !inferredTerminalSessionIds.has(session.runtimeSessionId)) continue;
+    if (session.liveness !== "exited" || runtimeSessionSemanticState(session) === "running") continue;
+    const binding = resolveTaskBoundRuntimeBinding(session, lease.taskId, lease.executionId);
+    if (binding) return binding;
+  }
+  return null;
 }

--- a/packages/daemon/src/repo-cell-task-mutation.ts
+++ b/packages/daemon/src/repo-cell-task-mutation.ts
@@ -68,12 +68,14 @@ export function taskMutation(
     if (terminalExecutionId !== null && terminalExecutionId !== activeLease.executionId)
       throw cell.cellCodedError(
         "runtime_terminal_superseded",
-        `Runtime terminal settlement belongs to ${terminalExecutionId}; ${activeLease.executionId} now holds the lease.`,
+        `Runtime terminal settlement belongs to ${terminalExecutionId}; ` +
+          `${activeLease.executionId} now holds the lease.`,
       );
     if (action.kind === "task-fallback-exhausted" && action.executionId !== activeLease.executionId)
       throw cell.cellCodedError(
         "lease_conflict",
-        `Fallback exhaustion belongs to ${String(action.executionId)}, but ${activeLease.executionId} holds the lease.`,
+        `Fallback exhaustion belongs to ${String(action.executionId)}, ` +
+          `but ${activeLease.executionId} holds the lease.`,
       );
     const execution = snapshot.executions.find((value) => value.executionId === activeLease.executionId),
       terminalRuntimeBinding =
@@ -390,9 +392,8 @@ function terminalExecutionRuntimeBinding(
             .map((stream) => stream.header.runtimeSessionId),
         )
       : null;
-  const sessions = [...(cell.projection.readRuntimeSessionsForTask(lease.taskId) as readonly RuntimeSession[])].sort(
-    (left, right) => right.lastObservedAt.localeCompare(left.lastObservedAt),
-  );
+  const taskSessions = cell.projection.readRuntimeSessionsForTask(lease.taskId) as readonly RuntimeSession[];
+  const sessions = [...taskSessions].sort((left, right) => right.lastObservedAt.localeCompare(left.lastObservedAt));
   for (const session of sessions) {
     if (runtimeSessionId !== null && session.runtimeSessionId !== runtimeSessionId) continue;
     if (inferredTerminalSessionIds !== null && !inferredTerminalSessionIds.has(session.runtimeSessionId)) continue;

--- a/packages/daemon/src/runtime-spawn-settlement.ts
+++ b/packages/daemon/src/runtime-spawn-settlement.ts
@@ -175,7 +175,6 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
       task: active.task,
       schedule: active.schedule,
       outcome: outcome === "succeeded" ? "succeeded" : "failed",
-      fallbackExhausted: false,
       reason: outcome === "succeeded" ? null : attemptOutcome.reason,
       endedAt,
       resultRef,

--- a/packages/daemon/src/runtime-spawn-types.ts
+++ b/packages/daemon/src/runtime-spawn-types.ts
@@ -61,7 +61,6 @@ export interface RuntimeAttemptTerminal {
   readonly task: { readonly taskId: string; readonly executionId: string } | null;
   readonly schedule: TrustedScheduleRuntime | null;
   readonly outcome: "succeeded" | "failed";
-  readonly fallbackExhausted: boolean;
   readonly reason: string | null;
   readonly endedAt: string;
   readonly resultRef: string | null;

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -736,7 +736,7 @@ export function makeRuntimeSpawner(input: {
       const reason = `Provider fallback exhausted after ${String(nextAttemptIndex)} attempt(s): ${outcome.reason}`;
       active.stream.appendFallbackState({ state: "exhausted", reason }, input.now());
       try {
-        await input.onAttemptTerminal?.({ ...terminal, outcome: "failed", fallbackExhausted: true, reason });
+        await input.onAttemptTerminal?.({ ...terminal, outcome: "failed", reason });
       } catch (error) {
         const settlementReason = [
           "Provider fallback exhaustion could not settle terminal state: ",
@@ -847,7 +847,6 @@ export function makeRuntimeSpawner(input: {
               header.taskId && header.executionId ? { taskId: header.taskId, executionId: header.executionId } : null,
             schedule: header.schedule ?? null,
             outcome: "failed",
-            fallbackExhausted: true,
             reason,
             endedAt: input.now(),
             resultRef: null,

--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -95,6 +95,7 @@ export function makeSquadCoordinator(input: {
   readonly rootDir: string;
   readonly projection: () => TaskProjection;
   readonly store: () => CanonicalEventStore;
+  readonly reacquireTaskLease: (taskId: string, binding: RuntimeBinding) => Promise<void>;
   readonly runtimeSpawner: () => {
     readonly spawn: (payload: JsonObject, binding: RuntimeBinding) => Promise<JsonObject>;
   };
@@ -352,6 +353,7 @@ export function makeSquadCoordinator(input: {
   async function spawnWorker(state: SquadState, plan: WorkerPlan, leaderTurnId: string): Promise<SquadState> {
     const attemptId = `worker-${state.workerAttempts.length + 1}`;
     try {
+      await input.reacquireTaskLease(state.taskId, state.binding);
       const receipt = await input.runtimeSpawner().spawn(
           {
             runtimeInstanceId: state.runtimeInstanceId,
@@ -419,6 +421,7 @@ export function makeSquadCoordinator(input: {
   }
 
   async function spawnLeader(state: SquadState, trigger: LeaderTrigger): Promise<SquadState> {
+    if (trigger.kind !== "initial") await input.reacquireTaskLease(state.taskId, state.binding);
     const turnId = `leader-${state.leaderTurns.length + 1}`,
       prompt =
         trigger.kind === "initial"

--- a/packages/daemon/test/lease-reservation-reclaim.contract.test.ts
+++ b/packages/daemon/test/lease-reservation-reclaim.contract.test.ts
@@ -1,9 +1,13 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { type ActorIdentity, type LeaseV1, type TaskLifecycleSnapshot, type TaskV1 } from "../../kernel/src/index.ts";
 import { taskSurfaceWrite } from "../src/repo-cell-task-command-docs.ts";
 import { taskMutation } from "../src/repo-cell-task-command.ts";
+import { openDispatchStream } from "../src/dispatch-stream.ts";
 
 const now = "2026-08-25T03:15:20.000Z";
 const owner = (executorId: string): ActorIdentity => ({
@@ -113,4 +117,147 @@ test("a different principal cannot reclaim the reservation before TTL", () => {
       }),
     (error: unknown) => error instanceof Error && "code" in error && error.code === "lease_conflict",
   );
+});
+
+test("the task owner can reclaim an orphaned lease held by another principal", () => {
+  const taskOwner = owner("task-owner"),
+    foreignLease = {
+      ...lease,
+      actor: {
+        principal: { personId: "person-worker" },
+        executor: { kind: "agent" as const, id: "departed-worker" },
+      },
+      phase: "orphaned" as const,
+    },
+    ownedTask = { ...task, createdBy: taskOwner },
+    ownedSnapshot = { ...snapshot(), task: ownedTask, lease: foreignLease };
+  const mutation = taskMutation(
+    cell,
+    { kind: "task-release", taskId: task.taskId, reason: "The worker is gone." },
+    ownedTask,
+    ownedSnapshot,
+    { actor: { principal: taskOwner.principal, executor: null }, source: "local" },
+  );
+
+  assert.equal(mutation.type, "lease_released");
+  assert.equal(mutation.releasedLease, foreignLease);
+});
+
+test("a stale RuntimeSession terminal cannot release a newer execution lease", () => {
+  assert.throws(
+    () =>
+      taskMutation(
+        cell,
+        {
+          kind: "task-release",
+          taskId: task.taskId,
+          terminalExecutionId: "exec-previous",
+          terminalRuntimeSessionId: "runtime-previous",
+        },
+        task,
+        snapshot(),
+        { actor: owner("replacement-worker"), source: "local" },
+      ),
+    (error: unknown) => error instanceof Error && "code" in error && error.code === "runtime_terminal_superseded",
+  );
+});
+
+test("the task owner reclaims a held lease after its bound dispatch reaches a terminal attempt", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-terminal-lease-reclaim-")),
+    taskOwner = owner("task-owner"),
+    worker = {
+      principal: { personId: "person-worker" },
+      executor: { kind: "agent" as const, id: "departed-worker" },
+    },
+    heldLease = { ...lease, actor: worker },
+    ownedTask = { ...task, createdBy: taskOwner },
+    execution = {
+      schema: "execution/v1" as const,
+      executionId: heldLease.executionId,
+      taskId: heldLease.taskId,
+      nodeId: "implementation" as const,
+      iteration: 0 as const,
+      state: "active" as const,
+      actor: worker,
+      claimedAt: now,
+      submittedAt: null,
+      closedAt: null,
+      submission: null,
+    },
+    runtimeSessionId = "runtime-terminal-owner-reclaim",
+    runtimeSession = {
+      runtimeSessionId,
+      instanceId: "codex-test",
+      installationId: "installation-test",
+      kindId: "codex",
+      definitionSnapshotRef: "artifact:runtime-definition/test",
+      providerSessionId: "provider-test",
+      transcriptRef: "file:transcript.jsonl",
+      launchGeneration: 1,
+      liveness: "exited" as const,
+      attachable: false,
+      taskBindings: [
+        {
+          taskId: heldLease.taskId,
+          executionId: heldLease.executionId,
+          providerSessionId: "provider-test",
+          transcriptRef: "file:transcript.jsonl",
+          boundAt: now,
+        },
+      ],
+      outcome: "succeeded" as const,
+      exitCode: 0,
+      resultRef: "artifact:runtime-result/test",
+      lastObservedAt: now,
+    },
+    terminalCell = {
+      ...cell,
+      rootDir,
+      projection: { readRuntimeSessionsForTask: () => [runtimeSession] },
+    },
+    terminalSnapshot = { ...snapshot(), task: ownedTask, executions: [execution], lease: heldLease },
+    taskOwnerBinding = { actor: { principal: taskOwner.principal, executor: null }, source: "local" as const };
+  try {
+    assert.throws(
+      () =>
+        taskMutation(
+          terminalCell,
+          { kind: "task-release", taskId: task.taskId },
+          ownedTask,
+          terminalSnapshot,
+          taskOwnerBinding,
+        ),
+      (error: unknown) => error instanceof Error && "code" in error && error.code === "lease_conflict",
+      "a RuntimeSession row without a terminal dispatch record is insufficient",
+    );
+    openDispatchStream(rootDir, {
+      dispatchId: "dispatch_aaaaaaaaaaaaaaaaaaaaaaaa",
+      taskId: heldLease.taskId,
+      executionId: heldLease.executionId,
+      runtimeSessionId,
+      instanceId: "codex-test",
+      startedAt: now,
+    }).appendAttemptOutcome(
+      {
+        classification: "worker_stop",
+        reason: "Worker reached a normal attempt boundary.",
+        provider: { instance: "codex-test", model: "test-model", kind: "codex" },
+        attemptGroupId: "dispatch_aaaaaaaaaaaaaaaaaaaaaaaa",
+        attemptIndex: 0,
+      },
+      now,
+    );
+
+    const mutation = taskMutation(
+      terminalCell,
+      { kind: "task-release", taskId: task.taskId, reason: "The bound worker exited." },
+      ownedTask,
+      terminalSnapshot,
+      taskOwnerBinding,
+    );
+    assert.equal(mutation.type, "lease_released");
+    assert.equal(mutation.releasedLease, heldLease);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
 });

--- a/packages/daemon/test/lease-reservation.integration.test.ts
+++ b/packages/daemon/test/lease-reservation.integration.test.ts
@@ -28,7 +28,7 @@ const definition: AgentDefinitionSnapshot = {
   baseUrl: "https://api.example.test/",
   authMode: "subscription",
 };
-test("task-bound spawn exit keeps its published execution releasable after a v7 cache restart", async () => {
+test("task-bound spawn exit keeps its released execution visible after a v7 cache restart", async () => {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-lease-reservation-")),
     root = path.join(parent, "repo"),
     userRoot = path.join(parent, "user"),
@@ -139,7 +139,8 @@ test("task-bound spawn exit keeps its published execution releasable after a v7 
   host = await open("lease-reservation-after");
   try {
     const released = await host.run(repoId, { kind: "task-release", taskId }, auth);
-    assert.equal(released.outcome, "applied", JSON.stringify(released));
+    assert.equal(released.outcome, "op_rejected", JSON.stringify(released));
+    assert.equal(released.code, "lease_not_found", JSON.stringify(released));
     const events = makeTaskEventStore({ repoId, rootDir: root }).read().events,
       sequence = events.map((event) => event.type),
       started = sequence.indexOf("execution_started"),

--- a/packages/daemon/test/review-independence-diagnostics.integration.test.ts
+++ b/packages/daemon/test/review-independence-diagnostics.integration.test.ts
@@ -30,42 +30,79 @@ test("#1541: each Execution Review refusal names its own cause and its own repai
   let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   try {
     initRepo(rootDir);
-    cell = await openRepoCell({ repoId: workspaceId("review-independence"), rootDir: canonicalRoot(rootDir), ownerId: "daemon-test" });
+    cell = await openRepoCell({
+      repoId: workspaceId("review-independence"),
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "daemon-test",
+    });
     // One shared principal, exactly as a single Windows host mints it: every local identity is uid 0.
     const collapsed = { personId: "0" } as const;
     const agentActor = { principal: collapsed, executor: { kind: "agent" as const, id: "windows-tester" } };
     const humanActor = { principal: collapsed, executor: null };
     const agent = { actor: agentActor, source: "local" as const, roles: ["$arbiter"] };
     const human = { actor: humanActor, source: "local" as const, roles: ["$arbiter"] };
-    const taskId = "task-review-axis", executionId = "exec-1";
+    const taskId = "task-review-axis",
+      executionId = "exec-1";
     assert.equal((await cell.run({ kind: "task-create", taskId, title: "Review axis" }, agent)).outcome, "applied");
     // The packet parses before authorization runs, so the file must exist for the refusal to be the one under test.
-    writeFileSync(path.join(rootDir, "review.json"), JSON.stringify({ verdict: "approved", reason: "Reviewed independently.", evidenceChecked: ["tests"] }));
+    writeFileSync(
+      path.join(rootDir, "review.json"),
+      JSON.stringify({ verdict: "approved", reason: "Reviewed independently.", evidenceChecked: ["tests"] }),
+    );
 
-    const beforeSubmission = await cell.run({ kind: "task-review-execution", taskId, executionId, reviewId: "r0", fromFile: "review.json" }, human);
+    const beforeSubmission = await cell.run(
+      { kind: "task-review-execution", taskId, executionId, reviewId: "r0", fromFile: "review.json" },
+      human,
+    );
     assert.equal(beforeSubmission.outcome, "op_rejected");
     assert.match(String(beforeSubmission.nextAction), /requires a submitted execution/u);
 
     assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, agent)).outcome, "applied");
     const commitSha = git(rootDir, "rev-parse", "HEAD");
-    writeFileSync(path.join(rootDir, "submission.json"), JSON.stringify({ completionClaim: "Ready.", deliverables: ["d"], outputs: ["o"], verificationNotes: ["v"], knownGaps: [], residualRisks: [], commitSha }));
-    assert.equal((await cell.run({ kind: "task-submit", taskId, executionId, fromFile: "submission.json" }, agent)).outcome, "applied");
-    writeFileSync(path.join(rootDir, "review.json"), JSON.stringify({ verdict: "approved", reason: "Reviewed independently.", evidenceChecked: ["tests"] }));
+    writeFileSync(
+      path.join(rootDir, "submission.json"),
+      JSON.stringify({
+        completionClaim: "Ready.",
+        deliverables: ["d"],
+        outputs: ["o"],
+        verificationNotes: ["v"],
+        knownGaps: [],
+        residualRisks: [],
+        commitSha,
+      }),
+    );
+    assert.equal(
+      (await cell.run({ kind: "task-submit", taskId, executionId, fromFile: "submission.json" }, agent)).outcome,
+      "applied",
+    );
+    writeFileSync(
+      path.join(rootDir, "review.json"),
+      JSON.stringify({ verdict: "approved", reason: "Reviewed independently.", evidenceChecked: ["tests"] }),
+    );
 
     // Missing the arbiter command class is a role problem, not an independence problem.
-    const withoutRole = await cell.run({ kind: "task-review-execution", taskId, executionId, reviewId: "r1", fromFile: "review.json" }, { ...human, roles: [] });
+    const withoutRole = await cell.run(
+      { kind: "task-review-execution", taskId, executionId, reviewId: "r1", fromFile: "review.json" },
+      { ...human, roles: [] },
+    );
     assert.equal(withoutRole.code, "actor_unauthorized");
     assert.match(String(withoutRole.nextAction), /arbiter command class/u);
 
     // The submitting executor reviewing itself is the one genuinely dependent case.
-    const selfReview = await cell.run({ kind: "task-review-execution", taskId, executionId, reviewId: "r2", fromFile: "review.json" }, agent);
+    const selfReview = await cell.run(
+      { kind: "task-review-execution", taskId, executionId, reviewId: "r2", fromFile: "review.json" },
+      agent,
+    );
     assert.equal(selfReview.code, "actor_unauthorized");
     assert.match(String(selfReview.nextAction), /independent of the submitting executor/u);
     assert.doesNotMatch(String(selfReview.nextAction), /declared no executor/u);
 
     // The repair the issue could not find: a bare human invocation reviews an agent-declared submission
     // on the very same principal. This is the assertion that falsifies "unreachable on Windows".
-    const reviewed = await cell.run({ kind: "task-review-execution", taskId, executionId, reviewId: "r3", fromFile: "review.json" }, human);
+    const reviewed = await cell.run(
+      { kind: "task-review-execution", taskId, executionId, reviewId: "r3", fromFile: "review.json" },
+      human,
+    );
     assert.equal(reviewed.outcome, "applied", JSON.stringify(reviewed));
   } finally {
     await cell?.close();
@@ -80,31 +117,82 @@ test("a bare-invocation execution has a visible warning and an audited recovery 
   let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
   try {
     initRepo(rootDir);
-    cell = await openRepoCell({ repoId: workspaceId("review-bare"), rootDir: canonicalRoot(rootDir), ownerId: "daemon-test" });
-    const bare = { actor: { principal: { personId: "0" }, executor: null }, source: "local" as const, roles: ["$arbiter"] };
-    const taskId = "task-bare-axis", executionId = "exec-bare";
+    cell = await openRepoCell({
+      repoId: workspaceId("review-bare"),
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "daemon-test",
+    });
+    const bare = {
+      actor: { principal: { personId: "0" }, executor: null },
+      source: "local" as const,
+      roles: ["$arbiter"],
+    };
+    const taskId = "task-bare-axis",
+      executionId = "exec-bare";
     assert.equal((await cell.run({ kind: "task-create", taskId, title: "Bare axis" }, bare)).outcome, "applied");
-    const started = await cell.run({ kind: "task-start", taskId, executionId }, bare) as Record<string, unknown>;
+    const started = (await cell.run({ kind: "task-start", taskId, executionId }, bare)) as Record<string, unknown>;
     assert.equal(started.outcome, "applied");
     assert.match(String(started.summary), /declared no executor/u);
     const commitSha = git(rootDir, "rev-parse", "HEAD");
-    assert.equal((await cell.run({ kind: "task-release", taskId, reason: "Rejoin as the agent that completed the work." }, bare)).outcome, "applied");
-    const agent = { actor: { principal: { personId: "0" }, executor: { kind: "agent" as const, id: "recovering-agent" } }, source: "local" as const, roles: ["$arbiter"] };
+    assert.equal(
+      (await cell.run({ kind: "task-release", taskId, reason: "Rejoin as the agent that completed the work." }, bare))
+        .outcome,
+      "applied",
+    );
+    const agent = {
+      actor: { principal: { personId: "0" }, executor: { kind: "agent" as const, id: "recovering-agent" } },
+      source: "local" as const,
+      roles: ["$arbiter"],
+    };
     assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, agent)).outcome, "applied");
-    writeFileSync(path.join(rootDir, "submission.json"), JSON.stringify({ completionClaim: "Ready.", deliverables: ["d"], outputs: ["o"], verificationNotes: ["v"], knownGaps: [], residualRisks: [], commitSha }));
-    assert.equal((await cell.run({ kind: "task-submit", taskId, executionId, fromFile: "submission.json" }, agent)).outcome, "applied");
-    writeFileSync(path.join(rootDir, "review.json"), JSON.stringify({ verdict: "approved", reason: "Reviewed.", evidenceChecked: ["tests"] }));
+    writeFileSync(
+      path.join(rootDir, "submission.json"),
+      JSON.stringify({
+        completionClaim: "Ready.",
+        deliverables: ["d"],
+        outputs: ["o"],
+        verificationNotes: ["v"],
+        knownGaps: [],
+        residualRisks: [],
+        commitSha,
+      }),
+    );
+    assert.equal(
+      (await cell.run({ kind: "task-submit", taskId, executionId, fromFile: "submission.json" }, agent)).outcome,
+      "applied",
+    );
+    writeFileSync(
+      path.join(rootDir, "review.json"),
+      JSON.stringify({ verdict: "approved", reason: "Reviewed.", evidenceChecked: ["tests"] }),
+    );
 
-    const refused = await cell.run({ kind: "task-review-execution", taskId, executionId, reviewId: "r1", fromFile: "review.json" }, bare);
+    const refused = await cell.run(
+      { kind: "task-review-execution", taskId, executionId, reviewId: "r1", fromFile: "review.json" },
+      bare,
+    );
     assert.equal(refused.code, "actor_unauthorized");
     assert.match(String(refused.nextAction), /declared no executor/u);
     assert.match(String(refused.nextAction), /original start/u);
 
-    const wrongPrincipal = { actor: { principal: { personId: "1" }, executor: { kind: "agent" as const, id: "recovering-agent" } }, source: "local" as const, roles: ["$arbiter"] };
-    const denied = await cell.run({ kind: "task-declare-executor", taskId, executionId, reason: "Claim from another principal." }, wrongPrincipal);
+    const wrongPrincipal = {
+      actor: { principal: { personId: "1" }, executor: { kind: "agent" as const, id: "recovering-agent" } },
+      source: "local" as const,
+      roles: ["$arbiter"],
+    };
+    const denied = await cell.run(
+      { kind: "task-declare-executor", taskId, executionId, reason: "Claim from another principal." },
+      wrongPrincipal,
+    );
     assert.equal(denied.code, "invalid_proof");
 
-    const declared = await cell.run({ kind: "task-declare-executor", taskId, reason: "Recovered the executor omitted by the original start invocation." }, agent) as Record<string, unknown>;
+    const declared = (await cell.run(
+      {
+        kind: "task-declare-executor",
+        taskId,
+        reason: "Recovered the executor omitted by the original start invocation.",
+      },
+      agent,
+    )) as Record<string, unknown>;
     assert.equal(declared.outcome, "applied", JSON.stringify(declared));
     const event = makeTaskEventStore({ repoId: "review-bare", rootDir }).readEvent(String(declared.opId));
     assert.equal(event?.type, "execution_executor_declared");
@@ -114,14 +202,26 @@ test("a bare-invocation execution has a visible warning and an audited recovery 
       assert.equal(event.payload.reason, "Recovered the executor omitted by the original start invocation.");
     }
 
-    const selfReview = await cell.run({ kind: "task-review-execution", taskId, executionId, reviewId: "r2", fromFile: "review.json" }, agent);
+    const selfReview = await cell.run(
+      { kind: "task-review-execution", taskId, executionId, reviewId: "r2", fromFile: "review.json" },
+      agent,
+    );
     assert.equal(selfReview.code, "actor_unauthorized");
     assert.match(String(selfReview.nextAction), /independent of the submitting executor/u);
 
-    const reviewed = await cell.run({ kind: "task-review-execution", taskId, executionId, reviewId: "r3", fromFile: "review.json" }, bare);
+    const reviewed = await cell.run(
+      { kind: "task-review-execution", taskId, executionId, reviewId: "r3", fromFile: "review.json" },
+      bare,
+    );
     assert.equal(reviewed.outcome, "applied", JSON.stringify(reviewed));
-    const wrongOwner = { actor: { principal: { personId: "person-outsider" }, executor: { kind: "agent" as const, id: "outsider" } }, source: "local" as const };
-    const consent = await cell.run({ kind: "task-review-consent", taskId, executionId, reviewId: "r3", consentId: "consent-wrong-owner" }, wrongOwner);
+    const wrongOwner = {
+      actor: { principal: { personId: "person-outsider" }, executor: { kind: "agent" as const, id: "outsider" } },
+      source: "local" as const,
+    };
+    const consent = await cell.run(
+      { kind: "task-review-consent", taskId, executionId, reviewId: "r3", consentId: "consent-wrong-owner" },
+      wrongOwner,
+    );
     assert.equal(consent.code, "actor_unauthorized");
     assert.match(String(consent.nextAction), /personId=0/u);
     assert.match(String(consent.nextAction), /executor=none/u);
@@ -189,7 +289,11 @@ test("a reviewed bare-invocation execution can declare its executor and complete
     );
     writeFileSync(
       path.join(rootDir, "review.json"),
-      JSON.stringify({ verdict: "approved", reason: "Independent review passed.", evidenceChecked: ["daemon integration"] }),
+      JSON.stringify({
+        verdict: "approved",
+        reason: "Independent review passed.",
+        evidenceChecked: ["daemon integration"],
+      }),
     );
     const reviewer = {
       actor: {
@@ -230,13 +334,16 @@ test("a reviewed bare-invocation execution can declare its executor and complete
     const negativeControl = {
       complete: await cell.run({ kind: "task-complete", taskId, executionId, ci: "passed" }, agent),
       consent: await cell.run(
-        { kind: "task-review-consent", taskId, executionId, reviewId: "review-approved", consentId: "consent-approved" },
+        {
+          kind: "task-review-consent",
+          taskId,
+          executionId,
+          reviewId: "review-approved",
+          consentId: "consent-approved",
+        },
         bare,
       ),
-      closeout: await cell.run(
-        { kind: "task-closeout", taskId, executionId, fromFile: "judgment.json" },
-        agent,
-      ),
+      closeout: await cell.run({ kind: "task-closeout", taskId, executionId, fromFile: "judgment.json" }, agent),
       start: await cell.run({ kind: "task-start", taskId, executionId }, agent),
       declareWrongPrincipal: await cell.run(
         { kind: "task-declare-executor", taskId, executionId, reason: "An outsider must not claim this execution." },
@@ -256,10 +363,7 @@ test("a reviewed bare-invocation execution can declare its executor and complete
     const unblocked = await cell.run({ kind: "task-transition", taskId, status: "active" }, bare);
     assert.equal(unblocked.outcome, "applied", JSON.stringify(unblocked));
     const completeRepair = await cell.run({ kind: "task-complete", taskId, executionId, ci: "passed" }, agent),
-      closeoutRepair = await cell.run(
-        { kind: "task-closeout", taskId, executionId, fromFile: "judgment.json" },
-        agent,
-      );
+      closeoutRepair = await cell.run({ kind: "task-closeout", taskId, executionId, fromFile: "judgment.json" }, agent);
     assert.equal(completeRepair.code, "executor_missing", JSON.stringify(completeRepair));
     assert.match(String(completeRepair.nextAction), /ha task declare-executor task-bare-reviewed/u);
     assert.equal(closeoutRepair.code, "executor_missing", JSON.stringify(closeoutRepair));
@@ -270,7 +374,7 @@ test("a reviewed bare-invocation execution can declare its executor and complete
     );
     assert.equal(denied.code, "invalid_proof", JSON.stringify(denied));
 
-    const declared = await cell.run(
+    const declared = (await cell.run(
       {
         kind: "task-declare-executor",
         taskId,
@@ -278,7 +382,7 @@ test("a reviewed bare-invocation execution can declare its executor and complete
         reason: "The original principal names the agent that completed the already approved execution.",
       },
       agent,
-    ) as Record<string, unknown>;
+    )) as Record<string, unknown>;
     assert.equal(declared.outcome, "applied", JSON.stringify(declared));
     const declaration = makeTaskEventStore({ repoId, rootDir }).readEvent(String(declared.opId));
     assert.equal(declaration?.type, "execution_executor_declared");
@@ -308,10 +412,10 @@ test("a reviewed bare-invocation execution can declare its executor and complete
       bare,
     );
     assert.equal(consented.outcome, "applied", JSON.stringify(consented));
-    const completed = await cell.run(
+    const completed = (await cell.run(
       { kind: "task-complete", taskId, executionId, ci: "passed", paths: ["README.md"] },
       bare,
-    ) as Record<string, unknown>;
+    )) as Record<string, unknown>;
     console.log(
       `executor-null-positive-control=${JSON.stringify({ completeRepair, closeoutRepair, denied, declared, consented, completed })}`,
     );
@@ -319,9 +423,11 @@ test("a reviewed bare-invocation execution can declare its executor and complete
     const shown = await cell.run({ kind: "task-show", taskId }, bare);
     assert.match(String(shown.evidence), /"status":"done"/u);
     assert.equal(
-      makeTaskEventStore({ repoId, rootDir }).read().events.some(
-        (event) => event.type === "review_recorded" && event.payload.review.verdict === "changes_requested",
-      ),
+      makeTaskEventStore({ repoId, rootDir })
+        .read()
+        .events.some(
+          (event) => event.type === "review_recorded" && event.payload.review.verdict === "changes_requested",
+        ),
       false,
     );
   } finally {
@@ -338,56 +444,231 @@ test("task-bound runtime sessions cannot review their own execution across exit 
     const processes: { exit: ((code: number | null) => void) | null }[] = [];
     let providerSequence = 0;
     cell = await openRepoCell({
-      repoId: workspaceId("review-runtime-bound"), rootDir: canonicalRoot(rootDir), ownerId: "daemon-test",
+      repoId: workspaceId("review-runtime-bound"),
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "daemon-test",
       runtimeDaemonRoute: { userRoot: rootDir, daemonId: "daemon-test", endpoint: path.join(rootDir, "daemon.sock") },
       prepareRuntimeLaunch: (_instanceId, request) => {
         const providerSessionId = request.providerSessionId ?? `provider-${++providerSequence}`;
-        return { definition: { schema: "agent-definition-snapshot/v1", configVersion: 1, instanceId: "review-runtime", installationId: "review-runtime-installation", kindId: "codex", providerId: "openai", model: "review-model", reasoningEffort: "medium", baseUrl: null, authMode: "subscription" }, installation: { installationId: "review-runtime-installation", kindId: "codex", executablePath: "/test/review-runtime", version: "1.0.0", observedAt: "2026-08-22T00:00:00.000Z" }, executablePath: "/test/review-runtime", args: [providerSessionId], env: {}, cwd: request.cwd, prompt: request.prompt };
+        return {
+          definition: {
+            schema: "agent-definition-snapshot/v1",
+            configVersion: 1,
+            instanceId: "review-runtime",
+            installationId: "review-runtime-installation",
+            kindId: "codex",
+            providerId: "openai",
+            model: "review-model",
+            reasoningEffort: "medium",
+            baseUrl: null,
+            authMode: "subscription",
+          },
+          installation: {
+            installationId: "review-runtime-installation",
+            kindId: "codex",
+            executablePath: "/test/review-runtime",
+            version: "1.0.0",
+            observedAt: "2026-08-22T00:00:00.000Z",
+          },
+          executablePath: "/test/review-runtime",
+          args: [providerSessionId],
+          env: {},
+          cwd: request.cwd,
+          prompt: request.prompt,
+        };
       },
       runtimeLaunch: (prepared) => {
-        const process = { exit: null as ((code: number | null) => void) | null }, providerSessionId = prepared.args[0]!;
+        const process = { exit: null as ((code: number | null) => void) | null },
+          providerSessionId = prepared.args[0]!;
         processes.push(process);
-        return { pid: 1_001 + processes.length, onOutput: (listener) => { queueMicrotask(() => listener(`${JSON.stringify({ type: "thread.started", thread_id: providerSessionId })}\n`)); }, onErrorOutput: () => undefined, onExit: (listener) => { process.exit = listener; }, terminate: () => process.exit?.(0) };
-      }
+        return {
+          pid: 1_001 + processes.length,
+          onOutput: (listener) => {
+            queueMicrotask(() =>
+              listener(`${JSON.stringify({ type: "thread.started", thread_id: providerSessionId })}\n`),
+            );
+          },
+          onErrorOutput: () => undefined,
+          onExit: (listener) => {
+            process.exit = listener;
+          },
+          terminate: () => process.exit?.(0),
+        };
+      },
     });
-    const principal = { personId: "person-worker" } as const, implementer = { actor: { principal, executor: { kind: "agent" as const, id: "implementer" } }, source: "local" as const }, arbiter = (id: string) => ({ actor: { principal, executor: { kind: "agent" as const, id } }, source: "local" as const, roles: ["$arbiter"] });
-    const taskId = "task-runtime-bound", executionId = "execution-runtime-bound";
-    assert.equal((await cell.run({ kind: "task-create", taskId, title: "Runtime-bound review" }, implementer)).outcome, "applied");
+    const principal = { personId: "person-worker" } as const,
+      implementer = {
+        actor: { principal, executor: { kind: "agent" as const, id: "implementer" } },
+        source: "local" as const,
+      },
+      arbiter = (id: string) => ({
+        actor: { principal, executor: { kind: "agent" as const, id } },
+        source: "local" as const,
+        roles: ["$arbiter"],
+      });
+    const taskId = "task-runtime-bound",
+      executionId = "execution-runtime-bound";
+    assert.equal(
+      (await cell.run({ kind: "task-create", taskId, title: "Runtime-bound review" }, implementer)).outcome,
+      "applied",
+    );
     assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, implementer)).outcome, "applied");
 
-    const original = await cell.spawnRuntime({ runtimeInstanceId: "review-runtime", cwd: { scope: "repo-root" }, prompt: "Implement the task.", taskId, idempotencyKey: "original-runtime" }, implementer);
-    await runtimeEvent(rootDir, "review-runtime-bound", (event) => event.type === "runtime_session_task_bound" && event.payload.runtimeSessionId === original.runtimeSessionId);
+    const original = await cell.spawnRuntime(
+      {
+        runtimeInstanceId: "review-runtime",
+        cwd: { scope: "repo-root" },
+        prompt: "Implement the task.",
+        taskId,
+        idempotencyKey: "original-runtime",
+      },
+      implementer,
+    );
+    await runtimeEvent(
+      rootDir,
+      "review-runtime-bound",
+      (event) =>
+        event.type === "runtime_session_task_bound" && event.payload.runtimeSessionId === original.runtimeSessionId,
+    );
     processes[0]!.exit?.(0);
-    await runtimeEvent(rootDir, "review-runtime-bound", (event) => event.type === "runtime_session_exited" && event.payload.runtimeSessionId === original.runtimeSessionId);
+    await runtimeEvent(
+      rootDir,
+      "review-runtime-bound",
+      (event) =>
+        event.type === "runtime_session_exited" && event.payload.runtimeSessionId === original.runtimeSessionId,
+    );
 
-    const resumed = await cell.spawnRuntime({ runtimeInstanceId: "review-runtime", cwd: { scope: "repo-root" }, prompt: "Resume the task.", taskId, providerSessionId: "provider-1", idempotencyKey: "resumed-runtime" }, implementer);
-    await runtimeEvent(rootDir, "review-runtime-bound", (event) => event.type === "runtime_session_task_bound" && event.payload.runtimeSessionId === resumed.runtimeSessionId);
+    assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, implementer)).outcome, "applied");
+    const resumed = await cell.spawnRuntime(
+      {
+        runtimeInstanceId: "review-runtime",
+        cwd: { scope: "repo-root" },
+        prompt: "Resume the task.",
+        taskId,
+        providerSessionId: "provider-1",
+        idempotencyKey: "resumed-runtime",
+      },
+      implementer,
+    );
+    await runtimeEvent(
+      rootDir,
+      "review-runtime-bound",
+      (event) =>
+        event.type === "runtime_session_task_bound" && event.payload.runtimeSessionId === resumed.runtimeSessionId,
+    );
 
     const commitSha = git(rootDir, "rev-parse", "HEAD");
-    writeFileSync(path.join(rootDir, "submission.json"), JSON.stringify({ completionClaim: "Ready.", deliverables: ["d"], outputs: ["o"], verificationNotes: ["v"], knownGaps: [], residualRisks: [], commitSha }));
-    assert.equal((await cell.run({ kind: "task-submit", taskId, executionId, fromFile: "submission.json" }, implementer)).outcome, "applied");
-    writeFileSync(path.join(rootDir, "review.json"), JSON.stringify({ verdict: "approved", reason: "Reviewed.", evidenceChecked: ["tests"] }));
+    writeFileSync(
+      path.join(rootDir, "submission.json"),
+      JSON.stringify({
+        completionClaim: "Ready.",
+        deliverables: ["d"],
+        outputs: ["o"],
+        verificationNotes: ["v"],
+        knownGaps: [],
+        residualRisks: [],
+        commitSha,
+      }),
+    );
+    assert.equal(
+      (await cell.run({ kind: "task-submit", taskId, executionId, fromFile: "submission.json" }, implementer)).outcome,
+      "applied",
+    );
+    writeFileSync(
+      path.join(rootDir, "review.json"),
+      JSON.stringify({ verdict: "approved", reason: "Reviewed.", evidenceChecked: ["tests"] }),
+    );
 
     // A dedicated reviewer runtime has no binding to this task/execution, so it can execute the
     // refusal's named command without changing either identity or review packet.
-    const unbound = await cell.spawnRuntime({ runtimeInstanceId: "review-runtime", cwd: { scope: "repo-root" }, prompt: "Review only.", taskId: null, idempotencyKey: "unbound-reviewer" }, implementer);
-    await runtimeEvent(rootDir, "review-runtime-bound", (event) => event.type === "runtime_session_provider_bound" && event.payload.runtimeSessionId === unbound.runtimeSessionId);
-    for (const [reviewId, runtimeSessionId] of [["review-exited", original.runtimeSessionId], ["review-resumed", resumed.runtimeSessionId]] as const) {
-      const denied = await cell.run({ kind: "task-review-execution", taskId, executionId, reviewId, fromFile: "review.json" }, arbiter(`runtime-session:${runtimeSessionId}`));
+    const unbound = await cell.spawnRuntime(
+      {
+        runtimeInstanceId: "review-runtime",
+        cwd: { scope: "repo-root" },
+        prompt: "Review only.",
+        taskId: null,
+        idempotencyKey: "unbound-reviewer",
+      },
+      implementer,
+    );
+    await runtimeEvent(
+      rootDir,
+      "review-runtime-bound",
+      (event) =>
+        event.type === "runtime_session_provider_bound" && event.payload.runtimeSessionId === unbound.runtimeSessionId,
+    );
+    for (const [reviewId, runtimeSessionId] of [
+      ["review-exited", original.runtimeSessionId],
+      ["review-resumed", resumed.runtimeSessionId],
+    ] as const) {
+      const denied = await cell.run(
+        { kind: "task-review-execution", taskId, executionId, reviewId, fromFile: "review.json" },
+        arbiter(`runtime-session:${runtimeSessionId}`),
+      );
       assert.equal(denied.code, "runtime_task_self_review_forbidden");
-      assert.equal(denied.nextAction, `This runtime is bound to task ${taskId} and execution ${executionId} and cannot review its own work; have an independent human or a runtime with no binding to this task and execution run ha task review-execution ${taskId} --execution-id ${executionId} --review-id ${reviewId} --from-file <review.json>.`);
-      assert.equal((await cell.run({ kind: "task-review-execution", taskId, executionId, reviewId, fromFile: "review.json" }, arbiter(`runtime-session:${unbound.runtimeSessionId}`))).outcome, "applied");
+      assert.equal(
+        denied.nextAction,
+        `This runtime is bound to task ${taskId} and execution ${executionId} and cannot review its own work; have an independent human or a runtime with no binding to this task and execution run ha task review-execution ${taskId} --execution-id ${executionId} --review-id ${reviewId} --from-file <review.json>.`,
+      );
+      assert.equal(
+        (
+          await cell.run(
+            { kind: "task-review-execution", taskId, executionId, reviewId, fromFile: "review.json" },
+            arbiter(`runtime-session:${unbound.runtimeSessionId}`),
+          )
+        ).outcome,
+        "applied",
+      );
     }
 
-    const directTaskId = "task-direct-review", directExecutionId = "execution-direct-review";
-    assert.equal((await cell.run({ kind: "task-create", taskId: directTaskId, title: "Direct review" }, implementer)).outcome, "applied");
-    assert.equal((await cell.run({ kind: "task-start", taskId: directTaskId, executionId: directExecutionId }, implementer)).outcome, "applied");
+    const directTaskId = "task-direct-review",
+      directExecutionId = "execution-direct-review";
+    assert.equal(
+      (await cell.run({ kind: "task-create", taskId: directTaskId, title: "Direct review" }, implementer)).outcome,
+      "applied",
+    );
+    assert.equal(
+      (await cell.run({ kind: "task-start", taskId: directTaskId, executionId: directExecutionId }, implementer))
+        .outcome,
+      "applied",
+    );
     const directCommitSha = git(rootDir, "rev-parse", "HEAD");
-    writeFileSync(path.join(rootDir, "submission.json"), JSON.stringify({ completionClaim: "Ready.", deliverables: ["d"], outputs: ["o"], verificationNotes: ["v"], knownGaps: [], residualRisks: [], commitSha: directCommitSha }));
-    assert.equal((await cell.run({ kind: "task-submit", taskId: directTaskId, executionId: directExecutionId, fromFile: "submission.json" }, implementer)).outcome, "applied");
-    writeFileSync(path.join(rootDir, "review.json"), JSON.stringify({ verdict: "approved", reason: "Reviewed by another agent.", evidenceChecked: ["tests"] }));
+    writeFileSync(
+      path.join(rootDir, "submission.json"),
+      JSON.stringify({
+        completionClaim: "Ready.",
+        deliverables: ["d"],
+        outputs: ["o"],
+        verificationNotes: ["v"],
+        knownGaps: [],
+        residualRisks: [],
+        commitSha: directCommitSha,
+      }),
+    );
+    assert.equal(
+      (
+        await cell.run(
+          { kind: "task-submit", taskId: directTaskId, executionId: directExecutionId, fromFile: "submission.json" },
+          implementer,
+        )
+      ).outcome,
+      "applied",
+    );
+    writeFileSync(
+      path.join(rootDir, "review.json"),
+      JSON.stringify({ verdict: "approved", reason: "Reviewed by another agent.", evidenceChecked: ["tests"] }),
+    );
     // A child/non-runtime agent has no runtime-session identity; existing executor independence decides it.
-    const reviewedByAgent = await cell.run({ kind: "task-review-execution", taskId: directTaskId, executionId: directExecutionId, reviewId: "review-child-agent", fromFile: "review.json" }, arbiter("child-reviewer"));
+    const reviewedByAgent = await cell.run(
+      {
+        kind: "task-review-execution",
+        taskId: directTaskId,
+        executionId: directExecutionId,
+        reviewId: "review-child-agent",
+        fromFile: "review.json",
+      },
+      arbiter("child-reviewer"),
+    );
     assert.equal(reviewedByAgent.outcome, "applied", JSON.stringify(reviewedByAgent));
   } finally {
     await cell?.close();
@@ -395,7 +676,11 @@ test("task-bound runtime sessions cannot review their own execution across exit 
   }
 });
 
-async function runtimeEvent(rootDir: string, repoId: string, matches: (event: ReturnType<ReturnType<typeof makeTaskEventStore>["read"]>["events"][number]) => boolean): Promise<void> {
+async function runtimeEvent(
+  rootDir: string,
+  repoId: string,
+  matches: (event: ReturnType<ReturnType<typeof makeTaskEventStore>["read"]>["events"][number]) => boolean,
+): Promise<void> {
   for (let attempt = 0; attempt < 100; attempt += 1) {
     if (makeTaskEventStore({ repoId, rootDir }).read().events.some(matches)) return;
     await new Promise((resolve) => setTimeout(resolve, 10));

--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -356,7 +356,7 @@ test("runtime spawn publishes a canonical session and makes it visible in overvi
   }
 });
 
-test("attached runtime settlement includes provider records persisted after attach before exit", async () => {
+test("attached task runtime settlement consumes its durable tail and releases its execution lease", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-runtime-attached-tail-"));
   let exit: ((code: number | null) => void) | null = null;
   try {
@@ -365,6 +365,11 @@ test("attached runtime settlement includes provider records persisted after atta
       repoId: workspaceId("runtime-attached-tail"),
       rootDir: canonicalRoot(root),
       ownerId: "attached-tail-test",
+      runtimeDaemonRoute: {
+        userRoot: path.join(root, ".daemon-user"),
+        daemonId: "attached-tail-test",
+        endpoint: path.join(root, ".daemon-user", "daemon.sock"),
+      },
       runtimeInstances: () => [
         {
           schemaVersion: 2,
@@ -404,18 +409,34 @@ test("attached runtime settlement includes provider records persisted after atta
       }),
     });
     try {
+      const taskId = "task-runtime-attached-tail",
+        executionId = "execution-runtime-attached-tail",
+        binding = {
+          actor: { principal: { personId: "person-attached-tail" }, executor: null },
+          source: "local" as const,
+        };
+      assert.equal(
+        (await cell.run({ kind: "task-create", taskId, title: "Attached tail lease" }, binding)).outcome,
+        "applied",
+      );
+      assert.equal(
+        (
+          await cell.run(
+            { kind: "task-start", taskId, executionId, executor: { kind: "agent", id: "attached-tail-worker" } },
+            binding,
+          )
+        ).outcome,
+        "applied",
+      );
       const receipt = await cell.spawnRuntime(
         {
           runtimeInstanceId: definition.instanceId,
           cwd: { scope: "repo-root" },
           prompt: "Settle the durable tail after attach",
-          taskId: null,
+          taskId,
           idempotencyKey: "attached-tail",
         },
-        {
-          actor: { principal: { personId: "person-attached-tail" }, executor: null },
-          source: "local",
-        },
+        binding,
       );
       const records = [
         { type: "thread.started", thread_id: "provider-attached-tail" },
@@ -449,20 +470,28 @@ test("attached runtime settlement includes provider records persisted after atta
       });
       assert.ok(exit, "runtime exit listener must be attached before the provider exits");
       exit(0);
-      await eventually(() =>
-        makeTaskEventStore({ repoId: "runtime-attached-tail", rootDir: root })
-          .read()
-          .events.some(
+      await eventually(() => {
+        const events = makeTaskEventStore({ repoId: "runtime-attached-tail", rootDir: root }).read().events;
+        return (
+          events.some(
             (event) =>
               event.type === "runtime_session_outcome_observed" &&
               event.payload.runtimeSessionId === receipt.runtimeSessionId,
-          ),
-      );
+          ) &&
+          events.some(
+            (event) =>
+              event.type === "lease_released" &&
+              event.taskId === taskId &&
+              event.payload.execution.executionId === executionId,
+          )
+        );
+      });
       const projection = makeTaskProjection({
           rootDir: root,
           eventStore: makeTaskEventStore({ repoId: "runtime-attached-tail", rootDir: root }),
         }),
-        settled = projection.readRuntimeSession(String(receipt.runtimeSessionId))!;
+        settled = projection.readRuntimeSession(String(receipt.runtimeSessionId))!,
+        taskSnapshot = projection.read(taskId).snapshot;
       projection.close();
       assert.deepEqual(
         {
@@ -472,6 +501,7 @@ test("attached runtime settlement includes provider records persisted after atta
         },
         { liveness: "exited", outcome: "succeeded", exitCode: 0 },
       );
+      assert.equal(taskSnapshot.lease, null, "terminal RuntimeSession settlement must release the execution lease");
     } finally {
       await cell.close();
     }

--- a/packages/daemon/test/squad-coordinator.test.ts
+++ b/packages/daemon/test/squad-coordinator.test.ts
@@ -1,0 +1,79 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ActorIdentity, LeaseV1, TaskLifecycleSnapshot, TaskV1 } from "../../kernel/src/index.ts";
+import { reacquireSquadTaskLease } from "../src/repo-cell-open.ts";
+
+const squadActor: ActorIdentity = {
+    principal: { personId: "person-squad" },
+    executor: { kind: "agent", id: "squad-runner" },
+  },
+  task: TaskV1 = {
+    schema: "task/v1",
+    taskId: "task-squad-reacquire",
+    title: "Squad reacquire",
+    taskClass: "standard",
+    status: "active",
+    graph: { maxIterations: 1, nodes: [], edges: [] },
+    currentNode: "implementation",
+    iteration: 0,
+    createdBy: squadActor,
+    completionGateIds: [],
+    presetSnapshotDigest: null,
+  };
+
+test("squad lease reacquisition reports conflict when another actor takes the released execution", async () => {
+  const execution = {
+      schema: "execution/v1" as const,
+      executionId: "execution-squad-reacquire",
+      taskId: task.taskId,
+      nodeId: "implementation" as const,
+      iteration: 0,
+      state: "active" as const,
+      actor: squadActor,
+      claimedAt: "2026-08-27T00:00:00.000Z",
+      submittedAt: null,
+      closedAt: null,
+      submission: null,
+    },
+    foreignLease: LeaseV1 = {
+      schema: "lease/v1",
+      taskId: task.taskId,
+      executionId: execution.executionId,
+      actor: {
+        principal: { personId: "person-other" },
+        executor: { kind: "agent", id: "other-runner" },
+      },
+      source: "local",
+      phase: "held",
+      expiresAt: "2026-08-28T00:00:00.000Z",
+      ttlMs: 86_400_000,
+      version: 2,
+    },
+    snapshot: TaskLifecycleSnapshot = {
+      revision: 3,
+      task,
+      executions: [execution],
+      reviews: [],
+      consents: [],
+      codeDocWitnesses: [],
+      gateWitnesses: [],
+      edgesTaken: [],
+      lease: foreignLease,
+    };
+  let starts = 0;
+
+  await assert.rejects(
+    reacquireSquadTaskLease({
+      taskId: task.taskId,
+      binding: { actor: squadActor, source: "local" },
+      snapshot,
+      start: () => {
+        starts += 1;
+        return Promise.resolve({ outcome: "applied" });
+      },
+    }),
+    (error: unknown) => error instanceof Error && "code" in error && error.code === "lease_conflict",
+  );
+  assert.equal(starts, 0, "a conflicting lease must not be reacquired or overwritten");
+});

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -37,6 +37,7 @@ export {
 } from "./domain/task-lifecycle.contract.ts";
 export { isSameExecution, isSamePerson } from "./domain/actor-domain-services.ts";
 export { resolveTaskBoundRuntimeBinding, runtimeSessionIdFromActor } from "./domain/task-bound-runtime-authority.ts";
+export type { TaskBoundRuntimeBinding } from "./domain/task-bound-runtime-authority.ts";
 export {
   compileTaskLifecycleWrite,
   lifecycleDocumentFetchPaths,

--- a/packages/kernel/src/ports/authorization-port.ts
+++ b/packages/kernel/src/ports/authorization-port.ts
@@ -17,6 +17,7 @@ export interface AuthorizationTargetSnapshot {
   readonly owner?: ActorIdentity | null;
   readonly lease?: LeaseV1 | null;
   readonly canonicalExecutionExists?: boolean;
+  readonly terminalRuntimeBinding?: TaskBoundRuntimeBinding | null;
   readonly executionActor?: ActorIdentity | null;
   readonly proposalActor?: ActorIdentity | null;
   readonly runtimeBinding?: TaskBoundRuntimeBinding | null;
@@ -127,6 +128,7 @@ function evaluatePredicate(
       (action.target === `task/${lease.taskId}` || action.target === `execution/${lease.executionId}`),
     runtimeSessionId = runtimeSessionIdFromActor(actor),
     runtimeBinding = target.runtimeBinding ?? null,
+    terminalRuntimeBinding = target.terminalRuntimeBinding ?? null,
     runtimeDelegation =
       leaseTargetsSubject &&
       lease?.phase === "held" &&
@@ -135,6 +137,11 @@ function evaluatePredicate(
       runtimeBinding.taskId === lease.taskId &&
       runtimeBinding.executionId === lease.executionId &&
       isSamePerson(lease.actor, actor);
+  const terminalRuntimeOwnsLease =
+    leaseTargetsSubject &&
+    lease !== null &&
+    terminalRuntimeBinding?.taskId === lease.taskId &&
+    terminalRuntimeBinding.executionId === lease.executionId;
   let holds = false;
   if (expression.predicate === "isOwner")
     holds = target.owner !== null && target.owner !== undefined && isSamePerson(target.owner, actor);
@@ -146,8 +153,9 @@ function evaluatePredicate(
     holds =
       leaseTargetsSubject &&
       lease !== null &&
-      (lease.phase === "orphaned" || target.canonicalExecutionExists === false) &&
-      isSamePerson(lease.actor, actor);
+      (lease.phase === "orphaned" || target.canonicalExecutionExists === false || terminalRuntimeOwnsLease) &&
+      (isSamePerson(lease.actor, actor) ||
+        (target.owner !== null && target.owner !== undefined && isSamePerson(target.owner, actor)));
   else if (expression.predicate === "dispatchesExecution")
     holds =
       leaseTargetsSubject &&

--- a/packages/kernel/src/ports/authorization-port.ts
+++ b/packages/kernel/src/ports/authorization-port.ts
@@ -153,9 +153,12 @@ function evaluatePredicate(
     holds =
       leaseTargetsSubject &&
       lease !== null &&
-      (lease.phase === "orphaned" || target.canonicalExecutionExists === false || terminalRuntimeOwnsLease) &&
-      (isSamePerson(lease.actor, actor) ||
-        (target.owner !== null && target.owner !== undefined && isSamePerson(target.owner, actor)));
+      ((isSamePerson(lease.actor, actor) &&
+        (lease.phase === "orphaned" || target.canonicalExecutionExists === false || terminalRuntimeOwnsLease)) ||
+        ((lease.phase === "orphaned" || terminalRuntimeOwnsLease) &&
+          target.owner !== null &&
+          target.owner !== undefined &&
+          isSamePerson(target.owner, actor)));
   else if (expression.predicate === "dispatchesExecution")
     holds =
       leaseTargetsSubject &&

--- a/packages/kernel/test/contracts/authorization-port.test.ts
+++ b/packages/kernel/test/contracts/authorization-port.test.ts
@@ -16,6 +16,7 @@ const owner: ActorIdentity = {
     executor: { kind: "agent", id: "implementer" },
   },
   humanOwner: ActorIdentity = { principal: owner.principal, executor: null },
+  taskOwner: ActorIdentity = { principal: { personId: "task-owner" }, executor: null },
   reviewer: ActorIdentity = {
     principal: owner.principal,
     executor: { kind: "agent", id: "reviewer" },
@@ -106,6 +107,33 @@ test("v2 models held and orphaned release bindings without overloading ownership
       target: { lease, canonicalExecutionExists: false },
     }).outcome,
     "allowed",
+  );
+});
+
+test("v2 lets the task owner reclaim a lease only after its execution is orphaned", () => {
+  const targetOwner = { principal: taskOwner.principal, executor: { kind: "agent", id: "task-creator" } } as const,
+    terminalRuntimeBinding = {
+      runtimeSessionId: "runtime-1",
+      taskId: lease.taskId,
+      executionId: lease.executionId,
+    };
+  assert.equal(
+    decide("execution.release", taskOwner, "execution/execution-1", {
+      target: { owner: targetOwner, lease, canonicalExecutionExists: true },
+    }).outcome,
+    "denied",
+  );
+  assert.equal(
+    decide("execution.release", taskOwner, "execution/execution-1", {
+      target: { owner: targetOwner, lease, canonicalExecutionExists: true, terminalRuntimeBinding },
+    }).outcome,
+    "allowed",
+  );
+  assert.equal(
+    decide("execution.release", outsider, "execution/execution-1", {
+      target: { owner: targetOwner, lease, canonicalExecutionExists: true, terminalRuntimeBinding },
+    }).outcome,
+    "denied",
   );
 });
 

--- a/packages/kernel/test/contracts/authorization-port.test.ts
+++ b/packages/kernel/test/contracts/authorization-port.test.ts
@@ -110,7 +110,7 @@ test("v2 models held and orphaned release bindings without overloading ownership
   );
 });
 
-test("v2 lets the task owner reclaim a lease only after its execution is orphaned", () => {
+test("v2 limits task-owner reclamation to orphaned leases and terminal Runtime bindings", () => {
   const targetOwner = { principal: taskOwner.principal, executor: { kind: "agent", id: "task-creator" } } as const,
     terminalRuntimeBinding = {
       runtimeSessionId: "runtime-1",
@@ -120,6 +120,18 @@ test("v2 lets the task owner reclaim a lease only after its execution is orphane
   assert.equal(
     decide("execution.release", taskOwner, "execution/execution-1", {
       target: { owner: targetOwner, lease, canonicalExecutionExists: true },
+    }).outcome,
+    "denied",
+  );
+  assert.equal(
+    decide("execution.release", taskOwner, "execution/execution-1", {
+      target: { owner: targetOwner, lease: { ...lease, phase: "orphaned" }, canonicalExecutionExists: true },
+    }).outcome,
+    "allowed",
+  );
+  assert.equal(
+    decide("execution.release", taskOwner, "execution/execution-1", {
+      target: { owner: targetOwner, lease, canonicalExecutionExists: false },
     }).outcome,
     "denied",
   );


### PR DESCRIPTION
# English

## Summary

0.35: an execution lease now lives exactly as long as its executor. When a runtime session reaches a terminal state (exited / cancelled / provider fault) — locally or through the fleet — the same await chain (serially, after the exit/outcome events) releases that execution's lease via the existing `task release` mutation; pending provider fallbacks keep theirs. Orphaned or terminal leases can be reclaimed by the task owner without impersonating the original runtime session, and a stale callback cannot release a newer execution. No `--force` / `--execution-id` bypass flags were added; the fallback-exhaustion-only terminal callback path is replaced.

## Architectural Justification

- Not required: Production-Delta churn is below 200 lines.

## What Changed

- `packages/daemon/src`: terminal runtime → `task release` in the same transaction (local + fleet); owner reclaim of orphaned/terminal leases; stale-callback guard.
- Tests: 45/45 targeted.

## Gate Harvest / 门收割

Deleted-Production-Paths: the fallback-exhaustion-only terminal callback path
Deleted-Gates-Fixtures: none (its assertions are replaced by the terminal-release cases in the same commit; no gate file removed)
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +239/-85

### Optional Evidence Claims

## Task And Scope

- Harness task: task_457e4bcfc68030f96d10aa6413
- Branch: codex/lease-lifecycle-035
- Public scope: packages/daemon/src (runtime-spawner, repo-cell-open, repo-cell-task-mutation, fleet edge/center lease paths), packages/kernel/src/ports/authorization-port.ts, packages/cli/src/cli-runtime-batch.ts (r3: restored work-stealing pool + per-task lease reacquisition), tests
- Private planning/evidence updated: yes
- Out of scope: provider exhaustion semantics (0.41+G10, #1883); lease TTL policy (unchanged)

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_457e4bcfc68030f96d10aa6413
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: aab3a081c757cc7f01ca9a14c1ef6dc0dd2aba21
- Branch merge-base with `origin/main`: aab3a081c757cc7f01ca9a14c1ef6dc0dd2aba21
- Last `git fetch origin` time: 2026-08-26T21:15:57Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_457e4bcfc68030f96d10aa6413 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Targeted daemon run 45/45
- [ ] Rebase onto 0.41+G10 after it merges (both touch the terminal callback); Opus review before merge
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO wrote the plan (delete-first: fix the lease lifecycle, no bypass flags) and will read the diff.
- Reviewer subagent: Codex worker (gpt-5.6-sol); Opus review pending.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Conflicts with 0.41+G10 on the terminal callback are expected and will be resolved by rebase before queueing.

## References

- Task: task_457e4bcfc68030f96d10aa6413
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

0.35:execution lease 的存续与执行者的存活严格绑定。runtime session 到终态(exited / cancelled / provider fault)——本地或经 fleet——同一 await 链(在退出/结果事件之后串行)通过现有 `task release` 写路径释放该 execution 的 lease;等待 fallback 的保留。孤儿/终态 lease 可由 task owner 回收,无需伪装原 runtime session;过期回调不能释放更新的 execution。没有新增 `--force` / `--execution-id` 旁路;替换了仅在 fallback 耗尽时触发的终态回调路径。

## 架构辩护

- 不需要:Production-Delta churn 低于 200 行。

## 改动内容

- `packages/daemon/src`:runtime 终态 → 同事务 `task release`(本地 + fleet);owner 回收孤儿/终态 lease;过期回调守卫。
- 测试:定向 45/45。

## 门收割 / Gate Harvest

- 删除的生产路径:仅 fallback 耗尽触发的终态回调路径
- 同 commit 删除的门 / fixture:none(其断言由同 commit 的终态释放用例替换;未删门文件)
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_457e4bcfc68030f96d10aa6413
- 分支:codex/lease-lifecycle-035
- 公开范围:packages/daemon/src(runtime-spawner、repo-cell-open、repo-cell-task-mutation、fleet edge/center lease 路径)、packages/kernel/src/ports/authorization-port.ts、packages/cli/src/cli-runtime-batch.ts(r3:恢复 work-stealing pool + 逐任务 lease 重取)、测试
- 私有计划 / 证据是否已更新:yes
- 范围外:provider 耗尽语义(0.41+G10,#1883);lease TTL 政策(不动)

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_457e4bcfc68030f96d10aa6413
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:aab3a081c757cc7f01ca9a14c1ef6dc0dd2aba21
- 当前分支与 `origin/main` 的 merge-base:aab3a081c757cc7f01ca9a14c1ef6dc0dd2aba21
- 最近一次 `git fetch origin` 时间:2026-08-26T21:15:57Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_457e4bcfc68030f96d10aa6413
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] daemon 定向 45/45
- [ ] 0.41+G10 合入后 rebase(两者都碰终态回调);合并前 Opus 复核
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 写 plan(删除优先:修 lease 生命周期,不加旁路 flag)并读 diff。
- Reviewer subagent:Codex worker(gpt-5.6-sol);Opus 复核待做。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 与 0.41+G10 在终态回调上预期有冲突,入队前 rebase 解决。

## 关联材料

- 任务:task_457e4bcfc68030f96d10aa6413
- 证据:任务包 artifacts/reports
- 审查:本 PR



r3 (after Opus review): squad continuation reacquires a lease only when both executionId and actor match (else `lease_conflict`); the fixed-wave batch rewrite was reverted to the original pool; the fallback-exhaustion-only terminal callback branches in `repo-cell-open.ts` and `fleet-edge-runtime.ts` plus the `fallbackExhausted` transport flag are now actually deleted; owner recovery in `authorization-port.ts` is narrowed to orphaned leases or a terminal runtime binding proving the same task+execution.


r3(Opus 复核后):squad 续轮只有 executionId 与 actor 都匹配时才视为已持有(否则 `lease_conflict`);固定 wave 的 batch 改写已回退为原 pool;`repo-cell-open.ts` 与 `fleet-edge-runtime.ts` 里仅 fallback 耗尽触发的终态回调分支及 `fallbackExhausted` 传输标记这次真的删除;`authorization-port.ts` 的 owner 回收收窄为孤儿 lease 或能证明同 task+execution 的终态 runtime binding。