### PR TITLE
fix(preset): let snapshot upgrade drop retired document slots

### DIFF
--- a/packages/preset/src/preset-bootstrap.ts
+++ b/packages/preset/src/preset-bootstrap.ts
@@ -367,7 +367,8 @@ export function compilePresetSnapshotUpgrade(input: CompilePresetSnapshotUpgrade
   if (addedPaths.length)
     throw bootstrapFailure(
       "upgrade_document_set_changed",
-      `Preset upgrade adds documents the task package does not have (${addedPaths.join(", ")}); recreate the task instead.`,
+      `Preset upgrade adds documents the task package does not have (${addedPaths.join(", ")}); ` +
+        "recreate the task instead.",
     );
   if (compiled.snapshot.digest === previousDigest)
     throw bootstrapFailure("snapshot_current", "Task already uses the current preset snapshot.");

--- a/packages/preset/src/preset-bootstrap.ts
+++ b/packages/preset/src/preset-bootstrap.ts
@@ -359,13 +359,15 @@ export function compilePresetSnapshotUpgrade(input: CompilePresetSnapshotUpgrade
     locale,
     slug: input.task.metadata?.slug,
   });
-  if (
-    stablePaths(compiled.documents.map(({ relativePath }) => relativePath)) !==
-    stablePaths(documents.map((item) => (item as { path: string }).path))
-  )
+  // A preset may drop a document slot (facts.md became a first-class entity in afa7f26fc); the retired file stays
+  // on disk as committed prose. Only a slot the package does not have yet would need materialization, so only
+  // additions are rejected.
+  const knownPaths = new Set(documents.map((item) => (item as { path: string }).path)),
+    addedPaths = compiled.documents.map(({ relativePath }) => relativePath).filter((item) => !knownPaths.has(item));
+  if (addedPaths.length)
     throw bootstrapFailure(
       "upgrade_document_set_changed",
-      "Preset upgrade changes the task document set and requires an explicit migration.",
+      `Preset upgrade adds documents the task package does not have (${addedPaths.join(", ")}); recreate the task instead.`,
     );
   if (compiled.snapshot.digest === previousDigest)
     throw bootstrapFailure("snapshot_current", "Task already uses the current preset snapshot.");
@@ -487,9 +489,6 @@ function taskRelations(input: CompileTaskPackageInput): readonly EntityRelationR
   const issues = validateRelationRecordsForHost(`task/${input.taskId}`, records);
   if (issues.length) throw bootstrapFailure("invalid_relation", `${issues[0]!.message}. Fix --relation and retry.`);
   return records;
-}
-function stablePaths(paths: readonly string[]): string {
-  return JSON.stringify([...paths].sort((left, right) => left.localeCompare(right)));
 }
 function bootstrapFailure(code: string, message: string): Error & { readonly code: string } {
   return Object.assign(new Error(message), { code });

--- a/packages/preset/src/preset-bootstrap.ts
+++ b/packages/preset/src/preset-bootstrap.ts
@@ -359,9 +359,9 @@ export function compilePresetSnapshotUpgrade(input: CompilePresetSnapshotUpgrade
     locale,
     slug: input.task.metadata?.slug,
   });
-  // A preset may drop a document slot (afa7f26fc retired the fact ledger document once facts became entities); the retired file stays
-  // on disk as committed prose. Only a slot the package does not have yet would need materialization, so only
-  // additions are rejected.
+  // A preset may retire a document slot (afa7f26fc retired the fact ledger document once facts became
+  // entities); the retired file stays on disk as committed prose. Only a slot the package does not have yet
+  // would need materialization, so only additions are rejected.
   const knownPaths = new Set(documents.map((item) => (item as { path: string }).path)),
     addedPaths = compiled.documents.map(({ relativePath }) => relativePath).filter((item) => !knownPaths.has(item));
   if (addedPaths.length)

--- a/packages/preset/src/preset-bootstrap.ts
+++ b/packages/preset/src/preset-bootstrap.ts
@@ -359,7 +359,7 @@ export function compilePresetSnapshotUpgrade(input: CompilePresetSnapshotUpgrade
     locale,
     slug: input.task.metadata?.slug,
   });
-  // A preset may drop a document slot (facts.md became a first-class entity in afa7f26fc); the retired file stays
+  // A preset may drop a document slot (afa7f26fc retired the fact ledger document once facts became entities); the retired file stays
   // on disk as committed prose. Only a slot the package does not have yet would need materialization, so only
   // additions are rejected.
   const knownPaths = new Set(documents.map((item) => (item as { path: string }).path)),

