### PR TITLE
fix(daemon): settle the task lease before publishing the runtime outcome

### DIFF
--- a/packages/daemon/src/runtime-spawn-settlement.ts
+++ b/packages/daemon/src/runtime-spawn-settlement.ts
@@ -138,20 +138,6 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
       `${active.dispatchOpId}-exited`,
       eventBinding,
     );
-    const outcomeEvent = await context.publishRuntimeEvent(
-      "runtime_session_outcome_observed",
-      {
-        runtimeSessionId: active.runtimeSessionId,
-        outcome,
-        exitCode: cancelled ? null : code,
-        resultRef,
-        result,
-      },
-      `${active.dispatchOpId}-outcome`,
-      eventBinding,
-      body,
-    );
-    context.input.onRuntimeOutcome?.(outcomeEvent.event, active.schedule);
     const notification =
       active.onExitCommand === null
         ? null
@@ -180,6 +166,20 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
       resultRef,
       binding: active.binding,
     });
+    const outcomeEvent = await context.publishRuntimeEvent(
+      "runtime_session_outcome_observed",
+      {
+        runtimeSessionId: active.runtimeSessionId,
+        outcome,
+        exitCode: cancelled ? null : code,
+        resultRef,
+        result,
+      },
+      `${active.dispatchOpId}-outcome`,
+      eventBinding,
+      body,
+    );
+    context.input.onRuntimeOutcome?.(outcomeEvent.event, active.schedule);
     if (notification) setImmediate(() => context.launchExitNotification({ ...notification, now: context.input.now }));
   } finally {
     context.exiting.delete(active.runtimeSessionId);

--- a/packages/daemon/test/lease-reservation.integration.test.ts
+++ b/packages/daemon/test/lease-reservation.integration.test.ts
@@ -145,10 +145,10 @@ test("task-bound spawn exit keeps its released execution visible after a v7 cach
       sequence = events.map((event) => event.type),
       started = sequence.indexOf("execution_started"),
       bound = sequence.indexOf("runtime_session_task_bound"),
-      exited = sequence.indexOf("runtime_session_outcome_observed"),
-      release = sequence.indexOf("lease_released");
+      release = sequence.indexOf("lease_released"),
+      outcome = sequence.indexOf("runtime_session_outcome_observed");
     assert.ok(started >= 0 && started < bound, sequence.join(" -> "));
-    assert.ok(bound < exited && exited < release, sequence.join(" -> "));
+    assert.ok(bound < release && release < outcome, sequence.join(" -> "));
 
     const rebuilt = new DatabaseSync(cache, { readOnly: true }),
       version = rebuilt.prepare("SELECT schema_version FROM projection_meta WHERE singleton = 1").get() as {

--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -356,7 +356,7 @@ test("runtime spawn publishes a canonical session and makes it visible in overvi
   }
 });
 
-test("attached task runtime settlement consumes its durable tail and releases its execution lease", async () => {
+test("attached task runtime settlement releases its execution lease before publishing the terminal outcome", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-runtime-attached-tail-"));
   let exit: ((code: number | null) => void) | null = null;
   try {
@@ -486,7 +486,19 @@ test("attached task runtime settlement consumes its durable tail and releases it
           )
         );
       });
-      const projection = makeTaskProjection({
+      const events = makeTaskEventStore({ repoId: "runtime-attached-tail", rootDir: root }).read().events,
+        outcomeIndex = events.findIndex(
+          (event) =>
+            event.type === "runtime_session_outcome_observed" &&
+            event.payload.runtimeSessionId === receipt.runtimeSessionId,
+        ),
+        releaseIndex = events.findIndex(
+          (event) =>
+            event.type === "lease_released" &&
+            event.taskId === taskId &&
+            event.payload.execution.executionId === executionId,
+        ),
+        projection = makeTaskProjection({
           rootDir: root,
           eventStore: makeTaskEventStore({ repoId: "runtime-attached-tail", rootDir: root }),
         }),
@@ -501,6 +513,7 @@ test("attached task runtime settlement consumes its durable tail and releases it
         },
         { liveness: "exited", outcome: "succeeded", exitCode: 0 },
       );
+      assert.ok(releaseIndex < outcomeIndex, "terminal outcome must not become visible before lease release");
       assert.equal(taskSnapshot.lease, null, "terminal RuntimeSession settlement must release the execution lease");
     } finally {
       await cell.close();


### PR DESCRIPTION
# English

## Summary

Fix for the main flake introduced by 0.35 (#1886): the runtime terminal path published `runtime_session_outcome_observed` before the task lease settlement had been appended, so a CLI batch that reacquires a lease as soon as the outcome is visible could hit `invalid_transition` (`runtime-cli.integration` red on Node 26 full-check and on a merge-queue draft). The settlement (`lease_released`) is now awaited before the outcome is published — one ordering invariant at the source; no CLI polling, retry or sleep. Net production delta 0 (the 14-line publish block moved).

## Architectural Justification

- Not required: Production-Delta churn is below 200 lines.

## What Changed

- `packages/daemon/src/runtime-spawn-settlement.ts:158`: await terminal settlement before publishing the outcome.
- `packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts:359`: asserts `lease_released` precedes the terminal outcome (fails on the pre-fix ordering).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +14/-14

### Optional Evidence Claims

## Task And Scope

- Harness task: task_e934154e856565558594c6ccde
- Branch: codex/lease-reacquire-race
- Public scope: packages/daemon/src/runtime-spawn-settlement.ts and its lifecycle test
- Private planning/evidence updated: yes
- Out of scope: CLI batch reacquisition logic (unchanged from #1886)

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_e934154e856565558594c6ccde
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: f016835814c2d44f9f9722d15707fd936f8c9867
- Branch merge-base with `origin/main`: f016835814c2d44f9f9722d15707fd936f8c9867
- Last `git fetch origin` time: 2026-08-26T23:44:29Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_e934154e856565558594c6ccde (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Pre-fix negative control 4 pass / 1 expected fail; post-fix lifecycle 5/5, runtime-cli.integration 1/1, cli-runtime-batch 1/1, provider-fallback 2/2, lease-reservation-reclaim 6/6 (Docker isolated)
- [x] implementation-contracts, line-density
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: repeated CI runs to measure the flake rate; CI is the authority.

## Review Evidence

- Self-review: CEO diagnosed the race from the main failure (outcome visible before lease_released) and read the diff.
- Reviewer subagent: Codex worker (gpt-5.6-sol); CEO diff read.
- Human review: pending
- Blocking findings: none

## Residual Risk

- If terminal lease settlement fails, the outcome stays unpublished; the failure is currently swallowed by `repo-cell-open.ts` (`pending.then(kick, kick)`) and `cli-runtime-wait.ts` polls without a deadline, so `ha runtime status --wait` would hang without a diagnostic. That swallow + missing deadline is a pre-existing defect made reachable by this ordering; filed as task_cd54c060b13573616503c4aec2 (fix by removing the swallow, not by adding a fallback).

## References

- Task: task_e934154e856565558594c6ccde
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

修 0.35(#1886)引入的 main flake:runtime 终态路径在 task lease 结算落盘之前就发布了 `runtime_session_outcome_observed`,于是 CLI batch 在 outcome 可见后立即重取 lease 会撞 `invalid_transition`(`runtime-cli.integration` 在 Node 26 全量与一次队列草稿上红)。现在先 await 结算(`lease_released`)再发布 outcome——在源头立一条顺序不变量;CLI 侧不加轮询/重试/sleep。生产净行数 0(14 行发布块移位)。

## 架构辩护

- 不需要:Production-Delta churn 低于 200 行。

## 改动内容

- `packages/daemon/src/runtime-spawn-settlement.ts:158`:先 await 终态结算再发布 outcome。
- `packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts:359`:断言 `lease_released` 早于终态 outcome(修复前红)。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_e934154e856565558594c6ccde
- 分支:codex/lease-reacquire-race
- 公开范围:packages/daemon/src/runtime-spawn-settlement.ts 及其生命周期测试
- 私有计划 / 证据是否已更新:yes
- 范围外:CLI batch 重取逻辑(与 #1886 相同,不动)

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_e934154e856565558594c6ccde
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:f016835814c2d44f9f9722d15707fd936f8c9867
- 当前分支与 `origin/main` 的 merge-base:f016835814c2d44f9f9722d15707fd936f8c9867
- 最近一次 `git fetch origin` 时间:2026-08-26T23:44:29Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_e934154e856565558594c6ccde
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] 修复前阴性对照 4 过 / 1 预期红;修复后 lifecycle 5/5、runtime-cli.integration 1/1、cli-runtime-batch 1/1、provider-fallback 2/2、lease-reservation-reclaim 6/6(Docker 隔离)
- [x] implementation-contracts、line-density
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:重复跑 CI 测 flake 率;以 CI 为权威。

## 审查证据

- 自查:CEO 从 main 失败诊断出竞态(outcome 先于 lease_released 可见)并读 diff。
- Reviewer subagent:Codex worker(gpt-5.6-sol);CEO 读 diff。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 若终态 lease 结算失败,outcome 保持未发布;该失败目前被 `repo-cell-open.ts` 的 `pending.then(kick, kick)` 静默吞掉,且 `cli-runtime-wait.ts` 轮询无 deadline,`ha runtime status --wait` 会无诊断挂死。这是本顺序变更让其可达的既有缺陷,已立项 task_cd54c060b13573616503c4aec2(修法是删除吞错,不加兜底)。

## 关联材料

- 任务:task_e934154e856565558594c6ccde
- 证据:任务包 artifacts/reports
- 审查:本 PR

