### PR TITLE
refactor(auth): unify execution owner authorization for consent and complete

### DIFF
--- a/packages/application/src/task-closeout-action.ts
+++ b/packages/application/src/task-closeout-action.ts
@@ -11,6 +11,7 @@ import {
   type LeaseV1,
   type WriteReceipt,
 } from "../../kernel/src/index.ts";
+import { deriveOwnerRoleBinding } from "../../kernel/src/domain/owner-role-binding.ts";
 
 const submissionFields = [
   "completionClaim",
@@ -279,14 +280,14 @@ export async function runTaskCloseoutAction(dependencies: TaskCloseoutActionDepe
     const stopped = await invoke(
       "review-consent",
       { kind: "task-review-consent", taskId, ...selector, reviewId, consentId },
-      task.createdBy,
+      caller,
     );
     if (stopped) return stopped;
   }
   const ciFlag = judgment.completion.ci === "passed" ? { ci: "passed" as const } : {};
   const pathFlag = judgment.completion.codeDocPaths.length ? { paths: judgment.completion.codeDocPaths } : {};
   const completion = { kind: "task-complete", taskId, ...selector, ...ciFlag, ...pathFlag };
-  const stopped = await invoke("complete", completion, task.createdBy);
+  const stopped = await invoke("complete", completion, caller);
   if (stopped) return stopped;
   const { stage: _stage, ...final } = steps.at(-1)!;
   return {
@@ -336,19 +337,21 @@ function authorizeCloseout(
   snapshot: Snapshot,
   opId: string,
 ): AuthorizationDecision {
+  const target = `task/${snapshot.task?.taskId ?? "missing"}` as const;
   return authorizationPort.authorize(
     {
       version: currentActionEnvelopeVersion,
       actionId: `${opId}:${scope}`,
       kind: "task.closeout",
-      target: `task/${snapshot.task?.taskId ?? "missing"}`,
+      target,
       actor,
       authorizationRef: `${DEFAULT_POLICY.id}@${DEFAULT_POLICY.version}`,
       idempotencyKey: `${opId}:${scope}`,
     },
     {
       ruleScope: scope,
-      target: { owner: snapshot.task?.createdBy ?? null, lease: snapshot.lease },
+      roleBindings: snapshot.task ? [deriveOwnerRoleBinding(snapshot.task.createdBy, target)] : [],
+      target: { lease: snapshot.lease },
       evaluatedAtCut: `canonical:${snapshot.revision}`,
     },
   );

--- a/packages/application/src/task-closeout-action.ts
+++ b/packages/application/src/task-closeout-action.ts
@@ -5,13 +5,13 @@ import {
   currentActionEnvelopeVersion,
   currentExecutionCuts,
   DEFAULT_POLICY,
+  deriveOwnerRoleBinding,
   type ActorIdentity,
   type AuthorizationDecision,
   type CloseoutSnapshot,
   type LeaseV1,
   type WriteReceipt,
 } from "../../kernel/src/index.ts";
-import { deriveOwnerRoleBinding } from "../../kernel/src/domain/owner-role-binding.ts";
 
 const submissionFields = [
   "completionClaim",

--- a/packages/application/test/execution-saga-v1.test.ts
+++ b/packages/application/test/execution-saga-v1.test.ts
@@ -20,7 +20,7 @@ test("event saga rejects a second executor and self-review, then completes on Re
         kind: "execution.review",
         target: "execution/execution-1",
         actor: owner,
-        authorizationRef: "default@2",
+        authorizationRef: "default@3",
         idempotencyKey: "review-self",
       },
       {

--- a/packages/application/test/fact-event-service-decision-lifecycle.test.ts
+++ b/packages/application/test/fact-event-service-decision-lifecycle.test.ts
@@ -58,7 +58,7 @@ test("Decision transition matrix, transport arbiter, claims, relation retirement
         kind: "decision.accept",
         target: "decision/dec_FIXTURE",
         actor,
-        authorizationRef: "default@2",
+        authorizationRef: "default@3",
         idempotencyKey: "decision-self-judgment",
       },
       {

--- a/packages/daemon/src/repo-cell-proof.ts
+++ b/packages/daemon/src/repo-cell-proof.ts
@@ -16,6 +16,7 @@ import {
   type TaskLifecycleCommand,
   type WriteReceipt,
 } from "../../kernel/src/index.ts";
+import { deriveOwnerRoleBinding } from "../../kernel/src/domain/owner-role-binding.ts";
 import { cellCodedError } from "./repo-cell-errors.ts";
 import { verifyCodeDocCommitPaths } from "./code-doc-path-verification.ts";
 import { submitLeaseRequiredMessage } from "./repo-cell-execution-selection.ts";
@@ -163,28 +164,28 @@ export async function proofFor(
     };
   }
   if (command.type === "RecordReviewConsent") {
-    const authorizationDecision = authorizeAction(
-      "task.consent",
-      `task/${command.taskId}`,
-      command.actor,
-      command.opId,
-      { target: { owner: snapshot.task?.createdBy ?? null }, evaluatedAtCut: `canonical:${snapshot.revision}` },
-    );
+    const executionTarget = `execution/${command.executionId}` as const,
+      ownerRoleBindings = snapshot.task ? [deriveOwnerRoleBinding(snapshot.task.createdBy, executionTarget)] : [];
+    const authorizationDecision = authorizeAction("task.consent", executionTarget, command.actor, command.opId, {
+      roleBindings: ownerRoleBindings,
+      target: {},
+      evaluatedAtCut: `canonical:${snapshot.revision}`,
+    });
     if (authorizationDecision.outcome === "denied")
       throw cellCodedError(
         "actor_unauthorized",
         snapshot.task
           ? [
-              "Review consent requires the Task owner (",
-              `${actorHint(snapshot.task.createdBy)}`,
-              "); retry with that person and executor identity.",
+              "Review consent requires the Execution owner principal (personId=",
+              `${snapshot.task.createdBy.principal.personId}`,
+              ").",
             ].join("")
-          : "Review consent requires an existing Task owner.",
+          : "Review consent requires an existing Execution owner.",
       );
     return {
       actorBinding: command.actor,
       capability: "execution-consent@v1",
-      capabilityRef: `task-owner:${command.actor.principal.personId}`,
+      capabilityRef: `execution-owner:${command.executionId}:${command.actor.principal.personId}`,
       authorizationDecision,
     };
   }
@@ -252,13 +253,19 @@ export function completeProof(
     throw cellCodedError("active_lease", "Complete requires the execution lease to be released.");
   const authorizationDecision = authorizeAction(
     "task.complete",
-    `task/${command.taskId}`,
+    `execution/${command.executionId}`,
     command.actor,
     command.opId,
-    { target: { owner: snapshot.task?.createdBy ?? null }, evaluatedAtCut: `canonical:${snapshot.revision}` },
+    {
+      roleBindings: snapshot.task
+        ? [deriveOwnerRoleBinding(snapshot.task.createdBy, `execution/${command.executionId}`)]
+        : [],
+      target: {},
+      evaluatedAtCut: `canonical:${snapshot.revision}`,
+    },
   );
   if (authorizationDecision.outcome === "denied")
-    throw cellCodedError("actor_unauthorized", "Complete requires the Task owner.");
+    throw cellCodedError("actor_unauthorized", "Complete requires the Execution owner principal.");
   const execution = snapshot.executions.find(
     (candidate) => candidate.executionId === command.executionId && candidate.submission !== null,
   );
@@ -271,7 +278,7 @@ export function completeProof(
     );
   return {
     capability: "task-complete@v1",
-    capabilityRef: `task-created-by:${command.taskId}:${command.actor.principal.personId}`,
+    capabilityRef: `execution-owner:${command.executionId}:${command.actor.principal.personId}`,
     actorRole: "owner",
     noActiveLease: true,
     gateReceipts: supplied,

--- a/packages/daemon/src/repo-cell-proof.ts
+++ b/packages/daemon/src/repo-cell-proof.ts
@@ -4,6 +4,7 @@ import {
   codeDocRecordId,
   consentedApprovedReview,
   currentCodeDocWitness,
+  deriveOwnerRoleBinding,
   heldLeaseForExecutionActor,
   makeTaskProjection,
   normalizeCommandEnvelope,
@@ -16,7 +17,6 @@ import {
   type TaskLifecycleCommand,
   type WriteReceipt,
 } from "../../kernel/src/index.ts";
-import { deriveOwnerRoleBinding } from "../../kernel/src/domain/owner-role-binding.ts";
 import { cellCodedError } from "./repo-cell-errors.ts";
 import { verifyCodeDocCommitPaths } from "./code-doc-path-verification.ts";
 import { submitLeaseRequiredMessage } from "./repo-cell-execution-selection.ts";

--- a/packages/daemon/test/doc-sync-slice-b.test.ts
+++ b/packages/daemon/test/doc-sync-slice-b.test.ts
@@ -135,7 +135,7 @@ test("Decision prose is an explicit idempotent doc-sync region in the canonical 
     const firstAction = { kind: "doc-submit", executionId: "execution-doc", paths: [relativePath] } as const;
     const first = await fixture.cell.run(firstAction, binding);
     assert.equal(first.outcome, "applied", JSON.stringify(first));
-    assert.equal(first.authorizationDecision?.policyRef, "default@2");
+    assert.equal(first.authorizationDecision?.policyRef, "default@3");
     assert.equal(first.authorizationDecision?.outcome, "allowed");
     const retried = await fixture.cell.run(firstAction, binding);
     assert.equal(retried.outcome, "no_changes");

--- a/packages/daemon/test/json-rpc-protocol.test.ts
+++ b/packages/daemon/test/json-rpc-protocol.test.ts
@@ -374,17 +374,17 @@ test("lifecycle commands publish typed events, machine files, rebuildable L2, an
     const assertCut = (receipt: Record<string, unknown>, type: string, paths: readonly string[]) => { assert.equal(receipt.outcome, "applied", JSON.stringify(receipt)); assert.equal(receipt.taskId, taskId); assert.equal(receipt.executionId, executionId); assert.deepEqual(receipt.changedPaths, paths); assert.equal(receipt.worktreeVisible, true); assert.equal(receipt.commitSha, null); assert.equal(typeof receipt.cut, "object"); assert.equal(typeof receipt.transition, "object"); assert.equal(Array.isArray(receipt.next), true); const event = makeTaskEventStore({ repoId: "lifecycle-files", rootDir }).readEvent(String(receipt.opId)); assert.equal(event?.type, type); if (event?.schema !== "task-event/v1") throw new Error("lifecycle receipt requires a TaskEvent"); assert.deepEqual(event.payload.documentClaims?.map((claim) => claim.path), paths); for (const target of paths) assert.equal(existsSync(path.join(rootDir, "harness", target)), true, target); };
     const indexPath = `${packagePath}/INDEX.md`, executionPath = `${packagePath}/executions/${executionId}.md`, reviewPath = `${packagePath}/reviews/review-life.md`, codeDocPath = `${packagePath}/code-doc-anchors.json`;
     const started = await cell.run({ kind: "task-start", taskId, executionId }, binding) as unknown as Record<string, unknown>; assertCut(started, "execution_started", [indexPath, executionPath]); assert.match(readFileSync(path.join(rootDir, "harness", executionPath), "utf8"), /State: active/u);
-    assert.equal((started.authorizationDecision as Record<string, unknown>).policyRef, "default@2");
+    assert.equal((started.authorizationDecision as Record<string, unknown>).policyRef, "default@3");
     assert.equal((started.authorizationDecision as Record<string, unknown>).outcome, "allowed");
     const commitSha = git(rootDir, "rev-parse", "HEAD"), beforeInvalidSubmit = makeTaskEventStore({ repoId: "lifecycle-files", rootDir }).readHead()?.revision; writeFileSync(path.join(rootDir, "submission.json"), JSON.stringify({ completionClaim: "incomplete", deliverables: [], outputs: [], verificationNotes: [], knownGaps: [], commitSha })); const invalidSubmit = await cell.run({ kind: "task-submit", taskId, executionId, fromFile: "submission.json" }, binding); assert.equal(invalidSubmit.outcome, "op_rejected"); assert.equal(makeTaskEventStore({ repoId: "lifecycle-files", rootDir }).readHead()?.revision, beforeInvalidSubmit); assert.equal(git(rootDir, "rev-parse", "HEAD"), commitSha); writeFileSync(path.join(rootDir, "submission.json"), JSON.stringify({ completionClaim: "Lifecycle output is ready.", deliverables: ["typed lifecycle"], outputs: ["machine files"], verificationNotes: ["tests"], knownGaps: [], residualRisks: [], commitSha }));
     const submitted = await cell.run({ kind: "task-submit", taskId, executionId, fromFile: "submission.json" }, binding) as unknown as Record<string, unknown>; assertCut(submitted, "execution_submitted", [indexPath, executionPath]); assert.deepEqual(submitted.transition, { from: "active/implementation", to: "in_review/review" }); assert.match(readFileSync(path.join(rootDir, "harness", executionPath), "utf8"), /State: submitted[\s\S]*Lifecycle output is ready/u);
     writeFileSync(path.join(rootDir, "review.json"), JSON.stringify({ verdict: "approved", reason: "Independent review passed.", evidenceChecked: ["tests"] })); const reviewBinding = withRoleBinding({ actor: { principal: { personId: "person-reviewer" }, executor: { kind: "agent" as const, id: "arbiter" } }, source: "local" as const }, "arbiter");
     const reviewed = await cell.run({ kind: "task-review-execution", taskId, executionId, reviewId: "review-life", fromFile: "review.json" }, reviewBinding) as unknown as Record<string, unknown>; assertCut(reviewed, "review_recorded", [indexPath, executionPath, reviewPath]); assert.equal(reviewed.reviewId, "review-life"); assert.match(readFileSync(path.join(rootDir, "harness", reviewPath), "utf8"), /Verdict: approved[\s\S]*Consent: pending/u);
-    assert.equal((reviewed.authorizationDecision as Record<string, unknown>).policyRef, "default@2");
+    assert.equal((reviewed.authorizationDecision as Record<string, unknown>).policyRef, "default@3");
     assert.equal((reviewed.authorizationDecision as Record<string, unknown>).outcome, "allowed");
     const reviewEvent = makeTaskEventStore({ repoId: "lifecycle-files", rootDir }).readEvent(String(reviewed.opId)); if (reviewEvent?.type !== "review_recorded") throw new Error("review event missing"); assert.equal(reviewed.reviewDigest, reviewDigest(reviewEvent.payload.review)); assert.equal(reviewed.contentDigest, reviewEvent.payload.review.contentDigest); writeFileSync(path.join(rootDir, "consent.json"), JSON.stringify({ reviewDigest: reviewed.reviewDigest, contentDigest: reviewed.contentDigest }));
     const consented = await cell.run({ kind: "task-review-consent", taskId, executionId, reviewId: "review-life", consentId: "consent-life", fromFile: "consent.json" }, binding) as unknown as Record<string, unknown>; assertCut(consented, "review_consent_recorded", [indexPath, executionPath, reviewPath]); assert.match(readFileSync(path.join(rootDir, "harness", reviewPath), "utf8"), /Consent: consent-life[\s\S]*Consent actor: person-owner/u);
-    assert.equal((consented.authorizationDecision as Record<string, unknown>).policyRef, "default@2");
+    assert.equal((consented.authorizationDecision as Record<string, unknown>).policyRef, "default@3");
     assert.equal((consented.authorizationDecision as Record<string, unknown>).outcome, "allowed");
     const witnessedPath = "README.md", beforeInvalidWitness = makeTaskEventStore({ repoId: "lifecycle-files", rootDir }).readHead()?.revision; for (const invalid of [{ commitSha: "f".repeat(40), paths: [witnessedPath] }, { commitSha, paths: ["../escape.md"] }, { commitSha, paths: [`${witnessedPath}.missing`] }]) assert.equal((await cell.run({ kind: "task-code-doc-reconcile", taskId, executionId, iteration: 0, ...invalid }, binding)).outcome, "op_rejected"); assert.equal(makeTaskEventStore({ repoId: "lifecycle-files", rootDir }).readHead()?.revision, beforeInvalidWitness); const reconciled = await cell.run({ kind: "task-code-doc-reconcile", taskId, executionId, commitSha, iteration: 0, paths: [witnessedPath] }, binding) as unknown as Record<string, unknown>; assertCut(reconciled, "code_doc_reconciled", [indexPath, executionPath, codeDocPath]); assert.deepEqual(JSON.parse(readFileSync(path.join(rootDir, "harness", codeDocPath), "utf8")), { schema: "code-doc-witness/v1", witnessId: String((makeTaskEventStore({ repoId: "lifecycle-files", rootDir }).readEvent(String(reconciled.opId)) as { payload: { witness: { witnessId: string } } }).payload.witness.witnessId), taskId, executionId, commitSha, iteration: 0, paths: [witnessedPath], actor, source: "local", reconciledAt: (makeTaskEventStore({ repoId: "lifecycle-files", rootDir }).readEvent(String(reconciled.opId)) as { occurredAt: string }).occurredAt });
     const lookedUp = await cell.run({ kind: "receipt-show", opId: reconciled.opId }, binding) as unknown as Record<string, unknown>; assert.deepEqual({ taskId: lookedUp.taskId, executionId: lookedUp.executionId, transition: lookedUp.transition, changedPaths: lookedUp.changedPaths }, { taskId, executionId, transition: reconciled.transition, changedPaths: reconciled.changedPaths });
@@ -503,7 +503,17 @@ test("code-doc repoint appends a replacement witness and rejects stale or unknow
 
 test("milestone-closeout uses the normal completion facade, review, and gates exactly once", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-completion-facade-")); let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
-  const taskId = "task-complete", executionId = "execution-complete", packagePath = "tasks/task-complete-completion-facade", binding = { actor, source: "local" as const };
+  const taskId = "task-complete",
+    executionId = "execution-complete",
+    packagePath = "tasks/task-complete-completion-facade",
+    binding = { actor, source: "local" as const },
+    ownerFromAnotherAgent = {
+      actor: {
+        principal: actor.principal,
+        executor: { kind: "agent" as const, id: "other-owner-agent" },
+      },
+      source: "local" as const,
+    };
   try {
     initRepo(rootDir); cell = await openRepoCell({ repoId: workspaceId("completion-facade"), rootDir: canonicalRoot(rootDir), ownerId: "completion-daemon" }); const store = () => makeTaskEventStore({ repoId: "completion-facade", rootDir });
     await cell.run({ kind: "task-create", taskId, title: "Completion facade", presetId: "milestone-closeout" }, binding); await cell.run({ kind: "task-start", taskId, executionId }, binding);
@@ -522,12 +532,66 @@ test("milestone-closeout uses the normal completion facade, review, and gates ex
     const executionPath = path.join(rootDir, "harness", `${packagePath}/executions/${executionId}.md`); assert.match(readFileSync(executionPath, "utf8"), /Reviews: review-dismissed\/dismissed, review-unselected\/approved, review-complete\/approved[\s\S]*Selected review: pending/u);
     writeFileSync(path.join(rootDir, "review.json"), JSON.stringify({ verdict: "approved", reason: "duplicate id", evidenceChecked: ["tests"] })); const duplicateReview = await cell.run({ kind: "task-review-execution", taskId, executionId, reviewId: "review-complete", fromFile: "review.json" }, reviewBinding("duplicate-reviewer")); assert.equal(duplicateReview.outcome, "op_rejected"); assert.match(String(duplicateReview.nextAction), /append-only Review history requires a new review id/u);
     const missingConsent = await cell.run({ kind: "task-complete", taskId, executionId, ci: "passed" }, binding) as unknown as Record<string, unknown>; assert.deepEqual({ outcome: missingConsent.outcome, code: missingConsent.code, steps: missingConsent.steps }, { outcome: "op_rejected", code: "consent_missing", steps: [] }); assert.match(String(missingConsent.nextAction), /--review-id <review-id>/u);
-    const consented = await cell.run({ kind: "task-review-consent", taskId, executionId, reviewId: "review-complete", consentId: "consent-complete" }, binding) as unknown as Record<string, unknown>; assert.equal(consented.outcome, "applied", JSON.stringify(consented)); assert.equal(consented.reviewId, "review-complete");
+    const consented = await cell.run(
+      {
+        kind: "task-review-consent",
+        taskId,
+        executionId,
+        reviewId: "review-complete",
+        consentId: "consent-complete",
+      },
+      ownerFromAnotherAgent,
+    ) as unknown as Record<string, unknown>;
+    assert.equal(consented.outcome, "applied", JSON.stringify(consented));
+    assert.equal(consented.reviewId, "review-complete");
     assert.match(readFileSync(executionPath, "utf8"), /Selected review: review-complete[\s\S]*Consent: consent-complete/u); assert.match(readFileSync(path.join(rootDir, "harness", `${packagePath}/reviews/review-unselected.md`), "utf8"), /Consent: pending/u); assert.match(readFileSync(path.join(rootDir, "harness", `${packagePath}/reviews/review-complete.md`), "utf8"), /Consent: consent-complete/u);
     const missingCi = await cell.run({ kind: "task-complete", taskId, executionId }, binding) as unknown as Record<string, unknown>; assert.deepEqual({ outcome: missingCi.outcome, code: missingCi.code, steps: missingCi.steps }, { outcome: "op_rejected", code: "ci_missing", steps: [] }); const beforeCi = store().read().revision, partial = await cell.run({ kind: "task-complete", taskId, executionId, ci: "passed" }, binding) as unknown as Record<string, unknown>; assert.deepEqual({ outcome: partial.outcome, code: partial.code, stoppedAt: partial.stoppedAt, stepTypes: (partial.steps as { eventId?: string }[]).map((step) => store().readEvent(String(step.opId))?.type) }, { outcome: "op_rejected", code: "code_doc_missing", stoppedAt: "code_doc_missing", stepTypes: ["completion_gate_verified"] }); assert.equal(store().read().revision, beforeCi + 1); assert.equal((await cell.run({ kind: "task-show", taskId }, binding)).evidence.includes('"gateWitnesses"'), true);
-    const beforeDenied = store().read().revision, denied = await cell.run({ kind: "task-complete", taskId, executionId, paths: ["README.md"] }, { ...binding, docWriteAllowed: false }) as unknown as Record<string, unknown>; assert.deepEqual({ outcome: denied.outcome, code: denied.code, stoppedAt: denied.stoppedAt, stepTypes: (denied.steps as { opId: string }[]).map((step) => store().readEvent(step.opId)?.type) }, { outcome: "op_rejected", code: "rbac_forbidden", stoppedAt: "doc-sync-settlement", stepTypes: ["code_doc_reconciled", undefined] }); assert.equal(store().read().revision, beforeDenied + 1); const completed = await cell.run({ kind: "task-complete", taskId, executionId }, binding) as unknown as Record<string, unknown>; assert.equal(completed.outcome, "applied", JSON.stringify(completed)); assert.equal(completed.reviewId, "review-complete"); assert.equal(completed.stoppedAt, undefined); assert.deepEqual((completed.steps as { opId: string }[]).map((step) => store().readEvent(step.opId)?.type), ["documents_written", "task_completed"]); assert.deepEqual(completed.gateChecks, [{ gate: "ci", status: "pass", witnessRef: (completed.gateChecks as { witnessRef: string }[])[0]!.witnessRef }, { gate: "code-doc-reconciliation", status: "pass", witnessRef: (completed.gateChecks as { witnessRef: string }[])[1]!.witnessRef }]); assert.deepEqual(completed.next, []); assert.equal(readFileSync(path.join(rootDir, "harness", closeoutPath), "utf8").includes("All checks passed"), true); assert.equal(readFileSync(path.join(rootDir, "harness", artifactPath), "utf8").includes("Canonical flow"), true);
-    assert.equal((completed.authorizationDecision as Record<string, unknown>).policyRef, "default@2");
+    const beforeDenied = store().read().revision, denied = await cell.run({ kind: "task-complete", taskId, executionId, paths: ["README.md"] }, { ...binding, docWriteAllowed: false }) as unknown as Record<string, unknown>; assert.deepEqual({ outcome: denied.outcome, code: denied.code, stoppedAt: denied.stoppedAt, stepTypes: (denied.steps as { opId: string }[]).map((step) => store().readEvent(step.opId)?.type) }, { outcome: "op_rejected", code: "rbac_forbidden", stoppedAt: "doc-sync-settlement", stepTypes: ["code_doc_reconciled", undefined] }); assert.equal(store().read().revision, beforeDenied + 1);
+    const completed = await cell.run(
+      { kind: "task-complete", taskId, executionId },
+      ownerFromAnotherAgent,
+    ) as unknown as Record<string, unknown>;
+    assert.equal(completed.outcome, "applied", JSON.stringify(completed));
+    assert.equal(completed.reviewId, "review-complete");
+    assert.equal(completed.stoppedAt, undefined);
+    assert.deepEqual(
+      (completed.steps as { opId: string }[]).map((step) => store().readEvent(step.opId)?.type),
+      ["documents_written", "task_completed"],
+    );
+    assert.deepEqual(completed.gateChecks, [
+      {
+        gate: "ci",
+        status: "pass",
+        witnessRef: (completed.gateChecks as { witnessRef: string }[])[0]!.witnessRef,
+      },
+      {
+        gate: "code-doc-reconciliation",
+        status: "pass",
+        witnessRef: (completed.gateChecks as { witnessRef: string }[])[1]!.witnessRef,
+      },
+    ]);
+    assert.deepEqual(completed.next, []);
+    assert.equal(readFileSync(path.join(rootDir, "harness", closeoutPath), "utf8").includes("All checks passed"), true);
+    assert.equal(readFileSync(path.join(rootDir, "harness", artifactPath), "utf8").includes("Canonical flow"), true);
+    assert.equal((completed.authorizationDecision as Record<string, unknown>).policyRef, "default@3");
     assert.equal((completed.authorizationDecision as Record<string, unknown>).outcome, "allowed");
+    assert.deepEqual(
+      (completed.authorizationDecision as { bindingsUsed: readonly Readonly<Record<string, unknown>>[] }).bindingsUsed,
+      [
+        {
+          predicate: "hasCommandClass",
+          satisfied: true,
+          role: "owner",
+          matched: {
+            actor: { kind: "person", id: actor.principal.personId },
+            role: "owner",
+            target: `execution/${executionId}`,
+            source: "derived",
+            expiresAt: null,
+          },
+        },
+      ],
+    );
     const completeEvent = store().readEvent(String(completed.opId)); assert.equal(completeEvent?.type, "task_completed"); assert.equal(store().read().events.filter((event) => event.type === "task_completed").length, 1); assert.equal(store().read().events.filter((event) => event.type !== "task_completed").every((event) => event.schema !== "task-event/v1" || event.payload.task.status !== "done"), true); const revision = store().read().revision, repeated = await cell.run({ kind: "task-complete", taskId, executionId }, binding); assert.equal(repeated.opId, completed.opId); assert.equal(store().read().revision, revision);
     await cell.close(); cell = undefined; const rebuilt = makeTaskProjection({ rootDir, eventStore: store() }); rebuilt.close(); rmSync(rebuilt.path, { force: true }); rebuilt.rebuild(); assert.equal(rebuilt.read(taskId).snapshot.task?.status, "done"); assert.equal(rebuilt.read(taskId).snapshot.gateWitnesses.length, 1); rebuilt.close();
   } finally { await cell?.close(); rmSync(rootDir, { recursive: true, force: true }); }
@@ -602,7 +666,7 @@ test("Decision judgment keeps the transport arbiter gate and returns the embedde
   try { initRepo(rootDir); cell = await openRepoCell({ repoId: workspaceId("decision-consent"), rootDir: canonicalRoot(rootDir), ownerId: "daemon-test" }); const human = { principal: { personId: "person-ceo" }, executor: null } as const, binding = { actor: human, source: "local" as const }, proposed = await cell.run(decisionProposal("Consent", "May the CEO judge this proposal?"), binding), decisionId = (JSON.parse(proposed.evidence) as { decisionId: string }).decisionId, before = makeTaskEventStore({ repoId: "decision-consent", rootDir }).readHead()!.revision;
     const denied = await cell.run({ kind: "decision-accept", decisionId, rationale: "CEO approval", judgmentOnlyRationale: "Explicit CEO judgment." }, binding); assert.deepEqual({ outcome: denied.outcome, code: denied.code }, { outcome: "op_rejected", code: "actor_unauthorized" }); assert.equal(makeTaskEventStore({ repoId: "decision-consent", rootDir }).readHead()?.revision, before);
     const accepted = await cell.run({ kind: "decision-accept", decisionId, rationale: "CEO approval", judgmentOnlyRationale: "Explicit CEO judgment." }, withRoleBinding(binding, "arbiter")); assert.equal(accepted.outcome, "applied", JSON.stringify(accepted)); assert.match(String((accepted as Record<string, unknown>).consentId), /^djc_[0-9a-f]{26}$/u); const event = makeTaskEventStore({ repoId: "decision-consent", rootDir }).readEvent(accepted.opId); assert.equal(event?.schema, "decision-event/v1"); if (event?.schema === "decision-event/v1" && event.type === "decision_accepted") assert.equal(event.payload.judgmentConsent.consentId, (accepted as Record<string, unknown>).consentId);
-    assert.equal(accepted.authorizationDecision?.policyRef, "default@2");
+    assert.equal(accepted.authorizationDecision?.policyRef, "default@3");
     assert.equal(accepted.authorizationDecision?.outcome, "allowed");
   } finally { await cell?.close(); rmSync(rootDir, { recursive: true, force: true }); }
 });

--- a/packages/daemon/test/review-consent.integration.test.ts
+++ b/packages/daemon/test/review-consent.integration.test.ts
@@ -11,6 +11,14 @@ import { openRepoCell } from "../src/repo-cell.ts";
 import { withRoleBinding } from "./role-binding.fixtures.ts";
 
 const actor = { principal: { personId: "person-owner" }, executor: { kind: "agent", id: "codex" } } as const;
+const ownerFromAnotherAgent = {
+    principal: actor.principal,
+    executor: { kind: "agent", id: "other-owner-agent" },
+  } as const,
+  outsider = {
+    principal: { personId: "person-outsider" },
+    executor: { kind: "agent", id: "outsider-agent" },
+  } as const;
 
 function initRepo(rootDir: string): void {
   git(rootDir, "init", "--quiet");
@@ -82,9 +90,20 @@ test("review-consent derives the recorded Review digests without a packet and st
     assert.match(String(typo.nextAction), /choose one of review-derived/u);
     assert.equal(store().readHead()?.revision, beforeTypo);
 
+    const beforeOutsiderConsent = store().readHead()?.revision,
+      outsiderConsent = (await cell.run(
+        { kind: "task-review-consent", taskId, consentId: "consent-outsider" },
+        { actor: outsider, source: "local" },
+      )) as unknown as Record<string, unknown>;
+    assert.deepEqual(
+      { outcome: outsiderConsent.outcome, code: outsiderConsent.code },
+      { outcome: "op_rejected", code: "actor_unauthorized" },
+    );
+    assert.equal(store().readHead()?.revision, beforeOutsiderConsent);
+
     const consented = (await cell.run(
       { kind: "task-review-consent", taskId, consentId: "consent-derived" },
-      binding,
+      { actor: ownerFromAnotherAgent, source: "local" },
     )) as unknown as Record<string, unknown>;
     assert.equal(consented.outcome, "applied", JSON.stringify(consented));
     const consentEvent = store().readEvent(String(consented.opId));
@@ -97,6 +116,27 @@ test("review-consent derives the recorded Review digests without a packet and st
         reviewDigest: reviewDigest(reviewEvent.payload.review),
         contentDigest: reviewEvent.payload.review.contentDigest,
       },
+    );
+    assert.deepEqual(
+      (
+        consented.authorizationDecision as {
+          readonly bindingsUsed: readonly Readonly<Record<string, unknown>>[];
+        }
+      ).bindingsUsed,
+      [
+        {
+          predicate: "hasCommandClass",
+          satisfied: true,
+          role: "owner",
+          matched: {
+            actor: { kind: "person", id: actor.principal.personId },
+            role: "owner",
+            target: `execution/${executionId}`,
+            source: "derived",
+            expiresAt: null,
+          },
+        },
+      ],
     );
 
     // Negative control: an operator-supplied packet with a well-formed but wrong digest must still be rejected.

--- a/packages/daemon/test/review-independence-diagnostics.integration.test.ts
+++ b/packages/daemon/test/review-independence-diagnostics.integration.test.ts
@@ -231,7 +231,7 @@ test("a bare-invocation execution has a visible warning and an audited recovery 
     );
     assert.equal(consent.code, "actor_unauthorized");
     assert.match(String(consent.nextAction), /personId=0/u);
-    assert.match(String(consent.nextAction), /executor=none/u);
+    assert.doesNotMatch(String(consent.nextAction), /executor=/u);
   } finally {
     await cell?.close();
     rmSync(rootDir, { recursive: true, force: true });

--- a/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
@@ -151,7 +151,7 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
         },
       });
       assert.equal(receipt.outcome, "applied", JSON.stringify(receipt));
-      assert.equal((receipt.authorizationDecision as { policyRef?: string } | null)?.policyRef, "default@2");
+      assert.equal((receipt.authorizationDecision as { policyRef?: string } | null)?.policyRef, "default@3");
       assert.equal((receipt.authorizationDecision as { outcome?: string } | null)?.outcome, "allowed");
       assert.equal(launchedEnv?.HARNESS_ACTOR, `agent:runtime-session:${receipt.runtimeSessionId}`);
       assert.equal(launchedEnv?.HARNESS_DAEMON_USER_ROOT, userRoot);
@@ -222,7 +222,7 @@ test("daemon ingress preserves executor-scoped task-bound runtime spawn", async 
         },
       });
       assert.equal(receipt.outcome, "applied", JSON.stringify(receipt));
-      assert.equal((receipt.authorizationDecision as { policyRef?: string } | null)?.policyRef, "default@2");
+      assert.equal((receipt.authorizationDecision as { policyRef?: string } | null)?.policyRef, "default@3");
       assert.equal((receipt.authorizationDecision as { outcome?: string } | null)?.outcome, "allowed");
       const bound = await eventuallyValue(
         async () =>

--- a/packages/daemon/test/task-closeout-action.test.ts
+++ b/packages/daemon/test/task-closeout-action.test.ts
@@ -144,12 +144,12 @@ function setup(initial = snapshot(), rejectStage?: CloseoutStep, setupCaller = c
   return { rootDir, calls, run };
 }
 
-test("closeout runs four canonical leaf commands with derived actor postures and no system-known selector", async () => {
+test("closeout runs four canonical leaf commands without impersonating the creator's executor", async () => {
   const value = setup();
   try {
     const receipt = await value.run();
     assert.equal(receipt.outcome, "applied");
-    assert.equal(receipt.authorizationDecision?.policyRef, "default@2");
+    assert.equal(receipt.authorizationDecision?.policyRef, "default@3");
     assert.equal(receipt.authorizationDecision?.outcome, "allowed");
     assert.equal(
       receipt.authorizationDecision?.bindingsUsed.some(
@@ -164,7 +164,7 @@ test("closeout runs four canonical leaf commands with derived actor postures and
     assert.ok(value.calls.every(({ action }) => action.executionId === undefined));
     assert.deepEqual(
       value.calls.map(({ actor }) => actor.executor?.id ?? null),
-      ["worker-agent", null, "owner-agent", "owner-agent"],
+      ["worker-agent", null, "worker-agent", "worker-agent"],
     );
     assert.deepEqual(value.calls.at(-1)?.action.paths, ["packages/application/src/task-closeout-action.ts"]);
   } finally {

--- a/packages/kernel/src/domain/default-policy.ts
+++ b/packages/kernel/src/domain/default-policy.ts
@@ -4,14 +4,13 @@ import type { PolicyDeclarationV1 } from "./policy.ts";
 const defaultPolicyDeclaration = {
   schema: "policy/v1",
   id: "default",
-  version: 2,
+  version: 3,
   predicates: Object.freeze([
-    { predicate: "isOwner" },
-    { predicate: "isSameExecutionOwner" },
     { predicate: "holdsExecutionLease" },
     { predicate: "reclaimsOrphanedLease" },
     { predicate: "dispatchesExecution" },
     { predicate: "delegatedByRuntimeSession" },
+    { predicate: "hasCommandClass", commandClass: "owner" },
     { predicate: "hasCommandClass", commandClass: "arbiter" },
     { predicate: "hasCommandClass", commandClass: "repo-write" },
     { predicate: "reviewIndependence", level: "L1" },
@@ -30,8 +29,14 @@ const defaultPolicyDeclaration = {
     "task.closeout",
   ]),
   rules: Object.freeze([
-    { action: "task.consent", anyOf: [{ allOf: [{ predicate: "isSameExecutionOwner" }] }] },
-    { action: "task.complete", anyOf: [{ allOf: [{ predicate: "isOwner" }] }] },
+    {
+      action: "task.consent",
+      anyOf: [{ allOf: [{ predicate: "hasCommandClass", commandClass: "owner" }] }],
+    },
+    {
+      action: "task.complete",
+      anyOf: [{ allOf: [{ predicate: "hasCommandClass", commandClass: "owner" }] }],
+    },
     { action: "execution.start", anyOf: [{ allOf: [{ predicate: "hasCommandClass", commandClass: "repo-write" }] }] },
     {
       action: "execution.review",
@@ -70,7 +75,11 @@ const defaultPolicyDeclaration = {
         { allOf: [{ predicate: "delegatedByRuntimeSession" }, { predicate: "sameWriteSource" }] },
       ],
     },
-    { action: "task.closeout", scope: "owner", anyOf: [{ allOf: [{ predicate: "isOwner" }] }] },
+    {
+      action: "task.closeout",
+      scope: "owner",
+      anyOf: [{ allOf: [{ predicate: "hasCommandClass", commandClass: "owner" }] }],
+    },
     {
       action: "task.closeout",
       scope: "active",

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -73,6 +73,7 @@ export type { EntityRef, EntityRefKind, ParsedEntityRef } from "./entity-ref.ts"
 
 export { deriveRoleBindings, roleBindingActorMatches, roleBindingApplies, roleBindingExpired } from "./role-binding.ts";
 export type { RoleBinding } from "./role-binding.ts";
+export { deriveOwnerRoleBinding } from "./owner-role-binding.ts";
 
 export {
   decisionEntityId,

--- a/packages/kernel/src/domain/owner-role-binding.ts
+++ b/packages/kernel/src/domain/owner-role-binding.ts
@@ -1,0 +1,15 @@
+import type { ActorIdentity } from "./actor-identity.ts";
+import type { EntityRef } from "./entity-ref.ts";
+import type { RoleBinding } from "./role-binding.ts";
+
+/** The non-transferable owner role is derived from the creator's principal axis. */
+export function deriveOwnerRoleBinding(createdBy: ActorIdentity, target: EntityRef): RoleBinding {
+  const binding: RoleBinding = {
+    actor: { kind: "person", id: createdBy.principal.personId },
+    role: "owner",
+    target,
+    source: "derived",
+    expiresAt: null,
+  };
+  return Object.freeze(binding);
+}

--- a/packages/kernel/src/domain/policy.ts
+++ b/packages/kernel/src/domain/policy.ts
@@ -9,8 +9,6 @@ import {
 import { isRecord } from "./write-chain.contract.ts";
 
 export const policyPredicateNames = Object.freeze([
-  "isOwner",
-  "isSameExecutionOwner",
   "holdsExecutionLease",
   "reclaimsOrphanedLease",
   "dispatchesExecution",
@@ -26,8 +24,6 @@ export const reviewIndependenceLevels = Object.freeze(["L1", "L2"] as const);
 export type ReviewIndependenceLevel = (typeof reviewIndependenceLevels)[number];
 
 type PolicyPredicate =
-  | { readonly predicate: "isOwner" }
-  | { readonly predicate: "isSameExecutionOwner" }
   | { readonly predicate: "holdsExecutionLease" }
   | { readonly predicate: "reclaimsOrphanedLease" }
   | { readonly predicate: "dispatchesExecution" }

--- a/packages/kernel/src/ports/authorization-port.ts
+++ b/packages/kernel/src/ports/authorization-port.ts
@@ -147,11 +147,7 @@ function evaluatePredicate(
     terminalRuntimeBinding?.taskId === lease.taskId &&
     terminalRuntimeBinding.executionId === lease.executionId;
   let holds = false;
-  if (expression.predicate === "isOwner")
-    holds = target.owner !== null && target.owner !== undefined && isSamePerson(target.owner, actor);
-  else if (expression.predicate === "isSameExecutionOwner")
-    holds = target.owner !== null && target.owner !== undefined && isSameExecution(target.owner, actor);
-  else if (expression.predicate === "holdsExecutionLease")
+  if (expression.predicate === "holdsExecutionLease")
     holds = leaseTargetsSubject && lease !== null && isSameExecution(lease.actor, actor);
   else if (expression.predicate === "reclaimsOrphanedLease")
     holds =

--- a/packages/kernel/test/contracts/authorization-policy-mutations.test.ts
+++ b/packages/kernel/test/contracts/authorization-policy-mutations.test.ts
@@ -39,15 +39,23 @@ const owner: ActorIdentity = {
   runtimeBinding = { runtimeSessionId: "runtime-1", taskId: "task-1", executionId: "execution-1" } as const;
 
 function commandRoles(actor: ActorIdentity, ...roles: readonly string[]) {
+  return rolesOnTarget(actor, "settings/repository", ...roles);
+}
+
+function rolesOnTarget(
+  actor: ActorIdentity,
+  target: Case["target"] | "settings/repository",
+  ...roles: readonly string[]
+) {
   return {
     roleBindings: roles.map((role) => ({
       actor: { kind: "person" as const, id: actor.principal.personId },
       role,
-      target: "settings/repository" as const,
+      target,
       source: "derived" as const,
       expiresAt: null,
     })),
-    roleBindingTargets: ["settings/repository" as const],
+    roleBindingTargets: [target],
   };
 }
 
@@ -64,33 +72,33 @@ const cases: readonly Case[] = [
   {
     label: "consent owner",
     kind: "task.consent",
-    target: "task/task-1",
-    actor: owner,
-    context: { target: { owner } },
+    target: "execution/execution-1",
+    actor: humanOwner,
+    context: { ...rolesOnTarget(owner, "execution/execution-1", "owner"), target: {} },
     expected: "allowed",
   },
   {
-    label: "consent executor mismatch",
+    label: "consent outsider",
     kind: "task.consent",
-    target: "task/task-1",
-    actor: humanOwner,
-    context: { target: { owner } },
+    target: "execution/execution-1",
+    actor: outsider,
+    context: { ...rolesOnTarget(owner, "execution/execution-1", "owner"), target: {} },
     expected: "denied",
   },
   {
     label: "complete owner",
     kind: "task.complete",
-    target: "task/task-1",
+    target: "execution/execution-1",
     actor: humanOwner,
-    context: { target: { owner } },
+    context: { ...rolesOnTarget(owner, "execution/execution-1", "owner"), target: {} },
     expected: "allowed",
   },
   {
     label: "complete outsider",
     kind: "task.complete",
-    target: "task/task-1",
+    target: "execution/execution-1",
     actor: outsider,
-    context: { target: { owner } },
+    context: { ...rolesOnTarget(owner, "execution/execution-1", "owner"), target: {} },
     expected: "denied",
   },
   {
@@ -266,7 +274,11 @@ const cases: readonly Case[] = [
     kind: "task.closeout",
     target: "task/task-1",
     actor: humanOwner,
-    context: { ruleScope: "owner", target: { owner, lease } },
+    context: {
+      ...rolesOnTarget(owner, "task/task-1", "owner"),
+      ruleScope: "owner",
+      target: { lease },
+    },
     expected: "allowed",
   },
   {
@@ -274,7 +286,11 @@ const cases: readonly Case[] = [
     kind: "task.closeout",
     target: "task/task-1",
     actor: outsider,
-    context: { ruleScope: "owner", target: { owner, lease } },
+    context: {
+      ...rolesOnTarget(owner, "task/task-1", "owner"),
+      ruleScope: "owner",
+      target: { lease },
+    },
     expected: "denied",
   },
   {
@@ -305,7 +321,7 @@ function assertLocationOracles(policy: PolicyDeclarationV1): void {
         kind: row.kind,
         target: row.target,
         actor: row.actor,
-        authorizationRef: "default@2",
+        authorizationRef: `${DEFAULT_POLICY.id}@${DEFAULT_POLICY.version}`,
         idempotencyKey: `mutation-${row.label}`,
       },
       { ...row.context, evaluatedAtCut: "canonical:mutation" },
@@ -318,11 +334,11 @@ function clonePolicy(): PolicyDeclarationV1 {
   return structuredClone(DEFAULT_POLICY);
 }
 
-test("the unmutated v2 Policy satisfies every location oracle", () => {
+test("the unmutated v3 Policy satisfies every location oracle", () => {
   assertLocationOracles(DEFAULT_POLICY);
 });
 
-test("every v2 rule deletion is killed by its location oracle", async (t) => {
+test("every v3 rule deletion is killed by its location oracle", async (t) => {
   for (const [ruleIndex, rule] of (DEFAULT_POLICY.rules ?? []).entries())
     await t.test(`${rule.action}:${rule.scope ?? "default"}`, () => {
       const mutant = clonePolicy(),
@@ -332,7 +348,7 @@ test("every v2 rule deletion is killed by its location oracle", async (t) => {
     });
 });
 
-test("every v2 rule-predicate deletion is killed by its location oracle", async (t) => {
+test("every v3 rule-predicate deletion is killed by its location oracle", async (t) => {
   for (const [ruleIndex, rule] of (DEFAULT_POLICY.rules ?? []).entries())
     for (const [clauseIndex, clause] of rule.anyOf.entries())
       for (const [predicateIndex, predicate] of clause.allOf.entries())

--- a/packages/kernel/test/contracts/authorization-port.test.ts
+++ b/packages/kernel/test/contracts/authorization-port.test.ts
@@ -52,7 +52,7 @@ function decide(
       kind,
       target,
       actor,
-      authorizationRef: "default@2",
+      authorizationRef: `${DEFAULT_POLICY.id}@${DEFAULT_POLICY.version}`,
       idempotencyKey: `idempotency-${kind}`,
     },
     { ...context, evaluatedAtCut: "canonical:17" },
@@ -62,29 +62,39 @@ function decide(
 function commandBinding(
   commandClass: string,
   actor: ActorIdentity,
+  target: ActionEnvelope["target"] = "settings/repository",
 ): Pick<AuthorizationContext, "roleBindings" | "roleBindingTargets"> {
   return {
     roleBindings: [
       {
         actor: { kind: "person", id: actor.principal.personId },
         role: commandClass,
-        target: "settings/repository",
+        target,
         source: "derived",
         expiresAt: null,
       },
     ],
-    roleBindingTargets: ["settings/repository"],
+    roleBindingTargets: [target],
   };
 }
 
-test("v2 separates principal ownership from exact execution ownership", () => {
-  assert.equal(decide("task.complete", humanOwner, "task/task-1", { target: { owner } }).outcome, "allowed");
-  assert.equal(decide("task.complete", outsider, "task/task-1", { target: { owner } }).outcome, "denied");
-  assert.equal(decide("task.consent", humanOwner, "task/task-1", { target: { owner } }).outcome, "denied");
-  assert.equal(decide("task.consent", owner, "task/task-1", { target: { owner } }).outcome, "allowed");
+test("v3 uses one Execution owner RoleBinding for consent and completion", () => {
+  const ownerBinding = commandBinding("owner", owner, "execution/execution-1");
+  for (const action of ["task.consent", "task.complete"])
+    assert.equal(
+      decide(action, humanOwner, "execution/execution-1", { ...ownerBinding, target: {} }).outcome,
+      "allowed",
+      action,
+    );
+  for (const action of ["task.consent", "task.complete"])
+    assert.equal(
+      decide(action, outsider, "execution/execution-1", { ...ownerBinding, target: {} }).outcome,
+      "denied",
+      action,
+    );
 });
 
-test("v2 admits execution start only through the server-admitted repo-write command class", () => {
+test("v3 admits execution start only through the server-admitted repo-write command class", () => {
   assert.equal(
     decide("execution.start", owner, "execution/execution-1", {
       ...commandBinding("repo-write", owner),
@@ -95,7 +105,7 @@ test("v2 admits execution start only through the server-admitted repo-write comm
   assert.equal(decide("execution.start", owner, "execution/execution-1", { target: {} }).outcome, "denied");
 });
 
-test("v2 models held and orphaned release bindings without overloading ownership", () => {
+test("v3 models held and orphaned release bindings without overloading ownership", () => {
   assert.equal(
     decide("execution.release", owner, "execution/execution-1", {
       target: { lease, canonicalExecutionExists: true },
@@ -128,7 +138,7 @@ test("v2 models held and orphaned release bindings without overloading ownership
   );
 });
 
-test("v2 limits task-owner reclamation to orphaned leases and terminal Runtime bindings", () => {
+test("v3 limits task-owner reclamation to orphaned leases and terminal Runtime bindings", () => {
   const targetOwner = { principal: taskOwner.principal, executor: { kind: "agent", id: "task-creator" } } as const,
     terminalRuntimeBinding = {
       runtimeSessionId: "runtime-1",
@@ -167,7 +177,7 @@ test("v2 limits task-owner reclamation to orphaned leases and terminal Runtime b
   );
 });
 
-test("v2 preserves same-principal dispatcher and live RuntimeSession handoff behavior", () => {
+test("v3 preserves same-principal dispatcher and live RuntimeSession handoff behavior", () => {
   assert.equal(decide("runtime.dispatch", humanOwner, "task/task-1", { target: { lease } }).outcome, "allowed");
   assert.equal(decide("runtime.dispatch", reviewer, "task/task-1", { target: { lease } }).outcome, "denied");
   assert.equal(
@@ -181,7 +191,7 @@ test("v2 preserves same-principal dispatcher and live RuntimeSession handoff beh
   );
 });
 
-test("v2 requires write-source equality on both direct and delegated document branches", () => {
+test("v3 requires write-source equality on both direct and delegated document branches", () => {
   assert.equal(
     decide("doc.submit", owner, "execution/execution-1", { writeSource: "local", target: { lease } }).outcome,
     "allowed",
@@ -208,7 +218,7 @@ test("v2 requires write-source equality on both direct and delegated document br
   );
 });
 
-test("v2 keeps execution review independent and rejects Decision outcomes from the proposal agent", () => {
+test("v3 keeps execution review independent and rejects Decision outcomes from the proposal agent", () => {
   assert.equal(
     decide("execution.review", reviewer, "execution/execution-1", {
       ...commandBinding("arbiter", reviewer),
@@ -256,7 +266,7 @@ test("the default port keeps broader Decision review independence disabled", () 
           kind: "decision.accept",
           target: "decision/decision-1",
           actor,
-          authorizationRef: "default@2",
+          authorizationRef: `${DEFAULT_POLICY.id}@${DEFAULT_POLICY.version}`,
           idempotencyKey: `gated-decision-${actor.executor?.id ?? "human"}`,
         },
         {
@@ -275,7 +285,7 @@ test("the default port keeps broader Decision review independence disabled", () 
         kind: "decision.accept",
         target: "decision/decision-1",
         actor: humanOwner,
-        authorizationRef: "default@2",
+        authorizationRef: `${DEFAULT_POLICY.id}@${DEFAULT_POLICY.version}`,
         idempotencyKey: "gated-decision-human",
       },
       {
@@ -288,9 +298,14 @@ test("the default port keeps broader Decision review independence disabled", () 
   );
 });
 
-test("v2 closeout selects owner and active-lease rules explicitly", () => {
+test("v3 closeout selects owner and active-lease rules explicitly", () => {
+  const ownerBinding = commandBinding("owner", owner, "task/task-1");
   assert.equal(
-    decide("task.closeout", humanOwner, "task/task-1", { ruleScope: "owner", target: { owner } }).outcome,
+    decide("task.closeout", humanOwner, "task/task-1", {
+      ...ownerBinding,
+      ruleScope: "owner",
+      target: {},
+    }).outcome,
     "allowed",
   );
   assert.equal(
@@ -302,7 +317,11 @@ test("v2 closeout selects owner and active-lease rules explicitly", () => {
     "denied",
   );
   assert.equal(
-    decide("task.closeout", outsider, "task/task-1", { ruleScope: "owner", target: { owner, lease } }).outcome,
+    decide("task.closeout", outsider, "task/task-1", {
+      ...ownerBinding,
+      ruleScope: "owner",
+      target: { lease },
+    }).outcome,
     "denied",
   );
 });
@@ -312,13 +331,13 @@ test("evaluation fails closed for stale policy references and missing action or 
     version: currentActionEnvelopeVersion,
     actionId: "stale",
     kind: "task.complete",
-    target: "task/task-1",
+    target: "execution/execution-1",
     actor: owner,
     authorizationRef: "default@1",
     idempotencyKey: "stale",
   };
   assert.deepEqual(
-    evaluateAuthorization(DEFAULT_POLICY, action, { target: { owner }, evaluatedAtCut: "canonical:17" }).reasonCodes,
+    evaluateAuthorization(DEFAULT_POLICY, action, { target: {}, evaluatedAtCut: "canonical:17" }).reasonCodes,
     ["authorization_ref_mismatch"],
   );
   assert.equal(

--- a/packages/kernel/test/contracts/policy-entity.test.ts
+++ b/packages/kernel/test/contracts/policy-entity.test.ts
@@ -5,9 +5,9 @@ import { DEFAULT_POLICY } from "../../src/domain/default-policy.ts";
 import { parsePolicyDeclarationV1, validatePolicyDeclarationV1 } from "../../src/domain/policy.ts";
 import { explainEntityKind } from "../../src/index.ts";
 
-test("the built-in v2 policy registers its binding predicates and applicable Actions", () => {
+test("the built-in v3 policy registers its binding predicates and applicable Actions", () => {
   assert.deepEqual(validatePolicyDeclarationV1(DEFAULT_POLICY), []);
-  assert.equal(DEFAULT_POLICY.version, 2);
+  assert.equal(DEFAULT_POLICY.version, 3);
   assert.deepEqual(DEFAULT_POLICY.actions, [
     "task.consent",
     "task.complete",
@@ -28,8 +28,6 @@ test("the built-in v2 policy registers its binding predicates and applicable Act
       ),
     ],
     [
-      "isSameExecutionOwner",
-      "isOwner",
       "hasCommandClass",
       "reviewIndependence",
       "isNotProposalAgent",
@@ -53,15 +51,15 @@ test("the built-in v2 policy registers its binding predicates and applicable Act
           .join("|")}`,
     ),
     [
-      'task.consent:-=>{"predicate":"isSameExecutionOwner"}',
-      'task.complete:-=>{"predicate":"isOwner"}',
+      'task.consent:-=>{"predicate":"hasCommandClass","commandClass":"owner"}',
+      'task.complete:-=>{"predicate":"hasCommandClass","commandClass":"owner"}',
       'execution.start:-=>{"predicate":"hasCommandClass","commandClass":"repo-write"}',
       'execution.review:-=>{"predicate":"hasCommandClass","commandClass":"arbiter"}+{"predicate":"reviewIndependence","level":"L1"}',
       'decision.accept:-=>{"predicate":"hasCommandClass","commandClass":"arbiter"}+{"predicate":"isNotProposalAgent"}',
       'execution.release:-=>{"predicate":"holdsExecutionLease"}|{"predicate":"reclaimsOrphanedLease"}',
       'runtime.dispatch:-=>{"predicate":"dispatchesExecution"}|{"predicate":"delegatedByRuntimeSession"}',
       'doc.submit:-=>{"predicate":"holdsExecutionLease"}+{"predicate":"sameWriteSource"}|{"predicate":"delegatedByRuntimeSession"}+{"predicate":"sameWriteSource"}',
-      'task.closeout:owner=>{"predicate":"isOwner"}',
+      'task.closeout:owner=>{"predicate":"hasCommandClass","commandClass":"owner"}',
       'task.closeout:active=>{"predicate":"holdsExecutionLease"}',
     ],
   );
@@ -71,8 +69,6 @@ test("ha entity explain policy exposes the registered predicate vocabulary, Acti
   const explanation = explainEntityKind("policy");
   assert.deepEqual(explanation.policy, {
     predicates: [
-      "isOwner",
-      "isSameExecutionOwner",
       "holdsExecutionLease",
       "reclaimsOrphanedLease",
       "dispatchesExecution",
@@ -94,8 +90,8 @@ test("policy schema rejects a missing version and invalid predicate arguments", 
   const withoutVersion = { ...DEFAULT_POLICY, version: undefined };
   assert.match(validatePolicyDeclarationV1(withoutVersion).join("\n"), /missing required field "version"/u);
   assert.throws(
-    () => parsePolicyDeclarationV1({ ...DEFAULT_POLICY, predicates: [{ predicate: "isOwner", level: "L1" }] }),
-    /isOwner does not accept arguments/u,
+    () => parsePolicyDeclarationV1({ ...DEFAULT_POLICY, predicates: [{ predicate: "sameWriteSource", level: "L1" }] }),
+    /sameWriteSource does not accept arguments/u,
   );
 });
 


### PR DESCRIPTION
# English

## Summary

RBAC Phase 3.4 (dec_CD53D4B150596BAF382944516E): `task.consent` and `task.complete` are decided by one predicate. Default Policy moves v2 → v3 and the consent, complete and closeout-owner rules all become `hasCommandClass(owner)` against an Execution-scoped derived `owner` RoleBinding whose actor is fixed to `createdBy.principal` (泽宇's ruling: owner = creator forever, an agent can be the owner). The two field-comparison evaluators `isOwner` and `isSameExecutionOwner` are deleted from the Policy vocabulary and the AuthorizationPort; consent/complete leaf commands now use the real caller instead of overwriting it with the task-creation executor. Review independence keeps the L1/L2 semantics from 3.2.

## Architectural Justification

- Not required: Production-Delta churn is below 200 lines.

## What Changed

- `packages/kernel/src/domain/owner-role-binding.ts` (new): single derived owner binding from `createdBy.principal`.
- `packages/kernel/src/domain/default-policy.ts` v3, `policy.ts`, `packages/kernel/src/ports/authorization-port.ts`: `isOwner`/`isSameExecutionOwner` removed; consent/complete/closeout-owner → `hasCommandClass(owner)`.
- `packages/daemon/src/repo-cell-proof.ts`, `packages/application/src/task-closeout-action.ts`: Execution as authorization subject with the injected owner binding; real caller on leaf commands.
- Tests: review-consent integration, json-rpc protocol, task-closeout action, authorization-port, policy-entity, policy mutations; Policy ref v3 followers.

## Gate Harvest / 门收割

Deleted-Production-Paths: Policy predicates `isOwner` and `isSameExecutionOwner` and their AuthorizationPort evaluator branches (packages/kernel/src/domain/policy.ts, ports/authorization-port.ts)
Deleted-Gates-Fixtures: authorization-port and policy-entity cases that asserted the field-comparison predicates (replaced by owner-binding cases in the same commit)
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +62/-35

### Optional Evidence Claims

## Task And Scope

- Harness task: task_1d1ba3cf36dfb2c9a85be3c044
- Branch: codex/consent-predicate
- Public scope: packages/kernel domain/ports (policy, owner binding), packages/daemon repo-cell-proof.ts, packages/application task-closeout-action.ts, tests
- Private planning/evidence updated: yes
- Out of scope: 3.3 DelegatedExecutionToken (task_d43f7002, separate PR); Policy as a first-class entity beyond the default policy document

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_1d1ba3cf36dfb2c9a85be3c044
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 33a0533375ac3c33db4b155c86a0118674e8fd6b
- Branch merge-base with `origin/main`: 33a0533375ac3c33db4b155c86a0118674e8fd6b
- Last `git fetch origin` time: 2026-08-27T10:46:46Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_1d1ba3cf36dfb2c9a85be3c044 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] review-consent integration, json-rpc protocol, task-closeout action, authorization-port, policy-entity and policy mutation tests green; typecheck
- [x] Rebased onto main after #1936; delta recomputed
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: integration tier locally by design; CI is the authority.

## Review Evidence

- Self-review: CEO checked the plan's deletion criterion (both comparison predicates gone) and the owner = createdBy ruling against the report.
- Reviewer subagent: Codex worker (gpt-5.6-sol); CEO acceptance.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Default Policy v3 changes the policy ref in stored fixtures; repositories pinned to v2 keep working because the ref is data, but any external policy document that named `isOwner` is now rejected loudly.

## References

- Task: task_1d1ba3cf36dfb2c9a85be3c044
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

RBAC Phase 3.4(dec_CD53D4B150596BAF382944516E):`task.consent` 与 `task.complete` 由同一条谓词判定。默认 Policy v2 → v3,consent、complete、closeout-owner 三条规则统一为 `hasCommandClass(owner)`,对象是 Execution 级派生 `owner` RoleBinding,actor 固定为 `createdBy.principal`(泽宇裁决:owner 永远是创建者,agent 也可以是 owner)。从 Policy 词表与 AuthorizationPort 删除 `isOwner`、`isSameExecutionOwner` 两条字段比较 evaluator;consent/complete 叶命令用真实 caller,不再被建 task 时的 executor 覆盖。评审独立性沿用 3.2 的 L1/L2。

## 架构辩护

- 不需要:Production-Delta churn 低于 200 行。

## 改动内容

- `packages/kernel/src/domain/owner-role-binding.ts`(新):由 `createdBy.principal` 派生的唯一 owner 绑定。
- `packages/kernel/src/domain/default-policy.ts` v3、`policy.ts`、`packages/kernel/src/ports/authorization-port.ts`:删除 `isOwner`/`isSameExecutionOwner`;consent/complete/closeout-owner → `hasCommandClass(owner)`。
- `packages/daemon/src/repo-cell-proof.ts`、`packages/application/src/task-closeout-action.ts`:授权主体改为 Execution 并注入 owner 绑定;叶命令用真实 caller。
- 测试:review-consent 集成、json-rpc 协议、task-closeout action、authorization-port、policy-entity、policy 变异;Policy ref v3 跟随。

## 门收割 / Gate Harvest

- 删除的生产路径:Policy 谓词 `isOwner`、`isSameExecutionOwner` 及其 AuthorizationPort evaluator 分支(packages/kernel/src/domain/policy.ts、ports/authorization-port.ts)
- 同 commit 删除的门 / fixture:断言字段比较谓词的 authorization-port 与 policy-entity 用例(同 commit 换成 owner 绑定用例)
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_1d1ba3cf36dfb2c9a85be3c044
- 分支:codex/consent-predicate
- 公开范围:packages/kernel domain/ports(policy、owner 绑定)、packages/daemon repo-cell-proof.ts、packages/application task-closeout-action.ts、测试
- 私有计划 / 证据是否已更新:yes
- 范围外:3.3 DelegatedExecutionToken(task_d43f7002,独立 PR);默认 policy 文档之外的 Policy 一等实体化

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_1d1ba3cf36dfb2c9a85be3c044
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:33a0533375ac3c33db4b155c86a0118674e8fd6b
- 当前分支与 `origin/main` 的 merge-base:33a0533375ac3c33db4b155c86a0118674e8fd6b
- 最近一次 `git fetch origin` 时间:2026-08-27T10:46:46Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_1d1ba3cf36dfb2c9a85be3c044
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] review-consent 集成、json-rpc 协议、task-closeout action、authorization-port、policy-entity 与 policy 变异测试绿;typecheck
- [x] #1936 合入后 rebase 到 main;delta 重算
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计本地不跑 integration tier;以 CI 为权威。

## 审查证据

- 自查:CEO 对照 plan 的删除判据(两条比较谓词都删)与 owner=createdBy 裁决核报告。
- Reviewer subagent:Codex worker(gpt-5.6-sol);CEO 验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 默认 Policy v3 改变了存储 fixture 里的 policy ref;钉在 v2 的仓库照常工作(ref 是数据),但任何外部 policy 文档若引用 `isOwner` 现在会被显式拒绝。

## 关联材料

- 任务:task_1d1ba3cf36dfb2c9a85be3c044
- 证据:任务包 artifacts/reports
- 审查:本 PR

