### PR TITLE
feat(daemon): expose runtime GitHub token to gh

### DIFF
--- a/packages/daemon/src/agent-runtime-instance-store.ts
+++ b/packages/daemon/src/agent-runtime-instance-store.ts
@@ -312,6 +312,7 @@ export function openRuntimeInstanceStore(input: {
     if (!secret)
       throw runtimeInstanceError("runtime_credential_unavailable", "The configured GitHub credential is unavailable.");
     return {
+      GH_TOKEN: secret,
       HARNESS_GITHUB_TOKEN: secret,
       GIT_ASKPASS_REQUIRE: "force",
       GIT_TERMINAL_PROMPT: "0",

--- a/packages/daemon/test/runtime-worker-github-credential-binding.test.ts
+++ b/packages/daemon/test/runtime-worker-github-credential-binding.test.ts
@@ -94,6 +94,7 @@ test("set, unset, and show project only GitHub credential state without rebuildi
       environment = await store.prepareWorkerGitEnvironment("codex-github-worker"),
       shown = store.command({ kind: "runtime-instance-show", instanceId: "codex-github-worker" });
     assert.deepEqual(environment, {
+      GH_TOKEN: secret,
       HARNESS_GITHUB_TOKEN: secret,
       GIT_ASKPASS_REQUIRE: "force",
       GIT_TERMINAL_PROMPT: "0",

--- a/packages/daemon/test/runtime-worker-github-credentials.integration.test.ts
+++ b/packages/daemon/test/runtime-worker-github-credentials.integration.test.ts
@@ -90,6 +90,7 @@ test("task-bound runtime settlement pushes only its own codex branch with the bo
         const taskBound = prepared.env.HARNESS_TASK_BOUND === "1";
         if (taskBound) {
           taskBoundLaunches += 1;
+          assert.equal(prepared.env.GH_TOKEN, secret);
           assert.equal(prepared.env.HARNESS_GITHUB_TOKEN, secret);
           assert.equal(prepared.env.GIT_ASKPASS, path.join(root, "tools", "git-hooks", "git-askpass"));
           mainPush = spawnSync("git", ["-C", workerRoot, "push", "origin", "HEAD:main"], {
@@ -98,6 +99,7 @@ test("task-bound runtime settlement pushes only its own codex branch with the bo
             env: prepared.env,
           });
         } else {
+          assert.equal(prepared.env.GH_TOKEN, undefined);
           assert.equal(prepared.env.HARNESS_GITHUB_TOKEN, undefined);
           assert.equal(prepared.env.GIT_ASKPASS, undefined);
         }


### PR DESCRIPTION
# English

## Summary

Worker runtimes spawned by the daemon had no GitHub credential usable by `gh` (fact F-080D14AD): the runtime-instance credential path exported only `HARNESS_GITHUB_TOKEN` for Git askpass, so `ci-triage-squad` could not read run logs. `prepareWorkerGitEnvironment` now also exports `GH_TOKEN` with the same resolved secret. Task, schedule and squad launches all pass through that one function; no Person binding, no declaration schema bump, no scope inference (token permissions stay a GitHub-side property, per CEO ruling r2 rejecting the three proposed abstractions).

## Architectural Justification

- Production-Delta as computed: one environment variable on the existing credential path.

## What Changed

- `packages/daemon/src/agent-runtime-instance-store.ts`: `GH_TOKEN` beside `HARNESS_GITHUB_TOKEN`.
- `runtime-worker-github-credential-binding.test.ts`, `runtime-worker-github-credentials.integration.test.ts`: assert both variables (bound) / neither (unbound).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +1/-0
Dependency-Change: none

### Optional Evidence Claims

## Task And Scope

- Harness task: task_8d64f19a1834c14dbc6c721660
- Branch: codex/runtime-gh-credential
- Public scope: daemon runtime-instance worker environment
- Private planning/evidence updated: yes
- Out of scope: Configuring a read-only fine-grained token on each runtime instance and verifying `gh pr merge` is rejected — a GitHub configuration step done by the CEO out of band.

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_8d64f19a1834c14dbc6c721660
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-28T18:54Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_8d64f19a1834c14dbc6c721660 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Worker (Sol) via `tools/dispatch-isolated-test.mjs`: credential-binding test 2/2, credentials integration test 1/1 green
- [x] CEO read the diff: exactly one added line in production
- [ ] CI on this PR
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO rejected the r1 proposal (new credential entity, declaration v2, center-to-edge grants) as speculative abstraction; this is the narrowed r2.
- Reviewer subagent: Sol implemented; CEO acceptance.
- Human review: pending
- Blocking findings: none

## Residual Risk

- None beyond the ordinary; the secret already reached the worker process, only the variable name `gh` reads is added.

## References

- Task: task_8d64f19a1834c14dbc6c721660
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

daemon 派出的 worker runtime 没有 `gh` 可用的 GitHub 凭据(fact F-080D14AD):runtime instance 凭据路径只为 Git askpass 导出 `HARNESS_GITHUB_TOKEN`,`ci-triage-squad` 读不了 run 日志。`prepareWorkerGitEnvironment` 现在同时导出同一 secret 的 `GH_TOKEN`。task / schedule / squad 三种 launch 都经这一个函数;不做 Person 绑定、不 bump 声明 schema、不推断 scope(token 权限是 GitHub 侧属性,CEO 裁决 r2 驳回了三项拟议抽象)。

## 架构辩护

- Production-Delta 实算:现有凭据路径上多一个环境变量。

## 改动内容

- `packages/daemon/src/agent-runtime-instance-store.ts`:`HARNESS_GITHUB_TOKEN` 旁增加 `GH_TOKEN`。
- 两个既有凭据测试:绑定时两个变量都在 / 未绑定时都不在。

## 门收割 / Gate Harvest

- 删除的生产路径:无
- 同 commit 删除的门 / fixture:无
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_8d64f19a1834c14dbc6c721660
- 分支:codex/runtime-gh-credential
- 公开范围:daemon runtime instance 的 worker 环境
- 私有计划 / 证据是否已更新:yes
- 范围外:在每个 runtime instance 上配置只读 fine-grained token 并验证 `gh pr merge` 被拒——CEO 在 GitHub 侧手动完成。

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_8d64f19a1834c14dbc6c721660
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-28T18:54Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_8d64f19a1834c14dbc6c721660
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] worker(Sol)经 `tools/dispatch-isolated-test.mjs`:binding 测试 2/2、integration 测试 1/1 绿
- [x] CEO 读 diff:生产代码恰好加一行
- [ ] 本 PR 的 CI
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 驳回 r1 提案(新凭据实体、声明 v2、中心到边缘授权)为猜测性抽象;本 PR 是收窄后的 r2。
- Reviewer subagent:Sol 实现;CEO 验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 无特别风险;secret 本就进入 worker 进程,只是加了 `gh` 读取的变量名。

## 关联材料

- 任务:task_8d64f19a1834c14dbc6c721660
- 证据:任务包 artifacts/reports
- 审查:本 PR
