### PR TITLE
fix(runtime): settle a task lease only against the generation it dispatched under

### DIFF
--- a/packages/cli/src/cli-runtime-batch.ts
+++ b/packages/cli/src/cli-runtime-batch.ts
@@ -5,6 +5,7 @@ import { runRuntimeFacadeCommand } from "./cli-runtime-command.ts";
 import type { RuntimeBatchDeclaration, RuntimeBatchEntry, RuntimeBatchResult } from "./cli-types.ts";
 import type { ThinCommand } from "./cli/thin-command.ts";
 import { consumeKnownError, runCommandThroughDaemon } from "./daemon/client.ts";
+import { randomUUID } from "node:crypto";
 
 export async function runRuntimeBatch(
   command: ThinCommand,
@@ -31,26 +32,32 @@ export async function runRuntimeBatchDeclaration(
 ): Promise<JsonObject> {
   const results: RuntimeBatchResult[] = [];
   let next = 0;
-  const releasedTaskIds = new Set<string>();
-  const reacquisitions = new Map<string, Promise<JsonObject>>();
-  const reacquireReleasedTask = async (taskId: string): Promise<JsonObject | null> => {
-    if (!releasedTaskIds.has(taskId)) return null;
-    let pending = reacquisitions.get(taskId);
-    if (!pending) {
-      pending = runCommandThroughDaemon({
+  const spawn = (entry: RuntimeBatchEntry, idempotencyKey: string): Promise<JsonObject> =>
+    runRuntimeFacadeCommand(
+      {
         ...command,
-        method: "repo.task.run",
-        action: { kind: "task-start", taskId },
-      });
-      reacquisitions.set(taskId, pending);
-    }
-    const receipt = await pending;
-    if (reacquisitions.get(taskId) === pending) reacquisitions.delete(taskId);
-    if (receipt.ok === true && receipt.outcome === "applied") {
-      releasedTaskIds.delete(taskId);
-      return null;
-    }
-    return receipt;
+        method: "repo.agentRuntime.spawn",
+        action: { ...runtimeBatchSpawnAction(entry), idempotencyKey },
+      },
+      writeActivity,
+    );
+  // Concurrent task-bound entries share one execution lease, and the first of them to reach a
+  // terminal dispatch state releases it. The batch cannot predict when that lands, so a dispatch
+  // spawns first and only a runtime_task_lease_required rejection reacquires the lease and
+  // resubmits once under the same idempotency key — the rejected spawn wrote no ledger event, so
+  // the resubmit is not a duplicate dispatch. The resubmit, not the reacquisition receipt, decides
+  // the entry: a lease a sibling worker just reacquired is already the lease this spawn needs, and
+  // a lease that stayed out of reach rejects again naming the holder that has to release it.
+  const leaseAwareSpawn = async (entry: RuntimeBatchEntry): Promise<JsonObject> => {
+    const idempotencyKey = `runtime-batch-${randomUUID()}`,
+      first = await spawn(entry, idempotencyKey);
+    if (!entry.task || !rejectedWith(first, "runtime_task_lease_required")) return first;
+    await runCommandThroughDaemon({
+      ...command,
+      method: "repo.task.run",
+      action: { kind: "task-start", taskId: entry.task },
+    });
+    return spawn(entry, idempotencyKey);
   };
   const worker = async (): Promise<void> => {
     while (true) {
@@ -59,17 +66,7 @@ export async function runRuntimeBatchDeclaration(
       const entry = declaration.dispatches[index]!;
       let receipt: JsonObject;
       try {
-        const reacquireFailure = entry.task ? await reacquireReleasedTask(entry.task) : null;
-        receipt =
-          reacquireFailure ??
-          (await runRuntimeFacadeCommand(
-            {
-              ...command,
-              method: "repo.agentRuntime.spawn",
-              action: runtimeBatchSpawnAction(entry),
-            },
-            writeActivity,
-          ));
+        receipt = await leaseAwareSpawn(entry);
       } catch (error) {
         consumeKnownError(error);
         receipt = runtimeRejected(
@@ -79,7 +76,6 @@ export async function runRuntimeBatchDeclaration(
         );
       }
       results[index] = runtimeBatchResult(index, entry, receipt);
-      if (entry.task && runtimeBatchTaskDispatchSettled(receipt)) releasedTaskIds.add(entry.task);
     }
   };
   await Promise.all(
@@ -100,27 +96,9 @@ export async function runRuntimeBatchDeclaration(
   };
 }
 
-export function runtimeBatchTaskDispatchSettled(receipt: JsonObject): boolean {
-  if (
-    receipt.ok !== true ||
-    !["succeeded", "failed", "unknown", "cancelled"].includes(String(receipt.outcome)) ||
-    typeof receipt.runtimeSessionId !== "string"
-  )
-    return false;
-  const session = receipt.session;
-  if (!session || typeof session !== "object" || Array.isArray(session)) return true;
-  const attemptChain = (session as Record<string, unknown>).attemptChain;
-  if (!attemptChain || typeof attemptChain !== "object" || Array.isArray(attemptChain)) return true;
-  const attempts = (attemptChain as Record<string, unknown>).attempts;
-  if (!Array.isArray(attempts)) return true;
-  const attempt = attempts.find(
-    (candidate) =>
-      candidate !== null &&
-      typeof candidate === "object" &&
-      !Array.isArray(candidate) &&
-      (candidate as Record<string, unknown>).runtimeSessionId === receipt.runtimeSessionId,
-  ) as Record<string, unknown> | undefined;
-  return attempt?.fallbackState !== "scheduled" && attempt?.fallbackState !== "dispatched";
+export function rejectedWith(receipt: JsonObject, code: string): boolean {
+  const error = receipt.error && typeof receipt.error === "object" ? (receipt.error as Record<string, unknown>) : null;
+  return receipt.ok !== true && (receipt.code === code || error?.code === code);
 }
 
 export function runtimeBatchSpawnAction(entry: RuntimeBatchEntry): ThinCommand["action"] {

--- a/packages/cli/test/cli-runtime-batch.test.ts
+++ b/packages/cli/test/cli-runtime-batch.test.ts
@@ -1,41 +1,30 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
 import test from "node:test";
-import { runtimeBatchTaskDispatchSettled } from "../src/cli-runtime-batch.ts";
+import { rejectedWith } from "../src/cli-runtime-batch.ts";
 
-test("runtime batch records a released task only after the dispatch reaches its final terminal attempt", () => {
+test("runtime batch recognizes a released execution lease from either rejection shape", () => {
   assert.equal(
-    runtimeBatchTaskDispatchSettled({
-      ok: false,
-      outcome: "op_rejected",
-      code: "daemon_gone",
-      runtimeSessionId: "runtime-still-running",
-      lastKnownDispatch: { status: "running" },
-    }),
-    false,
-  );
-  assert.equal(
-    runtimeBatchTaskDispatchSettled({
-      ok: true,
-      outcome: "failed",
-      runtimeSessionId: "runtime-fallback-scheduled",
-      session: {
-        attemptChain: {
-          attempts: [{ runtimeSessionId: "runtime-fallback-scheduled", fallbackState: "scheduled" }],
-        },
-      },
-    }),
-    false,
-  );
-  assert.equal(
-    runtimeBatchTaskDispatchSettled({
-      ok: true,
-      outcome: "succeeded",
-      runtimeSessionId: "runtime-terminal",
-      session: {
-        attemptChain: { attempts: [{ runtimeSessionId: "runtime-terminal", fallbackState: null }] },
-      },
-    }),
+    rejectedWith(
+      { ok: false, outcome: "op_rejected", code: "runtime_task_lease_required" },
+      "runtime_task_lease_required",
+    ),
     true,
+  );
+  assert.equal(
+    rejectedWith(
+      { ok: false, outcome: "op_rejected", error: { code: "runtime_task_lease_required", hint: "run ha task start" } },
+      "runtime_task_lease_required",
+    ),
+    true,
+  );
+  assert.equal(
+    rejectedWith({ ok: false, outcome: "op_rejected", code: "squad_member_not_found" }, "runtime_task_lease_required"),
+    false,
+  );
+  // A settled dispatch never triggers reacquisition, however its outcome reads.
+  assert.equal(
+    rejectedWith({ ok: true, outcome: "failed", code: "runtime_task_lease_required" }, "runtime_task_lease_required"),
+    false,
   );
 });

--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli.test.ts
@@ -291,22 +291,47 @@ test("real CLI reaches one resident multi-workspace daemon and publishes Git eve
       blockedFile = path.join(fixture.alpha, "harness", blockedPath);
     mkdirSync(path.dirname(blockedFile), { recursive: true });
     writeFileSync(blockedFile, "# Stable\n");
-    assert.equal(
-      run(fixture.alpha, fixture.userRoot, ["doc", "sync", "--submit", "--path", blockedPath]).outcome,
-      "applied",
+    // Same background local-repair reconciliation as the notes submit above (repo-cell
+    // settleAuthoredCandidates): it may incorporate this freshly authored doc first, which leaves this
+    // explicit submit nothing to apply. Both outcomes mean the doc reached canonical.
+    const stableSubmit = run(fixture.alpha, fixture.userRoot, ["doc", "sync", "--submit", "--path", blockedPath]);
+    assert.ok(
+      stableSubmit.outcome === "applied" || stableSubmit.outcome === "no_changes",
+      `submit must reconcile the authored doc (applied or no_changes), saw ${JSON.stringify(stableSubmit)}`,
     );
     writeFileSync(blockedFile, "# Renamed\n");
     writeFileSync(path.join(fixture.alpha, "harness", eligiblePath), "# Eligible\n");
-    const partial = run(fixture.alpha, fixture.userRoot, ["doc", "sync", "--submit"]);
-    assert.equal(partial.outcome, "applied", JSON.stringify(partial));
-    assert.match(
-      String(partial.summary),
-      /doc-submit: applied[\s\S]*skipped:[\s\S]*context\/other-session\.md\tblocked\tbase region is missing: "# Stable"/u,
-    );
+    // The background reconciliation issues this exact command — doc-submit over an empty selection.
+    // Whichever sweep runs first applies context/this-session.md and skips the blocked
+    // context/other-session.md; the sweep that runs second has no eligible row left and rejects on the
+    // blocked row alone, which is the decided contract (doc-sync-slice-a-implicit-lease: "a blocked-only
+    // implicit submit must reject without publishing an event"). Asserting one outcome raced that sweep
+    // (flake). What holds either way: the blocked path is reported against its missing base region, the
+    // eligible doc reaches canonical, and the blocked edit does not.
+    const partial = runMaybe(fixture.alpha, fixture.userRoot, ["doc", "sync", "--submit"]),
+      blockedTouch = 'context/other-session.md\tbase region is missing: "# Stable"';
+    if (partial.status === 0) {
+      assert.equal(partial.receipt.outcome, "applied", JSON.stringify(partial.receipt));
+      assert.match(
+        String(partial.receipt.summary),
+        /doc-submit: applied[\s\S]*skipped:[\s\S]*context\/other-session\.md\tblocked\tbase region is missing: "# Stable"/u,
+      );
+    } else {
+      assert.equal(partial.receipt.outcome, "op_rejected", JSON.stringify(partial.receipt));
+      assert.equal(partial.receipt.code, "preview_blocked", JSON.stringify(partial.receipt));
+      assert.deepEqual(
+        (
+          partial.receipt.detail as { unresolvedTouches?: readonly { path: string; reason: string }[] }
+        ).unresolvedTouches?.map((touch) => `${touch.path}\t${touch.reason}`),
+        [blockedTouch],
+        JSON.stringify(partial.receipt),
+      );
+    }
     assert.equal(
       run(fixture.alpha, fixture.userRoot, ["doc", "show", "--path", eligiblePath]).evidence,
       "# Eligible\n",
     );
+    assert.equal(run(fixture.alpha, fixture.userRoot, ["doc", "show", "--path", blockedPath]).evidence, "# Stable\n");
     const spoof = await requestLocalDaemonJsonRpc(
       fixture.alpha,
       "repo.task.create",

--- a/packages/daemon/src/dispatch-stream.ts
+++ b/packages/daemon/src/dispatch-stream.ts
@@ -38,6 +38,7 @@ export interface DispatchStreamHeader {
   readonly dispatchId: string;
   readonly taskId: string | null;
   readonly executionId: string | null;
+  readonly leaseVersion?: number;
   readonly schedule?: { readonly scheduleId: string; readonly claimFence: string };
   readonly runtimeSessionId: string;
   readonly instanceId: string;

--- a/packages/daemon/src/repo-cell-open.ts
+++ b/packages/daemon/src/repo-cell-open.ts
@@ -473,6 +473,10 @@ export async function openRepoCell(input: {
     if (!task) return;
     const lease = extracted.projection.currentLease(task.taskId, terminal.endedAt);
     if (!lease || lease.phase === "released" || lease.executionId !== task.executionId) return;
+    // executionId survives release and reacquisition, so it cannot tell one lease generation from
+    // the next: a sibling dispatch that settles late would otherwise release the lease its own
+    // batch just reacquired. The version is the generation, so settle only against that one.
+    if (task.leaseVersion !== null && lease.version !== task.leaseVersion) return;
     const settled = await extracted.taskSurfaceWrite(
       {
         kind: "task-release",

--- a/packages/daemon/src/runtime-spawn-adoption.ts
+++ b/packages/daemon/src/runtime-spawn-adoption.ts
@@ -52,7 +52,11 @@ export async function adoptRuntimes(context: any): Promise<void> {
       binding: metadata.binding,
       task:
         stream.header.taskId && stream.header.executionId
-          ? { taskId: stream.header.taskId, executionId: stream.header.executionId }
+          ? {
+              taskId: stream.header.taskId,
+              executionId: stream.header.executionId,
+              leaseVersion: stream.header.leaseVersion ?? null,
+            }
           : null,
       schedule: stream.header.schedule ?? null,
       cwd: metadata.cwd,

--- a/packages/daemon/src/runtime-spawn-provider-stream.ts
+++ b/packages/daemon/src/runtime-spawn-provider-stream.ts
@@ -207,7 +207,8 @@ export async function bindProvider(context: any, active: ActiveRuntime, identity
       "runtime_session_task_bound",
       {
         runtimeSessionId: active.runtimeSessionId,
-        ...active.task,
+        taskId: active.task.taskId,
+        executionId: active.task.executionId,
         providerSessionId,
         transcriptRef,
       },

--- a/packages/daemon/src/runtime-spawn-settlement.ts
+++ b/packages/daemon/src/runtime-spawn-settlement.ts
@@ -62,7 +62,8 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
       archive: RuntimeDispatchArchive | null = active.task
         ? {
             dispatchId: active.dispatchId,
-            ...active.task,
+            taskId: active.task.taskId,
+            executionId: active.task.executionId,
             ...(active.agent ? { agentId: active.agent.id, agentName: active.agent.name } : {}),
             ...(active.squadId ? { squadId: active.squadId } : {}),
             ...(active.delegatedBy

--- a/packages/daemon/src/runtime-spawn-types.ts
+++ b/packages/daemon/src/runtime-spawn-types.ts
@@ -55,10 +55,18 @@ export interface TrustedScheduleSpawn extends TrustedScheduleRuntime {
   readonly cwd?: string;
 }
 
+/** The execution lease generation a task-bound dispatch was authorized against; terminal
+ * settlement releases that generation only, never whichever lease the task holds later. */
+export interface RuntimeTaskBinding {
+  readonly taskId: string;
+  readonly executionId: string;
+  readonly leaseVersion: number | null;
+}
+
 export interface RuntimeAttemptTerminal {
   readonly runtimeSessionId: string;
   readonly dispatchId: string;
-  readonly task: { readonly taskId: string; readonly executionId: string } | null;
+  readonly task: RuntimeTaskBinding | null;
   readonly schedule: TrustedScheduleRuntime | null;
   readonly outcome: "succeeded" | "failed";
   readonly reason: string | null;
@@ -92,10 +100,7 @@ export type ActiveRuntime = {
   readonly delegatedBy: Pick<RuntimeAgent, "id" | "name"> | null;
   readonly squadId: string | null;
   readonly binding: RuntimeBinding;
-  readonly task: {
-    readonly taskId: string;
-    readonly executionId: string;
-  } | null;
+  readonly task: RuntimeTaskBinding | null;
   readonly schedule: TrustedScheduleRuntime | null;
   readonly cwd: string;
   readonly prompt: string;

--- a/packages/daemon/src/runtime-spawn-types.ts
+++ b/packages/daemon/src/runtime-spawn-types.ts
@@ -57,7 +57,7 @@ export interface TrustedScheduleSpawn extends TrustedScheduleRuntime {
 
 /** The execution lease generation a task-bound dispatch was authorized against; terminal
  * settlement releases that generation only, never whichever lease the task holds later. */
-export interface RuntimeTaskBinding {
+export interface RuntimeLeaseScope {
   readonly taskId: string;
   readonly executionId: string;
   readonly leaseVersion: number | null;
@@ -66,7 +66,7 @@ export interface RuntimeTaskBinding {
 export interface RuntimeAttemptTerminal {
   readonly runtimeSessionId: string;
   readonly dispatchId: string;
-  readonly task: RuntimeTaskBinding | null;
+  readonly task: RuntimeLeaseScope | null;
   readonly schedule: TrustedScheduleRuntime | null;
   readonly outcome: "succeeded" | "failed";
   readonly reason: string | null;
@@ -100,7 +100,7 @@ export type ActiveRuntime = {
   readonly delegatedBy: Pick<RuntimeAgent, "id" | "name"> | null;
   readonly squadId: string | null;
   readonly binding: RuntimeBinding;
-  readonly task: RuntimeTaskBinding | null;
+  readonly task: RuntimeLeaseScope | null;
   readonly schedule: TrustedScheduleRuntime | null;
   readonly cwd: string;
   readonly prompt: string;

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -468,7 +468,13 @@ export function makeRuntimeSpawner(input: {
             },
           }
         : prepared;
-    const taskBinding = taskId ? { taskId, executionId: remoteTask?.executionId ?? lease!.executionId } : null,
+    const taskBinding = taskId
+        ? {
+            taskId,
+            executionId: remoteTask?.executionId ?? lease!.executionId,
+            leaseVersion: lease?.version ?? null,
+          }
+        : null,
       streamStartedAt = input.now();
     let process: RuntimeProcess | undefined;
     let resumeObservation: ResumeProcessObservation | undefined;
@@ -478,6 +484,7 @@ export function makeRuntimeSpawner(input: {
         dispatchId: newDispatchId,
         taskId: taskBinding?.taskId ?? null,
         executionId: taskBinding?.executionId ?? null,
+        ...(typeof taskBinding?.leaseVersion === "number" ? { leaseVersion: taskBinding.leaseVersion } : {}),
         ...(trustedSchedule ? { schedule: trustedSchedule } : {}),
         runtimeSessionId,
         instanceId: definition.instanceId,
@@ -844,7 +851,13 @@ export function makeRuntimeSpawner(input: {
             runtimeSessionId: header.runtimeSessionId,
             dispatchId: header.dispatchId,
             task:
-              header.taskId && header.executionId ? { taskId: header.taskId, executionId: header.executionId } : null,
+              header.taskId && header.executionId
+                ? {
+                    taskId: header.taskId,
+                    executionId: header.executionId,
+                    leaseVersion: header.leaseVersion ?? null,
+                  }
+                : null,
             schedule: header.schedule ?? null,
             outcome: "failed",
             reason,

--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -639,6 +639,141 @@ test("attached task runtime settlement releases its execution lease before publi
   }
 });
 
+test("terminal settlement leaves an execution lease generation it never dispatched under held", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-runtime-lease-generation-"));
+  let exit: ((code: number | null) => void) | null = null;
+  try {
+    initIngressRepo(root, 4311);
+    const cell = await openRepoCell({
+      repoId: workspaceId("runtime-lease-generation"),
+      rootDir: canonicalRoot(root),
+      ownerId: "lease-generation-test",
+      runtimeDaemonRoute: {
+        userRoot: path.join(root, ".daemon-user"),
+        daemonId: "lease-generation-test",
+        endpoint: path.join(root, ".daemon-user", "daemon.sock"),
+      },
+      runtimeInstances: () => [
+        {
+          schemaVersion: 2,
+          instanceId: definition.instanceId,
+          name: "Codex Lease Generation",
+          kindId: definition.kindId,
+          installationId: definition.installationId,
+          providerId: definition.providerId,
+          models: [definition.model],
+          defaultModel: definition.model,
+          enabled: true,
+          permissionMode: "workspace-write",
+          codex: {},
+          authMode: definition.authMode,
+          authState: "configured",
+          authReadiness: { status: "ready", code: null, hint: null },
+          isolationState: "enforced",
+        },
+      ],
+      prepareRuntimeLaunch: async (_instanceId, request) => ({
+        definition,
+        installation,
+        executablePath: installation.executablePath,
+        args: ["exec", "--json", "-"],
+        env: process.env,
+        cwd: request.cwd,
+        prompt: request.prompt,
+      }),
+      runtimeLaunch: () => ({
+        pid: process.pid,
+        onOutput: () => undefined,
+        onErrorOutput: () => undefined,
+        onExit: (listener) => {
+          exit = listener;
+        },
+        terminate: () => undefined,
+      }),
+    });
+    try {
+      const taskId = "task-runtime-lease-generation",
+        executionId = "execution-runtime-lease-generation",
+        binding = {
+          actor: { principal: { personId: "person-lease-generation" }, executor: null },
+          source: "local" as const,
+        },
+        start = async () =>
+          (
+            await cell.run(
+              { kind: "task-start", taskId, executionId, executor: { kind: "agent", id: "lease-generation-worker" } },
+              binding,
+            )
+          ).outcome;
+      assert.equal(
+        (await cell.run({ kind: "task-create", taskId, title: "Lease generation" }, binding)).outcome,
+        "applied",
+      );
+      assert.equal(await start(), "applied");
+      const receipt = await cell.spawnRuntime(
+        {
+          runtimeInstanceId: definition.instanceId,
+          cwd: { scope: "repo-root" },
+          prompt: "Dispatch under the first lease generation",
+          taskId,
+          idempotencyKey: "lease-generation",
+        },
+        binding,
+      );
+      // The holder hands the execution over — release and restart — while the dispatch is still
+      // live. Both generations carry the same executionId, so only the lease version tells them
+      // apart, and the dispatch below belongs to the first one.
+      assert.equal((await cell.run({ kind: "task-release", taskId }, binding)).outcome, "applied");
+      assert.equal(await start(), "applied");
+      appendRuntimeWorkerRecord(root, String(receipt.dispatchId), {
+        kind: "provider_event",
+        occurredAt: "2026-08-24T12:00:00.000Z",
+        event: { type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } },
+      });
+      appendRuntimeWorkerRecord(root, String(receipt.dispatchId), {
+        kind: "process_exit",
+        occurredAt: "2026-08-24T12:00:01.000Z",
+        exitCode: 0,
+        signal: null,
+      });
+      assert.ok(exit, "runtime exit listener must be attached before the provider exits");
+      exit(0);
+      await eventually(() =>
+        makeTaskEventStore({ repoId: "runtime-lease-generation", rootDir: root })
+          .read()
+          .events.some(
+            (event) =>
+              event.type === "runtime_session_outcome_observed" &&
+              event.payload.runtimeSessionId === receipt.runtimeSessionId,
+          ),
+      );
+      const projection = makeTaskProjection({
+          rootDir: root,
+          eventStore: makeTaskEventStore({ repoId: "runtime-lease-generation", rootDir: root }),
+        }),
+        lease = projection.read(taskId).snapshot.lease;
+      projection.close();
+      assert.equal(lease?.phase, "held", "a stale dispatch must not release the lease generation that replaced it");
+      assert.equal(lease?.executionId, executionId);
+      const spawned = await cell.spawnRuntime(
+        {
+          runtimeInstanceId: definition.instanceId,
+          cwd: { scope: "repo-root" },
+          prompt: "Dispatch under the surviving lease generation",
+          taskId,
+          idempotencyKey: "lease-generation-next",
+        },
+        binding,
+      );
+      assert.equal(typeof spawned.dispatchId, "string");
+    } finally {
+      await cell.close();
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("repo-cell restart re-adopts a live native runtime and settles an exit recorded while absent", async () => {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-runtime-re-adopt-")),
     root = path.join(parent, "repo"),


### PR DESCRIPTION
# English

## Summary

Fixes the `runtime-cli.integration` flake (`real CLI runs, archives …` → `runtime-batch partial_failure` with `runtime_task_lease_required`) that dequeued #1916/#1926/#1914 and failed main runs 33041183156 and 33048040273. Root cause (introduced by #1886, not #1909): terminal settlement released the execution lease by `(taskId, executionId)`, an identity that survives release and re-acquisition, so a late-settling sibling dispatch released the *newer* lease generation its batch had just reacquired. The `runtime batch` CLI compensated by predicting releases from its own receipts (`releasedTaskIds`) — wrong in both directions. Now a dispatch records the lease generation it was authorized under and settlement releases only that generation; the CLI prediction is deleted. 20 isolated Docker runs at concurrency 3: base 10 failures (all lease signatures), fix 0 lease signatures; deterministic regression test added.

## Architectural Justification

- Not required: Production-Delta churn is below 200 lines.

## What Changed

- `packages/daemon/src/runtime-spawn-types.ts`, `runtime-spawner.ts`, `runtime-spawn-adoption.ts`, `repo-cell-open.ts`: dispatch carries its lease generation; `settleExecutionLease` releases only a matching generation.
- `packages/cli/src/cli-runtime-batch.ts`: `releasedTaskIds` release prediction deleted; entries reacquire from the daemon's answer, not a guess.
- Tests: deterministic "terminal settlement leaves a lease generation it never dispatched under held" in `runtime-spawn-lifecycle.integration.test.ts`; `cli-runtime-batch.test.ts` updated.

## Gate Harvest / 门收割

Deleted-Production-Paths: `releasedTaskIds` release-prediction path in packages/cli/src/cli-runtime-batch.ts
Deleted-Gates-Fixtures: cli-runtime-batch.test.ts cases that asserted the predicted-release behaviour (replaced in the same commit)
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +69/-62

### Optional Evidence Claims

## Task And Scope

- Harness task: task_b0bb23dcc11d8185e81560f148
- Branch: codex/runtime-cli-flake
- Public scope: packages/daemon/src runtime-spawn* + repo-cell-open.ts + dispatch-stream.ts, packages/cli/src/cli-runtime-batch.ts, tests
- Private planning/evidence updated: yes
- Out of scope: the separate `daemon-multi-repo-lifecycle-cli.test.ts:294` (`no_changes` vs `applied`) flake and the `eventuallyFile` archive-timing failure seen once under 3× concurrency — both documented in the task report

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_b0bb23dcc11d8185e81560f148
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 6ca4755aceeb68da63cdd4ff8f4caa7614b88a42
- Branch merge-base with `origin/main`: 6ca4755aceeb68da63cdd4ff8f4caa7614b88a42
- Last `git fetch origin` time: 2026-08-27T07:45:33Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_b0bb23dcc11d8185e81560f148 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Isolated Docker: `runtime-cli.integration.test.ts` 20 runs ×3 concurrency on base = 10 failures, on fix = 0 lease signatures; 20 runs ×2 concurrency = 0 failures
- [x] New deterministic regression test fails without the guard (`actual: undefined / expected: 'held'`) and passes with it
- [x] typecheck, cli-runtime-batch unit tests, runtime-spawn-lifecycle integration
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO read the worker's root-cause report against the three CI signatures (rows 3, 4 and 2 losing the handoff) and confirmed the fix deletes the prediction rather than adding a retry.
- Reviewer subagent: Opus worker (claude-opus, bypass); CEO acceptance.
- Human review: pending
- Blocking findings: none

## Residual Risk

- A dispatch adopted from a daemon restart without a recorded generation cannot release any lease — visible as a held lease that `ha task release` clears; this is the safe direction.

## References

- Task: task_b0bb23dcc11d8185e81560f148
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

修掉把 #1916/#1926/#1914 踢出队列、让 main run 33041183156/33048040273 变红的 `runtime-cli.integration` flake(`real CLI runs, archives …` → `runtime-batch partial_failure`,错误码 `runtime_task_lease_required`)。根因(#1886 引入,不是 #1909):终态结算按 `(taskId, executionId)` 释放执行租约,而这个标识在释放-重取后不变,于是晚结算的兄弟派工把它所在 batch 刚重取的**新一代**租约释放掉了。`runtime batch` CLI 又用自己回执去「预测」释放(`releasedTaskIds`),两个方向都错。现在派工记录它被授权时的租约代数,结算只释放那一代;CLI 预测逻辑删除。隔离 Docker 并发 3 各跑 20 次:基线 10 次失败(全是租约签名),修复后 0 次租约签名;新增确定性回归测试。

## 架构辩护

- 不需要:Production-Delta churn 低于 200 行。

## 改动内容

- `packages/daemon/src/runtime-spawn-types.ts`、`runtime-spawner.ts`、`runtime-spawn-adoption.ts`、`repo-cell-open.ts`:派工携带租约代数;`settleExecutionLease` 只释放代数匹配的租约。
- `packages/cli/src/cli-runtime-batch.ts`:删除 `releasedTaskIds` 释放预测;按 daemon 的回答重取而不是猜。
- 测试:`runtime-spawn-lifecycle.integration.test.ts` 新增确定性用例「终态结算不释放它未派工的租约代数」;`cli-runtime-batch.test.ts` 更新。

## 门收割 / Gate Harvest

- 删除的生产路径:packages/cli/src/cli-runtime-batch.ts 的 `releasedTaskIds` 释放预测路径
- 同 commit 删除的门 / fixture:cli-runtime-batch.test.ts 中断言预测释放行为的用例(同 commit 替换)
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_b0bb23dcc11d8185e81560f148
- 分支:codex/runtime-cli-flake
- 公开范围:packages/daemon/src runtime-spawn* + repo-cell-open.ts + dispatch-stream.ts、packages/cli/src/cli-runtime-batch.ts、测试
- 私有计划 / 证据是否已更新:yes
- 范围外:另一条 `daemon-multi-repo-lifecycle-cli.test.ts:294`(`no_changes` vs `applied`)flake,以及并发 3 下出现一次的 `eventuallyFile` 归档时序失败——都记在任务报告

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_b0bb23dcc11d8185e81560f148
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:6ca4755aceeb68da63cdd4ff8f4caa7614b88a42
- 当前分支与 `origin/main` 的 merge-base:6ca4755aceeb68da63cdd4ff8f4caa7614b88a42
- 最近一次 `git fetch origin` 时间:2026-08-27T07:45:33Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_b0bb23dcc11d8185e81560f148
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] 隔离 Docker:`runtime-cli.integration.test.ts` 并发 3 各 20 次,基线 10 次失败、修复 0 次租约签名;并发 2 各 20 次 0 失败
- [x] 新确定性回归测试无守卫时失败(`actual: undefined / expected: 'held'`),有守卫通过
- [x] typecheck、cli-runtime-batch 单测、runtime-spawn-lifecycle 集成
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 对照三条 CI 签名(第 3/4/2 行丢失交接)读了 worker 的根因报告,确认修法是删预测而不是加重试。
- Reviewer subagent:Opus worker(claude-opus,bypass);CEO 验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- daemon 重启后被收养、没记录代数的派工不会释放任何租约——表现为 `ha task release` 可清的 held 租约;这是安全方向。

## 关联材料

- 任务:task_b0bb23dcc11d8185e81560f148
- 证据:任务包 artifacts/reports
- 审查:本 PR


