### PR TITLE
fix(ci): stream vitest default reporter alongside the json reporter

### DIFF
--- a/tools/run-gui-tests.mjs
+++ b/tools/run-gui-tests.mjs
@@ -45,7 +45,9 @@ const quarantinePattern =
     ? excludedTestNamePattern(readTestQuarantine(repoRoot).map((entry) => entry.test))
     : null;
 const vitestArgs = [
-  ...(vitestResults ? ["--reporter=json", `--outputFile=${vitestResults}`] : []),
+  ...(vitestResults
+    ? ["--reporter=default", "--reporter=json", `--outputFile=${resolve(repoRoot, vitestResults)}`]
+    : []),
   ...(quarantinePattern ? [`--testNamePattern=${quarantinePattern}`] : []),
 ];
 const observationArgs = vitestArgs.length > 0 ? ["--", ...vitestArgs] : [];


### PR DESCRIPTION
# English

## Summary

When `full-check (26)` failed on main (runs 33186389071, 33192909821, 33195881502) the log showed only `npm error Lifecycle script test:gui failed`: `tools/run-gui-tests.mjs` passed a lone `--reporter=json`, which suppresses vitest's console reporter, and the observation artifact is produced by `run-manifest-gates.mjs`, which never runs once `npm run check` aborts at `test:gui`. The runner now passes `--reporter=default --reporter=json` and resolves the JSON output path against the repo root, so failing test names and assertions stream into the job log while the structured file is unchanged.

## Architectural Justification

- Production-Delta as computed: a reporter list change in one tooling script; no workflow edit.

## What Changed

- `tools/run-gui-tests.mjs`: `--reporter=default --reporter=json --outputFile=<repoRoot>/tmp/ci-observation/vitest.json`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: use the single CI-backed `Production-Delta` declaration below; do not enter a second metric.

## Machine-Readable Declarations

Production-Delta: +3/-1
Dependency-Change: none

### Optional Evidence Claims

## Task And Scope

- Harness task: task_be666ead5d6625d9f7c84d0923
- Branch: codex/ci-observability
- Public scope: GUI vitest runner used by CI
- Private planning/evidence updated: yes
- Out of scope: Uploading ci-observation on failed arms (would need a workflow change; not needed once the log carries the names).

## Version Impact

- Version: no version change because pre-release internal change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: none
- Authority: task_be666ead5d6625d9f7c84d0923
- Machine-check boundary: this PR only asserts the declaration exists; reviewers decide whether it is true and sufficient.
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: origin/main
- Branch merge-base with `origin/main`: origin/main
- Last `git fetch origin` time: 2026-08-28T22:16Z
- Sync method: none needed
- Public diff command: `git diff origin/main...HEAD`
- Private evidence commit/path: harness task package task_be666ead5d6625d9f7c84d0923 (artifacts/reports)
- Reviewer evidence path: same task package
- GitHub Actions `rewrite-ci` run URL: pending
- [x] Worker (agy): report with the three run URLs and the reporter mechanism quoted from vitest docs
- [x] CEO read the diff: reporter list only
- [ ] CI on this PR (a green run shows the default reporter output in the log)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Not run: full local matrix by design; CI is the authority.

## Review Evidence

- Self-review: CEO chose the reporter fix over an if:always() upload because it needs no workflow edit.
- Reviewer subagent: agy (Gemini) investigated and implemented; CEO acceptance.
- Human review: pending
- Blocking findings: none

## Residual Risk

- Slightly longer GUI test logs in CI.

## References

- Task: task_be666ead5d6625d9f7c84d0923
- Evidence: task package artifacts/reports
- Review: this PR

---

# 中文

## 概要

main 上 `full-check (26)` 失败时(run 33186389071 / 33192909821 / 33195881502)日志只有 `npm error Lifecycle script test:gui failed`:`tools/run-gui-tests.mjs` 只传了 `--reporter=json`,这会关掉 vitest 的控制台 reporter;而 observation artifact 由 `run-manifest-gates.mjs` 生成,`npm run check` 在 `test:gui` 处中止后它根本不会跑。现在 runner 传 `--reporter=default --reporter=json` 并把 JSON 输出路径按仓库根解析,失败测试名与断言直接进 job 日志,结构化文件不变。

## 架构辩护

- Production-Delta 实算:一个工具脚本的 reporter 列表改动;不改 workflow。

## 改动内容

- `tools/run-gui-tests.mjs`:`--reporter=default --reporter=json --outputFile=<repoRoot>/tmp/ci-observation/vitest.json`。

## 门收割 / Gate Harvest

- 删除的生产路径:无
- 同 commit 删除的门 / fixture:无
- 生产净行数:引用英文块中的 `Production-Delta`。

## 机读声明说明

- 见英文块。

## 任务与范围

- Harness 任务:task_be666ead5d6625d9f7c84d0923
- 分支:codex/ci-observability
- 公开范围:CI 使用的 GUI vitest runner
- 私有计划 / 证据是否已更新:yes
- 范围外:失败 arm 上传 ci-observation(需改 workflow;日志已带测试名后不再需要)。

## 版本影响

- 版本:不改版本,原因是预发布内部改动
- 发布影响:不发布

## 治理声明

- 是否触碰 protected surface:no
- protected surface 范围:none
- 依据:task_be666ead5d6625d9f7c84d0923
- 机器检查边界:本 PR 只声明该段存在;是否真实、充分由 reviewer 判断。
- Break-glass:no
- Break-glass 原因:不适用
- Break-glass 范围:不适用
- 后续治理任务:不适用

## 验证

- `origin/main` 基准 SHA:origin/main
- 当前分支与 `origin/main` 的 merge-base:origin/main
- 最近一次 `git fetch origin` 时间:2026-08-28T22:16Z
- 同步方式:不需要
- 公开 diff 命令:`git diff origin/main...HEAD`
- 私有证据 commit/path:harness 任务包 task_be666ead5d6625d9f7c84d0923
- Reviewer 证据路径:同上
- GitHub Actions `rewrite-ci` run URL:待定
- [x] worker(agy):报告含三个 run URL 与 vitest reporter 机制引用
- [x] CEO 读 diff:只改 reporter 列表
- [ ] 本 PR 的 CI(绿跑的日志里应可见 default reporter 输出)
- [ ] `npm ci`
- [ ] `git diff --check`
- [ ] `npm run check`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [ ] `npm run harness:check-implementation-contracts`
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 未运行:按设计不跑本地全量;以 CI 为权威。

## 审查证据

- 自查:CEO 选 reporter 修法而非 if:always() 上传,因为不需改 workflow。
- Reviewer subagent:agy(Gemini)调查并实现;CEO 验收。
- 人工审查:待定
- 阻塞发现:无

## 残余风险

- CI 里 GUI 测试日志略长。

## 关联材料

- 任务:task_be666ead5d6625d9f7c84d0923
- 证据:任务包 artifacts/reports
- 审查:本 PR
