### PR TITLE
fix(daemon): seed squad-run activity from its own transition time (G13 follow-up)

### DIFF
--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -85,6 +85,8 @@ type SquadState = {
   readonly phase: SquadRunPhase;
   readonly revision: number;
   readonly error: string | null;
+  /** 最近一次状态落盘时间(writeState 写入);早于该字段的持久化状态为 null。 */
+  readonly updatedAt: string | null;
 };
 
 type RuntimeOutcomeEvent = Extract<AgentRuntimeEventV1, { readonly type: "runtime_session_outcome_observed" }>;
@@ -133,6 +135,7 @@ export function makeSquadCoordinator(input: {
         phase: "planning",
         revision: 0,
         error: null,
+        updatedAt: null,
       };
     try {
       const running = await spawnLeader(state, { kind: "initial" });
@@ -183,7 +186,7 @@ export function makeSquadCoordinator(input: {
       cut = input.projection().readTaskStatuses([]),
       matching = readStates()
         .map(summaryDto)
-        .filter((run) => activePhase(run.phase) || query.since === null || run.latestActivityAt >= query.since)
+        .filter((run) => activePhase(run.phase) || query.since === null || runInActivityWindow(run, query.since))
         .filter((run) => matchesRunQuery(run, query.tokens))
         .sort(compareRunSummaries),
       selected = matching.slice(0, query.limit);
@@ -570,16 +573,19 @@ export function makeSquadCoordinator(input: {
 
   function writeState(state: SquadState): void {
     if (!state.stateDispatchId) throw new Error("Squad state has no owning dispatch stream.");
+    // 每次落盘都带上转换时间:latestActivityAt 的「run 自身活动」来源,也是读面能对
+    // terminal run 过窗的唯一自身时间证据(revise 不写盘,只在写盘点取真实时钟)。
+    const persisted: SquadState = { ...state, updatedAt: new Date().toISOString() };
     ensureSquadRunProjection();
     const projection = input.projection();
     projection.markSquadRunProjectionDirty();
     appendRuntimeWorkerRecord(input.rootDir, state.stateDispatchId, {
       kind: "squad_run_state",
-      squadRunId: state.squadRunId,
-      revision: state.revision,
-      state,
+      squadRunId: persisted.squadRunId,
+      revision: persisted.revision,
+      state: persisted,
     });
-    projection.upsertSquadRun({ squadRunId: state.squadRunId, revision: state.revision, state });
+    projection.upsertSquadRun({ squadRunId: persisted.squadRunId, revision: persisted.revision, state: persisted });
   }
 
   function statusDto(state: SquadState) {
@@ -674,9 +680,14 @@ export function makeSquadCoordinator(input: {
       leaderTurnCount: state.leaderTurns.length,
       workerAttemptCount: state.workerAttempts.length,
       runningCount: sessions.filter((session) => runtimeSessionSemanticState(session) === "running").length,
+      // 活动时间 = 成员会话的最后观测时间 ∪ run 自身最近一次状态落盘时间。只看会话时,
+      // 会话不可解析(未孵化/投影缺行)的 terminal run 会把 reduce 初值 1970 泄漏成
+      // 「从无活动」,导致它在任何 since 窗口恒不可见;以 updatedAt 为初值后,run 自身
+      // 的状态流转就是真实活动时间。
       latestActivityAt: sessions.reduce(
-        (latest, session) => (session.lastObservedAt > latest ? session.lastObservedAt : latest),
-        "1970-01-01T00:00:00.000Z",
+        (latest, session) =>
+          Date.parse(session.lastObservedAt) > Date.parse(latest) ? session.lastObservedAt : latest,
+        state.updatedAt ?? "1970-01-01T00:00:00.000Z",
       ),
     };
   }
@@ -862,6 +873,12 @@ function matchesRunQuery(run: SquadRunSummaryDto, tokens: readonly string[]): bo
 
 function activePhase(phase: SquadRunPhase): boolean {
   return phase === "planning" || phase === "leader_running" || phase === "workers_running";
+}
+
+/** 小队 run 版的活动窗判定,语义对齐 kernel 的 runtimeSessionInActivityWindow:比时间
+ * 瞬值而非字符串,不同毫秒精度/秒精度的 ISO 戳不会因字典序错判进出窗口。 */
+function runInActivityWindow(run: SquadRunSummaryDto, since: string): boolean {
+  return Date.parse(run.latestActivityAt) >= Date.parse(since);
 }
 
 function compareRunSummaries(left: SquadRunSummaryDto, right: SquadRunSummaryDto): number {

--- a/packages/daemon/test/squad-run-list-window.test.ts
+++ b/packages/daemon/test/squad-run-list-window.test.ts
@@ -1,0 +1,270 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { type RuntimeSession, type TaskProjection } from "../../kernel/src/index.ts";
+import { makeSquadCoordinator } from "../src/squad-coordinator.ts";
+import { appendRuntimeWorkerRecord, openDispatchStream } from "../src/dispatch-stream.ts";
+import { validateSquadRunsList } from "../src/squad-run-contract.ts";
+
+// 固定「现在」:窗口断言只看相对时间,不依赖真实时钟。
+const NOW = "2026-08-27T12:00:00.000Z",
+  DAY = 86_400_000,
+  sinceAgo = (ms: number) => new Date(Date.parse(NOW) - ms).toISOString();
+
+type SeedOptions = {
+  readonly squadRunId: string;
+  readonly phase: "planning" | "leader_running" | "workers_running" | "converged" | "failed";
+  readonly updatedAt?: string;
+  readonly leaderSessionId?: string;
+  readonly workerSessionId?: string;
+};
+
+function seedSquadRun(rootDir: string, options: SeedOptions): string {
+  const stateDispatchId = `dispatch_${options.squadRunId.slice(6)}`;
+  openDispatchStream(rootDir, {
+    dispatchId: stateDispatchId,
+    taskId: "task-squad",
+    executionId: "execution-squad",
+    runtimeSessionId: "runtime-owner",
+    instanceId: "instance-squad",
+    startedAt: "2026-08-27T11:00:00.000Z",
+  });
+  appendRuntimeWorkerRecord(rootDir, stateDispatchId, {
+    kind: "squad_run_state",
+    squadRunId: options.squadRunId,
+    revision: 3,
+    state: {
+      schema: "squad-run/v1",
+      squadRunId: options.squadRunId,
+      stateDispatchId,
+      squadId: "core-squad",
+      taskId: "task-squad",
+      runtimeInstanceId: "instance-squad",
+      cwd: rootDir,
+      mission: "window filter witness",
+      model: null,
+      effort: null,
+      leaderAgentId: "terra",
+      roster: "terra -> sol",
+      workers: ["sol"],
+      binding: { actor: { principal: { personId: "person-squad" }, executor: null }, source: "local" },
+      leaderTurns: options.leaderSessionId
+        ? [
+            {
+              turnId: "leader-1",
+              trigger: { kind: "initial" },
+              dispatchId: stateDispatchId,
+              runtimeSessionId: options.leaderSessionId,
+              decision: { kind: "converged" },
+            },
+          ]
+        : [],
+      leaderProviderSessionId: null,
+      currentLeaderRuntimeSessionId: null,
+      workerAttempts: options.workerSessionId
+        ? [
+            {
+              attemptId: "worker-1",
+              workerId: "sol",
+              dispatchId: null,
+              runtimeSessionId: options.workerSessionId,
+              rejection: null,
+            },
+          ]
+        : [],
+      observedWorkerRuntimeSessionIds: [],
+      pendingLeaderTriggers: [],
+      phase: options.phase,
+      revision: 3,
+      error: null,
+      ...(options.updatedAt === undefined ? {} : { updatedAt: options.updatedAt }),
+    },
+  });
+  return stateDispatchId;
+}
+
+function session(runtimeSessionId: string, lastObservedAt: string): RuntimeSession {
+  return {
+    runtimeSessionId,
+    instanceId: "instance-squad",
+    installationId: "installation-squad",
+    kindId: "codex",
+    definitionSnapshotRef: "artifact:runtime-definition/squad",
+    providerSessionId: null,
+    transcriptRef: null,
+    launchGeneration: 1,
+    liveness: "exited",
+    attachable: false,
+    taskBindings: [],
+    outcome: "succeeded",
+    exitCode: 0,
+    resultRef: null,
+    lastObservedAt,
+  };
+}
+
+/** 只给 list/readStates 走到的读面装桩:member 会话按需可解析或恒缺失。 */
+function projectionWith(sessions: readonly RuntimeSession[]): TaskProjection {
+  const rows: { squadRunId: string; revision: number; state: unknown }[] = [];
+  return {
+    readTaskStatuses: () => ({ status: "ready", rows: [], watermark: 1, sourceRevision: 1 }),
+    squadRunProjectionReady: () => rows.length > 0,
+    replaceSquadRuns: (value: typeof rows) => {
+      rows.length = 0;
+      rows.push(...value);
+    },
+    upsertSquadRun: (row: (typeof rows)[number]) => {
+      const known = rows.findIndex((candidate) => candidate.squadRunId === row.squadRunId);
+      if (known >= 0 && rows[known]!.revision > row.revision) return;
+      if (known >= 0) rows[known] = row;
+      else rows.push(row);
+    },
+    markSquadRunProjectionDirty: () => undefined,
+    readSquadRuns: () => rows,
+    readSquadRun: (squadRunId: string) => rows.find((row) => row.squadRunId === squadRunId) ?? null,
+    readRuntimeSession: (runtimeSessionId: string) =>
+      sessions.find((candidate) => candidate.runtimeSessionId === runtimeSessionId) ?? null,
+  } as unknown as TaskProjection;
+}
+
+function coordinator(rootDir: string, sessions: readonly RuntimeSession[]) {
+  const projection = projectionWith(sessions);
+  return {
+    coordinator: makeSquadCoordinator({
+      rootDir,
+      projection: () => projection,
+      store: () => {
+        throw new Error("store is not exercised by the list window");
+      },
+      runtimeSpawner: () => {
+        throw new Error("runtime spawner is not exercised by the list window");
+      },
+    }),
+    projection,
+  };
+}
+
+function withRootDir(use: (rootDir: string) => void): void {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-squad-window-"));
+  try {
+    use(rootDir);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+test("a terminal run whose member sessions are missing still passes a window covering its last state transition", () => {
+  withRootDir((rootDir) => {
+    seedSquadRun(rootDir, {
+      squadRunId: "squad_0123456789abcdef01234567",
+      phase: "converged",
+      updatedAt: "2026-08-27T11:55:00.000Z",
+      leaderSessionId: "runtime-leader",
+      workerSessionId: "runtime-worker",
+    });
+    // 投影里没有任何成员会话行(会话未孵化/已被裁剪):唯一活动证据是 run 自身的状态落盘。
+    const { coordinator: squad } = coordinator(rootDir, []);
+    const listed = squad.list({ since: sinceAgo(DAY) });
+    assert.deepEqual(listed.totals, { runs: 1 });
+    assert.equal(listed.runs[0]?.latestActivityAt, "2026-08-27T11:55:00.000Z");
+    assert.deepEqual(validateSquadRunsList(listed), []);
+  });
+});
+
+test("a terminal run outside the window stays hidden even without member sessions", () => {
+  withRootDir((rootDir) => {
+    seedSquadRun(rootDir, {
+      squadRunId: "squad_0123456789abcdef01234567",
+      phase: "converged",
+      updatedAt: "2026-08-20T11:55:00.000Z",
+    });
+    const { coordinator: squad } = coordinator(rootDir, []);
+    assert.deepEqual(squad.list({ since: sinceAgo(DAY) }).totals, { runs: 0 });
+    assert.deepEqual(squad.list({ since: sinceAgo(30 * DAY) }).totals, { runs: 1 });
+  });
+});
+
+test("member session activity later than the last transition wins as latestActivityAt", () => {
+  withRootDir((rootDir) => {
+    seedSquadRun(rootDir, {
+      squadRunId: "squad_0123456789abcdef01234567",
+      phase: "converged",
+      updatedAt: "2026-08-27T10:00:00.000Z",
+      leaderSessionId: "runtime-leader",
+      workerSessionId: "runtime-worker",
+    });
+    const { coordinator: squad } = coordinator(rootDir, [
+      session("runtime-leader", "2026-08-27T11:50:00.000Z"),
+      session("runtime-worker", "2026-08-27T11:55:00.000Z"),
+    ]);
+    const listed = squad.list({ since: sinceAgo(DAY) });
+    assert.deepEqual(listed.totals, { runs: 1 });
+    assert.equal(listed.runs[0]?.latestActivityAt, "2026-08-27T11:55:00.000Z");
+  });
+});
+
+test("active runs always pass the window and a missing since lists every run", () => {
+  withRootDir((rootDir) => {
+    seedSquadRun(rootDir, {
+      squadRunId: "squad_0123456789abcdef01234567",
+      phase: "workers_running",
+      updatedAt: "2026-08-01T00:00:00.000Z",
+    });
+    seedSquadRun(rootDir, {
+      squadRunId: "squad_0123456789abcdef99887766",
+      phase: "failed",
+      updatedAt: "2026-08-01T00:00:00.000Z",
+    });
+    const { coordinator: squad } = coordinator(rootDir, []);
+    assert.deepEqual(squad.list({ since: sinceAgo(DAY) }).totals, { runs: 1 });
+    assert.deepEqual(squad.list({}).totals, { runs: 2 });
+  });
+});
+
+test("the window compares instants, so a second-precision stamp does not sneak past a millisecond cutoff", () => {
+  withRootDir((rootDir) => {
+    seedSquadRun(rootDir, {
+      squadRunId: "squad_0123456789abcdef01234567",
+      phase: "converged",
+      updatedAt: "2026-08-27T00:00:00Z",
+    });
+    const { coordinator: squad } = coordinator(rootDir, []);
+    // 字典序里 "…00Z" > "…00.000Z"/"…00.500Z"('Z' > '.'),活动在 .000、截点在 .500
+    // 时必须按瞬值判为窗外。
+    assert.deepEqual(squad.list({ since: "2026-08-27T00:00:00.500Z" }).totals, { runs: 0 });
+    assert.deepEqual(squad.list({ since: "2026-08-27T00:00:00.000Z" }).totals, { runs: 1 });
+  });
+});
+
+test("a persisted transition stamps its own activity time", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-squad-window-"));
+  try {
+    seedSquadRun(rootDir, {
+      squadRunId: "squad_0123456789abcdef01234567",
+      phase: "workers_running",
+      workerSessionId: "runtime-worker",
+    });
+    const { coordinator: squad } = coordinator(rootDir, []);
+    const before = Date.now();
+    // observeOutcome 是真实写路径:worker 结算回调 → continueWorker → writeState 落盘。
+    await squad.observeOutcome({
+      schema: "agent-runtime-event/v1",
+      eventId: "event-outcome",
+      workspaceRevision: 4,
+      opId: "op-outcome",
+      actor: { principal: { personId: "person-squad" }, executor: null },
+      source: "local",
+      occurredAt: new Date().toISOString(),
+      type: "runtime_session_outcome_observed",
+      payload: { runtimeSessionId: "runtime-worker", outcome: "succeeded", exitCode: 0, resultRef: null },
+    } as Parameters<typeof squad.observeOutcome>[0]);
+    const stamp = squad.list({}).runs[0]?.latestActivityAt;
+    assert.notEqual(stamp, "1970-01-01T00:00:00.000Z");
+    assert.ok(stamp !== undefined && Date.parse(stamp) >= before, `transition stamp ${stamp} predates the write`);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
# English

## Summary

G13 follow-up: a terminal squad run whose member sessions cannot be resolved in the projection got `latestActivityAt = 1970-01-01` (the reduce seed leaked), so it was invisible in every activity window. Squad state now records `updatedAt` on every write and the summary seeds activity from it; the list window compares instants (`Date.parse`) like the kernel session window instead of ISO strings. The GUI 30d default stays: the CEO's premise that it merely masked this defect was refuted with data (the epoch value is invisible under 30d too, and the runs seen empty under 24h genuinely had no activity in 24h).

## Architectural Justification

- Not required: Production-Delta churn is below 200 lines.

## What Changed

- `packages/daemon/src/squad-coordinator.ts` (+24/-7): `SquadState.updatedAt` written on every `writeState`; summary seeds `latestActivityAt` from it; `runInActivityWindow` uses instants.
- `packages/daemon/test/squad-run-list-window.test.ts` (new, fast): 6 cases, incl. reverting the fix turns the first red.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +24/-7

### Optional Evidence Claims

## Task And Scope

- Harness task: task_94d8cc2ad57e54b22f3b1fb4bb
- Branch: codex/g13-since-filter
- Public scope: packages/daemon/src/squad-coordinator.ts and its new test
- Private planning/evidence updated: yes
- Out of scope: GUI sessions view default range (kept at 30d, product decision unchanged)

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_94d8cc2ad57e54b22f3b1fb4bb
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 1cb9a075d5c77e1f9549be9548e45e4fdcf4a339
- Branch merge-base with `origin/main`: 1cb9a075d5c77e1f9549be9548e45e4fdcf4a339
- Last `git fetch origin` time: 2026-08-26T22:15:08Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_94d8cc2ad57e54b22f3b1fb4bb (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] New fast test 6/6; typecheck; line-density in the worktree
- [x] CEO read the root cause and accepted the worker's objection on the GUI default
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO wrote the task plan with a wrong premise (daemon filter made 24h empty); the worker refuted it with G12's recorded data and fixed the real defect instead.
- Reviewer subagent: GLM-5.3 worker; CEO diff read.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Old persisted squad states have no `updatedAt`; they keep the epoch seed until their next write (same visibility as before, no regression).

## References

- Task: task_94d8cc2ad57e54b22f3b1fb4bb
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

G13 后续:成员会话在投影里解析不到的 terminal squad run,其 `latestActivityAt` 落成 `1970-01-01`(reduce 初值泄漏),于是在任何活动窗口都不可见。squad 状态每次落盘记 `updatedAt`,summary 以它为活动初值;列表窗口改用瞬值比较(`Date.parse`),与 kernel 会话窗一致,不再比 ISO 字符串。GUI 30d 默认保留:CEO「它只是在掩盖 daemon 缺陷」的前提被数据证伪(epoch 值在 30d 下同样不可见;24h 下为空的那些 run 在 24h 内确实没有活动)。

## 架构辩护

- 不需要:Production-Delta churn 低于 200 行。

## 改动内容

- `packages/daemon/src/squad-coordinator.ts`(+24/-7):`SquadState.updatedAt` 每次 `writeState` 写入;summary 以它为 `latestActivityAt` 初值;`runInActivityWindow` 用瞬值。
- `packages/daemon/test/squad-run-list-window.test.ts`(新,fast):6 用例,回退修复第一条即红。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_94d8cc2ad57e54b22f3b1fb4bb
- 分支:codex/g13-since-filter
- 公开范围:packages/daemon/src/squad-coordinator.ts 与新测试
- 私有计划 / 证据是否已更新:yes
- 范围外:GUI 会话页默认范围(保持 30d,产品决策不变)

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_94d8cc2ad57e54b22f3b1fb4bb
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:1cb9a075d5c77e1f9549be9548e45e4fdcf4a339
- 当前分支与 `origin/main` 的 merge-base:1cb9a075d5c77e1f9549be9548e45e4fdcf4a339
- 最近一次 `git fetch origin` 时间:2026-08-26T22:15:08Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_94d8cc2ad57e54b22f3b1fb4bb
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] 新 fast 测试 6/6;typecheck;worktree 内 line-density
- [x] CEO 读根因,接受 worker 关于 GUI 默认值的异议
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 写 plan 时前提有误(daemon 过滤让 24h 恒空);worker 用 G12 记录的数据证伪并改修真实缺陷。
- Reviewer subagent:GLM-5.3 worker;CEO 读 diff。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 旧的持久化 squad state 没有 `updatedAt`,下次写入前仍用 epoch 初值(可见性同修复前,无回归)。

## 关联材料

- 任务:task_94d8cc2ad57e54b22f3b1fb4bb
- 证据:任务包 artifacts/reports
- 审查:本 PR
