### PR TITLE
fix(gui): show live task package documents with an uncommitted marker (Phase 4.0 L4)

### DIFF
--- a/packages/daemon/src/doc-sync-reads.ts
+++ b/packages/daemon/src/doc-sync-reads.ts
@@ -1,6 +1,6 @@
 import { existsSync, lstatSync, readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
-import type { TaskProjection } from "../../kernel/src/index.ts";
+import { consumeKnownError, type TaskProjection } from "../../kernel/src/index.ts";
 import {
   canonicalEventCut,
   documentPath,
@@ -338,7 +338,8 @@ function worktreeDocumentIndex(packageRoot: string | null): readonly WorktreeDoc
     let entries: readonly import("node:fs").Dirent[];
     try {
       entries = readdirSync(directory, { withFileTypes: true });
-    } catch {
+    } catch (error) {
+      consumeKnownError(error);
       continue;
     }
     for (const entry of entries) {
@@ -368,7 +369,8 @@ function worktreeDocumentIndex(packageRoot: string | null): readonly WorktreeDoc
 function statFileSync(target: string): import("node:fs").Stats | null {
   try {
     return statSync(target);
-  } catch {
+  } catch (error) {
+    consumeKnownError(error);
     return null;
   }
 }
@@ -376,7 +378,8 @@ function statFileSync(target: string): import("node:fs").Stats | null {
 function statLinkSync(target: string): import("node:fs").Stats | null {
   try {
     return lstatSync(target);
-  } catch {
+  } catch (error) {
+    consumeKnownError(error);
     return null;
   }
 }

--- a/packages/daemon/src/doc-sync-reads.ts
+++ b/packages/daemon/src/doc-sync-reads.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, lstatSync, readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import type { TaskProjection } from "../../kernel/src/index.ts";
 import {
@@ -6,6 +6,7 @@ import {
   documentPath,
   resolveDocRoute,
   resolveHarnessLayout,
+  sha256Bytes,
   stableStringify,
   type DocEventV1,
   type DocSyncReceiptDetail,
@@ -194,12 +195,18 @@ export function readDocReceipt(input: Omit<Input, "action">, event: DocEventV1):
       };
 }
 
-export function readProjectedDocument(projection: TaskProjection, payload: Readonly<Record<string, unknown>>) {
+export function readProjectedDocument(
+  rootDir: string,
+  projection: TaskProjection,
+  payload: Readonly<Record<string, unknown>>,
+) {
   const taskId = requiredDocSyncText(payload.taskId, "taskId"),
     requested = requiredDocSyncText(payload.path, "path"),
     task = projection.read(taskId);
   if (!task.packagePath) throw docSyncError("task_not_found", `Task ${taskId} has no projected package path.`);
-  const read = projection.readDocument(documentPath(`${task.packagePath}/${requested}`));
+  const read = projection.readDocument(documentPath(`${task.packagePath}/${requested}`)),
+    packageRoot = taskPackageWorktreeRoot(rootDir, task.packagePath),
+    worktree = readWorktreeDocument(packageRoot, requested);
   return {
     ok: true as const,
     status: read.status,
@@ -207,14 +214,22 @@ export function readProjectedDocument(projection: TaskProjection, payload: Reado
     path: requested,
     body: read.document?.body ?? "",
     blobSha256: read.document?.blobSha256 ?? null,
+    // Live worktree view (task_e5defe69): the GUI file surface must show what is on disk
+    // now, not only the committed projection — an edited-but-unsynced plan is real work
+    // and must be visible and explicitly marked as not yet committed.
+    worktreeBody: worktree?.body ?? null,
+    worktreeBlobSha256: worktree?.blobSha256 ?? null,
+    uncommitted: worktree !== null && worktree.blobSha256 !== (read.document?.blobSha256 ?? null),
     watermark: read.watermark,
     sourceRevision: read.sourceRevision,
   };
 }
 
 /** GUI read repo.tasks.documents.list: projected documents under one task package,
- * with paths relative to the package root. */
+ * with paths relative to the package root. Files that exist only in the worktree (created
+ * but never doc-synced) are listed too, flagged uncommitted, so they are visible at all. */
 export function listProjectedTaskDocuments(
+  rootDir: string,
   projection: TaskProjection,
   payload: Readonly<Record<string, unknown>>,
 ): import("./protocol/daemon-protocol.contract.ts").DaemonTaskDocumentListResult {
@@ -223,15 +238,24 @@ export function listProjectedTaskDocuments(
   if (!task.packagePath) throw docSyncError("task_not_found", `Task ${taskId} has no projected package path.`);
   const prefix = `${task.packagePath}/`,
     basis = projection.readReplicaBasis(null),
-    documents = basis.documents
-      .filter((row) => row.path.startsWith(prefix))
-      .map((row) => ({
-        path: row.path.slice(prefix.length),
-        blobSha256: row.blobSha256,
-        size: row.size,
-        mediaType: row.mediaType,
-      }))
-      .sort((left, right) => left.path.localeCompare(right.path));
+    worktree = worktreeDocumentIndex(taskPackageWorktreeRoot(rootDir, task.packagePath)),
+    worktreeByPath = new Map(worktree.map((row) => [row.path, row])),
+    documents = [
+      ...basis.documents
+        .filter((row) => row.path.startsWith(prefix))
+        .map((row) => {
+          const relative = row.path.slice(prefix.length),
+            live = worktreeByPath.get(relative);
+          return {
+            path: relative,
+            blobSha256: row.blobSha256,
+            size: row.size,
+            mediaType: row.mediaType,
+            uncommitted: live !== undefined && live.blobSha256 !== row.blobSha256,
+          };
+        }),
+      ...worktree.filter((row) => !basis.documents.some((projected) => projected.path === `${prefix}${row.path}`)),
+    ].sort((left, right) => left.path.localeCompare(right.path));
   return {
     ok: true,
     status: task.status,
@@ -240,4 +264,119 @@ export function listProjectedTaskDocuments(
     watermark: basis.watermark,
     sourceRevision: basis.sourceRevision,
   };
+}
+
+const worktreeDocumentMaxBytes = 2 * 1024 * 1024,
+  worktreeDocumentMaxEntries = 2000,
+  worktreeDocumentExtensions = new Set([".md", ".json", ".yaml", ".yml", ".txt", ".html", ".htm"]);
+
+type WorktreeDocumentRow = {
+  readonly path: string;
+  readonly blobSha256: string;
+  readonly size: number;
+  readonly mediaType: string;
+  readonly uncommitted: true;
+};
+
+/** Task packages live under the authored harness root (harness/tasks/<package>), which is
+ * where doc-sync writes and where the live working copy the GUI must show resides. */
+function taskPackageWorktreeRoot(rootDir: string, packagePath: string): string | null {
+  const authoredRoot = path.resolve(resolveHarnessLayout(rootDir).authoredRoot),
+    packageRoot = path.resolve(authoredRoot, packagePath);
+  return packageRoot.startsWith(`${authoredRoot}${path.sep}`) ? packageRoot : null;
+}
+
+function resolveWorktreeDocumentPath(packageRoot: string | null, relative: string): string | null {
+  if (packageRoot === null || statLinkSync(packageRoot)?.isSymbolicLink()) return null;
+  const target = path.resolve(packageRoot, relative);
+  if (target !== packageRoot && !target.startsWith(`${packageRoot}${path.sep}`)) return null;
+  let cursor = packageRoot;
+  for (const segment of path.relative(packageRoot, target).split(path.sep)) {
+    cursor = path.join(cursor, segment);
+    if (statLinkSync(cursor)?.isSymbolicLink()) return null;
+  }
+  return target;
+}
+
+function worktreeDocumentMediaType(relative: string): string {
+  const extension = path.extname(relative).toLowerCase();
+  return extension === ".json"
+    ? "application/json"
+    : extension === ".html" || extension === ".htm"
+      ? "text/html"
+      : extension === ".yaml" || extension === ".yml"
+        ? "application/yaml"
+        : extension === ".md"
+          ? "text/markdown"
+          : "text/plain";
+}
+
+/** One live file from the task package's working copy, or null when it is absent. */
+function readWorktreeDocument(
+  packageRoot: string | null,
+  relative: string,
+): { readonly body: string; readonly blobSha256: string } | null {
+  const target = resolveWorktreeDocumentPath(packageRoot, relative);
+  if (target === null) return null;
+  const stat = statFileSync(target);
+  if (stat === null || !stat.isFile() || stat.size > worktreeDocumentMaxBytes) return null;
+  const bytes = readFileSync(target);
+  return { body: bytes.toString("utf8"), blobSha256: sha256Bytes(bytes) };
+}
+
+/** Document-shaped files currently on disk under the task package. The worktree is the
+ * truth for "what exists now"; the projection is the truth for "what is committed". */
+function worktreeDocumentIndex(packageRoot: string | null): readonly WorktreeDocumentRow[] {
+  if (packageRoot === null) return [];
+  const root = packageRoot,
+    rows: WorktreeDocumentRow[] = [];
+  if (!existsSync(root) || statLinkSync(root)?.isSymbolicLink() || !statFileSync(root)?.isDirectory()) return rows;
+  const queue: string[] = [root];
+  let visited = 0;
+  while (queue.length > 0 && rows.length < worktreeDocumentMaxEntries && visited < worktreeDocumentMaxEntries * 4) {
+    const directory = queue.shift()!;
+    let entries: readonly import("node:fs").Dirent[];
+    try {
+      entries = readdirSync(directory, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      visited += 1;
+      if (entry.name.startsWith(".")) continue;
+      const target = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        queue.push(target);
+        continue;
+      }
+      if (!entry.isFile() || !worktreeDocumentExtensions.has(path.extname(entry.name).toLowerCase())) continue;
+      const stat = statFileSync(target);
+      if (stat === null || stat.size > worktreeDocumentMaxBytes) continue;
+      const bytes = readFileSync(target);
+      rows.push({
+        path: path.relative(root, target).split(path.sep).join("/"),
+        blobSha256: sha256Bytes(bytes),
+        size: stat.size,
+        mediaType: worktreeDocumentMediaType(entry.name),
+        uncommitted: true,
+      });
+    }
+  }
+  return rows.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function statFileSync(target: string): import("node:fs").Stats | null {
+  try {
+    return statSync(target);
+  } catch {
+    return null;
+  }
+}
+
+function statLinkSync(target: string): import("node:fs").Stats | null {
+  try {
+    return lstatSync(target);
+  } catch {
+    return null;
+  }
 }

--- a/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
@@ -302,6 +302,11 @@ export type DaemonGuiReadResultMap = {
     readonly path: string;
     readonly body: string;
     readonly blobSha256: string | null;
+    /** Live worktree view (task_e5defe69): disk content now, and whether it diverges
+     * from the committed projection. Null body = no such file on disk. */
+    readonly worktreeBody: string | null;
+    readonly worktreeBlobSha256: string | null;
+    readonly uncommitted: boolean;
     readonly watermark: number;
     readonly sourceRevision: number;
   };
@@ -473,6 +478,9 @@ export interface TaskDocumentListEntryRow {
   readonly blobSha256: string;
   readonly size: number;
   readonly mediaType: string;
+  /** True when the worktree file diverges from the committed projection (or exists only
+   * in the worktree): the GUI marks these documents as not yet committed. */
+  readonly uncommitted: boolean;
 }
 
 export type DaemonTaskDocumentListResult = {

--- a/packages/daemon/src/protocol/daemon-protocol-schema-ids.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-schema-ids.ts
@@ -52,7 +52,19 @@ export const DAEMON_RELATION_GRAPH_SCHEMA = Object.freeze({
   }),
   DAEMON_DOCUMENT_READ_SCHEMA = Object.freeze({
     id: "daemon.document-read/v1",
-    required: Object.freeze(["ok", "status", "taskId", "path", "body", "blobSha256", "watermark", "sourceRevision"]),
+    required: Object.freeze([
+      "ok",
+      "status",
+      "taskId",
+      "path",
+      "body",
+      "blobSha256",
+      "worktreeBody",
+      "worktreeBlobSha256",
+      "uncommitted",
+      "watermark",
+      "sourceRevision",
+    ]),
   }),
   DAEMON_TASK_DOCUMENT_LIST_SCHEMA = Object.freeze({
     id: "daemon.task-document-list/v1",

--- a/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
@@ -37,6 +37,10 @@ export function validateDaemonDocumentRead(value: unknown): readonly string[] {
     typeof value.body !== "string" ||
     (value.blobSha256 !== null &&
       (typeof value.blobSha256 !== "string" || !/^[0-9a-f]{64}$/u.test(value.blobSha256))) ||
+    (value.worktreeBody !== null && typeof value.worktreeBody !== "string") ||
+    (value.worktreeBlobSha256 !== null &&
+      (typeof value.worktreeBlobSha256 !== "string" || !/^[0-9a-f]{64}$/u.test(value.worktreeBlobSha256))) ||
+    typeof value.uncommitted !== "boolean" ||
     !integer(value.watermark) ||
     !integer(value.sourceRevision)
   )
@@ -53,13 +57,14 @@ export function validateDaemonTaskDocumentList(value: unknown): readonly string[
     !Array.isArray(value.documents) ||
     value.documents.some(
       (row) =>
-        !exactRecord(row, ["path", "blobSha256", "size", "mediaType"]) ||
+        !exactRecord(row, ["path", "blobSha256", "size", "mediaType", "uncommitted"]) ||
         !nonEmpty(row.path) ||
         row.path.startsWith("/") ||
         row.path.split("/").includes("..") ||
         !/^[0-9a-f]{64}$/u.test(String(row.blobSha256)) ||
         !integer(row.size) ||
-        !nonEmpty(row.mediaType),
+        !nonEmpty(row.mediaType) ||
+        typeof row.uncommitted !== "boolean",
     ) ||
     !integer(value.watermark) ||
     !integer(value.sourceRevision)

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -255,8 +255,8 @@ export function createRepoCellApi(context: any): RepoCell {
         warnings: [],
       };
     },
-    "repo.tasks.document.read": (payload) => readProjectedDocument(context.projection, payload),
-    "repo.tasks.documents.list": (payload) => listProjectedTaskDocuments(context.projection, payload),
+    "repo.tasks.document.read": (payload) => readProjectedDocument(context.rootDir, context.projection, payload),
+    "repo.tasks.documents.list": (payload) => listProjectedTaskDocuments(context.rootDir, context.projection, payload),
     "repo.agentRuntime.overview": (payload) => context.runtimeReads.overview(payload),
     "repo.agentRuntime.sessionGroups": (payload) => context.runtimeReads.sessionGroups(payload),
     "repo.agentRuntime.sessions.read": (payload) => context.runtimeReads.session(payload),

--- a/packages/daemon/test/task-documents-list.integration.test.ts
+++ b/packages/daemon/test/task-documents-list.integration.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -15,14 +15,27 @@ test("repo.tasks.documents.list returns package-relative projected documents inc
   const repoId = "task-doc-list";
   const rootDir = mkdtempSync(path.join(tmpdir(), `ha-${repoId}-`));
   initRepo(rootDir);
-  const cell = await openRepoCell({ repoId: workspaceId(repoId), rootDir: canonicalRoot(rootDir), ownerId: `daemon-${repoId}` });
+  const cell = await openRepoCell({
+    repoId: workspaceId(repoId),
+    rootDir: canonicalRoot(rootDir),
+    ownerId: `daemon-${repoId}`,
+  });
   const binding: RepoCellBinding = { actor, source: "local" };
   try {
-    assert.equal((await cell.run({ kind: "task-create", taskId: "task-doc", title: "Docs" }, binding)).outcome, "applied");
-    assert.equal((await cell.run({ kind: "task-start", taskId: "task-doc", executionId: "execution-doc" }, binding)).outcome, "applied");
+    assert.equal(
+      (await cell.run({ kind: "task-create", taskId: "task-doc", title: "Docs" }, binding)).outcome,
+      "applied",
+    );
+    assert.equal(
+      (await cell.run({ kind: "task-start", taskId: "task-doc", executionId: "execution-doc" }, binding)).outcome,
+      "applied",
+    );
     // artifacts/ 文件走真实通道 task-artifact-add 进投影(destination 自动落 artifacts/)。
     writeFileSync(path.join(rootDir, "mission-report.md"), "# Report\n\nMission report.\n");
-    const added = await cell.run({ kind: "task-artifact-add", taskId: "task-doc", source: "mission-report.md", destination: "report.md" }, binding);
+    const added = await cell.run(
+      { kind: "task-artifact-add", taskId: "task-doc", source: "mission-report.md", destination: "report.md" },
+      binding,
+    );
     assert.equal(added.outcome, "applied", JSON.stringify(added));
 
     const listed = await cell.read("repo.tasks.documents.list", { taskId: "task-doc" });
@@ -47,7 +60,11 @@ test("repo.tasks.documents.list rejects an unknown task with task_not_found", as
   const repoId = "task-doc-list-missing";
   const rootDir = mkdtempSync(path.join(tmpdir(), `ha-${repoId}-`));
   initRepo(rootDir);
-  const cell = await openRepoCell({ repoId: workspaceId(repoId), rootDir: canonicalRoot(rootDir), ownerId: `daemon-${repoId}` });
+  const cell = await openRepoCell({
+    repoId: workspaceId(repoId),
+    rootDir: canonicalRoot(rootDir),
+    ownerId: `daemon-${repoId}`,
+  });
   try {
     await assert.rejects(
       () => cell.read("repo.tasks.documents.list", { taskId: "task-missing" }),
@@ -69,3 +86,79 @@ function initRepo(rootDir: string): void {
 function git(rootDir: string, ...args: string[]): string {
   return execFileSync("git", ["-C", rootDir, ...args], { encoding: "utf8" }).trim();
 }
+
+test("task documents expose the live worktree copy and mark it uncommitted", async () => {
+  const repoId = "task-doc-worktree";
+  const rootDir = mkdtempSync(path.join(tmpdir(), `ha-${repoId}-`));
+  initRepo(rootDir);
+  const cell = await openRepoCell({
+    repoId: workspaceId(repoId),
+    rootDir: canonicalRoot(rootDir),
+    ownerId: `daemon-${repoId}`,
+  });
+  const binding: RepoCellBinding = { actor, source: "local" };
+  try {
+    const created = (await cell.run({ kind: "task-create", taskId: "task-doc", title: "Docs" }, binding)) as {
+        readonly outcome: string;
+        readonly packagePath?: string;
+      },
+      packagePath = String(created.packagePath);
+    assert.equal(created.outcome, "applied");
+    assert.equal(
+      (await cell.run({ kind: "task-start", taskId: "task-doc", executionId: "execution-doc" }, binding)).outcome,
+      "applied",
+    );
+    const packageDir = path.join(rootDir, "harness", packagePath),
+      planPath = path.join(packageDir, "task_plan.md"),
+      scaffold = readFileSync(planPath, "utf8"),
+      committedBody = `${scaffold}\n## Worker Notes\n\nCanonical body.\n`;
+    writeFileSync(planPath, committedBody);
+    const submitted = await cell.run({ kind: "doc-submit", paths: [`${packagePath}/task_plan.md`] }, binding);
+    assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
+
+    // 改前:工作树与已提交投影一致,不标未提交。
+    const before = (await cell.read("repo.tasks.document.read", { taskId: "task-doc", path: "task_plan.md" })) as {
+      readonly uncommitted: boolean;
+      readonly worktreeBody: string | null;
+    };
+    assert.equal(before.uncommitted, false);
+    assert.match(before.worktreeBody ?? "", /Canonical body/u);
+
+    // 磁盘上直接改写(未 doc-sync):读面必须给出工作树实时内容并标注未提交。
+    writeFileSync(planPath, committedBody.replace("Canonical body.", "Fresh worktree body."));
+    const after = (await cell.read("repo.tasks.document.read", { taskId: "task-doc", path: "task_plan.md" })) as {
+      readonly uncommitted: boolean;
+      readonly worktreeBody: string | null;
+      readonly body: string;
+    };
+    assert.equal(after.uncommitted, true);
+    assert.match(after.worktreeBody ?? "", /Fresh worktree body/u);
+    assert.match(after.body, /Canonical body/u);
+
+    // 清单同样标注;新建(从未 sync)的文件也出现在清单里。
+    mkdirSync(path.join(packageDir, "artifacts"), { recursive: true });
+    writeFileSync(path.join(packageDir, "artifacts", "notes.md"), "# Notes\n");
+    const listed = (await cell.read("repo.tasks.documents.list", { taskId: "task-doc" })) as {
+      readonly documents: readonly { readonly path: string; readonly uncommitted: boolean }[];
+    };
+    const plan = listed.documents.find((row) => row.path === "task_plan.md");
+    assert.equal(plan?.uncommitted, true);
+    const fresh = listed.documents.find((row) => row.path === "artifacts/notes.md");
+    assert.equal(fresh?.uncommitted, true);
+    assert.equal((fresh as { readonly mediaType?: string } | undefined)?.mediaType, "text/markdown");
+    const freshRead = (await cell.read("repo.tasks.document.read", {
+      taskId: "task-doc",
+      path: "artifacts/notes.md",
+    })) as {
+      readonly blobSha256: string | null;
+      readonly uncommitted: boolean;
+      readonly worktreeBody: string | null;
+    };
+    assert.equal(freshRead.blobSha256, null);
+    assert.equal(freshRead.uncommitted, true);
+    assert.match(freshRead.worktreeBody ?? "", /Notes/u);
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/gui/src/renderer/api-client.ts
+++ b/packages/gui/src/renderer/api-client.ts
@@ -444,7 +444,8 @@ function readTaskDocumentListResult(value: unknown): TaskDocumentListProjectionR
         typeof doc.path !== "string" ||
         typeof doc.blobSha256 !== "string" ||
         !Number.isInteger(doc.size) ||
-        typeof doc.mediaType !== "string",
+        typeof doc.mediaType !== "string" ||
+        typeof doc.uncommitted !== "boolean",
     ) ||
     !Number.isInteger(result.watermark) ||
     !Number.isInteger(result.sourceRevision)
@@ -534,6 +535,9 @@ function readTaskDocumentResult(value: unknown): TaskDocumentProjectionRead {
     typeof result.taskId !== "string" ||
     typeof result.path !== "string" ||
     typeof result.body !== "string" ||
+    (result.worktreeBody !== null && typeof result.worktreeBody !== "string") ||
+    (result.worktreeBlobSha256 !== null && typeof result.worktreeBlobSha256 !== "string") ||
+    typeof result.uncommitted !== "boolean" ||
     !Number.isInteger(result.watermark) ||
     !Number.isInteger(result.sourceRevision)
   )

--- a/packages/gui/src/renderer/components/taskDetail/DocTree.tsx
+++ b/packages/gui/src/renderer/components/taskDetail/DocTree.tsx
@@ -137,6 +137,14 @@ function TreeNodeView({
           {t("components.docTree.missing")}
         </span>
       )}
+      {doc.uncommitted && (
+        <span
+          data-testid={`doc-uncommitted-${doc.path}`}
+          className="shrink-0 rounded border border-status-blocked/50 px-1 font-mono text-[9px] text-status-blocked"
+        >
+          {t("components.docTree.uncommitted")}
+        </span>
+      )}
     </button>
   );
 }

--- a/packages/gui/src/renderer/components/taskDetail/TaskFilesTab.tsx
+++ b/packages/gui/src/renderer/components/taskDetail/TaskFilesTab.tsx
@@ -14,13 +14,24 @@ interface TaskDocumentSidebarProps {
   readonly onOpenDoc: (path: string) => void;
 }
 
-export function TaskDocumentSidebar({ task, activeDoc, onActiveDocChange, onOpenDoc }: TaskDocumentSidebarProps) {
+export function TaskDocumentSidebar(props: TaskDocumentSidebarProps) {
+  const task = props.task;
+  const activeDoc = props.activeDoc;
+  const onActiveDocChange = props.onActiveDocChange;
+  const onOpenDoc = props.onOpenDoc;
   const documentList = useTaskDocumentListQuery(task.projectId, task.taskId);
-  const documents = useMemo(() => {
-    const projected =
-      documentList.data?.status === "ready" ? documentList.data.documents.map((document) => document.path) : [];
-    return projectedDocuments(projected);
-  }, [documentList.data]);
+  const documents = useMemo(
+    () =>
+      projectedDocuments(
+        documentList.data?.status === "ready"
+          ? documentList.data.documents.map((document) => ({
+              path: document.path,
+              ...(document.uncommitted ? { uncommitted: true } : {}),
+            }))
+          : [],
+      ),
+    [documentList.data],
+  );
   const tree = useMemo(() => buildDocTree(documents), [documents]);
 
   useEffect(() => {
@@ -81,17 +92,33 @@ function TaskFileBody({ repoId, taskId, path }: TaskFileBodyProps) {
   if (document.isPending) return <FileEmpty text="正在读取文档投影…" />;
   if (document.isError) return <p className="text-[12px] text-danger">文档读取失败：{document.error.message}</p>;
   if (document.data.status !== "ready") return <FileEmpty text="文档投影尚未追平。" />;
-  if (document.data.blobSha256 === null) return <FileEmpty text="该文件尚未物化。" />;
+  // 工作树实时内容优先(task_e5defe69):未提交的编辑是真实工作,必须可见并被标注,
+  // 而不是把读者留在已提交的旧文里;文件只在投影里(磁盘上已删)时如实回落到投影文。
+  const uncommitted = document.data.uncommitted,
+    body = uncommitted && document.data.worktreeBody !== null ? document.data.worktreeBody : document.data.body;
+  if (document.data.blobSha256 === null && document.data.worktreeBody === null)
+    return <FileEmpty text="该文件尚未物化。" />;
   const content = isHtmlDocument(path) ? (
-    <HtmlArtifactPreview content={document.data.body} path={path} />
+    <HtmlArtifactPreview content={body} path={path} />
   ) : (
-    <DocReader content={document.data.body} />
+    <DocReader content={body} />
   );
   return (
     <>
       <span data-testid="task-document-status" className="mb-3 block font-mono text-[10px] text-text-faint">
-        L2 · {document.data.status}
+        {uncommitted ? "L2 · 工作树未提交" : `L2 · ${document.data.status}`}
       </span>
+      {uncommitted && (
+        <p
+          data-testid="task-document-uncommitted"
+          className={[
+            "mb-3 border border-status-blocked/40 bg-status-blocked/10",
+            "px-2.5 py-1.5 text-[11px] text-status-blocked",
+          ].join(" ")}
+        >
+          工作树内容尚未提交:以下为磁盘当前内容,与已提交投影不同。
+        </p>
+      )}
       {content}
     </>
   );

--- a/packages/gui/src/renderer/i18n/locales/en-US/components.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/components.json
@@ -53,6 +53,7 @@
   "components.badges.urgentQueueQueue": "Urgent → queue order",
   "components.docTree.missing": "Missing",
   "components.docTree.required": "required",
+  "components.docTree.uncommitted": "uncommitted",
   "components.factInspector.checkingSourceSupportingRelationshipsContradictionsSupersedeStatus": "Checking the source, supporting relationships, contradictions and supersede status of this fact",
   "components.factInspector.closeFactInspector": "Close Fact Inspector",
   "components.factInspector.confidenceValue": "confidence {confidence}",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/components.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/components.json
@@ -53,6 +53,7 @@
   "components.badges.urgentQueueQueue": "紧急 → 队列排队",
   "components.docTree.missing": "缺失",
   "components.docTree.required": "必需",
+  "components.docTree.uncommitted": "未提交",
   "components.factInspector.checkingSourceSupportingRelationshipsContradictionsSupersedeStatus": "正在检查此 fact 的来源、支撑关系、矛盾与 supersede 状态",
   "components.factInspector.closeFactInspector": "关闭 Fact Inspector",
   "components.factInspector.confidenceValue": "置信度 {confidence}",

--- a/packages/gui/src/renderer/model/docTree.ts
+++ b/packages/gui/src/renderer/model/docTree.ts
@@ -30,14 +30,17 @@ interface TrieNode {
 }
 
 /** 投影清单 → 文档条目。投影列出的文件都在磁盘上,所以恒为 present 且非 required。 */
-export function projectedDocuments(projectedPaths: ReadonlyArray<string>): DocEntry[] {
-  return projectedPaths.map((path) => ({
+export function projectedDocuments(
+  projected: ReadonlyArray<{ readonly path: string; readonly uncommitted?: boolean }>,
+): DocEntry[] {
+  return projected.map(({ path, uncommitted }) => ({
     path,
     title: path.split("/").at(-1) ?? path,
     group: inferDocGroup(path),
     required: false,
     present: true,
     presence: "present" as const,
+    ...(uncommitted ? { uncommitted: true } : {}),
   }));
 }
 

--- a/packages/gui/src/renderer/model/types.ts
+++ b/packages/gui/src/renderer/model/types.ts
@@ -29,6 +29,8 @@ export interface DocEntry {
   present: boolean;
   /** 未完成文档 read 时不能把 absent 当 missing。 */
   presence?: "present" | "missing" | "unknown";
+  /** 工作树内容与已提交投影不同(或仅存在于工作树):树节点上标注「未提交」。 */
+  uncommitted?: boolean;
 }
 
 /** materialization gate / check 结果——任务详情收口区的"原因"维度 */

--- a/packages/gui/test/docTree.vitest.ts
+++ b/packages/gui/test/docTree.vitest.ts
@@ -1,10 +1,6 @@
 // harness-test-tier: integration
 import { describe, expect, it } from "vitest";
-import {
-  buildDocTree,
-  collectDirectoryPaths,
-  projectedDocuments,
-} from "../src/renderer/model/docTree.ts";
+import { buildDocTree, collectDirectoryPaths, projectedDocuments } from "../src/renderer/model/docTree.ts";
 import type { DocEntry } from "../src/renderer/model/types.ts";
 
 /**
@@ -28,10 +24,7 @@ function doc(path: string, overrides: Partial<DocEntry> = {}): DocEntry {
 
 describe("buildDocTree basic structure", () => {
   it("renders flat files as root-level leaves", () => {
-    const tree = buildDocTree([
-      doc("INDEX.md"),
-      doc("progress.md"),
-    ]);
+    const tree = buildDocTree([doc("INDEX.md"), doc("progress.md")]);
     expect(tree).toHaveLength(2);
     expect(tree.every((n) => !n.isDir)).toBe(true);
     expect(tree.map((n) => n.path)).toEqual(["INDEX.md", "progress.md"]);
@@ -44,18 +37,12 @@ describe("buildDocTree basic structure", () => {
 
 describe("buildDocTree ignores .gitkeep placeholders", () => {
   it("drops a root-level .gitkeep", () => {
-    const tree = buildDocTree([
-      doc("INDEX.md"),
-      doc(".gitkeep"),
-    ]);
+    const tree = buildDocTree([doc("INDEX.md"), doc(".gitkeep")]);
     expect(tree.map((n) => n.path)).toEqual(["INDEX.md"]);
   });
 
   it("drops a nested .gitkeep but keeps its siblings and directory", () => {
-    const tree = buildDocTree([
-      doc("artifacts/keymgmt-design/.gitkeep"),
-      doc("artifacts/keymgmt-design/design.md"),
-    ]);
+    const tree = buildDocTree([doc("artifacts/keymgmt-design/.gitkeep"), doc("artifacts/keymgmt-design/design.md")]);
     const artifacts = tree[0];
     const keymgmt = artifacts.children[0];
     expect(keymgmt.name).toBe("keymgmt-design");
@@ -63,10 +50,7 @@ describe("buildDocTree ignores .gitkeep placeholders", () => {
   });
 
   it("removes a directory that only held a .gitkeep", () => {
-    const tree = buildDocTree([
-      doc("INDEX.md"),
-      doc("artifacts/empty-dir/.gitkeep"),
-    ]);
+    const tree = buildDocTree([doc("INDEX.md"), doc("artifacts/empty-dir/.gitkeep")]);
     expect(tree.map((n) => n.name)).toEqual(["INDEX.md"]);
   });
 });
@@ -83,26 +67,15 @@ describe("buildDocTree nested directories", () => {
 
   it("groups files under their parent directories", () => {
     // Root: 2 dirs (artifacts, plan) + 2 files (INDEX, progress) — dirs first
-    expect(tree.map((n) => n.name)).toEqual([
-      "artifacts",
-      "plan",
-      "INDEX.md",
-      "progress.md",
-    ]);
+    expect(tree.map((n) => n.name)).toEqual(["artifacts", "plan", "INDEX.md", "progress.md"]);
 
     const artifacts = tree[0];
     expect(artifacts.isDir).toBe(true);
-    expect(artifacts.children.map((n) => n.name)).toEqual([
-      "orchestration",
-      "findings.md",
-    ]);
+    expect(artifacts.children.map((n) => n.name)).toEqual(["orchestration", "findings.md"]);
 
     const orchestration = artifacts.children[0];
     expect(orchestration.isDir).toBe(true);
-    expect(orchestration.children.map((n) => n.name)).toEqual([
-      "notes.md",
-      "report.md",
-    ]);
+    expect(orchestration.children.map((n) => n.name)).toEqual(["notes.md", "report.md"]);
   });
 
   it("preserves DocEntry on leaf nodes (present/required/title)", () => {
@@ -135,11 +108,7 @@ describe("buildDocTree nested directories", () => {
 
 describe("buildDocTree deep nesting", () => {
   it("handles arbitrarily deep paths (4+ levels)", () => {
-    const tree = buildDocTree([
-      doc("a/b/c/d/e.md"),
-      doc("a/b/f.md"),
-      doc("a/g.md"),
-    ]);
+    const tree = buildDocTree([doc("a/b/c/d/e.md"), doc("a/b/f.md"), doc("a/g.md")]);
 
     expect(tree).toHaveLength(1);
     const a = tree[0];
@@ -158,10 +127,7 @@ describe("buildDocTree deep nesting", () => {
   });
 
   it("merges files at different depths under the same ancestor", () => {
-    const tree = buildDocTree([
-      doc("artifacts/top.md"),
-      doc("artifacts/deep/inner.md"),
-    ]);
+    const tree = buildDocTree([doc("artifacts/top.md"), doc("artifacts/deep/inner.md")]);
 
     const artifacts = tree[0];
     expect(artifacts.children.map((n) => n.name)).toEqual(["deep", "top.md"]);
@@ -171,9 +137,7 @@ describe("buildDocTree deep nesting", () => {
 
 describe("buildDocTree title display", () => {
   it("uses DocEntry.title for file display name, not raw filename", () => {
-    const tree = buildDocTree([
-      doc("plan/task-plan.md", { title: "任务计划" }),
-    ]);
+    const tree = buildDocTree([doc("plan/task-plan.md", { title: "任务计划" })]);
     const plan = tree[0];
     expect(plan.name).toBe("plan"); // directory uses segment name
     expect(plan.children[0].name).toBe("任务计划"); // file uses title
@@ -182,10 +146,7 @@ describe("buildDocTree title display", () => {
 
 describe("collectDirectoryPaths", () => {
   it("collects directory paths up to maxDepth", () => {
-    const tree = buildDocTree([
-      doc("a/b.md"),
-      doc("x/y/z.md"),
-    ]);
+    const tree = buildDocTree([doc("a/b.md"), doc("x/y/z.md")]);
 
     // depth 0: top-level dirs only
     expect(collectDirectoryPaths(tree, 0).sort()).toEqual(["a", "x"]);
@@ -195,22 +156,23 @@ describe("collectDirectoryPaths", () => {
   });
 
   it("with maxDepth=0 returns only root directories (for default expand)", () => {
-    const tree = buildDocTree([
-      doc("artifacts/inner/deep.md"),
-      doc("plan/task.md"),
-    ]);
+    const tree = buildDocTree([doc("artifacts/inner/deep.md"), doc("plan/task.md")]);
     const rootDirs = collectDirectoryPaths(tree, 0);
     expect(rootDirs.sort()).toEqual(["artifacts", "plan"]);
   });
 });
 
-
 describe("projectedDocuments", () => {
   it("titles each entry by basename and groups artifacts/ apart from the rest", () => {
-    const entries = projectedDocuments(["task_plan.md", "artifacts/report.md", "artifacts/orchestration/notes.md"]);
+    const entries = projectedDocuments([
+      { path: "task_plan.md" },
+      { path: "artifacts/report.md", uncommitted: true },
+      { path: "artifacts/orchestration/notes.md" },
+    ]);
     expect(entries.map((entry) => entry.title)).toEqual(["task_plan.md", "report.md", "notes.md"]);
     expect(entries.map((entry) => entry.group)).toEqual(["进度", "证据", "证据"]);
     expect(entries.every((entry) => entry.present && !entry.required)).toBe(true);
+    expect(entries.map((entry) => entry.uncommitted ?? false)).toEqual([false, true, false]);
   });
 
   it("returns nothing for an empty projection", () => {

--- a/packages/gui/test/renderer-app-model.vitest.ts
+++ b/packages/gui/test/renderer-app-model.vitest.ts
@@ -344,6 +344,9 @@ describe("renderer app model", () => {
       path,
       body: "# Canonical task plan",
       blobSha256: "sha256:canonical",
+      worktreeBody: null,
+      worktreeBlobSha256: null,
+      uncommitted: false,
       watermark: 7,
       sourceRevision: 7,
     }));

--- a/packages/gui/test/task-detail-expression.vitest.ts
+++ b/packages/gui/test/task-detail-expression.vitest.ts
@@ -285,6 +285,17 @@ describe("Task detail expression", () => {
     expect(byTestId("task-files-tab").textContent).toContain("Canonical plan body");
   });
 
+  it("renders live worktree content and marks an unsynced task document", async () => {
+    installBridge({ uncommittedPlan: true });
+    await mount();
+
+    await clickTab("文件");
+    expect(byTestId("task-files-tab").textContent).toContain("Live worktree plan body");
+    expect(byTestId("task-files-tab").textContent).not.toContain("Canonical plan body");
+    expect(byTestId("task-document-uncommitted").textContent).toContain("工作树内容尚未提交");
+    expect(byTestId("doc-uncommitted-task_plan.md").textContent).toContain("未提交");
+  });
+
   it("adapts the detail card and reader to container width; manual layout controls still override", async () => {
     installBridge();
     await mount();
@@ -360,7 +371,7 @@ describe("Task detail expression", () => {
   });
 });
 
-function installBridge() {
+function installBridge({ uncommittedPlan = false }: { readonly uncommittedPlan?: boolean } = {}) {
   const bridge = {
     getTaskDocument: vi.fn(async ({ taskId, path }: { taskId: string; path: string }) => ({
       ok: true,
@@ -374,6 +385,9 @@ function installBridge() {
             ? '<style>body{color:#123}</style><h1>Night report</h1><script>window.open("https://example.invalid")</script>'
             : `# ${path}`,
       blobSha256: `sha256:${"d".repeat(64)}`,
+      worktreeBody: uncommittedPlan && path === "task_plan.md" ? "# Live worktree plan body" : null,
+      worktreeBlobSha256: uncommittedPlan && path === "task_plan.md" ? "e".repeat(64) : null,
+      uncommitted: uncommittedPlan && path === "task_plan.md",
       watermark: 7,
       sourceRevision: 7,
     })),
@@ -382,10 +396,28 @@ function installBridge() {
       status: "ready",
       taskId: "task-w3",
       documents: [
-        { path: "task_plan.md", blobSha256: "d".repeat(64), size: 20, mediaType: "text/markdown" },
-        { path: "INDEX.md", blobSha256: "e".repeat(64), size: 20, mediaType: "text/markdown" },
-        { path: "artifacts/report.md", blobSha256: "f".repeat(64), size: 20, mediaType: "text/markdown" },
-        { path: "artifacts/reports/night.html", blobSha256: "a".repeat(64), size: 120, mediaType: "text/html" },
+        {
+          path: "task_plan.md",
+          blobSha256: "d".repeat(64),
+          size: 20,
+          mediaType: "text/markdown",
+          uncommitted: uncommittedPlan,
+        },
+        { path: "INDEX.md", blobSha256: "e".repeat(64), size: 20, mediaType: "text/markdown", uncommitted: false },
+        {
+          path: "artifacts/report.md",
+          blobSha256: "f".repeat(64),
+          size: 20,
+          mediaType: "text/markdown",
+          uncommitted: false,
+        },
+        {
+          path: "artifacts/reports/night.html",
+          blobSha256: "a".repeat(64),
+          size: 120,
+          mediaType: "text/html",
+          uncommitted: false,
+        },
       ],
       watermark: 7,
       sourceRevision: 7,

--- a/tools/gates/canonical-event-compat.mjs
+++ b/tools/gates/canonical-event-compat.mjs
@@ -179,8 +179,14 @@ export function projectFrozenDaemonResponses(rootDir) {
       ["validateDaemonAgenda", model.agenda({ limit: 100 })],
       ["validateDaemonRelationGraph", model.relationGraph()],
       ["validateDaemonDecisionList", decisionRead],
-      ["validateDaemonDocumentRead", readProjectedDocument(projection, { taskId: DISPATCH_TASK_ID, path: "INDEX.md" })],
-      ["validateDaemonTaskDocumentList", listProjectedTaskDocuments(projection, { taskId: DISPATCH_TASK_ID })],
+      [
+        "validateDaemonDocumentRead",
+        readProjectedDocument(temporaryRoot, projection, { taskId: DISPATCH_TASK_ID, path: "INDEX.md" })
+      ],
+      [
+        "validateDaemonTaskDocumentList",
+        listProjectedTaskDocuments(temporaryRoot, projection, { taskId: DISPATCH_TASK_ID })
+      ],
       ["validateDaemonTaskDispatches", readTaskDispatches({ rootDir: temporaryRoot, projection, taskId: DISPATCH_TASK_ID })]
     ]);
     return [...responses].map(([name, value]) => ({ name, value, sourceEventIds: sourceEventIds(name) }));

--- a/tools/gates/test/canonical-event-compat.test.mjs
+++ b/tools/gates/test/canonical-event-compat.test.mjs
@@ -1,73 +1,107 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
 import test from "node:test";
-import { validateFrozenCanonicalEvents, validateFrozenDaemonReadside, validateProjectedDaemonResponses } from "../canonical-event-compat.mjs";
+import {
+  projectFrozenDaemonResponses,
+  validateFrozenCanonicalEvents,
+  validateFrozenDaemonReadside,
+  validateProjectedDaemonResponses,
+} from "../canonical-event-compat.mjs";
 import { repoRoot } from "../git.mjs";
 import { makeRepo } from "./helpers.mjs";
 
 test("canonical event compatibility gate names a rejected frozen sample", () => {
   const { rootDir } = makeRepo({
-    "packages/kernel/fixtures/canonical-events/task-event-v1/sample.json": "{\"schema\":\"task-event/v1\"}\n"
+    "packages/kernel/fixtures/canonical-events/task-event-v1/sample.json": '{"schema":"task-event/v1"}\n',
   });
 
-  const errors = validateFrozenCanonicalEvents(rootDir, [{
-    schema: "task-event/v1",
-    validate: () => ["legacy shape is no longer accepted"]
-  }]);
+  const errors = validateFrozenCanonicalEvents(rootDir, [
+    {
+      schema: "task-event/v1",
+      validate: () => ["legacy shape is no longer accepted"],
+    },
+  ]);
 
   assert.deepEqual(errors, [
-    "packages/kernel/fixtures/canonical-events/task-event-v1/sample.json: task-event/v1 rejected frozen sample: legacy shape is no longer accepted"
+    "packages/kernel/fixtures/canonical-events/task-event-v1/sample.json: task-event/v1 rejected frozen sample: legacy shape is no longer accepted",
   ]);
 });
 
 test("canonical event compatibility gate binds each sample to its directory schema", () => {
   const { rootDir } = makeRepo({
-    "packages/kernel/fixtures/canonical-events/task-event-v1/sample.json": "{\"schema\":\"doc-event/v1\"}\n"
+    "packages/kernel/fixtures/canonical-events/task-event-v1/sample.json": '{"schema":"doc-event/v1"}\n',
   });
 
-  assert.deepEqual(validateFrozenCanonicalEvents(rootDir, [{
-    schema: "task-event/v1",
-    validate: () => []
-  }]), [
-    "packages/kernel/fixtures/canonical-events/task-event-v1/sample.json: expected task-event/v1, found doc-event/v1"
-  ]);
+  assert.deepEqual(
+    validateFrozenCanonicalEvents(rootDir, [
+      {
+        schema: "task-event/v1",
+        validate: () => [],
+      },
+    ]),
+    ["packages/kernel/fixtures/canonical-events/task-event-v1/sample.json: expected task-event/v1, found doc-event/v1"],
+  );
 });
 
 test("canonical event compatibility gate verifies the frozen bytes, not only parsed JSON", () => {
   const { rootDir } = makeRepo({
-    "packages/kernel/fixtures/canonical-events/task-event-v1/sample.json": "{ \"schema\": \"task-event/v1\" }\n"
+    "packages/kernel/fixtures/canonical-events/task-event-v1/sample.json": '{ "schema": "task-event/v1" }\n',
   });
 
-  assert.deepEqual(validateFrozenCanonicalEvents(rootDir, [{
-    schema: "task-event/v1",
-    validate: () => []
-  }], () => { throw new Error("canonical event bytes are not canonical"); }), [
-    "packages/kernel/fixtures/canonical-events/task-event-v1/sample.json: frozen bytes are invalid: canonical event bytes are not canonical"
-  ]);
+  assert.deepEqual(
+    validateFrozenCanonicalEvents(
+      rootDir,
+      [
+        {
+          schema: "task-event/v1",
+          validate: () => [],
+        },
+      ],
+      () => {
+        throw new Error("canonical event bytes are not canonical");
+      },
+    ),
+    [
+      "packages/kernel/fixtures/canonical-events/task-event-v1/sample.json: frozen bytes are invalid: canonical event bytes are not canonical",
+    ],
+  );
 });
 
 test("canonical event compatibility gate names the source event, validator, and rejected field", () => {
-  const errors = validateProjectedDaemonResponses([{
-    name: "validateDaemonDecisionList",
-    sourceEventIds: ["event-83528bd4ab507b4464f6367395476707fd11d8b055bafa53eb569e189f0d1f58"],
-    value: { ok: true, decisions: [{}] }
-  }], [{
-    name: "validateDaemonDecisionList",
-    validate: () => ["compatibilityCanary is required"]
-  }]);
+  const errors = validateProjectedDaemonResponses(
+    [
+      {
+        name: "validateDaemonDecisionList",
+        sourceEventIds: ["event-83528bd4ab507b4464f6367395476707fd11d8b055bafa53eb569e189f0d1f58"],
+        value: { ok: true, decisions: [{}] },
+      },
+    ],
+    [
+      {
+        name: "validateDaemonDecisionList",
+        validate: () => ["compatibilityCanary is required"],
+      },
+    ],
+  );
 
   assert.deepEqual(errors, [
-    "event-83528bd4ab507b4464f6367395476707fd11d8b055bafa53eb569e189f0d1f58 -> validateDaemonDecisionList rejected projected history: compatibilityCanary is required"
+    "event-83528bd4ab507b4464f6367395476707fd11d8b055bafa53eb569e189f0d1f58 -> validateDaemonDecisionList rejected projected history: compatibilityCanary is required",
   ]);
 });
 
 test("canonical event compatibility gate requires a projected historical sample for every registered validator", () => {
-  assert.deepEqual(validateProjectedDaemonResponses([], [{
-    name: "validateDaemonAgenda",
-    validate: () => []
-  }]), [
-    "validateDaemonAgenda: no projected historical sample"
-  ]);
+  assert.deepEqual(
+    validateProjectedDaemonResponses(
+      [],
+      [
+        {
+          name: "validateDaemonAgenda",
+          validate: () => [],
+        },
+      ],
+    ),
+    ["validateDaemonAgenda: no projected historical sample"],
+  );
 });
 
 test("canonical event compatibility gate projects the locked history through production reads", () => {
@@ -75,4 +109,18 @@ test("canonical event compatibility gate projects the locked history through pro
   assert.deepEqual(result.errors, []);
   assert.equal(result.eventCount, 5);
   assert.ok(result.durationMs < 5_000);
+});
+
+test("locked-history document reads replay through the rootDir-first production signature without a worktree", () => {
+  const responses = new Map(projectFrozenDaemonResponses(repoRoot()).map(({ name, value }) => [name, value]));
+  const read = responses.get("validateDaemonDocumentRead"),
+    list = responses.get("validateDaemonTaskDocumentList");
+  assert.equal(read.ok, true);
+  assert.equal(read.uncommitted, false, "projection-only history must not be labelled uncommitted");
+  assert.equal(read.worktreeBody, null);
+  assert.equal(list.ok, true);
+  assert.ok(
+    list.documents.every((row) => row.uncommitted === false),
+    JSON.stringify(list.documents),
+  );
 });


### PR DESCRIPTION
# English

## Summary

Phase 4.0 line 4 (task_e5defe69): the GUI task file surface now shows what is on disk. `repo.tasks.document.read` returns both the canonical projection body and the live task-package worktree body with its hash and an `uncommitted` flag; `repo.tasks.documents.list` merges projected files with text files that exist only in the worktree. Reads are confined to the task package (symlink traversal rejected), one file ≤ 2 MiB, at most 2000 documents scanned. The GUI file tree marks uncommitted entries and the reader prefers the live body with an explicit notice; the projection stays as the committed-state reference.

## Architectural Justification

- Production-Delta +251/-34: one bounded worktree read added to the existing document read/list handlers; no new store, write path or fallback.

## What Changed

- `packages/daemon/src/doc-sync-reads.ts`, `repo-cell-api.ts`: live worktree body/hash/uncommitted on read; worktree-only files on list.
- `packages/daemon/src/protocol/daemon-protocol-gui-types.ts`, `daemon-protocol-schema-ids.ts`, `daemon-protocol-validate-results.ts`: new required fields registered.
- `packages/gui/src/renderer/components/taskDetail/DocTree.tsx`, `TaskFilesTab.tsx`, `model/docTree.ts`, `model/types.ts`, `api-client.ts`, i18n: uncommitted marker and live-body notice.
- Tests: daemon `task-documents-list.integration.test.ts`; gui `docTree`, `renderer-app-model`, `task-detail-expression` vitest.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +251/-34

### Optional Evidence Claims

## Task And Scope

- Harness task: task_e5defe6921fa47c4f770f30bac
- Branch: codex/gui-task-file-live
- Public scope: packages/daemon/src (document read/list + protocol types), packages/gui/src/renderer (task detail files), tests
- Private planning/evidence updated: yes
- Out of scope: Why the projection itself lags after `ha doc sync --submit` (repro step 2) is not touched here; until that is fixed a just-synced file can show as uncommitted for a while — filed as a follow-up task under Phase 4. Files deleted on disk but present in the projection still render the committed body without a marker (product ruling pending). Electron e2e not run in the worktree.

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_e5defe6921fa47c4f770f30bac
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-28T00:11:04Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_e5defe6921fa47c4f770f30bac (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] daemon `task-documents-list.integration.test.ts` 3/3; mutation check (force uncommitted=false) makes it 2/3, restored 3/3
- [x] gui vitest docTree + task-detail-expression + renderer-app-model 39/39
- [x] line-density pass; production-delta computed +251/-34; r2 adds consumeKnownError on 3 bounded fs catches and aligns the canonical-event-compat gate call with the rootDir-first signature
- [ ] CI on this PR
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix and Electron e2e by design; CI is the authority.

## Review Evidence

- Self-review: CEO semantic acceptance against repro-2026-08-24: uncommitted edits and worktree-only files are now visible and labelled; the deeper projection-lag layer is explicitly deferred, not hidden.
- Reviewer subagent: Started by GLM, finished by Sol (task_0e1432e9 line 4, report artifacts/reports/line4-task-file-live.md, fact F-036FFE61); accepted by CEO.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Bounded read only: text extensions, 2 MiB per file, 2000 documents; symlinks rejected. A lagging projection can mislabel a synced file as uncommitted until the follow-up lands.

## References

- Task: task_e5defe6921fa47c4f770f30bac
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

Phase 4.0 第 4 条线(task_e5defe69):GUI 的任务文件面现在显示磁盘上的内容。`repo.tasks.document.read` 同时返回 canonical projection 正文与 task package 工作树的实时正文、哈希和 `uncommitted` 标记;`repo.tasks.documents.list` 把投影文件与仅存在于工作树的文本文件合并。读取限制在 task package 内(拒绝符号链接穿越),单文件 ≤ 2 MiB,最多扫描 2000 个文档。GUI 文件树标出未提交项,reader 优先展示实时正文并给出明确提示;projection 保留为提交态依据。

## 架构辩护

- Production-Delta +251/-34:在现有 document read/list 处理器上加一个有界的工作树读取;无新 store、写路或 fallback。

## 改动内容

- `packages/daemon/src/doc-sync-reads.ts`、`repo-cell-api.ts`:read 返回实时正文/哈希/uncommitted;list 纳入仅工作树文件。
- `packages/daemon/src/protocol/daemon-protocol-gui-types.ts`、`daemon-protocol-schema-ids.ts`、`daemon-protocol-validate-results.ts`:登记新必填字段。
- `packages/gui/src/renderer/components/taskDetail/DocTree.tsx`、`TaskFilesTab.tsx`、`model/docTree.ts`、`model/types.ts`、`api-client.ts`、i18n:未提交标记与实时正文提示。
- 测试:daemon `task-documents-list.integration.test.ts`;gui `docTree`、`renderer-app-model`、`task-detail-expression` vitest。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_e5defe6921fa47c4f770f30bac
- 分支:codex/gui-task-file-live
- 公开范围:packages/daemon/src(document read/list + 协议类型)、packages/gui/src/renderer(任务详情文件面)、测试
- 私有计划 / 证据是否已更新:yes
- 范围外:`ha doc sync --submit` 后 projection 自身滞后(复现第 2 步)的原因不在本 PR;修好之前刚 sync 的文件可能短暂显示为未提交——已在 Phase 4 下立后续 task。磁盘已删但 projection 仍有的文件继续显示提交态正文且无标记(待产品裁决)。worktree 内未跑 Electron e2e。

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_e5defe6921fa47c4f770f30bac
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-28T00:11:04Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_e5defe6921fa47c4f770f30bac
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] daemon `task-documents-list.integration.test.ts` 3/3;变异检查(强制 uncommitted=false)变 2/3,恢复后 3/3
- [x] gui vitest docTree + task-detail-expression + renderer-app-model 39/39
- [x] line-density 通过;production-delta 实算 +251/-34;r2 给 3 处有界 fs catch 加 consumeKnownError,并把 canonical-event-compat 门的调用对齐 rootDir 首参签名
- [ ] 本 PR 的 CI
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量与 Electron e2e;以 CI 为权威。

## 审查证据

- 自查:CEO 对照 repro-2026-08-24 语义验收:未提交编辑与仅工作树文件现在可见并有标记;更深一层的 projection 滞后明确延后,不是被掩盖。
- Reviewer subagent:GLM 起头、Sol 收尾(task_0e1432e9 第 4 条线,报告 artifacts/reports/line4-task-file-live.md,fact F-036FFE61);CEO 验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 只做有界读取:文本扩展名、单文件 2 MiB、2000 个文档;拒绝符号链接。projection 滞后时,已 sync 的文件可能被误标未提交,直到后续任务落地。

## 关联材料

- 任务:task_e5defe6921fa47c4f770f30bac
- 证据:任务包 artifacts/reports
- 审查:本 PR
