### PR TITLE
fix(daemon): reject symlink escapes in runtime and terminal cwd

### DIFF
--- a/packages/daemon/src/contained-path.ts
+++ b/packages/daemon/src/contained-path.ts
@@ -1,0 +1,17 @@
+import { realpathSync } from "node:fs";
+import path from "node:path";
+import { consumeKnownError } from "../../kernel/src/index.ts";
+
+export function resolveContainedPath(rootDir: string, requestedPath: string): string | null {
+  let root: string, candidate: string;
+  try {
+    root = realpathSync.native(rootDir);
+    candidate = realpathSync.native(path.resolve(rootDir, requestedPath));
+  } catch (error) {
+    consumeKnownError(error);
+    return null;
+  }
+  const relative = path.relative(root, candidate);
+  if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) return null;
+  return candidate;
+}

--- a/packages/daemon/src/runtime-spawn-mission.ts
+++ b/packages/daemon/src/runtime-spawn-mission.ts
@@ -6,6 +6,7 @@ import { agentRolePrompt } from "./agent-role-prompts.ts";
 import { runtimeTypeMatchesKind } from "./agent-runtime-contract.ts";
 import type { RuntimeInstanceSummary } from "./agent-runtime-instances.ts";
 import { type ResolvedAgentSkill } from "./agent-skills.ts";
+import { resolveContainedPath } from "./contained-path.ts";
 import { requiredRuntimeSpawnText, runtimeSpawnError } from "./runtime-spawn-errors.ts";
 import type { RuntimeAgent, RuntimeDaemonRoute, RuntimeSessionSelection } from "./runtime-spawn-types.ts";
 
@@ -19,9 +20,9 @@ export function resolveRuntimeCwd(root: string, value: unknown): string {
     !["repo-root", "repo-relative"].includes(String(cwd.scope))
   )
     throw runtimeSpawnError("invalid_runtime_cwd", "Runtime cwd scope is invalid.");
