### PR TITLE
refactor(cli): narrow daemon-gone recovery to reachable paths (0.48)

### DIFF
--- a/packages/cli/src/cli-runtime-wait.ts
+++ b/packages/cli/src/cli-runtime-wait.ts
@@ -42,14 +42,17 @@ export async function waitForRuntime(
           statusReader = undefined;
         },
       );
-      if (isDaemonGone(next))
-        return runtimeDaemonGone(
+      if (isDaemonGone(next)) {
+        const runtime = current as unknown as AgentRuntimeSessionResult | undefined,
+          status = runtime?.session.activity.outcome ?? (runtime?.session ? "running" : "unknown"),
+          commandName = spawned ? "runtime-run" : "runtime-status";
+        return daemonGoneReceipt(commandName, next.cause, status, {
           runtimeSessionId,
-          spawned,
-          target,
-          current as unknown as AgentRuntimeSessionResult | undefined,
-          next.cause,
-        );
+          ...(target ?? {}),
+          ...(spawned ? { spawn: spawned } : {}),
+          lastKnownDispatch: lastKnownRuntimeDispatch(runtimeSessionId, target, runtime, status),
+        });
+      }
       if (next.ok !== true) return next;
       current = next;
       if (stream && !streamStarted) {
@@ -105,7 +108,17 @@ export async function waitForTaskDispatches(command: ThinCommand, taskId: string
     const next = await readDaemonSubscription(command, () =>
       runCommandThroughDaemon(readCommand, () => undefined, { autostart: false }),
     );
-    if (isDaemonGone(next)) return taskDispatchDaemonGone(taskId, current, next.cause);
+    if (isDaemonGone(next)) {
+      const dispatches = Array.isArray(current?.dispatches) ? current.dispatches : [],
+        rows = `${dispatches.length} row${dispatches.length === 1 ? "" : "s"}`;
+      return daemonGoneReceipt(
+        "runtime-status",
+        next.cause,
+        rows,
+        { taskId, lastKnownDispatches: dispatches },
+        `runtime-status task ${taskId}`,
+      );
+    }
     current = next;
     if (current.ok !== true) return current;
     if (current.status !== "pending" && taskDispatchesSettled(current)) break;
@@ -179,9 +192,7 @@ function recoverableSubscriptionFailure(error: unknown): boolean {
         : null,
     message = error instanceof Error ? error.message : String(error);
   return (
-    ["daemon_response_timeout", "daemon_closed", "ECONNREFUSED", "ECONNRESET", "ENOENT", "EPIPE", "ETIMEDOUT"].includes(
-      String(code),
-    ) ||
+    ["daemon_response_timeout", "daemon_closed", "ECONNREFUSED", "ECONNRESET", "ENOENT"].includes(String(code)) ||
     message === "daemon_unavailable" ||
     message === "daemon_stream_unavailable"
   );
@@ -200,76 +211,52 @@ function isDaemonGone(value: JsonObject | DaemonGone): value is DaemonGone {
   return "kind" in value && value.kind === "daemon-gone";
 }
 
-function runtimeDaemonGone(
+function lastKnownRuntimeDispatch(
   runtimeSessionId: string,
-  spawned: JsonObject | undefined,
   target: { readonly taskId: string; readonly dispatchId: string } | undefined,
   current: AgentRuntimeSessionResult | undefined,
-  cause: string,
-): JsonObject {
-  const session = current?.session,
-    activity = session?.activity,
-    attempts = session?.attemptChain?.attempts ?? [],
-    attempt = attempts.find((candidate) => candidate.runtimeSessionId === runtimeSessionId),
-    association = session?.associations[0],
-    status = activity?.outcome ?? (session ? "running" : "unknown"),
-    lastKnownDispatch = session
-      ? {
-          taskId: target?.taskId ?? association?.taskId ?? null,
-          dispatchId: target?.dispatchId ?? attempt?.dispatchId ?? null,
-          runtimeSessionId,
-          status,
-          liveness: session.liveness,
-          outcome: activity?.outcome ?? null,
-          exitCode: activity?.exitCode ?? null,
-          classification: attempt?.classification ?? null,
-          fallbackState: attempt?.fallbackState ?? null,
-        }
-      : null,
-    commandName = spawned ? "runtime-run" : "runtime-status",
-    hint =
-      `The daemon process and socket are gone. Last known dispatch status: ${status}. ` +
-      "Restart the daemon, then inspect the dispatch before deciding whether to run it again.";
+  status: string,
+): JsonObject | null {
+  const session = current?.session;
+  if (!session) return null;
+  const activity = session.activity,
+    attempt = session.attemptChain?.attempts.find((candidate) => candidate.runtimeSessionId === runtimeSessionId),
+    association = session.associations[0];
   return {
-    schema: "command-receipt/v2",
-    ok: false,
-    command: commandName,
-    outcome: "op_rejected",
-    origin: "cli",
-    code: "daemon_gone",
-    evidence: "rejection:daemon_gone",
+    taskId: target?.taskId ?? association?.taskId ?? null,
+    dispatchId: target?.dispatchId ?? attempt?.dispatchId ?? null,
     runtimeSessionId,
-    ...(target ?? {}),
-    ...(spawned ? { spawn: spawned } : {}),
-    lastKnownDispatch,
-    error: { code: "daemon_gone", hint, cause },
-    nextAction: hint,
-    summary: `${commandName}: daemon_gone; last known dispatch status ${status}`,
-    exitCode: 1,
+    status,
+    liveness: session.liveness,
+    outcome: activity.outcome ?? null,
+    exitCode: activity.exitCode ?? null,
+    classification: attempt?.classification ?? null,
+    fallbackState: attempt?.fallbackState ?? null,
   };
 }
 
-function taskDispatchDaemonGone(taskId: string, current: JsonObject | undefined, cause: string): JsonObject {
-  const dispatches = Array.isArray(current?.dispatches) ? current.dispatches : [],
-    hint =
-      `The daemon process and socket are gone. ${dispatches.length} last-known task dispatch status ` +
-      `row${dispatches.length === 1 ? " is" : "s are"} attached. ` +
-      "Restart the daemon, then inspect the task dispatches before deciding whether to run them again.";
+function daemonGoneReceipt(
+  command: string,
+  cause: string,
+  lastKnownStatus: string,
+  details: JsonObject,
+  summaryCommand = command,
+): JsonObject {
+  const hint =
+    `The daemon process and socket are gone. Last known dispatch status: ${lastKnownStatus}. ` +
+    "Restart the daemon, then inspect the recorded status before deciding whether to run again.";
   return {
     schema: "command-receipt/v2",
     ok: false,
-    command: "runtime-status",
+    command,
     outcome: "op_rejected",
     origin: "cli",
     code: "daemon_gone",
     evidence: "rejection:daemon_gone",
-    taskId,
-    lastKnownDispatches: dispatches,
+    ...details,
     error: { code: "daemon_gone", hint, cause },
     nextAction: hint,
-    summary:
-      `runtime-status task ${taskId}: daemon_gone; ` +
-      `${dispatches.length} last-known dispatch status row${dispatches.length === 1 ? "" : "s"}`,
+    summary: `${summaryCommand}: daemon_gone; last known dispatch status ${lastKnownStatus}`,
     exitCode: 1,
   };
 }

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -112,18 +112,14 @@ async function withAutostart(
     return await request();
   } catch (error) {
     if (!options.autostart) throw error;
-    const {
-      DaemonAutostartError,
-      ensureLocalDaemonRunning,
-      isDaemonUnreachable,
-      runtimeDaemonStartRefusalForUnavailable,
-    } = await import("../../../daemon/src/client/daemon-autostart.ts");
+    const { DaemonAutostartError, ensureLocalDaemonRunning, isDaemonUnreachable, runtimeDaemonStartRefusal } =
+      await import("../../../daemon/src/client/daemon-autostart.ts");
     const buildStale = isDaemonBuildStale(error);
     if (!buildStale && !isDaemonUnreachable(error)) throw error;
     if (buildStale) await waitForDaemonRestart(socketPath);
     // The failed connection (or the completed stale-daemon shutdown wait) already proves this
     // socket unavailable. A second socket probe can consume its full timeout without adding evidence.
-    const refusal = runtimeDaemonStartRefusalForUnavailable(options.env);
+    const refusal = runtimeDaemonStartRefusal(options.env);
     if (refusal) throw new DaemonAutostartError({ ok: false, ...refusal, attempts: 0 });
     const started = await ensureLocalDaemonRunning({
       socketPath,

--- a/packages/cli/src/daemon/control.ts
+++ b/packages/cli/src/daemon/control.ts
@@ -13,12 +13,7 @@ import { requestDaemonJsonRpcAt } from "../../../daemon/src/client/local-json-rp
 import type { DaemonShutdownExchange } from "../../../daemon/src/client/local-json-rpc-shutdown.ts";
 import { detachedProcessOptions, terminateProcess } from "../../../daemon/src/process-port.ts";
 import type { JsonObject } from "../../../daemon/src/protocol/json-rpc-types.ts";
-import {
-  ensureLocalDaemonRunning,
-  isDaemonUnreachable,
-  runtimeDaemonStartRefusal,
-  runtimeDaemonStartRefusalForUnavailable,
-} from "../../../daemon/src/client/daemon-autostart.ts";
+import { ensureLocalDaemonRunning, runtimeDaemonStartRefusal } from "../../../daemon/src/client/daemon-autostart.ts";
 import { readDaemonPid, startDaemon } from "../../../daemon/src/runtime.ts";
 import {
   daemonProcessAlive,
@@ -97,7 +92,7 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
       return finish(result, result.ok === true ? 0 : 1);
     }
     if (command === "serve") {
-      const refusal = await runtimeDaemonStartRefusal(localUserDaemonEndpoint(userRoot, daemonId));
+      const refusal = runtimeDaemonStartRefusal();
       if (refusal) return finish(daemonFailure("daemon-serve", "daemon_start_runtime_forbidden", refusal.hint), 1);
       return serve(userRoot, daemonId, finish);
     }
@@ -111,18 +106,14 @@ export async function runDaemonControl(argv: readonly string[], renderReceipt: R
           ),
           2,
         );
-      let running: Record<string, unknown> | null = null,
-        unavailable = false;
+      let running: Record<string, unknown> | null = null;
       try {
         running = await status(userRoot, daemonId);
       } catch (error) {
-        unavailable = isDaemonUnreachable(error);
         consumeKnownError(error);
       }
       if (running?.ok === true) return finish(running, 0);
-      const refusal = unavailable
-        ? runtimeDaemonStartRefusalForUnavailable()
-        : await runtimeDaemonStartRefusal(localUserDaemonEndpoint(userRoot, daemonId));
+      const refusal = runtimeDaemonStartRefusal();
       if (refusal) return finish(daemonFailure("daemon-start", "daemon_start_runtime_forbidden", refusal.hint), 1);
       const started = await ensureLocalDaemonRunning({
         socketPath: localUserDaemonEndpoint(userRoot, daemonId),

--- a/packages/cli/test/runtime-wait-reconnect.integration.test.ts
+++ b/packages/cli/test/runtime-wait-reconnect.integration.test.ts
@@ -91,6 +91,33 @@ test("runtime status --wait returns daemon_gone with the last-known dispatch aft
   }
 });
 
+test("task dispatch wait classifies an ENOENT reconnect as daemon_gone and retains the last-known rows", async () => {
+  const fixture = await openFixtureDaemon("task-daemon-gone"),
+    taskId = "task-runtime-wait",
+    dispatch = { dispatchId: "dispatch-runtime-wait", status: "running", fallbackState: null };
+  fixture.onRequest = (socket, request) => {
+    if (request.method === "protocol.hello") {
+      reply(socket, request.id, { ok: true });
+      return;
+    }
+    assert.equal(request.method, "repo.task.dispatches");
+    reply(socket, request.id, { ok: true, status: "ready", dispatches: [dispatch] });
+    socket.once("close", fixture.die);
+  };
+  const invocation = runWait(fixture, ["runtime", "status", "--task", taskId, "--wait", "--no-stream"]);
+  try {
+    const result = await invocation.result(10_000);
+    assert.equal(result.code, 1, result.stderr);
+    assert.equal(result.receipt.code, "daemon_gone");
+    assert.equal(result.receipt.taskId, taskId);
+    assert.deepEqual(result.receipt.lastKnownDispatches, [dispatch]);
+    assert.match(String((result.receipt.error as Record<string, unknown>).cause), /ENOENT/u);
+  } finally {
+    invocation.stop();
+    await fixture.close();
+  }
+});
+
 interface FixtureDaemon {
   readonly root: string;
   readonly userRoot: string;
@@ -131,6 +158,7 @@ async function openFixtureDaemon(daemonId: string): Promise<FixtureDaemon> {
         rmSync(daemonPidPath(userRoot, daemonId), { force: true });
         if (server.listening) server.close();
         for (const socket of sockets) socket.destroy();
+        rmSync(socketPath, { force: true });
       },
       close: async () => {
         fixture.die();
@@ -165,25 +193,24 @@ async function openFixtureDaemon(daemonId: string): Promise<FixtureDaemon> {
   return fixture;
 }
 
-function runWait(fixture: FixtureDaemon): {
+function runWait(
+  fixture: FixtureDaemon,
+  args: readonly string[] = ["runtime", "status", runtimeSessionId, "--wait", "--no-stream"],
+): {
   readonly closed: boolean;
   readonly result: (timeoutMs: number) => Promise<InvocationResult>;
   readonly stop: () => void;
 } {
   const { HARNESS_DAEMON_ENDPOINT: _endpoint, HARNESS_DAEMON_REPO_ID: _repoId, ...baseEnv } = process.env,
-    child = spawn(
-      process.execPath,
-      [cli, "--root", fixture.root, "--json", "runtime", "status", runtimeSessionId, "--wait", "--no-stream"],
-      {
-        env: {
-          ...baseEnv,
-          HARNESS_DAEMON_USER_ROOT: fixture.userRoot,
-          HARNESS_DAEMON_ID: fixture.daemonId,
-          HARNESS_DAEMON_REPO_ID: "runtime-wait",
-        },
-        stdio: ["ignore", "pipe", "pipe"],
+    child = spawn(process.execPath, [cli, "--root", fixture.root, "--json", ...args], {
+      env: {
+        ...baseEnv,
+        HARNESS_DAEMON_USER_ROOT: fixture.userRoot,
+        HARNESS_DAEMON_ID: fixture.daemonId,
+        HARNESS_DAEMON_REPO_ID: "runtime-wait",
       },
-    );
+      stdio: ["ignore", "pipe", "pipe"],
+    });
   let closed = false,
     stdout = "",
     stderr = "";

--- a/packages/daemon/src/client/daemon-autostart.ts
+++ b/packages/daemon/src/client/daemon-autostart.ts
@@ -48,7 +48,7 @@ export function isDaemonUnreachable(error: unknown): boolean {
   }
   return error instanceof Error && error.message === "daemon_unavailable";
 }
-export function runtimeDaemonStartRefusalForUnavailable(
+export function runtimeDaemonStartRefusal(
   env: NodeJS.ProcessEnv = process.env,
 ): { readonly code: "daemon_start_runtime_forbidden"; readonly hint: string } | null {
   if (env.HARNESS_ACTOR?.startsWith("agent:runtime-session:") !== true) return null;
@@ -59,14 +59,6 @@ export function runtimeDaemonStartRefusalForUnavailable(
       "Start the daemon from an operator shell with `ha daemon start --service`, then retry the worker command.",
     ].join(" "),
   };
-}
-export async function runtimeDaemonStartRefusal(
-  socketPath: string,
-  env: NodeJS.ProcessEnv = process.env,
-  probe: (socketPath: string) => Promise<boolean> = daemonSocketProbe,
-): Promise<{ readonly code: "daemon_start_runtime_forbidden"; readonly hint: string } | null> {
-  const refusal = runtimeDaemonStartRefusalForUnavailable(env);
-  return refusal === null || (await probe(socketPath)) ? null : refusal;
 }
 export async function ensureLocalDaemonRunning(input: {
   readonly socketPath: string;

--- a/packages/daemon/test/daemon-autostart.test.ts
+++ b/packages/daemon/test/daemon-autostart.test.ts
@@ -11,7 +11,6 @@ import {
   isDaemonUnreachable,
   readDaemonStartProgress,
   runtimeDaemonStartRefusal,
-  runtimeDaemonStartRefusalForUnavailable,
   type DaemonAutostartResult,
   type DaemonLaunchSpec,
 } from "../src/client/daemon-autostart.ts";
@@ -29,27 +28,11 @@ const launch = (): DaemonLaunchSpec => ({
   env: {},
 });
 
-test("runtime start refusal requires a runtime actor and an unavailable daemon", async () => {
-  let probes = 0;
-  const taskBoundOnly = await runtimeDaemonStartRefusal(
-    "/tmp/ha-autostart.sock",
-    { HARNESS_TASK_BOUND: "1" },
-    async () => {
-      probes += 1;
-      return false;
-    },
-  );
+test("runtime start refusal requires a runtime actor", () => {
+  const taskBoundOnly = runtimeDaemonStartRefusal({ HARNESS_TASK_BOUND: "1" });
   assert.equal(taskBoundOnly, null);
-  assert.equal(probes, 0, "a task-bound marker alone is not runtime identity");
 
-  const resident = await runtimeDaemonStartRefusal(
-    "/tmp/ha-autostart.sock",
-    { HARNESS_ACTOR: "agent:runtime-session:worker" },
-    async () => true,
-  );
-  assert.equal(resident, null, "a runtime actor may use a resident daemon");
-
-  const absent = runtimeDaemonStartRefusalForUnavailable({ HARNESS_ACTOR: "agent:runtime-session:worker" });
+  const absent = runtimeDaemonStartRefusal({ HARNESS_ACTOR: "agent:runtime-session:worker" });
   assert.equal(absent?.code, "daemon_start_runtime_forbidden");
 });
 


### PR DESCRIPTION
# English

## Summary

0.48 (anti-entropy review #5 items 3/4/5): the CLI's daemon-gone recovery in `cli-runtime-wait.ts` built the `daemon_gone` receipt in two places and matched error codes the client never emits (`EPIPE`, `ETIMEDOUT`); `daemon-autostart.ts` kept a socket-probing refusal path that duplicated the daemon client's own connection failure. One receipt constructor, only the `ENOENT` case that integration tests actually reach, and the redundant probe deleted. Net -34 production lines.

## Architectural Justification

- Not required: Production-Delta churn is below 200 lines.

## What Changed

- `packages/cli/src/cli-runtime-wait.ts`: single `daemon_gone` receipt constructor; `EPIPE`/`ETIMEDOUT` branches removed.
- `packages/daemon/src/client/daemon-autostart.ts`: socket-probing refusal path deleted.
- Tests: 14 daemon unit, 3 runtime-wait, 10 autostart (one named platform skip).

## Gate Harvest / 门收割

Deleted-Production-Paths: socket-probing refusal path in `daemon-autostart.ts`; duplicate `daemon_gone` receipt construction; unreachable `EPIPE`/`ETIMEDOUT` classification
Deleted-Gates-Fixtures: daemon-autostart unit cases that asserted the probe refusal (replaced in the same commit by the client-failure cases)
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +59/-93

### Optional Evidence Claims

## Task And Scope

- Harness task: task_370ec142e93c8dcf2be0143f98
- Branch: codex/cli-daemon-narrow-048
- Public scope: packages/cli/src/cli-runtime-wait.ts, packages/daemon/src/client/daemon-autostart.ts, their tests
- Private planning/evidence updated: yes
- Out of scope: daemon client stream semantics (unchanged, 0.45 #1881)

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_370ec142e93c8dcf2be0143f98
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: aab3a081c757cc7f01ca9a14c1ef6dc0dd2aba21
- Branch merge-base with `origin/main`: aab3a081c757cc7f01ca9a14c1ef6dc0dd2aba21
- Last `git fetch origin` time: 2026-08-26T21:37:43Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_370ec142e93c8dcf2be0143f98 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] typecheck, focused ESLint, file complexity, targeted tests in the worktree
- [x] CEO read the diff
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO filed the item from review #5 and read the diff (delete-only refactor).
- Reviewer subagent: Codex worker (gpt-5.6-sol); CEO diff read.
- Human review: pending
- Blocking findings: none

## Residual Risk

- A daemon socket that exists but refuses connections now surfaces as the client's own connection error instead of a pre-emptive refusal — same outcome, one fewer path.

## References

- Task: task_370ec142e93c8dcf2be0143f98
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

0.48(反熵审查#5 第 3/4/5 条):CLI 的 daemon-gone 恢复(`cli-runtime-wait.ts`)在两处构造 `daemon_gone` 回执,并匹配客户端从不发出的错误码(`EPIPE`、`ETIMEDOUT`);`daemon-autostart.ts` 保留了一条探测 socket 的拒绝路径,与 daemon client 自身的连接失败重复。收敛为一个回执构造器、只保留 integration 测试真能到达的 `ENOENT` 分支,删除冗余探测。生产净 -34 行。

## 架构辩护

- 不需要:Production-Delta churn 低于 200 行。

## 改动内容

- `packages/cli/src/cli-runtime-wait.ts`:单一 `daemon_gone` 回执构造器;删 `EPIPE`/`ETIMEDOUT` 分支。
- `packages/daemon/src/client/daemon-autostart.ts`:删 socket 探测拒绝路径。
- 测试:daemon 单元 14、runtime-wait 3、autostart 10(一个具名平台跳过)。

## 门收割 / Gate Harvest

- 删除的生产路径:`daemon-autostart.ts` 的 socket 探测拒绝路径;重复的 `daemon_gone` 回执构造;不可达的 `EPIPE`/`ETIMEDOUT` 归类
- 同 commit 删除的门 / fixture:断言探测拒绝的 daemon-autostart 单元用例(同 commit 替换为 client 失败用例)
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_370ec142e93c8dcf2be0143f98
- 分支:codex/cli-daemon-narrow-048
- 公开范围:packages/cli/src/cli-runtime-wait.ts、packages/daemon/src/client/daemon-autostart.ts 及其测试
- 私有计划 / 证据是否已更新:yes
- 范围外:daemon client 流语义(不动,0.45 #1881)

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_370ec142e93c8dcf2be0143f98
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:aab3a081c757cc7f01ca9a14c1ef6dc0dd2aba21
- 当前分支与 `origin/main` 的 merge-base:aab3a081c757cc7f01ca9a14c1ef6dc0dd2aba21
- 最近一次 `git fetch origin` 时间:2026-08-26T21:37:43Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_370ec142e93c8dcf2be0143f98
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] worktree 内 typecheck、定向 ESLint、文件复杂度、定向测试
- [x] CEO 读 diff
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 从审查#5 立项并读 diff(纯删减重构)。
- Reviewer subagent:Codex worker(gpt-5.6-sol);CEO 读 diff。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 存在但拒绝连接的 daemon socket 现在表现为 client 自身的连接错误,而非预先拒绝——结果相同,少一条路径。

## 关联材料

- 任务:task_370ec142e93c8dcf2be0143f98
- 证据:任务包 artifacts/reports
- 审查:本 PR


Note (Opus review): `ETIMEDOUT` is still accepted by `isDaemonUnreachable` and mapped to `daemon_unavailable` in `control.ts`; it was removed from the wait path because unix-socket connects never produce it, not because the client never emits it. `control.ts` `serve`/`start` now refuse a runtime actor unconditionally instead of only after probing for a listener — a small fail-closed tightening beyond the socket-probe deletion.


备注(Opus 复核):`ETIMEDOUT` 仍被 `isDaemonUnreachable` 接受并在 `control.ts` 映射为 `daemon_unavailable`;从 wait 路径删除是因为 unix socket 连接不会产生它,而不是客户端从不发出。`control.ts` 的 `serve`/`start` 现在对 runtime actor 无条件拒绝,不再先探测监听者——这是 socket 探测删除之外的一处小幅 fail-closed 收紧。