### PR TITLE
refactor(daemon): derive squad run activity from dispatch facts (review #6 item 2)

### DIFF
--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -182,8 +182,10 @@ export function makeSquadCoordinator(input: {
   const list = (payload: Readonly<Record<string, unknown>>): SquadRunsListResult => {
     const query = listQuery(payload),
       cut = input.projection().readTaskStatuses([]),
+      // 一次 list 内按 taskId memo 派工台账读:同 task 的多个 run 共享一次读,读放大按 task 数结算。
+      dispatchesByTaskId = new Map<string, readonly TaskDispatchRow[]>(),
       matching = readStates()
-        .map(summaryDto)
+        .map((state) => summaryDto(state, dispatchesByTaskId))
         .filter((run) => activePhase(run.phase) || query.since === null || runInActivityWindow(run, query.since))
         .filter((run) => matchesRunQuery(run, query.tokens))
         .sort(compareRunSummaries),
@@ -516,6 +518,26 @@ export function makeSquadCoordinator(input: {
     }).dispatches;
   }
 
+  /** list 专用:同 task 的多个 run 共享一次台账读(per-call memo,不跨 list 复用);单个
+   * run 的事实缺失(投影缺包路径)只降级自己的活动时间(可解析会话/无活动),不拖垮整页
+   * list。status/read 面对同一坏数据仍 fail-closed。 */
+  function summaryDispatchRows(
+    state: SquadState,
+    cache: Map<string, readonly TaskDispatchRow[]>,
+  ): readonly TaskDispatchRow[] {
+    const memoized = cache.get(state.taskId);
+    if (memoized !== undefined) return memoized;
+    let rows: readonly TaskDispatchRow[];
+    try {
+      rows = dispatchRows(state);
+    } catch (error) {
+      consumeKnownError(error); // 台账读不出:该 run 无派工事实。
+      rows = [];
+    }
+    cache.set(state.taskId, rows);
+    return rows;
+  }
+
   function terminalRow(state: SquadState, runtimeSessionId: string): TaskDispatchRow | undefined {
     return dispatchRows(state).find((row) => row.runtimeSessionId === runtimeSessionId && row.outcome !== null);
   }
@@ -661,8 +683,11 @@ export function makeSquadCoordinator(input: {
     };
   }
 
-  function summaryDto(state: SquadState): SquadRunSummaryDto {
-    const byDispatchId = new Map(dispatchRows(state).map((row) => [row.dispatchId, row])),
+  function summaryDto(
+    state: SquadState,
+    dispatchesByTaskId: Map<string, readonly TaskDispatchRow[]>,
+  ): SquadRunSummaryDto {
+    const byDispatchId = new Map(summaryDispatchRows(state, dispatchesByTaskId).map((row) => [row.dispatchId, row])),
       sessions = [
         ...state.leaderTurns.map((turn) => turn.runtimeSessionId),
         ...state.workerAttempts.flatMap((attempt) => (attempt.runtimeSessionId ? [attempt.runtimeSessionId] : [])),

--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -85,8 +85,6 @@ type SquadState = {
   readonly phase: SquadRunPhase;
   readonly revision: number;
   readonly error: string | null;
-  /** 最近一次状态落盘时间(writeState 写入);早于该字段的持久化状态为 null。 */
-  readonly updatedAt: string | null;
 };
 
 type RuntimeOutcomeEvent = Extract<AgentRuntimeEventV1, { readonly type: "runtime_session_outcome_observed" }>;
@@ -136,7 +134,6 @@ export function makeSquadCoordinator(input: {
         phase: "planning",
         revision: 0,
         error: null,
-        updatedAt: null,
       };
     try {
       const running = await spawnLeader(state, { kind: "initial" });
@@ -576,19 +573,16 @@ export function makeSquadCoordinator(input: {
 
   function writeState(state: SquadState): void {
     if (!state.stateDispatchId) throw new Error("Squad state has no owning dispatch stream.");
-    // 每次落盘都带上转换时间:latestActivityAt 的「run 自身活动」来源,也是读面能对
-    // terminal run 过窗的唯一自身时间证据(revise 不写盘,只在写盘点取真实时钟)。
-    const persisted: SquadState = { ...state, updatedAt: new Date().toISOString() };
     ensureSquadRunProjection();
     const projection = input.projection();
     projection.markSquadRunProjectionDirty();
     appendRuntimeWorkerRecord(input.rootDir, state.stateDispatchId, {
       kind: "squad_run_state",
-      squadRunId: persisted.squadRunId,
-      revision: persisted.revision,
-      state: persisted,
+      squadRunId: state.squadRunId,
+      revision: state.revision,
+      state,
     });
-    projection.upsertSquadRun({ squadRunId: persisted.squadRunId, revision: persisted.revision, state: persisted });
+    projection.upsertSquadRun({ squadRunId: state.squadRunId, revision: state.revision, state });
   }
 
   function statusDto(state: SquadState) {
@@ -668,12 +662,13 @@ export function makeSquadCoordinator(input: {
   }
 
   function summaryDto(state: SquadState): SquadRunSummaryDto {
-    const sessions = [
-      ...state.leaderTurns.map((turn) => turn.runtimeSessionId),
-      ...state.workerAttempts.flatMap((attempt) => (attempt.runtimeSessionId ? [attempt.runtimeSessionId] : [])),
-    ]
-      .map((runtimeSessionId) => input.projection().readRuntimeSession(runtimeSessionId))
-      .filter((session) => session !== null);
+    const byDispatchId = new Map(dispatchRows(state).map((row) => [row.dispatchId, row])),
+      sessions = [
+        ...state.leaderTurns.map((turn) => turn.runtimeSessionId),
+        ...state.workerAttempts.flatMap((attempt) => (attempt.runtimeSessionId ? [attempt.runtimeSessionId] : [])),
+      ]
+        .map((runtimeSessionId) => input.projection().readRuntimeSession(runtimeSessionId))
+        .filter((session) => session !== null);
     return {
       squadRunId: state.squadRunId,
       squadId: state.squadId,
@@ -683,14 +678,14 @@ export function makeSquadCoordinator(input: {
       leaderTurnCount: state.leaderTurns.length,
       workerAttemptCount: state.workerAttempts.length,
       runningCount: sessions.filter((session) => runtimeSessionSemanticState(session) === "running").length,
-      // 活动时间 = 成员会话的最后观测时间 ∪ run 自身最近一次状态落盘时间。只看会话时,
-      // 会话不可解析(未孵化/投影缺行)的 terminal run 会把 reduce 初值 1970 泄漏成
-      // 「从无活动」,导致它在任何 since 窗口恒不可见;以 updatedAt 为初值后,run 自身
-      // 的状态流转就是真实活动时间。
-      latestActivityAt: sessions.reduce(
-        (latest, session) =>
-          Date.parse(session.lastObservedAt) > Date.parse(latest) ? session.lastObservedAt : latest,
-        state.updatedAt ?? "1970-01-01T00:00:00.000Z",
+      // 活动时间只从已落盘事实按瞬值取 max:run 自有派工台账行(startedAt 恒有、归档另有 endedAt)∪ 成员会话最后观测时间;epoch 仅是空集的 max 恒等元,不是读取兜底。
+      latestActivityAt: [
+        ...state.leaderTurns.flatMap((turn) => dispatchRowStamps(byDispatchId.get(turn.dispatchId))),
+        ...state.workerAttempts.flatMap((attempt) => dispatchRowStamps(byDispatchId.get(attempt.dispatchId ?? ""))),
+        ...sessions.map((session) => session.lastObservedAt),
+      ].reduce(
+        (latest, stamp) => (Date.parse(stamp) > Date.parse(latest) ? stamp : latest),
+        "1970-01-01T00:00:00.000Z",
       ),
     };
   }
@@ -884,11 +879,16 @@ function runInActivityWindow(run: SquadRunSummaryDto, since: string): boolean {
   return Date.parse(run.latestActivityAt) >= Date.parse(since);
 }
 
+/** 派工台账行的已落盘时间事实:startedAt 恒有,endedAt 仅归档结算行有;无台账行的派工不贡献时间。 */
+function dispatchRowStamps(row: TaskDispatchRow | undefined): readonly string[] {
+  return row === undefined ? [] : [row.startedAt, ...(row.endedAt === null ? [] : [row.endedAt])];
+}
+
 function compareRunSummaries(left: SquadRunSummaryDto, right: SquadRunSummaryDto): number {
   const active = Number(activePhase(right.phase)) - Number(activePhase(left.phase));
   return (
     active ||
-    right.latestActivityAt.localeCompare(left.latestActivityAt) ||
+    Date.parse(right.latestActivityAt) - Date.parse(left.latestActivityAt) ||
     left.squadRunId.localeCompare(right.squadRunId)
   );
 }

--- a/packages/daemon/test/squad-run-list-window.test.ts
+++ b/packages/daemon/test/squad-run-list-window.test.ts
@@ -27,16 +27,18 @@ type SeedOptions = {
   readonly phase: "planning" | "leader_running" | "workers_running" | "converged" | "failed";
   readonly leader: DispatchFact;
   readonly worker?: DispatchFact;
+  readonly taskId?: string;
 };
 
 /** 与 production writeState 同构地种一个 run:squad_run_state 记录落在 leader 初始派工
  * 流里(状态流 = 首个 leader 派工流),leader/worker 派工流按各自 startedAt 落盘。 */
 function seedSquadRun(rootDir: string, options: SeedOptions): void {
+  const taskId = options.taskId ?? "task-squad";
   for (const fact of [options.leader, options.worker])
     if (fact)
       openDispatchStream(rootDir, {
         dispatchId: fact.dispatchId,
-        taskId: "task-squad",
+        taskId,
         executionId: "execution-squad",
         runtimeSessionId: fact.runtimeSessionId,
         instanceId: "instance-squad",
@@ -51,7 +53,7 @@ function seedSquadRun(rootDir: string, options: SeedOptions): void {
       squadRunId: options.squadRunId,
       stateDispatchId: options.leader.dispatchId,
       squadId: "core-squad",
-      taskId: "task-squad",
+      taskId,
       runtimeInstanceId: "instance-squad",
       cwd: rootDir,
       mission: "window filter witness",
@@ -93,11 +95,14 @@ function seedSquadRun(rootDir: string, options: SeedOptions): void {
 }
 
 /** 归档结算文档(dispatch-read archiveRow 的来源):endedAt 事实只从这条来。 */
-function archiveDoc(fact: DispatchFact & { readonly endedAt: string }): Record<string, unknown> {
+function archiveDoc(
+  fact: DispatchFact & { readonly endedAt: string },
+  taskId: string = "task-squad",
+): Record<string, unknown> {
   return {
     schema: "runtime-dispatch/v1",
     dispatchId: fact.dispatchId,
-    taskId: "task-squad",
+    taskId,
     executionId: "execution-squad",
     runtimeSessionId: fact.runtimeSessionId,
     instanceId: "instance-squad",
@@ -127,26 +132,33 @@ function session(runtimeSessionId: string, lastObservedAt: string): RuntimeSessi
 }
 
 /** 只给 list/readStates 走到的读面装桩:成员会话按需可解析或恒缺失;派工台账行来自
- * 真实派工流 + live index(startedAt),归档结算行(endedAt)按 dispatchId 呈现。 */
+ * 真实派工流 + live index(startedAt),归档结算行(endedAt)按 dispatchId 呈现。
+ * packagePathFor 允许把个别 task 的包路径投成 null(readTaskDispatches 对单 task 查询
+ * 缺包路径即抛,生产投影里 task 无包路径的形态);batchCalls 记录台账读的批量批读。 */
 function projectionWith(
   sessions: readonly RuntimeSession[],
   archives: ReadonlyMap<string, Record<string, unknown>> = new Map(),
-): TaskProjection {
-  const rows: { squadRunId: string; revision: number; state: unknown }[] = [];
+  packagePathFor: (taskId: string) => string | null = (taskId) => `tasks/${taskId}`,
+): TaskProjection & { readonly batchCalls: readonly (readonly string[])[] } {
+  const rows: { squadRunId: string; revision: number; state: unknown }[] = [],
+    batchCalls: (readonly string[])[] = [];
   return {
     readTaskStatuses: () => ({ status: "ready", rows: [], watermark: 1, sourceRevision: 1 }),
-    readTaskRuntimeBatch: (query: { readonly taskIds: readonly string[] }) => ({
-      status: "ready" as const,
-      taskIds: query.taskIds,
-      rows: query.taskIds.map((taskId) => ({
-        taskId,
-        title: "Squad window witness",
-        packagePath: `tasks/${taskId}`,
-        sessions: [],
-      })),
-      watermark: 1,
-      sourceRevision: 1,
-    }),
+    readTaskRuntimeBatch: (query: { readonly taskIds: readonly string[] }) => {
+      batchCalls.push(query.taskIds);
+      return {
+        status: "ready" as const,
+        taskIds: query.taskIds,
+        rows: query.taskIds.map((taskId) => ({
+          taskId,
+          title: "Squad window witness",
+          packagePath: packagePathFor(taskId),
+          sessions: [],
+        })),
+        watermark: 1,
+        sourceRevision: 1,
+      };
+    },
     readDocument: (documentPath: string) => {
       const archive = archives.get(/dispatch_[a-f0-9]{24}/u.exec(documentPath)?.[0] ?? "");
       return {
@@ -172,15 +184,17 @@ function projectionWith(
     readSquadRun: (squadRunId: string) => rows.find((row) => row.squadRunId === squadRunId) ?? null,
     readRuntimeSession: (runtimeSessionId: string) =>
       sessions.find((candidate) => candidate.runtimeSessionId === runtimeSessionId) ?? null,
-  } as unknown as TaskProjection;
+    batchCalls,
+  } as unknown as TaskProjection & { readonly batchCalls: readonly (readonly string[])[] };
 }
 
 function coordinator(
   rootDir: string,
   sessions: readonly RuntimeSession[],
   archives: ReadonlyMap<string, Record<string, unknown>> = new Map(),
+  packagePathFor?: (taskId: string) => string | null,
 ) {
-  const projection = projectionWith(sessions, archives);
+  const projection = projectionWith(sessions, archives, packagePathFor ?? ((taskId) => `tasks/${taskId}`));
   return {
     coordinator: makeSquadCoordinator({
       rootDir,
@@ -387,4 +401,158 @@ test("the real write path keeps deriving activity from dispatch facts, not a per
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }
+});
+
+test("a run whose task has no projected package path degrades alone instead of failing the list", () => {
+  withRootDir((rootDir) => {
+    const worker = {
+      dispatchId: "dispatch_00000000000000000000b2c3",
+      runtimeSessionId: "runtime-worker",
+      startedAt: "2026-08-27T11:30:00.000Z",
+      endedAt: "2026-08-27T11:55:00.000Z",
+    };
+    seedSquadRun(rootDir, {
+      squadRunId: "squad_0123456789abcdef01234567",
+      phase: "converged",
+      leader: {
+        dispatchId: "dispatch_00000000000000000000a1b2",
+        runtimeSessionId: "runtime-leader",
+        startedAt: "2026-08-27T11:00:00.000Z",
+      },
+      worker,
+    });
+    seedSquadRun(rootDir, {
+      squadRunId: "squad_0123456789abcdef99887766",
+      phase: "converged",
+      taskId: "task-no-package",
+      leader: {
+        dispatchId: "dispatch_00000000000000000000e5f6",
+        runtimeSessionId: "runtime-leader-broken",
+        startedAt: "2026-08-27T11:40:00.000Z",
+      },
+    });
+    const { coordinator: squad } = coordinator(
+      rootDir,
+      [],
+      new Map([[worker.dispatchId, archiveDoc(worker)]]),
+      (taskId) => (taskId === "task-no-package" ? null : `tasks/${taskId}`),
+    );
+    // 坏 run 的派工台账读会抛(投影缺包路径):list 不整页报错,只把该 run 的活动时间
+    // 退化为无活动;好 run 的派工事实照常进入派生。
+    const listed = squad.list({});
+    assert.deepEqual(listed.totals, { runs: 2 });
+    assert.deepEqual(
+      Object.fromEntries(listed.runs.map(({ squadRunId, latestActivityAt }) => [squadRunId, latestActivityAt])),
+      {
+        squad_0123456789abcdef01234567: "2026-08-27T11:55:00.000Z",
+        squad_0123456789abcdef99887766: "1970-01-01T00:00:00.000Z",
+      },
+    );
+    assert.deepEqual(validateSquadRunsList(listed), []);
+    // 无活动的 terminal run 在窗口内不可见,但不影响好 run 过窗。
+    assert.deepEqual(squad.list({ since: sinceAgo(DAY) }).totals, { runs: 1 });
+  });
+});
+
+test("a package-path-less run falls back to its resolvable member sessions for activity", () => {
+  withRootDir((rootDir) => {
+    seedSquadRun(rootDir, {
+      squadRunId: "squad_0123456789abcdef99887766",
+      phase: "converged",
+      taskId: "task-no-package",
+      leader: {
+        dispatchId: "dispatch_00000000000000000000e5f6",
+        runtimeSessionId: "runtime-leader-broken",
+        startedAt: "2026-08-27T11:00:00.000Z",
+      },
+    });
+    const { coordinator: squad } = coordinator(
+      rootDir,
+      [session("runtime-leader-broken", "2026-08-27T11:44:00.000Z")],
+      new Map(),
+      (taskId) => (taskId === "task-no-package" ? null : `tasks/${taskId}`),
+    );
+    // 台账读失败后,该 run 的活动时间退化为可解析会话的 lastObservedAt。
+    const listed = squad.list({ since: sinceAgo(DAY) });
+    assert.deepEqual(listed.totals, { runs: 1 });
+    assert.equal(listed.runs[0]?.latestActivityAt, "2026-08-27T11:44:00.000Z");
+  });
+});
+
+test("one list reads the dispatch ledger once per task, not once per run", () => {
+  withRootDir((rootDir) => {
+    for (const [squadRunId, suffix] of [
+      ["squad_0123456789abcdef01234567", "a1b2"],
+      ["squad_0123456789abcdef99887766", "c3d4"],
+      ["squad_0123456789abcdef55554444", "e5f6"],
+    ] as const) {
+      seedSquadRun(rootDir, {
+        squadRunId,
+        phase: "converged",
+        leader: {
+          dispatchId: `dispatch_00000000000000000000${suffix}`,
+          runtimeSessionId: `runtime-leader-${suffix}`,
+          startedAt: "2026-08-27T11:00:00.000Z",
+        },
+      });
+    }
+    const { coordinator: squad, projection } = coordinator(rootDir, []);
+    squad.list({});
+    // 同一 task 的多个 run 共享一次台账读:批量批读按 task 数结算,不随 run 数放大。
+    assert.deepEqual(projection.batchCalls, [["task-squad"]]);
+    // memo 只在单次 list 内生效:下一次 list 重新读,不吞掉两次 list 之间新落盘的事实。
+    squad.list({});
+    assert.deepEqual(projection.batchCalls, [["task-squad"], ["task-squad"]]);
+  });
+});
+
+test("a terminal run whose only activity fact is the leader dispatch passes the window", () => {
+  withRootDir((rootDir) => {
+    seedSquadRun(rootDir, {
+      squadRunId: "squad_0123456789abcdef01234567",
+      phase: "converged",
+      leader: {
+        dispatchId: "dispatch_00000000000000000000a1b2",
+        runtimeSessionId: "runtime-leader",
+        startedAt: "2026-08-27T10:00:00.000Z",
+      },
+    });
+    const { coordinator: squad } = coordinator(rootDir, []);
+    // 定点对照(派生去掉派工事实 → 红):无会话、无归档,窗口内可见的唯一证据是台账行
+    // 的 startedAt;派生若只剩会话,该 run 退化为 epoch 并在窗口内消失。
+    const listed = squad.list({ since: sinceAgo(DAY) });
+    assert.deepEqual(listed.totals, { runs: 1 });
+    assert.equal(listed.runs[0]?.latestActivityAt, "2026-08-27T10:00:00.000Z");
+  });
+});
+
+test("the summary ordering compares instants; a lexicographic stamp comparison would flip it", () => {
+  withRootDir((rootDir) => {
+    seedSquadRun(rootDir, {
+      squadRunId: "squad_0123456789abcdef01234fff",
+      phase: "converged",
+      leader: {
+        dispatchId: "dispatch_00000000000000000000a1b2",
+        runtimeSessionId: "runtime-leader-a",
+        startedAt: "2026-08-27T11:00:00.500Z",
+      },
+    });
+    seedSquadRun(rootDir, {
+      squadRunId: "squad_0123456789abcdef01234000",
+      phase: "converged",
+      leader: {
+        dispatchId: "dispatch_00000000000000000000c3d4",
+        runtimeSessionId: "runtime-leader-b",
+        startedAt: "2026-08-27T11:00:00Z",
+      },
+    });
+    const { coordinator: squad } = coordinator(rootDir, []);
+    // 定点对照(排序回退字典序 → 红):唯一活动事实分别是裸秒戳 "…00Z" 与 "…00.500Z",
+    // 字典序里 "…00Z" 更大('Z' > '.'),降序会先列秒精度 run;排序若把两者判等,
+    // squadRunId 兜底(升序)同样先列它(.500 run 的 id 故意取大,排除兜底碰对)。
+    assert.deepEqual(
+      squad.list({}).runs.map(({ squadRunId }) => squadRunId),
+      ["squad_0123456789abcdef01234fff", "squad_0123456789abcdef01234000"],
+    );
+  });
 });

--- a/packages/daemon/test/squad-run-list-window.test.ts
+++ b/packages/daemon/test/squad-run-list-window.test.ts
@@ -14,32 +14,42 @@ const NOW = "2026-08-27T12:00:00.000Z",
   DAY = 86_400_000,
   sinceAgo = (ms: number) => new Date(Date.parse(NOW) - ms).toISOString();
 
+/** 一条已落盘的派工事实:流头部 startedAt 恒有;归档结算行的 endedAt 按需补。 */
+type DispatchFact = {
+  readonly dispatchId: string;
+  readonly runtimeSessionId: string;
+  readonly startedAt: string;
+  readonly endedAt?: string;
+};
+
 type SeedOptions = {
   readonly squadRunId: string;
   readonly phase: "planning" | "leader_running" | "workers_running" | "converged" | "failed";
-  readonly updatedAt?: string;
-  readonly leaderSessionId?: string;
-  readonly workerSessionId?: string;
+  readonly leader: DispatchFact;
+  readonly worker?: DispatchFact;
 };
 
-function seedSquadRun(rootDir: string, options: SeedOptions): string {
-  const stateDispatchId = `dispatch_${options.squadRunId.slice(6)}`;
-  openDispatchStream(rootDir, {
-    dispatchId: stateDispatchId,
-    taskId: "task-squad",
-    executionId: "execution-squad",
-    runtimeSessionId: "runtime-owner",
-    instanceId: "instance-squad",
-    startedAt: "2026-08-27T11:00:00.000Z",
-  });
-  appendRuntimeWorkerRecord(rootDir, stateDispatchId, {
+/** 与 production writeState 同构地种一个 run:squad_run_state 记录落在 leader 初始派工
+ * 流里(状态流 = 首个 leader 派工流),leader/worker 派工流按各自 startedAt 落盘。 */
+function seedSquadRun(rootDir: string, options: SeedOptions): void {
+  for (const fact of [options.leader, options.worker])
+    if (fact)
+      openDispatchStream(rootDir, {
+        dispatchId: fact.dispatchId,
+        taskId: "task-squad",
+        executionId: "execution-squad",
+        runtimeSessionId: fact.runtimeSessionId,
+        instanceId: "instance-squad",
+        startedAt: fact.startedAt,
+      });
+  appendRuntimeWorkerRecord(rootDir, options.leader.dispatchId, {
     kind: "squad_run_state",
     squadRunId: options.squadRunId,
     revision: 3,
     state: {
       schema: "squad-run/v1",
       squadRunId: options.squadRunId,
-      stateDispatchId,
+      stateDispatchId: options.leader.dispatchId,
       squadId: "core-squad",
       taskId: "task-squad",
       runtimeInstanceId: "instance-squad",
@@ -51,26 +61,24 @@ function seedSquadRun(rootDir: string, options: SeedOptions): string {
       roster: "terra -> sol",
       workers: ["sol"],
       binding: { actor: { principal: { personId: "person-squad" }, executor: null }, source: "local" },
-      leaderTurns: options.leaderSessionId
-        ? [
-            {
-              turnId: "leader-1",
-              trigger: { kind: "initial" },
-              dispatchId: stateDispatchId,
-              runtimeSessionId: options.leaderSessionId,
-              decision: { kind: "converged" },
-            },
-          ]
-        : [],
+      leaderTurns: [
+        {
+          turnId: "leader-1",
+          trigger: { kind: "initial" },
+          dispatchId: options.leader.dispatchId,
+          runtimeSessionId: options.leader.runtimeSessionId,
+          decision: { kind: "converged" },
+        },
+      ],
       leaderProviderSessionId: null,
       currentLeaderRuntimeSessionId: null,
-      workerAttempts: options.workerSessionId
+      workerAttempts: options.worker
         ? [
             {
               attemptId: "worker-1",
               workerId: "sol",
-              dispatchId: null,
-              runtimeSessionId: options.workerSessionId,
+              dispatchId: options.worker.dispatchId,
+              runtimeSessionId: options.worker.runtimeSessionId,
               rejection: null,
             },
           ]
@@ -80,10 +88,22 @@ function seedSquadRun(rootDir: string, options: SeedOptions): string {
       phase: options.phase,
       revision: 3,
       error: null,
-      ...(options.updatedAt === undefined ? {} : { updatedAt: options.updatedAt }),
     },
   });
-  return stateDispatchId;
+}
+
+/** 归档结算文档(dispatch-read archiveRow 的来源):endedAt 事实只从这条来。 */
+function archiveDoc(fact: DispatchFact & { readonly endedAt: string }): Record<string, unknown> {
+  return {
+    schema: "runtime-dispatch/v1",
+    dispatchId: fact.dispatchId,
+    taskId: "task-squad",
+    executionId: "execution-squad",
+    runtimeSessionId: fact.runtimeSessionId,
+    instanceId: "instance-squad",
+    startedAt: fact.startedAt,
+    endedAt: fact.endedAt,
+  };
 }
 
 function session(runtimeSessionId: string, lastObservedAt: string): RuntimeSession {
@@ -106,11 +126,36 @@ function session(runtimeSessionId: string, lastObservedAt: string): RuntimeSessi
   };
 }
 
-/** 只给 list/readStates 走到的读面装桩:member 会话按需可解析或恒缺失。 */
-function projectionWith(sessions: readonly RuntimeSession[]): TaskProjection {
+/** 只给 list/readStates 走到的读面装桩:成员会话按需可解析或恒缺失;派工台账行来自
+ * 真实派工流 + live index(startedAt),归档结算行(endedAt)按 dispatchId 呈现。 */
+function projectionWith(
+  sessions: readonly RuntimeSession[],
+  archives: ReadonlyMap<string, Record<string, unknown>> = new Map(),
+): TaskProjection {
   const rows: { squadRunId: string; revision: number; state: unknown }[] = [];
   return {
     readTaskStatuses: () => ({ status: "ready", rows: [], watermark: 1, sourceRevision: 1 }),
+    readTaskRuntimeBatch: (query: { readonly taskIds: readonly string[] }) => ({
+      status: "ready" as const,
+      taskIds: query.taskIds,
+      rows: query.taskIds.map((taskId) => ({
+        taskId,
+        title: "Squad window witness",
+        packagePath: `tasks/${taskId}`,
+        sessions: [],
+      })),
+      watermark: 1,
+      sourceRevision: 1,
+    }),
+    readDocument: (documentPath: string) => {
+      const archive = archives.get(/dispatch_[a-f0-9]{24}/u.exec(documentPath)?.[0] ?? "");
+      return {
+        status: "ready" as const,
+        document: archive === undefined ? null : { body: JSON.stringify(archive) },
+        watermark: 1,
+        sourceRevision: 1,
+      };
+    },
     squadRunProjectionReady: () => rows.length > 0,
     replaceSquadRuns: (value: typeof rows) => {
       rows.length = 0;
@@ -130,8 +175,12 @@ function projectionWith(sessions: readonly RuntimeSession[]): TaskProjection {
   } as unknown as TaskProjection;
 }
 
-function coordinator(rootDir: string, sessions: readonly RuntimeSession[]) {
-  const projection = projectionWith(sessions);
+function coordinator(
+  rootDir: string,
+  sessions: readonly RuntimeSession[],
+  archives: ReadonlyMap<string, Record<string, unknown>> = new Map(),
+) {
+  const projection = projectionWith(sessions, archives);
   return {
     coordinator: makeSquadCoordinator({
       rootDir,
@@ -156,17 +205,26 @@ function withRootDir(use: (rootDir: string) => void): void {
   }
 }
 
-test("a terminal run whose member sessions are missing still passes a window covering its last state transition", () => {
+test("a terminal run whose member sessions are missing still passes a window covering its last settled dispatch", () => {
   withRootDir((rootDir) => {
+    const worker = {
+      dispatchId: "dispatch_00000000000000000000b2c3",
+      runtimeSessionId: "runtime-worker",
+      startedAt: "2026-08-27T11:30:00.000Z",
+      endedAt: "2026-08-27T11:55:00.000Z",
+    };
     seedSquadRun(rootDir, {
       squadRunId: "squad_0123456789abcdef01234567",
       phase: "converged",
-      updatedAt: "2026-08-27T11:55:00.000Z",
-      leaderSessionId: "runtime-leader",
-      workerSessionId: "runtime-worker",
+      leader: {
+        dispatchId: "dispatch_00000000000000000000a1b2",
+        runtimeSessionId: "runtime-leader",
+        startedAt: "2026-08-27T11:00:00.000Z",
+      },
+      worker,
     });
-    // 投影里没有任何成员会话行(会话未孵化/已被裁剪):唯一活动证据是 run 自身的状态落盘。
-    const { coordinator: squad } = coordinator(rootDir, []);
+    // 投影里没有任何成员会话行(未孵化/已被裁剪):唯一活动证据是 run 自有的派工事实。
+    const { coordinator: squad } = coordinator(rootDir, [], new Map([[worker.dispatchId, archiveDoc(worker)]]));
     const listed = squad.list({ since: sinceAgo(DAY) });
     assert.deepEqual(listed.totals, { runs: 1 });
     assert.equal(listed.runs[0]?.latestActivityAt, "2026-08-27T11:55:00.000Z");
@@ -179,7 +237,16 @@ test("a terminal run outside the window stays hidden even without member session
     seedSquadRun(rootDir, {
       squadRunId: "squad_0123456789abcdef01234567",
       phase: "converged",
-      updatedAt: "2026-08-20T11:55:00.000Z",
+      leader: {
+        dispatchId: "dispatch_00000000000000000000a1b2",
+        runtimeSessionId: "runtime-leader",
+        startedAt: "2026-08-19T10:00:00.000Z",
+      },
+      worker: {
+        dispatchId: "dispatch_00000000000000000000b2c3",
+        runtimeSessionId: "runtime-worker",
+        startedAt: "2026-08-20T11:55:00.000Z",
+      },
     });
     const { coordinator: squad } = coordinator(rootDir, []);
     assert.deepEqual(squad.list({ since: sinceAgo(DAY) }).totals, { runs: 0 });
@@ -187,14 +254,21 @@ test("a terminal run outside the window stays hidden even without member session
   });
 });
 
-test("member session activity later than the last transition wins as latestActivityAt", () => {
+test("member session activity later than every dispatch fact wins as latestActivityAt", () => {
   withRootDir((rootDir) => {
     seedSquadRun(rootDir, {
       squadRunId: "squad_0123456789abcdef01234567",
       phase: "converged",
-      updatedAt: "2026-08-27T10:00:00.000Z",
-      leaderSessionId: "runtime-leader",
-      workerSessionId: "runtime-worker",
+      leader: {
+        dispatchId: "dispatch_00000000000000000000a1b2",
+        runtimeSessionId: "runtime-leader",
+        startedAt: "2026-08-27T11:00:00.000Z",
+      },
+      worker: {
+        dispatchId: "dispatch_00000000000000000000b2c3",
+        runtimeSessionId: "runtime-worker",
+        startedAt: "2026-08-27T11:30:00.000Z",
+      },
     });
     const { coordinator: squad } = coordinator(rootDir, [
       session("runtime-leader", "2026-08-27T11:50:00.000Z"),
@@ -211,12 +285,25 @@ test("active runs always pass the window and a missing since lists every run", (
     seedSquadRun(rootDir, {
       squadRunId: "squad_0123456789abcdef01234567",
       phase: "workers_running",
-      updatedAt: "2026-08-01T00:00:00.000Z",
+      leader: {
+        dispatchId: "dispatch_00000000000000000000a1b2",
+        runtimeSessionId: "runtime-leader",
+        startedAt: "2026-08-01T00:00:00.000Z",
+      },
+      worker: {
+        dispatchId: "dispatch_00000000000000000000b2c3",
+        runtimeSessionId: "runtime-worker",
+        startedAt: "2026-08-01T01:00:00.000Z",
+      },
     });
     seedSquadRun(rootDir, {
       squadRunId: "squad_0123456789abcdef99887766",
       phase: "failed",
-      updatedAt: "2026-08-01T00:00:00.000Z",
+      leader: {
+        dispatchId: "dispatch_00000000000000000000c3d4",
+        runtimeSessionId: "runtime-leader-2",
+        startedAt: "2026-08-01T00:00:00.000Z",
+      },
     });
     const { coordinator: squad } = coordinator(rootDir, []);
     assert.deepEqual(squad.list({ since: sinceAgo(DAY) }).totals, { runs: 1 });
@@ -224,31 +311,65 @@ test("active runs always pass the window and a missing since lists every run", (
   });
 });
 
-test("the window compares instants, so a second-precision stamp does not sneak past a millisecond cutoff", () => {
+test("the window and the ordering compare instants, so a second-precision stamp does not sneak past a millisecond cutoff", () => {
   withRootDir((rootDir) => {
     seedSquadRun(rootDir, {
       squadRunId: "squad_0123456789abcdef01234567",
       phase: "converged",
-      updatedAt: "2026-08-27T00:00:00Z",
+      leader: {
+        dispatchId: "dispatch_00000000000000000000a1b2",
+        runtimeSessionId: "runtime-leader",
+        startedAt: "2026-08-26T23:00:00.000Z",
+      },
+      worker: {
+        dispatchId: "dispatch_00000000000000000000b2c3",
+        runtimeSessionId: "runtime-worker",
+        startedAt: "2026-08-27T00:00:00.500Z",
+      },
+    });
+    seedSquadRun(rootDir, {
+      squadRunId: "squad_0123456789abcdef99887766",
+      phase: "converged",
+      leader: {
+        dispatchId: "dispatch_00000000000000000000c3d4",
+        runtimeSessionId: "runtime-leader-2",
+        startedAt: "2026-08-26T23:00:00.000Z",
+      },
+      worker: {
+        dispatchId: "dispatch_00000000000000000000d4e5",
+        runtimeSessionId: "runtime-worker-2",
+        startedAt: "2026-08-27T00:00:00Z",
+      },
     });
     const { coordinator: squad } = coordinator(rootDir, []);
-    // 字典序里 "…00Z" > "…00.000Z"/"…00.500Z"('Z' > '.'),活动在 .000、截点在 .500
-    // 时必须按瞬值判为窗外。
-    assert.deepEqual(squad.list({ since: "2026-08-27T00:00:00.500Z" }).totals, { runs: 0 });
-    assert.deepEqual(squad.list({ since: "2026-08-27T00:00:00.000Z" }).totals, { runs: 1 });
+    // 字典序里 "…00Z" > "…00.500Z"('Z' > '.'):进出窗与先后排序都必须按瞬值判。
+    assert.deepEqual(squad.list({ since: "2026-08-27T00:00:00.500Z" }).totals, { runs: 1 });
+    assert.deepEqual(squad.list({ since: "2026-08-27T00:00:00.000Z" }).totals, { runs: 2 });
+    assert.deepEqual(
+      squad.list({}).runs.map(({ squadRunId }) => squadRunId),
+      ["squad_0123456789abcdef01234567", "squad_0123456789abcdef99887766"],
+    );
   });
 });
 
-test("a persisted transition stamps its own activity time", async () => {
+test("the real write path keeps deriving activity from dispatch facts, not a persisted clock", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-squad-window-"));
   try {
     seedSquadRun(rootDir, {
       squadRunId: "squad_0123456789abcdef01234567",
       phase: "workers_running",
-      workerSessionId: "runtime-worker",
+      leader: {
+        dispatchId: "dispatch_00000000000000000000a1b2",
+        runtimeSessionId: "runtime-leader",
+        startedAt: "2026-01-15T07:00:00.000Z",
+      },
+      worker: {
+        dispatchId: "dispatch_00000000000000000000b2c3",
+        runtimeSessionId: "runtime-worker",
+        startedAt: "2026-01-15T08:00:00.000Z",
+      },
     });
     const { coordinator: squad } = coordinator(rootDir, []);
-    const before = Date.now();
     // observeOutcome 是真实写路径:worker 结算回调 → continueWorker → writeState 落盘。
     await squad.observeOutcome({
       schema: "agent-runtime-event/v1",
@@ -261,9 +382,8 @@ test("a persisted transition stamps its own activity time", async () => {
       type: "runtime_session_outcome_observed",
       payload: { runtimeSessionId: "runtime-worker", outcome: "succeeded", exitCode: 0, resultRef: null },
     } as Parameters<typeof squad.observeOutcome>[0]);
-    const stamp = squad.list({}).runs[0]?.latestActivityAt;
-    assert.notEqual(stamp, "1970-01-01T00:00:00.000Z");
-    assert.ok(stamp !== undefined && Date.parse(stamp) >= before, `transition stamp ${stamp} predates the write`);
+    // 落盘不再自带时钟:活动时间仍是 worker 派工的已落盘事实,不是 wall-clock,更不是 epoch。
+    assert.equal(squad.list({}).runs[0]?.latestActivityAt, "2026-01-15T08:00:00.000Z");
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
# English

## Summary

Anti-entropy review #6 item 2: #1895 fixed invisible terminal squad runs by adding a persisted `SquadState.updatedAt` clock plus an epoch fallback — a compatibility state for a derivable value. Both are deleted. `latestActivityAt` is now derived at read time from the run's own dispatch ledger rows (leader turns / worker dispatch `startedAt`, archived settlement `endedAt`) ∪ resolvable member sessions, max by instant; the `since` window and ordering compare instants. The six G13 follow-up test semantics are preserved with fixtures built from real dispatch streams. Net production delta after r2: +25 (r1 was 25/25; the per-run isolation and memo helpers added in r2 account for the difference).

## Architectural Justification

- Not required: Production-Delta churn is below 200 lines.

## What Changed

- `packages/daemon/src/squad-coordinator.ts`: `updatedAt` field, per-write clock and read-side epoch fallback removed; activity derived from `readTaskDispatches` + sessions; instant comparisons.
- `packages/daemon/test/squad-run-list-window.test.ts`: fixtures from real dispatch streams; 5 mutation controls turn red.

## Gate Harvest / 门收割

Deleted-Production-Paths: `SquadState.updatedAt` persisted clock; read-side `updatedAt ?? epoch` fallback
Deleted-Gates-Fixtures: squad-run-list-window cases that injected the clock field (rewritten in the same commit on dispatch facts)
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +52/-27

### Optional Evidence Claims

## Task And Scope

- Harness task: task_4745d9b7fb8b4ed2f200853330
- Branch: codex/squad-activity-derive
- Public scope: packages/daemon/src/squad-coordinator.ts and its window test
- Private planning/evidence updated: yes
- Out of scope: GUI sessions view (unchanged); dispatch stream format (unchanged)

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_4745d9b7fb8b4ed2f200853330
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 1bb044a1a79f30855aec2c9e058a88bb59b9269e
- Branch merge-base with `origin/main`: 1bb044a1a79f30855aec2c9e058a88bb59b9269e
- Last `git fetch origin` time: 2026-08-26T23:44:54Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_4745d9b7fb8b4ed2f200853330 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] fast 6/6 + 5 mutation controls; contract (Docker isolated): squad-coordinator 1/1, agent-runtime-session-groups 4/4, squad-run-reads 4/4
- [x] tsc -b, eslint, prettier, tier manifest, line-density
- [ ] Opus read-only review before merge
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: GUI service-bridge with a resident daemon (left to CI).

## Review Evidence

- Self-review: CEO filed the item from review #6 and will read the derivation rule.
- Reviewer subagent: GLM-5.3 worker; Opus review pending.
- Human review: pending
- Blocking findings: none

## Residual Risk

- r2 (after Opus review): `list` memoises `readTaskDispatches` per taskId within one call, and a run whose dispatch ledger cannot be read degrades to session-only activity instead of failing the whole list (`status`/`read` stay fail-closed). `squadState()` never referenced `updatedAt`, so old persisted records are simply ignored — no parser change was needed. Net production is +25 after the isolation/memo helpers; the deletion of the clock/fallback stands. Archived settlement rows are pruned from the live index after first read, so `endedAt` may fall back to `startedAt` on later reads — window semantics unaffected.

## References

- Task: task_4745d9b7fb8b4ed2f200853330
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

反熵审查#6 第 2 项:#1895 用持久化的 `SquadState.updatedAt` 时钟 + epoch fallback 修 terminal squad run 不可见——给可派生值加了兼容状态。两者删除。`latestActivityAt` 改为读时派生:run 自有派工台账行(leader 轮 / worker 派工 `startedAt`、归档结算 `endedAt`)∪ 可解析成员会话,按瞬值取 max;`since` 窗口与排序比较瞬值。G13 follow-up 的 6 条测试语义保留,fixture 改为真实派工流构造。r2 后生产净 +25(r1 为 25/25;差额来自 r2 加的 per-run 隔离与 memo helper)。

## 架构辩护

- 不需要:Production-Delta churn 低于 200 行。

## 改动内容

- `packages/daemon/src/squad-coordinator.ts`:删 `updatedAt` 字段、每写打钟、读侧 epoch 兜底;活动时间由 `readTaskDispatches` + 会话派生;瞬值比较。
- `packages/daemon/test/squad-run-list-window.test.ts`:fixture 改为真实派工流;5 组变异对照能变红。

## 门收割 / Gate Harvest

- 删除的生产路径:`SquadState.updatedAt` 持久化时钟;读侧 `updatedAt ?? epoch` 兜底
- 同 commit 删除的门 / fixture:注入时钟字段的 squad-run-list-window 用例(同 commit 改写为派工事实)
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_4745d9b7fb8b4ed2f200853330
- 分支:codex/squad-activity-derive
- 公开范围:packages/daemon/src/squad-coordinator.ts 与其窗口测试
- 私有计划 / 证据是否已更新:yes
- 范围外:GUI 会话页(不动);派工流格式(不动)

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_4745d9b7fb8b4ed2f200853330
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:1bb044a1a79f30855aec2c9e058a88bb59b9269e
- 当前分支与 `origin/main` 的 merge-base:1bb044a1a79f30855aec2c9e058a88bb59b9269e
- 最近一次 `git fetch origin` 时间:2026-08-26T23:44:54Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_4745d9b7fb8b4ed2f200853330
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] fast 6/6 + 5 组变异对照;contract(Docker 隔离):squad-coordinator 1/1、agent-runtime-session-groups 4/4、squad-run-reads 4/4
- [x] tsc -b、eslint、prettier、tier manifest、line-density
- [ ] 合并前 Opus 只读复核
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:带常驻 daemon 的 GUI service-bridge(交 CI)。

## 审查证据

- 自查:CEO 从审查#6 立项并读派生规则。
- Reviewer subagent:GLM-5.3 worker;Opus 复核待做。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- r2(Opus 复核后):`list` 在单次调用内按 taskId memo `readTaskDispatches`;台账读不到的 run 退化为只按会话计活动,不再拖垮整页(`status`/`read` 保持 fail-closed)。`squadState()` 从未引用 `updatedAt`,旧持久化记录直接被忽略——无需改 parser。加了隔离/memo helper 后生产净 +25;时钟/兜底的删除不变。归档结算行首读后从 live index 剪除,后续读 `endedAt` 可能回落到 `startedAt`——窗口语义不受影响。

## 关联材料

- 任务:task_4745d9b7fb8b4ed2f200853330
- 证据:任务包 artifacts/reports
- 审查:本 PR


