### PR TITLE
fix(kernel): reject pre-budget squad declarations

### DIFF
--- a/packages/daemon/src/agent-entities.ts
+++ b/packages/daemon/src/agent-entities.ts
@@ -166,8 +166,8 @@ export function readAgentEntityGuiProjection<
     return {
       schema: "squad-entity-catalog/v1",
       ok: true,
-      squads: entities.map(({ id, value }) =>
-        squadEntityRow({ ...parseStoredSquadDeclaration(value, id), layer: "user", validity: "valid", issues: [] }),
+      squads: entities.map(({ value }) =>
+        squadEntityRow({ ...parseSquadDeclarationV1(value), layer: "user", validity: "valid", issues: [] }),
       ),
     } as never;
   }
@@ -191,7 +191,7 @@ export function readAgentEntityGuiProjection<
       },
     } as never;
   }
-  const squad = parseStoredSquadDeclaration(readyEntityValue(input.projection, "squad", entityId), entityId),
+  const squad = parseSquadDeclarationV1(readyEntityValue(input.projection, "squad", entityId)),
     missing = [squad.leader, ...squad.workers].filter((agentId) => {
       try {
         parseAgentDeclarationV1(readyEntityValue(input.projection, "agent", agentId));
@@ -248,10 +248,7 @@ export function readSquadDeclaration(input: {
   readonly entityStore?: EntityStore;
 }): SquadDeclarationV1 {
   const entityStore = input.entityStore ?? openEntityStore(input.rootDir),
-    squad = parseStoredSquadDeclaration(
-      readStoredDeclaration(input.rootDir, "squad", input.squadId, entityStore),
-      input.squadId,
-    ),
+    squad = parseSquadDeclarationV1(readStoredDeclaration(input.rootDir, "squad", input.squadId, entityStore)),
     missing = [squad.leader, ...squad.workers].filter((id) => {
       try {
         readAgentDeclaration({ rootDir: input.rootDir, agentId: id, entityStore });
@@ -299,7 +296,7 @@ export function resolveSquadDispatch(input: {
     throw entityError("squad_not_found", `A squad id is required to dispatch leader ${input.leaderId}.`);
   const matches: SquadDispatchSelection[] = [];
   for (const { id: squadId, value } of entityStore.list<SquadDeclarationV1>("squad")) {
-    const squad = parseStoredSquadDeclaration(value, squadId);
+    const squad = parseSquadDeclarationV1(value);
     if (squad.leader !== input.leaderId || !squad.workers.includes(input.workerId)) continue;
     const leader = readAgentDeclaration({ rootDir: input.rootDir, agentId: squad.leader, entityStore }),
       worker = readAgentDeclaration({ rootDir: input.rootDir, agentId: input.workerId, entityStore });
@@ -431,9 +428,9 @@ function listStoredEntities(
 ): readonly (AgentCatalogRow | SquadCatalogRow)[] {
   return entityStore
     .list<AgentDeclarationV1 & SquadDeclarationV1>(kind)
-    .map(({ id, value, documentPath: source }) => {
+    .map(({ value, documentPath: source }) => {
       const declaration = (
-        kind === "squad" ? parseStoredSquadDeclaration(value, id) : parseAgentDeclarationV1(value)
+        kind === "squad" ? parseSquadDeclarationV1(value) : parseAgentDeclarationV1(value)
       ) as AgentDeclarationV1 & SquadDeclarationV1;
       const { instructions: _instructions, roster: _roster, ...row } = declaration;
       return { ...row, layer: "user" as const, source, validity: "valid" as const, issues: [] as const };
@@ -541,22 +538,6 @@ function readStoredDeclaration(rootDir: string, kind: AgentEntityKind, id: strin
   const stored = (entityStore ?? openEntityStore(rootDir)).get(kind, id);
   if (!stored) throw entityError(`${kind}_not_found`, `${id} is not an installed ${kind}.`);
   return stored.value;
-}
-function parseStoredSquadDeclaration(value: unknown, squadId: string): SquadDeclarationV1 {
-  if (
-    value !== null &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    !Object.hasOwn(value, "leaderTurnBudget") &&
-    validateSquadDeclarationV1({ ...value, leaderTurnBudget: 1 }).length === 0
-  )
-    throw entityError(
-      "squad_declaration_outdated",
-      `Squad ${squadId} was installed without required field "leaderTurnBudget". ` +
-        `Add a positive leaderTurnBudget to its squad.json package ` +
-        `and run ha squad install --source <squad-package-dir>.`,
-    );
-  return parseSquadDeclarationV1(value);
 }
 function entityKind(actionKind: string): AgentEntityKind {
   if (!/^(?:agent|squad)-(?:list|inspect|validate|install)$/u.test(actionKind))

--- a/packages/daemon/test/agent-entities.test.ts
+++ b/packages/daemon/test/agent-entities.test.ts
@@ -14,11 +14,10 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { createEntityStore, makeTaskEventStore, makeTaskProjection, sha256Text } from "../../kernel/src/index.ts";
+import { createEntityStore, makeTaskEventStore, makeTaskProjection } from "../../kernel/src/index.ts";
 import {
   prepareAgentEntityInstall,
   readAgentEntityGuiProjection,
-  readSquadDeclaration,
   resolveSquadDispatch,
   runAgentEntityAction,
 } from "../src/agent-entities.ts";
@@ -260,76 +259,6 @@ test("Squad leader turn budgets are required positive integers", () => {
       /leaderTurnBudget.*positive integer/u,
     );
   assert.deepEqual(validateSquadDeclarationV1(squad), []);
-});
-
-test("an installed pre-budget Squad fails with coded reinstall guidance without blocking its replacement", () => {
-  const { leaderTurnBudget: _leaderTurnBudget, ...outdated } = squad,
-    body = `${JSON.stringify(outdated)}\n`,
-    sha256 = sha256Text(body),
-    entityStore = createEntityStore({
-      read: () => ({
-        schema: "canonical-event-stream/v1",
-        revision: 1,
-        events: [
-          {
-            schema: "agent-entity-event/v1",
-            eventId: "event-squad-core-squad-1",
-            workspaceRevision: 1,
-            opId: "op-squad-core-squad-1",
-            type: "agent_entity_written",
-            actor: { principal: { personId: "agent-entities-test" }, executor: null },
-            source: "local",
-            occurredAt: "2026-08-25T00:00:00.000Z",
-            payload: {
-              entityKind: "squad",
-              entityId: "core-squad",
-              declarationDocumentClaim: {
-                path: "squads/core-squad.json",
-                sha256,
-                size: Buffer.byteLength(body),
-                mediaType: "application/json",
-                policyId: "typed-agent-entity/v1",
-              },
-            },
-          } as never,
-        ],
-      }),
-      readContentBlob: (candidate) => (candidate === sha256 ? Buffer.from(body) : null),
-    });
-
-  assert.deepEqual(entityStore.get("squad", "core-squad")?.value, outdated);
-  assert.throws(
-    () => readSquadDeclaration({ rootDir: "/unused", squadId: "core-squad", entityStore }),
-    (error: unknown) =>
-      (error as { readonly code?: string }).code === "squad_declaration_outdated" &&
-      /ha squad install --source <squad-package-dir>/u.test(error instanceof Error ? error.message : ""),
-  );
-  assert.throws(
-    () =>
-      readAgentEntityGuiProjection({
-        kind: "squad-inspect",
-        entityId: "core-squad",
-        projection: {
-          listEntities: () => [],
-          getEntity: () => ({
-            kind: "squad",
-            id: "core-squad",
-            ownerId: null,
-            workspaceRevision: 1,
-            value: outdated,
-          }),
-        },
-      }),
-    (error: unknown) => (error as { readonly code?: string }).code === "squad_declaration_outdated",
-  );
-  assert.equal(
-    prepareAgentEntityInstall({
-      rootDir: "/unused",
-      entityStore,
-      action: { kind: "squad-install", declaration: squad },
-    }).report.changed,
-    true,
-  );
 });
 
 test("Agent skill discovery scans user and project roots and returns absolute selectable paths", () => {

--- a/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-ingress.integration.test.ts
@@ -5,11 +5,7 @@ import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSy
 import { hostname, tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import {
-  makeTaskEventStore,
-  makeTaskProjection,
-  type AgentDefinitionSnapshot,
-} from "../../kernel/src/index.ts";
+import { makeTaskEventStore, makeTaskProjection, type AgentDefinitionSnapshot } from "../../kernel/src/index.ts";
 import { type RuntimeInstallationWitness } from "../src/agent-runtime-instances.ts";
 import { localUserDaemonEndpoint } from "../src/client/local-daemon-target.ts";
 import { openDaemonHost } from "../src/daemon-host.ts";
@@ -1673,7 +1669,7 @@ async function eventually(check: () => boolean | Promise<boolean>): Promise<void
   await eventuallyValue(async () => ((await check()) ? true : null));
 }
 async function eventuallyValue<T>(read: () => T | null | Promise<T | null>): Promise<T> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+  for (let attempt = 0; attempt < 500; attempt += 1) {
     const value = await read();
     if (value !== null) return value;
     await new Promise((resolve) => setTimeout(resolve, 10));

--- a/packages/kernel/src/domain/entity-kind-projection.ts
+++ b/packages/kernel/src/domain/entity-kind-projection.ts
@@ -47,15 +47,6 @@ export function interpretEntityValue(
   value: unknown,
   label = `${contract.kind} declaration`,
 ): InterpretedEntityValue {
-  // Pre-budget Squad events are append-only history. Validate that exact old shape without
-  // inventing a budget, then carry it to the read boundary where reinstall guidance is available.
-  if (contract.kind === "squad" && isEntityRecord(value) && !Object.hasOwn(value, "leaderTurnBudget")) {
-    const currentShape = parseEntityJsonSchema(contract.schema, { ...value, leaderTurnBudget: 1 }, label);
-    if (!isEntityRecord(currentShape)) throw new Error(`${label} must be an object`);
-    const id = currentShape[contract.id.field];
-    if (typeof id !== "string") throw new Error(`${label} has no string identity`);
-    return { kind: contract.kind, id, value };
-  }
   const parsed = parseEntityJsonSchema(contract.schema, value, label);
   if (!isEntityRecord(parsed)) throw new Error(`${label} must be an object`);
   const id = parsed[contract.id.field];

--- a/packages/kernel/test/contracts/entity-store.test.ts
+++ b/packages/kernel/test/contracts/entity-store.test.ts
@@ -183,6 +183,46 @@ test("EntityStore get isolates current-schema rejection to the requested declara
   );
 });
 
+test("EntityStore rejects pre-budget squad declarations at the schema boundary", () => {
+  const stale = {
+      schema: "squad-declaration/v1",
+      id: "core-squad",
+      name: "Core Squad",
+      leader: "terra",
+      workers: ["terra"],
+      roster: "# Core Squad",
+    },
+    body = `${JSON.stringify(stale, null, 2)}\n`,
+    sha256 = createHash("sha256").update(body).digest("hex"),
+    event = {
+      schema: "entity-event/v1",
+      eventId: "event-stale-squad-1",
+      workspaceRevision: 1,
+      opId: "op-stale-squad-1",
+      type: "entity_upserted",
+      actor,
+      source: "local",
+      occurredAt: "2026-08-25T00:00:00.000Z",
+      payload: {
+        entityKind: "squad",
+        entityId: stale.id,
+        declarationDocumentClaim: {
+          path: "squads/core-squad.json",
+          sha256,
+          size: Buffer.byteLength(body),
+          mediaType: "application/json",
+          policyId: "typed-entity/v1",
+        },
+      },
+    } as EntityEventV1,
+    store = createEntityStore({
+      read: () => ({ schema: "canonical-event-stream/v1", revision: 1, events: [event] }),
+      readContentBlob: (candidate) => (candidate === sha256 ? Buffer.from(body) : null),
+    });
+
+  assert.throws(() => store.get("squad", stale.id), /missing required field "leaderTurnBudget"/u);
+});
+
 test("Entity upsert rejects schema-invalid declarations and tampered declaration bundles", () => {
   const store = createEntityStore({
     read: () => ({ schema: "canonical-event-stream/v1", revision: 0, events: [] }),


### PR DESCRIPTION
# English

## Summary

Phase 1/2 closeout audit DRIFT-1 (dec_57A9D27B delete-first). PR #1913 had re-introduced a per-kind compatibility branch in `entity-kind-projection.ts` that accepted historical squad declarations lacking `leaderTurnBudget`, plus a daemon read-boundary special case (`parseStoredSquadDeclaration`) that emitted reinstall guidance for that shape. Both are deleted: every EntityKind now goes through the one current schema, and a pre-budget squad blob is rejected at the shared EntityStore boundary like any other invalid declaration. The 1.7 invariant `rg 'contract.kind === "' packages/kernel/src` is back to zero. The five historical pre-budget squad claims in the canonical ledger are repaired by data, not code: the CEO re-installs the four squads through `ha squad install --source` after merge.

## Architectural Justification

- Production-Delta +7/-35: removes a compatibility layer and its reinstall-guidance twin; adds no mechanism.

## What Changed

- `packages/kernel/src/domain/entity-kind-projection.ts`: squad pre-budget branch removed (9 lines).
- `packages/daemon/src/agent-entities.ts`: `parseStoredSquadDeclaration` and the `squad_declaration_outdated` path removed; readers call `parseSquadDeclarationV1`.
- Tests: the outdated-shape tests deleted; `entity-store.test.ts` asserts a pre-budget squad blob is rejected at the shared schema boundary.
- `packages/daemon/test/runtime-spawn-ingress.integration.test.ts`: the provider-stub wait is a 5 s bounded window instead of 1 s — the claude stub's first frame took 1.1–1.9 s on the loaded runner and failed integration-shard (6) three times in a row at the old limit (task_20a3c274).

## Gate Harvest / 门收割

Deleted-Production-Paths: squad pre-budget branch in entity-kind-projection.ts; parseStoredSquadDeclaration and squad_declaration_outdated reinstall guidance in agent-entities.ts
Deleted-Gates-Fixtures: packages/daemon/test/agent-entities.test.ts squad_declaration_outdated cases (72 lines) — replaced by the entity-store rejection contract test
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +7/-35

### Optional Evidence Claims

## Task And Scope

- Harness task: task_bede6c3d7dc1730cdb73c85777
- Branch: codex/p12-drift1
- Public scope: packages/kernel/src/domain/entity-kind-projection.ts, packages/daemon/src/agent-entities.ts, their tests
- Private planning/evidence updated: yes
- Out of scope: Canonical data repair (four `ha squad install --source` runs) is an operator action after merge, recorded on task_bede6c3d.

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_bede6c3d7dc1730cdb73c85777
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-28
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_bede6c3d7dc1730cdb73c85777 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] kernel contract entity-store.test.ts 8/8; daemon agent-entities.test.ts 19/19; typecheck; changed-file eslint 0
- [x] `rg 'contract.kind === "' packages/kernel/src` → empty
- [ ] CI on this PR
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO read the worker report (task_bede6c3d artifacts/reports/r1.md) against the 1.7 closeout invariant and confirmed the ledger evidence (5 pre-budget claims across 4 squads) before opening this PR.
- Reviewer subagent: Codex worker (gpt-5.6-sol); CEO acceptance; source audit phase12-closeout-audit-20260828.md (Opus read-only).
- Human review: pending
- Blocking findings: none

## Residual Risk

- Between merge and the four re-installs, reads of the historical squad claims in the canonical ledger are rejected by schema; the CEO runs the installs immediately after pulling.

## References

- Task: task_bede6c3d7dc1730cdb73c85777
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

Phase 1/2 收口审计 DRIFT-1(dec_57A9D27B 删除优先)。PR #1913 在 `entity-kind-projection.ts` 重新引入了一个 per-kind 兼容分支,接受缺 `leaderTurnBudget` 的历史 squad 声明,并在 daemon 读边界加了 `parseStoredSquadDeclaration` 特判发 reinstall 指引。两处都删除:所有 EntityKind 走唯一现行 schema,旧形状 squad blob 在共享 EntityStore 边界被拒绝,与其它非法声明一致。1.7 不变量 `rg 'contract.kind === "' packages/kernel/src` 归零。canonical 台账里 5 条旧 squad claim 用数据而不是代码修:合并后 CEO 用 `ha squad install --source` 重装四个 squad。

## 架构辩护

- Production-Delta +7/-35:删掉兼容层及其 reinstall 指引孪生,不加机制。

## 改动内容

- `packages/kernel/src/domain/entity-kind-projection.ts`:删 squad pre-budget 分支(9 行)。
- `packages/daemon/src/agent-entities.ts`:删 `parseStoredSquadDeclaration` 与 `squad_declaration_outdated` 路径;读路径统一调 `parseSquadDeclarationV1`。
- 测试:删旧形状专用测试;`entity-store.test.ts` 断言 pre-budget squad blob 在共享 schema 边界被拒。
- `packages/daemon/test/runtime-spawn-ingress.integration.test.ts`:provider stub 等待窗从 1 s 放宽为 5 s 有界——claude stub 首帧在负载 runner 上要 1.1–1.9 s,旧上限下 integration-shard (6) 连红三次(task_20a3c274)。

## 门收割 / Gate Harvest

- 删除的生产路径:entity-kind-projection.ts 的 squad pre-budget 分支;agent-entities.ts 的 parseStoredSquadDeclaration 与 squad_declaration_outdated reinstall 指引
- 同 commit 删除的门 / fixture:packages/daemon/test/agent-entities.test.ts 的 squad_declaration_outdated 用例(72 行)——由 entity-store 拒绝契约测试取代
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_bede6c3d7dc1730cdb73c85777
- 分支:codex/p12-drift1
- 公开范围:packages/kernel/src/domain/entity-kind-projection.ts、packages/daemon/src/agent-entities.ts 及其测试
- 私有计划 / 证据是否已更新:yes
- 范围外:canonical 数据修复(四次 `ha squad install --source`)是合并后的操作者动作,记录在 task_bede6c3d。

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_bede6c3d7dc1730cdb73c85777
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-28
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_bede6c3d7dc1730cdb73c85777
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] kernel 契约 entity-store.test.ts 8/8;daemon agent-entities.test.ts 19/19;typecheck;改动文件 eslint 0
- [x] `rg 'contract.kind === "' packages/kernel/src` 为空
- [ ] 本 PR 的 CI
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 对照 1.7 closeout 不变量读了 worker 报告(task_bede6c3d artifacts/reports/r1.md),并核了台账证据(4 个 squad 共 5 条旧 claim)后开 PR。
- Reviewer subagent:Codex worker(gpt-5.6-sol);CEO 验收;来源审计 phase12-closeout-audit-20260828.md(Opus 只读)。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 合并到四次重装之间,canonical 台账里旧 squad claim 的读取会被 schema 拒绝;CEO 拉取后立即执行重装。

## 关联材料

- 任务:task_bede6c3d7dc1730cdb73c85777
- 证据:任务包 artifacts/reports
- 审查:本 PR
