### PR TITLE
feat(gui): territory view hides cancelled/archived tasks by default

### DIFF
--- a/packages/gui/src/renderer/graph-territory-preferences.ts
+++ b/packages/gui/src/renderer/graph-territory-preferences.ts
@@ -1,0 +1,46 @@
+import { consumeKnownError } from "../api/error-consumption.ts";
+
+/**
+ * 关系图领地视图「显示已归档」开关的本地记忆(task_b92c5138)。
+ *
+ * 判定本体在 model/taskFilters.ts(isTaskArchiveNoise,与看板共用,不第二份);
+ * 这里只管开关状态的 localStorage 读写。偏好语义与 terminal-preferences 同款:
+ * 默认 false(隐藏 cancelled/archived),坏值/坏存储回落默认,偏好读坏绝不挡视图。
+ * 按视图记忆:聚光灯不受此开关影响,也不共享这个键。
+ */
+const storageKey = "harness:gui:graph-territory-show-archived";
+
+/** renderer 的 localStorage;非 DOM 环境(如 SSR 渲染)返回 null,偏好回落默认。 */
+export function graphTerritoryPreferenceStorage(): {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+} | null {
+  return typeof window === "undefined" ? null : window.localStorage;
+}
+
+export function readGraphTerritoryShowArchived(
+  storage: { getItem(key: string): string | null } | null | undefined,
+): boolean {
+  if (!storage) return false;
+  try {
+    const parsed: unknown = JSON.parse(storage.getItem(storageKey) ?? "null");
+    // 只有显式 true 才打开;null(未设)/坏 JSON/其他值一律回落默认:隐藏。
+    return parsed === true;
+  } catch (cause) {
+    consumeKnownError(cause);
+    return false;
+  }
+}
+
+export function writeGraphTerritoryShowArchived(
+  storage: { setItem(key: string, value: string): void } | null | undefined,
+  showArchived: boolean,
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(storageKey, JSON.stringify(showArchived));
+  } catch (cause) {
+    // 隐私模式/quota 满:本会话开关仍生效,只是不跨会话记忆(显式消费,不静默吞)。
+    consumeKnownError(cause);
+  }
+}

--- a/packages/gui/src/renderer/model/taskFilters.ts
+++ b/packages/gui/src/renderer/model/taskFilters.ts
@@ -37,14 +37,20 @@ export const hasActiveTaskFilters = (filters: TaskFilters) =>
   filters.includeArchived ||
   filters.favoritesOnly;
 