-  const resolved =
-    cwd.scope === "repo-root" ? root : path.resolve(root, requiredRuntimeSpawnText(cwd.path, "cwd.path"));
-  if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`))
+  const requestedPath = cwd.scope === "repo-root" ? "." : requiredRuntimeSpawnText(cwd.path, "cwd.path"),
+    resolved = resolveContainedPath(root, requestedPath);
+  if (resolved === null)
     throw runtimeSpawnError("invalid_runtime_cwd", "Runtime cwd must stay inside the repository.");
   return resolved;
 }

--- a/packages/daemon/src/terminal-host.ts
+++ b/packages/daemon/src/terminal-host.ts
@@ -24,6 +24,7 @@ import {
   type TerminalBackendWarningCode,
   type TmuxController,
 } from "./terminal-tmux.ts";
+import { resolveContainedPath } from "./contained-path.ts";
 
 const scrollbackLimit = 1024 * 1024,
   replayLimit = 256 * 1024,
@@ -666,15 +667,15 @@ function resolveTerminalCwd(rootDir: string, value: unknown): string {
     !["repo-root", "repo-relative"].includes(String(cwd.scope))
   )
     throw terminalHostError("invalid_cwd", "cwd scope is invalid.");
-  const resolved =
-    cwd.scope === "repo-root" ? rootDir : path.resolve(rootDir, requiredTerminalText(cwd.path, "cwd.path"));
-  if (resolved !== rootDir && !resolved.startsWith(`${rootDir}${path.sep}`))
+  const requestedPath = cwd.scope === "repo-root" ? "." : requiredTerminalText(cwd.path, "cwd.path"),
+    resolved = resolveContainedPath(rootDir, requestedPath);
+  if (resolved === null)
     throw terminalHostError("invalid_cwd", "cwd must stay inside the repository.");
   return resolved;
 }
 function restoreTerminalCwd(rootDir: string, stored: string): string {
-  const resolved = stored === "." ? rootDir : path.resolve(rootDir, stored);
-  if (resolved !== rootDir && !resolved.startsWith(`${rootDir}${path.sep}`))
+  const resolved = resolveContainedPath(rootDir, stored);
+  if (resolved === null)
     throw new Error("invalid terminal session registry cwd");
   return resolved;
 }

--- a/packages/daemon/test/contained-path.integration.test.ts
+++ b/packages/daemon/test/contained-path.integration.test.ts
@@ -1,0 +1,156 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { resolveContainedPath } from "../src/contained-path.ts";
+import { resolveRuntimeCwd } from "../src/runtime-spawn-mission.ts";
+import { openTerminalHost } from "../src/terminal-host.ts";
+import type { TmuxController } from "../src/terminal-tmux.ts";
+
+const symlinkTests = { skip: process.platform === "win32" ? "requires POSIX file-symbolic-link semantics" : false };
+
+test("contained paths canonicalize valid paths and reject symlink escapes", symlinkTests, () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-contained-path-")),
+    root = path.join(parent, "repo"),
+    outside = path.join(parent, "outside"),
+    inside = path.join(root, "inside");
+  try {
+    mkdirSync(root);
+    mkdirSync(outside);
+    mkdirSync(inside);
+    mkdirSync(path.join(outside, "nested"));
+    symlinkSync(outside, path.join(root, "link"), "dir");
+    assert.equal(resolveContainedPath(root, "inside"), realpathSync.native(inside));
+    assert.equal(resolveContainedPath(root, "."), realpathSync.native(root));
+    assert.equal(resolveContainedPath(root, "link"), null);
+    assert.equal(resolveContainedPath(root, "link/nested"), null);
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("runtime cwd rejects symlink escapes", symlinkTests, () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-cwd-")),
+    root = path.join(parent, "repo"),
+    outside = path.join(parent, "outside");
+  try {
+    mkdirSync(root);
+    mkdirSync(outside);
+    mkdirSync(path.join(outside, "nested"));
+    symlinkSync(outside, path.join(root, "link"), "dir");
+    for (const requestedPath of ["link", "link/nested"]) {
+      assert.throws(
+        () => resolveRuntimeCwd(root, { scope: "repo-relative", path: requestedPath }),
+        (error: unknown) => error instanceof Error && "code" in error && error.code === "invalid_runtime_cwd",
+      );
+    }
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("terminal cwd rejects symlink escapes before spawning", symlinkTests, async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-terminal-cwd-")),
+    root = path.join(parent, "repo"),
+    outside = path.join(parent, "outside");
+  try {
+    mkdirSync(root);
+    mkdirSync(outside);
+    mkdirSync(path.join(outside, "nested"));
+    symlinkSync(outside, path.join(root, "link"), "dir");
+    let launches = 0;
+    const host = openTerminalHost({
+      repoId: "contained-path-terminal",
+      rootDir: root,
+      daemonGeneration: 1,
+      spawnPty: (() => {
+        launches += 1;
+        return fakePty();
+      }) as never,
+    });
+    try {
+      for (const requestedPath of ["link", "link/nested"]) {
+        assert.throws(
+          () =>
+            host.spawn({
+              idempotencyKey: `escape-${requestedPath.replaceAll("/", "-")}`,
+              backend: "direct-pty",
+              cwd: { scope: "repo-relative", path: requestedPath },
+              shellProfileId: "default",
+              name: "Escape",
+            }),
+          (error: unknown) => error instanceof Error && "code" in error && error.code === "invalid_cwd",
+        );
+      }
+      assert.equal(launches, 0);
+    } finally {
+      await host.close();
+    }
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("terminal session restore rejects a symlink escape", symlinkTests, () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-terminal-restore-cwd-")),
+    root = path.join(parent, "repo"),
+    outside = path.join(parent, "outside"),
+    registry = path.join(root, ".harness", "generated", "terminal-sessions.json");
+  try {
+    mkdirSync(root);
+    mkdirSync(outside);
+    symlinkSync(outside, path.join(root, "link"), "dir");
+    mkdirSync(path.dirname(registry), { recursive: true });
+    writeFileSync(
+      registry,
+      `${JSON.stringify({
+        schema: "terminal-session-registry/v1",
+        sessions: [
+          {
+            sessionId: "terminal-escape",
+            idempotencyKey: "escape",
+            name: "Escape",
+            cwd: "link",
+            shellProfile: "bash",
+            tmuxNamespace: "escape",
+            createdAt: "2026-08-25T00:00:00.000Z",
+            lastActivityAt: "2026-08-25T00:00:00.000Z",
+          },
+        ],
+      })}\n`,
+    );
+    assert.throws(
+      () =>
+        openTerminalHost({
+          repoId: "contained-path-restore",
+          rootDir: root,
+          daemonGeneration: 1,
+          registryFilePath: registry,
+          tmux: fakeTmuxController(),
+        }),
+      /invalid terminal session registry cwd/u,
+    );
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+function fakePty(): Record<string, unknown> {
+  return {
+    onData: () => ({ dispose: () => undefined }),
+    onExit: () => ({ dispose: () => undefined }),
+    write: () => undefined,
+    resize: () => undefined,
+    kill: () => undefined,
+  };
+}
+
+function fakeTmuxController(): TmuxController {
+  return {
+    probe: () => ({ available: true, executable: "/test/tmux", version: "tmux test" }),
+    hasSession: () => true,
+    killSession: () => undefined,
+  };
+}


### PR DESCRIPTION
# English

## Summary

Fixes #1824. Runtime and terminal cwd validation previously normalized paths lexically with `path.resolve` and checked a string prefix, so a symbolic link inside a repository could resolve outside the repository. Shared `resolveContainedPath` now canonicalizes the repository root and candidate with `realpathSync.native`, checks canonical containment with `path.relative`, and returns the canonical cwd. Runtime spawn, terminal launch, and terminal session restore all use the helper.

## Architectural Justification

- Not required: Production-Delta churn is 35 lines and net production change is +19 lines, below the 200/300 thresholds.

## What Changed

- `packages/daemon/src/contained-path.ts`: add the shared canonical containment helper and fail closed when the root or cwd cannot be resolved.
- `packages/daemon/src/runtime-spawn-mission.ts`: apply canonical containment to runtime cwd resolution.
- `packages/daemon/src/terminal-host.ts`: apply canonical containment to terminal launch and persisted session restore.
- `packages/daemon/test/contained-path.integration.test.ts`: cover valid paths, direct and symlinked-parent escapes, runtime rejection, rejection before PTY launch, and session-restore rejection.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +27/-8

### Optional Evidence Claims

## Task And Scope

- Harness task: not applicable; issue-driven repair for #1824 with no task record requested
- Branch: codex/issue-1824-symlink-cwd
- Public scope: packages/daemon/src/contained-path.ts, runtime-spawn-mission.ts, terminal-host.ts, and the focused integration test
- Private planning/evidence updated: not applicable
- Out of scope: descriptor-based guarantees against concurrent symlink replacement, nonexistent cwd support, and unrelated path consumers

## Version Impact

- Version: no version change because this is a pre-release internal bug fix
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: not applicable
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 6ca4755aceeb68da63cdd4ff8f4caa7614b88a42
- Branch merge-base with `origin/main`: 6ca4755aceeb68da63cdd4ff8f4caa7614b88a42
- Last `git fetch origin` time: 2026-08-27T06:16:54Z
- Sync method: rebase
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: none; no private harness evidence was created
- Reviewer evidence path: `packages/daemon/test/contained-path.integration.test.ts` and the three changed daemon source files
- GitHub Actions `rewrite-ci` run URL: pending
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check:pr` (typecheck, lint, fast/contract/integration tests, GUI tests, and 39 manifest gates; exit 0)
- [x] `npm run typecheck`
- [x] focused runtime and terminal tests (45 passed)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: the full `npm run check` and `npm test` aggregate was not rerun after rebase; the earlier aggregate hit the watchdog on an open handle in `daemon-host-recovery.test.ts`, while that file passed 12/12 when rerun alone. Two GUI E2E tests were skipped because Electron is not installed locally. `npm run pr:doctor` was attempted but currently fails on the repository's stale `headRefOid` GitHub CLI field, unrelated to this diff.

