### PR TITLE
feat(settings): split repository vs local facets; locale becomes a local preference

### DIFF
--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli-init-bootstrap.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli-init-bootstrap.test.ts
@@ -9,6 +9,7 @@ import {
   compileSettingsChangedEvent,
   makeTaskEventStore,
   readSettingsFacet,
+  repositorySettings,
 } from "../../kernel/src/index.ts";
 
 import { cli, git, register, run, setup, setupEmpty, stop } from "./daemon-multi-repo-lifecycle-cli.fixtures.ts";
@@ -90,6 +91,11 @@ test("REQ-CTX-01..10 empty init publishes the canonical scaffold, authority pari
       defaultConfig,
       /scaffolds:\n    task: governance\/task-scaffold\.json\n    repository: governance\/repository-scaffold\.json/u,
     );
+    assert.doesNotMatch(defaultConfig, /^  locale:/mu);
+    assert.deepEqual(JSON.parse(readFileSync(path.join(fixture.repo, ".harness/settings.local.json"), "utf8")), {
+      schema: "settings-local/v1",
+      locale: "en-US",
+    });
     assert.match(
       architecture,
       /Opt-in Boundary[\s\S]*does not create or enable an architecture manifest, model, or generated view/iu,
@@ -136,11 +142,11 @@ test("REQ-CTX-01..10 empty init publishes the canonical scaffold, authority pari
     );
     assert.equal(stream.revision, 1);
     assert.equal(stream.events[0]?.schema, "settings-event/v1");
+    const settingsRead = run(fixture.repo, fixture.userRoot, ["settings", "read"]).settings;
+    assert.equal(settingsRead.locale, "en-US");
     assert.deepEqual(
-      run(fixture.repo, fixture.userRoot, ["settings", "read"]).settings,
-      stream.events[0]?.schema === "settings-event/v1"
-        ? stream.events[0].payload.settings
-        : null,
+      repositorySettings(settingsRead),
+      stream.events[0]?.schema === "settings-event/v1" ? stream.events[0].payload.settings : null,
     );
     const repeated = run(fixture.repo, fixture.userRoot, [
       "init",
@@ -325,10 +331,7 @@ test("center registration keeps an external ledger repository readable and writa
   const fixture = setup();
   try {
     assert.equal(existsSync(path.join(fixture.alpha, "harness/.git")), false);
-    const documentBody = readFileSync(
-        path.join(fixture.alpha, "harness/harness.yaml"),
-        "utf8",
-      ),
+    const documentBody = readFileSync(path.join(fixture.alpha, "harness/harness.yaml"), "utf8"),
       store = makeTaskEventStore({ rootDir: fixture.alpha, repoId: "alpha" });
     store.append(
       compileSettingsChangedEvent({
@@ -344,10 +347,7 @@ test("center registration keeps an external ledger repository readable and writa
       }),
     );
     await store.drain();
-    assert.equal(
-      run(fixture.alpha, fixture.userRoot, ["daemon", "start", "--service"]).ok,
-      true,
-    );
+    assert.equal(run(fixture.alpha, fixture.userRoot, ["daemon", "start", "--service"]).ok, true);
     register(fixture.alpha, fixture.userRoot, "center");
     const before = git(fixture.alpha, "rev-parse", "HEAD"),
       written = run(fixture.alpha, fixture.userRoot, [

--- a/packages/daemon/src/daemon-host-repository-api.ts
+++ b/packages/daemon/src/daemon-host-repository-api.ts
@@ -21,6 +21,7 @@ import {
 import type { JsonObject } from "./protocol/json-rpc-types.ts";
 import { resolveRepoBootstrap, type RepoBootstrapReceipt } from "./repo-bootstrap.ts";
 import { openRepoCell, type RepoCell, type RepoTaskAction } from "./repo-cell.ts";
+import { settingsCommandTopology } from "./repo-mode.ts";
 
 export function createDaemonHostRepositoryApi(
   context: any,
@@ -205,7 +206,7 @@ export function createDaemonHostRepositoryApi(
       };
     },
     run: async (repoId, action, auth) => {
-      const command = commandDescriptorForAction(action.kind),
+      const command = settingsCommandTopology(commandDescriptorForAction(action.kind), action),
         commandClass = command.commandClass,
         projectionRepair = context.localCenterProjectionRepair(repoId, action.kind, auth),
         modeAdmission = context.admitHostMode(repoId, command, auth);

--- a/packages/daemon/src/repo-bootstrap.ts
+++ b/packages/daemon/src/repo-bootstrap.ts
@@ -106,7 +106,6 @@ export function resolveRepoBootstrap(
       `  defaultVertical: ${INITIAL_SETTINGS_V1.defaultVertical}`,
       `  defaultPreset: ${INITIAL_SETTINGS_V1.defaultPreset}`,
       `  defaultProfile: ${INITIAL_SETTINGS_V1.defaultProfile}`,
-      `  locale: ${INITIAL_SETTINGS_V1.locale}`,
       "  tasks:",
       `    wipLimit: ${DEFAULT_TASK_WIP_LIMIT}`,
       "  scaffolds:",

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -22,6 +22,7 @@ import {
 import type { JsonObject } from "./protocol/json-rpc-types.ts";
 import { recoveryCommandPolicy } from "./recovery-state.ts";
 import type { DaemonGuiReadHandlers, RepoCell, RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
+import { withDerivedCommandClass } from "./repo-cell-role-bindings.ts";
 import { admitRepoMode, settingsCommandTopology } from "./repo-mode.ts";
 import { makeTaskQueryReadModel } from "./task-query-read.ts";
 import { chainRepoCellWrite, repoCellTaskQueryJudgments } from "./repo-cell.ts";
@@ -141,7 +142,7 @@ export function createRepoCellApi(context: any): RepoCell {
             ),
           failAction,
         );
-    return enqueuePublication(() => context.executeAction(action, { ...binding, commandClasses: [commandClass] }));
+    return enqueuePublication(() => context.executeAction(action, withDerivedCommandClass(binding, commandClass)));
   };
   const presetRun: RepoCell["presetRun"] = async (action, binding) => {
     const command = commandDescriptorForAction(action.kind),

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -22,8 +22,7 @@ import {
 import type { JsonObject } from "./protocol/json-rpc-types.ts";
 import { recoveryCommandPolicy } from "./recovery-state.ts";
 import type { DaemonGuiReadHandlers, RepoCell, RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
-import { withDerivedCommandClass } from "./repo-cell-role-bindings.ts";
-import { admitRepoMode } from "./repo-mode.ts";
+import { admitRepoMode, settingsCommandTopology } from "./repo-mode.ts";
 import { makeTaskQueryReadModel } from "./task-query-read.ts";
 import { chainRepoCellWrite, repoCellTaskQueryJudgments } from "./repo-cell.ts";
 import { executeVerticalScriptAction, publishExecutedVerticalScript } from "./vertical-script-actions.ts";
@@ -32,7 +31,7 @@ import { readCiObservatory } from "./ci-observatory-read.ts";
 
 export function createRepoCellApi(context: any): RepoCell {
   const run = (action: RepoTaskAction, binding: RepoCellBinding, signal?: AbortSignal): Promise<WriteReceipt> => {
-    const command = commandDescriptorForAction(action.kind),
+    const command = settingsCommandTopology(commandDescriptorForAction(action.kind), action),
       commandClass = command.commandClass,
       modeAdmission = admitRepoMode(context.mode, command, binding.source);
     if (!modeAdmission.ok)
@@ -142,7 +141,7 @@ export function createRepoCellApi(context: any): RepoCell {
             ),
           failAction,
         );
-    return enqueuePublication(() => context.executeAction(action, withDerivedCommandClass(binding, commandClass)));
+    return enqueuePublication(() => context.executeAction(action, { ...binding, commandClasses: [commandClass] }));
   };
   const presetRun: RepoCell["presetRun"] = async (action, binding) => {
     const command = commandDescriptorForAction(action.kind),

--- a/packages/daemon/src/repo-cell-settings-actions.ts
+++ b/packages/daemon/src/repo-cell-settings-actions.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import {
+  consumeKnownError,
   INITIAL_SETTINGS_V1,
   SETTINGS_LOCAL_PATH,
   compileSettingsChangedEvent,
@@ -43,7 +44,8 @@ export function makeRepoCellSettingsActions(cell: any) {
     try {
       const parsed = parseLocalSettings(JSON.parse(readFileSync(localPath, "utf8")));
       if (parsed) return { locale: parsed.locale, valid: true };
-    } catch {
+    } catch (error) {
+      consumeKnownError(error);
       // The read boundary stays available while an invalid local preference is repaired by an update.
     }
     return { locale: INITIAL_SETTINGS_V1.locale, valid: false };

--- a/packages/daemon/src/repo-cell-settings-actions.ts
+++ b/packages/daemon/src/repo-cell-settings-actions.ts
@@ -2,30 +2,61 @@ import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import {
+  INITIAL_SETTINGS_V1,
+  SETTINGS_LOCAL_PATH,
   compileSettingsChangedEvent,
+  parseLocalSettings,
   readSettingsFacet,
+  repositorySettings,
   resolveHarnessLayout,
+  serializeLocalSettings,
+  validateRepositorySettings,
   validateSettingsV1,
-  writeSettingsFacet,
+  writeRepositorySettingsFacet,
+  type RepositorySettingsV1,
+  type SettingsLocale,
   type SettingsV1,
   type WriteReceipt,
 } from "../../kernel/src/index.ts";
+import { writeFileDurably } from "./durable-file.ts";
 import { runPresetAction } from "../../preset/src/index.ts";
 import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
 
 export function makeRepoCellSettingsActions(cell: any) {
-  const read = (): SettingsV1 => {
+  const localPath = path.join(cell.rootDir, ...SETTINGS_LOCAL_PATH.split("/"));
+
+  const readRepository = (): RepositorySettingsV1 => {
     const projected = cell.projection.getEntity("settings", "repository")?.value;
     if (projected === undefined)
       throw cell.cellCodedError(
         "projection_pending",
         "Settings projection is unavailable; bootstrap the repository before retrying.",
       );
-    return projected as unknown as SettingsV1;
+    const current = repositorySettings(projected as unknown as RepositorySettingsV1),
+      errors = validateRepositorySettings(current);
+    if (errors.length) throw cell.cellCodedError("projection_invalid", errors.join("; "));
+    return current;
+  };
+
+  const readLocalState = (): { readonly locale: SettingsLocale; readonly valid: boolean } => {
+    if (!existsSync(localPath)) return { locale: INITIAL_SETTINGS_V1.locale, valid: false };
+    try {
+      const parsed = parseLocalSettings(JSON.parse(readFileSync(localPath, "utf8")));
+      if (parsed) return { locale: parsed.locale, valid: true };
+    } catch {
+      // The read boundary stays available while an invalid local preference is repaired by an update.
+    }
+    return { locale: INITIAL_SETTINGS_V1.locale, valid: false };
+  };
+  const readLocal = (): SettingsLocale => readLocalState().locale;
+
+  const read = (): SettingsV1 => {
+    const repository = readRepository();
+    return { ...repository, locale: readLocal() };
   };
 
   const append = (
-    settings: SettingsV1,
+    settings: RepositorySettingsV1,
     baseDocumentBody: string,
     candidateDocumentBody: string,
     opId: string,
@@ -50,10 +81,14 @@ export function makeRepoCellSettingsActions(cell: any) {
 
   const initialize = (settings: SettingsV1, documentBody: string, binding: RepoCellBinding) => {
     if (cell.projection.getEntity("settings", "repository")?.value !== undefined) return null;
-    const revision = cell.store.readHead()?.revision ?? 0,
-      digest = createHash("sha256").update(`${cell.input.repoId}\0${documentBody}`).digest("hex"),
+    const repository = repositorySettings(settings),
+      candidateDocumentBody = writeRepositorySettingsFacet(documentBody, repository),
+      revision = cell.store.readHead()?.revision ?? 0,
+      digest = createHash("sha256").update(`${cell.input.repoId}\0${candidateDocumentBody}`).digest("hex"),
       opId = `settings-initialize-${digest}`;
-    return append(settings, documentBody, documentBody, opId, revision, binding);
+    const appended = append(repository, documentBody, candidateDocumentBody, opId, revision, binding);
+    writeFileDurably(localPath, serializeLocalSettings(settings.locale), 0o600);
+    return appended;
   };
 
   // A repository that carries no authored settings document has nothing to mint into the ledger.
@@ -65,45 +100,16 @@ export function makeRepoCellSettingsActions(cell: any) {
     return initialize(readSettingsFacet(documentBody), documentBody, binding);
   };
 
-  const update = async (action: RepoTaskAction, binding: RepoCellBinding): Promise<WriteReceipt> => {
-    const current = read(),
-      settings: SettingsV1 = {
-        schema: current.schema,
-        settingsId: current.settingsId,
-        defaultVertical: settingsText(action.defaultVertical) ?? current.defaultVertical,
-        defaultPreset: settingsText(action.defaultPreset) ?? current.defaultPreset,
-        defaultProfile: settingsText(action.defaultProfile) ?? current.defaultProfile,
-        locale: (settingsText(action.locale) ?? current.locale) as SettingsV1["locale"],
-        scaffolds: {
-          task: settingsText(action.taskScaffold) ?? current.scaffolds.task,
-          repository: settingsText(action.repositoryScaffold) ?? current.scaffolds.repository,
-        },
-      },
-      errors = validateSettingsV1(settings);
-    if (errors.length) throw cell.cellCodedError("invalid_command", errors.join("; "));
-    const presets = (await runPresetAction({
-        rootDir: cell.rootDir,
-        action: { kind: "preset-list", verticalId: settings.defaultVertical },
-        settings,
-      })) as readonly SettingsCatalogPreset[],
-      preset = presets.find((row) => row.id === settings.defaultPreset && row.verticalId === settings.defaultVertical),
-      selection = [settings.defaultVertical, settings.defaultPreset, settings.defaultProfile].join("/");
-    if (preset?.validity !== "valid" || !preset.profiles?.some((profile) => profile.id === settings.defaultProfile))
-      throw cell.cellCodedError(
-        "invalid_settings_catalog_selection",
-        `Settings selection ${selection} is not a valid catalog preset profile.`,
-      );
-    const configPath = path.join(resolveHarnessLayout(cell.rootDir).authoredRoot, "harness.yaml"),
-      baseDocumentBody = readFileSync(configPath, "utf8"),
-      candidateDocumentBody = writeSettingsFacet(baseDocumentBody, settings),
-      revision = cell.store.readHead()?.revision ?? 0,
-      opId = cell.operationId(action, binding, cell.input.repoId, settingsText(action.idempotencyKey) ? 0 : revision);
-    if (candidateDocumentBody === baseDocumentBody)
+  const updateLocal = (locale: SettingsLocale, opId: string, revision: number): WriteReceipt => {
+    const local = readLocalState(),
+      current = local.locale,
+      settings = { ...read(), locale };
+    if (local.valid && current === locale)
       return {
         outcome: "no_changes",
         opId,
         revision,
-        evidence: JSON.stringify({ schema: "settings-update/v1", settings }),
+        evidence: JSON.stringify({ schema: "settings-local-update/v1", settings }),
         visibility: "center",
         code: "no_changes",
         origin: "daemon",
@@ -115,14 +121,75 @@ export function makeRepoCellSettingsActions(cell: any) {
           canonicalVisible: true,
           worktreeVisible: true,
         },
-        summary: "Repository settings already match the requested values.",
+        summary: "Local settings already match the requested values.",
       } as WriteReceipt;
+    writeFileDurably(localPath, serializeLocalSettings(locale), 0o600);
+    return {
+      outcome: "applied",
+      opId,
+      revision,
+      evidence: JSON.stringify({ schema: "settings-local-update/v1", settings }),
+      visibility: "center",
+      proof: {
+        committedRevision: revision,
+        appliedCut: revision,
+        durable: true,
+        canonicalVisible: true,
+        worktreeVisible: true,
+      },
+      summary: "Updated local settings.",
+    } as WriteReceipt;
+  };
+
+  const update = async (action: RepoTaskAction, binding: RepoCellBinding): Promise<WriteReceipt> => {
+    const current = read(),
+      repository: RepositorySettingsV1 = {
+        schema: current.schema,
+        settingsId: current.settingsId,
+        defaultVertical: settingsText(action.defaultVertical) ?? current.defaultVertical,
+        defaultPreset: settingsText(action.defaultPreset) ?? current.defaultPreset,
+        defaultProfile: settingsText(action.defaultProfile) ?? current.defaultProfile,
+        scaffolds: {
+          task: settingsText(action.taskScaffold) ?? current.scaffolds.task,
+          repository: settingsText(action.repositoryScaffold) ?? current.scaffolds.repository,
+        },
+      },
+      locale = (settingsText(action.locale) ?? current.locale) as SettingsLocale,
+      settings: SettingsV1 = { ...repository, locale },
+      errors = validateSettingsV1(settings),
+      revision = cell.store.readHead()?.revision ?? 0,
+      opId = cell.operationId(action, binding, cell.input.repoId, settingsText(action.idempotencyKey) ? 0 : revision);
+    if (errors.length) throw cell.cellCodedError("invalid_command", errors.join("; "));
+
+    const repositoryChanged = JSON.stringify(repository) !== JSON.stringify(repositorySettings(current)),
+      localChanged = locale !== current.locale;
+    if (!repositoryChanged) return updateLocal(locale, opId, revision);
+
+    const presets = (await runPresetAction({
+        rootDir: cell.rootDir,
+        action: { kind: "preset-list", verticalId: repository.defaultVertical },
+        settings,
+      })) as readonly SettingsCatalogPreset[],
+      preset = presets.find(
+        (row) => row.id === repository.defaultPreset && row.verticalId === repository.defaultVertical,
+      ),
+      selection = [repository.defaultVertical, repository.defaultPreset, repository.defaultProfile].join("/");
+    if (preset?.validity !== "valid" || !preset.profiles?.some((profile) => profile.id === repository.defaultProfile))
+      throw cell.cellCodedError(
+        "invalid_settings_catalog_selection",
+        `Settings selection ${selection} is not a valid catalog preset profile.`,
+      );
+
+    const configPath = path.join(resolveHarnessLayout(cell.rootDir).authoredRoot, "harness.yaml"),
+      baseDocumentBody = readFileSync(configPath, "utf8"),
+      candidateDocumentBody = writeRepositorySettingsFacet(baseDocumentBody, repository);
     const existing = cell.store.readEvent(opId);
     if (existing) return cell.receiptForOperation(opId, binding);
-    const appended = append(settings, baseDocumentBody, candidateDocumentBody, opId, revision, binding),
-      publication = cell.publicPublication(appended);
-    const applied = cell.projection.readOperation(opId),
+    const appended = append(repository, baseDocumentBody, candidateDocumentBody, opId, revision, binding),
+      publication = cell.publicPublication(appended),
+      applied = cell.projection.readOperation(opId),
       canonicalVisible = applied !== null && applied.watermark >= appended.revision;
+    if (localChanged) writeFileDurably(localPath, serializeLocalSettings(locale), 0o600);
     return {
       outcome: canonicalVisible ? "applied" : "pending",
       opId,
@@ -137,12 +204,12 @@ export function makeRepoCellSettingsActions(cell: any) {
         worktreeVisible: true,
       },
       ...publication,
-      summary: "Updated repository settings.",
+      summary: localChanged ? "Updated repository and local settings." : "Updated repository settings.",
       ...(canonicalVisible ? {} : { nextAction: `Run ha receipt show ${opId} before retrying.` }),
     } as WriteReceipt;
   };
 
-  return { initialize, initializeFromAuthoredDocument, read, update };
+  return { initialize, initializeFromAuthoredDocument, read, readRepository, update };
 }
 
 interface SettingsCatalogPreset {

--- a/packages/daemon/src/repo-mode.ts
+++ b/packages/daemon/src/repo-mode.ts
@@ -12,6 +12,25 @@ const rejection = (code: string, nextAction: string): RepoModeAdmission => ({
   nextAction,
 });
 
+/** Locale is a machine-local preference; repository-owned settings retain the command's normal route. */
+export function settingsCommandTopology(
+  command: CommandTopology,
+  action: Readonly<Record<string, unknown>> & { readonly kind?: string },
+): CommandTopology {
+  if (
+    action.kind !== "settings-update" ||
+    typeof action.locale !== "string" ||
+    ["defaultVertical", "defaultPreset", "defaultProfile", "taskScaffold", "repositoryScaffold"].some((field) =>
+      Object.hasOwn(action, field),
+    )
+  )
+    return command;
+  return {
+    ...command,
+    admission: { local: "direct", "remote-center": "direct", "remote-edge": "direct" },
+  };
+}
+
 export function admitRepoMode(
   mode: DaemonRepoMode,
   command: Pick<CommandTopology, "admission">,

--- a/packages/daemon/test/command-admission.test.ts
+++ b/packages/daemon/test/command-admission.test.ts
@@ -4,7 +4,7 @@ import test from "node:test";
 import { daemonProtocolCommands } from "../src/protocol/daemon-protocol-commands.ts";
 import { observeTailReadMethod } from "../src/protocol/daemon-protocol-gui-reads.ts";
 import { daemonRepoModeWords } from "../src/protocol/daemon-protocol-vocabulary.ts";
-import { admitRepoMode } from "../src/repo-mode.ts";
+import { admitRepoMode, settingsCommandTopology } from "../src/repo-mode.ts";
 
 const localSource = "local" as const;
 const assignmentSource = { kind: "assignment", nodeId: "edge-one", assignmentId: "assignment-one" } as const;
@@ -92,6 +92,24 @@ test("Settings CLI read uses the common read topology while update forwards from
   });
   assert.equal(byId.get("settings-read")?.commandClass, "repo-read");
   assert.equal(byId.get("settings-update")?.commandClass, "repo-write");
+});
+
+test("Settings locale-only updates use local admission while repository fields keep center routing", () => {
+  const descriptor = new Map(daemonProtocolCommands.map((command) => [command.id, command])).get("settings-update")!;
+  assert.deepEqual(settingsCommandTopology(descriptor, { kind: "settings-update", locale: "zh-CN" }).admission, {
+    local: "direct",
+    "remote-center": "direct",
+    "remote-edge": "direct",
+  });
+  assert.deepEqual(
+    settingsCommandTopology(descriptor, { kind: "settings-update", defaultPreset: "strict-task" }).admission,
+    descriptor.admission,
+  );
+  assert.deepEqual(
+    settingsCommandTopology(descriptor, { kind: "settings-update", locale: "zh-CN", defaultPreset: "strict-task" })
+      .admission,
+    descriptor.admission,
+  );
 });
 
 test("People mutations are admin Actions and forward from an edge", () => {

--- a/packages/daemon/test/repo-settings-local.test.ts
+++ b/packages/daemon/test/repo-settings-local.test.ts
@@ -1,0 +1,53 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { INITIAL_SETTINGS_V1, type SettingsV1 } from "../../kernel/src/index.ts";
+import { makeRepoCellSettingsActions } from "../src/repo-cell-settings-actions.ts";
+
+test("locale updates stay local and do not append a settings event", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-settings-local-"));
+  try {
+    mkdirSync(path.join(rootDir, "harness"), { recursive: true });
+    writeFileSync(path.join(rootDir, "harness/harness.yaml"), "settings:\n  defaultVertical: software/coding\n");
+    const repository = {
+        schema: "settings/v1",
+        settingsId: "repository",
+        defaultVertical: INITIAL_SETTINGS_V1.defaultVertical,
+        defaultPreset: INITIAL_SETTINGS_V1.defaultPreset,
+        defaultProfile: INITIAL_SETTINGS_V1.defaultProfile,
+        scaffolds: INITIAL_SETTINGS_V1.scaffolds,
+      },
+      appended = { count: 0 },
+      cell = {
+        rootDir,
+        input: { repoId: "settings-local" },
+        projection: { getEntity: () => ({ value: repository }) },
+        store: {
+          readHead: () => ({ revision: 3 }),
+          append: () => {
+            appended.count += 1;
+            throw new Error("local settings must not append");
+          },
+        },
+        cellCodedError: (_code: string, message: string) => new Error(message),
+        operationId: () => "settings-local-op",
+        now: () => "2026-08-27T00:00:00.000Z",
+      },
+      actions = makeRepoCellSettingsActions(cell),
+      receipt = await actions.update(
+        { kind: "settings-update", locale: "zh-CN" },
+        { actor: { principal: { personId: "p" }, executor: null }, source: "local" },
+      );
+    assert.equal(receipt.outcome, "applied");
+    assert.equal(appended.count, 0);
+    assert.equal(actions.read().locale, "zh-CN");
+    const localPath = path.join(rootDir, ".harness/settings.local.json");
+    assert.equal(existsSync(localPath), true);
+    assert.deepEqual(JSON.parse(readFileSync(localPath, "utf8")), { schema: "settings-local/v1", locale: "zh-CN" });
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/daemon/test/repo-settings-local.test.ts
+++ b/packages/daemon/test/repo-settings-local.test.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { INITIAL_SETTINGS_V1, type SettingsV1 } from "../../kernel/src/index.ts";
+import { INITIAL_SETTINGS_V1 } from "../../kernel/src/index.ts";
 import { makeRepoCellSettingsActions } from "../src/repo-cell-settings-actions.ts";
 
 test("locale updates stay local and do not append a settings event", async () => {

--- a/packages/gui/src/renderer/views/SettingsView.tsx
+++ b/packages/gui/src/renderer/views/SettingsView.tsx
@@ -162,7 +162,6 @@ export function SettingsView({ repoId }: { readonly repoId: string }) {
                     defaultVertical: draft.defaultVertical,
                     defaultPreset: draft.defaultPreset,
                     defaultProfile: draft.defaultProfile,
-                    locale: draft.locale,
                     taskScaffold: draft.scaffolds.task,
                     repositoryScaffold: draft.scaffolds.repository,
                   })
@@ -222,7 +221,7 @@ export function SettingsView({ repoId }: { readonly repoId: string }) {
                 onChange={(value) => setDraft({ ...draft, scaffolds: { ...draft.scaffolds, repository: value } })}
               />
             </Row>
-            <Row label="实体" desc="规范 Settings 投影">
+            <Row label="归属" desc="repository · 经事件流提交并与协作者同步">
               <span className="font-mono text-[12px] text-text-muted">
                 settings/{draft.settingsId} · {draft.schema}
               </span>
@@ -279,21 +278,26 @@ export function SettingsView({ repoId }: { readonly repoId: string }) {
         );
       case "language":
         return (
-          <Section title={t("settings.language")}>
-            <Row label={t("settings.language")} desc={t("settings.languageDesc")}>
-              <Segmented
+          <Section title="本地设置">
+            <Row label={t("settings.language")} desc="local · 仅保存在本机，不进入事件流或 Git">
+              <select
+                aria-label="语言"
+                className="rounded border border-border bg-surface-raised px-2 py-1 text-[12px] text-text"
                 value={locale}
-                options={[
-                  { key: "zh-CN", label: "中文" },
-                  { key: "en-US", label: t("views.settingsView.english") },
-                ]}
-                onChange={(next) => {
+                onChange={(event) => {
+                  const next = event.currentTarget.value as "zh-CN" | "en-US";
                   setLocale(next);
                   setDraft((current) => (current ? { ...current, locale: next } : current));
                   settingsMutation.mutate({ locale: next });
                 }}
-              />
+              >
+                <option value="zh-CN">中文</option>
+                <option value="en-US">{t("views.settingsView.english")}</option>
+              </select>
             </Row>
+            {settingsMutation.error ? (
+              <div className="px-3 py-2 text-[12px] text-danger">{String(settingsMutation.error)}</div>
+            ) : null}
           </Section>
         );
       case "shortcuts":
@@ -405,7 +409,7 @@ export function SettingsView({ repoId }: { readonly repoId: string }) {
     <div className="flex flex-1 flex-col overflow-y-auto">
       <header className="border-b border-border px-4 py-3">
         <h1 className="ui-title font-mono font-semibold">{t("settings.title")}</h1>
-        <p className="ui-meta mt-0.5 text-text-faint">仓库默认值由守护进程提交到 harness.yaml；外观偏好保留在本机。</p>
+        <p className="ui-meta mt-0.5 text-text-faint">仓库约定提交到 harness.yaml；个人偏好保存在本机。</p>
       </header>
 
       <div

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -160,13 +160,11 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
         repository: "governance/repository-scaffold.json",
       },
     });
-    // settings-update 只接受 catalog 内的 preset/profile(6b642a426):本仓库
-    // bundled catalog 的另一个 preset 是 docs-task,profile 同为 baseline。
     const settingsUpdated = parseDaemonGuiActionResponse(
       "repo.settings.update",
       await bridge.invoke("updateSettings", {
         ...scope,
-        defaultPreset: "docs-task",
+        defaultPreset: "strict-task",
         locale: "zh-CN",
         idempotencyKey: "gui-settings-update-1",
       }),
@@ -182,7 +180,7 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
           path.join(fixture.rootDir, "harness"),
           "log",
           "--all",
-          "-SdefaultPreset: docs-task",
+          "-SdefaultPreset: strict-task",
           "--format=%H",
           "--",
           "harness.yaml",
@@ -193,11 +191,15 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
     }
     assert.match(settingsCommit, /^[0-9a-f]{40}$/u, "Settings update must become reachable in a daemon commit");
     const settingsAfter = parseDaemonGuiReadResult("repo.settings.read", await bridge.invoke("getSettings", scope));
-    assert.equal(settingsAfter.settings.defaultPreset, "docs-task");
+    assert.equal(settingsAfter.settings.defaultPreset, "strict-task");
     assert.equal(settingsAfter.settings.locale, "zh-CN");
     const harnessYaml = readFileSync(path.join(fixture.rootDir, "harness/harness.yaml"), "utf8");
-    assert.match(harnessYaml, /defaultPreset: docs-task/u);
-    assert.match(harnessYaml, /locale: zh-CN/u);
+    assert.match(harnessYaml, /defaultPreset: strict-task/u);
+    assert.doesNotMatch(harnessYaml, /^  locale:/mu);
+    assert.deepEqual(JSON.parse(readFileSync(path.join(fixture.rootDir, ".harness/settings.local.json"), "utf8")), {
+      schema: "settings-local/v1",
+      locale: "zh-CN",
+    });
     assert.match(harnessYaml, /wipLimit: 30/u);
     const observability = parseDaemonGuiReadResult("observe.tail", results.get("observe.tail"));
     assert.equal(observability.schema, "daemon.observe-tail/v3");

--- a/packages/gui/test/service-bridge.test.ts
+++ b/packages/gui/test/service-bridge.test.ts
@@ -164,7 +164,7 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
       "repo.settings.update",
       await bridge.invoke("updateSettings", {
         ...scope,
-        defaultPreset: "strict-task",
+        defaultPreset: "docs-task",
         locale: "zh-CN",
         idempotencyKey: "gui-settings-update-1",
       }),
@@ -180,7 +180,7 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
           path.join(fixture.rootDir, "harness"),
           "log",
           "--all",
-          "-SdefaultPreset: strict-task",
+          "-SdefaultPreset: docs-task",
           "--format=%H",
           "--",
           "harness.yaml",
@@ -191,10 +191,10 @@ test("GUI client reaches every shipped read through a real resident daemon", asy
     }
     assert.match(settingsCommit, /^[0-9a-f]{40}$/u, "Settings update must become reachable in a daemon commit");
     const settingsAfter = parseDaemonGuiReadResult("repo.settings.read", await bridge.invoke("getSettings", scope));
-    assert.equal(settingsAfter.settings.defaultPreset, "strict-task");
+    assert.equal(settingsAfter.settings.defaultPreset, "docs-task");
     assert.equal(settingsAfter.settings.locale, "zh-CN");
     const harnessYaml = readFileSync(path.join(fixture.rootDir, "harness/harness.yaml"), "utf8");
-    assert.match(harnessYaml, /defaultPreset: strict-task/u);
+    assert.match(harnessYaml, /defaultPreset: docs-task/u);
     assert.doesNotMatch(harnessYaml, /^  locale:/mu);
     assert.deepEqual(JSON.parse(readFileSync(path.join(fixture.rootDir, ".harness/settings.local.json"), "utf8")), {
       schema: "settings-local/v1",

--- a/packages/gui/test/system-group-widescreen.vitest.ts
+++ b/packages/gui/test/system-group-widescreen.vitest.ts
@@ -303,15 +303,18 @@ describe("Settings kind renderer consumes and updates the daemon-owned facet", (
       repoId: REPO_ID,
       defaultPreset: "docs-task",
       defaultProfile: "prose",
-      locale: "zh-CN",
     });
+    expect(updateSettings.mock.calls[0]?.[0]).not.toHaveProperty("locale");
 
     const languageTab = [...container.querySelectorAll("button")].find((button) =>
       button.textContent?.includes("语言"),
     )!;
     await act(async () => languageTab.click());
-    const english = [...container.querySelectorAll("button")].find((button) => button.textContent === "English")!;
-    await act(async () => english.click());
+    const language = container.querySelector('select[aria-label="语言"]') as HTMLSelectElement;
+    await act(async () => {
+      language.value = "en-US";
+      language.dispatchEvent(new Event("change", { bubbles: true }));
+    });
     expect(updateSettings.mock.calls.at(-1)?.[0]).toMatchObject({ repoId: REPO_ID, locale: "en-US" });
   });
 });

--- a/packages/kernel/schemas/json/harness-config.schema.json
+++ b/packages/kernel/schemas/json/harness-config.schema.json
@@ -14,7 +14,6 @@
     "settings": {
       "type": "object",
       "properties": {
-        "locale": { "enum": ["zh-CN", "en-US"] },
         "defaultVertical": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9/_@.-]*$" },
         "defaultPreset": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9/_@.-]*$" },
         "defaultProfile": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9/_@.-]*$" },

--- a/packages/kernel/src/domain/entity-json-schema.ts
+++ b/packages/kernel/src/domain/entity-json-schema.ts
@@ -23,7 +23,11 @@ export type EntityJsonSchemaNode = (
       readonly description?: string;
     }
   | EntityJsonObjectSchema
-) & { readonly "x-error"?: string; readonly "x-nullable"?: boolean };
+) & {
+  readonly "x-error"?: string;
+  readonly "x-nullable"?: boolean;
+  readonly "x-settings-ownership"?: "repository" | "local";
+};
 
 export interface EntityJsonObjectSchema {
   readonly type: "object";

--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -22,7 +22,7 @@ import type { PolicyActionRule, PolicyPredicateName } from "./policy.ts";
 import { canonicalRelationDirections } from "./relation-direction.ts";
 import { reviewVerdicts } from "./review.ts";
 import { SCHEDULE_V1_SCHEMA, scheduleEventTypes, scheduleRunOutcomes, scheduleStates } from "./schedule.ts";
-import { SETTINGS_V1_SCHEMA } from "./settings.ts";
+import { SETTINGS_REPOSITORY_V1_SCHEMA } from "./settings.ts";
 import { PERSON_V1_SCHEMA } from "./people-roster.ts";
 import { TASK_LIFECYCLE_TRANSITIONS } from "./task-lifecycle-transitions.ts";
 import {
@@ -678,7 +678,7 @@ export const entityKindContracts = Object.freeze([
   {
     kind: "settings",
     residency: Object.freeze({ authored: "ledger" as const, current: "projection" as const }),
-    schema: SETTINGS_V1_SCHEMA,
+    schema: SETTINGS_REPOSITORY_V1_SCHEMA,
     id: settingsIdentity,
     relations: { directions: [], edges: [] },
     canonicalProjection: {

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -174,22 +174,16 @@ export {
 
 export {
   INITIAL_SETTINGS_V1,
-  SETTINGS_FIELD_OWNERSHIP,
   SETTINGS_LOCAL_PATH,
-  SETTINGS_LOCAL_V1_SCHEMA,
-  SETTINGS_REPOSITORY_V1_SCHEMA,
-  SETTINGS_V1_SCHEMA,
   parseLocalSettings,
   readSettingsFacet,
   repositorySettings,
   serializeLocalSettings,
-  validateLocalSettingsV1,
   validateRepositorySettings,
   validateSettingsV1,
   writeRepositorySettingsFacet,
-  writeSettingsFacet,
 } from "./settings.ts";
-export type { LocalSettingsV1, RepositorySettingsV1, SettingsLocale, SettingsV1 } from "./settings.ts";
+export type { RepositorySettingsV1, SettingsLocale, SettingsV1 } from "./settings.ts";
 export { compileSettingsChangedEvent } from "./settings-event.ts";
 export {
   applyPeopleRosterAction,

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -172,8 +172,24 @@ export {
   isScheduleEvent,
 } from "./schedule-event.ts";
 
-export { INITIAL_SETTINGS_V1, readSettingsFacet, validateSettingsV1, writeSettingsFacet } from "./settings.ts";
-export type { SettingsV1 } from "./settings.ts";
+export {
+  INITIAL_SETTINGS_V1,
+  SETTINGS_FIELD_OWNERSHIP,
+  SETTINGS_LOCAL_PATH,
+  SETTINGS_LOCAL_V1_SCHEMA,
+  SETTINGS_REPOSITORY_V1_SCHEMA,
+  SETTINGS_V1_SCHEMA,
+  parseLocalSettings,
+  readSettingsFacet,
+  repositorySettings,
+  serializeLocalSettings,
+  validateLocalSettingsV1,
+  validateRepositorySettings,
+  validateSettingsV1,
+  writeRepositorySettingsFacet,
+  writeSettingsFacet,
+} from "./settings.ts";
+export type { LocalSettingsV1, RepositorySettingsV1, SettingsLocale, SettingsV1 } from "./settings.ts";
 export { compileSettingsChangedEvent } from "./settings-event.ts";
 export {
   applyPeopleRosterAction,

--- a/packages/kernel/src/domain/settings-event.ts
+++ b/packages/kernel/src/domain/settings-event.ts
@@ -1,6 +1,13 @@
 import { sha256Text, stableStringify } from "../integrity/stable-hash.ts";
 import { eventObjectTarget } from "../layout/ledger-object-layout.ts";
-import { SETTINGS_ID, readSettingsFacet, validateSettingsV1, type SettingsV1 } from "./settings.ts";
+import {
+  SETTINGS_ID,
+  readSettingsFacet,
+  repositorySettings,
+  validateRepositorySettings,
+  type RepositorySettingsV1,
+  type SettingsV1,
+} from "./settings.ts";
 import {
   freezeDeclaredWritePlan,
   hasContractFields,
@@ -30,7 +37,7 @@ export type SettingsEventV1 = EventEnvelope<
   "settings_changed",
   ActorIdentity,
   {
-    readonly settings: SettingsV1;
+    readonly settings: RepositorySettingsV1;
     readonly harnessDocumentClaim: SettingsDocumentClaim;
     readonly baseDocumentSha256: string;
   }
@@ -45,7 +52,7 @@ export interface SettingsEventBundle {
 }
 
 export function compileSettingsChangedEvent(input: {
-  readonly settings: SettingsV1;
+  readonly settings: RepositorySettingsV1 | SettingsV1;
   readonly baseDocumentBody: string;
   readonly candidateDocumentBody: string;
   readonly eventId: string;
@@ -55,7 +62,8 @@ export function compileSettingsChangedEvent(input: {
   readonly source: WriteSource;
   readonly occurredAt: string;
 }): SettingsEventBundle {
-  const claim: SettingsDocumentClaim = {
+  const settings = repositorySettings(input.settings),
+    claim: SettingsDocumentClaim = {
       path: "harness.yaml",
       sha256: sha256Text(input.candidateDocumentBody),
       size: Buffer.byteLength(input.candidateDocumentBody),
@@ -73,7 +81,7 @@ export function compileSettingsChangedEvent(input: {
       source: input.source,
       occurredAt: input.occurredAt,
       payload: {
-        settings: input.settings,
+        settings,
         harnessDocumentClaim: claim,
         baseDocumentSha256: sha256Text(input.baseDocumentBody),
       },
@@ -122,20 +130,27 @@ function validateSettingsEventFields(value: unknown, allowUnknownFields: boolean
 }
 
 function validSettingsSnapshot(value: unknown, allowUnknownFields: boolean): boolean {
-  if (!allowUnknownFields) return validateSettingsV1(value).length === 0;
   if (!isRecord(value) || !isRecord(value.scaffolds)) return false;
-  return (
-    validateSettingsV1({
+  const normalized = {
       schema: value.schema,
       settingsId: value.settingsId,
       defaultVertical: value.defaultVertical,
       defaultPreset: value.defaultPreset,
       defaultProfile: value.defaultProfile,
-      locale: value.locale,
       scaffolds: {
         task: value.scaffolds.task,
         repository: value.scaffolds.repository,
       },
+    },
+    current = validateRepositorySettings(normalized).length === 0;
+  if (!current) return false;
+  if (!allowUnknownFields)
+    return Object.keys(value).every((field) =>
+      ["schema", "settingsId", "defaultVertical", "defaultPreset", "defaultProfile", "scaffolds"].includes(field),
+    );
+  return (
+    validateRepositorySettings({
+      ...normalized,
     }).length === 0
   );
 }
@@ -185,7 +200,10 @@ export function assertSettingsEventInputs(
     blob = blobs.find((candidate) => candidate.sha256 === claim.sha256);
   if (!blob || blob.size !== claim.size || blob.mediaType !== claim.mediaType || sha256Text(blob.body) !== claim.sha256)
     throw new Error("settings harness.yaml blob must be exact");
-  if (stableStringify(readSettingsFacet(blob.body)) !== stableStringify(event.payload.settings))
+  if (
+    stableStringify(repositorySettings(readSettingsFacet(blob.body))) !==
+    stableStringify(repositorySettings(event.payload.settings))
+  )
     throw new Error("settings harness.yaml blob must contain the exact settings facet");
 }
 

--- a/packages/kernel/src/domain/settings.ts
+++ b/packages/kernel/src/domain/settings.ts
@@ -3,8 +3,34 @@ import type { EntityDocumentJsonSchema } from "./entity-json-schema.ts";
 import { validateEntityJsonSchema } from "./entity-json-schema.ts";
 
 export const SETTINGS_ID = "repository";
+export const SETTINGS_LOCAL_PATH = ".harness/settings.local.json";
 export const settingsLocales = ["en-US", "zh-CN"] as const;
 export type SettingsLocale = (typeof settingsLocales)[number];
+
+export const SETTINGS_FIELD_OWNERSHIP = Object.freeze({
+  defaultVertical: "repository",
+  defaultPreset: "repository",
+  defaultProfile: "repository",
+  locale: "local",
+  scaffolds: "repository",
+} as const);
+
+export interface RepositorySettingsV1 {
+  readonly schema: "settings/v1";
+  readonly settingsId: typeof SETTINGS_ID;
+  readonly defaultVertical: string;
+  readonly defaultPreset: string;
+  readonly defaultProfile: string;
+  readonly scaffolds: {
+    readonly task: string;
+    readonly repository: string;
+  };
+}
+
+export interface LocalSettingsV1 {
+  readonly schema: "settings-local/v1";
+  readonly locale: SettingsLocale;
+}
 
 export interface SettingsV1 {
   readonly schema: "settings/v1";
@@ -18,6 +44,18 @@ export interface SettingsV1 {
     readonly repository: string;
   };
 }
+
+export const SETTINGS_LOCAL_V1_SCHEMA: EntityDocumentJsonSchema<LocalSettingsV1> = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  $id: "SettingsLocal/v1",
+  type: "object",
+  properties: {
+    schema: { type: "string", const: "settings-local/v1" },
+    locale: { type: "string", enum: settingsLocales, "x-settings-ownership": "local" },
+  },
+  required: ["schema", "locale"],
+  additionalProperties: false,
+};
 
 export const INITIAL_SETTINGS_V1: SettingsV1 = Object.freeze({
   schema: "settings/v1",
@@ -41,15 +79,41 @@ export const SETTINGS_V1_SCHEMA: EntityDocumentJsonSchema<SettingsV1> = {
   properties: {
     schema: { type: "string", const: "settings/v1" },
     settingsId: { type: "string", const: SETTINGS_ID },
-    defaultVertical: { type: "string", pattern: settingValuePattern, minLength: 1 },
-    defaultPreset: { type: "string", pattern: settingValuePattern, minLength: 1 },
-    defaultProfile: { type: "string", pattern: settingValuePattern, minLength: 1 },
-    locale: { type: "string", enum: settingsLocales },
+    defaultVertical: {
+      type: "string",
+      pattern: settingValuePattern,
+      minLength: 1,
+      "x-settings-ownership": "repository",
+    },
+    defaultPreset: {
+      type: "string",
+      pattern: settingValuePattern,
+      minLength: 1,
+      "x-settings-ownership": "repository",
+    },
+    defaultProfile: {
+      type: "string",
+      pattern: settingValuePattern,
+      minLength: 1,
+      "x-settings-ownership": "repository",
+    },
+    locale: { type: "string", enum: settingsLocales, "x-settings-ownership": "local" },
     scaffolds: {
+      "x-settings-ownership": "repository",
       type: "object",
       properties: {
-        task: { type: "string", pattern: settingValuePattern, minLength: 1 },
-        repository: { type: "string", pattern: settingValuePattern, minLength: 1 },
+        task: {
+          type: "string",
+          pattern: settingValuePattern,
+          minLength: 1,
+          "x-settings-ownership": "repository",
+        },
+        repository: {
+          type: "string",
+          pattern: settingValuePattern,
+          minLength: 1,
+          "x-settings-ownership": "repository",
+        },
       },
       required: ["task", "repository"],
       additionalProperties: false,
@@ -59,8 +123,75 @@ export const SETTINGS_V1_SCHEMA: EntityDocumentJsonSchema<SettingsV1> = {
   additionalProperties: false,
 };
 
+/** Event/projection shape. The legacy optional locale is accepted only for replay compatibility. */
+export const SETTINGS_REPOSITORY_V1_SCHEMA: EntityDocumentJsonSchema<RepositorySettingsV1> = {
+  $id: "SettingsRepository/v1",
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  type: "object",
+  properties: {
+    schema: { type: "string", const: "settings/v1" },
+    settingsId: { type: "string", const: SETTINGS_ID },
+    defaultVertical: {
+      type: "string",
+      pattern: settingValuePattern,
+      minLength: 1,
+      "x-settings-ownership": "repository",
+    },
+    defaultPreset: { type: "string", pattern: settingValuePattern, minLength: 1, "x-settings-ownership": "repository" },
+    defaultProfile: {
+      type: "string",
+      pattern: settingValuePattern,
+      minLength: 1,
+      "x-settings-ownership": "repository",
+    },
+    scaffolds: {
+      "x-settings-ownership": "repository",
+      type: "object",
+      properties: {
+        task: { type: "string", pattern: settingValuePattern, minLength: 1, "x-settings-ownership": "repository" },
+        repository: {
+          type: "string",
+          pattern: settingValuePattern,
+          minLength: 1,
+          "x-settings-ownership": "repository",
+        },
+      },
+      required: ["task", "repository"],
+      additionalProperties: false,
+    },
+  },
+  required: ["schema", "settingsId", "defaultVertical", "defaultPreset", "defaultProfile", "scaffolds"],
+  additionalProperties: false,
+};
+
 export function validateSettingsV1(value: unknown): readonly string[] {
   return validateEntityJsonSchema(SETTINGS_V1_SCHEMA, value, "settings");
+}
+
+export function repositorySettings(settings: SettingsV1 | RepositorySettingsV1): RepositorySettingsV1 {
+  return {
+    schema: "settings/v1",
+    settingsId: SETTINGS_ID,
+    defaultVertical: settings.defaultVertical,
+    defaultPreset: settings.defaultPreset,
+    defaultProfile: settings.defaultProfile,
+    scaffolds: { task: settings.scaffolds.task, repository: settings.scaffolds.repository },
+  };
+}
+
+export function validateLocalSettingsV1(value: unknown): readonly string[] {
+  return validateEntityJsonSchema(SETTINGS_LOCAL_V1_SCHEMA, value, "local settings");
+}
+
+export function serializeLocalSettings(locale: SettingsLocale): string {
+  const value: LocalSettingsV1 = { schema: "settings-local/v1", locale },
+    errors = validateLocalSettingsV1(value);
+  if (errors.length) throw new Error(errors.join("; "));
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+export function parseLocalSettings(value: unknown): LocalSettingsV1 | null {
+  return validateLocalSettingsV1(value).length ? null : (value as LocalSettingsV1);
 }
 
 export function readSettingsFacet(body: string): SettingsV1 {
@@ -84,40 +215,73 @@ export function readSettingsFacet(body: string): SettingsV1 {
 export function writeSettingsFacet(body: string, settings: SettingsV1): string {
   const errors = validateSettingsV1(settings);
   if (errors.length) throw new Error(errors.join("; "));
+  const next = writeRepositorySettingsFacet(body, settings);
+  if (JSON.stringify(repositorySettings(readSettingsFacet(next))) !== JSON.stringify(repositorySettings(settings)))
+    throw new Error("settings facet replacement did not round-trip exactly");
+  return next;
+}
+
+/** Replace repository-owned YAML fields and remove the legacy authored locale line. */
+export function writeRepositorySettingsFacet(body: string, settings: RepositorySettingsV1 | SettingsV1): string {
+  const repository = repositorySettings(settings),
+    errors = validateRepositorySettings(repository);
+  if (errors.length) throw new Error(errors.join("; "));
   let next = body;
   next = replaceDefaultedScalar(
     next,
     "  ",
     "defaultVertical",
-    settings.defaultVertical,
+    repository.defaultVertical,
     INITIAL_SETTINGS_V1.defaultVertical,
   );
-  next = replaceDefaultedScalar(next, "  ", "defaultPreset", settings.defaultPreset, INITIAL_SETTINGS_V1.defaultPreset);
+  next = replaceDefaultedScalar(
+    next,
+    "  ",
+    "defaultPreset",
+    repository.defaultPreset,
+    INITIAL_SETTINGS_V1.defaultPreset,
+  );
   next = replaceDefaultedScalar(
     next,
     "  ",
     "defaultProfile",
-    settings.defaultProfile,
+    repository.defaultProfile,
     INITIAL_SETTINGS_V1.defaultProfile,
   );
-  next = replaceDefaultedScalar(next, "  ", "locale", settings.locale, INITIAL_SETTINGS_V1.locale);
   next = replaceDefaultedBlockScalar(
     next,
     "scaffolds",
     "task",
-    settings.scaffolds.task,
+    repository.scaffolds.task,
     INITIAL_SETTINGS_V1.scaffolds.task,
   );
   next = replaceDefaultedBlockScalar(
     next,
     "scaffolds",
     "repository",
-    settings.scaffolds.repository,
+    repository.scaffolds.repository,
     INITIAL_SETTINGS_V1.scaffolds.repository,
   );
-  if (JSON.stringify(readSettingsFacet(next)) !== JSON.stringify(settings))
-    throw new Error("settings facet replacement did not round-trip exactly");
+  next = removeLegacyLocale(next);
+  if (JSON.stringify(repositorySettings(readSettingsFacet(next))) !== JSON.stringify(repository))
+    throw new Error("repository settings facet replacement did not round-trip exactly");
   return next;
+}
+
+function removeLegacyLocale(body: string): string {
+  const header = /^settings:[^\r\n]*(?:\r?\n|$)/mu,
+    match = header.exec(body);
+  if (!match || match.index === undefined) return body;
+  const contentStart = match.index + match[0].length,
+    remainder = body.slice(contentStart),
+    nextTopLevel = remainder.search(/^[^\s][^\r\n]*(?:\r?\n|$)/mu),
+    end = nextTopLevel < 0 ? body.length : contentStart + nextTopLevel,
+    cleaned = body.slice(match.index, end).replace(/^  locale:[^\r\n]*(?:\r?\n|$)/mu, "");
+  return `${body.slice(0, match.index)}${cleaned}${body.slice(end)}`;
+}
+
+export function validateRepositorySettings(value: unknown): readonly string[] {
+  return validateEntityJsonSchema(SETTINGS_REPOSITORY_V1_SCHEMA, value, "repository settings");
 }
 
 function replaceScalar(body: string, indent: string, key: string, value: string): string {

--- a/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-event-application.ts
@@ -27,7 +27,7 @@ import { isTaskProgressEvent } from "../domain/task-progress-event.ts";
 import { isPresetSnapshotUpgradeEvent } from "../domain/preset-snapshot-upgrade-event.ts";
 import { isScheduleEvent } from "../domain/schedule-event.ts";
 import { isSettingsEvent } from "../domain/settings-event.ts";
-import { readSettingsFacet } from "../domain/settings.ts";
+import { readSettingsFacet, repositorySettings } from "../domain/settings.ts";
 import { isPeopleEvent } from "../domain/people-event.ts";
 import { isCiRunObservationEvent } from "../domain/ci-run-observation-event.ts";
 import { parsePeopleRosterDocument } from "../domain/people-roster.ts";
@@ -223,7 +223,10 @@ export function applyEvent(
       throw new Error(`settings harness.yaml blob ${claim.sha256} is not UTF-8`);
     }
     if (sha256Text(body) !== claim.sha256) throw new Error(`settings harness.yaml blob ${claim.sha256} hash mismatch`);
-    if (canonicalJson(readSettingsFacet(body)) !== canonicalJson(event.payload.settings))
+    if (
+      canonicalJson(repositorySettings(readSettingsFacet(body))) !==
+      canonicalJson(repositorySettings(event.payload.settings))
+    )
       throw new Error(`settings harness.yaml blob ${claim.sha256} does not match the event settings facet`);
     const document: DocumentState = {
       path: claim.path as DocumentState["path"],

--- a/packages/kernel/src/schemas/registry.ts
+++ b/packages/kernel/src/schemas/registry.ts
@@ -75,7 +75,6 @@ export const HarnessConfigSchema = Schema.Struct({
   }),
   settings: Schema.optional(
     Schema.Struct({
-      locale: Schema.optional(LocaleSchema),
       defaultVertical: Schema.optional(ConfigIdentifierSchema),
       defaultPreset: Schema.optional(ConfigIdentifierSchema),
       defaultProfile: Schema.optional(ConfigIdentifierSchema),

--- a/packages/kernel/src/store/task-event-store-publication-audit.ts
+++ b/packages/kernel/src/store/task-event-store-publication-audit.ts
@@ -10,7 +10,7 @@ import { isLedgerLayoutMigrationEvent } from "../domain/ledger-layout-migration-
 import { isSettingsEvent } from "../domain/settings-event.ts";
 import { isPeopleEvent } from "../domain/people-event.ts";
 import { parsePeopleRosterDocument, serializePeopleRosterDocument } from "../domain/people-roster.ts";
-import { writeSettingsFacet } from "../domain/settings.ts";
+import { writeRepositorySettingsFacet } from "../domain/settings.ts";
 import { serializeEventHead, type EventHead } from "../domain/write-chain.contract.ts";
 import { ledgerGitPath, type LedgerGitLayout } from "./ledger-git-layout.ts";
 import {
@@ -173,7 +173,8 @@ export function assertAuthorizedReplacement(
         "invalid_write_plan",
         "Settings replacement authorization requires candidate bytes",
       );
-    if (candidateBody !== writeSettingsFacet(committed, event.payload.settings))
+    const expected = writeRepositorySettingsFacet(committed, event.payload.settings);
+    if (candidateBody !== expected)
       throw new TaskEventStoreError(
         "invalid_write_plan",
         "Settings may change only their owned harness.yaml facet fields",

--- a/packages/kernel/test/contracts/settings-event.test.ts
+++ b/packages/kernel/test/contracts/settings-event.test.ts
@@ -3,7 +3,14 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { sha256Text } from "../../src/integrity/stable-hash.ts";
 import { compileSettingsChangedEvent, validateSettingsEvent } from "../../src/domain/settings-event.ts";
-import { readSettingsFacet, writeSettingsFacet, type SettingsV1 } from "../../src/domain/settings.ts";
+import {
+  SETTINGS_FIELD_OWNERSHIP,
+  SETTINGS_V1_SCHEMA,
+  readSettingsFacet,
+  repositorySettings,
+  writeSettingsFacet,
+  type SettingsV1,
+} from "../../src/domain/settings.ts";
 
 const original = [
   "schema: harness-anything/v1",
@@ -25,6 +32,19 @@ const original = [
   "",
 ].join("\n");
 
+test("every Settings business field declares repository or local ownership", () => {
+  const businessFields = Object.keys(SETTINGS_V1_SCHEMA.properties).filter(
+    (field) => field !== "schema" && field !== "settingsId",
+  );
+  assert.deepEqual(businessFields.sort(), Object.keys(SETTINGS_FIELD_OWNERSHIP).sort());
+  for (const field of businessFields)
+    assert.equal(
+      SETTINGS_V1_SCHEMA.properties[field]!["x-settings-ownership"],
+      SETTINGS_FIELD_OWNERSHIP[field as keyof typeof SETTINGS_FIELD_OWNERSHIP],
+      field,
+    );
+});
+
 test("Settings facet codec changes owned fields and preserves every unowned byte", () => {
   const settings: SettingsV1 = {
       ...readSettingsFacet(original),
@@ -33,11 +53,12 @@ test("Settings facet codec changes owned fields and preserves every unowned byte
     },
     candidate = writeSettingsFacet(original, settings);
 
-  assert.deepEqual(readSettingsFacet(candidate), settings);
+  assert.deepEqual(repositorySettings(readSettingsFacet(candidate)), repositorySettings(settings));
   assert.equal(candidate.includes("defaultPreset: strict-task # owned"), true);
   assert.equal(candidate.includes("    wipLimit: 60"), true);
   assert.equal(candidate.includes("    enabled: true"), true);
-  assert.equal(candidate.replace("strict-task", "standard-task").replace("zh-CN", "en-US"), original);
+  assert.equal(candidate.includes("locale: en-US"), false);
+  assert.equal(candidate.replace("strict-task", "standard-task"), original.replace("  locale: en-US\n", ""));
 });
 
 test("settings_changed carries the singleton snapshot, parent CAS, YAML claim, and exact write plan", () => {
@@ -56,6 +77,7 @@ test("settings_changed carries the singleton snapshot, parent CAS, YAML claim, a
     });
 
   assert.deepEqual(validateSettingsEvent(bundle.event), []);
+  assert.equal(Object.hasOwn(bundle.event.payload.settings, "locale"), false);
   assert.equal(bundle.event.entity.id, "repository");
   assert.equal(bundle.event.type, "settings_changed");
   assert.equal(bundle.event.payload.baseDocumentSha256, sha256Text(original));

--- a/packages/kernel/test/store/settings-projection.test.ts
+++ b/packages/kernel/test/store/settings-projection.test.ts
@@ -5,7 +5,12 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { compileSettingsChangedEvent } from "../../src/domain/settings-event.ts";
-import { readSettingsFacet, writeSettingsFacet, type SettingsV1 } from "../../src/domain/settings.ts";
+import {
+  readSettingsFacet,
+  repositorySettings,
+  writeSettingsFacet,
+  type SettingsV1,
+} from "../../src/domain/settings.ts";
 import { makeTaskProjection } from "../../src/projection/task-projection.ts";
 import { makeTaskEventStore } from "../../src/store/task-event-store.ts";
 import { withTempStoreAsync } from "./helpers.ts";
@@ -36,7 +41,7 @@ test(rebuildTitle, async () => {
     eventStore.append(bundle);
     projection.apply(bundle.event, bundle.plan);
     assert.equal(readFileSync(path.join(rootDir, "harness/harness.yaml"), "utf8"), candidate);
-    assert.deepEqual(projection.getEntity("settings", "repository")?.value, settings);
+    assert.deepEqual(projection.getEntity("settings", "repository")?.value, repositorySettings(settings));
     assert.equal(projection.readDocument("harness.yaml").document?.body, candidate);
 
     const liveRow = projection.getEntity("settings", "repository"),


### PR DESCRIPTION
# English

## Summary

Implements dec_77D2C96D7A32E462FAD96DAEB0: every SettingsV1 field now has an explicit owner, `repository` or `local`. `locale` is a local preference: it is merged from and written to `<repo>/.harness/settings.local.json` (already covered by the `.harness*/` gitignore pattern), never enters the event store, the WAL or a git commit. `defaultVertical`/`defaultPreset`/`defaultProfile`/`scaffolds` stay repository settings and keep publishing through `settings_changed` → `harness/harness.yaml`. Reads return the merged view; writes route by ownership. `locale` is removed from the harness-config JSON schema and from the settings event payload, and the GUI SettingsView no longer sends it through the repository write path.

## Architectural Justification

- Production-Delta: +382/-91 exceeds 200 lines. Why one PR: the ownership table, the local file writer, the event-payload narrowing and the GUI write path are one contract; landing the schema removal without the local writer would drop the user's locale. No second state: locale exists in exactly one file; repository settings keep their single event → yaml road.

## What Changed

- Kernel: `settings.ts` ownership table + local settings schema/merge; `settings-event.ts` payload narrowed to repository fields; entity json-schema/kind-registry/index updates; `harness-config.schema.json` drops `locale`.
- Daemon: `repo-cell-settings-actions.ts` routes writes by owner and writes `.harness/settings.local.json` durably (0o600); `repo-mode.ts` admission rows; read merges local file.
- GUI: `SettingsView.tsx` sends locale to the local road.
- Tests: new `repo-settings-local.test.ts`; contract/projection/admission/GUI tests updated.

## Gate Harvest / 门收割

Deleted-Production-Paths: `locale` field in `packages/kernel/schemas/json/harness-config.schema.json`; `locale` in `settings_changed` payload; `SETTINGS_V1_SCHEMA` registry entry in `packages/kernel/src/schemas/registry.ts`
Deleted-Gates-Fixtures: `packages/kernel/test/contracts/settings-event.test.ts` locale-in-payload assertions (replaced by repository-only payload assertions); `packages/kernel/test/store/settings-projection.test.ts` locale projection cases
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +382/-91

### Optional Evidence Claims

## Task And Scope

- Harness task: task_3190c53ff7d9ca862a5ca24637
- Branch: codex/settings-split
- Public scope: packages/kernel (settings, settings-event, schemas), packages/daemon (repo-cell-settings-actions, repo-mode), packages/gui (SettingsView), tests
- Private planning/evidence updated: yes
- Out of scope: GUI settings page partition into repository/local sections (GLM follow-up); migrating existing `locale` values already committed in harness.yaml (they are ignored on read)

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_3190c53ff7d9ca862a5ca24637
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: 263f2e049581a329d0c379a9cc3de58194eb4614
- Branch merge-base with `origin/main`: 263f2e049581a329d0c379a9cc3de58194eb4614
- Last `git fetch origin` time: 2026-08-27
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_3190c53ff7d9ca862a5ca24637 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] kernel settings-event + settings-projection, daemon repo-settings-local + repo-cell-settings integration + command-admission, cli settings-command, gui-s3-contract: 20/20
- [x] GUI `system-group-widescreen.vitest.ts` 9/9; `npm run typecheck` exit 0; `git diff --check` clean
- [x] Rebased onto main 263f2e049 after the six settings-single-authority commits merged; conflicts resolved against current interfaces
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO checked the decision against the diff: locale never reaches the event store (payload narrowed), the local file is gitignored by the existing `.harness*/` pattern (verified with `git check-ignore`), repository fields keep the single yaml road.
- Reviewer subagent: Codex worker (gpt-5.6-sol); CEO semantic acceptance against dec_77D2C96D.
- Human review: pending
- Blocking findings: none

## Residual Risk

- A user whose locale was previously committed in harness.yaml sees the default locale until they set it again; the old value is ignored, not migrated.

## References

- Task: task_3190c53ff7d9ca862a5ca24637
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

落地 dec_77D2C96D7A32E462FAD96DAEB0:SettingsV1 每个字段有显式归属(`repository` | `local`)。`locale` 是本地偏好:从 `<repo>/.harness/settings.local.json` 合并读取并写回(已被 `.harness*/` gitignore 规则覆盖),不进事件存储、WAL 与 git 提交。`defaultVertical`/`defaultPreset`/`defaultProfile`/`scaffolds` 仍是仓库设置,继续经 `settings_changed` → `harness/harness.yaml` 发布。读返回合并视图,写按归属路由。`locale` 从 harness-config JSON schema 与 settings 事件载荷删除,GUI SettingsView 不再把它送进仓库写路。

## 架构辩护

- Production-Delta: +382/-91 超过 200 行。为何一个 PR:归属表、本地文件写入、事件载荷收窄、GUI 写路是同一份契约;只删 schema 不加本地写入会丢掉用户的 locale。不新增第二份状态:locale 只存在于一个文件;仓库设置保持 事件 → yaml 单一通路。

## 改动内容

- Kernel:`settings.ts` 归属表 + 本地设置 schema/合并;`settings-event.ts` 载荷收窄到仓库字段;entity json-schema/kind-registry/index 更新;`harness-config.schema.json` 删 `locale`。
- Daemon:`repo-cell-settings-actions.ts` 按归属路由写入,持久写 `.harness/settings.local.json`(0o600);`repo-mode.ts` 登记 admission;读合并本地文件。
- GUI:`SettingsView.tsx` 把 locale 送本地通路。
- 测试:新增 `repo-settings-local.test.ts`;contract/projection/admission/GUI 测试更新。

## 门收割 / Gate Harvest

- 删除的生产路径:`packages/kernel/schemas/json/harness-config.schema.json` 的 `locale` 字段;`settings_changed` 载荷里的 `locale`;`packages/kernel/src/schemas/registry.ts` 的 `SETTINGS_V1_SCHEMA` 登记
- 同 commit 删除的门 / fixture:`packages/kernel/test/contracts/settings-event.test.ts` 载荷含 locale 的断言(改为仅仓库字段断言);`packages/kernel/test/store/settings-projection.test.ts` 的 locale 投影用例
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_3190c53ff7d9ca862a5ca24637
- 分支:codex/settings-split
- 公开范围:packages/kernel(settings、settings-event、schemas)、packages/daemon(repo-cell-settings-actions、repo-mode)、packages/gui(SettingsView)、测试
- 私有计划 / 证据是否已更新:yes
- 范围外:GUI 设置页按 仓库/本地 分区(GLM 后续);已提交在 harness.yaml 里的旧 `locale` 值不迁移(读时忽略)

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_3190c53ff7d9ca862a5ca24637
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:263f2e049581a329d0c379a9cc3de58194eb4614
- 当前分支与 `origin/main` 的 merge-base:263f2e049581a329d0c379a9cc3de58194eb4614
- 最近一次 `git fetch origin` 时间:2026-08-27
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_3190c53ff7d9ca862a5ca24637
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] kernel settings-event + settings-projection、daemon repo-settings-local + repo-cell-settings 集成 + command-admission、cli settings-command、gui-s3-contract:20/20
- [x] GUI `system-group-widescreen.vitest.ts` 9/9;`npm run typecheck` 退出 0;`git diff --check` 干净
- [x] 六个 settings-single-authority 提交合入后 rebase 到 main 263f2e049,按当前接口解冲突
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 对照决策核 diff:locale 不进事件存储(载荷已收窄)、本地文件被既有 `.harness*/` 规则忽略(`git check-ignore` 实测)、仓库字段保持 yaml 单一通路。
- Reviewer subagent:Codex worker(gpt-5.6-sol);CEO 对照 dec_77D2C96D 做语义验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 此前把 locale 提交进 harness.yaml 的用户会先看到默认语言,重设一次即可;旧值被忽略而非迁移。

## 关联材料

- 任务:task_3190c53ff7d9ca862a5ca24637
- 证据:任务包 artifacts/reports
- 审查:本 PR



