### PR TITLE
fix(daemon): surface agy tool steps as live activity

### DIFF
--- a/packages/daemon/src/runtime-spawn-provider-frames.ts
+++ b/packages/daemon/src/runtime-spawn-provider-frames.ts
@@ -162,7 +162,13 @@ export function parseAgyFrame(value: Record<string, unknown>, providerSessionId:
     const update = value.step_update;
     if (!isPlainRecord(update)) throw new Error("agy step_update frame is incomplete");
     const text = update.text_delta;
-    return typeof text === "string" ? { signals: [{ type: "activity", activity: "message", content: text }] } : {};
+    if (typeof text === "string") return { signals: [{ type: "activity", activity: "message", content: text }] };
+    // Tool steps carry no text; without them a read-only recon run looks idle until its final answer.
+    if (update.step_type === "tool") {
+      const { conversation_id: _conversation, step_index: _index, ...tool } = update;
+      return { signals: [{ type: "activity", activity: "tool", content: JSON.stringify(tool) }] };
+    }
+    return {};
   }
   if (value.event === "result") {
     const result = value.result;

--- a/packages/daemon/test/runtime-spawn-provider-frames-agy.test.ts
+++ b/packages/daemon/test/runtime-spawn-provider-frames-agy.test.ts
@@ -1,0 +1,44 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseAgyFrame } from "../src/runtime-spawn-provider-frames.ts";
+
+const conversation = { conversation_id: "agy-conversation", step_index: 2 };
+
+test("agy tool steps become tool activity so a read-only run is visible before its final answer", () => {
+  const active = parseAgyFrame(
+    {
+      event: "step_update",
+      step_update: {
+        ...conversation,
+        state: "ACTIVE",
+        step_type: "tool",
+        tool_name: "view_file",
+        tool_info: { name: "view_file", parameters: { AbsolutePath: "/repo/README.md" } },
+      },
+    },
+    "agy-conversation",
+  );
+  assert.equal(active.signals?.length, 1);
+  assert.equal(active.signals?.[0]?.activity, "tool");
+  const content = JSON.parse(active.signals?.[0]?.content ?? "{}") as Record<string, unknown>;
+  assert.equal(content.tool_name, "view_file");
+  assert.equal(content.state, "ACTIVE");
+  assert.equal(Object.hasOwn(content, "conversation_id"), false);
+});
+
+test("agy text deltas stay message activity and other text-less steps stay silent", () => {
+  const message = parseAgyFrame(
+    {
+      event: "step_update",
+      step_update: { ...conversation, state: "ACTIVE", step_type: "agent_response", text_delta: "hi" },
+    },
+    "agy-conversation",
+  );
+  assert.deepEqual(message.signals, [{ type: "activity", activity: "message", content: "hi" }]);
+  const silent = parseAgyFrame(
+    { event: "step_update", step_update: { ...conversation, state: "DONE", step_type: "user_input" } },
+    "agy-conversation",
+  );
+  assert.equal(silent.signals, undefined);
+});


### PR DESCRIPTION
# English

## Summary

agy (Gemini) sessions showed no live activity in the GUI until their final answer. The agy CLI does stream: every tool call arrives as a `step_update` frame with `step_type: "tool"`, `tool_name`, parameters and, on completion, output or error. Our frame parser only converted `text_delta` into activity and returned nothing for tool steps, so a read-only recon run (all tool calls, text only at the end) looked idle. Tool steps now publish `tool` activity exactly like the claude and codex adapters.

## Architectural Justification

- Production-Delta +7/-1: one branch added in `parseAgyFrame`; no new mechanism.

## What Changed

- `packages/daemon/src/runtime-spawn-provider-frames.ts`: `step_type === "tool"` steps become a `tool` activity signal carrying the step minus conversation/index ids.
- `packages/daemon/test/runtime-spawn-provider-frames-agy.test.ts` (fast): tool step → tool activity; text delta unchanged; text-less non-tool steps stay silent.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +7/-1

### Optional Evidence Claims

## Task And Scope

- Harness task: task_23827218c08728ab3f420caaaa
- Branch: codex/agy-tool-stream
- Public scope: packages/daemon agy frame parser + one unit test
- Private planning/evidence updated: yes
- Out of scope: GUI rendering of tool activity is unchanged (it already renders claude/codex tool activity). agy's own sandbox cwd quirk (`pwd` inside agy reports its scratch dir) is noted, not addressed.

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_23827218c08728ab3f420caaaa
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-28T06:13Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_23827218c08728ab3f420caaaa (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Node 24: new unit test 2/2; `discoverTestFiles` sees the new file
- [x] live sample: `agy -p … --output-format stream-json` emits `step_update` tool frames (ACTIVE/DONE/ERROR) — the shape the test uses
- [ ] CI on this PR
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO reproduced with a live agy probe and read the parser before changing it.
- Reviewer subagent: CEO-authored small diff; task task_23827218c08728ab3f420caaaa.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Tool frames can be large (command output); content is the raw step JSON, same as codex tool items today.

## References

- Task: task_23827218c08728ab3f420caaaa
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

agy(Gemini)会话在 GUI 里直到最终回答前都看不到实时活动。agy CLI 本身是有流的:每次工具调用都以 `step_update` 帧到达(`step_type: "tool"`、`tool_name`、参数,完成时带 output/error)。我们的帧解析器只把 `text_delta` 变成活动,工具步骤一律返回空——只读侦察(全程工具调用、最后才出文本)因此看起来像空转。现在工具步骤与 claude/codex 适配器一样发布 `tool` 活动。

## 架构辩护

- Production-Delta +7/-1:`parseAgyFrame` 加一个分支;没有新机制。

## 改动内容

- `packages/daemon/src/runtime-spawn-provider-frames.ts`:`step_type === "tool"` 的步骤变成 `tool` 活动信号(去掉 conversation/index id)。
- `packages/daemon/test/runtime-spawn-provider-frames-agy.test.ts`(fast):工具步骤 → tool 活动;text delta 不变;无文本的非工具步骤保持静默。

## 门收割 / Gate Harvest

- 删除的生产路径:none
- 同 commit 删除的门 / fixture:none
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_23827218c08728ab3f420caaaa
- 分支:codex/agy-tool-stream
- 公开范围:packages/daemon agy 帧解析器 + 一个单元测试
- 私有计划 / 证据是否已更新:yes
- 范围外:GUI 对 tool 活动的渲染不变(claude/codex 的已在渲染)。agy 自身 cwd 怪癖(agy 内 `pwd` 报它的 scratch 目录)只记录不处理。

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_23827218c08728ab3f420caaaa
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-28T06:13Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_23827218c08728ab3f420caaaa
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] Node 24:新单元测试 2/2;`discoverTestFiles` 能发现新文件
- [x] 实采样本:`agy -p … --output-format stream-json` 发出 `step_update` 工具帧(ACTIVE/DONE/ERROR),测试用的就是这个形状
- [ ] 本 PR 的 CI
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 用真实 agy 探针复现并读过解析器再改。
- Reviewer subagent:CEO 亲写小 diff;任务 task_23827218c08728ab3f420caaaa。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 工具帧可能较大(命令输出);content 是原始步骤 JSON,与现在 codex 的 tool item 一致。

## 关联材料

- 任务:task_23827218c08728ab3f420caaaa
- 证据:任务包 artifacts/reports
- 审查:本 PR
