### PR TITLE
ci: build native deps from setup-node headers on the Node 26 lanes

### DIFF
--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -65,7 +65,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
-      - run: npm_package_config_node_gyp_nodedir="$(dirname "$(dirname "$(command -v node)")")" npm ci
+      - run: echo "npm_config_nodedir=$(dirname "$(dirname "$(command -v node)")")" >> "$GITHUB_ENV"
+      - run: npm ci
       - run: git diff --check
       - run: sudo apt-get update && sudo apt-get install -y xvfb
       - run: npm run check
@@ -388,7 +389,8 @@ jobs:
         with:
           node-version: 26
           cache: npm
-      - run: npm_package_config_node_gyp_nodedir="$(dirname "$(dirname "$(command -v node)")")" npm ci
+      - run: echo "npm_config_nodedir=$(dirname "$(dirname "$(command -v node)")")" >> "$GITHUB_ENV"
+      - run: npm ci
       - run: node tools/run-manifest-gates.mjs --workflow-job node26-compatibility
       - name: Upload structured CI observation artifact
         if: always()

--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
-      - run: npm ci
+      - run: npm_package_config_node_gyp_nodedir="$(dirname "$(dirname "$(command -v node)")")" npm ci
       - run: git diff --check
       - run: sudo apt-get update && sudo apt-get install -y xvfb
       - run: npm run check
@@ -388,7 +388,7 @@ jobs:
         with:
           node-version: 26
           cache: npm
-      - run: npm ci
+      - run: npm_package_config_node_gyp_nodedir="$(dirname "$(dirname "$(command -v node)")")" npm ci
       - run: node tools/run-manifest-gates.mjs --workflow-job node26-compatibility
       - name: Upload structured CI observation artifact
         if: always()

