### PR TITLE
fix(daemon): scheduler reads schedule-list receipts through the shared typed parser

### DIFF
--- a/packages/cli/src/cli/thin-command-schedule.ts
+++ b/packages/cli/src/cli/thin-command-schedule.ts
@@ -1,4 +1,9 @@
 import type { SafePath } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
+import {
+  parseScheduleListReceipt,
+  type ScheduleListRow,
+} from "../../../daemon/src/protocol/daemon-protocol-validate-results.ts";
+import { consumeKnownError } from "../daemon/client.ts";
 import { accepted, nonEmpty, optionalFlags, readFlags, rejected } from "./thin-command-flags.ts";
 import type { ProtocolCommand, ThinCliInputDirectory, ThinParseResult } from "./thin-command-types.ts";
 
@@ -122,13 +127,19 @@ export function parseScheduleDuration(value: string): number | null {
 }
 
 export function renderScheduleList(receipt: Record<string, unknown>): string | null {
-  if (receipt.command !== "schedule-list" || !Array.isArray(receipt.schedules)) return null;
-  if (receipt.schedules.length === 0) return "No schedules.";
-  return receipt.schedules
-    .map((value) => {
-      const row = value as Record<string, unknown>,
-        status = row.status && typeof row.status === "object" ? (row.status as Record<string, unknown>) : null;
-      return [row.scheduleId, row.state, row.nextRunAt ?? "none", status?.activeRun ? "active" : "idle"]
+  if (receipt.command !== "schedule-list") return null;
+  let schedules: readonly ScheduleListRow[] | null;
+  try {
+    schedules = parseScheduleListReceipt(receipt);
+  } catch (error) {
+    consumeKnownError(error);
+    return null;
+  }
+  if (!schedules) return null;
+  if (schedules.length === 0) return "No schedules.";
+  return schedules
+    .map((row) => {
+      return [row.scheduleId, row.state, row.nextRunAt ?? "none", row.status.activeRun ? "active" : "idle"]
         .map(String)
         .join("\t");
     })

--- a/packages/cli/test/schedule-command.test.ts
+++ b/packages/cli/test/schedule-command.test.ts
@@ -1,6 +1,7 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
+import { createScheduleV1 } from "../../kernel/src/index.ts";
 import { parseThinCommand } from "../src/cli/thin-command.ts";
 import { parseScheduleDuration, renderScheduleList, renderScheduleShow } from "../src/cli/thin-command-schedule.ts";
 
@@ -153,15 +154,73 @@ test("Schedule show human renderer returns the complete schedule snapshot", () =
 });
 
 test("Schedule list human renderer shows state, next occurrence, and single-flight state", () => {
+  const actor = { principal: { personId: "schedule-cli-test" }, executor: null } as const,
+    armed = createScheduleV1({
+      scheduleId: "armed",
+      name: "Armed",
+      spec: {
+        trigger: { kind: "interval", everyMs: 60_000, anchorAt: "2026-08-26T13:59:00.000Z" },
+        target: { kind: "agent", agentId: "codex", runtimeInstanceId: "runtime-local" },
+        mission: "Run the armed Schedule.",
+      },
+      actor,
+      occurredAt: "2026-08-26T13:59:00.000Z",
+    }),
+    paused = createScheduleV1({
+      scheduleId: "paused",
+      name: "Paused",
+      state: "paused",
+      spec: {
+        trigger: { kind: "interval", everyMs: 60_000, anchorAt: "2026-08-26T13:59:00.000Z" },
+        target: { kind: "agent", agentId: "codex", runtimeInstanceId: "runtime-local" },
+        mission: "Run the paused Schedule.",
+      },
+      actor,
+      occurredAt: "2026-08-26T13:59:00.000Z",
+    });
   assert.equal(
     renderScheduleList({
       command: "schedule-list",
-      schedules: [
-        { scheduleId: "armed", state: "armed", nextRunAt: "2026-08-26T14:00:00.000Z", status: { activeRun: {} } },
-        { scheduleId: "paused", state: "paused", nextRunAt: null, status: { activeRun: null } },
-      ],
+      evidence: JSON.stringify({
+        schema: "schedule-list/v1",
+        schedules: [
+          {
+            ...armed,
+            status: {
+              ...armed.status,
+              activeRun: {
+                occurrenceId: "manual-active",
+                kind: "manual",
+                scheduledFor: "2026-08-26T13:59:00.000Z",
+                claimedAt: "2026-08-26T13:59:00.000Z",
+                nodeId: "local",
+                assignmentId: null,
+                claimFence: "claim-active",
+                attemptIndex: 0,
+              },
+            },
+            definitionRevision: 1,
+            nextRunAt: "2026-08-26T14:00:00.000Z",
+          },
+          { ...paused, definitionRevision: 2, nextRunAt: null },
+        ],
+      }),
     }),
     "armed\tarmed\t2026-08-26T14:00:00.000Z\tactive\npaused\tpaused\tnone\tidle",
   );
-  assert.equal(renderScheduleList({ command: "schedule-list", schedules: [] }), "No schedules.");
+  assert.equal(
+    renderScheduleList({
+      command: "schedule-list",
+      evidence: JSON.stringify({ schema: "schedule-list/v1", schedules: [] }),
+    }),
+    "No schedules.",
+  );
+  assert.equal(renderScheduleList({ command: "schedule-list", schedules: [] }), null);
+  assert.equal(
+    renderScheduleList({
+      command: "schedule-list",
+      evidence: JSON.stringify({ schema: "schedule-list/v2", schedules: [] }),
+    }),
+    null,
+  );
 });

--- a/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
@@ -27,6 +27,55 @@ import {
 import { receiptOutcomeWords } from "./daemon-protocol-vocabulary.ts";
 import { isJsonObject, type JsonObject } from "./json-rpc-types.ts";
 
+export type ScheduleListRow = {
+  readonly scheduleId: string;
+  readonly state: "armed" | "paused";
+  readonly spec: {
+    readonly trigger: { readonly kind: "interval"; readonly everyMs: number; readonly anchorAt: string };
+  };
+  readonly status: {
+    readonly automaticEvaluatedThrough: string;
+    readonly activeRun: unknown;
+  };
+  readonly updatedAt: string;
+  readonly definitionRevision: number;
+  readonly nextRunAt: string | null;
+};
+
+export function parseScheduleListReceipt(
+  receipt: Readonly<Record<string, unknown>>,
+): readonly ScheduleListRow[] | null {
+  if (typeof receipt.evidence !== "string") return null;
+  const payload: unknown = JSON.parse(receipt.evidence);
+  if (
+    !exactRecord(payload, ["schema", "schedules"]) ||
+    payload.schema !== "schedule-list/v1" ||
+    !Array.isArray(payload.schedules) ||
+    !payload.schedules.every(scheduleListRow)
+  )
+    return null;
+  return payload.schedules;
+}
+
+function scheduleListRow(value: unknown): value is ScheduleListRow {
+  if (!isJsonObject(value) || !isJsonObject(value.spec) || !isJsonObject(value.status)) return false;
+  const trigger = value.spec.trigger;
+  return (
+    isJsonObject(trigger) &&
+    nonEmpty(value.scheduleId) &&
+    (value.state === "armed" || value.state === "paused") &&
+    trigger.kind === "interval" &&
+    integer(trigger.everyMs) &&
+    Number(trigger.everyMs) >= 60_000 &&
+    nonEmpty(trigger.anchorAt) &&
+    nonEmpty(value.status.automaticEvaluatedThrough) &&
+    nonEmpty(value.updatedAt) &&
+    integer(value.definitionRevision) &&
+    Number(value.definitionRevision) >= 0 &&
+    (value.nextRunAt === null || nonEmpty(value.nextRunAt))
+  );
+}
+
 export function validateDaemonDocumentRead(value: unknown): readonly string[] {
   if (
     !recordWith(value, DAEMON_DOCUMENT_READ_SCHEMA.required) ||

--- a/packages/daemon/src/schedule-scheduler.ts
+++ b/packages/daemon/src/schedule-scheduler.ts
@@ -1,18 +1,13 @@
-import {
-  consumeKnownError,
-  nextScheduleOccurrence,
-  type ScheduleMissedReason,
-  type ScheduleV1,
-} from "../../kernel/src/index.ts";
+import { consumeKnownError, nextScheduleOccurrence, type ScheduleMissedReason } from "../../kernel/src/index.ts";
 import type { DaemonCommandClass } from "./identity/types.ts";
 import type { JsonObject } from "./protocol/json-rpc-types.ts";
+import { parseScheduleListReceipt, type ScheduleListRow } from "./protocol/daemon-protocol-validate-results.ts";
 import type { RepoCell, RepoCellBinding } from "./repo-cell.ts";
 
 export const scheduleAdmissionWindowMs = 60_000;
 
 type TimerHandle = ReturnType<typeof setTimeout>;
 type ScheduleAction = Readonly<Record<string, unknown>> & { readonly kind: string };
-type ScheduleListRow = ScheduleV1 & { readonly definitionRevision: number };
 type ScheduleTarget = {
   readonly repoId: string;
   readonly execute: (action: ScheduleAction) => Promise<Readonly<Record<string, unknown>>>;
@@ -214,9 +209,9 @@ export function makeScheduleScheduler(input: {
 
 async function listSchedules(target: ScheduleTarget): Promise<readonly ScheduleListRow[]> {
   const receipt = await target.execute({ kind: "schedule-list" }),
-    schedules = receipt.schedules;
-  if (!Array.isArray(schedules)) throw new Error("Schedule list receipt omitted schedules.");
-  return schedules as unknown as readonly ScheduleListRow[];
+    schedules = parseScheduleListReceipt(receipt);
+  if (!schedules) throw new Error("Schedule list receipt evidence is invalid.");
+  return schedules;
 }
 
 function evaluateSchedule(

--- a/packages/daemon/test/schedule-scheduler.test.ts
+++ b/packages/daemon/test/schedule-scheduler.test.ts
@@ -8,6 +8,22 @@ import type { RepoCell } from "../src/repo-cell.ts";
 const actor = { principal: { personId: "schedule-scheduler-test" }, executor: null } as const;
 const localBinding = () => ({ actor, source: "local" as const });
 
+test("schedule-list/v1 receipt evidence arms one Schedule", async () => {
+  const clock = fakeClock("2026-08-27T10:00:00.000Z"),
+    repo = fixtureRepo("receipt-evidence", "local", [schedule("e2e-probe")]),
+    scheduler = makeScheduleScheduler({
+      cells: new Map([[repo.repoId, repo.cell]]),
+      localBinding,
+      now: clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+    });
+  await scheduler.start();
+  assert.equal(clock.liveTimers().length, 1);
+  assert.equal(clock.liveTimers()[0]!.delayMs, 30 * 60_000);
+  scheduler.close();
+});
+
 test("one nearest timer launches different due Schedules concurrently", async () => {
   const clock = fakeClock("2026-08-27T10:00:00.000Z"),
     first = fixtureRepo("first", "local", [schedule("heartbeat-a")]),
@@ -226,8 +242,31 @@ function fixtureRepo(repoId: string, mode: DaemonRepoMode, schedules: MutableSch
     onFire: async (_scheduleId: string) => {},
     execute: async (action: Readonly<Record<string, unknown>>) => {
       actions.push(String(action.kind));
-      if (action.kind === "schedule-list")
-        return { outcome: "applied", schedules: schedules.map((value) => ({ ...value, definitionRevision: 1 })) };
+      if (action.kind === "schedule-list") {
+        const rows = schedules.map((value) => ({
+          ...value,
+          definitionRevision: 1,
+          nextRunAt: value.state === "armed" ? "2026-08-27T10:30:00.000Z" : null,
+        }));
+        return {
+          schema: "command-receipt/v2",
+          ok: true,
+          command: "schedule-list",
+          outcome: "applied",
+          opId: `read:schedule-list:${repoId}`,
+          revision: 1,
+          evidence: JSON.stringify({ schema: "schedule-list/v1", schedules: rows }),
+          visibility: "center",
+          proof: {
+            committedRevision: 1,
+            appliedCut: 1,
+            durable: true,
+            canonicalVisible: true,
+            worktreeVisible: null,
+          },
+          summary: `${rows.length} schedule(s)`,
+        };
+      }
       const value = schedules.find(({ scheduleId }) => scheduleId === action.scheduleId);
       assert.ok(value);
       if (action.kind === "schedule-settle" && action.phase === "missed") {


### PR DESCRIPTION
# English

## Summary

The daemon scheduler has been dead since 2026-08-27's cut-over: `listSchedules` read a convenience top-level `receipt.schedules` field that is not part of the authoritative receipt (`writeReceiptFields`), so every refresh on every attached repo failed with `Schedule list receipt omitted schedules.` (94 log lines, 6 repo ids) and no schedule was ever armed — `e2e-probe` last ran at 12:26Z and was never re-scheduled. The scheduler and the CLI now share one dependency-free typed parser (`parseScheduleListReceipt`) that reads and validates the `schedule-list/v1` envelope from `evidence`; the top-level read, the local structure guess and the cast are deleted. Negative control: on evidence-only receipts the old code fails 0/7 and arms no timer; the fix passes 7/7 and arms `e2e-probe` (30-min delay). Production +72/-17.

## Architectural Justification

- Production-Delta +72/-17: one shared reader (+) replaces two ad-hoc reads and casts (-); no compatibility branch, retry or fallback.

## What Changed

- `packages/daemon/src/protocol/daemon-protocol-validate-results.ts`: `parseScheduleListReceipt`.
- `packages/daemon/src/schedule-scheduler.ts`, `packages/cli/src/cli/thin-command-schedule.ts`: use it.
- Tests: daemon `schedule-scheduler.test.ts` (real command-receipt/v2 with JSON-string evidence; rejects top-level-only and wrong schema), CLI `schedule-command.test.ts` 5/5.

## Gate Harvest / 门收割

Deleted-Production-Paths: top-level `receipt.schedules` reads in scheduler and CLI (replaced by the shared evidence parser)
Deleted-Gates-Fixtures: scheduler test fixtures that carried the non-authoritative top-level `schedules` field
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +72/-17
Dependency-Change: none

### Optional Evidence Claims

## Task And Scope

- Harness task: task_dfd1d945322f734e4f399b398f
- Branch: codex/scheduler-receipt
- Public scope: packages/daemon scheduler + protocol result validation, packages/cli schedule command, their tests
- Private planning/evidence updated: yes
- Out of scope: Schedule productisation redesign (task_39e58593: occurrence claim, run history, GUI) is dispatched after this lands.

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_dfd1d945322f734e4f399b398f
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-28T14:53Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_dfd1d945322f734e4f399b398f (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Worker (Node 24): scheduler 7/7 (0/7 before), CLI schedule 5/5, schedule-actions integration 2/2 on a real temp daemon, fast tier 418/418, typecheck, lint, CLI build
- [x] CEO: reproduced the failure on the live daemon log (94 lines) and `ha schedule list --json` shape before the fix
- [x] production-delta computed +72/-17
- [ ] CI on this PR; after merge CEO restarts canonical daemon and checks the log stays clean for 5 min and e2e-probe gets a new occurrence
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO read r1.md's root-cause history (73c9551cb introduced the dual field, fc418dd89 read the wrong one) and the parser diff.
- Reviewer subagent: Sol implemented; CEO acceptance against task_dfd1d945's plan (single road, no compatibility branch).
- Human review: pending
- Blocking findings: none

## Residual Risk

- Any other consumer still reading top-level `schedules` would now see nothing — grep found none.

## References

- Task: task_dfd1d945322f734e4f399b398f
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

daemon 调度器自 2026-08-27 切换以来一直是死的:`listSchedules` 读的是回执顶层便利字段 `receipt.schedules`,它不在权威回执字段(`writeReceiptFields`)里,于是每个已 attach 仓的每次刷新都报 `Schedule list receipt omitted schedules.`(94 行日志、6 个 repo id),任何 schedule 从未 arm——`e2e-probe` 最后一次跑在 12:26Z 后再没被调度。现在 scheduler 与 CLI 共用一个无依赖的 typed parser(`parseScheduleListReceipt`),只从 `evidence` 读取并校验 `schedule-list/v1` 信封;顶层直读、局部结构猜测与强制 cast 删除。阴性对照:evidence-only 回执下旧代码 0/7 且不 arm timer;修后 7/7 且 arm 出 `e2e-probe`(30 分钟延时)。生产 +72/-17。

## 架构辩护

- Production-Delta +72/-17:一个共享 reader 替换两处随手读与 cast;没有兼容分支、重试或兜底。

## 改动内容

- `packages/daemon/src/protocol/daemon-protocol-validate-results.ts`:`parseScheduleListReceipt`。
- `packages/daemon/src/schedule-scheduler.ts`、`packages/cli/src/cli/thin-command-schedule.ts`:改用它。
- 测试:daemon `schedule-scheduler.test.ts`(真实 command-receipt/v2 + JSON 字符串 evidence;拒绝仅顶层与错 schema)、CLI `schedule-command.test.ts` 5/5。

## 门收割 / Gate Harvest

- 删除的生产路径:scheduler 与 CLI 里的顶层 `receipt.schedules` 直读(改为共享 evidence parser)
- 同 commit 删除的门 / fixture:带非权威顶层 `schedules` 字段的 scheduler 测试 fixture
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_dfd1d945322f734e4f399b398f
- 分支:codex/scheduler-receipt
- 公开范围:packages/daemon 调度器 + 协议结果校验、packages/cli schedule 命令及测试
- 私有计划 / 证据是否已更新:yes
- 范围外:定时任务产品化重设计(task_39e58593:occurrence claim、运行历史、GUI)在本 PR 合入后派。

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_dfd1d945322f734e4f399b398f
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-28T14:53Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_dfd1d945322f734e4f399b398f
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] worker(Node 24):scheduler 7/7(改前 0/7)、CLI schedule 5/5、schedule-actions 集成 2/2(真实临时 daemon)、fast 418/418、typecheck、lint、CLI build
- [x] CEO:改前在 daemon 日志(94 行)与 `ha schedule list --json` 上复现
- [x] production-delta 实算 +72/-17
- [ ] 本 PR 的 CI;合入后 CEO 重启 canonical daemon,看 5 分钟日志无该行、e2e-probe 出现新 occurrence
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 读了 r1.md 的根因史(73c9551cb 引入双字段,fc418dd89 读错的那个)与 parser diff。
- Reviewer subagent:Sol 实现;CEO 按 task_dfd1d945 的 plan(单一路径、无兼容分支)验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 若还有消费者读顶层 `schedules` 现在会读到空——grep 未发现。

## 关联材料

- 任务:task_dfd1d945322f734e4f399b398f
- 证据:任务包 artifacts/reports
- 审查:本 PR
