### PR TITLE
fix(daemon): forward relation graph facet reads through the resolved projection (main build hotfix)

### DIFF
--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -462,6 +462,7 @@ export function createRepoCellApi(context: any): RepoCell {
       agenda: (query) => currentQueryRead().agenda(query),
       guiTasks: (query) => currentQueryRead().guiTasks(query),
       relationGraph: () => currentQueryRead().relationGraph(),
+      relationGraphFacet: (query) => currentQueryRead().relationGraphFacet(query),
       relationGraphPage: (query) => currentQueryRead().relationGraphPage(query),
     };
   Object.assign(context.extracted, { taskListQueryFromAction, queryRead, relationQueryFromAction });


### PR DESCRIPTION
# English

## Summary

origin/main 0f9c06f6 does not build: PR #1983 (per-read projection resolution in `repo-cell-api.ts`) and PR #1987 (`relationGraphFacet` / decision `summary` projection on `TaskQueryReadModel`) merged cleanly in git but not in types — `repo-cell-api.ts(461,5): TS2741 Property 'relationGraphFacet' is missing … required in type 'TaskQueryReadModel'`. This forwards the facet read through the same per-read projection resolver as the other read-model members (no second construction path). Build green; json-rpc-protocol and repo-cell-latch-recovery tests green.

## Architectural Justification

- Production-Delta as computed: a forwarding member on the read model; nothing else.

## What Changed

- `packages/daemon/src/repo-cell-api.ts`: `relationGraphFacet` forwarded via the resolved projection.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +1/-0
Dependency-Change: none

### Optional Evidence Claims

## Task And Scope

- Harness task: task_e75157a2d1538a71726603aeef
- Branch: codex/hotfix-facet-merge
- Public scope: packages/daemon repo-cell-api read model (hotfix for a semantic merge conflict)
- Private planning/evidence updated: yes
- Out of scope: Why two green PRs produced a red main — each PR's CI ran on its own merge with the main of that moment; the second merge never re-ran the first. Rule follow-up: rebase-before-merge when two PRs touch the same file (recorded as a fact on task_e75157a2).

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_e75157a2d1538a71726603aeef
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-28T18:37Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_e75157a2d1538a71726603aeef (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Worker (Sol): `npm -w packages/cli run build` green; `node --test packages/daemon/test/json-rpc-protocol.test.ts packages/daemon/test/repo-cell-latch-recovery.test.ts` green
- [x] CEO: reproduced TS2741 on a fresh worktree from origin/main; build green on this branch
- [ ] CI on this PR
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO checked the fix is one forwarding member, not a duplicated read model.
- Reviewer subagent: Sol (author of both parents) fixed; CEO acceptance.
- Human review: pending
- Blocking findings: none

## Residual Risk

- none beyond the ordinary.

## References

- Task: task_e75157a2d1538a71726603aeef
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

origin/main 0f9c06f6 编不过:PR #1983(`repo-cell-api.ts` 每次读解析 projection)与 PR #1987(`TaskQueryReadModel` 上的 `relationGraphFacet` / decision `summary` projection)在 git 层合并干净、类型层没有——`repo-cell-api.ts(461,5): TS2741 Property 'relationGraphFacet' is missing … required in type 'TaskQueryReadModel'`。本 PR 把 facet 读经同一个每次读的 projection 解析器转发(不加第二条构造路径)。构建绿;json-rpc-protocol 与 repo-cell-latch-recovery 测试绿。

## 架构辩护

- Production-Delta 实算:读模型上一个转发成员;别无其它。

## 改动内容

- `packages/daemon/src/repo-cell-api.ts`:`relationGraphFacet` 经解析后的 projection 转发。

## 门收割 / Gate Harvest

- 删除的生产路径:无
- 同 commit 删除的门 / fixture:无
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_e75157a2d1538a71726603aeef
- 分支:codex/hotfix-facet-merge
- 公开范围:packages/daemon repo-cell-api 读模型(语义合并冲突热修)
- 私有计划 / 证据是否已更新:yes
- 范围外:两个绿 PR 合出红 main 的原因——各自 CI 跑在各自当时的 merge 上,第二个合并没有重跑第一个。规则后续:两 PR 触同一文件时合并前 rebase(记 fact 于 task_e75157a2)。

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_e75157a2d1538a71726603aeef
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-28T18:37Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_e75157a2d1538a71726603aeef
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] worker(Sol):`npm -w packages/cli run build` 绿;`node --test packages/daemon/test/json-rpc-protocol.test.ts packages/daemon/test/repo-cell-latch-recovery.test.ts` 绿
- [x] CEO:在 origin/main 新 worktree 上复现 TS2741;本分支构建绿
- [ ] 本 PR 的 CI
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 核实只是一个转发成员,不是复制的读模型。
- Reviewer subagent:Sol(两侧作者)修复;CEO 验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 无特别风险。

## 关联材料

- 任务:task_e75157a2d1538a71726603aeef
- 证据:任务包 artifacts/reports
- 审查:本 PR
