### PR TITLE
refactor(gui): narrow observe/runtime pages per review #5 items 7-9 (G14)

### DIFF
--- a/packages/gui/src/renderer/components/runtime/useRuntimeWorkspace.ts
+++ b/packages/gui/src/renderer/components/runtime/useRuntimeWorkspace.ts
@@ -385,7 +385,7 @@ export function useProviderWorkspace(repoId: string, requestedInstanceId: string
   const channel = useRuntimeChannel(repoId, async () => {
     await Promise.all([
       client.invalidateQueries({
-        queryKey: ["runtime-instances", "machine"],
+        queryKey: runtimeInstanceCatalogQueryKey,
       }),
       client.invalidateQueries({ queryKey: ["runtime-control", repoId] }),
     ]);
@@ -445,37 +445,18 @@ export function useProviderWorkspace(repoId: string, requestedInstanceId: string
             false,
           );
       }
-      await client.invalidateQueries({ queryKey: ["runtime-instances", "machine"] });
+      await client.invalidateQueries({ queryKey: runtimeInstanceCatalogQueryKey });
       await client.invalidateQueries({ queryKey: ["runtime-control", repoId] });
       return created;
     },
     updateInstance: (input: RuntimeInstanceUpdateInput) =>
       channel.run(t("agentRuntime.opInstanceUpdated"), () => runtimeInstanceClient.update(input)),
-    setInstanceEnabled: async (instanceId: string, enabled: boolean) => {
-      const queryKey = runtimeInstanceCatalogQueryKey,
-        previous = client.getQueryData<Awaited<ReturnType<typeof runtimeInstanceClient.list>>>(queryKey),
-        updatedAt = client.getQueryState(queryKey)?.dataUpdatedAt;
-      client.setQueryData<Awaited<ReturnType<typeof runtimeInstanceClient.list>>>(
-        queryKey,
-        (catalog) =>
-          catalog === undefined
-            ? catalog
-            : {
-                ...catalog,
-                instances: catalog.instances.map((instance) =>
-                  instance.instanceId === instanceId ? { ...instance, enabled } : instance,
-                ),
-              },
-        updatedAt === undefined ? undefined : { updatedAt },
-      );
-      const result = await channel.run(
-        t(enabled ? "agentRuntime.opInstanceEnabled" : "agentRuntime.opInstanceDisabled"),
-        () => runtimeInstanceClient.setEnabled(instanceId, enabled),
-        false,
-      );
-      if (result === null) client.setQueryData(queryKey, previous, updatedAt === undefined ? undefined : { updatedAt });
-      return result;
-    },
+    // 与 updateInstance 同一条 await + invalidate 通道:布尔开关回显等一次目录重读,
+    // 不做乐观写回滚(评审 #5 第 8 条:无实测延迟收益,删除优先)。
+    setInstanceEnabled: (instanceId: string, enabled: boolean) =>
+      channel.run(t(enabled ? "agentRuntime.opInstanceEnabled" : "agentRuntime.opInstanceDisabled"), () =>
+        runtimeInstanceClient.setEnabled(instanceId, enabled),
+      ),
     deleteInstance: (instanceId: string) =>
       channel.run(t("agentRuntime.opInstanceDeleted"), () => runtimeInstanceClient.delete(instanceId)),
     validateInstance: (instanceId: string) =>

--- a/packages/gui/src/renderer/daemon-observe-model.ts
+++ b/packages/gui/src/renderer/daemon-observe-model.ts
@@ -218,7 +218,6 @@ function sameCursor(left: ObserveTailCursor, right: ObserveTailCursor): boolean 
 }
 
 /** 行数到达上限后按增长方向的反侧丢弃;不足上限时原数组原样返回(见 OBSERVE_ROW_LIMIT)。 */
