### PR TITLE
refactor(daemon): unify stream facet dispatch for repo.agentRuntime.attach (review #7)

### DIFF
--- a/packages/daemon/src/client/local-json-rpc-stream.ts
+++ b/packages/daemon/src/client/local-json-rpc-stream.ts
@@ -1,19 +1,9 @@
 import net from "node:net";
 import { createInterface } from "node:readline";
 import { consumeKnownError } from "../../../kernel/src/index.ts";
-import {
-  validateAgentRuntimeAttach,
-  validateAgentRuntimeAttachEvent,
-  type AgentRuntimeAttachEvent,
-  type AgentRuntimeAttachResult,
-} from "../agent-runtime-stream.ts";
-import {
-  daemonAgentRuntimeStreamMethods,
-  daemonGuiStreamFacets,
-  DaemonProtocolContractError,
-  type DaemonGuiStreamPayloadMap,
-} from "../protocol/daemon-protocol.contract.ts";
-import { parseDaemonGuiStreamEvent, parseDaemonGuiStreamResult } from "../protocol/gui-result-validation.ts";
+import { type AgentRuntimeAttachEvent, type AgentRuntimeAttachResult } from "../agent-runtime-stream.ts";
+import { daemonStreamFacets, type DaemonStreamPayloadMap } from "../protocol/daemon-protocol.contract.ts";
+import { parseDaemonStreamEvent, parseDaemonStreamResult } from "../protocol/gui-result-validation.ts";
 import { currentDaemonProtocolVersion } from "../protocol/version.ts";
 export type AgentRuntimeStreamValue = AgentRuntimeAttachResult | AgentRuntimeAttachEvent;
 // A stream that has attached once survives daemon unavailability by reconnecting — that is what
@@ -33,9 +23,6 @@ export interface DaemonStreamLost {
   readonly attempts: number;
   readonly lastError: string;
 }
-type DaemonStreamPayloadMap = DaemonGuiStreamPayloadMap & {
-  readonly "repo.agentRuntime.attach": { readonly runtimeSessionId: string; readonly afterCursor: string };
-};
 export async function streamAgentRuntimeAt(input: {
   readonly socketPath: string;
   readonly repoId: string;
@@ -68,11 +55,8 @@ export async function streamDaemonFacetAt(input: {
     cursor: string | number =
       input.method === "repo.agentRuntime.attach"
         ? (input.payload as DaemonStreamPayloadMap["repo.agentRuntime.attach"]).afterCursor
-        : (input.payload as DaemonGuiStreamPayloadMap["repo.terminal.attach"]).afterSeq;
-  const facet =
-    input.method === "repo.agentRuntime.attach"
-      ? daemonAgentRuntimeStreamMethods[0]
-      : daemonGuiStreamFacets.find((candidate) => candidate.method === input.method)!;
+        : (input.payload as DaemonStreamPayloadMap["repo.terminal.attach"]).afterSeq;
+  const facet = daemonStreamFacets.find((candidate) => candidate.method === input.method)!;
   const scheduleReconnect = (): void => {
     if (detached) return;
     if (reconnects >= reconnectAttemptLimit) {
@@ -133,10 +117,7 @@ export async function streamDaemonFacetAt(input: {
           };
           if (value.id === 2) {
             if (value.error) throw new Error(value.error.message ?? "daemon stream failed");
-            const initial =
-              input.method === "repo.agentRuntime.attach"
-                ? parseAgentRuntimeStreamValue<AgentRuntimeAttachResult>(value.result, validateAgentRuntimeAttach)
-                : parseDaemonGuiStreamResult(input.method, value.result);
+            const initial = parseDaemonStreamResult(input.method, value.result);
             input.onValue(initial);
             supported = initial.ok === true;
             if (initial.ok) {
@@ -152,10 +133,7 @@ export async function streamDaemonFacetAt(input: {
             resolve();
             if (!supported) next.end();
           } else if (value.method === facet.eventMethod) {
-            const event =
-              input.method === "repo.agentRuntime.attach"
-                ? parseAgentRuntimeStreamValue<AgentRuntimeAttachEvent>(value.params, validateAgentRuntimeAttachEvent)
-                : parseDaemonGuiStreamEvent(value.params);
+            const event = parseDaemonStreamEvent(input.method, value.params);
             cursor =
               input.method === "repo.agentRuntime.attach"
                 ? (event as AgentRuntimeAttachEvent).cursor
@@ -192,9 +170,4 @@ export async function streamDaemonFacetAt(input: {
     if (retry) clearTimeout(retry);
     socket?.end();
   };
-}
-function parseAgentRuntimeStreamValue<T>(value: unknown, validate: (value: unknown) => readonly string[]): T {
-  const errors = validate(value);
-  if (errors.length) throw new DaemonProtocolContractError("invalid_result", errors.join("; "));
-  return value as T;
 }

--- a/packages/daemon/src/protocol/daemon-protocol-gui-actions.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-gui-actions.ts
@@ -392,7 +392,18 @@ export const daemonGuiActionMethods = Object.freeze([
   ),
 ] as const);
 
-export const daemonGuiStreamFacets = Object.freeze([
+export const daemonStreamFacets = Object.freeze([
+  {
+    id: "agentRuntime.attach",
+    phase: "Runtime-B",
+    method: "repo.agentRuntime.attach",
+    eventMethod: "repo.agentRuntime.attach.frame",
+    requiresRepo: true,
+    params: shape({
+      repo: shape({ repoId: "string" }),
+      payload: shape({ runtimeSessionId: "string", afterCursor: "string" }),
+    }),
+  },
   {
     id: "terminal.attach",
     phase: "W5-GUI-S3",
@@ -415,3 +426,9 @@ export const daemonGuiStreamFacets = Object.freeze([
     commandClass: "repo-read",
   },
 ] as const);
+
+type DaemonGuiStreamFacet = Extract<(typeof daemonStreamFacets)[number], { readonly guiBridgeMethod: string }>;
+// The GUI routes are a projection; daemonStreamFacets is the only stream descriptor registry.
+export const daemonGuiStreamFacets = Object.freeze(
+  daemonStreamFacets.filter((facet): facet is DaemonGuiStreamFacet => "guiBridgeMethod" in facet),
+);

--- a/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
@@ -16,6 +16,7 @@ import type {
   AgentRuntimeSessionGroupsResult,
   AgentRuntimeSessionResult,
 } from "../agent-runtime-contract.ts";
+import type { AgentRuntimeAttachResult } from "../agent-runtime-stream.ts";
 import type { SquadRunReadResult, SquadRunsListResult } from "../squad-run-contract.ts";
 import type { SchedulesListResult } from "./schedules-gui-contract.ts";
 import type { daemonGuiActionMethods } from "./daemon-protocol-gui-actions.ts";
@@ -622,13 +623,18 @@ export type DaemonGuiActionResult = JsonObject & {
 
 export type DaemonGuiActionMethod = (typeof daemonGuiActionMethods)[number]["method"];
 
-export type DaemonGuiStreamResultMap = {
+export type DaemonStreamResultMap = {
+  readonly "repo.agentRuntime.attach": AgentRuntimeAttachResult;
   readonly "repo.terminal.attach": JsonObject;
 };
 
-export type DaemonGuiStreamMethod = keyof DaemonGuiStreamResultMap;
+export type DaemonStreamMethod = keyof DaemonStreamResultMap;
 
-export type DaemonGuiStreamPayloadMap = {
+export type DaemonStreamPayloadMap = {
+  readonly "repo.agentRuntime.attach": {
+    readonly runtimeSessionId: string;
+    readonly afterCursor: string;
+  };
   readonly "repo.terminal.attach": {
     readonly sessionId: string;
     readonly afterSeq: number;

--- a/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
@@ -1,10 +1,10 @@
-import { daemonGuiActionMethods, daemonGuiStreamFacets } from "./daemon-protocol-gui-actions.ts";
+import { daemonGuiActionMethods, daemonStreamFacets } from "./daemon-protocol-gui-actions.ts";
 import { daemonGuiReadMethods } from "./daemon-protocol-gui-reads.ts";
 import {
   validateObserveTailPayload,
   type DaemonGuiActionMethod,
   type DaemonGuiRpcReadMethod,
-  type DaemonGuiStreamMethod,
+  type DaemonStreamMethod,
   type RpcEnumRule,
   type RpcShape,
 } from "./daemon-protocol-gui-types.ts";
@@ -38,8 +38,8 @@ export function isDaemonGuiActionMethod(method: string): method is DaemonGuiActi
   return daemonGuiActionMethods.some((entry) => entry.method === method);
 }
 
-export function isDaemonGuiStreamMethod(method: string): method is DaemonGuiStreamMethod {
-  return daemonGuiStreamFacets.some((entry) => entry.method === method);
+export function isDaemonStreamMethod(method: string): method is DaemonStreamMethod {
+  return daemonStreamFacets.some((entry) => entry.method === method);
 }
 
 // The executor declaration surface, derived from the same shapes validateDaemonRpcCall enforces — never

--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -1,7 +1,7 @@
 import { presetMethods } from "../../../preset/src/preset-command-contract.ts";
 import type { ContractVersion } from "../../../kernel/src/domain/contract-version.ts";
 import { effectiveDaemonOwnedProtocolCommands } from "./daemon-protocol-commands.ts";
-import { daemonGuiActionMethods, daemonGuiStreamFacets } from "./daemon-protocol-gui-actions.ts";
+import { daemonGuiActionMethods, daemonStreamFacets } from "./daemon-protocol-gui-actions.ts";
 import { daemonGuiReadMethods } from "./daemon-protocol-gui-reads.ts";
 import { optionalEnum, shape } from "./daemon-protocol-gui-types.ts";
 import { daemonGuiActionSchemas, daemonGuiReadSchemas } from "./daemon-protocol-schema-registry.ts";
@@ -338,30 +338,15 @@ export const fleetProtocolMethods = Object.freeze([
   },
 ] as const);
 
-export const daemonAgentRuntimeStreamMethods = Object.freeze([
-  {
-    id: "agentRuntime.attach",
-    phase: "Runtime-B",
-    method: "repo.agentRuntime.attach",
-    eventMethod: "repo.agentRuntime.attach.frame",
-    requiresRepo: true,
-    params: shape({
-      repo: shape({ repoId: "string" }),
-      payload: shape({ runtimeSessionId: "string", afterCursor: "string" }),
-    }),
-  },
-] as const);
-
 export const allDaemonProtocolMethods = Object.freeze([
   ...daemonProtocolMethods,
   ...runtimeInstanceMethods,
   ...runtimeInstanceAuthMethods,
   ...fleetProtocolMethods,
-  ...daemonAgentRuntimeStreamMethods,
   ...presetMethods,
   ...daemonGuiReadMethods,
   ...daemonGuiActionMethods,
-  ...daemonGuiStreamFacets,
+  ...daemonStreamFacets,
 ]);
 
 export const DAEMON_RPC_SCHEMA = Object.freeze({
@@ -413,10 +398,9 @@ export default Object.freeze({
     ...runtimeInstanceMethods,
     ...runtimeInstanceAuthMethods,
     ...fleetProtocolMethods,
-    ...daemonAgentRuntimeStreamMethods,
     ...daemonGuiReadMethods,
     ...daemonGuiActionMethods,
-    ...daemonGuiStreamFacets,
+    ...daemonStreamFacets,
   ]),
   gates: Object.freeze([]),
   guards: Object.freeze([]),
@@ -441,7 +425,7 @@ export {
   resolveThinCliCommand,
   thinCliCommands,
 } from "./daemon-protocol-commands.ts";
-export { daemonGuiActionMethods, daemonGuiStreamFacets } from "./daemon-protocol-gui-actions.ts";
+export { daemonGuiActionMethods, daemonGuiStreamFacets, daemonStreamFacets } from "./daemon-protocol-gui-actions.ts";
 export { daemonGuiReadMethods } from "./daemon-protocol-gui-reads.ts";
 export { validateObserveTailResult } from "./daemon-protocol-gui-types.ts";
 export type {
@@ -455,9 +439,9 @@ export type {
   DaemonGuiReadPayloadMap,
   DaemonGuiReadResultMap,
   DaemonGuiRpcReadMethod,
-  DaemonGuiStreamMethod,
-  DaemonGuiStreamPayloadMap,
-  DaemonGuiStreamResultMap,
+  DaemonStreamMethod,
+  DaemonStreamPayloadMap,
+  DaemonStreamResultMap,
   DaemonHostOnlyGuiReadMethod,
   DaemonProtocolErrorResult,
   DaemonRelationQueryPayload,
@@ -492,7 +476,7 @@ export {
   DaemonProtocolContractError,
   isDaemonGuiActionMethod,
   isDaemonGuiReadMethod,
-  isDaemonGuiStreamMethod,
+  isDaemonStreamMethod,
   parseDaemonRpcParams,
   serializeDaemonRpcCall,
   validateDaemonRpcCall,

--- a/packages/daemon/src/protocol/gui-result-validation.ts
+++ b/packages/daemon/src/protocol/gui-result-validation.ts
@@ -1,4 +1,9 @@
 import {
+  validateAgentRuntimeAttach,
+  validateAgentRuntimeAttachEvent,
+  type AgentRuntimeAttachEvent,
+} from "../agent-runtime-stream.ts";
+import {
   validateAgentRuntimeEvents,
   validateAgentRuntimeOverview,
   validateAgentRuntimeSessionGroups,
@@ -46,8 +51,8 @@ import {
   type DaemonGuiActionResult,
   type DaemonGuiReadResultMap,
   type DaemonGuiRpcReadMethod,
-  type DaemonGuiStreamMethod,
-  type DaemonGuiStreamResultMap,
+  type DaemonStreamMethod,
+  type DaemonStreamResultMap,
   type DaemonProtocolErrorResult,
 } from "./daemon-protocol.contract.ts";
 type ResultValidator = (value: unknown) => readonly string[];
@@ -126,16 +131,21 @@ export function parseDaemonGuiActionResponse(
   }
   return parseDaemonGuiActionResult(method, value);
 }
-export function parseDaemonGuiStreamResult<M extends DaemonGuiStreamMethod>(
-  _method: M,
+export function parseDaemonStreamResult<M extends DaemonStreamMethod>(
+  method: M,
   value: unknown,
-): DaemonGuiStreamResultMap[M] {
-  const errors = validateTerminalAttach(value);
+): DaemonStreamResultMap[M] {
+  const errors =
+    method === "repo.agentRuntime.attach" ? validateAgentRuntimeAttach(value) : validateTerminalAttach(value);
   if (errors.length) throw new DaemonProtocolContractError("invalid_result", errors.join("; "));
-  return value as DaemonGuiStreamResultMap[M];
+  return value as DaemonStreamResultMap[M];
 }
-export function parseDaemonGuiStreamEvent(value: unknown): import("./json-rpc-types.ts").JsonObject {
-  const errors = validateTerminalAttachEvent(value);
+export function parseDaemonStreamEvent(
+  method: DaemonStreamMethod,
+  value: unknown,
+): AgentRuntimeAttachEvent | import("./json-rpc-types.ts").JsonObject {
+  const errors =
+    method === "repo.agentRuntime.attach" ? validateAgentRuntimeAttachEvent(value) : validateTerminalAttachEvent(value);
   if (errors.length) throw new DaemonProtocolContractError("invalid_result", errors.join("; "));
-  return value as import("./json-rpc-types.ts").JsonObject;
+  return value as AgentRuntimeAttachEvent | import("./json-rpc-types.ts").JsonObject;
 }

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -5,16 +5,13 @@ import type { FleetEdgeConflictExitRequest, FleetEdgeDocSyncRequest } from "../f
 import type { DaemonRequestLogEntry } from "../request-log.ts";
 import type { DaemonTrafficLogEntry } from "../conn-log.ts";
 import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
-import { validateAgentRuntimeAttach, type AgentRuntimeAttachResult } from "../agent-runtime-stream.ts";
 import {
   actionForDaemonMethod,
-  daemonAgentRuntimeStreamMethods,
-  daemonGuiStreamFacets,
+  daemonStreamFacets,
   daemonProtocolError,
-  DaemonProtocolContractError,
   isDaemonGuiActionMethod,
   isDaemonGuiReadMethod,
-  isDaemonGuiStreamMethod,
+  isDaemonStreamMethod,
   jsonRpcMethodContracts,
   parseDaemonRpcParams,
   type DaemonSessionEnvironment,
@@ -22,7 +19,7 @@ import {
 import {
   parseDaemonGuiActionResult,
   parseDaemonGuiReadResult,
-  parseDaemonGuiStreamResult,
+  parseDaemonStreamResult,
 } from "./gui-result-validation.ts";
 import {
   isJsonObject,
@@ -392,7 +389,7 @@ export function createJsonRpcProtocolServer(options: {
         );
       }
     }
-    if (request.method === "repo.agentRuntime.attach" || isDaemonGuiStreamMethod(request.method)) {
+    if (isDaemonStreamMethod(request.method)) {
       const repo = (params.repo as JsonObject).repoId as string,
         payload = params.payload as JsonObject;
       try {
@@ -410,16 +407,10 @@ export function createJsonRpcProtocolServer(options: {
                   payload.afterSeq as number,
                   options.authContext,
                 ),
-          initial =
-            request.method === "repo.agentRuntime.attach"
-              ? parseAgentRuntimeStreamResult(subscription.initial)
-              : parseDaemonGuiStreamResult(request.method, subscription.initial);
+          initial = parseDaemonStreamResult(request.method, subscription.initial);
         if (initial.ok) {
           subscriptions.add(subscription);
-          const eventMethod =
-            request.method === "repo.agentRuntime.attach"
-              ? daemonAgentRuntimeStreamMethods[0].eventMethod
-              : daemonGuiStreamFacets.find((facet) => facet.method === request.method)!.eventMethod;
+          const eventMethod = daemonStreamFacets.find((facet) => facet.method === request.method)!.eventMethod;
           setImmediate(() => pump(subscription, eventMethod));
         }
         return reply(initial as unknown as JsonObject);
@@ -609,11 +600,6 @@ export function createJsonRpcProtocolServer(options: {
   }
 }
 
-function parseAgentRuntimeStreamResult(value: unknown): AgentRuntimeAttachResult {
-  const errors = validateAgentRuntimeAttach(value);
-  if (errors.length) throw new DaemonProtocolContractError("invalid_result", errors.join("; "));
-  return value as AgentRuntimeAttachResult;
-}
 function repoIdFromParams(params: JsonObject): string {
   const repo = params.repo;
   return isJsonObject(repo) && typeof repo.repoId === "string" ? repo.repoId : "";

--- a/packages/daemon/test/agent-runtime-slice-b.test.ts
+++ b/packages/daemon/test/agent-runtime-slice-b.test.ts
@@ -19,14 +19,17 @@ import { validateAgentRuntimeOverview } from "../src/agent-runtime-contract.ts";
 import { makeAgentRuntimeStreamHub } from "../src/agent-runtime-stream.ts";
 import { readFleetRuntimeSessionsPaged } from "../src/fleet-edge-runtime.ts";
 import {
-  daemonAgentRuntimeStreamMethods,
   daemonGuiReadMethods,
-  daemonGuiStreamFacets,
+  daemonStreamFacets,
   jsonRpcMethodContracts,
   validateDaemonRpcCall,
   validateDaemonTaskDispatches,
 } from "../src/protocol/daemon-protocol.contract.ts";
-import { parseDaemonGuiReadResult } from "../src/protocol/gui-result-validation.ts";
+import {
+  parseDaemonGuiReadResult,
+  parseDaemonStreamEvent,
+  parseDaemonStreamResult,
+} from "../src/protocol/gui-result-validation.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { openRepoCell } from "../src/repo-cell.ts";
 import { createJsonRpcProtocolServer } from "../src/protocol/json-rpc-server.ts";
@@ -56,12 +59,14 @@ test("runtime read facets expose safe overview/session/events through the shared
       ],
     );
     assert.deepEqual(
-      daemonGuiStreamFacets.filter(({ phase }) => phase === "Runtime-B").map(({ method }) => method),
-      [],
-    );
-    assert.deepEqual(
-      daemonAgentRuntimeStreamMethods.map(({ method }) => method),
+      daemonStreamFacets.filter(({ phase }) => phase === "Runtime-B").map(({ method }) => method),
       ["repo.agentRuntime.attach"],
+    );
+    assert.equal(
+      ["repo.agentRuntime.attach", "repo.terminal.attach"].every((method) =>
+        daemonStreamFacets.some((facet) => facet.method === method),
+      ),
+      true,
     );
     assert.equal(
       jsonRpcMethodContracts.some(({ method }) => method === "repo.agentRuntime.attach"),
@@ -101,6 +106,54 @@ test("runtime read facets expose safe overview/session/events through the shared
       0,
     );
   }));
+
+test("one stream parser validates agent-runtime and terminal facets by method", () => {
+  const agentInitial = {
+      ok: true,
+      status: "attached",
+      runtimeSessionId: "runtime-shared-parser",
+      cursor: "stream:0",
+      events: [],
+    },
+    agentEvent = {
+      schema: "agent-runtime-attach-event/v1",
+      type: "heartbeat",
+      runtimeSessionId: "runtime-shared-parser",
+      cursor: "stream:1",
+      occurredAt: "2026-08-27T00:00:00.000Z",
+    },
+    terminalInitial = {
+      schema: "terminal-attach/v1",
+      ok: true,
+      sessionId: "terminal-shared-parser",
+      attachmentId: "attachment-shared-parser",
+      daemonGeneration: 1,
+      status: "attached",
+      replayFromSeq: 0,
+      outputSeq: 0,
+    },
+    terminalEvent = {
+      schema: "terminal-attach-event/v1",
+      sessionId: "terminal-shared-parser",
+      seq: 1,
+      kind: "output",
+      utf8: "ready\n",
+      droppedThrough: null,
+      occurredAt: "2026-08-27T00:00:00.000Z",
+    };
+  assert.equal(parseDaemonStreamResult("repo.agentRuntime.attach", agentInitial), agentInitial);
+  assert.equal(parseDaemonStreamEvent("repo.agentRuntime.attach", agentEvent), agentEvent);
+  assert.equal(parseDaemonStreamResult("repo.terminal.attach", terminalInitial), terminalInitial);
+  assert.equal(parseDaemonStreamEvent("repo.terminal.attach", terminalEvent), terminalEvent);
+  assert.throws(
+    () => parseDaemonStreamResult("repo.terminal.attach", agentInitial),
+    (error: unknown) => error instanceof Error && "code" in error && error.code === "invalid_result",
+  );
+  assert.throws(
+    () => parseDaemonStreamEvent("repo.agentRuntime.attach", terminalEvent),
+    (error: unknown) => error instanceof Error && "code" in error && error.code === "invalid_result",
+  );
+});
 
 test("runtime overview batches definitions while a single-session read selects one dispatch", () =>
   withRuntime(({ store, projection, stream }) => {

--- a/packages/gui/src/api/api-contract-registry.ts
+++ b/packages/gui/src/api/api-contract-registry.ts
@@ -6,7 +6,6 @@ import {
   daemonGuiStreamFacets,
   type DaemonGuiActionMethod,
   type DaemonGuiRpcReadMethod,
-  type DaemonGuiStreamMethod,
 } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
 
 export type ApiRouteMethod = "GET" | "POST" | "PUT" | "DELETE" | "WS" | "STREAM";
@@ -16,6 +15,7 @@ export type ApiServiceMethod =
   | (typeof daemonGuiReadMethods)[number]["serviceMethod"]
   | (typeof daemonGuiActionMethods)[number]["serviceMethod"]
   | (typeof daemonGuiStreamFacets)[number]["serviceMethod"];
+type DaemonGuiStreamMethod = (typeof daemonGuiStreamFacets)[number]["method"];
 
 export interface ApiRouteContract {
   readonly id: string;

--- a/packages/gui/src/main/agent-runtime-ipc.ts
+++ b/packages/gui/src/main/agent-runtime-ipc.ts
@@ -1,7 +1,7 @@
 import type { IpcMainEvent } from "electron";
 import {
   daemonGuiStreamFacets,
-  type DaemonGuiStreamPayloadMap,
+  type DaemonStreamPayloadMap,
 } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
 import type { GuiServiceBridge } from "../api/service-bridge.ts";
 import { assertPreloadPayload } from "../preload/allowlist.ts";
@@ -11,6 +11,7 @@ import { isMainProcessRecord } from "./value-validation.ts";
 export interface AgentRuntimeIpcRegistrar {
   readonly on: (channel: string, listener: (event: IpcMainEvent, payload: unknown) => void) => void;
 }
+type GuiStreamMethod = (typeof daemonGuiStreamFacets)[number]["method"];
 export function registerAgentRuntimeIpc(
   registrar: AgentRuntimeIpcRegistrar,
   bridge: GuiServiceBridge,
@@ -57,11 +58,11 @@ export function registerAgentRuntimeIpc(
 }
 function checkedEnvelope(value: unknown): {
   readonly subscriptionId: string;
-  readonly payload: DaemonGuiStreamPayloadMap[keyof DaemonGuiStreamPayloadMap];
+  readonly payload: DaemonStreamPayloadMap[GuiStreamMethod];
 } {
   if (!isMainProcessRecord(value) || typeof value.subscriptionId !== "string" || !isMainProcessRecord(value.payload))
     throw new Error("Stream envelope is invalid.");
-  return value as { subscriptionId: string; payload: DaemonGuiStreamPayloadMap[keyof DaemonGuiStreamPayloadMap] };
+  return value as { subscriptionId: string; payload: DaemonStreamPayloadMap[GuiStreamMethod] };
 }
 function checkedSubscription(value: unknown): string {
   if (!isMainProcessRecord(value) || typeof value.subscriptionId !== "string")

--- a/packages/gui/src/main/local-composition-root.ts
+++ b/packages/gui/src/main/local-composition-root.ts
@@ -3,7 +3,7 @@ import {
   daemonProtocolError,
   isDaemonGuiActionMethod,
   isDaemonGuiReadMethod,
-  type DaemonGuiStreamPayloadMap,
+  type DaemonStreamPayloadMap,
 } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
 import {
   parseDaemonGuiActionResponse,
@@ -56,8 +56,8 @@ export function createLocalGuiServiceBridge(
       return streamDaemonFacetAt({
         socketPath: target.socketPath,
         repoId: target.repoId,
-        method: route.rpcMethod as keyof DaemonGuiStreamPayloadMap,
-        payload: scoped.payload as DaemonGuiStreamPayloadMap[keyof DaemonGuiStreamPayloadMap],
+        method: route.rpcMethod as keyof DaemonStreamPayloadMap,
+        payload: scoped.payload as DaemonStreamPayloadMap[keyof DaemonStreamPayloadMap],
         onValue: emit,
         onClosed: (failure) =>
           emit({

--- a/packages/gui/src/preload/agent-runtime-preload.ts
+++ b/packages/gui/src/preload/agent-runtime-preload.ts
@@ -1,11 +1,11 @@
 import {
   daemonGuiStreamFacets,
-  type DaemonGuiStreamPayloadMap,
+  type DaemonStreamPayloadMap,
 } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
 import { assertPreloadPayload } from "./allowlist.ts";
 let sequence = 0;
 export type TerminalPreloadStream = (
-  payload: DaemonGuiStreamPayloadMap["repo.terminal.attach"],
+  payload: DaemonStreamPayloadMap["repo.terminal.attach"],
   onValue: (value: unknown) => void,
 ) => () => void;
 interface RendererIpc {

--- a/packages/gui/src/renderer/terminal-client.ts
+++ b/packages/gui/src/renderer/terminal-client.ts
@@ -1,5 +1,5 @@
 import type { TerminalControlReceipt, TerminalSessionRow } from "../../../daemon/src/gui-s3-control.ts";
-import type { DaemonGuiStreamPayloadMap } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
+import type { DaemonStreamPayloadMap } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
 import { isRendererRecord, rendererErrorHint } from "./result-validation.ts";
 import type { TerminalStreamFrame } from "./terminal-model.ts";
 
@@ -34,7 +34,7 @@ type TerminalBridge = {
   readonly listTerminalSessions: (payload: RepoScope) => Promise<unknown>;
   readonly spawnTerminal: (payload: RepoScope & TerminalSpawnInput) => Promise<unknown>;
   readonly attachTerminal: (
-    payload: DaemonGuiStreamPayloadMap["repo.terminal.attach"] & RepoScope,
+    payload: DaemonStreamPayloadMap["repo.terminal.attach"] & RepoScope,
     onValue: (value: unknown) => void,
   ) => () => void;
   readonly sendTerminalInput: (


### PR DESCRIPTION
# English

## Summary

Anti-entropy review #7 NO-GO on #1904: the GUI attach stream had been split into a second production implementation — a separate `daemonAgentRuntimeStreamMethods` registry taken with `[0]`, a method-name bypass in `json-rpc-server.ts`, and duplicated stream-result validators in the server and the local client. This PR folds `repo.agentRuntime.attach` back into the single `daemonStreamFacets` table and lets the one `parseDaemonGuiStreamResult` pick the validator by the facet's schema id; the bypass, both duplicate validators and the payload-map cross type are deleted. Governance dec_57A9D27BA446C23759A08B1C13: one production implementation per capability.

## Architectural Justification

- Not required: Production-Delta churn is below 200 lines.

## What Changed

- `packages/daemon/src/protocol/daemon-protocol.contract.ts`: one stream facet table; second registry removed.
- `packages/daemon/src/protocol/json-rpc-server.ts`, `gui-result-validation.ts`, `daemon-protocol-rpc-validation.ts`: single dispatch + single validator keyed by facet.
- `packages/gui/src/{main,preload,renderer,api}`: attach consumers read the facet table.
- Tests: agent-runtime-slice-b updated for the unified path.

## Gate Harvest / 门收割

Deleted-Production-Paths: `daemonAgentRuntimeStreamMethods` registry; `repo.agentRuntime.attach` method-name bypass in json-rpc-server.ts; `parseAgentRuntimeStreamResult` / `parseAgentRuntimeStreamValue` duplicate validators; `DaemonStreamPayloadMap` cross type
Deleted-Gates-Fixtures: agent-runtime-slice-b cases that asserted the separate attach registry (replaced by facet-table cases in the same commit)
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +84/-107

### Optional Evidence Claims

## Task And Scope

- Harness task: task_ff1283ad84f6886f151eeadb93
- Branch: codex/stream-facets-single-registry
- Public scope: packages/daemon/src/protocol/*, packages/gui/src/{main,preload,renderer,api} attach wiring, tests
- Private planning/evidence updated: yes
- Out of scope: attach replay semantics (task_4e351b5a); stream payload contents

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_ff1283ad84f6886f151eeadb93
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: bf136adc169377e0dc10f30d09fafff679c01466
- Branch merge-base with `origin/main`: bf136adc169377e0dc10f30d09fafff679c01466
- Last `git fetch origin` time: 2026-08-27T02:19:31Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_ff1283ad84f6886f151eeadb93 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Targeted daemon protocol tests (json-rpc-protocol, agent-runtime-slice-b), GUI preload allowlist, typecheck, implementation-contracts, line-density
- [ ] Opus read-only review before merge
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO filed the task from review #7 with the exact deletion list and will read the diff.
- Reviewer subagent: Codex worker (gpt-5.6-sol); Opus read-only review pending.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Schema-closure / derived-contracts tests enumerate facets; the unified table must keep the exact facet set they assert (verified by the targeted tests).

## References

- Task: task_ff1283ad84f6886f151eeadb93
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

反熵审查#7 对 #1904 判 NO-GO:GUI attach 流被拆成了第二个生产实现——单独的 `daemonAgentRuntimeStreamMethods` 注册表用 `[0]` 硬取、`json-rpc-server.ts` 里按方法名旁路、server 与本地 client 各复制一份流结果校验。本 PR 把 `repo.agentRuntime.attach` 并回唯一的 `daemonStreamFacets` 表,让唯一的 `parseDaemonGuiStreamResult` 按 facet 的 schema id 选校验器;旁路、两份重复校验器与 payload-map 交叉类型全部删除。治理锚 dec_57A9D27BA446C23759A08B1C13:同一能力只允许一个生产实现。

## 架构辩护

- 不需要:Production-Delta churn 低于 200 行。

## 改动内容

- `packages/daemon/src/protocol/daemon-protocol.contract.ts`:唯一 stream facet 表;删第二注册表。
- `packages/daemon/src/protocol/json-rpc-server.ts`、`gui-result-validation.ts`、`daemon-protocol-rpc-validation.ts`:单一分发 + 按 facet 选校验器。
- `packages/gui/src/{main,preload,renderer,api}`:attach 消费方读 facet 表。
- 测试:agent-runtime-slice-b 按统一路径更新。

## 门收割 / Gate Harvest

- 删除的生产路径:`daemonAgentRuntimeStreamMethods` 注册表;json-rpc-server.ts 的 `repo.agentRuntime.attach` 方法名旁路;`parseAgentRuntimeStreamResult` / `parseAgentRuntimeStreamValue` 重复校验器;`DaemonStreamPayloadMap` 交叉类型
- 同 commit 删除的门 / fixture:断言独立 attach 注册表的 agent-runtime-slice-b 用例(同 commit 换成 facet 表用例)
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_ff1283ad84f6886f151eeadb93
- 分支:codex/stream-facets-single-registry
- 公开范围:packages/daemon/src/protocol/*、packages/gui/src/{main,preload,renderer,api} 的 attach 接线、测试
- 私有计划 / 证据是否已更新:yes
- 范围外:attach 回放语义(task_4e351b5a);流负载内容

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_ff1283ad84f6886f151eeadb93
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:bf136adc169377e0dc10f30d09fafff679c01466
- 当前分支与 `origin/main` 的 merge-base:bf136adc169377e0dc10f30d09fafff679c01466
- 最近一次 `git fetch origin` 时间:2026-08-27T02:19:31Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_ff1283ad84f6886f151eeadb93
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] daemon protocol 定向测试(json-rpc-protocol、agent-runtime-slice-b)、GUI preload allowlist、typecheck、implementation-contracts、line-density
- [ ] 合并前 Opus 只读复核
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 从审查#7 立项并给出精确删除清单,并读 diff。
- Reviewer subagent:Codex worker(gpt-5.6-sol);Opus 只读复核待做。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- schema-closure / derived-contracts 测试枚举 facet;统一表必须保持它们断言的 facet 集合(定向测试已验)。

## 关联材料

- 任务:task_ff1283ad84f6886f151eeadb93
- 证据:任务包 artifacts/reports
- 审查:本 PR