--- a/packages/preset/test/preset-resolver-snapshot-templates.test.ts
+++ b/packages/preset/test/preset-resolver-snapshot-templates.test.ts
@@ -254,7 +254,8 @@ test("snapshot upgrade atomically replaces the complete snapshot and typed task 
       (error: unknown) =>
         (error as { code?: string; message?: string }).code === "upgrade_document_set_changed" &&
         (error as Error).message ===
-          "Preset upgrade adds documents the task package does not have (upgrade-evidence.md); recreate the task instead.",
+          "Preset upgrade adds documents the task package does not have (upgrade-evidence.md); " +
+            "recreate the task instead.",
     );
   } finally {
     projection?.close();

--- a/packages/preset/test/preset-resolver-snapshot-templates.test.ts
+++ b/packages/preset/test/preset-resolver-snapshot-templates.test.ts
@@ -1,14 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  readdirSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -28,18 +20,9 @@ import {
   installPresetPackage,
   runPresetAction as runProjectedPresetAction,
 } from "../src/index.ts";
-import {
-  createRuntime,
-  decodePresetPackageV3,
-} from "../src/preset-resolver.ts";
+import { createRuntime, decodePresetPackageV3 } from "../src/preset-resolver.ts";
 
-import {
-  git,
-  makeFixture,
-  templateCatalog,
-  write,
-  writePackage,
-} from "./preset-resolver.fixtures.ts";
+import { git, makeFixture, templateCatalog, write, writePackage } from "./preset-resolver.fixtures.ts";
 const runPresetAction = (input: Parameters<typeof runProjectedPresetAction>[0]) =>
   runProjectedPresetAction({ ...input, settings: INITIAL_SETTINGS_V1 });
 test("snapshot upgrade atomically replaces the complete snapshot and typed task contract without touching task prose", () => {
@@ -109,12 +92,7 @@ test("snapshot upgrade atomically replaces the complete snapshot and typed task 
     const store = makeTaskEventStore({ repoId: "preset-upgrade", rootDir });
     projection = makeTaskProjection({ rootDir, eventStore: store });
     projection.rebuild();
-    const planPath = path.join(
-        rootDir,
-        "harness",
-        bootstrap.packagePath,
-        "task_plan.md",
-      ),
+    const planPath = path.join(rootDir, "harness", bootstrap.packagePath, "task_plan.md"),
       editedPlan = "# User plan\n\nKeep this prose.\n";
     mkdirSync(path.dirname(planPath), { recursive: true });
     writeFileSync(planPath, editedPlan);
@@ -126,9 +104,7 @@ test("snapshot upgrade atomically replaces the complete snapshot and typed task 
     const task = projection.read(taskId).snapshot.task!,
       contractPath = `${bootstrap.packagePath}/task-contract.json`,
       contract = {
-        body: bootstrap.documents.find(
-          ({ relativePath }) => relativePath === "task-contract.json",
-        )!.body,
+        body: bootstrap.documents.find(({ relativePath }) => relativePath === "task-contract.json")!.body,
       };
     let upgraded: ReturnType<typeof compilePresetSnapshotUpgrade> | undefined;
     assert.doesNotThrow(() => {
@@ -148,32 +124,18 @@ test("snapshot upgrade atomically replaces the complete snapshot and typed task 
     assert.notEqual(upgraded.snapshot.digest, task.presetSnapshotDigest);
     assert.equal(upgraded.snapshot.identity.version, "3.2.0");
     assert.equal(upgraded.event.payload.taskContractClaim.path, contractPath);
+    assert.equal(Object.hasOwn(upgraded.event.payload.task.metadata ?? {}, "longRunning"), false);
     assert.equal(
-      Object.hasOwn(upgraded.event.payload.task.metadata ?? {}, "longRunning"),
-      false,
-    );
-    assert.equal(
-      JSON.parse(
-        upgraded.blobs.find(
-          ({ sha256 }) =>
-            sha256 === upgraded!.event.payload.taskContractClaim.sha256,
-        )!.body,
-      ).packagePath,
+      JSON.parse(upgraded.blobs.find(({ sha256 }) => sha256 === upgraded!.event.payload.taskContractClaim.sha256)!.body)
+        .packagePath,
       bootstrap.packagePath,
     );
     store.append(upgraded);
     projection.apply(upgraded.event, upgraded.plan);
+    assert.equal(projection.read(taskId).snapshot.task?.presetSnapshotDigest, upgraded.snapshot.digest);
+    assert.deepEqual(projection.readPresetSnapshot(upgraded.snapshot.digest).snapshot, upgraded.snapshot);
     assert.equal(
-      projection.read(taskId).snapshot.task?.presetSnapshotDigest,
-      upgraded.snapshot.digest,
-    );
-    assert.deepEqual(
-      projection.readPresetSnapshot(upgraded.snapshot.digest).snapshot,
-      upgraded.snapshot,
-    );
-    assert.equal(
-      JSON.parse(projection.readDocument(contractPath).document!.body)
-        .presetSnapshotDigest,
+      JSON.parse(projection.readDocument(contractPath).document!.body).presetSnapshotDigest,
       upgraded.snapshot.digest,
     );
     assert.equal(readFileSync(planPath, "utf8"), editedPlan);
@@ -182,8 +144,7 @@ test("snapshot upgrade atomically replaces the complete snapshot and typed task 
         compilePresetSnapshotUpgrade({
           userRoot,
           task: projection.read(taskId).snapshot.task!,
-          taskContractBody:
-            projection.readDocument(contractPath).document!.body,
+          taskContractBody: projection.readDocument(contractPath).document!.body,
           actor: { principal: { personId: "person-1" }, executor: null },
           source: "local",
           workspaceRevision: 3,
@@ -191,8 +152,40 @@ test("snapshot upgrade atomically replaces the complete snapshot and typed task 
           opId: "op-current",
           occurredAt: "2026-08-14T00:02:00.000Z",
         }),
-      (error: unknown) =>
-        (error as { code?: string }).code === "snapshot_current",
+      (error: unknown) => (error as { code?: string }).code === "snapshot_current",
+    );
+    writePackage(sourceRoot, "upgrade-task", { version: "3.2.1" });
+    installPresetPackage({
+      source: path.join(sourceRoot, "upgrade-task"),
+      userRoot,
+    });
+    const retiredContract = JSON.parse(projection.readDocument(contractPath).document!.body) as {
+      documents: Array<{ path: string }>;
+    };
+    retiredContract.documents.push({
+      ...retiredContract.documents.find(({ path: item }) => item === "task_plan.md")!,
+      path: "facts.md",
+    });
+    const dropped = compilePresetSnapshotUpgrade({
+      userRoot,
+      task: projection.read(taskId).snapshot.task!,
+      taskContractBody: JSON.stringify(retiredContract),
+      actor: { principal: { personId: "person-1" }, executor: null },
+      source: "local",
+      workspaceRevision: 3,
+      eventId: "event-document-drop",
+      opId: "op-document-drop",
+      occurredAt: "2026-08-14T00:02:30.000Z",
+    });
+    assert.equal(dropped.snapshot.identity.version, "3.2.1");
+    assert.equal(
+      (
+        JSON.parse(
+          dropped.blobs.find(({ sha256 }) => sha256 === dropped.event.payload.taskContractClaim.sha256)!.body,
+        ) as { documents: Array<{ path: string }> }
+      ).documents.some(({ path: item }) => item === "facts.md"),
+      false,
+      "a document slot the preset retired must upgrade without a migration",
     );
     const profiles = [
       {
@@ -250,8 +243,7 @@ test("snapshot upgrade atomically replaces the complete snapshot and typed task 
         compilePresetSnapshotUpgrade({
           userRoot,
           task: projection.read(taskId).snapshot.task!,
-          taskContractBody:
-            projection.readDocument(contractPath).document!.body,
+          taskContractBody: projection.readDocument(contractPath).document!.body,
           actor: { principal: { personId: "person-1" }, executor: null },
           source: "local",
           workspaceRevision: 3,
@@ -260,10 +252,9 @@ test("snapshot upgrade atomically replaces the complete snapshot and typed task 
           occurredAt: "2026-08-14T00:03:00.000Z",
         }),
       (error: unknown) =>
-        (error as { code?: string; message?: string }).code ===
-          "upgrade_document_set_changed" &&
+        (error as { code?: string; message?: string }).code === "upgrade_document_set_changed" &&
         (error as Error).message ===
-          "Preset upgrade changes the task document set and requires an explicit migration.",
+          "Preset upgrade adds documents the task package does not have (upgrade-evidence.md); recreate the task instead.",
     );
   } finally {
     projection?.close();
@@ -297,13 +288,9 @@ test("user template selections resolve only package-local canonical catalog bodi
           source: path.join(sourceRoot, "user-impact"),
           userRoot: fixture.userRoot,
         }),
-      (error: unknown) =>
-        (error as { code?: string }).code === "missing_template_catalog",
+      (error: unknown) => (error as { code?: string }).code === "missing_template_catalog",
     );
-    write(
-      path.join(sourceRoot, "outside.md"),
-      "# Outside\n\n## User Impact\n\nMust not be read.\n",
-    );
+    write(path.join(sourceRoot, "outside.md"), "# Outside\n\n## User Impact\n\nMust not be read.\n");
     write(
       path.join(sourceRoot, "user-impact/template-catalog.json"),
       JSON.stringify(
@@ -337,8 +324,7 @@ test("user template selections resolve only package-local canonical catalog bodi
           source: path.join(sourceRoot, "user-impact"),
           userRoot: fixture.userRoot,
         }),
-      (error: unknown) =>
-        (error as { code?: string }).code === "missing_template",
+      (error: unknown) => (error as { code?: string }).code === "missing_template",
     );
     write(
       path.join(sourceRoot, "user-impact/template-catalog.json"),
@@ -385,11 +371,7 @@ test("user template selections resolve only package-local canonical catalog bodi
       locale: "en-US",
       purpose: "task-create",
     });
-    assert.match(
-      resolved.documents.find(({ slot }) => slot === "task.user.impact")
-        ?.body ?? "",
-      /Package body/u,
-    );
+    assert.match(resolved.documents.find(({ slot }) => slot === "task.user.impact")?.body ?? "", /Package body/u);
     assert.equal(resolved.snapshot.identity.layer, "user");
   } finally {
     fixture.cleanup();
@@ -419,10 +401,7 @@ test("the same self-contained package has identical bundled and user snapshot co
       profiles: profile,
       policyPath: "policy.json",
     });
-    write(
-      path.join(packageRoot, "policy.json"),
-      JSON.stringify({ schema: "preset-policy/v1", requires: [] }),
-    );
+    write(path.join(packageRoot, "policy.json"), JSON.stringify({ schema: "preset-policy/v1", requires: [] }));
     write(
       path.join(packageRoot, "template-catalog.json"),
       JSON.stringify(
@@ -450,10 +429,7 @@ test("the same self-contained package has identical bundled and user snapshot co
         ),
       ),
     );
-    write(
-      path.join(packageRoot, "templates/local-impact.md"),
-      "# Local only\n\n## Local Impact\n\nPackage body.\n",
-    );
+    write(path.join(packageRoot, "templates/local-impact.md"), "# Local only\n\n## Local Impact\n\nPackage body.\n");
     const request = {
         presetId: "local-impact",
         verticalId: "software/coding",
@@ -483,10 +459,7 @@ test("the same self-contained package has identical bundled and user snapshot co
     assert.deepEqual(semantics(user), semantics(bundled));
     assert.equal(bundled.snapshot.identity.layer, "bundled");
     assert.equal(user.snapshot.identity.layer, "user");
-    write(
-      path.join(packageRoot, "policy.json"),
-      JSON.stringify({ schema: "preset-policy/v0", requires: [] }),
-    );
+    write(path.join(packageRoot, "policy.json"), JSON.stringify({ schema: "preset-policy/v0", requires: [] }));
     assert.equal(
       (
         (await runPresetAction({
@@ -502,8 +475,7 @@ test("the same self-contained package has identical bundled and user snapshot co
           source: packageRoot,
           userRoot: fixture.userRoot,
         }),
-      (error: unknown) =>
-        (error as { code?: string }).code === "invalid_policy",
+      (error: unknown) => (error as { code?: string }).code === "invalid_policy",
     );
   } finally {
     fixture.cleanup();
@@ -577,10 +549,7 @@ test("seed and audit dry-runs report the two-layer inventory without mutation", 
       rootDir,
       action: { kind: "preset-seed" },
     })) as { mode: string; packageCount: number };
-    assert.deepEqual(
-      { mode: seeded.mode, packageCount: seeded.packageCount },
-      { mode: "apply", packageCount: 12 },
-    );
+    assert.deepEqual({ mode: seeded.mode, packageCount: seeded.packageCount }, { mode: "apply", packageCount: 12 });
     assert.equal(readdirSync(path.join(userRoot, "active")).length, 12);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });


### PR DESCRIPTION
# English

## Summary

Every task created before afa7f26fc (which promoted facts to first-class entities and dropped `facts.md` from the docs-task document set) could no longer be completed: `ha task complete` demands the current preset snapshot, `ha preset upgrade` rejected the task with `upgrade_document_set_changed` because the contract still listed `facts.md`, and the "explicit migration" the message pointed to never existed. 204 open tasks in the operating ledger are in this state, including the running milestone root. This PR makes the upgrade reject only *added* documents (the one case that would need materialization) and lets retired slots upgrade in place; the retired file stays on disk as committed prose.

## Architectural Justification

- Production-Delta +8/-8: the set-equality check is replaced by an additions-only check; `stablePaths` helper deleted.

## What Changed

- `packages/preset/src/preset-bootstrap.ts`: `compilePresetSnapshotUpgrade` rejects only paths the compiled package adds; message names the added paths; `stablePaths` removed.
- `packages/preset/test/preset-resolver-snapshot-templates.test.ts`: new case — a contract carrying a retired `facts.md` upgrades and the rewritten task-contract no longer lists it; the existing added-document rejection updated to the new message.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +8/-8

### Optional Evidence Claims

## Task And Scope

- Harness task: task_57d7f3d467adcf32be2accbb38
- Branch: codex/preset-upgrade-drop
- Public scope: packages/preset (snapshot upgrade compile + its test)
- Private planning/evidence updated: yes
- Out of scope: No bulk re-upgrade of the 204 affected tasks: each one upgrades on its own next `ha preset upgrade`/complete. The lease hint that prescribes `task start --execution-id` (also hit here) is tracked separately.

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_57d7f3d467adcf32be2accbb38
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-28T01:56Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_57d7f3d467adcf32be2accbb38 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Node 24: `packages/preset/test/preset-resolver-snapshot-templates.test.ts` 5/5 (new removal case + updated addition case)
- [x] production-delta computed +8/-8
- [ ] CI on this PR
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority. Canonical re-upgrade of task_bdf89b6e will be the first live positive control after merge.

## Review Evidence

- Self-review: CEO reproduced on canonical (task_bdf89b6e: upgrade rejected, complete rejected with preset_snapshot_mismatch), traced to afa7f26fc's doc-set change and to the absence of any migration command, and counted affected contracts (204 open).
- Reviewer subagent: CEO-authored, small diff; flow-defect task task_57d7f3d467adcf32be2accbb38.
- Human review: pending
- Blocking findings: none

## Residual Risk

- A preset that renames a slot (drop + add) still rejects, as before. Retired files linger in packages until someone deletes them; they are ordinary committed prose and no gate reads them.

## References

- Task: task_57d7f3d467adcf32be2accbb38
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

afa7f26fc(facts 实体化)把 `facts.md` 从 docs-task 文档集里删掉后,此前创建的任务全部关不掉:`ha task complete` 要求当前 preset 快照,`ha preset upgrade` 却因合同仍含 `facts.md` 报 `upgrade_document_set_changed`,而报错指向的「显式迁移」根本不存在。运行台账里 204 个未完成任务(含在跑的 milestone 根任务)处于此状态。本 PR 让升级只拒绝**新增**文档(唯一需要物化的情形),退役槽位原地升级;退役文件作为已提交 prose 留在盘上。

## 架构辩护

- Production-Delta +8/-8:集合相等检查换成只查新增;删除 `stablePaths` 辅助函数。

## 改动内容

- `packages/preset/src/preset-bootstrap.ts`:`compilePresetSnapshotUpgrade` 只拒绝编译包新增的路径,报错点名新增路径;删除 `stablePaths`。
- `packages/preset/test/preset-resolver-snapshot-templates.test.ts`:新用例——合同带退役 `facts.md` 可升级且重写后的 task-contract 不再列出它;原有新增文档拒绝用例改为新报错文案。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_57d7f3d467adcf32be2accbb38
- 分支:codex/preset-upgrade-drop
- 公开范围:packages/preset(快照升级编译及其测试)
- 私有计划 / 证据是否已更新:yes
- 范围外:不批量重升级 204 个受影响任务:各自在下次 `ha preset upgrade`/complete 时原地升级。同时撞到的 `task start --execution-id` 错误提示另有任务跟踪。

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_57d7f3d467adcf32be2accbb38
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-28T01:56Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_57d7f3d467adcf32be2accbb38
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] Node 24:`packages/preset/test/preset-resolver-snapshot-templates.test.ts` 5/5(新增退役用例 + 更新新增用例)
- [x] production-delta 实算 +8/-8
- [ ] 本 PR 的 CI
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。合并后对 task_bdf89b6e 的 canonical 升级是第一个真实阳性对照。

## 审查证据

- 自查:CEO 在 canonical 复现(task_bdf89b6e:upgrade 被拒、complete 报 preset_snapshot_mismatch),溯源到 afa7f26fc 的文档集变更与迁移命令缺失,并统计受影响合同(204 个未完成)。
- Reviewer subagent:CEO 亲写小 diff;流转缺陷任务 task_57d7f3d467adcf32be2accbb38。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- preset 若改名槽位(删+加)仍被拒,与之前一致。退役文件留在包内直到有人删除;它们是普通已提交 prose,没有门读它。

## 关联材料

- 任务:task_57d7f3d467adcf32be2accbb38
- 证据:任务包 artifacts/reports
- 审查:本 PR