+/**
+ * 看板降噪判定(唯一实现,看板与关系图领地共用,不第二份):
+ * status=cancelled 或 package disposition 非 active(archived/tombstoned)的 task
+ * 默认算噪音。看板入口 = matchesTask 的 !includeArchived 分支;关系图领地入口 =
+ * GraphView territory 的「显示已归档」开关(默认关 = 隐藏,task_b92c5138)。
+ */
+export const isTaskArchiveNoise = (task: Pick<TaskRow, "packageDisposition" | "coordinationStatus">): boolean =>
+  /* @gate-identity check-gui-status-judgments/gui-status-033 */
+  task.packageDisposition !== "active" ||
+  /* @gate-identity check-gui-status-judgments/gui-status-034 */
+  task.coordinationStatus === "cancelled";
+
 export function matchesTask(task: TaskRow, filters: TaskFilters, favorites?: ReadonlySet<string>): boolean {
-  if (
-    !filters.includeArchived &&
-    /* @gate-identity check-gui-status-judgments/gui-status-033 */
-    (task.packageDisposition !== "active" ||
-      /* @gate-identity check-gui-status-judgments/gui-status-034 */
-      task.coordinationStatus === "cancelled")
-  ) {
+  if (!filters.includeArchived && isTaskArchiveNoise(task)) {
     return false;
   }
 

--- a/packages/gui/src/renderer/views/GraphView.tsx
+++ b/packages/gui/src/renderer/views/GraphView.tsx
@@ -32,6 +32,12 @@ import {
 } from "../graph/entityStatusFilter";
 import { focusHistoryReducer, EMPTY_HISTORY, canBack, canForward } from "../navigation/focusHistory";
 import { activeProducesFactRefs } from "../model/triadic";
+import { isTaskArchiveNoise } from "../model/taskFilters";
+import {
+  graphTerritoryPreferenceStorage,
+  readGraphTerritoryShowArchived,
+  writeGraphTerritoryShowArchived,
+} from "../graph-territory-preferences";
 
 export type ViewMode = "territory" | "spotlight";
 
@@ -92,6 +98,14 @@ function GraphViewInner({
   // 用户手动展开的 zone 集。上千实体的真实数据下,折叠态保证首屏可读。
   const [expandedZones, setExpandedZones] = useState<Set<string>>(() => new Set());
   const [flowMode, setFlowMode] = useState<FlowAnimMode>("focus");
+  // 领地降噪开关(task_b92c5138):默认关 = 隐藏 cancelled/archived task(看板同规则,
+  // 判定 isTaskArchiveNoise 单一定义);localStorage 按视图记忆,坏值回落默认。
+  const [showArchived, setShowArchived] = useState(() =>
+    readGraphTerritoryShowArchived(graphTerritoryPreferenceStorage()),
+  );
+  useEffect(() => {
+    writeGraphTerritoryShowArchived(graphTerritoryPreferenceStorage(), showArchived);
+  }, [showArchived]);
   // 聚光灯布局统计(EgoNeighborhood 上报,页头计数与焦点面包屑共用)。
   const [spotlightStats, setSpotlightStats] = useState<{ nodes: number; edges: number; focusLabel: string | null }>({
     nodes: 0,
@@ -178,6 +192,8 @@ function GraphViewInner({
   // 筛选口径与 archive 线对齐:module/实体类型/实体状态筛选同样作用于领地。单种类 skel
   // 下 types 由 skel 独占。状态筛选在**行**上生效(archive 是过滤已渲染节点):块计数因此
   // 与可见 chip 一致,不会出现「徽章记了一笔、屏幕纹丝不动」的空筛。fact 不受状态筛选。
+  // 降噪(默认隐藏 cancelled/archived task)走同一条行过滤(isTaskArchiveNoise,与看板
+  // 共用),所以块/进度计数同样只数可见行;领地 L1 无关系线,隐藏行不留下悬空边。
   const territoryTypes = useMemo(
     () => (skel === "task" || skel === "decision" || skel === "fact" ? new Set<string>([skel]) : filters.types),
     [skel, filters.types],
@@ -187,7 +203,8 @@ function GraphViewInner({
     const taskVisible = (task: TaskRow) =>
       filters.modules.has(task.module) &&
       territoryTypes.has("task") &&
-      taskPassesStatusFilter(task, filters.entityStatus);
+      taskPassesStatusFilter(task, filters.entityStatus) &&
+      (showArchived || !isTaskArchiveNoise(task));
     const visibleTasks = tasks.filter(taskVisible);
     const moduleByTaskId = new Map(tasks.map((task) => [task.taskId, task.module] as const));
     // fact 跟随宿主 task 的 module 可见性;无宿主(未知/外部)不因 module 筛选隐藏。
@@ -225,6 +242,7 @@ function GraphViewInner({
     filters.modules,
     filters.entityStatus,
     territoryTypes,
+    showArchived,
   ]);
 
   const toggleZone = useCallback((zoneId: string) => {
@@ -304,6 +322,21 @@ function GraphViewInner({
             : `聚光灯 · ${spotlightStats.nodes} 节点 · ${spotlightStats.edges} 边`}
         </span>
         <GraphLegend showFulfillment={(coverageRows?.length ?? 0) > 0} />
+        {viewMode === "territory" && (
+          <span
+            className="inline-flex items-center gap-1 rounded bg-surface-raised px-1.5 py-0.5 font-mono text-text-muted"
+            title="与看板同一条降噪规则:status=cancelled 或 package disposition≠active 的 task 默认不画;点击切回全量(本机记忆)"
+          >
+            已归档
+            <button
+              data-testid="territory-archive-toggle"
+              onClick={() => setShowArchived((v) => !v)}
+              className="rounded px-1 text-[11px] text-text hover:bg-surface"
+            >
+              {showArchived ? "显示" : "隐藏"}
+            </button>
+          </span>
+        )}
         {territory && territory.unprojectedCount > 0 && (
           <span
             className="inline-flex items-center gap-1 rounded bg-stale/10 px-1.5 py-0.5 font-mono text-stale"

--- a/packages/gui/test/graph-view-regression.vitest.ts
+++ b/packages/gui/test/graph-view-regression.vitest.ts
@@ -5,6 +5,10 @@ import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { GraphView } from "../src/renderer/views/GraphView.tsx";
 import type { TaskRow, DecisionRow, RelationEdge } from "../src/renderer/model/types.ts";
+import {
+  readGraphTerritoryShowArchived,
+  writeGraphTerritoryShowArchived,
+} from "../src/renderer/graph-territory-preferences.ts";
 
 /**
  * 关系图页不因 ego 组件抽取而退化(W4 硬要求)。
@@ -16,18 +20,33 @@ import type { TaskRow, DecisionRow, RelationEdge } from "../src/renderer/model/t
 
 function task(taskId: string, title: string): TaskRow {
   return {
-    taskId, title, projectId: "proj",
-    coordinationStatus: "active", rawStatus: "active", freshness: "fresh",
-    packageDisposition: "active", closeoutReadiness: "not_required",
-    engine: "local", source: "local-document", module: "gui",
-    lastKnownAt: "2026-08-01T00:00:00.000Z", gates: [], docs: [],
+    taskId,
+    title,
+    projectId: "proj",
+    coordinationStatus: "active",
+    rawStatus: "active",
+    freshness: "fresh",
+    packageDisposition: "active",
+    closeoutReadiness: "not_required",
+    engine: "local",
+    source: "local-document",
+    module: "gui",
+    lastKnownAt: "2026-08-01T00:00:00.000Z",
+    gates: [],
+    docs: [],
   };
 }
 
 function decision(decisionId: string): DecisionRow {
   return {
-    decisionId, title: `决策 ${decisionId}`, state: "active", question: "Q?",
-    chosen: [], rejected: [], claims: [], proposedAt: "2026-08-01T00:00:00.000Z",
+    decisionId,
+    title: `决策 ${decisionId}`,
+    state: "active",
+    question: "Q?",
+    chosen: [],
+    rejected: [],
+    claims: [],
+    proposedAt: "2026-08-01T00:00:00.000Z",
   } as DecisionRow;
 }
 
@@ -45,23 +64,28 @@ async function mountGraph(overrides: Partial<Record<string, unknown>> = {}) {
   const div = document.createElement("div");
   document.body.appendChild(div);
   const root = createRoot(div);
-  const render = (props: Partial<Record<string, unknown>>) => act(async () => {
-    root.render(createElement(GraphView, {
-      tasks: fixtures.tasks,
-      decisions: fixtures.decisions,
-      facts: [],
-      relations: fixtures.relations,
-      focusRef: "decision/d1",
-      viewMode: "spotlight",
-      onViewModeChange: () => {},
-      ...props,
-    } as never));
-  });
+  const render = (props: Partial<Record<string, unknown>>) =>
+    act(async () => {
+      root.render(
+        createElement(GraphView, {
+          tasks: fixtures.tasks,
+          decisions: fixtures.decisions,
+          facts: [],
+          relations: fixtures.relations,
+          focusRef: "decision/d1",
+          viewMode: "spotlight",
+          onViewModeChange: () => {},
+          ...props,
+        } as never),
+      );
+    });
   await render(overrides);
   return { div, root: root as Root, render };
 }
 
-beforeAll(() => { globalThis.IS_REACT_ACT_ENVIRONMENT = true; });
+beforeAll(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
 
 describe("graph page keeps its behavior after the ego extraction (W4)", () => {
   it("spotlight renders focus card + neighbor chips and reports header counts", async () => {
@@ -72,14 +96,18 @@ describe("graph page keeps its behavior after the ego extraction (W4)", () => {
     expect(div.textContent).toContain("聚光灯 · 4 节点 · 3 边");
     // 同一时刻 DOM 里只有一个 ReactFlow(可访问性/选择器不二义)。
     expect(div.querySelectorAll(".react-flow").length).toBe(1);
-    await act(async () => { root.unmount(); });
+    await act(async () => {
+      root.unmount();
+    });
   });
 
   it("accumulated expansion survives a territory↔spotlight round trip", async () => {
     const { div, root, render } = await mountGraph();
     // 展开 t1:卡片 1 → 2,邻居累计 3 chip → 2。
     const chip = [...div.querySelectorAll("[data-testid='ego-chip']")].find((c) => c.textContent?.includes("任务一"))!;
-    await act(async () => { chip.dispatchEvent(new MouseEvent("click", { bubbles: true })); });
+    await act(async () => {
+      chip.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
     expect(div.querySelectorAll("[data-testid='ego-card']").length).toBe(2);
 
     // 去领地再回聚光灯:焦点引用不变(EntityWorkspace 切模式不清焦点),
@@ -91,19 +119,32 @@ describe("graph page keeps its behavior after the ego extraction (W4)", () => {
     expect(div.querySelectorAll("[data-testid='ego-card']").length).toBe(2);
     expect(div.querySelectorAll("[data-testid='ego-chip']").length).toBe(2);
     expect(div.querySelectorAll(".react-flow").length).toBe(1);
-    await act(async () => { root.unmount(); });
+    await act(async () => {
+      root.unmount();
+    });
   });
 
   it("territory chip click enters spotlight on that entity", async () => {
     const onViewModeChange = vi.fn();
     const onFocusEntityChange = vi.fn();
-    const { div, root } = await mountGraph({ viewMode: "territory", focusRef: null, onViewModeChange, onFocusEntityChange });
-    const chip = [...div.querySelectorAll("[data-testid='territory-chip']")].find((c) => c.textContent?.includes("决策 d1"));
+    const { div, root } = await mountGraph({
+      viewMode: "territory",
+      focusRef: null,
+      onViewModeChange,
+      onFocusEntityChange,
+    });
+    const chip = [...div.querySelectorAll("[data-testid='territory-chip']")].find((c) =>
+      c.textContent?.includes("决策 d1"),
+    );
     expect(chip).toBeDefined();
-    await act(async () => { (chip as HTMLElement).click(); });
+    await act(async () => {
+      (chip as HTMLElement).click();
+    });
     expect(onViewModeChange).toHaveBeenCalledWith("spotlight");
     expect(onFocusEntityChange).toHaveBeenCalledWith("decision/d1");
-    await act(async () => { root.unmount(); });
+    await act(async () => {
+      root.unmount();
+    });
   });
 
   it("clear focus empties the spotlight canvas", async () => {
@@ -111,6 +152,112 @@ describe("graph page keeps its behavior after the ego extraction (W4)", () => {
     await render({ focusRef: null });
     await act(async () => {});
     expect(div.querySelectorAll("[data-testid='ego-card']").length).toBe(0);
-    await act(async () => { root.unmount(); });
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});
+
+/**
+ * 领地降噪(task_b92c5138):territory 默认不渲染 cancelled/archived task 的 chip
+ * (判定与看板共用 isTaskArchiveNoise);「显示已归档」开关切回全量,且状态写入
+ * localStorage,重新挂载时读回 —— 坏值回落默认(隐藏)。
+ */
+describe("territory archive-noise filter (board parity)", () => {
+  function noiseTasks(): TaskRow[] {
+    return [
+      task("t_live", "在飞任务"),
+      { ...task("t_cancelled", "已取消任务"), coordinationStatus: "cancelled", rawStatus: "cancelled" },
+      { ...task("t_archived", "已归档任务"), packageDisposition: "archived" },
+    ];
+  }
+
+  function chipRefs(div: HTMLElement): string[] {
+    return [...div.querySelectorAll("[data-testid='territory-chip']")].map(
+      (chip) => (chip as HTMLElement).dataset.navRef ?? "",
+    );
+  }
+
+  async function mountTerritory(tasks: TaskRow[]) {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(
+        createElement(GraphView, {
+          tasks,
+          decisions: [],
+          facts: [],
+          relations: [],
+          focusRef: null,
+          viewMode: "territory",
+          onViewModeChange: () => {},
+        } as never),
+      );
+    });
+    return { div, root: root as Root };
+  }
+
+  beforeAll(() => {
+    window.localStorage.clear();
+  });
+
+  it("hides cancelled/archived chips by default and shows them after the toggle", async () => {
+    window.localStorage.clear();
+    const { div, root } = await mountTerritory(noiseTasks());
+    expect(chipRefs(div)).toEqual(["task/t_live"]);
+
+    const toggle = div.querySelector("[data-testid='territory-archive-toggle']") as HTMLElement;
+    expect(toggle).not.toBeNull();
+    expect(toggle.textContent).toContain("隐藏");
+    await act(async () => {
+      toggle.click();
+    });
+
+    expect(chipRefs(div).sort()).toEqual(["task/t_archived", "task/t_cancelled", "task/t_live"]);
+    // 开关状态落 localStorage;同一视图重新挂载读回(记忆)。
+    expect(window.localStorage.getItem("harness:gui:graph-territory-show-archived")).toBe("true");
+    await act(async () => {
+      root.unmount();
+    });
+
+    const second = await mountTerritory(noiseTasks());
+    expect(chipRefs(second.div).sort()).toEqual(["task/t_archived", "task/t_cancelled", "task/t_live"]);
+    await act(async () => {
+      second.root.unmount();
+    });
+  });
+
+  it("writes the default (hidden) on mount so the memory always reflects the live view", async () => {
+    window.localStorage.clear();
+    const { div, root } = await mountTerritory(noiseTasks());
+    expect(chipRefs(div)).toEqual(["task/t_live"]);
+    expect(window.localStorage.getItem("harness:gui:graph-territory-show-archived")).toBe("false");
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});
+
+describe("graph territory show-archived preference storage", () => {
+  it("round-trips through a storage stub and falls back to hidden on garbage", () => {
+    const stub = {
+      value: null as string | null,
+      getItem() {
+        return this.value;
+      },
+      setItem(_k: string, v: string) {
+        this.value = v;
+      },
+    };
+    expect(readGraphTerritoryShowArchived(stub)).toBe(false);
+    writeGraphTerritoryShowArchived(stub, true);
+    expect(readGraphTerritoryShowArchived(stub)).toBe(true);
+    writeGraphTerritoryShowArchived(stub, false);
+    expect(readGraphTerritoryShowArchived(stub)).toBe(false);
+    stub.value = "{not json";
+    expect(readGraphTerritoryShowArchived(stub)).toBe(false);
+    stub.value = '"yes"';
+    expect(readGraphTerritoryShowArchived(stub)).toBe(false);
   });
 });

--- a/packages/gui/test/taskFilters.vitest.ts
+++ b/packages/gui/test/taskFilters.vitest.ts
@@ -4,6 +4,7 @@ import {
   applyTaskFilters,
   DEFAULT_TASK_FILTERS,
   hasActiveTaskFilters,
+  isTaskArchiveNoise,
   matchesTask,
   sortByFavoritesFirst,
   taskFilterSummary,
@@ -65,19 +66,52 @@ describe("taskFilters status multi-select", () => {
   });
 
   it("makes relation unknown and every projected module explicitly filterable", () => {
-    const task = makeTask({ coordinationStatus: "planned", canonicalStatus: "planned", blocking: "unknown", module: "multiple (gui, kernel)", moduleKeys: ["gui", "kernel"] });
+    const task = makeTask({
+      coordinationStatus: "planned",
+      canonicalStatus: "planned",
+      blocking: "unknown",
+      module: "multiple (gui, kernel)",
+      moduleKeys: ["gui", "kernel"],
+    });
     expect(matchesTask(task, { ...DEFAULT_TASK_FILTERS, status: ["unknown"] })).toBe(true);
     expect(matchesTask(task, { ...DEFAULT_TASK_FILTERS, module: "gui" })).toBe(true);
   });
 });
 
+/**
+ * 看板降噪判定(task_b92c5138 起与关系图领地共用同一个 isTaskArchiveNoise,
+ * 不允许第二份实现):cancelled 状态或非 active disposition 的 task 默认是噪音。
+ */
+describe("taskFilters archive-noise rule (shared with graph territory)", () => {
+  it("flags cancelled status and non-active dispositions as noise", () => {
+    expect(isTaskArchiveNoise(makeTask())).toBe(false);
+    expect(isTaskArchiveNoise(makeTask({ coordinationStatus: "cancelled" }))).toBe(true);
+    expect(isTaskArchiveNoise(makeTask({ packageDisposition: "archived" }))).toBe(true);
+    expect(isTaskArchiveNoise(makeTask({ packageDisposition: "tombstoned" }))).toBe(true);
+    // 已取消且归档的行仍然只是「一条噪音」,不会因为两个字段同时命中而变化。
+    expect(isTaskArchiveNoise(makeTask({ coordinationStatus: "cancelled", packageDisposition: "archived" }))).toBe(
+      true,
+    );
+  });
+
+  it("board hides noise under the default filters and shows it with includeArchived", () => {
+    const tasks = [
+      makeTask({ taskId: "t_live" }),
+      makeTask({ taskId: "t_cancelled", coordinationStatus: "cancelled" }),
+      makeTask({ taskId: "t_archived", packageDisposition: "archived" }),
+    ];
+    expect(applyTaskFilters(tasks, { ...DEFAULT_TASK_FILTERS }).map((t) => t.taskId)).toEqual(["t_live"]);
+    expect(applyTaskFilters(tasks, { ...DEFAULT_TASK_FILTERS, includeArchived: true }).map((t) => t.taskId)).toEqual([
+      "t_live",
+      "t_cancelled",
+      "t_archived",
+    ]);
+  });
+});
+
 describe("taskFilters favoritesOnly", () => {
   it("filters to favorites set when favoritesOnly is true", () => {
-    const tasks = [
-      makeTask({ taskId: "t1" }),
-      makeTask({ taskId: "t2" }),
-      makeTask({ taskId: "t3" }),
-    ];
+    const tasks = [makeTask({ taskId: "t1" }), makeTask({ taskId: "t2" }), makeTask({ taskId: "t3" })];
     const favorites = new Set(["t1", "t3"]);
     const filters: TaskFilters = { ...DEFAULT_TASK_FILTERS, favoritesOnly: true };
     const filtered = applyTaskFilters(tasks, filters, favorites);
@@ -105,10 +139,7 @@ describe("sortByFavoritesFirst", () => {
   });
 
   it("returns identical order when no favorites", () => {
-    const items = [
-      { id: "a" },
-      { id: "b" },
-    ];
+    const items = [{ id: "a" }, { id: "b" }];
     const sorted = sortByFavoritesFirst(items, (item) => item.id, new Set());
     expect(sorted.map((item) => item.id)).toEqual(["a", "b"]);
   });

--- a/packages/gui/test/territory.vitest.ts
+++ b/packages/gui/test/territory.vitest.ts
@@ -16,6 +16,7 @@ import {
   taskPassesStatusFilter,
   decisionPassesStateFilter,
 } from "../src/renderer/graph/entityStatusFilter.ts";
+import { isTaskArchiveNoise } from "../src/renderer/model/taskFilters.ts";
 
 function task(overrides: Partial<TaskRow> = {}): TaskRow {
   return {
@@ -344,5 +345,37 @@ describe("territory honours the entity-status filter through the row predicates"
     const decisions = [dec(), { ...dec(), decisionId: "dec_2", state: "outcome_retired" } as DecisionRow];
     const visible = decisions.filter((row) => decisionPassesStateFilter(row, filter));
     expect(visible.map((row) => row.decisionId)).toEqual(["dec_1"]);
+  });
+});
+
+/**
+ * 领地降噪(task_b92c5138):cancelled/archived task 默认不渲染,判定与看板共用
+ * isTaskArchiveNoise。与实体状态筛选同一条行过滤路径,因此块/进度计数只数可见行
+ * —— 不会出现「进度条记了已取消的一笔、屏幕上却没有这个 chip」的空账。
+ */
+describe("territory hides cancelled/archived tasks behind the board noise rule", () => {
+  const rows = [
+    task({ taskId: "t_active", title: "Active", coordinationStatus: "active" }),
+    task({ taskId: "t_cancelled", title: "Cancelled", coordinationStatus: "cancelled" }),
+    task({ taskId: "t_archived", title: "Archived", packageDisposition: "archived" }),
+  ];
+  // GraphView taskVisible 的降噪子句原样:开关只翻转这一个谓词。
+  const visibleWithSwitch = (showArchived: boolean) => rows.filter((row) => showArchived || !isTaskArchiveNoise(row));
+
+  it("drops noise rows from chips by default and the zone progress counts only visible rows", () => {
+    const visible = visibleWithSwitch(false);
+    expect(visible.map((row) => row.taskId)).toEqual(["t_active"]);
+    const partition = partitionForSkel("task", visible, [], [], [], [], []);
+    const chips = [...partition.zones.flatMap((zone) => zone.chips), ...partition.landing];
+    expect(chips.map((chip) => chip.navRef)).toEqual(["task/t_active"]);
+    // 进度/总数跟可见行走,不把已取消的行记进块的「N/total」。
+    expect(partition.zones[0]!.progress?.total).toBe(1);
+  });
+
+  it("keeps the full set when the switch is on (显示已归档)", () => {
+    const visible = visibleWithSwitch(true);
+    const partition = partitionForSkel("task", visible, [], [], [], [], []);
+    const chips = [...partition.zones.flatMap((zone) => zone.chips), ...partition.landing];
+    expect(chips.map((chip) => chip.navRef).sort()).toEqual(["task/t_active", "task/t_archived", "task/t_cancelled"]);
   });
 });


### PR DESCRIPTION
# English

## Summary

Relation-graph territory view now hides cancelled tasks and packages whose disposition is not active (archived/tombstoned) by default, using the same predicate the board already uses: the inline condition in `model/taskFilters.ts` `matchesTask` is extracted as the single named export `isTaskArchiveNoise` and both views call it. A per-view '显示已归档' toggle (remembered via `graph-territory-preferences.ts`) restores the full graph. Dangling edges to hidden nodes are dropped. On canonical the territory shrinks from 964 to 826 blocks. Screenshots before/after at 1440/1920 plus the toggle-on state are in the task artifacts.

## Architectural Justification

- Production-Delta as computed: one shared predicate replaces an inline condition; the additions are the toggle + preference and tests (+342/-46 overall, mostly tests). The inline archive-noise condition in `matchesTask` is replaced by the shared predicate (refactor, not a path deletion).

## What Changed

- `packages/gui/src/renderer/model/taskFilters.ts`: `isTaskArchiveNoise` (single implementation).
- `views/GraphView.tsx`: default filter + toggle; `graph-territory-preferences.ts` (new).
- Tests: graph-view-regression, taskFilters, territory vitests.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +93/-8
Dependency-Change: none

### Optional Evidence Claims

## Task And Scope

- Harness task: task_b92c51389fd8877aee35a2316e
- Branch: codex/gui-graph-hide-archived
- Public scope: packages/gui graph view, task filters, territory preferences + vitests
- Private planning/evidence updated: yes
- Out of scope: relationGraph facet pagination (task_8d3b7b7b) untouched; task detail page is a separate PR.

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_b92c51389fd8877aee35a2316e
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-28T14:55Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_b92c51389fd8877aee35a2316e (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Worker (GLM): three vitest files green; screenshots 1440/1920 before/after + toggle-on
- [x] CEO: compared 1920 before/after — 964→826 blocks, '已归档 隐藏' chip visible, cancelled entries gone from clusters
- [x] production-delta computed
- [ ] CI on this PR
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO checked the predicate is shared (grep: one implementation) and the toggle defaults to hidden.
- Reviewer subagent: GLM implemented; CEO visual + semantic acceptance against task_b92c5138's plan.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Users looking for a cancelled task in the graph must flip the toggle.

## References

- Task: task_b92c51389fd8877aee35a2316e
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

关系图领地视图默认隐藏 cancelled 任务与 disposition 非 active(archived/tombstoned)的包,用看板同一条判定:`model/taskFilters.ts` `matchesTask` 的内联条件抽为唯一具名导出 `isTaskArchiveNoise`,两处视图共用。视图内「显示已归档」开关(经 `graph-territory-preferences.ts` 记忆)可切回全量;指向隐藏节点的悬空边一并去掉。canonical 上领地从 964 块降到 826。1440/1920 改前改后与开关打开态截图在任务包 artifacts。

## 架构辩护

- Production-Delta 实算:一个共享判定替换内联条件;新增是开关 + 偏好与测试(合计 +342/-46,大头是测试)。 `matchesTask` 的内联归档噪声条件改为共享判定(重构,非路径删除)。

## 改动内容

- `packages/gui/src/renderer/model/taskFilters.ts`:`isTaskArchiveNoise`(唯一实现)。
- `views/GraphView.tsx`:默认过滤 + 开关;新增 `graph-territory-preferences.ts`。
- 测试:graph-view-regression、taskFilters、territory vitest。

## 门收割 / Gate Harvest

- 删除的生产路径:无
- 同 commit 删除的门 / fixture:无
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_b92c51389fd8877aee35a2316e
- 分支:codex/gui-graph-hide-archived
- 公开范围:packages/gui 关系图视图、任务过滤、领地偏好 + vitest
- 私有计划 / 证据是否已更新:yes
- 范围外:relationGraph facet 分页(task_8d3b7b7b)不动;任务详情页另一 PR。

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_b92c51389fd8877aee35a2316e
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-28T14:55Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_b92c51389fd8877aee35a2316e
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] worker(GLM):三个 vitest 文件绿;1440/1920 改前改后 + 开关打开态截图
- [x] CEO:对比 1920 改前改后——964→826 块,「已归档 隐藏」chip 可见,簇内 cancelled 条目消失
- [x] production-delta 实算
- [ ] 本 PR 的 CI
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 核实判定共享(grep 唯一实现)且开关默认隐藏。
- Reviewer subagent:GLM 实现;CEO 按 task_b92c5138 的 plan 做视觉 + 语义验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 在图里找 cancelled 任务的用户要打开开关。

## 关联材料

- 任务:task_b92c51389fd8877aee35a2316e
- 证据:任务包 artifacts/reports
- 审查:本 PR
