### PR TITLE
fix(runtime): keep lease through sibling archive settlement

### DIFF
--- a/packages/cli/src/cli-runtime-batch.ts
+++ b/packages/cli/src/cli-runtime-batch.ts
@@ -41,8 +41,8 @@ export async function runRuntimeBatchDeclaration(
       },
       writeActivity,
     );
-  // Concurrent task-bound entries share one execution lease, and the first of them to reach a
-  // terminal dispatch state releases it. The batch cannot predict when that lands, so a dispatch
+  // Concurrent task-bound entries keep one execution lease through their final live sibling. A
+  // worker can still reach its next entry after an earlier generation was released, so a dispatch
   // spawns first and only a runtime_task_lease_required rejection reacquires the lease and
   // resubmits once under the same idempotency key — the rejected spawn wrote no ledger event, so
   // the resubmit is not a duplicate dispatch. The resubmit, not the reacquisition receipt, decides

--- a/packages/cli/test/runtime-cli.integration.test.ts
+++ b/packages/cli/test/runtime-cli.integration.test.ts
@@ -870,8 +870,15 @@ test("real CLI runs, archives task-bound dispatches, resumes, waits through stat
       true,
       JSON.stringify(batchDispatches),
     );
-    const slowBatchArchive = path.join(artifactRoot, "dispatches", `${String(batchRows[1]?.dispatchId)}.json`);
-    await eventuallyFile(slowBatchArchive);
+    const batchArchives = batchRows
+      .slice(1)
+      .map((row) => path.join(artifactRoot, "dispatches", `${String(row.dispatchId)}.json`));
+    assert.deepEqual(
+      batchArchives.filter((archive) => !existsSync(archive)),
+      [],
+      "runtime batch returned before every dispatch archive became visible",
+    );
+    const slowBatchArchive = batchArchives[0]!;
     assert.equal(
       (JSON.parse(readFileSync(slowBatchArchive, "utf8")) as Record<string, unknown>).reasoningEffort,
       "high",

--- a/packages/daemon/src/runtime-spawn-settlement.ts
+++ b/packages/daemon/src/runtime-spawn-settlement.ts
@@ -135,11 +135,24 @@ export async function publishExit(context: any, active: ActiveRuntime, code: num
     }
     context.processes.delete(active.runtimeSessionId);
     active.process.release?.();
+    const completedTask = active.task,
+      terminalTask =
+        completedTask &&
+        [...(context.processes as Map<string, ActiveRuntime>).values()].some(
+          (candidate) =>
+            candidate.task?.taskId === completedTask.taskId &&
+            candidate.task.executionId === completedTask.executionId &&
+            candidate.task.leaseVersion === completedTask.leaseVersion,
+        )
+          ? null
+          : completedTask;
+    // Every sibling archives while the generation that authorized it is still held. The final
+    // live sibling alone releases that generation, after all earlier siblings made their files visible.
     await context
       .settleFallback(active, attemptOutcome, {
         runtimeSessionId: active.runtimeSessionId,
         dispatchId: active.dispatchId,
-        task: active.task,
+        task: terminalTask,
         schedule: active.schedule,
         outcome: outcome === "succeeded" ? "succeeded" : "failed",
         reason: outcome === "succeeded" ? null : attemptOutcome.reason,


### PR DESCRIPTION
# English

## Summary

`runtime-cli.integration.test.ts` failed 2/10 (9/10 baseline on the isolated target) at the same 10 s `eventuallyFile` wait: concurrent task-bound dispatches share one execution lease generation and the first terminal sibling released it before a slower sibling called `archiveRuntimeDispatch`, so that archive was rejected as a lease conflict, swallowed by the daemon, and the CLI returned before the file existed. The spawner now withholds task-lease settlement while another live process authorized by the same `taskId`/`executionId`/`leaseVersion` remains; the final live sibling releases it. The test now asserts every archive exists when the CLI returns instead of polling. Isolated target: 10/10 twice.

## Architectural Justification

- Production-Delta as computed: the ordering assumption is removed at its owner (`runtime-spawn-settlement.ts`), no retry/timeout/second archive path.

## What Changed

- `packages/daemon/src/runtime-spawn-settlement.ts`: settle the task lease only from the final live sibling.
- `packages/cli/src/cli-runtime-batch.ts`: comment corrected.
- `packages/cli/test/runtime-cli.integration.test.ts`: assert archives exist at return.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +16/-3
Dependency-Change: none

### Optional Evidence Claims

## Task And Scope

- Harness task: task_310f3e84cc2703e3e6e777f965
- Branch: codex/flake-cli-archive
- Public scope: daemon runtime spawn settlement for concurrent task-bound dispatches
- Private planning/evidence updated: yes
- Out of scope: fleet-dual-sync flake still unclassified.

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_310f3e84cc2703e3e6e777f965
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-28T20:01Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_310f3e84cc2703e3e6e777f965 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Worker (Sol): isolated `runtime-cli.integration.test.ts` baseline 9/10, after fix 10/10 twice (report r1.md)
- [x] CEO read the diff: settlement withheld while a same-generation sibling is live; no swallow path added
- [ ] CI on this PR
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO checked no timeout was raised and the old first-terminal-release ordering is gone, not guarded.
- Reviewer subagent: Sol implemented after ci-triage-squad classification; CEO acceptance.
- Human review: pending
- Blocking findings: none

## Residual Risk

- A sibling that never exits would hold the lease generation open; it is bounded by the existing runtime cancel/teardown paths.

## References

- Task: task_310f3e84cc2703e3e6e777f965
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

`runtime-cli.integration.test.ts` 在同一个 10 秒 `eventuallyFile` 等待处 2/10 红(隔离目标基线 9/10):并发的 task 绑定 dispatch 共用一个 execution lease 代,第一个到终态的兄弟在更慢的兄弟调用 `archiveRuntimeDispatch` 前就释放了它,该归档被当作 lease 冲突拒绝、daemon 吞掉,CLI 在文件落地前返回。spawner 现在只要还有同一 `taskId`/`executionId`/`leaseVersion` 授权的活进程就不结算 task lease;最后一个活兄弟负责释放。测试改为断言 CLI 返回时所有归档已存在,不再轮询。隔离目标:两批 10/10。

## 架构辩护

- Production-Delta 实算:在所有者 `runtime-spawn-settlement.ts` 处删除顺序假设,无重试/超时/第二条归档路径。

## 改动内容

- `packages/daemon/src/runtime-spawn-settlement.ts`:只由最后一个活兄弟结算 task lease。
- `packages/cli/src/cli-runtime-batch.ts`:修正注释。
- `packages/cli/test/runtime-cli.integration.test.ts`:断言返回时归档已存在。

## 门收割 / Gate Harvest

- 删除的生产路径:无
- 同 commit 删除的门 / fixture:无
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_310f3e84cc2703e3e6e777f965
- 分支:codex/flake-cli-archive
- 公开范围:daemon 并发 task 绑定 dispatch 的 spawn 结算
- 私有计划 / 证据是否已更新:yes
- 范围外:fleet-dual-sync 抖动仍未分类。

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_310f3e84cc2703e3e6e777f965
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-28T20:01Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_310f3e84cc2703e3e6e777f965
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] worker(Sol):隔离目标基线 9/10,修后两批 10/10(报告 r1.md)
- [x] CEO 读 diff:同代兄弟存活时不结算;未新增吞错路径
- [ ] 本 PR 的 CI
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 核实未加超时,旧的「首个终态释放」顺序被删除而非加护栏。
- Reviewer subagent:ci-triage-squad 分类后 Sol 实现;CEO 验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 永不退出的兄弟会一直持有该 lease 代;由既有 runtime cancel/teardown 路径封顶。

## 关联材料

- 任务:task_310f3e84cc2703e3e6e777f965
- 证据:任务包 artifacts/reports
- 审查:本 PR
