### PR TITLE
fix(daemon): doc sync blocked receipts name the first blocked row; task-scoped sync wording

### DIFF
--- a/packages/daemon/src/agent-role-prompts.ts
+++ b/packages/daemon/src/agent-role-prompts.ts
@@ -17,7 +17,7 @@ const frameworkExecutionDiscipline = [
   "- Before handoff, rebase onto the latest origin/main and rerun the evidence commands.",
   [
     "- Submit receipts only through ",
-    "`ha doc sync --submit --path tasks/<pkg>/artifacts/reports/<file>.md`; ",
+    "`ha doc sync --submit --task <task-id>`; ",
     "do not commit public-repository artifacts.",
   ].join(""),
   [

--- a/packages/daemon/src/doc-sync-settlement.ts
+++ b/packages/daemon/src/doc-sync-settlement.ts
@@ -84,7 +84,8 @@ export function scanDetail(input: Input, scan: DocCandidateScan, code: string): 
           (code === "lease_conflict"
             ? "refresh status and submit through the matching execution or repository prose channel"
             : null)),
-    headingRestore = taskPlanHeadingRestore(input, scan);
+    headingRestore = taskPlanHeadingRestore(input, scan),
+    blocked = scan.rows.find((row) => row.state === "blocked");
   return {
     kind: "doc_sync",
     code,
@@ -134,10 +135,15 @@ export function scanDetail(input: Input, scan: DocCandidateScan, code: string): 
         : (executionChoice ??
           leaseConflict ??
           headingRestore ??
-          (scan.rows.some((row) => row.state === "blocked")
+          (blocked
             ? [
-                "run ha doc status, resolve the listed blocked candidates through their ",
-                "requiredRoute, then rerun ha doc sync --submit",
+                "resolve ",
+                `${blocked.path}`,
+                " through ",
+                `${blocked.requiredRoute ?? resolveDocRoute(documentPath(blocked.path)).requiredRoute}`,
+                ": ",
+                `${blocked.reason ?? "candidate is blocked"}`,
+                "; then rerun ha doc sync --submit",
               ].join("")
             : scan.rows.some((row) => row.state === "eligible")
               ? "submit this selection against the reported automatic base"

--- a/packages/daemon/test/doc-sync-slice-a-implicit-lease.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a-implicit-lease.test.ts
@@ -4,24 +4,12 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import {
-  makeTaskEventStore,
-  type TaskProjection,
-} from "../../kernel/src/index.ts";
+import { makeTaskEventStore, type TaskProjection } from "../../kernel/src/index.ts";
 import { runDocAction } from "../src/doc-sync-actions.ts";
-import {
-  canonicalRoot,
-  workspaceId,
-} from "../src/protocol/daemon-protocol.contract.ts";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
 import { openBootstrappedRepoCell as openRepoCell } from "./repo-settings.fixture.ts";
 
-import {
-  actor,
-  git,
-  initRepo,
-  rows,
-  write,
-} from "./doc-sync-slice-a.fixtures.ts";
+import { actor, git, initRepo, rows, write } from "./doc-sync-slice-a.fixtures.ts";
 test("implicit submit applies eligible prose and reports an unrelated blocked row as skipped", async () => {
   const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-partial-blocked-"));
   initRepo(rootDir);
@@ -34,58 +22,33 @@ test("implicit submit applies eligible prose and reports an unrelated blocked ro
     binding = { actor, source: "local" as const };
   try {
     write(rootDir, "context/blocked.md", "# Stable\n\nbase\n");
-    assert.equal(
-      (
-        await cell.run(
-          { kind: "doc-submit", paths: ["context/blocked.md"] },
-          binding,
-        )
-      ).outcome,
-      "applied",
-    );
+    assert.equal((await cell.run({ kind: "doc-submit", paths: ["context/blocked.md"] }, binding)).outcome, "applied");
     write(rootDir, "context/blocked.md", "# Renamed\n\nbase\n");
     write(rootDir, "context/eligible.md", "# Eligible\n\nship me\n");
-    const submitted = (await cell.run(
-      { kind: "doc-submit", paths: [] },
-      binding,
-    )) as Record<string, unknown>;
+    const submitted = (await cell.run({ kind: "doc-submit", paths: [] }, binding)) as Record<string, unknown>;
     assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
     assert.match(
       String(submitted.summary),
       /doc-submit: applied[\s\S]*context\/eligible\.md[\s\S]*skipped:[\s\S]*context\/blocked\.md\tblocked\tbase region is missing: "# Stable"/u,
     );
-    const event = makeTaskEventStore({ repoId, rootDir }).readEvent(
-      String(submitted.opId),
-    );
+    const event = makeTaskEventStore({ repoId, rootDir }).readEvent(String(submitted.opId));
     assert.equal(event?.schema, "doc-event/v1");
     if (event?.schema === "doc-event/v1")
       assert.deepEqual(
         event.payload.changes.map((change) => change.path),
         ["context/eligible.md"],
       );
-    assert.equal(
-      readFileSync(path.join(rootDir, "harness/context/eligible.md"), "utf8"),
-      "# Eligible\n\nship me\n",
-    );
-    assert.equal(
-      readFileSync(path.join(rootDir, "harness/context/blocked.md"), "utf8"),
-      "# Renamed\n\nbase\n",
-    );
+    assert.equal(readFileSync(path.join(rootDir, "harness/context/eligible.md"), "utf8"), "# Eligible\n\nship me\n");
+    assert.equal(readFileSync(path.join(rootDir, "harness/context/blocked.md"), "utf8"), "# Renamed\n\nbase\n");
     const settledHead = git(rootDir, "rev-parse", "HEAD"),
-      skippedOnly = (await cell.run(
-        { kind: "doc-submit", paths: [] },
-        binding,
-      )) as Record<string, unknown>;
-    assert.equal(
-      skippedOnly.outcome,
-      "op_rejected",
-      JSON.stringify(skippedOnly),
-    );
+      skippedOnly = (await cell.run({ kind: "doc-submit", paths: [] }, binding)) as Record<string, unknown>;
+    assert.equal(skippedOnly.outcome, "op_rejected", JSON.stringify(skippedOnly));
     assert.equal(skippedOnly.code, "preview_blocked");
     assert.match(
       String(skippedOnly.nextAction),
-      /ha doc status[\s\S]*ha doc sync --submit/u,
+      /resolve context\/blocked\.md through refresh-region-policy: base region is missing: "# Stable"/u,
     );
+    assert.doesNotMatch(String(skippedOnly.nextAction), /ha doc status/u);
     assert.equal(
       git(rootDir, "rev-parse", "HEAD"),
       settledHead,
@@ -98,9 +61,7 @@ test("implicit submit applies eligible prose and reports an unrelated blocked ro
 });
 
 test("implicit submit applies eligible prose and reports an unrelated deletion as skipped", async () => {
-  const rootDir = mkdtempSync(
-    path.join(tmpdir(), "ha-doc-a-partial-deletion-"),
-  );
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-partial-deletion-"));
   initRepo(rootDir);
   const repoId = workspaceId("partial-deletion"),
     cell = await openRepoCell({
@@ -111,43 +72,24 @@ test("implicit submit applies eligible prose and reports an unrelated deletion a
     binding = { actor, source: "local" as const };
   try {
     write(rootDir, "context/deleted.md", "# Retained\n");
-    assert.equal(
-      (
-        await cell.run(
-          { kind: "doc-submit", paths: ["context/deleted.md"] },
-          binding,
-        )
-      ).outcome,
-      "applied",
-    );
+    assert.equal((await cell.run({ kind: "doc-submit", paths: ["context/deleted.md"] }, binding)).outcome, "applied");
     rmSync(path.join(rootDir, "harness/context/deleted.md"));
     write(rootDir, "context/eligible.md", "# Eligible\n");
-    const submitted = (await cell.run(
-      { kind: "doc-submit", paths: [] },
-      binding,
-    )) as Record<string, unknown>;
+    const submitted = (await cell.run({ kind: "doc-submit", paths: [] }, binding)) as Record<string, unknown>;
     assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
     assert.match(
       String(submitted.summary),
       /doc-submit: applied[\s\S]*context\/eligible\.md[\s\S]*skipped:[\s\S]*context\/deleted\.md\tdeletion\tcanonical document is missing from the worktree/u,
     );
-    const event = makeTaskEventStore({ repoId, rootDir }).readEvent(
-      String(submitted.opId),
-    );
+    const event = makeTaskEventStore({ repoId, rootDir }).readEvent(String(submitted.opId));
     assert.equal(event?.schema, "doc-event/v1");
     if (event?.schema === "doc-event/v1")
       assert.deepEqual(
         event.payload.changes.map((change) => change.path),
         ["context/eligible.md"],
       );
-    assert.equal(
-      existsSync(path.join(rootDir, "harness/context/deleted.md")),
-      false,
-    );
-    assert.equal(
-      readFileSync(path.join(rootDir, "harness/context/eligible.md"), "utf8"),
-      "# Eligible\n",
-    );
+    assert.equal(existsSync(path.join(rootDir, "harness/context/deleted.md")), false);
+    assert.equal(readFileSync(path.join(rootDir, "harness/context/eligible.md"), "utf8"), "# Eligible\n");
   } finally {
     await cell.close();
     rmSync(rootDir, { recursive: true, force: true });
@@ -163,10 +105,7 @@ test("a runtime session with multiple matching held executions rejects with exac
     } as const,
     source = "local" as const,
     now = "2026-08-23T00:00:00.000Z",
-    paths = [
-      "tasks/task-route-a-a/artifacts/a.md",
-      "tasks/task-route-b-b/artifacts/b.md",
-    ] as const;
+    paths = ["tasks/task-route-a-a/artifacts/a.md", "tasks/task-route-b-b/artifacts/b.md"] as const;
   try {
     for (const target of paths) write(rootDir, target, `# ${target}\n`);
     const lease = (taskId: string, executionId: string) =>
@@ -184,10 +123,7 @@ test("a runtime session with multiple matching held executions rejects with exac
           ttlMs: 3_600_000,
           version: 1,
         }) as const,
-      leases = [
-        lease("task-route-a", "exec-route-a"),
-        lease("task-route-b", "exec-route-b"),
-      ],
+      leases = [lease("task-route-a", "exec-route-a"), lease("task-route-b", "exec-route-b")],
       projection = {
         taskIdForDocumentPath: (target: string) =>
           target.includes("task-route-a-a")
@@ -239,10 +175,7 @@ test("a runtime session with multiple matching held executions rejects with exac
     });
     assert.equal(rejected.outcome, "op_rejected");
     assert.equal(rejected.code, "lease_conflict");
-    assert.match(
-      rejected.nextAction ?? "",
-      /run the task command for the matching execution/u,
-    );
+    assert.match(rejected.nextAction ?? "", /run the task command for the matching execution/u);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }
@@ -279,25 +212,15 @@ test("path and implicit submits ride the repository prose channel when the task 
     },
     taskId = "task_PATHPR0SE000000000000AAAAA";
   try {
-    const created = (await cell.run(
-        { kind: "task-create", taskId, title: "path submit prose channel" },
-        person,
-      )) as { packagePath?: string },
+    const created = (await cell.run({ kind: "task-create", taskId, title: "path submit prose channel" }, person)) as {
+        packagePath?: string;
+      },
       packagePath = created.packagePath!;
     assert.equal(
-      (
-        await cell.run(
-          { kind: "task-start", taskId, executionId: "exec-path-prose" },
-          holder,
-        )
-      ).outcome,
+      (await cell.run({ kind: "task-start", taskId, executionId: "exec-path-prose" }, holder)).outcome,
       "applied",
     );
-    write(
-      rootDir,
-      `${packagePath}/artifacts/reports/leased.md`,
-      "# Leased task report\n",
-    );
+    write(rootDir, `${packagePath}/artifacts/reports/leased.md`, "# Leased task report\n");
     write(rootDir, "context/shared.md", "# Shared\n");
     const status = await cell.run(
       {
@@ -319,9 +242,7 @@ test("path and implicit submits ride the repository prose channel when the task 
       person,
     );
     assert.equal(scoped.outcome, "applied", JSON.stringify(scoped));
-    const event = makeTaskEventStore({ repoId, rootDir }).readEvent(
-      scoped.opId,
-    );
+    const event = makeTaskEventStore({ repoId, rootDir }).readEvent(scoped.opId);
     assert.equal(event?.schema, "doc-event/v1");
     if (event?.schema === "doc-event/v1") {
       assert.equal(
@@ -336,28 +257,11 @@ test("path and implicit submits ride the repository prose channel when the task 
     }
     // A dirty set confined to the leased task package must not regress to the old single-task lease pin either.
     write(rootDir, "context/shared.md", "# Shared\nsynced\n");
-    assert.equal(
-      (
-        await cell.run(
-          { kind: "doc-submit", paths: ["context/shared.md"] },
-          person,
-        )
-      ).outcome,
-      "applied",
-    );
+    assert.equal((await cell.run({ kind: "doc-submit", paths: ["context/shared.md"] }, person)).outcome, "applied");
     write(rootDir, `${packagePath}/artifacts/reports/second.md`, "# Second\n");
-    const implicit = (await cell.run(
-      { kind: "doc-submit", paths: [] },
-      person,
-    )) as Record<string, unknown>;
+    const implicit = (await cell.run({ kind: "doc-submit", paths: [] }, person)) as Record<string, unknown>;
     assert.equal(implicit.outcome, "applied", JSON.stringify(implicit));
-    assert.match(
-      String(implicit.summary),
-      new RegExp(
-        `applied:\\n${packagePath}/artifacts/reports/second\\.md`,
-        "u",
-      ),
-    );
+    assert.match(String(implicit.summary), new RegExp(`applied:\\n${packagePath}/artifacts/reports/second\\.md`, "u"));
     // Naming the foreign execution explicitly still refuses — and the receipt names the exit that works.
     write(rootDir, `${packagePath}/artifacts/reports/third.md`, "# Third\n");
     const explicit = (await cell.run(
@@ -440,10 +344,7 @@ test("a runtime actor with a lapsed lease is told the release and re-enter recov
       ),
     );
     await new Promise((resolve) => setTimeout(resolve, 50));
-    const rejected = (await cell.run(
-      { kind: "doc-submit", paths: [report] },
-      worker,
-    )) as {
+    const rejected = (await cell.run({ kind: "doc-submit", paths: [report] }, worker)) as {
       outcome?: string;
       code?: string;
       nextAction?: string;
@@ -458,22 +359,12 @@ test("a runtime actor with a lapsed lease is told the release and re-enter recov
     assert.match(rejected.nextAction ?? "", recipe);
     assert.match(rejected.detail?.nextAction ?? "", recipe);
     // The named recovery is real: same-execution re-entry restores a held lease this principal holds.
-    const released = (await cell.run(
-        { kind: "task-release", taskId },
-        worker,
-      )) as { outcome?: string },
-      reentered = (await cell.run(
-        { kind: "task-start", taskId, executionId: "exec-lapsed" },
-        worker,
-      )) as { outcome?: string };
-    assert.ok(
-      ["applied", "pending"].includes(String(released.outcome)),
-      JSON.stringify(released),
-    );
-    assert.ok(
-      ["applied", "pending"].includes(String(reentered.outcome)),
-      JSON.stringify(reentered),
-    );
+    const released = (await cell.run({ kind: "task-release", taskId }, worker)) as { outcome?: string },
+      reentered = (await cell.run({ kind: "task-start", taskId, executionId: "exec-lapsed" }, worker)) as {
+        outcome?: string;
+      };
+    assert.ok(["applied", "pending"].includes(String(released.outcome)), JSON.stringify(released));
+    assert.ok(["applied", "pending"].includes(String(reentered.outcome)), JSON.stringify(reentered));
   } finally {
     await cell.close();
     rmSync(rootDir, { recursive: true, force: true });
@@ -484,9 +375,7 @@ test("a runtime actor with a lapsed lease is told the release and re-enter recov
 // flipping the same lease back to held (what release+start does) makes the
 // identical submit apply.
 test("the named release-and-re-enter recovery terminates for a bound runtime session", async () => {
-  const rootDir = mkdtempSync(
-    path.join(tmpdir(), "ha-doc-a-recovery-terminates-"),
-  );
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-recovery-terminates-"));
   initRepo(rootDir);
   const runtimeActor = {
       principal: { personId: "person-owner" },
@@ -514,24 +403,16 @@ test("the named release-and-re-enter recovery terminates for a bound runtime ses
       ttlMs: 1_800_000,
       version: 1,
     } as const;
-    const documents = new Map<
-      string,
-      { readonly path: string; readonly blobSha256: string }
-    >();
+    const documents = new Map<string, { readonly path: string; readonly blobSha256: string }>();
     let watermark = 0;
     const projection = {
-        taskIdForDocumentPath: (target: string) =>
-          target.startsWith("tasks/task-recover-x/") ? "task-recover" : null,
-        currentLease: (taskId: string) =>
-          taskId === "task-recover" ? lease : null,
-        currentLeaseForExecution: (executionId: string) =>
-          executionId === "exec-recover" ? lease : null,
+        taskIdForDocumentPath: (target: string) => (target.startsWith("tasks/task-recover-x/") ? "task-recover" : null),
+        currentLease: (taskId: string) => (taskId === "task-recover" ? lease : null),
+        currentLeaseForExecution: (executionId: string) => (executionId === "exec-recover" ? lease : null),
         readRuntimeSession: () => ({
           runtimeSessionId: "recovery",
           liveness: "live",
-          taskBindings: [
-            { taskId: "task-recover", executionId: "exec-recover" },
-          ],
+          taskBindings: [{ taskId: "task-recover", executionId: "exec-recover" }],
         }),
         readDocument: (target: string) => ({
           status: "ready",
@@ -620,9 +501,7 @@ test("the named release-and-re-enter recovery terminates for a bound runtime ses
     })) as { outcome?: string; opId?: string };
     assert.equal(recovered.outcome, "applied", JSON.stringify(recovered));
     assert.equal(
-      makeTaskEventStore({ repoId: "recovery-terminates", rootDir }).readEvent(
-        String(recovered.opId),
-      )?.schema,
+      makeTaskEventStore({ repoId: "recovery-terminates", rootDir }).readEvent(String(recovered.opId))?.schema,
       "doc-event/v1",
     );
   } finally {

--- a/packages/daemon/test/doc-sync-slice-a.test.ts
+++ b/packages/daemon/test/doc-sync-slice-a.test.ts
@@ -1,6 +1,6 @@
 // harness-test-tier: integration
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -80,12 +80,57 @@ test("status, dry-run, and submit share the repeatable-path scanner and automati
     const acceptedCut = git(rootDir, "rev-parse", "HEAD"),
       blocked = await cell.run({ kind: "doc-dry-run", paths: ["context/a.md"] }, binding);
     assert.equal(rows(blocked.evidence)[0]?.state, "blocked");
-    assert.match(blocked.detail?.nextAction ?? "", /listed blocked candidates/u);
+    assert.match(
+      blocked.detail?.nextAction ?? "",
+      /resolve context\/a\.md through refresh-region-policy: base region is missing: "# A"/u,
+    );
+    assert.doesNotMatch(blocked.detail?.nextAction ?? "", /ha doc status/u);
     assert.doesNotMatch(blocked.detail?.nextAction ?? "", /doc retire|conflict scratch/iu);
     const rejected = await cell.run({ kind: "doc-submit", paths: ["context/a.md"] }, binding);
     assert.equal(rejected.outcome, "op_rejected");
     assert.equal(rejected.code, "preview_blocked");
     assert.equal(git(rootDir, "rev-parse", "HEAD"), acceptedCut);
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("blocked-only submit names the scanner-first closeout recovery", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-doc-a-blocked-closeout-"));
+  initRepo(rootDir);
+  const repoId = workspaceId("blocked-closeout"),
+    cell = await openRepoCell({
+      repoId,
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "blocked-closeout-daemon",
+    }),
+    binding = { actor, source: "local" as const },
+    laterBlocked = "tmp/z-blocked.md";
+  try {
+    write(rootDir, laterBlocked, "# Stable\n\nbase\n");
+    assert.equal((await cell.run({ kind: "doc-submit", paths: [laterBlocked] }, binding)).outcome, "applied");
+    const created = (await cell.run(
+      {
+        kind: "task-create",
+        taskId: "task_CLOSEOUTRECOVERY0000AAAAA",
+        title: "closeout recovery receipt",
+      },
+      binding,
+    )) as { outcome?: string; packagePath?: string };
+    assert.equal(created.outcome, "applied", JSON.stringify(created));
+    const closeout = `${created.packagePath}/closeout.md`,
+      closeoutTarget = path.join(rootDir, "harness", closeout);
+    write(rootDir, closeout, readFileSync(closeoutTarget, "utf8").replace("# Closeout", "# Removed"));
+    write(rootDir, laterBlocked, "# Removed\n\nbase\n");
+    const rejected = (await cell.run({ kind: "doc-submit", paths: [] }, binding)) as Record<string, unknown>;
+    assert.equal(rejected.outcome, "op_rejected", JSON.stringify(rejected));
+    assert.equal(rejected.code, "preview_blocked");
+    assert.match(String(rejected.nextAction), new RegExp(closeout.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
+    assert.match(String(rejected.nextAction), /refresh-region-policy/u);
+    assert.match(String(rejected.nextAction), /base region is missing: "# Closeout"/u);
+    assert.equal(String(rejected.nextAction).includes(laterBlocked), false);
+    assert.doesNotMatch(String(rejected.nextAction), /ha doc status/u);
   } finally {
     await cell.close();
     rmSync(rootDir, { recursive: true, force: true });

--- a/packages/preset/assets/software-coding/presets/worker-dispatch/templates/task.worker.flow/en-US.md
+++ b/packages/preset/assets/software-coding/presets/worker-dispatch/templates/task.worker.flow/en-US.md
@@ -31,4 +31,4 @@ Stop and report when scope, authority, required input, or a destructive choice i
 - Commit only files owned by this assignment.
 - Report the commit, changed files, verification, and residual risks.
 - Before handoff, rebase onto the latest `origin/main` and rerun the evidence commands.
-- Submit receipts only through `ha doc sync --submit --path tasks/<pkg>/artifacts/reports/<file>.md`.
+- Submit task-bound receipts only through `ha doc sync --submit --task <task-id>`.

--- a/packages/preset/assets/software-coding/presets/worker-dispatch/templates/task.worker.flow/zh-CN.md
+++ b/packages/preset/assets/software-coding/presets/worker-dispatch/templates/task.worker.flow/zh-CN.md
@@ -31,4 +31,4 @@
 - 只提交本次派活负责的文件。
 - 回报 commit、变更文件、验证结果和残余风险。
 - 交付前先 rebase 到最新 `origin/main`，再重跑证据命令。
-- 回执只经 `ha doc sync --submit --path tasks/<pkg>/artifacts/reports/<file>.md` 提交。
+- task-bound 回执只经 `ha doc sync --submit --task <task-id>` 提交。

--- a/packages/preset/assets/software-coding/templates/task.worker.flow/en-US.md
+++ b/packages/preset/assets/software-coding/templates/task.worker.flow/en-US.md
@@ -31,4 +31,4 @@ Stop and report when scope, authority, required input, or a destructive choice i
 - Commit only files owned by this assignment.
 - Report the commit, changed files, verification, and residual risks.
 - Before handoff, rebase onto the latest `origin/main` and rerun the evidence commands.
-- Submit receipts only through `ha doc sync --submit --path tasks/<pkg>/artifacts/reports/<file>.md`.
+- Submit task-bound receipts only through `ha doc sync --submit --task <task-id>`.

--- a/packages/preset/assets/software-coding/templates/task.worker.flow/zh-CN.md
+++ b/packages/preset/assets/software-coding/templates/task.worker.flow/zh-CN.md
@@ -31,4 +31,4 @@
 - 只提交本次派活负责的文件。
 - 回报 commit、变更文件、验证结果和残余风险。
 - 交付前先 rebase 到最新 `origin/main`，再重跑证据命令。
-- 回执只经 `ha doc sync --submit --path tasks/<pkg>/artifacts/reports/<file>.md` 提交。
+- task-bound 回执只经 `ha doc sync --submit --task <task-id>` 提交。

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -7,7 +7,7 @@ cd "$repo_root"
 staged_paths=$(git diff --cached --name-only --diff-filter=ACMRTUXB)
 if printf '%s\n' "$staged_paths" | grep -Eq '(^|/)(artifacts|harness)(/|$)'; then
   printf 'Refusing to commit authored or task artifacts from the public repository.\n' >&2
-  printf 'Use `ha doc sync --submit --path tasks/<pkg>/artifacts/reports/<file>.md` for receipts.\n' >&2
+  printf 'Use `ha doc sync --submit --task <task-id>` for task-bound receipts.\n' >&2
   exit 1
 fi
 

--- a/tools/worker-discipline-hooks.test.mjs
+++ b/tools/worker-discipline-hooks.test.mjs
@@ -29,6 +29,8 @@ test("public pre-commit rejects artifacts and harness paths", (context) => {
     const result = runHook(root, "pre-commit");
     assert.equal(result.status, 1, result.stderr);
     assert.match(result.stderr, /Refusing to commit authored or task artifacts/u);
+    assert.match(result.stderr, /ha doc sync --submit --task <task-id>/u);
+    assert.doesNotMatch(result.stderr, /--path|--execution-id/u);
     git(root, "reset", "--quiet", "HEAD", "--", `${directory}/receipt.md`);
   }
 });
@@ -147,12 +149,14 @@ test("worker handoff templates carry framework-owned publication rules", () => {
   for (const relativePath of templatePaths) {
     const body = readFileSync(path.join(repositoryRoot, relativePath), "utf8");
     assert.match(body, /origin\/main/u);
-    assert.match(body, /ha doc sync --submit --path tasks\/<pkg>\/artifacts\/reports\/<file>\.md/u);
+    assert.match(body, /ha doc sync --submit --task <task-id>/u);
+    assert.doesNotMatch(body, /ha doc sync --submit .*--(?:path|execution-id)/u);
     assert.doesNotMatch(body, /Do not push|不要 push/u);
   }
   const prompt = readFileSync(path.join(repositoryRoot, "packages/daemon/src/agent-role-prompts.ts"), "utf8");
   assert.match(prompt, /canonical repository root/u);
-  assert.match(prompt, /ha doc sync --submit --path tasks/u);
+  assert.match(prompt, /ha doc sync --submit --task <task-id>/u);
+  assert.doesNotMatch(prompt, /ha doc sync --submit .*--(?:path|execution-id)/u);
 });
 
 function makeRepo(context, prefix) {


### PR DESCRIPTION
# English

## Summary

First ontology-squad pilot run (squad_7569036bac9a4b0f9cdeb9cf, Commander = Sol) delivered hit-rate items #7 and #8. #8: `ha doc sync --submit` already runs a fresh scan in the same round; the blocked-only branch of `scanDetail` still answered with a generic 'run ha doc status' — it now names the first blocked row's path, reason and requiredRoute directly (production +10/-4, `doc-sync-settlement.ts`). #7: the CLI→`taskId`→`task.packagePath` prefix filter already scopes a task-bound sync to its package (negative test: `context/unrelated.md` is never selected), so no second scope mechanism was added — the stale 'use --path' wording in the agent role prompt, the four worker-flow templates and the pre-commit hook is narrowed to the task-scoped receipt sync (+12/-8).

## Architectural Justification

- Production-Delta as computed: two small deletions-first fixes; the large negative number is `doc-sync-slice-a-implicit-lease.test.ts` being prettier-reformatted by the commit hook (-165), not production.

## What Changed

- `packages/daemon/src/doc-sync-settlement.ts`: first blocked row's single-step action replaces the generic text.
- `packages/daemon/src/agent-role-prompts.ts`, worker-flow templates (en-US/zh-CN ×2), `tools/git-hooks/pre-commit`, `tools/worker-discipline-hooks.test.mjs`: task-scoped receipt sync wording.
- Tests: `doc-sync-slice-a.test.ts` (closeout missing `# Closeout`, two blocked rows → first only, no-status), `doc-sync-slice-a-implicit-lease.test.ts` contract sync.

## Gate Harvest / 门收割

Deleted-Production-Paths: the generic 'run ha doc status' nextAction branch in `doc-sync-settlement.ts`
Deleted-Gates-Fixtures: the generic-text assertions in `doc-sync-slice-a-implicit-lease.test.ts` (replaced by first-blocked-row assertions)
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +11/-5
Dependency-Change: none

### Optional Evidence Claims

## Task And Scope

- Harness task: task_b6439558bc2e73bedf6c22e671
- Branch: codex/squad-hitrate
- Public scope: packages/daemon doc-sync settlement + role prompts/templates + hooks and their tests
- Private planning/evidence updated: yes
- Out of scope: #12 amend, --prompt-file deletion / plan gate (task_bb18f528), orphan gate, agy bypass: not dispatched by the Commander in this run; next squad run.

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_b6439558bc2e73bedf6c22e671
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-28T16:58Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_b6439558bc2e73bedf6c22e671 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Workers (Sol ×2, isolated dispatcher): doc-sync slice-a tests red-then-green on the two behaviours; worker-discipline hook test green
- [x] CEO: read both worker receipts (`artifacts/reports/dispatch_db638fb3…`, `dispatch_8d01904c…`) and the commits; confirmed #7 adds no scope mechanism
- [x] production-delta computed
- [ ] CI on this PR
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO checked the pilot's own frictions are recorded as facts (F-1A53DF5A, pending: shared worktree, no synthesis report, undispatched items).
- Reviewer subagent: ontology-squad Commander (Sol) dispatched and accepted; CEO semantic acceptance against items #7/#8 of task_b6439558's plan.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Both workers shared the Commander's worktree (`.worktrees/squad-hitrate`) instead of one worktree each — recorded as pilot friction, not a code risk here since the commits are sequential.

## References

- Task: task_b6439558bc2e73bedf6c22e671
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

ontology-squad 首次试点(squad_7569036bac9a4b0f9cdeb9cf,Commander=Sol)交付命中率 #7 与 #8。#8:`ha doc sync --submit` 本就同轮先做 fresh scan;`scanDetail` 的 blocked-only 分支却仍泛泛回「先跑 ha doc status」——现在直接写出首条 blocked row 的 path/reason/requiredRoute(生产 +10/-4,`doc-sync-settlement.ts`)。#7:CLI→`taskId`→`task.packagePath` 前缀过滤已把 task-bound sync 限定到任务包(阴性测试:`context/unrelated.md` 永不入选),故不新造 scope 机制——只把 agent role prompt、四份 worker-flow 模板与 pre-commit hook 里陈旧的「用 --path」文案收窄成 task-scoped receipt sync(+12/-8)。

## 架构辩护

- Production-Delta 实算:两个删除优先的小修;大的负数来自 commit hook 对 `doc-sync-slice-a-implicit-lease.test.ts` 的整文件 prettier(-165),不是生产。

## 改动内容

- `packages/daemon/src/doc-sync-settlement.ts`:首条 blocked row 的单步行动替换泛化文案。
- `packages/daemon/src/agent-role-prompts.ts`、worker-flow 模板(en-US/zh-CN ×2)、`tools/git-hooks/pre-commit`、`tools/worker-discipline-hooks.test.mjs`:task-scoped receipt sync 文案。
- 测试:`doc-sync-slice-a.test.ts`(closeout 缺 `# Closeout`、两条 blocked 只报首条、无 status)、`doc-sync-slice-a-implicit-lease.test.ts` 契约同步。

## 门收割 / Gate Harvest

- 删除的生产路径:`doc-sync-settlement.ts` 里泛化的「run ha doc status」nextAction 分支
- 同 commit 删除的门 / fixture:`doc-sync-slice-a-implicit-lease.test.ts` 里的泛化文案断言(改为首条 blocked row 断言)
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_b6439558bc2e73bedf6c22e671
- 分支:codex/squad-hitrate
- 公开范围:packages/daemon doc-sync settlement + role prompt/模板 + hook 及测试
- 私有计划 / 证据是否已更新:yes
- 范围外:#12 amend、--prompt-file 删除/plan 门(task_bb18f528)、orphan gate、agy bypass:本轮 Commander 未派;下一轮 squad。

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_b6439558bc2e73bedf6c22e671
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-28T16:58Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_b6439558bc2e73bedf6c22e671
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] worker(Sol ×2,隔离派测):doc-sync slice-a 两项行为先红后绿;worker-discipline hook 测试绿
- [x] CEO:读两份 worker 回执(`artifacts/reports/dispatch_db638fb3…`、`dispatch_8d01904c…`)与 commit;确认 #7 未新增 scope 机制
- [x] production-delta 实算
- [ ] 本 PR 的 CI
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 核实试点自身摩擦已记 fact(F-1A53DF5A,待记:共用 worktree、无综合报告、未派项)。
- Reviewer subagent:ontology-squad Commander(Sol)派发并验收;CEO 按 task_b6439558 plan 的 #7/#8 做语义验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 两个 worker 与 Commander 共用 `.worktrees/squad-hitrate` 而非一 worker 一 worktree——记为试点摩擦;此处 commit 串行,无代码风险。

## 关联材料

- 任务:task_b6439558bc2e73bedf6c22e671
- 证据:任务包 artifacts/reports
- 审查:本 PR
