### PR TITLE
refactor(tools): single gate infrastructure allowlist; npm_package_config_node_gyp_nodedir

### DIFF
--- a/.github/workflows/rewrite-ci.yml
+++ b/.github/workflows/rewrite-ci.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
-      - run: echo "npm_config_nodedir=$(dirname "$(dirname "$(command -v node)")")" >> "$GITHUB_ENV"
+      - run: echo "npm_package_config_node_gyp_nodedir=$(dirname "$(dirname "$(command -v node)")")" >> "$GITHUB_ENV"
       - run: npm ci
       - run: git diff --check
       - run: sudo apt-get update && sudo apt-get install -y xvfb
@@ -389,7 +389,7 @@ jobs:
         with:
           node-version: 26
           cache: npm
-      - run: echo "npm_config_nodedir=$(dirname "$(dirname "$(command -v node)")")" >> "$GITHUB_ENV"
+      - run: echo "npm_package_config_node_gyp_nodedir=$(dirname "$(dirname "$(command -v node)")")" >> "$GITHUB_ENV"
       - run: npm ci
       - run: node tools/run-manifest-gates.mjs --workflow-job node26-compatibility
       - name: Upload structured CI observation artifact

--- a/tools/check-gate-manifest-invariants.mjs
+++ b/tools/check-gate-manifest-invariants.mjs
@@ -4,22 +4,11 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { deriveProtectedSurfaceRules } from "./check-pr-governance.mjs";
+import { INFRASTRUCTURE_COMMANDS } from "./gate-infrastructure-commands.mjs";
 
 const DEFAULT_ROOT = process.cwd();
 const SURFACE_CLASSES = new Set(["local", "pr", "main-full", "nightly", "manual"]);
 const POSITIVE_CONTROL_STATUSES = new Set(["covered", "documented-gap", "not-applicable"]);
-const INFRASTRUCTURE_COMMANDS = new Set([
-  "npm ci",
-  // Node 26 lanes export node-gyp's nodedir from the setup-node toolchain (dec_047D7AD197D9D096837A0BB36B).
-  'echo "npm_config_nodedir=$(dirname "$(dirname "$(command -v node)")")" >> "$GITHUB_ENV"',
-  "git diff --check",
-  "sudo apt-get update && sudo apt-get install -y xvfb",
-  // Building the packaged bin and configuring the checkout are properties of the runner, not
-  // gates: no manifest gate can declare them because they run before any gate does.
-  "npm run build -w @harness-anything/cli",
-  "git config --global core.autocrlf true"
-]);
-
 export function checkGateManifestInvariants(root = DEFAULT_ROOT) {
   const manifest = readJson(path.join(root, "tools/gate-manifest.json"));
   const workflow = parseWorkflow(readFileSync(path.join(root, ".github/workflows/rewrite-ci.yml"), "utf8"));
@@ -43,8 +32,8 @@ export function checkGateManifestInvariants(root = DEFAULT_ROOT) {
     counts: {
       gates: gates.length,
       deterministic: gates.filter((gate) => gate.deterministic === true).length,
-      findings: findings.length
-    }
+      findings: findings.length,
+    },
   };
 }
 
