### PR TITLE
fix(daemon): scheduler and socket share one command-receipt producer

### DIFF
--- a/packages/cli/test/schedule-command.test.ts
+++ b/packages/cli/test/schedule-command.test.ts
@@ -180,7 +180,10 @@ test("Schedule list human renderer shows state, next occurrence, and single-flig
     });
   assert.equal(
     renderScheduleList({
+      schema: "command-receipt/v2",
+      ok: true,
       command: "schedule-list",
+      outcome: "applied",
       evidence: JSON.stringify({
         schema: "schedule-list/v1",
         schedules: [
@@ -210,7 +213,10 @@ test("Schedule list human renderer shows state, next occurrence, and single-flig
   );
   assert.equal(
     renderScheduleList({
+      schema: "command-receipt/v2",
+      ok: true,
       command: "schedule-list",
+      outcome: "applied",
       evidence: JSON.stringify({ schema: "schedule-list/v1", schedules: [] }),
     }),
     "No schedules.",
@@ -218,7 +224,10 @@ test("Schedule list human renderer shows state, next occurrence, and single-flig
   assert.equal(renderScheduleList({ command: "schedule-list", schedules: [] }), null);
   assert.equal(
     renderScheduleList({
+      schema: "command-receipt/v2",
+      ok: true,
       command: "schedule-list",
+      outcome: "applied",
       evidence: JSON.stringify({ schema: "schedule-list/v2", schedules: [] }),
     }),
     null,

--- a/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-validate-results.ts
@@ -45,7 +45,14 @@ export type ScheduleListRow = {
 export function parseScheduleListReceipt(
   receipt: Readonly<Record<string, unknown>>,
 ): readonly ScheduleListRow[] | null {
-  if (typeof receipt.evidence !== "string") return null;
+  if (
+    receipt.schema !== "command-receipt/v2" ||
+    receipt.ok !== true ||
+    receipt.command !== "schedule-list" ||
+    receipt.outcome !== "applied" ||
+    typeof receipt.evidence !== "string"
+  )
+    return null;
   const payload: unknown = JSON.parse(receipt.evidence);
   if (
     !exactRecord(payload, ["schema", "schedules"]) ||
@@ -55,6 +62,40 @@ export function parseScheduleListReceipt(
   )
     return null;
   return payload.schedules;
+}
+
+export function makeDaemonCommandReceipt(command: string, receipt: object): JsonObject {
+  const {
+      schema: _schema,
+      ok: _ok,
+      command: _command,
+      error: _error,
+      ...fields
+    } = receipt as Readonly<Record<string, unknown>>,
+    ok = fields.outcome === "applied" || fields.outcome === "pending" || fields.outcome === "no_changes";
+  return {
+    schema: "command-receipt/v2",
+    ok,
+    command,
+    ...fields,
+    ...(!ok
+      ? {
+          error: {
+            code: typeof fields.code === "string" ? fields.code : "write_rejected",
+            hint: typeof fields.nextAction === "string" ? fields.nextAction : "Inspect the rejection.",
+          },
+        }
+      : {}),
+  } as JsonObject;
+}
+
+export function daemonCommandReceiptRejectionCode(receipt: Readonly<Record<string, unknown>>): string | null {
+  return receipt.schema === "command-receipt/v2" &&
+    receipt.ok === false &&
+    receipt.outcome === "op_rejected" &&
+    nonEmpty(receipt.code)
+    ? receipt.code
+    : null;
 }
 
 function scheduleListRow(value: unknown): value is ScheduleListRow {

--- a/packages/daemon/src/protocol/daemon-protocol.contract.ts
+++ b/packages/daemon/src/protocol/daemon-protocol.contract.ts
@@ -530,7 +530,9 @@ export {
   validateDaemonRelationGraph,
 } from "./daemon-protocol-validate-projections.ts";
 export {
+  daemonCommandReceiptRejectionCode,
   daemonProtocolError,
+  makeDaemonCommandReceipt,
   serializeDaemonAgenda,
   serializeDaemonDecisionList,
   serializeDaemonDocumentRead,

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -13,6 +13,7 @@ import {
   isDaemonGuiReadMethod,
   isDaemonStreamMethod,
   jsonRpcMethodContracts,
+  makeDaemonCommandReceipt,
   parseDaemonRpcParams,
   type DaemonSessionEnvironment,
 } from "./daemon-protocol.contract.ts";
@@ -521,17 +522,8 @@ export function createJsonRpcProtocolServer(options: {
     observed = { ...observed, command: action.kind, executor: declaredExecutorOrNull(action) };
     if (action.kind === "preset-run-start" || action.kind === "preset-run-status")
       return reply((await options.host.presetRun(repo, action, options.authContext)) as unknown as JsonObject);
-    const receipt = await options.host.run(repo, action, options.authContext);
-    const ok = receipt.outcome === "applied" || receipt.outcome === "pending" || receipt.outcome === "no_changes";
-    const result = {
-      schema: "command-receipt/v2",
-      ok,
-      command: action.kind,
-      ...receipt,
-      ...(!ok
-        ? { error: { code: receipt.code ?? "write_rejected", hint: receipt.nextAction ?? "Inspect the rejection." } }
-        : {}),
-    } as unknown as JsonObject;
+    const receipt = await options.host.run(repo, action, options.authContext),
+      result = makeDaemonCommandReceipt(action.kind, receipt);
     return reply(
       isDaemonGuiActionMethod(request.method)
         ? (parseDaemonGuiActionResult(request.method, result) as unknown as JsonObject)

--- a/packages/daemon/src/schedule-scheduler.ts
+++ b/packages/daemon/src/schedule-scheduler.ts
@@ -7,6 +7,7 @@ import {
   parseScheduleListReceipt,
   type ScheduleListRow,
 } from "./protocol/daemon-protocol-validate-results.ts";
+import { cellErrorCode } from "./repo-cell-errors.ts";
 import type { RepoCell, RepoCellBinding } from "./repo-cell.ts";
 
 export const scheduleAdmissionWindowMs = 60_000;
@@ -175,7 +176,7 @@ export function makeScheduleScheduler(input: {
         schedules = await listSchedules(target);
       } catch (error) {
         consumeKnownError(error);
-        if (errorCode(error) === "projection_pending") {
+        if (cellErrorCode(error) === "projection_pending") {
           pending = true;
           continue;
         }
@@ -332,15 +333,6 @@ function occurrenceKey(input: DueOccurrence): string {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-function errorCode(error: unknown): string | null {
-  return typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    typeof (error as { readonly code?: unknown }).code === "string"
-    ? (error as { readonly code: string }).code
-    : null;
 }
 
 function isRejected(outcome: PromiseSettledResult<unknown>): outcome is PromiseRejectedResult {

--- a/packages/daemon/src/schedule-scheduler.ts
+++ b/packages/daemon/src/schedule-scheduler.ts
@@ -1,7 +1,12 @@
 import { consumeKnownError, nextScheduleOccurrence, type ScheduleMissedReason } from "../../kernel/src/index.ts";
 import type { DaemonCommandClass } from "./identity/types.ts";
 import type { JsonObject } from "./protocol/json-rpc-types.ts";
-import { parseScheduleListReceipt, type ScheduleListRow } from "./protocol/daemon-protocol-validate-results.ts";
+import {
+  daemonCommandReceiptRejectionCode,
+  makeDaemonCommandReceipt,
+  parseScheduleListReceipt,
+  type ScheduleListRow,
+} from "./protocol/daemon-protocol-validate-results.ts";
 import type { RepoCell, RepoCellBinding } from "./repo-cell.ts";
 
 export const scheduleAdmissionWindowMs = 60_000;
@@ -82,6 +87,10 @@ export function makeScheduleScheduler(input: {
       armRetry();
       return;
     }
+    if (plan.pending) {
+      armRetry();
+      return;
+    }
     const first = plan.due.sort((left, right) => left.wakeAt.localeCompare(right.wakeAt))[0];
     if (!first) return;
     const delayMs = Math.max(0, Date.parse(first.wakeAt) - Date.parse(now()));
@@ -105,6 +114,10 @@ export function makeScheduleScheduler(input: {
     if (plan.missed.length) {
       if (await applyMissed(plan.missed)) await reconcile();
       else armRetry();
+      return;
+    }
+    if (plan.pending) {
+      armRetry();
       return;
     }
     const observedAt = now(),
@@ -145,14 +158,16 @@ export function makeScheduleScheduler(input: {
   async function evaluationPlan(): Promise<{
     readonly due: DueOccurrence[];
     readonly missed: MissedOccurrences[];
+    readonly pending: boolean;
   }> {
     const observedAt = now(),
       due: DueOccurrence[] = [],
       missed: MissedOccurrences[] = [],
       currentOccurrences = new Set<string>();
+    let pending = false;
     for (const [repoId, cell] of input.cells) {
-      const { mode } = cell.status();
-      if (mode === "remote-center") continue;
+      const { mode, state } = cell.status();
+      if (state !== "attached" || mode === "remote-center") continue;
       const target = targetFor(repoId, cell);
       if (!target) continue;
       let schedules: readonly ScheduleListRow[];
@@ -160,6 +175,14 @@ export function makeScheduleScheduler(input: {
         schedules = await listSchedules(target);
       } catch (error) {
         consumeKnownError(error);
+        if (errorCode(error) === "projection_pending") {
+          pending = true;
+          continue;
+        }
+        if (cell.status().state !== "attached") {
+          console.warn(`[schedule-scheduler] ${repoId} skipped: ${errorMessage(error)}`);
+          continue;
+        }
         console.warn(`[schedule-scheduler] ${repoId} refresh failed: ${errorMessage(error)}`);
         continue;
       }
@@ -183,7 +206,7 @@ export function makeScheduleScheduler(input: {
       }
     }
     for (const key of attempted) if (!currentOccurrences.has(key)) attempted.delete(key);
-    return { due, missed };
+    return { due, missed, pending };
   }
 
   function targetFor(repoId: string, cell: RepoCell): ScheduleTarget | null {
@@ -208,8 +231,11 @@ export function makeScheduleScheduler(input: {
 }
 
 async function listSchedules(target: ScheduleTarget): Promise<readonly ScheduleListRow[]> {
-  const receipt = await target.execute({ kind: "schedule-list" }),
-    schedules = parseScheduleListReceipt(receipt);
+  const receipt = makeDaemonCommandReceipt("schedule-list", await target.execute({ kind: "schedule-list" })),
+    rejectionCode = daemonCommandReceiptRejectionCode(receipt);
+  if (rejectionCode)
+    throw Object.assign(new Error(`Schedule list rejected: ${rejectionCode}.`), { code: rejectionCode });
+  const schedules = parseScheduleListReceipt(receipt);
   if (!schedules) throw new Error("Schedule list receipt evidence is invalid.");
   return schedules;
 }
@@ -306,6 +332,15 @@ function occurrenceKey(input: DueOccurrence): string {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function errorCode(error: unknown): string | null {
+  return typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof (error as { readonly code?: unknown }).code === "string"
+    ? (error as { readonly code: string }).code
+    : null;
 }
 
 function isRejected(outcome: PromiseSettledResult<unknown>): outcome is PromiseRejectedResult {

--- a/packages/daemon/test/schedule-scheduler.test.ts
+++ b/packages/daemon/test/schedule-scheduler.test.ts
@@ -8,7 +8,7 @@ import type { RepoCell } from "../src/repo-cell.ts";
 const actor = { principal: { personId: "schedule-scheduler-test" }, executor: null } as const;
 const localBinding = () => ({ actor, source: "local" as const });
 
-test("schedule-list/v1 receipt evidence arms one Schedule", async () => {
+test("raw RepoCell schedule-list receipt is normalized and arms one Schedule", async () => {
   const clock = fakeClock("2026-08-27T10:00:00.000Z"),
     repo = fixtureRepo("receipt-evidence", "local", [schedule("e2e-probe")]),
     scheduler = makeScheduleScheduler({
@@ -21,6 +21,125 @@ test("schedule-list/v1 receipt evidence arms one Schedule", async () => {
   await scheduler.start();
   assert.equal(clock.liveTimers().length, 1);
   assert.equal(clock.liveTimers()[0]!.delayMs, 30 * 60_000);
+  scheduler.close();
+});
+
+test("projection-pending Schedule reads retry silently and then arm", async () => {
+  const clock = fakeClock("2026-08-27T10:00:00.000Z"),
+    repo = fixtureRepo("projection-pending", "local", [schedule("e2e-probe")]),
+    warnings: string[] = [],
+    originalWarn = console.warn;
+  repo.listReceipts.push({
+    outcome: "op_rejected",
+    opId: "read:schedule-list:projection-pending",
+    code: "projection_pending",
+    origin: "daemon",
+    nextAction: "Entity projection is catching up (4096/41333); retry the read.",
+    evidence: "rejection:projection_pending",
+  });
+  console.warn = (message?: unknown) => warnings.push(String(message));
+  const scheduler = makeScheduleScheduler({
+    cells: new Map([[repo.repoId, repo.cell]]),
+    localBinding,
+    now: clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+  });
+  try {
+    await scheduler.start();
+    assert.equal(clock.liveTimers().length, 1);
+    assert.equal(clock.liveTimers()[0]!.delayMs, 1_000);
+    clock.liveTimers()[0]!.callback();
+    await scheduler.refresh();
+    assert.equal(clock.liveTimers().length, 1);
+    assert.equal(clock.liveTimers()[0]!.delayMs, 30 * 60_000);
+    assert.deepEqual(warnings, []);
+  } finally {
+    console.warn = originalWarn;
+    scheduler.close();
+  }
+});
+
+test("rejected Schedule reads report their code without parsing rejection evidence", async () => {
+  const clock = fakeClock("2026-08-27T10:00:00.000Z"),
+    repo = fixtureRepo("rejected", "local", []),
+    warnings: string[] = [],
+    originalWarn = console.warn;
+  repo.listReceipts.push({
+    outcome: "op_rejected",
+    opId: "read:schedule-list:rejected",
+    code: "repo_unavailable",
+    origin: "daemon",
+    nextAction: "Repair the repository data shape.",
+    evidence: "rejection:repo_unavailable",
+  });
+  console.warn = (message?: unknown) => warnings.push(String(message));
+  const scheduler = makeScheduleScheduler({
+    cells: new Map([[repo.repoId, repo.cell]]),
+    localBinding,
+    now: clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+  });
+  try {
+    await scheduler.start();
+    assert.deepEqual(warnings, [
+      "[schedule-scheduler] rejected refresh failed: Schedule list rejected: repo_unavailable.",
+    ]);
+    assert.equal(clock.liveTimers().length, 0);
+  } finally {
+    console.warn = originalWarn;
+    scheduler.close();
+  }
+});
+
+test("a Schedule rejection that latches its RepoCell is reported once as skipped", async () => {
+  const clock = fakeClock("2026-08-27T10:00:00.000Z"),
+    repo = fixtureRepo("latched", "local", []),
+    warnings: string[] = [],
+    originalWarn = console.warn;
+  repo.listReceipts.push({
+    outcome: "op_rejected",
+    opId: "read:schedule-list:latched",
+    code: "service_rejected",
+    origin: "daemon",
+    nextAction: "fact event payload is invalid",
+    evidence: "rejection:service_rejected",
+  });
+  repo.latchOnRejection = true;
+  console.warn = (message?: unknown) => warnings.push(String(message));
+  const scheduler = makeScheduleScheduler({
+    cells: new Map([[repo.repoId, repo.cell]]),
+    localBinding,
+    now: clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+  });
+  try {
+    await scheduler.start();
+    await scheduler.refresh();
+    assert.deepEqual(warnings, ["[schedule-scheduler] latched skipped: Schedule list rejected: service_rejected."]);
+    assert.equal(repo.actions.length, 1);
+  } finally {
+    console.warn = originalWarn;
+    scheduler.close();
+  }
+});
+
+test("unavailable RepoCells are outside scheduler refresh", async () => {
+  const clock = fakeClock("2026-08-27T10:00:00.000Z"),
+    repo = fixtureRepo("unavailable", "local", [schedule("never-read")]),
+    scheduler = makeScheduleScheduler({
+      cells: new Map([[repo.repoId, repo.cell]]),
+      localBinding,
+      now: clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+    });
+  repo.state = "unavailable";
+  await scheduler.start();
+  assert.deepEqual(repo.actions, []);
+  assert.equal(clock.liveTimers().length, 0);
   scheduler.close();
 });
 
@@ -239,19 +358,24 @@ function fixtureRepo(repoId: string, mode: DaemonRepoMode, schedules: MutableSch
     actions,
     fired,
     missed,
+    listReceipts: [] as Array<Readonly<Record<string, unknown>>>,
+    latchOnRejection: false,
+    state: "attached" as "attached" | "unavailable",
     onFire: async (_scheduleId: string) => {},
     execute: async (action: Readonly<Record<string, unknown>>) => {
       actions.push(String(action.kind));
       if (action.kind === "schedule-list") {
+        const queuedReceipt = fixture.listReceipts.shift();
+        if (queuedReceipt) {
+          if (fixture.latchOnRejection) fixture.state = "unavailable";
+          return queuedReceipt;
+        }
         const rows = schedules.map((value) => ({
           ...value,
           definitionRevision: 1,
           nextRunAt: value.state === "armed" ? "2026-08-27T10:30:00.000Z" : null,
         }));
         return {
-          schema: "command-receipt/v2",
-          ok: true,
-          command: "schedule-list",
           outcome: "applied",
           opId: `read:schedule-list:${repoId}`,
           revision: 1,
@@ -297,7 +421,7 @@ function fixtureRepo(repoId: string, mode: DaemonRepoMode, schedules: MutableSch
       repoId,
       rootDir: `/tmp/${repoId}`,
       mode,
-      state: "attached",
+      state: fixture.state,
       generation: 1,
       queueDepth: 0,
       lastError: null,


### PR DESCRIPTION
# English

## Summary

After PR #1981 the canonical daemon still logged `canonical refresh failed: Schedule list receipt omitted schedules` every cycle, and `refresh failed: Unexpected token 'r', "rejection:"... is not valid JSON` for attached repos, so no schedule was ever armed. Root cause (isolated daemon seeded from a copy of canonical's 41,334-event ledger): the in-daemon scheduler called `RepoCell.run({kind:"schedule-list"})` and received the raw write receipt, while `json-rpc-server.ts` attached `schema/ok/command/error` only on the socket path — the scheduler then `JSON.parse`d `rejection:projection_pending`. Fix: one `command-receipt/v2` producer shared by the socket server and the scheduler; the scheduler checks `ok/outcome/code` before touching `evidence`, lets a transient `projection_pending` cut ride the existing one-second refresh timer, and skips RepoCells whose daemon state is no longer `attached`. On the seeded ledger the daemon cold-started from an empty projection, reached `armed canonical/e2e-probe`, and logged zero `refresh failed` lines. Production +80/-18.

## Architectural Justification

- Production-Delta as computed: the shared receipt producer (+) replaces the socket-only envelope and the scheduler's parse-first path (-); the rest is scheduler tests with the real seeded receipts.

## What Changed

- `packages/daemon/src/protocol/daemon-protocol-validate-results.ts`, `daemon-protocol.contract.ts`: one receipt producer.
- `packages/daemon/src/protocol/json-rpc-server.ts`: uses it instead of attaching the envelope inline.
- `packages/daemon/src/schedule-scheduler.ts`: rejection-aware refresh; attached-only cells.
- Tests: `schedule-scheduler.test.ts` (raw in-daemon rejection, projection_pending ride-through, detached cell), `schedule-command.test.ts`.

## Gate Harvest / 门收割

Deleted-Production-Paths: the socket-only inline receipt envelope in `json-rpc-server.ts` and the scheduler's parse-before-check path
Deleted-Gates-Fixtures: scheduler test fixtures that fed a pre-enveloped receipt (replaced by the raw seeded receipts)
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +80/-18
Dependency-Change: none

### Optional Evidence Claims

## Task And Scope

- Harness task: task_d1af10322848e7c95cc65dbc0f
- Branch: codex/scheduler-canonical
- Public scope: packages/daemon protocol receipt producer + json-rpc server + schedule scheduler + tests
- Private planning/evidence updated: yes
- Out of scope: Schedule productisation (task_39e58593: occurrence claim, run history, GUI) follows once this is on canonical.

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_d1af10322848e7c95cc65dbc0f
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-28T18:15Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_d1af10322848e7c95cc65dbc0f (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Worker (Sol): seeded isolated daemon (copy of canonical, hermetic preflight) — both raw receipts captured verbatim in r1.md; cold start → `armed canonical/e2e-probe`, 0 `refresh failed`; scheduler + schedule-command tests green
- [x] CEO: read both receipts (same opId, different envelope) and confirmed no second payload shape was taught
- [x] production-delta computed
- [ ] CI on this PR; after merge CEO restarts canonical and watches 5 min of log + one e2e-probe occurrence
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO checked the fix is one producer, not a compatibility branch (grep: envelope attached in one place).
- Reviewer subagent: Sol implemented; CEO semantic acceptance against task_d1af1032's plan (one producer, one receipt shape).
- Human review: pending
- Blocking findings: none

## Residual Risk

- Repos whose ledger never yields a schedule payload are now skipped when not attached; if a repo is attached but permanently rejected, the log will say so with the code instead of a JSON error.

## References

- Task: task_d1af10322848e7c95cc65dbc0f
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

#1981 之后 canonical daemon 仍每轮记 `canonical refresh failed: Schedule list receipt omitted schedules`,附属仓则记 `refresh failed: Unexpected token 'r', "rejection:"... is not valid JSON`,任何 schedule 从未 arm。根因(用 canonical 41,334 个事件的副本喂隔离 daemon):daemon 内的 scheduler 调 `RepoCell.run({kind:"schedule-list"})` 拿到的是原始写回执,而 `json-rpc-server.ts` 只在 socket 路径上附加 `schema/ok/command/error`——scheduler 于是对 `rejection:projection_pending` 做 `JSON.parse`。修法:socket server 与 scheduler 共用一个 `command-receipt/v2` 生产者;scheduler 先看 `ok/outcome/code` 再碰 `evidence`,瞬时的 `projection_pending` 用既有一秒刷新定时器自然跟进,daemon 状态不再 `attached` 的 RepoCell 跳过。在种子台账上 daemon 从空 projection 冷启动,到达 `armed canonical/e2e-probe`,零条 `refresh failed`。生产 +80/-18。

## 架构辩护

- Production-Delta 实算:共享回执生产者(+)替换 socket 独有的信封与 scheduler 先 parse 的路径(-);其余是用真实种子回执写的 scheduler 测试。

## 改动内容

- `packages/daemon/src/protocol/daemon-protocol-validate-results.ts`、`daemon-protocol.contract.ts`:唯一回执生产者。
- `packages/daemon/src/protocol/json-rpc-server.ts`:改用它,不再内联附信封。
- `packages/daemon/src/schedule-scheduler.ts`:识别拒绝的刷新;只处理 attached 的 cell。
- 测试:`schedule-scheduler.test.ts`(daemon 内原始拒绝、projection_pending 跟进、detached cell)、`schedule-command.test.ts`。

## 门收割 / Gate Harvest

- 删除的生产路径:`json-rpc-server.ts` 里 socket 独有的内联回执信封,以及 scheduler 先 parse 后检查的路径
- 同 commit 删除的门 / fixture:喂预封装回执的 scheduler 测试 fixture(改为真实种子回执)
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_d1af10322848e7c95cc65dbc0f
- 分支:codex/scheduler-canonical
- 公开范围:packages/daemon 协议回执生产者 + json-rpc server + 定时调度器 + 测试
- 私有计划 / 证据是否已更新:yes
- 范围外:定时任务产品化(task_39e58593:occurrence claim、运行历史、GUI)在本 PR 上 canonical 后接续。

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_d1af10322848e7c95cc65dbc0f
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-28T18:15Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_d1af10322848e7c95cc65dbc0f
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] worker(Sol):种子隔离 daemon(canonical 副本,hermetic preflight)——两份原始回执逐字录入 r1.md;冷启动 → `armed canonical/e2e-probe`,0 条 `refresh failed`;scheduler + schedule-command 测试绿
- [x] CEO:读了两份回执(同 opId、不同信封),确认没有教 parser 第二种 payload 形状
- [x] production-delta 实算
- [ ] 本 PR 的 CI;合并后 CEO 重启 canonical,看 5 分钟日志 + 一次 e2e-probe occurrence
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 核实是单一生产者而非兼容分支(grep:信封只在一处附加)。
- Reviewer subagent:Sol 实现;CEO 按 task_d1af1032 的 plan(一个生产者、一种回执形状)验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 未 attached 的仓现在跳过;若某仓 attached 但持续被拒,日志会带拒绝码而不是 JSON 错误。

## 关联材料

- 任务:task_d1af10322848e7c95cc65dbc0f
- 证据:任务包 artifacts/reports
- 审查:本 PR