## Review Evidence

- Self-review: compared the issue reproduction and recent PR conventions (#1909, #1915, and #1925), inspected every runtime and terminal cwd call site, and verified canonical root/candidate containment.
- Reviewer subagent: not run
- Human review: pending
- Blocking findings: none

## Residual Risk

- `realpathSync.native` requires the cwd target to exist, so nonexistent cwd values fail as invalid. The helper returns a canonical path, which closes ordinary symlink escapes; a concurrent replacement after validation would require descriptor-based or no-symlink enforcement and remains out of scope.

## References

- Task: issue #1824
- Evidence: `packages/daemon/test/contained-path.integration.test.ts`
- Review: this PR

---

# 中文

## 概要

Fixes #1824。runtime 和 terminal 的 cwd 校验此前只用 `path.resolve` 做词法归一化，再用字符串前缀判断 containment，因此仓库内的符号链接可以把最终 cwd 指到仓库外。现在新增共享的 `resolveContainedPath`，用 `realpathSync.native` canonicalize 仓库根和候选路径，再用 `path.relative` 判断物理路径是否仍在仓库内，并返回 canonical cwd。runtime spawn、terminal launch 和 terminal session restore 都复用这个 helper。

## 架构辩护

- 不需要：Production-Delta churn 为 35 行、生产净增 19 行，低于 200/300 阈值。

## 改动内容

- `packages/daemon/src/contained-path.ts`：新增共享的 canonical containment helper；根目录或 cwd 无法解析时 fail closed。
- `packages/daemon/src/runtime-spawn-mission.ts`：runtime cwd 使用 canonical containment 校验。
- `packages/daemon/src/terminal-host.ts`：terminal 启动 cwd 和持久化 session restore 都使用同一校验。
- `packages/daemon/test/contained-path.integration.test.ts`：覆盖有效路径、直接符号链接、符号链接父目录、runtime 拒绝、PTY 启动前拒绝和 session restore 拒绝。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 同 commit 删除的门 / fixture：none
- 生产净行数：引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块中的唯一机读声明。

## 任务与范围

- Harness 任务：不适用；这是针对 #1824 的 issue 修复，未要求创建 task 记录
- 分支：codex/issue-1824-symlink-cwd
- 公开范围：packages/daemon/src/contained-path.ts、runtime-spawn-mission.ts、terminal-host.ts 和定向 integration test
- 私有计划 / 证据是否已更新：不适用
- 范围外：针对并发符号链接替换的 descriptor 保证、不存在 cwd 的支持，以及其他无关路径消费者

## 版本影响

- 版本：不改版本，原因是预发布内部 bug 修复
- 发布影响：不发布

## 治理声明

- 是否触碰 protected surface：no
- protected surface 范围：none
- 依据：不适用
- 机器检查边界：本 PR 只声明该段存在；声明是否真实、充分，由 reviewer 判断。
- Break-glass：no
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- `origin/main` 基准 SHA：6ca4755aceeb68da63cdd4ff8f4caa7614b88a42
- 当前分支与 `origin/main` 的 merge-base：6ca4755aceeb68da63cdd4ff8f4caa7614b88a42
- 最近一次 `git fetch origin` 时间：2026-08-27T06:16:54Z
- 同步方式：rebase
- 公开 diff 命令：`git diff origin/main...HEAD`
- 私有证据 commit/path：none；没有创建私有 harness 证据
- Reviewer 证据路径：`packages/daemon/test/contained-path.integration.test.ts` 和三个改动的 daemon 源文件
- GitHub Actions `rewrite-ci` run URL：待定
- [x] `npm ci`
- [x] `git diff --check`
- [x] `npm run check:pr`（typecheck、lint、fast/contract/integration、GUI 测试和 39 个 manifest gate；exit 0）
- [x] `npm run typecheck`
- [x] runtime 和 terminal 定向测试（45 项通过）
- [ ] `npm run check`
- [ ] `npm test`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行：rebase 后没有再次运行完整的 `npm run check` 和 `npm test` aggregate；此前 aggregate 因 `daemon-host-recovery.test.ts` 的开放句柄被 watchdog 超时，但该文件单独重跑为 12/12 通过。两个 GUI E2E 因本地未安装 Electron 而跳过。`npm run pr:doctor` 已尝试，但仓库自身仍请求过时的 `headRefOid` GitHub CLI 字段而失败，与本 diff 无关。

## 审查证据

- 自查：对照 issue 复现和近期 PR 约定（#1909、#1915、#1925），检查所有 runtime/terminal cwd 调用点，并验证 canonical root/candidate containment。
- Reviewer subagent：未运行
- 人工审查：待定
- 阻塞发现：无

## 残余风险

- `realpathSync.native` 要求 cwd 目标已存在，因此不存在的 cwd 会作为 invalid 被拒绝。helper 返回 canonical 路径，已解决普通符号链接越界；若要防御校验后发生的并发替换，需要 descriptor 或 no-symlink 机制，当前不在范围内。

## 关联材料

- Task：issue #1824
- Evidence：`packages/daemon/test/contained-path.integration.test.ts`
- Review：this PR

---

## PR Gate Checklist / PR 门禁清单

- [x] Branch is based on latest `origin/main`. / 分支基于最新 `origin/main`。
- [x] PR body uses this full template structure. / PR 描述使用本模板完整结构。
- [x] PR body uses two complete language blocks: `# English` first, then `# 中文`. / PR 正文使用两块完整正文：`# English` 在上，`# 中文` 在下。
- [x] PR body passes `tools/check-pr-body-bilingual.mjs`. / PR 正文通过 `tools/check-pr-body-bilingual.mjs`。
- [x] No private harness files are included. / 不包含私有 harness 文件。
- [x] No absolute local filesystem paths are included in this public PR body. / 本公开 PR 描述不包含本机绝对路径。
- [x] Public diff is limited to the stated task scope. / 公开 diff 限于声明的任务范围。