-/** 行数到达上限后按增长方向的反侧丢弃;不足上限时原数组原样返回(见 OBSERVE_ROW_LIMIT)。 */
 function capRows(rows: readonly ObserveRow[], growth: "history" | "follow"): readonly ObserveRow[] {
   if (rows.length <= OBSERVE_ROW_LIMIT) return rows;
   return growth === "history" ? rows.slice(0, OBSERVE_ROW_LIMIT) : rows.slice(rows.length - OBSERVE_ROW_LIMIT);

--- a/packages/gui/src/renderer/daemon-observe-model.ts
+++ b/packages/gui/src/renderer/daemon-observe-model.ts
@@ -3,7 +3,8 @@ import type { ObserveTailPayload, ObserveTailRead } from "../api/renderer-dto.ts
 /**
  * G6-B daemon 观察页的纯数据面:`observe.tail` 分页 → 可渲染行流。
  *
- * 契约(v3,权威):items 上限 64/页;history/live cursor 由客户端分别持有并原样回传;
+ * 契约(v3,权威):items 上限 64/页;累计行流双侧封顶 OBSERVE_ROW_LIMIT(方向见其注释);
+ * history/live cursor 由客户端分别持有并原样回传;
  * `unavailable` 携带机器原因(edge 镜像无事件 / center request-log 未接线),
  * `gap` 携带保留缺口原因(cursor 文件不在保留集 / 偏移越界),两者都不冒充空列表。
  * 本模块不做 IO、不碰 React,形状推导全部来自已到货的 page,供视图与 vitest 共用。
@@ -52,6 +53,13 @@ export interface ObserveTailSnapshot {
 
 const DETAIL_LIMIT = 2_000;
 
+/**
+ * 内存上限(#1855 前为 500,当时只丢最旧端——与触顶回翻头部插入冲突而被删)。
+ * 现行按增长方向的反侧丢弃:history 增长丢最新端、follow 增长丢最旧端,
+ * 两个方向翻页都保持在界内,长开的 pane 也不随 live 行无限累积。
+ */
+export const OBSERVE_ROW_LIMIT = 500;
+
 export function initialObserveTail(): ObserveTailSnapshot {
   return {
     rows: [],
@@ -86,7 +94,7 @@ export function applyObserveTailPage(state: ObserveTailSnapshot, page: ObserveTa
       historyGap = page.direction === "history";
     return {
       ...state,
-      rows: historyGap ? [marker, ...state.rows] : [marker],
+      rows: historyGap ? capRows([marker, ...state.rows], "history") : [marker],
       status: "gap",
       gap: page.gap,
       unavailable: null,
@@ -111,12 +119,15 @@ export function applyObserveTailPage(state: ObserveTailSnapshot, page: ObserveTa
     prepend = page.direction === "history",
     initializing = prepend && state.liveCursor === null,
     appendAfterGap = initializing && state.status === "gap",
-    rows =
+    headGrowth = prepend && !appendAfterGap,
+    rows = capRows(
       page.kind === "events"
-        ? mergeEventRows(state.rows, fresh, prepend && !appendAfterGap)
-        : prepend && !appendAfterGap
+        ? mergeEventRows(state.rows, fresh, headGrowth)
+        : headGrowth
           ? [...fresh, ...state.rows]
-          : [...state.rows, ...fresh];
+          : [...state.rows, ...fresh],
+      headGrowth ? "history" : "follow",
+    );
   return {
     ...state,
     rows,
@@ -195,8 +206,22 @@ function mergeEventRows(
   return prepend ? [...unique, ...existing] : [...existing, ...unique];
 }
 
+/**
+ * 结构比较,不依赖对象键序:cursor 只有 events(revision)与文件游标(fileId+offset)
+ * 两种形状,逐判别字段比较即可,避免 `JSON.stringify` 把键序差异误判为游标不同。
+ */
 function sameCursor(left: ObserveTailCursor, right: ObserveTailCursor): boolean {
-  return JSON.stringify(left) === JSON.stringify(right);
+  if (left === null || right === null) return left === right;
+  if (left.kind !== right.kind) return false;
+  if (left.kind === "events") return right.kind === "events" && left.revision === right.revision;
+  return right.kind !== "events" && left.fileId === right.fileId && left.offset === right.offset;
+}
+
+/** 行数到达上限后按增长方向的反侧丢弃;不足上限时原数组原样返回(见 OBSERVE_ROW_LIMIT)。 */
+/** 行数到达上限后按增长方向的反侧丢弃;不足上限时原数组原样返回(见 OBSERVE_ROW_LIMIT)。 */
+function capRows(rows: readonly ObserveRow[], growth: "history" | "follow"): readonly ObserveRow[] {
+  if (rows.length <= OBSERVE_ROW_LIMIT) return rows;
+  return growth === "history" ? rows.slice(0, OBSERVE_ROW_LIMIT) : rows.slice(rows.length - OBSERVE_ROW_LIMIT);
 }
 
 function gapMarkerRow(gap: { readonly reason: string; readonly requestedFileId: string }, seq: number): ObserveRow {

--- a/packages/gui/test/daemon-observe.vitest.ts
+++ b/packages/gui/test/daemon-observe.vitest.ts
@@ -11,6 +11,7 @@ import {
   initialObserveTail,
   observeTailRequest,
   observeEventRow,
+  OBSERVE_ROW_LIMIT,
 } from "../src/renderer/daemon-observe-model.ts";
 import { harnessClient, type SystemRepoRow } from "../src/renderer/api-client.ts";
 import type { ObserveTailRead } from "../src/api/renderer-dto.ts";
@@ -122,6 +123,11 @@ function logPage(kind: "repo-log" | "daemon-log"): ObserveTailRead {
     sourceCursor: { kind, fileId: "file-g6b", offset: 88 },
     done: true,
   };
+}
+
+/** 闭区间整数序列(封顶测试用它生成成段的 revision)。 */
+function range(from: number, to: number): number[] {
+  return Array.from({ length: to - from + 1 }, (_, index) => from + index);
 }
 
 setActiveLocale("zh-CN");
@@ -301,6 +307,97 @@ describe("G6-B observe 模型:分页 → 行流", () => {
     expect(entity.text).toBe("agent");
     expect(entity.text).not.toContain("entityId");
     expect(entity.detail).toContain("agent_g6b");
+  });
+
+  it("caughtUp 的游标相等是结构比较,不依赖对象键序", () => {
+    // 键序颠倒的同一游标:JSON.stringify 比较会误判不等(评审 #5 第 7 条的弱实现)。
+    const reordered = applyObserveTailPage(initialObserveTail(), {
+      ...EVENT_PAGE,
+      liveCursor: { revision: 13, kind: "events" },
+      sourceCursor: { kind: "events", revision: 13 },
+    });
+    expect(reordered.caughtUp).toBe(true);
+    const differentRevision = applyObserveTailPage(initialObserveTail(), {
+      ...EVENT_PAGE,
+      liveCursor: { kind: "events", revision: 13 },
+      sourceCursor: { kind: "events", revision: 14 },
+    });
+    expect(differentRevision.caughtUp).toBe(false);
+    const fileCursor = applyObserveTailPage(initialObserveTail(), {
+      ...logPage("repo-log"),
+      liveCursor: { offset: 88, fileId: "file-g6b", kind: "repo-log" },
+      sourceCursor: { kind: "repo-log", fileId: "file-g6b", offset: 88 },
+    });
+    expect(fileCursor.caughtUp).toBe(true);
+    const differentOffset = applyObserveTailPage(initialObserveTail(), {
+      ...logPage("repo-log"),
+      liveCursor: { kind: "repo-log", fileId: "file-g6b", offset: 88 },
+      sourceCursor: { kind: "repo-log", fileId: "file-g6b", offset: 4096 },
+    });
+    expect(differentOffset.caughtUp).toBe(false);
+  });
+
+  it("累计行流双侧封顶:history 增长保最旧端,follow 增长保最新端", () => {
+    const event = (revision: number) => ({
+        ...(EVENT_PAGE.items[0] as object),
+        eventId: `ev-cap-${revision}`,
+        workspaceRevision: revision,
+      }),
+      page = (revisions: readonly number[], direction: "history" | "follow"): ObserveTailRead => ({
+        ...EVENT_PAGE,
+        direction,
+        items: revisions.map(event) as never,
+        historyCursor: direction === "history" ? { kind: "events", revision: Math.min(...revisions) } : null,
+        liveCursor: { kind: "events", revision: Math.max(...revisions) },
+        sourceCursor: { kind: "events", revision: Math.max(...revisions) },
+        done: true,
+      });
+    // 装满 600 行(100 行最新页 + 500 行历史页,revision 区间互不重叠):超限后保最旧 500。
+    let state = applyObserveTailPage(initialObserveTail(), page(range(901, 1000), "history"));
+    expect(state.rows).toHaveLength(100);
+    state = applyObserveTailPage(state, page(range(401, 900), "history"));
+    expect(state.rows).toHaveLength(OBSERVE_ROW_LIMIT);
+    expect(state.rows[0]!.revision).toBe(401);
+    expect(state.rows.at(-1)!.revision).toBe(900);
+    // follow 追加 10 个新 revision(510 行)再超限:保最新 500,最旧 10 行被挤掉。
+    state = applyObserveTailPage(state, page(range(1001, 1010), "follow"));
+    expect(state.rows).toHaveLength(OBSERVE_ROW_LIMIT);
+    expect(state.rows[0]!.revision).toBe(411);
+    expect(state.rows.at(-1)!.revision).toBe(1010);
+  });
+
+  it("history gap 标记行同样计入上限,不突破内存边界", () => {
+    const event = (revision: number) => ({
+        ...(EVENT_PAGE.items[0] as object),
+        eventId: `ev-gap-${revision}`,
+        workspaceRevision: revision,
+      }),
+      full = applyObserveTailPage(initialObserveTail(), {
+        ...EVENT_PAGE,
+        items: Array.from({ length: OBSERVE_ROW_LIMIT }, (_, index) => event(index + 1)) as never,
+        historyCursor: { kind: "events", revision: 1 },
+        liveCursor: { kind: "events", revision: OBSERVE_ROW_LIMIT },
+        sourceCursor: { kind: "events", revision: OBSERVE_ROW_LIMIT },
+        done: false,
+      });
+    expect(full.rows).toHaveLength(OBSERVE_ROW_LIMIT);
+    const gapped = applyObserveTailPage(full, {
+      schema: "daemon.observe-tail/v3",
+      ok: true,
+      repoId: REPO_ID,
+      mode: "local",
+      kind: "repo-log",
+      direction: "history",
+      status: "gap",
+      items: [],
+      historyCursor: null,
+      liveCursor: null,
+      sourceCursor: null,
+      done: false,
+      gap: { reason: "cursor-file-not-retained", requestedFileId: "file-gone" },
+    });
+    expect(gapped.rows).toHaveLength(OBSERVE_ROW_LIMIT);
+    expect(gapped.rows[0]!.gapMarker).toEqual({ reason: "cursor-file-not-retained", requestedFileId: "file-gone" });
   });
 
   it("请求组装显式区分反向 history 与正向 follow", () => {

--- a/packages/gui/test/runtime-workspace-interactions.vitest.ts
+++ b/packages/gui/test/runtime-workspace-interactions.vitest.ts
@@ -470,7 +470,7 @@ describe("runtime entry split (W6 IA)", () => {
     expect(onSelectEntity).toHaveBeenCalledWith("agent/terra");
   });
 
-  it("acknowledges provider enablement before the daemon receipt and does not reread page data", async () => {
+  it("reflects provider enablement only after the daemon receipt, through one catalog reread", async () => {
     let settleUpdate: (value: Record<string, unknown>) => void = () => undefined;
     const update = vi.spyOn(runtimeInstanceClient, "setEnabled").mockImplementation(
         () =>
@@ -487,23 +487,47 @@ describe("runtime entry split (W6 IA)", () => {
     expect(toggle).toBeInstanceOf(HTMLButtonElement);
     expect(toggle?.getAttribute("aria-checked")).toBe("true");
 
-    const startedAt = performance.now();
     await act(async () => {
       (toggle as HTMLButtonElement).click();
     });
     await flushEffects();
 
-    expect(toggle?.getAttribute("aria-checked")).toBe("false");
-    expect(performance.now() - startedAt).toBeLessThan(300);
+    // 回执未到:开关保持原值——不再有乐观翻转(评审 #5 第 8 条删除)。
     expect(update).toHaveBeenCalledWith("provider-edit", false);
+    expect(toggle?.getAttribute("aria-checked")).toBe("true");
     expect(list).not.toHaveBeenCalled();
-    expect(agentRuntimeClient.overview).not.toHaveBeenCalled();
 
+    list.mockResolvedValue({
+      instances: [{ ...providerInstance, enabled: false }],
+      installations: providerInstallations,
+    });
     settleUpdate({ ok: true });
     await flushEffects();
+    await flushEffects();
+
     expect(toggle?.getAttribute("aria-checked")).toBe("false");
+    expect(list).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the enablement switch unchanged and surfaces the failure when the daemon rejects it", async () => {
+    vi.spyOn(runtimeInstanceClient, "setEnabled").mockRejectedValue(new Error("daemon refused"));
+    const list = vi.spyOn(runtimeInstanceClient, "list").mockResolvedValue({
+      instances: [providerInstance],
+      installations: providerInstallations,
+    });
+    await mountProviders("provider/provider-edit");
+    const toggle = byTestId("runtime-card-provider").querySelector('[role="switch"]');
+    expect(toggle).toBeInstanceOf(HTMLButtonElement);
+
+    await act(async () => {
+      (toggle as HTMLButtonElement).click();
+    });
+    await flushEffects();
+
+    expect(toggle?.getAttribute("aria-checked")).toBe("true");
     expect(list).not.toHaveBeenCalled();
-    expect(agentRuntimeClient.overview).not.toHaveBeenCalled();
+    const status = [...byTestId("providers-view").querySelectorAll('[role="status"]')].map((node) => node.textContent);
+    expect(status.some((text) => text?.includes("daemon refused"))).toBe(true);
   });
 
   it("prewarms and retains one shared machine catalog read", async () => {


### PR DESCRIPTION
# English

## Summary

G14 (anti-entropy review #5 items 7/8/9, GUI): `sameCursor` in the observe model compares cursor structure per discriminant field instead of `JSON.stringify` (key order no longer matters); the `setInstanceEnabled` optimistic write + rollback is deleted in favour of the shared await + invalidate channel; `OBSERVE_ROW_LIMIT=500` is restored with direction-aware eviction (history paging evicts the newest end, follow evicts the oldest end, gap markers count) backed by a measured 223.7 MB uncapped replay.

## Architectural Justification

- Not required: Production-Delta churn is below 200 lines.

## What Changed

- `packages/gui/src/renderer/daemon-observe-model.ts`: structural `sameCursor`; row cap with direction-aware eviction.
- `packages/gui/src/renderer/components/runtime/useRuntimeWorkspace.ts`: optimistic write/rollback removed; query keys unified to `runtimeInstanceCatalogQueryKey`.
- vitest: daemon-observe 17/17, runtime-workspace-interactions 19/19; three mutation checks turn the new tests red.

## Gate Harvest / 门收割

Deleted-Production-Paths: `setInstanceEnabled` optimistic cache write + failure rollback; `JSON.stringify` cursor comparison
Deleted-Gates-Fixtures: runtime-workspace-interactions cases that asserted the optimistic flip (replaced by await+invalidate cases in the same commit)
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +39/-34

### Optional Evidence Claims

## Task And Scope

- Harness task: task_82876130051438365bf2eb2a2c
- Branch: codex/gui-observe-narrow-g14
- Public scope: packages/gui/src/renderer (daemon-observe-model, useRuntimeWorkspace), packages/gui/test
- Private planning/evidence updated: yes
- Out of scope: Electron frame-rate at the 500-row cap (unmeasured; happy-dom cannot); observe stream daemon side (unchanged)

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_82876130051438365bf2eb2a2c
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 0322d0eb3bc603e7a826ef68ac120a5f28d3c159
- Branch merge-base with `origin/main`: 0322d0eb3bc603e7a826ef68ac120a5f28d3c159
- Last `git fetch origin` time: 2026-08-26T21:37:43Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_82876130051438365bf2eb2a2c (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Targeted vitest + full GUI suite 49 files / 485 tests in the worktree
- [ ] Opus read-only review before merge
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: real Electron rendering at the cap; CI is the authority.

## Review Evidence

- Self-review: CEO filed items 7-9 from review #5; will read the diff.
- Reviewer subagent: GLM-5.3 worker; Opus review pending.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Deep history paging followed by jump-to-latest crosses the evicted middle without a gap marker (accepted, dec_D563FCE1DADD64DBF8AD08437E); provider enable/disable now reflects after one round trip + catalog reread.

## References

- Task: task_82876130051438365bf2eb2a2c
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

G14(反熵审查#5 第 7/8/9 条,GUI):observe model 的 `sameCursor` 按判别字段比较 cursor 结构而非 `JSON.stringify`(键序不再影响);删除 `setInstanceEnabled` 的乐观写 + 回滚,统一走共享的 await + invalidate 通道;恢复 `OBSERVE_ROW_LIMIT=500` 并按方向淘汰(历史分页淘汰最新端、follow 淘汰最旧端,gap 标记计数),依据是实测 223.7 MB 的无上限回放。

## 架构辩护

- 不需要:Production-Delta churn 低于 200 行。

## 改动内容

- `packages/gui/src/renderer/daemon-observe-model.ts`:结构化 `sameCursor`;带方向淘汰的行上限。
- `packages/gui/src/renderer/components/runtime/useRuntimeWorkspace.ts`:删乐观写/回滚;query key 统一为 `runtimeInstanceCatalogQueryKey`。
- vitest:daemon-observe 17/17、runtime-workspace-interactions 19/19;三处变异检查都能让新测试变红。

## 门收割 / Gate Harvest

- 删除的生产路径:`setInstanceEnabled` 乐观缓存写 + 失败回滚;`JSON.stringify` 的 cursor 比较
- 同 commit 删除的门 / fixture:断言乐观翻转的 runtime-workspace-interactions 用例(同 commit 替换为 await+invalidate 用例)
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_82876130051438365bf2eb2a2c
- 分支:codex/gui-observe-narrow-g14
- 公开范围:packages/gui/src/renderer(daemon-observe-model、useRuntimeWorkspace)、packages/gui/test
- 私有计划 / 证据是否已更新:yes
- 范围外:500 行上限下的 Electron 帧率(未测;happy-dom 测不了);observe 流 daemon 侧(不动)

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_82876130051438365bf2eb2a2c
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:0322d0eb3bc603e7a826ef68ac120a5f28d3c159
- 当前分支与 `origin/main` 的 merge-base:0322d0eb3bc603e7a826ef68ac120a5f28d3c159
- 最近一次 `git fetch origin` 时间:2026-08-26T21:37:43Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_82876130051438365bf2eb2a2c
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] worktree 内定向 vitest + GUI 全套 49 文件 / 485 测试
- [ ] 合并前 Opus 只读复核
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:上限下的真实 Electron 渲染;以 CI 为权威。

## 审查证据

- 自查:CEO 从审查#5 立第 7-9 条;并读 diff。
- Reviewer subagent:GLM-5.3 worker;Opus 复核待做。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 深度历史分页后跳到最新会跨过被淘汰的中段且无 gap 标记(已接受,dec_D563FCE1DADD64DBF8AD08437E);provider 启停现在在一次往返 + catalog 重读后才反映。

## 关联材料

- 任务:task_82876130051438365bf2eb2a2c
- 证据:任务包 artifacts/reports
- 审查:本 PR

