### PR TITLE
feat(identity): delegated execution tokens as authorization actor proof

### DIFF
--- a/packages/cli/src/cli/thin-command-router.ts
+++ b/packages/cli/src/cli/thin-command-router.ts
@@ -103,6 +103,8 @@ const peopleRequiredInputs: Readonly<Record<string, readonly string[]>> = Object
   "people-add": ["--person-id", "--display-name", "--role", "--command-class"],
   "people-set-role": ["--person-id", "--role", "--command-class"],
   "people-bind": ["--actor", "--role", "--target"],
+  "people-delegate": ["--token-id", "--runtime-session-id", "--action", "--expires-at"],
+  "people-revoke-delegation": ["--token-id"],
   "people-remove": ["--person-id"],
 });
 

--- a/packages/cli/test/people-command.test.ts
+++ b/packages/cli/test/people-command.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { parseThinCommand } from "../src/cli/thin-command.ts";
 
-test("People CLI projects add, set-role, bind, and remove onto closed Action payloads", () => {
+test("People CLI projects registry and delegated-token mutations onto closed Action payloads", () => {
   const added = parseThinCommand([
     "people",
     "add",
@@ -58,6 +58,36 @@ test("People CLI projects add, set-role, bind, and remove onto closed Action pay
       role: "arbiter",
       target: "settings/repository",
     });
+  const delegated = parseThinCommand([
+    "people",
+    "delegate",
+    "--token-id",
+    "det_alice_runtime_1",
+    "--runtime-session-id",
+    "runtime_1",
+    "--action",
+    "execution.start",
+    "--action",
+    "doc.submit",
+    "--expires-at",
+    "2026-08-27T03:00:00.000Z",
+  ]);
+  assert.equal(delegated.ok, true);
+  if (delegated.ok)
+    assert.deepEqual(delegated.command.action, {
+      kind: "people-delegate",
+      tokenId: "det_alice_runtime_1",
+      runtimeSessionId: "runtime_1",
+      action: ["execution.start", "doc.submit"],
+      expiresAt: "2026-08-27T03:00:00.000Z",
+    });
+  const revoked = parseThinCommand(["people", "revoke-delegation", "--token-id", "det_alice_runtime_1"]);
+  assert.equal(revoked.ok, true);
+  if (revoked.ok)
+    assert.deepEqual(revoked.command.action, {
+      kind: "people-revoke-delegation",
+      tokenId: "det_alice_runtime_1",
+    });
   assert.equal(parseThinCommand(["people", "remove", "--person-id", "person_alice"]).ok, true);
 });
 
@@ -106,6 +136,14 @@ test("People CLI exposes one closed structured packet facet per public command",
     [
       ["people", "bind", "--from-file", "people-binding.json"],
       { kind: "people-bind", fromFile: "people-binding.json" },
+    ],
+    [
+      ["people", "delegate", "--from-file", "people-delegation.json"],
+      { kind: "people-delegate", fromFile: "people-delegation.json" },
+    ],
+    [
+      ["people", "revoke-delegation", "--from-file", "people-revocation.json"],
+      { kind: "people-revoke-delegation", fromFile: "people-revocation.json" },
     ],
     [
       ["people", "remove", "--from-file", "people-remove.json"],

--- a/packages/cli/test/thin-command-contract-parity.test.ts
+++ b/packages/cli/test/thin-command-contract-parity.test.ts
@@ -42,7 +42,7 @@ const frozenMutations = Object.freeze([
 ] as const);
 
 test("all public commands expose the canonical structured input facet", () => {
-  assert.equal(daemonProtocolCommands.length, 133);
+  assert.equal(daemonProtocolCommands.length, 134);
   for (const command of daemonProtocolCommands) {
     assert.equal(Object.hasOwn(command, "inputs"), true, `${command.id}: explicit inputs`);
     assert.deepEqual(deriveThinCliInputs(command), command.inputs, command.id);
@@ -78,6 +78,8 @@ test("all public commands expose the canonical structured input facet", () => {
     "people-add",
     "people-set-role",
     "people-bind",
+    "people-delegate",
+    "people-revoke-delegation",
     "people-remove",
     "schedule-show",
     "schedule-update",

--- a/packages/cli/test/thin-command-contract-parity.test.ts
+++ b/packages/cli/test/thin-command-contract-parity.test.ts
@@ -42,7 +42,7 @@ const frozenMutations = Object.freeze([
 ] as const);
 
 test("all public commands expose the canonical structured input facet", () => {
-  assert.equal(daemonProtocolCommands.length, 134);
+  assert.equal(daemonProtocolCommands.length, 135);
   for (const command of daemonProtocolCommands) {
     assert.equal(Object.hasOwn(command, "inputs"), true, `${command.id}: explicit inputs`);
     assert.deepEqual(deriveThinCliInputs(command), command.inputs, command.id);

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -8,7 +8,7 @@ import { emit, main, resolveCliVersion } from "../src/index.ts";
 
 test("top-level help renders a derived domain directory and domain help filters commands", () => {
   const help = renderThinHelp();
-  assert.equal(thinCliCommands.length, 133);
+  assert.equal(thinCliCommands.length, 134);
   for (const domain of [...new Set(daemonProtocolCommands.map((command) => command.path[0]))]
     .filter((value): value is string => value !== undefined)
     .sort())

--- a/packages/cli/test/thin-command.test.ts
+++ b/packages/cli/test/thin-command.test.ts
@@ -8,7 +8,7 @@ import { emit, main, resolveCliVersion } from "../src/index.ts";
 
 test("top-level help renders a derived domain directory and domain help filters commands", () => {
   const help = renderThinHelp();
-  assert.equal(thinCliCommands.length, 132);
+  assert.equal(thinCliCommands.length, 133);
   for (const domain of [...new Set(daemonProtocolCommands.map((command) => command.path[0]))]
     .filter((value): value is string => value !== undefined)
     .sort())
@@ -148,7 +148,14 @@ test("capabilities is an exact-set projection of the command contract", () => {
     ],
     script: ["preset-run-start", "script-inspect", "script-list", "script-run"],
     settings: ["settings-read", "settings-update"],
-    people: ["people-add", "people-bind", "people-remove", "people-set-role"],
+    people: [
+      "people-add",
+      "people-bind",
+      "people-delegate",
+      "people-remove",
+      "people-revoke-delegation",
+      "people-set-role",
+    ],
     squad: ["squad-inspect", "squad-install", "squad-list", "squad-run", "squad-status", "squad-validate"],
     task: [
       "task-amend",

--- a/packages/daemon/src/identity/people-roster.ts
+++ b/packages/daemon/src/identity/people-roster.ts
@@ -27,6 +27,7 @@ export function peopleRosterFromDocument(body: string): PeopleRoster {
     people: raw.people,
     roles: raw.roles,
     bindings: raw.bindings,
+    delegatedExecutionTokens: raw.delegatedExecutionTokens,
     resolveCredential: (credential, providerId) => {
       const person = peopleByCredential.get(credentialKey(credential));
       if (!person)

--- a/packages/daemon/src/identity/types.ts
+++ b/packages/daemon/src/identity/types.ts
@@ -5,6 +5,7 @@ import type {
   CredentialRef as KernelCredentialRef,
   PeopleCommandClass,
   PersonProfile as KernelPersonProfile,
+  DelegatedExecutionToken,
   RoleBinding,
   RolePolicy as KernelRolePolicy,
 } from "../../../kernel/src/index.ts";
@@ -23,6 +24,7 @@ export interface PeopleRoster {
   readonly people: ReadonlyArray<PersonProfile>;
   readonly roles: ReadonlyArray<RolePolicy>;
   readonly bindings: ReadonlyArray<RoleBinding>;
+  readonly delegatedExecutionTokens: ReadonlyArray<DelegatedExecutionToken>;
   readonly resolveCredential: (
     credential: CredentialRef,
     providerId: string,

--- a/packages/daemon/src/protocol/daemon-protocol-commands-people.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-people.ts
@@ -14,6 +14,13 @@ export const peopleAddJsonFields = Object.freeze(["personId", "displayName", "ro
   peopleSetRoleJsonAllowedFields = Object.freeze([...peopleSetRoleJsonFields, "idempotencyKey"] as const),
   peopleBindJsonFields = Object.freeze(["actor", "role", "target"] as const),
   peopleBindJsonAllowedFields = Object.freeze([...peopleBindJsonFields, "expiresAt", "idempotencyKey"] as const),
+  peopleDelegateJsonFields = Object.freeze(["tokenId", "runtimeSessionId", "action", "expiresAt"] as const),
+  peopleDelegateJsonAllowedFields = Object.freeze([...peopleDelegateJsonFields, "idempotencyKey"] as const),
+  peopleRevokeDelegationJsonFields = Object.freeze(["tokenId"] as const),
+  peopleRevokeDelegationJsonAllowedFields = Object.freeze([
+    ...peopleRevokeDelegationJsonFields,
+    "idempotencyKey",
+  ] as const),
   peopleRemoveJsonFields = Object.freeze(["personId"] as const),
   peopleRemoveJsonAllowedFields = Object.freeze([...peopleRemoveJsonFields, "idempotencyKey"] as const);
 
@@ -68,6 +75,20 @@ const peopleWriteTopology = {
       },
       {
         regex: "^(?:person|executor):[A-Za-z0-9][A-Za-z0-9._:-]*$",
+        conflictsWith: ["--from-file"],
+      },
+    ),
+  tokenIdInput = () =>
+    cliInput(
+      "--token-id",
+      "single",
+      false,
+      {
+        code: "missing_field",
+        nextAction: "Use --token-id with a stable det_ identifier, or use --from-file.",
+      },
+      {
+        regex: "^det_[A-Za-z0-9][A-Za-z0-9._:-]{0,126}$",
         conflictsWith: ["--from-file"],
       },
     ),
@@ -151,6 +172,69 @@ export const peopleProtocolCommands = Object.freeze([
       roleInput(),
       textInput("--target", false, "Use --target with one EntityRef, or use --from-file."),
       textInput("--expires-at", false, "Use an ISO-8601 UTC timestamp ending in Z, or omit it."),
+      idempotencyInput(),
+    ],
+    ...peopleWriteTopology,
+  }),
+  defineCliCommand({
+    id: "people-delegate",
+    actionKind: "people-delegate",
+    phase: "Persons-Registry",
+    path: ["people", "delegate"],
+    summary: "Delegate a closed Action set from the authenticated principal to one RuntimeSession.",
+    method: "repo.task.run",
+    inputs: [
+      fromFileInput(peopleDelegateJsonFields, peopleDelegateJsonAllowedFields),
+      tokenIdInput(),
+      cliInput(
+        "--runtime-session-id",
+        "single",
+        false,
+        {
+          code: "missing_field",
+          nextAction: "Use --runtime-session-id with one RuntimeSession identifier, or use --from-file.",
+        },
+        { regex: "^[A-Za-z0-9][A-Za-z0-9._:-]*$", conflictsWith: ["--from-file"] },
+      ),
+      cliInput(
+        "--action",
+        "repeated",
+        false,
+        {
+          code: "missing_field",
+          nextAction: "Repeat --action for every delegated Action kind, or use --from-file.",
+        },
+        {
+          regex: "^[A-Za-z][A-Za-z0-9]*(?:[._-][A-Za-z0-9]+)*$",
+          minItems: 1,
+          unique: true,
+          conflictsWith: ["--from-file"],
+        },
+      ),
+      cliInput(
+        "--expires-at",
+        "single",
+        false,
+        {
+          code: "missing_field",
+          nextAction: "Use --expires-at with an ISO-8601 UTC timestamp ending in Z, or use --from-file.",
+        },
+        { minLength: 1, conflictsWith: ["--from-file"] },
+      ),
+      idempotencyInput(),
+    ],
+    ...peopleWriteTopology,
+  }),
+  defineCliCommand({
+    id: "people-revoke-delegation",
+    actionKind: "people-revoke-delegation",
+    phase: "Persons-Registry",
+    path: ["people", "revoke-delegation"],
+    summary: "Revoke one DelegatedExecutionToken through the canonical Action writer.",
+    method: "repo.task.run",
+    inputs: [
+      fromFileInput(peopleRevokeDelegationJsonFields, peopleRevokeDelegationJsonAllowedFields),
+      tokenIdInput(),
       idempotencyInput(),
     ],
     ...peopleWriteTopology,

--- a/packages/daemon/src/repo-cell-action-dispatch.ts
+++ b/packages/daemon/src/repo-cell-action-dispatch.ts
@@ -33,6 +33,8 @@ export async function executeAction(
     action.kind === "people-add" ||
     action.kind === "people-set-role" ||
     action.kind === "people-bind" ||
+    action.kind === "people-delegate" ||
+    action.kind === "people-revoke-delegation" ||
     action.kind === "people-remove"
   )
     return cell.peopleActions.run(action, binding);

--- a/packages/daemon/src/repo-cell-people-actions.ts
+++ b/packages/daemon/src/repo-cell-people-actions.ts
@@ -16,8 +16,12 @@ import {
   peopleAddJsonFields,
   peopleBindJsonAllowedFields,
   peopleBindJsonFields,
+  peopleDelegateJsonAllowedFields,
+  peopleDelegateJsonFields,
   peopleRemoveJsonAllowedFields,
   peopleRemoveJsonFields,
+  peopleRevokeDelegationJsonAllowedFields,
+  peopleRevokeDelegationJsonFields,
   peopleSetRoleJsonAllowedFields,
   peopleSetRoleJsonFields,
 } from "./protocol/daemon-protocol-commands-people.ts";
@@ -27,7 +31,8 @@ import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
 export function makeRepoCellPeopleActions(cell: any) {
   const run = (action: RepoTaskAction, binding: RepoCellBinding): WriteReceipt => {
     const resolvedAction = resolvePeopleAction(cell.rootDir, action),
-      domainAction = parsePeopleAction(resolvedAction),
+      occurredAt = cell.now(),
+      domainAction = parsePeopleAction(resolvedAction, binding.actor.principal.personId, occurredAt),
       peoplePath = path.join(resolveHarnessLayout(cell.rootDir).authoredRoot, "people.yaml"),
       currentBody = existsSync(peoplePath) ? readFileSync(peoplePath, "utf8") : null,
       revision = cell.store.readHead()?.revision ?? 0,
@@ -45,7 +50,7 @@ export function makeRepoCellPeopleActions(cell: any) {
         workspaceRevision: revision + 1,
         actor: binding.actor,
         source: binding.source,
-        occurredAt: cell.now(),
+        occurredAt,
       });
     if (compiled.bundle === null) return noChangesReceipt(opId, revision, compiled.summary, compiled.roster);
     const existing = cell.store.readEvent(opId);
@@ -86,6 +91,11 @@ const peoplePacketContracts: Readonly<
   "people-add": { required: peopleAddJsonFields, allowed: peopleAddJsonAllowedFields },
   "people-set-role": { required: peopleSetRoleJsonFields, allowed: peopleSetRoleJsonAllowedFields },
   "people-bind": { required: peopleBindJsonFields, allowed: peopleBindJsonAllowedFields },
+  "people-delegate": { required: peopleDelegateJsonFields, allowed: peopleDelegateJsonAllowedFields },
+  "people-revoke-delegation": {
+    required: peopleRevokeDelegationJsonFields,
+    allowed: peopleRevokeDelegationJsonAllowedFields,
+  },
   "people-remove": { required: peopleRemoveJsonFields, allowed: peopleRemoveJsonAllowedFields },
 });
 
@@ -114,9 +124,9 @@ function resolvePeopleAction(rootDir: string, action: RepoTaskAction): RepoTaskA
   if (unknown.length) throw invalidPeopleCommand(`Remove unsupported people input fields: ${unknown.join(", ")}`);
   if (missing.length) throw invalidPeopleCommand(`Add required people input fields: ${missing.join(", ")}`);
   for (const [field, value] of Object.entries(packet)) {
-    if (field === "commandClass") {
+    if (field === "commandClass" || field === "action") {
       if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string" || !entry.trim()))
-        throw invalidPeopleCommand("commandClass must be a non-empty array of non-empty strings");
+        throw invalidPeopleCommand(`${field} must be a non-empty array of non-empty strings`);
     } else if (field === "expiresAt" && value === null) {
       continue;
     } else if (typeof value !== "string" || !value.trim()) {
@@ -126,7 +136,7 @@ function resolvePeopleAction(rootDir: string, action: RepoTaskAction): RepoTaskA
   return { kind: action.kind, ...packet };
 }
 
-function parsePeopleAction(action: RepoTaskAction): PeopleRosterAction {
+function parsePeopleAction(action: RepoTaskAction, issuerPersonId: string, occurredAt: string): PeopleRosterAction {
   if (action.kind === "people-bind") {
     const actor = parseRoleBindingActor(requiredPeopleText(action.actor, "actor")),
       expiresAt = action.expiresAt === null ? null : (peopleText(action.expiresAt) ?? null);
@@ -141,6 +151,28 @@ function parsePeopleAction(action: RepoTaskAction): PeopleRosterAction {
       },
     };
   }
+  if (action.kind === "people-delegate") {
+    return {
+      kind: action.kind,
+      token: {
+        schema: "delegated-execution-token/v1",
+        tokenId: requiredPeopleText(action.tokenId, "token-id"),
+        issuer: { personId: issuerPersonId },
+        delegate: { runtimeSessionId: requiredPeopleText(action.runtimeSessionId, "runtime-session-id") },
+        allowedActions: requiredDelegatedActions(action.action),
+        issuedAt: occurredAt,
+        expiresAt: requiredPeopleText(action.expiresAt, "expires-at"),
+        revokedAt: null,
+      },
+    };
+  }
+  if (action.kind === "people-revoke-delegation")
+    return {
+      kind: action.kind,
+      tokenId: requiredPeopleText(action.tokenId, "token-id"),
+      issuerPersonId,
+      revokedAt: occurredAt,
+    };
   const personId = requiredPeopleText(action.personId, "person-id");
   if (action.kind === "people-remove") return { kind: action.kind, personId };
   const roleId = requiredPeopleText(action.role, "role"),
@@ -178,6 +210,15 @@ function parsePeopleAction(action: RepoTaskAction): PeopleRosterAction {
     },
     rolePolicy,
   };
+}
+
+function requiredDelegatedActions(value: unknown): readonly string[] {
+  const actions = (Array.isArray(value) ? value : [value])
+    .map(peopleText)
+    .filter((entry): entry is string => Boolean(entry));
+  if (actions.length === 0) throw invalidPeopleCommand("At least one --action is required");
+  if (new Set(actions).size !== actions.length) throw invalidPeopleCommand("Delegated Actions must be unique");
+  return actions;
 }
 
 function parseRoleBindingActor(value: string): { readonly kind: "person" | "executor"; readonly id: string } {

--- a/packages/daemon/test/command-admission.test.ts
+++ b/packages/daemon/test/command-admission.test.ts
@@ -10,8 +10,8 @@ const localSource = "local" as const;
 const assignmentSource = { kind: "assignment", nodeId: "edge-one", assignmentId: "assignment-one" } as const;
 const admissionRoutes = new Set(["direct", "via-assignment", "via-center-forward", "rejected"]);
 
-test("all 134 daemon commands close every repo-mode admission cell", () => {
-  assert.equal(daemonProtocolCommands.length, 134);
+test("all 135 daemon commands close every repo-mode admission cell", () => {
+  assert.equal(daemonProtocolCommands.length, 135);
   let cells = 0;
   for (const command of daemonProtocolCommands) {
     assert.deepEqual(Object.keys(command.admission).sort(), [...daemonRepoModeWords].sort(), command.id);
@@ -35,7 +35,7 @@ test("all 134 daemon commands close every repo-mode admission cell", () => {
       }
     }
   }
-  assert.equal(cells, 134 * 3);
+  assert.equal(cells, 135 * 3);
 });
 
 test("observe.tail declares direct admission and named source residency for every tail kind", () => {

--- a/packages/daemon/test/command-admission.test.ts
+++ b/packages/daemon/test/command-admission.test.ts
@@ -10,8 +10,8 @@ const localSource = "local" as const;
 const assignmentSource = { kind: "assignment", nodeId: "edge-one", assignmentId: "assignment-one" } as const;
 const admissionRoutes = new Set(["direct", "via-assignment", "via-center-forward", "rejected"]);
 
-test("all 133 daemon commands close every repo-mode admission cell", () => {
-  assert.equal(daemonProtocolCommands.length, 133);
+test("all 134 daemon commands close every repo-mode admission cell", () => {
+  assert.equal(daemonProtocolCommands.length, 134);
   let cells = 0;
   for (const command of daemonProtocolCommands) {
     assert.deepEqual(Object.keys(command.admission).sort(), [...daemonRepoModeWords].sort(), command.id);
@@ -35,7 +35,7 @@ test("all 133 daemon commands close every repo-mode admission cell", () => {
       }
     }
   }
-  assert.equal(cells, 133 * 3);
+  assert.equal(cells, 134 * 3);
 });
 
 test("observe.tail declares direct admission and named source residency for every tail kind", () => {
@@ -96,7 +96,14 @@ test("Settings CLI read uses the common read topology while update forwards from
 
 test("People mutations are admin Actions and forward from an edge", () => {
   const byId = new Map(daemonProtocolCommands.map((command) => [command.id, command]));
-  for (const id of ["people-add", "people-set-role", "people-bind", "people-remove"]) {
+  for (const id of [
+    "people-add",
+    "people-set-role",
+    "people-bind",
+    "people-delegate",
+    "people-revoke-delegation",
+    "people-remove",
+  ]) {
     assert.deepEqual(byId.get(id)?.admission, {
       local: "direct",
       "remote-center": "direct",

--- a/packages/daemon/test/people-actions.integration.test.ts
+++ b/packages/daemon/test/people-actions.integration.test.ts
@@ -275,3 +275,60 @@ test("People Action commands hydrate closed from-file packets inside the workspa
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("People delegated tokens issue and revoke through the canonical people event writer", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-people-delegation-"));
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    initRepo(root);
+    let now = "2026-08-27T02:00:00.000Z";
+    cell = await openRepoCell({
+      repoId: workspaceId("people-delegation"),
+      rootDir: canonicalRoot(root),
+      ownerId: "people-daemon",
+      now: () => now,
+    });
+    const delegatingActor = { ...actor, principal: { personId: "person_zeyu" } },
+      binding = { actor: delegatingActor, source: "local" as const },
+      issued = await cell.run(
+        {
+          kind: "people-delegate",
+          tokenId: "det_owner_runtime_1",
+          runtimeSessionId: "runtime_1",
+          action: ["execution.start", "doc.submit"],
+          expiresAt: "2026-08-27T03:00:00.000Z",
+        },
+        binding,
+      );
+    assert.equal(issued.outcome, "applied", JSON.stringify(issued));
+    let roster = parsePeopleRosterDocument(readFileSync(path.join(root, "harness/people.yaml"), "utf8"));
+    assert.deepEqual(roster.delegatedExecutionTokens, [
+      {
+        schema: "delegated-execution-token/v1",
+        tokenId: "det_owner_runtime_1",
+        issuer: { personId: delegatingActor.principal.personId },
+        delegate: { runtimeSessionId: "runtime_1" },
+        allowedActions: ["doc.submit", "execution.start"],
+        issuedAt: now,
+        expiresAt: "2026-08-27T03:00:00.000Z",
+        revokedAt: null,
+      },
+    ]);
+    assert.match(issued.evidence ?? "", /det_owner_runtime_1/u);
+
+    now = "2026-08-27T02:30:00.000Z";
+    const revoked = await cell.run({ kind: "people-revoke-delegation", tokenId: "det_owner_runtime_1" }, binding);
+    assert.equal(revoked.outcome, "applied", JSON.stringify(revoked));
+    roster = parsePeopleRosterDocument(readFileSync(path.join(root, "harness/people.yaml"), "utf8"));
+    assert.equal(roster.delegatedExecutionTokens[0]?.revokedAt, now);
+    assert.equal(
+      makeTaskEventStore({ repoId: "people-delegation", rootDir: root })
+        .read()
+        .events.filter(({ schema }) => schema === "people-event/v1").length,
+      2,
+    );
+  } finally {
+    await cell?.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/daemon/test/people-roster-merge.test.ts
+++ b/packages/daemon/test/people-roster-merge.test.ts
@@ -133,6 +133,34 @@ test("declared RoleBindings union by identity and conflicting validity refuses",
   );
 });
 
+test("DelegatedExecutionTokens union by token id and conflicting revocation refuses", () => {
+  const token = {
+      schema: "delegated-execution-token/v1",
+      tokenId: "det_owner_runtime_1",
+      issuer: { personId: "person_zeyu" },
+      delegate: { runtimeSessionId: "runtime_1" },
+      allowedActions: ["execution.start"],
+      issuedAt: "2026-08-27T02:00:00.000Z",
+      expiresAt: "2026-08-27T03:00:00.000Z",
+      revokedAt: null,
+    },
+    source = JSON.parse(bootstrapRoster([bootstrapPerson])) as Record<string, unknown>;
+  source.delegatedExecutionTokens = [token];
+  const carried = peopleRosterFromDocument(
+    merged(`${JSON.stringify(source, null, 2)}\n`, bootstrapRoster([bootstrapPerson])).body,
+  );
+  assert.deepEqual(carried.delegatedExecutionTokens, [token]);
+
+  const revoked = {
+    ...source,
+    delegatedExecutionTokens: [{ ...token, revokedAt: "2026-08-27T02:30:00.000Z" }],
+  };
+  assert.match(
+    refusal(`${JSON.stringify(source, null, 2)}\n`, `${JSON.stringify(revoked, null, 2)}\n`),
+    /DelegatedExecutionToken det_owner_runtime_1 differs on each side/u,
+  );
+});
+
 test("a person's own roles union but a role's authority definition must agree on both sides", () => {
   const wider = legacyRoster.replace(
     "commandClasses: [admin, repo-write, repo-read, arbiter]",

--- a/packages/kernel/src/domain/delegated-execution-token.ts
+++ b/packages/kernel/src/domain/delegated-execution-token.ts
@@ -1,0 +1,140 @@
+import type { ActorIdentity } from "./actor-identity.ts";
+import { runtimeSessionIdFromActor } from "./task-bound-runtime-authority.ts";
+import { timestamp } from "./timestamp.ts";
+import { hasOnlyFields, isRecord } from "./write-chain.contract.ts";
+
+export const DELEGATED_EXECUTION_TOKEN_SCHEMA = "delegated-execution-token/v1" as const;
+
+export interface DelegatedExecutionToken {
+  readonly schema: typeof DELEGATED_EXECUTION_TOKEN_SCHEMA;
+  readonly tokenId: string;
+  readonly issuer: { readonly personId: string };
+  readonly delegate: { readonly runtimeSessionId: string };
+  readonly allowedActions: readonly string[];
+  readonly issuedAt: string;
+  readonly expiresAt: string;
+  readonly revokedAt: string | null;
+}
+
+export type DelegatedExecutionTokenReasonCode =
+  | "delegated_token_contract_invalid"
+  | "delegated_token_actor_mismatch"
+  | "delegated_token_action_forbidden"
+  | "delegated_token_not_yet_valid"
+  | "delegated_token_expired"
+  | "delegated_token_revoked";
+
+export type DelegatedExecutionTokenVerification =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reasonCode: DelegatedExecutionTokenReasonCode };
+
+export class DelegatedExecutionTokenContractError extends Error {
+  readonly code = "invalid_delegated_execution_token";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "DelegatedExecutionTokenContractError";
+  }
+}
+
+export function parseDelegatedExecutionToken(value: unknown): DelegatedExecutionToken {
+  const errors = validateDelegatedExecutionToken(value);
+  if (errors.length) throw new DelegatedExecutionTokenContractError(errors.join("; "));
+  const token = value as DelegatedExecutionToken;
+  return {
+    schema: DELEGATED_EXECUTION_TOKEN_SCHEMA,
+    tokenId: token.tokenId.trim(),
+    issuer: { personId: token.issuer.personId.trim() },
+    delegate: { runtimeSessionId: token.delegate.runtimeSessionId.trim() },
+    allowedActions: Object.freeze(token.allowedActions.map((action) => action.trim()).sort()),
+    issuedAt: token.issuedAt,
+    expiresAt: token.expiresAt,
+    revokedAt: token.revokedAt,
+  };
+}
+
+export function validateDelegatedExecutionToken(value: unknown): readonly string[] {
+  if (!isRecord(value)) return ["DelegatedExecutionToken must be an object"];
+  const required = ["schema", "tokenId", "issuer", "delegate", "allowedActions", "issuedAt", "expiresAt", "revokedAt"],
+    errors: string[] = [],
+    unsupported = Object.keys(value).filter((field) => !required.includes(field));
+  if (unsupported.length) errors.push(`DelegatedExecutionToken has unsupported fields: ${unsupported.join(", ")}`);
+  if (!required.every((field) => Object.hasOwn(value, field)))
+    errors.push(`DelegatedExecutionToken requires ${required.join(", ")}`);
+  if (value.schema !== DELEGATED_EXECUTION_TOKEN_SCHEMA)
+    errors.push(`DelegatedExecutionToken schema must be ${DELEGATED_EXECUTION_TOKEN_SCHEMA}`);
+  if (typeof value.tokenId !== "string" || !/^det_[A-Za-z0-9][A-Za-z0-9._:-]{0,126}$/u.test(value.tokenId))
+    errors.push("DelegatedExecutionToken tokenId must start with det_ and contain only stable identifier characters");
+  if (!isRecord(value.issuer) || !hasOnlyFields(value.issuer, ["personId"]) || !personId(value.issuer.personId))
+    errors.push("DelegatedExecutionToken issuer must name one principal personId");
+  if (
+    !isRecord(value.delegate) ||
+    !hasOnlyFields(value.delegate, ["runtimeSessionId"]) ||
+    !identifier(value.delegate.runtimeSessionId)
+  )
+    errors.push("DelegatedExecutionToken delegate must name one RuntimeSession");
+  if (
+    !Array.isArray(value.allowedActions) ||
+    value.allowedActions.length === 0 ||
+    value.allowedActions.some((action) => !actionName(action))
+  )
+    errors.push("DelegatedExecutionToken requires at least one allowed Action");
+  else if (new Set(value.allowedActions).size !== value.allowedActions.length)
+    errors.push("DelegatedExecutionToken allowed Actions must be unique");
+  if (!timestamp(value.issuedAt)) errors.push("DelegatedExecutionToken issuedAt must be an ISO-8601 UTC timestamp");
+  if (!timestamp(value.expiresAt)) errors.push("DelegatedExecutionToken expiresAt must be an ISO-8601 UTC timestamp");
+  if (
+    timestamp(value.issuedAt) &&
+    timestamp(value.expiresAt) &&
+    Date.parse(value.expiresAt) <= Date.parse(value.issuedAt)
+  )
+    errors.push("DelegatedExecutionToken expiresAt must be later than issuedAt");
+  if (value.revokedAt !== null && !timestamp(value.revokedAt))
+    errors.push("DelegatedExecutionToken revokedAt must be null or an ISO-8601 UTC timestamp");
+  if (
+    timestamp(value.issuedAt) &&
+    timestamp(value.revokedAt) &&
+    Date.parse(value.revokedAt) < Date.parse(value.issuedAt)
+  )
+    errors.push("DelegatedExecutionToken revokedAt cannot be earlier than issuedAt");
+  return errors;
+}
+
+export function verifyDelegatedExecutionToken(
+  value: unknown,
+  actor: ActorIdentity,
+  actionKind: string,
+  evaluatedAt: string,
+): DelegatedExecutionTokenVerification {
+  let token: DelegatedExecutionToken;
+  try {
+    token = parseDelegatedExecutionToken(value);
+  } catch {
+    return { ok: false, reasonCode: "delegated_token_contract_invalid" };
+  }
+  if (
+    token.issuer.personId !== actor.principal.personId ||
+    token.delegate.runtimeSessionId !== runtimeSessionIdFromActor(actor)
+  )
+    return { ok: false, reasonCode: "delegated_token_actor_mismatch" };
+  if (!token.allowedActions.includes(actionKind)) return { ok: false, reasonCode: "delegated_token_action_forbidden" };
+  if (!timestamp(evaluatedAt)) return { ok: false, reasonCode: "delegated_token_contract_invalid" };
+  const at = Date.parse(evaluatedAt);
+  if (at < Date.parse(token.issuedAt)) return { ok: false, reasonCode: "delegated_token_not_yet_valid" };
+  if (at >= Date.parse(token.expiresAt)) return { ok: false, reasonCode: "delegated_token_expired" };
+  if (token.revokedAt !== null && at >= Date.parse(token.revokedAt))
+    return { ok: false, reasonCode: "delegated_token_revoked" };
+  return { ok: true };
+}
+
+function actionName(value: unknown): value is string {
+  return typeof value === "string" && /^[A-Za-z][A-Za-z0-9]*(?:[._-][A-Za-z0-9]+)*$/u.test(value);
+}
+
+function identifier(value: unknown): value is string {
+  return typeof value === "string" && /^[A-Za-z0-9][A-Za-z0-9._:-]*$/u.test(value);
+}
+
+function personId(value: unknown): value is string {
+  return typeof value === "string" && /^[A-Za-z][A-Za-z0-9_-]{0,62}$/u.test(value);
+}

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -74,6 +74,7 @@ export type { EntityRef, EntityRefKind, ParsedEntityRef } from "./entity-ref.ts"
 export { deriveRoleBindings, roleBindingActorMatches, roleBindingApplies, roleBindingExpired } from "./role-binding.ts";
 export type { RoleBinding } from "./role-binding.ts";
 export { deriveOwnerRoleBinding } from "./owner-role-binding.ts";
+export type { DelegatedExecutionToken } from "./delegated-execution-token.ts";
 
 export {
   decisionEntityId,

--- a/packages/kernel/src/domain/people-event.ts
+++ b/packages/kernel/src/domain/people-event.ts
@@ -182,6 +182,8 @@ const peopleActions: readonly PeopleRosterAction["kind"][] = Object.freeze([
   "people-add",
   "people-set-role",
   "people-bind",
+  "people-delegate",
+  "people-revoke-delegation",
   "people-remove",
   "people-reconcile",
   "people-replace",

--- a/packages/kernel/src/domain/people-roster.ts
+++ b/packages/kernel/src/domain/people-roster.ts
@@ -1,4 +1,5 @@
 import type { EntityDocumentJsonSchema } from "./entity-json-schema.ts";
+import { parseDelegatedExecutionToken, type DelegatedExecutionToken } from "./delegated-execution-token.ts";
 import {
   parseRoleBinding,
   roleBindingKey,
@@ -52,6 +53,7 @@ export interface PeopleRosterDocumentV1 {
   readonly people: readonly PersonProfile[];
   readonly roles: readonly RolePolicy[];
   readonly bindings: readonly RoleBinding[];
+  readonly delegatedExecutionTokens: readonly DelegatedExecutionToken[];
 }
 
 export const PERSON_V1_SCHEMA: EntityDocumentJsonSchema<PersonProfile> = {
@@ -102,6 +104,16 @@ export type PeopleRosterAction =
       readonly kind: "people-bind";
       readonly binding: RoleBinding;
     }
+  | {
+      readonly kind: "people-delegate";
+      readonly token: DelegatedExecutionToken;
+    }
+  | {
+      readonly kind: "people-revoke-delegation";
+      readonly tokenId: string;
+      readonly issuerPersonId: string;
+      readonly revokedAt: string;
+    }
   | { readonly kind: "people-remove"; readonly personId: string }
   | { readonly kind: "people-reconcile"; readonly sourceBody: string }
   | { readonly kind: "people-replace"; readonly sourceBody: string };
@@ -128,13 +140,20 @@ export function parsePeopleRosterDocument(body: string): PeopleRosterDocumentV1 
   const raw = parsePeopleYaml(body);
   if (raw.schema !== PEOPLE_ROSTER_SCHEMA)
     throw new PeopleRosterContractError(`people.yaml schema must be ${PEOPLE_ROSTER_SCHEMA}`);
-  validatePeopleRoster(raw.people, raw.roles, raw.bindings);
-  return { schema: PEOPLE_ROSTER_SCHEMA, people: raw.people, roles: raw.roles, bindings: raw.bindings };
+  validatePeopleRoster(raw.people, raw.roles, raw.bindings, raw.delegatedExecutionTokens);
+  return {
+    schema: PEOPLE_ROSTER_SCHEMA,
+    people: raw.people,
+    roles: raw.roles,
+    bindings: raw.bindings,
+    delegatedExecutionTokens: raw.delegatedExecutionTokens,
+  };
 }
 
 export function serializePeopleRosterDocument(roster: PeopleRosterDocumentV1): string {
   const bindings = roster.bindings ?? [];
-  validatePeopleRoster(roster.people, roster.roles, bindings);
+  const delegatedExecutionTokens = roster.delegatedExecutionTokens ?? [];
+  validatePeopleRoster(roster.people, roster.roles, bindings, delegatedExecutionTokens);
   return `${JSON.stringify(
     {
       schema: PEOPLE_ROSTER_SCHEMA,
@@ -144,6 +163,9 @@ export function serializePeopleRosterDocument(roster: PeopleRosterDocumentV1): s
         commandClasses: [...commandClasses],
       })),
       ...(bindings.length ? { bindings: bindings.map(orderedBinding) } : {}),
+      ...(delegatedExecutionTokens.length
+        ? { delegatedExecutionTokens: delegatedExecutionTokens.map(orderedDelegatedExecutionToken) }
+        : {}),
     },
     null,
     2,
@@ -159,6 +181,9 @@ export function applyPeopleRosterAction(
   if (action.kind === "people-add") next = addPerson(current, action.person, action.rolePolicy);
   else if (action.kind === "people-set-role") next = setPersonRole(current, action.personId, action.rolePolicy);
   else if (action.kind === "people-bind") next = bindActorRole(current, action.binding);
+  else if (action.kind === "people-delegate") next = issueDelegatedExecutionToken(current, action.token);
+  else if (action.kind === "people-revoke-delegation")
+    next = revokeDelegatedExecutionToken(current, action.tokenId, action.issuerPersonId, action.revokedAt);
   else if (action.kind === "people-remove") next = removePerson(current, action.personId);
   else if (action.kind === "people-replace") next = parsePeopleRosterDocument(action.sourceBody);
   else {
@@ -176,7 +201,11 @@ export function applyPeopleRosterAction(
           ? action.personId
           : action.kind === "people-bind" && action.binding.actor.kind === "person"
             ? action.binding.actor.id
-            : null;
+            : action.kind === "people-delegate"
+              ? action.token.issuer.personId
+              : action.kind === "people-revoke-delegation"
+                ? action.issuerPersonId
+                : null;
   return {
     action: action.kind,
     targetPersonId,
@@ -197,12 +226,13 @@ function addPerson(
   if (roster.people.length > 0 && person.roles.includes("owner"))
     throw new PeopleRosterContractError("the owner role is reserved for the bootstrap creator");
   const roles = withRolePolicy(roster.roles, rolePolicy);
-  validatePeopleRoster([...roster.people, person], roles, roster.bindings);
+  validatePeopleRoster([...roster.people, person], roles, roster.bindings, roster.delegatedExecutionTokens);
   return {
     schema: PEOPLE_ROSTER_SCHEMA,
     people: [...roster.people, person],
     roles,
     bindings: roster.bindings,
+    delegatedExecutionTokens: roster.delegatedExecutionTokens,
   };
 }
 
@@ -221,8 +251,14 @@ function setPersonRole(
     people = roster.people.map((person) =>
       person.personId === personId ? { ...person, roles: [rolePolicy.roleId] } : person,
     );
-  validatePeopleRoster(people, roles, roster.bindings);
-  return { schema: PEOPLE_ROSTER_SCHEMA, people, roles, bindings: roster.bindings };
+  validatePeopleRoster(people, roles, roster.bindings, roster.delegatedExecutionTokens);
+  return {
+    schema: PEOPLE_ROSTER_SCHEMA,
+    people,
+    roles,
+    bindings: roster.bindings,
+    delegatedExecutionTokens: roster.delegatedExecutionTokens,
+  };
 }
 
 function bindActorRole(roster: PeopleRosterDocumentV1, value: RoleBinding): PeopleRosterDocumentV1 {
@@ -240,8 +276,53 @@ function bindActorRole(roster: PeopleRosterDocumentV1, value: RoleBinding): Peop
       existing < 0
         ? [...roster.bindings, binding]
         : roster.bindings.map((candidate, index) => (index === existing ? binding : candidate));
-  validatePeopleRoster(roster.people, roster.roles, bindings);
+  validatePeopleRoster(roster.people, roster.roles, bindings, roster.delegatedExecutionTokens);
   return { ...roster, bindings };
+}
+
+function issueDelegatedExecutionToken(
+  roster: PeopleRosterDocumentV1,
+  value: DelegatedExecutionToken,
+): PeopleRosterDocumentV1 {
+  const token = parseRosterDelegatedExecutionToken(value),
+    issuer = roster.people.find((person) => person.personId === token.issuer.personId && !person.disabled);
+  if (!issuer)
+    throw new PeopleRosterContractError(`DelegatedExecutionToken issuer ${token.issuer.personId} is not enabled`);
+  const existing = roster.delegatedExecutionTokens.find((candidate) => candidate.tokenId === token.tokenId);
+  if (existing) {
+    const sameRequest =
+      existing.revokedAt === null &&
+      existing.issuer.personId === token.issuer.personId &&
+      existing.delegate.runtimeSessionId === token.delegate.runtimeSessionId &&
+      existing.expiresAt === token.expiresAt &&
+      JSON.stringify(existing.allowedActions) === JSON.stringify(token.allowedActions);
+    if (sameRequest) return roster;
+    throw new PeopleRosterContractError(`DelegatedExecutionToken ${token.tokenId} already exists`);
+  }
+  const delegatedExecutionTokens = [...roster.delegatedExecutionTokens, token];
+  validatePeopleRoster(roster.people, roster.roles, roster.bindings, delegatedExecutionTokens);
+  return { ...roster, delegatedExecutionTokens };
+}
+
+function revokeDelegatedExecutionToken(
+  roster: PeopleRosterDocumentV1,
+  tokenId: string,
+  issuerPersonId: string,
+  revokedAt: string,
+): PeopleRosterDocumentV1 {
+  const existing = roster.delegatedExecutionTokens.find((token) => token.tokenId === tokenId);
+  if (!existing) throw new PeopleRosterContractError(`DelegatedExecutionToken ${tokenId} does not exist`);
+  if (existing.issuer.personId !== issuerPersonId)
+    throw new PeopleRosterContractError(
+      `Only DelegatedExecutionToken issuer ${existing.issuer.personId} may revoke it`,
+    );
+  if (existing.revokedAt !== null) return roster;
+  const revoked = parseRosterDelegatedExecutionToken({ ...existing, revokedAt }),
+    delegatedExecutionTokens = roster.delegatedExecutionTokens.map((token) =>
+      token.tokenId === tokenId ? revoked : token,
+    );
+  validatePeopleRoster(roster.people, roster.roles, roster.bindings, delegatedExecutionTokens);
+  return { ...roster, delegatedExecutionTokens };
 }
 
 function removePerson(roster: PeopleRosterDocumentV1, personId: string): PeopleRosterDocumentV1 {
@@ -253,6 +334,7 @@ function removePerson(roster: PeopleRosterDocumentV1, personId: string): PeopleR
     ...roster,
     people: roster.people.filter((person) => person.personId !== personId),
     bindings: roster.bindings.filter((binding) => binding.actor.kind !== "person" || binding.actor.id !== personId),
+    delegatedExecutionTokens: roster.delegatedExecutionTokens.filter((token) => token.issuer.personId !== personId),
   };
 }
 
@@ -291,12 +373,18 @@ function peopleActionSummary(action: PeopleRosterAction, personId: string | null
       `Bound ${action.binding.actor.kind} ${action.binding.actor.id} as ` +
       `${action.binding.role} on ${action.binding.target}.`
     );
+  if (action.kind === "people-delegate")
+    return (
+      `Delegated ${action.token.issuer.personId} Actions to RuntimeSession ` +
+      `${action.token.delegate.runtimeSessionId} via ${action.token.tokenId}.`
+    );
+  if (action.kind === "people-revoke-delegation") return `Revoked DelegatedExecutionToken ${action.tokenId}.`;
   if (action.kind === "people-remove") return `Removed person ${personId}.`;
   return action.kind === "people-reconcile" ? "Reconciled the people roster." : "Replaced the people roster.";
 }
 
 function emptyPeopleRoster(): PeopleRosterDocumentV1 {
-  return { schema: PEOPLE_ROSTER_SCHEMA, people: [], roles: [], bindings: [] };
+  return { schema: PEOPLE_ROSTER_SCHEMA, people: [], roles: [], bindings: [], delegatedExecutionTokens: [] };
 }
 
 export type PeopleRosterMerge =
@@ -394,8 +482,27 @@ export function mergePeopleRosterDocuments(sourceBody: string, destinationBody: 
       };
   }
 
+  const delegatedExecutionTokens = [...destination.delegatedExecutionTokens];
+  for (const token of source.delegatedExecutionTokens) {
+    const existing = delegatedExecutionTokens.find((candidate) => candidate.tokenId === token.tokenId);
+    if (!existing) {
+      delegatedExecutionTokens.push(token);
+      continue;
+    }
+    if (
+      JSON.stringify(orderedDelegatedExecutionToken(existing)) !== JSON.stringify(orderedDelegatedExecutionToken(token))
+    )
+      return {
+        ok: false,
+        reason: [
+          `DelegatedExecutionToken ${token.tokenId} differs on each side;`,
+          "a roster union cannot choose which delegation is authoritative",
+        ].join(" "),
+      };
+  }
+
   try {
-    validatePeopleRoster(people, roles, bindings);
+    validatePeopleRoster(people, roles, bindings, delegatedExecutionTokens);
   } catch (error) {
     return {
       ok: false,
@@ -417,6 +524,7 @@ export function mergePeopleRosterDocuments(sourceBody: string, destinationBody: 
       people,
       roles,
       bindings,
+      delegatedExecutionTokens,
     }),
     summary,
   };
@@ -477,6 +585,7 @@ export function validatePeopleRoster(
   people: readonly PersonProfile[],
   roles: readonly RolePolicy[],
   bindings: readonly RoleBinding[] = [],
+  delegatedExecutionTokens: readonly DelegatedExecutionToken[] = [],
 ): void {
   const personIds = new Set<string>(),
     credentialKeys = new Set<string>(),
@@ -532,11 +641,26 @@ export function validatePeopleRoster(
       throw new PeopleRosterContractError(`duplicate RoleBinding: ${key.replaceAll("\0", ":")}`);
     bindingKeys.add(key);
   }
+  const tokenIds = new Set<string>();
+  for (const value of delegatedExecutionTokens) {
+    const token = parseRosterDelegatedExecutionToken(value);
+    if (tokenIds.has(token.tokenId))
+      throw new PeopleRosterContractError(`duplicate DelegatedExecutionToken: ${token.tokenId}`);
+    tokenIds.add(token.tokenId);
+  }
 }
 
 function parseRosterRoleBinding(value: unknown): RoleBinding {
   try {
     return parseRoleBinding(value);
+  } catch (error) {
+    throw new PeopleRosterContractError(error instanceof Error ? error.message : String(error));
+  }
+}
+
+function parseRosterDelegatedExecutionToken(value: unknown): DelegatedExecutionToken {
+  try {
+    return parseDelegatedExecutionToken(value);
   } catch (error) {
     throw new PeopleRosterContractError(error instanceof Error ? error.message : String(error));
   }
@@ -567,13 +691,31 @@ function orderedBinding(binding: RoleBinding): Readonly<Record<string, unknown>>
   };
 }
 
+function orderedDelegatedExecutionToken(token: DelegatedExecutionToken): Readonly<Record<string, unknown>> {
+  return {
+    schema: token.schema,
+    tokenId: token.tokenId,
+    issuer: { personId: token.issuer.personId },
+    delegate: { runtimeSessionId: token.delegate.runtimeSessionId },
+    allowedActions: [...token.allowedActions],
+    issuedAt: token.issuedAt,
+    expiresAt: token.expiresAt,
+    revokedAt: token.revokedAt,
+  };
+}
+
 function credentialKey(credential: CredentialRef): string {
   return `${credential.kind}\0${credential.issuer}\0${credential.subject}`;
 }
 
 function rosterShapeError(roster: ParsedRoster): string | null {
-  if (!Array.isArray(roster.people) || !Array.isArray(roster.roles) || !Array.isArray(roster.bindings))
-    return "people, roles, and bindings must all be lists";
+  if (
+    !Array.isArray(roster.people) ||
+    !Array.isArray(roster.roles) ||
+    !Array.isArray(roster.bindings) ||
+    !Array.isArray(roster.delegatedExecutionTokens)
+  )
+    return "people, roles, bindings, and delegatedExecutionTokens must all be lists";
   for (const person of roster.people) {
     if (!person || typeof person.personId !== "string" || !person.personId) return "every person needs a personId";
     if (typeof person.displayName !== "string") return `person ${person.personId} needs a displayName`;
@@ -587,6 +729,13 @@ function rosterShapeError(roster: ParsedRoster): string | null {
   for (const binding of roster.bindings) {
     const errors = validateRoleBinding(binding);
     if (errors.length) return errors.join("; ");
+  }
+  for (const token of roster.delegatedExecutionTokens) {
+    try {
+      parseDelegatedExecutionToken(token);
+    } catch (error) {
+      return describe(error);
+    }
   }
   return null;
 }
@@ -604,13 +753,21 @@ type ParsedRoster = {
   readonly people: PersonProfile[];
   readonly roles: RolePolicy[];
   readonly bindings: RoleBinding[];
+  readonly delegatedExecutionTokens: DelegatedExecutionToken[];
 };
 
 function parsePeopleYaml(body: string): ParsedRoster {
   const trimmed = body.trimStart();
   if (trimmed.startsWith("{")) {
-    const parsed = JSON.parse(body) as Omit<ParsedRoster, "bindings"> & { readonly bindings?: RoleBinding[] };
-    return { ...parsed, bindings: parsed.bindings ?? [] };
+    const parsed = JSON.parse(body) as Omit<ParsedRoster, "bindings" | "delegatedExecutionTokens"> & {
+      readonly bindings?: RoleBinding[];
+      readonly delegatedExecutionTokens?: DelegatedExecutionToken[];
+    };
+    return {
+      ...parsed,
+      bindings: parsed.bindings ?? [],
+      delegatedExecutionTokens: parsed.delegatedExecutionTokens ?? [],
+    };
   }
 
   let schema = "";
@@ -721,6 +878,7 @@ function parsePeopleYaml(body: string): ParsedRoster {
     people: people as PersonProfile[],
     roles: roles as RolePolicy[],
     bindings: bindings as RoleBinding[],
+    delegatedExecutionTokens: [],
   };
 }
 

--- a/packages/kernel/src/ports/authorization-port.ts
+++ b/packages/kernel/src/ports/authorization-port.ts
@@ -5,6 +5,13 @@ import { DEFAULT_POLICY } from "../domain/default-policy.ts";
 import type { EntityRef } from "../domain/entity-ref.ts";
 import type { LeaseV1 } from "../domain/execution.ts";
 import {
+  parseDelegatedExecutionToken,
+  validateDelegatedExecutionToken,
+  verifyDelegatedExecutionToken,
+  type DelegatedExecutionToken,
+  type DelegatedExecutionTokenVerification,
+} from "../domain/delegated-execution-token.ts";
+import {
   validatePolicyDeclarationV1,
   type PolicyActionRule,
   type PolicyDeclarationV1,
@@ -27,6 +34,7 @@ export interface AuthorizationTargetSnapshot {
 
 /** Volatile bindings are inputs to evaluation, not fields added to ActionEnvelope. */
 export interface AuthorizationContext {
+  readonly delegatedExecutionToken?: DelegatedExecutionToken;
   readonly ruleScope?: string;
   readonly roleBindings?: readonly RoleBinding[];
   readonly roleBindingTargets?: readonly EntityRef[];
@@ -73,18 +81,25 @@ export function evaluateAuthorization(
             (candidate.scope === undefined ? context.ruleScope === undefined : candidate.scope === context.ruleScope),
         ),
     authorizationRefMatches = action.authorizationRef === policyRef,
+    tokenVerification = verifyActorProof(action, context),
     evaluated = rules.map((rule) => evaluateRule(rule, action, context)),
     allowed = policyValid && actionValid && authorizationRefMatches && evaluated.some((result) => result.allowed),
-    bindingsUsed = evaluated.flatMap((result) => result.bindings),
+    actorProofAllowed = tokenVerification === null || tokenVerification.ok,
+    authorizationAllowed = allowed && actorProofAllowed,
+    tokenBinding = context.delegatedExecutionToken
+      ? receiptDelegatedExecutionToken(context.delegatedExecutionToken)
+      : null,
+    bindingsUsed = [...(tokenBinding ? [tokenBinding] : []), ...evaluated.flatMap((result) => result.bindings)],
     missing = rules.length === 0 ? "policy_rule_missing" : null,
-    reasonCodes = allowed
+    reasonCodes = authorizationAllowed
       ? ["authorization_allowed"]
       : [
+          ...(tokenVerification !== null && !tokenVerification.ok ? [tokenVerification.reasonCode] : []),
           ...(authorizationRefMatches ? [] : ["authorization_ref_mismatch"]),
           ...(policyValid ? [] : ["policy_contract_invalid"]),
           ...(actionValid ? [] : ["action_envelope_invalid"]),
           ...(missing ? [missing] : []),
-          ...(rules.length && policyValid && actionValid && authorizationRefMatches
+          ...(!allowed && rules.length && policyValid && actionValid && authorizationRefMatches
             ? ["authorization_predicate_failed"]
             : []),
         ];
@@ -93,15 +108,28 @@ export function evaluateAuthorization(
     actor: action.actor,
     subject: action.target,
     bindingsUsed: Object.freeze(bindingsUsed),
-    outcome: allowed ? "allowed" : "denied",
+    outcome: authorizationAllowed ? "allowed" : "denied",
     reasonCodes: Object.freeze(reasonCodes),
     nextActions: Object.freeze(
-      allowed
+      authorizationAllowed
         ? []
         : [missing ? `Define Policy rule ${action.kind}.` : `Retry ${action.kind} with authorized bindings.`],
     ),
     evaluatedAtCut: context.evaluatedAtCut,
   });
+}
+
+function verifyActorProof(
+  action: ActionEnvelope,
+  context: AuthorizationContext,
+): DelegatedExecutionTokenVerification | null {
+  if (!context.delegatedExecutionToken) return null;
+  return verifyDelegatedExecutionToken(
+    context.delegatedExecutionToken,
+    action.actor,
+    action.kind,
+    context.evaluatedAt ?? "",
+  );
 }
 
 function evaluateRule(
@@ -209,6 +237,17 @@ function receiptRoleBinding(binding: RoleBinding): ReceiptJsonValue {
     source: binding.source,
     expiresAt: binding.expiresAt,
   };
+}
+
+function receiptDelegatedExecutionToken(value: unknown): Readonly<Record<string, ReceiptJsonValue>> | null {
+  if (validateDelegatedExecutionToken(value).length) return null;
+  const token = parseDelegatedExecutionToken(value);
+  return Object.freeze({
+    proof: "delegated-execution-token",
+    tokenId: token.tokenId,
+    issuerPersonId: token.issuer.personId,
+    runtimeSessionId: token.delegate.runtimeSessionId,
+  });
 }
 
 export const authorizationPort = createAuthorizationPort(DEFAULT_POLICY);

--- a/packages/kernel/test/contracts/authorization-port.test.ts
+++ b/packages/kernel/test/contracts/authorization-port.test.ts
@@ -2,12 +2,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { DEFAULT_POLICY } from "../../src/domain/default-policy.ts";
+import { validateWriteReceipt } from "../../src/domain/receipt-domain-registry.ts";
 import { createAuthorizationPort, evaluateAuthorization } from "../../src/ports/authorization-port.ts";
 import {
   currentActionEnvelopeVersion,
   type ActionEnvelope,
   type ActorIdentity,
   type AuthorizationContext,
+  type DelegatedExecutionToken,
   type LeaseV1,
 } from "../../src/index.ts";
 
@@ -343,5 +345,76 @@ test("evaluation fails closed for stale policy references and missing action or 
   assert.equal(
     decide("task.closeout", owner, "task/task-1", { target: { owner, lease } }).reasonCodes[0],
     "policy_rule_missing",
+  );
+});
+
+test("AuthorizationDecision audits the DelegatedExecutionToken used as actor proof", () => {
+  const delegatedActor: ActorIdentity = {
+      principal: { personId: "owner" },
+      executor: { kind: "agent", id: "runtime-session:runtime-1" },
+    },
+    token: DelegatedExecutionToken = {
+      schema: "delegated-execution-token/v1",
+      tokenId: "det_owner_runtime_1",
+      issuer: delegatedActor.principal,
+      delegate: { runtimeSessionId: "runtime-1" },
+      allowedActions: ["execution.start"],
+      issuedAt: "2026-08-27T02:00:00.000Z",
+      expiresAt: "2026-08-27T03:00:00.000Z",
+      revokedAt: null,
+    },
+    decision = decide("execution.start", delegatedActor, "execution/execution-1", {
+      ...commandBinding("repo-write", delegatedActor),
+      delegatedExecutionToken: token,
+      evaluatedAt: "2026-08-27T02:30:00.000Z",
+      target: {},
+    });
+  assert.equal(decision.outcome, "allowed");
+  assert.deepEqual(decision.bindingsUsed[0], {
+    proof: "delegated-execution-token",
+    tokenId: token.tokenId,
+    issuerPersonId: "owner",
+    runtimeSessionId: "runtime-1",
+  });
+  assert.deepEqual(
+    validateWriteReceipt({
+      outcome: "op_rejected",
+      opId: "op-token-audit",
+      code: "audit_sample",
+      origin: "test",
+      nextAction: "No action is required.",
+      evidence: "authorization:det_owner_runtime_1",
+      authorizationDecision: decision,
+    }),
+    [],
+  );
+
+  const expired = decide("execution.start", delegatedActor, "execution/execution-1", {
+    ...commandBinding("repo-write", delegatedActor),
+    delegatedExecutionToken: token,
+    evaluatedAt: token.expiresAt,
+    target: {},
+  });
+  assert.equal(expired.outcome, "denied");
+  assert.ok(expired.reasonCodes.includes("delegated_token_expired"));
+  const revoked = decide("execution.start", delegatedActor, "execution/execution-1", {
+    ...commandBinding("repo-write", delegatedActor),
+    delegatedExecutionToken: { ...token, revokedAt: "2026-08-27T02:20:00.000Z" },
+    evaluatedAt: "2026-08-27T02:30:00.000Z",
+    target: {},
+  });
+  assert.equal(revoked.outcome, "denied");
+  assert.ok(revoked.reasonCodes.includes("delegated_token_revoked"));
+  const malformed = decide("execution.start", delegatedActor, "execution/execution-1", {
+    ...commandBinding("repo-write", delegatedActor),
+    delegatedExecutionToken: {} as DelegatedExecutionToken,
+    evaluatedAt: "2026-08-27T02:30:00.000Z",
+    target: {},
+  });
+  assert.equal(malformed.outcome, "denied");
+  assert.ok(malformed.reasonCodes.includes("delegated_token_contract_invalid"));
+  assert.equal(
+    malformed.bindingsUsed.some((binding) => binding.proof === "delegated-execution-token"),
+    false,
   );
 });

--- a/packages/kernel/test/contracts/delegated-execution-token.test.ts
+++ b/packages/kernel/test/contracts/delegated-execution-token.test.ts
@@ -1,0 +1,70 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  parseDelegatedExecutionToken,
+  verifyDelegatedExecutionToken,
+  type DelegatedExecutionToken,
+} from "../../src/domain/delegated-execution-token.ts";
+
+const token: DelegatedExecutionToken = {
+  schema: "delegated-execution-token/v1",
+  tokenId: "det_offline_owner_1",
+  issuer: { personId: "person_owner" },
+  delegate: { runtimeSessionId: "runtime_1" },
+  allowedActions: ["execution.start", "doc.submit"],
+  issuedAt: "2026-08-27T02:00:00.000Z",
+  expiresAt: "2026-08-27T03:00:00.000Z",
+  revokedAt: null,
+};
+
+const actor = {
+  principal: token.issuer,
+  executor: { kind: "agent" as const, id: `runtime-session:${token.delegate.runtimeSessionId}` },
+};
+
+test("DelegatedExecutionToken is a closed ledger-verifiable principal delegation", () => {
+  assert.deepEqual(parseDelegatedExecutionToken(token), {
+    ...token,
+    allowedActions: ["doc.submit", "execution.start"],
+  });
+  assert.throws(() => parseDelegatedExecutionToken({ ...token, allowedActions: [] }), /at least one allowed Action/u);
+  assert.throws(
+    () => parseDelegatedExecutionToken({ ...token, expiresAt: token.issuedAt }),
+    /expiresAt must be later than issuedAt/u,
+  );
+  assert.throws(
+    () => parseDelegatedExecutionToken({ ...token, bearerSecret: "not-ledger-safe" }),
+    /unsupported fields: bearerSecret/u,
+  );
+});
+
+test("token proof binds principal, RuntimeSession, Action scope, expiry, and revocation", () => {
+  assert.deepEqual(verifyDelegatedExecutionToken(token, actor, "doc.submit", "2026-08-27T02:30:00.000Z"), { ok: true });
+  assert.equal(
+    verifyDelegatedExecutionToken(token, actor, "task.complete", "2026-08-27T02:30:00.000Z").reasonCode,
+    "delegated_token_action_forbidden",
+  );
+  assert.equal(
+    verifyDelegatedExecutionToken(
+      token,
+      { ...actor, principal: { personId: "person_other" } },
+      "doc.submit",
+      "2026-08-27T02:30:00.000Z",
+    ).reasonCode,
+    "delegated_token_actor_mismatch",
+  );
+  assert.equal(
+    verifyDelegatedExecutionToken(token, actor, "doc.submit", token.expiresAt).reasonCode,
+    "delegated_token_expired",
+  );
+  assert.equal(
+    verifyDelegatedExecutionToken(
+      { ...token, revokedAt: "2026-08-27T02:20:00.000Z" },
+      actor,
+      "doc.submit",
+      "2026-08-27T02:30:00.000Z",
+    ).reasonCode,
+    "delegated_token_revoked",
+  );
+});

--- a/packages/kernel/test/contracts/people-roster-action.test.ts
+++ b/packages/kernel/test/contracts/people-roster-action.test.ts
@@ -190,3 +190,44 @@ test("people bind persists only declared RoleBindings and removes a deleted pers
     /only persist declared RoleBindings/u,
   );
 });
+
+test("people delegate and revoke mutate the same roster without a token store", () => {
+  const bootstrapped = applyPeopleRosterAction(null, {
+      kind: "people-add",
+      person: owner,
+      rolePolicy: { roleId: "owner", commandClasses: ["admin"] },
+    }),
+    token = {
+      schema: "delegated-execution-token/v1" as const,
+      tokenId: "det_owner_runtime_1",
+      issuer: { personId: owner.personId },
+      delegate: { runtimeSessionId: "runtime_1" },
+      allowedActions: ["execution.start"],
+      issuedAt: "2026-08-27T02:00:00.000Z",
+      expiresAt: "2026-08-27T03:00:00.000Z",
+      revokedAt: null,
+    },
+    delegated = applyPeopleRosterAction(bootstrapped.body, { kind: "people-delegate", token }),
+    revoked = applyPeopleRosterAction(delegated.body, {
+      kind: "people-revoke-delegation",
+      tokenId: token.tokenId,
+      issuerPersonId: owner.personId,
+      revokedAt: "2026-08-27T02:30:00.000Z",
+    });
+  assert.equal(delegated.action, "people-delegate");
+  assert.deepEqual(parsePeopleRosterDocument(delegated.body).delegatedExecutionTokens, [token]);
+  assert.equal(
+    parsePeopleRosterDocument(revoked.body).delegatedExecutionTokens[0]?.revokedAt,
+    "2026-08-27T02:30:00.000Z",
+  );
+  assert.throws(
+    () =>
+      applyPeopleRosterAction(delegated.body, {
+        kind: "people-revoke-delegation",
+        tokenId: token.tokenId,
+        issuerPersonId: "person_other",
+        revokedAt: "2026-08-27T02:30:00.000Z",
+      }),
+    /Only DelegatedExecutionToken issuer person_owner may revoke it/u,
+  );
+});


### PR DESCRIPTION
# English

## Summary

RBAC Phase 3.3 (dec_CD53D4B150596BAF382944516E, RBAC S2/S6): a `delegated-execution-token/v1` contract — issuer person, delegate RuntimeSession, allowed Action set, issued/expires/revoked timestamps — stored through the existing `people.yaml` projection, `people_changed` event, WAL and RepoCell write queue (no token store, no new write path, no bearer secret or PKI). `ha people delegate` / `ha people revoke-delegation` issue and revoke. The AuthorizationPort accepts a token as *actor proof* only: after the token is accepted the request still has to pass Policy, RoleBinding and `hasCommandClass` from 3.2, so a token never bypasses authorization. The AuthorizationDecision records `{proof: delegated-execution-token, tokenId, issuerPersonId, runtimeSessionId}` in `bindingsUsed` for audit.

## Architectural Justification

- Production-Delta: +496/-24 exceeds 200 lines: the contract, its People-action writer, the port's proof branch and the two CLI commands land together because a token nobody can issue or a proof nobody records is a dead path. No new store, transport or authorization entry point — the token rides the existing People write path and the existing Policy chain.

## What Changed

- `packages/kernel/src/domain`: `delegated-execution-token/v1` contract in the People roster; issue/revoke actions.
- `packages/kernel/src/ports/authorization-port.ts`: token as actor proof; decision audit entry.
- `packages/daemon/src/identity` + people actions: projection/validation of tokens.
- `packages/cli/src/cli`: `ha people delegate`, `ha people revoke-delegation` (direct flags or `--from-file`).
- Tests: kernel contract, authorization-port proof/deny cases, people action integration, CLI people tests.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +496/-24

### Optional Evidence Claims

## Task And Scope

- Harness task: task_d43f70021ef0cb30dbaf2c3ff9
- Branch: codex/delegated-token
- Public scope: packages/kernel domain/ports (token contract, authorization proof), packages/daemon identity/people actions, packages/cli people delegate/revoke, tests
- Private planning/evidence updated: yes
- Out of scope: Phase 5 black-box worker resolving the token from the ledger cut into AuthorizationContext; Policy entity (3.4 follow-up)

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_d43f70021ef0cb30dbaf2c3ff9
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 33a0533375ac3c33db4b155c86a0118674e8fd6b
- Branch merge-base with `origin/main`: 33a0533375ac3c33db4b155c86a0118674e8fd6b
- Last `git fetch origin` time: 2026-08-27T11:12:03Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_d43f70021ef0cb30dbaf2c3ff9 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] kernel contract, authorization-port proof accept/deny/expired/revoked, people action integration, CLI people tests green; typecheck
- [x] Rebased onto main after #1936 (Sol rebase report in the task package)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: integration tier locally by design; CI is the authority.

## Review Evidence

- Self-review: CEO checked the four design boundaries in the report (closed contract, existing write path only, proof-not-bypass, audit entry) against the plan and the RBAC rulings.
- Reviewer subagent: Codex worker (gpt-5.6-sol); CEO acceptance.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Until Phase 5 wires the token into worker transport, tokens can be issued and audited but no runtime presents one; the proof branch is covered by port tests only.

## References

- Task: task_d43f70021ef0cb30dbaf2c3ff9
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

RBAC Phase 3.3(dec_CD53D4B150596BAF382944516E,RBAC S2/S6):`delegated-execution-token/v1` 契约——签发人、被委托 RuntimeSession、允许的 Action 集合、签发/到期/撤销时间——经既有 `people.yaml` 投影、`people_changed` 事件、WAL 与 RepoCell 写队列存储(无 token 专用 store、无新写路、无 bearer secret 或 PKI)。`ha people delegate` / `ha people revoke-delegation` 签发与撤销。AuthorizationPort 只把 token 当 **actor 证明**:token 通过后仍须过 3.2 的 Policy、RoleBinding 与 `hasCommandClass`,token 不绕过授权。AuthorizationDecision 在 `bindingsUsed` 记录 `{proof: delegated-execution-token, tokenId, issuerPersonId, runtimeSessionId}` 供审计。

## 架构辩护

- Production-Delta: +496/-24 超过 200 行:契约、People action 写入、port 的 proof 分支与两条 CLI 命令一起落地,因为没人能签发的 token 或没人记录的 proof 都是死路径。不新增 store、传输或授权入口——token 复用既有 People 写路与既有 Policy 链。

## 改动内容

- `packages/kernel/src/domain`:People roster 内的 `delegated-execution-token/v1` 契约;签发/撤销 action。
- `packages/kernel/src/ports/authorization-port.ts`:token 作 actor proof;决策审计条目。
- `packages/daemon/src/identity` + people actions:token 的投影/校验。
- `packages/cli/src/cli`:`ha people delegate`、`ha people revoke-delegation`(直接 flag 或 `--from-file`)。
- 测试:kernel contract、authorization-port proof/deny 用例、people action 集成、CLI people 测试。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_d43f70021ef0cb30dbaf2c3ff9
- 分支:codex/delegated-token
- 公开范围:packages/kernel domain/ports(token 契约、授权 proof)、packages/daemon identity/people actions、packages/cli people delegate/revoke、测试
- 私有计划 / 证据是否已更新:yes
- 范围外:Phase 5 黑盒 worker 从 ledger cut 解析 token 进 AuthorizationContext;Policy 实体(3.4 后续)

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_d43f70021ef0cb30dbaf2c3ff9
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:33a0533375ac3c33db4b155c86a0118674e8fd6b
- 当前分支与 `origin/main` 的 merge-base:33a0533375ac3c33db4b155c86a0118674e8fd6b
- 最近一次 `git fetch origin` 时间:2026-08-27T11:12:03Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_d43f70021ef0cb30dbaf2c3ff9
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] kernel contract、authorization-port proof 接受/拒绝/过期/撤销、people action 集成、CLI people 测试绿;typecheck
- [x] #1936 合入后 rebase 到 main(Sol rebase 报告在任务包)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计本地不跑 integration tier;以 CI 为权威。

## 审查证据

- 自查:CEO 对照 plan 与 RBAC 裁决核报告的四条设计边界(闭合契约、只用既有写路、proof 不绕过、审计条目)。
- Reviewer subagent:Codex worker(gpt-5.6-sol);CEO 验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- Phase 5 把 token 接进 worker 传输之前,token 可签发可审计但没有 runtime 会出示;proof 分支目前只有 port 测试覆盖。

## 关联材料

- 任务:task_d43f70021ef0cb30dbaf2c3ff9
- 证据:任务包 artifacts/reports
- 审查:本 PR