@@ -60,19 +49,21 @@ function checkProtectedSurfaceCoverage(manifest, root, findings) {
   const trackedFiles = readTrackedFiles(root);
   for (const declaration of declarations) {
     const rules = deriveProtectedSurfaceRules({
-      gates: [{
-        id: declaration.gateId,
-        changeControl: {
-          requiresGovernanceEvidence: true,
-          protectedSurfaces: [declaration.surface]
-        }
-      }]
+      gates: [
+        {
+          id: declaration.gateId,
+          changeControl: {
+            requiresGovernanceEvidence: true,
+            protectedSurfaces: [declaration.surface],
+          },
+        },
+      ],
     });
     const matchesTrackedFile = trackedFiles.some((file) => rules.some((rule) => rule.matcher(file)));
     if (!matchesTrackedFile) {
       const derivedRules = rules.map((rule) => JSON.stringify(rule.display)).join(", ") || "none";
       findings.push(
-        `${declaration.gateId} protected surface ${JSON.stringify(declaration.surface)} matches no tracked files (derived rules: ${derivedRules})`
+        `${declaration.gateId} protected surface ${JSON.stringify(declaration.surface)} matches no tracked files (derived rules: ${derivedRules})`,
       );
     }
   }
@@ -81,7 +72,7 @@ function checkProtectedSurfaceCoverage(manifest, root, findings) {
 function readTrackedFiles(root) {
   const result = spawnSync("git", ["ls-files", "-z"], {
     cwd: root,
-    encoding: "utf8"
+    encoding: "utf8",
   });
   if (result.status !== 0) {
     throw new Error(`git ls-files failed: ${(result.stderr || result.stdout).trim()}`);
@@ -117,8 +108,8 @@ function checkWorkflowCommands(manifest, workflow, gates, findings) {
       }
       for (const gate of matchingGates) {
         const declaredJobs = job.isPullRequestJob
-          ? gate.executionSurfaces?.rewriteCi?.pullRequestJobs ?? []
-          : gate.executionSurfaces?.rewriteCi?.nonPullRequestJobs ?? [];
+          ? (gate.executionSurfaces?.rewriteCi?.pullRequestJobs ?? [])
+          : (gate.executionSurfaces?.rewriteCi?.nonPullRequestJobs ?? []);
         if (!declaredJobs.includes(job.id)) {
           findings.push(`workflow job ${job.id} runs ${gate.id}, but that gate does not declare the job`);
         }
@@ -193,11 +184,7 @@ function parseManifestRunner(command) {
   if (!match) return null;
   const args = match[1] ?? "";
   const workflowJob = /(?:^|\s)--workflow-job\s+(\S+)/u.exec(args)?.[1] ?? null;
-  const excludes = new Set(
-    (/(?:^|\s)--exclude\s+(\S+)/u.exec(args)?.[1] ?? "")
-      .split(",")
-      .filter(Boolean)
-  );
+  const excludes = new Set((/(?:^|\s)--exclude\s+(\S+)/u.exec(args)?.[1] ?? "").split(",").filter(Boolean));
   return { workflowJob, excludes };
 }
 
@@ -232,8 +219,12 @@ function parseWorkflow(text) {
   }
 
   for (const job of jobs.values()) {
-    job.isPullRequestJob = job.ifExpressions.some((expression) => expression.includes("github.event_name == 'pull_request'"));
-    job.isNonPullRequestJob = job.ifExpressions.some((expression) => expression.includes("github.event_name != 'pull_request'"));
+    job.isPullRequestJob = job.ifExpressions.some((expression) =>
+      expression.includes("github.event_name == 'pull_request'"),
+    );
+    job.isNonPullRequestJob = job.ifExpressions.some((expression) =>
+      expression.includes("github.event_name != 'pull_request'"),
+    );
   }
   return jobs;
 }
@@ -272,8 +263,11 @@ function checkClassificationFields(gate, findings) {
   if (!positiveControl || !POSITIVE_CONTROL_STATUSES.has(positiveControl.status)) {
     findings.push(`${gate.id} must declare positiveControl.status as covered, documented-gap, or not-applicable`);
   }
-  if (!Array.isArray(positiveControl?.evidence) || positiveControl.evidence.length === 0
-    || positiveControl.evidence.some((entry) => typeof entry !== "string" || entry.trim() === "")) {
+  if (
+    !Array.isArray(positiveControl?.evidence) ||
+    positiveControl.evidence.length === 0 ||
+    positiveControl.evidence.some((entry) => typeof entry !== "string" || entry.trim() === "")
+  ) {
     findings.push(`${gate.id} must declare non-empty positiveControl.evidence`);
   }
 }
@@ -316,7 +310,9 @@ function parseArgs(argv) {
 
 function printResult(result) {
   if (result.ok) {
-    console.log(`Gate manifest invariants passed (${result.counts.deterministic}/${result.counts.gates} deterministic gates).`);
+    console.log(
+      `Gate manifest invariants passed (${result.counts.deterministic}/${result.counts.gates} deterministic gates).`,
+    );
     return;
   }
   console.error(`Gate manifest invariants failed with ${result.findings.length} finding(s):`);

--- a/tools/check-gate-manifest-invariants.test.mjs
+++ b/tools/check-gate-manifest-invariants.test.mjs
@@ -16,7 +16,7 @@ test("accepts a consistent deterministic gate on local, PR, and main-full surfac
     writeFixture(root, {
       deterministic: true,
       surfaceClasses: ["local", "pr", "main-full"],
-      pullRequestJobs: ["boundaries"]
+      pullRequestJobs: ["boundaries"],
     });
 
     const result = runChecker(root);
@@ -33,7 +33,7 @@ test("positive control rejects a deterministic gate without the PR execution sur
     writeFixture(root, {
       deterministic: true,
       surfaceClasses: ["local", "main-full"],
-      pullRequestJobs: []
+      pullRequestJobs: [],
     });
 
     const result = runChecker(root);
@@ -51,12 +51,15 @@ test("rejects manifest workflow execution surfaces that drift from the actual jo
       deterministic: true,
       surfaceClasses: ["local", "pr", "main-full"],
       pullRequestJobs: ["boundaries"],
-      workflowRun: "echo manifest runner was removed"
+      workflowRun: "echo manifest runner was removed",
     });
 
     const result = runChecker(root);
     assert.equal(result.status, 1);
-    assert.match(result.stderr, /example-gate declares PR workflow job boundaries, but its command is absent from that job/u);
+    assert.match(
+      result.stderr,
+      /example-gate declares PR workflow job boundaries, but its command is absent from that job/u,
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -74,8 +77,8 @@ test("rejects an actual PR gate job that is absent from the manifest workflow in
         "    if: github.event_name == 'pull_request'",
         "    runs-on: ubuntu-latest",
         "    steps:",
-        "      - run: npm run harness:extra-gate"
-      ]
+        "      - run: npm run harness:extra-gate",
+      ],
     });
 
     const result = runChecker(root);
@@ -93,12 +96,15 @@ test("rejects a main-full declaration when the full-check aggregate step drifts"
       deterministic: true,
       surfaceClasses: ["local", "pr", "main-full"],
       pullRequestJobs: ["boundaries"],
-      fullCheckRun: "echo full check was removed"
+      fullCheckRun: "echo full check was removed",
     });
 
     const result = runChecker(root);
     assert.equal(result.status, 1);
-    assert.match(result.stderr, /example-gate declares non-PR workflow job full-check, but its command is absent from that job/u);
+    assert.match(
+      result.stderr,
+      /example-gate declares non-PR workflow job full-check, but its command is absent from that job/u,
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -110,7 +116,7 @@ test("rejects canonical PR surface labels without a declared PR workflow job", (
     writeFixture(root, {
       deterministic: false,
       surfaceClasses: ["local", "pr", "main-full"],
-      pullRequestJobs: []
+      pullRequestJobs: [],
     });
 
     const result = runChecker(root);
@@ -121,14 +127,14 @@ test("rejects canonical PR surface labels without a declared PR workflow job", (
   }
 });
 
-test("rejects an unmanifested command added to an existing PR gate job", () => {
+test("rejects a workflow command absent from the shared infrastructure list", () => {
   const root = makeFixtureRoot();
   try {
     writeFixture(root, {
       deterministic: true,
       surfaceClasses: ["local", "pr", "main-full"],
       pullRequestJobs: ["boundaries"],
-      workflowRun: "npm run harness:unmanifested"
+      workflowRun: "npm run harness:unmanifested",
     });
 
     const result = runChecker(root);
@@ -150,13 +156,13 @@ test("rejects protected surfaces that match no tracked files", () => {
         "tools/example-gate.mjs",
         "packages/gui/e2e",
         "packages/kernel/fixtures/canonical-events/",
-        "decision:dec_example"
+        "decision:dec_example",
       ],
       trackedFiles: [
         "tools/example-gate.mjs",
         "packages/gui/e2e/example.e2e.mjs",
-        "packages/kernel/fixtures/canonical-events/example.json"
-      ]
+        "packages/kernel/fixtures/canonical-events/example.json",
+      ],
     });
 
     const result = runChecker(root);
@@ -177,24 +183,27 @@ function makeFixtureRoot() {
   return root;
 }
 
-function writeFixture(root, {
-  deterministic,
-  surfaceClasses,
-  pullRequestJobs,
-  workflowRun = "node tools/run-manifest-gates.mjs --workflow-job boundaries",
-  workflowExtra = [],
-  fullCheckRun = "npm run check",
-  protectedSurfaces = [],
-  trackedFiles = []
-}) {
+function writeFixture(
+  root,
+  {
+    deterministic,
+    surfaceClasses,
+    pullRequestJobs,
+    workflowRun = "node tools/run-manifest-gates.mjs --workflow-job boundaries",
+    workflowExtra = [],
+    fullCheckRun = "npm run check",
+    protectedSurfaces = [],
+    trackedFiles = [],
+  },
+) {
   const manifest = {
     schema: "harness-anything/gate-manifest/v2",
     surfaces: {
       rewriteCi: {
         pullRequestGateJobs: ["boundaries"],
         helperJobsNotRegisteredAsGates: [],
-        nonPullRequestGateJobs: ["full-check"]
-      }
+        nonPullRequestGateJobs: ["full-check"],
+      },
     },
     gates: [
       {
@@ -204,37 +213,39 @@ function writeFixture(root, {
         deterministic: false,
         positiveControl: {
           status: "not-applicable",
-          evidence: ["Composite runner; leaf gates own positive controls."]
+          evidence: ["Composite runner; leaf gates own positive controls."],
         },
         executionSurfaces: {
           classes: ["local", "main-full"],
           packageJson: { check: true, checkPr: false, script: "check" },
           rewriteCi: { pullRequestJobs: [], nonPullRequestJobs: ["full-check"] },
-          branchProtection: { required: false, contexts: [] }
-        }
+          branchProtection: { required: false, contexts: [] },
+        },
       },
       {
         id: "example-gate",
         command: "npm run harness:example-gate",
         deterministic,
-        ...(protectedSurfaces.length > 0 ? {
-          changeControl: {
-            requiresGovernanceEvidence: true,
-            protectedSurfaces
-          }
-        } : {}),
+        ...(protectedSurfaces.length > 0
+          ? {
+              changeControl: {
+                requiresGovernanceEvidence: true,
+                protectedSurfaces,
+              },
+            }
+          : {}),
         positiveControl: {
           status: "covered",
-          evidence: ["tools/example-gate.test.mjs"]
+          evidence: ["tools/example-gate.test.mjs"],
         },
         executionSurfaces: {
           classes: surfaceClasses,
           packageJson: { check: true, checkPr: true, script: "harness:example-gate" },
           rewriteCi: { pullRequestJobs, nonPullRequestJobs: ["full-check"] },
-          branchProtection: { required: true, contexts: ["boundaries"] }
-        }
-      }
-    ]
+          branchProtection: { required: true, contexts: ["boundaries"] },
+        },
+      },
+    ],
   };
   const workflow = [
     "name: rewrite-ci",
@@ -251,7 +262,7 @@ function writeFixture(root, {
     "    steps:",
     `      - run: ${workflowRun}`,
     ...workflowExtra,
-    ""
+    "",
   ].join("\n");
 
   writeFileSync(path.join(root, "tools/gate-manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
@@ -278,6 +289,6 @@ function runChecker(root) {
   return spawnSync(process.execPath, [checkerPath, "--root", root], {
     cwd: repoRoot,
     encoding: "utf8",
-    env: process.env
+    env: process.env,
   });
 }

--- a/tools/check-gate-surface.mjs
+++ b/tools/check-gate-surface.mjs
@@ -15,24 +15,11 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { boundaryAllowlistAuthorityFindings } from "./gate-surface-boundary-policy.mjs";
+import { INFRASTRUCTURE_COMMANDS } from "./gate-infrastructure-commands.mjs";
 import { selectManifestGateIds } from "./run-manifest-gates.mjs";
 
 const DEFAULT_ROOT = process.cwd();
 const MANIFEST_GATE_RUNNER = "node tools/run-manifest-gates.mjs";
-const INFRASTRUCTURE_RUN_COMMANDS = new Set([
-  "npm ci",
-  // Node 26 lanes build node-pty from setup-node's local headers instead of downloading them
-  // (dec_047D7AD197D9D096837A0BB36B); the export is workspace setup, not a gate.
-  'echo "npm_config_nodedir=$(dirname "$(dirname "$(command -v node)")")" >> "$GITHUB_ENV"',
-  "git diff --check",
-  "mkdir -p artifacts/gui-e2e",
-  "sudo apt-get update && sudo apt-get install -y xvfb",
-  // The first-run gate exercises the packaged bin, so the bin has to exist before it runs.
-  "npm run build -w @harness-anything/cli",
-  // Setting the checkout to convert line endings is the crlf-checkout job's whole point; it is
-  // a property of the checkout, not a gate command, so no manifest gate can declare it.
-  "git config --global core.autocrlf true"
-]);
 
 export function checkGateSurface(root = DEFAULT_ROOT) {
   const findings = [];
@@ -63,8 +50,8 @@ export function checkGateSurface(root = DEFAULT_ROOT) {
       packageCheckCommands: splitShellAndList(packageScripts.check ?? "").length,
       packageCheckPrCommands: splitShellAndList(packageScripts["check:pr"] ?? "").length,
       pullRequestJobs: workflow.pullRequestJobs.length,
-      branchProtectionContexts: branchContexts.length
-    }
+      branchProtectionContexts: branchContexts.length,
+    },
   };
 }
 
@@ -74,27 +61,27 @@ function checkPackageScripts({ findings, manifest, gates, gatesById, commandToGa
     aggregateName: "check",
     commands: splitShellAndList(packageScripts.check ?? ""),
     manifest,
-    commandToGateIds
+    commandToGateIds,
   });
   const actualCheckPrIds = mapAggregateCommands({
     findings,
     aggregateName: "check:pr",
     commands: splitShellAndList(packageScripts["check:pr"] ?? ""),
     manifest,
-    commandToGateIds
+    commandToGateIds,
   });
 
   compareIdSets({
     findings,
     label: "package.json scripts.check",
     expected: manifest.surfaces?.packageJson?.check ?? [],
-    actual: actualCheckIds
+    actual: actualCheckIds,
   });
   compareIdSets({
     findings,
     label: "package.json scripts.check:pr",
     expected: manifest.surfaces?.packageJson?.checkPr ?? [],
-    actual: actualCheckPrIds
+    actual: actualCheckPrIds,
   });
 
   for (const gate of gates) {
@@ -105,16 +92,20 @@ function checkPackageScripts({ findings, manifest, gates, gatesById, commandToGa
     }
 
     if (!gate.aggregate && Boolean(packageSurface.check) !== actualCheckIds.includes(gate.id)) {
-      findings.push(formatFinding(
-        "package-json",
-        `${gate.id} executionSurfaces.packageJson.check=${packageSurface.check} but scripts.check membership is ${actualCheckIds.includes(gate.id)}.`
-      ));
+      findings.push(
+        formatFinding(
+          "package-json",
+          `${gate.id} executionSurfaces.packageJson.check=${packageSurface.check} but scripts.check membership is ${actualCheckIds.includes(gate.id)}.`,
+        ),
+      );
     }
     if (!gate.aggregate && Boolean(packageSurface.checkPr) !== actualCheckPrIds.includes(gate.id)) {
-      findings.push(formatFinding(
-        "package-json",
-        `${gate.id} executionSurfaces.packageJson.checkPr=${packageSurface.checkPr} but scripts.check:pr membership is ${actualCheckPrIds.includes(gate.id)}.`
-      ));
+      findings.push(
+        formatFinding(
+          "package-json",
+          `${gate.id} executionSurfaces.packageJson.checkPr=${packageSurface.checkPr} but scripts.check:pr membership is ${actualCheckPrIds.includes(gate.id)}.`,
+        ),
+      );
     }
 
     if (packageSurface.check || packageSurface.checkPr || packageSurface.script) {
@@ -122,7 +113,10 @@ function checkPackageScripts({ findings, manifest, gates, gatesById, commandToGa
     }
   }
 
-  for (const id of [...(manifest.surfaces?.packageJson?.check ?? []), ...(manifest.surfaces?.packageJson?.checkPr ?? [])]) {
+  for (const id of [
+    ...(manifest.surfaces?.packageJson?.check ?? []),
+    ...(manifest.surfaces?.packageJson?.checkPr ?? []),
+  ]) {
     if (!gatesById.has(id)) {
       findings.push(formatFinding("package-json", `manifest.surfaces.packageJson references unknown gate id ${id}.`));
     }
@@ -131,38 +125,50 @@ function checkPackageScripts({ findings, manifest, gates, gatesById, commandToGa
 
 function checkRewriteCi({ findings, manifest, gates, workflow, commandToGateIds }) {
   const helperJobs = manifest.surfaces?.rewriteCi?.helperJobsNotRegisteredAsGates ?? [];
-  const actualPullRequestGateJobs = workflow.pullRequestJobs.filter((job) => !helperJobs.includes(job.id)).map((job) => job.id);
+  const actualPullRequestGateJobs = workflow.pullRequestJobs
+    .filter((job) => !helperJobs.includes(job.id))
+    .map((job) => job.id);
   const actualNonPullRequestGateJobs = workflow.nonPullRequestJobs.map((job) => job.id);
 
   compareIdSets({
     findings,
     label: ".github/workflows/rewrite-ci.yml pull_request gate jobs",
     expected: manifest.surfaces?.rewriteCi?.pullRequestGateJobs ?? [],
-    actual: actualPullRequestGateJobs
+    actual: actualPullRequestGateJobs,
   });
   compareIdSets({
     findings,
     label: ".github/workflows/rewrite-ci.yml non-pull_request gate jobs",
     expected: manifest.surfaces?.rewriteCi?.nonPullRequestGateJobs ?? [],
-    actual: actualNonPullRequestGateJobs
+    actual: actualNonPullRequestGateJobs,
   });
 
   const jobsById = new Map(workflow.jobs.map((job) => [job.id, job]));
   for (const job of workflow.pullRequestJobs.filter((candidate) => !helperJobs.includes(candidate.id))) {
     for (const command of job.runCommands) {
-      if (INFRASTRUCTURE_RUN_COMMANDS.has(command)) {
+      if (INFRASTRUCTURE_COMMANDS.has(command)) {
         continue;
       }
       const runnerInvocation = parseManifestRunnerCommand(command);
       if (runnerInvocation) {
         if (runnerInvocation.workflowJob !== job.id) {
-          findings.push(formatFinding("rewrite-ci", `${job.id} runs manifest gate runner for ${runnerInvocation.workflowJob ?? "no workflow job"}.`));
+          findings.push(
+            formatFinding(
+              "rewrite-ci",
+              `${job.id} runs manifest gate runner for ${runnerInvocation.workflowJob ?? "no workflow job"}.`,
+            ),
+          );
         }
         continue;
       }
       const mappedIds = commandToGateIds.get(command) ?? [];
       if (mappedIds.length === 0) {
-        findings.push(formatFinding("rewrite-ci", `${job.id} runs ${JSON.stringify(command)} but no manifest gate declares that command.`));
+        findings.push(
+          formatFinding(
+            "rewrite-ci",
+            `${job.id} runs ${JSON.stringify(command)} but no manifest gate declares that command.`,
+          ),
+        );
       }
     }
   }
@@ -176,16 +182,28 @@ function checkRewriteCi({ findings, manifest, gates, workflow, commandToGateIds 
 
     if (gate.tier === "pr-required") {
       if ((rewriteSurface.pullRequestJobs ?? []).length === 0) {
-        findings.push(formatFinding("rewrite-ci", `${gate.id} is pr-required but declares no pull-request workflow job.`));
+        findings.push(
+          formatFinding("rewrite-ci", `${gate.id} is pr-required but declares no pull-request workflow job.`),
+        );
       }
       for (const jobId of rewriteSurface.pullRequestJobs ?? []) {
         const job = jobsById.get(jobId);
         if (!job || !job.isPullRequestJob) {
-          findings.push(formatFinding("rewrite-ci", `${gate.id} expects pull-request job ${jobId}, but that job is not a pull_request job.`));
+          findings.push(
+            formatFinding(
+              "rewrite-ci",
+              `${gate.id} expects pull-request job ${jobId}, but that job is not a pull_request job.`,
+            ),
+          );
           continue;
         }
         if (!jobRunsGateCommand({ job, gate, manifest, gates })) {
-          findings.push(formatFinding("rewrite-ci", `${gate.id} expects ${jobId} to run ${JSON.stringify(gate.command)}, but the command is absent.`));
+          findings.push(
+            formatFinding(
+              "rewrite-ci",
+              `${gate.id} expects ${jobId} to run ${JSON.stringify(gate.command)}, but the command is absent.`,
+            ),
+          );
         }
       }
     }
@@ -198,7 +216,7 @@ function checkBranchProtection({ findings, manifest, gates, branchContexts }) {
     findings,
     label: ".github/branch-protection.md required contexts",
     expected: manifestContexts,
-    actual: branchContexts
+    actual: branchContexts,
   });
 
   const declaredRequiredContexts = new Set();
@@ -210,16 +228,18 @@ function checkBranchProtection({ findings, manifest, gates, branchContexts }) {
     }
     const gateContexts = gate.githubContext?.requiredContexts ?? [];
     if (Boolean(branchSurface.required) !== gateContexts.length > 0) {
-      findings.push(formatFinding(
-        "branch-protection",
-        `${gate.id} executionSurfaces.branchProtection.required=${branchSurface.required} but githubContext.requiredContexts has ${gateContexts.length} entries.`
-      ));
+      findings.push(
+        formatFinding(
+          "branch-protection",
+          `${gate.id} executionSurfaces.branchProtection.required=${branchSurface.required} but githubContext.requiredContexts has ${gateContexts.length} entries.`,
+        ),
+      );
     }
     compareIdSets({
       findings,
       label: `${gate.id} branch protection contexts`,
       expected: gateContexts,
-      actual: branchSurface.contexts ?? []
+      actual: branchSurface.contexts ?? [],
     });
 
     if (gate.tier === "pr-required" && gateContexts.length === 0) {
@@ -228,14 +248,24 @@ function checkBranchProtection({ findings, manifest, gates, branchContexts }) {
     for (const context of gateContexts) {
       declaredRequiredContexts.add(context);
       if (!branchContexts.includes(context)) {
-        findings.push(formatFinding("branch-protection", `${gate.id} requires context ${context}, but .github/branch-protection.md does not list it.`));
+        findings.push(
+          formatFinding(
+            "branch-protection",
+            `${gate.id} requires context ${context}, but .github/branch-protection.md does not list it.`,
+          ),
+        );
       }
     }
   }
 
   for (const context of branchContexts) {
     if (!declaredRequiredContexts.has(context)) {
-      findings.push(formatFinding("branch-protection", `.github/branch-protection.md lists ${context}, but no manifest gate declares that required context.`));
+      findings.push(
+        formatFinding(
+          "branch-protection",
+          `.github/branch-protection.md lists ${context}, but no manifest gate declares that required context.`,
+        ),
+      );
     }
   }
 }
@@ -276,7 +306,12 @@ function mapAggregateCommands({ findings, aggregateName, commands, manifest, com
     if (runnerInvocation) {
       const expandedIds = expandManifestRunnerIds({ invocation: runnerInvocation, manifest });
       if (runnerInvocation.packageSurface === null) {
-        findings.push(formatFinding("package-json", `package.json scripts.${aggregateName} uses manifest gate runner without --package-surface.`));
+        findings.push(
+          formatFinding(
+            "package-json",
+            `package.json scripts.${aggregateName} uses manifest gate runner without --package-surface.`,
+          ),
+        );
       }
       ids.push(...expandedIds);
       continue;
@@ -284,7 +319,12 @@ function mapAggregateCommands({ findings, aggregateName, commands, manifest, com
 
     const mappedIds = commandToGateIds.get(command) ?? [];
     if (mappedIds.length === 0) {
-      findings.push(formatFinding("package-json", `package.json scripts.${aggregateName} contains ${JSON.stringify(command)} but no manifest gate declares that command.`));
+      findings.push(
+        formatFinding(
+          "package-json",
+          `package.json scripts.${aggregateName} contains ${JSON.stringify(command)} but no manifest gate declares that command.`,
+        ),
+      );
       continue;
     }
     ids.push(...mappedIds);
@@ -310,7 +350,12 @@ function checkCommandResolvableInPackageScripts({ findings, gate, packageScripts
 
   for (const scriptName of new Set(commandScriptNames)) {
     if (!Object.hasOwn(packageScripts, scriptName)) {
-      findings.push(formatFinding("package-json", `${gate.id} references package script ${scriptName}, but package.json does not define it.`));
+      findings.push(
+        formatFinding(
+          "package-json",
+          `${gate.id} references package script ${scriptName}, but package.json does not define it.`,
+        ),
+      );
     }
   }
 }
@@ -319,7 +364,11 @@ function jobRunsGateCommand({ job, gate, manifest, gates }) {
   if (job.runCommands.includes(gate.command)) {
     return true;
   }
-  if (job.runCommands.some((command) => manifestRunnerCoversGate({ command, gateId: gate.id, workflowJob: job.id, manifest }))) {
+  if (
+    job.runCommands.some((command) =>
+      manifestRunnerCoversGate({ command, gateId: gate.id, workflowJob: job.id, manifest }),
+    )
+  ) {
     return true;
   }
   const parts = splitShellAndList(gate.command);
@@ -388,7 +437,7 @@ function parseRewriteCi(text) {
         id: jobMatch[1],
         ifExpressions: [],
         runCommands: [],
-        nodeVersions: []
+        nodeVersions: [],
       };
       jobs.push(current);
       continue;
@@ -433,14 +482,18 @@ function parseRewriteCi(text) {
   }
 
   for (const job of jobs) {
-    job.isPullRequestJob = job.ifExpressions.some((expression) => expression.includes("github.event_name == 'pull_request'"));
-    job.isNonPullRequestJob = job.ifExpressions.some((expression) => expression.includes("github.event_name != 'pull_request'"));
+    job.isPullRequestJob = job.ifExpressions.some((expression) =>
+      expression.includes("github.event_name == 'pull_request'"),
+    );
+    job.isNonPullRequestJob = job.ifExpressions.some((expression) =>
+      expression.includes("github.event_name != 'pull_request'"),
+    );
   }
 
   return {
     jobs,
     pullRequestJobs: jobs.filter((job) => job.isPullRequestJob),
-    nonPullRequestJobs: jobs.filter((job) => job.isNonPullRequestJob)
+    nonPullRequestJobs: jobs.filter((job) => job.isNonPullRequestJob),
   };
 }
 
@@ -479,9 +532,7 @@ function splitShellAndList(script) {
 }
 
 function parseManifestRunnerCommand(command) {
-  let normalized = command
-    .replace(/\s+2>&1\s+\|\s+tee\s+artifacts\/gui-e2e\/gui-e2e\.log\s*$/u, "")
-    .trim();
+  let normalized = command.replace(/\s+2>&1\s+\|\s+tee\s+artifacts\/gui-e2e\/gui-e2e\.log\s*$/u, "").trim();
   if (normalized.startsWith("xvfb-run --auto-servernum ")) {
     normalized = normalized.slice("xvfb-run --auto-servernum ".length).trim();
   }
@@ -492,7 +543,7 @@ function parseManifestRunnerCommand(command) {
   const invocation = {
     packageSurface: null,
     workflowJob: null,
-    exclude: new Set()
+    exclude: new Set(),
   };
 
   for (let index = 0; index < args.length; index += 1) {

--- a/tools/check-gate-surface.test.mjs
+++ b/tools/check-gate-surface.test.mjs
@@ -90,6 +90,29 @@ test("gate surface check rejects a PR workflow lane that no longer runs a requir
   }
 });
 
+test("gate surface check rejects a workflow command absent from the shared infrastructure list", () => {
+  const root = makeFixtureRoot();
+  try {
+    writeFixture(root, {
+      workflow(workflow) {
+        return workflow.replace(
+          "      - run: npm run harness:check-import-boundaries\n",
+          "      - run: npm run harness:check-import-boundaries\n      - run: npm run harness:unmanifested\n",
+        );
+      },
+    });
+
+    const result = runChecker(root);
+    assert.notEqual(result.status, 0);
+    assert.match(
+      result.stderr,
+      /boundaries runs "npm run harness:unmanifested" but no manifest gate declares that command/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("gate surface check accepts a GUI E2E manifest runner wrapped by xvfb and tee", () => {
   const root = makeFixtureRoot();
   try {

--- a/tools/gate-infrastructure-commands.mjs
+++ b/tools/gate-infrastructure-commands.mjs
@@ -1,0 +1,19 @@
+/**
+ * Workflow setup commands that do not correspond to manifest gates.
+ *
+ * Both gate-manifest checkers use this set to distinguish runner setup from
+ * unmanifested gate commands in rewrite-ci.yml.
+ */
+export const INFRASTRUCTURE_COMMANDS = new Set([
+  "npm ci",
+  // Node 26 lanes build node-pty from setup-node's local headers instead of downloading them
+  // (dec_047D7AD197D9D096837A0BB36B); the export is workspace setup, not a gate.
+  'echo "npm_package_config_node_gyp_nodedir=$(dirname "$(dirname "$(command -v node)")")" >> "$GITHUB_ENV"',
+  "git diff --check",
+  "mkdir -p artifacts/gui-e2e",
+  "sudo apt-get update && sudo apt-get install -y xvfb",
+  // Building the packaged bin and configuring the checkout are properties of the runner, not
+  // gates: no manifest gate can declare them because they run before any gate does.
+  "npm run build -w @harness-anything/cli",
+  "git config --global core.autocrlf true",
+]);


### PR DESCRIPTION
# English

## Summary

`tools/check-gate-surface.mjs` and `tools/check-gate-manifest-invariants.mjs` each kept their own INFRASTRUCTURE command allowlist, so every new workflow `run:` line had to be added twice (PR #1985 hit this). The allowlist now lives once in `tools/gate-infrastructure-commands.mjs` and both checkers import it; negative controls confirm an unlisted command is reported by both. In the same change the deprecated `npm_config_nodedir` export in the two Node 26 workflow steps becomes its npm 11 successor `npm_package_config_node_gyp_nodedir` (decision dec_C19FF6ABF8C427EBFD5A93F12D, refines dec_047D7AD197D9D096837A0BB36B); the node26-compatibility lane passes locally under Node v26.8.1.

## Architectural Justification

- Production-Delta as computed: one shared set replaces two hand-maintained copies; the workflow edit is a two-line rename covered by dec_C19FF6ABF8C427EBFD5A93F12D.

## What Changed

- `tools/gate-infrastructure-commands.mjs` (new, single source).
- `tools/check-gate-surface.mjs`, `tools/check-gate-manifest-invariants.mjs`: import it; own copies deleted.
- their `.test.mjs`: negative controls for an unlisted command.
- `.github/workflows/rewrite-ci.yml`: `npm_config_nodedir` → `npm_package_config_node_gyp_nodedir` in full-check and node26-compatibility.

## Gate Harvest / 门收割

Deleted-Production-Paths: the two per-checker INFRASTRUCTURE allowlists inside check-gate-surface.mjs and check-gate-manifest-invariants.mjs; the deprecated npm_config_nodedir export
Deleted-Gates-Fixtures: node --test tools/check-gate-surface.test.mjs tools/check-gate-manifest-invariants.test.mjs (18 pass); both checkers green; node26-compatibility manifest job green under Node v26.8.1
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +159/-93
Dependency-Change: none

### Optional Evidence Claims

## Task And Scope

- Harness task: task_b8a8dcd2359fd21fd5c09032cb
- Branch: codex/gate-allowlist-dedupe
- Public scope: gate checkers' infrastructure allowlist; two workflow env exports
- Private planning/evidence updated: yes
- Out of scope: none

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_b8a8dcd2359fd21fd5c09032cb
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-28T22:16Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_b8a8dcd2359fd21fd5c09032cb (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Worker (Terra): checker tests 18/18; both checkers green; `npx --yes node@26 tools/run-manifest-gates.mjs --workflow-job node26-compatibility` passed under v26.8.1
- [x] CEO: decision dec_C19FF6ABF8C427EBFD5A93F12D accepted for the protected-surface rename
- [ ] CI on this PR
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO checked the workflow diff is exactly the two-line rename and the shared set is the only allowlist left.
- Reviewer subagent: Terra implemented; CEO acceptance + decision.
- Human review: pending
- Blocking findings: none

## Residual Risk

- If npm on the CI runner predates the successor variable, node-gyp falls back to downloading headers (the pre-#1985 behaviour) — CI on this PR is the check.

## References

- Task: task_b8a8dcd2359fd21fd5c09032cb
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

`tools/check-gate-surface.mjs` 与 `tools/check-gate-manifest-invariants.mjs` 各自维护一份 INFRASTRUCTURE 命令 allowlist,每加一条 workflow `run:` 都要写两遍(PR #1985 踩过)。现在 allowlist 只在 `tools/gate-infrastructure-commands.mjs` 存一份,两个检查器都导入它;阴性对照证明未登记命令会被两者同时报出。同一改动把两个 Node 26 workflow 步骤里已弃用的 `npm_config_nodedir` 导出改为 npm 11 后继名 `npm_package_config_node_gyp_nodedir`(decision dec_C19FF6ABF8C427EBFD5A93F12D,refines dec_047D7AD197D9D096837A0BB36B);node26-compatibility lane 本地在 Node v26.8.1 下通过。

## 架构辩护

- Production-Delta 实算:一个共享集合替代两份手工副本;workflow 改动是两行重命名,由 dec_C19FF6ABF8C427EBFD5A93F12D 覆盖。

## 改动内容

- `tools/gate-infrastructure-commands.mjs`(新增,唯一来源)。
- 两个检查器导入它,各自副本删除。
- 两个 `.test.mjs`:未登记命令的阴性对照。
- `rewrite-ci.yml`:full-check 与 node26-compatibility 中 `npm_config_nodedir` → `npm_package_config_node_gyp_nodedir`。

## 门收割 / Gate Harvest

- 删除的生产路径:两个检查器内各自的 INFRASTRUCTURE allowlist;已弃用的 npm_config_nodedir 导出
- 同 commit 删除的门 / fixture:两个检查器测试 18 通过;两个检查器绿;node26-compatibility manifest job 在 Node v26.8.1 下绿
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_b8a8dcd2359fd21fd5c09032cb
- 分支:codex/gate-allowlist-dedupe
- 公开范围:gate 检查器的 infrastructure allowlist;两处 workflow 环境导出
- 私有计划 / 证据是否已更新:yes
- 范围外:无

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_b8a8dcd2359fd21fd5c09032cb
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-28T22:16Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_b8a8dcd2359fd21fd5c09032cb
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] worker(Terra):检查器测试 18/18;两个检查器绿;node26-compatibility 在 v26.8.1 下通过
- [x] CEO:保护面重命名已由 decision dec_C19FF6ABF8C427EBFD5A93F12D 裁决
- [ ] 本 PR 的 CI
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 核实 workflow diff 恰为两行重命名,共享集合是唯一剩余 allowlist。
- Reviewer subagent:Terra 实现;CEO 验收并裁决。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- 若 CI runner 的 npm 早于后继变量,node-gyp 退回下载头文件(#1985 前行为)——本 PR 的 CI 即验证。

## 关联材料

- 任务:task_b8a8dcd2359fd21fd5c09032cb
- 证据:任务包 artifacts/reports
- 审查:本 PR
