### PR TITLE
fix(gates): diff changed files from the merge base

### DIFF
--- a/tools/gates/git.mjs
+++ b/tools/gates/git.mjs
@@ -5,7 +5,7 @@ export function git(rootDir, args, options = {}) {
     cwd: rootDir,
     encoding: options.encoding ?? "utf8",
     maxBuffer: 64 * 1024 * 1024,
-    stdio: ["ignore", "pipe", "pipe"]
+    stdio: ["ignore", "pipe", "pipe"],
   });
 }
 
@@ -23,7 +23,7 @@ export function pathExistsAt(rootDir, revision, filePath) {
 }
 
 export function changedFiles(rootDir, base, head = "HEAD") {
-  return git(rootDir, ["diff", "--name-only", "-z", base, head, "--"])
+  return git(rootDir, ["diff", "--name-only", "-z", `${base}...${head}`, "--"])
     .split("\0")
     .filter(Boolean);
 }

--- a/tools/gates/test/git.test.mjs
+++ b/tools/gates/test/git.test.mjs
@@ -1,0 +1,24 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import { changedFiles, git } from "../git.mjs";
+import { commitAll, makeRepo, writeRepoFile } from "./helpers.mjs";
+
+test("changedFiles measures the head from its merge base when the target branch advances", () => {
+  const { rootDir } = makeRepo({ "shared.txt": "shared\n" });
+  const targetBranch = git(rootDir, ["rev-parse", "--abbrev-ref", "HEAD"]).trim();
+
+  git(rootDir, ["checkout", "-q", "-b", "feature"]);
+  writeRepoFile(rootDir, "feature.txt", "feature\n");
+  const featureHead = commitAll(rootDir, "feature change");
+
+  git(rootDir, ["checkout", "-q", targetBranch]);
+  writeRepoFile(rootDir, "package.json", "{}\n");
+  const advancedTarget = commitAll(rootDir, "target-only dependency manifest");
+
+  assert.deepEqual(git(rootDir, ["diff", "--name-only", advancedTarget, featureHead, "--"]).trim().split("\n"), [
+    "feature.txt",
+    "package.json",
+  ]);
+  assert.deepEqual(changedFiles(rootDir, advancedTarget, featureHead), ["feature.txt"]);
+});


### PR DESCRIPTION
# English

## Summary

`tools/gates/git.mjs` `changedFiles` used two-dot `git diff base head`, so every file changed on main after the branch point was attributed to the PR. On PR #1970 (which touched no package.json) the dependency-policy gate demanded a Dependency-Change declaration because PR #1971 had bumped versions on main. `changedFiles` now diffs from the merge base (`base...head`), with a test that builds a repo where main moves after the branch point and proves those files are no longer reported.

## Architectural Justification

- Production-Delta as computed: a two-line semantic fix plus its test.

## What Changed

- `tools/gates/git.mjs`: `base...head`.
- `tools/gates/test/git.test.mjs`: merge-base regression.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +2/-2
Dependency-Change: none

### Optional Evidence Claims

## Task And Scope

- Harness task: task_0b80d6e55ae16af1b7a9f48135
- Branch: codex/gate-three-dot
- Public scope: tools/gates/git.mjs + its test
- Private planning/evidence updated: yes
- Out of scope: Individual gates' own diff calls are not audited here.

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_0b80d6e55ae16af1b7a9f48135
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-28T13:08Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_0b80d6e55ae16af1b7a9f48135 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Worker: `node --test tools/gates/test/git.test.mjs` green
- [x] CEO: the phantom attribution was observed live on PR #1970 and disappeared after a rebase, consistent with two-dot semantics
- [x] production-delta computed
- [ ] CI on this PR
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO read the 4-line diff.
- Reviewer subagent: Sol implemented; CEO acceptance against task_0b80d6e5.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Gates that relied on seeing upstream changes (none known) would now see fewer files.

## References

- Task: task_0b80d6e55ae16af1b7a9f48135
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

`tools/gates/git.mjs` 的 `changedFiles` 用的是两点 `git diff base head`,分支点之后 main 上改的每个文件都被算成本 PR 的改动。PR #1970 一个 package.json 都没碰,却因 #1971 在 main 上升了版本而被 dependency-policy 要求 Dependency-Change 声明。现在 `changedFiles` 从 merge base 起算(`base...head`),测试构造 main 在分支点之后前进的仓库,证明那些文件不再被报告。

## 架构辩护

- Production-Delta 实算:两行语义修正加测试。

## 改动内容

- `tools/gates/git.mjs`:`base...head`。
- `tools/gates/test/git.test.mjs`:merge-base 回归。

## 门收割 / Gate Harvest

- 删除的生产路径:无
- 同 commit 删除的门 / fixture:无——门逻辑不变,只修正文件归因输入
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_0b80d6e55ae16af1b7a9f48135
- 分支:codex/gate-three-dot
- 公开范围:tools/gates/git.mjs 及其测试
- 私有计划 / 证据是否已更新:yes
- 范围外:各门自己的 diff 调用不在本 PR 审计范围。

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_0b80d6e55ae16af1b7a9f48135
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-28T13:08Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_0b80d6e55ae16af1b7a9f48135
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] worker:`node --test tools/gates/test/git.test.mjs` 绿
- [x] CEO:幻影归因在 PR #1970 上实测出现、rebase 后消失,与两点语义一致
- [x] production-delta 实算
- [ ] 本 PR 的 CI
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 读了 4 行 diff。
- Reviewer subagent:Sol 实现;CEO 按 task_0b80d6e5 验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 若有门依赖看到上游改动(未知有),现在会看到更少文件。

## 关联材料

- 任务:task_0b80d6e55ae16af1b7a9f48135
- 证据:任务包 artifacts/reports
- 审查:本 PR