--- a/tools/check-gate-manifest-invariants.mjs
+++ b/tools/check-gate-manifest-invariants.mjs
@@ -10,6 +10,8 @@ const SURFACE_CLASSES = new Set(["local", "pr", "main-full", "nightly", "manual"
 const POSITIVE_CONTROL_STATUSES = new Set(["covered", "documented-gap", "not-applicable"]);
 const INFRASTRUCTURE_COMMANDS = new Set([
   "npm ci",
+  // Node 26 lanes export node-gyp's nodedir from the setup-node toolchain (dec_047D7AD197D9D096837A0BB36B).
+  'echo "npm_config_nodedir=$(dirname "$(dirname "$(command -v node)")")" >> "$GITHUB_ENV"',
   "git diff --check",
   "sudo apt-get update && sudo apt-get install -y xvfb",
   // Building the packaged bin and configuring the checkout are properties of the runner, not

--- a/tools/check-gate-surface.mjs
+++ b/tools/check-gate-surface.mjs
@@ -31,7 +31,7 @@ const INFRASTRUCTURE_RUN_COMMANDS = new Set([
   "npm run build -w @harness-anything/cli",
   // Setting the checkout to convert line endings is the crlf-checkout job's whole point; it is
   // a property of the checkout, not a gate command, so no manifest gate can declare it.
-  "git config --global core.autocrlf true",
+  "git config --global core.autocrlf true"
 ]);
 
 export function checkGateSurface(root = DEFAULT_ROOT) {
@@ -63,8 +63,8 @@ export function checkGateSurface(root = DEFAULT_ROOT) {
       packageCheckCommands: splitShellAndList(packageScripts.check ?? "").length,
       packageCheckPrCommands: splitShellAndList(packageScripts["check:pr"] ?? "").length,
       pullRequestJobs: workflow.pullRequestJobs.length,
-      branchProtectionContexts: branchContexts.length,
-    },
+      branchProtectionContexts: branchContexts.length
+    }
   };
 }
 
@@ -74,27 +74,27 @@ function checkPackageScripts({ findings, manifest, gates, gatesById, commandToGa
     aggregateName: "check",
     commands: splitShellAndList(packageScripts.check ?? ""),
     manifest,
-    commandToGateIds,
+    commandToGateIds
   });
   const actualCheckPrIds = mapAggregateCommands({
     findings,
     aggregateName: "check:pr",
     commands: splitShellAndList(packageScripts["check:pr"] ?? ""),
     manifest,
-    commandToGateIds,
+    commandToGateIds
   });
 
   compareIdSets({
     findings,
     label: "package.json scripts.check",
     expected: manifest.surfaces?.packageJson?.check ?? [],
-    actual: actualCheckIds,
+    actual: actualCheckIds
   });
   compareIdSets({
     findings,
     label: "package.json scripts.check:pr",
     expected: manifest.surfaces?.packageJson?.checkPr ?? [],
-    actual: actualCheckPrIds,
+    actual: actualCheckPrIds
   });
 
   for (const gate of gates) {
@@ -105,20 +105,16 @@ function checkPackageScripts({ findings, manifest, gates, gatesById, commandToGa
     }
 
     if (!gate.aggregate && Boolean(packageSurface.check) !== actualCheckIds.includes(gate.id)) {
-      findings.push(
-        formatFinding(
-          "package-json",
-          `${gate.id} executionSurfaces.packageJson.check=${packageSurface.check} but scripts.check membership is ${actualCheckIds.includes(gate.id)}.`,
-        ),
-      );
+      findings.push(formatFinding(
+        "package-json",
+        `${gate.id} executionSurfaces.packageJson.check=${packageSurface.check} but scripts.check membership is ${actualCheckIds.includes(gate.id)}.`
+      ));
     }
     if (!gate.aggregate && Boolean(packageSurface.checkPr) !== actualCheckPrIds.includes(gate.id)) {
-      findings.push(
-        formatFinding(
-          "package-json",
-          `${gate.id} executionSurfaces.packageJson.checkPr=${packageSurface.checkPr} but scripts.check:pr membership is ${actualCheckPrIds.includes(gate.id)}.`,
-        ),
-      );
+      findings.push(formatFinding(
+        "package-json",
+        `${gate.id} executionSurfaces.packageJson.checkPr=${packageSurface.checkPr} but scripts.check:pr membership is ${actualCheckPrIds.includes(gate.id)}.`
+      ));
     }
 
     if (packageSurface.check || packageSurface.checkPr || packageSurface.script) {
@@ -126,10 +122,7 @@ function checkPackageScripts({ findings, manifest, gates, gatesById, commandToGa
     }
   }
 
-  for (const id of [
-    ...(manifest.surfaces?.packageJson?.check ?? []),
-    ...(manifest.surfaces?.packageJson?.checkPr ?? []),
-  ]) {
+  for (const id of [...(manifest.surfaces?.packageJson?.check ?? []), ...(manifest.surfaces?.packageJson?.checkPr ?? [])]) {
     if (!gatesById.has(id)) {
       findings.push(formatFinding("package-json", `manifest.surfaces.packageJson references unknown gate id ${id}.`));
     }
@@ -138,22 +131,20 @@ function checkPackageScripts({ findings, manifest, gates, gatesById, commandToGa
 
 function checkRewriteCi({ findings, manifest, gates, workflow, commandToGateIds }) {
   const helperJobs = manifest.surfaces?.rewriteCi?.helperJobsNotRegisteredAsGates ?? [];
-  const actualPullRequestGateJobs = workflow.pullRequestJobs
-    .filter((job) => !helperJobs.includes(job.id))
-    .map((job) => job.id);
+  const actualPullRequestGateJobs = workflow.pullRequestJobs.filter((job) => !helperJobs.includes(job.id)).map((job) => job.id);
   const actualNonPullRequestGateJobs = workflow.nonPullRequestJobs.map((job) => job.id);
 
   compareIdSets({
     findings,
     label: ".github/workflows/rewrite-ci.yml pull_request gate jobs",
     expected: manifest.surfaces?.rewriteCi?.pullRequestGateJobs ?? [],
-    actual: actualPullRequestGateJobs,
+    actual: actualPullRequestGateJobs
   });
   compareIdSets({
     findings,
     label: ".github/workflows/rewrite-ci.yml non-pull_request gate jobs",
     expected: manifest.surfaces?.rewriteCi?.nonPullRequestGateJobs ?? [],
-    actual: actualNonPullRequestGateJobs,
+    actual: actualNonPullRequestGateJobs
   });
 
   const jobsById = new Map(workflow.jobs.map((job) => [job.id, job]));
@@ -165,23 +156,13 @@ function checkRewriteCi({ findings, manifest, gates, workflow, commandToGateIds 
       const runnerInvocation = parseManifestRunnerCommand(command);
       if (runnerInvocation) {
         if (runnerInvocation.workflowJob !== job.id) {
-          findings.push(
-            formatFinding(
-              "rewrite-ci",
-              `${job.id} runs manifest gate runner for ${runnerInvocation.workflowJob ?? "no workflow job"}.`,
-            ),
-          );
+          findings.push(formatFinding("rewrite-ci", `${job.id} runs manifest gate runner for ${runnerInvocation.workflowJob ?? "no workflow job"}.`));
         }
         continue;
       }
       const mappedIds = commandToGateIds.get(command) ?? [];
       if (mappedIds.length === 0) {
-        findings.push(
-          formatFinding(
-            "rewrite-ci",
-            `${job.id} runs ${JSON.stringify(command)} but no manifest gate declares that command.`,
-          ),
-        );
+        findings.push(formatFinding("rewrite-ci", `${job.id} runs ${JSON.stringify(command)} but no manifest gate declares that command.`));
       }
     }
   }
@@ -195,28 +176,16 @@ function checkRewriteCi({ findings, manifest, gates, workflow, commandToGateIds 
 
     if (gate.tier === "pr-required") {
       if ((rewriteSurface.pullRequestJobs ?? []).length === 0) {
-        findings.push(
-          formatFinding("rewrite-ci", `${gate.id} is pr-required but declares no pull-request workflow job.`),
-        );
+        findings.push(formatFinding("rewrite-ci", `${gate.id} is pr-required but declares no pull-request workflow job.`));
       }
       for (const jobId of rewriteSurface.pullRequestJobs ?? []) {
         const job = jobsById.get(jobId);
         if (!job || !job.isPullRequestJob) {
-          findings.push(
-            formatFinding(
-              "rewrite-ci",
-              `${gate.id} expects pull-request job ${jobId}, but that job is not a pull_request job.`,
-            ),
-          );
+          findings.push(formatFinding("rewrite-ci", `${gate.id} expects pull-request job ${jobId}, but that job is not a pull_request job.`));
           continue;
         }
         if (!jobRunsGateCommand({ job, gate, manifest, gates })) {
-          findings.push(
-            formatFinding(
-              "rewrite-ci",
-              `${gate.id} expects ${jobId} to run ${JSON.stringify(gate.command)}, but the command is absent.`,
-            ),
-          );
+          findings.push(formatFinding("rewrite-ci", `${gate.id} expects ${jobId} to run ${JSON.stringify(gate.command)}, but the command is absent.`));
         }
       }
     }
@@ -229,7 +198,7 @@ function checkBranchProtection({ findings, manifest, gates, branchContexts }) {
     findings,
     label: ".github/branch-protection.md required contexts",
     expected: manifestContexts,
-    actual: branchContexts,
+    actual: branchContexts
   });
 
   const declaredRequiredContexts = new Set();
@@ -241,18 +210,16 @@ function checkBranchProtection({ findings, manifest, gates, branchContexts }) {
     }
     const gateContexts = gate.githubContext?.requiredContexts ?? [];
     if (Boolean(branchSurface.required) !== gateContexts.length > 0) {
-      findings.push(
-        formatFinding(
-          "branch-protection",
-          `${gate.id} executionSurfaces.branchProtection.required=${branchSurface.required} but githubContext.requiredContexts has ${gateContexts.length} entries.`,
-        ),
-      );
+      findings.push(formatFinding(
+        "branch-protection",
+        `${gate.id} executionSurfaces.branchProtection.required=${branchSurface.required} but githubContext.requiredContexts has ${gateContexts.length} entries.`
+      ));
     }
     compareIdSets({
       findings,
       label: `${gate.id} branch protection contexts`,
       expected: gateContexts,
-      actual: branchSurface.contexts ?? [],
+      actual: branchSurface.contexts ?? []
     });
 
     if (gate.tier === "pr-required" && gateContexts.length === 0) {
@@ -261,24 +228,14 @@ function checkBranchProtection({ findings, manifest, gates, branchContexts }) {
     for (const context of gateContexts) {
       declaredRequiredContexts.add(context);
       if (!branchContexts.includes(context)) {
-        findings.push(
-          formatFinding(
-            "branch-protection",
-            `${gate.id} requires context ${context}, but .github/branch-protection.md does not list it.`,
-          ),
-        );
+        findings.push(formatFinding("branch-protection", `${gate.id} requires context ${context}, but .github/branch-protection.md does not list it.`));
       }
     }
   }
 
   for (const context of branchContexts) {
     if (!declaredRequiredContexts.has(context)) {
-      findings.push(
-        formatFinding(
-          "branch-protection",
-          `.github/branch-protection.md lists ${context}, but no manifest gate declares that required context.`,
-        ),
-      );
+      findings.push(formatFinding("branch-protection", `.github/branch-protection.md lists ${context}, but no manifest gate declares that required context.`));
     }
   }
 }
@@ -319,12 +276,7 @@ function mapAggregateCommands({ findings, aggregateName, commands, manifest, com
     if (runnerInvocation) {
       const expandedIds = expandManifestRunnerIds({ invocation: runnerInvocation, manifest });
       if (runnerInvocation.packageSurface === null) {
-        findings.push(
-          formatFinding(
-            "package-json",
-            `package.json scripts.${aggregateName} uses manifest gate runner without --package-surface.`,
-          ),
-        );
+        findings.push(formatFinding("package-json", `package.json scripts.${aggregateName} uses manifest gate runner without --package-surface.`));
       }
       ids.push(...expandedIds);
       continue;
@@ -332,12 +284,7 @@ function mapAggregateCommands({ findings, aggregateName, commands, manifest, com
 
     const mappedIds = commandToGateIds.get(command) ?? [];
     if (mappedIds.length === 0) {
-      findings.push(
-        formatFinding(
-          "package-json",
-          `package.json scripts.${aggregateName} contains ${JSON.stringify(command)} but no manifest gate declares that command.`,
-        ),
-      );
+      findings.push(formatFinding("package-json", `package.json scripts.${aggregateName} contains ${JSON.stringify(command)} but no manifest gate declares that command.`));
       continue;
     }
     ids.push(...mappedIds);
@@ -363,12 +310,7 @@ function checkCommandResolvableInPackageScripts({ findings, gate, packageScripts
 
   for (const scriptName of new Set(commandScriptNames)) {
     if (!Object.hasOwn(packageScripts, scriptName)) {
-      findings.push(
-        formatFinding(
-          "package-json",
-          `${gate.id} references package script ${scriptName}, but package.json does not define it.`,
-        ),
-      );
+      findings.push(formatFinding("package-json", `${gate.id} references package script ${scriptName}, but package.json does not define it.`));
     }
   }
 }
@@ -377,11 +319,7 @@ function jobRunsGateCommand({ job, gate, manifest, gates }) {
   if (job.runCommands.includes(gate.command)) {
     return true;
   }
-  if (
-    job.runCommands.some((command) =>
-      manifestRunnerCoversGate({ command, gateId: gate.id, workflowJob: job.id, manifest }),
-    )
-  ) {
+  if (job.runCommands.some((command) => manifestRunnerCoversGate({ command, gateId: gate.id, workflowJob: job.id, manifest }))) {
     return true;
   }
   const parts = splitShellAndList(gate.command);
@@ -450,7 +388,7 @@ function parseRewriteCi(text) {
         id: jobMatch[1],
         ifExpressions: [],
         runCommands: [],
-        nodeVersions: [],
+        nodeVersions: []
       };
       jobs.push(current);
       continue;
@@ -495,18 +433,14 @@ function parseRewriteCi(text) {
   }
 
   for (const job of jobs) {
-    job.isPullRequestJob = job.ifExpressions.some((expression) =>
-      expression.includes("github.event_name == 'pull_request'"),
-    );
-    job.isNonPullRequestJob = job.ifExpressions.some((expression) =>
-      expression.includes("github.event_name != 'pull_request'"),
-    );
+    job.isPullRequestJob = job.ifExpressions.some((expression) => expression.includes("github.event_name == 'pull_request'"));
+    job.isNonPullRequestJob = job.ifExpressions.some((expression) => expression.includes("github.event_name != 'pull_request'"));
   }
 
   return {
     jobs,
     pullRequestJobs: jobs.filter((job) => job.isPullRequestJob),
-    nonPullRequestJobs: jobs.filter((job) => job.isNonPullRequestJob),
+    nonPullRequestJobs: jobs.filter((job) => job.isNonPullRequestJob)
   };
 }
 
@@ -545,7 +479,9 @@ function splitShellAndList(script) {
 }
 
 function parseManifestRunnerCommand(command) {
-  let normalized = command.replace(/\s+2>&1\s+\|\s+tee\s+artifacts\/gui-e2e\/gui-e2e\.log\s*$/u, "").trim();
+  let normalized = command
+    .replace(/\s+2>&1\s+\|\s+tee\s+artifacts\/gui-e2e\/gui-e2e\.log\s*$/u, "")
+    .trim();
   if (normalized.startsWith("xvfb-run --auto-servernum ")) {
     normalized = normalized.slice("xvfb-run --auto-servernum ".length).trim();
   }
@@ -556,7 +492,7 @@ function parseManifestRunnerCommand(command) {
   const invocation = {
     packageSurface: null,
     workflowJob: null,
-    exclude: new Set(),
+    exclude: new Set()
   };
 
   for (let index = 0; index < args.length; index += 1) {

--- a/tools/check-gate-surface.mjs
+++ b/tools/check-gate-surface.mjs
@@ -21,6 +21,9 @@ const DEFAULT_ROOT = process.cwd();
 const MANIFEST_GATE_RUNNER = "node tools/run-manifest-gates.mjs";
 const INFRASTRUCTURE_RUN_COMMANDS = new Set([
   "npm ci",
+  // Node 26 lanes build node-pty from setup-node's local headers instead of downloading them
+  // (dec_047D7AD197D9D096837A0BB36B); the export is workspace setup, not a gate.
+  'echo "npm_config_nodedir=$(dirname "$(dirname "$(command -v node)")")" >> "$GITHUB_ENV"',
   "git diff --check",
   "mkdir -p artifacts/gui-e2e",
   "sudo apt-get update && sudo apt-get install -y xvfb",
@@ -28,7 +31,7 @@ const INFRASTRUCTURE_RUN_COMMANDS = new Set([
   "npm run build -w @harness-anything/cli",
   // Setting the checkout to convert line endings is the crlf-checkout job's whole point; it is
   // a property of the checkout, not a gate command, so no manifest gate can declare it.
-  "git config --global core.autocrlf true"
+  "git config --global core.autocrlf true",
 ]);
 
 export function checkGateSurface(root = DEFAULT_ROOT) {
@@ -60,8 +63,8 @@ export function checkGateSurface(root = DEFAULT_ROOT) {
       packageCheckCommands: splitShellAndList(packageScripts.check ?? "").length,
       packageCheckPrCommands: splitShellAndList(packageScripts["check:pr"] ?? "").length,
       pullRequestJobs: workflow.pullRequestJobs.length,
-      branchProtectionContexts: branchContexts.length
-    }
+      branchProtectionContexts: branchContexts.length,
+    },
   };
 }
 
@@ -71,27 +74,27 @@ function checkPackageScripts({ findings, manifest, gates, gatesById, commandToGa
     aggregateName: "check",
     commands: splitShellAndList(packageScripts.check ?? ""),
     manifest,
-    commandToGateIds
+    commandToGateIds,
   });
   const actualCheckPrIds = mapAggregateCommands({
     findings,
     aggregateName: "check:pr",
     commands: splitShellAndList(packageScripts["check:pr"] ?? ""),
     manifest,
-    commandToGateIds
+    commandToGateIds,
   });
 
   compareIdSets({
     findings,
     label: "package.json scripts.check",
     expected: manifest.surfaces?.packageJson?.check ?? [],
-    actual: actualCheckIds
+    actual: actualCheckIds,
   });
   compareIdSets({
     findings,
     label: "package.json scripts.check:pr",
     expected: manifest.surfaces?.packageJson?.checkPr ?? [],
-    actual: actualCheckPrIds
+    actual: actualCheckPrIds,
   });
 
   for (const gate of gates) {
@@ -102,16 +105,20 @@ function checkPackageScripts({ findings, manifest, gates, gatesById, commandToGa
     }
 
     if (!gate.aggregate && Boolean(packageSurface.check) !== actualCheckIds.includes(gate.id)) {
-      findings.push(formatFinding(
-        "package-json",
-        `${gate.id} executionSurfaces.packageJson.check=${packageSurface.check} but scripts.check membership is ${actualCheckIds.includes(gate.id)}.`
-      ));
+      findings.push(
+        formatFinding(
+          "package-json",
+          `${gate.id} executionSurfaces.packageJson.check=${packageSurface.check} but scripts.check membership is ${actualCheckIds.includes(gate.id)}.`,
+        ),
+      );
     }
     if (!gate.aggregate && Boolean(packageSurface.checkPr) !== actualCheckPrIds.includes(gate.id)) {
-      findings.push(formatFinding(
-        "package-json",
-        `${gate.id} executionSurfaces.packageJson.checkPr=${packageSurface.checkPr} but scripts.check:pr membership is ${actualCheckPrIds.includes(gate.id)}.`
-      ));
+      findings.push(
+        formatFinding(
+          "package-json",
+          `${gate.id} executionSurfaces.packageJson.checkPr=${packageSurface.checkPr} but scripts.check:pr membership is ${actualCheckPrIds.includes(gate.id)}.`,
+        ),
+      );
     }
 
     if (packageSurface.check || packageSurface.checkPr || packageSurface.script) {
@@ -119,7 +126,10 @@ function checkPackageScripts({ findings, manifest, gates, gatesById, commandToGa
     }
   }
 
-  for (const id of [...(manifest.surfaces?.packageJson?.check ?? []), ...(manifest.surfaces?.packageJson?.checkPr ?? [])]) {
+  for (const id of [
+    ...(manifest.surfaces?.packageJson?.check ?? []),
+    ...(manifest.surfaces?.packageJson?.checkPr ?? []),
+  ]) {
     if (!gatesById.has(id)) {
       findings.push(formatFinding("package-json", `manifest.surfaces.packageJson references unknown gate id ${id}.`));
     }
@@ -128,20 +138,22 @@ function checkPackageScripts({ findings, manifest, gates, gatesById, commandToGa
 
 function checkRewriteCi({ findings, manifest, gates, workflow, commandToGateIds }) {
   const helperJobs = manifest.surfaces?.rewriteCi?.helperJobsNotRegisteredAsGates ?? [];
-  const actualPullRequestGateJobs = workflow.pullRequestJobs.filter((job) => !helperJobs.includes(job.id)).map((job) => job.id);
+  const actualPullRequestGateJobs = workflow.pullRequestJobs
+    .filter((job) => !helperJobs.includes(job.id))
+    .map((job) => job.id);
   const actualNonPullRequestGateJobs = workflow.nonPullRequestJobs.map((job) => job.id);
 
   compareIdSets({
     findings,
     label: ".github/workflows/rewrite-ci.yml pull_request gate jobs",
     expected: manifest.surfaces?.rewriteCi?.pullRequestGateJobs ?? [],
-    actual: actualPullRequestGateJobs
+    actual: actualPullRequestGateJobs,
   });
   compareIdSets({
     findings,
     label: ".github/workflows/rewrite-ci.yml non-pull_request gate jobs",
     expected: manifest.surfaces?.rewriteCi?.nonPullRequestGateJobs ?? [],
-    actual: actualNonPullRequestGateJobs
+    actual: actualNonPullRequestGateJobs,
   });
 
   const jobsById = new Map(workflow.jobs.map((job) => [job.id, job]));
@@ -153,13 +165,23 @@ function checkRewriteCi({ findings, manifest, gates, workflow, commandToGateIds 
       const runnerInvocation = parseManifestRunnerCommand(command);
       if (runnerInvocation) {
         if (runnerInvocation.workflowJob !== job.id) {
-          findings.push(formatFinding("rewrite-ci", `${job.id} runs manifest gate runner for ${runnerInvocation.workflowJob ?? "no workflow job"}.`));
+          findings.push(
+            formatFinding(
+              "rewrite-ci",
+              `${job.id} runs manifest gate runner for ${runnerInvocation.workflowJob ?? "no workflow job"}.`,
+            ),
+          );
         }
         continue;
       }
       const mappedIds = commandToGateIds.get(command) ?? [];
       if (mappedIds.length === 0) {
-        findings.push(formatFinding("rewrite-ci", `${job.id} runs ${JSON.stringify(command)} but no manifest gate declares that command.`));
+        findings.push(
+          formatFinding(
+            "rewrite-ci",
+            `${job.id} runs ${JSON.stringify(command)} but no manifest gate declares that command.`,
+          ),
+        );
       }
     }
   }
@@ -173,16 +195,28 @@ function checkRewriteCi({ findings, manifest, gates, workflow, commandToGateIds 
 
     if (gate.tier === "pr-required") {
       if ((rewriteSurface.pullRequestJobs ?? []).length === 0) {
-        findings.push(formatFinding("rewrite-ci", `${gate.id} is pr-required but declares no pull-request workflow job.`));
+        findings.push(
+          formatFinding("rewrite-ci", `${gate.id} is pr-required but declares no pull-request workflow job.`),
+        );
       }
       for (const jobId of rewriteSurface.pullRequestJobs ?? []) {
         const job = jobsById.get(jobId);
         if (!job || !job.isPullRequestJob) {
-          findings.push(formatFinding("rewrite-ci", `${gate.id} expects pull-request job ${jobId}, but that job is not a pull_request job.`));
+          findings.push(
+            formatFinding(
+              "rewrite-ci",
+              `${gate.id} expects pull-request job ${jobId}, but that job is not a pull_request job.`,
+            ),
+          );
           continue;
         }
         if (!jobRunsGateCommand({ job, gate, manifest, gates })) {
-          findings.push(formatFinding("rewrite-ci", `${gate.id} expects ${jobId} to run ${JSON.stringify(gate.command)}, but the command is absent.`));
+          findings.push(
+            formatFinding(
+              "rewrite-ci",
+              `${gate.id} expects ${jobId} to run ${JSON.stringify(gate.command)}, but the command is absent.`,
+            ),
+          );
         }
       }
     }
@@ -195,7 +229,7 @@ function checkBranchProtection({ findings, manifest, gates, branchContexts }) {
     findings,
     label: ".github/branch-protection.md required contexts",
     expected: manifestContexts,
-    actual: branchContexts
+    actual: branchContexts,
   });
 
   const declaredRequiredContexts = new Set();
@@ -207,16 +241,18 @@ function checkBranchProtection({ findings, manifest, gates, branchContexts }) {
     }
     const gateContexts = gate.githubContext?.requiredContexts ?? [];
     if (Boolean(branchSurface.required) !== gateContexts.length > 0) {
-      findings.push(formatFinding(
-        "branch-protection",
-        `${gate.id} executionSurfaces.branchProtection.required=${branchSurface.required} but githubContext.requiredContexts has ${gateContexts.length} entries.`
-      ));
+      findings.push(
+        formatFinding(
+          "branch-protection",
+          `${gate.id} executionSurfaces.branchProtection.required=${branchSurface.required} but githubContext.requiredContexts has ${gateContexts.length} entries.`,
+        ),
+      );
     }
     compareIdSets({
       findings,
       label: `${gate.id} branch protection contexts`,
       expected: gateContexts,
-      actual: branchSurface.contexts ?? []
+      actual: branchSurface.contexts ?? [],
     });
 
     if (gate.tier === "pr-required" && gateContexts.length === 0) {
@@ -225,14 +261,24 @@ function checkBranchProtection({ findings, manifest, gates, branchContexts }) {
     for (const context of gateContexts) {
       declaredRequiredContexts.add(context);
       if (!branchContexts.includes(context)) {
-        findings.push(formatFinding("branch-protection", `${gate.id} requires context ${context}, but .github/branch-protection.md does not list it.`));
+        findings.push(
+          formatFinding(
+            "branch-protection",
+            `${gate.id} requires context ${context}, but .github/branch-protection.md does not list it.`,
+          ),
+        );
       }
     }
   }
 
   for (const context of branchContexts) {
     if (!declaredRequiredContexts.has(context)) {
-      findings.push(formatFinding("branch-protection", `.github/branch-protection.md lists ${context}, but no manifest gate declares that required context.`));
+      findings.push(
+        formatFinding(
+          "branch-protection",
+          `.github/branch-protection.md lists ${context}, but no manifest gate declares that required context.`,
+        ),
+      );
     }
   }
 }
@@ -273,7 +319,12 @@ function mapAggregateCommands({ findings, aggregateName, commands, manifest, com
     if (runnerInvocation) {
       const expandedIds = expandManifestRunnerIds({ invocation: runnerInvocation, manifest });
       if (runnerInvocation.packageSurface === null) {
-        findings.push(formatFinding("package-json", `package.json scripts.${aggregateName} uses manifest gate runner without --package-surface.`));
+        findings.push(
+          formatFinding(
+            "package-json",
+            `package.json scripts.${aggregateName} uses manifest gate runner without --package-surface.`,
+          ),
+        );
       }
       ids.push(...expandedIds);
       continue;
@@ -281,7 +332,12 @@ function mapAggregateCommands({ findings, aggregateName, commands, manifest, com
 
     const mappedIds = commandToGateIds.get(command) ?? [];
     if (mappedIds.length === 0) {
-      findings.push(formatFinding("package-json", `package.json scripts.${aggregateName} contains ${JSON.stringify(command)} but no manifest gate declares that command.`));
+      findings.push(
+        formatFinding(
+          "package-json",
+          `package.json scripts.${aggregateName} contains ${JSON.stringify(command)} but no manifest gate declares that command.`,
+        ),
+      );
       continue;
     }
     ids.push(...mappedIds);
@@ -307,7 +363,12 @@ function checkCommandResolvableInPackageScripts({ findings, gate, packageScripts
 
   for (const scriptName of new Set(commandScriptNames)) {
     if (!Object.hasOwn(packageScripts, scriptName)) {
-      findings.push(formatFinding("package-json", `${gate.id} references package script ${scriptName}, but package.json does not define it.`));
+      findings.push(
+        formatFinding(
+          "package-json",
+          `${gate.id} references package script ${scriptName}, but package.json does not define it.`,
+        ),
+      );
     }
   }
 }
@@ -316,7 +377,11 @@ function jobRunsGateCommand({ job, gate, manifest, gates }) {
   if (job.runCommands.includes(gate.command)) {
     return true;
   }
-  if (job.runCommands.some((command) => manifestRunnerCoversGate({ command, gateId: gate.id, workflowJob: job.id, manifest }))) {
+  if (
+    job.runCommands.some((command) =>
+      manifestRunnerCoversGate({ command, gateId: gate.id, workflowJob: job.id, manifest }),
+    )
+  ) {
     return true;
   }
   const parts = splitShellAndList(gate.command);
@@ -385,7 +450,7 @@ function parseRewriteCi(text) {
         id: jobMatch[1],
         ifExpressions: [],
         runCommands: [],
-        nodeVersions: []
+        nodeVersions: [],
       };
       jobs.push(current);
       continue;
@@ -430,14 +495,18 @@ function parseRewriteCi(text) {
   }
 
   for (const job of jobs) {
-    job.isPullRequestJob = job.ifExpressions.some((expression) => expression.includes("github.event_name == 'pull_request'"));
-    job.isNonPullRequestJob = job.ifExpressions.some((expression) => expression.includes("github.event_name != 'pull_request'"));
+    job.isPullRequestJob = job.ifExpressions.some((expression) =>
+      expression.includes("github.event_name == 'pull_request'"),
+    );
+    job.isNonPullRequestJob = job.ifExpressions.some((expression) =>
+      expression.includes("github.event_name != 'pull_request'"),
+    );
   }
 
   return {
     jobs,
     pullRequestJobs: jobs.filter((job) => job.isPullRequestJob),
-    nonPullRequestJobs: jobs.filter((job) => job.isNonPullRequestJob)
+    nonPullRequestJobs: jobs.filter((job) => job.isNonPullRequestJob),
   };
 }
 
@@ -476,9 +545,7 @@ function splitShellAndList(script) {
 }
 
 function parseManifestRunnerCommand(command) {
-  let normalized = command
-    .replace(/\s+2>&1\s+\|\s+tee\s+artifacts\/gui-e2e\/gui-e2e\.log\s*$/u, "")
-    .trim();
+  let normalized = command.replace(/\s+2>&1\s+\|\s+tee\s+artifacts\/gui-e2e\/gui-e2e\.log\s*$/u, "").trim();
   if (normalized.startsWith("xvfb-run --auto-servernum ")) {
     normalized = normalized.slice("xvfb-run --auto-servernum ".length).trim();
   }
@@ -489,7 +556,7 @@ function parseManifestRunnerCommand(command) {
   const invocation = {
     packageSurface: null,
     workflowJob: null,
-    exclude: new Set()
+    exclude: new Set(),
   };
 
   for (let index = 0; index < args.length; index += 1) {


### PR DESCRIPTION
# English

## Summary

The required `node26-compatibility` check and `full-check (26)` went red five times on 2026-08-28; three of those runs share one signature: `node-pty@1.1.0` ships no Linux prebuild, so `npm ci` runs `node-gyp rebuild`, and `node-gyp@12.4.0` downloads `node-v26.8.1-headers.tar.gz` from nodejs.org — the transfer got HTTP 200 and then aborted (`terminated` / `Completion callback never invoked`). Reruns and an isolated Linux build with local headers succeed on Node 26.8.1, so this is an external transfer failure, not an ABI problem. Fix (decision dec_047D7AD197D9D096837A0BB36B): both Node 26 `npm ci` steps set node-gyp's `nodedir` to the toolcache root of the node selected by `setup-node`, so nothing is downloaded. Two lines replaced, zero net lines; no retry, no `continue-on-error`, no lane demotion.

## Architectural Justification

- Production-Delta as computed: +5/-0; workflow + the export line allow-listed in both tooling checkers (check-gate-surface and check-gate-manifest-invariants keep two copies of the same infrastructure-command list — follow-up task).

## What Changed

- `.github/workflows/rewrite-ci.yml`: in `full-check` and `node26-compatibility`, a step before `npm ci` exports `npm_config_nodedir` (the toolcache root of the node selected by setup-node) to `GITHUB_ENV`; `npm ci` itself is unchanged so the gate-surface check still maps it.
- `tools/check-gate-surface.mjs`, `tools/check-gate-manifest-invariants.mjs`: that export line is listed as an infrastructure command (workspace setup, not a gate).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +5/-0
Dependency-Change: none

### Optional Evidence Claims

## Task And Scope

- Harness task: task_8559db9a0d2faa17acf96fdcdd
- Branch: codex/node26-pty
- Public scope: CI workflow (protected surface) under decision dec_047D7AD1
- Private planning/evidence updated: yes
- Out of scope: The two other main-branch reds in the task brief failed later in GUI tests and are not this cause (task_8559db9a r1.md).

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_8559db9a0d2faa17acf96fdcdd
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-28T17:36Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_8559db9a0d2faa17acf96fdcdd (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Worker (Sol): run-by-run log diff of the five runs; isolated Linux build under Node 26.8.1 with local headers succeeds; report `harness/tasks/task_8559db9a*/artifacts/reports/r1.md`
- [x] CEO: decision dec_047D7AD1 recorded with fact F-D84161CC; diff limited to the two npm ci lines
- [ ] This PR's `node26-compatibility` green, and its `npm ci` log shows no `gyp http` access to nodejs.org
- [ ] After merge: `full-check (26)` green twice on main
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: no local matrix; the lane itself is the test.

## Review Evidence

- Self-review: CEO checked the env var is read by node-gyp (`npm_package_config_node_gyp_nodedir` → `--nodedir`) per node-gyp's config resolution.
- Reviewer subagent: Sol investigated (report-only by checkpoint); CEO landed the diff under the decision.
- Human review: pending
- Blocking findings: none

## Residual Risk

- If setup-node ever stops installing headers, the build would fail loudly at compile time rather than silently downloading — acceptable.

## References

- Task: task_8559db9a0d2faa17acf96fdcdd
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

required 的 `node26-compatibility` 与 `full-check (26)` 在 2026-08-28 红了五次;其中三次同一签名:`node-pty@1.1.0` 没有 Linux prebuild,`npm ci` 走 `node-gyp rebuild`,`node-gyp@12.4.0` 从 nodejs.org 下载 `node-v26.8.1-headers.tar.gz`——HTTP 200 后传输中断(`terminated` / `Completion callback never invoked`)。重跑与本地头文件的隔离 Linux 构建在 Node 26.8.1 上都成功,所以是外部传输故障而非 ABI 问题。修法(决策 dec_047D7AD197D9D096837A0BB36B):两个 Node 26 的 `npm ci` 步骤把 node-gyp 的 `nodedir` 指向 `setup-node` 选中的 toolcache 根,不再下载。替换 2 行、净零行;无重试、无 `continue-on-error`、不降级 lane。

## 架构辩护

- Production-Delta 实算:+5/-0;workflow + 两个 tooling 检查器各登记一行(check-gate-surface 与 check-gate-manifest-invariants 各维护一份相同的基础设施命令表——另立后续任务)。

## 改动内容

- `.github/workflows/rewrite-ci.yml`:`full-check` 与 `node26-compatibility` 在 `npm ci` 前加一步把 `npm_config_nodedir`(setup-node 选中 node 的 toolcache 根)写进 `GITHUB_ENV`;`npm ci` 本身不变,gate-surface 检查仍能映射它。
- `tools/check-gate-surface.mjs`、`tools/check-gate-manifest-invariants.mjs`:该导出行登记为基础设施命令(工作区准备,不是门)。

## 门收割 / Gate Harvest

- 删除的生产路径:无
- 同 commit 删除的门 / fixture:无
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_8559db9a0d2faa17acf96fdcdd
- 分支:codex/node26-pty
- 公开范围:CI workflow(protected surface),依据决策 dec_047D7AD1
- 私有计划 / 证据是否已更新:yes
- 范围外:任务简述里另两次 main 红是后续 GUI 测试失败,与本因无关(task_8559db9a r1.md)。

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_8559db9a0d2faa17acf96fdcdd
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-28T17:36Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_8559db9a0d2faa17acf96fdcdd
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] worker(Sol):五次 run 的逐条日志对比;Node 26.8.1 本地头文件隔离 Linux 构建成功;报告 `harness/tasks/task_8559db9a*/artifacts/reports/r1.md`
- [x] CEO:决策 dec_047D7AD1 已立并挂 fact F-D84161CC;diff 只含两行 npm ci
- [ ] 本 PR 的 `node26-compatibility` 绿,且 `npm ci` 日志无 `gyp http` 访问 nodejs.org
- [ ] 合并后 main 的 `full-check (26)` 连续两次绿
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:不跑本地矩阵;这条 lane 本身就是测试。

## 审查证据

- 自查:CEO 核实 node-gyp 会读该环境变量(`npm_package_config_node_gyp_nodedir` → `--nodedir`)。
- Reviewer subagent:Sol 调查(按 checkpoint 只出报告);CEO 依决策落 diff。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 若 setup-node 以后不再装头文件,构建会在编译期明确失败而不是静默下载——可接受。

## 关联材料

- 任务:task_8559db9a0d2faa17acf96fdcdd
- 证据:任务包 artifacts/reports
- 审查:本 PR
