### PR TITLE
fix(kernel): cold rebuild recreates projection DDL (schema 14)

### DIFF
--- a/packages/daemon/test/lease-reservation.integration.test.ts
+++ b/packages/daemon/test/lease-reservation.integration.test.ts
@@ -154,7 +154,7 @@ test("task-bound spawn exit keeps its released execution visible after a v12 cac
         .prepare("SELECT entity_id FROM entity_projection WHERE entity_kind = 'execution' AND task_id = ?")
         .get(taskId) as { readonly entity_id: string } | undefined;
     rebuilt.close();
-    assert.equal(version.schema_version, 13); // taskProjectionSchemaVersion in kernel projection-schema.ts
+    assert.equal(version.schema_version, 14); // taskProjectionSchemaVersion in kernel projection-schema.ts
     assert.equal(execution?.entity_id, executionId);
   } finally {
     await host.close();

--- a/packages/kernel/src/projection/projection-schema.ts
+++ b/packages/kernel/src/projection/projection-schema.ts
@@ -1,5 +1,5 @@
-// Version 13 forces upgraded nodes to discard version-12 warm caches before
-// replaying fact-rekey ledger rewrites that preserve opId and workspaceRevision.
-// A version mismatch takes the discard-and-replay path; squad-coordinator then
-// sees its durable ready marker cleared and replays dispatch streams locally.
-export const taskProjectionSchemaVersion = 13;
+// Version 14 discards caches whose fact/fact_fts tables predate first-class,
+// optionally taskless Facts. CREATE TABLE IF NOT EXISTS cannot migrate that DDL.
+// A version mismatch takes the discard-and-replay path; explicit rebuild uses
+// the same cold path so it also repairs a cache whose version metadata is wrong.
+export const taskProjectionSchemaVersion = 14;

--- a/packages/kernel/src/projection/rebuildable-task-projection-database.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-database.ts
@@ -8,7 +8,7 @@ import { createRelationGraphProjectionTables } from "./relation-graph-projection
 import { taskProjectionSchemaVersion } from "./projection-schema.ts";
 import { createTaskRelationProjectionTable } from "./task-query-projection.ts";
 import type { EventStreamPort } from "./rebuildable-task-projection-types.ts";
-import { queryRows, runSql, transaction } from "./rebuildable-task-projection-sql.ts";
+import { queryRows, runSql } from "./rebuildable-task-projection-sql.ts";
 export type { ProjectionPage, TaskProjectionListQuery, TaskRelationQuery } from "./task-query-projection.ts";
 export type { TaskProjection } from "./task-projection-port.ts";
 
@@ -16,7 +16,6 @@ export type { TaskProjection } from "./task-projection-port.ts";
 interface ProjectionDatabaseOwner {
   readonly use: <A>(operation: (db: DatabaseSync) => A) => A;
   readonly discard: () => void;
-  readonly reset: () => void;
   readonly close: () => void;
 }
 
@@ -73,9 +72,6 @@ export function withDatabase<A>(
 export function discardDatabase(projectionPath: string, readHead: EventStreamPort["readHead"]): void {
   projectionDatabaseOwner(projectionPath, readHead).discard();
 }
-export function resetDatabase(projectionPath: string, readHead: EventStreamPort["readHead"]): void {
-  projectionDatabaseOwner(projectionPath, readHead).reset();
-}
 // close() shares discard()'s invariant: callers close a projection so they can remove its file, and
 // a handle held by any other owner blocks that on Windows. Closing only the caller's owner made
 // `projection.close(); rm(projection.path)` -- the documented teardown -- fail there.
@@ -128,28 +124,6 @@ function projectionDatabaseOwner(
     closeProjectionHandlesAt(resolvedProjectionPath);
     localRuntimeStateFileSystem.remove(projectionPath);
   };
-  const reset = () => {
-    closeProjectionHandlesAt(resolvedProjectionPath);
-    initialize();
-    transaction(db!, () => {
-      const tables = queryRows(
-        db!,
-        "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name DESC",
-      );
-      for (const row of tables) {
-        const name = String(row.name);
-        if (name === "projection_meta" || name.includes("_fts_")) continue;
-        runSql(db!, `DELETE FROM "${name.replaceAll('"', '""')}"`);
-      }
-      runSql(
-        db!,
-        [
-          "UPDATE projection_meta SET watermark = 0, scan_cursor = NULL, scanned_revision = 0,",
-          "head_digest = NULL, state_digest = NULL, squad_run_ready = 0 WHERE singleton = 1",
-        ].join(" "),
-      );
-    });
-  };
   const initialize = () => {
     open();
     const observed = projectionSchemaVersion(db!);
@@ -172,7 +146,7 @@ function projectionDatabaseOwner(
     if (!matchesLedgerIdentity(db!, readHead())) throw new ProjectionIdentityMismatchError();
     return operation(db!);
   };
-  const owner = { use, discard, reset, close };
+  const owner = { use, discard, close };
   owners.set(projectionPath, owner);
   return owner;
 }

--- a/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-factory.ts
@@ -35,8 +35,8 @@ import type { TaskProjection } from "./task-projection-port.ts";
 import type { EventStreamPort, ProjectionContext } from "./rebuildable-task-projection-types.ts";
 import {
   closeDatabase,
+  discardDatabase,
   ProjectionIdentityMismatchError,
-  resetDatabase,
   withDatabase,
 } from "./rebuildable-task-projection-database.ts";
 import { reduceBatch } from "./rebuildable-task-projection-catch-up.ts";
@@ -89,7 +89,7 @@ export function makeTaskProjection(options: {
       );
     } catch (error) {
       if (!(error instanceof ProjectionIdentityMismatchError)) throw error;
-      if (readHead() === null) resetDatabase(projectionPath, readHead);
+      if (readHead() === null) discardDatabase(projectionPath, readHead);
       else consumeKnownError(error);
     }
   }

--- a/packages/kernel/src/projection/rebuildable-task-projection-reads.ts
+++ b/packages/kernel/src/projection/rebuildable-task-projection-reads.ts
@@ -11,7 +11,7 @@ import type {
   TaskProjectionListRead,
   TaskProjectionRead,
 } from "./projection-reads.ts";
-import { resetDatabase, withDatabase } from "./rebuildable-task-projection-database.ts";
+import { discardDatabase, withDatabase } from "./rebuildable-task-projection-database.ts";
 import { catchUpRound } from "./rebuildable-task-projection-catch-up.ts";
 import { markRuntimeSessionsUnknown, readSnapshot } from "./rebuildable-task-projection-runtime.ts";
 import {
@@ -51,26 +51,26 @@ export function listProjection(
       const rows =
         /* @gate-identity check-bypass-write-boundary/bypass-write-012 */
         db
-        .prepare(
-          [
-            "SELECT task_snapshot.task_id AS task_id, task_package.package_path AS package_path,",
-            "COALESCE(task_generation.generation, 'v1') AS generation,",
-            "task_snapshot.workspace_revision AS workspace_revision,",
-            `${taskCreatedAtSql("task_snapshot.task_id")} AS created_at,`,
-            "event_index.event_json AS event_json FROM task_snapshot",
-            "LEFT JOIN task_package USING(task_id) LEFT JOIN task_generation USING(task_id)",
-            "JOIN event_index ON event_index.workspace_revision = task_snapshot.workspace_revision",
-            "ORDER BY task_snapshot.task_id",
-          ].join(" "),
-        )
-        .all() as unknown as readonly {
-        readonly task_id: string;
-        readonly package_path: string | null;
-        readonly generation: "v0" | "v1";
-        readonly workspace_revision: number;
-        readonly created_at: string | null;
-        readonly event_json: string;
-      }[];
+          .prepare(
+            [
+              "SELECT task_snapshot.task_id AS task_id, task_package.package_path AS package_path,",
+              "COALESCE(task_generation.generation, 'v1') AS generation,",
+              "task_snapshot.workspace_revision AS workspace_revision,",
+              `${taskCreatedAtSql("task_snapshot.task_id")} AS created_at,`,
+              "event_index.event_json AS event_json FROM task_snapshot",
+              "LEFT JOIN task_package USING(task_id) LEFT JOIN task_generation USING(task_id)",
+              "JOIN event_index ON event_index.workspace_revision = task_snapshot.workspace_revision",
+              "ORDER BY task_snapshot.task_id",
+            ].join(" "),
+          )
+          .all() as unknown as readonly {
+          readonly task_id: string;
+          readonly package_path: string | null;
+          readonly generation: "v0" | "v1";
+          readonly workspace_revision: number;
+          readonly created_at: string | null;
+          readonly event_json: string;
+        }[];
       return {
         status: current === round.sourceRevision ? "ready" : "pending",
         rows: rows.map((row) => ({
@@ -120,8 +120,8 @@ export function readDocument(
       row =
         /* @gate-identity check-bypass-write-boundary/bypass-write-013 */
         db.prepare("SELECT value_json FROM document WHERE path = ?").get(documentPath) as
-        | { readonly value_json: string }
-        | undefined;
+          | { readonly value_json: string }
+          | undefined;
     return {
       status: current === round.sourceRevision ? "ready" : "pending",
       document: row ? (JSON.parse(row.value_json) as DocumentState) : null,
@@ -143,8 +143,8 @@ export function readPresetSnapshot(
       row =
         /* @gate-identity check-bypass-write-boundary/bypass-write-014 */
         db.prepare("SELECT value_json FROM preset_snapshot WHERE digest = ?").get(digest) as
-        | { readonly value_json: string }
-        | undefined;
+          | { readonly value_json: string }
+          | undefined;
     return {
       status: current === round.sourceRevision ? "ready" : "pending",
       snapshot: row ? JSON.parse(row.value_json) : null,
@@ -170,8 +170,8 @@ export function readProjection(
       status: current === round.sourceRevision ? "ready" : "pending",
       snapshot: readSnapshot(db, taskId, now()),
       packagePath:
+        /* @gate-identity check-bypass-write-boundary/bypass-write-015 */
         (
-          /* @gate-identity check-bypass-write-boundary/bypass-write-015 */
           db.prepare("SELECT package_path FROM task_package WHERE task_id = ?").get(taskId) as
             | { readonly package_path: string }
             | undefined
@@ -194,7 +194,10 @@ export function rebuildProjection(
   eventStore: EventStreamPort,
   limit: number,
 ): ProjectionRebuildReceipt {
-  resetDatabase(projectionPath, readHead);
+  // Rebuild is a schema repair boundary as well as a data replay. Deleting the disposable
+  // database ensures CREATE TABLE materializes current DDL instead of retaining any table
+  // whose shape changed while its version metadata was stale or incorrect.
+  discardDatabase(projectionPath, readHead);
   let transactions = 0,
     reducedItems = 0,
     maxBatchItems = 0;

--- a/packages/kernel/test/store/projection-ddl-rebuild.test.ts
+++ b/packages/kernel/test/store/projection-ddl-rebuild.test.ts
@@ -1,0 +1,147 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import { compileFactWrite, type FactEventDraftV1 } from "../../src/domain/fact-event.ts";
+import { taskProjectionSchemaVersion } from "../../src/projection/projection-schema.ts";
+import { makeTaskProjection } from "../../src/projection/task-projection.ts";
+import { makeTaskEventStore } from "../../src/store/task-event-store.ts";
+import { withTempStoreAsync } from "./helpers.ts";
+
+const previousProjectionSchemaVersion = 13;
+
+test("a projection schema bump discards pre-first-class Fact DDL before replay", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    const { projectionPath, eventStore } = tasklessFactLedger(rootDir, "automatic-ddl-rebuild", "F-ABE050B5");
+    writeLegacyFactProjection(projectionPath, previousProjectionSchemaVersion);
+
+    const projection = makeTaskProjection({ rootDir, eventStore });
+    assert.equal(projection.searchFacts({ query: "standalone" }).facts[0]?.factId, "F-ABE050B5");
+    projection.close();
+    assertCurrentFactSchema(projectionPath);
+  });
+});
+
+test("explicit projection rebuild replaces stale DDL even when its version claims to be current", async () => {
+  await withTempStoreAsync(async (rootDir) => {
+    const { projectionPath, eventStore } = tasklessFactLedger(rootDir, "explicit-ddl-rebuild", "F-C01DB01D");
+    writeLegacyFactProjection(projectionPath, taskProjectionSchemaVersion);
+
+    const projection = makeTaskProjection({ rootDir, eventStore });
+    const rebuilt = projection.rebuild();
+    assert.equal(rebuilt.watermark, 1);
+    assert.equal(projection.searchFacts({ query: "standalone" }).facts[0]?.factId, "F-C01DB01D");
+    projection.close();
+    assertCurrentFactSchema(projectionPath);
+  });
+});
+
+function tasklessFactLedger(rootDir: string, repoId: string, factId: string) {
+  initRepo(rootDir);
+  const eventStore = makeTaskEventStore({ repoId, rootDir }),
+    event: FactEventDraftV1 = {
+      schema: "fact-event/v1",
+      eventId: `event-${factId}`,
+      workspaceRevision: 1,
+      opId: `op-${factId}`,
+      factId,
+      type: "fact_recorded",
+      actor: { principal: { personId: "projection-ddl-test" }, executor: null },
+      source: "local",
+      occurredAt: "2026-08-28T00:00:00.000Z",
+      payload: {
+        statement: "A standalone observation exercises the current Fact schema.",
+        evidenceSource: "projection DDL regression fixture",
+        observedAt: "2026-08-28T00:00:00.000Z",
+        confidence: "high",
+        memoryClass: "semantic",
+        memoryTags: [],
+        provenance: [
+          {
+            runtime: "codex",
+            sessionId: "projection-ddl-rebuild",
+            transcriptReachability: "by_session_id",
+            boundAt: "2026-08-28T00:00:00.000Z",
+          },
+        ],
+      },
+    };
+  eventStore.append(compileFactWrite({ event }));
+  return { eventStore, projectionPath: path.join(rootDir, ".harness/cache/task.sqlite") };
+}
+
+function writeLegacyFactProjection(projectionPath: string, schemaVersion: number): void {
+  mkdirSync(path.dirname(projectionPath), { recursive: true });
+  const db = new DatabaseSync(projectionPath);
+  try {
+    db.exec(`
+      CREATE TABLE projection_meta (
+        singleton INTEGER PRIMARY KEY CHECK(singleton=1), schema_version INTEGER NOT NULL,
+        watermark INTEGER NOT NULL, scan_cursor TEXT, scanned_revision INTEGER NOT NULL,
+        head_digest TEXT, state_digest TEXT, squad_run_ready INTEGER NOT NULL CHECK(squad_run_ready IN (0, 1))
+      );
+      INSERT INTO projection_meta VALUES (1, ${schemaVersion}, 0, NULL, 0, NULL, NULL, 0);
+      CREATE TABLE fact (
+        task_id TEXT NOT NULL, fact_id TEXT NOT NULL, ref TEXT NOT NULL UNIQUE,
+        statement TEXT NOT NULL, evidence_source TEXT NOT NULL, observed_at TEXT NOT NULL,
+        confidence TEXT NOT NULL, memory_class TEXT NOT NULL, op_id TEXT NOT NULL UNIQUE,
+        workspace_revision INTEGER NOT NULL, row_json TEXT NOT NULL, PRIMARY KEY(task_id, fact_id)
+      );
+      CREATE VIRTUAL TABLE fact_fts USING fts5(
+        task_id UNINDEXED, fact_id UNINDEXED, statement, evidence_source,
+        tokenize='unicode61 remove_diacritics 2'
+      );
+      CREATE INDEX fact_filter ON fact(task_id, confidence, memory_class, observed_at);
+    `);
+  } finally {
+    db.close();
+  }
+}
+
+function assertCurrentFactSchema(projectionPath: string): void {
+  const db = new DatabaseSync(projectionPath, { readOnly: true });
+  try {
+    const factColumns = db.prepare("PRAGMA table_info(fact)").all() as unknown as readonly {
+        readonly name: string;
+        readonly notnull: number;
+        readonly pk: number;
+      }[],
+      ftsColumns = db.prepare("PRAGMA table_info(fact_fts)").all() as unknown as readonly {
+        readonly name: string;
+      }[];
+    assert.deepEqual(
+      factColumns
+        .filter(({ name }) => name === "task_id" || name === "fact_id")
+        .map(({ name, notnull, pk }) => ({
+          name,
+          notnull,
+          pk,
+        })),
+      [
+        { name: "task_id", notnull: 0, pk: 0 },
+        { name: "fact_id", notnull: 1, pk: 1 },
+      ],
+    );
+    assert.deepEqual(
+      ftsColumns.map(({ name }) => name),
+      ["fact_id", "statement", "evidence_source"],
+    );
+    assert.equal(db.prepare("SELECT 1 FROM sqlite_master WHERE type='index' AND name='fact_filter'").get(), undefined);
+  } finally {
+    db.close();
+  }
+}
+
+function initRepo(rootDir: string): void {
+  git(rootDir, "init", "--quiet");
+  git(rootDir, "config", "user.name", "Projection DDL Test");
+  git(rootDir, "config", "user.email", "projection-ddl@example.invalid");
+  git(rootDir, "commit", "--allow-empty", "--quiet", "-m", "fixture base");
+}
+
+function git(rootDir: string, ...args: readonly string[]): string {
+  return execFileSync("git", ["-C", rootDir, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}

--- a/packages/kernel/test/store/projection-identity-binding.test.ts
+++ b/packages/kernel/test/store/projection-identity-binding.test.ts
@@ -15,7 +15,7 @@ import { withTempStoreAsync } from "./helpers.ts";
 // produces: the whole ledger is rewritten while the head revision stays put. A projection cache
 // scanned from one ledger must not be able to impersonate the other's cache. Opening a cache
 // against a same-revision ledger with a different head eventDigest must fail closed until an
-// explicit rebuild clears it in place.
+// explicit rebuild discards it and replays the source ledger.
 test("projection cache identity mismatch is explicit and rebuild remains available", async () => {
   await withTempStoreAsync(async (rootA) => {
     await withTempStoreAsync(async (rootB) => {

--- a/packages/kernel/test/store/schedule-projection.test.ts
+++ b/packages/kernel/test/store/schedule-projection.test.ts
@@ -15,10 +15,10 @@ import { withTempStoreAsync } from "./helpers.ts";
 
 const actor = { principal: { personId: "person-schedule" }, executor: null } as const;
 
-test("Schedule definition and run view share one canonical stream and rebuild exactly without an additional schema bump", async () => {
+test("Schedule definition and run view share one canonical stream and rebuild exactly", async () => {
   await withTempStoreAsync(async (rootDir) => {
     initRepo(rootDir);
-    assert.equal(taskProjectionSchemaVersion, 13);
+    assert.equal(taskProjectionSchemaVersion, 14);
     const eventStore = makeTaskEventStore({ repoId: "schedule-projection", rootDir }),
       projection = makeTaskProjection({ rootDir, eventStore }),
       schedule = baseSchedule(),

--- a/packages/kernel/test/store/task-projection.test.ts
+++ b/packages/kernel/test/store/task-projection.test.ts
@@ -1,7 +1,7 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { DatabaseSync } from "node:sqlite";
@@ -324,20 +324,28 @@ test("cold replay still rejects a missing claimed blob after batch verification"
   });
 });
 
-test("cold rebuild resets the projection in place and accepts a larger bounded replay window", async () => {
+test("cold rebuild replaces the projection database and accepts a larger bounded replay window", async () => {
   await withTempStoreAsync(async (rootDir) => {
     initRepo(rootDir);
-    const eventStore = makeTaskEventStore({ repoId: "in-place-rebuild", rootDir }),
+    const eventStore = makeTaskEventStore({ repoId: "replacement-rebuild", rootDir }),
       projection = makeTaskProjection({ rootDir, eventStore });
     const first = lifecycleFixture().events[0]!;
     eventStore.append(taskBundle(first));
     projection.apply(first, taskLifecycleWritePlan(first));
-    const before = statSync(projection.path).ino;
+    projection.close();
+    const stale = new DatabaseSync(projection.path);
+    stale.exec("CREATE TABLE stale_projection_ddl (value TEXT)");
+    stale.close();
     const rebuilt = projection.rebuild();
-    const after = statSync(projection.path).ino;
     assert.equal(rebuilt.watermark, 1);
-    assert.equal(after, before);
     assert.equal(rebuilt.metrics.maxBatchItems <= 4096, true);
+    projection.close();
+    const replacement = new DatabaseSync(projection.path, { readOnly: true });
+    assert.equal(
+      replacement.prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name='stale_projection_ddl'").get(),
+      undefined,
+    );
+    replacement.close();
   });
 });
 


### PR DESCRIPTION
# English

## Summary

Canonical was wedged on 2026-08-28 because the SQLite projection carried `fact`/`fact_fts` DDL from before facts became first-class (`task_id NOT NULL`, 4-column FTS): `CREATE TABLE IF NOT EXISTS` never migrates DDL and `ha daemon projection rebuild` only cleared rows, so the first task-less fact failed every catch-up and no command could run. The projection schema generation is now 14, which invalidates any cache still holding the old Fact DDL; explicit `projection rebuild` and headless identity recovery discard the disposable SQLite database and recreate it from the current DDL instead of truncating tables. A regression test builds a database with the pre-first-class DDL and proves the rebuild path recreates it.

## Architectural Justification

- Production-Delta as computed: `rebuildable-task-projection-database.ts` loses the per-table truncation path (-30) in favour of one discard-and-recreate; reads are simplified accordingly.

## What Changed

- `packages/kernel/src/projection/projection-schema.ts`: generation 14 with the invalidation rationale.
- `rebuildable-task-projection-database.ts`, `-factory.ts`, `-reads.ts`: rebuild/recovery discard the database file and recreate DDL.
- `packages/kernel/test/store/projection-ddl-rebuild.test.ts` (new) + version pins updated in lease-reservation, identity-binding, schedule-projection, task-projection tests.

## Gate Harvest / 门收割

Deleted-Production-Paths: per-table truncation in `rebuildable-task-projection-database.ts` (replaced by discard-and-recreate)
Deleted-Gates-Fixtures: schema-version pins in `lease-reservation.integration.test.ts`, `projection-identity-binding.test.ts`, `schedule-projection.test.ts`, `task-projection.test.ts` moved 13 → 14 (fixture expectations, no gate logic)
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +39/-62
Dependency-Change: none

### Optional Evidence Claims

## Task And Scope

- Harness task: task_447adb14480da0d8df21142bdf
- Branch: codex/projection-ddl-rebuild
- Public scope: packages/kernel projection database/factory/reads + kernel store tests
- Private planning/evidence updated: yes
- Out of scope: Ledger events and the fact-rekey migration are untouched; GUI untouched.

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_447adb14480da0d8df21142bdf
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-28T13:15Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_447adb14480da0d8df21142bdf (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Worker (Node 24): projection-ddl-rebuild 2/2 + adjacent kernel/daemon projection suites, tsc, ESLint on changed files, file-complexity and implementation-contract gates
- [x] CEO: reproduced the original wedge on canonical (fact.task_id NOT NULL, fact_fts 4 columns) before this change; canonical now runs schema 13 → will cold-rebuild once more on 14
- [x] production-delta computed
- [ ] CI on this PR
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO read the database diff: rebuild now unlinks and recreates rather than truncating; the new test seeds the exact pre-first-class DDL seen on canonical.
- Reviewer subagent: Sol implemented; CEO semantic acceptance against task_447adb14 (filed from the live incident).
- Human review: pending
- Blocking findings: none

## Residual Risk

- Every node cold-rebuilds once on upgrade (≈41 s on canonical's 40k events).

## References

- Task: task_447adb14480da0d8df21142bdf
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

2026-08-28 canonical 被卡死:SQLite 投影里 `fact`/`fact_fts` 的 DDL 还停留在 fact 元语化之前(`task_id NOT NULL`、4 列 FTS)——`CREATE TABLE IF NOT EXISTS` 不迁 DDL,`ha daemon projection rebuild` 只清行,第一条不带 task 的 fact 让每次 catch-up 都失败,任何命令都跑不了。现在投影 schema 代际升到 14,凡是还带旧 Fact DDL 的缓存一律失效;显式 `projection rebuild` 与 headless 身份恢复改为丢弃一次性 SQLite 库、按现行 DDL 重建,而不是截断表。回归测试用元语化之前的 DDL 建库并证明重建路径会重建它。

## 架构辩护

- Production-Delta 实算:这不是新增机制而是把两条路收成一条——`rebuildable-task-projection-database.ts` 原来对每张表分别截断(保留旧 DDL),现在改为丢弃整个一次性 SQLite 文件再按现行 DDL 重建,删掉约三十行逐表截断代码;读路 `-reads.ts` 相应简化。投影是可重建缓存,丢弃重建是它本来的契约,不需要保留任何兼容层或迁移脚本。

## 改动内容

- `packages/kernel/src/projection/projection-schema.ts`:代际 14 并注明失效理由。
- `rebuildable-task-projection-database.ts`、`-factory.ts`、`-reads.ts`:rebuild/恢复改为丢弃库文件并重建 DDL。
- 新增 `packages/kernel/test/store/projection-ddl-rebuild.test.ts`;lease-reservation、identity-binding、schedule-projection、task-projection 测试的版本 pin 更新。

## 门收割 / Gate Harvest

- 删除的生产路径:`rebuildable-task-projection-database.ts` 的逐表截断(改为丢弃重建)
- 同 commit 删除的门 / fixture:`lease-reservation.integration.test.ts`、`projection-identity-binding.test.ts`、`schedule-projection.test.ts`、`task-projection.test.ts` 的 schema 版本 pin 13 → 14(fixture 期望,不含门逻辑)
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_447adb14480da0d8df21142bdf
- 分支:codex/projection-ddl-rebuild
- 公开范围:packages/kernel 投影 database/factory/reads + kernel store 测试
- 私有计划 / 证据是否已更新:yes
- 范围外:账本事件与 fact-rekey 迁移不动;GUI 不动。

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_447adb14480da0d8df21142bdf
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-28T13:15Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_447adb14480da0d8df21142bdf
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] worker(Node 24):projection-ddl-rebuild 2/2 + 相邻 kernel/daemon 投影套件、tsc、改动文件 ESLint、file-complexity 与 implementation-contract 门
- [x] CEO:改动前在 canonical 复现了原始卡死(fact.task_id NOT NULL、fact_fts 4 列);canonical 现为 schema 13 → 升到 14 会再冷重建一次
- [x] production-delta 实算
- [ ] 本 PR 的 CI
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 读了 database diff:rebuild 改为删文件重建而非截断;新测试灌入的正是 canonical 上见到的旧 DDL。
- Reviewer subagent:Sol 实现;CEO 按 task_447adb14(现场事故立项)做语义验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 每个节点升级后冷重建一次(canonical 4 万事件约 41 s)。

## 关联材料

- 任务:task_447adb14480da0d8df21142bdf
- 证据:任务包 artifacts/reports
- 审查:本 PR
