### PR TITLE
fix(cli): stop polling attached runtime waits

### DIFF
--- a/packages/cli/src/cli-runtime-wait.ts
+++ b/packages/cli/src/cli-runtime-wait.ts
@@ -11,6 +11,15 @@ import {
 
 type DaemonGone = { readonly kind: "daemon-gone"; readonly cause: string };
 type RuntimeStreamSignal = "terminal" | "lost";
+type RuntimeStatusRead = () => Promise<JsonObject | DaemonGone>;
+type RuntimeFallbackResult = {
+  readonly lastKnown: JsonObject;
+  readonly result: JsonObject | DaemonGone;
+};
+type RuntimeStreamWait = {
+  readonly detach?: () => void;
+  readonly signal?: RuntimeStreamSignal;
+};
 
 const fallbackPollBaseMs = 500,
   fallbackPollMaxMs = 2_000,
@@ -25,80 +34,46 @@ export async function waitForRuntime(
   target?: { readonly taskId: string; readonly dispatchId: string },
 ): Promise<JsonObject> {
   let statusReader: Awaited<ReturnType<typeof openRuntimeStatusReader>> | undefined;
-  let current: JsonObject | undefined,
-    detach: (() => void) | undefined,
-    streamAttempted = false,
-    finishAfterRead = false,
-    fallbackProgress: string | undefined,
-    fallbackDelayMs = fallbackPollBaseMs,
-    exitedAt: number | undefined;
+  let current: JsonObject | undefined, detach: (() => void) | undefined;
   try {
-    for (;;) {
-      const next = await readDaemonSubscription(
-        command,
-        async () => {
-          statusReader ??= await openRuntimeStatusReader(command, runtimeSessionId, target);
-          return statusReader.read();
-        },
-        () => {
-          statusReader?.close();
-          statusReader = undefined;
-        },
-      );
-      if (isDaemonGone(next)) {
-        const runtime = current as unknown as AgentRuntimeSessionResult | undefined,
-          status = runtime?.session.activity.outcome ?? (runtime?.session ? "running" : "unknown"),
-          commandName = spawned ? "runtime-run" : "runtime-status";
-        return daemonGoneReceipt(commandName, next.cause, status, {
-          runtimeSessionId,
-          ...(target ?? {}),
-          ...(spawned ? { spawn: spawned } : {}),
-          lastKnownDispatch: lastKnownRuntimeDispatch(runtimeSessionId, target, runtime, status),
-        });
+    const readStatus = () =>
+        readDaemonSubscription(
+          command,
+          async () => {
+            statusReader ??= await openRuntimeStatusReader(command, runtimeSessionId, target);
+            return statusReader.read();
+          },
+          () => {
+            statusReader?.close();
+            statusReader = undefined;
+          },
+        ),
+      initial = await readStatus();
+    if (isDaemonGone(initial)) return runtimeDaemonGoneReceipt(initial, current, runtimeSessionId, target, spawned);
+    if (initial.ok !== true) return initial;
+    current = initial;
+    const initialSession = (current as unknown as AgentRuntimeSessionResult).session;
+    if (initialSession.activity.outcome === null) {
+      const streamed =
+        stream && initialSession.attachCapability === "supported"
+          ? await waitForStreamedRuntime(command, runtimeSessionId, writeActivity)
+          : undefined;
+      detach = streamed?.detach;
+      if (streamed?.signal) {
+        const next = await readStatus();
+        if (isDaemonGone(next)) return runtimeDaemonGoneReceipt(next, current, runtimeSessionId, target, spawned);
+        if (next.ok !== true) return next;
+        current = next;
       }
-      if (next.ok !== true) return next;
-      current = next;
-      const session = (current as unknown as AgentRuntimeSessionResult).session;
-      if (session.activity.outcome !== null || finishAfterRead) break;
-      if (stream && !streamAttempted && session.attachCapability === "supported") {
-        streamAttempted = true;
-        let streamAttached = false,
-          resolveStreamSignal: (signal: RuntimeStreamSignal) => void = () => undefined;
-        const streamSignal = new Promise<RuntimeStreamSignal>((resolve) => {
-          resolveStreamSignal = resolve;
-        });
-        try {
-          detach = await streamRuntimeThroughDaemon(
-            command,
-            runtimeSessionId,
-            (value) => {
-              renderRuntimeFrames(value, writeActivity);
-              streamAttached ||= runtimeStreamAttached(value);
-              const signal = runtimeStreamWakeSignal(value);
-              if (signal) resolveStreamSignal(signal);
-            },
-            () => resolveStreamSignal("lost"),
-          );
-        } catch (error) {
-          consumeKnownError(error);
-          writeActivity(`[stream] ${error instanceof Error ? error.message : String(error)}\n`);
-        }
-        if (streamAttached) {
-          const signal = await streamSignal;
-          finishAfterRead = signal === "terminal";
-          continue;
-        }
+      const currentSession = (current as unknown as AgentRuntimeSessionResult).session;
+      if (!streamed?.signal || (streamed.signal === "lost" && currentSession.activity.outcome === null)) {
+        const fallback = await waitForRuntimeFallback(current, readStatus);
+        current = fallback.lastKnown;
+        if (isDaemonGone(fallback.result))
+          return runtimeDaemonGoneReceipt(fallback.result, current, runtimeSessionId, target, spawned);
+        if (fallback.result.ok !== true) return fallback.result;
+        current = fallback.result;
       }
-      if (session.liveness === "exited") {
-        exitedAt ??= Date.now();
-        if (Date.now() - exitedAt >= settlementWaitMs) break;
-      } else exitedAt = undefined;
-      const progress = runtimePollProgress(session);
-      if (progress !== fallbackProgress) {
-        fallbackProgress = progress;
-        fallbackDelayMs = fallbackPollBaseMs;
-      } else fallbackDelayMs = Math.min(fallbackDelayMs * 2, fallbackPollMaxMs);
-      await new Promise((resolve) => setTimeout(resolve, fallbackDelayMs));
     }
   } finally {
     statusReader?.close();
@@ -132,6 +107,81 @@ export async function waitForRuntime(
     summary: text || reason || `${commandName}: ${outcome}`,
     exitCode: outcome === "succeeded" ? 0 : 1,
   };
+}
+
+async function waitForStreamedRuntime(
+  command: ThinCommand,
+  runtimeSessionId: string,
+  writeActivity: (text: string) => void,
+): Promise<RuntimeStreamWait> {
+  let streamAttached = false,
+    resolveStreamSignal: (signal: RuntimeStreamSignal) => void = () => undefined,
+    detach: (() => void) | undefined;
+  const streamSignal = new Promise<RuntimeStreamSignal>((resolve) => {
+    resolveStreamSignal = resolve;
+  });
+  try {
+    detach = await streamRuntimeThroughDaemon(
+      command,
+      runtimeSessionId,
+      (value) => {
+        renderRuntimeFrames(value, writeActivity);
+        streamAttached ||= runtimeStreamAttached(value);
+        const signal = runtimeStreamWakeSignal(value);
+        if (signal) resolveStreamSignal(signal);
+      },
+      () => resolveStreamSignal("lost"),
+    );
+  } catch (error) {
+    consumeKnownError(error);
+    writeActivity(`[stream] ${error instanceof Error ? error.message : String(error)}\n`);
+  }
+  return streamAttached ? { detach, signal: await streamSignal } : { detach };
+}
+
+async function waitForRuntimeFallback(
+  initial: JsonObject,
+  readStatus: RuntimeStatusRead,
+): Promise<RuntimeFallbackResult> {
+  let current = initial,
+    fallbackProgress: string | undefined,
+    fallbackDelayMs = fallbackPollBaseMs,
+    exitedAt: number | undefined;
+  for (;;) {
+    const session = (current as unknown as AgentRuntimeSessionResult).session;
+    if (session.activity.outcome !== null) return { lastKnown: current, result: current };
+    if (session.liveness === "exited") {
+      exitedAt ??= Date.now();
+      if (Date.now() - exitedAt >= settlementWaitMs) return { lastKnown: current, result: current };
+    } else exitedAt = undefined;
+    const progress = runtimePollProgress(session);
+    if (progress !== fallbackProgress) {
+      fallbackProgress = progress;
+      fallbackDelayMs = fallbackPollBaseMs;
+    } else fallbackDelayMs = Math.min(fallbackDelayMs * 2, fallbackPollMaxMs);
+    await new Promise((resolve) => setTimeout(resolve, fallbackDelayMs));
+    const next = await readStatus();
+    if (isDaemonGone(next) || next.ok !== true) return { lastKnown: current, result: next };
+    current = next;
+  }
+}
+
+function runtimeDaemonGoneReceipt(
+  gone: DaemonGone,
+  current: JsonObject | undefined,
+  runtimeSessionId: string,
+  target: { readonly taskId: string; readonly dispatchId: string } | undefined,
+  spawned: JsonObject | undefined,
+): JsonObject {
+  const runtime = current as unknown as AgentRuntimeSessionResult | undefined,
+    status = runtime?.session.activity.outcome ?? (runtime?.session ? "running" : "unknown"),
+    commandName = spawned ? "runtime-run" : "runtime-status";
+  return daemonGoneReceipt(commandName, gone.cause, status, {
+    runtimeSessionId,
+    ...(target ?? {}),
+    ...(spawned ? { spawn: spawned } : {}),
+    lastKnownDispatch: lastKnownRuntimeDispatch(runtimeSessionId, target, runtime, status),
+  });
 }
 
 export async function waitForTaskDispatches(command: ThinCommand, taskId: string): Promise<JsonObject> {

--- a/packages/cli/src/cli-runtime-wait.ts
+++ b/packages/cli/src/cli-runtime-wait.ts
@@ -10,6 +10,11 @@ import {
 } from "./daemon/client.ts";
 
 type DaemonGone = { readonly kind: "daemon-gone"; readonly cause: string };
+type RuntimeStreamSignal = "terminal" | "lost";
+
+const fallbackPollBaseMs = 500,
+  fallbackPollMaxMs = 2_000,
+  settlementWaitMs = 5_000;
 
 export async function waitForRuntime(
   command: ThinCommand,
@@ -22,9 +27,13 @@ export async function waitForRuntime(
   let statusReader: Awaited<ReturnType<typeof openRuntimeStatusReader>> | undefined;
   let current: JsonObject | undefined,
     detach: (() => void) | undefined,
-    streamStarted = false;
+    streamAttempted = false,
+    finishAfterRead = false,
+    fallbackProgress: string | undefined,
+    fallbackDelayMs = fallbackPollBaseMs,
+    exitedAt: number | undefined;
   try {
-    for (let exitedPolls = 0; ; ) {
+    for (;;) {
       const next = await readDaemonSubscription(
         command,
         async () => {
@@ -49,20 +58,47 @@ export async function waitForRuntime(
       }
       if (next.ok !== true) return next;
       current = next;
-      if (stream && !streamStarted) {
-        streamStarted = true;
+      const session = (current as unknown as AgentRuntimeSessionResult).session;
+      if (session.activity.outcome !== null || finishAfterRead) break;
+      if (stream && !streamAttempted && session.attachCapability === "supported") {
+        streamAttempted = true;
+        let streamAttached = false,
+          resolveStreamSignal: (signal: RuntimeStreamSignal) => void = () => undefined;
+        const streamSignal = new Promise<RuntimeStreamSignal>((resolve) => {
+          resolveStreamSignal = resolve;
+        });
         try {
-          detach = await streamRuntimeThroughDaemon(command, runtimeSessionId, (value) =>
-            renderRuntimeFrames(value, writeActivity),
+          detach = await streamRuntimeThroughDaemon(
+            command,
+            runtimeSessionId,
+            (value) => {
+              renderRuntimeFrames(value, writeActivity);
+              streamAttached ||= runtimeStreamAttached(value);
+              const signal = runtimeStreamWakeSignal(value);
+              if (signal) resolveStreamSignal(signal);
+            },
+            () => resolveStreamSignal("lost"),
           );
         } catch (error) {
           consumeKnownError(error);
           writeActivity(`[stream] ${error instanceof Error ? error.message : String(error)}\n`);
         }
+        if (streamAttached) {
+          const signal = await streamSignal;
+          finishAfterRead = signal === "terminal";
+          continue;
+        }
       }
-      const session = (current as unknown as AgentRuntimeSessionResult).session;
-      if (session.activity.outcome !== null || (session.liveness === "exited" && ++exitedPolls >= 20)) break;
-      await new Promise((resolve) => setTimeout(resolve, 250));
+      if (session.liveness === "exited") {
+        exitedAt ??= Date.now();
+        if (Date.now() - exitedAt >= settlementWaitMs) break;
+      } else exitedAt = undefined;
+      const progress = runtimePollProgress(session);
+      if (progress !== fallbackProgress) {
+        fallbackProgress = progress;
+        fallbackDelayMs = fallbackPollBaseMs;
+      } else fallbackDelayMs = Math.min(fallbackDelayMs * 2, fallbackPollMaxMs);
+      await new Promise((resolve) => setTimeout(resolve, fallbackDelayMs));
     }
   } finally {
     statusReader?.close();
@@ -295,4 +331,29 @@ export function renderRuntimeFrames(value: unknown, write: (text: string) => voi
   }
   if (record.type === "activity" && typeof record.content === "string")
     write(`[${String(record.activity)}] ${record.content}\n`);
+}
+
+function runtimeStreamAttached(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return record.ok === true && ["attached", "gap"].includes(String(record.status));
+}
+
+function runtimeStreamWakeSignal(value: unknown): RuntimeStreamSignal | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  if (record.type === "exit") return "terminal";
+  if (record.type === "gap" || record.status === "gap") return "lost";
+  if (Array.isArray(record.events))
+    for (const event of record.events) {
+      const signal = runtimeStreamWakeSignal(event);
+      if (signal) return signal;
+    }
+  return null;
+}
+
+function runtimePollProgress(session: AgentRuntimeSessionResult["session"]): string {
+  return [session.liveness, session.semanticState ?? "", session.streamCursor, session.activity.outcome ?? ""].join(
+    "\0",
+  );
 }

--- a/packages/cli/test/runtime-wait-reconnect.integration.test.ts
+++ b/packages/cli/test/runtime-wait-reconnect.integration.test.ts
@@ -12,6 +12,187 @@ import { localUserDaemonEndpoint } from "../../daemon/src/client/local-daemon-ta
 const cli = path.resolve("packages/cli/src/index.ts"),
   runtimeSessionId = "runtime-wait-reconnect";
 
+test("runtime status --wait reads once after an attached stream reports exit", async () => {
+  const fixture = await openFixtureDaemon("stream-terminal");
+  let statusReads = 0,
+    terminal = false,
+    attachSocket: net.Socket | undefined;
+  fixture.onRequest = (socket, request) => {
+    if (request.method === "protocol.hello") {
+      reply(socket, request.id, { ok: true });
+      return;
+    }
+    if (request.method === "repo.agentRuntime.attach") {
+      attachSocket = socket;
+      reply(socket, request.id, {
+        ok: true,
+        status: "attached",
+        runtimeSessionId,
+        cursor: "stream:0",
+        events: [],
+      });
+      return;
+    }
+    assert.equal(request.method, "repo.agentRuntime.sessions.read");
+    statusReads += 1;
+    reply(socket, request.id, runtimeStatus(terminal));
+  };
+  const invocation = runWait(fixture, ["runtime", "status", runtimeSessionId, "--wait"], false);
+  try {
+    for (const deadline = Date.now() + 2_000; (!attachSocket || statusReads < 1) && Date.now() < deadline; )
+      await delay(20);
+    assert.ok(attachSocket, "the runtime stream must attach");
+    assert.equal(statusReads, 1);
+    await delay(1_200);
+    assert.equal(statusReads, 1, "an attached stream must not perform periodic status reads");
+    terminal = true;
+    attachSocket.write(
+      `${JSON.stringify({
+        jsonrpc: "2.0",
+        method: "repo.agentRuntime.attach.frame",
+        params: {
+          schema: "agent-runtime-attach-event/v1",
+          type: "exit",
+          runtimeSessionId,
+          cursor: "stream:1",
+          occurredAt: "2026-08-28T00:00:00.000Z",
+          outcome: "succeeded",
+        },
+      })}\n`,
+    );
+    const result = await invocation.result(2_000);
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.stdout.trim(), "settled after reconnect");
+    assert.equal(statusReads, 2, "the exit signal must trigger exactly one final authoritative read");
+  } finally {
+    invocation.stop();
+    await fixture.close();
+  }
+});
+
+test("runtime status --wait reads once when an attached stream requires a snapshot", async () => {
+  const fixture = await openFixtureDaemon("stream-gap");
+  let statusReads = 0,
+    terminal = false;
+  fixture.onRequest = (socket, request) => {
+    if (request.method === "protocol.hello") {
+      reply(socket, request.id, { ok: true });
+      return;
+    }
+    if (request.method === "repo.agentRuntime.attach") {
+      terminal = true;
+      reply(socket, request.id, {
+        ok: true,
+        status: "gap",
+        runtimeSessionId,
+        cursor: "stream:40",
+        events: [
+          {
+            schema: "agent-runtime-attach-event/v1",
+            type: "gap",
+            runtimeSessionId,
+            cursor: "stream:40",
+            occurredAt: "2026-08-28T00:00:00.000Z",
+            required: "snapshot",
+          },
+        ],
+      });
+      return;
+    }
+    assert.equal(request.method, "repo.agentRuntime.sessions.read");
+    statusReads += 1;
+    reply(socket, request.id, runtimeStatus(terminal));
+  };
+  const invocation = runWait(fixture, ["runtime", "status", runtimeSessionId, "--wait"], false);
+  try {
+    const result = await invocation.result(2_000);
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.stdout.trim(), "settled after reconnect");
+    assert.equal(statusReads, 2, "a stream gap must trigger exactly one authoritative snapshot read");
+  } finally {
+    invocation.stop();
+    await fixture.close();
+  }
+});
+
+test("runtime status --wait reads once after an attached stream exhausts reconnects", async () => {
+  const fixture = await openFixtureDaemon("stream-lost");
+  let statusReads = 0,
+    attachAttempts = 0,
+    terminal = false;
+  fixture.onRequest = (socket, request) => {
+    if (request.method === "protocol.hello") {
+      reply(socket, request.id, { ok: true });
+      return;
+    }
+    if (request.method === "repo.agentRuntime.attach") {
+      attachAttempts += 1;
+      if (attachAttempts === 1) {
+        reply(socket, request.id, {
+          ok: true,
+          status: "attached",
+          runtimeSessionId,
+          cursor: "stream:0",
+          events: [],
+        });
+        terminal = true;
+        setTimeout(() => socket.destroy(), 20);
+      } else socket.destroy();
+      return;
+    }
+    assert.equal(request.method, "repo.agentRuntime.sessions.read");
+    statusReads += 1;
+    reply(socket, request.id, runtimeStatus(terminal));
+  };
+  const invocation = runWait(fixture, ["runtime", "status", runtimeSessionId, "--wait"], false);
+  try {
+    const result = await invocation.result(12_000);
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.stdout.trim(), "settled after reconnect");
+    assert.equal(attachAttempts, 6, "the attached stream must spend its bounded reconnect budget");
+    assert.equal(statusReads, 2, "stream loss must trigger exactly one final authoritative read");
+  } finally {
+    invocation.stop();
+    await fixture.close();
+  }
+});
+
+test("runtime status --wait fallback backs off to two seconds and resets on cursor progress", async () => {
+  const fixture = await openFixtureDaemon("fallback-backoff"),
+    readTimes: number[] = [];
+  let statusReads = 0;
+  fixture.onRequest = (socket, request) => {
+    if (request.method === "protocol.hello") {
+      reply(socket, request.id, { ok: true });
+      return;
+    }
+    assert.equal(request.method, "repo.agentRuntime.sessions.read");
+    statusReads += 1;
+    readTimes.push(Date.now());
+    reply(
+      socket,
+      request.id,
+      runtimeStatus(statusReads === 6, statusReads === 6, false, false, statusReads >= 5 ? "stream:1" : "stream:0"),
+    );
+  };
+  const invocation = runWait(fixture);
+  try {
+    const result = await invocation.result(9_000),
+      intervals = readTimes.slice(1).map((at, index) => at - readTimes[index]!);
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.receipt.outcome, "succeeded");
+    assert.equal(statusReads, 6);
+    assert.ok(intervals[0]! >= 400, `first fallback interval was ${intervals[0]}ms`);
+    assert.ok(intervals[1]! >= 900, `second fallback interval was ${intervals[1]}ms`);
+    assert.ok(intervals[2]! >= 1_900, `third fallback interval was ${intervals[2]}ms`);
+    assert.ok(intervals[3]! >= 1_900, `capped fallback interval was ${intervals[3]}ms`);
+    assert.ok(intervals[4]! >= 400 && intervals[4]! < 1_800, `cursor reset interval was ${intervals[4]}ms`);
+  } finally {
+    invocation.stop();
+    await fixture.close();
+  }
+});
+
 test("runtime status --wait reconnects after a protocol.hello deadline and returns the terminal dispatch", async () => {
   const fixture = await openFixtureDaemon("slow-hello");
   let allowHello = false,
@@ -110,7 +291,7 @@ test("runtime status --wait bounds an exited session whose outcome never becomes
     assert.equal(result.receipt.code, "runtime_settlement_failed");
     assert.equal(result.receipt.outcome, "unknown");
     assert.match(String(result.receipt.reason), /runtime_settlement_failed/u);
-    assert.equal(statusReads, 20);
+    assert.equal(statusReads, 5);
   } finally {
     invocation.stop();
     await fixture.close();
@@ -268,13 +449,14 @@ async function openFixtureDaemon(daemonId: string): Promise<FixtureDaemon> {
 function runWait(
   fixture: FixtureDaemon,
   args: readonly string[] = ["runtime", "status", runtimeSessionId, "--wait", "--no-stream"],
+  json = true,
 ): {
   readonly closed: boolean;
   readonly result: (timeoutMs: number) => Promise<InvocationResult>;
   readonly stop: () => void;
 } {
   const { HARNESS_DAEMON_ENDPOINT: _endpoint, HARNESS_DAEMON_REPO_ID: _repoId, ...baseEnv } = process.env,
-    child = spawn(process.execPath, [cli, "--root", fixture.root, "--json", ...args], {
+    child = spawn(process.execPath, [cli, "--root", fixture.root, ...(json ? ["--json"] : []), ...args], {
       env: {
         ...baseEnv,
         HARNESS_DAEMON_USER_ROOT: fixture.userRoot,
@@ -291,7 +473,12 @@ function runWait(
   const completion = new Promise<InvocationResult>((resolve) => {
     child.once("close", (code) => {
       closed = true;
-      resolve({ code, receipt: stdout.trim() ? (JSON.parse(stdout) as Record<string, unknown>) : {}, stderr });
+      resolve({
+        code,
+        receipt: json && stdout.trim() ? (JSON.parse(stdout) as Record<string, unknown>) : {},
+        stdout,
+        stderr,
+      });
     });
   });
   return {
@@ -308,6 +495,7 @@ function runWait(
 interface InvocationResult {
   readonly code: number | null;
   readonly receipt: Record<string, unknown>;
+  readonly stdout: string;
   readonly stderr: string;
 }
 
@@ -341,6 +529,7 @@ function runtimeStatus(
   exited = terminal,
   settlementFailed = false,
   unknownOutcome = false,
+  streamCursor = "stream:0",
 ): Record<string, unknown> {
   return {
     ok: true,
@@ -355,7 +544,7 @@ function runtimeStatus(
       definitionSnapshot: {},
       liveness: exited ? "exited" : "live",
       attachCapability: "supported",
-      streamCursor: "stream:0",
+      streamCursor,
       associations: [
         {
           taskId: "task-runtime-wait",


### PR DESCRIPTION
# English

## Summary

`ha runtime status --wait` no longer polls the daemon every 250 ms. The streamed path waits on the attached stream and performs exactly one authoritative `repo.agentRuntime.sessions.read` after an `exit` frame, a `gap` that requires a snapshot, or the stream's bounded reconnect budget reporting loss; the non-stream fallback backs off 500 ms → 1 s → 2 s cap and resets only on runtime state/cursor progress. Measured with six concurrent waiters on the same daemon and ready schema-14 projection: 14.858 reads/s before → 1.348 reads/s after (−90.93%, under the 3.0 reads/s acceptance ceiling from task_be97f0d8). The fixed 250 ms loop is deleted.

## Architectural Justification

- Production-Delta as computed: +151/-40 after r2 split `waitForRuntime` into the streamed wait and the capped non-stream fallback (CLI structure gate: 44 branch markers > 40); the removed poll loop and its helpers are the deletions, no behaviour change in r2.

## What Changed

- `packages/cli/src/cli-runtime-wait.ts`: delete the 250 ms poll; stream-driven wait with one authoritative read per terminal/gap/loss event; capped backoff fallback.
- `packages/cli/test/runtime-wait-reconnect.integration.test.ts`: attached stream held open without status reads; exactly one read after exit/gap/loss.

## Gate Harvest / 门收割

Deleted-Production-Paths: the fixed 250 ms status poll loop in `cli-runtime-wait.ts`
Deleted-Gates-Fixtures: the protocol assertion in `runtime-wait-reconnect.integration.test.ts` that expected periodic status reads (rewritten to assert exactly one read per exit/gap/loss)
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +151/-40
Dependency-Change: none

### Optional Evidence Claims

## Task And Scope

- Harness task: task_4b7f2c0e88c4a6aec977cb8237
- Branch: codex/wait-poll
- Public scope: packages/cli runtime wait + its integration test
- Private planning/evidence updated: yes
- Out of scope: GUI-side read amplifier (task_9d536062) and daemon document serialisation cost are separate tasks.

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_4b7f2c0e88c4a6aec977cb8237
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-28T16:16Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_4b7f2c0e88c4a6aec977cb8237 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Worker (Sol): runtime-wait-reconnect integration test green; six-waiter measurement `artifacts/runs/after-six-fallback-r2/` 246 reads in 182.481 s
- [x] CEO: read r1.md verdict and before/after table against task_be97f0d8's acceptance contract (≤3 reads/s)
- [x] production-delta computed
- [ ] CI on this PR
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO checked the before number is the S1 measurement (8,953 reads / 602.562 s) not re-measured.
- Reviewer subagent: Sol implemented; CEO semantic acceptance against task_4b7f2c0e's plan.
- Human review: pending
- Blocking findings: none

## Residual Risk

- A daemon that never emits exit/gap frames would leave a streamed waiter idle until the reconnect budget reports loss (bounded by design).

## References

- Task: task_4b7f2c0e88c4a6aec977cb8237
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

`ha runtime status --wait` 不再每 250 ms 轮询 daemon。流式路径只等 attached stream,在 `exit` 帧、需要快照的 `gap`、或有界重连预算报丢失后,恰好做一次权威 `repo.agentRuntime.sessions.read`;非流式兜底 500 ms → 1 s → 2 s 封顶退避,只在运行态/游标推进时重置。同一 daemon、同一 schema-14 projection 上六个并发 waiter 实测:改前 14.858 reads/s → 改后 1.348 reads/s(−90.93%,低于 task_be97f0d8 定的 3.0 reads/s 验收上限)。固定 250 ms 循环删除。

## 架构辩护

- Production-Delta 实算:+151/-40,r2 把 `waitForRuntime` 按流式等待 / 封顶非流式兜底拆成两个函数(CLI 结构门:44 分支标记 > 40);删除项是轮询循环及其 helper,r2 无行为变化。

## 改动内容

- `packages/cli/src/cli-runtime-wait.ts`:删 250 ms 轮询;流驱动等待,终止/gap/丢失事件各恰一次权威读;封顶退避兜底。
- `packages/cli/test/runtime-wait-reconnect.integration.test.ts`:attached stream 保持打开且无状态读;exit/gap/loss 后恰一次读。

## 门收割 / Gate Harvest

- 删除的生产路径:`cli-runtime-wait.ts` 里固定 250 ms 的状态轮询循环
- 同 commit 删除的门 / fixture:`runtime-wait-reconnect.integration.test.ts` 里期待周期状态读的协议断言(改为断言 exit/gap/loss 后恰一次读)
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_4b7f2c0e88c4a6aec977cb8237
- 分支:codex/wait-poll
- 公开范围:packages/cli runtime wait 及其集成测试
- 私有计划 / 证据是否已更新:yes
- 范围外:GUI 侧读放大器(task_9d536062)与 daemon 文档序列化成本另立任务。

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_4b7f2c0e88c4a6aec977cb8237
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-28T16:16Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_4b7f2c0e88c4a6aec977cb8237
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] worker(Sol):runtime-wait-reconnect 集成测试绿;六 waiter 实测 `artifacts/runs/after-six-fallback-r2/` 182.481 s 内 246 次读
- [x] CEO:对照 task_be97f0d8 的验收契约(≤3 reads/s)读 r1.md 结论与前后表
- [x] production-delta 实算
- [ ] 本 PR 的 CI
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 核实改前数字取自 S1 实测(8,953 次 / 602.562 s)而非重测。
- Reviewer subagent:Sol 实现;CEO 按 task_4b7f2c0e 的 plan 做语义验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 若 daemon 从不发 exit/gap 帧,流式 waiter 会空等到重连预算报丢失(设计上有界)。

## 关联材料

- 任务:task_4b7f2c0e88c4a6aec977cb8237
- 证据:任务包 artifacts/reports
- 审查:本 PR
