### PR TITLE
fix(daemon): bound dispatch stream hot-path reads instead of parsing 1.2 GB per call

### DIFF
--- a/packages/daemon/src/dispatch-read.ts
+++ b/packages/daemon/src/dispatch-read.ts
@@ -8,7 +8,8 @@ import {
   readDispatchLiveIndex,
   readDispatchStream,
   readDispatchStreamHeader,
-  readDispatchStreams,
+  readDispatchStreamSummary,
+  readDispatchStreamHeaders,
   removeDispatchLiveIndexEntries,
   type DispatchStreamHeader,
 } from "./dispatch-stream.ts";
@@ -68,7 +69,9 @@ export function readTaskDispatches(
   }
   const rows = new Map<string, TaskDispatchRow>();
   for (const [dispatchId, candidate] of candidates) {
-    const stream = /^dispatch_[a-f0-9]{24}$/u.test(dispatchId) ? readDispatchStream(input.rootDir, dispatchId) : null,
+    const stream = /^dispatch_[a-f0-9]{24}$/u.test(dispatchId)
+        ? readDispatchStreamSummary(input.rootDir, dispatchId)
+        : null,
       lost =
         stream?.records.some((record) => record.kind === "process_lost") === true ||
         (stream?.process?.exited === false &&
@@ -158,11 +161,18 @@ export function readRuntimeAttemptChain(
   rootDir: string,
   runtimeSessionId: string,
 ): AgentRuntimeAttemptChainDto | undefined {
-  const streams = readDispatchStreams(rootDir),
-    target = streams.find((stream) => stream.header.runtimeSessionId === runtimeSessionId);
+  const headers = readDispatchStreamHeaders(rootDir),
+    targetHeader = headers.find((header) => header.runtimeSessionId === runtimeSessionId);
+  if (!targetHeader) return undefined;
+  const target = readDispatchStreamSummary(rootDir, targetHeader.dispatchId);
   if (!target) return undefined;
   const groupId = attemptGroupId(target),
-    attempts = streams
+    attempts = headers
+      .filter(
+        (header) => header.dispatchId === targetHeader.dispatchId || header.fallbackAttempt?.attemptGroupId === groupId,
+      )
+      .map((header) => readDispatchStreamSummary(rootDir, header.dispatchId))
+      .filter((stream): stream is NonNullable<ReturnType<typeof readDispatchStream>> => stream !== null)
       .filter((stream) => attemptGroupId(stream) === groupId)
       .map((stream) => ({
         dispatchId: stream.header.dispatchId,

--- a/packages/daemon/src/dispatch-stream.ts
+++ b/packages/daemon/src/dispatch-stream.ts
@@ -112,6 +112,30 @@ export interface DispatchLiveIndex {
   readonly entries: readonly DispatchLiveIndexEntry[];
 }
 
+/** Metadata needed by daemon hot paths without retaining provider event bodies. */
+export type DispatchStreamSummary = Omit<NonNullable<ReturnType<typeof readDispatchStream>>, "records"> & {
+  readonly records: readonly DispatchStreamRecord[];
+};
+
+type SummaryCacheEntry = {
+  readonly mtimeMs: number;
+  readonly size: number;
+  readonly value: DispatchStreamSummary | null;
+};
+
+const summaryCache = new Map<string, SummaryCacheEntry>();
+const summaryHeadBytes = 16 * 1024;
+const summaryTailBytes = 128 * 1024;
+const summaryKinds = new Set([
+  "provider_binding",
+  "process_started",
+  "process_exit",
+  "process_lost",
+  "attempt_outcome",
+  "fallback_state",
+  "squad_run_state",
+]);
+
 export function openDispatchStream(
   rootDir: string,
   header: Omit<DispatchStreamHeader, "schema" | "kind" | "eventStreamRef">,
@@ -163,6 +187,7 @@ export function reopenDispatchStream(rootDir: string, header: DispatchStreamHead
 export function removeDispatchStream(rootDir: string, dispatchId: string): void {
   const target = dispatchStreamPath(rootDir, dispatchId),
     header = readDispatchStreamHeader(rootDir, dispatchId);
+  summaryCache.delete(target);
   if (existsSync(target)) unlinkSync(target);
   if (header?.taskId)
     removeDispatchLiveIndexEntries(rootDir, [
@@ -239,6 +264,59 @@ export function readDispatchStreamHeader(rootDir: string, dispatchId: string): D
   return isHeader(first) && first.dispatchId === dispatchId ? first : null;
 }
 
+/**
+ * Read lifecycle metadata without loading provider output. Lifecycle records are
+ * written at the head or tail of a stream; the bounded windows keep daemon
+ * scans proportional to stream count rather than provider transcript size.
+ */
+export function readDispatchStreamSummary(rootDir: string, dispatchId: string): DispatchStreamSummary | null {
+  const target = dispatchStreamPath(rootDir, dispatchId);
+  if (!existsSync(target) || !statSync(target).isFile()) {
+    summaryCache.delete(target);
+    return null;
+  }
+  const stat = statSync(target),
+    cached = summaryCache.get(target);
+  if (cached?.mtimeMs === stat.mtimeMs && cached.size === stat.size) return cached.value;
+  const header = readDispatchStreamHeader(rootDir, dispatchId);
+  if (!header) {
+    summaryCache.set(target, { mtimeMs: stat.mtimeMs, size: stat.size, value: null });
+    return null;
+  }
+  const headerEnd = firstLineEndOffset(target, stat.size);
+  const chunks = readBoundedStreamWindows(target, stat.size, headerEnd),
+    records: DispatchStreamRecord[] = [];
+  const seenOffsets = new Set<number>();
+  for (const chunk of chunks) {
+    for (const line of completeLines(chunk.text, chunk.offset, stat.size)) {
+      if (line.offset === 0 || seenOffsets.has(line.offset)) continue;
+      seenOffsets.add(line.offset);
+      const kind = lineKind(line.value);
+      if (!kind || !summaryKinds.has(kind)) continue;
+      const record = parseRecord(line.value);
+      if (record) records.push(record);
+    }
+  }
+  const value = summarizeDispatch(header, records);
+  summaryCache.set(target, { mtimeMs: stat.mtimeMs, size: stat.size, value });
+  return value;
+}
+
+export function readDispatchStreamHeaders(rootDir: string): readonly DispatchStreamHeader[] {
+  const root = dispatchStreamRoot(rootDir);
+  if (!existsSync(root) || !statSync(root).isDirectory()) return [];
+  return readdirSync(root)
+    .filter((name) => /^dispatch_[a-f0-9]{24}\.jsonl$/u.test(name))
+    .map((name) => readDispatchStreamHeader(rootDir, name.slice(0, -6)))
+    .filter((header): header is DispatchStreamHeader => header !== null);
+}
+
+export function readDispatchStreamSummaries(rootDir: string): readonly DispatchStreamSummary[] {
+  return readDispatchStreamHeaders(rootDir)
+    .map((header) => readDispatchStreamSummary(rootDir, header.dispatchId))
+    .filter((stream): stream is DispatchStreamSummary => stream !== null);
+}
+
 export function readDispatchStream(
   rootDir: string,
   dispatchId: string,
@@ -260,54 +338,13 @@ export function readDispatchStream(
   const lines = readFileSync(target, "utf8").split(/\r?\n/u).filter(Boolean),
     first = parseRecord(lines[0]);
   if (!isHeader(first) || first.dispatchId !== dispatchId) return null;
-  let providerSessionId: string | null = null,
-    processState: DispatchProcessState | null = null,
-    attemptOutcome: RuntimeAttemptOutcome | null = null,
-    fallbackState: "scheduled" | "dispatched" | "exhausted" | null = null,
-    fallbackSchedule: {
-      readonly notBeforeAt: string;
-      readonly nextProvider: { readonly instance: string; readonly model?: string };
-    } | null = null,
-    nextDispatchId: string | null = null;
   const records = lines
     .slice(1)
     .map(parseRecord)
     .filter((record): record is DispatchStreamRecord => record !== null);
-  for (const record of records) {
-    if (record.kind === "provider_binding" && typeof record.providerSessionId === "string") {
-      providerSessionId = record.providerSessionId;
-    }
-    if (record.kind === "process_started" && Number.isInteger(record.pid) && Number(record.pid) > 0) {
-      processState = { pid: Number(record.pid), exitCode: null, signal: null, exited: false };
-    }
-    if (record.kind === "process_exit" && processState) {
-      processState = {
-        ...processState,
-        exitCode: Number.isInteger(record.exitCode) ? Number(record.exitCode) : null,
-        signal: typeof record.signal === "string" ? record.signal : null,
-        exited: true,
-      };
-    }
-    if (record.kind === "attempt_outcome" && isRuntimeAttemptOutcome(record)) attemptOutcome = record;
-    if (record.kind === "fallback_state" && ["scheduled", "dispatched", "exhausted"].includes(String(record.state))) {
-      fallbackState = record.state as typeof fallbackState;
-      fallbackSchedule =
-        record.state === "scheduled" &&
-        typeof record.notBeforeAt === "string" &&
-        isFallbackProvider(record.nextProvider)
-          ? { notBeforeAt: record.notBeforeAt, nextProvider: record.nextProvider }
-          : null;
-      nextDispatchId = typeof record.nextDispatchId === "string" ? record.nextDispatchId : nextDispatchId;
-    }
-  }
+  const summary = summarizeDispatch(first, records);
   return {
-    header: first,
-    providerSessionId,
-    process: processState,
-    attemptOutcome,
-    fallbackState,
-    fallbackSchedule,
-    nextDispatchId,
+    ...summary,
     records,
   };
 }
@@ -436,12 +473,123 @@ function readStoredDispatchLiveIndex(target: string, taskId: string): DispatchLi
   }
 }
 function appendJsonl(target: string, value: unknown): void {
+  summaryCache.delete(target);
   const descriptor = openSync(target, fsConstants.O_APPEND | fsConstants.O_WRONLY);
   try {
     writeFileSync(descriptor, `${JSON.stringify(scrubProviderValue(value))}\n`, "utf8");
   } finally {
     closeSync(descriptor);
   }
+}
+
+function summarizeDispatch(
+  header: DispatchStreamHeader,
+  records: readonly DispatchStreamRecord[],
+): DispatchStreamSummary {
+  let providerSessionId: string | null = null,
+    processState: DispatchProcessState | null = null,
+    attemptOutcome: RuntimeAttemptOutcome | null = null,
+    fallbackState: "scheduled" | "dispatched" | "exhausted" | null = null,
+    fallbackSchedule: DispatchStreamSummary["fallbackSchedule"] = null,
+    nextDispatchId: string | null = null;
+  for (const record of records) {
+    if (record.kind === "provider_binding" && typeof record.providerSessionId === "string")
+      providerSessionId = record.providerSessionId;
+    if (record.kind === "process_started" && Number.isInteger(record.pid) && Number(record.pid) > 0)
+      processState = { pid: Number(record.pid), exitCode: null, signal: null, exited: false };
+    if (record.kind === "process_exit" && processState)
+      processState = {
+        ...processState,
+        exitCode: Number.isInteger(record.exitCode) ? Number(record.exitCode) : null,
+        signal: typeof record.signal === "string" ? record.signal : null,
+        exited: true,
+      };
+    if (record.kind === "attempt_outcome" && isRuntimeAttemptOutcome(record)) attemptOutcome = record;
+    if (record.kind === "fallback_state" && ["scheduled", "dispatched", "exhausted"].includes(String(record.state))) {
+      fallbackState = record.state as typeof fallbackState;
+      fallbackSchedule =
+        record.state === "scheduled" &&
+        typeof record.notBeforeAt === "string" &&
+        isFallbackProvider(record.nextProvider)
+          ? { notBeforeAt: record.notBeforeAt, nextProvider: record.nextProvider }
+          : null;
+      nextDispatchId = typeof record.nextDispatchId === "string" ? record.nextDispatchId : nextDispatchId;
+    }
+  }
+  return {
+    header,
+    providerSessionId,
+    process: processState,
+    attemptOutcome,
+    fallbackState,
+    fallbackSchedule,
+    nextDispatchId,
+    records,
+  };
+}
+
+function readBoundedStreamWindows(
+  target: string,
+  size: number,
+  headerEnd: number,
+): readonly { offset: number; text: string }[] {
+  const descriptor = openSync(target, fsConstants.O_RDONLY);
+  try {
+    const windows = [
+      { offset: 0, length: Math.min(size, summaryHeadBytes) },
+      ...(headerEnd < size ? [{ offset: headerEnd, length: Math.min(size - headerEnd, summaryHeadBytes) }] : []),
+    ];
+    if (size > summaryHeadBytes)
+      windows.push({ offset: Math.max(0, size - summaryTailBytes), length: Math.min(size, summaryTailBytes) });
+    return windows.map(({ offset, length }) => {
+      const bytes = Buffer.alloc(length),
+        read = readSync(descriptor, bytes, 0, length, offset);
+      return { offset, text: bytes.subarray(0, read).toString("utf8") };
+    });
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function firstLineEndOffset(target: string, size: number): number {
+  const descriptor = openSync(target, fsConstants.O_RDONLY);
+  try {
+    let offset = 0;
+    while (offset < size) {
+      const bytes = Buffer.alloc(Math.min(4096, size - offset));
+      const read = readSync(descriptor, bytes, 0, bytes.length, offset);
+      if (read === 0) return size;
+      const newline = bytes.subarray(0, read).indexOf(10);
+      if (newline !== -1) return offset + newline + 1;
+      offset += read;
+    }
+    return size;
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function completeLines(text: string, offset: number, size: number): readonly { offset: number; value: string }[] {
+  const lines = text.split(/\r?\n/u),
+    result: { offset: number; value: string }[] = [];
+  let cursor = offset;
+  for (let index = 0; index < lines.length; index += 1) {
+    const value = lines[index]!;
+    const end = cursor + Buffer.byteLength(value) + 1;
+    if (index > 0 && cursor === offset) {
+      cursor = end;
+      continue;
+    }
+    if (end > size && index === lines.length - 1) break;
+    if (value.trim()) result.push({ offset: cursor, value });
+    cursor = end;
+  }
+  return result;
+}
+
+function lineKind(value: string): string | null {
+  const match = /"kind"\s*:\s*"([^"\\]+)"/u.exec(value);
+  return match?.[1] ?? null;
 }
 function parseRecord(value: string | undefined): Record<string, unknown> | null {
   if (!value) return null;

--- a/packages/daemon/src/repo-cell-task-mutation.ts
+++ b/packages/daemon/src/repo-cell-task-mutation.ts
@@ -15,7 +15,7 @@ import {
   type TaskV1,
 } from "../../kernel/src/index.ts";
 import { authorizeAction } from "./authorization.ts";
-import { readDispatchStreams } from "./dispatch-stream.ts";
+import { readDispatchStreamHeaders, readDispatchStreamSummary } from "./dispatch-stream.ts";
 import type { RepoCellBinding, RepoTaskAction, Snapshot } from "./repo-cell-types.ts";
 
 export function taskMutation(
@@ -373,17 +373,18 @@ function terminalExecutionRuntimeBinding(
   const inferredTerminalSessionIds =
     runtimeSessionId === null
       ? new Set(
-          readDispatchStreams(cell.rootDir)
+          readDispatchStreamHeaders(cell.rootDir)
+            .filter((header) => header.taskId === lease.taskId && header.executionId === lease.executionId)
+            .map((header) => readDispatchStreamSummary(cell.rootDir, header.dispatchId))
             .filter(
               (stream) =>
-                stream.header.taskId === lease.taskId &&
-                stream.header.executionId === lease.executionId &&
-                stream.attemptOutcome !== null &&
+                stream?.attemptOutcome !== null &&
+                stream?.attemptOutcome !== undefined &&
                 (stream.attemptOutcome.classification !== "provider_fault" ||
                   stream.header.fallbackAttempt === undefined ||
                   stream.fallbackState === "exhausted"),
             )
-            .map((stream) => stream.header.runtimeSessionId),
+            .map((stream) => stream!.header.runtimeSessionId),
         )
       : null;
   const taskSessions = cell.projection.readRuntimeSessionsForTask(lease.taskId) as readonly RuntimeSession[];

--- a/packages/daemon/src/runtime-spawn-adoption.ts
+++ b/packages/daemon/src/runtime-spawn-adoption.ts
@@ -1,7 +1,8 @@
 import {
   appendRuntimeWorkerRecord,
   readDispatchStream,
-  readDispatchStreams,
+  readDispatchStreamHeaders,
+  readDispatchStreamSummary,
   reopenDispatchStream,
   type DispatchStreamHeader,
 } from "./dispatch-stream.ts";
@@ -18,13 +19,18 @@ export async function adoptRuntimes(context: any): Promise<void> {
   const byId = new Map(
     sessions.map((session: { readonly runtimeSessionId: string }) => [session.runtimeSessionId, session]),
   );
-  for (const stream of readDispatchStreams(context.input.rootDir)) {
-    context.reconcileFallback(stream);
-    const session = byId.get(stream.header.runtimeSessionId) as
+  for (const header of readDispatchStreamHeaders(context.input.rootDir)) {
+    const fallbackSummary = header.fallbackAttempt
+      ? readDispatchStreamSummary(context.input.rootDir, header.dispatchId)
+      : null;
+    if (fallbackSummary) context.reconcileFallback(fallbackSummary);
+    const session = byId.get(header.runtimeSessionId) as
       | { readonly liveness: string; readonly outcome: string | null }
       | undefined;
-    const metadata = adoptableMetadata(stream.header);
-    if (!session || session.liveness === "exited" || session.outcome !== null || !stream.process || !metadata) continue;
+    const metadata = adoptableMetadata(header);
+    if (!session || session.liveness === "exited" || session.outcome !== null || !metadata) continue;
+    const stream = readDispatchStream(context.input.rootDir, header.dispatchId);
+    if (!stream?.process) continue;
     const runtimeProcess = adoptNativeProcess(
       context.input.rootDir,
       stream.header.dispatchId,

--- a/packages/daemon/src/squad-coordinator.ts
+++ b/packages/daemon/src/squad-coordinator.ts
@@ -9,7 +9,7 @@ import {
   type TaskProjection,
 } from "../../kernel/src/index.ts";
 import { readSquadDeclaration } from "./agent-entities.ts";
-import { appendRuntimeWorkerRecord, readDispatchStreams } from "./dispatch-stream.ts";
+import { appendRuntimeWorkerRecord, readDispatchStreamSummaries } from "./dispatch-stream.ts";
 import { readTaskDispatches } from "./dispatch-read.ts";
 import type { TaskDispatchRow } from "./protocol/daemon-protocol.contract.ts";
 import type { JsonObject } from "./protocol/json-rpc-types.ts";
@@ -623,7 +623,7 @@ export function makeSquadCoordinator(input: {
     const projection = input.projection();
     if (projection.squadRunProjectionReady()) return;
     const states = new Map<string, SquadState>();
-    for (const stream of readDispatchStreams(input.rootDir)) {
+    for (const stream of readDispatchStreamSummaries(input.rootDir)) {
       for (const record of stream.records) {
         if (record.kind !== "squad_run_state") continue;
         const state = squadState(record.state);

--- a/packages/daemon/test/dispatch-stream.test.ts
+++ b/packages/daemon/test/dispatch-stream.test.ts
@@ -10,6 +10,7 @@ import {
   openDispatchStream,
   readDispatchLiveIndex,
   readDispatchStream,
+  readDispatchStreamSummary,
 } from "../src/dispatch-stream.ts";
 
 test("the live index rebuilds exactly from dispatch stream headers", () => {
@@ -62,6 +63,42 @@ test("process lifecycle observations remain in the append-only dispatch stream",
     assert.deepEqual(stream?.process, { pid: 4321, exitCode: null, signal: "SIGKILL", exited: true });
     assert.deepEqual(
       stream?.records.map((record) => record.kind),
+      ["process_started", "process_exit"],
+    );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("dispatch summaries skip provider bodies and refresh when lifecycle records append", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-summary-"));
+  try {
+    const dispatchId = "dispatch_444444444444444444444444";
+    openDispatchStream(rootDir, {
+      dispatchId,
+      taskId: "task-3",
+      executionId: "execution-3",
+      runtimeSessionId: "runtime_444444444444444444444444",
+      instanceId: "instance-1",
+      startedAt: "2026-08-24T00:00:00.000Z",
+      prompt: "p".repeat(64 * 1024),
+    });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_started", pid: 9876 });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, {
+      kind: "provider_event",
+      event: { text: "x".repeat(512 * 1024) },
+    });
+    const running = readDispatchStreamSummary(rootDir, dispatchId);
+    assert.deepEqual(running?.process, { pid: 9876, exitCode: null, signal: null, exited: false });
+    assert.deepEqual(
+      running?.records.map((record) => record.kind),
+      ["process_started"],
+    );
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_exit", exitCode: 0, signal: null });
+    const exited = readDispatchStreamSummary(rootDir, dispatchId);
+    assert.deepEqual(exited?.process, { pid: 9876, exitCode: 0, signal: null, exited: true });
+    assert.deepEqual(
+      exited?.records.map((record) => record.kind),
       ["process_started", "process_exit"],
     );
   } finally {


### PR DESCRIPTION
# English

## Summary

Root cause of the daemon's 110% CPU / 4.5 GB RSS (fresh process within 9 minutes; `ha task list` 13–31 s): `readDispatchStream` did `readFileSync().split().map(JSON.parse)` over every dispatch stream on every hot-path call — 696 JSONL files, 1.24 GB, dominated by provider output bodies nobody downstream reads. Five directory-wide full scans are deleted (dispatch-read candidate parse and attempt-chain parse, task-mutation terminal inference, spawn adoption, squad projection). They now read bounded windows (header + 16 KiB after it + 128 KiB tail, where lifecycle records live) through `readDispatchStreamSummary`, cached by path + mtime + size with explicit invalidation on append/removal. Measured on the canonical directory: 4,455 ms / 1.63 M records → 355 ms cold / 70 ms cached, 1,719 records.

## Architectural Justification

- Production-Delta +227/-62 exceeds 200 lines. Why one PR: the five callers and the bounded reader are one change — deleting the scans without the bounded reader leaves callers with nothing to call. The cache is the one added mechanism; its invalidation (append, removal, external mtime/size change) is tested, and no resident index service or transcript store was added.

## What Changed

- `dispatch-stream.ts`: `readDispatchStreamSummary`, `readDispatchStreamHeaders`, bounded window reader, mtime+size cache with explicit invalidation.
- `dispatch-read.ts`, `repo-cell-task-mutation.ts`, `runtime-spawn-adoption.ts`, `squad-coordinator.ts`: full scans replaced by summary/header reads.
- `dispatch-stream.test.ts`: 64 KiB header + 512 KiB provider body + lifecycle tail + cache invalidation.

## Gate Harvest / 门收割

Deleted-Production-Paths: full-parse call sites at dispatch-read.ts:71 and :161, repo-cell-task-mutation.ts:376, runtime-spawn-adoption.ts:21, squad-coordinator.ts:626
Deleted-Gates-Fixtures: `packages/daemon/test/dispatch-stream.test.ts` full-parse expectations replaced by the bounded-window + cache-invalidation cases
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +227/-62

### Optional Evidence Claims

## Task And Scope

- Harness task: task_f026e19b72b71f97598fbd3ecb
- Branch: codex/dispatch-stream-hotpath
- Public scope: packages/daemon/src dispatch-stream, dispatch-read, repo-cell-task-mutation, runtime-spawn-adoption, squad-coordinator; packages/daemon/test
- Private planning/evidence updated: yes
- Out of scope: archiving or compacting old dispatch streams (1.2 GB on disk stays); the remaining intentional single-dispatch full readers used by provider recovery

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_f026e19b72b71f97598fbd3ecb
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: bb7d3a227f1bc79492101fb49ba005e891da40f4
- Branch merge-base with `origin/main`: bb7d3a227f1bc79492101fb49ba005e891da40f4
- Last `git fetch origin` time: 2026-08-27
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_f026e19b72b71f97598fbd3ecb (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Before/after measured on the canonical dispatch directory (696 files, 1.24 GB): 4,455 ms → 355 ms cold → 70 ms cached
- [x] Node 24: dispatch-stream + dispatch-read 10/10; provider-fallback + lifecycle 5/5; squad recovery/detail/reads 14/14; runtime-spawn-lifecycle 6/6 (35/35 combined); typecheck, lint
- [ ] After merge: resident daemon CPU idle and `ha task list` under 1 s (CEO measures)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO took the 10 s inspector profile that named this hot path (82% in readDispatchStreams→readFileSync→parseRecord), checked the report's delete list against the five call sites, and read the invalidation test.
- Reviewer subagent: Codex worker (gpt-5.6-sol, xhigh); CEO acceptance. Fact F-8C02EE68 on task_5450bf02 holds the profile.
- Human review: pending
- Blocking findings: none

## Residual Risk

- A lifecycle record further than 128 KiB from the tail of a stream would be missed by the summary; the test covers a 512 KiB provider body before the tail, and lifecycle records are appended last by construction.

## References

- Task: task_f026e19b72b71f97598fbd3ecb
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

daemon 110% CPU / 4.5 GB RSS(新进程 9 分钟内;`ha task list` 13–31 s)的根因:`readDispatchStream` 对每个 dispatch stream 都 `readFileSync().split().map(JSON.parse)`,每次热路径调用整读 696 个 JSONL、1.24 GB,其中绝大多数是下游根本不读的 provider 输出体。删掉五处目录级全量扫描(dispatch-read 候选解析与 attempt 链解析、task-mutation 终态推断、spawn adoption、squad 投影),改为经 `readDispatchStreamSummary` 读有界窗口(header + 其后 16 KiB + 尾部 128 KiB,生命周期记录在尾部),按 路径+mtime+size 缓存,append/删除显式失效。canonical 目录实测:4,455 ms / 163 万条 → 冷 355 ms / 缓存 70 ms,1,719 条。

## 架构辩护

- Production-Delta +227/-62 超过 200 行。为何一个 PR:五个调用方与有界读取器是同一改动——只删扫描不给有界读取器,调用方无物可调。缓存是唯一新增机制;失效条件(append、删除、外部 mtime/size 变化)有测试,未新增常驻索引服务或转录存储。

## 改动内容

- `dispatch-stream.ts`:`readDispatchStreamSummary`、`readDispatchStreamHeaders`、有界窗口读取、mtime+size 缓存与显式失效。
- `dispatch-read.ts`、`repo-cell-task-mutation.ts`、`runtime-spawn-adoption.ts`、`squad-coordinator.ts`:全量扫描换成摘要/头读取。
- `dispatch-stream.test.ts`:64 KiB header + 512 KiB provider body + 生命周期尾 + 缓存失效。

## 门收割 / Gate Harvest

- 删除的生产路径:dispatch-read.ts:71 与 :161、repo-cell-task-mutation.ts:376、runtime-spawn-adoption.ts:21、squad-coordinator.ts:626 的全量解析调用点
- 同 commit 删除的门 / fixture:`packages/daemon/test/dispatch-stream.test.ts` 的全量解析期望改为有界窗口 + 缓存失效用例
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_f026e19b72b71f97598fbd3ecb
- 分支:codex/dispatch-stream-hotpath
- 公开范围:packages/daemon/src 的 dispatch-stream、dispatch-read、repo-cell-task-mutation、runtime-spawn-adoption、squad-coordinator;packages/daemon/test
- 私有计划 / 证据是否已更新:yes
- 范围外:归档/压缩旧 dispatch stream(磁盘上 1.2 GB 不动);provider 恢复路径保留的单 dispatch 全量读取

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_f026e19b72b71f97598fbd3ecb
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:bb7d3a227f1bc79492101fb49ba005e891da40f4
- 当前分支与 `origin/main` 的 merge-base:bb7d3a227f1bc79492101fb49ba005e891da40f4
- 最近一次 `git fetch origin` 时间:2026-08-27
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_f026e19b72b71f97598fbd3ecb
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] canonical dispatch 目录(696 文件,1.24 GB)前后对照:4,455 ms → 冷 355 ms → 缓存 70 ms
- [x] Node 24:dispatch-stream + dispatch-read 10/10;provider-fallback + lifecycle 5/5;squad recovery/detail/reads 14/14;runtime-spawn-lifecycle 6/6(合计 35/35);typecheck、lint
- [ ] 合入后:常驻 daemon CPU 空闲、`ha task list` 1 s 以内(CEO 实测)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 亲自抓的 10 秒 inspector profile 指向这条热路径(82% 在 readDispatchStreams→readFileSync→parseRecord),对照报告的删除清单核了五个调用点,读了失效测试。
- Reviewer subagent:Codex worker(gpt-5.6-sol,xhigh);CEO 验收。profile 记在 task_5450bf02 的 fact F-8C02EE68。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 若生命周期记录距 stream 尾部超过 128 KiB 会被摘要漏掉;测试覆盖了尾部前 512 KiB provider body 的情形,且生命周期记录按构造总是最后追加。

## 关联材料

- 任务:task_f026e19b72b71f97598fbd3ecb
- 证据:任务包 artifacts/reports
- 审查:本 PR
