### PR TITLE
refactor: delete six zero-reader leftovers from Phase 4.0 PRs (anti-entropy)

### DIFF
--- a/packages/daemon/src/doc-sync-reads.ts
+++ b/packages/daemon/src/doc-sync-reads.ts
@@ -218,7 +218,6 @@ export function readProjectedDocument(
     // now, not only the committed projection — an edited-but-unsynced plan is real work
     // and must be visible and explicitly marked as not yet committed.
     worktreeBody: worktree?.body ?? null,
-    worktreeBlobSha256: worktree?.blobSha256 ?? null,
     uncommitted: worktree !== null && worktree.blobSha256 !== (read.document?.blobSha256 ?? null),
     watermark: read.watermark,
     sourceRevision: read.sourceRevision,

--- a/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-gui-types.ts
@@ -305,7 +305,6 @@ export type DaemonGuiReadResultMap = {
     /** Live worktree view (task_e5defe69): disk content now, and whether it diverges
      * from the committed projection. Null body = no such file on disk. */
     readonly worktreeBody: string | null;
-    readonly worktreeBlobSha256: string | null;
     readonly uncommitted: boolean;
     readonly watermark: number;
     readonly sourceRevision: number;

--- a/packages/daemon/src/protocol/daemon-protocol-schema-ids.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-schema-ids.ts
@@ -60,7 +60,6 @@ export const DAEMON_RELATION_GRAPH_SCHEMA = Object.freeze({
       "body",
       "blobSha256",
       "worktreeBody",
-      "worktreeBlobSha256",
       "uncommitted",
       "watermark",
       "sourceRevision",

--- a/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
@@ -38,8 +38,6 @@ export function validateDaemonDocumentRead(value: unknown): readonly string[] {
     (value.blobSha256 !== null &&
       (typeof value.blobSha256 !== "string" || !/^[0-9a-f]{64}$/u.test(value.blobSha256))) ||
     (value.worktreeBody !== null && typeof value.worktreeBody !== "string") ||
-    (value.worktreeBlobSha256 !== null &&
-      (typeof value.worktreeBlobSha256 !== "string" || !/^[0-9a-f]{64}$/u.test(value.worktreeBlobSha256))) ||
     typeof value.uncommitted !== "boolean" ||
     !integer(value.watermark) ||
     !integer(value.sourceRevision)

--- a/packages/daemon/src/runtime-spawner.ts
+++ b/packages/daemon/src/runtime-spawner.ts
@@ -186,7 +186,6 @@ export function makeRuntimeSpawner(input: {
         "agentId",
         "targetAgentId",
         "squadId",
-        "parentRuntimeSessionId",
         "model",
         "effort",
         "permissionMode",
@@ -221,12 +220,7 @@ export function makeRuntimeSpawner(input: {
           : requiredRuntimeSpawnText(payload.targetAgentId, "targetAgentId"),
       squadId = payload.squadId === undefined ? undefined : requiredRuntimeSpawnText(payload.squadId, "squadId"),
       // Delegation provenance: which already-running runtime session invoked this spawn.
-      // Explicit input serves routes whose binding carries no executor (fleet edge); the
-      // local CLI route already declares the caller runtime session in binding.actor.
-      parentRuntimeSessionId =
-        payload.parentRuntimeSessionId === undefined
-          ? runtimeSessionIdFromActor(binding.actor)
-          : requiredRuntimeSpawnText(payload.parentRuntimeSessionId, "parentRuntimeSessionId"),
+      parentRuntimeSessionId = runtimeSessionIdFromActor(binding.actor),
       model = payload.model === undefined ? undefined : requiredRuntimeSpawnText(payload.model, "model"),
       effort = payload.effort === undefined ? undefined : requiredRuntimeSpawnText(payload.effort, "effort"),
       permissionMode =

--- a/packages/daemon/test/dispatch-parent-session.integration.test.ts
+++ b/packages/daemon/test/dispatch-parent-session.integration.test.ts
@@ -12,8 +12,7 @@ import type { RuntimeProcess } from "../src/runtime-spawn-types.ts";
 import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
 
-const explicitParentSessionId = "runtime_0123456789abcdef01234567",
-  bindingSessionId = "runtime_89abcdef0123456789abcdef",
+const bindingSessionId = "runtime_89abcdef0123456789abcdef",
   personBinding = {
     actor: { principal: { personId: "person-parent-session" }, executor: null },
     source: "local" as const,
@@ -32,57 +31,6 @@ const explicitParentSessionId = "runtime_0123456789abcdef01234567",
     version: "1.0.0",
     observedAt: "2026-08-28T00:00:00.000Z",
   };
-
-test("a delegated dispatch records the caller-declared parent runtime session on its stream header", async () => {
-  const parent = mkdtempSync(path.join(tmpdir(), "ha-parent-session-edge-")),
-    root = path.join(parent, "repo");
-  mkdirSync(root);
-  git(root, "init", "-q");
-  git(root, "config", "user.name", "Parent Session Test");
-  git(root, "config", "user.email", "parent-session@example.invalid");
-  git(root, "commit", "--allow-empty", "-qm", "base");
-  const cell = await openRepoCell({
-    repoId: workspaceId("parent-session-edge"),
-    rootDir: canonicalRoot(root),
-    ownerId: "parent-session-test",
-    runtimeInstances: () => [runtimeInstance("codex-parent")],
-    prepareRuntimeLaunch: async (instanceId, request) => ({
-      definition: definition(instanceId, request.model ?? "codex-parent-model"),
-      installation,
-      executablePath: installation.executablePath,
-      args: ["exec", "--json", "-"],
-      env: {},
-      cwd: request.cwd,
-      prompt: request.prompt,
-    }),
-    runtimeLaunch: () => fakeProcess(7101, "success"),
-  });
-  try {
-    await installSquad(cell);
-    const receipt = await cell.spawnRuntime(
-      {
-        runtimeInstanceId: "codex-parent",
-        agentId: "parent-leader",
-        targetAgentId: "parent-worker",
-        squadId: "parent-squad",
-        parentRuntimeSessionId: explicitParentSessionId,
-        cwd: { scope: "repo-root" },
-        prompt: "Delegate one worker.",
-        taskId: null,
-        idempotencyKey: "parent-session-explicit",
-      },
-      executorBinding,
-    );
-    const stream = readDispatchStream(root, String(receipt.dispatchId));
-    assert.ok(stream, "delegated dispatch stream exists");
-    assert.equal(stream.header.parentRuntimeSessionId, explicitParentSessionId);
-    assert.equal(stream.header.delegatedByAgentId, "parent-leader");
-    assert.equal(stream.header.squadId, "parent-squad");
-  } finally {
-    await cell.close();
-    rmSync(parent, { recursive: true, force: true });
-  }
-});
 
 test("a local binding executor names the parent runtime session when the caller passes none", async () => {
   const parent = mkdtempSync(path.join(tmpdir(), "ha-parent-session-binding-")),
@@ -172,7 +120,6 @@ test("a leader-only squad dispatch keeps its squad attribution after settlement 
         runtimeInstanceId: "codex-parent",
         agentId: "parent-leader",
         squadId: "parent-squad",
-        parentRuntimeSessionId: explicitParentSessionId,
         cwd: { scope: "repo-root" },
         prompt: "Run as the attributed squad leader.",
         taskId,
@@ -183,7 +130,7 @@ test("a leader-only squad dispatch keeps its squad attribution after settlement 
     const stream = readDispatchStream(root, String(receipt.dispatchId));
     assert.ok(stream, "leader dispatch stream exists");
     assert.equal(stream.header.squadId, "parent-squad");
-    assert.equal(stream.header.parentRuntimeSessionId, explicitParentSessionId);
+    assert.equal(Object.hasOwn(stream.header, "parentRuntimeSessionId"), false);
     assert.equal(Object.hasOwn(stream.header, "delegatedByAgentId"), false);
     const rows = await eventually(async () => {
       const result = (await cell.read("repo.task.dispatches", { taskId })) as {
@@ -197,8 +144,9 @@ test("a leader-only squad dispatch keeps its squad attribution after settlement 
       const settled = result.dispatches.find((row) => row.endedAt !== null);
       return settled?.dispatchPath ? result.dispatches : null;
     });
-    const leaderRow = rows.find((row) => row.parentRuntimeSessionId === explicitParentSessionId);
-    assert.ok(leaderRow, "settled leader row keeps its parent session edge");
+    const leaderRow = rows.find((row) => row.squadId === "parent-squad");
+    assert.ok(leaderRow, "settled leader row keeps its squad attribution");
+    assert.equal(Object.hasOwn(leaderRow, "parentRuntimeSessionId"), false);
     assert.equal(leaderRow.squadId, "parent-squad");
     const document = (await cell.read("repo.tasks.document.read", {
         taskId,
@@ -206,7 +154,7 @@ test("a leader-only squad dispatch keeps its squad attribution after settlement 
       })) as { readonly body: string },
       archived = JSON.parse(document.body) as Record<string, unknown>;
     assert.equal(archived.squadId, "parent-squad");
-    assert.equal(archived.parentRuntimeSessionId, explicitParentSessionId);
+    assert.equal(Object.hasOwn(archived, "parentRuntimeSessionId"), false);
     assert.equal(Object.hasOwn(archived, "delegatedByAgentId"), false);
   } finally {
     await cell.close();

--- a/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
+++ b/packages/daemon/test/runtime-spawn-lifecycle.integration.test.ts
@@ -141,7 +141,7 @@ test("runtime spawn publishes a canonical session and makes it visible in overvi
           error.code === "invalid_runtime_spawn" &&
           error.message ===
             'Runtime spawn payload contains an unknown field "permission_mode"; allowed fields: "runtimeInstanceId", ' +
-              '"dispatchId", "agentId", "targetAgentId", "squadId", "parentRuntimeSessionId", "model", "effort", "permissionMode", "cwd", ' +
+              '"dispatchId", "agentId", "targetAgentId", "squadId", "model", "effort", "permissionMode", "cwd", ' +
               '"prompt", "promptSource", "onExitCommand", "taskId", "idempotencyKey", "providerSessionId".',
       );
       await assert.rejects(

--- a/packages/gui/src/renderer/api-client.ts
+++ b/packages/gui/src/renderer/api-client.ts
@@ -536,7 +536,6 @@ function readTaskDocumentResult(value: unknown): TaskDocumentProjectionRead {
     typeof result.path !== "string" ||
     typeof result.body !== "string" ||
     (result.worktreeBody !== null && typeof result.worktreeBody !== "string") ||
-    (result.worktreeBlobSha256 !== null && typeof result.worktreeBlobSha256 !== "string") ||
     typeof result.uncommitted !== "boolean" ||
     !Number.isInteger(result.watermark) ||
     !Number.isInteger(result.sourceRevision)

--- a/packages/gui/src/renderer/components/DispatchDialog.tsx
+++ b/packages/gui/src/renderer/components/DispatchDialog.tsx
@@ -50,7 +50,7 @@ export function DispatchDialog({
     [cwdPath, setCwdPath] = useState(""),
     [model, setModel] = useState(""),
     [effort, setEffort] = useState("");
-  const executor = dispatchExecutorRef(useMemo(() => ({ subject }), [subject])),
+  const executor = dispatchExecutorRef({ subject }),
     runtimeType = executor?.runtimeType ?? "";
   const compatible = useMemo(() => compatibleDispatchInstances(runtimeType, instances), [runtimeType, instances]);
   const instance =

--- a/packages/gui/src/renderer/components/runtime/SquadCard.tsx
+++ b/packages/gui/src/renderer/components/runtime/SquadCard.tsx
@@ -190,7 +190,6 @@ export function SquadCard({ detail, row, agents, busy, onSave, onSelectAgent, on
 
         <Sect title={t("agentRuntime.actions")}>
           <div className="flex flex-wrap items-center gap-2">
-            <Hint>{t("agentRuntime.launchSquadHint")}</Hint>
             <span className="flex-1" />
             <Btn
               variant="primary"

--- a/packages/gui/src/renderer/components/runtime/SquadCockpit.tsx
+++ b/packages/gui/src/renderer/components/runtime/SquadCockpit.tsx
@@ -11,33 +11,28 @@ import type { RuntimeDockRow } from "./useRuntimeWorkspace.ts";
 // leader→worker 边、parentRuntimeSessionId 定「哪一次 Commander 会话派出的」——不引入
 // 第二个真相源,不做时间邻近猜测。
 
-export interface SquadCockpitRow extends RuntimeDockRow {
-  readonly delegatedByAgentId: string | null;
-  readonly parentRuntimeSessionId: string | null;
-}
-
 export type SquadCommanderRun = {
-  readonly row: SquadCockpitRow;
-  readonly children: readonly SquadCockpitRow[];
+  readonly row: RuntimeDockRow;
+  readonly children: readonly RuntimeDockRow[];
 };
 
 export type SquadCockpitModel = {
   readonly commanderRuns: readonly SquadCommanderRun[];
-  readonly unboundWorkers: readonly SquadCockpitRow[];
+  readonly unboundWorkers: readonly RuntimeDockRow[];
 };
 
 /** 纯分组:Commander 行 = 该小队里执行者是 leader 的派工;下级行按
  * parentRuntimeSessionId 绑到对应 Commander 会话,没有该边的历史行走 unbound,
  * 仍以 squadId + delegatedByAgentId 呈现小队归属与 agent 级组织边。 */
-export function squadCockpitModel(squad: SquadEntityDetail, rows: readonly SquadCockpitRow[]): SquadCockpitModel {
+export function squadCockpitModel(squad: SquadEntityDetail, rows: readonly RuntimeDockRow[]): SquadCockpitModel {
   const ordered = [...rows]
       .filter((row) => row.squadId === squad.id)
       .sort((left, right) => right.startedAt.localeCompare(left.startedAt)),
     commanderRuns = ordered
       .filter((row) => row.agentId === squad.leader)
-      .map((row) => ({ row, children: [] as SquadCockpitRow[] })),
+      .map((row) => ({ row, children: [] as RuntimeDockRow[] })),
     bySession = new Map(commanderRuns.map((run) => [run.row.runtimeSessionId, run])),
-    unboundWorkers: SquadCockpitRow[] = [];
+    unboundWorkers: RuntimeDockRow[] = [];
   for (const row of ordered) {
     if (row.agentId === squad.leader) continue;
     const parent = row.parentRuntimeSessionId === null ? undefined : bySession.get(row.parentRuntimeSessionId);
@@ -55,7 +50,7 @@ export function SquadCockpit({
   onOpenSession,
 }: {
   readonly squad: SquadEntityDetail;
-  readonly rows: readonly SquadCockpitRow[];
+  readonly rows: readonly RuntimeDockRow[];
   readonly busy: boolean;
   readonly onLaunch: () => void;
   readonly onOpenSession: (runtimeSessionId: string) => void;
@@ -141,7 +136,7 @@ function CockpitLane({
   role,
   onOpenSession,
 }: {
-  readonly row: SquadCockpitRow;
+  readonly row: RuntimeDockRow;
   readonly role: "commander" | "worker";
   readonly onOpenSession: (runtimeSessionId: string) => void;
 }) {

--- a/packages/gui/src/renderer/components/runtime/useRuntimeWorkspace.ts
+++ b/packages/gui/src/renderer/components/runtime/useRuntimeWorkspace.ts
@@ -38,7 +38,6 @@ export type RuntimeDockRow = {
   readonly taskId: string | null;
   readonly taskTitle: string | null;
   readonly startedAt: string;
-  readonly endedAt: string | null;
   readonly status: string;
   readonly liveness: "live" | "stale" | "unknown" | "exited" | null;
   readonly dispatchId: string | null;
@@ -276,7 +275,6 @@ export function useAgentSquadWorkspace(
       taskId: row.taskId,
       taskTitle: relatedLabels.get(row.taskId) ?? null,
       startedAt: row.startedAt,
-      endedAt: row.endedAt ?? null,
       status: row.status,
       liveness: null,
       dispatchId: row.dispatchId,

--- a/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/en-US/agentRuntime.json
@@ -154,7 +154,6 @@
   "agentRuntime.rosterHint": "The leader does no capability scoring: it reads this roster and decides in natural language.",
   "agentRuntime.rosterWarn": "The wording is load-bearing configuration: write what each member can do, not what each member is.",
   "agentRuntime.launchSquad": "Launch Commander…",
-  "agentRuntime.launchSquadHint": "One launch starts the Commander session; the Commander decomposes and dispatches its own workers.",
   "agentRuntime.noSessions": "No session",
   "agentRuntime.unattributed": "Unattributed",
   "agentRuntime.noTask": "no task",

--- a/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
+++ b/packages/gui/src/renderer/i18n/locales/zh-CN/agentRuntime.json
@@ -154,7 +154,6 @@
   "agentRuntime.rosterHint": "Leader 不做能力评分,它读这份花名册用自然语言判断派谁。",
   "agentRuntime.rosterWarn": "措辞本身是承重配置 —— 写「会什么」,别写「是什么」。",
   "agentRuntime.launchSquad": "启动 Commander…",
-  "agentRuntime.launchSquadHint": "一次启动只起 Commander 会话;由 Commander 自主拆解并派发下级。",
   "agentRuntime.noSessions": "无会话",
   "agentRuntime.unattributed": "未归属",
   "agentRuntime.noTask": "未绑定任务",

--- a/packages/gui/test/agent-runtime-renderer.vitest.ts
+++ b/packages/gui/test/agent-runtime-renderer.vitest.ts
@@ -559,7 +559,6 @@ describe("agent runtime renderer", () => {
       "Worker #1",
       "4 members",
       "Leader turn budget",
-      "One launch starts the Commander session",
     ])
       expect(squad).toContain(text);
     expect(squad).toContain('data-testid="squad-leader-turn-budget"');

--- a/packages/gui/test/entityIdGateFixtures.ts
+++ b/packages/gui/test/entityIdGateFixtures.ts
@@ -332,7 +332,6 @@ export const FIXTURE_DOCK_ROW: RuntimeDockRow = {
   providerSessionId: null,
   eventStreamRef: null,
   startedAt: AT,
-  endedAt: null,
   outcome: null,
   status: "running",
   squad: null,

--- a/packages/gui/test/renderer-app-model.vitest.ts
+++ b/packages/gui/test/renderer-app-model.vitest.ts
@@ -345,7 +345,6 @@ describe("renderer app model", () => {
       body: "# Canonical task plan",
       blobSha256: "sha256:canonical",
       worktreeBody: null,
-      worktreeBlobSha256: null,
       uncommitted: false,
       watermark: 7,
       sourceRevision: 7,

--- a/packages/gui/test/squad-cockpit.vitest.ts
+++ b/packages/gui/test/squad-cockpit.vitest.ts
@@ -3,11 +3,8 @@ import { beforeAll, describe, expect, it } from "vitest";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { SquadEntityDetail } from "../src/renderer/agent-entity-client.ts";
-import {
-  SquadCockpit,
-  squadCockpitModel,
-  type SquadCockpitRow,
-} from "../src/renderer/components/runtime/SquadCockpit.tsx";
+import { SquadCockpit, squadCockpitModel } from "../src/renderer/components/runtime/SquadCockpit.tsx";
+import type { RuntimeDockRow } from "../src/renderer/components/runtime/useRuntimeWorkspace.ts";
 import { setActiveLocale } from "../src/renderer/i18n/core.ts";
 
 beforeAll(() => setActiveLocale("en-US"));
@@ -22,7 +19,7 @@ const squad: SquadEntityDetail = {
   prompts: [],
 };
 
-function row(overrides: Partial<SquadCockpitRow> & { readonly runtimeSessionId: string }): SquadCockpitRow {
+function row(overrides: Partial<RuntimeDockRow> & { readonly runtimeSessionId: string }): RuntimeDockRow {
   return {
     agentId: null,
     agentName: null,
@@ -34,7 +31,6 @@ function row(overrides: Partial<SquadCockpitRow> & { readonly runtimeSessionId: 
     taskId: "task-a",
     taskTitle: "Task A",
     startedAt: "2026-08-28T00:00:00.000Z",
-    endedAt: null,
     status: "running",
     liveness: null,
     dispatchId: null,
@@ -61,7 +57,6 @@ describe("squad cockpit model", () => {
         delegatedByAgentId: "fable",
         parentRuntimeSessionId: "runtime-leader-1",
         status: "succeeded",
-        endedAt: "2026-08-28T00:05:00.000Z",
       }),
       row({
         runtimeSessionId: "runtime-leader-2",
@@ -106,7 +101,7 @@ describe("squad cockpit model", () => {
 });
 
 describe("squad cockpit page", () => {
-  const cockpit = (rows: readonly SquadCockpitRow[]) =>
+  const cockpit = (rows: readonly RuntimeDockRow[]) =>
     renderToStaticMarkup(
       createElement(SquadCockpit, {
         squad,
@@ -142,7 +137,6 @@ describe("squad cockpit page", () => {
         delegatedByAgentId: "fable",
         parentRuntimeSessionId: "runtime-leader-1",
         status: "failed",
-        endedAt: "2026-08-28T00:05:00.000Z",
       }),
     ]);
     // 三条流同屏:Commander lane 与两条 worker lane 都在 DOM 里,组织关系可读。
@@ -164,7 +158,6 @@ describe("squad cockpit page", () => {
         delegatedByAgentId: "fable",
         parentRuntimeSessionId: "runtime-leader-1",
         status: "succeeded",
-        endedAt: "2026-08-28T00:05:00.000Z",
       }),
     ]);
     expect(markup).toContain('data-testid="squad-lane-runtime-worker-done"');

--- a/packages/gui/test/task-detail-expression.vitest.ts
+++ b/packages/gui/test/task-detail-expression.vitest.ts
@@ -386,7 +386,6 @@ function installBridge({ uncommittedPlan = false }: { readonly uncommittedPlan?:
             : `# ${path}`,
       blobSha256: `sha256:${"d".repeat(64)}`,
       worktreeBody: uncommittedPlan && path === "task_plan.md" ? "# Live worktree plan body" : null,
-      worktreeBlobSha256: uncommittedPlan && path === "task_plan.md" ? "e".repeat(64) : null,
       uncommitted: uncommittedPlan && path === "task_plan.md",
       watermark: 7,
       sourceRevision: 7,


### PR DESCRIPTION
# English

## Summary

Anti-entropy pass over the four Phase 4.0 PRs (#1961–#1964, base 1bf70f00b → 81e80d115), per dec_57A9D27BA446C23759A08B1C13 (delete first). An independent read-only review found six leftovers with zero readers; this PR deletes them and nothing else: (1) the `worktreeBlobSha256` field carried daemon → protocol → GUI and validated twice while `uncommitted` already answers the only question the client asks; (2) `RuntimeDockRow.endedAt`; (3) the explicit `parentRuntimeSessionId` payload input on runtime spawn — provenance now derives only from the authenticated executor (`binding.actor`); (4) the `SquadCockpitRow` interface that re-declared fields `RuntimeDockRow` already has; (5) the orphan `launchSquadHint` text left in SquadCard after its button moved to the cockpit, with its two locale keys; (6) a `useMemo` wrapping a literal in DispatchDialog.

## Architectural Justification

- Production-Delta +10/-30: deletions only; the +10 are the simplified replacements (`dispatchExecutorRef({ subject })`, `RuntimeDockRow` annotations).

## What Changed

- `packages/daemon/src/doc-sync-reads.ts`, `protocol/daemon-protocol-gui-types.ts`, `daemon-protocol-schema-ids.ts`, `daemon-protocol-validate-results.ts`, `packages/gui/src/renderer/api-client.ts`: `worktreeBlobSha256` removed end to end.
- `packages/daemon/src/runtime-spawner.ts`: explicit `parentRuntimeSessionId` input branch removed; allowed-fields message updated.
- `packages/gui/src/renderer/components/runtime/useRuntimeWorkspace.ts`, `SquadCockpit.tsx`, `SquadCard.tsx`, `components/DispatchDialog.tsx`, i18n `agentRuntime.json` (en-US, zh-CN).
- Tests/fixtures updated: dispatch-parent-session.integration, runtime-spawn-lifecycle.integration, task-detail-expression, renderer-app-model, entityIdGateFixtures, squad-cockpit.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +10/-30

### Optional Evidence Claims

## Task And Scope

- Harness task: task_2c1ca9f89224dbdd7d61451ccf
- Branch: codex/phase40-antientropy-deletions
- Public scope: packages/daemon/src (doc-sync-reads, protocol types, runtime-spawner), packages/gui/src/renderer (runtime components, dispatch dialog, i18n), matching tests
- Private planning/evidence updated: yes
- Out of scope: The review also confirmed what stays: the daemon/CLI `targetAgentId` path still has three production senders (squad-coordinator, `ha runtime --to`, runtime batch); #1962's URL validation is one function; #1964 has one body render path. The pre-existing `planeAllowsApiKey` alias predates these PRs.

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_2c1ca9f89224dbdd7d61451ccf
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-28T01:07:00Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_2c1ca9f89224dbdd7d61451ccf (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] CEO on Node 24: grep of each removed symbol returns 0 in packages/*/src; daemon dispatch-parent-session + runtime-spawn-lifecycle + task-documents-list 11/11; line-density, file-complexity, canonical-event-compat, test-selection pass; production-delta computed +10/-30
- [x] Worker: GUI focused vitest 67/67, typecheck, eslint (report artifacts/reports/deletions.md, fact F-F59F3B4A)
- [ ] CI on this PR
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO verified the reviewer's six findings by grep on 81e80d115 before dispatch and re-verified the deletions on the branch; each item's replacement is the thing that already existed.
- Reviewer subagent: Findings by an independent Opus anti-entropy review; deletions by Luna (task_2c1ca9f89224dbdd7d61451ccf); accepted by CEO.
- Human review: pending
- Blocking findings: none

## Residual Risk

- None functional: no reader existed for any removed symbol; the spawn payload no longer accepts an explicit parent session, which no caller sent.

## References

- Task: task_2c1ca9f89224dbdd7d61451ccf
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

按 dec_57A9D27BA446C23759A08B1C13(删除优先)对 Phase 4.0 四个 PR(#1961–#1964,基线 1bf70f00b → 81e80d115)做反熵。独立只读审查找到六项零读端残留,本 PR 只删它们:(1)`worktreeBlobSha256` 从 daemon → 协议 → GUI 一路携带并校验两遍,而客户端唯一要问的问题 `uncommitted` 已经回答;(2)`RuntimeDockRow.endedAt`;(3)runtime spawn 的显式 `parentRuntimeSessionId` 入参——来源只从已认证 executor(`binding.actor`)派生;(4)重复声明 `RuntimeDockRow` 已有字段的 `SquadCockpitRow` 接口;(5)按钮移到 cockpit 后留在 SquadCard 的孤儿文案 `launchSquadHint` 及其两个 locale 键;(6)DispatchDialog 里包着字面量的 `useMemo`。

## 架构辩护

- Production-Delta +10/-30:只有删除;+10 是简化后的替换写法(`dispatchExecutorRef({ subject })`、`RuntimeDockRow` 注解)。

## 改动内容

- `packages/daemon/src/doc-sync-reads.ts`、`protocol/daemon-protocol-gui-types.ts`、`daemon-protocol-schema-ids.ts`、`daemon-protocol-validate-results.ts`、`packages/gui/src/renderer/api-client.ts`:端到端删除 `worktreeBlobSha256`。
- `packages/daemon/src/runtime-spawner.ts`:删除显式 `parentRuntimeSessionId` 入参分支;allowed-fields 提示同步。
- `packages/gui/src/renderer/components/runtime/useRuntimeWorkspace.ts`、`SquadCockpit.tsx`、`SquadCard.tsx`、`components/DispatchDialog.tsx`、i18n `agentRuntime.json`(en-US、zh-CN)。
- 测试/夹具同步:dispatch-parent-session.integration、runtime-spawn-lifecycle.integration、task-detail-expression、renderer-app-model、entityIdGateFixtures、squad-cockpit。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_2c1ca9f89224dbdd7d61451ccf
- 分支:codex/phase40-antientropy-deletions
- 公开范围:packages/daemon/src(doc-sync-reads、协议类型、runtime-spawner)、packages/gui/src/renderer(runtime 组件、派工对话框、i18n)、对应测试
- 私有计划 / 证据是否已更新:yes
- 范围外:审查同时确认该留的:daemon/CLI 的 `targetAgentId` 路径仍有三个生产发送方(squad-coordinator、`ha runtime --to`、runtime batch);#1962 的 URL 校验是同一个函数;#1964 只有一套 body 渲染路径。既有的 `planeAllowsApiKey` 别名早于这些 PR。

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_2c1ca9f89224dbdd7d61451ccf
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-28T01:07:00Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_2c1ca9f89224dbdd7d61451ccf
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] CEO 在 Node 24:每个被删符号在 packages/*/src 中 grep 为 0;daemon dispatch-parent-session + runtime-spawn-lifecycle + task-documents-list 11/11;line-density、file-complexity、canonical-event-compat、test-selection 通过;production-delta 实算 +10/-30
- [x] worker:GUI 定向 vitest 67/67、typecheck、eslint(报告 artifacts/reports/deletions.md,fact F-F59F3B4A)
- [ ] 本 PR 的 CI
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 派活前在 81e80d115 上 grep 实证了六项,分支上再次实证删除;每项的替代者都是本来就存在的东西。
- Reviewer subagent:Opus 独立反熵审查发现;Luna 执行删除(task_2c1ca9f89224dbdd7d61451ccf);CEO 验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 无功能风险:被删符号都没有读端;spawn payload 不再接受显式父会话,而本来也没有调用方发它。

## 关联材料

- 任务:task_2c1ca9f89224dbdd7d61451ccf
- 证据:任务包 artifacts/reports
- 审查:本 PR
