### PR TITLE
fix(runtime): expose settlement failures instead of hanging the wait

### DIFF
--- a/packages/cli/src/cli-runtime-wait.ts
+++ b/packages/cli/src/cli-runtime-wait.ts
@@ -36,19 +36,19 @@ export async function waitForRuntime(
           statusReader = undefined;
         },
       );
-      if (next.kind === "daemon-gone") {
+      if (isDaemonGone(next)) {
         const runtime = current as unknown as AgentRuntimeSessionResult | undefined,
           status = runtime?.session.activity.outcome ?? (runtime?.session ? "running" : "unknown"),
           commandName = spawned ? "runtime-run" : "runtime-status";
-        return daemonGoneReceipt(commandName, String(next.cause), status, {
+        return daemonGoneReceipt(commandName, next.cause, status, {
           runtimeSessionId,
           ...(target ?? {}),
           ...(spawned ? { spawn: spawned } : {}),
           lastKnownDispatch: lastKnownRuntimeDispatch(runtimeSessionId, target, runtime, status),
         });
       }
-      if ((next as JsonObject).ok !== true) return next as JsonObject;
-      current = next as JsonObject;
+      if (next.ok !== true) return next;
+      current = next;
       if (stream && !streamStarted) {
         streamStarted = true;
         try {
@@ -70,9 +70,10 @@ export async function waitForRuntime(
   }
   const result = current as unknown as AgentRuntimeSessionResult,
     text = result.result?.text ?? "",
-    settlementFailed =
-      result.session.activity.outcome === null || text.startsWith("Runtime terminal settlement failed ("),
     outcome = result.session.activity.outcome ?? "unknown",
+    settlementFailed =
+      result.session.activity.outcome === null ||
+      (outcome === "unknown" && result.session.activity.reasonCode !== undefined),
     commandName = spawned ? "runtime-run" : "runtime-status",
     providerExit = Number.isInteger(result.session.activity.exitCode),
     failureCode = settlementFailed ? "runtime_settlement_failed" : providerExit ? "provider_exit" : "runtime_failed",
@@ -108,18 +109,18 @@ export async function waitForTaskDispatches(command: ThinCommand, taskId: string
     const next = await readDaemonSubscription(command, () =>
       runCommandThroughDaemon(readCommand, () => undefined, { autostart: false }),
     );
-    if (next.kind === "daemon-gone") {
+    if (isDaemonGone(next)) {
       const dispatches = Array.isArray(current?.dispatches) ? current.dispatches : [],
         rows = `${dispatches.length} row${dispatches.length === 1 ? "" : "s"}`;
       return daemonGoneReceipt(
         "runtime-status",
-        String(next.cause),
+        next.cause,
         rows,
         { taskId, lastKnownDispatches: dispatches },
         `runtime-status task ${taskId}`,
       );
     }
-    current = next as JsonObject;
+    current = next;
     if (current.ok !== true) return current;
     if (current.status !== "pending" && taskDispatchesSettled(current)) break;
     await new Promise((resolve) => setTimeout(resolve, 250));
@@ -201,6 +202,10 @@ async function daemonGone(command: ThinCommand): Promise<boolean> {
     livePid = pid !== null && daemonProcessAlive(pid),
     liveSocket = await daemonSocketProbe(target.socketPath);
   return !livePid && !liveSocket;
+}
+
+function isDaemonGone(value: JsonObject | DaemonGone): value is DaemonGone {
+  return "kind" in value && value.kind === "daemon-gone";
 }
 
 function lastKnownRuntimeDispatch(

--- a/packages/cli/src/cli-runtime-wait.ts
+++ b/packages/cli/src/cli-runtime-wait.ts
@@ -9,13 +9,7 @@ import {
   streamRuntimeThroughDaemon,
 } from "./daemon/client.ts";
 
-const reconnectBaseDelayMs = 250,
-  reconnectMaxDelayMs = 5_000;
-
-interface DaemonGone {
-  readonly kind: "daemon-gone";
-  readonly cause: string;
-}
+type DaemonGone = { readonly kind: "daemon-gone"; readonly cause: string };
 
 export async function waitForRuntime(
   command: ThinCommand,
@@ -30,7 +24,7 @@ export async function waitForRuntime(
     detach: (() => void) | undefined,
     streamStarted = false;
   try {
-    for (;;) {
+    for (let exitedPolls = 0; ; ) {
       const next = await readDaemonSubscription(
         command,
         async () => {
@@ -42,19 +36,19 @@ export async function waitForRuntime(
           statusReader = undefined;
         },
       );
-      if (isDaemonGone(next)) {
+      if (next.kind === "daemon-gone") {
         const runtime = current as unknown as AgentRuntimeSessionResult | undefined,
           status = runtime?.session.activity.outcome ?? (runtime?.session ? "running" : "unknown"),
           commandName = spawned ? "runtime-run" : "runtime-status";
-        return daemonGoneReceipt(commandName, next.cause, status, {
+        return daemonGoneReceipt(commandName, String(next.cause), status, {
           runtimeSessionId,
           ...(target ?? {}),
           ...(spawned ? { spawn: spawned } : {}),
           lastKnownDispatch: lastKnownRuntimeDispatch(runtimeSessionId, target, runtime, status),
         });
       }
-      if (next.ok !== true) return next;
-      current = next;
+      if ((next as JsonObject).ok !== true) return next as JsonObject;
+      current = next as JsonObject;
       if (stream && !streamStarted) {
         streamStarted = true;
         try {
@@ -66,7 +60,8 @@ export async function waitForRuntime(
           writeActivity(`[stream] ${error instanceof Error ? error.message : String(error)}\n`);
         }
       }
-      if ((current as unknown as AgentRuntimeSessionResult).session.activity.outcome !== null) break;
+      const session = (current as unknown as AgentRuntimeSessionResult).session;
+      if (session.activity.outcome !== null || (session.liveness === "exited" && ++exitedPolls >= 20)) break;
       await new Promise((resolve) => setTimeout(resolve, 250));
     }
   } finally {
@@ -74,24 +69,29 @@ export async function waitForRuntime(
     detach?.();
   }
   const result = current as unknown as AgentRuntimeSessionResult,
-    outcome = result.session.activity.outcome!,
     text = result.result?.text ?? "",
+    settlementFailed =
+      result.session.activity.outcome === null || text.startsWith("Runtime terminal settlement failed ("),
+    outcome = result.session.activity.outcome ?? "unknown",
     commandName = spawned ? "runtime-run" : "runtime-status",
     providerExit = Number.isInteger(result.session.activity.exitCode),
+    failureCode = settlementFailed ? "runtime_settlement_failed" : providerExit ? "provider_exit" : "runtime_failed",
     reason =
       outcome === "succeeded"
         ? null
         : text ||
-          (providerExit
-            ? `Provider exited with code ${String(result.session.activity.exitCode)} without a diagnostic.`
-            : `${commandName}: ${outcome}`);
+          (settlementFailed
+            ? "runtime_settlement_failed: daemon reported the runtime exited but no terminal outcome became visible."
+            : providerExit
+              ? `Provider exited with code ${String(result.session.activity.exitCode)} without a diagnostic.`
+              : `${commandName}: ${outcome}`);
   return {
     ...current,
     command: commandName,
     outcome,
     runtimeSessionId,
     ...(spawned ? { spawn: spawned } : {}),
-    ...(reason ? { code: providerExit ? "provider_exit" : "runtime_failed", reason } : {}),
+    ...(reason ? { code: failureCode, reason } : {}),
     summary: text || reason || `${commandName}: ${outcome}`,
     exitCode: outcome === "succeeded" ? 0 : 1,
   };
@@ -108,18 +108,18 @@ export async function waitForTaskDispatches(command: ThinCommand, taskId: string
     const next = await readDaemonSubscription(command, () =>
       runCommandThroughDaemon(readCommand, () => undefined, { autostart: false }),
     );
-    if (isDaemonGone(next)) {
+    if (next.kind === "daemon-gone") {
       const dispatches = Array.isArray(current?.dispatches) ? current.dispatches : [],
         rows = `${dispatches.length} row${dispatches.length === 1 ? "" : "s"}`;
       return daemonGoneReceipt(
         "runtime-status",
-        next.cause,
+        String(next.cause),
         rows,
         { taskId, lastKnownDispatches: dispatches },
         `runtime-status task ${taskId}`,
       );
     }
-    current = next;
+    current = next as JsonObject;
     if (current.ok !== true) return current;
     if (current.status !== "pending" && taskDispatchesSettled(current)) break;
     await new Promise((resolve) => setTimeout(resolve, 250));
@@ -176,13 +176,9 @@ async function readDaemonSubscription(
       if (!recoverableSubscriptionFailure(error)) throw error;
       if (await daemonGone(command))
         return { kind: "daemon-gone", cause: error instanceof Error ? error.message : String(error) };
-      await new Promise((resolve) => setTimeout(resolve, reconnectDelayMs(attempt++)));
+      await new Promise((resolve) => setTimeout(resolve, Math.min(250 * 2 ** attempt++, 5_000)));
     }
   }
-}
-
-function reconnectDelayMs(attempt: number): number {
-  return Math.min(reconnectBaseDelayMs * 2 ** attempt, reconnectMaxDelayMs);
 }
 
 function recoverableSubscriptionFailure(error: unknown): boolean {
@@ -205,10 +201,6 @@ async function daemonGone(command: ThinCommand): Promise<boolean> {
     livePid = pid !== null && daemonProcessAlive(pid),
     liveSocket = await daemonSocketProbe(target.socketPath);
   return !livePid && !liveSocket;
-}
-
-function isDaemonGone(value: JsonObject | DaemonGone): value is DaemonGone {
-  return "kind" in value && value.kind === "daemon-gone";
 }
 
 function lastKnownRuntimeDispatch(

--- a/packages/cli/src/cli/thin-command.ts
+++ b/packages/cli/src/cli/thin-command.ts
@@ -6,6 +6,7 @@ export const thinCliLocalErrorCodes = Object.freeze([
   "duplicate_field",
   "invalid_field",
   "missing_field",
+  "runtime_settlement_failed",
   "unknown_field",
   "unsupported_command",
 ]);

--- a/packages/cli/test/runtime-wait-reconnect.integration.test.ts
+++ b/packages/cli/test/runtime-wait-reconnect.integration.test.ts
@@ -142,6 +142,27 @@ test("runtime status --wait surfaces a canonical settlement failure diagnostic",
   }
 });
 
+test("runtime status --wait does not infer settlement failure from an unknown outcome's text", async () => {
+  const fixture = await openFixtureDaemon("unknown-outcome");
+  fixture.onRequest = (socket, request) => {
+    if (request.method === "protocol.hello") {
+      reply(socket, request.id, { ok: true });
+      return;
+    }
+    reply(socket, request.id, runtimeStatus(false, true, false, true));
+  };
+  const invocation = runWait(fixture);
+  try {
+    const result = await invocation.result(2_000);
+    assert.equal(result.code, 1, result.stderr);
+    assert.equal(result.receipt.code, "provider_exit");
+    assert.equal(result.receipt.outcome, "unknown");
+  } finally {
+    invocation.stop();
+    await fixture.close();
+  }
+});
+
 test("task dispatch wait classifies an ENOENT reconnect as daemon_gone and retains the last-known rows", async () => {
   const fixture = await openFixtureDaemon("task-daemon-gone"),
     taskId = "task-runtime-wait",
@@ -315,7 +336,12 @@ function reply(socket: net.Socket, id: number, result: Record<string, unknown>):
   socket.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
 }
 
-function runtimeStatus(terminal: boolean, exited = terminal, settlementFailed = false): Record<string, unknown> {
+function runtimeStatus(
+  terminal: boolean,
+  exited = terminal,
+  settlementFailed = false,
+  unknownOutcome = false,
+): Record<string, unknown> {
   return {
     ok: true,
     status: "ready",
@@ -340,21 +366,24 @@ function runtimeStatus(terminal: boolean, exited = terminal, settlementFailed = 
       ],
       activity: {
         lastObservedAt: "2026-08-27T00:00:00.000Z",
-        outcome: terminal ? "succeeded" : settlementFailed ? "unknown" : null,
+        outcome: terminal ? "succeeded" : settlementFailed || unknownOutcome ? "unknown" : null,
         exitCode: exited ? 0 : null,
-        resultRef: terminal || settlementFailed ? "result:fixture" : null,
+        resultRef: terminal || settlementFailed || unknownOutcome ? "result:fixture" : null,
+        ...(settlementFailed ? { reasonCode: "runtime_lease_release_failed" } : {}),
       },
     },
     result: settlementFailed
       ? {
           ref: "result:fixture",
-          text: "Runtime terminal settlement failed (runtime_lease_release_failed): injected failure",
+          text: "injected failure: runtime_lease_release_failed",
         }
-      : terminal
-        ? { ref: "result:fixture", text: "settled after reconnect" }
-        : null,
-    watermark: terminal || settlementFailed ? 2 : 1,
-    sourceRevision: terminal || settlementFailed ? 2 : 1,
+      : unknownOutcome
+        ? { ref: "result:fixture", text: "Runtime terminal settlement failed (provider-authored diagnostic)" }
+        : terminal
+          ? { ref: "result:fixture", text: "settled after reconnect" }
+          : null,
+    watermark: terminal || settlementFailed || unknownOutcome ? 2 : 1,
+    sourceRevision: terminal || settlementFailed || unknownOutcome ? 2 : 1,
   };
 }
 

--- a/packages/cli/test/runtime-wait-reconnect.integration.test.ts
+++ b/packages/cli/test/runtime-wait-reconnect.integration.test.ts
@@ -91,6 +91,57 @@ test("runtime status --wait returns daemon_gone with the last-known dispatch aft
   }
 });
 
+test("runtime status --wait bounds an exited session whose outcome never becomes visible", async () => {
+  const fixture = await openFixtureDaemon("settlement-failed");
+  let statusReads = 0;
+  fixture.onRequest = (socket, request) => {
+    if (request.method === "protocol.hello") {
+      reply(socket, request.id, { ok: true });
+      return;
+    }
+    assert.equal(request.method, "repo.agentRuntime.sessions.read");
+    statusReads += 1;
+    reply(socket, request.id, runtimeStatus(false, true));
+  };
+  const invocation = runWait(fixture);
+  try {
+    const result = await invocation.result(8_000);
+    assert.equal(result.code, 1, result.stderr);
+    assert.equal(result.receipt.code, "runtime_settlement_failed");
+    assert.equal(result.receipt.outcome, "unknown");
+    assert.match(String(result.receipt.reason), /runtime_settlement_failed/u);
+    assert.equal(statusReads, 20);
+  } finally {
+    invocation.stop();
+    await fixture.close();
+  }
+});
+
+test("runtime status --wait surfaces a canonical settlement failure diagnostic", async () => {
+  const fixture = await openFixtureDaemon("settlement-outcome");
+  let statusReads = 0;
+  fixture.onRequest = (socket, request) => {
+    if (request.method === "protocol.hello") {
+      reply(socket, request.id, { ok: true });
+      return;
+    }
+    statusReads += 1;
+    reply(socket, request.id, runtimeStatus(false, true, true));
+  };
+  const invocation = runWait(fixture);
+  try {
+    const result = await invocation.result(2_000);
+    assert.equal(result.code, 1, result.stderr);
+    assert.equal(result.receipt.code, "runtime_settlement_failed");
+    assert.equal(result.receipt.outcome, "unknown");
+    assert.match(String(result.receipt.reason), /runtime_lease_release_failed/u);
+    assert.equal(statusReads, 1);
+  } finally {
+    invocation.stop();
+    await fixture.close();
+  }
+});
+
 test("task dispatch wait classifies an ENOENT reconnect as daemon_gone and retains the last-known rows", async () => {
   const fixture = await openFixtureDaemon("task-daemon-gone"),
     taskId = "task-runtime-wait",
@@ -264,7 +315,7 @@ function reply(socket: net.Socket, id: number, result: Record<string, unknown>):
   socket.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
 }
 
-function runtimeStatus(terminal: boolean): Record<string, unknown> {
+function runtimeStatus(terminal: boolean, exited = terminal, settlementFailed = false): Record<string, unknown> {
   return {
     ok: true,
     status: "ready",
@@ -276,7 +327,7 @@ function runtimeStatus(terminal: boolean): Record<string, unknown> {
       kindId: "codex",
       definitionSnapshotRef: "fixture-definition",
       definitionSnapshot: {},
-      liveness: terminal ? "exited" : "live",
+      liveness: exited ? "exited" : "live",
       attachCapability: "supported",
       streamCursor: "stream:0",
       associations: [
@@ -289,14 +340,21 @@ function runtimeStatus(terminal: boolean): Record<string, unknown> {
       ],
       activity: {
         lastObservedAt: "2026-08-27T00:00:00.000Z",
-        outcome: terminal ? "succeeded" : null,
-        exitCode: terminal ? 0 : null,
-        resultRef: terminal ? "result:fixture" : null,
+        outcome: terminal ? "succeeded" : settlementFailed ? "unknown" : null,
+        exitCode: exited ? 0 : null,
+        resultRef: terminal || settlementFailed ? "result:fixture" : null,
       },
     },
-    result: terminal ? { ref: "result:fixture", text: "settled after reconnect" } : null,
-    watermark: terminal ? 2 : 1,
-    sourceRevision: terminal ? 2 : 1,
+    result: settlementFailed
+      ? {
+          ref: "result:fixture",
+          text: "Runtime terminal settlement failed (runtime_lease_release_failed): injected failure",
+        }
+      : terminal
+        ? { ref: "result:fixture", text: "settled after reconnect" }
+        : null,
+    watermark: terminal || settlementFailed ? 2 : 1,
+    sourceRevision: terminal || settlementFailed ? 2 : 1,
   };
 }
 

--- a/packages/daemon/src/agent-runtime-contract.ts
+++ b/packages/daemon/src/agent-runtime-contract.ts
@@ -90,6 +90,7 @@ export interface AgentRuntimeSessionDto {
     readonly outcome: "succeeded" | "failed" | "unknown" | "cancelled" | null;
     readonly exitCode: number | null;
     readonly resultRef: string | null;
+    readonly reasonCode?: string;
   };
 }
 export interface AgentRuntimeLifecycleDto {
@@ -421,13 +422,19 @@ function validSession(value: unknown): value is AgentRuntimeSessionDto {
     value.associations.every(validAssociation) &&
     (value.attemptChain === undefined || validAttemptChain(value.attemptChain)) &&
     isAgentRuntimeContractRecord(value.activity) &&
-    hasExactAgentRuntimeContractFields(value.activity, ["lastObservedAt", "outcome", "exitCode", "resultRef"]) &&
+    hasAgentRuntimeContractFields(
+      value.activity,
+      ["lastObservedAt", "outcome", "exitCode", "resultRef"],
+      ["reasonCode"],
+    ) &&
     typeof value.activity.lastObservedAt === "string" &&
     (value.activity.outcome === null ||
       ["succeeded", "failed", "unknown", "cancelled"].includes(String(value.activity.outcome))) &&
     (value.activity.exitCode === null ||
       (Number.isInteger(value.activity.exitCode) && (value.activity.exitCode as number) >= 0)) &&
-    (value.activity.resultRef === null || typeof value.activity.resultRef === "string")
+    (value.activity.resultRef === null || typeof value.activity.resultRef === "string") &&
+    (value.activity.reasonCode === undefined ||
+      (typeof value.activity.reasonCode === "string" && value.activity.reasonCode.length > 0))
   );
 }
 function validAttemptChain(value: unknown): value is AgentRuntimeAttemptChainDto {

--- a/packages/daemon/src/agent-runtime-read.ts
+++ b/packages/daemon/src/agent-runtime-read.ts
@@ -85,6 +85,7 @@ export function makeAgentRuntimeReadModel(input: {
         outcome: session.outcome,
         exitCode: session.exitCode,
         resultRef: session.resultRef,
+        ...(session.reasonCode ? { reasonCode: session.reasonCode } : {}),
       },
     };
   };

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -300,14 +300,8 @@ export async function openRepoCell(input: {
       queueDepth -= 1;
       if (state === "attached") await work();
     });
-    tail = pending.then(
-      () => undefined,
-      () => undefined,
-    );
-    void pending.then(
-      () => replica.kick(),
-      () => replica.kick(),
-    );
+    tail = pending.catch(() => undefined);
+    void pending.then(() => replica.kick(), console.error);
   };
   let settleExecutionLease: (terminal: RuntimeAttemptTerminal) => Promise<void> = async () => {
     throw cellCodedError("runtime_preconditions_unavailable", "RepoCell execution settlement is not ready.");

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -301,7 +301,13 @@ export async function openRepoCell(input: {
       if (state === "attached") await work();
     });
     tail = pending.catch(() => undefined);
-    void pending.then(() => replica.kick(), console.error);
+    void pending.then(
+      () => replica.kick(),
+      (error: unknown) => {
+        console.error(error);
+        replica.kick();
+      },
+    );
   };
   let settleExecutionLease: (terminal: RuntimeAttemptTerminal) => Promise<void> = async () => {
     throw cellCodedError("runtime_preconditions_unavailable", "RepoCell execution settlement is not ready.");

--- a/packages/daemon/src/runtime-spawn-errors.ts
+++ b/packages/daemon/src/runtime-spawn-errors.ts
@@ -75,7 +75,7 @@ export function runtimeErrorCode(error: unknown): string | null {
 }
 
 export function runtimeErrorMessage(error: unknown): string {
-  return scrubProviderValue(error instanceof Error ? error.message : String(error)) as string;
+  return String(scrubProviderValue(error instanceof Error ? error.message : String(error))).slice(0, 1024);
 }
 
 export function isRuntimeEvent(value: { readonly schema: string }): value is AgentRuntimeEventV1 {

--- a/packages/daemon/src/runtime-spawn-settlement.ts
+++ b/packages/daemon/src/runtime-spawn-settlement.ts
@@ -7,6 +7,7 @@ import { consumeDurableOutput } from "./runtime-spawn-provider-stream.ts";
 import type { ActiveRuntime } from "./runtime-spawn-types.ts";
 import { pushWorkerBranch } from "./runtime-worker-push.ts";
 import { classifyRuntimeExit } from "./runtime-provider-fault.ts";
+import { runtimeErrorCode, runtimeErrorMessage } from "./runtime-spawn-errors.ts";
 
 export async function publishExit(context: any, active: ActiveRuntime, code: number | null): Promise<void> {
   if (
@@ -30,11 +31,12 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
         (code === 0 && (active.finalText === null || active.providerOutcome === null)))
     )
       context.markProtocolError(active);
-    const { outcome, ...classifiedAttempt } = classifyRuntimeExit(active, code),
+    const { outcome: initialOutcome, ...classifiedAttempt } = classifyRuntimeExit(active, code),
       attemptOutcome = {
         ...classifiedAttempt,
         reason: String(scrubProviderValue(classifiedAttempt.reason)).slice(0, 1024),
       };
+    let outcome = initialOutcome;
     active.stream.appendAttemptOutcome(attemptOutcome, context.input.now());
     let body = context.runtimeResultText(active, code, outcome);
     if (active.task && outcome === "succeeded") {
@@ -48,14 +50,14 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
         body = `${body}\n\nWorker branch push failed (no retry): ${detail || "GitHub credential resolution failed."}`;
       }
     }
-    const sha256 = createHash("sha256").update(body).digest("hex"),
+    let sha256 = createHash("sha256").update(body).digest("hex"),
       result: RuntimeResultClaim = {
         sha256,
         size: Buffer.byteLength(body),
         mediaType: context.resultMediaType,
       },
-      resultRef = `artifact:runtime-result/sha256/${sha256}`,
-      endedAt = context.input.now(),
+      resultRef = `artifact:runtime-result/sha256/${sha256}`;
+    const endedAt = context.input.now(),
       archive: RuntimeDispatchArchive | null = active.task
         ? {
             dispatchId: active.dispatchId,
@@ -114,17 +116,6 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
         const detail = String(scrubProviderValue(error instanceof Error ? error.message : String(error))).slice(0, 512);
         console.warn(`[runtime-archive] ${active.dispatchId} could not be archived: ${detail}`);
       }
-    context.input.stream.publish(active.runtimeSessionId, { type: "exit", outcome });
-    context.input.recordLifecycle?.({
-      event: "runtime_exit",
-      runtimeSessionId: active.runtimeSessionId,
-      dispatchId: active.dispatchId,
-      pid: active.process.pid,
-      exitCode: active.lossExitCode ?? (cancelled ? null : code),
-      signal: active.lossSignal,
-      outcome: active.lossReason ? "lost" : outcome,
-      reason: active.lossReason,
-    });
     if (cancelled)
       await context.publishRuntimeEvent(
         "runtime_session_cancelled",
@@ -138,33 +129,38 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
       `${active.dispatchOpId}-exited`,
       eventBinding,
     );
-    const notification =
-      active.onExitCommand === null
-        ? null
-        : {
-            command: active.onExitCommand,
-            cwd: active.cwd,
-            stream: active.stream,
-            payload: {
-              schema: "runtime-session-exited/v1" as const,
-              runtimeSessionId: active.runtimeSessionId,
-              outcome,
-              exitCode: cancelled ? null : code,
-              nextAction: `ha runtime status ${active.runtimeSessionId} --wait`,
-            },
-          };
     context.processes.delete(active.runtimeSessionId);
     active.process.release?.();
-    await context.settleFallback(active, attemptOutcome, {
+    await context
+      .settleFallback(active, attemptOutcome, {
+        runtimeSessionId: active.runtimeSessionId,
+        dispatchId: active.dispatchId,
+        task: active.task,
+        schedule: active.schedule,
+        outcome: outcome === "succeeded" ? "succeeded" : "failed",
+        reason: outcome === "succeeded" ? null : attemptOutcome.reason,
+        endedAt,
+        resultRef,
+        binding: active.binding,
+      })
+      .catch((error: unknown) => {
+        consumeKnownError(error);
+        const settlementCode = runtimeErrorCode(error) ?? "runtime_settlement_failed";
+        outcome = "unknown";
+        body = `Runtime terminal settlement failed (${settlementCode}): ${runtimeErrorMessage(error)}`;
+        sha256 = createHash("sha256").update(body).digest("hex");
+        result = { sha256, size: Buffer.byteLength(body), mediaType: context.resultMediaType };
+        resultRef = `artifact:runtime-result/sha256/${sha256}`;
+      });
+    context.input.recordLifecycle?.({
+      event: "runtime_exit",
       runtimeSessionId: active.runtimeSessionId,
       dispatchId: active.dispatchId,
-      task: active.task,
-      schedule: active.schedule,
-      outcome: outcome === "succeeded" ? "succeeded" : "failed",
-      reason: outcome === "succeeded" ? null : attemptOutcome.reason,
-      endedAt,
-      resultRef,
-      binding: active.binding,
+      pid: active.process.pid,
+      exitCode: active.lossExitCode ?? (cancelled ? null : code),
+      signal: active.lossSignal,
+      outcome: active.lossReason ? "lost" : outcome,
+      reason: active.lossReason,
     });
     const outcomeEvent = await context.publishRuntimeEvent(
       "runtime_session_outcome_observed",
@@ -180,7 +176,23 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
       body,
     );
     context.input.onRuntimeOutcome?.(outcomeEvent.event, active.schedule);
-    if (notification) setImmediate(() => context.launchExitNotification({ ...notification, now: context.input.now }));
+    context.input.stream.publish(active.runtimeSessionId, { type: "exit", outcome });
+    if (active.onExitCommand !== null)
+      setImmediate(() =>
+        context.launchExitNotification({
+          command: active.onExitCommand,
+          cwd: active.cwd,
+          stream: active.stream,
+          payload: {
+            schema: "runtime-session-exited/v1" as const,
+            runtimeSessionId: active.runtimeSessionId,
+            outcome,
+            exitCode: cancelled ? null : code,
+            nextAction: `ha runtime status ${active.runtimeSessionId} --wait`,
+          },
+          now: context.input.now,
+        }),
+      );
   } finally {
     context.exiting.delete(active.runtimeSessionId);
   }

--- a/packages/daemon/src/runtime-spawn-settlement.ts
+++ b/packages/daemon/src/runtime-spawn-settlement.ts
@@ -50,7 +50,8 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
         body = `${body}\n\nWorker branch push failed (no retry): ${detail || "GitHub credential resolution failed."}`;
       }
     }
-    let sha256 = createHash("sha256").update(body).digest("hex"),
+    let reasonCode: string | null = null,
+      sha256 = createHash("sha256").update(body).digest("hex"),
       result: RuntimeResultClaim = {
         sha256,
         size: Buffer.byteLength(body),
@@ -116,19 +117,20 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
         const detail = String(scrubProviderValue(error instanceof Error ? error.message : String(error))).slice(0, 512);
         console.warn(`[runtime-archive] ${active.dispatchId} could not be archived: ${detail}`);
       }
-    if (cancelled)
+    if (cancelled) {
       await context.publishRuntimeEvent(
         "runtime_session_cancelled",
         { runtimeSessionId: active.runtimeSessionId },
         active.cancelOpId ?? `${active.dispatchOpId}-cancelled`,
         eventBinding,
       );
-    await context.publishRuntimeEvent(
-      "runtime_session_exited",
-      { runtimeSessionId: active.runtimeSessionId },
-      `${active.dispatchOpId}-exited`,
-      eventBinding,
-    );
+      await context.publishRuntimeEvent(
+        "runtime_session_exited",
+        { runtimeSessionId: active.runtimeSessionId },
+        `${active.dispatchOpId}-exited`,
+        eventBinding,
+      );
+    }
     context.processes.delete(active.runtimeSessionId);
     active.process.release?.();
     await context
@@ -145,13 +147,21 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
       })
       .catch((error: unknown) => {
         consumeKnownError(error);
-        const settlementCode = runtimeErrorCode(error) ?? "runtime_settlement_failed";
+        const settlementCode = runtimeErrorCode(error) || "runtime_settlement_failed";
+        reasonCode = settlementCode;
         outcome = "unknown";
         body = `Runtime terminal settlement failed (${settlementCode}): ${runtimeErrorMessage(error)}`;
         sha256 = createHash("sha256").update(body).digest("hex");
         result = { sha256, size: Buffer.byteLength(body), mediaType: context.resultMediaType };
         resultRef = `artifact:runtime-result/sha256/${sha256}`;
       });
+    if (!cancelled)
+      await context.publishRuntimeEvent(
+        "runtime_session_exited",
+        { runtimeSessionId: active.runtimeSessionId },
+        `${active.dispatchOpId}-exited`,
+        eventBinding,
+      );
     context.input.recordLifecycle?.({
       event: "runtime_exit",
       runtimeSessionId: active.runtimeSessionId,
@@ -170,6 +180,7 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
         exitCode: cancelled ? null : code,
         resultRef,
         result,
+        ...(reasonCode ? { reasonCode } : {}),
       },
       `${active.dispatchOpId}-outcome`,
       eventBinding,

--- a/packages/daemon/test/fleet-transport.integration.test.ts
+++ b/packages/daemon/test/fleet-transport.integration.test.ts
@@ -585,6 +585,8 @@ test(
   async (t) => {
     const fixture = await fleetFixture(["tasks/task-fleet-fleet"]);
     t.after(() => fixture.close());
+    const taskReleaseBarrier = fixture.blockTaskRelease();
+    t.after(taskReleaseBarrier.release);
     const center = await fixture.center(),
       edgeRoot = path.join(fixture.root, "runtime-edge"),
       edgeUserRoot = path.join(fixture.root, "runtime-edge-user"),
@@ -745,6 +747,17 @@ test(
     assert.equal(launchedEnv?.HARNESS_DAEMON_USER_ROOT, edgeUserRoot);
     assert.equal(launchedEnv?.HARNESS_DAEMON_ID, "fleet-runtime-edge");
     assert.equal(launchedEnv?.HARNESS_DAEMON_REPO_ID, fixture.assignment.repoId);
+    await taskReleaseBarrier.started;
+    await delay(5_100);
+    const settlingEvents = makeTaskEventStore({ repoId: fixture.assignment.repoId, rootDir: fixture.repo })
+      .read()
+      .events.filter(
+        (event) =>
+          (event.type === "runtime_session_exited" || event.type === "runtime_session_outcome_observed") &&
+          event.payload.runtimeSessionId === receipt.runtimeSessionId,
+      );
+    assert.deepEqual(settlingEvents, [], "edge must not publish exited while center settlement is pending");
+    taskReleaseBarrier.release();
     const waitForOutcome = async (runtimeSessionId: unknown) => {
       const deadline = Date.now() + 20_000;
       let status: Awaited<ReturnType<typeof fixture.host.read>> | null = null;
@@ -765,6 +778,24 @@ test(
       return status;
     };
     assert.equal((await waitForOutcome(receipt.runtimeSessionId))?.session.activity.outcome, "succeeded");
+    const settledEvents = makeTaskEventStore({ repoId: fixture.assignment.repoId, rootDir: fixture.repo }).read()
+        .events,
+      leaseReleaseIndex = settledEvents.findIndex(
+        (event) => event.type === "lease_released" && event.taskId === fixture.assignment.taskId,
+      ),
+      runtimeExitIndex = settledEvents.findIndex(
+        (event) =>
+          event.type === "runtime_session_exited" && event.payload.runtimeSessionId === receipt.runtimeSessionId,
+      ),
+      runtimeOutcomeIndex = settledEvents.findIndex(
+        (event) =>
+          event.type === "runtime_session_outcome_observed" &&
+          event.payload.runtimeSessionId === receipt.runtimeSessionId,
+      );
+    assert.ok(
+      leaseReleaseIndex < runtimeExitIndex && runtimeExitIndex < runtimeOutcomeIndex,
+      "center settlement must precede the adjacent edge exit and outcome events",
+    );
     const after = await fixture.host.read(fixture.assignment.repoId, "repo.tasks.list", {}, fixture.auth);
     assert.ok(after.sourceRevision > before.sourceRevision);
     await t.test("provider session resume keeps the center-observed runtime instance", async () => {
@@ -1259,7 +1290,8 @@ async function fleetFixture(paths: readonly string[] = ["tasks/task-fleet-fleet/
     owned = reclaimer();
   let nodeActive = true,
     expiresAt = "2099-01-01T00:00:00.000Z",
-    assignmentDelayMs = 0;
+    assignmentDelayMs = 0,
+    taskReleaseBarrier: { readonly started: () => void; readonly wait: Promise<void> } | null = null;
   mkdirSync(path.join(repo, "harness"), { recursive: true });
   mkdirSync(emptyPath);
   initRepo(repo);
@@ -1347,11 +1379,33 @@ async function fleetFixture(paths: readonly string[] = ["tasks/task-fleet-fleet/
     setAssignmentDelay: (value: number) => {
       assignmentDelayMs = value;
     },
+    blockTaskRelease: () => {
+      let started!: () => void, release!: () => void;
+      const startedPromise = new Promise<void>((resolve) => {
+          started = resolve;
+        }),
+        wait = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+      taskReleaseBarrier = { started, wait };
+      return { started: startedPromise, release };
+    },
     commitCount: () => Number(git(repo, "rev-list", "--count", "refs/ha/canonical")),
     center: () =>
       owned.hold(
         listenFleetTls({
-          host,
+          host: {
+            ...host,
+            run: async (...args: Parameters<typeof host.run>) => {
+              const barrier = taskReleaseBarrier;
+              if (args[1].kind === "task-release" && barrier) {
+                barrier.started();
+                await barrier.wait;
+                if (taskReleaseBarrier === barrier) taskReleaseBarrier = null;
+              }
+              return host.run(...args);
+            },
+          },
           stateRoot,
           key,
           cert,

--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -358,7 +358,8 @@ test("runtime spawn publishes a canonical session and makes it visible in overvi
 
 test("attached task runtime settlement releases its execution lease before publishing the terminal outcome", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-runtime-attached-tail-"));
-  let exit: ((code: number | null) => void) | null = null;
+  let exit: ((code: number | null) => void) | null = null,
+    failSettlement = false;
   try {
     initIngressRepo(root, 4310);
     const cell = await openRepoCell({
@@ -407,6 +408,12 @@ test("attached task runtime settlement releases its execution lease before publi
         },
         terminate: () => undefined,
       }),
+      killpoint: (point) => {
+        if (failSettlement && point === "after_sqlite_commit")
+          throw Object.assign(new Error("injected terminal lease settlement failure"), {
+            code: "runtime_lease_release_failed",
+          });
+      },
     });
     try {
       const taskId = "task-runtime-attached-tail",
@@ -515,6 +522,103 @@ test("attached task runtime settlement releases its execution lease before publi
       );
       assert.ok(releaseIndex < outcomeIndex, "terminal outcome must not become visible before lease release");
       assert.equal(taskSnapshot.lease, null, "terminal RuntimeSession settlement must release the execution lease");
+
+      const failedTaskId = "task-runtime-settlement-failed",
+        failedExecutionId = "execution-runtime-settlement-failed";
+      assert.equal(
+        (await cell.run({ kind: "task-create", taskId: failedTaskId, title: "Failed settlement" }, binding)).outcome,
+        "applied",
+      );
+      assert.equal(
+        (
+          await cell.run(
+            {
+              kind: "task-start",
+              taskId: failedTaskId,
+              executionId: failedExecutionId,
+              executor: { kind: "agent", id: "failed-settlement-worker" },
+            },
+            binding,
+          )
+        ).outcome,
+        "applied",
+      );
+      const failedReceipt = await cell.spawnRuntime(
+        {
+          runtimeInstanceId: definition.instanceId,
+          cwd: { scope: "repo-root" },
+          prompt: "Expose a failed terminal lease settlement",
+          taskId: failedTaskId,
+          idempotencyKey: "failed-settlement",
+        },
+        binding,
+      );
+      for (const event of records) {
+        appendRuntimeWorkerRecord(root, String(failedReceipt.dispatchId), {
+          kind: "provider_event",
+          occurredAt: "2026-08-24T12:01:00.000Z",
+          event,
+        });
+      }
+      appendRuntimeWorkerRecord(root, String(failedReceipt.dispatchId), {
+        kind: "process_exit",
+        occurredAt: "2026-08-24T12:01:01.000Z",
+        exitCode: 0,
+        signal: null,
+      });
+      failSettlement = true;
+      assert.ok(exit, "failed-settlement runtime must attach its exit listener");
+      exit(0);
+      await eventually(() => {
+        const terminal = makeTaskEventStore({ repoId: "runtime-attached-tail", rootDir: root })
+          .read()
+          .events.find(
+            (event) =>
+              event.type === "runtime_session_outcome_observed" &&
+              event.payload.runtimeSessionId === failedReceipt.runtimeSessionId,
+          );
+        return terminal?.type === "runtime_session_outcome_observed" && terminal.payload.outcome === "unknown";
+      });
+      const failedEvents = makeTaskEventStore({ repoId: "runtime-attached-tail", rootDir: root }).read().events,
+        failedExitIndex = failedEvents.findIndex(
+          (event) =>
+            event.type === "runtime_session_exited" &&
+            event.payload.runtimeSessionId === failedReceipt.runtimeSessionId,
+        ),
+        failedOutcomeIndex = failedEvents.findIndex(
+          (event) =>
+            event.type === "runtime_session_outcome_observed" &&
+            event.payload.runtimeSessionId === failedReceipt.runtimeSessionId,
+        ),
+        failedStatus = await cell.read("repo.agentRuntime.sessions.read", {
+          runtimeSessionId: failedReceipt.runtimeSessionId,
+        });
+      assert.ok(failedExitIndex < failedOutcomeIndex, "the failed settlement still publishes one terminal outcome");
+      assert.equal(
+        failedEvents.filter(
+          (event) =>
+            event.type === "runtime_session_outcome_observed" &&
+            event.payload.runtimeSessionId === failedReceipt.runtimeSessionId,
+        ).length,
+        1,
+      );
+      assert.equal(failedStatus.session.activity.outcome, "unknown");
+      assert.match(failedStatus.result?.text ?? "", /runtime_lease_release_failed/u);
+      failSettlement = false;
+      assert.equal(
+        (await cell.run({ kind: "task-create", taskId: "task-after-settlement-failure", title: "Tail live" }, binding))
+          .outcome,
+        "applied",
+      );
+      assert.equal(
+        failedEvents.some(
+          (event) =>
+            event.type === "lease_released" &&
+            event.taskId === failedTaskId &&
+            event.payload.execution.executionId === failedExecutionId,
+        ),
+        true,
+      );
     } finally {
       await cell.close();
     }

--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -590,6 +590,11 @@ test("attached task runtime settlement releases its execution lease before publi
             event.type === "runtime_session_outcome_observed" &&
             event.payload.runtimeSessionId === failedReceipt.runtimeSessionId,
         ),
+        failedOutcome = failedEvents.find(
+          (event) =>
+            event.type === "runtime_session_outcome_observed" &&
+            event.payload.runtimeSessionId === failedReceipt.runtimeSessionId,
+        ),
         failedStatus = await cell.read("repo.agentRuntime.sessions.read", {
           runtimeSessionId: failedReceipt.runtimeSessionId,
         });
@@ -603,6 +608,11 @@ test("attached task runtime settlement releases its execution lease before publi
         1,
       );
       assert.equal(failedStatus.session.activity.outcome, "unknown");
+      assert.equal(
+        failedOutcome?.type === "runtime_session_outcome_observed" && failedOutcome.payload.reasonCode,
+        "runtime_lease_release_failed",
+      );
+      assert.equal(failedStatus.session.activity.reasonCode, "runtime_lease_release_failed");
       assert.match(failedStatus.result?.text ?? "", /runtime_lease_release_failed/u);
       failSettlement = false;
       assert.equal(

--- a/packages/kernel/src/domain/agent-runtime.ts
+++ b/packages/kernel/src/domain/agent-runtime.ts
@@ -102,6 +102,7 @@ export interface RuntimeSession {
   readonly outcome: "succeeded" | "failed" | "unknown" | "cancelled" | null;
   readonly exitCode: number | null;
   readonly resultRef: string | null;
+  readonly reasonCode?: string;
   readonly lastObservedAt: string;
 }
 export type RuntimeSessionSemanticState =
@@ -248,6 +249,7 @@ interface RuntimePayloads {
     readonly exitCode: number | null;
     readonly resultRef: string;
     readonly result: RuntimeResultClaim;
+    readonly reasonCode?: string;
   };
   readonly runtime_dispatch_outcome_unknown: { readonly dispatchId: string; readonly runtimeSessionId: string };
 }
@@ -310,7 +312,13 @@ function validateAgentRuntimePayloadFields(
   value: unknown,
   allowUnknownFields: boolean,
 ): readonly string[] {
-  if (!isRecord(value) || !(allowUnknownFields ? hasRequiredFields : hasOnlyFields)(value, payloadFields[type]))
+  const optionalFields = type === "runtime_session_outcome_observed" ? ["reasonCode"] : [];
+  if (
+    !isRecord(value) ||
+    !hasRequiredFields(value, payloadFields[type]) ||
+    (!allowUnknownFields &&
+      Object.keys(value).some((field) => !payloadFields[type].includes(field) && !optionalFields.includes(field)))
+  )
     return ["agent runtime payload fields are incomplete or unknown"];
   const ids = payloadFields[type].filter((field) => /(?:Id|Key)$/u.test(field));
   if (ids.some((field) => !isNonEmptyString(value[field]))) return ["agent runtime payload identity is invalid"];
@@ -351,6 +359,7 @@ function validateAgentRuntimePayloadFields(
     type === "runtime_session_outcome_observed" &&
     (!["succeeded", "failed", "unknown", "cancelled"].includes(String(value.outcome)) ||
       (value.exitCode !== null && (!Number.isInteger(value.exitCode) || (value.exitCode as number) < 0)) ||
+      (value.reasonCode !== undefined && !isNonEmptyString(value.reasonCode)) ||
       !validResult(value.resultRef, value.result, allowUnknownFields))
   )
     return ["runtime outcome observation is invalid"];
@@ -502,6 +511,7 @@ export function reduceRuntimeSession(
       outcome: event.payload.outcome,
       exitCode: event.payload.exitCode,
       resultRef: event.payload.resultRef,
+      ...(event.payload.reasonCode ? { reasonCode: event.payload.reasonCode } : {}),
       lastObservedAt: event.occurredAt,
     };
   return current;


### PR DESCRIPTION
# English

## Summary

Flow defect found by the Opus review of #1901: when terminal lease settlement failed, the error was swallowed by `repo-cell-open.ts`'s `pending.then(kick, kick)` and no outcome was published, while `cli-runtime-wait.ts` polled forever — `ha runtime status --wait` hung without a diagnostic. The swallow is deleted: a settlement failure now publishes one observable `unknown` terminal outcome carrying the original error code; the writer tail still self-heals without the rejection-side kick; the CLI exits with `runtime_settlement_failed` after a bounded number of observations of an exited runtime with no outcome (not a wall-clock timeout). Net -1 production line.

## Architectural Justification

- Not required: Production-Delta churn is below 200 lines.

## What Changed

- `packages/daemon/src/repo-cell-open.ts`, `runtime-spawn-settlement.ts`, `runtime-spawn-active.ts`: settlement failure → `unknown` outcome with the error code; rejection-side kick removed.
- `packages/cli/src/cli-runtime-wait.ts`: bounded observations then `runtime_settlement_failed` (registered error code).
- Tests: lifecycle 5/5, runtime-cli.integration 1/1, cli-wait 5/5 incl. injected settlement failure.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +113/-74

### Optional Evidence Claims

## Task And Scope

- Harness task: task_cd54c060b13573616503c4aec2
- Branch: codex/settlement-visibility
- Public scope: packages/daemon/src (repo-cell-open, runtime-spawn-settlement, runtime-spawn-active), packages/cli/src/cli-runtime-wait.ts, tests
- Private planning/evidence updated: yes
- Out of scope: GUI rendering of the new failure reason (reads the existing outcome/reason fields)

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_cd54c060b13573616503c4aec2
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 36f466d08c12b5eb22a4f766d05fd549f2befc79
- Branch merge-base with `origin/main`: 36f466d08c12b5eb22a4f766d05fd549f2befc79
- Last `git fetch origin` time: 2026-08-27T01:17:21Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_cd54c060b13573616503c4aec2 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Targeted daemon + CLI tests; implementation-contracts; check-cli-error-codes; line-density; CLI build
- [x] Opus review r1 NO-GO (fleet-edge 30s settlement window vs 5s bound; prose sniffing) → r2: edge publishes `exited` only after settlement; structured `reasonCode` replaces text matching; `isDaemonGone` guard restored
- [ ] Opus review r2
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO filed the defect from the #1901 review and wrote the plan (delete the swallow, no fallback); will read the diff.
- Reviewer subagent: Codex worker (gpt-5.6-sol); Opus review pending.
- Human review: pending
- Blocking findings: none

## Residual Risk

- A settlement failure now surfaces as an `unknown` outcome rather than a hang; operators must read the reason code to distinguish it from a genuine unknown worker exit.

## References

- Task: task_cd54c060b13573616503c4aec2
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

Opus 复核 #1901 时发现的流转缺陷:终态 lease 结算失败时,错误被 `repo-cell-open.ts` 的 `pending.then(kick, kick)` 吞掉且不发 outcome,而 `cli-runtime-wait.ts` 无限轮询——`ha runtime status --wait` 无诊断挂死。删掉吞错:结算失败现在发布唯一可观察的 `unknown` 终态并保留原始错误码;writer tail 仍自愈但不再静默做 rejection 侧 kick;CLI 在对「已退出但无 outcome」的 runtime 有界次数观察后以 `runtime_settlement_failed` 退出(不是墙钟超时)。生产净 -1 行。

## 架构辩护

- 不需要:Production-Delta churn 低于 200 行。

## 改动内容

- `packages/daemon/src/repo-cell-open.ts`、`runtime-spawn-settlement.ts`、`runtime-spawn-active.ts`:结算失败 → 带错误码的 `unknown` outcome;删 rejection 侧 kick。
- `packages/cli/src/cli-runtime-wait.ts`:有界观察后 `runtime_settlement_failed`(错误码已登记)。
- 测试:lifecycle 5/5、runtime-cli.integration 1/1、cli-wait 5/5(含注入结算失败)。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_cd54c060b13573616503c4aec2
- 分支:codex/settlement-visibility
- 公开范围:packages/daemon/src(repo-cell-open、runtime-spawn-settlement、runtime-spawn-active)、packages/cli/src/cli-runtime-wait.ts、测试
- 私有计划 / 证据是否已更新:yes
- 范围外:新失败原因的 GUI 渲染(读既有 outcome/reason 字段)

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_cd54c060b13573616503c4aec2
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:36f466d08c12b5eb22a4f766d05fd549f2befc79
- 当前分支与 `origin/main` 的 merge-base:36f466d08c12b5eb22a4f766d05fd549f2befc79
- 最近一次 `git fetch origin` 时间:2026-08-27T01:17:21Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_cd54c060b13573616503c4aec2
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] daemon + CLI 定向测试;implementation-contracts;check-cli-error-codes;line-density;CLI 构建
- [x] Opus 复核 r1 NO-GO(fleet-edge 30s 结算窗口 vs 5s 有界观察;文本嗅探)→ r2:edge 结算完成后才发布 `exited`;结构化 `reasonCode` 取代文本匹配;恢复 `isDaemonGone` 守卫
- [ ] Opus 复核 r2
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 从 #1901 复核立项并写 plan(删吞错,不加兜底);并读 diff。
- Reviewer subagent:Codex worker(gpt-5.6-sol);Opus 复核待做。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 结算失败现在表现为 `unknown` outcome 而非挂死;操作者需读 reason 码区分它与真实的 worker 未知退出。

## 关联材料

- 任务:task_cd54c060b13573616503c4aec2
- 证据:任务包 artifacts/reports
- 审查:本 PR
